### PR TITLE
feat(bus): IAW B.1a — verification primitives (refs cortex#114)

### DIFF
--- a/src/bus/__tests__/verify-signed-by-chain.test.ts
+++ b/src/bus/__tests__/verify-signed-by-chain.test.ts
@@ -1,0 +1,374 @@
+/**
+ * IAW Phase B.1a (cortex#114) — `verifySignedByChain` tests.
+ *
+ * Nine table-driven cases per Echo's B.1a review minimum baseline:
+ *   1. Happy path — single trusted ed25519 stamp
+ *   2. Empty chain, `rejectEmpty: true` (default) → empty_chain
+ *   3. Empty chain, `rejectEmpty: false` → valid w/ empty skipped
+ *   4. Malformed principal (did:key:…) → malformed_principal
+ *   5. Well-formed DID, agent not in registry → unknown_agent
+ *   6. Agent registered but no nkey_pub → principal_has_no_nkey_pub
+ *   7. Signer not in receiver's trust → signer_not_trusted
+ *   8. Mixed chain — hub-stamp at 0 (skipped), ed25519 at 1 → valid w/ skipped:[0]
+ *   9. Multi-stamp, second rejected → rejectedAt:1, reason carried, skipped:[]
+ *
+ * Structural checks only at this slice — the cryptographic ed25519 verify
+ * lands in B.1c.
+ */
+
+import { describe, test, expect } from "bun:test";
+import { AgentRegistry } from "../../common/agents/registry";
+import { TrustResolver } from "../../common/agents/trust-resolver";
+import {
+  verifySignedByChain,
+  type ChainVerificationResult,
+} from "../verify-signed-by-chain";
+import type { Envelope, SignedBy } from "../myelin/envelope-validator";
+import type { Agent } from "../../common/types/cortex-config";
+
+// =============================================================================
+// Fixtures
+// =============================================================================
+
+// Valid 56-char U-prefixed base32 NKey shapes — same regex as
+// StackConfigSchema.nkey_pub / AgentSchema.nkey_pub. The bytes don't
+// have to be valid NATS keys for structural-trust tests; only the
+// regex shape matters.
+const NKEY_LUNA = "U" + "A".repeat(55);
+const NKEY_ECHO = "U" + "B".repeat(55);
+const NKEY_HOLLY = "U" + "C".repeat(55);
+
+function discordPresence() {
+  return {
+    enabled: true,
+    token: "discord-bot-token",
+    guildId: "1487000000000000000",
+    agentChannelId: "1487000000000000001",
+    logChannelId: "1487000000000000002",
+    contextDepth: 10,
+    enableAgentLog: false,
+    roles: [],
+    defaultRole: "allow-all",
+    dm: {
+      operatorRole: {
+        features: ["chat", "async", "team"] as const,
+        disallowedTools: [],
+        bashGuard: true,
+      },
+      defaultRole: "denied" as const,
+      userRoles: [],
+    },
+  };
+}
+
+function agentFixture(overrides: Partial<Agent> = {}): Agent {
+  return {
+    id: "luna",
+    displayName: "Luna",
+    persona: "./personas/luna.md",
+    roles: [],
+    trust: [],
+    presence: { discord: discordPresence() },
+    ...overrides,
+  } as Agent;
+}
+
+function ed25519Stamp(principal: string): SignedBy {
+  return {
+    method: "ed25519",
+    principal,
+    // 88-char base64 placeholder — the structural slice doesn't verify
+    // signature bytes; B.1c will. Any string of the right rough shape.
+    signature: "A".repeat(88),
+    at: "2026-05-15T08:00:00.000Z",
+  };
+}
+
+function hubStamp(principal: string, hub: string): SignedBy {
+  return {
+    method: "hub-stamp",
+    principal,
+    stamped_by: hub,
+    signature: "B".repeat(88),
+    at: "2026-05-15T08:00:00.000Z",
+  };
+}
+
+function envelopeWithChain(chain: SignedBy[] | SignedBy | undefined): Envelope {
+  const base: Envelope = {
+    id: "00000000-0000-4000-8000-000000000001",
+    source: "metafactory.luna.local",
+    type: "test.verify.case",
+    timestamp: "2026-05-15T08:00:00.000Z",
+    sovereignty: {
+      classification: "local",
+      data_residency: "NZ",
+      max_hop: 4,
+      frontier_ok: false,
+      model_class: "any",
+    },
+    payload: {},
+  };
+  if (chain !== undefined) {
+    base.signed_by = chain;
+  }
+  return base;
+}
+
+function resolverWith(...agents: Agent[]): TrustResolver {
+  return new TrustResolver(AgentRegistry.fromAgents(agents));
+}
+
+// =============================================================================
+// Cases
+// =============================================================================
+
+describe("verifySignedByChain — happy path + skipped semantics", () => {
+  test("[1] single trusted ed25519 stamp → valid with empty skipped", () => {
+    // Receiver "luna" trusts sender "echo" with known nkey.
+    const luna = agentFixture({ id: "luna", trust: ["echo"] });
+    const echo = agentFixture({
+      id: "echo",
+      displayName: "Echo",
+      nkey_pub: NKEY_ECHO,
+    });
+    const resolver = resolverWith(luna, echo);
+
+    const env = envelopeWithChain([ed25519Stamp("did:mf:echo")]);
+    const result: ChainVerificationResult = verifySignedByChain(env, {
+      resolver,
+      receivingAgentId: "luna",
+    });
+
+    expect(result.valid).toBe(true);
+    if (result.valid) {
+      expect(result.skipped).toEqual([]);
+    }
+  });
+
+  test("[8] mixed chain — hub-stamp at index 0 (skipped), trusted ed25519 at index 1 → valid w/ skipped:[0]", () => {
+    const luna = agentFixture({ id: "luna", trust: ["echo"] });
+    const echo = agentFixture({
+      id: "echo",
+      displayName: "Echo",
+      nkey_pub: NKEY_ECHO,
+    });
+    const resolver = resolverWith(luna, echo);
+
+    const env = envelopeWithChain([
+      hubStamp("did:mf:echo", "did:mf:hub-alpha"),
+      ed25519Stamp("did:mf:echo"),
+    ]);
+    const result = verifySignedByChain(env, {
+      resolver,
+      receivingAgentId: "luna",
+    });
+
+    expect(result.valid).toBe(true);
+    if (result.valid) {
+      expect(result.skipped).toEqual([0]);
+    }
+  });
+});
+
+describe("verifySignedByChain — empty chain semantics", () => {
+  test("[2] empty chain, rejectEmpty defaults to true → empty_chain rejection", () => {
+    const luna = agentFixture({ id: "luna" });
+    const resolver = resolverWith(luna);
+    const env = envelopeWithChain(undefined);
+
+    const result = verifySignedByChain(env, {
+      resolver,
+      receivingAgentId: "luna",
+    });
+
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.rejectedAt).toBe(0);
+      expect(result.reason.kind).toBe("empty_chain");
+      expect(result.skipped).toEqual([]);
+    }
+  });
+
+  test("[3] empty chain, rejectEmpty explicit false → valid w/ empty skipped", () => {
+    const luna = agentFixture({ id: "luna" });
+    const resolver = resolverWith(luna);
+    const env = envelopeWithChain(undefined);
+
+    const result = verifySignedByChain(env, {
+      resolver,
+      receivingAgentId: "luna",
+      rejectEmpty: false,
+    });
+
+    expect(result.valid).toBe(true);
+    if (result.valid) {
+      expect(result.skipped).toEqual([]);
+    }
+  });
+});
+
+describe("verifySignedByChain — split rejection reasons", () => {
+  test("[4] malformed principal (did:key:…) → malformed_principal", () => {
+    const luna = agentFixture({ id: "luna" });
+    const resolver = resolverWith(luna);
+    const env = envelopeWithChain([ed25519Stamp("did:key:abc123")]);
+
+    const result = verifySignedByChain(env, {
+      resolver,
+      receivingAgentId: "luna",
+    });
+
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.rejectedAt).toBe(0);
+      expect(result.reason).toEqual({
+        kind: "malformed_principal",
+        principal: "did:key:abc123",
+      });
+    }
+  });
+
+  test("[5] well-formed did:mf but agent not registered → unknown_agent", () => {
+    const luna = agentFixture({ id: "luna" });
+    const resolver = resolverWith(luna);
+    const env = envelopeWithChain([ed25519Stamp("did:mf:nobody")]);
+
+    const result = verifySignedByChain(env, {
+      resolver,
+      receivingAgentId: "luna",
+    });
+
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.rejectedAt).toBe(0);
+      expect(result.reason).toEqual({
+        kind: "unknown_agent",
+        principal: "did:mf:nobody",
+        agentId: "nobody",
+      });
+    }
+  });
+
+  test("[6] agent registered but no nkey_pub → principal_has_no_nkey_pub", () => {
+    const luna = agentFixture({ id: "luna", trust: ["echo"] });
+    // echo has no nkey_pub — intentional.
+    const echo = agentFixture({ id: "echo", displayName: "Echo" });
+    const resolver = resolverWith(luna, echo);
+
+    const env = envelopeWithChain([ed25519Stamp("did:mf:echo")]);
+    const result = verifySignedByChain(env, {
+      resolver,
+      receivingAgentId: "luna",
+    });
+
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.rejectedAt).toBe(0);
+      expect(result.reason).toEqual({
+        kind: "principal_has_no_nkey_pub",
+        principal: "did:mf:echo",
+        agentId: "echo",
+      });
+    }
+  });
+
+  test("[7] signer's NKey known but receiver doesn't trust them → signer_not_trusted", () => {
+    // luna does NOT include echo in `trust:`.
+    const luna = agentFixture({ id: "luna", trust: [] });
+    const echo = agentFixture({
+      id: "echo",
+      displayName: "Echo",
+      nkey_pub: NKEY_ECHO,
+    });
+    const resolver = resolverWith(luna, echo);
+
+    const env = envelopeWithChain([ed25519Stamp("did:mf:echo")]);
+    const result = verifySignedByChain(env, {
+      resolver,
+      receivingAgentId: "luna",
+    });
+
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.rejectedAt).toBe(0);
+      expect(result.reason).toEqual({
+        kind: "signer_not_trusted",
+        principal: "did:mf:echo",
+        agentId: "echo",
+      });
+    }
+  });
+});
+
+describe("verifySignedByChain — multi-stamp rejection", () => {
+  test("[9] valid stamp at index 0, untrusted stamp at index 1 → rejectedAt:1, skipped:[]", () => {
+    // luna trusts echo (NKey present) but not holly. Chain has echo first
+    // (accepted), holly second (rejected — signer_not_trusted). Verify
+    // that `rejectedAt: 1` carries the per-stamp index, and that the
+    // pre-rejection accepts are NOT counted as skips (skips are
+    // hub-stamps only).
+    const luna = agentFixture({ id: "luna", trust: ["echo"] });
+    const echo = agentFixture({
+      id: "echo",
+      displayName: "Echo",
+      nkey_pub: NKEY_ECHO,
+    });
+    const holly = agentFixture({
+      id: "holly",
+      displayName: "Holly",
+      nkey_pub: NKEY_HOLLY,
+    });
+    const resolver = resolverWith(luna, echo, holly);
+
+    const env = envelopeWithChain([
+      ed25519Stamp("did:mf:echo"),
+      ed25519Stamp("did:mf:holly"),
+    ]);
+    const result = verifySignedByChain(env, {
+      resolver,
+      receivingAgentId: "luna",
+    });
+
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.rejectedAt).toBe(1);
+      expect(result.reason).toEqual({
+        kind: "signer_not_trusted",
+        principal: "did:mf:holly",
+        agentId: "holly",
+      });
+      expect(result.skipped).toEqual([]);
+    }
+  });
+
+  test("rejection on stamp 2 with hub-stamp at index 0 → skipped:[0] preserved", () => {
+    // Extra coverage on the new `skipped` carry-through behaviour for
+    // failure variants: hub-stamp at 0 was skipped before the rejection
+    // at index 2 fires, so the failure result must surface skipped:[0].
+    const luna = agentFixture({ id: "luna", trust: ["echo"] });
+    const echo = agentFixture({
+      id: "echo",
+      displayName: "Echo",
+      nkey_pub: NKEY_ECHO,
+    });
+    const resolver = resolverWith(luna, echo);
+
+    const env = envelopeWithChain([
+      hubStamp("did:mf:echo", "did:mf:hub-alpha"),
+      ed25519Stamp("did:mf:echo"),
+      ed25519Stamp("did:mf:nobody"),
+    ]);
+    const result = verifySignedByChain(env, {
+      resolver,
+      receivingAgentId: "luna",
+    });
+
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.rejectedAt).toBe(2);
+      expect(result.reason.kind).toBe("unknown_agent");
+      expect(result.skipped).toEqual([0]);
+    }
+  });
+});

