### PR TITLE
chore(lint): sweep #9 — type cortex-relay CLI options + drop unsafe template casts (-22)

### DIFF
--- a/src/taps/cc-events/relay.ts
+++ b/src/taps/cc-events/relay.ts
@@ -16,6 +16,19 @@ import { RawEventSchema } from "./hooks/lib/event-types";
 import { NatsLink } from "../../bus/nats/connection";
 import { createCcEventPublisher } from "./cc-events";
 
+// Per-command Commander option shapes. Pin the permissive `opts: any`
+// default to the actual flag set so `opts.policy` etc. narrow.
+interface StartOptions {
+  policy: string;
+  foreground?: boolean;
+  natsUrl?: string;
+  natsToken?: string;
+  org?: string;
+}
+interface TestOptions {
+  policy: string;
+}
+
 // =============================================================================
 // Paths
 // =============================================================================
@@ -149,7 +162,7 @@ program
     "--org <org>",
     "Operator/org segment for published subjects (local.{org}.{type}). Falls back to env var GROVE_OPERATOR or NATS_ORG.",
   )
-  .action(async (options) => {
+  .action(async (options: StartOptions) => {
     if (!existsSync(options.policy)) {
       console.error(`Policy file not found: ${options.policy}`);
       console.error("Run the installer to create the default policy.");
@@ -201,7 +214,7 @@ program
         // relay's primary archival job. Log and continue JSONL-only.
         console.error(
           `cortex-relay: nats startup failed — continuing without bus publishing: ${
-            err instanceof Error ? err.message : err
+            err instanceof Error ? err.message : String(err)
           }`,
         );
         natsLink = undefined;
@@ -215,7 +228,7 @@ program
     writeFileSync(PID_FILE, String(process.pid));
 
     // Run retention sweep on startup (removes stale JSONL files)
-    runRetentionSweep();
+    void runRetentionSweep();
 
     console.log("cortex-relay: starting...");
     console.log(`  Policy: ${options.policy}`);
@@ -226,7 +239,7 @@ program
 
     // Watch and process
     const cleanup = watchRawEvents(RAW_DIR, (rawPath) => {
-      const filename = rawPath.split("/").pop()!;
+      const filename = rawPath.split("/").pop() ?? rawPath;
       const publishedPath = join(PUBLISHED_DIR, filename);
       const count = processor.processFile(rawPath, publishedPath);
       if (count > 0) {
@@ -248,7 +261,9 @@ program
     }, 5000);
 
     // Periodic retention sweep (every 6 hours)
-    const retentionInterval = setInterval(runRetentionSweep, 6 * 60 * 60 * 1000);
+    const retentionInterval = setInterval(() => {
+      void runRetentionSweep();
+    }, 6 * 60 * 60 * 1000);
 
     // Handle shutdown
     const shutdown = async () => {
@@ -261,7 +276,7 @@ program
           await natsLink.close();
         } catch (err) {
           console.error(
-            `cortex-relay: nats close error: ${err instanceof Error ? err.message : err}`,
+            `cortex-relay: nats close error: ${err instanceof Error ? err.message : String(err)}`,
           );
         }
       }
@@ -318,7 +333,7 @@ program
   .command("test <event-json>")
   .description("Test policy against an event JSON file or string")
   .option("--policy <path>", "Path to relay policy YAML", DEFAULT_POLICY)
-  .action((eventJson, options) => {
+  .action((eventJson: string, options: TestOptions) => {
     const policy = loadPolicy(options.policy);
 
     let raw: unknown;


### PR DESCRIPTION
## Summary

Targets `src/taps/cc-events/relay.ts` (22 errors). Three small clusters:

1. **Untyped Commander option blocks** (~15 errors). Both `start` and `test` `.action((options) => …)` had `options` typed as `any` by default; `options.policy`/`.natsUrl`/`.natsToken`/`.org` propagated `any` through every downstream access.
2. **Unsafe template-literal interpolations** of `err` — two sites used `err instanceof Error ? err.message : err`; the else branch produced `unknown` which `restrict-template-expressions` rejects.
3. **Floating promises** on `runRetentionSweep()` — two callsites (initial + setInterval) discarded a Promise.
4. **One non-null assertion** on `.split("/").pop()!`.

## Approach

- Added `StartOptions` + `TestOptions` interfaces matching the Commander flag set; pinned each `.action((opts: T) => …)` signature.
- Replaced `: err` template branch with `: String(err)` — same runtime stringification, satisfies the rule's intent.
- `void runRetentionSweep()` (one-shot) and `setInterval(() => { void runRetentionSweep(); }, ...)` make fire-and-forget explicit.
- Replaced `.split("/").pop()!` with `?? rawPath` — survives input with no `/` separator instead of crashing.

## Lint impact

- Repo-wide: **676 → 654 errors** (-22)
- `src/taps/cc-events/relay.ts`: **22 → 0 errors**

Rule-bucket drops:
| Δ | Rule |
|---|---|
| -10 | `no-unsafe-member-access` (50 → 40) |
| -3  | `no-unsafe-assignment` (30 → 27) |
| -3  | `no-unsafe-argument` (16 → 13) |
| -2  | `restrict-template-expressions` |
| -1  | `no-floating-promises` |
| -1  | `no-misused-promises` |
| -1  | `no-non-null-assertion` |
| -1  | `no-unsafe-call` |

## Test plan

- [x] `bunx tsc --noEmit` clean
- [x] `bun run lint:errors` reports 654 (was 676)
- [x] `bun test src/taps/` 179/179 pass

## Out of Scope

- Other ~654 errors. Next candidates:
| Errors | File |
|---|---|
| 63 | `src/cortex.ts` (dashboard wiring broken — needs cleanup) |
| 56 | `src/cli/cortex/commands/cloud.ts` |
| 46 | `src/bus/dispatch-handler.ts` |
| 38 | `src/surface/mc/api/handlers.ts` (3000-line file, diverse small fixes) |
| 26 | `src/adapters/discord/index.ts` |

## Refs

- cortex#152 (lint gate)
- cortex#154-#161 (sweeps #1-#8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)