### PR TITLE
chore(lint): sweep #35 — no-unnecessary-condition (61→50)

### DIFF
--- a/src/adapters/mattermost/server.ts
+++ b/src/adapters/mattermost/server.ts
@@ -130,7 +130,7 @@ export function createMattermostServer(
 
         const msg: MattermostInboundMessage = {
           channelId: payload.channel_id,
-          channelName: payload.channel_name ?? "unknown",
+          channelName: payload.channel_name,
           postId: payload.post_id,
           rootId: payload.post_id, // Webhook doesn't provide root_id; use post_id
           userId: payload.user_id,

--- a/src/bus/myelin/envelope-validator.ts
+++ b/src/bus/myelin/envelope-validator.ts
@@ -334,10 +334,9 @@ export function tryParseEnvelope(value: unknown): Envelope | null {
  */
 export function getSignedByChain(envelope: Envelope): SignedBy[] {
   const value = envelope.signed_by;
-  if (value === undefined || value === null) return [];
+  if (value === undefined) return [];
   if (Array.isArray(value)) return value;
-  if (typeof value === "object") return [value];
-  return [];
+  return [value];
 }
 
 /**

--- a/src/bus/nats/connection.ts
+++ b/src/bus/nats/connection.ts
@@ -239,5 +239,10 @@ export class NatsLink {
 function stringifyStatusData(data: unknown): string {
   if (typeof data === "string") return data;
   if (typeof data === "number" || typeof data === "boolean") return String(data);
+  // JSON.stringify per the JS spec returns `string | undefined`
+  // (undefined for `undefined` / function inputs), but TS's lib.es5
+  // signature claims `string`. Keep the fallback for the spec-correct
+  // case; suppress the lint rule that trusts the lib.es5 lie.
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   return JSON.stringify(data) ?? "(unknown)";
 }

--- a/src/common/types/cortex-config.ts
+++ b/src/common/types/cortex-config.ts
@@ -338,7 +338,12 @@ export const AgentSchema = z.object({
    */
   runtime: AgentRuntimeSchema.optional(),
 }).refine(
-  (agent) => Object.values(agent.presence).some((p) => p !== undefined),
+  // Zod's `.refine` callback receives the parsed type; presence values
+  // are `DiscordPresence | MattermostPresence | undefined`. Use `Boolean`
+  // to coerce — lint sees the refine inference differently than tsc and
+  // flags the explicit `!== undefined` as "no overlap" even though the
+  // optional fields above legitimately produce undefined values.
+  (agent) => Object.values(agent.presence).some(Boolean),
   { message: "agent must have at least one presence block", path: ["presence"] },
 );
 

--- a/src/renderers/pagerduty.ts
+++ b/src/renderers/pagerduty.ts
@@ -130,10 +130,16 @@ export class PagerDutyRenderer implements Renderer {
       // `envelope.id` raw would then TypeError inside the catch and
       // surface as an unhandled rejection. Match the DashboardRenderer
       // pattern (Holly cycle 2 nit).
+      // The TS type says `envelope: Envelope` (non-null), but the catch
+      // exists for the defense-in-depth case where a bug routes a null/
+      // undefined envelope through. Keep the optional chain + fallback
+      // so a thrown TypeError doesn't escape as an unhandled rejection.
+      /* eslint-disable @typescript-eslint/no-unnecessary-condition */
       console.warn(
         `pagerduty-renderer: failed to forward envelope ${envelope?.id ?? "<unknown>"}:`,
         err instanceof Error ? err.message : err,
       );
+      /* eslint-enable @typescript-eslint/no-unnecessary-condition */
     }
   }
 

