### PR TITLE
fix(ci): vendor compass label-check; remove broken cross-repo checkout (closes cortex#16)

### DIFF
--- a/.github/scripts/label-check.ts
+++ b/.github/scripts/label-check.ts
@@ -1,0 +1,69 @@
+#!/usr/bin/env bun
+/**
+ * label-check.ts — Verify that a GitHub repo has all required ecosystem labels.
+ *
+ * Usage: bun label-check.ts <org/repo>
+ *
+ * Exit code 0 = all labels present, 1 = missing labels.
+ *
+ * Vendored from `the-metafactory/compass:engine/ci/label-check.ts` (commit
+ * df944b7, 2026-05-09 v0.8.3) into cortex as part of cortex#16 fix.
+ *
+ * Why vendored: compass is a private repo and cortex's CI workflow had no
+ * cross-repo PAT, so the original `bun ../compass/engine/ci/run-all.ts`
+ * invocation failed on every PR + main run since MIG-0 bootstrap. Vendoring
+ * one ~40-LOC file with zero deps mirrors the precedent set by myelin
+ * envelope schema vendoring at G-1100.B (cortex#11). Update this copy when
+ * compass evolves the validator surface.
+ */
+
+const REQUIRED_LABELS = [
+  "bug",
+  "documentation",
+  "feature",
+  "infrastructure",
+  "now",
+  "next",
+  "future",
+  "handover",
+];
+
+const repo = process.argv[2];
+if (!repo) {
+  console.error("Usage: bun label-check.ts <org/repo>");
+  process.exit(1);
+}
+
+const proc = Bun.spawnSync([
+  "gh",
+  "label",
+  "list",
+  "--repo",
+  repo,
+  "--json",
+  "name",
+  "--limit",
+  "100",
+]);
+if (proc.exitCode !== 0) {
+  console.error(`Failed to list labels for ${repo}: ${proc.stderr.toString()}`);
+  process.exit(1);
+}
+
+const labels: { name: string }[] = JSON.parse(proc.stdout.toString());
+const labelNames = new Set(labels.map((l) => l.name));
+const missing = REQUIRED_LABELS.filter((l) => !labelNames.has(l));
+
+if (missing.length > 0) {
+  console.error(`${repo} is missing ${missing.length} required label(s):`);
+  for (const l of missing) {
+    console.error(`  - ${l}`);
+  }
+  console.error(`\nFix with: bun standards/scripts/sync-labels.ts ${repo}`);
+  process.exit(1);
+} else {
+  console.log(
+    `${repo} has all ${REQUIRED_LABELS.length} required ecosystem labels.`,
+  );
+  process.exit(0);
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,11 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      # `gh label list` queries GraphQL `repository.labels`, which requires
+      # the `issues: read` scope (labels live under the issues subsystem
+      # in GitHub's permission model). Without this the call fails with
+      # "Resource not accessible by integration".
+      issues: read
     steps:
       - name: Checkout cortex
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,31 +6,31 @@ on:
   pull_request:
     branches: [main]
 
+# Compass governance validators are vendored at .github/scripts/ rather than
+# pulled from a sibling checkout of the-metafactory/compass. Original setup
+# (cross-repo checkout via GH_PAT_COMPASS_RO) failed on every run since the
+# MIG-0 bootstrap because (a) the PAT secret was never provisioned and (b)
+# compass's engine/ci/ only contains label-check.ts (no run-all.ts).
+# Vendoring follows the same pattern as the myelin envelope schema vendor
+# at src/bus/myelin/vendor/ (cortex#11 G-1100.B). Update the vendored copy
+# when compass evolves its validator surface.
+# Tracked at cortex#16.
 jobs:
   validators:
     name: Compass governance validators
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout cortex
         uses: actions/checkout@v4
-        with:
-          path: cortex
-
-      - name: Checkout compass
-        uses: actions/checkout@v4
-        with:
-          repository: the-metafactory/compass
-          path: compass
-          token: ${{ secrets.GH_PAT_COMPASS_RO || github.token }}
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
 
-      - name: Run compass validators
-        working-directory: cortex
-        run: |
-          bun ../compass/engine/ci/run-all.ts \
-            --owner the-metafactory \
-            --repo cortex
+      - name: Label check
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: bun .github/scripts/label-check.ts the-metafactory/cortex


### PR DESCRIPTION
## What

Closes cortex#16. Fixes the CI workflow that has been **failing on every PR + main run since MIG-0 bootstrap**.

## Diagnosis

\`.github/workflows/ci.yml\` (the only workflow on the repo) was failing because:

1. **PAT secret never provisioned** — workflow used \`secrets.GH_PAT_COMPASS_RO || github.token\`. \`gh secret list --repo the-metafactory/cortex\` returns empty, so the fallback \`github.token\` was always in effect — and it can't checkout the private \`the-metafactory/compass\` repo. Every run failed at the compass-checkout step with a 404.

2. **Script invoked doesn't exist in compass** — workflow ran \`bun ../compass/engine/ci/run-all.ts\` but compass's \`engine/ci/\` only contains \`label-check.ts\`. Even with PAT access, the run command would have thrown.

The check itself is the **ecosystem-standard label parity audit** (bug/documentation/feature/infrastructure/now/next/future/handover) — a useful safeguard worth keeping operational.

## Fix

Vendor \`label-check.ts\` into \`.github/scripts/label-check.ts\` and update the workflow to run the vendored copy. Removes the cross-repo checkout entirely, so no PAT is needed.

Same pattern as the myelin envelope schema vendor at \`src/bus/myelin/vendor/\` (cortex#11 G-1100.B): one small, stable upstream file copied in with provenance comment, updated when the upstream evolves.

**Source provenance:** \`the-metafactory/compass:engine/ci/label-check.ts\` @ commit \`df944b7\` (v0.8.3, 2026-05-09).

## Verification

Local smoke test from worktree:
- \`bunx tsc --noEmit\` → exit 0
- \`bun .github/scripts/label-check.ts the-metafactory/cortex\` → \`"the-metafactory/cortex has all 8 required ecosystem labels."\`

After merge, this PR's CI run should be the **first green CI run on cortex** since the repo was bootstrapped.

## Why no \`gh-actions\` workflow consolidation now

This PR keeps the workflow structure intact (one job named "Compass governance validators"), only swapping the broken script invocation for the vendored one. The validator surface in compass is currently 1 file; if compass adds more validators later, the cleanest path is updating this PR's vendored script (or adding a sibling). No other cortex CI consolidation is in scope.

Refs cortex#16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)