### PR TITLE
docs(iaw): mark Phase A complete — A.1–A.6 + acceptance criteria all met (refs cortex#113)

### DIFF
--- a/docs/plan-internet-of-agentic-work.md
+++ b/docs/plan-internet-of-agentic-work.md
@@ -71,54 +71,54 @@ Total: 12–18 weeks if strictly sequenced. Phases A and B are sequenceable; Pha
 - Myelin namespace extension issue filed (Phase A.5).
 - cortex#92 (substrate harness design PR) merged or its Q5/Q6/Q7 resolved.
 
-### A.1 Substrate harness types + ClaudeCodeHarness refactor (cortex#91 PR-A)
+### A.1 Substrate harness types + ClaudeCodeHarness refactor (cortex#91 PR-A) — ✅ done (PR #125, #126)
 
-- [ ] **A.1.1** `SessionHarness` interface defined in `src/common/substrates/types.ts`. Methods: `dispatch(req): AsyncIterable<MyelinEnvelope>`, lifecycle hooks (`onStart`, `onStop`).
-- [ ] **A.1.2** `ClaudeCodeHarness` implementation refactored out of `src/runner/cc-session.ts`. The spawn-and-stream-json logic moves behind the `SessionHarness.dispatch()` contract.
-- [ ] **A.1.3** `BusPeerHarness` stub — connects to NATS via the existing `MyelinRuntime`; publishes a dispatch envelope; subscribes to the reply subject. Pattern matches sage's existing peer behaviour.
-- [ ] **A.1.4** Tests: substrate harness unit tests cover both implementations; `cc-session` regression tests pass behind the new interface.
-- [ ] **A.1.5** `bunx tsc --noEmit` clean.
+- [x] **A.1.1** `SessionHarness` interface defined in `src/common/substrates/types.ts`. Methods: `dispatch(req): AsyncIterable<MyelinEnvelope>`, lifecycle hooks (`onStart`, `onStop`). — PR #125
+- [x] **A.1.2** `ClaudeCodeHarness` implementation refactored out of `src/runner/cc-session.ts`. The spawn-and-stream-json logic moves behind the `SessionHarness.dispatch()` contract. — PR #125
+- [x] **A.1.3** `BusPeerHarness` stub — connects to NATS via the existing `MyelinRuntime`; publishes a dispatch envelope; subscribes to the reply subject. Pattern matches sage's existing peer behaviour. — PR #126
+- [x] **A.1.4** Tests: substrate harness unit tests cover both implementations; `cc-session` regression tests pass behind the new interface. — PR #125, #126
+- [x] **A.1.5** `bunx tsc --noEmit` clean. — verified at PR #126 merge
 
-### A.2 Envelope upgrade to post-F-021 myelin (cortex#109 sub-task)
+### A.2 Envelope upgrade to post-F-021 myelin (cortex#109 sub-task) — ✅ done (PR #128, follow-up #151)
 
-- [ ] **A.2.1** Bump `src/bus/myelin/envelope-validator.ts` `SCHEMA_SOURCE_COMMIT` from `96b14ea` to current myelin HEAD (post-#31 chain-of-stamps + F-021 task fields + `signed_by[]` array form).
-- [ ] **A.2.2** Update vendored schema at `src/bus/myelin/vendor/envelope.schema.json` to match.
-- [ ] **A.2.3** Wire chain-of-stamps consumption — read inbound `signed_by[]` and surface to dispatch-handler. No verification yet (that's Phase B); just structural parsing.
-- [ ] **A.2.4** Verify existing tests pass against the new schema; add tests for new fields (`requirements`, `distribution_mode`, `target_principal`, `deadline`, `sovereignty_required`).
+- [x] **A.2.1** Bump `src/bus/myelin/envelope-validator.ts` `SCHEMA_SOURCE_COMMIT` from `96b14ea` to current myelin HEAD (post-#31 chain-of-stamps + F-021 task fields + `signed_by[]` array form). — PR #128 (→ `4578ae1`), then PR #151 (→ `b69c877`).
+- [x] **A.2.2** Update vendored schema at `src/bus/myelin/vendor/envelope.schema.json` to match. — PR #128, refreshed at PR #151
+- [x] **A.2.3** Wire chain-of-stamps consumption — read inbound `signed_by[]` and surface to dispatch-handler. No verification yet (that's Phase B); just structural parsing. — PR #128
+- [x] **A.2.4** Verify existing tests pass against the new schema; add tests for new fields (`requirements`, `distribution_mode`, `target_principal`, `deadline`, `sovereignty_required`). — PR #128
 
-### A.3 Parameterise classification at the four emit sites (cortex#109 main work)
+### A.3 Parameterise classification at the four emit sites (cortex#109 main work) — ✅ done (PR #129)
 
-- [ ] **A.3.1** `src/bus/dispatch-events.ts:73` — accept `classification` as a constructor arg; default `"local"`.
-- [ ] **A.3.2** `src/bus/system-events.ts:102` — same.
-- [ ] **A.3.3** `src/bus/github-events.ts:89` — same.
-- [ ] **A.3.4** `src/taps/cc-events/cc-events.ts:99` — same.
-- [ ] **A.3.5** `src/bus/myelin/runtime.ts:236` — `publish()` derives subject prefix from `envelope.sovereignty.classification` (uses `deriveNatsSubject()` from myelin); rejects misaligned `classification` ↔ subject combinations at publish time.
-- [ ] **A.3.6** Tests: each emit site has a regression test that publishing with `classification: "federated"` produces a `federated.*` subject, not `local.*`.
+- [x] **A.3.1** `src/bus/dispatch-events.ts:73` — accept `classification` as a constructor arg; default `"local"`. — PR #129
+- [x] **A.3.2** `src/bus/system-events.ts:102` — same. — PR #129
+- [x] **A.3.3** `src/bus/github-events.ts:89` — same. — PR #129
+- [x] **A.3.4** `src/taps/cc-events/cc-events.ts:99` — same. — PR #129
+- [x] **A.3.5** `src/bus/myelin/runtime.ts:236` — `publish()` derives subject prefix from `envelope.sovereignty.classification` (uses `deriveNatsSubject()` from myelin); rejects misaligned `classification` ↔ subject combinations at publish time. — PR #129
+- [x] **A.3.6** Tests: each emit site has a regression test that publishing with `classification: "federated"` produces a `federated.*` subject, not `local.*`. — PR #129
 
-### A.4 Add visibility filter to surface-router (cortex#109 §B)
+### A.4 Add visibility filter to surface-router (cortex#109 §B) — ✅ done (PR #134)
 
-- [ ] **A.4.1** Extend `RendererSchema` in `src/common/types/cortex-config.ts` with a `visibility:` block:
+- [x] **A.4.1** Extend `RendererSchema` in `src/common/types/cortex-config.ts` with a `visibility:` block: — PR #134
   - `max_classification: "local" | "federated" | "public"` — renderer refuses higher.
   - `require_residency: string[]` — renderer accepts only matching residency.
   - `require_model_class: string[]` — renderer accepts only matching model class.
-- [ ] **A.4.2** Surface-router (`src/bus/surface-router.ts`) applies the visibility filter in `adapterMatches()` before invoking `adapter.render()`. Sovereignty mismatch = quiet skip + (optional) log.
-- [ ] **A.4.3** Dashboard renderer (`src/renderers/dashboard.ts`) declares its visibility config — default `max_classification: "local"` for parity with today.
-- [ ] **A.4.4** Tests: a `federated.*` envelope is dropped by a `max_classification: local` renderer; same envelope is rendered by a `max_classification: federated` renderer.
+- [x] **A.4.2** Surface-router (`src/bus/surface-router.ts`) applies the visibility filter in `adapterMatches()` before invoking `adapter.render()`. Sovereignty mismatch = quiet skip + (optional) log. — PR #134
+- [x] **A.4.3** Dashboard renderer (`src/renderers/dashboard.ts`) declares its visibility config — default `max_classification: "local"` for parity with today. — PR #134
+- [x] **A.4.4** Tests: a `federated.*` envelope is dropped by a `max_classification: local` renderer; same envelope is rendered by a `max_classification: federated` renderer. — PR #134
 
-### A.5 Add `stack:` block to cortex.yaml schema (Q7 lock-in)
+### A.5 Add `stack:` block to cortex.yaml schema (Q7 lock-in) — ✅ done (PR #140, #151; myelin#113 closed)
 
-- [ ] **A.5.1** File myelin issue: extend `specs/namespace.md` to allow `local.{operator}.{stack}.>` and `federated.{operator}.{stack}.>` subject grammars. `deriveNatsSubject()` and `validateSubjectEnvelopeAlignment()` extended to accept either form. Backward compatibility: if no stack segment, default-derive as `{operator_id}/default`.
-- [ ] **A.5.2** Cortex consumes the myelin extension once it lands — bump vendored envelope as needed.
-- [ ] **A.5.3** Extend `CortexConfig` in `src/common/types/cortex-config.ts` with a `stack:` block:
+- [x] **A.5.1** File myelin issue: extend `specs/namespace.md` to allow `local.{operator}.{stack}.>` and `federated.{operator}.{stack}.>` subject grammars. `deriveNatsSubject()` and `validateSubjectEnvelopeAlignment()` extended to accept either form. Backward compatibility: if no stack segment, default-derive as `{operator_id}/default`. — myelin#113 filed + merged 2026-05-13 (myelin PR #114, squash `91bf2b42`)
+- [x] **A.5.2** Cortex consumes the myelin extension once it lands — bump vendored envelope as needed. — PR #151 (vendored bump `4578ae1` → `b69c877` + stack-aware `deriveNatsSubject(opts)` adoption)
+- [x] **A.5.3** Extend `CortexConfig` in `src/common/types/cortex-config.ts` with a `stack:` block: — PR #140
   - `stack.id` — string matching `{operator_id}/{stack_id}` format with regex validation.
   - `stack.nkey_pub` — base32 NKey public key (signed by operator account NKey).
-- [ ] **A.5.4** `cortex.ts` entrypoint reads `stack:` at boot; falls back to `${operator.id}/default` if undeclared.
-- [ ] **A.5.5** `MyelinRuntime.publish()` includes the stack segment in subject derivation when present.
-- [ ] **A.5.6** Tests: cortex.yaml with `stack: { id: andreas/research }` emits envelopes on `local.andreas.research.>` instead of `local.andreas.>`; backward-compat test with no `stack:` block still emits `local.andreas.>` (which now becomes `local.andreas.default.>` once myelin extension lands).
+- [x] **A.5.4** `cortex.ts` entrypoint reads `stack:` at boot; falls back to `${operator.id}/default` if undeclared. — PR #140
+- [x] **A.5.5** `MyelinRuntime.publish()` includes the stack segment in subject derivation when present. — PR #151
+- [x] **A.5.6** Tests: cortex.yaml with `stack: { id: andreas/research }` emits envelopes on `local.andreas.research.>` instead of `local.andreas.>`; backward-compat test with no `stack:` block still emits `local.andreas.>` (which now becomes `local.andreas.default.>` once myelin extension lands). — PR #140 + #151
 
-### A.6 Add `capabilities:` block to cortex.yaml schema (Q2 lock-in)
+### A.6 Add `capabilities:` block to cortex.yaml schema (Q2 lock-in) — ✅ done (PR #146)
 
-- [ ] **A.6.1** Extend `CortexConfig` with a `capabilities:` block — array of capability declarations conforming to the constrained schema:
+- [x] **A.6.1** Extend `CortexConfig` with a `capabilities:` block — array of capability declarations conforming to the constrained schema: — PR #146
   ```yaml
   capabilities:
     - id: code-review.typescript
@@ -128,22 +128,34 @@ Total: 12–18 weeks if strictly sequenced. Phases A and B are sequenceable; Pha
       rate: { per_minute: 10 }   # optional
       cost: { cents_per_request: 2 }  # optional
   ```
-- [ ] **A.6.2** Schema validator enforces required fields (`id`, `description`, `tags`, `provided_by`); optional `rate` / `cost` validated as structured envelopes.
-- [ ] **A.6.3** Per-agent `capabilities[]` annotations within `agents[]` are first-class — the stack-level `capabilities:` block is the union plus any stack-extras.
-- [ ] **A.6.4** Tests: invalid capability declarations (free-text, missing `id`) are rejected at config load; valid ones parse into the typed object.
+- [x] **A.6.2** Schema validator enforces required fields (`id`, `description`, `tags`, `provided_by`); optional `rate` / `cost` validated as structured envelopes. — PR #146
+- [x] **A.6.3** Per-agent `capabilities[]` annotations within `agents[]` are first-class — the stack-level `capabilities:` block is the union plus any stack-extras. — PR #146
+- [x] **A.6.4** Tests: invalid capability declarations (free-text, missing `id`) are rejected at config load; valid ones parse into the typed object. — PR #146
 
-### Phase A acceptance criteria
+### Schema-grammar hardening (entry criterion for A.5.5) — ✅ done (PR #144, #149)
 
-- `SessionHarness` interface compiles + tested; `ClaudeCodeHarness` passes all current `cc-session.ts` tests behind new interface.
-- `BusPeerHarness` connects to local sage daemon and routes a fake review task end-to-end.
-- Cortex no longer hardcodes `classification` at any of the four emit sites.
-- Surface-router applies `sovereignty.classification` filter in `adapterMatches()`.
-- Renderer config supports `visibility:` block (max_classification / require_residency / require_model_class).
-- cortex.yaml `stack:` block validates and propagates into outbound envelopes' subject form.
-- cortex.yaml `capabilities:` block validates and is queryable from the substrate harness.
-- Vendored envelope past `96b14ea`; `signed_by[]` array surfaces structurally (no verification yet).
+The `{operator_id}` and `{stack_id}` segments are embedded in NATS subjects after A.5.5. To keep them safe boundaries for downstream pattern-matchers, all three identifier schemas were tightened to the letter-prefix grammar `/^[a-z][a-z0-9-]*$/`:
+
+- [x] `OperatorSchema.id` — PR #144 (closes cortex#141)
+- [x] `StackConfigSchema.id` segments — PR #144 (closes cortex#141)
+- [x] `AgentSchema.id`, `trust[]` entry, `CapabilityProviderIdSchema` — PR #149 (closes cortex#145)
+
+### Phase A acceptance criteria — ✅ all met (2026-05-15)
+
+- [x] `SessionHarness` interface compiles + tested; `ClaudeCodeHarness` passes all current `cc-session.ts` tests behind new interface. — PR #125, #126
+- [x] `BusPeerHarness` connects to local sage daemon and routes a fake review task end-to-end. — PR #126
+- [x] Cortex no longer hardcodes `classification` at any of the four emit sites. — PR #129
+- [x] Surface-router applies `sovereignty.classification` filter in `adapterMatches()`. — PR #134
+- [x] Renderer config supports `visibility:` block (max_classification / require_residency / require_model_class). — PR #134
+- [x] cortex.yaml `stack:` block validates and propagates into outbound envelopes' subject form. — PR #140 + #151
+- [x] cortex.yaml `capabilities:` block validates and is queryable from the substrate harness. — PR #146
+- [x] Vendored envelope past `96b14ea`; `signed_by[]` array surfaces structurally (no verification yet). — PR #128 (→ `4578ae1`), refreshed at PR #151 (→ `b69c877`)
 
 **Phase A does NOT require Phase B or later.** It unblocks single-stack federation; multi-operator waits for Phase D.
+
+**Carry-over to Phase B (or future ops cycle):**
+- **cortex#138** — JetStream `TASKS` stream filter shape (`local.*.tasks.>` → `local.*.*.tasks.>`). Cortex publishes stack-aware subjects today (PR #151), but cortex has no in-tree TASKS-stream consumer to break; the filter cutover is an operator-side NATS-server action (cortex.yaml ships no stream config). Reframed as a forward gate that lands when cortex grows a TASKS-stream consumer in Phase B/C.
+- **cortex#139** — parallel-checkpoint proposal closed as moot. The myelin-lead-time risk it hedged against did not materialise: myelin#113 (the upstream namespace PR) merged 2026-05-13 at 16:01, three hours after cortex#139 was filed.
 
 ---
 

--- a/src/common/types/stack.ts
+++ b/src/common/types/stack.ts
@@ -5,10 +5,8 @@
  * one operator can run multiple cortex stacks side-by-side
  * (`andreas/research`, `andreas/production`, `andreas/code`, …). The
  * subject-grammar extension that lets `local.{operator}.{stack}.…` envelopes
- * coexist with the current `local.{operator}.…` form is filed as a
- * **myelin** issue (myelin#113) and lands separately; this primitive ships
- * cortex-side ahead of that PR so the config surface is in place when the
- * envelope namespace lands.
+ * coexist with the legacy `local.{operator}.…` form lives in myelin
+ * (myelin#113 — closed by myelin PR #114, squash `91bf2b42`, 2026-05-13).
  *
  * What this file delivers (A.5.3 + A.5.4):
  *   - `StackConfigSchema` — Zod schema for the optional top-level `stack:`
@@ -20,17 +18,25 @@
  *     omitted, it default-derives `${operator.id}/default` so existing
  *     deployments preserve their identity verbatim (no behaviour change).
  *
- * What this file does NOT do:
- *   - **No subject derivation.** A.5.5 — `MyelinRuntime.publish()`
- *     consuming the stack segment — is blocked on myelin#113 and lands in
- *     a follow-up PR. Today `deriveStackId` is observed at boot and exposed
- *     on `LoadedConfig`/`StartCortexOptions` so call-sites can read it
- *     ahead of the namespace cutover, but no emit subject changes.
- *   - **No JetStream filter change.** The TASKS stream filter rewrite
- *     (`local.*.tasks.>` → `local.*.*.tasks.>`) is cortex#138 and ships
- *     separately.
- *   - **No envelope bump.** The vendored myelin envelope upgrade (A.5.2)
- *     waits on myelin#113.
+ * Cutover state (post-PR #151, A.5.5 shipped):
+ *   - **Subject derivation flips on the wire.** `MyelinRuntime.publish()`
+ *     now derives subjects via the stack-aware `deriveNatsSubject({ stack })`
+ *     ported from myelin (`b69c877`). Emitted envelopes carry the stack
+ *     segment in `local.{operator}.{stack}.>` form. Operators with no
+ *     `stack:` block fall through to the namespace spec's default-derived
+ *     `${operator.id}/default` for backward compatibility (myelin
+ *     `specs/namespace.md` §Backward-compat).
+ *   - **Vendored envelope past `96b14ea`.** PR #128 bumped to `4578ae1`;
+ *     PR #151 refreshed to `b69c877` to pick up stack-aware subject
+ *     derivation.
+ *
+ * Carry-over to Phase B / ops:
+ *   - **JetStream `TASKS` stream filter.** cortex#138 — the
+ *     `local.*.tasks.>` → `local.*.*.tasks.>` filter cutover — is an
+ *     operator-side NATS-server config change, not cortex code. Cortex
+ *     publishes stack-aware subjects today but ships no TASKS-stream
+ *     consumer of its own; the filter cutover lands when the first
+ *     in-tree consumer arrives (Phase B / Phase C).
  */
 
 import { z } from "zod/v4";


### PR DESCRIPTION
## Summary

Phase A of the Internet of Agentic Work landed across PR #125, #126, #128, #129, #134, #140, #144, #146, #149, #151 over the past week. This PR ticks the plan-document checkboxes against the actual merge state and refreshes the stale \`stack.ts\` header comment.

\`refs cortex#113\`

## Phase A mapping

| Slice | PRs | Status |
|---|---|---|
| A.1 — Substrate harness + ClaudeCodeHarness | #125, #126 | ✅ |
| A.2 — Envelope post-F-021 (signed_by[], task fields) | #128 (→ \`4578ae1\`), #151 (→ \`b69c877\`) | ✅ |
| A.3 — Parameterise classification at 4 emit sites | #129 | ✅ |
| A.4 — Visibility filter on surface-router | #134 | ✅ |
| A.5 — \`stack:\` block schema + boot + publish cutover | #140 (config/boot) + #151 (publish) | ✅ |
| A.6 — \`capabilities:\` block schema | #146 | ✅ |
| Schema-grammar trilogy (entry to A.5.5) | #144 (operator/stack id), #149 (agent id) | ✅ |
| Upstream myelin#113 (namespace \`{stack}\` segment) | myelin PR #114 (squash \`91bf2b42\`), 2026-05-13 | ✅ |

## Changes

- **\`docs/plan-internet-of-agentic-work.md\`** — every A.1.x through A.6.x checkbox flipped to \`[x]\` with the originating PR cited next to each item. New "Schema-grammar hardening" subsection appended to capture #144/#149. Phase A acceptance-criteria list now ticks with PR references. New "Carry-over" subsection records cortex#138 (JetStream filter — operator-side action, no in-tree consumer to break) and cortex#139 (parallel checkpoint — moot because myelin#113 merged three hours after the proposal was filed).
- **\`src/common/types/stack.ts\`** — header comment block refreshed. The "What this file does NOT do" warnings about subject derivation not having shipped, the envelope not having been bumped, and the myelin upstream being blocked were stale post-PR #151. New "Cutover state" + "Carry-over" sections describe today's reality.

## Verification

- \`bunx tsc --noEmit\` — clean
- \`bun run lint:errors\` — clean (0 errors)
- No source-level behaviour changes — only doc + comment edits

## Follow-up (in gh comments after merge)

- Close cortex#113 (Phase A meta) — all sub-items done
- Close cortex#138 with the reframing note (forward gate for Phase B/C consumer)
- Close cortex#139 as moot (myelin#113 already shipped)