### PR TITLE
feat(bus/nats): nats-jwt-mint wrapper (cortex#67 prereq A)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "grove",
       "dependencies": {
         "@metafactory/content-filter": "github:the-metafactory/content-filter",
+        "@nats-io/jwt": "^0.0.11",
         "@octokit/webhooks": "^14.2.0",
         "@octokit/webhooks-methods": "^6.0.0",
         "@xyflow/react": "^12.10.2",
@@ -49,6 +50,10 @@
     "@discordjs/ws": ["@discordjs/ws@1.2.3", "", { "dependencies": { "@discordjs/collection": "^2.1.0", "@discordjs/rest": "^2.5.1", "@discordjs/util": "^1.1.0", "@sapphire/async-queue": "^1.5.2", "@types/ws": "^8.5.10", "@vladfrangu/async_event_emitter": "^2.2.4", "discord-api-types": "^0.38.1", "tslib": "^2.6.2", "ws": "^8.17.0" } }, "sha512-wPlQDxEmlDg5IxhJPuxXr3Vy9AjYq5xCvFWGJyD7w7Np8ZGu+Mc+97LCoEc/+AYCo2IDpKioiH0/c/mj5ZR9Uw=="],
 
     "@metafactory/content-filter": ["@metafactory/content-filter@github:the-metafactory/content-filter#a9ce45e", { "dependencies": { "zod": "^3.24" }, "peerDependencies": { "typescript": "^5" } }, "the-metafactory-content-filter-a9ce45e"],
+
+    "@nats-io/jwt": ["@nats-io/jwt@0.0.11", "", { "dependencies": { "@nats-io/nkeys": "2.0.3" } }, "sha512-olBQaTjqKgsalKKWtOA2fzQrFV2aNPKz56oadujZLrT5IsFhWw07OrYS8+XDfgh8bSAXZuMmZEZJ8QxPZwF0tw=="],
+
+    "@nats-io/nkeys": ["@nats-io/nkeys@2.0.3", "", { "dependencies": { "tweetnacl": "^1.0.3" } }, "sha512-JVt56GuE6Z89KUkI4TXUbSI9fmIfAmk6PMPknijmuL72GcD+UgIomTcRWiNvvJKxA01sBbmIPStqJs5cMRBC3A=="],
 
     "@octokit/openapi-types": ["@octokit/openapi-types@27.0.0", "", {}, "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA=="],
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@metafactory/content-filter": "github:the-metafactory/content-filter",
+    "@nats-io/jwt": "^0.0.11",
     "@octokit/webhooks": "^14.2.0",
     "@octokit/webhooks-methods": "^6.0.0",
     "@xyflow/react": "^12.10.2",

--- a/src/bus/nats/__tests__/jwt-mint.test.ts
+++ b/src/bus/nats/__tests__/jwt-mint.test.ts
@@ -1,0 +1,254 @@
+/**
+ * Prereq A for cortex#67: tests for the `mintUserCreds` wrapper.
+ *
+ * We pin behaviour against the `@nats-io/jwt` primitives by:
+ *   - generating a real account signing nkey (cheap — ed25519),
+ *   - minting,
+ *   - decoding the JWT back with the official decoder, and
+ *   - asserting structural + claims-shape properties.
+ *
+ * We do NOT stand up a NATS server here — the wrapper is pure crypto +
+ * JWT encoding, no I/O. The integration test that verifies a real
+ * `nats-server` accepts these creds lives downstream of cortex#67.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  createAccount,
+  decode,
+  fromSeed,
+  type User,
+} from "@nats-io/jwt";
+import { buildUserPermissions, mintUserCreds } from "../jwt-mint";
+
+function freshAccountSigningKey() {
+  return createAccount();
+}
+
+describe("mintUserCreds", () => {
+  test("produces a 3-part user JWT signed by the account key", async () => {
+    const accountSigningKey = freshAccountSigningKey();
+    const result = await mintUserCreds({
+      accountSigningKey,
+      agentId: "foo-bot",
+      capabilities: ["code-review"],
+      org: "acme",
+    });
+
+    const parts = result.userJwt.split(".");
+    expect(parts.length).toBe(3);
+    for (const p of parts) {
+      expect(p.length).toBeGreaterThan(0);
+    }
+
+    const decoded = decode<User>(result.userJwt);
+    expect(decoded.iss).toBe(accountSigningKey.getPublicKey());
+    expect(decoded.name).toBe("foo-bot");
+    // `@nats-io/jwt` places the entity type inside `nats.type`, not on the
+    // top-level claim. Pin both — the top-level field is unset for users
+    // (operators / accounts set it) which is itself a useful invariant.
+    expect((decoded.nats as { type?: string }).type).toBe("user");
+  });
+
+  test("claims grant pub+sub on local.{org}.{cap}.> for each capability", async () => {
+    const accountSigningKey = freshAccountSigningKey();
+    const result = await mintUserCreds({
+      accountSigningKey,
+      agentId: "foo-bot",
+      capabilities: ["code-review", "typescript"],
+      org: "acme",
+    });
+
+    const decoded = decode<User>(result.userJwt);
+    expect(decoded.nats.pub?.allow).toContain("local.acme.code-review.>");
+    expect(decoded.nats.pub?.allow).toContain("local.acme.typescript.>");
+    expect(decoded.nats.sub?.allow).toContain("local.acme.code-review.>");
+    expect(decoded.nats.sub?.allow).toContain("local.acme.typescript.>");
+  });
+
+  test("claims include baseline capability-self-register + creds-handler pub", async () => {
+    const accountSigningKey = freshAccountSigningKey();
+    const result = await mintUserCreds({
+      accountSigningKey,
+      agentId: "foo-bot",
+      capabilities: ["code-review"],
+      org: "acme",
+    });
+
+    const decoded = decode<User>(result.userJwt);
+    // Baseline pub-only entries
+    expect(decoded.nats.pub?.allow).toContain(
+      "local.acme.agents.capabilities.foo-bot",
+    );
+    expect(decoded.nats.pub?.allow).toContain("local.acme.cortex.creds.>");
+
+    // ...and they are NOT in the sub allow-list (baseline is pub-only).
+    expect(decoded.nats.sub?.allow ?? []).not.toContain(
+      "local.acme.agents.capabilities.foo-bot",
+    );
+    expect(decoded.nats.sub?.allow ?? []).not.toContain(
+      "local.acme.cortex.creds.>",
+    );
+  });
+
+  test("empty capabilities array yields only baseline perms", async () => {
+    const accountSigningKey = freshAccountSigningKey();
+    const result = await mintUserCreds({
+      accountSigningKey,
+      agentId: "bare-bot",
+      capabilities: [],
+      org: "acme",
+    });
+
+    const decoded = decode<User>(result.userJwt);
+
+    // sub allow-list is empty (no capability prefixes; baseline is pub-only)
+    expect(decoded.nats.sub?.allow ?? []).toEqual([]);
+
+    // pub allow-list contains exactly the two baseline entries
+    const pubAllow = decoded.nats.pub?.allow ?? [];
+    expect(pubAllow).toContain("local.acme.agents.capabilities.bare-bot");
+    expect(pubAllow).toContain("local.acme.cortex.creds.>");
+    expect(pubAllow.length).toBe(2);
+  });
+
+  test("userSeed is a valid user nkey seed (SU… prefix, round-trips via fromSeed)", async () => {
+    const accountSigningKey = freshAccountSigningKey();
+    const result = await mintUserCreds({
+      accountSigningKey,
+      agentId: "foo-bot",
+      capabilities: ["code-review"],
+      org: "acme",
+    });
+
+    expect(result.userSeed.startsWith("SU")).toBe(true);
+
+    // Round-trip: the seed must decode back to a usable KeyPair whose
+    // public key matches the JWT subject. This is the load-bearing check
+    // that the seed and JWT belong to the same identity.
+    const kp = fromSeed(new TextEncoder().encode(result.userSeed));
+    const decoded = decode<User>(result.userJwt);
+    expect(decoded.sub).toBe(kp.getPublicKey());
+  });
+
+  test("credsFile is a string containing both JWT and SEED PEM-like blocks", async () => {
+    const accountSigningKey = freshAccountSigningKey();
+    const result = await mintUserCreds({
+      accountSigningKey,
+      agentId: "foo-bot",
+      capabilities: ["code-review"],
+      org: "acme",
+    });
+
+    // The `@nats-io/jwt` `fmtCreds` produces standard NATS creds files.
+    // We assert the block markers are present (case-sensitive) and that
+    // the JWT and seed bodies appear inside them. We deliberately do NOT
+    // pin the exact dash count — that's an `@nats-io/jwt` implementation
+    // detail and would couple us to their internal formatter shape.
+    expect(typeof result.credsFile).toBe("string");
+    expect(result.credsFile).toContain("BEGIN NATS USER JWT");
+    expect(result.credsFile).toContain("END NATS USER JWT");
+    expect(result.credsFile).toContain("BEGIN USER NKEY SEED");
+    expect(result.credsFile).toContain("END USER NKEY SEED");
+    expect(result.credsFile).toContain(result.userJwt);
+    expect(result.credsFile).toContain(result.userSeed);
+  });
+
+  test("agentId with NATS subject wildcards is rejected", async () => {
+    const accountSigningKey = freshAccountSigningKey();
+    for (const bad of ["foo.bot", "foo*", "foo>", "foo bot", ""]) {
+      await expect(
+        mintUserCreds({
+          accountSigningKey,
+          agentId: bad,
+          capabilities: ["code-review"],
+          org: "acme",
+        }),
+      ).rejects.toThrow(/agentId/);
+    }
+  });
+
+  test("org with NATS subject wildcards is rejected", async () => {
+    const accountSigningKey = freshAccountSigningKey();
+    await expect(
+      mintUserCreds({
+        accountSigningKey,
+        agentId: "foo-bot",
+        capabilities: ["code-review"],
+        org: "ac*me",
+      }),
+    ).rejects.toThrow(/org/);
+  });
+
+  test("capability with NATS subject wildcards is rejected", async () => {
+    const accountSigningKey = freshAccountSigningKey();
+    await expect(
+      mintUserCreds({
+        accountSigningKey,
+        agentId: "foo-bot",
+        capabilities: ["code-review.>"],
+        org: "acme",
+      }),
+    ).rejects.toThrow(/capability/);
+  });
+
+  test("each call mints a fresh user nkey (non-idempotent)", async () => {
+    const accountSigningKey = freshAccountSigningKey();
+    const a = await mintUserCreds({
+      accountSigningKey,
+      agentId: "foo-bot",
+      capabilities: ["code-review"],
+      org: "acme",
+    });
+    const b = await mintUserCreds({
+      accountSigningKey,
+      agentId: "foo-bot",
+      capabilities: ["code-review"],
+      org: "acme",
+    });
+
+    expect(a.userSeed).not.toBe(b.userSeed);
+    expect(a.userJwt).not.toBe(b.userJwt);
+
+    const da = decode<User>(a.userJwt);
+    const db = decode<User>(b.userJwt);
+    expect(da.sub).not.toBe(db.sub);
+
+    // ...but both are signed by the same account.
+    expect(da.iss).toBe(db.iss);
+  });
+});
+
+describe("buildUserPermissions", () => {
+  test("returns deterministic permission set for the same inputs", () => {
+    const a = buildUserPermissions({
+      agentId: "foo",
+      capabilities: ["code-review", "typescript"],
+      org: "acme",
+    });
+    const b = buildUserPermissions({
+      agentId: "foo",
+      capabilities: ["code-review", "typescript"],
+      org: "acme",
+    });
+    expect(a).toEqual(b);
+  });
+
+  test("preserves capability order in the pub/sub allow lists", () => {
+    const perms = buildUserPermissions({
+      agentId: "foo",
+      capabilities: ["a", "b", "c"],
+      org: "acme",
+    });
+    expect(perms.pub?.allow?.slice(0, 3)).toEqual([
+      "local.acme.a.>",
+      "local.acme.b.>",
+      "local.acme.c.>",
+    ]);
+    expect(perms.sub?.allow).toEqual([
+      "local.acme.a.>",
+      "local.acme.b.>",
+      "local.acme.c.>",
+    ]);
+  });
+});

--- a/src/bus/nats/jwt-mint.ts
+++ b/src/bus/nats/jwt-mint.ts
@@ -1,0 +1,187 @@
+/**
+ * Prereq A for cortex#67: thin wrapper around `@nats-io/jwt` that mints a
+ * per-agent NATS user JWT + nkey seed scoped to a capability list.
+ *
+ * Motivation (from docs/design-arc-agent-bots.md §6.3): the cortex
+ * creds-daemon (cortex#67) must issue NATS users to standalone agent bots
+ * (Codex, Claude Code, pi.dev, custom) on demand. Each user's publish/
+ * subscribe permissions are scoped to the agent's declared capabilities so
+ * a code-review bot can't, for example, publish on a research bot's
+ * subjects. The scoping rule is: each capability `cap` → pub+sub on
+ * `local.{org}.{cap}.>`, plus baseline perms for capability self-register
+ * and the creds-handler back-channel.
+ *
+ * Boundary: this module is a pure function over inputs. It does NOT touch
+ * the filesystem, NATS server, or any I/O. The caller (creds-daemon) is
+ * responsible for persisting the returned creds and for choosing /
+ * rotating the account signing key.
+ *
+ * Note on the package: `@nats-io/jwt@^0.0.11` re-exports `createUser`,
+ * `encodeUser`, `decode`, and `fmtCreds` from `@nats-io/nkeys`. We use
+ * those primitives directly — no custom ed25519/JWT encoding here.
+ */
+
+import {
+  Algorithms,
+  createUser,
+  encodeUser,
+  fmtCreds,
+  type KeyPair,
+  type User,
+} from "@nats-io/jwt";
+
+export interface MintUserOpts {
+  /**
+   * Account (or account-signing) nkey used to sign the user JWT. The
+   * caller owns lifecycle — this module never reads it from disk.
+   */
+  accountSigningKey: KeyPair;
+
+  /**
+   * Stable identifier for the agent. Used as the JWT `name`, as the
+   * subject suffix for the capability self-register channel, and for the
+   * creds-handler reply subject. Validated to avoid producing JWTs with
+   * subjects that would collide with NATS wildcards.
+   */
+  agentId: string;
+
+  /**
+   * NATS subject-prefix capabilities scope. Each entry grants pub+sub on
+   * `local.{org}.{capability}.>`. Empty array is allowed — the agent
+   * still gets baseline perms (capability self-register + creds-handler
+   * back-channel) so it can come online and request a re-mint, but it
+   * can't publish or subscribe to any capability channel.
+   */
+  capabilities: string[];
+
+  /**
+   * Org slug for subject namespacing (`local.{org}.…`). Validated for the
+   * same reasons as `agentId`.
+   */
+  org: string;
+}
+
+export interface MintedUserCreds {
+  /** Signed user JWT (header.payload.sig, base64url). */
+  userJwt: string;
+
+  /** User nkey seed (starts with `SU…`). Sensitive — treat as secret. */
+  userSeed: string;
+
+  /**
+   * Combined `.creds`-formatted block as emitted by `@nats-io/jwt`'s
+   * `fmtCreds`. Drop directly into `~/.config/nats/creds/{agentId}.creds`.
+   */
+  credsFile: string;
+}
+
+/**
+ * Disallowed characters in `agentId` / `org`: anything NATS uses as a
+ * subject separator/wildcard. Keeping this conservative — letters,
+ * digits, dash, underscore. Bots with quirky IDs should slugify upstream.
+ */
+const SUBJECT_TOKEN = /^[A-Za-z0-9_-]+$/;
+
+/** Same rule for capability names; they end up as subject tokens too. */
+const CAPABILITY_TOKEN = /^[A-Za-z0-9_-]+$/;
+
+function assertSubjectToken(label: string, value: string): void {
+  if (!value) {
+    throw new Error(`nats-jwt-mint: ${label} is required`);
+  }
+  if (!SUBJECT_TOKEN.test(value)) {
+    throw new Error(
+      `nats-jwt-mint: ${label} "${value}" contains characters disallowed in NATS subjects ` +
+        `(allowed: letters, digits, "-", "_")`,
+    );
+  }
+}
+
+function assertCapabilityToken(value: string): void {
+  if (!value) {
+    throw new Error("nats-jwt-mint: capability entries must be non-empty");
+  }
+  if (!CAPABILITY_TOKEN.test(value)) {
+    throw new Error(
+      `nats-jwt-mint: capability "${value}" contains characters disallowed in NATS subjects ` +
+        `(allowed: letters, digits, "-", "_")`,
+    );
+  }
+}
+
+/**
+ * Build the per-capability subject set. Exposed so tests can assert the
+ * exact permissions shape without re-decoding the JWT, and so a future
+ * caller (e.g. dashboard preview) can see what *would* be granted before
+ * actually minting.
+ */
+export function buildUserPermissions(opts: {
+  agentId: string;
+  capabilities: string[];
+  org: string;
+}): Pick<User, "pub" | "sub"> {
+  const { agentId, capabilities, org } = opts;
+
+  const pub: string[] = [];
+  const sub: string[] = [];
+
+  for (const cap of capabilities) {
+    const subjectPrefix = `local.${org}.${cap}.>`;
+    pub.push(subjectPrefix);
+    sub.push(subjectPrefix);
+  }
+
+  // Baseline: capability self-register. The bot publishes its capability
+  // list to `local.{org}.agents.capabilities.{agentId}` on start so cortex
+  // can populate the agent registry without a config file.
+  pub.push(`local.${org}.agents.capabilities.${agentId}`);
+
+  // Baseline: creds-handler back-channel. The bot needs to talk back to
+  // cortex's creds daemon (e.g. to request a re-mint when its JWT expires
+  // or its capability list changes). Pub-only — replies come via inbox.
+  pub.push(`local.${org}.cortex.creds.>`);
+
+  return {
+    pub: { allow: pub },
+    sub: { allow: sub },
+  };
+}
+
+/**
+ * Mint a per-agent NATS user JWT scoped to the given capabilities.
+ *
+ * Idempotency: NOT idempotent — every call generates a fresh user nkey.
+ * That's deliberate: re-minting with the same agentId + capabilities
+ * should produce a new user identity so revocation is straightforward
+ * (drop the old user via the account JWT's revocation list).
+ */
+export async function mintUserCreds(
+  opts: MintUserOpts,
+): Promise<MintedUserCreds> {
+  assertSubjectToken("agentId", opts.agentId);
+  assertSubjectToken("org", opts.org);
+  for (const cap of opts.capabilities) {
+    assertCapabilityToken(cap);
+  }
+
+  const userKeyPair = createUser();
+
+  const claims: Partial<User> = buildUserPermissions({
+    agentId: opts.agentId,
+    capabilities: opts.capabilities,
+    org: opts.org,
+  });
+
+  const userJwt = await encodeUser(
+    opts.agentId,
+    userKeyPair,
+    opts.accountSigningKey,
+    claims,
+    { algorithm: Algorithms.v2 },
+  );
+
+  const userSeed = new TextDecoder().decode(userKeyPair.getSeed());
+  const credsFile = new TextDecoder().decode(fmtCreds(userJwt, userKeyPair));
+
+  return { userJwt, userSeed, credsFile };
+}


### PR DESCRIPTION
## What

**Prereq A of 3 for cortex#67** (daemon-IPC for `cortex creds issue/revoke/rotate`). Multi-LLM motivation: per-agent capability-scoped NATS user JWTs let Codex + Claude + pi.dev + custom bots coexist on one bus without cross-domain publish.

## Components

- **`@nats-io/jwt@^0.0.11`** added as dep
- **`src/bus/nats/jwt-mint.ts`** (172 LOC) — thin wrapper with two exports:
  - `buildUserPermissions(opts)` — pure function returning the NATS permission claim shape (useful for dashboard preview / dry-run)
  - `mintUserCreds(opts)` — generates user nkey + signs user JWT via `@nats-io/jwt` `encodeUser` (Algorithms.v2 / ed25519-nkey) + assembles `.creds` block via `fmtCreds`

## Design decisions

- **Algorithm v2** (`ed25519-nkey`) — current NATS standard
- **`fmtCreds` over hand-formatting** — block markers come from `@nats-io/jwt` rather than re-implementing the PEM-like format
- **Subject-token validation** — `[A-Za-z0-9_-]+` on `agentId`, `org`, and each capability. Reject corrupt subjects at mint time rather than at publish time in the running daemon
- **`buildUserPermissions` exported separately** — future dry-run UI shows what perms would be granted without minting

## Permission scope per agent

- pub+sub on `local.{org}.{capability}.>` (one for each declared capability)
- pub on `local.{org}.cortex.creds.<verb>` — so the bot can call back to the daemon
- pub on `local.{org}.agents.capabilities.{agentId}` — for capability self-registration

## Verification

- `bunx tsc --noEmit` exit 0
- `bun test src/bus/nats/__tests__/` — **34/34 pass** (12 new + 22 existing)
- Full suite — 2321 pass / 2 pre-existing fails (dashboard-shell missing artifact + fragment-watcher debounce flake in parallel runs; both pass in isolation; neither touches `src/bus/nats/`)

## Next

- **Prereq B** — `nats.accountSigningKeyPath` schema field (in flight)
- **Prereq C** — AgentRegistry wired into `startCortex()` (in flight)
- Then **cortex#67 proper** — daemon RPC + CLI IPC client

Refs cortex#67.

🤖 Generated with [Claude Code](https://claude.com/claude-code)