### PR TITLE
fix(schema): tighten AgentSchema.id and trust[] entry regex to letter-prefix (closes cortex#145)

### DIFF
--- a/src/common/types/__tests__/capability.test.ts
+++ b/src/common/types/__tests__/capability.test.ts
@@ -253,18 +253,18 @@ describe("CapabilitySchema.provided_by", () => {
     ).toThrow(/at least one provider agent id/);
   });
 
-  test("accepts digit-only provider id today (parity with AgentSchema.id on main; tightens with cortex#145)", () => {
+  test("rejects digit-only provider id (Discord-snowflake paste-bug; tightened by cortex#145)", () => {
     // Real failure mode this pins: an operator pastes a Discord snowflake into
-    // provided_by and the schema silently accepts it. Today this MUST parse
-    // because `provided_by` mirrors `AgentSchema.id`'s loose `/^[a-z0-9-]+$/`
-    // on main — tightening both to letter-prefix is cortex#145's job. The
-    // assertion here pins the current grammar parity so the schema doesn't
-    // drift from AgentSchema.id before cortex#145 lands; when #145 merges,
-    // this test flips to a `toThrow` (along with the snowflake-style ones in
-    // cortex-config.test.ts for AgentSchema.id itself).
+    // provided_by and the schema silently accepts it. cortex#145 closed the
+    // operator/stack/agent letter-prefix trilogy (cortex#141 → cortex#144 →
+    // cortex#145) so the gate now catches the paste-bug deterministically at
+    // parse time rather than relying on the cross-field provider-resolution
+    // refine to surface it later. `provided_by` mirrors `AgentSchema.id`'s
+    // letter-prefix regex; once one tightens, the other must too — that's
+    // why they're enforced as a single coordinated edit in cortex#145.
     expect(() =>
       CapabilitySchema.parse(minCapability({ provided_by: ["1497204875912609844"] })),
-    ).not.toThrow();
+    ).toThrow(/starting with a letter/);
   });
 
   test("rejects uppercase provider id", () => {

--- a/src/common/types/__tests__/cortex-config.test.ts
+++ b/src/common/types/__tests__/cortex-config.test.ts
@@ -216,21 +216,94 @@ describe("AgentSchema", () => {
     })).toThrow(/at least one presence/);
   });
 
+  // ---------------------------------------------------------------------
+  // cortex#145 — letter-prefix rule (closes the operator/stack/agent
+  // letter-prefix trilogy: cortex#141 → cortex#144 → cortex#145)
+  // ---------------------------------------------------------------------
+
+  test("accepts canonical letter-prefixed agent ids", () => {
+    // The realistic agent population — all letter-prefixed today.
+    expect(AgentSchema.parse(minAgent({ id: "luna" })).id).toBe("luna");
+    expect(AgentSchema.parse(minAgent({ id: "echo" })).id).toBe("echo");
+    expect(AgentSchema.parse(minAgent({ id: "team-research" })).id).toBe("team-research");
+  });
+
+  test("accepts agent id with internal digits (only the prefix is gated)", () => {
+    // The rule is letter-PREFIX, not letter-only. Internal digits are fine
+    // — `agent-2026`, `team-42-research` etc.
+    expect(AgentSchema.parse(minAgent({ id: "agent-2026" })).id).toBe("agent-2026");
+    expect(AgentSchema.parse(minAgent({ id: "team-42-research" })).id).toBe("team-42-research");
+    expect(AgentSchema.parse(minAgent({ id: "a1" })).id).toBe("a1");
+  });
+
+  test("rejects digit-prefix agent id (cortex#145 — letter-prefix rule)", () => {
+    // The unified grammar requires letter-prefix on all three of
+    // `OperatorSchema.id`, `StackConfigSchema.id` segments, and
+    // `AgentSchema.id`. Agent ids end up embedded in NATS subjects
+    // post-A.5.5 (`local.{op}.{stack}.dispatch.{agent}.>`); digit-prefix
+    // segments interact poorly with downstream pattern-matchers.
+    expect(() => AgentSchema.parse(minAgent({ id: "2agent" }))).toThrow(
+      /starting with a letter/,
+    );
+    // The error message MUST surface the migration hint so operators see
+    // what to do, not just what's wrong.
+    expect(() => AgentSchema.parse(minAgent({ id: "2agent" }))).toThrow(
+      /team-2agent|agent-2026/,
+    );
+  });
+
+  test("rejects digit-prefix-with-hyphen agent id", () => {
+    expect(() => AgentSchema.parse(minAgent({ id: "7-luna" }))).toThrow(
+      /starting with a letter/,
+    );
+  });
+
+  test("rejects all-digit agent id (Discord-snowflake paste-bug)", () => {
+    expect(() => AgentSchema.parse(minAgent({ id: "1497204875912609844" }))).toThrow(
+      /starting with a letter/,
+    );
+  });
+
+  test("rejects hyphen-prefix agent id (must start with a letter, not punctuation)", () => {
+    expect(() => AgentSchema.parse(minAgent({ id: "-luna" }))).toThrow(
+      /starting with a letter/,
+    );
+  });
+
   test("accepts trust list of agent ids (no resolution)", () => {
     const parsed = AgentSchema.parse(minAgent({ trust: ["echo", "holly"] }));
     expect(parsed.trust).toEqual(["echo", "holly"]);
   });
 
