### PR TITLE
chore(lint): sweep #38 — final 22 to zero + gate ESLint blocking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,15 +42,13 @@ jobs:
 
   # ──────────────────────────────────────────────────────────────────
   # Lint — strict ESLint gate. Ported from arc + myelin patterns
-  # (arc PR #150 sweep + myelin#120..#127 chain). Cortex starts with a
-  # non-gating sweep window: `continue-on-error: true` while the
-  # baseline (~1261 errors at port time) burns down. Flip the flag
-  # once the count hits 0; tracked in a follow-up issue.
+  # (arc PR #150 sweep + myelin#120..#127 chain). Baseline at port
+  # time was ~1261 errors; sweeps #1..#38 drove it to 0 (cortex PRs
+  # #152..#191). Gate is now blocking — new code must pass lint.
   # ──────────────────────────────────────────────────────────────────
   lint:
     name: Lint
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
 
@@ -60,5 +58,5 @@ jobs:
 
       - run: bun install --frozen-lockfile
 
-      - name: ESLint (errors only — advisory until sweep complete)
+      - name: ESLint (errors only — blocking gate)
         run: bun run lint:errors

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -133,6 +133,7 @@ export default tseslint.config(
       "**/*.bak.ts",
       "eslint.config.js",
       "scripts/",
+      ".github/scripts/",
       ".claude/",
       ".specify/",
       ".triage/",

--- a/src/adapters/__tests__/envelope-renderer.test.ts
+++ b/src/adapters/__tests__/envelope-renderer.test.ts
@@ -110,11 +110,11 @@ describe("formatEnvelopeAsMarkdown — payload code block", () => {
     // Extract the JSON between the ```json … ``` fence and ensure it
     // round-trips back to the original object — proves we didn't drop
     // or reformat any field.
-    const match = out.match(/```json\n([\s\S]*?)\n```/);
+    const match = /```json\n([\s\S]*?)\n```/.exec(out);
     expect(match).not.toBeNull();
     const captured = match?.[1];
     expect(captured).toBeDefined();
-    const parsed = JSON.parse(captured as string);
+    const parsed = JSON.parse(captured!);
     expect(parsed).toEqual(payload);
   });
 });

