### PR TITLE
fix(cutover): tidy-up — log path, mkdir, noisy warnings, env var (refs cortex#88)

### DIFF
--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -68,15 +68,15 @@ provides:
 
   hooks:
     - event: SessionStart
-      command: ${CLAUDE_DIR}/hooks/CortexContext.hook.ts
+      command: ${PAI_DIR}/hooks/CortexContext.hook.ts
     - event: PostToolUse
-      command: ${CLAUDE_DIR}/hooks/CortexEventLogger.hook.ts
+      command: ${PAI_DIR}/hooks/CortexEventLogger.hook.ts
     - event: Stop
-      command: ${CLAUDE_DIR}/hooks/CortexEventLogger.hook.ts
+      command: ${PAI_DIR}/hooks/CortexEventLogger.hook.ts
     - event: UserPromptSubmit
-      command: ${CLAUDE_DIR}/hooks/CortexEventLogger.hook.ts
+      command: ${PAI_DIR}/hooks/CortexEventLogger.hook.ts
     - event: PreToolUse
-      command: ${CLAUDE_DIR}/hooks/CortexBashGuard.hook.ts
+      command: ${PAI_DIR}/hooks/CortexBashGuard.hook.ts
       matcher: Bash
 
 # Lifecycle scripts (mirror grove-v2 three-stage pattern):

--- a/src/bus/myelin/__tests__/runtime.test.ts
+++ b/src/bus/myelin/__tests__/runtime.test.ts
@@ -91,16 +91,20 @@ function makeFakeNatsConnection() {
 }
 
 describe("MyelinRuntime", () => {
-  let logs: { kind: "log" | "warn" | "error"; msg: string }[];
+  let logs: { kind: "log" | "info" | "warn" | "error"; msg: string }[];
   let restore: () => void;
 
   beforeEach(() => {
     logs = [];
     const origLog = console.log;
+    const origInfo = console.info;
     const origWarn = console.warn;
     const origError = console.error;
     console.log = (...args: unknown[]) => {
       logs.push({ kind: "log", msg: args.map(String).join(" ") });
+    };
+    console.info = (...args: unknown[]) => {
+      logs.push({ kind: "info", msg: args.map(String).join(" ") });
     };
     console.warn = (...args: unknown[]) => {
       logs.push({ kind: "warn", msg: args.map(String).join(" ") });
@@ -110,6 +114,7 @@ describe("MyelinRuntime", () => {
     };
     restore = () => {
       console.log = origLog;
+      console.info = origInfo;
       console.warn = origWarn;
       console.error = origError;
     };
@@ -157,7 +162,10 @@ describe("MyelinRuntime", () => {
     await runtime.stop();
   });
 
-  test("warns + returns disabled when nats.url present but subjects empty", async () => {
+  test("cortex#88 item 6: emits info (not warn) when nats.url set but subjects empty", async () => {
+    // The publish-only case (typical cortex deployment today). Returning
+    // `enabled: false` is preserved — only the log level changes — so
+    // callers gated on `runtime.enabled` continue to behave identically.
     const config = makeConfig({
       url: "nats://localhost:4222",
       name: "grove-bot",
@@ -166,9 +174,16 @@ describe("MyelinRuntime", () => {
     const runtime = await startMyelinRuntime(config);
     expect(runtime.enabled).toBe(false);
     const warned = logs.some(
-      (l) => l.kind === "warn" && l.msg.includes("nats.subjects is empty"),
+      (l) => l.kind === "warn" && l.msg.includes("subjects"),
     );
-    expect(warned).toBe(true);
+    expect(warned).toBe(false);
+    const informed = logs.some(
+      (l) =>
+        l.kind === "info" &&
+        l.msg.includes("nats.subjects empty") &&
+        l.msg.includes("no subscriptions started"),
+    );
+    expect(informed).toBe(true);
   });
 
   test("returns disabled when NATS connect fails (logs error, doesn't throw)", async () => {

--- a/src/bus/myelin/runtime.ts
+++ b/src/bus/myelin/runtime.ts
@@ -128,8 +128,18 @@ export async function startMyelinRuntime(
   );
 
   if (subjects.length === 0) {
-    console.warn(
-      "myelin-runtime: nats.url configured but nats.subjects is empty — no subscriptions started",
+    // cortex#88 item 6: empty `subjects` is the typical state today —
+    // cortex publishes envelopes but doesn't subscribe (subscription
+    // routing is G-1111+ territory). Demoted from `console.warn` to
+    // `console.info`: the prior wording ("no subscriptions started")
+    // misled every operator into chasing a phantom misconfiguration on
+    // every boot. The runtime IS still considered disabled here because
+    // `publish` from this branch requires the same connect-and-subscribe
+    // path the populated case takes — keeping the early-return preserves
+    // the existing publish-disabled contract until G-1111 wires the
+    // publish-only mode end-to-end.
+    console.info(
+      "myelin-runtime: nats.url configured, nats.subjects empty — no subscriptions started (this is normal for current cortex deployments; subscription routing lands in G-1111)",
     );
     return {
       enabled: false,

--- a/src/cli/cortex/commands/__tests__/migrate-config.test.ts
+++ b/src/cli/cortex/commands/__tests__/migrate-config.test.ts
@@ -648,6 +648,43 @@ describe("convertBotYaml — schema-sourced defaults", () => {
 });
 
 // ---------------------------------------------------------------------------
+// cortex#88 item 1 — paths.* grove → cortex rewrite
+// ---------------------------------------------------------------------------
+
+describe("convertBotYaml — paths rewrite (cortex#88 item 1)", () => {
+  test("rewrites grove path defaults under paths.* to cortex equivalents", () => {
+    const legacy: LegacyBotYaml = {
+      agent: { name: "luna", displayName: "Luna", personaFile: "./personas/luna.md" },
+      discord: [{ token: "t", guildId: "1", agentChannelId: "2", logChannelId: "3" }],
+      paths: {
+        publishedEventsDir: "~/.claude/events/published",
+        logDir: "~/.config/grove/logs",
+      },
+    };
+    const result = convertBotYaml(legacy, {});
+    const paths = (result.cortex.paths ?? {}) as Record<string, string>;
+    expect(paths.logDir).toBe("~/.config/cortex/logs");
+    // Non-grove paths pass through unchanged
+    expect(paths.publishedEventsDir).toBe("~/.claude/events/published");
+    // Operator sees a warning surfacing the substitution
+    const pathsWarn = result.warnings.find((w) => w.field === "paths");
+    expect(pathsWarn?.message).toMatch(/grove path\(s\)/);
+  });
+
+  test("leaves a paths block that already targets cortex unchanged", () => {
+    const legacy: LegacyBotYaml = {
+      agent: { name: "luna", displayName: "Luna", personaFile: "./personas/luna.md" },
+      discord: [{ token: "t", guildId: "1", agentChannelId: "2", logChannelId: "3" }],
+      paths: { logDir: "~/.config/cortex/logs" },
+    };
+    const result = convertBotYaml(legacy, {});
+    const paths = (result.cortex.paths ?? {}) as Record<string, string>;
+    expect(paths.logDir).toBe("~/.config/cortex/logs");
+    expect(result.warnings.find((w) => w.field === "paths")).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // buildTrustList — extracted helper (Holly cortex#51 round 1 architecture)
 // ---------------------------------------------------------------------------
 
@@ -706,6 +743,21 @@ describe("runMigrateConfig", () => {
     const written = YAML.parse(readFileSync(out, "utf-8"));
     // Re-parse via the schema to confirm the file is a valid cortex.yaml
     expect(() => CortexConfigSchema.parse(written)).not.toThrow();
+  });
+
+  test("cortex#88 item 5: creates missing parent dir before writing --out", async () => {
+    // Reproduce the fresh-host case: target lives under a non-existent
+    // `~/.config/cortex/` equivalent. Without mkdirSync, writeFileSync
+    // ENOENTs; with it, the dir is created and the write succeeds.
+    const tmpRoot = mkdtempSync(join(tmpdir(), "cortex-mig-7-2e-mkdir-"));
+    const out = join(tmpRoot, "fresh-host", "nested", "cortex.yaml");
+    const code = await runMigrateConfig([
+      join(FIXTURE_DIR, "minimal.bot.yaml"),
+      "--out",
+      out,
+    ]);
+    expect(code).toBe(0);
+    expect(existsSync(out)).toBe(true);
   });
 
   test("--strict returns exit code 2 when warnings present", async () => {

--- a/src/cli/cortex/commands/migrate-config-lib.ts
+++ b/src/cli/cortex/commands/migrate-config-lib.ts
@@ -551,13 +551,51 @@ export function convertBotYaml(
   if (legacy.attachments !== undefined) cortex.attachments = legacy.attachments;
   if (legacy.execution !== undefined) cortex.execution = legacy.execution;
   if (legacy.github !== undefined) cortex.github = legacy.github;
-  if (legacy.paths !== undefined) cortex.paths = legacy.paths;
+  if (legacy.paths !== undefined) cortex.paths = rewritePaths(legacy.paths, warnings);
   if (legacy.networksDir !== undefined) cortex.networksDir = legacy.networksDir;
   if (legacy.networks !== undefined) cortex.networks = legacy.networks;
   if (legacy.nats !== undefined) cortex.nats = convertNats(legacy.nats, warnings);
 
   const parsed = CortexConfigSchema.parse(cortex);
   return { cortex: parsed, warnings, mappings };
+}
+
+/**
+ * Rewrite grove-era path strings (`~/.config/grove/...`) under the legacy
+ * `paths:` block to their cortex equivalents (`~/.config/cortex/...`).
+ *
+ * cortex#88 item 1: legacy `bot.yaml` carries `paths.logDir:
+ * ~/.config/grove/logs` (the BotConfigSchema default in production grove-v2).
+ * Without rewriting, the emitted cortex.yaml ships a stale grove path that
+ * any consumer of `config.paths.logDir` will then write to — even though
+ * the launchd plist's `StandardOutPath` already points at
+ * `~/.config/cortex/logs` (per scripts/postinstall.sh). The two diverge,
+ * and operators chasing missing logs get sent on a wild grove chase.
+ *
+ * Strategy: shallow substring rewrite over string-valued fields. Non-string
+ * fields (rare, but `unknown` shape leaves the door open) pass through
+ * unchanged. A warning surfaces whenever any rewrite fired so the operator
+ * sees the substitution in the migrate-config report.
+ */
+function rewritePaths(legacyPaths: unknown, warnings: ConversionWarning[]): unknown {
+  if (!legacyPaths || typeof legacyPaths !== "object") return legacyPaths;
+  const paths = { ...(legacyPaths as Record<string, unknown>) };
+  const rewrites: string[] = [];
+  for (const [key, value] of Object.entries(paths)) {
+    if (typeof value !== "string") continue;
+    if (value.includes("/.config/grove/")) {
+      const next = value.replace("/.config/grove/", "/.config/cortex/");
+      paths[key] = next;
+      rewrites.push(`paths.${key}: "${value}" → "${next}"`);
+    }
+  }
+  if (rewrites.length > 0) {
+    warnings.push({
+      field: "paths",
+      message: `rewrote grove path(s) to cortex equivalents: ${rewrites.join("; ")}`,
+    });
+  }
+  return paths;
 }
 
 /**

--- a/src/cli/cortex/commands/migrate-config.ts
+++ b/src/cli/cortex/commands/migrate-config.ts
@@ -20,7 +20,7 @@
  *   2  — strict-mode warnings (would have succeeded without --strict)
  */
 
-import { readFileSync, writeFileSync } from "fs";
+import { mkdirSync, readFileSync, writeFileSync } from "fs";
 import { dirname, resolve } from "path";
 import YAML from "yaml";
 
@@ -150,6 +150,10 @@ export async function runMigrateConfig(argv: string[]): Promise<number> {
     const yamlOut = YAML.stringify(result.cortex, { indent: 2, lineWidth: 0 });
     if (args.out) {
       const outPath = resolve(args.out);
+      // cortex#88 item 5: a fresh host has no `~/.config/cortex/`, so
+      // writeFileSync ENOENTs unless we ensure the parent exists. mkdir
+      // recursive is idempotent — pre-existing dirs are a no-op.
+      mkdirSync(dirname(outPath), { recursive: true });
       writeFileSync(outPath, yamlOut, "utf-8");
       console.error(`wrote ${outPath} (${result.cortex.agents.length} agent(s), ${result.cortex.renderers.length} renderer(s))`);
     } else {

--- a/src/common/config/__tests__/loader.test.ts
+++ b/src/common/config/__tests__/loader.test.ts
@@ -182,6 +182,82 @@ describe("legacy fallback", () => {
 });
 
 // ---------------------------------------------------------------------------
+// cortex#88 item 7: networksDir-missing log level
+// ---------------------------------------------------------------------------
+
+describe("networksDir-missing log level (cortex#88 item 7)", () => {
+  function captureConsole(): {
+    logs: { kind: "info" | "warn"; msg: string }[];
+    restore: () => void;
+  } {
+    const logs: { kind: "info" | "warn"; msg: string }[] = [];
+    const origInfo = console.info;
+    const origWarn = console.warn;
+    console.info = (...args: unknown[]) => {
+      logs.push({ kind: "info", msg: args.map(String).join(" ") });
+    };
+    console.warn = (...args: unknown[]) => {
+      logs.push({ kind: "warn", msg: args.map(String).join(" ") });
+    };
+    return {
+      logs,
+      restore: () => {
+        console.info = origInfo;
+        console.warn = origWarn;
+      },
+    };
+  }
+
+  test("default networksDir absent → info-level only (no warn)", () => {
+    // migrate-config emits `networksDir: ./networks` even when the operator
+    // never created the directory. Make sure that the default-value-absent
+    // case is informational, not a warning.
+    const configPath = writeCentralConfig(testDir, {
+      agent: { name: "luna", displayName: "Luna" },
+      claude: { timeoutMs: 120000 },
+      networksDir: "./networks",
+    });
+    rmSync(join(testDir, "networks"), { recursive: true });
+
+    const cap = captureConsole();
+    try {
+      loadConfig(configPath);
+    } finally {
+      cap.restore();
+    }
+    const warns = cap.logs.filter((l) => l.kind === "warn" && l.msg.includes("networksDir"));
+    expect(warns).toHaveLength(0);
+    const infos = cap.logs.filter((l) => l.kind === "info" && l.msg.includes("networksDir"));
+    expect(infos.length).toBeGreaterThan(0);
+  });
+
+  test("non-default networksDir absent → keeps console.warn", () => {
+    // Operator explicitly pointed networksDir at a non-default path that
+    // doesn't exist — that's almost certainly a typo or missing mount,
+    // worth surfacing loudly.
+    const configPath = writeCentralConfig(testDir, {
+      agent: { name: "luna", displayName: "Luna" },
+      claude: { timeoutMs: 120000 },
+      networksDir: "./operator-typo-here",
+    });
+
+    const cap = captureConsole();
+    try {
+      loadConfig(configPath);
+    } finally {
+      cap.restore();
+    }
+    const warns = cap.logs.filter(
+      (l) =>
+        l.kind === "warn" &&
+        l.msg.includes("networksDir") &&
+        l.msg.includes("does not exist"),
+    );
+    expect(warns.length).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // T6.4: Malformed network file error reporting
 // ---------------------------------------------------------------------------
 

--- a/src/common/config/loader.ts
+++ b/src/common/config/loader.ts
@@ -121,7 +121,15 @@ export function loadConfigWithAgents(path: string): LoadedConfig {
 
   // Networks load against the on-disk path regardless of legacy/cortex shape —
   // both shapes share the same networks/ contract (G-500).
-  const explicitNetworksDir = typeof raw.networksDir === "string";
+  //
+  // cortex#88 item 7: `explicitNetworksDir` was true whenever `networksDir`
+  // appeared anywhere in raw yaml — but migrate-config emits the schema
+  // default (`./networks`) verbatim, so every startup tripped the
+  // `does not exist` warn. Treat the literal default value as "not
+  // explicit" so the warning fires only when the operator pointed
+  // networksDir at a non-default path that's actually missing.
+  const explicitNetworksDir =
+    typeof raw.networksDir === "string" && raw.networksDir !== "./networks";
   const networksDir = resolve(
     configDir,
     (typeof raw.networksDir === "string" ? raw.networksDir : "./networks"),
@@ -473,7 +481,15 @@ export function loadAgentsDirectory(dir: string): Agent[] {
 function loadNetworkFiles(networksDir: string, explicit: boolean): NetworkFile[] {
   if (!existsSync(networksDir)) {
     if (explicit) {
+      // Operator pointed networksDir at a non-default path that doesn't
+      // exist — surface loudly so they notice the typo / missing mount.
       console.warn(`config-loader: networksDir "${networksDir}" does not exist — no networks loaded`);
+    } else {
+      // cortex#88 item 7: the default path is absent. This is fine —
+      // networks/ is optional today — but surface at info-level so
+      // an operator who actually expected fragments to load can spot
+      // the path mismatch.
+      console.info(`config-loader: default networksDir "${networksDir}" not present — no networks loaded (this is fine if you haven't created any network fragments)`);
     }
     return [];
   }


### PR DESCRIPTION
Quick-win subset of cortex#88 — five surgical fixes uncovered during the v1 operator-mode cutover. The remaining items (2, 3, 4, 8) need deeper changes and are deferred to a follow-on PR.

Refs #88 (this PR addresses items 1/5/6/7/9). When this merges, tick these checkboxes on the issue:

- [x] Item 1 — `migrate-config` emits stale grove `logDir`
- [x] Item 5 — `migrate-config emit` crashes if target dir is missing
- [x] Item 6 — `myelin-runtime` "no subscriptions started" warning is too loud when intentional
- [x] Item 7 — `config-loader` `networksDir does not exist` warning fires every startup
- [x] Item 9 — arc-manifest uses `${CLAUDE_DIR}` for hook paths but Claude Code exports `${PAI_DIR}`

Deferred to a follow-on PR (bigger surface):
- [ ] Item 2 — `cortex start --dry-run` advertised in docs but not implemented
- [ ] Item 3 — `migrate-config` emits agent IDs as `luna`/`luna-2`/`luna-3` regardless of identity
- [ ] Item 4 — `migrate-config` repeats the same `agentChannelId` across agents
- [ ] Item 8 — v1 cutover docs missing the `leafnodes[].account` requirement for operator-mode

## What landed

**Item 1 — `src/cli/cortex/commands/migrate-config-lib.ts`**
New `rewritePaths()` helper rewrites string values under `paths.*` that contain `/.config/grove/` to `/.config/cortex/`, surfacing a warning per substitution. Production grove `bot.yaml` carries the legacy `BotConfigSchema` default `~/.config/grove/logs`; without this, the emitted cortex.yaml diverged from the launchd plist's `StandardOutPath` (already cortex-side per `scripts/postinstall.sh`).

**Item 5 — `src/cli/cortex/commands/migrate-config.ts`**
`mkdirSync(dirname(outPath), { recursive: true })` before `writeFileSync(outPath, …)`. Fresh-host installs (no prior `~/.config/cortex/`) previously ENOENTed; mkdir recursive is idempotent against pre-existing dirs.

**Item 6 — `src/bus/myelin/runtime.ts`**
Demoted the "nats.url configured but nats.subjects is empty" log from `console.warn` to `console.info`. Empty `subjects` is the typical cortex deployment today (G-1111+ adds subscription routing). The runtime still returns `enabled: false` here so the existing publish-disabled contract is preserved end-to-end.

**Item 7 — `src/common/config/loader.ts`**
The literal default `./networks` is now treated as not-explicit: an absent default path fires `console.info` instead of `console.warn`. Operators pointing `networksDir` at a non-default missing path (typo / missing mount) still get the loud warn.

**Item 9 — `arc-manifest.yaml`**
Swapped `${CLAUDE_DIR}` → `${PAI_DIR}` on all five `hooks.*` `command:` paths. `${PAI_DIR}` is the env var Claude Code actually exports (verified: `PAI_DIR=/Users/andreas/.claude`) and matches Grove/Recall/PAI-core conventions. `${CLAUDE_DIR}` expanded to empty and produced `/bin/sh: /hooks/CortexEventLogger.hook.ts: No such file or directory` on every tool call.

## Test plan

- [x] `bunx tsc --noEmit` clean across the repo
- [x] `bun test src/cli/cortex src/bus/myelin src/common/config` — 354 pass / 0 fail
- [x] Added focused regression tests:
  - `convertBotYaml — paths rewrite (cortex#88 item 1)` — two cases (rewrite fires + leaves cortex-shaped paths alone)
  - `runMigrateConfig > cortex#88 item 5: creates missing parent dir before writing --out` — nested fresh-host target
  - `cortex#88 item 6: emits info (not warn) when nats.url set but subjects empty` — asserts no warn + correct info wording
  - `networksDir-missing log level (cortex#88 item 7)` — two cases (default → info; explicit non-default → warn)
- [x] Full suite: only pre-existing flakes (mission-control dashboard SPA per cortex#89; macOS watcher debounce timing) — verified present on pristine `main` HEAD.

## Diff

```
 arc-manifest.yaml                                  | 10 +--
 src/bus/myelin/__tests__/runtime.test.ts           | 23 +++++--
 src/bus/myelin/runtime.ts                          | 14 +++-
 src/cli/cortex/commands/__tests__/migrate-config.test.ts | 52 +++++++++++++++
 src/cli/cortex/commands/migrate-config-lib.ts      | 40 +++++++++++-
 src/cli/cortex/commands/migrate-config.ts          |  6 +-
 src/common/config/__tests__/loader.test.ts         | 76 ++++++++++++++++++++++
 src/common/config/loader.ts                        | 18 ++++-
 8 files changed, 225 insertions(+), 14 deletions(-)
```