### PR TITLE
feat(common): C-108.x — PresenceBinding + getPlatformUserId on PlatformAdapter (MIG-7.2c-binding)

### DIFF
--- a/src/adapters/discord/index.ts
+++ b/src/adapters/discord/index.ts
@@ -295,6 +295,24 @@ export class DiscordAdapter implements PlatformAdapter {
   }
 
   /**
+   * MIG-7.2c-binding: Return the Discord snowflake of the bot account this
+   * adapter is logged in as. discord.js populates `client.user` after the
+   * `ready` event fires (which `start()` awaits via `client.login`). Calling
+   * this before `start()` completes — or after `stop()` — throws.
+   */
+  async getPlatformUserId(): Promise<string> {
+    const userId = this.client?.user?.id;
+    if (!userId) {
+      throw new Error(
+        `discord-adapter[${this.instanceId}]: getPlatformUserId() called ` +
+          `before start() completed or after stop() — client.user is null. ` +
+          `Ensure PresenceBinding awaits start() before binding.`,
+      );
+    }
+    return userId;
+  }
+
+  /**
    * F-092: Hot-reload safe config fields.
    * Only updates fields that don't require reconnection.
    */

--- a/src/adapters/mattermost/index.ts
+++ b/src/adapters/mattermost/index.ts
@@ -57,6 +57,8 @@ export class MattermostAdapter implements PlatformAdapter {
   private botConfig: BotConfig;
   private scopedConfig: BotConfig; // Config with mattermost scoped to this instance
   private adapterConfig: MattermostAdapterConfig;
+  /** MIG-7.2c-binding: lazily-fetched bot user id from `/api/v4/users/me`. */
+  private cachedPlatformUserId: string | null = null;
 
   constructor(adapterConfig: MattermostAdapterConfig, botConfig: BotConfig) {
     this.instanceId = adapterConfig.instanceId;
@@ -112,6 +114,46 @@ export class MattermostAdapter implements PlatformAdapter {
   async stop(): Promise<void> {
     this.stopPoller?.();
     this.stopPoller = null;
+    // Drop the cached id so a subsequent start() picks up the current
+    // /users/me — guards against a token swap between sessions.
+    this.cachedPlatformUserId = null;
+  }
+
+  /**
+   * MIG-7.2c-binding: Return the Mattermost user id of the bot account this
+   * adapter is connected as. Fetches `/api/v4/users/me` on first call and
+   * caches the result; subsequent calls are zero-RPC. Cache cleared on
+   * `stop()` so a token rotation between sessions re-fetches cleanly.
+   */
+  async getPlatformUserId(): Promise<string> {
+    if (this.cachedPlatformUserId) return this.cachedPlatformUserId;
+
+    const apiUrl = this.adapterConfig.apiUrl;
+    const apiToken = this.adapterConfig.apiToken;
+    if (!apiUrl || !apiToken) {
+      throw new Error(
+        `mattermost-adapter[${this.instanceId}]: getPlatformUserId() requires ` +
+          `apiUrl + apiToken on the adapter config.`,
+      );
+    }
+
+    const res = await fetch(`${apiUrl}/api/v4/users/me`, {
+      headers: { Authorization: `Bearer ${apiToken}` },
+    });
+    if (!res.ok) {
+      throw new Error(
+        `mattermost-adapter[${this.instanceId}]: GET /api/v4/users/me failed ` +
+          `with HTTP ${res.status} ${res.statusText}.`,
+      );
+    }
+    const me = (await res.json()) as { id?: string };
+    if (!me.id) {
+      throw new Error(
+        `mattermost-adapter[${this.instanceId}]: /api/v4/users/me returned no id field.`,
+      );
+    }
+    this.cachedPlatformUserId = me.id;
+    return me.id;
   }
 
   /**

--- a/src/adapters/mattermost/index.ts
+++ b/src/adapters/mattermost/index.ts
@@ -137,8 +137,13 @@ export class MattermostAdapter implements PlatformAdapter {
       );
     }
 
+    // Bound the startup-time call so a hung Mattermost server doesn't block
+    // PresenceBinding.startAndBind indefinitely. 10s is generous for a single
+    // /users/me round-trip; if the server is slower than that, startup
+    // failure with a clear error beats waiting forever (Holly W2 review).
     const res = await fetch(`${apiUrl}/api/v4/users/me`, {
       headers: { Authorization: `Bearer ${apiToken}` },
+      signal: AbortSignal.timeout(10_000),
     });
     if (!res.ok) {
       throw new Error(

--- a/src/adapters/mock.ts
+++ b/src/adapters/mock.ts
@@ -42,6 +42,8 @@ export class MockAdapter implements PlatformAdapter {
   accessDecision: AccessDecision = ALLOW_ALL;
   /** Configurable return value for fetchContext */
   contextMessages: ContextMessage[] = [];
+  /** MIG-7.2c-binding: Configurable return value for getPlatformUserId. Default `"mock-bot-user"`. */
+  platformUserId: string = "mock-bot-user";
   /** MIG-3b: Configurable subject patterns the surface face listens for. Default `mock.>`
    *  matches anything under `mock.*` for surface-router integration tests. */
   surfaceSubjects: string[] = ["mock.>"];
@@ -83,6 +85,10 @@ export class MockAdapter implements PlatformAdapter {
   async stop(): Promise<void> {
     this.started = false;
     this.onMessage = undefined;
+  }
+
+  async getPlatformUserId(): Promise<string> {
+    return this.platformUserId;
   }
 
   async fetchContext(_msg: InboundMessage, _depth: number): Promise<ContextMessage[]> {

--- a/src/adapters/types.ts
+++ b/src/adapters/types.ts
@@ -110,6 +110,19 @@ export interface PlatformAdapter {
   /** Disconnect and clean up resources */
   stop(): Promise<void>;
 
+  /**
+   * MIG-7.2c-binding: Return the platform user id of the bot account this
+   * adapter is connected as. Required for `PresenceBinding` to register the
+   * adapter with the process-wide `TrustResolver` so inbound messages from
+   * peer agents are resolvable by their platform id (§9.3).
+   *
+   * Contract: callable only after `start()` has completed. Adapters that
+   * learn their bot id at connect-time (e.g. Discord via `client.user`)
+   * MUST throw if called pre-start; adapters that fetch on demand (e.g.
+   * Mattermost via `/api/v4/users/me`) MAY cache the result.
+   */
+  getPlatformUserId(): Promise<string>;
+
   /** Fetch conversation history for context */
   fetchContext(msg: InboundMessage, depth: number): Promise<ContextMessage[]>;
   /** Check if the message author has access */

--- a/src/common/agents/__tests__/presence-binding.test.ts
+++ b/src/common/agents/__tests__/presence-binding.test.ts
@@ -1,0 +1,459 @@
+/**
+ * MIG-7.2c-binding — PresenceBinding tests.
+ *
+ * Covers the start-then-register / unregister-then-stop lifecycle, the
+ * unsupported-platform guard, the partial-failure rollback path, and the
+ * idempotent re-bind / unbind semantics. Uses an inline `FakeAdapter` that
+ * mimics enough of `PlatformAdapter` for the binding's purposes —
+ * MockAdapter has `platform = "mock"` which the binding rejects, so we
+ * need a fake that pretends to be discord/mattermost.
+ */
+
+import { describe, test, expect, beforeEach } from "bun:test";
+
+import {
+  AgentNotFoundError,
+  AgentRegistry,
+} from "../registry";
+import {
+  PresenceBinding,
+  UnsupportedPlatformError,
+} from "../presence-binding";
+import {
+  PlatformIdAlreadyRegisteredError,
+  TrustResolver,
+  type Platform,
+} from "../trust-resolver";
+import type { Agent } from "../../types/cortex-config";
+import type {
+  AccessDecision,
+  ContextMessage,
+  InboundMessage,
+  OutboundFile,
+  PlatformAdapter,
+  ResponseTarget,
+} from "../../../adapters/types";
+
+// =============================================================================
+// FakeAdapter — minimal PlatformAdapter that pretends to be `discord` or
+// `mattermost`. Tracks lifecycle calls so tests can assert on the order
+// the binding invokes start / getPlatformUserId / stop.
+// =============================================================================
+
+class FakeAdapter implements PlatformAdapter {
+  readonly platform: string;
+  readonly instanceId: string;
+  /** What `getPlatformUserId()` resolves to. */
+  platformUserId: string;
+  /** If non-null, `start()` rejects with this error. */
+  startError: Error | null = null;
+  /** If non-null, `getPlatformUserId()` rejects with this error. */
+  getPlatformUserIdError: Error | null = null;
+  /** If non-null, `stop()` rejects with this error. */
+  stopError: Error | null = null;
+
+  // Call recorders
+  readonly calls: string[] = [];
+
+  constructor(opts: {
+    platform: string;
+    instanceId?: string;
+    platformUserId?: string;
+  }) {
+    this.platform = opts.platform;
+    this.instanceId = opts.instanceId ?? `${opts.platform}-fake`;
+    this.platformUserId = opts.platformUserId ?? `${opts.platform}-bot-userid`;
+  }
+
+  async start(_onMessage: (msg: InboundMessage) => Promise<void>): Promise<void> {
+    this.calls.push("start");
+    if (this.startError) throw this.startError;
+  }
+
+  async stop(): Promise<void> {
+    this.calls.push("stop");
+    if (this.stopError) throw this.stopError;
+  }
+
+  async getPlatformUserId(): Promise<string> {
+    this.calls.push("getPlatformUserId");
+    if (this.getPlatformUserIdError) throw this.getPlatformUserIdError;
+    return this.platformUserId;
+  }
+
+  async fetchContext(_msg: InboundMessage, _depth: number): Promise<ContextMessage[]> {
+    return [];
+  }
+  resolveAccess(_msg: InboundMessage): AccessDecision {
+    return { allowed: true, features: { chat: true, async: true, team: true } };
+  }
+  async postResponse(_t: ResponseTarget, _text: string, _files?: OutboundFile[]) {}
+  async sendTyping(_t: ResponseTarget) {}
+  async sendProgress(_t: ResponseTarget, _text: string) {}
+  async clearProgress(_t: ResponseTarget) {}
+  async createThread(msg: InboundMessage, _name: string): Promise<ResponseTarget> {
+    return { instanceId: this.instanceId, channelId: msg.channelId };
+  }
+  async notifyOperator(_text: string) {}
+}
+
+// =============================================================================
+// Fixtures (registry + trust resolver)
+// =============================================================================
+
+function discordPresence() {
+  return {
+    enabled: true,
+    token: "discord-bot-token",
+    guildId: "1487000000000000000",
+    agentChannelId: "1487000000000000001",
+    logChannelId: "1487000000000000002",
+    contextDepth: 10,
+    enableAgentLog: false,
+    roles: [],
+    defaultRole: "allow-all",
+    dm: {
+      operatorRole: {
+        features: ["chat", "async", "team"] as const,
+        disallowedTools: [],
+        bashGuard: true,
+      },
+      defaultRole: "denied" as const,
+      userRoles: [],
+    },
+  };
+}
+
+function agentFixture(overrides: Partial<Agent> = {}): Agent {
+  return {
+    id: "luna",
+    displayName: "Luna",
+    persona: "./personas/luna.md",
+    roles: [],
+    trust: [],
+    presence: { discord: discordPresence() },
+    ...overrides,
+  } as Agent;
+}
+
+function noopMessageHandler(): (msg: InboundMessage) => Promise<void> {
+  return async () => {};
+}
+
+// =============================================================================
+// Construction
+// =============================================================================
+
+describe("PresenceBinding — construction", () => {
+  let registry: AgentRegistry;
+  let resolver: TrustResolver;
+
+  beforeEach(() => {
+    registry = AgentRegistry.fromAgents([agentFixture({ id: "luna" })]);
+    resolver = new TrustResolver(registry);
+  });
+
+  test("accepts a discord-platform adapter", () => {
+    const adapter = new FakeAdapter({ platform: "discord" });
+    const binding = new PresenceBinding("luna", adapter, resolver);
+    expect(binding.registeredPlatform).toBe("discord");
+    expect(binding.registeredAgentId).toBe("luna");
+    expect(binding.registeredPlatformId).toBeUndefined();
+  });
+
+  test("accepts a mattermost-platform adapter", () => {
+    const adapter = new FakeAdapter({ platform: "mattermost" });
+    const binding = new PresenceBinding("luna", adapter, resolver);
+    expect(binding.registeredPlatform).toBe("mattermost");
+  });
+
+  test("rejects an unknown platform with UnsupportedPlatformError", () => {
+    const adapter = new FakeAdapter({ platform: "mock" });
+    expect(() => new PresenceBinding("luna", adapter, resolver))
+      .toThrow(UnsupportedPlatformError);
+  });
+
+  test("UnsupportedPlatformError carries the offending platform and known list", () => {
+    const adapter = new FakeAdapter({ platform: "slack" });
+    try {
+      new PresenceBinding("luna", adapter, resolver);
+      throw new Error("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(UnsupportedPlatformError);
+      const e = err as UnsupportedPlatformError;
+      expect(e.platform).toBe("slack");
+      expect(e.knownPlatforms).toEqual(["discord", "mattermost"]);
+    }
+  });
+});
+
+// =============================================================================
+// startAndBind — happy path
+// =============================================================================
+
+describe("PresenceBinding.startAndBind", () => {
+  let registry: AgentRegistry;
+  let resolver: TrustResolver;
+
+  beforeEach(() => {
+    registry = AgentRegistry.fromAgents([
+      agentFixture({ id: "luna" }),
+      agentFixture({ id: "echo" }),
+    ]);
+    resolver = new TrustResolver(registry);
+  });
+
+  test("calls start → getPlatformUserId → register in order", async () => {
+    const adapter = new FakeAdapter({
+      platform: "discord",
+      platformUserId: "1487100000000000001",
+    });
+    const binding = new PresenceBinding("luna", adapter, resolver);
+
+    await binding.startAndBind(noopMessageHandler());
+
+    expect(adapter.calls).toEqual(["start", "getPlatformUserId"]);
+    expect(binding.registeredPlatformId).toBe("1487100000000000001");
+    expect(resolver.lookupAgentId("discord", "1487100000000000001")).toBe("luna");
+  });
+
+  test("registers under the constructor's agent id, not adapter.instanceId", async () => {
+    const adapter = new FakeAdapter({
+      platform: "discord",
+      instanceId: "this-is-not-the-agent-id",
+      platformUserId: "1487100000000000001",
+    });
+    const binding = new PresenceBinding("luna", adapter, resolver);
+
+    await binding.startAndBind(noopMessageHandler());
+
+    expect(resolver.lookupAgentId("discord", "1487100000000000001")).toBe("luna");
+  });
+
+  test("idempotent re-bind to the same platform user id is a no-op at the resolver", async () => {
+    const adapter = new FakeAdapter({
+      platform: "discord",
+      platformUserId: "1487100000000000001",
+    });
+    const binding = new PresenceBinding("luna", adapter, resolver);
+
+    await binding.startAndBind(noopMessageHandler());
+    // Second start of the SAME binding/adapter — TrustResolver.register is
+    // idempotent for same-agent re-registration, so this must not throw.
+    await binding.startAndBind(noopMessageHandler());
+
+    expect(resolver.size).toBe(1);
+    expect(resolver.lookupAgentId("discord", "1487100000000000001")).toBe("luna");
+  });
+
+  test("rejects when a different agent already owns the platform user id", async () => {
+    const adapter1 = new FakeAdapter({
+      platform: "discord",
+      platformUserId: "1487100000000000001",
+    });
+    const binding1 = new PresenceBinding("luna", adapter1, resolver);
+    await binding1.startAndBind(noopMessageHandler());
+
+    // Adapter2 has the SAME platform id but tries to bind as echo — identity-
+    // theft attempt. The trust resolver rejects this; the binding rolls back
+    // by stopping adapter2.
+    const adapter2 = new FakeAdapter({
+      platform: "discord",
+      platformUserId: "1487100000000000001",
+    });
+    const binding2 = new PresenceBinding("echo", adapter2, resolver);
+
+    await expect(binding2.startAndBind(noopMessageHandler())).rejects.toThrow(
+      PlatformIdAlreadyRegisteredError,
+    );
+    // Rollback: adapter2 was stopped despite the registration failure.
+    expect(adapter2.calls).toEqual(["start", "getPlatformUserId", "stop"]);
+    // The original luna mapping is untouched.
+    expect(resolver.lookupAgentId("discord", "1487100000000000001")).toBe("luna");
+  });
+});
+
+// =============================================================================
+// startAndBind — failure paths
+// =============================================================================
+
+describe("PresenceBinding.startAndBind — failure paths", () => {
+  let registry: AgentRegistry;
+  let resolver: TrustResolver;
+
+  beforeEach(() => {
+    registry = AgentRegistry.fromAgents([agentFixture({ id: "luna" })]);
+    resolver = new TrustResolver(registry);
+  });
+
+  test("adapter.start() failure → nothing registered, no rollback stop", async () => {
+    const adapter = new FakeAdapter({ platform: "discord" });
+    adapter.startError = new Error("connect refused");
+    const binding = new PresenceBinding("luna", adapter, resolver);
+
+    await expect(binding.startAndBind(noopMessageHandler())).rejects.toThrow("connect refused");
+
+    // start() failed before getPlatformUserId — so no rollback needed.
+    expect(adapter.calls).toEqual(["start"]);
+    expect(resolver.size).toBe(0);
+    expect(binding.registeredPlatformId).toBeUndefined();
+  });
+
+  test("getPlatformUserId() failure → adapter is stopped, error is re-thrown", async () => {
+    const adapter = new FakeAdapter({ platform: "discord" });
+    adapter.getPlatformUserIdError = new Error("client.user is null");
+    const binding = new PresenceBinding("luna", adapter, resolver);
+
+    await expect(binding.startAndBind(noopMessageHandler())).rejects.toThrow("client.user is null");
+
+    // Rollback: start succeeded, getPlatformUserId failed, stop() ran.
+    expect(adapter.calls).toEqual(["start", "getPlatformUserId", "stop"]);
+    expect(resolver.size).toBe(0);
+    expect(binding.registeredPlatformId).toBeUndefined();
+  });
+
+  test("register() failure on unknown agent → adapter is stopped, AgentNotFoundError re-thrown", async () => {
+    const adapter = new FakeAdapter({ platform: "discord" });
+    // "ghost" is not in the registry, so trustResolver.register throws.
+    const binding = new PresenceBinding("ghost", adapter, resolver);
+
+    await expect(binding.startAndBind(noopMessageHandler())).rejects.toThrow(AgentNotFoundError);
+
+    expect(adapter.calls).toEqual(["start", "getPlatformUserId", "stop"]);
+    expect(resolver.size).toBe(0);
+  });
+
+  test("stop() failure during rollback is suppressed; original error wins", async () => {
+    const adapter = new FakeAdapter({ platform: "discord" });
+    adapter.getPlatformUserIdError = new Error("primary failure");
+    adapter.stopError = new Error("stop also exploded");
+    const binding = new PresenceBinding("luna", adapter, resolver);
+
+    // The "primary failure" is the actionable one — stop errors during
+    // rollback would obscure it, so the binding swallows them.
+    await expect(binding.startAndBind(noopMessageHandler())).rejects.toThrow("primary failure");
+    expect(adapter.calls).toEqual(["start", "getPlatformUserId", "stop"]);
+  });
+});
+
+// =============================================================================
+// unbindAndStop
+// =============================================================================
+
+describe("PresenceBinding.unbindAndStop", () => {
+  let registry: AgentRegistry;
+  let resolver: TrustResolver;
+
+  beforeEach(() => {
+    registry = AgentRegistry.fromAgents([agentFixture({ id: "luna" })]);
+    resolver = new TrustResolver(registry);
+  });
+
+  test("happy path: unregister then stop", async () => {
+    const adapter = new FakeAdapter({
+      platform: "discord",
+      platformUserId: "1487100000000000001",
+    });
+    const binding = new PresenceBinding("luna", adapter, resolver);
+    await binding.startAndBind(noopMessageHandler());
+
+    await binding.unbindAndStop();
+
+    expect(adapter.calls).toEqual(["start", "getPlatformUserId", "stop"]);
+    expect(resolver.size).toBe(0);
+    expect(binding.registeredPlatformId).toBeUndefined();
+  });
+
+  test("idempotent — second unbind is a no-op", async () => {
+    const adapter = new FakeAdapter({
+      platform: "discord",
+      platformUserId: "1487100000000000001",
+    });
+    const binding = new PresenceBinding("luna", adapter, resolver);
+    await binding.startAndBind(noopMessageHandler());
+    await binding.unbindAndStop();
+    // Reset call log to assert second-call behavior cleanly.
+    adapter.calls.length = 0;
+
+    await binding.unbindAndStop();
+
+    // No platform id is registered anymore → no unregister call observable.
+    // The adapter is stopped a second time — explicit, predictable behavior.
+    expect(adapter.calls).toEqual(["stop"]);
+  });
+
+  test("safe to call when startAndBind was never called", async () => {
+    const adapter = new FakeAdapter({ platform: "discord" });
+    const binding = new PresenceBinding("luna", adapter, resolver);
+
+    await binding.unbindAndStop();
+
+    expect(adapter.calls).toEqual(["stop"]);
+    expect(resolver.size).toBe(0);
+  });
+
+  test("after rollback in startAndBind, unbindAndStop is still safe", async () => {
+    const adapter = new FakeAdapter({ platform: "discord" });
+    adapter.getPlatformUserIdError = new Error("client.user is null");
+    const binding = new PresenceBinding("luna", adapter, resolver);
+    await expect(binding.startAndBind(noopMessageHandler())).rejects.toThrow();
+
+    // Rollback already stopped the adapter and never registered. Calling
+    // unbindAndStop after that should not double-unregister or double-throw.
+    await binding.unbindAndStop();
+
+    // Second stop call (after rollback's first one) — the adapter records
+    // both, but the binding doesn't throw on the predictable second stop.
+    expect(adapter.calls).toEqual(["start", "getPlatformUserId", "stop", "stop"]);
+  });
+});
+
+// =============================================================================
+// Multi-platform per agent
+// =============================================================================
+
+describe("PresenceBinding — multi-platform per agent", () => {
+  test("an agent with discord + mattermost gets two bindings; both register", async () => {
+    const registry = AgentRegistry.fromAgents([agentFixture({ id: "luna" })]);
+    const resolver = new TrustResolver(registry);
+
+    const discordAdapter = new FakeAdapter({
+      platform: "discord",
+      platformUserId: "1487100000000000001",
+    });
+    const mattermostAdapter = new FakeAdapter({
+      platform: "mattermost",
+      platformUserId: "luna-mm-userid-abc123",
+    });
+
+    const discordBinding = new PresenceBinding("luna", discordAdapter, resolver);
+    const mattermostBinding = new PresenceBinding("luna", mattermostAdapter, resolver);
+
+    await discordBinding.startAndBind(noopMessageHandler());
+    await mattermostBinding.startAndBind(noopMessageHandler());
+
+    expect(resolver.size).toBe(2);
+    expect(resolver.identitiesOf("luna")).toEqual([
+      { platform: "discord" as Platform, platformId: "1487100000000000001" },
+      { platform: "mattermost" as Platform, platformId: "luna-mm-userid-abc123" },
+    ]);
+
+    await discordBinding.unbindAndStop();
+    expect(resolver.size).toBe(1);
+    expect(resolver.lookupAgentId("mattermost", "luna-mm-userid-abc123")).toBe("luna");
+
+    await mattermostBinding.unbindAndStop();
+    expect(resolver.size).toBe(0);
+  });
+});
+
+// =============================================================================
+// Module shape
+// =============================================================================
+
+describe("Module shape", () => {
+  test("exports PresenceBinding + UnsupportedPlatformError", () => {
+    expect(typeof PresenceBinding).toBe("function");
+    expect(typeof UnsupportedPlatformError).toBe("function");
+  });
+});

--- a/src/common/agents/__tests__/presence-binding.test.ts
+++ b/src/common/agents/__tests__/presence-binding.test.ts
@@ -456,4 +456,22 @@ describe("Module shape", () => {
     expect(typeof PresenceBinding).toBe("function");
     expect(typeof UnsupportedPlatformError).toBe("function");
   });
+
+  test("known-platforms list matches the TrustResolver.Platform union (drift guard)", () => {
+    // Compile-time exhaustiveness comes from the `satisfies Record<Platform, true>`
+    // bound on KNOWN_PLATFORMS in presence-binding.ts. This runtime check is the
+    // belt-and-suspenders: build a sample agent with each Platform variant in
+    // turn (via the FakeAdapter) and confirm the binding accepts it. If a new
+    // Platform variant is added to the union without updating KNOWN_PLATFORMS,
+    // the compile-time check fails first; if KNOWN_PLATFORMS is updated but the
+    // adapter wiring isn't, this runtime check stays green but the missing
+    // adapter-side wiring will surface in 7.2c-{platform} implementation work.
+    const registry = AgentRegistry.fromAgents([agentFixture({ id: "luna" })]);
+    const resolver = new TrustResolver(registry);
+    const platforms: Platform[] = ["discord", "mattermost"];
+    for (const platform of platforms) {
+      const adapter = new FakeAdapter({ platform });
+      expect(() => new PresenceBinding("luna", adapter, resolver)).not.toThrow();
+    }
+  });
 });

--- a/src/common/agents/presence-binding.ts
+++ b/src/common/agents/presence-binding.ts
@@ -51,18 +51,25 @@ import { type Platform, type TrustResolver } from "./trust-resolver";
 // =============================================================================
 
 /**
- * The platforms the trust resolver accepts. Mirrors the `Platform` union in
- * `trust-resolver.ts` — kept in a `Set` so the binding can narrow an
- * adapter's `platform: string` field at construction time.
+ * The platforms the trust resolver accepts, expressed as a record keyed by
+ * every variant of the `Platform` union. The `satisfies Record<Platform, …>`
+ * bound is the compile-time drift guard Holly W1 asked for: if a new
+ * variant is added to the `Platform` union in `trust-resolver.ts` without
+ * adding a key here, this literal fails to typecheck — the runtime
+ * narrowing stays in sync with the union by construction.
  *
- * Adding a new platform requires (1) extending the `Platform` union and
- * (2) adding the value here. The duplication is deliberate: the union is
- * compile-time, the set is runtime, and TypeScript can't bridge that.
+ * Use `isKnownPlatform` to narrow an adapter's `platform: string` field at
+ * the binding boundary.
  */
-const KNOWN_PLATFORMS: ReadonlySet<Platform> = new Set<Platform>(["discord", "mattermost"]);
+const KNOWN_PLATFORMS = {
+  discord: true,
+  mattermost: true,
+} as const satisfies Record<Platform, true>;
+
+const KNOWN_PLATFORM_LIST: readonly Platform[] = Object.keys(KNOWN_PLATFORMS) as Platform[];
 
 function isKnownPlatform(s: string): s is Platform {
-  return KNOWN_PLATFORMS.has(s as Platform);
+  return Object.hasOwn(KNOWN_PLATFORMS, s);
 }
 
 // =============================================================================
@@ -85,16 +92,15 @@ export class UnsupportedPlatformError extends Error {
   readonly knownPlatforms: readonly Platform[];
 
   constructor(platform: string) {
-    const known = [...KNOWN_PLATFORMS];
     super(
       `PresenceBinding: adapter.platform "${platform}" is not a known trust-resolver ` +
-        `platform (known: ${known.join(", ")}). Extend the Platform union in ` +
-        `src/common/agents/trust-resolver.ts and the KNOWN_PLATFORMS set in ` +
+        `platform (known: ${KNOWN_PLATFORM_LIST.join(", ")}). Extend the Platform union in ` +
+        `src/common/agents/trust-resolver.ts and the KNOWN_PLATFORMS record in ` +
         `src/common/agents/presence-binding.ts before binding adapters for new platforms.`,
     );
     this.name = "UnsupportedPlatformError";
     this.platform = platform;
-    this.knownPlatforms = known;
+    this.knownPlatforms = KNOWN_PLATFORM_LIST;
   }
 }
 
@@ -149,7 +155,7 @@ export class PresenceBinding {
     } catch (err) {
       try {
         await this.adapter.stop();
-      } catch {
+      } catch (_rollbackErr) {
         // Rollback best-effort; the caller's actionable signal is `err`.
       }
       throw err;

--- a/src/common/agents/presence-binding.ts
+++ b/src/common/agents/presence-binding.ts
@@ -1,0 +1,187 @@
+/**
+ * MIG-7.2c-binding — PresenceBinding.
+ *
+ * Glue between a `PlatformAdapter` (Discord / Mattermost / ...) and the
+ * process-wide `TrustResolver` (MIG-7.2b). Owns the start-then-register +
+ * unregister-then-stop lifecycle pair that ensures the platform user id is
+ * known to the trust map for exactly the window the adapter is connected.
+ *
+ * The binding is intentionally a *helper*, not a subclass: each existing
+ * adapter keeps its current constructor shape, and the cortex.ts wiring
+ * step (next sub-PR — MIG-7.2c-discord) just wraps each adapter in a
+ * PresenceBinding instead of calling `adapter.start()` directly.
+ *
+ * ## Lifecycle (the only correct order)
+ *
+ *   1. `await binding.startAndBind(onMessage)`
+ *        a. `adapter.start(onMessage)` — connect first; platform user id is
+ *           only available post-connect (e.g. Discord populates
+ *           `client.user` on the `ready` event).
+ *        b. `adapter.getPlatformUserId()` — learn the id.
+ *        c. `trustResolver.register(...)` — publish the mapping so peer
+ *           adapters can resolve inbound trust by platform id.
+ *
+ *   2. `await binding.unbindAndStop()`
+ *        a. `trustResolver.unregister(...)` — peers see the agent as
+ *           "offline" immediately on shutdown (graceful disconnect).
+ *        b. `adapter.stop()` — close the socket.
+ *
+ * Failure paths are explicit:
+ *   - If `adapter.start()` throws → no register, no stop (start failed; the
+ *     adapter is already in its pre-start state).
+ *   - If `getPlatformUserId()` or `register()` throws after a successful
+ *     start → roll back via `adapter.stop()` so we don't leak an unbound,
+ *     connected adapter. The original error is re-thrown; stop errors are
+ *     suppressed because the original failure is the actionable signal.
+ *
+ * ## Out of scope for this sub-PR
+ *
+ *   - Adapter constructor refactor to `(Agent, Presence, ...)` lands at
+ *     MIG-7.2c-discord / MIG-7.2c-mattermost. The binding takes today's
+ *     constructed adapters as-is.
+ *   - Reconnect retry / backoff. Adapters handle their own reconnect; the
+ *     binding just bind/unbinds at the outer lifecycle boundary.
+ */
+
+import type { PlatformAdapter, InboundMessage } from "../../adapters/types";
+import { type Platform, type TrustResolver } from "./trust-resolver";
+
+// =============================================================================
+// Known platform narrowing
+// =============================================================================
+
+/**
+ * The platforms the trust resolver accepts. Mirrors the `Platform` union in
+ * `trust-resolver.ts` — kept in a `Set` so the binding can narrow an
+ * adapter's `platform: string` field at construction time.
+ *
+ * Adding a new platform requires (1) extending the `Platform` union and
+ * (2) adding the value here. The duplication is deliberate: the union is
+ * compile-time, the set is runtime, and TypeScript can't bridge that.
+ */
+const KNOWN_PLATFORMS: ReadonlySet<Platform> = new Set<Platform>(["discord", "mattermost"]);
+
+function isKnownPlatform(s: string): s is Platform {
+  return KNOWN_PLATFORMS.has(s as Platform);
+}
+
+// =============================================================================
+// Errors
+// =============================================================================
+
+/**
+ * Thrown when constructing a `PresenceBinding` against an adapter whose
+ * `platform` is not in the `Platform` union (e.g. the test mock with
+ * `platform = "mock"`, or a hypothetical future Slack adapter that lands
+ * before the union is extended).
+ *
+ * Distinct class so callers can `instanceof`-check and surface a clear
+ * "this platform isn't wired through trust resolution yet" message rather
+ * than the generic "platform identity unknown" downstream error from
+ * `trustResolver.register`.
+ */
+export class UnsupportedPlatformError extends Error {
+  readonly platform: string;
+  readonly knownPlatforms: readonly Platform[];
+
+  constructor(platform: string) {
+    const known = [...KNOWN_PLATFORMS];
+    super(
+      `PresenceBinding: adapter.platform "${platform}" is not a known trust-resolver ` +
+        `platform (known: ${known.join(", ")}). Extend the Platform union in ` +
+        `src/common/agents/trust-resolver.ts and the KNOWN_PLATFORMS set in ` +
+        `src/common/agents/presence-binding.ts before binding adapters for new platforms.`,
+    );
+    this.name = "UnsupportedPlatformError";
+    this.platform = platform;
+    this.knownPlatforms = known;
+  }
+}
+
+// =============================================================================
+// PresenceBinding
+// =============================================================================
+
+/**
+ * Binds a `PlatformAdapter` to a `TrustResolver` for the duration of the
+ * adapter's connected lifetime. Single-use: each adapter instance gets its
+ * own binding. Bindings are NOT reused across reconnect cycles — the
+ * adapter handles reconnect internally, and the binding's
+ * `(platformUserId → agentId)` registration is idempotent for same-agent
+ * re-registration (see `TrustResolver.register`).
+ */
+export class PresenceBinding {
+  private readonly platform: Platform;
+  private platformUserId: string | undefined;
+
+  /**
+   * @throws UnsupportedPlatformError if `adapter.platform` is not in the
+   *         `Platform` union understood by the trust resolver.
+   */
+  constructor(
+    private readonly agentId: string,
+    private readonly adapter: PlatformAdapter,
+    private readonly trustResolver: TrustResolver,
+  ) {
+    if (!isKnownPlatform(adapter.platform)) {
+      throw new UnsupportedPlatformError(adapter.platform);
+    }
+    this.platform = adapter.platform;
+  }
+
+  /**
+   * Start the underlying adapter, learn its platform user id, and register
+   * the mapping with the trust resolver. The three steps run sequentially
+   * because each depends on the previous one succeeding.
+   *
+   * On `start()` failure: nothing is registered, nothing to roll back.
+   * On `getPlatformUserId()` or `register()` failure after `start()`
+   * succeeded: the adapter is stopped before re-throwing, so we never
+   * leave a connected-but-unbound adapter behind. Stop errors during
+   * rollback are suppressed (the original error is the one that matters).
+   */
+  async startAndBind(onMessage: (msg: InboundMessage) => Promise<void>): Promise<void> {
+    await this.adapter.start(onMessage);
+    try {
+      const platformUserId = await this.adapter.getPlatformUserId();
+      this.trustResolver.register(this.platform, platformUserId, this.agentId);
+      this.platformUserId = platformUserId;
+    } catch (err) {
+      try {
+        await this.adapter.stop();
+      } catch {
+        // Rollback best-effort; the caller's actionable signal is `err`.
+      }
+      throw err;
+    }
+  }
+
+  /**
+   * Unregister the platform mapping and stop the underlying adapter.
+   * Idempotent — safe to call when `startAndBind()` was never called or
+   * already unbound. Stops the adapter even when unregister is a no-op so
+   * a binding constructed-but-never-bound can still be drained safely.
+   */
+  async unbindAndStop(): Promise<void> {
+    if (this.platformUserId !== undefined) {
+      this.trustResolver.unregister(this.platform, this.platformUserId);
+      this.platformUserId = undefined;
+    }
+    await this.adapter.stop();
+  }
+
+  /** The platform user id this binding registered, or undefined if not bound. */
+  get registeredPlatformId(): string | undefined {
+    return this.platformUserId;
+  }
+
+  /** The agent id this binding registered for. */
+  get registeredAgentId(): string {
+    return this.agentId;
+  }
+
+  /** The platform (narrowed to the trust-resolver union) for this binding. */
+  get registeredPlatform(): Platform {
+    return this.platform;
+  }
+}


### PR DESCRIPTION
Smallest slice of the MIG-7.2c adapter-refactor trilogy. Encapsulates the adapter-startup → trust-map-registration handshake in one place so the remaining 7.2c-discord / 7.2c-mattermost sub-PRs can refactor the adapter constructors to `(Agent, Presence, ...)` without re-implementing the binding lifecycle in each.

## Interface change

Adds a single required method to `PlatformAdapter`:

```ts
getPlatformUserId(): Promise<string>;
```

Contract: callable only after `start()` completes. Discord throws if called pre-start (`client.user` is null); Mattermost fetches `/api/v4/users/me` and caches the result, dropping the cache on `stop()` so a token rotation between sessions re-fetches cleanly.

## PresenceBinding

`src/common/agents/presence-binding.ts` (~165 LOC). Wraps an adapter and exposes two lifecycle methods:

- **`startAndBind(onMessage)`** — `adapter.start()` → `getPlatformUserId()` → `trustResolver.register(...)`. On post-start failure, rolls back via `adapter.stop()` so we never leak a connected-but-unbound adapter. Stop errors during rollback are suppressed so the actionable primary error surfaces.
- **`unbindAndStop()`** — `trustResolver.unregister(...)` then `adapter.stop()`. Idempotent: safe to call when never bound, after rollback, or twice.

`UnsupportedPlatformError` (custom class with `.platform` + `.knownPlatforms`) fires at construction when `adapter.platform` isn't in `TrustResolver.Platform`. Catches the `MockAdapter` footgun (`platform = "mock"`) and surfaces future-platform-not-wired-yet cases cleanly rather than as a generic downstream error.

## Adapter implementations

- **DiscordAdapter**: returns `this.client.user.id`. Throws if called pre-start or post-stop.
- **MattermostAdapter**: fetches `/api/v4/users/me` lazily via configured `apiToken`. Caches; cache cleared on `stop()`. Explicit errors on missing config, non-2xx, or missing `id`.
- **MockAdapter**: new `platformUserId` field (default `"mock-bot-user"`) for test overrides.

## Tests

`src/common/agents/__tests__/presence-binding.test.ts` — 18 tests, 45 expects:

- Construction: discord + mattermost accepted; mock + slack rejected with `UnsupportedPlatformError`
- `startAndBind` happy path: start → getPlatformUserId → register call order
- Idempotent re-bind (same agent, TrustResolver no-op)
- Identity-theft attempt (different agent, same platform id) rejected with `PlatformIdAlreadyRegisteredError` + rollback
- `start()` failure → nothing registered, no rollback stop
- `getPlatformUserId()` failure → adapter stopped, original error wins
- `register()` failure on unknown agent → adapter stopped, `AgentNotFoundError`
- `stop()` failure during rollback suppressed; primary failure surfaces
- `unbindAndStop` happy + idempotent (twice, never-bound, after-rollback)
- Multi-platform per agent (discord + mattermost on same Luna)

Uses inline `FakeAdapter` rather than the project's `MockAdapter` (which the binding intentionally rejects).

## Out of scope

- Adapter constructor refactor to `(Agent, Presence, ...)` — that's the **7.2c-discord** and **7.2c-mattermost** sub-PRs.
- Reconnect retry / backoff — adapters own their own reconnect; binding is bind-once at the outer cortex.ts lifecycle.
- Wiring `cortex.ts` to construct `PresenceBindings` from `CortexConfig.agents` — at MIG-7 cutover proper.

## Test plan

- [x] `bunx tsc --noEmit` clean
- [x] `bun test src/common/agents/__tests__/presence-binding.test.ts` — 18/18 pass
- [x] Full suite — 1960/1961 pass; the 1 fail is the pre-existing mission-control React shell test gated on `bun build` at MIG-7 cutover

Refs cortex#9 (MIG-7 umbrella), cortex#40 (MIG-7.2 base), cortex#42 (MIG-7.2a AgentRegistry), cortex#43 (MIG-7.2b TrustResolver).

🤖 Generated with [Claude Code](https://claude.com/claude-code)