### PR TITLE
chore(cortex): C-108 — accumulated nit sweep across MIG PRs (closes cortex#34)

### DIFF
--- a/src/adapters/discord/__tests__/client-degraded.test.ts
+++ b/src/adapters/discord/__tests__/client-degraded.test.ts
@@ -116,12 +116,10 @@ describe("createDiscordClient degraded timer", () => {
       (client as any).emit("shardDisconnect", { code: 1006 } as any, 0);
       await new Promise((r) => setTimeout(r, 40));
       (client as any).emit("shardReady", 0);
-      // Every log line we emitted should carry the [discord-test] prefix
-      const ours = lines.filter((l) => l.startsWith("grove-bot:"));
+      // Every log line we emitted should carry the `discord-test:` prefix
+      // (instanceId-derived component name — see `client.ts`'s `tag`).
+      const ours = lines.filter((l) => l.startsWith("discord-test:"));
       expect(ours.length).toBeGreaterThan(0);
-      for (const l of ours) {
-        expect(l).toContain("[discord-test]");
-      }
       expect(health.degraded).toBe(false);
       client.removeAllListeners();
       client.destroy();

--- a/src/adapters/discord/attachments.ts
+++ b/src/adapters/discord/attachments.ts
@@ -229,12 +229,12 @@ function cleanDirRecursive(dirPath: string): void {
           unlinkSync(entryPath);
         }
       } catch (err) {
-        console.warn("grove-bot: attachment cleanup: failed to remove entry:", entryPath, err instanceof Error ? err.message : err);
+        console.warn("discord-attachments: cleanup: failed to remove entry:", entryPath, err instanceof Error ? err.message : err);
       }
     }
     rmdirSync(dirPath);
   } catch (err) {
-    console.warn("grove-bot: attachment cleanup: failed to remove dir:", dirPath, err instanceof Error ? err.message : err);
+    console.warn("discord-attachments: cleanup: failed to remove dir:", dirPath, err instanceof Error ? err.message : err);
   }
 }
 
@@ -265,11 +265,11 @@ export function cleanupExpiredDirs(): number {
           cleaned++;
         }
       } catch (err) {
-        console.warn("grove-bot: attachment cleanup: failed to stat/clean dir:", dir, err instanceof Error ? err.message : err);
+        console.warn("discord-attachments: cleanup: failed to stat/clean dir:", dir, err instanceof Error ? err.message : err);
       }
     }
   } catch (err) {
-    console.warn("grove-bot: attachment cleanup: failed to read temp base:", err instanceof Error ? err.message : err);
+    console.warn("discord-attachments: cleanup: failed to read temp base:", err instanceof Error ? err.message : err);
   }
 
   return cleaned;
@@ -291,12 +291,12 @@ export function collectOutputFiles(sessionId: string): string[] {
           const stat = statSync(p);
           return stat.isFile() && stat.size <= ATTACHMENT_LIMITS.discordMaxUploadBytes;
         } catch (err) {
-          console.warn("grove-bot: collectOutputFiles: failed to stat:", p, err instanceof Error ? err.message : err);
+          console.warn("discord-attachments: collectOutputFiles: failed to stat:", p, err instanceof Error ? err.message : err);
           return false;
         }
       });
   } catch (err) {
-    console.warn("grove-bot: collectOutputFiles: failed to read output dir:", err instanceof Error ? err.message : err);
+    console.warn("discord-attachments: collectOutputFiles: failed to read output dir:", err instanceof Error ? err.message : err);
     return [];
   }
 }
@@ -329,13 +329,13 @@ export async function processInboundAttachments(
     );
 
     if (errors.length > 0) {
-      console.log(`grove-bot: attachment errors: ${errors.join("; ")}`);
+      console.log(`discord-attachments: errors: ${errors.join("; ")}`);
     }
 
     if (processed.length > 0) {
       prompt = buildAttachmentPrompt(processed);
       dirs.push(getSessionDir(attachSessionId));
-      console.log(`grove-bot: processed ${processed.length} attachment(s)`);
+      console.log(`discord-attachments: processed ${processed.length} attachment(s)`);
     }
   }
 
@@ -356,18 +356,18 @@ function getDirSize(dirPath: string): number {
             try {
               total += statSync(join(entryPath, file)).size;
             } catch (err) {
-              console.warn("grove-bot: getDirSize: failed to stat file:", join(entryPath, file), err instanceof Error ? err.message : err);
+              console.warn("discord-attachments: getDirSize: failed to stat file:", join(entryPath, file), err instanceof Error ? err.message : err);
             }
           }
         } else {
           total += stat.size;
         }
       } catch (err) {
-        console.warn("grove-bot: getDirSize: failed to stat entry:", entryPath, err instanceof Error ? err.message : err);
+        console.warn("discord-attachments: getDirSize: failed to stat entry:", entryPath, err instanceof Error ? err.message : err);
       }
     }
   } catch (err) {
-    console.warn("grove-bot: getDirSize: failed to read dir:", dirPath, err instanceof Error ? err.message : err);
+    console.warn("discord-attachments: getDirSize: failed to read dir:", dirPath, err instanceof Error ? err.message : err);
   }
   return total;
 }

