### PR TITLE
feat(cortex): C-102.2 — myelin envelope validator + subscriber (MIG-1.3 + 1.4)

### DIFF
--- a/src/bus/myelin/__tests__/envelope-validator.test.ts
+++ b/src/bus/myelin/__tests__/envelope-validator.test.ts
@@ -1,0 +1,184 @@
+/**
+ * G-1100.B: Envelope validator tests.
+ *
+ * Uses the real example envelopes from upstream myelin as fixtures —
+ * valid-envelope.json and invalid-missing-sovereignty.json — copied
+ * into __fixtures__/ at vendor time. If the schema is upgraded, these
+ * fixtures should be re-copied alongside the schema (see
+ * SCHEMA_SOURCE_COMMIT in envelope-validator.ts).
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  SCHEMA_SOURCE_COMMIT,
+  tryParseEnvelope,
+  validateEnvelope,
+} from "../envelope-validator";
+import validEnvelope from "../vendor/__fixtures__/valid-envelope.json" with { type: "json" };
+import invalidMissingSovereignty from "../vendor/__fixtures__/invalid-missing-sovereignty.json" with { type: "json" };
+
+describe("envelope-validator", () => {
+  test("schema source commit is recorded for upgrade audit", () => {
+    expect(SCHEMA_SOURCE_COMMIT).toMatch(/^[0-9a-f]{40}$/);
+  });
+
+  test("validates the upstream valid example", () => {
+    const result = validateEnvelope(validEnvelope);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.envelope.id).toBe("550e8400-e29b-41d4-a716-446655440000");
+      expect(result.envelope.sovereignty.classification).toBe("local");
+      expect(result.envelope.sovereignty.model_class).toBe("local-only");
+    }
+  });
+
+  test("rejects the upstream invalid example (missing sovereignty)", () => {
+    const result = validateEnvelope(invalidMissingSovereignty);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      // The Ajv error path or schemaPath should reference sovereignty.
+      const surfacesSovereignty = result.errors.some(
+        (e) =>
+          e.instancePath.includes("sovereignty") ||
+          e.schemaPath.includes("sovereignty") ||
+          e.params?.missingProperty === "sovereignty",
+      );
+      expect(surfacesSovereignty).toBe(true);
+    }
+  });
+
+  test("rejects an envelope with bad sovereignty.classification", () => {
+    const bad = {
+      ...(validEnvelope as object),
+      sovereignty: {
+        ...(validEnvelope as { sovereignty: object }).sovereignty,
+        classification: "secret", // not in {local, federated, public}
+      },
+    };
+    const result = validateEnvelope(bad);
+    expect(result.ok).toBe(false);
+  });
+
+  test("rejects an envelope with non-uuid id", () => {
+    const bad = { ...(validEnvelope as object), id: "not-a-uuid" };
+    const result = validateEnvelope(bad);
+    expect(result.ok).toBe(false);
+  });
+
+  test("rejects an envelope missing required type field", () => {
+    const bad = { ...(validEnvelope as { type?: string } & object) };
+    delete (bad as { type?: string }).type;
+    const result = validateEnvelope(bad);
+    expect(result.ok).toBe(false);
+  });
+
+  test("accepts an envelope without optional correlation_id and extensions", () => {
+    const minimal = { ...(validEnvelope as object) };
+    delete (minimal as { correlation_id?: string }).correlation_id;
+    delete (minimal as { extensions?: object }).extensions;
+    const result = validateEnvelope(minimal);
+    expect(result.ok).toBe(true);
+  });
+
+  test("tryParseEnvelope returns the envelope on valid input", () => {
+    const env = tryParseEnvelope(validEnvelope);
+    expect(env).not.toBeNull();
+    expect(env?.type).toBe("ops.deploy.completed");
+  });
+
+  test("tryParseEnvelope returns null on invalid input", () => {
+    const env = tryParseEnvelope(invalidMissingSovereignty);
+    expect(env).toBeNull();
+  });
+
+  test("tryParseEnvelope returns null on garbage", () => {
+    expect(tryParseEnvelope(null)).toBeNull();
+    expect(tryParseEnvelope("a string")).toBeNull();
+    expect(tryParseEnvelope(42)).toBeNull();
+    expect(tryParseEnvelope({})).toBeNull();
+  });
+
+  // signed_by coverage — added per Echo cycle-1 review of #71. The schema
+  // defines a oneOf over ed25519 and hub-stamp; without these tests the
+  // identity-attestation path is silent. Base64 strings are 88-char ed25519
+  // sig length per the schema's minLength constraint.
+  const ED25519_SIG = "A".repeat(88);
+
+  test("accepts an envelope with valid ed25519 signed_by", () => {
+    const env = {
+      ...(validEnvelope as object),
+      signed_by: {
+        method: "ed25519",
+        principal: "did:mf:luna",
+        signature: ED25519_SIG,
+        at: "2026-05-08T09:00:00Z",
+      },
+    };
+    const result = validateEnvelope(env);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.envelope.signed_by?.method).toBe("ed25519");
+    }
+  });
+
+  test("accepts an envelope with valid hub-stamp signed_by", () => {
+    const env = {
+      ...(validEnvelope as object),
+      signed_by: {
+        method: "hub-stamp",
+        principal: "did:mf:luna",
+        stamped_by: "did:mf:hub-eu-1",
+        signature: ED25519_SIG,
+        at: "2026-05-08T09:00:00Z",
+      },
+    };
+    const result = validateEnvelope(env);
+    expect(result.ok).toBe(true);
+    if (result.ok && result.envelope.signed_by?.method === "hub-stamp") {
+      expect(result.envelope.signed_by.stamped_by).toBe("did:mf:hub-eu-1");
+    }
+  });
+
+  test("rejects an ed25519 signed_by missing the signature field", () => {
+    const env = {
+      ...(validEnvelope as object),
+      signed_by: {
+        method: "ed25519",
+        principal: "did:mf:luna",
+        // signature: missing
+        at: "2026-05-08T09:00:00Z",
+      },
+    };
+    const result = validateEnvelope(env);
+    expect(result.ok).toBe(false);
+  });
+
+  test("rejects a hub-stamp signed_by missing stamped_by", () => {
+    const env = {
+      ...(validEnvelope as object),
+      signed_by: {
+        method: "hub-stamp",
+        principal: "did:mf:luna",
+        // stamped_by: missing — required for hub-stamp shape
+        signature: ED25519_SIG,
+        at: "2026-05-08T09:00:00Z",
+      },
+    };
+    const result = validateEnvelope(env);
+    expect(result.ok).toBe(false);
+  });
+
+  test("rejects a signed_by with non-DID principal", () => {
+    const env = {
+      ...(validEnvelope as object),
+      signed_by: {
+        method: "ed25519",
+        principal: "not-a-did",
+        signature: ED25519_SIG,
+        at: "2026-05-08T09:00:00Z",
+      },
+    };
+    const result = validateEnvelope(env);
+    expect(result.ok).toBe(false);
+  });
+});

--- a/src/bus/myelin/__tests__/subscriber.test.ts
+++ b/src/bus/myelin/__tests__/subscriber.test.ts
@@ -1,0 +1,386 @@
+/**
+ * G-1100.D: MyelinSubscriber tests.
+ *
+ * Drives the compose layer end-to-end against the same multi-consumer
+ * fake NatsConnection used by G-1100.C, plus the actual G-1100.B
+ * validator (no mocks for the validator — we want the real Ajv2020
+ * compiled schema in the loop).
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import type { NatsConnection, Subscription, Status } from "nats";
+import { MyelinSubscriber, type InvalidEnvelopeReason } from "../subscriber";
+import { NatsLink } from "../../nats/connection";
+import validEnvelope from "../vendor/__fixtures__/valid-envelope.json" with { type: "json" };
+
+// ---- fakes (same shape as nats-subscription.test.ts; copied because tests
+//      are read-side primitives and copying keeps each suite independent) ----
+
+function makeFakeSubscription() {
+  type Msg = { subject: string; data: Uint8Array };
+  const queue: Msg[] = [];
+  let waiter: ((m: Msg | null) => void) | null = null;
+  let drained = false;
+  const iterator = (async function* () {
+    while (true) {
+      if (queue.length > 0) {
+        yield queue.shift()!;
+        continue;
+      }
+      if (drained) return;
+      const next = await new Promise<Msg | null>((r) => (waiter = r));
+      if (next === null) return;
+      yield next;
+    }
+  })();
+  const drain = mock(async () => {
+    drained = true;
+    waiter?.(null);
+  });
+  const sub = {
+    [Symbol.asyncIterator]: () => iterator,
+    drain,
+    closed: Promise.resolve(),
+  } as unknown as Subscription;
+  return {
+    sub,
+    push: (subject: string, data: Uint8Array) => {
+      const msg = { subject, data };
+      if (waiter) {
+        const w = waiter;
+        waiter = null;
+        w(msg);
+      } else {
+        queue.push(msg);
+      }
+    },
+    drain,
+  };
+}
+
+function makeFakeConnection() {
+  const subs: ReturnType<typeof makeFakeSubscription>[] = [];
+  const listeners = new Set<(s: Status | null) => void>();
+  let closed = false;
+
+  const status = () =>
+    (async function* () {
+      const queue: (Status | null)[] = [];
+      let waiter: ((s: Status | null) => void) | null = null;
+      const listener = (s: Status | null) => {
+        if (waiter) {
+          const w = waiter;
+          waiter = null;
+          w(s);
+        } else {
+          queue.push(s);
+        }
+      };
+      listeners.add(listener);
+      try {
+        while (true) {
+          if (queue.length > 0) {
+            const next = queue.shift()!;
+            if (next === null) return;
+            yield next;
+            continue;
+          }
+          if (closed) return;
+          const next = await new Promise<Status | null>((r) => (waiter = r));
+          if (next === null) return;
+          yield next;
+        }
+      } finally {
+        listeners.delete(listener);
+      }
+    })();
+
+  const subscribe = mock((_pattern: string) => {
+    const fake = makeFakeSubscription();
+    subs.push(fake);
+    return fake.sub;
+  });
+
+  const drain = mock(async () => {
+    closed = true;
+    for (const l of listeners) l(null);
+  });
+
+  const fakeNc = { status, subscribe, drain } as unknown as NatsConnection;
+  return {
+    nc: fakeNc,
+    subAt: (i: number) => subs[i],
+    pushStatus: (s: Status) => {
+      for (const l of listeners) l(s);
+    },
+    subscribe,
+    drain,
+  };
+}
+
+async function makeLink() {
+  const fake = makeFakeConnection();
+  const link = await NatsLink.connect({
+    url: "nats://localhost:4222",
+    name: "myelin-test",
+    connectImpl: (async () => fake.nc) as never,
+  });
+  return { link, fake };
+}
+
+async function flushMicrotasks(times = 8) {
+  for (let i = 0; i < times; i++) {
+    await Promise.resolve();
+  }
+}
+
+function bytes(obj: unknown): Uint8Array {
+  return new TextEncoder().encode(JSON.stringify(obj));
+}
+
+// ---- tests ----
+
+describe("MyelinSubscriber", () => {
+  let restoreConsole: () => void;
+  beforeEach(() => {
+    const orig = {
+      warn: console.warn,
+      error: console.error,
+      info: console.info,
+    };
+    console.warn = mock(() => {});
+    console.error = mock(() => {});
+    console.info = mock(() => {});
+    restoreConsole = () => {
+      console.warn = orig.warn;
+      console.error = orig.error;
+      console.info = orig.info;
+    };
+  });
+  afterEach(() => restoreConsole());
+
+  test("delivers valid envelopes to onEnvelope", async () => {
+    const { link, fake } = await makeLink();
+    const received: { type: string; subject: string }[] = [];
+    const sub = MyelinSubscriber.start(link, {
+      pattern: "local.acme.>",
+      onEnvelope: (env, subject) => {
+        received.push({ type: env.type, subject });
+      },
+    });
+    fake.subAt(0)!.push("local.acme.deploy", bytes(validEnvelope));
+    await flushMicrotasks();
+    expect(received).toEqual([
+      { type: "ops.deploy.completed", subject: "local.acme.deploy" },
+    ]);
+    await sub.stop();
+    await link.close();
+  });
+
+  test("routes schema failures to onInvalidEnvelope with structured reason", async () => {
+    const { link, fake } = await makeLink();
+    const received: unknown[] = [];
+    const drops: { reason: InvalidEnvelopeReason; subject: string }[] = [];
+    const sub = MyelinSubscriber.start(link, {
+      pattern: "local.acme.>",
+      onEnvelope: (env, subject) => {
+        received.push({ env, subject });
+      },
+      onInvalidEnvelope: (reason, subject) => {
+        drops.push({ reason, subject });
+      },
+    });
+    const invalid = { ...(validEnvelope as object), type: 12345 };
+    fake.subAt(0)!.push("local.acme.bad", bytes(invalid));
+    await flushMicrotasks();
+    expect(received).toEqual([]);
+    expect(drops.length).toBe(1);
+    expect(drops[0]!.subject).toBe("local.acme.bad");
+    expect(drops[0]!.reason.kind).toBe("schema");
+    if (drops[0]!.reason.kind === "schema") {
+      expect(drops[0]!.reason.errors.length).toBeGreaterThan(0);
+      expect(drops[0]!.reason.firstPath).toBeDefined();
+      expect(drops[0]!.reason.firstMessage).toBeDefined();
+    }
+    await sub.stop();
+    await link.close();
+  });
+
+  test("routes JSON parse failures to onInvalidEnvelope", async () => {
+    const { link, fake } = await makeLink();
+    const drops: { reason: InvalidEnvelopeReason }[] = [];
+    const sub = MyelinSubscriber.start(link, {
+      pattern: "local.acme.>",
+      onEnvelope: () => {},
+      onInvalidEnvelope: (reason) => {
+        drops.push({ reason });
+      },
+    });
+    fake.subAt(0)!.push("local.acme.broken", new TextEncoder().encode("{ not json"));
+    await flushMicrotasks();
+    expect(drops.length).toBe(1);
+    expect(drops[0]!.reason.kind).toBe("json-parse");
+    if (drops[0]!.reason.kind === "json-parse") {
+      expect(drops[0]!.reason.message).toBeTruthy();
+    }
+    await sub.stop();
+    await link.close();
+  });
+
+  test("default sink logs subject and reason without raw snippet", async () => {
+    const { link, fake } = await makeLink();
+    const sub = MyelinSubscriber.start(link, {
+      pattern: "local.acme.>",
+      onEnvelope: () => {},
+    });
+    fake.subAt(0)!.push("local.acme.bad", bytes({ definitely: "not an envelope" }));
+    await flushMicrotasks();
+    expect((console.warn as ReturnType<typeof mock>).mock.calls.length).toBeGreaterThan(0);
+    const msg = String((console.warn as ReturnType<typeof mock>).mock.calls[0]?.[0]);
+    expect(msg).toContain("dropped invalid envelope");
+    expect(msg).toContain("local.acme.bad");
+    expect(msg).toContain("data.length=");
+    expect(msg).not.toContain("payload snippet:");
+    await sub.stop();
+    await link.close();
+  });
+
+  test("default sink includes snippet when logRawSnippet is true", async () => {
+    const { link, fake } = await makeLink();
+    const sub = MyelinSubscriber.start(link, {
+      pattern: "local.acme.>",
+      onEnvelope: () => {},
+      logRawSnippet: true,
+    });
+    fake.subAt(0)!.push("local.acme.bad", bytes({ definitely: "not an envelope" }));
+    await flushMicrotasks();
+    expect((console.warn as ReturnType<typeof mock>).mock.calls.length).toBeGreaterThan(0);
+    const msg = String((console.warn as ReturnType<typeof mock>).mock.calls[0]?.[0]);
+    expect(msg).toContain("payload snippet:");
+    await sub.stop();
+    await link.close();
+  });
+
+  test("default sink does not leak payload bytes when logRawSnippet is false", async () => {
+    const { link, fake } = await makeLink();
+    const sub = MyelinSubscriber.start(link, {
+      pattern: "local.acme.>",
+      onEnvelope: () => {},
+      // logRawSnippet defaults to false — assert the off-path explicitly
+    });
+    // Embed an obviously-secret-looking string in the payload. The
+    // default sink must not include it, regardless of how the schema
+    // failure is rendered.
+    const payloadBytes = bytes({ shape: "wrong", secret: "hunter2-bearer-XYZ" });
+    fake.subAt(0)!.push("local.acme.leaky", payloadBytes);
+    await flushMicrotasks();
+    const msg = String((console.warn as ReturnType<typeof mock>).mock.calls[0]?.[0]);
+    expect(msg).not.toContain("hunter2");
+    expect(msg).not.toContain("payload snippet:");
+    expect(msg).toContain("data.length=");
+    await sub.stop();
+    await link.close();
+  });
+
+  test("default sink strips CRLF from subject (no log injection)", async () => {
+    const { link, fake } = await makeLink();
+    const sub = MyelinSubscriber.start(link, {
+      pattern: "local.acme.>",
+      onEnvelope: () => {},
+    });
+    // NATS subjects shouldn't normally contain CRLF, but a malicious
+    // peer could publish with a crafted subject. Default sink must
+    // strip control chars before interpolation.
+    fake.subAt(0)!.push(
+      "local.acme.bad\n[FAKE-LOG] grove-bot: SECURITY auth-bypass-detected",
+      bytes({ shape: "wrong" }),
+    );
+    await flushMicrotasks();
+    const msg = String((console.warn as ReturnType<typeof mock>).mock.calls[0]?.[0]);
+    // Newline before "[FAKE-LOG]" must be stripped.
+    expect(msg).not.toMatch(/\n\[FAKE-LOG\]/);
+    expect(msg).toContain("dropped invalid envelope");
+    await sub.stop();
+    await link.close();
+  });
+
+  test("default sink strips CRLF from Ajv instancePath echoed via crafted JSON keys", async () => {
+    const { link, fake } = await makeLink();
+    const sub = MyelinSubscriber.start(link, {
+      pattern: "local.acme.>",
+      onEnvelope: () => {},
+    });
+    // Ajv echoes the JSON property name into `instancePath` when an
+    // unknown property is present (with `additionalProperties: false`).
+    // A malicious publisher could inject a CRLF via a crafted key;
+    // sanitization must apply to the assembled reason string, not just
+    // to subject + snippet.
+    const malicious: Record<string, unknown> = {
+      ...(validEnvelope as object),
+    };
+    malicious["evil\n[FAKE-LOG] grove-bot: SECURITY"] = "bypass";
+    fake.subAt(0)!.push("local.acme.injection", bytes(malicious));
+    await flushMicrotasks();
+    const msg = String((console.warn as ReturnType<typeof mock>).mock.calls[0]?.[0]);
+    expect(msg).not.toMatch(/\n\[FAKE-LOG\]/);
+    expect(msg).toContain("dropped invalid envelope");
+    await sub.stop();
+    await link.close();
+  });
+
+  test("schema arm forwards the full Ajv errors array, not just the first", async () => {
+    const { link, fake } = await makeLink();
+    const drops: { reason: InvalidEnvelopeReason }[] = [];
+    const sub = MyelinSubscriber.start(link, {
+      pattern: "local.acme.>",
+      onEnvelope: () => {},
+      onInvalidEnvelope: (reason) => drops.push({ reason }),
+    });
+    // Two independent violations: bad type AND missing id.
+    const broken = { ...(validEnvelope as object), type: 12345 } as Record<string, unknown>;
+    delete broken.id;
+    fake.subAt(0)!.push("local.acme.multi", bytes(broken));
+    await flushMicrotasks();
+    expect(drops.length).toBe(1);
+    expect(drops[0]!.reason.kind).toBe("schema");
+    if (drops[0]!.reason.kind === "schema") {
+      expect(drops[0]!.reason.errors.length).toBeGreaterThanOrEqual(2);
+    }
+    await sub.stop();
+    await link.close();
+  });
+
+  test("a thrown onEnvelope routes through onError, doesn't kill delivery", async () => {
+    const { link, fake } = await makeLink();
+    const handled: string[] = [];
+    const errors: { msg: string; subject: string }[] = [];
+    const sub = MyelinSubscriber.start(link, {
+      pattern: "local.acme.>",
+      onEnvelope: (_env, subject) => {
+        if (subject.endsWith(".boom")) throw new Error("handler boom");
+        handled.push(subject);
+      },
+      onError: (err, subject) => errors.push({ msg: err.message, subject }),
+    });
+    fake.subAt(0)!.push("local.acme.first", bytes(validEnvelope));
+    fake.subAt(0)!.push("local.acme.boom", bytes(validEnvelope));
+    fake.subAt(0)!.push("local.acme.third", bytes(validEnvelope));
+    await flushMicrotasks(16);
+    expect(handled).toEqual(["local.acme.first", "local.acme.third"]);
+    expect(errors).toEqual([{ msg: "handler boom", subject: "local.acme.boom" }]);
+    await sub.stop();
+    await link.close();
+  });
+
+  test("stop() drains the inner subscription (idempotent)", async () => {
+    const { link, fake } = await makeLink();
+    const sub = MyelinSubscriber.start(link, {
+      pattern: "local.acme.>",
+      onEnvelope: () => {},
+    });
+    await sub.stop();
+    await sub.stop();
+    expect(fake.subAt(0)!.drain).toHaveBeenCalledTimes(1);
+    await link.close();
+  });
+});

--- a/src/bus/myelin/envelope-validator.ts
+++ b/src/bus/myelin/envelope-validator.ts
@@ -1,0 +1,132 @@
+/**
+ * G-1100.B: Myelin envelope validator.
+ *
+ * Validates inbound envelopes against the vendored myelin schema. The
+ * schema is copied verbatim from `~/Developer/myelin/schemas/envelope.schema.json`
+ * pinned at commit 96b14ea (myelin#22 — MY-400 Group 1: identity types).
+ * Per docs/design-collaboration-surface.md §9 coupling rules, grove
+ * MUST NOT import from `myelin/` at runtime — the schema travels with us
+ * by value.
+ *
+ * To upgrade the schema: copy the file, update the `SCHEMA_SOURCE_COMMIT`
+ * constant, run the tests, ship a PR. There is no auto-sync.
+ */
+
+// The myelin schema declares draft 2020-12 ($schema), so use Ajv's
+// 2020-12 build rather than the default draft-07 entry point.
+import Ajv2020, { type ValidateFunction, type ErrorObject } from "ajv/dist/2020";
+import addFormats from "ajv-formats";
+import schema from "./vendor/envelope.schema.json" with { type: "json" };
+
+/** Pin so future maintainers know which myelin commit the schema was lifted from. */
+export const SCHEMA_SOURCE_COMMIT = "96b14ea6f0adfdface89d326e4e6cb36856a073f";
+
+/**
+ * Hand-typed Envelope shape matching the JSON Schema. We hand-write rather
+ * than codegen because (a) the schema is small and stable, (b) the manual
+ * type doubles as documentation for callers, (c) avoiding a build step keeps
+ * the import-safe / zero-side-effect property of this module.
+ */
+export interface Envelope {
+  /** UUID v4 — unique per envelope. */
+  id: string;
+  /** `org.agent.instance` — 2-5 dotted segments. */
+  source: string;
+  /** `domain.entity.action` — what kind of signal this is. */
+  type: string;
+  /** ISO-8601 timestamp. */
+  timestamp: string;
+  /** UUID v4 — links related envelopes across a workflow. Optional. */
+  correlation_id?: string;
+  /** The message's passport. Sovereignty travels with the envelope. */
+  sovereignty: {
+    classification: "local" | "federated" | "public";
+    /** ISO 3166-1 alpha-2 country code (e.g. "NZ", "DE"). */
+    data_residency: string;
+    /** Maximum number of hops the envelope may traverse. ≥ 0. */
+    max_hop: number;
+    /** Whether the envelope's payload may be processed by frontier models. */
+    frontier_ok: boolean;
+    /** Constraint on which model class may process the payload. */
+    model_class: "local-only" | "frontier" | "any";
+  };
+  /** Reserved for future marketplace integration. Empty object today. */
+  economics?: Record<string, unknown>;
+  /** Forward-compatible metadata. Optional. */
+  extensions?: Record<string, unknown>;
+  /** Arbitrary signal content. */
+  payload: Record<string, unknown>;
+  /**
+   * Identity attestation — proves who sent this envelope. Optional in the
+   * schema (envelope predates MY-400 identity layer). Discriminated on
+   * `method`: `ed25519` is the bare per-bot signature; `hub-stamp` adds a
+   * federation-hub re-signature for cross-org trust. Both shapes are
+   * defined upstream — see `envelope.schema.json` `signed_by.oneOf`.
+   */
+  signed_by?: SignedByEd25519 | SignedByHubStamp;
+}
+
+/**
+ * Bare ed25519 signature — the principal signs the envelope directly.
+ * Used for intra-org traffic where every bot's `did:mf:*` principal is
+ * trusted and key material is held locally.
+ */
+export interface SignedByEd25519 {
+  method: "ed25519";
+  /** Principal DID — `did:mf:<name>` per myelin convention. */
+  principal: string;
+  /** Base64-encoded ed25519 signature (88+ chars). */
+  signature: string;
+  /** ISO-8601 timestamp the signature was produced. */
+  at: string;
+}
+
+/**
+ * Hub-stamped signature — a federation hub re-signs after verifying the
+ * principal's bare signature. Used for cross-org traffic where the
+ * receiver trusts the hub but not necessarily the originating bot.
+ */
+export interface SignedByHubStamp {
+  method: "hub-stamp";
+  /** Originating principal — `did:mf:<name>`. */
+  principal: string;
+  /** Hub principal that re-signed — `did:mf:<hub-name>`. */
+  stamped_by: string;
+  /** Base64-encoded ed25519 signature from the hub. */
+  signature: string;
+  /** ISO-8601 timestamp the hub signed. */
+  at: string;
+}
+
+export type ValidationResult =
+  | { ok: true; envelope: Envelope }
+  | { ok: false; errors: ErrorObject[] };
+
+const ajv = new Ajv2020({ allErrors: true, strict: false });
+addFormats(ajv);
+const compiled: ValidateFunction = ajv.compile(schema as object);
+
+/**
+ * Validate an unknown value against the myelin envelope schema. On success,
+ * returns the value typed as `Envelope` (no defensive copy — the value
+ * is the same reference). On failure, returns the Ajv error array.
+ *
+ * Pure function. Safe to call from any context. Compiled validator is
+ * created once at module load.
+ */
+export function validateEnvelope(value: unknown): ValidationResult {
+  if (compiled(value)) {
+    return { ok: true, envelope: value as Envelope };
+  }
+  return { ok: false, errors: compiled.errors ?? [] };
+}
+
+/**
+ * Convenience for callers that just want a typed envelope or `null` (and
+ * are willing to swallow the error detail). For loggable callers, prefer
+ * `validateEnvelope` so you can surface the specific failure path.
+ */
+export function tryParseEnvelope(value: unknown): Envelope | null {
+  const result = validateEnvelope(value);
+  return result.ok ? result.envelope : null;
+}

