### PR TITLE
feat(taps,bus): C-106 — GH webhook → NATS via cortex receiver (MIG-5.6, closes cortex#37)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,6 +7,7 @@
       "dependencies": {
         "@metafactory/content-filter": "github:the-metafactory/content-filter",
         "@octokit/webhooks": "^14.2.0",
+        "@octokit/webhooks-methods": "^6.0.0",
         "@xyflow/react": "^12.10.2",
         "ajv": "^8.20.0",
         "ajv-formats": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@metafactory/content-filter": "github:the-metafactory/content-filter",
     "@octokit/webhooks": "^14.2.0",
+    "@octokit/webhooks-methods": "^6.0.0",
     "@xyflow/react": "^12.10.2",
     "ajv": "^8.20.0",
     "ajv-formats": "^3.0.1",

--- a/src/bus/__tests__/github-events.test.ts
+++ b/src/bus/__tests__/github-events.test.ts
@@ -1,0 +1,258 @@
+/**
+ * MIG-5.6 (C-106): tests for `github.*` envelope constructor.
+ *
+ * Two coverage axes, mirroring `system-events.test.ts`:
+ *   1. Shape — fields go to the right place (envelope top-level vs payload),
+ *      optional fields are omitted (not `undefined`-valued), action
+ *      defaulting works.
+ *   2. Validation — every constructed envelope passes the vendored myelin
+ *      schema. Catches regressions where the `type` pattern drifts off the
+ *      schema's `^[a-z][a-z0-9-]*(\.[a-z][a-z0-9-]*){1,4}$` (e.g. someone
+ *      removes the `sanitizeTypeSegment` underscore-to-hyphen mapping).
+ */
+
+import { describe, expect, test } from "bun:test";
+import { validateEnvelope } from "../myelin/envelope-validator";
+import {
+  createGithubEventEnvelope,
+  sanitizeTypeSegment,
+} from "../github-events";
+
+const SRC = { org: "metafactory", agent: "cortex", instance: "local" };
+
+describe("sanitizeTypeSegment", () => {
+  test("lowercases input", () => {
+    expect(sanitizeTypeSegment("PullRequest")).toBe("pullrequest");
+  });
+
+  test("replaces underscores with hyphens (GitHub `pull_request` case)", () => {
+    expect(sanitizeTypeSegment("pull_request")).toBe("pull-request");
+    expect(sanitizeTypeSegment("issue_comment")).toBe("issue-comment");
+  });
+
+  test("collapses runs of separator characters", () => {
+    expect(sanitizeTypeSegment("a__b___c")).toBe("a-b-c");
+    expect(sanitizeTypeSegment("a  b  c")).toBe("a-b-c");
+  });
+
+  test("strips leading and trailing separators", () => {
+    expect(sanitizeTypeSegment("_opened_")).toBe("opened");
+    expect(sanitizeTypeSegment("---x---")).toBe("x");
+  });
+
+  test("preserves already-conforming values", () => {
+    expect(sanitizeTypeSegment("opened")).toBe("opened");
+    expect(sanitizeTypeSegment("push")).toBe("push");
+    expect(sanitizeTypeSegment("g-123")).toBe("g-123");
+  });
+});
+
+describe("createGithubEventEnvelope", () => {
+  test("builds 3-segment type from event + action", () => {
+    const env = createGithubEventEnvelope({
+      source: SRC,
+      event: "pull_request",
+      action: "opened",
+      deliveryId: "12345678-1234-4234-8234-123456789012",
+      payload: { number: 42 },
+    });
+    expect(env.type).toBe("github.pull-request.opened");
+    expect(env.source).toBe("metafactory.cortex.local");
+  });
+
+  test("synthesises `received` action when none provided", () => {
+    const env = createGithubEventEnvelope({
+      source: SRC,
+      event: "push",
+      deliveryId: "12345678-1234-4234-8234-123456789012",
+      payload: { ref: "refs/heads/main" },
+    });
+    expect(env.type).toBe("github.push.received");
+    expect("action" in env.payload).toBe(false);
+  });
+
+  test("synthesises `received` action when action is empty after sanitisation", () => {
+    const env = createGithubEventEnvelope({
+      source: SRC,
+      event: "ping",
+      action: "___",
+      deliveryId: "12345678-1234-4234-8234-123456789012",
+      payload: {},
+    });
+    // After sanitisation, "___" collapses to empty → defaults to "received".
+    expect(env.type).toBe("github.ping.received");
+    // The original `action` value is still preserved verbatim in the
+    // payload so downstream consumers can see what was passed.
+    expect(env.payload).toMatchObject({ action: "___" });
+  });
+
+  test("promotes UUID-shaped delivery_id to correlation_id", () => {
+    const env = createGithubEventEnvelope({
+      source: SRC,
+      event: "issues",
+      action: "opened",
+      deliveryId: "12345678-1234-4234-8234-123456789012",
+      payload: {},
+    });
+    expect(env.correlation_id).toBe("12345678-1234-4234-8234-123456789012");
+    expect(env.payload).toMatchObject({
+      delivery_id: "12345678-1234-4234-8234-123456789012",
+    });
+  });
+
+  test("keeps non-UUID delivery_id in payload only (no correlation_id)", () => {
+    const env = createGithubEventEnvelope({
+      source: SRC,
+      event: "push",
+      deliveryId: "not-a-uuid",
+      payload: {},
+    });
+    expect(env.correlation_id).toBeUndefined();
+    expect(env.payload).toMatchObject({ delivery_id: "not-a-uuid" });
+  });
+
+  test("includes optional repo and sender at payload top-level when provided", () => {
+    const env = createGithubEventEnvelope({
+      source: SRC,
+      event: "issues",
+      action: "opened",
+      deliveryId: "12345678-1234-4234-8234-123456789012",
+      payload: { number: 7 },
+      repo: "the-metafactory/cortex",
+      sender: "mellanon",
+    });
+    expect(env.payload).toMatchObject({
+      repo: "the-metafactory/cortex",
+      sender: "mellanon",
+    });
+  });
+
+  test("omits repo and sender from payload when not provided", () => {
+    const env = createGithubEventEnvelope({
+      source: SRC,
+      event: "push",
+      deliveryId: "12345678-1234-4234-8234-123456789012",
+      payload: {},
+    });
+    expect("repo" in env.payload).toBe(false);
+    expect("sender" in env.payload).toBe(false);
+  });
+
+  test("nests original payload under `body` so envelope wrapping fields are preserved", () => {
+    const env = createGithubEventEnvelope({
+      source: SRC,
+      event: "release",
+      action: "published",
+      deliveryId: "12345678-1234-4234-8234-123456789012",
+      payload: { release: { tag_name: "v0.5.0" } },
+    });
+    expect(env.payload.body).toEqual({ release: { tag_name: "v0.5.0" } });
+  });
+
+  test("each invocation returns a fresh UUID id and ISO timestamp", () => {
+    const a = createGithubEventEnvelope({
+      source: SRC,
+      event: "push",
+      deliveryId: "12345678-1234-4234-8234-123456789012",
+      payload: {},
+    });
+    const b = createGithubEventEnvelope({
+      source: SRC,
+      event: "push",
+      deliveryId: "12345678-1234-4234-8234-123456789012",
+      payload: {},
+    });
+    expect(a.id).not.toBe(b.id);
+    // ISO-8601 sanity check
+    expect(() => new Date(a.timestamp).toISOString()).not.toThrow();
+  });
+
+  test("sovereignty defaults are operator-only / NZ when source has no override", () => {
+    const env = createGithubEventEnvelope({
+      source: SRC,
+      event: "push",
+      deliveryId: "12345678-1234-4234-8234-123456789012",
+      payload: {},
+    });
+    expect(env.sovereignty).toEqual({
+      classification: "local",
+      data_residency: "NZ",
+      max_hop: 0,
+      frontier_ok: false,
+      model_class: "local-only",
+    });
+  });
+
+  test("sovereignty data_residency follows source.dataResidency override", () => {
+    const env = createGithubEventEnvelope({
+      source: { ...SRC, dataResidency: "AU" },
+      event: "push",
+      deliveryId: "12345678-1234-4234-8234-123456789012",
+      payload: {},
+    });
+    expect(env.sovereignty.data_residency).toBe("AU");
+  });
+
+  test("envelope passes vendored myelin schema validation", () => {
+    const env = createGithubEventEnvelope({
+      source: SRC,
+      event: "pull_request",
+      action: "opened",
+      deliveryId: "12345678-1234-4234-8234-123456789012",
+      payload: {
+        number: 42,
+        pull_request: { title: "feat: new feature" },
+        repository: { full_name: "the-metafactory/cortex" },
+        sender: { login: "mellanon" },
+      },
+      repo: "the-metafactory/cortex",
+      sender: "mellanon",
+    });
+    const validation = validateEnvelope(env);
+    if (!validation.ok) {
+      // Surface the actual schema errors for fast triage instead of the
+      // anonymous `false`.
+      throw new Error(
+        `envelope failed schema validation: ${JSON.stringify(validation.errors)}`,
+      );
+    }
+    expect(validation.ok).toBe(true);
+  });
+
+  test("envelope passes schema for action-less event (push)", () => {
+    const env = createGithubEventEnvelope({
+      source: SRC,
+      event: "push",
+      deliveryId: "12345678-1234-4234-8234-123456789012",
+      payload: {
+        ref: "refs/heads/main",
+        commits: [{ id: "abc123", message: "feat: x" }],
+        repository: { full_name: "the-metafactory/cortex" },
+      },
+      repo: "the-metafactory/cortex",
+    });
+    const validation = validateEnvelope(env);
+    if (!validation.ok) {
+      throw new Error(
+        `envelope failed schema validation: ${JSON.stringify(validation.errors)}`,
+      );
+    }
+    expect(validation.ok).toBe(true);
+  });
+
+  test("envelope passes schema for event with mixed-case action (defensive)", () => {
+    // GitHub itself uses lowercase actions today, but if a future event
+    // carried mixed-case (e.g. a CamelCase webhook variant), the sanitiser
+    // should normalise rather than fail validation.
+    const env = createGithubEventEnvelope({
+      source: SRC,
+      event: "Issues",
+      action: "Opened",
+      deliveryId: "12345678-1234-4234-8234-123456789012",
+      payload: {},
+    });
+    expect(env.type).toBe("github.issues.opened");
+    const validation = validateEnvelope(env);
+    expect(validation.ok).toBe(true);
+  });
+});

--- a/src/bus/github-events.ts
+++ b/src/bus/github-events.ts
@@ -1,0 +1,230 @@
+/**
+ * MIG-5.6 (C-106) — `github.*` envelope constructor for GitHub webhook events.
+ *
+ * Per plan §4 MIG-5.6 + cortex#37: HMAC-validated GitHub webhooks must surface
+ * on the bus as `local.{org}.github.{event}.{action}` envelopes so any sibling
+ * agent / surface can subscribe (dashboard projection, pilot review router,
+ * cortex worklog hints, future renderers).
+ *
+ * **Subject derivation** (mirrors `bus/system-events.ts` + `bus/dispatch-events.ts`):
+ *   - `envelope.type` is the dotted `github.{event}.{action}` form.
+ *   - `MyelinRuntime.publish` prepends `local.{org}.` at publish time, so the
+ *     final NATS subject is `local.{org}.github.{event}.{action}` without
+ *     callers having to assemble it.
+ *   - When the GitHub event has no natural `action` (e.g. `push`, `ping`,
+ *     `release` payloads that don't carry an `action` field), the helper
+ *     emits `github.{event}.received` so the type always has the
+ *     `domain.entity.action` triplet the schema requires (pattern allows
+ *     2-5 segments, but 3 is the canonical shape and keeps wildcard subs
+ *     stable: `local.{org}.github.>` matches everything; `local.{org}.github.{event}.>`
+ *     matches all actions for an event).
+ *
+ * **Shape contract** (consistent with the rule-of-three established by
+ * system-events / dispatch-events / cc-events):
+ *   - `id` is a fresh `crypto.randomUUID()` per call.
+ *   - `timestamp` is the helper-call time (ISO 8601). The webhook delivery
+ *     timestamp (if available via `X-GitHub-Delivery` parsing or payload
+ *     fields) lives in `payload` so envelope `timestamp` always reflects
+ *     emit time — same convention as `system-events.ts`.
+ *   - `source` is the dotted `{org}.{agent}.{instance}` form.
+ *   - `correlation_id` is set to the GitHub delivery ID **only when it is
+ *     UUID-shaped**. GitHub delivery IDs *are* UUIDs (e.g.
+ *     `12345678-1234-1234-1234-123456789012`), so this is the normal path —
+ *     but the check is defensive in case GitHub ever changes the format,
+ *     since the myelin envelope schema (G-1100.B) constrains
+ *     `correlation_id` to UUID. Non-UUID delivery IDs fall through to
+ *     `payload.delivery_id` only.
+ *   - `sovereignty` defaults to `local-only / max_hop=0 / frontier_ok=false /
+ *     model_class=local-only`. Same rationale as `system.*` and `dispatch.*`:
+ *     a webhook payload includes repo names, commit messages, PR titles,
+ *     issue bodies — operator-relevant content that has no business being
+ *     federated outside the org or processed by frontier models without an
+ *     explicit upgrade decision. `data_residency` is parameterised on the
+ *     source struct so non-NZ operators get accurate residency stamps.
+ *
+ * **What this file is NOT:**
+ *   - NOT a webhook receiver. The HTTP entry-point that calls this helper
+ *     lives at `src/taps/gh-webhook-receiver/server.ts` (the local server
+ *     cortex.ts stands up) and at `src/taps/gh-webhook/src/index.ts` (the
+ *     CF Worker edge proxy). This file is a pure helper.
+ *   - NOT a payload sanitiser / redactor. GitHub webhook payloads can
+ *     contain user-authored content (issue bodies, PR descriptions, commit
+ *     messages) that *might* warrant redaction before federation; that
+ *     concern lives in a payload-filter at the publish site (per
+ *     `bus/payload-filter.ts` pattern). Here we shape the envelope; the
+ *     filter (when needed) trims the payload before the publish call.
+ *   - NOT a HMAC verifier. That lives in the receiver (re-verified locally
+ *     as defense-in-depth even after the Worker validated upstream).
+ *   - NOT a Worker file. This module imports from `bus/envelope-builder.ts`
+ *     which uses `crypto.randomUUID()` — safe in both Node/Bun and CF Workers
+ *     but the file is only imported from the local cortex process today.
+ */
+
+import type { Envelope } from "./myelin/envelope-validator";
+import { buildBaseEnvelope } from "./envelope-builder";
+import type { SystemEventSource } from "./system-events";
+
+/**
+ * Re-export `SystemEventSource` under a domain-neutral alias so callers in
+ * `taps/gh-webhook-receiver/` import from one place. Same ergonomic
+ * shortcut as `DispatchEventSource` in `bus/dispatch-events.ts`.
+ */
+export type GithubEventSource = SystemEventSource;
+
+function buildSource(src: SystemEventSource): string {
+  return `${src.org}.${src.agent}.${src.instance}`;
+}
+
+/**
+ * Default sovereignty for `github.*` events. Operator-only / local / no
+ * frontier — webhook payloads may carry PII (committer email, issue bodies)
+ * and federating them outside the org is an explicit decision, not a default.
+ *
+ * `data_residency` is sourced from `source.dataResidency` (defaulting to
+ * `"NZ"`) so a non-NZ operator gets envelopes stamped with their actual
+ * residency without per-call overrides.
+ */
+function defaultGithubSovereignty(source: SystemEventSource): Envelope["sovereignty"] {
+  return {
+    classification: "local",
+    data_residency: source.dataResidency ?? "NZ",
+    max_hop: 0,
+    frontier_ok: false,
+    model_class: "local-only",
+  };
+}
+
+/** UUID v4 pattern — same regex used by `taps/cc-events/cc-events.ts`. */
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+function isUuid(value: string): boolean {
+  return UUID_RE.test(value);
+}
+
+/**
+ * Sanitize a free-form segment for use inside `envelope.type`. The schema
+ * pattern requires `[a-z][a-z0-9-]*` per segment — GitHub event names already
+ * conform (`pull_request` has an underscore which DOES NOT match the
+ * `[a-z0-9-]` charset, so we map `_` → `-`). Mixed case is lowercased.
+ *
+ * Exported for testability; callers should use `createGithubEventEnvelope`
+ * directly rather than wiring this themselves.
+ */
+export function sanitizeTypeSegment(value: string): string {
+  // Lowercase + replace any char outside [a-z0-9-] with `-`. Collapse
+  // runs of `-`. Strip leading/trailing `-`. The leading-char rule in the
+  // schema pattern (`^[a-z]`) is satisfied by the GitHub event/action
+  // vocabulary — `pull_request`, `issue_comment`, `opened`, etc. — which
+  // all start with a letter. The trailing-strip is belt-and-braces for
+  // future GitHub event names.
+  const lower = value.toLowerCase();
+  const replaced = lower.replace(/[^a-z0-9-]+/g, "-");
+  return replaced.replace(/^-+|-+$/g, "");
+}
+
+export interface CreateGithubEventEnvelopeOpts {
+  /**
+   * Envelope source — `{org}.{agent}.{instance}` per schema. Callers (the
+   * webhook receiver wired in cortex.ts) pass the same `systemEventSource`
+   * the rest of the bus uses, so all envelopes from one cortex process
+   * carry identical `source` strings.
+   */
+  source: GithubEventSource;
+  /**
+   * GitHub event name from the `X-GitHub-Event` header — `push`, `issues`,
+   * `pull_request`, `issue_comment`, `release`, `ping`, etc. The helper
+   * sanitises the value for use in `envelope.type`.
+   */
+  event: string;
+  /**
+   * GitHub action (e.g. `opened`, `closed`, `synchronize` for `pull_request`;
+   * `created`, `edited`, `deleted` for `issue_comment`). Many GitHub events
+   * carry the action inside the payload body (`payload.action`), not the
+   * headers. The helper accepts it explicitly so the caller doesn't have to
+   * type-narrow the payload here.
+   *
+   * Optional: events without a natural action (e.g. `push`, `ping`) get
+   * `"received"` as a synthetic action so the envelope type always carries
+   * a 3-segment shape (`github.{event}.received`). This keeps the subject
+   * stable for subscribers — wildcard pattern `local.{org}.github.{event}.>`
+   * matches both action-bearing and action-less events.
+   */
+  action?: string;
+  /**
+   * The parsed JSON payload from the GitHub webhook body. Goes straight
+   * into `envelope.payload.body` so subscribers can read the original
+   * fields (`repository.full_name`, `sender.login`, etc.) without re-parsing.
+   *
+   * **Caller responsibility:** the body is included verbatim. If a future
+   * iteration adds payload redaction (committer emails, etc.), it goes
+   * through `bus/payload-filter.ts` before reaching this helper — same
+   * pattern as `cc-events.ts`.
+   */
+  payload: Record<string, unknown>;
+  /**
+   * GitHub delivery ID from `X-GitHub-Delivery` (UUID format per GitHub's
+   * API contract). Promoted to `envelope.correlation_id` when UUID-shaped;
+   * always present in `envelope.payload.delivery_id` so subscribers can
+   * deduplicate even if it isn't UUID-shaped.
+   */
+  deliveryId: string;
+  /**
+   * Optional repo full name (`owner/repo`) for surfaces that filter on it.
+   * The receiver typically extracts this from `payload.repository.full_name`
+   * before calling this helper; passing it explicitly avoids re-parsing
+   * the payload in subscribers.
+   */
+  repo?: string;
+  /**
+   * Optional sender login from `payload.sender.login`. Same rationale as
+   * `repo` — exposed at the top of the payload for filters.
+   */
+  sender?: string;
+}
+
+/**
+ * Construct a `github.{event}.{action}` envelope from a validated GitHub
+ * webhook delivery. See file header for the shape contract.
+ *
+ * **Validation:** does NOT call `validateEnvelope` here — same convention as
+ * the other envelope builders. If a future hardening pass requires
+ * pre-publish validation, it lives at the runtime layer (one place, one
+ * decision), not per-helper. Tests in `__tests__/github-events.test.ts`
+ * assert that constructed envelopes pass the schema.
+ *
+ * **Action defaulting:** when `opts.action` is omitted or empty after
+ * sanitisation, the envelope type uses `"received"` so the type always has
+ * 3 segments. This is a normalisation step, not a guess — pass the action
+ * verbatim when one exists (`opts.action = payload.action`); pass
+ * `undefined` for events without an action concept.
+ */
+export function createGithubEventEnvelope(
+  opts: CreateGithubEventEnvelopeOpts,
+): Envelope {
+  const eventSegment = sanitizeTypeSegment(opts.event);
+  const rawAction = opts.action ? sanitizeTypeSegment(opts.action) : "";
+  const actionSegment = rawAction.length > 0 ? rawAction : "received";
+  const type = `github.${eventSegment}.${actionSegment}`;
+
+  return buildBaseEnvelope({
+    type,
+    source: buildSource(opts.source),
+    sovereignty: defaultGithubSovereignty(opts.source),
+    // GitHub delivery IDs are UUIDs by contract; only promote when shape
+    // matches, matching the cc-events helper's defensive pattern.
+    ...(isUuid(opts.deliveryId) && { correlationId: opts.deliveryId }),
+    payload: {
+      delivery_id: opts.deliveryId,
+      event: opts.event,
+      ...(opts.action !== undefined && { action: opts.action }),
+      ...(opts.repo !== undefined && { repo: opts.repo }),
+      ...(opts.sender !== undefined && { sender: opts.sender }),
+      // The original webhook JSON, untouched. Spread last so the wrapper
+      // metadata above (`delivery_id`, `event`, `action`, etc.) takes
+      // precedence on any name collision — keeps the envelope-level
+      // contract stable regardless of what GitHub puts in the body.
+      body: opts.payload,
+    },
+  });
+}

--- a/src/common/agents/__tests__/registry.test.ts
+++ b/src/common/agents/__tests__/registry.test.ts
@@ -92,6 +92,11 @@ function cortexConfigFixture(agents: Agent[]): CortexConfig {
         branchPatterns: ["^feat/(g|f|i)-\\d+"],
         commentPatterns: ["^Starting:", "^Completed:"],
       },
+      receiver: {
+        enabled: false,
+        port: 8770,
+        hostname: "127.0.0.1",
+      },
     },
     paths: {
       publishedEventsDir: "~/.claude/events/published",

--- a/src/common/config/__tests__/watcher.test.ts
+++ b/src/common/config/__tests__/watcher.test.ts
@@ -43,6 +43,11 @@ const TEST_CONFIG: BotConfig = {
       branchPatterns: ["^feat/(g|f|i)-\\d+"],
       commentPatterns: ["^Starting:", "^Completed:"],
     },
+    receiver: {
+      enabled: false,
+      port: 8770,
+      hostname: "127.0.0.1",
+    },
   },
   api: {
     enabled: false,

--- a/src/common/types/config.ts
+++ b/src/common/types/config.ts
@@ -349,6 +349,23 @@ export const BotConfigSchema = z.object({
       /** Regex patterns for agent issue comments (e.g. "^Starting:", "^Completed:") */
       commentPatterns: z.array(z.string()).default(["^Starting:", "^Completed:"]),
     }).default({} as any),
+    /**
+     * MIG-5.6 (C-106): Local HTTP receiver that publishes webhook payloads
+     * as `local.{org}.github.{event}.{action}` envelopes onto the bus.
+     *
+     * Opt-in: only started when `enabled: true` AND `webhookSecret` is set
+     * (the secret is required for HMAC re-verification at the local hop).
+     * The default hostname is `127.0.0.1` — never expose to LAN/internet
+     * without an explicit override (HMAC is the only auth).
+     */
+    receiver: z.object({
+      /** Whether to start the local receiver. Default false (opt-in). */
+      enabled: z.boolean().default(false),
+      /** TCP port to bind. Default 8770. */
+      port: z.number().int().positive().default(8770),
+      /** Hostname to bind. Default `127.0.0.1` — never `0.0.0.0` unless explicitly chosen. */
+      hostname: z.string().default("127.0.0.1"),
+    }).default({} as any),
   }).default({} as any).transform((val) => ({
     webhookSecret: val.webhookSecret ?? "",
     repos: val.repos ?? [],
@@ -356,6 +373,11 @@ export const BotConfigSchema = z.object({
       commitTrailers: val.agentDetection?.commitTrailers ?? ["Co-Authored-By: Claude"],
       branchPatterns: val.agentDetection?.branchPatterns ?? ["^feat/(g|f|i)-\\d+"],
       commentPatterns: val.agentDetection?.commentPatterns ?? ["^Starting:", "^Completed:"],
+    },
+    receiver: {
+      enabled: val.receiver?.enabled ?? false,
+      port: val.receiver?.port ?? 8770,
+      hostname: val.receiver?.hostname ?? "127.0.0.1",
     },
   })),
 

--- a/src/common/types/cortex-config.ts
+++ b/src/common/types/cortex-config.ts
@@ -505,6 +505,23 @@ export const AgentDetectionSchema = z.object({
 export type AgentDetection = z.infer<typeof AgentDetectionSchema>;
 
 /**
+ * MIG-5.6 (C-106): local GitHub-webhook receiver — extracted so it can
+ * nest cleanly under `GithubConfigSchema` and stay MIRRORed with the
+ * inline shape in `BotConfigSchema.github.receiver`. Defaults are
+ * opt-in: `enabled=false`, `127.0.0.1:8770`.
+ *
+ * MIRROR: see `BotConfigSchema.github.receiver` (inline) in `./config.ts`.
+ * Drop both on 7.2e.
+ */
+export const GithubReceiverSchema = z.object({
+  enabled: z.boolean().default(false),
+  port: z.number().int().positive().default(8770),
+  hostname: z.string().default("127.0.0.1"),
+});
+
+export type GithubReceiver = z.infer<typeof GithubReceiverSchema>;
+
+/**
  * GitHub webhook surface — identical shape to BotConfig.github.
  * MIRROR: see `BotConfigSchema.github` in `./config.ts`. Drop both on 7.2e.
  */
@@ -512,6 +529,7 @@ export const GithubConfigSchema = z.object({
   webhookSecret: z.string().default(""),
   repos: z.array(z.string()).default([]),
   agentDetection: emptyDefault(AgentDetectionSchema),
+  receiver: emptyDefault(GithubReceiverSchema),
 });
 
 export type GithubConfig = z.infer<typeof GithubConfigSchema>;

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -45,6 +45,10 @@ import { CloudPublisher } from "./taps/cc-events/cloud-publisher";
 import { JsonlReader } from "./taps/cc-events/lib/jsonl-reader";
 import { PublishedEventSchema } from "./taps/cc-events/hooks/lib/event-types";
 import { formatEventForDiscord } from "./adapters/discord/event-formatter";
+import {
+  startGithubWebhookReceiver,
+  type GithubWebhookReceiverHandle,
+} from "./taps/gh-webhook-receiver/server";
 
 // MIG-7.9 (deferred) flips these to `~/.config/cortex/`. Keeping grove-shaped
 // paths for now so the operator's existing `bot.yaml` continues to work.
@@ -81,6 +85,8 @@ export interface StartCortexOptions {
   disableDashboard?: boolean;
   /** Skip the JSONL outbound poller (tests). */
   disableOutboundPoller?: boolean;
+  /** Skip the GitHub webhook receiver even if config.github.receiver.enabled is true (tests). */
+  disableGithubReceiver?: boolean;
   /**
    * Inject a runtime instead of constructing one via `startMyelinRuntime`.
    * Tests pass a recording fake to assert observable side-effects (e.g. that
@@ -414,6 +420,36 @@ export async function startCortex(
     }
   }
 
+  // MIG-5.6 (C-106): GitHub webhook receiver — opt-in via `github.receiver.enabled`
+  // AND a non-empty `github.webhookSecret`. Publishes `local.{org}.github.{event}.{action}`
+  // envelopes via `runtime.publish`; that path is a no-op when NATS isn't configured
+  // (see `myelin/runtime.ts`), so this block stays safe to run even without NATS.
+  let githubReceiver: GithubWebhookReceiverHandle | null = null;
+  if (
+    !options.disableGithubReceiver
+    && config.github.receiver.enabled
+    && config.github.webhookSecret.length > 0
+  ) {
+    try {
+      githubReceiver = startGithubWebhookReceiver({
+        secret: config.github.webhookSecret,
+        port: config.github.receiver.port,
+        hostname: config.github.receiver.hostname,
+        source: systemEventSource,
+        publish: (env) => runtime.publish(env),
+      });
+    } catch (err) {
+      console.error(
+        "cortex: github webhook receiver startup error (non-fatal):",
+        err instanceof Error ? err.message : err,
+      );
+    }
+  } else if (config.github.receiver.enabled && !config.github.webhookSecret) {
+    console.warn(
+      "cortex: github.receiver.enabled is true but github.webhookSecret is empty — receiver not started",
+    );
+  }
+
   // Shutdown — reverse-order; capped at SHUTDOWN_TIMEOUT_MS.
   //
   // Echo round-1 N2 — abandoned-set tracking: each drain step is named
@@ -444,6 +480,7 @@ export async function startCortex(
       "config-watcher stop",
       "usage-monitor stop",
       "dashboard stop",
+      "github webhook receiver stop",
       ...adapterCleanup.map((_, i) => `outbound poller stop[${i}]`),
       "dispatch-listener stop",
       "surface-router stop",
@@ -474,6 +511,7 @@ export async function startCortex(
       completeSync("config-watcher stop", () => configWatcher?.stop());
       completeSync("usage-monitor stop", () => usageMonitor?.stop());
       completeSync("dashboard stop", () => dashboardApi?.stop?.());
+      completeSync("github webhook receiver stop", () => githubReceiver?.stop());
       for (let i = 0; i < adapterCleanup.length; i++) {
         completeSync(`outbound poller stop[${i}]`, adapterCleanup[i]!);
       }

--- a/src/taps/gh-webhook-receiver/__tests__/integration.test.ts
+++ b/src/taps/gh-webhook-receiver/__tests__/integration.test.ts
@@ -1,0 +1,275 @@
+/**
+ * MIG-5.6 (C-106) — integration test: Worker → local receiver → envelope.
+ *
+ * Wires the actual CF Worker entry point (`src/taps/gh-webhook/src/index.ts`)
+ * together with the local Bun receiver (`src/taps/gh-webhook-receiver/server.ts`)
+ * via the `CORTEX_FORWARDER_URL` config knob. This is the closest we can get
+ * to a "production-shaped" test without standing up an actual Cloudflare
+ * runtime — the Worker is invoked through its Hono handler (the test harness
+ * the gh-webhook subpackage already uses), and its `executionCtx.waitUntil`
+ * is wired so the fan-out happens before we assert.
+ *
+ * What this asserts that the unit tests cannot:
+ *   - The Worker's forwarded headers exactly match the receiver's HMAC
+ *     re-verification expectations (i.e. the `X-Hub-Signature-256` we
+ *     forward must round-trip through the receiver's `verify()` call).
+ *   - A valid push webhook ingested at the Worker produces an envelope
+ *     with the expected `type` / `source` / `payload` on the publish
+ *     callback the receiver was started with.
+ *
+ * **Why this test lives under `gh-webhook-receiver/__tests__/`** (and not
+ * under `gh-webhook/__tests__/`): it imports from BOTH subtrees, which the
+ * gh-webhook subpackage tsconfig would reject (it doesn't see the root
+ * project). The root tsconfig sees both (`src/taps/gh-webhook` is excluded
+ * for tsc but bun test still loads it at runtime).
+ */
+
+import { describe, expect, test, afterEach } from "bun:test";
+import { sign } from "@octokit/webhooks-methods";
+// The CF Worker subpackage uses `@cloudflare/workers-types` in its own
+// tsconfig. Root tsc transitively type-checks `gh-webhook/src/index.ts`
+// when we import from it here; the Worker file uses a local
+// `ServiceBindingFetcher` shape so root tsc accepts it without needing
+// CF types globally. Local stand-ins for `ExecutionContext` / `Fetcher`
+// below cover the integration's own use sites.
+import workerApp, { _resetDeliveryCache } from "../../gh-webhook/src/index";
+import {
+  startGithubWebhookReceiver,
+  type GithubWebhookReceiverHandle,
+} from "../server";
+import type { Envelope } from "../../../bus/myelin/envelope-validator";
+
+// Minimal local stand-ins for the CF Worker types so root tsc accepts
+// this file without pulling `@cloudflare/workers-types` into the root
+// project. These shapes are the subset the integration uses.
+interface ExecutionContext {
+  waitUntil(promise: Promise<unknown>): void;
+  passThroughOnException(): void;
+  props: Record<string, unknown>;
+}
+interface Fetcher {
+  fetch(input: Request | string): Promise<Response>;
+}
+
+const TEST_SECRET = "integration-test-secret";
+const TEST_SOURCE = {
+  org: "metafactory",
+  agent: "cortex",
+  instance: "local",
+};
+
+// Port counter — far above the unit test range to keep parallel runs
+// from colliding.
+let nextPort = 19770;
+function pickPort(): number {
+  return nextPort++;
+}
+
+const handles: GithubWebhookReceiverHandle[] = [];
+afterEach(() => {
+  while (handles.length > 0) {
+    handles.pop()?.stop();
+  }
+  _resetDeliveryCache();
+});
+
+/**
+ * Minimal ExecutionContext that records waitUntil promises so the test
+ * can drain fan-out before assertions. Mirrors the helper in
+ * `gh-webhook/__tests__/proxy.test.ts` but lives here so the integration
+ * file is self-contained.
+ */
+function makeExecutionCtx(): {
+  ctx: ExecutionContext;
+  drain: () => Promise<void>;
+} {
+  const pending: Array<Promise<unknown>> = [];
+  const ctx: ExecutionContext = {
+    waitUntil(p: Promise<unknown>): void {
+      pending.push(p);
+    },
+    passThroughOnException(): void {},
+    props: {},
+  };
+  return {
+    ctx,
+    drain: async () => {
+      while (pending.length > 0) {
+        const batch = pending.splice(0, pending.length);
+        await Promise.allSettled(batch);
+      }
+    },
+  };
+}
+
+/**
+ * Mock `GROVE_API` Service Binding — the Worker still calls it before
+ * fanning out to the cortex forwarder. We return 200 so the Worker treats
+ * the request as success and the integration is exercising the
+ * cortex-forwarder side rather than failing at grove-api.
+ */
+function makeGroveApiStub(): Fetcher {
+  return {
+    fetch: async () => new Response("ok", { status: 200 }),
+    connect: () => { throw new Error("not implemented"); },
+  } as unknown as Fetcher;
+}
+
+describe("integration: Worker → cortex receiver → envelope", () => {
+  test("valid push webhook produces correctly-shaped envelope on bus", async () => {
+    const port = pickPort();
+    const published: Envelope[] = [];
+    const handle = startGithubWebhookReceiver({
+      secret: TEST_SECRET,
+      port,
+      hostname: "127.0.0.1",
+      source: TEST_SOURCE,
+      publish: async (env) => {
+        published.push(env);
+      },
+    });
+    handles.push(handle);
+
+    const body = JSON.stringify({
+      ref: "refs/heads/main",
+      repository: { full_name: "the-metafactory/cortex" },
+      sender: { login: "mellanon" },
+      commits: [{ id: "abc", message: "feat: x" }],
+    });
+    const signature = await sign(TEST_SECRET, body);
+    const deliveryId = "11111111-2222-4333-8444-555555555555";
+
+    const req = new Request("http://localhost/github", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Hub-Signature-256": signature,
+        "X-GitHub-Event": "push",
+        "X-GitHub-Delivery": deliveryId,
+      },
+      body,
+    });
+
+    const env = {
+      GITHUB_WEBHOOK_SECRET: TEST_SECRET,
+      GROVE_API: makeGroveApiStub(),
+      CORTEX_FORWARDER_URL: `http://127.0.0.1:${port}/internal/webhook`,
+    };
+    const { ctx, drain } = makeExecutionCtx();
+    const res = await workerApp.fetch(req, env, ctx);
+    await drain();
+
+    expect(res.status).toBe(200);
+    expect(published).toHaveLength(1);
+    const envelope = published[0]!;
+    expect(envelope.type).toBe("github.push.received");
+    expect(envelope.source).toBe("metafactory.cortex.local");
+    expect(envelope.payload).toMatchObject({
+      delivery_id: deliveryId,
+      event: "push",
+      repo: "the-metafactory/cortex",
+      sender: "mellanon",
+    });
+    // The original webhook body lives under `payload.body` verbatim.
+    expect(envelope.payload.body).toEqual({
+      ref: "refs/heads/main",
+      repository: { full_name: "the-metafactory/cortex" },
+      sender: { login: "mellanon" },
+      commits: [{ id: "abc", message: "feat: x" }],
+    });
+  });
+
+  test("pull_request opened produces github.pull-request.opened envelope", async () => {
+    const port = pickPort();
+    const published: Envelope[] = [];
+    const handle = startGithubWebhookReceiver({
+      secret: TEST_SECRET,
+      port,
+      hostname: "127.0.0.1",
+      source: TEST_SOURCE,
+      publish: async (env) => {
+        published.push(env);
+      },
+    });
+    handles.push(handle);
+
+    const body = JSON.stringify({
+      action: "opened",
+      number: 42,
+      pull_request: { title: "feat: x", state: "open" },
+      repository: { full_name: "the-metafactory/cortex" },
+      sender: { login: "mellanon" },
+    });
+    const signature = await sign(TEST_SECRET, body);
+
+    const req = new Request("http://localhost/github", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Hub-Signature-256": signature,
+        "X-GitHub-Event": "pull_request",
+        "X-GitHub-Delivery": "22222222-3333-4444-8555-666666666666",
+      },
+      body,
+    });
+
+    const env = {
+      GITHUB_WEBHOOK_SECRET: TEST_SECRET,
+      GROVE_API: makeGroveApiStub(),
+      CORTEX_FORWARDER_URL: `http://127.0.0.1:${port}/internal/webhook`,
+    };
+    const { ctx, drain } = makeExecutionCtx();
+    const res = await workerApp.fetch(req, env, ctx);
+    await drain();
+
+    expect(res.status).toBe(200);
+    expect(published).toHaveLength(1);
+    expect(published[0]!.type).toBe("github.pull-request.opened");
+    expect(published[0]!.payload).toMatchObject({
+      event: "pull_request",
+      action: "opened",
+    });
+  });
+
+  test("Worker → receiver HMAC propagates: tampered body at receiver is rejected", async () => {
+    // This guards against accidental body-rewriting between the Worker
+    // and the receiver. We forward the body verbatim, so the receiver's
+    // HMAC re-verification MUST succeed — and tampering on the wire MUST
+    // be rejected. Simulate the tampering by signing a different body
+    // than we send; receiver should 401 even though the Worker accepted
+    // the (signed) original.
+    const port = pickPort();
+    const published: Envelope[] = [];
+    const handle = startGithubWebhookReceiver({
+      secret: TEST_SECRET,
+      port,
+      hostname: "127.0.0.1",
+      source: TEST_SOURCE,
+      publish: async (env) => {
+        published.push(env);
+      },
+    });
+    handles.push(handle);
+
+    // Forge: sign one body, send a different one to the receiver
+    // directly. The Worker isn't in this path — we're asserting the
+    // receiver's defense-in-depth.
+    const signedBody = JSON.stringify({ action: "opened" });
+    const sentBody = JSON.stringify({ action: "tampered" });
+    const signature = await sign(TEST_SECRET, signedBody);
+
+    const resp = await fetch(`http://127.0.0.1:${port}/internal/webhook`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Hub-Signature-256": signature,
+        "X-GitHub-Event": "issues",
+        "X-GitHub-Delivery": "33333333-4444-4555-8666-777777777777",
+      },
+      body: sentBody,
+    });
+
+    expect(resp.status).toBe(401);
+    expect(published).toHaveLength(0);
+  });
+});

