### PR TITLE
chore(lint): sweep #10 — type config-loader Zod errors + drop dead conditions (-25)

### DIFF
--- a/src/common/config/loader.ts
+++ b/src/common/config/loader.ts
@@ -90,6 +90,25 @@ export interface LoadedConfig {
  * BotConfigSchema (legacy) rather than CortexConfigSchema's anti-field
  * rejections.
  */
+interface ZodLikeIssue {
+  path?: (string | number)[];
+  message: string;
+}
+interface ZodLikeError {
+  issues?: ZodLikeIssue[];
+  errors?: ZodLikeIssue[];
+}
+
+/**
+ * Runtime check for a Zod-shaped error. Zod v3 exposes `.errors`, Zod v4
+ * exposes `.issues`. Cortex's schemas straddle both — accept either.
+ */
+function isZodLikeError(err: unknown): err is ZodLikeError {
+  if (typeof err !== "object" || err === null) return false;
+  const e = err as { issues?: unknown; errors?: unknown };
+  return Array.isArray(e.issues) || Array.isArray(e.errors);
+}
+
 function isCortexShape(raw: Record<string, unknown>): boolean {
   return (
     raw.operator !== null &&
@@ -168,19 +187,27 @@ export function loadConfigWithAgents(path: string): LoadedConfig {
     isLegacyMode = true;
   }
 
-  // Aggregate discord/mattermost from networks into top-level arrays
+  // Aggregate discord/mattermost from networks into top-level arrays.
+  // Top-level `raw.discord` / `raw.mattermost` may be either a single
+  // object or an array — normalize to array, ignore everything else.
+  const rawDiscord = raw.discord;
+  const rawMattermost = raw.mattermost;
+  const topDiscord: unknown[] = Array.isArray(rawDiscord)
+    ? rawDiscord
+    : rawDiscord !== undefined && rawDiscord !== null
+      ? [rawDiscord]
+      : [];
+  const topMattermost: unknown[] = Array.isArray(rawMattermost)
+    ? rawMattermost
+    : rawMattermost !== undefined && rawMattermost !== null
+      ? [rawMattermost]
+      : [];
   const aggregatedDiscord = isLegacyMode
-    ? networks.flatMap(n => n.discord)
-    : [
-        ...(raw.discord ? (Array.isArray(raw.discord) ? raw.discord : [raw.discord]) : []),
-        ...networks.flatMap(n => n.discord),
-      ];
+    ? networks.flatMap((n) => n.discord)
+    : [...topDiscord, ...networks.flatMap((n) => n.discord)];
   const aggregatedMattermost = isLegacyMode
-    ? networks.flatMap(n => n.mattermost)
-    : [
-        ...(raw.mattermost ? (Array.isArray(raw.mattermost) ? raw.mattermost : [raw.mattermost]) : []),
-        ...networks.flatMap(n => n.mattermost),
-      ];
+    ? networks.flatMap((n) => n.mattermost)
+    : [...topMattermost, ...networks.flatMap((n) => n.mattermost)];
 
   const merged = {
     ...raw,
@@ -224,16 +251,25 @@ function loadCortexShape(
   // the operator-friendly migration message baked into CortexConfigSchema.
   const cortexConfig: CortexConfig = CortexConfigSchema.parse(raw);
 
-  const firstAgent = cortexConfig.agents[0]!;
+  // CortexConfigSchema guarantees `agents.min(1)`, so [0] is always defined
+  // at runtime; noUncheckedIndexedAccess still types it as possibly undefined.
+  const firstAgent = cortexConfig.agents[0];
+  if (firstAgent === undefined) {
+    throw new Error("invariant: agents schema enforced .min(1) but [0] missing");
+  }
 
   // Synthesize the BotConfig `agent:` singular from operator + first agent.
   // Downstream consumers that read `config.agent.name` get the first agent's
   // id; per-instance routing flows via `inlineAgents` so the multi-agent
   // case stays correct.
+  // `operator.id` and `operator.dataResidency` are non-optional after parse
+  // (required + default respectively), so the prior `!== undefined` guards
+  // were dead conditions. `discordId` and `mattermostId` are genuinely
+  // optional — keep the spread-on-truthy pattern there.
   const synthesizedAgent = {
     name: firstAgent.id,
     displayName: firstAgent.displayName,
-    ...(cortexConfig.operator.id !== undefined && { operatorId: cortexConfig.operator.id }),
+    operatorId: cortexConfig.operator.id,
     ...(cortexConfig.operator.displayName !== undefined && {
       operatorName: cortexConfig.operator.displayName,
     }),
@@ -243,9 +279,7 @@ function loadCortexShape(
     ...(cortexConfig.operator.mattermostId !== undefined && {
       operatorMattermostId: cortexConfig.operator.mattermostId,
     }),
-    ...(cortexConfig.operator.dataResidency !== undefined && {
-      dataResidency: cortexConfig.operator.dataResidency,
-    }),
+    dataResidency: cortexConfig.operator.dataResidency,
     personaFile: firstAgent.persona,
   };
 
@@ -531,16 +565,27 @@ function loadNetworkFiles(networksDir: string, explicit: boolean): NetworkFile[]
     try {
       raw = parseYaml(content);
     } catch (err) {
-      throw new Error(`Failed to parse network file ${filename}: ${err instanceof Error ? err.message : err}`);
+      throw new Error(
+        `Failed to parse network file ${filename}: ${err instanceof Error ? err.message : String(err)}`,
+        { cause: err },
+      );
     }
 
     let network: NetworkFile;
     try {
       network = NetworkFileSchema.parse(raw);
-    } catch (err: any) {
-      const issues = err.issues ?? err.errors ?? [];
-      const details = issues.map((i: any) => `  ${i.path?.join(".")}: ${i.message}`).join("\n");
-      throw new Error(`Validation error in ${filename}:\n${details || err.message}`);
+    } catch (err) {
+      // Zod errors expose either `.issues` (v4) or `.errors` (v3) — narrow
+      // via runtime feature-detection without `any`.
+      const zodIssues = isZodLikeError(err) ? (err.issues ?? err.errors ?? []) : [];
+      const details = zodIssues
+        .map((i) => `  ${i.path?.join(".") ?? "?"}: ${i.message}`)
+        .join("\n");
+      const message = err instanceof Error ? err.message : String(err);
+      throw new Error(
+        `Validation error in ${filename}:\n${details !== "" ? details : message}`,
+        { cause: err },
+      );
     }
 
     if (seenIds.has(network.id)) {
@@ -555,14 +600,14 @@ function loadNetworkFiles(networksDir: string, explicit: boolean): NetworkFile[]
 
 function hasLegacyCloudConfig(raw: Record<string, unknown>): boolean {
   const api = raw.api as Record<string, unknown> | undefined;
-  return !!(api?.endpoint && api?.apiKey);
+  return !!(api?.endpoint && api.apiKey);
 }
 
 function buildLegacyNetwork(raw: Record<string, unknown>): NetworkFile {
   const api = raw.api as Record<string, unknown>;
   const agent = raw.agent as Record<string, unknown> | undefined;
 
-  const operatorId = (api.operatorId || (agent ? agent.operatorId : undefined)) as string | undefined;
+  const operatorId = (api.operatorId ?? (agent ? agent.operatorId : undefined)) as string | undefined;
   if (!operatorId) {
     console.warn(
       "config-loader: no operatorId configured (api.operatorId or agent.operatorId). " +


### PR DESCRIPTION
## Summary

Targets `src/common/config/loader.ts` (25 errors). Three small clusters:

1. **Spread of `any` from raw YAML** (2 errors). `raw.discord` / `raw.mattermost` came back from `parseYaml` as `unknown` but were spread into arrays via `Array.isArray(raw.discord) ? raw.discord : [raw.discord]` — the spread inherited `any`-ish unsafety.
2. **Untyped Zod error narrowing** (~15 errors). Network-file parse loop did `catch (err: any) { err.issues ?? err.errors ?? []; .map((i: any) => …) }` — Zod v3 vs v4 expose validation issues under different field names so prior code reached for `any` to walk both.
3. **Dead `!== undefined` checks** in `loadCortexShape` synthesized agent (2 errors). `cortexConfig.operator.id` is required by schema, `dataResidency` has `.default("NZ")` — both are non-undefined after parse.
4. **Misc** — `!` non-null assertion on `agents[0]`, `||`→`??`, redundant `?.` after a truthy check, missing `cause:` in re-thrown error.

## Approach

- Normalized `raw.discord`/`raw.mattermost` upfront into typed `unknown[]` aggregates via explicit `Array.isArray` + nullish guards.
- Added `ZodLikeIssue` + `ZodLikeError` interfaces and `isZodLikeError(err): err is ZodLikeError` runtime narrower — accepts both `.issues` (v4) and `.errors` (v3) without `any`.
- Replaced `agents[0]!` with a runtime check that throws an invariant-violation error if Zod's `.min(1)` somehow got bypassed.
- Inlined `operatorId` and `dataResidency` directly into the synthesized agent object (was: spread on dead-truthy guards).
- Both re-thrown errors in network-file parse now carry `{ cause: err }` per `preserve-caught-error`. Template branches use `String(err)` instead of bare `err`.
- `hasLegacyCloudConfig`: `api?.apiKey` → `api.apiKey` (already inside `api?.endpoint && …` guard).
- `buildLegacyNetwork`: `||` → `??` for safer falsy coalescing (operatorId="" would have been treated as missing under `||`, preserved with `??`).

## Lint impact

- Repo-wide: **654 → 629 errors** (-25)
- `src/common/config/loader.ts`: **25 → 0 errors**

## Test plan

- [x] `bunx tsc --noEmit` clean
- [x] `bun run lint:errors` reports 629 (was 654)
- [x] `bun test src/common/` 409/409 pass

## Out of Scope

- Other ~629 errors. Next candidates: cortex.ts (63), cloud.ts (56), dispatch-handler.ts (46), handlers.ts (38), adapters/discord/index.ts (26).

## Refs

- cortex#152 (lint gate)
- cortex#154-#162 (sweeps #1-#9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)