### PR TITLE
feat(nats): NatsLink credsAuthenticator support (closes cortex#86)

### DIFF
--- a/src/bus/myelin/runtime.ts
+++ b/src/bus/myelin/runtime.ts
@@ -145,6 +145,10 @@ export async function startMyelinRuntime(
     link = await NatsLink.connect({
       url: nats.url,
       token: nats.token,
+      // cortex#86: operator-mode auth path. NatsLink loader expands ~/
+      // and enforces chmod 600; if both token and credsPath are set,
+      // credsPath wins with a warn log.
+      ...(nats.credsPath ? { credsPath: nats.credsPath } : {}),
       name: nats.name,
       ...(options?.connectImpl ? { connectImpl: options.connectImpl } : {}),
     });

--- a/src/bus/nats/__tests__/connection.test.ts
+++ b/src/bus/nats/__tests__/connection.test.ts
@@ -6,9 +6,32 @@
  */
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
-import type { NatsConnection } from "nats";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "fs";
+import { homedir, tmpdir } from "os";
+import { join } from "path";
+import type { ConnectionOptions, NatsConnection } from "nats";
 import { Events } from "nats";
 import { NatsLink } from "../connection";
+
+// Synthetic .creds file content modelled on `nsc generate creds` output.
+// Real value isn't validated by the loader (NATS does that at connect-time);
+// the loader only enforces existence + chmod 600 before handing bytes to
+// `credsAuthenticator`. Test seam never actually authenticates, so the
+// content can be any non-empty UTF-8.
+const FAKE_CREDS_CONTENT = `-----BEGIN NATS USER JWT-----
+eyJ0eXAiOiJKV1QiLCJhbGciOiJlZDI1NTE5LW5rZXkifQ.eyJqdGkiOiJURVNUIn0.fake
+------END NATS USER JWT------
+
+************************* IMPORTANT *************************
+NKEY Seed printed below can be used to sign and prove identity.
+NKEYs are sensitive and should be treated as secrets.
+
+-----BEGIN USER NKEY SEED-----
+SUFAKEFAKEFAKEFAKEFAKEFAKEFAKEFAKEFAKEFAKEFAKEFAKEFAKEFAKEFAK
+------END USER NKEY SEED------
+
+*************************************************************
+`;
 
 function makeFakeConnection() {
   const statusEvents: { type: string; data: unknown }[] = [];
@@ -244,5 +267,123 @@ describe("NatsLink", () => {
     expect(fake.publishes[0]?.subject).toBe("local.metafactory.test");
     expect(fake.publishes[0]?.payload).toBe(bytes);
     await link.close();
+  });
+
+  // ─────────────────────────────────────────────────────────────────────
+  // cortex#86: credsPath / credsAuthenticator wiring for operator-mode NATS.
+  //
+  // These tests exercise the loader + connectImpl handoff using a synthetic
+  // .creds file on disk. They DO NOT validate the JWT/seed content (NATS
+  // does that at the server) — they verify that:
+  //   - `credsPath` set → connectImpl receives `authenticator` (not token)
+  //   - chmod gate refuses anything looser than 600
+  //   - operator-readable error on missing file
+  //   - `token` + `credsPath` together: credsPath wins, warn logged
+  //   - leading `~/` expands to $HOME (production cortex.yaml uses this)
+  // ─────────────────────────────────────────────────────────────────────
+  describe("creds-auth (cortex#86)", () => {
+    let tmpDir: string;
+    let credsFile: string;
+
+    beforeEach(() => {
+      tmpDir = mkdtempSync(join(tmpdir(), "natslink-creds-"));
+      credsFile = join(tmpDir, "test.creds");
+      writeFileSync(credsFile, FAKE_CREDS_CONTENT, "utf8");
+      chmodSync(credsFile, 0o600);
+    });
+
+    afterEach(() => {
+      rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    test("credsPath set → connectImpl receives authenticator, not token", async () => {
+      const fake = makeFakeConnection();
+      const capturedOpts: ConnectionOptions[] = [];
+      const connectImpl = mock(async (opts: ConnectionOptions) => {
+        capturedOpts.push(opts);
+        return fake.nc;
+      });
+      const link = await NatsLink.connect({
+        url: "nats://localhost:4222",
+        credsPath: credsFile,
+        connectImpl: connectImpl as never,
+      });
+      const opts = capturedOpts[0]!;
+      expect(typeof opts.authenticator).toBe("function");
+      expect(opts.token).toBeUndefined();
+      await link.close();
+    });
+
+    test("credsPath rejects chmod 644 with operator-readable error", async () => {
+      // POSIX-only: NTFS chmod is meaningless and the loader skips the gate.
+      if (process.platform === "win32") return;
+      chmodSync(credsFile, 0o644);
+      await expect(
+        NatsLink.connect({
+          url: "nats://localhost:4222",
+          credsPath: credsFile,
+          connectImpl: async () => makeFakeConnection().nc,
+        }),
+      ).rejects.toThrow(/chmod 600.*644/);
+    });
+
+    test("credsPath ENOENT bubbles up a clear error including the path", async () => {
+      const missing = join(tmpDir, "does-not-exist.creds");
+      await expect(
+        NatsLink.connect({
+          url: "nats://localhost:4222",
+          credsPath: missing,
+          connectImpl: async () => makeFakeConnection().nc,
+        }),
+      ).rejects.toThrow(/does-not-exist\.creds|ENOENT/);
+    });
+
+    test("credsPath + token → credsPath wins, warn logged about precedence", async () => {
+      const fake = makeFakeConnection();
+      const capturedOpts: ConnectionOptions[] = [];
+      const connectImpl = mock(async (opts: ConnectionOptions) => {
+        capturedOpts.push(opts);
+        return fake.nc;
+      });
+      const link = await NatsLink.connect({
+        url: "nats://localhost:4222",
+        name: "creds-vs-token",
+        token: "ignored-token-value",
+        credsPath: credsFile,
+        connectImpl: connectImpl as never,
+      });
+      expect(consoleSpy.warn).toHaveBeenCalled();
+      const warnMsg = String(consoleSpy.warn.mock.calls[0]?.[0] ?? "");
+      expect(warnMsg).toMatch(/credsPath|precedence|token/i);
+      const opts = capturedOpts[0]!;
+      expect(typeof opts.authenticator).toBe("function");
+      expect(opts.token).toBeUndefined();
+      await link.close();
+    });
+
+    test("leading ~ in credsPath expands to homedir", async () => {
+      // Place a creds file directly under $HOME so the ~-relative path
+      // resolves to a real existing file. Cleanup at teardown.
+      const homeCredsFile = join(homedir(), `.natslink-creds-test-${process.pid}.creds`);
+      writeFileSync(homeCredsFile, FAKE_CREDS_CONTENT, "utf8");
+      chmodSync(homeCredsFile, 0o600);
+      try {
+        const tildePath = `~/${homeCredsFile.slice(homedir().length + 1)}`;
+        const fake = makeFakeConnection();
+        const capturedOpts: ConnectionOptions[] = [];
+        const link = await NatsLink.connect({
+          url: "nats://localhost:4222",
+          credsPath: tildePath,
+          connectImpl: async (opts) => {
+            capturedOpts.push(opts);
+            return fake.nc;
+          },
+        });
+        expect(typeof capturedOpts[0]?.authenticator).toBe("function");
+        await link.close();
+      } finally {
+        rmSync(homeCredsFile, { force: true });
+      }
+    });
   });
 });

--- a/src/bus/nats/connection.ts
+++ b/src/bus/nats/connection.ts
@@ -13,8 +13,12 @@
  * (G-1100.E wires that up).
  */
 
+import { readFile } from "fs/promises";
+import { statSync } from "fs";
+import { homedir } from "os";
 import {
   connect as natsConnect,
+  credsAuthenticator,
   Events,
   type ConnectionOptions,
   type NatsConnection,
@@ -25,10 +29,63 @@ export interface NatsLinkOptions {
   url: string;
   /** Bearer token for the connect-time auth. Optional. */
   token?: string;
+  /**
+   * Path to a NATS user `.creds` file for operator-mode auth (cortex#86).
+   * The loader expands a leading `~/` to `$HOME`, enforces chmod 600 on
+   * POSIX (file MUST NOT be group- or world-readable — `.creds` carries
+   * an NKey seed + signed JWT), reads the bytes, and passes them to
+   * `credsAuthenticator(...)` as `ConnectionOptions.authenticator`.
+   * When both `token` and `credsPath` are set, `credsPath` wins and a
+   * warn log explains the precedence so operators notice a duplicated
+   * config rather than silently picking one.
+   */
+  credsPath?: string;
   /** Connection name surfaced on the server's `varz` endpoint. */
   name?: string;
   /** Override the underlying nats `connect` function (test seam). */
   connectImpl?: (opts: ConnectionOptions) => Promise<NatsConnection>;
+}
+
+/** Expand a leading `~/` (or bare `~`) to the operator's home directory. */
+function expandTilde(path: string): string {
+  if (path === "~") return homedir();
+  if (path.startsWith("~/")) return `${homedir()}${path.slice(1)}`;
+  return path;
+}
+
+/**
+ * Read a NATS user `.creds` file from disk and return its bytes for
+ * `credsAuthenticator(...)`. Mirrors the chmod gate in
+ * `src/common/config/account-signing-key.ts` — `.creds` files carry the
+ * user's NKey seed and a signed JWT, both of which are sensitive enough
+ * to refuse loading from a group- or world-readable file.
+ *
+ * Throws with an operator-readable message when:
+ *   - The file is missing or unreadable (ENOENT / EACCES propagate).
+ *   - On POSIX, the file mode is not exactly `0o600`.
+ *
+ * On Windows the chmod gate is skipped (NTFS uses ACLs, not mode bits)
+ * and a stderr note records the skip so the operator knows.
+ */
+async function loadCredsBytes(rawPath: string): Promise<Uint8Array> {
+  const path = expandTilde(rawPath);
+  if (process.platform !== "win32") {
+    const stat = statSync(path); // throws ENOENT here if the file is missing
+    const mode = stat.mode & 0o777;
+    if (mode !== 0o600) {
+      throw new Error(
+        `nats-connection: creds file ${path} must be chmod 600, found ${mode
+          .toString(8)
+          .padStart(3, "0")}`,
+      );
+    }
+  } else {
+    process.stderr.write(
+      `[nats-connection] chmod 600 gate skipped on win32 — NTFS ACLs are the operator's responsibility (${path})\n`,
+    );
+  }
+  const buf = await readFile(path);
+  return new Uint8Array(buf);
 }
 
 /**
@@ -63,13 +120,31 @@ export class NatsLink {
     const connectImpl = opts.connectImpl ?? natsConnect;
     const name = opts.name ?? "grove-bot";
 
-    const raw = await connectImpl({
+    // Build base connect options. We branch on auth mode separately so that
+    // an operator-mode `.creds` connection never leaks a bearer token into
+    // the wire — `credsAuthenticator` and `token` are mutually exclusive
+    // server-side, and the warn log calls out the precedence explicitly.
+    const connectOpts: ConnectionOptions = {
       servers: [opts.url],
-      token: opts.token,
       name,
       // Defer reconnect to the underlying client; we just log status.
       reconnect: true,
-    });
+    };
+
+    if (opts.credsPath) {
+      if (opts.token) {
+        console.warn(
+          `nats-connection: "${name}" — both 'token' and 'credsPath' set; ` +
+            `'credsPath' takes precedence (operator-mode auth wins).`,
+        );
+      }
+      const credsBytes = await loadCredsBytes(opts.credsPath);
+      connectOpts.authenticator = credsAuthenticator(credsBytes);
+    } else if (opts.token) {
+      connectOpts.token = opts.token;
+    }
+
+    const raw = await connectImpl(connectOpts);
 
     return new NatsLink(raw, name);
   }

--- a/src/bus/nats/connection.ts
+++ b/src/bus/nats/connection.ts
@@ -14,8 +14,6 @@
  */
 
 import { readFile } from "fs/promises";
-import { statSync } from "fs";
-import { homedir } from "os";
 import {
   connect as natsConnect,
   credsAuthenticator,
@@ -23,6 +21,8 @@ import {
   type ConnectionOptions,
   type NatsConnection,
 } from "nats";
+import { enforceChmod600 } from "../../common/config/file-permissions";
+import { expandTilde } from "../../common/config/loader";
 
 export interface NatsLinkOptions {
   /** NATS server URL (e.g. nats://localhost:4222). */
@@ -46,44 +46,32 @@ export interface NatsLinkOptions {
   connectImpl?: (opts: ConnectionOptions) => Promise<NatsConnection>;
 }
 
-/** Expand a leading `~/` (or bare `~`) to the operator's home directory. */
-function expandTilde(path: string): string {
-  if (path === "~") return homedir();
-  if (path.startsWith("~/")) return `${homedir()}${path.slice(1)}`;
-  return path;
-}
-
 /**
  * Read a NATS user `.creds` file from disk and return its bytes for
- * `credsAuthenticator(...)`. Mirrors the chmod gate in
- * `src/common/config/account-signing-key.ts` — `.creds` files carry the
- * user's NKey seed and a signed JWT, both of which are sensitive enough
- * to refuse loading from a group- or world-readable file.
+ * `credsAuthenticator(...)`. `.creds` files carry the user's NKey seed
+ * and a signed JWT — both sensitive enough to refuse loading from a
+ * group- or world-readable file.
+ *
+ * Uses the canonical `expandTilde` from `common/config/loader.ts` (so
+ * the no-`$HOME` failure surfaces consistently with cortex.yaml load)
+ * and the shared `enforceChmod600` permission gate from
+ * `common/config/file-permissions.ts` (same policy as the operator
+ * account signing-key loader — Echo cortex#87 round-1 extraction).
  *
  * Throws with an operator-readable message when:
- *   - The file is missing or unreadable (ENOENT / EACCES propagate).
- *   - On POSIX, the file mode is not exactly `0o600`.
- *
- * On Windows the chmod gate is skipped (NTFS uses ACLs, not mode bits)
- * and a stderr note records the skip so the operator knows.
+ *   - `expandTilde` rejects (no `$HOME` set).
+ *   - The file is missing / unreadable (ENOENT / EACCES propagate).
+ *   - The file mode is not exactly `0o600` on POSIX.
  */
 async function loadCredsBytes(rawPath: string): Promise<Uint8Array> {
   const path = expandTilde(rawPath);
-  if (process.platform !== "win32") {
-    const stat = statSync(path); // throws ENOENT here if the file is missing
-    const mode = stat.mode & 0o777;
-    if (mode !== 0o600) {
-      throw new Error(
-        `nats-connection: creds file ${path} must be chmod 600, found ${mode
-          .toString(8)
-          .padStart(3, "0")}`,
-      );
-    }
-  } else {
-    process.stderr.write(
-      `[nats-connection] chmod 600 gate skipped on win32 — NTFS ACLs are the operator's responsibility (${path})\n`,
-    );
-  }
+  // `enforceChmod600` is sync (statSync) — that's intentional in the
+  // sibling loader to keep the stat-then-read TOCTOU window minimal.
+  // The subsequent async `readFile` widens that window slightly, but
+  // the daemon owns `~/.config/nats/` entirely so the practical risk
+  // is near zero — an attacker who can swap files in the daemon's
+  // home has already won.
+  enforceChmod600(path);
   const buf = await readFile(path);
   return new Uint8Array(buf);
 }

--- a/src/common/config/__tests__/file-permissions.test.ts
+++ b/src/common/config/__tests__/file-permissions.test.ts
@@ -1,0 +1,88 @@
+/**
+ * cortex#87 — shared chmod-600 gate.
+ *
+ * Two existing consumers — `account-signing-key.ts` and
+ * `bus/nats/connection.ts` — both rely on this single helper. Each
+ * has its own integration-shaped tests that exercise the gate through
+ * its caller; this file pins the policy at the unit level so a future
+ * change to the helper (loosening / tightening / Windows behaviour)
+ * surfaces here, not in the consumer suites.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { enforceChmod600 } from "../file-permissions";
+
+describe("enforceChmod600", () => {
+  let dir: string;
+  let file: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "file-permissions-"));
+    file = join(dir, "secret");
+    writeFileSync(file, "x", "utf8");
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("accepts a file at chmod 600", () => {
+    if (process.platform === "win32") return;
+    chmodSync(file, 0o600);
+    expect(() => enforceChmod600(file)).not.toThrow();
+  });
+
+  test("rejects chmod 644 with operator-readable error containing path + actual mode", () => {
+    if (process.platform === "win32") return;
+    chmodSync(file, 0o644);
+    expect(() => enforceChmod600(file)).toThrow(
+      new RegExp(`${file.replace(/[/\\.]/g, "\\$&")}.*must be chmod 600.*644`),
+    );
+  });
+
+  test("rejects chmod 640 (group-readable)", () => {
+    if (process.platform === "win32") return;
+    chmodSync(file, 0o640);
+    expect(() => enforceChmod600(file)).toThrow(/must be chmod 600.*640/);
+  });
+
+  test("rejects chmod 666 (world-writable)", () => {
+    if (process.platform === "win32") return;
+    chmodSync(file, 0o666);
+    expect(() => enforceChmod600(file)).toThrow(/must be chmod 600.*666/);
+  });
+
+  test("rejects chmod 400 (read-only but not the policy)", () => {
+    // We require 0600 specifically — daemon needs to read AND write.
+    // 0400 usually means an operator ran `chmod a-w` by hand; that's
+    // a different operator action and should fail loudly, not slip past.
+    if (process.platform === "win32") return;
+    chmodSync(file, 0o400);
+    expect(() => enforceChmod600(file)).toThrow(/must be chmod 600.*400/);
+  });
+
+  test("rejects chmod 700 (owner-executable)", () => {
+    if (process.platform === "win32") return;
+    chmodSync(file, 0o700);
+    expect(() => enforceChmod600(file)).toThrow(/must be chmod 600.*700/);
+  });
+
+  test("propagates ENOENT for missing file", () => {
+    if (process.platform === "win32") return;
+    const missing = join(dir, "does-not-exist");
+    expect(() => enforceChmod600(missing)).toThrow(/ENOENT|no such file/i);
+  });
+
+  test("on win32 the gate is skipped (NTFS uses ACLs)", () => {
+    if (process.platform !== "win32") return;
+    // On Windows, even a "wrong" mode value doesn't throw — the gate
+    // emits a stderr note and returns. Document the behaviour so a
+    // future change to Windows handling (ACL probing, etc.) trips
+    // this assertion.
+    chmodSync(file, 0o644);
+    expect(() => enforceChmod600(file)).not.toThrow();
+  });
+});

--- a/src/common/config/account-signing-key.ts
+++ b/src/common/config/account-signing-key.ts
@@ -41,20 +41,9 @@
  * canonical `NatsConfigSchema`. Drop legacy on MIG-7.2e.
  */
 
-import { promises as fsp, statSync } from "fs";
+import { promises as fsp } from "fs";
 import { fromSeed, type KeyPair } from "nkeys.js";
-
-/**
- * Octal mode mask for the POSIX permission bits we care about. The full
- * stat `mode` field also encodes the file type (regular, dir, symlink),
- * so we mask before comparing.
- */
-const POSIX_MODE_MASK = 0o777;
-
-/**
- * Expected mode for the account signing key file: owner-only read/write.
- */
-const REQUIRED_MODE = 0o600;
+import { enforceChmod600 } from "./file-permissions";
 
 /**
  * Account signing key seed prefix. NATS nkey seeds for an *account* always
@@ -77,29 +66,10 @@ const ACCOUNT_SEED_PREFIX = "SA";
  * @returns A KeyPair ready for `sign(input)` calls.
  */
 export async function loadAccountSigningKey(path: string): Promise<KeyPair> {
-  // 1. Permission gate. Sync `statSync` keeps the check tight (one syscall
-  //    inline with the read) and avoids a TOCTOU window between stat + open
-  //    being any wider than it has to be. On Windows the mode bits are not
-  //    meaningful — gate it behind the platform check rather than fail
-  //    every Windows operator.
-  if (process.platform !== "win32") {
-    const stat = statSync(path); // throws ENOENT here if the path is bogus
-    const mode = stat.mode & POSIX_MODE_MASK;
-    if (mode !== REQUIRED_MODE) {
-      throw new Error(
-        `account signing key ${path} must be chmod 600, found ${mode.toString(8).padStart(3, "0")}`,
-      );
-    }
-  } else {
-    // Best-effort note on Windows. We still want to load the key so the
-    // daemon runs there for dev, but we want the operator to know we
-    // didn't enforce the permission gate. `process.stderr.write` because
-    // there is no logger threaded in here yet (loader is intentionally
-    // dependency-free).
-    process.stderr.write(
-      `[account-signing-key] chmod 600 gate skipped on win32 — NTFS ACLs are the operator's responsibility (${path})\n`,
-    );
-  }
+  // 1. Permission gate. Delegated to the shared `enforceChmod600` helper
+  //    (extracted in cortex#87 — same policy now backs the NATS creds
+  //    loader, so policy changes ripple to both consumers in one place).
+  enforceChmod600(path);
 
   // 2. Read + trim. Operators routinely leave a trailing newline after
   //    `nsc generate nkey -a > account.nk`; `fromSeed` would reject the

--- a/src/common/config/file-permissions.ts
+++ b/src/common/config/file-permissions.ts
@@ -1,0 +1,62 @@
+/**
+ * Shared filesystem-permission helpers.
+ *
+ * Extracted in cortex#87 (Echo round-1 finding: the chmod-600 gate was
+ * being duplicated across `account-signing-key.ts` and the new
+ * NatsLink creds path). Consolidating here means future policy changes
+ * — loosening to allow `0o400`, tightening to also reject group-owned,
+ * Windows ACL probing instead of skip — happen in one place and ripple
+ * to every consumer.
+ *
+ * Callers:
+ *   - `account-signing-key.ts` (operator account signing key, SA-prefix)
+ *   - `bus/nats/connection.ts` (NATS user `.creds`, JWT + NKey seed)
+ */
+
+import { statSync } from "fs";
+
+/** POSIX permission bits — file `mode & this` strips the file-type bits. */
+const POSIX_MODE_MASK = 0o777;
+
+/** Owner-only read/write. The only mode we accept for sensitive secrets. */
+const REQUIRED_MODE = 0o600;
+
+/**
+ * Assert that a file is `chmod 600` on POSIX (owner-only read/write).
+ *
+ * Throws an operator-readable error when the mode is anything else,
+ * including modes that are nominally tighter (e.g. `0o400`) — the
+ * daemon expects to be able to read AND write its own secrets, and a
+ * `0o400` file usually means the operator ran `chmod a-w` by hand and
+ * we'd prefer the loud failure to a silent partial enforcement.
+ *
+ * On Windows the gate is skipped with a stderr note. NTFS uses ACLs,
+ * not POSIX mode bits, so `stat.mode` there is meaningless. Operators
+ * on Windows are responsible for managing ACLs out of band.
+ *
+ * Propagates `ENOENT` / `EACCES` from `statSync` — callers can let
+ * those bubble up unchanged; the path is already in the error.
+ *
+ * @param path Absolute or process-relative path to check. Tilde-expansion
+ *   is the caller's responsibility (use `expandTilde` in `loader.ts`).
+ */
+export function enforceChmod600(path: string): void {
+  if (process.platform === "win32") {
+    // Best-effort note so the operator knows the gate didn't fire.
+    // No logger threaded in here (this module stays dependency-free).
+    process.stderr.write(
+      `[file-permissions] chmod 600 gate skipped on win32 — NTFS ACLs are the operator's responsibility (${path})\n`,
+    );
+    return;
+  }
+  // Sync `statSync` keeps the check tight (one syscall) and avoids
+  // widening the TOCTOU window beyond what the caller's subsequent read
+  // already implies.
+  const stat = statSync(path); // throws ENOENT if missing
+  const mode = stat.mode & POSIX_MODE_MASK;
+  if (mode !== REQUIRED_MODE) {
+    throw new Error(
+      `${path} must be chmod 600, found ${mode.toString(8).padStart(3, "0")}`,
+    );
+  }
+}

--- a/src/common/types/__tests__/cortex-config.test.ts
+++ b/src/common/types/__tests__/cortex-config.test.ts
@@ -339,6 +339,39 @@ describe("NatsConfigSchema", () => {
       accountSigningKeyPath: 42,
     })).toThrow();
   });
+
+  // ─── credsPath (cortex#86) ─────────────────────────────────────────────
+  // Path is just a string at the schema layer; chmod 600 + ~/ expansion +
+  // file-read live in the NatsLink loader (`../bus/nats/connection.ts`).
+  // Schema only carries shape so legacy + cortex config loaders agree.
+
+  test("credsPath is optional (absent → undefined)", () => {
+    const parsed = NatsConfigSchema.parse({ url: "nats://localhost:4222" });
+    expect(parsed.credsPath).toBeUndefined();
+  });
+
+  test("credsPath accepts an absolute path", () => {
+    const parsed = NatsConfigSchema.parse({
+      url: "nats://localhost:4222",
+      credsPath: "/etc/cortex/cortex.creds",
+    });
+    expect(parsed.credsPath).toBe("/etc/cortex/cortex.creds");
+  });
+
+  test("credsPath accepts a ~/ path (expansion happens in loader, not schema)", () => {
+    const parsed = NatsConfigSchema.parse({
+      url: "nats://localhost:4222",
+      credsPath: "~/.config/nats/cortex.creds",
+    });
+    expect(parsed.credsPath).toBe("~/.config/nats/cortex.creds");
+  });
+
+  test("credsPath rejects non-string", () => {
+    expect(() => NatsConfigSchema.parse({
+      url: "nats://localhost:4222",
+      credsPath: 42,
+    })).toThrow();
+  });
 });
 
 // =============================================================================
@@ -375,6 +408,19 @@ describe("BotConfigSchema.nats.accountSigningKeyPath (MIRROR)", () => {
       minBotConfig({ accountSigningKeyPath: "/etc/cortex/account-signing.nk" }),
     );
     expect(parsed.nats?.accountSigningKeyPath).toBe("/etc/cortex/account-signing.nk");
+  });
+
+  test("credsPath (cortex#86) mirrors onto BotConfig.nats", () => {
+    const parsed = BotConfigSchema.parse(
+      minBotConfig({ credsPath: "~/.config/nats/cortex.creds" }),
+    );
+    expect(parsed.nats?.credsPath).toBe("~/.config/nats/cortex.creds");
+  });
+
+  test("credsPath rejects non-string on legacy BotConfig.nats", () => {
+    expect(() =>
+      BotConfigSchema.parse(minBotConfig({ credsPath: 42 })),
+    ).toThrow();
   });
 
   test("rejects non-string on legacy BotConfig.nats", () => {

--- a/src/common/types/config.ts
+++ b/src/common/types/config.ts
@@ -486,6 +486,14 @@ export const BotConfigSchema = z.object({
      */
     accountSigningKeyPath: z.string().optional(),
     /**
+     * cortex#86 — path to a NATS user `.creds` file for operator-mode
+     * connect auth. See `NatsConfigSchema.credsPath` in `./cortex-config.ts`
+     * for the canonical docstring; this entry MIRRORS the field so that
+     * the migrate-config loader can synthesize a BotConfig from cortex.yaml
+     * without stripping the creds path. Drop both on MIG-7.2e.
+     */
+    credsPath: z.string().optional(),
+    /**
      * MIG-7.2e: NKey identity for envelope signing (MY-400). Optional.
      * Mirror of `NatsConfigSchema.identity` in `./cortex-config.ts` so the
      * loader can synthesize a BotConfig from cortex.yaml without stripping

--- a/src/common/types/cortex-config.ts
+++ b/src/common/types/cortex-config.ts
@@ -464,6 +464,17 @@ export const NatsConfigSchema = z.object({
   /** Optional NKey identity for envelope signing (MY-400). */
   identity: NatsIdentitySchema.optional(),
   /**
+   * cortex#86 — path to a NATS user `.creds` file for operator-mode connect
+   * auth. When set, the daemon authenticates via `credsAuthenticator(...)`
+   * instead of anonymous / bearer-token. Leading `~/` expands to `$HOME`;
+   * the `NatsLink` loader enforces chmod 600 on POSIX. Wins over `token`
+   * when both are set (warn log explains precedence).
+   *
+   * MIRROR: `BotConfigSchema.nats.credsPath` in `./config.ts`. Drop both
+   * on MIG-7.2e alongside `identity` and `accountSigningKeyPath`.
+   */
+  credsPath: z.string().optional(),
+  /**
    * Absolute path to operator account signing nkey file. Loaded into daemon
    * memory only. File MUST be chmod 600 (loader enforces). Optional — when
    * absent, cortex creds mutation subcommands return exit 2.


### PR DESCRIPTION
Closes #86. Unblocks the v1 cutover step that pivots the local `nats-server` to operator-mode (`nsc generate config --mem-resolver`) — without this PR, removing anonymous auth would orphan the cortex daemon's own NATS connection.

## Summary

- `NatsLinkOptions` gains `credsPath?: string`. When set: leading `~/` expands to `$HOME`, chmod 600 enforced on POSIX, bytes passed to `credsAuthenticator(...)` as `ConnectionOptions.authenticator`.
- `token` + `credsPath` together → `credsPath` wins, warn log explains precedence (no silent winner).
- `NatsConfigSchema.credsPath` + `BotConfigSchema.nats.credsPath` mirror (matches existing `accountSigningKeyPath` MIRROR pattern; drop both on MIG-7.2e).
- `MyelinRuntime.start()` threads `credsPath` through to `NatsLink.connect()`. Legacy bot.yaml configs untouched — the option only fires when set.

## Test plan

- [x] `bun test src/bus/nats/` — 16/16 pass (5 new creds-auth cases + 11 existing)
- [x] `bun test src/bus/myelin/` — pass (runtime thread-through)
- [x] `bun test src/common/types/` — pass (4 schema cases + 2 mirror cases added)
- [x] `bun test src/bus/nats/ src/bus/myelin/ src/common/types/` — 145/145 pass
- [x] `bunx tsc --noEmit` on the worktree — clean

### Pre-existing failure (unrelated, NOT introduced by this PR)

`src/surface/mc/__tests__/server.test.ts > "serves the React dashboard shell on GET /"` ENOENT — looking for `dist/dashboard-v2/index.html` which a fresh worktree hasn't built. **Reproduces on cortex `main` (a8680aa)** without any of this PR's changes:

```
$ cd ~/Developer/cortex && bun test src/surface/mc/__tests__/server.test.ts
(fail) mission-control server > serves the React dashboard shell on GET /
 3 pass / 1 fail (same as on this branch)
```

Worth filing as a separate test-fixture issue (dashboard build should be a `bun test` precondition, or the test should self-build / skip when `dist/` is absent). Out of scope for cortex#86.

## Manual verification path (v1 cutover)

This is the last cortex code change blocking the operator-mode pivot. Andreas's deployment already has `nsc` bootstrap + `cortex.yaml` `nats:` block staged; once this merges + `arc upgrade Cortex`:

```bash
# 1. Merge nsc-generated resolver into nats-server config
cat ~/.config/nats/resolver.conf >> ~/.config/nats/local.conf
# 2. Restart nats-server (loses anonymous auth)
# 3. Confirm cortex.yaml has nats.credsPath wired
yq '.nats.credsPath' ~/.config/cortex/cortex.yaml   # → ~/.config/nats/cortex.creds
# 4. Restart cortex daemon — connects via creds, not anonymous
```

## Out of scope

- Refactor cortex to consume `myelin.NATSTransport` directly (cleaner, bigger lift)
- Capability-scoped JWT mint pass-through (already cortex#81)
- Envelope signing via `nats.identity.seedPath` (MY-400 ladder in myelin)

## Review

`recommend: merge` on a clean run. Pre-existing dashboard flake should not block — file a separate test-fixture issue if it bites in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)