### PR TITLE
feat(cli/cortex): F-3 — agents reload/list CLI

### DIFF
--- a/.specify/specs/F-3-cortex-agents-reload-cli/plan.md
+++ b/.specify/specs/F-3-cortex-agents-reload-cli/plan.md
@@ -1,0 +1,92 @@
+---
+feature: "cortex agents reload CLI"
+spec: "./spec.md"
+status: "draft"
+---
+
+# Technical Plan: cortex agents reload CLI
+
+## Architecture
+
+```
+src/cli/cortex/commands/agents.ts
+├── parseArgs(argv) → ParsedAgentsArgs       // hand-rolled, matches migrate-config pattern
+├── runAgentsReload(args) → ExitResult       // exported, calls loadAgentsDirectory
+├── runAgentsList(args) → ExitResult         // exported, calls loadAgentsDirectory
+├── dispatchAgents(argv) → ExitResult        // top-level subcommand router
+└── (if main) parses process.argv + exits
+
+src/cli/cortex/commands/__tests__/agents.test.ts
+└── exhaustive coverage of both subcommands + arg parsing
+```
+
+Both `runAgentsReload` and `runAgentsList` accept an explicit `agentsDir` (resolved from `--config`) so tests can drive against tmp dirs without touching `~/.config`.
+
+## Technology Stack
+
+| Component | Choice | Rationale |
+|-----------|--------|-----------|
+| Arg parsing | hand-rolled | matches migrate-config.ts convention; no commander dependency for a small CLI |
+| Loader | `loadAgentsDirectory` from F-2 | already covers fragment validation |
+| Tests | `bun:test` + tmpdir fixtures | mirrors fragment-loader.test.ts |
+| Output formatting | plain text default, `--json` flag for structured | aligns with `cloud.ts` precedent |
+
+## API Contracts
+
+```typescript
+export interface ParsedAgentsArgs {
+  subcommand: "reload" | "list" | "help" | "unknown";
+  config: string | undefined;
+  fragment: string | undefined;
+  json: boolean;
+  help: boolean;
+}
+
+export interface ExitResult {
+  exitCode: 0 | 1 | 2;
+  stdout: string;
+  stderr: string;
+}
+
+export function parseAgentsArgs(argv: string[]): ParsedAgentsArgs;
+export function runAgentsReload(args: ParsedAgentsArgs): ExitResult;
+export function runAgentsList(args: ParsedAgentsArgs): ExitResult;
+export function dispatchAgents(argv: string[]): ExitResult;
+```
+
+## Implementation Strategy
+
+1. parseAgentsArgs — handles `--config`, `--fragment`, `--json`, `--help`, plus positional subcommand
+2. runAgentsReload — resolves agents.d/ dir, calls loadAgentsDirectory, formats output
+3. runAgentsList — same, different format
+4. dispatchAgents — routes to the above; prints help on unknown / no subcommand
+
+## File Structure
+
+```
+src/cli/cortex/commands/
+├── agents.ts                            # new — entry + parseArgs + handlers + dispatcher
+└── __tests__/
+    ├── agents.test.ts                   # new — 15+ tests
+    └── fixtures/                        # new — reuse F-2 fixture patterns
+        ├── agents.d-valid/
+        │   ├── echo.yaml
+        │   └── echo.md (persona)
+        └── agents.d-broken/
+            └── broken.yaml
+```
+
+## Risks
+
+| Risk | Mitigation |
+|------|-----------|
+| `--config` defaults to `~/.config/cortex/cortex.yaml` which may not exist on dev box | If config missing AND `--fragment` not specified, exit 2 with friendly error |
+| Persona path relative to fragment file but operator runs CLI from different cwd | Loader already handles path resolution against fragment dir |
+| Future evolution to talk to running daemon would break stdout contract | Document v1 as "validation only" in CLI help text |
+
+## Estimated Complexity
+
+- **New files:** 1 source + 1 test + 2 fixture dirs (~5 files)
+- **Modified files:** 0
+- **Estimated tasks:** 6
+- **Debt score:** 1 (small, well-scoped, all wraps F-2)

