### PR TITLE
feat(adapters/discord): C-108.x — drop transitional botConfig + retrim infra JSDoc (MIG-7.2c-discord-cleanup)

### DIFF
--- a/src/adapters/discord/__tests__/client-degraded.test.ts
+++ b/src/adapters/discord/__tests__/client-degraded.test.ts
@@ -1,12 +1,10 @@
 import { test, expect, describe, afterEach, beforeEach, mock, spyOn } from "bun:test";
-import { createDiscordClient, type DiscordClientOptions } from "../client";
-import type { BotConfig } from "../../../common/types/config";
+import { createDiscordClient, type DiscordClientOptions, type DiscordClientDisplayInfo } from "../client";
 
-// Minimal config stub — createDiscordClient only reads agent.displayName + discord[].guildId
-const stubConfig = {
-  agent: { displayName: "Test" },
-  discord: [{ guildId: "g1" }],
-} as unknown as BotConfig;
+// MIG-7.2c-discord-cleanup: createDiscordClient takes the display info
+// directly. Single-guild per adapter; the prior `discord: [...]` array stub
+// is no longer applicable.
+const stubInfo: DiscordClientDisplayInfo = { displayName: "Test", guildId: "g1" };
 
 let originalError: typeof console.error;
 let originalLog: typeof console.log;
