### PR TITLE
feat(substrates): SessionHarness interface + ClaudeCodeHarness (refs cortex#113)

### DIFF
--- a/src/common/substrates/__tests__/types.test.ts
+++ b/src/common/substrates/__tests__/types.test.ts
@@ -1,0 +1,250 @@
+/**
+ * IAW Phase A.1 — Type-level smoke tests for the substrate harness protocol.
+ *
+ * These tests don't exercise behaviour (there's none — types.ts is pure
+ * types). Instead they pin the *shape* of each exported type so a future
+ * accidental rename (e.g. `allow[]` → `tools[]`) is caught at PR time
+ * rather than at downstream import sites.
+ *
+ * **Coverage axes:**
+ *   1. `HarnessId` enumerates all 7 known substrates (cortex#91 §F).
+ *      Adding/removing a value is a typed change that fails this test
+ *      until the test list is updated — forcing the author to think
+ *      about which downstream switch statements need updating.
+ *   2. Each interface is instantiable with its minimum required fields,
+ *      and each optional field is independently omissible.
+ *   3. `SessionHarness.dispatch()` returns something awaitable as an
+ *      async iterable (compile-time + one runtime drain).
+ *   4. `ToolCapability.allow` is a `string[]` (not enum) — confirming
+ *      the Q1-α "harness-native strings, no translation" lock-in.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type {
+  Capability,
+  DispatchRequest,
+  HarnessId,
+  MyelinEnvelope,
+  SessionHarness,
+  ToolCapability,
+} from "../types";
+
+// ---------------------------------------------------------------------------
+// HarnessId exhaustiveness
+// ---------------------------------------------------------------------------
+
+describe("HarnessId", () => {
+  /**
+   * Exhaustive list of known substrates per cortex#91 §F. Update both this
+   * array AND the `HarnessId` union when adding a new substrate — drift is
+   * the bug this test exists to catch.
+   */
+  const ALL_HARNESS_IDS: HarnessId[] = [
+    "claude-code",
+    "bus-peer",
+    "openai-codex",
+    "cursor",
+    "gemini",
+    "mistral",
+    "pi-dev",
+  ];
+
+  test("includes all seven known substrates", () => {
+    expect(ALL_HARNESS_IDS).toHaveLength(7);
+  });
+
+  test("exhaustive switch compiles for all seven values", () => {
+    // If a new HarnessId is added without updating this switch, tsc fails
+    // (the `never` assignment becomes ill-typed). Compile-time proof that
+    // every downstream switch must enumerate the union exhaustively.
+    function exhaustive(id: HarnessId): string {
+      switch (id) {
+        case "claude-code": return "cc";
+        case "bus-peer": return "bp";
+        case "openai-codex": return "codex";
+        case "cursor": return "cursor";
+        case "gemini": return "gemini";
+        case "mistral": return "mistral";
+        case "pi-dev": return "pi";
+        default: {
+          const _exhaustive: never = id;
+          return _exhaustive;
+        }
+      }
+    }
+    expect(exhaustive("claude-code")).toBe("cc");
+    expect(exhaustive("bus-peer")).toBe("bp");
+    expect(exhaustive("pi-dev")).toBe("pi");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Capability
+// ---------------------------------------------------------------------------
+
+describe("Capability", () => {
+  test("minimum-required shape compiles", () => {
+    const cap: Capability = {
+      id: "code-review",
+      description: "Reviews PRs for correctness and style",
+    };
+    expect(cap.id).toBe("code-review");
+    expect(cap.tags).toBeUndefined();
+  });
+
+  test("with optional tags compiles", () => {
+    const cap: Capability = {
+      id: "code-review.typescript",
+      description: "TypeScript-aware code review",
+      tags: ["typescript", "code-review"],
+    };
+    expect(cap.tags).toEqual(["typescript", "code-review"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ToolCapability
+// ---------------------------------------------------------------------------
+
+describe("ToolCapability", () => {
+  test("allow is a plain string array (Q1-α — substrate-native)", () => {
+    const tools: ToolCapability = {
+      allow: ["Bash", "Edit", "Write"],
+    };
+    // string[] (not enum) — proves the harness can pass any substrate's
+    // native tool vocabulary through without cortex-side translation.
+    expect(tools.allow).toEqual(["Bash", "Edit", "Write"]);
+    expect(tools.deny).toBeUndefined();
+  });
+
+  test("deny is independently optional", () => {
+    const tools: ToolCapability = {
+      allow: ["*"],
+      deny: ["WebFetch"],
+    };
+    expect(tools.deny).toEqual(["WebFetch"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DispatchRequest
+// ---------------------------------------------------------------------------
+
+describe("DispatchRequest", () => {
+  test("minimum-required shape compiles", () => {
+    const req: DispatchRequest = {
+      persona: { path: "/agents/cortex.md", content: "# Cortex persona" },
+      prompt: "say hello",
+      tools: { allow: ["Bash"] },
+      context: [],
+      agent: { id: "cortex", displayName: "Cortex" },
+      requestId: "00000000-0000-4000-8000-000000000000",
+    };
+    expect(req.timeoutMs).toBeUndefined();
+    expect(req.inactivityMs).toBeUndefined();
+    expect(req.agent.runtime).toBeUndefined();
+  });
+
+  test("with Q6 timeouts and runtime hint compiles", () => {
+    const req: DispatchRequest = {
+      persona: { path: "/agents/luna.md", content: "# Luna" },
+      prompt: "review this PR",
+      tools: { allow: ["Read", "Grep"], deny: ["Bash"] },
+      context: [
+        { kind: "discord-history", data: [{ author: "andreas", text: "hi" }] },
+        { kind: "env", data: { operator: "andreas", entity: "pr/45" } },
+      ],
+      agent: {
+        id: "luna",
+        displayName: "Luna",
+        runtime: { harness: "claude-code" },
+      },
+      requestId: "11111111-1111-4111-8111-111111111111",
+      timeoutMs: 300_000,
+      inactivityMs: 60_000,
+    };
+    expect(req.agent.runtime?.harness).toBe("claude-code");
+    expect(req.timeoutMs).toBe(300_000);
+    expect(req.inactivityMs).toBe(60_000);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SessionHarness
+// ---------------------------------------------------------------------------
+
+describe("SessionHarness", () => {
+  /**
+   * A trivial in-test harness implementation. Used to assert the interface
+   * is implementable end-to-end (the type-check + the runtime drain both
+   * prove no field is unimplementable).
+   */
+  class NoopHarness implements SessionHarness {
+    readonly id: HarnessId = "claude-code";
+    readonly capabilities: Capability[] = [
+      { id: "noop", description: "Does nothing" },
+    ];
+
+    async *dispatch(_req: DispatchRequest): AsyncIterable<MyelinEnvelope> {
+      // Yield a synthetic terminal envelope — minimal valid shape per
+      // the validator's required fields.
+      yield {
+        id: "00000000-0000-4000-8000-000000000001",
+        source: "metafactory.cortex.test",
+        type: "dispatch.task.completed",
+        timestamp: new Date().toISOString(),
+        sovereignty: {
+          classification: "local",
+          data_residency: "NZ",
+          max_hop: 0,
+          frontier_ok: false,
+          model_class: "local-only",
+        },
+        payload: { task_id: _req.requestId, agent_id: _req.agent.id },
+      };
+    }
+
+    async shutdown(_opts: { graceful: boolean }): Promise<void> {
+      // No-op — proves the optional method can be implemented as a
+      // single Promise<void>.
+    }
+  }
+
+  test("interface is implementable end-to-end", async () => {
+    const harness: SessionHarness = new NoopHarness();
+    expect(harness.id).toBe("claude-code");
+    expect(harness.capabilities).toHaveLength(1);
+    expect(harness.shutdown).toBeDefined();
+  });
+
+  test("dispatch yields at least one terminal envelope", async () => {
+    const harness: SessionHarness = new NoopHarness();
+    const req: DispatchRequest = {
+      persona: { path: "/p.md", content: "" },
+      prompt: "x",
+      tools: { allow: [] },
+      context: [],
+      agent: { id: "test", displayName: "Test" },
+      requestId: "22222222-2222-4222-8222-222222222222",
+    };
+
+    const collected: MyelinEnvelope[] = [];
+    for await (const env of harness.dispatch(req)) {
+      collected.push(env);
+    }
+    expect(collected.length).toBeGreaterThanOrEqual(1);
+    expect(collected.at(-1)?.type).toBe("dispatch.task.completed");
+  });
+
+  test("shutdown is optional — harness may omit it", () => {
+    class MinimalHarness implements SessionHarness {
+      readonly id: HarnessId = "bus-peer";
+      readonly capabilities: Capability[] = [];
+      async *dispatch(_req: DispatchRequest): AsyncIterable<MyelinEnvelope> {
+        // never yields — placeholder for shape test only
+      }
+    }
+    const h: SessionHarness = new MinimalHarness();
+    expect(h.shutdown).toBeUndefined();
+  });
+});

--- a/src/common/substrates/types.ts
+++ b/src/common/substrates/types.ts
@@ -1,0 +1,429 @@
+/**
+ * IAW Phase A.1 (cortex#113) — Substrate harness protocol types.
+ *
+ * Origin: cortex#91 — "design: SessionHarness interface — multi-substrate
+ * agent dispatch". Synthesis: cortex#110 / cortex#112 / the IAW design doc
+ * (`docs/design-internet-of-agentic-work.md`) §3.1, §4 "cortex#91".
+ *
+ * **What this file is.** A pure-type contract that lets cortex's runner
+ * dispatch a task to an execution substrate (Claude Code in-process, an
+ * out-of-process bus peer like sage, a future Codex/Cursor/Gemini/Mistral
+ * CLI, a direct pi.dev call) without the caller knowing which one is
+ * actually on the other side. The shape mirrors `MyelinRuntime` so the
+ * dispatch contract reads symmetrically across substrate boundaries.
+ *
+ * **Why types-only.** Phase A.1 freezes the interface; Phase A.1b flips
+ * dispatch-listener over; Phases A.2–A.5 evolve the envelope/subject layer
+ * underneath. Keeping types and implementation in separate PRs limits the
+ * blast radius of each cutover.
+ *
+ * **OSI/M1–M7 layering** (design doc §1):
+ *   - This protocol sits at **M6 (composition)**. It's application-layer
+ *     glue between the runner (M7) and any execution substrate. It does
+ *     NOT define wire format (that's M3 — myelin envelope) and does NOT
+ *     define transport (that's M2 — `MyelinRuntime`). It only defines the
+ *     *function-call shape* between a cortex agent and its substrate.
+ *   - The async-iterable yield contract is what makes the protocol
+ *     symmetric between in-process spawn substrates (events arrive as
+ *     stream-json from a child) and bus-peer substrates (envelopes arrive
+ *     via NATS subscription on `local.{op}.{stack}.dispatch.<id>.>`).
+ *
+ * **Q-lock-ins consulted (design doc §5, 2026-05-13 Andreas):**
+ *   - **Q1-α (tool capability format).** `ToolCapability.allow[]` is
+ *     harness-native strings — no cross-substrate translation layer in
+ *     cortex. Claude Code sees `["Bash", "Edit", "Write"]`, a future
+ *     Codex harness would see `["exec"]`. Cortex stays out of the
+ *     translation business. See `ToolCapability` doc.
+ *   - **Q1 (stack identity).** `agent.id` accepts a string today; the
+ *     `{operator_id}/{stack_id}` shape is enforced by cortex.yaml's
+ *     `stack:` block in Phase A.5 — not at this protocol layer. A.1 only
+ *     needs the type to *carry* the identity.
+ *   - **Q5 (streaming subject convention).** `DispatchRequest.requestId`
+ *     is the subject suffix for `local.{op}.{stack}.dispatch.<harnessId>.<requestId>.{progress|complete|error|timeout}`.
+ *     This file types the semantic but does NOT wire NATS publishing —
+ *     that's Phase B's NKey-signed envelope work.
+ *   - **Q6 (timeout semantics).** Two caps that race, first-to-expire
+ *     wins: wall-clock (default 300_000ms) AND inactivity between
+ *     envelopes (default 60_000ms). See `DispatchRequest.timeoutMs` /
+ *     `inactivityMs` docs.
+ *   - **Q7 (stack as protocol primitive).** Subject namespace gains a
+ *     `{stack}` segment — typed via the implicit shape of `requestId`'s
+ *     position in the subject. A.5 work materialises the cortex.yaml side.
+ *
+ * **What this file is NOT.**
+ *   - NOT a transport — `MyelinRuntime.publish()` and `subscribe()` still
+ *     own NATS publishing. Harnesses produce envelopes; the surface-router
+ *     decides where (and whether) to publish them.
+ *   - NOT an envelope schema — `MyelinEnvelope` (alias for `Envelope` in
+ *     `src/bus/myelin/envelope-validator.ts`) is the wire schema. This
+ *     file types the *flow* by which envelopes get produced.
+ *   - NOT a runtime registry — there's no `HarnessRegistry` here. Wiring
+ *     a concrete `SessionHarness` instance into the runner is A.1b work
+ *     (the dispatch-listener flip).
+ *   - NOT a policy engine — `tools.allow[]` is a substrate-native ACL.
+ *     Cross-principal authorisation lives in cortex#107's PolicyEngine,
+ *     consumed by the runner BEFORE calling `dispatch()`.
+ */
+
+import type { Envelope } from "../../bus/myelin/envelope-validator";
+
+// ---------------------------------------------------------------------------
+// MyelinEnvelope alias
+// ---------------------------------------------------------------------------
+
+/**
+ * Alias for the canonical envelope type from `bus/myelin/envelope-validator`.
+ * Re-exported under the `MyelinEnvelope` name to make the substrate protocol
+ * read closer to the design-doc prose (which always says "MyelinEnvelope")
+ * without forcing the rest of the codebase to migrate its `Envelope` imports.
+ */
+export type MyelinEnvelope = Envelope;
+
+// ---------------------------------------------------------------------------
+// HarnessId — closed enum of known substrates
+// ---------------------------------------------------------------------------
+
+/**
+ * Closed enum of substrate harness implementations cortex knows about.
+ *
+ * Spelled out as a string-literal union (rather than a const-string array)
+ * so a `switch (harness.id)` statement in the runner gets exhaustiveness
+ * checking from `tsc`. Adding a new substrate is a typed change at every
+ * dispatch decision point — the compiler enumerates the work for you.
+ *
+ * The seven known substrates (per cortex#91 §"Implementations" and
+ * §"Future harnesses"):
+ *
+ *   - `"claude-code"`   — in-process child via `claude --print
+ *                         --output-format stream-json`. The first
+ *                         implementation (this PR).
+ *   - `"bus-peer"`      — out-of-process daemon reachable via NATS,
+ *                         using the publish-dispatch + subscribe-reply
+ *                         pattern sage already implements. Lands in
+ *                         the A.1b follow-up alongside the dispatch flip.
+ *   - `"openai-codex"`  — Codex CLI child process. Stubbed in cortex#91 §F.
+ *   - `"cursor"`        — Cursor CLI child process. Tracked via cortex#70.
+ *   - `"gemini"`        — gemini-cli child process.
+ *   - `"mistral"`       — Mistral CLI / API.
+ *   - `"pi-dev"`        — direct pi.dev call without bus indirection;
+ *                         used for cortex-co-located agents.
+ *
+ * **Why not `string`?** Because the runtime needs to refuse the unknown.
+ * A new harness must be a typed registration, not a free-form string,
+ * so any agent config referencing an unimplemented substrate fails fast.
+ */
+export type HarnessId =
+  | "claude-code"
+  | "bus-peer"
+  | "openai-codex"
+  | "cursor"
+  | "gemini"
+  | "mistral"
+  | "pi-dev";
+
+// ---------------------------------------------------------------------------
+// Capability
+// ---------------------------------------------------------------------------
+
+/**
+ * Self-described capability a harness can provide. Used by the future
+ * capability registry (Q2 lock-in, A.6 work) and by orchestrator agents
+ * (design doc §3.6) to reason about delegation.
+ *
+ * **Q2 lock-in shape note.** A.1 ships a SUBSET of the constrained schema
+ * from §5/Q2 (`id`, `description`, optional `tags`). Phase A.6 grows it
+ * to add `provided_by[]`, optional `rate`, optional `cost`. We ship the
+ * subset today so the harness protocol doesn't block on the full schema
+ * roll-out — the additional fields are purely metadata for the capability
+ * registry, not for dispatch decisions.
+ *
+ * **What this is NOT.** Not a runtime claim — a `Capability` listed here
+ * is a *declaration* about what the harness can do. Whether a given
+ * dispatch is allowed to use it is governed by `DispatchRequest.tools`
+ * (substrate-side ACL) and cortex#107's PolicyEngine (principal-side ACL).
+ */
+export interface Capability {
+  /**
+   * Capability id — slug, network-stable. Examples: `"code-review"`,
+   * `"design-doc-review"`, `"code-review.typescript"`. Must match
+   * `[a-z0-9.-]+` once Q2 §A.6 lands; A.1 enforces no format constraint.
+   */
+  id: string;
+  /** Short human-readable summary. Rendered in dashboard agent cards. */
+  description: string;
+  /**
+   * Optional taxonomic tags — language (`"typescript"`, `"python"`),
+   * domain (`"security"`, `"perf"`), modality (`"async"`, `"streaming"`).
+   * Order is not semantic.
+   */
+  tags?: string[];
+}
+
+// ---------------------------------------------------------------------------
+// ToolCapability
+// ---------------------------------------------------------------------------
+
+/**
+ * Substrate-native tool ACL for a single dispatch.
+ *
+ * **Q1-α lock-in (2026-05-13 Andreas, design doc §5).** Strings in
+ * `allow[]` / `deny[]` are *substrate-native* — Claude Code sees
+ * `["Bash", "Edit", "Write"]`, a future Codex harness would see
+ * `["exec"]`. Cortex deliberately does NOT translate across substrates.
+ * The harness is the authority on what its substrate's tool vocabulary
+ * looks like; cortex passes the strings through.
+ *
+ * **Why a negative deny-list in addition to allow?** Some substrates
+ * expose a wildcard `*` allow-by-default mode (e.g. CC's hook-free runs).
+ * In those cases, `deny[]` is the only practical surface for an
+ * operator-side ACL — "let it do anything except this specific tool".
+ * Most call sites set only `allow[]` and leave `deny[]` undefined.
+ */
+export interface ToolCapability {
+  /**
+   * Allowed tools — substrate-native strings. Empty array = no tools
+   * (the harness should refuse to dispatch). For wildcard "all tools",
+   * pass `["*"]` if the substrate recognises it; otherwise enumerate.
+   */
+  allow: string[];
+  /**
+   * Optional deny-list. Intersection with `allow[]` resolves to "denied".
+   * Used when `allow[]` is a wildcard and the operator wants to subtract
+   * specific tools. Most dispatches leave this undefined.
+   */
+  deny?: string[];
+}
+
+// ---------------------------------------------------------------------------
+// DispatchRequest
+// ---------------------------------------------------------------------------
+
+/**
+ * The full input to `SessionHarness.dispatch()` — everything a substrate
+ * needs to do one task end-to-end and emit lifecycle envelopes.
+ *
+ * **Naming convention.** camelCase on this interface; envelope payloads
+ * are snake_case per G-1100.B schema. The harness is the translation
+ * layer — runner code writes camelCase; envelopes that flow back on the
+ * bus carry snake_case fields.
+ *
+ * **Per-field design-doc anchors:**
+ *   - `persona` — design doc §2 (M7 persona files), `architecture.md` §9.3.
+ *   - `prompt` — the operator-or-agent-generated work request.
+ *   - `tools` — Q1-α lock-in (substrate-native tool strings).
+ *   - `context` — pluggable context bundle: discord-history, attachments,
+ *     env vars, prior session state. Harness consumes whichever kinds it
+ *     understands; unknown kinds are ignored, not errored.
+ *   - `agent` — logical agent id + display + optional runtime hint. The
+ *     `runtime.harness` field is informational — `SessionHarness.id`
+ *     is the authoritative substrate the dispatch is running on.
+ *   - `requestId` — Q5 lock-in subject suffix; correlates progress /
+ *     complete / error / timeout envelopes for one dispatch.
+ *   - `timeoutMs` / `inactivityMs` — Q6 lock-in (two caps race).
+ */
+export interface DispatchRequest {
+  /**
+   * Agent persona. `path` is the resolved file path (for provenance in
+   * envelopes and dashboard renderers); `content` is the resolved
+   * markdown body the substrate will inject as system prompt.
+   *
+   * Both fields are required because the runner ALREADY reads the
+   * persona file to validate it exists; passing both saves the
+   * substrate a redundant read and keeps it filesystem-decoupled.
+   */
+  persona: {
+    /** Absolute or repo-relative path. Used for provenance only. */
+    path: string;
+    /** Resolved markdown content — what the substrate actually injects. */
+    content: string;
+  };
+  /**
+   * The work request itself. The substrate is free to embed this in
+   * whatever prompt-engineering scaffold it requires (security
+   * preamble, examples, etc.) — the contents are NOT mutated by the
+   * runner before this point.
+   */
+  prompt: string;
+  /**
+   * Substrate-native tool ACL. See `ToolCapability` doc.
+   *
+   * The runner builds this from the agent's role + the principal's
+   * policy decision (cortex#107). By the time it reaches the harness,
+   * all policy work is done — the harness MUST NOT widen the set.
+   */
+  tools: ToolCapability;
+  /**
+   * Pluggable context bundle. The runner attaches whatever the agent's
+   * trigger source produced (Discord message history, GitHub PR diffs,
+   * attachments, environment hints). The harness handles whichever
+   * `kind` values it recognises; unknown kinds are silently dropped.
+   *
+   * Common kinds in v1:
+   *   - `"discord-history"` — array of recent messages in the thread
+   *   - `"attachments"` — list of `AttachmentInfo` objects
+   *   - `"env"` — operator-and-entity hints (operator id, repo, entity)
+   *
+   * The shape is `unknown` because we deliberately don't constrain
+   * extensibility — adding a new context kind should not require a
+   * protocol-layer schema change. Validation, if any, is harness-side.
+   */
+  context: Array<{ kind: string; data: unknown }>;
+  /**
+   * Agent identity for the dispatch. `id` and `displayName` are the
+   * minimum the runner needs for envelope provenance; `runtime.harness`
+   * is an informational hint — the *actual* substrate is whichever
+   * `SessionHarness` instance the runner picked.
+   */
+  agent: {
+    /** Logical agent id — must match `agents[].id` in cortex.yaml. */
+    id: string;
+    /** Display name surfaced to humans on dashboard / Discord. */
+    displayName: string;
+    /**
+     * Optional runtime hint. The `harness` field is informational —
+     * the actual substrate is determined by which `SessionHarness`
+     * instance the runner resolves at dispatch time. Present here so
+     * the harness can short-circuit on a mismatch ("you told me you
+     * want claude-code but you're calling a bus-peer harness").
+     *
+     * Stack identity (Q1) is NOT carried here — it's a property of
+     * the operator's cortex.yaml `stack:` block (A.5 work). The
+     * harness receives stack identity via the runner's outer scope,
+     * not as a per-dispatch parameter.
+     */
+    runtime?: {
+      harness?: HarnessId;
+    };
+  };
+  /**
+   * Q5 lock-in (design doc §5, 2026-05-13).
+   *
+   * Subject suffix for streaming envelopes. The full subject is
+   *   `local.{operator}.{stack}.dispatch.<harnessId>.<requestId>.progress`
+   *   `local.{operator}.{stack}.dispatch.<harnessId>.<requestId>.complete`
+   *   `local.{operator}.{stack}.dispatch.<harnessId>.<requestId>.error`
+   *   `local.{operator}.{stack}.dispatch.<harnessId>.<requestId>.timeout`
+   *
+   * A.1 types the convention but does NOT wire NATS publishing — the
+   * harness emits envelopes via the async-iterable yield, and the
+   * caller (runner / dispatch-listener flip in A.1b) is responsible
+   * for translating yields into `runtime.publish(envelope)` on the
+   * correct subject. Wiring at the publish layer is Phase B work
+   * (NKey-signed envelopes).
+   *
+   * Format: a UUID v4 is recommended (matches `Envelope.id` shape).
+   * Required because all four terminal envelope subjects need it.
+   */
+  requestId: string;
+  /**
+   * Q6 lock-in (design doc §5, 2026-05-13).
+   *
+   * Wall-clock cap. Hard upper bound on dispatch duration — once the
+   * substrate has been running this long, the harness MUST emit a
+   * `timeout` terminal envelope and shut the substrate down. Defaults
+   * to 300_000ms (5 minutes) when omitted; harness implementations
+   * read the default from their own constants if unset.
+   *
+   * Races with `inactivityMs`; first-to-expire wins.
+   */
+  timeoutMs?: number;
+  /**
+   * Q6 lock-in (design doc §5, 2026-05-13).
+   *
+   * Inactivity cap. If no envelope has been yielded for this many
+   * milliseconds, the harness MUST emit a `timeout` terminal envelope
+   * and shut down. Defaults to 60_000ms (60 seconds) when omitted.
+   *
+   * Distinct from `timeoutMs`: a long-running substrate that emits a
+   * progress envelope every 30s never trips `inactivityMs` but will
+   * trip `timeoutMs` after 5 minutes. A wedged substrate that emits
+   * nothing trips `inactivityMs` first.
+   */
+  inactivityMs?: number;
+}
+
+// ---------------------------------------------------------------------------
+// SessionHarness
+// ---------------------------------------------------------------------------
+
+/**
+ * The substrate harness interface — cortex's single abstraction over any
+ * agent execution engine.
+ *
+ * **Contract:**
+ *   1. Constructor wiring (substrate-specific) is the responsibility of
+ *      each implementation. The runner instantiates a harness with
+ *      whatever dependencies it needs (CC CLI path, NATS link, etc.).
+ *   2. `dispatch(req)` produces an `AsyncIterable<MyelinEnvelope>`. The
+ *      harness MUST yield at least one terminal envelope (`completed`,
+ *      `failed`, `aborted`, or a Q5 `timeout`) before the iterator
+ *      closes. Yielding nothing is a protocol violation.
+ *   3. Yields between dispatch and terminal are *progress* envelopes —
+ *      typically `dispatch.task.started` plus any substrate-specific
+ *      streaming events (tool-use lines, partial text, etc.).
+ *   4. `shutdown(opts)` is optional. When present, callers invoke it
+ *      during graceful runner shutdown. `opts.graceful = false` means
+ *      "abort active dispatches immediately"; `true` means "let
+ *      in-flight dispatches finish, refuse new ones".
+ *
+ * **What this interface does NOT prescribe:**
+ *   - Whether the harness publishes envelopes itself — caller responsibility.
+ *   - Whether yields are 1:1 with bus envelopes — fine to yield
+ *     coalesced/filtered envelopes if the harness has substrate-specific
+ *     reason to (e.g. CC's `text` events coalesce into one summary line).
+ *   - The wire format of context kinds — `context[].data` is `unknown`.
+ *   - Authorization — the runner gates dispatch via cortex#107 before
+ *     calling `dispatch()`. The harness trusts its input.
+ *
+ * **Cross-references:**
+ *   - cortex#91 §"Proposed interface" — the canonical spec.
+ *   - design doc §3.1 ("multi-stack per operator") — why this is M6.
+ *   - design doc §4 "cortex#91" — dependency graph.
+ *   - plan doc §2 Phase A.1 — implementation slice.
+ */
+export interface SessionHarness {
+  /**
+   * Substrate identifier. Must be one of `HarnessId`'s known values.
+   * Used by the runner to log "dispatching task X to substrate Y" and
+   * to derive the Q5 subject prefix `dispatch.<harnessId>.<requestId>.>`.
+   */
+  readonly id: HarnessId;
+  /**
+   * Capabilities this harness provides. The capability registry (A.6)
+   * aggregates across all harnesses cortex has registered. Each harness
+   * declares its own capabilities at construction time and surfaces
+   * them here; the registry never mutates this list.
+   */
+  readonly capabilities: Capability[];
+  /**
+   * Dispatch a task. Returns an async iterable of myelin envelopes
+   * representing the dispatch's lifecycle: zero-or-more progress
+   * envelopes followed by exactly one terminal envelope.
+   *
+   * **Iteration semantics.**
+   *   - `for await (const env of harness.dispatch(req)) { ... }` is the
+   *     canonical consumption pattern.
+   *   - The iterable MUST close after yielding a terminal envelope —
+   *     callers rely on iterator close to free resources.
+   *   - If the caller breaks early, the harness MUST shut the substrate
+   *     down (no orphaned child processes / NATS subscriptions).
+   *
+   * **Error propagation.**
+   *   - Harness throwing during `dispatch()` setup (e.g. spawn fails) is
+   *     a hard error — caller catches it and emits its own envelope.
+   *   - Harness yielding an `error` terminal envelope is the normal
+   *     path for runtime failures inside the substrate.
+   */
+  dispatch(req: DispatchRequest): AsyncIterable<MyelinEnvelope>;
+  /**
+   * Optional graceful-shutdown hook. Called during cortex daemon
+   * shutdown to give the harness a chance to drain in-flight dispatches
+   * (or abort them). When omitted, the caller treats the harness as
+   * stateless across dispatches (no shutdown needed).
+   *
+   * @param opts.graceful  `true` = let in-flight dispatches finish,
+   *                       refuse new ones. `false` = abort everything
+   *                       in-flight immediately (SIGTERM equivalent).
+   */
+  shutdown?(opts: { graceful: boolean }): Promise<void>;
+}

--- a/src/substrates/claude-code/__tests__/harness.test.ts
+++ b/src/substrates/claude-code/__tests__/harness.test.ts
@@ -1,0 +1,407 @@
+/**
+ * IAW Phase A.1 — `ClaudeCodeHarness` happy-path + terminal-state tests.
+ *
+ * **Coverage axes:**
+ *   1. Instantiation — minimum/full opts both compile and produce a
+ *      harness with the expected `id` and `capabilities`.
+ *   2. Happy path — dispatch yields started → completed in order, with
+ *      the same `correlation_id` and a result summary derived from
+ *      `CCSessionResult.response`.
+ *   3. Failure path — non-zero exit yields started → failed with the
+ *      exit code in the error summary.
+ *   4. Abort path — `result.aborted === true` yields started → aborted
+ *      with `reason = result.abortReason` (Echo round-1 W1 fix carried
+ *      through from dispatch-listener).
+ *   5. Factory throw — constructor-thrown exception yields started →
+ *      failed with the thrown message.
+ *   6. CCSessionOpts mapping — `tools.allow`/`tools.deny` become
+ *      `allowedTools`/`disallowedTools`; env-kind context populates
+ *      operator/entity/project; both timeout fields collapse to the
+ *      minimum on cc-session's existing timer.
+ *   7. Shutdown — `graceful: false` calls kill on active sessions;
+ *      post-shutdown `dispatch()` yields started → failed (refused).
+ *
+ * NO real CC processes are spawned. Every test injects a fake
+ * `ccSessionFactory` per the protocol contract.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { ClaudeCodeHarness, type CCSessionFactory } from "../harness";
+import type { CCSessionOpts, CCSessionResult } from "../../../runner/cc-session";
+import type { DispatchEventSource } from "../../../bus/dispatch-events";
+import type {
+  DispatchRequest,
+  MyelinEnvelope,
+} from "../../../common/substrates/types";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const SOURCE: DispatchEventSource = {
+  org: "metafactory",
+  agent: "cortex",
+  instance: "local",
+};
+
+const REQUEST_ID = "11111111-1111-4111-8111-111111111111";
+
+function makeRequest(overrides: Partial<DispatchRequest> = {}): DispatchRequest {
+  return {
+    persona: { path: "/agents/cortex.md", content: "# Cortex" },
+    prompt: "say hello",
+    tools: { allow: ["Bash", "Read"] },
+    context: [],
+    agent: { id: "cortex", displayName: "Cortex" },
+    requestId: REQUEST_ID,
+    ...overrides,
+  };
+}
+
+function makeResult(overrides: Partial<CCSessionResult> = {}): CCSessionResult {
+  return {
+    success: true,
+    response: "Hello, world!\nMore details below.",
+    exitCode: 0,
+    durationMs: 100,
+    sessionId: "session-abc",
+    ...overrides,
+  };
+}
+
+/**
+ * Capturing factory. Records every opts seen and returns a session whose
+ * `wait()` resolves to the provided result.
+ */
+function captureFactory(result: CCSessionResult): {
+  factory: CCSessionFactory;
+  opts: CCSessionOpts[];
+  killCalls: number;
+} {
+  const seen: CCSessionOpts[] = [];
+  let killCalls = 0;
+  const factory: CCSessionFactory = (opts) => {
+    seen.push(opts);
+    const session = {
+      start() { return session; },
+      async wait() { return result; },
+      kill() { killCalls += 1; },
+    };
+    return session;
+  };
+  return {
+    factory,
+    opts: seen,
+    get killCalls() { return killCalls; },
+  } as { factory: CCSessionFactory; opts: CCSessionOpts[]; killCalls: number };
+}
+
+async function drain(it: AsyncIterable<MyelinEnvelope>): Promise<MyelinEnvelope[]> {
+  const out: MyelinEnvelope[] = [];
+  for await (const env of it) out.push(env);
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Instantiation
+// ---------------------------------------------------------------------------
+
+describe("ClaudeCodeHarness — instantiation", () => {
+  test("id is 'claude-code'", () => {
+    const h = new ClaudeCodeHarness({ source: SOURCE });
+    expect(h.id).toBe("claude-code");
+  });
+
+  test("capabilities defaults to empty array", () => {
+    const h = new ClaudeCodeHarness({ source: SOURCE });
+    expect(h.capabilities).toEqual([]);
+  });
+
+  test("capabilities passthrough when provided", () => {
+    const h = new ClaudeCodeHarness({
+      source: SOURCE,
+      capabilities: [
+        { id: "code-review", description: "Reviews PRs" },
+        { id: "research", description: "Web research", tags: ["search"] },
+      ],
+    });
+    expect(h.capabilities).toHaveLength(2);
+    expect(h.capabilities[0]?.id).toBe("code-review");
+    expect(h.capabilities[1]?.tags).toEqual(["search"]);
+  });
+
+  test("shutdown method is defined (optional in protocol but provided here)", () => {
+    const h = new ClaudeCodeHarness({ source: SOURCE });
+    expect(typeof h.shutdown).toBe("function");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Happy path
+// ---------------------------------------------------------------------------
+
+describe("ClaudeCodeHarness — happy path", () => {
+  test("yields started then completed for a successful session", async () => {
+    const result = makeResult();
+    const cap = captureFactory(result);
+    const h = new ClaudeCodeHarness({ source: SOURCE, ccSessionFactory: cap.factory });
+
+    const envelopes = await drain(h.dispatch(makeRequest()));
+
+    expect(envelopes).toHaveLength(2);
+    expect(envelopes[0]?.type).toBe("dispatch.task.started");
+    expect(envelopes[1]?.type).toBe("dispatch.task.completed");
+  });
+
+  test("started + completed share the same correlation_id (= requestId)", async () => {
+    const result = makeResult();
+    const cap = captureFactory(result);
+    const h = new ClaudeCodeHarness({ source: SOURCE, ccSessionFactory: cap.factory });
+
+    const envelopes = await drain(h.dispatch(makeRequest()));
+
+    expect(envelopes[0]?.correlation_id).toBe(REQUEST_ID);
+    expect(envelopes[1]?.correlation_id).toBe(REQUEST_ID);
+  });
+
+  test("completed envelope carries the result summary (first line only)", async () => {
+    const result = makeResult({ response: "Hello, world!\nDetails follow." });
+    const cap = captureFactory(result);
+    const h = new ClaudeCodeHarness({ source: SOURCE, ccSessionFactory: cap.factory });
+
+    const envelopes = await drain(h.dispatch(makeRequest()));
+    const completed = envelopes[1];
+
+    expect(completed?.payload.result_summary).toBe("Hello, world!");
+  });
+
+  test("envelope source matches the harness source triple", async () => {
+    const cap = captureFactory(makeResult());
+    const h = new ClaudeCodeHarness({ source: SOURCE, ccSessionFactory: cap.factory });
+
+    const envelopes = await drain(h.dispatch(makeRequest()));
+    expect(envelopes[0]?.source).toBe("metafactory.cortex.local");
+    expect(envelopes[1]?.source).toBe("metafactory.cortex.local");
+  });
+
+  test("non-uuid requestId still produces a uuid correlation_id", async () => {
+    const cap = captureFactory(makeResult());
+    const h = new ClaudeCodeHarness({ source: SOURCE, ccSessionFactory: cap.factory });
+    const req = makeRequest({ requestId: "not-a-uuid" });
+
+    const envelopes = await drain(h.dispatch(req));
+
+    // Two envelopes, both with the same generated correlation_id
+    // (a real UUID, not the input string).
+    const c0 = envelopes[0]?.correlation_id;
+    const c1 = envelopes[1]?.correlation_id;
+    expect(c0).toBeDefined();
+    expect(c0).not.toBe("not-a-uuid");
+    expect(c0).toMatch(/^[0-9a-f-]{36}$/);
+    expect(c1).toBe(c0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CCSessionOpts mapping
+// ---------------------------------------------------------------------------
+
+describe("ClaudeCodeHarness — DispatchRequest → CCSessionOpts mapping", () => {
+  test("tools.allow/deny pass through as substrate-native strings (Q1-α)", async () => {
+    const cap = captureFactory(makeResult());
+    const h = new ClaudeCodeHarness({ source: SOURCE, ccSessionFactory: cap.factory });
+    const req = makeRequest({
+      tools: { allow: ["Bash", "Edit"], deny: ["WebFetch"] },
+    });
+
+    await drain(h.dispatch(req));
+
+    expect(cap.opts[0]?.allowedTools).toEqual(["Bash", "Edit"]);
+    expect(cap.opts[0]?.disallowedTools).toEqual(["WebFetch"]);
+  });
+
+  test("empty tools.allow drops the field rather than passing an empty array", async () => {
+    const cap = captureFactory(makeResult());
+    const h = new ClaudeCodeHarness({ source: SOURCE, ccSessionFactory: cap.factory });
+
+    await drain(h.dispatch(makeRequest({ tools: { allow: [] } })));
+
+    expect(cap.opts[0]?.allowedTools).toBeUndefined();
+  });
+
+  test("Q6: both timeouts collapse to the minimum on cc-session timer", async () => {
+    const cap = captureFactory(makeResult());
+    const h = new ClaudeCodeHarness({ source: SOURCE, ccSessionFactory: cap.factory });
+    const req = makeRequest({ timeoutMs: 300_000, inactivityMs: 60_000 });
+
+    await drain(h.dispatch(req));
+
+    // Until A.1b splits the timers, the more conservative cap wins.
+    expect(cap.opts[0]?.timeoutMs).toBe(60_000);
+  });
+
+  test("Q6: single timeout maps through directly", async () => {
+    const cap = captureFactory(makeResult());
+    const h = new ClaudeCodeHarness({ source: SOURCE, ccSessionFactory: cap.factory });
+
+    await drain(h.dispatch(makeRequest({ timeoutMs: 30_000 })));
+    expect(cap.opts[0]?.timeoutMs).toBe(30_000);
+
+    await drain(h.dispatch(makeRequest({ inactivityMs: 45_000 })));
+    expect(cap.opts[1]?.timeoutMs).toBe(45_000);
+  });
+
+  test("env-kind context populates operator/entity/project", async () => {
+    const cap = captureFactory(makeResult());
+    const h = new ClaudeCodeHarness({ source: SOURCE, ccSessionFactory: cap.factory });
+    const req = makeRequest({
+      context: [
+        { kind: "env", data: { operator: "andreas", entity: "pr/45", project: "cortex" } },
+        { kind: "discord-history", data: [{ author: "andreas", text: "hi" }] },
+      ],
+    });
+
+    await drain(h.dispatch(req));
+
+    expect(cap.opts[0]?.operator).toBe("andreas");
+    expect(cap.opts[0]?.entity).toBe("pr/45");
+    expect(cap.opts[0]?.project).toBe("cortex");
+  });
+
+  test("unknown context kinds are silently ignored", async () => {
+    const cap = captureFactory(makeResult());
+    const h = new ClaudeCodeHarness({ source: SOURCE, ccSessionFactory: cap.factory });
+    const req = makeRequest({
+      context: [
+        { kind: "unknown-kind", data: { random: "stuff" } },
+        { kind: "another-unknown", data: 42 },
+      ],
+    });
+
+    // Should NOT throw — protocol contract says unknown kinds are dropped.
+    const envelopes = await drain(h.dispatch(req));
+    expect(envelopes).toHaveLength(2);
+    expect(envelopes[1]?.type).toBe("dispatch.task.completed");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Failure paths
+// ---------------------------------------------------------------------------
+
+describe("ClaudeCodeHarness — failure paths", () => {
+  test("non-zero exit yields started → failed with exit code summary", async () => {
+    const cap = captureFactory(makeResult({ success: false, exitCode: 1 }));
+    const h = new ClaudeCodeHarness({ source: SOURCE, ccSessionFactory: cap.factory });
+
+    const envelopes = await drain(h.dispatch(makeRequest()));
+
+    expect(envelopes[1]?.type).toBe("dispatch.task.failed");
+    expect(envelopes[1]?.payload.error_summary).toBe("claude exited 1");
+  });
+
+  test("factory throw yields started → failed with the thrown message", async () => {
+    const factory: CCSessionFactory = () => {
+      throw new Error("spawn ENOENT: claude not in path");
+    };
+    const h = new ClaudeCodeHarness({ source: SOURCE, ccSessionFactory: factory });
+
+    const envelopes = await drain(h.dispatch(makeRequest()));
+
+    expect(envelopes).toHaveLength(2);
+    expect(envelopes[1]?.type).toBe("dispatch.task.failed");
+    expect(envelopes[1]?.payload.error_summary).toBe("spawn ENOENT: claude not in path");
+  });
+
+  test("aborted=true yields started → aborted with reason from result", async () => {
+    const cap = captureFactory(makeResult({
+      success: false,
+      exitCode: 1,
+      aborted: true,
+      abortReason: "timeout",
+    }));
+    const h = new ClaudeCodeHarness({ source: SOURCE, ccSessionFactory: cap.factory });
+
+    const envelopes = await drain(h.dispatch(makeRequest()));
+
+    expect(envelopes[1]?.type).toBe("dispatch.task.aborted");
+    expect(envelopes[1]?.payload.reason).toBe("timeout");
+  });
+
+  test("exitCode=143 without aborted flag still yields aborted (defense-in-depth)", async () => {
+    const cap = captureFactory(makeResult({
+      success: false,
+      exitCode: 143,
+    }));
+    const h = new ClaudeCodeHarness({ source: SOURCE, ccSessionFactory: cap.factory });
+
+    const envelopes = await drain(h.dispatch(makeRequest()));
+
+    expect(envelopes[1]?.type).toBe("dispatch.task.aborted");
+    expect(envelopes[1]?.payload.reason).toBe("timeout");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Shutdown
+// ---------------------------------------------------------------------------
+
+describe("ClaudeCodeHarness — shutdown", () => {
+  test("graceful=true flips flag; in-flight dispatches finish naturally", async () => {
+    const cap = captureFactory(makeResult());
+    const h = new ClaudeCodeHarness({ source: SOURCE, ccSessionFactory: cap.factory });
+
+    await h.shutdown({ graceful: true });
+
+    // Post-shutdown dispatch refuses cleanly (still yields the protocol-
+    // required started + terminal pair, but the terminal is `failed`).
+    const envelopes = await drain(h.dispatch(makeRequest()));
+    expect(envelopes[0]?.type).toBe("dispatch.task.started");
+    expect(envelopes[1]?.type).toBe("dispatch.task.failed");
+    expect(envelopes[1]?.payload.error_summary).toBe("harness shutting down");
+    expect(cap.killCalls).toBe(0);
+  });
+
+  test("graceful=false kills any active session in the tracker", async () => {
+    // Build a session whose wait() never resolves so we can observe kill().
+    const killOrder: string[] = [];
+    let resolveWait: ((r: CCSessionResult) => void) | null = null;
+    const factory: CCSessionFactory = () => {
+      const session = {
+        start() { return session; },
+        wait() {
+          return new Promise<CCSessionResult>((resolve) => {
+            resolveWait = resolve;
+          });
+        },
+        kill() {
+          killOrder.push("killed");
+          // Settle wait so the dispatch generator completes.
+          resolveWait?.({
+            success: false,
+            response: "",
+            exitCode: 143,
+            durationMs: 0,
+            aborted: true,
+            abortReason: "timeout",
+          });
+        },
+      };
+      return session;
+    };
+
+    const h = new ClaudeCodeHarness({ source: SOURCE, ccSessionFactory: factory });
+    const dispatchPromise = drain(h.dispatch(makeRequest()));
+
+    // Yield to let the dispatch generator add the session to activeSessions
+    // before we call shutdown.
+    await new Promise((r) => setTimeout(r, 0));
+
+    await h.shutdown({ graceful: false });
+
+    const envelopes = await dispatchPromise;
+    expect(killOrder).toEqual(["killed"]);
+    expect(envelopes[1]?.type).toBe("dispatch.task.aborted");
+  });
+});

--- a/src/substrates/claude-code/harness.ts
+++ b/src/substrates/claude-code/harness.ts
@@ -1,0 +1,508 @@
+/**
+ * IAW Phase A.1 (cortex#113) — `ClaudeCodeHarness`.
+ *
+ * The first concrete `SessionHarness` implementation. Wraps the existing
+ * `CCSession` primitive (`src/runner/cc-session.ts`) behind the substrate
+ * harness protocol defined in `src/common/substrates/types.ts`.
+ *
+ * **Why a wrapper, not a refactor of cc-session.ts?**
+ *   Per cortex#113 A.1 scope and the §"What NOT to touch in this PR" rules,
+ *   `cc-session.ts` stays intact. The dispatch-listener (at
+ *   `src/runner/dispatch-listener.ts`) STILL calls `cc-session` directly
+ *   today. This harness exists in PARALLEL — Phase A.1b flips the listener
+ *   over to call `ClaudeCodeHarness.dispatch()` instead, and from that
+ *   moment on the listener stops knowing about CCSession directly.
+ *
+ *   Two-step migration: ship the abstraction first, swap the call sites
+ *   second. Keeps each PR small enough to review and revert independently.
+ *
+ * **Translation contract.**
+ *   Input: a `DispatchRequest` from the protocol layer.
+ *   Output: an async iterable of `MyelinEnvelope`s carrying the dispatch
+ *   lifecycle:
+ *
+ *     1. `dispatch.task.started`   — yielded immediately at spawn time.
+ *     2. (optional) progress envelopes — A.1 does NOT yield interim
+ *        progress envelopes (no schema for them yet — that's part of
+ *        cortex#109 §B and Phase A.3 emit-site parameterisation).
+ *        cc-session's `text` / `tool-use` events are observed internally
+ *        by the harness for inactivity-timer reset purposes only.
+ *     3. Exactly ONE terminal envelope:
+ *          - `dispatch.task.completed` on `success === true`
+ *          - `dispatch.task.aborted`   on `aborted === true` OR
+ *                                     `exitCode === 143` (SIGTERM)
+ *          - `dispatch.task.failed`    on every other outcome (incl.
+ *                                     constructor-throws from cc-session)
+ *
+ *   The terminal envelope is the LAST yield; the iterator closes
+ *   immediately afterwards. This matches the protocol contract in
+ *   `SessionHarness.dispatch()` doc.
+ *
+ * **What is COPIED vs IMPORTED from cc-session.ts:**
+ *   - We IMPORT `CCSession`, `CCSessionOpts`, `CCSessionResult` directly —
+ *     no copy. The harness is a new caller of the existing primitive.
+ *   - We IMPORT the four lifecycle envelope constructors from
+ *     `bus/dispatch-events.ts` — `createDispatchTaskStarted/Completed/
+ *     Failed/AbortedEvent`. These are the same constructors
+ *     `dispatch-listener.ts` uses; cortex emits ONE envelope shape per
+ *     lifecycle event regardless of which caller produced it.
+ *
+ * **Q-lock-in alignment (design doc §5):**
+ *   - Q1-α: `req.tools.allow[]` strings pass through as CC's `allowedTools`
+ *     with no translation. The harness IS the substrate-native layer.
+ *   - Q5: `req.requestId` is *carried* but A.1 does NOT publish on
+ *     `dispatch.<harnessId>.<requestId>.>` subjects. The runner picks the
+ *     subject when it publishes the yielded envelopes (A.1b/B work).
+ *   - Q6: `req.timeoutMs` becomes CCSession's `timeoutMs` (its existing
+ *     inactivity timer). `req.inactivityMs` is reserved for the post-A.1
+ *     wall-clock + inactivity split — currently CCSession only implements
+ *     the inactivity cap. We thread BOTH fields so the harness call site
+ *     doesn't break when the cc-session timer model is split in A.1b.
+ *
+ * **Anti-scope:**
+ *   - NOT publishing — the harness yields envelopes; callers publish.
+ *   - NOT validating envelopes — the constructors used here all produce
+ *     schema-conformant shapes by construction. The validator is a
+ *     belt-and-braces check at publish time, not at construction.
+ *   - NOT modifying CCSession — every interaction is via its public
+ *     `start()` / `wait()` / `kill()` API.
+ *   - NOT registering with a `HarnessRegistry` — no such registry exists
+ *     in A.1. Wiring is dispatch-listener flip (A.1b) work.
+ */
+
+import { randomUUID } from "crypto";
+
+import { CCSession, type CCSessionOpts, type CCSessionResult } from "../../runner/cc-session";
+import type { Envelope } from "../../bus/myelin/envelope-validator";
+import type {
+  Capability,
+  DispatchRequest,
+  HarnessId,
+  MyelinEnvelope,
+  SessionHarness,
+} from "../../common/substrates/types";
+import {
+  createDispatchTaskAbortedEvent,
+  createDispatchTaskCompletedEvent,
+  createDispatchTaskFailedEvent,
+  createDispatchTaskStartedEvent,
+  type DispatchEventSource,
+} from "../../bus/dispatch-events";
+
+// ---------------------------------------------------------------------------
+// Session factory — same shape as dispatch-listener uses
+// ---------------------------------------------------------------------------
+
+/**
+ * Mirror of `CCSessionLike` in `runner/dispatch-listener.ts` — kept here
+ * to avoid a circular dependency between the new substrates module and the
+ * legacy runner module. Once A.1b flips the listener over, the two shapes
+ * merge into this one.
+ */
+export interface CCSessionLike {
+  start(): CCSessionLike;
+  wait(): Promise<CCSessionResult>;
+  kill?(): void;
+}
+
+export type CCSessionFactory = (opts: CCSessionOpts) => CCSessionLike;
+
+/** Default factory — produces a real CCSession that spawns `claude`. */
+const defaultCCSessionFactory: CCSessionFactory = (opts) => new CCSession(opts);
+
+// ---------------------------------------------------------------------------
+// Options
+// ---------------------------------------------------------------------------
+
+/**
+ * Constructor options for `ClaudeCodeHarness`.
+ *
+ * Every field is either operator-derived (the `source` triple, used as
+ * envelope `source` for lifecycle events) or test-injection (the
+ * factory). No CC-binary path here — `CCSession` already resolves
+ * `claude` from `$PATH`; injecting a path is out-of-scope for A.1.
+ */
+export interface ClaudeCodeHarnessOpts {
+  /**
+   * Envelope source triple — `{org, agent, instance}` — stamped onto
+   * every lifecycle envelope this harness produces. Sourced from
+   * cortex.yaml's `operator.id` + the agent id + `local` (or whatever
+   * the runner uses as instance label).
+   *
+   * Per dispatch-events.ts: `agent` here is the *cortex* agent name,
+   * not the dispatched-to agent. Confusing naming inherited from the
+   * envelope spec — see `DispatchEventSource` for the precise contract.
+   */
+  source: DispatchEventSource;
+  /**
+   * Optional test injection. Default constructs a real `CCSession` that
+   * spawns `claude`. Tests pass a fake that yields a deterministic
+   * `CCSessionResult` from `wait()`.
+   */
+  ccSessionFactory?: CCSessionFactory;
+  /**
+   * Optional declared capabilities. Surfaces in `harness.capabilities`
+   * for the future capability registry (A.6 work). Defaults to an empty
+   * array — the harness declares nothing on its own and lets the agent
+   * config carry per-agent capability annotations instead.
+   */
+  capabilities?: Capability[];
+}
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+/**
+ * Claude Code substrate harness — in-process child via `claude --print
+ * --output-format stream-json`. See file header for the full contract.
+ */
+export class ClaudeCodeHarness implements SessionHarness {
+  readonly id: HarnessId = "claude-code";
+  readonly capabilities: Capability[];
+
+  private readonly source: DispatchEventSource;
+  private readonly factory: CCSessionFactory;
+
+  /**
+   * In-flight sessions — used by `shutdown({ graceful: false })` to fan a
+   * kill out to every active dispatch. A `Set` rather than an array
+   * because we add/remove unordered and care about identity, not order.
+   */
+  private readonly activeSessions = new Set<CCSessionLike>();
+
+  /**
+   * Once `shutdown` has been called, refuse new dispatches. Avoids the
+   * race where a `dispatch()` call lands AFTER the runner began draining
+   * but BEFORE the harness reference was dropped — without this flag,
+   * the new dispatch would spawn a CC session the runner can't track.
+   */
+  private shuttingDown = false;
+
+  constructor(opts: ClaudeCodeHarnessOpts) {
+    this.source = opts.source;
+    this.factory = opts.ccSessionFactory ?? defaultCCSessionFactory;
+    this.capabilities = opts.capabilities ?? [];
+  }
+
+  /**
+   * Dispatch a task. See `SessionHarness.dispatch` doc for the lifecycle
+   * contract. Implementation notes:
+   *
+   *   - We yield `dispatch.task.started` BEFORE calling `start()` so that
+   *     the lifecycle envelope is observable even if `start()` throws
+   *     synchronously (rare — but `Bun.spawn()` can fail at the syscall
+   *     layer if `claude` is missing from $PATH).
+   *   - We then call `start()` and `wait()`. cc-session's internal stream
+   *     parser handles all the tool-use / text event interpretation; the
+   *     harness consumes only the final result.
+   *   - We translate the result to ONE terminal envelope by mirroring
+   *     dispatch-listener.ts's `handleDispatchEnvelope` logic exactly,
+   *     so this harness is a behavioural drop-in for the listener (which
+   *     is what A.1b will leverage).
+   */
+  async *dispatch(req: DispatchRequest): AsyncIterable<MyelinEnvelope> {
+    // Stabilise correlation_id ONCE per dispatch — the helper falls back
+    // to a fresh UUID when `requestId` isn't UUID-shaped, and we need
+    // every envelope in this dispatch to share the same value. Re-calling
+    // the helper per envelope would mint a new UUID every time.
+    const correlationId = this.correlationFor(req);
+
+    if (this.shuttingDown) {
+      // Yield a failed terminal envelope rather than throwing — keeps
+      // the protocol invariant (always at least one terminal envelope).
+      yield this.buildStartedEnvelope(req, new Date(), correlationId);
+      yield this.buildFailedEnvelope(req, new Date(), correlationId, "harness shutting down");
+      return;
+    }
+
+    const startedAt = new Date();
+    yield this.buildStartedEnvelope(req, startedAt, correlationId);
+
+    const ccOpts = this.buildCCOpts(req);
+
+    let session: CCSessionLike | null = null;
+    let result: CCSessionResult | null = null;
+    let runtimeError: Error | null = null;
+
+    try {
+      session = this.factory(ccOpts);
+      this.activeSessions.add(session);
+      session.start();
+      result = await session.wait();
+    } catch (err) {
+      runtimeError = err instanceof Error ? err : new Error(String(err));
+    } finally {
+      if (session) this.activeSessions.delete(session);
+    }
+
+    yield this.buildTerminalEnvelope(req, startedAt, correlationId, result, runtimeError);
+  }
+
+  /**
+   * Graceful shutdown. With `graceful: true` we just flip the flag —
+   * in-flight dispatches finish naturally, new ones get the refusal
+   * path. With `graceful: false` we additionally kill every active
+   * session, so their `wait()` settles fast (cc-session's kill path
+   * resolves `wait()` within 2s via SIGTERM escalation).
+   */
+  async shutdown(opts: { graceful: boolean }): Promise<void> {
+    this.shuttingDown = true;
+    if (opts.graceful) return;
+
+    // Hard shutdown — kill every active session. Don't await — kill is
+    // synchronous and `wait()` settlement happens via cc-session's own
+    // exit-listener wiring on the dispatch generator side.
+    for (const session of this.activeSessions) {
+      try {
+        session.kill?.();
+      } catch (err) {
+        // Best-effort: a kill on an already-exited process can throw.
+        // Log and continue — we still want to attempt every session.
+        process.stderr.write(
+          `claude-code-harness: shutdown kill failed: ${
+            err instanceof Error ? err.message : String(err)
+          }\n`,
+        );
+      }
+    }
+    this.activeSessions.clear();
+  }
+
+  // -------------------------------------------------------------------------
+  // Internal helpers
+  // -------------------------------------------------------------------------
+
+  /**
+   * Translate a `DispatchRequest` to `CCSessionOpts`. Maps the protocol-
+   * level camelCase fields onto cc-session's existing options shape.
+   *
+   * The translation is intentionally narrow — A.1 only carries enough
+   * fields to make a basic CC dispatch work. Later phases (A.3 emit-site
+   * parameterisation, A.5 stack identity) will extend this map without
+   * breaking the contract.
+   */
+  private buildCCOpts(req: DispatchRequest): CCSessionOpts {
+    const opts: CCSessionOpts = {
+      prompt: req.prompt,
+      agentId: req.agent.id,
+      agentName: req.agent.displayName,
+    };
+
+    // Q1-α: harness-native tool strings pass through untouched.
+    if (req.tools.allow.length > 0) {
+      opts.allowedTools = [...req.tools.allow];
+    }
+    if (req.tools.deny && req.tools.deny.length > 0) {
+      opts.disallowedTools = [...req.tools.deny];
+    }
+
+    // Q6: wall-clock cap maps to cc-session's existing inactivity timer
+    // today. cc-session's timer is fundamentally inactivity-based — the
+    // wall-clock split lands in A.1b alongside the listener flip. For
+    // A.1, the more conservative of the two caps wins, so we set the
+    // timer to `min(timeoutMs, inactivityMs)` when both are provided.
+    const timeoutMs = req.timeoutMs;
+    const inactivityMs = req.inactivityMs;
+    if (timeoutMs !== undefined && inactivityMs !== undefined) {
+      opts.timeoutMs = Math.min(timeoutMs, inactivityMs);
+    } else if (timeoutMs !== undefined) {
+      opts.timeoutMs = timeoutMs;
+    } else if (inactivityMs !== undefined) {
+      opts.timeoutMs = inactivityMs;
+    }
+
+    // Surface env context kinds the substrate understands. Unknown kinds
+    // are silently dropped per the protocol contract.
+    for (const ctx of req.context) {
+      if (ctx.kind === "env" && typeof ctx.data === "object" && ctx.data !== null) {
+        const env = ctx.data as Record<string, unknown>;
+        if (typeof env.operator === "string") opts.operator = env.operator;
+        if (typeof env.entity === "string") opts.entity = env.entity;
+        if (typeof env.project === "string") opts.project = env.project;
+      }
+    }
+
+    return opts;
+  }
+
+  /**
+   * Per-dispatch correlation key. Uses `requestId` when valid (UUID), else
+   * mints a fresh UUID. This keeps all lifecycle envelopes for one
+   * dispatch on the same `correlation_id` even when the caller supplies a
+   * non-UUID request id (which the envelope schema would reject).
+   *
+   * Same defensive pattern that lives in dispatch-listener.ts — the
+   * schema only allows UUID `correlation_id`, so we shield the caller
+   * from accidental validation failures at publish time.
+   */
+  private correlationFor(req: DispatchRequest): string {
+    return isUuid(req.requestId) ? req.requestId : randomUUID();
+  }
+
+  private buildStartedEnvelope(
+    req: DispatchRequest,
+    startedAt: Date,
+    correlationId: string,
+  ): Envelope {
+    return createDispatchTaskStartedEvent({
+      source: this.source,
+      taskId: req.requestId,
+      agentId: req.agent.id,
+      correlationId,
+      startedAt,
+    });
+  }
+
+  private buildCompletedEnvelope(
+    req: DispatchRequest,
+    startedAt: Date,
+    correlationId: string,
+    completedAt: Date,
+    resultSummary?: string,
+  ): Envelope {
+    return createDispatchTaskCompletedEvent({
+      source: this.source,
+      taskId: req.requestId,
+      agentId: req.agent.id,
+      correlationId,
+      startedAt,
+      completedAt,
+      ...(resultSummary !== undefined && { resultSummary }),
+    });
+  }
+
+  private buildFailedEnvelope(
+    req: DispatchRequest,
+    startedAt: Date,
+    correlationId: string,
+    errorSummary: string,
+  ): Envelope {
+    return createDispatchTaskFailedEvent({
+      source: this.source,
+      taskId: req.requestId,
+      agentId: req.agent.id,
+      correlationId,
+      startedAt,
+      failedAt: new Date(),
+      errorSummary: truncateError(errorSummary),
+    });
+  }
+
+  private buildAbortedEnvelope(
+    req: DispatchRequest,
+    startedAt: Date,
+    correlationId: string,
+    reason: string,
+  ): Envelope {
+    return createDispatchTaskAbortedEvent({
+      source: this.source,
+      taskId: req.requestId,
+      agentId: req.agent.id,
+      correlationId,
+      startedAt,
+      abortedAt: new Date(),
+      reason,
+    });
+  }
+
+  /**
+   * Map a `CCSessionResult` (or runtime error) to a terminal lifecycle
+   * envelope. Mirrors `handleDispatchEnvelope`'s tail logic in
+   * `runner/dispatch-listener.ts` — see Echo's W1 round-1 note there
+   * about why we trust `result.aborted` over `exitCode === 143`.
+   */
+  private buildTerminalEnvelope(
+    req: DispatchRequest,
+    startedAt: Date,
+    correlationId: string,
+    result: CCSessionResult | null,
+    runtimeError: Error | null,
+  ): Envelope {
+    if (runtimeError) {
+      return this.buildFailedEnvelope(req, startedAt, correlationId, runtimeError.message);
+    }
+
+    if (!result) {
+      // Defensive: factory returned a session whose wait() resolved with
+      // nothing parseable. Treat as failure — silent success on a no-op
+      // session is the worst-of-both-worlds outcome.
+      return this.buildFailedEnvelope(
+        req,
+        startedAt,
+        correlationId,
+        "session factory returned no result",
+      );
+    }
+
+    if (result.success) {
+      return this.buildCompletedEnvelope(
+        req,
+        startedAt,
+        correlationId,
+        new Date(),
+        result.response ? truncateSummary(result.response) : undefined,
+      );
+    }
+
+    // Distinguish abort (timeout / external kill) from a regular failure.
+    // Same logic as dispatch-listener.ts:388 — trust `aborted` over the
+    // 143 exit code (the inactivity path resolves with exitCode 1 BEFORE
+    // SIGTERM/143 actually fires).
+    if (result.aborted === true || result.exitCode === 143) {
+      return this.buildAbortedEnvelope(
+        req,
+        startedAt,
+        correlationId,
+        result.abortReason ?? "timeout",
+      );
+    }
+
+    return this.buildFailedEnvelope(
+      req,
+      startedAt,
+      correlationId,
+      `claude exited ${result.exitCode}`,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Local helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Cheap UUID v4-ish validator. The envelope schema requires UUID-shaped
+ * `correlation_id`; this check avoids minting a fresh UUID when the
+ * caller already supplied a valid one as `requestId`.
+ *
+ * Pattern lifted verbatim from `bus/dispatch-events.ts` / `dispatch-
+ * listener.ts` conventions — we match the same 8-4-4-4-12 hex layout
+ * without enforcing the version/variant nibbles (the JSON Schema does
+ * the strict check downstream).
+ */
+function isUuid(s: string): boolean {
+  return /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/.test(
+    s,
+  );
+}
+
+/**
+ * Trim error messages so a verbose stack doesn't blow the worklog limit
+ * downstream. 500 chars matches the `system.inbound.failed` convention
+ * (system-events §3.5.4). Copied from dispatch-listener.ts:419 — same
+ * cap, same rationale.
+ */
+function truncateError(msg: string): string {
+  return msg.length > 500 ? msg.slice(0, 497) + "..." : msg;
+}
+
+/**
+ * Trim CC response summaries. Surfaces typically render the first line +
+ * "(more)..." — cap at 1000 chars to leave room for a label prefix
+ * without truncation surprises. Copied from dispatch-listener.ts:428.
+ */
+function truncateSummary(text: string): string {
+  const first = text.split("\n", 1)[0] ?? text;
+  return first.length > 1000 ? first.slice(0, 997) + "..." : first;
+}


### PR DESCRIPTION
**Refs:** cortex#113 (IAW Phase A entry criteria) + cortex#91 (substrate harness origin spec) + design doc §3, §4 (`docs/design-internet-of-agentic-work.md` once cortex#112 merges).

This is the **first** Internet of Agentic Work (IAW) Phase A PR. It lands the foundation every later phase composes on top of.

## What this PR ships

Pure interface + one concrete implementation that wraps the existing `cc-session.ts` primitive. The dispatch-listener KEEPS calling `cc-session` directly today — flipping it over to `ClaudeCodeHarness.dispatch()` is Phase A.1b in a follow-up PR. This is deliberate: the abstraction lands first, the call-site swap lands second, so each PR is small enough to review and revert independently.

### Files added (4)

| File | Purpose |
|---|---|
| `src/common/substrates/types.ts` | Protocol layer — `HarnessId`, `Capability`, `ToolCapability`, `DispatchRequest`, `SessionHarness`, + `MyelinEnvelope` alias. Operator-facing docstrings with OSI/M1–M7 layering reasoning. Q1/Q5/Q6/Q7 lock-ins from design doc §5 are cross-referenced inline. |
| `src/common/substrates/__tests__/types.test.ts` | Type-level smoke tests — `HarnessId` exhaustiveness (7 substrates), interface instantiability, async-iterable contract. |
| `src/substrates/claude-code/harness.ts` | `ClaudeCodeHarness implements SessionHarness` — wraps `CCSession`, reuses the four lifecycle envelope constructors from `bus/dispatch-events.ts` so it is a behavioural drop-in for `dispatch-listener.ts` (which A.1b will leverage). |
| `src/substrates/claude-code/__tests__/harness.test.ts` | Happy-path, non-zero-exit, abort (`aborted: true` AND `exitCode: 143`), factory-throw, DispatchRequest→CCSessionOpts mapping, shutdown (graceful + hard) coverage. Mock factory injection — no real `claude` processes spawned. |

### Q-lock-in alignment (design doc §5, 2026-05-13 Andreas)

- **Q1-α (tool capability):** `ToolCapability.allow[]` is `string[]` of substrate-native tokens (CC sees `["Bash", "Edit", "Write"]`; future Codex sees `["exec"]`). Cortex stays out of the translation business. Confirmed by `types.test.ts` "allow is a plain string array (Q1-α — substrate-native)".
- **Q5 (streaming subject):** `DispatchRequest.requestId` is typed and carried but A.1 does NOT wire NATS publishing — yielded envelopes are the harness's only output. Subject derivation `dispatch.<harnessId>.<requestId>.{progress|complete|error|timeout}` is documented in `DispatchRequest.requestId` doc; Phase B's NKey-signed envelope work owns the publish layer.
- **Q6 (timeout):** `timeoutMs` (wall-clock, default 300_000) + `inactivityMs` (default 60_000) — both fields typed. Until A.1b splits cc-session's single inactivity timer, the harness collapses both to `min(timeoutMs, inactivityMs)` and passes that to `CCSession.timeoutMs`. Test pins the behaviour.
- **Q7 (stack as protocol primitive):** subject namespace gets a `{stack}` segment — referenced in the Q5 docs but A.5 work materialises the cortex.yaml `stack:` block. A.1 types accept stack identity but don't enforce schema.

### Anti-scope (explicit per cortex#113 A.1 contract)

- `src/runner/dispatch-listener.ts` — **NOT touched**. dispatch-listener keeps calling `cc-session` directly. The flip lands in A.1b.
- `src/runner/cc-session.ts` — **NOT modified**. The harness is a new caller of the existing public API.
- `cortex.yaml` schema (`AgentRuntimeSchema`, `CortexConfig`) — **NOT touched**. The `stack:` block + the `capabilities:` block are A.5 / A.6 work.
- NATS publishing — Q5 streaming subjects are typed but envelopes are not WIRED to `runtime.publish()`. Phase B's NKey-signed envelope work owns publishing.
- `BusPeerHarness` — out of scope for A.1 (cortex#91 §"Implementations" puts it in A.1b alongside the dispatch flip).

### Verification

- `bunx tsc --noEmit` — clean.
- `bun test src/common/substrates/ src/substrates/` — **32 pass / 0 fail**.
- `bun test` (full suite) — **2540 pass / 1 skip / 0 fail** across 140 files. No regressions vs. main.

## Test plan

- [ ] `bunx tsc --noEmit` clean
- [ ] `bun test src/common/substrates/ src/substrates/` passes (32 tests)
- [ ] `bun test` overall green (no new failures)
- [ ] `dispatch-listener.ts` diff is empty in this PR
- [ ] `cc-session.ts` diff is empty in this PR
- [ ] `cortex-config.ts` diff is empty in this PR

## What's next (remaining Phase A work)

- **A.1b** — flip `dispatch-listener.ts` from calling `cc-session` directly to calling `ClaudeCodeHarness.dispatch()`; ship `BusPeerHarness` for sage.
- **A.2** — bump vendored envelope past `96b14ea` (cortex#109 sub-task) and surface `signed_by[]` structurally.
- **A.3** — parameterise `classification` at the four hardcoded emit sites (`dispatch-events`, `system-events`, `github-events`, `cc-events`) + `MyelinRuntime.publish()` subject derivation.
- **A.4** — surface-router visibility filter (`RendererSchema.visibility`).
- **A.5** — `stack:` block in cortex.yaml + `local.{operator}.{stack}.>` subject form materialised at `MyelinRuntime.publish()`.

recommend: merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)