### PR TITLE
feat(envelope): IAW A.2 — bump vendored myelin envelope to post-F-021 + signed_by (refs cortex#113, cortex#109)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -246,7 +246,7 @@ What cortex depends on, what cortex must not do, and what to read in each upstre
 |--------|--------|
 | Spec home | `the-metafactory/myelin` — `schemas/envelope.schema.json` + `specs/namespace.md`. |
 | Status | ✅ Shipped (MY-100 — ISA 30/30 complete). MY-102 (TS library) and MY-200 (sovereignty enforcement) on the myelin roadmap. |
-| Cortex's dependency | **Vendored** at `src/bus/myelin/vendor/` — pinned at upstream commit `96b14ea`. Vendor bumps are explicit PRs. |
+| Cortex's dependency | **Vendored** at `src/bus/myelin/vendor/` — pinned at upstream commit `4578ae1` (IAW Phase A.2 bump from `96b14ea`, post-F-021 task envelope + MY-400 chain-of-stamps + F-15 economics). Vendor bumps are explicit PRs. |
 | Cortex's contract | Cortex never extends the envelope schema. Cortex validates inbound envelopes via Ajv2020 before processing. Cortex publishes envelopes whose `type` matches the documented `domain.entity.action` grammar. Cortex sets `sovereignty` per-envelope at publish time (defaults: `local`, `frontier_ok: true`, `model_class: any` for review/dispatch domains; tightened for sensitive payloads). |
 | Subject namespace | `local.{org}.{domain}.{entity}.{action}` (org-only), `federated.{org}.{domain}.{entity}.{action}` (cross-org via sovereignty), `public.{domain}.{entity}.{action}` (unrestricted). |
 | Coupling discipline | Cortex MUST NOT runtime-import `myelin/` — vendor schema only. (Once MY-102 ships a `@metafactory/myelin` TS library it may be added as a dependency.) |

--- a/src/bus/myelin/__tests__/envelope-validator.test.ts
+++ b/src/bus/myelin/__tests__/envelope-validator.test.ts
@@ -10,9 +10,12 @@
 
 import { describe, expect, test } from "bun:test";
 import {
+  getLastStampPrincipal,
+  getSignedByChain,
   SCHEMA_SOURCE_COMMIT,
   tryParseEnvelope,
   validateEnvelope,
+  type Envelope,
 } from "../envelope-validator";
 import validEnvelope from "../vendor/__fixtures__/valid-envelope.json" with { type: "json" };
 import invalidMissingSovereignty from "../vendor/__fixtures__/invalid-missing-sovereignty.json" with { type: "json" };
@@ -104,7 +107,7 @@ describe("envelope-validator", () => {
   // sig length per the schema's minLength constraint.
   const ED25519_SIG = "A".repeat(88);
 
-  test("accepts an envelope with valid ed25519 signed_by", () => {
+  test("accepts an envelope with valid ed25519 signed_by (legacy single-stamp shim)", () => {
     const env = {
       ...(validEnvelope as object),
       signed_by: {
@@ -117,7 +120,12 @@ describe("envelope-validator", () => {
     const result = validateEnvelope(env);
     expect(result.ok).toBe(true);
     if (result.ok) {
-      expect(result.envelope.signed_by?.method).toBe("ed25519");
+      // Single-stamp wire shape — surfaced as the object form. `getSignedByChain`
+      // normalises this to an array in the next describe block.
+      const stamp = result.envelope.signed_by;
+      expect(stamp && !Array.isArray(stamp) ? stamp.method : null).toBe(
+        "ed25519",
+      );
     }
   });
 
@@ -134,8 +142,13 @@ describe("envelope-validator", () => {
     };
     const result = validateEnvelope(env);
     expect(result.ok).toBe(true);
-    if (result.ok && result.envelope.signed_by?.method === "hub-stamp") {
-      expect(result.envelope.signed_by.stamped_by).toBe("did:mf:hub-eu-1");
+    if (result.ok) {
+      const stamp = result.envelope.signed_by;
+      expect(
+        stamp && !Array.isArray(stamp) && stamp.method === "hub-stamp"
+          ? stamp.stamped_by
+          : null,
+      ).toBe("did:mf:hub-eu-1");
     }
   });
 
@@ -180,5 +193,299 @@ describe("envelope-validator", () => {
     };
     const result = validateEnvelope(env);
     expect(result.ok).toBe(false);
+  });
+
+  // IAW Phase A.2 — chain-of-stamps (myelin#31). Cortex now surfaces the
+  // array form of `signed_by` so Phase B can wire trust decisions against
+  // real chain shapes; this slice asserts the schema accepts the array
+  // form and the cortex helpers normalise both shapes uniformly.
+
+  test("accepts an envelope with a chain-of-stamps (array form, myelin#31)", () => {
+    const env = {
+      ...(validEnvelope as object),
+      signed_by: [
+        {
+          method: "ed25519",
+          principal: "did:mf:luna",
+          signature: ED25519_SIG,
+          at: "2026-05-08T09:00:00Z",
+          role: "origin",
+        },
+        {
+          method: "hub-stamp",
+          principal: "did:mf:luna",
+          stamped_by: "did:mf:hub-eu-1",
+          signature: ED25519_SIG,
+          at: "2026-05-08T09:00:01Z",
+          role: "transit",
+        },
+      ],
+    };
+    const result = validateEnvelope(env);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      const stamp = result.envelope.signed_by;
+      expect(Array.isArray(stamp)).toBe(true);
+      if (Array.isArray(stamp)) {
+        expect(stamp.length).toBe(2);
+        expect(stamp[0]?.method).toBe("ed25519");
+        expect(stamp[0]?.role).toBe("origin");
+        expect(stamp[1]?.method).toBe("hub-stamp");
+      }
+    }
+  });
+
+  test("rejects a chain-of-stamps with an invalid stamp shape", () => {
+    const env = {
+      ...(validEnvelope as object),
+      signed_by: [
+        {
+          method: "ed25519",
+          principal: "did:mf:luna",
+          signature: ED25519_SIG,
+          at: "2026-05-08T09:00:00Z",
+        },
+        {
+          method: "ed25519",
+          principal: "did:mf:luna",
+          // signature: missing — second stamp is malformed
+          at: "2026-05-08T09:00:01Z",
+        },
+      ],
+    };
+    const result = validateEnvelope(env);
+    expect(result.ok).toBe(false);
+  });
+
+  test("rejects an empty chain-of-stamps", () => {
+    const env = { ...(validEnvelope as object), signed_by: [] };
+    const result = validateEnvelope(env);
+    // The schema requires minItems: 1 when the array shape is used.
+    expect(result.ok).toBe(false);
+  });
+
+  test("accepts an unknown stamp role at the schema layer (forward-compat)", () => {
+    // The schema's `stampRole` enum is closed today, so a literal unknown
+    // role would be rejected. Older stamps with no `role` field at all
+    // remain accepted — verified by the legacy-shim test above. This test
+    // exercises the canonical, well-known roles to lock the enum surface.
+    const env = {
+      ...(validEnvelope as object),
+      signed_by: [
+        {
+          method: "ed25519",
+          principal: "did:mf:luna",
+          signature: ED25519_SIG,
+          at: "2026-05-08T09:00:00Z",
+          role: "notary",
+        },
+      ],
+    };
+    const result = validateEnvelope(env);
+    expect(result.ok).toBe(true);
+  });
+});
+
+describe("envelope-validator — F-021 task envelope fields (IAW Phase A.2)", () => {
+  // F-021 adds five optional task-routing fields. They are SURFACED in cortex
+  // (visible on the typed Envelope) but not yet acted on for routing or
+  // trust — that's IAW Phase B / cortex#102 territory.
+
+  const ED25519_SIG = "A".repeat(88);
+
+  test("accepts an envelope with all F-021 task fields populated (direct)", () => {
+    const env = {
+      ...(validEnvelope as object),
+      requirements: ["code-review", "typescript"],
+      sovereignty_required: "strict",
+      deadline: "2026-06-01T00:00:00Z",
+      distribution_mode: "direct",
+      target_principal: "did:mf:echo",
+    };
+    const result = validateEnvelope(env);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.envelope.requirements).toEqual(["code-review", "typescript"]);
+      expect(result.envelope.sovereignty_required).toBe("strict");
+      expect(result.envelope.distribution_mode).toBe("direct");
+      expect(result.envelope.target_principal).toBe("did:mf:echo");
+      expect(result.envelope.deadline).toBe("2026-06-01T00:00:00Z");
+    }
+  });
+
+  test("accepts a broadcast envelope with no target_principal", () => {
+    const env = {
+      ...(validEnvelope as object),
+      distribution_mode: "broadcast",
+      sovereignty_required: "open",
+    };
+    const result = validateEnvelope(env);
+    expect(result.ok).toBe(true);
+  });
+
+  test("rejects a direct envelope missing target_principal", () => {
+    const env = {
+      ...(validEnvelope as object),
+      distribution_mode: "direct",
+      // target_principal: missing — schema cross-field rule rejects
+    };
+    const result = validateEnvelope(env);
+    expect(result.ok).toBe(false);
+  });
+
+  test("rejects a delegate envelope missing target_principal", () => {
+    const env = {
+      ...(validEnvelope as object),
+      distribution_mode: "delegate",
+    };
+    const result = validateEnvelope(env);
+    expect(result.ok).toBe(false);
+  });
+
+  test("rejects an unknown sovereignty_required mode", () => {
+    const env = {
+      ...(validEnvelope as object),
+      sovereignty_required: "absolute",
+    };
+    const result = validateEnvelope(env);
+    expect(result.ok).toBe(false);
+  });
+
+  test("rejects an unknown distribution_mode", () => {
+    const env = {
+      ...(validEnvelope as object),
+      distribution_mode: "multicast",
+      target_principal: "did:mf:echo",
+    };
+    const result = validateEnvelope(env);
+    expect(result.ok).toBe(false);
+  });
+
+  test("rejects a target_principal that is not a DID", () => {
+    const env = {
+      ...(validEnvelope as object),
+      distribution_mode: "direct",
+      target_principal: "echo@example.com",
+    };
+    const result = validateEnvelope(env);
+    expect(result.ok).toBe(false);
+  });
+
+  test("accepts an envelope with the F-021 bidding sovereignty mode", () => {
+    const env = {
+      ...(validEnvelope as object),
+      sovereignty_required: "bidding",
+      distribution_mode: "broadcast",
+    };
+    const result = validateEnvelope(env);
+    expect(result.ok).toBe(true);
+  });
+
+  test("envelope without F-021 fields stays valid (backward compatible)", () => {
+    // The pre-F-021 fixture has no task fields — the new schema must accept
+    // it unchanged. This locks the back-compat guarantee for legacy emitters
+    // until A.3 parameterises emit sites.
+    const result = validateEnvelope(validEnvelope);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.envelope.requirements).toBeUndefined();
+      expect(result.envelope.distribution_mode).toBeUndefined();
+      expect(result.envelope.target_principal).toBeUndefined();
+    }
+  });
+
+  test("rejects a requirements tag that violates the DID-style pattern", () => {
+    const env = {
+      ...(validEnvelope as object),
+      requirements: ["TypeScript"], // capital letter — pattern is lowercase only
+    };
+    const result = validateEnvelope(env);
+    expect(result.ok).toBe(false);
+  });
+});
+
+describe("envelope-validator — chain helpers (IAW Phase A.2)", () => {
+  const ED25519_SIG = "A".repeat(88);
+
+  test("getSignedByChain returns [] for an unsigned envelope", () => {
+    const env = tryParseEnvelope(validEnvelope);
+    expect(env).not.toBeNull();
+    expect(getSignedByChain(env as Envelope)).toEqual([]);
+  });
+
+  test("getSignedByChain normalises a single-stamp object to a 1-element array", () => {
+    const env: Envelope = {
+      ...(validEnvelope as unknown as Envelope),
+      signed_by: {
+        method: "ed25519",
+        principal: "did:mf:luna",
+        signature: ED25519_SIG,
+        at: "2026-05-08T09:00:00Z",
+      },
+    };
+    const chain = getSignedByChain(env);
+    expect(chain.length).toBe(1);
+    expect(chain[0]?.method).toBe("ed25519");
+  });
+
+  test("getSignedByChain returns the array form as-is", () => {
+    const env: Envelope = {
+      ...(validEnvelope as unknown as Envelope),
+      signed_by: [
+        {
+          method: "ed25519",
+          principal: "did:mf:luna",
+          signature: ED25519_SIG,
+          at: "2026-05-08T09:00:00Z",
+          role: "origin",
+        },
+        {
+          method: "hub-stamp",
+          principal: "did:mf:luna",
+          stamped_by: "did:mf:hub-eu-1",
+          signature: ED25519_SIG,
+          at: "2026-05-08T09:00:01Z",
+          role: "transit",
+        },
+      ],
+    };
+    const chain = getSignedByChain(env);
+    expect(chain.length).toBe(2);
+    expect(chain[1]?.method).toBe("hub-stamp");
+  });
+
+  test("getLastStampPrincipal returns the principal of the last stamp", () => {
+    const env: Envelope = {
+      ...(validEnvelope as unknown as Envelope),
+      signed_by: [
+        {
+          method: "ed25519",
+          principal: "did:mf:luna",
+          signature: ED25519_SIG,
+          at: "2026-05-08T09:00:00Z",
+        },
+        {
+          method: "hub-stamp",
+          principal: "did:mf:luna",
+          stamped_by: "did:mf:hub-eu-1",
+          signature: ED25519_SIG,
+          at: "2026-05-08T09:00:01Z",
+        },
+      ],
+    };
+    expect(getLastStampPrincipal(env)).toBe("did:mf:luna");
+  });
+
+  test("getLastStampPrincipal returns undefined for an unsigned envelope", () => {
+    const env = tryParseEnvelope(validEnvelope);
+    expect(env).not.toBeNull();
+    expect(getLastStampPrincipal(env as Envelope)).toBeUndefined();
+  });
+
+  test("schema source commit points at the post-F-021 myelin pin", () => {
+    // Lock the pin so future bumps surface in a code review.
+    expect(SCHEMA_SOURCE_COMMIT).toBe(
+      "4578ae1e9bc595e667fbb356ea2c12c8c2c3cc8a",
+    );
   });
 });

--- a/src/bus/myelin/envelope-validator.ts
+++ b/src/bus/myelin/envelope-validator.ts
@@ -1,15 +1,33 @@
 /**
- * G-1100.B: Myelin envelope validator.
+ * G-1100.B / IAW Phase A.2: Myelin envelope validator.
  *
  * Validates inbound envelopes against the vendored myelin schema. The
  * schema is copied verbatim from `~/Developer/myelin/schemas/envelope.schema.json`
- * pinned at commit 96b14ea (myelin#22 — MY-400 Group 1: identity types).
- * Per docs/design-collaboration-surface.md §9 coupling rules, grove
- * MUST NOT import from `myelin/` at runtime — the schema travels with us
- * by value.
+ * pinned at commit 4578ae1 (myelin main, post-F-021 + MY-400 chain-of-stamps
+ * + F-15 economics + F-5 sovereignty policy + F-10 bidding + F-11 capability
+ * discovery + F-019/F-020 task subjects).
  *
- * To upgrade the schema: copy the file, update the `SCHEMA_SOURCE_COMMIT`
- * constant, run the tests, ship a PR. There is no auto-sync.
+ * Per docs/design-collaboration-surface.md §9 coupling rules, cortex MUST
+ * NOT import from `myelin/` at runtime — the schema travels with us by
+ * value. To upgrade the schema: copy the file, update the
+ * `SCHEMA_SOURCE_COMMIT` constant, extend the vendored types below, run the
+ * tests, ship a PR. There is no auto-sync.
+ *
+ * **IAW Phase A.2 bump (from commit 96b14ea → 4578ae1):**
+ *
+ * The vendored Envelope interface now mirrors the post-F-021 wire shape.
+ * New optional fields surfaced (NOT consumed for trust decisions in this
+ * slice — that's IAW Phase B / cortex#102):
+ *
+ *   - `signed_by` accepts a single stamp OR a chain (`SignedBy[]`) per
+ *     myelin#31. `getSignedByChain()` normalises both shapes into an array.
+ *   - `requirements`, `sovereignty_required`, `deadline`,
+ *     `distribution_mode`, `target_principal` per F-021.
+ *   - `economics` upgraded to F-15 typed shape (`budget` / `actual` /
+ *     `wallet` / `billing_ref` / `currency`), still optional and not
+ *     security-bearing per myelin architecture.md §5.2.
+ *   - Stamps may carry an optional semantic `role` (`origin` / `transit` /
+ *     `accountability` / `sovereignty` / `notary`) per myelin#31.
  */
 
 // The myelin schema declares draft 2020-12 ($schema), so use Ajv's
@@ -19,7 +37,7 @@ import addFormats from "ajv-formats";
 import schema from "./vendor/envelope.schema.json" with { type: "json" };
 
 /** Pin so future maintainers know which myelin commit the schema was lifted from. */
-export const SCHEMA_SOURCE_COMMIT = "96b14ea6f0adfdface89d326e4e6cb36856a073f";
+export const SCHEMA_SOURCE_COMMIT = "4578ae1e9bc595e667fbb356ea2c12c8c2c3cc8a";
 
 /**
  * Hand-typed Envelope shape matching the JSON Schema. We hand-write rather
@@ -50,21 +68,83 @@ export interface Envelope {
     /** Constraint on which model class may process the payload. */
     model_class: "local-only" | "frontier" | "any";
   };