@@ -30,7 +28,7 @@ afterEach(() => {
 function setupClient(options: DiscordClientOptions = {}) {
   const onDegraded = mock();
   const onRecovered = mock();
-  const result = createDiscordClient(stubConfig, {
+  const result = createDiscordClient(stubInfo, {
     instanceId: "discord-test",
     degradedThresholdMs: 50,
     onDegraded,
@@ -206,7 +204,7 @@ describe("createDiscordClient degraded timer", () => {
 
   test("onDegraded callback throwing does not break event handling", async () => {
     const errSpy = spyOn(console, "error").mockImplementation(() => {});
-    const { client, health } = createDiscordClient(stubConfig, {
+    const { client, health } = createDiscordClient(stubInfo, {
       degradedThresholdMs: 20,
       onDegraded: () => { throw new Error("callback boom"); },
     });

--- a/src/adapters/discord/__tests__/operator-dm-buffer.test.ts
+++ b/src/adapters/discord/__tests__/operator-dm-buffer.test.ts
@@ -18,7 +18,6 @@
 
 import { test, expect, describe, beforeEach, afterEach } from "bun:test";
 import { DiscordAdapter, type DiscordAdapterInfra } from "../index";
-import type { BotConfig } from "../../../common/types/config";
 import { DMConfigSchema } from "../../../common/types/config";
 import type { Agent, DiscordPresence } from "../../../common/types/cortex-config";
 import type { ConnectionHealth } from "../client";
@@ -77,14 +76,9 @@ function makeAdapter(opts: {
     trust: [],
     presence: { discord: presence },
   };
-  const botConfig = {
-    agent: { name: "test", displayName: "Test" },
-    discord: [{ guildId: "g1" }],
-  } as unknown as BotConfig;
   const infra: DiscordAdapterInfra = {
     instanceId: "discord-test",
     operator: { discordId: "operator-123" },
-    botConfig,
   };
   const adapter = new DiscordAdapter(agent, presence, infra);
 

--- a/src/adapters/discord/__tests__/render-envelope.test.ts
+++ b/src/adapters/discord/__tests__/render-envelope.test.ts
@@ -19,7 +19,6 @@ import { test, expect, describe, beforeEach, afterEach } from "bun:test";
 import { DiscordAdapter, type DiscordAdapterInfra } from "../index";
 import { DMConfigSchema } from "../../../common/types/config";
 import type { Agent, DiscordPresence } from "../../../common/types/cortex-config";
-import type { BotConfig } from "../../../common/types/config";
 import type { ConnectionHealth } from "../client";
 import type { Envelope } from "../../../bus/myelin/envelope-validator";
 
@@ -98,14 +97,9 @@ function makeAdapter(opts: {
     trust: [],
     presence: { discord: presence },
   };
-  const botConfig = {
-    agent: { name: "test", displayName: "Test" },
-    discord: [{ guildId: "g1" }],
-  } as unknown as BotConfig;
   const infra: DiscordAdapterInfra = {
     instanceId: "discord-renderer",
     operator: {},
-    botConfig,
     ...(opts.surfaceSubjects !== undefined && { surfaceSubjects: opts.surfaceSubjects }),
     ...(opts.surfaceFallbackChannelId !== undefined && { surfaceFallbackChannelId: opts.surfaceFallbackChannelId }),
     ...(opts.surfaceFilter !== undefined && { surfaceFilter: opts.surfaceFilter }),

--- a/src/adapters/discord/__tests__/system-events.test.ts
+++ b/src/adapters/discord/__tests__/system-events.test.ts
@@ -17,15 +17,9 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import type { Envelope } from "../../../bus/myelin/envelope-validator";
 import type { MyelinRuntime } from "../../../bus/myelin/runtime";
-import type { BotConfig } from "../../../common/types/config";
 import { DMConfigSchema } from "../../../common/types/config";
 import type { Agent, DiscordPresence } from "../../../common/types/cortex-config";
 import { DiscordAdapter, type DiscordAdapterInfra } from "../index";
-
-const stubBotConfig = {
-  agent: { name: "test", displayName: "Test", operatorId: "andreas" },
-  discord: [{ guildId: "g1" }],
-} as unknown as BotConfig;
 
 // MIG-7.2c-discord-flip: build a fresh (agent, presence) pair for each
 // adapter so tests can mutate them safely. Overrides on `presence` mirror
@@ -95,7 +89,6 @@ async function buildStartedAdapter(opts: {
   const infra: DiscordAdapterInfra = {
     instanceId: "discord-test",
     operator: {},
-    botConfig: stubBotConfig,
     ...(opts.runtime !== undefined && { runtime: opts.runtime }),
     ...(opts.systemEventSource !== undefined && { systemEventSource: opts.systemEventSource }),
   };

--- a/src/adapters/discord/__tests__/update-config.test.ts
+++ b/src/adapters/discord/__tests__/update-config.test.ts
@@ -99,11 +99,9 @@ function makeBotConfig(overrides: Partial<{
 function makeAdapter(overrides: { presence?: Partial<DiscordPresence> } = {}) {
   const presence = makePresence(overrides.presence);
   const agent = makeAgent(presence);
-  const botConfig = makeBotConfig();
   const infra: DiscordAdapterInfra = {
     instanceId: "luna-discord-guild-1",
     operator: {},
-    botConfig,
   };
   return new DiscordAdapter(agent, presence, infra);
 }
@@ -113,9 +111,6 @@ function getPresence(adapter: DiscordAdapter): DiscordPresence {
 }
 function getAgent(adapter: DiscordAdapter): Agent {
   return (adapter as unknown as { agent: Agent }).agent;
-}
-function getInfra(adapter: DiscordAdapter): DiscordAdapterInfra {
-  return (adapter as unknown as { infra: DiscordAdapterInfra }).infra;
 }
 
 describe("DiscordAdapter.updateConfig", () => {
@@ -180,15 +175,5 @@ describe("DiscordAdapter.updateConfig", () => {
     const agentAfter = getAgent(adapter);
     expect(agentAfter.id).toBe("luna-rebranded");
     expect(agentAfter.displayName).toBe("Luna v2");
-  });
-
-  test("infra.botConfig is refreshed for client.ts pass-through", () => {
-    const adapter = makeAdapter();
-    const next = makeBotConfig({ displayName: "Luna Reload" });
-    adapter.updateConfig(next);
-    // The transitional getter routes `this.botConfig` through `infra.botConfig`,
-    // so the most direct check is on infra. The next createDiscordClient call
-    // (on reconnect) will read from this fresh reference.
-    expect(getInfra(adapter).botConfig).toBe(next);
   });
 });

--- a/src/adapters/discord/client.ts
+++ b/src/adapters/discord/client.ts
@@ -4,7 +4,6 @@
  */
 
 import { Client, GatewayIntentBits, Partials, type TextChannel, type ThreadChannel, type Message } from "discord.js";
-import type { BotConfig } from "../../common/types/config";
 
 export interface ConnectionHealth {
   reconnectCount: number;
@@ -43,13 +42,30 @@ export interface DiscordClientResult {
   health: ConnectionHealth;
 }
 
+/**
+ * Display-only metadata stamped into the connection-ready log lines.
+ *
+ * MIG-7.2c-discord-cleanup: replaces the previous `BotConfig` parameter so
+ * `createDiscordClient` no longer reaches across the whole config tree to
+ * print a `Agent: …` / `Guild(s): …` line. The cortex-config agent /
+ * presence model is one Discord presence per agent, so `guildId` is a
+ * single value (the legacy `config.discord.map(d => d.guildId).join(", ")`
+ * was redundant — every adapter only ever ran one guild).
+ */
+export interface DiscordClientDisplayInfo {
+  /** Parent agent's `displayName` — appears on the `Agent: …` log line. */
+  displayName: string;
+  /** This presence's `guildId` — appears on the `Guild: …` log line. */
+  guildId: string;
+}
+
 function formatUptime(since: Date | null): string {
   if (!since) return "never";
   return `${((Date.now() - since.getTime()) / 1000).toFixed(0)}s`;
 }
 
 export function createDiscordClient(
-  config: BotConfig,
+  info: DiscordClientDisplayInfo,
   options: DiscordClientOptions = {},
 ): DiscordClientResult {
   const instanceId = options.instanceId ?? "discord";
@@ -96,9 +112,8 @@ export function createDiscordClient(
     health.currentlyConnected = true;
     health.lastConnectedAt = new Date();
     console.log(`${tag}: connected as ${client.user?.tag}`);
-    console.log(`  Agent: ${config.agent.displayName}`);
-    const guildIds = config.discord.map((d) => d.guildId).join(", ");
-    console.log(`  Guild(s): ${guildIds || "none"}`);
+    console.log(`  Agent: ${info.displayName}`);
+    console.log(`  Guild: ${info.guildId}`);
   });
 
   client.on("shardReady", (shardId) => {

--- a/src/adapters/discord/index.ts
+++ b/src/adapters/discord/index.ts
@@ -34,39 +34,17 @@ import {
 import { formatEnvelopeAsMarkdown } from "../envelope-renderer";
 
 /**
- * MIG-7.2c-discord-flip: cortex-deployment-level wiring passed alongside the
- * agent + presence pair. Bundles four concerns the agent/presence model
- * itself doesn't carry:
+ * Cortex-deployment-level wiring passed alongside the agent + presence pair.
+ * Bundles the deployment-scoped concerns the agent/presence model itself
+ * doesn't carry: the routing/log-prefix `instanceId`, the operator's
+ * platform identity, bus wiring for `system.adapter.*` envelope emission,
+ * and the MIG-3b surface-router fields.
  *
- *  1. `instanceId` — the surface-router / log-prefix key for this adapter.
- *     Derived by `cortex.ts` from `${agent.id}-discord` (or
- *     `${agent.id}-discord-${guildId}` while `botConfig.discord[]` still
- *     allows multiple instances per agent.name; collapses to plain
- *     `${agent.id}-discord` at MIG-7.2e when migrate-config emits a real
- *     `agents[]` array).
- *
- *  2. `operator` — operator-level identity (currently just `discordId`).
- *     Architecture §9.1: the operator is who runs the cortex deployment,
- *     distinct from the agents they host. This block moves the legacy
- *     `botConfig.agent.operatorDiscordId` out of the agent block onto its
- *     proper home.
- *
- *  3. `runtime` + `systemEventSource` — bus wiring for `system.adapter.*`
- *     emission. Folded in here from the prior `DiscordAdapterRuntimeWiring`
- *     constructor parameter so the constructor has three params instead of
- *     four, all of them load-bearing data.
- *
- *  4. Surface-router fields (`surfaceSubjects`, `surfaceFilter`,
- *     `surfaceFallbackChannelId`) — MIG-3b additions that tell the adapter
- *     which bus subjects to project onto a fallback Discord channel. These
- *     are activity-centric (arch §9.2 — renderers project bus state, not
- *     credentials), so they migrate to a dedicated `kind: discord-channel`
- *     renderer at MIG-7.2d. They park here transitionally for the flip
- *     slice; `DiscordAdapter` keeps reading them from `this.infra.*`.
- *
- *  5. `botConfig` — transitional pass-through for `createDiscordClient` and
- *     `updateConfig` back-compat. Removed at MIG-7.2c-discord-cleanup when
- *     `client.ts` and the sub-modules take the new shape directly.
+ * The surface-router fields (`surfaceSubjects`, `surfaceFilter`,
+ * `surfaceFallbackChannelId`) park here transitionally — architecture §9.2
+ * makes them a renderer concern (activity-centric, not agent-credential),
+ * and a dedicated `kind: discord-channel` renderer lifts them out at
+ * MIG-7.2d. Until then, `DiscordAdapter` reads them via `this.infra.*`.
  *
  * Anti-pattern note (G-1111 §4.6.2): a degraded adapter publishing its OWN
  * `degraded` event is the wrong long-term home — that belongs to a sibling
@@ -75,9 +53,18 @@ import { formatEnvelopeAsMarkdown } from "../envelope-renderer";
  * a follow-on iteration.
  */
 export interface DiscordAdapterInfra {
+  /** Surface-router + log-prefix key. Cortex derives `${agent.id}-discord-${guildId}` while
+   * BotConfig.discord[] still permits multiple entries per agent.name; collapses to
+   * `${agent.id}-discord` at MIG-7.2e when migrate-config emits a real agents[] array. */
   instanceId: string;
+  /** Operator's platform identity. Architecture §9.1: the operator runs the cortex
+   * deployment, distinct from the agents they host. */
   operator: { discordId?: string };
+  /** Myelin runtime for `system.adapter.*` envelope emission. Optional — adapters started
+   * without NATS still track degradation/reconnect locally. */
   runtime?: MyelinRuntime;
+  /** `{org}.{agent}.{instance}` source triple stamped onto emitted `system.*` envelopes
+   * (spec §3.6 names the agent, not the operator). */
   systemEventSource?: SystemEventSource;
   /** MIG-3b: NATS subject patterns this adapter renders to Discord. Empty/undefined → adapter
    * never matches in the surface-router (still subscribes for messages, just doesn't render
@@ -88,8 +75,6 @@ export interface DiscordAdapterInfra {
   /** MIG-3b: fallback Discord channel ID for envelope rendering when no per-envelope routing
    * rule applies. Channel ID, NOT name. Moves to Renderer at MIG-7.2d. */
   surfaceFallbackChannelId?: string;
-  /** Transitional pass-through for `createDiscordClient` + `updateConfig` until MIG-7.2c-discord-cleanup. */
-  botConfig: BotConfig;
 }
 
 interface PendingResult {
@@ -108,15 +93,6 @@ export class DiscordAdapter implements PlatformAdapter {
   private agent: Agent;
   private presence: DiscordPresence;
   private infra: DiscordAdapterInfra;
-  /**
-   * Transitional alias for `infra.botConfig`. The `start()` path passes
-   * `botConfig` to `createDiscordClient` and `updateConfig` mutates it.
-   * `client.ts` still takes `BotConfig`; both call-sites move to the new
-   * shape at MIG-7.2c-discord-cleanup, at which point this field plus
-   * `infra.botConfig` both drop out.
-   */
-  private get botConfig(): BotConfig { return this.infra.botConfig; }
-  private set botConfig(next: BotConfig) { this.infra.botConfig = next; }
   /**
    * Cached pointers to `infra.runtime` / `infra.systemEventSource`. Kept as
    * dedicated fields (rather than always reading via `this.infra.*`) so the
@@ -158,7 +134,9 @@ export class DiscordAdapter implements PlatformAdapter {
   }
 
   async start(onMessage: (msg: InboundMessage) => Promise<void>): Promise<void> {
-    const { client, health } = createDiscordClient(this.botConfig, {
+    const { client, health } = createDiscordClient(
+      { displayName: this.agent.displayName, guildId: this.presence.guildId },
+      {
       instanceId: this.instanceId,
       // MIG-3b-ii: emit `system.adapter.{degraded,recovered}` envelopes so
       // operators get out-of-band visibility (see G-1111 §3.5.3 + §4.6).
@@ -368,15 +346,7 @@ export class DiscordAdapter implements PlatformAdapter {
       dm: newInstance.dm,
     };
 
-    // Refresh transitional pass-through. `createDiscordClient` already ran
-    // at construction so the live discord.js client is unaffected; this
-    // assignment is for `client.ts`'s log line that reads
-    // `config.agent.displayName` on subsequent reconnects, and for any
-    // future caller that grabs `this.botConfig` for hot-reloadable runtime
-    // params (`claude.timeoutMs`, etc.).
-    this.botConfig = config;
-
-    // Rebuild agent AFTER both `presence` and `botConfig` are refreshed so
+    // Rebuild agent AFTER `this.presence` is refreshed so
     // `agent.presence.discord` and `agent.id` / `agent.displayName` reflect
     // the post-reload state. Same hot-reload-sync invariant Holly flagged
     // at MIG-7.2c-internal cycle 1: a stale agent reference becomes a

--- a/src/adapters/discord/index.ts
+++ b/src/adapters/discord/index.ts
@@ -137,18 +137,19 @@ export class DiscordAdapter implements PlatformAdapter {
     const { client, health } = createDiscordClient(
       { displayName: this.agent.displayName, guildId: this.presence.guildId },
       {
-      instanceId: this.instanceId,
-      // MIG-3b-ii: emit `system.adapter.{degraded,recovered}` envelopes so
-      // operators get out-of-band visibility (see G-1111 §3.5.3 + §4.6).
-      // The callbacks are also wired to console.error for log retention;
-      // the bus emission is additive, not a replacement.
-      onDegraded: ({ instanceId, thresholdMs, since }) => {
-        this.publishAdapterDegraded({ instanceId, thresholdMs, since });
+        instanceId: this.instanceId,
+        // MIG-3b-ii: emit `system.adapter.{degraded,recovered}` envelopes so
+        // operators get out-of-band visibility (see G-1111 §3.5.3 + §4.6).
+        // The callbacks are also wired to console.error for log retention;
+        // the bus emission is additive, not a replacement.
+        onDegraded: ({ instanceId, thresholdMs, since }) => {
+          this.publishAdapterDegraded({ instanceId, thresholdMs, since });
+        },
+        onRecovered: ({ instanceId, degradedForMs }) => {
+          this.publishAdapterRecovered({ instanceId, degradedForMs });
+        },
       },
-      onRecovered: ({ instanceId, degradedForMs }) => {
-        this.publishAdapterRecovered({ instanceId, degradedForMs });
-      },
-    });
+    );
     this.client = client;
     this.connectionHealth = health;
 

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -245,7 +245,6 @@ export async function startCortex(
           },
           runtime,
           systemEventSource,
-          botConfig: config,
         },
       );
       // Register the adapter's surface-router face. Empty `surfaceSubjects`


### PR DESCRIPTION
## Summary

Third and final sub-slice of MIG-7.2c. Drops the transitional `infra.botConfig` field that #47 kept as a back-compat bridge for `createDiscordClient` and `updateConfig`. `client.ts` now takes a focused `DiscordClientDisplayInfo` (`{ displayName, guildId }`) instead of reaching across the whole `BotConfig` tree to print two log lines. The 39-line `DiscordAdapterInfra` JSDoc Holly nit-flagged at cycle 1 collapses to the post-cleanup shape.

## Migration context

cortex#9 / `docs/plan-cortex-migration.md` §4 MIG-7.2c. Closes the Discord adapter trilogy:

- ~~MIG-7.2c-discord-internal~~ (#46, merged) — adapter computes `this.presence` / `this.agent` behind unchanged constructor
- ~~MIG-7.2c-discord-flip~~ (#47, merged) — constructor flipped to `(Agent, DiscordPresence, infra)`
- **MIG-7.2c-discord-cleanup** ← this PR — drop the transitional `botConfig` field; sub-modules take the cortex-config shape directly

Next slices: MIG-7.2c-mattermost (constructor flip + `/users/me` dedup per Holly W1 carry-forward from #45), then MIG-7.2d Renderer interface, then MIG-7.2e migrate-config helper.

## Refactor scope

**`src/adapters/discord/client.ts`** (+25/-12):
- drop `import type { BotConfig }`
- new `DiscordClientDisplayInfo` interface — `{ displayName, guildId }`
- `createDiscordClient(config: BotConfig, options)` → `createDiscordClient(info: DiscordClientDisplayInfo, options)`
- `ready` handler reads `info.displayName` (was `config.agent.displayName`) and `info.guildId` (was `config.discord.map(d => d.guildId).join(", ")`). Single-guild per adapter is the new normal — the array map was always redundant given one Client per Discord guild.

**`src/adapters/discord/index.ts`** (+0/-76 net):
- `DiscordAdapterInfra.botConfig` field removed
- `private get/set botConfig` accessor on `DiscordAdapter` removed
- `start()` builds the `DiscordClientDisplayInfo` inline from `this.agent.displayName` + `this.presence.guildId`
- `updateConfig()` loses the `this.botConfig = config` line; the agent rebuild path (Holly cycle 1 invariant from #46) stays intact
- 39-line `DiscordAdapterInfra` JSDoc trimmed to the 4 concerns that remain post-cleanup; per-field JSDoc gains brief callouts so the interface stands on its own

**`src/cortex.ts`** (+0/-1):
- drop `botConfig: config` from the `DiscordAdapterInfra` literal

**Test fixtures** (5 files, -50 net):
- `client-degraded.test.ts` — `stubConfig: BotConfig` → `stubInfo: DiscordClientDisplayInfo`
- `operator-dm-buffer.test.ts` — drops the local `botConfig` stub + `BotConfig` import
- `render-envelope.test.ts` — same
- `system-events.test.ts` — drops `stubBotConfig` + `BotConfig` import
- `update-config.test.ts` — drops the `infra.botConfig is refreshed` test (surface no longer exists) + the `getInfra` helper. 7 tests → 6 tests

## Test plan

- [x] `bunx tsc --noEmit` clean
- [x] `bun test src/adapters/discord/__tests__/` — 91/91 pass (was 92; -1 for the now-deleted infra.botConfig refresh test)
- [x] `bun test` (full suite) — 1967 pass, 1 pre-existing mission-control React-shell fail (unchanged; gated on MIG-7 cutover)
- [x] no behavioural changes for callers — `start()` log lines now read `Guild: <single-id>` instead of `Guild(s): <comma-joined>` (cosmetic; every prior deployment ran a single guild per Client anyway)

🤖 Generated with [Claude Code](https://claude.com/claude-code)