### PR TITLE
feat(emit): IAW A.3 — classification parameter at emit sites (federation unblock) (refs cortex#113)

### DIFF
--- a/src/bus/__tests__/dispatch-events.test.ts
+++ b/src/bus/__tests__/dispatch-events.test.ts
@@ -253,3 +253,53 @@ describe("dispatch.task.* — data_residency parameterisation", () => {
     }
   });
 });
+
+describe("dispatch.task.* — classification parameterisation (IAW A.3)", () => {
+  const common = {
+    source: SOURCE,
+    taskId: TASK_ID,
+    agentId: "cortex",
+    startedAt: STARTED_AT,
+  };
+
+  test("omitting classification defaults to local for every lifecycle helper", () => {
+    const envs = [
+      createDispatchTaskStartedEvent(common),
+      createDispatchTaskCompletedEvent({ ...common, completedAt: COMPLETED_AT }),
+      createDispatchTaskFailedEvent({ ...common, failedAt: COMPLETED_AT, errorSummary: "x" }),
+      createDispatchTaskAbortedEvent({ ...common, abortedAt: COMPLETED_AT, reason: "timeout" }),
+    ];
+    for (const env of envs) {
+      expect(env.sovereignty.classification).toBe("local");
+      expect(validateEnvelope(env).ok).toBe(true);
+    }
+  });
+
+  test("classification: 'federated' flows into envelope.sovereignty for every helper", () => {
+    const fed = { ...common, classification: "federated" as const };
+    const envs = [
+      createDispatchTaskStartedEvent(fed),
+      createDispatchTaskCompletedEvent({ ...fed, completedAt: COMPLETED_AT }),
+      createDispatchTaskFailedEvent({ ...fed, failedAt: COMPLETED_AT, errorSummary: "x" }),
+      createDispatchTaskAbortedEvent({ ...fed, abortedAt: COMPLETED_AT, reason: "timeout" }),
+    ];
+    for (const env of envs) {
+      expect(env.sovereignty.classification).toBe("federated");
+      expect(validateEnvelope(env).ok).toBe(true);
+    }
+  });
+
+  test("classification: 'public' flows into envelope.sovereignty for every helper", () => {
+    const pub = { ...common, classification: "public" as const };
+    const envs = [
+      createDispatchTaskStartedEvent(pub),
+      createDispatchTaskCompletedEvent({ ...pub, completedAt: COMPLETED_AT }),
+      createDispatchTaskFailedEvent({ ...pub, failedAt: COMPLETED_AT, errorSummary: "x" }),
+      createDispatchTaskAbortedEvent({ ...pub, abortedAt: COMPLETED_AT, reason: "timeout" }),
+    ];
+    for (const env of envs) {
+      expect(env.sovereignty.classification).toBe("public");
+      expect(validateEnvelope(env).ok).toBe(true);
+    }
+  });
+});

--- a/src/bus/__tests__/github-events.test.ts
+++ b/src/bus/__tests__/github-events.test.ts
@@ -256,3 +256,37 @@ describe("createGithubEventEnvelope", () => {
     expect(validation.ok).toBe(true);
   });
 });
+
+describe("github.* — classification parameterisation (IAW A.3)", () => {
+  const baseOpts = {
+    source: SRC,
+    event: "pull_request",
+    action: "opened",
+    deliveryId: "12345678-1234-4234-8234-123456789012",
+    payload: { number: 42 },
+  };
+
+  test("omitting classification defaults to local (operator-private)", () => {
+    const env = createGithubEventEnvelope(baseOpts);
+    expect(env.sovereignty.classification).toBe("local");
+    expect(validateEnvelope(env).ok).toBe(true);
+  });
+
+  test("classification: 'federated' flows into envelope.sovereignty", () => {
+    const env = createGithubEventEnvelope({
+      ...baseOpts,
+      classification: "federated",
+    });
+    expect(env.sovereignty.classification).toBe("federated");
+    expect(validateEnvelope(env).ok).toBe(true);
+  });
+
+  test("classification: 'public' flows into envelope.sovereignty", () => {
+    const env = createGithubEventEnvelope({
+      ...baseOpts,
+      classification: "public",
+    });
+    expect(env.sovereignty.classification).toBe("public");
+    expect(validateEnvelope(env).ok).toBe(true);
+  });
+});

--- a/src/bus/__tests__/system-events.test.ts
+++ b/src/bus/__tests__/system-events.test.ts
@@ -314,3 +314,103 @@ describe("data_residency parameterisation", () => {
     }
   });
 });
