### PR TITLE
chore(lint): sweep #3 — type EventLogger.hook.ts CC hook input (-69)

### DIFF
--- a/src/taps/cc-events/hooks/EventLogger.hook.ts
+++ b/src/taps/cc-events/hooks/EventLogger.hook.ts
@@ -7,8 +7,65 @@
 
 import { appendFileSync, mkdirSync, chmodSync, existsSync, readFileSync } from "fs";
 import { join } from "path";
-import { createRawEvent } from "./lib/event-types";
+import { createRawEvent, type RawEvent } from "./lib/event-types";
 import { mapHookToEventType, EVENT_TYPES } from "./lib/event-taxonomy";
+
+// =============================================================================
+// Hook input shape — what Claude Code writes to stdin per hook firing.
+// All fields are optional because different hook events surface different
+// subsets (PostToolUse has tool_input/tool_output; UserPromptSubmit has
+// prompt; Stop has summary/duration_ms; etc.). The runtime infers
+// hook_event_name when CC omits it.
+// =============================================================================
+
+type HookEventName = RawEvent["source"]["hook"];
+
+interface TodoEntry {
+  content: string;
+  status: "in_progress" | "completed" | "pending";
+  activeForm?: string;
+}
+
+interface HookToolInput {
+  file_path?: string;
+  command?: string;
+  description?: string;
+  todos?: TodoEntry[];
+}
+
+interface HookInput {
+  tool_name?: string;
+  tool?: { name?: string };
+  tool_input?: HookToolInput;
+  tool_output?: unknown;
+  hook_event_name?: HookEventName;
+  hook_type?: HookEventName;
+  prompt?: string;
+  last_assistant_message?: string;
+  transcript_path?: string;
+  summary?: string;
+  duration_ms?: number;
+  session_id?: string;
+}
+
+interface UsageCache {
+  five_hour?: unknown;
+  seven_day?: unknown;
+  seven_day_opus?: unknown;
+  seven_day_sonnet?: unknown;
+  extra_usage?: unknown;
+}
+
+const VALID_HOOK_EVENTS: readonly HookEventName[] = [
+  "PostToolUse",
+  "Stop",
+  "UserPromptSubmit",
+  "SessionStart",
+];
+
+function isHookEventName(v: string): v is HookEventName {
+  return (VALID_HOOK_EVENTS as readonly string[]).includes(v);
+}
 
 // =============================================================================
 // Configuration
