### PR TITLE
fix(discord): permit trusted peer bots through messageCreate filter

### DIFF
--- a/src/adapters/discord/__tests__/trusted-bots.test.ts
+++ b/src/adapters/discord/__tests__/trusted-bots.test.ts
@@ -1,0 +1,146 @@
+/**
+ * cortex#84 — bot-to-bot trust allowlist.
+ *
+ * Holly silently dropped Ivy's @-mentions because `isMentionForBot`
+ * rejected every bot-authored message via a blanket
+ * `message.author.bot` check. This suite pins the new behaviour:
+ *
+ *   - Default (no allowlist): all bot authors still dropped.
+ *   - Allowlist entry present: that bot's mentions pass through.
+ *   - Self-id never allowed, even if accidentally listed
+ *     (anti-self-loop guard, the original reason the bot filter exists).
+ *
+ * The function is pure — no discord.js client init needed. We hand-roll
+ * the minimal `Message` / `Client` shapes the function actually reads.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { Client, Message } from "discord.js";
+import { isMentionForBot } from "../client";
+import { DiscordInstanceSchema } from "../../../common/types/config";
+
+const SELF_ID = "1111";
+const PEER_BOT_ID = "1497898452351455393"; // Holly's id from cortex#84 timeline
+const UNTRUSTED_BOT_ID = "9999";
+const HUMAN_ID = "285727653603049472";
+
+function makeClient(): Client {
+  // isMentionForBot reads `client.user.id` and `message.mentions.has(client.user)`.
+  // The minimal stub is a user object with a stable identity reference so
+  // mentions.has can identity-check.
+  const user = { id: SELF_ID } as Client["user"];
+  return { user } as Client;
+}
+
+function makeMessage(opts: {
+  authorId: string;
+  bot: boolean;
+  mentionsSelf: boolean;
+  client: Client;
+}): Message {
+  // `mentions.has` is called with the client.user object; return true iff
+  // the test marked this message as mentioning self.
+  return {
+    author: { id: opts.authorId, bot: opts.bot },
+    mentions: {
+      has: (user: { id: string }) => opts.mentionsSelf && user.id === opts.client.user!.id,
+    },
+  } as unknown as Message;
+}
+
+describe("isMentionForBot — default (no allowlist)", () => {
+  const client = makeClient();
+
+  test("human @-mention passes", () => {
+    const msg = makeMessage({ authorId: HUMAN_ID, bot: false, mentionsSelf: true, client });
+    expect(isMentionForBot(msg, client)).toBe(true);
+  });
+
+  test("human without @-mention is rejected", () => {
+    const msg = makeMessage({ authorId: HUMAN_ID, bot: false, mentionsSelf: false, client });
+    expect(isMentionForBot(msg, client)).toBe(false);
+  });
+
+  test("bot @-mention dropped when no allowlist supplied (pre-cortex#84 behaviour preserved)", () => {
+    const msg = makeMessage({ authorId: PEER_BOT_ID, bot: true, mentionsSelf: true, client });
+    expect(isMentionForBot(msg, client)).toBe(false);
+  });
+
+  test("own message never mentions self (self-loop guard)", () => {
+    const msg = makeMessage({ authorId: SELF_ID, bot: true, mentionsSelf: true, client });
+    expect(isMentionForBot(msg, client)).toBe(false);
+  });
+});
+
+describe("isMentionForBot — trustedBotIds allowlist (cortex#84)", () => {
+  const client = makeClient();
+  const trusted = new Set<string>([PEER_BOT_ID]);
+
+  test("trusted peer bot @-mention passes", () => {
+    const msg = makeMessage({ authorId: PEER_BOT_ID, bot: true, mentionsSelf: true, client });
+    expect(isMentionForBot(msg, client, trusted)).toBe(true);
+  });
+
+  test("untrusted bot @-mention still dropped", () => {
+    const msg = makeMessage({ authorId: UNTRUSTED_BOT_ID, bot: true, mentionsSelf: true, client });
+    expect(isMentionForBot(msg, client, trusted)).toBe(false);
+  });
+
+  test("self id NEVER allowed even when explicitly listed (anti-self-loop regression)", () => {
+    const selfListed = new Set<string>([SELF_ID, PEER_BOT_ID]);
+    const msg = makeMessage({ authorId: SELF_ID, bot: true, mentionsSelf: true, client });
+    expect(isMentionForBot(msg, client, selfListed)).toBe(false);
+  });
+
+  test("trusted peer bot without @-mention is still rejected (mention-required path)", () => {
+    const msg = makeMessage({ authorId: PEER_BOT_ID, bot: true, mentionsSelf: false, client });
+    expect(isMentionForBot(msg, client, trusted)).toBe(false);
+  });
+
+  test("human @-mention still passes when allowlist is non-empty (no regression on humans)", () => {
+    const msg = makeMessage({ authorId: HUMAN_ID, bot: false, mentionsSelf: true, client });
+    expect(isMentionForBot(msg, client, trusted)).toBe(true);
+  });
+
+  test("empty allowlist matches default behaviour (bots dropped)", () => {
+    const empty = new Set<string>();
+    const msg = makeMessage({ authorId: PEER_BOT_ID, bot: true, mentionsSelf: true, client });
+    expect(isMentionForBot(msg, client, empty)).toBe(false);
+  });
+});
+
+describe("DiscordInstanceSchema.trustedBotIds (cortex#84)", () => {
+  const minInstance = {
+    token: "x",
+    guildId: "g",
+    agentChannelId: "a",
+    logChannelId: "l",
+  };
+
+  test("defaults to empty array when omitted", () => {
+    const parsed = DiscordInstanceSchema.parse(minInstance);
+    expect(parsed.trustedBotIds).toEqual([]);
+  });
+
+  test("accepts a populated array of Discord user ids", () => {
+    const parsed = DiscordInstanceSchema.parse({
+      ...minInstance,
+      trustedBotIds: [PEER_BOT_ID, "1487024060411023491"],
+    });
+    expect(parsed.trustedBotIds).toEqual([PEER_BOT_ID, "1487024060411023491"]);
+  });
+
+  test("coerces numeric ids to strings (snowflakes-as-numbers in YAML)", () => {
+    const parsed = DiscordInstanceSchema.parse({
+      ...minInstance,
+      trustedBotIds: [1497898452351455393n.toString(), 1487024060411023491n.toString()],
+    });
+    expect(parsed.trustedBotIds.every((id) => typeof id === "string")).toBe(true);
+  });
+
+  test("rejects a non-array value", () => {
+    expect(() =>
+      DiscordInstanceSchema.parse({ ...minInstance, trustedBotIds: PEER_BOT_ID }),
+    ).toThrow();
+  });
+});

--- a/src/adapters/discord/client.ts
+++ b/src/adapters/discord/client.ts
@@ -184,14 +184,27 @@ export function createDiscordClient(
 
 /**
  * Check if a message is an @-mention for our bot.
- * Ignores all bot messages AND explicitly ignores our own messages
- * to prevent self-response loops when multiple bot processes are running.
+ *
+ * Default policy: ignore all bot-authored messages and ALWAYS ignore our
+ * own messages (self-loop guard, even across redundant bot processes).
+ *
+ * `trustedBotIds` (cortex#84) is an optional allowlist of Discord user
+ * ids of peer bots that are permitted to ping us. When a bot-authored
+ * message comes from a listed id, the mention check proceeds. The self
+ * id is NEVER allowed even if accidentally listed — the self-check runs
+ * first and short-circuits.
  */
