### PR TITLE
test(fragment-loader): accept claude-code substrate in standalone mode (gorse)

### DIFF
--- a/src/common/config/__tests__/fragment-loader.test.ts
+++ b/src/common/config/__tests__/fragment-loader.test.ts
@@ -80,6 +80,46 @@ runtime:
       expect(() => loadAgentsDirectory(dir)).toThrow(FragmentLoadError);
     });
 
+    test("accepts claude-code substrate in standalone mode (gorse — the-metafactory/gorse)", () => {
+      // Claude Code is documented in `docs/design-arc-agent-bots.md` §3.1
+      // as the in-process default. The schema permits `standalone` mode
+      // for it as well — used by `the-metafactory/gorse`, a security
+      // assessment bus peer that drives Claude Code inside an ephemeral
+      // E2B sandbox per dispatch. This test prevents a future refactor
+      // from accidentally constraining `claude-code` to `in-process` only.
+      const dir = mkdtempSync(join(tmpdir(), "agents-d-claude-standalone-"));
+      const personaPath = join(dir, "gorse.md");
+      writeFileSync(personaPath, `---\ndisplayName: Gorse\n---\n`);
+      writeFileSync(
+        join(dir, "gorse.yaml"),
+        `id: gorse
+displayName: Gorse
+persona: ${personaPath}
+roles: [agent-restricted]
+presence:
+  discord:
+    enabled: false
+    token: "t"
+    guildId: "0"
+    agentChannelId: "1"
+    logChannelId: "2"
+runtime:
+  substrate: claude-code
+  mode: standalone
+  capabilities: [security-recon, security-webassessment, security-engagement]
+`,
+      );
+      const agents = loadAgentsDirectory(dir);
+      expect(agents).toHaveLength(1);
+      expect(agents[0]!.runtime!.substrate).toBe("claude-code");
+      expect(agents[0]!.runtime!.mode).toBe("standalone");
+      expect(agents[0]!.runtime!.capabilities).toEqual([
+        "security-recon",
+        "security-webassessment",
+        "security-engagement",
+      ]);
+    });
+
     test("accepts in-process runtime with empty capabilities (capabilities optional for in-process)", () => {
       const dir = mkdtempSync(join(tmpdir(), "agents-d-inprocess-empty-"));
       const personaPath = join(dir, "echo.md");


### PR DESCRIPTION
Adds a positive test asserting that \`runtime.substrate: claude-code\` with \`runtime.mode: standalone\` parses cleanly through \`AgentRuntimeSchema\`. This is the substrate combination [\`the-metafactory/gorse\`](https://github.com/the-metafactory/gorse) uses — a security assessment bus peer that drives Claude Code inside an ephemeral E2B sandbox per dispatch (recon / webassessment / full engagement).

## Why this is the right form of \"allow gorse into cortex\"

- Cortex's substrate enum already includes \`claude-code\` (no enum change needed — unlike the cursor case in cortex#124 which extended the enum).
- The \`mode\` enum (\`in-process | standalone\`) is independent of substrate in the schema today, but \`docs/design-arc-agent-bots.md\` §3.1 frames Claude Code as the in-process default. A future refactor that read the design doc as a constraint could mistakenly tighten the schema to forbid \`claude-code + standalone\`. This test pins that combination as supported so the gorse install path stays unbroken.
- No production code change. Gorse's \`arc-manifest.yaml\` ships the exact runtime block in the fixture below; \`arc install github:the-metafactory/gorse\` succeeds out of the box once this lands.

## What gorse is

Third bot in the sage/alpha/gorse family. Sage (pi.dev) and alpha (cursor) do code review; gorse does security assessment. Tri-mode dispatch via envelope payload field:

| Mode | Skill subtree | Sandbox | Cost |
|---|---|---|---|
| \`recon\` | Security/Recon | E2B 2 vCPU / 4 GiB / 20m | ~\$0.40 |
| \`webassessment\` | Security/WebAssessment (OWASP A01-A10) | E2B 4 vCPU / 8 GiB / 60m | ~\$1.85 |
| \`full\` | both, chained | E2B 4 vCPU / 8 GiB / 90m | ~\$3.00 |

Queue group: \`security-reviewers\` (separate from sage/alpha's \`code-reviewers\`). Trust peers: luna, sage, alpha, pilot, compass, fern.

## Test plan

- [x] \`bun test src/common/config/__tests__/fragment-loader.test.ts\` — 33 pass (32 + 1 new)
- [x] \`bunx tsc --noEmit\` — clean
- [x] Manual: this is the substrate parsing check; live install happens out-of-repo

## Scope

Single test addition. No production code change. No design doc change (worked-example update can be a follow-up so it doesn't conflict with cortex#124's design-arc-agent-bots §3.2 edit currently in flight).

## References

- Reference implementation: \`the-metafactory/gorse\` (private)
- Sibling to cortex#70 / PR #124 (cursor substrate enum addition)
- Future follow-up: \`docs/design-arc-agent-bots.md\` §7.4 worked example for claude-code/standalone (defer until #124 merges)

🤖 Generated with [Claude Code](https://claude.com/claude-code)