### PR TITLE
feat(cortex): C-102.1 — NATS transport primitives (MIG-1.1 + 1.2)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,0 +1,197 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "grove",
+      "dependencies": {
+        "@metafactory/content-filter": "github:the-metafactory/content-filter",
+        "@octokit/webhooks": "^14.2.0",
+        "@xyflow/react": "^12.10.2",
+        "ajv": "^8.20.0",
+        "ajv-formats": "^3.0.1",
+        "chokidar": "^5.0.0",
+        "commander": "^14.0.3",
+        "discord.js": "^14.25.1",
+        "elkjs": "^0.11.1",
+        "grove-auth": "file:../grove-auth",
+        "nats": "^2.29.3",
+        "react": "^19.2.4",
+        "react-dom": "^19.2.4",
+        "yaml": "^2.8.3",
+        "zod": "^4.3.6",
+      },
+      "devDependencies": {
+        "@types/bun": "latest",
+        "@types/react": "^19.2.14",
+        "@types/react-dom": "^19.2.3",
+      },
+      "peerDependencies": {
+        "typescript": "^5",
+      },
+    },
+  },
+  "packages": {
+    "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20260403.1", "", {}, "sha512-p6oSNt3yUwcxSoXZ7qCog7+kgQbkSx1Beoci7TMb/xbRF05VR0cO/p1XUE2SLHZ7IgSIc3tNMpFKa0L0fa3Lzg=="],
+
+    "@discordjs/builders": ["@discordjs/builders@1.14.0", "", { "dependencies": { "@discordjs/formatters": "^0.6.2", "@discordjs/util": "^1.2.0", "@sapphire/shapeshift": "^4.0.0", "discord-api-types": "^0.38.40", "fast-deep-equal": "^3.1.3", "ts-mixer": "^6.0.4", "tslib": "^2.6.3" } }, "sha512-7pVKxVWkeLUtrTo9nTYkjRcJk0Hlms6lYervXAD7E7+K5lil9ms2JrEB1TalMiHvQMh7h1HJZ4fCJa0/vHpl4w=="],
+
+    "@discordjs/collection": ["@discordjs/collection@1.5.3", "", {}, "sha512-SVb428OMd3WO1paV3rm6tSjM4wC+Kecaa1EUGX7vc6/fddvw/6lg90z4QtCqm21zvVe92vMMDt9+DkIvjXImQQ=="],
+
+    "@discordjs/formatters": ["@discordjs/formatters@0.6.2", "", { "dependencies": { "discord-api-types": "^0.38.33" } }, "sha512-y4UPwWhH6vChKRkGdMB4odasUbHOUwy7KL+OVwF86PvT6QVOwElx+TiI1/6kcmcEe+g5YRXJFiXSXUdabqZOvQ=="],
+
+    "@discordjs/rest": ["@discordjs/rest@2.6.1", "", { "dependencies": { "@discordjs/collection": "^2.1.1", "@discordjs/util": "^1.2.0", "@sapphire/async-queue": "^1.5.3", "@sapphire/snowflake": "^3.5.5", "@vladfrangu/async_event_emitter": "^2.4.6", "discord-api-types": "^0.38.40", "magic-bytes.js": "^1.13.0", "tslib": "^2.6.3", "undici": "6.24.1" } }, "sha512-wwQdgjeaoYFiaG+atbqx6aJDpqW7JHAo0HrQkBTbYzM3/PJ3GweQIpgElNcGZ26DCUOXMyawYd0YF7vtr+fZXg=="],
+
+    "@discordjs/util": ["@discordjs/util@1.2.0", "", { "dependencies": { "discord-api-types": "^0.38.33" } }, "sha512-3LKP7F2+atl9vJFhaBjn4nOaSWahZ/yWjOvA4e5pnXkt2qyXRCHLxoBQy81GFtLGCq7K9lPm9R517M1U+/90Qg=="],
+
+    "@discordjs/ws": ["@discordjs/ws@1.2.3", "", { "dependencies": { "@discordjs/collection": "^2.1.0", "@discordjs/rest": "^2.5.1", "@discordjs/util": "^1.1.0", "@sapphire/async-queue": "^1.5.2", "@types/ws": "^8.5.10", "@vladfrangu/async_event_emitter": "^2.2.4", "discord-api-types": "^0.38.1", "tslib": "^2.6.2", "ws": "^8.17.0" } }, "sha512-wPlQDxEmlDg5IxhJPuxXr3Vy9AjYq5xCvFWGJyD7w7Np8ZGu+Mc+97LCoEc/+AYCo2IDpKioiH0/c/mj5ZR9Uw=="],
+
+    "@metafactory/content-filter": ["@metafactory/content-filter@github:the-metafactory/content-filter#a9ce45e", { "dependencies": { "zod": "^3.24" }, "peerDependencies": { "typescript": "^5" } }, "the-metafactory-content-filter-a9ce45e"],
+
+    "@octokit/openapi-types": ["@octokit/openapi-types@27.0.0", "", {}, "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA=="],
+
+    "@octokit/openapi-webhooks-types": ["@octokit/openapi-webhooks-types@12.1.0", "", {}, "sha512-WiuzhOsiOvb7W3Pvmhf8d2C6qaLHXrWiLBP4nJ/4kydu+wpagV5Fkz9RfQwV2afYzv3PB+3xYgp4mAdNGjDprA=="],
+
+    "@octokit/request-error": ["@octokit/request-error@7.1.0", "", { "dependencies": { "@octokit/types": "^16.0.0" } }, "sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw=="],
+
+    "@octokit/types": ["@octokit/types@16.0.0", "", { "dependencies": { "@octokit/openapi-types": "^27.0.0" } }, "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg=="],
+
+    "@octokit/webhooks": ["@octokit/webhooks@14.2.0", "", { "dependencies": { "@octokit/openapi-webhooks-types": "12.1.0", "@octokit/request-error": "^7.0.0", "@octokit/webhooks-methods": "^6.0.0" } }, "sha512-da6KbdNCV5sr1/txD896V+6W0iamFWrvVl8cHkBSPT+YlvmT3DwXa4jxZnQc+gnuTEqSWbBeoSZYTayXH9wXcw=="],
+
+    "@octokit/webhooks-methods": ["@octokit/webhooks-methods@6.0.0", "", {}, "sha512-MFlzzoDJVw/GcbfzVC1RLR36QqkTLUf79vLVO3D+xn7r0QgxnFoLZgtrzxiQErAjFUOdH6fas2KeQJ1yr/qaXQ=="],
+
+    "@sapphire/async-queue": ["@sapphire/async-queue@1.5.5", "", {}, "sha512-cvGzxbba6sav2zZkH8GPf2oGk9yYoD5qrNWdu9fRehifgnFZJMV+nuy2nON2roRO4yQQ+v7MK/Pktl/HgfsUXg=="],
+
+    "@sapphire/shapeshift": ["@sapphire/shapeshift@4.0.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "lodash": "^4.17.21" } }, "sha512-d9dUmWVA7MMiKobL3VpLF8P2aeanRTu6ypG2OIaEv/ZHH/SUQ2iHOVyi5wAPjQ+HmnMuL0whK9ez8I/raWbtIg=="],
+
+    "@sapphire/snowflake": ["@sapphire/snowflake@3.5.3", "", {}, "sha512-jjmJywLAFoWeBi1W7994zZyiNWPIiqRRNAmSERxyg93xRGzNYvGjlZ0gR6x0F4gPRi2+0O6S71kOZYyr3cxaIQ=="],
+
+    "@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
+
+    "@types/d3-color": ["@types/d3-color@3.1.3", "", {}, "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="],
+
+    "@types/d3-drag": ["@types/d3-drag@3.0.7", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ=="],
+
+    "@types/d3-interpolate": ["@types/d3-interpolate@3.0.4", "", { "dependencies": { "@types/d3-color": "*" } }, "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA=="],
+
+    "@types/d3-selection": ["@types/d3-selection@3.0.11", "", {}, "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w=="],
+
+    "@types/d3-transition": ["@types/d3-transition@3.0.9", "", { "dependencies": { "@types/d3-selection": "*" } }, "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg=="],
+
+    "@types/d3-zoom": ["@types/d3-zoom@3.0.8", "", { "dependencies": { "@types/d3-interpolate": "*", "@types/d3-selection": "*" } }, "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw=="],
+
+    "@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
+
+    "@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
+
+    "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
+
+    "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
+
+    "@vladfrangu/async_event_emitter": ["@vladfrangu/async_event_emitter@2.4.7", "", {}, "sha512-Xfe6rpCTxSxfbswi/W/Pz7zp1WWSNn4A0eW4mLkQUewCrXXtMj31lCg+iQyTkh/CkusZSq9eDflu7tjEDXUY6g=="],
+
+    "@xyflow/react": ["@xyflow/react@12.10.2", "", { "dependencies": { "@xyflow/system": "0.0.76", "classcat": "^5.0.3", "zustand": "^4.4.0" }, "peerDependencies": { "react": ">=17", "react-dom": ">=17" } }, "sha512-CgIi6HwlcHXwlkTpr0fxLv/0sRVNZ8IdwKLzzeCscaYBwpvfcH1QFOCeaTCuEn1FQEs/B8CjnTSjhs8udgmBgQ=="],
+
+    "@xyflow/system": ["@xyflow/system@0.0.76", "", { "dependencies": { "@types/d3-drag": "^3.0.7", "@types/d3-interpolate": "^3.0.4", "@types/d3-selection": "^3.0.10", "@types/d3-transition": "^3.0.8", "@types/d3-zoom": "^3.0.8", "d3-drag": "^3.0.0", "d3-interpolate": "^3.0.1", "d3-selection": "^3.0.0", "d3-zoom": "^3.0.0" } }, "sha512-hvwvnRS1B3REwVDlWexsq7YQaPZeG3/mKo1jv38UmnpWmxihp14bW6VtEOuHEwJX2FvzFw8k77LyKSk/wiZVNA=="],
+
+    "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
+
+    "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
+
+    "bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
+
+    "chokidar": ["chokidar@5.0.0", "", { "dependencies": { "readdirp": "^5.0.0" } }, "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw=="],
+
+    "classcat": ["classcat@5.0.5", "", {}, "sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w=="],
+
+    "commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
+
+    "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
+
+    "d3-color": ["d3-color@3.1.0", "", {}, "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="],
+
+    "d3-dispatch": ["d3-dispatch@3.0.1", "", {}, "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg=="],
+
+    "d3-drag": ["d3-drag@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-selection": "3" } }, "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg=="],
+
+    "d3-ease": ["d3-ease@3.0.1", "", {}, "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w=="],
+
+    "d3-interpolate": ["d3-interpolate@3.0.1", "", { "dependencies": { "d3-color": "1 - 3" } }, "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g=="],
+
+    "d3-selection": ["d3-selection@3.0.0", "", {}, "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ=="],
+
+    "d3-timer": ["d3-timer@3.0.1", "", {}, "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA=="],
+
+    "d3-transition": ["d3-transition@3.0.1", "", { "dependencies": { "d3-color": "1 - 3", "d3-dispatch": "1 - 3", "d3-ease": "1 - 3", "d3-interpolate": "1 - 3", "d3-timer": "1 - 3" }, "peerDependencies": { "d3-selection": "2 - 3" } }, "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w=="],
+
+    "d3-zoom": ["d3-zoom@3.0.0", "", { "dependencies": { "d3-dispatch": "1 - 3", "d3-drag": "2 - 3", "d3-interpolate": "1 - 3", "d3-selection": "2 - 3", "d3-transition": "2 - 3" } }, "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw=="],
+
+    "discord-api-types": ["discord-api-types@0.38.42", "", {}, "sha512-qs1kya7S84r5RR8m9kgttywGrmmoHaRifU1askAoi+wkoSefLpZP6aGXusjNw5b0jD3zOg3LTwUa3Tf2iHIceQ=="],
+
+    "discord.js": ["discord.js@14.25.1", "", { "dependencies": { "@discordjs/builders": "^1.13.0", "@discordjs/collection": "1.5.3", "@discordjs/formatters": "^0.6.2", "@discordjs/rest": "^2.6.0", "@discordjs/util": "^1.2.0", "@discordjs/ws": "^1.2.3", "@sapphire/snowflake": "3.5.3", "discord-api-types": "^0.38.33", "fast-deep-equal": "3.1.3", "lodash.snakecase": "4.1.1", "magic-bytes.js": "^1.10.0", "tslib": "^2.6.3", "undici": "6.21.3" } }, "sha512-2l0gsPOLPs5t6GFZfQZKnL1OJNYFcuC/ETWsW4VtKVD/tg4ICa9x+jb9bkPffkMdRpRpuUaO/fKkHCBeiCKh8g=="],
+
+    "elkjs": ["elkjs@0.11.1", "", {}, "sha512-zxxR9k+rx5ktMwT/FwyLdPCrq7xN6e4VGGHH8hA01vVYKjTFik7nHOxBnAYtrgYUB1RpAiLvA1/U2YraWxyKKg=="],
+
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-uri": ["fast-uri@3.1.2", "", {}, "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ=="],
+
+    "grove-auth": ["grove-auth@file:../grove-auth", { "dependencies": { "hono": "^4.7.0" }, "devDependencies": { "@cloudflare/workers-types": "^4.20250327.0", "typescript": "^5.8.0" } }],
+
+    "hono": ["hono@4.12.10", "", {}, "sha512-mx/p18PLy5og9ufies2GOSUqep98Td9q4i/EF6X7yJgAiIopxqdfIO3jbqsi3jRgTgw88jMDEzVKi+V2EF+27w=="],
+
+    "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "lodash": ["lodash@4.17.23", "", {}, "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w=="],
+
+    "lodash.snakecase": ["lodash.snakecase@4.1.1", "", {}, "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw=="],
+
+    "magic-bytes.js": ["magic-bytes.js@1.13.0", "", {}, "sha512-afO2mnxW7GDTXMm5/AoN1WuOcdoKhtgXjIvHmobqTD1grNplhGdv3PFOyjCVmrnOZBIT/gD/koDKpYG+0mvHcg=="],
+
+    "nats": ["nats@2.29.3", "", { "dependencies": { "nkeys.js": "1.1.0" } }, "sha512-tOQCRCwC74DgBTk4pWZ9V45sk4d7peoE2njVprMRCBXrhJ5q5cYM7i6W+Uvw2qUrcfOSnuisrX7bEx3b3Wx4QA=="],
+
+    "nkeys.js": ["nkeys.js@1.1.0", "", { "dependencies": { "tweetnacl": "1.0.3" } }, "sha512-tB/a0shZL5UZWSwsoeyqfTszONTt4k2YS0tuQioMOD180+MbombYVgzDUYHlx+gejYK6rgf08n/2Df99WY0Sxg=="],
+
+    "react": ["react@19.2.4", "", {}, "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ=="],
+
+    "react-dom": ["react-dom@19.2.4", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.4" } }, "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ=="],
+
+    "readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
+
+    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
+    "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
+
+    "ts-mixer": ["ts-mixer@6.0.4", "", {}, "sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA=="],
+
+    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "tweetnacl": ["tweetnacl@1.0.3", "", {}, "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici": ["undici@6.21.3", "", {}, "sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw=="],
+
+    "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+
+    "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
+
+    "ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
+
+    "yaml": ["yaml@2.8.3", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg=="],
+
+    "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+
+    "zustand": ["zustand@4.5.7", "", { "dependencies": { "use-sync-external-store": "^1.2.2" }, "peerDependencies": { "@types/react": ">=16.8", "immer": ">=9.0.6", "react": ">=16.8" }, "optionalPeers": ["@types/react", "immer", "react"] }, "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw=="],
+
+    "@discordjs/rest/@discordjs/collection": ["@discordjs/collection@2.1.1", "", {}, "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg=="],
+
+    "@discordjs/rest/@sapphire/snowflake": ["@sapphire/snowflake@3.5.5", "", {}, "sha512-xzvBr1Q1c4lCe7i6sRnrofxeO1QTP/LKQ6A6qy0iB4x5yfiSfARMEQEghojzTNALDTcv8En04qYNIco9/K9eZQ=="],
+
+    "@discordjs/rest/undici": ["undici@6.24.1", "", {}, "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA=="],
+
+    "@discordjs/ws/@discordjs/collection": ["@discordjs/collection@2.1.1", "", {}, "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg=="],
+
+    "@metafactory/content-filter/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "grove",
+  "module": "index.ts",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "build:dashboard": "bun build src/mission-control/dashboard-v2/index.html --outdir dist/dashboard-v2 --target browser",
+    "watch:dashboard": "bun build src/mission-control/dashboard-v2/index.html --outdir dist/dashboard-v2 --target browser --watch"
+  },
+  "devDependencies": {
+    "@types/bun": "latest",
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3"
+  },
+  "peerDependencies": {
+    "typescript": "^5"
+  },
+  "dependencies": {
+    "@metafactory/content-filter": "github:the-metafactory/content-filter",
+    "@octokit/webhooks": "^14.2.0",
+    "@xyflow/react": "^12.10.2",
+    "ajv": "^8.20.0",
+    "ajv-formats": "^3.0.1",
+    "chokidar": "^5.0.0",
+    "commander": "^14.0.3",
+    "discord.js": "^14.25.1",
+    "elkjs": "^0.11.1",
+    "grove-auth": "file:../grove-auth",
+    "nats": "^2.29.3",
+    "react": "^19.2.4",
+    "react-dom": "^19.2.4",
+    "yaml": "^2.8.3",
+    "zod": "^4.3.6"
+  }
+}

--- a/src/bus/nats/__tests__/connection.test.ts
+++ b/src/bus/nats/__tests__/connection.test.ts
@@ -1,0 +1,212 @@
+/**
+ * G-1100.A: NATS connection primitive tests.
+ *
+ * Uses the `connectImpl` test seam to inject a fake nats.js connection
+ * without standing up a real NATS server.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import type { NatsConnection } from "nats";
+import { Events } from "nats";
+import { NatsLink } from "../connection";
+
+function makeFakeConnection() {
+  const statusEvents: { type: string; data: unknown }[] = [];
+  // Promise the test awaits to know an event has been observed by the status
+  // loop. Avoids real-time setTimeout sleeps in tests.
+  let observed: Promise<void> = Promise.resolve();
+  let pushStatus: ((s: { type: string; data: unknown }) => void) | null = null;
+  let closeStatus: (() => void) | null = null;
+
+  const statusIterator = (async function* () {
+    while (true) {
+      const next = await new Promise<{ type: string; data: unknown } | null>((resolve) => {
+        pushStatus = resolve as (s: { type: string; data: unknown }) => void;
+        closeStatus = () => resolve(null);
+      });
+      if (next === null) return;
+      yield next;
+    }
+  })();
+
+  const drain = mock(async () => {
+    if (closeStatus) closeStatus();
+  });
+
+  const fakeNc = {
+    status: () => statusIterator,
+    drain,
+  } as unknown as NatsConnection;
+
+  return {
+    nc: fakeNc,
+    /**
+     * Push a status event AND return a promise that resolves once the
+     * NatsLink status loop has had a chance to observe it. Tests await this
+     * instead of sleeping, so they're deterministic on loaded CI.
+     */
+    push: async (status: { type: string; data: unknown }) => {
+      observed = new Promise<void>((resolve) => {
+        // Schedule resolution AFTER the iterator yields the value the loop
+        // will observe — two microtask flushes is enough for the event to
+        // hop from `resolve(next)` → loop body → console.* call.
+        queueMicrotask(() => queueMicrotask(resolve));
+      });
+      pushStatus?.(status);
+      statusEvents.push(status);
+      await observed;
+    },
+    drain,
+    statusEvents,
+  };
+}
+
+describe("NatsLink", () => {
+  let consoleSpy: {
+    info: ReturnType<typeof mock>;
+    warn: ReturnType<typeof mock>;
+    error: ReturnType<typeof mock>;
+    debug: ReturnType<typeof mock>;
+  };
+  let originalConsole: {
+    info: typeof console.info;
+    warn: typeof console.warn;
+    error: typeof console.error;
+    debug: typeof console.debug;
+  };
+
+  beforeEach(() => {
+    originalConsole = {
+      info: console.info,
+      warn: console.warn,
+      error: console.error,
+      debug: console.debug,
+    };
+    consoleSpy = {
+      info: mock(() => {}),
+      warn: mock(() => {}),
+      error: mock(() => {}),
+      debug: mock(() => {}),
+    };
+    console.info = consoleSpy.info;
+    console.warn = consoleSpy.warn;
+    console.error = consoleSpy.error;
+    console.debug = consoleSpy.debug;
+  });
+
+  afterEach(() => {
+    console.info = originalConsole.info;
+    console.warn = originalConsole.warn;
+    console.error = originalConsole.error;
+    console.debug = originalConsole.debug;
+  });
+
+  test("requires a url", async () => {
+    await expect(NatsLink.connect({ url: "" })).rejects.toThrow(/url is required/);
+  });
+
+  test("connects via injected impl and exposes raw + name", async () => {
+    const fake = makeFakeConnection();
+    const capturedOpts: unknown[] = [];
+    const connectImpl = mock(async (opts: unknown) => {
+      capturedOpts.push(opts);
+      return fake.nc;
+    });
+    const link = await NatsLink.connect({
+      url: "nats://localhost:4222",
+      name: "test-link",
+      connectImpl: connectImpl as never,
+    });
+    expect(link.name).toBe("test-link");
+    expect(link.raw).toBe(fake.nc);
+    expect(connectImpl).toHaveBeenCalledTimes(1);
+    expect(capturedOpts[0]).toMatchObject({
+      servers: ["nats://localhost:4222"],
+      name: "test-link",
+      reconnect: true,
+    });
+    await link.close();
+  });
+
+  test("defaults name to grove-bot", async () => {
+    const fake = makeFakeConnection();
+    const link = await NatsLink.connect({
+      url: "nats://localhost:4222",
+      connectImpl: async () => fake.nc,
+    });
+    expect(link.name).toBe("grove-bot");
+    await link.close();
+  });
+
+  test("close() drains exactly once (idempotent)", async () => {
+    const fake = makeFakeConnection();
+    const link = await NatsLink.connect({
+      url: "nats://localhost:4222",
+      connectImpl: async () => fake.nc,
+    });
+    await link.close();
+    await link.close();
+    expect(fake.drain).toHaveBeenCalledTimes(1);
+  });
+
+  test("logs disconnect events as warn", async () => {
+    const fake = makeFakeConnection();
+    const link = await NatsLink.connect({
+      url: "nats://localhost:4222",
+      name: "warn-test",
+      connectImpl: async () => fake.nc,
+    });
+    await fake.push({ type: Events.Disconnect, data: "nats://localhost:4222" });
+    expect(consoleSpy.warn).toHaveBeenCalled();
+    const msg = String(consoleSpy.warn.mock.calls[0]?.[0]);
+    expect(msg).toContain("warn-test");
+    expect(msg).toContain("disconnected");
+    await link.close();
+  });
+
+  test("logs reconnect events as info", async () => {
+    const fake = makeFakeConnection();
+    const link = await NatsLink.connect({
+      url: "nats://localhost:4222",
+      name: "info-test",
+      connectImpl: async () => fake.nc,
+    });
+    await fake.push({ type: Events.Reconnect, data: "nats://localhost:4222" });
+    expect(consoleSpy.info).toHaveBeenCalled();
+    const msg = String(consoleSpy.info.mock.calls[0]?.[0]);
+    expect(msg).toContain("info-test");
+    expect(msg).toContain("reconnected");
+    await link.close();
+  });
+
+  test("logs error events as error", async () => {
+    const fake = makeFakeConnection();
+    const link = await NatsLink.connect({
+      url: "nats://localhost:4222",
+      name: "err-test",
+      connectImpl: async () => fake.nc,
+    });
+    await fake.push({ type: Events.Error, data: new Error("boom") });
+    expect(consoleSpy.error).toHaveBeenCalled();
+    const msg = String(consoleSpy.error.mock.calls[0]?.[0]);
+    expect(msg).toContain("err-test");
+    expect(msg).toContain("error");
+    await link.close();
+  });
+
+  test("propagates underlying connect errors", async () => {
+    const failing = mock(async () => {
+      throw new Error("ECONNREFUSED");
+    });
+    await expect(
+      NatsLink.connect({ url: "nats://nowhere", connectImpl: failing as never }),
+    ).rejects.toThrow(/ECONNREFUSED/);
+  });
+
+  test("module is import-safe (no side effects on import)", () => {
+    // The mere act of importing nats-connection should not connect, log, or
+    // throw — verified implicitly by the test runner having loaded the module
+    // already without an active NATS server. Make it explicit:
+    expect(typeof NatsLink.connect).toBe("function");
+  });
+});

