### PR TITLE
chore(lint): sweep #26 — three more small files batched (-21)

### DIFF
--- a/src/adapters/discord/event-formatter.ts
+++ b/src/adapters/discord/event-formatter.ts
@@ -8,6 +8,10 @@ import { POSTABLE_EVENTS } from "../../common/types/context";
 
 const MAX_SUMMARY_LENGTH = 400;
 
+function asString(v: unknown): string {
+  return typeof v === "string" ? v : "";
+}
+
 export function isPostableEvent(eventType: string): boolean {
   return (POSTABLE_EVENTS as readonly string[]).includes(eventType);
 }
@@ -34,19 +38,24 @@ export function formatEventForDiscord(event: PublishedEvent): string | null {
   const label = EVENT_LABELS[event.event_type] ?? event.event_type.split(".").pop();
 
   let detail = "";
-  if (event.payload.prompt_preview) {
+  const promptPreview = asString(event.payload.prompt_preview);
+  const summaryText = asString(event.payload.summary);
+  const pathText = asString(event.payload.path);
+  const activeTask = asString(event.payload.active_task);
+  const agentDescription = asString(event.payload.agent_description);
+  if (promptPreview) {
     // User input — show as quote
-    detail = `> ${String(event.payload.prompt_preview)}`;
-  } else if (event.payload.summary) {
-    detail = String(event.payload.summary);
-  } else if (event.payload.path) {
-    detail = `\`${event.payload.path}\``;
-  } else if (event.payload.active_task) {
+    detail = `> ${promptPreview}`;
+  } else if (summaryText) {
+    detail = summaryText;
+  } else if (pathText) {
+    detail = `\`${pathText}\``;
+  } else if (activeTask) {
     const summary = event.payload.todo_summary as { total?: number; completed?: number } | undefined;
     const progress = summary ? ` (${summary.completed ?? 0}/${summary.total ?? 0})` : "";
-    detail = `${event.payload.active_task}${progress}`;
-  } else if (event.payload.agent_description) {
-    detail = String(event.payload.agent_description);
+    detail = `${activeTask}${progress}`;
+  } else if (agentDescription) {
+    detail = agentDescription;
   }
 
   if (detail.length > MAX_SUMMARY_LENGTH) {

--- a/src/runner/message-parser.ts
+++ b/src/runner/message-parser.ts
@@ -36,15 +36,15 @@ const MAX_CONTEXT_DEPTH = 100;
  */
 export function parseMessageKeywords(
   content: string,
-  defaultDepth: number,
+  _defaultDepth: number,
 ): ParsedMessage {
   let cleaned = content;
   let contextDepth: number | undefined;
 
   // Extract context:N (can appear anywhere in the message)
-  const contextMatch = cleaned.match(CONTEXT_PATTERN);
-  if (contextMatch) {
-    contextDepth = Math.min(parseInt(contextMatch[1]!, 10), MAX_CONTEXT_DEPTH);
+  const contextMatch = CONTEXT_PATTERN.exec(cleaned);
+  if (contextMatch?.[1] !== undefined) {
+    contextDepth = Math.min(parseInt(contextMatch[1], 10), MAX_CONTEXT_DEPTH);
     cleaned = cleaned.replace(contextMatch[0], " ").replace(/\s+/g, " ").trim();
   }
 
@@ -54,9 +54,9 @@ export function parseMessageKeywords(
   }
 
   // Check for /learning command
-  const learningMatch = cleaned.trim().match(/^\/learning\s+(.*)/i);
-  if (learningMatch) {
-    const args = learningMatch[1]!.trim();
+  const learningMatch = /^\/learning\s+(.*)/i.exec(cleaned.trim());
+  if (learningMatch?.[1] !== undefined) {
+    const args = learningMatch[1].trim();
 
     // /learning list
     if (/^list$/i.test(args)) {
@@ -69,7 +69,7 @@ export function parseMessageKeywords(
     }
 
     // /learning remove <id>
-    const removeMatch = args.match(/^remove\s+(\S+)/i);
+    const removeMatch = /^remove\s+(\S+)/i.exec(args);
     if (removeMatch) {
       return {
         mode: "learning",
@@ -80,7 +80,7 @@ export function parseMessageKeywords(
     }
 
     // /learning search <query>
-    const searchMatch = args.match(/^search\s+(.+)/i);
+    const searchMatch = /^search\s+(.+)/i.exec(args);
     if (searchMatch) {
       return {
         mode: "learning",

--- a/src/surface/mc/session/endpoint-resolver.ts
+++ b/src/surface/mc/session/endpoint-resolver.ts
@@ -7,7 +7,6 @@
 
 import type { Database } from "bun:sqlite";
 import type { Subprocess } from "bun";
-import type { EndpointKind } from "../types";
 import type { SessionEndpoint, ManagedProcess } from "./types";
 import type { StreamJsonContentBlock } from "./stream-json";
 import { NotControllable, SessionConflict, SessionClosed } from "./types";
@@ -97,8 +96,7 @@ export function spawnControlledSession(
   if (existing) {
     const existingManaged = processManager.get(existing.id);
     if (
-      existingManaged &&
-      existingManaged.proc.exitCode === null &&
+      existingManaged?.proc.exitCode === null &&
       !existingManaged.closing
     ) {
       // Healthy active session — return its endpoint. Idempotent spawn.
@@ -178,11 +176,11 @@ export function spawnControlledSession(
       processManager.remove(session.id);
       endSession(db, session.id);
     })
-    .catch((err) => {
+    .catch((err: unknown) => {
       // endSession / processManager.remove should never throw, but if they do
       // (e.g. DB closed mid-shutdown) we must not leave an unhandled rejection.
       process.stderr.write(
-        `[endpoint] auto-exit cleanup failed for ${session.id}: ${(err as Error).message}\n`
+        `[endpoint] auto-exit cleanup failed for ${session.id}: ${err instanceof Error ? err.message : String(err)}\n`
       );
     });
 
@@ -201,7 +199,7 @@ export function createControlledEndpoint(
   sessionId: string
 ): SessionEndpoint {
   return {
-    kind: "local.process.controlled" as EndpointKind,
+    kind: "local.process.controlled",
     sessionId,
 
     // Explicit annotation matches SessionEndpoint.write; TS method-parameter
@@ -229,7 +227,7 @@ export function createControlledEndpoint(
       if (stdin === undefined || typeof stdin === "number") {
         throw new SessionClosed(sessionId, managed.proc.exitCode);
       }
-      stdin.write(framed);
+      void stdin.write(framed);
       // NOTE: FileSink backpressure (Promise return from write) is a Phase B
       // concern — Phase A dispatches small operator messages only. When the
       // dispatcher lands, switch to an async write path that awaits
@@ -248,24 +246,29 @@ export function createControlledEndpoint(
           managed.proc.kill("SIGTERM");
         } catch (err) {
           process.stderr.write(
-            `[endpoint] SIGTERM failed for ${sessionId}: ${(err as Error).message}\n`
+            `[endpoint] SIGTERM failed for ${sessionId}: ${err instanceof Error ? err.message : String(err)}\n`
           );
         }
 
         // Wait graceful, escalate to SIGKILL if needed.
         const result = await Promise.race([
           managed.proc.exited.then(() => "exited" as const),
-          new Promise<"timeout">((r) =>
-            setTimeout(() => r("timeout"), CLOSE_GRACEFUL_TIMEOUT_MS)
-          ),
+          new Promise<"timeout">((r) => {
+            setTimeout(() => { r("timeout"); }, CLOSE_GRACEFUL_TIMEOUT_MS);
+          }),
         ]);
 
+        // managed.proc.exitCode is `number | null`; TS narrowed it to null
+        // earlier (line 246's `if (managed.proc.exitCode === null)`), but
+        // the child can exit during the SIGTERM grace race — the re-check
+        // is load-bearing despite the literal-comparison appearing dead.
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
         if (result === "timeout" && managed.proc.exitCode === null) {
           try {
             managed.proc.kill("SIGKILL");
           } catch (err) {
             process.stderr.write(
-              `[endpoint] SIGKILL failed for ${sessionId}: ${(err as Error).message}\n`
+              `[endpoint] SIGKILL failed for ${sessionId}: ${err instanceof Error ? err.message : String(err)}\n`
             );
           }
           await managed.proc.exited;
@@ -281,7 +284,7 @@ export function createControlledEndpoint(
           await managed.dispatcherDone;
         } catch (err) {
           process.stderr.write(
-            `[endpoint] dispatcher drain failed for ${sessionId}: ${(err as Error).message}\n`
+            `[endpoint] dispatcher drain failed for ${sessionId}: ${err instanceof Error ? err.message : String(err)}\n`
           );
         }
       }
@@ -294,7 +297,7 @@ export function createControlledEndpoint(
 
 function createObservedEndpoint(sessionId: string): SessionEndpoint {
   return {
-    kind: "local.observed" as EndpointKind,
+    kind: "local.observed",
     sessionId,
 
     // Signature mirrors SessionEndpoint.write (string | StreamJsonContentBlock[]).


### PR DESCRIPTION
event-formatter (7), message-parser (7), endpoint-resolver (7). `asString` helper, regexp-exec swaps, drop literal-cast on discriminated unions, typed catch callbacks, brace-wrap setTimeout arrows. **246 → 225 (-21)**. 1530 tests pass.