### PR TITLE
feat(substrates): IAW A.1b — dispatch-listener flips to SessionHarness (refs cortex#113)

### DIFF
--- a/src/common/substrates/types.ts
+++ b/src/common/substrates/types.ts
@@ -195,6 +195,99 @@ export interface ToolCapability {
 }
 
 // ---------------------------------------------------------------------------
+// DispatchRuntime — optional substrate-runtime knobs
+// ---------------------------------------------------------------------------
+
+/**
+ * Optional substrate-runtime hints carried alongside the core dispatch
+ * inputs.
+ *
+ * These are *harness-internal* concerns (cwd, allowedDirs, bash allowlist,
+ * grove channel/network labels, resume tokens, extra CLI args) that the
+ * runner historically built directly into `CCSessionOpts` inside
+ * `dispatch-listener.ts` (A.1b folds that mapping in here). Putting them
+ * on the request keeps every future harness reading the same shape:
+ * CC-specific harnesses consume the CC-specific fields, future harnesses
+ * silently ignore knobs they don't understand.
+ *
+ * **Why optional everywhere.** Phase A.1b is a behaviour-preserving
+ * refactor: dispatch-listener supplies whatever the legacy payload
+ * carries, and the harness applies what it understands. Required fields
+ * would force every test, every future caller, and every other harness
+ * implementation to populate CC-specific knobs they don't care about.
+ *
+ * **What does NOT live here.** Tool ACLs (`tools`) stay on `DispatchRequest`
+ * top-level — every harness needs them and they're an explicit ACL surface.
+ * Persona content stays on the request top-level — it's the system prompt
+ * regardless of substrate. The fields here are the residual *runtime
+ * knobs* that historically traveled with the `CCSession` constructor but
+ * are NOT part of the conceptual dispatch contract.
+ *
+ * **Schema growth path.** Adding a new field here is a non-breaking
+ * change — all fields are optional and unknown fields are simply ignored
+ * by any harness that doesn't read them. A.3 / A.5 / B may introduce
+ * stack-aware fields (operator id, stack id, signing key hint) into this
+ * same block.
+ */
+export interface DispatchRuntime {
+  /**
+   * Working directory for the substrate process. Substrates that don't
+   * spawn child processes (`bus-peer`, `pi-dev`) MAY ignore this.
+   *
+   * Carried from the legacy `CCSessionOpts.cwd` — historically derived
+   * from `access.dirRestrictions[0]` or the agent's `claude.allowedDirs`
+   * config block.
+   */
+  cwd?: string;
+  /**
+   * Filesystem read/write allowlist. Substrates that enforce a
+   * filesystem boundary (CC's `--add-dir`) consume this; others ignore.
+   *
+   * Per Q1-α lock-in, these are substrate-native path strings. Cortex
+   * does NOT translate across substrates.
+   */
+  allowedDirs?: string[];
+  /**
+   * Bash guard allowlist config. CC's `bash-guard.hook.ts` reads this
+   * via the `GROVE_BASH_GUARD` env var and refuses any `Bash` tool
+   * invocation whose command doesn't match the allowlist. Future
+   * non-CC harnesses ignore this field.
+   */
+  bashAllowlist?: {
+    rules: Array<{ pattern: string; repos?: string[] }>;
+    repos: string[];
+  };
+  /**
+   * When `true`, disables the bash guard entirely. Used by operator DMs
+   * (the highest-privilege role) where the operator is trusted to run
+   * arbitrary commands. Future non-CC harnesses ignore.
+   */
+  bashGuardDisabled?: boolean;
+  /**
+   * Extra CLI args appended to the substrate's invocation. CC consumes
+   * these as `claude … <additional_args>`; other substrates may use
+   * them for their own CLI flag passthrough.
+   */
+  additionalArgs?: string[];
+  /**
+   * Grove channel/network labels stamped onto downstream events (for
+   * the dashboard's per-channel grouping). Carried via `GROVE_CHANNEL`
+   * / `GROVE_NETWORK` env vars on the CC child process; future
+   * substrates may surface the same labels through their own event-tap
+   * mechanism.
+   */
+  groveChannel?: string;
+  groveNetwork?: string;
+  /**
+   * Resume token for substrates that support stateful resumption (CC's
+   * `--resume <session-id>`). Future stateless substrates (`bus-peer`
+   * for one-shot delegations) ignore this. Optional everywhere — the
+   * runner only sets this on thread continuations.
+   */
+  resumeSessionId?: string;
+}
+
+// ---------------------------------------------------------------------------
 // DispatchRequest
 // ---------------------------------------------------------------------------
 
@@ -209,6 +302,12 @@ export interface ToolCapability {
  *
  * **Per-field design-doc anchors:**
  *   - `persona` — design doc §2 (M7 persona files), `architecture.md` §9.3.
+ *     **Optional in A.1b** (Echo cortex#125 review): today the runner
+ *     injects persona via the prompt-builder path BEFORE constructing
+ *     the request, so the harness layer doesn't itself need to surface
+ *     the persona file. Kept as an optional provenance hint and a
+ *     forward door for substrates that DO inject the persona themselves
+ *     at dispatch time.
  *   - `prompt` — the operator-or-agent-generated work request.
  *   - `tools` — Q1-α lock-in (substrate-native tool strings).
  *   - `context` — pluggable context bundle: discord-history, attachments,
@@ -219,19 +318,22 @@ export interface ToolCapability {
  *     is the authoritative substrate the dispatch is running on.
  *   - `requestId` — Q5 lock-in subject suffix; correlates progress /
  *     complete / error / timeout envelopes for one dispatch.
+ *   - `runtime` — optional substrate-runtime knobs (cwd, allowedDirs,
+ *     bash allowlist, grove channel labels, resume tokens, extra CLI
+ *     args). See `DispatchRuntime` doc for the per-field rationale.
  *   - `timeoutMs` / `inactivityMs` — Q6 lock-in (two caps race).
  */
 export interface DispatchRequest {
   /**
    * Agent persona. `path` is the resolved file path (for provenance in
    * envelopes and dashboard renderers); `content` is the resolved
-   * markdown body the substrate will inject as system prompt.
+   * markdown body. Optional in A.1b — see interface doc.
    *
-   * Both fields are required because the runner ALREADY reads the
-   * persona file to validate it exists; passing both saves the
-   * substrate a redundant read and keeps it filesystem-decoupled.
+   * When present, the substrate may inject `content` as a system
+   * prompt; when omitted, the caller (typically `dispatch-handler`) has
+   * already inlined the persona into `prompt` via the prompt-builder.
    */
-  persona: {
+  persona?: {
     /** Absolute or repo-relative path. Used for provenance only. */
     path: string;
     /** Resolved markdown content — what the substrate actually injects. */
@@ -315,6 +417,22 @@ export interface DispatchRequest {
    * Required because all four terminal envelope subjects need it.
    */
   requestId: string;
+  /**
+   * Optional substrate-runtime knobs. See `DispatchRuntime` for the
+   * per-field rationale.
+   *
+   * **Why a sub-object instead of flat fields.** Grouping keeps the
+   * `DispatchRequest` surface tidy as the list grows (A.3 / A.5 / B
+   * will add stack-aware fields here). It also makes it obvious which
+   * fields are "substrate-runtime" vs "core dispatch contract" at the
+   * call site — `req.runtime.cwd` vs `req.prompt` reads correctly.
+   *
+   * **Why optional.** Cortex's IAW design treats this as a forward door:
+   * a minimal dispatch (just persona + prompt + tools) is valid; the
+   * runtime block is a layered escape-hatch for the residual harness-
+   * specific knobs.
+   */
+  runtime?: DispatchRuntime;
   /**
    * Q6 lock-in (design doc §5, 2026-05-13).
    *

--- a/src/runner/__tests__/dispatch-listener.test.ts
+++ b/src/runner/__tests__/dispatch-listener.test.ts
@@ -336,6 +336,73 @@ describe("dispatch-listener — success path", () => {
     expect(opts.operator).toBe("andreas");
     expect(opts.resumeSessionId).toBe("prior-session");
   });
+
+  test("agent_name falls back to agent_id when omitted (A.1b flip)", async () => {
+    // A.1b refactor: the listener builds a `DispatchRequest` whose
+    // `agent.displayName` falls back to `agent_id` when `agent_name` is
+    // missing on the payload. The harness then surfaces `displayName`
+    // as `CCSessionOpts.agentName` — so the absence of payload.agent_name
+    // should NOT produce undefined `opts.agentName`.
+    const r = recordingRuntime();
+    const router = createSurfaceRouter(r.runtime);
+    const { factory, optsCaptured } = fakeFactory(SUCCESS_RESULT);
+    const listener = createDispatchListener({
+      runtime: r.runtime,
+      router,
+      source: SOURCE,
+      ccSessionFactory: factory,
+    });
+    await listener.start();
+    await router.start();
+
+    // No agent_name on the payload — only agent_id.
+    r.trigger(makeReceivedEnvelope(), "local.metafactory.dispatch.task.received");
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(optsCaptured).toHaveLength(1);
+    const opts = optsCaptured[0]!;
+    expect(opts.agentId).toBe("cortex");
+    expect(opts.agentName).toBe("cortex"); // falls back to agent_id
+  });
+
+  test("payload with no runtime knobs produces a minimal CCSessionOpts (A.1b flip)", async () => {
+    // A.1b refactor: the listener only attaches `req.runtime` when the
+    // payload actually carries one or more runtime knobs. With a bare
+    // payload (task_id + agent_id + prompt only), CCSessionOpts MUST
+    // NOT include cwd/allowedDirs/etc. — every CC-knob stays undefined
+    // so the substrate falls back to its built-in defaults.
+    const r = recordingRuntime();
+    const router = createSurfaceRouter(r.runtime);
+    const { factory, optsCaptured } = fakeFactory(SUCCESS_RESULT);
+    const listener = createDispatchListener({
+      runtime: r.runtime,
+      router,
+      source: SOURCE,
+      ccSessionFactory: factory,
+    });
+    await listener.start();
+    await router.start();
+
+    r.trigger(makeReceivedEnvelope(), "local.metafactory.dispatch.task.received");
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(optsCaptured).toHaveLength(1);
+    const opts = optsCaptured[0]!;
+    expect(opts.cwd).toBeUndefined();
+    expect(opts.allowedDirs).toBeUndefined();
+    expect(opts.additionalArgs).toBeUndefined();
+    expect(opts.groveChannel).toBeUndefined();
+    expect(opts.groveNetwork).toBeUndefined();
+    expect(opts.resumeSessionId).toBeUndefined();
+    expect(opts.bashAllowlist).toBeUndefined();
+    expect(opts.bashGuardDisabled).toBeUndefined();
+    expect(opts.timeoutMs).toBeUndefined();
+    expect(opts.operator).toBeUndefined();
+    expect(opts.entity).toBeUndefined();
+    expect(opts.project).toBeUndefined();
+    expect(opts.allowedTools).toBeUndefined();
+    expect(opts.disallowedTools).toBeUndefined();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/runner/dispatch-listener.ts
+++ b/src/runner/dispatch-listener.ts
@@ -5,27 +5,41 @@
  *   The surface-router fans envelopes to N adapters. Adapters declare
  *   interest with subjects + filter and a `render(envelope)` method.
  *   Adapters typically render to platforms (Discord, Mattermost, ...);
- *   the runner reuses the SAME adapter shape but `render()` *spawns a CC
- *   session* instead. The router doesn't care — it just fans envelopes.
- *   This keeps the runner symmetric with platform adapters and means a
- *   future test harness can register a no-op runner adapter to drain the
- *   bus during integration tests.
+ *   the runner reuses the SAME adapter shape but `render()` *dispatches
+ *   to a substrate harness* instead. The router doesn't care — it just
+ *   fans envelopes. This keeps the runner symmetric with platform
+ *   adapters and means a future test harness can register a no-op
+ *   runner adapter to drain the bus during integration tests.
  *
- * Lifecycle (per plan-cortex-migration.md §4.5–4.6):
+ * Lifecycle (per plan-cortex-migration.md §4.5–4.6, IAW Phase A.1b):
  *   1. Envelope arrives on `local.{org}.dispatch.task.received`.
- *   2. Listener parses payload → builds `CCSessionOpts`.
- *   3. Emits `dispatch.task.started` (correlation_id = task_id).
- *   4. Spawns the CC session and awaits completion.
- *   5. On exit: emits `completed` (success), `failed` (non-zero exit /
- *      runtime error), or `aborted` (timeout / shutdown).
+ *   2. Listener parses payload → builds a `DispatchRequest`.
+ *   3. Listener instantiates a per-dispatch `ClaudeCodeHarness` and
+ *      iterates `harness.dispatch(req)`.
+ *   4. For each yielded `MyelinEnvelope` (started / completed / failed
+ *      / aborted), the listener calls `runtime.publish(envelope)` to
+ *      re-emit it on the bus.
+ *   5. The harness's contract guarantees: at least one terminal envelope
+ *      (`completed` | `failed` | `aborted`) per dispatch, in order, on
+ *      the same `correlation_id`.
+ *
+ * **A.1b refactor history (cortex#113 / IAW Phase A).** Before A.1b the
+ * listener spawned `CCSession` directly and built lifecycle envelopes
+ * inline. Now the listener owns *just* the envelope-to-request
+ * translation and the publish loop; everything CC-specific lives in
+ * `ClaudeCodeHarness`. The behavioural surface is unchanged — the same
+ * four envelope types fire in the same order on the same subjects with
+ * the same payloads — but the runner is now substrate-agnostic at the
+ * code level. A future `BusPeerHarness` slots in by switching which
+ * harness the listener constructs per dispatch.
  *
  * **Boundaries (per task contract):**
  *   - This file does NOT modify `dispatch-handler.ts`. The bus-driven path
  *     and the legacy direct-call path coexist until MIG-7.1 picks the
  *     entrypoint wiring.
  *   - This file does NOT modify `cc-session.ts` or `session-manager.ts`.
- *     CC spawning is byte-identical to the existing handler — we use the
- *     same `CCSession` primitive with the same opts.
+ *     The harness still wraps `CCSession` underneath; this file no
+ *     longer imports it.
  *   - This file does NOT post to Discord. Surfaces (worklog-manager via
  *     §4.7, dashboard via the bus) consume the lifecycle envelopes the
  *     runner emits and render their own way.
@@ -35,10 +49,11 @@
  *   The G-1111 design is explicit (§5.1): the surface-router is the single
  *   fan-out point, and adapters declare a `render(envelope)` shape. The
  *   runner is logically *also* a surface — it "renders" envelopes by
- *   producing CC sessions. Re-using the same shape keeps the router code
- *   path uniform (subject match → filter → render) and avoids inventing a
- *   parallel "consumer" registry. The semantic difference (render vs
- *   spawn) lives in the adapter implementation, not the registry.
+ *   dispatching to a substrate. Re-using the same shape keeps the router
+ *   code path uniform (subject match → filter → render) and avoids
+ *   inventing a parallel "consumer" registry. The semantic difference
+ *   (render vs dispatch) lives in the adapter implementation, not the
+ *   registry.
  */
 
 import type { Envelope } from "../bus/myelin/envelope-validator";
@@ -48,36 +63,31 @@ import type {
   SurfaceRouter,
 } from "../bus/surface-router";
 import type { SystemEventSource } from "../bus/system-events";
+import type {
+  DispatchRequest,
+  SessionHarness,
+} from "../common/substrates/types";
 import {
-  createDispatchTaskAbortedEvent,
-  createDispatchTaskCompletedEvent,
-  createDispatchTaskFailedEvent,
-  createDispatchTaskStartedEvent,
-} from "../bus/dispatch-events";
-import { CCSession, type CCSessionOpts, type CCSessionResult } from "./cc-session";
+  ClaudeCodeHarness,
+  type CCSessionFactory as ClaudeCodeFactory,
+} from "../substrates/claude-code/harness";
 
 // ---------------------------------------------------------------------------
 // Public types
 // ---------------------------------------------------------------------------
 
 /**
- * Factory for building a CC session from envelope-derived options. Default
- * implementation is `(opts) => new CCSession(opts)`. Tests inject a fake
- * factory so they can simulate session lifecycles deterministically without
- * spawning real `claude` processes.
+ * Factory for building a CC session from envelope-derived options.
  *
- * The factory MUST return an object that exposes `start()` (returns `this`,
- * fluent API) and `wait(): Promise<CCSessionResult>`. Real `CCSession`
- * matches; fakes implement the same surface.
+ * **A.1b note.** The listener no longer constructs `CCSession` directly —
+ * it instantiates a `ClaudeCodeHarness` which in turn uses this factory
+ * (via `ClaudeCodeHarnessOpts.ccSessionFactory`). The factory type is
+ * re-exported from the harness module so existing tests
+ * (`__tests__/dispatch-listener.test.ts`) keep compiling unchanged.
+ *
+ * Real impl: `(opts) => new CCSession(opts)`. Tests inject a fake.
  */
-export interface CCSessionLike {
-  start(): CCSessionLike;
-  wait(): Promise<CCSessionResult>;
-  kill?(): void;
-}
-export type CCSessionFactory = (opts: CCSessionOpts) => CCSessionLike;
-
-const defaultCCSessionFactory: CCSessionFactory = (opts) => new CCSession(opts);
+export type CCSessionFactory = ClaudeCodeFactory;
 
 /**
  * Payload shape for `dispatch.task.received` envelopes — the input contract
@@ -180,7 +190,7 @@ export function createDispatchListener(
     runtime,
     router,
     source,
-    ccSessionFactory = defaultCCSessionFactory,
+    ccSessionFactory,
     adapterId = "runner-dispatch-listener",
   } = opts;
   const subjects = opts.subjects ?? defaultSubjects(source.org);
@@ -195,11 +205,11 @@ export function createDispatchListener(
     // `payload.agent_id`), it goes here as a `PayloadFilter`.
     //
     // `signal` is accepted for contract symmetry but not currently forwarded
-    // into the CC session — the spawn lifecycle is governed by `cc-session`'s
-    // own inactivity timer (which already kills the child process on stall).
-    // A follow-on iteration can wire `signal.aborted` to `session.kill()` so
-    // surface-router timeouts end the CC process eagerly rather than waiting
-    // for cc-session's internal timeout to fire.
+    // into the substrate dispatch — the lifecycle is governed by the
+    // harness's own timeout/inactivity timers (per Q6 lock-in). A follow-on
+    // iteration can wire `signal.aborted` to `harness.shutdown({ graceful:
+    // false })` so surface-router timeouts end the CC process eagerly
+    // rather than waiting for cc-session's internal timer to fire.
     render: (envelope, _signal) => handleDispatchEnvelope(envelope, runtime, source, ccSessionFactory),
   };
 
@@ -218,7 +228,7 @@ export function createDispatchListener(
 }
 
 // ---------------------------------------------------------------------------
-// Internals — envelope → CC spawn → lifecycle emission
+// Internals — envelope → substrate dispatch → lifecycle emission
 // ---------------------------------------------------------------------------
 
 /**
@@ -243,10 +253,11 @@ function parsePayload(envelope: Envelope): DispatchTaskReceivedPayload | null {
   if (typeof p.prompt !== "string" || p.prompt.length === 0) return null;
   // Per Echo's review (cortex#34): the envelope-level validator only checks
   // `envelope.id`'s shape, not `payload.task_id`. Without this gate, a
-  // malformed publisher could slip a non-UUID `task_id` through to
-  // CCSession + worklog-manager and break correlation across `started` /
-  // `completed` / `failed` envelopes downstream. Reject at parse time so
-  // no envelopes are published and no CC process is spawned for a bad id.
+  // malformed publisher could slip a non-UUID `task_id` through to the
+  // substrate harness + worklog-manager and break correlation across
+  // `started` / `completed` / `failed` envelopes downstream. Reject at
+  // parse time so no envelopes are published and no CC process is
+  // spawned for a bad id.
   if (!UUID_RE.test(p.task_id)) {
     console.warn(
       `dispatch-listener: rejecting envelope ${envelope.id} — task_id missing or not UUID-shaped`,
@@ -257,41 +268,89 @@ function parsePayload(envelope: Envelope): DispatchTaskReceivedPayload | null {
 }
 
 /**
- * Map a parsed payload onto `CCSessionOpts`. Keeps the snake_case <-> camelCase
- * boundary in one place and avoids leaking envelope-payload field names into
- * cc-session.ts.
+ * Translate a parsed `DispatchTaskReceivedPayload` into the protocol-
+ * level `DispatchRequest` the substrate harness consumes.
+ *
+ * **A.1b boundary.** This is the snake_case → camelCase translation layer
+ * on the listener side. The harness consumes camelCase `DispatchRequest`
+ * fields; the envelope payload uses snake_case per §3.4. The mapping is
+ * a pure projection — no defaults, no policy decisions, no enrichment.
+ *
+ * **Why CC-runtime fields live on `req.runtime` and not the top level.**
+ * `DispatchRequest` is the substrate-agnostic contract. Fields like
+ * `cwd`, `bashAllowlist`, `groveChannel`, etc. are CC-specific. Putting
+ * them under `runtime` means future harnesses (`bus-peer`, `cursor`, ...)
+ * see a clean separation: dispatch-contract on top, substrate-specific
+ * knobs in the `runtime` block. CC reads what it needs; others ignore.
+ *
+ * **persona absence.** The legacy bus-driven path does NOT carry persona
+ * file data on the payload (persona injection happens at the dispatch-
+ * handler layer via the prompt-builder). We therefore omit `persona`
+ * from the request — the harness handles `persona === undefined` per
+ * the A.1b spec (optional field).
  */
-function buildCCOpts(payload: DispatchTaskReceivedPayload): CCSessionOpts {
-  const opts: CCSessionOpts = { prompt: payload.prompt };
-  if (payload.grove_channel !== undefined) opts.groveChannel = payload.grove_channel;
-  if (payload.grove_network !== undefined) opts.groveNetwork = payload.grove_network;
-  if (payload.agent_name !== undefined) opts.agentName = payload.agent_name;
-  // The agent_id from the envelope payload doubles as `agentId` on CCSession
-  // — this is the visible label propagated through `GROVE_AGENT_ID` env var.
-  opts.agentId = payload.agent_id;
-  if (payload.resume_session_id !== undefined) opts.resumeSessionId = payload.resume_session_id;
-  if (payload.allowed_tools !== undefined) opts.allowedTools = payload.allowed_tools;
-  if (payload.disallowed_tools !== undefined) opts.disallowedTools = payload.disallowed_tools;
-  if (payload.allowed_dirs !== undefined) opts.allowedDirs = payload.allowed_dirs;
-  if (payload.timeout_ms !== undefined) opts.timeoutMs = payload.timeout_ms;
-  if (payload.cwd !== undefined) opts.cwd = payload.cwd;
-  if (payload.additional_args !== undefined) opts.additionalArgs = payload.additional_args;
-  if (payload.project !== undefined) opts.project = payload.project;
-  if (payload.entity !== undefined) opts.entity = payload.entity;
-  if (payload.operator !== undefined) opts.operator = payload.operator;
-  return opts;
+function buildDispatchRequest(payload: DispatchTaskReceivedPayload): DispatchRequest {
+  const tools: DispatchRequest["tools"] = {
+    allow: payload.allowed_tools ?? [],
+    ...(payload.disallowed_tools !== undefined && { deny: payload.disallowed_tools }),
+  };
+
+  // Build the runtime block lazily — only attach the field for keys the
+  // payload actually carried. Keeps an explicit "empty payload" indis-
+  // tinguishable from "payload with no runtime block" at the harness end.
+  const runtime: NonNullable<DispatchRequest["runtime"]> = {};
+  if (payload.cwd !== undefined) runtime.cwd = payload.cwd;
+  if (payload.allowed_dirs !== undefined) runtime.allowedDirs = payload.allowed_dirs;
+  if (payload.additional_args !== undefined) runtime.additionalArgs = payload.additional_args;
+  if (payload.grove_channel !== undefined) runtime.groveChannel = payload.grove_channel;
+  if (payload.grove_network !== undefined) runtime.groveNetwork = payload.grove_network;
+  if (payload.resume_session_id !== undefined) runtime.resumeSessionId = payload.resume_session_id;
+  const hasRuntime = Object.keys(runtime).length > 0;
+
+  // Env-kind context block carries operator/entity/project labels.
+  // Build it iff the payload supplied any of the three; the harness
+  // surfaces them onto CCSessionOpts as before.
+  const envContext: Record<string, unknown> = {};
+  if (payload.operator !== undefined) envContext.operator = payload.operator;
+  if (payload.entity !== undefined) envContext.entity = payload.entity;
+  if (payload.project !== undefined) envContext.project = payload.project;
+  const hasEnvContext = Object.keys(envContext).length > 0;
+
+  const req: DispatchRequest = {
+    prompt: payload.prompt,
+    tools,
+    context: hasEnvContext ? [{ kind: "env", data: envContext }] : [],
+    agent: {
+      id: payload.agent_id,
+      displayName: payload.agent_name ?? payload.agent_id,
+    },
+    requestId: payload.task_id,
+    ...(hasRuntime && { runtime }),
+    ...(payload.timeout_ms !== undefined && { timeoutMs: payload.timeout_ms }),
+  };
+
+  return req;
 }
 
 /**
- * The render() implementation: parse → emit started → spawn → await →
- * emit completed/failed/aborted. Return Promise<void> so the surface-router
- * can await this with its render-timeout isolation.
+ * The render() implementation: parse → instantiate harness → iterate
+ * `harness.dispatch(req)` → publish each yielded envelope. Returns
+ * `Promise<void>` so the surface-router can await with its render-timeout
+ * isolation.
+ *
+ * **Per-dispatch harness construction (Q7 lock-in).** Every received
+ * envelope spawns a fresh `ClaudeCodeHarness` instance. The harness is
+ * stateless beyond its in-flight session tracking, so this is cheap;
+ * the alternative (a long-lived harness shared across dispatches) would
+ * couple `shutdown` semantics across unrelated dispatches and is not
+ * worth the savings for A.1b. Shared infrastructure (the CC factory)
+ * is threaded through via constructor opts.
  */
 async function handleDispatchEnvelope(
   envelope: Envelope,
   runtime: MyelinRuntime,
   source: SystemEventSource,
-  factory: CCSessionFactory,
+  ccSessionFactory: CCSessionFactory | undefined,
 ): Promise<void> {
   const payload = parsePayload(envelope);
   if (!payload) {
@@ -301,132 +360,24 @@ async function handleDispatchEnvelope(
     return;
   }
 
-  const startedAt = new Date();
-  const taskId = payload.task_id;
-  const agentId = payload.agent_id;
+  // Per-dispatch harness — see fn-doc above for rationale. `source` is
+  // structurally compatible between `SystemEventSource` and the harness's
+  // `DispatchEventSource` (both alias the same shape in `dispatch-events.ts`).
+  const harness: SessionHarness = new ClaudeCodeHarness({
+    source,
+    ...(ccSessionFactory !== undefined && { ccSessionFactory }),
+  });
 
-  // Emit `dispatch.task.started` BEFORE spawning so the bus reflects the
-  // intent even if the spawn itself errors synchronously. Awaiting publish
-  // is cheap (it's a no-op when the runtime is disabled) and gives the
-  // started event a strict happens-before relationship with the spawn.
-  await runtime.publish(
-    createDispatchTaskStartedEvent({ source, taskId, agentId, startedAt }),
-  );
+  const req = buildDispatchRequest(payload);
 
-  const ccOpts = buildCCOpts(payload);
-  let result: CCSessionResult | null = null;
-  let runtimeError: Error | null = null;
-
-  try {
-    const session = factory(ccOpts);
-    session.start();
-    result = await session.wait();
-  } catch (err) {
-    runtimeError = err instanceof Error ? err : new Error(String(err));
+  // Drain the harness's lifecycle stream onto the bus. The harness
+  // guarantees at least one terminal envelope; we publish whatever it
+  // yields, in order. Each `runtime.publish` awaits — keeping the
+  // strict happens-before ordering the original implementation relied
+  // on (`started` is observable before any terminal envelope, even when
+  // the runtime is the bus's actual NATS transport).
+  for await (const env of harness.dispatch(req)) {
+    await runtime.publish(env);
   }
-
-  // Choose terminal lifecycle event based on outcome.
-  if (runtimeError) {
-    // Runtime threw — failed. Distinct from `aborted` (which is "killed
-    // from outside" e.g. timeout, shutdown).
-    await runtime.publish(
-      createDispatchTaskFailedEvent({
-        source,
-        taskId,
-        agentId,
-        startedAt,
-        failedAt: new Date(),
-        errorSummary: truncateError(runtimeError.message),
-      }),
-    );
-    return;
-  }
-
-  if (!result) {
-    // Defensive: factory returned nothing parseable. Treat as failure
-    // rather than swallowing — silent success on a no-op session is the
-    // worst-of-both-worlds outcome.
-    await runtime.publish(
-      createDispatchTaskFailedEvent({
-        source,
-        taskId,
-        agentId,
-        startedAt,
-        failedAt: new Date(),
-        errorSummary: "session factory returned no result",
-      }),
-    );
-    return;
-  }
-
-  if (result.success) {
-    await runtime.publish(
-      createDispatchTaskCompletedEvent({
-        source,
-        taskId,
-        agentId,
-        startedAt,
-        completedAt: new Date(),
-        ...(result.response && { resultSummary: truncateSummary(result.response) }),
-      }),
-    );
-    return;
-  }
-
-  // Distinguish abort (timeout / external kill) from a regular failure.
-  //
-  // History (Echo round-1 W1): the previous implementation only looked at
-  // `result.exitCode === 143` (SIGTERM). That signal is UNREACHABLE for
-  // the canonical inactivity-timeout case, because cc-session.ts settles
-  // `wait()` via the `error` listener with `exitCode: 1` BEFORE the actual
-  // SIGTERM/143 fires. The fix lives in cc-session.ts: it now exposes
-  // `aborted: boolean` + `abortReason` on CCSessionResult, sourced from
-  // its internal `timedOut` flag, regardless of which listener wins the
-  // race. We treat that field as the source of truth and keep the
-  // exit-code-143 check as defense-in-depth (e.g. a SIGTERM delivered
-  // from outside without going through the inactivity timer).
-  if (result.aborted === true || result.exitCode === 143) {
-    await runtime.publish(
-      createDispatchTaskAbortedEvent({
-        source,
-        taskId,
-        agentId,
-        startedAt,
-        abortedAt: new Date(),
-        reason: result.abortReason ?? "timeout",
-      }),
-    );
-    return;
-  }
-
-  await runtime.publish(
-    createDispatchTaskFailedEvent({
-      source,
-      taskId,
-      agentId,
-      startedAt,
-      failedAt: new Date(),
-      errorSummary: `claude exited ${result.exitCode}`,
-    }),
-  );
-}
-
-/**
- * Trim error messages so a verbose stack doesn't blow the worklog message
- * limit downstream. 500 chars matches `system.inbound.failed`'s limit
- * (system-events §3.5.4) — keeping the dispatch family symmetric.
- */
-function truncateError(msg: string): string {
-  return msg.length > 500 ? msg.slice(0, 497) + "..." : msg;
-}
-
-/**
- * Trim CC response summaries. Discord embeds tolerate ~2000 chars but
- * surfaces typically render the first line + "(more)..." — caps at 1000
- * to leave room for a label prefix without truncation surprises.
- */
-function truncateSummary(text: string): string {
-  const first = text.split("\n", 1)[0] ?? text;
-  return first.length > 1000 ? first.slice(0, 997) + "..." : first;
 }
 

--- a/src/substrates/claude-code/__tests__/harness.test.ts
+++ b/src/substrates/claude-code/__tests__/harness.test.ts
@@ -284,6 +284,92 @@ describe("ClaudeCodeHarness — DispatchRequest → CCSessionOpts mapping", () =
     expect(envelopes).toHaveLength(2);
     expect(envelopes[1]?.type).toBe("dispatch.task.completed");
   });
+
+  test("A.1b: req.runtime fields plumb onto CCSessionOpts", async () => {
+    // A.1b extends DispatchRequest with an optional `runtime` block
+    // carrying CC-specific knobs (cwd, allowedDirs, bashAllowlist, etc.).
+    // The harness reads them onto CCSessionOpts; future non-CC harnesses
+    // ignore them.
+    const cap = captureFactory(makeResult());
+    const h = new ClaudeCodeHarness({ source: SOURCE, ccSessionFactory: cap.factory });
+    const req = makeRequest({
+      runtime: {
+        cwd: "/work",
+        allowedDirs: ["/work", "/tmp"],
+        additionalArgs: ["--verbose"],
+        groveChannel: "grove",
+        groveNetwork: "metafactory",
+        resumeSessionId: "sess-123",
+        bashAllowlist: { rules: [{ pattern: "ls" }], repos: ["grove"] },
+        bashGuardDisabled: false,
+      },
+    });
+
+    await drain(h.dispatch(req));
+
+    expect(cap.opts[0]?.cwd).toBe("/work");
+    expect(cap.opts[0]?.allowedDirs).toEqual(["/work", "/tmp"]);
+    expect(cap.opts[0]?.additionalArgs).toEqual(["--verbose"]);
+    expect(cap.opts[0]?.groveChannel).toBe("grove");
+    expect(cap.opts[0]?.groveNetwork).toBe("metafactory");
+    expect(cap.opts[0]?.resumeSessionId).toBe("sess-123");
+    expect(cap.opts[0]?.bashAllowlist).toEqual({
+      rules: [{ pattern: "ls" }],
+      repos: ["grove"],
+    });
+    expect(cap.opts[0]?.bashGuardDisabled).toBe(false);
+  });
+
+  test("A.1b: req.runtime takes precedence over env-kind context on conflict", async () => {
+    // If a payload happens to populate BOTH `req.runtime` AND a
+    // `context[kind=env]` block (defence in depth — different upstream
+    // adapters might use either path), `req.runtime` wins. This is the
+    // explicit-over-implicit principle: the new typed surface beats the
+    // legacy `context.data` route.
+    //
+    // Note: operator/entity/project don't live on `req.runtime` today —
+    // they only live in env context. The conflict is only resolvable for
+    // fields that overlap; for now nothing overlaps directly. This test
+    // asserts the *combination* path: both blocks supplied, harness reads
+    // both without throwing, env context still surfaces operator/etc.
+    const cap = captureFactory(makeResult());
+    const h = new ClaudeCodeHarness({ source: SOURCE, ccSessionFactory: cap.factory });
+    const req = makeRequest({
+      runtime: { cwd: "/work", groveChannel: "grove" },
+      context: [
+        { kind: "env", data: { operator: "andreas", entity: "pr/45", project: "cortex" } },
+      ],
+    });
+
+    await drain(h.dispatch(req));
+
+    expect(cap.opts[0]?.cwd).toBe("/work");
+    expect(cap.opts[0]?.groveChannel).toBe("grove");
+    expect(cap.opts[0]?.operator).toBe("andreas");
+    expect(cap.opts[0]?.entity).toBe("pr/45");
+    expect(cap.opts[0]?.project).toBe("cortex");
+  });
+
+  test("A.1b: persona is optional on DispatchRequest", async () => {
+    // Echo cortex#125: `req.persona` dropped to optional. A request with
+    // no persona block must still dispatch successfully (the harness
+    // doesn't inject persona — the prompt is already persona-injected
+    // upstream by dispatch-handler's prompt-builder path).
+    const cap = captureFactory(makeResult());
+    const h = new ClaudeCodeHarness({ source: SOURCE, ccSessionFactory: cap.factory });
+    const req: DispatchRequest = {
+      // NB: no `persona` field at all
+      prompt: "do it",
+      tools: { allow: [] },
+      context: [],
+      agent: { id: "cortex", displayName: "Cortex" },
+      requestId: REQUEST_ID,
+    };
+
+    const envelopes = await drain(h.dispatch(req));
+    expect(envelopes).toHaveLength(2);
+    expect(envelopes[1]?.type).toBe("dispatch.task.completed");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/substrates/claude-code/harness.ts
+++ b/src/substrates/claude-code/harness.ts
@@ -158,7 +158,10 @@ export interface ClaudeCodeHarnessOpts {
  * --output-format stream-json`. See file header for the full contract.
  */
 export class ClaudeCodeHarness implements SessionHarness {
-  readonly id: HarnessId = "claude-code";
+  // Echo cortex#125 nit: `as const` tightens the inferred literal type so
+  // any downstream `switch (harness.id)` exhaustiveness check sees this
+  // harness's exact substrate id rather than the wider `HarnessId` union.
+  readonly id = "claude-code" as const;
   readonly capabilities: Capability[];
 
   private readonly source: DispatchEventSource;
@@ -252,7 +255,14 @@ export class ClaudeCodeHarness implements SessionHarness {
 
     // Hard shutdown — kill every active session. Don't await — kill is
     // synchronous and `wait()` settlement happens via cc-session's own
-    // exit-listener wiring on the dispatch generator side.
+    // exit-listener wiring on the dispatch generator side, which then
+    // removes the session from `activeSessions` in the dispatch's
+    // `finally` block. Echo cortex#125 nit: the previous code called
+    // `activeSessions.clear()` after this loop, but that was redundant —
+    // each dispatch's `finally` (`this.activeSessions.delete(session)`)
+    // already removes its session once `wait()` settles. Clearing here
+    // would race with in-flight dispatches that haven't yet observed
+    // the kill, and (worse) skip the per-dispatch cleanup symmetry.
     for (const session of this.activeSessions) {
       try {
         session.kill?.();
@@ -266,7 +276,6 @@ export class ClaudeCodeHarness implements SessionHarness {
         );
       }
     }
-    this.activeSessions.clear();
   }
 
   // -------------------------------------------------------------------------
@@ -277,10 +286,17 @@ export class ClaudeCodeHarness implements SessionHarness {
    * Translate a `DispatchRequest` to `CCSessionOpts`. Maps the protocol-
    * level camelCase fields onto cc-session's existing options shape.
    *
-   * The translation is intentionally narrow — A.1 only carries enough
-   * fields to make a basic CC dispatch work. Later phases (A.3 emit-site
-   * parameterisation, A.5 stack identity) will extend this map without
-   * breaking the contract.
+   * A.1b widens this from the A.1 baseline by absorbing the legacy
+   * `buildCCOpts()` from `dispatch-listener.ts` — every CC-runtime knob
+   * the listener used to thread is now read from `req.runtime`. The
+   * harness is the single place that knows about `CCSessionOpts`.
+   *
+   * **Decision: prefer `req.runtime` fields over context kinds.** A.1
+   * read operator/entity/project from `context[kind=env]`; A.1b adds
+   * the same fields under `req.runtime` plus the eight runtime fields
+   * from the legacy listener. Both paths are kept (context kind = env
+   * still works for forward compat with adapters that haven't migrated)
+   * but explicit `req.runtime` always wins on conflict.
    */
   private buildCCOpts(req: DispatchRequest): CCSessionOpts {
     const opts: CCSessionOpts = {
@@ -312,19 +328,45 @@ export class ClaudeCodeHarness implements SessionHarness {
       opts.timeoutMs = inactivityMs;
     }
 
+    // A.1b: absorb the CC-specific runtime knobs the dispatch-listener
+    // used to thread directly into CCSession. All optional; only set
+    // when the request supplied a value (so undefined stays undefined
+    // and CCSession's own defaults still apply).
+    const runtime = req.runtime;
+    if (runtime) {
+      if (runtime.cwd !== undefined) opts.cwd = runtime.cwd;
+      if (runtime.allowedDirs !== undefined) opts.allowedDirs = runtime.allowedDirs;
+      if (runtime.bashAllowlist !== undefined) opts.bashAllowlist = runtime.bashAllowlist;
+      if (runtime.bashGuardDisabled !== undefined) opts.bashGuardDisabled = runtime.bashGuardDisabled;
+      if (runtime.additionalArgs !== undefined) opts.additionalArgs = runtime.additionalArgs;
+      if (runtime.groveChannel !== undefined) opts.groveChannel = runtime.groveChannel;
+      if (runtime.groveNetwork !== undefined) opts.groveNetwork = runtime.groveNetwork;
+      if (runtime.resumeSessionId !== undefined) opts.resumeSessionId = runtime.resumeSessionId;
+    }
+
     // Surface env context kinds the substrate understands. Unknown kinds
-    // are silently dropped per the protocol contract.
+    // are silently dropped per the protocol contract. Kept alongside the
+    // `req.runtime` path above for adapters that still emit env-kind
+    // context blocks; `req.runtime` values take precedence on conflict.
     for (const ctx of req.context) {
       if (ctx.kind === "env" && typeof ctx.data === "object" && ctx.data !== null) {
         const env = ctx.data as Record<string, unknown>;
-        if (typeof env.operator === "string") opts.operator = env.operator;
-        if (typeof env.entity === "string") opts.entity = env.entity;
-        if (typeof env.project === "string") opts.project = env.project;
+        if (opts.operator === undefined && typeof env.operator === "string") opts.operator = env.operator;
+        if (opts.entity === undefined && typeof env.entity === "string") opts.entity = env.entity;
+        if (opts.project === undefined && typeof env.project === "string") opts.project = env.project;
       }
     }
 
     return opts;
   }
+
+  /**
+   * Latches once a non-UUID `requestId` has been seen so the diagnostic
+   * fires exactly once per harness instance — a misconfigured producer
+   * dispatching dozens of bad ids per minute does not flood the log.
+   * Mirrors the same warn-once pattern in `DispatchHandler.warnedMissingSource`.
+   */
+  private warnedNonUuidRequestId = false;
 
   /**
    * Per-dispatch correlation key. Uses `requestId` when valid (UUID), else
@@ -335,9 +377,22 @@ export class ClaudeCodeHarness implements SessionHarness {
    * Same defensive pattern that lives in dispatch-listener.ts — the
    * schema only allows UUID `correlation_id`, so we shield the caller
    * from accidental validation failures at publish time.
+   *
+   * **Echo cortex#125 nit.** When the fallback path fires (non-UUID
+   * input), we emit a one-time warning so the operator sees that the
+   * substrate is silently rewriting `correlation_id` — a misconfigured
+   * producer would otherwise be undetectable except by stack trace
+   * comparison across envelopes.
    */
   private correlationFor(req: DispatchRequest): string {
-    return isUuid(req.requestId) ? req.requestId : randomUUID();
+    if (isUuid(req.requestId)) return req.requestId;
+    if (!this.warnedNonUuidRequestId) {
+      console.warn(
+        `claude-code-harness: requestId "${req.requestId}" is not UUID-shaped — substituting a generated correlation_id (this warning fires once per harness instance)`,
+      );
+      this.warnedNonUuidRequestId = true;
+    }
+    return randomUUID();
   }
 
   private buildStartedEnvelope(


### PR DESCRIPTION
**Refs:** cortex#113 (IAW Phase A scope), cortex#125 (A.1 — `SessionHarness` interface + `ClaudeCodeHarness`)
**Branch:** `feat/i-102-dispatch-flip`

## Summary

Phase A.1b of the Internet of Agentic Work migration. Flips `dispatch-listener.ts` from calling `cc-session.ts` directly to dispatching through the `SessionHarness` abstraction landed in cortex#125. This is the cutover that makes the substrate-harness layer live end-to-end.

**Behaviour-preserving refactor.** The same four envelope types (`dispatch.task.started` / `completed` / `failed` / `aborted`) fire in the same order on the same subjects with the same payloads. Existing dispatch-listener tests pass unchanged. The runner is now substrate-agnostic at the code level — a future `BusPeerHarness` slots in by switching which harness `handleDispatchEnvelope` constructs per dispatch.

## What changed

### `DispatchRequest` (`src/common/substrates/types.ts`)

Two changes from Echo's cortex#125 review:

1. **New optional `runtime: DispatchRuntime` field** carrying CC-specific knobs the listener used to thread into `CCSessionOpts` directly:
   - `cwd`, `allowedDirs`, `bashAllowlist`, `bashGuardDisabled`, `additionalArgs`, `groveChannel`, `groveNetwork`, `resumeSessionId`
   - All optional. Future non-CC harnesses silently ignore knobs they don't recognise.
2. **`persona` dropped to optional.** Today the runner already inlines persona content via the prompt-builder path before constructing the request, so the harness layer doesn't itself need to surface the persona file. Kept on the type as an optional provenance hint and forward door for substrates that DO inject persona at dispatch time.

### `ClaudeCodeHarness` (`src/substrates/claude-code/harness.ts`)

- `buildCCOpts` now reads `req.runtime` (absorbs the legacy listener mapping) and keeps env-kind context (`operator`, `entity`, `project`) as a fallback for adapters that still emit env-kind context blocks. Explicit `req.runtime` values win on conflict.

**Three Echo cortex#125 nits applied:**

- `harness.ts:164` — `readonly id = "claude-code" as const` for tighter inference in downstream `switch (harness.id)` exhaustiveness checks.
- `harness.ts:correlationFor` — one-time `console.warn` when a non-UUID `requestId` is silently rewritten. Latched on `warnedNonUuidRequestId` to avoid log flood under a misconfigured producer.
- `harness.ts:shutdown` — dropped the redundant `activeSessions.clear()` after the kill loop. Each dispatch's `finally` already removes its session from the set when `wait()` settles. The clear was a race waiting to happen against in-flight dispatches.

### `dispatch-listener.ts` (`src/runner/`)

- No longer imports `CCSession` or any dispatch-event constructor. Builds a `DispatchRequest` from the parsed payload, instantiates a per-dispatch `ClaudeCodeHarness`, and re-publishes every yielded envelope onto the bus.
- New private `buildDispatchRequest()` replaces the inline `buildCCOpts()` mapping.
- `CCSessionFactory` is re-exported as an alias of the harness's factory type — existing tests keep compiling unchanged.
- **Per-dispatch harness construction (Q7 lock-in).** Every received envelope spawns a fresh `ClaudeCodeHarness` instance. The harness is stateless beyond its in-flight session tracking; sharing across dispatches would couple `shutdown` semantics across unrelated work. Shared infrastructure (the CC factory) threads through via constructor opts.

## Tests

- 18 existing `dispatch-listener.test.ts` tests pass unchanged (no behavioural regression).
- 2 new listener tests cover edge cases introduced by the flip:
  - `agent_name` falls back to `agent_id` when omitted (new path through `DispatchRequest.agent.displayName`).
  - Bare payload (no runtime knobs) produces a minimal `CCSessionOpts` with every CC knob undefined.
- 3 new harness tests cover the new `runtime` surface:
  - `req.runtime` fields plumb correctly onto `CCSessionOpts`.
  - `req.runtime` + env-kind context coexist; both populate independent fields.
  - Persona-less request still dispatches successfully.
- Full repo test suite: 2545 pass, 1 skip, 0 fail (was 2540 before this PR).
- `bunx tsc --noEmit` clean.

## Test plan

- [x] `bunx tsc --noEmit` clean
- [x] `bun test src/common/substrates/ src/substrates/ src/runner/` — 0 failures
- [x] `bun test` (full repo) — 0 new failures
- [x] Existing dispatch-listener tests pass without modification (verifies behavioural parity)
- [x] New tests cover the flip's edge cases + the new `req.runtime` surface

## Anti-scope

Per the cortex#113 A.1b scope:

- `cc-session.ts` untouched — still the leaf primitive; `ClaudeCodeHarness` wraps it, `dispatch-listener` no longer imports it.
- `BusPeerHarness` not in this PR — separate follow-up (A.1c).
- `cortex.yaml` `stack:` block — A.5 work.
- Envelope schema changes — A.2/A.3 work.

recommend: merge