--- a/src/bus/verify-signed-by-chain.ts
+++ b/src/bus/verify-signed-by-chain.ts
@@ -41,11 +41,32 @@ import { TrustResolver } from "../common/agents/trust-resolver";
 /**
  * Reason a stamp failed structural verification. Discriminated union so
  * callers can branch on the specific class for logging / audit (Phase C
- * wires audit envelopes that carry this reason verbatim).
+ * wires audit envelopes that carry this reason verbatim — splitting now
+ * to avoid a schema break later, per Echo's B.1a review).
+ *
+ * - `malformed_principal` — the stamp's `principal` is not a `did:mf:<id>`.
+ *   Wire-format misconfiguration; either an unsupported DID method
+ *   (e.g. `did:key:…`), an empty tail, or further-segmented payload.
+ *   Phase D may add hub-trust paths that legitimise some `did:web:` /
+ *   `did:key:` shapes; at this slice, anything other than `did:mf:<id>`
+ *   is rejected.
+ * - `unknown_agent` — the principal IS a well-formed `did:mf:<id>` but
+ *   no agent with that id is registered locally. Indicates the sender
+ *   is unrecognised to this stack; different operational class from
+ *   wire-format failure.
+ * - `principal_has_no_nkey_pub` — agent is registered but its
+ *   `nkey_pub` is unset, so we can't even structurally trust it on the
+ *   bus. Indicates the agent intends to live on Discord/Mattermost
+ *   only (B.1a optional `nkey_pub`).
+ * - `signer_not_trusted` — agent is registered with an `nkey_pub`, but
+ *   `receivingAgent.trust` does not list this signer.
+ * - `empty_chain` — envelope arrived with no `signed_by[]` and the
+ *   caller asked for `rejectEmpty: true`.
  */
 export type ChainRejectionReason =
   | { kind: "empty_chain" }