--- a/src/bus/nats/__tests__/subscription.test.ts
+++ b/src/bus/nats/__tests__/subscription.test.ts
@@ -1,0 +1,371 @@
+/**
+ * G-1100.C: nats-subscription tests.
+ *
+ * Drives the subscription primitive against a fake NatsLink whose `.raw`
+ * is a minimal in-memory NATS-shaped fake. No real NATS server.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import type { NatsConnection, Subscription, Status } from "nats";
+import { Events } from "nats";
+import { NatsSubscription } from "../subscription";
+import { NatsLink } from "../connection";
+
+/**
+ * Build a fake Subscription that exposes a `push(subject, data)` test seam,
+ * a `drain()` mock, and an async-iterator that yields whatever's been pushed
+ * (until drained).
+ */
+function makeFakeSubscription() {
+  type Msg = { subject: string; data: Uint8Array };
+  const queue: Msg[] = [];
+  let waiter: ((m: Msg | null) => void) | null = null;
+  let drained = false;
+
+  const iterator = (async function* () {
+    while (true) {
+      if (queue.length > 0) {
+        yield queue.shift()!;
+        continue;
+      }
+      if (drained) return;
+      const next = await new Promise<Msg | null>((resolve) => {
+        waiter = resolve;
+      });
+      if (next === null) return;
+      yield next;
+    }
+  })();
+
+  const drain = mock(async () => {
+    drained = true;
+    waiter?.(null);
+  });
+
+  const sub = {
+    [Symbol.asyncIterator]: () => iterator,
+    drain,
+    closed: Promise.resolve(),
+  } as unknown as Subscription;
+
+  return {
+    sub,
+    push: (subject: string, data: Uint8Array) => {
+      const msg = { subject, data };
+      if (waiter) {
+        const w = waiter;
+        waiter = null;
+        w(msg);
+      } else {
+        queue.push(msg);
+      }
+    },
+    drain,
+  };
+}
+
+/** Fake NatsConnection that hands out fake subscriptions and a multi-consumer
+ *  status stream. Each `status()` call returns a new iterator so multiple
+ *  consumers (NatsLink + NatsSubscription) can both observe events — matching
+ *  the real nats.js behaviour.
+ */
+function makeFakeConnection() {
+  const subs: ReturnType<typeof makeFakeSubscription>[] = [];
+  const listeners = new Set<(s: Status | null) => void>();
+  let closed = false;
+
+  const status = () =>
+    (async function* () {
+      // Each consumer gets its own queue so multi-consumer iteration works.
+      const queue: (Status | null)[] = [];
+      let waiter: ((s: Status | null) => void) | null = null;
+      const listener = (s: Status | null) => {
+        if (waiter) {
+          const w = waiter;
+          waiter = null;
+          w(s);
+        } else {
+          queue.push(s);
+        }
+      };
+      listeners.add(listener);
+      try {
+        while (true) {
+          if (queue.length > 0) {
+            const next = queue.shift()!;
+            if (next === null) return;
+            yield next;
+            continue;
+          }
+          if (closed) return;
+          const next = await new Promise<Status | null>((r) => (waiter = r));
+          if (next === null) return;
+          yield next;
+        }
+      } finally {
+        listeners.delete(listener);
+      }
+    })();
+
+  const subscribe = mock((_pattern: string) => {
+    const fake = makeFakeSubscription();
+    subs.push(fake);
+    return fake.sub;
+  });
+
+  const drain = mock(async () => {
+    closed = true;
+    for (const l of listeners) l(null);
+  });
+
+  const fakeNc = {
+    status,
+    subscribe,
+    drain,
+  } as unknown as NatsConnection;
+
+  return {
+    nc: fakeNc,
+    subAt: (i: number) => subs[i],
+    pushStatus: (s: Status) => {
+      for (const l of listeners) l(s);
+    },
+    subscribe,
+    drain,
+  };
+}
+
+/** Build a NatsLink wrapping a fake connection. */
+async function makeLink() {
+  const fake = makeFakeConnection();
+  const link = await NatsLink.connect({
+    url: "nats://localhost:4222",
+    name: "subscription-test",
+    connectImpl: (async () => fake.nc) as never,
+  });
+  return { link, fake };
+}
+
+/** Yield to microtask queue several times so async iterators can advance. */
+async function flushMicrotasks(times = 4) {
+  for (let i = 0; i < times; i++) {
+    await Promise.resolve();
+  }
+}
+
+describe("NatsSubscription", () => {
+  let originalConsole: typeof console.error;
+  beforeEach(() => {
+    originalConsole = console.error;
+    console.error = mock(() => {});
+  });
+  afterEach(() => {
+    console.error = originalConsole;
+  });
+
+  test("requires a pattern", async () => {
+    const { link } = await makeLink();
+    expect(() =>
+      NatsSubscription.start(link, {
+        pattern: "",
+        onMessage: () => {},
+      }),
+    ).toThrow(/pattern is required/);
+    await link.close();
+  });
+
+  test("subscribes to the requested pattern", async () => {
+    const { link, fake } = await makeLink();
+    const sub = NatsSubscription.start(link, {
+      pattern: "local.acme.>",
+      onMessage: () => {},
+    });
+    expect(fake.subscribe).toHaveBeenCalledTimes(1);
+    expect(fake.subscribe.mock.calls[0]?.[0]).toBe("local.acme.>");
+    await sub.stop();
+    await link.close();
+  });
+
+  test("delivers messages to onMessage", async () => {
+    const { link, fake } = await makeLink();
+    const received: { subject: string; data: string }[] = [];
+    const sub = NatsSubscription.start(link, {
+      pattern: "local.acme.>",
+      onMessage: (subject, data) => {
+        received.push({ subject, data: new TextDecoder().decode(data) });
+      },
+    });
+    fake.subAt(0)!.push("local.acme.test", new TextEncoder().encode("hello"));
+    await flushMicrotasks(8);
+    expect(received).toEqual([{ subject: "local.acme.test", data: "hello" }]);
+    await sub.stop();
+    await link.close();
+  });
+
+  test("handler error routes through onError, doesn't kill the loop", async () => {
+    const { link, fake } = await makeLink();
+    const errors: { msg: string; subject: string }[] = [];
+    const handled: string[] = [];
+    const sub = NatsSubscription.start(link, {
+      pattern: "local.acme.>",
+      onMessage: (subject, data) => {
+        if (new TextDecoder().decode(data) === "boom") throw new Error("test boom");
+        handled.push(subject);
+      },
+      onError: (err, subject) => errors.push({ msg: err.message, subject }),
+    });
+    fake.subAt(0)!.push("local.acme.first", new TextEncoder().encode("ok"));
+    fake.subAt(0)!.push("local.acme.second", new TextEncoder().encode("boom"));
+    fake.subAt(0)!.push("local.acme.third", new TextEncoder().encode("ok"));
+    await flushMicrotasks(16);
+    expect(handled).toEqual(["local.acme.first", "local.acme.third"]);
+    expect(errors).toEqual([{ msg: "test boom", subject: "local.acme.second" }]);
+    await sub.stop();
+    await link.close();
+  });
+
+  test("re-subscribes on Reconnect event", async () => {
+    const { link, fake } = await makeLink();
+    const sub = NatsSubscription.start(link, {
+      pattern: "local.acme.>",
+      onMessage: () => {},
+    });
+    expect(fake.subscribe).toHaveBeenCalledTimes(1);
+    fake.pushStatus({ type: Events.Reconnect, data: "nats://localhost:4222" } as Status);
+    await flushMicrotasks(8);
+    expect(fake.subscribe).toHaveBeenCalledTimes(2);
+    expect(fake.subscribe.mock.calls[1]?.[0]).toBe("local.acme.>");
+    await sub.stop();
+    await link.close();
+  });
+
+  test("stop() drains the subscription (idempotent)", async () => {
+    const { link, fake } = await makeLink();
+    const sub = NatsSubscription.start(link, {
+      pattern: "local.acme.>",
+      onMessage: () => {},
+    });
+    await sub.stop();
+    await sub.stop();
+    expect(fake.subAt(0)!.drain).toHaveBeenCalledTimes(1);
+    await link.close();
+  });
+
+  test("after reconnect, old subscription is orphaned (no delivery)", async () => {
+    const { link, fake } = await makeLink();
+    const received: string[] = [];
+    const sub = NatsSubscription.start(link, {
+      pattern: "local.acme.>",
+      onMessage: (subject) => {
+        received.push(subject);
+      },
+    });
+    fake.pushStatus({ type: Events.Reconnect, data: "nats://localhost:4222" } as Status);
+    await flushMicrotasks(8);
+    // Old subscription (subAt 0) — pushing into it must NOT reach the
+    // active onMessage since the consume loop reading it has exited.
+    fake.subAt(0)!.push("local.acme.old", new TextEncoder().encode("orphan"));
+    await flushMicrotasks(8);
+    expect(received).toEqual([]);
+    await sub.stop();
+    await link.close();
+  });
+
+  test("after reconnect, new subscription delivers messages", async () => {
+    const { link, fake } = await makeLink();
+    const received: string[] = [];
+    const sub = NatsSubscription.start(link, {
+      pattern: "local.acme.>",
+      onMessage: (subject) => {
+        received.push(subject);
+      },
+    });
+    fake.pushStatus({ type: Events.Reconnect, data: "nats://localhost:4222" } as Status);
+    await flushMicrotasks(8);
+    // New subscription (subAt 1) — pushing into it MUST reach onMessage.
+    fake.subAt(1)!.push("local.acme.new", new TextEncoder().encode("fresh"));
+    await flushMicrotasks(8);
+    expect(received).toEqual(["local.acme.new"]);
+    await sub.stop();
+    await link.close();
+  });
+
+  test("a thrown onError sink does not kill delivery", async () => {
+    const { link, fake } = await makeLink();
+    const handled: string[] = [];
+    const sub = NatsSubscription.start(link, {
+      pattern: "local.acme.>",
+      onMessage: (subject, data) => {
+        if (new TextDecoder().decode(data) === "boom") throw new Error("handler boom");
+        handled.push(subject);
+      },
+      onError: () => {
+        // Pathological sink that always throws.
+        throw new Error("sink boom");
+      },
+    });
+    fake.subAt(0)!.push("local.acme.before", new TextEncoder().encode("ok"));
+    fake.subAt(0)!.push("local.acme.boom", new TextEncoder().encode("boom"));
+    fake.subAt(0)!.push("local.acme.after", new TextEncoder().encode("ok"));
+    await flushMicrotasks(16);
+    // Loop must keep delivering messages despite the bad sink.
+    expect(handled).toEqual(["local.acme.before", "local.acme.after"]);
+    await sub.stop();
+    await link.close();
+  });
+
+  test("subscribe failure on reconnect logs error, no spurious 're-subscribed'", async () => {
+    const { link, fake } = await makeLink();
+    // Replace subscribe with one that throws on the SECOND call (reconnect path).
+    let callCount = 0;
+    const realSubscribe = fake.nc.subscribe;
+    (fake.nc as { subscribe: typeof realSubscribe }).subscribe = ((
+      ...args: Parameters<typeof realSubscribe>
+    ) => {
+      callCount++;
+      if (callCount === 2) throw new Error("auth revoked between disconnect and reconnect");
+      return realSubscribe(...args);
+    }) as typeof realSubscribe;
+
+    const errors: string[] = [];
+    const infos: string[] = [];
+    const origError = console.error;
+    const origInfo = console.info;
+    console.error = (...args: unknown[]) => {
+      errors.push(args.map((a) => String(a)).join(" "));
+    };
+    console.info = (...args: unknown[]) => {
+      infos.push(args.map((a) => String(a)).join(" "));
+    };
+
+    const sub = NatsSubscription.start(link, {
+      pattern: "local.acme.>",
+      onMessage: () => {},
+    });
+    fake.pushStatus({ type: Events.Reconnect, data: "nats://localhost:4222" } as Status);
+    await flushMicrotasks(8);
+
+    console.error = origError;
+    console.info = origInfo;
+
+    // Subscribe-failed branch: expect the failure log AND no 're-subscribed' info log.
+    const failureLogged = errors.some((e) => e.includes("subscribe failed"));
+    const spuriousReSub = infos.some((i) => i.includes("re-subscribed after reconnect"));
+    expect(failureLogged).toBe(true);
+    expect(spuriousReSub).toBe(false);
+
+    await sub.stop();
+    await link.close();
+  });
+
+  test("rejects a whitespace-only pattern", async () => {
+    const { link } = await makeLink();
+    expect(() =>
+      NatsSubscription.start(link, {
+        pattern: "   ",
+        onMessage: () => {},
+      }),
+    ).toThrow(/non-empty/);
+    await link.close();
+  });
+});

