### PR TITLE
feat(cli/cortex): C-108.x — migrate-config bot.yaml → cortex.yaml (MIG-7.2e)

### DIFF
--- a/src/cli/cortex/commands/__tests__/fixtures/full.bot.yaml
+++ b/src/cli/cortex/commands/__tests__/fixtures/full.bot.yaml
@@ -1,0 +1,80 @@
+agent:
+  name: luna
+  displayName: Luna
+  operatorId: jc
+  operatorName: Jens-Christian
+  operatorDiscordId: "112233445566778899"
+  operatorMattermostId: mm-jc-id
+  dataResidency: NZ
+  personaFile: ./personas/luna.md
+
+discord:
+  - token: discord-token-aaaa
+    guildId: "100000000000000001"
+    agentChannelId: "100000000000000002"
+    logChannelId: "100000000000000003"
+    worklogChannelId: "100000000000000004"
+    contextDepth: 12
+    enableAgentLog: true
+    operatorRoleId: "100000000000000099"
+    roles:
+      - name: operator
+        users: ["112233445566778899"]
+        features: [chat, async, team]
+
+mattermost:
+  - apiUrl: https://mm.example.com
+    apiToken: mm-token-xxxx
+    triggerWord: "@luna"
+    channels: ["chan-a", "chan-b"]
+    pollIntervalMs: 5000
+
+trustedAgentBots:
+  - discordId: "600000000000000001"
+    name: echo
+
+claude:
+  timeoutMs: 120000
+  asyncTimeoutMs: 900000
+  additionalArgs: ["--allowedTools", "Bash"]
+  allowedTools: []
+  disallowedTools: ["WebFetch"]
+  allowedDirs: ["/Users/jc/work"]
+  readOnlyDirs: []
+
+attachments:
+  enabled: true
+  maxFileSizeBytes: 10485760
+
+execution:
+  default: local
+
+github:
+  webhookSecret: secret-shhh
+  repos:
+    - the-metafactory/cortex
+  agentDetection:
+    commitTrailers: ["Co-Authored-By: Claude"]
+    branchPatterns: ["^feat/(g|f|i)-\\d+"]
+    commentPatterns: ["^Starting:", "^Completed:"]
+
+api:
+  enabled: true
+  port: 8767
+
+paths:
+  publishedEventsDir: ~/.claude/events/published
+  logDir: ~/.config/cortex/logs
+
+grove:
+  notifications:
+    discord: true
+  baseUrl: https://grove.example.com
+
+networksDir: ./networks
+
+nats:
+  url: nats://localhost:4222
+  name: cortex
+  subjects:
+    - local.{org}.>

--- a/src/cli/cortex/commands/__tests__/fixtures/minimal.bot.yaml
+++ b/src/cli/cortex/commands/__tests__/fixtures/minimal.bot.yaml
@@ -1,0 +1,21 @@
+agent:
+  name: luna
+  displayName: Luna
+  operatorId: jc
+  operatorName: Jens-Christian
+  operatorDiscordId: "112233445566778899"
+  dataResidency: NZ
+  personaFile: ./personas/luna.md
+
+discord:
+  - token: discord-token-aaaa
+    guildId: "100000000000000001"
+    agentChannelId: "100000000000000002"
+    logChannelId: "100000000000000003"
+    contextDepth: 10
+
+claude:
+  timeoutMs: 120000
+
+paths:
+  logDir: ~/.config/cortex/logs

--- a/src/cli/cortex/commands/__tests__/fixtures/mismatched-lengths.bot.yaml
+++ b/src/cli/cortex/commands/__tests__/fixtures/mismatched-lengths.bot.yaml
@@ -1,0 +1,21 @@
+agent:
+  name: luna
+  displayName: Luna
+  operatorId: jc
+  dataResidency: NZ
+  personaFile: ./personas/luna.md
+
+discord:
+  - token: token-a
+    guildId: "200000000000000001"
+    agentChannelId: "200000000000000002"
+    logChannelId: "200000000000000003"
+  - token: token-b
+    guildId: "300000000000000001"
+    agentChannelId: "300000000000000002"
+    logChannelId: "300000000000000003"
+
+mattermost:
+  - apiUrl: https://mm.example.com
+    apiToken: mm-token-x
+    triggerWord: "@luna"

--- a/src/cli/cortex/commands/__tests__/fixtures/missing-persona.bot.yaml
+++ b/src/cli/cortex/commands/__tests__/fixtures/missing-persona.bot.yaml
@@ -1,0 +1,12 @@
+agent:
+  name: ghost
+  displayName: Ghost
+  operatorId: jc
+  dataResidency: NZ
+  personaFile: ./personas/ghost.md
+
+discord:
+  - token: ghost-token
+    guildId: "900000000000000001"
+    agentChannelId: "900000000000000002"
+    logChannelId: "900000000000000003"

--- a/src/cli/cortex/commands/__tests__/fixtures/multi-discord.bot.yaml
+++ b/src/cli/cortex/commands/__tests__/fixtures/multi-discord.bot.yaml
@@ -1,0 +1,23 @@
+agent:
+  name: luna
+  displayName: Luna
+  operatorId: jc
+  dataResidency: NZ
+  personaFile: ./personas/luna.md
+
+discord:
+  - instanceId: luna-guild-a
+    token: token-a
+    guildId: "200000000000000001"
+    agentChannelId: "200000000000000002"
+    logChannelId: "200000000000000003"
+  - instanceId: luna-guild-b
+    token: token-b
+    guildId: "300000000000000001"
+    agentChannelId: "300000000000000002"
+    logChannelId: "300000000000000003"
+  - instanceId: luna-guild-c
+    token: token-c
+    guildId: "400000000000000001"
+    agentChannelId: "400000000000000002"
+    logChannelId: "400000000000000003"

--- a/src/cli/cortex/commands/__tests__/fixtures/personas/echo.md
+++ b/src/cli/cortex/commands/__tests__/fixtures/personas/echo.md
@@ -1,0 +1,3 @@
+# Echo
+
+Test persona for migrate-config fixture.

--- a/src/cli/cortex/commands/__tests__/fixtures/personas/luna.md
+++ b/src/cli/cortex/commands/__tests__/fixtures/personas/luna.md
@@ -1,0 +1,3 @@
+# Luna
+
+Test persona for migrate-config fixture.

--- a/src/cli/cortex/commands/__tests__/fixtures/trust.bot.yaml
+++ b/src/cli/cortex/commands/__tests__/fixtures/trust.bot.yaml
@@ -1,0 +1,20 @@
+agent:
+  name: luna
+  displayName: Luna
+  operatorId: jc
+  dataResidency: NZ
+  personaFile: ./personas/luna.md
+
+discord:
+  - token: luna-token
+    guildId: "500000000000000001"
+    agentChannelId: "500000000000000002"
+    logChannelId: "500000000000000003"
+
+trustedAgentBots:
+  - discordId: "600000000000000001"
+    name: echo
+  - discordId: "700000000000000001"
+    name: holly
+  - discordId: "800000000000000001"
+    name: ivy

