### PR TITLE
feat(adapters/discord): C-108.x — DiscordAdapter computes this.agent/this.presence (MIG-7.2c-discord-internal)

### DIFF
--- a/src/adapters/discord/index.ts
+++ b/src/adapters/discord/index.ts
@@ -15,6 +15,8 @@ import type {
   ContextMessage,
 } from "../types";
 import type { BotConfig, DiscordRole, DMConfig } from "../../common/types/config";
+import { DMConfigSchema } from "../../common/types/config";
+import type { Agent, DiscordPresence } from "../../common/types/cortex-config";
 import { createDiscordClient, isMentionForBot, extractContent, type ConnectionHealth } from "./client";
 import { fetchContext } from "./context-fetcher";
 import { postToDiscord } from "./response-poster";
@@ -99,6 +101,28 @@ export class DiscordAdapter implements PlatformAdapter {
   private connectionHealth: ConnectionHealth | null = null;
   private botConfig: BotConfig;
   private adapterConfig: DiscordAdapterConfig;
+  /**
+   * MIG-7.2c-internal: presence-shape mirror of the legacy `adapterConfig`
+   * credential/role/DM fields. Computed once at construction and kept in sync
+   * by `updateConfig` so the rest of the class can already read from the
+   * cortex-config shape. The constructor signature is intentionally unchanged
+   * in this slice — the flip to `(Agent, DiscordPresence, infra)` happens in
+   * MIG-7.2c-discord-flip and removes the back-conversion below.
+   *
+   * Fields that don't map onto `DiscordPresenceSchema` (operatorDiscordId,
+   * surface*) stay on `adapterConfig` for now. They move to the operator and
+   * Renderer config respectively in later slices.
+   */
+  private presence: DiscordPresence;
+  /**
+   * MIG-7.2c-internal: minimal agent stub built from `botConfig.agent` plus
+   * the freshly-computed presence. The `persona` field is a documented
+   * placeholder until MIG-7.2c-discord-flip plumbs the real persona path
+   * down from the operator's cortex.yaml. No method currently reads from
+   * `this.agent`; this field exists so the flip slice can wire the AgentRegistry
+   * / TrustResolver paths without touching the constructor again.
+   */
+  private agent: Agent;
   private runtime: MyelinRuntime | undefined;
   private systemEventSource: SystemEventSource | undefined;
   /**
@@ -116,6 +140,8 @@ export class DiscordAdapter implements PlatformAdapter {
     this.instanceId = adapterConfig.instanceId;
     this.adapterConfig = adapterConfig;
     this.botConfig = botConfig;
+    this.presence = DiscordAdapter.toPresence(adapterConfig);
+    this.agent = DiscordAdapter.toAgent(botConfig, this.presence);
     this.runtime = wiring.runtime;
     this.systemEventSource = wiring.systemEventSource;
 
@@ -286,7 +312,7 @@ export class DiscordAdapter implements PlatformAdapter {
       await onMessage(inboundMsg);
     });
 
-    await this.client.login(this.adapterConfig.token);
+    await this.client.login(this.presence.token);
   }
 
   async stop(): Promise<void> {
@@ -334,6 +360,12 @@ export class DiscordAdapter implements PlatformAdapter {
     this.adapterConfig.defaultRole = newInstance.defaultRole;
     this.adapterConfig.dm = newInstance.dm;
 
+    // MIG-7.2c-internal: mirror the same hot-reload-safe fields into the
+    // presence shape so subsequent reads via `this.presence.*` see the
+    // updated values. Rebuild via the same helper used at construction so
+    // schema-default behaviour stays identical across the two paths.
+    this.presence = DiscordAdapter.toPresence(this.adapterConfig);
+
     // Update bot config (for claude execution settings)
     this.botConfig = config;
 
@@ -356,8 +388,8 @@ export class DiscordAdapter implements PlatformAdapter {
     }
 
     const role = resolveRole(msg.authorId, {
-      roles: this.adapterConfig.roles ?? [],
-      defaultRole: this.adapterConfig.defaultRole ?? "allow-all",
+      roles: this.presence.roles,
+      defaultRole: this.presence.defaultRole,
     });
 
     if (role.denied) {
@@ -383,7 +415,7 @@ export class DiscordAdapter implements PlatformAdapter {
 
   /** G-300: Resolve access for DM messages */
   private resolveDMAccess(msg: InboundMessage): AccessDecision {
-    const dm = this.adapterConfig.dm;
+    const dm = this.presence.dm;
 
     // Operator DM — full access
     if (msg.dmType === "operator" && dm?.operatorRole) {
@@ -706,6 +738,73 @@ export class DiscordAdapter implements PlatformAdapter {
       attachment: f.content,
       name: f.filename,
     }));
+  }
+
+  // ---------------------------------------------------------------------------
+  // MIG-7.2c-internal: back-conversion helpers
+  //
+  // These translate the legacy `(DiscordAdapterConfig, BotConfig)` constructor
+  // inputs into the cortex-config `(Agent, DiscordPresence)` shape so the rest
+  // of the class can already read from the target types. Both helpers are
+  // deleted by MIG-7.2c-discord-flip when the constructor signature flips.
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Build a `DiscordPresence`-shaped object from the credential/role/DM
+   * fields on `DiscordAdapterConfig`. Built structurally rather than via
+   * `DiscordPresenceSchema.parse` because the legacy `DiscordAdapterConfig`
+   * is a plain TS interface that doesn't enforce the schema's stricter
+   * runtime invariants (e.g. `contextDepth: z.number().positive()` rejects
+   * 0, which test fixtures legitimately use). Schema-strictness re-enters
+   * the pipeline at MIG-7.2c-discord-flip when `cortex.ts` switches over
+   * to parsing `cortex.yaml` upstream.
+   *
+   * `enabled` defaults to `true`, `roles` to `[]`, `defaultRole` to
+   * `"allow-all"`, `dm` to the schema's own default shape, matching the
+   * `DiscordPresenceSchema` field defaults so call-sites see equivalent
+   * values regardless of which constructor path runs. Optional fields not
+   * carried by the legacy adapter config (`worklogChannelId`,
+   * `operatorRoleId`) stay undefined.
+   */
+  private static toPresence(adapterConfig: DiscordAdapterConfig): DiscordPresence {
+    return {
+      enabled: true,
+      token: adapterConfig.token,
+      guildId: adapterConfig.guildId,
+      agentChannelId: adapterConfig.agentChannelId,
+      logChannelId: adapterConfig.logChannelId,
+      contextDepth: adapterConfig.contextDepth,
+      enableAgentLog: adapterConfig.enableAgentLog,
+      roles: adapterConfig.roles ?? [],
+      defaultRole: adapterConfig.defaultRole ?? "allow-all",
+      dm: adapterConfig.dm ?? DMConfigSchema.parse({}),
+    };
+  }
+
+  /**
+   * Build a minimal `Agent` from `BotConfig.agent` plus the freshly-computed
+   * presence. `persona` is a documented placeholder — `BotConfig` has no
+   * persona-file field, so the real path stays out of reach until
+   * MIG-7.2c-discord-flip plumbs it from `cortex.yaml`. `roles` and `trust`
+   * default to empty arrays for the same reason: the legacy bot.yaml carries
+   * no such fields.
+   *
+   * Built structurally (no `AgentSchema.parse`) for the same reason
+   * `toPresence` is — keep this slice's constructor strictness identical to
+   * the pre-refactor adapter so existing test fixtures keep working
+   * unchanged. No adapter method currently reads from `this.agent`; the
+   * field exists so the flip slice doesn't need a second constructor
+   * refactor to wire AgentRegistry / TrustResolver paths.
+   */
+  private static toAgent(botConfig: BotConfig, presence: DiscordPresence): Agent {
+    return {
+      id: botConfig.agent.name,
+      displayName: botConfig.agent.displayName,
+      persona: "(deferred-mig-7.2c-flip)",
+      roles: [],
+      trust: [],
+      presence: { discord: presence },
+    };
   }
 
   // ---------------------------------------------------------------------------