-  /** Reserved for future marketplace integration. Empty object today. */
-  economics?: Record<string, unknown>;
+  /**
+   * F-15 economics block — token budget, actual usage, billing attribution.
+   * Mutable annotation field; intermediaries may aggregate. Per myelin
+   * `architecture.md` §5.2 this field MUST NOT inform security or trust
+   * decisions — surface it for observability and cost accounting only.
+   */
+  economics?: Economics;
   /** Forward-compatible metadata. Optional. */
   extensions?: Record<string, unknown>;
   /** Arbitrary signal content. */
   payload: Record<string, unknown>;
   /**
    * Identity attestation — proves who sent this envelope. Optional in the
-   * schema (envelope predates MY-400 identity layer). Discriminated on
-   * `method`: `ed25519` is the bare per-bot signature; `hub-stamp` adds a
-   * federation-hub re-signature for cross-org trust. Both shapes are
-   * defined upstream — see `envelope.schema.json` `signed_by.oneOf`.
+   * schema (envelopes predate MY-400 identity layer).
+   *
+   * **Wire shapes accepted (myelin#31 chain-of-stamps):**
+   *   - Single stamp object (legacy back-compat shim, single signer).
+   *   - Array of stamps (canonical post-#31 chain form). Each stamp signs
+   *     the canonical bytes of the envelope *including the prior chain* —
+   *     tampering with any earlier stamp invalidates every subsequent
+   *     stamp's signature.
+   *
+   * Cortex callers that want a uniform view should use
+   * {@link getSignedByChain} to normalise both shapes to `SignedBy[]`.
+   *
+   * IAW Phase A.2: `signed_by` is **surfaced but not yet consumed for
+   * trust decisions** — that wiring lands in IAW Phase B (cortex#102).
    */