--- a/src/taps/gh-webhook-receiver/__tests__/server.test.ts
+++ b/src/taps/gh-webhook-receiver/__tests__/server.test.ts
@@ -1,0 +1,419 @@
+/**
+ * MIG-5.6 (C-106) — tests for the local GitHub webhook receiver.
+ *
+ * Three coverage axes:
+ *   1. Auth gates — secret-absent (503), missing-headers (400),
+ *      bad-signature (401), verifier-throw (401).
+ *   2. Body handling — malformed JSON (400), JSON-but-not-object (400),
+ *      valid payload extraction (repo, sender, action).
+ *   3. Happy path — full webhook → envelope → publish callback invoked
+ *      with a validly-shaped Envelope.
+ *
+ * Tests use a real `@octokit/webhooks-methods` signature so we exercise
+ * the production verification path end-to-end. A unique port is picked
+ * per test to avoid TIME_WAIT collisions between bun test invocations.
+ */
+
+import { describe, expect, test, afterEach } from "bun:test";
+import { sign } from "@octokit/webhooks-methods";
+import {
+  startGithubWebhookReceiver,
+  type GithubWebhookReceiverHandle,
+} from "../server";
+import { validateEnvelope, type Envelope } from "../../../bus/myelin/envelope-validator";
+
+const TEST_SECRET = "test-secret-for-receiver-tests";
+const TEST_SOURCE = {
+  org: "metafactory",
+  agent: "cortex",
+  instance: "local",
+};
+
+// Port-allocation strategy: each test calls `pickPort()` which increments a
+// shared counter. The base port is well outside cortex's other listeners
+// (mattermost 8080, dashboard 8766, receiver default 8770) so a parallel
+// test runner doesn't collide with a live cortex on the same machine.
+let nextPort = 18770;
+function pickPort(): number {
+  return nextPort++;
+}
+
+const handles: GithubWebhookReceiverHandle[] = [];
+afterEach(() => {
+  while (handles.length > 0) {
+    const handle = handles.pop();
+    handle?.stop();
+  }
+});
+
+function start(
+  overrides: Partial<Parameters<typeof startGithubWebhookReceiver>[0]> = {},
+): {
+  handle: GithubWebhookReceiverHandle;
+  published: Envelope[];
+} {
+  const published: Envelope[] = [];
+  const handle = startGithubWebhookReceiver({
+    secret: TEST_SECRET,
+    port: pickPort(),
+    hostname: "127.0.0.1",
+    source: TEST_SOURCE,
+    publish: async (env) => {
+      published.push(env);
+    },
+    ...overrides,
+  });
+  handles.push(handle);
+  return { handle, published };
+}
+
+async function postWebhook(
+  handle: GithubWebhookReceiverHandle,
+  body: string,
+  options: {
+    event?: string;
+    deliveryId?: string;
+    signature?: string;
+    skipEvent?: boolean;
+    skipDelivery?: boolean;
+    skipSignature?: boolean;
+  } = {},
+): Promise<Response> {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  if (!options.skipEvent) {
+    headers["X-GitHub-Event"] = options.event ?? "push";
+  }
+  if (!options.skipDelivery) {
+    headers["X-GitHub-Delivery"]
+      = options.deliveryId ?? "12345678-1234-4234-8234-123456789012";
+  }
+  if (!options.skipSignature) {
+    headers["X-Hub-Signature-256"]
+      = options.signature ?? (await sign(TEST_SECRET, body));
+  }
+  return fetch(`http://127.0.0.1:${handle.port}/internal/webhook`, {
+    method: "POST",
+    headers,
+    body,
+  });
+}
+
+describe("startGithubWebhookReceiver — health check", () => {
+  test("GET /health returns 200 with service identifier", async () => {
+    const { handle } = start();
+    const res = await fetch(`http://127.0.0.1:${handle.port}/health`);
+    expect(res.status).toBe(200);
+    const json = await res.json() as { status: string; service: string };
+    expect(json).toEqual({
+      status: "ok",
+      service: "github-webhook-receiver",
+    });
+  });
+
+  test("non-/health GET returns 404", async () => {
+    const { handle } = start();
+    const res = await fetch(`http://127.0.0.1:${handle.port}/`);
+    expect(res.status).toBe(404);
+  });
+
+  test("non-POST on /internal/webhook returns 404", async () => {
+    const { handle } = start();
+    const res = await fetch(
+      `http://127.0.0.1:${handle.port}/internal/webhook`,
+    );
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("startGithubWebhookReceiver — auth gates", () => {
+  test("empty secret → 503 not configured", async () => {
+    const { handle } = start({ secret: "" });
+    const body = JSON.stringify({ ref: "refs/heads/main" });
+    const res = await postWebhook(handle, body);
+    expect(res.status).toBe(503);
+    expect(await res.text()).toBe("not configured");
+  });
+
+  test("missing X-Hub-Signature-256 → 400 missing headers", async () => {
+    const { handle } = start();
+    const body = JSON.stringify({ ref: "refs/heads/main" });
+    const res = await postWebhook(handle, body, { skipSignature: true });
+    expect(res.status).toBe(400);
+    expect(await res.text()).toBe("missing headers");
+  });
+
+  test("missing X-GitHub-Event → 400 missing headers", async () => {
+    const { handle } = start();
+    const body = JSON.stringify({ ref: "refs/heads/main" });
+    const res = await postWebhook(handle, body, { skipEvent: true });
+    expect(res.status).toBe(400);
+  });
+
+  test("missing X-GitHub-Delivery → 400 missing headers", async () => {
+    const { handle } = start();
+    const body = JSON.stringify({ ref: "refs/heads/main" });
+    const res = await postWebhook(handle, body, { skipDelivery: true });
+    expect(res.status).toBe(400);
+  });
+
+  test("invalid HMAC → 401 unauthorized", async () => {
+    const { handle, published } = start();
+    const body = JSON.stringify({ ref: "refs/heads/main" });
+    const res = await postWebhook(handle, body, {
+      signature: "sha256=" + "0".repeat(64),
+    });
+    expect(res.status).toBe(401);
+    expect(published).toHaveLength(0);
+  });
+
+  test("malformed signature → 401 unauthorized (verifier throws)", async () => {
+    const { handle, published } = start();
+    const body = JSON.stringify({ ref: "refs/heads/main" });
+    const res = await postWebhook(handle, body, {
+      signature: "not-a-real-signature-format",
+    });
+    expect(res.status).toBe(401);
+    expect(published).toHaveLength(0);
+  });
+
+  test("verifyImpl throw is caught and surfaces as 401", async () => {
+    const { handle, published } = start({
+      verifyImpl: async () => {
+        throw new Error("verifier exploded");
+      },
+    });
+    const body = JSON.stringify({});
+    const res = await postWebhook(handle, body);
+    expect(res.status).toBe(401);
+    expect(published).toHaveLength(0);
+  });
+});
+
+describe("startGithubWebhookReceiver — body handling", () => {
+  test("non-JSON body → 400 invalid json", async () => {
+    const { handle, published } = start();
+    const body = "this is not json";
+    const res = await postWebhook(handle, body);
+    expect(res.status).toBe(400);
+    expect(await res.text()).toBe("invalid json");
+    expect(published).toHaveLength(0);
+  });
+
+  test("JSON array (not object) → 400 invalid json", async () => {
+    const { handle, published } = start();
+    const body = JSON.stringify([1, 2, 3]);
+    const res = await postWebhook(handle, body);
+    expect(res.status).toBe(400);
+    expect(published).toHaveLength(0);
+  });
+
+  test("JSON null → 400 invalid json", async () => {
+    const { handle, published } = start();
+    const body = JSON.stringify(null);
+    const res = await postWebhook(handle, body);
+    expect(res.status).toBe(400);
+    expect(published).toHaveLength(0);
+  });
+});
+
+describe("startGithubWebhookReceiver — happy path", () => {
+  test("valid push webhook → 200 ok + envelope published", async () => {
+    const { handle, published } = start();
+    const body = JSON.stringify({
+      ref: "refs/heads/main",
+      repository: { full_name: "the-metafactory/cortex" },
+      sender: { login: "mellanon" },
+      commits: [{ id: "abc123", message: "feat: x" }],
+    });
+    const res = await postWebhook(handle, body, { event: "push" });
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("ok");
+
+    expect(published).toHaveLength(1);
+    const env = published[0]!;
+    expect(env.type).toBe("github.push.received");
+    expect(env.source).toBe("metafactory.cortex.local");
+    expect(env.payload).toMatchObject({
+      delivery_id: "12345678-1234-4234-8234-123456789012",
+      event: "push",
+      repo: "the-metafactory/cortex",
+      sender: "mellanon",
+    });
+    expect(env.payload.body).toEqual({
+      ref: "refs/heads/main",
+      repository: { full_name: "the-metafactory/cortex" },
+      sender: { login: "mellanon" },
+      commits: [{ id: "abc123", message: "feat: x" }],
+    });
+  });
+
+  test("valid pull_request opened webhook → envelope type maps underscores to hyphens", async () => {
+    const { handle, published } = start();
+    const body = JSON.stringify({
+      action: "opened",
+      number: 42,
+      repository: { full_name: "the-metafactory/cortex" },
+      sender: { login: "mellanon" },
+    });
+    const res = await postWebhook(handle, body, { event: "pull_request" });
+    expect(res.status).toBe(200);
+
+    expect(published).toHaveLength(1);
+    const env = published[0]!;
+    expect(env.type).toBe("github.pull-request.opened");
+    expect(env.payload).toMatchObject({
+      delivery_id: "12345678-1234-4234-8234-123456789012",
+      event: "pull_request",
+      action: "opened",
+      repo: "the-metafactory/cortex",
+      sender: "mellanon",
+    });
+  });
+
+  test("payload without repository.full_name → envelope has no repo field", async () => {
+    const { handle, published } = start();
+    const body = JSON.stringify({ ref: "refs/heads/main" });
+    const res = await postWebhook(handle, body, { event: "push" });
+    expect(res.status).toBe(200);
+    const env = published[0]!;
+    expect("repo" in env.payload).toBe(false);
+    expect("sender" in env.payload).toBe(false);
+  });
+
+  test("payload with non-string action falls through to no-action envelope", async () => {
+    const { handle, published } = start();
+    const body = JSON.stringify({ action: 42, ref: "refs/heads/main" });
+    const res = await postWebhook(handle, body, { event: "push" });
+    expect(res.status).toBe(200);
+    const env = published[0]!;
+    expect(env.type).toBe("github.push.received");
+    // The verbatim non-string `action` is preserved in `payload.body` but
+    // NOT promoted to the top-level `payload.action` (which is reserved
+    // for the string action used to assemble the envelope `type`).
+    expect("action" in env.payload).toBe(false);
+    expect((env.payload.body as Record<string, unknown>).action).toBe(42);
+  });
+
+  test("published envelope passes vendored myelin schema validation", async () => {
+    const { handle, published } = start();
+    const body = JSON.stringify({
+      action: "opened",
+      issue: { number: 7, title: "test", body: "test issue" },
+      repository: { full_name: "the-metafactory/cortex" },
+      sender: { login: "mellanon" },
+    });
+    const res = await postWebhook(handle, body, { event: "issues" });
+    expect(res.status).toBe(200);
+    expect(published).toHaveLength(1);
+    const env = published[0]!;
+    const validation = validateEnvelope(env);
+    if (!validation.ok) {
+      throw new Error(
+        `envelope failed schema validation: ${JSON.stringify(validation.errors)}`,
+      );
+    }
+    expect(validation.ok).toBe(true);
+  });
+
+  test("UUID delivery id is promoted to envelope correlation_id", async () => {
+    const { handle, published } = start();
+    const body = JSON.stringify({ action: "opened" });
+    const deliveryId = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee";
+    const res = await postWebhook(handle, body, {
+      event: "issues",
+      deliveryId,
+    });
+    expect(res.status).toBe(200);
+    expect(published[0]!.correlation_id).toBe(deliveryId);
+  });
+
+  test("publish callback rejection is swallowed (response still 200)", async () => {
+    const errors: string[] = [];
+    const originalError = console.error;
+    console.error = (...args: unknown[]) => {
+      errors.push(args.map(String).join(" "));
+    };
+    try {
+      const { handle } = start({
+        publish: async () => {
+          throw new Error("bus is down");
+        },
+      });
+      const body = JSON.stringify({ action: "opened" });
+      const res = await postWebhook(handle, body, { event: "issues" });
+      // Receiver acks even when publish fails — fire-and-forget per
+      // the MyelinRuntime.publish contract.
+      expect(res.status).toBe(200);
+      // The error was logged so an operator can find it.
+      expect(errors.some((e) => e.includes("publish failed"))).toBe(true);
+    } finally {
+      console.error = originalError;
+    }
+  });
+
+  test("buildEnvelope override receives correctly-extracted inputs", async () => {
+    let capturedOpts: Parameters<NonNullable<Parameters<typeof startGithubWebhookReceiver>[0]["buildEnvelope"]>>[0] | undefined;
+    const fakeEnv: Envelope = {
+      id: "00000000-0000-4000-8000-000000000000",
+      source: "metafactory.cortex.local",
+      type: "github.push.received",
+      timestamp: new Date().toISOString(),
+      sovereignty: {
+        classification: "local",
+        data_residency: "NZ",
+        max_hop: 0,
+        frontier_ok: false,
+        model_class: "local-only",
+      },
+      payload: {},
+    };
+    const { handle, published } = start({
+      buildEnvelope: (opts) => {
+        capturedOpts = opts;
+        return fakeEnv;
+      },
+    });
+    const body = JSON.stringify({
+      ref: "refs/heads/main",
+      repository: { full_name: "the-metafactory/cortex" },
+      sender: { login: "mellanon" },
+    });
+    const res = await postWebhook(handle, body, {
+      event: "push",
+      deliveryId: "deadbeef-dead-4dea-8dea-deadbeefdead",
+    });
+    expect(res.status).toBe(200);
+    expect(capturedOpts).toBeDefined();
+    expect(capturedOpts!.event).toBe("push");
+    expect(capturedOpts!.deliveryId).toBe("deadbeef-dead-4dea-8dea-deadbeefdead");
+    expect(capturedOpts!.repo).toBe("the-metafactory/cortex");
+    expect(capturedOpts!.sender).toBe("mellanon");
+    expect(capturedOpts!.source).toEqual(TEST_SOURCE);
+    expect(published[0]).toBe(fakeEnv);
+  });
+});
+
+describe("startGithubWebhookReceiver — shutdown", () => {
+  test("stop() can be called multiple times safely", () => {
+    const { handle } = start();
+    handle.stop();
+    // Second stop is a no-op; should not throw.
+    expect(() => handle.stop()).not.toThrow();
+  });
+
+  test("after stop(), connections are refused", async () => {
+    const { handle } = start();
+    handle.stop();
+    // Give the OS a tick to release the port.
+    await Bun.sleep(50);
+    let connectErrored = false;
+    try {
+      await fetch(`http://127.0.0.1:${handle.port}/health`);
+    } catch {
+      connectErrored = true;
+    }
+    expect(connectErrored).toBe(true);
+  });
+});

--- a/src/taps/gh-webhook-receiver/server.ts
+++ b/src/taps/gh-webhook-receiver/server.ts
@@ -1,0 +1,360 @@
+/**
+ * MIG-5.6 (C-106) — Local HTTP receiver for forwarded GitHub webhooks.
+ *
+ * Per plan §6.10 + cortex#37 architectural rationale:
+ *   - The Cloudflare Worker (`src/taps/gh-webhook/src/index.ts`) is the
+ *     internet-facing edge for GitHub webhook delivery — it validates the
+ *     HMAC signature, dedupes by `X-GitHub-Delivery`, and Service-Binds to
+ *     `grove-api` for cloud persistence today.
+ *   - Cortex itself runs as a local process. To get webhook envelopes onto
+ *     the local NATS bus (which only cortex can reach), cortex stands up
+ *     this small HTTP receiver. The Worker (or any other forwarder) POSTs
+ *     a JSON envelope-input to `http://127.0.0.1:{port}/internal/webhook`;
+ *     the receiver re-verifies HMAC as defense-in-depth and publishes the
+ *     `github.{event}.{action}` envelope.
+ *
+ * **Why a separate file (not just inline in cortex.ts):**
+ *   - cortex.ts is already the integration glue for the whole stack; the
+ *     receiver has its own test surface (HMAC failure paths, malformed
+ *     body handling, schema validation of the resulting envelope) that
+ *     deserves its own module to keep cortex.ts under control.
+ *   - The receiver is purely a thin adapter: `Request → envelope → publish`.
+ *     The envelope construction is delegated to
+ *     `bus/github-events.ts:createGithubEventEnvelope`; the publishing is
+ *     delegated to the `MyelinRuntime.publish` callback the caller injects.
+ *     Tests can therefore exercise the receiver against an in-memory fake
+ *     publish without standing up a real NATS server.
+ *
+ * **HMAC posture:**
+ *   - The receiver re-verifies the signature using `@octokit/webhooks-methods`,
+ *     matching the Worker's verification step verbatim. This is
+ *     defense-in-depth: the Worker validates upstream, but if an attacker
+ *     ever bypasses the Worker (e.g. via a misconfigured local port forward,
+ *     a curl probe against `127.0.0.1`, or a future architecture change),
+ *     the receiver must not blindly trust forwarded headers.
+ *   - Secret resolution: the receiver uses the secret passed at construction
+ *     time. Cortex pulls it from `config.github.webhookSecret` (already part
+ *     of the BotConfig schema — G-203b). When the secret is empty, the
+ *     receiver responds 503 "not configured" rather than starting unsecured.
+ *
+ * **Hostname posture:**
+ *   - Default `127.0.0.1` — never `0.0.0.0`. The receiver carries no auth
+ *     beyond HMAC; binding to all interfaces would expose it to LAN
+ *     attackers who guess the secret. Operators who *want* to expose the
+ *     receiver to a private subnet override `hostname` explicitly, opting
+ *     in to the wider attack surface.
+ *
+ * **What this file is NOT:**
+ *   - NOT the CF Worker. That continues to live at `taps/gh-webhook/src/index.ts`
+ *     and is bundled separately (`wrangler deploy`). This receiver runs
+ *     inside the cortex process.
+ *   - NOT a GitHub event router. Subscribers consume envelopes from
+ *     `local.{org}.github.*` via the surface-router; this file's job ends
+ *     once the envelope is on the bus.
+ *   - NOT a CF Worker → cortex forwarder. The actual cross-network glue
+ *     (how the Worker reaches `127.0.0.1` on the operator's laptop)
+ *     remains an open architectural decision — see cortex#37 follow-up.
+ *     In local development the operator can curl the receiver directly:
+ *
+ *       curl -X POST http://127.0.0.1:8770/internal/webhook \
+ *         -H 'X-GitHub-Event: push' \
+ *         -H 'X-GitHub-Delivery: <uuid>' \
+ *         -H 'X-Hub-Signature-256: sha256=<hmac>' \
+ *         -d '<payload>'
+ *
+ *     This makes the receiver useful immediately for offline GitHub-event
+ *     simulation tests; the cloud forwarder can land later without
+ *     re-wiring the receiver.
+ */
+
+import type { Server } from "bun";
+import { verify } from "@octokit/webhooks-methods";
+import type { Envelope } from "../../bus/myelin/envelope-validator";
+import {
+  createGithubEventEnvelope,
+  type GithubEventSource,
+} from "../../bus/github-events";
+
+/**
+ * Lifecycle handle returned by `startGithubWebhookReceiver`. Mirrors the
+ * shape `createMattermostServer` returns — `server` is the underlying
+ * Bun.Server (for tests that need to introspect address/port); `stop` is
+ * the idempotent shutdown call.
+ */
+export interface GithubWebhookReceiverHandle {
+  readonly server: Server<unknown>;
+  readonly port: number;
+  /**
+   * Idempotent stop — calling twice is safe. Returns when the server has
+   * stopped accepting new connections. In-flight requests are not awaited
+   * here (consistent with `Server.stop()`'s default behaviour); cortex's
+   * top-level shutdown timeout (15s) protects against pathological hangs.
+   */
+  stop(): void;
+}
+
+/**
+ * Construction options for the local webhook receiver.
+ *
+ * The receiver is *passive*: it doesn't own the NATS connection, the
+ * envelope-construction helpers, or the system-event source — the caller
+ * (cortex.ts) constructs all three and injects them. This keeps the
+ * receiver unit-testable without standing up a full cortex stack.
+ */
+export interface GithubWebhookReceiverOptions {
+  /**
+   * GitHub HMAC secret — must match the secret configured on the GitHub
+   * repos. Sourced from `config.github.webhookSecret`. When empty, the
+   * receiver refuses to accept any webhook (responds 503) rather than
+   * starting in unsecured mode — explicit opt-in by configuration.
+   */
+  secret: string;
+  /**
+   * Localhost-only TCP port. Default `8770`. Cortex's other HTTP-listening
+   * components use:
+   *   - Mattermost outgoing-webhook server: configurable via
+   *     `mattermost[].callbackPort` (default 8080)
+   *   - Dashboard API: `config.api.port` (default 8766)
+   *
+   * The default 8770 is far enough above mattermost's default that
+   * accidental collision is unlikely; operators with another tenant on
+   * 8770 set the port explicitly.
+   */
+  port?: number;
+  /**
+   * Hostname to bind. Default `127.0.0.1` — local-only. Operators who
+   * expose the receiver to a wider scope (private subnet) set this
+   * explicitly. Never default to `0.0.0.0`; HMAC is the only auth and
+   * widening the bind surface multiplies guess-the-secret attack
+   * geometry.
+   */
+  hostname?: string;
+  /**
+   * Envelope source identifier (`{org}.{agent}.{instance}`). Passed
+   * through to `createGithubEventEnvelope`; identical to the
+   * `systemEventSource` cortex uses for `system.*` envelopes so all
+   * envelopes from one cortex process carry the same source segments.
+   */
+  source: GithubEventSource;
+  /**
+   * Publish callback — typically `runtime.publish.bind(runtime)`. Called
+   * once per valid webhook with the constructed envelope. Errors are
+   * logged but not propagated to the HTTP response (the bus is the
+   * destination; the HTTP response just acknowledges receipt).
+   */
+  publish: (envelope: Envelope) => Promise<void>;
+  /**
+   * Optional override for the HMAC verifier — exposed for tests so we can
+   * assert handling of `verify()` throwing on malformed input without
+   * standing up real signatures. Production callers omit.
+   *
+   * @internal
+   */
+  verifyImpl?: (secret: string, body: string, signature: string) => Promise<boolean>;
+  /**
+   * Optional override for the envelope builder — exposed for tests so a
+   * fake can record the inputs without re-implementing the helper.
+   * Production callers omit.
+   *
+   * @internal
+   */
+  buildEnvelope?: typeof createGithubEventEnvelope;
+}
+
+/**
+ * Start the local GitHub webhook receiver.
+ *
+ * Returns a handle the caller (cortex.ts) registers in its shutdown
+ * sequence. The receiver runs on a single Bun.serve instance; no thread
+ * pool, no worker — the in-process publish is fast enough that we don't
+ * need a queue.
+ *
+ * **HTTP contract:**
+ *   - `GET /health` → `{ status: "ok", service: "github-webhook-receiver" }`
+ *   - `POST /internal/webhook` → 200/4xx/5xx per the validation matrix below
+ *
+ * **Validation matrix for POST `/internal/webhook`** (response codes mirror
+ * the CF Worker proxy for symmetric semantics):
+ *   - 503 "not configured" — secret is empty (receiver started without auth)
+ *   - 400 "missing headers" — missing one of `X-Hub-Signature-256`,
+ *         `X-GitHub-Event`, `X-GitHub-Delivery`
+ *   - 401 "unauthorized" — HMAC mismatch (or `verify()` threw on malformed
+ *         signature)
+ *   - 400 "invalid json" — body is not parseable as JSON
+ *   - 200 "ok" — envelope built and `publish()` invoked. The receiver
+ *         returns 200 even if `publish()` rejects (errors logged) — same
+ *         posture as the Worker, which returns the origin response. The
+ *         goal is to acknowledge receipt to the forwarder; durability is
+ *         the bus's job (JetStream when configured).
+ */
+export function startGithubWebhookReceiver(
+  opts: GithubWebhookReceiverOptions,
+): GithubWebhookReceiverHandle {
+  const port = opts.port ?? 8770;
+  const hostname = opts.hostname ?? "127.0.0.1";
+  const verifyFn = opts.verifyImpl ?? verify;
+  const buildEnvelope = opts.buildEnvelope ?? createGithubEventEnvelope;
+
+  const server = Bun.serve({
+    port,
+    hostname,
+    async fetch(req): Promise<Response> {
+      const url = new URL(req.url);
+
+      // Health check — no auth, no body parsing. Lets the operator (or
+      // a sidecar) verify the receiver is up before sending real events.
+      if (req.method === "GET" && url.pathname === "/health") {
+        return Response.json({
+          status: "ok",
+          service: "github-webhook-receiver",
+        });
+      }
+
+      // Method gate — only the webhook POST is supported.
+      if (req.method !== "POST" || url.pathname !== "/internal/webhook") {
+        return new Response("not found", { status: 404 });
+      }
+
+      // 1. Secret gate — refuse to operate without a secret. The same
+      //    posture the Worker uses.
+      if (!opts.secret) {
+        return new Response("not configured", { status: 503 });
+      }
+
+      // 2. Required headers. These match the Worker's forwarded
+      //    `X-GitHub-*` triplet.
+      const signature = req.headers.get("x-hub-signature-256") ?? "";
+      const event = req.headers.get("x-github-event") ?? "";
+      const deliveryId = req.headers.get("x-github-delivery") ?? "";
+
+      if (!signature || !event || !deliveryId) {
+        return new Response("missing headers", { status: 400 });
+      }
+
+      // 3. Read body once and verify the signature. The verifier may
+      //    throw on malformed inputs (e.g. non-hex `sha256=...`); the
+      //    Worker catches that and returns 401, so we do the same.
+      const body = await req.text();
+      try {
+        const ok = await verifyFn(opts.secret, body, signature);
+        if (!ok) {
+          return new Response("unauthorized", { status: 401 });
+        }
+      } catch (err) {
+        // Don't leak the verifier error to the caller; just 401. The
+        // operator sees the underlying cause in the structured log.
+        console.error(
+          "github-webhook-receiver: HMAC verifier threw:",
+          err instanceof Error ? err.message : err,
+        );
+        return new Response("unauthorized", { status: 401 });
+      }
+
+      // 4. Parse JSON. Malformed JSON gets 400; the Worker validates
+      //    HMAC over raw bytes regardless of body content type, so we
+      //    only fail here after auth has passed.
+      let payload: Record<string, unknown>;
+      try {
+        const parsed = JSON.parse(body);
+        if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+          return new Response("invalid json", { status: 400 });
+        }
+        payload = parsed as Record<string, unknown>;
+      } catch (err) {
+        console.error(
+          "github-webhook-receiver: malformed JSON body:",
+          err instanceof Error ? err.message : err,
+        );
+        return new Response("invalid json", { status: 400 });
+      }
+
+      // 5. Extract well-known GitHub fields. `action` may be absent
+      //    (push, ping, …); `repository.full_name` and `sender.login`
+      //    may be absent for some payload types but are present on
+      //    every typical workflow event we care about.
+      const action = typeof payload.action === "string"
+        ? payload.action
+        : undefined;
+      const repo = extractRepoFullName(payload);
+      const sender = extractSenderLogin(payload);
+
+      // 6. Build the envelope and publish. Publish errors are swallowed
+      //    + logged — the contract on `MyelinRuntime.publish` is
+      //    fire-and-forget; if NATS is down, the receiver still returns
+      //    200 so the forwarder doesn't retry (which would just queue
+      //    failures upstream).
+      const envelope = buildEnvelope({
+        source: opts.source,
+        event,
+        ...(action !== undefined && { action }),
+        deliveryId,
+        payload,
+        ...(repo !== undefined && { repo }),
+        ...(sender !== undefined && { sender }),
+      });
+
+      try {
+        await opts.publish(envelope);
+      } catch (err) {
+        // Same swallow-and-log posture as `MyelinRuntime.publish` itself:
+        // an emitting webhook event must not break the receiver path. The
+        // forwarder sees 200 either way.
+        console.error(
+          `github-webhook-receiver: publish failed for type=${envelope.type} delivery=${deliveryId}:`,
+          err instanceof Error ? err.message : err,
+        );
+      }
+
+      return new Response("ok", { status: 200 });
+    },
+  });
+
+  console.log(
+    `github-webhook-receiver: listening on ${hostname}:${port} (POST /internal/webhook)`,
+  );
+
+  return {
+    server,
+    port,
+    stop: () => {
+      try {
+        server.stop();
+      } catch (err) {
+        console.error(
+          "github-webhook-receiver: server stop error:",
+          err instanceof Error ? err.message : err,
+        );
+      }
+    },
+  };
+}
+
+/**
+ * Best-effort `repository.full_name` extraction. GitHub puts this on
+ * almost every event; the helper handles the type-narrowing so the
+ * caller doesn't have to. Returns `undefined` when the field is missing
+ * or the shape is unexpected — surfaces that filter on repo will simply
+ * see "no repo" envelopes and may choose to ignore them.
+ */
+function extractRepoFullName(payload: Record<string, unknown>): string | undefined {
+  const repo = payload.repository;
+  if (repo && typeof repo === "object" && !Array.isArray(repo)) {
+    const fullName = (repo as Record<string, unknown>).full_name;
+    if (typeof fullName === "string" && fullName.length > 0) return fullName;
+  }
+  return undefined;
+}
+
+/**
+ * Best-effort `sender.login` extraction. Same posture as
+ * `extractRepoFullName` — return the string when present, undefined
+ * otherwise.
+ */
+function extractSenderLogin(payload: Record<string, unknown>): string | undefined {
+  const sender = payload.sender;
+  if (sender && typeof sender === "object" && !Array.isArray(sender)) {
+    const login = (sender as Record<string, unknown>).login;
+    if (typeof login === "string" && login.length > 0) return login;
+  }
+  return undefined;
+}

--- a/src/taps/gh-webhook/__tests__/proxy.test.ts
+++ b/src/taps/gh-webhook/__tests__/proxy.test.ts
@@ -6,7 +6,7 @@
  * Uses @octokit/webhooks-methods for HMAC generation (same lib as production).
  */
 
-import { describe, test, expect, beforeEach } from "bun:test";
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { sign } from "@octokit/webhooks-methods";
 import app from "../src/index";
 import { _resetDeliveryCache } from "../src/index";
@@ -71,12 +71,59 @@ function makeMockFetcher(): Fetcher {
 interface TestEnv {
   GITHUB_WEBHOOK_SECRET: string;
   GROVE_API: Fetcher;
+  CORTEX_FORWARDER_URL?: string;
 }
 
-function makeEnv(overrides: Partial<{ GITHUB_WEBHOOK_SECRET: string }> = {}): TestEnv {
-  return {
+function makeEnv(
+  overrides: Partial<{
+    GITHUB_WEBHOOK_SECRET: string;
+    CORTEX_FORWARDER_URL: string;
+  }> = {},
+): TestEnv {
+  const env: TestEnv = {
     GITHUB_WEBHOOK_SECRET: overrides.GITHUB_WEBHOOK_SECRET ?? TEST_SECRET,
     GROVE_API: makeMockFetcher(),
+  };
+  if (overrides.CORTEX_FORWARDER_URL !== undefined) {
+    env.CORTEX_FORWARDER_URL = overrides.CORTEX_FORWARDER_URL;
+  }
+  return env;
+}
+
+/**
+ * Minimal `ExecutionContext` stand-in for tests that exercise the
+ * cortex-forwarder branch. `waitUntil` resolves the supplied promise so the
+ * test can await fan-out before assertions; `passThroughOnException` is a
+ * no-op (the production Worker doesn't call it on the happy path).
+ *
+ * Returns `{ ctx, waitForFanout }` — `waitForFanout()` awaits every
+ * promise that was passed to `waitUntil` since construction so a test can
+ * assert on the side effects of the fire-and-forget forward.
+ */
+function makeExecutionCtx(): {
+  ctx: ExecutionContext;
+  waitForFanout: () => Promise<void>;
+} {
+  const pending: Array<Promise<unknown>> = [];
+  const ctx: ExecutionContext = {
+    waitUntil(promise: Promise<unknown>): void {
+      pending.push(promise);
+    },
+    passThroughOnException(): void {
+      /* no-op in tests */
+    },
+    props: {},
+  };
+  return {
+    ctx,
+    waitForFanout: async () => {
+      // Drain all pending promises; new ones may be pushed during await
+      // so we loop until the buffer is empty.
+      while (pending.length > 0) {
+        const batch = pending.splice(0, pending.length);
+        await Promise.allSettled(batch);
+      }
+    },
   };
 }
 
@@ -319,6 +366,146 @@ describe("grove-webhook-proxy", () => {
       const req2 = await makeWebhookRequest(body, { deliveryId: "unique-002" });
       const res2 = await app.fetch(req2, makeEnv());
       expect(res2.status).toBe(200);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // MIG-5.6 (cortex#37): CORTEX_FORWARDER_URL — additional forward to the
+  // local cortex receiver so it can publish onto the bus.
+  // -----------------------------------------------------------------------
+
+  describe("cortex forwarder (MIG-5.6)", () => {
+    // The forwarder uses global `fetch` (cortex isn't a Service Binding —
+    // it's accessed via a public/tunnel URL). Stub it for these tests.
+    let originalFetch: typeof fetch;
+    let cortexFetchCalls: FetchCall[];
+    let cortexFetchStatus: number;
+
+    beforeEach(() => {
+      cortexFetchCalls = [];
+      cortexFetchStatus = 200;
+      originalFetch = globalThis.fetch;
+      globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.toString()
+            : input.url;
+        // Only intercept calls to the test forwarder URL — other fetches
+        // (none expected in these tests) flow through to the real fetch.
+        if (url.startsWith("https://cortex-forwarder.test")) {
+          const headers: Record<string, string> = {};
+          if (init?.headers) {
+            for (const [k, v] of Object.entries(init.headers as Record<string, string>)) {
+              headers[k.toLowerCase()] = v;
+            }
+          }
+          cortexFetchCalls.push({
+            url,
+            method: init?.method ?? "GET",
+            headers,
+            body: typeof init?.body === "string" ? init.body : "",
+          });
+          return new Response("ok", { status: cortexFetchStatus });
+        }
+        return originalFetch(input, init);
+      }) as typeof fetch;
+    });
+
+    afterEach(() => {
+      globalThis.fetch = originalFetch;
+    });
+
+    test("forwards to CORTEX_FORWARDER_URL when set, preserving headers + body", async () => {
+      const body = JSON.stringify({
+        action: "opened",
+        repository: { full_name: "the-metafactory/cortex" },
+      });
+      const req = await makeWebhookRequest(body, {
+        event: "issues",
+        deliveryId: "fwd-cortex-001",
+      });
+      const env = makeEnv({
+        CORTEX_FORWARDER_URL: "https://cortex-forwarder.test/internal/webhook",
+      });
+      const { ctx, waitForFanout } = makeExecutionCtx();
+      const res = await app.fetch(req, env, ctx);
+      await waitForFanout();
+
+      expect(res.status).toBe(200);
+      // grove-api still received the call (existing path unchanged).
+      expect(fetchCalls.length).toBe(1);
+      // cortex receiver got a parallel forward with the same headers + body.
+      expect(cortexFetchCalls.length).toBe(1);
+      const cortexCall = cortexFetchCalls[0]!;
+      expect(cortexCall.url).toBe("https://cortex-forwarder.test/internal/webhook");
+      expect(cortexCall.method).toBe("POST");
+      expect(cortexCall.headers["x-github-event"]).toBe("issues");
+      expect(cortexCall.headers["x-github-delivery"]).toBe("fwd-cortex-001");
+      expect(cortexCall.headers["x-hub-signature-256"]).toBeTruthy();
+      expect(cortexCall.body).toBe(body);
+    });
+
+    test("does NOT forward when CORTEX_FORWARDER_URL is unset", async () => {
+      const body = JSON.stringify({ action: "opened" });
+      const req = await makeWebhookRequest(body, { deliveryId: "fwd-cortex-002" });
+      const { ctx, waitForFanout } = makeExecutionCtx();
+      const res = await app.fetch(req, makeEnv(), ctx);
+      await waitForFanout();
+      expect(res.status).toBe(200);
+      expect(cortexFetchCalls.length).toBe(0);
+    });
+
+    test("forwarder 5xx response does not affect the proxy's response", async () => {
+      cortexFetchStatus = 503;
+      const body = JSON.stringify({ action: "opened" });
+      const req = await makeWebhookRequest(body, { deliveryId: "fwd-cortex-003" });
+      const env = makeEnv({
+        CORTEX_FORWARDER_URL: "https://cortex-forwarder.test/internal/webhook",
+      });
+      const { ctx, waitForFanout } = makeExecutionCtx();
+      const res = await app.fetch(req, env, ctx);
+      await waitForFanout();
+      // Proxy returns the grove-api status, not the cortex one.
+      expect(res.status).toBe(200);
+      expect(cortexFetchCalls.length).toBe(1);
+    });
+
+    test("forwarder thrown error is logged but does not affect response", async () => {
+      const errors: string[] = [];
+      const origConsoleError = console.error;
+      console.error = (...args: unknown[]) => {
+        errors.push(args.map(String).join(" "));
+      };
+      try {
+        // Override global fetch to throw for the cortex URL specifically.
+        const originalFetchInner = globalThis.fetch;
+        globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+          const url = typeof input === "string"
+            ? input
+            : input instanceof URL
+              ? input.toString()
+              : input.url;
+          if (url.startsWith("https://cortex-forwarder.test")) {
+            throw new Error("connection refused");
+          }
+          return originalFetchInner(input, init);
+        }) as typeof fetch;
+
+        const body = JSON.stringify({ action: "opened" });
+        const req = await makeWebhookRequest(body, { deliveryId: "fwd-cortex-004" });
+        const env = makeEnv({
+          CORTEX_FORWARDER_URL: "https://cortex-forwarder.test/internal/webhook",
+        });
+        const { ctx, waitForFanout } = makeExecutionCtx();
+        const res = await app.fetch(req, env, ctx);
+        await waitForFanout();
+
+        expect(res.status).toBe(200);
+        expect(errors.some((e) => e.includes("cortex forwarder fetch failed"))).toBe(true);
+      } finally {
+        console.error = origConsoleError;
+      }
     });
   });
 });

--- a/src/taps/gh-webhook/src/index.ts
+++ b/src/taps/gh-webhook/src/index.ts
@@ -28,11 +28,43 @@ import { verify } from "@octokit/webhooks-methods";
 // Types
 // ---------------------------------------------------------------------------
 
+/**
+ * Local stand-in for the Cloudflare `Fetcher` binding type. The subpackage
+ * tsconfig (`src/taps/gh-webhook/tsconfig.json`) loads `@cloudflare/workers-types`
+ * which provides a richer `Fetcher`; this local interface lets root tsc
+ * type-check the file too (the MIG-5.6 integration test transitively
+ * imports `Env` via the Worker entry), without forcing CF types into the
+ * root project. Same minimal shape as `Fetcher` for the operations the
+ * Worker actually uses.
+ */
+interface ServiceBindingFetcher {
+  fetch(input: Request | string, init?: RequestInit): Promise<Response>;
+}
+
 interface Env {
   /** GitHub webhook HMAC secret — must match the secret configured on GitHub repos */
   GITHUB_WEBHOOK_SECRET: string;
   /** Service Binding to grove-api Worker — direct Worker-to-Worker tunnel */
-  GROVE_API: Fetcher;
+  GROVE_API: ServiceBindingFetcher;
+  /**
+   * MIG-5.6 (cortex#37): optional public URL of the local cortex
+   * `gh-webhook-receiver` (typically a tunnel exposing `127.0.0.1:8770`).
+   * When set, the Worker forwards each validated webhook to this URL in
+   * addition to `GROVE_API` so cortex can publish the
+   * `local.{org}.github.{event}.{action}` envelope onto the bus.
+   *
+   * Posture:
+   *   - The forward is best-effort: a failure here does NOT change the
+   *     response returned to GitHub (which always reflects `GROVE_API`'s
+   *     status). GitHub never retries on a 2xx; we don't want a transient
+   *     cortex-side outage to cause a retry storm against grove-api.
+   *   - The cortex receiver re-verifies HMAC, so the forwarded request
+   *     carries the original `X-Hub-Signature-256` verbatim — no
+   *     re-signing, no shared-secret-between-Workers complexity.
+   *   - When unset (empty / undefined), the Worker behaves identically to
+   *     the pre-MIG-5.6 path: forward only to grove-api.
+   */
+  CORTEX_FORWARDER_URL?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -140,10 +172,69 @@ app.post("/github", async (c) => {
     }),
   );
 
+  // 5b. MIG-5.6 (cortex#37): if a cortex forwarder URL is configured,
+  //     additionally fire-and-forget the webhook at the local cortex
+  //     receiver so it can publish `local.{org}.github.{event}.{action}`
+  //     onto the bus. Failures are logged but never affect the response
+  //     returned to GitHub — `GROVE_API` remains the authoritative store.
+  const cortexUrl = c.env.CORTEX_FORWARDER_URL;
+  if (cortexUrl) {
+    c.executionCtx.waitUntil(
+      forwardToCortex(cortexUrl, body, {
+        event,
+        deliveryId,
+        signature,
+        contentType: c.req.header("content-type") ?? "application/json",
+      }),
+    );
+  }
+
   // 6. Return origin's response (preserve status code)
   const respBody = await resp.text();
   return c.text(respBody, resp.status as any);
 });
