### PR TITLE
feat(common): nats.accountSigningKeyPath schema + chmod 600 loader (cortex#67 prereq B)

### DIFF
--- a/src/common/config/__tests__/account-signing-key.test.ts
+++ b/src/common/config/__tests__/account-signing-key.test.ts
@@ -1,0 +1,181 @@
+/**
+ * C-108 (Prereq B for cortex#67): tests for the operator account signing
+ * key loader.
+ *
+ * Coverage maps to the four spec bullets:
+ *   1. Valid SA-prefixed seed at chmod 600 → succeeds, returns KeyPair.
+ *   2. chmod 644 → throws "must be chmod 600".
+ *   3. Wrong prefix (SO / SU / SP) → throws "expected SA...".
+ *   4. Missing file → throws ENOENT.
+ *
+ * Plus one cross-check: the loaded KeyPair's `getPublicKey()` matches what
+ * a fresh `fromSeed()` on the same bytes produces — i.e. we didn't silently
+ * mangle the seed during read/trim.
+ *
+ * Test seeds are generated fresh per-suite via `createAccount()` so we don't
+ * commit real-looking key material into the repo. The tmpdir is wiped in
+ * `afterEach` so successive runs (and parallel test runs) don't collide.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { chmodSync, mkdirSync, rmSync, writeFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { createAccount, createOperator, createUser, fromSeed } from "nkeys.js";
+import { loadAccountSigningKey } from "../account-signing-key";
+
+let testDir: string;
+
+beforeEach(() => {
+  testDir = join(tmpdir(), `cortex-asknk-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(testDir, { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(testDir, { recursive: true, force: true });
+});
+
+/**
+ * Write a fresh seed file at the given mode. Returns `{ path, seed }` so
+ * tests can both load the file *and* assert against the originating seed
+ * (for the public-key round-trip check).
+ */
+function writeSeedFile(filename: string, seed: string, mode: number): { path: string; seed: string } {
+  const path = join(testDir, filename);
+  writeFileSync(path, seed);
+  chmodSync(path, mode);
+  return { path, seed };
+}
+
+function newAccountSeed(): string {
+  // `getSeed()` returns the seed bytes (ASCII base32); decode to string for
+  // file writing. NATS nkey seeds are always pure ASCII so UTF-8 decode is
+  // lossless.
+  const kp = createAccount();
+  return new TextDecoder().decode(kp.getSeed());
+}
+
+function newOperatorSeed(): string {
+  return new TextDecoder().decode(createOperator().getSeed());
+}
+
+function newUserSeed(): string {
+  return new TextDecoder().decode(createUser().getSeed());
+}
+
+// ---------------------------------------------------------------------------
+// Happy path
+// ---------------------------------------------------------------------------
+
+describe("loadAccountSigningKey — happy path", () => {
+  test("loads valid SA-prefixed seed at chmod 600", async () => {
+    const seed = newAccountSeed();
+    expect(seed.startsWith("SA")).toBe(true); // sanity: helper produced an account seed
+
+    const { path } = writeSeedFile("account.nk", seed, 0o600);
+    const kp = await loadAccountSigningKey(path);
+
+    // KeyPair is the duck-typed interface from nkeys.js; the public-account
+    // prefix on the *public key* side is `A` (Prefix.Account encodes to A...).
+    expect(kp.getPublicKey().startsWith("A")).toBe(true);
+  });
+
+  test("trims trailing newline before parsing", async () => {
+    // Real-world: `nsc generate nkey -a > account.nk` leaves a trailing \n.
+    // If the loader doesn't trim, `fromSeed` rejects the bytes.
+    const seed = newAccountSeed();
+    const { path } = writeSeedFile("account.nk", seed + "\n", 0o600);
+    const kp = await loadAccountSigningKey(path);
+    expect(kp.getPublicKey().startsWith("A")).toBe(true);
+  });
+
+  test("loaded KeyPair public key matches direct fromSeed()", async () => {
+    // Cross-check: the path through the loader must be observationally
+    // identical to calling fromSeed() on the same bytes. Catches a class
+    // of bugs where the loader subtly mutates the seed (e.g. trims more
+    // than whitespace) and silently produces a different KeyPair.
+    const seed = newAccountSeed();
+    const { path } = writeSeedFile("account.nk", seed, 0o600);
+    const loaded = await loadAccountSigningKey(path);
+    const direct = fromSeed(new TextEncoder().encode(seed));
+    expect(loaded.getPublicKey()).toBe(direct.getPublicKey());
+  });
+});
+
+// ---------------------------------------------------------------------------
+// chmod gate
+// ---------------------------------------------------------------------------
+
+describe("loadAccountSigningKey — chmod gate", () => {
+  test("throws clear error when mode is 0644", async () => {
+    if (process.platform === "win32") return; // gate doesn't run on Windows
+    const seed = newAccountSeed();
+    const { path } = writeSeedFile("account.nk", seed, 0o644);
+    await expect(loadAccountSigningKey(path)).rejects.toThrow(/must be chmod 600/);
+    await expect(loadAccountSigningKey(path)).rejects.toThrow(/644/);
+  });
+
+  test("throws when mode is 0640 (group readable)", async () => {
+    if (process.platform === "win32") return;
+    const seed = newAccountSeed();
+    const { path } = writeSeedFile("account.nk", seed, 0o640);
+    await expect(loadAccountSigningKey(path)).rejects.toThrow(/must be chmod 600/);
+  });
+
+  test("throws when mode is 0666 (world writable)", async () => {
+    if (process.platform === "win32") return;
+    const seed = newAccountSeed();
+    const { path } = writeSeedFile("account.nk", seed, 0o666);
+    await expect(loadAccountSigningKey(path)).rejects.toThrow(/must be chmod 600/);
+  });
+
+  test("throws when mode is 0700 (owner-executable, still wrong)", async () => {
+    // 0700 is too permissive in the "executable" axis even though group/world
+    // see nothing. We want exactly 0600 — anything else is a typo.
+    if (process.platform === "win32") return;
+    const seed = newAccountSeed();
+    const { path } = writeSeedFile("account.nk", seed, 0o700);
+    await expect(loadAccountSigningKey(path)).rejects.toThrow(/must be chmod 600/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Prefix gate
+// ---------------------------------------------------------------------------
+
+describe("loadAccountSigningKey — prefix gate", () => {
+  test("rejects operator seed (SO prefix)", async () => {
+    const seed = newOperatorSeed();
+    expect(seed.startsWith("SO")).toBe(true);
+    const { path } = writeSeedFile("operator.nk", seed, 0o600);
+    await expect(loadAccountSigningKey(path)).rejects.toThrow(/expected account signing key/);
+    await expect(loadAccountSigningKey(path)).rejects.toThrow(/SA\.\.\./);
+    await expect(loadAccountSigningKey(path)).rejects.toThrow(/SO\.\.\./);
+  });
+
+  test("rejects user seed (SU prefix)", async () => {
+    const seed = newUserSeed();
+    expect(seed.startsWith("SU")).toBe(true);
+    const { path } = writeSeedFile("user.nk", seed, 0o600);
+    await expect(loadAccountSigningKey(path)).rejects.toThrow(/expected account signing key/);
+    await expect(loadAccountSigningKey(path)).rejects.toThrow(/SU\.\.\./);
+  });
+
+  test("rejects garbage seed (SP-shaped placeholder)", async () => {
+    // A made-up "SP..." string the loader should reject *before* it hits
+    // nkeys.fromSeed (the prefix gate runs first).
+    const { path } = writeSeedFile("garbage.nk", "SPAAAAAAAAAAAAAAAAAAAAAA", 0o600);
+    await expect(loadAccountSigningKey(path)).rejects.toThrow(/expected account signing key/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Missing file
+// ---------------------------------------------------------------------------
+
+describe("loadAccountSigningKey — missing file", () => {
+  test("throws ENOENT-flavored error", async () => {
+    const path = join(testDir, "does-not-exist.nk");
+    await expect(loadAccountSigningKey(path)).rejects.toThrow(/ENOENT|no such file/i);
+  });
+});

--- a/src/common/config/account-signing-key.ts
+++ b/src/common/config/account-signing-key.ts
@@ -1,0 +1,133 @@
+/**
+ * C-108 (Prereq B for cortex#67): operator account signing key loader.
+ *
+ * The operator's account signing key (NATS "SA"-prefixed nkey seed) is what
+ * mints per-agent NATS user JWTs (cortex#58 D7 + §6.3, design-arc-agent-bots).
+ * It is the most sensitive key material the cortex daemon holds — it never
+ * leaves daemon memory, is never logged, and is never persisted to disk by
+ * cortex itself.
+ *
+ * Threat model (one paragraph): a leaked account signing key lets an attacker
+ * mint user JWTs for any agent in the operator's account, bypassing every
+ * cortex-side authorization check. Since the key sits on the operator's
+ * laptop / server filesystem, the next-best mitigation is to refuse to load
+ * it unless the file is chmod 600 (owner-only read/write). This loader
+ * enforces that gate; the schema field (`nats.accountSigningKeyPath`) is
+ * MIRRORed across `BotConfigSchema.nats` + `NatsConfigSchema` so both the
+ * legacy bot.yaml shape and the post-MIG-7.2e cortex-config shape carry it.
+ *
+ * Behavior:
+ *   - `fs.statSync(path).mode & 0o777` MUST equal `0o600` (POSIX). On
+ *     Windows, the chmod gate is logged and skipped — NTFS uses ACLs
+ *     instead, and the macOS/Linux mode bits we read there are always
+ *     `0o666`. The expectation is that operators on Windows manage ACLs
+ *     out-of-band; supporting Windows is a soft goal here, not a target
+ *     platform for the daemon.
+ *   - The seed file is read, trimmed of whitespace (operators tend to
+ *     leave a trailing newline), and parsed via `nkeys.fromSeed`.
+ *   - The parsed seed MUST be account-prefixed ("SA..."). Operator
+ *     signing keys ("SO...") and user signing keys ("SU...") are
+ *     rejected — the design wants the operator's *account* signing key,
+ *     not the operator root key, because account-level signing is what
+ *     scopes minted JWTs to the operator's account.
+ *
+ * NOT covered here (deferred to C-067 itself):
+ *   - In-memory zeroization after use. The KeyPair is held for the
+ *     daemon lifetime; we revisit when we add credential rotation.
+ *   - Hardware-backed signing (yubikey / TPM). Future work; the
+ *     `loadAccountSigningKey` signature is the seam.
+ *
+ * MIRROR: schema field carried in both `BotConfigSchema.nats` + the
+ * canonical `NatsConfigSchema`. Drop legacy on MIG-7.2e.
+ */
+
+import { promises as fsp, statSync } from "fs";
+import { fromSeed, type KeyPair } from "nkeys.js";
+
+/**
+ * Octal mode mask for the POSIX permission bits we care about. The full
+ * stat `mode` field also encodes the file type (regular, dir, symlink),
+ * so we mask before comparing.
+ */
+const POSIX_MODE_MASK = 0o777;
+
+/**
+ * Expected mode for the account signing key file: owner-only read/write.
+ */
+const REQUIRED_MODE = 0o600;
+
+/**
+ * Account signing key seed prefix. NATS nkey seeds for an *account* always
+ * start with `SA` (Seed + Account prefix bytes, base32-encoded). Operator
+ * seeds are `SO`, user seeds are `SU`, server seeds are `SN`, etc. We want
+ * the account one specifically — see file header.
+ */
+const ACCOUNT_SEED_PREFIX = "SA";
+
+/**
+ * Load + validate the operator's account signing nkey from disk.
+ *
+ * Throws (with a clear, operator-facing message) on:
+ *   - File missing / unreadable (propagates ENOENT / EACCES).
+ *   - chmod not exactly `0600` on POSIX (no group / world access).
+ *   - Seed not prefixed `SA` (i.e. not an account seed).
+ *   - Seed bytes that `nkeys.fromSeed` rejects as malformed.
+ *
+ * @param path Absolute or process-relative path to the seed file.
+ * @returns A KeyPair ready for `sign(input)` calls.
+ */
+export async function loadAccountSigningKey(path: string): Promise<KeyPair> {
+  // 1. Permission gate. Sync `statSync` keeps the check tight (one syscall
+  //    inline with the read) and avoids a TOCTOU window between stat + open
+  //    being any wider than it has to be. On Windows the mode bits are not
+  //    meaningful — gate it behind the platform check rather than fail
+  //    every Windows operator.
+  if (process.platform !== "win32") {
+    const stat = statSync(path); // throws ENOENT here if the path is bogus
+    const mode = stat.mode & POSIX_MODE_MASK;
+    if (mode !== REQUIRED_MODE) {
+      throw new Error(
+        `account signing key ${path} must be chmod 600, found ${mode.toString(8).padStart(3, "0")}`,
+      );
+    }
+  } else {
+    // Best-effort note on Windows. We still want to load the key so the
+    // daemon runs there for dev, but we want the operator to know we
+    // didn't enforce the permission gate. `process.stderr.write` because
+    // there is no logger threaded in here yet (loader is intentionally
+    // dependency-free).
+    process.stderr.write(
+      `[account-signing-key] chmod 600 gate skipped on win32 — NTFS ACLs are the operator's responsibility (${path})\n`,
+    );
+  }
+
+  // 2. Read + trim. Operators routinely leave a trailing newline after
+  //    `nsc generate nkey -a > account.nk`; `fromSeed` would reject the
+  //    raw bytes if we passed them as-is.
+  const raw = await fsp.readFile(path, "utf-8");
+  const seed = raw.trim();
+
+  // 3. Prefix gate. `nkeys.fromSeed` will accept anything that decodes
+  //    cleanly, including operator/user/server seeds — so we have to
+  //    enforce the SA prefix ourselves. Reject early with a clear error
+  //    that tells the operator which kind of key they handed us.
+  if (!seed.startsWith(ACCOUNT_SEED_PREFIX)) {
+    const actualPrefix = seed.slice(0, 2);
+    throw new Error(
+      `expected account signing key (prefix ${ACCOUNT_SEED_PREFIX}...), got ${actualPrefix}... at ${path}`,
+    );
+  }
+
+  // 4. Parse. `fromSeed` expects Uint8Array; we encode the trimmed string
+  //    via TextEncoder (UTF-8 is identical to ASCII for the base32
+  //    alphabet nkey seeds live in).
+  const seedBytes = new TextEncoder().encode(seed);
+  try {
+    return fromSeed(seedBytes);
+  } catch (err) {
+    // Re-throw with the path attached so operators can pinpoint the
+    // bad file when they have multiple nkey files staged.
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(`failed to parse account signing key at ${path}: ${message}`);
+  }
+}

--- a/src/common/types/__tests__/cortex-config.test.ts
+++ b/src/common/types/__tests__/cortex-config.test.ts
@@ -313,6 +313,75 @@ describe("NatsConfigSchema", () => {
       publicKey: "U" + "abcdefghijklmnopqrstuvwxyz".padEnd(55, "A"),
     })).toThrow();
   });
+
+  // C-108 (Prereq B for cortex#67): the account signing key path field is
+  // optional, accepts a string path, and parses through unchanged. We don't
+  // validate the path's contents at schema time — that's the loader's job
+  // (`src/common/config/account-signing-key.ts`). Schema only carries the
+  // shape; runtime owns the chmod + prefix gates.
+
+  test("accountSigningKeyPath is optional (absent → undefined)", () => {
+    const parsed = NatsConfigSchema.parse({ url: "nats://localhost:4222" });
+    expect(parsed.accountSigningKeyPath).toBeUndefined();
+  });
+
+  test("accountSigningKeyPath accepts a string path", () => {
+    const parsed = NatsConfigSchema.parse({
+      url: "nats://localhost:4222",
+      accountSigningKeyPath: "/etc/cortex/account-signing.nk",
+    });
+    expect(parsed.accountSigningKeyPath).toBe("/etc/cortex/account-signing.nk");
+  });
+
+  test("accountSigningKeyPath rejects non-string", () => {
+    expect(() => NatsConfigSchema.parse({
+      url: "nats://localhost:4222",
+      accountSigningKeyPath: 42,
+    })).toThrow();
+  });
+});
+
+// =============================================================================
+// BotConfigSchema.nats.accountSigningKeyPath — MIRROR of cortex-config field
+// =============================================================================
+//
+// We MIRROR the field across both schemas during the MIG-7.2 overlap window.
+// Asserting the legacy schema accepts it (and round-trips it) protects against
+// drift — if someone edits one schema and forgets the other, this test fails.
+
+describe("BotConfigSchema.nats.accountSigningKeyPath (MIRROR)", () => {
+  /** Minimal BotConfig shell to exercise the optional `nats` block. */
+  function minBotConfig(natsExtras: Record<string, unknown> = {}) {
+    return {
+      agent: { name: "test", displayName: "Test", operatorId: "op" },
+      discord: [],
+      mattermost: [],
+      claude: { timeoutMs: 1000 },
+      paths: { publishedEventsDir: "/tmp/x" },
+      nats: {
+        url: "nats://localhost:4222",
+        ...natsExtras,
+      },
+    };
+  }
+
+  test("absent on legacy BotConfig.nats → undefined", () => {
+    const parsed = BotConfigSchema.parse(minBotConfig());
+    expect(parsed.nats?.accountSigningKeyPath).toBeUndefined();
+  });
+
+  test("accepts a string path on legacy BotConfig.nats", () => {
+    const parsed = BotConfigSchema.parse(
+      minBotConfig({ accountSigningKeyPath: "/etc/cortex/account-signing.nk" }),
+    );
+    expect(parsed.nats?.accountSigningKeyPath).toBe("/etc/cortex/account-signing.nk");
+  });
+
+  test("rejects non-string on legacy BotConfig.nats", () => {
+    expect(() => BotConfigSchema.parse(
+      minBotConfig({ accountSigningKeyPath: 42 }),
+    )).toThrow();
+  });
 });
 
 // =============================================================================

--- a/src/common/types/config.ts
+++ b/src/common/types/config.ts
@@ -453,6 +453,16 @@ export const BotConfigSchema = z.object({
      * single template works across operators.
      */
     subjects: z.array(z.string().min(1)).default([]),
+    /**
+     * Absolute path to operator account signing nkey file. Loaded into
+     * daemon memory only. File MUST be chmod 600 (loader enforces).
+     * Optional — when absent, cortex creds mutation subcommands return
+     * exit 2.
+     *
+     * MIRROR: `NatsConfigSchema.accountSigningKeyPath` in
+     * `./cortex-config.ts`. Drop both on MIG-7.2e.
+     */
+    accountSigningKeyPath: z.string().optional(),
   }).optional(),
 
   /**

--- a/src/common/types/cortex-config.ts
+++ b/src/common/types/cortex-config.ts
@@ -463,6 +463,21 @@ export const NatsConfigSchema = z.object({
   subjects: z.array(z.string().min(1)).default([]),
   /** Optional NKey identity for envelope signing (MY-400). */
   identity: NatsIdentitySchema.optional(),
+  /**
+   * Absolute path to operator account signing nkey file. Loaded into daemon
+   * memory only. File MUST be chmod 600 (loader enforces). Optional — when
+   * absent, cortex creds mutation subcommands return exit 2.
+   *
+   * The account signing key is what mints per-agent NATS user JWTs (C-067,
+   * cortex#58 D7 + §6.3). It is the most sensitive key material cortex
+   * holds; it must never be logged, persisted to disk by cortex, or shipped
+   * to any renderer. See `src/common/config/account-signing-key.ts` for the
+   * loader that enforces chmod 600 and SA-prefix.
+   *
+   * MIRROR: `BotConfigSchema.nats.accountSigningKeyPath` in `./config.ts`.
+   * Drop both on MIG-7.2e.
+   */
+  accountSigningKeyPath: z.string().optional(),
 });
 
 export type NatsConfig = z.infer<typeof NatsConfigSchema>;


### PR DESCRIPTION
## What

**Prereq B of 3 for cortex#67**. Adds the config field that tells the cortex daemon where to find the operator account signing nkey, plus the loader that enforces chmod 600 file perms.

## Schema (MIRRORed)

- `src/common/types/config.ts:BotConfigSchema.nats.accountSigningKeyPath` — legacy
- `src/common/types/cortex-config.ts:NatsConfigSchema.accountSigningKeyPath` — canonical post-MIG-7.2

Both optional. Both carry MIRROR breadcrumb per established pattern. Canonical schema has full JSDoc on motivation + chmod 600 contract + exit-2 contract for absent path.

## Loader (`src/common/config/account-signing-key.ts`)

`loadAccountSigningKey(path): Promise<KeyPair>` — four gates:

1. **chmod 600** (POSIX-only; Windows logs warning + skips)
2. **Read + trim**
3. **`SA` prefix gate** (account signing key; rejects SO/SU/garbage)
4. **`nkeys.fromSeed` parse** (returns `KeyPair`)

Imports `KeyPair` + `fromSeed` from `nkeys.js` (transitive via `nats@2.29.3`). No new dependency.

## Tests

- **`__tests__/account-signing-key.test.ts`** — 11 cases: happy path (incl. trailing-newline + direct-fromSeed cross-check), chmod gate (0644/0640/0666/0700), prefix gate (SO/SU/garbage), missing file (ENOENT). Uses `createAccount()` / `createOperator()` / `createUser()` from `nkeys.js` to generate real seeds per test.
- **`__tests__/cortex-config.test.ts`** — 6 new cases: 3 on `NatsConfigSchema` (optional, accepts string, rejects non-string) + 3 on `BotConfigSchema.nats` MIRROR (same trio)

## Verification

- `bunx tsc --noEmit` exit 0
- Loader tests: **11/11 pass**
- Schema tests: **61/61 pass** (55 pre-existing + 6 new)
- `bun test src/common src/bus` — **443/443 pass**
- 3 unrelated `src/surface/mc` failures reproduce on clean `origin/main` (missing dashboard bundle artifact — not from this work)

## Next

- **Prereq A** — `nats-jwt-mint` wrapper — already opened as cortex#71
- **Prereq C** — AgentRegistry wired into `startCortex()` (still in flight)
- Then **cortex#67 proper** — daemon RPC + CLI IPC client

Refs cortex#67.

🤖 Generated with [Claude Code](https://claude.com/claude-code)