### PR TITLE
chore(lint): sweep #28 — 6-file mid-tier batch (-27)

### DIFF
--- a/src/cli/cortex/commands/creds.ts
+++ b/src/cli/cortex/commands/creds.ts
@@ -98,6 +98,9 @@ export type ArcErrorCode =
 interface ArcEnvelopeError {
   schema: typeof ARC_NATS_SCHEMA_V1;
   ok: false;
+  // ArcErrorCode literal union widens to `string` to allow forward-compat
+  // codes from arc; the literal members document the known set.
+  // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
   error: { code: ArcErrorCode | string; message: string };
 }
 
@@ -249,13 +252,13 @@ export function runCredsList(args: ParsedCredsArgs): ExitResult {
     // id = filename stem before the FIRST dot. `echo.creds` → `echo`,
     // `my.agent.creds` → `my` (`my.agent` would fail the regex anyway).
     // Symlinks are skipped (lstatSync above).
-    const id = filename.split(".")[0]!;
+    const id = filename.split(".")[0] ?? "";
     if (!AGENT_ID_REGEX.test(id)) {
       skippedMalformed.push(filename);
       continue;
     }
     if (seenIds.has(id)) {
-      skippedColliding.push({ id, first: seenIds.get(id)!, second: filename });
+      skippedColliding.push({ id, first: seenIds.get(id) ?? "", second: filename });
       continue;
     }
     seenIds.set(id, filename);
@@ -519,7 +522,7 @@ function formatArcResult(
     };
   }
 
-  if (call.envelope.ok === false) {
+  if (!call.envelope.ok) {
     return formatArcError(call.envelope, args, subcommand);
   }
   return formatArcSuccess(call.envelope, args, subcommand);
@@ -609,7 +612,7 @@ function formatArcSuccess(
   }
   if (subcommand === "revoke" && "revokedPubKey" in env && !("newPubKey" in env)) {
     lines.push(`  revoked_pub_key: ${env.revokedPubKey}`);
-    lines.push(`  creds_file_deleted: ${(env as ArcEnvelopeRemoveBot).credsFileDeleted}`);
+    lines.push(`  creds_file_deleted: ${env.credsFileDeleted}`);
   }
   return { exitCode: 0, stdout: lines.join("\n") + "\n", stderr: "" };
 }

--- a/src/renderers/dashboard.ts
+++ b/src/renderers/dashboard.ts
@@ -59,6 +59,9 @@ export class DashboardRenderer implements Renderer {
     this.visibility = config.visibility;
   }
 
