### PR TITLE
chore(lint): sweep #6 — config watcher dynamic-key access (-41)

### DIFF
--- a/src/common/config/watcher.ts
+++ b/src/common/config/watcher.ts
@@ -118,6 +118,14 @@ function compareConfigs(oldConfig: BotConfig, newConfig: BotConfig): {
   const applied: string[] = [];
   const requiresRestart: string[] = [];
 
+  // Helper: dynamic-key access on a typed object via a structural cast.
+  // `Record<string, unknown>` is structurally satisfied by every object, so
+  // this avoids the `any` cast that would otherwise break type-safety on
+  // surrounding code. Used for dynamic-key walks where the key set is only
+  // known at runtime (e.g., diffing config blocks).
+  const pickField = (obj: object, key: string): unknown =>
+    (obj as Record<string, unknown>)[key];
+
   // Helper: deep compare two values
   const isDifferent = (a: unknown, b: unknown): boolean => {
     if (a === b) return false;
@@ -125,13 +133,13 @@ function compareConfigs(oldConfig: BotConfig, newConfig: BotConfig): {
     if (a === null || b === null) return a !== b;
     if (Array.isArray(a) && Array.isArray(b)) {
       if (a.length !== b.length) return true;
-      return a.some((item, i) => isDifferent(item, b[i]));
+      return a.some((item, i) => isDifferent(item, b[i] as unknown));
     }
     if (typeof a === "object" && typeof b === "object") {
-      const aKeys = Object.keys(a as object);
-      const bKeys = Object.keys(b as object);
+      const aKeys = Object.keys(a);
+      const bKeys = Object.keys(b);
       if (aKeys.length !== bKeys.length) return true;
-      return aKeys.some((key) => isDifferent((a as any)[key], (b as any)[key]));
+      return aKeys.some((key) => isDifferent(pickField(a, key), pickField(b, key)));
     }
     return true;
   };
@@ -153,35 +161,35 @@ function compareConfigs(oldConfig: BotConfig, newConfig: BotConfig): {
   // Agent fields
   if (isDifferent(oldConfig.agent, newConfig.agent)) {
     for (const key of Object.keys(newConfig.agent)) {
-      checkField(`agent.${key}`, (oldConfig.agent as any)[key], (newConfig.agent as any)[key]);
+      checkField(`agent.${key}`, pickField(oldConfig.agent, key), pickField(newConfig.agent, key));
     }
   }
 
   // Claude fields
   if (isDifferent(oldConfig.claude, newConfig.claude)) {
     for (const key of Object.keys(newConfig.claude)) {
-      checkField(`claude.${key}`, (oldConfig.claude as any)[key], (newConfig.claude as any)[key]);
+      checkField(`claude.${key}`, pickField(oldConfig.claude, key), pickField(newConfig.claude, key));
     }
   }
 
   // Attachments fields
   if (isDifferent(oldConfig.attachments, newConfig.attachments)) {
     for (const key of Object.keys(newConfig.attachments)) {
-      checkField(`attachments.${key}`, (oldConfig.attachments as any)[key], (newConfig.attachments as any)[key]);
+      checkField(`attachments.${key}`, pickField(oldConfig.attachments, key), pickField(newConfig.attachments, key));
     }
   }
 
   // GitHub fields
   if (isDifferent(oldConfig.github, newConfig.github)) {
     for (const key of Object.keys(newConfig.github)) {
-      checkField(`github.${key}`, (oldConfig.github as any)[key], (newConfig.github as any)[key]);
+      checkField(`github.${key}`, pickField(oldConfig.github, key), pickField(newConfig.github, key));
     }
   }
 
   // API fields
   if (isDifferent(oldConfig.api, newConfig.api)) {
     for (const key of Object.keys(newConfig.api)) {
-      checkField(`api.${key}`, (oldConfig.api as any)[key], (newConfig.api as any)[key]);
+      checkField(`api.${key}`, pickField(oldConfig.api, key), pickField(newConfig.api, key));
     }
   }
 
@@ -205,7 +213,7 @@ function compareConfigs(oldConfig: BotConfig, newConfig: BotConfig): {
       }
       for (const key of Object.keys(newInst)) {
         if (key === "instanceId") continue;
-        checkField(`${platformName}.${key}`, (oldInst as any)[key], (newInst as any)[key]);
+        checkField(`${platformName}.${key}`, pickField(oldInst, key), pickField(newInst, key));
       }
     }
 
@@ -221,7 +229,12 @@ function compareConfigs(oldConfig: BotConfig, newConfig: BotConfig): {
     oldConfig.discord,
     newConfig.discord,
     "discord",
-    (inst) => (inst as any).instanceId ?? (inst as any).guildId
+    (inst) => {
+      const id = pickField(inst, "instanceId");
+      const guild = pickField(inst, "guildId");
+      return (typeof id === "string" ? id : undefined) ??
+        (typeof guild === "string" ? guild : "default");
+    }
   );
 
   // Mattermost instances
@@ -229,7 +242,10 @@ function compareConfigs(oldConfig: BotConfig, newConfig: BotConfig): {
     oldConfig.mattermost,
     newConfig.mattermost,
     "mattermost",
-    (inst) => (inst as any).instanceId ?? "default"
+    (inst) => {
+      const id = pickField(inst, "instanceId");
+      return typeof id === "string" ? id : "default";
+    }
   );
 
   return { applied, requiresRestart };
@@ -262,7 +278,9 @@ export class ConfigWatcher {
     // Debounced reload: wait 200ms after last change before reloading
     const triggerReload = () => {
       if (this.reloadTimeout) clearTimeout(this.reloadTimeout);
-      this.reloadTimeout = setTimeout(() => this.reload(), 200);
+      this.reloadTimeout = setTimeout(() => {
+        this.reload();
+      }, 200);
     };
 
     this.watcher = watch(this.configPath, { persistent: false }, (eventType: string) => {
@@ -421,7 +439,9 @@ export class AgentsDirectoryWatcher {
 
     const triggerReload = (source: "watcher" | "sighup" | "cli" = "watcher") => {
       if (this.reloadTimeout) clearTimeout(this.reloadTimeout);
-      this.reloadTimeout = setTimeout(() => this.reload(source), this.debounceMs);
+      this.reloadTimeout = setTimeout(() => {
+        this.reload(source);
+      }, this.debounceMs);
     };
 
     this.watcher = watch(this.agentsDir, { persistent: false }, (eventType: string, filename: string | null) => {
@@ -574,8 +594,9 @@ function deepEqual(a: unknown, b: unknown): boolean {
     return true;
   }
   if (Array.isArray(b)) return false;
-  const aKeys = Object.keys(a as object);
-  const bKeys = Object.keys(b as object);
+  if (b === undefined) return false;
+  const aKeys = Object.keys(a);
+  const bKeys = Object.keys(b);
   if (aKeys.length !== bKeys.length) return false;
   for (const key of aKeys) {
     if (!Object.prototype.hasOwnProperty.call(b, key)) return false;


### PR DESCRIPTION
## Summary

Targets `src/common/config/watcher.ts` (41 errors). Two root causes:

1. The hot-reload diff walks BotConfig blocks via dynamic-key indexing (`Object.keys(newConfig.agent)` → `(oldConfig.agent as any)[key]`). The `as any` casts at 9 call sites + 4 inside helper functions all propagated `any` through every subsequent access.
2. Two `setTimeout(() => this.reload(...), ms)` callsites returned a void from the arrow function shorthand.
3. A handful of redundant `as object` casts where TS narrowing already covered the type, plus one missed `undefined` guard in the `deepEqual` helper.

## Approach

- Added a local `pickField(obj: object, key: string): unknown` helper that wraps the dynamic-key access via a structural `Record<string, unknown>` cast. Satisfied by every object structurally — no `any` involved. Replaces 9 call-site `as any` casts.
- For the discord/mattermost instance ID extractors that read `(inst as any).instanceId ?? (inst as any).guildId`, switched to `pickField(inst, ...)` + `typeof` narrowing so the runtime fallback to "default" survives a missing or non-string field.
- `setTimeout` callbacks wrap as `() => { this.reload(...); }` so the void return is intentional. (Initial draft used `void this.reload(...)`, but since `reload()` is synchronous void-returning, `no-meaningless-void-operator` flagged — dropped the `void`.)
- Dropped redundant `Object.keys(a as object)` casts where `a` is already narrowed; added a missing `b === undefined` guard in `deepEqual` that TS demanded after the cast was removed.

## Lint impact

- Repo-wide: **790 → 749 errors** (-41)
- `src/common/config/watcher.ts`: **41 → 0 errors**

Rule-bucket drops:
| Δ | Rule |
|---|---|
| -17 | `no-explicit-any` (37 → 20) |
| -17 | `no-unsafe-member-access` (85 → 68) |
| -3  | `no-unnecessary-type-assertion` (73 → 70) |
| -2  | `no-unsafe-return` |
| -2  | `no-confusing-void-expression` |

## Test plan

- [x] `bunx tsc --noEmit` clean
- [x] `bun run lint:errors` reports 749 (was 790)
- [x] `bun test src/common/` 409/409 pass

## Out of Scope

- Other ~749 errors. Next candidate files:
| Errors | File |
|---|---|
| 63 | `src/cortex.ts` (dashboard wiring broken — needs cleanup PR) |
| 56 | `src/cli/cortex/commands/cloud.ts` (diverse, no shared root) |
| 46 | `src/bus/dispatch-handler.ts` |
| 38 | `src/surface/mc/api/handlers.ts` |
| 37 | `src/runner/stream-parser.ts` |

## Refs

- cortex#152 (lint gate)
- cortex#154-#158 (sweeps #1-#5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)