--- a/src/adapters/discord/client.ts
+++ b/src/adapters/discord/client.ts
@@ -53,7 +53,11 @@ export function createDiscordClient(
   options: DiscordClientOptions = {},
 ): DiscordClientResult {
   const instanceId = options.instanceId ?? "discord";
-  const tag = `[${instanceId}]`;
+  // Logs use the instanceId directly as the prefix component (e.g.
+  // `discord-luna: shard 0 ready`). Multi-adapter deployments scope a unique
+  // instanceId per discord.js client, so the prefix disambiguates without
+  // needing a separate `grove-bot:`/`cortex:` umbrella.
+  const tag = instanceId;
   const degradedThresholdMs = options.degradedThresholdMs ?? 60_000;
   const health: ConnectionHealth = {
     reconnectCount: 0,
@@ -91,7 +95,7 @@ export function createDiscordClient(
   client.on("ready", () => {
     health.currentlyConnected = true;
     health.lastConnectedAt = new Date();
-    console.log(`grove-bot: ${tag} connected as ${client.user?.tag}`);
+    console.log(`${tag}: connected as ${client.user?.tag}`);
     console.log(`  Agent: ${config.agent.displayName}`);
     const guildIds = config.discord.map((d) => d.guildId).join(", ");
     console.log(`  Guild(s): ${guildIds || "none"}`);
@@ -107,12 +111,12 @@ export function createDiscordClient(
       // disconnect duration, not just "time since DEGRADED was declared".
       const degradedForMs = Date.now() - health.degradedSince.getTime();
       console.warn(
-        `grove-bot: ${tag} shard ${shardId} RECOVERED after ${(degradedForMs / 1000).toFixed(0)}s disconnected (reconnects so far: ${health.reconnectCount})`
+        `${tag}: shard ${shardId} RECOVERED after ${(degradedForMs / 1000).toFixed(0)}s disconnected (reconnects so far: ${health.reconnectCount})`
       );
       try {
         options.onRecovered?.({ instanceId, degradedForMs });
       } catch (err) {
-        console.error(`grove-bot: ${tag} onRecovered callback threw:`, err instanceof Error ? err.message : err);
+        console.error(`${tag}: onRecovered callback threw:`, err instanceof Error ? err.message : err);
       }
     }
     health.degraded = false;
@@ -120,14 +124,14 @@ export function createDiscordClient(
     if (!wasDegraded) {
       // Normal reconnect within threshold — emit the routine ready log. When
       // we crossed the degraded threshold, RECOVERED above already conveys it.
-      console.log(`grove-bot: ${tag} shard ${shardId} ready (reconnects so far: ${health.reconnectCount})`);
+      console.log(`${tag}: shard ${shardId} ready (reconnects so far: ${health.reconnectCount})`);
     }
   });
 
   client.on("shardDisconnect", (closeEvent, shardId) => {
     health.currentlyConnected = false;
     health.lastDisconnectedAt = new Date();
-    console.error(`grove-bot: ${tag} shard ${shardId} disconnected (code: ${closeEvent.code}, uptime: ${formatUptime(health.lastConnectedAt)})`);
+    console.error(`${tag}: shard ${shardId} disconnected (code: ${closeEvent.code}, uptime: ${formatUptime(health.lastConnectedAt)})`);
     clearDegradedTimer();
     // Stamp degradedSince at disconnect time — the moment outage minutes
     // started accruing — even though `degraded` only flips after the
@@ -137,27 +141,27 @@ export function createDiscordClient(
     degradedTimer = setTimeout(() => {
       health.degraded = true;
       console.error(
-        `grove-bot: ${tag} shard ${shardId} DEGRADED — disconnected > ${(degradedThresholdMs / 1000).toFixed(0)}s without recovery`
+        `${tag}: shard ${shardId} DEGRADED — disconnected > ${(degradedThresholdMs / 1000).toFixed(0)}s without recovery`
       );
       try {
         options.onDegraded?.({ instanceId, thresholdMs: degradedThresholdMs, since: disconnectAt });
       } catch (err) {
-        console.error(`grove-bot: ${tag} onDegraded callback threw:`, err instanceof Error ? err.message : err);
+        console.error(`${tag}: onDegraded callback threw:`, err instanceof Error ? err.message : err);
       }
     }, degradedThresholdMs);
   });
 
   client.on("shardReconnecting", (shardId) => {
     health.reconnectCount++;
-    console.log(`grove-bot: ${tag} shard ${shardId} reconnecting (#${health.reconnectCount}, last connected: ${formatUptime(health.lastConnectedAt)} ago)`);
+    console.log(`${tag}: shard ${shardId} reconnecting (#${health.reconnectCount}, last connected: ${formatUptime(health.lastConnectedAt)} ago)`);
   });
 
   client.on("error", (error) => {
-    console.error(`grove-bot: ${tag} Discord client error:`, error.message);
+    console.error(`${tag}: Discord client error:`, error.message);
   });
 
   client.on("shardError", (error, shardId) => {
-    console.error(`grove-bot: ${tag} shard ${shardId} WebSocket error:`, error.message);
+    console.error(`${tag}: shard ${shardId} WebSocket error:`, error.message);
   });
 
   return { client, health };

--- a/src/adapters/discord/index.ts
+++ b/src/adapters/discord/index.ts
@@ -101,6 +101,12 @@ export class DiscordAdapter implements PlatformAdapter {
   private adapterConfig: DiscordAdapterConfig;
   private runtime: MyelinRuntime | undefined;
   private systemEventSource: SystemEventSource | undefined;
+  /**
+   * Latches once we've warned about the runtime-without-source case so a
+   * busy adapter doesn't flood the log with the same diagnostic on every
+   * shard event. Cleared only when the adapter is reconstructed.
+   */
+  private warnedMissingSource = false;
 
   constructor(
     adapterConfig: DiscordAdapterConfig,
@@ -788,25 +794,35 @@ export class DiscordAdapter implements PlatformAdapter {
   // ---------------------------------------------------------------------------
 
   /**
-   * Common gate for `system.adapter.*` emission. Splits the "no runtime
-   * configured" case (silent — bot was started without NATS) from the "no
-   * source configured but runtime present" case (warn once — operator wired
-   * NATS but forgot to pass `systemEventSource`, which is a config bug worth
-   * surfacing).
+   * Common gate for `system.adapter.*` emission. Returns the bound runtime +
+   * source pair when both are configured, or `null` otherwise. Splits the "no
+   * runtime configured" case (silent — bot was started without NATS) from the
+   * "no source configured but runtime present" case (warn once — operator
+   * wired NATS but forgot to pass `systemEventSource`, which is a config bug
+   * worth surfacing).
+   *
+   * Returning the pair (rather than a boolean) lets callers publish without
+   * any non-null assertions on `this.runtime` / `this.systemEventSource` —
+   * the discriminated shape carries the type evidence the compiler needs.
    */
-  private canPublishSystemEvent(): boolean {
-    if (!this.runtime) return false;
-    if (!this.systemEventSource) {
-      // Warn once per missing-source occurrence — without the source, we'd
-      // emit envelopes that fail schema validation on the receiver side. The
-      // operator needs this signal at start time, not buried in error logs
-      // after a real outage.
-      console.warn(
-        `discord-${this.instanceId}: runtime is configured but systemEventSource is missing — system.* events will not be emitted`,
-      );
-      return false;
+  private canPublishSystemEvent(): { runtime: MyelinRuntime; source: SystemEventSource } | null {
+    const runtime = this.runtime;
+    if (!runtime) return null;
+    const source = this.systemEventSource;
+    if (!source) {
+      if (!this.warnedMissingSource) {
+        // Warn once per process — without the source, we'd emit envelopes
+        // that fail schema validation on the receiver side. The operator
+        // needs this signal at start time, not flooded across every shard
+        // disconnect during a real outage.
+        console.warn(
+          `discord-${this.instanceId}: runtime is configured but systemEventSource is missing — system.* events will not be emitted`,
+        );
+        this.warnedMissingSource = true;
+      }
+      return null;
     }
-    return true;
+    return { runtime, source };
   }
 
   private publishAdapterDegraded(opts: {
@@ -814,9 +830,10 @@ export class DiscordAdapter implements PlatformAdapter {
     thresholdMs: number;
     since: Date;
   }): void {
-    if (!this.canPublishSystemEvent()) return;
+    const wiring = this.canPublishSystemEvent();
+    if (!wiring) return;
     const env = createSystemAdapterDegradedEvent({
-      source: this.systemEventSource!,
+      source: wiring.source,
       adapterId: opts.instanceId,
       platform: "discord",
       disconnectedSince: opts.since,
@@ -825,22 +842,23 @@ export class DiscordAdapter implements PlatformAdapter {
     });
     // Fire-and-forget — `MyelinRuntime.publish` swallows + logs errors so we
     // never crash the bot just because a degraded notification couldn't ship.
-    void this.runtime!.publish(env);
+    void wiring.runtime.publish(env);
   }
 
   private publishAdapterRecovered(opts: {
     instanceId: string;
     degradedForMs: number;
   }): void {
-    if (!this.canPublishSystemEvent()) return;
+    const wiring = this.canPublishSystemEvent();
+    if (!wiring) return;
     const env = createSystemAdapterRecoveredEvent({
-      source: this.systemEventSource!,
+      source: wiring.source,
       adapterId: opts.instanceId,
       platform: "discord",
       degradedForMs: opts.degradedForMs,
       reconnectAttempts: this.connectionHealth?.reconnectCount,
     });
-    void this.runtime!.publish(env);
+    void wiring.runtime.publish(env);
   }
 
   private publishAdapterDisconnected(opts: {
@@ -849,7 +867,8 @@ export class DiscordAdapter implements PlatformAdapter {
     closeReason?: string;
     wasClean: boolean;
   }): void {
-    if (!this.canPublishSystemEvent()) return;
+    const wiring = this.canPublishSystemEvent();
+    if (!wiring) return;
     // The disconnect timestamp lives on the connection-health snapshot; if
     // discord.js fired shardDisconnect before connection-health updated (or
     // the field was cleared between event and publish), fall back to "now"
@@ -857,7 +876,7 @@ export class DiscordAdapter implements PlatformAdapter {
     const disconnectedSince =
       this.connectionHealth?.lastDisconnectedAt ?? new Date();
     const env = createSystemAdapterDisconnectedEvent({
-      source: this.systemEventSource!,
+      source: wiring.source,
       adapterId: this.instanceId,
       platform: "discord",
       disconnectedSince,
@@ -868,6 +887,6 @@ export class DiscordAdapter implements PlatformAdapter {
       }),
       wasClean: opts.wasClean,
     });
-    void this.runtime!.publish(env);
+    void wiring.runtime.publish(env);
   }
 }

--- a/src/adapters/discord/index.ts
+++ b/src/adapters/discord/index.ts
@@ -120,7 +120,7 @@ export class DiscordAdapter implements PlatformAdapter {
     // it here avoids the "why is nothing rendering?" diagnostic dance.
     if (adapterConfig.surfaceSubjects?.length === 0) {
       console.warn(
-        `grove-bot: discord-${this.instanceId} surfaceSubjects is empty — adapter will never render bus envelopes`,
+        `discord-${this.instanceId}: surfaceSubjects is empty — adapter will never render bus envelopes`,
       );
     }
   }
@@ -202,7 +202,7 @@ export class DiscordAdapter implements PlatformAdapter {
           const res = await fetch(messageTxt.url);
           if (res.ok) finalContent = (await res.text()).trim();
         } catch (err) {
-          console.warn("grove-bot: discord: failed to fetch message.txt attachment:", err instanceof Error ? err.message : err);
+          console.warn(`discord-${this.instanceId}: failed to fetch message.txt attachment:`, err instanceof Error ? err.message : err);
         }
       }
 
@@ -229,7 +229,7 @@ export class DiscordAdapter implements PlatformAdapter {
             try {
               parent = (await this.client.channels.fetch(thread.parentId)) as TextChannel | null;
             } catch (err) {
-              console.warn("grove-bot: discord: failed to fetch parent channel:", err instanceof Error ? err.message : err);
+              console.warn(`discord-${this.instanceId}: failed to fetch parent channel:`, err instanceof Error ? err.message : err);
             }
           }
           channelName = parent?.name ?? undefined;
@@ -238,7 +238,7 @@ export class DiscordAdapter implements PlatformAdapter {
           channelName = (channel as TextChannel).name ?? undefined;
         }
         if (channelName) {
-          console.log(`grove-bot: channel="${channelName}"${threadName ? ` thread="${threadName}"` : ""}`);
+          console.log(`discord-${this.instanceId}: channel="${channelName}"${threadName ? ` thread="${threadName}"` : ""}`);
         }
       }
 
@@ -428,9 +428,9 @@ export class DiscordAdapter implements PlatformAdapter {
           if (oldest) this.pendingResults.delete(oldest);
         }
         this.pendingResults.set(key, { target, text, files, createdAt: Date.now() });
-        console.warn(`grove-bot: discord: buffered result for ${key} (Discord disconnected, ${this.pendingResults.size} pending)`);
+        console.warn(`discord-${this.instanceId}: buffered result for ${key} (Discord disconnected, ${this.pendingResults.size} pending)`);
       } else {
-        console.error("grove-bot: discord: postResponse failed while connected:", err instanceof Error ? err.message : err);
+        console.error(`discord-${this.instanceId}: postResponse failed while connected:`, err instanceof Error ? err.message : err);
       }
     }
   }
@@ -486,7 +486,7 @@ export class DiscordAdapter implements PlatformAdapter {
     this.progressMessages.delete(key);
     this.progressSending.delete(key);
     try { await msg?.delete(); } catch (err) {
-      console.warn("grove-bot: discord: failed to delete progress message:", err instanceof Error ? err.message : err);
+      console.warn(`discord-${this.instanceId}: failed to delete progress message:`, err instanceof Error ? err.message : err);
     }
   }
 
@@ -509,7 +509,7 @@ export class DiscordAdapter implements PlatformAdapter {
         _native: thread,
       };
     } catch (err) {
-      console.warn("grove-bot: discord: thread creation failed, falling back to channel:", err instanceof Error ? err.message : err);
+      console.warn(`discord-${this.instanceId}: thread creation failed, falling back to channel:`, err instanceof Error ? err.message : err);
       return { instanceId: this.instanceId, channelId: msg.channelId, _native: nativeMsg.channel };
     }
   }
@@ -536,7 +536,7 @@ export class DiscordAdapter implements PlatformAdapter {
       //     the same failure forever and crowd out genuinely transient DMs.
       if (DiscordAdapter.isPermanentlyUndeliverableDMError(err)) {
         console.warn(
-          "grove-bot: discord: dropping operator DM, permanently undeliverable:",
+          `discord-${this.instanceId}: dropping operator DM, permanently undeliverable:`,
           err instanceof Error ? err.message : err,
         );
         return;
@@ -544,7 +544,7 @@ export class DiscordAdapter implements PlatformAdapter {
       if (!this.connectionHealth?.currentlyConnected && isRetryableError(err)) {
         this.bufferOperatorDM(text);
       } else {
-        console.warn("grove-bot: discord: failed to notify operator:", err instanceof Error ? err.message : err);
+        console.warn(`discord-${this.instanceId}: failed to notify operator:`, err instanceof Error ? err.message : err);
       }
     }
   }
@@ -581,7 +581,7 @@ export class DiscordAdapter implements PlatformAdapter {
     }
     this.pendingOperatorDMs.push({ text, createdAt: Date.now() });
     console.warn(
-      `grove-bot: discord: buffered operator DM (Discord disconnected, ${this.pendingOperatorDMs.length} pending)`
+      `discord-${this.instanceId}: buffered operator DM (Discord disconnected, ${this.pendingOperatorDMs.length} pending)`
     );
   }
 
@@ -594,7 +594,7 @@ export class DiscordAdapter implements PlatformAdapter {
     );
     const expired = before - this.pendingOperatorDMs.length;
     if (expired > 0) {
-      console.warn(`grove-bot: discord: expired ${expired} pending operator DM(s)`);
+      console.warn(`discord-${this.instanceId}: expired ${expired} pending operator DM(s)`);
     }
   }
 
@@ -611,7 +611,7 @@ export class DiscordAdapter implements PlatformAdapter {
     const toDeliver = this.pendingOperatorDMs;
     this.pendingOperatorDMs = [];
 
-    console.log(`grove-bot: discord: draining ${toDeliver.length} pending operator DM(s)`);
+    console.log(`discord-${this.instanceId}: draining ${toDeliver.length} pending operator DM(s)`);
     try {
       const operator = await this.client.users.fetch(operatorId);
       for (const pending of toDeliver) {
@@ -619,14 +619,14 @@ export class DiscordAdapter implements PlatformAdapter {
           await operator.send(pending.text);
         } catch (err) {
           console.error(
-            "grove-bot: discord: failed to deliver buffered operator DM:",
+            `discord-${this.instanceId}: failed to deliver buffered operator DM:`,
             err instanceof Error ? err.message : err,
           );
         }
       }
     } catch (err) {
       console.error(
-        "grove-bot: discord: could not fetch operator user to drain DMs:",
+        `discord-${this.instanceId}: could not fetch operator user to drain DMs:`,
         err instanceof Error ? err.message : err,
       );
     }
@@ -635,23 +635,23 @@ export class DiscordAdapter implements PlatformAdapter {
   private async deliverPendingResult(key: string, pending: PendingResult): Promise<boolean> {
     const channel = await this.resolveChannel(pending.target, true);
     if (!channel) {
-      console.warn(`grove-bot: discord: could not resolve channel ${key} for pending result, dropping`);
+      console.warn(`discord-${this.instanceId}: could not resolve channel ${key} for pending result, dropping`);
       return false;
     }
     await postToDiscord(channel, pending.text, DiscordAdapter.toDiscordFiles(pending.files));
-    console.log(`grove-bot: discord: delivered pending result to ${key}`);
+    console.log(`discord-${this.instanceId}: delivered pending result to ${key}`);
     return true;
   }
 
   private async drainPendingResults(): Promise<void> {
     if (this.pendingResults.size === 0) return;
-    console.log(`grove-bot: discord: draining ${this.pendingResults.size} pending result(s) after reconnect`);
+    console.log(`discord-${this.instanceId}: draining ${this.pendingResults.size} pending result(s) after reconnect`);
 
     for (const [key, pending] of this.pendingResults) {
       try {
         await this.deliverPendingResult(key, pending);
       } catch (err) {
-        console.error(`grove-bot: discord: failed to deliver pending result to ${key}:`, err instanceof Error ? err.message : err);
+        console.error(`discord-${this.instanceId}: failed to deliver pending result to ${key}:`, err instanceof Error ? err.message : err);
       }
     }
     this.pendingResults.clear();
@@ -661,7 +661,7 @@ export class DiscordAdapter implements PlatformAdapter {
     const now = Date.now();
     for (const [key, pending] of this.pendingResults) {
       if (now - pending.createdAt > DiscordAdapter.PENDING_TTL_MS) {
-        console.warn(`grove-bot: discord: expired pending result for ${key} (age: ${((now - pending.createdAt) / 1000).toFixed(0)}s)`);
+        console.warn(`discord-${this.instanceId}: expired pending result for ${key} (age: ${((now - pending.createdAt) / 1000).toFixed(0)}s)`);
         this.pendingResults.delete(key);
       }
     }
@@ -760,20 +760,20 @@ export class DiscordAdapter implements PlatformAdapter {
     // from a transient gateway blip in the logs.
     if (this.client === null) {
       console.warn(
-        `grove-bot: discord-${this.instanceId} renderEnvelope called before start() — dropping envelope ${envelope.id}`,
+        `discord-${this.instanceId}: renderEnvelope called before start() — dropping envelope ${envelope.id}`,
       );
       return;
     }
     if (!this.client.isReady()) {
       console.warn(
-        `grove-bot: discord-${this.instanceId} renderEnvelope called while shard reconnecting — dropping envelope ${envelope.id}`,
+        `discord-${this.instanceId}: renderEnvelope called while shard reconnecting — dropping envelope ${envelope.id}`,
       );
       return;
     }
     const channelId = this.adapterConfig.surfaceFallbackChannelId;
     if (!channelId) {
       console.warn(
-        `grove-bot: discord-${this.instanceId} has no surfaceFallbackChannelId configured — dropping envelope ${envelope.id}`,
+        `discord-${this.instanceId}: has no surfaceFallbackChannelId configured — dropping envelope ${envelope.id}`,
       );
       return;
     }
@@ -802,7 +802,7 @@ export class DiscordAdapter implements PlatformAdapter {
       // operator needs this signal at start time, not buried in error logs
       // after a real outage.
       console.warn(
-        `grove-bot: discord-${this.instanceId} runtime is configured but systemEventSource is missing — system.* events will not be emitted`,
+        `discord-${this.instanceId}: runtime is configured but systemEventSource is missing — system.* events will not be emitted`,
       );
       return false;
     }

--- a/src/adapters/discord/index.ts
+++ b/src/adapters/discord/index.ts
@@ -743,7 +743,7 @@ export class DiscordAdapter implements PlatformAdapter {
       id: this.instanceId,
       subjects: this.adapterConfig.surfaceSubjects ?? [],
       ...(this.adapterConfig.surfaceFilter ? { filter: this.adapterConfig.surfaceFilter } : {}),
-      render: (envelope) => this.renderEnvelope(envelope),
+      render: (envelope, signal) => this.renderEnvelope(envelope, signal),
     };
   }
 
@@ -761,11 +761,18 @@ export class DiscordAdapter implements PlatformAdapter {
    * channel) and sovereignty-aware redaction. This method stays as the
    * default fallback for envelopes that don't match a registered template.
    *
+   * `signal` is the surface-router's per-render abort signal. We accept it
+   * for contract symmetry but don't currently forward it into discord.js —
+   * the underlying client doesn't accept an AbortSignal and `postResponse`
+   * already buffers on disconnect, so the timeout-cancellation benefit is
+   * marginal. Future refinement: thread the signal into a fetch-based
+   * Discord REST client (a follow-on iteration when v2 templates land).
+   *
    * Failure modes: this method never throws — `postResponse` already swallows
    * delivery errors and buffers when disconnected. The router's
    * `renderWithIsolation` wraps us in a timeout regardless.
    */
-  private async renderEnvelope(envelope: Envelope): Promise<void> {
+  private async renderEnvelope(envelope: Envelope, _signal?: AbortSignal): Promise<void> {
     // Buffering at the adapter level would duplicate `postResponse`'s
     // existing pending-result mechanism; instead we drop here and rely
     // on JetStream replay (per design-cortex.md §3.3 "lost event ≠ lost

--- a/src/adapters/discord/index.ts
+++ b/src/adapters/discord/index.ts
@@ -157,9 +157,19 @@ export class DiscordAdapter implements PlatformAdapter {
         shardId,
         closeCode: closeEvent.code,
         closeReason: closeEvent.reason,
-        // discord.js wsCloseCode convention: 1000 / 1001 are clean shutdowns,
-        // anything else is unclean. Keep this conservative — surfaces filter
-        // on this for incident vs flap classification.
+        // `was_clean` follows RFC 6455 close-frame semantics: codes 1000/1001
+        // are clean; everything else is unclean.
+        //
+        // Discord layers gateway-specific 4xxx codes on top of the WebSocket
+        // standard set (see https://discord.com/developers/docs/topics/opcodes-and-status-codes#gateway):
+        //   - 4004 (auth failed)         — permanent; was_clean: false
+        //   - 4014 (disallowed intents)  — permanent; was_clean: false
+        //   - 4000 (unknown error)       — retryable; was_clean: false
+        // All currently classify as unclean; a surface that wants
+        // transient-vs-permanent must inspect `code` itself. Keep this
+        // conservative — surfaces filter on `was_clean` for incident vs
+        // flap classification, and an "unknown 4xxx" being flagged unclean
+        // is the right default during an outage.
         wasClean: closeEvent.code === 1000 || closeEvent.code === 1001,
       });
     });

--- a/src/adapters/discord/response-poster.ts
+++ b/src/adapters/discord/response-poster.ts
@@ -98,7 +98,7 @@ export async function postToDiscord(
         onRetry: (attempt, err, delayMs) => {
           const msg = err instanceof Error ? err.message : String(err);
           console.warn(
-            `grove-bot: discord: send retry #${attempt} for channel ${channel.id} in ${delayMs.toFixed(0)}ms (${msg})`
+            `discord-response-poster: send retry #${attempt} for channel ${channel.id} in ${delayMs.toFixed(0)}ms (${msg})`
           );
         },
         ...retryOptions,

--- a/src/adapters/mattermost/context.ts
+++ b/src/adapters/mattermost/context.ts
@@ -91,7 +91,7 @@ export async function fetchMattermostContext(
     });
 
     if (!postRes.ok) {
-      console.error(`grove-bot: mattermost API error fetching post: ${postRes.status}`);
+      console.error(`mattermost-context: API error fetching post: ${postRes.status}`);
       return { messages: [], formatted: "" };
     }
 
@@ -151,7 +151,7 @@ export async function fetchMattermostContext(
       formatted: formatContextForClaude(messages),
     };
   } catch (error) {
-    console.error("grove-bot: mattermost context fetch error:", error);
+    console.error("mattermost-context: fetch error:", error);
     return { messages: [], formatted: "" };
   }
 }

--- a/src/adapters/mattermost/index.ts
+++ b/src/adapters/mattermost/index.ts
@@ -317,7 +317,7 @@ export class MattermostAdapter implements PlatformAdapter {
       id: this.instanceId,
       subjects: this.adapterConfig.surfaceSubjects ?? [],
       ...(this.adapterConfig.surfaceFilter ? { filter: this.adapterConfig.surfaceFilter } : {}),
-      render: (envelope) => this.renderEnvelope(envelope),
+      render: (envelope, signal) => this.renderEnvelope(envelope, signal),
     };
   }
 
@@ -328,12 +328,19 @@ export class MattermostAdapter implements PlatformAdapter {
    * `postReply` (no rootId — top-level post in the channel). v2 routing
    * lives in the Renderer model (MIG-7.2d).
    *
+   * `signal` is the surface-router's per-render abort signal. Accepted for
+   * contract symmetry; not currently forwarded — `postReply` is a thin
+   * fetch wrapper that doesn't take an AbortSignal yet. A follow-on
+   * iteration can thread it through `postReply` so a hung HTTP request
+   * actually unwinds at the timeout (today the timed-out fetch keeps
+   * running in the background until its own connect/read deadline fires).
+   *
    * Failure mode: `postReply` may throw on HTTP error; we catch + log
    * here so the surface-router's `renderWithIsolation` doesn't have to
    * be the only safety net. Dropping is acceptable because JetStream
    * replay handles redelivery.
    */
-  private async renderEnvelope(envelope: Envelope): Promise<void> {
+  private async renderEnvelope(envelope: Envelope, _signal?: AbortSignal): Promise<void> {
     const channelId = this.adapterConfig.surfaceFallbackChannelId;
     if (!channelId) {
       console.warn(

--- a/src/adapters/mattermost/index.ts
+++ b/src/adapters/mattermost/index.ts
@@ -76,7 +76,7 @@ export class MattermostAdapter implements PlatformAdapter {
     // config-typo signal worth surfacing.
     if (adapterConfig.surfaceSubjects?.length === 0) {
       console.warn(
-        `grove-bot: mattermost-${this.instanceId} surfaceSubjects is empty — adapter will never render bus envelopes`,
+        `mattermost-${this.instanceId}: surfaceSubjects is empty — adapter will never render bus envelopes`,
       );
     }
   }
@@ -276,7 +276,7 @@ export class MattermostAdapter implements PlatformAdapter {
         await postReply(dmChannel.id, text, undefined, apiUrl, apiToken);
       }
     } catch (err) {
-      console.warn("grove-bot: mattermost: failed to notify operator:", err instanceof Error ? err.message : err);
+      console.warn(`mattermost-${this.instanceId}: failed to notify operator:`, err instanceof Error ? err.message : err);
     }
   }
 
@@ -337,7 +337,7 @@ export class MattermostAdapter implements PlatformAdapter {
     const channelId = this.adapterConfig.surfaceFallbackChannelId;
     if (!channelId) {
       console.warn(
-        `grove-bot: mattermost-${this.instanceId} has no surfaceFallbackChannelId configured — dropping envelope ${envelope.id}`,
+        `mattermost-${this.instanceId}: has no surfaceFallbackChannelId configured — dropping envelope ${envelope.id}`,
       );
       return;
     }
@@ -351,7 +351,7 @@ export class MattermostAdapter implements PlatformAdapter {
       );
     } catch (err) {
       console.warn(
-        `grove-bot: mattermost-${this.instanceId} renderEnvelope failed for envelope ${envelope.id}:`,
+        `mattermost-${this.instanceId}: renderEnvelope failed for envelope ${envelope.id}:`,
         err instanceof Error ? err.message : err,
       );
     }

--- a/src/adapters/mattermost/poller.ts
+++ b/src/adapters/mattermost/poller.ts
@@ -134,13 +134,13 @@ export async function postReply(
     });
 
     if (!res.ok) {
-      console.error(`grove-bot: mattermost post failed: ${res.status} ${await res.text()}`);
+      console.error(`mattermost-poller: post failed: ${res.status} ${await res.text()}`);
       return null;
     }
     const created = await res.json() as Record<string, unknown>;
     return (created.id as string) ?? null;
   } catch (error) {
-    console.error("grove-bot: mattermost post error:", error);
+    console.error("mattermost-poller: post error:", error);
     return null;
   }
 }
@@ -196,7 +196,7 @@ export async function fetchMattermostFileInfos(
         source: "mattermost",
       });
     } catch (err) {
-      console.warn("grove-bot: mattermost-poller: failed to fetch file info:", fileId, err instanceof Error ? err.message : err);
+      console.warn("mattermost-poller: failed to fetch file info:", fileId, err instanceof Error ? err.message : err);
     }
   }
 
@@ -268,13 +268,13 @@ export async function postReplyWithFiles(
     });
 
     if (!res.ok) {
-      console.error(`grove-bot: mattermost post with files failed: ${res.status}`);
+      console.error(`mattermost-poller: post with files failed: ${res.status}`);
       return null;
     }
     const created = await res.json() as Record<string, unknown>;
     return (created.id as string) ?? null;
   } catch (error) {
-    console.error("grove-bot: mattermost post with files error:", error);
+    console.error("mattermost-poller: post with files error:", error);
     return null;
   }
 }