--- a/src/adapters/discord/index.ts
+++ b/src/adapters/discord/index.ts
@@ -369,6 +369,16 @@ export class DiscordAdapter implements PlatformAdapter {
     // Update bot config (for claude execution settings)
     this.botConfig = config;
 
+    // MIG-7.2c-internal (Holly cycle 1, major/architecture): rebuild
+    // `this.agent` AFTER both `this.presence` and `this.botConfig` have
+    // been updated, otherwise `this.agent.presence.discord` and
+    // `this.agent.id` / `this.agent.displayName` drift out of sync with
+    // the live config. Harmless in this slice (no method reads from
+    // `this.agent`), but the flip slice wires PresenceBinding /
+    // TrustResolver through this field, where a stale value becomes a
+    // silent runtime regression on every hot-reload.
+    this.agent = DiscordAdapter.toAgent(this.botConfig, this.presence);
+
     console.log(`discord-adapter[${this.instanceId}]: config updated`);
   }
 


### PR DESCRIPTION
## Summary

First sub-slice of MIG-7.2c. Internal-only refactor: `DiscordAdapter` mirrors its `(DiscordAdapterConfig, BotConfig)` inputs into cortex-config-shaped `this.presence: DiscordPresence` and `this.agent: Agent` fields, so methods read from the target shape without changing the constructor signature.

