### PR TITLE
chore(lint): sweep #17 — jsonl-reader replace require() with import (-10)

### DIFF
--- a/src/taps/cc-events/lib/jsonl-reader.ts
+++ b/src/taps/cc-events/lib/jsonl-reader.ts
@@ -3,7 +3,8 @@
  * Reads new lines from a JSONL file, tracking position for incremental reads.
  */
 
-import { readFileSync, statSync, existsSync } from "fs";
+import { readFileSync, readdirSync, statSync, existsSync } from "fs";
+import { join } from "path";
 import type { RawEvent } from "../hooks/lib/event-types";
 
 export class JsonlReader {
@@ -23,9 +24,7 @@ export class JsonlReader {
    */
   skipAllToEnd(dir: string): void {
     if (!existsSync(dir)) return;
-    const { readdirSync } = require("fs");
-    const { join } = require("path");
-    const files = readdirSync(dir).filter((f: string) => f.endsWith(".jsonl"));
+    const files = readdirSync(dir).filter((f) => f.endsWith(".jsonl"));
     for (const file of files) {
       this.skipToEnd(join(dir, file));
     }


### PR DESCRIPTION
2× CommonJS `require()` inside method → lifted to top-level `import`. **515 → 505 (-10)**. jsonl-reader: 10 → 0.