### PR TITLE
fix(schema): unify OperatorSchema.id and StackConfigSchema.id grammars (closes cortex#141)

### DIFF
--- a/src/common/types/__tests__/cortex-config.test.ts
+++ b/src/common/types/__tests__/cortex-config.test.ts
@@ -105,6 +105,56 @@ describe("OperatorSchema", () => {
     expect(parsed.id).toBe("andreas-dev-2026");
   });
 
+  // ---------------------------------------------------------------------
+  // cortex#141 — letter-prefix rule (unified with StackConfigSchema)
+  // ---------------------------------------------------------------------
+
+  test("accepts canonical letter-prefixed operator ids", () => {
+    // The realistic operator population — all letter-prefixed today.
+    expect(OperatorSchema.parse({ id: "andreas" }).id).toBe("andreas");
+    expect(OperatorSchema.parse({ id: "jcfischer" }).id).toBe("jcfischer");
+    expect(OperatorSchema.parse({ id: "metafactory" }).id).toBe("metafactory");
+    expect(OperatorSchema.parse({ id: "team-research" }).id).toBe("team-research");
+  });
+
+  test("accepts operator id with internal digits (only the prefix is gated)", () => {
+    // The rule is letter-PREFIX, not letter-only. Internal digits are fine
+    // — `team-42-research`, `andreas-2026` etc. round-trip through both
+    // schemas after cortex#141 closes the gap.
+    expect(OperatorSchema.parse({ id: "team-42-research" }).id).toBe("team-42-research");
+    expect(OperatorSchema.parse({ id: "andreas-2026" }).id).toBe("andreas-2026");
+    expect(OperatorSchema.parse({ id: "a1" }).id).toBe("a1");
+  });
+
+  test("rejects digit-prefix operator id (cortex#141 — letter-prefix rule)", () => {
+    // The unified grammar requires letter-prefix on both `OperatorSchema.id`
+    // and `StackConfigSchema.id` segments. A digit-prefix id like `"2andreas"`
+    // would default-derive to `"2andreas/default"` — a string the stack
+    // schema rejects. Fail fast at the upstream Zod gate with an actionable
+    // error message rather than letting the divergence surface later at
+    // subject-derivation or self-consistency-check time.
+    expect(() => OperatorSchema.parse({ id: "2andreas" })).toThrow(
+      /starting with a letter/,
+    );
+    // The error message MUST surface the migration hint so operators see
+    // what to do, not just what's wrong.
+    expect(() => OperatorSchema.parse({ id: "2andreas" })).toThrow(
+      /team2andreas|andreas-2026/,
+    );
+  });
+
+  test("rejects all-digit operator id", () => {
+    expect(() => OperatorSchema.parse({ id: "123" })).toThrow(
+      /starting with a letter/,
+    );
+  });
+
+  test("rejects hyphen-prefix operator id (must start with a letter, not punctuation)", () => {
+    expect(() => OperatorSchema.parse({ id: "-andreas" })).toThrow(
+      /starting with a letter/,
+    );
+  });
+
   test("defaults dataResidency to NZ", () => {
     const parsed = OperatorSchema.parse({ id: "andreas" });
     expect(parsed.dataResidency).toBe("NZ");

--- a/src/common/types/__tests__/stack.test.ts
+++ b/src/common/types/__tests__/stack.test.ts
@@ -19,7 +19,7 @@
 
 import { describe, test, expect } from "bun:test";
 
-import { CortexConfigSchema } from "../cortex-config";
+import { CortexConfigSchema, OperatorSchema } from "../cortex-config";
 import {
   StackConfigSchema,
   deriveStackId,
@@ -325,13 +325,20 @@ describe("deriveStackId", () => {
 // =============================================================================
 
 describe("deriveStackId × StackConfigSchema round-trip invariant", () => {
-  // `OperatorSchema.id` is `/^[a-z0-9-]+$/` (digit-prefix legal, no underscores).
-  // `StackConfigSchema.id` segments are `/^[a-z][a-z0-9_-]*$/` (letter-prefix
-  // mandatory, underscores legal). These grammars overlap on the realistic
-  // common case (letter-prefixed alphanumeric + hyphen) but diverge at the
-  // edges. The grammar unification decision is tracked in cortex#141; this
-  // suite pins the current behaviour so the A.5.5 namespace cutover does not
-  // surface the divergence as a runtime error without warning.
+  // cortex#141 closed the divergence: `OperatorSchema.id` was tightened to
+  // `/^[a-z][a-z0-9-]*$/` (letter-prefix mandatory, hyphen allowed, no
+  // underscores), and `StackConfigSchema.id` segments remain
+  // `/^[a-z][a-z0-9_-]*$/` (letter-prefix mandatory, underscores additionally
+  // allowed in the stack-id half). The two grammars now agree on letter-prefix
+  // — every value `OperatorSchema.id` accepts default-derives to a stack id
+  // `StackConfigSchema.id` accepts.
+  //
+  // This suite is the round-trip invariant test: anything that survives the
+  // upstream `OperatorSchema.id` gate must round-trip cleanly through
+  // `deriveStackId → StackConfigSchema.id`. The digit-prefix path that used
+  // to surface the divergence is now blocked at the upstream gate
+  // (`OperatorSchema.id.parse("2andreas")` throws), so the latent runtime
+  // failure A.5.5 was at risk of surfacing is structurally impossible.
 
   const stackIdSchema = StackConfigSchema.shape.id;
 
@@ -363,16 +370,24 @@ describe("deriveStackId × StackConfigSchema round-trip invariant", () => {
     expect(() => stackIdSchema.parse(derived.id)).not.toThrow();
   });
 
-  test("KNOWN GAP (cortex#141): digit-prefix operator id default-derives to a string StackConfigSchema rejects", () => {
-    // `2andreas` is legal under `OperatorSchema.id` (`/^[a-z0-9-]+$/`) today.
-    // `StackConfigSchema.id` requires letter-prefix on each segment, so the
-    // default-derived `2andreas/default` fails the stack schema. This test
-    // documents the divergence so an unintended schema tightening (or an
-    // A.5.5 self-consistency check that round-trips through the stack
-    // schema) doesn't silently break this path; resolution is tracked in
-    // cortex#141 (unify the two grammars before A.5.5 lands).
-    const derived = deriveStackId({ operator: { id: "2andreas" } });
-    expect(derived.id).toBe("2andreas/default");
-    expect(() => stackIdSchema.parse(derived.id)).toThrow();
+  test("cortex#141 closed: digit-prefix operator id is rejected at OperatorSchema gate", () => {
+    // Pre-cortex#141: `OperatorSchema.id` accepted `"2andreas"` (regex
+    // `/^[a-z0-9-]+$/`), so `deriveStackId` produced `"2andreas/default"` —
+    // a string `StackConfigSchema.id` rejected. The divergence was a latent
+    // self-inconsistency that A.5.5's namespace cutover would surface as a
+    // runtime error.
+    //
+    // Post-cortex#141: `OperatorSchema.id` regex is `/^[a-z][a-z0-9-]*$/`
+    // (letter-prefix mandatory). Digit-prefix operator ids are rejected at
+    // the upstream Zod gate, so `deriveStackId` never receives an invalid
+    // input from a parsed `CortexConfig`. The latent divergence is
+    // structurally closed — this test pins the invariant.
+    expect(() => OperatorSchema.parse({ id: "2andreas" })).toThrow(
+      /starting with a letter/,
+    );
+    // `deriveStackId` itself is a total function and still works on the
+    // narrowed `DeriveStackIdInput` shape — but no production code path can
+    // pass a digit-prefix `operator.id` through to it, because every config
+    // is parsed through `OperatorSchema` first.
   });
 });

--- a/src/common/types/cortex-config.ts
+++ b/src/common/types/cortex-config.ts
@@ -86,11 +86,24 @@ function emptyDefault<T extends z.ZodObject<z.ZodRawShape>>(schema: T) {
 export const OperatorSchema = z.object({
   /**
    * Operator identifier — used as the `{org}` subject segment on the bus
-   * (`local.{org}.…`). Must be safe to embed verbatim in NATS subjects, so
-   * the same regex agents use applies: lowercase alphanumeric + hyphen. No
-   * dots, no wildcards, no whitespace.
+   * (`local.{org}.…`). Must be safe to embed verbatim in NATS subjects.
+   *
+   * Grammar: lowercase alphanumeric + hyphen, **first character must be a
+   * letter**. The letter-prefix rule mirrors `StackConfigSchema.id` segments
+   * (cortex#141): NATS subject segments starting with a digit interact poorly
+   * with downstream pattern-matchers that treat segments as numeric literals.
+   * Letter-prefix is the safe boundary.
+   *
+   * Closing cortex#141 — the round-trip invariant `OperatorSchema.id →
+   * deriveStackId → StackConfigSchema.id` now holds for every value the
+   * upstream gate accepts. Migration hint for an operator hitting this rule:
+   * rename `2andreas` → `team2andreas` or `andreas-2026` (prepend / wrap the
+   * digits with a letter-prefixed token).
    */
-  id: z.string().min(1).regex(/^[a-z0-9-]+$/, "operator id must be lowercase alphanumeric"),
+  id: z.string().min(1).regex(
+    /^[a-z][a-z0-9-]*$/,
+    "operator id must be lowercase alphanumeric + hyphen, starting with a letter (e.g. 'andreas', 'team-research'); rename digit-prefixed ids like '2andreas' to 'team2andreas' or 'andreas-2026'",
+  ),
   /** Display name shown on the dashboard. Defaults to `id`. */
   displayName: z.string().optional(),
   /** Operator's Discord user id — receives DM notifications from agents. */

--- a/src/common/types/stack.ts
+++ b/src/common/types/stack.ts
@@ -55,12 +55,13 @@ import { z } from "zod/v4";
  *     nkey_pub: UA…
  *
  * The `id` regex enforces `{operator_id}/{stack_id}` where each segment is
- * lowercase alphanumeric + hyphens/underscores, starting with a letter. This
- * matches the broader `{operator}` regex on `OperatorSchema.id` (lowercase
- * alphanumeric + hyphen) but additionally permits underscores in the
- * stack-id half — operators tend to spell stack names with `_` (e.g.
- * `andreas/research_2026`) more naturally than they spell their own
- * identifier.
+ * lowercase alphanumeric + hyphens/underscores, starting with a letter. Both
+ * `OperatorSchema.id` and `StackConfigSchema.id` segments share the letter-
+ * prefix rule (unified by cortex#141 before the IAW A.5.5 namespace cutover);
+ * the stack-id half additionally permits underscores — operators tend to
+ * spell stack names with `_` (e.g. `andreas/research_2026`) more naturally
+ * than they spell their own identifier, so the asymmetry is retained on
+ * purpose for underscores while being closed for the letter-prefix rule.
  *
  * Why each segment must start with a letter: NATS subject segments
  * starting with a digit interact poorly with some downstream subscribers'


### PR DESCRIPTION
## Summary

Tightens `OperatorSchema.id` regex from `/^[a-z0-9-]+$/` to `/^[a-z][a-z0-9-]*$/` so every value the upstream Zod gate accepts default-derives (via `deriveStackId`) to a stack id that `StackConfigSchema.id` accepts. Closes the latent self-inconsistency Echo's round-1 review of cortex#140 flagged before the IAW A.5.5 subject namespace cutover lands.

Closes cortex#141.

## Decision rationale (option 1 from cortex#141)

The issue enumerated three options. This PR lands **option 1** — tighten `OperatorSchema.id` — rather than loosen `StackConfigSchema.id`.

| Option | Why not chosen |
|--------|---------------|
| Option 1 — tighten `OperatorSchema.id` (this PR) | **Chosen.** Letter-prefix is the safer NATS-subject boundary; the same rule already applies to `StackConfigSchema.id` segments. |
| Option 2 — loosen `StackConfigSchema.id` to match operator regex | Would lose the underscores-in-stack-id ergonomic (`andreas/research_2026`) and lose the letter-prefix safety on both schemas. |
| Option 3 — document + regression-test only | cortex#140 landed this; cortex#141 is the structural follow-up. |

**Why letter-prefix:** NATS subject segments starting with a digit interact poorly with downstream pattern-matchers that treat segments as numeric literals. Letter-prefix is the safe boundary for the same reason `StackConfigSchema.id` segments and (existing) agent ids document.

## Migration safety

- **No observed production usage.** `git grep -E '"\s*id:\s*"?[0-9]' src/` returns zero operator-id matches across the codebase. The structurally affected population is empty.
- **Actionable error at parse time.** The tightened Zod regex carries an error message that names the new rule **and** includes a one-line fix hint:
  > `operator id must be lowercase alphanumeric + hyphen, starting with a letter (e.g. 'andreas', 'team-research'); rename digit-prefixed ids like '2andreas' to 'team2andreas' or 'andreas-2026'`
  
  Asserted in the new `cortex-config.test.ts` regression test — the error message MUST surface the migration hint, not just the rule.
- **Underscores are intentionally NOT added** to `OperatorSchema.id`. Stack ids retain underscore support (`andreas/research_2026`) because stack names tend to use underscores more naturally than operator ids do; the asymmetry is retained on purpose for underscores while being closed for the letter-prefix rule.

## Test changes

- **`src/common/types/__tests__/cortex-config.test.ts`** — five new tests on `OperatorSchema`:
  - Accepts canonical letter-prefixed ids (`andreas`, `jcfischer`, `metafactory`, `team-research`).
  - Accepts operator ids with **internal** digits (`team-42-research`, `andreas-2026`, `a1`) — the rule is letter-PREFIX, not letter-only.
  - Rejects digit-prefix (`2andreas`) with assertion that the error message contains both the new rule and the migration hint.
  - Rejects all-digit (`123`).
  - Rejects hyphen-prefix (`-andreas`).
- **`src/common/types/__tests__/stack.test.ts`** — the `KNOWN GAP (cortex#141)` test is reframed:
  - **Pre-this-PR:** asserted that `deriveStackId({ operator: { id: \"2andreas\" } })` produces `\"2andreas/default\"` AND that `StackConfigSchema.id.parse(...)` rejects it (pinning the divergence).
  - **Post-this-PR:** asserts that `OperatorSchema.parse({ id: \"2andreas\" })` THROWS at the upstream gate — the divergence is closed at config-load, so `deriveStackId` never receives an invalid input from a parsed `CortexConfig`. The describe-block comment is rewritten to document the closure and explain why the underscores-in-stack-id asymmetry is retained.
- **`src/common/types/stack.ts`** — header docstring updated. The section explaining the `id` regex now notes that both `OperatorSchema.id` and `StackConfigSchema.id` segments share the letter-prefix rule (unified by cortex#141), while the underscores-in-stack-id half retains its asymmetry on purpose.

## Verification

```
bunx tsc --noEmit                                    # clean, 0 errors
bun test                                             # 2675 pass, 0 fail, 1 skip, 6335 expect() calls (was 2670 baseline)
bun .github/scripts/label-check.ts the-metafactory/cortex  # all 8 required labels present
git grep -E '\"\\s*id:\\s*\"?[0-9]' src/             # zero matches (no production digit-prefix ids)
```

## References

- cortex#141 — this issue (acceptance criteria: decision + tighten/loosen + regression test update + migration path)
- cortex#140 — IAW A.5.3+A.5.4 round-1 review follow-up (Echo flagged the divergence)
- cortex#113 — IAW Phase A meta (A.5.5 namespace cutover is the next entry criterion)

## Out of scope

- `StackConfigSchema.id` regex (option 2 path — not chosen)
- `OperatorSchema.id` length / charset rules beyond letter-prefix
- The NKey regex pattern (separate issue: cortex#143)
- Anything outside `src/common/types/` and its tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)