--- a/.specify/specs/F-3-cortex-agents-reload-cli/spec.md
+++ b/.specify/specs/F-3-cortex-agents-reload-cli/spec.md
@@ -1,0 +1,120 @@
+---
+id: "F-3"
+feature: "cortex agents reload CLI"
+status: "draft"
+created: "2026-05-12"
+depends_on: "F-2 (loadAgentsDirectory)"
+---
+
+# Specification: cortex agents reload CLI
+
+## Overview
+
+Ship `cortex agents` CLI subcommand with two sub-actions: `reload` and `list`. Validates `~/.config/cortex/agents.d/` fragments via F-2's `loadAgentsDirectory()` and prints results. Operator-facing diagnostic tool callable from arc lifecycle scripts after dropping a new fragment, or run standalone to inspect current agent registry.
+
+This feature is a **validation-only CLI** in v1 — it does NOT talk to a running cortex daemon. Daemon-IPC (the actual "tell the running cortex to reload now" behavior) waits for cortex.ts startup integration of `AgentsDirectoryWatcher` and the operator-account daemon IPC channel (both follow-up work).
+
+## User Scenarios
+
+### Scenario 1: arc lifecycle script validates fragment after install
+
+```bash
+arc install foo-review-bot
+# lifecycle postinstall calls:
+cortex agents reload --config ~/.config/cortex/cortex.yaml
+# Exit 0 → fragment loads cleanly; arc proceeds.
+# Exit 1 → fragment invalid; arc rolls back.
+```
+
+**Acceptance Criteria:**
+- [ ] `cortex agents reload` exits 0 when all fragments load cleanly
+- [ ] `cortex agents reload` exits 1 when any fragment fails to load
+- [ ] Error output names the failing file + reason
+- [ ] Defaults `--config` to `~/.config/cortex/cortex.yaml`
+
+### Scenario 2: Operator inspects current agent registry
+
+```bash
+cortex agents list
+# echo                 — claude-code / in-process / 1 capability
+# holly                — claude-code / in-process / 2 capabilities
+# codex-rev            — codex / standalone / 1 capability
+```
+
+**Acceptance Criteria:**
+- [ ] `cortex agents list` prints each loaded agent on its own line
+- [ ] Output includes id, substrate, mode, capability count
+- [ ] `--json` flag emits structured output for scripting
+- [ ] Sorted alphabetically by id
+
+### Scenario 3: Operator validates a specific fragment file
+
+```bash
+cortex agents reload --fragment ~/.config/cortex/agents.d/foo.yaml
+# Validates ONLY that fragment, ignores others. Useful for pre-install dry-run.
+```
+
+**Acceptance Criteria:**
+- [ ] `--fragment <path>` mode validates a single file
+- [ ] Exit 0 / 1 as above
+- [ ] Conflicts with id existing in the registry are warned but not errors (the file might not be installed yet)
+
+## Functional Requirements
+
+### FR-1: `cortex agents reload [--config <path>] [--fragment <path>] [--json]`
+
+- Validates fragments via `loadAgentsDirectory()` (F-2).
+- `--config <path>` (default: `~/.config/cortex/cortex.yaml`) determines where the `agents.d/` directory lives — sibling of the config file.
+- `--fragment <path>` mode: parse + validate a single fragment file as `Agent` via `AgentSchema.parse()`. Doesn't run the directory loader.
+- `--json` mode: emit structured JSON `{ status: "ok" | "error", agents: [{id, substrate, mode, capabilities}], error?: {file, reason} }`.
+- Exit codes:
+  - `0` — all fragments parse + validate
+  - `1` — at least one fragment fails (named in error output)
+  - `2` — usage error (bad flags / missing file)
+
+### FR-2: `cortex agents list [--config <path>] [--json]`
+
+- Lists agents from `loadAgentsDirectory(<configDir>/agents.d/)`.
+- Default text format: `<id>  —  <substrate> / <mode> / <N> capabilities`.
+- `--json` format: array of `{id, displayName, substrate, mode, capabilities}` objects.
+- Sorted alphabetically by id.
+- Exit codes:
+  - `0` — list rendered (possibly empty)
+  - `1` — loader failure
+  - `2` — usage error
+
+### FR-3: CLI dispatch shell
+
+A small `src/cli/cortex/commands/agents.ts` entry handles the `agents` subcommand: parses the next positional (`reload` / `list`), dispatches to the right handler, prints help on no-subcommand or `--help`.
+
+## Non-Functional Requirements
+
+- **Performance**: load + report under 100ms for ≤50 fragments.
+- **Security**: no shell expansion outside `~` → `$HOME` (via F-2's `expandTilde`).
+- **Failure behavior**:
+  - Loader throws `FragmentLoadError` → exit 1, name file + reason to stderr.
+  - Config path doesn't exist → exit 2, name path to stderr.
+  - Unknown subcommand → exit 2, print help.
+
+## Key Entities
+
+| Entity | Description |
+|--------|-------------|
+| `agentsReloadCommand(argv)` | Pure function — takes argv array, returns `{exitCode, stdout, stderr}` for testability. |
+| `agentsListCommand(argv)` | Same shape. |
+| `dispatchAgents(argv)` | Top-level dispatcher for the subcommand tree. |
+
+## Success Criteria
+
+- [ ] `bun src/cli/cortex/commands/agents.ts reload --config <tmp-config>` returns 0 against a valid agents.d/
+- [ ] Same returns 1 against an agents.d/ with a malformed fragment
+- [ ] `... agents list` prints the agent set in stable order
+- [ ] `--json` flag emits parseable JSON
+- [ ] 15+ tests pass; tsc clean
+- [ ] Echo review approves with 0 blockers / 0 majors
+
+## Out of Scope
+
+- **Live daemon-reload IPC** — sending SIGHUP or NATS request/reply to a running cortex daemon. Waits for cortex.ts integration of `AgentsDirectoryWatcher` (separate follow-up).
+- **`cortex agents add/remove`** — fragment authoring via CLI. Out of scope; arc + manual file edit are the v1 channels.
+- **Trust resolution at the CLI** — the CLI uses `loadAgentsDirectory()` which doesn't run trust resolution. Construction of `AgentRegistry` (which DOES resolve trust) is deferred to the running daemon's startup path.

--- a/.specify/specs/F-3-cortex-agents-reload-cli/tasks.md
+++ b/.specify/specs/F-3-cortex-agents-reload-cli/tasks.md
@@ -1,0 +1,75 @@
+---
+feature: "cortex agents reload CLI"
+plan: "./plan.md"
+status: "pending"
+total_tasks: 6
+completed: 0
+---
+
+# Tasks: cortex agents reload CLI
+
+## Legend
+- `[T]` — test required (TDD: test first)
+- `[P]` — parallel-safe within group
+
+## Group 1: parser
+
+- [ ] **T-1.1** parseAgentsArgs tests [T]
+  - subcommand routing (reload/list/help/unknown)
+  - flag parsing (--config, --fragment, --json, --help)
+  - positional handling, multiple flags, default values
+
+- [ ] **T-1.2** Implement parseAgentsArgs [T]
+
+## Group 2: handlers
+
+- [ ] **T-2.1** Fixtures [P]
+  - `__tests__/fixtures/agents.d-valid/echo.yaml` + persona
+  - `__tests__/fixtures/agents.d-broken/broken.yaml` (malformed)
+
+- [ ] **T-2.2** runAgentsReload tests [T] (depends: T-1.2, T-2.1)
+  - happy path → exit 0, agent ids in stdout
+  - broken fragment → exit 1, error in stderr
+  - --json mode → parseable JSON
+  - --fragment mode → single-file validation
+  - missing config dir → exit 2
+
+- [ ] **T-2.3** Implement runAgentsReload [T] (depends: T-2.2)
+
+- [ ] **T-2.4** runAgentsList tests + implementation [T] (depends: T-2.1)
+  - empty agents.d/ → 0, empty output
+  - sorted output
+  - --json mode
+
+## Group 3: dispatcher + main
+
+- [ ] **T-3.1** dispatchAgents test [T] (depends: T-2.3, T-2.4)
+  - "reload" routes to runAgentsReload
+  - "list" routes to runAgentsList
+  - unknown subcommand → exit 2 with help
+  - no subcommand → exit 2 with help
+  - --help → exit 0 with help text
+
+- [ ] **T-3.2** main block (if import.meta.main) handles process.argv + process.exit
+
+## Execution
+
+1. T-1.1 → T-1.2
+2. T-2.1 (parallel with T-1.x)
+3. T-2.2 → T-2.3
+4. T-2.4 (parallel with T-2.3)
+5. T-3.1 → T-3.2
+6. Full regression check
+
+## Progress
+
+| Task | Status |
+|------|--------|
+| T-1.1 | pending |
+| T-1.2 | pending |
+| T-2.1 | pending |
+| T-2.2 | pending |
+| T-2.3 | pending |
+| T-2.4 | pending |
+| T-3.1 | pending |
+| T-3.2 | pending |

--- a/src/cli/cortex/commands/__tests__/agents.test.ts
+++ b/src/cli/cortex/commands/__tests__/agents.test.ts
@@ -156,7 +156,7 @@ describe("runAgentsReload", () => {
     expect(parsed.agents[0].id).toBe("echo");
   });
 
-  test("--json on failure emits structured error", () => {
+  test("--json on failure emits envelope with agents:[] + error (M4 round-1)", () => {
     const cfg = mkdtempSync(join(tmpdir(), "f3-cfg-json-err-"));
     seedConfigDir(cfg, BROKEN_DIR);
     const r = runAgentsReload(
@@ -166,7 +166,18 @@ describe("runAgentsReload", () => {
     // JSON goes to stdout even on failure so scripts can parse it.
     const parsed = JSON.parse(r.stdout);
     expect(parsed.status).toBe("error");
+    // Echo M4 round 1: `agents` MUST be present (empty array) so consumers
+    // can iterate without status-checking.
+    expect(parsed.agents).toEqual([]);
     expect(parsed.error.file).toContain("broken.yaml");
+    expect(parsed.error.reason).toBeTruthy();
+  });
+
+  test("--fragment <dir> exits 2 with usage error, not 1 (Echo round-1 nit)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "f3-frag-dir-"));
+    const r = runAgentsReload(parseAgentsArgs(["reload", "--fragment", dir]));
+    expect(r.exitCode).toBe(2);
+    expect(r.stderr).toMatch(/expects a file, got a directory/);
   });
 
   test("--fragment validates a single file", () => {

--- a/src/cli/cortex/commands/__tests__/agents.test.ts
+++ b/src/cli/cortex/commands/__tests__/agents.test.ts
@@ -1,0 +1,285 @@
+// F-3 — cortex agents reload/list CLI tests.
+
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, writeFileSync, copyFileSync, mkdirSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+
+import {
+  parseAgentsArgs,
+  runAgentsReload,
+  runAgentsList,
+  dispatchAgents,
+} from "../agents";
+
+const FIXTURES = join(import.meta.dir, "fixtures");
+const VALID_DIR = join(FIXTURES, "agents.d-valid");
+const BROKEN_DIR = join(FIXTURES, "agents.d-broken");
+const PERSONA_PATH = join(FIXTURES, "personas", "echo.md");
+
+// =============================================================================
+// parseAgentsArgs
+// =============================================================================
+
+describe("parseAgentsArgs", () => {
+  test("parses 'reload' subcommand", () => {
+    const args = parseAgentsArgs(["reload"]);
+    expect(args.subcommand).toBe("reload");
+    expect(args.help).toBe(false);
+  });
+
+  test("parses 'list' subcommand", () => {
+    const args = parseAgentsArgs(["list"]);
+    expect(args.subcommand).toBe("list");
+  });
+
+  test("--help yields subcommand=help", () => {
+    expect(parseAgentsArgs(["--help"]).subcommand).toBe("help");
+    expect(parseAgentsArgs(["-h"]).subcommand).toBe("help");
+  });
+
+  test("unknown subcommand marked as 'unknown'", () => {
+    expect(parseAgentsArgs(["status"]).subcommand).toBe("unknown");
+  });
+
+  test("no args → unknown (caller decides what to do)", () => {
+    expect(parseAgentsArgs([]).subcommand).toBe("unknown");
+  });
+
+  test("parses --config flag", () => {
+    const args = parseAgentsArgs(["reload", "--config", "/tmp/foo.yaml"]);
+    expect(args.config).toBe("/tmp/foo.yaml");
+  });
+
+  test("parses --fragment flag", () => {
+    const args = parseAgentsArgs(["reload", "--fragment", "/tmp/foo.yaml"]);
+    expect(args.fragment).toBe("/tmp/foo.yaml");
+  });
+
+  test("parses --json flag", () => {
+    expect(parseAgentsArgs(["list", "--json"]).json).toBe(true);
+    expect(parseAgentsArgs(["list"]).json).toBe(false);
+  });
+
+  test("--help inside subcommand sets help and preserves subcommand", () => {
+    const args = parseAgentsArgs(["reload", "--help"]);
+    expect(args.subcommand).toBe("reload");
+    expect(args.help).toBe(true);
+  });
+
+  test("multiple flags in any order", () => {
+    const args = parseAgentsArgs([
+      "reload",
+      "--json",
+      "--config",
+      "/tmp/c.yaml",
+      "--fragment",
+      "/tmp/f.yaml",
+    ]);
+    expect(args.subcommand).toBe("reload");
+    expect(args.json).toBe(true);
+    expect(args.config).toBe("/tmp/c.yaml");
+    expect(args.fragment).toBe("/tmp/f.yaml");
+  });
+});
+
+// =============================================================================
+// runAgentsReload
+// =============================================================================
+
+describe("runAgentsReload", () => {
+  test("exit 0 on valid agents.d/ via --config", () => {
+    const cfg = mkdtempSync(join(tmpdir(), "f3-cfg-"));
+    seedConfigDir(cfg, VALID_DIR);
+    const r = runAgentsReload(parseAgentsArgs(["reload", "--config", join(cfg, "cortex.yaml")]));
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toContain("echo");
+    expect(r.stdout).toMatch(/1 fragment.*OK/);
+  });
+
+  test("exit 1 on broken fragment, error in stderr names the file", () => {
+    const cfg = mkdtempSync(join(tmpdir(), "f3-cfg-broken-"));
+    seedConfigDir(cfg, BROKEN_DIR);
+    const r = runAgentsReload(parseAgentsArgs(["reload", "--config", join(cfg, "cortex.yaml")]));
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr).toContain("broken.yaml");
+  });
+
+  test("exit 2 when config path's directory does not exist", () => {
+    const r = runAgentsReload(
+      parseAgentsArgs([
+        "reload",
+        "--config",
+        "/tmp/nonexistent-path-xyz/cortex.yaml",
+      ]),
+    );
+    expect(r.exitCode).toBe(2);
+    expect(r.stderr).toMatch(/config directory.*does not exist/);
+  });
+
+  test("--json on success emits parseable JSON", () => {
+    const cfg = mkdtempSync(join(tmpdir(), "f3-cfg-json-"));
+    seedConfigDir(cfg, VALID_DIR);
+    const r = runAgentsReload(
+      parseAgentsArgs(["reload", "--config", join(cfg, "cortex.yaml"), "--json"]),
+    );
+    expect(r.exitCode).toBe(0);
+    const parsed = JSON.parse(r.stdout);
+    expect(parsed.status).toBe("ok");
+    expect(parsed.agents).toBeInstanceOf(Array);
+    expect(parsed.agents.length).toBeGreaterThan(0);
+    expect(parsed.agents[0].id).toBe("echo");
+  });
+
+  test("--json on failure emits structured error", () => {
+    const cfg = mkdtempSync(join(tmpdir(), "f3-cfg-json-err-"));
+    seedConfigDir(cfg, BROKEN_DIR);
+    const r = runAgentsReload(
+      parseAgentsArgs(["reload", "--config", join(cfg, "cortex.yaml"), "--json"]),
+    );
+    expect(r.exitCode).toBe(1);
+    // JSON goes to stdout even on failure so scripts can parse it.
+    const parsed = JSON.parse(r.stdout);
+    expect(parsed.status).toBe("error");
+    expect(parsed.error.file).toContain("broken.yaml");
+  });
+
+  test("--fragment validates a single file", () => {
+    const validFragment = join(VALID_DIR, "echo.yaml");
+    const r = runAgentsReload(parseAgentsArgs(["reload", "--fragment", validFragment]));
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toContain("echo");
+  });
+
+  test("--fragment exit 1 when file is malformed", () => {
+    const brokenFragment = join(BROKEN_DIR, "broken.yaml");
+    const r = runAgentsReload(parseAgentsArgs(["reload", "--fragment", brokenFragment]));
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr).toContain("broken.yaml");
+  });
+
+  test("--fragment exit 2 when file does not exist", () => {
+    const r = runAgentsReload(
+      parseAgentsArgs(["reload", "--fragment", "/tmp/nonexistent-fragment.yaml"]),
+    );
+    expect(r.exitCode).toBe(2);
+    expect(r.stderr).toMatch(/fragment file.*does not exist/);
+  });
+});
+
+// =============================================================================
+// runAgentsList
+// =============================================================================
+
+describe("runAgentsList", () => {
+  test("lists agents in alphabetical order", () => {
+    const cfg = mkdtempSync(join(tmpdir(), "f3-list-"));
+    seedConfigDir(cfg, VALID_DIR);
+    const r = runAgentsList(parseAgentsArgs(["list", "--config", join(cfg, "cortex.yaml")]));
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toContain("echo");
+    expect(r.stdout).toContain("claude-code");
+    expect(r.stdout).toContain("in-process");
+  });
+
+  test("empty agents.d/ → exit 0, empty agent list", () => {
+    const cfg = mkdtempSync(join(tmpdir(), "f3-empty-"));
+    writeFileSync(join(cfg, "cortex.yaml"), "agents: []\n");
+    mkdirSync(join(cfg, "agents.d"));
+    const r = runAgentsList(parseAgentsArgs(["list", "--config", join(cfg, "cortex.yaml")]));
+    expect(r.exitCode).toBe(0);
+    // Should be no error and either empty or just headers
+    expect(r.stderr).toBe("");
+  });
+
+  test("--json emits agent objects sorted by id", () => {
+    const cfg = mkdtempSync(join(tmpdir(), "f3-list-json-"));
+    seedConfigDir(cfg, VALID_DIR);
+    const r = runAgentsList(
+      parseAgentsArgs(["list", "--config", join(cfg, "cortex.yaml"), "--json"]),
+    );
+    expect(r.exitCode).toBe(0);
+    const parsed = JSON.parse(r.stdout);
+    expect(Array.isArray(parsed)).toBe(true);
+    expect(parsed[0].id).toBe("echo");
+    expect(parsed[0]).toHaveProperty("substrate");
+    expect(parsed[0]).toHaveProperty("mode");
+    expect(parsed[0]).toHaveProperty("capabilities");
+  });
+});
+
+// =============================================================================
+// dispatchAgents
+// =============================================================================
+
+describe("dispatchAgents", () => {
+  test("routes 'reload' to runAgentsReload", () => {
+    const cfg = mkdtempSync(join(tmpdir(), "f3-dispatch-reload-"));
+    seedConfigDir(cfg, VALID_DIR);
+    const r = dispatchAgents(["reload", "--config", join(cfg, "cortex.yaml")]);
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toContain("echo");
+  });
+
+  test("routes 'list' to runAgentsList", () => {
+    const cfg = mkdtempSync(join(tmpdir(), "f3-dispatch-list-"));
+    seedConfigDir(cfg, VALID_DIR);
+    const r = dispatchAgents(["list", "--config", join(cfg, "cortex.yaml")]);
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toContain("echo");
+  });
+
+  test("--help prints help and exits 0", () => {
+    const r = dispatchAgents(["--help"]);
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toContain("cortex agents");
+    expect(r.stdout).toContain("reload");
+    expect(r.stdout).toContain("list");
+  });
+
+  test("unknown subcommand prints help and exits 2", () => {
+    const r = dispatchAgents(["status"]);
+    expect(r.exitCode).toBe(2);
+    expect(r.stderr).toContain("unknown");
+    expect(r.stderr).toContain("status");
+  });
+
+  test("no subcommand prints help and exits 2", () => {
+    const r = dispatchAgents([]);
+    expect(r.exitCode).toBe(2);
+    expect(r.stderr).toContain("usage");
+  });
+
+  test("subcommand --help routes through dispatcher", () => {
+    const r = dispatchAgents(["reload", "--help"]);
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toContain("reload");
+  });
+});
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+/**
+ * Seed a config dir at `cfg` whose `agents.d/` mirrors `srcAgentsDir`. The
+ * `cortex.yaml` is a minimal placeholder; runAgentsReload looks for
+ * `<cfgDir>/agents.d/` derived from the config path.
+ */
+function seedConfigDir(cfg: string, srcAgentsDir: string): void {
+  writeFileSync(join(cfg, "cortex.yaml"), "agents: []\n");
+  const agentsD = join(cfg, "agents.d");
+  mkdirSync(agentsD, { recursive: true });
+  const personasD = join(cfg, "personas");
+  mkdirSync(personasD, { recursive: true });
+  // Copy the fixture's persona.
+  copyFileSync(PERSONA_PATH, join(personasD, "echo.md"));
+  // Copy the fixture's fragments — but rewrite the persona path so it
+  // resolves correctly against the new agents.d/ directory.
+  const fs = require("fs") as typeof import("fs");
+  for (const filename of fs.readdirSync(srcAgentsDir)) {
+    if (!filename.endsWith(".yaml")) continue;
+    const content = fs.readFileSync(join(srcAgentsDir, filename), "utf-8");
+    fs.writeFileSync(join(agentsD, filename), content);
+  }
+}

--- a/src/cli/cortex/commands/__tests__/agents.test.ts
+++ b/src/cli/cortex/commands/__tests__/agents.test.ts
@@ -10,6 +10,7 @@ import {
   runAgentsReload,
   runAgentsList,
   dispatchAgents,
+  AgentsArgsError,
 } from "../agents";
 
 const FIXTURES = join(import.meta.dir, "fixtures");
@@ -80,6 +81,30 @@ describe("parseAgentsArgs", () => {
     expect(args.json).toBe(true);
     expect(args.config).toBe("/tmp/c.yaml");
     expect(args.fragment).toBe("/tmp/f.yaml");
+  });
+
+  // Echo M1 on cortex#63 — parser now throws on bad-flag cases (matches
+  // migrate-config convention).
+  describe("AgentsArgsError on usage failures", () => {
+    test("throws when --config is missing its value", () => {
+      expect(() => parseAgentsArgs(["reload", "--config"])).toThrow(AgentsArgsError);
+    });
+
+    test("throws when --config is followed by another flag", () => {
+      expect(() => parseAgentsArgs(["reload", "--config", "--json"])).toThrow(AgentsArgsError);
+    });
+
+    test("throws when --fragment is missing its value", () => {
+      expect(() => parseAgentsArgs(["reload", "--fragment"])).toThrow(AgentsArgsError);
+    });
+
+    test("throws on unknown flag", () => {
+      expect(() => parseAgentsArgs(["reload", "--verbose"])).toThrow(AgentsArgsError);
+    });
+
+    test("throws on extra positional argument", () => {
+      expect(() => parseAgentsArgs(["reload", "extra-arg"])).toThrow(AgentsArgsError);
+    });
   });
 });
 
@@ -165,6 +190,86 @@ describe("runAgentsReload", () => {
     expect(r.exitCode).toBe(2);
     expect(r.stderr).toMatch(/fragment file.*does not exist/);
   });
+
+  test("--fragment with `~`-prefixed persona path resolves via $HOME (Echo B1)", () => {
+    // Persona file under $HOME — fragment refers to it as `~/path/file.md`.
+    const home = process.env.HOME;
+    if (!home) return; // skip if HOME unset (CI rarity)
+    const personaHomeRel = `f3-b1-persona-${Date.now()}`;
+    const personaAbs = join(home, personaHomeRel, "echo.md");
+    mkdirSync(join(home, personaHomeRel), { recursive: true });
+    writeFileSync(personaAbs, `---\ndisplayName: Echo\n---\n`);
+
+    const fragmentDir = mkdtempSync(join(tmpdir(), "f3-b1-frag-"));
+    writeFileSync(
+      join(fragmentDir, "echo.yaml"),
+      `id: echo
+displayName: Echo
+persona: "~/${personaHomeRel}/echo.md"
+roles: [agent-restricted]
+presence:
+  discord:
+    enabled: false
+    token: "t"
+    guildId: "0"
+    agentChannelId: "1"
+    logChannelId: "2"
+`,
+    );
+
+    const r = runAgentsReload(
+      parseAgentsArgs(["reload", "--fragment", join(fragmentDir, "echo.yaml")]),
+    );
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toContain("echo");
+  });
+
+  test("--fragment routes a schema-validation failure (not just YAML-parse) — m3 nit", () => {
+    // Echo m3 — fixture that parses as YAML but fails AgentSchema.
+    const dir = mkdtempSync(join(tmpdir(), "f3-schema-fail-"));
+    writeFileSync(
+      join(dir, "broken.yaml"),
+      // Missing displayName (required) — parses fine, fails schema.
+      `id: broken
+roles: [agent-restricted]
+persona: ./missing.md
+presence:
+  discord:
+    enabled: false
+    token: t
+    guildId: "0"
+    agentChannelId: "1"
+    logChannelId: "2"
+`,
+    );
+    const r = runAgentsReload(
+      parseAgentsArgs(["reload", "--fragment", join(dir, "broken.yaml")]),
+    );
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr).toContain("schema validation failed");
+    expect(r.stderr).toMatch(/displayName/i);
+  });
+
+  test("success text includes the validation-only caveat (Echo M3)", () => {
+    const cfg = mkdtempSync(join(tmpdir(), "f3-validation-note-"));
+    seedConfigDir(cfg, VALID_DIR);
+    const r = runAgentsReload(
+      parseAgentsArgs(["reload", "--config", join(cfg, "cortex.yaml")]),
+    );
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toContain("validation-only");
+  });
+
+  test("--fragment 1 MiB cap applies (Echo M2 hardening parity)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "f3-frag-toobig-"));
+    const padding = "#" + " padding ".repeat(140_000);
+    writeFileSync(join(dir, "huge.yaml"), `id: huge\n${padding}\n`);
+    const r = runAgentsReload(
+      parseAgentsArgs(["reload", "--fragment", join(dir, "huge.yaml")]),
+    );
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr).toContain("exceeds");
+  });
 });
 
 // =============================================================================
