### PR TITLE
feat(bus): C-102 — myelin-runtime ported (MIG-1.5, closes cortex#13)

### DIFF
--- a/src/bus/myelin/__tests__/runtime.test.ts
+++ b/src/bus/myelin/__tests__/runtime.test.ts
@@ -1,0 +1,232 @@
+/**
+ * G-1100.E: MyelinRuntime tests.
+ *
+ * Tests focus on the opt-in / no-op surface — when nats config is
+ * absent, runtime is a no-op (the bot stays installable). When
+ * configured, it logs and connects. Direct integration with a real NATS
+ * server is deferred to manual smoke (per design §8 / iteration plan).
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import type { NatsConnection, Subscription, Status } from "nats";
+import type { BotConfig } from "../../../common/types/config";
+import { startMyelinRuntime } from "../runtime";
+
+function makeConfig(natsBlock: BotConfig["nats"]): BotConfig {
+  return {
+    agent: {
+      name: "luna",
+      displayName: "Luna",
+      operatorId: "andreas",
+      operatorName: "Andreas",
+    },
+    nats: natsBlock,
+  } as unknown as BotConfig;
+}
+
+function makeFakeNatsConnection() {
+  const statusListeners = new Set<(s: Status | null) => void>();
+  const subscribePatterns: string[] = [];
+
+  const status = () =>
+    (async function* () {
+      const queue: (Status | null)[] = [];
+      let waiter: ((s: Status | null) => void) | null = null;
+      const listener = (s: Status | null) => {
+        if (waiter) {
+          const w = waiter;
+          waiter = null;
+          w(s);
+        } else {
+          queue.push(s);
+        }
+      };
+      statusListeners.add(listener);
+      try {
+        while (true) {
+          if (queue.length > 0) {
+            const next = queue.shift()!;
+            if (next === null) return;
+            yield next;
+            continue;
+          }
+          const next = await new Promise<Status | null>((r) => (waiter = r));
+          if (next === null) return;
+          yield next;
+        }
+      } finally {
+        statusListeners.delete(listener);
+      }
+    })();
+
+  const subscribe = mock((pattern: string) => {
+    subscribePatterns.push(pattern);
+    let iteratorResolve: (() => void) | null = null;
+    const iteratorDone = new Promise<void>((r) => {
+      iteratorResolve = r;
+    });
+    const iterator = (async function* () {
+      await iteratorDone;
+    })();
+    return {
+      [Symbol.asyncIterator]: () => iterator,
+      drain: mock(async () => {
+        iteratorResolve?.();
+      }),
+      closed: Promise.resolve(),
+    } as unknown as Subscription;
+  });
+
+  const drain = mock(async () => {
+    for (const l of statusListeners) l(null);
+  });
+
+  const nc = { status, subscribe, drain } as unknown as NatsConnection;
+  return { nc, subscribe, subscribePatterns };
+}
+
+describe("MyelinRuntime", () => {
+  let logs: { kind: "log" | "warn" | "error"; msg: string }[];
+  let restore: () => void;
+
+  beforeEach(() => {
+    logs = [];
+    const origLog = console.log;
+    const origWarn = console.warn;
+    const origError = console.error;
+    console.log = (...args: unknown[]) => {
+      logs.push({ kind: "log", msg: args.map(String).join(" ") });
+    };
+    console.warn = (...args: unknown[]) => {
+      logs.push({ kind: "warn", msg: args.map(String).join(" ") });
+    };
+    console.error = (...args: unknown[]) => {
+      logs.push({ kind: "error", msg: args.map(String).join(" ") });
+    };
+    restore = () => {
+      console.log = origLog;
+      console.warn = origWarn;
+      console.error = origError;
+    };
+  });
+  afterEach(() => restore());
+
+  test("returns disabled runtime when nats config absent", async () => {
+    const config = makeConfig(undefined);
+    const runtime = await startMyelinRuntime(config);
+    expect(runtime.enabled).toBe(false);
+    expect(logs.filter((l) => l.msg.includes("myelin"))).toEqual([]);
+    await runtime.stop();
+  });
+
+  test("warns + returns disabled when nats.url present but subjects empty", async () => {
+    const config = makeConfig({
+      url: "nats://localhost:4222",
+      name: "grove-bot",
+      subjects: [],
+    });
+    const runtime = await startMyelinRuntime(config);
+    expect(runtime.enabled).toBe(false);
+    const warned = logs.some(
+      (l) => l.kind === "warn" && l.msg.includes("nats.subjects is empty"),
+    );
+    expect(warned).toBe(true);
+  });
+
+  test("returns disabled when NATS connect fails (logs error, doesn't throw)", async () => {
+    const config = makeConfig({
+      url: "nats://localhost:9999",
+      name: "grove-bot",
+      subjects: ["local.test.>"],
+    });
+    const runtime = await startMyelinRuntime(config, {
+      connectImpl: async () => {
+        throw new Error("connection refused");
+      },
+    });
+    expect(runtime.enabled).toBe(false);
+    const errored = logs.some(
+      (l) => l.kind === "error" && l.msg.includes("failed to connect"),
+    );
+    expect(errored).toBe(true);
+  });
+
+  test("subjects placeholder {org} is substituted from agent.operatorId", async () => {
+    const fake = makeFakeNatsConnection();
+    const config = makeConfig({
+      url: "nats://localhost:4222",
+      name: "grove-bot",
+      subjects: ["local.{org}.attention.>"],
+    });
+    const runtime = await startMyelinRuntime(config, {
+      connectImpl: async () => fake.nc,
+    });
+    expect(runtime.enabled).toBe(true);
+    expect(fake.subscribePatterns[0]).toBe("local.andreas.attention.>");
+    await runtime.stop();
+  });
+
+  test("redacts token-form credentials from NATS URL in log output", async () => {
+    const fake = makeFakeNatsConnection();
+    const config = makeConfig({
+      url: "nats://secret-token@localhost:4222",
+      name: "grove-bot",
+      subjects: ["local.test.>"],
+    });
+    const runtime = await startMyelinRuntime(config, {
+      connectImpl: async () => fake.nc,
+    });
+    expect(runtime.enabled).toBe(true);
+    const connectLog = logs.find(
+      (l) => l.kind === "log" && l.msg.includes("myelin runtime connected"),
+    );
+    expect(connectLog).toBeDefined();
+    expect(connectLog!.msg).not.toContain("secret-token");
+    expect(connectLog!.msg).toContain("***@");
+    await runtime.stop();
+  });
+
+  test("redacts user:pass-form credentials from NATS URL", async () => {
+    const fake = makeFakeNatsConnection();
+    const config = makeConfig({
+      url: "nats://alice:hunter2@localhost:4222",
+      name: "grove-bot",
+      subjects: ["local.test.>"],
+    });
+    const runtime = await startMyelinRuntime(config, {
+      connectImpl: async () => fake.nc,
+    });
+    expect(runtime.enabled).toBe(true);
+    const connectLog = logs.find(
+      (l) => l.kind === "log" && l.msg.includes("myelin runtime connected"),
+    );
+    expect(connectLog).toBeDefined();
+    // Both user and password redacted.
+    expect(connectLog!.msg).not.toContain("alice");
+    expect(connectLog!.msg).not.toContain("hunter2");
+    expect(connectLog!.msg).toContain("***@");
+    await runtime.stop();
+  });
+
+  test("stop() on enabled runtime drains subscribers and closes link, idempotent", async () => {
+    const fake = makeFakeNatsConnection();
+    const config = makeConfig({
+      url: "nats://localhost:4222",
+      name: "grove-bot",
+      subjects: ["local.test.>"],
+    });
+    const runtime = await startMyelinRuntime(config, {
+      connectImpl: async () => fake.nc,
+    });
+    expect(runtime.enabled).toBe(true);
+    await runtime.stop();
+    await runtime.stop(); // second call must not redo work
+    // The "stopped" log line must appear exactly once across both
+    // invocations, not twice — proves the `stopped` flag in the
+    // closure actually short-circuits.
+    const stoppedLines = logs.filter(
+      (l) => l.kind === "log" && l.msg.includes("myelin runtime stopped"),
+    );
+    expect(stoppedLines.length).toBe(1);
+  });
+});

--- a/src/bus/myelin/runtime.ts
+++ b/src/bus/myelin/runtime.ts
@@ -1,0 +1,146 @@
+/**
+ * G-1100.E: Myelin runtime — opt-in startup hook for grove-bot.
+ *
+ * Reads `bot.yaml.nats?` and, if present, opens a NatsLink and starts a
+ * MyelinSubscriber per configured subject pattern. Logs received
+ * envelopes (subject + envelope.id + correlation_id + type) for
+ * visibility — no fan-out to existing handlers in this slice; that's
+ * G-1101+ work.
+ *
+ * Coupling rule (per docs/design-collaboration-surface.md §9):
+ * If `bot.yaml.nats` is absent, this module is a no-op — grove starts
+ * without NATS just as it always has. The bot stays installable
+ * without a NATS server present.
+ */
+
+import type { ConnectionOptions, NatsConnection } from "nats";
+import type { BotConfig } from "../../common/types/config";
+import { NatsLink } from "../nats/connection";
+import { MyelinSubscriber } from "./subscriber";
+import type { Envelope } from "./envelope-validator";
+
+/** Lifecycle handle so grove-bot can clean up on shutdown. */
+export interface MyelinRuntime {
+  readonly enabled: boolean;
+  /** Best-effort shutdown — drains subscribers, closes the link. */
+  stop(): Promise<void>;
+}
+
+/**
+ * Start the myelin runtime if `config.nats?` is present. Returns a
+ * `MyelinRuntime` whose `enabled` field reflects whether anything was
+ * actually started. Errors during startup are logged and swallowed —
+ * a misconfigured NATS section must NOT crash the bot (the rest of
+ * grove keeps working without it).
+ */
+/**
+ * Internal/test-only options. Production callers pass `config` only;
+ * tests inject a fake `connectImpl` to avoid standing up a real
+ * `nats-server`. The shape mirrors `NatsLink.connect`'s own seam
+ * (typed against `ConnectionOptions` from `nats`) so a fake here is a
+ * fake there — no `unknown`, no `as never` casts.
+ *
+ * @internal — not meant for production use; the constructor signature
+ *             may change without semver guarantees.
+ */
+export interface MyelinRuntimeOptions {
+  connectImpl?: (opts: ConnectionOptions) => Promise<NatsConnection>;
+}
+
+export async function startMyelinRuntime(
+  config: BotConfig,
+  options?: MyelinRuntimeOptions,
+): Promise<MyelinRuntime> {
+  if (!config.nats?.url) {
+    return { enabled: false, stop: async () => {} };
+  }
+
+  const nats = config.nats;
+  const subjects = nats.subjects.map((s) =>
+    s.replaceAll("{org}", config.agent.operatorId ?? "default"),
+  );
+
+  if (subjects.length === 0) {
+    console.warn(
+      "grove-bot: nats.url configured but nats.subjects is empty — no subscriptions started",
+    );
+    return { enabled: false, stop: async () => {} };
+  }
+
+  let link: NatsLink;
+  const safeUrl = nats.url.replace(/\/\/[^@/]+@/, "//***@");
+  try {
+    link = await NatsLink.connect({
+      url: nats.url,
+      token: nats.token,
+      name: nats.name,
+      ...(options?.connectImpl ? { connectImpl: options.connectImpl } : {}),
+    });
+    console.log(
+      `grove-bot: myelin runtime connected to ${safeUrl} as "${nats.name}"`,
+    );
+  } catch (err) {
+    console.error(
+      "grove-bot: myelin runtime failed to connect — continuing without NATS:",
+      err instanceof Error ? err.message : err,
+    );
+    return { enabled: false, stop: async () => {} };
+  }
+
+  const subscribers: MyelinSubscriber[] = [];
+  for (const pattern of subjects) {
+    try {
+      const sub = MyelinSubscriber.start(link, {
+        pattern,
+        onEnvelope: (env, subject) => logEnvelope(env, subject),
+      });
+      subscribers.push(sub);
+      console.log(`grove-bot: myelin subscribed to "${pattern}"`);
+    } catch (err) {
+      console.error(
+        `grove-bot: myelin failed to subscribe to "${pattern}":`,
+        err instanceof Error ? err.message : err,
+      );
+    }
+  }
+
+  if (subscribers.length === 0) {
+    // Nothing actually subscribed — close the link so we don't hold a
+    // socket open for nothing.
+    await link.close().catch(() => {});
+    return { enabled: false, stop: async () => {} };
+  }
+
+  let stopped = false;
+  return {
+    enabled: true,
+    stop: async () => {
+      if (stopped) return;
+      stopped = true;
+      // Drain subscribers first so they exit cleanly; then close the
+      // underlying link.
+      await Promise.allSettled(subscribers.map((s) => s.stop()));
+      await link.close().catch((err) => {
+        console.error(
+          "grove-bot: myelin runtime close error:",
+          err instanceof Error ? err.message : err,
+        );
+      });
+      console.log("grove-bot: myelin runtime stopped");
+    },
+  };
+}
+
+/**
+ * Default envelope handler for G-1100.E — log enough context that an
+ * operator triaging a missing-message complaint can find the envelope
+ * in the bus. Fan-out to specific event handlers (pilot errand
+ * projection, signal alert ingestion, etc.) is the next iteration's
+ * work and uses the same Envelope type from this layer.
+ */
+function logEnvelope(env: Envelope, subject: string): void {
+  const corr = env.correlation_id ? ` correlation=${env.correlation_id}` : "";
+  console.log(
+    `grove-bot: myelin received envelope subject=${subject} id=${env.id} type=${env.type}${corr}`,
+  );
+}


### PR DESCRIPTION
## What

MIG-1.5 — port `myelin-runtime.ts` + its 7-test suite from grove-v2 into `cortex/src/bus/myelin/`. **Closes cortex#13** (the follow-up tracker filed when MIG-1.5 was deferred from MIG-1.4 because BotConfig coupling needed MIG-7.2 to land first).

That deferral rationale resolved 2026-05-09: cortex#20 landed `BotConfig` at `src/common/types/config.ts` via MIG-7.3.

## The keystone unlock

With runtime in cortex, the migration plan's strict-block deferrals on **MIG-3b** (adapters register with surface-router), **MIG-4b** (runner subscribes via bus), **MIG-5b** (taps publish envelopes), and most of **MIG-7** (cortex.ts entrypoint wiring) are released. Those phases can now sequence — they were waiting on this single port.

## Source mapping

| Source (grove-v2) | Target (cortex) | Notes |
|---|---|---|
| `src/bot/lib/myelin-runtime.ts` (146 LOC) | `src/bus/myelin/runtime.ts` | byte-identical except 4 import rewrites |
| `src/bot/lib/__tests__/myelin-runtime.test.ts` (232 LOC, 7 tests) | `src/bus/myelin/__tests__/runtime.test.ts` | byte-identical except 2 import rewrites |

## Import rewrites

**runtime.ts (4):**
| Before | After | Reason |
|---|---|---|
| `from "../types/config"` | `from "../../common/types/config"` | BotConfig at MIG-7.3 home |
| `from "./nats-connection"` | `from "../nats/connection"` | NatsLink under nats/ subtree (MIG-1.1) |
| `from "./myelin-subscriber"` | `from "./subscriber"` | MyelinSubscriber under myelin/ subtree (MIG-1.4) |
| `from "./myelin/envelope-validator"` | `from "./envelope-validator"` | Envelope sibling now we're inside myelin/ (MIG-1.2) |

**runtime.test.ts (2):**
| Before | After |
|---|---|
| `from "../../types/config"` | `from "../../../common/types/config"` |
| `from "../myelin-runtime"` | `from "../runtime"` |

## Verification

- cortex root \`bunx tsc --noEmit\` exit 0
- \`bun test src/bus/myelin/__tests__/runtime.test.ts\` — **7/7 pass** (matches grove-v2 baseline per cortex#13 closure criterion)

## Plan grounding

`docs/architecture.md` §8 places `bus/myelin/` at top level under `cortex/src/`. cortex#13 named the closure criterion exactly: "Copy + update import paths + Forward myelin-runtime.test.ts (7/7 tests) + Wire into cortex's entrypoint per MIG-7.1." This PR does the first three; the entrypoint wiring (MIG-7.1) is its own work.

§1.3 non-goal "not a behaviour change" honoured — code is byte-identical to grove-v2's G-1100.E port except for the 6 mechanical import-path rewrites.

Refs cortex#3 (MIG-1 umbrella), **closes cortex#13**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)