### PR TITLE
fix(cutover): tidy-up — collision + duplicate-hint + §9 cross-refs + dry-run zero-agent (closes cortex#106)

### DIFF
--- a/docs/plan-cortex-migration.md
+++ b/docs/plan-cortex-migration.md
@@ -730,6 +730,23 @@ configuration while debugging the operator-mode setup offline. Cortex
 itself does not need to be restarted — the bot reconnects to the
 re-loaded NATS server within a few seconds.
 
+### 9.5 Related work
+
+The operator-mode pivot only carries weight end-to-end alongside the code
+landings that make a federated, signed, trust-aware fabric usable. Cross-
+references so a reader of §9 can navigate to the related primitives:
+
+- [cortex#86 — NatsLink credsAuthenticator support](https://github.com/the-metafactory/cortex/issues/86):
+  landed the daemon's own connect path against operator-mode NATS
+  (creds-based authenticator wired into the in-process bot↔server link).
+  Without #86 the bot can connect to a mem-resolver server but not to an
+  operator-mode one — §9 assumes #86 is in place.
+- [cortex#98 — TrustResolver auto-populate `trustedBotIds`](https://github.com/the-metafactory/cortex/issues/98):
+  landed the inter-bot allowlist so peer bots inside the same cortex
+  instance can DM each other under the operator-mode signing universe.
+  Without #98 the per-agent `trust:` lists in cortex.yaml are honoured
+  for outbound trust but inbound trust silently drops peer messages.
+
 ---
 
 *This plan is the ground truth for the migration. When reality drifts from it, update the plan first, then the world. For "what cortex IS" architecture, see `docs/design-cortex.md`.*

--- a/src/__tests__/cortex.test.ts
+++ b/src/__tests__/cortex.test.ts
@@ -726,4 +726,33 @@ describe("runDryRun — config validator (cortex#88 item 2)", () => {
     expect(result.stdout).toBe("");
     rmSync(dir, { recursive: true, force: true });
   });
+
+  test("cortex#106 item 4: legacy bot.yaml shape (no inlineAgents) exits 2", () => {
+    // Pre-cortex#106: a legacy bot.yaml with a valid singular `agent:` block
+    // loaded fine, the loader returned `inlineAgents: []`, and dry-run
+    // reported "1 agents" via a hardcoded fallback that masked the
+    // degenerate case. Post-cortex#106: report the actual zero-agent count
+    // and exit non-zero so the operator sees the config is invalid for
+    // the cortex-shape pipeline.
+    const dir = mkdtempSync(join(tmpdir(), "cortex-dryrun-zero-"));
+    const cfgPath = join(dir, "bot.yaml");
+    writeFileSync(
+      cfgPath,
+      [
+        "agent:",
+        "  name: luna",
+        "  displayName: Luna",
+        "discord: []",
+        "mattermost: []",
+        "claude: {}",
+        "",
+      ].join("\n"),
+      "utf-8",
+    );
+    const result = runDryRun(cfgPath);
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr).toMatch(/has no agents — config invalid/);
+    expect(result.stdout).toBe("");
+    rmSync(dir, { recursive: true, force: true });
+  });
 });

--- a/src/cli/cortex/commands/__tests__/migrate-config.test.ts
+++ b/src/cli/cortex/commands/__tests__/migrate-config.test.ts
@@ -827,6 +827,95 @@ describe("convertBotYaml — agent id detection (cortex#88 item 3)", () => {
 });
 
 // ---------------------------------------------------------------------------
