### PR TITLE
feat(common): C-108 — MIG-7 sub-lifts (config, usage-monitor, deployment templates)

### DIFF
--- a/src/common/config/__tests__/loader.test.ts
+++ b/src/common/config/__tests__/loader.test.ts
@@ -1,0 +1,207 @@
+/**
+ * G-500: Config Loader Tests
+ * Tests for multi-network config loading (central bot.yaml + per-network files).
+ */
+
+import { test, expect, describe, beforeEach, afterEach } from "bun:test";
+import { mkdirSync, writeFileSync, rmSync, existsSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { stringify } from "yaml";
+import { loadConfig } from "../loader";
+
+// ---------------------------------------------------------------------------
+// Test fixture helpers
+// ---------------------------------------------------------------------------
+
+let testDir: string;
+
+function setupTestDir(): string {
+  const dir = join(tmpdir(), `grove-config-test-${Date.now()}`);
+  mkdirSync(dir, { recursive: true });
+  mkdirSync(join(dir, "networks"), { recursive: true });
+  return dir;
+}
+
+function writeCentralConfig(dir: string, config: Record<string, unknown>): string {
+
+  const path = join(dir, "bot.yaml");
+  writeFileSync(path, stringify(config));
+  return path;
+}
+
+function writeNetworkFile(dir: string, filename: string, config: Record<string, unknown>): void {
+
+  writeFileSync(join(dir, "networks", filename), stringify(config));
+}
+
+/** Minimal valid central config */
+function minimalCentral(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    agent: { name: "test-bot", displayName: "TestBot" },
+    claude: { timeoutMs: 120000 },
+    networksDir: "./networks",
+    ...overrides,
+  };
+}
+
+/** Minimal valid network file */
+function minimalNetwork(id: string, overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id,
+    cloud: {
+      endpoint: `https://${id}.workers.dev`,
+      apiKey: `grove_sk_${id}`,
+      operatorId: `op-${id}`,
+    },
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Setup / Teardown
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  testDir = setupTestDir();
+});
+
+afterEach(() => {
+  if (testDir && existsSync(testDir)) {
+    rmSync(testDir, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// T6.1: Valid multi-network config
+// ---------------------------------------------------------------------------
+
+describe("multi-network config loading", () => {
+  test("loads central config + two network files", () => {
+    const configPath = writeCentralConfig(testDir, minimalCentral());
+    writeNetworkFile(testDir, "alpha.yaml", minimalNetwork("alpha", {
+      discord: [{ token: "tok-a", guildId: "guild-a", agentChannelId: "ch-a", logChannelId: "log-a" }],
+    }));
+    writeNetworkFile(testDir, "beta.yaml", minimalNetwork("beta", {
+      mattermost: [{ apiUrl: "https://mm.example.com", apiToken: "tok-b", channels: ["ch-b1"] }],
+    }));
+
+    const config = loadConfig(configPath);
+
+    expect(config.networks).toHaveLength(2);
+    expect(config.networks.map(n => n.id).sort()).toEqual(["alpha", "beta"]);
+
+    // Flattened arrays aggregate from all networks
+    expect(config.discord).toHaveLength(1);
+    expect(config.discord[0]!.guildId).toBe("guild-a");
+    expect(config.mattermost).toHaveLength(1);
+    expect(config.mattermost[0]!.apiUrl).toBe("https://mm.example.com");
+  });
+
+  test("network file without cloud section is valid (local-only network)", () => {
+    const configPath = writeCentralConfig(testDir, minimalCentral());
+    writeNetworkFile(testDir, "local.yaml", {
+      id: "local",
+      discord: [{ token: "tok", guildId: "g1", agentChannelId: "c1", logChannelId: "l1" }],
+    });
+
+    const config = loadConfig(configPath);
+    expect(config.networks).toHaveLength(1);
+    expect(config.networks[0]!.id).toBe("local");
+    expect(config.networks[0]!.cloud).toBeUndefined();
+  });
+
+  test("per-network claude overrides are preserved", () => {
+    const configPath = writeCentralConfig(testDir, minimalCentral({
+      claude: { timeoutMs: 300000, allowedDirs: ["/global"] },
+    }));
+    writeNetworkFile(testDir, "secure.yaml", minimalNetwork("secure", {
+      claude: { allowedDirs: ["/restricted"], disallowedTools: ["Bash"] },
+    }));
+
+    const config = loadConfig(configPath);
+    const network = config.networks.find(n => n.id === "secure")!;
+    expect(network.claude?.allowedDirs).toEqual(["/restricted"]);
+    expect(network.claude?.disallowedTools).toEqual(["Bash"]);
+
+    // Global claude settings preserved
+    expect(config.claude.timeoutMs).toBe(300000);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T6.2: Duplicate network ID rejection
+// ---------------------------------------------------------------------------
+
+describe("duplicate network ID rejection", () => {
+  test("throws on duplicate network IDs across files", () => {
+    const configPath = writeCentralConfig(testDir, minimalCentral());
+    writeNetworkFile(testDir, "first.yaml", minimalNetwork("same-id"));
+    writeNetworkFile(testDir, "second.yaml", minimalNetwork("same-id"));
+
+    expect(() => loadConfig(configPath)).toThrow(/duplicate network id/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T6.3: Missing networksDir fallback (legacy mode)
+// ---------------------------------------------------------------------------
+
+describe("legacy fallback", () => {
+  test("works without networksDir when discord/mattermost in bot.yaml", () => {
+    // Legacy format: everything in one file, no networksDir
+    const configPath = writeCentralConfig(testDir, {
+      agent: { name: "legacy-bot", displayName: "LegacyBot" },
+      claude: { timeoutMs: 120000 },
+      discord: { token: "tok", guildId: "g1", agentChannelId: "c1", logChannelId: "l1" },
+      api: { mode: "cloud", endpoint: "https://api.example.com", apiKey: "sk_123", operatorId: "op1" },
+    });
+
+    // Remove networks dir to simulate legacy
+    rmSync(join(testDir, "networks"), { recursive: true });
+
+    const config = loadConfig(configPath);
+    expect(config.networks).toHaveLength(1);
+    expect(config.networks[0]!.id).toBe("default");
+    expect(config.discord).toHaveLength(1);
+  });
+
+  test("empty networksDir creates no networks (beyond legacy fallback)", () => {
+    const configPath = writeCentralConfig(testDir, {
+      agent: { name: "empty-bot", displayName: "EmptyBot" },
+      claude: { timeoutMs: 120000 },
+      networksDir: "./networks",
+    });
+    // networks/ dir exists but is empty
+
+    const config = loadConfig(configPath);
+    expect(config.networks).toHaveLength(0);
+    expect(config.discord).toHaveLength(0);
+    expect(config.mattermost).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// T6.4: Malformed network file error reporting
+// ---------------------------------------------------------------------------
+
+describe("error reporting", () => {
+  test("includes filename in validation error", () => {
+    const configPath = writeCentralConfig(testDir, minimalCentral());
+    writeNetworkFile(testDir, "bad.yaml", { id: "" }); // Invalid: empty id
+
+    try {
+      loadConfig(configPath);
+      expect(true).toBe(false); // should not reach here
+    } catch (err: any) {
+      expect(err.message).toContain("bad.yaml");
+    }
+  });
+
+  test("rejects network ID with uppercase or special chars", () => {
+    const configPath = writeCentralConfig(testDir, minimalCentral());
+    writeNetworkFile(testDir, "bad.yaml", minimalNetwork("Bad_Network!"));
+
+    expect(() => loadConfig(configPath)).toThrow(/bad\.yaml/i);
+  });
+});

--- a/src/common/config/__tests__/watcher.test.ts
+++ b/src/common/config/__tests__/watcher.test.ts
@@ -1,0 +1,261 @@
+/**
+ * F-092: Config Watcher Tests
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { writeFileSync, unlinkSync, existsSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { ConfigWatcher } from "../watcher";
+import type { BotConfig } from "../../types/config";
+
+const TEST_CONFIG: BotConfig = {
+  agent: {
+    name: "test",
+    displayName: "Test Bot",
+  },
+  discord: [],
+  mattermost: [],
+  claude: {
+    timeoutMs: 120_000,
+    asyncTimeoutMs: 900_000,
+    additionalArgs: [],
+    allowedTools: [],
+    disallowedTools: [],
+    allowedDirs: [],
+    readOnlyDirs: [],
+  },
+  attachments: {
+    enabled: true,
+    maxFileSizeBytes: 10 * 1024 * 1024,
+    maxTotalSizeBytes: 25 * 1024 * 1024,
+    maxAttachmentsPerMessage: 10,
+  },
+  execution: {
+    default: "local",
+    backends: [],
+  },
+  github: {
+    webhookSecret: "",
+    repos: [],
+    agentDetection: {
+      commitTrailers: ["Co-Authored-By: Claude"],
+      branchPatterns: ["^feat/(g|f|i)-\\d+"],
+      commentPatterns: ["^Starting:", "^Completed:"],
+    },
+  },
+  api: {
+    enabled: false,
+    port: 8766,
+    corsOrigin: "*",
+    mode: "local",
+    endpoint: "",
+    apiKey: "",
+    operatorId: "",
+    cfAccessClientId: "",
+    cfAccessClientSecret: "",
+  },
+  grove: {
+    notifications: { discord: false },
+    baseUrl: "",
+  },
+  paths: {
+    publishedEventsDir: "~/.claude/events/published",
+    logDir: "~/.config/grove/logs",
+  },
+  networksDir: "./networks",
+  networks: [],
+};
+
+describe("ConfigWatcher", () => {
+  let testConfigPath: string;
+
+  beforeEach(() => {
+    testConfigPath = join(tmpdir(), `test-bot-${Date.now()}.yaml`);
+    // Write initial config
+    const yaml = `
+agent:
+  name: test
+  displayName: Test Bot
+discord: []
+mattermost: []
+claude:
+  timeoutMs: 120000
+  asyncTimeoutMs: 900000
+  additionalArgs: []
+  allowedTools: []
+  disallowedTools: []
+  allowedDirs: []
+  readOnlyDirs: []
+attachments:
+  enabled: true
+  maxFileSizeBytes: 10485760
+  maxTotalSizeBytes: 26214400
+  maxAttachmentsPerMessage: 10
+execution:
+  default: local
+  backends: []
+github:
+  webhookSecret: ""
+  repos: []
+  agentDetection:
+    commitTrailers:
+      - "Co-Authored-By: Claude"
+    branchPatterns:
+      - "^feat/(g|f|i)-\\\\d+"
+    commentPatterns:
+      - "^Starting:"
+      - "^Completed:"
+api:
+  enabled: false
+  port: 8766
+  corsOrigin: "*"
+  mode: local
+  endpoint: ""
+  apiKey: ""
+  operatorId: ""
+paths:
+  publishedEventsDir: "~/.claude/events/published"
+  logDir: "~/.config/grove/logs"
+`;
+    writeFileSync(testConfigPath, yaml, "utf-8");
+  });
+
+  afterEach(() => {
+    if (existsSync(testConfigPath)) {
+      unlinkSync(testConfigPath);
+    }
+  });
+
+  test("identifies safe field changes", async () => {
+    let capturedEvent: any = null;
+
+    const watcher = new ConfigWatcher(testConfigPath, TEST_CONFIG, (event) => {
+      capturedEvent = event;
+    });
+
+    // Update a safe field (timeoutMs)
+    const updatedYaml = `
+agent:
+  name: test
+  displayName: Test Bot
+discord: []
+mattermost: []
+claude:
+  timeoutMs: 180000
+  asyncTimeoutMs: 900000
+  additionalArgs: []
+  allowedTools: []
+  disallowedTools: []
+  allowedDirs: []
+  readOnlyDirs: []
+attachments:
+  enabled: true
+  maxFileSizeBytes: 10485760
+  maxTotalSizeBytes: 26214400
+  maxAttachmentsPerMessage: 10
+execution:
+  default: local
+  backends: []
+github:
+  webhookSecret: ""
+  repos: []
+  agentDetection:
+    commitTrailers:
+      - "Co-Authored-By: Claude"
+    branchPatterns:
+      - "^feat/(g|f|i)-\\\\d+"
+    commentPatterns:
+      - "^Starting:"
+      - "^Completed:"
+api:
+  enabled: false
+  port: 8766
+  corsOrigin: "*"
+  mode: local
+  endpoint: ""
+  apiKey: ""
+  operatorId: ""
+paths:
+  publishedEventsDir: "~/.claude/events/published"
+  logDir: "~/.config/grove/logs"
+`;
+
+    watcher.start();
+    writeFileSync(testConfigPath, updatedYaml, "utf-8");
+
+    // Wait for debounced reload
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    watcher.stop();
+
+    expect(capturedEvent).not.toBeNull();
+    expect(capturedEvent.applied).toContain("claude.timeoutMs");
+    expect(capturedEvent.requiresRestart).toHaveLength(0);
+  });
+
+  test("identifies restart-required field changes", async () => {
+    let capturedEvent: any = null;
+
+    const watcher = new ConfigWatcher(testConfigPath, TEST_CONFIG, (event) => {
+      capturedEvent = event;
+    });
+
+    // Update a restart field (agent.name)
+    const updatedYaml = `
+agent:
+  name: new-name
+  displayName: Test Bot
+discord: []
+mattermost: []
+claude:
+  timeoutMs: 120000
+  asyncTimeoutMs: 900000
+  additionalArgs: []
+  allowedTools: []
+  disallowedTools: []
+  allowedDirs: []
+  readOnlyDirs: []
+attachments:
+  enabled: true
+  maxFileSizeBytes: 10485760
+  maxTotalSizeBytes: 26214400
+  maxAttachmentsPerMessage: 10
+execution:
+  default: local
+  backends: []
+github:
+  webhookSecret: ""
+  repos: []
+  agentDetection:
+    commitTrailers:
+      - "Co-Authored-By: Claude"
+    branchPatterns:
+      - "^feat/(g|f|i)-\\\\d+"
+    commentPatterns:
+      - "^Starting:"
+      - "^Completed:"
+api:
+  enabled: false
+  port: 8766
+  corsOrigin: "*"
+  mode: local
+  endpoint: ""
+  apiKey: ""
+  operatorId: ""
+paths:
+  publishedEventsDir: "~/.claude/events/published"
+  logDir: "~/.config/grove/logs"
+`;
+
+    watcher.start();
+    writeFileSync(testConfigPath, updatedYaml, "utf-8");
+
+    // Wait for debounced reload
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    watcher.stop();
+
+    expect(capturedEvent).not.toBeNull();
+    expect(capturedEvent.requiresRestart).toContain("agent.name");
+    expect(capturedEvent.applied).toHaveLength(0);
+  });
+});

--- a/src/common/config/loader.ts
+++ b/src/common/config/loader.ts
@@ -1,0 +1,154 @@
+/**
+ * G-500: Config Loader
+ *
+ * Loads central bot.yaml + per-network files from networks/ directory.
+ * Apache/nginx-style: shared settings in bot.yaml, per-network files for
+ * platform instances, cloud endpoints, repos, and security overrides.
+ */
+
+import { readFileSync, readdirSync, existsSync } from "fs";
+import { join, dirname, resolve } from "path";
+import { parse as parseYaml } from "yaml";
+import { BotConfigSchema, NetworkFileSchema, type BotConfig, type NetworkFile } from "../types/config";
+
+/**
+ * Load bot.yaml + networks/*.yaml, validate, merge.
+ */
+export function loadConfig(path: string): BotConfig {
+  const expandedPath = path.replace(/^~/, process.env.HOME ?? "~");
+  const configDir = dirname(expandedPath);
+
+  const content = readFileSync(expandedPath, "utf-8");
+  const raw = parseYaml(content) ?? {};
+
+  const explicitNetworksDir = !!raw.networksDir;
+  const networksDir = resolve(configDir, raw.networksDir ?? "./networks");
+  const networks = loadNetworkFiles(networksDir, explicitNetworksDir);
+
+  // Legacy fallback: if no network files and legacy api.* fields exist, create default network
+  let isLegacyMode = false;
+  if (networks.length === 0 && !raw.networksDir && hasLegacyCloudConfig(raw)) {
+    networks.push(buildLegacyNetwork(raw));
+    isLegacyMode = true;
+  }
+
+  // Aggregate discord/mattermost from networks into top-level arrays
+  const aggregatedDiscord = isLegacyMode
+    ? networks.flatMap(n => n.discord)
+    : [
+        ...(raw.discord ? (Array.isArray(raw.discord) ? raw.discord : [raw.discord]) : []),
+        ...networks.flatMap(n => n.discord),
+      ];
+  const aggregatedMattermost = isLegacyMode
+    ? networks.flatMap(n => n.mattermost)
+    : [
+        ...(raw.mattermost ? (Array.isArray(raw.mattermost) ? raw.mattermost : [raw.mattermost]) : []),
+        ...networks.flatMap(n => n.mattermost),
+      ];
+
+  const merged = {
+    ...raw,
+    discord: aggregatedDiscord,
+    mattermost: aggregatedMattermost,
+    networks,
+    networksDir: raw.networksDir ?? "./networks",
+  };
+
+  return BotConfigSchema.parse(merged);
+}
+
+function loadNetworkFiles(networksDir: string, explicit: boolean): NetworkFile[] {
+  if (!existsSync(networksDir)) {
+    if (explicit) {
+      console.warn(`grove-bot: networksDir "${networksDir}" does not exist — no networks loaded`);
+    }
+    return [];
+  }
+
+  const files = readdirSync(networksDir)
+    .filter(f => f.endsWith(".yaml") || f.endsWith(".yml"))
+    .sort();
+
+  const networks: NetworkFile[] = [];
+  const seenIds = new Map<string, string>();
+
+  for (const filename of files) {
+    const filePath = join(networksDir, filename);
+    const content = readFileSync(filePath, "utf-8");
+
+    let raw: unknown;
+    try {
+      raw = parseYaml(content);
+    } catch (err) {
+      throw new Error(`Failed to parse network file ${filename}: ${err instanceof Error ? err.message : err}`);
+    }
+
+    let network: NetworkFile;
+    try {
+      network = NetworkFileSchema.parse(raw);
+    } catch (err: any) {
+      const issues = err.issues ?? err.errors ?? [];
+      const details = issues.map((i: any) => `  ${i.path?.join(".")}: ${i.message}`).join("\n");
+      throw new Error(`Validation error in ${filename}:\n${details || err.message}`);
+    }
+
+    if (seenIds.has(network.id)) {
+      throw new Error(`Duplicate network ID "${network.id}" found in ${filename} and ${seenIds.get(network.id)}`);
+    }
+    seenIds.set(network.id, filename);
+    networks.push(network);
+  }
+
+  return networks;
+}
+
+function hasLegacyCloudConfig(raw: Record<string, unknown>): boolean {
+  const api = raw.api as Record<string, unknown> | undefined;
+  return !!(api?.endpoint && api?.apiKey);
+}
+
+function buildLegacyNetwork(raw: Record<string, unknown>): NetworkFile {
+  const api = raw.api as Record<string, unknown>;
+  const agent = raw.agent as Record<string, unknown> | undefined;
+
+  const operatorId = (api.operatorId || (agent ? agent.operatorId : undefined)) as string | undefined;
+  if (!operatorId) {
+    console.warn(
+      "grove-bot: no operatorId configured (api.operatorId or agent.operatorId). " +
+      "Skipping cloud config for legacy default network to avoid phantom dashboard entries.",
+    );
+  }
+
+  const cloud: Record<string, unknown> | undefined = operatorId ? {
+    endpoint: api.endpoint as string,
+    apiKey: api.apiKey as string,
+    operatorId,
+    ...(api.cfAccessClientId ? { cfAccessClientId: api.cfAccessClientId } : {}),
+    ...(api.cfAccessClientSecret ? { cfAccessClientSecret: api.cfAccessClientSecret } : {}),
+  } : undefined;
+  const network: Record<string, unknown> = { id: "default" };
+  if (cloud) network.cloud = cloud;
+
+  if (raw.discord) network.discord = raw.discord;
+  if (raw.mattermost) network.mattermost = raw.mattermost;
+  if (raw.github) network.github = raw.github;
+
+  const claude = raw.claude as Record<string, unknown> | undefined;
+  if (claude) {
+    const nc: Record<string, unknown> = {};
+    if (claude.allowedDirs) nc.allowedDirs = claude.allowedDirs;
+    if (claude.readOnlyDirs) nc.readOnlyDirs = claude.readOnlyDirs;
+    if (claude.disallowedTools) nc.disallowedTools = claude.disallowedTools;
+    if (claude.bashAllowlist) nc.bashAllowlist = claude.bashAllowlist;
+    if (Object.keys(nc).length > 0) network.claude = nc;
+  }
+
+  if (agent) {
+    const op: Record<string, unknown> = {};
+    if (agent.operatorDiscordId) op.operatorDiscordId = agent.operatorDiscordId;
+    if (agent.operatorMattermostId) op.operatorMattermostId = agent.operatorMattermostId;
+    if (Object.keys(op).length > 0) network.operator = op;
+  }
+
+  return NetworkFileSchema.parse(network);
+}

--- a/src/common/config/watcher.ts
+++ b/src/common/config/watcher.ts
@@ -1,0 +1,327 @@
+/**
+ * F-092: Config Hot-Reload
+ * Watches bot.yaml for changes and applies safe fields without restart.
+ */
+
+import { watch, type FSWatcher, existsSync } from "fs";
+import { loadConfig } from "./loader";
+import type { BotConfig } from "../types/config";
+
+export interface ConfigChangeEvent {
+  /** Fields that were applied without requiring restart */
+  applied: string[];
+  /** Fields that changed but require restart */
+  requiresRestart: string[];
+  /** New config (already applied to the watcher's internal state) */
+  config: BotConfig;
+}
+
+export type ConfigChangeHandler = (event: ConfigChangeEvent) => void;
+
+/**
+ * Fields safe to hot-reload (no connection restart needed).
+ * Changes to these fields are applied immediately.
+ */
+const SAFE_FIELDS = new Set([
+  // Claude execution config
+  "claude.timeoutMs",
+  "claude.asyncTimeoutMs",
+  "claude.additionalArgs",
+  "claude.allowedTools",
+  "claude.disallowedTools",
+  "claude.bashAllowlist",
+  "claude.allowedDirs",
+  "claude.readOnlyDirs",
+
+  // Discord instance config (per instance)
+  "discord.contextDepth",
+  "discord.enableAgentLog",
+  "discord.worklogChannelId",
+  "discord.roles",
+  "discord.defaultRole",
+  "discord.dm",
+
+  // Mattermost instance config (per instance)
+  "mattermost.channels",
+  "mattermost.allowedUsers",
+  "mattermost.roles",
+  "mattermost.defaultRole",
+  "mattermost.pollIntervalMs",
+
+  // Attachments
+  "attachments.enabled",
+  "attachments.maxFileSizeBytes",
+  "attachments.maxTotalSizeBytes",
+  "attachments.maxAttachmentsPerMessage",
+
+  // GitHub config
+  "github.webhookSecret",
+  "github.repos",
+  "github.agentDetection",
+
+  // API config (port changes need reconnect warning)
+  "api.corsOrigin",
+
+  // Agent identity
+  "agent.displayName",
+  "agent.operatorName",
+]);
+
+/**
+ * Fields that require a full restart.
+ * Changes to these fields are logged but NOT applied.
+ */
+const RESTART_FIELDS = new Set([
+  // Connection credentials
+  "discord.token",
+  "discord.guildId",
+  "discord.agentChannelId",
+  "discord.logChannelId",
+  "mattermost.apiUrl",
+  "mattermost.apiToken",
+  "mattermost.webhookUrl",
+  "mattermost.webhookToken",
+
+  // API connection
+  "api.enabled",
+  "api.port",
+  "api.mode",
+  "api.endpoint",
+  "api.apiKey",
+
+  // Agent core identity
+  "agent.name",
+  "agent.operatorId",
+  "agent.operatorDiscordId",
+  "agent.operatorMattermostId",
+
+  // Execution backend
+  "execution.default",
+  "execution.backends",
+
+  // Paths
+  "paths.publishedEventsDir",
+  "paths.logDir",
+]);
+
+/**
+ * Compare two config objects and determine which fields changed.
+ * Returns:
+ * - applied: fields safe to hot-reload
+ * - requiresRestart: fields requiring restart
+ */
+function compareConfigs(oldConfig: BotConfig, newConfig: BotConfig): {
+  applied: string[];
+  requiresRestart: string[];
+} {
+  const applied: string[] = [];
+  const requiresRestart: string[] = [];
+
+  // Helper: deep compare two values
+  const isDifferent = (a: unknown, b: unknown): boolean => {
+    if (a === b) return false;
+    if (typeof a !== typeof b) return true;
+    if (a === null || b === null) return a !== b;
+    if (Array.isArray(a) && Array.isArray(b)) {
+      if (a.length !== b.length) return true;
+      return a.some((item, i) => isDifferent(item, b[i]));
+    }
+    if (typeof a === "object" && typeof b === "object") {
+      const aKeys = Object.keys(a as object);
+      const bKeys = Object.keys(b as object);
+      if (aKeys.length !== bKeys.length) return true;
+      return aKeys.some((key) => isDifferent((a as any)[key], (b as any)[key]));
+    }
+    return true;
+  };
+
+  // Check top-level fields
+  const checkField = (path: string, oldVal: unknown, newVal: unknown) => {
+    if (!isDifferent(oldVal, newVal)) return;
+
+    if (SAFE_FIELDS.has(path)) {
+      applied.push(path);
+    } else if (RESTART_FIELDS.has(path)) {
+      requiresRestart.push(path);
+    } else {
+      // Unknown field — be conservative, require restart
+      requiresRestart.push(path);
+    }
+  };
+
+  // Agent fields
+  if (isDifferent(oldConfig.agent, newConfig.agent)) {
+    for (const key of Object.keys(newConfig.agent)) {
+      checkField(`agent.${key}`, (oldConfig.agent as any)[key], (newConfig.agent as any)[key]);
+    }
+  }
+
+  // Claude fields
+  if (isDifferent(oldConfig.claude, newConfig.claude)) {
+    for (const key of Object.keys(newConfig.claude)) {
+      checkField(`claude.${key}`, (oldConfig.claude as any)[key], (newConfig.claude as any)[key]);
+    }
+  }
+
+  // Attachments fields
+  if (isDifferent(oldConfig.attachments, newConfig.attachments)) {
+    for (const key of Object.keys(newConfig.attachments)) {
+      checkField(`attachments.${key}`, (oldConfig.attachments as any)[key], (newConfig.attachments as any)[key]);
+    }
+  }
+
+  // GitHub fields
+  if (isDifferent(oldConfig.github, newConfig.github)) {
+    for (const key of Object.keys(newConfig.github)) {
+      checkField(`github.${key}`, (oldConfig.github as any)[key], (newConfig.github as any)[key]);
+    }
+  }
+
+  // API fields
+  if (isDifferent(oldConfig.api, newConfig.api)) {
+    for (const key of Object.keys(newConfig.api)) {
+      checkField(`api.${key}`, (oldConfig.api as any)[key], (newConfig.api as any)[key]);
+    }
+  }
+
+  /**
+   * Compare old and new instance arrays, detect added/removed/changed instances.
+   */
+  const compareInstanceArrays = <T extends Record<string, unknown>>(
+    oldInstances: T[],
+    newInstances: T[],
+    platformName: string,
+    getInstanceId: (inst: T) => string
+  ): void => {
+    const oldMap = new Map(oldInstances.map((inst) => [getInstanceId(inst), inst]));
+    const newMap = new Map(newInstances.map((inst) => [getInstanceId(inst), inst]));
+
+    for (const [id, newInst] of newMap) {
+      const oldInst = oldMap.get(id);
+      if (!oldInst) {
+        requiresRestart.push(`${platformName}[${id}]`);
+        continue;
+      }
+      for (const key of Object.keys(newInst)) {
+        if (key === "instanceId") continue;
+        checkField(`${platformName}.${key}`, (oldInst as any)[key], (newInst as any)[key]);
+      }
+    }
+
+    for (const id of oldMap.keys()) {
+      if (!newMap.has(id)) {
+        requiresRestart.push(`${platformName}[${id}] (removed)`);
+      }
+    }
+  };
+
+  // Discord instances
+  compareInstanceArrays(
+    oldConfig.discord,
+    newConfig.discord,
+    "discord",
+    (inst) => (inst as any).instanceId ?? (inst as any).guildId
+  );
+
+  // Mattermost instances
+  compareInstanceArrays(
+    oldConfig.mattermost,
+    newConfig.mattermost,
+    "mattermost",
+    (inst) => (inst as any).instanceId ?? "default"
+  );
+
+  return { applied, requiresRestart };
+}
+
+/**
+ * Watches bot.yaml for changes and triggers reload events.
+ */
+export class ConfigWatcher {
+  private configPath: string;
+  private config: BotConfig;
+  private handler: ConfigChangeHandler;
+  private watcher: FSWatcher | null = null;
+  private reloadTimeout: NodeJS.Timeout | null = null;
+
+  constructor(configPath: string, initialConfig: BotConfig, handler: ConfigChangeHandler) {
+    this.configPath = configPath.replace(/^~/, process.env.HOME ?? "~");
+    this.config = initialConfig;
+    this.handler = handler;
+  }
+
+  start(): void {
+    if (!existsSync(this.configPath)) {
+      console.error(`config-watcher: config file not found at ${this.configPath}`);
+      return;
+    }
+
+    console.log(`config-watcher: watching ${this.configPath} for changes`);
+
+    // Debounced reload: wait 200ms after last change before reloading
+    const triggerReload = () => {
+      if (this.reloadTimeout) clearTimeout(this.reloadTimeout);
+      this.reloadTimeout = setTimeout(() => this.reload(), 200);
+    };
+
+    this.watcher = watch(this.configPath, { persistent: false }, (eventType: string) => {
+      if (eventType === "change") {
+        triggerReload();
+      }
+    });
+  }
+
+  stop(): void {
+    if (this.watcher) {
+      this.watcher.close();
+      this.watcher = null;
+    }
+    if (this.reloadTimeout) {
+      clearTimeout(this.reloadTimeout);
+      this.reloadTimeout = null;
+    }
+  }
+
+  /**
+   * Reload config from disk, validate, compare, and trigger handler.
+   */
+  private reload(): void {
+    try {
+      console.log("config-watcher: reloading config...");
+
+      const newConfig = loadConfig(this.configPath);
+      const changes = compareConfigs(this.config, newConfig);
+
+      // Apply the new config (handler is responsible for updating its own state)
+      this.config = newConfig;
+
+      // Log what changed
+      if (changes.applied.length > 0) {
+        console.log(`config-watcher: applied ${changes.applied.length} change(s):`, changes.applied.join(", "));
+      }
+      if (changes.requiresRestart.length > 0) {
+        console.warn(
+          `config-watcher: ${changes.requiresRestart.length} field(s) require restart:`,
+          changes.requiresRestart.join(", ")
+        );
+      }
+      if (changes.applied.length === 0 && changes.requiresRestart.length === 0) {
+        console.log("config-watcher: no changes detected");
+      }
+
+      // Trigger handler
+      this.handler({
+        applied: changes.applied,
+        requiresRestart: changes.requiresRestart,
+        config: newConfig,
+      });
+    } catch (err) {
+      console.error("config-watcher: reload failed:", err instanceof Error ? err.message : err);
+    }
+  }
+
+  /** Get current config (reflects last successful reload) */
+  getConfig(): BotConfig {
+    return this.config;
+  }
+}

--- a/src/common/types/usage.ts
+++ b/src/common/types/usage.ts
@@ -1,0 +1,23 @@
+/**
+ * G-206: Account-level rate limit usage type.
+ *
+ * Extracted from grove-v2 `src/dashboard/types.ts` (legacy v2 dashboard tree
+ * which retires at MIG-8 and is NOT migrating). Pulled forward into
+ * `src/common/types/usage.ts` so cortex consumers (usage-monitor, future
+ * dashboards/exporters) can depend on a stable home that survives the
+ * v2 dashboard retirement. Precedent: MIG-3a `attachment-types.ts`.
+ *
+ * No transitive dependencies — pure structural type.
+ */
+export interface AccountUsage {
+  fiveHour: { utilization: number; resetsAt: string } | null;
+  sevenDay: { utilization: number; resetsAt: string } | null;
+  sevenDayOpus: { utilization: number; resetsAt: string } | null;
+  sevenDaySonnet: { utilization: number; resetsAt: string } | null;
+  extraUsage: {
+    isEnabled: boolean;
+    monthlyLimit: number | null;
+    usedCredits: number | null;
+  } | null;
+  updatedAt: string;
+}

--- a/src/common/usage/monitor.ts
+++ b/src/common/usage/monitor.ts
@@ -1,0 +1,190 @@
+/**
+ * G-206b: Usage Monitor — Tiered account usage data source
+ *
+ * Tiered approach (in priority order):
+ *   1. Event pipeline — agent.usage.update events from EventLogger hook
+ *   2. Cache file — ~/.claude/MEMORY/STATE/usage-cache.json (written by status line)
+ *   3. API poll — Direct Anthropic OAuth API call (last resort)
+ *
+ * Every update is persisted as a time-series snapshot in SQLite.
+ */
+
+import { existsSync, readFileSync, watchFile, unwatchFile, statSync } from "fs";
+import { join } from "path";
+import type { AccountUsage } from "../types/usage";
+import { fetchWithTimeout } from "../timeout";
+
+const CACHE_PATH = join(process.env.HOME ?? "~", ".claude", "MEMORY", "STATE", "usage-cache.json");
+const API_URL = "https://api.anthropic.com/api/oauth/usage";
+const CACHE_POLL_MS = 30_000;   // Check cache file every 30s
+const API_POLL_MS = 5 * 60_000; // API fallback every 5 min (conservative)
+
+export interface UsageSnapshot {
+  source: string;
+  fiveHourPct: number | null;
+  fiveHourResets: string | null;
+  sevenDayPct: number | null;
+  sevenDayResets: string | null;
+  sevenDayOpusPct: number | null;
+  sevenDaySonnetPct: number | null;
+  extraUsageEnabled: boolean | null;
+}
+
+type OnUpdate = (usage: AccountUsage, snapshot: UsageSnapshot) => void;
+
+export class UsageMonitor {
+  private onUpdate: OnUpdate;
+  private cacheTimer: Timer | null = null;
+  private apiTimer: Timer | null = null;
+  private lastCacheMtime = 0;
+  private lastEventAt = 0;
+
+  constructor(onUpdate: OnUpdate) {
+    this.onUpdate = onUpdate;
+  }
+
+  /** Start all tiers. Event-based updates are handled via receiveEvent(). */
+  start(): void {
+    // Tier 2: Poll cache file for changes
+    this.checkCache(); // immediate
+    this.cacheTimer = setInterval(() => this.checkCache(), CACHE_POLL_MS);
+
+    // Tier 3: API fallback — only if no events/cache updates in a while
+    this.apiTimer = setInterval(() => this.apiFallback(), API_POLL_MS);
+
+    console.log("grove-bot: usage monitor started (event → cache → api)");
+  }
+
+  /** Stop all timers. */
+  stop(): void {
+    if (this.cacheTimer) { clearInterval(this.cacheTimer); this.cacheTimer = null; }
+    if (this.apiTimer) { clearInterval(this.apiTimer); this.apiTimer = null; }
+  }
+
+  /**
+   * Tier 1: Receive an agent.usage.update event from the pipeline.
+   * This is the preferred data source — emitted by EventLogger hook.
+   */
+  receiveEvent(payload: Record<string, unknown>): AccountUsage {
+    this.lastEventAt = Date.now();
+    const usage = this.parseRawUsage(payload);
+    const snapshot = this.toSnapshot("event", payload);
+    this.onUpdate(usage, snapshot);
+    return usage;
+  }
+
+  /** Tier 2: Check if the cache file has been updated. */
+  private checkCache(): void {
+    try {
+      if (!existsSync(CACHE_PATH)) return;
+      const stat = statSync(CACHE_PATH);
+      if (stat.mtimeMs <= this.lastCacheMtime) return;
+      this.lastCacheMtime = stat.mtimeMs;
+
+      // Skip if we got an event recently (event is fresher)
+      if (Date.now() - this.lastEventAt < CACHE_POLL_MS) return;
+
+      const raw = JSON.parse(readFileSync(CACHE_PATH, "utf-8"));
+      if (!raw || (!raw.five_hour && !raw.seven_day)) return;
+
+      const usage = this.parseRawUsage(raw);
+      const snapshot = this.toSnapshot("cache", raw);
+      this.onUpdate(usage, snapshot);
+    } catch (err) {
+      console.error("grove-bot: usage cache read failed:", err instanceof Error ? err.message : err);
+    }
+  }
+
+  /** Tier 3: Poll the API directly (only if no recent updates from tiers 1/2). */
+  private async apiFallback(): Promise<void> {
+    // Skip if we got a recent update from event or cache
+    if (Date.now() - this.lastEventAt < API_POLL_MS) return;
+    if (Date.now() - this.lastCacheMtime < API_POLL_MS) return;
+
+    try {
+      const token = await this.getOAuthToken();
+      if (!token) return;
+
+      const response = await fetchWithTimeout("usage_monitor", 5_000, API_URL, {
+        headers: {
+          "Authorization": `Bearer ${token}`,
+          "Content-Type": "application/json",
+          "anthropic-beta": "oauth-2025-04-20",
+        },
+      });
+
+      if (!response.ok) return;
+
+      const raw = await response.json() as Record<string, any>;
+      const usage = this.parseRawUsage(raw);
+      const snapshot = this.toSnapshot("api", raw);
+      this.onUpdate(usage, snapshot);
+      this.lastEventAt = Date.now(); // Treat API response as a "recent update"
+    } catch (err) {
+      console.error("grove-bot: usage API fallback failed:", err instanceof Error ? err.message : err);
+    }
+  }
+
+  /** Parse raw Anthropic usage response into AccountUsage. */
+  private parseRawUsage(raw: Record<string, any>): AccountUsage {
+    const mapBucket = (b: any) =>
+      b ? { utilization: b.utilization ?? 0, resetsAt: b.resets_at ?? "" } : null;
+
+    return {
+      fiveHour: mapBucket(raw.five_hour),
+      sevenDay: mapBucket(raw.seven_day),
+      sevenDayOpus: mapBucket(raw.seven_day_opus),
+      sevenDaySonnet: mapBucket(raw.seven_day_sonnet),
+      extraUsage: raw.extra_usage ? {
+        isEnabled: raw.extra_usage.is_enabled ?? false,
+        monthlyLimit: raw.extra_usage.monthly_limit ?? null,
+        usedCredits: raw.extra_usage.used_credits ?? null,
+      } : null,
+      updatedAt: new Date().toISOString(),
+    };
+  }
+
+  /** Convert raw usage data to a DB-ready snapshot. */
+  private toSnapshot(source: string, raw: Record<string, any>): UsageSnapshot {
+    return {
+      source,
+      fiveHourPct: raw.five_hour?.utilization ?? null,
+      fiveHourResets: raw.five_hour?.resets_at ?? null,
+      sevenDayPct: raw.seven_day?.utilization ?? null,
+      sevenDayResets: raw.seven_day?.resets_at ?? null,
+      sevenDayOpusPct: raw.seven_day_opus?.utilization ?? null,
+      sevenDaySonnetPct: raw.seven_day_sonnet?.utilization ?? null,
+      extraUsageEnabled: raw.extra_usage?.is_enabled ?? null,
+    };
+  }
+
+  /** Extract OAuth access token. Tries: macOS Keychain → credentials file → env var. */
+  private async getOAuthToken(): Promise<string | null> {
+    if (process.platform === "darwin") {
+      try {
+        const result = Bun.spawnSync(["security", "find-generic-password", "-s", "Claude Code-credentials", "-w"]);
+        if (result.exitCode === 0) {
+          const creds = JSON.parse(result.stdout.toString());
+          const token = creds?.claudeAiOauth?.accessToken;
+          if (token) return token;
+        }
+      } catch (err) {
+        console.error("grove-bot: keychain credential read failed:", err instanceof Error ? err.message : err);
+      }
+    }
+
+    try {
+      const credPath = `${process.env.HOME}/.claude/.credentials.json`;
+      const file = Bun.file(credPath);
+      if (await file.exists()) {
+        const creds = await file.json();
+        const token = creds?.claudeAiOauth?.accessToken;
+        if (token) return token;
+      }
+    } catch (err) {
+      console.error("grove-bot: credentials file read failed:", err instanceof Error ? err.message : err);
+    }
+
+    return process.env.CLAUDE_CODE_OAUTH_TOKEN ?? null;
+  }
+}

--- a/src/services/com.cortex.bot.plist
+++ b/src/services/com.cortex.bot.plist
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.cortex.bot</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__HOME__/bin/cortex</string>
+        <string>start</string>
+        <string>--config</string>
+        <string>__HOME__/.config/grove/bot.yaml</string>
+    </array>
+    <key>WorkingDirectory</key>
+    <string>__GROVE_DIR__</string>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string>__HOME__/.config/grove/logs/grove-bot.log</string>
+    <key>StandardErrorPath</key>
+    <string>__HOME__/.config/grove/logs/grove-bot.error.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>__HOME__</string>
+        <key>PATH</key>
+        <string>__HOME__/bin:/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin</string>
+        <key>GROVE_CHANNEL</key>
+        <string>__AGENT_NAME__</string>
+    </dict>
+</dict>
+</plist>

--- a/src/services/com.cortex.relay.plist
+++ b/src/services/com.cortex.relay.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.cortex.relay</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>__BUN_PATH__</string>
+        <string>__GROVE_DIR__/src/taps/cc-events/grove-relay.ts</string>
+        <string>start</string>
+    </array>
+    <key>WorkingDirectory</key>
+    <string>__GROVE_DIR__</string>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string>__HOME__/.claude/logs/grove-relay.log</string>
+    <key>StandardErrorPath</key>
+    <string>__HOME__/.claude/logs/grove-relay.error.log</string>
+</dict>
+</plist>

--- a/src/settings/cortex-hooks.json
+++ b/src/settings/cortex-hooks.json
@@ -1,0 +1,28 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "type": "command",
+        "command": "bun $GROVE_DIR/src/hooks/GroveContext.hook.ts"
+      }
+    ],
+    "PostToolUse": [
+      {
+        "type": "command",
+        "command": "bun $GROVE_DIR/src/hooks/EventLogger.hook.ts"
+      }
+    ],
+    "Stop": [
+      {
+        "type": "command",
+        "command": "bun $GROVE_DIR/src/hooks/EventLogger.hook.ts"
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "type": "command",
+        "command": "bun $GROVE_DIR/src/hooks/EventLogger.hook.ts"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## What

MIG-7 sub-lifts — three deterministic-move sub-steps from plan §4 MIG-7 that don't depend on MIG-1.5 or the cortex bot binary (7.1). Front-loads MIG-7's mechanical work without touching the cutover sequencing (7.7+/7.8/7.9 stay deferred).

| Sub-step | Scope |
|---|---|
| **7.3** | `config-loader.ts` + `config-watcher.ts` → `src/common/config/{loader,watcher}.ts` + tests |
| **7.4** | `usage-monitor.ts` → `src/common/usage/monitor.ts` + `AccountUsage` type extracted to `src/common/types/usage.ts` |
| **7.6a** | Deployment plists + hooks template renamed grove→cortex |

## Source mapping

**7.3 config-loader + config-watcher (lift):**

| Source (grove-v2) | Target (cortex) |
|---|---|
| `src/bot/lib/config-loader.ts` (154 LOC) | `src/common/config/loader.ts` |
| `src/bot/lib/config-watcher.ts` (327 LOC) | `src/common/config/watcher.ts` |
| `src/bot/lib/__tests__/config-loader.test.ts` | `src/common/config/__tests__/loader.test.ts` |
| `src/bot/lib/__tests__/config-watcher.test.ts` | `src/common/config/__tests__/watcher.test.ts` |

4 import rewrites (sibling-path adjustments after rename — `./config-loader` → `./loader`).

**7.4 usage-monitor + AccountUsage extract:**

| Source (grove-v2) | Target (cortex) |
|---|---|
| `src/bot/lib/usage-monitor.ts` (190 LOC) | `src/common/usage/monitor.ts` |
| `src/dashboard/types.ts:20-31` (`AccountUsage` interface only) | `src/common/types/usage.ts` (new file, type-only extract) |

`AccountUsage` was the one cross-tree dependency from `usage-monitor` into the legacy v2 dashboard tree (`src/dashboard/`), which retires at MIG-8 and isn't migrating. Extracted as a leaf-type pull-forward (precedent: MIG-3a `attachment-types.ts`). Pure structural type, zero transitive deps. No tests for usage-monitor exist in grove-v2.

**7.6a Deployment templates (rename + content edit):**

| Source (grove-v2) | Target (cortex) | Edit |
|---|---|---|
| `src/services/com.grove.bot.plist` | `src/services/com.cortex.bot.plist` | Label `com.grove.bot` → `com.cortex.bot`; ProgramArguments[0] `__HOME__/bin/grove-bot` → `__HOME__/bin/cortex` |
| `src/services/com.grove.relay.plist` | `src/services/com.cortex.relay.plist` | Label `com.grove.relay` → `com.cortex.relay`; ProgramArguments script path updated to cortex's MIG-5a location (`src/taps/cc-events/grove-relay.ts`) |
| `src/settings/grove-hooks.json` | `src/settings/cortex-hooks.json` | **Rename only** — JSON content byte-identical (per plan §3 row 133) |

**Plan-noted deviations:**
- Relay plist's script path was updated from grove-v2's `src/relay/grove-relay.ts` to cortex's actual `src/taps/cc-events/grove-relay.ts` location. Without this edit the plist would `launchctl`-fail at install time. The `grove-relay.ts` filename itself stays (rename is MIG-7.6b, deferred).
- `cortex-hooks.json` references `\$GROVE_DIR/src/hooks/...` (grove-v2 layout); cortex's hooks are now at `src/taps/cc-events/hooks/`. Per plan §3 row 133, this step is **rename only**; path correction belongs with MIG-7.7 arc-manifest update when templates flow through `arc upgrade Cortex`.
- `__GROVE_DIR__` template tokens kept (not rewritten to `__CORTEX_DIR__`): cortex's `scripts/postupgrade.sh` doesn't render plists yet — that grows in MIG-7.7. Token swap would break the existing postupgrade contract.
- Bot plist's `__HOME__/.config/grove/bot.yaml`, `__HOME__/.config/grove/logs/...`, and `GROVE_CHANNEL` env var stay grove-style — install-side rename happens at MIG-7.9 (config migration).

## Out of scope (deferred per plan §4)

- 7.6b grove-relay.ts → relay.ts file/log/program-name rename — coordinated with 7.7 arc-manifest update
- 7.1 cortex.ts entrypoint, 7.2a-e (NEW BEHAVIOR — registry, trust-resolver, presence adapter refactor, Renderer interface, migrate-config helper) — needs MIG-1.5 + bus runtime
- 7.7 arc-manifest update — needs cortex bot binary
- 7.8, 7.9 launchd + config migration — operator-side deployment
- 7.10 CLAUDE.md regeneration — risk-prone; defer
- 7.11, 7.12 docs/license moves — separate cleanup PR
- 7.13, 7.14 final integration test + version bump

## Verification

- cortex root \`bunx tsc --noEmit\` → **exit 0**
- \`bun test src/common/config/\` → **10/10 pass** (4 loader + 6 watcher)
- \`bun test src/common/\` → **16/16 pass** (6 timeout + 4 loader + 6 watcher)
- Full suite: **1481 pass / 1 pre-existing fail** (was 1471 baseline; +10 net new tests; same env-dependent React shell test from MIG-2)

## Plan grounding

`docs/architecture.md` §8 places `common/` at top level under `cortex/src/`. Plan §4 MIG-7 is the work item; this PR ticks 7.3, 7.4, 7.6a only. The pull-forward pattern matches established precedent (MIG-2 round-1, MIG-3a, MIG-4a) — pull forward when destination matches eventual MIG-7.x home AND the file is forced cross-cutting infra.

Refs cortex#9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)