### PR TITLE
feat(scripts): C-108.x — legacy launchd plist cleanup in preupgrade (MIG-7.8)

### DIFF
--- a/docs/plan-cortex-migration.md
+++ b/docs/plan-cortex-migration.md
@@ -514,16 +514,17 @@ Each phase = one umbrella issue with a task-list checklist + one or more PRs. Pi
   - **Pre-flight**: verify legacy grove is uninstalled (`arc list | grep -i grove` returns nothing) before MIG-7. If legacy grove is still installed, the symlink at `~/bin/grove-bot` is owned by legacy's manifest; running `arc upgrade Cortex` does NOT touch it. Sequence: `arc uninstall Grove` (legacy) → `arc upgrade Cortex` → verify `~/bin/cortex` resolves and `~/bin/grove-bot` no longer exists.
   - **Deprecation shim**: separately, install a one-line `~/bin/grove-bot` shim that prints "use `cortex` instead" and execs `~/bin/cortex "$@"`. Manual operator step, not part of the manifest. Removed in MIG-8.4.
   - **Rollback**: `arc uninstall Cortex` + `arc upgrade Grove` (re-installs legacy at v0.29.0). Both `arc upgrade` commands are idempotent.
-- [ ] **7.8** Update launchd plist `~/Library/LaunchAgents/com.grove.bot.plist` → `com.cortex.bot.plist`.
-  - **Pre-flight**: confirm bot is idle (no in-flight CC sessions) before unloading the old plist. Run `cortex queue --pending` (or equivalent post-MIG-7 command) — should be 0.
-  - **Sequence (atomic-ish)**:
-    1. `launchctl unload ~/Library/LaunchAgents/com.grove.bot.plist` (stops legacy)
-    2. Verify the old bot is stopped (`pgrep -f grove-bot` returns nothing)
-    3. `cp` the rendered new plist to `~/Library/LaunchAgents/com.cortex.bot.plist`
-    4. `launchctl load -w ~/Library/LaunchAgents/com.cortex.bot.plist`
-    5. Verify cortex started (`pgrep -f 'cortex start'` returns a PID; tail `~/.config/cortex/logs/cortex.log` for "shard ready" lines)
-    6. Only after verification: `rm ~/Library/LaunchAgents/com.grove.bot.plist`
-  - **Rollback**: if step 4 or 5 fails: `launchctl unload ~/Library/LaunchAgents/com.cortex.bot.plist`, `launchctl load ~/Library/LaunchAgents/com.grove.bot.plist`. The old plist still works because we didn't delete it until step 6.
+- [x] **7.8** Cut launchd over from legacy `com.grove.{bot,relay}.plist` to `ai.meta-factory.cortex.{bot,relay}.plist`.
+  - **Implementation**: handled automatically by `arc upgrade Cortex` via the MIG-7.7 lifecycle scripts (extended by MIG-7.8):
+    - `scripts/preupgrade.sh` — kills any lingering `~/bin/grove-bot` / `~/bin/grove-relay` PIDs, unloads (`launchctl unload`) and removes (`rm -f`) `~/Library/LaunchAgents/com.grove.bot.plist` and `com.grove.relay.plist` when present, then unloads cortex's own plists ready for symlink refresh. Idempotent on hosts where legacy was never installed.
+    - `scripts/postinstall.sh` — renders `ai.meta-factory.cortex.{bot,relay}.plist` into `~/Library/LaunchAgents/`.
+    - `scripts/postupgrade.sh` — `launchctl load`s the freshly rendered plists.
+  - **Operator command**: `arc upgrade Cortex` — single command runs the full cutover. The pre-flight `arc uninstall Grove` (plan §4 7.7) is *recommended* but no longer load-bearing; the preupgrade cleanup is belt-and-braces.
+  - **Verification**: after `arc upgrade Cortex` completes:
+    - `launchctl list | grep ai.meta-factory.cortex` — two entries (bot + relay)
+    - `pgrep -f "${HOME}/bin/cortex start"` — non-empty PID
+    - `ls ~/Library/LaunchAgents/com.grove.*.plist 2>/dev/null` — empty (legacy plists removed)
+  - **Rollback**: `arc uninstall Cortex && arc upgrade Grove` re-installs legacy at v0.29.0 — grove's own installer re-renders `com.grove.bot.plist` from its own source. Cortex's preupgrade.sh removed the legacy plist; on a re-install grove rewrites it. No manual recovery needed.
 - [ ] **7.9** Migrate `~/.config/grove/bot.yaml` → `~/.config/cortex/cortex.yaml`.
   - **Note**: this is a **schema transformation** (per §9 / `migrate-config.ts` from step 7.2e), not just a path rename. The new file has different top-level keys (`agents:` + `renderers:` instead of `discord:` + `mattermost:` + `trustedAgentBots:`).
   - **Sequence**:

--- a/scripts/preupgrade.sh
+++ b/scripts/preupgrade.sh
@@ -35,6 +35,19 @@ if [ "$(uname)" = "Darwin" ]; then
     echo "  ✓ Old relay processes terminated"
   fi
 
+  # Belt: kill any lingering legacy grove-bot processes anchored to the
+  # legacy ~/bin/grove-bot path. The launchctl unload further down is the
+  # braces; this catches a grove-bot that was started outside launchd or
+  # whose plist was hand-removed.
+  GROVE_BOT_PIDS=$(pgrep -f "${HOME}/bin/grove-bot" 2>/dev/null || true)
+  if [ -n "${GROVE_BOT_PIDS}" ]; then
+    echo "  Killing legacy grove-bot processes: ${GROVE_BOT_PIDS}"
+    kill ${GROVE_BOT_PIDS} 2>/dev/null || true
+    sleep 1
+    kill -9 ${GROVE_BOT_PIDS} 2>/dev/null || true
+    echo "  ✓ Legacy grove-bot processes terminated"
+  fi
+
   # Clean up legacy grove-bot symlink if it's still owned by a stale install
   # (operator pre-flight should have run `arc uninstall Grove` already; this
   # is a belt-and-braces clean-up so the deprecation shim install step has a
@@ -46,6 +59,28 @@ if [ "$(uname)" = "Darwin" ]; then
       echo "  ✓ Removed stale legacy ~/bin/grove-bot symlink (→ ${LEGACY_TARGET})"
     fi
   fi
+
+  # MIG-7.8 — legacy launchd plist cutover. The `com.grove.bot` and
+  # `com.grove.relay` plists may linger at ~/Library/LaunchAgents/ if
+  # grove's own uninstall lifecycle didn't run (operator removed the repo
+  # manually, or `arc uninstall Grove` was skipped). Unload + remove them
+  # so the new `ai.meta-factory.cortex.*` plists own launchd cleanly.
+  # Idempotent: short-circuits when the legacy plist is absent.
+  for legacy_label in com.grove.bot com.grove.relay; do
+    legacy_plist="${LAUNCH_DIR}/${legacy_label}.plist"
+    if [ ! -e "${legacy_plist}" ]; then
+      continue
+    fi
+    # Anchor to label name to avoid partial matches (e.g. `com.grove.bot`
+    # vs a hypothetical `com.grove.bot.dev`). launchctl list column 3 is
+    # the registered label.
+    if launchctl list 2>/dev/null | awk '{print $3}' | grep -qx "${legacy_label}"; then
+      launchctl unload "${legacy_plist}" 2>/dev/null || true
+      echo "  ✓ Legacy ${legacy_label} daemon stopped"
+    fi
+    rm -f "${legacy_plist}"
+    echo "  ✓ Removed legacy ${legacy_plist}"
+  done
 
   if launchctl list 2>/dev/null | grep -q "ai.meta-factory.cortex.bot"; then
     launchctl unload "${LAUNCH_DIR}/ai.meta-factory.cortex.bot.plist" 2>/dev/null || true


### PR DESCRIPTION
## Summary

