### PR TITLE
chore(lint): sweep #36 — no-unnecessary-type-assertion (50→33)

### DIFF
--- a/src/__tests__/cortex.test.ts
+++ b/src/__tests__/cortex.test.ts
@@ -582,7 +582,7 @@ presence:
             trustedBotIds: [],
           },
         },
-      } as Agent,
+      },
       {
         id: "echo",
         displayName: "EchoFromInline",
@@ -612,7 +612,7 @@ presence:
             trustedBotIds: [],
           },
         },
-      } as Agent,
+      },
     ];
 
     const handle = await startCortex(minimalConfig(), {

--- a/src/bus/myelin/__tests__/envelope-validator.test.ts
+++ b/src/bus/myelin/__tests__/envelope-validator.test.ts
@@ -72,7 +72,7 @@ describe("envelope-validator", () => {
 
   test("rejects an envelope missing required type field", () => {
     const bad = { ...(validEnvelope as { type?: string }) };
-    delete (bad as { type?: string }).type;
+    delete bad.type;
     const result = validateEnvelope(bad);
     expect(result.ok).toBe(false);
   });

--- a/src/bus/myelin/__tests__/subscriber.test.ts
+++ b/src/bus/myelin/__tests__/subscriber.test.ts
@@ -123,7 +123,7 @@ async function makeLink() {
   const link = await NatsLink.connect({
     url: "nats://localhost:4222",
     name: "myelin-test",
-    connectImpl: (async () => fake.nc) as never,
+    connectImpl: async () => fake.nc,
   });
   return { link, fake };
 }

--- a/src/common/agents/__tests__/presence-binding.test.ts
+++ b/src/common/agents/__tests__/presence-binding.test.ts
@@ -434,8 +434,8 @@ describe("PresenceBinding — multi-platform per agent", () => {
 
     expect(resolver.size).toBe(2);
     expect(resolver.identitiesOf("luna")).toEqual([
-      { platform: "discord" as Platform, platformId: "1487100000000000001" },
-      { platform: "mattermost" as Platform, platformId: "luna-mm-userid-abc123" },
+      { platform: "discord", platformId: "1487100000000000001" },
+      { platform: "mattermost", platformId: "luna-mm-userid-abc123" },
     ]);
 
     await discordBinding.unbindAndStop();

--- a/src/common/agents/__tests__/registry.test.ts
+++ b/src/common/agents/__tests__/registry.test.ts
@@ -111,7 +111,7 @@ function cortexConfigFixture(agents: Agent[]): CortexConfig {
     // include it explicitly. Registry tests don't exercise capabilities; an
     // empty array is the right zero-value.
     capabilities: [],
-  } as CortexConfig;
+  };
 }
 
 // =============================================================================
@@ -362,7 +362,7 @@ describe("AgentRegistry — immutability", () => {
     ]);
     const luna = registry.getById("luna");
     expect(() => {
-      (luna.trust as string[]).push("evil");
+      luna.trust.push("evil");
     }).toThrow();
   });
 

--- a/src/common/agents/__tests__/trust-resolver-operator-verify.test.ts
+++ b/src/common/agents/__tests__/trust-resolver-operator-verify.test.ts
@@ -114,7 +114,7 @@ function agentFixture(): Agent {
     roles: [],
     trust: [],
     presence: {},
-  } as Agent;
+  };
 }
 
 function registryWithLuna(): AgentRegistry {
@@ -261,7 +261,7 @@ describe("verifyOperatorSignedRequest", () => {
 
   test("malformed_envelope — missing fields", () => {
     const result = verifyOperatorSignedRequest(
-      { subject: "x", userJwt: "y" } as unknown,
+      { subject: "x", userJwt: "y" },
       trustedAccountSigningKey.getPublicKey(),
       { expectedSubject: "x" },
     );

--- a/src/common/agents/__tests__/trust-resolver.test.ts
+++ b/src/common/agents/__tests__/trust-resolver.test.ts
@@ -22,7 +22,6 @@ import {
 import {
   PlatformIdAlreadyRegisteredError,
   TrustResolver,
-  type Platform,
 } from "../trust-resolver";
 import type { Agent } from "../../types/cortex-config";
 
@@ -346,7 +345,7 @@ describe("TrustResolver — platform key encoding", () => {
     // platformId portion survives.
     const resolver = new TrustResolver(registryOf(agentFixture({ id: "luna" })));
     const weirdId = "abc|def|ghi";
-    resolver.register("discord" as Platform, weirdId, "luna");
+    resolver.register("discord", weirdId, "luna");
     expect(resolver.lookupAgentId("discord", weirdId)).toBe("luna");
     const owned = resolver.identitiesOf("luna");
     expect(owned).toEqual([{ platform: "discord", platformId: weirdId }]);

--- a/src/substrates/claude-code/__tests__/harness.test.ts
+++ b/src/substrates/claude-code/__tests__/harness.test.ts
@@ -94,7 +94,7 @@ function captureFactory(result: CCSessionResult): {
     factory,
     opts: seen,
     get killCalls() { return killCalls; },
-  } as { factory: CCSessionFactory; opts: CCSessionOpts[]; killCalls: number };
+  };
 }
 
 async function drain(it: AsyncIterable<MyelinEnvelope>): Promise<MyelinEnvelope[]> {

--- a/src/surface/mc/__tests__/client-registry.test.ts
+++ b/src/surface/mc/__tests__/client-registry.test.ts
@@ -1,12 +1,12 @@
 import { describe, it, expect } from "bun:test";
 import { WsClientRegistry } from "../ws/client-registry";
-import type { WsData, WsServerMessage } from "../ws/types";
+import type { WsServerMessage } from "../ws/types";
 
 // Minimal fake ServerWebSocket for unit testing
 function fakeWs(clientId: string): { ws: any; sent: string[] } {
   const sent: string[] = [];
   const ws = {
-    data: { clientId } as WsData,
+    data: { clientId },
     send(msg: string) {
       sent.push(msg);
     },

--- a/src/surface/mc/__tests__/ingestor.test.ts
+++ b/src/surface/mc/__tests__/ingestor.test.ts
@@ -133,10 +133,10 @@ describe("ingestEvents", () => {
   it("logs unregistered session drops to stderr", () => {
     const written: string[] = [];
     const origWrite = process.stderr.write;
-    process.stderr.write = ((chunk: string) => {
+    process.stderr.write = (chunk: string) => {
       written.push(chunk);
       return true;
-    }) as typeof process.stderr.write;
+    };
 
     try {
       const events = [makeRawEvent("e-1", "totally-unknown-session")];

--- a/src/surface/mc/__tests__/notification-render.test.ts
+++ b/src/surface/mc/__tests__/notification-render.test.ts
@@ -13,7 +13,6 @@ import {
   truncateWordBoundary,
   type RenderContext,
 } from "../notifications/render";
-import type { BlockReason } from "../types";
 import type { NotificationIntent } from "../notifications/should-notify";
 
 const intentP1Err: NotificationIntent = {
@@ -32,7 +31,7 @@ function ctx(overrides: Partial<RenderContext> = {}): RenderContext {
     blockReason: {
       kind: "tool.error",
       payload: { tool_name: "bash", error_message: "permission denied" },
-    } as BlockReason,
+    },
     cycle: 3,
     observedAgo: "2s ago",
     deepLink: "https://grove.meta-factory.ai/?focus=assignment/01HZ&from=dm",

--- a/src/surface/mc/__tests__/state-machine.test.ts
+++ b/src/surface/mc/__tests__/state-machine.test.ts
@@ -228,7 +228,7 @@ describe("state machine — exhaustive matrix", () => {
     if (type === "block") {
       return { type, reason: permissionBlock };
     }
-    return { type } as Action;
+    return { type };
   }
 
   for (const from of STATES) {

--- a/src/surface/mc/db/events.ts
+++ b/src/surface/mc/db/events.ts
@@ -263,7 +263,7 @@ export function createOperatorCurationEvent(
   return insertEvent(db, {
     sessionId,
     type: "operator.curation",
-    payload: payload as unknown as Record<string, unknown>,
+    payload,
   });
 }
 


### PR DESCRIPTION
## Summary
- Drive `no-unnecessary-type-assertion` to zero (17→0). 13 files.
- **50 → 33 errors (-17, -34%)**.

## Patterns
- Drop item-casts inside typed-array literals (`} as Agent` in `Agent[]`).
- Drop function-return casts where return type is declared.
- Drop literal-arg casts (`"discord" as Platform`) where the parameter accepts the union.
- Drop overload-ducking casts (`process.stderr.write` assignment, `connectImpl` factory).
- Drop double-casts (`payload as unknown as Record<string, unknown>`) where the source type already extends the target.

## Verify
- `bunx tsc --noEmit` → exit 0
- `bun run lint:errors` → 33 problems (was 50)
- `bun test` → 2742 pass / 1 skip / 0 fail / 6429 expects

## Out of scope
- 33 remaining errors stay for follow-up sweeps. Top: `no-unused-vars` (4), `no-require-imports` (4), `no-misused-promises` (3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)