-export function isMentionForBot(message: Message, client: Client): boolean {
+export function isMentionForBot(
+  message: Message,
+  client: Client,
+  trustedBotIds?: ReadonlySet<string>,
+): boolean {
   if (!client.user) return false;
-  // Explicit self-check — never respond to our own messages
+  // Explicit self-check — never respond to our own messages, regardless
+  // of any allowlist. Defends against accidentally listing the bot's own
+  // user id in `trustedBotIds`.
   if (message.author.id === client.user.id) return false;
-  if (message.author.bot) return false;
+  if (message.author.bot && !trustedBotIds?.has(message.author.id)) return false;
   return message.mentions.has(client.user);
 }
 

--- a/src/adapters/discord/index.ts
+++ b/src/adapters/discord/index.ts
@@ -75,6 +75,22 @@ export interface DiscordAdapterInfra {
   /** MIG-3b: fallback Discord channel ID for envelope rendering when no per-envelope routing
    * rule applies. Channel ID, NOT name. Moves to Renderer at MIG-7.2d. */
   surfaceFallbackChannelId?: string;
+  /**
+   * cortex#84: Discord user ids of peer bots whose messages this adapter
+   * is permitted to act on. Empty/undefined → strict default (drop every
+   * bot-authored message, the pre-cortex#84 behaviour).
+   *
+   * The adapter's own bot id is NEVER allowed regardless of this set —
+   * the self-check in the messageCreate handler short-circuits before
+   * the allowlist is consulted.
+   *
+   * Bridge field; at MIG-7.2e the in-process TrustResolver populates the
+   * effective allowlist from `agents[].trust`. Cross-process trust still
+   * needs this field because the resolver only sees adapters running in
+   * its own process. See `DiscordInstance.trustedBotIds` in
+   * `common/types/config.ts`.
+   */
+  trustedBotIds?: ReadonlySet<string>;
 }
 
 interface PendingResult {
@@ -103,6 +119,14 @@ export class DiscordAdapter implements PlatformAdapter {
   private runtime: MyelinRuntime | undefined;
   private systemEventSource: SystemEventSource | undefined;
   /**
+   * cortex#84: snapshot of `infra.trustedBotIds` taken at construction
+   * time. `ReadonlySet` so a misbehaving caller can't mutate the
+   * allowlist after the adapter has cached the reference. Empty set when
+   * no allowlist was supplied — the default "drop every bot author"
+   * branch becomes an O(1) `set.has` lookup that returns false.
+   */
+  private readonly trustedBotIds: ReadonlySet<string>;
+  /**
    * Latches once we've warned about the runtime-without-source case so a
    * busy adapter doesn't flood the log with the same diagnostic on every
    * shard event. Cleared only when the adapter is reconstructed.
@@ -120,6 +144,10 @@ export class DiscordAdapter implements PlatformAdapter {
     this.instanceId = infra.instanceId;
     this.runtime = infra.runtime;
     this.systemEventSource = infra.systemEventSource;
+    // cortex#84: snapshot the allowlist at construction. Pre-build the
+    // empty-set sentinel so the messageCreate hot path can call
+    // `set.has` unconditionally without a null check.
+    this.trustedBotIds = infra.trustedBotIds ?? new Set<string>();
 
     // MIG-3b: warn once at construction if surfaceSubjects is explicitly empty.
     // `undefined` is silent (adapter opted out of bus rendering entirely);
@@ -201,12 +229,20 @@ export class DiscordAdapter implements PlatformAdapter {
       const isDM = message.channel.type === ChannelType.DM;
 
       if (isDM) {
-        // Never respond to our own messages or other bots
+        // Self-loop guard — never respond to our own DMs, regardless of
+        // any trustedBotIds entry (the bot's own id is never allowed).
         if (message.author.id === this.client.user?.id) return;
-        if (message.author.bot) return;
+        // cortex#84: drop bot-authored DMs unless the author is an
+        // operator-blessed peer in `trustedBotIds`. The role-resolver
+        // (resolveDMAccess) then makes the final allow/deny call on
+        // the message, so listing a bot here is necessary-but-not-
+        // sufficient to elicit a response.
+        if (message.author.bot && !this.trustedBotIds.has(message.author.id)) return;
       } else {
-        // Guild: require @mention
-        if (!isMentionForBot(message, this.client)) return;
+        // Guild: require @mention (which itself honours trustedBotIds
+        // via the same allowlist — peer bots that @-mention us are
+        // allowed through; un-listed bot authors are dropped).
+        if (!isMentionForBot(message, this.client, this.trustedBotIds)) return;
       }
 
       const content = isDM ? message.content.trim() : extractContent(message, this.client);

--- a/src/common/types/config.ts
+++ b/src/common/types/config.ts
@@ -122,6 +122,28 @@ export const DiscordInstanceSchema = z.object({
    * See `docs/design-mc-f11-discord-notifications.md` Decision 5.
    */
   operatorRoleId: z.coerce.string().optional(),
+
+  /**
+   * cortex#84: Discord user IDs of peer bots that are permitted to
+   * trigger this bot. Bot-authored messages are dropped by default to
+   * prevent self-loops and unsolicited bot chatter; entries listed here
+   * are allowed through the author-bot filter and then handled by the
+   * normal role-based access path (so the operator still has to grant
+   * each peer bot a role in `roles[]` or `dm.userRoles[]` to actually
+   * respond).
+   *
+   * Each entry is a Discord snowflake. The bot's own user id is NEVER
+   * allowed regardless of this list (anti-self-loop guard kept).
+   *
+   * Bridge field — at MIG-7.2e cortex.ts will switch to reading
+   * `agents[].trust` from cortex.yaml and the in-process TrustResolver
+   * (see `src/common/agents/trust-resolver.ts`) will populate the
+   * effective allowlist automatically for peer bots co-hosted in the
+   * same cortex process. This field stays as the cross-process bridge
+   * (e.g. Ivy in PAI's local cortex trusting Holly in a server cortex),
+   * since the resolver only sees adapters started in its own process.
+   */
+  trustedBotIds: z.array(z.coerce.string()).default([]),
 });
 
 export type DiscordInstance = z.infer<typeof DiscordInstanceSchema>;

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -353,6 +353,12 @@ export async function startCortex(
       presence: { discord: presence },
     };
     try {
+      // cortex#84: build the trusted-peer-bot allowlist once per adapter
+      // start so the messageCreate hot path doesn't re-allocate per event.
+      // Empty list → adapter falls back to "drop every bot author"
+      // (pre-cortex#84 behaviour). MIG-7.2e will derive this from
+      // `agents[].trust` + in-process TrustResolver where possible.
+      const trustedBotIds = new Set<string>(instance.trustedBotIds);
       const adapter = new DiscordAdapter(
         agent,
         presence,
@@ -363,6 +369,7 @@ export async function startCortex(
           },
           runtime,
           systemEventSource,
+          trustedBotIds,
         },
       );
       // Register the adapter's surface-router face. Empty `surfaceSubjects`
@@ -370,7 +377,7 @@ export async function startCortex(
       router.register(adapter.surfaceConfig);
       await adapter.start((msg) => dispatchHandler.handleMessage(adapter, msg));
       adapters.push(adapter);
-      console.log(`cortex: discord adapter started (instance: ${instanceId}, guild: ${instance.guildId})`);
+      console.log(`cortex: discord adapter started (instance: ${instanceId}, guild: ${instance.guildId}, trustedBotIds: ${trustedBotIds.size})`);
 
       // Outbound JSONL → #agent-log + worklog (opt-in). Dashboard + cloud
       // delivery handled by the HTTP path (H-004).


### PR DESCRIPTION
## Summary

- Closes cortex#84 — Holly silently dropped Ivy's @-mentions because the Discord adapter rejected every bot author at `messageCreate` ingress (DM handler + `isMentionForBot`), so legitimate bot-to-bot pings never reached the role-resolver or the CC pipeline.
- Introduces a `trustedBotIds` allowlist on `DiscordInstanceSchema` plus matching `DiscordAdapterInfra.trustedBotIds`. Bot-authored messages are now dropped only when the author isn't listed. The bot's own id is still rejected unconditionally — the self-loop guard stays intact.
- Bridge field. At MIG-7.2e cortex.ts will load `agents[]` from cortex.yaml and the in-process `TrustResolver` will populate the allowlist from `agents[].trust` automatically. `trustedBotIds` remains the cross-process bridge (e.g. Ivy in PAI's local cortex trusting Holly in a server cortex), since the resolver only sees adapters started in its own process.

## Root cause

`src/adapters/discord/index.ts:206` (DM) and `src/adapters/discord/client.ts:194` (`isMentionForBot`) both unconditionally returned on `message.author.bot === true`. The filter predates the MIG-7.2b `TrustResolver` / `PresenceBinding` work — trust infra exists but was never wired into the ingress filter.

## What changed

| File | Change |
|------|--------|
| `src/common/types/config.ts` | `DiscordInstanceSchema.trustedBotIds: z.array(z.coerce.string()).default([])` — new bridge field with docstring |
| `src/adapters/discord/client.ts` | `isMentionForBot` accepts optional `trustedBotIds: ReadonlySet<string>`; bot-author drop is now gated by allowlist; self-check still short-circuits first |
| `src/adapters/discord/index.ts` | `DiscordAdapterInfra.trustedBotIds?: ReadonlySet<string>` + constructor snapshot; DM filter and guild filter both consult the set |
| `src/cortex.ts` | Build the `Set<string>` from `instance.trustedBotIds` once per adapter start, pass into infra; log line surfaces the size |
| `src/adapters/discord/__tests__/trusted-bots.test.ts` | 14 new tests (default-drop, allowlist-pass, untrusted-drop, anti-self-loop, mention-required path, schema default/populated/coerce/reject-non-array) |

## Operator note (not in scope for this PR)

Listing a peer bot in `trustedBotIds` is **necessary but not sufficient** — the role-resolver still has to grant access:

- **Guild channels**: add the peer bot's Discord id to a `roles[].users` entry on the receiving agent (e.g. an `agent-restricted` role).
- **DMs**: add the peer bot's id to a `dm.userRoles[].users` entry on the receiving agent. Without this the message passes the filter but `resolveDMAccess` returns the default `denied`.

## Out of Scope

- Mattermost adapter (cortex#84 timeline is Discord-only; same pattern applies if needed).
- Auto-derivation of `trustedBotIds` from `agents[].trust` — that lands at MIG-7.2e when cortex.ts switches to the cortex.yaml loader.
- Pre-existing dashboard-shell test failure (`src/surface/mc/__tests__/server.test.ts` expects `src/dist/dashboard-v2/index.html`). Reproduces on `main` without my changes — separate path-resolver bug (the resolver climbs two levels from `src/surface/mc/server.ts` but the build target is `dist/` at repo root).

## Test plan

- [x] `bun test src/adapters/discord/__tests__/trusted-bots.test.ts` — 14/14 pass
- [x] `bun test src/adapters/discord/ src/common/types/` — 184/184 pass (no regressions in adjacent suites)
- [x] `bunx tsc --noEmit` — exit 0
- [x] Full suite: 2401 pass / 1 pre-existing fail (dashboard-shell, see Out of Scope)
- [ ] Operator validation: enable `trustedBotIds: ["<ivy-discord-id>"]` on Holly's discord instance, post a guild ping from Ivy, confirm Holly responds within seconds

🤖 Generated with [Claude Code](https://claude.com/claude-code)