-  test("rejects trust entries that aren't agent ids (Holly W2-3)", () => {
+  test("rejects trust entries that aren't agent ids (Holly W2-3; tightened by cortex#145)", () => {
     // Common typo / paste-bug: putting a Discord user id into the trust list.
-    // Schema catches it with the same `^[a-z0-9-]+$` regex as agent ids.
+    // Schema catches it with the same `^[a-z][a-z0-9-]*$` regex as agent ids
+    // (operator/stack/agent letter-prefix trilogy closed by cortex#145). The
+    // letter-prefix rule catches the digit-only Discord-snowflake paste-bug
+    // deterministically — pre-#145 the regex was `^[a-z0-9-]+$` and digit-only
+    // entries silently slipped past the structural check.
     expect(() => AgentSchema.parse(minAgent({
       trust: ["echo", "1497898452351455393"], // ← Discord id, all digits
-    }))).not.toThrow(); // digits-only is technically valid; the bug we catch is uppercase / dots / wildcards
+    }))).toThrow(/starting with a letter/);
     expect(() => AgentSchema.parse(minAgent({ trust: ["Echo"] }))).toThrow();
     expect(() => AgentSchema.parse(minAgent({ trust: ["echo bot"] }))).toThrow();
     expect(() => AgentSchema.parse(minAgent({ trust: ["echo.bot"] }))).toThrow();
     expect(() => AgentSchema.parse(minAgent({ trust: ["<@1497>"] }))).toThrow();