--- a/src/bus/myelin/subscriber.ts
+++ b/src/bus/myelin/subscriber.ts
@@ -1,0 +1,182 @@
+/**
+ * G-1100.D: Myelin envelope subscriber.
+ *
+ * Composes G-1100.C's `NatsSubscription` (raw bytes from a NATS subject
+ * pattern) with G-1100.B's `validateEnvelope` to deliver typed,
+ * schema-validated `Envelope` objects to a callback.
+ *
+ * Invalid envelopes are routed to `onInvalidEnvelope` as a discriminated
+ * union (`json-parse` vs `schema`) with the full Ajv error array on the
+ * schema branch. Default sink logs subject + reason only; raw payload
+ * snippet is gated behind `logRawSnippet` to prevent leaking credentials
+ * or PII from misconfigured publishers.
+ *
+ * Coupling rule (per docs/design-collaboration-surface.md §9):
+ * Subscribe-only — never publishes. The publish path is gated by a
+ * subject allowlist that lands in a follow-up (issue #70).
+ */
+
+import type { ErrorObject } from "ajv/dist/2020";
+import type { NatsLink } from "../nats/connection";
+import { NatsSubscription } from "../nats/subscription";
+import { validateEnvelope, type Envelope } from "./envelope-validator";
+
+export type { ErrorObject };
+
+/** Per-envelope handler. Errors thrown propagate to onError. */
+export type EnvelopeHandler = (envelope: Envelope, subject: string) => void | Promise<void>;
+
+/** Optional sink for *handler* errors (NOT for invalid envelopes — those are
+ *  always logged and dropped by the validator branch, never surfaced as a
+ *  handler error). */
+export type EnvelopeErrorHandler = (err: Error, subject: string) => void;
+
+/** Discriminated reason for invalid envelopes. */
+export type InvalidEnvelopeReason =
+  | { kind: "json-parse"; message: string }
+  | { kind: "schema"; errors: ErrorObject[]; firstPath: string; firstMessage: string };
+
+/** Optional sink invoked when an envelope fails validation. Defaults to a
+ *  structured console.warn so a missing handler doesn't make drops invisible. */
+export type InvalidEnvelopeHandler = (
+  reason: InvalidEnvelopeReason,
+  subject: string,
+  rawSnippet: string,
+) => void;
+
+export interface MyelinSubscriberOptions {
+  /** NATS subject pattern, e.g. `local.acme.>`. Required. */
+  pattern: string;
+  /** Per-valid-envelope handler. */
+  onEnvelope: EnvelopeHandler;
+  /** Optional sink for handler throws. */
+  onError?: EnvelopeErrorHandler;
+  /** Optional sink for envelope validation failures. */
+  onInvalidEnvelope?: InvalidEnvelopeHandler;
+  /** Include raw payload snippet in default invalid-envelope log. Off by
+   *  default to prevent leaking credentials or PII from misconfigured
+   *  upstream publishers. */
+  logRawSnippet?: boolean;
+}
+
+const utf8 = new TextDecoder("utf-8", { fatal: false });
+
+/** Strip C0 control characters (newlines, tabs, etc.) to prevent log injection. */
+function sanitizeForLog(s: string): string {
+  return s.replace(/[\x00-\x1f\x7f]/g, "");
+}
+
+/**
+ * A live myelin subscriber. Wraps a `NatsSubscription`; same lifecycle
+ * (start at construction, stop via `stop()`, reconnects handled by the
+ * inner subscription).
+ */
+export class MyelinSubscriber {
+  readonly pattern: string;
+  private readonly subscription: NatsSubscription;
+  private readonly onEnvelope: EnvelopeHandler;
+  private readonly onError: EnvelopeErrorHandler;
+  private readonly onInvalidEnvelope: InvalidEnvelopeHandler;
+
+  private constructor(link: NatsLink, opts: MyelinSubscriberOptions) {
+    this.pattern = opts.pattern;
+    this.onEnvelope = opts.onEnvelope;
+    this.onError = opts.onError ?? defaultHandlerErrorLog;
+    this.onInvalidEnvelope =
+      opts.onInvalidEnvelope ?? makeDefaultInvalidEnvelopeLog(opts.logRawSnippet ?? false);
+
+    this.subscription = NatsSubscription.start(link, {
+      pattern: opts.pattern,
+      onMessage: (subject, data) => this.handleRaw(subject, data),
+      onError: (err, subject) => this.onError(err, subject),
+    });
+  }
+
+  /** Start a new myelin subscriber. */
+  static start(link: NatsLink, opts: MyelinSubscriberOptions): MyelinSubscriber {
+    return new MyelinSubscriber(link, opts);
+  }
+
+  /** Stop the subscriber. Drains the inner subscription. Idempotent. */
+  async stop(): Promise<void> {
+    await this.subscription.stop();
+  }
+
+  private async handleRaw(subject: string, data: Uint8Array): Promise<void> {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(utf8.decode(data));
+    } catch (err) {
+      this.onInvalidEnvelope(
+        { kind: "json-parse", message: err instanceof Error ? err.message : String(err) },
+        subject,
+        safeSnippet(data),
+      );
+      return;
+    }
+
+    const result = validateEnvelope(parsed);
+    if (!result.ok) {
+      const first = result.errors[0];
+      this.onInvalidEnvelope(
+        {
+          kind: "schema",
+          errors: result.errors,
+          firstPath: first?.instancePath || "/",
+          firstMessage: first?.message ?? "(no message)",
+        },
+        subject,
+        safeSnippet(data),
+      );
+      return;
+    }
+
+    try {
+      await this.onEnvelope(result.envelope, subject);
+    } catch (err) {
+      this.onError(
+        err instanceof Error ? err : new Error(String(err)),
+        subject,
+      );
+    }
+  }
+}
+
+function defaultHandlerErrorLog(err: Error, subject: string): void {
+  console.error(
+    `grove-bot: myelin-subscriber onEnvelope handler error on "${sanitizeForLog(subject)}":`,
+    err.message,
+  );
+}
+
+function makeDefaultInvalidEnvelopeLog(logRawSnippet: boolean): InvalidEnvelopeHandler {
+  return (reason, subject, rawSnippet) => {
+    const safeSubject = sanitizeForLog(subject);
+    // The reason string is built from data that may transitively echo
+    // attacker-controlled bytes — JSON.parse's error message can include
+    // the offending input, and Ajv's `instancePath` echoes attacker-
+    // chosen JSON property names verbatim. Sanitize the assembled
+    // string before interpolating into the log line so a crafted CRLF
+    // in a key (e.g. `{"\n[FAKE-LOG]": …}`) cannot split the log.
+    const reasonStr = sanitizeForLog(
+      reason.kind === "json-parse"
+        ? `JSON parse error: ${reason.message}`
+        : `schema: ${reason.firstPath} ${reason.firstMessage} (${reason.errors.length} error(s))`,
+    );
+    // Always emit `data.length=N` so log-aggregation regexes have a
+    // stable shape; append the sanitised snippet only when opt-in.
+    const lengthSuffix = `data.length=${rawSnippet.length}`;
+    const snippetSuffix = logRawSnippet
+      ? `; payload snippet: ${sanitizeForLog(rawSnippet)}`
+      : "";
+    console.warn(
+      `grove-bot: myelin-subscriber dropped invalid envelope on "${safeSubject}" — ${reasonStr}; ${lengthSuffix}${snippetSuffix}`,
+    );
+  };
+}
+
+/** First 200 bytes of the payload, decoded as UTF-8 with replacement chars
+ *  for invalid sequences. */
+function safeSnippet(data: Uint8Array): string {
+  return utf8.decode(data.slice(0, 200));
+}