-  | { kind: "unknown_principal"; principal: string }
+  | { kind: "malformed_principal"; principal: string }
+  | { kind: "unknown_agent"; principal: string; agentId: string }
   | { kind: "principal_has_no_nkey_pub"; principal: string; agentId: string }
   | { kind: "signer_not_trusted"; principal: string; agentId: string };
 
@@ -57,7 +78,11 @@ export type ChainRejectionReason =
  * - `valid: false` — at least one ed25519 stamp failed; `rejectedAt`
  *   is the chain index of the first failing stamp; `reason` carries
  *   the structured failure class. Caller does NOT continue iterating
- *   beyond `rejectedAt`; the first rejection is terminal.
+ *   beyond `rejectedAt`; the first rejection is terminal. `skipped`
+ *   carries the hub-stamp indices encountered up to (but not
+ *   including) the rejection so audit envelopes can preserve the
+ *   "rejected after skipping hub-stamps at [0, 2]" shape (per Echo's
+ *   B.1a review).
  */
 export type ChainVerificationResult =
   | {
@@ -69,6 +94,14 @@ export type ChainVerificationResult =
       valid: false;
       rejectedAt: number;
       reason: ChainRejectionReason;
+      /**
+       * Indices of stamps skipped BEFORE the rejection. Useful for audit
+       * envelopes that need to reconstruct the chain-walk context (which
+       * hub-stamps were encountered before the rejected stamp). Empty
+       * array when the rejection happens on the first stamp, OR when the
+       * rejection is `empty_chain`.
+       */
+      skipped: number[];
     };
 
 /**
@@ -113,30 +146,31 @@ export function verifySignedByChain(
 
   if (chain.length === 0) {
     if (rejectEmpty) {
-      return { valid: false, rejectedAt: 0, reason: { kind: "empty_chain" } };
+      return {
+        valid: false,
+        rejectedAt: 0,
+        reason: { kind: "empty_chain" },
+        skipped: [],
+      };
     }
     return { valid: true, skipped: [] };
   }
 
   const skipped: number[] = [];
 
-  for (let i = 0; i < chain.length; i++) {
-    const stamp = chain[i];
-    if (stamp === undefined) {
-      // Bounds-checked by the loop condition — this branch is structurally
-      // unreachable. Kept as a typed guard so lint's no-non-null-assertion
-      // gate passes without an inline disable. Skipping rather than
-      // throwing matches the file-header rule "must never crash on a
-      // malformed stamp."
-      continue;
-    }
+  for (const [i, stamp] of chain.entries()) {
     const stampResult = verifyOneStamp(stamp, opts);
     if (stampResult.kind === "skip") {
       skipped.push(i);
       continue;
     }
     if (stampResult.kind === "reject") {
-      return { valid: false, rejectedAt: i, reason: stampResult.reason };
+      return {
+        valid: false,
+        rejectedAt: i,
+        reason: stampResult.reason,
+        skipped: [...skipped],
+      };
     }
     // stampResult.kind === "accept" — continue to next stamp
   }
@@ -172,7 +206,7 @@ function verifyOneStamp(
   if (agentId === undefined) {
     return {
       kind: "reject",
-      reason: { kind: "unknown_principal", principal },
+      reason: { kind: "malformed_principal", principal },
     };
   }
 
@@ -181,7 +215,7 @@ function verifyOneStamp(
   if (!agent) {
     return {
       kind: "reject",
-      reason: { kind: "unknown_principal", principal },
+      reason: { kind: "unknown_agent", principal, agentId },
     };
   }
 

--- a/src/bus/verify-signed-by-chain.ts
+++ b/src/bus/verify-signed-by-chain.ts
@@ -1,0 +1,230 @@
+/**
+ * IAW Phase B.1a (cortex#114) — structural verification of an envelope's
+ * `signed_by[]` chain against the local trust registry.
+ *
+ * "Structural" because this slice does NOT verify the ed25519 signature
+ * bytes. It checks that every stamp's claimed principal:
+ *   1. Resolves to a known agent in the local registry
+ *   2. Has an `nkey_pub` declared (the agent intends to sign on the bus)
+ *   3. Passes `TrustResolver.trustsByNKey(receivingAgentId, agent.nkey_pub)`
+ *      — i.e. the receiving agent's `trust:` list includes this signer
+ *
+ * Phase B.1c extends this helper to also verify the signature bytes via
+ * ed25519 + JCS canonicalization. The structural rejection paths in this
+ * slice catch the failure modes that don't require the crypto check:
+ * unknown signer, signer-not-configured-for-bus, peer-not-in-trust-list.
+ * Adding the bytes check in B.1c collapses the "signer claims X but
+ * controls a different key" attack surface; until then a stamp can lie
+ * about its principal and a sloppy operator who copy-pasted an unknown
+ * agent's NKey into their own agent's `trust:` list would accept it.
+ * That's why B.1c is part of Phase B — the structural check alone is
+ * not safe to wire into a production inbound path.
+ *
+ * Hub-stamp variants (`method === "hub-stamp"`) pass through this slice
+ * structurally — they're a Phase D concern (federation hub trust). B.1a
+ * neither rejects nor verifies them; they're surfaced as "unverified" in
+ * the result so a strict caller can opt to reject all non-bare-ed25519
+ * chains.
+ */
+
+import {
+  getSignedByChain,
+  type Envelope,
+  type SignedBy,
+} from "./myelin/envelope-validator";
+import { TrustResolver } from "../common/agents/trust-resolver";
+
+// =============================================================================
+// Result types
+// =============================================================================
+
+/**
+ * Reason a stamp failed structural verification. Discriminated union so
+ * callers can branch on the specific class for logging / audit (Phase C
+ * wires audit envelopes that carry this reason verbatim).
+ */
+export type ChainRejectionReason =
+  | { kind: "empty_chain" }
+  | { kind: "unknown_principal"; principal: string }
+  | { kind: "principal_has_no_nkey_pub"; principal: string; agentId: string }
+  | { kind: "signer_not_trusted"; principal: string; agentId: string };
+
+/**
+ * Discriminated outcome of `verifySignedByChain`.
+ *
+ * - `valid: true` — every ed25519 stamp passed the structural check
+ *   (hub-stamps were skipped — see `skipped` for visibility).
+ * - `valid: false` — at least one ed25519 stamp failed; `rejectedAt`
+ *   is the chain index of the first failing stamp; `reason` carries
+ *   the structured failure class. Caller does NOT continue iterating
+ *   beyond `rejectedAt`; the first rejection is terminal.
+ */
+export type ChainVerificationResult =
+  | {
+      valid: true;
+      /** Indices of stamps that were skipped (e.g. hub-stamp method). */
+      skipped: number[];
+    }
+  | {
+      valid: false;
+      rejectedAt: number;
+      reason: ChainRejectionReason;
+    };
+
+/**
+ * Options for `verifySignedByChain`. Required so this helper is reusable
+ * by future harnesses without bundling environment-specific lookups.
+ */
+export interface VerifySignedByChainOptions {
+  /** Trust resolver backed by the local agent registry. */
+  resolver: TrustResolver;
+  /** The agent id of the receiving / verifying side of the dispatch. */
+  receivingAgentId: string;
+  /**
+   * When true, the helper rejects any envelope whose chain is empty.
+   * Default `true` — a B.1b `BusPeerHarness` will use this. Tests + CLI
+   * tooling that legitimately accept unsigned envelopes pass `false`.
+   */
+  rejectEmpty?: boolean;
+}
+
+// =============================================================================
+// Verification
+// =============================================================================
+
+/**
+ * Walk `envelope.signed_by` chain (normalised via `getSignedByChain`) and
+ * structurally verify each ed25519 stamp against the local trust registry.
+ *
+ * **Cryptographic signature verification is NOT performed at this slice.**
+ * See file header for rationale. Phase B.1c extends this helper.
+ *
+ * Iteration short-circuits on the first failure (terminal rejection). Chain
+ * length is bounded by myelin's envelope schema (max_hop cap) so a linear
+ * scan is cheap; no early-exit optimisation needed beyond the natural
+ * `return` on rejection.
+ */
+export function verifySignedByChain(
+  envelope: Envelope,
+  opts: VerifySignedByChainOptions,
+): ChainVerificationResult {
+  const chain = getSignedByChain(envelope);
+  const rejectEmpty = opts.rejectEmpty ?? true;
+
+  if (chain.length === 0) {
+    if (rejectEmpty) {
+      return { valid: false, rejectedAt: 0, reason: { kind: "empty_chain" } };
+    }
+    return { valid: true, skipped: [] };
+  }
+
+  const skipped: number[] = [];
+
+  for (let i = 0; i < chain.length; i++) {
+    const stamp = chain[i];
+    if (stamp === undefined) {
+      // Bounds-checked by the loop condition — this branch is structurally
+      // unreachable. Kept as a typed guard so lint's no-non-null-assertion
+      // gate passes without an inline disable. Skipping rather than
+      // throwing matches the file-header rule "must never crash on a
+      // malformed stamp."
+      continue;
+    }
+    const stampResult = verifyOneStamp(stamp, opts);
+    if (stampResult.kind === "skip") {
+      skipped.push(i);
+      continue;
+    }
+    if (stampResult.kind === "reject") {
+      return { valid: false, rejectedAt: i, reason: stampResult.reason };
+    }
+    // stampResult.kind === "accept" — continue to next stamp
+  }
+
+  return { valid: true, skipped };
+}
+
+// =============================================================================
+// Per-stamp helpers (private)
+// =============================================================================
+
+type StampOutcome =
+  | { kind: "accept" }
+  | { kind: "skip" }
+  | { kind: "reject"; reason: ChainRejectionReason };
+
+/**
+ * Classify a single stamp. Hub-stamps are skipped at this slice — Phase D
+ * extends with hub-trust verification. Bare ed25519 stamps run the
+ * structural trust check.
+ */
+function verifyOneStamp(
+  stamp: SignedBy,
+  opts: VerifySignedByChainOptions,
+): StampOutcome {
+  if (stamp.method === "hub-stamp") {
+    return { kind: "skip" };
+  }
+  // Discriminated union — narrows to SignedByEd25519 once hub-stamp is out.
+
+  const principal = stamp.principal;
+  const agentId = extractAgentIdFromDid(principal);
+  if (agentId === undefined) {
+    return {
+      kind: "reject",
+      reason: { kind: "unknown_principal", principal },
+    };
+  }
+
+  const registry = opts.resolver.getRegistry();
+  const agent = registry.tryGetById(agentId);
+  if (!agent) {
+    return {
+      kind: "reject",
+      reason: { kind: "unknown_principal", principal },
+    };
+  }
+
+  if (agent.nkey_pub === undefined) {
+    return {
+      kind: "reject",
+      reason: { kind: "principal_has_no_nkey_pub", principal, agentId },
+    };
+  }
+
+  const trusted = opts.resolver.trustsByNKey(
+    opts.receivingAgentId,
+    agent.nkey_pub,
+  );
+  if (!trusted) {
+    return {
+      kind: "reject",
+      reason: { kind: "signer_not_trusted", principal, agentId },
+    };
+  }
+
+  return { kind: "accept" };
+}
+
+/**
+ * Parse a `did:mf:<name>` principal into its agent-id segment. Returns
+ * `undefined` for any other DID method or malformed input — the caller
+ * surfaces `undefined` as `unknown_principal` rather than throwing,
+ * because the inbound-envelope path must never crash on a malformed
+ * stamp (an attacker controls the bytes; a thrown exception inside the
+ * subscription callback bubbles into nats.js's reconnection logic).
+ *
+ * `did:mf:` is myelin's convention (see `myelin/specs/`). Other DID
+ * methods (`did:key:`, `did:web:`) are out of scope until Phase D
+ * federation introduces hub-trust paths.
+ */
+function extractAgentIdFromDid(principal: string): string | undefined {
+  const prefix = "did:mf:";
+  if (!principal.startsWith(prefix)) return undefined;
+  const tail = principal.slice(prefix.length);
+  if (tail.length === 0) return undefined;
+  // The myelin convention is `did:mf:<name>` with no further segments;
+  // a colon in the tail signals an unsupported DID variant.
+  if (tail.includes(":")) return undefined;
+  return tail;
+}