--- a/src/surface/mc/api/github-ref.ts
+++ b/src/surface/mc/api/github-ref.ts
@@ -262,5 +262,5 @@ export function canonicalUrl(ref: GitHubRef): string {
  * Type guard: distinguish `ParseError` from `GitHubRef`.
  */
 export function isParseError(x: GitHubRef | ParseError): x is ParseError {
-  return (x as ParseError).error !== undefined;
+  return "error" in x;
 }

--- a/src/surface/mc/notifications/render.ts
+++ b/src/surface/mc/notifications/render.ts
@@ -223,10 +223,9 @@ function renderBlockReasonLine(reason: BlockReason | null): string | null {
     const msg = reason.payload.error_message;
     return `tool.error: ${tool} — "${msg}"`;
   }
-  if (reason.kind === "review.checkpoint") {
-    return `review.checkpoint: "${reason.payload.description}"`;
-  }
-  return null;
+  // BlockReason has exactly three kinds; after the two `if` returns
+  // above, narrowing leaves only "review.checkpoint".
+  return `review.checkpoint: "${reason.payload.description}"`;
 }
 
 function renderChannelContextLine(ctx: RenderContext): string | null {

--- a/src/surface/mc/notifications/should-notify.ts
+++ b/src/surface/mc/notifications/should-notify.ts
@@ -131,11 +131,13 @@ export function shouldNotify(input: ShouldNotifyInput): NotificationIntent | nul
     };
   }
 
-  if (to === "blocked") {
-    // The blocked-row matrix branches on (priority, kind, risk). The
-    // schema's `risk_hint` is optional and free-form on the agent side; we
-    // narrow it to the three documented buckets ("high"/"medium"/"low")
-    // and treat anything else (including `undefined`) as "medium".
+  // `to` narrows to "blocked" — every other AssignmentState returned
+  // above. The blocked-row matrix branches on (priority, kind, risk).
+  // The schema's `risk_hint` is optional and free-form on the agent
+  // side; we narrow it to the three documented buckets
+  // ("high"/"medium"/"low") and treat anything else (including
+  // `undefined`) as "medium".
+  {
     if (!blockReason) {
       // Schema invariant: state=blocked ↔ block_reason non-null. If we get
       // here, the caller violated that invariant — fail safe by emitting a
@@ -211,21 +213,17 @@ export function shouldNotify(input: ShouldNotifyInput): NotificationIntent | nul
       };
     }
 
-    if (blockReason.kind === "review.checkpoint") {
-      // review.checkpoint is "agent asked for human sign-off". DM, no ping
-      // even at P0 — the operator already opted in by configuring agents
-      // that emit checkpoints.
-      return {
-        audiences: ["dm"],
-        severity: "silent",
-        urgencyTag: priorityPrefix(priority),
-      };
-    }
+    // BlockReason has exactly three kinds; permission.request and
+    // tool.error returned above, so review.checkpoint is the only kind
+    // left. "agent asked for human sign-off" — DM, no ping even at P0
+    // (the operator opted in by configuring agents that emit
+    // checkpoints).
+    return {
+      audiences: ["dm"],
+      severity: "silent",
+      urgencyTag: priorityPrefix(priority),
+    };
   }
-
-  // Defensive fall-through: unknown future states or block-reason kinds.
-  // Returning null is the safe default — push surfaces are best-effort.
-  return null;
 }
 
 // `operator.input.requested` is contemplated by Decision 1 (last row of

--- a/src/surface/mc/session/stdout-dispatcher.ts
+++ b/src/surface/mc/session/stdout-dispatcher.ts
@@ -83,6 +83,7 @@ async function consumeStream(
   let buffer = "";
 
   try {
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     while (true) {
       const { value, done } = await reader.read();
       if (done) break;


### PR DESCRIPTION
## Summary
- Drive `no-unnecessary-condition` to zero (10→0).
- **61 → 50 errors (-11, -18%)**.

## Patterns
- Drop redundant fallbacks where the source type already excludes nullish.
- Replace cast-then-undefined-check with `"key" in x` discriminator.
- Collapse exhaustive discriminated-union branches to inline returns.
- Block-level `eslint-disable` only where the conditional is load-bearing (defense-in-depth catch in pagerduty, JSON.stringify spec-vs-lib.es5 mismatch).
- Inline-disable on idiomatic `while (true)` reader loop.

## Verify
- `bunx tsc --noEmit` → exit 0
- `bun run lint:errors` → 50 problems (was 61)
- `bun test` → 2743 pass / 0 fail / 6429 expects

## Out of scope
- 50 remaining errors stay for follow-up sweeps. Top cluster: `no-unnecessary-type-assertion` (17).

🤖 Generated with [Claude Code](https://claude.com/claude-code)