--- a/src/bus/myelin/vendor/__fixtures__/invalid-missing-sovereignty.json
+++ b/src/bus/myelin/vendor/__fixtures__/invalid-missing-sovereignty.json
@@ -1,0 +1,9 @@
+{
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "source": "acme.monitor.prod-01",
+  "type": "ops.deploy.completed",
+  "timestamp": "2026-05-06T15:00:00Z",
+  "payload": {
+    "note": "This envelope is intentionally invalid — missing sovereignty block"
+  }
+}

--- a/src/bus/myelin/vendor/__fixtures__/valid-envelope.json
+++ b/src/bus/myelin/vendor/__fixtures__/valid-envelope.json
@@ -1,0 +1,23 @@
+{
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "source": "acme.monitor.prod-01",
+  "type": "ops.deploy.completed",
+  "timestamp": "2026-05-06T15:00:00Z",
+  "correlation_id": "7c9e6679-7425-40de-944b-e07fc1f90ae7",
+  "sovereignty": {
+    "classification": "local",
+    "data_residency": "DE",
+    "max_hop": 0,
+    "frontier_ok": false,
+    "model_class": "local-only"
+  },
+  "economics": {},
+  "extensions": {
+    "trace_id": "abc123"
+  },
+  "payload": {
+    "service": "api-gateway",
+    "version": "2.4.1",
+    "environment": "production"
+  }
+}

