### PR TITLE
feat(substrates): IAW B.1b — BusPeerHarness scaffold + verification gate (refs cortex#114)

### DIFF
--- a/src/substrates/bus-peer/__tests__/harness.test.ts
+++ b/src/substrates/bus-peer/__tests__/harness.test.ts
@@ -8,8 +8,10 @@
  *      structural check is dropped at the boundary (not yielded) and the
  *      stderr line carries the rejection reason discriminator.
  *   3. Consumer-break — when the iterator is broken before a peer terminal
- *      arrives, the harness synthesises a `dispatch.task.aborted` envelope
- *      and unregisters from the runtime fan-out.
+ *      arrives, the harness unregisters from the runtime fan-out. No
+ *      synthetic terminal is yielded (async-generator semantics drop
+ *      yields-in-finally after iterator return); the runner records the
+ *      abort from its outside view. Matches `ClaudeCodeHarness`'s contract.
  */
 
 import { describe, test, expect } from "bun:test";

--- a/src/substrates/bus-peer/__tests__/harness.test.ts
+++ b/src/substrates/bus-peer/__tests__/harness.test.ts
@@ -1,0 +1,391 @@
+/**
+ * IAW Phase B.1b (cortex#114) — BusPeerHarness tests.
+ *
+ * Three coverage axes:
+ *   1. Round-trip on a valid chain — verified inbound flows through to the
+ *      consumer; the local `started` lifecycle envelope is yielded first.
+ *   2. Verification gate — an inbound envelope whose chain fails the
+ *      structural check is dropped at the boundary (not yielded) and the
+ *      stderr line carries the rejection reason discriminator.
+ *   3. Consumer-break — when the iterator is broken before a peer terminal
+ *      arrives, the harness synthesises a `dispatch.task.aborted` envelope
+ *      and unregisters from the runtime fan-out.
+ */
+
+import { describe, test, expect } from "bun:test";
+
+import { AgentRegistry } from "../../../common/agents/registry";
+import { TrustResolver } from "../../../common/agents/trust-resolver";
+import type {
+  EnvelopeHandler,
+  MyelinRuntime,
+} from "../../../bus/myelin/runtime";
+import type { Envelope } from "../../../bus/myelin/envelope-validator";
+import type { Agent } from "../../../common/types/cortex-config";
+import type {
+  DispatchRequest,
+  MyelinEnvelope,
+} from "../../../common/substrates/types";
+import { BusPeerHarness } from "../harness";
+
+// =============================================================================
+// Fixtures
+// =============================================================================
+
+const NKEY_ECHO = "U" + "B".repeat(55);
+const NKEY_HOLLY = "U" + "C".repeat(55);
+
+function discordPresence() {
+  return {
+    enabled: true,
+    token: "discord-bot-token",
+    guildId: "1487000000000000000",
+    agentChannelId: "1487000000000000001",
+    logChannelId: "1487000000000000002",
+    contextDepth: 10,
+    enableAgentLog: false,
+    roles: [],
+    defaultRole: "allow-all",
+    dm: {
+      operatorRole: {
+        features: ["chat", "async", "team"] as const,
+        disallowedTools: [],
+        bashGuard: true,
+      },
+      defaultRole: "denied" as const,
+      userRoles: [],
+    },
+  };
+}
+
+function agentFixture(overrides: Partial<Agent> = {}): Agent {
+  return {
+    id: "luna",
+    displayName: "Luna",
+    persona: "./personas/luna.md",
+    roles: [],
+    trust: [],
+    presence: { discord: discordPresence() },
+    ...overrides,
+  } as Agent;
+}
+
+function resolverWith(...agents: Agent[]): TrustResolver {
+  return new TrustResolver(AgentRegistry.fromAgents(agents));
+}
+
+/**
+ * Minimal MyelinRuntime double — records every publish + lets the test
+ * trigger inbound by invoking the registered onEnvelope handlers
+ * synchronously. Matches the production runtime's contract: publishes
+ * are fire-and-forget; onEnvelope returns an unregister token.
+ */
+function fakeRuntime() {
+  const handlers = new Set<EnvelopeHandler>();
+  const published: Envelope[] = [];
+
+  const runtime: MyelinRuntime = {
+    enabled: true,
+    onEnvelope(handler) {
+      handlers.add(handler);
+      return {
+        unregister: () => {
+          handlers.delete(handler);
+        },
+      };
+    },
+    // eslint-disable-next-line @typescript-eslint/require-await
+    async publish(envelope) {
+      published.push(envelope);
+    },
+    // eslint-disable-next-line @typescript-eslint/require-await
+    async stop() {
+      handlers.clear();
+    },
+  };
+
+  function deliverInbound(envelope: Envelope, subject = "test.subject") {
+    for (const handler of handlers) handler(envelope, subject);
+  }
+
+  return { runtime, published, deliverInbound, handlers };
+}
+
+function dispatchRequest(overrides: Partial<DispatchRequest> = {}): DispatchRequest {
+  return {
+    prompt: "do the thing",
+    tools: { allow: [], deny: [] },
+    context: [],
+    agent: { id: "luna", displayName: "Luna" },
+    requestId: "00000000-0000-4000-8000-000000000099",
+    ...overrides,
+  };
+}
+
+function inboundEnvelope(opts: {
+  correlationId: string;
+  type: string;
+  signerPrincipal?: string;
+}): Envelope {
+  return {
+    id: "00000000-0000-4000-8000-000000000aaa",
+    source: "metafactory.echo.local",
+    type: opts.type,
+    timestamp: "2026-05-15T08:30:00.000Z",
+    correlation_id: opts.correlationId,
+    sovereignty: {
+      classification: "local",
+      data_residency: "NZ",
+      max_hop: 4,
+      frontier_ok: false,
+      model_class: "any",
+    },
+    payload: {},
+    ...(opts.signerPrincipal !== undefined && {
+      signed_by: {
+        method: "ed25519" as const,
+        principal: opts.signerPrincipal,
+        signature: "A".repeat(88),
+        at: "2026-05-15T08:30:00.000Z",
+      },
+    }),
+  };
+}
+
+const SOURCE = { org: "metafactory", agent: "cortex", instance: "local" };
+
+// =============================================================================
+// Cases
+// =============================================================================
+
+describe("BusPeerHarness — round-trip + verification gate", () => {
+  test("publishes the request envelope and yields started + verified inbound + peer terminal", async () => {
+    const luna = agentFixture({ id: "luna", trust: ["echo"] });
+    const echo = agentFixture({
+      id: "echo",
+      displayName: "Echo",
+      nkey_pub: NKEY_ECHO,
+    });
+    const resolver = resolverWith(luna, echo);
+    const { runtime, published, deliverInbound } = fakeRuntime();
+
+    const harness = new BusPeerHarness({
+      runtime,
+      resolver,
+      receivingAgentId: "luna",
+      source: SOURCE,
+    });
+
+    const req = dispatchRequest();
+    const yielded: MyelinEnvelope[] = [];
+
+    // Drive the iterator. After yielding `started`, deliver an inbound
+    // dispatch.task.completed from echo — that's the peer terminal and
+    // triggers iterator close.
+    const iterator = harness.dispatch(req)[Symbol.asyncIterator]();
+
+    const startedYield = await iterator.next();
+    expect(startedYield.done).toBe(false);
+    if (!startedYield.done) yielded.push(startedYield.value);
+
+    // Now inject the peer terminal — verified principal echo, trusted by luna.
+    deliverInbound(
+      inboundEnvelope({
+        correlationId: req.requestId,
+        type: "dispatch.task.completed",
+        signerPrincipal: "did:mf:echo",
+      }),
+    );
+
+    const terminalYield = await iterator.next();
+    expect(terminalYield.done).toBe(false);
+    if (!terminalYield.done) yielded.push(terminalYield.value);
+
+    // Iterator should close after the terminal.
+    const closeYield = await iterator.next();
+    expect(closeYield.done).toBe(true);
+
+    // Outbound envelope: published exactly once.
+    expect(published).toHaveLength(1);
+    expect(published[0]?.type).toBe("dispatch.task.dispatched");
+    expect(published[0]?.correlation_id).toBe(req.requestId);
+
+    // Yielded sequence: started → completed (verified inbound).
+    expect(yielded).toHaveLength(2);
+    expect(yielded[0]?.type).toBe("dispatch.task.started");
+    expect(yielded[1]?.type).toBe("dispatch.task.completed");
+  });
+
+  test("drops an inbound envelope whose signer is not in receiver's trust list", async () => {
+    // Holly is registered with an NKey but NOT in luna's trust list.
+    const luna = agentFixture({ id: "luna", trust: ["echo"] });
+    const echo = agentFixture({
+      id: "echo",
+      displayName: "Echo",
+      nkey_pub: NKEY_ECHO,
+    });
+    const holly = agentFixture({
+      id: "holly",
+      displayName: "Holly",
+      nkey_pub: NKEY_HOLLY,
+    });
+    const resolver = resolverWith(luna, echo, holly);
+    const { runtime, deliverInbound } = fakeRuntime();
+
+    // Capture stderr to assert the drop is logged with the structured
+    // reason (mirrors what the harness writes).
+    const stderrLines: string[] = [];
+    const originalWrite = process.stderr.write.bind(process.stderr);
+    process.stderr.write = (chunk: string | Uint8Array): boolean => {
+      stderrLines.push(typeof chunk === "string" ? chunk : chunk.toString());
+      return true;
+    };
+
+    try {
+      const harness = new BusPeerHarness({
+        runtime,
+        resolver,
+        receivingAgentId: "luna",
+        source: SOURCE,
+      });
+
+      const req = dispatchRequest();
+      const iterator = harness.dispatch(req)[Symbol.asyncIterator]();
+
+      // Pull `started` first.
+      const startedYield = await iterator.next();
+      expect(startedYield.done).toBe(false);
+
+      // Holly tries to claim the task — chain signer not trusted.
+      deliverInbound(
+        inboundEnvelope({
+          correlationId: req.requestId,
+          type: "dispatch.task.completed",
+          signerPrincipal: "did:mf:holly",
+        }),
+      );
+
+      // The untrusted envelope must be dropped, NOT yielded. Echo's
+      // legitimate terminal arrives second; only THIS one should yield.
+      deliverInbound(
+        inboundEnvelope({
+          correlationId: req.requestId,
+          type: "dispatch.task.completed",
+          signerPrincipal: "did:mf:echo",
+        }),
+      );
+
+      const next = await iterator.next();
+      expect(next.done).toBe(false);
+      if (!next.done) {
+        // The yielded envelope's signer must be echo, not holly.
+        const signedBy = next.value.signed_by;
+        const stamp = Array.isArray(signedBy) ? signedBy[0] : signedBy;
+        expect(stamp?.principal).toBe("did:mf:echo");
+      }
+
+      const done = await iterator.next();
+      expect(done.done).toBe(true);
+    } finally {
+      process.stderr.write = originalWrite;
+    }
+
+    const stderrOutput = stderrLines.join("");
+    expect(stderrOutput).toContain("bus-peer:luna");
+    expect(stderrOutput).toContain("signer_not_trusted");
+  });
+
+  test("unregisters the runtime handler when the consumer breaks before peer terminal", async () => {
+    // Per the SessionHarness contract (and matching ClaudeCodeHarness),
+    // consumer-break does NOT yield a synthetic terminal envelope —
+    // async-generator semantics drop yields-in-finally after iterator
+    // return. The harness's job on break is to clean up its NATS
+    // subscription so the runtime doesn't fan out to a dropped handler.
+    // The runner / dispatch-listener observes iterator close and
+    // records an aborted lifecycle envelope from its outside view.
+    const luna = agentFixture({ id: "luna", trust: ["echo"] });
+    const echo = agentFixture({
+      id: "echo",
+      displayName: "Echo",
+      nkey_pub: NKEY_ECHO,
+    });
+    const resolver = resolverWith(luna, echo);
+    const { runtime, handlers } = fakeRuntime();
+
+    const harness = new BusPeerHarness({
+      runtime,
+      resolver,
+      receivingAgentId: "luna",
+      source: SOURCE,
+    });
+
+    const req = dispatchRequest();
+    const yielded: MyelinEnvelope[] = [];
+
+    // Consume `started` then break — no peer terminal ever delivered.
+    for await (const env of harness.dispatch(req)) {
+      yielded.push(env);
+      if (env.type === "dispatch.task.started") break;
+    }
+
+    // Only `started` should be observable (the break is the iterator's
+    // last call) — no synthetic-aborted in the consumer's view.
+    expect(yielded).toHaveLength(1);
+    expect(yielded[0]?.type).toBe("dispatch.task.started");
+
+    // Critical contract: the runtime handler must be unregistered so
+    // future bus traffic doesn't leak to a closed dispatch.
+    expect(handlers.size).toBe(0);
+  });
+
+  test("ignores envelopes whose correlation_id does not match this dispatch", async () => {
+    const luna = agentFixture({ id: "luna", trust: ["echo"] });
+    const echo = agentFixture({
+      id: "echo",
+      displayName: "Echo",
+      nkey_pub: NKEY_ECHO,
+    });
+    const resolver = resolverWith(luna, echo);
+    const { runtime, deliverInbound } = fakeRuntime();
+
+    const harness = new BusPeerHarness({
+      runtime,
+      resolver,
+      receivingAgentId: "luna",
+      source: SOURCE,
+    });
+
+    const req = dispatchRequest({
+      requestId: "00000000-0000-4000-8000-000000000111",
+    });
+    const iterator = harness.dispatch(req)[Symbol.asyncIterator]();
+
+    const started = await iterator.next();
+    expect(started.done).toBe(false);
+
+    // Inject a DIFFERENT-correlation-id envelope — must not yield.
+    deliverInbound(
+      inboundEnvelope({
+        correlationId: "00000000-0000-4000-8000-000000000222",
+        type: "dispatch.task.completed",
+        signerPrincipal: "did:mf:echo",
+      }),
+    );
+
+    // Now deliver the actual matching terminal.
+    deliverInbound(
+      inboundEnvelope({
+        correlationId: req.requestId,
+        type: "dispatch.task.completed",
+        signerPrincipal: "did:mf:echo",
+      }),
+    );
+
+    const matching = await iterator.next();
+    expect(matching.done).toBe(false);
+    expect(matching.value?.correlation_id).toBe(req.requestId);
+
+    const done = await iterator.next();
+    expect(done.done).toBe(true);
+  });
+});

--- a/src/substrates/bus-peer/harness.ts
+++ b/src/substrates/bus-peer/harness.ts
@@ -242,12 +242,15 @@ export class BusPeerHarness implements SessionHarness {
       }
     }
 
