### PR TITLE
chore(lint): sweep #37 — unused-vars + require-imports + misused-promises (33→22)

### DIFF
--- a/src/adapters/discord/client.ts
+++ b/src/adapters/discord/client.ts
@@ -3,7 +3,7 @@
  * Initializes discord.js client with required intents and event handlers.
  */
 
-import { Client, GatewayIntentBits, Partials, type TextChannel, type ThreadChannel, type Message } from "discord.js";
+import { Client, GatewayIntentBits, Partials, type Message } from "discord.js";
 
 export interface ConnectionHealth {
   reconnectCount: number;

--- a/src/adapters/mattermost/server.ts
+++ b/src/adapters/mattermost/server.ts
@@ -162,6 +162,6 @@ export function createMattermostServer(
 
   return {
     server,
-    stop: () => server.stop(),
+    stop: () => { void server.stop(); },
   };
 }

--- a/src/cli/cortex/commands/__tests__/agents.test.ts
+++ b/src/cli/cortex/commands/__tests__/agents.test.ts
@@ -1,7 +1,7 @@
 // F-3 — cortex agents reload/list CLI tests.
 
 import { describe, expect, test } from "bun:test";
-import { mkdtempSync, writeFileSync, copyFileSync, mkdirSync } from "fs";
+import { mkdtempSync, writeFileSync, copyFileSync, mkdirSync, readdirSync, readFileSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 
@@ -402,10 +402,9 @@ function seedConfigDir(cfg: string, srcAgentsDir: string): void {
   copyFileSync(PERSONA_PATH, join(personasD, "echo.md"));
   // Copy the fixture's fragments — but rewrite the persona path so it
   // resolves correctly against the new agents.d/ directory.
-  const fs = require("fs") as typeof import("fs");
-  for (const filename of fs.readdirSync(srcAgentsDir)) {
+  for (const filename of readdirSync(srcAgentsDir)) {
     if (!filename.endsWith(".yaml")) continue;
-    const content = fs.readFileSync(join(srcAgentsDir, filename), "utf-8");
-    fs.writeFileSync(join(agentsD, filename), content);
+    const content = readFileSync(join(srcAgentsDir, filename), "utf-8");
+    writeFileSync(join(agentsD, filename), content);
   }
 }

--- a/src/substrates/claude-code/harness.ts
+++ b/src/substrates/claude-code/harness.ts
@@ -77,7 +77,6 @@ import type { Envelope } from "../../bus/myelin/envelope-validator";
 import type {
   Capability,
   DispatchRequest,
-  HarnessId,
   MyelinEnvelope,
   SessionHarness,
 } from "../../common/substrates/types";

--- a/src/surface/mc/db/metrics.ts
+++ b/src/surface/mc/db/metrics.ts
@@ -329,7 +329,6 @@ export function computeFleetMetrics(
   opts: FleetMetricsOptions
 ): FleetMetrics {
   const sinceIso = opts.since.toISOString();
-  const sinceMs = opts.since.getTime();
 
   // Pull every assignment that intersects the window. An assignment counts
   // when:

--- a/src/surface/mc/index.ts
+++ b/src/surface/mc/index.ts
@@ -45,8 +45,8 @@ try {
     process.exit(0);
   };
 
-  process.on("SIGINT", shutdown);
-  process.on("SIGTERM", shutdown);
+  process.on("SIGINT", () => { void shutdown(); });
+  process.on("SIGTERM", () => { void shutdown(); });
 } catch (err) {
   process.stderr.write(
     `[mission-control] FATAL: ${(err as Error).message}\n`

--- a/src/taps/cc-events/lib/__tests__/event-processor.test.ts
+++ b/src/taps/cc-events/lib/__tests__/event-processor.test.ts
@@ -1,7 +1,7 @@
 import { test, expect, describe, beforeEach, afterEach } from "bun:test";
 import { EventProcessor } from "../event-processor";
 import { JsonlReader } from "../jsonl-reader";
-import { mkdirSync, writeFileSync, readFileSync, rmSync, existsSync } from "fs";
+import { mkdirSync, writeFileSync, readFileSync, rmSync, existsSync, appendFileSync } from "fs";
 import { join } from "path";
 import type { RelayPolicy } from "../policy-schema";
 
@@ -10,7 +10,6 @@ const RAW_DIR = join(TEST_DIR, "raw");
 const PUB_DIR = join(TEST_DIR, "published");
 
 function writeEvent(file: string, event: Record<string, unknown>) {
-  const { appendFileSync } = require("fs");
   appendFileSync(file, JSON.stringify(event) + "\n");
 }
 

--- a/src/taps/cc-events/lib/__tests__/jsonl-reader.test.ts
+++ b/src/taps/cc-events/lib/__tests__/jsonl-reader.test.ts
@@ -1,12 +1,11 @@
 import { test, expect, describe, beforeEach, afterEach } from "bun:test";
 import { JsonlReader } from "../jsonl-reader";
-import { mkdirSync, writeFileSync, rmSync, existsSync } from "fs";
+import { mkdirSync, writeFileSync, rmSync, existsSync, appendFileSync } from "fs";
 import { join } from "path";
 
 const TEST_DIR = join(import.meta.dir, ".test-jsonl");
 
 function writeEvent(file: string, event: Record<string, unknown>) {
-  const { appendFileSync } = require("fs");
   appendFileSync(file, JSON.stringify(event) + "\n");
 }
 
@@ -62,7 +61,6 @@ describe("JsonlReader", () => {
     const reader = new JsonlReader();
 
     writeEvent(file, sampleEvent(1));
-    const { appendFileSync } = require("fs");
     appendFileSync(file, "this is not json\n");
     writeEvent(file, sampleEvent(2));
 


### PR DESCRIPTION
## Summary
- Three small rule families to zero: `no-unused-vars` (4→0), `no-require-imports` (4→0), `no-misused-promises` (3→0).
- **33 → 22 errors (-11, -33%)**.

## Patterns
- Drop unused type imports + locals (no-op replacements where the runtime narrowed differently).
- Replace `require("fs")` shims with named ESM imports.
- Wrap async callbacks passed to void-returning listener slots with `() => { void fn(); }`.

## Verify
- `bunx tsc --noEmit` → exit 0
- `bun run lint:errors` → 22 problems (was 33)
- `bun test` → 2742 pass / 1 skip / 0 fail / 6429 expects

## Out of scope
- 22 remaining errors stay for follow-up sweeps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)