### PR TITLE
chore(lint): sweep #32 — 8-file batch: policy-engine + sinks + iterations + presets (-22)

### DIFF
--- a/src/cli/cortex/commands/migrate-config.ts
+++ b/src/cli/cortex/commands/migrate-config.ts
@@ -51,7 +51,7 @@ export function parseArgs(argv: string[]): ParsedArgs {
     help: false,
   };
   for (let i = 0; i < argv.length; i++) {
-    const a = argv[i]!;
+    const a = argv[i] ?? "";
     if (a === "--help" || a === "-h") {
       args.help = true;
     } else if (a === "--check") {
@@ -94,6 +94,7 @@ function printHelp(): void {
  * test harness; the bottom of this file calls it from `process.argv` when
  * the script is executed directly.
  */
+// eslint-disable-next-line @typescript-eslint/require-await
 export async function runMigrateConfig(argv: string[]): Promise<number> {
   let args: ParsedArgs;
   try {
@@ -169,8 +170,8 @@ export async function runMigrateConfig(argv: string[]): Promise<number> {
 
 if (import.meta.main) {
   runMigrateConfig(process.argv.slice(2)).then(
-    (code) => process.exit(code),
-    (err) => {
+    (code) => { process.exit(code); },
+    (err: unknown) => {
       console.error("Fatal:", err);
       process.exit(1);
     },

--- a/src/common/agents/trust-resolver.ts
+++ b/src/common/agents/trust-resolver.ts
@@ -291,7 +291,7 @@ export function verifyOperatorUserJwt(
       reason: "wrong_issuer",
       detail:
         `jwt iss=${claims.iss} does not match trusted operator pubkey ` +
-        `${operatorAccountSigningPublicKey}`,
+        operatorAccountSigningPublicKey,
     };
   }
 
@@ -320,7 +320,7 @@ export function verifyOperatorUserJwt(
     };
   }
 
-  return { ok: true, userPublicKey: claims.sub, agentName: claims.name ?? "" };
+  return { ok: true, userPublicKey: claims.sub, agentName: claims.name };
 }
 
 /**
@@ -384,7 +384,7 @@ export function verifyOperatorSignedRequest(
     };
   }
 
-  const env = envelope as SignedRequest;
+  const env = envelope;
 
   if (env.subject !== opts.expectedSubject) {
     return {

--- a/src/runner/learning-store.ts
+++ b/src/runner/learning-store.ts
@@ -32,7 +32,7 @@ export class LearningStore {
   }
 
   private migrate(): void {
-    this.db.exec(`
+    this.db.run(`
       CREATE TABLE IF NOT EXISTS learnings (
         id TEXT PRIMARY KEY,
         content TEXT NOT NULL,
@@ -90,7 +90,7 @@ export class LearningStore {
       usage_count: number;
     }[];
 
-    return rows.map(this.rowToLearning);
+    return rows.map((r) => this.rowToLearning(r));
   }
 
   /**
@@ -113,7 +113,7 @@ export class LearningStore {
       usage_count: number;
     }[];
 
-    return rows.map(this.rowToLearning);
+    return rows.map((r) => this.rowToLearning(r));
   }
 
   /**

--- a/src/runner/security-preamble.ts
+++ b/src/runner/security-preamble.ts
@@ -42,8 +42,13 @@ export function buildSecurityPreamble(config: BotConfig, configPath?: string, op
   );
 
   if (!opts?.skipFilesystemRestriction) {
+    // Tests pass partial config objects without claude defaults; the `?? []`
+    // fallbacks are load-bearing for those code paths even though Zod
+    // schemas guarantee non-null in production.
+    /* eslint-disable @typescript-eslint/no-unnecessary-condition */
     const dirs = opts?.overrideDirs ?? config.claude.allowedDirs ?? [];
     const readOnlyDirs = config.claude.readOnlyDirs ?? [];
+    /* eslint-enable @typescript-eslint/no-unnecessary-condition */
     const allDirs = [...dirs, ...readOnlyDirs];
 
     if (allDirs.length > 0) {
@@ -80,7 +85,7 @@ export function buildSecurityPreamble(config: BotConfig, configPath?: string, op
         .map((r) => r.pattern.replace(/^\^/, "").replace(/\\s\+.*/, "").replace(/\\b$/, ""))
         .slice(0, 6)
         .join(", ");
-      const repoList = bashAllowlist.repos?.length
+      const repoList = bashAllowlist.repos.length
         ? bashAllowlist.repos.join(", ")
         : "any";
       rules.push(

--- a/src/surface/mc/api/iteration-import.ts
+++ b/src/surface/mc/api/iteration-import.ts
@@ -537,7 +537,7 @@ export function parentMetadataFromWebhook(
     return null;
   }
   const repo = env.repository as { full_name?: string; name?: string; owner?: { login?: string } };
-  const issue = env.issue as IssuesWebhookEnvelope["issue"];
+  const issue = env.issue;
   const owner = repo.owner?.login;
   const name = repo.name;
   if (typeof owner !== "string" || typeof name !== "string") return null;
@@ -553,7 +553,7 @@ export function parentMetadataFromWebhook(
         .map((l) =>
           typeof l === "string"
             ? l
-            : typeof l?.name === "string"
+            : typeof l.name === "string"
               ? l.name
               : null
         )
@@ -602,7 +602,7 @@ export function subIssueRefsFromWebhook(envelope: unknown): {
   ) {
     return null;
   }
-  const issue = env.issue as IssuesWebhookEnvelope["issue"];
+  const issue = env.issue;
   const parent = issue.parent;
   if (!parent || typeof parent !== "object") return null;
   if (typeof parent.number !== "number" || !Number.isInteger(parent.number)) {

--- a/src/surface/mc/db/iterations.ts
+++ b/src/surface/mc/db/iterations.ts
@@ -661,16 +661,23 @@ export function canTransitionServer(
   current: IterationState,
   proposed: IterationState
 ): boolean {
+  // TS narrows TRANSITIONS[current] to a Set when `current` is a known
+  // IterationState; the `!allowed` guards remain load-bearing for
+  // forward-compat if the union expands.
+  /* eslint-disable @typescript-eslint/no-unnecessary-condition */
   const allowed = TRANSITIONS[current];
   if (!allowed) return false;
   return allowed.has(proposed);
+  /* eslint-enable @typescript-eslint/no-unnecessary-condition */
 }
 
 /** Enumerate the legal next states from `current`. Order is matrix-insertion. */
 export function nextStatesServer(current: IterationState): IterationState[] {
+  /* eslint-disable @typescript-eslint/no-unnecessary-condition */
   const allowed = TRANSITIONS[current];
   if (!allowed) return [];
   return [...allowed];
+  /* eslint-enable @typescript-eslint/no-unnecessary-condition */
 }
 
 // ---------------------------------------------------------------------------
@@ -690,7 +697,7 @@ function hydrateListItem(
     source_parent_ref: row.source_parent_ref,
     task_count: row.task_count,
     imported_at:
-      row.imported_at === null || row.imported_at === undefined
+      row.imported_at === null
         ? null
         : epochSecondsToIso(row.imported_at),
     created_at: epochSecondsToIso(row.created_at),

--- a/src/surface/mc/notifications/discord-sink.ts
+++ b/src/surface/mc/notifications/discord-sink.ts
@@ -310,6 +310,7 @@ export async function maybeNotifyDiscord(
 // Internal dispatch
 // ---------------------------------------------------------------------
 
+// eslint-disable-next-line @typescript-eslint/require-await
 async function dispatchIntent(
   deps: MaybeNotifyDeps,
   intent: NotificationIntent,
@@ -468,7 +469,8 @@ async function flushDMBuffer(key: string): Promise<void> {
     // N=1: render the original single-event DM body at flush time (N1 in
     // PR #23 review — defer rendering to flush so a coalesced burst never
     // pays for the per-entry render cost).
-    const only = buffer.entries[0]!;
+    const only = buffer.entries[0];
+    if (!only) return;
     const payload = renderDM(only.renderCtx);
     await sendDMSafely(buffer, payload, only.assignmentId);
     return;
@@ -596,7 +598,9 @@ async function flushChannelBuffer(channelId: string): Promise<void> {
   if (buffer.timer !== null) buffer.scheduler.cancel(buffer.timer);
 
   if (buffer.entries.length === 1) {
-    const only = buffer.entries[0]! as PendingCoalesceEntry & {
+    const onlyEntry = buffer.entries[0];
+    if (!onlyEntry) return;
+    const only = onlyEntry as PendingCoalesceEntry & {
       fallbackPayload?: string;
       alreadyDecorated?: boolean;
     };

--- a/src/taps/cc-events/lib/policy-engine.ts
+++ b/src/taps/cc-events/lib/policy-engine.ts
@@ -67,7 +67,7 @@ function deepMapStrings(
     if (typeof value === "string") {
       result[key] = fn(value);
     } else if (Array.isArray(value)) {
-      result[key] = value.map((item) =>
+      result[key] = (value as unknown[]).map((item): unknown =>
         typeof item === "string"
           ? fn(item)
           : item && typeof item === "object"


### PR DESCRIPTION
Eight 3-4 error files. Caught a security-preamble test regression mid-sweep when removing schema-default fallbacks; restored with inline suppression + comment about test partial-config code paths. **109 → 87 (-22)**. 2743/2743 pass.