@@ -79,84 +136,102 @@ async function main() {
     const input = await new Response(Bun.stdin.stream()).text();
     if (!input.trim()) process.exit(0);
 
-    const hookInput = JSON.parse(input);
+    const hookInput = JSON.parse(input) as HookInput;
 
-    const toolName: string | undefined = hookInput.tool_name ?? hookInput.tool?.name;
+    const toolName: string | undefined =
+      hookInput.tool_name ?? hookInput.tool?.name;
 
-    // Infer hook type from input shape (CC doesn't always include hook_event_name)
-    let hookType: string = hookInput.hook_event_name ?? hookInput.hook_type ?? "unknown";
+    // Infer hook type from input shape (CC doesn't always include hook_event_name).
+    let hookType: HookEventName | "unknown" =
+      hookInput.hook_event_name ?? hookInput.hook_type ?? "unknown";
     if (hookType === "unknown") {
-      if (hookInput.tool_name || hookInput.tool_input) hookType = "PostToolUse";
-      else if (hookInput.prompt) hookType = "UserPromptSubmit";
-      else if (hookInput.last_assistant_message || hookInput.transcript_path) hookType = "Stop";
+      if (hookInput.tool_name !== undefined || hookInput.tool_input !== undefined) {
+        hookType = "PostToolUse";
+      } else if (hookInput.prompt !== undefined) {
+        hookType = "UserPromptSubmit";
+      } else if (
+        hookInput.last_assistant_message !== undefined ||
+        hookInput.transcript_path !== undefined
+      ) {
+        hookType = "Stop";
+      }
     }
     const sessionId: string =
       hookInput.session_id ?? process.env.CLAUDE_SESSION_ID ?? "unknown";
+
+    if (hookType === "unknown" || !isHookEventName(hookType)) {
+      // Unrecognised hook shape — write nothing, exit silently.
+      process.exit(0);
+    }
 
     const eventType = mapHookToEventType(hookType, toolName);
 
     // Build payload from hook input (raw — relay will filter)
     const payload: Record<string, unknown> = {};
 
-    if (hookInput.tool_input) payload.tool_input = hookInput.tool_input;
-    if (hookInput.tool_output) payload.tool_output = hookInput.tool_output;
-    if (hookInput.prompt) {
+    if (hookInput.tool_input !== undefined) payload.tool_input = hookInput.tool_input;
+    if (hookInput.tool_output !== undefined) payload.tool_output = hookInput.tool_output;
+    if (hookInput.prompt !== undefined) {
       let preview = hookInput.prompt;
       // Strip grove-bot wrapper to show just the user's message
-      const latestMatch = preview.match(/Latest message from .+?:\n(.+)/s);
-      const mentionMatch = preview.match(/The user who mentioned you is .+?\.\s*$/);
-      if (latestMatch) {
+      const latestMatch = /Latest message from .+?:\n(.+)/s.exec(preview);
+      const mentionMatch = /The user who mentioned you is .+?\.\s*$/.exec(preview);
+      if (latestMatch?.[1] !== undefined) {
         preview = latestMatch[1];
       } else if (mentionMatch) {
         preview = "(mentioned in conversation)";
       }
       // Strip XML/system tags (e.g. <task-notification>, <tool-use-id>) —
-      // Claude Code injects these as internal prompts, not user content
+      // Claude Code injects these as internal prompts, not user content.
       preview = preview.replace(/<[^>]+>/g, "").trim();
       if (preview) {
         payload.prompt_preview = preview.slice(0, 200);
       }
     }
-    if (hookInput.summary) payload.summary = hookInput.summary;
-    if (hookInput.duration_ms) payload.duration_ms = hookInput.duration_ms;
-    if (toolName) payload.tool_name = toolName;
+    if (hookInput.summary !== undefined) payload.summary = hookInput.summary;
+    if (hookInput.duration_ms !== undefined) payload.duration_ms = hookInput.duration_ms;
+    if (toolName !== undefined) payload.tool_name = toolName;
 
     // File path from tool input (for file.changed events)
-    if (hookInput.tool_input?.file_path) {
+    if (hookInput.tool_input?.file_path !== undefined) {
       payload.path = hookInput.tool_input.file_path;
     }
-    if (hookInput.tool_input?.command) {
+    if (hookInput.tool_input?.command !== undefined) {
       payload.command_preview = hookInput.tool_input.command.slice(0, 200);
     }
 
     // H-001: Explicit metadata from spawn boundary
-    if (groveProject) payload.project = groveProject;
-    if (groveEntity) payload.entity = groveEntity;
-    if (groveOperator) payload.operator = groveOperator;
+    if (groveProject !== undefined) payload.project = groveProject;
+    if (groveEntity !== undefined) payload.entity = groveEntity;
+    if (groveOperator !== undefined) payload.operator = groveOperator;
 
     // TodoWrite payload: extract task names and statuses
-    if (toolName === "TodoWrite" && hookInput.tool_input?.todos) {
-      const todos = hookInput.tool_input.todos as { content: string; status: string; activeForm?: string }[];
-      const inProgress = todos.filter((t: { status: string }) => t.status === "in_progress");
-      const completed = todos.filter((t: { status: string }) => t.status === "completed");
-      const pending = todos.filter((t: { status: string }) => t.status === "pending");
+    if (toolName === "TodoWrite" && hookInput.tool_input?.todos !== undefined) {
+      const todos = hookInput.tool_input.todos;
+      const inProgress = todos.filter((t) => t.status === "in_progress");
+      const completed = todos.filter((t) => t.status === "completed");
+      const pending = todos.filter((t) => t.status === "pending");
       payload.todo_summary = {
         total: todos.length,
         completed: completed.length,
         in_progress: inProgress.length,
         pending: pending.length,
       };
-      if (inProgress.length > 0) {
-        payload.active_task = inProgress[0]!.activeForm ?? inProgress[0]!.content;
+      const firstActive = inProgress[0];
+      if (firstActive !== undefined) {
+        payload.active_task = firstActive.activeForm ?? firstActive.content;
       }
     }
 
     // Agent/Task spawned: extract description
-    if (toolName === "Agent" && hookInput.tool_input?.description) {
+    if (
+      toolName === "Agent" &&
+      hookInput.tool_input?.description !== undefined
+    ) {
       payload.agent_description = hookInput.tool_input.description;
     }
 
-    const event = createRawEvent(eventType, hookType as any, payload, {
+    const event = createRawEvent(eventType, hookType, payload, {
       sessionId,
       toolName,
       networkId: groveNetwork,
@@ -171,7 +246,7 @@ async function main() {
     if (hookType === "UserPromptSubmit") {
       const heartbeat = createRawEvent(
         EVENT_TYPES.SESSION_HEARTBEAT,
-        hookType as any,
+        hookType,
         { project: groveProject, entity: groveEntity, operator: groveOperator },
         { sessionId, networkId: groveNetwork }
       );
@@ -187,11 +262,11 @@ async function main() {
           ".claude", "MEMORY", "STATE", "usage-cache.json"
         );
         if (existsSync(usageCachePath)) {
-          const cached = JSON.parse(readFileSync(usageCachePath, "utf-8"));
-          if (cached && (cached.five_hour || cached.seven_day)) {
+          const cached = JSON.parse(readFileSync(usageCachePath, "utf-8")) as UsageCache | null;
+          if (cached && (cached.five_hour !== undefined || cached.seven_day !== undefined)) {
             const usageEvent = createRawEvent(
               EVENT_TYPES.USAGE_UPDATE,
-              hookType as any,
+              hookType,
               {
                 five_hour: cached.five_hour ?? null,
                 seven_day: cached.seven_day ?? null,
@@ -220,4 +295,4 @@ async function main() {
   process.exit(0);
 }
 
-main();
+void main();


### PR DESCRIPTION
## Summary

Targets the next-largest cluster after sweep #1: `src/taps/cc-events/hooks/EventLogger.hook.ts` was at 69 errors (41 `no-unsafe-member-access` + 10 `no-unsafe-assignment` + 6 `no-unsafe-call` + 3 `no-unsafe-argument` + 3 `no-explicit-any` + smaller), all rooted in `JSON.parse(input)` returning `any` and propagating through every downstream `hookInput.field` access.

## Approach

Mirrors arc PR #150 / myelin#120-#127 / cortex#154:

- Added `HookInput` interface for the parsed CC hook payload, with per-event field optionality (different hook events surface different subsets — PostToolUse has tool_input, UserPromptSubmit has prompt, Stop has summary/duration_ms).
- Sub-types: `HookEventName` (lifted from `RawEvent["source"]["hook"]` enum), `TodoEntry`, `HookToolInput`, `UsageCache`.
- `JSON.parse(input) as HookInput` + `JSON.parse(usageCache) as UsageCache | null` give the parsed values structural typing.
- `isHookEventName(v): v is HookEventName` type guard plus a `VALID_HOOK_EVENTS` literal-array constant — replaces the three `hookType as any` casts at the `createRawEvent` call sites with validated narrowing. **Behavior change:** unrecognised hook shapes now exit silently rather than emit an unknown event_type. Drop is intentional — the prior code threaded `"unknown"` through to a downstream consumer that the schema rejected anyway.
- `str.match(re)` → `re.exec(str)` per `prefer-regexp-exec`.
- `void main()` for the top-level promise.
- `=== undefined` checks where TS narrowing needs them under the typed-checked preset.

## Lint impact

- Repo-wide: **1004 → 935 errors** (-69)
- `EventLogger.hook.ts`: **69 → 0 errors**

Rule-bucket drops:
| Δ | Rule |
|---|---|
| -41 | `no-unsafe-member-access` (181 → 140) |
| -10 | `no-unsafe-assignment` (98 → 88) |
| -6  | `no-unsafe-call` (34 → 28) |
| -3  | `no-unsafe-argument` (37 → 34) |
| -3  | `no-explicit-any` (52 → 49) |
| -2  | `no-unnecessary-type-assertion` |
| -2  | `no-non-null-assertion` |
| -1  | `no-floating-promises` |
| -1  | `prefer-regexp-exec` |

## Out of Scope

- Other ~935 errors. Next candidate files:
| Errors | File |
|---|---|
| 63 | `src/cortex.ts` |
| 56 | `src/cli/cortex/commands/cloud.ts` |
| 53 | `src/cli/discord/discord.ts` |
| 47 | `src/cli/discord/lib/discord.ts` |
| 46 | `src/bus/dispatch-handler.ts` |

## Test plan

- [x] `bunx tsc --noEmit` clean
- [x] `bun run lint:errors` reports 935 (was 1004)
- [x] `bun test src/taps/cc-events/` 134/134 pass
- [x] `EventLogger.hook.ts` standalone lint: 0 errors

## Refs

- cortex#152 (lint gate)
- cortex#154 (sweep #1) + cortex#155 (sweep #2)
- arc#150 + myelin#120-#127 (sweep pattern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)