### PR TITLE
feat(trust): operator-signature verifier on TrustResolver (closes cortex#76)

### DIFF
--- a/src/common/agents/__tests__/trust-resolver-operator-verify.test.ts
+++ b/src/common/agents/__tests__/trust-resolver-operator-verify.test.ts
@@ -221,7 +221,9 @@ describe("verifyOperatorSignedRequest", () => {
       ts: new Date().toISOString(),
       payload: { verb: "issue", agent_id: "luna" },
     });
-    const result = verifyOperatorSignedRequest(env, trustedAccountSigningKey.getPublicKey());
+    const result = verifyOperatorSignedRequest(env, trustedAccountSigningKey.getPublicKey(), {
+      expectedSubject: "local.acme.cortex.creds.issue",
+    });
     expect(result.ok).toBe(true);
     if (result.ok) expect(result.userPublicKey).toBe(userKey.getPublicKey());
   });
@@ -261,6 +263,7 @@ describe("verifyOperatorSignedRequest", () => {
     const result = verifyOperatorSignedRequest(
       { subject: "x", userJwt: "y" } as unknown,
       trustedAccountSigningKey.getPublicKey(),
+      { expectedSubject: "x" },
     );
     expect(result.ok).toBe(false);
     if (!result.ok) expect(result.reason).toBe("malformed_envelope");
@@ -270,13 +273,16 @@ describe("verifyOperatorSignedRequest", () => {
     const result = verifyOperatorSignedRequest(
       "not an envelope",
       trustedAccountSigningKey.getPublicKey(),
+      { expectedSubject: "irrelevant" },
     );
     expect(result.ok).toBe(false);
     if (!result.ok) expect(result.reason).toBe("malformed_envelope");
   });
 
   test("malformed_envelope — null", () => {
-    const result = verifyOperatorSignedRequest(null, trustedAccountSigningKey.getPublicKey());
+    const result = verifyOperatorSignedRequest(null, trustedAccountSigningKey.getPublicKey(), {
+      expectedSubject: "irrelevant",
+    });
     expect(result.ok).toBe(false);
     if (!result.ok) expect(result.reason).toBe("malformed_envelope");
   });
@@ -290,7 +296,9 @@ describe("verifyOperatorSignedRequest", () => {
       ts: new Date().toISOString(),
       payload: { verb: "issue", agent_id: "luna" },
     });
-    const result = verifyOperatorSignedRequest(env, trustedAccountSigningKey.getPublicKey());
+    const result = verifyOperatorSignedRequest(env, trustedAccountSigningKey.getPublicKey(), {
+      expectedSubject: "local.acme.cortex.creds.issue",
+    });
     expect(result.ok).toBe(false);
     if (!result.ok) expect(result.reason).toBe("wrong_issuer");
   });
@@ -305,7 +313,9 @@ describe("verifyOperatorSignedRequest", () => {
       ts: oldTs,
       payload: {},
     });
-    const result = verifyOperatorSignedRequest(env, trustedAccountSigningKey.getPublicKey());
+    const result = verifyOperatorSignedRequest(env, trustedAccountSigningKey.getPublicKey(), {
+      expectedSubject: "s",
+    });
     expect(result.ok).toBe(false);
     if (!result.ok) expect(result.reason).toBe("ts_out_of_range");
   });
@@ -320,7 +330,9 @@ describe("verifyOperatorSignedRequest", () => {
       ts: futureTs,
       payload: {},
     });
-    const result = verifyOperatorSignedRequest(env, trustedAccountSigningKey.getPublicKey());
+    const result = verifyOperatorSignedRequest(env, trustedAccountSigningKey.getPublicKey(), {
+      expectedSubject: "s",
+    });
     expect(result.ok).toBe(false);
     if (!result.ok) expect(result.reason).toBe("ts_out_of_range");
   });
@@ -334,7 +346,9 @@ describe("verifyOperatorSignedRequest", () => {
       ts: "not-a-date",
       payload: {},
     });
-    const result = verifyOperatorSignedRequest(env, trustedAccountSigningKey.getPublicKey());
+    const result = verifyOperatorSignedRequest(env, trustedAccountSigningKey.getPublicKey(), {
+      expectedSubject: "s",
+    });
     expect(result.ok).toBe(false);
     if (!result.ok) expect(result.reason).toBe("ts_out_of_range");
   });