-  signed_by?: SignedByEd25519 | SignedByHubStamp;
+  signed_by?: SignedBy | SignedBy[];
+  /**
+   * F-021 — capability tags the task needs. Matched against AGENT_CAPABILITIES
+   * (myelin#11). Empty array = no filter. Pattern parallels DID_RE: no
+   * trailing or consecutive hyphens.
+   */
+  requirements?: string[];
+  /**
+   * F-021 — minimum agent sovereignty mode required to ack the task.
+   *
+   * | mode | semantics |
+   * |---|---|
+   * | `open` | ack all |
+   * | `selective` | evaluate-and-may-nak |
+   * | `strict` | explicit capability + sovereignty match |
+   * | `bidding` | F-10 broadcast bid-request, collect signed responses, select winner |
+   */
+  sovereignty_required?: SovereigntyRequirement;
+  /** F-021 — ISO-8601 absolute soft deadline. Informs nak `not-now` decisions. */
+  deadline?: string;
+  /**
+   * F-021 — operator-facing routing semantics.
+   *
+   * | mode | semantics |
+   * |---|---|
+   * | `broadcast` | competing consumers — first ack wins |
+   * | `direct` | named recipient — requires `target_principal` |
+   * | `delegate` | outcome handoff (multi-step orchestration) — requires `target_principal` |
+   */
+  distribution_mode?: DistributionMode;
+  /**
+   * F-021 — required when `distribution_mode` is `direct` or `delegate`.
+   * DID of the receiving agent (`did:mf:<name>`).
+   */
+  target_principal?: string;
 }
