### PR TITLE
feat(config): IAW A.6 — capabilities: block schema + per-agent reference validation (refs cortex#113)

### DIFF
--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -2,7 +2,7 @@
 # See: https://github.com/the-metafactory/arc
 
 name: "Cortex"
-version: "0.1.0"
+version: "0.2.0"
 type: component
 tier: community
 description: "Layer-7 collaboration surface for the metafactory ecosystem — the M7 application that consumes the Myelin stack"

--- a/src/common/agents/__tests__/registry.test.ts
+++ b/src/common/agents/__tests__/registry.test.ts
@@ -104,6 +104,13 @@ function cortexConfigFixture(agents: Agent[]): CortexConfig {
     },
     networksDir: "./networks",
     networks: [],
+    // IAW Phase A.6 (cortex#113) — the `capabilities:` block has a `.default([])`
+    // on the schema, but the inferred CortexConfig OUTPUT type lists it as a
+    // required field (defaults always present after parse). Fixture literals
+    // that `as CortexConfig` cast through this builder therefore need to
+    // include it explicitly. Registry tests don't exercise capabilities; an
+    // empty array is the right zero-value.
+    capabilities: [],
   } as CortexConfig;
 }
 

--- a/src/common/types/__tests__/capability.test.ts
+++ b/src/common/types/__tests__/capability.test.ts
@@ -1,0 +1,693 @@
+/**
+ * IAW Phase A.6 — `CapabilitySchema` + cortex.yaml integration tests
+ * (cortex#113).
+ *
+ * Three surfaces under test:
+ *   1. `CapabilitySchema` — field-level grammar and structural invariants
+ *      on a single capability declaration (id regex, description non-empty,
+ *      tag regex, provider id regex, rate/cost envelope shapes).
+ *   2. `CortexConfigSchema` integration — the top-level `capabilities:`
+ *      block parses cleanly when absent (default `[]`), accepts a populated
+ *      catalog, and rejects duplicate capability ids at the document level.
+ *   3. Cross-field reference invariants (A.6.3) — every
+ *      `agents[].runtime.capabilities[]` reference resolves to a declared
+ *      `capabilities[].id`, and every `capabilities[].provided_by[]`
+ *      reference resolves to a declared `agents[].id`. Symmetric dangling-
+ *      reference guards; the error messages name the offending agent/id
+ *      and the specific path the operator should edit.
+ *
+ * Test layout mirrors `./stack.test.ts`: minimal fixture builders at the
+ * top, schema-level tests next, document-level tests after, and the
+ * cross-field-invariant suite last.
+ */
+
+import { describe, test, expect } from "bun:test";
+
+import {
+  CapabilitySchema,
+  type Capability,
+  type CapabilityCost,
+  type CapabilityRate,
+} from "../capability";
+import { CortexConfigSchema } from "../cortex-config";
+
+// =============================================================================
+// Fixture helpers (mirror the patterns in stack.test.ts + cortex-config.test.ts)
+// =============================================================================
+
+function minOperator() {
+  return { id: "andreas" };
+}
+
+function minDiscordPresence() {
+  return {
+    token: "discord-bot-token",
+    guildId: "1487000000000000000",
+    agentChannelId: "1487000000000000001",
+    logChannelId: "1487000000000000002",
+  };
+}
+
+function minAgent(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "luna",
+    displayName: "Luna",
+    persona: "./personas/luna.md",
+    presence: { discord: minDiscordPresence() },
+    ...overrides,
+  };
+}
+
+function minConfig(overrides: Record<string, unknown> = {}) {
+  return {
+    operator: minOperator(),
+    agents: [minAgent()],
+    claude: {},
+    ...overrides,
+  };
+}
+
+/**
+ * A minimum-valid capability declaration. Tests that need a variant clone
+ * this and override only the field under examination.
+ */
+function minCapability(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "code-review.typescript",
+    description: "TypeScript code review with type-checking analysis",
+    tags: ["typescript", "code-review"],
+    provided_by: ["luna"],
+    ...overrides,
+  };
+}
+
+// =============================================================================
+// CapabilitySchema — id grammar
+// =============================================================================
+
+describe("CapabilitySchema.id grammar", () => {
+  test("accepts canonical dot-separated id", () => {
+    const parsed = CapabilitySchema.parse(minCapability());
+    expect(parsed.id).toBe("code-review.typescript");
+  });
+
+  test("accepts bare single-segment id (no sub-capability)", () => {
+    const parsed = CapabilitySchema.parse(minCapability({ id: "code-review" }));
+    expect(parsed.id).toBe("code-review");
+  });
+
+  test("accepts multi-segment id with three levels", () => {
+    const parsed = CapabilitySchema.parse(
+      minCapability({ id: "literature-search.medline.full-text" }),
+    );
+    expect(parsed.id).toBe("literature-search.medline.full-text");
+  });
+
+  test("accepts underscores inside segments", () => {
+    const parsed = CapabilitySchema.parse(
+      minCapability({ id: "image_gen.dall_e_3" }),
+    );
+    expect(parsed.id).toBe("image_gen.dall_e_3");
+  });
+
+  test("rejects uppercase id segments", () => {
+    expect(() =>
+      CapabilitySchema.parse(minCapability({ id: "Code-Review" })),
+    ).toThrow(/capability id must be dot-separated/);
+    expect(() =>
+      CapabilitySchema.parse(minCapability({ id: "code-review.TypeScript" })),
+    ).toThrow(/capability id must be dot-separated/);
+  });
+
+  test("rejects whitespace anywhere in id", () => {
+    expect(() => CapabilitySchema.parse(minCapability({ id: "code review" }))).toThrow();
+    expect(() => CapabilitySchema.parse(minCapability({ id: " code-review" }))).toThrow();
+    expect(() => CapabilitySchema.parse(minCapability({ id: "code-review " }))).toThrow();
+  });
+
+  test("rejects digit-prefix segments (letter-prefix rule)", () => {
+    expect(() => CapabilitySchema.parse(minCapability({ id: "2d-rendering" }))).toThrow(
+      /capability id must be dot-separated/,
+    );
+    expect(() =>
+      CapabilitySchema.parse(minCapability({ id: "code-review.3d" })),
+    ).toThrow(/capability id must be dot-separated/);
+  });
+
+  test("rejects leading/trailing/consecutive dots", () => {
+    expect(() => CapabilitySchema.parse(minCapability({ id: ".code-review" }))).toThrow();
+    expect(() => CapabilitySchema.parse(minCapability({ id: "code-review." }))).toThrow();
+    expect(() =>
+      CapabilitySchema.parse(minCapability({ id: "code-review..typescript" })),
+    ).toThrow();
+  });
+
+  test("rejects empty id", () => {
+    expect(() => CapabilitySchema.parse(minCapability({ id: "" }))).toThrow(
+      /capability id is required/,
+    );
+  });
+
+  test("rejects NATS wildcards in id", () => {
+    expect(() => CapabilitySchema.parse(minCapability({ id: "code-review.*" }))).toThrow();
+    expect(() => CapabilitySchema.parse(minCapability({ id: "code-review.>" }))).toThrow();
+  });
+});
+
+// =============================================================================
+// CapabilitySchema — description / tags / provided_by
+// =============================================================================
+
+describe("CapabilitySchema.description", () => {
+  test("rejects empty string", () => {
+    expect(() =>
+      CapabilitySchema.parse(minCapability({ description: "" })),
+    ).toThrow(/capability\.description is required/);
+  });
+
+  test("rejects missing field entirely", () => {
+    const { description: _omitted, ...rest } = minCapability();
+    expect(() => CapabilitySchema.parse(rest)).toThrow();
+  });
+
+  test("accepts a single-character description (e.g. '.')", () => {
+    const parsed = CapabilitySchema.parse(minCapability({ description: "." }));
+    expect(parsed.description).toBe(".");
+  });
+});
+
+describe("CapabilitySchema.tags", () => {
+  test("defaults to empty array when omitted", () => {
+    const { tags: _omitted, ...rest } = minCapability();
+    const parsed = CapabilitySchema.parse(rest);
+    expect(parsed.tags).toEqual([]);
+  });
+
+  test("accepts canonical tag list", () => {
+    const parsed = CapabilitySchema.parse(
+      minCapability({ tags: ["typescript", "code-review", "ts"] }),
+    );
+    expect(parsed.tags).toEqual(["typescript", "code-review", "ts"]);
+  });
+
+  test("rejects uppercase tag", () => {
+    expect(() =>
+      CapabilitySchema.parse(minCapability({ tags: ["TypeScript"] })),
+    ).toThrow(/capability tags must be lowercase/);
+  });
+
+  test("rejects digit-prefix tag", () => {
+    expect(() => CapabilitySchema.parse(minCapability({ tags: ["2d"] }))).toThrow(
+      /capability tags must be lowercase/,
+    );
+  });
+
+  test("rejects whitespace-bearing tag", () => {
+    expect(() =>
+      CapabilitySchema.parse(minCapability({ tags: ["code review"] })),
+    ).toThrow();
+  });
+
+  test("rejects dot-bearing tag (tags are flat, not taxonomic)", () => {
+    expect(() =>
+      CapabilitySchema.parse(minCapability({ tags: ["code.review"] })),
+    ).toThrow();
+  });
+});
+
+describe("CapabilitySchema.provided_by", () => {
+  test("accepts a single provider", () => {
+    const parsed = CapabilitySchema.parse(minCapability({ provided_by: ["luna"] }));
+    expect(parsed.provided_by).toEqual(["luna"]);
+  });
+
+  test("accepts multiple providers", () => {
+    const parsed = CapabilitySchema.parse(
+      minCapability({ provided_by: ["luna", "echo", "holly"] }),
+    );
+    expect(parsed.provided_by).toEqual(["luna", "echo", "holly"]);
+  });
+
+  test("rejects empty provider list (≥1 required)", () => {
+    expect(() =>
+      CapabilitySchema.parse(minCapability({ provided_by: [] })),
+    ).toThrow(/at least one provider agent id/);
+  });
+
+  test("rejects digit-only provider id (mismatched grammar)", () => {
+    // Real failure mode: operator pastes a Discord snowflake into provided_by.
+    expect(() =>
+      CapabilitySchema.parse(minCapability({ provided_by: ["1497204875912609844"] })),
+    ).not.toThrow();
+    // ^ digit-only is structurally allowed because AgentSchema.id on `main` is
+    // `/^[a-z0-9-]+$/` — provided_by mirrors that. cortex#145 will tighten both
+    // to letter-prefix. We pin the current grammar parity here so the schema
+    // doesn't drift relative to AgentSchema.id.
+  });
+
+  test("rejects uppercase provider id", () => {
+    expect(() =>
+      CapabilitySchema.parse(minCapability({ provided_by: ["Luna"] })),
+    ).toThrow(/provided_by entries must be agent ids/);
+  });
+
+  test("rejects underscore in provider id (matches AgentSchema.id grammar)", () => {
+    // AgentSchema.id is `/^[a-z0-9-]+$/` — no underscores. We mirror that.
+    expect(() =>
+      CapabilitySchema.parse(minCapability({ provided_by: ["my_agent"] })),
+    ).toThrow(/provided_by entries must be agent ids/);
+  });
+});
+
+// =============================================================================
+// CapabilitySchema — rate / cost envelopes
+// =============================================================================
+
+describe("CapabilitySchema.rate", () => {
+  test("accepts per_minute alone", () => {
+    const parsed = CapabilitySchema.parse(
+      minCapability({ rate: { per_minute: 10 } }),
+    );
+    expect(parsed.rate).toEqual({ per_minute: 10 });
+  });
+
+  test("accepts mixed-window rate (per_minute + per_day)", () => {
+    const parsed = CapabilitySchema.parse(
+      minCapability({ rate: { per_minute: 10, per_day: 5000 } }),
+    );
+    expect(parsed.rate).toEqual({ per_minute: 10, per_day: 5000 });
+  });
+
+  test("rejects empty rate envelope", () => {
+    expect(() =>
+      CapabilitySchema.parse(minCapability({ rate: {} })),
+    ).toThrow(/at least one window/);
+  });
+
+  test("rejects zero per_minute (not a meaningful rate)", () => {
+    expect(() =>
+      CapabilitySchema.parse(minCapability({ rate: { per_minute: 0 } })),
+    ).toThrow();
+  });
+
+  test("rejects negative per_hour", () => {
+    expect(() =>
+      CapabilitySchema.parse(minCapability({ rate: { per_hour: -1 } })),
+    ).toThrow();
+  });
+
+  test("rejects fractional per_day", () => {
+    expect(() =>
+      CapabilitySchema.parse(minCapability({ rate: { per_day: 1.5 } })),
+    ).toThrow();
+  });
+});
+
+describe("CapabilitySchema.cost", () => {
+  test("accepts cents_per_request alone", () => {
+    const parsed = CapabilitySchema.parse(
+      minCapability({ cost: { cents_per_request: 2 } }),
+    );
+    expect(parsed.cost).toEqual({ cents_per_request: 2 });
+  });
+
+  test("accepts cents_per_token alone", () => {
+    const parsed = CapabilitySchema.parse(
+      minCapability({ cost: { cents_per_token: 0.001 } }),
+    );
+    expect(parsed.cost).toEqual({ cents_per_token: 0.001 });
+  });
+
+  test("accepts zero cents_per_request (declared-free is a meaningful signal)", () => {
+    const parsed = CapabilitySchema.parse(
+      minCapability({ cost: { cents_per_request: 0 } }),
+    );
+    expect(parsed.cost).toEqual({ cents_per_request: 0 });
+  });
+
+  test("rejects empty cost envelope", () => {
+    expect(() => CapabilitySchema.parse(minCapability({ cost: {} }))).toThrow(
+      /at least one unit/,
+    );
+  });
+
+  test("rejects negative cents_per_token", () => {
+    expect(() =>
+      CapabilitySchema.parse(minCapability({ cost: { cents_per_token: -0.5 } })),
+    ).toThrow();
+  });
+});
+
+// =============================================================================
+// CortexConfigSchema integration — `capabilities:` block at top level
+// =============================================================================
+
+describe("CortexConfigSchema with capabilities: block", () => {
+  test("absent capabilities: block parses cleanly (default [])", () => {
+    const parsed = CortexConfigSchema.parse(minConfig());
+    expect(parsed.capabilities).toEqual([]);
+  });
+
+  test("populated capabilities: block round-trips through CortexConfigSchema", () => {
+    const parsed = CortexConfigSchema.parse(
+      minConfig({ capabilities: [minCapability()] }),
+    );
+    expect(parsed.capabilities).toHaveLength(1);
+    expect(parsed.capabilities[0]?.id).toBe("code-review.typescript");
+    expect(parsed.capabilities[0]?.provided_by).toEqual(["luna"]);
+  });
+
+  test("invalid capability id is rejected at top-level CortexConfig parse", () => {
+    expect(() =>
+      CortexConfigSchema.parse(
+        minConfig({ capabilities: [minCapability({ id: "Code-Review" })] }),
+      ),
+    ).toThrow(/capability id must be dot-separated/);
+  });
+
+  test("missing description is rejected at top-level CortexConfig parse", () => {
+    expect(() =>
+      CortexConfigSchema.parse(
+        minConfig({
+          capabilities: [
+            { id: "code-review.typescript", tags: [], provided_by: ["luna"] },
+          ],
+        }),
+      ),
+    ).toThrow();
+  });
+
+  test("free-text capability declaration (string instead of object) is rejected", () => {
+    // The most common "free-text" mistake: writing the capability as a bare
+    // string slug. The schema is explicitly constrained per Q2 lock-in.
+    expect(() =>
+      CortexConfigSchema.parse(
+        minConfig({ capabilities: ["code-review.typescript"] }),
+      ),
+    ).toThrow();
+  });
+});
+
+// =============================================================================
+// Document-level invariants — uniqueness + cross-field references (A.6.3)
+// =============================================================================
+
+describe("CortexConfigSchema — capability id uniqueness", () => {
+  test("duplicate capability ids in catalog rejected", () => {
+    expect(() =>
+      CortexConfigSchema.parse(
+        minConfig({
+          capabilities: [
+            minCapability({ id: "code-review.typescript" }),
+            minCapability({ id: "code-review.typescript", description: "dup" }),
+          ],
+        }),
+      ),
+    ).toThrow(/capability ids must be unique/);
+  });
+
+  test("two distinct ids in catalog parse cleanly", () => {
+    const parsed = CortexConfigSchema.parse(
+      minConfig({
+        capabilities: [
+          minCapability({ id: "code-review.typescript" }),
+          minCapability({ id: "code-review.python" }),
+        ],
+      }),
+    );
+    expect(parsed.capabilities).toHaveLength(2);
+  });
+});
+
+describe("CortexConfigSchema — provided_by → agents[] reference resolution", () => {
+  test("provided_by referencing declared agent parses", () => {
+    const parsed = CortexConfigSchema.parse(
+      minConfig({
+        agents: [minAgent({ id: "echo" })],
+        capabilities: [minCapability({ provided_by: ["echo"] })],
+      }),
+    );
+    expect(parsed.capabilities[0]?.provided_by).toEqual(["echo"]);
+  });
+
+  test("provided_by referencing undeclared agent is rejected with named error", () => {
+    // ZodError.message JSON-encodes the issues array, so inner double-quotes
+    // get backslash-escaped. The regex matches the substring shape without
+    // anchoring on the quote character (`["]` lets us accept either).
+    expect(() =>
+      CortexConfigSchema.parse(
+        minConfig({
+          agents: [minAgent({ id: "luna" })],
+          capabilities: [
+            minCapability({
+              id: "code-review.typescript",
+              provided_by: ["echo"], // not declared
+            }),
+          ],
+        }),
+      ),
+    ).toThrow(/lists provider agent .*echo/);
+  });
+
+  test("error message names the offending capability and the declared agent set", () => {
+    try {
+      CortexConfigSchema.parse(
+        minConfig({
+          agents: [minAgent({ id: "luna" }), minAgent({ id: "echo" })],
+          capabilities: [
+            minCapability({
+              id: "code-review.typescript",
+              provided_by: ["holly"], // not in [luna, echo]
+            }),
+          ],
+        }),
+      );
+      throw new Error("expected parse to throw");
+    } catch (e) {
+      const msg = (e as Error).message;
+      expect(msg).toContain("code-review.typescript");
+      expect(msg).toContain("holly");
+      expect(msg).toContain("luna");
+      expect(msg).toContain("echo");
+    }
+  });
+
+  test("multiple dangling provider references are all reported", () => {
+    // Operators with many broken references see the full batch, not just
+    // the first — the superRefine accumulates issues across the walk.
+    try {
+      CortexConfigSchema.parse(
+        minConfig({
+          agents: [minAgent({ id: "luna" })],
+          capabilities: [
+            minCapability({
+              id: "code-review.typescript",
+              provided_by: ["luna", "echo"], // echo not declared
+            }),
+            minCapability({
+              id: "deploy",
+              provided_by: ["holly"], // holly not declared
+            }),
+          ],
+        }),
+      );
+      throw new Error("expected parse to throw");
+    } catch (e) {
+      const msg = (e as Error).message;
+      expect(msg).toContain("echo");
+      expect(msg).toContain("holly");
+    }
+  });
+});
+
+describe("CortexConfigSchema — agents[].runtime.capabilities → catalog (A.6.3)", () => {
+  test("agent runtime capability referencing declared catalog entry parses", () => {
+    const parsed = CortexConfigSchema.parse(
+      minConfig({
+        agents: [
+          minAgent({
+            id: "luna",
+            runtime: {
+              substrate: "claude-code",
+              mode: "in-process",
+              capabilities: ["code-review.typescript"],
+            },
+          }),
+        ],
+        capabilities: [minCapability({ id: "code-review.typescript", provided_by: ["luna"] })],
+      }),
+    );
+    expect(parsed.agents[0]?.runtime?.capabilities).toEqual([
+      "code-review.typescript",
+    ]);
+  });
+
+  test("agent claiming undeclared capability is rejected (dangling reference)", () => {
+    expect(() =>
+      CortexConfigSchema.parse(
+        minConfig({
+          agents: [
+            minAgent({
+              id: "luna",
+              runtime: {
+                substrate: "claude-code",
+                mode: "in-process",
+                capabilities: ["code-review.typescript"], // not in empty catalog
+              },
+            }),
+          ],
+          // capabilities: omitted → defaults to []
+        }),
+      ),
+    ).toThrow(/claims capability .*code-review\.typescript/);
+  });
+
+  test("error message names the agent, the capability id, and the catalog state", () => {
+    try {
+      CortexConfigSchema.parse(
+        minConfig({
+          agents: [
+            minAgent({
+              id: "echo",
+              runtime: {
+                substrate: "claude-code",
+                mode: "in-process",
+                capabilities: ["deploy.k8s"],
+              },
+            }),
+          ],
+          capabilities: [
+            minCapability({ id: "code-review.typescript", provided_by: ["echo"] }),
+          ],
+        }),
+      );
+      throw new Error("expected parse to throw");
+    } catch (e) {
+      // ZodError.message is JSON-encoded; we assert on bare identifiers
+      // rather than the surrounding quote character so the test doesn't
+      // brittle-couple to JSON escaping.
+      const msg = (e as Error).message;
+      expect(msg).toContain("echo");
+      expect(msg).toContain("deploy.k8s");
+      expect(msg).toContain("code-review.typescript"); // the declared catalog id
+    }
+  });
+
+  test("empty catalog + empty agent runtime.capabilities parses cleanly", () => {
+    // Backward-compat path: deployments not yet declaring any capabilities
+    // continue to parse without surfacing a refine error.
+    const parsed = CortexConfigSchema.parse(
+      minConfig({
+        agents: [
+          minAgent({
+            id: "luna",
+            runtime: {
+              substrate: "claude-code",
+              mode: "in-process",
+              capabilities: [],
+            },
+          }),
+        ],
+      }),
+    );
+    expect(parsed.capabilities).toEqual([]);
+    expect(parsed.agents[0]?.runtime?.capabilities).toEqual([]);
+  });
+
+  test("multiple agents may share a capability id (catalog is stack-wide)", () => {
+    // Q2 lock-in: a capability declaration is stack-wide. Multiple agents
+    // can reference the same id, and the catalog's `provided_by[]` can list
+    // multiple providers — they're parallel expressions of the same fact.
+    const parsed = CortexConfigSchema.parse(
+      minConfig({
+        agents: [
+          minAgent({
+            id: "luna",
+            runtime: {
+              substrate: "claude-code",
+              mode: "in-process",
+              capabilities: ["code-review.typescript"],
+            },
+          }),
+          {
+            id: "echo",
+            displayName: "Echo",
+            persona: "./personas/echo.md",
+            presence: { discord: minDiscordPresence() },
+            runtime: {
+              substrate: "claude-code",
+              mode: "in-process",
+              capabilities: ["code-review.typescript"],
+            },
+          },
+        ],
+        capabilities: [
+          minCapability({
+            id: "code-review.typescript",
+            provided_by: ["luna", "echo"],
+          }),
+        ],
+      }),
+    );
+    expect(parsed.capabilities[0]?.provided_by).toEqual(["luna", "echo"]);
+    expect(parsed.agents.map((a) => a.runtime?.capabilities)).toEqual([
+      ["code-review.typescript"],
+      ["code-review.typescript"],
+    ]);
+  });
+
+  test("multiple dangling agent references are all reported", () => {
+    try {
+      CortexConfigSchema.parse(
+        minConfig({
+          agents: [
+            minAgent({
+              id: "luna",
+              runtime: {
+                substrate: "claude-code",
+                mode: "in-process",
+                capabilities: ["missing-a", "missing-b"],
+              },
+            }),
+          ],
+        }),
+      );
+      throw new Error("expected parse to throw");
+    } catch (e) {
+      const msg = (e as Error).message;
+      expect(msg).toContain("missing-a");
+      expect(msg).toContain("missing-b");
+    }
+  });
+});
+
+// =============================================================================
+// Type round-trip — exported type aliases match the schema
+// =============================================================================
+
+describe("Type exports", () => {
+  test("Capability infers from CapabilitySchema", () => {
+    // The structural compile-time check: a `Capability` value can be
+    // constructed inline matching the schema's output shape. If the type
+    // export drifts, this test fails to compile rather than asserting
+    // at runtime.
+    const cap: Capability = {
+      id: "code-review.typescript",
+      description: "TypeScript code review",
+      tags: ["typescript"],
+      provided_by: ["luna"],
+    };
+    const parsed = CapabilitySchema.parse(cap);
+    expect(parsed.id).toBe(cap.id);
+  });
+
+  test("CapabilityRate type aligns with the rate envelope shape", () => {
+    const rate: CapabilityRate = { per_minute: 10 };
+    expect(rate.per_minute).toBe(10);
+  });
+
+  test("CapabilityCost type aligns with the cost envelope shape", () => {
+    const cost: CapabilityCost = { cents_per_request: 2 };
+    expect(cost.cents_per_request).toBe(2);
+  });
+});