+
+describe("classification parameterisation (IAW A.3)", () => {
+  // Federation unblock — every `system.*` helper now accepts an optional
+  // `classification` that flows into envelope.sovereignty.classification.
+  // Defaults remain `"local"` for back-compat; opt-in `"federated"` /
+  // `"public"` lets cortex emit envelopes that match myelin's namespace
+  // grammar (and pass `validateSubjectEnvelopeAlignment` when paired with
+  // the runtime's subject derivation).
+  const source = { org: "metafactory", agent: "cortex", instance: "local" };
+
+  test("omitting classification defaults to local across all helpers", () => {
+    const degraded = createSystemAdapterDegradedEvent({
+      source,
+      adapterId: "x", platform: "discord",
+      disconnectedSince: new Date(), thresholdMs: 1,
+    });
+    const recovered = createSystemAdapterRecoveredEvent({
+      source,
+      adapterId: "x", platform: "discord", degradedForMs: 1,
+    });
+    const disconnected = createSystemAdapterDisconnectedEvent({
+      source,
+      adapterId: "x", platform: "discord",
+      disconnectedSince: new Date(), wasClean: true,
+    });
+    const aborted = createSystemInboundAbortedEvent({
+      source,
+      adapterId: "x", inboundMessageId: "1",
+      timeoutSource: "unknown", timeoutMs: 1, elapsedMs: 1,
+      phase: "pre_dispatch",
+    });
+    for (const env of [degraded, recovered, disconnected, aborted]) {
+      expect(env.sovereignty.classification).toBe("local");
+      expect(validateEnvelope(env).ok).toBe(true);
+    }
+  });
+
+  test("classification: 'federated' opts into the federation namespace", () => {
+    const degraded = createSystemAdapterDegradedEvent({
+      source,
+      adapterId: "x", platform: "discord",
+      disconnectedSince: new Date(), thresholdMs: 1,
+      classification: "federated",
+    });
+    const recovered = createSystemAdapterRecoveredEvent({
+      source,
+      adapterId: "x", platform: "discord", degradedForMs: 1,
+      classification: "federated",
+    });
+    const disconnected = createSystemAdapterDisconnectedEvent({
+      source,
+      adapterId: "x", platform: "discord",
+      disconnectedSince: new Date(), wasClean: true,
+      classification: "federated",
+    });
+    const aborted = createSystemInboundAbortedEvent({
+      source,
+      adapterId: "x", inboundMessageId: "1",
+      timeoutSource: "unknown", timeoutMs: 1, elapsedMs: 1,
+      phase: "pre_dispatch",
+      classification: "federated",
+    });
+    for (const env of [degraded, recovered, disconnected, aborted]) {
+      expect(env.sovereignty.classification).toBe("federated");
+      // Schema must still accept the federated classification.
+      expect(validateEnvelope(env).ok).toBe(true);
+    }
+  });
+
+  test("classification: 'public' opts into the public namespace", () => {
+    const degraded = createSystemAdapterDegradedEvent({
+      source,
+      adapterId: "x", platform: "discord",
+      disconnectedSince: new Date(), thresholdMs: 1,
+      classification: "public",
+    });
+    const recovered = createSystemAdapterRecoveredEvent({
+      source,
+      adapterId: "x", platform: "discord", degradedForMs: 1,
+      classification: "public",
+    });
+    const disconnected = createSystemAdapterDisconnectedEvent({
+      source,
+      adapterId: "x", platform: "discord",
+      disconnectedSince: new Date(), wasClean: true,
+      classification: "public",
+    });
+    const aborted = createSystemInboundAbortedEvent({
+      source,
+      adapterId: "x", inboundMessageId: "1",
+      timeoutSource: "unknown", timeoutMs: 1, elapsedMs: 1,
+      phase: "pre_dispatch",
+      classification: "public",
+    });
+    for (const env of [degraded, recovered, disconnected, aborted]) {
+      expect(env.sovereignty.classification).toBe("public");
+      expect(validateEnvelope(env).ok).toBe(true);
+    }
+  });
+});

--- a/src/bus/dispatch-events.ts
+++ b/src/bus/dispatch-events.ts
@@ -42,7 +42,7 @@
  *     (since `correlation_id` constraint is UUID).
  */
 
-import type { Envelope } from "./myelin/envelope-validator";
+import type { Classification, Envelope } from "./myelin/envelope-validator";
 import { buildBaseEnvelope as buildSharedEnvelope } from "./envelope-builder";
 import type { SystemEventSource } from "./system-events";
 