+
+/**
+ * Discriminated stamp shape — one entry in an envelope's `signed_by` chain.
+ * `method` selects which fields are present:
+ *   - `"ed25519"` — bare per-bot signature; intra-org trust.
+ *   - `"hub-stamp"` — federation hub re-signature for cross-org trust.
+ *
+ * Optional `role` (myelin#31) is the semantic position of the stamp in the
+ * chain (`origin` / `transit` / `accountability` / `sovereignty` / `notary`).
+ * Consumers that need role-aware predicates MUST handle the undefined case
+ * — pre-#31 stamps and the legacy shim do not carry a role.
+ */
+export type SignedBy = SignedByEd25519 | SignedByHubStamp;
 
 /**
  * Bare ed25519 signature — the principal signs the envelope directly.
@@ -79,6 +159,8 @@ export interface SignedByEd25519 {
   signature: string;
   /** ISO-8601 timestamp the signature was produced. */
   at: string;
+  /** Optional semantic role of this stamp in the chain (myelin#31). */
+  role?: StampRole;
 }
 
 /**
@@ -96,6 +178,80 @@ export interface SignedByHubStamp {
   signature: string;
   /** ISO-8601 timestamp the hub signed. */
   at: string;
+  /** Optional semantic role of this stamp in the chain (myelin#31). */
+  role?: StampRole;
+}
+
+/**
+ * Semantic position of a stamp inside a chain (myelin#31). Roles describe
+ * what the stamp ATTESTS, not what the principal IS. Optional for
+ * back-compat — pre-#31 stamps do not carry a role.
+ */
+export type StampRole =
+  | "origin"
+  | "transit"
+  | "accountability"
+  | "sovereignty"
+  | "notary";
+
+/**
+ * F-021 — `sovereignty_required` enum. Determines how aggressively
+ * candidates may decline a task before nakking.
+ */
+export type SovereigntyRequirement =
+  | "open"
+  | "selective"
+  | "strict"
+  | "bidding";
+
+/** F-021 — `distribution_mode` enum. */
+export type DistributionMode = "broadcast" | "direct" | "delegate";
+
+/**
+ * F-15 economics — token budget, actual usage, billing attribution.
+ *
+ * Per myelin `architecture.md` §5.2, this is a **mutable annotation field**
+ * sitting intentionally outside the L4 signature so intermediaries can
+ * accumulate cost without invalidating attestations. It MUST NOT inform
+ * security or trust decisions — surface it for observability only.
+ */
+export interface Economics {
+  /** Publisher-set constraints on resource usage. */
+  budget?: EconomicsBudget;
+  /** Actual usage populated by executor; aggregated by hubs in delegate chains. */
+  actual?: EconomicsActual;
+  /** DID of principal receiving/paying for this work. */
+  wallet?: string;
+  /** External invoice or tracking reference. */
+  billing_ref?: string;
+  /** ISO 4217 currency code when not USD. */
+  currency?: string;
+  /** Forward-compatible — schema allows additional properties. */
+  [key: string]: unknown;
+}
+
+export interface EconomicsBudget {
+  /** Maximum total tokens (input + output) permitted. */
+  max_tokens?: number;
+  /** Maximum cost in USD. */
+  max_cost_usd?: number;
+  [key: string]: unknown;
+}
+
+export interface EconomicsActual {
+  /** LLM input tokens consumed. */
+  input_tokens?: number;
+  /** LLM output tokens generated. */
+  output_tokens?: number;
+  /** Convenience total — may equal input + output, may not (delegate aggregation). */
+  total_tokens?: number;
+  /** Lowercase model identifier (e.g. `claude-sonnet-4`, `gpt-4o`). */
+  model?: string;
+  /** Execution duration in milliseconds. */
+  duration_ms?: number;
+  /** Computed cost in USD. */
+  cost_usd?: number;
+  [key: string]: unknown;
 }
 
 export type ValidationResult =