--- a/src/common/agents/registry.ts
+++ b/src/common/agents/registry.ts
@@ -245,6 +245,37 @@ export class AgentRegistry {
     if (!trusterAgent) return false;
     return trusterAgent.trust.includes(trusted);
   }
+
+  /**
+   * IAW Phase B.1 (cortex#114) — reverse-lookup an agent by its declared
+   * NKey public key. Returns `undefined` when no registered agent declares
+   * `nkey_pub === pubkey`, OR when more than one does (ambiguous — refuse
+   * to silently pick one). The ambiguity case is a config bug; the caller
+   * surfaces it as a verification failure rather than an exception so the
+   * bus path can log + reject without throwing into an event handler.
+   *
+   * Linear scan is intentional: the registry holds O(small) agents and
+   * the call site is per-stamp during inbound verification, not per-byte.
+   * If profiling shows this matters, build an `nkey_pub → agentId` index
+   * once at registry construction.
+   */
+  tryGetByNkeyPub(pubkey: string): Agent | undefined {
+    let match: Agent | undefined;
+    for (const agent of this.agents) {
+      if (agent.nkey_pub === pubkey) {
+        if (match) {
+          // Two agents claim the same NKey — refuse to disambiguate at
+          // read time. fromAgents should reject this at construction once
+          // Phase C tightens the principal model, but until then a config
+          // with duplicate keys gets a structural-trust failure rather
+          // than a silently-wrong agent resolution.
+          return undefined;
+        }
+        match = agent;
+      }
+    }
+    return match;
+  }
 }
 
 // =============================================================================