--- a/src/cli/cortex/commands/__tests__/migrate-config.test.ts
+++ b/src/cli/cortex/commands/__tests__/migrate-config.test.ts
@@ -1,0 +1,456 @@
+/**
+ * MIG-7.2e — migrate-config tests.
+ *
+ * Fixture-driven: each `*.bot.yaml` under `./fixtures/` represents a real
+ * grove-v2 deployment shape. Tests assert the conversion output rounds-trips
+ * through `CortexConfigSchema` and that warnings / mappings track expectations.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync, mkdtempSync, writeFileSync, existsSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import YAML from "yaml";
+
+import {
+  convertBotYaml,
+  formatCheckReport,
+  type LegacyBotYaml,
+} from "../migrate-config-lib";
+import { parseArgs, runMigrateConfig } from "../migrate-config";
+import { CortexConfigSchema } from "../../../../common/types/cortex-config";
+
+const FIXTURE_DIR = join(import.meta.dir, "fixtures");
+
+function loadFixture(name: string): LegacyBotYaml {
+  const raw = readFileSync(join(FIXTURE_DIR, name), "utf-8");
+  return YAML.parse(raw) as LegacyBotYaml;
+}
+
+// ---------------------------------------------------------------------------
+// Argument parsing
+// ---------------------------------------------------------------------------
+
+describe("parseArgs", () => {
+  test("parses input + --out", () => {
+    const args = parseArgs(["in.yaml", "--out", "out.yaml"]);
+    expect(args.input).toBe("in.yaml");
+    expect(args.out).toBe("out.yaml");
+    expect(args.check).toBe(false);
+    expect(args.strict).toBe(false);
+  });
+
+  test("parses --out=FORM equality syntax", () => {
+    const args = parseArgs(["in.yaml", "--out=out.yaml"]);
+    expect(args.out).toBe("out.yaml");
+  });
+
+  test("parses --check + --strict toggles", () => {
+    const args = parseArgs(["in.yaml", "--check", "--strict"]);
+    expect(args.check).toBe(true);
+    expect(args.strict).toBe(true);
+  });
+
+  test("rejects unknown flags", () => {
+    expect(() => parseArgs(["in.yaml", "--bogus"])).toThrow(/unknown flag/);
+  });
+
+  test("rejects --out without a value", () => {
+    expect(() => parseArgs(["in.yaml", "--out"])).toThrow(/requires a path/);
+  });
+
+  test("treats trailing flag as missing arg", () => {
+    expect(() => parseArgs(["in.yaml", "--out", "--check"])).toThrow(/requires a path/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Conversion: minimal single-agent
+// ---------------------------------------------------------------------------
+
+describe("convertBotYaml — minimal single-agent", () => {
+  test("emits one agent with discord presence + valid operator", () => {
+    const legacy = loadFixture("minimal.bot.yaml");
+    const result = convertBotYaml(legacy, { configDir: FIXTURE_DIR });
+
+    expect(result.cortex.operator.id).toBe("jc");
+    expect(result.cortex.operator.discordId).toBe("112233445566778899");
+    expect(result.cortex.operator.dataResidency).toBe("NZ");
+
+    expect(result.cortex.agents).toHaveLength(1);
+    const agent = result.cortex.agents[0]!;
+    expect(agent.id).toBe("luna");
+    expect(agent.displayName).toBe("Luna");
+    expect(agent.persona).toBe("./personas/luna.md");
+    expect(agent.presence.discord).toBeDefined();
+    expect(agent.presence.discord!.guildId).toBe("100000000000000001");
+    expect(agent.presence.mattermost).toBeUndefined();
+    expect(agent.trust).toEqual([]);
+  });
+
+  test("output round-trips through CortexConfigSchema", () => {
+    const legacy = loadFixture("minimal.bot.yaml");
+    const result = convertBotYaml(legacy, { configDir: FIXTURE_DIR });
+    // convertBotYaml already calls schema.parse internally, but re-parsing the
+    // returned object verifies the result is structurally complete (no fields
+    // dropped by the strict refine).
+    expect(() => CortexConfigSchema.parse(result.cortex)).not.toThrow();
+  });
+
+  test("produces a mapping entry for the single discord instance", () => {
+    const legacy = loadFixture("minimal.bot.yaml");
+    const result = convertBotYaml(legacy, { configDir: FIXTURE_DIR });
+    expect(result.mappings).toHaveLength(1);
+    expect(result.mappings[0]).toMatchObject({
+      legacyKind: "discord",
+      legacyIndex: 0,
+      newAgentId: "luna",
+      newPresence: "discord",
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Conversion: multi-discord (suffix synthesis)
+// ---------------------------------------------------------------------------
+
+describe("convertBotYaml — multi-discord", () => {
+  test("emits N agents with -2, -3 suffixes", () => {
+    const legacy = loadFixture("multi-discord.bot.yaml");
+    const result = convertBotYaml(legacy, { configDir: FIXTURE_DIR });
+    expect(result.cortex.agents.map((a) => a.id)).toEqual(["luna", "luna-2", "luna-3"]);
+  });
+
+  test("each variant carries its own discord presence", () => {
+    const legacy = loadFixture("multi-discord.bot.yaml");
+    const result = convertBotYaml(legacy, { configDir: FIXTURE_DIR });
+    expect(result.cortex.agents[0]!.presence.discord!.token).toBe("token-a");
+    expect(result.cortex.agents[1]!.presence.discord!.token).toBe("token-b");
+    expect(result.cortex.agents[2]!.presence.discord!.token).toBe("token-c");
+  });
+
+  test("emits one warning announcing the suffix expansion", () => {
+    const legacy = loadFixture("multi-discord.bot.yaml");
+    const result = convertBotYaml(legacy, { configDir: FIXTURE_DIR });
+    const warning = result.warnings.find((w) => w.field === "agents");
+    expect(warning).toBeDefined();
+    expect(warning!.message).toMatch(/emitting 3 agents/);
+  });
+
+  test("mapping table records all 3 input instanceIds", () => {
+    const legacy = loadFixture("multi-discord.bot.yaml");
+    const result = convertBotYaml(legacy, { configDir: FIXTURE_DIR });
+    expect(result.mappings.map((m) => m.legacyInstanceId)).toEqual([
+      "luna-guild-a",
+      "luna-guild-b",
+      "luna-guild-c",
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Conversion: trustedAgentBots round-trip
+// ---------------------------------------------------------------------------
+
+describe("convertBotYaml — trustedAgentBots", () => {
+  test("maps each entry's `name` into agents[].trust", () => {
+    const legacy = loadFixture("trust.bot.yaml");
+    const result = convertBotYaml(legacy, { configDir: FIXTURE_DIR });
+    expect(result.cortex.agents[0]!.trust).toEqual(["echo", "holly", "ivy"]);
+  });
+
+  test("normalizes mixed-case trusted-bot names with a warning", () => {
+    const legacy: LegacyBotYaml = {
+      agent: {
+        name: "luna",
+        displayName: "Luna",
+        operatorId: "jc",
+        personaFile: "./personas/luna.md",
+      },
+      discord: [
+        {
+          token: "t",
+          guildId: "1",
+          agentChannelId: "2",
+          logChannelId: "3",
+        },
+      ],
+      trustedAgentBots: [{ discordId: "9", name: "Echo Bot" }],
+    };
+    const result = convertBotYaml(legacy, { configDir: FIXTURE_DIR });
+    expect(result.cortex.agents[0]!.trust).toEqual(["echo-bot"]);
+    expect(result.warnings.some((w) => w.field === "trustedAgentBots")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Conversion: persona-file validation
+// ---------------------------------------------------------------------------
+
+describe("convertBotYaml — persona-file validation", () => {
+  test("warns when personaFile path does not exist on disk", () => {
+    const legacy = loadFixture("missing-persona.bot.yaml");
+    const result = convertBotYaml(legacy, { configDir: FIXTURE_DIR });
+    const personaWarn = result.warnings.find((w) => w.field === "agents[ghost].persona");
+    expect(personaWarn).toBeDefined();
+    expect(personaWarn!.message).toMatch(/persona file not found/);
+  });
+
+  test("skips file-existence check when configDir is omitted", () => {
+    const legacy = loadFixture("missing-persona.bot.yaml");
+    const result = convertBotYaml(legacy, {});
+    // file-existence warning suppressed without a configDir
+    const personaWarn = result.warnings.find(
+      (w) => w.field === "agents[ghost].persona" && /not found/.test(w.message),
+    );
+    expect(personaWarn).toBeUndefined();
+  });
+
+  test("defaults to ./personas/<id>.md when personaFile omitted, with warning", () => {
+    const legacy: LegacyBotYaml = {
+      agent: { name: "luna", displayName: "Luna", operatorId: "jc" },
+      discord: [{ token: "t", guildId: "1", agentChannelId: "2", logChannelId: "3" }],
+    };
+    const result = convertBotYaml(legacy, {});
+    expect(result.cortex.agents[0]!.persona).toBe("./personas/luna.md");
+    const w = result.warnings.find((x) => x.field === "agents[luna].persona");
+    expect(w).toBeDefined();
+    expect(w!.message).toMatch(/defaulted/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Conversion: full bot.yaml (every field exercised)
+// ---------------------------------------------------------------------------
+
+describe("convertBotYaml — full fixture", () => {
+  test("output passes CortexConfigSchema validation", () => {
+    const legacy = loadFixture("full.bot.yaml");
+    const result = convertBotYaml(legacy, { configDir: FIXTURE_DIR });
+    expect(() => CortexConfigSchema.parse(result.cortex)).not.toThrow();
+  });
+
+  test("operator block carries discord + mattermost + dataResidency", () => {
+    const legacy = loadFixture("full.bot.yaml");
+    const result = convertBotYaml(legacy, { configDir: FIXTURE_DIR });
+    expect(result.cortex.operator).toEqual({
+      id: "jc",
+      displayName: "Jens-Christian",
+      discordId: "112233445566778899",
+      mattermostId: "mm-jc-id",
+      dataResidency: "NZ",
+    });
+  });
+
+  test("emits both discord and mattermost presence on a single agent", () => {
+    const legacy = loadFixture("full.bot.yaml");
+    const result = convertBotYaml(legacy, { configDir: FIXTURE_DIR });
+    expect(result.cortex.agents).toHaveLength(1);
+    const agent = result.cortex.agents[0]!;
+    expect(agent.presence.discord).toBeDefined();
+    expect(agent.presence.mattermost).toBeDefined();
+    expect(agent.presence.discord!.worklogChannelId).toBe("100000000000000004");
+    expect(agent.presence.discord!.operatorRoleId).toBe("100000000000000099");
+    expect(agent.presence.mattermost!.apiUrl).toBe("https://mm.example.com");
+  });
+
+  test("legacy api.enabled=true synthesizes a dashboard renderer", () => {
+    const legacy = loadFixture("full.bot.yaml");
+    const result = convertBotYaml(legacy, { configDir: FIXTURE_DIR });
+    const dash = result.cortex.renderers.find((r) => r.kind === "dashboard");
+    expect(dash).toBeDefined();
+    expect(dash!.kind).toBe("dashboard");
+    if (dash && dash.kind === "dashboard") {
+      expect(dash.port).toBe(8767);
+    }
+    expect(result.warnings.some((w) => w.field === "api")).toBe(true);
+  });
+
+  test("warns about dropped `grove:` block", () => {
+    const legacy = loadFixture("full.bot.yaml");
+    const result = convertBotYaml(legacy, { configDir: FIXTURE_DIR });
+    expect(result.warnings.some((w) => w.field === "grove")).toBe(true);
+  });
+
+  test("passes nats config through unchanged", () => {
+    const legacy = loadFixture("full.bot.yaml");
+    const result = convertBotYaml(legacy, { configDir: FIXTURE_DIR });
+    expect(result.cortex.nats?.url).toBe("nats://localhost:4222");
+    expect(result.cortex.nats?.subjects).toEqual(["local.{org}.>"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Conversion: structural failures
+// ---------------------------------------------------------------------------
+
+describe("convertBotYaml — structural failures", () => {
+  test("throws when input is not an object", () => {
+    expect(() => convertBotYaml("not an object" as unknown as LegacyBotYaml)).toThrow(/not an object/);
+  });
+
+  test("throws when agent block is missing", () => {
+    expect(() => convertBotYaml({ discord: [] } as unknown as LegacyBotYaml)).toThrow(/missing required `agent:`/);
+  });
+
+  test("throws when agent.name is missing", () => {
+    expect(() =>
+      convertBotYaml({ agent: { displayName: "x" } } as unknown as LegacyBotYaml),
+    ).toThrow(/agent\.name/);
+  });
+
+  test("throws when agent.displayName is missing", () => {
+    expect(() =>
+      convertBotYaml({ agent: { name: "luna" } } as unknown as LegacyBotYaml),
+    ).toThrow(/agent\.displayName/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Operator id normalization
+// ---------------------------------------------------------------------------
+
+describe("convertBotYaml — operator id normalization", () => {
+  test("upcases dataResidency when 2 lowercase letters", () => {
+    const legacy: LegacyBotYaml = {
+      agent: {
+        name: "luna",
+        displayName: "Luna",
+        operatorId: "jc",
+        dataResidency: "ch",
+        personaFile: "./personas/luna.md",
+      },
+      discord: [{ token: "t", guildId: "1", agentChannelId: "2", logChannelId: "3" }],
+    };
+    const result = convertBotYaml(legacy, { configDir: FIXTURE_DIR });
+    expect(result.cortex.operator.dataResidency).toBe("CH");
+    expect(result.warnings.some((w) => w.field === "operator.dataResidency")).toBe(true);
+  });
+
+  test("falls back to NZ when dataResidency is malformed", () => {
+    const legacy: LegacyBotYaml = {
+      agent: {
+        name: "luna",
+        displayName: "Luna",
+        operatorId: "jc",
+        dataResidency: "Switzerland",
+        personaFile: "./personas/luna.md",
+      },
+      discord: [{ token: "t", guildId: "1", agentChannelId: "2", logChannelId: "3" }],
+    };
+    const result = convertBotYaml(legacy, { configDir: FIXTURE_DIR });
+    expect(result.cortex.operator.dataResidency).toBe("NZ");
+  });
+
+  test("normalizes mixed-case operatorId with a warning", () => {
+    const legacy: LegacyBotYaml = {
+      agent: {
+        name: "luna",
+        displayName: "Luna",
+        operatorId: "JC",
+        personaFile: "./personas/luna.md",
+      },
+      discord: [{ token: "t", guildId: "1", agentChannelId: "2", logChannelId: "3" }],
+    };
+    const result = convertBotYaml(legacy, { configDir: FIXTURE_DIR });
+    expect(result.cortex.operator.id).toBe("jc");
+    expect(result.warnings.some((w) => w.field === "operator.id")).toBe(true);
+  });
+
+  test("falls back operator.id to agent.name when operatorId unset", () => {
+    const legacy: LegacyBotYaml = {
+      agent: {
+        name: "luna",
+        displayName: "Luna",
+        personaFile: "./personas/luna.md",
+      },
+      discord: [{ token: "t", guildId: "1", agentChannelId: "2", logChannelId: "3" }],
+    };
+    const result = convertBotYaml(legacy, { configDir: FIXTURE_DIR });
+    expect(result.cortex.operator.id).toBe("luna");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Check report rendering
+// ---------------------------------------------------------------------------
+
+describe("formatCheckReport", () => {
+  test("lists operator, agents, renderers, mappings and warnings", () => {
+    const legacy = loadFixture("full.bot.yaml");
+    const result = convertBotYaml(legacy, { configDir: FIXTURE_DIR });
+    const report = formatCheckReport(result);
+    expect(report).toMatch(/operator: jc/);
+    expect(report).toMatch(/agents: +1/);
+    expect(report).toMatch(/instance mappings:/);
+    expect(report).toMatch(/warnings/);
+  });
+
+  test("reports `warnings: none` when no warnings produced", () => {
+    const legacy = loadFixture("minimal.bot.yaml");
+    const result = convertBotYaml(legacy, { configDir: FIXTURE_DIR });
+    const report = formatCheckReport(result);
+    if (result.warnings.length === 0) {
+      expect(report).toMatch(/warnings: none/);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runMigrateConfig — end-to-end CLI smoke
+// ---------------------------------------------------------------------------
+
+describe("runMigrateConfig", () => {
+  test("--check exits 0 with valid input", async () => {
+    const code = await runMigrateConfig([
+      join(FIXTURE_DIR, "minimal.bot.yaml"),
+      "--check",
+    ]);
+    expect(code).toBe(0);
+  });
+
+  test("writes output to --out file", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "cortex-mig-7-2e-"));
+    const out = join(dir, "cortex.yaml");
+    const code = await runMigrateConfig([
+      join(FIXTURE_DIR, "minimal.bot.yaml"),
+      "--out",
+      out,
+    ]);
+    expect(code).toBe(0);
+    expect(existsSync(out)).toBe(true);
+    const written = YAML.parse(readFileSync(out, "utf-8"));
+    // Re-parse via the schema to confirm the file is a valid cortex.yaml
+    expect(() => CortexConfigSchema.parse(written)).not.toThrow();
+  });
+
+  test("--strict returns exit code 2 when warnings present", async () => {
+    // missing-persona fixture produces a persona-file-not-found warning
+    const code = await runMigrateConfig([
+      join(FIXTURE_DIR, "missing-persona.bot.yaml"),
+      "--check",
+      "--strict",
+    ]);
+    expect(code).toBe(2);
+  });
+
+  test("returns exit code 1 for missing input file", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "cortex-mig-7-2e-"));
+    const bogus = join(dir, "nonexistent.bot.yaml");
+    const code = await runMigrateConfig([bogus]);
+    expect(code).toBe(1);
+  });
+
+  test("returns exit code 1 for invalid YAML", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "cortex-mig-7-2e-"));
+    const bad = join(dir, "bad.yaml");
+    writeFileSync(bad, "agent: {name: luna, displayName: [unterminated", "utf-8");
+    const code = await runMigrateConfig([bad]);
+    expect(code).toBe(1);
+  });
+
+  test("returns exit code 0 with --help", async () => {
+    const code = await runMigrateConfig(["--help"]);
+    expect(code).toBe(0);
+  });
+});

--- a/src/cli/cortex/commands/__tests__/migrate-config.test.ts
+++ b/src/cli/cortex/commands/__tests__/migrate-config.test.ts
@@ -372,6 +372,148 @@ describe("convertBotYaml — operator id normalization", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Mismatched discord / mattermost array lengths
+// (Holly cortex#51 round 1 major #2 — locked here so the synthesis logic
+//  for "2 discord + 1 mattermost" can't silently change.)
+// ---------------------------------------------------------------------------
+
+describe("convertBotYaml — mismatched discord/mattermost lengths", () => {
+  test("emits N=max(discord, mattermost) agents", () => {
+    const legacy = loadFixture("mismatched-lengths.bot.yaml");
+    const result = convertBotYaml(legacy, { configDir: FIXTURE_DIR });
+    expect(result.cortex.agents.map((a) => a.id)).toEqual(["luna", "luna-2"]);
+  });
+
+  test("first agent carries both discord and mattermost presence", () => {
+    const legacy = loadFixture("mismatched-lengths.bot.yaml");
+    const result = convertBotYaml(legacy, { configDir: FIXTURE_DIR });
+    expect(result.cortex.agents[0]!.presence.discord).toBeDefined();
+    expect(result.cortex.agents[0]!.presence.mattermost).toBeDefined();
+  });
+
+  test("second agent has only discord (mattermost ran out)", () => {
+    const legacy = loadFixture("mismatched-lengths.bot.yaml");
+    const result = convertBotYaml(legacy, { configDir: FIXTURE_DIR });
+    expect(result.cortex.agents[1]!.presence.discord).toBeDefined();
+    expect(result.cortex.agents[1]!.presence.mattermost).toBeUndefined();
+  });
+
+  test("empty discord + populated mattermost emits 1 mattermost-only agent", () => {
+    const legacy: LegacyBotYaml = {
+      agent: {
+        name: "luna",
+        displayName: "Luna",
+        operatorId: "jc",
+        personaFile: "./personas/luna.md",
+      },
+      discord: [],
+      mattermost: [
+        { apiUrl: "https://mm.example.com", apiToken: "tok" },
+      ],
+    };
+    const result = convertBotYaml(legacy, { configDir: FIXTURE_DIR });
+    expect(result.cortex.agents).toHaveLength(1);
+    expect(result.cortex.agents[0]!.presence.discord).toBeUndefined();
+    expect(result.cortex.agents[0]!.presence.mattermost).toBeDefined();
+  });
+
+  test("output round-trips through CortexConfigSchema", () => {
+    const legacy = loadFixture("mismatched-lengths.bot.yaml");
+    const result = convertBotYaml(legacy, { configDir: FIXTURE_DIR });
+    expect(() => CortexConfigSchema.parse(result.cortex)).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// First-variant display name (Holly cortex#51 round 1 nit-1)
+// ---------------------------------------------------------------------------
+
+describe("convertBotYaml — first-variant display name", () => {
+  test("when variantCount > 1, agents[0] keeps bare displayName", () => {
+    const legacy = loadFixture("multi-discord.bot.yaml");
+    const result = convertBotYaml(legacy, { configDir: FIXTURE_DIR });
+    expect(result.cortex.agents[0]!.displayName).toBe("Luna");
+    expect(result.cortex.agents[1]!.displayName).toBe("Luna (2)");
+    expect(result.cortex.agents[2]!.displayName).toBe("Luna (3)");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Degenerate agent.name (Holly cortex#51 round 1 suggestion)
+// ---------------------------------------------------------------------------
+
+describe("convertBotYaml — degenerate agent.name", () => {
+  test("throws when agent.name normalizes to empty string", () => {
+    const legacy: LegacyBotYaml = {
+      agent: { name: "!!!", displayName: "Bang" },
+      discord: [{ token: "t", guildId: "1", agentChannelId: "2", logChannelId: "3" }],
+    };
+    expect(() => convertBotYaml(legacy, {})).toThrow(/cannot be derived to a valid agent id/);
+  });
+
+  test("throws when trustedAgentBots entry normalizes to empty string", () => {
+    const legacy: LegacyBotYaml = {
+      agent: { name: "luna", displayName: "Luna", personaFile: "./personas/luna.md" },
+      discord: [{ token: "t", guildId: "1", agentChannelId: "2", logChannelId: "3" }],
+      trustedAgentBots: [{ name: "!!!" }],
+    };
+    expect(() => convertBotYaml(legacy, {})).toThrow(/cannot be derived/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Defaults sourced from CortexConfig schema (Holly cortex#51 round 1 major #1)
+// ---------------------------------------------------------------------------
+
+describe("convertBotYaml — schema-sourced defaults", () => {
+  test("discord presence fills schema defaults for unspecified fields", () => {
+    const legacy: LegacyBotYaml = {
+      agent: { name: "luna", displayName: "Luna", personaFile: "./personas/luna.md" },
+      discord: [{ token: "t", guildId: "1", agentChannelId: "2", logChannelId: "3" }],
+    };
+    const result = convertBotYaml(legacy, {});
+    const d = result.cortex.agents[0]!.presence.discord!;
+    expect(d.contextDepth).toBe(10);
+    expect(d.enableAgentLog).toBe(false);
+    expect(d.defaultRole).toBe("allow-all");
+    expect(d.enabled).toBe(true);
+    // dm block defaults from DMConfigSchema (operatorRole defaulted from DMRoleSchema)
+    expect(d.dm.defaultRole).toBe("denied");
+  });
+
+  test("mattermost presence fills schema defaults for unspecified fields", () => {
+    const legacy: LegacyBotYaml = {
+      agent: { name: "luna", displayName: "Luna", personaFile: "./personas/luna.md" },
+      mattermost: [{ apiUrl: "https://mm.example.com" }],
+    };
+    const result = convertBotYaml(legacy, {});
+    const m = result.cortex.agents[0]!.presence.mattermost!;
+    expect(m.callbackPort).toBe(8080);
+    expect(m.pollIntervalMs).toBe(3000);
+    expect(m.defaultRole).toBe("allow-all");
+    expect(m.allowedUsers).toEqual([]);
+    expect(m.channels).toEqual([]);
+  });
+
+  test("malformed renderers entry throws at the conversion site (not the final parse)", () => {
+    const legacy: LegacyBotYaml = {
+      agent: { name: "luna", displayName: "Luna", personaFile: "./personas/luna.md" },
+      discord: [{ token: "t", guildId: "1", agentChannelId: "2", logChannelId: "3" }],
+      renderers: [{ kind: "dashbord" } as unknown],
+    };
+    expect(() => convertBotYaml(legacy, {})).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildTrustList — extracted helper (Holly cortex#51 round 1 architecture)
+// ---------------------------------------------------------------------------
+
+// (Coverage of buildTrustList behaviors is folded into the trustedAgentBots
+//  and degenerate-name describe blocks above; the helper is exercised via
+//  the public `convertBotYaml` boundary.)
+
+// ---------------------------------------------------------------------------
 // Check report rendering
 // ---------------------------------------------------------------------------
 

--- a/src/cli/cortex/commands/migrate-config-lib.ts
+++ b/src/cli/cortex/commands/migrate-config-lib.ts
@@ -1,0 +1,535 @@
+/**
+ * MIG-7.2e — Pure conversion logic for `bot.yaml` (grove-v2) → `cortex.yaml`.
+ *
+ * Side-effect-free: takes a parsed legacy object, returns the converted object
+ * + a list of warnings + a mapping table for `--check` output. The CLI wrapper
+ * in `migrate-config.ts` handles file IO and stdout formatting.
+ *
+ * Coupling boundary: this module imports the cortex-config Zod schema and
+ * verifies its output round-trips through `.parse()`. It does NOT import the
+ * legacy `BotConfigSchema` — the legacy file in the wild may carry fields
+ * (`personaFile`, `trustedAgentBots`) that were dropped from the in-repo
+ * schema, so we accept input permissively and validate output strictly.
+ */
+
+import { existsSync } from "fs";
+import { isAbsolute, resolve } from "path";
+
+import {
+  type CortexConfig,
+  CortexConfigSchema,
+  type DiscordPresence,
+  type MattermostPresence,
+} from "../../../common/types/cortex-config";
+
+// =============================================================================
+// Legacy input shape — permissive
+// =============================================================================
+
+/**
+ * Legacy `bot.yaml` fields we accept. Not a Zod schema: real grove-v2
+ * deployments may carry historical fields (`personaFile`, `trustedAgentBots`)
+ * that no longer exist in `BotConfigSchema`. Accepting them as `unknown` lets
+ * the converter translate them rather than fail at the input gate.
+ */
+export interface LegacyAgent {
+  name: string;
+  displayName: string;
+  operatorId?: string;
+  operatorName?: string;
+  operatorDiscordId?: string;
+  operatorMattermostId?: string;
+  dataResidency?: string;
+  personaFile?: string;
+}
+
+export interface LegacyDiscordInstance {
+  instanceId?: string;
+  enabled?: boolean;
+  token: string;
+  guildId: string | number;
+  agentChannelId: string | number;
+  logChannelId: string | number;
+  worklogChannelId?: string | number;
+  contextDepth?: number;
+  enableAgentLog?: boolean;
+  roles?: unknown[];
+  defaultRole?: string;
+  dm?: unknown;
+  operatorRoleId?: string | number;
+}
+
+export interface LegacyMattermostInstance {
+  instanceId?: string;
+  enabled?: boolean;
+  callbackPort?: number;
+  triggerWord?: string;
+  webhookUrl?: string;
+  apiUrl?: string;
+  apiToken?: string;
+  webhookToken?: string;
+  channels?: string[];
+  pollIntervalMs?: number;
+  allowedUsers?: string[];
+  roles?: unknown[];
+  defaultRole?: string;
+}
+
+export interface LegacyTrustedAgentBot {
+  /** Discord user id of the peer bot. Used only for human reference today. */
+  discordId?: string;
+  /** Mattermost user id of the peer bot. Used only for human reference today. */
+  mattermostId?: string;
+  /** Agent id of the peer bot — this is what migrates into `trust:`. */
+  name: string;
+}
+
+export interface LegacyBotYaml {
+  agent: LegacyAgent;
+  discord?: LegacyDiscordInstance[] | LegacyDiscordInstance;
+  mattermost?: LegacyMattermostInstance[] | LegacyMattermostInstance;
+  trustedAgentBots?: LegacyTrustedAgentBot[];
+  claude?: unknown;
+  attachments?: unknown;
+  execution?: unknown;
+  github?: unknown;
+  api?: { enabled?: boolean; port?: number; corsOrigin?: string; mode?: string };
+  paths?: unknown;
+  grove?: unknown;
+  networksDir?: string;
+  networks?: unknown[];
+  nats?: unknown;
+  renderers?: unknown[];
+  [key: string]: unknown;
+}
+
+// =============================================================================
+// Conversion output
+// =============================================================================
+
+export interface ConversionWarning {
+  field: string;
+  message: string;
+}
+
+export interface InstanceMapping {
+  legacyKind: "discord" | "mattermost";
+  legacyIndex: number;
+  legacyInstanceId: string | undefined;
+  newAgentId: string;
+  newPresence: "discord" | "mattermost";
+}
+
+export interface ConversionResult {
+  /** The cortex.yaml-shaped object, ready to YAML.stringify and write. */
+  cortex: CortexConfig;
+  /** Non-fatal warnings — surfaced to stderr by the CLI. */
+  warnings: ConversionWarning[];
+  /**
+   * Per-instance mapping table — shown by `--check`. Validates that each
+   * legacy `discord[].instanceId` / `mattermost[].instanceId` maps to exactly
+   * one new agent presence (plan §4 7.2e validation criterion #1).
+   */
+  mappings: InstanceMapping[];
+}
+
+/**
+ * Options controlling validation strictness. The CLI flips `strict: true` for
+ * `--strict` mode (warnings → errors).
+ */
+export interface ConvertOptions {
+  /**
+   * Directory the input `bot.yaml` was loaded from. Used to resolve
+   * `personaFile` paths for the file-exists validation. Optional — when
+   * omitted, persona files are not checked on disk (e.g. when tests parse
+   * fixtures via in-memory strings rather than file paths).
+   */
+  configDir?: string;
+}
+
+// =============================================================================
+// Conversion
+// =============================================================================
+
+const AGENT_ID_PATTERN = /^[a-z0-9-]+$/;
+
+function toArray<T>(val: T[] | T | undefined): T[] {
+  if (val === undefined) return [];
+  return Array.isArray(val) ? val : [val];
+}
+
+function coerceString(val: string | number | undefined): string | undefined {
+  if (val === undefined) return undefined;
+  return String(val);
+}
+
+/**
+ * Lift a legacy `agent.name` to a cortex agent id. The cortex schema enforces
+ * `^[a-z0-9-]+$`; legacy `agent.name` historically allowed mixed case (Luna,
+ * Echo, …) so we lowercase and replace any disallowed char with `-`.
+ */
+function deriveAgentId(legacyName: string): string {
+  return legacyName.trim().toLowerCase().replace(/[^a-z0-9-]+/g, "-").replace(/^-+|-+$/g, "");
+}
+
+/**
+ * Lift the operator block out of the singular legacy `agent:` field. The
+ * cortex `operator:` carries id / displayName / discordId / mattermostId /
+ * dataResidency — all lifted from the legacy `agent.operator*` fields.
+ *
+ * Falls back to `agent.name` for the operator id when `operatorId` is unset,
+ * since pre-cortex deployments often ran one bot per operator without a
+ * distinct operatorId.
+ */
+function buildOperator(
+  legacy: LegacyBotYaml,
+  warnings: ConversionWarning[],
+): CortexConfig["operator"] {
+  const a = legacy.agent;
+
+  const rawOperatorId = a.operatorId ?? a.name;
+  const operatorId = deriveAgentId(rawOperatorId);
+  if (operatorId !== rawOperatorId) {
+    warnings.push({
+      field: "operator.id",
+      message: `operatorId "${rawOperatorId}" normalized to "${operatorId}" (cortex requires lowercase alphanumeric + hyphen)`,
+    });
+  }
+
+  let dataResidency = a.dataResidency;
+  if (dataResidency === undefined) {
+    dataResidency = "NZ";
+  } else if (!/^[A-Z]{2}$/.test(dataResidency)) {
+    const fixed = dataResidency.toUpperCase();
+    if (/^[A-Z]{2}$/.test(fixed)) {
+      warnings.push({
+        field: "operator.dataResidency",
+        message: `dataResidency "${dataResidency}" upcased to "${fixed}"`,
+      });
+      dataResidency = fixed;
+    } else {
+      warnings.push({
+        field: "operator.dataResidency",
+        message: `dataResidency "${dataResidency}" not a 2-letter ISO-3166 code; defaulting to "NZ"`,
+      });
+      dataResidency = "NZ";
+    }
+  }
+
+  const operator: CortexConfig["operator"] = { id: operatorId, dataResidency };
+  if (a.operatorName) operator.displayName = a.operatorName;
+  if (a.operatorDiscordId) operator.discordId = a.operatorDiscordId;
+  if (a.operatorMattermostId) operator.mattermostId = a.operatorMattermostId;
+  return operator;
+}
+
+/**
+ * Convert a single legacy discord instance to a cortex DiscordPresence block.
+ * Drops `instanceId` — cortex computes it at runtime from
+ * `${agent.id}-discord` (per RESUME §Decisions §1).
+ */
+function convertDiscordPresence(inst: LegacyDiscordInstance): DiscordPresence {
+  const presence = {
+    enabled: inst.enabled ?? true,
+    token: inst.token,
+    guildId: String(inst.guildId),
+    agentChannelId: String(inst.agentChannelId),
+    logChannelId: String(inst.logChannelId),
+    contextDepth: inst.contextDepth ?? 10,
+    enableAgentLog: inst.enableAgentLog ?? false,
+    roles: (inst.roles as DiscordPresence["roles"]) ?? [],
+    defaultRole: inst.defaultRole ?? "allow-all",
+    dm: (inst.dm as DiscordPresence["dm"]) ?? {
+      operatorRole: { features: ["chat", "async", "team"], disallowedTools: [], bashGuard: true },
+      defaultRole: "denied" as const,
+      userRoles: [],
+    },
+  } as DiscordPresence;
+  const worklog = coerceString(inst.worklogChannelId);
+  if (worklog) presence.worklogChannelId = worklog;
+  const role = coerceString(inst.operatorRoleId);
+  if (role) presence.operatorRoleId = role;
+  return presence;
+}
+
+/**
+ * Convert a single legacy mattermost instance. Same field-for-field lift as
+ * discord; `instanceId` dropped.
+ */
+function convertMattermostPresence(inst: LegacyMattermostInstance): MattermostPresence {
+  return {
+    enabled: inst.enabled ?? true,
+    callbackPort: inst.callbackPort ?? 8080,
+    triggerWord: inst.triggerWord,
+    webhookUrl: inst.webhookUrl,
+    apiUrl: inst.apiUrl,
+    apiToken: inst.apiToken,
+    webhookToken: inst.webhookToken,
+    channels: inst.channels ?? [],
+    pollIntervalMs: inst.pollIntervalMs ?? 3000,
+    allowedUsers: inst.allowedUsers ?? [],
+    roles: (inst.roles as MattermostPresence["roles"]) ?? [],
+    defaultRole: inst.defaultRole ?? "allow-all",
+  } as MattermostPresence;
+}
+
+/**
+ * Resolve the persona file path for a converted agent. Returns the path the
+ * cortex.yaml should carry plus an optional warning when the file doesn't
+ * exist on disk (only checked when `configDir` is supplied).
+ *
+ * Fallback when `personaFile` is unset: `./personas/${agentId}.md`. The
+ * cortex schema requires a non-empty string here; the warning surfaces the
+ * fact that the file may need to be created.
+ */
+function resolvePersona(
+  legacyPersonaFile: string | undefined,
+  agentId: string,
+  configDir: string | undefined,
+  warnings: ConversionWarning[],
+): string {
+  const personaPath = legacyPersonaFile?.trim() || `./personas/${agentId}.md`;
+
+  if (configDir) {
+    const abs = isAbsolute(personaPath) ? personaPath : resolve(configDir, personaPath);
+    if (!existsSync(abs)) {
+      warnings.push({
+        field: `agents[${agentId}].persona`,
+        message: `persona file not found at ${abs}${legacyPersonaFile ? "" : " (defaulted from agent name)"}`,
+      });
+    }
+  } else if (!legacyPersonaFile) {
+    warnings.push({
+      field: `agents[${agentId}].persona`,
+      message: `agent.personaFile not set; defaulted to ${personaPath}`,
+    });
+  }
+
+  return personaPath;
+}
+
+/**
+ * Synthesize the cortex `agents[]` list from the singular legacy `agent` plus
+ * the (possibly multi-entry) `discord[]` and `mattermost[]` arrays.
+ *
+ * Strategy (per RESUME §MIG-7.2e Agents synthesis):
+ *   - Pair discord[i] with mattermost[i] under one agent.
+ *   - Index 0 → base agent id (deriveAgentId(agent.name)).
+ *   - Index ≥1 → `${base}-${i + 1}` (so `luna-2`, `luna-3`).
+ *   - Trust list propagates to every variant.
+ *   - Persona path propagates to every variant.
+ */
+function buildAgents(
+  legacy: LegacyBotYaml,
+  warnings: ConversionWarning[],
+  mappings: InstanceMapping[],
+  configDir: string | undefined,
+): { agents: CortexConfig["agents"]; baseId: string } {
+  const discordInstances = toArray(legacy.discord);
+  const mattermostInstances = toArray(legacy.mattermost);
+  const baseId = deriveAgentId(legacy.agent.name);
+
+  if (!AGENT_ID_PATTERN.test(baseId)) {
+    throw new Error(
+      `agent.name "${legacy.agent.name}" cannot be derived to a valid agent id (^[a-z0-9-]+$)`,
+    );
+  }
+
+  const trust = (legacy.trustedAgentBots ?? []).map((t) => {
+    const id = deriveAgentId(t.name);
+    if (!AGENT_ID_PATTERN.test(id)) {
+      throw new Error(
+        `trustedAgentBots[].name "${t.name}" cannot be derived to a valid agent id (^[a-z0-9-]+$)`,
+      );
+    }
+    if (id !== t.name) {
+      warnings.push({
+        field: "trustedAgentBots",
+        message: `trusted bot name "${t.name}" normalized to "${id}"`,
+      });
+    }
+    return id;
+  });
+
+  const persona = resolvePersona(legacy.agent.personaFile, baseId, configDir, warnings);
+  const displayName = legacy.agent.displayName || legacy.agent.name;
+
+  const variantCount = Math.max(discordInstances.length, mattermostInstances.length, 1);
+
+  if (variantCount > 1) {
+    warnings.push({
+      field: "agents",
+      message: `legacy bot.yaml carries ${discordInstances.length} discord + ${mattermostInstances.length} mattermost instance(s) under a single agent.name — emitting ${variantCount} agents (${baseId}, ${baseId}-2, …)`,
+    });
+  }
+
+  const agents: CortexConfig["agents"] = [];
+  for (let i = 0; i < variantCount; i++) {
+    const variantId = i === 0 ? baseId : `${baseId}-${i + 1}`;
+    const presence: CortexConfig["agents"][number]["presence"] = {};
+    const d = discordInstances[i];
+    const m = mattermostInstances[i];
+    if (d) {
+      presence.discord = convertDiscordPresence(d);
+      mappings.push({
+        legacyKind: "discord",
+        legacyIndex: i,
+        legacyInstanceId: d.instanceId,
+        newAgentId: variantId,
+        newPresence: "discord",
+      });
+    }
+    if (m) {
+      presence.mattermost = convertMattermostPresence(m);
+      mappings.push({
+        legacyKind: "mattermost",
+        legacyIndex: i,
+        legacyInstanceId: m.instanceId,
+        newAgentId: variantId,
+        newPresence: "mattermost",
+      });
+    }
+    agents.push({
+      id: variantId,
+      displayName: variantCount === 1 ? displayName : `${displayName} (${i + 1})`,
+      persona,
+      roles: [],
+      trust,
+      presence,
+    });
+  }
+
+  return { agents, baseId };
+}
+
+/**
+ * Synthesize a dashboard renderer entry from the legacy `api:` block when
+ * `api.enabled` is true. Pre-existing top-level `renderers[]` in the legacy
+ * input passes through unchanged.
+ */
+function buildRenderers(legacy: LegacyBotYaml, warnings: ConversionWarning[]): CortexConfig["renderers"] {
+  const renderers: CortexConfig["renderers"] = [];
+
+  if (Array.isArray(legacy.renderers)) {
+    for (const r of legacy.renderers) {
+      renderers.push(r as CortexConfig["renderers"][number]);
+    }
+  }
+
+  if (legacy.api && legacy.api.enabled === true) {
+    const port = typeof legacy.api.port === "number" ? legacy.api.port : 8767;
+    renderers.push({ kind: "dashboard", port, subscribe: ["local.{org}.>"], projections: [] });
+    warnings.push({
+      field: "api",
+      message: `legacy api.enabled=true synthesized as renderers[].kind=dashboard (port ${port}); cloud-mode api fields (endpoint, apiKey, …) are NOT carried — re-add via networks/`,
+    });
+  }
+
+  return renderers;
+}
+
+/**
+ * Convert a legacy bot.yaml-shaped object to cortex.yaml-shape. Pure: no IO
+ * apart from optional `existsSync` for persona-file validation.
+ *
+ * Throws on structurally invalid input (e.g. missing `agent.name`). Returns
+ * the converted object plus warnings + mappings. The caller (CLI) decides
+ * whether warnings are fatal (`--strict`) or advisory.
+ *
+ * The output is validated against `CortexConfigSchema` so the helper never
+ * emits a YAML that cortex itself would reject at load. If schema parse
+ * fails, the error is re-thrown verbatim so the operator sees the field
+ * path Zod identified.
+ */
+export function convertBotYaml(
+  legacy: LegacyBotYaml,
+  opts: ConvertOptions = {},
+): ConversionResult {
+  if (!legacy || typeof legacy !== "object") {
+    throw new Error("input is not an object");
+  }
+  if (!legacy.agent || typeof legacy.agent !== "object") {
+    throw new Error("bot.yaml missing required `agent:` block");
+  }
+  if (!legacy.agent.name || typeof legacy.agent.name !== "string") {
+    throw new Error("bot.yaml missing required `agent.name`");
+  }
+  if (!legacy.agent.displayName || typeof legacy.agent.displayName !== "string") {
+    throw new Error("bot.yaml missing required `agent.displayName`");
+  }
+
+  const warnings: ConversionWarning[] = [];
+  const mappings: InstanceMapping[] = [];
+
+  const operator = buildOperator(legacy, warnings);
+  const { agents } = buildAgents(legacy, warnings, mappings, opts.configDir);
+  const renderers = buildRenderers(legacy, warnings);
+
+  if (legacy.grove !== undefined) {
+    warnings.push({
+      field: "grove",
+      message: "legacy `grove:` block (F-11 notification toggles) is dropped — re-implement via renderers when needed",
+    });
+  }
+
+  const cortex: Record<string, unknown> = {
+    operator,
+    agents,
+    renderers,
+  };
+
+  if (legacy.claude !== undefined) cortex.claude = legacy.claude;
+  else cortex.claude = {};
+
+  if (legacy.attachments !== undefined) cortex.attachments = legacy.attachments;
+  if (legacy.execution !== undefined) cortex.execution = legacy.execution;
+  if (legacy.github !== undefined) cortex.github = legacy.github;
+  if (legacy.paths !== undefined) cortex.paths = legacy.paths;
+  if (legacy.networksDir !== undefined) cortex.networksDir = legacy.networksDir;
+  if (legacy.networks !== undefined) cortex.networks = legacy.networks;
+  if (legacy.nats !== undefined) cortex.nats = legacy.nats;
+
+  const parsed = CortexConfigSchema.parse(cortex);
+  return { cortex: parsed, warnings, mappings };
+}
+
+/**
+ * Render a `--check` summary table. Returns a multi-line string suitable for
+ * stdout. Pure — no console.log inside.
+ */
+export function formatCheckReport(result: ConversionResult): string {
+  const lines: string[] = [];
+  lines.push("cortex migrate-config — dry-run report");
+  lines.push("");
+  lines.push(`operator: ${result.cortex.operator.id} (dataResidency=${result.cortex.operator.dataResidency})`);
+  lines.push(`agents:   ${result.cortex.agents.length}`);
+  for (const a of result.cortex.agents) {
+    const platforms = [
+      a.presence.discord ? "discord" : null,
+      a.presence.mattermost ? "mattermost" : null,
+    ].filter(Boolean).join(", ");
+    lines.push(`  - ${a.id} (${platforms}) persona=${a.persona} trust=[${a.trust.join(", ")}]`);
+  }
+  lines.push(`renderers: ${result.cortex.renderers.length}`);
+  for (const r of result.cortex.renderers) {
+    lines.push(`  - ${r.kind}`);
+  }
+  lines.push("");
+  if (result.mappings.length > 0) {
+    lines.push("instance mappings:");
+    for (const m of result.mappings) {
+      const label = m.legacyInstanceId ?? `<auto-${m.legacyIndex}>`;
+      lines.push(`  ${m.legacyKind}[${m.legacyIndex}] ${label}  →  agents[${m.newAgentId}].presence.${m.newPresence}`);
+    }
+    lines.push("");
+  }
+  if (result.warnings.length > 0) {
+    lines.push(`warnings (${result.warnings.length}):`);
+    for (const w of result.warnings) {
+      lines.push(`  [${w.field}] ${w.message}`);
+    }
+  } else {
+    lines.push("warnings: none");
+  }
+  return lines.join("\n");
+}