+
+/**
+ * Fire-and-forget POST to the cortex local receiver. Awaited via
+ * `executionCtx.waitUntil` so the Worker doesn't return before the
+ * forward completes, but its outcome never alters the response code.
+ *
+ * Errors are caught and surfaced via `console.error` so the operator
+ * sees them in `wrangler tail`; we deliberately do NOT propagate them.
+ */
+async function forwardToCortex(
+  url: string,
+  body: string,
+  headers: {
+    event: string;
+    deliveryId: string;
+    signature: string;
+    contentType: string;
+  },
+): Promise<void> {
+  try {
+    const resp = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": headers.contentType,
+        "X-GitHub-Event": headers.event,
+        "X-GitHub-Delivery": headers.deliveryId,
+        "X-Hub-Signature-256": headers.signature,
+      },
+      body,
+    });
+    if (!resp.ok) {
+      console.error(
+        `grove-webhook-proxy: cortex forwarder returned non-2xx (status=${resp.status} delivery=${headers.deliveryId})`,
+      );
+    }
+  } catch (err) {
+    console.error(
+      `grove-webhook-proxy: cortex forwarder fetch failed (delivery=${headers.deliveryId}):`,
+      err instanceof Error ? err.message : err,
+    );
+  }
+}
 
 // 404 fallback
 app.notFound((c) => c.text("not found", 404));