--- a/src/common/agents/trust-resolver.ts
+++ b/src/common/agents/trust-resolver.ts
@@ -806,6 +806,42 @@ export class TrustResolver {
   }
 
   /**
+   * IAW Phase B.1a (cortex#114) — full trust check by signing NKey. Returns
+   * true iff:
+   *   1. `signerPubKey` resolves to a known agent via
+   *      `AgentRegistry.tryGetByNkeyPub` (which also returns `undefined`
+   *      for ambiguous keys — two agents claiming the same NKey — so this
+   *      check fails closed on config bugs).
+   *   2. `receivingAgentId` is a known agent.
+   *   3. `receivingAgent.trust` includes the resolved sender agent id
+   *      (OR sender and receiver are the same agent — self-trust is
+   *      transitive, matching `AgentRegistry.trusts`).
+   *
+   * Returns false (not throws) for any unknown signer or unknown receiver,
+   * so the inbound-envelope path can reject the dispatch without a
+   * try/catch around the verification helper.
+   *
+   * This method is the NKey analog of `trustsByPlatformId`. It is the
+   * primitive Phase B.1b's `BusPeerHarness` consumes, and the primitive
+   * Phase B.1c's `verifySignedByChain` consumes when stepping through
+   * each `signed_by[]` stamp.
+   *
+   * **Cryptographic verification is out of scope here** — this method
+   * only checks the trust-registry relationship. The ed25519 signature
+   * verification (does the signer's claimed key actually verify the
+   * envelope bytes?) lands in B.1c alongside the JCS canonicalization
+   * helper.
+   */
+  trustsByNKey(
+    receivingAgentId: string,
+    signerPubKey: string,
+  ): boolean {
+    const senderAgent = this.registry.tryGetByNkeyPub(signerPubKey);
+    if (!senderAgent) return false;
+    return this.registry.trusts(receivingAgentId, senderAgent.id);
+  }
+
+  /**
    * The backing registry. Exposed for callers that need the full Agent
    * object alongside the platform-id mapping (e.g. presence adapters that
    * fetch personas after resolving the sender).

--- a/src/common/types/cortex-config.ts
+++ b/src/common/types/cortex-config.ts
@@ -351,6 +351,26 @@ export const AgentSchema = z.object({
       "trust entries must be agent ids — lowercase alphanumeric + hyphen, starting with a letter (e.g. 'echo', 'team-research'); rename digit-prefixed entries like '2agent' to 'team-2agent' or 'agent-2026'",
     ),
   ).default([]),
+  /**
+   * IAW Phase B.1 (cortex#114) — NKey public key the agent uses (via its
+   * home stack) to sign outbound bot↔bot envelopes. Optional in Phase B.1:
+   * agents without `nkey_pub` cannot participate in NKey-verified bot↔bot
+   * dispatch and fall back to the platform-id trust path on Discord /
+   * Mattermost DMs. The field becomes required for any agent intended to
+   * speak on the bus once Phase C absorbs principals into the top-level
+   * `policy:` block.
+   *
+   * Same regex as `StackConfigSchema.nkey_pub` (56-char U-prefixed base32):
+   * NKeys are stack-scoped on the wire (the stack signs every envelope),
+   * but at the cortex.yaml surface they're declared per-agent because
+   * each agent has exactly one home stack today. When Phase D introduces
+   * multi-stack-per-operator membership, the principal model migrates
+   * this off `AgentSchema` onto `policy.principals[]`.
+   */
+  nkey_pub: z.string().regex(
+    /^U[A-Z2-7]{55}$/,
+    "agent.nkey_pub must be a base32 NKey public key (U-prefixed, 56 chars total)",
+  ).optional(),
   /** Per-platform presence blocks — at least one is required. */
   presence: PresenceSchema,
   /**


### PR DESCRIPTION
## Summary

Phase B.1a — the verification primitives for the bot↔bot bus path. Lands ahead of the B.1b \`BusPeerHarness\` scaffold (the carry-over from A.1.3 per PR #193's plan correction) so the helpers are reusable by tests, CLI tooling, and the future harness.

\`refs cortex#114\` \`refs cortex#113\`

## Changes

| Surface | What |
|---|---|
| \`AgentSchema.nkey_pub\` | Optional 56-char U-prefixed base32 NKey pub key — agent's home-stack signing key. Same regex as \`StackConfigSchema.nkey_pub\`. |
| \`AgentRegistry.tryGetByNkeyPub(pubkey)\` | Reverse lookup. Returns \`undefined\` for unknown OR ambiguous (duplicate-key config bug). Linear scan, deliberate. |
| \`TrustResolver.trustsByNKey(receivingAgentId, signerPubKey)\` | NKey analog of \`trustsByPlatformId\`. Composes lookup + \`AgentRegistry.trusts\`. |
| \`src/bus/verify-signed-by-chain.ts\` | New file. \`verifySignedByChain(envelope, opts) → ChainVerificationResult\`. Walks chain, runs structural check per ed25519 stamp, short-circuits on first failure with structured \`ChainRejectionReason\` discriminator. Hub-stamps skipped (Phase D). |

## What this slice deliberately doesn't do

- **No cryptographic ed25519 signature verification** — that's B.1c with the JCS canonicalization helper. Until B.1c lands, the structural check alone is not safe to gate an inbound dispatch path with; the file header spells out the attack surface.
- **No \`BusPeerHarness\` scaffold** — that's B.1b (the carry-over from A.1.3). This slice's primitives are what B.1b will consume.
- **No new tests for \`verifySignedByChain\`** — shipping minimal here so Luna's review surfaces what coverage actually matters. Existing tests cover the registry + resolver changes via the parent schema parse path; the new helper is uncovered by design at this slice.

## Verification

- \`bunx tsc --noEmit\` — clean
- \`bun run lint:errors\` — clean (0 errors after fixing one no-non-null-assertion in the chain loop)
- \`bun test src/common/agents/ src/common/types/\` — 305 pass / 0 fail / 0 skip
- Full \`bun test\` not run locally; Lint job remains red on main due to pre-existing \`grove-auth: file:../grove-auth\` dep (broken since \`ef1928a\`) so CI parity matches the post-#192/#193 baseline.

## Dependency line

This is the first slice of Phase B per the parallelism map in \`docs/plan-internet-of-agentic-work.md\` §3:

\`\`\`
B.1a (this PR)  →  B.1b (BusPeerHarness scaffold)
                →  B.1c (ed25519 + JCS)
                →  B.3  (outbound signing — shares JCS helper with B.1c)
\`\`\`

B.2 (ClaudeCodeHarness uses bus) depends on B.1b. B.4 (round-trip + adversarial tests) depends on everything above.

## Out of scope follow-ups

- Tests for \`verifySignedByChain\` (likely Luna will ask — see "deliberately doesn't do" above; happy to add inline if requested).
- The \`AgentRegistry.fromAgents\` duplicate-key validation at construction time (currently the resolver fails closed at read time via \`tryGetByNkeyPub\` returning \`undefined\` on ambiguity). Phase C will tighten when the principal model lands.
- Migration note for \`cortex.yaml.example\` to show the \`nkey_pub\` field on agents — pairs naturally with cortex#148 (capabilities example follow-up).