--- a/src/bus/nats/connection.ts
+++ b/src/bus/nats/connection.ts
@@ -1,0 +1,153 @@
+/**
+ * G-1100.A: NATS connection primitive.
+ *
+ * Thin wrapper around the `nats` package's connect/close lifecycle, with
+ * structured logging on disconnect / reconnect / error events. Used by the
+ * upcoming G-1100.C subscription primitive and the G-1100.D myelin
+ * subscriber compose.
+ *
+ * Coupling rule (per docs/design-collaboration-surface.md §9):
+ * Grove must stay installable without NATS configured. This module is
+ * import-safe — instantiation is via the `NatsLink.connect()` factory and
+ * only happens when grove-bot is started with a configured NATS URL
+ * (G-1100.E wires that up).
+ */
+
+import {
+  connect as natsConnect,
+  Events,
+  type ConnectionOptions,
+  type NatsConnection,
+} from "nats";
+
+export interface NatsLinkOptions {
+  /** NATS server URL (e.g. nats://localhost:4222). */
+  url: string;
+  /** Bearer token for the connect-time auth. Optional. */
+  token?: string;
+  /** Connection name surfaced on the server's `varz` endpoint. */
+  name?: string;
+  /** Override the underlying nats `connect` function (test seam). */
+  connectImpl?: (opts: ConnectionOptions) => Promise<NatsConnection>;
+}
+
+/**
+ * A live NATS connection plus a structured-logging adapter. The underlying
+ * `NatsConnection` is exposed via `raw` for higher-level primitives
+ * (subscriptions, JetStream) but lifecycle is owned here.
+ */
+export class NatsLink {
+  /** Underlying nats.js connection. Use `.subscribe(...)` etc. via this. */
+  readonly raw: NatsConnection;
+  /** Connection name (surfaced in logs). */
+  readonly name: string;
+
+  private readonly statusLoop: Promise<void>;
+  private closed = false;
+
+  private constructor(raw: NatsConnection, name: string) {
+    this.raw = raw;
+    this.name = name;
+    this.statusLoop = this.consumeStatusEvents();
+  }
+
+  /**
+   * Open a NATS connection. Returns a `NatsLink` ready to use. Throws if the
+   * server is unreachable or auth fails.
+   */
+  static async connect(opts: NatsLinkOptions): Promise<NatsLink> {
+    if (!opts.url) {
+      throw new Error("nats-connection: url is required");
+    }
+
+    const connectImpl = opts.connectImpl ?? natsConnect;
+    const name = opts.name ?? "grove-bot";
+
+    const raw = await connectImpl({
+      servers: [opts.url],
+      token: opts.token,
+      name,
+      // Defer reconnect to the underlying client; we just log status.
+      reconnect: true,
+    });
+
+    return new NatsLink(raw, name);
+  }
+
+  /**
+   * Close the connection cleanly. Drains in-flight subscriptions before
+   * disconnecting (per nats.js convention). Idempotent. Drain is bounded
+   * by `drainTimeoutMs` (default 5 s) so an unreachable server can't hang
+   * process exit.
+   */
+  async close(drainTimeoutMs = 5_000): Promise<void> {
+    if (this.closed) return;
+    this.closed = true;
+    try {
+      await Promise.race([
+        this.raw.drain(),
+        new Promise<void>((_, reject) =>
+          setTimeout(
+            () => reject(new Error(`drain timed out after ${drainTimeoutMs}ms`)),
+            drainTimeoutMs,
+          ),
+        ),
+      ]);
+    } catch (err) {
+      // Drain can fail if already closed by the server, or hit our timeout.
+      // Log and proceed — caller wants close() to resolve.
+      console.error(
+        `grove-bot: nats-connection "${this.name}" drain error:`,
+        err instanceof Error ? err.message : err,
+      );
+    }
+    // Wait for the status loop to drain so close() is deterministic.
+    try {
+      await this.statusLoop;
+    } catch {
+      // Status loop logs its own errors; close() shouldn't fail because of them.
+    }
+  }
+
+  /** Async iterator over status events — logs each one with the connection name. */
+  private async consumeStatusEvents(): Promise<void> {
+    try {
+      for await (const status of this.raw.status()) {
+        if (this.closed) return;
+        switch (status.type) {
+          case Events.Disconnect:
+            console.warn(
+              `grove-bot: nats-connection "${this.name}" disconnected from ${status.data}`,
+            );
+            break;
+          case Events.Reconnect:
+            console.info(
+              `grove-bot: nats-connection "${this.name}" reconnected to ${status.data}`,
+            );
+            break;
+          case Events.Error:
+            console.error(
+              `grove-bot: nats-connection "${this.name}" error:`,
+              status.data,
+            );
+            break;
+          // LDM, Update, etc. are quieter — log at debug level for now.
+          default:
+            console.debug(
+              `grove-bot: nats-connection "${this.name}" status:`,
+              status.type,
+              status.data,
+            );
+        }
+      }
+    } catch (err) {
+      // Status iterator can throw on close — only log if we weren't expecting it.
+      if (!this.closed) {
+        console.error(
+          `grove-bot: nats-connection "${this.name}" status loop error:`,
+          err instanceof Error ? err.message : err,
+        );
+      }
+    }
+  }
+}