+  // Renderer interface contract — both methods MUST be Promise<void>.
+  // No I/O today, but signature stays for future Mission Control wiring.
+  /* eslint-disable @typescript-eslint/require-await */
   async start(): Promise<void> {
     // Buffer is already empty + bounded; no I/O to perform. The lifecycle
     // hook is here for symmetry — Mission Control integration at MIG-7.13
@@ -71,6 +74,7 @@ export class DashboardRenderer implements Renderer {
     // Tests rely on this for clean per-test isolation.
     this.buffer = [];
   }
+  /* eslint-enable @typescript-eslint/require-await */
 
   get surfaceConfig(): SurfaceAdapter {
     return {
@@ -86,6 +90,7 @@ export class DashboardRenderer implements Renderer {
     };
   }
 
+  // eslint-disable-next-line @typescript-eslint/require-await
   async render(envelope: Envelope, _signal?: AbortSignal): Promise<void> {
     // Renderer contract §2: never throw. The push/shift are infallible,
     // but the try-catch + null guard are defense-in-depth so a future
@@ -97,6 +102,9 @@ export class DashboardRenderer implements Renderer {
       // dispatch, but a malformed value sneaking through MUST NOT
       // corrupt the buffer + leak into Mission Control's projection
       // pipeline via getRecent(). Silently drop instead.
+      // Defensive null/object check guards against future malformed input
+      // even though TS narrows it. Suppress dead-condition on this surface.
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       if (envelope === null || typeof envelope !== "object") return;
       this.buffer.push(envelope);
       if (this.buffer.length > this.bufferSize) {
@@ -110,8 +118,8 @@ export class DashboardRenderer implements Renderer {
       }
     } catch (err) {
       console.warn(
-        `dashboard-renderer: render() swallowed an error while buffering envelope ${envelope?.id ?? "<null>"}:`,
-        err instanceof Error ? err.message : err,
+        `dashboard-renderer: render() swallowed an error while buffering envelope ${envelope.id}:`,
+        err instanceof Error ? err.message : String(err),
       );
     }
   }

--- a/src/runner/cc-session.ts
+++ b/src/runner/cc-session.ts
@@ -146,10 +146,10 @@ export class CCSession extends EventEmitter {
       this.stdoutDone = this.pipeStdout();
 
       // Wire stderr (for error detection)
-      this.pipeStderr();
+      void this.pipeStderr();
 
       // Wire exit (waits for stdout drain before emitting "exit")
-      this.wireExit();
+      void this.wireExit();
     } catch (error) {
       const err = error instanceof Error ? error : new Error(String(error));
       this.emit("error", err);
@@ -258,6 +258,7 @@ export class CCSession extends EventEmitter {
     const decoder = new TextDecoder();
 
     try {
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       while (true) {
         const { done, value } = await reader.read();
         if (done) break;
@@ -273,7 +274,7 @@ export class CCSession extends EventEmitter {
       // Flush any remaining buffer
       const remaining = this.lineBuffer.flush();
       if (remaining) this.processLine(remaining);
-    } catch (err) {
+    } catch (_err) {
       // Stream closed — expected on process exit
     }
   }
@@ -288,13 +289,14 @@ export class CCSession extends EventEmitter {
     const chunks: string[] = [];
 
     try {
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       while (true) {
         const { done, value } = await reader.read();
         if (done) break;
         chunks.push(decoder.decode(value, { stream: true }));
       }
     } catch (err) {
-      console.warn("cc-session: stderr stream closed:", err instanceof Error ? err.message : err);
+      console.warn("cc-session: stderr stream closed:", err instanceof Error ? err.message : String(err));
     }
 
     const stderrText = chunks.join("");

--- a/src/surface/mc/db/init.ts
+++ b/src/surface/mc/db/init.ts
@@ -17,11 +17,11 @@ export function initDatabase(dbPath: string): Database {
   mkdirSync(dirname(dbPath), { recursive: true });
 
   const db = new Database(dbPath, { create: true });
-  db.exec("PRAGMA journal_mode = WAL");
-  db.exec("PRAGMA foreign_keys = ON");
+  db.run("PRAGMA journal_mode = WAL");
+  db.run("PRAGMA foreign_keys = ON");
 
   for (const sql of SCHEMA_SQL) {
-    db.exec(sql);
+    db.run(sql);
   }
 
   // F-13 — additive ALTERs guarded against re-application. SQLite has no
@@ -34,10 +34,10 @@ export function initDatabase(dbPath: string): Database {
       .query(`SELECT 1 FROM pragma_table_info(?) WHERE name = ?`)
       .get(m.table, m.column);
     if (!present) {
-      db.exec(m.ddl);
+      db.run(m.ddl);
     }
     if (m.post) {
-      for (const sql of m.post) db.exec(sql);
+      for (const sql of m.post) db.run(sql);
     }
   }
 

--- a/src/taps/cc-events/cloud-publisher.ts
+++ b/src/taps/cc-events/cloud-publisher.ts
@@ -23,7 +23,7 @@
  */
 
 import type { PublishedEvent } from "./hooks/lib/event-types";
-import type { NetworkResolver, NetworkConfig } from "../../common/types/config";
+import type { NetworkResolver } from "../../common/types/config";
 import { fetchWithTimeout } from "../../common/timeout";
 
 export interface CloudPublisherConfig {
@@ -55,7 +55,7 @@ export class CloudPublisher {
     this.retryBaseMs = config.retryBaseMs ?? 1000;
 
     this.interval = setInterval(() => {
-      this.flushInternal();
+      void this.flushInternal();
     }, this.batchIntervalMs);
   }
 
@@ -79,7 +79,7 @@ export class CloudPublisher {
     }
 
     if (this.buffer.length >= this.batchSizeLimit) {
-      this.flushInternal();
+      void this.flushInternal();
     }
   }
 
@@ -138,7 +138,7 @@ export class CloudPublisher {
         }
       } catch (err) {
         console.error(
-          `cloud-publisher: endpoint UNREACHABLE for network "${networkId}" (${url}): ${err instanceof Error ? err.message : err}`,
+          `cloud-publisher: endpoint UNREACHABLE for network "${networkId}" (${url}): ${err instanceof Error ? err.message : String(err)}`,
         );
       }
     }
@@ -173,7 +173,8 @@ export class CloudPublisher {
       if (!eventsByNetwork.has(networkId)) {
         eventsByNetwork.set(networkId, []);
       }
-      eventsByNetwork.get(networkId)!.push(event);
+      const bucket = eventsByNetwork.get(networkId);
+      if (bucket) bucket.push(event);
     }
 
     // Send each network's batch separately

--- a/src/taps/gh-webhook-receiver/server.ts
+++ b/src/taps/gh-webhook-receiver/server.ts
@@ -255,7 +255,7 @@ export function startGithubWebhookReceiver(
       //    only fail here after auth has passed.
       let payload: Record<string, unknown>;
       try {
-        const parsed = JSON.parse(body);
+        const parsed: unknown = JSON.parse(body);
         if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
           return new Response("invalid json", { status: 400 });
         }
@@ -318,11 +318,11 @@ export function startGithubWebhookReceiver(
     port,
     stop: () => {
       try {
-        server.stop();
+        void server.stop();
       } catch (err) {
         console.error(
           "github-webhook-receiver: server stop error:",
-          err instanceof Error ? err.message : err,
+          err instanceof Error ? err.message : String(err),
         );
       }
     },


### PR DESCRIPTION
Six 5-error files: gh-webhook server, cloud-publisher, db/init (deprecated exec→run), cc-session, dashboard renderer (require-await suppressions), creds CLI. **198 → 171 (-27)**. 2743/2743 pass.