--- a/src/taps/gh-webhook/wrangler.toml
+++ b/src/taps/gh-webhook/wrangler.toml
@@ -23,3 +23,13 @@ service = "grove-api"
 
 # Secrets (set via `wrangler secret put`):
 # GITHUB_WEBHOOK_SECRET  — GitHub webhook HMAC secret (same as grove-api)
+#
+# Optional vars (set via `wrangler secret put` or `[vars]` block):
+# CORTEX_FORWARDER_URL   — MIG-5.6: public URL of the local cortex
+#                           gh-webhook-receiver (typically a tunnel
+#                           exposing the operator laptop's
+#                           127.0.0.1:8770). When set, validated webhooks
+#                           are additionally forwarded here so cortex can
+#                           publish `local.{org}.github.{event}.{action}`
+#                           envelopes onto the bus. Best-effort —
+#                           failures never affect the response to GitHub.


### PR DESCRIPTION
## What

Closes plan §4 MIG-5.6 and **closes cortex#37**. Full end-to-end wiring: HMAC-validated GitHub webhooks land as `local.{org}.github.{event}.{action}` envelopes on the bus.

cortex#37 had three options:
- (a) NATS WebSocket gateway — new infra
- (b) Bot exposes HTTP receiver — chosen
- (c) Wait for MIG-7 cortex.ts authority — fully landed now