@@ -319,17 +319,17 @@ export function createMattermostPoller(options: MattermostPollerOptions): { stop
       if (!botUserId) {
         botUserId = await fetchBotUserId(apiUrl, apiToken);
         if (!botUserId) {
-          console.error("grove-bot: mattermost couldn't fetch bot user ID — check apiToken");
+          console.error("mattermost-poller: couldn't fetch bot user ID — check apiToken");
           return;
         }
-        console.log(`grove-bot: mattermost bot user ID: ${botUserId}`);
+        console.log(`mattermost-poller: bot user ID: ${botUserId}`);
       }
 
       // Refresh DM channels periodically (every ~20 polls)
       if (dmRefreshCount % 20 === 0) {
         dmChannelIds = await fetchDMChannels(botUserId, apiUrl, apiToken);
         if (dmRefreshCount === 0 && dmChannelIds.length > 0) {
-          console.log(`grove-bot: mattermost found ${dmChannelIds.length} DM channel(s)`);
+          console.log(`mattermost-poller: found ${dmChannelIds.length} DM channel(s)`);
         }
       }
       dmRefreshCount++;
@@ -371,7 +371,7 @@ export function createMattermostPoller(options: MattermostPollerOptions): { stop
           const userName = await fetchUserName(post.user_id, apiUrl, apiToken, userCache);
           const content = isDM ? post.message.trim() : extractAfterTrigger(post.message, triggerWord);
 
-          console.log(`grove-bot: mattermost inbound from ${userName} ${isDM ? "[DM]" : `in #${channelName}`}: ${content.slice(0, 100)}`);
+          console.log(`mattermost-poller: inbound from ${userName} ${isDM ? "[DM]" : `in #${channelName}`}: ${content.slice(0, 100)}`);
 
           const msg: MattermostInboundMessage = {
             channelId: post.channel_id,
@@ -391,10 +391,10 @@ export function createMattermostPoller(options: MattermostPollerOptions): { stop
             if (response) {
               const replyId = await postReply(post.channel_id, response, msg.rootId, apiUrl, apiToken);
               if (replyId) ourPostIds.add(replyId);
-              console.log(`grove-bot: mattermost replied in #${channelName}`);
+              console.log(`mattermost-poller: replied in #${channelName}`);
             }
           } catch (error) {
-            console.error(`grove-bot: mattermost handler error:`, error);
+            console.error(`mattermost-poller: handler error:`, error);
             const errReplyId = await postReply(
               post.channel_id,
               "Sorry, I encountered an error processing your request.",
@@ -411,7 +411,7 @@ export function createMattermostPoller(options: MattermostPollerOptions): { stop
 
       lastCheckTime = Date.now();
     } catch (error) {
-      console.error("grove-bot: mattermost poll error:", error);
+      console.error("mattermost-poller: poll error:", error);
     }
   };
 
@@ -426,7 +426,7 @@ export function createMattermostPoller(options: MattermostPollerOptions): { stop
   const interval = setInterval(poll, pollIntervalMs);
   poll(); // First poll immediately
 
-  console.log(`grove-bot: mattermost polling ${configuredChannels.length} channel(s) + DMs every ${pollIntervalMs / 1000}s for "${triggerWord}"`);
+  console.log(`mattermost-poller: polling ${configuredChannels.length} channel(s) + DMs every ${pollIntervalMs / 1000}s for "${triggerWord}"`);
 
   return {
     stop: () => {

--- a/src/adapters/mattermost/server.ts
+++ b/src/adapters/mattermost/server.ts
@@ -140,7 +140,7 @@ export function createMattermostServer(
           timestamp: payload.timestamp,
         };
 
-        console.log(`grove-bot: mattermost inbound from ${msg.userName} in #${msg.channelName}: ${content.slice(0, 100)}`);
+        console.log(`mattermost-server: inbound from ${msg.userName} in #${msg.channelName}: ${content.slice(0, 100)}`);
 
         // Invoke handler and return response
         const response = await onMessage(msg);
@@ -149,7 +149,7 @@ export function createMattermostServer(
           headers: { "Content-Type": "application/json" },
         });
       } catch (error) {
-        console.error("grove-bot: mattermost webhook error:", error);
+        console.error("mattermost-server: webhook error:", error);
         return new Response(
           JSON.stringify({ text: "An error occurred processing your request." }),
           { status: 500, headers: { "Content-Type": "application/json" } }
@@ -158,7 +158,7 @@ export function createMattermostServer(
     },
   });
 
-  console.log(`grove-bot: mattermost webhook server listening on port ${port}`);
+  console.log(`mattermost-server: webhook server listening on port ${port}`);
 
   return {
     server,

--- a/src/adapters/mock.ts
+++ b/src/adapters/mock.ts
@@ -66,7 +66,10 @@ export class MockAdapter implements PlatformAdapter {
     return {
       id: this.instanceId,
       subjects: this.surfaceSubjects,
-      render: async (envelope) => {
+      // The mock accepts `signal` for contract symmetry but ignores it — there's
+      // no I/O to cancel. Tests that need to assert on the abort path can
+      // construct a custom SurfaceAdapter literal that observes `signal.aborted`.
+      render: async (envelope, _signal) => {
         this.envelopesRendered.push(envelope);
       },
     };

--- a/src/bus/__tests__/dispatch-events.test.ts
+++ b/src/bus/__tests__/dispatch-events.test.ts
@@ -222,3 +222,34 @@ describe("dispatch.task.* — correlation_id contract", () => {
     expect(aborted.correlation_id).toBe(TASK_ID);
   });
 });
+
+describe("dispatch.task.* — data_residency parameterisation", () => {
+  test("source without dataResidency defaults to NZ", () => {
+    const env = createDispatchTaskStartedEvent({
+      source: SOURCE,
+      taskId: TASK_ID,
+      agentId: "cortex",
+      startedAt: STARTED_AT,
+    });
+    expect(env.sovereignty.data_residency).toBe("NZ");
+  });
+
+  test("source.dataResidency overrides the default for every lifecycle helper", () => {
+    const sourceAU: DispatchEventSource = { ...SOURCE, dataResidency: "AU" };
+    const common = {
+      source: sourceAU,
+      taskId: TASK_ID,
+      agentId: "cortex",
+      startedAt: STARTED_AT,
+    };
+    const envs = [
+      createDispatchTaskStartedEvent(common),
+      createDispatchTaskCompletedEvent({ ...common, completedAt: COMPLETED_AT }),
+      createDispatchTaskFailedEvent({ ...common, failedAt: COMPLETED_AT, errorSummary: "x" }),
+      createDispatchTaskAbortedEvent({ ...common, abortedAt: COMPLETED_AT, reason: "timeout" }),
+    ];
+    for (const env of envs) {
+      expect(env.sovereignty.data_residency).toBe("AU");
+    }
+  });
+});

--- a/src/bus/__tests__/envelope-builder.test.ts
+++ b/src/bus/__tests__/envelope-builder.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Tests for `src/bus/envelope-builder.ts` — the shared envelope skeleton
+ * lifted from system-events / dispatch-events / cc-events when the rule
+ * of three was satisfied (MIG-7 sweep).
+ */
+
+import { describe, expect, test } from "bun:test";
+import { buildBaseEnvelope } from "../envelope-builder";
+import { validateEnvelope } from "../myelin/envelope-validator";
+
+const SOVEREIGNTY = {
+  classification: "local" as const,
+  data_residency: "NZ",
+  max_hop: 0,
+  frontier_ok: false,
+  model_class: "local-only" as const,
+};
+
+describe("buildBaseEnvelope", () => {
+  test("populates id (fresh UUID) and timestamp (current ISO) per call", () => {
+    const a = buildBaseEnvelope({
+      type: "test.event.fired",
+      source: "metafactory.cortex.local",
+      sovereignty: SOVEREIGNTY,
+      payload: {},
+    });
+    const b = buildBaseEnvelope({
+      type: "test.event.fired",
+      source: "metafactory.cortex.local",
+      sovereignty: SOVEREIGNTY,
+      payload: {},
+    });
+
+    expect(a.id).not.toBe(b.id);
+    expect(a.id).toMatch(/^[0-9a-f-]{36}$/);
+    expect(a.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  test("threads provided fields verbatim", () => {
+    const env = buildBaseEnvelope({
+      type: "test.event.fired",
+      source: "metafactory.cortex.local",
+      sovereignty: SOVEREIGNTY,
+      payload: { foo: "bar", n: 1 },
+    });
+
+    expect(env.type).toBe("test.event.fired");
+    expect(env.source).toBe("metafactory.cortex.local");
+    expect(env.sovereignty).toEqual(SOVEREIGNTY);
+    expect(env.payload).toEqual({ foo: "bar", n: 1 });
+  });
+
+  test("correlation_id is set when provided", () => {
+    const env = buildBaseEnvelope({
+      type: "test.event.fired",
+      source: "metafactory.cortex.local",
+      sovereignty: SOVEREIGNTY,
+      correlationId: "11111111-1111-4111-8111-111111111111",
+      payload: {},
+    });
+    expect(env.correlation_id).toBe("11111111-1111-4111-8111-111111111111");
+  });
+
+  test("correlation_id is omitted when not provided", () => {
+    const env = buildBaseEnvelope({
+      type: "test.event.fired",
+      source: "metafactory.cortex.local",
+      sovereignty: SOVEREIGNTY,
+      payload: {},
+    });
+    expect("correlation_id" in env).toBe(false);
+  });
+
+  test("correlation_id is omitted when empty string passed (truthy gate)", () => {
+    const env = buildBaseEnvelope({
+      type: "test.event.fired",
+      source: "metafactory.cortex.local",
+      sovereignty: SOVEREIGNTY,
+      correlationId: "",
+      payload: {},
+    });
+    expect("correlation_id" in env).toBe(false);
+  });
+
+  test("output passes the myelin schema validator with valid inputs", () => {
+    const env = buildBaseEnvelope({
+      type: "test.event.fired",
+      source: "metafactory.cortex.local",
+      sovereignty: SOVEREIGNTY,
+      payload: { repo: "grove" },
+    });
+    const v = validateEnvelope(env);
+    expect(v.ok).toBe(true);
+  });
+
+  test("payload reference is not aliased (caller can mutate without affecting envelope)", () => {
+    const payload: Record<string, unknown> = { foo: "bar" };
+    const env = buildBaseEnvelope({
+      type: "test.event.fired",
+      source: "metafactory.cortex.local",
+      sovereignty: SOVEREIGNTY,
+      payload,
+    });
+    // The current contract DOES alias payload by reference (no defensive
+    // copy). Document that behaviour explicitly so a future refactor
+    // changing it has to update this test consciously. Domain helpers
+    // construct fresh payload literals at every call site, so the alias
+    // is harmless in practice.
+    expect(env.payload).toBe(payload);
+  });
+});

--- a/src/bus/__tests__/surface-router.test.ts
+++ b/src/bus/__tests__/surface-router.test.ts
@@ -465,6 +465,87 @@ describe("createSurfaceRouter — render timeout", () => {
 });
 
 // ---------------------------------------------------------------------------
+// AbortSignal contract
+// ---------------------------------------------------------------------------
+
+describe("createSurfaceRouter — render(envelope, signal)", () => {
+  test("render() receives an AbortSignal that is not aborted on the happy path", async () => {
+    const router = createSurfaceRouter(fakeRuntime(), { renderTimeoutMs: 1000 });
+    let receivedSignal: AbortSignal | undefined;
+    const adapter: SurfaceAdapter = {
+      id: "signal-observer",
+      subjects: [">"],
+      render: async (_env, signal) => {
+        receivedSignal = signal;
+      },
+    };
+    router.register(adapter);
+
+    await router.dispatch(makeEnvelope());
+
+    expect(receivedSignal).toBeDefined();
+    expect(receivedSignal?.aborted).toBe(false);
+  });
+
+  test("render() signal aborts when the render times out", async () => {
+    const router = createSurfaceRouter(fakeRuntime(), { renderTimeoutMs: 30 });
+    let observedSignal: AbortSignal | undefined;
+    let abortedAt: number | null = null;
+    const adapter: SurfaceAdapter = {
+      id: "signal-aborter",
+      subjects: [">"],
+      render: (_env, signal) => {
+        observedSignal = signal;
+        return new Promise((resolve) => {
+          // Don't resolve — let the timeout fire. Subscribe to abort so we
+          // can record the cancellation moment.
+          signal?.addEventListener("abort", () => {
+            abortedAt = Date.now();
+            resolve();
+          });
+        });
+      },
+    };
+    router.register(adapter);
+
+    const start = Date.now();
+    await router.dispatch(makeEnvelope());
+    const elapsed = Date.now() - start;
+
+    expect(observedSignal).toBeDefined();
+    expect(observedSignal?.aborted).toBe(true);
+    expect(abortedAt).not.toBeNull();
+    // Abort fires within the timeout window (with generous CI margin).
+    expect(elapsed).toBeLessThan(500);
+  });
+
+  test("adapter that ignores the signal still gets timed out (race wins)", async () => {
+    const errors: { id: string; err: Error }[] = [];
+    const router = createSurfaceRouter(fakeRuntime(), {
+      renderTimeoutMs: 30,
+      onAdapterError: (id, err) => errors.push({ id, err }),
+    });
+    // Adapter does NOT subscribe to the signal — render hangs indefinitely.
+    // Promise.race must still resolve via the timeout branch.
+    const adapter: SurfaceAdapter = {
+      id: "signal-ignorer",
+      subjects: [">"],
+      render: () => new Promise(() => {}),
+    };
+    router.register(adapter);
+
+    const start = Date.now();
+    await router.dispatch(makeEnvelope());
+    const elapsed = Date.now() - start;
+
+    expect(elapsed).toBeLessThan(500);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]?.id).toBe("signal-ignorer");
+    expect(errors[0]?.err.message).toContain("timeout");
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Lifecycle
 // ---------------------------------------------------------------------------
 

--- a/src/bus/__tests__/system-events.test.ts
+++ b/src/bus/__tests__/system-events.test.ts
@@ -256,3 +256,61 @@ describe("createSystemInboundAbortedEvent", () => {
     }
   });
 });
+
+describe("data_residency parameterisation", () => {
+  test("omitting source.dataResidency defaults to NZ across all helpers", () => {
+    const sourceNoRes = { org: "metafactory", agent: "cortex", instance: "local" };
+    const degraded = createSystemAdapterDegradedEvent({
+      source: sourceNoRes,
+      adapterId: "x", platform: "discord",
+      disconnectedSince: new Date(), thresholdMs: 1,
+    });
+    const recovered = createSystemAdapterRecoveredEvent({
+      source: sourceNoRes,
+      adapterId: "x", platform: "discord", degradedForMs: 1,
+    });
+    const disconnected = createSystemAdapterDisconnectedEvent({
+      source: sourceNoRes,
+      adapterId: "x", platform: "discord",
+      disconnectedSince: new Date(), wasClean: true,
+    });
+    const aborted = createSystemInboundAbortedEvent({
+      source: sourceNoRes,
+      adapterId: "x", inboundMessageId: "1",
+      timeoutSource: "unknown", timeoutMs: 1, elapsedMs: 1,
+      phase: "pre_dispatch",
+    });
+    for (const env of [degraded, recovered, disconnected, aborted]) {
+      expect(env.sovereignty.data_residency).toBe("NZ");
+    }
+  });
+
+  test("source.dataResidency overrides the default in every helper", () => {
+    const sourceAU = { org: "metafactory", agent: "cortex", instance: "local", dataResidency: "AU" };
+    const degraded = createSystemAdapterDegradedEvent({
+      source: sourceAU,
+      adapterId: "x", platform: "discord",
+      disconnectedSince: new Date(), thresholdMs: 1,
+    });
+    const recovered = createSystemAdapterRecoveredEvent({
+      source: sourceAU,
+      adapterId: "x", platform: "discord", degradedForMs: 1,
+    });
+    const disconnected = createSystemAdapterDisconnectedEvent({
+      source: sourceAU,
+      adapterId: "x", platform: "discord",
+      disconnectedSince: new Date(), wasClean: true,
+    });
+    const aborted = createSystemInboundAbortedEvent({
+      source: sourceAU,
+      adapterId: "x", inboundMessageId: "1",
+      timeoutSource: "unknown", timeoutMs: 1, elapsedMs: 1,
+      phase: "pre_dispatch",
+    });
+    for (const env of [degraded, recovered, disconnected, aborted]) {
+      expect(env.sovereignty.data_residency).toBe("AU");
+      // Schema must still accept the override.
+      expect(validateEnvelope(env).ok).toBe(true);
+    }
+  });
+});

--- a/src/bus/dispatch-events.ts
+++ b/src/bus/dispatch-events.ts
@@ -58,13 +58,19 @@ function buildSource(src: SystemEventSource): string {
  * Default sovereignty for `dispatch.task.*` events. Same posture as
  * `system.*`: operator-only, local residency, no federation, no frontier.
  *
+ * `data_residency` is sourced from `source.dataResidency` (defaulting to
+ * `"NZ"` for the original cortex deployment) so a non-NZ operator gets
+ * envelopes stamped with their actual residency. Mirrors the parameterisation
+ * pattern in `system-events.ts` so both event domains read the same field
+ * off the same source struct.
+ *
  * Returned as a fresh literal per call so a downstream mutation on one
  * envelope's `sovereignty` cannot leak into a sibling envelope.
  */
-function defaultDispatchSovereignty(): Envelope["sovereignty"] {
+function defaultDispatchSovereignty(source: SystemEventSource): Envelope["sovereignty"] {
   return {
     classification: "local",
-    data_residency: "NZ",
+    data_residency: source.dataResidency ?? "NZ",
     max_hop: 0,
     frontier_ok: false,
     model_class: "local-only",
@@ -128,7 +134,7 @@ function buildBaseEnvelope(
     type,
     timestamp: new Date().toISOString(),
     correlation_id: common.correlationId ?? common.taskId,
-    sovereignty: defaultDispatchSovereignty(),
+    sovereignty: defaultDispatchSovereignty(common.source),
     payload: {
       task_id: common.taskId,
       agent_id: common.agentId,

--- a/src/bus/dispatch-events.ts
+++ b/src/bus/dispatch-events.ts
@@ -43,6 +43,7 @@
  */
 
 import type { Envelope } from "./myelin/envelope-validator";
+import { buildBaseEnvelope as buildSharedEnvelope } from "./envelope-builder";
 import type { SystemEventSource } from "./system-events";
 
 // Re-export `SystemEventSource` under a domain-neutral alias so callers
@@ -116,31 +117,34 @@ export interface DispatchTaskCommonOpts {
   correlationId?: string;
 }
 
-// TODO (deferred — Echo round-1 s3): when MIG-7+ adds further event
-// families (e.g. `agent.task.*`, `system.*` lifecycle helpers beyond
-// the existing `system-events.ts`), lift this `buildBaseEnvelope` shape
-// into a shared helper (e.g. `bus/envelope-builder.ts`). Premature
-// extraction now would orphan a one-call-site abstraction; the right
-// time is when a second helper file would otherwise duplicate the
-// `id/source/type/timestamp/correlation_id/sovereignty/payload` skeleton.
+/**
+ * Domain-specific wrapper around `buildSharedEnvelope` (from
+ * `bus/envelope-builder.ts`). Threads dispatch-specific defaults:
+ * sovereignty posture, source-string assembly, and the
+ * `correlation_id ?? taskId` invariant that all four lifecycle events
+ * for a single task share one correlation key.
+ *
+ * The shared helper handles the `id`/`timestamp`/`payload`/`sovereignty`
+ * skeleton; this thin wrapper exists so each dispatch-task constructor
+ * doesn't have to repeat the source-build + sovereignty + correlation-
+ * fallback boilerplate.
+ */
 function buildBaseEnvelope(
   type: string,
   common: DispatchTaskCommonOpts,
   payloadExtras: Record<string, unknown>,
 ): Envelope {
-  return {
-    id: crypto.randomUUID(),
-    source: buildSource(common.source),
+  return buildSharedEnvelope({
     type,
-    timestamp: new Date().toISOString(),
-    correlation_id: common.correlationId ?? common.taskId,
+    source: buildSource(common.source),
     sovereignty: defaultDispatchSovereignty(common.source),
+    correlationId: common.correlationId ?? common.taskId,
     payload: {
       task_id: common.taskId,
       agent_id: common.agentId,
       ...payloadExtras,
     },
-  };
+  });
 }
 
 // ---------------------------------------------------------------------------

--- a/src/bus/dispatch-handler.ts
+++ b/src/bus/dispatch-handler.ts
@@ -112,11 +112,11 @@ export class DispatchHandler extends EventEmitter {
     this.cleanupInterval = setInterval(() => {
       const removed = this.sessions.cleanupIdle();
       if (removed.length > 0) {
-        console.log(`grove-bot: cleaned up ${removed.length} idle session(s)`);
+        console.log(`dispatch-handler: cleaned up ${removed.length} idle session(s)`);
       }
       const expiredDirs = cleanupExpiredDirs();
       if (expiredDirs > 0) {
-        console.log(`grove-bot: cleaned up ${expiredDirs} expired attachment dir(s)`);
+        console.log(`dispatch-handler: cleaned up ${expiredDirs} expired attachment dir(s)`);
       }
     }, 60_000);
   }
@@ -140,7 +140,7 @@ export class DispatchHandler extends EventEmitter {
       skipBashGuard: true,
       skipFilesystemRestriction: true,
     });
-    console.log("message-router: config updated");
+    console.log("dispatch-handler: config updated");
   }
 
   /** Get current config (for watcher initialization) */
@@ -157,10 +157,10 @@ export class DispatchHandler extends EventEmitter {
         // G-300: Unknown DMs are silently ignored (no response to user)
         // But always log for audit — helps decide if permissions need changing
         if (msg.isDM) {
-          console.log(`grove-bot: [DM-REJECT] ignored DM from ${msg.authorName} (${msg.authorId}) — "${msg.content.slice(0, 100)}"`);
+          console.log(`dispatch-handler: [DM-REJECT] ignored DM from ${msg.authorName} (${msg.authorId}) — "${msg.content.slice(0, 100)}"`);
           return;
         }
-        console.log(`grove-bot: denied ${msg.authorName} (${msg.authorId}) on ${adapter.instanceId} — ${access.denyReason ?? "no role"}`);
+        console.log(`dispatch-handler: denied ${msg.authorName} (${msg.authorId}) on ${adapter.instanceId} — ${access.denyReason ?? "no role"}`);
         const target = this.targetFromMsg(adapter, msg);
         await adapter.postResponse(target, access.denyReason ?? "Sorry, I'm not set up to respond to you. Ask the operator to add you to a role.");
         return;
@@ -169,7 +169,7 @@ export class DispatchHandler extends EventEmitter {
       // 2. Log DM access for audit trail
       if (msg.isDM) {
         const dmLabel = msg.dmType === "operator" ? "operator" : `user:${msg.authorName}`;
-        console.log(`grove-bot: [DM-ACCESS] ${dmLabel} (${msg.authorId}) — bashGuard:${access.bashGuard !== false}`);
+        console.log(`dispatch-handler: [DM-ACCESS] ${dmLabel} (${msg.authorId}) — bashGuard:${access.bashGuard !== false}`);
       } else {
         // Operator notification (non-operator guild messages)
         await this.notifyOperatorIfNeeded(adapter, msg);
@@ -204,7 +204,7 @@ export class DispatchHandler extends EventEmitter {
         : { repo: null, repoShort: null, entityType: null, entityRef: null } as ChannelContext;
 
       if (channelCtx.repo) {
-        console.log(`grove-bot: channel context → ${channelCtx.repo}${channelCtx.entityType ? ` (${channelCtx.entityType} ${channelCtx.entityRef})` : ""}`);
+        console.log(`dispatch-handler: channel context → ${channelCtx.repo}${channelCtx.entityType ? ` (${channelCtx.entityType} ${channelCtx.entityRef})` : ""}`);
       }
 
       // Use channel-resolved repo name for event attribution (e.g., "meta-factory" not "luna")
@@ -348,12 +348,12 @@ export class DispatchHandler extends EventEmitter {
           break;
       }
     } catch (error) {
-      console.error(`grove-bot: router error on ${adapter.instanceId}:`, error);
+      console.error(`dispatch-handler: error on ${adapter.instanceId}:`, error);
       try {
         const target = this.targetFromMsg(adapter, msg);
         await adapter.postResponse(target, "An error occurred while processing your request.");
       } catch (postErr) {
-        console.error("grove-bot: router: failed to post error response:", postErr instanceof Error ? postErr.message : postErr);
+        console.error("dispatch-handler: failed to post error response:", postErr instanceof Error ? postErr.message : postErr);
       }
     }
   }
@@ -431,20 +431,20 @@ export class DispatchHandler extends EventEmitter {
 
       if (useSession && result.sessionId) {
         this.sessions.setSession(sessionKey, result.sessionId);
-        console.log(`grove-bot: ${resumeSessionId ? "resumed" : "new"} session ${result.sessionId} for ${sessionKey}`);
+        console.log(`dispatch-handler: ${resumeSessionId ? "resumed" : "new"} session ${result.sessionId} for ${sessionKey}`);
       }
     } else {
       await adapter.postResponse(target, `Sorry, I couldn't process that. (exit code: ${result.exitCode})`);
     }
 
     if (result.usage) {
-      console.log(`grove-bot: responded in ${result.durationMs}ms (${result.usage.inputTokens}in/${result.usage.outputTokens}out${result.usage.costUsd ? ` $${result.usage.costUsd.toFixed(4)}` : ""})`);
+      console.log(`dispatch-handler: responded in ${result.durationMs}ms (${result.usage.inputTokens}in/${result.usage.outputTokens}out${result.usage.costUsd ? ` $${result.usage.costUsd.toFixed(4)}` : ""})`);
       // G-206: Forward usage to dashboard state
       if (result.sessionId) {
         this.emit("session-usage", result.sessionId, result.usage);
       }
     } else {
-      console.log(`grove-bot: responded in ${result.durationMs}ms`);
+      console.log(`dispatch-handler: responded in ${result.durationMs}ms`);
     }
   }
 
@@ -526,7 +526,7 @@ export class DispatchHandler extends EventEmitter {
           this.sessions.setSession(sessionKey, session.sessionId);
         }
       } catch (err) {
-        console.error("grove-bot: async result post failed:", err);
+        console.error("dispatch-handler: async result post failed:", err);
       }
       this.taskTracker.complete(taskId);
     });
@@ -537,7 +537,7 @@ export class DispatchHandler extends EventEmitter {
       try {
         await adapter.postResponse(replyTarget, `Task failed: ${err.message}`);
       } catch (postErr) {
-        console.error("grove-bot: router: failed to post task error:", postErr instanceof Error ? postErr.message : postErr);
+        console.error("dispatch-handler: failed to post task error:", postErr instanceof Error ? postErr.message : postErr);
       }
       this.taskTracker.complete(taskId);
     });
@@ -545,7 +545,7 @@ export class DispatchHandler extends EventEmitter {
     session.on("exit", (code: number) => {
       clearInterval(typingInterval);
       if (session.usage) {
-        console.log(`grove-bot: async task completed (exit ${code}, ${session.usage.inputTokens}in/${session.usage.outputTokens}out)`);
+        console.log(`dispatch-handler: async task completed (exit ${code}, ${session.usage.inputTokens}in/${session.usage.outputTokens}out)`);
         // G-206: Forward usage to dashboard state
         if (session.sessionId) {
           this.emit("session-usage", session.sessionId, session.usage);
@@ -555,7 +555,7 @@ export class DispatchHandler extends EventEmitter {
 
     session.start();
     this.taskTracker.track(taskId, session, replyTarget.channelId, msg.content.slice(0, 100));
-    console.log(`grove-bot: async task ${taskId} dispatched on ${adapter.instanceId}`);
+    console.log(`dispatch-handler: async task ${taskId} dispatched on ${adapter.instanceId}`);
   }
 
   // ---------------------------------------------------------------------------
@@ -617,7 +617,7 @@ export class DispatchHandler extends EventEmitter {
         const preview = text.slice(0, 300);
         await adapter.postResponse(replyTarget, `**${member}**: ${preview}${text.length > 300 ? "..." : ""}`);
       } catch (err) {
-        console.warn("grove-bot: router: failed to post team progress:", err instanceof Error ? err.message : err);
+        console.warn("dispatch-handler: failed to post team progress:", err instanceof Error ? err.message : err);
       }
     });
 
@@ -625,7 +625,7 @@ export class DispatchHandler extends EventEmitter {
       try {
         await adapter.postResponse(replyTarget, result);
       } catch (err) {
-        console.error("grove-bot: team synthesis post failed:", err);
+        console.error("dispatch-handler: team synthesis post failed:", err);
       }
       this.taskTracker.complete(taskId);
     });
@@ -634,14 +634,14 @@ export class DispatchHandler extends EventEmitter {
       try {
         await adapter.postResponse(replyTarget, `Team failed: ${err.message}`);
       } catch (postErr) {
-        console.error("grove-bot: router: failed to post team error:", postErr instanceof Error ? postErr.message : postErr);
+        console.error("dispatch-handler: failed to post team error:", postErr instanceof Error ? postErr.message : postErr);
       }
       this.taskTracker.complete(taskId);
     });
 
     team.start();
     const { traceId, teamId } = team.getTraceContext();
-    console.log(`grove-bot: team ${teamId} dispatched on ${adapter.instanceId} (trace: ${traceId})`);
+    console.log(`dispatch-handler: team ${teamId} dispatched on ${adapter.instanceId} (trace: ${traceId})`);
   }
 
   // ---------------------------------------------------------------------------
@@ -710,7 +710,7 @@ export class DispatchHandler extends EventEmitter {
     try {
       await adapter.notifyOperator(text);
     } catch (err) {
-      console.warn("grove-bot: router: failed to notify operator:", err instanceof Error ? err.message : err);
+      console.warn("dispatch-handler: failed to notify operator:", err instanceof Error ? err.message : err);
     }
   }
 

--- a/src/bus/envelope-builder.ts
+++ b/src/bus/envelope-builder.ts
@@ -1,0 +1,95 @@
+/**
+ * MIG-7 — Shared envelope skeleton helper.
+ *
+ * Three event domains now construct G-1100.B envelopes from the same
+ * `id / source / type / timestamp / correlation_id / sovereignty / payload`
+ * skeleton:
+ *
+ *   - `bus/system-events.ts`     — `system.*`     (operator-only system signals)
+ *   - `bus/dispatch-events.ts`   — `dispatch.task.*` (task lifecycle)
+ *   - `taps/cc-events/cc-events.ts` — `cc.*` (relay-lifted CC hooks)
+ *
+ * Rule of three is satisfied: each domain re-implements the same envelope
+ * skeleton, just with different default sovereignty + payload extras. Lift
+ * the common skeleton here so an envelope-shape change (e.g. a new schema
+ * field) lives in one place rather than three. The defaults stay in their
+ * respective domain files because each domain has slightly different
+ * sovereignty postures and source-default conventions; this helper takes
+ * the already-resolved sovereignty and source as inputs.
+ *
+ * Per the deferred TODO in `dispatch-events.ts`: this is the right time to
+ * extract — earlier extraction would have orphaned a one-call-site
+ * abstraction, but with three domains in play the duplication cost has
+ * crossed the maintenance break-even.
+ *
+ * **What this file is NOT:**
+ *   - NOT a sovereignty defaulter — each domain owns its own posture.
+ *   - NOT a source-string builder — domains have different segment defaults
+ *     (e.g. `cc-events` defaults agent="cortex" instance="relay"; `system-events`
+ *     requires all three explicitly). This helper takes the already-built
+ *     dotted source string.
+ *   - NOT a validator — call `validateEnvelope` from the schema validator if
+ *     you need pre-publish validation; this builder produces a literal that
+ *     conforms to the type but doesn't run the JSON Schema.
+ *   - NOT a generator of `id`/`timestamp` defaults outside its scope — both
+ *     are produced fresh per call (UUID + new Date.toISOString()) so
+ *     downstream consumers can't share envelope identity by mistake.
+ */
+
+import type { Envelope } from "./myelin/envelope-validator";
+
+export interface BaseEnvelopeOpts {
+  /** Envelope `type` — `domain.entity.action` per G-1100.B. */
+  type: string;
+  /** Pre-built source string — `org.agent.instance` (2-5 dotted segments). */
+  source: string;
+  /** Payload — domain-specific contents. */
+  payload: Record<string, unknown>;
+  /**
+   * Optional UUID-shaped `correlation_id`. Set on the envelope only when
+   * provided; omitted entirely otherwise (the schema makes it optional).
+   * Callers MUST pass UUID-shaped values here — the schema rejects
+   * non-UUID `correlation_id`. For non-UUID workflow keys (e.g. the
+   * `adapter:{id}:{iso}` convention from system-events), keep them in
+   * the payload instead.
+   */
+  correlationId?: string;
+  /**
+   * Pre-built sovereignty object. Domain helpers compute defaults using
+   * their own posture (typically local-only / NZ / max_hop=0), then pass
+   * the result here. This helper does NOT default-fill sovereignty — that
+   * decision lives in the domain layer.
+   */
+  sovereignty: Envelope["sovereignty"];
+}
+
+/**
+ * Build a fresh envelope literal from the common skeleton.
+ *
+ * Each call produces:
+ *   - a fresh `crypto.randomUUID()` for `id` (envelope idempotency key)
+ *   - a fresh `new Date().toISOString()` for `timestamp`
+ *
+ * This means callers MUST NOT cache a returned envelope and re-emit it as a
+ * different signal — the `id` and `timestamp` are baked in at construction
+ * time. To produce a sibling envelope, call `buildBaseEnvelope` again with
+ * fresh inputs.
+ *
+ * `correlation_id` is set on the envelope only when `opts.correlationId` is
+ * truthy; this matches the existing per-domain behaviour where the field
+ * is omitted (not `undefined`) when no correlation is intended.
+ */
+export function buildBaseEnvelope(opts: BaseEnvelopeOpts): Envelope {
+  const envelope: Envelope = {
+    id: crypto.randomUUID(),
+    source: opts.source,
+    type: opts.type,
+    timestamp: new Date().toISOString(),
+    sovereignty: opts.sovereignty,
+    payload: opts.payload,
+  };
+  if (opts.correlationId) {
+    envelope.correlation_id = opts.correlationId;
+  }
+  return envelope;
+}

--- a/src/bus/myelin/__tests__/runtime.test.ts
+++ b/src/bus/myelin/__tests__/runtime.test.ts
@@ -347,6 +347,11 @@ describe("MyelinRuntime", () => {
     });
 
     test("publish after stop() is a no-op (no late publishes after drain)", async () => {
+      // Pins the post-stop semantic documented on `publishEnabled` in
+      // runtime.ts: once `stop()` returns, calls to `runtime.publish(...)`
+      // must short-circuit before reaching `link.publish`. The underlying
+      // nats client is drain-safe, but the runtime contract is explicit:
+      // post-stop publish is a no-op the caller can rely on.
       const fake = makeFakeNatsConnection();
       const runtime = await startMyelinRuntime(
         makeConfig({

--- a/src/bus/myelin/__tests__/runtime.test.ts
+++ b/src/bus/myelin/__tests__/runtime.test.ts
@@ -216,7 +216,7 @@ describe("MyelinRuntime", () => {
     });
     expect(runtime.enabled).toBe(true);
     const connectLog = logs.find(
-      (l) => l.kind === "log" && l.msg.includes("myelin runtime connected"),
+      (l) => l.kind === "log" && l.msg.includes("myelin-runtime: connected"),
     );
     expect(connectLog).toBeDefined();
     expect(connectLog!.msg).not.toContain("secret-token");
@@ -236,7 +236,7 @@ describe("MyelinRuntime", () => {
     });
     expect(runtime.enabled).toBe(true);
     const connectLog = logs.find(
-      (l) => l.kind === "log" && l.msg.includes("myelin runtime connected"),
+      (l) => l.kind === "log" && l.msg.includes("myelin-runtime: connected"),
     );
     expect(connectLog).toBeDefined();
     // Both user and password redacted.
@@ -263,7 +263,7 @@ describe("MyelinRuntime", () => {
     // invocations, not twice — proves the `stopped` flag in the
     // closure actually short-circuits.
     const stoppedLines = logs.filter(
-      (l) => l.kind === "log" && l.msg.includes("myelin runtime stopped"),
+      (l) => l.kind === "log" && l.msg.includes("myelin-runtime: stopped"),
     );
     expect(stoppedLines.length).toBe(1);
   });

--- a/src/bus/myelin/runtime.ts
+++ b/src/bus/myelin/runtime.ts
@@ -27,7 +27,7 @@ import type { Envelope } from "./envelope-validator";
  */
 export type EnvelopeHandler = (envelope: Envelope, subject: string) => void;
 
-/** Lifecycle handle so grove-bot can clean up on shutdown. */
+/** Lifecycle handle so cortex can clean up on shutdown. */
 export interface MyelinRuntime {
   readonly enabled: boolean;
   /**
@@ -129,7 +129,7 @@ export async function startMyelinRuntime(
 
   if (subjects.length === 0) {
     console.warn(
-      "grove-bot: nats.url configured but nats.subjects is empty — no subscriptions started",
+      "myelin-runtime: nats.url configured but nats.subjects is empty — no subscriptions started",
     );
     return {
       enabled: false,
@@ -149,11 +149,11 @@ export async function startMyelinRuntime(
       ...(options?.connectImpl ? { connectImpl: options.connectImpl } : {}),
     });
     console.log(
-      `grove-bot: myelin runtime connected to ${safeUrl} as "${nats.name}"`,
+      `myelin-runtime: connected to ${safeUrl} as "${nats.name}"`,
     );
   } catch (err) {
     console.error(
-      "grove-bot: myelin runtime failed to connect — continuing without NATS:",
+      "myelin-runtime: failed to connect — continuing without NATS:",
       err instanceof Error ? err.message : err,
     );
     return {
@@ -180,7 +180,7 @@ export async function startMyelinRuntime(
               handler(env, subject);
             } catch (err) {
               console.error(
-                "grove-bot: myelin onEnvelope handler threw:",
+                "myelin-runtime: onEnvelope handler threw:",
                 err instanceof Error ? err.message : err,
               );
             }
@@ -188,10 +188,10 @@ export async function startMyelinRuntime(
         },
       });
       subscribers.push(sub);
-      console.log(`grove-bot: myelin subscribed to "${pattern}"`);
+      console.log(`myelin-runtime: subscribed to "${pattern}"`);
     } catch (err) {
       console.error(
-        `grove-bot: myelin failed to subscribe to "${pattern}":`,
+        `myelin-runtime: failed to subscribe to "${pattern}":`,
         err instanceof Error ? err.message : err,
       );
     }
@@ -230,7 +230,7 @@ export async function startMyelinRuntime(
       // most failure modes here (closed connection, oversized payload) are
       // already-bad-state signals.
       console.error(
-        `grove-bot: myelin publish failed for subject=${subject} id=${envelope.id} type=${envelope.type}:`,
+        `myelin-runtime: publish failed for subject=${subject} id=${envelope.id} type=${envelope.type}:`,
         err instanceof Error ? err.message : err,
       );
     }
@@ -248,11 +248,11 @@ export async function startMyelinRuntime(
       await Promise.allSettled(subscribers.map((s) => s.stop()));
       await link.close().catch((err) => {
         console.error(
-          "grove-bot: myelin runtime close error:",
+          "myelin-runtime: close error:",
           err instanceof Error ? err.message : err,
         );
       });
-      console.log("grove-bot: myelin runtime stopped");
+      console.log("myelin-runtime: stopped");
     },
   };
 }
@@ -267,6 +267,6 @@ export async function startMyelinRuntime(
 function logEnvelope(env: Envelope, subject: string): void {
   const corr = env.correlation_id ? ` correlation=${env.correlation_id}` : "";
   console.log(
-    `grove-bot: myelin received envelope subject=${subject} id=${env.id} type=${env.type}${corr}`,
+    `myelin-runtime: received envelope subject=${subject} id=${env.id} type=${env.type}${corr}`,
   );
 }

--- a/src/bus/myelin/runtime.ts
+++ b/src/bus/myelin/runtime.ts
@@ -218,7 +218,15 @@ export async function startMyelinRuntime(
 
   const publishEnabled = async (envelope: Envelope): Promise<void> => {
     if (stopped) {
-      // Don't publish during shutdown — link.drain() may already be in flight.
+      // Post-stop publish: short-circuit. The runtime's `link.drain()`
+      // (called inside `stop()` below) flushes pending publishes before the
+      // underlying connection closes; a publish call that races between
+      // `stopped = true` and `link.close()` would either flush along with
+      // drain or be dropped silently — never crash the caller. The check
+      // here is belt-and-braces: the underlying nats client is already
+      // drain-safe, but short-circuiting at this layer keeps the contract
+      // explicit ("publish-after-stop is a no-op") and saves a JSON.stringify
+      // of the envelope on the shutdown path.
       return;
     }
     const subject = `local.${org}.${envelope.type}`;

--- a/src/bus/myelin/subscriber.ts
+++ b/src/bus/myelin/subscriber.ts
@@ -144,7 +144,7 @@ export class MyelinSubscriber {
 
 function defaultHandlerErrorLog(err: Error, subject: string): void {
   console.error(
-    `grove-bot: myelin-subscriber onEnvelope handler error on "${sanitizeForLog(subject)}":`,
+    `myelin-subscriber: onEnvelope handler error on "${sanitizeForLog(subject)}":`,
     err.message,
   );
 }
@@ -170,7 +170,7 @@ function makeDefaultInvalidEnvelopeLog(logRawSnippet: boolean): InvalidEnvelopeH
       ? `; payload snippet: ${sanitizeForLog(rawSnippet)}`
       : "";
     console.warn(
-      `grove-bot: myelin-subscriber dropped invalid envelope on "${safeSubject}" — ${reasonStr}; ${lengthSuffix}${snippetSuffix}`,
+      `myelin-subscriber: dropped invalid envelope on "${safeSubject}" — ${reasonStr}; ${lengthSuffix}${snippetSuffix}`,
     );
   };
 }

--- a/src/bus/nats/connection.ts
+++ b/src/bus/nats/connection.ts
@@ -115,7 +115,7 @@ export class NatsLink {
       // Drain can fail if already closed by the server, or hit our timeout.
       // Log and proceed — caller wants close() to resolve.
       console.error(
-        `grove-bot: nats-connection "${this.name}" drain error:`,
+        `nats-connection: "${this.name}" drain error:`,
         err instanceof Error ? err.message : err,
       );
     }
@@ -135,24 +135,24 @@ export class NatsLink {
         switch (status.type) {
           case Events.Disconnect:
             console.warn(
-              `grove-bot: nats-connection "${this.name}" disconnected from ${status.data}`,
+              `nats-connection: "${this.name}" disconnected from ${status.data}`,
             );
             break;
           case Events.Reconnect:
             console.info(
-              `grove-bot: nats-connection "${this.name}" reconnected to ${status.data}`,
+              `nats-connection: "${this.name}" reconnected to ${status.data}`,
             );
             break;
           case Events.Error:
             console.error(
-              `grove-bot: nats-connection "${this.name}" error:`,
+              `nats-connection: "${this.name}" error:`,
               status.data,
             );
             break;
           // LDM, Update, etc. are quieter — log at debug level for now.
           default:
             console.debug(
-              `grove-bot: nats-connection "${this.name}" status:`,
+              `nats-connection: "${this.name}" status:`,
               status.type,
               status.data,
             );
@@ -162,7 +162,7 @@ export class NatsLink {
       // Status iterator can throw on close — only log if we weren't expecting it.
       if (!this.closed) {
         console.error(
-          `grove-bot: nats-connection "${this.name}" status loop error:`,
+          `nats-connection: "${this.name}" status loop error:`,
           err instanceof Error ? err.message : err,
         );
       }

--- a/src/bus/nats/subscription.ts
+++ b/src/bus/nats/subscription.ts
@@ -113,7 +113,7 @@ export class NatsSubscription {
       } catch (err) {
         // Drain can fail if the connection is already closed; log and proceed.
         console.error(
-          `grove-bot: nats-subscription "${this.pattern}" drain error:`,
+          `nats-subscription: "${this.pattern}" drain error:`,
           err instanceof Error ? err.message : err,
         );
       }
@@ -144,7 +144,7 @@ export class NatsSubscription {
       // page someone — and leave `subscription` null so stop() won't
       // try to drain a phantom.
       console.error(
-        `grove-bot: nats-subscription "${this.pattern}" subscribe failed:`,
+        `nats-subscription: "${this.pattern}" subscribe failed:`,
         err instanceof Error ? err.message : err,
       );
       this.subscription = null;
@@ -157,7 +157,7 @@ export class NatsSubscription {
     const loop = this.consume(this.subscription).catch((err) => {
       if (!this.stopped) {
         console.error(
-          `grove-bot: nats-subscription "${this.pattern}" consume loop rejection:`,
+          `nats-subscription: "${this.pattern}" consume loop rejection:`,
           err instanceof Error ? err.message : err,
         );
       }
@@ -197,7 +197,7 @@ export class NatsSubscription {
     } catch (err) {
       if (!this.stopped) {
         console.error(
-          `grove-bot: nats-subscription "${this.pattern}" consume loop error:`,
+          `nats-subscription: "${this.pattern}" consume loop error:`,
           err instanceof Error ? err.message : err,
         );
       }
@@ -228,7 +228,7 @@ export class NatsSubscription {
           if (old) {
             old.drain().catch((err) => {
               console.error(
-                `grove-bot: nats-subscription "${this.pattern}" pre-reconnect drain error:`,
+                `nats-subscription: "${this.pattern}" pre-reconnect drain error:`,
                 err instanceof Error ? err.message : err,
               );
             });
@@ -245,7 +245,7 @@ export class NatsSubscription {
           // misleading "subscribe failed → re-subscribed" log pair.
           if (this.subscribeOnce()) {
             console.info(
-              `grove-bot: nats-subscription "${this.pattern}" re-subscribed after reconnect`,
+              `nats-subscription: "${this.pattern}" re-subscribed after reconnect`,
             );
           }
         }
@@ -253,7 +253,7 @@ export class NatsSubscription {
     } catch (err) {
       if (!this.stopped) {
         console.error(
-          `grove-bot: nats-subscription "${this.pattern}" status loop error:`,
+          `nats-subscription: "${this.pattern}" status loop error:`,
           err instanceof Error ? err.message : err,
         );
       }
@@ -280,7 +280,7 @@ export class NatsSubscription {
 
 function defaultErrorLog(err: Error, subject: string): void {
   console.error(
-    `grove-bot: nats-subscription handler error on "${subject}":`,
+    `nats-subscription: handler error on "${subject}":`,
     err.message,
   );
 }

--- a/src/bus/surface-router.ts
+++ b/src/bus/surface-router.ts
@@ -53,8 +53,19 @@ export interface SurfaceAdapter {
   subjects: string[];
   /** Optional client-side filter applied AFTER subject match. */
   filter?: PayloadFilter;
-  /** Adapter-specific rendering. Bounded by router's renderTimeoutMs. */
-  render(envelope: Envelope): Promise<void>;
+  /**
+   * Adapter-specific rendering. Bounded by router's renderTimeoutMs.
+   *
+   * `signal` is an opt-in `AbortSignal` that fires when the router's per-render
+   * timeout elapses. Adapters that issue I/O (HTTP, NATS, sub-process) SHOULD
+   * forward the signal to those calls so the loser of `Promise.race` is
+   * actually cancelled — without it, the timed-out work keeps running in the
+   * background, holding sockets and spending quota. Adapters that do nothing
+   * but synchronous CPU (mocks, formatters) MAY accept the parameter and
+   * ignore it; the contract is opt-in for backwards compatibility with
+   * existing render functions.
+   */
+  render(envelope: Envelope, signal?: AbortSignal): Promise<void>;
   /** Optional liveness probe. Currently unused by the router; reserved
    *  for the dashboard's adapter-health panel (G-1111.E follow-on). */
   health?(): Promise<{ ok: boolean; lag?: number }>;
@@ -259,10 +270,23 @@ function adapterMatches(adapter: SurfaceAdapter, envelope: Envelope, subject: st
 }
 
 /**
- * Run `adapter.render(envelope)` under a timeout. Errors and timeouts
- * route to `onAdapterError`. **Never throws.** The contract is critical
- * for the §5.3 isolation rule — a slow or buggy adapter MUST NOT block
- * sibling adapters' renders.
+ * Run `adapter.render(envelope, signal)` under a timeout. Errors and
+ * timeouts route to `onAdapterError`. **Never throws.** The contract is
+ * critical for the §5.3 isolation rule — a slow or buggy adapter MUST NOT
+ * block sibling adapters' renders.
+ *
+ * On timeout, two things happen in tandem:
+ *
+ *   1. `Promise.race` resolves the timeout branch, freeing the dispatch loop
+ *      so sibling adapters keep getting their turn (the §5.3 isolation rule).
+ *   2. The `AbortController` aborts the signal we passed into `render()`,
+ *      so the loser of the race can stop its in-flight I/O instead of
+ *      running to completion in the background. Without this, a hanging
+ *      HTTP call or NATS request would leak past the timeout, holding
+ *      sockets and spending quota long after the dispatch resolved.
+ *
+ * Adapters that don't accept the signal still get the race-cancellation
+ * behaviour; they just don't get to wind down their own work.
  */
 async function renderWithIsolation(
   adapter: SurfaceAdapter,
@@ -270,17 +294,20 @@ async function renderWithIsolation(
   timeoutMs: number,
   onAdapterError: SurfaceRouterOptions["onAdapterError"],
 ): Promise<void> {
+  const ac = new AbortController();
   let timer: ReturnType<typeof setTimeout> | null = null;
   try {
     const timeoutPromise = new Promise<never>((_, reject) => {
       timer = setTimeout(() => {
-        reject(new Error(`render timeout after ${timeoutMs}ms`));
+        const err = new Error(`render timeout after ${timeoutMs}ms`);
+        ac.abort(err);
+        reject(err);
       }, timeoutMs);
     });
 
     // Defensively wrap the render call in case it throws synchronously
     // before returning a promise.
-    const renderPromise = (async () => adapter.render(envelope))();
+    const renderPromise = (async () => adapter.render(envelope, ac.signal))();
 
     await Promise.race([renderPromise, timeoutPromise]);
   } catch (err) {

--- a/src/bus/surface-router.ts
+++ b/src/bus/surface-router.ts
@@ -230,7 +230,7 @@ export function createSurfaceRouter(
           // Should not happen — renderWithIsolation never rejects. If it
           // does, log defensively rather than crash dispatch.
           console.error(
-            "grove-bot: surface-router internal error — renderWithIsolation rejected:",
+            "surface-router: internal error — renderWithIsolation rejected:",
             r.reason instanceof Error ? r.reason.message : r.reason,
           );
         }
@@ -300,7 +300,7 @@ function safeReportError(
     // Default sink: log so a missing observer doesn't make adapter
     // failures invisible.
     console.error(
-      `grove-bot: surface-router adapter "${adapterId}" render failed:`,
+      `surface-router: adapter "${adapterId}" render failed:`,
       err.message,
     );
     return;
@@ -310,7 +310,7 @@ function safeReportError(
   } catch (hookErr) {
     // A throwing observer must not poison the dispatch loop.
     console.error(
-      `grove-bot: surface-router onAdapterError hook threw for "${adapterId}":`,
+      `surface-router: onAdapterError hook threw for "${adapterId}":`,
       hookErr instanceof Error ? hookErr.message : hookErr,
     );
   }

--- a/src/bus/system-events.ts
+++ b/src/bus/system-events.ts
@@ -52,6 +52,7 @@
  */
 
 import type { Envelope } from "./myelin/envelope-validator";
+import { buildBaseEnvelope } from "./envelope-builder";
 
 /**
  * Source identifier used by every `system.*` event. Three dotted segments
@@ -161,11 +162,9 @@ export interface SystemAdapterDegradedOpts {
 export function createSystemAdapterDegradedEvent(
   opts: SystemAdapterDegradedOpts,
 ): Envelope {
-  return {
-    id: crypto.randomUUID(),
-    source: buildSource(opts.source),
+  return buildBaseEnvelope({
     type: "system.adapter.degraded",
-    timestamp: new Date().toISOString(),
+    source: buildSource(opts.source),
     sovereignty: defaultSystemSovereignty(opts.source),
     payload: {
       adapter_id: opts.adapterId,
@@ -180,7 +179,7 @@ export function createSystemAdapterDegradedEvent(
       }),
       ...(opts.shardId !== undefined && { shard_id: opts.shardId }),
     },
-  };
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -215,11 +214,9 @@ export interface SystemAdapterRecoveredOpts {
 export function createSystemAdapterRecoveredEvent(
   opts: SystemAdapterRecoveredOpts,
 ): Envelope {
-  return {
-    id: crypto.randomUUID(),
-    source: buildSource(opts.source),
+  return buildBaseEnvelope({
     type: "system.adapter.recovered",
-    timestamp: new Date().toISOString(),
+    source: buildSource(opts.source),
     sovereignty: defaultSystemSovereignty(opts.source),
     payload: {
       adapter_id: opts.adapterId,
@@ -232,7 +229,7 @@ export function createSystemAdapterRecoveredEvent(
         reconnect_attempts: opts.reconnectAttempts,
       }),
     },
-  };
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -265,11 +262,9 @@ export interface SystemAdapterDisconnectedOpts {
 export function createSystemAdapterDisconnectedEvent(
   opts: SystemAdapterDisconnectedOpts,
 ): Envelope {
-  return {
-    id: crypto.randomUUID(),
-    source: buildSource(opts.source),
+  return buildBaseEnvelope({
     type: "system.adapter.disconnected",
-    timestamp: new Date().toISOString(),
+    source: buildSource(opts.source),
     sovereignty: defaultSystemSovereignty(opts.source),
     payload: {
       adapter_id: opts.adapterId,
@@ -280,7 +275,7 @@ export function createSystemAdapterDisconnectedEvent(
       ...(opts.closeCode !== undefined && { close_code: opts.closeCode }),
       ...(opts.closeReason !== undefined && { close_reason: opts.closeReason }),
     },
-  };
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -345,12 +340,11 @@ export interface SystemInboundAbortedOpts {
 export function createSystemInboundAbortedEvent(
   opts: SystemInboundAbortedOpts,
 ): Envelope {
-  const envelope: Envelope = {
-    id: crypto.randomUUID(),
-    source: buildSource(opts.source),
+  return buildBaseEnvelope({
     type: "system.inbound.aborted",
-    timestamp: new Date().toISOString(),
+    source: buildSource(opts.source),
     sovereignty: defaultSystemSovereignty(opts.source),
+    ...(opts.correlationId !== undefined && { correlationId: opts.correlationId }),
     payload: {
       adapter_id: opts.adapterId,
       inbound_message_id: opts.inboundMessageId,
@@ -359,9 +353,5 @@ export function createSystemInboundAbortedEvent(
       elapsed_ms: opts.elapsedMs,
       phase: opts.phase,
     },
-  };
-  if (opts.correlationId !== undefined) {
-    envelope.correlation_id = opts.correlationId;
-  }
-  return envelope;
+  });
 }

--- a/src/bus/system-events.ts
+++ b/src/bus/system-events.ts
@@ -70,6 +70,15 @@ export interface SystemEventSource {
   agent: string;
   /** Stable instance name — usually `local` for in-process emission. */
   instance: string;
+  /**
+   * Operator residency code stamped into `envelope.sovereignty.data_residency`.
+   * Defaults to `"NZ"` when omitted — matches the original cortex deployment.
+   * Operators in other jurisdictions (AU, EU, US) pass their own ISO-3166-style
+   * code so envelopes accurately reflect data residency for compliance audits.
+   * The field is only used when constructing the default sovereignty object;
+   * callers that override `sovereignty` directly bypass it entirely.
+   */
+  dataResidency?: string;
 }
 
 function buildSource(src: SystemEventSource): string {
@@ -83,13 +92,14 @@ function buildSource(src: SystemEventSource): string {
  *
  * `system.*` events expose internal grove state — operator-only, never
  * federated outside the org, never sent to frontier models. The `data_residency`
- * default of "NZ" matches the operator's residency for andreas's deployment;
- * downstream consumers that re-publish for a different operator must override.
+ * field is sourced from `source.dataResidency` (defaulting to `"NZ"`) so a
+ * non-NZ operator gets envelopes stamped with their actual residency without
+ * having to override the entire sovereignty object at every call site.
  */
-function defaultSystemSovereignty(): Envelope["sovereignty"] {
+function defaultSystemSovereignty(source: SystemEventSource): Envelope["sovereignty"] {
   return {
     classification: "local",
-    data_residency: "NZ",
+    data_residency: source.dataResidency ?? "NZ",
     max_hop: 0,
     frontier_ok: false,
     model_class: "local-only",
@@ -156,7 +166,7 @@ export function createSystemAdapterDegradedEvent(
     source: buildSource(opts.source),
     type: "system.adapter.degraded",
     timestamp: new Date().toISOString(),
-    sovereignty: defaultSystemSovereignty(),
+    sovereignty: defaultSystemSovereignty(opts.source),
     payload: {
       adapter_id: opts.adapterId,
       platform: opts.platform,
@@ -210,7 +220,7 @@ export function createSystemAdapterRecoveredEvent(
     source: buildSource(opts.source),
     type: "system.adapter.recovered",
     timestamp: new Date().toISOString(),
-    sovereignty: defaultSystemSovereignty(),
+    sovereignty: defaultSystemSovereignty(opts.source),
     payload: {
       adapter_id: opts.adapterId,
       platform: opts.platform,
@@ -260,7 +270,7 @@ export function createSystemAdapterDisconnectedEvent(
     source: buildSource(opts.source),
     type: "system.adapter.disconnected",
     timestamp: new Date().toISOString(),
-    sovereignty: defaultSystemSovereignty(),
+    sovereignty: defaultSystemSovereignty(opts.source),
     payload: {
       adapter_id: opts.adapterId,
       platform: opts.platform,
@@ -340,7 +350,7 @@ export function createSystemInboundAbortedEvent(
     source: buildSource(opts.source),
     type: "system.inbound.aborted",
     timestamp: new Date().toISOString(),
-    sovereignty: defaultSystemSovereignty(),
+    sovereignty: defaultSystemSovereignty(opts.source),
     payload: {
       adapter_id: opts.adapterId,
       inbound_message_id: opts.inboundMessageId,

--- a/src/cli/cortex/commands/cloud.ts
+++ b/src/cli/cortex/commands/cloud.ts
@@ -395,7 +395,7 @@ async function cloudSetup(flags: Record<string, string>): Promise<void> {
       }
     }
   } catch (err) {
-    console.warn("grove-bot: cloud setup: failed to read bot.yaml for repos:", err instanceof Error ? err.message : err);
+    console.warn("cortex: cloud setup: failed to read bot.yaml for repos:", err instanceof Error ? err.message : err);
   }
 
   const reposResult = await runWranglerSecretPut("GITHUB_REPOS", repos, cfEnv, workerDir);

--- a/src/common/config/loader.ts
+++ b/src/common/config/loader.ts
@@ -60,7 +60,7 @@ export function loadConfig(path: string): BotConfig {
 function loadNetworkFiles(networksDir: string, explicit: boolean): NetworkFile[] {
   if (!existsSync(networksDir)) {
     if (explicit) {
-      console.warn(`grove-bot: networksDir "${networksDir}" does not exist — no networks loaded`);
+      console.warn(`config-loader: networksDir "${networksDir}" does not exist — no networks loaded`);
     }
     return [];
   }
@@ -114,7 +114,7 @@ function buildLegacyNetwork(raw: Record<string, unknown>): NetworkFile {
   const operatorId = (api.operatorId || (agent ? agent.operatorId : undefined)) as string | undefined;
   if (!operatorId) {
     console.warn(
-      "grove-bot: no operatorId configured (api.operatorId or agent.operatorId). " +
+      "config-loader: no operatorId configured (api.operatorId or agent.operatorId). " +
       "Skipping cloud config for legacy default network to avoid phantom dashboard entries.",
     );
   }

--- a/src/common/types/config.ts
+++ b/src/common/types/config.ts
@@ -263,6 +263,11 @@ export const BotConfigSchema = z.object({
     operatorDiscordId: z.string().optional(),
     /** Operator's Mattermost user ID — receives DM notifications when others talk to the bot */
     operatorMattermostId: z.string().optional(),
+    /** Operator data residency stamped into `sovereignty.data_residency` on emitted
+     *  envelopes (system.*, dispatch.task.*, cc.*). ISO-3166 country code; defaults
+     *  to "NZ" when omitted. Operators in AU/EU/US/etc. set this to match their
+     *  jurisdiction so envelopes accurately reflect residency for compliance audits. */
+    dataResidency: z.string().optional(),
   }),
 
   /** Discord instances — accepts a single object (legacy) or array (multi-instance) */

--- a/src/common/usage/monitor.ts
+++ b/src/common/usage/monitor.ts
@@ -52,7 +52,7 @@ export class UsageMonitor {
     // Tier 3: API fallback — only if no events/cache updates in a while
     this.apiTimer = setInterval(() => this.apiFallback(), API_POLL_MS);
 
-    console.log("grove-bot: usage monitor started (event → cache → api)");
+    console.log("usage-monitor: started (event → cache → api)");
   }
 
   /** Stop all timers. */
@@ -91,7 +91,7 @@ export class UsageMonitor {
       const snapshot = this.toSnapshot("cache", raw);
       this.onUpdate(usage, snapshot);
     } catch (err) {
-      console.error("grove-bot: usage cache read failed:", err instanceof Error ? err.message : err);
+      console.error("usage-monitor: cache read failed:", err instanceof Error ? err.message : err);
     }
   }
 
@@ -121,7 +121,7 @@ export class UsageMonitor {
       this.onUpdate(usage, snapshot);
       this.lastEventAt = Date.now(); // Treat API response as a "recent update"
     } catch (err) {
-      console.error("grove-bot: usage API fallback failed:", err instanceof Error ? err.message : err);
+      console.error("usage-monitor: API fallback failed:", err instanceof Error ? err.message : err);
     }
   }
 
@@ -169,7 +169,7 @@ export class UsageMonitor {
           if (token) return token;
         }
       } catch (err) {
-        console.error("grove-bot: keychain credential read failed:", err instanceof Error ? err.message : err);
+        console.error("usage-monitor: keychain credential read failed:", err instanceof Error ? err.message : err);
       }
     }
 
@@ -182,7 +182,7 @@ export class UsageMonitor {
         if (token) return token;
       }
     } catch (err) {
-      console.error("grove-bot: credentials file read failed:", err instanceof Error ? err.message : err);
+      console.error("usage-monitor: credentials file read failed:", err instanceof Error ? err.message : err);
     }
 
     return process.env.CLAUDE_CODE_OAUTH_TOKEN ?? null;

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -148,10 +148,17 @@ export async function startCortex(
 
   // SystemEventSource for `system.*` envelopes (spec §3.6:
   // `{operatorId}.cortex.{instance}`). `local` until federation lands.
+  // `dataResidency` flows from `config.agent.dataResidency` so a non-NZ
+  // operator gets envelopes stamped with their actual residency without
+  // touching the per-event constructors. Defaults to "NZ" when absent
+  // (the original cortex deployment's residency).
   const systemEventSource: SystemEventSource = {
     org: config.agent.operatorId ?? "default",
     agent: "cortex",
     instance: "local",
+    ...(config.agent.dataResidency !== undefined && {
+      dataResidency: config.agent.dataResidency,
+    }),
   };
 
   // Dispatch-handler — synchronous platform-message → CC pipeline.

--- a/src/runner/__tests__/dispatch-listener.test.ts
+++ b/src/runner/__tests__/dispatch-listener.test.ts
@@ -508,6 +508,45 @@ describe("dispatch-listener — malformed payload", () => {
 
     expect(r.published).toHaveLength(0);
   });
+
+  test("non-UUID task_id → rejected at parse time (no envelopes published, no CC spawned)", async () => {
+    // Per Echo's review (cortex#34): payload-level UUID gate. A producer that
+    // slips a non-UUID `task_id` past the envelope validator must not result
+    // in a CC process spawn or any downstream `started`/`completed` envelope —
+    // those would be uncorrelated and break the §3.3.4 ordering contract.
+    const r = recordingRuntime();
+    const router = createSurfaceRouter(r.runtime);
+    const { factory, optsCaptured } = fakeFactory(SUCCESS_RESULT);
+    const listener = createDispatchListener({
+      runtime: r.runtime,
+      router,
+      source: SOURCE,
+      ccSessionFactory: factory,
+    });
+    await listener.start();
+    await router.start();
+
+    const malformed: Envelope = {
+      id: "00000000-0000-4000-8000-000000000000",
+      source: "metafactory.dispatch-handler.local",
+      type: "dispatch.task.received",
+      timestamp: "2026-05-09T12:00:00Z",
+      sovereignty: {
+        classification: "local",
+        data_residency: "NZ",
+        max_hop: 0,
+        frontier_ok: false,
+        model_class: "local-only",
+      },
+      // shape is wrong on multiple axes: bare string, no hyphens, wrong length
+      payload: { task_id: "not-a-uuid", agent_id: "cortex", prompt: "x" },
+    };
+    r.trigger(malformed, "local.metafactory.dispatch.task.received");
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(r.published).toHaveLength(0);
+    expect(optsCaptured).toHaveLength(0);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/runner/cc-session.ts
+++ b/src/runner/cc-session.ts
@@ -171,7 +171,7 @@ export class CCSession extends EventEmitter {
     const proc = this.proc;
     setTimeout(() => {
       try { proc.kill("SIGTERM"); } catch (err) {
-        console.warn("grove-bot: cc-session: SIGTERM failed (process likely already exited):", err instanceof Error ? err.message : err);
+        console.warn("cc-session: SIGTERM failed (process likely already exited):", err instanceof Error ? err.message : err);
       }
     }, 2_000);
   }
@@ -238,7 +238,7 @@ export class CCSession extends EventEmitter {
     const timeout = this.opts.timeoutMs ?? 120_000;
     this.timeoutId = setTimeout(() => {
       const mins = Math.round(timeout / 60_000);
-      console.error(`grove-bot: cc-session timed out after ${mins} minutes of inactivity`);
+      console.error(`cc-session: timed out after ${mins} minutes of inactivity`);
       this.timedOut = true;
       this.kill();
       this.emit("error", new Error(`Timed out after ${mins} minute${mins !== 1 ? "s" : ""} of inactivity`));
@@ -294,7 +294,7 @@ export class CCSession extends EventEmitter {
         chunks.push(decoder.decode(value, { stream: true }));
       }
     } catch (err) {
-      console.warn("grove-bot: cc-session: stderr stream closed:", err instanceof Error ? err.message : err);
+      console.warn("cc-session: stderr stream closed:", err instanceof Error ? err.message : err);
     }
 
     const stderrText = chunks.join("");

--- a/src/runner/dispatch-listener.ts
+++ b/src/runner/dispatch-listener.ts
@@ -193,7 +193,14 @@ export function createDispatchListener(
     // No payload filter on the listener side — every received envelope
     // is meant for the runner. If we add multi-runner routing (filter on
     // `payload.agent_id`), it goes here as a `PayloadFilter`.
-    render: (envelope) => handleDispatchEnvelope(envelope, runtime, source, ccSessionFactory),
+    //
+    // `signal` is accepted for contract symmetry but not currently forwarded
+    // into the CC session — the spawn lifecycle is governed by `cc-session`'s
+    // own inactivity timer (which already kills the child process on stall).
+    // A follow-on iteration can wire `signal.aborted` to `session.kill()` so
+    // surface-router timeouts end the CC process eagerly rather than waiting
+    // for cc-session's internal timeout to fire.
+    render: (envelope, _signal) => handleDispatchEnvelope(envelope, runtime, source, ccSessionFactory),
   };
 
   return {

--- a/src/runner/dispatch-listener.ts
+++ b/src/runner/dispatch-listener.ts
@@ -224,25 +224,28 @@ export function createDispatchListener(
  * (a producer that emits `received` and never sees `started` knows
  * something went wrong).
  */
+// UUID v1-v5 shape per RFC 4122 §3 — same regex used by the envelope
+// validator on `envelope.id`, applied here at the payload layer for
+// `payload.task_id`.
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
 function parsePayload(envelope: Envelope): DispatchTaskReceivedPayload | null {
   const p = envelope.payload as Partial<DispatchTaskReceivedPayload> | undefined;
   if (!p) return null;
   if (typeof p.task_id !== "string" || typeof p.agent_id !== "string") return null;
   if (typeof p.prompt !== "string" || p.prompt.length === 0) return null;
-  // TODO (deferred to MIG-7.x — Echo round-1 s2): payload-level UUID
-  // validation on `task_id`. Not added here because:
-  //   1. The envelope-level `validateEnvelope` already checks `envelope.id`
-  //      shape — the typical caller path (dispatch-handler emitting onto
-  //      the bus) sets `correlation_id = task_id` and runs through the
-  //      same UUID validator already.
-  //   2. Adding a second UUID regex here re-implements that check at a
-  //      different layer without a clear failure mode it would catch —
-  //      the only producer who could slip a non-UUID `task_id` past us
-  //      is a producer that bypasses validateEnvelope, which is an
-  //      architectural problem that belongs at the validator layer.
-  // When MIG-7+ adds a multi-runner federation, payload-shape contracts
-  // become first-class (per §4.x) — that's the right place to add a
-  // payload-level Zod schema for `dispatch.task.received`.
+  // Per Echo's review (cortex#34): the envelope-level validator only checks
+  // `envelope.id`'s shape, not `payload.task_id`. Without this gate, a
+  // malformed publisher could slip a non-UUID `task_id` through to
+  // CCSession + worklog-manager and break correlation across `started` /
+  // `completed` / `failed` envelopes downstream. Reject at parse time so
+  // no envelopes are published and no CC process is spawned for a bad id.
+  if (!UUID_RE.test(p.task_id)) {
+    console.warn(
+      `dispatch-listener: rejecting envelope ${envelope.id} — task_id missing or not UUID-shaped`,
+    );
+    return null;
+  }
   return p as DispatchTaskReceivedPayload;
 }
 

--- a/src/runner/event-utils.ts
+++ b/src/runner/event-utils.ts
@@ -1,12 +1,21 @@
 /**
- * Shared utilities for extracting metadata from published events.
- * Used by both dashboard-state and worklog-manager to avoid duplication.
+ * Runner-side event utilities for the `PublishedEvent` shape (CC hook events
+ * lifted by the relay). Used by `dashboard-state` and `worklog-manager` to
+ * detect project / extract GitHub references / surface activity entries.
  *
- * TODO(MIG-7): This is the bot/lib version of event-utils, distinct from
- * `src/common/event-utils.ts` (the mc/tap version). They cover different
- * event shapes (`PublishedEvent` here vs `IngestEvent` there) — overlapping
- * function names work on different surfaces. Consolidation pass scheduled
- * at MIG-7 alongside the broader common/types reorg.
+ * Distinct from `src/common/event-utils.ts`, which serves the `IngestEvent`
+ * shape used by the mc API + cc-events tap. The two files share function
+ * names (`detectProject`) but operate on different event types and live in
+ * different surfaces of the codebase. The naming overlap is intentional —
+ * each surface has its own canonical "given an event, infer the project"
+ * implementation, and consolidating them would force a lossy union type
+ * (PublishedEvent | IngestEvent) that obscures which surface a caller is
+ * really on. No consolidation is planned.
+ *
+ * If you find yourself wanting to call one from the other, you're probably
+ * on the wrong side of the surface boundary — the runner shouldn't be
+ * inspecting IngestEvents, and the mc/tap layer shouldn't be inspecting
+ * PublishedEvents. Reach for the projection at the boundary instead.
  */
 
 import type { PublishedEvent } from "../taps/cc-events/hooks/lib/event-types";

--- a/src/runner/prompt-filter.ts
+++ b/src/runner/prompt-filter.ts
@@ -29,11 +29,11 @@ try {
   const mod = await import("@metafactory/content-filter");
   filterContentString = mod.filterContentString;
   console.log(
-    "grove-bot: prompt-filter: @metafactory/content-filter loaded — inbound prompts will be scanned",
+    "prompt-filter: @metafactory/content-filter loaded — inbound prompts will be scanned",
   );
 } catch (err) {
   console.error(
-    "grove-bot: prompt-filter: WARN @metafactory/content-filter failed to load — " +
+    "prompt-filter: WARN @metafactory/content-filter failed to load — " +
       "inbound prompts are NOT being scanned for prompt injection:",
     err instanceof Error ? err.message : err,
   );
@@ -78,7 +78,7 @@ export function scanPrompt(prompt: string, source: string): PromptFilterResult {
       const reasons = [...patternIds, ...encodingTypes];
       const reasonStr = reasons.length > 0 ? reasons.join(", ") : "unspecified";
       console.log(
-        `grove-bot: prompt blocked by content filter (${reasonStr}): ${prompt.slice(0, 100)}`,
+        `prompt-filter: prompt blocked by content filter (${reasonStr}): ${prompt.slice(0, 100)}`,
       );
       return {
         allowed: false,
@@ -90,7 +90,7 @@ export function scanPrompt(prompt: string, source: string): PromptFilterResult {
     return { allowed: true, score: result.overall_confidence };
   } catch (error) {
     // Fail-open on filter errors — don't block legitimate messages
-    console.error("grove-bot: content filter error:", error);
+    console.error("prompt-filter: content filter error:", error);
     return { allowed: true };
   }
 }

--- a/src/runner/task-tracker.ts
+++ b/src/runner/task-tracker.ts
@@ -55,7 +55,7 @@ export class TaskTracker {
   async shutdown(timeoutMs = 10_000): Promise<void> {
     if (this.tasks.size === 0) return;
 
-    console.log(`grove-bot: shutting down ${this.tasks.size} in-flight task(s)...`);
+    console.log(`task-tracker: shutting down ${this.tasks.size} in-flight task(s)...`);
 
     const exitPromises: Promise<void>[] = [];
 

--- a/src/runner/worklog-manager.ts
+++ b/src/runner/worklog-manager.ts
@@ -40,8 +40,16 @@ export class WorklogManager {
   /**
    * Clean up stale session→thread mappings for sessions that never completed.
    * Call periodically (e.g. every 5 minutes). Removes entries older than maxAgeMs.
+   *
+   * Default: 6h. Long-running CC tasks (research sweeps, multi-step builds)
+   * routinely exceed the previous 30-minute floor, and the consequence of
+   * eviction-during-progress is "terminal envelope arrives, can't find its
+   * thread, channel-level summary still posts but per-thread summary is
+   * lost" — graceful degradation, but avoidable. 6h covers nearly every
+   * realistic in-process task without making the maps unbounded; longer
+   * runs should pick a custom value (per Echo round-1 s4).
    */
-  cleanupStaleSessions(maxAgeMs = 30 * 60 * 1000): number {
+  cleanupStaleSessions(maxAgeMs = 6 * 60 * 60 * 1000): number {
     const now = Date.now();
     let removed = 0;
     for (const [sessionId, lastSeen] of this.sessionLastSeen) {
@@ -255,20 +263,17 @@ export class WorklogManager {
    *   bot config). Passing it explicitly keeps the dependency direction
    *   clean (no config import here).
    *
-   * KNOWN LIMITATION (Echo round-1 s4, deferred): the bus path keys
-   * threads by `task_id` and shares the `sessionThreads` map with the
-   * direct-call path. `cleanupStaleSessions` defaults to a 30-minute
-   * staleness window — long-running CC tasks that exceed that window
-   * will have their thread ID evicted from the map even if the task is
-   * still in progress, after which a late `dispatch.task.completed`
-   * envelope can no longer find its thread. This is acceptable for
-   * MIG-4b because: (a) the default cc-session inactivity timeout is
-   * 2 minutes, well under the 30-minute floor; (b) the bus path's
-   * fallback for "thread missing" is to skip the per-thread post but
-   * still emit the channel-level summary (graceful degradation, not
-   * data loss); (c) loosening the cleanup default is a cross-cutting
-   * design conversation (it also affects the direct-call path) better
-   * scoped to a follow-up rather than this PR.
+   * KNOWN LIMITATION (Echo round-1 s4): the bus path keys threads by
+   * `task_id` and shares the `sessionThreads` map with the direct-call
+   * path. `cleanupStaleSessions` now defaults to a 6-hour staleness
+   * window (was 30 minutes — raised in C-108 sweep so long-running tasks
+   * don't lose their thread mapping before the terminal envelope arrives).
+   * Tasks that exceed even the 6h floor will still have their thread ID
+   * evicted from the map, after which a late terminal envelope can no
+   * longer find its thread. The bus path's fallback for "thread missing"
+   * is to skip the per-thread post but still emit the channel-level
+   * summary (graceful degradation, not data loss). Callers that need a
+   * different window pass `maxAgeMs` explicitly.
    */
   surfaceConfig(opts: { org: string; adapterId?: string }): SurfaceAdapter {
     const subjects = [`local.${opts.org}.dispatch.task.>`];

--- a/src/runner/worklog-manager.ts
+++ b/src/runner/worklog-manager.ts
@@ -280,7 +280,12 @@ export class WorklogManager {
     return {
       id: opts.adapterId ?? "worklog-manager",
       subjects,
-      render: (envelope: Envelope) => this.renderDispatchEnvelope(envelope),
+      // `signal` is accepted for contract symmetry; not forwarded into
+      // discord.js calls (channel.send / thread.create) which don't take an
+      // AbortSignal today. Future refinement when those call paths gain
+      // signal support.
+      render: (envelope: Envelope, _signal?: AbortSignal) =>
+        this.renderDispatchEnvelope(envelope),
     };
   }
 

--- a/src/taps/cc-events/__tests__/cc-events.test.ts
+++ b/src/taps/cc-events/__tests__/cc-events.test.ts
@@ -133,6 +133,14 @@ describe("createCcEventEnvelope", () => {
     expect(e2.sovereignty.max_hop).toBe(0);
   });
 
+  test("source.dataResidency overrides the NZ default", () => {
+    const env = createCcEventEnvelope({
+      event: makeEvent(),
+      source: { org: "metafactory", agent: "cortex", instance: "relay", dataResidency: "EU" },
+    });
+    expect(env.sovereignty.data_residency).toBe("EU");
+  });
+
   test("payload includes top-level PublishedEvent fields plus payload spread", () => {
     const event = makeEvent({
       event_id: "evt-abc",

--- a/src/taps/cc-events/cc-events.ts
+++ b/src/taps/cc-events/cc-events.ts
@@ -48,6 +48,7 @@
  */
 
 import type { Envelope } from "../../bus/myelin/envelope-validator";
+import { buildBaseEnvelope } from "../../bus/envelope-builder";
 import type { NatsLink } from "../../bus/nats/connection";
 import type { PublishedEvent } from "./hooks/lib/event-types";
 
@@ -146,15 +147,19 @@ export function createCcEventEnvelope(
   opts: CreateCcEventEnvelopeOpts,
 ): Envelope {
   const { event } = opts;
-  const envelope: Envelope = {
-    id: crypto.randomUUID(),
-    source: buildSource(opts.source),
+  // Use the shared envelope builder for the skeleton, then override
+  // `timestamp` with the PublishedEvent's hook timestamp so envelope ts ==
+  // hook ts (the relay may batch-process; using `now()` from the shared
+  // helper would smear chronology across batched events). The override is
+  // a single line and preserves the rule-of-three extraction for the rest
+  // of the skeleton.
+  const envelope = buildBaseEnvelope({
     type: event.event_type,
-    // Mirror the published event's timestamp so envelope ts == hook ts.
-    // The relay may batch-process; using `now()` would smear chronology
-    // across batched events.
-    timestamp: event.timestamp,
+    source: buildSource(opts.source),
     sovereignty: defaultCcSovereignty(opts.source),
+    // Only set correlation_id when session_id has the UUID shape the schema
+    // requires. Non-UUID session ids fall through to payload.session_id only.
+    ...(isUuid(event.session_id) && { correlationId: event.session_id }),
     payload: {
       // Flatten the PublishedEvent into the envelope payload. Downstream
       // consumers who want the legacy taxonomy can read these fields
@@ -171,14 +176,8 @@ export function createCcEventEnvelope(
       // live at top-level on the PublishedEvent, not inside payload.
       ...event.payload,
     },
-  };
-
-  // Only set correlation_id when session_id has the UUID shape the schema
-  // requires. Non-UUID session ids fall through to payload.session_id only.
-  if (isUuid(event.session_id)) {
-    envelope.correlation_id = event.session_id;
-  }
-
+  });
+  envelope.timestamp = event.timestamp;
   return envelope;
 }
 

--- a/src/taps/cc-events/cc-events.ts
+++ b/src/taps/cc-events/cc-events.ts
@@ -69,6 +69,14 @@ export interface CcEventSource {
   agent?: string;
   /** Stable instance name. Defaults to `"relay"`. */
   instance?: string;
+  /**
+   * Operator residency code stamped into `envelope.sovereignty.data_residency`.
+   * Defaults to `"NZ"` when omitted — matches the original cortex deployment.
+   * Operators in other jurisdictions pass their own ISO-3166-style code so
+   * envelopes accurately reflect data residency. Mirrors the parameterisation
+   * pattern in `bus/system-events.ts` and `bus/dispatch-events.ts`.
+   */
+  dataResidency?: string;
 }
 
 function buildSource(src: CcEventSource | undefined): string {
@@ -80,14 +88,15 @@ function buildSource(src: CcEventSource | undefined): string {
 /**
  * Default sovereignty for `cc.*` envelopes. Same posture as `system.*`:
  * operator-only, local residency, no federation, no frontier-model
- * processing. Returned as a fresh literal per call so a downstream
- * mutation on one envelope's sovereignty cannot leak into a sibling
- * envelope.
+ * processing. `data_residency` reads from `source.dataResidency`
+ * (defaulting to `"NZ"`). Returned as a fresh literal per call so a
+ * downstream mutation on one envelope's sovereignty cannot leak into
+ * a sibling envelope.
  */
-function defaultCcSovereignty(): Envelope["sovereignty"] {
+function defaultCcSovereignty(source: CcEventSource | undefined): Envelope["sovereignty"] {
   return {
     classification: "local",
-    data_residency: "NZ",
+    data_residency: source?.dataResidency ?? "NZ",
     max_hop: 0,
     frontier_ok: false,
     model_class: "local-only",
@@ -145,7 +154,7 @@ export function createCcEventEnvelope(
     // The relay may batch-process; using `now()` would smear chronology
     // across batched events.
     timestamp: event.timestamp,
-    sovereignty: defaultCcSovereignty(),
+    sovereignty: defaultCcSovereignty(opts.source),
     payload: {
       // Flatten the PublishedEvent into the envelope payload. Downstream
       // consumers who want the legacy taxonomy can read these fields
@@ -195,6 +204,10 @@ export interface CreateCcEventPublisherOpts {
    */
   instance?: string;
   /**
+   * Operator residency stamped into envelope sovereignty. Defaults to `"NZ"`.
+   */
+  dataResidency?: string;
+  /**
    * Override the envelope-construction helper. Lets tests assert on the
    * envelope shape without needing a real NATS connection. Defaults to
    * `createCcEventEnvelope`.
@@ -224,6 +237,7 @@ export function createCcEventPublisher(
     org,
     agent: opts.agent ?? "cortex",
     instance: opts.instance ?? "relay",
+    ...(opts.dataResidency !== undefined && { dataResidency: opts.dataResidency }),
   };
   const buildEnvelope =
     opts.buildEnvelope ??

--- a/src/taps/cc-events/cloud-publisher.ts
+++ b/src/taps/cc-events/cloud-publisher.ts
@@ -75,7 +75,7 @@ export class CloudPublisher {
     if (this.buffer.length > CloudPublisher.MAX_BUFFER_SIZE) {
       const dropped = this.buffer.length - CloudPublisher.MAX_BUFFER_SIZE;
       this.buffer.splice(0, dropped);
-      console.warn(`grove-bot: cloud publisher dropped ${dropped} oldest event(s) (buffer full)`);
+      console.warn(`cloud-publisher: dropped ${dropped} oldest event(s) (buffer full)`);
     }
 
     if (this.buffer.length >= this.batchSizeLimit) {
@@ -123,22 +123,22 @@ export class CloudPublisher {
         if (res.status >= 300 && res.status < 400) {
           const location = res.headers.get("location") ?? "(unknown)";
           console.error(
-            `grove-bot: cloud endpoint STALE for network "${networkId}"\n` +
+            `cloud-publisher: endpoint STALE for network "${networkId}"\n` +
             `  URL: ${url}\n` +
             `  Got: HTTP ${res.status} -> ${location}\n` +
             `  This usually means the Worker route was changed but the network config still has the old URL.\n` +
             `  Fix: update cloud.endpoint in the network config file, then restart.`,
           );
         } else if (res.ok) {
-          console.log(`grove-bot: cloud endpoint OK for network "${networkId}" (${config.endpoint})`);
+          console.log(`cloud-publisher: endpoint OK for network "${networkId}" (${config.endpoint})`);
         } else {
           console.warn(
-            `grove-bot: cloud endpoint returned HTTP ${res.status} for network "${networkId}" (${url})`,
+            `cloud-publisher: endpoint returned HTTP ${res.status} for network "${networkId}" (${url})`,
           );
         }
       } catch (err) {
         console.error(
-          `grove-bot: cloud endpoint UNREACHABLE for network "${networkId}" (${url}): ${err instanceof Error ? err.message : err}`,
+          `cloud-publisher: endpoint UNREACHABLE for network "${networkId}" (${url}): ${err instanceof Error ? err.message : err}`,
         );
       }
     }
@@ -188,7 +188,7 @@ export class CloudPublisher {
 
     if (!networkConfig) {
       console.warn(
-        `grove-bot: unknown network "${networkId}" — skipping ${events.length} event(s). ` +
+        `cloud-publisher: unknown network "${networkId}" — skipping ${events.length} event(s). ` +
         `Check networks[] config or ensure GROVE_NETWORK matches a configured network.`,
       );
       return;
@@ -221,7 +221,7 @@ export class CloudPublisher {
         if (res.status >= 300 && res.status < 400) {
           const location = res.headers.get("location") ?? "(unknown)";
           console.error(
-            `grove-bot: cloud endpoint STALE for network "${networkId}" — got HTTP ${res.status} -> ${location}\n` +
+            `cloud-publisher: endpoint STALE for network "${networkId}" — got HTTP ${res.status} -> ${location}\n` +
             `  URL: ${url}\n` +
             `  This usually means the Worker route was changed but the network config still has the old URL.\n` +
             `  Fix: update cloud.endpoint in the network config file, then restart.\n` +
@@ -231,11 +231,11 @@ export class CloudPublisher {
         }
 
         console.error(
-          `grove-bot: cloud publish failed for network "${networkId}" (attempt ${attempt}/${this.maxRetries}): HTTP ${res.status}`,
+          `cloud-publisher: publish failed for network "${networkId}" (attempt ${attempt}/${this.maxRetries}): HTTP ${res.status}`,
         );
       } catch (err) {
         console.error(
-          `grove-bot: cloud publish error for network "${networkId}" (attempt ${attempt}/${this.maxRetries}):`,
+          `cloud-publisher: publish error for network "${networkId}" (attempt ${attempt}/${this.maxRetries}):`,
           err instanceof Error ? err.message : err,
         );
       }
@@ -249,7 +249,7 @@ export class CloudPublisher {
 
     // All retries exhausted -- drop the batch (events are in local JSONL)
     console.error(
-      `grove-bot: cloud publish dropped ${events.length} event(s) for network "${networkId}" after ${this.maxRetries} retries`,
+      `cloud-publisher: publish dropped ${events.length} event(s) for network "${networkId}" after ${this.maxRetries} retries`,
     );
   }
 }


### PR DESCRIPTION
## What

Sweep PR for tracker [cortex#34](https://github.com/the-metafactory/cortex/issues/34). Closes the accumulated technical debt across cortex#14, #17, #18, #19, #22, #24, #25, #26, #27, #28, #29, #30, #32 — Echo nits/findings deferred during the original PRs.

## Sweep applied

### High priority — log-prefix renames (8 source files, 22+ strings)

Decision: `grove-bot:` compound prefix dropped where component noun exists; `cortex:` only when no component noun. Single-binary identity matches reality (cortex.ts entrypoint at MIG-7.1 landed).

- `src/bus/dispatch-handler.ts` — `message-router:` / `grove-bot: router*` → `dispatch-handler:`
- `src/bus/myelin/runtime.ts` — `grove-bot: myelin …` → `myelin-runtime: …` (10 strings + JSDoc)
- `src/bus/surface-router.ts` — `grove-bot: surface-router …` → `surface-router: …`
- `src/adapters/discord/index.ts` — drop `grove-bot:` from instance-prefixed messages
- `src/adapters/mattermost/index.ts` — same
- Plus runner/, taps/, cli/, common/ — all stale `grove-bot:` removed

Production source now has 0 `grove-bot:` log prefixes (only operator-instruction text in cli/cortex/commands/cloud.ts referencing legacy CLI binary name remains — out of scope for log prefixes; that's MIG-7.6a/cutover work).

### Medium priority

- **canPublishSystemEvent → discriminated `{runtime, source} | null`** (DiscordAdapter): removed 6 non-null assertions; `warnedMissingSource` latch added so diagnostic prints once per process
- **Runtime post-stop publish race comment expanded** (`myelin/runtime.ts:218–235`) + test docline
- **Discord `wasClean` comment expanded** with 4xxx codes (4004 auth, 4014 intents, 4000 unknown)
- **dispatch-listener.parsePayload UUID validation** on `task_id` — non-UUID rejected at parse, no envelopes published, no CC spawned
- **WorklogManager.cleanupStaleSessions** default raised 30min → 6h so long-running tasks don't lose thread mapping

### Low priority (also fixed per Andreas)

- **AbortSignal in SurfaceAdapter.render() contract** — router constructs AbortController per render, aborts on timeout; adapters opt-in to honour. 3 new router tests pin the contract.
- **`data_residency` parameterized** across all 3 event domains (system/dispatch/cc-events) via `SystemEventSource.dataResidency` + threaded through cortex.ts entrypoint. Defaults to "NZ" so single-operator deployments unchanged.
- **`buildBaseEnvelope` extracted** to new `src/bus/envelope-builder.ts` — rule of three satisfied (system + dispatch + cc-events). 7 new tests pin contract; refactored 3 event files.
- **event-utils duality** — replaced `TODO(MIG-7)` with doc-block explaining the duality is intentional (different surfaces, different event shapes, no consolidation planned).
- **invokeClaudeCode** verified retired in cortex#30 (MIG-4.8). No work needed.

## Tests added

- 3 surface-router AbortSignal tests
- 7 envelope-builder shared-helper tests
- 1 dispatch-listener UUID rejection test
- data_residency tests across system/dispatch/cc-events suites
- Plus updates to existing tests for new log strings

## Verification

- cortex root \`bunx tsc --noEmit\` → **exit 0**
- \`bun test\` full suite — **1832 pass / 1 pre-existing fail** (the React shell test from MIG-2)

## Commits

12 commits on top of main:
- `d9abf76` chore: remove grove-bot: log prefix from bus/
- `ac9f3b3` chore: remove grove-bot: log prefix from adapters/
- `bf8814c` chore: remove grove-bot: log prefix from runner/, taps/, cli/, common/
- `d248f0f` refactor: DiscordAdapter.canPublishSystemEvent returns discriminated wiring
- `a278f98` docs: document post-stop publish race in MyelinRuntime
- `7bdbb6b` docs: expand wasClean comment with Discord 4xxx codes
- `e5c0a1c` feat: UUID-shape validation on dispatch payload task_id
- `bb30792` feat: raise WorklogManager.cleanupStaleSessions default to 6h
- `b49f97e` refactor: surface adapter render() takes optional AbortSignal
- `2e29933` feat: parameterise sovereignty.data_residency across event domains
- `3f15eb2` refactor: extract shared buildBaseEnvelope helper
- `8c57f1d` docs: clarify runner/event-utils.ts vs common/event-utils.ts duality

Closes cortex#34.

🤖 Generated with [Claude Code](https://claude.com/claude-code)