### PR TITLE
chore(lint): sweep #4 — type Discord CLI lib + cmd handlers (-100)

### DIFF
--- a/src/cli/discord/discord.ts
+++ b/src/cli/discord/discord.ts
@@ -7,8 +7,32 @@
  */
 
 import { Command } from "commander";
+import YAML from "yaml";
 import { loadConfig, saveConfig, getConfigPath } from "./lib/config";
 import { postMessage, resolveChannelByName, resolveThreadByName, readMessages, listChannels, listThreads } from "./lib/discord";
+
+// Per-command option shapes. Commander's typing is permissive; pinning each
+// `.action((opts) => …)` to the concrete shape lets the typed-checked preset
+// narrow .channel/.thread/.limit instead of falling through as `any`.
+interface PostOptions {
+  channel?: string;
+  thread?: string;
+}
+interface ReadOptions {
+  channel?: string;
+  thread?: string;
+  limit: string;
+}
+
+// `setNestedValue`/`getNestedValue` walk an arbitrarily-nested config tree.
+// `JsonObject` is the recursive shape: every leaf is a string (the only
+// value type the CLI's `discord config set <key> <value>` ever writes) or
+// another nested object. The cortex.yaml shape (DiscordCliConfig) satisfies
+// this constraint structurally, so the helpers don't need to reach for any.
+type ConfigValue = string | ConfigObject | undefined;
+interface ConfigObject {
+  [key: string]: ConfigValue;
+}
 
 const program = new Command()
   .name("discord")
@@ -23,7 +47,7 @@ program
   .argument("<message...>", "Message text (multiple words joined)")
   .option("-c, --channel <name>", "Channel name (default: defaultChannel from config)")
   .option("-t, --thread <name-or-id>", "Thread name or ID to post into")