@@ -349,7 +363,9 @@ describe("verifyOperatorSignedRequest", () => {
       payload: {},
       signature: "@@@not valid base64!!!@@@",
     };
-    const result = verifyOperatorSignedRequest(env, trustedAccountSigningKey.getPublicKey());
+    const result = verifyOperatorSignedRequest(env, trustedAccountSigningKey.getPublicKey(), {
+      expectedSubject: "s",
+    });
     expect(result.ok).toBe(false);
     if (!result.ok) {
       // Either malformed_signature (decode failed) OR signature_invalid (decoded
@@ -373,6 +389,7 @@ describe("verifyOperatorSignedRequest", () => {
     const result = verifyOperatorSignedRequest(
       tampered,
       trustedAccountSigningKey.getPublicKey(),
+      { expectedSubject: "s" },
     );
     expect(result.ok).toBe(false);
     if (!result.ok) expect(result.reason).toBe("signature_invalid");
@@ -388,9 +405,14 @@ describe("verifyOperatorSignedRequest", () => {
       payload: { verb: "issue", agent_id: "luna" },
     });
     const tampered: SignedRequest = { ...env, subject: "local.acme.cortex.creds.revoke" };
+    // expectedSubject matches the tampered subject so we exercise the signature
+    // check (not the subject_mismatch short-circuit). This proves the signature
+    // covers `subject` end-to-end — even if the transport delivered the envelope
+    // on the tampered subject, the canonical bytes still won't verify.
     const result = verifyOperatorSignedRequest(
       tampered,
       trustedAccountSigningKey.getPublicKey(),
+      { expectedSubject: "local.acme.cortex.creds.revoke" },
     );
     expect(result.ok).toBe(false);
     if (!result.ok) expect(result.reason).toBe("signature_invalid");
@@ -409,6 +431,7 @@ describe("verifyOperatorSignedRequest", () => {
     const result = verifyOperatorSignedRequest(
       tampered,
       trustedAccountSigningKey.getPublicKey(),
+      { expectedSubject: "s" },
     );
     expect(result.ok).toBe(false);
     if (!result.ok) expect(result.reason).toBe("signature_invalid");
@@ -426,7 +449,9 @@ describe("verifyOperatorSignedRequest", () => {
       ts: new Date().toISOString(),
       payload: {},
     });
-    const result = verifyOperatorSignedRequest(env, trustedAccountSigningKey.getPublicKey());
+    const result = verifyOperatorSignedRequest(env, trustedAccountSigningKey.getPublicKey(), {
+      expectedSubject: "s",
+    });
     expect(result.ok).toBe(false);
     if (!result.ok) expect(result.reason).toBe("signature_invalid");
   });
@@ -445,7 +470,7 @@ describe("verifyOperatorSignedRequest", () => {
     const tightResult = verifyOperatorSignedRequest(
       env,
       trustedAccountSigningKey.getPublicKey(),
-      { signedRequestMaxAgeSec: 10 },
+      { expectedSubject: "s", signedRequestMaxAgeSec: 10 },
     );
     expect(tightResult.ok).toBe(false);
     if (!tightResult.ok) expect(tightResult.reason).toBe("ts_out_of_range");
@@ -454,6 +479,7 @@ describe("verifyOperatorSignedRequest", () => {
     const lenientResult = verifyOperatorSignedRequest(
       env,
       trustedAccountSigningKey.getPublicKey(),
+      { expectedSubject: "s" },
     );
     expect(lenientResult.ok).toBe(true);
   });
@@ -511,7 +537,7 @@ describe("TrustResolver.verifyOperatorSignature", () => {
 
   test("throws OperatorVerifierNotConfiguredError when pubkey absent", () => {
     const resolver = new TrustResolver(registryWithLuna());
-    expect(() => resolver.verifyOperatorSignature({})).toThrow(
+    expect(() => resolver.verifyOperatorSignature({}, { expectedSubject: "x" })).toThrow(
       OperatorVerifierNotConfiguredError,
     );
     expect(() => resolver.verifyUserJwt("any.jwt.value")).toThrow(
@@ -531,7 +557,9 @@ describe("TrustResolver.verifyOperatorSignature", () => {
       ts: new Date().toISOString(),
       payload: { verb: "issue", agent_id: "luna" },
     });
-    const result = resolver.verifyOperatorSignature(env);
+    const result = resolver.verifyOperatorSignature(env, {
+      expectedSubject: "local.acme.cortex.creds.issue",
+    });
     expect(result.ok).toBe(true);
   });
 
@@ -575,7 +603,7 @@ describe("TrustResolver.verifyOperatorSignature", () => {
       ts: new Date().toISOString(),
       payload: {},
     });
-    const result = resolver.verifyOperatorSignature(env);
+    const result = resolver.verifyOperatorSignature(env, { expectedSubject: "s" });
     expect(result.ok).toBe(false);
     if (!result.ok) expect(result.reason).toBe("wrong_issuer");
   });

--- a/src/common/agents/__tests__/trust-resolver-operator-verify.test.ts
+++ b/src/common/agents/__tests__/trust-resolver-operator-verify.test.ts
@@ -1,0 +1,605 @@
+/**
+ * cortex#76 — TrustResolver operator-signature verifier tests.
+ *
+ * Covers:
+ *   - Module-level `verifyOperatorUserJwt`:
+ *       - Happy path: valid JWT minted by trusted operator → ok
+ *       - wrong_issuer: JWT minted by a different account signing key
+ *       - expired: JWT with `exp` in the past
+ *       - not_yet_valid: JWT with `nbf` in the future
+ *       - malformed_jwt: empty / garbage / wrong segment count
+ *       - clock-skew tolerance honoured at the boundary
+ *
+ *   - Module-level `verifyOperatorSignedRequest`:
+ *       - Happy path: well-formed envelope with valid signature → ok
+ *       - malformed_envelope: missing fields, wrong types
+ *       - subject_mismatch: envelope.subject ≠ expectedSubject
+ *       - ts_out_of_range: too old, too far in future, unparseable
+ *       - malformed_signature: not base64url, length wrong
+ *       - signature_invalid: payload mutated, subject mutated, JWT swapped
+ *       - JWT issuer chain still enforced (re-uses verifyOperatorUserJwt path)
+ *
+ *   - TrustResolver instance methods:
+ *       - verifyOperatorSignature delegates correctly
+ *       - verifyUserJwt delegates correctly
+ *       - OperatorVerifierNotConfiguredError when pubkey absent
+ *       - isOperatorVerifierConfigured reflects construction
+ *       - Construction without options is backward-compatible (no opts arg)
+ */
+
+import { describe, test, expect, beforeAll } from "bun:test";
+
+import { createAccount, createUser, type KeyPair } from "@nats-io/nkeys";
+import { Algorithms, encodeUser } from "@nats-io/jwt";
+
+import { AgentRegistry } from "../registry";
+import {
+  canonicalSignedRequestBytes,
+  OperatorVerifierNotConfiguredError,
+  TrustResolver,
+  verifyOperatorSignedRequest,
+  verifyOperatorUserJwt,
+  type SignedRequest,
+} from "../trust-resolver";
+import type { Agent } from "../../types/cortex-config";
+
+// =============================================================================
+// Fixtures
+// =============================================================================
+
+/** Operator account signing keypair — the trust anchor for all tests. */
+let trustedAccountSigningKey: KeyPair;
+/** A different operator account signing keypair — used for "wrong issuer" tests. */
+let untrustedAccountSigningKey: KeyPair;
+/** Fresh per-test user keypairs minted as if by `mintUserCreds`. */
+
+beforeAll(() => {
+  trustedAccountSigningKey = createAccount();
+  untrustedAccountSigningKey = createAccount();
+});
+
+interface MintedFixture {
+  jwt: string;
+  userKey: KeyPair;
+  agentName: string;
+}
+
+/**
+ * Mint a JWT analogous to `mintUserCreds()` output — signed by the given
+ * account key, scoped to a fresh user nkey. Optional override of valid-window
+ * claims (`exp` / `nbf`) for time-related test cases.
+ */
+async function mintJwtFixture(
+  accountSigningKey: KeyPair,
+  agentName = "test-agent",
+  opts: { exp?: number; nbf?: number } = {},
+): Promise<MintedFixture> {
+  const userKey = createUser();
+  const jwt = await encodeUser(
+    agentName,
+    userKey,
+    accountSigningKey,
+    { pub: { allow: [] }, sub: { allow: [] } },
+    { algorithm: Algorithms.v2, exp: opts.exp, nbf: opts.nbf },
+  );
+  return { jwt, userKey, agentName };
+}
+
+/** Base64url-encode a Uint8Array (no padding, `-_` instead of `+/`). */
+function base64UrlEncode(bytes: Uint8Array): string {
+  let binary = "";
+  for (const b of bytes) binary += String.fromCharCode(b);
+  return btoa(binary).replace(/=+$/, "").replace(/\+/g, "-").replace(/\//g, "_");
+}
+
+/**
+ * Sign a request envelope using a user keypair. Mirrors what cortex#75's
+ * NATS producer would do — provides the canonical reference implementation
+ * tests use to assert verifier acceptance.
+ */
+function signRequest(
+  userKey: KeyPair,
+  parts: { subject: string; userJwt: string; nonce: string; ts: string; payload: unknown },
+): SignedRequest {
+  const canonical = canonicalSignedRequestBytes(parts);
+  const signature = base64UrlEncode(userKey.sign(canonical));
+  return { ...parts, signature };
+}
+
+function agentFixture(): Agent {
+  return {
+    id: "luna",
+    displayName: "Luna",
+    persona: "./personas/luna.md",
+    roles: [],
+    trust: [],
+    presence: {},
+  } as Agent;
+}
+
+function registryWithLuna(): AgentRegistry {
+  return AgentRegistry.fromAgents([agentFixture()]);
+}
+
+// =============================================================================
+// verifyOperatorUserJwt
+// =============================================================================
+
+describe("verifyOperatorUserJwt", () => {
+  test("happy path — JWT minted by trusted operator verifies", async () => {
+    const { jwt, userKey, agentName } = await mintJwtFixture(trustedAccountSigningKey, "luna");
+    const result = verifyOperatorUserJwt(jwt, trustedAccountSigningKey.getPublicKey());
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.userPublicKey).toBe(userKey.getPublicKey());
+      expect(result.agentName).toBe(agentName);
+    }
+  });
+
+  test("wrong_issuer — JWT minted by a different account is rejected", async () => {
+    const { jwt } = await mintJwtFixture(untrustedAccountSigningKey, "rogue");
+    const result = verifyOperatorUserJwt(jwt, trustedAccountSigningKey.getPublicKey());
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe("wrong_issuer");
+      expect(result.detail).toContain("does not match trusted operator");
+    }
+  });
+
+  test("expired — JWT with exp in the past is rejected", async () => {
+    const past = Math.floor(Date.now() / 1000) - 3600; // 1h ago, well past 60s skew
+    const { jwt } = await mintJwtFixture(trustedAccountSigningKey, "luna", { exp: past });
+    const result = verifyOperatorUserJwt(jwt, trustedAccountSigningKey.getPublicKey());
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("expired");
+  });
+
+  test("expired — JWT just inside the skew tolerance is accepted", async () => {
+    // exp = now - 30s, skew = 60s → still within tolerance
+    const past = Math.floor(Date.now() / 1000) - 30;
+    const { jwt } = await mintJwtFixture(trustedAccountSigningKey, "luna", { exp: past });
+    const result = verifyOperatorUserJwt(jwt, trustedAccountSigningKey.getPublicKey(), {
+      clockSkewToleranceSec: 60,
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  test("not_yet_valid — JWT with nbf in the future is rejected", async () => {
+    const future = Math.floor(Date.now() / 1000) + 3600;
+    const { jwt } = await mintJwtFixture(trustedAccountSigningKey, "luna", { nbf: future });
+    const result = verifyOperatorUserJwt(jwt, trustedAccountSigningKey.getPublicKey());
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("not_yet_valid");
+  });
+
+  test("malformed_jwt — empty string is rejected", () => {
+    const result = verifyOperatorUserJwt("", trustedAccountSigningKey.getPublicKey());
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("malformed_jwt");
+  });
+
+  test("malformed_jwt — garbage segments are rejected", () => {
+    const result = verifyOperatorUserJwt(
+      "not.a.real-jwt",
+      trustedAccountSigningKey.getPublicKey(),
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("malformed_jwt");
+  });
+
+  test("malformed_jwt — single segment is rejected", () => {
+    const result = verifyOperatorUserJwt("oneblob", trustedAccountSigningKey.getPublicKey());
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("malformed_jwt");
+  });
+
+  test("clock-skew tolerance — explicit nowMs honoured", async () => {
+    const { jwt } = await mintJwtFixture(trustedAccountSigningKey, "luna", {
+      exp: Math.floor(Date.now() / 1000) + 10,
+    });
+    // Pretend "now" is 1h in the future — should be expired.
+    const futureMs = Date.now() + 60 * 60 * 1000;
+    const result = verifyOperatorUserJwt(jwt, trustedAccountSigningKey.getPublicKey(), {
+      nowMs: futureMs,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("expired");
+  });
+});
+
+// =============================================================================
+// verifyOperatorSignedRequest
+// =============================================================================
+
+describe("verifyOperatorSignedRequest", () => {
+  test("happy path — envelope signed by user nkey under trusted JWT verifies", async () => {
+    const { jwt, userKey } = await mintJwtFixture(trustedAccountSigningKey, "luna");
+    const env = signRequest(userKey, {
+      subject: "local.acme.cortex.creds.issue",
+      userJwt: jwt,
+      nonce: "nonce-1",
+      ts: new Date().toISOString(),
+      payload: { verb: "issue", agent_id: "luna" },
+    });
+    const result = verifyOperatorSignedRequest(env, trustedAccountSigningKey.getPublicKey());
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.userPublicKey).toBe(userKey.getPublicKey());
+  });
+
+  test("happy path — expectedSubject matches envelope.subject", async () => {
+    const { jwt, userKey } = await mintJwtFixture(trustedAccountSigningKey, "luna");
+    const env = signRequest(userKey, {
+      subject: "local.acme.cortex.creds.issue",
+      userJwt: jwt,
+      nonce: "n",
+      ts: new Date().toISOString(),
+      payload: { verb: "issue", agent_id: "luna" },
+    });
+    const result = verifyOperatorSignedRequest(env, trustedAccountSigningKey.getPublicKey(), {
+      expectedSubject: "local.acme.cortex.creds.issue",
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  test("subject_mismatch — expectedSubject differs from envelope.subject", async () => {
+    const { jwt, userKey } = await mintJwtFixture(trustedAccountSigningKey, "luna");
+    const env = signRequest(userKey, {
+      subject: "local.acme.cortex.creds.issue",
+      userJwt: jwt,
+      nonce: "n",
+      ts: new Date().toISOString(),
+      payload: { verb: "issue", agent_id: "luna" },
+    });
+    const result = verifyOperatorSignedRequest(env, trustedAccountSigningKey.getPublicKey(), {
+      expectedSubject: "local.acme.cortex.creds.rotate",
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("subject_mismatch");
+  });
+
+  test("malformed_envelope — missing fields", () => {
+    const result = verifyOperatorSignedRequest(
+      { subject: "x", userJwt: "y" } as unknown,
+      trustedAccountSigningKey.getPublicKey(),
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("malformed_envelope");
+  });
+
+  test("malformed_envelope — non-object envelope", () => {
+    const result = verifyOperatorSignedRequest(
+      "not an envelope",
+      trustedAccountSigningKey.getPublicKey(),
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("malformed_envelope");
+  });
+
+  test("malformed_envelope — null", () => {
+    const result = verifyOperatorSignedRequest(null, trustedAccountSigningKey.getPublicKey());
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("malformed_envelope");
+  });
+
+  test("wrong_issuer — JWT signed by untrusted operator is rejected", async () => {
+    const { jwt, userKey } = await mintJwtFixture(untrustedAccountSigningKey, "rogue");
+    const env = signRequest(userKey, {
+      subject: "local.acme.cortex.creds.issue",
+      userJwt: jwt,
+      nonce: "n",
+      ts: new Date().toISOString(),
+      payload: { verb: "issue", agent_id: "luna" },
+    });
+    const result = verifyOperatorSignedRequest(env, trustedAccountSigningKey.getPublicKey());
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("wrong_issuer");
+  });
+
+  test("ts_out_of_range — too old", async () => {
+    const { jwt, userKey } = await mintJwtFixture(trustedAccountSigningKey, "luna");
+    const oldTs = new Date(Date.now() - 1000 * 60 * 60).toISOString(); // 1h ago
+    const env = signRequest(userKey, {
+      subject: "s",
+      userJwt: jwt,
+      nonce: "n",
+      ts: oldTs,
+      payload: {},
+    });
+    const result = verifyOperatorSignedRequest(env, trustedAccountSigningKey.getPublicKey());
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("ts_out_of_range");
+  });
+
+  test("ts_out_of_range — too far in future", async () => {
+    const { jwt, userKey } = await mintJwtFixture(trustedAccountSigningKey, "luna");
+    const futureTs = new Date(Date.now() + 1000 * 60 * 60).toISOString();
+    const env = signRequest(userKey, {
+      subject: "s",
+      userJwt: jwt,
+      nonce: "n",
+      ts: futureTs,
+      payload: {},
+    });
+    const result = verifyOperatorSignedRequest(env, trustedAccountSigningKey.getPublicKey());
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("ts_out_of_range");
+  });
+
+  test("ts_out_of_range — unparseable timestamp", async () => {
+    const { jwt, userKey } = await mintJwtFixture(trustedAccountSigningKey, "luna");
+    const env = signRequest(userKey, {
+      subject: "s",
+      userJwt: jwt,
+      nonce: "n",
+      ts: "not-a-date",
+      payload: {},
+    });
+    const result = verifyOperatorSignedRequest(env, trustedAccountSigningKey.getPublicKey());
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("ts_out_of_range");
+  });
+
+  test("malformed_signature — non-base64url chars", async () => {
+    const { jwt } = await mintJwtFixture(trustedAccountSigningKey, "luna");
+    const env: SignedRequest = {
+      subject: "s",
+      userJwt: jwt,
+      nonce: "n",
+      ts: new Date().toISOString(),
+      payload: {},
+      signature: "@@@not valid base64!!!@@@",
+    };
+    const result = verifyOperatorSignedRequest(env, trustedAccountSigningKey.getPublicKey());
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      // Either malformed_signature (decode failed) OR signature_invalid (decoded
+      // but wrong bytes). Either is acceptable — both are structured failures.
+      expect(["malformed_signature", "signature_invalid"]).toContain(result.reason);
+    }
+  });
+
+  test("signature_invalid — payload mutated after signing", async () => {
+    const { jwt, userKey } = await mintJwtFixture(trustedAccountSigningKey, "luna");
+    const ts = new Date().toISOString();
+    const env = signRequest(userKey, {
+      subject: "s",
+      userJwt: jwt,
+      nonce: "n",
+      ts,
+      payload: { verb: "issue", agent_id: "luna" },
+    });
+    // Attacker swaps the payload to a privileged verb — signature should fail.
+    const tampered: SignedRequest = { ...env, payload: { verb: "rotate", agent_id: "luna" } };
+    const result = verifyOperatorSignedRequest(
+      tampered,
+      trustedAccountSigningKey.getPublicKey(),
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("signature_invalid");
+  });
+
+  test("signature_invalid — subject mutated after signing (defeats subject-rebinding)", async () => {
+    const { jwt, userKey } = await mintJwtFixture(trustedAccountSigningKey, "luna");
+    const env = signRequest(userKey, {
+      subject: "local.acme.cortex.creds.issue",
+      userJwt: jwt,
+      nonce: "n",
+      ts: new Date().toISOString(),
+      payload: { verb: "issue", agent_id: "luna" },
+    });
+    const tampered: SignedRequest = { ...env, subject: "local.acme.cortex.creds.revoke" };
+    const result = verifyOperatorSignedRequest(
+      tampered,
+      trustedAccountSigningKey.getPublicKey(),
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("signature_invalid");
+  });
+
+  test("signature_invalid — nonce mutated after signing", async () => {
+    const { jwt, userKey } = await mintJwtFixture(trustedAccountSigningKey, "luna");
+    const env = signRequest(userKey, {
+      subject: "s",
+      userJwt: jwt,
+      nonce: "original-nonce",
+      ts: new Date().toISOString(),
+      payload: {},
+    });
+    const tampered: SignedRequest = { ...env, nonce: "different-nonce" };
+    const result = verifyOperatorSignedRequest(
+      tampered,
+      trustedAccountSigningKey.getPublicKey(),
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("signature_invalid");
+  });
+
+  test("signature_invalid — JWT swapped to a different user's JWT (signature can't migrate)", async () => {
+    const aliceFixture = await mintJwtFixture(trustedAccountSigningKey, "alice");
+    const bobFixture = await mintJwtFixture(trustedAccountSigningKey, "bob");
+    // Bob signs the request, but envelope claims Alice's JWT — verifier should
+    // reject because the signature won't verify under Alice's pubkey.
+    const env = signRequest(bobFixture.userKey, {
+      subject: "s",
+      userJwt: aliceFixture.jwt, // mismatched
+      nonce: "n",
+      ts: new Date().toISOString(),
+      payload: {},
+    });
+    const result = verifyOperatorSignedRequest(env, trustedAccountSigningKey.getPublicKey());
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("signature_invalid");
+  });
+
+  test("custom signedRequestMaxAgeSec is honoured", async () => {
+    const { jwt, userKey } = await mintJwtFixture(trustedAccountSigningKey, "luna");
+    const ts = new Date(Date.now() - 30 * 1000).toISOString(); // 30s ago
+    const env = signRequest(userKey, {
+      subject: "s",
+      userJwt: jwt,
+      nonce: "n",
+      ts,
+      payload: {},
+    });
+    // With max age = 10s, 30s old envelope must reject.
+    const tightResult = verifyOperatorSignedRequest(
+      env,
+      trustedAccountSigningKey.getPublicKey(),
+      { signedRequestMaxAgeSec: 10 },
+    );
+    expect(tightResult.ok).toBe(false);
+    if (!tightResult.ok) expect(tightResult.reason).toBe("ts_out_of_range");
+
+    // With default max age (300s), 30s old envelope must accept.
+    const lenientResult = verifyOperatorSignedRequest(
+      env,
+      trustedAccountSigningKey.getPublicKey(),
+    );
+    expect(lenientResult.ok).toBe(true);
+  });
+});
+
+// =============================================================================
+// canonicalSignedRequestBytes
+// =============================================================================
+
+describe("canonicalSignedRequestBytes", () => {
+  test("identical inputs produce identical bytes", () => {
+    const a = canonicalSignedRequestBytes({
+      subject: "s",
+      nonce: "n",
+      ts: "2026-01-01T00:00:00Z",
+      payload: { x: 1 },
+    });
+    const b = canonicalSignedRequestBytes({
+      subject: "s",
+      nonce: "n",
+      ts: "2026-01-01T00:00:00Z",
+      payload: { x: 1 },
+    });
+    expect(Buffer.from(a).equals(Buffer.from(b))).toBe(true);
+  });
+
+  test("different subjects produce different bytes", () => {
+    const a = canonicalSignedRequestBytes({
+      subject: "s1",
+      nonce: "n",
+      ts: "t",
+      payload: {},
+    });
+    const b = canonicalSignedRequestBytes({
+      subject: "s2",
+      nonce: "n",
+      ts: "t",
+      payload: {},
+    });
+    expect(Buffer.from(a).equals(Buffer.from(b))).toBe(false);
+  });
+});
+
+// =============================================================================
+// TrustResolver instance methods
+// =============================================================================
+
+describe("TrustResolver.verifyOperatorSignature", () => {
+  test("backward-compatible — constructor without options still works", () => {
+    // Pre-cortex#76 callers passed only the registry. Must still compile + run.
+    const resolver = new TrustResolver(registryWithLuna());
+    expect(resolver.size).toBe(0);
+    expect(resolver.isOperatorVerifierConfigured).toBe(false);
+  });
+
+  test("throws OperatorVerifierNotConfiguredError when pubkey absent", () => {
+    const resolver = new TrustResolver(registryWithLuna());
+    expect(() => resolver.verifyOperatorSignature({})).toThrow(
+      OperatorVerifierNotConfiguredError,
+    );
+    expect(() => resolver.verifyUserJwt("any.jwt.value")).toThrow(
+      OperatorVerifierNotConfiguredError,
+    );
+  });
+
+  test("delegates to verifyOperatorSignedRequest with configured pubkey", async () => {
+    const resolver = new TrustResolver(registryWithLuna(), {
+      operatorAccountSigningPublicKey: trustedAccountSigningKey.getPublicKey(),
+    });
+    const { jwt, userKey } = await mintJwtFixture(trustedAccountSigningKey, "luna");
+    const env = signRequest(userKey, {
+      subject: "local.acme.cortex.creds.issue",
+      userJwt: jwt,
+      nonce: "n",
+      ts: new Date().toISOString(),
+      payload: { verb: "issue", agent_id: "luna" },
+    });
+    const result = resolver.verifyOperatorSignature(env);
+    expect(result.ok).toBe(true);
+  });
+
+  test("delegates to verifyOperatorUserJwt", async () => {
+    const resolver = new TrustResolver(registryWithLuna(), {
+      operatorAccountSigningPublicKey: trustedAccountSigningKey.getPublicKey(),
+    });
+    const { jwt } = await mintJwtFixture(trustedAccountSigningKey, "luna");
+    const result = resolver.verifyUserJwt(jwt);
+    expect(result.ok).toBe(true);
+  });
+
+  test("expectedSubject passed through to delegate", async () => {
+    const resolver = new TrustResolver(registryWithLuna(), {
+      operatorAccountSigningPublicKey: trustedAccountSigningKey.getPublicKey(),
+    });
+    const { jwt, userKey } = await mintJwtFixture(trustedAccountSigningKey, "luna");
+    const env = signRequest(userKey, {
+      subject: "local.acme.cortex.creds.issue",
+      userJwt: jwt,
+      nonce: "n",
+      ts: new Date().toISOString(),
+      payload: {},
+    });
+    const result = resolver.verifyOperatorSignature(env, {
+      expectedSubject: "local.acme.cortex.creds.rotate",
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("subject_mismatch");
+  });
+
+  test("rejects JWT from untrusted operator at instance layer too", async () => {
+    const resolver = new TrustResolver(registryWithLuna(), {
+      operatorAccountSigningPublicKey: trustedAccountSigningKey.getPublicKey(),
+    });
+    const { jwt, userKey } = await mintJwtFixture(untrustedAccountSigningKey, "rogue");
+    const env = signRequest(userKey, {
+      subject: "s",
+      userJwt: jwt,
+      nonce: "n",
+      ts: new Date().toISOString(),
+      payload: {},
+    });
+    const result = resolver.verifyOperatorSignature(env);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("wrong_issuer");
+  });
+
+  test("isOperatorVerifierConfigured reflects construction", () => {
+    const unconfigured = new TrustResolver(registryWithLuna());
+    expect(unconfigured.isOperatorVerifierConfigured).toBe(false);
+
+    const configured = new TrustResolver(registryWithLuna(), {
+      operatorAccountSigningPublicKey: trustedAccountSigningKey.getPublicKey(),
+    });
+    expect(configured.isOperatorVerifierConfigured).toBe(true);
+  });
+
+  test("custom clock-skew tolerance flows through to delegate", async () => {
+    const resolver = new TrustResolver(registryWithLuna(), {
+      operatorAccountSigningPublicKey: trustedAccountSigningKey.getPublicKey(),
+      clockSkewToleranceSec: 0, // strictest
+    });
+    // exp = now - 5s, zero skew → expired
+    const past = Math.floor(Date.now() / 1000) - 5;
+    const { jwt } = await mintJwtFixture(trustedAccountSigningKey, "luna", { exp: past });
+    const result = resolver.verifyUserJwt(jwt);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.reason).toBe("expired");
+  });
+});

--- a/src/common/agents/trust-resolver.ts
+++ b/src/common/agents/trust-resolver.ts
@@ -58,6 +58,9 @@
  *     v1 concern.
  */
 
+import { decode, type User } from "@nats-io/jwt";
+import { fromPublic } from "@nats-io/nkeys";
+
 import type { Agent } from "../types/cortex-config";
 import { AgentNotFoundError, AgentRegistry } from "./registry";
 
@@ -76,6 +79,411 @@ export type Platform = "discord" | "mattermost";
 export interface PlatformIdentity {
   readonly platform: Platform;
   readonly platformId: string;
+}
+
+// =============================================================================
+// Operator-signature verification (cortex#76)
+// =============================================================================
+
+/**
+ * Options for an operator-aware `TrustResolver`. Optional — when omitted, the
+ * resolver behaves as the pre-cortex#76 platform-identity map and the
+ * operator-verification methods throw `OperatorVerifierNotConfiguredError`.
+ *
+ * The operator account signing public key (`A…` prefix) is the trust anchor:
+ * every NATS user JWT minted by `mintUserCreds()` carries this pubkey in its
+ * `iss` claim. A request is "operator-trusted" iff its user JWT chains to
+ * this pubkey AND the request payload is signed by the user nkey that owns
+ * the JWT's `sub` claim.
+ */
+export interface TrustResolverOptions {
+  /**
+   * Operator account signing public key (`A…`). Pass `keyPair.getPublicKey()`
+   * from the result of `loadAccountSigningKey()` in `cortex.ts`. The pubkey
+   * is public material — safe to log, safe to embed in config diagnostics.
+   *
+   * NOT the seed. NOT the keypair. Just the public key string. The verifier
+   * never needs signing material — verification is one-way.
+   */
+  operatorAccountSigningPublicKey?: string;
+
+  /**
+   * Optional clock-skew tolerance (seconds) for `exp` / `nbf` JWT claims and
+   * for `ts` on signed-request envelopes. Defaults to 60s. Set higher for
+   * test rigs running with deliberately divergent clocks; set to 0 for the
+   * strictest production posture.
+   */
+  clockSkewToleranceSec?: number;
+
+  /**
+   * Optional max age (seconds) for signed-request `ts` — defends against
+   * replay of a captured envelope long after the fact. Defaults to 300s
+   * (5 minutes). The user nkey signature alone has no built-in freshness
+   * guarantee, so the verifier enforces this at the envelope layer.
+   */
+  signedRequestMaxAgeSec?: number;
+}
+
+/**
+ * Default tolerances. Exported so consumers can match production policy in
+ * out-of-band scripts (e.g. a `cortex trust verify --jwt …` debug command).
+ */
+export const DEFAULT_CLOCK_SKEW_SEC = 60;
+export const DEFAULT_SIGNED_REQUEST_MAX_AGE_SEC = 300;
+
+/**
+ * A signed NATS request envelope. The shape composes with `mintUserCreds()`:
+ *
+ *   - `userJwt` is the JWT minted for the requesting agent (the `userJwt`
+ *     field returned by `mintUserCreds`). It carries the user's nkey
+ *     pubkey in `sub` and the operator account signing pubkey in `iss`.
+ *   - `subject` is the NATS subject the request is published on. Bound into
+ *     the canonical form so a captured signature can't be replayed against
+ *     a different subject (e.g. lift a `creds.issue` signature and aim it
+ *     at `creds.rotate`).
+ *   - `nonce` is a fresh, per-request random token. Bound into the canonical
+ *     form to defend against in-window replays. The verifier itself does
+ *     not maintain a nonce-seen cache — that's the caller's responsibility
+ *     if they want at-most-once semantics. The nonce is here so a future
+ *     cache CAN exist; today's value-add is preventing identical-payload
+ *     in-window replays from being byte-identical envelopes.
+ *   - `ts` is an ISO-8601 timestamp. Bound into the canonical form AND
+ *     checked against `signedRequestMaxAgeSec` for replay defence.
+ *   - `payload` is the request body (verb + args, etc.). Arbitrary JSON.
+ *     Canonicalised via `JSON.stringify(payload)` — callers are responsible
+ *     for ensuring stable key order if their payloads contain objects whose
+ *     key order varies across runtimes. For the cortex#75 use case (CredsRequest)
+ *     payloads are flat `{verb, agent_id}` so this is not a concern.
+ *   - `signature` is base64url of the ed25519 signature over the canonical
+ *     bytes, produced by the user's nkey via `KeyPair.sign(bytes)`.
+ *
+ * # Why this shape vs. pure NATS-level auth?
+ *
+ * NATS authenticates the connection via the user JWT at CONNECT time. The
+ * server enforces subject permissions baked into the JWT. That's sufficient
+ * if the application trusts the NATS server to relay the connection identity
+ * faithfully. But cortex's threat model assumes the NATS server is a
+ * separate trust domain (operator may run NATS managed by Synadia, etc.) —
+ * so the verifier re-establishes identity end-to-end at the application
+ * layer. The signature over the canonical form gives the application
+ * cryptographic proof of producer identity per request, not just per
+ * connection.
+ */
+export interface SignedRequest {
+  readonly subject: string;
+  readonly userJwt: string;
+  readonly nonce: string;
+  readonly ts: string;
+  readonly payload: unknown;
+  /** Base64url-encoded ed25519 signature over `canonicalSignedRequestBytes`. */
+  readonly signature: string;
+}
+
+/**
+ * Outcome of a verification attempt. Discriminated on `ok` so callers can
+ * branch on the failure reason without parsing strings. The structured
+ * `reason` lets the consumer (e.g. cortex#75's NATS transport gate) log /
+ * meter the failure class without surfacing it back to the requesting bot
+ * (which would leak verifier internals).
+ */
+export type OperatorVerificationResult =
+  | { ok: true; userPublicKey: string; agentName: string }
+  | { ok: false; reason: OperatorVerificationFailure; detail: string };
+
+export type OperatorVerificationFailure =
+  | "malformed_jwt"
+  | "wrong_issuer"
+  | "expired"
+  | "not_yet_valid"
+  | "malformed_envelope"
+  | "subject_mismatch"
+  | "ts_out_of_range"
+  | "malformed_signature"
+  | "signature_invalid";
+
+/**
+ * Thrown when an operator-verification method is called on a `TrustResolver`
+ * built without an `operatorAccountSigningPublicKey`. Lets the consumer fail
+ * fast with a clear message rather than silently rejecting every request.
+ */
+export class OperatorVerifierNotConfiguredError extends Error {
+  constructor() {
+    super(
+      "TrustResolver.verifyOperatorSignature called but no operatorAccountSigningPublicKey " +
+        "was supplied at construction. Pass options.operatorAccountSigningPublicKey " +
+        "(e.g. accountSigningKey.getPublicKey() from loadAccountSigningKey) when " +
+        "instantiating the resolver if you intend to verify operator-signed requests.",
+    );
+    this.name = "OperatorVerifierNotConfiguredError";
+  }
+}
+
+/**
+ * Build the canonical byte-string that the user nkey signs. The format is a
+ * deliberately simple newline-separated tuple of subject, nonce, ts, and
+ * `JSON.stringify(payload)`. Newline separators are safe because subject /
+ * nonce / ts are all token-shaped (no literal newlines), and `JSON.stringify`
+ * never emits a bare newline.
+ *
+ * Exported so the matching `signSignedRequest` helper (and tests, and any
+ * future producer in cortex#75) computes IDENTICAL bytes — there must be
+ * exactly one canonical form in the codebase or signatures will silently
+ * mismatch.
+ */
+export function canonicalSignedRequestBytes(parts: {
+  subject: string;
+  nonce: string;
+  ts: string;
+  payload: unknown;
+}): Uint8Array {
+  const canonical = `${parts.subject}\n${parts.nonce}\n${parts.ts}\n${JSON.stringify(parts.payload)}`;
+  return new TextEncoder().encode(canonical);
+}
+
+/**
+ * Verify a NATS user JWT against the operator account signing public key.
+ *
+ * `@nats-io/jwt`'s `decode` already verifies the JWT signature against the
+ * pubkey in the `iss` claim — so a successful decode means the JWT is
+ * self-consistent. This wrapper adds the missing checks the consumer cares
+ * about: (a) `iss` actually matches the operator we trust, (b) the JWT is
+ * within its validity window.
+ *
+ * Pure function over inputs. No I/O. No state.
+ */
+export function verifyOperatorUserJwt(
+  jwt: string,
+  operatorAccountSigningPublicKey: string,
+  opts: { clockSkewToleranceSec?: number; nowMs?: number } = {},
+): OperatorVerificationResult {
+  if (typeof jwt !== "string" || jwt.length === 0) {
+    return { ok: false, reason: "malformed_jwt", detail: "jwt is empty or not a string" };
+  }
+
+  let claims;
+  try {
+    claims = decode<User>(jwt);
+  } catch (err) {
+    return {
+      ok: false,
+      reason: "malformed_jwt",
+      detail: `jwt decode failed: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+
+  if (claims.iss !== operatorAccountSigningPublicKey) {
+    return {
+      ok: false,
+      reason: "wrong_issuer",
+      detail:
+        `jwt iss=${claims.iss} does not match trusted operator pubkey ` +
+        `${operatorAccountSigningPublicKey}`,
+    };
+  }
+
+  const skew = opts.clockSkewToleranceSec ?? DEFAULT_CLOCK_SKEW_SEC;
+  const nowSec = Math.floor((opts.nowMs ?? Date.now()) / 1000);
+  if (typeof claims.exp === "number" && claims.exp > 0 && claims.exp + skew < nowSec) {
+    return {
+      ok: false,
+      reason: "expired",
+      detail: `jwt expired at exp=${claims.exp} (now=${nowSec}, skew=${skew}s)`,
+    };
+  }
+  if (typeof claims.nbf === "number" && claims.nbf > 0 && claims.nbf - skew > nowSec) {
+    return {
+      ok: false,
+      reason: "not_yet_valid",
+      detail: `jwt not yet valid: nbf=${claims.nbf} (now=${nowSec}, skew=${skew}s)`,
+    };
+  }
+
+  if (typeof claims.sub !== "string" || claims.sub.length === 0) {
+    return {
+      ok: false,
+      reason: "malformed_jwt",
+      detail: "jwt sub (user pubkey) is missing or empty",
+    };
+  }
+
+  return { ok: true, userPublicKey: claims.sub, agentName: claims.name ?? "" };
+}
+
+/**
+ * Verify a full operator-signed request envelope: JWT chains to operator,
+ * envelope shape is well-formed, the timestamp is within the freshness
+ * window, and the ed25519 signature over the canonical bytes verifies
+ * against the user's nkey pubkey (taken from the JWT's `sub`).
+ *
+ * The check order matches the cost / specificity profile:
+ *   1. Envelope shape (cheap, structural)
+ *   2. JWT verify + freshness (cheap, structural)
+ *   3. Subject + ts envelope bindings (cheap, semantic)
+ *   4. Signature verify (expensive, cryptographic)
+ *
+ * Pure function. The caller is responsible for nonce-replay state if they
+ * need at-most-once semantics — see `SignedRequest.nonce` rationale.
+ */
+export function verifyOperatorSignedRequest(
+  envelope: unknown,
+  operatorAccountSigningPublicKey: string,
+  opts: {
+    clockSkewToleranceSec?: number;
+    signedRequestMaxAgeSec?: number;
+    nowMs?: number;
+    /** Optional explicit subject the caller expects — defends against an envelope
+     *  whose self-declared `subject` doesn't match the NATS subject it actually
+     *  arrived on. Skip in unit tests; supply in real transports. */
+    expectedSubject?: string;
+  } = {},
+): OperatorVerificationResult {
+  if (!isSignedRequestShape(envelope)) {
+    return {
+      ok: false,
+      reason: "malformed_envelope",
+      detail: "envelope does not match SignedRequest shape",
+    };
+  }
+
+  const env = envelope as SignedRequest;
+
+  if (opts.expectedSubject !== undefined && env.subject !== opts.expectedSubject) {
+    return {
+      ok: false,
+      reason: "subject_mismatch",
+      detail: `envelope.subject="${env.subject}" but transport delivered on "${opts.expectedSubject}"`,
+    };
+  }
+
+  const jwtResult = verifyOperatorUserJwt(env.userJwt, operatorAccountSigningPublicKey, {
+    clockSkewToleranceSec: opts.clockSkewToleranceSec,
+    nowMs: opts.nowMs,
+  });
+  if (!jwtResult.ok) return jwtResult;
+
+  // Envelope freshness — defend against replay even when the JWT itself is
+  // long-lived. ISO-8601 parse is permissive; reject zero-length / NaN.
+  const tsMs = Date.parse(env.ts);
+  if (!Number.isFinite(tsMs)) {
+    return {
+      ok: false,
+      reason: "ts_out_of_range",
+      detail: `envelope.ts="${env.ts}" is not a valid ISO-8601 date`,
+    };
+  }
+  const nowMs = opts.nowMs ?? Date.now();
+  const maxAgeMs = (opts.signedRequestMaxAgeSec ?? DEFAULT_SIGNED_REQUEST_MAX_AGE_SEC) * 1000;
+  const skewMs = (opts.clockSkewToleranceSec ?? DEFAULT_CLOCK_SKEW_SEC) * 1000;
+  // Two-sided check: the envelope must not be older than the max age, and
+  // must not be too far in the future (clock skew tolerated).
+  if (nowMs - tsMs > maxAgeMs) {
+    return {
+      ok: false,
+      reason: "ts_out_of_range",
+      detail: `envelope ts=${env.ts} older than ${maxAgeMs / 1000}s (delta=${(nowMs - tsMs) / 1000}s)`,
+    };
+  }
+  if (tsMs - nowMs > skewMs) {
+    return {
+      ok: false,
+      reason: "ts_out_of_range",
+      detail: `envelope ts=${env.ts} too far in future (delta=${(tsMs - nowMs) / 1000}s, skew=${skewMs / 1000}s)`,
+    };
+  }
+
+  // Crypto verify last — most expensive step. Decode base64url to bytes,
+  // reconstruct the public-key KeyPair, verify.
+  let sigBytes: Uint8Array;
+  try {
+    sigBytes = decodeBase64Url(env.signature);
+  } catch (err) {
+    return {
+      ok: false,
+      reason: "malformed_signature",
+      detail: `signature is not valid base64url: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+
+  let userKeyPair;
+  try {
+    userKeyPair = fromPublic(jwtResult.userPublicKey);
+  } catch (err) {
+    return {
+      ok: false,
+      reason: "malformed_jwt",
+      detail: `jwt sub="${jwtResult.userPublicKey}" is not a valid NKey public key: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+
+  const canonical = canonicalSignedRequestBytes({
+    subject: env.subject,
+    nonce: env.nonce,
+    ts: env.ts,
+    payload: env.payload,
+  });
+
+  let verified: boolean;
+  try {
+    verified = userKeyPair.verify(canonical, sigBytes);
+  } catch (err) {
+    // `KeyPair.verify` shouldn't throw for valid inputs, but defensively
+    // catch malformed sig lengths etc. so a bug in the producer surfaces
+    // as a structured failure rather than crashing the verifier.
+    return {
+      ok: false,
+      reason: "signature_invalid",
+      detail: `verify threw: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+
+  if (!verified) {
+    return {
+      ok: false,
+      reason: "signature_invalid",
+      detail: "ed25519 signature does not verify against jwt sub pubkey",
+    };
+  }
+
+  return jwtResult;
+}
+
+/**
+ * Type guard for `SignedRequest`. Conservative — checks every field's
+ * presence and string-ness (except `payload`, which is allowed to be any
+ * JSON value including null).
+ */
+function isSignedRequestShape(value: unknown): value is SignedRequest {
+  if (typeof value !== "object" || value === null) return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.subject === "string" &&
+    typeof v.userJwt === "string" &&
+    typeof v.nonce === "string" &&
+    typeof v.ts === "string" &&
+    typeof v.signature === "string" &&
+    "payload" in v
+  );
+}
+
+/**
+ * Decode a base64url string to bytes. Accepts the `@nats-io/jwt`
+ * convention (no padding, `-_` instead of `+/`). Throws on invalid chars
+ * via the spec'd atob fallback.
+ *
+ * We inline this rather than importing `Base64UrlCodec` from
+ * `@nats-io/jwt/lib/base64` — that path isn't part of the package's public
+ * exports and would couple us to its internals. `atob` is stdlib in Bun
+ * and Node 18+, which both target environments support.
+ */
+function decodeBase64Url(input: string): Uint8Array {
+  // Re-introduce padding atob requires.
+  const pad = input.length % 4 === 0 ? "" : "=".repeat(4 - (input.length % 4));
+  const b64 = input.replace(/-/g, "+").replace(/_/g, "/") + pad;
+  // atob throws on non-base64 chars. Let it.
+  const binary = atob(b64);
+  const out = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) out[i] = binary.charCodeAt(i);
+  return out;
 }
 
 // =============================================================================
@@ -131,8 +539,82 @@ export class TrustResolver {
   /** Reverse: agentId → Set<`${platform}:${platformId}`> */
   private readonly reverse = new Map<string, Set<string>>();
 
-  constructor(registry: AgentRegistry) {
+  /**
+   * Operator account signing public key, if configured. When undefined,
+   * `verifyOperatorSignature` throws `OperatorVerifierNotConfiguredError`.
+   * See `TrustResolverOptions.operatorAccountSigningPublicKey`.
+   */
+  private readonly operatorAccountSigningPublicKey: string | undefined;
+  private readonly clockSkewToleranceSec: number;
+  private readonly signedRequestMaxAgeSec: number;
+
+  constructor(registry: AgentRegistry, options: TrustResolverOptions = {}) {
     this.registry = registry;
+    this.operatorAccountSigningPublicKey = options.operatorAccountSigningPublicKey;
+    this.clockSkewToleranceSec = options.clockSkewToleranceSec ?? DEFAULT_CLOCK_SKEW_SEC;
+    this.signedRequestMaxAgeSec =
+      options.signedRequestMaxAgeSec ?? DEFAULT_SIGNED_REQUEST_MAX_AGE_SEC;
+  }
+
+  /**
+   * cortex#76 — verify that a NATS request envelope was signed by
+   * operator-trusted credentials. Returns a structured result rather than
+   * a plain boolean so callers (e.g. the cortex#75 NATS transport gate)
+   * can branch on the specific failure class for logging / metering.
+   *
+   * @param signedRequest The envelope. See `SignedRequest`.
+   * @param opts.expectedSubject The NATS subject the message arrived on —
+   *        defends against an attacker re-aiming a valid signature at a
+   *        different subject. Strongly recommended in production transports.
+   *
+   * @throws OperatorVerifierNotConfiguredError if the resolver was built
+   *         without `operatorAccountSigningPublicKey`.
+   *
+   * Delegates to the module-level `verifyOperatorSignedRequest`. Sibling
+   * pure functions exposed for callers that don't want the resolver
+   * instance (e.g. tooling, debug CLI).
+   */
+  verifyOperatorSignature(
+    signedRequest: unknown,
+    opts: { expectedSubject?: string; nowMs?: number } = {},
+  ): OperatorVerificationResult {
+    if (!this.operatorAccountSigningPublicKey) {
+      throw new OperatorVerifierNotConfiguredError();
+    }
+    return verifyOperatorSignedRequest(signedRequest, this.operatorAccountSigningPublicKey, {
+      clockSkewToleranceSec: this.clockSkewToleranceSec,
+      signedRequestMaxAgeSec: this.signedRequestMaxAgeSec,
+      expectedSubject: opts.expectedSubject,
+      nowMs: opts.nowMs,
+    });
+  }
+
+  /**
+   * cortex#76 — convenience: verify just the user JWT against the trusted
+   * operator pubkey, without requiring a full signed envelope. Useful at
+   * NATS-connection authorization time when the application only has the
+   * connection's user JWT and wants to gate the connection on operator
+   * trust before accepting subscriptions.
+   *
+   * @throws OperatorVerifierNotConfiguredError if the resolver was built
+   *         without `operatorAccountSigningPublicKey`.
+   */
+  verifyUserJwt(
+    jwt: string,
+    opts: { nowMs?: number } = {},
+  ): OperatorVerificationResult {
+    if (!this.operatorAccountSigningPublicKey) {
+      throw new OperatorVerifierNotConfiguredError();
+    }
+    return verifyOperatorUserJwt(jwt, this.operatorAccountSigningPublicKey, {
+      clockSkewToleranceSec: this.clockSkewToleranceSec,
+      nowMs: opts.nowMs,
+    });
+  }
+
+  /** True iff the resolver was constructed with an operator pubkey. */
+  get isOperatorVerifierConfigured(): boolean {
+    return this.operatorAccountSigningPublicKey !== undefined;
   }
 
   /**

--- a/src/common/agents/trust-resolver.ts
+++ b/src/common/agents/trust-resolver.ts
@@ -154,6 +154,13 @@ export const DEFAULT_SIGNED_REQUEST_MAX_AGE_SEC = 300;
  *     for ensuring stable key order if their payloads contain objects whose
  *     key order varies across runtimes. For the cortex#75 use case (CredsRequest)
  *     payloads are flat `{verb, agent_id}` so this is not a concern.
+ *     Note: `JSON.stringify(payload)` is non-deterministic for nested objects
+ *     across runtimes (key ordering, number representation, whitespace).
+ *     Safe for the current flat key-value payload shape. If payload shape ever
+ *     grows to nested objects, either restrict the shape at the transport
+ *     layer or swap in a deterministic canonicaliser (e.g. RFC 8785 JCS) at
+ *     `canonicalSignedRequestBytes` — but do it in lock-step with all
+ *     producers, since the producer and verifier MUST agree byte-for-byte.
  *   - `signature` is base64url of the ed25519 signature over the canonical
  *     bytes, produced by the user's nkey via `KeyPair.sign(bytes)`.
  *
@@ -229,6 +236,13 @@ export class OperatorVerifierNotConfiguredError extends Error {
  * future producer in cortex#75) computes IDENTICAL bytes — there must be
  * exactly one canonical form in the codebase or signatures will silently
  * mismatch.
+ *
+ * Determinism caveat: `JSON.stringify(payload)` is NOT guaranteed
+ * byte-identical across runtimes for nested objects — key order is
+ * insertion order in V8 / JSC / Bun, but spec only guarantees order for
+ * string keys. Today's cortex#75 payloads are flat `{verb, agent_id}` so
+ * this is fine. If the payload grows nested, swap to a deterministic
+ * canonicaliser (e.g. RFC 8785 JCS) in lock-step with all producers.
  */
 export function canonicalSignedRequestBytes(parts: {
   subject: string;
@@ -323,6 +337,29 @@ export function verifyOperatorUserJwt(
  *
  * Pure function. The caller is responsible for nonce-replay state if they
  * need at-most-once semantics — see `SignedRequest.nonce` rationale.
+ *
+ * # Replay-window note
+ *
+ * The verifier enforces TWO independent freshness windows:
+ *   - envelope `ts` must be within `signedRequestMaxAgeSec` (default 300s)
+ *   - the user JWT's `exp` must be within `clockSkewToleranceSec` (default 60s)
+ *
+ * These stack — the effective max-replay-age is `min(maxAge, jwtExp − now)`.
+ * If the JWT is long-lived (cortex's default credential lifetime), `ts`
+ * dominates. If the JWT is short-lived (rotated frequently), `jwt.exp`
+ * dominates. Callers tuning either knob should consider both.
+ *
+ * # `expectedSubject` is required
+ *
+ * The caller MUST supply the NATS subject the transport actually delivered
+ * the envelope on. The verifier then checks that `envelope.subject` matches.
+ * This binds the signature to the transport delivery channel at the
+ * application layer — without it, an attacker who captures a valid envelope
+ * on subject A could replay it on subject B, because the signature only
+ * covers `envelope.subject` (which they don't need to alter). Making this
+ * parameter required at the type level forces production transports to
+ * pass it; tests that don't care about the subject check pass the same
+ * subject they signed with.
  */
 export function verifyOperatorSignedRequest(
   envelope: unknown,
@@ -331,11 +368,13 @@ export function verifyOperatorSignedRequest(
     clockSkewToleranceSec?: number;
     signedRequestMaxAgeSec?: number;
     nowMs?: number;
-    /** Optional explicit subject the caller expects — defends against an envelope
-     *  whose self-declared `subject` doesn't match the NATS subject it actually
-     *  arrived on. Skip in unit tests; supply in real transports. */
-    expectedSubject?: string;
-  } = {},
+    /** The NATS subject the transport delivered this envelope on. Bound into
+     *  the verifier so a captured envelope can't be replayed against a
+     *  different subject. REQUIRED — no default-skip. Tests that don't care
+     *  about the subject check pass the same subject the envelope was signed
+     *  with. */
+    expectedSubject: string;
+  },
 ): OperatorVerificationResult {
   if (!isSignedRequestShape(envelope)) {
     return {
@@ -347,7 +386,7 @@ export function verifyOperatorSignedRequest(
 
   const env = envelope as SignedRequest;
 
-  if (opts.expectedSubject !== undefined && env.subject !== opts.expectedSubject) {
+  if (env.subject !== opts.expectedSubject) {
     return {
       ok: false,
       reason: "subject_mismatch",
@@ -444,6 +483,10 @@ export function verifyOperatorSignedRequest(
     };
   }
 
+  // Reuse the `ok: true` result from `verifyOperatorUserJwt` — it already
+  // carries the validated `userPublicKey` and `agentName`. Constructing a
+  // fresh object here would be redundant and risk drift if the success
+  // shape gains new fields.
   return jwtResult;
 }
 
@@ -563,9 +606,12 @@ export class TrustResolver {
    * can branch on the specific failure class for logging / metering.
    *
    * @param signedRequest The envelope. See `SignedRequest`.
-   * @param opts.expectedSubject The NATS subject the message arrived on —
-   *        defends against an attacker re-aiming a valid signature at a
-   *        different subject. Strongly recommended in production transports.
+   * @param opts.expectedSubject REQUIRED. The NATS subject the transport
+   *        delivered the envelope on. Bound into the verifier to defend
+   *        against signature-rebinding: an attacker who captures a valid
+   *        envelope on subject A would otherwise be able to replay it on
+   *        subject B. Required at the type level so production transports
+   *        cannot accidentally skip the check.
    *
    * @throws OperatorVerifierNotConfiguredError if the resolver was built
    *         without `operatorAccountSigningPublicKey`.
@@ -576,7 +622,7 @@ export class TrustResolver {
    */
   verifyOperatorSignature(
     signedRequest: unknown,
-    opts: { expectedSubject?: string; nowMs?: number } = {},
+    opts: { expectedSubject: string; nowMs?: number },
   ): OperatorVerificationResult {
     if (!this.operatorAccountSigningPublicKey) {
       throw new OperatorVerifierNotConfiguredError();


### PR DESCRIPTION
## What

Closes **cortex#76**. Adds the NATS-side operator-trust verifier `TrustResolver` was missing — the primitive that answers _"is this NATS request signed by operator-trusted creds?"_ Strict prerequisite for **cortex#75** (NATS transport for creds), which now unblocks.

## Shape chosen

**Option 1 — extension of `TrustResolver`** (per cortex#76 issue body's preference). Constructor takes a new optional `TrustResolverOptions` arg; backward-compatible (all 26 pre-existing tests pass unchanged).

New class methods:
- `verifyOperatorSignature(signedRequest, opts?)` — the issue's primary ask
- `verifyUserJwt(jwt, opts?)` — connection-time auth helper for cortex#75's NATS accept path
- `isOperatorVerifierConfigured: boolean` — flag accessor

Plus three module-level pure functions exported so CLI / tooling / tests can use them without an instance: `verifyOperatorUserJwt`, `verifyOperatorSignedRequest`, `canonicalSignedRequestBytes`.

## Signed-request format

Composes existing primitives (NOT invented):

```ts
SignedRequest = {
  subject:   string,    // NATS subject — bound into canonical form
  userJwt:   string,    // JWT minted by mintUserCreds() (cortex#71)
  nonce:     string,    // per-request random; bound into canonical
  ts:        string,    // ISO-8601; freshness-checked
  payload:   unknown,   // request body — JSON.stringify()'d into canonical
  signature: string,    // base64url ed25519 over canonical bytes
}
Canonical bytes: `${subject}\n${nonce}\n${ts}\n${JSON.stringify(payload)}`
```

Verification flow:
1. `@nats-io/jwt decode<User>()` self-verifies JWT signature
2. Verifier adds the **trust-anchor check** (`iss === operatorAccountSigningPublicKey`)
3. Plus `exp`/`nbf` with configurable clock-skew tolerance
4. User nkey pubkey from JWT's `sub` claim verifies ed25519 signature over canonical bytes
5. `subject` binding defeats signature-rebinding attacks
6. `ts` + `maxAge` defeats in-window replay

## Tests (35 new, all pass)

`src/common/agents/__tests__/trust-resolver-operator-verify.test.ts`:
- `verifyOperatorUserJwt` (8): happy + wrong_issuer + expired (past skew + within skew) + not_yet_valid + 3 malformed paths + custom `nowMs`
- `verifyOperatorSignedRequest` (16): two happy paths + subject_mismatch + 3 malformed_envelope paths + wrong_issuer + 3 ts_out_of_range paths + malformed_signature + 4 signature_invalid tamper paths + custom maxAge
- `canonicalSignedRequestBytes` (2): determinism + sensitivity to subject change
- `TrustResolver` instance (9): backward-compat + `OperatorVerifierNotConfiguredError` + delegate happy + plumbing + flag + skew tolerance

**Test fixtures mint real JWTs** via `@nats-io/jwt encodeUser` + `@nats-io/nkeys createAccount/createUser` — the verifier exercises the exact JWT format `mintUserCreds()` produces.

## Verification

- `bunx tsc --noEmit` → exit 0
- `bun test src/common/agents/` → **109/109** (26 pre-existing + 35 new + 48 from other agent tests, all green)
- Full suite → **2417 pass / 1 pre-existing fail** (the env-dependent React shell test from MIG-2)

## Three design calls I made (flagged for review)

1. **Two methods rather than one.** Issue specified `verifyOperatorSignature(subject, signedRequest)`. I shipped both that AND `verifyUserJwt(jwt)` because cortex#75 will plausibly want JWT-only validation at connection-accept time. If narrower surface preferred, drop `verifyUserJwt` — it's a thin delegate.
2. **`expectedSubject` is optional.** Strongly recommended for production transports (defends against attacker rebinding a captured signature to a different subject by mutating `envelope.subject` to match). Defaults to skipped for unit-test ergonomics. cortex#75 should pass it.
3. **Nonce-replay state is the caller's job.** Verifier checks ts within `signedRequestMaxAgeSec` (default 300s) but does NOT maintain a seen-nonce set. If cortex#75 wants at-most-once semantics, the transport layer adds that. Rationale: verifier is pure; statefulness belongs in the consumer.

Refs cortex#74 (v1 UNIX-socket), cortex#75 (NATS transport — next).

🤖 Generated with [Claude Code](https://claude.com/claude-code)