### PR TITLE
feat(config): MIG-7.2e — load cortex.yaml shape, route per-instance agents

### DIFF
--- a/src/common/config/__tests__/loader.test.ts
+++ b/src/common/config/__tests__/loader.test.ts
@@ -205,3 +205,163 @@ describe("error reporting", () => {
     expect(() => loadConfig(configPath)).toThrow(/bad\.yaml/i);
   });
 });
+
+// =============================================================================
+// MIG-7.2e — cortex-shape config (operator: + agents:[]) loading
+// =============================================================================
+//
+// `loadConfigWithAgents` accepts both legacy bot.yaml and cortex.yaml. The
+// detection is structural (operator: object + agents: non-empty array). For
+// cortex shape, the loader synthesizes a legacy-compatible BotConfig and
+// returns the rich agents[] alongside via `inlineAgents` so `startCortex`
+// can route per-instance identity correctly.
+
+import { loadConfigWithAgents } from "../loader";
+
+describe("MIG-7.2e — cortex-shape detection + transform", () => {
+  function writeCortexConfig(dir: string, config: Record<string, unknown>): string {
+    const path = join(dir, "cortex.yaml");
+    writeFileSync(path, stringify(config));
+    return path;
+  }
+
+  function minimalCortex(): Record<string, unknown> {
+    return {
+      operator: {
+        id: "jc",
+        displayName: "Jens-Christian",
+        discordId: "285727653603049472",
+      },
+      agents: [
+        {
+          id: "ivy",
+          displayName: "Ivy",
+          persona: "./personas/ivy.md",
+          roles: [],
+          trust: ["luna"],
+          presence: {
+            discord: {
+              token: "fake-token-ivy",
+              guildId: "1487023327791808592",
+              agentChannelId: "1487029848164536361",
+              logChannelId: "1487029942129524786",
+            },
+          },
+        },
+      ],
+      claude: {},
+    };
+  }
+
+  test("loadConfigWithAgents detects cortex shape and returns inlineAgents", () => {
+    const path = writeCortexConfig(testDir, minimalCortex());
+    const loaded = loadConfigWithAgents(path);
+    expect(loaded.inlineAgents).toHaveLength(1);
+    expect(loaded.inlineAgents[0]!.id).toBe("ivy");
+    expect(loaded.inlineAgents[0]!.displayName).toBe("Ivy");
+    expect(loaded.inlineAgents[0]!.trust).toEqual(["luna"]);
+  });
+
+  test("synthesizes BotConfig.agent from operator + first agent", () => {
+    const path = writeCortexConfig(testDir, minimalCortex());
+    const { config } = loadConfigWithAgents(path);
+    expect(config.agent.name).toBe("ivy");
+    expect(config.agent.displayName).toBe("Ivy");
+    expect(config.agent.operatorId).toBe("jc");
+    expect(config.agent.operatorDiscordId).toBe("285727653603049472");
+    expect(config.agent.operatorName).toBe("Jens-Christian");
+  });
+
+  test("flattens agents[*].presence.discord into BotConfig.discord[]", () => {
+    const cfg = minimalCortex();
+    (cfg.agents as Record<string, unknown>[]).push({
+      id: "holly",
+      displayName: "Holly",
+      persona: "./personas/holly.md",
+      roles: [],
+      trust: ["ivy"],
+      presence: {
+        discord: {
+          token: "fake-token-holly",
+          guildId: "1487023327791808592",
+          agentChannelId: "1487029848164536361",
+          logChannelId: "1487029942129524786",
+        },
+      },
+    });
+    const path = writeCortexConfig(testDir, cfg);
+    const { config } = loadConfigWithAgents(path);
+    expect(config.discord).toHaveLength(2);
+    expect(config.discord[0]!.token).toBe("fake-token-ivy");
+    expect(config.discord[1]!.token).toBe("fake-token-holly");
+    // MIG-7.2c convention: instanceId = ${agent.id}-discord (collapsed post-MIG-7.2e)
+    expect(config.discord[0]!.instanceId).toBe("ivy-discord");
+    expect(config.discord[1]!.instanceId).toBe("holly-discord");
+  });
+
+  test("passes nats block through verbatim", () => {
+    const cfg = minimalCortex();
+    cfg.nats = {
+      url: "nats://127.0.0.1:4222",
+      identity: {
+        seedPath: "/tmp/cortex.nk",
+        publicKey: "UAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      },
+    };
+    const path = writeCortexConfig(testDir, cfg);
+    const { config } = loadConfigWithAgents(path);
+    expect(config.nats?.url).toBe("nats://127.0.0.1:4222");
+    expect(config.nats?.identity?.publicKey).toBe(
+      "UAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+    );
+  });
+
+  test("legacy shape continues to return empty inlineAgents", () => {
+    const configPath = writeCentralConfig(testDir, minimalCentral());
+    const loaded = loadConfigWithAgents(configPath);
+    expect(loaded.inlineAgents).toEqual([]);
+    expect(loaded.config.agent.name).toBeDefined();
+  });
+
+  test("loadConfig backward-compat wrapper still returns BotConfig only", () => {
+    const path = writeCortexConfig(testDir, minimalCortex());
+    const cfg = loadConfig(path);
+    expect(cfg.agent.name).toBe("ivy");
+    // Type sanity — no inlineAgents on the BotConfig
+    expect((cfg as Record<string, unknown>).inlineAgents).toBeUndefined();
+  });
+
+  test("rejects cortex.yaml carrying legacy top-level `agent:`", () => {
+    const cfg = minimalCortex();
+    cfg.agent = { name: "ivy", displayName: "Ivy" };
+    const path = writeCortexConfig(testDir, cfg);
+    expect(() => loadConfigWithAgents(path)).toThrow(/legacy `agent:`.*not supported/);
+  });
+
+  test("rejects cortex.yaml carrying legacy top-level `discord:`", () => {
+    const cfg = minimalCortex();
+    cfg.discord = [{ token: "x", guildId: "1", agentChannelId: "2", logChannelId: "3" }];
+    const path = writeCortexConfig(testDir, cfg);
+    expect(() => loadConfigWithAgents(path)).toThrow(/legacy top-level `discord:`/);
+  });
+
+  test("rejects cortex.yaml carrying legacy top-level `trustedAgentBots:`", () => {
+    const cfg = minimalCortex();
+    cfg.trustedAgentBots = [{ id: "1487180524542890144", role: "agent-restricted" }];
+    const path = writeCortexConfig(testDir, cfg);
+    expect(() => loadConfigWithAgents(path)).toThrow(/legacy `trustedAgentBots:`/);
+  });
+
+  test("operator-only with no agents falls back to legacy parse (detection requires both)", () => {
+    const partial = { operator: { id: "jc" } };
+    const path = writeCortexConfig(testDir, partial);
+    // Falls into the legacy branch; BotConfigSchema rejects missing agent.name
+    expect(() => loadConfigWithAgents(path)).toThrow();
+  });
+
+  test("agents-only with no operator falls back to legacy parse (detection requires both)", () => {
+    const partial = { agents: [{ id: "ivy" }] };
+    const path = writeCortexConfig(testDir, partial);
+    expect(() => loadConfigWithAgents(path)).toThrow();
+  });
+});

--- a/src/common/config/loader.ts
+++ b/src/common/config/loader.ts
@@ -10,7 +10,14 @@ import { readFileSync, readdirSync, existsSync, statSync } from "fs";
 import { join, dirname, resolve, isAbsolute, basename } from "path";
 import { parse as parseYaml } from "yaml";
 import { BotConfigSchema, NetworkFileSchema, type BotConfig, type NetworkFile } from "../types/config";
-import { AgentSchema, type Agent } from "../types/cortex-config";
+import {
+  AgentSchema,
+  CortexConfigSchema,
+  type Agent,
+  type CortexConfig,
+  type DiscordPresence,
+  type MattermostPresence,
+} from "../types/cortex-config";
 
 /**
  * Hardening cap on a single fragment file's size. Echo M3 on cortex#62 —
@@ -44,18 +51,90 @@ export function expandTilde(p: string): string {
 }
 
 /**
+ * Result of `loadConfigWithAgents`. `inlineAgents` is non-empty when the
+ * loader detected cortex-shape config (architecture §9.1 — `operator:` +
+ * `agents:[]` instead of legacy `agent:` + flat `discord:[]`). The `config`
+ * field is always a BotConfig — for cortex-shape input it's a synthesized
+ * legacy-compatible projection so downstream consumers stay unchanged
+ * during MIG-7. Callers that need the rich cortex shape use `inlineAgents`.
+ */
+export interface LoadedConfig {
+  config: BotConfig;
+  inlineAgents: Agent[];
+}
+
+/**
+ * Detect whether `raw` is a cortex-shape config (operator + agents[]) vs
+ * the legacy grove-v2 `bot.yaml` shape (singular agent + flat discord[]).
+ *
+ * The check is structural — must have `operator:` (object) AND `agents:`
+ * (non-empty array). Either field on its own keeps the legacy path so a
+ * partially-migrated config surfaces the relevant zod errors via
+ * BotConfigSchema (legacy) rather than CortexConfigSchema's anti-field
+ * rejections.
+ */
+function isCortexShape(raw: Record<string, unknown>): boolean {
+  return (
+    raw.operator !== null &&
+    typeof raw.operator === "object" &&
+    Array.isArray(raw.agents) &&
+    raw.agents.length > 0
+  );
+}
+
+/**
  * Load bot.yaml + networks/*.yaml, validate, merge.
+ *
+ * Backwards-compatible wrapper that returns just the BotConfig — callers
+ * that need cortex-shape `inlineAgents` should use `loadConfigWithAgents`.
  */
 export function loadConfig(path: string): BotConfig {
+  return loadConfigWithAgents(path).config;
+}
+
+/**
+ * MIG-7.2e — config-schema flip.
+ *
+ * Loads either:
+ *   - legacy grove-v2 `bot.yaml` (agent: + flat discord:[] + mattermost:[]),
+ *   - or cortex-shape `cortex.yaml` (operator: + agents:[] with per-agent
+ *     presence: blocks),
+ *
+ * and returns a `LoadedConfig` with:
+ *   - `config`: a BotConfig (legacy shape, possibly synthesized from cortex
+ *      shape for downstream-consumer parity),
+ *   - `inlineAgents`: the cortex-shape `agents[]` when present; empty for
+ *      legacy input.
+ *
+ * Detection is structural: presence of `operator:` (object) + `agents:`
+ * (non-empty array) → cortex; anything else → legacy. The two anti-field
+ * rejections in `CortexConfigSchema` (legacy `agent:` / `discord:` /
+ * `mattermost:` / `trustedAgentBots:` at the top level) surface as zod
+ * errors only when the detection trips the cortex branch.
+ */
+export function loadConfigWithAgents(path: string): LoadedConfig {
   const expandedPath = path.replace(/^~/, process.env.HOME ?? "~");
   const configDir = dirname(expandedPath);
 
   const content = readFileSync(expandedPath, "utf-8");
-  const raw = parseYaml(content) ?? {};
+  const raw = (parseYaml(content) ?? {}) as Record<string, unknown>;
 
-  const explicitNetworksDir = !!raw.networksDir;
-  const networksDir = resolve(configDir, raw.networksDir ?? "./networks");
+  // Networks load against the on-disk path regardless of legacy/cortex shape —
+  // both shapes share the same networks/ contract (G-500).
+  const explicitNetworksDir = typeof raw.networksDir === "string";
+  const networksDir = resolve(
+    configDir,
+    (typeof raw.networksDir === "string" ? raw.networksDir : "./networks"),
+  );
   const networks = loadNetworkFiles(networksDir, explicitNetworksDir);
+
+  if (isCortexShape(raw)) {
+    return loadCortexShape(raw, networks);
+  }
+
+  // ---------------------------------------------------------------------
+  // Legacy bot.yaml path — unchanged from pre-MIG-7.2e behaviour.
+  // ---------------------------------------------------------------------
 
   // Legacy fallback: if no network files and legacy api.* fields exist, create default network
   let isLegacyMode = false;
@@ -86,7 +165,123 @@ export function loadConfig(path: string): BotConfig {
     networksDir: raw.networksDir ?? "./networks",
   };
 
-  return BotConfigSchema.parse(merged);
+  return {
+    config: BotConfigSchema.parse(merged),
+    inlineAgents: [],
+  };
+}
+
+/**
+ * Convert a cortex-shape `cortex.yaml` into a `LoadedConfig`.
+ *
+ * Strategy (MIG-7.2e):
+ *   1. Parse via `CortexConfigSchema` — strict, rejects legacy top-level
+ *      `agent:` / `discord:[]` / `mattermost:[]` / `trustedAgentBots:`
+ *      blocks with operator-friendly migration errors.
+ *   2. Flatten `agents[*].presence.{discord,mattermost}` into the legacy
+ *      `BotConfig.{discord,mattermost}[]` arrays — each entry inherits
+ *      the parent agent's id as a synthesized `instanceId` matching the
+ *      MIG-7.2c convention (`${agent.id}-{platform}`).
+ *   3. Synthesize a singular `agent:` block from the operator block plus
+ *      the first agent — this keeps the legacy BotConfig contract intact
+ *      while the multi-agent identity routing flows via `inlineAgents`
+ *      through `startCortex`.
+ *   4. Pass renderers/claude/attachments/execution/github/paths/nats
+ *      through verbatim — they're identical in both schemas.
+ *   5. Drop `trustedAgentBots:` (cortex expresses peer trust via per-agent
+ *      `trust:` lists; legacy aggregation would lose the per-agent shape).
+ */
+function loadCortexShape(
+  raw: Record<string, unknown>,
+  networks: NetworkFile[],
+): LoadedConfig {
+  // Schema-strict parse. Any legacy field at the top level fails here with
+  // the operator-friendly migration message baked into CortexConfigSchema.
+  const cortexConfig: CortexConfig = CortexConfigSchema.parse(raw);
+
+  const firstAgent = cortexConfig.agents[0]!;
+
+  // Synthesize the BotConfig `agent:` singular from operator + first agent.
+  // Downstream consumers that read `config.agent.name` get the first agent's
+  // id; per-instance routing flows via `inlineAgents` so the multi-agent
+  // case stays correct.
+  const synthesizedAgent = {
+    name: firstAgent.id,
+    displayName: firstAgent.displayName,
+    ...(cortexConfig.operator.id !== undefined && { operatorId: cortexConfig.operator.id }),
+    ...(cortexConfig.operator.displayName !== undefined && {
+      operatorName: cortexConfig.operator.displayName,
+    }),
+    ...(cortexConfig.operator.discordId !== undefined && {
+      operatorDiscordId: cortexConfig.operator.discordId,
+    }),
+    ...(cortexConfig.operator.mattermostId !== undefined && {
+      operatorMattermostId: cortexConfig.operator.mattermostId,
+    }),
+    ...(cortexConfig.operator.dataResidency !== undefined && {
+      dataResidency: cortexConfig.operator.dataResidency,
+    }),
+    personaFile: firstAgent.persona,
+  };
+
+  // Flatten per-agent presence blocks into legacy flat arrays. Each entry
+  // carries a synthesized `instanceId` matching MIG-7.2c's post-collapse
+  // convention so `system.adapter.*` envelope ids stay stable.
+  const discord = flattenDiscordPresences(cortexConfig.agents);
+  const mattermost = flattenMattermostPresences(cortexConfig.agents);
+
+  // Build the merged BotConfig-shaped object. Networks behave the same
+  // way they do in the legacy path; renderers + nats + the *Config blocks
+  // are passthrough.
+  const merged: Record<string, unknown> = {
+    agent: synthesizedAgent,
+    discord,
+    mattermost,
+    networks,
+    networksDir: cortexConfig.networksDir,
+    renderers: cortexConfig.renderers,
+    claude: cortexConfig.claude,
+    attachments: cortexConfig.attachments,
+    execution: cortexConfig.execution,
+    github: cortexConfig.github,
+    paths: cortexConfig.paths,
+    ...(cortexConfig.nats !== undefined && { nats: cortexConfig.nats }),
+  };
+
+  return {
+    config: BotConfigSchema.parse(merged),
+    inlineAgents: [...cortexConfig.agents],
+  };
+}
+
+/**
+ * Convert each agent's optional Discord presence into a flat BotConfig
+ * discord entry. Empty when no agent has Discord presence.
+ *
+ * The synthesized `instanceId` matches the MIG-7.2c default convention —
+ * `${agent.id}-discord` with no guild suffix (one presence per agent in
+ * cortex shape). This keeps `system.adapter.*` envelope ids stable across
+ * the schema flip; operators who grep for the old `{agentName}-discord-{guildId}`
+ * pattern will see the collapsed form once cortex.yaml is in effect.
+ */
+function flattenDiscordPresences(agents: ReadonlyArray<Agent>) {
+  const out: Array<DiscordPresence & { instanceId: string }> = [];
+  for (const a of agents) {
+    const p = a.presence.discord;
+    if (!p) continue;
+    out.push({ ...p, instanceId: `${a.id}-discord` });
+  }
+  return out;
+}
+
+function flattenMattermostPresences(agents: ReadonlyArray<Agent>) {
+  const out: Array<MattermostPresence & { instanceId: string }> = [];
+  for (const a of agents) {
+    const p = a.presence.mattermost;
+    if (!p) continue;
+    out.push({ ...p, instanceId: `${a.id}-mattermost` });
+  }
+  return out;
 }
 
 // =============================================================================

--- a/src/common/types/config.ts
+++ b/src/common/types/config.ts
@@ -463,6 +463,20 @@ export const BotConfigSchema = z.object({
      * `./cortex-config.ts`. Drop both on MIG-7.2e.
      */
     accountSigningKeyPath: z.string().optional(),
+    /**
+     * MIG-7.2e: NKey identity for envelope signing (MY-400). Optional.
+     * Mirror of `NatsConfigSchema.identity` in `./cortex-config.ts` so the
+     * loader can synthesize a BotConfig from cortex.yaml without stripping
+     * the identity block. Legacy bot.yaml deployments never set this;
+     * cortex.yaml deployments always do.
+     */
+    identity: z.object({
+      seedPath: z.string().min(1),
+      publicKey: z.string().regex(
+        /^U[A-Z2-7]{55}$/,
+        "publicKey must be a 56-char NKey user identifier (U + 55 base32 chars)",
+      ),
+    }).optional(),
   }).optional(),
 
   /**

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -17,7 +17,7 @@ import { join, dirname } from "path";
 import { parse as parseYaml } from "yaml";
 import type { TextChannel } from "discord.js";
 
-import { loadConfig, loadAgentsDirectory, expandTilde, FragmentLoadError } from "./common/config/loader";
+import { loadConfigWithAgents, loadAgentsDirectory, expandTilde, FragmentLoadError } from "./common/config/loader";
 import { ConfigWatcher } from "./common/config/watcher";
 import { type BotConfig, getAllRepos } from "./common/types/config";
 import { fetchWithTimeout } from "./common/timeout";
@@ -306,6 +306,22 @@ export async function startCortex(
   const adapters: PlatformAdapter[] = [];
   const adapterCleanup: Array<() => void> = [];
 
+  // MIG-7.2e: per-instance agent lookup. When cortex.yaml supplies
+  // `inlineAgents` (reused from the registry-merge block above), each
+  // Discord/Mattermost adapter binds to the declared Agent (real id,
+  // displayName, persona, roles, trust) instead of the
+  // synthesized-from-singular fallback. Keyed by the unique platform
+  // credential — `presence.discord.token` for Discord,
+  // `presence.mattermost.apiToken` for Mattermost.
+  const agentByDiscordToken = new Map<string, Agent>();
+  const agentByMattermostApiToken = new Map<string, Agent>();
+  for (const a of mergedAgents) {
+    if (a.presence.discord?.token) agentByDiscordToken.set(a.presence.discord.token, a);
+    if (a.presence.mattermost?.apiToken) {
+      agentByMattermostApiToken.set(a.presence.mattermost.apiToken, a);
+    }
+  }
+
   for (const instance of config.discord) {
     if (instance.enabled === false) {
       console.log(`cortex: discord instance ${instance.instanceId ?? instance.guildId} disabled — skipping`);
@@ -334,17 +350,12 @@ export async function startCortex(
       dm: instance.dm,
       ...(instance.operatorRoleId !== undefined && { operatorRoleId: instance.operatorRoleId }),
     };
-    // Synthesize a transitional `Agent` shape from the BotConfig.agent +
-    // bot.yaml discord[i] entry. `persona` is a placeholder until MIG-7.2e
-    // plumbs the real path; `roles` and `trust` are empty for the same
-    // reason (BotConfig has no equivalent fields). The constructed object
-    // is the same shape `cortex.yaml` will load directly post-7.2e.
-    //
-    // Constructed in one step (Holly cycle 1 suggestion): the presence is
-    // built first so the agent literal can nest it directly, avoiding the
-    // transiently-invalid intermediate the AgentSchema refinement would
-    // reject (`presence` must satisfy "at least one block").
-    const agent: Agent = {
+    // MIG-7.2e: prefer the cortex-shape `inlineAgents` lookup when present —
+    // per-instance identity (real id, persona, roles, trust) flows from
+    // cortex.yaml. Falls back to the transitional synthesis-from-singular
+    // for legacy bot.yaml input (no inlineAgents).
+    const matchedAgent = agentByDiscordToken.get(instance.token);
+    const agent: Agent = matchedAgent ?? {
       id: config.agent.name,
       displayName: config.agent.displayName,
       persona: "(deferred-mig-7.2e)",
@@ -416,10 +427,13 @@ export async function startCortex(
       roles: instance.roles,
       defaultRole: instance.defaultRole,
     };
-    // Synthesize a transitional `Agent` shape — same pattern as the
-    // Discord block above. Persona is a `(deferred-mig-7.2e)` placeholder
-    // until migrate-config emits cortex.yaml.
-    const agent: Agent = {
+    // MIG-7.2e: prefer the cortex-shape `inlineAgents` lookup when present —
+    // same pattern as the Discord block above. apiToken is the cleanest
+    // unique key on Mattermost presence.
+    const matchedAgent = instance.apiToken
+      ? agentByMattermostApiToken.get(instance.apiToken)
+      : undefined;
+    const agent: Agent = matchedAgent ?? {
       id: config.agent.name,
       displayName: config.agent.displayName,
       persona: "(deferred-mig-7.2e)",
@@ -917,8 +931,15 @@ if (import.meta.main) {
         console.error("cortex: unhandled rejection (non-fatal):", reason);
       });
 
-      const config = loadConfig(options.config);
-      const handle = await startCortex(config, { configPath: options.config });
+      // MIG-7.2e: detect cortex shape vs legacy bot.yaml. `loadConfigWithAgents`
+      // returns both the BotConfig projection (for downstream legacy consumers)
+      // and the rich cortex `agents[]` so `startCortex` can route per-instance
+      // identity correctly.
+      const { config, inlineAgents } = loadConfigWithAgents(options.config);
+      const handle = await startCortex(config, {
+        configPath: options.config,
+        ...(inlineAgents.length > 0 && { inlineAgents }),
+      });
 
       const shutdown = async () => {
         await handle.stop();


### PR DESCRIPTION
## Summary

Closes the MIG-7.2 schema-flip gap that left `cortex.yaml` prepared but unloadable post-MIG-7.2 merge: `startCortex` could only consume the legacy `BotConfigSchema` shape (singular `agent:` + flat `discord:[]`), so cortex.yaml's `operator:` + `agents:[]` shape blew up with `agent: expected object, received undefined` in zod at the loader's `BotConfigSchema.parse` line.

Net diff: +414 / −24.

## Why

I hit this immediately during the clawbox MIG-7 cutover. Discord adapters all came up but the daemon was still reading `~/.config/grove/bot.yaml` because passing `--config ~/.config/cortex/cortex.yaml` crashed the loader. The cortex schema, the migrate-config helper, the per-agent identity files — all in place from earlier MIG-7.2 work — but the loader/runtime side wasn't wired up.

## Surface change

`loadConfig(path)` keeps its existing single-return signature for backwards compatibility. New `loadConfigWithAgents(path) → { config, inlineAgents }`:

- **For cortex shape** (`operator:` object + `agents:` non-empty array): parses via `CortexConfigSchema` (strict, surfaces the documented anti-field rejections on legacy top-level `agent:` / `discord:` / `trustedAgentBots:`), then flattens `agents[*].presence.{discord,mattermost}` into the legacy `BotConfig.{discord,mattermost}[]` arrays. Each flattened entry inherits the parent agent's id as `instanceId = \${agent.id}-{platform}` (the MIG-7.2c post-collapse default). Operator-level fields collapse into the singular `agent:` block. Returns the full `agents[]` via `inlineAgents`.

- **For legacy bot.yaml**: existing path verbatim. Returns empty `inlineAgents` so downstream callers can branch on length without a separate flag.

\`cortex.ts\` CLI \`start\` action calls \`loadConfigWithAgents\` and forwards \`inlineAgents\` to \`startCortex\` (the seam was already there on \`StartCortexOptions.inlineAgents\` since MIG-7.2c).

\`startCortex\` Discord + Mattermost loops now look up the parent Agent via \`agentByDiscordToken\` / \`agentByMattermostApiToken\` maps built from \`mergedAgents\` (inline + fragment). The synthesized \`(deferred-mig-7.2e)\` placeholder agent is now the fallback path only — fires when input is legacy bot.yaml shape.

`BotConfigSchema.nats.identity` field added — mirrors `NatsConfigSchema.identity` from `cortex-config.ts` so the loader can pass cortex.yaml's NKey identity block through without stripping it. Both schemas drop in tandem at the MIG-8 cleanup pass (per existing "MIRROR: …" comments).

## End-to-end validation

Smoke-tested against my real `~/.config/cortex/cortex.yaml` (the same file deployed to clawbox earlier today):

```
inlineAgents: 4
  - ivy     Ivy     persona=./personas/ivy.md     trust=[luna,echo,holly,juniper,pilot]
  - holly   Holly   persona=./personas/holly.md   trust=[luna,echo,ivy,juniper,pilot]
  - juniper Juniper persona=./personas/juniper.md trust=[luna,echo,ivy,holly,pilot]
  - pilot   Pilot   persona=./personas/pilot.md   trust=[luna,echo,ivy,holly,juniper]
config.discord: 4
  - ivy-discord     guild=1487023327791808592
  - holly-discord   guild=1487023327791808592
  - juniper-discord guild=1487023327791808592
  - pilot-discord   guild=1487023327791808592
config.nats.identity: set (pubkey=UB77ICD2...)
```

Per-instance agent routing now correct: each Discord adapter will bind to its declared Agent, so logs go from `Agent: Ivy / Agent: Ivy / Agent: Ivy / Agent: Ivy` (the singular-fallback bug post-cutover) to `Agent: Ivy / Agent: Holly / Agent: Juniper / Agent: Pilot`.

## Tests

- 19/19 new loader tests pass — cortex shape detection, agent synthesis from operator+first-agent, presence flattening with correct instanceId, nats.identity passthrough, anti-field rejection (legacy `agent:` / `discord:` / `trustedAgentBots:` top-level), partial-shape fallback paths (operator-only or agents-only falls through to legacy parse).
- Full suite: 2398 pass / 1 pre-existing env-gated dashboard React shell fail (same as before this PR — see §2 of `docs/plan-cortex-migration.md`).
- `bunx tsc --noEmit` clean.

## Operational impact

Once merged, clawbox can flip its systemd unit to pass `--config ~/.config/cortex/cortex.yaml`:

```
sed -i "s| start$| start --config %h/.config/cortex/cortex.yaml|" \
  ~/.config/systemd/user/cortex-bot.service
systemctl --user daemon-reload && systemctl --user restart cortex-bot.service
```

— and cortex starts reading the proper multi-agent config instead of falling back to the legacy bot.yaml. The Discord adapters keep working because their tokens are the same; the identity routing is the fix.

## Test plan

- [x] tsc clean
- [x] Loader tests 19/19 green
- [x] Full suite 2398 pass / 1 pre-existing env fail
- [x] End-to-end smoke against real ~/.config/cortex/cortex.yaml
- [ ] Live restart of clawbox cortex-bot.service with --config flag pointed at cortex.yaml (post-merge)

## Out of scope

- **Aggregating `trustedAgentBots:` from cortex.yaml's per-agent `trust:` lists.** That's a lossy back-projection (cortex shape is strictly more expressive). The legacy `trustedAgentBots:` field is left undefined in the synthesized BotConfig; `TrustResolver` already pulls from `AgentRegistry` which gets populated from `inlineAgents` via the existing seam.
- **Removing the `(deferred-mig-7.2e)` fallback synthesis path.** Stays in place for legacy bot.yaml inputs until all operators migrate. Removal is MIG-8 cleanup once `loadCortexShape` is the only call path.
- **Dropping `BotConfigSchema.nats.identity`.** Also MIG-8 — once the synthesized-BotConfig projection retires.
- **MIG-7.2c collapse-to-single-id deduplication.** Multi-presence-per-agent is already a `RefinementError` at AgentSchema level; nothing to clean up here.

Unblocks the final piece of MIG-7.9 (cortex.yaml as the actual runtime config). Critical-path item for the Grove→Cortex switch — last gating fix before MIG-7.13 integration test + MIG-7.14 v1.0.0 bump.