@@ -192,7 +297,7 @@ describe("runAgentsList", () => {
     expect(r.stderr).toBe("");
   });
 
-  test("--json emits agent objects sorted by id", () => {
+  test("--json emits unified envelope with agents sorted by id (Echo M4)", () => {
     const cfg = mkdtempSync(join(tmpdir(), "f3-list-json-"));
     seedConfigDir(cfg, VALID_DIR);
     const r = runAgentsList(
@@ -200,11 +305,21 @@ describe("runAgentsList", () => {
     );
     expect(r.exitCode).toBe(0);
     const parsed = JSON.parse(r.stdout);
-    expect(Array.isArray(parsed)).toBe(true);
-    expect(parsed[0].id).toBe("echo");
-    expect(parsed[0]).toHaveProperty("substrate");
-    expect(parsed[0]).toHaveProperty("mode");
-    expect(parsed[0]).toHaveProperty("capabilities");
+    expect(parsed.status).toBe("ok");
+    expect(Array.isArray(parsed.agents)).toBe(true);
+    expect(parsed.agents[0].id).toBe("echo");
+    expect(parsed.agents[0]).toHaveProperty("substrate");
+    expect(parsed.agents[0]).toHaveProperty("mode");
+    expect(parsed.agents[0]).toHaveProperty("capabilities");
+  });
+
+  test("empty agents.d/ prints message (Echo m2 consistency)", () => {
+    const cfg = mkdtempSync(join(tmpdir(), "f3-list-empty-message-"));
+    writeFileSync(join(cfg, "cortex.yaml"), "agents: []\n");
+    mkdirSync(join(cfg, "agents.d"));
+    const r = runAgentsList(parseAgentsArgs(["list", "--config", join(cfg, "cortex.yaml")]));
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toContain("0 agents");
   });
 });
 

--- a/src/cli/cortex/commands/__tests__/fixtures/agents.d-broken/broken.yaml
+++ b/src/cli/cortex/commands/__tests__/fixtures/agents.d-broken/broken.yaml
@@ -1,0 +1,4 @@
+id: broken
+displayName: "missing closing quote
+persona: ../personas/echo.md
+roles: [agent-restricted]

--- a/src/cli/cortex/commands/__tests__/fixtures/agents.d-valid/echo.yaml
+++ b/src/cli/cortex/commands/__tests__/fixtures/agents.d-valid/echo.yaml
@@ -1,0 +1,16 @@
+id: echo
+displayName: Echo
+persona: ../personas/echo.md
+roles: [agent-restricted]
+trust: []
+presence:
+  discord:
+    enabled: false
+    token: "t"
+    guildId: "0"
+    agentChannelId: "1"
+    logChannelId: "2"
+runtime:
+  substrate: claude-code
+  mode: in-process
+  capabilities: [code-review, typescript]

--- a/src/cli/cortex/commands/__tests__/fixtures/personas/echo.md
+++ b/src/cli/cortex/commands/__tests__/fixtures/personas/echo.md
@@ -1,3 +1,7 @@
+---
+displayName: Echo
+---
+
 # Echo
 
-Test persona for migrate-config fixture.
+F-3 fixture persona.

--- a/src/cli/cortex/commands/agents.ts
+++ b/src/cli/cortex/commands/agents.ts
@@ -18,16 +18,16 @@
  *   2  — usage error (bad flags, missing files, unknown subcommand)
  */
 
-import { existsSync, readFileSync } from "fs";
-import { dirname, basename, isAbsolute } from "path";
-import { parse as parseYaml } from "yaml";
+import { existsSync } from "fs";
+import { dirname } from "path";
 
 import {
   loadAgentsDirectory,
+  loadAgentFromFile,
   FragmentLoadError,
   expandTilde,
 } from "../../../common/config/loader";
-import { AgentSchema, type Agent } from "../../../common/types/cortex-config";
+import { type Agent } from "../../../common/types/cortex-config";
 
 // =============================================================================
 // Types
@@ -53,9 +53,26 @@ export interface ExitResult {
 // =============================================================================
 
 /**
- * Hand-rolled arg parser matching the migrate-config.ts convention. Returns
- * `subcommand = "unknown"` for both empty input and unrecognized first
- * positional — the caller decides whether to print help vs error.
+ * `AgentsArgsError` carries a usage-error message for parser-level failures
+ * (bad flag, missing flag value, extra positional). Surfacing as a throw
+ * lets `dispatchAgents` map it cleanly to an exit-2 ExitResult — Echo M1
+ * on cortex#63 (parser was silently swallowing these previously).
+ */
+export class AgentsArgsError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "AgentsArgsError";
+  }
+}
+
+/**
+ * Hand-rolled arg parser matching the migrate-config.ts convention — Echo M1
+ * fix: now THROWS `AgentsArgsError` on unknown flags, `--config` / `--fragment`
+ * without a value, and extra positionals. migrate-config does the same
+ * (`migrate-config.ts:55-77`); this aligns with the documented convention.
+ *
+ * Returns `subcommand = "unknown"` for empty input and unrecognized first
+ * positional — those aren't parser errors (caller decides to print help).
  */
 export function parseAgentsArgs(argv: string[]): ParsedAgentsArgs {
   const out: ParsedAgentsArgs = {
@@ -71,12 +88,11 @@ export function parseAgentsArgs(argv: string[]): ParsedAgentsArgs {
     return out;
   }
 
-  // First positional or help-flag determines the subcommand.
   let i = 0;
   while (i < argv.length) {
     const arg = argv[i]!;
     if (arg === "--help" || arg === "-h") {
-      if (out.subcommand === "unknown") {
+      if (out.subcommand === "unknown" && out.rawSubcommand === "") {
         out.subcommand = "help";
       } else {
         out.help = true;
@@ -90,28 +106,35 @@ export function parseAgentsArgs(argv: string[]): ParsedAgentsArgs {
       continue;
     }
     if (arg === "--config") {
+      if (i + 1 >= argv.length || argv[i + 1]!.startsWith("-")) {
+        throw new AgentsArgsError(`--config requires a path argument`);
+      }
       out.config = argv[i + 1];
       i += 2;
       continue;
     }
     if (arg === "--fragment") {
+      if (i + 1 >= argv.length || argv[i + 1]!.startsWith("-")) {
+        throw new AgentsArgsError(`--fragment requires a path argument`);
+      }
       out.fragment = argv[i + 1];
       i += 2;
       continue;
     }
-    // First positional: subcommand
-    if (out.subcommand === "unknown" && !arg.startsWith("-")) {
+    if (arg.startsWith("-")) {
+      throw new AgentsArgsError(`unknown flag: ${arg}`);
+    }
+    // Positional: only one allowed (the subcommand).
+    if (out.rawSubcommand === "") {
       out.rawSubcommand = arg;
       if (arg === "reload" || arg === "list") {
         out.subcommand = arg;
-      } else {
-        out.subcommand = "unknown";
       }
+      // else: subcommand stays "unknown" — caller routes via rawSubcommand
       i++;
       continue;
     }
-    // Unknown flag or extra positional — ignore (or fail). For v1, ignore.
-    i++;
+    throw new AgentsArgsError(`unexpected extra positional argument: "${arg}"`);
   }
 
   return out;
@@ -125,19 +148,13 @@ const DEFAULT_CONFIG_PATH = "~/.config/cortex/cortex.yaml";
 
 export function runAgentsReload(args: ParsedAgentsArgs): ExitResult {
   if (args.help) {
-    return {
-      exitCode: 0,
-      stdout: reloadHelp(),
-      stderr: "",
-    };
+    return { exitCode: 0, stdout: reloadHelp(), stderr: "" };
   }
 
-  // --fragment mode: validate a single file.
   if (args.fragment) {
     return reloadFragment(args.fragment, args.json);
   }
 
-  // --config mode: validate the agents.d/ directory next to cortex.yaml.
   const configPath = expandTilde(args.config ?? DEFAULT_CONFIG_PATH);
   const configDir = dirname(configPath);
 
@@ -154,48 +171,25 @@ export function runAgentsReload(args: ParsedAgentsArgs): ExitResult {
   try {
     const agents = loadAgentsDirectory(agentsDir);
     if (args.json) {
-      return {
-        exitCode: 0,
-        stdout: JSON.stringify({ status: "ok", agents: agents.map(summarizeAgent) }, null, 2) + "\n",
-        stderr: "",
-      };
+      return { exitCode: 0, stdout: jsonOk(agents), stderr: "" };
     }
     if (agents.length === 0) {
       return {
         exitCode: 0,
-        stdout: `0 fragments in ${agentsDir} — nothing to load (OK)\n`,
+        stdout: `0 fragments in ${agentsDir} — nothing to load (OK)\n\n${VALIDATION_ONLY_NOTE}\n`,
         stderr: "",
       };
     }
-    const lines = agents.map(formatAgentLine).join("\n");
-    const summary = `${agents.length} fragment${agents.length === 1 ? "" : "s"} loaded OK`;
     return {
       exitCode: 0,
-      stdout: `${lines}\n\n${summary}\n`,
+      stdout:
+        agents.map(formatAgentLine).join("\n") + "\n\n" + successFooter(agents.length),
       stderr: "",
     };
   } catch (err) {
     if (err instanceof FragmentLoadError) {
-      if (args.json) {
-        return {
-          exitCode: 1,
-          // JSON goes to stdout even on failure so scripts can parse it.
-          stdout:
-            JSON.stringify(
-              { status: "error", error: { file: err.file, reason: err.reason } },
-              null,
-              2,
-            ) + "\n",
-          stderr: "",
-        };
-      }
-      return {
-        exitCode: 1,
-        stdout: "",
-        stderr: `cortex agents reload: ${err.message}\n`,
-      };
+      return jsonOrTextError(err, args.json);
     }
-    // Unexpected error
     return {
       exitCode: 1,
       stdout: "",
@@ -205,9 +199,12 @@ export function runAgentsReload(args: ParsedAgentsArgs): ExitResult {
 }
 
 /**
- * Validate a single fragment file (no directory traversal). Schema-validates
- * and confirms the persona file exists. Returns exit 1 on validation
- * failure, exit 2 on file-missing (usage error).
+ * Validate a single fragment file (no directory traversal). Echo M2 on
+ * cortex#63 — now delegates to shared `loadAgentFromFile` so the
+ * single-file path gets the same hardening as the directory path: 1 MiB
+ * size cap, ENOENT race, schema validation, persona-path resolution + ~
+ * expansion (Echo B1 fix). Caller-only logic: file-existence check,
+ * vanished-mid-call mapping, exit code mapping.
  */
 function reloadFragment(fragmentPath: string, json: boolean): ExitResult {
   const expanded = expandTilde(fragmentPath);
@@ -220,110 +217,40 @@ function reloadFragment(fragmentPath: string, json: boolean): ExitResult {
     };
   }
 
-  let content: string;
   try {
-    content = readFileSync(expanded, "utf-8");
-  } catch (err) {
-    return {
-      exitCode: 1,
-      stdout: "",
-      stderr: `cortex agents reload: read failed for "${expanded}": ${err instanceof Error ? err.message : String(err)}\n`,
-    };
-  }
-
-  let raw: unknown;
-  try {
-    raw = parseYaml(content);
-  } catch (err) {
-    const reason = err instanceof Error ? err.message : String(err);
+    const agent = loadAgentFromFile(expanded, dirname(expanded));
+    if (agent === null) {
+      // File vanished between existsSync above and the loader's stat. Treat
+      // as a usage error (operator-actionable: re-run).
+      return {
+        exitCode: 2,
+        stdout: "",
+        stderr: `cortex agents reload: fragment "${expanded}" disappeared between check and read; retry\n`,
+      };
+    }
     if (json) {
       return {
-        exitCode: 1,
-        stdout:
-          JSON.stringify(
-            { status: "error", error: { file: expanded, reason: `YAML parse error: ${reason}` } },
-            null,
-            2,
-          ) + "\n",
+        exitCode: 0,
+        stdout: jsonOk([agent]),
         stderr: "",
       };
     }
-    return {
-      exitCode: 1,
-      stdout: "",
-      stderr: `cortex agents reload: ${basename(expanded)}: YAML parse error: ${reason}\n`,
-    };
-  }
-
-  let agent: Agent;
-  try {
-    agent = AgentSchema.parse(raw);
-  } catch (err: unknown) {
-    const issues = (err as { issues?: Array<{ path?: unknown[]; message: string }> }).issues ?? [];
-    const details =
-      issues.length > 0
-        ? issues.map((i) => `  ${(i.path ?? []).join(".")}: ${i.message}`).join("\n")
-        : err instanceof Error
-          ? err.message
-          : String(err);
-    if (json) {
-      return {
-        exitCode: 1,
-        stdout:
-          JSON.stringify(
-            { status: "error", error: { file: expanded, reason: `schema validation failed: ${details}` } },
-            null,
-            2,
-          ) + "\n",
-        stderr: "",
-      };
-    }
-    return {
-      exitCode: 1,
-      stdout: "",
-      stderr: `cortex agents reload: ${basename(expanded)}: schema validation failed:\n${details}\n`,
-    };
-  }
-
-  // Persona file check (loader does this; replicate here for the single-file path).
-  const personaPath = isAbsolute(agent.persona)
-    ? agent.persona
-    : `${dirname(expanded)}/${agent.persona}`;
-  if (!existsSync(expandTilde(personaPath))) {
-    if (json) {
-      return {
-        exitCode: 1,
-        stdout:
-          JSON.stringify(
-            {
-              status: "error",
-              error: { file: expanded, reason: `persona file does not exist: ${personaPath}` },
-            },
-            null,
-            2,
-          ) + "\n",
-        stderr: "",
-      };
-    }
-    return {
-      exitCode: 1,
-      stdout: "",
-      stderr: `cortex agents reload: ${basename(expanded)}: persona file does not exist: ${personaPath}\n`,
-    };
-  }
-
-  if (json) {
     return {
       exitCode: 0,
-      stdout: JSON.stringify({ status: "ok", agents: [summarizeAgent(agent)] }, null, 2) + "\n",
+      stdout:
+        formatAgentLine(agent) + "\n\n" + successFooter(1),
       stderr: "",
     };
+  } catch (err) {
+    if (err instanceof FragmentLoadError) {
+      return jsonOrTextError(err, json);
+    }
+    return {
+      exitCode: 1,
+      stdout: "",
+      stderr: `cortex agents reload: unexpected error: ${err instanceof Error ? err.message : String(err)}\n`,
+    };
   }
-  return {
-    exitCode: 0,
-    stdout: `${formatAgentLine(agent)}\n\n1 fragment loaded OK\n`,
-    stderr: "",
-  };
 }
 
 // =============================================================================
@@ -352,14 +279,16 @@ export function runAgentsList(args: ParsedAgentsArgs): ExitResult {
     const agents = loadAgentsDirectory(agentsDir);
     const sorted = [...agents].sort((a, b) => a.id.localeCompare(b.id));
     if (args.json) {
-      return {
-        exitCode: 0,
-        stdout: JSON.stringify(sorted.map(summarizeAgent), null, 2) + "\n",
-        stderr: "",
-      };
+      // Echo M4 — JSON envelope is `{status, agents, error?}` everywhere.
+      return { exitCode: 0, stdout: jsonOk(sorted), stderr: "" };
     }
     if (sorted.length === 0) {
-      return { exitCode: 0, stdout: "", stderr: "" };
+      // Echo m2 — align with `reload` empty-dir text output for consistency.
+      return {
+        exitCode: 0,
+        stdout: `0 agents in ${agentsDir}\n`,
+        stderr: "",
+      };
     }
     return {
       exitCode: 0,
@@ -368,11 +297,7 @@ export function runAgentsList(args: ParsedAgentsArgs): ExitResult {
     };
   } catch (err) {
     if (err instanceof FragmentLoadError) {
-      return {
-        exitCode: 1,
-        stdout: "",
-        stderr: `cortex agents list: ${err.message}\n`,
-      };
+      return jsonOrTextError(err, args.json, "list");
     }
     return {
       exitCode: 1,
@@ -387,7 +312,20 @@ export function runAgentsList(args: ParsedAgentsArgs): ExitResult {
 // =============================================================================
 
 export function dispatchAgents(argv: string[]): ExitResult {
-  const args = parseAgentsArgs(argv);
+  let args: ParsedAgentsArgs;
+  try {
+    args = parseAgentsArgs(argv);
+  } catch (err) {
+    // Echo M1 — parser now throws AgentsArgsError on bad flags. Map to exit 2.
+    if (err instanceof AgentsArgsError) {
+      return {
+        exitCode: 2,
+        stdout: "",
+        stderr: `cortex agents: ${err.message}\n${topLevelHelp()}`,
+      };
+    }
+    throw err;
+  }
 
   switch (args.subcommand) {
     case "reload":
@@ -410,6 +348,66 @@ export function dispatchAgents(argv: string[]): ExitResult {
         stderr: `cortex agents: unknown subcommand "${args.rawSubcommand}".\n${topLevelHelp()}`,
       };
   }
+}
+
+// =============================================================================
+// Output helpers — Echo M3 + M4 on cortex#63
+// =============================================================================
+
+/**
+ * Validation-only caveat appended to success output so arc lifecycle scripts
+ * (and operators reading stdout) don't infer "the running daemon reloaded."
+ * Echo M3 on cortex#63.
+ */
+const VALIDATION_ONLY_NOTE =
+  "note: validation-only — this CLI does NOT signal a running cortex daemon to reload (v1).";
+
+function successFooter(n: number): string {
+  const summary = `${n} fragment${n === 1 ? "" : "s"} loaded OK`;
+  return `${summary}\n${VALIDATION_ONLY_NOTE}\n`;
+}
+
+/**
+ * Unified JSON success envelope — Echo M4 on cortex#63 — `{ status, agents }`
+ * is the same shape on both `reload` and `list`. No bare arrays.
+ */
+function jsonOk(agents: Agent[]): string {
+  return (
+    JSON.stringify(
+      { status: "ok", agents: agents.map(summarizeAgent) },
+      null,
+      2,
+    ) + "\n"
+  );
+}
+
+/**
+ * Unified error mapping for `FragmentLoadError` — emits JSON envelope on
+ * stdout when `--json` is set, plain stderr otherwise. Exit code is always 1
+ * (validation failure).
+ */
+function jsonOrTextError(
+  err: FragmentLoadError,
+  json: boolean,
+  command: "reload" | "list" = "reload",
+): ExitResult {
+  if (json) {
+    return {
+      exitCode: 1,
+      stdout:
+        JSON.stringify(
+          { status: "error", error: { file: err.file, reason: err.reason } },
+          null,
+          2,
+        ) + "\n",
+      stderr: "",
+    };
+  }
+  return {
+    exitCode: 1,
+    stdout: "",
+    stderr: `cortex agents ${command}: ${err.message}\n`,
+  };
 }
 
 // =============================================================================

--- a/src/cli/cortex/commands/agents.ts
+++ b/src/cli/cortex/commands/agents.ts
@@ -18,7 +18,7 @@
  *   2  — usage error (bad flags, missing files, unknown subcommand)
  */
 
-import { existsSync } from "fs";
+import { existsSync, statSync } from "fs";
 import { dirname } from "path";
 
 import {
@@ -155,18 +155,9 @@ export function runAgentsReload(args: ParsedAgentsArgs): ExitResult {
     return reloadFragment(args.fragment, args.json);
   }
 
-  const configPath = expandTilde(args.config ?? DEFAULT_CONFIG_PATH);
-  const configDir = dirname(configPath);
-
-  if (!existsSync(configDir)) {
-    return {
-      exitCode: 2,
-      stdout: "",
-      stderr: `cortex agents reload: config directory "${configDir}" does not exist\n`,
-    };
-  }
-
-  const agentsDir = `${configDir}/agents.d`;
+  const resolved = resolveAgentsDir(args, "reload");
+  if ("exit" in resolved) return resolved.exit;
+  const agentsDir = resolved.agentsDir;
 
   try {
     const agents = loadAgentsDirectory(agentsDir);
@@ -217,6 +208,23 @@ function reloadFragment(fragmentPath: string, json: boolean): ExitResult {
     };
   }
 
+  // Echo round-1 nit — pointing --fragment at a directory is a usage error,
+  // not a validation failure. Catch with statSync before the loader hits
+  // readFileSync and throws EISDIR (which we'd otherwise wrap as exit 1).
+  try {
+    if (statSync(expanded).isDirectory()) {
+      return {
+        exitCode: 2,
+        stdout: "",
+        stderr: `cortex agents reload: --fragment expects a file, got a directory: "${expanded}"\n`,
+      };
+    }
+  } catch (err) {
+    // statSync failed (e.g. permission denied) — let the loader surface a
+    // clearer error.
+    void err;
+  }
+
   try {
     const agent = loadAgentFromFile(expanded, dirname(expanded));
     if (agent === null) {
@@ -262,18 +270,9 @@ export function runAgentsList(args: ParsedAgentsArgs): ExitResult {
     return { exitCode: 0, stdout: listHelp(), stderr: "" };
   }
 
-  const configPath = expandTilde(args.config ?? DEFAULT_CONFIG_PATH);
-  const configDir = dirname(configPath);
-
-  if (!existsSync(configDir)) {
-    return {
-      exitCode: 2,
-      stdout: "",
-      stderr: `cortex agents list: config directory "${configDir}" does not exist\n`,
-    };
-  }
-
-  const agentsDir = `${configDir}/agents.d`;
+  const resolved = resolveAgentsDir(args, "list");
+  if ("exit" in resolved) return resolved.exit;
+  const agentsDir = resolved.agentsDir;
 
   try {
     const agents = loadAgentsDirectory(agentsDir);
@@ -368,23 +367,47 @@ function successFooter(n: number): string {
 }
 
 /**
- * Unified JSON success envelope — Echo M4 on cortex#63 — `{ status, agents }`
- * is the same shape on both `reload` and `list`. No bare arrays.
+ * **JSON envelope contract** (Echo M4 round 1 on cortex#63):
+ *
+ * ```ts
+ * interface AgentsJsonEnvelope {
+ *   status: "ok" | "error";
+ *   agents: AgentSummary[];      // ALWAYS present — empty array on error
+ *   error?: { file: string; reason: string };  // present iff status === "error"
+ * }
+ * ```
+ *
+ * Matches spec.md FR-1 verbatim. Scripting consumers can `.agents.map(…)`
+ * without status-guarding when they don't care about errors, or check
+ * `.status === "ok"` when they do.
  */
+export interface AgentsJsonEnvelope {
+  status: "ok" | "error";
+  agents: ReturnType<typeof summarizeAgent>[];
+  error?: { file: string; reason: string };
+}
+
 function jsonOk(agents: Agent[]): string {
-  return (
-    JSON.stringify(
-      { status: "ok", agents: agents.map(summarizeAgent) },
-      null,
-      2,
-    ) + "\n"
-  );
+  const envelope: AgentsJsonEnvelope = {
+    status: "ok",
+    agents: agents.map(summarizeAgent),
+  };
+  return JSON.stringify(envelope, null, 2) + "\n";
+}
+
+function jsonError(file: string, reason: string): string {
+  const envelope: AgentsJsonEnvelope = {
+    status: "error",
+    agents: [], // M4 round 1: present-but-empty on error so consumers can iterate without status-checking
+    error: { file, reason },
+  };
+  return JSON.stringify(envelope, null, 2) + "\n";
 }
 
 /**
- * Unified error mapping for `FragmentLoadError` — emits JSON envelope on
- * stdout when `--json` is set, plain stderr otherwise. Exit code is always 1
- * (validation failure).
+ * Unified error mapping for `FragmentLoadError`. Emits the canonical
+ * envelope on stdout when `--json` is set, plain stderr otherwise. Exit
+ * code is always 1 (validation failure).
  */
 function jsonOrTextError(
   err: FragmentLoadError,
@@ -394,12 +417,7 @@ function jsonOrTextError(
   if (json) {
     return {
       exitCode: 1,
-      stdout:
-        JSON.stringify(
-          { status: "error", error: { file: err.file, reason: err.reason } },
-          null,
-          2,
-        ) + "\n",
+      stdout: jsonError(err.file, err.reason),
       stderr: "",
     };
   }
@@ -408,6 +426,32 @@ function jsonOrTextError(
     stdout: "",
     stderr: `cortex agents ${command}: ${err.message}\n`,
   };
+}
+
+/**
+ * Shared config-dir resolution + missing-dir bailout. Echo round-1 nit-
+ * duplication on cortex#63 — both `runAgentsReload` and `runAgentsList`
+ * had this block. Now both call this helper.
+ *
+ * Returns either the resolved `agentsDir` path, or an `ExitResult` with
+ * exit code 2 if the config directory is missing.
+ */
+function resolveAgentsDir(
+  args: ParsedAgentsArgs,
+  command: "reload" | "list",
+): { agentsDir: string } | { exit: ExitResult } {
+  const configPath = expandTilde(args.config ?? DEFAULT_CONFIG_PATH);
+  const configDir = dirname(configPath);
+  if (!existsSync(configDir)) {
+    return {
+      exit: {
+        exitCode: 2,
+        stdout: "",
+        stderr: `cortex agents ${command}: config directory "${configDir}" does not exist\n`,
+      },
+    };
+  }
+  return { agentsDir: `${configDir}/agents.d` };
 }
 
 // =============================================================================

--- a/src/cli/cortex/commands/agents.ts
+++ b/src/cli/cortex/commands/agents.ts
@@ -1,0 +1,509 @@
+#!/usr/bin/env bun
+/**
+ * F-3 — `cortex agents <subcommand>` CLI.
+ *
+ * Validation-only CLI for inspecting and validating `agents.d/` fragments
+ * against the cortex schema. Wraps F-2's `loadAgentsDirectory()`. Does NOT
+ * talk to a running cortex daemon in v1 — daemon-IPC is a follow-up that
+ * waits for cortex.ts integration of `AgentsDirectoryWatcher`.
+ *
+ * Usage:
+ *   bun src/cli/cortex/commands/agents.ts reload [--config <path>] [--fragment <path>] [--json]
+ *   bun src/cli/cortex/commands/agents.ts list   [--config <path>] [--json]
+ *   bun src/cli/cortex/commands/agents.ts --help
+ *
+ * Exit codes:
+ *   0  — success
+ *   1  — validation failure (named fragment / file)
+ *   2  — usage error (bad flags, missing files, unknown subcommand)
+ */
+
+import { existsSync, readFileSync } from "fs";
+import { dirname, basename, isAbsolute } from "path";
+import { parse as parseYaml } from "yaml";
+
+import {
+  loadAgentsDirectory,
+  FragmentLoadError,
+  expandTilde,
+} from "../../../common/config/loader";
+import { AgentSchema, type Agent } from "../../../common/types/cortex-config";
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export interface ParsedAgentsArgs {
+  subcommand: "reload" | "list" | "help" | "unknown";
+  rawSubcommand: string;
+  config: string | undefined;
+  fragment: string | undefined;
+  json: boolean;
+  help: boolean;
+}
+
+export interface ExitResult {
+  exitCode: 0 | 1 | 2;
+  stdout: string;
+  stderr: string;
+}
+
+// =============================================================================
+// parseAgentsArgs
+// =============================================================================
+
+/**
+ * Hand-rolled arg parser matching the migrate-config.ts convention. Returns
+ * `subcommand = "unknown"` for both empty input and unrecognized first
+ * positional — the caller decides whether to print help vs error.
+ */
+export function parseAgentsArgs(argv: string[]): ParsedAgentsArgs {
+  const out: ParsedAgentsArgs = {
+    subcommand: "unknown",
+    rawSubcommand: "",
+    config: undefined,
+    fragment: undefined,
+    json: false,
+    help: false,
+  };
+
+  if (argv.length === 0) {
+    return out;
+  }
+
+  // First positional or help-flag determines the subcommand.
+  let i = 0;
+  while (i < argv.length) {
+    const arg = argv[i]!;
+    if (arg === "--help" || arg === "-h") {
+      if (out.subcommand === "unknown") {
+        out.subcommand = "help";
+      } else {
+        out.help = true;
+      }
+      i++;
+      continue;
+    }
+    if (arg === "--json") {
+      out.json = true;
+      i++;
+      continue;
+    }
+    if (arg === "--config") {
+      out.config = argv[i + 1];
+      i += 2;
+      continue;
+    }
+    if (arg === "--fragment") {
+      out.fragment = argv[i + 1];
+      i += 2;
+      continue;
+    }
+    // First positional: subcommand
+    if (out.subcommand === "unknown" && !arg.startsWith("-")) {
+      out.rawSubcommand = arg;
+      if (arg === "reload" || arg === "list") {
+        out.subcommand = arg;
+      } else {
+        out.subcommand = "unknown";
+      }
+      i++;
+      continue;
+    }
+    // Unknown flag or extra positional — ignore (or fail). For v1, ignore.
+    i++;
+  }
+
+  return out;
+}
+
+// =============================================================================
+// runAgentsReload
+// =============================================================================
+
+const DEFAULT_CONFIG_PATH = "~/.config/cortex/cortex.yaml";
+
+export function runAgentsReload(args: ParsedAgentsArgs): ExitResult {
+  if (args.help) {
+    return {
+      exitCode: 0,
+      stdout: reloadHelp(),
+      stderr: "",
+    };
+  }
+
+  // --fragment mode: validate a single file.
+  if (args.fragment) {
+    return reloadFragment(args.fragment, args.json);
+  }
+
+  // --config mode: validate the agents.d/ directory next to cortex.yaml.
+  const configPath = expandTilde(args.config ?? DEFAULT_CONFIG_PATH);
+  const configDir = dirname(configPath);
+
+  if (!existsSync(configDir)) {
+    return {
+      exitCode: 2,
+      stdout: "",
+      stderr: `cortex agents reload: config directory "${configDir}" does not exist\n`,
+    };
+  }
+
+  const agentsDir = `${configDir}/agents.d`;
+
+  try {
+    const agents = loadAgentsDirectory(agentsDir);
+    if (args.json) {
+      return {
+        exitCode: 0,
+        stdout: JSON.stringify({ status: "ok", agents: agents.map(summarizeAgent) }, null, 2) + "\n",
+        stderr: "",
+      };
+    }
+    if (agents.length === 0) {
+      return {
+        exitCode: 0,
+        stdout: `0 fragments in ${agentsDir} — nothing to load (OK)\n`,
+        stderr: "",
+      };
+    }
+    const lines = agents.map(formatAgentLine).join("\n");
+    const summary = `${agents.length} fragment${agents.length === 1 ? "" : "s"} loaded OK`;
+    return {
+      exitCode: 0,
+      stdout: `${lines}\n\n${summary}\n`,
+      stderr: "",
+    };
+  } catch (err) {
+    if (err instanceof FragmentLoadError) {
+      if (args.json) {
+        return {
+          exitCode: 1,
+          // JSON goes to stdout even on failure so scripts can parse it.
+          stdout:
+            JSON.stringify(
+              { status: "error", error: { file: err.file, reason: err.reason } },
+              null,
+              2,
+            ) + "\n",
+          stderr: "",
+        };
+      }
+      return {
+        exitCode: 1,
+        stdout: "",
+        stderr: `cortex agents reload: ${err.message}\n`,
+      };
+    }
+    // Unexpected error
+    return {
+      exitCode: 1,
+      stdout: "",
+      stderr: `cortex agents reload: unexpected error: ${err instanceof Error ? err.message : String(err)}\n`,
+    };
+  }
+}
+
+/**
+ * Validate a single fragment file (no directory traversal). Schema-validates
+ * and confirms the persona file exists. Returns exit 1 on validation
+ * failure, exit 2 on file-missing (usage error).
+ */
+function reloadFragment(fragmentPath: string, json: boolean): ExitResult {
+  const expanded = expandTilde(fragmentPath);
+
+  if (!existsSync(expanded)) {
+    return {
+      exitCode: 2,
+      stdout: "",
+      stderr: `cortex agents reload: fragment file "${expanded}" does not exist\n`,
+    };
+  }
+
+  let content: string;
+  try {
+    content = readFileSync(expanded, "utf-8");
+  } catch (err) {
+    return {
+      exitCode: 1,
+      stdout: "",
+      stderr: `cortex agents reload: read failed for "${expanded}": ${err instanceof Error ? err.message : String(err)}\n`,
+    };
+  }
+
+  let raw: unknown;
+  try {
+    raw = parseYaml(content);
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    if (json) {
+      return {
+        exitCode: 1,
+        stdout:
+          JSON.stringify(
+            { status: "error", error: { file: expanded, reason: `YAML parse error: ${reason}` } },
+            null,
+            2,
+          ) + "\n",
+        stderr: "",
+      };
+    }
+    return {
+      exitCode: 1,
+      stdout: "",
+      stderr: `cortex agents reload: ${basename(expanded)}: YAML parse error: ${reason}\n`,
+    };
+  }
+
+  let agent: Agent;
+  try {
+    agent = AgentSchema.parse(raw);
+  } catch (err: unknown) {
+    const issues = (err as { issues?: Array<{ path?: unknown[]; message: string }> }).issues ?? [];
+    const details =
+      issues.length > 0
+        ? issues.map((i) => `  ${(i.path ?? []).join(".")}: ${i.message}`).join("\n")
+        : err instanceof Error
+          ? err.message
+          : String(err);
+    if (json) {
+      return {
+        exitCode: 1,
+        stdout:
+          JSON.stringify(
+            { status: "error", error: { file: expanded, reason: `schema validation failed: ${details}` } },
+            null,
+            2,
+          ) + "\n",
+        stderr: "",
+      };
+    }
+    return {
+      exitCode: 1,
+      stdout: "",
+      stderr: `cortex agents reload: ${basename(expanded)}: schema validation failed:\n${details}\n`,
+    };
+  }
+
+  // Persona file check (loader does this; replicate here for the single-file path).
+  const personaPath = isAbsolute(agent.persona)
+    ? agent.persona
+    : `${dirname(expanded)}/${agent.persona}`;
+  if (!existsSync(expandTilde(personaPath))) {
+    if (json) {
+      return {
+        exitCode: 1,
+        stdout:
+          JSON.stringify(
+            {
+              status: "error",
+              error: { file: expanded, reason: `persona file does not exist: ${personaPath}` },
+            },
+            null,
+            2,
+          ) + "\n",
+        stderr: "",
+      };
+    }
+    return {
+      exitCode: 1,
+      stdout: "",
+      stderr: `cortex agents reload: ${basename(expanded)}: persona file does not exist: ${personaPath}\n`,
+    };
+  }
+
+  if (json) {
+    return {
+      exitCode: 0,
+      stdout: JSON.stringify({ status: "ok", agents: [summarizeAgent(agent)] }, null, 2) + "\n",
+      stderr: "",
+    };
+  }
+  return {
+    exitCode: 0,
+    stdout: `${formatAgentLine(agent)}\n\n1 fragment loaded OK\n`,
+    stderr: "",
+  };
+}
+
+// =============================================================================
+// runAgentsList
+// =============================================================================
+
+export function runAgentsList(args: ParsedAgentsArgs): ExitResult {
+  if (args.help) {
+    return { exitCode: 0, stdout: listHelp(), stderr: "" };
+  }
+
+  const configPath = expandTilde(args.config ?? DEFAULT_CONFIG_PATH);
+  const configDir = dirname(configPath);
+
+  if (!existsSync(configDir)) {
+    return {
+      exitCode: 2,
+      stdout: "",
+      stderr: `cortex agents list: config directory "${configDir}" does not exist\n`,
+    };
+  }
+
+  const agentsDir = `${configDir}/agents.d`;
+
+  try {
+    const agents = loadAgentsDirectory(agentsDir);
+    const sorted = [...agents].sort((a, b) => a.id.localeCompare(b.id));
+    if (args.json) {
+      return {
+        exitCode: 0,
+        stdout: JSON.stringify(sorted.map(summarizeAgent), null, 2) + "\n",
+        stderr: "",
+      };
+    }
+    if (sorted.length === 0) {
+      return { exitCode: 0, stdout: "", stderr: "" };
+    }
+    return {
+      exitCode: 0,
+      stdout: sorted.map(formatAgentLine).join("\n") + "\n",
+      stderr: "",
+    };
+  } catch (err) {
+    if (err instanceof FragmentLoadError) {
+      return {
+        exitCode: 1,
+        stdout: "",
+        stderr: `cortex agents list: ${err.message}\n`,
+      };
+    }
+    return {
+      exitCode: 1,
+      stdout: "",
+      stderr: `cortex agents list: unexpected error: ${err instanceof Error ? err.message : String(err)}\n`,
+    };
+  }
+}
+
+// =============================================================================
+// dispatchAgents
+// =============================================================================
+
+export function dispatchAgents(argv: string[]): ExitResult {
+  const args = parseAgentsArgs(argv);
+
+  switch (args.subcommand) {
+    case "reload":
+      return runAgentsReload(args);
+    case "list":
+      return runAgentsList(args);
+    case "help":
+      return { exitCode: 0, stdout: topLevelHelp(), stderr: "" };
+    case "unknown":
+      if (args.rawSubcommand === "") {
+        return {
+          exitCode: 2,
+          stdout: "",
+          stderr: `cortex agents: usage error — no subcommand specified.\n${topLevelHelp()}`,
+        };
+      }
+      return {
+        exitCode: 2,
+        stdout: "",
+        stderr: `cortex agents: unknown subcommand "${args.rawSubcommand}".\n${topLevelHelp()}`,
+      };
+  }
+}
+
+// =============================================================================
+// Formatters
+// =============================================================================
+
+function summarizeAgent(a: Agent): {
+  id: string;
+  displayName: string;
+  substrate: string;
+  mode: string;
+  capabilities: string[];
+} {
+  return {
+    id: a.id,
+    displayName: a.displayName,
+    substrate: a.runtime?.substrate ?? "claude-code",
+    mode: a.runtime?.mode ?? "in-process",
+    capabilities: a.runtime?.capabilities ?? [],
+  };
+}
+
+function formatAgentLine(a: Agent): string {
+  const substrate = a.runtime?.substrate ?? "claude-code";
+  const mode = a.runtime?.mode ?? "in-process";
+  const capCount = a.runtime?.capabilities.length ?? 0;
+  return `${a.id.padEnd(20)} — ${substrate} / ${mode} / ${capCount} capabilit${capCount === 1 ? "y" : "ies"}`;
+}
+
+// =============================================================================
+// Help text
+// =============================================================================
+
+function topLevelHelp(): string {
+  return `cortex agents — inspect + validate agent fragments
+
+Usage:
+  cortex agents reload [options]
+  cortex agents list   [options]
+  cortex agents --help
+
+Subcommands:
+  reload   Validate fragments in ~/.config/cortex/agents.d/ (or --fragment <path>)
+  list     List loaded agents with substrate / mode / capabilities
+
+Common options:
+  --config <path>     cortex.yaml path (default: ~/.config/cortex/cortex.yaml)
+  --json              emit structured JSON (machine-readable)
+  --help, -h          show help
+
+Exit codes:
+  0    success
+  1    validation failure
+  2    usage error (bad flag, missing config, unknown subcommand)
+`;
+}
+
+function reloadHelp(): string {
+  return `cortex agents reload — validate agents.d/ fragments
+
+Usage:
+  cortex agents reload [--config <path>] [--fragment <path>] [--json]
+
+Options:
+  --config <path>      cortex.yaml path (default: ~/.config/cortex/cortex.yaml)
+                       The agents.d/ directory next to this file is loaded.
+  --fragment <path>    Validate a single fragment file (overrides --config dir mode)
+  --json               Emit structured JSON
+
+In v1, this command is validation-only. It does NOT signal a running cortex
+daemon to reload — that wiring lands when cortex.ts integrates the
+AgentsDirectoryWatcher (separate follow-up).
+`;
+}
+
+function listHelp(): string {
+  return `cortex agents list — list loaded agents
+
+Usage:
+  cortex agents list [--config <path>] [--json]
+
+Options:
+  --config <path>      cortex.yaml path (default: ~/.config/cortex/cortex.yaml)
+  --json               Emit array of agent summary objects
+`;
+}
+
+// =============================================================================
+// Main
+// =============================================================================
+
+if (import.meta.main) {
+  const result = dispatchAgents(process.argv.slice(2));
+  if (result.stdout) process.stdout.write(result.stdout);
+  if (result.stderr) process.stderr.write(result.stderr);
+  process.exit(result.exitCode);
+}

--- a/src/common/config/loader.ts
+++ b/src/common/config/loader.ts
@@ -131,6 +131,114 @@ export class FragmentLoadError extends Error {
  * Agent list in `AgentRegistry` (`src/common/agents/registry.ts`) which
  * throws `UnknownAgentReferenceError` on unresolved trust at construction.
  */
+/**
+ * Load and validate a single fragment file. Extracted from `loadAgentsDirectory`
+ * (Echo M2 on cortex#63) so consumers like the CLI's `--fragment` mode get
+ * the same hardening: 1 MiB size cap, ENOENT race handling, schema validation,
+ * filename-stem warning, persona-path resolution + existence check.
+ *
+ * `personaBaseDir` is the directory relative paths in `agent.persona` resolve
+ * against — typically the fragment's own directory.
+ *
+ * Returns `null` if the file vanished between caller's directory-listing and
+ * this call (ENOENT race). The directory loader skips such files; single-file
+ * callers translate `null` into a clear "file disappeared" error.
+ */
+export function loadAgentFromFile(filePath: string, personaBaseDir: string): Agent | null {
+  // Echo M3 — size guard before readFileSync.
+  let size: number;
+  try {
+    size = statSync(filePath).size;
+  } catch (err) {
+    if (err instanceof Error && (err as NodeJS.ErrnoException).code === "ENOENT") {
+      return null;
+    }
+    throw new FragmentLoadError(
+      filePath,
+      `stat failed: ${err instanceof Error ? err.message : String(err)}`,
+      err instanceof Error ? err : undefined,
+    );
+  }
+  if (size > FRAGMENT_MAX_BYTES) {
+    throw new FragmentLoadError(
+      filePath,
+      `fragment exceeds ${FRAGMENT_MAX_BYTES} bytes (got ${size}); refusing to read`,
+    );
+  }
+
+  let content: string;
+  try {
+    content = readFileSync(filePath, "utf-8");
+  } catch (err) {
+    if (err instanceof Error && (err as NodeJS.ErrnoException).code === "ENOENT") {
+      return null;
+    }
+    throw new FragmentLoadError(
+      filePath,
+      `read failed: ${err instanceof Error ? err.message : String(err)}`,
+      err instanceof Error ? err : undefined,
+    );
+  }
+
+  let raw: unknown;
+  try {
+    raw = parseYaml(content);
+  } catch (err) {
+    throw new FragmentLoadError(
+      filePath,
+      `YAML parse error: ${err instanceof Error ? err.message : String(err)}`,
+      err instanceof Error ? err : undefined,
+    );
+  }
+
+  // Echo N6 — operator-UX warn when id and filename stem disagree.
+  const filename = basename(filePath);
+  const filenameStem = basename(filename, filename.endsWith(".yml") ? ".yml" : ".yaml");
+  if (raw && typeof raw === "object" && "id" in raw) {
+    const declaredId = (raw as { id?: unknown }).id;
+    if (typeof declaredId === "string" && declaredId !== filenameStem) {
+      console.warn(
+        `agents-loader: fragment ${filename} declares id "${declaredId}" which differs from its filename stem "${filenameStem}". Convention is to match — operator tooling (arc, cortex agents list) keys on the id, but mismatch obscures filesystem lookup.`,
+      );
+    }
+  }
+
+  let agent: Agent;
+  try {
+    agent = AgentSchema.parse(raw);
+  } catch (err: unknown) {
+    const issues = (err as { issues?: Array<{ path?: unknown[]; message: string }> }).issues ?? [];
+    const details =
+      issues.length > 0
+        ? issues.map((i) => `  ${(i.path ?? []).join(".")}: ${i.message}`).join("\n")
+        : err instanceof Error
+          ? err.message
+          : String(err);
+    throw new FragmentLoadError(
+      filePath,
+      `schema validation failed:\n${details}`,
+      err instanceof Error ? err : undefined,
+    );
+  }
+
+  // Resolve persona path: ~ FIRST (so a `~/personas/foo.md` is fully
+  // expanded before isAbsolute check), then relative → absolute against
+  // the fragment's directory. Echo B1 fix: must expand BEFORE join.
+  const personaPathExpanded = expandTilde(agent.persona);
+  const personaPathResolved = isAbsolute(personaPathExpanded)
+    ? personaPathExpanded
+    : resolve(personaBaseDir, personaPathExpanded);
+
+  if (!existsSync(personaPathResolved)) {
+    throw new FragmentLoadError(
+      filePath,
+      `persona file does not exist: ${personaPathResolved}`,
+    );
+  }
+
+  return { ...agent, persona: personaPathResolved };
+}
+
 export function loadAgentsDirectory(dir: string): Agent[] {
   const expandedDir = expandTilde(dir);
 
@@ -148,95 +256,10 @@ export function loadAgentsDirectory(dir: string): Agent[] {
 
   for (const filename of files) {
     const filePath = join(expandedDir, filename);
-
-    // Echo M3 — size guard before readFileSync.
-    let size: number;
-    try {
-      size = statSync(filePath).size;
-    } catch (err) {
-      // Race: file was in readdir's list but vanished before we statSync'd
-      // (operator just deleted it, or arc is mid-uninstall). Skip silently
-      // — the reload loop continues with the rest of the directory.
-      if (
-        err instanceof Error &&
-        (err as NodeJS.ErrnoException).code === "ENOENT"
-      ) {
-        continue;
-      }
-      throw new FragmentLoadError(
-        filePath,
-        `stat failed: ${err instanceof Error ? err.message : String(err)}`,
-        err instanceof Error ? err : undefined,
-      );
-    }
-    if (size > FRAGMENT_MAX_BYTES) {
-      throw new FragmentLoadError(
-        filePath,
-        `fragment exceeds ${FRAGMENT_MAX_BYTES} bytes (got ${size}); refusing to read`,
-      );
-    }
-
-    let content: string;
-    try {
-      content = readFileSync(filePath, "utf-8");
-    } catch (err) {
-      // Same race window — between stat and read.
-      if (
-        err instanceof Error &&
-        (err as NodeJS.ErrnoException).code === "ENOENT"
-      ) {
-        continue;
-      }
-      throw new FragmentLoadError(
-        filePath,
-        `read failed: ${err instanceof Error ? err.message : String(err)}`,
-        err instanceof Error ? err : undefined,
-      );
-    }
-
-    // Echo N6 — warn if agent.id doesn't match filename stem. Filename is
-    // operator/arc convention; mismatched id is a footgun for both. We log
-    // rather than throw — operator may have legitimate reasons (e.g.
-    // versioned fragment filenames like `echo.v2.yaml`).
-    const filenameStem = basename(filename, filename.endsWith(".yml") ? ".yml" : ".yaml");
-
-    let raw: unknown;
-    try {
-      raw = parseYaml(content);
-    } catch (err) {
-      throw new FragmentLoadError(
-        filePath,
-        `YAML parse error: ${err instanceof Error ? err.message : String(err)}`,
-        err instanceof Error ? err : undefined,
-      );
-    }
-
-    // Echo N6 — operator-UX warn when id and filename stem disagree.
-    if (raw && typeof raw === "object" && "id" in raw) {
-      const declaredId = (raw as { id?: unknown }).id;
-      if (typeof declaredId === "string" && declaredId !== filenameStem) {
-        console.warn(
-          `agents-loader: fragment ${filename} declares id "${declaredId}" which differs from its filename stem "${filenameStem}". Convention is to match — operator tooling (arc, cortex agents list) keys on the id, but mismatch obscures filesystem lookup.`,
-        );
-      }
-    }
-
-    let agent: Agent;
-    try {
-      agent = AgentSchema.parse(raw);
-    } catch (err: unknown) {
-      const issues = (err as { issues?: Array<{ path?: unknown[]; message: string }> }).issues ?? [];
-      const details =
-        issues.length > 0
-          ? issues.map((i) => `  ${(i.path ?? []).join(".")}: ${i.message}`).join("\n")
-          : err instanceof Error
-            ? err.message
-            : String(err);
-      throw new FragmentLoadError(
-        filePath,
-        `schema validation failed:\n${details}`,
-        err instanceof Error ? err : undefined,
-      );
+    const agent = loadAgentFromFile(filePath, expandedDir);
+    if (agent === null) {
+      // File vanished between readdir and read — skip silently.
+      continue;
     }
 
     if (seenIds.has(agent.id)) {
@@ -246,23 +269,7 @@ export function loadAgentsDirectory(dir: string): Agent[] {
       );
     }
     seenIds.set(agent.id, filename);
-
-    // Resolve persona path: ~ → $HOME, then relative → absolute against the
-    // fragment file's directory. The Agent type stays in
-    // shape-fully-resolved-path; downstream callers don't re-resolve.
-    const personaPathExpanded = expandTilde(agent.persona);
-    const personaPathResolved = isAbsolute(personaPathExpanded)
-      ? personaPathExpanded
-      : resolve(expandedDir, personaPathExpanded);
-
-    if (!existsSync(personaPathResolved)) {
-      throw new FragmentLoadError(
-        filePath,
-        `persona file does not exist: ${personaPathResolved}`,
-      );
-    }
-
-    agents.push({ ...agent, persona: personaPathResolved });
+    agents.push(agent);
   }
 
   return agents;


### PR DESCRIPTION
## Summary

Third of five Phase A pieces for arc-installable cortex sub-bots (cortex#60 §11). Ships the `cortex agents` CLI with two subcommands — `reload` (validate fragments) and `list` (display loaded agents).

**Validation-only in v1.** Does NOT signal a running cortex daemon to reload. Daemon-IPC wiring waits for cortex.ts integration of F-2's `AgentsDirectoryWatcher` (separate follow-up). For now this CLI is the arc-lifecycle-script and operator diagnostic surface.

## Subcommands

### `cortex agents reload [--config <path>] [--fragment <path>] [--json]`

- Validates fragments in `agents.d/` (next to `--config`'s cortex.yaml, default `~/.config/cortex/cortex.yaml`)
- `--fragment <path>` mode: validate a single file (pre-install dry-run)
- `--json` mode: structured output for scripting
- Exit: 0 ok / 1 validation fail / 2 usage error

### `cortex agents list [--config <path>] [--json]`

- Lists loaded agents sorted alphabetically by id
- Default format: `<id>  —  <substrate> / <mode> / <N> capabilities`
- `--json` mode: array of `{id, displayName, substrate, mode, capabilities}` objects

## What's in

| File | Lines | Purpose |
|------|------:|---------|
| `src/cli/cortex/commands/agents.ts` | ~510 | parser + handlers + dispatcher + main |
| `src/cli/cortex/commands/__tests__/agents.test.ts` | ~280 | 27 tests |
| `__tests__/fixtures/agents.d-valid/` + `agents.d-broken/` + `personas/echo.md` | small | fixture data |
| `.specify/specs/F-3-*/{spec,plan,tasks}.md` | — | SpecFlow artifacts |

## What's NOT in (deferred)

- **Live daemon reload signaling** — SIGHUP handler in `cortex.ts` or NATS request/reply. Needs `AgentsDirectoryWatcher` wired into the running daemon (separate follow-up, depends on cortex.ts evolution).
- **`cortex agents add/remove`** — fragment authoring. Out of scope; arc lifecycle scripts + manual edits are the v1 channels.
- **Trust resolution in CLI** — CLI uses `loadAgentsDirectory` which doesn't resolve trust; `AgentRegistry` construction is the daemon's job.

## Test plan

- [x] `bun test src/cli/cortex/commands/__tests__/agents.test.ts` — 27 pass / 0 fail
- [x] `bun test` (full suite) — 2204 pass / 1 fail (known pre-existing mission-control test per RESUME.md)
- [x] `bunx tsc --noEmit` — clean
- [x] Manual: `bun src/cli/cortex/commands/agents.ts --help` → renders help
- [x] Manual: `bun src/cli/cortex/commands/agents.ts reload --fragment <valid.yaml>` → exit 0

## Migration impact

None. New CLI surface only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)