### PR TITLE
chore(lint): sweep #34 — base-to-string + require-await + non-null-assertion (74→61)

### DIFF
--- a/src/adapters/mattermost/__tests__/bot-user.test.ts
+++ b/src/adapters/mattermost/__tests__/bot-user.test.ts
@@ -61,7 +61,7 @@ describe("fetchBotUserId", () => {
   test("requests the /api/v4/users/me path off the supplied apiUrl (strips trailing slash)", async () => {
     let capturedUrl = "";
     stubFetch(async (input) => {
-      capturedUrl = typeof input === "string" ? input : String(input);
+      capturedUrl = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
       return new Response(JSON.stringify({ id: "u-1" }), {
         status: 200,
         headers: { "Content-Type": "application/json" },
@@ -76,7 +76,7 @@ describe("fetchBotUserId", () => {
   test("handles apiUrl WITHOUT a trailing slash identically", async () => {
     let capturedUrl = "";
     stubFetch(async (input) => {
-      capturedUrl = typeof input === "string" ? input : String(input);
+      capturedUrl = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
       return new Response(JSON.stringify({ id: "u-1" }), {
         status: 200,
         headers: { "Content-Type": "application/json" },

--- a/src/adapters/mattermost/__tests__/render-envelope.test.ts
+++ b/src/adapters/mattermost/__tests__/render-envelope.test.ts
@@ -58,7 +58,7 @@ beforeEach(() => {
       headers: { "Content-Type": "application/json" },
     });
   globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
-    const url = typeof input === "string" ? input : input.toString();
+    const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
     let body: unknown;
     if (init?.body && typeof init.body === "string") {
       try {

--- a/src/bus/myelin/envelope-validator.ts
+++ b/src/bus/myelin/envelope-validator.ts
@@ -351,7 +351,8 @@ export function getSignedByChain(envelope: Envelope): SignedBy[] {
 export function getLastStampPrincipal(envelope: Envelope): string | undefined {
   const chain = getSignedByChain(envelope);
   if (chain.length === 0) return undefined;
-  return chain[chain.length - 1]!.principal;
+  const last = chain[chain.length - 1];
+  return last?.principal;
 }
 
 /**

--- a/src/bus/nats/connection.ts
+++ b/src/bus/nats/connection.ts
@@ -197,12 +197,12 @@ export class NatsLink {
         switch (status.type) {
           case Events.Disconnect:
             console.warn(
-              `nats-connection: "${this.name}" disconnected from ${String(status.data)}`,
+              `nats-connection: "${this.name}" disconnected from ${stringifyStatusData(status.data)}`,
             );
             break;
           case Events.Reconnect:
             console.info(
-              `nats-connection: "${this.name}" reconnected to ${String(status.data)}`,
+              `nats-connection: "${this.name}" reconnected to ${stringifyStatusData(status.data)}`,
             );
             break;
           case Events.Error:
@@ -230,4 +230,14 @@ export class NatsLink {
       }
     }
   }
+}
+
+/** NATS status events carry a `data` payload that the client lib types
+ *  loosely as `unknown` even though Disconnect/Reconnect are strings.
+ *  Branch on shape so the lint rule doesn't fire on Object's default
+ *  stringification. */
+function stringifyStatusData(data: unknown): string {
+  if (typeof data === "string") return data;
+  if (typeof data === "number" || typeof data === "boolean") return String(data);
+  return JSON.stringify(data) ?? "(unknown)";
 }

--- a/src/common/config/__tests__/fragment-watcher.test.ts
+++ b/src/common/config/__tests__/fragment-watcher.test.ts
@@ -263,7 +263,11 @@ function yamlStringify(obj: Record<string, unknown>, indent = 0): string {
     } else if (typeof val === "string") {
       out += `${pad}${key}: "${val}"\n`;
     } else {
-      out += `${pad}${key}: ${val}\n`;
+      // Fallthrough — numbers/booleans/null. The `?? "null"` shields the
+      // template literal from the no-base-to-string rule on object-typed
+      // narrowings that Bun's `Record<string, unknown>` value union picks
+      // up after the `typeof === "object"` branch lands.
+      out += `${pad}${key}: ${val as number | boolean | null ?? "null"}\n`;
     }
   }
   return out;

--- a/src/renderers/__tests__/pagerduty.test.ts
+++ b/src/renderers/__tests__/pagerduty.test.ts
@@ -38,7 +38,7 @@ interface FetchCall {
 function makeFetch(handler: (call: FetchCall) => Response | Promise<Response>): { fetchImpl: typeof fetch; calls: FetchCall[] } {
   const calls: FetchCall[] = [];
   const fetchImpl = (async (input: RequestInfo | URL, init?: RequestInit) => {
-    const url = typeof input === "string" ? input : input.toString();
+    const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
     const body = typeof init?.body === "string" ? JSON.parse(init.body) : init?.body;
     const call: FetchCall = { url, body, headers: init?.headers };
     calls.push(call);

--- a/src/runner/dispatch-listener.ts
+++ b/src/runner/dispatch-listener.ts
@@ -215,10 +215,15 @@ export function createDispatchListener(
 
   return {
     surfaceConfig,
+    // start/stop are part of the surface-listener contract — return
+    // Promise<void> even when the body is sync, so callers can await
+    // alongside other lifecycle hooks (cc-session, bus, taps).
+    // eslint-disable-next-line @typescript-eslint/require-await
     async start() {
       if (registration) return;
       registration = router.register(surfaceConfig);
     },
+    // eslint-disable-next-line @typescript-eslint/require-await
     async stop() {
       if (!registration) return;
       registration.unregister();

--- a/src/substrates/claude-code/harness.ts
+++ b/src/substrates/claude-code/harness.ts
@@ -249,6 +249,11 @@ export class ClaudeCodeHarness implements SessionHarness {
    * session, so their `wait()` settles fast (cc-session's kill path
    * resolves `wait()` within 2s via SIGTERM escalation).
    */
+  // Substrate contract — shutdown is Promise<void> for caller symmetry
+  // with other substrates whose bodies may await teardown work. Body
+  // here is sync (kills are issued, dispatch finallys observe via the
+  // exit listener), so the rule fires; the contract wins.
+  // eslint-disable-next-line @typescript-eslint/require-await
   async shutdown(opts: { graceful: boolean }): Promise<void> {
     this.shuttingDown = true;
     if (opts.graceful) return;

--- a/src/surface/mc/db/metrics.ts
+++ b/src/surface/mc/db/metrics.ts
@@ -306,7 +306,10 @@ function percentile(sortedAsc: number[], p: number): number | null {
     sortedAsc.length - 1,
     Math.max(0, Math.ceil(p * sortedAsc.length) - 1)
   );
-  return sortedAsc[idx]!;
+  // idx is mathematically bounded to [0, len-1] above, so the lookup
+  // cannot return undefined. `?? null` keeps the function total without
+  // a non-null assertion.
+  return sortedAsc[idx] ?? null;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/taps/cc-events/__tests__/cloud-publisher.test.ts
+++ b/src/taps/cc-events/__tests__/cloud-publisher.test.ts
@@ -59,7 +59,8 @@ beforeEach(() => {
   fetchDelay = 0;
 
   globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
-    fetchCalls.push({ url: String(input), init: init! });
+    const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+    fetchCalls.push({ url, init: init! });
     if (fetchDelay > 0) {
       await new Promise((r) => setTimeout(r, fetchDelay));
     }

--- a/src/taps/cc-events/hooks/lib/event-taxonomy.ts
+++ b/src/taps/cc-events/hooks/lib/event-taxonomy.ts
@@ -63,8 +63,9 @@ export function mapHookToEventType(
       return EVENT_TYPES.SESSION_STARTED;
 
     case "PostToolUse":
-      if (toolName && toolName in TOOL_EVENT_MAP) {
-        return TOOL_EVENT_MAP[toolName]!;
+      if (toolName) {
+        const mapped = TOOL_EVENT_MAP[toolName];
+        if (mapped) return mapped;
       }
       return `tool.${(toolName ?? "unknown").toLowerCase()}.used`;
 


### PR DESCRIPTION
## Summary
- Three rule families to zero: `no-base-to-string` (8→0), `require-await` (3→0), `no-non-null-assertion` (3→0).
- **74 → 61 errors (-13, -18%)**.

## Patterns
- Fetch stubs in tests: `input instanceof URL ? .href : .url` for `RequestInfo | URL` (Request/URL both stringify safely but rule can't prove it from the union).
- nats/connection: `stringifyStatusData(unknown)` helper for `status.data` (typed `unknown`, payload is server URL string).
- Surface-listener / substrate contract methods: `// eslint-disable-next-line require-await` with comment about contract symmetry.
- Bounded-index lookups: `?? null` / lookup-then-guard instead of `!`.

## Verify
- `bunx tsc --noEmit` → exit 0
- `bun run lint:errors` → 61 problems (was 74)
- `bun test` → 2743 pass / 0 fail / 6429 expects

## Out of scope
- 61 remaining errors stay for follow-up sweeps. Top clusters: `no-unnecessary-condition` (10), `no-unnecessary-type-assertion` (17).

🤖 Generated with [Claude Code](https://claude.com/claude-code)