The public surface is unchanged: `new DiscordAdapter(DiscordAdapterConfig, BotConfig, wiring)` works exactly as before. All callsites (`cortex.ts`, Discord sub-modules, the seven test files) continue unchanged.

## Migration context

Part of cortex#9 / `docs/plan-cortex-migration.md` §4 MIG-7.2c. Slice-A of three planned sub-PRs for the Discord adapter:

- **MIG-7.2c-discord-internal** ← this PR — mirror reads behind the existing constructor
- **MIG-7.2c-discord-flip** — flip constructor signature to `(Agent, DiscordPresence, infra)`; cortex.ts derives both from `botConfig.discord[i]` + operator fields; test fixtures update
- **MIG-7.2c-discord-cleanup** — drop the back-conversion helpers + the legacy `DiscordAdapterConfig` interface; sub-modules (client.ts, response-poster.ts, etc.) take the new shape directly

## What moved

- new private fields `presence: DiscordPresence`, `agent: Agent`
- new private statics `toPresence(adapterConfig)`, `toAgent(botConfig, presence)`
- constructor computes both via the helpers right after the existing field assignments
- `updateConfig` rebuilds `this.presence` after mutating `adapterConfig` so hot-reload stays correct
- method reads migrated:
  - `start()` — `client.login(this.presence.token)`
  - `resolveAccess` — `roles` + `defaultRole`
  - `resolveDMAccess` — `dm`

## What did NOT move

Fields without a clean presence target stay on `this.adapterConfig` for now:
- `operatorDiscordId` → migrates to `infra.operator.discordId` at 7.2c-discord-flip
- `surfaceSubjects` / `surfaceFilter` / `surfaceFallbackChannelId` → migrate to the Renderer config at MIG-7.2d (per architecture §9.2 — activity-centric, not agent-credential)

`agent.persona` is a documented placeholder (`"(deferred-mig-7.2c-flip)"`) because `BotConfig` has no persona-file field; the real path comes in at flip time when `cortex.ts` plumbs `cortex.yaml` upstream. No method currently reads from `this.agent`; it's wired so the flip slice can hand it to `PresenceBinding` / `TrustResolver` without a second constructor refactor.

## Structural-build rationale

Both helpers are intentionally structural (not `DiscordPresenceSchema.parse(...)`-based). `DiscordAdapterConfig` is a plain TS interface that test fixtures legitimately pass values the zod schema would reject (e.g. `contextDepth: 0`); using `.parse()` here would tighten runtime validation in a way that's out of scope for the internal slice. Schema-strictness re-enters the pipeline at flip time when `cortex.ts` parses `cortex.yaml` upstream.

The structural defaults match the equivalent `DiscordPresenceSchema` defaults (`enabled: true`, `roles: []`, `defaultRole: "allow-all"`, `dm: DMConfigSchema.parse({})`) so call-sites see equivalent values regardless of which constructor path runs.

## Test plan

- [x] `bunx tsc --noEmit` clean
- [x] `bun test src/adapters/discord/__tests__/` — 85/85 pass
- [x] `bun test` (full suite) — 1961 pass, 1 pre-existing mission-control React-shell fail (unchanged across the migration; RESUME.md caveat: gated on MIG-7 cutover)
- [x] no behavioural changes for callers — adapter constructor signature, public method shapes, and field reads all preserve pre-refactor semantics

🤖 Generated with [Claude Code](https://claude.com/claude-code)