### PR TITLE
feat(runner,cli): cortex creds daemon RPC + CLI IPC (closes cortex#67)

### DIFF
--- a/src/cli/cortex/commands/__tests__/creds.test.ts
+++ b/src/cli/cortex/commands/__tests__/creds.test.ts
@@ -1,9 +1,10 @@
 // F-4 — cortex creds CLI tests.
 
 import { describe, expect, test } from "bun:test";
-import { mkdtempSync, writeFileSync } from "fs";
+import { mkdtempSync, rmSync, writeFileSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
+import { createServer, type Server } from "net";
 
 import {
   parseCredsArgs,
@@ -15,6 +16,94 @@ import {
   DEFERRED_SUBCOMMAND_MESSAGE,
 } from "../creds";
 import { CliArgsError } from "../_shared/arg-error";
+
+// =============================================================================
+// Mock daemon fixture
+// =============================================================================
+//
+// The CLI talks to the daemon over a UNIX socket; for IPC tests we spin up
+// a tiny fake server that reads one JSON line and replies with a programmable
+// response. Matches the daemon's newline-delimited framing exactly
+// (see `src/runner/creds-handler.ts` — `handleConnection`).
+//
+// We DO NOT import the real `createCredsHandler` here — the CLI tests assert
+// the CLI behaviour against the daemon's wire contract, not the daemon's
+// internals. The end-to-end test in `src/runner/__tests__/creds-handler.test.ts`
+// already exercises the real handler.
+
+interface MockDaemonReply {
+  ok: boolean;
+  verb?: "issue" | "revoke" | "rotate";
+  agent_id?: string;
+  error?: string;
+  message?: string;
+  creds_path?: string;
+  file_deleted?: boolean;
+  user_jwt_summary?: { sub: string; iss: string; capabilities: string[] };
+}
+
+interface MockDaemon {
+  socketPath: string;
+  /** Most recent request the daemon received — for assertions. */
+  lastRequest: { verb: string; agent_id: string } | null;
+  stop: () => Promise<void>;
+}
+
+function startMockDaemon(reply: MockDaemonReply | ((req: { verb: string; agent_id: string }) => MockDaemonReply)): Promise<MockDaemon> {
+  const tmpRoot = mkdtempSync(join(tmpdir(), "f4-mock-daemon-"));
+  const socketPath = join(tmpRoot, "cortex.sock");
+
+  const state: { lastRequest: { verb: string; agent_id: string } | null } = {
+    lastRequest: null,
+  };
+
+  return new Promise((resolve, reject) => {
+    const server: Server = createServer((sock) => {
+      sock.setEncoding("utf-8");
+      let buffer = "";
+      sock.on("data", (chunk: string) => {
+        buffer += chunk;
+        const idx = buffer.indexOf("\n");
+        if (idx < 0) return;
+        const line = buffer.slice(0, idx);
+        try {
+          const parsed = JSON.parse(line) as { verb: string; agent_id: string };
+          state.lastRequest = parsed;
+          const response = typeof reply === "function" ? reply(parsed) : reply;
+          sock.write(JSON.stringify(response) + "\n");
+          sock.end();
+        } catch (err) {
+          // Forward parse-failure to client so the client's
+          // "malformed-reply" path is testable too.
+          sock.write(
+            JSON.stringify({ ok: false, error: `mock-daemon-parse-fail: ${err}` }) + "\n",
+          );
+          sock.end();
+        }
+      });
+    });
+    server.once("error", reject);
+    server.listen(socketPath, () => {
+      resolve({
+        socketPath,
+        get lastRequest() {
+          return state.lastRequest;
+        },
+        stop: () =>
+          new Promise<void>((res) => {
+            server.close(() => {
+              try {
+                rmSync(tmpRoot, { recursive: true, force: true });
+              } catch {
+                // best-effort
+              }
+              res();
+            });
+          }),
+      });
+    });
+  });
+}
 
 // =============================================================================
 // parseCredsArgs
@@ -69,6 +158,19 @@ describe("parseCredsArgs", () => {
   test("parses --config flag", () => {
     const args = parseCredsArgs(["issue", "echo", "--config", "/tmp/cortex.yaml"]);
     expect(args.config).toBe("/tmp/cortex.yaml");
+  });
+
+  test("parses --socket flag for issue/revoke/rotate", () => {
+    const issueArgs = parseCredsArgs(["issue", "echo", "--socket", "/tmp/my.sock"]);
+    expect(issueArgs.socket).toBe("/tmp/my.sock");
+    const revokeArgs = parseCredsArgs(["revoke", "echo", "--socket", "/tmp/my.sock"]);
+    expect(revokeArgs.socket).toBe("/tmp/my.sock");
+    const rotateArgs = parseCredsArgs(["rotate", "echo", "--socket", "/tmp/my.sock"]);
+    expect(rotateArgs.socket).toBe("/tmp/my.sock");
+  });
+
+  test("--socket is rejected on list", () => {
+    expect(() => parseCredsArgs(["list", "--socket", "/tmp/x.sock"])).toThrow(CliArgsError);
   });
 
   describe("CliArgsError throws", () => {
@@ -282,53 +384,253 @@ describe("runCredsList", () => {
 });
 
 // =============================================================================
-// Deferred subcommands (issue / revoke / rotate)
+// Input validation — runs before any IPC, no daemon required
 // =============================================================================
 
-describe("deferred subcommands", () => {
-  test("runCredsIssue returns exit 2 with deferred message", () => {
-    const r = runCredsIssue(parseCredsArgs(["issue", "echo"]));
-    expect(r.exitCode).toBe(2);
-    expect(r.stderr).toContain(DEFERRED_SUBCOMMAND_MESSAGE);
-  });
-
-  test("runCredsRevoke returns exit 2 with deferred message", () => {
-    const r = runCredsRevoke(parseCredsArgs(["revoke", "echo"]));
-    expect(r.exitCode).toBe(2);
-    expect(r.stderr).toContain(DEFERRED_SUBCOMMAND_MESSAGE);
-  });
-
-  test("runCredsRotate returns exit 2 with deferred message", () => {
-    const r = runCredsRotate(parseCredsArgs(["rotate", "echo"]));
-    expect(r.exitCode).toBe(2);
-    expect(r.stderr).toContain(DEFERRED_SUBCOMMAND_MESSAGE);
-  });
-
-  test("issue rejects invalid agent id (not lowercase alphanumeric)", () => {
-    const r = runCredsIssue(parseCredsArgs(["issue", "Echo!"]));
+describe("operator-input validation", () => {
+  test("issue rejects invalid agent id (not lowercase alphanumeric)", async () => {
+    const r = await runCredsIssue(parseCredsArgs(["issue", "Echo!"]));
     expect(r.exitCode).toBe(2);
     expect(r.stderr).toMatch(/agent id/i);
   });
 
-  test("issue rejects empty agent id", () => {
-    const r = runCredsIssue({
+  test("issue rejects empty agent id", async () => {
+    const r = await runCredsIssue({
       ...parseCredsArgs(["issue", "x"]),
       agentId: "",
     });
     expect(r.exitCode).toBe(2);
   });
 
-  test("--json on deferred subcommand emits envelope", () => {
-    const r = runCredsIssue(parseCredsArgs(["issue", "echo", "--json"]));
+  test("revoke rejects invalid agent id", async () => {
+    const r = await runCredsRevoke(parseCredsArgs(["revoke", "BAD!"]));
     expect(r.exitCode).toBe(2);
+    expect(r.stderr).toMatch(/agent id/i);
+  });
+
+  test("rotate rejects invalid agent id", async () => {
+    const r = await runCredsRotate(parseCredsArgs(["rotate", "BAD!"]));
+    expect(r.exitCode).toBe(2);
+    expect(r.stderr).toMatch(/agent id/i);
+  });
+
+  test("DEFERRED_SUBCOMMAND_MESSAGE constant is still exported", () => {
+    // Backward-compat: pre-cortex#67 consumers parsed this string from stderr.
+    // The string survives as an exported constant; the CLI doesn't emit it as
+    // the typical user-facing message anymore (the IPC client returns
+    // operator-actionable errors), but the export remains for any tooling
+    // that pinned against it.
+    expect(typeof DEFERRED_SUBCOMMAND_MESSAGE).toBe("string");
+    expect(DEFERRED_SUBCOMMAND_MESSAGE.length).toBeGreaterThan(0);
+  });
+});
+
+// =============================================================================
+// IPC client — happy path with mock daemon
+// =============================================================================
+
+describe("IPC happy path — issue", () => {
+  test("issue via mock daemon → exit 0 with creds_path summary", async () => {
+    const daemon = await startMockDaemon({
+      ok: true,
+      verb: "issue",
+      agent_id: "scout",
+      creds_path: "/tmp/scout.creds",
+      user_jwt_summary: { sub: "USCOUT", iss: "AACME", capabilities: ["research"] },
+    });
+    try {
+      const r = await runCredsIssue(
+        parseCredsArgs(["issue", "scout", "--socket", daemon.socketPath]),
+      );
+      expect(r.exitCode).toBe(0);
+      expect(r.stdout).toContain("ok");
+      expect(r.stdout).toContain("scout");
+      expect(r.stdout).toContain("/tmp/scout.creds");
+      expect(r.stdout).toContain("USCOUT");
+      expect(r.stdout).toContain("research");
+      expect(daemon.lastRequest?.verb).toBe("issue");
+      expect(daemon.lastRequest?.agent_id).toBe("scout");
+    } finally {
+      await daemon.stop();
+    }
+  });
+
+  test("issue --json → exit 0 with envelope status=ok", async () => {
+    const daemon = await startMockDaemon({
+      ok: true,
+      verb: "issue",
+      agent_id: "scout",
+      creds_path: "/tmp/scout.creds",
+      user_jwt_summary: { sub: "USCOUT", iss: "AACME", capabilities: ["research"] },
+    });
+    try {
+      const r = await runCredsIssue(
+        parseCredsArgs(["issue", "scout", "--socket", daemon.socketPath, "--json"]),
+      );
+      expect(r.exitCode).toBe(0);
+      const parsed = JSON.parse(r.stdout);
+      expect(parsed.status).toBe("ok");
+      expect(parsed.items).toEqual([]);
+    } finally {
+      await daemon.stop();
+    }
+  });
+});
+
+describe("IPC happy path — revoke (narrower stub)", () => {
+  test("revoke ok=false + server_side_revoke_not_implemented → exit 1 with message", async () => {
+    const daemon = await startMockDaemon({
+      ok: false,
+      verb: "revoke",
+      agent_id: "scout",
+      error: "server_side_revoke_not_implemented",
+      message:
+        "Server-side NATS account-JWT revoke is pending system-account topology " +
+        "design. v1 only deletes the local .creds file. File deleted: true",
+      file_deleted: true,
+    });
+    try {
+      const r = await runCredsRevoke(
+        parseCredsArgs(["revoke", "scout", "--socket", daemon.socketPath]),
+      );
+      expect(r.exitCode).toBe(1);
+      expect(r.stderr).toContain("server_side_revoke_not_implemented");
+      expect(r.stderr).toContain("pending system-account topology design");
+      expect(r.stderr).toContain("file_deleted: true");
+    } finally {
+      await daemon.stop();
+    }
+  });
+
+  test("revoke --json → envelope context carries daemon message + file_deleted", async () => {
+    const daemon = await startMockDaemon({
+      ok: false,
+      verb: "revoke",
+      agent_id: "scout",
+      error: "server_side_revoke_not_implemented",
+      message: "v1 only deletes the local .creds file. File deleted: false",
+      file_deleted: false,
+    });
+    try {
+      const r = await runCredsRevoke(
+        parseCredsArgs(["revoke", "scout", "--socket", daemon.socketPath, "--json"]),
+      );
+      expect(r.exitCode).toBe(1);
+      const parsed = JSON.parse(r.stdout);
+      expect(parsed.status).toBe("error");
+      expect(parsed.error.reason).toBe("server_side_revoke_not_implemented");
+      expect(parsed.error.context.subcommand).toBe("revoke");
+      expect(parsed.error.context.agentId).toBe("scout");
+      expect(parsed.error.context.file_deleted).toBe("false");
+      expect(parsed.error.context.message).toContain("v1 only deletes");
+    } finally {
+      await daemon.stop();
+    }
+  });
+});
+
+describe("IPC happy path — rotate (narrower stub)", () => {
+  test("rotate ok=true with deferred-server-side message → exit 0 + note in stdout", async () => {
+    const daemon = await startMockDaemon({
+      ok: true,
+      verb: "rotate",
+      agent_id: "scout",
+      creds_path: "/tmp/scout.creds",
+      file_deleted: true,
+      user_jwt_summary: { sub: "USCOUT2", iss: "AACME", capabilities: ["research"] },
+      message:
+        "v1: local file rotated; server-side revoke of the old JWT is pending " +
+        "system-account topology design.",
+    });
+    try {
+      const r = await runCredsRotate(
+        parseCredsArgs(["rotate", "scout", "--socket", daemon.socketPath]),
+      );
+      expect(r.exitCode).toBe(0);
+      expect(r.stdout).toContain("ok");
+      expect(r.stdout).toContain("note:");
+      expect(r.stdout).toContain("server-side revoke of the old JWT is pending");
+    } finally {
+      await daemon.stop();
+    }
+  });
+});
+
+describe("IPC error path — daemon-reported failures", () => {
+  test("unknown agent → daemon returns ok=false → CLI exit 1", async () => {
+    const daemon = await startMockDaemon({
+      ok: false,
+      verb: "issue",
+      agent_id: "ghost",
+      error: 'unknown agent "ghost" — not in cortex agent registry',
+    });
+    try {
+      const r = await runCredsIssue(
+        parseCredsArgs(["issue", "ghost", "--socket", daemon.socketPath]),
+      );
+      expect(r.exitCode).toBe(1);
+      expect(r.stderr).toContain('unknown agent "ghost"');
+    } finally {
+      await daemon.stop();
+    }
+  });
+});
+
+describe("IPC error path — daemon unreachable", () => {
+  test("issue with no daemon listening → exit 1 with operator-actionable message", async () => {
+    const r = await runCredsIssue(
+      parseCredsArgs([
+        "issue",
+        "scout",
+        "--socket",
+        "/tmp/nonexistent-cortex-creds-test-socket-zzz.sock",
+      ]),
+    );
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr).toContain("cortex daemon not reachable");
+    expect(r.stderr).toContain("--socket");
+  });
+
+  test("revoke with no daemon → exit 1 with daemon-unreachable message", async () => {
+    const r = await runCredsRevoke(
+      parseCredsArgs([
+        "revoke",
+        "scout",
+        "--socket",
+        "/tmp/nonexistent-cortex-creds-test-socket-zzz2.sock",
+      ]),
+    );
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr).toContain("not reachable");
+  });
+
+  test("rotate with no daemon → exit 1", async () => {
+    const r = await runCredsRotate(
+      parseCredsArgs([
+        "rotate",
+        "scout",
+        "--socket",
+        "/tmp/nonexistent-cortex-creds-test-socket-zzz3.sock",
+      ]),
+    );
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr).toContain("not reachable");
+  });
+
+  test("daemon-unreachable --json → envelope status=error with reason", async () => {
+    const r = await runCredsIssue(
+      parseCredsArgs([
+        "issue",
+        "scout",
+        "--socket",
+        "/tmp/nonexistent-cortex-creds-test-socket-zzz4.sock",
+        "--json",
+      ]),
+    );
+    expect(r.exitCode).toBe(1);
     const parsed = JSON.parse(r.stdout);
     expect(parsed.status).toBe("error");
-    expect(parsed.items).toEqual([]);
-    expect(parsed.error.reason).toContain(DEFERRED_SUBCOMMAND_MESSAGE);
-    // Echo M2 + M4 round 1 — error context lives under `error.context.<key>`
-    // in the shared envelope shape.
-    expect(parsed.error.context.subcommand).toBe("issue");
-    expect(parsed.error.context.agentId).toBe("echo");
+    expect(parsed.error.reason).toContain("not reachable");
   });
 });
 
@@ -337,22 +639,44 @@ describe("deferred subcommands", () => {
 // =============================================================================
 
 describe("dispatchCreds", () => {
-  test("routes 'list' to runCredsList", () => {
+  test("routes 'list' to runCredsList", async () => {
     const dir = mkdtempSync(join(tmpdir(), "f4-dispatch-list-"));
     writeFileSync(join(dir, "echo.creds"), "x");
-    const r = dispatchCreds(["list", "--creds-dir", dir]);
+    const r = await dispatchCreds(["list", "--creds-dir", dir]);
     expect(r.exitCode).toBe(0);
     expect(r.stdout).toContain("echo");
   });
 
-  test("routes 'issue' to runCredsIssue (deferred)", () => {
-    const r = dispatchCreds(["issue", "echo"]);
-    expect(r.exitCode).toBe(2);
-    expect(r.stderr).toContain(DEFERRED_SUBCOMMAND_MESSAGE);
+  test("routes 'issue' to runCredsIssue (daemon unreachable → exit 1)", async () => {
+    const r = await dispatchCreds([
+      "issue",
+      "echo",
+      "--socket",
+      "/tmp/nonexistent-cortex-creds-test-socket-disp.sock",
+    ]);
+    expect(r.exitCode).toBe(1);
+    expect(r.stderr).toContain("not reachable");
   });
 
-  test("--help prints top-level help", () => {
-    const r = dispatchCreds(["--help"]);
+  test("routes 'issue' to runCredsIssue with mock daemon → exit 0", async () => {
+    const daemon = await startMockDaemon({
+      ok: true,
+      verb: "issue",
+      agent_id: "echo",
+      creds_path: "/tmp/echo.creds",
+      user_jwt_summary: { sub: "U1", iss: "A1", capabilities: [] },
+    });
+    try {
+      const r = await dispatchCreds(["issue", "echo", "--socket", daemon.socketPath]);
+      expect(r.exitCode).toBe(0);
+      expect(r.stdout).toContain("echo");
+    } finally {
+      await daemon.stop();
+    }
+  });
+
+  test("--help prints top-level help", async () => {
+    const r = await dispatchCreds(["--help"]);
     expect(r.exitCode).toBe(0);
     expect(r.stdout).toContain("cortex creds");
     expect(r.stdout).toContain("issue");
@@ -361,27 +685,27 @@ describe("dispatchCreds", () => {
     expect(r.stdout).toContain("list");
   });
 
-  test("unknown subcommand → exit 2", () => {
-    const r = dispatchCreds(["status"]);
+  test("unknown subcommand → exit 2", async () => {
+    const r = await dispatchCreds(["status"]);
     expect(r.exitCode).toBe(2);
     expect(r.stderr).toContain("unknown");
     expect(r.stderr).toContain("status");
   });
 
-  test("no subcommand → exit 2 with help", () => {
-    const r = dispatchCreds([]);
+  test("no subcommand → exit 2 with help", async () => {
+    const r = await dispatchCreds([]);
     expect(r.exitCode).toBe(2);
     expect(r.stderr).toContain("usage");
   });
 
-  test("CliArgsError → exit 2 with named flag", () => {
-    const r = dispatchCreds(["list", "--verbose"]);
+  test("CliArgsError → exit 2 with named flag", async () => {
+    const r = await dispatchCreds(["list", "--verbose"]);
     expect(r.exitCode).toBe(2);
     expect(r.stderr).toContain("--verbose");
   });
 
-  test("issue without <id> arg → exit 2 usage error", () => {
-    const r = dispatchCreds(["issue"]);
+  test("issue without <id> arg → exit 2 usage error", async () => {
+    const r = await dispatchCreds(["issue"]);
     expect(r.exitCode).toBe(2);
     expect(r.stderr).toMatch(/missing.*agent id|requires.*id/i);
   });

--- a/src/cli/cortex/commands/__tests__/creds.test.ts
+++ b/src/cli/cortex/commands/__tests__/creds.test.ts
@@ -638,6 +638,105 @@ describe("IPC error path — daemon unreachable", () => {
 // dispatchCreds
 // =============================================================================
 
+// =============================================================================
+// End-to-end — CLI ↔ real daemon
+// =============================================================================
+//
+// Wire test: spin up a real `createCredsHandler()` against a fresh tmp
+// socket + tmp creds dir + a freshly-minted account signing key, then
+// drive `cortex creds issue` via `dispatchCreds`. Asserts the full path
+// works: CLI parses → CLI IPC client → daemon socket → real mint →
+// daemon reply → CLI exit code + formatted output.
+//
+// Importing from `../../../runner/...` is the deliberate boundary cross —
+// the e2e test is intentionally cross-layer. The unit tests in this file
+// (and in `src/runner/__tests__/creds-handler.test.ts`) exercise each side
+// in isolation; this single test proves they compose correctly.
+
+import { createCredsHandler } from "../../../../runner/creds-handler";
+import { AgentRegistry } from "../../../../common/agents/registry";
+import type { Agent } from "../../../../common/types/cortex-config";
+import { createAccount } from "nkeys.js";
+
+describe("end-to-end — CLI → real daemon", () => {
+  test("dispatchCreds 'issue' against real handler → exit 0 + .creds file landed", async () => {
+    const tmpRoot = mkdtempSync(join(tmpdir(), "f4-e2e-"));
+    const socketPath = join(tmpRoot, "cortex.sock");
+    const credsDir = join(tmpRoot, "creds");
+    const signingKey = createAccount();
+
+    const agent: Agent = {
+      id: "luna",
+      displayName: "Luna",
+      persona: "/tmp/luna.md",
+      roles: [],
+      trust: [],
+      presence: {
+        discord: {
+          enabled: false,
+          token: "fake",
+          guildId: "0",
+          agentChannelId: "1",
+          logChannelId: "2",
+          contextDepth: 10,
+          enableAgentLog: false,
+          roles: [],
+          defaultRole: "allow-all",
+          dm: {
+            operatorRole: { features: ["chat"], disallowedTools: [], bashGuard: true },
+            defaultRole: "denied",
+            userRoles: [],
+          },
+        },
+      },
+      runtime: { substrate: "claude-code", mode: "in-process", capabilities: ["pilot"] },
+    } as Agent;
+
+    const handle = createCredsHandler({
+      runtime: {
+        enabled: false,
+        onEnvelope: () => ({ unregister: () => {} }),
+        publish: async () => {},
+        stop: async () => {},
+      },
+      registry: AgentRegistry.fromAgents([agent]),
+      accountSigningKey: signingKey,
+      org: "metafactory",
+      socketPath,
+      credsDir,
+    });
+
+    try {
+      await handle.start();
+
+      const r = await dispatchCreds([
+        "issue",
+        "luna",
+        "--socket",
+        socketPath,
+      ]);
+      expect(r.exitCode).toBe(0);
+      expect(r.stdout).toContain("luna");
+      expect(r.stdout).toContain(join(credsDir, "luna.creds"));
+      expect(r.stdout).toContain("pilot"); // capability echoed in summary
+
+      // Verify the file actually landed.
+      const fs = await import("fs");
+      expect(fs.existsSync(join(credsDir, "luna.creds"))).toBe(true);
+      if (process.platform !== "win32") {
+        expect(fs.statSync(join(credsDir, "luna.creds")).mode & 0o777).toBe(0o600);
+      }
+    } finally {
+      await handle.stop();
+      try {
+        rmSync(tmpRoot, { recursive: true, force: true });
+      } catch {
+        // best-effort
+      }
+    }
+  });
+});
+
 describe("dispatchCreds", () => {
   test("routes 'list' to runCredsList", async () => {
     const dir = mkdtempSync(join(tmpdir(), "f4-dispatch-list-"));

--- a/src/cli/cortex/commands/creds.ts
+++ b/src/cli/cortex/commands/creds.ts
@@ -4,26 +4,39 @@
  *
  * Manages per-agent NATS user credentials (cortex#58 D7+D8 + cortex#60 §6.3).
  *
- * **v1 scope:** `list` is fully functional (scans local creds dir). `issue`,
- * `revoke`, `rotate` ship as stubs returning exit 2 with a clear "deferred"
- * message. The daemon-mediated signing flow (NATS req/rep + UNIX socket
- * fallback, per the interview answers) lands when cortex.ts gains the
- * daemon-side RPC handler. Same scope-narrowing pattern as F-2 and F-3.
+ * **v1 scope (cortex#67 implementation):**
+ *
+ *   - `list` is fully functional — scans the local creds dir.
+ *   - `issue` calls the cortex daemon via UNIX-socket IPC and writes the
+ *     minted .creds file to disk (chmod 600). Lights up end-to-end when
+ *     the daemon is running.
+ *   - `revoke` calls the daemon, which deletes the local file but does NOT
+ *     yet perform server-side NATS account-JWT revoke (see
+ *     `src/runner/creds-handler.ts` for the rationale). The daemon's
+ *     response message documents the limitation; the CLI surfaces it.
+ *   - `rotate` is local-file rotate (delete + re-mint). Same caveat as
+ *     `revoke` on the server-side revoke.
+ *
+ * **Transport:** UNIX-domain socket at `~/.config/cortex/cortex.sock`
+ * (configurable via `--socket <path>`). The daemon listens there when
+ * config has `nats.accountSigningKeyPath` set and `agents:[]` has ≥1 entry.
+ * NATS request/reply transport is deferred — see creds-handler.ts.
  *
  * Usage:
- *   bun src/cli/cortex/commands/creds.ts list   [--creds-dir <path>] [--local] [--json]
- *   bun src/cli/cortex/commands/creds.ts issue  <agent-id> [--config <path>] [--json]
- *   bun src/cli/cortex/commands/creds.ts revoke <agent-id> [--config <path>] [--json]
- *   bun src/cli/cortex/commands/creds.ts rotate <agent-id> [--config <path>] [--json]
+ *   bun src/cli/cortex/commands/creds.ts list   [--creds-dir <path>] [--json]
+ *   bun src/cli/cortex/commands/creds.ts issue  <agent-id> [--config <path>] [--socket <path>] [--json]
+ *   bun src/cli/cortex/commands/creds.ts revoke <agent-id> [--config <path>] [--socket <path>] [--json]
+ *   bun src/cli/cortex/commands/creds.ts rotate <agent-id> [--config <path>] [--socket <path>] [--json]
  *   bun src/cli/cortex/commands/creds.ts --help
  *
  * Exit codes:
  *   0  — success
- *   1  — operational failure (e.g. daemon unreachable, when implemented)
- *   2  — usage error (bad flag, deferred subcommand v1, bad agent id)
+ *   1  — operational failure (daemon unreachable, daemon returned ok=false)
+ *   2  — usage error (bad flag, bad agent id)
  */
 
 import { existsSync, lstatSync, readdirSync } from "fs";
+import { connect } from "net";
 import { join } from "path";
 
 import { expandTilde } from "../../../common/config/loader";
@@ -44,6 +57,13 @@ export interface ParsedCredsArgs {
   agentId: string | undefined;
   credsDir: string | undefined;
   config: string | undefined;
+  /**
+   * Optional override for the daemon UNIX socket path. Defaults to
+   * `~/.config/cortex/cortex.sock` to match the daemon's default
+   * (`src/runner/creds-handler.ts`). Used by tests + operators with
+   * non-standard deployments.
+   */
+  socket: string | undefined;
   json: boolean;
   help: boolean;
 }
@@ -74,9 +94,20 @@ export interface CredsItem {
 }
 
 /**
- * Message emitted by the v1 stubs for `issue` / `revoke` / `rotate`. Exported
- * so tests can assert against the exact string without it living in two
- * places.
+ * Pre-cortex#67 deferred-stub message. Kept exported for two reasons:
+ *   1. The shared `_shared/envelope.ts` shape stays stable for scripting
+ *      consumers — the JSON envelope's `error.reason` still surfaces a
+ *      clear deferred-feature explanation when the daemon is unreachable
+ *      (we re-use it as the fallback message).
+ *   2. Pre-existing tests pin against the constant; keeping it preserves
+ *      backward compatibility for downstream tooling that parsed the
+ *      stderr string.
+ *
+ * Now that cortex#67 has landed, the IPC client returns operator-actionable
+ * errors (e.g. "cortex daemon not reachable; ensure it is running and that
+ * its socket is at <path>"). The legacy DEFERRED_SUBCOMMAND_MESSAGE is no
+ * longer the typical user-facing message — only fired when something at
+ * the CLI parse layer rejects before IPC.
  */
 export const DEFERRED_SUBCOMMAND_MESSAGE =
   "not yet implemented — pending cortex daemon-IPC integration (cortex#67). " +
@@ -91,6 +122,16 @@ export const DEFERRED_SUBCOMMAND_MESSAGE =
  */
 const AGENT_ID_REGEX = /^[a-z0-9-]+$/;
 const DEFAULT_CREDS_DIR = "~/.config/nats/creds";
+
+/**
+ * Default daemon socket path. Matches the daemon's default in
+ * `src/runner/creds-handler.ts`. Operators can override via `--socket`.
+ */
+const DEFAULT_SOCKET_PATH = "~/.config/cortex/cortex.sock";
+
+/** IPC request timeout — UNIX-local calls finish in milliseconds; 5 s is
+ *  generous and matches the daemon's per-request timeout. */
+const IPC_TIMEOUT_MS = 5_000;
 
 /** Hardening cap on `readdirSync` entry count (Echo H1 nit cortex#64).
  *  A creds directory with thousands of entries is a misconfiguration; refuse
@@ -110,9 +151,18 @@ const CREDS_SPEC: SubcommandSpec<"list" | "issue" | "revoke" | "rotate"> = {
   cliName: "creds",
   subcommands: {
     list: { flags: { "--creds-dir": "value" } },
-    issue: { positionals: ["agent-id"], flags: { "--config": "value" } },
-    revoke: { positionals: ["agent-id"], flags: { "--config": "value" } },
-    rotate: { positionals: ["agent-id"], flags: { "--config": "value" } },
+    issue: {
+      positionals: ["agent-id"],
+      flags: { "--config": "value", "--socket": "value" },
+    },
+    revoke: {
+      positionals: ["agent-id"],
+      flags: { "--config": "value", "--socket": "value" },
+    },
+    rotate: {
+      positionals: ["agent-id"],
+      flags: { "--config": "value", "--socket": "value" },
+    },
   },
   universal: { "--help": "bool", "-h": "bool", "--json": "bool" },
 };
@@ -163,6 +213,7 @@ export function parseCredsArgs(argv: string[]): ParsedCredsArgs {
         agentId: undefined,
         credsDir: undefined,
         config: undefined,
+        socket: undefined,
         json: false,
         help: false,
       };
@@ -176,6 +227,7 @@ export function parseCredsArgs(argv: string[]): ParsedCredsArgs {
     agentId: parsed.positionals["agent-id"],
     credsDir: valueFlag(parsed.flags, "--creds-dir"),
     config: valueFlag(parsed.flags, "--config"),
+    socket: valueFlag(parsed.flags, "--socket"),
     json: boolFlag(parsed.flags, "--json"),
     help: parsed.help,
   };
@@ -314,31 +366,190 @@ export function runCredsList(args: ParsedCredsArgs): ExitResult {
 }
 
 // =============================================================================
-// runCredsIssue / Revoke / Rotate (v1 stubs)
+// IPC client — daemon UNIX socket
 // =============================================================================
 
-export function runCredsIssue(args: ParsedCredsArgs): ExitResult {
-  return runDeferredSubcommand(args, "issue");
+/**
+ * Daemon response envelope. Mirrors `CredsResponse` from the daemon-side
+ * `src/runner/creds-handler.ts`. Defined here as a local type so the CLI
+ * doesn't import the runner-side module (keeps the CLI build slim).
+ */
+interface DaemonResponse {
+  ok: boolean;
+  verb: "issue" | "revoke" | "rotate";
+  agent_id?: string;
+  error?: string;
+  message?: string;
+  creds_path?: string;
+  file_deleted?: boolean;
+  user_jwt_summary?: {
+    sub: string;
+    iss: string;
+    capabilities: string[];
+  };
 }
 
-export function runCredsRevoke(args: ParsedCredsArgs): ExitResult {
-  return runDeferredSubcommand(args, "revoke");
+/**
+ * Thrown when the daemon socket is unreachable (file missing, ECONNREFUSED,
+ * permission denied). Caller maps to exit 1 + operator-facing message.
+ *
+ * NOT thrown when the daemon returns `ok=false` — that's a structured
+ * response, not a transport failure.
+ */
+class DaemonUnreachableError extends Error {
+  readonly socketPath: string;
+  // `cause` is on Error in ES2022+ but tsconfig's `noImplicitOverride` flags
+  // it; declare the override explicitly. Same pattern used by the runner's
+  // own structured errors.
+  override readonly cause: Error | undefined;
+  constructor(socketPath: string, cause?: Error) {
+    super(
+      `cortex daemon not reachable at ${socketPath}` +
+        (cause ? ` (${cause.message})` : "") +
+        " — ensure the daemon is running, that creds-handler started without errors, " +
+        "and that the socket path matches (override with --socket <path>).",
+    );
+    this.name = "DaemonUnreachableError";
+    this.socketPath = socketPath;
+    this.cause = cause;
+  }
 }
 
-export function runCredsRotate(args: ParsedCredsArgs): ExitResult {
-  return runDeferredSubcommand(args, "rotate");
+/**
+ * Send a `{verb, agent_id}` request to the daemon socket and parse the
+ * JSON response. Newline-delimited framing — matches the daemon-side
+ * `handleConnection`'s newline expectation (see creds-handler.ts comment
+ * for the Bun-specific rationale).
+ *
+ * Throws `DaemonUnreachableError` on transport failure. Returns the
+ * parsed `DaemonResponse` on a clean round-trip — the caller decides how
+ * to surface `ok=false` envelopes.
+ */
+async function callDaemon(
+  socketPath: string,
+  verb: "issue" | "revoke" | "rotate",
+  agentId: string,
+): Promise<DaemonResponse> {
+  const expandedSocket = expandTilde(socketPath);
+  return new Promise<DaemonResponse>((resolve, reject) => {
+    const client = connect(expandedSocket);
+    let buffer = "";
+    let settled = false;
+    client.setEncoding("utf-8");
+
+    const settleErr = (err: Error) => {
+      if (settled) return;
+      settled = true;
+      try {
+        client.destroy();
+      } catch {
+        // best-effort cleanup
+      }
+      reject(err);
+    };
+
+    const timeout = setTimeout(() => {
+      settleErr(
+        new DaemonUnreachableError(
+          expandedSocket,
+          new Error(`request timed out after ${IPC_TIMEOUT_MS}ms`),
+        ),
+      );
+    }, IPC_TIMEOUT_MS);
+
+    client.on("connect", () => {
+      client.write(JSON.stringify({ verb, agent_id: agentId }) + "\n");
+    });
+
+    client.on("data", (chunk: string) => {
+      buffer += chunk;
+    });
+
+    client.on("end", () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      const raw = buffer.trim();
+      if (raw.length === 0) {
+        reject(
+          new DaemonUnreachableError(
+            expandedSocket,
+            new Error("daemon closed connection without sending a response"),
+          ),
+        );
+        return;
+      }
+      try {
+        resolve(JSON.parse(raw) as DaemonResponse);
+      } catch (err) {
+        reject(
+          new Error(
+            `cortex creds ${verb}: daemon returned malformed JSON ("${raw}"): ${err instanceof Error ? err.message : String(err)}`,
+          ),
+        );
+      }
+    });
+
+    client.on("error", (err: NodeJS.ErrnoException) => {
+      if (settled) return;
+      // ENOENT (socket file missing), ECONNREFUSED (no listener), EACCES
+      // (permission denied) all map to the same operator-actionable
+      // "daemon not reachable" error.
+      if (
+        err.code === "ENOENT" ||
+        err.code === "ECONNREFUSED" ||
+        err.code === "EACCES" ||
+        err.code === "EPERM"
+      ) {
+        settleErr(new DaemonUnreachableError(expandedSocket, err));
+        return;
+      }
+      settleErr(err);
+    });
+  });
 }
 
-function runDeferredSubcommand(
+// =============================================================================
+// runCredsIssue / Revoke / Rotate — IPC-backed
+// =============================================================================
+
+export async function runCredsIssue(args: ParsedCredsArgs): Promise<ExitResult> {
+  return runSubcommandViaDaemon(args, "issue");
+}
+
+export async function runCredsRevoke(args: ParsedCredsArgs): Promise<ExitResult> {
+  return runSubcommandViaDaemon(args, "revoke");
+}
+
+export async function runCredsRotate(args: ParsedCredsArgs): Promise<ExitResult> {
+  return runSubcommandViaDaemon(args, "rotate");
+}
+
+/**
+ * Shared driver for `issue` / `revoke` / `rotate`.
+ *
+ * Flow:
+ *   1. Help short-circuit.
+ *   2. Operator-input validation (agent id presence + regex).
+ *   3. IPC call via `callDaemon()`.
+ *   4. Map response → ExitResult. Daemon `ok=true` → exit 0; daemon
+ *      `ok=false` with a known stub-error → exit 1 with the daemon's
+ *      message verbatim; transport failure → exit 1 with a "daemon
+ *      not reachable" message.
+ *
+ * Why not split the validation + IPC into two functions? Keeps the call
+ * graph flat and the error-envelope shape consistent across all three
+ * verbs without an extra indirection layer.
+ */
+async function runSubcommandViaDaemon(
   args: ParsedCredsArgs,
   subcommand: "issue" | "revoke" | "rotate",
-): ExitResult {
+): Promise<ExitResult> {
   if (args.help) {
-    return { exitCode: 0, stdout: deferredSubcommandHelp(subcommand), stderr: "" };
+    return { exitCode: 0, stdout: subcommandHelp(subcommand), stderr: "" };
   }
 
-  // Validate the agent id at the CLI layer — surface operator input errors
-  // before the deferred-stub message, even though v1 won't act.
+  // Operator-input validation.
   if (!args.agentId) {
     const reason = `missing agent id (usage: cortex creds ${subcommand} <agent-id>)`;
     if (args.json) {
@@ -370,18 +581,130 @@ function runDeferredSubcommand(
     };
   }
 
-  if (args.json) {
+  const socketPath = args.socket ?? DEFAULT_SOCKET_PATH;
+  let response: DaemonResponse;
+  try {
+    response = await callDaemon(socketPath, subcommand, args.agentId);
+  } catch (err) {
+    // Transport failure — daemon unreachable or malformed reply.
+    const reason = err instanceof Error ? err.message : String(err);
+    if (args.json) {
+      return {
+        exitCode: 1,
+        stdout: errorEnvelopeForSubcommand(reason, subcommand, args.agentId),
+        stderr: "",
+      };
+    }
     return {
-      exitCode: 2,
-      stdout: errorEnvelopeForSubcommand(DEFERRED_SUBCOMMAND_MESSAGE, subcommand, args.agentId),
+      exitCode: 1,
+      stdout: "",
+      stderr: `cortex creds ${subcommand}: ${reason}\n`,
+    };
+  }
+
+  return formatDaemonResponse(response, args, subcommand);
+}
+
+/**
+ * Map a daemon response envelope into an `ExitResult`.
+ *
+ * The mapping is verb-aware because the narrower stubs (`revoke`,
+ * `rotate`) carry an operator-friendly `message` field that supplements
+ * `error`. We surface both so the operator understands exactly what
+ * happened.
+ *
+ * Exit codes:
+ *   - 0 on `ok=true`
+ *   - 1 on `ok=false` — the daemon spoke but reported a failure (unknown
+ *     agent, mint error, the narrower-stub `revoke` deferred-server-side
+ *     case, etc.)
+ */
+function formatDaemonResponse(
+  response: DaemonResponse,
+  args: ParsedCredsArgs,
+  subcommand: "issue" | "revoke" | "rotate",
+): ExitResult {
+  if (args.json) {
+    // The CLI's JSON envelope wraps the daemon's response — we don't pass
+    // the daemon envelope through verbatim because the CLI envelope shape
+    // (`status / items / error`) is the stable scripting contract. Embed
+    // the daemon-supplied summary in the `context` map for callers that
+    // want to inspect it.
+    const ctx: Record<string, string> = {
+      subcommand,
+      agentId: args.agentId ?? "",
+      verb: response.verb,
+    };
+    if (response.creds_path) ctx.creds_path = response.creds_path;
+    if (response.message) ctx.message = response.message;
+    if (response.user_jwt_summary?.sub) ctx.sub = response.user_jwt_summary.sub;
+    if (response.user_jwt_summary?.iss) ctx.iss = response.user_jwt_summary.iss;
+    if (response.user_jwt_summary?.capabilities) {
+      ctx.capabilities = response.user_jwt_summary.capabilities.join(",");
+    }
+    if (response.file_deleted !== undefined) {
+      ctx.file_deleted = String(response.file_deleted);
+    }
+
+    if (response.ok) {
+      return {
+        exitCode: 0,
+        stdout: renderJson({
+          status: "ok",
+          items: [],
+          // We don't surface success metadata in `error` (would be
+          // misleading). Embed in `error.context` only on failure path
+          // below. Operators who want structured success metadata in
+          // JSON parse the text stdout from the non-JSON path.
+          //
+          // For now, success returns the envelope shape with empty
+          // items + no error field. The interesting fields land in the
+          // text mode.
+        } as Parameters<typeof renderJson>[0]),
+        stderr: "",
+      };
+    }
+
+    return {
+      exitCode: 1,
+      stdout: renderJson(
+        envelopeError<CredsItem>(response.error ?? "daemon reported failure", ctx),
+      ),
       stderr: "",
     };
   }
-  return {
-    exitCode: 2,
-    stdout: "",
-    stderr: `cortex creds ${subcommand}: ${DEFERRED_SUBCOMMAND_MESSAGE}\n`,
-  };
+
+  // Text mode — human-readable summary.
+  if (response.ok) {
+    const lines: string[] = [];
+    lines.push(`cortex creds ${subcommand}: ok — agent="${response.agent_id}"`);
+    if (response.creds_path) {
+      lines.push(`  creds_path: ${response.creds_path}`);
+    }
+    if (response.user_jwt_summary) {
+      lines.push(`  sub: ${response.user_jwt_summary.sub}`);
+      lines.push(`  iss: ${response.user_jwt_summary.iss}`);
+      lines.push(
+        `  capabilities: ${response.user_jwt_summary.capabilities.length > 0 ? response.user_jwt_summary.capabilities.join(", ") : "(none)"}`,
+      );
+    }
+    if (response.message) {
+      lines.push(`  note: ${response.message}`);
+    }
+    return { exitCode: 0, stdout: lines.join("\n") + "\n", stderr: "" };
+  }
+
+  // Failure — combine `error` (machine code) + `message` (operator-facing)
+  // on stderr so the operator sees both.
+  const errLines: string[] = [];
+  errLines.push(`cortex creds ${subcommand}: ${response.error ?? "daemon reported failure"}`);
+  if (response.message) {
+    errLines.push(`  ${response.message}`);
+  }
+  if (response.file_deleted !== undefined) {
+    errLines.push(`  file_deleted: ${response.file_deleted}`);
+  }
+  return { exitCode: 1, stdout: "", stderr: errLines.join("\n") + "\n" };
 }
 
 /** Build a creds-specific error envelope (uses shared `context` for
@@ -400,7 +723,13 @@ function errorEnvelopeForSubcommand(
 // dispatchCreds
 // =============================================================================
 
-export function dispatchCreds(argv: string[]): ExitResult {
+/**
+ * Async because `issue` / `revoke` / `rotate` perform real IPC (UNIX
+ * socket round-trip with the cortex daemon). `list`, `help`, and the
+ * usage-error branches remain synchronous but are wrapped in the same
+ * `Promise<ExitResult>` for caller uniformity.
+ */
+export async function dispatchCreds(argv: string[]): Promise<ExitResult> {
   let args: ParsedCredsArgs;
   try {
     args = parseCredsArgs(argv);
@@ -419,11 +748,11 @@ export function dispatchCreds(argv: string[]): ExitResult {
     case "list":
       return runCredsList(args);
     case "issue":
-      return runCredsIssue(args);
+      return await runCredsIssue(args);
     case "revoke":
-      return runCredsRevoke(args);
+      return await runCredsRevoke(args);
     case "rotate":
-      return runCredsRotate(args);
+      return await runCredsRotate(args);
     case "help":
       return { exitCode: 0, stdout: topLevelHelp(), stderr: "" };
     case "unknown":
@@ -463,22 +792,25 @@ function topLevelHelp(): string {
 
 Usage:
   cortex creds list   [--creds-dir <path>] [--json]
-  cortex creds issue  <agent-id> [--config <path>] [--json]
-  cortex creds revoke <agent-id> [--config <path>] [--json]
-  cortex creds rotate <agent-id> [--config <path>] [--json]
+  cortex creds issue  <agent-id> [--config <path>] [--socket <path>] [--json]
+  cortex creds revoke <agent-id> [--config <path>] [--socket <path>] [--json]
+  cortex creds rotate <agent-id> [--config <path>] [--socket <path>] [--json]
   cortex creds --help
 
 Subcommands:
-  list     List existing creds files (v1: filesystem-only — fully functional)
-  issue    Mint creds for an agent (v1: deferred — see cortex#60 §6.3)
-  revoke   Revoke creds (v1: deferred)
-  rotate   Revoke + issue atomically (v1: deferred)
+  list     List existing creds files (filesystem-only)
+  issue    Mint creds for an agent — daemon-mediated (cortex#67)
+  revoke   Revoke creds — v1: deletes local file only; server-side revoke
+           is pending system-account topology design (see cortex#67)
+  rotate   Local-file rotate (delete + re-mint). Same server-side caveat
+           as revoke for the old JWT.
 
 Per-subcommand options:
-  list:    --creds-dir <path>   Directory containing .creds files (default: ~/.config/nats/creds)
-  issue:   --config <path>      cortex.yaml path (for v2 daemon contact)
-  revoke:  --config <path>      same
-  rotate:  --config <path>      same
+  list:     --creds-dir <path>  Directory containing .creds files (default: ~/.config/nats/creds)
+  issue:    --config <path>     cortex.yaml path (informational; daemon owns its own config)
+            --socket <path>     Daemon socket path (default: ~/.config/cortex/cortex.sock)
+  revoke:   --config / --socket  same
+  rotate:   --config / --socket  same
 
 Universal options:
   --json               Emit structured JSON envelope (shared shape via _shared/envelope.ts)
@@ -489,8 +821,8 @@ error (exit 2). E.g. \`cortex creds issue echo --creds-dir /tmp\` is rejected.
 
 Exit codes:
   0    success
-  1    operational failure
-  2    usage error / deferred subcommand
+  1    operational failure (daemon unreachable, daemon reported ok=false)
+  2    usage error (bad flag, bad agent id, missing positional)
 `;
 }
 
@@ -512,19 +844,32 @@ Behavior:
 `;
 }
 
-function deferredSubcommandHelp(sub: "issue" | "revoke" | "rotate"): string {
-  return `cortex creds ${sub} — ${sub} per-agent NATS credentials (v1: deferred)
+function subcommandHelp(sub: "issue" | "revoke" | "rotate"): string {
+  const verbDesc =
+    sub === "issue"
+      ? "mint a fresh per-agent NATS user JWT scoped to the agent's runtime.capabilities"
+      : sub === "revoke"
+        ? "revoke an agent's local creds file (v1: server-side revoke pending)"
+        : "rotate: delete local file + re-issue (v1: server-side revoke pending)";
+
+  return `cortex creds ${sub} — ${verbDesc}
 
 Usage:
-  cortex creds ${sub} <agent-id> [--config <path>] [--json]
+  cortex creds ${sub} <agent-id> [--config <path>] [--socket <path>] [--json]
 
-${DEFERRED_SUBCOMMAND_MESSAGE}
+Behavior:
+  - Connects to the cortex daemon via UNIX socket (default: ~/.config/cortex/cortex.sock).
+  - Daemon performs the action, returns a JSON envelope.
+  - CLI maps the envelope to exit 0 (ok) or exit 1 (daemon reported failure / unreachable).
 
-When implemented, the v2 surface will:
-  - Validate the agent id against the cortex.yaml registry
-  - Connect to the cortex daemon via NATS req/rep (preferred) or UNIX socket (fallback)
-  - Daemon performs server-side ${sub === "issue" ? "mint" : sub === "revoke" ? "revoke (server-side first)" : "rotate (revoke + mint atomic)"}
-  - On success, write/remove the local creds file at ~/.config/nats/creds/<id>.creds
+${sub === "revoke" || sub === "rotate" ? `Note: v1 only modifies the LOCAL .creds file. Server-side NATS account-JWT
+revoke is pending system-account topology design (see src/runner/creds-handler.ts).
+The daemon's response documents the limitation; the CLI surfaces it on stderr.
+
+` : ""}Exit codes:
+  0    daemon reported ok=true
+  1    daemon reported ok=false OR daemon not reachable
+  2    bad agent id / missing positional / bad flag
 `;
 }
 
@@ -533,7 +878,9 @@ When implemented, the v2 surface will:
 // =============================================================================
 
 if (import.meta.main) {
-  const result = dispatchCreds(process.argv.slice(2));
+  // dispatchCreds is async because issue/revoke/rotate IPC over UNIX socket.
+  // top-level await is available in Bun.
+  const result = await dispatchCreds(process.argv.slice(2));
   if (result.stdout) process.stdout.write(result.stdout);
   if (result.stderr) process.stderr.write(result.stderr);
   process.exit(result.exitCode);

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -24,6 +24,7 @@ import { fetchWithTimeout } from "./common/timeout";
 import { UsageMonitor } from "./common/usage/monitor";
 import { AgentRegistry } from "./common/agents/registry";
 import { createCredsHandler, type CredsHandler } from "./runner/creds-handler";
+import { loadAccountSigningKey } from "./common/config/account-signing-key";
 import type { UsageStats } from "./runner/stream-parser";
 
 import { buildSecurityPreamble } from "./runner/security-preamble";
@@ -239,18 +240,45 @@ export async function startCortex(
     console.log("cortex: agent registry assembled — 0 agents (no inline agents, no fragments)");
   }
 
-  // cortex#67 — conditional creds handler. Today the body is a stub
-  // (src/runner/creds-handler.ts); the conditional shape lives here so the
-  // full implementation can swap in without touching cortex.ts. Gated on
-  // runtime being enabled + at least one registered agent — there's no
-  // point minting per-agent NATS JWTs without either a NATS link or any
-  // agent to scope creds to. The account-signing-key gate arrives once
-  // prereq B has landed.
+  // cortex#67 — creds handler. Daemon-side RPC surface for `cortex creds
+  // issue / revoke / rotate` (see `src/runner/creds-handler.ts`). Gated on
+  // ALL of:
+  //   - `runtime.enabled` (no point minting NATS creds without a NATS link)
+  //   - `agentRegistry.size > 0` (no agents → nothing to issue creds for)
+  //   - `config.nats?.accountSigningKeyPath` set (operator opted in to
+  //     daemon-mediated minting; without the signing key the handler can't
+  //     produce valid JWTs)
+  //
+  // The signing-key file is loaded via prereq B's `loadAccountSigningKey`
+  // which enforces chmod 600 + SA-prefix. Load failure is non-fatal at the
+  // creds-handler scope: the rest of cortex keeps running, the operator
+  // sees an explicit error pointing at the offending file. Same shape as
+  // the runtime-startup error path above.
   let credsHandler: CredsHandler | null = null;
-  if (runtime.enabled && agentRegistry.size > 0) {
-    credsHandler = createCredsHandler({ runtime, registry: agentRegistry });
-    await credsHandler.start();
-    console.log("cortex: creds handler ready (stub)");
+  if (
+    runtime.enabled
+    && agentRegistry.size > 0
+    && config.nats?.accountSigningKeyPath
+  ) {
+    try {
+      const accountSigningKey = await loadAccountSigningKey(
+        expandTilde(config.nats.accountSigningKeyPath),
+      );
+      credsHandler = createCredsHandler({
+        runtime,
+        registry: agentRegistry,
+        accountSigningKey,
+        org: config.agent.operatorId ?? "default",
+      });
+      await credsHandler.start();
+      console.log("cortex: creds handler ready");
+    } catch (err) {
+      credsHandler = null;
+      console.error(
+        "cortex: creds handler startup error (non-fatal):",
+        err instanceof Error ? err.message : err,
+      );
+    }
   }
 
   // Surface router (in-process fan-out).

--- a/src/runner/__tests__/creds-handler.test.ts
+++ b/src/runner/__tests__/creds-handler.test.ts
@@ -1,29 +1,40 @@
 /**
- * cortex#67 prereq C — creds-handler stub tests.
+ * cortex#67 — creds-handler tests.
  *
- * The stub's surface is intentionally minimal: a factory that accepts a
- * runtime + registry and returns a `{ start, stop }` handle whose methods
- * are idempotent no-ops. We assert the surface shape + idempotence so the
- * future replacement (cortex#67 full implementation) is constrained to keep
- * those guarantees.
+ * Two layers:
  *
- * Scope:
- *   - createCredsHandler returns a CredsHandler with async start/stop
- *   - start() is idempotent (calling twice does not throw)
- *   - stop() is idempotent (calling twice does not throw)
- *   - stop() before start() is safe (no preconditions on lifecycle order)
- *   - start() resolves quickly (the stub does no real work)
+ *   1. **Surface + idempotence** (carried from the prereq-C stub) — the
+ *      factory shape and lifecycle invariants stay intact. Tests pinned at
+ *      this layer protect the public type from accidental regressions.
+ *   2. **End-to-end fake-daemon** — spin up the real handler against a
+ *      tmp socket path + tmp creds dir + a fresh `nkeys.createAccount()`
+ *      signing key, then drive `issue` / `revoke` / `rotate` via a local
+ *      UNIX-socket client. Asserts the cred file lands at the expected
+ *      path with chmod 600, that the JWT decodes back to the agent's
+ *      capabilities, that the narrower stubs return the documented
+ *      responses, and that error paths produce structured envelopes.
  *
- * Out of scope (lands with cortex#67):
- *   - JWT minting per agent capability set
- *   - Account signing key handling
- *   - Refresh-timer behaviour
- *   - Publishing minted creds via the runtime
+ * We do NOT stand up a real `nats-server` here — the handler's JWT-minting
+ * is pure crypto. The integration test that verifies a real `nats-server`
+ * accepts these creds lives downstream of cortex#67.
  */
 
-import { describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { chmodSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "fs";
+import { join, dirname } from "path";
+import { tmpdir } from "os";
+import { connect, createServer, type Socket } from "net";
+import { createAccount, type KeyPair } from "nkeys.js";
+import { decode, type User } from "@nats-io/jwt";
 
-import { createCredsHandler, type CredsHandlerOpts } from "../creds-handler";
+import {
+  createCredsHandler,
+  handleRequest,
+  parseCredsRequest,
+  type CredsHandlerOpts,
+  type CredsRequest,
+  type CredsResponse,
+} from "../creds-handler";
 import { AgentRegistry } from "../../common/agents/registry";
 import type { Agent } from "../../common/types/cortex-config";
 import type { MyelinRuntime } from "../../bus/myelin/runtime";
@@ -33,10 +44,9 @@ import type { MyelinRuntime } from "../../bus/myelin/runtime";
 // =============================================================================
 
 /**
- * Disabled MyelinRuntime — the stub doesn't touch the runtime, but the type
- * requires one. A `enabled: false` no-op runtime is the minimal shape that
- * compiles; once cortex#67 actually publishes creds via `runtime.publish`,
- * the test will swap this for a recording fake.
+ * Disabled MyelinRuntime — the v1 handler doesn't reach into the runtime
+ * (UNIX-socket only); the field exists for v2 forward-compat. We pass a
+ * disabled stub so the type satisfies without any side effects.
  */
 function fakeRuntime(): MyelinRuntime {
   return {
@@ -48,17 +58,18 @@ function fakeRuntime(): MyelinRuntime {
 }
 
 /**
- * Single-agent registry — enough to satisfy the stub's `registry` opt without
- * needing to wire trust-closure validation against multiple peers. The agent's
- * `runtime.capabilities` field is what cortex#67 will read; we set a
- * non-empty value here so a future test that exercises the real handler can
- * assert the capability flowed into the minted JWT.
+ * Build a fake agent with the given id + capabilities. The runtime block is
+ * populated so `agent.runtime.capabilities` flows into the minted JWT.
+ *
+ * Other fields (persona, presence) are set to minimal-valid placeholders so
+ * `AgentRegistry.fromAgents` accepts the entry. None of them factor into
+ * the creds handler's behaviour.
  */
-function fakeRegistry(): AgentRegistry {
-  const agent: Agent = {
-    id: "scout",
-    displayName: "Scout",
-    persona: "/tmp/scout-persona.md",
+function fakeAgent(id: string, capabilities: string[]): Agent {
+  return {
+    id,
+    displayName: id,
+    persona: `/tmp/${id}-persona.md`,
     roles: [],
     trust: [],
     presence: {
@@ -86,108 +97,716 @@ function fakeRegistry(): AgentRegistry {
     runtime: {
       substrate: "claude-code",
       mode: "in-process",
-      capabilities: ["research"],
+      capabilities,
     },
   } as Agent;
-  return AgentRegistry.fromAgents([agent]);
 }
 
-function fakeOpts(): CredsHandlerOpts {
-  return { runtime: fakeRuntime(), registry: fakeRegistry() };
+/** Default single-agent registry. */
+function fakeRegistry(): AgentRegistry {
+  return AgentRegistry.fromAgents([fakeAgent("scout", ["research"])]);
+}
+
+/**
+ * Build CredsHandlerOpts with a fresh signing key + tmp creds dir + tmp
+ * socket path. Returns the opts plus the temp paths so tests can assert
+ * against / clean up the temp state.
+ */
+interface FakeOptsResult {
+  opts: CredsHandlerOpts;
+  socketPath: string;
+  credsDir: string;
+  signingKey: KeyPair;
+  cleanup: () => void;
+}
+function fakeOpts(overrides?: { registry?: AgentRegistry; org?: string }): FakeOptsResult {
+  const tmpRoot = mkdtempSync(join(tmpdir(), "cortex-creds-test-"));
+  const socketPath = join(tmpRoot, "cortex.sock");
+  const credsDir = join(tmpRoot, "creds");
+  const signingKey = createAccount();
+  const opts: CredsHandlerOpts = {
+    runtime: fakeRuntime(),
+    registry: overrides?.registry ?? fakeRegistry(),
+    accountSigningKey: signingKey,
+    org: overrides?.org ?? "acme",
+    socketPath,
+    credsDir,
+  };
+  return {
+    opts,
+    socketPath,
+    credsDir,
+    signingKey,
+    cleanup: () => {
+      try {
+        rmSync(tmpRoot, { recursive: true, force: true });
+      } catch {
+        // best-effort
+      }
+    },
+  };
 }
 
 // =============================================================================
-// Surface shape
+// Surface shape + idempotence (carried from prereq-C stub)
 // =============================================================================
 
 describe("createCredsHandler — surface", () => {
   test("returns a handle with async start and stop methods", () => {
-    const handle = createCredsHandler(fakeOpts());
-    expect(handle).toBeDefined();
-    expect(typeof handle.start).toBe("function");
-    expect(typeof handle.stop).toBe("function");
+    const fixture = fakeOpts();
+    try {
+      const handle = createCredsHandler(fixture.opts);
+      expect(handle).toBeDefined();
+      expect(typeof handle.start).toBe("function");
+      expect(typeof handle.stop).toBe("function");
+    } finally {
+      fixture.cleanup();
+    }
   });
 
-  test("start() returns a Promise", () => {
-    const handle = createCredsHandler(fakeOpts());
-    const result = handle.start();
-    expect(result).toBeInstanceOf(Promise);
-    return result;
-  });
-
-  test("stop() returns a Promise", () => {
-    const handle = createCredsHandler(fakeOpts());
-    const result = handle.stop();
-    expect(result).toBeInstanceOf(Promise);
-    return result;
+  test("stop() returns a Promise even before start()", () => {
+    const fixture = fakeOpts();
+    try {
+      const handle = createCredsHandler(fixture.opts);
+      const result = handle.stop();
+      expect(result).toBeInstanceOf(Promise);
+      return result.finally(fixture.cleanup);
+    } catch (err) {
+      fixture.cleanup();
+      throw err;
+    }
   });
 });
 
-// =============================================================================
-// Idempotence — the stub MUST tolerate repeated lifecycle calls. The full
-// cortex#67 handler will share this guarantee (the cortex.ts shutdown drain
-// calls stop() once but a future signal-handler retry path could land here).
-// =============================================================================
-
-describe("createCredsHandler — idempotent lifecycle (stub)", () => {
+describe("createCredsHandler — idempotent lifecycle", () => {
   test("start() can be called twice without throwing", async () => {
-    const handle = createCredsHandler(fakeOpts());
-    await handle.start();
-    await handle.start();
+    const fixture = fakeOpts();
+    const handle = createCredsHandler(fixture.opts);
+    try {
+      await handle.start();
+      await handle.start();
+    } finally {
+      await handle.stop();
+      fixture.cleanup();
+    }
   });
 
   test("stop() can be called twice without throwing", async () => {
-    const handle = createCredsHandler(fakeOpts());
-    await handle.start();
-    await handle.stop();
-    await handle.stop();
+    const fixture = fakeOpts();
+    const handle = createCredsHandler(fixture.opts);
+    try {
+      await handle.start();
+      await handle.stop();
+      await handle.stop();
+    } finally {
+      fixture.cleanup();
+    }
   });
 
   test("stop() before start() is a safe no-op", async () => {
-    // Defensive: a caller that constructs a handler and then bails before
-    // start() (e.g. an upstream gate threw) must still be able to call
-    // stop() during shutdown without exploding.
-    const handle = createCredsHandler(fakeOpts());
-    await handle.stop();
-  });
-
-  test("start() resolves promptly — stub does no real work", async () => {
-    const handle = createCredsHandler(fakeOpts());
-    const before = Date.now();
-    await handle.start();
-    const elapsed = Date.now() - before;
-    // Generous upper bound — the stub should resolve in microseconds. We
-    // assert <100ms so this test doesn't flake on a loaded CI runner while
-    // still catching a regression where the future real handler accidentally
-    // ships in stub-shape but with real work tacked on.
-    expect(elapsed).toBeLessThan(100);
+    const fixture = fakeOpts();
+    const handle = createCredsHandler(fixture.opts);
+    try {
+      await handle.stop();
+    } finally {
+      fixture.cleanup();
+    }
   });
 });
 
 // =============================================================================
-// Opts handling — the stub captures opts in its closure (today the body is a
-// no-op but cortex#67 will use them); ensure construction with valid opts
-// succeeds for both empty and populated registries.
+// handleRequest — transport-agnostic core
 // =============================================================================
 
-describe("createCredsHandler — opts", () => {
-  test("accepts a registry with zero agents (caller responsible for gating)", () => {
-    // cortex.ts gates `agentRegistry.size > 0` BEFORE calling
-    // createCredsHandler — but the factory itself should not enforce a
-    // non-empty registry. Keeps the contract symmetric with the future
-    // real handler (which might still want to construct against an empty
-    // registry to register a "no agents yet" sentinel).
-    const opts: CredsHandlerOpts = {
-      runtime: fakeRuntime(),
-      registry: AgentRegistry.fromAgents([]),
-    };
-    expect(() => createCredsHandler(opts)).not.toThrow();
+describe("handleRequest — issue", () => {
+  test("issue mints + writes a chmod-600 creds file at credsDir/{agentId}.creds", async () => {
+    const fixture = fakeOpts();
+    try {
+      const response = await handleRequest(
+        { verb: "issue", agent_id: "scout" },
+        {
+          registry: fixture.opts.registry,
+          accountSigningKey: fixture.signingKey,
+          org: "acme",
+          credsDir: fixture.credsDir,
+        },
+      );
+      expect(response.ok).toBe(true);
+      expect(response.verb).toBe("issue");
+      expect(response.agent_id).toBe("scout");
+      expect(response.creds_path).toBe(join(fixture.credsDir, "scout.creds"));
+
+      // File exists and has chmod 600.
+      const stat = statSync(response.creds_path!);
+      expect(stat.isFile()).toBe(true);
+      if (process.platform !== "win32") {
+        // mode & 0o777 to mask off the file-type bits.
+        expect(stat.mode & 0o777).toBe(0o600);
+      }
+    } finally {
+      fixture.cleanup();
+    }
   });
 
-  test("accepts a registry with agents declaring runtime.capabilities", () => {
-    // The motivating use case for cortex#67: each agent's `runtime.capabilities`
-    // bounds the NATS user permissions on its minted JWT. The stub doesn't
-    // read it yet but the factory must accept the shape.
-    expect(() => createCredsHandler(fakeOpts())).not.toThrow();
+  test("issue rejects unknown agent_id", async () => {
+    const fixture = fakeOpts();
+    try {
+      const response = await handleRequest(
+        { verb: "issue", agent_id: "ghost" },
+        {
+          registry: fixture.opts.registry,
+          accountSigningKey: fixture.signingKey,
+          org: "acme",
+          credsDir: fixture.credsDir,
+        },
+      );
+      expect(response.ok).toBe(false);
+      expect(response.error).toMatch(/unknown agent "ghost"/);
+      expect(response.agent_id).toBe("ghost");
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  test("issued JWT scopes pub+sub to agent's runtime.capabilities", async () => {
+    const fixture = fakeOpts({
+      registry: AgentRegistry.fromAgents([fakeAgent("multi", ["code-review", "typescript"])]),
+    });
+    try {
+      const response = await handleRequest(
+        { verb: "issue", agent_id: "multi" },
+        {
+          registry: fixture.opts.registry,
+          accountSigningKey: fixture.signingKey,
+          org: "acme",
+          credsDir: fixture.credsDir,
+        },
+      );
+      expect(response.ok).toBe(true);
+      expect(response.user_jwt_summary).toBeDefined();
+      expect(response.user_jwt_summary?.capabilities).toEqual(["code-review", "typescript"]);
+
+      // Decode the .creds file contents to recover the JWT and assert the
+      // capability subjects landed on the allow lists.
+      //
+      // `@nats-io/jwt`'s `fmtCreds` emits dash count `-----BEGIN...-----`
+      // (5 dashes each side) for the BEGIN line and `------END...------`
+      // (6 dashes each side) for the END line. We don't pin the exact
+      // dash count here — match BEGIN with `>=3` dashes either side and
+      // capture the body up to the matching END marker. Keeps the
+      // assertion forward-compat with formatter tweaks.
+      const credsFile = readFileSync(response.creds_path!, "utf-8");
+      const jwtMatch = credsFile.match(
+        /-{3,}\s*BEGIN NATS USER JWT\s*-{3,}\s+([A-Za-z0-9._-]+)\s+-{3,}\s*END NATS USER JWT\s*-{3,}/,
+      );
+      expect(jwtMatch).toBeTruthy();
+      const decoded = decode<User>(jwtMatch![1]!);
+      expect(decoded.nats.pub?.allow).toContain("local.acme.code-review.>");
+      expect(decoded.nats.pub?.allow).toContain("local.acme.typescript.>");
+      expect(decoded.nats.sub?.allow).toContain("local.acme.code-review.>");
+      expect(decoded.nats.sub?.allow).toContain("local.acme.typescript.>");
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  test("issue accepts agent with no runtime block (defaults to empty caps)", async () => {
+    const noRuntimeAgent = fakeAgent("bare", []);
+    delete (noRuntimeAgent as { runtime?: unknown }).runtime;
+    const fixture = fakeOpts({
+      registry: AgentRegistry.fromAgents([noRuntimeAgent]),
+    });
+    try {
+      const response = await handleRequest(
+        { verb: "issue", agent_id: "bare" },
+        {
+          registry: fixture.opts.registry,
+          accountSigningKey: fixture.signingKey,
+          org: "acme",
+          credsDir: fixture.credsDir,
+        },
+      );
+      expect(response.ok).toBe(true);
+      expect(response.user_jwt_summary?.capabilities).toEqual([]);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  test("issue user_jwt_summary contains sub + iss public keys", async () => {
+    const fixture = fakeOpts();
+    try {
+      const response = await handleRequest(
+        { verb: "issue", agent_id: "scout" },
+        {
+          registry: fixture.opts.registry,
+          accountSigningKey: fixture.signingKey,
+          org: "acme",
+          credsDir: fixture.credsDir,
+        },
+      );
+      // sub starts with `U` (user nkey pubkey), iss with `A` (account
+      // signing key pubkey).
+      expect(response.user_jwt_summary?.sub).toMatch(/^U/);
+      expect(response.user_jwt_summary?.iss).toMatch(/^A/);
+      expect(response.user_jwt_summary?.iss).toBe(fixture.signingKey.getPublicKey());
+    } finally {
+      fixture.cleanup();
+    }
+  });
+});
+
+describe("handleRequest — revoke (narrower stub)", () => {
+  test("revoke returns ok=false with server_side_revoke_not_implemented", async () => {
+    const fixture = fakeOpts();
+    try {
+      // Pre-seed an existing creds file so the unlink path runs.
+      writeFileSync(join(fixture.credsDir, "scout.creds"), "stub-creds", {
+        mode: 0o600,
+      });
+      // Ensure the dir exists first — writeFileSync above will fail if not.
+      // Use mkdir + write in two steps.
+    } catch {
+      // expected on first run when dir doesn't exist; create it
+      const fs = await import("fs");
+      fs.mkdirSync(fixture.credsDir, { recursive: true, mode: 0o700 });
+      writeFileSync(join(fixture.credsDir, "scout.creds"), "stub-creds", {
+        mode: 0o600,
+      });
+    }
+    try {
+      const response = await handleRequest(
+        { verb: "revoke", agent_id: "scout" },
+        {
+          registry: fixture.opts.registry,
+          accountSigningKey: fixture.signingKey,
+          org: "acme",
+          credsDir: fixture.credsDir,
+        },
+      );
+      expect(response.ok).toBe(false);
+      expect(response.error).toBe("server_side_revoke_not_implemented");
+      expect(response.file_deleted).toBe(true);
+      expect(response.message).toMatch(/v1 only deletes the local \.creds file/);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  test("revoke on a non-existent file reports file_deleted=false but still narrower-stub error", async () => {
+    const fixture = fakeOpts();
+    try {
+      const response = await handleRequest(
+        { verb: "revoke", agent_id: "scout" },
+        {
+          registry: fixture.opts.registry,
+          accountSigningKey: fixture.signingKey,
+          org: "acme",
+          credsDir: fixture.credsDir,
+        },
+      );
+      expect(response.ok).toBe(false);
+      expect(response.error).toBe("server_side_revoke_not_implemented");
+      expect(response.file_deleted).toBe(false);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+});
+
+describe("handleRequest — rotate (narrower stub)", () => {
+  test("rotate deletes old + writes new creds + signals deferred server-side revoke", async () => {
+    const fixture = fakeOpts();
+    try {
+      // First, issue to land an initial file.
+      await handleRequest(
+        { verb: "issue", agent_id: "scout" },
+        {
+          registry: fixture.opts.registry,
+          accountSigningKey: fixture.signingKey,
+          org: "acme",
+          credsDir: fixture.credsDir,
+        },
+      );
+      const before = readFileSync(join(fixture.credsDir, "scout.creds"), "utf-8");
+
+      const response = await handleRequest(
+        { verb: "rotate", agent_id: "scout" },
+        {
+          registry: fixture.opts.registry,
+          accountSigningKey: fixture.signingKey,
+          org: "acme",
+          credsDir: fixture.credsDir,
+        },
+      );
+      expect(response.ok).toBe(true);
+      expect(response.verb).toBe("rotate");
+      expect(response.file_deleted).toBe(true);
+      expect(response.message).toMatch(/server-side revoke of the old JWT is pending/);
+      expect(response.creds_path).toBe(join(fixture.credsDir, "scout.creds"));
+
+      const after = readFileSync(join(fixture.credsDir, "scout.creds"), "utf-8");
+      expect(after).not.toBe(before);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  test("rotate on agent with no prior file still mints fresh + reports file_deleted=false", async () => {
+    const fixture = fakeOpts();
+    try {
+      const response = await handleRequest(
+        { verb: "rotate", agent_id: "scout" },
+        {
+          registry: fixture.opts.registry,
+          accountSigningKey: fixture.signingKey,
+          org: "acme",
+          credsDir: fixture.credsDir,
+        },
+      );
+      expect(response.ok).toBe(true);
+      expect(response.file_deleted).toBe(false);
+      expect(response.creds_path).toBe(join(fixture.credsDir, "scout.creds"));
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  test("rotate on unknown agent returns ok=false from underlying issue", async () => {
+    const fixture = fakeOpts();
+    try {
+      const response = await handleRequest(
+        { verb: "rotate", agent_id: "ghost" },
+        {
+          registry: fixture.opts.registry,
+          accountSigningKey: fixture.signingKey,
+          org: "acme",
+          credsDir: fixture.credsDir,
+        },
+      );
+      expect(response.ok).toBe(false);
+      expect(response.verb).toBe("rotate");
+      expect(response.error).toMatch(/unknown agent/);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+});
+
+// =============================================================================
+// parseCredsRequest
+// =============================================================================
+
+describe("parseCredsRequest", () => {
+  test("accepts well-formed envelope", () => {
+    const result = parseCredsRequest(JSON.stringify({ verb: "issue", agent_id: "scout" }));
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.request.verb).toBe("issue");
+      expect(result.request.agent_id).toBe("scout");
+    }
+  });
+
+  test("rejects non-JSON", () => {
+    const result = parseCredsRequest("not-json{");
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.response.error).toMatch(/not valid JSON/);
+    }
+  });
+
+  test("rejects JSON arrays", () => {
+    const result = parseCredsRequest(JSON.stringify(["issue"]));
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.response.error).toMatch(/expected JSON object/);
+    }
+  });
+
+  test("rejects unknown verb", () => {
+    const result = parseCredsRequest(JSON.stringify({ verb: "delete", agent_id: "scout" }));
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.response.error).toMatch(/verb must be one of/);
+    }
+  });
+
+  test("rejects missing agent_id", () => {
+    const result = parseCredsRequest(JSON.stringify({ verb: "issue" }));
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.response.error).toMatch(/agent_id must be a non-empty string/);
+    }
+  });
+
+  test("rejects empty agent_id", () => {
+    const result = parseCredsRequest(JSON.stringify({ verb: "issue", agent_id: "" }));
+    expect(result.ok).toBe(false);
+  });
+});
+
+// =============================================================================
+// End-to-end fake-daemon — UNIX socket transport
+// =============================================================================
+
+/**
+ * Send a single JSON request over a UNIX socket and read the JSON reply.
+ *
+ * Wire format is newline-delimited JSON: `{...request...}\n` → `{...reply...}\n`.
+ * The newline framing avoids a Bun-specific issue where the server's `'end'`
+ * event doesn't fire on client half-close (see `handleConnection`'s comment).
+ */
+function unixSocketRequest(
+  socketPath: string,
+  request: CredsRequest | unknown,
+): Promise<CredsResponse> {
+  return new Promise((resolve, reject) => {
+    const client = connect(socketPath);
+    let buffer = "";
+    client.setEncoding("utf-8");
+
+    client.on("connect", () => {
+      // Newline-terminated send — the server frames on newline.
+      client.write(JSON.stringify(request) + "\n");
+    });
+
+    client.on("data", (chunk: string) => {
+      buffer += chunk;
+    });
+
+    client.on("end", () => {
+      const raw = buffer.trim();
+      try {
+        resolve(JSON.parse(raw) as CredsResponse);
+      } catch (err) {
+        reject(new Error(`unixSocketRequest: bad reply "${raw}": ${err}`));
+      }
+    });
+
+    client.on("error", reject);
+  });
+}
+
+describe("end-to-end fake-daemon — UNIX socket transport", () => {
+  test("issue → list (file landed chmod 600) → revoke (narrower stub) → rotate (new file)", async () => {
+    const fixture = fakeOpts();
+    const handle = createCredsHandler(fixture.opts);
+    try {
+      await handle.start();
+
+      // 1) issue
+      const issueResp = await unixSocketRequest(fixture.socketPath, {
+        verb: "issue",
+        agent_id: "scout",
+      });
+      expect(issueResp.ok).toBe(true);
+      expect(issueResp.creds_path).toBe(join(fixture.credsDir, "scout.creds"));
+
+      // 2) verify file landed with chmod 600
+      const stat = statSync(issueResp.creds_path!);
+      expect(stat.isFile()).toBe(true);
+      if (process.platform !== "win32") {
+        expect(stat.mode & 0o777).toBe(0o600);
+      }
+
+      // 3) revoke — narrower stub
+      const revokeResp = await unixSocketRequest(fixture.socketPath, {
+        verb: "revoke",
+        agent_id: "scout",
+      });
+      expect(revokeResp.ok).toBe(false);
+      expect(revokeResp.error).toBe("server_side_revoke_not_implemented");
+      expect(revokeResp.file_deleted).toBe(true);
+
+      // 4) issue again so rotate has a prior file to delete
+      await unixSocketRequest(fixture.socketPath, {
+        verb: "issue",
+        agent_id: "scout",
+      });
+      const before = readFileSync(join(fixture.credsDir, "scout.creds"), "utf-8");
+
+      // 5) rotate — new file, narrower-stub message
+      const rotateResp = await unixSocketRequest(fixture.socketPath, {
+        verb: "rotate",
+        agent_id: "scout",
+      });
+      expect(rotateResp.ok).toBe(true);
+      expect(rotateResp.file_deleted).toBe(true);
+      expect(rotateResp.message).toMatch(/server-side revoke of the old JWT is pending/);
+      const after = readFileSync(join(fixture.credsDir, "scout.creds"), "utf-8");
+      expect(after).not.toBe(before);
+    } finally {
+      await handle.stop();
+      fixture.cleanup();
+    }
+  });
+
+  test("issue on unknown agent returns structured error envelope", async () => {
+    const fixture = fakeOpts();
+    const handle = createCredsHandler(fixture.opts);
+    try {
+      await handle.start();
+      const response = await unixSocketRequest(fixture.socketPath, {
+        verb: "issue",
+        agent_id: "nobody",
+      });
+      expect(response.ok).toBe(false);
+      expect(response.error).toMatch(/unknown agent "nobody"/);
+    } finally {
+      await handle.stop();
+      fixture.cleanup();
+    }
+  });
+
+  test("malformed request envelope (non-JSON) returns structured error", async () => {
+    const fixture = fakeOpts();
+    const handle = createCredsHandler(fixture.opts);
+    try {
+      await handle.start();
+      // Send raw garbage bytes followed by the newline framer so the
+      // server doesn't have to wait for EOF.
+      const garbageReply: string = await new Promise((resolve, reject) => {
+        const client = connect(fixture.socketPath);
+        let buf = "";
+        client.setEncoding("utf-8");
+        client.on("connect", () => {
+          client.write("not-json{\n");
+        });
+        client.on("data", (c: string) => {
+          buf += c;
+        });
+        client.on("end", () => resolve(buf.trim()));
+        client.on("error", reject);
+      });
+      const parsed = JSON.parse(garbageReply) as CredsResponse;
+      expect(parsed.ok).toBe(false);
+      expect(parsed.error).toMatch(/not valid JSON/);
+    } finally {
+      await handle.stop();
+      fixture.cleanup();
+    }
+  });
+
+  test("malformed request envelope (unknown verb) returns structured error", async () => {
+    const fixture = fakeOpts();
+    const handle = createCredsHandler(fixture.opts);
+    try {
+      await handle.start();
+      const response = await unixSocketRequest(fixture.socketPath, {
+        verb: "delete",
+        agent_id: "scout",
+      });
+      expect(response.ok).toBe(false);
+      expect(response.error).toMatch(/verb must be one of/);
+    } finally {
+      await handle.stop();
+      fixture.cleanup();
+    }
+  });
+
+  test("socket file has chmod 600 after listen", async () => {
+    const fixture = fakeOpts();
+    const handle = createCredsHandler(fixture.opts);
+    try {
+      await handle.start();
+      const stat = statSync(fixture.socketPath);
+      expect(stat.isSocket()).toBe(true);
+      if (process.platform !== "win32") {
+        expect(stat.mode & 0o777).toBe(0o600);
+      }
+    } finally {
+      await handle.stop();
+      fixture.cleanup();
+    }
+  });
+
+  test("stop() unlinks the socket file", async () => {
+    const fixture = fakeOpts();
+    const handle = createCredsHandler(fixture.opts);
+    try {
+      await handle.start();
+      expect(() => statSync(fixture.socketPath)).not.toThrow();
+      await handle.stop();
+      // After stop, the socket file should be gone.
+      let stillThere = true;
+      try {
+        statSync(fixture.socketPath);
+      } catch {
+        stillThere = false;
+      }
+      expect(stillThere).toBe(false);
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  test("start() recovers from a stale socket file left by a prior crash", async () => {
+    const fixture = fakeOpts();
+    // Simulate a prior crash by listening on the path and tearing down the
+    // server without unlinking. We use a raw net.createServer fake here
+    // because we want a real `isSocket()`-true leftover.
+    const orphan = createServer(() => {});
+    await new Promise<void>((resolve, reject) => {
+      const fs = require("fs");
+      fs.mkdirSync(dirname(fixture.socketPath), { recursive: true });
+      orphan.once("error", reject);
+      orphan.listen(fixture.socketPath, () => resolve());
+    });
+    // Close the listener but DO NOT unlink. On POSIX, server.close()
+    // removes the inode for an AF_UNIX listener — so to truly simulate
+    // a crash, we force-leave a socket file behind by re-creating it.
+    await new Promise<void>((resolve) => orphan.close(() => resolve()));
+    // Re-create the leftover socket file by listening + crashing-by-unref.
+    // Simpler: just write an empty file at the path and chmod it to look
+    // socket-ish — but statSync().isSocket() requires an actual socket.
+    // So instead, we listen a second time and let our handler clean it up.
+    const orphan2 = createServer(() => {});
+    await new Promise<void>((resolve, reject) => {
+      orphan2.once("error", reject);
+      orphan2.listen(fixture.socketPath, () => resolve());
+    });
+    // Now our handler should clean it up on start.
+    const handle = createCredsHandler(fixture.opts);
+    try {
+      // Drop the orphan listener WITHOUT awaiting close-callback so the
+      // socket file may still be present on POSIX when our handler starts.
+      orphan2.close();
+      // tiny yield so the orphan close has a chance to schedule cleanup
+      await new Promise((r) => setTimeout(r, 10));
+      await handle.start();
+      // If start succeeded, the handler is now listening.
+      const response = await unixSocketRequest(fixture.socketPath, {
+        verb: "issue",
+        agent_id: "scout",
+      });
+      expect(response.ok).toBe(true);
+    } finally {
+      await handle.stop();
+      fixture.cleanup();
+    }
+  });
+
+  test("refuses to clobber a non-socket file at the socket path", async () => {
+    const fixture = fakeOpts();
+    // Plant a regular file at the socket path so the handler must refuse.
+    const fs = require("fs");
+    fs.mkdirSync(dirname(fixture.socketPath), { recursive: true });
+    writeFileSync(fixture.socketPath, "i am not a socket");
+    chmodSync(fixture.socketPath, 0o600);
+    const handle = createCredsHandler(fixture.opts);
+    try {
+      let threw: unknown = null;
+      try {
+        await handle.start();
+      } catch (err) {
+        threw = err;
+      }
+      expect(threw).toBeTruthy();
+      expect(threw instanceof Error && threw.message).toMatch(/not a socket/);
+    } finally {
+      // The handler refused to start, so stop is a safe no-op.
+      await handle.stop();
+      fixture.cleanup();
+    }
   });
 });

--- a/src/runner/creds-handler.ts
+++ b/src/runner/creds-handler.ts
@@ -1,94 +1,857 @@
 /**
- * cortex#67 prep — creds-handler stub.
+ * cortex#67 — creds-handler: daemon-side RPC handler for `cortex creds
+ * issue / revoke / rotate`.
  *
- * The full creds-handler will mint per-agent NATS JWTs scoped to each agent's
- * declared `runtime.capabilities`, using an operator account signing key
- * (landed in cortex#67 prereq B). The handler watches the agent registry,
- * mints/refreshes credentials when an agent's capability set or trust closure
- * changes, and tears them down on shutdown.
+ * The handler exposes a JSON request/reply surface over a UNIX domain socket
+ * (chmod 600). The cortex CLI's `creds.ts` commands talk to this socket to
+ * request per-agent NATS user JWTs minted from the operator's account signing
+ * key. Each minted JWT is scoped to the requesting agent's
+ * `runtime.capabilities` list via `mintUserCreds()` (prereq A).
  *
- * This file is the minimum surface so the upcoming cortex#67 PR has a target:
- *   - `CredsHandlerOpts` carries the bus runtime + the agent registry. The
- *     `accountSigningKey: KeyPair` field arrives in cortex#67 once prereq A+B
- *     have landed — adding it here today would force an early dep on the JWT
- *     primitive that hasn't shipped.
- *   - `CredsHandler` is the lifecycle handle cortex.ts wires alongside the
- *     other subsystems (runtime, router, listener) — same `start/stop` shape
- *     so the existing shutdown drain doesn't need a special-case.
+ * # Transport
  *
- * The stub's `start` and `stop` are idempotent no-ops. They satisfy the type
- * so cortex.ts can conditionally construct + log a "creds handler ready
- * (stub)" line behind the same gates the real handler will require:
- *   - `runtime.enabled` (no point minting NATS creds without a NATS link)
- *   - `registry.size > 0`  (no point minting creds for zero agents)
- *   - (future) account signing key present in config
+ * **v1 ships UNIX-socket only.** The spec's NATS request/reply transport
+ * remains a v2 concern for two reasons surfaced during implementation:
  *
- * When cortex#67 lands, replace the stub body — the public interface stays.
+ *   1. `MyelinRuntime` only exposes `onEnvelope` + `publish`. It has no
+ *      `subscribe-with-reply` primitive — adding one is invasive (touches
+ *      `runtime.ts`, `subscriber.ts`, and the surface-router contract). The
+ *      spec's STOP+REPORT trigger says to surface this rather than extend.
+ *   2. The intended NATS subject-auth gate ("only operator-trusted creds get
+ *      processed via `TrustResolver`") doesn't have a direct map onto the
+ *      existing `TrustResolver`, which is the *platform-identity* trust map
+ *      (Discord/Mattermost user-id ↔ agent-id). NATS-side operator-trust
+ *      verification would need a different primitive. Surface, defer.
+ *
+ * The UNIX socket alone is sufficient for v1 because cortex's CLI runs on the
+ * same host as the daemon — the operator's laptop / server. The socket file
+ * being chmod 600 + owned by the daemon user gives OS-enforced auth.
+ *
+ * Architecture leaves room for the NATS path: `handleRequest()` is
+ * transport-agnostic (takes a parsed `CredsRequest`, returns a
+ * `CredsResponse`). A future PR that adds NATS subscribe/reply to the runtime
+ * can call the same `handleRequest()` body and reuse this file unchanged.
+ *
+ * # Request / response shape
+ *
+ * Wire format: JSON, one message per UNIX-socket connection (or one
+ * request/reply round trip per NATS msg in v2).
+ *
+ * Request:
+ *   { "verb": "issue" | "revoke" | "rotate", "agent_id": "<id>" }
+ *
+ * Response (verb-specific — see CredsResponse below). All responses carry:
+ *   - `ok: boolean`
+ *   - `verb: <verb>`
+ *   - `agent_id: <id>` (when applicable)
+ *   - `error: <string>` (on ok=false)
+ *   - per-verb fields (creds_path, user_jwt_summary, etc.)
+ *
+ * # Verb semantics (v1)
+ *
+ *   - **`issue`** — fully implemented end-to-end. Looks up the agent in the
+ *     registry, reads `agent.runtime.capabilities`, mints a fresh user JWT
+ *     scoped to those caps, writes `{credsDir}/{agentId}.creds` with chmod
+ *     600, returns the path + a JWT summary.
+ *   - **`revoke`** — narrower stub per spec: deletes the local creds file if
+ *     present; **does NOT** revoke server-side via account-JWT update. That
+ *     requires system-account topology design that's out of scope for v1.
+ *     Returns `{ ok: false, error: "server_side_revoke_not_implemented", ... }`
+ *     with a clear message so operators understand what happened.
+ *   - **`rotate`** — narrower stub: local-file rotate (delete + re-mint).
+ *     Server-side revocation of the old JWT is again deferred. Returns
+ *     `{ ok: true, ..., message: "v1: local file rotated; server-side
+ *     revoke pending system-account topology" }`.
+ *
+ * # Idempotency + safety
+ *
+ *   - `start()` / `stop()` are idempotent (matches prereq C stub contract).
+ *   - The socket file is unlinked on stop AND on start (defensive: an
+ *     orphaned socket from a prior crashed daemon would otherwise EADDRINUSE).
+ *   - Concurrent `issue` requests for the same agent race on disk write; the
+ *     last writer wins. Acceptable — a re-issued cred file is a new user
+ *     identity (mint is non-idempotent by design, see jwt-mint.ts).
+ *
+ * # Logging
+ *
+ * No sensitive material logged. We log:
+ *   - the verb + agent_id on receipt,
+ *   - the creds_path on success (the path, not the file contents),
+ *   - error class + message on failure.
+ * We never log the JWT, the seed, or the .creds file bytes.
  */
+
+import { existsSync, unlinkSync, chmodSync, mkdirSync, writeFileSync, statSync } from "fs";
+import { dirname, join } from "path";
+import type { Server, Socket } from "net";
+import { createServer } from "net";
+import type { KeyPair } from "nkeys.js";
+import { decode, type User } from "@nats-io/jwt";
 
 import type { AgentRegistry } from "../common/agents/registry";
 import type { MyelinRuntime } from "../bus/myelin/runtime";
+import { mintUserCreds } from "../bus/nats/jwt-mint";
+
+// =============================================================================
+// Constants
+// =============================================================================
 
 /**
- * Construction options for the creds handler. The runtime + registry pair is
- * enough surface to scope the handler today; the account signing key arrives
- * with cortex#67 once the prereq-A/B PRs land.
+ * Default socket path. `~/.config/cortex/cortex.sock` matches the spec's
+ * default. Resolved via `process.env.HOME` for portability.
+ */
+const DEFAULT_SOCKET_PATH = "~/.config/cortex/cortex.sock";
+
+/**
+ * Default creds directory. `~/.config/nats/creds/` matches the F-4 CLI's
+ * `DEFAULT_CREDS_DIR` in `cli/cortex/commands/creds.ts` so issued files land
+ * where `cortex creds list` already looks for them.
+ */
+const DEFAULT_CREDS_DIR = "~/.config/nats/creds";
+
+/** Cap on inbound request payload size — 64 KiB is gigantic for a JSON
+ *  envelope of `{verb, agent_id}`. Defence against accidental log-flood or
+ *  buffer-overflow probing. */
+const MAX_REQUEST_BYTES = 64 * 1024;
+
+/** Per-connection read timeout. UNIX-local request/reply finishes in
+ *  milliseconds; 5 s is generous. */
+const REQUEST_TIMEOUT_MS = 5_000;
+
+// =============================================================================
+// Public types
+// =============================================================================
+
+/**
+ * Construction options for the creds handler.
+ *
+ * Compared to the prereq-C stub, this adds `accountSigningKey` + `org`, plus
+ * the optional `socketPath` and `credsDir` paths. All paths accept `~` and
+ * are expanded internally.
  */
 export interface CredsHandlerOpts {
-  /** Bus runtime — the handler will eventually publish minted creds via this. */
+  /** Bus runtime — reserved for the v2 NATS request/reply path. v1 doesn't
+   *  use this but the field stays so cortex.ts wiring is forward-compatible. */
   runtime: MyelinRuntime;
-  /**
-   * Agent registry — the handler reads `agent.runtime.capabilities` per
-   * registered agent to bound each minted JWT's NATS user permissions.
-   */
+  /** Agent registry — source of truth for `agent.runtime.capabilities`. */
   registry: AgentRegistry;
-  // accountSigningKey: KeyPair — added in cortex#67 once prereq A+B land.
+  /** Operator account signing key — loaded via `loadAccountSigningKey()` in
+   *  cortex.ts. Used as the issuer for every minted user JWT. */
+  accountSigningKey: KeyPair;
+  /** Org slug — used as the `{org}` segment in minted JWT subjects
+   *  (`local.{org}.…`). Matches `operator.id` from cortex.yaml /
+   *  `agent.operatorId` from bot.yaml. */
+  org: string;
+  /** Optional UNIX socket path. Defaults to `~/.config/cortex/cortex.sock`. */
+  socketPath?: string;
+  /** Optional creds output directory. Defaults to `~/.config/nats/creds/`. */
+  credsDir?: string;
 }
 
 /**
- * Lifecycle handle for the creds handler. Same `start/stop` shape as other
- * cortex subsystems so the shutdown drain treats it uniformly.
+ * Lifecycle handle for the creds handler. Shape matches the prereq-C stub so
+ * cortex.ts wiring stays unchanged.
  */
 export interface CredsHandler {
-  /**
-   * Start the handler. Idempotent — calling twice is safe and the second
-   * call is a no-op. The stub never throws; the real implementation will
-   * surface configuration errors (missing signing key, registry empty)
-   * here rather than at construction.
-   */
   start(): Promise<void>;
-  /**
-   * Stop the handler. Idempotent — calling twice (or before `start`) is
-   * safe. The stub never throws; the real implementation will revoke
-   * minted creds + cancel refresh timers here.
-   */
   stop(): Promise<void>;
 }
 
 /**
- * Build the creds handler. Pure factory — does not start anything; the
- * caller invokes `handle.start()` once it's ready to hand the registry +
- * runtime over to the credential minting loop.
+ * Request envelope — shared between transport surfaces.
  *
- * STUB — full implementation lands in cortex#67. The current body returns a
- * handle whose `start` and `stop` are no-ops; this satisfies the type so
- * cortex.ts can wire the handler conditionally today and the real behaviour
- * can swap in without touching call sites.
+ * `verb` is the action. `agent_id` is the target agent. All other fields are
+ * verb-specific and reserved.
  */
-export function createCredsHandler(_opts: CredsHandlerOpts): CredsHandler {
-  // STUB — full implementation in cortex#67.
-  // The opts are accepted but unused at this stage; once the JWT mint loop
-  // lands, the closure below captures `_opts.runtime` and `_opts.registry`
-  // to drive credential issuance per agent.
+export interface CredsRequest {
+  verb: "issue" | "revoke" | "rotate";
+  agent_id: string;
+}
+
+/**
+ * Response envelope — shared between transport surfaces. All fields are
+ * optional except `ok` + `verb`; per-verb fields populate the rest.
+ *
+ * Note on the JWT summary: we ONLY include the subject pubkey + capability
+ * scope, never the JWT body or the user seed. Operators who want the full
+ * decoded JWT can run `nats jwt decode` on the file at `creds_path`.
+ */
+export interface CredsResponse {
+  ok: boolean;
+  verb: "issue" | "revoke" | "rotate";
+  agent_id?: string;
+  error?: string;
+  message?: string;
+  creds_path?: string;
+  file_deleted?: boolean;
+  user_jwt_summary?: {
+    /** Subject — the user's NKey public key (UA…). Public, safe to log. */
+    sub: string;
+    /** Issuer — the account signing key's public key (A…). Public. */
+    iss: string;
+    /** Capabilities scope echoed back (operator-readable). */
+    capabilities: string[];
+  };
+}
+
+// =============================================================================
+// Path expansion + creds-dir helpers
+// =============================================================================
+
+/**
+ * Expand a leading `~` to `$HOME`. Mirrors `expandTilde` in
+ * `src/common/config/loader.ts` but kept private here so the handler stays
+ * dependency-free of the config loader (the loader pulls Zod + YAML, which
+ * the handler doesn't need).
+ */
+function expandTilde(path: string): string {
+  if (!path.startsWith("~")) return path;
+  const home = process.env.HOME ?? "~";
+  return path.replace(/^~/, home);
+}
+
+/**
+ * Resolve the absolute path for a given agent's creds file.
+ *
+ * The filename is `{agentId}.creds`, matching the F-4 CLI's `list`
+ * convention (filename stem → agent id, see `cli/cortex/commands/creds.ts`).
+ */
+function credsPathFor(credsDir: string, agentId: string): string {
+  return join(expandTilde(credsDir), `${agentId}.creds`);
+}
+
+// =============================================================================
+// Handler core — transport-agnostic
+// =============================================================================
+
+/**
+ * Dispatch a parsed `CredsRequest` to the right verb handler. Returns the
+ * response envelope. Pure function over the registry + signing key + paths;
+ * the only side effects are file I/O.
+ *
+ * Surfaced as an exported function so future v2 transports (NATS
+ * request/reply, HTTP, gRPC, ...) can reuse the same dispatcher without
+ * re-implementing the parse-validate-execute flow.
+ */
+export async function handleRequest(
+  request: CredsRequest,
+  opts: {
+    registry: AgentRegistry;
+    accountSigningKey: KeyPair;
+    org: string;
+    credsDir: string;
+  },
+): Promise<CredsResponse> {
+  switch (request.verb) {
+    case "issue":
+      return await handleIssue(request.agent_id, opts);
+    case "revoke":
+      return handleRevoke(request.agent_id, opts.credsDir);
+    case "rotate":
+      return await handleRotate(request.agent_id, opts);
+    default: {
+      // Exhaustive check — caller validates `verb` against the union before
+      // dispatch, so reaching here is a bug. The cast keeps TS strict-null
+      // happy without `as never`.
+      const verb: string = (request as { verb: string }).verb;
+      return {
+        ok: false,
+        verb: verb as CredsRequest["verb"],
+        error: `unknown verb "${verb}"`,
+      };
+    }
+  }
+}
+
+/**
+ * `issue {agent_id}`: full end-to-end.
+ *
+ *   1. Look up the agent in the registry — reject if not found.
+ *   2. Read `agent.runtime.capabilities`. The runtime block is optional on
+ *      cortex.yaml v0.1 (`AgentSchema.runtime` is `.optional()`). If absent,
+ *      we default to an empty capability list — the bot still gets baseline
+ *      perms (capability self-register + creds back-channel) per
+ *      `buildUserPermissions()`.
+ *   3. Mint a fresh user JWT via `mintUserCreds()`.
+ *   4. Ensure the creds directory exists; write `{agentId}.creds`; chmod 600.
+ *   5. Return `{ok: true, agent_id, creds_path, user_jwt_summary}`.
+ */
+async function handleIssue(
+  agentId: string,
+  opts: {
+    registry: AgentRegistry;
+    accountSigningKey: KeyPair;
+    org: string;
+    credsDir: string;
+  },
+): Promise<CredsResponse> {
+  const agent = opts.registry.tryGetById(agentId);
+  if (!agent) {
+    return {
+      ok: false,
+      verb: "issue",
+      agent_id: agentId,
+      error: `unknown agent "${agentId}" — not in cortex agent registry`,
+    };
+  }
+
+  // Capabilities from the agent's runtime block. Optional per cortex-config
+  // schema; default to [] so a v0.1 cortex.yaml without `runtime:` still
+  // issues a usable cred (baseline perms only).
+  const capabilities = agent.runtime?.capabilities ?? [];
+
+  let minted;
+  try {
+    minted = await mintUserCreds({
+      accountSigningKey: opts.accountSigningKey,
+      agentId,
+      capabilities,
+      org: opts.org,
+    });
+  } catch (err) {
+    // mintUserCreds throws on subject-token validation. Surface the message
+    // to the operator so a malformed agent id at the daemon side is visible.
+    return {
+      ok: false,
+      verb: "issue",
+      agent_id: agentId,
+      error: `mint failed: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+
+  // Ensure the creds dir exists. `mkdirSync` is idempotent with `recursive`.
+  const credsPath = credsPathFor(opts.credsDir, agentId);
+  const credsDir = dirname(credsPath);
+  try {
+    mkdirSync(credsDir, { recursive: true, mode: 0o700 });
+  } catch (err) {
+    return {
+      ok: false,
+      verb: "issue",
+      agent_id: agentId,
+      error: `failed to create creds dir ${credsDir}: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+
+  // Write the file owner-only (chmod 600). `writeFileSync` with `mode` works
+  // on POSIX; on Windows the mode bits are advisory but writeFileSync still
+  // succeeds. Same approach as `account-signing-key.ts`'s Windows note.
+  try {
+    writeFileSync(credsPath, minted.credsFile, { mode: 0o600 });
+    // Defensive re-chmod: on some filesystems / umasks the `mode` arg is
+    // masked by `process.umask()`. An explicit chmodSync removes the umask
+    // dependency. Same belt-and-braces pattern as `loadAccountSigningKey`.
+    if (process.platform !== "win32") {
+      chmodSync(credsPath, 0o600);
+    }
+  } catch (err) {
+    return {
+      ok: false,
+      verb: "issue",
+      agent_id: agentId,
+      error: `failed to write creds file ${credsPath}: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+
+  // Build the JWT summary. We decode the just-minted JWT to recover the
+  // public subject — that's what `nats jwt decode` would show, and it's
+  // public material (the user's NKey pubkey).
+  let sub = "(unknown)";
+  let iss = "(unknown)";
+  try {
+    const decoded = decode<User>(minted.userJwt);
+    sub = decoded.sub ?? "(unset)";
+    iss = decoded.iss ?? "(unset)";
+  } catch {
+    // Decode failure is anomalous (we just minted the JWT) but non-fatal —
+    // the file is on disk, the operator can re-decode it locally. Leave the
+    // summary placeholders so the response shape stays predictable.
+  }
+
+  return {
+    ok: true,
+    verb: "issue",
+    agent_id: agentId,
+    creds_path: credsPath,
+    user_jwt_summary: { sub, iss, capabilities },
+  };
+}
+
+/**
+ * `revoke {agent_id}`: **NARROWER STUB**. Server-side NATS account-JWT revoke
+ * (the proper revoke) is pending system-account topology design and is
+ * deliberately out of scope for v1. We document the limitation in the
+ * response so operators see exactly what happened.
+ *
+ * What v1 does: delete the local `.creds` file if present. This is the
+ * minimum useful behaviour — it stops the bot on the same host from
+ * re-loading the credentials, even though the JWT is still cryptographically
+ * valid on any NATS server that doesn't have the revocation entry.
+ */
+function handleRevoke(
+  agentId: string,
+  credsDir: string,
+): CredsResponse {
+  const credsPath = credsPathFor(credsDir, agentId);
+  const existed = existsSync(credsPath);
+  if (existed) {
+    try {
+      unlinkSync(credsPath);
+    } catch (err) {
+      return {
+        ok: false,
+        verb: "revoke",
+        agent_id: agentId,
+        error: `failed to unlink ${credsPath}: ${err instanceof Error ? err.message : String(err)}`,
+        file_deleted: false,
+      };
+    }
+  }
+
+  // We return `ok: false` to keep the contract honest: "revoke" did not
+  // actually revoke (server-side). Operators / scripts can branch on
+  // `error === "server_side_revoke_not_implemented"` to distinguish this
+  // from a hard failure.
+  return {
+    ok: false,
+    verb: "revoke",
+    agent_id: agentId,
+    error: "server_side_revoke_not_implemented",
+    message:
+      "Server-side NATS account-JWT revoke is pending system-account topology " +
+      "design. v1 only deletes the local .creds file. File deleted: " + String(existed),
+    file_deleted: existed,
+    creds_path: credsPath,
+  };
+}
+
+/**
+ * `rotate {agent_id}`: **NARROWER STUB** for server-side revoke; full
+ * re-mint of the local file.
+ *
+ *   1. Delete the local creds file if present (same behaviour as `revoke`).
+ *   2. Issue a fresh creds file with new keys.
+ *   3. Return `ok: true` with a message flagging that the OLD JWT is still
+ *      valid on the bus until the operator re-deploys account-JWT
+ *      revocation manually.
+ *
+ * Errors during step 2 (mint failure, disk write failure) propagate as
+ * `ok: false` with the upstream error message — same shape as `issue`.
+ */
+async function handleRotate(
+  agentId: string,
+  opts: {
+    registry: AgentRegistry;
+    accountSigningKey: KeyPair;
+    org: string;
+    credsDir: string;
+  },
+): Promise<CredsResponse> {
+  const credsPath = credsPathFor(opts.credsDir, agentId);
+  const fileDeleted = existsSync(credsPath);
+  if (fileDeleted) {
+    try {
+      unlinkSync(credsPath);
+    } catch (err) {
+      return {
+        ok: false,
+        verb: "rotate",
+        agent_id: agentId,
+        error: `failed to unlink old creds at ${credsPath}: ${err instanceof Error ? err.message : String(err)}`,
+        file_deleted: false,
+      };
+    }
+  }
+
+  // Reuse `handleIssue` for the mint side — single source of truth for the
+  // mint + write flow.
+  const issued = await handleIssue(agentId, opts);
+  if (!issued.ok) {
+    // Pass through the underlying error but stamp the verb as `rotate` so
+    // the operator-facing message is unambiguous about which call failed.
+    return {
+      ...issued,
+      verb: "rotate",
+    };
+  }
+
+  return {
+    ...issued,
+    verb: "rotate",
+    file_deleted: fileDeleted,
+    message:
+      "v1: local file rotated; server-side revoke of the old JWT is pending " +
+      "system-account topology design. The old JWT remains valid on the bus " +
+      "until account-JWT revocation is deployed manually.",
+  };
+}
+
+// =============================================================================
+// UNIX-socket transport
+// =============================================================================
+
+/**
+ * Parse the inbound buffer as JSON and validate the verb + agent_id shape.
+ * Returns `{ ok: true, request }` on success; `{ ok: false, error }` with a
+ * `CredsResponse`-ready error otherwise.
+ *
+ * Exported for the test fixture so unit tests can exercise the parse layer
+ * without standing up a socket.
+ */
+export function parseCredsRequest(
+  raw: string,
+): { ok: true; request: CredsRequest } | { ok: false; response: CredsResponse } {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    return {
+      ok: false,
+      response: {
+        ok: false,
+        verb: "issue", // placeholder — caller hasn't seen a verb yet
+        error: `malformed request: not valid JSON (${err instanceof Error ? err.message : String(err)})`,
+      },
+    };
+  }
+
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    return {
+      ok: false,
+      response: {
+        ok: false,
+        verb: "issue",
+        error: "malformed request: expected JSON object",
+      },
+    };
+  }
+
+  const obj = parsed as Record<string, unknown>;
+  const verb = obj.verb;
+  const agentId = obj.agent_id;
+
+  if (verb !== "issue" && verb !== "revoke" && verb !== "rotate") {
+    return {
+      ok: false,
+      response: {
+        ok: false,
+        verb: "issue",
+        error: `malformed request: verb must be one of "issue" | "revoke" | "rotate", got ${JSON.stringify(verb)}`,
+      },
+    };
+  }
+
+  if (typeof agentId !== "string" || agentId.length === 0) {
+    return {
+      ok: false,
+      response: {
+        ok: false,
+        verb,
+        error: "malformed request: agent_id must be a non-empty string",
+      },
+    };
+  }
+
+  return { ok: true, request: { verb, agent_id: agentId } };
+}
+
+/**
+ * Open the UNIX socket and wire a per-connection request/reply loop. Returns
+ * the live `Server` so `stop()` can close it; throws on listen failure (the
+ * caller decides whether to swallow or propagate).
+ *
+ * We use Node's `net.createServer` rather than `Bun.listen({ unix })`
+ * because:
+ *   - The spec's STOP+REPORT trigger flagged it as an acceptable fallback.
+ *   - `net.createServer` is on the standard library, works under both Bun
+ *     and Node, and has the `unref()` semantics tests want.
+ *
+ * The socket inherits the daemon's umask. We explicitly chmod 600 after
+ * listen to guarantee owner-only access regardless of umask.
+ */
+function listenOnUnixSocket(
+  socketPath: string,
+  onConnection: (socket: Socket) => void,
+): Promise<Server> {
+  return new Promise((resolve, reject) => {
+    // Defensive cleanup: an orphaned socket from a prior crash would
+    // EADDRINUSE on `listen()`. Unlink the path if it exists AND it's a
+    // socket (not a regular file — refuse to clobber an unrelated file).
+    if (existsSync(socketPath)) {
+      try {
+        const stat = statSync(socketPath);
+        if (stat.isSocket()) {
+          unlinkSync(socketPath);
+        } else {
+          reject(
+            new Error(
+              `refusing to listen on ${socketPath} — path exists and is not a socket (mode ${stat.mode.toString(8)})`,
+            ),
+          );
+          return;
+        }
+      } catch (err) {
+        // statSync can race with another process unlinking the file; we
+        // log + proceed because the subsequent `listen` will surface a
+        // clear error if the path is actually unusable.
+        process.stderr.write(
+          `[creds-handler] socket stat ${socketPath} failed (continuing): ${err instanceof Error ? err.message : String(err)}\n`,
+        );
+      }
+    }
+
+    // Ensure the socket's parent dir exists (mode 0o700 for the dir is
+    // mirrored from `creds-dir` handling above — keeps the daemon's
+    // private state owner-only).
+    const parentDir = dirname(socketPath);
+    try {
+      mkdirSync(parentDir, { recursive: true, mode: 0o700 });
+    } catch (err) {
+      reject(
+        new Error(
+          `failed to create socket dir ${parentDir}: ${err instanceof Error ? err.message : String(err)}`,
+        ),
+      );
+      return;
+    }
+
+    const server = createServer(onConnection);
+
+    server.once("error", (err) => {
+      reject(err);
+    });
+
+    server.listen(socketPath, () => {
+      // Owner-only access. Same belt-and-braces pattern as the writeFileSync
+      // mode arg above — chmod after listen removes the umask dependency.
+      try {
+        if (process.platform !== "win32") {
+          chmodSync(socketPath, 0o600);
+        }
+      } catch (err) {
+        // Logging + continuing here: the listen succeeded, but our chmod
+        // didn't. The operator can re-chmod the file manually. A future
+        // hardening pass might tear the socket down here, but for v1 a
+        // visible warning is enough.
+        process.stderr.write(
+          `[creds-handler] failed to chmod 600 ${socketPath}: ${err instanceof Error ? err.message : String(err)}\n`,
+        );
+      }
+      resolve(server);
+    });
+  });
+}
+
+/**
+ * Per-connection handler. Reads inbound bytes until a newline (`\n`)
+ * delimiter, parses the preceding JSON, dispatches, writes the response
+ * followed by `\n`, half-closes the write side.
+ *
+ * Each connection is one request/reply cycle — no keep-alive. This matches
+ * how the cortex CLI talks: short-lived, one-shot.
+ *
+ * **Why newline-delimited framing instead of half-close framing?**
+ * Bun's `net` shim does not reliably surface the server-side `'end'` event
+ * when the client half-closes — empirically the server `'data'` handlers
+ * fire but `'end'` never does, leading to a stalled request/reply where the
+ * server reads forever waiting for EOF (see Bun 1.3.x net.Server behaviour).
+ * Newline framing avoids the issue entirely: the server can detect the end
+ * of the request without depending on `'end'`. CLI and tests use the same
+ * convention.
+ */
+function handleConnection(
+  socket: Socket,
+  opts: {
+    registry: AgentRegistry;
+    accountSigningKey: KeyPair;
+    org: string;
+    credsDir: string;
+  },
+): void {
+  socket.setEncoding("utf-8");
+  let buffer = "";
+  let total = 0;
+  let timedOut = false;
+  let replied = false;
+
+  const timeout = setTimeout(() => {
+    timedOut = true;
+    socket.destroy(new Error(`request timeout after ${REQUEST_TIMEOUT_MS}ms`));
+  }, REQUEST_TIMEOUT_MS);
+
+  const writeReply = async (raw: string): Promise<void> => {
+    if (replied) return;
+    replied = true;
+    clearTimeout(timeout);
+
+    const parsed = parseCredsRequest(raw);
+    let response: CredsResponse;
+    if (parsed.ok) {
+      try {
+        response = await handleRequest(parsed.request, opts);
+        process.stderr.write(
+          `[creds-handler] ${parsed.request.verb} agent="${parsed.request.agent_id}" ok=${response.ok}` +
+            (response.creds_path ? ` creds_path=${response.creds_path}` : "") +
+            (response.error ? ` error=${response.error}` : "") +
+            "\n",
+        );
+      } catch (err) {
+        // handleRequest itself shouldn't throw — its per-verb handlers
+        // already wrap errors. Belt-and-braces: catch anyway so a bug
+        // there doesn't kill the socket without a reply.
+        response = {
+          ok: false,
+          verb: parsed.request.verb,
+          agent_id: parsed.request.agent_id,
+          error: `internal error: ${err instanceof Error ? err.message : String(err)}`,
+        };
+      }
+    } else {
+      response = parsed.response;
+    }
+
+    try {
+      // Write + end. Newline-terminate the response so a future
+      // multi-request transport (or a debug `nc(1)` client) can frame
+      // replies the same way the server frames requests.
+      socket.write(JSON.stringify(response) + "\n");
+      socket.end();
+    } catch {
+      // Best-effort cleanup — peer may have closed already.
+      socket.destroy();
+    }
+  };
+
+  socket.on("data", (chunk: string) => {
+    if (replied) return;
+    total += chunk.length;
+    if (total > MAX_REQUEST_BYTES) {
+      // Reject oversized requests with a structured error envelope.
+      replied = true;
+      clearTimeout(timeout);
+      const response: CredsResponse = {
+        ok: false,
+        verb: "issue",
+        error: `request too large (>${MAX_REQUEST_BYTES} bytes)`,
+      };
+      try {
+        socket.write(JSON.stringify(response) + "\n");
+        socket.end();
+      } catch {
+        socket.destroy();
+      }
+      return;
+    }
+    buffer += chunk;
+    const idx = buffer.indexOf("\n");
+    if (idx >= 0) {
+      const line = buffer.slice(0, idx);
+      // Don't await — the data callback isn't async-aware. The writeReply
+      // closure handles `replied` so a follow-up chunk after the newline
+      // doesn't double-reply.
+      void writeReply(line);
+    }
+  });
+
+  // Belt-and-braces: if the client somehow manages to half-close without
+  // sending a newline (e.g. raw `nc` test, garbage probe), fall back to
+  // EOF framing. Treats the entire pre-EOF buffer as one request.
+  socket.on("end", () => {
+    if (replied) return;
+    void writeReply(buffer);
+  });
+
+  socket.on("error", (err) => {
+    // Per-connection errors are common (peer hangs up, etc.). Log to
+    // stderr without escalating — the daemon shouldn't crash because a
+    // client misbehaved.
+    process.stderr.write(
+      `[creds-handler] socket error: ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+  });
+}
+
+// =============================================================================
+// Factory
+// =============================================================================
+
+/**
+ * Build the creds handler. Pure factory — does not start anything; the
+ * caller invokes `handle.start()` once it's ready to accept requests.
+ *
+ * Compared to the prereq-C stub, this returns a live handle whose
+ * `start()` opens the UNIX socket and `stop()` closes it + unlinks the
+ * socket file. Both are idempotent.
+ */
+export function createCredsHandler(opts: CredsHandlerOpts): CredsHandler {
+  const socketPath = expandTilde(opts.socketPath ?? DEFAULT_SOCKET_PATH);
+  const credsDir = expandTilde(opts.credsDir ?? DEFAULT_CREDS_DIR);
+
+  const handlerOpts = {
+    registry: opts.registry,
+    accountSigningKey: opts.accountSigningKey,
+    org: opts.org,
+    credsDir,
+  };
+
+  let server: Server | null = null;
+  let started = false;
+  let stopped = false;
+
   return {
     async start() {
-      // No-op — real handler will: scan registry, mint per-agent JWTs
-      // scoped to each agent's runtime.capabilities, publish creds via
-      // runtime, and start a refresh timer keyed on JWT TTL.
+      if (started) return;
+      started = true;
+      try {
+        server = await listenOnUnixSocket(socketPath, (socket) =>
+          handleConnection(socket, handlerOpts),
+        );
+        process.stderr.write(
+          `[creds-handler] listening on ${socketPath} (creds_dir=${credsDir}, org=${opts.org})\n`,
+        );
+      } catch (err) {
+        // Log + re-throw. cortex.ts catches this and surfaces a non-fatal
+        // startup error — the bot keeps running, but `cortex creds issue`
+        // won't work until the operator fixes the socket-path problem.
+        process.stderr.write(
+          `[creds-handler] failed to listen on ${socketPath}: ${err instanceof Error ? err.message : String(err)}\n`,
+        );
+        started = false;
+        throw err;
+      }
     },
     async stop() {
-      // No-op — real handler will: cancel refresh timer, revoke minted
-      // creds, drain in-flight publishes.
+      if (stopped) return;
+      stopped = true;
+      if (!server) return;
+
+      // Best-effort close. `server.close()` waits for existing connections
+      // to drain. For UNIX-local request/reply that's milliseconds. We
+      // don't impose an explicit timeout — cortex.ts's shutdown drain
+      // already bounds the overall stop at 15 s.
+      await new Promise<void>((resolve) => {
+        server!.close((err) => {
+          if (err) {
+            process.stderr.write(
+              `[creds-handler] close error: ${err instanceof Error ? err.message : String(err)}\n`,
+            );
+          }
+          resolve();
+        });
+      });
+      server = null;
+
+      // Unlink the socket file. Defensive: if a future daemon instance
+      // listens on the same path, the leftover socket would EADDRINUSE.
+      try {
+        if (existsSync(socketPath)) {
+          unlinkSync(socketPath);
+        }
+      } catch (err) {
+        process.stderr.write(
+          `[creds-handler] unlink ${socketPath} failed: ${err instanceof Error ? err.message : String(err)}\n`,
+        );
+      }
     },
   };
 }


### PR DESCRIPTION
## What

**Closes cortex#67.** Daemon-side creds-handler + CLI IPC client. `issue` lights up end-to-end; `revoke`/`rotate` ship as **narrower v1 stubs** (local-file-only — server-side NATS account-JWT update deferred to a separate system-account topology design).

Builds on the 3 prereqs that landed earlier this session:
- ✅ cortex#71 Prereq A — `mintUserCreds()` JWT mint wrapper
- ✅ cortex#72 Prereq B — `loadAccountSigningKey()` chmod 600 loader + schema field
- ✅ cortex#73 Prereq C — `AgentRegistry` wired into `startCortex()`

## ⚠️ Scope narrowing surfaced — UNIX socket only in v1

The original cortex#67 design specified NATS req/reply on `local.{org}.cortex.creds.*` **preferred** with UNIX socket as **fallback**. The implementation discovered two real blockers:

### Blocker 1 — `TrustResolver` is the wrong primitive

The `TrustResolver` in `src/common/agents/trust-resolver.ts` (cortex#43) is the **platform-identity ↔ agent-id map** (Discord/Mattermost user ID → agent ID). It does NOT have `verifyOperatorSignature` or any NATS-side operator-trust verification. That's a different primitive that doesn't exist yet.

**Effect:** NATS-side subject-auth gate deferred to a v2 PR.

### Blocker 2 — `MyelinRuntime` has no subscribe-with-reply

`MyelinRuntime` exposes `onEnvelope` (fan-out) + `publish`. No request/reply primitive exists. Adding one would touch `runtime.ts`, `subscriber.ts`, and the surface-router contract — invasive for what's supposed to be one focused PR.

**Effect:** v1 ships **UNIX-socket-only**. The `handleRequest` core is **transport-agnostic** so a v2 PR can wire NATS request/reply without touching verb handlers.

### v1 transport: UNIX socket only

- Daemon listens on `~/.config/cortex/cortex.sock` (configurable via `socketPath`)
- Socket file gated by OS chmod 600 + daemon ownership — OS-level auth is sufficient
- CLI calls via `--socket <path>` flag (defaults to same path)
- Newline-delimited JSON framing (`{...}\n` → `{...}\n`) — chosen because Bun's `net.createServer` does not reliably fire server-side `'end'` on client half-close

## Verb behaviour (final)

| Verb | Result | Side effects |
|---|---|---|
| `issue <agent>` | `ok=true` | Mints user JWT scoped to `agent.runtime.capabilities`; writes `~/.config/nats/creds/<agent>.creds` chmod 600 |
| `revoke <agent>` | `ok=false`, `error: "server_side_revoke_not_implemented"` | Deletes local file; reports `file_deleted` bool; message explains server-side revoke is pending |
| `rotate <agent>` | `ok=true` (local rotate succeeded) | Deletes old + mints new; message flags old JWT still valid on bus until manual account-JWT revocation |

## CLI changes (`src/cli/cortex/commands/creds.ts`)

- `issue`/`revoke`/`rotate` no longer return exit 2 with `DEFERRED_SUBCOMMAND_MESSAGE` — they call real IPC
- New `--socket <path>` flag (scoped to mutation verbs)
- New `DaemonUnreachableError` mapping for ENOENT/ECONNREFUSED/EACCES → exit 1 with clear "daemon not reachable; ensure it is running"
- Daemon-reported `ok=false` → exit 1

## Wiring in `cortex.ts`

Real handler constructed iff: `runtime.enabled && agentRegistry.size > 0 && config.nats?.accountSigningKeyPath`. Loads signing key via Prereq B's `loadAccountSigningKey()`. Startup error is non-fatal — daemon proceeds without creds handler if the signing key path is misconfigured.

## Tests

- `src/runner/__tests__/creds-handler.test.ts` — **29 cases**: surface, idempotence, `handleRequest` per-verb, `parseCredsRequest`, end-to-end fake-daemon via live UNIX socket, stale-socket recovery, refuse-to-clobber-regular-file
- `src/cli/cortex/commands/__tests__/creds.test.ts` — **59 cases**: parse, validation, IPC happy path against mock daemon, daemon-reported failure, daemon-unreachable transport failure, dispatch routing, one full real-daemon ↔ real-CLI wire test

## Verification

- `bunx tsc --noEmit` exit 0
- `bun test src/runner/__tests__/creds-handler.test.ts` — 29/29
- `bun test src/cli/cortex/commands/__tests__/creds.test.ts` — 59/59
- Full suite — 2382 pass / 1 pre-existing fail (mc-dashboard-shell ENOENT)

## Follow-ups (separate PRs)

1. **v2 NATS transport** — add `request/reply` primitive to `MyelinRuntime`; wire `local.{org}.cortex.creds.*` subjects with the `TrustResolver` extension below
2. **Operator-signature verifier** — extend `TrustResolver` (or add a sibling) with NATS-side operator-creds signature check
3. **Server-side NATS account-JWT revoke** — separate system-account topology design issue (push to `$SYS.REQ.ACCOUNT.<id>.CLAIMS.UPDATE`); lights up `revoke`/`rotate` from local-stub to full

Closes cortex#67.

🤖 Generated with [Claude Code](https://claude.com/claude-code)