### PR TITLE
feat(common/types): F-1 — persona format specification (v1.0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 dist/
 tmp-screenshots/
 .playwright-cli/
+.specflow/

--- a/.specify/specs/F-1-persona-format-specification/plan.md
+++ b/.specify/specs/F-1-persona-format-specification/plan.md
@@ -1,0 +1,205 @@
+---
+feature: "Persona format specification"
+spec: "./spec.md"
+status: "draft"
+---
+
+# Technical Plan: Persona format specification
+
+## Architecture Overview
+
+This is a documentation feature with one tiny code artifact: a version constant. Two deliverables land in the cortex repo:
+
+```
+1. docs/persona-format.md            ── the schema reference doc
+2. src/common/types/persona-format.ts ── PERSONA_FORMAT_VERSION = "1.0.0" constant
+```
+
+The constant is the runtime source-of-truth that `CortexHostAdapter.detect()` (F-5) and the agents.d loader (F-2) compare bot-declared ranges against. Today nothing reads the constant — it lands now so downstream features can import it without circular dependency.
+
+```
+┌─────────────────────────────────┐
+│ docs/persona-format.md          │
+│ ── schema reference             │
+│ ── examples (minimal + full)    │
+│ ── versioning policy            │
+│ ── error handling               │
+└──────────────┬──────────────────┘
+               │ semver constant referenced from doc
+               ▼
+┌─────────────────────────────────┐
+│ src/common/types/persona-       │
+│ format.ts                       │
+│ ── PERSONA_FORMAT_VERSION       │
+│ ── (later) Zod schema for       │
+│    frontmatter                  │
+└──────────────┬──────────────────┘
+               │ (future, in F-2)
+               ▼
+┌─────────────────────────────────┐
+│ F-2 agents.d loader             │
+│ F-5 CortexHostAdapter           │
+│ (out of scope here)             │
+└─────────────────────────────────┘
+```
+
+## Technology Stack
+
+| Component | Choice | Rationale |
+|-----------|--------|-----------|
+| Language | TypeScript | cortex standard |
+| Runtime | Bun | cortex standard |
+| Doc format | Markdown | cortex `docs/design-*.md` convention |
+| Version constant pattern | `export const X = "..."` | matches existing cortex pattern (e.g. arc-manifest version handling) |
+
+## Constitutional Compliance
+
+- [x] **CLI-First:** N/A — no new CLI surface; the doc is the artifact.
+- [x] **Library-First:** the version constant is a pure module import — consumable by any cortex component.
+- [x] **Test-First:** the constant gets a unit test verifying semver shape (`/^\d+\.\d+\.\d+$/`). The doc is verified via existence + structural grep in tests.
+- [x] **Deterministic:** the constant is literal; no probabilistic behavior.
+- [x] **Code Before Prompts:** no prompts involved.
+
+## Data Model
+
+### Persona file (markdown with frontmatter)
+
+```typescript
+// Conceptual — actual Zod schema lands in F-2 (agents.d loader is the consumer)
+interface PersonaFile {
+  frontmatter: {
+    displayName: string;                  // required
+    preferredModel?: string;              // optional
+    allowedTools?: string[];              // optional
+    behavior?: Record<string, unknown>;   // optional, opaque
+    temperature?: number;                 // optional, 0..1
+    maxTokens?: number;                   // optional, >0
+    tags?: string[];                      // optional
+  };
+  body: string;                           // markdown prose (used as system prompt prefix)
+}
+```
+
+### Version constant module
+
+```typescript
+// src/common/types/persona-format.ts
+/**
+ * Current persona-format version implemented by this cortex build.
+ * Bot manifests declare a supported range via `runtime.persona-format: ^1.0`
+ * in arc-manifest. See docs/persona-format.md §Versioning.
+ */
+export const PERSONA_FORMAT_VERSION = "1.0.0" as const;
+```
+
+That is the entire module. No types. No exports beyond the constant.
+
+## API Contracts
+
+No new API surface beyond the constant.
+
+## Implementation Strategy
+
+### Phase 1: Foundation (this feature, entirely)
+
+The single phase. Three artifacts:
+1. `src/common/types/persona-format.ts` — the version constant
+2. `src/common/types/__tests__/persona-format.test.ts` — unit test for the constant
+3. `docs/persona-format.md` — the human-readable schema reference
+
+Phases 2 and 3 do not exist in this feature — consumers (F-2, F-5) take the next steps.
+
+## File Structure
+
+```
+src/common/types/
+├── persona-format.ts             # NEW — single export PERSONA_FORMAT_VERSION
+└── __tests__/
+    └── persona-format.test.ts    # NEW — semver shape test + doc-existence test
+
+docs/
+└── persona-format.md             # NEW — schema reference (~250 lines)
+```
+
+## Risk Assessment
+
+| Risk | Impact | Likelihood | Mitigation |
+|------|--------|------------|------------|
+| Doc and code drift (constant says 1.0.0; doc says 1.1.0) | Low (no consumers yet at merge time) | Med (real risk once F-2 lands) | Test asserts the constant matches what doc declares in its `## Current version` section. |
+| Bot ecosystem demands a different versioning model | Med (would require a v1 rewrite) | Low (no bots ship yet) | Watch arc#117 + agent-skills spec evolution; revisit before B.1 bot package ships. |
+| YAML frontmatter parsing edge case breaks F-2 | Med (downstream) | Low (yaml package is mature) | F-2's tests will catch; this feature explicitly defers parser implementation. |
+
+## Failure Mode Analysis
+
+### How This Code Can Fail
+
+| Failure Mode | Trigger | Detection | Degradation | Recovery |
+|-------------|---------|-----------|-------------|----------|
+| Constant export removed/renamed | Refactor accident | F-2's import fails at build | TypeScript compile error | Restore export |
+| Doc deleted | Cleanup accident | Test asserts doc exists | Test failure on next CI | Restore from git |
+| Version constant out of semver shape | Manual edit error | Unit test regex | Test failure | Fix constant |
+
+### Assumptions That Could Break
+
+| Assumption | What Would Invalidate It | Detection Strategy |
+|-----------|-------------------------|-------------------|
+| `^1.0` is the syntax operators will write in arc-manifest | arc#117 lands a different range syntax | arc-side audit before F-5 lands |
+| `yaml` package's `parse()` is acceptable for v1 frontmatter | Spec adopts a non-YAML alternative (TOML?) | Watch agent-skills spec |
+| Markdown body is treated as opaque text by runtime | Runtime evolves to need structured markdown sections | Surface in cortex runner PRs |
+
+### Blast Radius
+
+- **Files touched:** 3 new files (1 source, 1 test, 1 doc); 0 modified
+- **Systems affected:** none at merge time (F-2 + F-5 will consume on landing)
+- **Rollback strategy:** revert the PR — no dependents yet
+
+## Dependencies
+
+### External
+
+None.
+
+### Internal
+
+None — fresh file in `src/common/types/`.
+
+## Migration/Deployment
+
+- No DB migrations
+- No env vars
+- No breaking changes (additive — feature didn't exist before)
+
+## Estimated Complexity
+
+- **New files:** 3
+- **Modified files:** 0
+- **Test files:** 1
+- **Estimated tasks:** 4 (constant, constant-test, doc, doc-test)
+- **Debt score:** 1 (minimal — well-scoped, documented, tested)
+
+## Longevity Assessment
+
+### Maintainability Indicators
+
+| Indicator | Status | Notes |
+|-----------|--------|-------|
+| Readability: Can a developer understand this in 6 months? | Yes | Single-export module + Markdown doc |
+| Testability: Can changes be verified without manual testing? | Yes | Unit test + grep test |
+| Documentation: Is the "why" captured, not just the "what"? | Yes | spec.md captures why; doc captures what + how |
+
+### Evolution Vectors
+
+| What Might Change | Preparation | Impact |
+|------------------|-------------|--------|
+| Schema bump 1.0 → 1.1 (new optional field) | Bump constant + update doc + bump bot manifests' ranges | Low (semver compatible) |
+| Schema bump 1.0 → 2.0 (breaking) | Major bump + deprecation cycle | Med (bot package migrations) |
+| Runtime adds enforcement of `allowedTools` | Separate runner-side feature; doc gains "enforced" note | Med |
+
+### Deletion Criteria
+
+When should this code be deleted?
+
+- [ ] Feature superseded by: an upstream standard (e.g. Agent Skills spec) that fully replaces this schema
+- [ ] Dependency deprecated: `yaml` package no longer maintained → migration to alternative
+- [ ] User need eliminated: no more bot packages → unlikely
+- [ ] Maintenance cost exceeds value when: schema versioning bureaucracy outweighs ecosystem benefit (unlikely while ecosystem grows)

--- a/.specify/specs/F-1-persona-format-specification/spec.md
+++ b/.specify/specs/F-1-persona-format-specification/spec.md
@@ -1,0 +1,196 @@
+---
+id: "F-1"
+feature: "Persona format specification"
+status: "draft"
+created: "2026-05-12"
+source: "Interview answers from cortex#60 design + Ivy session 2026-05-11"
+---
+
+# Specification: Persona format specification
+
+## Overview
+
+Define and document the canonical persona file format for arc-installable cortex sub-bots. A persona file pairs structured YAML frontmatter (preferred model, allowed tools, behavior flags) with a markdown prose body (persona character + behavior guidance). Bot packages ship `persona.md` files; cortex consumes them at agent registration time. Persona schema is semver-versioned; bot manifests declare a supported range via `persona-format: ^1.0`.
+
+This feature is documentation only — no runtime code. Cortex's existing config loader already accepts a `persona` field as an opaque file path; this spec defines what's inside that file.
+
+## User Scenarios
+
+### Scenario 1: Bot author writes a new persona
+
+**As a** bot author packaging a code-review bot
+**I want to** know the canonical persona file format before I write `persona.md`
+**So that** my bot package installs cleanly into cortex without runtime schema-mismatch errors
+
+**Acceptance Criteria:**
+- [ ] `docs/persona-format.md` exists on `main` with a complete schema reference
+- [ ] The doc includes a minimal worked example (~10 lines)
+- [ ] The doc includes a comprehensive worked example (all optional fields populated)
+- [ ] The doc declares the current version (`1.0`) and version-compatibility policy
+- [ ] An author can copy the minimal example, edit `displayName` + system-prompt body, and have a valid persona without further reading
+
+### Scenario 2: Cortex maintainer evolves the persona schema
+
+**As a** cortex maintainer adding a new optional field to the persona format
+**I want to** the version-compatibility policy to be unambiguous
+**So that** my schema bump (e.g. 1.0 → 1.1) doesn't break existing bots
+
+**Acceptance Criteria:**
+- [ ] Doc declares semver rules: optional-field additions = minor bump; required-field changes = major bump; default-value changes = minor bump
+- [ ] Doc names a deprecation pathway (warn for 1 minor cycle, then remove on next major)
+- [ ] Doc names where the version constant lives in cortex source (`src/common/types/persona-format.ts`)
+
+### Scenario 3: Bot installation rejects persona-format version skew
+
+**As a** cortex operator running `arc install <bot>`
+**I want to** see a clear error if the bot's declared `persona-format` range doesn't satisfy cortex's implemented version
+**So that** I don't get cryptic load-time failures later
+
+**Acceptance Criteria:**
+- [ ] Doc specifies that bot manifest declares `persona-format: ^1.0` (semver range) in arc-manifest
+- [ ] Doc specifies cortex's `CortexHostAdapter.detect()` includes a `persona-format-version` check against the bot's declared range
+- [ ] Doc specifies install-time error wording when range fails
+
+## Functional Requirements
+
+### FR-1: Format structure
+
+The persona file is a markdown file with a YAML frontmatter block. The frontmatter block is required (even if minimal) and uses the standard `---` delimiters. The body following the frontmatter is markdown prose and constitutes the agent's persona/behavior text.
+
+```markdown
+---
+displayName: Echo
+preferredModel: claude-opus-4-7
+allowedTools: [Read, Grep, Bash]
+behavior:
+  pre-commit-review: true
+  proactive-suggestions: false
+---
+
+# Echo — Code Review Agent
+
+You are Echo, a meticulous senior code reviewer...
+```
+
+**Validation:** YAML frontmatter parses with `yaml` package; required fields are present; unknown fields generate a warning but don't reject.
+
+### FR-2: Required frontmatter fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `displayName` | string | Human-readable name shown in dashboard. MUST match the `displayName` in `agents.d/<id>.yaml` if both are set (cortex warns on mismatch). |
+
+### FR-3: Optional frontmatter fields (v1.0)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `preferredModel` | string | Claude model id (e.g. `claude-opus-4-7`, `claude-sonnet-4-6`, `claude-haiku-4-5`). Cortex's runner uses this if set; falls back to operator default. |
+| `allowedTools` | string[] | Tool allowlist for the agent. If unset, cortex applies the role's default allowlist. Subset of cortex's known tools (Read/Edit/Write/Grep/Bash/Agent/Skill/…). |
+| `behavior` | object | Free-form key-value flags for persona-specific behavior toggles. Cortex passes through to the agent runtime opaquely (no schema enforcement on this object's interior). |
+| `temperature` | number | Sampling temperature override (0.0–1.0). Falls back to cortex default. |
+| `maxTokens` | number | Max output tokens per turn. Falls back to cortex default. |
+| `tags` | string[] | Free-form labels for filtering/discovery in dashboard. |
+
+### FR-4: Prose body
+
+The markdown body following the frontmatter is the agent's persona/behavior text — passed to the model as the system prompt prefix at session start. No schema enforcement on body content; bot author owns this prose.
+
+**Convention (not enforced):** the body should open with a one-paragraph identity statement (who the agent is, what they do) followed by behavior guidance, examples, and tone notes. Examples below show the convention.
+
+### FR-5: Version declaration
+
+The persona format itself is versioned via the cortex codebase, not the persona file. A bot's `arc-manifest.yaml` declares the persona-format version range the bot supports:
+
+```yaml
+# arc-manifest.yaml
+runtime:
+  persona-format: ^1.0   # semver range (npm-compatible)
+```
+
+Cortex's current persona-format version is exported as a constant: `src/common/types/persona-format.ts` → `export const PERSONA_FORMAT_VERSION = "1.0.0";`. The `CortexHostAdapter.detect()` checks the bot's declared range against this constant at install time and rejects the install (with a clear error) if the range is not satisfied.
+
+**Why arc-manifest, not frontmatter:** the bot package is the source of truth (cortex#58 D5). Putting the version in arc-manifest keeps the answer in one place; putting it in frontmatter would let the bot's manifest and persona file drift.
+
+### FR-6: Versioning policy
+
+| Change type | Version bump |
+|-------------|--------------|
+| Add optional field | Minor (1.0 → 1.1) |
+| Change default value of optional field | Minor |
+| Add required field | Major (1.0 → 2.0) |
+| Remove field | Major |
+| Tighten type/validation on existing field | Major |
+| Loosen type/validation on existing field | Minor |
+
+**Deprecation pathway:** when removing a field, mark it deprecated in the prior minor release (warn at load), then remove in the next major. Cortex emits load-time warnings naming the deprecated field, the version it'll be removed in, and the replacement (if any).
+
+## Non-Functional Requirements
+
+- **Performance:** persona file load is one-off at agent registration; no per-message cost. File size MUST be under 100KB (warn at 50KB; reject above 100KB).
+- **Security:** persona file contents are passed to the model verbatim — bot authors are trusted with what they write here. Frontmatter is parsed with `yaml` package's `parse()` (NOT `parseAllDocuments` — single doc only).
+- **Failure Behavior:**
+  - On missing file: cortex rejects agent registration with a clear error naming the expected path.
+  - On unparseable frontmatter: cortex rejects registration; error names line number.
+  - On missing `displayName`: rejected.
+  - On unknown frontmatter field: warning logged with the field name; agent still registers.
+  - On `persona-format` range unsatisfied: cortex's `CortexHostAdapter.detect()` rejects install before any files are dropped.
+
+## Key Entities
+
+| Entity | Description | Key Attributes |
+|--------|-------------|----------------|
+| Persona file | Markdown file with YAML frontmatter | `displayName` (required), optional `preferredModel`, `allowedTools`, `behavior`, `temperature`, `maxTokens`, `tags` + prose body |
+| Persona format version | Semver string constant in cortex source | `PERSONA_FORMAT_VERSION` exported from `src/common/types/persona-format.ts` |
+| Bot persona-format declaration | Semver range in arc-manifest | `runtime.persona-format: ^1.0` |
+
+## Success Criteria
+
+- [ ] `docs/persona-format.md` exists on `main`
+- [ ] Doc has: schema reference, minimal example, comprehensive example, versioning policy section, error-handling section
+- [ ] A bot author can author a valid `persona.md` in under 5 minutes by copy-editing the minimal example
+- [ ] Echo review (1 round) approves with 0 blockers / 0 majors
+- [ ] `src/common/types/persona-format.ts` exists with `PERSONA_FORMAT_VERSION = "1.0.0"` constant + JSDoc pointing at the doc
+
+## Assumptions
+
+| Assumption | What Would Invalidate It | Detection Strategy |
+|-----------|-------------------------|-------------------|
+| Bot authors are humans (not generated bots) | Auto-generated bot packages | n/a for v1 — accept; revisit if 50%+ bots are generated |
+| Markdown + YAML frontmatter is universally familiar | Bot ecosystem shifts to a different format | Watch agentic-skill spec evolution; revisit if mainstream shifts |
+| Semver in npm syntax is the right range syntax | Bot ecosystem uses a different range syntax | Match arc#117's chosen syntax (assume npm semver per current arc docs) |
+| Frontmatter parsing is fast enough to never be a bottleneck | Bot has 100+ agents | Load timing in F-2's tests; revisit if >50ms per agent at startup |
+
+## System Context
+
+### Upstream Dependencies
+
+| System | What We Get | What Breaks If It Changes | Version/Contract |
+|--------|-------------|---------------------------|------------------|
+| `yaml` npm package | YAML parser | Frontmatter parsing breaks | ^2.8.3 (current cortex pin) |
+
+### Downstream Consumers
+
+| System | What They Expect | Breaking Change Threshold |
+|--------|-----------------|--------------------------|
+| F-2 `agents.d/` loader | Persona file at the path declared in fragment's `persona:` field, parseable per this spec | Any required-field addition would break existing personas |
+| `CortexHostAdapter` (F-5) | `persona-format` semver range field in arc-manifest | Range syntax change |
+| Bot packages (claude-review-bot, codex-review-bot, …) | Stable schema; clear evolution policy | Major version bumps |
+
+### Adjacent Systems (Implicit Coupling)
+
+| System | Implicit Dependency | Risk |
+|--------|---------------------|------|
+| cortex dashboard | `displayName` from persona file vs from `agents.d/<id>.yaml` fragment | Mismatched display in two places; mitigated by warn-on-mismatch |
+| Agent runtime (cortex's runner) | `preferredModel`, `temperature`, `maxTokens` from persona feed into Claude API params | Format change requires runtime change |
+
+## [NEEDS CLARIFICATION]
+
+- None for v1 — interview answers locked all decision points. Open items rolled to future minor versions.
+
+## Out of Scope
+
+- **Persona file inheritance** — no `extends: parent-persona.md` mechanism in v1. Each persona is self-contained.
+- **Multi-language personas** — single-locale only. Bot packages targeting non-English deployments ship locale-specific persona files (`persona-de.md`, `persona-fr.md`) and the manifest pins the locale; cortex picks one at install based on operator preference. This is bot-author convention, not schema feature.
+- **Live persona reload** — persona changes require `arc upgrade <bot>` (cortex#58 §12). Live watch is a future enhancement.
+- **Tool-allowlist enforcement** — `allowedTools` is advisory in v1; actual enforcement lives in the agent runner (not in this doc).
+- **Behavior flag schema** — `behavior:` is an opaque object in v1. Specific flags are documented per-bot by the bot author, not by cortex.

--- a/.specify/specs/F-1-persona-format-specification/tasks.md
+++ b/.specify/specs/F-1-persona-format-specification/tasks.md
@@ -1,0 +1,101 @@
+---
+feature: "Persona format specification"
+plan: "./plan.md"
+status: "pending"
+total_tasks: 4
+completed: 0
+---
+
+# Tasks: Persona format specification
+
+## Legend
+
+- `[T]` - Test required (TDD: test FIRST)
+- `[P]` - Parallel-safe within group
+- `depends: T-X.Y` - Sequential dependency
+
+## Task Groups
+
+### Group 1: Version constant (foundation)
+
+- [ ] **T-1.1** Write failing test for `PERSONA_FORMAT_VERSION` constant [T] [P]
+  - File: `src/common/types/__tests__/persona-format.test.ts`
+  - Test contents: import `PERSONA_FORMAT_VERSION`; assert it matches `/^\d+\.\d+\.\d+$/`; assert value is `"1.0.0"`.
+  - RED: test fails because import resolves to nothing.
+
+- [ ] **T-1.2** Create the constant module [T] (depends: T-1.1)
+  - File: `src/common/types/persona-format.ts`
+  - Contents: JSDoc + `export const PERSONA_FORMAT_VERSION = "1.0.0" as const;`
+  - JSDoc points at `docs/persona-format.md` for the schema reference.
+  - GREEN: T-1.1 passes.
+
+### Group 2: Documentation (the artifact)
+
+- [ ] **T-2.1** Write failing test for `docs/persona-format.md` existence + structure [T] [P]
+  - File: `src/common/types/__tests__/persona-format.test.ts` (extends T-1.1's test file)
+  - Test contents:
+    - `existsSync` check on `docs/persona-format.md`
+    - Read file; assert it contains required section headings: `## Schema`, `## Versioning`, `## Examples`, `## Error handling`, `## Current version`
+    - Assert `## Current version` section names the same constant value as `PERSONA_FORMAT_VERSION` (regex match `1\.0\.0`)
+  - RED: tests fail because doc doesn't exist.
+
+- [ ] **T-2.2** Write `docs/persona-format.md` [T] (depends: T-2.1)
+  - File: `docs/persona-format.md`
+  - Sections (per spec.md FR-1..FR-6):
+    1. Header (status, version, links to spec / arc-agent-bots design)
+    2. `## Schema` — frontmatter required + optional fields with types + descriptions
+    3. `## Examples` — minimal (~10 lines) + comprehensive (all optional fields)
+    4. `## Versioning` — semver policy table (minor/major triggers) + deprecation pathway
+    5. `## Error handling` — what cortex rejects vs warns on
+    6. `## Current version` — single line: `PERSONA_FORMAT_VERSION = "1.0.0"` + pointer to `src/common/types/persona-format.ts`
+    7. `## Related docs` — links to design-arc-agent-bots.md, design-pi-dev-review-agent.md, architecture.md
+  - GREEN: T-2.1 passes.
+
+## Dependency Graph
+
+```
+T-1.1 ──> T-1.2
+                ╲
+                 ╲
+T-2.1 ──> T-2.2 ──╲──> all tests green
+```
+
+T-1.1 and T-2.1 can run as parallel "RED" phase. T-1.2 and T-2.2 likewise parallel "GREEN" phase.
+
+## Execution Order
+
+1. Parallel: T-1.1 + T-2.1 (both write failing tests)
+2. Parallel: T-1.2 + T-2.2 (both implement)
+3. Verify: `bun test src/common/types/__tests__/persona-format.test.ts` all green
+4. Verify: full `bun test` no regressions (1 pre-existing fail is the mission-control React shell test per RESUME.md — ignore)
+5. Commit + open PR
+
+## Progress Tracking
+
+| Task | Status | Started | Completed | Notes |
+|------|--------|---------|-----------|-------|
+| T-1.1 | pending | - | - | |
+| T-1.2 | pending | - | - | |
+| T-2.1 | pending | - | - | |
+| T-2.2 | pending | - | - | |
+
+## TDD Enforcement
+
+All [T] tasks follow RED → GREEN → BLUE. Coverage ratio target: 1.0 (one test file per source file).
+
+## Post-Implementation Verification
+
+### Functional
+- [ ] Unit tests pass for the constant + doc structure
+- [ ] `bunx tsc --noEmit` clean
+- [ ] `bun test` full suite clean (modulo known mission-control fail)
+
+### Failure (Doctorow Gate — applicable subset)
+- [ ] **Edit constant to wrong shape** ("1.0" missing patch) → test catches → revert
+- [ ] **Delete a doc section** → test catches → revert
+- [ ] **Edit doc's "Current version" to "1.0.1"** → test catches mismatch → revert
+
+### Maintainability
+- [ ] Doc reads in under 5 minutes
+- [ ] Minimal example is copy-paste-ready
+- [ ] No orphan code (constant is intentionally unused at merge; consumers land in F-2/F-5)

--- a/docs/persona-format.md
+++ b/docs/persona-format.md
@@ -1,0 +1,203 @@
+# Persona Format Specification
+
+**Status:** v1.0 — first release of the persona file schema for arc-installable cortex sub-bots.
+**Date:** 2026-05-12
+**Driver:** F-1 — see `.specify/specs/F-1-persona-format-specification/spec.md`
+**Related docs:**
+- `docs/design-arc-agent-bots.md` (§4 manifest, D5 persona-ownership-by-bot-package)
+- `docs/design-pi-dev-review-agent.md` (substrate/presence decoupling that motivates this)
+- `docs/architecture.md` §9 (agent + presence/renderer model)
+
+---
+
+## What is a persona file?
+
+A persona file is the system prompt prefix + per-agent configuration that a cortex sub-bot ships in its arc package. When cortex registers an agent, it reads the persona file at the path declared in the agent's `agents.d/<id>.yaml` fragment and uses it to build the runtime context for that agent's Claude Code (or other substrate) sessions.
+
+Personas are owned by the **bot package** (cortex#58 D5). The bot author edits `persona.md` in the bot's source repo; `arc install <bot>` drops it under `~/.config/cortex/personas/<id>.md`. Cortex's `personas/` directory is rendered output, not a source of truth.
+
+## Schema
+
+A persona file is a markdown file with a single YAML frontmatter block followed by markdown prose. The frontmatter is required (even if minimal). The prose body is passed to the substrate as the agent's system prompt prefix.
+
+### Frontmatter — required fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `displayName` | string | Human-readable name shown in the cortex dashboard. If the agent's `agents.d/<id>.yaml` fragment also declares `displayName`, the two MUST match; cortex logs a warning on mismatch. |
+
+That's the only required frontmatter field. Everything else is optional.
+
+### Frontmatter — optional fields (v1.0)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `preferredModel` | string | Claude model id (e.g. `claude-opus-4-7`, `claude-sonnet-4-6`, `claude-haiku-4-5`). Cortex's runner uses this when set; falls back to the operator default declared in `cortex.yaml`. |
+| `allowedTools` | string[] | Tool allowlist for the agent. Subset of cortex's known tools (`Read`, `Edit`, `Write`, `Grep`, `Bash`, `Agent`, `Skill`, etc.). Advisory in v1; runtime enforcement lands in a future cortex release. |
+| `behavior` | object | Free-form key-value flags for persona-specific behavior toggles. Cortex passes the object through to the substrate opaquely — no schema enforcement on the interior. Bot author documents its keys in the bot's own README. |
+| `temperature` | number | Sampling temperature override, `0.0` to `1.0`. Falls back to the cortex default if unset. |
+| `maxTokens` | number | Max output tokens per turn. Falls back to the cortex default if unset. |
+| `tags` | string[] | Free-form labels for filtering / discovery in the dashboard (e.g. `[code-review, typescript]`). No semantic meaning to cortex; convention only. |
+
+### Body
+
+The markdown body following the closing `---` is the agent's persona / behavior text. It is passed to the substrate verbatim as the system prompt prefix at session start. Cortex applies no schema enforcement on body content — the bot author owns this prose.
+
+**Convention (not enforced):**
+- Open with a one-paragraph identity statement (who the agent is, what they do).
+- Follow with behavior guidance: voice, tone, when to push back, when to escalate.
+- Optionally include worked examples of the agent's expected output format.
+- Close with explicit constraints or anti-patterns the agent should avoid.
+
+This is the format Echo, Holly, Luna, and Ivy follow today inside cortex; the same shape extends to sub-bots.
+
+## Examples
+
+### Minimal (~10 lines)
+
+```markdown
+---
+displayName: Echo
+---
+
+# Echo
+
+You are Echo, a senior code reviewer. Apply the cortex review lenses
+(CodeQuality, Security, Architecture, EcosystemCompliance) in order.
+Surface findings as blockers / majors / suggestions / nits with clear
+file:line references and proposed fixes.
+```
+
+This is enough to ship a working sub-bot. `arc install` drops this file at `~/.config/cortex/personas/echo.md`; cortex picks it up via the `persona:` path in the agent's `agents.d/echo.yaml` fragment.
+
+### Comprehensive (all optional fields populated)
+
+```markdown
+---
+displayName: Codex-Rev
+preferredModel: claude-opus-4-7
+allowedTools: [Read, Grep, Bash]
+behavior:
+  pre-commit-review: true
+  proactive-suggestions: false
+  cite-line-numbers: always
+temperature: 0.2
+maxTokens: 4096
+tags: [code-review, typescript, security]
+---
+
+# Codex-Rev — Codex CLI Review Substrate
+
+You are Codex-Rev, a Codex-CLI-substrate code reviewer running standalone
+under cortex's bus. You're a peer of cortex's in-process Echo agent: same
+review discipline, different substrate.
+
+## Voice
+
+- Direct. No filler.
+- Cite `file:line` for every finding.
+- Quote the offending snippet inline; show the proposed fix as a diff.
+
+## Lenses
+
+Apply in order. Stop at the first verdict-determining finding.
+
+1. **CodeQuality** — duplication, naming, dead code
+2. **Security** — input validation, auth, secret handling
+3. **Architecture** — coupling, layering, dependency direction
+4. **EcosystemCompliance** — conventional commits, SOPs, label hygiene
+
+## Anti-patterns (refuse to do)
+
+- Do NOT request blocker-level changes for stylistic preferences.
+- Do NOT recommend abstractions for code that has one consumer.
+- Do NOT defer to "could be" — every finding is "this is" with evidence.
+
+## When to escalate
+
+If you find a finding that crosses repos (e.g. cortex change needs a
+matching myelin change), surface it explicitly in the review summary
+under `### Cross-repo coordination` and tag the relevant operator.
+```
+
+This is the kind of persona file a substrate-specific sub-bot would ship.
+
+## Versioning
+
+The persona format itself is versioned via a constant in cortex's source — `src/common/types/persona-format.ts` exports `PERSONA_FORMAT_VERSION`. Bot packages declare a supported semver range in their `arc-manifest.yaml`:
+
+```yaml
+# arc-manifest.yaml
+runtime:
+  persona-format: ^1.0   # npm-style semver range
+```
+
+Cortex's `CortexHostAdapter.detect()` (F-5) compares the bot's range against `PERSONA_FORMAT_VERSION` at install time. If the range is not satisfied, `arc install` aborts with a clear error before any files are dropped.
+
+### Semver policy
+
+| Change type | Version bump |
+|-------------|--------------|
+| Add optional field | Minor (1.0 → 1.1) |
+| Change default value of optional field | Minor |
+| Add required field | Major (1.0 → 2.0) |
+| Remove field | Major |
+| Tighten type / validation on existing field | Major |
+| Loosen type / validation on existing field | Minor |
+
+### Deprecation pathway
+
+When removing a field:
+
+1. Mark it deprecated in the next minor release. Cortex emits a load-time warning naming the field, the version it will be removed in, and the replacement (if any).
+2. Wait one full minor cycle so bot authors can update.
+3. Remove the field in the next major. Bots declaring an old range silently keep working until they bump.
+
+### Changelog (this file's own version)
+
+| Version | Date | Change |
+|---------|------|--------|
+| 1.0.0 | 2026-05-12 | Initial release — `displayName` required; optional fields `preferredModel`, `allowedTools`, `behavior`, `temperature`, `maxTokens`, `tags`; markdown body free-form. |
+
+## Error handling
+
+| Scenario | Cortex behavior |
+|----------|-----------------|
+| Persona file missing at declared path | Reject agent registration. Error names the expected path. |
+| Frontmatter unparseable (bad YAML) | Reject registration. Error names line + column from the YAML parser. |
+| Frontmatter missing `displayName` | Reject registration. Error names the required field. |
+| Frontmatter has unknown field | Warning logged; agent still registers. Forwards-compatibility with future minor versions. |
+| `displayName` in persona disagrees with `agents.d/<id>.yaml` fragment | Warning logged; fragment's `displayName` wins (operator-edited config takes precedence — cortex#58 §5 inline-vs-fragment rule generalizes here). |
+| `temperature` out of `0..1` range | Reject registration. Error names the value + expected range. |
+| `maxTokens` non-positive | Reject registration. |
+| `allowedTools` references a tool cortex doesn't know about | Warning logged; unknown tool is dropped from the allowlist; agent registers with the rest. |
+| File size > 100KB | Reject registration. Personas this large are almost certainly a misuse. |
+| File size > 50KB | Warning logged; agent registers. Soft signal that the persona may be overgrown. |
+| `arc-manifest.yaml`'s `runtime.persona-format` range not satisfied by `PERSONA_FORMAT_VERSION` | `arc install` aborts via `CortexHostAdapter.detect()` (F-5). No persona files are dropped on disk. |
+
+## Current version
+
+```typescript
+// src/common/types/persona-format.ts
+export const PERSONA_FORMAT_VERSION = "1.0.0" as const;
+```
+
+This constant is the source of truth. Bumping this value requires updating:
+
+1. The constant in `src/common/types/persona-format.ts`
+2. This document's `## Versioning > Changelog` section
+3. The unit test in `src/common/types/__tests__/persona-format.test.ts` asserting the exact value
+
+The unit test additionally asserts that the version string in the `## Current version` section of this doc matches the constant — a deliberate guard against drift between doc and code.
+
+## Related docs
+
+- `docs/design-arc-agent-bots.md` — arc-installable sub-bots design (§4 manifest, §5 fragment, §6.1 loader, D5 persona ownership)
+- `docs/design-pi-dev-review-agent.md` — substrate/presence decoupling
+- `docs/architecture.md` §9 — agent + presence/renderer model (roles, trust, presence per the broader cortex model)
+- `arc-manifest.yaml` (cortex root) — example of where `runtime.persona-format: ^1.0` is declared by a bot package
+- `.specify/specs/F-1-persona-format-specification/` — the spec / plan / tasks for this feature
+
+---
+
+*Schema version 1.0.0 — first release. Future revisions follow the semver policy above.*

--- a/docs/persona-format.md
+++ b/docs/persona-format.md
@@ -32,11 +32,11 @@ That's the only required frontmatter field. Everything else is optional.
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `preferredModel` | string | Claude model id (e.g. `claude-opus-4-7`, `claude-sonnet-4-6`, `claude-haiku-4-5`). Cortex's runner uses this when set; falls back to the operator default declared in `cortex.yaml`. |
-| `allowedTools` | string[] | Tool allowlist for the agent. Subset of cortex's known tools (`Read`, `Edit`, `Write`, `Grep`, `Bash`, `Agent`, `Skill`, etc.). Advisory in v1; runtime enforcement lands in a future cortex release. |
+| `preferredModel` | string | Claude model id. **Free-form string in v1** — cortex does not validate against a closed enum. Both short aliases (`claude-opus-4-7`) and fully-qualified ids (`claude-opus-4-7-20251022`) are accepted. The runner passes the value through to the Anthropic SDK verbatim; if the model id is unknown to Anthropic, the SDK returns an error at first API call (operator-debuggable, not install-time). Non-Anthropic substrates (Codex, pi.dev, custom) interpret the field per their own runtime contract. When unset, cortex falls back to the operator default declared in `cortex.yaml`. Future cortex versions MAY tighten this to an enum; that would be a major version bump per §Versioning. |
+| `allowedTools` | string[] | Tool allowlist for the agent. **Free-form string list in v1** — cortex does not validate against a closed enum. The canonical v1.0 tool names cortex knows about are: `Read`, `Edit`, `Write`, `Grep`, `Bash`, `Glob`, `Agent`, `Skill`, `WebFetch`, `WebSearch`, `NotebookEdit`, `TodoWrite`, `BashOutput`, `KillShell`. Future tool additions land via additive enum extension (minor bump). Field is advisory in v1 — runtime enforcement (filtering the substrate's tool palette to this allowlist) lands in a future cortex release; until then the runner ignores the field with an info-level log. Unknown tool names in v1: warning logged with the name; field is preserved on the agent for future enforcement. |
 | `behavior` | object | Free-form key-value flags for persona-specific behavior toggles. Cortex passes the object through to the substrate opaquely — no schema enforcement on the interior. Bot author documents its keys in the bot's own README. |
-| `temperature` | number | Sampling temperature override, `0.0` to `1.0`. Falls back to the cortex default if unset. |
-| `maxTokens` | number | Max output tokens per turn. Falls back to the cortex default if unset. |
+| `temperature` | number | Sampling temperature override, `0.0` to `1.0` **inclusive** on both bounds. Falls back to the cortex default if unset. |
+| `maxTokens` | number | Max output tokens per turn (positive integer). Falls back to the cortex default if unset. |
 | `tags` | string[] | Free-form labels for filtering / discovery in the dashboard (e.g. `[code-review, typescript]`). No semantic meaning to cortex; convention only. |
 
 ### Body
@@ -139,11 +139,13 @@ Cortex's `CortexHostAdapter.detect()` (F-5) compares the bot's range against `PE
 | Change type | Version bump |
 |-------------|--------------|
 | Add optional field | Minor (1.0 → 1.1) |
-| Change default value of optional field | Minor |
+| Change default value of optional field — **case A:** new default is operator-overridable (cortex.yaml-level fallback) | Minor — operator can intervene to preserve old behavior |
+| Change default value of optional field — **case B:** new default observably alters per-bot output (e.g. a temperature default change) | Major — bots that relied on the prior default see different runtime behavior with no version of their own to bump |
 | Add required field | Major (1.0 → 2.0) |
 | Remove field | Major |
 | Tighten type / validation on existing field | Major |
 | Loosen type / validation on existing field | Minor |
+| Add an entry to a known-tool list (`allowedTools` canonical names) or a known-model list | Minor — additive only |
 
 ### Deprecation pathway
 
@@ -164,13 +166,15 @@ When removing a field:
 | Scenario | Cortex behavior |
 |----------|-----------------|
 | Persona file missing at declared path | Reject agent registration. Error names the expected path. |
-| Frontmatter unparseable (bad YAML) | Reject registration. Error names line + column from the YAML parser. |
+| Persona file present but **no `---` frontmatter block at all** (pure markdown body, no delimiters) | Reject registration. Error distinguishes from "file missing" — names the file path and shows the minimal required frontmatter: `displayName: <name>`. |
+| Frontmatter unparseable (bad YAML inside `---` delimiters) | Reject registration. Error names line + column from the YAML parser. |
 | Frontmatter missing `displayName` | Reject registration. Error names the required field. |
-| Frontmatter has unknown field | Warning logged; agent still registers. Forwards-compatibility with future minor versions. |
+| Frontmatter has **unknown field** (not in the v1 schema) | Warning logged with the field name; field is preserved on the agent (forwards-compatibility with future minor versions); registration succeeds. |
+| Frontmatter has **known field with wrong type** (e.g. `displayName: 42`, `tags: "code-review"`, `temperature: "warm"`, `allowedTools: "Read,Edit"`) | Reject registration. Error names the field, the expected type, and the received value. This is distinct from unknown-field-warn — known fields with bad types catch the most common hand-authored-YAML mistakes and surface them at install time rather than runtime. |
 | `displayName` in persona disagrees with `agents.d/<id>.yaml` fragment | Warning logged; fragment's `displayName` wins (operator-edited config takes precedence — cortex#58 §5 inline-vs-fragment rule generalizes here). |
-| `temperature` out of `0..1` range | Reject registration. Error names the value + expected range. |
-| `maxTokens` non-positive | Reject registration. |
-| `allowedTools` references a tool cortex doesn't know about | Warning logged; unknown tool is dropped from the allowlist; agent registers with the rest. |
+| `temperature` out of `0.0` to `1.0` inclusive range | Reject registration. Error names the value + expected `[0.0, 1.0]` range. |
+| `maxTokens` non-positive or non-integer | Reject registration. Error names the value. |
+| `allowedTools` references a tool cortex doesn't know about | Warning logged; unknown tool name is preserved on the agent (advisory in v1; future enforcement may drop or reject); other tool names register normally. |
 | File size > 100KB | Reject registration. Personas this large are almost certainly a misuse. |
 | File size > 50KB | Warning logged; agent registers. Soft signal that the persona may be overgrown. |
 | `arc-manifest.yaml`'s `runtime.persona-format` range not satisfied by `PERSONA_FORMAT_VERSION` | `arc install` aborts via `CortexHostAdapter.detect()` (F-5). No persona files are dropped on disk. |

--- a/src/common/types/__tests__/persona-format.test.ts
+++ b/src/common/types/__tests__/persona-format.test.ts
@@ -1,0 +1,69 @@
+/**
+ * F-1 — Persona format specification.
+ *
+ * Verifies the version constant + the canonical schema doc.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { existsSync, readFileSync } from "fs";
+import { join } from "path";
+
+import { PERSONA_FORMAT_VERSION } from "../persona-format";
+
+const REPO_ROOT = join(import.meta.dir, "..", "..", "..", "..");
+const DOC_PATH = join(REPO_ROOT, "docs", "persona-format.md");
+
+describe("PERSONA_FORMAT_VERSION", () => {
+  test("matches semver shape major.minor.patch", () => {
+    expect(PERSONA_FORMAT_VERSION).toMatch(/^\d+\.\d+\.\d+$/);
+  });
+
+  test("is exactly the v1 release value", () => {
+    expect(PERSONA_FORMAT_VERSION).toBe("1.0.0");
+  });
+});
+
+describe("docs/persona-format.md", () => {
+  test("exists at the expected path", () => {
+    expect(existsSync(DOC_PATH)).toBe(true);
+  });
+
+  describe("required sections", () => {
+    const required = [
+      "## Schema",
+      "## Examples",
+      "## Versioning",
+      "## Error handling",
+      "## Current version",
+      "## Related docs",
+    ];
+
+    for (const heading of required) {
+      test(`contains heading "${heading}"`, () => {
+        const body = readFileSync(DOC_PATH, "utf-8");
+        expect(body).toContain(heading);
+      });
+    }
+  });
+
+  test('"Current version" section names the same value as PERSONA_FORMAT_VERSION', () => {
+    const body = readFileSync(DOC_PATH, "utf-8");
+    // Locate the section + the next heading boundary.
+    const sectionStart = body.indexOf("## Current version");
+    expect(sectionStart).toBeGreaterThan(-1);
+    const nextHeading = body.indexOf("\n## ", sectionStart + 1);
+    const section =
+      nextHeading > -1 ? body.slice(sectionStart, nextHeading) : body.slice(sectionStart);
+    // The version constant string must appear verbatim in this section.
+    expect(section).toContain(PERSONA_FORMAT_VERSION);
+  });
+
+  test("Current version section points at the source-of-truth file", () => {
+    const body = readFileSync(DOC_PATH, "utf-8");
+    const sectionStart = body.indexOf("## Current version");
+    const nextHeading = body.indexOf("\n## ", sectionStart + 1);
+    const section =
+      nextHeading > -1 ? body.slice(sectionStart, nextHeading) : body.slice(sectionStart);
+    expect(section).toContain("src/common/types/persona-format.ts");
+  });
+});

--- a/src/common/types/__tests__/persona-format.test.ts
+++ b/src/common/types/__tests__/persona-format.test.ts
@@ -6,11 +6,25 @@
 
 import { describe, expect, test } from "bun:test";
 import { existsSync, readFileSync } from "fs";
-import { join } from "path";
+import { dirname, join } from "path";
 
 import { PERSONA_FORMAT_VERSION } from "../persona-format";
 
-const REPO_ROOT = join(import.meta.dir, "..", "..", "..", "..");
+/**
+ * Walk up from this test file to find the repo root marker (`package.json`).
+ * Beats hardcoded `../../../../` which silently breaks if the test file ever
+ * moves to a deeper directory (Echo N2 on cortex#61).
+ */
+function findRepoRoot(start: string): string {
+  let dir = start;
+  while (dir !== "/" && dir !== "") {
+    if (existsSync(join(dir, "package.json"))) return dir;
+    dir = dirname(dir);
+  }
+  throw new Error(`could not find package.json walking up from ${start}`);
+}
+
+const REPO_ROOT = findRepoRoot(import.meta.dir);
 const DOC_PATH = join(REPO_ROOT, "docs", "persona-format.md");
 
 describe("PERSONA_FORMAT_VERSION", () => {
@@ -46,16 +60,19 @@ describe("docs/persona-format.md", () => {
     }
   });
 
-  test('"Current version" section names the same value as PERSONA_FORMAT_VERSION', () => {
+  test('"Current version" section binds the version to its TypeScript declaration', () => {
     const body = readFileSync(DOC_PATH, "utf-8");
-    // Locate the section + the next heading boundary.
     const sectionStart = body.indexOf("## Current version");
     expect(sectionStart).toBeGreaterThan(-1);
     const nextHeading = body.indexOf("\n## ", sectionStart + 1);
     const section =
       nextHeading > -1 ? body.slice(sectionStart, nextHeading) : body.slice(sectionStart);
-    // The version constant string must appear verbatim in this section.
-    expect(section).toContain(PERSONA_FORMAT_VERSION);
+    // Tightened from substring (.toContain) to a regex anchored on the
+    // canonical TypeScript declaration shape (Echo N1 on cortex#61). A stale
+    // version literal sitting in a code comment elsewhere can no longer
+    // satisfy the guard.
+    const pattern = new RegExp(`PERSONA_FORMAT_VERSION\\s*=\\s*"${PERSONA_FORMAT_VERSION}"`);
+    expect(section).toMatch(pattern);
   });
 
   test("Current version section points at the source-of-truth file", () => {
@@ -65,5 +82,22 @@ describe("docs/persona-format.md", () => {
     const section =
       nextHeading > -1 ? body.slice(sectionStart, nextHeading) : body.slice(sectionStart);
     expect(section).toContain("src/common/types/persona-format.ts");
+  });
+
+  test('"Versioning" Changelog table includes a row for the current version', () => {
+    // Echo M1 on cortex#61 — drift guard expanded to also cover the
+    // Versioning > Changelog table. The doc instructs maintainers to update
+    // both Current version and Changelog in lockstep when bumping the
+    // constant; before this guard, a bump that forgot Changelog stayed green.
+    const body = readFileSync(DOC_PATH, "utf-8");
+    const sectionStart = body.indexOf("## Versioning");
+    expect(sectionStart).toBeGreaterThan(-1);
+    const nextHeading = body.indexOf("\n## ", sectionStart + 1);
+    const section =
+      nextHeading > -1 ? body.slice(sectionStart, nextHeading) : body.slice(sectionStart);
+    // Changelog row format: `| <version> | <date> | <description> |`. Match
+    // a pipe-delimited row that opens with the canonical version literal.
+    const rowPattern = new RegExp(`\\|\\s*${PERSONA_FORMAT_VERSION.replace(/\./g, "\\.")}\\s*\\|`);
+    expect(section).toMatch(rowPattern);
   });
 });

--- a/src/common/types/persona-format.ts
+++ b/src/common/types/persona-format.ts
@@ -1,0 +1,23 @@
+/**
+ * F-1 — Persona format version constant.
+ *
+ * Bot packages declare a supported range via `runtime.persona-format: ^1.0`
+ * in their `arc-manifest.yaml`. Cortex compares the bot's declared range
+ * against this constant at install time (see `CortexHostAdapter.detect()`
+ * — F-5) and rejects the install if the range is not satisfied.
+ *
+ * Schema reference, examples, and versioning policy: `docs/persona-format.md`.
+ *
+ * Bump rules (see `docs/persona-format.md` §Versioning):
+ *   - Add optional field → minor bump
+ *   - Add required field → major bump
+ *   - Default value change → minor
+ *   - Type/validation tightening → major
+ *   - Type/validation loosening → minor
+ *
+ * When bumping, update three places in lock-step:
+ *   1. This constant
+ *   2. `docs/persona-format.md` §Current version + §Versioning changelog
+ *   3. The unit test asserting the exact value
+ */
+export const PERSONA_FORMAT_VERSION = "1.0.0" as const;


### PR DESCRIPTION
## Summary

First of five Phase A pieces for arc-installable cortex sub-bots (cortex#60 §11). Lands the persona schema reference doc + version constant — consumed by F-2 (agents.d loader) and F-5 (CortexHostAdapter).

**Interview answers locked (per AskUserQuestion with JC, 2026-05-11):**
- Persona shape: **markdown body + YAML frontmatter** (structured fields + prose)
- Version compatibility: **semver in arc-manifest** (`persona-format: ^1.0`)

## Artifacts

| File | Type | Purpose |
|------|------|---------|
| `docs/persona-format.md` | new (~190 lines) | Schema reference, examples, versioning policy, error handling |
| `src/common/types/persona-format.ts` | new (single export) | `PERSONA_FORMAT_VERSION = "1.0.0"` constant |
| `src/common/types/__tests__/persona-format.test.ts` | new (11 tests) | Semver shape + doc structure + doc/code drift guard |
| `.gitignore` | modified (1 line) | Adds `.specflow/` |
| `.specify/specs/F-1-persona-format-specification/{spec,plan,tasks}.md` | new | SpecFlow lifecycle artifacts |

## Schema highlights

Required frontmatter: `displayName` only.
Optional frontmatter: `preferredModel`, `allowedTools`, `behavior` (opaque object), `temperature`, `maxTokens`, `tags`.
Body: markdown prose, passed verbatim as system prompt prefix. Convention documented but not enforced.

## Test plan

- [x] `bun test src/common/types/__tests__/persona-format.test.ts` — 11 pass / 0 fail
- [x] `bunx tsc --noEmit` — clean
- [x] Doc/code drift guard: unit test asserts the version string in `## Current version` matches `PERSONA_FORMAT_VERSION`
- [x] All 6 required doc section headings asserted by unit tests

## Out of scope

- **Zod schema for frontmatter parsing** — F-2's responsibility (loader is the consumer; runtime types live where they're used)
- **`CortexHostAdapter.detect()` range check** — F-5 (blocked on arc#117 Phase 1)
- **Tool-allowlist runtime enforcement** — substrate-runner concern, separate feature
- **Live persona reload** — cortex#58 §12 (future enhancement)

## Migration impact

None. Net-additive feature. `PERSONA_FORMAT_VERSION` constant has no consumers at merge time — F-2 and F-5 will import on landing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)