### PR TITLE
feat(bus): C-102 — wire surface-router.start/stop into runtime.onEnvelope (MIG-1.9 final)

### DIFF
--- a/src/bus/__tests__/surface-router.test.ts
+++ b/src/bus/__tests__/surface-router.test.ts
@@ -34,6 +34,33 @@ function fakeRuntime(): MyelinRuntime {
   };
 }
 
+/**
+ * `fakeRuntime` plus a `trigger()` helper for end-to-end wiring tests.
+ * Use when the test needs to simulate an envelope arriving on the bus
+ * (i.e. the runtime side of the surface-router contract).
+ */
+function fakeRuntimeWithTrigger(): {
+  runtime: MyelinRuntime;
+  trigger: (env: Envelope, subject: string) => void;
+  registrationCount: () => number;
+} {
+  const handlers = new Set<Parameters<MyelinRuntime["onEnvelope"]>[0]>();
+  return {
+    runtime: {
+      enabled: true,
+      onEnvelope: (handler) => {
+        handlers.add(handler);
+        return { unregister: () => { handlers.delete(handler); } };
+      },
+      stop: async () => {},
+    },
+    trigger: (env, subject) => {
+      for (const h of handlers) h(env, subject);
+    },
+    registrationCount: () => handlers.size,
+  };
+}
+
 function makeEnvelope(overrides: Partial<Envelope> = {}): Envelope {
   return {
     id: "00000000-0000-4000-8000-000000000000",
@@ -486,10 +513,9 @@ describe("createSurfaceRouter — lifecycle", () => {
 
 describe("createSurfaceRouter — runtime integration shape", () => {
   test("router accepts a MyelinRuntime stub and dispatches when called externally", async () => {
-    // The future wiring: a runtime modification that calls
-    // `router.dispatch(envelope, subject)` from its envelope handler.
-    // Until that lands, simulate it here so the integration shape is
-    // pinned down in tests.
+    // The legacy direct-dispatch path — verifies dispatch() works even
+    // when the runtime hasn't fired the handler. Useful for unit tests
+    // and for callers that want to push synthetic envelopes through.
     const runtime = fakeRuntime();
     const router = createSurfaceRouter(runtime);
 
@@ -497,7 +523,6 @@ describe("createSurfaceRouter — runtime integration shape", () => {
     router.register(a.adapter);
     await router.start();
 
-    // Simulate three envelopes arriving from the runtime.
     const envs = [
       makeEnvelope({ id: "11111111-1111-4111-8111-111111111111" }),
       makeEnvelope({ id: "22222222-2222-4222-8222-222222222222" }),
@@ -511,5 +536,72 @@ describe("createSurfaceRouter — runtime integration shape", () => {
     expect(a.calls.map((c) => c.id)).toEqual(envs.map((e) => e.id));
 
     await router.stop();
+  });
+
+  test("start() registers an onEnvelope handler on the runtime", async () => {
+    const fake = fakeRuntimeWithTrigger();
+    const router = createSurfaceRouter(fake.runtime);
+
+    expect(fake.registrationCount()).toBe(0);
+    await router.start();
+    expect(fake.registrationCount()).toBe(1);
+    await router.start(); // idempotent — must not double-register
+    expect(fake.registrationCount()).toBe(1);
+    await router.stop();
+  });
+
+  test("stop() unregisters the runtime onEnvelope handler", async () => {
+    const fake = fakeRuntimeWithTrigger();
+    const router = createSurfaceRouter(fake.runtime);
+
+    await router.start();
+    expect(fake.registrationCount()).toBe(1);
+    await router.stop();
+    expect(fake.registrationCount()).toBe(0);
+    await router.stop(); // idempotent
+    expect(fake.registrationCount()).toBe(0);
+  });
+
+  test("end-to-end: runtime envelope reaches registered adapter via wired handler", async () => {
+    // The §4.355 integration acceptance shape: register a fake adapter,
+    // simulate an envelope arriving from the runtime, assert the
+    // adapter received it.
+    const fake = fakeRuntimeWithTrigger();
+    const router = createSurfaceRouter(fake.runtime);
+
+    const a = recordingAdapter({ id: "a", subjects: ["local.metafactory.review.>"] });
+    router.register(a.adapter);
+    await router.start();
+
+    fake.trigger(
+      makeEnvelope({ id: "12121212-1212-4121-8121-121212121212" }),
+      "local.metafactory.review.cycle.completed",
+    );
+
+    // Dispatch is fire-and-forget from the handler's perspective. Yield
+    // to the microtask queue so allSettled completes before we assert.
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(a.calls).toHaveLength(1);
+    expect(a.calls[0]!.id).toBe("12121212-1212-4121-8121-121212121212");
+
+    await router.stop();
+  });
+
+  test("after stop(), runtime envelopes do not reach adapters (handler unregistered)", async () => {
+    const fake = fakeRuntimeWithTrigger();
+    const router = createSurfaceRouter(fake.runtime);
+    const a = recordingAdapter({ id: "a", subjects: ["local.metafactory.>"] });
+    router.register(a.adapter);
+
+    await router.start();
+    fake.trigger(makeEnvelope(), "local.metafactory.review.cycle.completed");
+    await new Promise((r) => setTimeout(r, 0));
+    expect(a.calls).toHaveLength(1);
+
+    await router.stop();
+    fake.trigger(makeEnvelope(), "local.metafactory.review.cycle.completed");
+    await new Promise((r) => setTimeout(r, 0));
+    expect(a.calls).toHaveLength(1); // unchanged — stop unregistered the handler
   });
 });

--- a/src/bus/surface-router.ts
+++ b/src/bus/surface-router.ts
@@ -156,18 +156,14 @@ const DEFAULT_RENDER_TIMEOUT_MS = 5000;
 
 /**
  * Construct a surface router that consumes envelopes from
- * `MyelinRuntime`. The runtime parameter is currently retained for the
- * future wiring hook (see file header) — the router does not call into
- * the runtime today; the runtime will call into the router via
- * `dispatch()` once an `onEnvelope` registration surface lands.
+ * `MyelinRuntime`. On `start()`, the router registers an
+ * `onEnvelope` handler with the runtime; on `stop()`, the
+ * registration unwinds. Production callers should construct the
+ * router after `startMyelinRuntime` returns and `await router.start()`
+ * before publishing.
  */
 export function createSurfaceRouter(
-  // Reserved for the future runtime → router wiring (see file header).
-  // Today the parameter is part of the contract but the router does not
-  // call into the runtime; the runtime will call `dispatch()` on this
-  // router once an `onEnvelope` registration surface is added there.
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  _runtime: MyelinRuntime,
+  runtime: MyelinRuntime,
   opts?: SurfaceRouterOptions,
 ): SurfaceRouter {
   const adapters: SurfaceAdapter[] = [];
@@ -176,8 +172,11 @@ export function createSurfaceRouter(
 
   let started = false;
   let stopped = false;
+  let envelopeReg: { unregister: () => void } | null = null;
 
-  return {
+  // Forward declaration — start() needs to reference dispatch by name to
+  // bind the runtime's onEnvelope handler.
+  const router: SurfaceRouter = {
     register(adapter) {
       adapters.push(adapter);
       return {
@@ -191,11 +190,25 @@ export function createSurfaceRouter(
     async start() {
       if (started) return;
       started = true;
+      // Wire runtime → router. Each envelope from any active subscription
+      // arrives at the router with its actual NATS subject (so wildcard
+      // patterns route correctly).
+      envelopeReg = runtime.onEnvelope((env, subject) => {
+        // dispatch() returns a Promise; we don't await — the runtime's
+        // subscriber loop must not block on adapter rendering. The router
+        // already isolates adapter errors via renderWithIsolation so this
+        // floating Promise resolves cleanly.
+        void router.dispatch(env, subject);
+      });
     },
 
     async stop() {
       if (stopped) return;
       stopped = true;
+      if (envelopeReg) {
+        envelopeReg.unregister();
+        envelopeReg = null;
+      }
     },
 
     async dispatch(envelope, subject) {
@@ -224,6 +237,8 @@ export function createSurfaceRouter(
       }
     },
   };
+
+  return router;
 }
 
 // =============================================================================


### PR DESCRIPTION
## What

Closes the MIG-1.9 surface-router trilogy. cortex#25 added the router primitive; cortex#26 added the runtime hook; **this PR wires them together** so adapters registered via `router.register()` start receiving bus envelopes immediately on `router.start()`.

## API now functionally complete

\`\`\`typescript
// In cortex.ts entrypoint (MIG-7.1, future):
const runtime = await startMyelinRuntime(config);
const router = createSurfaceRouter(runtime, { onAdapterError: telemetry });
await router.start();

router.register({
  id: "discord-grove",
  subjects: ["local.metafactory.review.>"],
  filter: { payload: { repo: ["grove-v2"] } },
  render: async (env) => discord.post(env),
});

// Bus envelopes now flow runtime → router → matched adapters automatically.
\`\`\`

## Mechanics

- `start()` calls `runtime.onEnvelope((env, subj) => router.dispatch(env, subj))` and stores the registration token; idempotent
- `stop()` unregisters and clears the token; idempotent
- Floating Promise from `router.dispatch()` is intentional — the runtime's subscriber loop must not block on adapter rendering. Router already isolates adapter errors via `renderWithIsolation`

## New tests (4)

- **start() registers an onEnvelope handler on the runtime** — single registration on start, idempotent
- **stop() unregisters the runtime onEnvelope handler** — registration removed, idempotent
- **end-to-end: runtime envelope reaches registered adapter via wired handler** — the **spec §4.355 integration acceptance shape**: register fake adapter, simulate runtime envelope, assert receipt. **Closes the cortex#13 closure criterion item 5.**
- **after stop(), runtime envelopes do not reach adapters** — proves the unregister path actually unwinds

Plus new `fakeRuntimeWithTrigger()` helper for end-to-end tests.

## Verification

- cortex root \`bunx tsc --noEmit\` → **exit 0**
- \`bun test src/bus/__tests__/surface-router.test.ts\` → **40/40 pass** (was 36/36; **+4 new wiring tests**)
- \`bun test src/bus/myelin/__tests__/runtime.test.ts\` → **9/9** (unchanged)
- Full suite: **1646 / 1647 pass** (1 pre-existing React shell fail)

## MIG-1 status after this lands

| Step | Status |
|---|---|
| 1.1 nats-connection (G-1100.A) | ✅ done (cortex#10) |
| 1.2 nats-subscription (G-1100.C) | ✅ done (cortex#11) |
| 1.3 myelin schema (G-1100.B) | ✅ done (cortex#11) |
| 1.4 myelin-subscriber (G-1100.D) | ✅ done (cortex#12) |
| 1.5 myelin-runtime (G-1100.E) | ✅ done (cortex#22) |
| 1.6 dispatch-handler | ✅ done (cortex#24) |
| 1.7 inbound-queue | ✅ no port (JetStream durability) |
| 1.8 network-resolver | ✅ done (cortex#24) |
| 1.9 surface-router (G-1111.A) | ✅ **done with this PR** (cortex#25 + #26 + this) |

**MIG-1 bus runtime is functionally complete.** Single subscription source preserved (router piggybacks on runtime). §5.3 adapter isolation tested end-to-end.

This unblocks **MIG-3.4/3.5** (adapters register with surface-router), **MIG-4.5** (runner subscribes via router), **MIG-5.5/5.6** (taps publish through MyelinRuntime), and **MIG-7.1** (cortex.ts entrypoint).

Refs cortex#3 (MIG-1 umbrella). Closes the MIG-1.9 trilogy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)