### PR TITLE
feat(cli/cortex): cortex#65 — F-3 envelope retrofit + F-4 round-2 nits

### DIFF
--- a/.specify/specs/F-4-cortex-creds-cli/spec.md
+++ b/.specify/specs/F-4-cortex-creds-cli/spec.md
@@ -18,23 +18,23 @@ Per the locked design (cortex#58 D8 + interview F-4 answers):
 - **Daemon-mediated signing** — CLI is thin; operator signing key lives in cortex daemon memory only
 - **Fail-on-offline-revoke** — revoke aborts when NATS server unreachable
 
-**v1 scope:** ship the CLI structure complete + `list --local` fully functional (filesystem scan). `issue`/`revoke`/`rotate` ship as structured "deferred" subcommands that emit a clear error pointing at the daemon-IPC follow-up. This matches the F-2/F-3 pattern where the foundational APIs ship before the cortex.ts integration that wires them into a running daemon.
+**v1 scope:** ship the CLI structure complete + `list` fully functional (filesystem scan). `issue`/`revoke`/`rotate` ship as structured "deferred" subcommands that emit a clear error pointing at the daemon-IPC follow-up. This matches the F-2/F-3 pattern where the foundational APIs ship before the cortex.ts integration that wires them into a running daemon.
 
 ## User Scenarios
 
 ### Scenario 1: Operator inventories per-agent creds
 
 ```bash
-cortex creds list --local
+cortex creds list
 # echo                 ~/.config/nats/creds/echo.creds      issued 2026-05-12T01:00
 # holly                ~/.config/nats/creds/holly.creds     issued 2026-05-12T01:00
 # codex-rev            ~/.config/nats/creds/codex-rev.creds issued 2026-05-12T01:00
 ```
 
 **Acceptance Criteria:**
-- [ ] `cortex creds list --local` scans `~/.config/nats/creds/` (configurable via `--creds-dir`)
+- [ ] `cortex creds list` scans `~/.config/nats/creds/` (configurable via `--creds-dir`)
 - [ ] Output includes agent id (filename stem), full path, file mtime
-- [ ] `--json` mode emits structured array
+- [ ] `--json` mode emits structured envelope (see FR-6)
 - [ ] Empty dir → exit 0, "0 creds files" message
 - [ ] Sorted alphabetically by id
 
@@ -42,13 +42,13 @@ cortex creds list --local
 
 ```bash
 cortex creds issue foo
-# (v1) → exit 2 with: "creds issue requires the cortex daemon (not yet wired); see <follow-up-issue>"
+# (v1) → exit 2 with: "not yet implemented — pending cortex daemon-IPC integration (cortex#67)"
 # (future) → mints user JWT via daemon-IPC, writes ~/.config/nats/creds/foo.creds
 ```
 
 **Acceptance Criteria (v1):**
 - [ ] `cortex creds issue <id>` returns exit 2 with a clear "not yet implemented — pending daemon IPC" message
-- [ ] Error message names the cortex repo follow-up issue (`cortex#TBD — cortex creds daemon-IPC integration`)
+- [ ] Error message cites cortex#67 (the filed daemon-IPC follow-up issue)
 - [ ] Help text documents the deferral
 
 **Acceptance Criteria (future, not in F-4 v1):**

--- a/src/cli/cortex/commands/__tests__/agents.test.ts
+++ b/src/cli/cortex/commands/__tests__/agents.test.ts
@@ -151,9 +151,9 @@ describe("runAgentsReload", () => {
     expect(r.exitCode).toBe(0);
     const parsed = JSON.parse(r.stdout);
     expect(parsed.status).toBe("ok");
-    expect(parsed.agents).toBeInstanceOf(Array);
-    expect(parsed.agents.length).toBeGreaterThan(0);
-    expect(parsed.agents[0].id).toBe("echo");
+    expect(parsed.items).toBeInstanceOf(Array);
+    expect(parsed.items.length).toBeGreaterThan(0);
+    expect(parsed.items[0].id).toBe("echo");
   });
 
   test("--json on failure emits envelope with agents:[] + error (M4 round-1)", () => {
@@ -168,8 +168,8 @@ describe("runAgentsReload", () => {
     expect(parsed.status).toBe("error");
     // Echo M4 round 1: `agents` MUST be present (empty array) so consumers
     // can iterate without status-checking.
-    expect(parsed.agents).toEqual([]);
-    expect(parsed.error.file).toContain("broken.yaml");
+    expect(parsed.items).toEqual([]);
+    expect(parsed.error.context.file).toContain("broken.yaml");
     expect(parsed.error.reason).toBeTruthy();
   });
 
@@ -317,11 +317,11 @@ describe("runAgentsList", () => {
     expect(r.exitCode).toBe(0);
     const parsed = JSON.parse(r.stdout);
     expect(parsed.status).toBe("ok");
-    expect(Array.isArray(parsed.agents)).toBe(true);
-    expect(parsed.agents[0].id).toBe("echo");
-    expect(parsed.agents[0]).toHaveProperty("substrate");
-    expect(parsed.agents[0]).toHaveProperty("mode");
-    expect(parsed.agents[0]).toHaveProperty("capabilities");
+    expect(Array.isArray(parsed.items)).toBe(true);
+    expect(parsed.items[0].id).toBe("echo");
+    expect(parsed.items[0]).toHaveProperty("substrate");
+    expect(parsed.items[0]).toHaveProperty("mode");
+    expect(parsed.items[0]).toHaveProperty("capabilities");
   });
 
   test("empty agents.d/ prints message (Echo m2 consistency)", () => {

--- a/src/cli/cortex/commands/__tests__/creds.test.ts
+++ b/src/cli/cortex/commands/__tests__/creds.test.ts
@@ -253,6 +253,32 @@ describe("runCredsList", () => {
       expect(r.stderr).toContain("BadName.creds");
     });
   });
+
+  // cortex#65 — Echo round-2 H1 nit on cortex#64: cap was enforced in
+  // code but not exercised by a test. Closes the regression risk if
+  // someone flips `>` to `>=`.
+  describe("hardening cap (Echo H1)", () => {
+    test("refuses to enumerate when directory has > 10_000 entries", () => {
+      const dir = mkdtempSync(join(tmpdir(), "f4-h1-cap-"));
+      for (let i = 0; i < 10_001; i++) {
+        writeFileSync(join(dir, `agent-${i}.creds`), "x");
+      }
+      const r = runCredsList(parseCredsArgs(["list", "--creds-dir", dir]));
+      expect(r.exitCode).toBe(1);
+      expect(r.stderr).toMatch(/refusing to enumerate/);
+      expect(r.stderr).toContain("10001");
+      expect(r.stderr).toContain("10000");
+    });
+
+    test("accepts exactly 10_000 entries (boundary)", () => {
+      const dir = mkdtempSync(join(tmpdir(), "f4-h1-boundary-"));
+      for (let i = 0; i < 10_000; i++) {
+        writeFileSync(join(dir, `agent-${i}.creds`), "x");
+      }
+      const r = runCredsList(parseCredsArgs(["list", "--creds-dir", dir]));
+      expect(r.exitCode).toBe(0);
+    });
+  });
 });
 
 // =============================================================================

--- a/src/cli/cortex/commands/_shared/assert-exhaustive.ts
+++ b/src/cli/cortex/commands/_shared/assert-exhaustive.ts
@@ -4,17 +4,10 @@
  * compile time; the runtime branch surfaces a clear error if the type
  * assertion ever lapses (e.g. unsafe cast upstream).
  *
- * Returns the standard `ExitResult` shape (exit 2, stderr message) so
- * dispatchers can plug it into their `default:` arm without ceremony.
- *
  * Reused across F-3 (`dispatchAgents`), F-4 (`dispatchCreds`), and any
  * future cortex CLI dispatcher.
  */
-export interface ExitResult {
-  exitCode: 0 | 1 | 2;
-  stdout: string;
-  stderr: string;
-}
+import type { ExitResult } from "./exit-result";
 
 export function assertExhaustive(value: never, cliName: string): ExitResult {
   return {

--- a/src/cli/cortex/commands/_shared/exit-result.ts
+++ b/src/cli/cortex/commands/_shared/exit-result.ts
@@ -1,0 +1,14 @@
+/**
+ * Standard CLI exit-result shape across cortex subcommand handlers.
+ * Returned by every `runSubcommand(args) → ExitResult` and consumed by
+ * the dispatcher's `process.exit` glue.
+ *
+ * Extracted from `_shared/assert-exhaustive.ts` (cortex#65 — Echo round-2
+ * ExitResult-duplication nit on cortex#64). The handler files (agents.ts,
+ * creds.ts) used to redeclare this shape inline; now they import.
+ */
+export interface ExitResult {
+  exitCode: 0 | 1 | 2;
+  stdout: string;
+  stderr: string;
+}

--- a/src/cli/cortex/commands/agents.ts
+++ b/src/cli/cortex/commands/agents.ts
@@ -21,6 +21,9 @@
 import { existsSync, statSync } from "fs";
 import { dirname } from "path";
 
+import { CliArgsError } from "./_shared/arg-error";
+import { envelopeError, envelopeOk, renderJson } from "./_shared/envelope";
+import { type ExitResult } from "./_shared/exit-result";
 import {
   loadAgentsDirectory,
   loadAgentFromFile,
@@ -42,28 +45,22 @@ export interface ParsedAgentsArgs {
   help: boolean;
 }
 
-export interface ExitResult {
-  exitCode: 0 | 1 | 2;
-  stdout: string;
-  stderr: string;
-}
+// ExitResult moved to `_shared/exit-result.ts` (cortex#65). Importing
+// above; re-exporting for backward compat with external imports of
+// `ExitResult` via `agents.ts`.
+export { type ExitResult } from "./_shared/exit-result";
 
 // =============================================================================
 // parseAgentsArgs
 // =============================================================================
 
 /**
- * `AgentsArgsError` carries a usage-error message for parser-level failures
- * (bad flag, missing flag value, extra positional). Surfacing as a throw
- * lets `dispatchAgents` map it cleanly to an exit-2 ExitResult — Echo M1
- * on cortex#63 (parser was silently swallowing these previously).
+ * @deprecated cortex#65 — use `CliArgsError` from `./_shared/arg-error`.
+ * Aliased here so external imports of `AgentsArgsError` (e.g. cortex#63 test
+ * patterns) continue working through the rename. Future PRs should switch
+ * to the shared class directly.
  */
-export class AgentsArgsError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = "AgentsArgsError";
-  }
-}
+export const AgentsArgsError = CliArgsError;
 
 /**
  * Hand-rolled arg parser matching the migrate-config.ts convention — Echo M1
@@ -107,7 +104,7 @@ export function parseAgentsArgs(argv: string[]): ParsedAgentsArgs {
     }
     if (arg === "--config") {
       if (i + 1 >= argv.length || argv[i + 1]!.startsWith("-")) {
-        throw new AgentsArgsError(`--config requires a path argument`);
+        throw new CliArgsError("agents", `--config requires a path argument`);
       }
       out.config = argv[i + 1];
       i += 2;
@@ -115,14 +112,14 @@ export function parseAgentsArgs(argv: string[]): ParsedAgentsArgs {
     }
     if (arg === "--fragment") {
       if (i + 1 >= argv.length || argv[i + 1]!.startsWith("-")) {
-        throw new AgentsArgsError(`--fragment requires a path argument`);
+        throw new CliArgsError("agents", `--fragment requires a path argument`);
       }
       out.fragment = argv[i + 1];
       i += 2;
       continue;
     }
     if (arg.startsWith("-")) {
-      throw new AgentsArgsError(`unknown flag: ${arg}`);
+      throw new CliArgsError("agents", `unknown flag: ${arg}`);
     }
     // Positional: only one allowed (the subcommand).
     if (out.rawSubcommand === "") {
@@ -134,7 +131,7 @@ export function parseAgentsArgs(argv: string[]): ParsedAgentsArgs {
       i++;
       continue;
     }
-    throw new AgentsArgsError(`unexpected extra positional argument: "${arg}"`);
+    throw new CliArgsError("agents", `unexpected extra positional argument: "${arg}"`);
   }
 
   return out;
@@ -315,8 +312,8 @@ export function dispatchAgents(argv: string[]): ExitResult {
   try {
     args = parseAgentsArgs(argv);
   } catch (err) {
-    // Echo M1 — parser now throws AgentsArgsError on bad flags. Map to exit 2.
-    if (err instanceof AgentsArgsError) {
+    // Echo M1 — parser throws CliArgsError on bad flags. Map to exit 2.
+    if (err instanceof CliArgsError) {
       return {
         exitCode: 2,
         stdout: "",
@@ -367,48 +364,27 @@ function successFooter(n: number): string {
 }
 
 /**
- * **JSON envelope contract** (Echo M4 round 1 on cortex#63):
+ * Per-agent metadata returned in the JSON envelope's `items` array.
+ * cortex#65 — F-3 retrofit to the shared `CliJsonEnvelope<T>` shape
+ * introduced in F-4 (cortex#64). Scripting consumers now see structurally
+ * identical envelopes across `cortex agents` and `cortex creds`:
  *
  * ```ts
- * interface AgentsJsonEnvelope {
- *   status: "ok" | "error";
- *   agents: AgentSummary[];      // ALWAYS present — empty array on error
- *   error?: { file: string; reason: string };  // present iff status === "error"
- * }
+ * { status: "ok" | "error", items: T[], error?: { reason, context? } }
  * ```
  *
- * Matches spec.md FR-1 verbatim. Scripting consumers can `.agents.map(…)`
- * without status-guarding when they don't care about errors, or check
- * `.status === "ok"` when they do.
+ * **Breaking change vs F-3 cycle 2:** the OLD F-3 envelope was
+ * `{status, agents: [], error?: {file, reason}}`. New shape uses `items`
+ * (not `agents`) and `error.context.file` (not `error.file`). F-3 only
+ * just merged (cortex#63), so this contract change is acceptable in the
+ * "no-external-consumers-yet" window per Echo M2 framing on cortex#64.
  */
-export interface AgentsJsonEnvelope {
-  status: "ok" | "error";
-  agents: ReturnType<typeof summarizeAgent>[];
-  error?: { file: string; reason: string };
-}
+export type AgentSummary = ReturnType<typeof summarizeAgent>;
 
 function jsonOk(agents: Agent[]): string {
-  const envelope: AgentsJsonEnvelope = {
-    status: "ok",
-    agents: agents.map(summarizeAgent),
-  };
-  return JSON.stringify(envelope, null, 2) + "\n";
+  return renderJson(envelopeOk<AgentSummary>(agents.map(summarizeAgent)));
 }
 
-function jsonError(file: string, reason: string): string {
-  const envelope: AgentsJsonEnvelope = {
-    status: "error",
-    agents: [], // M4 round 1: present-but-empty on error so consumers can iterate without status-checking
-    error: { file, reason },
-  };
-  return JSON.stringify(envelope, null, 2) + "\n";
-}
-
-/**
- * Unified error mapping for `FragmentLoadError`. Emits the canonical
- * envelope on stdout when `--json` is set, plain stderr otherwise. Exit
- * code is always 1 (validation failure).
- */
 function jsonOrTextError(
   err: FragmentLoadError,
   json: boolean,
@@ -417,7 +393,9 @@ function jsonOrTextError(
   if (json) {
     return {
       exitCode: 1,
-      stdout: jsonError(err.file, err.reason),
+      stdout: renderJson(
+        envelopeError<AgentSummary>(err.reason, { file: err.file }),
+      ),
       stderr: "",
     };
   }

--- a/src/cli/cortex/commands/creds.ts
+++ b/src/cli/cortex/commands/creds.ts
@@ -30,6 +30,7 @@ import { expandTilde } from "../../../common/config/loader";
 import { CliArgsError } from "./_shared/arg-error";
 import { envelopeError, envelopeOk, renderJson } from "./_shared/envelope";
 import { assertExhaustive } from "./_shared/assert-exhaustive";
+import { type ExitResult } from "./_shared/exit-result";
 
 // =============================================================================
 // Types
@@ -45,11 +46,10 @@ export interface ParsedCredsArgs {
   help: boolean;
 }
 
-export interface ExitResult {
-  exitCode: 0 | 1 | 2;
-  stdout: string;
-  stderr: string;
-}
+// ExitResult moved to `_shared/exit-result.ts` (cortex#65 — Echo round-2
+// duplication nit on cortex#64). Imported above. Kept re-export for any
+// external consumer that grabbed the type via `creds.ts` directly.
+export { type ExitResult } from "./_shared/exit-result";
 
 /**
  * Per-creds-file metadata returned in the JSON envelope's `items` array.


### PR DESCRIPTION
## Summary

Closes cortex#65 (F-3 retrofit to `_shared/{arg-error,envelope}.ts`) + the 3 advisory nits Echo left on cortex#64 round 2 that fit naturally into the same retrofit surface.

## F-3 retrofit (cortex#65 scope)

- Replaced local `AgentsArgsError` with `CliArgsError` from `_shared/arg-error.ts`. Backward-compat alias `export const AgentsArgsError = CliArgsError` retained.
- Replaced local `AgentsJsonEnvelope` with `CliJsonEnvelope<AgentSummary>` from `_shared/envelope.ts`. **Breaking change** for the JSON envelope shape (`agents` → `items`, `error.file` → `error.context.file`) — acceptable in the "no-external-consumers-yet" window since F-3 only just merged (cortex#63) per Echo's M2 framing.
- All 4 `throw new AgentsArgsError(...)` switched to `throw new CliArgsError("agents", ...)`.
- `dispatchAgents` catch matches `CliArgsError`.

## F-4 round-2 nits (Echo cortex#64 cycle 2)

- **ExitResult duplication** → extracted to new `src/cli/cortex/commands/_shared/exit-result.ts`. Both `creds.ts` and `agents.ts` import + re-export.
- **H1 cap untested** → 2 new tests covering the 10_000-entry boundary.
- **F-4 spec residuals** → Scenario 1 dropped `--local`; Scenario 2 cites cortex#67 instead of `cortex#TBD`.

## Cross-CLI envelope consistency

Scripting consumers can now pin against `CliJsonEnvelope<T>` for both `cortex agents` (T = AgentSummary) and `cortex creds` (T = CredsItem) with no per-CLI handling. The "scripting consumers don't need per-CLI handling" claim from F-4 spec.md FR-6 is now true.

## Test plan

- [x] `bun test src/cli/cortex/commands/__tests__/`: 154 pass / 0 fail
- [x] `bun test` full suite: 2261 pass / 1 fail (known pre-existing mission-control test)
- [x] `bunx tsc --noEmit`: clean

## Out of scope (still tracked)

- cortex#66 — generic `parseSubcommandArgs(spec, argv)` extract (larger design)
- cortex#67 — daemon-IPC for issue/revoke/rotate (blocked on cortex.ts evolution)

Closes cortex#65.

🤖 Generated with [Claude Code](https://claude.com/claude-code)