### PR TITLE
fix(routing): drop isPrivateChannel gate from auto-thread (follow-up to cortex#121)

### DIFF
--- a/src/adapters/discord/index.ts
+++ b/src/adapters/discord/index.ts
@@ -431,7 +431,17 @@ export class DiscordAdapter implements PlatformAdapter {
       //     but with `trustedBotIds` peer-mentions can also reach this
       //     point — we don't want adapter A auto-threading on a message
       //     that mentions adapter B.
-      if (!isDM && !isThread && !isPrivateChannel) {
+      // cortex#122: drop the `!isPrivateChannel` gate. That heuristic is
+      // `channel.members?.size === 2` — without the `GuildMembers` intent
+      // (cortex's client only enables `Guilds` + `GuildMessages`), the
+      // bot's `members` collection is a CACHE of users it has seen, not
+      // the real guild member list. In #cortex with only the bot + the
+      // pinging peer cached, `members.size === 2` evaluates true → the
+      // auto-thread block skips when it shouldn't. We don't need the
+      // private-channel gate here anyway: a real group DM would have
+      // `channel.type === ChannelType.GroupDM` and we'd want auto-thread
+      // there too in principle. The DM + thread gates remain.
+      if (!isDM && !isThread) {
         // Match against the RAW Discord content (`message.content`),
         // not `finalContent` — the latter has the @-mention stripped by
         // `extractContent`, and the wire format anchors on `<@bot>`.


### PR DESCRIPTION
## Symptom

cortex#121 landed the auto-thread on `review <repo>#<N>` wire format. On Andreas's host the gate skipped on every ping — auto-thread never fired. Diagnosed by tailing the bot log during a fresh \`<@EchoID> review cortex#121\` ping: the \`discord-echo-discord: channel=\"cortex\"\` log fires (messageCreate runs) and the dispatch-handler responds, but the auto-thread log line is missing.

## Root cause

\`isPrivateChannel\` in \`src/adapters/discord/index.ts\` is computed as \`channel.members?.size === 2\`. Cortex's Discord client (\`src/adapters/discord/client.ts\`) only enables \`Guilds\` + \`GuildMessages\` intents — NOT \`GuildMembers\`. So \`channel.members\` is a CACHE of users the bot has seen, not the real guild roster. In #cortex with only the bot + the pinging peer cached, \`members.size === 2\` evaluates true → \`isPrivateChannel\` becomes true → auto-thread block short-circuits.

## Fix

Drop the \`!isPrivateChannel\` gate from the auto-thread block. Keep DM + thread gates. The private-channel gate isn't needed for review-wire-format auto-threading anyway: a genuine group DM has \`channel.type === ChannelType.GroupDM\` (not detected by the members.size heuristic).

## Diff

- \`src/adapters/discord/index.ts:434\` — \`!isDM && !isThread && !isPrivateChannel\` → \`!isDM && !isThread\`. 1-line gate change + docstring explaining the cache-vs-intent reason.

## Verification

- \`bun test src/adapters/discord/\` — 154/154 pass, 0 fail (auto-thread tests already mocked the path; this PR is a gate change, not a logic change)
- \`bunx tsc --noEmit\` clean
- Manual test (post-merge + arc upgrade): Luna pings Echo → \`cortex/pr/<N>\` thread created, Echo replies in-thread

## Out of scope

- Echo's nits from cortex#121 review (N1 archived-thread re-creation, N2 race, N3 channel-type cases, N4 missing telemetry envelope) — all carry forward as separate follow-ups
- Fixing \`isPrivateChannel\` semantics globally — that's a discord-client.ts intent decision the operator should make consciously (and may want to enable \`GuildMembers\` for other reasons)

## Review

\`recommend: merge\` on a clean run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)