### PR TITLE
chore(lint): sweep #27 — 4-file batch: migrate-config + subscription test + github-fetch (-27)

### DIFF
--- a/src/bus/nats/__tests__/subscription.test.ts
+++ b/src/bus/nats/__tests__/subscription.test.ts
@@ -17,7 +17,7 @@ import { NatsLink } from "../connection";
  * (until drained).
  */
 function makeFakeSubscription() {
-  type Msg = { subject: string; data: Uint8Array };
+  interface Msg { subject: string; data: Uint8Array }
   const queue: Msg[] = [];
   let waiter: ((m: Msg | null) => void) | null = null;
   let drained = false;
@@ -141,7 +141,7 @@ async function makeLink() {
   const link = await NatsLink.connect({
     url: "nats://localhost:4222",
     name: "subscription-test",
-    connectImpl: (async () => fake.nc) as never,
+    connectImpl: (async () => fake.nc),
   });
   return { link, fake };
 }
@@ -231,7 +231,7 @@ describe("NatsSubscription", () => {
       onMessage: () => {},
     });
     expect(fake.subscribe).toHaveBeenCalledTimes(1);
-    fake.pushStatus({ type: Events.Reconnect, data: "nats://localhost:4222" } as Status);
+    fake.pushStatus({ type: Events.Reconnect, data: "nats://localhost:4222" });
     await flushMicrotasks(8);
     expect(fake.subscribe).toHaveBeenCalledTimes(2);
     expect(fake.subscribe.mock.calls[1]?.[0]).toBe("local.acme.>");
@@ -260,7 +260,7 @@ describe("NatsSubscription", () => {
         received.push(subject);
       },
     });
-    fake.pushStatus({ type: Events.Reconnect, data: "nats://localhost:4222" } as Status);
+    fake.pushStatus({ type: Events.Reconnect, data: "nats://localhost:4222" });
     await flushMicrotasks(8);
     // Old subscription (subAt 0) — pushing into it must NOT reach the
     // active onMessage since the consume loop reading it has exited.
@@ -280,7 +280,7 @@ describe("NatsSubscription", () => {
         received.push(subject);
       },
     });
-    fake.pushStatus({ type: Events.Reconnect, data: "nats://localhost:4222" } as Status);
+    fake.pushStatus({ type: Events.Reconnect, data: "nats://localhost:4222" });
     await flushMicrotasks(8);
     // New subscription (subAt 1) — pushing into it MUST reach onMessage.
     fake.subAt(1)!.push("local.acme.new", new TextEncoder().encode("fresh"));
@@ -325,7 +325,7 @@ describe("NatsSubscription", () => {
       callCount++;
       if (callCount === 2) throw new Error("auth revoked between disconnect and reconnect");
       return realSubscribe(...args);
-    }) as typeof realSubscribe;
+    });
 
     const errors: string[] = [];
     const infos: string[] = [];
@@ -342,7 +342,7 @@ describe("NatsSubscription", () => {
       pattern: "local.acme.>",
       onMessage: () => {},
     });
-    fake.pushStatus({ type: Events.Reconnect, data: "nats://localhost:4222" } as Status);
+    fake.pushStatus({ type: Events.Reconnect, data: "nats://localhost:4222" });
     await flushMicrotasks(8);
 
     console.error = origError;

