### PR TITLE
feat(bus): C-102 — surface-router primitive + payload-filter (MIG-1.9, G-1111.A)

### DIFF
--- a/src/bus/__tests__/payload-filter.test.ts
+++ b/src/bus/__tests__/payload-filter.test.ts
@@ -1,0 +1,381 @@
+/**
+ * Tests for `src/bus/payload-filter.ts` — G-1111.A v1 operator subset.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { Envelope } from "../myelin/envelope-validator";
+import { matchesFilter, type PayloadFilter } from "../payload-filter";
+
+// ---------------------------------------------------------------------------
+// Envelope factory — we only care about the fields the filter inspects, so
+// build a structurally-valid Envelope-shaped object via a single helper.
+// ---------------------------------------------------------------------------
+
+function makeEnvelope(overrides: Partial<Envelope> = {}): Envelope {
+  return {
+    id: "00000000-0000-4000-8000-000000000000",
+    source: "metafactory.pilot.local",
+    type: "review.cycle.completed",
+    timestamp: "2026-05-09T12:00:00Z",
+    sovereignty: {
+      classification: "local",
+      data_residency: "NZ",
+      max_hop: 0,
+      frontier_ok: true,
+      model_class: "any",
+    },
+    payload: { repo: "grove", urgency: "normal" },
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Degenerate cases
+// ---------------------------------------------------------------------------
+
+describe("matchesFilter — degenerate cases", () => {
+  test("undefined filter passes (no filter = match all)", () => {
+    expect(matchesFilter(makeEnvelope(), undefined)).toBe(true);
+  });
+
+  test("empty filter object passes", () => {
+    expect(matchesFilter(makeEnvelope(), {})).toBe(true);
+  });
+
+  test("filter with only an empty envelope pattern passes", () => {
+    expect(matchesFilter(makeEnvelope(), { envelope: {} })).toBe(true);
+  });
+
+  test("filter with only an empty payload pattern passes", () => {
+    expect(matchesFilter(makeEnvelope(), { payload: {} })).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Exact match (any-of)
+// ---------------------------------------------------------------------------
+
+describe("matchesFilter — exact match (any-of)", () => {
+  test("single literal in array — matches", () => {
+    const filter: PayloadFilter = { payload: { repo: ["grove"] } };
+    expect(matchesFilter(makeEnvelope(), filter)).toBe(true);
+  });
+
+  test("single literal in array — no match", () => {
+    const filter: PayloadFilter = { payload: { repo: ["myelin"] } };
+    expect(matchesFilter(makeEnvelope(), filter)).toBe(false);
+  });
+
+  test("multi-literal any-of — matches first", () => {
+    const filter: PayloadFilter = { payload: { repo: ["grove", "myelin"] } };
+    expect(matchesFilter(makeEnvelope(), filter)).toBe(true);
+  });
+
+  test("multi-literal any-of — matches second", () => {
+    const filter: PayloadFilter = { payload: { repo: ["myelin", "grove"] } };
+    expect(matchesFilter(makeEnvelope(), filter)).toBe(true);
+  });
+
+  test("multi-literal any-of — no match in any", () => {
+    const filter: PayloadFilter = { payload: { repo: ["myelin", "signal"] } };
+    expect(matchesFilter(makeEnvelope(), filter)).toBe(false);
+  });
+
+  test("number literal exact match", () => {
+    const env = makeEnvelope({ payload: { cycle: 3 } });
+    expect(matchesFilter(env, { payload: { cycle: [3] } })).toBe(true);
+    expect(matchesFilter(env, { payload: { cycle: [4] } })).toBe(false);
+  });
+
+  test("boolean literal exact match", () => {
+    const env = makeEnvelope({ payload: { final: true } });
+    expect(matchesFilter(env, { payload: { final: [true] } })).toBe(true);
+    expect(matchesFilter(env, { payload: { final: [false] } })).toBe(false);
+  });
+
+  test("missing field — exact match fails", () => {
+    const filter: PayloadFilter = { payload: { foo: ["bar"] } };
+    expect(matchesFilter(makeEnvelope(), filter)).toBe(false);
+  });
+
+  test("empty candidate list — never matches", () => {
+    const filter: PayloadFilter = { payload: { repo: [] } };
+    expect(matchesFilter(makeEnvelope(), filter)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// anything-but
+// ---------------------------------------------------------------------------
+
+describe("matchesFilter — anything-but", () => {
+  test("scalar form — matches when actual differs", () => {
+    const env = makeEnvelope({ payload: { urgency: "low" } });
+    const filter: PayloadFilter = { payload: { urgency: [{ "anything-but": "high" }] } };
+    expect(matchesFilter(env, filter)).toBe(true);
+  });
+
+  test("scalar form — fails when actual equals banned", () => {
+    const env = makeEnvelope({ payload: { urgency: "low" } });
+    const filter: PayloadFilter = { payload: { urgency: [{ "anything-but": "low" }] } };
+    expect(matchesFilter(env, filter)).toBe(false);
+  });
+
+  test("array form — matches when actual not in list", () => {
+    const env = makeEnvelope({ payload: { urgency: "normal" } });
+    const filter: PayloadFilter = {
+      payload: { urgency: [{ "anything-but": ["low", "high"] }] },
+    };
+    expect(matchesFilter(env, filter)).toBe(true);
+  });
+
+  test("array form — fails when actual in list", () => {
+    const env = makeEnvelope({ payload: { urgency: "high" } });
+    const filter: PayloadFilter = {
+      payload: { urgency: [{ "anything-but": ["low", "high"] }] },
+    };
+    expect(matchesFilter(env, filter)).toBe(false);
+  });
+
+  test("missing field — anything-but fails (presence required)", () => {
+    const filter: PayloadFilter = {
+      payload: { absent: [{ "anything-but": "x" }] },
+    };
+    expect(matchesFilter(makeEnvelope(), filter)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// prefix
+// ---------------------------------------------------------------------------
+
+describe("matchesFilter — prefix", () => {
+  test("matches when string starts with prefix", () => {
+    const env = makeEnvelope({ payload: { title: "[security] fix CVE" } });
+    const filter: PayloadFilter = { payload: { title: [{ prefix: "[security]" }] } };
+    expect(matchesFilter(env, filter)).toBe(true);
+  });
+
+  test("does not match when string lacks prefix", () => {
+    const env = makeEnvelope({ payload: { title: "fix CVE" } });
+    const filter: PayloadFilter = { payload: { title: [{ prefix: "[security]" }] } };
+    expect(matchesFilter(env, filter)).toBe(false);
+  });
+
+  test("empty prefix matches any string", () => {
+    const env = makeEnvelope({ payload: { title: "anything" } });
+    const filter: PayloadFilter = { payload: { title: [{ prefix: "" }] } };
+    expect(matchesFilter(env, filter)).toBe(true);
+  });
+
+  test("non-string field never matches a prefix operator", () => {
+    const env = makeEnvelope({ payload: { count: 42 } });
+    const filter: PayloadFilter = { payload: { count: [{ prefix: "4" }] } };
+    expect(matchesFilter(env, filter)).toBe(false);
+  });
+
+  test("missing field fails prefix match", () => {
+    const filter: PayloadFilter = { payload: { absent: [{ prefix: "" }] } };
+    expect(matchesFilter(makeEnvelope(), filter)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// exists
+// ---------------------------------------------------------------------------
+
+describe("matchesFilter — exists", () => {
+  test("{exists: true} matches when present", () => {
+    const filter: PayloadFilter = { payload: { repo: [{ exists: true }] } };
+    expect(matchesFilter(makeEnvelope(), filter)).toBe(true);
+  });
+
+  test("{exists: true} fails when absent", () => {
+    const filter: PayloadFilter = { payload: { absent: [{ exists: true }] } };
+    expect(matchesFilter(makeEnvelope(), filter)).toBe(false);
+  });
+
+  test("{exists: false} matches when absent", () => {
+    const filter: PayloadFilter = { payload: { absent: [{ exists: false }] } };
+    expect(matchesFilter(makeEnvelope(), filter)).toBe(true);
+  });
+
+  test("{exists: false} fails when present", () => {
+    const filter: PayloadFilter = { payload: { repo: [{ exists: false }] } };
+    expect(matchesFilter(makeEnvelope(), filter)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// equals-ignore-case
+// ---------------------------------------------------------------------------
+
+describe("matchesFilter — equals-ignore-case", () => {
+  test("matches across case differences", () => {
+    const env = makeEnvelope({ payload: { state: "Approved" } });
+    const filter: PayloadFilter = {
+      payload: { state: [{ "equals-ignore-case": "APPROVED" }] },
+    };
+    expect(matchesFilter(env, filter)).toBe(true);
+  });
+
+  test("does not match different content", () => {
+    const env = makeEnvelope({ payload: { state: "rejected" } });
+    const filter: PayloadFilter = {
+      payload: { state: [{ "equals-ignore-case": "approved" }] },
+    };
+    expect(matchesFilter(env, filter)).toBe(false);
+  });
+
+  test("non-string never matches equals-ignore-case", () => {
+    const env = makeEnvelope({ payload: { count: 1 } });
+    const filter: PayloadFilter = {
+      payload: { count: [{ "equals-ignore-case": "1" }] },
+    };
+    expect(matchesFilter(env, filter)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Mixed and-or — multi-key (AND across keys, OR within a leaf)
+// ---------------------------------------------------------------------------
+
+describe("matchesFilter — multi-key AND, multi-value OR", () => {
+  test("two keys both match", () => {
+    const env = makeEnvelope({ payload: { repo: "grove", urgency: "high" } });
+    const filter: PayloadFilter = {
+      payload: { repo: ["grove"], urgency: ["high"] },
+    };
+    expect(matchesFilter(env, filter)).toBe(true);
+  });
+
+  test("two keys, one fails => filter fails", () => {
+    const env = makeEnvelope({ payload: { repo: "grove", urgency: "low" } });
+    const filter: PayloadFilter = {
+      payload: { repo: ["grove"], urgency: ["high"] },
+    };
+    expect(matchesFilter(env, filter)).toBe(false);
+  });
+
+  test("OR within a single key's array", () => {
+    const env = makeEnvelope({ payload: { urgency: "high" } });
+    const filter: PayloadFilter = {
+      payload: {
+        urgency: [{ prefix: "med" }, { "equals-ignore-case": "HIGH" }],
+      },
+    };
+    expect(matchesFilter(env, filter)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Nested paths
+// ---------------------------------------------------------------------------
+
+describe("matchesFilter — nested paths", () => {
+  test("nested key matches", () => {
+    const env = makeEnvelope({
+      payload: { pr: { repo: "grove", number: 42 } },
+    });
+    const filter: PayloadFilter = {
+      payload: { pr: { repo: ["grove"] } },
+    };
+    expect(matchesFilter(env, filter)).toBe(true);
+  });
+
+  test("nested key fails", () => {
+    const env = makeEnvelope({
+      payload: { pr: { repo: "myelin", number: 42 } },
+    });
+    const filter: PayloadFilter = {
+      payload: { pr: { repo: ["grove"] } },
+    };
+    expect(matchesFilter(env, filter)).toBe(false);
+  });
+
+  test("two-deep nested key", () => {
+    const env = makeEnvelope({
+      payload: { reviewer: { principal: { did: "did:mf:luna" } } },
+    });
+    const filter: PayloadFilter = {
+      payload: { reviewer: { principal: { did: ["did:mf:luna"] } } },
+    };
+    expect(matchesFilter(env, filter)).toBe(true);
+  });
+
+  test("nested missing object — leaf misses", () => {
+    const filter: PayloadFilter = {
+      payload: { pr: { repo: ["grove"] } },
+    };
+    expect(matchesFilter(makeEnvelope(), filter)).toBe(false);
+  });
+
+  test("nested missing object with {exists: false} subtree passes", () => {
+    const filter: PayloadFilter = {
+      payload: { pr: { repo: [{ exists: false }] } },
+    };
+    expect(matchesFilter(makeEnvelope(), filter)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Envelope-level matching
+// ---------------------------------------------------------------------------
+
+describe("matchesFilter — envelope-level", () => {
+  test("envelope.type exact match", () => {
+    const env = makeEnvelope();
+    const filter: PayloadFilter = {
+      envelope: { type: ["review.cycle.completed"] },
+    };
+    expect(matchesFilter(env, filter)).toBe(true);
+  });
+
+  test("envelope.type prefix match", () => {
+    const env = makeEnvelope();
+    const filter: PayloadFilter = {
+      envelope: { type: [{ prefix: "review." }] },
+    };
+    expect(matchesFilter(env, filter)).toBe(true);
+  });
+
+  test("envelope.source mismatch", () => {
+    const env = makeEnvelope({ source: "metafactory.discord.luna" });
+    const filter: PayloadFilter = {
+      envelope: { source: ["metafactory.pilot.local"] },
+    };
+    expect(matchesFilter(env, filter)).toBe(false);
+  });
+
+  test("envelope AND payload — both must pass", () => {
+    const env = makeEnvelope();
+    const passing: PayloadFilter = {
+      envelope: { type: [{ prefix: "review." }] },
+      payload: { repo: ["grove"] },
+    };
+    expect(matchesFilter(env, passing)).toBe(true);
+
+    const failing: PayloadFilter = {
+      envelope: { type: [{ prefix: "review." }] },
+      payload: { repo: ["myelin"] },
+    };
+    expect(matchesFilter(env, failing)).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Unknown-operator fail-closed (defensive)
+// ---------------------------------------------------------------------------
+
+describe("matchesFilter — unknown operator fails closed", () => {
+  test("operator object with an unrecognised key never matches", () => {
+    const env = makeEnvelope();
+    // Build a value that bypasses the FilterValue union via a cast — this
+    // models a malformed config that slipped past type-check (e.g.,
+    // hand-edited YAML).
+    const filter = {
+      payload: { repo: [{ "wildcard-glob": "gr*ve" } as unknown as { prefix: string }] },
+    } satisfies PayloadFilter;
+    expect(matchesFilter(env, filter)).toBe(false);
+  });
+});

--- a/src/bus/__tests__/surface-router.test.ts
+++ b/src/bus/__tests__/surface-router.test.ts
@@ -1,0 +1,507 @@
+/**
+ * Tests for `src/bus/surface-router.ts` — G-1111.A.
+ *
+ * Cover:
+ *   - subjectMatches: > terminal, * single segment, literals, edge cases
+ *   - register / unregister
+ *   - dispatch by subject and by filter (positive + negative)
+ *   - adapter isolation: failing adapter doesn't block siblings
+ *   - timeout: hanging render is cancelled at renderTimeoutMs
+ *   - onAdapterError hook receives errors and timeouts
+ *   - start/stop lifecycle
+ *
+ * MyelinRuntime is mocked as a plain stub — we never touch real NATS.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { Envelope } from "../myelin/envelope-validator";
+import type { MyelinRuntime } from "../myelin/runtime";
+import { createSurfaceRouter, subjectMatches, type SurfaceAdapter } from "../surface-router";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function fakeRuntime(): MyelinRuntime {
+  return { enabled: true, stop: async () => {} };
+}
+
+function makeEnvelope(overrides: Partial<Envelope> = {}): Envelope {
+  return {
+    id: "00000000-0000-4000-8000-000000000000",
+    source: "metafactory.pilot.local",
+    type: "review.cycle.completed",
+    timestamp: "2026-05-09T12:00:00Z",
+    sovereignty: {
+      classification: "local",
+      data_residency: "NZ",
+      max_hop: 0,
+      frontier_ok: true,
+      model_class: "any",
+    },
+    payload: { repo: "grove", urgency: "normal" },
+    ...overrides,
+  };
+}
+
+interface RecordingAdapter {
+  adapter: SurfaceAdapter;
+  calls: Envelope[];
+}
+
+function recordingAdapter(opts: {
+  id: string;
+  subjects: string[];
+  filter?: SurfaceAdapter["filter"];
+  behaviour?: "ok" | "throw" | "hang";
+  hangMs?: number;
+}): RecordingAdapter {
+  const calls: Envelope[] = [];
+  return {
+    calls,
+    adapter: {
+      id: opts.id,
+      subjects: opts.subjects,
+      ...(opts.filter ? { filter: opts.filter } : {}),
+      render: async (env) => {
+        calls.push(env);
+        if (opts.behaviour === "throw") {
+          throw new Error(`adapter "${opts.id}" intentional failure`);
+        }
+        if (opts.behaviour === "hang") {
+          await new Promise((r) => setTimeout(r, opts.hangMs ?? 60_000));
+        }
+      },
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// subjectMatches
+// ---------------------------------------------------------------------------
+
+describe("subjectMatches — literal", () => {
+  test("identical literal subject matches", () => {
+    expect(subjectMatches("local.metafactory.review.cycle.completed", "local.metafactory.review.cycle.completed")).toBe(true);
+  });
+
+  test("non-matching literal does not match", () => {
+    expect(subjectMatches("local.metafactory.review.cycle.completed", "local.metafactory.review.cycle.requested")).toBe(false);
+  });
+
+  test("longer pattern than subject does not match", () => {
+    expect(subjectMatches("local.metafactory.review.cycle.completed", "local.metafactory.review")).toBe(false);
+  });
+
+  test("longer subject than literal pattern does not match", () => {
+    expect(subjectMatches("local.metafactory.review", "local.metafactory.review.cycle.completed")).toBe(false);
+  });
+
+  test("empty pattern never matches", () => {
+    expect(subjectMatches("", "local.x")).toBe(false);
+  });
+
+  test("empty subject never matches", () => {
+    expect(subjectMatches("local.x", "")).toBe(false);
+  });
+});
+
+describe("subjectMatches — `*` single segment", () => {
+  test("`*` matches any single segment", () => {
+    expect(subjectMatches("local.metafactory.review.*.completed", "local.metafactory.review.cycle.completed")).toBe(true);
+    expect(subjectMatches("local.metafactory.review.*.completed", "local.metafactory.review.errand.completed")).toBe(true);
+  });
+
+  test("`*` does NOT span multiple segments", () => {
+    expect(subjectMatches("local.metafactory.review.*.completed", "local.metafactory.review.cycle.foo.completed")).toBe(false);
+  });
+
+  test("`*` requires exactly one segment present", () => {
+    expect(subjectMatches("local.metafactory.review.*", "local.metafactory.review")).toBe(false);
+    expect(subjectMatches("local.metafactory.review.*", "local.metafactory.review.cycle")).toBe(true);
+  });
+
+  test("multiple `*` segments compose", () => {
+    expect(subjectMatches("local.*.review.*.completed", "local.metafactory.review.cycle.completed")).toBe(true);
+    expect(subjectMatches("local.*.review.*.completed", "local.metafactory.review.cycle.requested")).toBe(false);
+  });
+});
+
+describe("subjectMatches — `>` terminal wildcard", () => {
+  test("`>` matches any number of trailing segments (≥1)", () => {
+    expect(subjectMatches("local.metafactory.review.>", "local.metafactory.review.cycle.completed")).toBe(true);
+    expect(subjectMatches("local.metafactory.review.>", "local.metafactory.review.errand")).toBe(true);
+    expect(subjectMatches("local.metafactory.review.>", "local.metafactory.review.cycle.foo.bar.baz")).toBe(true);
+  });
+
+  test("`>` requires at least one trailing segment", () => {
+    expect(subjectMatches("local.metafactory.review.>", "local.metafactory.review")).toBe(false);
+  });
+
+  test("`>` alone matches any non-empty subject (≥1 segment)", () => {
+    expect(subjectMatches(">", "local")).toBe(true);
+    expect(subjectMatches(">", "local.x.y")).toBe(true);
+  });
+
+  test("`>` non-terminal is treated as no-match (defensive)", () => {
+    expect(subjectMatches("local.>.completed", "local.x.completed")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// register / unregister
+// ---------------------------------------------------------------------------
+
+describe("createSurfaceRouter — register / unregister", () => {
+  test("registered adapter receives matching envelopes", async () => {
+    const router = createSurfaceRouter(fakeRuntime());
+    const a = recordingAdapter({ id: "a", subjects: ["review.>"] });
+    router.register(a.adapter);
+
+    const env = makeEnvelope();
+    await router.dispatch(env);
+
+    expect(a.calls).toHaveLength(1);
+    expect(a.calls[0]?.id).toBe(env.id);
+  });
+
+  test("unregister removes adapter from dispatch", async () => {
+    const router = createSurfaceRouter(fakeRuntime());
+    const a = recordingAdapter({ id: "a", subjects: ["review.>"] });
+    const handle = router.register(a.adapter);
+
+    handle.unregister();
+    await router.dispatch(makeEnvelope());
+
+    expect(a.calls).toHaveLength(0);
+  });
+
+  test("unregister is idempotent (calling twice is safe)", () => {
+    const router = createSurfaceRouter(fakeRuntime());
+    const a = recordingAdapter({ id: "a", subjects: ["review.>"] });
+    const handle = router.register(a.adapter);
+
+    expect(() => {
+      handle.unregister();
+      handle.unregister();
+    }).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Subject matching in dispatch
+// ---------------------------------------------------------------------------
+
+describe("createSurfaceRouter — subject match dispatch", () => {
+  test("subject match → render called", async () => {
+    const router = createSurfaceRouter(fakeRuntime());
+    const a = recordingAdapter({ id: "a", subjects: ["local.metafactory.review.>"] });
+    router.register(a.adapter);
+
+    await router.dispatch(makeEnvelope(), "local.metafactory.review.cycle.completed");
+    expect(a.calls).toHaveLength(1);
+  });
+
+  test("subject no-match → render NOT called", async () => {
+    const router = createSurfaceRouter(fakeRuntime());
+    const a = recordingAdapter({ id: "a", subjects: ["local.metafactory.review.>"] });
+    router.register(a.adapter);
+
+    await router.dispatch(makeEnvelope(), "local.metafactory.attention.item.enqueued");
+    expect(a.calls).toHaveLength(0);
+  });
+
+  test("union semantics: any of the adapter's subjects can match", async () => {
+    const router = createSurfaceRouter(fakeRuntime());
+    const a = recordingAdapter({
+      id: "a",
+      subjects: ["local.metafactory.review.>", "local.metafactory.attention.>"],
+    });
+    router.register(a.adapter);
+
+    await router.dispatch(makeEnvelope(), "local.metafactory.attention.item.enqueued");
+    expect(a.calls).toHaveLength(1);
+  });
+
+  test("default subject (envelope.type) is used when subject omitted", async () => {
+    const router = createSurfaceRouter(fakeRuntime());
+    const a = recordingAdapter({ id: "a", subjects: ["review.cycle.completed"] });
+    router.register(a.adapter);
+
+    await router.dispatch(makeEnvelope({ type: "review.cycle.completed" }));
+    expect(a.calls).toHaveLength(1);
+  });
+
+  test("two adapters subscribing to different subjects each get their own", async () => {
+    const router = createSurfaceRouter(fakeRuntime());
+    const review = recordingAdapter({ id: "review", subjects: ["local.metafactory.review.>"] });
+    const attention = recordingAdapter({ id: "att", subjects: ["local.metafactory.attention.>"] });
+    router.register(review.adapter);
+    router.register(attention.adapter);
+
+    await router.dispatch(makeEnvelope(), "local.metafactory.review.cycle.completed");
+    expect(review.calls).toHaveLength(1);
+    expect(attention.calls).toHaveLength(0);
+
+    await router.dispatch(makeEnvelope(), "local.metafactory.attention.item.enqueued");
+    expect(review.calls).toHaveLength(1);
+    expect(attention.calls).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Filter matching in dispatch
+// ---------------------------------------------------------------------------
+
+describe("createSurfaceRouter — filter dispatch", () => {
+  test("filter match → render called", async () => {
+    const router = createSurfaceRouter(fakeRuntime());
+    const a = recordingAdapter({
+      id: "a",
+      subjects: ["local.metafactory.review.>"],
+      filter: { payload: { repo: ["grove"] } },
+    });
+    router.register(a.adapter);
+
+    await router.dispatch(
+      makeEnvelope({ payload: { repo: "grove" } }),
+      "local.metafactory.review.cycle.completed",
+    );
+    expect(a.calls).toHaveLength(1);
+  });
+
+  test("filter no-match → render NOT called", async () => {
+    const router = createSurfaceRouter(fakeRuntime());
+    const a = recordingAdapter({
+      id: "a",
+      subjects: ["local.metafactory.review.>"],
+      filter: { payload: { repo: ["myelin"] } },
+    });
+    router.register(a.adapter);
+
+    await router.dispatch(
+      makeEnvelope({ payload: { repo: "grove" } }),
+      "local.metafactory.review.cycle.completed",
+    );
+    expect(a.calls).toHaveLength(0);
+  });
+
+  test("subject matches but filter blocks → no render", async () => {
+    const router = createSurfaceRouter(fakeRuntime());
+    const pager = recordingAdapter({
+      id: "pagerduty",
+      subjects: ["local.metafactory.>"],
+      filter: { payload: { urgency: ["high"] } },
+    });
+    router.register(pager.adapter);
+
+    await router.dispatch(
+      makeEnvelope({ payload: { urgency: "low" } }),
+      "local.metafactory.review.cycle.completed",
+    );
+    expect(pager.calls).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Adapter isolation
+// ---------------------------------------------------------------------------
+
+describe("createSurfaceRouter — adapter isolation (§5.3)", () => {
+  test("failing adapter does not block siblings", async () => {
+    const errors: { id: string; err: Error }[] = [];
+    const router = createSurfaceRouter(fakeRuntime(), {
+      onAdapterError: (id, err) => errors.push({ id, err }),
+    });
+
+    const broken = recordingAdapter({ id: "broken", subjects: ["review.>"], behaviour: "throw" });
+    const ok1 = recordingAdapter({ id: "ok1", subjects: ["review.>"] });
+    const ok2 = recordingAdapter({ id: "ok2", subjects: ["review.>"] });
+    router.register(broken.adapter);
+    router.register(ok1.adapter);
+    router.register(ok2.adapter);
+
+    await router.dispatch(makeEnvelope(), "review.cycle.completed");
+
+    expect(broken.calls).toHaveLength(1);
+    expect(ok1.calls).toHaveLength(1);
+    expect(ok2.calls).toHaveLength(1);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]?.id).toBe("broken");
+    expect(errors[0]?.err.message).toContain("intentional failure");
+  });
+
+  test("dispatch never throws — even if every adapter fails", async () => {
+    const router = createSurfaceRouter(fakeRuntime(), { onAdapterError: () => {} });
+    router.register(recordingAdapter({ id: "a", subjects: [">"], behaviour: "throw" }).adapter);
+    router.register(recordingAdapter({ id: "b", subjects: [">"], behaviour: "throw" }).adapter);
+
+    await expect(router.dispatch(makeEnvelope())).resolves.toBeUndefined();
+  });
+
+  test("synchronous throw before render returns a promise is captured", async () => {
+    const errors: { id: string; err: Error }[] = [];
+    const router = createSurfaceRouter(fakeRuntime(), {
+      onAdapterError: (id, err) => errors.push({ id, err }),
+    });
+
+    const sync: SurfaceAdapter = {
+      id: "sync-throw",
+      subjects: [">"],
+      render: () => {
+        throw new Error("sync boom");
+      },
+    };
+    const ok = recordingAdapter({ id: "ok", subjects: [">"] });
+    router.register(sync);
+    router.register(ok.adapter);
+
+    await router.dispatch(makeEnvelope());
+
+    expect(ok.calls).toHaveLength(1);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]?.id).toBe("sync-throw");
+    expect(errors[0]?.err.message).toBe("sync boom");
+  });
+
+  test("a throwing onAdapterError hook does not poison dispatch", async () => {
+    const router = createSurfaceRouter(fakeRuntime(), {
+      onAdapterError: () => {
+        throw new Error("hook is buggy");
+      },
+    });
+    const broken = recordingAdapter({ id: "broken", subjects: [">"], behaviour: "throw" });
+    const ok = recordingAdapter({ id: "ok", subjects: [">"] });
+    router.register(broken.adapter);
+    router.register(ok.adapter);
+
+    await expect(router.dispatch(makeEnvelope())).resolves.toBeUndefined();
+    expect(ok.calls).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Timeout
+// ---------------------------------------------------------------------------
+
+describe("createSurfaceRouter — render timeout", () => {
+  test("hanging render is cancelled at renderTimeoutMs", async () => {
+    const errors: { id: string; err: Error }[] = [];
+    const router = createSurfaceRouter(fakeRuntime(), {
+      renderTimeoutMs: 30,
+      onAdapterError: (id, err) => errors.push({ id, err }),
+    });
+
+    const hanging = recordingAdapter({
+      id: "hanging",
+      subjects: [">"],
+      behaviour: "hang",
+      hangMs: 5000,
+    });
+    const fast = recordingAdapter({ id: "fast", subjects: [">"] });
+    router.register(hanging.adapter);
+    router.register(fast.adapter);
+
+    const start = Date.now();
+    await router.dispatch(makeEnvelope());
+    const elapsed = Date.now() - start;
+
+    // Should resolve well before the 5s hang — give a generous ceiling for
+    // CI flakiness.
+    expect(elapsed).toBeLessThan(2000);
+    expect(fast.calls).toHaveLength(1);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]?.id).toBe("hanging");
+    expect(errors[0]?.err.message).toContain("timeout");
+  });
+
+  test("default timeout (5s) is applied when not overridden", async () => {
+    // Just check the default exists and dispatch works under it without
+    // hanging. We don't actually wait 5s — register a fast adapter and
+    // verify default-config dispatch works.
+    const router = createSurfaceRouter(fakeRuntime());
+    const fast = recordingAdapter({ id: "fast", subjects: [">"] });
+    router.register(fast.adapter);
+    await router.dispatch(makeEnvelope());
+    expect(fast.calls).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Lifecycle
+// ---------------------------------------------------------------------------
+
+describe("createSurfaceRouter — lifecycle", () => {
+  test("start() is idempotent", async () => {
+    const router = createSurfaceRouter(fakeRuntime());
+    await router.start();
+    await router.start();
+    await router.start();
+    // No assertion beyond "doesn't throw"
+  });
+
+  test("stop() is idempotent", async () => {
+    const router = createSurfaceRouter(fakeRuntime());
+    await router.stop();
+    await router.stop();
+  });
+
+  test("dispatch after stop is a no-op (resolves, no render)", async () => {
+    const router = createSurfaceRouter(fakeRuntime());
+    const a = recordingAdapter({ id: "a", subjects: [">"] });
+    router.register(a.adapter);
+
+    await router.start();
+    await router.stop();
+    await router.dispatch(makeEnvelope());
+
+    expect(a.calls).toHaveLength(0);
+  });
+
+  test("dispatch before start works (start() is a state marker, not a gate)", async () => {
+    // The current contract: start() is informational; dispatch is always
+    // available pre-start. Pin this behaviour so a future refactor that
+    // wants to gate dispatch behind start() must update this test
+    // explicitly.
+    const router = createSurfaceRouter(fakeRuntime());
+    const a = recordingAdapter({ id: "a", subjects: [">"] });
+    router.register(a.adapter);
+
+    await router.dispatch(makeEnvelope());
+    expect(a.calls).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Integration shape — fake MyelinRuntime path (the future wiring)
+// ---------------------------------------------------------------------------
+
+describe("createSurfaceRouter — runtime integration shape", () => {
+  test("router accepts a MyelinRuntime stub and dispatches when called externally", async () => {
+    // The future wiring: a runtime modification that calls
+    // `router.dispatch(envelope, subject)` from its envelope handler.
+    // Until that lands, simulate it here so the integration shape is
+    // pinned down in tests.
+    const runtime = fakeRuntime();
+    const router = createSurfaceRouter(runtime);
+
+    const a = recordingAdapter({ id: "a", subjects: ["local.metafactory.review.>"] });
+    router.register(a.adapter);
+    await router.start();
+
+    // Simulate three envelopes arriving from the runtime.
+    const envs = [
+      makeEnvelope({ id: "11111111-1111-4111-8111-111111111111" }),
+      makeEnvelope({ id: "22222222-2222-4222-8222-222222222222" }),
+      makeEnvelope({ id: "33333333-3333-4333-8333-333333333333" }),
+    ];
+    for (const e of envs) {
+      await router.dispatch(e, "local.metafactory.review.cycle.completed");
+    }
+
+    expect(a.calls).toHaveLength(3);
+    expect(a.calls.map((c) => c.id)).toEqual(envs.map((e) => e.id));
+
+    await router.stop();
+  });
+});

--- a/src/bus/payload-filter.ts
+++ b/src/bus/payload-filter.ts
@@ -1,0 +1,185 @@
+/**
+ * G-1111.A — Payload filter (subset of EventBridge content-filter grammar).
+ *
+ * Per `/tmp/g-1111-spec.md` §4.3 — surfaces declare client-side payload
+ * filters that run AFTER NATS broker-side subject matching. v1 supports a
+ * deliberately small operator set; the rest of EventBridge's grammar
+ * (numeric, cidr, wildcard, $or) is added only when a real adapter needs it.
+ *
+ * Operator support (v1):
+ *   - exact match (any-of)        ["a", "b"]
+ *   - anything-but                [{"anything-but": v}] | [{"anything-but": [v1, v2]}]
+ *   - prefix                      [{"prefix": str}]
+ *   - exists                      [{"exists": bool}]
+ *   - equals-ignore-case          [{"equals-ignore-case": str}]
+ *
+ * Patterns are JSON-shape: keys nest by JSON structure, leaves are an
+ * array of FilterValue (any one of which matches). A field passes iff the
+ * actual value matches at least one entry in the leaf array. The whole
+ * pattern passes iff every key in the pattern passes (logical AND across
+ * keys, OR within a single key's array).
+ *
+ * Pure function. No side effects. Safe to call from any context.
+ */
+
+import type { Envelope } from "./myelin/envelope-validator";
+
+/**
+ * One acceptable form for a leaf in a payload-filter pattern. Strings,
+ * numbers, and booleans are exact-match literals; the object forms are
+ * the EventBridge-style operators.
+ */
+export type FilterValue =
+  | string
+  | number
+  | boolean
+  | { "anything-but": string | number | boolean | Array<string | number | boolean> }
+  | { prefix: string }
+  | { exists: boolean }
+  | { "equals-ignore-case": string };
+
+/**
+ * A pattern matches a JSON object. Nesting follows the JSON structure of
+ * the value being matched: a key whose value is an array of FilterValue
+ * is a leaf; a key whose value is another PayloadFilterPattern descends
+ * into that subtree.
+ */
+export type PayloadFilterPattern = {
+  [key: string]: FilterValue[] | PayloadFilterPattern;
+};
+
+/**
+ * A surface-adapter's full filter. The `envelope` pattern matches the
+ * outer envelope context (type, source, correlation_id, etc.); the
+ * `payload` pattern matches the envelope's payload object. Both are
+ * optional — a filter with neither key matches everything (degenerate but
+ * legal).
+ */
+export interface PayloadFilter {
+  envelope?: PayloadFilterPattern;
+  payload?: PayloadFilterPattern;
+}
+
+/**
+ * Test whether `envelope` passes `filter`. `undefined` filter passes
+ * (i.e., no filter = match all).
+ *
+ * Semantics:
+ *   - The envelope-pattern (if present) is matched against the envelope
+ *     object itself, treating the envelope as a JSON-like record.
+ *   - The payload-pattern (if present) is matched against `envelope.payload`.
+ *   - Both must pass when both are present.
+ *
+ * Missing fields:
+ *   - For most operators, a missing field fails the leaf (no value to
+ *     match) — except `{exists: false}`, which is exactly the "field is
+ *     absent" predicate.
+ *   - `{anything-but: ...}` on a missing field fails: there's nothing to
+ *     compare, so we cannot prove the value is "anything but X". Mirrors
+ *     EventBridge semantics — anything-but requires presence.
+ */
+export function matchesFilter(envelope: Envelope, filter: PayloadFilter | undefined): boolean {
+  if (!filter) return true;
+  if (filter.envelope && !matchPattern(envelope as unknown as Record<string, unknown>, filter.envelope)) {
+    return false;
+  }
+  if (filter.payload && !matchPattern(envelope.payload, filter.payload)) {
+    return false;
+  }
+  return true;
+}
+
+// =============================================================================
+// Internal — pattern walking
+// =============================================================================
+
+function matchPattern(value: unknown, pattern: PayloadFilterPattern): boolean {
+  // Pattern is an object describing required structure of `value`. Every
+  // key in the pattern must pass.
+  if (!isPlainObject(value)) {
+    // The pattern expects nested keys, but value isn't an object — only an
+    // {exists: false} leaf can pass against a non-object value, but at the
+    // pattern-root level the "object-ness" of value is presumed (we
+    // entered matchPattern because the caller had an envelope/payload
+    // record). For a nested non-object value reached via descent, the
+    // pattern can only be satisfied if every key it requires is itself
+    // declared `{exists: false}`. Walk the pattern and check.
+    for (const key of Object.keys(pattern)) {
+      const sub = pattern[key];
+      if (!sub) continue;
+      if (Array.isArray(sub)) {
+        // Leaf: value at `value[key]` cannot be looked up because value
+        // isn't an object — treat as missing.
+        if (!matchLeaf(undefined, sub)) return false;
+      } else {
+        // Nested pattern but no object to descend into — match against
+        // `undefined` recursively. Will pass only for fully-{exists:false}
+        // subtrees.
+        if (!matchPattern(undefined, sub)) return false;
+      }
+    }
+    return true;
+  }
+
+  for (const key of Object.keys(pattern)) {
+    const sub = pattern[key];
+    if (!sub) continue;
+    const fieldValue = (value as Record<string, unknown>)[key];
+    if (Array.isArray(sub)) {
+      if (!matchLeaf(fieldValue, sub)) return false;
+    } else {
+      if (!matchPattern(fieldValue, sub)) return false;
+    }
+  }
+  return true;
+}
+
+function matchLeaf(actual: unknown, candidates: FilterValue[]): boolean {
+  // Empty candidate list never matches (would be a useless pattern). EB
+  // treats this as a config error; we choose "no match" for total-function
+  // safety — a legal but vacuous leaf returns false.
+  if (candidates.length === 0) return false;
+
+  for (const candidate of candidates) {
+    if (matchOne(actual, candidate)) return true;
+  }
+  return false;
+}
+
+function matchOne(actual: unknown, candidate: FilterValue): boolean {
+  // Literal exact-match — strings, numbers, booleans.
+  if (typeof candidate === "string" || typeof candidate === "number" || typeof candidate === "boolean") {
+    return actual === candidate;
+  }
+
+  // Operator object — exactly one of the supported keys.
+  if ("anything-but" in candidate) {
+    if (actual === undefined) return false; // see file-level note: anything-but requires presence
+    const banned = candidate["anything-but"];
+    if (Array.isArray(banned)) {
+      return !banned.includes(actual as string | number | boolean);
+    }
+    return actual !== banned;
+  }
+  if ("prefix" in candidate) {
+    return typeof actual === "string" && actual.startsWith(candidate.prefix);
+  }
+  if ("exists" in candidate) {
+    return candidate.exists ? actual !== undefined : actual === undefined;
+  }
+  if ("equals-ignore-case" in candidate) {
+    return (
+      typeof actual === "string" &&
+      actual.toLocaleLowerCase() === candidate["equals-ignore-case"].toLocaleLowerCase()
+    );
+  }
+
+  // Unknown operator — fail closed. New operators must be explicitly
+  // added here; silently accepting an unknown shape would mask config
+  // typos.
+  return false;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/src/bus/surface-router.ts
+++ b/src/bus/surface-router.ts
@@ -1,0 +1,302 @@
+/**
+ * G-1111.A — Surface router (cortex MIG-1.9).
+ *
+ * Per `/tmp/g-1111-spec.md` §5: the in-process fan-out point that
+ * dispatches one validated envelope to N matching surface adapters.
+ * Adapters declare interest via NATS-style subject patterns plus an
+ * optional payload filter; the router applies broker-side subject
+ * matching first (cheap), then payload filtering (expressive), then
+ * invokes `adapter.render(envelope)` with timeout + isolation.
+ *
+ * Component placement (spec §5.1):
+ *   MyelinRuntime owns the NATS subscription. The router does NOT open
+ *   its own subscriptions. Adapters never subscribe directly.
+ *
+ * Integration with MyelinRuntime (current cortex state):
+ *   The G-1100.E `MyelinRuntime` interface today is `{ enabled, stop() }`
+ *   only — it hard-codes `logEnvelope` as the per-envelope handler and
+ *   exposes no public registration point for an external consumer like
+ *   this router. Wiring the router to receive live envelopes therefore
+ *   requires a runtime change to add an `onEnvelope(handler)` registration
+ *   surface, which is explicitly out of scope for this PR (per the task
+ *   contract: "DO NOT modify MyelinRuntime in this PR").
+ *
+ *   This file ships the router as a self-contained dispatcher whose
+ *   public `dispatch(envelope, subject?)` is the integration entry point.
+ *   Tests exercise it directly. A follow-up PR will add the runtime hook
+ *   so production envelopes flow into `dispatch()`.
+ *
+ * Per spec §5.3: failing adapters MUST NOT block others. Render calls
+ * fan out via `Promise.allSettled`; each is wrapped in a per-render
+ * timeout (default 5s); errors and timeouts are captured via the
+ * optional `onAdapterError` hook and never thrown out of `dispatch()`.
+ */
+
+import type { Envelope } from "./myelin/envelope-validator";
+import type { MyelinRuntime } from "./myelin/runtime";
+import { matchesFilter, type PayloadFilter } from "./payload-filter";
+
+// =============================================================================
+// Public types
+// =============================================================================
+
+/**
+ * One surface adapter. Adapters are dumb-by-design — they declare their
+ * NATS subject patterns + an optional payload filter and a `render()`
+ * function. The router does the matching + isolation; the adapter just
+ * renders.
+ */
+export interface SurfaceAdapter {
+  /** Stable identifier — used in error reporting and metrics. */
+  id: string;
+  /** One or more NATS subject patterns (union — match ANY). */
+  subjects: string[];
+  /** Optional client-side filter applied AFTER subject match. */
+  filter?: PayloadFilter;
+  /** Adapter-specific rendering. Bounded by router's renderTimeoutMs. */
+  render(envelope: Envelope): Promise<void>;
+  /** Optional liveness probe. Currently unused by the router; reserved
+   *  for the dashboard's adapter-health panel (G-1111.E follow-on). */
+  health?(): Promise<{ ok: boolean; lag?: number }>;
+}
+
+export interface SurfaceRouterOptions {
+  /** Per-render timeout in ms. Default 5000 (per spec §7.5). */
+  renderTimeoutMs?: number;
+  /** Hook called on render error or timeout. Signature is intentionally
+   *  fire-and-forget — the router never awaits this. Throws inside this
+   *  hook are swallowed (with a console.error) so a buggy hook can't
+   *  poison the dispatch loop. */
+  onAdapterError?(adapterId: string, err: Error): void;
+}
+
+export interface SurfaceRouter {
+  /** Register an adapter. Returns an unregister handle for symmetry with
+   *  EventEmitter / RxJS / etc. patterns. */
+  register(adapter: SurfaceAdapter): { unregister: () => void };
+  /** Mark the router as ready to dispatch. Idempotent. Today this is a
+   *  state transition only; once the runtime exposes an `onEnvelope`
+   *  hook, `start()` will be where we register that. */
+  start(): Promise<void>;
+  /** Stop accepting new dispatches. After stop, `dispatch()` is a no-op
+   *  (still returns a resolved promise). Idempotent. */
+  stop(): Promise<void>;
+  /** Dispatch one envelope to all matching adapters. Subject is optional;
+   *  when omitted, it is derived from `envelope.type` for local testing.
+   *  Production callers (the future runtime hook) MUST pass the actual
+   *  NATS subject so wildcard patterns match correctly. */
+  dispatch(envelope: Envelope, subject?: string): Promise<void>;
+}
+
+// =============================================================================
+// Subject-pattern matching (NATS-style)
+// =============================================================================
+
+/**
+ * NATS-style subject-pattern match.
+ *
+ *   `>` matches one-or-more trailing segments (must be the LAST token).
+ *   `*` matches exactly one segment.
+ *   Otherwise literal segment compare.
+ *
+ * Examples (from spec §4.2):
+ *   `local.metafactory.review.>`          matches any review.* depth ≥ 1
+ *   `local.metafactory.review.*.completed` matches one segment between review and completed
+ *   `local.metafactory.review.cycle.completed` literal — itself only
+ *
+ * Edge cases:
+ *   - `>` anywhere but the terminal position: treated as a literal segment
+ *     (NATS rejects this at subscribe time; we mirror by being conservative).
+ *   - Empty pattern or empty subject: never matches.
+ *   - `>` alone matches every non-empty subject.
+ */
+export function subjectMatches(pattern: string, subject: string): boolean {
+  if (pattern.length === 0 || subject.length === 0) return false;
+
+  const patternParts = pattern.split(".");
+  const subjectParts = subject.split(".");
+  const pLen = patternParts.length;
+  const sLen = subjectParts.length;
+
+  for (let i = 0; i < pLen; i++) {
+    const p = patternParts[i];
+
+    if (p === ">") {
+      // `>` must be terminal; if not, fall through to literal comparison
+      // and necessarily fail (since "no segment can equal `>`" is a
+      // safe interpretation of malformed patterns).
+      if (i !== pLen - 1) return false;
+      // Terminal `>`: needs at least one subject segment remaining.
+      return sLen >= pLen;
+    }
+
+    // No more subject segments to consume — pattern is longer than
+    // subject (and we haven't hit a `>`), so no match.
+    if (i >= sLen) return false;
+
+    if (p === "*") {
+      // `*` matches exactly one segment (any content). Continue.
+      continue;
+    }
+
+    // Literal compare.
+    if (p !== subjectParts[i]) return false;
+  }
+
+  // Pattern fully consumed without a `>`. Subject must have the same
+  // length to match (no excess trailing segments).
+  return pLen === sLen;
+}
+
+// =============================================================================
+// Implementation
+// =============================================================================
+
+const DEFAULT_RENDER_TIMEOUT_MS = 5000;
+
+/**
+ * Construct a surface router that consumes envelopes from
+ * `MyelinRuntime`. The runtime parameter is currently retained for the
+ * future wiring hook (see file header) — the router does not call into
+ * the runtime today; the runtime will call into the router via
+ * `dispatch()` once an `onEnvelope` registration surface lands.
+ */
+export function createSurfaceRouter(
+  // Reserved for the future runtime → router wiring (see file header).
+  // Today the parameter is part of the contract but the router does not
+  // call into the runtime; the runtime will call `dispatch()` on this
+  // router once an `onEnvelope` registration surface is added there.
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  _runtime: MyelinRuntime,
+  opts?: SurfaceRouterOptions,
+): SurfaceRouter {
+  const adapters: SurfaceAdapter[] = [];
+  const renderTimeoutMs = opts?.renderTimeoutMs ?? DEFAULT_RENDER_TIMEOUT_MS;
+  const onAdapterError = opts?.onAdapterError;
+
+  let started = false;
+  let stopped = false;
+
+  return {
+    register(adapter) {
+      adapters.push(adapter);
+      return {
+        unregister: () => {
+          const idx = adapters.indexOf(adapter);
+          if (idx !== -1) adapters.splice(idx, 1);
+        },
+      };
+    },
+
+    async start() {
+      if (started) return;
+      started = true;
+    },
+
+    async stop() {
+      if (stopped) return;
+      stopped = true;
+    },
+
+    async dispatch(envelope, subject) {
+      if (stopped) return;
+
+      const effectiveSubject = subject ?? envelope.type;
+      const matched = adapters.filter((a) => adapterMatches(a, envelope, effectiveSubject));
+      if (matched.length === 0) return;
+
+      const settled = await Promise.allSettled(
+        matched.map((a) => renderWithIsolation(a, envelope, renderTimeoutMs, onAdapterError)),
+      );
+
+      // `renderWithIsolation` already swallows; the allSettled here is
+      // belt-and-braces against any future change to that helper. Walk the
+      // results so a future logger or metric can hang off this loop.
+      for (const r of settled) {
+        if (r.status === "rejected") {
+          // Should not happen — renderWithIsolation never rejects. If it
+          // does, log defensively rather than crash dispatch.
+          console.error(
+            "grove-bot: surface-router internal error — renderWithIsolation rejected:",
+            r.reason instanceof Error ? r.reason.message : r.reason,
+          );
+        }
+      }
+    },
+  };
+}
+
+// =============================================================================
+// Internal helpers
+// =============================================================================
+
+function adapterMatches(adapter: SurfaceAdapter, envelope: Envelope, subject: string): boolean {
+  // Subject-pattern union: any matching pattern proceeds to the filter.
+  let subjectHit = false;
+  for (const pattern of adapter.subjects) {
+    if (subjectMatches(pattern, subject)) {
+      subjectHit = true;
+      break;
+    }
+  }
+  if (!subjectHit) return false;
+  return matchesFilter(envelope, adapter.filter);
+}
+
+/**
+ * Run `adapter.render(envelope)` under a timeout. Errors and timeouts
+ * route to `onAdapterError`. **Never throws.** The contract is critical
+ * for the §5.3 isolation rule — a slow or buggy adapter MUST NOT block
+ * sibling adapters' renders.
+ */
+async function renderWithIsolation(
+  adapter: SurfaceAdapter,
+  envelope: Envelope,
+  timeoutMs: number,
+  onAdapterError: SurfaceRouterOptions["onAdapterError"],
+): Promise<void> {
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  try {
+    const timeoutPromise = new Promise<never>((_, reject) => {
+      timer = setTimeout(() => {
+        reject(new Error(`render timeout after ${timeoutMs}ms`));
+      }, timeoutMs);
+    });
+
+    // Defensively wrap the render call in case it throws synchronously
+    // before returning a promise.
+    const renderPromise = (async () => adapter.render(envelope))();
+
+    await Promise.race([renderPromise, timeoutPromise]);
+  } catch (err) {
+    const error = err instanceof Error ? err : new Error(String(err));
+    safeReportError(adapter.id, error, onAdapterError);
+  } finally {
+    if (timer !== null) clearTimeout(timer);
+  }
+}
+
+function safeReportError(
+  adapterId: string,
+  err: Error,
+  hook: SurfaceRouterOptions["onAdapterError"],
+): void {
+  if (!hook) {
+    // Default sink: log so a missing observer doesn't make adapter
+    // failures invisible.
+    console.error(
+      `grove-bot: surface-router adapter "${adapterId}" render failed:`,
+      err.message,
+    );
+    return;
+  }
+  try {
+    hook(adapterId, err);
+  } catch (hookErr) {
+    // A throwing observer must not poison the dispatch loop.
+    console.error(
+      `grove-bot: surface-router onAdapterError hook threw for "${adapterId}":`,
+      hookErr instanceof Error ? hookErr.message : hookErr,
+    );
+  }
+}


### PR DESCRIPTION
## What

MIG-1.9 — implement the **surface-router primitive** + **payload-filter** in `src/bus/`. New code per G-1111.A spec (read from `feat/g-1111-event-taxonomy` design doc §4–§5). This is the keystone for MIG-3b/4b/5b: those phases register adapters/runner/taps with this router.

## Components delivered

**`src/bus/payload-filter.ts`** (185 LOC):
- EventBridge content-filter grammar subset per G-1111 §4.3
- Operators: exact match (any-of), `anything-but`, `prefix`, `exists`, `equals-ignore-case`
- Pattern semantics: AND across keys, OR within a leaf array
- Filters apply to envelope context AND payload, nested by JSON structure
- Unknown operators fail closed (defensive)

**`src/bus/surface-router.ts`** (302 LOC):
- `SurfaceAdapter` interface (id, subjects, filter?, render, optional health)
- `SurfaceRouter`: register / unregister / start / stop / dispatch
- `subjectMatches(pattern, subject)` exported helper (NATS-style: `>` terminal, `*` single, literal)
- Adapter isolation: per-render timeout (default 5000ms) + `Promise.allSettled` fan-out + `onAdapterError` observability hook
- `dispatch()` never throws — all adapter errors captured

## API shape

\`\`\`typescript
const router = createSurfaceRouter(myelinRuntime, {
  renderTimeoutMs: 5000,
  onAdapterError: (id, err) => observability.report(id, err),
});

router.register({
  id: "discord-grove",
  subjects: ["local.metafactory.review.>"],
  filter: { payload: { repo: ["grove", "grove-v2"] } },
  render: async (envelope) => { /* post to Discord */ },
});

await router.start();
// ... envelopes flow ...
await router.stop();
\`\`\`

## Tests (79 new)

- **payload-filter** — 43 tests across 9 describe blocks: degenerate cases, exact-match, anything-but (scalar + array, missing-field semantics), prefix, exists (true/false × present/absent), equals-ignore-case, multi-key AND / multi-value OR, two-deep nesting, envelope-level matching, unknown-operator fail-closed.
- **surface-router** — 36 tests across 8 describe blocks: subjectMatches edge cases, register/unregister, subject-match dispatch (positive/negative/union), filter dispatch, adapter isolation (fail-isolated, throwing observer, sync-throw), timeout cancellation, lifecycle (start/stop idempotent, dispatch-after-stop no-op), runtime-integration shape.

## Verification

- cortex root \`bunx tsc --noEmit\` → **exit 0**
- \`bun test src/bus/__tests__/payload-filter.test.ts\` → **43/43**
- \`bun test src/bus/__tests__/surface-router.test.ts\` → **36/36**
- \`bun test src/bus/\` → **152/152** (was 73; **+79 net new**)
- Full suite: **1640/1641** (1 pre-existing React shell test, same as MIG-2)

## Design decisions

1. **`dispatch(envelope, subject?)` two-arg signature.** Spec says \`dispatch(envelope: Envelope): Promise<void>\` (test-only). I added an optional second \`subject\` parameter — strictly additive, doesn't break the spec contract — because reconstructing the NATS subject from envelope alone is unreliable (`envelope.type = domain.entity.action`; org segment isn't always derivable from `envelope.source`). When omitted (test path), `envelope.type` is the synthetic subject. Test-pinned.
2. **Defensive `console.error` fallback when `onAdapterError` not provided.** Drop-on-the-floor is unsafe for an isolation-critical path. Logs with `grove-bot: surface-router adapter "<id>" render failed:` prefix matching existing runtime/subscriber convention.
3. **Hanging render leaks until completion.** JS has no Promise cancellation; `Promise.race` resolves but the loser keeps running. Acceptable v1 (dispatch unblocked, which is what §5.3 requires). Future: pass `AbortSignal` to `render()`.
4. **`MyelinRuntime` integration deferred to follow-up PR.** Current runtime hardcodes `logEnvelope` as the per-envelope handler — no public registration seam. Per task contract I did NOT modify the runtime in this PR. The router accepts runtime as constructor param to preserve the contract. Wiring is a one-line edit at `runtime.ts:95` in a follow-up: add `onEnvelope(handler)` registration; existing logging keeps working alongside fan-out to router. Once that lands, MIG-1.9 plan-tick + the §5.3 integration acceptance test become natural.

## What this PR is NOT

- **No MyelinRuntime modification** — explicitly out of scope per task contract; lands in follow-up.
- **No YAML adapter-config-loader** — spec §4.4. Adapters can be programmatically registered from cortex.ts entrypoint (MIG-7.1); YAML config loader is G-1111.E follow-up.
- **No specific adapter implementations** — Discord/Mattermost/PagerDuty/Dashboard adapter classes land in MIG-3b/4b plus future work.

## Plan grounding

`docs/architecture.md` §8 — bus/ at top level. Plan §4 MIG-1.9. Spec at `/tmp/g-1111-spec.md` (saved from `feat/g-1111-event-taxonomy:docs/design-event-taxonomy.md`) §4 + §5.

Refs cortex#3 (MIG-1 umbrella).

🤖 Generated with [Claude Code](https://claude.com/claude-code)