--- a/src/bus/myelin/vendor/envelope.schema.json
+++ b/src/bus/myelin/vendor/envelope.schema.json
@@ -1,0 +1,113 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://myelin.metafactory.ai/schemas/envelope/v1",
+  "title": "Myelin Envelope",
+  "description": "Universal message envelope for the agentic nervous system. One schema for all signals — sovereignty travels with the message.",
+  "type": "object",
+  "required": ["id", "source", "type", "timestamp", "sovereignty", "payload"],
+  "properties": {
+    "id": {
+      "type": "string",
+      "format": "uuid",
+      "description": "Unique identifier for this envelope instance."
+    },
+    "source": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9-]*(\\.[a-z][a-z0-9-]*){2,4}$",
+      "description": "Origin address. Minimum 3 segments (org.agent.instance), up to 5 for domain-scoped agents (org.domain.agent.instance.replica).",
+      "examples": ["acme.monitor.prod-01", "metafactory.pilot.local", "acme.security.scanner.prod-01"]
+    },
+    "type": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9-]*(\\.[a-z][a-z0-9-]*){1,4}$",
+      "description": "Signal type: domain.entity.action (2-5 segments)",
+      "examples": ["code.pr.review", "security.alert.created", "pipeline.job.completed"]
+    },
+    "timestamp": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO-8601 timestamp of envelope creation."
+    },
+    "correlation_id": {
+      "type": "string",
+      "format": "uuid",
+      "description": "Links related envelopes across a workflow or conversation."
+    },
+    "sovereignty": {
+      "type": "object",
+      "description": "The message's passport — declares where it can travel and what can process it.",
+      "required": ["classification", "data_residency", "max_hop", "frontier_ok", "model_class"],
+      "properties": {
+        "classification": {
+          "type": "string",
+          "enum": ["local", "federated", "public"],
+          "description": "local: never leaves org boundary. federated: crosses boundaries subject to sovereignty rules. public: unrestricted."
+        },
+        "data_residency": {
+          "type": "string",
+          "pattern": "^[A-Z]{2}$",
+          "description": "ISO 3166-1 alpha-2 country code for data residency requirements.",
+          "examples": ["CH", "DE", "US"]
+        },
+        "max_hop": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Maximum number of federation hops permitted. 0 = origin only."
+        },
+        "frontier_ok": {
+          "type": "boolean",
+          "description": "Whether this message may be processed by frontier (cloud) AI models."
+        },
+        "model_class": {
+          "type": "string",
+          "enum": ["local-only", "frontier", "any"],
+          "description": "Constrains which model class may process this signal."
+        }
+      },
+      "additionalProperties": false
+    },
+    "economics": {
+      "type": "object",
+      "description": "Reserved for future token economics, wallet integration, and budget constraints. Do not populate in v1 — schema will be defined when payment infrastructure matures.",
+      "properties": {},
+      "additionalProperties": true
+    },
+    "signed_by": {
+      "type": "object",
+      "description": "Identity attestation — proves who sent this envelope. Discriminated on method.",
+      "oneOf": [
+        {
+          "required": ["method", "principal", "signature", "at"],
+          "properties": {
+            "method": { "const": "ed25519" },
+            "principal": { "type": "string", "pattern": "^did:mf:[a-z][a-z0-9._-]+$" },
+            "signature": { "type": "string", "minLength": 88, "pattern": "^[A-Za-z0-9+/]+=*$" },
+            "at": { "type": "string", "format": "date-time" }
+          },
+          "additionalProperties": false
+        },
+        {
+          "required": ["method", "principal", "stamped_by", "signature", "at"],
+          "properties": {
+            "method": { "const": "hub-stamp" },
+            "principal": { "type": "string", "pattern": "^did:mf:[a-z][a-z0-9._-]+$" },
+            "stamped_by": { "type": "string", "pattern": "^did:mf:[a-z][a-z0-9._-]+$" },
+            "signature": { "type": "string", "minLength": 88, "pattern": "^[A-Za-z0-9+/]+=*$" },
+            "at": { "type": "string", "format": "date-time" }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "extensions": {
+      "type": "object",
+      "description": "Forward-compatible extension point. Use for routing hints, debug context, trace IDs, or domain-specific metadata without requiring a schema version bump.",
+      "additionalProperties": true
+    },
+    "payload": {
+      "type": "object",
+      "description": "Arbitrary signal content. Structure is domain-specific — the envelope does not constrain payload shape."
+    }
+  },
+  "additionalProperties": false
+}


### PR DESCRIPTION
## Summary

Second sub-PR of MIG-1 (cortex#3 — Bus runtime). Strict port from grove-v2's G-1100.B + G-1100.D ladders into `cortex/src/bus/myelin/`. No behavior change.

## What's in this PR

| Source (grove-v2) | Target (cortex) | Tests |
|---|---|---|
| `src/bot/lib/myelin/envelope.schema.json` | `src/bus/myelin/vendor/envelope.schema.json` | (vendored, untouched) |
| `src/bot/lib/myelin/__fixtures__/` | `src/bus/myelin/vendor/__fixtures__/` | (fixtures, untouched) |
| `src/bot/lib/myelin/envelope-validator.ts` | `src/bus/myelin/envelope-validator.ts` | 15/15 forwarded |
| `src/bot/lib/myelin-subscriber.ts` | `src/bus/myelin/subscriber.ts` | 11/11 forwarded |

Vendor split per architecture §3.3 + plan §2.1: schema + fixtures live under `vendor/` (untouched upstream), validator at `bus/myelin/` (cortex code consuming vendor/).

## What's deferred (intentional)

**`myelin-runtime.ts` (MIG-1.5) NOT in this PR.** It depends on `BotConfig` from `src/bot/types/config.ts` which moves at MIG-7 (config consolidation phase). Stubbing BotConfig here would create churn at the cutover; cleaner to defer runtime to a post-MIG-7 follow-up. Tracking issue filed.

**Other deferred to subsequent sub-PRs of MIG-1** (per plan §4 numbering):
- MIG-1.6 dispatch-handler (was message-router; plan line 342)
- MIG-1.7 (no copy — inbound-queue.ts is legacy-grove-only; plan line 343)
- MIG-1.8 network-resolver
- MIG-1.9 surface-router (NEW code, G-1111.A)
- MIG-1.10 fail-safe rule check at config-load

## Test plan

- [x] `bunx tsc --noEmit` clean
- [x] `bun test src/bus/` — **46/46 pass** (15 validator + 11 subscriber + 9 connection + 11 subscription — full G-1100 ladder forwarded)
- [x] Echo (sub-agent) APPROVE — pure port, vendor split correct, deferral defensible. Three minor nits addressed (description numbering corrected here; MIG-1.5 tracking issue filed; `grove-bot:` log prefix flagged for MIG-7 rename).

Refs cortex#3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)