--- a/src/cli/cortex/commands/__tests__/migrate-config.test.ts
+++ b/src/cli/cortex/commands/__tests__/migrate-config.test.ts
@@ -193,7 +193,7 @@ describe("convertBotYaml — trustedAgentBots", () => {
       discord: [{ token: "t", guildId: "1", agentChannelId: "2", logChannelId: "3" }],
       trustedAgentBots: [
         // production shape — id + role only, no symbolic name
-        ({ id: "1487180524542890144", role: "agent-restricted" } as unknown) as LegacyBotYaml["trustedAgentBots"] extends (infer U)[] | undefined ? U : never,
+        { id: "1487180524542890144", role: "agent-restricted" },
       ],
     };
     const result = convertBotYaml(legacy);
@@ -210,7 +210,7 @@ describe("convertBotYaml — trustedAgentBots", () => {
       agent: { name: "ivy", displayName: "Ivy", operatorId: "jc" },
       discord: [{ token: "t", guildId: "1", agentChannelId: "2", logChannelId: "3" }],
       trustedAgentBots: [
-        ({ discordId: "9999", role: "agent-restricted" } as unknown) as LegacyBotYaml["trustedAgentBots"] extends (infer U)[] | undefined ? U : never,
+        { discordId: "9999", role: "agent-restricted" },
       ],
     };
     const result = convertBotYaml(legacy);
@@ -224,9 +224,9 @@ describe("convertBotYaml — trustedAgentBots", () => {
       discord: [{ token: "t", guildId: "1", agentChannelId: "2", logChannelId: "3" }],
       trustedAgentBots: [
         { name: "luna" },
-        ({ id: "abc", role: "agent-restricted" } as unknown) as LegacyBotYaml["trustedAgentBots"] extends (infer U)[] | undefined ? U : never,
+        { id: "abc", role: "agent-restricted" },
         { name: "holly" },
-        ({ id: "def" } as unknown) as LegacyBotYaml["trustedAgentBots"] extends (infer U)[] | undefined ? U : never,
+        { id: "def" },
       ],
     };
     const result = convertBotYaml(legacy);
@@ -343,7 +343,7 @@ describe("convertBotYaml — persona-file validation", () => {
     const result = convertBotYaml(legacy, {});
     // file-existence warning suppressed without a configDir
     const personaWarn = result.warnings.find(
-      (w) => w.field === "agents[ghost].persona" && /not found/.test(w.message),
+      (w) => w.field === "agents[ghost].persona" && w.message.includes("not found"),
     );
     expect(personaWarn).toBeUndefined();
   });
@@ -402,7 +402,7 @@ describe("convertBotYaml — full fixture", () => {
     const dash = result.cortex.renderers.find((r) => r.kind === "dashboard");
     expect(dash).toBeDefined();
     expect(dash!.kind).toBe("dashboard");
-    if (dash && dash.kind === "dashboard") {
+    if (dash?.kind === "dashboard") {
       expect(dash.port).toBe(8767);
     }
     expect(result.warnings.some((w) => w.field === "api")).toBe(true);
@@ -641,7 +641,7 @@ describe("convertBotYaml — schema-sourced defaults", () => {
     const legacy: LegacyBotYaml = {
       agent: { name: "luna", displayName: "Luna", personaFile: "./personas/luna.md" },
       discord: [{ token: "t", guildId: "1", agentChannelId: "2", logChannelId: "3" }],
-      renderers: [{ kind: "dashbord" } as unknown],
+      renderers: [{ kind: "dashbord" }],
     };
     expect(() => convertBotYaml(legacy, {})).toThrow();
   });

--- a/src/cli/cortex/commands/migrate-config-lib.ts
+++ b/src/cli/cortex/commands/migrate-config-lib.ts
@@ -312,6 +312,7 @@ function resolvePersona(
   configDir: string | undefined,
   warnings: ConversionWarning[],
 ): string {
+  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   const personaPath = legacyPersonaFile?.trim() || `./personas/${agentId}.md`;
 
   if (configDir) {
@@ -346,7 +347,8 @@ function buildTrustList(
 ): string[] {
   const out: string[] = [];
   for (let i = 0; i < legacyTrust.length; i++) {
-    const t = legacyTrust[i]!;
+    const t = legacyTrust[i];
+    if (!t) continue;
     // Production grove-v2 carries trustedAgentBots entries with only a
     // Discord/Mattermost id and no symbolic agent name. Surface those as
     // warnings (operator hand-maps post-migration) rather than crashing.
@@ -548,11 +550,9 @@ function buildAgents(
         });
       }
     }
-    if (!id) {
-      // Fallback: agent.name (only safe for the first variant — subsequent
-      // variants need a distinct id, hence the numeric suffix at index ≥1).
-      id = i === 0 ? baseId : `${baseId}-${i + 1}`;
-    }
+    // Fallback: agent.name (only safe for the first variant — subsequent
+    // variants need a distinct id, hence the numeric suffix at index ≥1).
+    id ??= i === 0 ? baseId : `${baseId}-${i + 1}`;
     // Last-resort: a role-hint produced an id that collides with one
     // already claimed by an earlier adapter. Fall through to numeric.
     // cortex#106 item 1: drop the off-by-one — `variantIds.length` is the
@@ -584,7 +584,8 @@ function buildAgents(
 
   const agents: CortexConfig["agents"] = [];
   for (let i = 0; i < variantCount; i++) {
-    const variantId = variantIds[i]!;
+    const variantId = variantIds[i];
+    if (!variantId) continue;
     const presence: CortexConfig["agents"][number]["presence"] = {};
     const d = discordInstances[i];
     const m = mattermostInstances[i];
@@ -643,7 +644,7 @@ function buildRenderers(legacy: LegacyBotYaml, warnings: ConversionWarning[]): C
     }
   }
 
-  if (legacy.api && legacy.api.enabled === true) {
+  if (legacy.api?.enabled === true) {
     const port = typeof legacy.api.port === "number" ? legacy.api.port : 8767;
     renderers.push(RendererSchema.parse({ kind: "dashboard", port }));
     warnings.push({
@@ -672,12 +673,17 @@ export function convertBotYaml(
   legacy: LegacyBotYaml,
   opts: ConvertOptions = {},
 ): ConversionResult {
+  // TS narrows `legacy: LegacyBotYaml` to non-null, but the function is a
+  // public API surface and callers may hand in raw YAML parse output;
+  // runtime defence is load-bearing.
+  /* eslint-disable @typescript-eslint/no-unnecessary-condition */
   if (!legacy || typeof legacy !== "object") {
     throw new Error("input is not an object");
   }
   if (!legacy.agent || typeof legacy.agent !== "object") {
     throw new Error("bot.yaml missing required `agent:` block");
   }
+  /* eslint-enable @typescript-eslint/no-unnecessary-condition */
   if (!legacy.agent.name || typeof legacy.agent.name !== "string") {
     throw new Error("bot.yaml missing required `agent.name`");
   }

--- a/src/surface/mc/api/github-fetch.ts
+++ b/src/surface/mc/api/github-fetch.ts
@@ -160,6 +160,11 @@ export async function fetchIssueOrPr(
     exitCode = code;
   } catch (err) {
     clearTimeout(timer);
+    // sigkillTimer + timedOut are nullable/false at the start; the rule
+    // sees them as always-falsy because the only assignments happen
+    // inside callbacks the executor scheduled. Real runtime updates fire
+    // post-timeout — these guards are load-bearing.
+    /* eslint-disable @typescript-eslint/no-unnecessary-condition */
     if (sigkillTimer) clearTimeout(sigkillTimer);
     if (timedOut) {
       return {
@@ -167,12 +172,14 @@ export async function fetchIssueOrPr(
         message: "GitHub took too long to respond. Try again.",
       };
     }
+    /* eslint-enable @typescript-eslint/no-unnecessary-condition */
     return {
       kind: "spawn_failed",
-      message: `gh CLI failed: ${(err as Error).message}`,
+      message: `gh CLI failed: ${err instanceof Error ? err.message : String(err)}`,
     };
   }
   clearTimeout(timer);
+  /* eslint-disable @typescript-eslint/no-unnecessary-condition */
   if (sigkillTimer) clearTimeout(sigkillTimer);
 
   if (timedOut) {
@@ -181,6 +188,7 @@ export async function fetchIssueOrPr(
       message: "GitHub took too long to respond. Try again.",
     };
   }
+  /* eslint-enable @typescript-eslint/no-unnecessary-condition */
 
   if (exitCode !== 0) {
     // Map gh's common stderr shapes to kinds.
@@ -253,7 +261,7 @@ export async function fetchIssueOrPr(
   const labels: string[] = Array.isArray(raw.labels)
     ? raw.labels
         .map((l) =>
-          typeof l === "string" ? l : typeof l?.name === "string" ? l.name : null
+          typeof l === "string" ? l : typeof l.name === "string" ? l.name : null
         )
         .filter((s): s is string => s !== null)
     : [];
@@ -277,6 +285,11 @@ export async function fetchIssueOrPr(
 export function isGitHubFetchError(
   x: GitHubIssueOrPr | GitHubFetchError
 ): x is GitHubFetchError {
+  // TS sees `kind` as non-undefined on the GitHubFetchError branch (literal
+  // union) — but isGitHubFetchError is the runtime narrower for unions
+  // where TS can't yet prove the discriminant. Suppress the dead-condition
+  // warning since the check IS the type guard.
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   return (x as GitHubFetchError).kind !== undefined;
 }
 


### PR DESCRIPTION
Scoped auto-fix wave for no-unnecessary-type-assertion (12), rest manual: type→interface, prefer-includes, ??= shorthand, optional-chain collapse, load-bearing condition suppressions for callback-set flags. **225 → 198 (-27)**. 1694/1694 pass.