### PR TITLE
feat(cutover): tidy-up remainder — dry-run, agent id detection, agentChannelId warn, docs (closes cortex#88)

### DIFF
--- a/docs/plan-cortex-migration.md
+++ b/docs/plan-cortex-migration.md
@@ -649,4 +649,87 @@ The migration is complete when all of:
 
 ---
 
+## 9. Operator cutover — operator-mode NATS
+
+This section captures the operational recipe for the v1 cutover host moving
+NATS from `--mem-resolver` test mode to operator mode while preserving the
+existing leafnode federation. Surfaced from the 2026-05-13 v1 cutover as
+cortex#88 item 8 — `nsc generate config --mem-resolver` produces a
+resolver.conf that does NOT carry the per-remote `account:` binding leaf
+federation needs, and `nats-server` refuses to start with
+`operator mode requires account nkeys in remotes` if you merge the two
+configs naively.
+
+### 9.1 Where the operator-mode requirement comes from
+
+Operator-mode NATS demands every leafnode `remotes[]` entry declare which
+LOCAL account (in this operator's signing-key universe) the remote
+connection is bound to. Without it, the server can't determine subject
+isolation for inbound leafnode traffic and refuses to start.
+
+`nsc generate config --mem-resolver` only emits the operator + accounts
++ a `resolver: MEMORY` block. It assumes a single-tenant, no-federation
+deployment and does not know about your `leafnodes:` block.
+
+### 9.2 The required injection
+
+For each `remotes[]` entry under `leafnodes:`, add an `account:` field
+carrying the 56-char A-prefixed pubkey of the LOCAL account the remote
+should bind to. Example for an operator using a single `ANDREAS_AGENTS`
+account:
+
+```conf
+leafnodes {
+  remotes = [
+    {
+      url:  "nats-leaf://leaf.example.com:7422"
+      credentials: "/Users/andreas/.nats/leaf.creds"
+
+      # cortex#88 item 8 — operator-mode binding. Without this line
+      # nats-server fails to start with:
+      #   "operator mode requires account nkeys in remotes"
+      account: "ABXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+    }
+  ]
+}
+```
+
+The pubkey above is a placeholder — substitute your local account's
+A-prefixed pubkey. Find it with:
+
+```bash
+nsc list accounts -o "$NSC_OPERATOR" | awk '/^│ ANDREAS_AGENTS/ {print $4}'
+# or:
+nsc describe account ANDREAS_AGENTS | awk '/Account ID/ {print $3}'
+```
+
+### 9.3 End-to-end cutover sequence
+
+1. **Snapshot current config.** `cp ~/.nats/local.conf ~/.nats/local.conf.pre-cutover`.
+2. **Generate operator-mode resolver.** `nsc generate config --mem-resolver > /tmp/resolver.conf`.
+3. **Merge into local.conf.** Append the operator + accounts + resolver
+   blocks from `/tmp/resolver.conf` into `local.conf`, preserving the
+   existing `leafnodes:` block.
+4. **Inject account binding.** For each entry under
+   `leafnodes.remotes[]`, add the `account: "A..."` line per §9.2.
+5. **Restart nats-server.** `launchctl unload ~/Library/LaunchAgents/io.nats.server.plist && launchctl load ~/Library/LaunchAgents/io.nats.server.plist`.
+6. **Verify startup.**
+   - `tail -f /usr/local/var/log/nats/nats-server.log` should show
+     `Operator: <name>` + `Account [ANDREAS_AGENTS] cache loaded` +
+     no `operator mode requires account nkeys in remotes` error.
+   - `nats stream ls --server nats://localhost:4222 --creds ~/.nats/user.creds`
+     should return without auth errors.
+7. **Verify cortex.** `cortex start --config ~/.config/cortex/cortex.yaml --dry-run` confirms the config still parses (cortex#88 item 2); `cortex status` after `launchctl load …cortex.bot.plist` shows the bot connected to the operator-mode server.
+
+### 9.4 Rollback
+
+If step 6 surfaces an unrecoverable error: restore `local.conf` from the
+pre-cutover snapshot (`cp ~/.nats/local.conf.pre-cutover ~/.nats/local.conf`),
+unload/load the launchd plist again, and resume on the mem-resolver
+configuration while debugging the operator-mode setup offline. Cortex
+itself does not need to be restarted — the bot reconnects to the
+re-loaded NATS server within a few seconds.
+
+---
+
 *This plan is the ground truth for the migration. When reality drifts from it, update the plan first, then the world. For "what cortex IS" architecture, see `docs/design-cortex.md`.*

--- a/src/__tests__/cortex.test.ts
+++ b/src/__tests__/cortex.test.ts
@@ -29,7 +29,7 @@ import { join } from "path";
 import { tmpdir } from "os";
 import { BotConfigSchema, type BotConfig } from "../common/types/config";
 import type { Agent } from "../common/types/cortex-config";
-import { startCortex } from "../cortex";
+import { runDryRun, startCortex } from "../cortex";
 import type { Envelope } from "../bus/myelin/envelope-validator";
 import type { EnvelopeHandler, MyelinRuntime } from "../bus/myelin/runtime";
 
@@ -616,5 +616,112 @@ presence:
 
     await handle.stop();
     rmSync(tmpAgentsDir, { recursive: true, force: true });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cortex#88 item 2 — `cortex start --dry-run`
+// ---------------------------------------------------------------------------
+
+describe("runDryRun — config validator (cortex#88 item 2)", () => {
+  test("success path: returns exit 0 with one-line OK summary", () => {
+    // Minimal cortex.yaml-shape config: operator + one agent w/ discord
+    // presence. `loadConfigWithAgents` detects cortex shape from the
+    // presence of `operator:` + `agents:` and validates against
+    // `CortexConfigSchema`.
+    const dir = mkdtempSync(join(tmpdir(), "cortex-dryrun-ok-"));
+    const cfgPath = join(dir, "cortex.yaml");
+    writeFileSync(
+      cfgPath,
+      [
+        "operator:",
+        "  id: jc",
+        "  dataResidency: NZ",
+        "agents:",
+        "  - id: luna",
+        "    displayName: Luna",
+        "    persona: ./personas/luna.md",
+        "    roles: []",
+        "    trust: []",
+        "    presence:",
+        "      discord:",
+        "        token: tok",
+        "        guildId: \"100000000000000001\"",
+        "        agentChannelId: \"100000000000000002\"",
+        "        logChannelId: \"100000000000000003\"",
+        "renderers: []",
+        "claude: {}",
+        "nats:",
+        "  url: nats://localhost:4222",
+        "  subjects: [\"local.jc.>\"]",
+        "",
+      ].join("\n"),
+      "utf-8",
+    );
+    const result = runDryRun(cfgPath);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toMatch(/cortex config validation OK/);
+    expect(result.stdout).toMatch(/1 agents/);
+    expect(result.stdout).toMatch(/0 renderers/);
+    expect(result.stdout).toMatch(/NATS=nats:\/\/localhost:4222/);
+    expect(result.stderr).toBe("");
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("success path: NATS disabled when nats block absent", () => {
+    const dir = mkdtempSync(join(tmpdir(), "cortex-dryrun-no-nats-"));
+    const cfgPath = join(dir, "cortex.yaml");
+    writeFileSync(
+      cfgPath,
+      [
+        "operator:",
+        "  id: jc",
+        "agents:",
+        "  - id: luna",
+        "    displayName: Luna",
+        "    persona: ./personas/luna.md",
+        "    roles: []",
+        "    trust: []",
+        "    presence:",
+        "      discord:",
+        "        token: tok",
+        "        guildId: \"100000000000000001\"",
+        "        agentChannelId: \"100000000000000002\"",
+        "        logChannelId: \"100000000000000003\"",
+        "renderers: []",
+        "claude: {}",
+        "",
+      ].join("\n"),
+      "utf-8",
+    );
+    const result = runDryRun(cfgPath);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toMatch(/NATS=\(disabled\)/);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("failure path: returns exit 2 with operator-readable schema error", () => {
+    // Cortex-shape input with a missing required field (no displayName on
+    // the agent) — should be rejected by CortexConfigSchema.
+    const dir = mkdtempSync(join(tmpdir(), "cortex-dryrun-fail-"));
+    const cfgPath = join(dir, "cortex.yaml");
+    writeFileSync(
+      cfgPath,
+      [
+        "operator:",
+        "  id: jc",
+        "agents:",
+        "  - id: luna",
+        // missing: displayName, persona, roles, trust, presence
+        "renderers: []",
+        "",
+      ].join("\n"),
+      "utf-8",
+    );
+    const result = runDryRun(cfgPath);
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr).toMatch(/cortex config validation FAILED/);
+    expect(result.stdout).toBe("");
+    rmSync(dir, { recursive: true, force: true });
   });
 });

--- a/src/cli/cortex/commands/__tests__/migrate-config.test.ts
+++ b/src/cli/cortex/commands/__tests__/migrate-config.test.ts
@@ -827,6 +827,106 @@ describe("convertBotYaml — agent id detection (cortex#88 item 3)", () => {
 });
 
 // ---------------------------------------------------------------------------
+// cortex#88 item 4 — shared agentChannelId across agents
+// ---------------------------------------------------------------------------
+
+describe("convertBotYaml — shared agentChannelId warning (cortex#88 item 4)", () => {
+  test("warn fires when 2+ agents share the same agentChannelId", () => {
+    // Grove monobot production shape: three Discord adapters, each with
+    // an `agent-*` role hint (so cortex#88 item 3's detection picks the
+    // distinct ids), but all three repeat the same `agentChannelId`
+    // because grove's bot.yaml carried one shared #agent-log channel.
+    // After migrate-config, all three cortex agents emit with the same
+    // id — per-agent log routing silently no-ops.
+    const sharedChannel = "1487029848164536361";
+    const legacy: LegacyBotYaml = {
+      agent: { name: "luna", displayName: "Luna", personaFile: "./personas/luna.md" },
+      discord: [
+        {
+          token: "luna-token",
+          guildId: "1",
+          agentChannelId: sharedChannel,
+          logChannelId: "3",
+          roles: [{ name: "agent-luna", users: ["100000000000000001"], features: ["chat"] }],
+        },
+        {
+          token: "echo-token",
+          guildId: "10",
+          agentChannelId: sharedChannel,
+          logChannelId: "30",
+          roles: [{ name: "agent-echo", users: ["200000000000000002"], features: ["chat"] }],
+        },
+        {
+          token: "forge-token",
+          guildId: "100",
+          agentChannelId: sharedChannel,
+          logChannelId: "300",
+          roles: [{ name: "agent-forge", users: ["300000000000000003"], features: ["chat"] }],
+        },
+      ],
+    };
+    const result = convertBotYaml(legacy, {});
+    const sharedWarns = result.warnings.filter((w) => w.field === "agents.agentChannelId");
+    expect(sharedWarns).toHaveLength(1);
+    expect(sharedWarns[0]!.message).toMatch(/agents \[luna,echo,forge\] share agentChannelId 1487029848164536361/);
+    expect(sharedWarns[0]!.message).toMatch(/set distinct channels in cortex.yaml for per-agent log routing/);
+    // The channel id is NOT blanked — operator may want shared logging.
+    for (const a of result.cortex.agents) {
+      expect(a.presence.discord?.agentChannelId).toBe(sharedChannel);
+    }
+  });
+
+  test("warn skipped when each agent has a distinct agentChannelId", () => {
+    // Same multi-adapter monobot shape, but each adapter declares its own
+    // channel id. No warning should fire.
+    const legacy: LegacyBotYaml = {
+      agent: { name: "luna", displayName: "Luna", personaFile: "./personas/luna.md" },
+      discord: [
+        {
+          token: "luna-token",
+          guildId: "1",
+          agentChannelId: "111111111111111111",
+          logChannelId: "3",
+          roles: [{ name: "agent-luna", users: ["100000000000000001"], features: ["chat"] }],
+        },
+        {
+          token: "echo-token",
+          guildId: "10",
+          agentChannelId: "222222222222222222",
+          logChannelId: "30",
+          roles: [{ name: "agent-echo", users: ["200000000000000002"], features: ["chat"] }],
+        },
+        {
+          token: "forge-token",
+          guildId: "100",
+          agentChannelId: "333333333333333333",
+          logChannelId: "300",
+          roles: [{ name: "agent-forge", users: ["300000000000000003"], features: ["chat"] }],
+        },
+      ],
+    };
+    const result = convertBotYaml(legacy, {});
+    expect(result.warnings.filter((w) => w.field === "agents.agentChannelId")).toHaveLength(0);
+  });
+
+  test("warn skipped for single-agent legacy bot.yaml", () => {
+    // Single-adapter case can't share by definition — the detection must
+    // not produce a spurious warning.
+    const legacy: LegacyBotYaml = {
+      agent: { name: "luna", displayName: "Luna", personaFile: "./personas/luna.md" },
+      discord: [{
+        token: "t",
+        guildId: "1",
+        agentChannelId: "111111111111111111",
+        logChannelId: "3",
+      }],
+    };
+    const result = convertBotYaml(legacy, {});
+    expect(result.warnings.filter((w) => w.field === "agents.agentChannelId")).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // buildTrustList — extracted helper (Holly cortex#51 round 1 architecture)
 // ---------------------------------------------------------------------------
 

--- a/src/cli/cortex/commands/__tests__/migrate-config.test.ts
+++ b/src/cli/cortex/commands/__tests__/migrate-config.test.ts
@@ -685,6 +685,148 @@ describe("convertBotYaml — paths rewrite (cortex#88 item 1)", () => {
 });
 
 // ---------------------------------------------------------------------------
+// cortex#88 item 3 — agent id detection from role-resolver hints
+// ---------------------------------------------------------------------------
+
+describe("convertBotYaml — agent id detection (cortex#88 item 3)", () => {
+  test("infers agent id from `agent-<X>` role hint when users[] is non-empty", () => {
+    // Grove monobot bot.yaml shape: the discord adapter carries an
+    // `agent-echo` role-resolver block with the bot's own Discord user id
+    // in `users[]`. That's the canonical hint of WHICH agent this adapter
+    // represents — migrate-config should emit `echo`, not `luna`.
+    const legacy: LegacyBotYaml = {
+      agent: { name: "luna", displayName: "Luna", personaFile: "./personas/luna.md" },
+      discord: [{
+        token: "echo-token",
+        guildId: "1",
+        agentChannelId: "2",
+        logChannelId: "3",
+        roles: [
+          { name: "operator", users: ["112233445566778899"], features: ["chat"] },
+          { name: "agent-echo", users: ["999888777666555444"], features: ["chat"] },
+        ],
+      }],
+    };
+    const result = convertBotYaml(legacy, {});
+    expect(result.cortex.agents).toHaveLength(1);
+    expect(result.cortex.agents[0]!.id).toBe("echo");
+    // Warning surfaces the inference for operator audit trail.
+    const hintWarn = result.warnings.find((w) => w.field === "agents[0].id");
+    expect(hintWarn?.message).toMatch(/inferred from role-resolver hint/);
+  });
+
+  test("falls back to agent.name when no role hint matches", () => {
+    // No `agent-*` role at all — preserve pre-#88 behaviour
+    // (deriveAgentId(agent.name) at index 0, numeric suffix at index ≥1).
+    const legacy: LegacyBotYaml = {
+      agent: { name: "luna", displayName: "Luna", personaFile: "./personas/luna.md" },
+      discord: [{
+        token: "t",
+        guildId: "1",
+        agentChannelId: "2",
+        logChannelId: "3",
+        roles: [
+          { name: "operator", users: ["112233445566778899"], features: ["chat"] },
+        ],
+      }],
+    };
+    const result = convertBotYaml(legacy, {});
+    expect(result.cortex.agents[0]!.id).toBe("luna");
+    expect(result.warnings.find((w) => w.field === "agents[0].id")).toBeUndefined();
+  });
+
+  test("falls back to numeric suffix for second variant when no role hint matches", () => {
+    // Two discord adapters, neither has an `agent-*` role hint. Index 0
+    // gets `luna` (from agent.name), index 1 gets `luna-2`.
+    const legacy: LegacyBotYaml = {
+      agent: { name: "luna", displayName: "Luna", personaFile: "./personas/luna.md" },
+      discord: [
+        { token: "t1", guildId: "1", agentChannelId: "2", logChannelId: "3" },
+        { token: "t2", guildId: "10", agentChannelId: "20", logChannelId: "30" },
+      ],
+    };
+    const result = convertBotYaml(legacy, {});
+    expect(result.cortex.agents.map((a) => a.id)).toEqual(["luna", "luna-2"]);
+  });
+
+  test("first matching hint wins when multiple `agent-*` roles are present", () => {
+    // Pathological config: two valid `agent-*` hints in one adapter's
+    // roles[]. Deterministic policy is first-wins so an operator can rely
+    // on top-of-list precedence when hand-editing.
+    const legacy: LegacyBotYaml = {
+      agent: { name: "luna", displayName: "Luna", personaFile: "./personas/luna.md" },
+      discord: [{
+        token: "t",
+        guildId: "1",
+        agentChannelId: "2",
+        logChannelId: "3",
+        roles: [
+          { name: "agent-forge", users: ["111111111111111111"], features: ["chat"] },
+          { name: "agent-echo", users: ["222222222222222222"], features: ["chat"] },
+        ],
+      }],
+    };
+    const result = convertBotYaml(legacy, {});
+    expect(result.cortex.agents[0]!.id).toBe("forge");
+  });
+
+  test("ignores `agent-*` roles whose users[] is empty", () => {
+    // Brief specifies the hint requires users[] non-empty. An empty
+    // users[] entry is structurally just a role definition — not a bot
+    // identity claim. Fall through to agent.name.
+    const legacy: LegacyBotYaml = {
+      agent: { name: "luna", displayName: "Luna", personaFile: "./personas/luna.md" },
+      discord: [{
+        token: "t",
+        guildId: "1",
+        agentChannelId: "2",
+        logChannelId: "3",
+        roles: [
+          { name: "agent-echo", users: [], features: ["chat"] },
+        ],
+      }],
+    };
+    const result = convertBotYaml(legacy, {});
+    expect(result.cortex.agents[0]!.id).toBe("luna");
+  });
+
+  test("applies role-resolver hints per adapter in a multi-discord bot.yaml", () => {
+    // Three-adapter monobot (grove production shape). Each adapter carries
+    // a distinct `agent-*` role-resolver hint — migrate-config should
+    // emit three agents with the inferred ids in the SAME order as the
+    // discord[] blocks (so per-instance mappings stay stable).
+    const legacy: LegacyBotYaml = {
+      agent: { name: "luna", displayName: "Luna", personaFile: "./personas/luna.md" },
+      discord: [
+        {
+          token: "luna-token",
+          guildId: "1",
+          agentChannelId: "2",
+          logChannelId: "3",
+          roles: [{ name: "agent-luna", users: ["100000000000000001"], features: ["chat"] }],
+        },
+        {
+          token: "echo-token",
+          guildId: "10",
+          agentChannelId: "20",
+          logChannelId: "30",
+          roles: [{ name: "agent-echo", users: ["200000000000000002"], features: ["chat"] }],
+        },
+        {
+          token: "forge-token",
+          guildId: "100",
+          agentChannelId: "200",
+          logChannelId: "300",
+          roles: [{ name: "agent-forge", users: ["300000000000000003"], features: ["chat"] }],
+        },
+      ],
+    };
+    const result = convertBotYaml(legacy, {});
+    expect(result.cortex.agents.map((a) => a.id)).toEqual(["luna", "echo", "forge"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // buildTrustList — extracted helper (Holly cortex#51 round 1 architecture)
 // ---------------------------------------------------------------------------
 

--- a/src/cli/cortex/commands/migrate-config-lib.ts
+++ b/src/cli/cortex/commands/migrate-config-lib.ts
@@ -431,6 +431,49 @@ function detectAgentIdFromRoleHints(inst: LegacyDiscordInstance): string | undef
 }
 
 /**
+ * cortex#88 item 4 — flag when 2+ agents share the same
+ * `presence.discord.agentChannelId` after conversion.
+ *
+ * Grove's `bot.yaml` predates multi-agent — each Discord adapter block
+ * carries one `agentChannelId` per adapter, but in production the same
+ * id is repeated across all 3 adapters (the monobot legacy: agent events
+ * for Luna / Echo / Forge all land in the same channel). After
+ * migrate-config, all 3 cortex agents end up with an identical
+ * `agentChannelId` and per-agent log routing silently no-ops — every
+ * bot still posts into the shared channel.
+ *
+ * We don't blank the field: an operator may genuinely WANT a shared
+ * log channel for cross-agent context. The warning surfaces the
+ * situation so the operator decides — set distinct ids in cortex.yaml
+ * or accept the shared default.
+ *
+ * Fires at most ONCE per distinct shared id (so a 4-agent legacy config
+ * sharing one id produces one warning, not three).
+ */
+function detectSharedAgentChannelId(
+  agents: CortexConfig["agents"],
+  warnings: ConversionWarning[],
+): void {
+  const byChannel = new Map<string, string[]>();
+  for (const a of agents) {
+    const cid = a.presence.discord?.agentChannelId;
+    if (!cid) continue;
+    const existing = byChannel.get(cid) ?? [];
+    existing.push(a.id);
+    byChannel.set(cid, existing);
+  }
+  for (const [cid, ids] of byChannel) {
+    if (ids.length < 2) continue;
+    warnings.push({
+      field: "agents.agentChannelId",
+      message:
+        `WARN: migrate-config: agents [${ids.join(",")}] share agentChannelId ${cid} ` +
+        `— set distinct channels in cortex.yaml for per-agent log routing`,
+    });
+  }
+}
+
+/**
  * Synthesize the cortex `agents[]` list from the singular legacy `agent` plus
  * the (possibly multi-entry) `discord[]` and `mattermost[]` arrays.
  *
@@ -621,6 +664,7 @@ export function convertBotYaml(
 
   const operator = buildOperator(legacy, warnings);
   const { agents } = buildAgents(legacy, warnings, mappings, opts.configDir);
+  detectSharedAgentChannelId(agents, warnings);
   const renderers = buildRenderers(legacy, warnings);
 
   if (legacy.grove !== undefined) {

--- a/src/cli/cortex/commands/migrate-config-lib.ts
+++ b/src/cli/cortex/commands/migrate-config-lib.ts
@@ -382,15 +382,71 @@ function buildTrustList(
 }
 
 /**
+ * cortex#88 item 3 — detect the bot identity for a single legacy
+ * `bot.yaml.discord[i]` block by scanning its `roles[]` for the legacy
+ * "this-is-the-bot-identity" hint.
+ *
+ * Grove's role-resolver historically carries one role per Discord identity
+ * (`agent-luna`, `agent-echo`, `agent-forge`, …). The role's `users[]` array
+ * lists the bot's own Discord user id — that is the operator's existing
+ * mapping from "Discord adapter block N" to "the agent whose bot token sits
+ * here". Without this signal, migrate-config falls through to numeric
+ * suffixing (`luna-2`, `luna-3`) regardless of which Discord identity each
+ * adapter actually represents — bug surfaced in production at the v1 cutover
+ * (cortex#88 item 3).
+ *
+ * Rules:
+ *   - `roles[]` is `unknown[]` on the legacy schema; iterate defensively
+ *     (objects only, ignore strings / nulls).
+ *   - Match the FIRST entry whose `name` starts with `agent-` AND whose
+ *     `users[]` carries at least one non-empty string (the bot's id).
+ *     "First wins" is deterministic and matches operator expectation: if
+ *     someone hand-edits bot.yaml with multiple `agent-*` hints they meant
+ *     the top one.
+ *   - The returned id is the `name` minus the `agent-` prefix, normalized
+ *     through `deriveAgentId` so the cortex schema's `^[a-z0-9-]+$`
+ *     constraint holds (a hypothetical `agent-Echo` becomes `echo`).
+ *   - When no hint matches: return undefined and let the caller fall back
+ *     to legacy numeric suffixing.
+ */
+function detectAgentIdFromRoleHints(inst: LegacyDiscordInstance): string | undefined {
+  const roles = inst.roles;
+  if (!Array.isArray(roles)) return undefined;
+  for (const raw of roles) {
+    if (!raw || typeof raw !== "object") continue;
+    const role = raw as Record<string, unknown>;
+    const name = role.name;
+    if (typeof name !== "string" || !name.startsWith("agent-")) continue;
+    const users = role.users;
+    if (!Array.isArray(users)) continue;
+    const hasUser = users.some((u) => typeof u === "string" && u.trim().length > 0);
+    if (!hasUser) continue;
+    const stripped = name.slice("agent-".length);
+    if (stripped.length === 0) continue;
+    const id = deriveAgentId(stripped);
+    if (!AGENT_ID_PATTERN.test(id)) continue;
+    return id;
+  }
+  return undefined;
+}
+
+/**
  * Synthesize the cortex `agents[]` list from the singular legacy `agent` plus
  * the (possibly multi-entry) `discord[]` and `mattermost[]` arrays.
  *
- * Strategy (per RESUME §MIG-7.2e Agents synthesis):
+ * Strategy (per RESUME §MIG-7.2e Agents synthesis, refined by cortex#88
+ * item 3):
  *   - Pair discord[i] with mattermost[i] under one agent.
- *   - Index 0 → base agent id (deriveAgentId(agent.name)).
- *   - Index ≥1 → `${base}-${i + 1}` (so `luna-2`, `luna-3`).
- *   - Trust list propagates to every variant.
- *   - Persona path propagates to every variant.
+ *   - PRIMARY id source: scan each discord adapter's `roles[]` for the
+ *     legacy `agent-<name>` role-resolver hint with a non-empty `users[]`
+ *     (the bot's own Discord id). When found, that's the agent id.
+ *   - SECONDARY fallback: `deriveAgentId(agent.name)` (the singular legacy
+ *     field, what migrate-config used unconditionally before cortex#88
+ *     item 3 landed).
+ *   - LAST-RESORT fallback: numeric variant (`luna-2`, `luna-3`) when
+ *     neither hint nor agent.name produces a distinct id and the operator
+ *     has multiple adapters. Matches pre-#88 behaviour for parity.
+ *   - Trust list and persona path propagate to every variant.
  */
 function buildAgents(
   legacy: LegacyBotYaml,
@@ -422,9 +478,44 @@ function buildAgents(
     });
   }
 
+  // First pass: compute each variant's id using the cortex#88-item-3
+  // detection ladder (role-hint → agent.name → numeric). We need every id
+  // resolved before constructing presence blocks so collision-avoidance
+  // for the numeric fallback can see the IDs that the hint path already
+  // claimed.
+  const claimedIds = new Set<string>();
+  const variantIds: string[] = [];
+  for (let i = 0; i < variantCount; i++) {
+    const d = discordInstances[i];
+    let id: string | undefined;
+    if (d) {
+      id = detectAgentIdFromRoleHints(d);
+      if (id) {
+        warnings.push({
+          field: `agents[${i}].id`,
+          message:
+            `discord[${i}] agent id "${id}" inferred from role-resolver hint ` +
+            `(role name starting with "agent-" carrying a non-empty users[])`,
+        });
+      }
+    }
+    if (!id) {
+      // Fallback: agent.name (only safe for the first variant — subsequent
+      // variants need a distinct id, hence the numeric suffix at index ≥1).
+      id = i === 0 ? baseId : `${baseId}-${i + 1}`;
+    }
+    // Last-resort: a role-hint produced an id that collides with one
+    // already claimed by an earlier adapter. Fall through to numeric.
+    while (claimedIds.has(id)) {
+      id = `${baseId}-${variantIds.length + 1 + 1}`;
+    }
+    claimedIds.add(id);
+    variantIds.push(id);
+  }
+
   const agents: CortexConfig["agents"] = [];
   for (let i = 0; i < variantCount; i++) {
-    const variantId = i === 0 ? baseId : `${baseId}-${i + 1}`;
+    const variantId = variantIds[i]!;
     const presence: CortexConfig["agents"][number]["presence"] = {};
     const d = discordInstances[i];
     const m = mattermostInstances[i];

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -913,6 +913,53 @@ function checkSingleton(): void {
   }
 }
 
+// cortex#88 item 2 — `cortex start --dry-run` config validator.
+//
+// `scripts/postinstall.sh` already advertises `cortex start --config <path>
+// --dry-run` to operators as a post-migration sanity check. This helper
+// implements that contract: parse the file through the normal load path
+// (`loadConfigWithAgents`, which validates against both `BotConfigSchema`
+// and `CortexConfigSchema` depending on shape), print a one-line OK
+// summary, exit 0. Schema parse failures surface verbatim with exit 2 so
+// the postinstall path stays distinguishable from "file unreadable" (1).
+//
+// Exported so the unit tests can invoke it in-process with captured stdout
+// /stderr — the production CLI block below delegates to it as well. No
+// adapter startup, no NATS connect, no plist render, no daemon — purely
+// schema validation.
+export interface DryRunResult {
+  exitCode: 0 | 2;
+  stdout: string;
+  stderr: string;
+}
+
+export function runDryRun(configPath: string): DryRunResult {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  try {
+    const { config, inlineAgents } = loadConfigWithAgents(configPath);
+    // For cortex-shape input `inlineAgents.length` is the canonical agent
+    // count (operator perspective). Legacy bot.yaml carries one singular
+    // `agent:` field — fall back to 1 in that case so the operator sees a
+    // truthful number rather than `0 agents` on a working legacy config.
+    const agentCount = inlineAgents.length > 0 ? inlineAgents.length : 1;
+    const rendererCount = config.renderers?.length ?? 0;
+    const natsUrl = config.nats?.url ?? "(disabled)";
+    stdout.push(
+      `cortex config validation OK — ${agentCount} agents, ${rendererCount} renderers, NATS=${natsUrl}`,
+    );
+    return { exitCode: 0, stdout: stdout.join("\n") + "\n", stderr: stderr.join("\n") };
+  } catch (err) {
+    // Operator-readable: surface the Zod-shaped message verbatim. The
+    // schema's own error formatter is already field-pathed (`agent.name:
+    // Required`, etc.) so we don't try to re-pretty-print here.
+    stderr.push(
+      `cortex config validation FAILED: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return { exitCode: 2, stdout: stdout.join("\n"), stderr: stderr.join("\n") + "\n" };
+  }
+}
+
 // `import.meta.main` is true only when this file is the CLI entrypoint.
 // Skipping the CLI wiring at module load is what lets tests
 // `import { startCortex }` here without parsing argv or registering signal
@@ -927,7 +974,17 @@ if (import.meta.main) {
     .command("start")
     .description("Start the bot")
     .option("--config <path>", "Path to bot config YAML", DEFAULT_CONFIG)
+    .option("--dry-run", "Validate config file and exit (no adapter / NATS / daemon startup)")
     .action(async (options) => {
+      // cortex#88 item 2 — short-circuit: skip PID file, signal handlers,
+      // and the full startCortex pipeline. Just parse + validate the config.
+      if (options.dryRun) {
+        const result = runDryRun(options.config);
+        if (result.stdout) process.stdout.write(result.stdout);
+        if (result.stderr) process.stderr.write(result.stderr);
+        process.exit(result.exitCode);
+      }
+
       mkdirSync(STATE_DIR, { recursive: true });
       checkSingleton();
       writeFileSync(PID_FILE, String(process.pid));


### PR DESCRIPTION
Remainder of cortex#88 — the four items deferred from cortex#95 (the
quick-win subset of the v1 cutover follow-ups). With this PR landed,
cortex#88 closes.

Refs #88. When this merges, tick these checkboxes on the issue:

- [x] Item 2 — `cortex start --dry-run` advertised in docs but not implemented
- [x] Item 3 — `migrate-config` emits agent IDs as `luna`/`luna-2`/`luna-3` regardless of identity
- [x] Item 4 — `migrate-config` repeats the same `agentChannelId` across agents
- [x] Item 8 — v1 cutover docs missing the `leafnodes[].account` requirement for operator-mode

`closes cortex#88` — issue auto-closes on merge.

## What landed

**Item 2 — `cortex start --dry-run` (`src/cortex.ts` + `src/__tests__/cortex.test.ts`)**

New Commander option `--dry-run` on `cortex start`. Validation
logic extracted into an exported `runDryRun(configPath)` helper so
unit tests can invoke it in-process. On success: prints
`cortex config validation OK — N agents, M renderers, NATS=<url>`
to stdout, exit 0. On failure: prints
`cortex config validation FAILED: <schema-error>` to stderr, exit 2.
No adapter / NATS / plist / daemon startup — short-circuit lives
before `mkdirSync(STATE_DIR)` + `checkSingleton()`. Unblocks the
recipe `scripts/postinstall.sh` has been advertising at line 70.

**Item 3 — agent id detection (`src/cli/cortex/commands/migrate-config-lib.ts`)**

New `detectAgentIdFromRoleHints()` helper scans each
`discord[i].roles[]` for the legacy `agent-<name>` role-resolver
hint (the role whose `users[]` carries the bot's own Discord id).
When found, the stripped name becomes the cortex agent id.

Detection ladder:

  1. Role-resolver hint
  2. `deriveAgentId(agent.name)` (pre-#88 behaviour at index 0)
  3. Numeric variant (`luna-2`, `luna-3`) — last resort for index ≥1
     or hint-derived id collisions

Per-adapter warning surfaces the inference for operator audit.

**Item 4 — shared agentChannelId warning (same file)**

New `detectSharedAgentChannelId()` runs after `buildAgents()`. When
2+ converted agents share the same `presence.discord.agentChannelId`,
emits one warning per distinct shared id:

```
WARN: migrate-config: agents [luna,echo,forge] share agentChannelId
1487029848164536361 — set distinct channels in cortex.yaml for
per-agent log routing
```

The field is NOT blanked — an operator may genuinely want shared
log routing. Warning surfaces, operator decides.

**Item 8 — operator-mode + leafnode docs (`docs/plan-cortex-migration.md`)**

New §9 covering the v1 cutover operator-mode recipe end-to-end:

  - §9.1 Why operator mode demands `account:` on leafnode remotes
  - §9.2 The required YAML injection (placeholder A-prefixed pubkey
    + the `nsc list accounts` / `nsc describe account` invocations
    to find your real one)
  - §9.3 Cutover sequence (snapshot → generate → merge → inject →
    restart → verify cortex via `cortex start --dry-run`)
  - §9.4 Rollback path (no cortex restart needed; bot reconnects)

The §9 placement matches the brief — keeps the existing v1 recipe
context co-located rather than spinning up a separate
`sop-operator-mode-nats.md`.

## Test plan

- [x] `bunx tsc --noEmit` — clean across the repo
- [x] `bun test src/cli/cortex/ src/__tests__/cortex.test.ts` — 255 pass / 0 fail
- [x] Full suite: `bun test` — 2448 pass / 1 skip / 0 fail
- [x] Added focused regression tests:
  - `runDryRun — config validator (cortex#88 item 2)` — success / NATS-disabled / schema-failure
  - `convertBotYaml — agent id detection (cortex#88 item 3)` — hint present (single + multi-discord) / no hint → agent.name / no hint multi → numeric / first-hint-wins / empty users[] ignored
  - `convertBotYaml — shared agentChannelId warning (cortex#88 item 4)` — warn fires for 3 sharers (exact message format verbatim) / warn skipped for distinct ids / warn skipped for single agent

## Notes for review

- Item 3 + Item 4 touch `migrate-config-lib.ts` which cortex#95 also touched. The `rewritePaths()` helper + the `mkdirSync` in `migrate-config.ts` are preserved unchanged.
- The dry-run validator goes through `loadConfigWithAgents` (not directly `CortexConfigSchema.parse`) so it handles BOTH legacy `bot.yaml` and cortex-shape `cortex.yaml` inputs — matches what `cortex start` (the non-dry path) does in production.