### PR TITLE
chore(lint): sweep #33 — batch 5 small files (87→74)

### DIFF
--- a/src/adapters/mattermost/context.ts
+++ b/src/adapters/mattermost/context.ts
@@ -45,7 +45,8 @@ async function fetchUserName(
   apiToken: string,
   userCache: Map<string, string>
 ): Promise<string> {
-  if (userCache.has(userId)) return userCache.get(userId)!;
+  const cached = userCache.get(userId);
+  if (cached !== undefined) return cached;
 
   try {
     const res = await fetch(`${apiUrl}/api/v4/users/${userId}`, {
@@ -55,6 +56,9 @@ async function fetchUserName(
     if (!res.ok) return "unknown";
 
     const user = await res.json() as MattermostUser;
+    // `||` preserves empty-string fallthrough to next field; `??` would
+    // not. Mattermost returns "" for omitted optional fields.
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     const name = user.nickname || user.username || `${user.first_name} ${user.last_name}`.trim() || "unknown";
     userCache.set(userId, name);
     return name;
@@ -130,7 +134,7 @@ export async function fetchMattermostContext(
 
     for (const id of postsResponse.order.slice().reverse()) {
       const p = postsResponse.posts[id];
-      if (!p || !p.message) continue;
+      if (!p?.message) continue;
       // Skip the triggering post itself — it'll be the prompt
       if (p.id === postId) continue;
 

--- a/src/bus/myelin/subscriber.ts
+++ b/src/bus/myelin/subscriber.ts
@@ -63,6 +63,7 @@ const utf8 = new TextDecoder("utf-8", { fatal: false });
 
 /** Strip C0 control characters (newlines, tabs, etc.) to prevent log injection. */
 function sanitizeForLog(s: string): string {
+  // eslint-disable-next-line no-control-regex
   return s.replace(/[\x00-\x1f\x7f]/g, "");
 }
 
@@ -88,7 +89,7 @@ export class MyelinSubscriber {
     this.subscription = NatsSubscription.start(link, {
       pattern: opts.pattern,
       onMessage: (subject, data) => this.handleRaw(subject, data),
-      onError: (err, subject) => this.onError(err, subject),
+      onError: (err, subject) => { this.onError(err, subject); },
     });
   }
 
@@ -122,7 +123,7 @@ export class MyelinSubscriber {
         {
           kind: "schema",
           errors: result.errors,
-          firstPath: first?.instancePath || "/",
+          firstPath: first?.instancePath ?? "/",
           firstMessage: first?.message ?? "(no message)",
         },
         subject,

--- a/src/bus/payload-filter.ts
+++ b/src/bus/payload-filter.ts
@@ -44,9 +44,9 @@ export type FilterValue =
  * is a leaf; a key whose value is another PayloadFilterPattern descends
  * into that subtree.
  */
-export type PayloadFilterPattern = {
+export interface PayloadFilterPattern {
   [key: string]: FilterValue[] | PayloadFilterPattern;
-};
+}
 
 /**
  * A surface-adapter's full filter. The `envelope` pattern matches the
@@ -80,7 +80,7 @@ export interface PayloadFilter {
  */
 export function matchesFilter(envelope: Envelope, filter: PayloadFilter | undefined): boolean {
   if (!filter) return true;
-  if (filter.envelope && !matchPattern(envelope as unknown as Record<string, unknown>, filter.envelope)) {
+  if (filter.envelope && !matchPattern(envelope, filter.envelope)) {
     return false;
   }
   if (filter.payload && !matchPattern(envelope.payload, filter.payload)) {
@@ -124,7 +124,7 @@ function matchPattern(value: unknown, pattern: PayloadFilterPattern): boolean {
   for (const key of Object.keys(pattern)) {
     const sub = pattern[key];
     if (!sub) continue;
-    const fieldValue = (value as Record<string, unknown>)[key];
+    const fieldValue = value[key];
     if (Array.isArray(sub)) {
       if (!matchLeaf(fieldValue, sub)) return false;
     } else {

--- a/src/cli/cortex/commands/__tests__/cloud.test.ts
+++ b/src/cli/cortex/commands/__tests__/cloud.test.ts
@@ -232,9 +232,9 @@ describe("parseArgs", () => {
       "--admin-key", "admin-secret",
     ]);
     expect(args.command).toBe("add-operator");
-    expect(args.flags["name"]).toBe("JC");
+    expect(args.flags.name).toBe("JC");
     expect(args.flags["agent-name"]).toBe("Ivy");
-    expect(args.flags["endpoint"]).toBe("https://grove-api.meta-factory.ai");
+    expect(args.flags.endpoint).toBe("https://grove-api.meta-factory.ai");
     expect(args.flags["admin-key"]).toBe("admin-secret");
   });
 
@@ -245,7 +245,7 @@ describe("parseArgs", () => {
       "--admin-key", "secret",
     ]);
     expect(args.command).toBe("status");
-    expect(args.flags["endpoint"]).toBe("https://grove-api.meta-factory.ai");
+    expect(args.flags.endpoint).toBe("https://grove-api.meta-factory.ai");
     expect(args.flags["admin-key"]).toBe("secret");
   });
 

--- a/src/taps/cc-events/lib/file-watcher.ts
+++ b/src/taps/cc-events/lib/file-watcher.ts
@@ -27,5 +27,7 @@ export function watchRawEvents(
     }
   });
 
-  return () => watcher.close();
+  return () => {
+    watcher.close();
+  };
 }


### PR DESCRIPTION
## Summary
- Drive 5 small files to lint-clean: mattermost/context.ts, myelin/subscriber.ts, payload-filter.ts, cloud.test.ts, file-watcher.ts.
- Cluster: **87 → 74 errors (-13, -15%)**.

## Patterns applied
- `userCache.get(id) !== undefined` instead of `!`-bang on Map lookup.
- Block-scoped `// eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing` on user.nickname/username chain (empty-string fallthrough is load-bearing).
- `!p?.message` instead of `!p || !p.message`.
- `// eslint-disable-next-line no-control-regex` on `\x00-\x1f` log sanitizer.
- Misc nullish/optional-chain tidies.

## Verify
- `bunx tsc --noEmit` → exit 0
- `bun run lint:errors` → 74 problems (was 87)
- `bun test` → 2743 pass / 0 fail / 6429 expects

## Out of scope
- 74 remaining errors stay for follow-up sweeps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)