### PR TITLE
chore(lint): sweep #29 — 5-file batch: channel-context + mattermost + nats + policy-schema (-20)

### DIFF
--- a/src/adapters/discord/channel-context.ts
+++ b/src/adapters/discord/channel-context.ts
@@ -35,10 +35,10 @@ export function resolveChannelContext(
 ): ChannelContext {
   const empty: ChannelContext = { repo: null, repoShort: null, entityType: null, entityRef: null };
 
-  if (!repos || repos.length === 0) return empty;
+  if (repos.length === 0) return empty;
 
   for (const fullRepo of repos) {
-    const short = fullRepo.split("/").pop()!;
+    const short = fullRepo.split("/").pop() ?? fullRepo;
     if (channelName !== short) continue;
 
     if (!threadName) {
@@ -53,18 +53,18 @@ export function resolveChannelContext(
 
     const rest = threadName.slice(prefix.length);
 
-    const issueMatch = rest.match(/^issue\/(\d+)$/);
+    const issueMatch = /^issue\/(\d+)$/.exec(rest);
     if (issueMatch) {
       return { repo: fullRepo, repoShort: short, entityType: "issue", entityRef: issueMatch[1] ?? null };
     }
 
-    const prMatch = rest.match(/^pr\/(\d+)$/);
+    const prMatch = /^pr\/(\d+)$/.exec(rest);
     if (prMatch) {
       return { repo: fullRepo, repoShort: short, entityType: "pr", entityRef: prMatch[1] ?? null };
     }
 
     // Feature ID patterns: g-204, f-007, i-400, dd-49
-    const featureMatch = rest.match(/^(g|f|i|dd)-(\d+)$/i);
+    const featureMatch = /^(g|f|i|dd)-(\d+)$/i.exec(rest);
     if (featureMatch) {
       return { repo: fullRepo, repoShort: short, entityType: "feature", entityRef: rest };
     }

--- a/src/adapters/mattermost/index.ts
+++ b/src/adapters/mattermost/index.ts
@@ -113,6 +113,10 @@ export class MattermostAdapter implements PlatformAdapter {
     }
   }
 
+  // PlatformAdapter contract — start/stop/clearProgress/createThread MUST be
+  // Promise<void>. Mattermost's polling loop and per-channel state mutations
+  // are sync today; suppress require-await for the interface conformance.
+  /* eslint-disable @typescript-eslint/require-await */
   async start(onMessage: (msg: InboundMessage) => Promise<void>): Promise<void> {
     const { stop } = createMattermostPoller({
       agentName: this.agent.id,
@@ -208,7 +212,9 @@ export class MattermostAdapter implements PlatformAdapter {
     console.log(`mattermost-adapter[${this.instanceId}]: config updated`);
   }
 
-  async fetchContext(msg: InboundMessage, depth: number): Promise<ContextMessage[]> {
+  /* eslint-enable @typescript-eslint/require-await */
+
+  async fetchContext(msg: InboundMessage, _depth: number): Promise<ContextMessage[]> {
     const mmMsg = msg._native as MattermostInboundMessage | undefined;
     if (!mmMsg) return [];
 
@@ -286,12 +292,14 @@ export class MattermostAdapter implements PlatformAdapter {
     );
   }
 
+  // eslint-disable-next-line @typescript-eslint/require-await
   async clearProgress(target: ResponseTarget): Promise<void> {
     const key = target.threadId ?? target.channelId;
     this.progressSent.delete(key);
     // Mattermost: no easy delete — leave the single progress message
   }
 
+  // eslint-disable-next-line @typescript-eslint/require-await
   async createThread(msg: InboundMessage, _name: string): Promise<ResponseTarget> {
     // Mattermost threading: reply to the original post (rootId)
     const mmMsg = msg._native as MattermostInboundMessage | undefined;

--- a/src/bus/nats/__tests__/connection.test.ts
+++ b/src/bus/nats/__tests__/connection.test.ts
@@ -45,7 +45,7 @@ function makeFakeConnection() {
   const statusIterator = (async function* () {
     while (true) {
       const next = await new Promise<{ type: string; data: unknown } | null>((resolve) => {
-        pushStatus = resolve as (s: { type: string; data: unknown }) => void;
+        pushStatus = resolve;
         closeStatus = () => resolve(null);
       });
       if (next === null) return;
@@ -146,7 +146,7 @@ describe("NatsLink", () => {
     const link = await NatsLink.connect({
       url: "nats://localhost:4222",
       name: "test-link",
-      connectImpl: connectImpl as never,
+      connectImpl,
     });
     expect(link.name).toBe("test-link");
     expect(link.raw).toBe(fake.nc);
@@ -230,7 +230,7 @@ describe("NatsLink", () => {
       throw new Error("ECONNREFUSED");
     });
     await expect(
-      NatsLink.connect({ url: "nats://nowhere", connectImpl: failing as never }),
+      NatsLink.connect({ url: "nats://nowhere", connectImpl: failing }),
     ).rejects.toThrow(/ECONNREFUSED/);
   });
 
@@ -306,7 +306,7 @@ describe("NatsLink", () => {
       const link = await NatsLink.connect({
         url: "nats://localhost:4222",
         credsPath: credsFile,
-        connectImpl: connectImpl as never,
+        connectImpl,
       });
       const opts = capturedOpts[0]!;
       expect(typeof opts.authenticator).toBe("function");
@@ -350,7 +350,7 @@ describe("NatsLink", () => {
         name: "creds-vs-token",
         token: "ignored-token-value",
         credsPath: credsFile,
-        connectImpl: connectImpl as never,
+        connectImpl,
       });
       expect(consoleSpy.warn).toHaveBeenCalled();
       const warnMsg = String(consoleSpy.warn.mock.calls[0]?.[0] ?? "");

--- a/src/bus/nats/connection.ts
+++ b/src/bus/nats/connection.ts
@@ -167,19 +167,18 @@ export class NatsLink {
     try {
       await Promise.race([
         this.raw.drain(),
-        new Promise<void>((_, reject) =>
-          setTimeout(
-            () => reject(new Error(`drain timed out after ${drainTimeoutMs}ms`)),
-            drainTimeoutMs,
-          ),
-        ),
+        new Promise<void>((_, reject) => {
+          setTimeout(() => {
+            reject(new Error(`drain timed out after ${drainTimeoutMs}ms`));
+          }, drainTimeoutMs);
+        }),
       ]);
     } catch (err) {
       // Drain can fail if already closed by the server, or hit our timeout.
       // Log and proceed — caller wants close() to resolve.
       console.error(
         `nats-connection: "${this.name}" drain error:`,
-        err instanceof Error ? err.message : err,
+        err instanceof Error ? err.message : String(err),
       );
     }
     // Wait for the status loop to drain so close() is deterministic.
@@ -198,12 +197,12 @@ export class NatsLink {
         switch (status.type) {
           case Events.Disconnect:
             console.warn(
-              `nats-connection: "${this.name}" disconnected from ${status.data}`,
+              `nats-connection: "${this.name}" disconnected from ${String(status.data)}`,
             );
             break;
           case Events.Reconnect:
             console.info(
-              `nats-connection: "${this.name}" reconnected to ${status.data}`,
+              `nats-connection: "${this.name}" reconnected to ${String(status.data)}`,
             );
             break;
           case Events.Error:

--- a/src/taps/cc-events/lib/policy-schema.ts
+++ b/src/taps/cc-events/lib/policy-schema.ts
@@ -14,10 +14,17 @@ const regexString = z.string().check((ctx) => {
   try {
     new RegExp(ctx.value);
   } catch {
+    // Zod v4's $ZodIssueBase is a heavily-discriminated union; the
+    // `custom` issue shape is the simplest manual literal we can push.
+    // The union signature doesn't widen to accept `{ code: "custom", ... }`
+    // without a cast, so suppress here at the boundary instead of widening
+    // the project-wide types.
+    /* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument */
     ctx.issues.push({
       code: "custom",
       message: `Invalid regex pattern: ${ctx.value}`,
     } as any);
+    /* eslint-enable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-argument */
   }
 });
 


### PR DESCRIPTION
channel-context regex-exec, mattermost adapter require-await suppressions (interface contract), nats connection brace-wrap + String stringification, drop `as never` test casts, localized Zod issue cast. **171 → 151 (-20)**. 2743 tests pass.