### PR TITLE
chore(lint): sweep #7 — type CC stream-json parser (-37)

### DIFF
--- a/src/runner/stream-parser.ts
+++ b/src/runner/stream-parser.ts
@@ -20,6 +20,53 @@ export interface StreamEvent {
   raw: unknown;
 }
 
+// =============================================================================
+// CC stream-json line shapes — narrow projection of what the parser reads.
+// CC emits five message kinds; we only act on three (system/init, assistant,
+// result). Unknown kinds fall through to `null`. These types describe the
+// fields actually accessed; CC may add other fields without breaking us.
+// =============================================================================
+
+interface StreamSystemInit {
+  type: "system";
+  subtype: string;
+  session_id?: string;
+}
+
+interface StreamContentBlock {
+  type: string;
+  name?: string;
+  input?: Record<string, unknown>;
+  text?: string;
+}
+
+interface StreamAssistantMessage {
+  type: "assistant";
+  message?: {
+    content?: string | StreamContentBlock[];
+  };
+}
+
+interface StreamUsageRaw {
+  input_tokens?: number;
+  output_tokens?: number;
+  cache_read_input_tokens?: number;
+}
+
+interface StreamResultMessage {
+  type: "result";
+  result?: string;
+  session_id?: string;
+  usage?: StreamUsageRaw;
+  total_cost_usd?: number;
+}
+
+type StreamLine =
+  | StreamSystemInit
+  | StreamAssistantMessage
+  | StreamResultMessage
+  | { type: string };
+
 /**
  * Parse a single JSONL line from CC stream-json output.
  * Returns null for empty lines or unrecognized message types.
@@ -28,21 +75,22 @@ export function parseStreamLine(line: string): StreamEvent | null {
   const trimmed = line.trim();
   if (!trimmed) return null;
 
-  let parsed: any;
+  let parsed: StreamLine;
   try {
-    parsed = JSON.parse(trimmed);
+    parsed = JSON.parse(trimmed) as StreamLine;
   } catch {
     return null;
   }
 
   // System init — contains session ID
-  if (parsed.type === "system" && parsed.subtype === "init") {
-    return { type: "init", sessionId: parsed.session_id, raw: parsed };
+  if (parsed.type === "system" && (parsed as StreamSystemInit).subtype === "init") {
+    const init = parsed as StreamSystemInit;
+    return { type: "init", sessionId: init.session_id, raw: parsed };
   }
 
   // Assistant message — incremental text and tool use
   if (parsed.type === "assistant") {
-    const content = parsed.message?.content;
+    const content = (parsed as StreamAssistantMessage).message?.content;
     // Check for tool_use blocks first
     const toolUse = extractToolUse(content);
     if (toolUse) return { type: "tool_use", toolName: toolUse.name, toolInput: toolUse.input, raw: parsed };
@@ -53,11 +101,12 @@ export function parseStreamLine(line: string): StreamEvent | null {
 
   // Final result — complete response + usage
   if (parsed.type === "result") {
+    const result = parsed as StreamResultMessage;
     return {
       type: "result",
-      text: parsed.result ?? "",
-      sessionId: parsed.session_id,
-      usage: normalizeUsage(parsed),
+      text: result.result ?? "",
+      sessionId: result.session_id,
+      usage: normalizeUsage(result),
       raw: parsed,
     };
   }
@@ -70,8 +119,9 @@ export function parseStreamLine(line: string): StreamEvent | null {
  */
 function extractToolUse(content: unknown): { name: string; input: Record<string, unknown> } | null {
   if (!Array.isArray(content)) return null;
-  const block = content.find((b: any) => b.type === "tool_use");
-  if (!block) return null;
+  const blocks = content as StreamContentBlock[];
+  const block = blocks.find((b) => b.type === "tool_use");
+  if (block?.name === undefined) return null;
   return { name: block.name, input: block.input ?? {} };
 }
 
@@ -82,9 +132,10 @@ function extractToolUse(content: unknown): { name: string; input: Record<string,
 export function extractText(content: unknown): string | null {
   if (typeof content === "string") return content;
   if (Array.isArray(content)) {
-    const text = content
-      .filter((b: any) => b.type === "text")
-      .map((b: any) => b.text)
+    const blocks = content as StreamContentBlock[];
+    const text = blocks
+      .filter((b) => b.type === "text")
+      .map((b) => b.text ?? "")
       .join("");
     return text || null;
   }
@@ -92,7 +143,7 @@ export function extractText(content: unknown): string | null {
 }
 
 /** Normalize usage stats from CC result message */
-function normalizeUsage(parsed: any): UsageStats | undefined {
+function normalizeUsage(parsed: StreamResultMessage): UsageStats | undefined {
   const usage = parsed.usage;
   if (!usage) return undefined;
   return {


### PR DESCRIPTION
## Summary

Targets `src/runner/stream-parser.ts` (37 errors). Single root cause: `JSON.parse(trimmed)` typed as `any` propagated through every `parsed.type`, `parsed.message?.content`, `(b: any) => b.type`, etc.

## Approach

Mirrors arc PR #150 / myelin#120-#127 / cortex#154-#159:

- Added narrow CC stream-json line shapes (`StreamSystemInit`, `StreamAssistantMessage`, `StreamResultMessage`, `StreamContentBlock`, `StreamUsageRaw`) + a discriminated `StreamLine` union for the parser-side cast. Only fields actually accessed are typed; CC may add unrelated fields without breaking us.
- `JSON.parse(trimmed) as StreamLine` lets each branch downcast to the discriminated variant for field access.
- `extractToolUse` and `extractText` narrow `unknown` → typed `StreamContentBlock[]` via a single cast at the array boundary.
- `normalizeUsage(parsed: StreamResultMessage)` (was `any`) — caller already narrows.
- Replaced `if (!block || block.name === undefined)` with `if (block?.name === undefined)` per `prefer-optional-chain`.
- Loosened `subtype: "init"` → `subtype: string` in `StreamSystemInit` so the `subtype === "init"` guard at the call site stays meaningful (literal type made it tautological per `no-unnecessary-condition`).

## Lint impact

- Repo-wide: **749 → 712 errors** (-37)
- `src/runner/stream-parser.ts`: **37 → 0 errors**

Rule-bucket drops:
| Δ | Rule |
|---|---|
| -18 | `no-unsafe-member-access` (68 → 50) |
| -13 | `no-unsafe-assignment` (43 → 30) |
| -5  | `no-explicit-any` (20 → 15) |
| -1  | `no-unsafe-return` |

## Test plan

- [x] `bunx tsc --noEmit` clean
- [x] `bun run lint:errors` reports 712 (was 749)
- [x] `bun test src/runner/` 186/186 pass

## Out of Scope

- Other ~712 errors. Next candidates:
| Errors | File |
|---|---|
| 63 | `src/cortex.ts` (dashboard wiring broken — needs cleanup, not lint) |
| 56 | `src/cli/cortex/commands/cloud.ts` |
| 46 | `src/bus/dispatch-handler.ts` |
| 38 | `src/surface/mc/api/handlers.ts` |
| 36 | `src/common/types/config.ts` |

## Refs

- cortex#152 (lint gate)
- cortex#154-#159 (sweeps #1-#6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)