### PR TITLE
fix(migrate-config): robust handling of production bot.yaml shapes

### DIFF
--- a/src/cli/cortex/commands/__tests__/migrate-config.test.ts
+++ b/src/cli/cortex/commands/__tests__/migrate-config.test.ts
@@ -181,6 +181,148 @@ describe("convertBotYaml — trustedAgentBots", () => {
     expect(result.cortex.agents[0]!.trust).toEqual(["echo-bot"]);
     expect(result.warnings.some((w) => w.field === "trustedAgentBots")).toBe(true);
   });
+
+  // Production grove-v2 shape carries trustedAgentBots entries with `id:`
+  // (Discord snowflake) + `role:` and no symbolic `name:`. The migrator now
+  // skips those with a warning that surfaces the platform id so the operator
+  // can hand-map post-migration. Previously this path crashed with
+  // `undefined is not an object (evaluating 'legacyName.trim')`.
+  test("skips entries missing `name` with a warning naming the Discord id", () => {
+    const legacy: LegacyBotYaml = {
+      agent: { name: "ivy", displayName: "Ivy", operatorId: "jc" },
+      discord: [{ token: "t", guildId: "1", agentChannelId: "2", logChannelId: "3" }],
+      trustedAgentBots: [
+        // production shape — id + role only, no symbolic name
+        ({ id: "1487180524542890144", role: "agent-restricted" } as unknown) as LegacyBotYaml["trustedAgentBots"] extends (infer U)[] | undefined ? U : never,
+      ],
+    };
+    const result = convertBotYaml(legacy);
+    expect(result.cortex.agents[0]!.trust).toEqual([]);
+    const warn = result.warnings.find((w) => w.field === "trustedAgentBots");
+    expect(warn).toBeDefined();
+    expect(warn!.message).toMatch(/missing symbolic `name`/);
+    expect(warn!.message).toMatch(/1487180524542890144/);
+    expect(warn!.message).toMatch(/role="agent-restricted"/);
+  });
+
+  test("falls back to `discordId` field in the warning when `id` is absent", () => {
+    const legacy: LegacyBotYaml = {
+      agent: { name: "ivy", displayName: "Ivy", operatorId: "jc" },
+      discord: [{ token: "t", guildId: "1", agentChannelId: "2", logChannelId: "3" }],
+      trustedAgentBots: [
+        ({ discordId: "9999", role: "agent-restricted" } as unknown) as LegacyBotYaml["trustedAgentBots"] extends (infer U)[] | undefined ? U : never,
+      ],
+    };
+    const result = convertBotYaml(legacy);
+    expect(result.cortex.agents[0]!.trust).toEqual([]);
+    expect(result.warnings.find((w) => w.field === "trustedAgentBots")!.message).toMatch(/9999/);
+  });
+
+  test("mixed list — keeps named entries, skips id-only ones, ordering preserved", () => {
+    const legacy: LegacyBotYaml = {
+      agent: { name: "ivy", displayName: "Ivy", operatorId: "jc" },
+      discord: [{ token: "t", guildId: "1", agentChannelId: "2", logChannelId: "3" }],
+      trustedAgentBots: [
+        { name: "luna" },
+        ({ id: "abc", role: "agent-restricted" } as unknown) as LegacyBotYaml["trustedAgentBots"] extends (infer U)[] | undefined ? U : never,
+        { name: "holly" },
+        ({ id: "def" } as unknown) as LegacyBotYaml["trustedAgentBots"] extends (infer U)[] | undefined ? U : never,
+      ],
+    };
+    const result = convertBotYaml(legacy);
+    expect(result.cortex.agents[0]!.trust).toEqual(["luna", "holly"]);
+    const trustWarnings = result.warnings.filter((w) => w.field === "trustedAgentBots");
+    expect(trustWarnings).toHaveLength(2);
+    expect(trustWarnings[0]!.message).toMatch(/trustedAgentBots\[1\]/);
+    expect(trustWarnings[1]!.message).toMatch(/trustedAgentBots\[3\]/);
+  });
+
+  test("empty `name` string still triggers skip-with-warning, not silent acceptance", () => {
+    const legacy: LegacyBotYaml = {
+      agent: { name: "ivy", displayName: "Ivy", operatorId: "jc" },
+      discord: [{ token: "t", guildId: "1", agentChannelId: "2", logChannelId: "3" }],
+      trustedAgentBots: [{ id: "xyz", name: "   " }],
+    };
+    const result = convertBotYaml(legacy);
+    expect(result.cortex.agents[0]!.trust).toEqual([]);
+    expect(result.warnings.find((w) => w.field === "trustedAgentBots")!.message)
+      .toMatch(/missing symbolic `name`/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Conversion: nats.identity shape divergence
+// ---------------------------------------------------------------------------
+
+describe("convertBotYaml — nats.identity shape divergence", () => {
+  // Real production grove-v2 bot.yaml ships nats.identity in `{did, keyPath}`
+  // shape; cortex schema requires `{seedPath, publicKey}`. The migrator
+  // strips the block + warns rather than crashing inside CortexConfigSchema.parse.
+  test("strips legacy {did, keyPath} identity with a warning carrying the derive hint", () => {
+    const legacy: LegacyBotYaml = {
+      agent: { name: "ivy", displayName: "Ivy", operatorId: "jc" },
+      discord: [{ token: "t", guildId: "1", agentChannelId: "2", logChannelId: "3" }],
+      nats: {
+        url: "nats://127.0.0.1:4222",
+        identity: { did: "did:mf:jc-ivy", keyPath: "~/.config/metafactory/keys/jc-ivy.key" },
+      },
+    };
+    const result = convertBotYaml(legacy);
+    // identity stripped from cortex output
+    expect(((result.cortex.nats as Record<string, unknown> | undefined)?.identity)).toBeUndefined();
+    // rest of nats survives
+    expect((result.cortex.nats as Record<string, unknown> | undefined)?.url).toBe("nats://127.0.0.1:4222");
+    const warn = result.warnings.find((w) => w.field === "nats.identity");
+    expect(warn).toBeDefined();
+    expect(warn!.message).toMatch(/keys: did, keyPath/);
+    expect(warn!.message).toMatch(/did=did:mf:jc-ivy/);
+    expect(warn!.message).toMatch(/nkeys -inkey/);
+    expect(warn!.message).toMatch(/jc-ivy\.key/);
+  });
+
+  test("passes through cortex-shaped {seedPath, publicKey} identity unchanged (no warning)", () => {
+    const legacy: LegacyBotYaml = {
+      agent: { name: "ivy", displayName: "Ivy", operatorId: "jc" },
+      discord: [{ token: "t", guildId: "1", agentChannelId: "2", logChannelId: "3" }],
+      nats: {
+        url: "nats://127.0.0.1:4222",
+        identity: {
+          seedPath: "/path/to/seed.nk",
+          publicKey: "UAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+        },
+      },
+    };
+    const result = convertBotYaml(legacy);
+    const identity = (result.cortex.nats as Record<string, unknown> | undefined)?.identity as Record<string, unknown> | undefined;
+    expect(identity?.seedPath).toBe("/path/to/seed.nk");
+    expect(identity?.publicKey).toBe("UAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
+    expect(result.warnings.find((w) => w.field === "nats.identity")).toBeUndefined();
+  });
+
+  test("missing identity block — nats survives, no warning", () => {
+    const legacy: LegacyBotYaml = {
+      agent: { name: "ivy", displayName: "Ivy", operatorId: "jc" },
+      discord: [{ token: "t", guildId: "1", agentChannelId: "2", logChannelId: "3" }],
+      nats: { url: "nats://127.0.0.1:4222" },
+    };
+    const result = convertBotYaml(legacy);
+    expect((result.cortex.nats as Record<string, unknown> | undefined)?.url).toBe("nats://127.0.0.1:4222");
+    expect(result.warnings.find((w) => w.field === "nats.identity")).toBeUndefined();
+  });
+
+  test("warning omits the derive hint when keyPath is also missing", () => {
+    const legacy: LegacyBotYaml = {
+      agent: { name: "ivy", displayName: "Ivy", operatorId: "jc" },
+      discord: [{ token: "t", guildId: "1", agentChannelId: "2", logChannelId: "3" }],
+      // identity exists but is structurally garbage — no recoverable seed path
+      nats: { url: "nats://127.0.0.1:4222", identity: { weirdField: 42 } },
+    };
+    const result = convertBotYaml(legacy);
+    const warn = result.warnings.find((w) => w.field === "nats.identity");
+    expect(warn).toBeDefined();
+    expect(warn!.message).toMatch(/once you have an NKey seed/);
+    expect(warn!.message).not.toMatch(/nkeys -inkey/);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/cli/cortex/commands/migrate-config-lib.ts
+++ b/src/cli/cortex/commands/migrate-config-lib.ts
@@ -81,10 +81,26 @@ export interface LegacyMattermostInstance {
 export interface LegacyTrustedAgentBot {
   /** Discord user id of the peer bot. Used only for human reference today. */
   discordId?: string;
+  /** Alias for `discordId` — production grove-v2 configs frequently use this
+   *  bare field name (no symbolic agent name alongside it). The migrator
+   *  treats `id` and `discordId` as interchangeable. */
+  id?: string;
   /** Mattermost user id of the peer bot. Used only for human reference today. */
   mattermostId?: string;
-  /** Agent id of the peer bot — this is what migrates into `trust:`. */
-  name: string;
+  /** Discord role binding (`agent-restricted`, etc.). Surfaced in warnings
+   *  on entries that get skipped so the operator can hand-map them. */
+  role?: string;
+  /**
+   * Agent id of the peer bot — this is what migrates into `trust:`.
+   *
+   * Historically required, but production grove-v2 deployments often ship
+   * entries with only a Discord id and no symbolic name (see
+   * clawbox:~/.config/grove/bot.yaml). The migrator now tolerates a missing
+   * `name`: entries without a derivable agent id are skipped with a warning
+   * that surfaces the raw platform id so the operator can hand-edit the
+   * generated cortex.yaml `agents[].trust` list post-migration.
+   */
+  name?: string;
 }
 
 export interface LegacyBotYaml {
@@ -328,9 +344,28 @@ function buildTrustList(
   legacyTrust: LegacyTrustedAgentBot[],
   warnings: ConversionWarning[],
 ): string[] {
-  return legacyTrust.map((t) => {
+  const out: string[] = [];
+  for (let i = 0; i < legacyTrust.length; i++) {
+    const t = legacyTrust[i]!;
+    // Production grove-v2 carries trustedAgentBots entries with only a
+    // Discord/Mattermost id and no symbolic agent name. Surface those as
+    // warnings (operator hand-maps post-migration) rather than crashing.
+    if (typeof t.name !== "string" || t.name.trim().length === 0) {
+      const rawPlatformId = t.id ?? t.discordId ?? t.mattermostId ?? "(no id)";
+      const roleHint = t.role ? ` role="${t.role}"` : "";
+      warnings.push({
+        field: "trustedAgentBots",
+        message:
+          `trustedAgentBots[${i}] missing symbolic \`name\` (platform id: ${rawPlatformId}${roleHint}) — ` +
+          `skipping. Hand-map this entry in cortex.yaml under the relevant agent's \`trust:\` list ` +
+          `once you know which agent id corresponds to ${rawPlatformId}.`,
+      });
+      continue;
+    }
     const id = deriveAgentId(t.name);
     if (!AGENT_ID_PATTERN.test(id)) {
+      // Non-empty `name` that doesn't derive to a valid agent id is still
+      // an operator error worth surfacing loudly.
       throw new Error(
         `trustedAgentBots[].name "${t.name}" cannot be derived to a valid agent id (^[a-z0-9-]+$)`,
       );
@@ -341,8 +376,9 @@ function buildTrustList(
         message: `trusted bot name "${t.name}" normalized to "${id}"`,
       });
     }
-    return id;
-  });
+    out.push(id);
+  }
+  return out;
 }
 
 /**
@@ -518,10 +554,56 @@ export function convertBotYaml(
   if (legacy.paths !== undefined) cortex.paths = legacy.paths;
   if (legacy.networksDir !== undefined) cortex.networksDir = legacy.networksDir;
   if (legacy.networks !== undefined) cortex.networks = legacy.networks;
-  if (legacy.nats !== undefined) cortex.nats = legacy.nats;
+  if (legacy.nats !== undefined) cortex.nats = convertNats(legacy.nats, warnings);
 
   const parsed = CortexConfigSchema.parse(cortex);
   return { cortex: parsed, warnings, mappings };
+}
+
+/**
+ * Translate `legacy.nats` onto the cortex `NatsConfigSchema` shape.
+ *
+ * Real production grove-v2 bot.yaml carries `nats.identity` in a legacy
+ * `{ did, keyPath }` shape — DID + raw NKey seed path. Cortex's
+ * `NatsIdentitySchema` requires `{ seedPath, publicKey }` (NKey seed path
+ * plus a 56-char `U…` user pubkey) for envelope signing.
+ *
+ * The shapes can't be auto-translated — cortex needs the U-prefixed public
+ * key derived from the seed, which we don't have at migration time.
+ * Stripping the block with a warning is the right move: identity is
+ * optional in cortex, the operator can run `nkeys -inkey ~/.nkey/foo.nk
+ * -pubout` once post-migration and hand-add `seedPath` + `publicKey` to
+ * the new cortex.yaml.
+ *
+ * Any other unknown fields under `nats` pass through; only the
+ * shape-mismatched identity block is stripped.
+ */
+function convertNats(legacyNats: unknown, warnings: ConversionWarning[]): unknown {
+  if (!legacyNats || typeof legacyNats !== "object") return legacyNats;
+  const nats = { ...(legacyNats as Record<string, unknown>) };
+  const identity = nats.identity;
+  if (identity && typeof identity === "object") {
+    const id = identity as Record<string, unknown>;
+    const hasCortexShape = typeof id.seedPath === "string" && typeof id.publicKey === "string";
+    if (!hasCortexShape) {
+      // Legacy `{did, keyPath}` or any other partial shape — strip + warn.
+      const legacyKeys = Object.keys(id).join(", ");
+      const keyPath = typeof id.keyPath === "string" ? id.keyPath : undefined;
+      const did = typeof id.did === "string" ? id.did : undefined;
+      const hint = keyPath
+        ? ` Derive the U-prefixed pubkey via \`nkeys -inkey ${keyPath} -pubout\` and add` +
+          ` \`nats.identity.seedPath: ${keyPath}\` + \`nats.identity.publicKey: U…\` to cortex.yaml.`
+        : " Add `nats.identity.seedPath` + `nats.identity.publicKey` to cortex.yaml once you have an NKey seed.";
+      warnings.push({
+        field: "nats.identity",
+        message:
+          `legacy nats.identity shape (keys: ${legacyKeys}${did ? `; did=${did}` : ""}) does not match` +
+          ` cortex schema {seedPath, publicKey} — stripping block.${hint}`,
+      });
+      delete nats.identity;
+    }
+  }
+  return nats;
 }
 
 /**


### PR DESCRIPTION
## Summary

MIG-7.9 dry-run against real grove-v2 bot.yaml on clawbox surfaced two schema-divergence crashes the existing migrator didn't handle. Both fixed defensively — cortex-shaped inputs pass through unchanged.

## Two crashes fixed

### 1. `trustedAgentBots[]` with Discord id but no symbolic name

**Production shape** (e.g. clawbox `~/.config/grove/bot.yaml`):
```yaml
trustedAgentBots:
  - id: \"1487180524542890144\"      # Discord snowflake, NO \`name:\` field
    role: \"agent-restricted\"
```

**Previously:** `Error: conversion failed: undefined is not an object (evaluating 'legacyName.trim')` — crash inside `buildTrustList` → `deriveAgentId(undefined)`.

**Fix:**
- Tolerate missing `name`: skip with warning, surface the raw platform id + role in the warning so the operator can hand-map the entry into the relevant agent's `trust:` list post-migration.
- Accept `id` as an alias for `discordId` (the production shape).

**Warning shape:**
```
trustedAgentBots[0] missing symbolic \`name\` (platform id: 1487180524542890144 role=\"agent-restricted\") —
  skipping. Hand-map this entry in cortex.yaml under the relevant agent's \`trust:\` list once you
  know which agent id corresponds to 1487180524542890144.
```

### 2. `nats.identity` in legacy `{did, keyPath}` shape

**Production shape:**
```yaml
nats:
  url: \"nats://127.0.0.1:4222\"
  identity:
    did: did:mf:jc-ivy
    keyPath: ~/.config/metafactory/keys/jc-ivy.key
```

**Cortex schema** requires `{seedPath, publicKey}` where `publicKey` is a 56-char U-prefix NKey user identifier.

**Previously:** crashed in `CortexConfigSchema.parse` with two zod `invalid_type` errors at `nats.identity.seedPath` and `nats.identity.publicKey`.

**Fix:** strip the legacy block with a warning that surfaces a concrete derivation hint:
```
legacy nats.identity shape (keys: did, keyPath; did=did:mf:jc-ivy) does not match cortex schema
  {seedPath, publicKey} — stripping block. Derive the U-prefixed pubkey via
  \`nkeys -inkey ~/.config/metafactory/keys/jc-ivy.key -pubout\` and add
  \`nats.identity.seedPath: ~/.config/metafactory/keys/jc-ivy.key\` +
  \`nats.identity.publicKey: U…\` to cortex.yaml.
```

The shapes can't be auto-translated — cortex needs the U-prefixed pubkey derived from the seed, which we don't have at migration time. Identity is optional in cortex; stripping with a hint is the right delegation.

## End-to-end validation

Dry-ran against clawbox's real bot.yaml (390 lines, 4 discord instances, 6 trustedAgentBots entries with only Discord ids, legacy `{did, keyPath}` nats identity). Output:

```
operator: jc (dataResidency=NZ)
agents:   4
  - ivy (discord) persona=./personas/ivy.md trust=[]
  - ivy-2 (discord) persona=./personas/ivy.md trust=[]
  - ivy-3 (discord) persona=./personas/ivy.md trust=[]
  - ivy-4 (discord) persona=./personas/ivy.md trust=[]
renderers: 1
  - dashboard

instance mappings:
  discord[0] discord-ivy     →  agents[ivy].presence.discord
  discord[1] discord-holly   →  agents[ivy-2].presence.discord
  discord[2] discord-juniper →  agents[ivy-3].presence.discord
  discord[3] discord-pilot   →  agents[ivy-4].presence.discord

warnings (10): 6 trustedAgentBots skipped + 1 persona-not-found +
               1 multi-instance + 1 api→dashboard + 1 nats.identity stripped
```

All 10 warnings are expected — the operator-side post-migration steps (hand-map 6 trust entries to agent ids, add `nats.identity` with derived pubkey, optionally rename `ivy-2..ivy-4` to `holly/juniper/pilot`) are surfaced clearly enough that the migration is now actionable.

## Tests

- 59/59 green in `migrate-config.test.ts` (was 55).
- 4 new tests for trustedAgentBots robustness (skip-with-warning, role-hint, mixed list, empty `name` string).
- 4 new tests for nats.identity (legacy strip + cortex pass-through + no-identity no-warn + garbage-shape hint omission).

## Test plan

- [x] `bunx tsc --noEmit` clean
- [x] `bun test src/cli/cortex/commands/__tests__/migrate-config.test.ts` — 59/59 green
- [x] End-to-end dry-run against clawbox bot.yaml: completes with valid cortex.yaml output + 10 expected warnings
- [ ] Live full-suite re-run post-merge (no expected regressions; touch surface is migrate-config-lib only)

## Out of scope

- **No auto-translation of legacy `{did, keyPath}` → `{seedPath, publicKey}`.** We don't have the public key at migration time (it's derived from the seed file we'd have to read + run through nkeys). The hint in the warning gives the operator the exact one-line command to derive it.
- **No agent-instance-name reattribution.** The migrator emits `ivy, ivy-2, ivy-3, ivy-4` per the existing variant-id convention. The operator will hand-rename to `ivy, holly, juniper, pilot` post-migration (each was a separate instance in grove-v2's flat `discord[]` array; cortex's schema reasonably treats them as numbered variants of the declared agent.name).

Unblocks MIG-7.9 (run migrate-config against real bot.yaml → emit cortex.yaml). Critical-path item for the Grove→Cortex switch.