### PR TITLE
feat(taps): C-108.x — relay rename grove-relay → cortex-relay (MIG-7.6b)

### DIFF
--- a/src/services/com.cortex.relay.plist
+++ b/src/services/com.cortex.relay.plist
@@ -7,7 +7,7 @@
     <key>ProgramArguments</key>
     <array>
         <string>__BUN_PATH__</string>
-        <string>__GROVE_DIR__/src/taps/cc-events/grove-relay.ts</string>
+        <string>__GROVE_DIR__/src/taps/cc-events/relay.ts</string>
         <string>start</string>
     </array>
     <key>WorkingDirectory</key>
@@ -17,8 +17,8 @@
     <key>KeepAlive</key>
     <true/>
     <key>StandardOutPath</key>
-    <string>__HOME__/.claude/logs/grove-relay.log</string>
+    <string>__HOME__/.claude/logs/cortex-relay.log</string>
     <key>StandardErrorPath</key>
-    <string>__HOME__/.claude/logs/grove-relay.error.log</string>
+    <string>__HOME__/.claude/logs/cortex-relay.error.log</string>
 </dict>
 </plist>

--- a/src/taps/cc-events/cc-events.ts
+++ b/src/taps/cc-events/cc-events.ts
@@ -5,10 +5,10 @@
  * pre-myelin Claude Code hook taxonomy (`agent.task.started`,
  * `tool.bash.executed`, etc.) co-exists with the cross-process G-1111
  * vocabulary. The path forward is "Some in-process events MAY be lifted to
- * the bus by grove-relay" — same correlation_id, separate vocabulary —
+ * the bus by cortex-relay" — same correlation_id, separate vocabulary —
  * which is what this helper enables.
  *
- * The grove-relay (cc-events tap) reads CC hooks from
+ * The cortex-relay (cc-events tap) reads CC hooks from
  * `~/.claude/events/raw/`, applies the relay policy, writes published
  * events to `~/.claude/events/published/`, and ALSO — when a
  * `MyelinRuntime` is attached — wraps each published event in a Myelin