--- a/src/common/types/__tests__/capability.test.ts
+++ b/src/common/types/__tests__/capability.test.ts
@@ -174,6 +174,25 @@ describe("CapabilitySchema.description", () => {
     const parsed = CapabilitySchema.parse(minCapability({ description: "." }));
     expect(parsed.description).toBe(".");
   });
+
+  test("rejects whitespace-only description (`.trim().min(1)` guard)", () => {
+    // `.min(1)` alone accepts `" "` (length 1) — `.trim().min(1)` rejects
+    // it because the trimmed length is 0. Pins the operator-facing contract:
+    // blank-looking descriptions never propagate to the registry / dashboard.
+    expect(() =>
+      CapabilitySchema.parse(minCapability({ description: "   " })),
+    ).toThrow(/capability\.description is required/);
+    expect(() =>
+      CapabilitySchema.parse(minCapability({ description: "\t\n " })),
+    ).toThrow(/capability\.description is required/);
+  });
+
+  test("trims surrounding whitespace on otherwise-valid descriptions", () => {
+    const parsed = CapabilitySchema.parse(
+      minCapability({ description: "  TypeScript review  " }),
+    );
+    expect(parsed.description).toBe("TypeScript review");
+  });
 });
 
 describe("CapabilitySchema.tags", () => {

--- a/src/common/types/__tests__/capability.test.ts
+++ b/src/common/types/__tests__/capability.test.ts
@@ -234,15 +234,18 @@ describe("CapabilitySchema.provided_by", () => {
     ).toThrow(/at least one provider agent id/);
   });
 
-  test("rejects digit-only provider id (mismatched grammar)", () => {
-    // Real failure mode: operator pastes a Discord snowflake into provided_by.
+  test("accepts digit-only provider id today (parity with AgentSchema.id on main; tightens with cortex#145)", () => {
+    // Real failure mode this pins: an operator pastes a Discord snowflake into
+    // provided_by and the schema silently accepts it. Today this MUST parse
+    // because `provided_by` mirrors `AgentSchema.id`'s loose `/^[a-z0-9-]+$/`
+    // on main — tightening both to letter-prefix is cortex#145's job. The
+    // assertion here pins the current grammar parity so the schema doesn't
+    // drift from AgentSchema.id before cortex#145 lands; when #145 merges,
+    // this test flips to a `toThrow` (along with the snowflake-style ones in
+    // cortex-config.test.ts for AgentSchema.id itself).
     expect(() =>
       CapabilitySchema.parse(minCapability({ provided_by: ["1497204875912609844"] })),
     ).not.toThrow();
-    // ^ digit-only is structurally allowed because AgentSchema.id on `main` is
-    // `/^[a-z0-9-]+$/` — provided_by mirrors that. cortex#145 will tighten both
-    // to letter-prefix. We pin the current grammar parity here so the schema
-    // doesn't drift relative to AgentSchema.id.
   });
 
   test("rejects uppercase provider id", () => {

--- a/src/common/types/capability.ts
+++ b/src/common/types/capability.ts
@@ -1,0 +1,289 @@
+/**
+ * IAW Phase A.6 — capability declaration primitive (refs cortex#113).
+ *
+ * Background (docs/design-internet-of-agentic-work.md §5 Q2 lock-in,
+ * 2026-05-13 Andreas):
+ *
+ *   "Two-part: (a) network capabilities = aggregated across all agents in all
+ *   stacks part of the network; (b) operator can ALSO declare stack-level
+ *   capabilities (and per-agent capability annotations) in cortex.yaml using
+ *   a constrained schema — defined interface, NOT free text. 'Keep it simple.'
+ *   Schema covers: capability id, description, tags (e.g., language tags),
+ *   provided_by agent ids, optional rate/cost."
+ *
+ * The Q2 lock-in is explicit: schema-bounded, NOT free-text, so the future
+ * network registry (Q3) can index capabilities deterministically and
+ * orchestrator agents (§3.6) can reason about delegation without natural-
+ * language disambiguation.
+ *
+ * What this file delivers (A.6.1 + A.6.2):
+ *   - `CapabilitySchema` — Zod schema for a single capability declaration.
+ *     Required fields: `id`, `description`, `tags`, `provided_by`.
+ *     Optional fields: `rate`, `cost` — both structured envelopes, never
+ *     free-text strings.
+ *
+ * What this file does NOT do:
+ *   - **No runtime capability matching / dispatch logic.** That's a future
+ *     phase (Phase E orchestrator pattern, §3.6 of the design doc). A.6 is
+ *     schema-only: the catalog is parsed and queryable, but nothing on the
+ *     dispatch path consumes it yet.
+ *   - **No network registry registration.** Phase D, D.4 cloud-side
+ *     registry service.
+ *   - **No tightening of `AgentSchema.id`.** That's cortex#145. `provided_by`
+ *     mirrors the SAME pattern `AgentSchema.id` uses on `main` today
+ *     (`/^[a-z0-9-]+$/`); once cortex#145 lands and tightens `AgentSchema.id`,
+ *     this regex tightens with it (single edit, one-segment grammar parity).
+ *
+ * The per-agent reference validation (A.6.3) — every id in an agent's
+ * `runtime.capabilities[]` must exist in the top-level `capabilities[]` block
+ * — lives on `CortexConfigSchema` itself (a `.refine()` over the parsed
+ * config), not here. Keeping the structural schema and the cross-field guard
+ * separate mirrors how `CortexConfigSchema` already handles the unique-agent-
+ * ids invariant in `cortex-config.ts`.
+ */
+
+import { z } from "zod/v4";
+
+// =============================================================================
+// Sub-schemas — rate / cost envelopes
+// =============================================================================
+
+/**
+ * Optional rate envelope. The design doc Q2 leaves the form unspecified
+ * beyond "rate (requests per unit time)"; we anchor on a small fixed set of
+ * windows so the schema is deterministic and orchestrator agents can compare
+ * rates without parsing free-text duration strings.
+ *
+ * Why three windows: most reasonable rate ceilings on agent capabilities
+ * (LLM-driven code review, embedding lookup, etc.) fall into one of these
+ * buckets. A capability author picks the window that's natural for the
+ * dominant constraint — short windows for burst-rate limits, longer for
+ * daily quotas. Mixed windows are allowed (e.g. 10/min AND 5000/day), which
+ * is the realistic shape for downstream-API-bounded capabilities.
+ *
+ * Why `positive int`: requests-per-window is a count; zero is not a valid
+ * rate (zero would be "the capability does not exist", which is a different
+ * concept than "rate-limited") and fractional rates are not meaningful at
+ * the window granularity we offer. Operators wanting fractional ceilings
+ * pick a larger window (1/min → 60/hour).
+ *
+ * At least one field must be set — an empty rate envelope (`rate: {}`) is
+ * the same shape as no envelope at all, so we reject it explicitly with a
+ * pointed error message rather than silently treating it as no constraint.
+ */
+const CapabilityRateSchema = z
+  .object({
+    per_minute: z.number().int().positive().optional(),
+    per_hour: z.number().int().positive().optional(),
+    per_day: z.number().int().positive().optional(),
+  })
+  .refine(
+    (r) => r.per_minute !== undefined || r.per_hour !== undefined || r.per_day !== undefined,
+    {
+      message:
+        "capability.rate must declare at least one window (per_minute, per_hour, or per_day); omit the `rate:` block entirely to mean 'no rate constraint'",
+    },
+  );
+
+export type CapabilityRate = z.infer<typeof CapabilityRateSchema>;
+
+/**
+ * Optional cost envelope. The design doc Q2 leaves the form unspecified
+ * beyond "cost (cents per request, or token-class pricing)"; we anchor on
+ * two unit forms: per-request flat fees and per-token rates.
+ *
+ * No currency field. The first deployment is single-currency (cents = USD
+ * cents); operators with a different currency convert at config time. Adding
+ * a currency field at this stage would over-engineer the schema (Q2 calls
+ * "keep it simple") and create a second migration when we add it for real.
+ *
+ * `nonnegative` rather than `positive`: a $0/request capability is a real
+ * thing (free local-only models, intra-org capabilities, etc.) and should
+ * declare zero rather than omitting the field — declared-zero communicates
+ * "we considered cost and it's zero" vs. omitted communicates "we didn't
+ * think about cost yet". The distinction matters when the orchestrator
+ * agent reads the field to make routing decisions.
+ *
+ * At least one field required — same rationale as `CapabilityRateSchema`:
+ * an empty `cost: {}` block is rejected explicitly.
+ */
+const CapabilityCostSchema = z
+  .object({
+    cents_per_request: z.number().nonnegative().optional(),
+    cents_per_token: z.number().nonnegative().optional(),
+  })
+  .refine(
+    (c) => c.cents_per_request !== undefined || c.cents_per_token !== undefined,
+    {
+      message:
+        "capability.cost must declare at least one unit (cents_per_request or cents_per_token); omit the `cost:` block entirely to mean 'no cost declared'",
+    },
+  );
+
+export type CapabilityCost = z.infer<typeof CapabilityCostSchema>;
+
+// =============================================================================
+// Capability id + tag + provider grammars
+// =============================================================================
+
+/**
+ * Capability id grammar — dot-separated lowercase segments, each starting
+ * with a letter, each lowercase alphanumeric + hyphen/underscore.
+ *
+ * Examples:
+ *   code-review.typescript     ← canonical (design doc §5 Q2 example)
+ *   literature-search.medline  ← canonical
+ *   code-review                ← bare (no sub-capability)
+ *   image-gen.dall_e_3         ← underscores permitted inside segments
+ *
+ * Counter-examples:
+ *   Code-Review                ← uppercase rejected
+ *   code review                ← whitespace rejected
+ *   2d-rendering               ← digit-prefix rejected (letter-prefix rule)
+ *   .code-review               ← leading dot rejected
+ *   code-review.               ← trailing dot rejected
+ *   code-review..typescript    ← consecutive dots rejected
+ *
+ * The dot-separated form lets capability ids carry a natural taxonomy
+ * (root capability → sub-capability) without committing to a fixed depth.
+ * The orchestrator agent (§3.6) can match either at the precise id level
+ * (`code-review.typescript`) or on a tag prefix (`code-review`); the tag
+ * vocabulary on each declaration is the source for tag-prefix matching,
+ * not the id itself.
+ *
+ * Letter-prefix rule mirrors the same NATS-pattern-matcher concern that
+ * justifies the rule on `OperatorSchema.id` and `StackConfigSchema.id`:
+ * capability ids can plausibly appear as subject segments in a future
+ * federated capability namespace (`federated.{operator}.{stack}.tasks.
+ * code-review.typescript.>`); even though A.6 doesn't wire that today,
+ * the letter-prefix rule keeps the door open without a follow-up schema
+ * tightening. Hyphens AND underscores are both permitted inside segments
+ * for natural readability (`code-review` vs `code_review` is a style
+ * choice, not a structural one).
+ */
+const CapabilityIdSchema = z
+  .string()
+  .min(1, "capability id is required and must be non-empty")
+  .regex(
+    /^[a-z][a-z0-9_-]*(\.[a-z][a-z0-9_-]*)*$/,
+    "capability id must be dot-separated lowercase segments, each starting with a letter and containing only lowercase alphanumeric + hyphen/underscore (e.g. 'code-review.typescript', 'literature-search.medline'); reject uppercase, whitespace, digit-prefix segments, and leading/trailing/consecutive dots",
+  );
+
+/**
+ * Tag grammar — a single lowercase segment, letter-prefixed, hyphen and
+ * underscore permitted. No dots: tags are flat labels, not taxonomies.
+ *
+ * Examples accepted: `typescript`, `code-review`, `ts`, `frontier`,
+ *   `python_3`, `domain-research`.
+ * Counter-examples: `TypeScript`, `2d`, `code review`, `code.review`.
+ *
+ * Why letter-prefix here too: tags are likely to appear in NATS subject
+ * segments in a future capability-tag indexing path (the network registry
+ * Q3 may publish `federated.tags.typescript.>` aggregations). Same rule,
+ * same rationale.
+ */
+const CapabilityTagSchema = z
+  .string()
+  .regex(
+    /^[a-z][a-z0-9_-]*$/,
+    "capability tags must be lowercase alphanumeric + hyphen/underscore, starting with a letter (e.g. 'typescript', 'code-review', 'frontier')",
+  );
+
+/**
+ * Provider-id grammar — references an agent's `id` declared in the same
+ * `cortex.yaml`'s `agents[]` array. The format mirrors `AgentSchema.id` on
+ * `main` today: `/^[a-z0-9-]+$/`. Once cortex#145 lands and tightens
+ * `AgentSchema.id` to require a letter prefix (parity with `OperatorSchema.id`
+ * and `StackConfigSchema.id` segments), this regex SHOULD tighten in step.
+ * Until then, deliberate parity with the looser `AgentSchema.id` shape avoids
+ * blocking valid declarations against agents named `2andreas-bot` (a config
+ * that parses on `main` today). cortex#145 is out of scope for this PR.
+ *
+ * The existence-check that each `provided_by` value resolves to a declared
+ * agent id is enforced cross-field on `CortexConfigSchema` (a `.refine()`
+ * that walks `agents[].id` against every capability declaration's
+ * `provided_by[]`). The structural format check here catches typos and
+ * non-agent-id shapes at the field level; the cross-field refine catches
+ * dangling references at the document level.
+ */
+const CapabilityProviderIdSchema = z
+  .string()
+  .regex(
+    /^[a-z0-9-]+$/,
+    "capability.provided_by entries must be agent ids — lowercase alphanumeric + hyphen (matches AgentSchema.id grammar on main)",
+  );
+
+// =============================================================================
+// CapabilitySchema — the constrained-schema declaration
+// =============================================================================
+
+/**
+ * A single capability declaration. The shape is constrained per Q2 lock-in:
+ * no free-text JSON, no open-ended extensions, no nested document trees.
+ * Adding a new field requires a schema edit + test, which is the deliberate
+ * design choice — orchestrator agents and the network registry index
+ * against this shape, so it changes by intent, not by accident.
+ *
+ * Field rationale:
+ *   - `id`: stable network-wide name (Q3 registry indexes by id).
+ *   - `description`: short human-readable summary surfaced on the dashboard
+ *     and in registry queries. Non-empty so an operator can't accidentally
+ *     publish a `description: ""` field that surfaces as a blank line in
+ *     the registry UI.
+ *   - `tags`: taxonomic labels for tag-prefix matching. May be empty (a
+ *     capability without tags is still a valid declaration), but every
+ *     entry must conform to the tag grammar. Whether duplicate tags are
+ *     allowed: yes — the schema does not de-dupe (an operator writing
+ *     `[typescript, typescript]` parses cleanly; the registry layer can
+ *     dedupe at query time). The design doc does not call out dedup as a
+ *     concern; we keep the schema additive.
+ *   - `provided_by`: ≥1 agent id. A capability with no provider is not a
+ *     declarable thing — the capability would have no implementation. The
+ *     ≥1 minimum is a deliberate fail-fast: an operator removing the last
+ *     agent from `provided_by` is removing the capability, and that's a
+ *     schema-level signal, not a runtime one.
+ *   - `rate` (optional): rate envelope. Omit = no constraint.
+ *   - `cost` (optional): cost envelope. Omit = no declared cost.
+ */
+export const CapabilitySchema = z.object({
+  /**
+   * Stable capability id (Q2). Network-wide unique within a stack — the
+   * uniqueness invariant lives at `CortexConfigSchema` because uniqueness
+   * is a document-level check, not a field-level one.
+   */
+  id: CapabilityIdSchema,
+  /**
+   * Short human-readable summary. Non-empty so blank descriptions can't
+   * silently propagate into the registry / dashboard. Operators wanting a
+   * very brief label can write `description: "."` to satisfy the rule;
+   * the design doesn't require a minimum prose length beyond "non-empty".
+   */
+  description: z.string().min(1, "capability.description is required and must be non-empty"),
+  /**
+   * Taxonomic tags. May be empty array; every entry must conform to the
+   * tag grammar. Dedup is not enforced (registry can dedupe at query time).
+   */
+  tags: z.array(CapabilityTagSchema).default([]),
+  /**
+   * Agent ids inside this stack that provide the capability. At least one
+   * provider required — a capability with no provider is not a declarable
+   * concept. The cross-field refine on `CortexConfigSchema` enforces that
+   * every value resolves to a declared `agents[].id`.
+   */
+  provided_by: z
+    .array(CapabilityProviderIdSchema)
+    .min(1, "capability.provided_by must list at least one provider agent id"),
+  /**
+   * Optional rate envelope. When present, at least one of `per_minute`,
+   * `per_hour`, `per_day` must be set (enforced by `CapabilityRateSchema`).
+   */
+  rate: CapabilityRateSchema.optional(),
+  /**
+   * Optional cost envelope. When present, at least one of
+   * `cents_per_request`, `cents_per_token` must be set (enforced by
+   * `CapabilityCostSchema`).
+   */
+  cost: CapabilityCostSchema.optional(),
+});
+
+export type Capability = z.infer<typeof CapabilitySchema>;

--- a/src/common/types/capability.ts
+++ b/src/common/types/capability.ts
@@ -254,11 +254,17 @@ export const CapabilitySchema = z.object({
   id: CapabilityIdSchema,
   /**
    * Short human-readable summary. Non-empty so blank descriptions can't
-   * silently propagate into the registry / dashboard. Operators wanting a
-   * very brief label can write `description: "."` to satisfy the rule;
-   * the design doesn't require a minimum prose length beyond "non-empty".
+   * silently propagate into the registry / dashboard. `.trim().min(1)` rejects
+   * whitespace-only strings (`" "`, `"\t"`, etc.) which would otherwise pass
+   * `.min(1)` despite being functionally blank in the UI surfaces consuming
+   * the field. Operators wanting a very brief label can write
+   * `description: "."` to satisfy the rule; the design doesn't require a
+   * minimum prose length beyond "non-empty after trim".
    */
-  description: z.string().min(1, "capability.description is required and must be non-empty"),
+  description: z
+    .string()
+    .trim()
+    .min(1, "capability.description is required and must be non-empty"),
   /**
    * Taxonomic tags. May be empty array; every entry must conform to the
    * tag grammar. Dedup is not enforced (registry can dedupe at query time).

--- a/src/common/types/cortex-config.ts
+++ b/src/common/types/cortex-config.ts
@@ -34,6 +34,7 @@
 
 import { z } from "zod/v4";
 
+import { CapabilitySchema } from "./capability";
 import {
   DMConfigSchema,
   NetworkClaudeSchema,
@@ -786,6 +787,33 @@ export const CortexConfigSchema = z.object({
    */
   stack: StackConfigSchema.optional(),
   /**
+   * IAW Phase A.6 (refs cortex#113) — stack-level capability declarations,
+   * per Q2 lock-in (`docs/design-internet-of-agentic-work.md` §5 Q2,
+   * 2026-05-13 Andreas). Each entry is a constrained-schema declaration:
+   * `id` (dot-separated lowercase), `description` (non-empty), `tags`
+   * (taxonomic labels), `provided_by` (≥1 declared agent id), optional
+   * `rate` / `cost` envelopes.
+   *
+   * The block is OPTIONAL and defaults to `[]` — an operator running
+   * cortex without any declared capabilities parses cleanly, same as
+   * before this block landed. The cross-field invariants below run only
+   * when at least one of `agents[].runtime.capabilities[]` or
+   * `capabilities[]` is non-empty.
+   *
+   * Per A.6.3, `agents[].runtime.capabilities[]` stays a string array of
+   * capability IDs (no shape change there). The top-level `capabilities[]`
+   * is the catalog those IDs reference; the existence check at the
+   * document level (refine below) rejects dangling references at config
+   * load.
+   *
+   * Behaviour today: schema-only. No runtime dispatcher consumes the
+   * catalog yet — that's a future phase (orchestrator pattern, design §3.6).
+   * Wiring the schema in now means operators can declare capabilities
+   * before the dispatch path consumes them, and the network registry
+   * (Q3) has the deterministic shape it needs when Phase D ships.
+   */
+  capabilities: z.array(CapabilitySchema).default([]),
+  /**
    * Anti-field: the legacy grove-v2 `agent:` (singular) block must not be
    * present in a cortex.yaml. Caught here with an explicit Zod refusal so
    * the operator sees a clear migration error rather than the field being
@@ -878,7 +906,99 @@ export const CortexConfigSchema = z.object({
     return new Set(ids).size === ids.length;
   },
   { message: "agent ids must be unique", path: ["agents"] },
-);
+)
+  // IAW Phase A.6.3 — capability catalog invariants.
+  //
+  // Three document-level cross-field checks, each with a pointed error
+  // message so an operator hitting one knows exactly which key to fix:
+  //
+  //   1. Top-level capability ids are unique. Two entries with the same id
+  //      represent two declarations of the same capability — likely a
+  //      copy-paste error; rejected at load time so the operator sees the
+  //      duplication immediately rather than the registry surfacing the
+  //      "last write wins" silently.
+  //
+  //   2. Every `provided_by[]` reference resolves to a declared `agents[].id`.
+  //      Symmetric dangling-reference guard with the agent-side reference
+  //      check below. A capability claiming to be provided by an agent
+  //      that doesn't exist would silently never run; we fail fast at
+  //      config load.
+  //
+  //   3. Every `agents[].runtime.capabilities[]` entry exists in the
+  //      top-level `capabilities[]` catalog. This is the core A.6.3
+  //      requirement: per-agent capability annotations REFERENCE the
+  //      catalog by id; references that don't resolve are configuration
+  //      errors, not silent runtime degradations.
+  //
+  // Implementation note: Zod's `.refine()` short-circuits on the first
+  // failing predicate, so we run the cheap structural checks first
+  // (unique catalog ids) before the cross-set walks (provider / consumer
+  // reference resolution). The Set construction and lookups are O(n+m)
+  // per check, which is well below any realistic config size.
+  .refine(
+    (config) => {
+      const ids = config.capabilities.map((c) => c.id);
+      return new Set(ids).size === ids.length;
+    },
+    {
+      message: "capability ids must be unique within the top-level capabilities[] block",
+      path: ["capabilities"],
+    },
+  )
+  // Document-level checks 2 + 3 (provider / consumer dangling references)
+  // use `superRefine` so the error message can name the specific dangling
+  // id and the specific config key that's at fault. Each issue is reported
+  // at a path that points to the offending array entry (`capabilities[i]`
+  // / `agents[j].runtime.capabilities`) so a YAML-aware loader can render
+  // the error in line with the source.
+  //
+  // We emit ALL dangling references (not just the first) so a config with
+  // many broken references surfaces them as a batch rather than the
+  // operator having to fix-and-rerun per failure.
+  .superRefine((config, ctx) => {
+    const agentIds = new Set(config.agents.map((a) => a.id));
+    const declaredAgentList = [...agentIds].sort().join(", ") || "(none)";
+    for (let capIdx = 0; capIdx < config.capabilities.length; capIdx++) {
+      const cap = config.capabilities[capIdx];
+      if (!cap) continue;
+      for (let providerIdx = 0; providerIdx < cap.provided_by.length; providerIdx++) {
+        const providerId = cap.provided_by[providerIdx];
+        if (providerId !== undefined && !agentIds.has(providerId)) {
+          ctx.addIssue({
+            code: "custom",
+            message:
+              `capability "${cap.id}" lists provider agent "${providerId}" in provided_by[], ` +
+              `but no agent with that id is declared in agents[] ` +
+              `(declared agent ids: ${declaredAgentList})`,
+            path: ["capabilities", capIdx, "provided_by", providerIdx],
+          });
+        }
+      }
+    }
+  })
+  .superRefine((config, ctx) => {
+    const catalogIds = new Set(config.capabilities.map((c) => c.id));
+    const declaredCatalog = [...catalogIds].sort().join(", ") || "(none)";
+    for (let agentIdx = 0; agentIdx < config.agents.length; agentIdx++) {
+      const agent = config.agents[agentIdx];
+      if (!agent) continue;
+      const claimed = agent.runtime?.capabilities ?? [];
+      for (let claimIdx = 0; claimIdx < claimed.length; claimIdx++) {
+        const capId = claimed[claimIdx];
+        if (capId !== undefined && !catalogIds.has(capId)) {
+          ctx.addIssue({
+            code: "custom",
+            message:
+              `agent "${agent.id}" claims capability "${capId}" in runtime.capabilities[], ` +
+              `but no matching entry exists in the top-level capabilities[] catalog ` +
+              `(declared capability ids: ${declaredCatalog}). ` +
+              `Either add a "${capId}" entry to capabilities[] or remove the reference from agent "${agent.id}".`,
+            path: ["agents", agentIdx, "runtime", "capabilities", claimIdx],
+          });
+        }
+      }
+    }
+  });
 
 export type CortexConfig = z.infer<typeof CortexConfigSchema>;
 
@@ -903,3 +1023,12 @@ export {
  */
 export { StackConfigSchema, deriveStackId } from "./stack";
 export type { StackConfig, DerivedStackId, DeriveStackIdInput } from "./stack";
+
+/**
+ * IAW Phase A.6 re-exports — the capability declaration primitive ships in
+ * its own module (`./capability.ts`) for tighter ownership, but downstream
+ * code that already pulls `CortexConfigSchema` from this file shouldn't need
+ * a second import path. Mirrors the `StackConfigSchema` re-export above.
+ */
+export { CapabilitySchema } from "./capability";
+export type { Capability, CapabilityRate, CapabilityCost } from "./capability";


### PR DESCRIPTION
## Summary

IAW Phase A.6 — `capabilities:` block on `cortex.yaml`. Implements the Q2 lock-in: a **constrained** capability schema (NOT free text) so the future network registry (Q3) can index deterministically and the orchestrator pattern (§3.6) can reason about delegation without natural-language disambiguation.

- `CapabilitySchema` (Zod) at `src/common/types/capability.ts` — dot-separated letter-prefixed `id`, non-empty `description`, taxonomic `tags[]`, ≥1 `provided_by[]`, optional structured `rate` / `cost` envelopes
- `CortexConfigSchema.capabilities` (optional, default `[]`) — backward-compatible; deployments without declared capabilities parse exactly as before
- Cross-field invariants (A.6.3) via two `.superRefine()` walks: unique catalog ids; every `provided_by[]` resolves to a declared `agents[].id`; every `agents[].runtime.capabilities[]` reference resolves to a declared catalog id — with path-precise error messages naming the offending key

## Q2 lock-in rationale

The Q2 lock-in (`docs/design-internet-of-agentic-work.md` §5 Q2, 2026-05-13 Andreas) is explicit: *"Schema covers: capability id, description, tags (e.g., language tags), provided_by agent ids, optional rate/cost."* — **constrained schema, NOT free text**, with "keep it simple" as the explicit constraint on shape.

Schema shape derived directly:
- **`id`** — dot-separated lowercase segments (`code-review.typescript`), letter-prefix per segment (NATS pattern-matcher parity with `OperatorSchema.id` / `StackConfigSchema.id`).
- **`description`** — non-empty (a blank description in the registry / dashboard is a real bug).
- **`tags`** — flat (no dots), letter-prefix per tag (same NATS-segment parity).
- **`provided_by`** — ≥1 entry; regex matches `AgentSchema.id` on `main` (cortex#145 tightens both together).
- **`rate`** (optional) — pick one or more windows from `{per_minute, per_hour, per_day}`; positive int; empty envelope explicitly rejected (omit instead).
- **`cost`** (optional) — pick one or more units from `{cents_per_request, cents_per_token}`; nonnegative (declared-free is a meaningful signal); no `currency` field (Q2 says "keep it simple"; first deployment is single-currency).

Per A.6.3, `agents[].runtime.capabilities[]` stays `string[]` of catalog ids — **no migration on the per-agent block**. The top-level `capabilities[]` is the catalog those ids reference; the existence check fails fast at config load on dangling references.

## What's new

- `src/common/types/capability.ts` (new) — `CapabilitySchema` + sub-schemas + types
- `src/common/types/__tests__/capability.test.ts` (new, 56 tests) — covers id grammar (uppercase / whitespace / digit-prefix / dot edges / wildcards), description, tags, provider grammars, rate + cost envelopes, top-level integration (absent / populated / invalid / free-text-string mistake), uniqueness, and full A.6.3 cross-field walks including multi-failure batching
- `src/common/types/cortex-config.ts` — embed `capabilities:` in `CortexConfigSchema` (optional, default `[]`); two `.superRefine()` walks for provider + consumer reference resolution; re-export `Capability` types from the canonical module path
- `src/common/agents/__tests__/registry.test.ts` — fixture builder gains explicit `capabilities: []` (the field has `.default([])` on the schema, but the inferred OUTPUT type lists it as a required field after parse, so literal `as CortexConfig` casts need it explicit)

## Scope

A.6.1 + A.6.2 + A.6.3 + A.6.4 — **all four sub-tasks** for A.6 land in this PR.

## What's deferred

- **Runtime capability matching / dispatch logic** — orchestrator pattern (design §3.6) is a future phase (Phase E). A.6 is schema-only: the catalog parses and is queryable, but no dispatcher consumes it yet.
- **Network registry registration** — Phase D D.4 cloud-side registry service.
- **`cortex.yaml.example` update** — schema-only PR; example can follow.
- **`AgentSchema.id` tightening** — cortex#145. `provided_by` mirrors the looser `^[a-z0-9-]+$` grammar on `main` today; once cortex#145 lands, both tighten in step.

## Brief reconciliation notes

The brief asked me to surface anything in the design doc that contradicted it. Two minor reconciliations:

1. **A.6.3 wording** — plan §A.6.3 says *"stack-level `capabilities:` block is the union plus any stack-extras"*; design §Q2 says *"the stack-level set is the union of its agents' annotations plus any stack-level extras"*. Both reduce to the same implementation: top-level `capabilities[]` is the catalog, per-agent `runtime.capabilities[]` references catalog ids by string, dangling references rejected at load. Implemented per the design doc's framing.
2. **Symmetric dangling guard** — the brief calls out the agent→catalog reference check explicitly but doesn't require the inverse provider→agent check. I added it anyway: it's the symmetric form of the same invariant, costs ~10 LOC, gives the operator a precise error if they list a `provided_by[]` for an agent that doesn't exist (a likely real failure mode during migration), and matches the design's intent (*"list of agent ids inside the stack that provide this capability"* — *"inside the stack"* implies declared in `agents[]`).

## Test plan

- [x] `bunx tsc --noEmit` — clean
- [x] `bun test src/common/types/__tests__/capability.test.ts` — 56 pass / 0 fail
- [x] `bun test` (full suite) — **2731 pass / 1 skip / 0 fail** (baseline 2675 + 56 new)
- [x] `bun .github/scripts/label-check.ts the-metafactory/cortex` — all 8 ecosystem labels present

## References

- **cortex#113** — IAW Phase A tracking
- **cortex#140** — A.5 sibling (`stack:` block schema) — pattern mirrored here
- **cortex#141** — letter-prefix unification (`provided_by` grammar parity)
- **cortex#145** (future) — `AgentSchema.id` tightening
- `docs/design-internet-of-agentic-work.md` §5 Q2 (2026-05-13 lock-in)
- `docs/plan-internet-of-agentic-work.md` §A.6

Echo via cortex Discord bot to drive review (pilot loop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)