### PR TITLE
chore(lint): sweep #2 — array-type cosmetic fix (Array<T> → T[]) (-93)

### DIFF
--- a/src/adapters/discord/__tests__/attachments-timeout.test.ts
+++ b/src/adapters/discord/__tests__/attachments-timeout.test.ts
@@ -66,7 +66,7 @@ describe("processAttachment onTimeoutAbort hook", () => {
     const sessionDir = join(tmpdir(), `cortex-c104-${Date.now()}-${Math.random()}`);
     mkdirSync(sessionDir, { recursive: true });
 
-    const calls: Array<{ source: string; attachmentName: string }> = [];
+    const calls: { source: string; attachmentName: string }[] = [];
     const info = makeInfo({ originalName: "hangs.png" });
 
     // The default attachment_fetch timeout is 30 s; that's too long for a

--- a/src/adapters/discord/__tests__/auto-thread.test.ts
+++ b/src/adapters/discord/__tests__/auto-thread.test.ts
@@ -73,7 +73,7 @@ class FakeTextChannel {
   id: string;
   name: string;
   existingThreads: FakeThread[] = [];
-  createCalls: Array<{ name: string; autoArchiveDuration: number; type: number }> = [];
+  createCalls: { name: string; autoArchiveDuration: number; type: number }[] = [];
   /** When set, `threads.create` throws this error — exercises the
    *  create-failure fallback path. */
   createError: Error | null = null;

--- a/src/adapters/discord/__tests__/operator-dm-buffer.test.ts
+++ b/src/adapters/discord/__tests__/operator-dm-buffer.test.ts
@@ -108,11 +108,11 @@ function makeAdapter(opts: {
   return { adapter, sends, health, client };
 }
 
-function getBuffer(adapter: DiscordAdapter): Array<{ text: string; createdAt: number }> {
-  return (adapter as unknown as { pendingOperatorDMs: Array<{ text: string; createdAt: number }> }).pendingOperatorDMs;
+function getBuffer(adapter: DiscordAdapter): { text: string; createdAt: number }[] {
+  return (adapter as unknown as { pendingOperatorDMs: { text: string; createdAt: number }[] }).pendingOperatorDMs;
 }
-function setBuffer(adapter: DiscordAdapter, items: Array<{ text: string; createdAt: number }>): void {
-  (adapter as unknown as { pendingOperatorDMs: Array<{ text: string; createdAt: number }> }).pendingOperatorDMs = items;
+function setBuffer(adapter: DiscordAdapter, items: { text: string; createdAt: number }[]): void {
+  (adapter as unknown as { pendingOperatorDMs: { text: string; createdAt: number }[] }).pendingOperatorDMs = items;
 }
 async function callDrain(adapter: DiscordAdapter): Promise<void> {
   await (adapter as unknown as { drainPendingOperatorDMs: () => Promise<void> }).drainPendingOperatorDMs();
@@ -260,7 +260,7 @@ describe("drainPendingOperatorDMs", () => {
   });
 
   test("propagates users.fetch failure: drains nothing, surfaces the error via console", async () => {
-    let errorMessages: string[] = [];
+    const errorMessages: string[] = [];
     console.error = (...args: unknown[]) => { errorMessages.push(args.join(" ")); };
     const fetchUser = async (): Promise<FakeUser> => {
       throw new Error("operator-fetch-failed");
@@ -278,7 +278,7 @@ describe("drainPendingOperatorDMs", () => {
 
   test("per-message send failure: keeps draining remaining messages", async () => {
     const sends: string[] = [];
-    let errorMessages: string[] = [];
+    const errorMessages: string[] = [];
     console.error = (...args: unknown[]) => { errorMessages.push(args.join(" ")); };
     let calls = 0;
     const fetchUser = async (): Promise<FakeUser> => ({

--- a/src/adapters/discord/__tests__/render-envelope.test.ts
+++ b/src/adapters/discord/__tests__/render-envelope.test.ts
@@ -73,7 +73,7 @@ function makeAdapter(opts: {
   /** If false, the adapter has no client at all (pre-start state). */
   withClient?: boolean;
 } = {}) {
-  const sends: Array<{ channelId: string; text: string }> = [];
+  const sends: { channelId: string; text: string }[] = [];
   // MIG-7.2c-discord-flip: constructor now takes (agent, presence, infra).
   // Surface fields live on `infra` for this slice and move to a dedicated
   // Renderer at MIG-7.2d.

--- a/src/adapters/discord/__tests__/retry.test.ts
+++ b/src/adapters/discord/__tests__/retry.test.ts
@@ -121,7 +121,7 @@ describe("retryWithBackoff", () => {
   });
 
   test("calls onRetry hook with attempt and delay", async () => {
-    const retries: Array<{ attempt: number; delayMs: number }> = [];
+    const retries: { attempt: number; delayMs: number }[] = [];
     let calls = 0;
     await retryWithBackoff(
       async () => {

--- a/src/adapters/discord/attachment-types.ts
+++ b/src/adapters/discord/attachment-types.ts
@@ -67,7 +67,7 @@ export const ALLOWED_MIME_TYPES = new Set([
  * Magic byte signatures for common file types.
  * Used to validate that declared MIME matches actual content (anti-polyglot).
  */
-export const MAGIC_BYTES: Array<{ mime: string; bytes: number[]; offset?: number }> = [
+export const MAGIC_BYTES: { mime: string; bytes: number[]; offset?: number }[] = [
   { mime: "image/png", bytes: [0x89, 0x50, 0x4e, 0x47] },
   { mime: "image/jpeg", bytes: [0xff, 0xd8, 0xff] },
   { mime: "image/gif", bytes: [0x47, 0x49, 0x46, 0x38] },

--- a/src/adapters/discord/index.ts
+++ b/src/adapters/discord/index.ts
@@ -736,7 +736,7 @@ export class DiscordAdapter implements PlatformAdapter {
   //     completed", "task Y failed", "warning Z"). Coalescing by key would
   //     drop messages that the operator needs to see. Order and completeness
   //     matter more than dedup, so we use a FIFO array.
-  private pendingOperatorDMs: Array<{ text: string; createdAt: number }> = [];
+  private pendingOperatorDMs: { text: string; createdAt: number }[] = [];
   private static readonly PENDING_TTL_MS = 10 * 60 * 1000; // 10 minutes
   private static readonly PENDING_MAX_SIZE = 100;
   private static readonly PENDING_OPERATOR_MAX = 50;
@@ -1051,7 +1051,7 @@ export class DiscordAdapter implements PlatformAdapter {
     }
   }
 
-  private static toDiscordFiles(files?: OutboundFile[]): Array<{ attachment: Buffer | string; name: string }> | undefined {
+  private static toDiscordFiles(files?: OutboundFile[]): { attachment: Buffer | string; name: string }[] | undefined {
     return files?.map((f) => ({
       attachment: f.content,
       name: f.filename,

--- a/src/adapters/discord/response-poster.ts
+++ b/src/adapters/discord/response-poster.ts
@@ -80,7 +80,7 @@ export function splitMessage(content: string): string[] {
 export async function postToDiscord(
   channel: TextChannel | ThreadChannel,
   content: string,
-  files?: Array<{ attachment: Buffer | string; name: string }>,
+  files?: { attachment: Buffer | string; name: string }[],
   retryOptions?: RetryOptions
 ): Promise<void> {
   const decoded = decodeHtmlEntities(content);

--- a/src/adapters/mattermost/poller.ts
+++ b/src/adapters/mattermost/poller.ts
@@ -64,7 +64,7 @@ async function fetchDMChannels(
       { headers: { Authorization: `Bearer ${apiToken}` } }
     );
     if (!res.ok) return [];
-    const channels = await res.json() as Array<{ id: string; type: string }>;
+    const channels = await res.json() as { id: string; type: string }[];
     return channels.filter((ch) => ch.type === "D").map((ch) => ch.id);
   } catch {
     return [];
@@ -182,8 +182,8 @@ export async function fetchMattermostFileInfos(
   fileIds: string[],
   apiUrl: string,
   apiToken: string
-): Promise<Array<{ originalName: string; url: string; contentType: string; size: number; source: "mattermost" }>> {
-  const results: Array<{ originalName: string; url: string; contentType: string; size: number; source: "mattermost" }> = [];
+): Promise<{ originalName: string; url: string; contentType: string; size: number; source: "mattermost" }[]> {
+  const results: { originalName: string; url: string; contentType: string; size: number; source: "mattermost" }[] = [];
 
   for (const fileId of fileIds) {
     try {
@@ -230,7 +230,7 @@ export async function uploadMattermostFile(
     });
 
     if (!res.ok) return null;
-    const data = await res.json() as { file_infos?: Array<{ id: string }> };
+    const data = await res.json() as { file_infos?: { id: string }[] };
     return data.file_infos?.[0]?.id ?? null;
   } catch {
     return null;

--- a/src/adapters/mock.ts
+++ b/src/adapters/mock.ts
@@ -26,13 +26,13 @@ export class MockAdapter implements PlatformAdapter {
   readonly instanceId: string;
 
   /** Recorded postResponse calls */
-  sentMessages: Array<{ target: ResponseTarget; text: string; files?: OutboundFile[] }> = [];
+  sentMessages: { target: ResponseTarget; text: string; files?: OutboundFile[] }[] = [];
   /** Recorded sendTyping calls */
   typingSent: ResponseTarget[] = [];
   /** Recorded sendProgress calls */
-  progressSent: Array<{ target: ResponseTarget; text: string }> = [];
+  progressSent: { target: ResponseTarget; text: string }[] = [];
   /** Recorded createThread calls */
-  threadsCreated: Array<{ msg: InboundMessage; name: string }> = [];
+  threadsCreated: { msg: InboundMessage; name: string }[] = [];
   /** Recorded notifyOperator calls */
   operatorNotifications: string[] = [];
   /** MIG-3b: Recorded envelopes received via surfaceConfig.render() */

--- a/src/adapters/types.ts
+++ b/src/adapters/types.ts
@@ -69,7 +69,7 @@ export interface AccessDecision {
   /** Whether bash guard should be active. Default: true. Operator DM may set false. */
   bashGuard?: boolean;
   /** Override bash allowlist (DM role may specify its own) */
-  bashAllowlist?: { rules: Array<{ pattern: string; repos?: string[] }>; repos: string[] };
+  bashAllowlist?: { rules: { pattern: string; repos?: string[] }[]; repos: string[] };
   /** Whether this is a DM conversation */
   isDM?: boolean;
   /** Human-readable denial reason */

--- a/src/bus/payload-filter.ts
+++ b/src/bus/payload-filter.ts
@@ -33,7 +33,7 @@ export type FilterValue =
   | string
   | number
   | boolean
-  | { "anything-but": string | number | boolean | Array<string | number | boolean> }
+  | { "anything-but": string | number | boolean | (string | number | boolean)[] }
   | { prefix: string }
   | { exists: boolean }
   | { "equals-ignore-case": string };

--- a/src/cli/cortex/commands/cloud.ts
+++ b/src/cli/cortex/commands/cloud.ts
@@ -631,8 +631,8 @@ async function cloudStatus(flags: Record<string, string>): Promise<void> {
     const stateRes = await fetch(`${base}/api/state`);
     if (stateRes.ok) {
       const state = (await stateRes.json()) as {
-        agents?: Array<{ id: string; name: string; status: string }>;
-        sessions?: Array<{ session_id: string; status: string; agent_name: string }>;
+        agents?: { id: string; name: string; status: string }[];
+        sessions?: { session_id: string; status: string; agent_name: string }[];
       };
 
       const agents = state.agents ?? [];
@@ -965,12 +965,12 @@ async function cloudWebhooksCheck(flags: Record<string, string>): Promise<void> 
         continue;
       }
 
-      const hooks = await hooksRes.json() as Array<{
+      const hooks = await hooksRes.json() as {
         id: number;
         active: boolean;
         config: { url: string };
         last_response: { code: number; message: string };
-      }>;
+      }[];
 
       const groveHook = hooks.find((h) => h.config.url?.includes("/api/github/webhook"));
       if (!groveHook) {

--- a/src/common/agents/__tests__/trust-resolver.test.ts
+++ b/src/common/agents/__tests__/trust-resolver.test.ts
@@ -370,7 +370,7 @@ describe("cortex#98 (part B) — auto-populate trustedBotIds from agents[].trust
     resolver: TrustResolver,
     agentTrust: readonly string[],
     selfAgentId: string,
-    explicit: ReadonlyArray<string>,
+    explicit: readonly string[],
   ): Set<string> {
     // Mirror of the merge cortex.ts performs at the bottom of the Discord
     // adapter-start loop. Kept in lock-step with the cortex.ts

--- a/src/common/config/loader.ts
+++ b/src/common/config/loader.ts
@@ -294,8 +294,8 @@ function loadCortexShape(
  * the schema flip; operators who grep for the old `{agentName}-discord-{guildId}`
  * pattern will see the collapsed form once cortex.yaml is in effect.
  */
-function flattenDiscordPresences(agents: ReadonlyArray<Agent>) {
-  const out: Array<DiscordPresence & { instanceId: string }> = [];
+function flattenDiscordPresences(agents: readonly Agent[]) {
+  const out: (DiscordPresence & { instanceId: string })[] = [];
   for (const a of agents) {
     const p = a.presence.discord;
     if (!p) continue;
@@ -304,8 +304,8 @@ function flattenDiscordPresences(agents: ReadonlyArray<Agent>) {
   return out;
 }
 
-function flattenMattermostPresences(agents: ReadonlyArray<Agent>) {
-  const out: Array<MattermostPresence & { instanceId: string }> = [];
+function flattenMattermostPresences(agents: readonly Agent[]) {
+  const out: (MattermostPresence & { instanceId: string })[] = [];
   for (const a of agents) {
     const p = a.presence.mattermost;
     if (!p) continue;
@@ -432,7 +432,7 @@ export function loadAgentFromFile(filePath: string, personaBaseDir: string): Age
   try {
     agent = AgentSchema.parse(raw);
   } catch (err: unknown) {
-    const issues = (err as { issues?: Array<{ path?: unknown[]; message: string }> }).issues ?? [];
+    const issues = (err as { issues?: { path?: unknown[]; message: string }[] }).issues ?? [];
     const details =
       issues.length > 0
         ? issues.map((i) => `  ${(i.path ?? []).join(".")}: ${i.message}`).join("\n")

--- a/src/common/substrates/types.ts
+++ b/src/common/substrates/types.ts
@@ -254,7 +254,7 @@ export interface DispatchRuntime {
    * non-CC harnesses ignore this field.
    */
   bashAllowlist?: {
-    rules: Array<{ pattern: string; repos?: string[] }>;
+    rules: { pattern: string; repos?: string[] }[];
     repos: string[];
   };
   /**
@@ -369,7 +369,7 @@ export interface DispatchRequest {
    * extensibility — adding a new context kind should not require a
    * protocol-layer schema change. Validation, if any, is harness-side.
    */
-  context: Array<{ kind: string; data: unknown }>;
+  context: { kind: string; data: unknown }[];
   /**
    * Agent identity for the dispatch. `id` and `displayName` are the
    * minimum the runner needs for envelope provenance; `runtime.harness`

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -370,7 +370,7 @@ export async function startCortex(
 
   // Adapters (Discord + Mattermost).
   const adapters: PlatformAdapter[] = [];
-  const adapterCleanup: Array<() => void> = [];
+  const adapterCleanup: (() => void)[] = [];
 
   // MIG-7.2e: per-instance agent lookup. When cortex.yaml supplies
   // `inlineAgents` (reused from the registry-merge block above), each

--- a/src/runner/__tests__/agent-team.test.ts
+++ b/src/runner/__tests__/agent-team.test.ts
@@ -29,7 +29,7 @@ describe("AgentTeam", () => {
       timeoutMs: 120_000,
     });
 
-    const progressMessages: Array<{ member: string; text: string }> = [];
+    const progressMessages: { member: string; text: string }[] = [];
 
     team.on("progress", (member: string, text: string) => {
       progressMessages.push({ member, text });

--- a/src/runner/__tests__/dispatch-listener.test.ts
+++ b/src/runner/__tests__/dispatch-listener.test.ts
@@ -111,9 +111,9 @@ function makeReceivedEnvelope(
  */
 function fakeFactory(result: CCSessionResult): {
   factory: CCSessionFactory;
-  optsCaptured: Array<Parameters<CCSessionFactory>[0]>;
+  optsCaptured: Parameters<CCSessionFactory>[0][];
 } {
-  const optsCaptured: Array<Parameters<CCSessionFactory>[0]> = [];
+  const optsCaptured: Parameters<CCSessionFactory>[0][] = [];
   const factory: CCSessionFactory = (opts) => {
     optsCaptured.push(opts);
     const session = {

--- a/src/runner/agent-team.ts
+++ b/src/runner/agent-team.ts
@@ -87,7 +87,7 @@ function buildModeratorPrompt(userPrompt: string, participants: TeamParticipantC
  */
 function buildSynthesisPrompt(
   userPrompt: string,
-  participantResults: Array<{ name: string; result: string }>
+  participantResults: { name: string; result: string }[]
 ): string {
   const results = participantResults
     .map((p) => `### @${p.name}\n${p.result}`)

--- a/src/runner/cc-session.ts
+++ b/src/runner/cc-session.ts
@@ -27,7 +27,7 @@ export interface CCSessionOpts {
   cwd?: string;
   additionalArgs?: string[];
   /** Bash allowlist config — passed to bash-guard.hook.ts via GROVE_BASH_GUARD env var. */
-  bashAllowlist?: { rules: Array<{ pattern: string; repos?: string[] }>; repos: string[] };
+  bashAllowlist?: { rules: { pattern: string; repos?: string[] }[]; repos: string[] };
   /** G-300: When true, disables bash guard entirely (operator DM). */
   bashGuardDisabled?: boolean;
   /** H-001: Explicit project context (e.g., "grove", "meta-factory") */

--- a/src/runner/learning-store.ts
+++ b/src/runner/learning-store.ts
@@ -80,7 +80,7 @@ export class LearningStore {
        WHERE is_active = 1
        ORDER BY created_at DESC
        LIMIT ?`,
-    ).all(limit) as Array<{
+    ).all(limit) as {
       id: string;
       content: string;
       author_id: string;
@@ -88,7 +88,7 @@ export class LearningStore {
       created_at: string;
       is_active: number;
       usage_count: number;
-    }>;
+    }[];
 
     return rows.map(this.rowToLearning);
   }
@@ -103,7 +103,7 @@ export class LearningStore {
        FROM learnings
        WHERE is_active = 1 AND content LIKE ?
        ORDER BY usage_count DESC, created_at DESC`,
-    ).all(pattern) as Array<{
+    ).all(pattern) as {
       id: string;
       content: string;
       author_id: string;
@@ -111,7 +111,7 @@ export class LearningStore {
       created_at: string;
       is_active: number;
       usage_count: number;
-    }>;
+    }[];
 
     return rows.map(this.rowToLearning);
   }
@@ -161,7 +161,7 @@ export class LearningStore {
       `SELECT id, content, author_id, author_name, created_at, is_active, usage_count
        FROM learnings
        WHERE is_active = 1`,
-    ).all() as Array<{
+    ).all() as {
       id: string;
       content: string;
       author_id: string;
@@ -169,7 +169,7 @@ export class LearningStore {
       created_at: string;
       is_active: number;
       usage_count: number;
-    }>;
+    }[];
 
     if (allActive.length === 0) return [];
 

--- a/src/runner/task-tracker.ts
+++ b/src/runner/task-tracker.ts
@@ -33,7 +33,7 @@ export class TaskTracker {
   }
 
   /** List all active (in-flight) tasks. */
-  active(): Array<{ id: string; channelId: string; durationMs: number; description?: string }> {
+  active(): { id: string; channelId: string; durationMs: number; description?: string }[] {
     const now = Date.now();
     return Array.from(this.tasks.values()).map((t) => ({
       id: t.id,

--- a/src/surface/mc/__tests__/api.test.ts
+++ b/src/surface/mc/__tests__/api.test.ts
@@ -269,7 +269,7 @@ describe("POST /api/sessions", () => {
     // but the parsed JSON body has already resolved so the DB write is complete.
     const events = t.db
       .query("SELECT type, payload FROM events WHERE session_id = ? ORDER BY timestamp")
-      .all(body.sessionId) as Array<{ type: string; payload: string }>;
+      .all(body.sessionId) as { type: string; payload: string }[];
     const operatorInputs = events.filter((e) => e.type === "operator.input");
     expect(operatorInputs).toHaveLength(1);
     const first = operatorInputs[0]!;
@@ -307,7 +307,7 @@ describe("POST /api/sessions", () => {
       .query(
         "SELECT payload FROM events WHERE session_id = ? AND type = 'operator.curation'"
       )
-      .all(body.sessionId) as Array<{ payload: string }>;
+      .all(body.sessionId) as { payload: string }[];
     expect(events).toHaveLength(1);
     const payload = JSON.parse(events[0]!.payload);
     expect(payload.kind).toBe("dispatch");
@@ -350,7 +350,7 @@ describe("POST /api/sessions", () => {
       .query(
         "SELECT id FROM agent_task_assignment WHERE task_id = 't-debounce'"
       )
-      .all() as Array<{ id: string }>;
+      .all() as { id: string }[];
     expect(rows).toHaveLength(1);
   });
 
@@ -396,7 +396,7 @@ describe("POST /api/sessions", () => {
     // Exactly one assignment row, one ManagedProcess.
     const rows = t.db
       .query(`SELECT id FROM agent_task_assignment WHERE task_id = 't-race'`)
-      .all() as Array<{ id: string }>;
+      .all() as { id: string }[];
     expect(rows).toHaveLength(1);
     expect(t.pm.size).toBe(1);
   });
@@ -563,7 +563,7 @@ describe("POST /api/sessions", () => {
 // loop-double-fire invariant in test form.
 describe("POST /api/sessions — F-11 Discord notification hook", () => {
   let t: TestContext;
-  let calls: Array<{ from: string; to: string }>;
+  let calls: { from: string; to: string }[];
 
   beforeEach(async () => {
     const tmpDir = join(tmpdir(), `mc-api-f11-${Date.now()}-${Math.random()}`);
@@ -671,7 +671,7 @@ describe("POST /api/assignments/:id/input", () => {
 
     const events = t.db
       .query("SELECT type, payload FROM events WHERE session_id = ? AND type = 'operator.input'")
-      .all(sessionId) as Array<{ payload: string }>;
+      .all(sessionId) as { payload: string }[];
     const texts = events.map((e) => JSON.parse(e.payload).text as string);
     expect(texts).toContain("second turn");
   });
@@ -870,7 +870,7 @@ describe("POST /api/assignments/:id/input", () => {
       .get() as { payload: string };
     const parsed = JSON.parse(stored.payload) as {
       text?: string;
-      images?: Array<{ media_type: string; data: string }>;
+      images?: { media_type: string; data: string }[];
     };
     expect(parsed.text).toBeUndefined();
     expect(parsed.images).toHaveLength(1);
@@ -1109,7 +1109,7 @@ describe("GET /api/assignments/:id/events", () => {
     );
     expect(res.status).toBe(200);
     const body = (await res.json()) as {
-      events: Array<{ id: string }>;
+      events: { id: string }[];
       hasMore: boolean;
       sessionId: string;
     };
@@ -1123,20 +1123,20 @@ describe("GET /api/assignments/:id/events", () => {
     const { assignmentId, eventIds } = seedEvents(5);
     const page1 = (await (await fetch(
       `${t.baseUrl}/api/assignments/${assignmentId}/events?limit=2`
-    )).json()) as { events: Array<{ id: string }>; hasMore: boolean };
+    )).json()) as { events: { id: string }[]; hasMore: boolean };
     expect(page1.events.map((e) => e.id)).toEqual(eventIds.slice(3, 5));
     expect(page1.hasMore).toBe(true);
 
     const firstId = page1.events[0]!.id;
     const page2 = (await (await fetch(
       `${t.baseUrl}/api/assignments/${assignmentId}/events?limit=2&before=${firstId}`
-    )).json()) as { events: Array<{ id: string }>; hasMore: boolean };
+    )).json()) as { events: { id: string }[]; hasMore: boolean };
     expect(page2.events.map((e) => e.id)).toEqual(eventIds.slice(1, 3));
     expect(page2.hasMore).toBe(true);
 
     const page3 = (await (await fetch(
       `${t.baseUrl}/api/assignments/${assignmentId}/events?limit=2&before=${page2.events[0]!.id}`
-    )).json()) as { events: Array<{ id: string }>; hasMore: boolean };
+    )).json()) as { events: { id: string }[]; hasMore: boolean };
     expect(page3.events.map((e) => e.id)).toEqual([eventIds[0]!]);
     expect(page3.hasMore).toBe(false);
   });
@@ -1235,7 +1235,7 @@ describe("GET /api/tasks", () => {
       sourceSystem?: "github" | "internal";
       sourceExternalId?: string | null;
       sourceUrl?: string | null;
-      assignments?: Array<{ id: string; agentId: string; state: string }>;
+      assignments?: { id: string; agentId: string; state: string }[];
     } = {}
   ): void {
     const title = opts.title ?? `Task ${id}`;

--- a/src/surface/mc/__tests__/curation-endpoints.test.ts
+++ b/src/surface/mc/__tests__/curation-endpoints.test.ts
@@ -167,7 +167,7 @@ describe("POST /api/assignments/:id/requeue", () => {
       .query(
         "SELECT type, payload FROM events WHERE session_id = ? AND type = 'operator.curation'"
       )
-      .all(sessionId) as Array<{ type: string; payload: string }>;
+      .all(sessionId) as { type: string; payload: string }[];
     expect(events).toHaveLength(1);
     const payload = JSON.parse(events[0]!.payload);
     expect(payload.kind).toBe("requeue");
@@ -200,7 +200,7 @@ describe("POST /api/assignments/:id/requeue", () => {
       .query(
         "SELECT payload FROM events WHERE session_id = ? AND type = 'operator.curation'"
       )
-      .all(sessionId) as Array<{ payload: string }>;
+      .all(sessionId) as { payload: string }[];
     expect(events).toHaveLength(1);
     expect(JSON.parse(events[0]!.payload).reason).toBe("external dep recovered");
   });
@@ -308,7 +308,7 @@ describe("POST /api/assignments/:id/abandon", () => {
       .query(
         "SELECT payload FROM events WHERE session_id = ? AND type = 'operator.curation'"
       )
-      .all(sessionId) as Array<{ payload: string }>;
+      .all(sessionId) as { payload: string }[];
     expect(events).toHaveLength(1);
     const payload = JSON.parse(events[0]!.payload);
     expect(payload.kind).toBe("abandon");
@@ -341,7 +341,7 @@ describe("POST /api/assignments/:id/abandon", () => {
       .query(
         "SELECT payload FROM events WHERE session_id = ? AND type = 'operator.curation'"
       )
-      .all(sessionId) as Array<{ payload: string }>;
+      .all(sessionId) as { payload: string }[];
     expect(events).toHaveLength(1);
     const payload = JSON.parse(events[0]!.payload);
     expect(payload.targetKind).toBe("task");
@@ -506,7 +506,7 @@ describe("POST /api/assignments/:id/handoff", () => {
       .query(
         "SELECT payload FROM events WHERE session_id = ? AND type = 'operator.curation'"
       )
-      .all(body.newSessionId) as Array<{ payload: string }>;
+      .all(body.newSessionId) as { payload: string }[];
     expect(events).toHaveLength(1);
     const payload = JSON.parse(events[0]!.payload);
     expect(payload.kind).toBe("handoff");
@@ -519,7 +519,7 @@ describe("POST /api/assignments/:id/handoff", () => {
       .query(
         "SELECT payload FROM events WHERE session_id = ? AND type = 'state.transition'"
       )
-      .all(oldSessionId) as Array<{ payload: string }>;
+      .all(oldSessionId) as { payload: string }[];
     const cancelHit = cancelEvents.find(
       (e) => JSON.parse(e.payload).action === "cancel"
     );

--- a/src/surface/mc/__tests__/discord-sink.test.ts
+++ b/src/surface/mc/__tests__/discord-sink.test.ts
@@ -55,8 +55,8 @@ class FakeScheduler implements FlushScheduler {
 }
 
 class FakeNotifier implements DiscordNotifier {
-  dms: Array<{ userId: string; text: string }> = [];
-  channelMessages: Array<{ channelId: string; text: string }> = [];
+  dms: { userId: string; text: string }[] = [];
+  channelMessages: { channelId: string; text: string }[] = [];
   failNextDM = false;
   failNextChannel = false;
 

--- a/src/surface/mc/__tests__/ingestor.test.ts
+++ b/src/surface/mc/__tests__/ingestor.test.ts
@@ -172,7 +172,7 @@ describe("ingestEvents", () => {
       .query(
         "SELECT payload FROM events WHERE session_id = 's-obs' AND type = 'state.transition'"
       )
-      .all() as Array<{ payload: string }>;
+      .all() as { payload: string }[];
     expect(transitions).toHaveLength(1);
     const p = JSON.parse(transitions[0]!.payload);
     expect(p.from).toBe("dispatched");

--- a/src/surface/mc/__tests__/iterations.test.ts
+++ b/src/surface/mc/__tests__/iterations.test.ts
@@ -101,7 +101,7 @@ describe("iterations schema migration", () => {
     try {
       const cols = h.db
         .query(`SELECT name FROM pragma_table_info('iterations')`)
-        .all() as Array<{ name: string }>;
+        .all() as { name: string }[];
       const colNames = cols.map((c) => c.name).sort();
       expect(colNames).toEqual(
         [
@@ -122,7 +122,7 @@ describe("iterations schema migration", () => {
 
       const tCols = h.db
         .query(`SELECT name FROM pragma_table_info('tasks')`)
-        .all() as Array<{ name: string }>;
+        .all() as { name: string }[];
       expect(tCols.some((c) => c.name === "iteration_id")).toBe(true);
     } finally {
       teardown(h);
@@ -150,7 +150,7 @@ describe("iterations schema migration", () => {
           `SELECT name FROM sqlite_master WHERE type = 'index'
            AND name IN ('idx_iterations_state_priority', 'idx_tasks_iteration')`
         )
-        .all() as Array<{ name: string }>;
+        .all() as { name: string }[];
       const names = indexes.map((r) => r.name).sort();
       expect(names).toEqual([
         "idx_iterations_state_priority",

--- a/src/surface/mc/__tests__/metrics-endpoints.test.ts
+++ b/src/surface/mc/__tests__/metrics-endpoints.test.ts
@@ -66,12 +66,12 @@ function seedAssignment(
     agentName: string;
     taskId: string;
     createdAt: string;
-    transitions: Array<{
+    transitions: {
       timestamp: string;
       from: string;
       to: string;
       blockReason?: { kind: string; payload: Record<string, unknown> };
-    }>;
+    }[];
   }
 ): void {
   db.exec(
@@ -224,7 +224,7 @@ describe("GET /api/metrics/fleet", () => {
         count: number;
         completedCount: number;
         p50CycleMs: number;
-        perAgent: Array<{ agentId: string; completed: number }>;
+        perAgent: { agentId: string; completed: number }[];
       };
     };
     expect(body.metrics.count).toBe(1);
@@ -263,7 +263,7 @@ describe("GET /api/metrics/fleet", () => {
     );
     expect(res.status).toBe(200);
     const body = (await res.json()) as {
-      metrics: { count: number; perAgent: Array<{ agentId: string }> };
+      metrics: { count: number; perAgent: { agentId: string }[] };
     };
     expect(body.metrics.count).toBe(1);
     expect(body.metrics.perAgent.length).toBe(1);

--- a/src/surface/mc/__tests__/metrics.test.ts
+++ b/src/surface/mc/__tests__/metrics.test.ts
@@ -45,14 +45,14 @@ interface SeedAssignment {
   /** ISO-8601 — when the assignment row was inserted (start of the queued segment). */
   createdAt: string;
   /** Ordered list of state transitions; the assignment ends in the final state. */
-  transitions: Array<{
+  transitions: {
     /** ISO-8601 timestamp of the transition. */
     timestamp: string;
     from: AssignmentState;
     to: AssignmentState;
     /** Required when `to === 'blocked'`. */
     blockReason?: BlockReason;
-  }>;
+  }[];
 }
 
 let monotonicSuffix = 0;

--- a/src/surface/mc/__tests__/stream-json.test.ts
+++ b/src/surface/mc/__tests__/stream-json.test.ts
@@ -87,7 +87,7 @@ describe("buildStreamJsonMessage (content-block overload)", () => {
       { type: "text", text: "after" },
     ];
     const parsed = parseFirstLine(buildStreamJsonMessage(blocks)) as {
-      content: Array<{ type: string }>;
+      content: { type: string }[];
     };
     expect(parsed.content.map((b) => b.type)).toEqual([
       "text",

--- a/src/surface/mc/__tests__/task-create-endpoints.test.ts
+++ b/src/surface/mc/__tests__/task-create-endpoints.test.ts
@@ -396,7 +396,7 @@ describe("POST /api/tasks", () => {
       .query(
         "SELECT type, payload FROM events WHERE session_id = ? AND type = 'operator.curation'"
       )
-      .all(body.shadowSessionId) as Array<{ type: string; payload: string }>;
+      .all(body.shadowSessionId) as { type: string; payload: string }[];
     expect(events).toHaveLength(1);
     const payload = JSON.parse(events[0]!.payload);
     expect(payload.kind).toBe("task.imported");
@@ -535,7 +535,7 @@ describe("POST /api/tasks/:taskId/abandon", () => {
       .query(
         "SELECT payload FROM events WHERE session_id = ? AND type = 'operator.curation' ORDER BY id DESC"
       )
-      .all(shadowSessionId) as Array<{ payload: string }>;
+      .all(shadowSessionId) as { payload: string }[];
     // First event was task.imported (from create); this is the abandon.
     const lastPayload = JSON.parse(events[0]!.payload);
     expect(lastPayload.kind).toBe("abandon");
@@ -576,7 +576,7 @@ describe("POST /api/tasks/:taskId/abandon", () => {
       .query(
         "SELECT payload FROM events WHERE session_id = ? AND type = 'operator.curation' ORDER BY id DESC"
       )
-      .all(shadowSessionId) as Array<{ payload: string }>;
+      .all(shadowSessionId) as { payload: string }[];
     const last = JSON.parse(events[0]!.payload);
     expect(last.reason).toBe("no longer relevant");
   });
@@ -648,7 +648,7 @@ describe("F-9 working-agent filter", () => {
     const res = await fetch(`${t.baseUrl}/api/working-agents`);
     expect(res.status).toBe(200);
     const body = await res.json();
-    const ids = (body.agents as Array<{ agent_id: string }>).map(
+    const ids = (body.agents as { agent_id: string }[]).map(
       (a) => a.agent_id
     );
     expect(ids).not.toContain(SHADOW_AGENT_ID);
@@ -683,12 +683,12 @@ describe("GET /api/tasks projection", () => {
     const res = await fetch(`${t.baseUrl}/api/tasks`);
     expect(res.status).toBe(200);
     const body = await res.json();
-    const row = (body.tasks as Array<{
+    const row = (body.tasks as {
       id: string;
       shadow_assignment_id: string | null;
       assignments: unknown[];
       aggregate_state: string | null;
-    }>).find((tt) => tt.id === created.taskId);
+    }[]).find((tt) => tt.id === created.taskId);
     expect(row).toBeTruthy();
     expect(row!.shadow_assignment_id).toBe(created.shadowAssignmentId);
     // The assignments roll-up does NOT include the shadow row.
@@ -705,10 +705,10 @@ describe("GET /api/tasks projection", () => {
     `);
     const res = await fetch(`${t.baseUrl}/api/tasks`);
     const body = await res.json();
-    const row = (body.tasks as Array<{
+    const row = (body.tasks as {
       id: string;
       shadow_assignment_id: string | null;
-    }>).find((tt) => tt.id === "T-internal");
+    }[]).find((tt) => tt.id === "T-internal");
     expect(row).toBeTruthy();
     expect(row!.shadow_assignment_id).toBeNull();
   });

--- a/src/surface/mc/api/github-fetch.ts
+++ b/src/surface/mc/api/github-fetch.ts
@@ -76,7 +76,7 @@ interface RawGithubIssue {
   state?: string;
   body?: string | null;
   html_url?: string;
-  labels?: Array<{ name?: string } | string> | null;
+  labels?: ({ name?: string } | string)[] | null;
   pull_request?: unknown;
 }
 

--- a/src/surface/mc/api/iteration-import.ts
+++ b/src/surface/mc/api/iteration-import.ts
@@ -488,7 +488,7 @@ export interface IssuesWebhookEnvelope {
     body: string | null;
     html_url: string;
     state: string;
-    labels?: Array<{ name?: string } | string> | null;
+    labels?: ({ name?: string } | string)[] | null;
     /**
      * GitHub's sub-issue surface. When present, the issue is a child
      * of `parent`; the parent's owner/repo/number identifies the
@@ -549,7 +549,7 @@ export function parentMetadataFromWebhook(
   }
 
   const labels: string[] = Array.isArray(issue.labels)
-    ? (issue.labels as Array<{ name?: string } | string>)
+    ? (issue.labels as ({ name?: string } | string)[])
         .map((l) =>
           typeof l === "string"
             ? l

--- a/src/surface/mc/db/events.ts
+++ b/src/surface/mc/db/events.ts
@@ -130,13 +130,13 @@ export function listEventsForSession(
            ORDER BY id DESC
            LIMIT ?`
         )
-        .all(sessionId, opts.before, limit + 1) as Array<{
+        .all(sessionId, opts.before, limit + 1) as {
         id: string;
         session_id: string;
         type: string;
         payload: string;
         timestamp: string;
-      }>)
+      }[])
     : (db
         .query(
           `SELECT id, session_id, type, payload, timestamp
@@ -145,13 +145,13 @@ export function listEventsForSession(
            ORDER BY id DESC
            LIMIT ?`
         )
-        .all(sessionId, limit + 1) as Array<{
+        .all(sessionId, limit + 1) as {
         id: string;
         session_id: string;
         type: string;
         payload: string;
         timestamp: string;
-      }>);
+      }[]);
 
   const hasMore = rows.length > limit;
   const page = hasMore ? rows.slice(0, limit) : rows;
@@ -184,11 +184,11 @@ export function listEventsForSession(
 export interface OperatorInputEventPayload {
   text?: string;
   attachments?: string[];
-  images?: Array<{
+  images?: {
     media_type: string;
     /** Raw base64 (no data-URL prefix). */
     data: string;
-  }>;
+  }[];
 }
 
 export function createOperatorInputEvent(

--- a/src/surface/mc/db/iterations.ts
+++ b/src/surface/mc/db/iterations.ts
@@ -304,7 +304,7 @@ export function listInboxItems(
        ORDER BY updated_at DESC, id ASC
        LIMIT ?`
     )
-    .all(...(params as never[]), limit) as Array<{
+    .all(...(params as never[]), limit) as {
       id: string;
       title: string;
       priority: number;
@@ -314,7 +314,7 @@ export function listInboxItems(
       source_external_id: string | null;
       created_at: number;
       updated_at: number;
-    }>;
+    }[];
 
   return rows.map((r) => ({
     id: r.id,

--- a/src/surface/mc/db/metrics.ts
+++ b/src/surface/mc/db/metrics.ts
@@ -85,14 +85,14 @@ export interface FleetMetrics {
   /** Mean ms per assignment blocked under each kind. */
   meanByBlockReason: Record<BlockReasonKind, number>;
   /** Top three block-reason kinds by total ms across the window, descending. */
-  topBlockers: Array<{
+  topBlockers: {
     kind: BlockReasonKind;
     totalMs: number;
     /** Distinct assignments that hit this block reason at least once. */
     assignments: number;
-  }>;
+  }[];
   /** Per-agent breakdown. Sorted by completed DESC, then p50 ASC (faster first). */
-  perAgent: Array<{
+  perAgent: {
     agentId: string;
     agentName: string;
     completed: number;
@@ -100,7 +100,7 @@ export interface FleetMetrics {
     /** Block reason consuming the most blocked time for this agent. Null
      *  if the agent had no blocked time inside the window. */
     topBlocker: BlockReasonKind | null;
-  }>;
+  }[];
 }
 
 export interface FleetMetricsOptions {
@@ -169,7 +169,7 @@ function parseIsoMs(iso: string): number {
  */
 function accumulateIntervals(
   createdAtMs: number,
-  transitions: Array<{ ts: number; from: AssignmentState; to: AssignmentState; blockReason?: BlockReason }>,
+  transitions: { ts: number; from: AssignmentState; to: AssignmentState; blockReason?: BlockReason }[],
   byState: Record<AssignmentState, number>,
   byBlockReason: Record<BlockReasonKind, number>,
   nowMs: number
@@ -236,7 +236,7 @@ function accumulateIntervals(
 function loadTransitionsForAssignment(
   db: Database,
   assignmentId: string
-): Array<{ ts: number; from: AssignmentState; to: AssignmentState; blockReason?: BlockReason }> {
+): { ts: number; from: AssignmentState; to: AssignmentState; blockReason?: BlockReason }[] {
   const rows = db
     .query(
       `SELECT s.assignment_id AS assignment_id, e.timestamp AS timestamp, e.payload AS payload

--- a/src/taps/cc-events/__tests__/integration.test.ts
+++ b/src/taps/cc-events/__tests__/integration.test.ts
@@ -27,7 +27,7 @@ const policyPath = join(import.meta.dir, "..", "relay-policy.yaml");
 const policyYaml = readFileSync(policyPath, "utf-8");
 const policy = RelayPolicySchema.parse(parse(policyYaml));
 
-function writeRawAndProcess(rawFile: string, pubFile: string, events: Array<ReturnType<typeof createRawEvent>>) {
+function writeRawAndProcess(rawFile: string, pubFile: string, events: ReturnType<typeof createRawEvent>[]) {
   for (const event of events) {
     appendFileSync(rawFile, JSON.stringify(event) + "\n");
   }

--- a/src/taps/cc-events/hooks/EventLogger.hook.ts
+++ b/src/taps/cc-events/hooks/EventLogger.hook.ts
@@ -136,7 +136,7 @@ async function main() {
 
     // TodoWrite payload: extract task names and statuses
     if (toolName === "TodoWrite" && hookInput.tool_input?.todos) {
-      const todos = hookInput.tool_input.todos as Array<{ content: string; status: string; activeForm?: string }>;
+      const todos = hookInput.tool_input.todos as { content: string; status: string; activeForm?: string }[];
       const inProgress = todos.filter((t: { status: string }) => t.status === "in_progress");
       const completed = todos.filter((t: { status: string }) => t.status === "completed");
       const pending = todos.filter((t: { status: string }) => t.status === "pending");

--- a/src/taps/cc-events/lib/__tests__/event-processor.test.ts
+++ b/src/taps/cc-events/lib/__tests__/event-processor.test.ts
@@ -160,7 +160,7 @@ describe("EventProcessor", () => {
     test("invoked once per filtered event with the published shape", () => {
       const rawFile = join(RAW_DIR, "hook.jsonl");
       const pubFile = join(PUB_DIR, "hook.jsonl");
-      const captured: Array<{ event_id: string; event_type: string }> = [];
+      const captured: { event_id: string; event_type: string }[] = [];
 
       const processor = new EventProcessor(testPolicy, {
         onPublished: (event) => {

--- a/src/taps/gh-webhook-receiver/__tests__/integration.test.ts
+++ b/src/taps/gh-webhook-receiver/__tests__/integration.test.ts
@@ -83,7 +83,7 @@ function makeExecutionCtx(): {
   ctx: ExecutionContext;
   drain: () => Promise<void>;
 } {
-  const pending: Array<Promise<unknown>> = [];
+  const pending: Promise<unknown>[] = [];
   const ctx: ExecutionContext = {
     waitUntil(p: Promise<unknown>): void {
       pending.push(p);


### PR DESCRIPTION
## Summary

Pure stylistic sweep: drives `@typescript-eslint/array-type` to zero by converting all `Array<T>` references to `T[]` syntax. The rule's default option is `array` (`T[]`); cortex's existing code mixes both forms inherited from grove-v2 / various authors.

## Approach

Scoped single-rule auto-fix. A throwaway `eslint.config.array-type-only.js` enabled ONLY `array-type` (every other rule disabled), `bunx eslint --fix --config <throwaway> .` applied the fix, throwaway deleted before commit.

This dance is needed because a blanket `bun run lint:fix` removes load-bearing type casts in `parser.ts` and exposes a stale dynamic-import in `cortex.ts` (noted in cortex#152 description).

41 files touched, 108 lines flipped, **no behavior change** — same TypeScript array type, two surface syntaxes.

## Lint impact

- Repo-wide: **1097 → 1004 errors** (-93)
- `@typescript-eslint/array-type`: **93 → 0**

## Test plan

- [x] `bunx tsc --noEmit` clean
- [x] `bun run lint:errors` reports 1004 (was 1097)
- [x] `bun test` 2742/2743 pass, 1 skip, 0 fail
- [x] Throwaway `eslint.config.array-type-only.js` removed before commit

## Out of Scope

- Other ~1004 errors. Next candidate buckets:
| Count | Rule |
|---|---|
| 181 | `no-unsafe-member-access` |
| 121 | `no-unnecessary-condition` |
| 98  | `no-unsafe-assignment` |
| 73  | `no-unnecessary-type-assertion` |
| 68  | `no-base-to-string` |

## Refs

- cortex#152 (lint gate)
- cortex#154 (sweep #1 — github-events.ts, 164 → 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)