--- a/src/cli/cortex/commands/migrate-config-lib.ts
+++ b/src/cli/cortex/commands/migrate-config-lib.ts
@@ -19,7 +19,10 @@ import {
   type CortexConfig,
   CortexConfigSchema,
   type DiscordPresence,
+  DiscordPresenceSchema,
   type MattermostPresence,
+  MattermostPresenceSchema,
+  RendererSchema,
 } from "../../../common/types/cortex-config";
 
 // =============================================================================
@@ -227,50 +230,55 @@ function buildOperator(
  * Convert a single legacy discord instance to a cortex DiscordPresence block.
  * Drops `instanceId` — cortex computes it at runtime from
  * `${agent.id}-discord` (per RESUME §Decisions §1).
+ *
+ * Delegates default-application to `DiscordPresenceSchema.parse()` rather than
+ * hand-coding `?? value` fallbacks, so the source-of-truth for defaults stays
+ * in `cortex-config.ts`. Holly W2-1 (cortex#51 round 1) flagged that
+ * duplicating those defaults silently diverges if the schema evolves; parsing
+ * through the schema removes both the duplication and the trailing `as
+ * DiscordPresence` cast that suppressed type-checking on the manually built
+ * object.
  */
 function convertDiscordPresence(inst: LegacyDiscordInstance): DiscordPresence {
-  const presence = {
-    enabled: inst.enabled ?? true,
+  const candidate: Record<string, unknown> = {
     token: inst.token,
     guildId: String(inst.guildId),
     agentChannelId: String(inst.agentChannelId),
     logChannelId: String(inst.logChannelId),
-    contextDepth: inst.contextDepth ?? 10,
-    enableAgentLog: inst.enableAgentLog ?? false,
-    roles: (inst.roles as DiscordPresence["roles"]) ?? [],
-    defaultRole: inst.defaultRole ?? "allow-all",
-    dm: (inst.dm as DiscordPresence["dm"]) ?? {
-      operatorRole: { features: ["chat", "async", "team"], disallowedTools: [], bashGuard: true },
-      defaultRole: "denied" as const,
-      userRoles: [],
-    },
-  } as DiscordPresence;
+  };
+  if (inst.enabled !== undefined) candidate.enabled = inst.enabled;
+  if (inst.contextDepth !== undefined) candidate.contextDepth = inst.contextDepth;
+  if (inst.enableAgentLog !== undefined) candidate.enableAgentLog = inst.enableAgentLog;
+  if (inst.roles !== undefined) candidate.roles = inst.roles;
+  if (inst.defaultRole !== undefined) candidate.defaultRole = inst.defaultRole;
+  if (inst.dm !== undefined) candidate.dm = inst.dm;
   const worklog = coerceString(inst.worklogChannelId);
-  if (worklog) presence.worklogChannelId = worklog;
+  if (worklog) candidate.worklogChannelId = worklog;
   const role = coerceString(inst.operatorRoleId);
-  if (role) presence.operatorRoleId = role;
-  return presence;
+  if (role) candidate.operatorRoleId = role;
+  return DiscordPresenceSchema.parse(candidate);
 }
 
 /**
  * Convert a single legacy mattermost instance. Same field-for-field lift as
- * discord; `instanceId` dropped.
+ * discord; `instanceId` dropped. Same Zod-parse-vs-hand-cast tradeoff as
+ * `convertDiscordPresence` (see Holly round-1 finding).
  */
 function convertMattermostPresence(inst: LegacyMattermostInstance): MattermostPresence {
-  return {
-    enabled: inst.enabled ?? true,
-    callbackPort: inst.callbackPort ?? 8080,
-    triggerWord: inst.triggerWord,
-    webhookUrl: inst.webhookUrl,
-    apiUrl: inst.apiUrl,
-    apiToken: inst.apiToken,
-    webhookToken: inst.webhookToken,
-    channels: inst.channels ?? [],
-    pollIntervalMs: inst.pollIntervalMs ?? 3000,
-    allowedUsers: inst.allowedUsers ?? [],
-    roles: (inst.roles as MattermostPresence["roles"]) ?? [],
-    defaultRole: inst.defaultRole ?? "allow-all",
-  } as MattermostPresence;
+  const candidate: Record<string, unknown> = {};
+  if (inst.enabled !== undefined) candidate.enabled = inst.enabled;
+  if (inst.callbackPort !== undefined) candidate.callbackPort = inst.callbackPort;
+  if (inst.triggerWord !== undefined) candidate.triggerWord = inst.triggerWord;
+  if (inst.webhookUrl !== undefined) candidate.webhookUrl = inst.webhookUrl;
+  if (inst.apiUrl !== undefined) candidate.apiUrl = inst.apiUrl;
+  if (inst.apiToken !== undefined) candidate.apiToken = inst.apiToken;
+  if (inst.webhookToken !== undefined) candidate.webhookToken = inst.webhookToken;
+  if (inst.channels !== undefined) candidate.channels = inst.channels;
+  if (inst.pollIntervalMs !== undefined) candidate.pollIntervalMs = inst.pollIntervalMs;
+  if (inst.allowedUsers !== undefined) candidate.allowedUsers = inst.allowedUsers;
+  if (inst.roles !== undefined) candidate.roles = inst.roles;
+  if (inst.defaultRole !== undefined) candidate.defaultRole = inst.defaultRole;
+  return MattermostPresenceSchema.parse(candidate);
 }
 
 /**
@@ -309,6 +317,35 @@ function resolvePersona(
 }
 
 /**
+ * Map legacy `trustedAgentBots[].name` entries onto cortex agent ids. Each
+ * name is normalized through `deriveAgentId` (lowercase + hyphen) so legacy
+ * "Echo Bot" → "echo-bot". A name that normalizes to the empty string (e.g.
+ * "!!!") throws — silently dropping it would produce an agent with a wrong
+ * trust list. (Holly cortex#51 round 1 architecture suggestion: extract for
+ * readability + isolated testability.)
+ */
+function buildTrustList(
+  legacyTrust: LegacyTrustedAgentBot[],
+  warnings: ConversionWarning[],
+): string[] {
+  return legacyTrust.map((t) => {
+    const id = deriveAgentId(t.name);
+    if (!AGENT_ID_PATTERN.test(id)) {
+      throw new Error(
+        `trustedAgentBots[].name "${t.name}" cannot be derived to a valid agent id (^[a-z0-9-]+$)`,
+      );
+    }
+    if (id !== t.name) {
+      warnings.push({
+        field: "trustedAgentBots",
+        message: `trusted bot name "${t.name}" normalized to "${id}"`,
+      });
+    }
+    return id;
+  });
+}
+
+/**
  * Synthesize the cortex `agents[]` list from the singular legacy `agent` plus
  * the (possibly multi-entry) `discord[]` and `mattermost[]` arrays.
  *
@@ -335,21 +372,7 @@ function buildAgents(
     );
   }
 
-  const trust = (legacy.trustedAgentBots ?? []).map((t) => {
-    const id = deriveAgentId(t.name);
-    if (!AGENT_ID_PATTERN.test(id)) {
-      throw new Error(
-        `trustedAgentBots[].name "${t.name}" cannot be derived to a valid agent id (^[a-z0-9-]+$)`,
-      );
-    }
-    if (id !== t.name) {
-      warnings.push({
-        field: "trustedAgentBots",
-        message: `trusted bot name "${t.name}" normalized to "${id}"`,
-      });
-    }
-    return id;
-  });
+  const trust = buildTrustList(legacy.trustedAgentBots ?? [], warnings);
 
   const persona = resolvePersona(legacy.agent.personaFile, baseId, configDir, warnings);
   const displayName = legacy.agent.displayName || legacy.agent.name;
@@ -391,7 +414,11 @@ function buildAgents(
     }
     agents.push({
       id: variantId,
-      displayName: variantCount === 1 ? displayName : `${displayName} (${i + 1})`,
+      // Keep the first variant's displayName bare so the operator's existing
+      // single-instance deployment doesn't gain a `(1)` suffix when they
+      // later add a second guild. Only index ≥1 carries an enumeration tag.
+      // (Holly cortex#51 round 1 nit-1.)
+      displayName: i === 0 ? displayName : `${displayName} (${i + 1})`,
       persona,
       roles: [],
       trust,
@@ -412,13 +439,17 @@ function buildRenderers(legacy: LegacyBotYaml, warnings: ConversionWarning[]): C
 
   if (Array.isArray(legacy.renderers)) {
     for (const r of legacy.renderers) {
-      renderers.push(r as CortexConfig["renderers"][number]);
+      // Parse each entry through the discriminated-union schema rather than
+      // an `as` cast — a typo (`kind: "dashbord"`) surfaces here with field
+      // path "renderers[i].kind" instead of the opaque top-level Zod error
+      // emitted by CortexConfigSchema.parse() at the end of conversion.
+      renderers.push(RendererSchema.parse(r));
     }
   }
 
   if (legacy.api && legacy.api.enabled === true) {
     const port = typeof legacy.api.port === "number" ? legacy.api.port : 8767;
-    renderers.push({ kind: "dashboard", port, subscribe: ["local.{org}.>"], projections: [] });
+    renderers.push(RendererSchema.parse({ kind: "dashboard", port }));
     warnings.push({
       field: "api",
       message: `legacy api.enabled=true synthesized as renderers[].kind=dashboard (port ${port}); cloud-mode api fields (endpoint, apiKey, …) are NOT carried — re-add via networks/`,

--- a/src/cli/cortex/commands/migrate-config.ts
+++ b/src/cli/cortex/commands/migrate-config.ts
@@ -1,0 +1,174 @@
+#!/usr/bin/env bun
+/**
+ * MIG-7.2e — `bun src/cli/cortex/commands/migrate-config.ts <input.yaml>`
+ *
+ * One-shot CLI that reads a grove-v2-shaped `bot.yaml` and emits a
+ * cortex-shaped `cortex.yaml`. Wraps the pure conversion logic in
+ * `./migrate-config-lib.ts`.
+ *
+ * Usage:
+ *   bun src/cli/cortex/commands/migrate-config.ts <input.yaml> [--out <output.yaml>] [--check] [--strict]
+ *
+ * Flags:
+ *   --out FILE     Write to FILE (default: stdout)
+ *   --check        Validate only — print conversion table + warnings; don't write output
+ *   --strict       Fail on warnings (default: warnings → stderr but exit 0)
+ *
+ * Exit codes:
+ *   0  — conversion succeeded
+ *   1  — conversion failed (invalid input, schema validation error)
+ *   2  — strict-mode warnings (would have succeeded without --strict)
+ */
+
+import { readFileSync, writeFileSync } from "fs";
+import { dirname, resolve } from "path";
+import YAML from "yaml";
+
+import {
+  convertBotYaml,
+  formatCheckReport,
+  type LegacyBotYaml,
+} from "./migrate-config-lib";
+
+interface ParsedArgs {
+  input: string | undefined;
+  out: string | undefined;
+  check: boolean;
+  strict: boolean;
+  help: boolean;
+}
+
+/**
+ * Hand-rolled arg parser matching the pattern in `cloud.ts` — no Commander
+ * dependency. Returns positional + flag values; the caller validates.
+ */
+export function parseArgs(argv: string[]): ParsedArgs {
+  const args: ParsedArgs = {
+    input: undefined,
+    out: undefined,
+    check: false,
+    strict: false,
+    help: false,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i]!;
+    if (a === "--help" || a === "-h") {
+      args.help = true;
+    } else if (a === "--check") {
+      args.check = true;
+    } else if (a === "--strict") {
+      args.strict = true;
+    } else if (a === "--out") {
+      const next = argv[i + 1];
+      if (next === undefined || next.startsWith("--")) {
+        throw new Error("--out requires a path argument");
+      }
+      args.out = next;
+      i++;
+    } else if (a.startsWith("--out=")) {
+      args.out = a.slice("--out=".length);
+    } else if (a.startsWith("--")) {
+      throw new Error(`unknown flag: ${a}`);
+    } else if (args.input === undefined) {
+      args.input = a;
+    } else {
+      throw new Error(`unexpected positional argument: ${a}`);
+    }
+  }
+  return args;
+}
+
+function printHelp(): void {
+  console.log("cortex migrate-config — convert grove-v2 bot.yaml to cortex.yaml\n");
+  console.log("Usage:");
+  console.log("  bun src/cli/cortex/commands/migrate-config.ts <input.yaml> [options]\n");
+  console.log("Options:");
+  console.log("  --out FILE     Write to FILE (default: stdout)");
+  console.log("  --check        Validate only — print mapping table + warnings; don't emit yaml");
+  console.log("  --strict       Fail on warnings (default: warnings → stderr, exit 0)");
+  console.log("  -h, --help     Show this help");
+}
+
+/**
+ * Run the migrate-config workflow against argv. Exported for the in-process
+ * test harness; the bottom of this file calls it from `process.argv` when
+ * the script is executed directly.
+ */
+export async function runMigrateConfig(argv: string[]): Promise<number> {
+  let args: ParsedArgs;
+  try {
+    args = parseArgs(argv);
+  } catch (err) {
+    console.error("Error:", err instanceof Error ? err.message : String(err));
+    printHelp();
+    return 1;
+  }
+
+  if (args.help) {
+    printHelp();
+    return 0;
+  }
+
+  if (!args.input) {
+    console.error("Error: <input.yaml> is required\n");
+    printHelp();
+    return 1;
+  }
+
+  const inputPath = resolve(args.input);
+  let raw: string;
+  try {
+    raw = readFileSync(inputPath, "utf-8");
+  } catch (err) {
+    console.error(`Error: cannot read ${inputPath}: ${err instanceof Error ? err.message : String(err)}`);
+    return 1;
+  }
+
+  let legacy: LegacyBotYaml;
+  try {
+    legacy = YAML.parse(raw) as LegacyBotYaml;
+  } catch (err) {
+    console.error(`Error: invalid YAML in ${inputPath}: ${err instanceof Error ? err.message : String(err)}`);
+    return 1;
+  }
+
+  let result;
+  try {
+    result = convertBotYaml(legacy, { configDir: dirname(inputPath) });
+  } catch (err) {
+    console.error(`Error: conversion failed: ${err instanceof Error ? err.message : String(err)}`);
+    return 1;
+  }
+
+  for (const w of result.warnings) {
+    console.error(`warning [${w.field}] ${w.message}`);
+  }
+
+  if (args.check) {
+    console.log(formatCheckReport(result));
+  } else {
+    const yamlOut = YAML.stringify(result.cortex, { indent: 2, lineWidth: 0 });
+    if (args.out) {
+      const outPath = resolve(args.out);
+      writeFileSync(outPath, yamlOut, "utf-8");
+      console.error(`wrote ${outPath} (${result.cortex.agents.length} agent(s), ${result.cortex.renderers.length} renderer(s))`);
+    } else {
+      process.stdout.write(yamlOut);
+    }
+  }
+
+  if (args.strict && result.warnings.length > 0) {
+    return 2;
+  }
+  return 0;
+}
+
+if (import.meta.main) {
+  runMigrateConfig(process.argv.slice(2)).then(
+    (code) => process.exit(code),
+    (err) => {
+      console.error("Fatal:", err);
+      process.exit(1);
+    },
+  );
+}


### PR DESCRIPTION
## Summary

One-shot CLI that converts a grove-v2-shaped `bot.yaml` to a cortex-shaped `cortex.yaml`, satisfying plan §4 MIG-7.2e. The conversion lives in a pure helper (`migrate-config-lib.ts`) wrapped by a hand-rolled CLI (`migrate-config.ts`, matching the existing `cloud.ts` style).

Closes the conversion side of MIG-7.9 — operator still has to run `cortex start --dry-run` on the produced `cortex.yaml` before flipping the launchd plist.

## Conversion rules (per RESUME §MIG-7.2e)

| Legacy `bot.yaml` | New `cortex.yaml` | Notes |
|---|---|---|
| `agent.operator*` fields | `operator.{id,displayName,discordId,mattermostId,dataResidency}` | operatorId defaults to `agent.name`; dataResidency upcases / falls back to `NZ` |
| `agent.name` + `discord[]` + `mattermost[]` | `agents[]` | Multi-instance synthesizes `${name}`, `${name}-2`, … with a warning |
| `discord[].instanceId` | _dropped_ | Cortex re-derives at runtime per MIG-7.2c-discord-flip; mapping table in `--check` records each legacy id → new presence |
| `personaFile` | `agents[].persona` | Defaults to `./personas/<id>.md` with warning; file existence checked when `configDir` provided |
| `trustedAgentBots[].name` | `agents[].trust[]` | Each name normalized through cortex agent-id regex |
| `api.enabled: true` | `renderers: [{ kind: dashboard, port }]` | Cloud-mode `api.*` fields (endpoint, apiKey, …) drop with warning — re-add via per-network file layout |
| `grove:` block | _dropped_ | F-11 toggles re-implement via renderers later |
| `claude/attachments/execution/github/paths/networksDir/networks/nats/renderers[]` | _pass-through_ | unchanged |

## Validation surface

- Output is parsed through `CortexConfigSchema` inside `convertBotYaml` → the CLI never emits a yaml that cortex itself rejects at load.
- Structural input failures (missing `agent.name`, non-object input) throw eagerly with a pointer at the offending field.
- `--strict` upgrades any warning to exit code 2; otherwise warnings hit stderr and the run exits 0.

## CLI shape

```
bun src/cli/cortex/commands/migrate-config.ts <input.yaml> [--out <out.yaml>] [--check] [--strict]
```

`--check` prints the operator block, agent list, renderer list, instance-mapping table, and warnings without emitting the yaml. `--out FILE` writes to disk (else stdout).

## Test plan

- [x] `bunx tsc --noEmit` clean (worktree)
- [x] `bun test src/cli/cortex/commands/__tests__/migrate-config.test.ts` — 40/40 pass
- [x] Full suite: 2048 pass, 1 fail (pre-existing mission-control React shell test from MIG-2 deferred — known caveat, not from this branch)
- [x] CLI smoke against `full.bot.yaml` fixture — `--check` output matches expectations (1 agent with discord+mattermost presence, dashboard renderer, 2 warnings for `api` + `grove`).
- [x] Fixtures cover the 5 plan-§4 scenarios + argument parsing + operator-id normalization + structural failures + end-to-end exit codes.

## Migration phase

`docs/plan-cortex-migration.md` §4 step 7.2e (line 504). Plan checkbox ticks in a docs PR after this lands (per the convention at commit 7e95a69).

🤖 Generated with [Claude Code](https://claude.com/claude-code)