@@ -129,4 +285,42 @@ export function validateEnvelope(value: unknown): ValidationResult {
 export function tryParseEnvelope(value: unknown): Envelope | null {
   const result = validateEnvelope(value);
   return result.ok ? result.envelope : null;
+}
+
+/**
+ * Normalise `envelope.signed_by` into a stamp chain (myelin#31).
+ *
+ * The wire format accepts two shapes — a single stamp object (legacy
+ * back-compat shim) or an array of stamps (canonical post-#31 form). This
+ * helper coerces both into `SignedBy[]` without mutating the input. An
+ * unsigned envelope returns `[]`.
+ *
+ * IAW Phase A.2: this is the **surfacing** primitive. Trust-decision
+ * wiring (verify signatures, walk roles, enforce sovereignty against the
+ * chain) is IAW Phase B (cortex#102). Today, the chain is exposed so
+ * downstream consumers can log it, count hops, and start building Phase B
+ * fixtures against real shapes.
+ *
+ * Pure function. No side effects. Safe to call from any context.
+ */
+export function getSignedByChain(envelope: Envelope): SignedBy[] {
+  const value = envelope.signed_by;
+  if (value === undefined || value === null) return [];
+  if (Array.isArray(value)) return value;
+  if (typeof value === "object") return [value];
+  return [];
+}
+
+/**
+ * Return the principal of the LAST stamp in the chain, or `undefined` for
+ * unsigned envelopes. The last stamp is the most recent attestor — the
+ * entity that actually published the envelope on this hop.
+ *
+ * Surfacing primitive — paired with {@link getSignedByChain}. Not yet
+ * consumed for trust decisions in cortex (Phase B / cortex#102 territory).
+ */
+export function getLastStampPrincipal(envelope: Envelope): string | undefined {
+  const chain = getSignedByChain(envelope);
+  if (chain.length === 0) return undefined;
+  return chain[chain.length - 1]!.principal;
 }

--- a/src/bus/myelin/vendor/envelope.schema.json
+++ b/src/bus/myelin/vendor/envelope.schema.json
@@ -68,34 +68,69 @@
     },
     "economics": {
       "type": "object",
-      "description": "Reserved for future token economics, wallet integration, and budget constraints. Do not populate in v1 — schema will be defined when payment infrastructure matures.",
-      "properties": {},
+      "description": "F-15: token economics, cost tracking, and billing attribution. Mutable annotation field — intermediaries may aggregate. MUST NOT inform security or trust decisions (architecture.md §5.2).",
+      "properties": {
+        "budget": {
+          "type": "object",
+          "description": "Publisher-set constraints on resource usage.",
+          "properties": {
+            "max_tokens": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "Maximum total tokens (input + output) permitted."
+            },
+            "max_cost_usd": {
+              "type": "number",
+              "minimum": 0,
+              "description": "Maximum cost in USD."
+            }
+          },
+          "additionalProperties": true
+        },
+        "actual": {
+          "type": "object",
+          "description": "Actual resource usage populated by executor; aggregated by hubs in delegate chains.",
+          "properties": {
+            "input_tokens": { "type": "integer", "minimum": 0 },
+            "output_tokens": { "type": "integer", "minimum": 0 },
+            "total_tokens": { "type": "integer", "minimum": 0 },
+            "model": {
+              "type": "string",
+              "pattern": "^[a-z][a-z0-9-]*$",
+              "description": "Lowercase model identifier (e.g., claude-sonnet-4, gpt-4o)."
+            },
+            "duration_ms": { "type": "integer", "minimum": 0 },
+            "cost_usd": { "type": "number", "minimum": 0 }
+          },
+          "additionalProperties": true
+        },
+        "wallet": {
+          "type": "string",
+          "pattern": "^did:mf:[a-z](?:[a-z0-9._]|-(?!-))+$",
+          "description": "DID of principal receiving/paying for this work."
+        },
+        "billing_ref": {
+          "type": "string",
+          "maxLength": 256,
+          "description": "External invoice or tracking reference."
+        },
+        "currency": {
+          "type": "string",
+          "pattern": "^[A-Z]{3}$",
+          "description": "ISO 4217 currency code when not USD."
+        }
+      },
       "additionalProperties": true
     },
     "signed_by": {
-      "type": "object",
-      "description": "Identity attestation — proves who sent this envelope. Discriminated on method.",
+      "description": "Identity chain (myelin#31). Each stamp signs the canonical bytes of the envelope including the prior chain — tampering with any earlier stamp invalidates every subsequent stamp. Accepted shapes: a single stamp object (legacy back-compat shim, normalized to a one-element chain) or an array of stamps (canonical form).",
       "oneOf": [
+        { "$ref": "#/$defs/signedByStamp" },
         {
-          "required": ["method", "principal", "signature", "at"],
-          "properties": {
-            "method": { "const": "ed25519" },
-            "principal": { "type": "string", "pattern": "^did:mf:[a-z][a-z0-9._-]+$" },
-            "signature": { "type": "string", "minLength": 88, "pattern": "^[A-Za-z0-9+/]+=*$" },
-            "at": { "type": "string", "format": "date-time" }
-          },
-          "additionalProperties": false
-        },
-        {
-          "required": ["method", "principal", "stamped_by", "signature", "at"],
-          "properties": {
-            "method": { "const": "hub-stamp" },
-            "principal": { "type": "string", "pattern": "^did:mf:[a-z][a-z0-9._-]+$" },
-            "stamped_by": { "type": "string", "pattern": "^did:mf:[a-z][a-z0-9._-]+$" },
-            "signature": { "type": "string", "minLength": 88, "pattern": "^[A-Za-z0-9+/]+=*$" },
-            "at": { "type": "string", "format": "date-time" }
-          },
-          "additionalProperties": false
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 16,
+          "items": { "$ref": "#/$defs/signedByStamp" }
         }
       ]
     },