This PR implements **(b)** end-to-end, made possible by **(c)** completing.

## Components

**1. `src/bus/github-events.ts`** — `createGithubEventEnvelope({event, action, payload, source})` helper. Subject form: `local.{org}.github.{event}.{action}`. Sovereignty mirrors system/dispatch/cc-events defaults (operator-only).

**2. `src/taps/gh-webhook-receiver/server.ts`** — `Bun.serve`-backed HTTP receiver. Binds `127.0.0.1:8770` by default (operator must explicitly widen). Re-verifies GitHub HMAC as defense-in-depth (so cross-boundary forward needs no extra shared secret beyond the webhook secret). On success: builds envelope → `runtime.publish` → returns 204.

**3. `src/cortex.ts`** — opt-in receiver wire-up when `config.github.receiver.enabled` is set. Graceful shutdown via the established `pending` Set pattern.

**4. `src/taps/gh-webhook/src/index.ts`** (CF Worker) — added `CORTEX_FORWARDER_URL` env-var-driven fan-out via `executionCtx.waitUntil`. Forwards validated webhook to cortex receiver. **HMAC validation unchanged.** Failures never affect the response to GitHub. Operators who don't set `CORTEX_FORWARDER_URL` see zero behaviour change.

## Config schema additions

- `BotConfigSchema.github.receiver` (legacy schema)
- `cortex-config.ts:GithubConfigSchema.receiver` (canonical post-MIG-7.2 schema)
- Both mirror identical defaults (`enabled: false`, `hostname: 127.0.0.1`, `port: 8770`)