--- a/src/bus/nats/subscription.ts
+++ b/src/bus/nats/subscription.ts
@@ -1,0 +1,286 @@
+/**
+ * G-1100.C: NATS subject-pattern subscription primitive.
+ *
+ * Thin wrapper around `NatsLink.raw.subscribe(pattern)` that:
+ *   - Yields raw bytes per message (no envelope decode here — that's
+ *     G-1100.D's job; the validator and the subscription primitive stay
+ *     separate so each can be tested in isolation).
+ *   - Re-subscribes on reconnect (the underlying nats.js client emits a
+ *     reconnect event but does NOT auto-restore subscriptions; we handle
+ *     that explicitly).
+ *   - Drains cleanly on stop.
+ *
+ * Coupling rule (per docs/design-collaboration-surface.md §9):
+ * This module reads from NATS only — it never publishes. The myelin
+ * subscriber compose (G-1100.D) wraps this with envelope validation; the
+ * subject allowlist for any future publishing path is tracked in #70.
+ */
+
+import {
+  Events,
+  type NatsConnection,
+  type Subscription,
+  type SubscriptionOptions,
+} from "nats";
+import type { NatsLink } from "./connection";
+
+/** Callback invoked once per received message. Errors thrown propagate to onError. */
+export type RawMessageHandler = (subject: string, data: Uint8Array) => void | Promise<void>;
+
+/** Optional error sink for handler failures. Logged if absent. */
+export type RawErrorHandler = (err: Error, subject: string) => void;
+
+export interface NatsSubscriptionOptions {
+  /** NATS subject pattern, e.g. `local.acme.>`. Required. */
+  pattern: string;
+  /** Per-message handler. */
+  onMessage: RawMessageHandler;
+  /** Optional error sink — invoked on handler throws. */
+  onError?: RawErrorHandler;
+  /** Optional underlying-subscription options (queue group, max, etc.). */
+  natsOptions?: SubscriptionOptions;
+}
+
+/**
+ * A live subject-pattern subscription. Re-subscribes automatically on
+ * reconnect; stops cleanly on `stop()`.
+ */
+export class NatsSubscription {
+  readonly pattern: string;
+  private readonly link: NatsLink;
+  private readonly onMessage: RawMessageHandler;
+  private readonly onError: RawErrorHandler;
+  private readonly natsOptions?: SubscriptionOptions;
+
+  private subscription: Subscription | null = null;
+  /**
+   * All consume loops we've ever started — most recent at the end. Across
+   * a reconnect lifecycle there can be a handful (the previous loop usually
+   * exits naturally as the old iterator closes, but if it rejects we want
+   * the rejection captured here, not orphaned with no `.catch`). `stop()`
+   * awaits them all so tail errors surface.
+   */
+  private readonly consumeLoops: Promise<void>[] = [];
+  private stopped = false;
+
+  private constructor(link: NatsLink, opts: NatsSubscriptionOptions) {
+    this.link = link;
+    this.pattern = opts.pattern;
+    this.onMessage = opts.onMessage;
+    this.onError = opts.onError ?? defaultErrorLog;
+    this.natsOptions = opts.natsOptions;
+    this.subscribeOnce();
+    // Fire-and-forget the status watcher. Errors are logged inside
+    // watchReconnects; the loop exits when the underlying connection
+    // closes (link owner's lifecycle), so we don't need to track the
+    // promise here.
+    void this.watchReconnects();
+  }
+
+  /** Open a new subscription. Returns once the underlying NATS subscription is registered. */
+  static start(link: NatsLink, opts: NatsSubscriptionOptions): NatsSubscription {
+    const pattern = (opts.pattern ?? "").trim();
+    if (!pattern) {
+      throw new Error("nats-subscription: pattern is required (non-empty, non-whitespace)");
+    }
+    return new NatsSubscription(link, { ...opts, pattern });
+  }
+
+  /**
+   * Stop the subscription. Drains in-flight messages and waits for the
+   * consume loop to exit. Idempotent.
+   *
+   * The status loop is NOT awaited here — it can only exit when the
+   * underlying connection closes, which is the link owner's
+   * responsibility (typically via `NatsLink.close()`). After `stop()`
+   * the status loop early-exits on its next observed event because
+   * `this.stopped` is set; until then it sits idle waiting for an event
+   * that won't come — no work, no leak that survives connection close.
+   */
+  async stop(): Promise<void> {
+    if (this.stopped) return;
+    this.stopped = true;
+    // No race in the current code: in single-threaded JS, the entire
+    // Reconnect branch in watchReconnects runs synchronously from its
+    // outer `if (this.stopped) return;` check through `subscribeOnce()`,
+    // with no await between. So stop() and watchReconnects can't
+    // interleave inside the swap. If a future change adds an await
+    // inside that branch, this read becomes load-bearing — keep it.
+    const sub = this.subscription;
+    if (sub) {
+      try {
+        await sub.drain();
+      } catch (err) {
+        // Drain can fail if the connection is already closed; log and proceed.
+        console.error(
+          `grove-bot: nats-subscription "${this.pattern}" drain error:`,
+          err instanceof Error ? err.message : err,
+        );
+      }
+    }
+    // Await every consume loop we've ever started — multiple may exist
+    // across reconnects; settledResults lets stop() resolve even if some
+    // rejected. Reject reasons would have already been logged inside
+    // consume() so we just swallow here.
+    await Promise.allSettled(this.consumeLoops);
+  }
+
+  /**
+   * Open one subscription on the underlying connection.
+   *
+   * Returns true on success, false if `raw.subscribe()` threw — caller
+   * uses this so a misleading "re-subscribed" log doesn't fire on the
+   * failure path. (Round-1 had no error log; round-2 added one but the
+   * "re-subscribed" line still fired — Echo cycle-2 regression note.)
+   */
+  private subscribeOnce(): boolean {
+    const raw: NatsConnection = this.link.raw;
+    try {
+      this.subscription = raw.subscribe(this.pattern, this.natsOptions);
+    } catch (err) {
+      // Subscribe can throw synchronously if the connection is in an
+      // unusable state (auth revoked between disconnect and reconnect,
+      // server gone). Surface — this is exactly the failure that should
+      // page someone — and leave `subscription` null so stop() won't
+      // try to drain a phantom.
+      console.error(
+        `grove-bot: nats-subscription "${this.pattern}" subscribe failed:`,
+        err instanceof Error ? err.message : err,
+      );
+      this.subscription = null;
+      return false;
+    }
+    // Wrap the consume loop so unhandled rejections become caught
+    // rejections owned by `consumeLoops`. Without `.catch`, a rejection
+    // from the OLD generation's loop after we've moved on becomes an
+    // unhandled-promise warning with nothing watching.
+    const loop = this.consume(this.subscription).catch((err) => {
+      if (!this.stopped) {
+        console.error(
+          `grove-bot: nats-subscription "${this.pattern}" consume loop rejection:`,
+          err instanceof Error ? err.message : err,
+        );
+      }
+    });
+    this.consumeLoops.push(loop);
+    return true;
+  }
+
+  private async consume(sub: Subscription): Promise<void> {
+    try {
+      for await (const msg of sub) {
+        if (this.stopped) return;
+        try {
+          await this.onMessage(msg.subject, msg.data);
+        } catch (err) {
+          // Guard the onError invocation itself — a thrown onError must
+          // not kill the consume loop. The whole point of the sink is
+          // to keep delivery alive. Fall back to defaultErrorLog so the
+          // failure is at least visible.
+          try {
+            this.onError(
+              err instanceof Error ? err : new Error(String(err)),
+              msg.subject,
+            );
+          } catch (sinkErr) {
+            defaultErrorLog(
+              sinkErr instanceof Error ? sinkErr : new Error(String(sinkErr)),
+              msg.subject,
+            );
+            defaultErrorLog(
+              err instanceof Error ? err : new Error(String(err)),
+              msg.subject,
+            );
+          }
+        }
+      }
+    } catch (err) {
+      if (!this.stopped) {
+        console.error(
+          `grove-bot: nats-subscription "${this.pattern}" consume loop error:`,
+          err instanceof Error ? err.message : err,
+        );
+      }
+    }
+  }
+
+  /**
+   * Watch the connection's status stream for Reconnect events; on each
+   * reconnect, re-subscribe (nats.js reconnects the connection but does
+   * NOT auto-restore subject subscriptions — they're considered client
+   * state).
+   */
+  private async watchReconnects(): Promise<void> {
+    try {
+      for await (const status of this.link.raw.status()) {
+        if (this.stopped) return;
+        if (status.type === Events.Reconnect) {
+          // Drain the old subscription before opening the new one. Two
+          // reasons: (a) closes the old iterator deterministically so the
+          // prior consume loop exits — without this it stays blocked
+          // waiting for messages on a subscription that's now an orphan
+          // server-side; (b) `stop()` later awaits every loop in
+          // `consumeLoops`, and a never-exiting loop would hang stop().
+          // Drain failures are best-effort and logged inside `consume()`.
+          //
+          const old = this.subscription;
+          this.subscription = null;
+          if (old) {
+            old.drain().catch((err) => {
+              console.error(
+                `grove-bot: nats-subscription "${this.pattern}" pre-reconnect drain error:`,
+                err instanceof Error ? err.message : err,
+              );
+            });
+          }
+          // Prune already-settled loops from previous generations so the
+          // array doesn't grow unbounded over a long-running connection
+          // (Echo cycle-2 nit). Tracks live loops only; the old loop we
+          // just drained becomes settled shortly after this point and
+          // will be pruned on the next reconnect.
+          this.pruneSettledLoops();
+          // Only emit "re-subscribed" on the success branch — Echo
+          // cycle-2 caught the regression where this fired even after
+          // `subscribeOnce()` logged a subscribe failure, producing the
+          // misleading "subscribe failed → re-subscribed" log pair.
+          if (this.subscribeOnce()) {
+            console.info(
+              `grove-bot: nats-subscription "${this.pattern}" re-subscribed after reconnect`,
+            );
+          }
+        }
+      }
+    } catch (err) {
+      if (!this.stopped) {
+        console.error(
+          `grove-bot: nats-subscription "${this.pattern}" status loop error:`,
+          err instanceof Error ? err.message : err,
+        );
+      }
+    }
+  }
+
+  /**
+   * Bound `consumeLoops` to the last two generations (current + previous).
+   *
+   * JS gives no synchronous "is this promise settled" check, so we can't
+   * filter by liveness. The previous-generation loop is drained at
+   * reconnect time and settles within a microtask or two, so keeping
+   * just the last two is enough to cover the realistic "stop() awaits a
+   * still-pending loop" case while keeping the array bounded over a
+   * long-running connection (Echo cycle-2 nit).
+   */
+  private pruneSettledLoops(): void {
+    const KEEP = 2;
+    if (this.consumeLoops.length > KEEP) {
+      this.consumeLoops.splice(0, this.consumeLoops.length - KEEP);
+    }
+  }
+}
+
+function defaultErrorLog(err: Error, subject: string): void {
+  console.error(
+    `grove-bot: nats-subscription handler error on "${subject}":`,
+    err.message,
+  );
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,30 @@
+{
+  "compilerOptions": {
+    // Environment setup & latest features
+    "lib": ["ESNext"],
+    "target": "ESNext",
+    "module": "Preserve",
+    "moduleDetection": "force",
+    "jsx": "react-jsx",
+    "allowJs": true,
+
+    // Bundler mode
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "noEmit": true,
+
+    // Best practices
+    "strict": true,
+    "skipLibCheck": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+
+    // Some stricter flags (disabled by default)
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "noPropertyAccessFromIndexSignature": false
+  },
+  "exclude": ["src/worker", "src/webhook-proxy"]
+}


### PR DESCRIPTION
## Summary

First sub-PR of MIG-1 (cortex#3 — Bus runtime). Strict port from grove-v2's G-1100.A + G-1100.C ladders into `cortex/src/bus/nats/`. No behavior change; pure relocation + minor file rename (drops the `nats-` filename prefix since the parent directory already qualifies them).

## What's in this PR

| From (grove-v2) | To (cortex) | Notes |
|---|---|---|
| `src/bot/lib/nats-connection.ts` (153 LOC) | `src/bus/nats/connection.ts` | NatsLink — connect/close/structured logging |
| `src/bot/lib/nats-subscription.ts` (286 LOC) | `src/bus/nats/subscription.ts` | Pattern-subscribe + reconnect-aware re-subscribe |
| `__tests__/nats-connection.test.ts` | `src/bus/nats/__tests__/connection.test.ts` | 9/9 tests forwarded |
| `__tests__/nats-subscription.test.ts` | `src/bus/nats/__tests__/subscription.test.ts` | 11/11 tests forwarded |
| `package.json` + `tsconfig.json` + `bun.lock` | top-level | Bootstrap deps; **content forwarded as-is** |

Imports rewired for the file renames: `./nats-connection` → `./connection`, `../nats-{connection,subscription}` → `../{connection,subscription}`.

## What's intentionally NOT renamed in this PR (deferred to MIG-7)

Per `docs/plan-cortex-migration.md` §4 MIG-7 (the cutover phase), the following remain at their grove-v2 names by design:

- **`package.json` `name` field** stays as `"grove"`. Full package.json rewrite (name, version, scripts, deps cleanup) lands at MIG-7.7. `bun.lock` is consistent with package.json (both say `grove`); the lock is not stale.
- **Console log prefix `grove-bot:`** in connection.ts + subscription.ts. Renames to `cortex:` at MIG-7.7 alongside the binary rename. Pure string change with no code-shape implication.
- **Default subscriber name `name: "grove-bot"`** in connection.ts. Same category — flips at MIG-7.7 along with the test assertion that pins it.

These deferrals are **explicit by plan**, not regressions. Doing them here would add noise to a pure-port PR and require lockstep test changes; bundling them with the rename phase is cleaner.

## What's NOT in this PR (next sub-PRs in MIG-1)

- Myelin envelope validator + runtime + subscriber (MIG-1.3..1.6)
- Dispatch-handler / message-router rename (MIG-1.7)
- Network-resolver (MIG-1.8)
- Surface-router (MIG-1.9 — new code, G-1111.A target)
- Fail-safe rule check at config-load (MIG-1.10)

## Test plan

- [x] `bunx tsc --noEmit` clean
- [x] `bun test src/bus/` — 20/20 pass (9 connection + 11 subscription, forwarded from grove-v2's G-1100 retro evidence)
- [x] Echo (sub-agent) round-1 review: **APPROVE-WITH-FIXES** — only minor was a PR-description-vs-reality mismatch on the package.json `name` field. Fixed in this description revision.

Refs cortex#3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)