@@ -107,7 +142,82 @@
     "payload": {
       "type": "object",
       "description": "Arbitrary signal content. Structure is domain-specific — the envelope does not constrain payload shape."
+    },
+    "requirements": {
+      "type": "array",
+      "description": "F-021: capability tags the task needs. Match against AGENT_CAPABILITIES KV (myelin#9). Empty array = no filter. Pattern parallels DID_RE — no trailing or consecutive hyphens.",
+      "items": {
+        "type": "string",
+        "pattern": "^[a-z](?:[a-z0-9]|-(?!-)){0,62}[a-z0-9]$"
+      },
+      "maxItems": 10,
+      "examples": [["code-review", "typescript"], ["security-scan"]]
+    },
+    "sovereignty_required": {
+      "type": "string",
+      "enum": ["open", "selective", "strict", "bidding"],
+      "description": "F-021: minimum agent sovereignty mode. open = ack all; selective = evaluate-and-may-nak; strict = explicit capability + sovereignty match; bidding (F-10) = broadcast bid-request, collect signed responses, select winner."
+    },
+    "deadline": {
+      "type": "string",
+      "format": "date-time",
+      "description": "F-021: ISO-8601 absolute soft deadline. Informs nak `not-now` decisions."
+    },
+    "distribution_mode": {
+      "type": "string",
+      "enum": ["broadcast", "direct", "delegate"],
+      "description": "F-021: operator-facing routing semantics. broadcast = competing consumers; direct = named recipient; delegate = outcome handoff (multi-step orchestration)."
+    },
+    "target_principal": {
+      "type": "string",
+      "pattern": "^did:mf:[a-z](?:[a-z0-9._]|-(?!-))+$",
+      "description": "F-021: required when distribution_mode is direct or delegate. DID of the receiving agent."
     }
   },