@@ -241,7 +241,7 @@ export function createCcEventPublisher(
       // operator-facing — when a publish fails repeatedly the operator
       // sees it in launchd output and can investigate the NATS server.
       process.stderr.write(
-        `grove-relay: nats publish failed for subject=${subject} id=${envelope.id} type=${envelope.type}: ${
+        `cortex-relay: nats publish failed for subject=${subject} id=${envelope.id} type=${envelope.type}: ${
           err instanceof Error ? err.message : String(err)
         }\n`,
       );

--- a/src/taps/cc-events/lib/event-processor.ts
+++ b/src/taps/cc-events/lib/event-processor.ts
@@ -88,7 +88,7 @@ export class EventProcessor {
             this.onPublished(result);
           } catch (err) {
             process.stderr.write(
-              `grove-relay: onPublished hook threw for event_id=${result.event_id}: ${
+              `cortex-relay: onPublished hook threw for event_id=${result.event_id}: ${
                 err instanceof Error ? err.message : String(err)
               }\n`,
             );

--- a/src/taps/cc-events/lib/jsonl-reader.ts
+++ b/src/taps/cc-events/lib/jsonl-reader.ts
@@ -54,7 +54,7 @@ export class JsonlReader {
       try {
         events.push(JSON.parse(trimmed) as RawEvent);
       } catch (err) {
-        console.warn("grove-relay: jsonl-reader: skipping malformed line:", err instanceof Error ? err.message : err);
+        console.warn("cortex-relay: jsonl-reader: skipping malformed line:", err instanceof Error ? err.message : err);
       }
     }
 

--- a/src/taps/cc-events/relay.ts
+++ b/src/taps/cc-events/relay.ts
@@ -152,7 +152,7 @@ program
   .action(async (options) => {
     if (!existsSync(options.policy)) {
       console.error(`Policy file not found: ${options.policy}`);
-      console.error("Run grove install.sh to create default policy");
+      console.error("Run the installer to create the default policy.");
       process.exit(1);
     }
 

--- a/src/taps/cc-events/relay.ts
+++ b/src/taps/cc-events/relay.ts
@@ -117,7 +117,7 @@ async function runRetentionSweep(): Promise<void> {
   const totalDeleted = raw.deleted + pub.deleted;
   if (totalCompressed > 0 || totalDeleted > 0) {
     console.log(
-      `grove-relay: retention sweep — compressed ${totalCompressed} file(s), ` +
+      `cortex-relay: retention sweep — compressed ${totalCompressed} file(s), ` +
       `deleted ${totalDeleted} archive(s) (raw: ${COMPRESS_AFTER_DAYS}d→gz, ${DELETE_AFTER_DAYS}d→delete)`
     );
   }
@@ -128,7 +128,7 @@ async function runRetentionSweep(): Promise<void> {
 // =============================================================================
 
 const program = new Command()
-  .name("grove-relay")
+  .name("cortex-relay")
   .description("PAI event relay — filters raw events to published events")
   .version("0.1.0");
 
@@ -186,7 +186,7 @@ program
         natsLink = await NatsLink.connect({
           url: natsUrl,
           token: natsToken,
-          name: "grove-relay",
+          name: "cortex-relay",
         });
         onPublished = createCcEventPublisher({
           link: natsLink,
@@ -194,13 +194,13 @@ program
         });
         const safeUrl = natsUrl.replace(/\/\/[^@/]+@/, "//***@");
         console.log(
-          `grove-relay: nats publishing enabled — ${safeUrl} (org="${org}")`,
+          `cortex-relay: nats publishing enabled — ${safeUrl} (org="${org}")`,
         );
       } catch (err) {
         // Per the design rule: failed NATS startup must NOT crash the
         // relay's primary archival job. Log and continue JSONL-only.
         console.error(
-          `grove-relay: nats startup failed — continuing without bus publishing: ${
+          `cortex-relay: nats startup failed — continuing without bus publishing: ${
             err instanceof Error ? err.message : err
           }`,
         );
@@ -217,7 +217,7 @@ program
     // Run retention sweep on startup (removes stale JSONL files)
     runRetentionSweep();
 
-    console.log("grove-relay: starting...");
+    console.log("cortex-relay: starting...");
     console.log(`  Policy: ${options.policy}`);
     console.log(`  Raw:    ${RAW_DIR} (${COMPRESS_AFTER_DAYS}d→gz, ${DELETE_AFTER_DAYS}d→delete)`);
     console.log(`  Pub:    ${PUBLISHED_DIR} (${COMPRESS_AFTER_DAYS}d→gz, ${DELETE_AFTER_DAYS}d→delete)`);
@@ -252,7 +252,7 @@ program
 
     // Handle shutdown
     const shutdown = async () => {
-      console.log("\ngrove-relay: shutting down...");
+      console.log("\ncortex-relay: shutting down...");
       cleanup();
       clearInterval(interval);
       clearInterval(retentionInterval);
@@ -261,7 +261,7 @@ program
           await natsLink.close();
         } catch (err) {
           console.error(
-            `grove-relay: nats close error: ${err instanceof Error ? err.message : err}`,
+            `cortex-relay: nats close error: ${err instanceof Error ? err.message : err}`,
           );
         }
       }
@@ -272,7 +272,7 @@ program
     process.on("SIGINT", () => { shutdown().catch(() => process.exit(1)); });
     process.on("SIGTERM", () => { shutdown().catch(() => process.exit(1)); });
 
-    console.log("grove-relay: daemon started (Ctrl+C to stop)");
+    console.log("cortex-relay: daemon started (Ctrl+C to stop)");
   });
 
 program
@@ -280,7 +280,7 @@ program
   .description("Stop the relay daemon")
   .action(() => {
     if (!existsSync(PID_FILE)) {
-      console.log("grove-relay: not running (no PID file)");
+      console.log("cortex-relay: not running (no PID file)");
       return;
     }
 
@@ -288,9 +288,9 @@ program
     try {
       process.kill(pid, "SIGTERM");
       unlinkSync(PID_FILE);
-      console.log(`grove-relay: stopped (PID ${pid})`);
+      console.log(`cortex-relay: stopped (PID ${pid})`);
     } catch {
-      console.log(`grove-relay: process ${pid} not found, cleaning up PID file`);
+      console.log(`cortex-relay: process ${pid} not found, cleaning up PID file`);
       unlinkSync(PID_FILE);
     }
   });
@@ -300,16 +300,16 @@ program
   .description("Check relay status")
   .action(() => {
     if (!existsSync(PID_FILE)) {
-      console.log("grove-relay: not running");
+      console.log("cortex-relay: not running");
       return;
     }
 
     const pid = parseInt(readFileSync(PID_FILE, "utf-8").trim());
     try {
       process.kill(pid, 0); // Check if process exists
-      console.log(`grove-relay: running (PID ${pid})`);
+      console.log(`cortex-relay: running (PID ${pid})`);
     } catch {
-      console.log("grove-relay: stale PID file (not running)");
+      console.log("cortex-relay: stale PID file (not running)");
       unlinkSync(PID_FILE);
     }
   });


### PR DESCRIPTION
## What

Closes the deferred MIG-7.6b checkbox from cortex#9 (Echo round-1 m2 on cortex#17 flagged it). Mechanical rename of the cc-events relay from operator-facing `grove-relay` name to cortex-internal `cortex-relay`.

## Changes

- `src/taps/cc-events/grove-relay.ts` → `src/taps/cc-events/relay.ts` (git mv; 92% similarity, history preserved)
- Commander program: `.name("grove-relay")` → `.name("cortex-relay")`
- NATS client identity: `name: "grove-relay"` → `"cortex-relay"`
- 15 user-visible log strings updated across:
  - `src/taps/cc-events/relay.ts` (12 log strings: retention, nats startup, daemon lifecycle, stop/status)
  - `src/taps/cc-events/cc-events.ts` (1 log + 2 architecture doc-comments)
  - `src/taps/cc-events/lib/event-processor.ts` (1 onPublished hook error log)
  - `src/taps/cc-events/lib/jsonl-reader.ts` (1 malformed-line warn)
- `src/services/com.cortex.relay.plist`:
  - `ProgramArguments[1]` script path: `grove-relay.ts` → `relay.ts` (required — old path no longer exists)
  - `StandardOutPath`: `grove-relay.log` → `cortex-relay.log`
  - `StandardErrorPath`: `grove-relay.error.log` → `cortex-relay.error.log`

## Out of scope

Per plan §4 7.6b coordination note:

- **MIG-7.7** — `arc-manifest.yaml` `provides:` update + symlink coexistence (`~/bin/grove-relay` ↔ `~/bin/cortex-relay`) during operator cutover
- **MIG-7.8** — launchd deployed-plist rename + atomic load/unload sequence

These land in their own PRs.

## Verification

- `bunx tsc --noEmit` → exit 0
- `bun test src/taps/cc-events/` → 127/127 pass
- Full cortex suite → 1804 pass / 1 fail (pre-existing `mission-control > serves the React dashboard shell on GET /` — the MIG-2 deferred test per Luna stocktake)
- `grep -rn "grove-relay" src/ docs/architecture.md README.md CHANGELOG.md CLAUDE.md arc-manifest.yaml` → no remaining refs

## Plan grounding

`docs/plan-cortex-migration.md` §4 MIG-7.6b. Closes the deferred checkbox.

Refs cortex#9 (MIG-7 umbrella).

🤖 Generated with [Claude Code](https://claude.com/claude-code)