+// cortex#106 items 1 + 2 — collision-fallback off-by-one + duplicate-hint warn
+// ---------------------------------------------------------------------------
+
+describe("convertBotYaml — collision fallback numbering (cortex#106 item 1)", () => {
+  test("three adapters all hinting the same id walk luna, luna-2, luna-3", () => {
+    // Pathological config: three adapters all carry `agent-luna` hints. The
+    // first wins via the hint path; subsequent collisions must walk the
+    // numeric ladder cleanly (`luna-2`, `luna-3`). Pre-cortex#106 the
+    // fallback formula carried `+1+1`, jumping to `luna-3`, `luna-4`.
+    const legacy: LegacyBotYaml = {
+      agent: { name: "luna", displayName: "Luna", personaFile: "./personas/luna.md" },
+      discord: [
+        {
+          token: "t1", guildId: "1", agentChannelId: "2", logChannelId: "3",
+          roles: [{ name: "agent-luna", users: ["100000000000000001"], features: ["chat"] }],
+        },
+        {
+          token: "t2", guildId: "10", agentChannelId: "20", logChannelId: "30",
+          roles: [{ name: "agent-luna", users: ["200000000000000002"], features: ["chat"] }],
+        },
+        {
+          token: "t3", guildId: "100", agentChannelId: "200", logChannelId: "300",
+          roles: [{ name: "agent-luna", users: ["300000000000000003"], features: ["chat"] }],
+        },
+      ],
+    };
+    const result = convertBotYaml(legacy, {});
+    expect(result.cortex.agents.map((a) => a.id)).toEqual(["luna", "luna-2", "luna-3"]);
+  });
+});
+
+describe("convertBotYaml — duplicate hint across adapters (cortex#106 item 2)", () => {
+  test("warn fires when two adapters both claim the same `agent-<X>` hint", () => {
+    // Operator misconfigured: two adapters both declare an `agent-echo`
+    // role-resolver hint. The first wins (id="echo"); the second falls
+    // back to numeric (`luna-2`). A WARN surfaces the collision so the
+    // operator sees it instead of silently inheriting the wrong identity.
+    const legacy: LegacyBotYaml = {
+      agent: { name: "luna", displayName: "Luna", personaFile: "./personas/luna.md" },
+      discord: [
+        {
+          token: "t1", guildId: "1", agentChannelId: "2", logChannelId: "3",
+          roles: [{ name: "agent-echo", users: ["100000000000000001"], features: ["chat"] }],
+        },
+        {
+          token: "t2", guildId: "10", agentChannelId: "20", logChannelId: "30",
+          roles: [{ name: "agent-echo", users: ["200000000000000002"], features: ["chat"] }],
+        },
+      ],
+    };
+    const result = convertBotYaml(legacy, {});
+    expect(result.cortex.agents.map((a) => a.id)).toEqual(["echo", "luna-2"]);
+    const dupWarn = result.warnings.find((w) =>
+      w.message.includes("both claim agent-echo hint"),
+    );
+    expect(dupWarn).toBeDefined();
+    expect(dupWarn!.message).toMatch(/agents \[echo,luna-2\] both claim agent-echo hint/);
+    expect(dupWarn!.message).toMatch(/first wins; second falls back to numeric/);
+    expect(dupWarn!.field).toBe("agents[1].id");
+  });
+
+  test("warn does NOT fire when each adapter declares a distinct `agent-<X>` hint", () => {
+    // Healthy config: three adapters, three distinct hints. No duplicate-
+    // hint warning should appear.
+    const legacy: LegacyBotYaml = {
+      agent: { name: "luna", displayName: "Luna", personaFile: "./personas/luna.md" },
+      discord: [
+        {
+          token: "t1", guildId: "1", agentChannelId: "2", logChannelId: "3",
+          roles: [{ name: "agent-luna", users: ["100000000000000001"], features: ["chat"] }],
+        },
+        {
+          token: "t2", guildId: "10", agentChannelId: "20", logChannelId: "30",
+          roles: [{ name: "agent-echo", users: ["200000000000000002"], features: ["chat"] }],
+        },
+        {
+          token: "t3", guildId: "100", agentChannelId: "200", logChannelId: "300",
+          roles: [{ name: "agent-forge", users: ["300000000000000003"], features: ["chat"] }],
+        },
+      ],
+    };
+    const result = convertBotYaml(legacy, {});
+    expect(result.cortex.agents.map((a) => a.id)).toEqual(["luna", "echo", "forge"]);
+    const dupWarns = result.warnings.filter((w) => w.message.includes("both claim agent-"));
+    expect(dupWarns).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // cortex#88 item 4 — shared agentChannelId across agents
 // ---------------------------------------------------------------------------
 

--- a/src/cli/cortex/commands/migrate-config-lib.ts
+++ b/src/cli/cortex/commands/migrate-config-lib.ts
@@ -527,13 +527,19 @@ function buildAgents(
   // for the numeric fallback can see the IDs that the hint path already
   // claimed.
   const claimedIds = new Set<string>();
+  // cortex#106 item 2: track which agent id first claimed each `agent-<X>`
+  // hint so a second adapter declaring the same hint surfaces a WARN
+  // instead of silently falling through to numeric numbering.
+  const hintFirstClaimer = new Map<string, string>();
   const variantIds: string[] = [];
   for (let i = 0; i < variantCount; i++) {
     const d = discordInstances[i];
+    let hintId: string | undefined;
     let id: string | undefined;
     if (d) {
-      id = detectAgentIdFromRoleHints(d);
-      if (id) {
+      hintId = detectAgentIdFromRoleHints(d);
+      if (hintId) {
+        id = hintId;
         warnings.push({
           field: `agents[${i}].id`,
           message:
@@ -549,8 +555,28 @@ function buildAgents(
     }
     // Last-resort: a role-hint produced an id that collides with one
     // already claimed by an earlier adapter. Fall through to numeric.
+    // cortex#106 item 1: drop the off-by-one — `variantIds.length` is the
+    // index of the variant being assigned, so `+1` yields the right suffix
+    // (`luna-2` at i=1, `luna-3` at i=2), not `luna-3`/`luna-4`.
     while (claimedIds.has(id)) {
-      id = `${baseId}-${variantIds.length + 1 + 1}`;
+      id = `${baseId}-${variantIds.length + 1}`;
+    }
+    // cortex#106 item 2: duplicate `agent-<X>` hint across adapters —
+    // operator misconfigured two adapters to both claim the same identity.
+    // Emit once per duplicated hint (the second adapter's appearance) so
+    // the operator sees both adapter ids and the resolved numeric fallback.
+    if (hintId !== undefined) {
+      const firstClaimer = hintFirstClaimer.get(hintId);
+      if (firstClaimer !== undefined) {
+        warnings.push({
+          field: `agents[${i}].id`,
+          message:
+            `WARN: migrate-config: agents [${firstClaimer},${id}] both claim ` +
+            `agent-${hintId} hint — first wins; second falls back to numeric`,
+        });
+      } else {
+        hintFirstClaimer.set(hintId, id);
+      }
     }
     claimedIds.add(id);
     variantIds.push(id);

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -1048,11 +1048,19 @@ export function runDryRun(configPath: string): DryRunResult {
   const stderr: string[] = [];
   try {
     const { config, inlineAgents } = loadConfigWithAgents(configPath);
-    // For cortex-shape input `inlineAgents.length` is the canonical agent
-    // count (operator perspective). Legacy bot.yaml carries one singular
-    // `agent:` field — fall back to 1 in that case so the operator sees a
-    // truthful number rather than `0 agents` on a working legacy config.
-    const agentCount = inlineAgents.length > 0 ? inlineAgents.length : 1;
+    // cortex#106 item 4: clamp to the actual length — don't mask a degenerate
+    // "no agents" config behind a fallback of 1. For cortex-shape input
+    // `CortexConfigSchema.agents.min(1)` enforces ≥1 at parse time, so a
+    // zero here means a legacy bot.yaml shape that the loader returned with
+    // empty `inlineAgents` AND no synthesized singular agent — surface that
+    // as a hard failure rather than reporting "1 agent" misleadingly.
+    const agentCount = inlineAgents.length;
+    if (agentCount === 0) {
+      stderr.push(
+        `cortex config validation FAILED: ${configPath} has no agents — config invalid`,
+      );
+      return { exitCode: 2, stdout: stdout.join("\n"), stderr: stderr.join("\n") + "\n" };
+    }
     const rendererCount = config.renderers?.length ?? 0;
     const natsUrl = config.nats?.url ?? "(disabled)";
     stdout.push(


### PR DESCRIPTION
## Summary

Echo's round-1 follow-up findings on cortex#104. Four surgical fixes; cortex#104 merged with these deferred per the pilot-loop SOP.

## Items

- [x] **Item 1** — `detectAgentIdFromRoleHints` collision-fallback off-by-one
  - `src/cli/cortex/commands/migrate-config-lib.ts` (was line 553) — collision-fallback formula dropped from `${baseId}-${variantIds.length + 1 + 1}` → `${baseId}-${variantIds.length + 1}`. Pre-fix, three adapters all hinting `agent-luna` walked `luna`, `luna-3`, `luna-4`; post-fix they walk `luna`, `luna-2`, `luna-3`.
  - Test: `convertBotYaml — collision fallback numbering (cortex#106 item 1)` in `src/cli/cortex/commands/__tests__/migrate-config.test.ts`

- [x] **Item 2** — Duplicate `agent-<X>` hint across adapters silently falls through
  - Same file — added `hintFirstClaimer: Map<string, string>` to track which agent id first claimed each hint, and emit `WARN: migrate-config: agents [a,b] both claim agent-<X> hint — first wins; second falls back to numeric` when a second adapter declares the same hint. Once per duplicated hint, attached to `agents[i].id` where `i` is the second adapter's index.
  - Tests: `convertBotYaml — duplicate hint across adapters (cortex#106 item 2)` — covers the warn-fires case AND the no-spurious-warn case for the healthy three-distinct-hints config (grove production shape).

- [x] **Item 3** — §9 missing cross-refs to cortex#86 + cortex#98
  - `docs/plan-cortex-migration.md` — added §9.5 "Related work" linking cortex#86 (NatsLink credsAuthenticator — the daemon's own connect path against operator-mode NATS) and cortex#98 (TrustResolver auto-populate — the inter-bot allowlist). §9 now stands as the operator's recipe AND the navigation hub to the code work the recipe depends on.

- [x] **Item 4** — Dry-run agent count fallback to 1
  - `src/cortex.ts` `runDryRun` — clamp `agentCount` to `inlineAgents.length` (drop the `> 0 ? : 1` mask) and exit 2 with `cortex config validation FAILED: <path> has no agents — config invalid` when zero. `CortexConfigSchema.agents.min(1)` enforces ≥1 for cortex-shape input at parse time, so the new path fires only for the legacy bot.yaml shape (loader returns `inlineAgents: []`) — exactly the regression-into-cortex case dry-run is meant to detect.
  - Test: `cortex#106 item 4: legacy bot.yaml shape (no inlineAgents) exits 2` in `src/__tests__/cortex.test.ts`

## Test coverage

```
bun test src/cli/cortex/commands/__tests__/migrate-config.test.ts   →  74 pass, 0 fail
bun test src/__tests__/cortex.test.ts                                →  18 pass, 0 fail
bun test                                                              →  2465 pass, 0 fail, 1 skip
bunx tsc --noEmit                                                     →  clean
```

## Diff scope

```
docs/plan-cortex-migration.md                            | +17     (item 3 — cross-refs only)
src/__tests__/cortex.test.ts                             | +29     (item 4 test)
src/cli/cortex/commands/__tests__/migrate-config.test.ts | +89     (items 1+2 tests)
src/cli/cortex/commands/migrate-config-lib.ts            |  +29/-3 (items 1+2 logic)
src/cortex.ts                                            |  +13/-5 (item 4 logic)
                                                           -----------
                                                            +177/-8 (mostly tests + comments)
```

Surgical — no changes to cortex#104's `rewritePaths()` / `mkdirSync` / `detectSharedAgentChannelId`. No refactoring of unrelated code.

closes cortex#106