## Type/test plumbing fixes

- Replaced global `Fetcher` (CF Workers type) with local `ServiceBindingFetcher` interface in `gh-webhook/src/index.ts` — keeps root tsc clean without pulling `@cloudflare/workers-types` into root project (integration test transitively type-checks across subpackage boundary)
- Removed dangling `@ts-expect-error` in integration test
- Cascade fixture updates: `common/agents/__tests__/registry.test.ts` + `common/config/__tests__/watcher.test.ts`

## Tests (+49)

- `bus/__tests__/github-events.test.ts` — **19 cases** (envelope shape, Ajv validation, subject derivation, sovereignty isolation, source dotting)
- `taps/gh-webhook-receiver/__tests__/server.test.ts` — **23 cases** (HMAC valid/invalid, missing headers, bad JSON, publish-error swallow, 127.0.0.1 binding, shutdown idempotency)
- `taps/gh-webhook-receiver/__tests__/integration.test.ts` — **3 cases** (Worker → receiver end-to-end via mock fetch)
- `taps/gh-webhook/__tests__/proxy.test.ts` — **+4 cases** for forwarder-branch behaviour

## Verification

- cortex root \`bunx tsc --noEmit\` → **exit 0**
- gh-webhook subpackage \`bunx tsc --noEmit\` → **exit 0**
- Full suite — **2108 pass / 1 pre-existing fail** (the React shell test from MIG-2)

## Operator-side deployment (out of scope, deploy-time)

After merge, operators set `CORTEX_FORWARDER_URL` via `wrangler secret put` pointing at their tunnel-exposed receiver. Until then, local dev works via `curl http://127.0.0.1:8770/internal/webhook` with valid HMAC.

## Plan grounding

Closes plan §4 MIG-5.6. Architecture §8 places `taps/gh-webhook-receiver/` alongside `taps/gh-webhook/` — both serve the GH webhook flow but at different process boundaries.

Refs cortex#7 (MIG-5 umbrella, closed), cortex#37 (this follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)