### PR TITLE
chore(deps): discord.js v15 prep -- Client ready -> clientReady (closes cortex#90)

### DIFF
--- a/src/adapters/discord/client.ts
+++ b/src/adapters/discord/client.ts
@@ -108,7 +108,10 @@ export function createDiscordClient(
     failIfNotExists: false,
   });
 
-  client.on("ready", () => {
+  // discord.js v15 renamed `ready` → `clientReady` to disambiguate from the
+  // gateway READY frame; `clientReady` is already emitted alongside `ready`
+  // on v14, so the listener fires identically. See discord.js#10358.
+  client.on("clientReady", () => {
     health.currentlyConnected = true;
     health.lastConnectedAt = new Date();
     console.log(`${tag}: connected as ${client.user?.tag}`);

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -766,7 +766,8 @@ function setupOutboundLog(
 
   let pollInterval: ReturnType<typeof setInterval> | null = null;
 
-  client.on("ready", () => {
+  // discord.js v15 prep — see comment in adapters/discord/client.ts.
+  client.on("clientReady", () => {
     if (!existsSync(eventsDir)) {
       console.log(`cortex: published events dir not found (${eventsDir}), skipping outbound`);
       return;


### PR DESCRIPTION
## Summary

- Renames the two top-level `Client.on("ready", ...)` listeners to `Client.on("clientReady", ...)` per the discord.js v15 migration notice. Pure no-op on v14 (both names are emitted), removes the deprecation warning today, and prevents the silent never-connect that v15 would produce when `ready` is removed.
- Surgical: two listener lines, plus brief in-code comments explaining the rename. discord.js itself is NOT upgraded -- that's a separate migration.
- Does NOT touch sharding events (`shardReady`, `shardDisconnect`, `shardReconnecting`, `shardError`) -- those are different events on the WebSocketShard manager and are unaffected by the rename.

## Files touched

- `src/adapters/discord/client.ts` -- primary `createDiscordClient` connection-ready handler that logs `connected as ${tag}` / `Agent:` / `Guild:` lines. Log shape preserved -- only the EVENT was renamed.
- `src/cortex.ts` -- `setupOutboundLog` handler that bootstraps the published-events JSONL stream once the Discord client is connected. Same rename.

See discord.js#10358 (https://github.com/discordjs/discord.js/pull/10358) for the upstream rationale.

## Test plan

- [x] `bun test src/adapters/discord/` -- 111/111 pass
- [x] `bunx tsc --noEmit` -- clean
- [x] `grep -rn '\.on("ready"\|\.once("ready"' src/` -- no remaining hits
- [x] Repo-wide `bun test` -- only pre-existing flakes remain (mission-control React shell test fails on `ENOENT` because the dashboard is not built in this worktree; `AgentsDirectoryWatcher` timing test is flaky). Neither is related to Discord events.
- [ ] Operator: boot cortex daemon and confirm the `DeprecationWarning: The ready event has been renamed to clientReady` line no longer appears in `cortex-bot.error.log` at startup. Log shape (`luna-discord: shard 0 ready (reconnects so far: 0)` followed by `connected as Luna#6518`) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)