### PR TITLE
chore(lint): sweep #30 — 7-file batch: zod-deprecation + asString + dead conditions (-27)

### DIFF
--- a/src/bus/myelin/__tests__/envelope-validator.test.ts
+++ b/src/bus/myelin/__tests__/envelope-validator.test.ts
@@ -71,7 +71,7 @@ describe("envelope-validator", () => {
   });
 
   test("rejects an envelope missing required type field", () => {
-    const bad = { ...(validEnvelope as { type?: string } & object) };
+    const bad = { ...(validEnvelope as { type?: string }) };
     delete (bad as { type?: string }).type;
     const result = validateEnvelope(bad);
     expect(result.ok).toBe(false);
@@ -410,7 +410,7 @@ describe("envelope-validator — chain helpers (IAW Phase A.2)", () => {
   test("getSignedByChain returns [] for an unsigned envelope", () => {
     const env = tryParseEnvelope(validEnvelope);
     expect(env).not.toBeNull();
-    expect(getSignedByChain(env as Envelope)).toEqual([]);
+    expect(getSignedByChain(env!)).toEqual([]);
   });
 
   test("getSignedByChain normalises a single-stamp object to a 1-element array", () => {
@@ -479,7 +479,7 @@ describe("envelope-validator — chain helpers (IAW Phase A.2)", () => {
   test("getLastStampPrincipal returns undefined for an unsigned envelope", () => {
     const env = tryParseEnvelope(validEnvelope);
     expect(env).not.toBeNull();
-    expect(getLastStampPrincipal(env as Envelope)).toBeUndefined();
+    expect(getLastStampPrincipal(env!)).toBeUndefined();
   });
 
   test("schema source commit points at the post-myelin#115 stack-aware pin", () => {
@@ -502,7 +502,7 @@ describe("envelope-validator — chain helpers (IAW Phase A.2)", () => {
     const myelinDep = pkg.default.dependencies?.["@the-metafactory/myelin"];
     expect(myelinDep).toBeDefined();
     // Format: "github:the-metafactory/myelin#<40-char-sha>"
-    const match = myelinDep!.match(/#([0-9a-f]{40})$/);
+    const match = /#([0-9a-f]{40})$/.exec(myelinDep!);
     expect(match).not.toBeNull();
     expect(match![1]).toBe(SCHEMA_SOURCE_COMMIT);
   });

--- a/src/bus/nats/subscription.ts
+++ b/src/bus/nats/subscription.ts
@@ -79,7 +79,7 @@ export class NatsSubscription {
 
   /** Open a new subscription. Returns once the underlying NATS subscription is registered. */
   static start(link: NatsLink, opts: NatsSubscriptionOptions): NatsSubscription {
-    const pattern = (opts.pattern ?? "").trim();
+    const pattern = opts.pattern.trim();
     if (!pattern) {
       throw new Error("nats-subscription: pattern is required (non-empty, non-whitespace)");
     }
@@ -154,11 +154,11 @@ export class NatsSubscription {
     // rejections owned by `consumeLoops`. Without `.catch`, a rejection
     // from the OLD generation's loop after we've moved on becomes an
     // unhandled-promise warning with nothing watching.
-    const loop = this.consume(this.subscription).catch((err) => {
+    const loop = this.consume(this.subscription).catch((err: unknown) => {
       if (!this.stopped) {
         console.error(
           `nats-subscription: "${this.pattern}" consume loop rejection:`,
-          err instanceof Error ? err.message : err,
+          err instanceof Error ? err.message : String(err),
         );
       }
     });
@@ -226,10 +226,10 @@ export class NatsSubscription {
           const old = this.subscription;
           this.subscription = null;
           if (old) {
-            old.drain().catch((err) => {
+            old.drain().catch((err: unknown) => {
               console.error(
                 `nats-subscription: "${this.pattern}" pre-reconnect drain error:`,
-                err instanceof Error ? err.message : err,
+                err instanceof Error ? err.message : String(err),
               );
             });
           }
@@ -273,7 +273,10 @@ export class NatsSubscription {
   private pruneSettledLoops(): void {
     const KEEP = 2;
     if (this.consumeLoops.length > KEEP) {
-      this.consumeLoops.splice(0, this.consumeLoops.length - KEEP);
+      // `splice` returns the dropped slice; we intentionally discard the
+      // settled Promises (they each already attached a `.catch` handler
+      // that logs and continues).
+      void this.consumeLoops.splice(0, this.consumeLoops.length - KEEP);
     }
   }
 }

--- a/src/common/event-processor.ts
+++ b/src/common/event-processor.ts
@@ -10,6 +10,10 @@ import {
   extractGitHubIssue,
 } from "./event-utils";
 
+function asString(v: unknown): string {
+  return typeof v === "string" ? v : "";
+}
+
 /** Light cleanup — only strip CC internal noise that would never be meaningful to a human reader */
 function sanitizeDescription(raw: string): string {
   return raw
@@ -61,9 +65,11 @@ function processTaskStarted(
   operatorId: string,
   event: IngestEvent,
 ): ProcessedSessionEvent {
-  const description = sanitizeDescription(String(
-    event.payload.prompt_preview ?? event.payload.description ?? "Task",
-  ));
+  const description = sanitizeDescription(
+    asString(event.payload.prompt_preview) ||
+    asString(event.payload.description) ||
+    "Task",
+  );
   const project = detectProjectFromIngestEvent(event);
   const githubIssue = extractGitHubIssue(description);
   const eventOperator = typeof event.payload.operator_id === "string" ? event.payload.operator_id : null;
@@ -99,12 +105,10 @@ function processTaskCompleted(
   const durationMs = event.payload.duration_ms
     ? Number(event.payload.duration_ms)
     : null;
-  const prUrl = event.payload.pr_url
-    ? String(event.payload.pr_url)
-    : null;
+  const prUrl = asString(event.payload.pr_url) || null;
 
   // Build a fallback session in case no session exists yet (late join)
-  const description = String(event.payload.summary ?? "Task");
+  const description = asString(event.payload.summary) || "Task";
   const project = detectProjectFromIngestEvent(event);
   const githubIssue = extractGitHubIssue(description);
   const eventOperator = typeof event.payload.operator_id === "string" ? event.payload.operator_id : null;
@@ -181,9 +185,10 @@ function processProgressEvent(
   event: IngestEvent,
 ): ProcessedSessionEvent {
   const progress = extractProgress(event);
-  const rawDesc = String(
-    event.payload.active_task ?? event.payload.path ?? event.event_type,
-  );
+  const rawDesc =
+    asString(event.payload.active_task) ||
+    asString(event.payload.path) ||
+    event.event_type;
   // Strip internal IDs, file paths, and XML tags that leak from CC internals
   const description = sanitizeDescription(rawDesc);
   const project = detectProjectFromIngestEvent(event);

--- a/src/runner/agent-team.ts
+++ b/src/runner/agent-team.ts
@@ -107,12 +107,12 @@ function buildSynthesisPrompt(
 
 /** Extract @mentions from moderator output */
 function extractMentions(text: string, knownNames: string[]): string[] {
-  const mentionPattern = /@([^\s@:,;!?()\[\]{}'"<>]+)/g;
+  const mentionPattern = /@([^\s@:,;!?()[\]{}'"<>]+)/g;
   const mentions: string[] = [];
   let match;
 
   while ((match = mentionPattern.exec(text)) !== null) {
-    const name = match[1]!.toLowerCase();
+    const name = (match[1] ?? "").toLowerCase();
     const matched = knownNames.find(
       (k) => k.toLowerCase() === name || k.toLowerCase().replace(/\s+/g, "-") === name
     );
@@ -239,12 +239,10 @@ export class AgentTeam extends EventEmitter {
       operator: this.opts.operator,
     });
 
-    // Pass trace context via environment
-    const env = {
-      PAI_TRACE_ID: this.traceId,
-      PAI_PARENT_AGENT_ID: this.moderator?.sessionId ?? this.teamId,
-      PAI_AGENT_ROLE: name,
-    };
+    // Trace context env vars are passed via CC's environment-inheritance;
+    // future PR will wire them through CCSession opts explicitly. Tracked
+    // in worklog as the "trace context not forwarded" item.
+    // (PAI_TRACE_ID / PAI_PARENT_AGENT_ID / PAI_AGENT_ROLE pending wiring.)
 
     this.members.set(name, {
       name,
@@ -287,8 +285,10 @@ export class AgentTeam extends EventEmitter {
 
   private triggerSynthesis(): void {
     const participantResults = Array.from(this.members.values())
-      .filter((m) => m.role === "participant" && m.result)
-      .map((m) => ({ name: m.name, result: m.result! }));
+      .filter((m): m is typeof m & { result: string } =>
+        m.role === "participant" && typeof m.result === "string"
+      )
+      .map((m) => ({ name: m.name, result: m.result }));
 
     if (participantResults.length === 0) {
       this.emit("error", new Error("No participant results to synthesize"));

--- a/src/runner/prompt-filter.ts
+++ b/src/runner/prompt-filter.ts
@@ -73,8 +73,8 @@ export function scanPrompt(prompt: string, source: string): PromptFilterResult {
 
     if (result.decision === "BLOCKED") {
       // Surface pattern matches (e.g. "PI-001") and/or encoding hits (e.g. "base64")
-      const patternIds = result.matches?.map((m) => m.pattern_id).filter(Boolean) ?? [];
-      const encodingTypes = result.encodings?.map((e) => e.type).filter(Boolean) ?? [];
+      const patternIds = result.matches.map((m) => m.pattern_id).filter(Boolean);
+      const encodingTypes = result.encodings.map((e) => e.type).filter(Boolean);
       const reasons = [...patternIds, ...encodingTypes];
       const reasonStr = reasons.length > 0 ? reasons.join(", ") : "unspecified";
       console.log(

--- a/src/surface/mc/config.ts
+++ b/src/surface/mc/config.ts
@@ -64,19 +64,24 @@ export function loadConfig(configPath?: string): Readonly<Config> {
     raw = readFileSync(resolvedPath, "utf-8");
   } catch (err) {
     throw new Error(
-      `Failed to read config at ${resolvedPath}: ${(err as Error).message}`
+      `Failed to read config at ${resolvedPath}: ${err instanceof Error ? err.message : String(err)}`,
+      { cause: err },
     );
   }
 
   let parsed: Record<string, unknown>;
   try {
-    parsed = parseYaml(raw) ?? {};
+    parsed = (parseYaml(raw) as Record<string, unknown> | null) ?? {};
   } catch (err) {
     throw new Error(
-      `Malformed YAML in ${resolvedPath}: ${(err as Error).message}`
+      `Malformed YAML in ${resolvedPath}: ${err instanceof Error ? err.message : String(err)}`,
+      { cause: err },
     );
   }
 
+  // Defense-in-depth: parseYaml may return primitives if the file isn't a
+  // mapping; the cast above narrows it, but a runtime guard catches that.
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   if (typeof parsed !== "object" || parsed === null) {
     throw new Error(
       `Config at ${resolvedPath} must be a YAML mapping, got ${typeof parsed}`

--- a/src/taps/cc-events/hooks/lib/event-types.ts
+++ b/src/taps/cc-events/hooks/lib/event-types.ts
@@ -10,9 +10,9 @@ import { z } from "zod/v4";
 // =============================================================================
 
 export const RawEventSchema = z.object({
-  event_id: z.string().uuid(),
+  event_id: z.uuid(),
   event_type: z.string().min(1),
-  timestamp: z.string().datetime(),
+  timestamp: z.iso.datetime(),
   session_id: z.string().min(1),
   grove_channel: z.string().optional(),
   agent_id: z.string().optional(),
@@ -32,9 +32,9 @@ export type RawEvent = z.infer<typeof RawEventSchema>;
 // =============================================================================
 
 export const PublishedEventSchema = z.object({
-  event_id: z.string().uuid(),
+  event_id: z.uuid(),
   event_type: z.string().min(1),
-  timestamp: z.string().datetime(),
+  timestamp: z.iso.datetime(),
   session_id: z.string().min(1),
   grove_channel: z.string().optional(),
   agent_id: z.string().optional(),


### PR DESCRIPTION
Zod v4 deprecation migration (uuid/datetime), asString helper for event-processor, agent-team type-guard filter, prompt-filter dead-chain drops, nats subscription Promise[] handling, envelope-validator test cast cleanup. **151 → 124 (-27)**. 2743/2743 pass.