+  });
+
+  test("rejects digit-prefix trust entry with migration hint (cortex#145)", () => {
+    expect(() => AgentSchema.parse(minAgent({ trust: ["2agent"] }))).toThrow(
+      /starting with a letter/,
+    );
+    expect(() => AgentSchema.parse(minAgent({ trust: ["2agent"] }))).toThrow(
+      /team-2agent|agent-2026/,
+    );
+  });
+
+  test("rejects hyphen-prefix trust entry", () => {
+    expect(() => AgentSchema.parse(minAgent({ trust: ["-echo"] }))).toThrow(
+      /starting with a letter/,
+    );
   });
 
   test("accepts both discord and mattermost presence on same agent", () => {

--- a/src/common/types/capability.ts
+++ b/src/common/types/capability.ts
@@ -29,10 +29,11 @@
  *     dispatch path consumes it yet.
  *   - **No network registry registration.** Phase D, D.4 cloud-side
  *     registry service.
- *   - **No tightening of `AgentSchema.id`.** That's cortex#145. `provided_by`
- *     mirrors the SAME pattern `AgentSchema.id` uses on `main` today
- *     (`/^[a-z0-9-]+$/`); once cortex#145 lands and tightens `AgentSchema.id`,
- *     this regex tightens with it (single edit, one-segment grammar parity).
+ *   - **Mirrors `AgentSchema.id` grammar.** `provided_by` uses the same
+ *     letter-prefix regex `/^[a-z][a-z0-9-]*$/` as `AgentSchema.id` so the
+ *     two cannot drift — closing the operator/stack/agent letter-prefix
+ *     trilogy (cortex#141 → cortex#144 → cortex#145). A future change to
+ *     the agent-id grammar is a single coordinated edit to both regexes.
  *
  * The per-agent reference validation (A.6.3) — every id in an agent's
  * `runtime.capabilities[]` must exist in the top-level `capabilities[]` block
@@ -191,13 +192,10 @@ const CapabilityTagSchema = z
 
 /**
  * Provider-id grammar — references an agent's `id` declared in the same
- * `cortex.yaml`'s `agents[]` array. The format mirrors `AgentSchema.id` on
- * `main` today: `/^[a-z0-9-]+$/`. Once cortex#145 lands and tightens
- * `AgentSchema.id` to require a letter prefix (parity with `OperatorSchema.id`
- * and `StackConfigSchema.id` segments), this regex SHOULD tighten in step.
- * Until then, deliberate parity with the looser `AgentSchema.id` shape avoids
- * blocking valid declarations against agents named `2andreas-bot` (a config
- * that parses on `main` today). cortex#145 is out of scope for this PR.
+ * `cortex.yaml`'s `agents[]` array. The format mirrors `AgentSchema.id`:
+ * `/^[a-z][a-z0-9-]*$/` (letter-prefix). cortex#145 closed the operator/
+ * stack/agent letter-prefix trilogy (cortex#141 → cortex#144 → cortex#145);
+ * `provided_by` tightened in the same PR for one-segment grammar parity.
  *
  * The existence-check that each `provided_by` value resolves to a declared
  * agent id is enforced cross-field on `CortexConfigSchema` (a `.refine()`
@@ -209,8 +207,8 @@ const CapabilityTagSchema = z
 const CapabilityProviderIdSchema = z
   .string()
   .regex(
-    /^[a-z0-9-]+$/,
-    "capability.provided_by entries must be agent ids — lowercase alphanumeric + hyphen (matches AgentSchema.id grammar on main)",
+    /^[a-z][a-z0-9-]*$/,
+    "capability.provided_by entries must be agent ids — lowercase alphanumeric + hyphen, starting with a letter (matches AgentSchema.id grammar — operator/stack/agent letter-prefix trilogy closed by cortex#145); rename digit-prefixed ids like '2agent' to 'team-2agent' or 'agent-2026'",
   );
 
 // =============================================================================

--- a/src/common/types/cortex-config.ts
+++ b/src/common/types/cortex-config.ts
@@ -294,8 +294,26 @@ export const AgentRuntimeSchema = z.object({
 export type AgentRuntime = z.infer<typeof AgentRuntimeSchema>;
 
 export const AgentSchema = z.object({
-  /** Logical agent id — stable across deployments. Lowercase, alphanumeric. */
-  id: z.string().min(1).regex(/^[a-z0-9-]+$/, "Agent id must be lowercase alphanumeric"),
+  /**
+   * Logical agent id — stable across deployments.
+   *
+   * Grammar: lowercase alphanumeric + hyphen, **first character must be a
+   * letter**. Mirrors `OperatorSchema.id` and `StackConfigSchema.id` segments
+   * (cortex#141, cortex#144): the same trilogy of identifiers that end up
+   * embedded verbatim in NATS subjects (`local.{op}.{stack}.dispatch.{agent}.>`
+   * after A.5.5). NATS subject segments starting with a digit interact poorly
+   * with downstream pattern-matchers that treat segments as numeric literals;
+   * letter-prefix is the safe boundary.
+   *
+   * Closing cortex#145 — the last permissive regex in the operator/stack/agent
+   * trilogy now tightens to the same letter-prefix rule. Migration hint for an
+   * agent id hitting this rule: rename `2agent` → `team-2agent` or
+   * `agent-2026` (prepend / wrap the digits with a letter-prefixed token).
+   */
+  id: z.string().min(1).regex(
+    /^[a-z][a-z0-9-]*$/,
+    "agent id must be lowercase alphanumeric + hyphen, starting with a letter (e.g. 'luna', 'echo', 'team-research'); rename digit-prefixed ids like '2agent' to 'team-2agent' or 'agent-2026'",
+  ),
   /** Display name shown to humans. */
   displayName: z.string().min(1),
   /**
@@ -316,17 +334,22 @@ export const AgentSchema = z.object({
    * adapter treats it as agent-originated (vs human-originated).
    *
    * Coupling rule (§9.3): values MUST be agent ids — never platform user ids.
-   * Schema-level format check applies the same `^[a-z0-9-]+$` regex as
-   * `AgentSchema.id` and `OperatorSchema.id` so a typo (e.g. accidentally
-   * pasting a Discord user id like `"1497..."`) is caught at config load,
-   * not silently when the registry fails to resolve the reference
-   * (Holly W2 review).
+   * Schema-level format check applies the same `^[a-z][a-z0-9-]*$` regex as
+   * `AgentSchema.id` and `OperatorSchema.id` (cortex#141/#144/#145 trilogy) so
+   * a typo (e.g. accidentally pasting a Discord user id like `"1497..."`) is
+   * caught at config load, not silently when the registry fails to resolve
+   * the reference (Holly W2 review). The letter-prefix rule also catches the
+   * digit-only-snowflake paste-bug deterministically rather than relying on
+   * downstream registry resolution to fail.
    *
    * Validation that the referenced ids resolve to known agents happens at
    * load time in the agent registry (MIG-7.2a), not in this schema.
    */
   trust: z.array(
-    z.string().regex(/^[a-z0-9-]+$/, "trust entries must be agent ids (lowercase alphanumeric)"),
+    z.string().regex(
+      /^[a-z][a-z0-9-]*$/,
+      "trust entries must be agent ids — lowercase alphanumeric + hyphen, starting with a letter (e.g. 'echo', 'team-research'); rename digit-prefixed entries like '2agent' to 'team-2agent' or 'agent-2026'",
+    ),
   ).default([]),
   /** Per-platform presence blocks — at least one is required. */
   presence: PresenceSchema,

--- a/src/common/types/cortex-config.ts
+++ b/src/common/types/cortex-config.ts
@@ -310,7 +310,7 @@ export const AgentSchema = z.object({
    * agent id hitting this rule: rename `2agent` → `team-2agent` or
    * `agent-2026` (prepend / wrap the digits with a letter-prefixed token).
    */
-  id: z.string().min(1).regex(
+  id: z.string().regex(
     /^[a-z][a-z0-9-]*$/,
     "agent id must be lowercase alphanumeric + hyphen, starting with a letter (e.g. 'luna', 'echo', 'team-research'); rename digit-prefixed ids like '2agent' to 'team-2agent' or 'agent-2026'",
   ),


### PR DESCRIPTION
## Summary

Closes the **operator/stack/agent letter-prefix trilogy** (cortex#141 → cortex#144 → cortex#145). Every metafactory-ecosystem identifier that ends up embedded in a NATS subject segment now obeys the same rule: lowercase alphanumeric + hyphen, starting with a letter.

`closes cortex#145`

## Schema changes

| Symbol | Before | After |
|---|---|---|
| `AgentSchema.id` | `/^[a-z0-9-]+$/` | `/^[a-z][a-z0-9-]*$/` |
| `AgentSchema.trust[]` entry | `/^[a-z0-9-]+$/` | `/^[a-z][a-z0-9-]*$/` |
| `CapabilityProviderIdSchema` | `/^[a-z0-9-]+$/` | `/^[a-z][a-z0-9-]*$/` |

Error messages mirror the operator-id format introduced in cortex#144 — they name the rule clearly and surface a one-line rename hint for digit-prefix violators (`2agent` → `team-2agent` or `agent-2026`).

## Trilogy completion

`AgentSchema.id` ids end up embedded in NATS subjects after A.5.5 (`local.{op}.{stack}.dispatch.{agent}.>`). The letter-prefix rule is the safe boundary for the same reason cortex#141 cited for `OperatorSchema.id` and cortex#144 cited for `StackConfigSchema.id` segments: NATS subject segments starting with a digit interact poorly with downstream pattern-matchers that treat segments as numeric literals.

After this PR, the operator/stack/agent letter-prefix trilogy is closed and `CapabilityProviderIdSchema` (which the cortex#146 prologue declared MUST mirror `AgentSchema.id`) tightens in step.

## Migration safety

`git grep -E '"\s*id:\s*"?[0-9]' src/` returns **zero matches** — no digit-prefix agent fixtures exist anywhere in the tree. The engineer who did cortex#141 found the same when checking `OperatorSchema.id` callers; that hasn't changed.

## Test changes

- **New `AgentSchema` letter-prefix coverage** in `cortex-config.test.ts`:
  - accepts canonical letter-prefix ids (`luna`, `echo`, `team-research`)
  - accepts ids with internal digits (`agent-2026`, `team-42-research`, `a1`)
  - rejects digit-prefix (`2agent`) with hint-message assertion
  - rejects digit-prefix-with-hyphen (`7-luna`)
  - rejects all-digit (Discord-snowflake paste-bug)
  - rejects hyphen-prefix
- **`trust[]` entry coverage** — same valid/invalid shape; the pre-existing "digit-only is technically valid" branch flipped to assert throw (the Discord-snowflake paste-bug that test pinned is now caught at parse time).
- **`capability.test.ts:237` flipped** — was "accepts digit-only provider id today (parity with AgentSchema.id on main; tightens with cortex#145)" with `not.toThrow`; now "rejects digit-only provider id (Discord-snowflake paste-bug; tightened by cortex#145)" with `toThrow(/starting with a letter/)`. Comment updated to describe the closed trilogy.
- **Prologue comment in `capability.ts`** updated from forward-looking ("once cortex#145 lands...") to past-tense parity declaration.

## Verification

```
bunx tsc --noEmit                                       ✓ clean
bun test                                                ✓ 2741 pass, 1 skip, 0 fail (6426 expect() calls)
bun .github/scripts/label-check.ts the-metafactory/cortex  ✓ all 8 ecosystem labels present
git grep -E '"\s*id:\s*"?[0-9]' src/                     ✓ zero matches
```

## Out of scope (deliberately)

- `OperatorSchema.id` and `StackConfigSchema.id` — already tightened in cortex#141/#144
- NKey regex extraction — that's cortex#143, separate PR
- IAW design doc / plan doc / vendored myelin envelope — no edits
- `arc-manifest.yaml` version — cortex#146 already bumped to 0.2.0

## References

- cortex#145 (this PR)
- cortex#141 — `OperatorSchema.id` letter-prefix
- cortex#144 — engineer-flagged this gap; same migration-hint error-message style
- cortex#146 — `CapabilityProviderIdSchema` introduced with a forward-looking comment pointing at cortex#145