@@ -57,7 +57,7 @@ function buildSource(src: SystemEventSource): string {
 
 /**
  * Default sovereignty for `dispatch.task.*` events. Same posture as
- * `system.*`: operator-only, local residency, no federation, no frontier.
+ * `system.*`: operator-only by default, local residency, no frontier.
  *
  * `data_residency` is sourced from `source.dataResidency` (defaulting to
  * `"NZ"` for the original cortex deployment) so a non-NZ operator gets
@@ -65,12 +65,21 @@ function buildSource(src: SystemEventSource): string {
  * pattern in `system-events.ts` so both event domains read the same field
  * off the same source struct.
  *
+ * **IAW Phase A.3:** `classification` is now an optional parameter
+ * (defaulting to `"local"` for back-compat). Callers may opt into
+ * `"federated"` or `"public"` when dispatch lifecycle events need to cross
+ * operator boundaries (e.g. a federated multi-org dispatch). The default
+ * keeps every existing call site behaving identically.
+ *
  * Returned as a fresh literal per call so a downstream mutation on one
  * envelope's `sovereignty` cannot leak into a sibling envelope.
  */
-function defaultDispatchSovereignty(source: SystemEventSource): Envelope["sovereignty"] {
+function defaultDispatchSovereignty(
+  source: SystemEventSource,
+  classification: Classification = "local",
+): Envelope["sovereignty"] {
   return {
-    classification: "local",
+    classification,
     data_residency: source.dataResidency ?? "NZ",
     max_hop: 0,
     frontier_ok: false,
@@ -115,6 +124,16 @@ export interface DispatchTaskCommonOpts {
    * share one correlation key" guarantee.
    */
   correlationId?: string;
+  /**
+   * IAW Phase A.3 — optional sovereignty classification. Defaults to
+   * `"local"` (operator-private). Set to `"federated"` when a dispatch
+   * lifecycle event needs to reach peer operators (e.g. a multi-org task
+   * pipeline whose progress should surface on federated dashboards);
+   * `"public"` for global visibility. Mismatch with the publish-time
+   * subject is a protocol violation (see
+   * {@link validateSubjectEnvelopeAlignment}).
+   */
+  classification?: Classification;
 }
 
 /**
@@ -137,7 +156,7 @@ function buildBaseEnvelope(
   return buildSharedEnvelope({
     type,
     source: buildSource(common.source),
-    sovereignty: defaultDispatchSovereignty(common.source),
+    sovereignty: defaultDispatchSovereignty(common.source, common.classification),
     correlationId: common.correlationId ?? common.taskId,
     payload: {
       task_id: common.taskId,

--- a/src/bus/github-events.ts
+++ b/src/bus/github-events.ts
@@ -60,7 +60,7 @@
  *     but the file is only imported from the local cortex process today.
  */
 
-import type { Envelope } from "./myelin/envelope-validator";
+import type { Classification, Envelope } from "./myelin/envelope-validator";
 import { buildBaseEnvelope } from "./envelope-builder";
 import type { SystemEventSource } from "./system-events";
 
@@ -76,17 +76,28 @@ function buildSource(src: SystemEventSource): string {
 }
 
 /**
- * Default sovereignty for `github.*` events. Operator-only / local / no
- * frontier — webhook payloads may carry PII (committer email, issue bodies)
- * and federating them outside the org is an explicit decision, not a default.
+ * Default sovereignty for `github.*` events. Operator-only by default / local
+ * residency / no frontier — webhook payloads may carry PII (committer email,
+ * issue bodies) and federating them outside the org is an explicit decision,
+ * not a default.
  *
  * `data_residency` is sourced from `source.dataResidency` (defaulting to
  * `"NZ"`) so a non-NZ operator gets envelopes stamped with their actual
  * residency without per-call overrides.
+ *
+ * **IAW Phase A.3:** `classification` is now an optional parameter
+ * (defaulting to `"local"` for back-compat). Callers may opt into
+ * `"federated"` or `"public"` when a GitHub event has been explicitly
+ * deemed shareable beyond the org boundary (e.g. a public-repo PR-merged
+ * event that powers a cross-org community dashboard). Default preserves
+ * the prior operator-private posture.
  */
-function defaultGithubSovereignty(source: SystemEventSource): Envelope["sovereignty"] {
+function defaultGithubSovereignty(
+  source: SystemEventSource,
+  classification: Classification = "local",
+): Envelope["sovereignty"] {
   return {
-    classification: "local",
+    classification,
     data_residency: source.dataResidency ?? "NZ",
     max_hop: 0,
     frontier_ok: false,
@@ -181,6 +192,17 @@ export interface CreateGithubEventEnvelopeOpts {
    * `repo` — exposed at the top of the payload for filters.
    */
   sender?: string;
+  /**
+   * IAW Phase A.3 — optional sovereignty classification. Defaults to
+   * `"local"`. GitHub webhook payloads can carry user-authored content
+   * (PR titles, issue bodies, committer emails); operator-private is the
+   * sensible default. Set `"federated"` only when an explicit operator
+   * decision has scoped the event for cross-org consumption (e.g. an
+   * open-source repo's release event powering a federated changelog
+   * dashboard). Mismatch with the publish-time subject is a protocol
+   * violation (see {@link validateSubjectEnvelopeAlignment}).
+   */
+  classification?: Classification;
 }
 
 /**
@@ -210,7 +232,7 @@ export function createGithubEventEnvelope(
   return buildBaseEnvelope({
     type,
     source: buildSource(opts.source),
-    sovereignty: defaultGithubSovereignty(opts.source),
+    sovereignty: defaultGithubSovereignty(opts.source, opts.classification),
     // GitHub delivery IDs are UUIDs by contract; only promote when shape
     // matches, matching the cc-events helper's defensive pattern.
     ...(isUuid(opts.deliveryId) && { correlationId: opts.deliveryId }),

--- a/src/bus/myelin/__tests__/envelope-validator.test.ts
+++ b/src/bus/myelin/__tests__/envelope-validator.test.ts
@@ -10,11 +10,13 @@
 
 import { describe, expect, test } from "bun:test";
 import {
+  deriveNatsSubject,
   getLastStampPrincipal,
   getSignedByChain,
   SCHEMA_SOURCE_COMMIT,
   tryParseEnvelope,
   validateEnvelope,
+  validateSubjectEnvelopeAlignment,
   type Envelope,
 } from "../envelope-validator";
 import validEnvelope from "../vendor/__fixtures__/valid-envelope.json" with { type: "json" };
@@ -487,5 +489,123 @@ describe("envelope-validator — chain helpers (IAW Phase A.2)", () => {
     expect(SCHEMA_SOURCE_COMMIT).toBe(
       "4578ae1e9bc595e667fbb356ea2c12c8c2c3cc8a",
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// IAW Phase A.3 — subject derivation + envelope alignment.
+// ---------------------------------------------------------------------------
+
+describe("deriveNatsSubject (IAW A.3)", () => {
+  function envWithClassification(
+    classification: Envelope["sovereignty"]["classification"],
+    source = "metafactory.cortex.local",
+    type = "system.adapter.degraded",
+  ): Envelope {
+    return {
+      ...(validEnvelope as unknown as Envelope),
+      source,
+      type,
+      sovereignty: {
+        ...(validEnvelope as unknown as Envelope).sovereignty,
+        classification,
+      },
+    };
+  }
+
+  test("local classification → local.{org}.{type}", () => {
+    const env = envWithClassification("local");
+    expect(deriveNatsSubject(env)).toBe(
+      "local.metafactory.system.adapter.degraded",
+    );
+  });
+
+  test("federated classification → federated.{org}.{type}", () => {
+    const env = envWithClassification("federated");
+    expect(deriveNatsSubject(env)).toBe(
+      "federated.metafactory.system.adapter.degraded",
+    );
+  });
+
+  test("public classification → public.{type} (no org segment)", () => {
+    const env = envWithClassification("public");
+    expect(deriveNatsSubject(env)).toBe("public.system.adapter.degraded");
+  });
+
+  test("derives {org} from envelope.source's first segment", () => {
+    // A different operator (`acme.*`) routes onto its own subject namespace
+    // without any runtime-side configuration.
+    const env = envWithClassification("local", "acme.cortex.prod-01");
+    expect(deriveNatsSubject(env)).toBe(
+      "local.acme.system.adapter.degraded",
+    );
+  });
+});
+
+describe("validateSubjectEnvelopeAlignment (IAW A.3)", () => {
+  function envWithClassification(
+    classification: Envelope["sovereignty"]["classification"],
+  ): Envelope {
+    return {
+      ...(validEnvelope as unknown as Envelope),
+      sovereignty: {
+        ...(validEnvelope as unknown as Envelope).sovereignty,
+        classification,
+      },
+    };
+  }
+
+  test("aligned local subject", () => {
+    const env = envWithClassification("local");
+    const result = validateSubjectEnvelopeAlignment(
+      "local.metafactory.system.adapter.degraded",
+      env,
+    );
+    expect(result.aligned).toBe(true);
+    expect(result.expected).toBe("local");
+    expect(result.actual).toBe("local");
+  });
+
+  test("aligned federated subject", () => {
+    const env = envWithClassification("federated");
+    const result = validateSubjectEnvelopeAlignment(
+      "federated.metafactory.system.adapter.degraded",
+      env,
+    );
+    expect(result.aligned).toBe(true);
+  });
+
+  test("aligned public subject (no org segment)", () => {
+    const env = envWithClassification("public");
+    const result = validateSubjectEnvelopeAlignment(
+      "public.system.adapter.degraded",
+      env,
+    );
+    expect(result.aligned).toBe(true);
+  });
+
+  test("misaligned subject is detected — federated envelope on local subject", () => {
+    // The protocol violation IAW A.3 guards against: a federated envelope
+    // accidentally published on a `local.*` subject would leak operator-
+    // private semantics onto the federated bus, or vice versa.
+    const env = envWithClassification("federated");
+    const result = validateSubjectEnvelopeAlignment(
+      "local.metafactory.system.adapter.degraded",
+      env,
+    );
+    expect(result.aligned).toBe(false);
+    expect(result.expected).toBe("federated");
+    expect(result.actual).toBe("local");
+  });
+
+  test("misaligned subject is detected — local envelope on public subject", () => {
+    const env = envWithClassification("local");
+    const result = validateSubjectEnvelopeAlignment(
+      "public.system.adapter.degraded",
+      env,
+    );
+    expect(result.aligned).toBe(false);
+    expect(result.expected).toBe("local");
+    expect(result.actual).toBe("public");
   });
 });

--- a/src/bus/myelin/__tests__/runtime.test.ts
+++ b/src/bus/myelin/__tests__/runtime.test.ts
@@ -326,14 +326,74 @@ describe("MyelinRuntime", () => {
       const env = makeEnvelope({ type: "system.adapter.degraded" });
       await runtime.publish(env);
       expect(fake.publish).toHaveBeenCalledTimes(1);
-      // operatorId in makeConfig is "andreas" — that becomes the {org} segment.
+      // IAW Phase A.3: subject `{org}` comes from `envelope.source`'s first
+      // segment ("metafactory" here), NOT from `agent.operatorId`. Subject
+      // prefix mirrors `envelope.sovereignty.classification` ("local" here),
+      // satisfying `validateSubjectEnvelopeAlignment`. Emit-site helpers
+      // populate `envelope.source` with the operator-side `agent.operatorId`,
+      // so the two values agree at runtime — the test fixture exercises the
+      // derive-from-envelope path directly.
       expect(fake.publishes[0]?.subject).toBe(
-        "local.andreas.system.adapter.degraded",
+        "local.metafactory.system.adapter.degraded",
       );
       // Payload is the JSON-serialised envelope; round-trip restores it intact.
       const payload = fake.publishes[0]?.payload as string;
       expect(typeof payload).toBe("string");
       expect(JSON.parse(payload)).toEqual(env);
+      await runtime.stop();
+    });
+
+    test("enabled runtime: publish derives federated.{org}.{type} subject", async () => {
+      // IAW Phase A.3 — federation unblock. When an emit site opts into
+      // `classification: "federated"`, the envelope's sovereignty AND the
+      // runtime-derived subject move in lockstep onto the `federated.*`
+      // namespace. This is what makes cortex able to emit federated
+      // envelopes for the first time.
+      const fake = makeFakeNatsConnection();
+      const runtime = await startMyelinRuntime(
+        makeConfig({
+          url: "nats://localhost:4222",
+          name: "grove-bot",
+          subjects: ["local.{org}.>"],
+        }),
+        { connectImpl: async () => fake.nc },
+      );
+      const baseEnv = makeEnvelope();
+      const env = {
+        ...baseEnv,
+        sovereignty: { ...baseEnv.sovereignty, classification: "federated" as const },
+      };
+      await runtime.publish(env);
+      expect(fake.publish).toHaveBeenCalledTimes(1);
+      expect(fake.publishes[0]?.subject).toBe(
+        "federated.metafactory.system.adapter.degraded",
+      );
+      await runtime.stop();
+    });
+
+    test("enabled runtime: publish derives public.{type} subject (no org segment)", async () => {
+      // IAW Phase A.3 — public-tier envelopes drop the `{org}` segment per
+      // myelin's grammar (public is global). The runtime applies this
+      // automatically via `deriveNatsSubject`.
+      const fake = makeFakeNatsConnection();
+      const runtime = await startMyelinRuntime(
+        makeConfig({
+          url: "nats://localhost:4222",
+          name: "grove-bot",
+          subjects: ["local.{org}.>"],
+        }),
+        { connectImpl: async () => fake.nc },
+      );
+      const baseEnv = makeEnvelope();
+      const env = {
+        ...baseEnv,
+        sovereignty: { ...baseEnv.sovereignty, classification: "public" as const },
+      };
+      await runtime.publish(env);
+      expect(fake.publish).toHaveBeenCalledTimes(1);
+      expect(fake.publishes[0]?.subject).toBe(
+        "public.system.adapter.degraded",
+      );
       await runtime.stop();
     });
 

--- a/src/bus/myelin/envelope-validator.ts
+++ b/src/bus/myelin/envelope-validator.ts
@@ -324,3 +324,68 @@ export function getLastStampPrincipal(envelope: Envelope): string | undefined {
   if (chain.length === 0) return undefined;
   return chain[chain.length - 1]!.principal;
 }
+
+/**
+ * Sovereignty classification values per the myelin envelope schema. Exported
+ * so emit-site helpers (`system-events.ts`, `dispatch-events.ts`,
+ * `github-events.ts`, `taps/cc-events/cc-events.ts`) can accept an optional
+ * `classification` parameter without redeclaring the enum.
+ */
+export type Classification = Envelope["sovereignty"]["classification"];
+
+/**
+ * IAW Phase A.3 — port of myelin's `deriveNatsSubject` (myelin
+ * `src/envelope.ts:337-345`, pinned at `SCHEMA_SOURCE_COMMIT` above).
+ *
+ * Subject prefix mirrors `envelope.sovereignty.classification` per the
+ * 1:1 alignment myelin enforces with
+ * {@link validateSubjectEnvelopeAlignment}:
+ *
+ *   - `classification === "local"`     → `local.{org}.{type}`
+ *   - `classification === "federated"` → `federated.{org}.{type}`
+ *   - `classification === "public"`    → `public.{type}` (no org — public is global)
+ *
+ * `{org}` is the first dotted segment of `envelope.source` (the same value
+ * cortex's MyelinRuntime captures from `agent.operatorId` at startup, so
+ * subject and source stay symmetrical).
+ *
+ * Pure function; safe to call from any context.
+ */
+export function deriveNatsSubject(envelope: Envelope): string {
+  const classification = envelope.sovereignty.classification;
+  if (classification === "public") {
+    // Public is global — no `{org}` segment. Matches myelin's grammar.
+    return `public.${envelope.type}`;
+  }
+  const org = envelope.source.split(".")[0] ?? "default";
+  return `${classification}.${org}.${envelope.type}`;
+}
+
+/**
+ * IAW Phase A.3 — port of myelin's `validateSubjectEnvelopeAlignment`
+ * (myelin `src/envelope.ts:347-358`). Pure validator: confirms the leading
+ * segment of a NATS subject matches `envelope.sovereignty.classification`.
+ *
+ * Cortex uses this as a defensive invariant when publishing on a
+ * `MyelinRuntime` — a `local.*` subject must NOT carry a `federated` or
+ * `public` envelope (and vice-versa). Misalignment is a protocol violation:
+ * downstream peers may drop or reject the envelope.
+ *
+ * Result shape mirrors myelin so a future merge keeps the same surface.
+ */
+export function validateSubjectEnvelopeAlignment(
+  subject: string,
+  envelope: Envelope,
+): {
+  aligned: boolean;
+  expected: Classification;
+  actual: string;
+} {
+  const subjectPrefix = subject.split(".")[0] ?? "";
+  const envelopeClassification = envelope.sovereignty.classification;
+  return {
+    aligned: subjectPrefix === envelopeClassification,
+    expected: envelopeClassification,
+    actual: subjectPrefix,
+  };
+}

--- a/src/bus/myelin/runtime.ts
+++ b/src/bus/myelin/runtime.ts
@@ -17,7 +17,7 @@ import type { ConnectionOptions, NatsConnection } from "nats";
 import type { BotConfig } from "../../common/types/config";
 import { NatsLink } from "../nats/connection";
 import { MyelinSubscriber } from "./subscriber";
-import type { Envelope } from "./envelope-validator";
+import { deriveNatsSubject, type Envelope } from "./envelope-validator";
 
 /**
  * Per-envelope handler. Receives validated envelopes from any active
@@ -42,10 +42,24 @@ export interface MyelinRuntime {
   /**
    * Publish an envelope to NATS.
    *
-   * Subject is derived from `envelope.type` per G-1111 §3.1: a fully
-   * qualified subject `local.{org}.{type}` is constructed at publish time,
-   * where `{org}` is the bot's `agent.operatorId` and `{type}` is the
-   * envelope's already-dotted `domain.entity.action`. No wildcards.
+   * Subject is derived from `envelope.sovereignty.classification` +
+   * `envelope.type` per G-1111 §3.1 and the myelin grammar:
+   *
+   *   - `classification === "local"`     → `local.{org}.{type}`
+   *   - `classification === "federated"` → `federated.{org}.{type}`
+   *   - `classification === "public"`    → `public.{type}` (no `{org}` segment)
+   *
+   * `{org}` is the first dotted segment of `envelope.source` (which
+   * cortex's `system-events.ts` etc. populate from `agent.operatorId`).
+   * The 1:1 alignment between subject prefix and `sovereignty.classification`
+   * is myelin's protocol-level invariant — see
+   * {@link validateSubjectEnvelopeAlignment}.
+   *
+   * **IAW Phase A.3:** prior to this slice the runtime hardcoded
+   * `local.{org}.{type}` here, making federated/public emission structurally
+   * impossible. Subject derivation now mirrors classification, so an emit
+   * site that opts into `classification: "federated"` flows end-to-end
+   * (envelope + subject) without further runtime changes.
    *
    * **No-op when the runtime is disabled** (no NATS configured) so callers
    * can fire-and-forget without checking `enabled` first. This matters at
@@ -223,11 +237,6 @@ export async function startMyelinRuntime(
     };
   }
 
-  // Capture the org segment once at runtime-start time — `agent.operatorId`
-  // is the same value used to substitute `{org}` in subscribe subjects, so
-  // publish and subscribe stay symmetrical.
-  const org = config.agent.operatorId ?? "default";
-
   let stopped = false;
 
   const publishEnabled = async (envelope: Envelope): Promise<void> => {
@@ -243,7 +252,18 @@ export async function startMyelinRuntime(
       // of the envelope on the shutdown path.
       return;
     }
-    const subject = `local.${org}.${envelope.type}`;
+    // IAW Phase A.3: subject derivation now mirrors
+    // `envelope.sovereignty.classification`. Prior code hardcoded
+    // `local.{org}.{type}` here, making federated/public emission
+    // structurally impossible — `{org}` came from `config.agent.operatorId`
+    // and the classification prefix was always "local". `deriveNatsSubject`
+    // reads classification + extracts `{org}` from `envelope.source` so the
+    // 1:1 subject↔classification invariant
+    // (`validateSubjectEnvelopeAlignment`) holds for every emit site
+    // without further changes. `envelope.source`'s first segment is the
+    // same value `agent.operatorId` produces when emit-site helpers
+    // assemble it, so subscribe-side `{org}` substitution stays symmetric.
+    const subject = deriveNatsSubject(envelope);
     try {
       link.publish(subject, JSON.stringify(envelope));
     } catch (err) {

--- a/src/bus/system-events.ts
+++ b/src/bus/system-events.ts
@@ -51,7 +51,7 @@
  * connection-watcher refactor is a follow-on iteration.
  */
 
-import type { Envelope } from "./myelin/envelope-validator";
+import type { Classification, Envelope } from "./myelin/envelope-validator";
 import { buildBaseEnvelope } from "./envelope-builder";
 
 /**
@@ -91,15 +91,24 @@ function buildSource(src: SystemEventSource): string {
  * callers receive a fresh object literal (no aliasing risk if a caller
  * mutates the returned envelope's `sovereignty`).
  *
- * `system.*` events expose internal grove state — operator-only, never
- * federated outside the org, never sent to frontier models. The `data_residency`
- * field is sourced from `source.dataResidency` (defaulting to `"NZ"`) so a
- * non-NZ operator gets envelopes stamped with their actual residency without
- * having to override the entire sovereignty object at every call site.
+ * `system.*` events expose internal grove state — operator-only by default,
+ * never sent to frontier models. The `data_residency` field is sourced from
+ * `source.dataResidency` (defaulting to `"NZ"`) so a non-NZ operator gets
+ * envelopes stamped with their actual residency without having to override
+ * the entire sovereignty object at every call site.
+ *
+ * **IAW Phase A.3:** `classification` is now an optional parameter
+ * (defaulting to `"local"` for back-compat). Callers may opt into
+ * `"federated"` or `"public"` when an operator-side decision determines the
+ * envelope's reach. The default keeps every existing call site behaving
+ * identically.
  */
-function defaultSystemSovereignty(source: SystemEventSource): Envelope["sovereignty"] {
+function defaultSystemSovereignty(
+  source: SystemEventSource,
+  classification: Classification = "local",
+): Envelope["sovereignty"] {
   return {
-    classification: "local",
+    classification,
     data_residency: source.dataResidency ?? "NZ",
     max_hop: 0,
     frontier_ok: false,
@@ -150,6 +159,15 @@ export interface SystemAdapterDegradedOpts {
   reconnectAttempts?: number;
   /** Platform-specific shard/connection identifier. Optional. */
   shardId?: number;
+  /**
+   * IAW Phase A.3 — optional sovereignty classification. Defaults to
+   * `"local"` (operator-private). Set to `"federated"` to publish on
+   * `federated.{org}.system.adapter.degraded` so peer dashboards in the
+   * operator's federation policy can render the event; `"public"` for
+   * global visibility. Mismatch with the publish-time subject is a
+   * protocol violation (see {@link validateSubjectEnvelopeAlignment}).
+   */
+  classification?: Classification;
 }
 
 /**
@@ -165,7 +183,7 @@ export function createSystemAdapterDegradedEvent(
   return buildBaseEnvelope({
     type: "system.adapter.degraded",
     source: buildSource(opts.source),
-    sovereignty: defaultSystemSovereignty(opts.source),
+    sovereignty: defaultSystemSovereignty(opts.source, opts.classification),
     payload: {
       adapter_id: opts.adapterId,
       platform: opts.platform,
@@ -202,6 +220,12 @@ export interface SystemAdapterRecoveredOpts {
   disconnectedSince?: Date;
   /** How many attempts before recovery. Optional. */
   reconnectAttempts?: number;
+  /**
+   * IAW Phase A.3 — optional sovereignty classification. Defaults to
+   * `"local"`. See `SystemAdapterDegradedOpts.classification` for the full
+   * doc.
+   */
+  classification?: Classification;
 }
 
 /**
@@ -217,7 +241,7 @@ export function createSystemAdapterRecoveredEvent(
   return buildBaseEnvelope({
     type: "system.adapter.recovered",
     source: buildSource(opts.source),
-    sovereignty: defaultSystemSovereignty(opts.source),
+    sovereignty: defaultSystemSovereignty(opts.source, opts.classification),
     payload: {
       adapter_id: opts.adapterId,
       platform: opts.platform,
@@ -250,6 +274,12 @@ export interface SystemAdapterDisconnectedOpts {
   closeReason?: string;
   /** True if this was a clean shutdown (vs unexpected drop). */
   wasClean: boolean;
+  /**
+   * IAW Phase A.3 — optional sovereignty classification. Defaults to
+   * `"local"`. See `SystemAdapterDegradedOpts.classification` for the full
+   * doc.
+   */
+  classification?: Classification;
 }
 
 /**
@@ -265,7 +295,7 @@ export function createSystemAdapterDisconnectedEvent(
   return buildBaseEnvelope({
     type: "system.adapter.disconnected",
     source: buildSource(opts.source),
-    sovereignty: defaultSystemSovereignty(opts.source),
+    sovereignty: defaultSystemSovereignty(opts.source, opts.classification),
     payload: {
       adapter_id: opts.adapterId,
       platform: opts.platform,
@@ -321,6 +351,12 @@ export interface SystemInboundAbortedOpts {
   /** Wall time from dispatch start to abort (ms). */
   elapsedMs: number;
   phase: SystemInboundAbortedPhase;
+  /**
+   * IAW Phase A.3 — optional sovereignty classification. Defaults to
+   * `"local"`. See `SystemAdapterDegradedOpts.classification` for the full
+   * doc.
+   */
+  classification?: Classification;
 }
 
 /**
@@ -343,7 +379,7 @@ export function createSystemInboundAbortedEvent(
   return buildBaseEnvelope({
     type: "system.inbound.aborted",
     source: buildSource(opts.source),
-    sovereignty: defaultSystemSovereignty(opts.source),
+    sovereignty: defaultSystemSovereignty(opts.source, opts.classification),
     ...(opts.correlationId !== undefined && { correlationId: opts.correlationId }),
     payload: {
       adapter_id: opts.adapterId,

--- a/src/taps/cc-events/__tests__/cc-events.test.ts
+++ b/src/taps/cc-events/__tests__/cc-events.test.ts
@@ -296,3 +296,106 @@ describe("createCcEventPublisher", () => {
     expect(env.payload.custom).toBe(true);
   });
 });
+
+// ---------------------------------------------------------------------------
+// IAW Phase A.3 — classification parameterisation
+// ---------------------------------------------------------------------------
+
+describe("cc-events classification parameterisation (IAW A.3)", () => {
+  function makeLink() {
+    const calls: { subject: string; payload: string }[] = [];
+    return {
+      calls,
+      stub: {
+        publish(subject: string, payload: string | Uint8Array) {
+          calls.push({
+            subject,
+            payload:
+              typeof payload === "string"
+                ? payload
+                : new TextDecoder().decode(payload),
+          });
+        },
+      } as unknown as Parameters<typeof createCcEventPublisher>[0]["link"],
+    };
+  }
+
+  test("createCcEventEnvelope: omitting classification defaults to local", () => {
+    const env = createCcEventEnvelope({
+      event: makeEvent(),
+      source: { org: "metafactory" },
+    });
+    expect(env.sovereignty.classification).toBe("local");
+    expect(validateEnvelope(env).ok).toBe(true);
+  });
+
+  test("createCcEventEnvelope: classification: 'federated' flows into sovereignty", () => {
+    const env = createCcEventEnvelope({
+      event: makeEvent(),
+      source: { org: "metafactory" },
+      classification: "federated",
+    });
+    expect(env.sovereignty.classification).toBe("federated");
+    expect(validateEnvelope(env).ok).toBe(true);
+  });
+
+  test("createCcEventEnvelope: classification: 'public' flows into sovereignty", () => {
+    const env = createCcEventEnvelope({
+      event: makeEvent(),
+      source: { org: "metafactory" },
+      classification: "public",
+    });
+    expect(env.sovereignty.classification).toBe("public");
+    expect(validateEnvelope(env).ok).toBe(true);
+  });
+
+  test("createCcEventPublisher: federated classification yields federated.{org}.{type} subject", () => {
+    // The end-to-end federation unblock for the cc-events tap. Prior code
+    // hardcoded `local.{org}.{type}` regardless of classification, leaving
+    // the relay unable to emit on `federated.*` even if the caller wanted
+    // it. Now the subject mirrors the envelope's classification.
+    const link = makeLink();
+    const pub = createCcEventPublisher({
+      link: link.stub,
+      org: "metafactory",
+      classification: "federated",
+    });
+    pub(makeEvent({ event_type: "tool.bash.executed" }));
+    expect(link.calls).toHaveLength(1);
+    expect(link.calls[0]!.subject).toBe(
+      "federated.metafactory.tool.bash.executed",
+    );
+    const env = JSON.parse(link.calls[0]!.payload);
+    expect(env.sovereignty.classification).toBe("federated");
+  });
+
+  test("createCcEventPublisher: public classification yields public.{type} subject (no org)", () => {
+    const link = makeLink();
+    const pub = createCcEventPublisher({
+      link: link.stub,
+      org: "metafactory",
+      classification: "public",
+    });
+    pub(makeEvent({ event_type: "tool.bash.executed" }));
+    expect(link.calls).toHaveLength(1);
+    // Public is global — no `{org}` segment per myelin grammar.
+    expect(link.calls[0]!.subject).toBe("public.tool.bash.executed");
+    const env = JSON.parse(link.calls[0]!.payload);
+    expect(env.sovereignty.classification).toBe("public");
+  });
+
+  test("createCcEventPublisher: default classification 'local' preserves prior subject behaviour", () => {
+    // Back-compat: omitting `classification` gives the same subject the
+    // pre-A.3 code path produced. Subscribers under `local.{org}.>` keep
+    // seeing the events untouched.
+    const link = makeLink();
+    const pub = createCcEventPublisher({
+      link: link.stub,
+      org: "metafactory",
+    });
+    pub(makeEvent({ event_type: "tool.bash.executed" }));
+    expect(link.calls[0]!.subject).toBe(
+      "local.metafactory.tool.bash.executed",
+    );
+  });
+});

--- a/src/taps/cc-events/cc-events.ts
+++ b/src/taps/cc-events/cc-events.ts
@@ -47,7 +47,11 @@
  *     read them directly.
  */
 
-import type { Envelope } from "../../bus/myelin/envelope-validator";
+import {
+  deriveNatsSubject,
+  type Classification,
+  type Envelope,
+} from "../../bus/myelin/envelope-validator";
 import { buildBaseEnvelope } from "../../bus/envelope-builder";
 import type { NatsLink } from "../../bus/nats/connection";
 import type { PublishedEvent } from "./hooks/lib/event-types";
@@ -88,15 +92,25 @@ function buildSource(src: CcEventSource | undefined): string {
 
 /**
  * Default sovereignty for `cc.*` envelopes. Same posture as `system.*`:
- * operator-only, local residency, no federation, no frontier-model
+ * operator-only by default, local residency, no frontier-model
  * processing. `data_residency` reads from `source.dataResidency`
  * (defaulting to `"NZ"`). Returned as a fresh literal per call so a
  * downstream mutation on one envelope's sovereignty cannot leak into
  * a sibling envelope.
+ *
+ * **IAW Phase A.3:** `classification` is now an optional parameter
+ * (defaulting to `"local"` for back-compat). Cortex's hook stream carries
+ * internal session activity (file paths, tool names, command previews);
+ * operator-private is the right default. Callers may opt into
+ * `"federated"` or `"public"` for explicit cross-operator visibility
+ * scenarios. Default preserves the prior posture.
  */
-function defaultCcSovereignty(source: CcEventSource | undefined): Envelope["sovereignty"] {
+function defaultCcSovereignty(
+  source: CcEventSource | undefined,
+  classification: Classification = "local",
+): Envelope["sovereignty"] {
   return {
-    classification: "local",
+    classification,
     data_residency: source?.dataResidency ?? "NZ",
     max_hop: 0,
     frontier_ok: false,
@@ -130,6 +144,16 @@ export interface CreateCcEventEnvelopeOpts {
    * to match the bot's `agent.operatorId`.
    */
   source?: CcEventSource;
+  /**
+   * IAW Phase A.3 — optional sovereignty classification. Defaults to
+   * `"local"`. CC hook events carry internal session activity (file paths,
+   * tool names); operator-private is the sensible default. Callers may opt
+   * into `"federated"` or `"public"` for explicit cross-operator scenarios
+   * (e.g. a public demo session whose events should reach a community
+   * dashboard). Mismatch with the publish-time subject is a protocol
+   * violation (see {@link validateSubjectEnvelopeAlignment}).
+   */
+  classification?: Classification;
 }
 
 /**
@@ -156,7 +180,7 @@ export function createCcEventEnvelope(
   const envelope = buildBaseEnvelope({
     type: event.event_type,
     source: buildSource(opts.source),
-    sovereignty: defaultCcSovereignty(opts.source),
+    sovereignty: defaultCcSovereignty(opts.source, opts.classification),
     // Only set correlation_id when session_id has the UUID shape the schema
     // requires. Non-UUID session ids fall through to payload.session_id only.
     ...(isUuid(event.session_id) && { correlationId: event.session_id }),
@@ -189,9 +213,10 @@ export interface CreateCcEventPublisherOpts {
   /** Live NATS connection. Caller owns the lifecycle. */
   link: NatsLink;
   /**
-   * Operator/org segment used in the published subject. Forms the second
-   * segment of `local.{org}.{type}`. Defaults to `"default"` to mirror the
-   * MyelinRuntime convention when `agent.operatorId` is absent.
+   * Operator/org segment used in the envelope `source` and (when
+   * classification is `local` or `federated`) the published NATS subject.
+   * Defaults to `"default"` to mirror the MyelinRuntime convention when
+   * `agent.operatorId` is absent.
    */
   org?: string;
   /**
@@ -207,6 +232,13 @@ export interface CreateCcEventPublisherOpts {
    */
   dataResidency?: string;
   /**
+   * IAW Phase A.3 — optional sovereignty classification. Defaults to
+   * `"local"` for back-compat. Set `"federated"` or `"public"` to scope
+   * relay-lifted CC hooks beyond the org. Applied to every envelope this
+   * publisher produces.
+   */
+  classification?: Classification;
+  /**
    * Override the envelope-construction helper. Lets tests assert on the
    * envelope shape without needing a real NATS connection. Defaults to
    * `createCcEventEnvelope`.
@@ -216,17 +248,25 @@ export interface CreateCcEventPublisherOpts {
 
 /**
  * Build an `onPublished` callback that wraps each PublishedEvent in a
- * Myelin envelope and publishes it on `local.{org}.{type}`.
+ * Myelin envelope and publishes it.
  *
  * Returned callback is **synchronous from the relay's perspective** —
  * Core NATS publishes are fire-and-forget at the client layer. Errors
  * surface to the EventProcessor's logging path but never throw out;
  * a flaky NATS must not break the JSONL pipeline.
  *
- * Subject form mirrors the MyelinRuntime.publish contract (G-1100.E):
- * `local.{org}.{envelope.type}`. Symmetry with subscribe-side patterns
- * means a `local.{org}.>` subscriber sees these CC-lifted events out
- * of the box.
+ * **IAW Phase A.3:** subject derivation now mirrors
+ * `envelope.sovereignty.classification` via `deriveNatsSubject`:
+ *
+ *   - `classification === "local"`     → `local.{org}.{type}`
+ *   - `classification === "federated"` → `federated.{org}.{type}`
+ *   - `classification === "public"`    → `public.{type}` (no `{org}` segment)
+ *
+ * Prior code hardcoded `local.{org}.{type}` here regardless of
+ * classification. The 1:1 subject↔classification invariant
+ * ({@link validateSubjectEnvelopeAlignment}) now holds for relay-lifted
+ * CC events too. The default `classification: "local"` keeps existing
+ * subscribers behaving identically.
  */
 export function createCcEventPublisher(
   opts: CreateCcEventPublisherOpts,
@@ -238,14 +278,16 @@ export function createCcEventPublisher(
     instance: opts.instance ?? "relay",
     ...(opts.dataResidency !== undefined && { dataResidency: opts.dataResidency }),
   };
+  const classification: Classification = opts.classification ?? "local";
   const buildEnvelope =
     opts.buildEnvelope ??
     ((event: PublishedEvent, src: CcEventSource) =>
-      createCcEventEnvelope({ event, source: src }));
+      createCcEventEnvelope({ event, source: src, classification }));
 
   return (event: PublishedEvent) => {
     const envelope = buildEnvelope(event, source);
-    const subject = `local.${org}.${envelope.type}`;
+    // Subject mirrors envelope classification per IAW A.3.
+    const subject = deriveNatsSubject(envelope);
     try {
       opts.link.publish(subject, JSON.stringify(envelope));
     } catch (err) {


### PR DESCRIPTION
## Refs

- cortex#113 IAW Phase A.3 (parameterise classification at the four hardcoded emit sites)
- cortex#109 (envelope-visibility composition with subject-namespace routing)

## What changed (5 sites)

### Emit sites (4)

Each helper now accepts an optional `classification?: Classification` parameter, default `"local"` for back-compat. The parameter flows into `envelope.sovereignty.classification`:

| File | Helper(s) |
|---|---|
| `src/bus/system-events.ts` | `createSystemAdapterDegradedEvent`, `createSystemAdapterRecoveredEvent`, `createSystemAdapterDisconnectedEvent`, `createSystemInboundAbortedEvent` |
| `src/bus/dispatch-events.ts` | all four `dispatch.task.*` lifecycle helpers (via shared `DispatchTaskCommonOpts`) |
| `src/bus/github-events.ts` | `createGithubEventEnvelope` |
| `src/taps/cc-events/cc-events.ts` | `createCcEventEnvelope` + `createCcEventPublisher` factory |

### Subject derivation (1)

`MyelinRuntime.publish` and `createCcEventPublisher` (the cc-events tap publishes directly, not via MyelinRuntime) now derive subjects via the newly-vendored `deriveNatsSubject(envelope)`:

- `local` → `local.{org}.{type}` (unchanged)
- `federated` → `federated.{org}.{type}` (new)
- `public` → `public.{type}` (new — no `{org}` segment per myelin grammar)

`{org}` is now derived from `envelope.source`'s first segment, keeping the subject↔envelope-classification alignment invariant per myelin's `validateSubjectEnvelopeAlignment` (also vendored in this PR).

## Why this matters

> Cortex emits `classification: \"local\"` in 4 sites … Effect: cortex literally cannot emit a `federated.*` or `public.*` envelope today. Multi-operator + cloud-aggregation work has no inbound surface. — cortex#109

After this PR, cortex CAN emit `federated.*` and `public.*` envelopes for the first time. Federation is now **structurally possible**. Trust + accept-rules wiring (decide who to trust, what to accept) is Phase D (cortex#102+, deferred).

## Back-compat

- Every existing caller continues to pass no `classification` arg → defaults to `"local"`.
- Every existing emitted envelope continues to carry `classification: \"local\"`.
- Every existing subject continues to be `local.{org}.{type}`.
- The only behaviour change is that `{org}` in `MyelinRuntime.publish` now comes from `envelope.source` instead of `agent.operatorId`. In every production call path these two values agree (emit-site helpers populate `envelope.source` from `agent.operatorId`), so external behaviour is identical. One runtime test was updated to reflect the new (correct) symmetry.

## Test plan

- [x] `bunx tsc --noEmit` clean
- [x] `bun test src/bus/ src/taps/` — 449 pass, 0 fail (was 423; +26 new tests covering local/federated/public at each emit site + `deriveNatsSubject` + `validateSubjectEnvelopeAlignment`)
- [x] Full `bun test` — 2591 pass, 0 fail (no new failures across the repo)
- [x] Default-`local` regression coverage at every emit site (same envelope shape as pre-PR)
- [x] Federated case: envelope carries `\"federated\"` + subject is `federated.{org}.{type}`
- [x] Public case: envelope carries `\"public\"` + subject is `public.{type}` (no org)
- [x] `validateSubjectEnvelopeAlignment` matrix: 3 aligned + 2 misaligned cases

## What is NOT in this PR (per A.3 scope)

- Operator-side cortex.yaml `stack:` block (A.5)
- Visibility filter on surface-router (A.4)
- Trust decisions based on classification (Phase D)
- Any new envelope schema fields (A.2 already shipped those)

`recommend: merge`