### PR TITLE
feat(common): C-108.x — AgentRegistry over CortexConfig (MIG-7.2a)

### DIFF
--- a/src/common/agents/__tests__/registry.test.ts
+++ b/src/common/agents/__tests__/registry.test.ts
@@ -14,6 +14,7 @@
 import { describe, test, expect } from "bun:test";
 
 import {
+  AgentNotFoundError,
   AgentRegistry,
   DuplicateAgentIdError,
   UnknownAgentReferenceError,
@@ -106,10 +107,11 @@ function cortexConfigFixture(agents: Agent[]): CortexConfig {
 // =============================================================================
 
 describe("AgentRegistry.fromConfig", () => {
-  test("builds an empty registry path is illegal — CortexConfig requires ≥1 agent (schema layer)", () => {
-    // Defensive: even bypassing the schema, the registry handles zero agents
-    // by simply having size === 0. The schema is the gatekeeper for the
-    // "≥1 agent" rule (architecture §9.1). The registry doesn't re-enforce it.
+  test("zero-agent registries are tolerated at the registry layer", () => {
+    // The schema (CortexConfigSchema.agents.min(1)) is the gatekeeper for
+    // the architecture §9.1 "≥1 agent" rule. The registry itself does not
+    // re-enforce it — passing `[]` directly to `fromAgents` is legal so
+    // tests can construct empty registries without setting up a full config.
     const registry = AgentRegistry.fromAgents([]);
     expect(registry.size).toBe(0);
     expect(registry.getAll()).toEqual([]);
@@ -200,8 +202,22 @@ describe("AgentRegistry.getById / tryGetById", () => {
     expect(registry.getById("luna").id).toBe("luna");
   });
 
-  test("getById throws for an unknown id", () => {
-    expect(() => registry.getById("ghost")).toThrow(UnknownAgentReferenceError);
+  test("getById throws AgentNotFoundError for an unknown id (Holly W1)", () => {
+    // Previous revision reused UnknownAgentReferenceError with a
+    // `"<caller>"` placeholder fromAgent — misleading because plain lookup
+    // has no trust-relationship semantics. AgentNotFoundError is a dedicated
+    // class with just the offending id.
+    let err: unknown;
+    try {
+      registry.getById("ghost");
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(AgentNotFoundError);
+    expect(err).not.toBeInstanceOf(UnknownAgentReferenceError);
+    expect((err as AgentNotFoundError).id).toBe("ghost");
+    expect((err as AgentNotFoundError).name).toBe("AgentNotFoundError");
+    expect((err as AgentNotFoundError).message).toBe('no agent registered with id "ghost"');
   });
 
   test("tryGetById returns the agent for a known id", () => {
@@ -241,9 +257,9 @@ describe("AgentRegistry.getTrustedPeers", () => {
     expect(registry.getTrustedPeers("luna").map((a) => a.id)).toEqual(["echo"]);
   });
 
-  test("throws if the agent itself is unknown", () => {
+  test("throws AgentNotFoundError if the agent itself is unknown", () => {
     const registry = AgentRegistry.fromAgents([agentFixture({ id: "luna" })]);
-    expect(() => registry.getTrustedPeers("ghost")).toThrow(UnknownAgentReferenceError);
+    expect(() => registry.getTrustedPeers("ghost")).toThrow(AgentNotFoundError);
   });
 });
 
@@ -305,6 +321,55 @@ describe("AgentRegistry — immutability", () => {
     sourceAgents.push(agentFixture({ id: "holly" }));
     expect(registry.size).toBe(2);
     expect(registry.tryGetById("holly")).toBeUndefined();
+  });
+
+  test("agent objects returned by getById are deep-frozen (Holly W2)", () => {
+    // Previous revision shallow-froze the array but not the agents
+    // themselves — a downstream `registry.getById("luna").trust.push("x")`
+    // would silently bypass the trust closure invariant. Deep-freeze
+    // closes the gap.
+    const registry = AgentRegistry.fromAgents([
+      agentFixture({ id: "luna", roles: ["operator"], trust: [] }),
+    ]);
+    const luna = registry.getById("luna");
+    expect(Object.isFrozen(luna)).toBe(true);
+    expect(Object.isFrozen(luna.trust)).toBe(true);
+    expect(Object.isFrozen(luna.roles)).toBe(true);
+    expect(Object.isFrozen(luna.presence)).toBe(true);
+    if (luna.presence.discord) {
+      expect(Object.isFrozen(luna.presence.discord)).toBe(true);
+    }
+  });
+
+  test("attempted mutation of an agent's trust array fails in strict mode", () => {
+    // Bun's test runner runs ESM modules in strict mode by default, so
+    // pushing onto a frozen array throws. This is the load-bearing
+    // assertion for the deep-freeze guarantee.
+    const registry = AgentRegistry.fromAgents([
+      agentFixture({ id: "luna", trust: [] }),
+    ]);
+    const luna = registry.getById("luna");
+    expect(() => {
+      (luna.trust as string[]).push("evil");
+    }).toThrow();
+  });
+
+  test("attempted mutation of an agent's presence block fails in strict mode", () => {
+    const registry = AgentRegistry.fromAgents([
+      agentFixture({ id: "luna" }),
+    ]);
+    const luna = registry.getById("luna");
+    expect(() => {
+      (luna.presence as { discord?: unknown }).discord = undefined;
+    }).toThrow();
+  });
+
+  test("deep-freezing an already-frozen agent is a no-op (idempotent)", () => {
+    // Tests sometimes pass already-frozen Agents back through fromAgents
+    // (e.g. when building a registry from another registry's getAll()).
+    // Re-freezing must not throw.
+    const base = AgentRegistry.fromAgents([agentFixture({ id: "luna" })]);
+    expect(() => AgentRegistry.fromAgents(base.getAll())).not.toThrow();
   });
 });
 

--- a/src/common/agents/__tests__/registry.test.ts
+++ b/src/common/agents/__tests__/registry.test.ts
@@ -1,0 +1,343 @@
+/**
+ * MIG-7.2a — Agent registry tests.
+ *
+ * Covers:
+ *   - Construction from parsed CortexConfig and from raw Agent[] arrays
+ *   - Trust closure validation (forward refs, missing refs, self-trust)
+ *   - Strict + soft lookup semantics
+ *   - getTrustedPeers — resolves to Agent objects, filters self-trust
+ *   - `trusts(a, b)` — explicit + self-trust
+ *   - Immutability — the registry surface refuses mutation
+ *   - Order preservation — config order matches getAll() order
+ */
+
+import { describe, test, expect } from "bun:test";
+
+import {
+  AgentRegistry,
+  DuplicateAgentIdError,
+  UnknownAgentReferenceError,
+} from "../registry";
+import type { Agent, CortexConfig } from "../../types/cortex-config";
+
+// =============================================================================
+// Fixture builders
+// =============================================================================
+
+function discordPresence() {
+  return {
+    enabled: true,
+    token: "discord-bot-token",
+    guildId: "1487000000000000000",
+    agentChannelId: "1487000000000000001",
+    logChannelId: "1487000000000000002",
+    contextDepth: 10,
+    enableAgentLog: false,
+    roles: [],
+    defaultRole: "allow-all",
+    dm: {
+      operatorRole: {
+        features: ["chat", "async", "team"] as const,
+        disallowedTools: [],
+        bashGuard: true,
+      },
+      defaultRole: "denied" as const,
+      userRoles: [],
+    },
+  };
+}
+
+function agentFixture(overrides: Partial<Agent> = {}): Agent {
+  return {
+    id: "luna",
+    displayName: "Luna",
+    persona: "./personas/luna.md",
+    roles: [],
+    trust: [],
+    presence: { discord: discordPresence() },
+    ...overrides,
+  } as Agent;
+}
+
+function cortexConfigFixture(agents: Agent[]): CortexConfig {
+  return {
+    operator: {
+      id: "andreas",
+      dataResidency: "NZ",
+    },
+    agents,
+    renderers: [],
+    claude: {
+      timeoutMs: 120_000,
+      asyncTimeoutMs: 900_000,
+      additionalArgs: [],
+      allowedTools: [],
+      disallowedTools: [],
+      allowedDirs: [],
+      readOnlyDirs: [],
+    },
+    attachments: {
+      enabled: true,
+      maxFileSizeBytes: 10 * 1024 * 1024,
+      maxTotalSizeBytes: 25 * 1024 * 1024,
+      maxAttachmentsPerMessage: 10,
+    },
+    execution: { default: "local", backends: [] },
+    github: {
+      webhookSecret: "",
+      repos: [],
+      agentDetection: {
+        commitTrailers: ["Co-Authored-By: Claude"],
+        branchPatterns: ["^feat/(g|f|i)-\\d+"],
+        commentPatterns: ["^Starting:", "^Completed:"],
+      },
+    },
+    paths: {
+      publishedEventsDir: "~/.claude/events/published",
+      logDir: "~/.config/cortex/logs",
+    },
+    networksDir: "./networks",
+    networks: [],
+  } as CortexConfig;
+}
+
+// =============================================================================
+// Construction
+// =============================================================================
+
+describe("AgentRegistry.fromConfig", () => {
+  test("builds an empty registry path is illegal — CortexConfig requires ≥1 agent (schema layer)", () => {
+    // Defensive: even bypassing the schema, the registry handles zero agents
+    // by simply having size === 0. The schema is the gatekeeper for the
+    // "≥1 agent" rule (architecture §9.1). The registry doesn't re-enforce it.
+    const registry = AgentRegistry.fromAgents([]);
+    expect(registry.size).toBe(0);
+    expect(registry.getAll()).toEqual([]);
+  });
+
+  test("builds registry from CortexConfig", () => {
+    const config = cortexConfigFixture([
+      agentFixture({ id: "luna", displayName: "Luna" }),
+      agentFixture({ id: "echo", displayName: "Echo" }),
+    ]);
+    const registry = AgentRegistry.fromConfig(config);
+    expect(registry.size).toBe(2);
+    expect(registry.getById("luna").displayName).toBe("Luna");
+    expect(registry.getById("echo").displayName).toBe("Echo");
+  });
+
+  test("preserves config order in getAll()", () => {
+    const config = cortexConfigFixture([
+      agentFixture({ id: "luna" }),
+      agentFixture({ id: "echo" }),
+      agentFixture({ id: "holly" }),
+      agentFixture({ id: "ivy" }),
+    ]);
+    const registry = AgentRegistry.fromConfig(config);
+    expect(registry.getAll().map((a) => a.id)).toEqual(["luna", "echo", "holly", "ivy"]);
+  });
+
+  test("rejects duplicate agent ids at registry layer (defence-in-depth)", () => {
+    expect(() => AgentRegistry.fromAgents([
+      agentFixture({ id: "luna" }),
+      agentFixture({ id: "luna", displayName: "Luna 2" }),
+    ])).toThrow(DuplicateAgentIdError);
+  });
+});
+
+// =============================================================================
+// Trust closure validation
+// =============================================================================
+
+describe("AgentRegistry — trust closure", () => {
+  test("accepts forward references (luna trusts echo, echo defined later)", () => {
+    expect(() => AgentRegistry.fromAgents([
+      agentFixture({ id: "luna", trust: ["echo"] }),
+      agentFixture({ id: "echo" }),
+    ])).not.toThrow();
+  });
+
+  test("throws UnknownAgentReferenceError on missing trust target", () => {
+    let thrown: unknown;
+    try {
+      AgentRegistry.fromAgents([
+        agentFixture({ id: "luna", trust: ["ghost"] }),
+      ]);
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(UnknownAgentReferenceError);
+    expect((thrown as UnknownAgentReferenceError).fromAgent).toBe("luna");
+    expect((thrown as UnknownAgentReferenceError).unresolvedId).toBe("ghost");
+    expect((thrown as Error).message).toMatch(/trust:\[\] must be a known agent id/);
+  });
+
+  test("allows self-trust at construction time", () => {
+    expect(() => AgentRegistry.fromAgents([
+      agentFixture({ id: "luna", trust: ["luna"] }),
+    ])).not.toThrow();
+  });
+
+  test("trust closure is validated across all agents (not just first)", () => {
+    expect(() => AgentRegistry.fromAgents([
+      agentFixture({ id: "luna", trust: ["echo"] }),
+      agentFixture({ id: "echo", trust: ["holly"] }), // ← holly missing
+    ])).toThrow(/echo.*holly/s);
+  });
+});
+
+// =============================================================================
+// Lookup semantics
+// =============================================================================
+
+describe("AgentRegistry.getById / tryGetById", () => {
+  const registry = AgentRegistry.fromAgents([
+    agentFixture({ id: "luna" }),
+    agentFixture({ id: "echo" }),
+  ]);
+
+  test("getById returns the agent for a known id", () => {
+    expect(registry.getById("luna").id).toBe("luna");
+  });
+
+  test("getById throws for an unknown id", () => {
+    expect(() => registry.getById("ghost")).toThrow(UnknownAgentReferenceError);
+  });
+
+  test("tryGetById returns the agent for a known id", () => {
+    expect(registry.tryGetById("luna")?.id).toBe("luna");
+  });
+
+  test("tryGetById returns undefined for an unknown id", () => {
+    expect(registry.tryGetById("ghost")).toBeUndefined();
+  });
+});
+
+// =============================================================================
+// getTrustedPeers
+// =============================================================================
+
+describe("AgentRegistry.getTrustedPeers", () => {
+  test("resolves trust ids to Agent objects in declaration order", () => {
+    const registry = AgentRegistry.fromAgents([
+      agentFixture({ id: "luna", trust: ["echo", "holly"] }),
+      agentFixture({ id: "echo" }),
+      agentFixture({ id: "holly" }),
+    ]);
+    const peers = registry.getTrustedPeers("luna");
+    expect(peers.map((a) => a.id)).toEqual(["echo", "holly"]);
+  });
+
+  test("returns empty array for an agent with no trust list", () => {
+    const registry = AgentRegistry.fromAgents([agentFixture({ id: "luna" })]);
+    expect(registry.getTrustedPeers("luna")).toEqual([]);
+  });
+
+  test("filters out self-trust", () => {
+    const registry = AgentRegistry.fromAgents([
+      agentFixture({ id: "luna", trust: ["luna", "echo"] }),
+      agentFixture({ id: "echo" }),
+    ]);
+    expect(registry.getTrustedPeers("luna").map((a) => a.id)).toEqual(["echo"]);
+  });
+
+  test("throws if the agent itself is unknown", () => {
+    const registry = AgentRegistry.fromAgents([agentFixture({ id: "luna" })]);
+    expect(() => registry.getTrustedPeers("ghost")).toThrow(UnknownAgentReferenceError);
+  });
+});
+
+// =============================================================================
+// trusts(a, b)
+// =============================================================================
+
+describe("AgentRegistry.trusts", () => {
+  const registry = AgentRegistry.fromAgents([
+    agentFixture({ id: "luna", trust: ["echo", "holly"] }),
+    agentFixture({ id: "echo", trust: [] }),
+    agentFixture({ id: "holly", trust: [] }),
+  ]);
+
+  test("returns true for an explicit trust relationship", () => {
+    expect(registry.trusts("luna", "echo")).toBe(true);
+    expect(registry.trusts("luna", "holly")).toBe(true);
+  });
+
+  test("returns false when truster does not trust trusted", () => {
+    expect(registry.trusts("echo", "luna")).toBe(false);
+    expect(registry.trusts("echo", "holly")).toBe(false);
+  });
+
+  test("returns true for self-trust (each agent trusts itself)", () => {
+    expect(registry.trusts("luna", "luna")).toBe(true);
+    expect(registry.trusts("echo", "echo")).toBe(true);
+  });
+
+  test("returns false when truster is unknown", () => {
+    expect(registry.trusts("ghost", "luna")).toBe(false);
+  });
+
+  test("returns false when trusted is unknown but truster is known", () => {
+    // Trust closure validation at fromConfig prevents this state normally,
+    // but the method handles it defensively.
+    expect(registry.trusts("luna", "ghost")).toBe(false);
+  });
+});
+
+// =============================================================================
+// Immutability
+// =============================================================================
+
+describe("AgentRegistry — immutability", () => {
+  test("getAll() result is frozen", () => {
+    const registry = AgentRegistry.fromAgents([agentFixture({ id: "luna" })]);
+    const all = registry.getAll();
+    expect(Object.isFrozen(all)).toBe(true);
+  });
+
+  test("registry survives external mutation of source array", () => {
+    const sourceAgents = [
+      agentFixture({ id: "luna" }),
+      agentFixture({ id: "echo" }),
+    ];
+    const registry = AgentRegistry.fromAgents(sourceAgents);
+    // Mutate the source array externally — the registry must not reflect it.
+    sourceAgents.push(agentFixture({ id: "holly" }));
+    expect(registry.size).toBe(2);
+    expect(registry.tryGetById("holly")).toBeUndefined();
+  });
+});
+
+// =============================================================================
+// Error class identity
+// =============================================================================
+
+describe("AgentRegistry — error classes", () => {
+  test("UnknownAgentReferenceError carries fromAgent + unresolvedId fields", () => {
+    let err: unknown;
+    try {
+      AgentRegistry.fromAgents([agentFixture({ id: "luna", trust: ["ghost"] })]);
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(UnknownAgentReferenceError);
+    expect(err).toBeInstanceOf(Error);
+    expect((err as UnknownAgentReferenceError).name).toBe("UnknownAgentReferenceError");
+    expect((err as UnknownAgentReferenceError).fromAgent).toBe("luna");
+    expect((err as UnknownAgentReferenceError).unresolvedId).toBe("ghost");
+  });
+
+  test("DuplicateAgentIdError carries the duplicated id", () => {
+    let err: unknown;
+    try {
+      AgentRegistry.fromAgents([
+        agentFixture({ id: "luna" }),
+        agentFixture({ id: "luna" }),
+      ]);
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(DuplicateAgentIdError);
+    expect((err as DuplicateAgentIdError).id).toBe("luna");
+  });
+});

--- a/src/common/agents/registry.ts
+++ b/src/common/agents/registry.ts
@@ -1,0 +1,217 @@
+/**
+ * MIG-7.2a — Agent registry.
+ *
+ * Given a parsed `CortexConfig`, the registry builds an immutable lookup
+ * keyed by agent id. Each entry exposes the static identity bundle
+ * (`{ id, displayName, persona, roles, trust, presence }`) plus the helper
+ * methods presence adapters and the runner need at startup:
+ *
+ *   - `getById(id)`           — strict lookup; throws if unknown
+ *   - `tryGetById(id)`        — soft lookup; returns undefined
+ *   - `getAll()`              — iteration order matches config order
+ *   - `getTrustedPeers(id)`   — resolve an agent's `trust:` list to Agent
+ *                                objects; throws if any unresolved
+ *   - `withPlatformId(...)`   — extension point for the trust-resolver
+ *                                (MIG-7.2b); returns a registry view that
+ *                                also knows platform user ids
+ *
+ * Architecture §9.3 rules enforced at construction:
+ *
+ *   1. Trust entries MUST resolve — every id in any agent's `trust:` list
+ *      MUST be a known agent in the registry. Unknown ids surface here,
+ *      not later when an inbound message arrives from a peer.
+ *   2. Self-trust is silently allowed — an agent trusting itself is a no-op
+ *      but isn't a config bug worth refusing the deployment over. (Self-
+ *      trust is filtered out of `getTrustedPeers()` so callers don't have
+ *      to special-case the bot's own messages.)
+ *   3. The registry is immutable — `Object.freeze` on the index keeps
+ *      downstream code from mutating in flight.
+ *
+ * NOT in scope for 7.2a:
+ *
+ *   - Platform user id ↔ agent id mapping (`platformId → agentId`) — that
+ *     lives in `trust-resolver.ts` per MIG-7.2b. Presence adapters register
+ *     their own user id at connect time, and the resolver maintains the
+ *     process-wide bidirectional map.
+ *   - Persona file loading — `persona` here is the path string from
+ *     CortexConfig; loading the markdown is the presence adapter's job
+ *     when it builds its agent context.
+ *   - Role/capability resolution — `roles` is the string list from config;
+ *     the role → capability bundle mapping lives elsewhere (G-121 etc.).
+ */
+
+import type { Agent, CortexConfig } from "../types/cortex-config";
+
+// =============================================================================
+// Public surface
+// =============================================================================
+
+/**
+ * Thrown when a trust reference cannot be resolved at registry construction.
+ * The error carries the offending agent + the unresolved id so the operator
+ * sees exactly which line of cortex.yaml is wrong.
+ */
+export class UnknownAgentReferenceError extends Error {
+  readonly fromAgent: string;
+  readonly unresolvedId: string;
+
+  constructor(fromAgent: string, unresolvedId: string) {
+    super(
+      `agent "${fromAgent}" trusts "${unresolvedId}", but no agent with that id is registered. ` +
+        `Check the agents[] block in cortex.yaml — every entry in trust:[] must be a known agent id.`,
+    );
+    this.name = "UnknownAgentReferenceError";
+    this.fromAgent = fromAgent;
+    this.unresolvedId = unresolvedId;
+  }
+}
+
+/**
+ * Thrown when `AgentRegistry.fromConfig` is called with duplicate agent ids.
+ * Zod's `CortexConfigSchema` already catches this at parse time, but the
+ * registry double-checks to remain safe when callers bypass schema parse
+ * (e.g. in tests that hand-build an `Agent[]` array).
+ */
+export class DuplicateAgentIdError extends Error {
+  readonly id: string;
+
+  constructor(id: string) {
+    super(`duplicate agent id "${id}" — agent ids must be unique`);
+    this.name = "DuplicateAgentIdError";
+    this.id = id;
+  }
+}
+
+/**
+ * The agent registry — immutable lookup over a parsed cortex config.
+ *
+ * Build via the static factory `AgentRegistry.fromConfig(config)`; never
+ * `new AgentRegistry(...)` directly. The factory is the only place that
+ * validates the trust closure; constructing a registry from a hand-built
+ * agent array (via `fromAgents([...])`) is also supported for tests.
+ */
+export class AgentRegistry {
+  /**
+   * Iteration order matches the order agents appear in `cortex.yaml`. Stable
+   * across registry rebuilds (no sorting, no re-keying). Downstream code that
+   * cares about ordering (e.g. the dashboard's actor-column layout) can rely
+   * on this.
+   */
+  readonly agents: readonly Agent[];
+
+  private readonly index: ReadonlyMap<string, Agent>;
+
+  private constructor(agents: readonly Agent[], index: ReadonlyMap<string, Agent>) {
+    this.agents = agents;
+    this.index = index;
+  }
+
+  /**
+   * Build a registry from a parsed CortexConfig. Validates the trust closure
+   * — every id mentioned in any `trust:` list must match a registered agent.
+   */
+  static fromConfig(config: CortexConfig): AgentRegistry {
+    return AgentRegistry.fromAgents(config.agents);
+  }
+
+  /**
+   * Build a registry from a raw agent array. Validates uniqueness + trust
+   * closure. Used by `fromConfig` and directly by tests.
+   */
+  static fromAgents(agents: readonly Agent[]): AgentRegistry {
+    const index = new Map<string, Agent>();
+    for (const agent of agents) {
+      if (index.has(agent.id)) {
+        throw new DuplicateAgentIdError(agent.id);
+      }
+      index.set(agent.id, agent);
+    }
+
+    // Validate trust closure AFTER all agents are indexed, so forward
+    // references (luna trusts echo, echo defined later) work cleanly.
+    for (const agent of agents) {
+      for (const trustedId of agent.trust) {
+        if (!index.has(trustedId)) {
+          throw new UnknownAgentReferenceError(agent.id, trustedId);
+        }
+      }
+    }
+
+    return new AgentRegistry(Object.freeze([...agents]), index);
+  }
+
+  /**
+   * Strict lookup. Throws if no agent with that id is registered. Use this
+   * when you've already validated the id (e.g. it came from a parsed
+   * envelope's `actor.agent_id`) and an unknown id is a bug, not a normal
+   * branch.
+   */
+  getById(id: string): Agent {
+    const agent = this.index.get(id);
+    if (!agent) {
+      throw new UnknownAgentReferenceError("<caller>", id);
+    }
+    return agent;
+  }
+
+  /**
+   * Soft lookup. Returns `undefined` for unknown ids. Use this when the id
+   * may legitimately be unknown (e.g. probing whether an inbound platform
+   * id corresponds to a registered agent before deciding how to route).
+   */
+  tryGetById(id: string): Agent | undefined {
+    return this.index.get(id);
+  }
+
+  /**
+   * Enumerate all registered agents in config order.
+   */
+  getAll(): readonly Agent[] {
+    return this.agents;
+  }
+
+  /**
+   * Number of registered agents. Cheap shorthand.
+   */
+  get size(): number {
+    return this.agents.length;
+  }
+
+  /**
+   * Resolve an agent's `trust:` list to Agent objects. Self-trust entries
+   * (an agent trusting its own id) are filtered out — they're harmless in
+   * config but would cause downstream code to double-process the bot's own
+   * messages. Throws `UnknownAgentReferenceError` if any trusted id is not
+   * registered, even though `fromConfig` already validates this — the second
+   * check guards against callers who hand-mutated an agent's trust array
+   * after registry construction.
+   */
+  getTrustedPeers(id: string): Agent[] {
+    const agent = this.getById(id);
+    const peers: Agent[] = [];
+    for (const trustedId of agent.trust) {
+      if (trustedId === id) {
+        // Self-trust: filter out silently per architecture §9.3 rationale.
+        continue;
+      }
+      const peer = this.index.get(trustedId);
+      if (!peer) {
+        throw new UnknownAgentReferenceError(id, trustedId);
+      }
+      peers.push(peer);
+    }
+    return peers;
+  }
+
+  /**
+   * Whether `truster` trusts `trusted`. Self-trust returns `true` (an agent
+   * trusts itself transitively; this matters for routing inbound messages
+   * the bot wrote itself).
+   */
+  trusts(truster: string, trusted: string): boolean {
+    if (truster === trusted) return true;
+    const trusterAgent = this.tryGetById(truster);
+    if (!trusterAgent) return false;
+    return trusterAgent.trust.includes(trusted);
+  }
+}

--- a/src/common/agents/registry.ts
+++ b/src/common/agents/registry.ts
@@ -6,14 +6,12 @@
  * (`{ id, displayName, persona, roles, trust, presence }`) plus the helper
  * methods presence adapters and the runner need at startup:
  *
- *   - `getById(id)`           — strict lookup; throws if unknown
+ *   - `getById(id)`           — strict lookup; throws `AgentNotFoundError`
  *   - `tryGetById(id)`        — soft lookup; returns undefined
  *   - `getAll()`              — iteration order matches config order
  *   - `getTrustedPeers(id)`   — resolve an agent's `trust:` list to Agent
  *                                objects; throws if any unresolved
- *   - `withPlatformId(...)`   — extension point for the trust-resolver
- *                                (MIG-7.2b); returns a registry view that
- *                                also knows platform user ids
+ *   - `trusts(truster, trusted)` — boolean trust check (self-trust → true)
  *
  * Architecture §9.3 rules enforced at construction:
  *
@@ -50,6 +48,9 @@ import type { Agent, CortexConfig } from "../types/cortex-config";
  * Thrown when a trust reference cannot be resolved at registry construction.
  * The error carries the offending agent + the unresolved id so the operator
  * sees exactly which line of cortex.yaml is wrong.
+ *
+ * NOT used for plain `getById` misses — that's `AgentNotFoundError` with no
+ * trust-relationship implication.
  */
 export class UnknownAgentReferenceError extends Error {
   readonly fromAgent: string;
@@ -63,6 +64,21 @@ export class UnknownAgentReferenceError extends Error {
     this.name = "UnknownAgentReferenceError";
     this.fromAgent = fromAgent;
     this.unresolvedId = unresolvedId;
+  }
+}
+
+/**
+ * Thrown by `AgentRegistry.getById` when an id has no matching agent. Plain
+ * lookup miss; no trust-relationship implication. Use `tryGetById` if a miss
+ * is a normal branch in your code path.
+ */
+export class AgentNotFoundError extends Error {
+  readonly id: string;
+
+  constructor(id: string) {
+    super(`no agent registered with id "${id}"`);
+    this.name = "AgentNotFoundError";
+    this.id = id;
   }
 }
 
@@ -117,19 +133,30 @@ export class AgentRegistry {
   /**
    * Build a registry from a raw agent array. Validates uniqueness + trust
    * closure. Used by `fromConfig` and directly by tests.
+   *
+   * **Deep immutability:** each agent is recursively frozen before being
+   * indexed so a downstream `registry.getById("luna").trust.push("evil")`
+   * fails in strict mode rather than silently bypassing the trust closure
+   * invariant that the constructor validated. The defensive copy of the
+   * outer array further isolates the registry from external mutation of
+   * the source.
    */
   static fromAgents(agents: readonly Agent[]): AgentRegistry {
+    const frozen: Agent[] = [];
     const index = new Map<string, Agent>();
-    for (const agent of agents) {
-      if (index.has(agent.id)) {
-        throw new DuplicateAgentIdError(agent.id);
+
+    for (const raw of agents) {
+      if (index.has(raw.id)) {
+        throw new DuplicateAgentIdError(raw.id);
       }
+      const agent = deepFreezeAgent(raw);
+      frozen.push(agent);
       index.set(agent.id, agent);
     }
 
     // Validate trust closure AFTER all agents are indexed, so forward
     // references (luna trusts echo, echo defined later) work cleanly.
-    for (const agent of agents) {
+    for (const agent of frozen) {
       for (const trustedId of agent.trust) {
         if (!index.has(trustedId)) {
           throw new UnknownAgentReferenceError(agent.id, trustedId);
@@ -137,19 +164,19 @@ export class AgentRegistry {
       }
     }
 
-    return new AgentRegistry(Object.freeze([...agents]), index);
+    return new AgentRegistry(Object.freeze(frozen), index);
   }
 
   /**
-   * Strict lookup. Throws if no agent with that id is registered. Use this
-   * when you've already validated the id (e.g. it came from a parsed
-   * envelope's `actor.agent_id`) and an unknown id is a bug, not a normal
-   * branch.
+   * Strict lookup. Throws `AgentNotFoundError` if no agent with that id is
+   * registered. Use this when you've already validated the id (e.g. it
+   * came from a parsed envelope's `actor.agent_id`) and an unknown id is
+   * a bug, not a normal branch.
    */
   getById(id: string): Agent {
     const agent = this.index.get(id);
     if (!agent) {
-      throw new UnknownAgentReferenceError("<caller>", id);
+      throw new AgentNotFoundError(id);
     }
     return agent;
   }
@@ -181,10 +208,14 @@ export class AgentRegistry {
    * Resolve an agent's `trust:` list to Agent objects. Self-trust entries
    * (an agent trusting its own id) are filtered out — they're harmless in
    * config but would cause downstream code to double-process the bot's own
-   * messages. Throws `UnknownAgentReferenceError` if any trusted id is not
-   * registered, even though `fromConfig` already validates this — the second
-   * check guards against callers who hand-mutated an agent's trust array
-   * after registry construction.
+   * messages.
+   *
+   * Throws `AgentNotFoundError` if `id` itself is unknown.
+   * Throws `UnknownAgentReferenceError` if any trusted id is not registered.
+   * The second check is defence-in-depth — `fromAgents` already validates
+   * the trust closure, and deep-freezing each agent prevents mutation, so
+   * this branch is structurally unreachable in production. Kept for tests
+   * that bypass the factory or call from unfrozen contexts.
    */
   getTrustedPeers(id: string): Agent[] {
     const agent = this.getById(id);
@@ -214,4 +245,28 @@ export class AgentRegistry {
     if (!trusterAgent) return false;
     return trusterAgent.trust.includes(trusted);
   }
+}
+
+// =============================================================================
+// Private helpers
+// =============================================================================
+
+/**
+ * Recursively freeze an Agent and its nested mutable surfaces (`trust`,
+ * `roles`, and the per-platform `presence` blocks). Closes Holly's
+ * shallow-freeze warning — without this, a downstream
+ * `registry.getById("luna").trust.push("evil")` would succeed and silently
+ * bypass the trust-closure invariant the constructor validated.
+ *
+ * Re-freezing an already-frozen object is a no-op, so calling this twice
+ * (e.g. tests that pass an already-frozen Agent into `fromAgents`) is safe.
+ */
+function deepFreezeAgent(agent: Agent): Agent {
+  Object.freeze(agent.trust);
+  Object.freeze(agent.roles);
+  if (agent.presence.discord) Object.freeze(agent.presence.discord);
+  if (agent.presence.mattermost) Object.freeze(agent.presence.mattermost);
+  Object.freeze(agent.presence);
+  Object.freeze(agent);
+  return agent;
 }


### PR DESCRIPTION
## What

The agent registry sits between the parsed CortexConfig (MIG-7.2 base, just merged in cortex#40) and the downstream presence-adapter (MIG-7.2c) and runner (MIG-7.2b) consumers.

Given the \`agents: []\` block from a parsed config, the registry builds an immutable lookup keyed by agent id and validates the trust closure — every id any agent trusts must resolve to a known agent.

## Public surface

\`\`\`ts
class AgentRegistry {
  static fromConfig(config: CortexConfig): AgentRegistry;
  static fromAgents(agents: readonly Agent[]): AgentRegistry;
  getById(id: string): Agent;          // strict; throws UnknownAgentReferenceError
  tryGetById(id: string): Agent | undefined;  // soft
  getAll(): readonly Agent[];          // frozen, config-order
  getTrustedPeers(id: string): Agent[]; // filters self-trust
  trusts(truster: string, trusted: string): boolean;
  readonly size: number;
  readonly agents: readonly Agent[];
}
\`\`\`

## Architecture §9.3 rules enforced

1. **Trust closure** — every \`trust:[]\` entry must resolve to a known agent. \`UnknownAgentReferenceError\` carries \`fromAgent\` + \`unresolvedId\` fields so the operator sees the bad line.
2. **Forward references work** — luna trusts echo, echo defined later in the YAML — both validated in a two-pass build.
3. **Self-trust silently allowed** — \`getTrustedPeers\` filters it out so callers don't double-process the bot's own messages.
4. **Immutable surface** — \`Object.freeze\` on the agents array, defensive copy in \`fromAgents\` so external mutation of the source array doesn't leak in.

## Custom error classes

- \`UnknownAgentReferenceError(fromAgent, unresolvedId)\` — typed fields for downstream operator-message rendering
- \`DuplicateAgentIdError(id)\` — defence-in-depth (Zod catches at parse; registry re-checks for tests bypassing the schema)

## Out of scope (deferred per plan §4)

- **MIG-7.2b** — \`platformId → agentId\` trust-resolver. Presence adapters register their own user id at connect time; resolver maintains the process-wide bidirectional map.
- **MIG-7.2c** — adapter refactor to consume \`Agent\` objects (\`new DiscordPresenceAdapter(agent, presence)\`).
- Persona file loading — \`agent.persona\` is a path string here; loading markdown is the presence adapter's job.
- Role → capability bundle resolution — \`agent.roles\` is a string list; the mapping lives elsewhere (G-121).

## Verification

- \`bunx tsc --noEmit\` → **exit 0**
- \`bun test src/common/agents/__tests__/registry.test.ts\` → **25/25 pass**
- Full cortex suite → **1904 pass / 1 fail** (pre-existing MIG-2 React-shell test, unrelated)

## Plan grounding

\`docs/plan-cortex-migration.md\` §4 MIG-7.2a. \`docs/architecture.md\` §9.3 (trust by agent id, immutable identity bundle).

Refs cortex#9 (MIG-7 umbrella), follows cortex#40 (MIG-7.2 base).

🤖 Generated with [Claude Code](https://claude.com/claude-code)