### PR TITLE
feat(cortex,runner): AgentRegistry in startCortex + creds-handler stub (cortex#67 prereq C)

### DIFF
--- a/src/__tests__/cortex.test.ts
+++ b/src/__tests__/cortex.test.ts
@@ -24,7 +24,11 @@
  */
 
 import { describe, expect, test } from "bun:test";
+import { mkdtempSync, writeFileSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
 import { BotConfigSchema, type BotConfig } from "../common/types/config";
+import type { Agent } from "../common/types/cortex-config";
 import { startCortex } from "../cortex";
 import type { Envelope } from "../bus/myelin/envelope-validator";
 import type { EnvelopeHandler, MyelinRuntime } from "../bus/myelin/runtime";
@@ -455,5 +459,162 @@ describe("startCortex — error surface", () => {
     });
     expect(handle).toBeDefined();
     await handle.stop();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cortex#67 prereq C — AgentRegistry wiring
+// ---------------------------------------------------------------------------
+
+describe("startCortex — agent registry (cortex#67 prereq C)", () => {
+  test("exposes an empty registry when no inline agents + agents.d/ is empty", async () => {
+    // Production callers today pass BotConfig (no inline agents) and may have
+    // no `agents.d/` directory yet. The registry must still construct cleanly
+    // and the handle must surface it — the creds handler downstream will
+    // simply gate itself off (`registry.size > 0` check).
+    const config = minimalConfig();
+    const tmpAgentsDir = mkdtempSync(join(tmpdir(), "cortex-test-agents-empty-"));
+    const handle = await startCortex(config, {
+      disableConfigWatcher: true,
+      disableDashboard: true,
+      disableOutboundPoller: true,
+      agentsDir: tmpAgentsDir,
+    });
+    expect(handle.agentRegistry).toBeDefined();
+    expect(handle.agentRegistry.size).toBe(0);
+    expect(handle.agentRegistry.getAll()).toEqual([]);
+    await handle.stop();
+    rmSync(tmpAgentsDir, { recursive: true, force: true });
+  });
+
+  test("merges inline agents + agents.d/ fragments (inline wins on id conflict)", async () => {
+    // Design §6.1 — when an inline cortex.yaml agent shares an id with a
+    // fragment under agents.d/, the inline entry wins. We exercise both
+    // sources here: two inline agents (luna + echo), two fragments (echo +
+    // holly), and assert echo resolves to the inline definition while holly
+    // (fragment-only) is still present.
+    const tmpAgentsDir = mkdtempSync(join(tmpdir(), "cortex-test-agents-merge-"));
+
+    // Drop fragments — each needs a persona file on disk per the loader's
+    // existence check. Echo's fragment declares a `(fragment-source)` persona
+    // marker so we can assert later that the inline definition shadowed it.
+    const echoFragmentPersona = join(tmpAgentsDir, "echo-fragment.md");
+    writeFileSync(echoFragmentPersona, "echo from fragment\n");
+    writeFileSync(
+      join(tmpAgentsDir, "echo.yaml"),
+      `id: echo
+displayName: EchoFromFragment
+persona: ./echo-fragment.md
+presence:
+  discord:
+    enabled: false
+    token: "frag-echo"
+    guildId: "0"
+    agentChannelId: "1"
+    logChannelId: "2"
+`,
+    );
+    const hollyPersona = join(tmpAgentsDir, "holly.md");
+    writeFileSync(hollyPersona, "holly from fragment\n");
+    writeFileSync(
+      join(tmpAgentsDir, "holly.yaml"),
+      `id: holly
+displayName: Holly
+persona: ./holly.md
+presence:
+  discord:
+    enabled: false
+    token: "frag-holly"
+    guildId: "0"
+    agentChannelId: "1"
+    logChannelId: "2"
+`,
+    );
+
+    // Inline agents — luna fresh, echo overriding the fragment.
+    const inlineAgents: Agent[] = [
+      {
+        id: "luna",
+        displayName: "Luna",
+        persona: "/tmp/luna-inline.md",
+        roles: [],
+        trust: [],
+        presence: {
+          discord: {
+            enabled: false,
+            token: "inline-luna",
+            guildId: "0",
+            agentChannelId: "1",
+            logChannelId: "2",
+            contextDepth: 10,
+            enableAgentLog: false,
+            roles: [],
+            defaultRole: "allow-all",
+            dm: {
+              operatorRole: {
+                features: ["chat", "async", "team"],
+                disallowedTools: [],
+                bashGuard: true,
+              },
+              defaultRole: "denied",
+              userRoles: [],
+            },
+          },
+        },
+      } as Agent,
+      {
+        id: "echo",
+        displayName: "EchoFromInline",
+        persona: "/tmp/echo-inline.md",
+        roles: [],
+        trust: [],
+        presence: {
+          discord: {
+            enabled: false,
+            token: "inline-echo",
+            guildId: "0",
+            agentChannelId: "1",
+            logChannelId: "2",
+            contextDepth: 10,
+            enableAgentLog: false,
+            roles: [],
+            defaultRole: "allow-all",
+            dm: {
+              operatorRole: {
+                features: ["chat", "async", "team"],
+                disallowedTools: [],
+                bashGuard: true,
+              },
+              defaultRole: "denied",
+              userRoles: [],
+            },
+          },
+        },
+      } as Agent,
+    ];
+
+    const handle = await startCortex(minimalConfig(), {
+      disableConfigWatcher: true,
+      disableDashboard: true,
+      disableOutboundPoller: true,
+      agentsDir: tmpAgentsDir,
+      inlineAgents,
+    });
+
+    // Three agents total: luna (inline-only), echo (inline wins), holly (fragment-only).
+    expect(handle.agentRegistry.size).toBe(3);
+    const ids = handle.agentRegistry.getAll().map((a) => a.id).sort();
+    expect(ids).toEqual(["echo", "holly", "luna"]);
+
+    // Inline-wins assertion — echo's displayName comes from the inline entry,
+    // not the fragment's `EchoFromFragment`.
+    expect(handle.agentRegistry.getById("echo").displayName).toBe("EchoFromInline");
+    // Fragment-only agent still resolves.
+    expect(handle.agentRegistry.getById("holly").displayName).toBe("Holly");
+    // Inline-only agent still resolves.
+    expect(handle.agentRegistry.getById("luna").displayName).toBe("Luna");
+
+    await handle.stop();
+    rmSync(tmpAgentsDir, { recursive: true, force: true });
   });
 });

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -17,11 +17,13 @@ import { join, dirname } from "path";
 import { parse as parseYaml } from "yaml";
 import type { TextChannel } from "discord.js";
 
-import { loadConfig } from "./common/config/loader";
+import { loadConfig, loadAgentsDirectory, expandTilde, FragmentLoadError } from "./common/config/loader";
 import { ConfigWatcher } from "./common/config/watcher";
 import { type BotConfig, getAllRepos } from "./common/types/config";
 import { fetchWithTimeout } from "./common/timeout";
 import { UsageMonitor } from "./common/usage/monitor";
+import { AgentRegistry } from "./common/agents/registry";
+import { createCredsHandler, type CredsHandler } from "./runner/creds-handler";
 import type { UsageStats } from "./runner/stream-parser";
 
 import { buildSecurityPreamble } from "./runner/security-preamble";
@@ -73,6 +75,19 @@ export interface CortexHandle {
    * so launchd knows to log a dirty shutdown.
    */
   readonly lastShutdownAbandoned: readonly string[];
+  /**
+   * cortex#67 prereq C — agent registry assembled at startup from inline
+   * cortex.yaml `agents[]` + fragments under `agents.d/` (inline wins on id
+   * conflict per design §6.1). Read-only; downstream consumers (creds
+   * handler, dashboard, future trust/capability surfaces) look up agents
+   * here rather than synthesising local `Agent` shapes.
+   *
+   * Today this coexists with the transitional inline `Agent` synthesis at
+   * cortex.ts:246 and :321 (Discord + Mattermost adapter wiring). Those
+   * paths land in MIG-7.2c-presence-adapter-flip; this PR does not refactor
+   * them.
+   */
+  readonly agentRegistry: AgentRegistry;
 }
 
 /** Optional test-only injection points. Production callers omit. */
@@ -104,6 +119,32 @@ export interface StartCortexOptions {
    * @internal — not part of the public API; semver does not apply.
    */
   shutdownTimeoutMs?: number;
+  /**
+   * Override the agents.d/ fragment directory the AgentRegistry assembly
+   * step reads. Production code derives this from the config file's
+   * directory (`{configDir}/agents.d`) matching `cortex agents` CLI
+   * behaviour, falling back to `~/.config/cortex/agents.d/` when no
+   * `configPath` was supplied. Tests pass a tmp dir so the registry
+   * assembly path runs without touching the operator's real `agents.d/`.
+   *
+   * @internal — not part of the public API; semver does not apply.
+   */
+  agentsDir?: string;
+  /**
+   * Inline `Agent[]` to merge with the fragment-loaded list when building
+   * the registry. Mirrors the cortex.yaml `agents[]` block (design §6.1):
+   * inline entries win on id conflict with fragments.
+   *
+   * BotConfig (today's legacy shape) carries no inline `agents[]` field, so
+   * production callers pass nothing and the registry is built purely from
+   * fragments. The seam exists today so tests can assemble a registry
+   * without writing fragment files, and so the cortex.yaml migration
+   * (MIG-7.2e) can plumb the real inline list through without changing
+   * this signature.
+   *
+   * @internal — not part of the public API; semver does not apply.
+   */
+  inlineAgents?: readonly Agent[];
 }
 
 /**
@@ -146,6 +187,70 @@ export async function startCortex(
     } catch (err) {
       console.error("cortex: myelin runtime startup error (non-fatal):", err instanceof Error ? err.message : err);
     }
+  }
+
+  // cortex#67 prereq C — assemble the AgentRegistry from inline agents +
+  // fragments dropped under `agents.d/`. Per design §6.1, inline entries win
+  // on id conflict with fragments.
+  //
+  // The fragment directory defaults to `{configDir}/agents.d` (matching the
+  // `cortex agents` CLI's resolver) so an operator who already manages
+  // fragments via that command sees them honoured at daemon startup too.
+  // When `options.configPath` is absent (e.g. tests with in-memory config),
+  // we fall back to `~/.config/cortex/agents.d/`.
+  //
+  // Fragment-load errors are non-fatal at this stage of the migration: the
+  // bot must keep starting in BotConfig mode even when an operator's
+  // experimental fragment is malformed. Once the cortex.yaml migration is
+  // complete (MIG-7.2e), the rule flips to strict per spec §FR-4.
+  const agentsDir = options.agentsDir
+    ?? (options.configPath ? join(dirname(expandedConfigPath), "agents.d") : expandTilde("~/.config/cortex/agents.d/"));
+  let fragmentAgents: Agent[] = [];
+  try {
+    fragmentAgents = loadAgentsDirectory(agentsDir);
+  } catch (err) {
+    if (err instanceof FragmentLoadError) {
+      console.error(`cortex: agents.d fragment load failed (non-fatal during BotConfig migration): ${err.message}`);
+    } else {
+      throw err;
+    }
+  }
+
+  // Merge: inline wins on id conflict (design §6.1). BotConfig today carries
+  // no inline `agents[]`, so production callers pass `inlineAgents: undefined`
+  // and the merged list is just the fragments. The seam exists so tests can
+  // exercise the merge rule without writing fragment files, and so MIG-7.2e
+  // can plumb the real inline list through without changing the signature.
+  const inlineAgents = options.inlineAgents ?? [];
+  const inlineIds = new Set(inlineAgents.map((a) => a.id));
+  const shadowedFragmentCount = fragmentAgents.filter((a) => inlineIds.has(a.id)).length;
+  const mergedAgents: Agent[] = [
+    ...inlineAgents,
+    ...fragmentAgents.filter((a) => !inlineIds.has(a.id)),
+  ];
+  const agentRegistry = AgentRegistry.fromAgents(mergedAgents);
+  if (mergedAgents.length > 0) {
+    console.log(
+      `cortex: agent registry assembled — ${mergedAgents.length} agent(s) `
+        + `(${inlineAgents.length} inline + ${fragmentAgents.length} fragment, `
+        + `${shadowedFragmentCount} fragment override(s) shadowed by inline)`,
+    );
+  } else {
+    console.log("cortex: agent registry assembled — 0 agents (no inline agents, no fragments)");
+  }
+
+  // cortex#67 — conditional creds handler. Today the body is a stub
+  // (src/runner/creds-handler.ts); the conditional shape lives here so the
+  // full implementation can swap in without touching cortex.ts. Gated on
+  // runtime being enabled + at least one registered agent — there's no
+  // point minting per-agent NATS JWTs without either a NATS link or any
+  // agent to scope creds to. The account-signing-key gate arrives once
+  // prereq B has landed.
+  let credsHandler: CredsHandler | null = null;
+  if (runtime.enabled && agentRegistry.size > 0) {
+    credsHandler = createCredsHandler({ runtime, registry: agentRegistry });
+    await credsHandler.start();
+    console.log("cortex: creds handler ready (stub)");
   }
 
   // Surface router (in-process fan-out).
@@ -497,6 +602,7 @@ export async function startCortex(
       ...adapterStopNames,
       ...rendererStopNames,
       "cloud publisher close",
+      ...(credsHandler ? ["creds handler stop"] : []),
       "runtime stop",
     ];
     for (const slot of allSlots) pending.add(slot);
@@ -534,6 +640,9 @@ export async function startCortex(
         await completeAsync(rendererStopNames[i]!, renderers[i]!.stop());
       }
       await completeAsync("cloud publisher close", cloudPublisher?.close());
+      if (credsHandler) {
+        await completeAsync("creds handler stop", credsHandler.stop());
+      }
       await completeAsync("runtime stop", runtime.stop());
     };
 
@@ -562,6 +671,9 @@ export async function startCortex(
     stop,
     get lastShutdownAbandoned() {
       return lastShutdownAbandoned;
+    },
+    get agentRegistry() {
+      return agentRegistry;
     },
   };
 }

--- a/src/runner/__tests__/creds-handler.test.ts
+++ b/src/runner/__tests__/creds-handler.test.ts
@@ -1,0 +1,193 @@
+/**
+ * cortex#67 prereq C — creds-handler stub tests.
+ *
+ * The stub's surface is intentionally minimal: a factory that accepts a
+ * runtime + registry and returns a `{ start, stop }` handle whose methods
+ * are idempotent no-ops. We assert the surface shape + idempotence so the
+ * future replacement (cortex#67 full implementation) is constrained to keep
+ * those guarantees.
+ *
+ * Scope:
+ *   - createCredsHandler returns a CredsHandler with async start/stop
+ *   - start() is idempotent (calling twice does not throw)
+ *   - stop() is idempotent (calling twice does not throw)
+ *   - stop() before start() is safe (no preconditions on lifecycle order)
+ *   - start() resolves quickly (the stub does no real work)
+ *
+ * Out of scope (lands with cortex#67):
+ *   - JWT minting per agent capability set
+ *   - Account signing key handling
+ *   - Refresh-timer behaviour
+ *   - Publishing minted creds via the runtime
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { createCredsHandler, type CredsHandlerOpts } from "../creds-handler";
+import { AgentRegistry } from "../../common/agents/registry";
+import type { Agent } from "../../common/types/cortex-config";
+import type { MyelinRuntime } from "../../bus/myelin/runtime";
+
+// =============================================================================
+// Fixture builders
+// =============================================================================
+
+/**
+ * Disabled MyelinRuntime — the stub doesn't touch the runtime, but the type
+ * requires one. A `enabled: false` no-op runtime is the minimal shape that
+ * compiles; once cortex#67 actually publishes creds via `runtime.publish`,
+ * the test will swap this for a recording fake.
+ */
+function fakeRuntime(): MyelinRuntime {
+  return {
+    enabled: false,
+    onEnvelope: () => ({ unregister: () => {} }),
+    publish: async () => {},
+    stop: async () => {},
+  };
+}
+
+/**
+ * Single-agent registry — enough to satisfy the stub's `registry` opt without
+ * needing to wire trust-closure validation against multiple peers. The agent's
+ * `runtime.capabilities` field is what cortex#67 will read; we set a
+ * non-empty value here so a future test that exercises the real handler can
+ * assert the capability flowed into the minted JWT.
+ */
+function fakeRegistry(): AgentRegistry {
+  const agent: Agent = {
+    id: "scout",
+    displayName: "Scout",
+    persona: "/tmp/scout-persona.md",
+    roles: [],
+    trust: [],
+    presence: {
+      discord: {
+        enabled: false,
+        token: "fake",
+        guildId: "0",
+        agentChannelId: "1",
+        logChannelId: "2",
+        contextDepth: 10,
+        enableAgentLog: false,
+        roles: [],
+        defaultRole: "allow-all",
+        dm: {
+          operatorRole: {
+            features: ["chat", "async", "team"],
+            disallowedTools: [],
+            bashGuard: true,
+          },
+          defaultRole: "denied",
+          userRoles: [],
+        },
+      },
+    },
+    runtime: {
+      substrate: "claude-code",
+      mode: "in-process",
+      capabilities: ["research"],
+    },
+  } as Agent;
+  return AgentRegistry.fromAgents([agent]);
+}
+
+function fakeOpts(): CredsHandlerOpts {
+  return { runtime: fakeRuntime(), registry: fakeRegistry() };
+}
+
+// =============================================================================
+// Surface shape
+// =============================================================================
+
+describe("createCredsHandler — surface", () => {
+  test("returns a handle with async start and stop methods", () => {
+    const handle = createCredsHandler(fakeOpts());
+    expect(handle).toBeDefined();
+    expect(typeof handle.start).toBe("function");
+    expect(typeof handle.stop).toBe("function");
+  });
+
+  test("start() returns a Promise", () => {
+    const handle = createCredsHandler(fakeOpts());
+    const result = handle.start();
+    expect(result).toBeInstanceOf(Promise);
+    return result;
+  });
+
+  test("stop() returns a Promise", () => {
+    const handle = createCredsHandler(fakeOpts());
+    const result = handle.stop();
+    expect(result).toBeInstanceOf(Promise);
+    return result;
+  });
+});
+
+// =============================================================================
+// Idempotence — the stub MUST tolerate repeated lifecycle calls. The full
+// cortex#67 handler will share this guarantee (the cortex.ts shutdown drain
+// calls stop() once but a future signal-handler retry path could land here).
+// =============================================================================
+
+describe("createCredsHandler — idempotent lifecycle (stub)", () => {
+  test("start() can be called twice without throwing", async () => {
+    const handle = createCredsHandler(fakeOpts());
+    await handle.start();
+    await handle.start();
+  });
+
+  test("stop() can be called twice without throwing", async () => {
+    const handle = createCredsHandler(fakeOpts());
+    await handle.start();
+    await handle.stop();
+    await handle.stop();
+  });
+
+  test("stop() before start() is a safe no-op", async () => {
+    // Defensive: a caller that constructs a handler and then bails before
+    // start() (e.g. an upstream gate threw) must still be able to call
+    // stop() during shutdown without exploding.
+    const handle = createCredsHandler(fakeOpts());
+    await handle.stop();
+  });
+
+  test("start() resolves promptly — stub does no real work", async () => {
+    const handle = createCredsHandler(fakeOpts());
+    const before = Date.now();
+    await handle.start();
+    const elapsed = Date.now() - before;
+    // Generous upper bound — the stub should resolve in microseconds. We
+    // assert <100ms so this test doesn't flake on a loaded CI runner while
+    // still catching a regression where the future real handler accidentally
+    // ships in stub-shape but with real work tacked on.
+    expect(elapsed).toBeLessThan(100);
+  });
+});
+
+// =============================================================================
+// Opts handling — the stub captures opts in its closure (today the body is a
+// no-op but cortex#67 will use them); ensure construction with valid opts
+// succeeds for both empty and populated registries.
+// =============================================================================
+
+describe("createCredsHandler — opts", () => {
+  test("accepts a registry with zero agents (caller responsible for gating)", () => {
+    // cortex.ts gates `agentRegistry.size > 0` BEFORE calling
+    // createCredsHandler — but the factory itself should not enforce a
+    // non-empty registry. Keeps the contract symmetric with the future
+    // real handler (which might still want to construct against an empty
+    // registry to register a "no agents yet" sentinel).
+    const opts: CredsHandlerOpts = {
+      runtime: fakeRuntime(),
+      registry: AgentRegistry.fromAgents([]),
+    };
+    expect(() => createCredsHandler(opts)).not.toThrow();
+  });
+
+  test("accepts a registry with agents declaring runtime.capabilities", () => {
+    // The motivating use case for cortex#67: each agent's `runtime.capabilities`
+    // bounds the NATS user permissions on its minted JWT. The stub doesn't
+    // read it yet but the factory must accept the shape.
+    expect(() => createCredsHandler(fakeOpts())).not.toThrow();
+  });
+});

--- a/src/runner/creds-handler.ts
+++ b/src/runner/creds-handler.ts
@@ -1,0 +1,94 @@
+/**
+ * cortex#67 prep — creds-handler stub.
+ *
+ * The full creds-handler will mint per-agent NATS JWTs scoped to each agent's
+ * declared `runtime.capabilities`, using an operator account signing key
+ * (landed in cortex#67 prereq B). The handler watches the agent registry,
+ * mints/refreshes credentials when an agent's capability set or trust closure
+ * changes, and tears them down on shutdown.
+ *
+ * This file is the minimum surface so the upcoming cortex#67 PR has a target:
+ *   - `CredsHandlerOpts` carries the bus runtime + the agent registry. The
+ *     `accountSigningKey: KeyPair` field arrives in cortex#67 once prereq A+B
+ *     have landed — adding it here today would force an early dep on the JWT
+ *     primitive that hasn't shipped.
+ *   - `CredsHandler` is the lifecycle handle cortex.ts wires alongside the
+ *     other subsystems (runtime, router, listener) — same `start/stop` shape
+ *     so the existing shutdown drain doesn't need a special-case.
+ *
+ * The stub's `start` and `stop` are idempotent no-ops. They satisfy the type
+ * so cortex.ts can conditionally construct + log a "creds handler ready
+ * (stub)" line behind the same gates the real handler will require:
+ *   - `runtime.enabled` (no point minting NATS creds without a NATS link)
+ *   - `registry.size > 0`  (no point minting creds for zero agents)
+ *   - (future) account signing key present in config
+ *
+ * When cortex#67 lands, replace the stub body — the public interface stays.
+ */
+
+import type { AgentRegistry } from "../common/agents/registry";
+import type { MyelinRuntime } from "../bus/myelin/runtime";
+
+/**
+ * Construction options for the creds handler. The runtime + registry pair is
+ * enough surface to scope the handler today; the account signing key arrives
+ * with cortex#67 once the prereq-A/B PRs land.
+ */
+export interface CredsHandlerOpts {
+  /** Bus runtime — the handler will eventually publish minted creds via this. */
+  runtime: MyelinRuntime;
+  /**
+   * Agent registry — the handler reads `agent.runtime.capabilities` per
+   * registered agent to bound each minted JWT's NATS user permissions.
+   */
+  registry: AgentRegistry;
+  // accountSigningKey: KeyPair — added in cortex#67 once prereq A+B land.
+}
+
+/**
+ * Lifecycle handle for the creds handler. Same `start/stop` shape as other
+ * cortex subsystems so the shutdown drain treats it uniformly.
+ */
+export interface CredsHandler {
+  /**
+   * Start the handler. Idempotent — calling twice is safe and the second
+   * call is a no-op. The stub never throws; the real implementation will
+   * surface configuration errors (missing signing key, registry empty)
+   * here rather than at construction.
+   */
+  start(): Promise<void>;
+  /**
+   * Stop the handler. Idempotent — calling twice (or before `start`) is
+   * safe. The stub never throws; the real implementation will revoke
+   * minted creds + cancel refresh timers here.
+   */
+  stop(): Promise<void>;
+}
+
+/**
+ * Build the creds handler. Pure factory — does not start anything; the
+ * caller invokes `handle.start()` once it's ready to hand the registry +
+ * runtime over to the credential minting loop.
+ *
+ * STUB — full implementation lands in cortex#67. The current body returns a
+ * handle whose `start` and `stop` are no-ops; this satisfies the type so
+ * cortex.ts can wire the handler conditionally today and the real behaviour
+ * can swap in without touching call sites.
+ */
+export function createCredsHandler(_opts: CredsHandlerOpts): CredsHandler {
+  // STUB — full implementation in cortex#67.
+  // The opts are accepted but unused at this stage; once the JWT mint loop
+  // lands, the closure below captures `_opts.runtime` and `_opts.registry`
+  // to drive credential issuance per agent.
+  return {
+    async start() {
+      // No-op — real handler will: scan registry, mint per-agent JWTs
+      // scoped to each agent's runtime.capabilities, publish creds via
+      // runtime, and start a refresh timer keyed on JWT TTL.
+    },
+    async stop() {
+      // No-op — real handler will: cancel refresh timer, revoke minted
+      // creds, drain in-flight publishes.
+    },
+  };
+}


### PR DESCRIPTION
## What

**Prereq C of 3 for cortex#67**. Wires `AgentRegistry` into `startCortex()` so the upcoming `CredsHandler` can look up `agent.runtime.capabilities` to scope minted JWTs. Plus the creds-handler stub file (so cortex#67 has a real target file to fill in).

## Changes

**Commit 1 — `8a48698 feat(runner): creds-handler stub (cortex#67 prep)`:**
- `src/runner/creds-handler.ts` (new) — exports `CredsHandlerOpts`, `CredsHandler`, `createCredsHandler` stub. `start()`/`stop()` are idempotent no-ops; satisfies the type so cortex.ts can wire it conditionally now.
- `src/runner/__tests__/creds-handler.test.ts` — 9 tests: surface shape, idempotent lifecycle, opts acceptance.

**Commit 2 — `c2a3fd1 feat(cortex): wire AgentRegistry into startCortex()`:**
- `src/cortex.ts` — assemble registry from inline agents + fragments (inline-wins on id conflict per design §6.1). Expose via `CortexHandle.agentRegistry`. Conditionally construct creds-handler stub gated on `runtime.enabled && registry.size > 0`. Inline Agent synthesis at original `:246`/`:321` (now `:351`/`:426` after additions) **untouched** — those land in MIG-7.2c presence-adapter follow-ups; this PR coexists.
- `src/__tests__/cortex.test.ts` — empty-registry path + inline+fragment merge tests.

## Design notes (worth flagging at review)

- **`StartCortexOptions.agentsDir` + `inlineAgents`** — two `@internal` test seams added. The first lets tests point at a tmp `agents.d/`; the second carries the inline `Agent[]` list (BotConfig today has no inline `agents[]`, so production passes nothing — forward-prep for MIG-7.2e). Both marked `@internal — not part of public API`.
- **`agentsDir` default resolution** — task said `config.agentsDir ?? "~/.config/cortex/agents.d/"`, but BotConfig has no `agentsDir` field. Matched the `cortex agents` CLI's resolver: `{configDir}/agents.d` when `options.configPath` is provided, else `expandTilde("~/.config/cortex/agents.d/")`. Consistent with operator expectation that the daemon reads the same fragment dir the CLI manages.
- **Fragment-load errors non-fatal during BotConfig migration** — caught `FragmentLoadError` and logged. Per design §FR-4 the rule flips to strict once MIG-7.2e completes. Comment in code spells this out.
- **Shutdown drain ordering** — creds-handler stop runs BEFORE `runtime stop` (the real handler will use the runtime, so it must drain first). Slot is only registered when `credsHandler !== null`.

## Verification

- `bunx tsc --noEmit` exit 0
- Targeted tests: **23/23 pass** (`bun test src/__tests__/cortex.test.ts src/runner/__tests__/creds-handler.test.ts`)
- Full suite: **2320/2321** (1 pre-existing `src/surface/mc/__tests__/server.test.ts` ENOENT on `dist/dashboard-v2/index.html` — unrelated to this PR)

## Next

With Prereq A (cortex#71, merged), B (cortex#72, merging now), and C (this PR) landed, **cortex#67 proper** can implement the daemon RPC handler + CLI IPC client.

Refs cortex#67.

🤖 Generated with [Claude Code](https://claude.com/claude-code)