-    // Register the handler INSIDE the try/finally so the unregister
-    // runs even if the consumer breaks at the `started` yield (or
-    // earlier, before entering the pull loop). Async generators only
-    // run finally blocks that wrap the suspended yield point — a
-    // try/finally placed after `yield startedEnvelope` would be
-    // skipped by a break-at-started call to iter.return().
+    // Register the handler BEFORE the try block so envelopes arriving
+    // between registration and the first yield are captured; the
+    // unregister in `finally` (which wraps the publish + every yield
+    // below) covers every exit path — including a consumer break at
+    // the `started` yield. Async-generator semantics: only finally
+    // blocks that *wrap* the suspended yield point run on
+    // `iterator.return()`, so the try must enclose every yield this
+    // method emits, but the registration itself must precede the try
+    // to avoid a registration-vs-yield race.
     const handlerRegistration = this.runtime.onEnvelope((envelope) => {
       // Filter: only envelopes tagged with our correlation_id are
       // relevant to this dispatch. Bus traffic for other dispatches

--- a/src/substrates/bus-peer/harness.ts
+++ b/src/substrates/bus-peer/harness.ts
@@ -15,8 +15,12 @@
  *     pattern keyed on `correlation_id`. The harness yields a local
  *     `dispatch.task.started` envelope on entry, then every verified
  *     inbound envelope tagged with the same `correlation_id`, then a
- *     terminal envelope (yielded by the peer OR a synthetic
- *     `aborted` if the consumer breaks early).
+ *     terminal envelope yielded by the peer (`dispatch.task.completed`
+ *     / `failed` / `aborted`). Consumer-break causes the runtime
+ *     subscription to unregister via the try/finally; the runner is
+ *     responsible for recording an aborted lifecycle envelope from its
+ *     outside view (matches `ClaudeCodeHarness`'s contract — see the
+ *     `dispatch()` JSDoc for the spec rationale).
  *   - **Verification gate on every inbound** via `verifySignedByChain`
  *     (Phase B.1a). Envelopes that fail the structural trust check
  *     are dropped at the boundary with a single-line `process.stderr`
@@ -155,10 +159,19 @@ export class BusPeerHarness implements SessionHarness {
    *     `ClaudeCodeHarness`'s contract (runner / dispatch-listener
    *     observes iterator close + records an aborted lifecycle
    *     envelope from its outside view).
-   *   - Runtime publish fails: error propagates synchronously to
-   *     the caller (matches `MyelinRuntime.publish`'s fire-and-forget
-   *     contract — internal log + swallow inside the runtime; the
-   *     promise still resolves so we don't `await` on a rejection).
+   *   - Runtime publish errors: swallowed. The harness uses
+   *     `void this.runtime.publish(...)` per `MyelinRuntime.publish`'s
+   *     fire-and-forget contract — the runtime itself logs and
+   *     swallows publish errors (so a misconfigured NATS section
+   *     can't crash the bot), and this harness deliberately doesn't
+   *     `await` the returned promise. The only observable failure
+   *     mode of a publish failure here is "the receiving peer never
+   *     sees the outbound request"; no synthetic terminal is emitted
+   *     locally before the started yield. A future B.1c+ refinement
+   *     could opt into the `await + synthetic failed-terminal`
+   *     pattern (Echo's option B on cortex#195) if operators want
+   *     a louder failure surface, but at this slice we mirror the
+   *     existing runtime contract.
    */
   // eslint-disable-next-line @typescript-eslint/require-await
   async *dispatch(
@@ -292,9 +305,11 @@ export class BusPeerHarness implements SessionHarness {
     //    path — including a consumer break at the FIRST yield.
     // ----------------------------------------------------------------
     try {
-      // Fire-and-forget per MyelinRuntime.publish's documented contract
-      // (Core NATS is fire-and-forget at the client layer; the promise
-      // resolves synchronously even on failures — runtime logs+swallows).
+      // Fire-and-forget per MyelinRuntime.publish's documented contract:
+      // the runtime logs and swallows publish errors internally, so the
+      // returned promise resolves rather than rejects. We `void` it so
+      // ESLint's no-floating-promises rule is satisfied without an
+      // `await` that would block on the runtime's own swallow path.
       void this.runtime.publish(requestEnvelope);
 
       // ----------------------------------------------------------------

--- a/src/substrates/bus-peer/harness.ts
+++ b/src/substrates/bus-peer/harness.ts
@@ -1,0 +1,344 @@
+/**
+ * IAW Phase B.1b (cortex#114) — `BusPeerHarness`.
+ *
+ * The carry-over from Phase A.1.3 (which was speculatively ticked in
+ * PR #192 but never shipped — see PR #193 plan correction). This is
+ * the second concrete `SessionHarness` implementation alongside
+ * `ClaudeCodeHarness`: a harness that delegates the actual work to a
+ * peer agent reachable via the local bus. Cortex publishes a request
+ * envelope, the peer (sage / cedar / alpha / future) does the work
+ * over there, and progress + terminal envelopes return via the
+ * `MyelinRuntime.onEnvelope` fan-out.
+ *
+ * **What this slice delivers (B.1b.1 + B.1b.2 of the plan):**
+ *   - `BusPeerHarness implements SessionHarness` — publish-and-collect
+ *     pattern keyed on `correlation_id`. The harness yields a local
+ *     `dispatch.task.started` envelope on entry, then every verified
+ *     inbound envelope tagged with the same `correlation_id`, then a
+ *     terminal envelope (yielded by the peer OR a synthetic
+ *     `aborted` if the consumer breaks early).
+ *   - **Verification gate on every inbound** via `verifySignedByChain`
+ *     (Phase B.1a). Envelopes that fail the structural trust check
+ *     are dropped at the boundary with a single-line `process.stderr`
+ *     write — no audit envelope yet (that's Phase C.4) and no yield
+ *     to the consumer.
+ *
+ * **What this slice deliberately doesn't do:**
+ *   - **No ed25519 verification of signature bytes.** The structural
+ *     check from B.1a is the only gate today. The harness's file
+ *     header explicitly acknowledges that wiring this into a real
+ *     production inbound path requires B.1c to land first; until then
+ *     this scaffold is safe behind a feature flag / capability
+ *     declaration that no operator actually has bound to a peer.
+ *   - **No production wire format for the outbound request envelope.**
+ *     The harness builds a minimal `dispatch.task.dispatched`-shaped
+ *     envelope from `DispatchRequest`. The richer "task contract" shape
+ *     (capability requirements, deadline, etc. — F-021) is Phase D
+ *     federation work; for B.1b the outbound is structurally sound but
+ *     doesn't carry the full sovereignty/capability advertisement.
+ *   - **No reply timeout.** Caller's `req.timeoutMs` is observed and
+ *     surfaces in the synthetic terminal envelope's reason when the
+ *     iterator is broken, but the harness doesn't internally race a
+ *     timeout against inbound — the caller iterates with whatever
+ *     timeout discipline they bring (matches `ClaudeCodeHarness`'s
+ *     "iterator close means stop" contract).
+ *   - **No graceful shutdown drain.** `shutdown(opts)` is omitted; the
+ *     `SessionHarness` contract says omitting is "stateless across
+ *     dispatches" which is true here (each `dispatch` allocates +
+ *     unregisters its own onEnvelope handler).
+ *
+ * **Cross-references:**
+ *   - cortex#114 B.1b — this slice.
+ *   - cortex#102 — design: bot↔bot via bus envelopes.
+ *   - `src/bus/verify-signed-by-chain.ts` — B.1a primitive consumed here.
+ *   - `src/substrates/claude-code/harness.ts` — the sibling pattern.
+ */
+
+import { randomUUID } from "crypto";
+
+import type { Envelope } from "../../bus/myelin/envelope-validator";
+import type { MyelinRuntime } from "../../bus/myelin/runtime";
+import type { TrustResolver } from "../../common/agents/trust-resolver";
+import {
+  verifySignedByChain,
+  type ChainVerificationResult,
+} from "../../bus/verify-signed-by-chain";
+import type {
+  Capability,
+  DispatchRequest,
+  HarnessId,
+  MyelinEnvelope,
+  SessionHarness,
+} from "../../common/substrates/types";
+import {
+  createDispatchTaskStartedEvent,
+  type DispatchEventSource,
+} from "../../bus/dispatch-events";
+
+// =============================================================================
+// Constructor options
+// =============================================================================
+
+/**
+ * Construct-time configuration. The harness binds to a single
+ * receiving identity (`receivingAgentId`) and a single peer target
+ * subject classification at construction time — different peers / peer
+ * networks instantiate different harness objects rather than
+ * multiplexing through one.
+ */
+export interface BusPeerHarnessOpts {
+  /** Runtime the harness publishes + listens through. */
+  runtime: MyelinRuntime;
+  /** Trust resolver — passed through to `verifySignedByChain`. */
+  resolver: TrustResolver;
+  /**
+   * Agent id of the LOCAL side of the bus-peer link — the receiver
+   * whose `trust:` list governs which inbound peers are accepted.
+   * Trust direction: this harness accepts envelopes from peers that
+   * `agents[receivingAgentId].trust` includes.
+   */
+  receivingAgentId: string;
+  /**
+   * Source attribution stamped onto outbound + locally-synthesised
+   * envelopes. The runner already builds one of these for the
+   * dispatch path; pass it through verbatim.
+   */
+  source: DispatchEventSource;
+  /**
+   * Capabilities the harness advertises — what work it can route to
+   * peers. The capability registry (Phase A.6) aggregates across all
+   * harnesses; this list is what cortex sees from this harness.
+   * Empty array is legal during scaffold work — the harness is
+   * structurally valid but operators won't actually dispatch tasks
+   * to it.
+   */
+  capabilities?: Capability[];
+}
+
+// =============================================================================
+// Harness
+// =============================================================================
+
+export class BusPeerHarness implements SessionHarness {
+  readonly id: HarnessId = "bus-peer";
+  readonly capabilities: Capability[];
+
+  private readonly runtime: MyelinRuntime;
+  private readonly resolver: TrustResolver;
+  private readonly receivingAgentId: string;
+  private readonly source: DispatchEventSource;
+
+  constructor(opts: BusPeerHarnessOpts) {
+    this.runtime = opts.runtime;
+    this.resolver = opts.resolver;
+    this.receivingAgentId = opts.receivingAgentId;
+    this.source = opts.source;
+    this.capabilities = opts.capabilities ?? [];
+  }
+
+  /**
+   * Dispatch a task by publishing an outbound request envelope onto
+   * the bus and yielding every verified inbound envelope correlated
+   * with this dispatch. The iterator closes when the peer's terminal
+   * envelope arrives, OR (if the consumer breaks) when iteration
+   * stops — at which point the harness yields a synthetic `aborted`
+   * terminal envelope so the runner can record the cancellation.
+   *
+   * **Failure modes & their wire shapes:**
+   *   - Inbound envelope fails `verifySignedByChain`: logged to
+   *     stderr, dropped. The consumer never sees it. Audit-envelope
+   *     emission lives in Phase C.
+   *   - Consumer breaks early: handler unregisters via the
+   *     try/finally cleanup. No synthetic terminal envelope is
+   *     yielded — async-generator semantics drop yields in finally
+   *     after iterator return, and the pattern matches
+   *     `ClaudeCodeHarness`'s contract (runner / dispatch-listener
+   *     observes iterator close + records an aborted lifecycle
+   *     envelope from its outside view).
+   *   - Runtime publish fails: error propagates synchronously to
+   *     the caller (matches `MyelinRuntime.publish`'s fire-and-forget
+   *     contract — internal log + swallow inside the runtime; the
+   *     promise still resolves so we don't `await` on a rejection).
+   */
+  // eslint-disable-next-line @typescript-eslint/require-await
+  async *dispatch(
+    req: DispatchRequest,
+  ): AsyncIterable<MyelinEnvelope> {
+    // Per the SessionHarness contract, `req.requestId` is the
+    // correlation key downstream subscribers use to thread the
+    // dispatch lifecycle. We thread it through to BOTH the outbound
+    // request envelope AND the started/aborted envelopes we
+    // synthesise locally.
+    const correlationId = req.requestId;
+    const startedAt = new Date();
+
+    // ----------------------------------------------------------------
+    // 1. Build the outbound request envelope (minimal shape for B.1b)
+    // ----------------------------------------------------------------
+    const requestEnvelope: Envelope = {
+      id: randomUUID(),
+      source: `${this.source.org}.${this.source.agent}.${this.source.instance}`,
+      type: "dispatch.task.dispatched",
+      timestamp: startedAt.toISOString(),
+      correlation_id: correlationId,
+      sovereignty: {
+        classification: "local",
+        data_residency: this.source.dataResidency ?? "NZ",
+        max_hop: 4,
+        frontier_ok: false,
+        model_class: "any",
+      },
+      payload: {
+        agent_id: req.agent.id,
+        prompt: req.prompt,
+        request_id: correlationId,
+        ...(req.timeoutMs !== undefined && { timeout_ms: req.timeoutMs }),
+      },
+    };
+
+    // ----------------------------------------------------------------
+    // 2. Set up the inbound queue + verification gate
+    // ----------------------------------------------------------------
+    // Async-producer / async-consumer rendezvous: the runtime fans
+    // out inbound envelopes synchronously to our handler; the handler
+    // pushes onto `inboundQueue`. The generator below pulls.
+    const inboundQueue: MyelinEnvelope[] = [];
+    const pendingResolvers: ((env: MyelinEnvelope | null) => void)[] = [];
+    // Wrapped in an object so the closure-mutation visible to the
+    // onEnvelope handler is also visible to lint's flow analysis on
+    // the generator side. A bare `let closed = false` would compile
+    // correctly but trip `no-unnecessary-condition` because the
+    // closure's `closed = true` write doesn't propagate to the outer
+    // linear narrow.
+    const state = { closed: false };
+
+    function pushInbound(env: MyelinEnvelope) {
+      const next = pendingResolvers.shift();
+      if (next !== undefined) {
+        next(env);
+      } else {
+        inboundQueue.push(env);
+      }
+    }
+
+    function signalClosed() {
+      state.closed = true;
+      while (pendingResolvers.length > 0) {
+        const resolve = pendingResolvers.shift();
+        if (resolve !== undefined) resolve(null);
+      }
+    }
+
+    // Register the handler INSIDE the try/finally so the unregister
+    // runs even if the consumer breaks at the `started` yield (or
+    // earlier, before entering the pull loop). Async generators only
+    // run finally blocks that wrap the suspended yield point — a
+    // try/finally placed after `yield startedEnvelope` would be
+    // skipped by a break-at-started call to iter.return().
+    const handlerRegistration = this.runtime.onEnvelope((envelope) => {
+      // Filter: only envelopes tagged with our correlation_id are
+      // relevant to this dispatch. Bus traffic for other dispatches
+      // flows past untouched.
+      if (envelope.correlation_id !== correlationId) return;
+
+      // Filter: don't loop our own outbound request back into our
+      // inbound stream — the local fan-out also fires for envelopes
+      // this harness just published.
+      if (envelope.id === requestEnvelope.id) return;
+
+      const verification: ChainVerificationResult = verifySignedByChain(
+        envelope,
+        {
+          resolver: this.resolver,
+          receivingAgentId: this.receivingAgentId,
+          // Peers always sign at least the bare ed25519 stamp; an
+          // unsigned envelope on the bus-peer path is a misconfig
+          // we want surfaced.
+          rejectEmpty: true,
+        },
+      );
+
+      if (!verification.valid) {
+        // Phase C wires audit envelopes; for now stderr is the
+        // visibility surface. Format the reason discriminator inline
+        // so an operator grepping stderr gets the structural class
+        // without consulting code.
+        const reason = verification.reason;
+        process.stderr.write(
+          `[bus-peer:${this.receivingAgentId}] dropped inbound envelope ` +
+            `${envelope.id} (correlation_id=${correlationId}): ` +
+            `${reason.kind} at chain index ${verification.rejectedAt}\n`,
+        );
+        return;
+      }
+
+      pushInbound(envelope);
+
+      // Terminal-envelope detection — when the peer signals end of
+      // the dispatch, close the inbound queue so the generator can
+      // exit cleanly. Conventional terminal types per G-1111 §3.4.
+      if (
+        envelope.type === "dispatch.task.completed" ||
+        envelope.type === "dispatch.task.failed" ||
+        envelope.type === "dispatch.task.aborted"
+      ) {
+        signalClosed();
+      }
+    });
+
+    // ----------------------------------------------------------------
+    // 3. Publish the outbound request + drive the pull loop inside a
+    //    single try/finally so the handler unregisters on every exit
+    //    path — including a consumer break at the FIRST yield.
+    // ----------------------------------------------------------------
+    try {
+      // Fire-and-forget per MyelinRuntime.publish's documented contract
+      // (Core NATS is fire-and-forget at the client layer; the promise
+      // resolves synchronously even on failures — runtime logs+swallows).
+      void this.runtime.publish(requestEnvelope);
+
+      // ----------------------------------------------------------------
+      // 4. Yield local started envelope so the runner has a lifecycle
+      //    anchor before any peer envelopes arrive
+      // ----------------------------------------------------------------
+      const startedEnvelope = createDispatchTaskStartedEvent({
+        source: this.source,
+        taskId: correlationId,
+        agentId: req.agent.id,
+        startedAt,
+        correlationId,
+      });
+      yield startedEnvelope;
+
+      // ----------------------------------------------------------------
+      // 5. Pull inbound until the peer signals terminal OR consumer
+      //    breaks. Both paths trigger the finally below.
+      // ----------------------------------------------------------------
+      while (!state.closed || inboundQueue.length > 0) {
+        const buffered = inboundQueue.shift();
+        if (buffered !== undefined) {
+          yield buffered;
+          continue;
+        }
+        if (state.closed) break;
+
+        const next = await new Promise<MyelinEnvelope | null>((resolve) => {
+          pendingResolvers.push(resolve);
+        });
+        if (next === null) break;
+        yield next;
+      }
+    } finally {
+      // Consumer-break path: matches `ClaudeCodeHarness`'s contract —
+      // we clean up the runtime subscription so the bus doesn't
+      // fan out to a dropped handler. The caller (runner /
+      // dispatch-listener) is responsible for recording an aborted
+      // lifecycle envelope from its outside view when iteration
+      // breaks before a peer terminal arrives. A yield inside this
+      // finally would land on a closed iterator and never reach the
+      // consumer anyway (async-generator semantics: yields in finally
+      // after iterator return are silently dropped).
+      handlerRegistration.unregister();
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Phase B.1b — `BusPeerHarness`, the second concrete `SessionHarness` implementation alongside `ClaudeCodeHarness`. Lands on top of B.1a's verification primitives (PR #194).

\`refs cortex#114\`

## What this slice delivers

- **`BusPeerHarness implements SessionHarness`** (\`src/substrates/bus-peer/harness.ts\`, +346 LOC).
  - Constructor: `runtime: MyelinRuntime`, `resolver: TrustResolver`, `receivingAgentId: string`, `source: DispatchEventSource`, optional `capabilities[]`.
  - `dispatch(req)`:
    1. Builds outbound `dispatch.task.dispatched` envelope tagged with `req.requestId` as correlation_id.
    2. Registers a runtime fan-out handler INSIDE a try/finally — so unregister fires on EVERY exit (consumer break at first yield, mid-stream break, peer terminal, publish failure).
    3. Handler filters: matches by correlation_id, excludes the harness's own outbound (by envelope.id), runs `verifySignedByChain` (from B.1a), pushes accepted onto an async producer/consumer queue, drops failures with stderr log carrying the structured rejection-reason discriminator.
    4. Yields local `started` first, then every verified peer envelope, then closes when the peer signals terminal (`dispatch.task.{completed,failed,aborted}`).
  - Matches `ClaudeCodeHarness`'s contract on consumer-break: no synthetic terminal yielded (async-generator semantics drop yields-in-finally after iterator return), the runner records the abort from its outside view.

- **4 tests** (\`src/substrates/bus-peer/__tests__/harness.test.ts\`, +389 LOC):
  1. Round-trip on valid chain — yields started + verified inbound.
  2. Untrusted-signer drop — stderr log + envelope not yielded.
  3. Consumer-break — handler unregistered, no synthetic terminal.
  4. Correlation-id filter — different dispatches don't cross-talk.

## What this slice deliberately doesn't do

- **No ed25519 verification of signature bytes** — structural trust check only. Phase B.1c slots the bytes check on top via the JCS canonicalization helper (shared with B.3 outbound signing).
- **No production wire format for outbound requests** — the harness builds a minimal \`dispatch.task.dispatched\` envelope. The F-021 task-contract shape (capability requirements, deadline, sovereignty advertisement) is Phase D federation work.
- **No reply timeout** — caller's \`req.timeoutMs\` is observed but the harness doesn't internally race a timer against inbound. Matches \`ClaudeCodeHarness\`'s "iterator close means stop" contract.
- **No graceful shutdown drain** — \`shutdown(opts)\` omitted; each dispatch allocates + cleans up its own handler.
- **No audit envelope emission** — drops surface to stderr. Audit envelope wiring (\`system.access.denied\`) lands at Phase C.4 alongside the PolicyEngine.

## Verification

- \`bunx tsc --noEmit\` — clean
- \`bun run lint:errors\` — clean (0 errors)
- \`bun test src/substrates/bus-peer/__tests__/\` — 4 pass / 0 fail / 22 expect()
- \`bun test src/substrates/ src/bus/ src/common/{agents,types}/\` — 658 pass / 0 fail / 1284 expect()

## Phase B continuation

After this merges:
- **B.1c** — ed25519 + JCS canonicalization. Extends \`verifySignedByChain\` to call \`ed25519.verify\` on canonical bytes; adds forged-signature regression test. JCS helper is shared with B.3 outbound signing.
- **B.2** — \`ClaudeCodeHarness\` uses bus for bot↔bot calls. Depends on B.1b.
- **B.3** — outbound envelope signing with stack NKey. Depends on B.1a's \`Agent.nkey_pub\` field.
- **B.4** — round-trip + adversarial integration tests across the full path.