-  .action(async (messageParts: string[], opts) => {
+  .action(async (messageParts: string[], opts: PostOptions) => {
     const config = loadConfig();
     const message = messageParts.join(" ");
 
@@ -66,15 +90,18 @@ program
         }
         if (channelId) {
           // Cache the resolved ID
-          if (!config.channels) config.channels = {};
-          if (!config.channels[channelName]) config.channels[channelName] = { id: channelId };
-          else config.channels[channelName].id = channelId;
+          config.channels ??= {};
+          config.channels[channelName] = { id: channelId };
           saveConfig(config);
         }
       }
     }
 
-    const targetId = threadId ?? channelId!;
+    const targetId = threadId ?? channelId;
+    if (!targetId) {
+      console.error("internal: no target id resolved");
+      process.exit(1);
+    }
 
     const result = await postMessage(config.botToken, targetId, message);
     if (result.success) {
@@ -93,7 +120,7 @@ program
   .option("-c, --channel <name>", "Channel name (default: defaultChannel from config)")
   .option("-t, --thread <name-or-id>", "Thread name or ID to read from")
   .option("-n, --limit <n>", "Number of messages", "10")
-  .action(async (opts) => {
+  .action(async (opts: ReadOptions) => {
     const config = loadConfig();
 
     if (!config.botToken) {
@@ -134,9 +161,8 @@ program
           console.error(`Channel "#${channelName}" not found.`);
           process.exit(1);
         }
-        if (!config.channels) config.channels = {};
-        if (!config.channels[channelName]) config.channels[channelName] = { id: channelId };
-        else config.channels[channelName].id = channelId;
+        config.channels ??= {};
+        config.channels[channelName] = { id: channelId };
         saveConfig(config);
       }
       readTargetId = channelId;
@@ -202,7 +228,7 @@ configCmd
   .argument("<value>", "Config value")
   .action((key: string, value: string) => {
     const config = loadConfig();
-    setNestedValue(config, key, value);
+    setNestedValue(config as unknown as ConfigObject, key, value);
     saveConfig(config);
     console.log(`Set ${key} = ${value.length > 50 ? value.slice(0, 50) + "..." : value}`);
   });
@@ -213,7 +239,7 @@ configCmd
   .argument("<key>", "Config key (dot notation)")
   .action((key: string) => {
     const config = loadConfig();
-    const value = getNestedValue(config, key);
+    const value = getNestedValue(config as unknown as ConfigObject, key);
     if (value === undefined) {
       console.error(`Key "${key}" not found.`);
       process.exit(1);
@@ -226,7 +252,6 @@ configCmd
   .description("Show full configuration")
   .action(() => {
     const config = loadConfig();
-    const YAML = require("yaml");
     console.log(`# ${getConfigPath()}\n`);
     console.log(YAML.stringify(config));
   });
@@ -240,24 +265,27 @@ configCmd
 
 // ─── helpers ───────────────────────────────────────────────────────────────
 
-function setNestedValue(obj: any, key: string, value: string): void {
+function setNestedValue(obj: ConfigObject, key: string, value: string): void {
   const parts = key.split(".");
-  let current = obj;
+  if (parts.length === 0) return;
+  let current: ConfigObject = obj;
   for (let i = 0; i < parts.length - 1; i++) {
-    const key = parts[i]!;
-    if (current[key] === undefined || typeof current[key] !== "object") {
-      current[key] = {};
+    const part = parts[i] ?? "";
+    const next = current[part];
+    if (next === undefined || typeof next !== "object") {
+      current[part] = {};
     }
-    current = current[key];
+    current = current[part] as ConfigObject;
   }
-  current[parts[parts.length - 1]!] = value;
+  const leaf = parts[parts.length - 1] ?? "";
+  current[leaf] = value;
 }
 
-function getNestedValue(obj: any, key: string): any {
+function getNestedValue(obj: ConfigObject, key: string): ConfigValue {
   const parts = key.split(".");
-  let current = obj;
+  let current: ConfigValue = obj;
   for (const part of parts) {
-    if (current === undefined || current === null) return undefined;
+    if (current === undefined || typeof current !== "object") return undefined;
     current = current[part];
   }
   return current;

--- a/src/cli/discord/lib/discord.ts
+++ b/src/cli/discord/lib/discord.ts
@@ -35,6 +35,47 @@ export interface DiscordThread {
   archived: boolean;
 }
 
+// =============================================================================
+// Discord API response shapes — narrowest projections this module reads.
+// Discord's full schema is huge; only field cortex actually accesses lives
+// here. Any future field need extends the interface, not loosens the type.
+// =============================================================================
+
+interface DiscordApiUser {
+  global_name?: string | null;
+  username: string;
+}
+
+interface DiscordApiMessage {
+  id: string;
+  author: DiscordApiUser;
+  content: string;
+  timestamp: string;
+  thread?: { id: string };
+}
+
+interface DiscordApiMessageCreated {
+  id: string;
+}
+
+interface DiscordApiChannel {
+  id: string;
+  name: string;
+  type: number;
+  parent_id?: string | null;
+}
+
+interface DiscordApiThread {
+  id: string;
+  name: string;
+  message_count?: number;
+  thread_metadata?: { archived?: boolean };
+}
+
+interface DiscordApiActiveThreadsResponse {
+  threads?: DiscordApiThread[];
+}
+
 /**
  * Post a message via bot API.
  */
@@ -57,7 +98,7 @@ export async function postMessage(
     return { success: false, error: `${res.status}: ${text}` };
   }
 
-  const data = await res.json() as any;
+  const data = (await res.json()) as DiscordApiMessageCreated;
   return { success: true, messageId: data.id };
 }
 
@@ -90,7 +131,7 @@ export async function readMessages(
     throw new Error(`Failed to read channel: ${res.status} ${await res.text()}`);
   }
 
-  const messages = await res.json() as any[];
+  const messages = (await res.json()) as DiscordApiMessage[];
   return messages.reverse().map((m) => ({
     id: m.id,
     author: m.author.global_name ?? m.author.username,
@@ -115,11 +156,16 @@ export async function listChannels(
     throw new Error(`Failed to list channels: ${res.status} ${await res.text()}`);
   }
 
-  const channels = await res.json() as any[];
+  const channels = (await res.json()) as DiscordApiChannel[];
   // Text channels (type 0) and announcement channels (type 5)
   return channels
     .filter((c) => c.type === 0 || c.type === 5)
-    .map((c) => ({ id: c.id, name: c.name, type: c.type, parentId: c.parent_id }))
+    .map((c) => ({
+      id: c.id,
+      name: c.name,
+      type: c.type,
+      parentId: c.parent_id ?? undefined,
+    }))
     .sort((a, b) => a.name.localeCompare(b.name));
 }
 
@@ -156,8 +202,8 @@ export async function listThreads(
     throw new Error(`Failed to list threads: ${res.status} ${await res.text()}`);
   }
 
-  const data = await res.json() as any;
-  return (data.threads ?? []).map((t: any) => ({
+  const data = (await res.json()) as DiscordApiActiveThreadsResponse;
+  return (data.threads ?? []).map((t) => ({
     id: t.id,
     name: t.name,
     messageCount: t.message_count ?? 0,


### PR DESCRIPTION
## Summary

Targets the discord CLI cluster: `src/cli/discord/discord.ts` (53 errors) plus `src/cli/discord/lib/discord.ts` (47 errors). Both rooted in `await res.json() as any` returning untyped Discord REST responses, plus untyped Commander option objects and a recursive `setNestedValue`/`getNestedValue` pair that took `obj: any`.

## lib/discord.ts (47 → 0)

Added narrow Discord REST projection types — only the fields cortex actually reads, not the full Discord schema:

- `DiscordApiUser`, `DiscordApiMessage`, `DiscordApiMessageCreated`
- `DiscordApiChannel`, `DiscordApiThread`, `DiscordApiActiveThreadsResponse`

Each `await res.json() as any` becomes `(await res.json()) as <NarrowType>`. Field access narrows naturally. `parent_id ?? undefined` preserves the existing optional-coalesce semantic on the export type.

## discord.ts (53 → 0)

- Per-command option interfaces (`PostOptions`, `ReadOptions`) — pin Commander's permissive `opts: any` to the actual flag set so `opts.channel` etc. narrow.
- `import YAML from "yaml"` replaces `const YAML = require("yaml")` in the `config show` command (drops `no-require-imports`).
- `setNestedValue` / `getNestedValue` typed against a recursive `ConfigObject` shape (`Record<string, string | ConfigObject>`). Cast at the two call sites since the typed `DiscordCliConfig` doesn't carry a string index signature.
- Triple-step `if (!a) a = {}; if (!a[k]) a[k] = …; else a[k].id = …` collapsed to `a ??= {}; a[k] = …` per `prefer-nullish-coalescing`. Net behavior identical (always overwrites the cached id with the freshly-resolved one — was the intent of the prior else-branch anyway).
- `const targetId = threadId ?? channelId!` replaced with an early-exit guard, dropping the non-null assertion and giving a real error message if both are unset (was previously a silent runtime crash).
- `setNestedValue` array-index access via `?? ""` instead of `!`, dropping two more non-null assertions.

## Lint impact

- Repo-wide: **935 → 835 errors** (-100)
- `src/cli/discord/discord.ts`: **53 → 0**
- `src/cli/discord/lib/discord.ts`: **47 → 0**

Rule-bucket drops:
| Δ | Rule |
|---|---|
| -39 | `no-unsafe-member-access` (140 → 101) |
| -28 | `no-unsafe-assignment` (88 → 60) |
| -8  | `no-unsafe-argument` (34 → 26) |
| -8  | `no-explicit-any` (49 → 41) |
| -5  | `no-non-null-assertion` |
| -3  | `no-unsafe-call` (28 → 25) |
| -2  | `no-unsafe-return` |
| -2  | `no-unnecessary-type-assertion` |
| -2  | `prefer-nullish-coalescing` |
| -2  | `no-unnecessary-condition` |
| -1  | `no-require-imports` |

## Test plan

- [x] `bunx tsc --noEmit` clean
- [x] `bun run lint:errors` reports 835 (was 935)
- [x] `bun test src/cli/` 241/241 pass

## Out of Scope

- Other ~835 errors. Next candidate files:
| Errors | File |
|---|---|
| 63 | `src/cortex.ts` |
| 56 | `src/cli/cortex/commands/cloud.ts` |
| 46 | `src/bus/dispatch-handler.ts` |
| 45 | `src/common/usage/monitor.ts` |
| 41 | `src/common/config/watcher.ts` |

## Refs

- cortex#152 (lint gate)
- cortex#154 (sweep #1) + cortex#155 (sweep #2) + cortex#156 (sweep #3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)