### PR TITLE
feat(common): C-108.x — TrustResolver — platformId ↔ agentId map (MIG-7.2b)

### DIFF
--- a/src/common/agents/__tests__/trust-resolver.test.ts
+++ b/src/common/agents/__tests__/trust-resolver.test.ts
@@ -1,0 +1,328 @@
+/**
+ * MIG-7.2b — TrustResolver tests.
+ *
+ * Covers:
+ *   - Construction over an AgentRegistry
+ *   - register / unregister semantics + idempotent reconnect
+ *   - Fail-closed: unknown agent id at register throws AgentNotFoundError
+ *   - Identity-claim refusal: re-register to a different agent throws
+ *   - Forward + reverse lookup helpers
+ *   - Full trust check by platform identity (the actual call path
+ *     receiving adapters use)
+ *   - Multi-platform per agent (Discord + Mattermost simultaneously)
+ *   - Unregister cleanup (forward + reverse indexes drop entries)
+ */
+
+import { describe, test, expect, beforeEach } from "bun:test";
+
+import {
+  AgentNotFoundError,
+  AgentRegistry,
+} from "../registry";
+import {
+  PlatformIdAlreadyRegisteredError,
+  TrustResolver,
+  type Platform,
+} from "../trust-resolver";
+import type { Agent } from "../../types/cortex-config";
+
+// =============================================================================
+// Fixtures
+// =============================================================================
+
+function discordPresence() {
+  return {
+    enabled: true,
+    token: "discord-bot-token",
+    guildId: "1487000000000000000",
+    agentChannelId: "1487000000000000001",
+    logChannelId: "1487000000000000002",
+    contextDepth: 10,
+    enableAgentLog: false,
+    roles: [],
+    defaultRole: "allow-all",
+    dm: {
+      operatorRole: {
+        features: ["chat", "async", "team"] as const,
+        disallowedTools: [],
+        bashGuard: true,
+      },
+      defaultRole: "denied" as const,
+      userRoles: [],
+    },
+  };
+}
+
+function agentFixture(overrides: Partial<Agent> = {}): Agent {
+  return {
+    id: "luna",
+    displayName: "Luna",
+    persona: "./personas/luna.md",
+    roles: [],
+    trust: [],
+    presence: { discord: discordPresence() },
+    ...overrides,
+  } as Agent;
+}
+
+function registryOf(...agents: Agent[]): AgentRegistry {
+  return AgentRegistry.fromAgents(agents);
+}
+
+// Some plausible-looking platform ids — these are just strings to the
+// resolver, no validation against Discord snowflake format.
+const LUNA_DISCORD_ID = "1487100000000000001";
+const ECHO_DISCORD_ID = "1487100000000000002";
+const HOLLY_DISCORD_ID = "1487100000000000003";
+const LUNA_MATTERMOST_ID = "luna-mm-userid-abc123";
+
+// =============================================================================
+// Construction
+// =============================================================================
+
+describe("TrustResolver — construction", () => {
+  test("empty resolver has size 0", () => {
+    const resolver = new TrustResolver(registryOf(agentFixture({ id: "luna" })));
+    expect(resolver.size).toBe(0);
+  });
+
+  test("backing registry is exposed via getRegistry()", () => {
+    const registry = registryOf(agentFixture({ id: "luna" }));
+    const resolver = new TrustResolver(registry);
+    expect(resolver.getRegistry()).toBe(registry);
+  });
+});
+
+// =============================================================================
+// register / unregister
+// =============================================================================
+
+describe("TrustResolver.register", () => {
+  let resolver: TrustResolver;
+
+  beforeEach(() => {
+    resolver = new TrustResolver(registryOf(
+      agentFixture({ id: "luna" }),
+      agentFixture({ id: "echo" }),
+    ));
+  });
+
+  test("registers a new platform identity", () => {
+    resolver.register("discord", LUNA_DISCORD_ID, "luna");
+    expect(resolver.size).toBe(1);
+    expect(resolver.lookupAgentId("discord", LUNA_DISCORD_ID)).toBe("luna");
+  });
+
+  test("rejects registration for unknown agent id (fail-closed §9.3)", () => {
+    expect(() => resolver.register("discord", LUNA_DISCORD_ID, "ghost"))
+      .toThrow(AgentNotFoundError);
+    expect(resolver.size).toBe(0);
+  });
+
+  test("idempotent: re-registering the same agent is a silent no-op", () => {
+    resolver.register("discord", LUNA_DISCORD_ID, "luna");
+    expect(() => resolver.register("discord", LUNA_DISCORD_ID, "luna")).not.toThrow();
+    expect(resolver.size).toBe(1);
+  });
+
+  test("rejects claiming a registered platform id for a different agent", () => {
+    resolver.register("discord", LUNA_DISCORD_ID, "luna");
+    let err: unknown;
+    try {
+      resolver.register("discord", LUNA_DISCORD_ID, "echo");
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(PlatformIdAlreadyRegisteredError);
+    expect((err as PlatformIdAlreadyRegisteredError).existingAgentId).toBe("luna");
+    expect((err as PlatformIdAlreadyRegisteredError).attemptedAgentId).toBe("echo");
+    expect((err as PlatformIdAlreadyRegisteredError).platform).toBe("discord");
+    expect((err as PlatformIdAlreadyRegisteredError).platformId).toBe(LUNA_DISCORD_ID);
+    // Original mapping is preserved.
+    expect(resolver.lookupAgentId("discord", LUNA_DISCORD_ID)).toBe("luna");
+  });
+
+  test("same platform id across different platforms is OK", () => {
+    // A Discord id and a Mattermost id could collide as strings (unlikely
+    // but valid). Treat them as different identities.
+    resolver.register("discord", "1487", "luna");
+    resolver.register("mattermost", "1487", "echo");
+    expect(resolver.lookupAgentId("discord", "1487")).toBe("luna");
+    expect(resolver.lookupAgentId("mattermost", "1487")).toBe("echo");
+  });
+
+  test("one agent can own multiple platform identities", () => {
+    resolver.register("discord", LUNA_DISCORD_ID, "luna");
+    resolver.register("mattermost", LUNA_MATTERMOST_ID, "luna");
+    expect(resolver.size).toBe(2);
+    const owned = resolver.identitiesOf("luna");
+    expect(owned).toContainEqual({ platform: "discord", platformId: LUNA_DISCORD_ID });
+    expect(owned).toContainEqual({ platform: "mattermost", platformId: LUNA_MATTERMOST_ID });
+  });
+});
+
+describe("TrustResolver.unregister", () => {
+  let resolver: TrustResolver;
+
+  beforeEach(() => {
+    resolver = new TrustResolver(registryOf(agentFixture({ id: "luna" })));
+    resolver.register("discord", LUNA_DISCORD_ID, "luna");
+  });
+
+  test("removes the forward mapping", () => {
+    resolver.unregister("discord", LUNA_DISCORD_ID);
+    expect(resolver.lookupAgentId("discord", LUNA_DISCORD_ID)).toBeUndefined();
+    expect(resolver.size).toBe(0);
+  });
+
+  test("removes the reverse mapping for the affected agent", () => {
+    resolver.unregister("discord", LUNA_DISCORD_ID);
+    expect(resolver.identitiesOf("luna")).toEqual([]);
+  });
+
+  test("unregistering an unknown pair is a silent no-op", () => {
+    expect(() => resolver.unregister("discord", "unregistered-id")).not.toThrow();
+    expect(resolver.size).toBe(1); // existing luna mapping intact
+  });
+
+  test("unregistering one of an agent's multiple identities leaves the others", () => {
+    resolver.register("mattermost", LUNA_MATTERMOST_ID, "luna");
+    resolver.unregister("discord", LUNA_DISCORD_ID);
+    expect(resolver.identitiesOf("luna")).toEqual([
+      { platform: "mattermost", platformId: LUNA_MATTERMOST_ID },
+    ]);
+  });
+});
+
+// =============================================================================
+// Lookup helpers
+// =============================================================================
+
+describe("TrustResolver — lookup", () => {
+  let resolver: TrustResolver;
+
+  beforeEach(() => {
+    resolver = new TrustResolver(registryOf(
+      agentFixture({ id: "luna" }),
+      agentFixture({ id: "echo" }),
+    ));
+    resolver.register("discord", LUNA_DISCORD_ID, "luna");
+  });
+
+  test("lookupAgentId returns the agent id for a registered pair", () => {
+    expect(resolver.lookupAgentId("discord", LUNA_DISCORD_ID)).toBe("luna");
+  });
+
+  test("lookupAgentId returns undefined for an unregistered pair", () => {
+    expect(resolver.lookupAgentId("discord", "unknown-id")).toBeUndefined();
+    expect(resolver.lookupAgentId("mattermost", LUNA_DISCORD_ID)).toBeUndefined();
+  });
+
+  test("lookupAgent returns the full Agent object", () => {
+    const luna = resolver.lookupAgent("discord", LUNA_DISCORD_ID);
+    expect(luna?.id).toBe("luna");
+    expect(luna?.displayName).toBe("Luna");
+  });
+
+  test("lookupAgent returns undefined for an unregistered pair", () => {
+    expect(resolver.lookupAgent("discord", "unknown-id")).toBeUndefined();
+  });
+
+  test("identitiesOf returns [] for an agent with no registrations", () => {
+    expect(resolver.identitiesOf("echo")).toEqual([]);
+  });
+
+  test("identitiesOf returns [] for an unknown agent", () => {
+    expect(resolver.identitiesOf("ghost")).toEqual([]);
+  });
+});
+
+// =============================================================================
+// trustsByPlatformId — the load-bearing call from receiving adapters
+// =============================================================================
+
+describe("TrustResolver.trustsByPlatformId", () => {
+  test("true when receiver's agent trusts the sender's agent", () => {
+    const resolver = new TrustResolver(registryOf(
+      agentFixture({ id: "echo", trust: ["luna"] }),
+      agentFixture({ id: "luna" }),
+    ));
+    resolver.register("discord", LUNA_DISCORD_ID, "luna");
+    expect(resolver.trustsByPlatformId("echo", "discord", LUNA_DISCORD_ID)).toBe(true);
+  });
+
+  test("false when receiver's agent does not trust the sender", () => {
+    const resolver = new TrustResolver(registryOf(
+      agentFixture({ id: "echo", trust: [] }),
+      agentFixture({ id: "luna" }),
+    ));
+    resolver.register("discord", LUNA_DISCORD_ID, "luna");
+    expect(resolver.trustsByPlatformId("echo", "discord", LUNA_DISCORD_ID)).toBe(false);
+  });
+
+  test("false when the sender platform id is unregistered (human message)", () => {
+    const resolver = new TrustResolver(registryOf(
+      agentFixture({ id: "echo", trust: ["luna"] }),
+      agentFixture({ id: "luna" }),
+    ));
+    // No register call — the sender is a human Discord user, not an agent.
+    expect(resolver.trustsByPlatformId("echo", "discord", "human-user-id")).toBe(false);
+  });
+
+  test("false when the receiver agent itself is unknown", () => {
+    const resolver = new TrustResolver(registryOf(
+      agentFixture({ id: "luna" }),
+    ));
+    resolver.register("discord", LUNA_DISCORD_ID, "luna");
+    expect(resolver.trustsByPlatformId("ghost-receiver", "discord", LUNA_DISCORD_ID)).toBe(false);
+  });
+
+  test("self-trust resolves correctly across the platform-id layer", () => {
+    // luna sends to herself via Discord → trustsByPlatformId("luna", ...) is true
+    const resolver = new TrustResolver(registryOf(agentFixture({ id: "luna" })));
+    resolver.register("discord", LUNA_DISCORD_ID, "luna");
+    expect(resolver.trustsByPlatformId("luna", "discord", LUNA_DISCORD_ID)).toBe(true);
+  });
+
+  test("multi-trust: luna trusts both echo and holly via discord", () => {
+    const resolver = new TrustResolver(registryOf(
+      agentFixture({ id: "luna", trust: ["echo", "holly"] }),
+      agentFixture({ id: "echo" }),
+      agentFixture({ id: "holly" }),
+    ));
+    resolver.register("discord", ECHO_DISCORD_ID, "echo");
+    resolver.register("discord", HOLLY_DISCORD_ID, "holly");
+    expect(resolver.trustsByPlatformId("luna", "discord", ECHO_DISCORD_ID)).toBe(true);
+    expect(resolver.trustsByPlatformId("luna", "discord", HOLLY_DISCORD_ID)).toBe(true);
+  });
+
+  test("respects platform isolation: discord trust ≠ mattermost trust", () => {
+    const resolver = new TrustResolver(registryOf(
+      agentFixture({ id: "echo", trust: ["luna"] }),
+      agentFixture({ id: "luna" }),
+    ));
+    // Register luna only on Discord. Mattermost id for luna is not registered.
+    resolver.register("discord", LUNA_DISCORD_ID, "luna");
+    expect(resolver.trustsByPlatformId("echo", "discord", LUNA_DISCORD_ID)).toBe(true);
+    // Same id on mattermost → not registered → false.
+    expect(resolver.trustsByPlatformId("echo", "mattermost", LUNA_DISCORD_ID)).toBe(false);
+  });
+});
+
+// =============================================================================
+// Platform key encoding — defensive against id strings containing the separator
+// =============================================================================
+
+describe("TrustResolver — platform key encoding", () => {
+  test("platform ids containing |  are unambiguously parsed (defence-in-depth)", () => {
+    // Discord/Mattermost ids never contain `|`, but if a future platform
+    // does, the parseKey logic splits on the FIRST `|` so a `|` in the
+    // platformId portion survives.
+    const resolver = new TrustResolver(registryOf(agentFixture({ id: "luna" })));
+    const weirdId = "abc|def|ghi";
+    resolver.register("discord" as Platform, weirdId, "luna");
+    expect(resolver.lookupAgentId("discord", weirdId)).toBe("luna");
+    const owned = resolver.identitiesOf("luna");
+    expect(owned).toEqual([{ platform: "discord", platformId: weirdId }]);
+  });
+});

--- a/src/common/agents/trust-resolver.ts
+++ b/src/common/agents/trust-resolver.ts
@@ -1,0 +1,280 @@
+/**
+ * MIG-7.2b — Trust resolver.
+ *
+ * Process-wide bidirectional `(platform, platformUserId) ↔ agentId` map. Sits
+ * atop the AgentRegistry (MIG-7.2a) — the registry is the authoritative
+ * agent source, the resolver layers the platform-id mapping on top.
+ *
+ * Architecture §9.3 ("Coupling discipline"):
+ *
+ *   > Cross-agent trust resolves at adapter startup: each presence adapter,
+ *   > on connect, learns its own platform user id (e.g. `discord.client.user.id`)
+ *   > and registers it in a process-wide `(platformId → agentId)` map. When
+ *   > an inbound message arrives from a known platform id, the receiving
+ *   > adapter looks up the source agent and consults its parent's `trust:` list.
+ *
+ * This module owns that map. It replaces grove-v2's hand-maintained
+ * `trustedAgentBots` list (an array of platform user ids that the operator
+ * manually kept in sync). The resolver builds the equivalent state from
+ * adapter-connect-time registrations — no manual sync, no drift.
+ *
+ * ## Lifecycle
+ *
+ *   1. Cortex boot:        `new TrustResolver(registry)`  (no platform IDs yet)
+ *   2. Discord adapter for Luna connects:
+ *                          `resolver.register("discord", "1487...", "luna")`
+ *   3. Inbound message from `1487...`:
+ *                          `resolver.lookupAgentByPlatformId("discord", "1487...")`
+ *                          → returns the Luna Agent
+ *   4. Receiving adapter (Echo) checks trust:
+ *                          `resolver.trustsByPlatformId("echo", "discord", "1487...")`
+ *                          → true iff echo.trust includes luna
+ *   5. Discord adapter for Luna disconnects:
+ *                          `resolver.unregister("discord", "1487...")`
+ *
+ * ## Invariants
+ *
+ *   - A given `(platform, platformId)` maps to **at most one** agent at a
+ *     time. Re-registering the same pair to a different agent throws
+ *     `PlatformIdAlreadyRegisteredError` so a misconfigured presence
+ *     adapter doesn't silently steal another agent's identity.
+ *   - An agent can have multiple platform identities (e.g. Discord +
+ *     Mattermost simultaneously). The reverse index `agentId →
+ *     Set<{platform, platformId}>` carries them all.
+ *   - `register` requires the target agent id to be a known agent in the
+ *     backing registry. Unknown ids throw — fail-closed per §9.3 ("A
+ *     presence adapter MUST refuse to start if its parent agent's id is
+ *     missing from the registry").
+ *
+ * ## NOT in scope for 7.2b
+ *
+ *   - Adapter refactor — `DiscordPresenceAdapter(agent, presence)` lands at
+ *     MIG-7.2c. The resolver is callable by today's adapters via a shim if
+ *     useful, but the new constructor shape isn't enforced here.
+ *   - Persistence — the resolver is in-memory. Cortex restart re-registers
+ *     all platform ids when adapters reconnect; there's no SQLite-backed
+ *     cache. (If reconnect storms become a problem post-MIG-7, revisit.)
+ *   - Cross-process state — single-process only. Multi-shard cortex isn't a
+ *     v1 concern.
+ */
+
+import type { Agent } from "../types/cortex-config";
+import { AgentNotFoundError, AgentRegistry } from "./registry";
+
+// =============================================================================
+// Public types
+// =============================================================================
+
+/**
+ * Known platform names. Constrained to the platforms cortex actually supports
+ * — adding a new platform requires adding the value here AND a presence-block
+ * variant in `cortex-config.ts`.
+ */
+export type Platform = "discord" | "mattermost";
+
+/** A `(platform, platformId)` pair that uniquely identifies a connected presence. */
+export interface PlatformIdentity {
+  readonly platform: Platform;
+  readonly platformId: string;
+}
+
+// =============================================================================
+// Errors
+// =============================================================================
+
+/**
+ * Thrown when `register` would overwrite an existing mapping with a
+ * different agent. Re-registering the same agent for the same platform id
+ * is a no-op (idempotent reconnect); claiming someone else's id throws so a
+ * misconfigured token doesn't silently steal another agent's identity.
+ */
+export class PlatformIdAlreadyRegisteredError extends Error {
+  readonly platform: Platform;
+  readonly platformId: string;
+  readonly existingAgentId: string;
+  readonly attemptedAgentId: string;
+
+  constructor(
+    platform: Platform,
+    platformId: string,
+    existingAgentId: string,
+    attemptedAgentId: string,
+  ) {
+    super(
+      `platform identity ${platform}:${platformId} is already registered to agent ` +
+        `"${existingAgentId}" — refusing to claim it for "${attemptedAgentId}". ` +
+        `Check that the Discord/Mattermost token belongs to the expected bot account.`,
+    );
+    this.name = "PlatformIdAlreadyRegisteredError";
+    this.platform = platform;
+    this.platformId = platformId;
+    this.existingAgentId = existingAgentId;
+    this.attemptedAgentId = attemptedAgentId;
+  }
+}
+
+// =============================================================================
+// TrustResolver
+// =============================================================================
+
+/**
+ * Process-wide map between platform user ids and agent ids, backed by an
+ * AgentRegistry. Mutable — adapters register on connect, unregister on
+ * disconnect. Single-process; no persistence.
+ */
+export class TrustResolver {
+  private readonly registry: AgentRegistry;
+
+  /** Forward: `${platform}:${platformId}` → agentId */
+  private readonly forward = new Map<string, string>();
+
+  /** Reverse: agentId → Set<`${platform}:${platformId}`> */
+  private readonly reverse = new Map<string, Set<string>>();
+
+  constructor(registry: AgentRegistry) {
+    this.registry = registry;
+  }
+
+  /**
+   * Register a platform identity for an agent. Called by presence adapters
+   * on connect with their freshly-learned platform user id.
+   *
+   * @throws AgentNotFoundError if `agentId` is not in the backing registry.
+   * @throws PlatformIdAlreadyRegisteredError if the `(platform, platformId)`
+   *         pair is already registered to a *different* agent. Re-registering
+   *         the same agent is idempotent (no-op).
+   */
+  register(platform: Platform, platformId: string, agentId: string): void {
+    // Validate agent existence — fail-closed per architecture §9.3.
+    if (!this.registry.tryGetById(agentId)) {
+      throw new AgentNotFoundError(agentId);
+    }
+
+    const key = makeKey(platform, platformId);
+    const existing = this.forward.get(key);
+    if (existing) {
+      if (existing === agentId) {
+        // Idempotent reconnect — silently OK.
+        return;
+      }
+      throw new PlatformIdAlreadyRegisteredError(platform, platformId, existing, agentId);
+    }
+
+    this.forward.set(key, agentId);
+    let owned = this.reverse.get(agentId);
+    if (!owned) {
+      owned = new Set();
+      this.reverse.set(agentId, owned);
+    }
+    owned.add(key);
+  }
+
+  /**
+   * Remove a platform identity registration. Called by presence adapters on
+   * graceful disconnect. Silently no-op on unknown pairs (avoids spurious
+   * errors during shutdown races).
+   */
+  unregister(platform: Platform, platformId: string): void {
+    const key = makeKey(platform, platformId);
+    const agentId = this.forward.get(key);
+    if (!agentId) return;
+    this.forward.delete(key);
+    const owned = this.reverse.get(agentId);
+    if (owned) {
+      owned.delete(key);
+      if (owned.size === 0) this.reverse.delete(agentId);
+    }
+  }
+
+  /**
+   * Reverse lookup: given a platform user id, return the registered agent
+   * id (or undefined). The caller usually pairs this with
+   * `registry.getById(agentId)` to get the full Agent object.
+   */
+  lookupAgentId(platform: Platform, platformId: string): string | undefined {
+    return this.forward.get(makeKey(platform, platformId));
+  }
+
+  /**
+   * Reverse lookup: given a platform user id, return the registered Agent
+   * (or undefined). Convenience wrapper combining `lookupAgentId` and the
+   * registry.
+   */
+  lookupAgent(platform: Platform, platformId: string): Agent | undefined {
+    const agentId = this.lookupAgentId(platform, platformId);
+    if (!agentId) return undefined;
+    return this.registry.tryGetById(agentId);
+  }
+
+  /**
+   * Forward lookup: given an agent id, return all platform identities it has
+   * registered. Order is registration order. Returns `[]` for unknown or
+   * unregistered agents.
+   */
+  identitiesOf(agentId: string): PlatformIdentity[] {
+    const owned = this.reverse.get(agentId);
+    if (!owned) return [];
+    const out: PlatformIdentity[] = [];
+    for (const key of owned) {
+      const [platform, platformId] = parseKey(key);
+      out.push({ platform, platformId });
+    }
+    return out;
+  }
+
+  /**
+   * Full trust check by platform identity. Returns true iff:
+   *   1. The `(platform, platformId)` is registered to a known agent.
+   *   2. `receivingAgentId` is a known agent.
+   *   3. `receivingAgent.trust` includes the sender's agent id
+   *      (OR sender and receiver are the same agent — self-trust is
+   *      transitive, matching `AgentRegistry.trusts`).
+   *
+   * Returns false (not throws) for any unknown identity, so the receiving
+   * adapter can fall back to human-message handling without a try/catch.
+   */
+  trustsByPlatformId(
+    receivingAgentId: string,
+    senderPlatform: Platform,
+    senderPlatformId: string,
+  ): boolean {
+    const senderAgentId = this.lookupAgentId(senderPlatform, senderPlatformId);
+    if (!senderAgentId) return false;
+    return this.registry.trusts(receivingAgentId, senderAgentId);
+  }
+
+  /**
+   * The backing registry. Exposed for callers that need the full Agent
+   * object alongside the platform-id mapping (e.g. presence adapters that
+   * fetch personas after resolving the sender).
+   */
+  getRegistry(): AgentRegistry {
+    return this.registry;
+  }
+
+  /** Number of currently-registered platform identities (debug + tests). */
+  get size(): number {
+    return this.forward.size;
+  }
+}
+
+// =============================================================================
+// Private — key encoding
+// =============================================================================
+
+/**
+ * Encode a `(platform, platformId)` pair into a Map key. Separator chosen to
+ * avoid collision with Discord/Mattermost id characters (digits + dashes for
+ * snowflakes, lowercase alphanumeric for Mattermost). `|` is reserved across
+ * both platforms.
+ */
+function makeKey(platform: Platform, platformId: string): string {
+  return `${platform}|${platformId}`;
+}
+
+function parseKey(key: string): [Platform, string] {
+  const sep = key.indexOf("|");
+  const platform = key.slice(0, sep) as Platform;
+  const platformId = key.slice(sep + 1);
+  return [platform, platformId];
+}


### PR DESCRIPTION
## What

Third PR in the MIG-7.2 sub-PR sequence after #40 (CortexConfig schema) and #42 (AgentRegistry).

The trust resolver owns the runtime bidirectional `(platform, platformUserId) ↔ agentId` map per architecture §9.3: "each presence adapter, on connect, learns its own platform user id … and registers it in a process-wide map."

Replaces grove-v2's hand-maintained `trustedAgentBots` list (operator-maintained array of Discord ids that drifted over time) with adapter-connect-time registrations — no manual sync, no drift.

## Public surface

```ts
class TrustResolver {
  constructor(registry: AgentRegistry);
  register(platform, platformId, agentId): void;       // fail-closed
  unregister(platform, platformId): void;              // silent no-op on unknown
  lookupAgentId(platform, platformId): string | undefined;
  lookupAgent(platform, platformId): Agent | undefined;
  identitiesOf(agentId): PlatformIdentity[];
  trustsByPlatformId(receivingId, senderPlatform, senderPlatformId): boolean;
  getRegistry(): AgentRegistry;
  readonly size: number;
}
```

`PlatformIdAlreadyRegisteredError` thrown on re-register-to-different-agent (carries `platform`, `platformId`, `existingAgentId`, `attemptedAgentId`). Idempotent re-register of the same agent is a silent no-op.

## Invariants

1. **At-most-one mapping per `(platform, platformId)`** — refuses identity theft
2. **Fail-closed on unknown agent** — `register("...", "ghost")` throws `AgentNotFoundError`
3. **Multi-platform per agent** — luna on Discord AND Mattermost both live; reverse index Set per agent
4. **Platform isolation** — same id string across platforms = two distinct identities

## Out of scope (deferred)

- **MIG-7.2c** — adapter refactor (`new DiscordPresenceAdapter(agent, presence)` constructor shape). Resolver is callable from today's adapters via a shim if useful; new shape not enforced here.
- Persistence — in-memory only; reconnect re-registers.
- Multi-process / multi-shard cortex — v1 single-process only.

## Verification

- `bunx tsc --noEmit` → **exit 0**
- `bun test src/common/agents/__tests__/trust-resolver.test.ts` → **26/26 pass**
- Full cortex suite → **1934 pass / 1 fail** (pre-existing MIG-2 fail, unrelated)

## Plan grounding

\`docs/plan-cortex-migration.md\` §4 MIG-7.2b. \`docs/architecture.md\` §9.3 (coupling discipline — trust resolves at adapter startup).

Refs cortex#9 (MIG-7 umbrella), follows cortex#42 (MIG-7.2a).

🤖 Generated with [Claude Code](https://claude.com/claude-code)