-  "additionalProperties": false
+  "allOf": [
+    {
+      "if": {
+        "properties": { "distribution_mode": { "enum": ["direct", "delegate"] } },
+        "required": ["distribution_mode"]
+      },
+      "then": { "required": ["target_principal"] }
+    }
+  ],
+  "additionalProperties": false,
+  "$defs": {
+    "signedByStamp": {
+      "type": "object",
+      "description": "A single identity attestation in the chain (myelin#31). Discriminated on method.",
+      "oneOf": [
+        {
+          "required": ["method", "principal", "signature", "at"],
+          "properties": {
+            "method": { "const": "ed25519" },
+            "principal": { "type": "string", "pattern": "^did:mf:[a-z](?:[a-z0-9._]|-(?!-))+$" },
+            "signature": { "type": "string", "minLength": 88, "pattern": "^[A-Za-z0-9+/]+=*$" },
+            "at": { "type": "string", "format": "date-time" },
+            "role": { "$ref": "#/$defs/stampRole" }
+          },
+          "additionalProperties": false
+        },
+        {
+          "required": ["method", "principal", "stamped_by", "signature", "at"],
+          "properties": {
+            "method": { "const": "hub-stamp" },
+            "principal": { "type": "string", "pattern": "^did:mf:[a-z](?:[a-z0-9._]|-(?!-))+$" },
+            "stamped_by": { "type": "string", "pattern": "^did:mf:[a-z](?:[a-z0-9._]|-(?!-))+$" },
+            "signature": { "type": "string", "minLength": 88, "pattern": "^[A-Za-z0-9+/]+=*$" },
+            "at": { "type": "string", "format": "date-time" },
+            "role": { "$ref": "#/$defs/stampRole" }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "stampRole": {
+      "type": "string",
+      "enum": ["origin", "transit", "accountability", "sovereignty", "notary"],
+      "description": "Semantic role of this stamp in the chain (myelin#31). Optional for back-compat."
+    }
+  }
 }


### PR DESCRIPTION
## Summary

Mechanical schema upgrade — no behaviour change beyond surfacing new fields. This is IAW Phase A work item **A.2** from cortex#113 and step **C** from cortex#109.

The vendored myelin envelope schema in cortex was pinned at `96b14ea` — pre-F-021, pre-MY-400 chain-of-stamps. Cortex needs the post-F-021 envelope shape so IAW Phase B (cortex#102 NKey-signed bot↔bot) has somewhere to write trust-decision wiring. This PR bumps the pin and surfaces the new fields structurally; **no consumer in this PR makes trust decisions on `signed_by[]`** — that's Phase B's job.

| | Old pin | New pin |
|---|---|---|
| myelin commit | `96b14ea6f0adfdface89d326e4e6cb36856a073f` | `4578ae1e9bc595e667fbb356ea2c12c8c2c3cc8a` (myelin `main` HEAD) |
| Captures | MY-400 Group 1 identity types only | F-5 sovereignty policy engine · F-10 bidding · F-11 capability discovery · F-15 economics · F-019/F-020 task subjects · F-021 task envelope · MY-400 chain-of-stamps |

## Vendored Envelope interface diff (concept)

```diff
 export interface Envelope {
   …
-  economics?: Record<string, unknown>;
+  economics?: Economics;  // F-15 typed: budget / actual / wallet / billing_ref / currency
   payload: Record<string, unknown>;
-  signed_by?: SignedByEd25519 | SignedByHubStamp;
+  signed_by?: SignedBy | SignedBy[];   // myelin#31 chain-of-stamps
+  requirements?: string[];              // F-021 capability tags
+  sovereignty_required?: SovereigntyRequirement;  // F-021 open/selective/strict/bidding
+  deadline?: string;                    // F-021 ISO-8601 soft deadline
+  distribution_mode?: DistributionMode; // F-021 broadcast/direct/delegate
+  target_principal?: string;            // F-021 required when direct/delegate
 }

 // Stamps now carry optional semantic role (myelin#31):
 export interface SignedByEd25519 {
   method: "ed25519"; principal: string; signature: string; at: string;
+  role?: StampRole;  // origin / transit / accountability / sovereignty / notary
 }
```

## New surfacing primitives

```ts
// Pure helpers that normalise legacy single-stamp and post-#31 array shapes:
export function getSignedByChain(envelope: Envelope): SignedBy[];
export function getLastStampPrincipal(envelope: Envelope): string | undefined;
```

**`signed_by[]` is SURFACED but NOT yet used for trust decisions.** No consumer in this PR verifies signatures, walks roles, or enforces sovereignty against the chain. That wiring is IAW Phase B (cortex#102).

## What this PR is NOT

- **NOT a trust-decision wiring** — Phase B / cortex#102 territory.
- **NOT an emit-site change** — the four hardcoded `classification: \"local\"` sites stay; A.3 parameterises them next.
- **NOT a cortex.yaml schema change** — A.5 work.
- **NOT a behaviour change for legacy senders** — pre-F-021 envelopes still validate (back-compat test locks this).

## Test plan

- [x] `bunx tsc --noEmit` clean (no errors anywhere in the worktree).
- [x] `bun test src/bus/ src/runner/` — 436 pass / 0 fail across 29 files.
- [x] `bun test` (full suite) — 2565 pass / 1 skip / 0 fail across 140 files.
- [x] `bun test src/bus/myelin/__tests__/envelope-validator.test.ts` — 35 pass.
- New test coverage:
  - Chain-of-stamps array form acceptance (with `role` field).
  - Invalid-stamp inside a chain rejection.
  - Empty-chain rejection (`minItems: 1`).
  - All F-021 task fields populated (direct mode).
  - F-021 cross-field rule: `direct`/`delegate` require `target_principal`.
  - F-021 unknown-enum rejection (`sovereignty_required`, `distribution_mode`).
  - F-021 `target_principal` DID-shape enforcement.
  - F-021 `requirements[]` lowercase-pattern enforcement.
  - F-021 `bidding` sovereignty mode acceptance.
  - Back-compat: pre-F-021 fixture still validates.
  - `getSignedByChain` over unsigned / single-stamp / array forms.
  - `getLastStampPrincipal` over signed / unsigned envelopes.
  - Pin commit assertion (locks future bumps to surface in code review).

## References

- **cortex#113** — IAW Phase A umbrella (this is work item A.2).
- **cortex#109** — envelope-visibility composition (this is step C of the implementation slice).
- **cortex#102** — bot↔bot NKey identity in Phase B; consumes `signed_by[]` for trust decisions.
- **myelin#92** — chain-of-stamps PR (MY-400).
- **myelin#46** — F-021 task envelope extension.

recommend: merge