MIG-7.8 — closes the legacy launchd plist cutover gap. Extends `scripts/preupgrade.sh` (shipped in MIG-7.7 / #52) to unload + remove `~/Library/LaunchAgents/com.grove.bot.plist` and `com.grove.relay.plist` when they linger from a stale grove install. Idempotent — does nothing on hosts where legacy was never installed.

After this PR: `arc upgrade Cortex` is the single operator command for plan §4 MIG-7.8. preupgrade stops + cleans legacy, then postinstall renders + postupgrade loads the new `ai.meta-factory.cortex.{bot,relay}.plist`. No `cortex migrate-plist` CLI needed.

Plan checkbox §4 7.8 ticked. Closes the launchd-side of cortex#9.

## What changed

**`scripts/preupgrade.sh`** (+35 lines)

- Belt: kill any lingering `pgrep -f ${HOME}/bin/grove-bot` PIDs before the launchctl unload (mirrors existing cortex / relay PID-kill patterns; catches a grove-bot started outside launchd or whose plist was hand-removed).
- Cleanup loop over `com.grove.bot` + `com.grove.relay`: for each label, if the plist file exists at `${LAUNCH_DIR}/${legacy_label}.plist`:
  - If currently loaded (anchored via `launchctl list | awk '{print $3}' | grep -qx ${legacy_label}` — column 3 is the registered label, exact match avoids a hypothetical `com.grove.bot.dev` false-positive), `launchctl unload` it.
  - `rm -f` the plist file.
- Each step has `2>/dev/null || true` guards (matches the existing pattern in this file).

**`docs/plan-cortex-migration.md`** (+11 -10)

- Replaced the long 6-step manual sequence in §4 7.8 with a description of the new lifecycle-script-driven shape:
  - Operator command: `arc upgrade Cortex`.
  - Verification: 3 commands (`launchctl list | grep ai.meta-factory.cortex`, `pgrep -f \"\${HOME}/bin/cortex start\"`, `ls ~/Library/LaunchAgents/com.grove.*.plist 2>/dev/null`).
  - Rollback unchanged: `arc uninstall Cortex && arc upgrade Grove`.
- Ticked the checkbox (`[x]`).

## Why this shape

Considered three options:
1. **Pure docs PR** — sequence in a runbook. Error-prone copy-paste for the operator.
2. **`cortex migrate-plist` CLI helper** — ~200 LOC + ~100 LOC tests. Extra operator command. Over-engineered for a once-ever cleanup.
3. **Extend preupgrade.sh** (chosen). ~30 lines bash + docs. Mirrors the existing legacy-symlink cleanup block 5 lines above. `arc upgrade Cortex` does it all.

Option 3 keeps the operator's mental model simple (one `arc upgrade` command) and reuses MIG-7.7's lifecycle plumbing. Idempotency falls out naturally — the `[ ! -e \"\${legacy_plist}\" ] && continue` guard makes a fresh cortex install on a host that never had grove a no-op.

## Test plan

- [x] `bash -n scripts/preupgrade.sh` — syntax OK
- [x] `bunx tsc --noEmit` — clean (no TS changes; verifies pre-push hook will pass)
- [x] Manual walkthrough of the bash logic on a host with no legacy plists — every guarded branch short-circuits
- [ ] After merge: operator runs `arc upgrade Cortex` on a host with stale grove plists and verifies the post-conditions in the docs section. (Deferred — happens in MIG-7 cutover acceptance.)

## Out of scope (explicitly deferred)

- Verifying cortex bot actually loaded after `launchctl load` in `postupgrade.sh` (the current `|| true` swallows failures with a misleading `✓` echo). Gap in MIG-7.7; separate small PR if anyone wants it.
- Anchoring the existing cortex-side `grep -q \"ai.meta-factory.cortex.bot\"` matches the same way as the new legacy block (substring vs `grep -qx` on column 3). Existing code from #52; not refactored here to keep this PR focused.
- The legacy `com.grove.bot` plist label was inferred from plan §4 7.8's text and historical grove-v2 deployment patterns. Confirmed against the existing grove-bot symlink cleanup block (which already targets `~/bin/grove-bot`); the launchd label and binary symlink shared the `grove-bot` stem. If a grove fork used a different label, the cleanup is a no-op (the `[ ! -e ]` guard short-circuits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)