### PR TITLE
chore(lint): sweep #31 — 5-file batch: policy-loader + tests + role-resolver (-15)

### DIFF
--- a/src/adapters/discord/context-fetcher.ts
+++ b/src/adapters/discord/context-fetcher.ts
@@ -30,18 +30,16 @@ function messagesToContext(
   return Array.from(fetched.values())
     .sort((a, b) => a.createdTimestamp - b.createdTimestamp)
     .map((msg) => {
-      const attachments: ContextAttachment[] = msg.attachments
-        ? Array.from(msg.attachments.values()).map((a) => ({
-            name: a.name ?? "unknown",
-            url: a.url,
-            contentType: a.contentType ?? "application/octet-stream",
-            size: a.size ?? 0,
-          }))
-        : [];
+      const attachments: ContextAttachment[] = Array.from(msg.attachments.values()).map((a) => ({
+        name: a.name,
+        url: a.url,
+        contentType: a.contentType ?? "application/octet-stream",
+        size: a.size,
+      }));
 
       return {
         role: msg.author.id === botUserId ? "assistant" as const : "human" as const,
-        author: msg.author.displayName ?? msg.author.username,
+        author: msg.author.displayName,
         content: msg.content,
         timestamp: msg.createdAt.toISOString(),
         ...(attachments.length > 0 ? { attachments } : {}),

--- a/src/adapters/discord/role-resolver.ts
+++ b/src/adapters/discord/role-resolver.ts
@@ -58,7 +58,7 @@ export function resolveRole(userId: string, config: BotConfig | RoleConfig): Res
 
   if ("roles" in config && "defaultRole" in config && !("agent" in config)) {
     // RoleConfig passed directly (new adapter path)
-    const rc = config as RoleConfig;
+    const rc = config;
     roles = rc.roles;
     defaultRoleName = rc.defaultRole;
     globalDisallowed = [];
@@ -69,8 +69,8 @@ export function resolveRole(userId: string, config: BotConfig | RoleConfig): Res
     const instance = bc.discord[0];
     roles = instance?.roles ?? [];
     defaultRoleName = instance?.defaultRole ?? "allow-all";
-    globalDisallowed = bc.claude.disallowedTools ?? [];
-    globalAllowedDirs = bc.claude.allowedDirs ?? [];
+    globalDisallowed = bc.claude.disallowedTools;
+    globalAllowedDirs = bc.claude.allowedDirs;
   }
 
   // No roles configured = everyone gets full access (backward compat)
@@ -117,7 +117,7 @@ function roleToResolved(
     name: role.name,
     features: new Set(role.features),
     disallowedTools: mergedDisallowed,
-    allowedDirs: role.allowedDirs !== undefined ? role.allowedDirs : (globalAllowedDirs.length > 0 ? globalAllowedDirs : undefined),
+    allowedDirs: role.allowedDirs ?? (globalAllowedDirs.length > 0 ? globalAllowedDirs : undefined),
     allowedSkills: role.allowedSkills,
     denied: false,
   };

--- a/src/adapters/mattermost/__tests__/bot-user.test.ts
+++ b/src/adapters/mattermost/__tests__/bot-user.test.ts
@@ -61,7 +61,7 @@ describe("fetchBotUserId", () => {
   test("requests the /api/v4/users/me path off the supplied apiUrl (strips trailing slash)", async () => {
     let capturedUrl = "";
     stubFetch(async (input) => {
-      capturedUrl = typeof input === "string" ? input : input.toString();
+      capturedUrl = typeof input === "string" ? input : String(input);
       return new Response(JSON.stringify({ id: "u-1" }), {
         status: 200,
         headers: { "Content-Type": "application/json" },
@@ -76,7 +76,7 @@ describe("fetchBotUserId", () => {
   test("handles apiUrl WITHOUT a trailing slash identically", async () => {
     let capturedUrl = "";
     stubFetch(async (input) => {
-      capturedUrl = typeof input === "string" ? input : input.toString();
+      capturedUrl = typeof input === "string" ? input : String(input);
       return new Response(JSON.stringify({ id: "u-1" }), {
         status: 200,
         headers: { "Content-Type": "application/json" },
@@ -122,11 +122,11 @@ describe("fetchBotUserId", () => {
       return new Promise((_resolve, reject) => {
         const signal = init?.signal;
         if (signal?.aborted) {
-          reject(signal.reason ?? new DOMException("aborted", "AbortError"));
+          reject(signal.reason instanceof Error ? signal.reason : new DOMException("aborted", "AbortError"));
           return;
         }
         signal?.addEventListener("abort", () => {
-          reject(signal.reason ?? new DOMException("aborted", "AbortError"));
+          reject(signal.reason instanceof Error ? signal.reason : new DOMException("aborted", "AbortError"));
         });
       });
     });

--- a/src/bus/__tests__/network-resolver.test.ts
+++ b/src/bus/__tests__/network-resolver.test.ts
@@ -99,10 +99,10 @@ describe("getNetworkForChannel", () => {
   test("resolves Mattermost channel to correct network", () => {
     const config = makeConfig([
       makeNetwork("workplace", {
-        mattermost: [{ apiUrl: "https://mm.example.com", apiToken: "t", channels: ["ch-1", "ch-2"], enabled: true, pollIntervalMs: 3000, allowedUsers: [], roles: [], defaultRole: "allow-all", callbackPort: 8080 }] as any,
+        mattermost: [{ apiUrl: "https://mm.example.com", apiToken: "t", channels: ["ch-1", "ch-2"], enabled: true, pollIntervalMs: 3000, allowedUsers: [], roles: [], defaultRole: "allow-all", callbackPort: 8080 }],
       }),
       makeNetwork("personal", {
-        mattermost: [{ apiUrl: "https://mm2.example.com", apiToken: "t", channels: ["ch-3"], enabled: true, pollIntervalMs: 3000, allowedUsers: [], roles: [], defaultRole: "allow-all", callbackPort: 8081 }] as any,
+        mattermost: [{ apiUrl: "https://mm2.example.com", apiToken: "t", channels: ["ch-3"], enabled: true, pollIntervalMs: 3000, allowedUsers: [], roles: [], defaultRole: "allow-all", callbackPort: 8081 }],
       }),
     ]);
 
@@ -114,7 +114,7 @@ describe("getNetworkForChannel", () => {
   test("returns undefined for unknown channel", () => {
     const config = makeConfig([
       makeNetwork("workplace", {
-        mattermost: [{ apiUrl: "https://mm.example.com", apiToken: "t", channels: ["ch-1"], enabled: true, pollIntervalMs: 3000, allowedUsers: [], roles: [], defaultRole: "allow-all", callbackPort: 8080 }] as any,
+        mattermost: [{ apiUrl: "https://mm.example.com", apiToken: "t", channels: ["ch-1"], enabled: true, pollIntervalMs: 3000, allowedUsers: [], roles: [], defaultRole: "allow-all", callbackPort: 8080 }],
       }),
     ]);
 
@@ -186,7 +186,7 @@ describe("buildNetworkLookups", () => {
         discord: [{ token: "t", guildId: "g1", agentChannelId: "c", logChannelId: "l", contextDepth: 10, enableAgentLog: false, roles: [], defaultRole: "allow-all", enabled: true, dm: {} as any }] as any,
       }),
       makeNetwork("beta", {
-        mattermost: [{ apiUrl: "https://mm", apiToken: "t", channels: ["ch-1", "ch-2"], enabled: true, pollIntervalMs: 3000, allowedUsers: [], roles: [], defaultRole: "allow-all", callbackPort: 8080 }] as any,
+        mattermost: [{ apiUrl: "https://mm", apiToken: "t", channels: ["ch-1", "ch-2"], enabled: true, pollIntervalMs: 3000, allowedUsers: [], roles: [], defaultRole: "allow-all", callbackPort: 8080 }],
       }),
     ]);
 

--- a/src/taps/cc-events/lib/policy-loader.ts
+++ b/src/taps/cc-events/lib/policy-loader.ts
@@ -9,6 +9,6 @@ import { RelayPolicySchema, type RelayPolicy } from "./policy-schema";
 
 export function loadPolicy(path: string): RelayPolicy {
   const content = readFileSync(path, "utf-8");
-  const raw = parseYaml(content);
+  const raw: unknown = parseYaml(content);
   return RelayPolicySchema.parse(raw);
 }


### PR DESCRIPTION
policy-loader unknown cast, network-resolver test auto-fix, bot-user test base-to-string + reject-Error narrowing, context-fetcher + role-resolver dead-chain drops. **124 → 109 (-15)**.