--- a/src/adapters/discord/__tests__/operator-dm-buffer.test.ts
+++ b/src/adapters/discord/__tests__/operator-dm-buffer.test.ts
@@ -177,6 +177,10 @@ describe("notifyOperator + buffer write semantics", () => {
     // Simulate the race: connectionHealth is true at the start of the call,
     // but the underlying `users.fetch` throws a transient error, and by the
     // time the catch runs, connectionHealth has flipped to false.
+    // Declared with `let` so the closure can capture-then-bind it after
+    // `makeAdapter` returns the health object. ESLint's prefer-const sees
+    // a single assignment; the definite-assignment guard is intentional.
+    // eslint-disable-next-line prefer-const
     let healthRef!: ConnectionHealth;
     const fetchUser = async (): Promise<FakeUser> => {
       // Flip health right before the throw

--- a/src/adapters/discord/response-poster.ts
+++ b/src/adapters/discord/response-poster.ts
@@ -15,7 +15,7 @@ export const DISCORD_MAX_LENGTH = 2000;
 export function decodeHtmlEntities(text: string): string {
   return text
     // Decode numeric entities (&#233; → é, &#x00E9; → é)
-    .replace(/&#(\d+);/g, (match, dec) => {
+    .replace(/&#(\d+);/g, (match: string, dec: string) => {
       const codePoint = parseInt(dec, 10);
       // Valid Unicode: 0 to 0x10FFFF (1114111)
       if (codePoint < 0 || codePoint > 0x10FFFF) {
@@ -23,7 +23,7 @@ export function decodeHtmlEntities(text: string): string {
       }
       return String.fromCodePoint(codePoint);
     })
-    .replace(/&#x([0-9A-Fa-f]+);/g, (match, hex) => {
+    .replace(/&#x([0-9A-Fa-f]+);/g, (match: string, hex: string) => {
       const codePoint = parseInt(hex, 16);
       if (codePoint < 0 || codePoint > 0x10FFFF) {
         return match; // Leave invalid entities unchanged

--- a/src/bus/myelin/__tests__/runtime.test.ts
+++ b/src/bus/myelin/__tests__/runtime.test.ts
@@ -66,6 +66,10 @@ function makeFakeNatsConnection() {
     const iteratorDone = new Promise<void>((r) => {
       iteratorResolve = r;
     });
+    // No `yield` — closes immediately when iteratorDone resolves. The
+    // myelin runtime's subscriber loop only checks the `done` flag, so a
+    // generator that returns without yielding satisfies the contract.
+    // eslint-disable-next-line require-yield
     const iterator = (async function* () {
       await iteratorDone;
     })();

--- a/src/bus/myelin/__tests__/subscriber.test.ts
+++ b/src/bus/myelin/__tests__/subscriber.test.ts
@@ -17,7 +17,7 @@ import validEnvelope from "../vendor/__fixtures__/valid-envelope.json" with { ty
 //      are read-side primitives and copying keeps each suite independent) ----
 
 function makeFakeSubscription() {
-  type Msg = { subject: string; data: Uint8Array };
+  interface Msg { subject: string; data: Uint8Array }
   const queue: Msg[] = [];
   let waiter: ((m: Msg | null) => void) | null = null;
   let drained = false;

--- a/src/cli/discord/lib/config.ts
+++ b/src/cli/discord/lib/config.ts
@@ -33,7 +33,7 @@ const CONFIG_PATH = join(process.env.HOME ?? "~", ".config", "grove", "cli.yaml"
 export function loadConfig(): DiscordCliConfig {
   if (!existsSync(CONFIG_PATH)) return {};
   const text = readFileSync(CONFIG_PATH, "utf-8");
-  return YAML.parse(text) ?? {};
+  return (YAML.parse(text) as DiscordCliConfig | undefined) ?? {};
 }
 
 export function saveConfig(config: DiscordCliConfig): void {

--- a/src/common/config/account-signing-key.ts
+++ b/src/common/config/account-signing-key.ts
@@ -98,6 +98,6 @@ export async function loadAccountSigningKey(path: string): Promise<KeyPair> {
     // Re-throw with the path attached so operators can pinpoint the
     // bad file when they have multiple nkey files staged.
     const message = err instanceof Error ? err.message : String(err);
-    throw new Error(`failed to parse account signing key at ${path}: ${message}`);
+    throw new Error(`failed to parse account signing key at ${path}: ${message}`, { cause: err });
   }
 }

--- a/src/runner/__tests__/session-manager.test.ts
+++ b/src/runner/__tests__/session-manager.test.ts
@@ -26,7 +26,7 @@ describe("SessionManager", () => {
 
     // Small delay
     const start = Date.now();
-    while (Date.now() - start < 10) {} // busy wait 10ms
+    while (Date.now() - start < 10) { /* busy wait 10ms */ }
 
     const second = manager.getSession("thread-1");
     expect(second!.lastActivity).toBeGreaterThanOrEqual(firstTime);

--- a/src/runner/db-utils.ts
+++ b/src/runner/db-utils.ts
@@ -20,7 +20,7 @@ export function initDatabase(dbPath: string): Database {
   }
 
   const db = new Database(dbPath);
-  db.exec("PRAGMA journal_mode = WAL");
-  db.exec("PRAGMA busy_timeout = 5000");
+  db.run("PRAGMA journal_mode = WAL");
+  db.run("PRAGMA busy_timeout = 5000");
   return db;
 }

--- a/src/runner/task-tracker.ts
+++ b/src/runner/task-tracker.ts
@@ -62,7 +62,7 @@ export class TaskTracker {
     for (const task of this.tasks.values()) {
       exitPromises.push(
         new Promise<void>((resolve) => {
-          task.session.on("exit", () => resolve());
+          task.session.on("exit", () => { resolve(); });
           // Give it a moment to finish naturally, then kill
           setTimeout(() => {
             task.session.kill();

--- a/src/surface/mc/__tests__/api.test.ts
+++ b/src/surface/mc/__tests__/api.test.ts
@@ -1868,7 +1868,7 @@ describe("PATCH /api/iterations/:id", () => {
     await teardown(t);
   });
 
-  function seedIter(id: string, state: string = "inbox"): void {
+  function seedIter(id: string, state = "inbox"): void {
     t.db.query(
       `INSERT INTO iterations (id, title, state, priority) VALUES (?, ?, ?, 2)`
     ).run(id, `Iter ${id}`, state);

--- a/src/surface/mc/__tests__/db-init.test.ts
+++ b/src/surface/mc/__tests__/db-init.test.ts
@@ -70,6 +70,6 @@ describe("initDatabase", () => {
     expect(err).toBeDefined();
     // The underlying syscall error includes the offending path — verify it
     // surfaces so the operator can act.
-    expect(String((err as Error).message)).toContain(blocker);
+    expect((err as Error).message).toContain(blocker);
   });
 });

--- a/src/surface/mc/__tests__/server.test.ts
+++ b/src/surface/mc/__tests__/server.test.ts
@@ -108,6 +108,6 @@ describe("mission-control server", () => {
       err = e;
     }
     expect(err).toBeDefined();
-    expect(String((err as Error).message)).toContain(String(testPort));
+    expect((err as Error).message).toContain(String(testPort));
   });
 });

--- a/src/surface/mc/notifications.ts
+++ b/src/surface/mc/notifications.ts
@@ -274,11 +274,12 @@ export function observeTransitionForCancel(
   if (managed.closing) return null;
   if (managed.proc.exitCode !== null) return null;
 
-  return deps.closeSession(sessionId).catch((err) => {
+  return deps.closeSession(sessionId).catch((err: unknown) => {
     // Best-effort enforcement: the DB state is the source of truth, the
     // kill is enforcement on top. Log and swallow.
+    const message = err instanceof Error ? err.message : String(err);
     process.stderr.write(
-      `[notifications] observeTransitionForCancel: closeSession(${sessionId}) failed: ${(err as Error).message}\n`
+      `[notifications] observeTransitionForCancel: closeSession(${sessionId}) failed: ${message}\n`
     );
   });
 }

--- a/src/surface/mc/notifications/render.ts
+++ b/src/surface/mc/notifications/render.ts
@@ -246,7 +246,7 @@ function renderChannelContextLine(ctx: RenderContext): string | null {
 }
 
 function pickSummary(ctx: RenderContext): string | null {
-  if (ctx.blockReason && ctx.blockReason.kind === "permission.request") {
+  if (ctx.blockReason?.kind === "permission.request") {
     const c = ctx.blockReason.payload.context;
     if (c && c.length > 0) return truncateWordBoundary(c, SUMMARY_MAX);
   }

--- a/src/surface/mc/session/process-manager.ts
+++ b/src/surface/mc/session/process-manager.ts
@@ -98,9 +98,9 @@ export class ProcessManager {
       entries.map(async (m) => {
         const result = await Promise.race([
           m.proc.exited,
-          new Promise<typeof TIMEOUT>((r) =>
-            setTimeout(() => r(TIMEOUT), gracefulTimeoutMs)
-          ),
+          new Promise<typeof TIMEOUT>((r) => {
+            setTimeout(() => { r(TIMEOUT); }, gracefulTimeoutMs);
+          }),
         ]);
 
         if (result === TIMEOUT && m.proc.exitCode === null) {

--- a/src/surface/mc/session/stdout-dispatcher.ts
+++ b/src/surface/mc/session/stdout-dispatcher.ts
@@ -63,12 +63,13 @@ export function startStdoutDispatcher(
   stdout: ReadableStream<Uint8Array>,
   deps: StdoutDispatcherDeps
 ): StdoutDispatcherHandle {
-  const done = consumeStream(stdout, deps).catch((err) => {
+  const done = consumeStream(stdout, deps).catch((err: unknown) => {
     // Reading CC's stdout should never throw in normal operation, but if the
     // stream errors (e.g. process killed mid-read) we surface it rather than
     // drop it — a silent swallow here would hide dispatcher crashes.
+    const message = err instanceof Error ? err.message : String(err);
     process.stderr.write(
-      `[stdout-dispatcher] stream read failed for ${deps.sessionId}: ${(err as Error).message}\n`
+      `[stdout-dispatcher] stream read failed for ${deps.sessionId}: ${message}\n`
     );
   });
   return { done };

--- a/src/taps/cc-events/__tests__/cloud-publisher.test.ts
+++ b/src/taps/cc-events/__tests__/cloud-publisher.test.ts
@@ -134,7 +134,7 @@ describe("CloudPublisher", () => {
     await pub.flush();
 
     const headers = fetchCalls[0]!.init.headers as Record<string, string>;
-    expect(headers["Authorization"]).toBe("Bearer grove_sk_secret");
+    expect(headers.Authorization).toBe("Bearer grove_sk_secret");
     expect(headers["Content-Type"]).toBe("application/json");
 
     pub.close();


### PR DESCRIPTION
## Summary
- Drive remaining 22 errors to zero across 11 distinct rule families.
- **Cortex now lints clean.**
- Flip CI lint job from advisory (`continue-on-error: true`) to **blocking**.

## Final per-rule fixes
- prefer-regexp-exec, non-nullable-type-assertion-style (envelope-renderer test)
- prefer-const (operator-dm-buffer test — closure capture, inline-disable)
- no-unsafe-argument (response-poster — type String.replace callback args)
- require-yield (runtime test — yield-less generator intentional)
- consistent-type-definitions (subscriber test — type→interface)
- no-unsafe-return (cli/discord config — type YAML.parse result)
- preserve-caught-error (account-signing-key — `{ cause: err }`)
- no-empty (session-manager test — comment-only block)
- no-deprecated (db-utils — `db.exec` → `db.run`)
- no-confusing-void-expression (task-tracker, process-manager)
- no-inferrable-types (api test)
- no-unnecessary-type-conversion (db-init, server tests)
- use-unknown-in-catch-callback-variable (notifications, stdout-dispatcher)
- prefer-optional-chain (notifications/render)
- dot-notation (cloud-publisher test)
- Config: `.github/scripts/` added to ignores (outside tsconfig scope).

## Sweep summary
PRs #152 + #154..#191 drove the full **~1261 → 0** baseline across 38 sweeps.

## Verify
- `bunx tsc --noEmit` → exit 0
- `bun run lint:errors` → **0 problems**
- `bun test` → 2742 pass / 1 skip / 0 fail / 6429 expects

🤖 Generated with [Claude Code](https://claude.com/claude-code)