### PR TITLE
fix: absorb grove-auth into worker as user-auth/

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -17,7 +17,6 @@
         "commander": "^14.0.3",
         "discord.js": "^14.25.1",
         "elkjs": "^0.11.1",
-        "grove-auth": "file:../grove-auth",
         "hono": "4.12.10",
         "nats": "^2.29.3",
         "react": "^19.2.4",
@@ -39,8 +38,6 @@
     },
   },
   "packages": {
-    "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20260403.1", "", {}, "sha512-p6oSNt3yUwcxSoXZ7qCog7+kgQbkSx1Beoci7TMb/xbRF05VR0cO/p1XUE2SLHZ7IgSIc3tNMpFKa0L0fa3Lzg=="],
-
     "@discordjs/builders": ["@discordjs/builders@1.14.0", "", { "dependencies": { "@discordjs/formatters": "^0.6.2", "@discordjs/util": "^1.2.0", "@sapphire/shapeshift": "^4.0.0", "discord-api-types": "^0.38.40", "fast-deep-equal": "^3.1.3", "ts-mixer": "^6.0.4", "tslib": "^2.6.3" } }, "sha512-7pVKxVWkeLUtrTo9nTYkjRcJk0Hlms6lYervXAD7E7+K5lil9ms2JrEB1TalMiHvQMh7h1HJZ4fCJa0/vHpl4w=="],
 
     "@discordjs/collection": ["@discordjs/collection@1.5.3", "", {}, "sha512-SVb428OMd3WO1paV3rm6tSjM4wC+Kecaa1EUGX7vc6/fddvw/6lg90z4QtCqm21zvVe92vMMDt9+DkIvjXImQQ=="],
@@ -262,8 +259,6 @@
     "flatted": ["flatted@3.4.2", "", {}, "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA=="],
 
     "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
-
-    "grove-auth": ["grove-auth@file:../grove-auth", { "dependencies": { "hono": "^4.7.0" }, "devDependencies": { "@cloudflare/workers-types": "^4.20250327.0", "typescript": "^5.8.0" } }],
 
     "hono": ["hono@4.12.10", "", {}, "sha512-mx/p18PLy5og9ufies2GOSUqep98Td9q4i/EF6X7yJgAiIopxqdfIO3jbqsi3jRgTgw88jMDEzVKi+V2EF+27w=="],
 

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "commander": "^14.0.3",
     "discord.js": "^14.25.1",
     "elkjs": "^0.11.1",
-    "grove-auth": "file:../grove-auth",
     "hono": "4.12.10",
     "nats": "^2.29.3",
     "react": "^19.2.4",

--- a/src/surface/mc/worker/package.json
+++ b/src/surface/mc/worker/package.json
@@ -8,7 +8,6 @@
     "db:migrate": "wrangler d1 execute GROVE_DB --file=./schema.sql"
   },
   "dependencies": {
-    "grove-auth": "file:../../../../../grove-auth",
     "hono": "^4.7.0",
     "@octokit/webhooks-methods": "^5.0.0"
   },

--- a/src/surface/mc/worker/src/index.ts
+++ b/src/surface/mc/worker/src/index.ts
@@ -6,7 +6,7 @@
 
 import { Hono } from "hono";
 import { cors } from "hono/cors";
-import { authRoutes, type AuthBindings } from "grove-auth";
+import { authRoutes, type AuthBindings } from "./user-auth";
 import { rateLimit } from "./rate-limiter";
 import { ingestRoutes } from "./routes/ingest";
 import { stateRoutes } from "./routes/state";

--- a/src/surface/mc/worker/src/routes/admin.ts
+++ b/src/surface/mc/worker/src/routes/admin.ts
@@ -13,7 +13,7 @@
 import { Hono } from "hono";
 import type { Env } from "../index";
 import { requireAdmin, type OperatorKey } from "../auth";
-import { requireRole } from "grove-auth";
+import { requireRole } from "../user-auth";
 
 export const adminRoutes = new Hono<{ Bindings: Env }>();
 

--- a/src/surface/mc/worker/src/user-auth/README.md
+++ b/src/surface/mc/worker/src/user-auth/README.md
@@ -1,0 +1,55 @@
+# user-auth
+
+User, agent, and role auth surface for the Mission Control worker. Absorbed
+from the standalone `grove-auth` repo
+([the-metafactory/grove-auth](https://github.com/the-metafactory/grove-auth))
+in cortex#198 as part of the grove → cortex consolidation.
+
+This module is now first-class cortex source. There is no upstream sync
+relationship — edit it like any other worker code.
+
+## What lives here
+
+- **`types.ts`** — Role hierarchy (`viewer < operator < admin`), scope hierarchy
+  (`read < write < admin`), user/agent/grant records, the `AuthBindings`
+  env shape consumed by the worker.
+- **`authorize.ts`** — Pure decision functions: `checkRole`, `checkAgentAccess`.
+  No I/O; testable in isolation.
+- **`middleware/`** — Hono middleware composed by the worker entrypoint:
+  - `require-auth.ts` — CF Access JWT → D1 user lookup → context binding.
+  - `require-role.ts` — Role-gate factory (`requireRole("admin")` etc.).
+  - `require-agent-access.ts` — Agent grant-scope gate.
+  - `cf-access.ts` — CF Access JWT validation primitives.
+  - `audit.ts` — Audit-log emitter (fire-and-forget, writes to D1).
+- **`routes/auth.ts`** — `authRoutes` Hono router mounted by the worker
+  at `/auth/*` (whoami, enrol, etc.).
+- **`index.ts`** — Public re-exports. Consumers import from `./user-auth`
+  (or `../user-auth` from the routes/ subdir).
+
+## What was intentionally not absorbed
+
+- `src/middleware/require-role.test.ts` and `src/routes/auth.test.ts` from
+  upstream — the worker doesn't run tests today, so the test surface stays
+  in the original repo until cortex's worker grows a test runner.
+- `src/schema/*.sql` — schema lives in the worker's own
+  `migrations/` directory (`0001_auth_tables.sql`, `0002_seed_data.sql`).
+  Those files were forked from grove-auth at a similar time; if the schema
+  drifts, sync direction is cortex → upstream, since cortex is the live
+  consumer.
+
+## Relationship to the worker's existing `auth.ts`
+
+`src/auth.ts` in the worker is a different surface — operator API-key auth
+(`requireApiKey`, `requireAdmin`, `OperatorKey`) for bot operators posting
+to `/api/ingest`. It does not overlap with anything here. The two coexist:
+operator-key auth gates the ingest path; user-auth gates the dashboard
+read path.
+
+## Provenance
+
+Absorbed from `the-metafactory/grove-auth` at SHA
+`5a0785766b52172d8a4e9091f9189a6096112d52` ("chore: bump to v0.4.1",
+2026-04-03 baseline + small follow-ups). See cortex#198 for the absorption
+rationale and the CI failure mode (`bun install --frozen-lockfile` blew up
+on the `file:../grove-auth` sibling-path dep, which only resolved on
+Andreas's local filesystem).

--- a/src/surface/mc/worker/src/user-auth/authorize.ts
+++ b/src/surface/mc/worker/src/user-auth/authorize.ts
@@ -1,0 +1,71 @@
+/**
+ * GA-1: Pure authorization logic — no Hono, no D1, no side effects.
+ * Both middleware and tests call these functions, ensuring tests exercise
+ * the same code paths as production.
+ */
+
+import type { Role, GrantScope, AgentClass } from "./types";
+import { ROLE_HIERARCHY, SCOPE_HIERARCHY } from "./types";
+
+// =============================================================================
+// Role check
+// =============================================================================
+
+export type RoleCheckResult =
+  | { allowed: true }
+  | { allowed: false; error: "insufficient_role"; required: Role; current: Role };
+
+/** Check if a user's role meets the minimum required level. */
+export function checkRole(userRole: Role, minRole: Role): RoleCheckResult {
+  if (ROLE_HIERARCHY[userRole] >= ROLE_HIERARCHY[minRole]) {
+    return { allowed: true };
+  }
+  return { allowed: false, error: "insufficient_role", required: minRole, current: userRole };
+}
+
+// =============================================================================
+// Agent access check
+// =============================================================================
+
+export interface AgentAccessInput {
+  userId: string;
+  userRole: Role;
+  agentOwnerId: string;
+  agentClass: AgentClass;
+  grantScope: GrantScope | null;
+  requiredScope: GrantScope;
+}
+
+export type AgentAccessResult =
+  | { allowed: true; resolution: "owner" | "grant" | "admin" | "cattle"; availableScope: GrantScope }
+  | { allowed: false; error: "no_agent_access"; availableScope: GrantScope | null };
+
+/**
+ * Determine if a user can access an agent at the required scope level.
+ * Resolution order: owner → active grant → admin bypass → cattle open access.
+ */
+export function checkAgentAccess(input: AgentAccessInput): AgentAccessResult {
+  const { userId, userRole, agentOwnerId, agentClass, grantScope, requiredScope } = input;
+
+  // 1. Owner → full access
+  if (agentOwnerId === userId) {
+    return { allowed: true, resolution: "owner", availableScope: "control" };
+  }
+
+  // 2. Active grant with sufficient scope
+  if (grantScope && SCOPE_HIERARCHY[grantScope] >= SCOPE_HIERARCHY[requiredScope]) {
+    return { allowed: true, resolution: "grant", availableScope: grantScope };
+  }
+
+  // 3. Admin bypass
+  if (userRole === "admin") {
+    return { allowed: true, resolution: "admin", availableScope: "control" };
+  }
+
+  // 4. Cattle open access (any operator)
+  if (agentClass === "cattle" && ROLE_HIERARCHY[userRole] >= ROLE_HIERARCHY["operator"]) {
+    return { allowed: true, resolution: "cattle", availableScope: "control" };
+  }
+
+  return { allowed: false, error: "no_agent_access", availableScope: grantScope };
+}

--- a/src/surface/mc/worker/src/user-auth/index.ts
+++ b/src/surface/mc/worker/src/user-auth/index.ts
@@ -1,0 +1,35 @@
+/**
+ * user-auth — User, agent, and role auth for the Mission Control worker.
+ *
+ * Absorbed from the standalone grove-auth repo in cortex#198; see
+ * ./README.md for provenance. Public API: middleware + types + authRoutes.
+ */
+
+export {
+  requireAuth,
+  authenticateUser,
+  requireRole,
+  requireAgentAccess,
+  getUserByEmail,
+  validateCfAccessJwt,
+  getCfAccessEmail,
+  logAuditEvent,
+  getClientIp,
+} from "./middleware";
+
+export type {
+  Role,
+  AgentClass,
+  GrantScope,
+  UserRecord,
+  AgentRecord,
+  GrantRecord,
+  AuthBindings,
+} from "./types";
+
+export { ROLE_HIERARCHY, SCOPE_HIERARCHY } from "./types";
+
+export { checkRole, checkAgentAccess } from "./authorize";
+export type { RoleCheckResult, AgentAccessInput, AgentAccessResult } from "./authorize";
+
+export { authRoutes } from "./routes/auth";

--- a/src/surface/mc/worker/src/user-auth/middleware/audit.ts
+++ b/src/surface/mc/worker/src/user-auth/middleware/audit.ts
@@ -1,0 +1,41 @@
+/**
+ * GA-1: Audit logging helper for auth middleware.
+ * Fire-and-forget writes to D1 audit_log table.
+ */
+
+import type { Context } from "hono";
+
+/** Log an auth event to D1 audit_log table. Fire-and-forget (non-blocking). */
+export function logAuditEvent(
+  db: D1Database,
+  event: {
+    eventType: string;
+    result: "success" | "failure";
+    ip: string;
+    endpoint: string;
+    method: string;
+    identity?: string;
+    detail?: string;
+  },
+): void {
+  db.prepare(`
+    INSERT INTO audit_log (event_type, result, ip, endpoint, method, identity, detail)
+    VALUES (?, ?, ?, ?, ?, ?, ?)
+  `).bind(
+    event.eventType,
+    event.result,
+    event.ip,
+    event.endpoint,
+    event.method,
+    event.identity ?? null,
+    event.detail ?? null,
+  ).run().catch((_err: unknown) => {
+    // Audit log write failures should not break the request — best-effort logging
+  });
+}
+
+export function getClientIp(c: Context): string {
+  return c.req.header("CF-Connecting-IP")
+    ?? c.req.header("X-Forwarded-For")?.split(",")[0]?.trim()
+    ?? "unknown";
+}

--- a/src/surface/mc/worker/src/user-auth/middleware/cf-access.ts
+++ b/src/surface/mc/worker/src/user-auth/middleware/cf-access.ts
@@ -1,0 +1,121 @@
+/**
+ * GA-1: CF Access JWT validation helpers.
+ * Extracted for reuse by requireRole() — the JWT validation logic itself.
+ */
+
+import type { AuthBindings } from "../types";
+
+/** CF Access JWKs include `kid` which standard JsonWebKey does not. */
+type CfAccessJwk = JsonWebKey & { kid?: string };
+
+const CF_ACCESS_TEAM = "metafactory";
+const CF_CERTS_URL = `https://${CF_ACCESS_TEAM}.cloudflareaccess.com/cdn-cgi/access/certs`;
+
+// Cache the JWK keyset in module scope (warm across requests within same isolate)
+let cachedKeys: { keys: CfAccessJwk[]; fetchedAt: number } | null = null;
+const KEY_CACHE_TTL_MS = 10 * 60 * 1000; // 10 minutes
+
+async function getCfAccessKeys(): Promise<CfAccessJwk[]> {
+  if (cachedKeys && Date.now() - cachedKeys.fetchedAt < KEY_CACHE_TTL_MS) {
+    return cachedKeys.keys;
+  }
+  const res = await fetch(CF_CERTS_URL);
+  if (!res.ok) throw new Error(`Failed to fetch CF Access certs: ${res.status}`);
+  const data = await res.json() as { keys: CfAccessJwk[] };
+  cachedKeys = { keys: data.keys, fetchedAt: Date.now() };
+  return data.keys;
+}
+
+async function importKey(jwk: JsonWebKey): Promise<CryptoKey> {
+  return crypto.subtle.importKey(
+    "jwk",
+    jwk,
+    { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" },
+    false,
+    ["verify"],
+  );
+}
+
+function base64urlDecode(str: string): Uint8Array {
+  const padded = str.replace(/-/g, "+").replace(/_/g, "/");
+  const binary = atob(padded);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return bytes;
+}
+
+/**
+ * Validate a CF Access JWT.
+ * Returns the decoded payload on success, or null on failure.
+ */
+export async function validateCfAccessJwt(
+  token: string,
+  audience: string,
+): Promise<Record<string, unknown> | null> {
+  const parts = token.split(".");
+  if (parts.length !== 3) return null;
+
+  const [headerB64, payloadB64, signatureB64] = parts as [string, string, string];
+
+  let header: { kid?: string; alg?: string };
+  try {
+    header = JSON.parse(new TextDecoder().decode(base64urlDecode(headerB64)));
+  } catch (_err: unknown) {
+    return null;
+  }
+  if (header.alg !== "RS256") return null;
+
+  let payload: Record<string, unknown>;
+  try {
+    payload = JSON.parse(new TextDecoder().decode(base64urlDecode(payloadB64)));
+  } catch (_err: unknown) {
+    return null;
+  }
+
+  const aud = payload.aud;
+  if (Array.isArray(aud) ? !aud.includes(audience) : aud !== audience) return null;
+
+  // Reject tokens without expiry — CF Access tokens should always include exp
+  const exp = payload.exp as number | undefined;
+  if (!exp || exp < Math.floor(Date.now() / 1000)) return null;
+
+  const keys = await getCfAccessKeys();
+  const matchingKeys = header.kid
+    ? keys.filter((k) => k.kid === header.kid)
+    : keys;
+
+  const signedData = new TextEncoder().encode(`${headerB64}.${payloadB64}`);
+  const signature = base64urlDecode(signatureB64);
+
+  for (const jwk of matchingKeys) {
+    try {
+      const cryptoKey = await importKey(jwk);
+      const valid = await crypto.subtle.verify("RSASSA-PKCS1-v1_5", cryptoKey, signature, signedData);
+      if (valid) return payload;
+    } catch (_err: unknown) {
+      continue; // Try next key
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Extract CF Access email from JWT cookie.
+ * Returns null if no audience configured (local dev), no cookie, or invalid JWT.
+ */
+export async function getCfAccessEmail(
+  env: AuthBindings,
+  req: { header(name: string): string | undefined },
+): Promise<string | null> {
+  const audience = env.CF_ACCESS_AUD;
+  if (!audience) return null;
+
+  const cookie = req.header("Cookie") ?? "";
+  const match = cookie.match(/CF_Authorization=([^;]+)/);
+  const token = match?.[1];
+  if (!token) return null;
+
+  const payload = await validateCfAccessJwt(token, audience);
+  return payload ? (payload.email as string) ?? null : null;
+}

--- a/src/surface/mc/worker/src/user-auth/middleware/index.ts
+++ b/src/surface/mc/worker/src/user-auth/middleware/index.ts
@@ -1,0 +1,5 @@
+export { requireAuth, authenticateUser, getUserByEmail } from "./require-auth";
+export { requireRole } from "./require-role";
+export { requireAgentAccess } from "./require-agent-access";
+export { validateCfAccessJwt, getCfAccessEmail } from "./cf-access";
+export { logAuditEvent, getClientIp } from "./audit";

--- a/src/surface/mc/worker/src/user-auth/middleware/require-agent-access.ts
+++ b/src/surface/mc/worker/src/user-auth/middleware/require-agent-access.ts
@@ -1,0 +1,98 @@
+/**
+ * GA-1: requireAgentAccess() — agent-level access control middleware.
+ * Resolution order: owner → active grant → admin bypass → cattle open access.
+ * Single JOIN query for performance.
+ * Design: docs/design-auth-aaa.md v2
+ */
+
+import type { Context, Next } from "hono";
+import type { AgentClass, AuthBindings, GrantScope, UserRecord } from "../types";
+import { checkAgentAccess } from "../authorize";
+import { logAuditEvent, getClientIp } from "./audit";
+
+/**
+ * Middleware factory that checks agent-level access.
+ * Reads agentId from route params. Resolution order:
+ * 1. Caller is agent owner → full access
+ * 2. Caller has active grant with sufficient scope → granted access
+ * 3. Caller is admin → bypass
+ * 4. Agent is cattle class → any operator can access
+ * Otherwise → 403.
+ *
+ * Requires requireRole() to have run first (needs c.get("user")).
+ */
+export function requireAgentAccess(requiredScope: GrantScope) {
+  return async function (c: Context<{ Bindings: AuthBindings; Variables: { user: UserRecord } }>, next: Next) {
+    const ip = getClientIp(c);
+    const endpoint = new URL(c.req.url).pathname;
+    const method = c.req.method;
+    const user = c.get("user");
+    const agentId = c.req.param("agentId");
+
+    if (!agentId) {
+      return c.json({ error: "missing agentId parameter" }, 400);
+    }
+
+    // Single query: fetch agent + best matching grant in one round-trip
+    const row = await c.env.GROVE_DB.prepare(`
+      SELECT
+        a.id AS agent_id,
+        a.owner_id,
+        a.class AS agent_class,
+        g.scope AS grant_scope
+      FROM agents a
+      LEFT JOIN agent_grants g
+        ON g.agent_id = a.id
+        AND g.grantee_id = ?
+        AND g.revoked_at IS NULL
+        AND (g.expires_at IS NULL OR g.expires_at > datetime('now'))
+      WHERE a.id = ?
+      ORDER BY
+        CASE g.scope WHEN 'control' THEN 2 WHEN 'review' THEN 1 WHEN 'read' THEN 0 ELSE -1 END DESC
+      LIMIT 1
+    `).bind(user.id, agentId).first<{
+      agent_id: string;
+      owner_id: string;
+      agent_class: AgentClass;
+      grant_scope: GrantScope | null;
+    }>();
+
+    if (!row) {
+      logAuditEvent(c.env.GROVE_DB, {
+        eventType: "agent_access", result: "failure", ip, endpoint, method,
+        identity: user.email, detail: `agent ${agentId} not found`,
+      });
+      return c.json({ error: "agent_not_found", agentId }, 404);
+    }
+
+    const result = checkAgentAccess({
+      userId: user.id,
+      userRole: user.role,
+      agentOwnerId: row.owner_id,
+      agentClass: row.agent_class,
+      grantScope: row.grant_scope,
+      requiredScope,
+    });
+
+    if (!result.allowed) {
+      logAuditEvent(c.env.GROVE_DB, {
+        eventType: "agent_access", result: "failure", ip, endpoint, method,
+        identity: user.email,
+        detail: `no_agent_access: agent=${agentId}, required=${requiredScope}, available=${result.availableScope ?? "none"}`,
+      });
+      return c.json({
+        error: result.error,
+        agentId,
+        required_scope: requiredScope,
+        available_scope: result.availableScope,
+      }, 403);
+    }
+
+    logAuditEvent(c.env.GROVE_DB, {
+      eventType: "agent_access", result: "success", ip, endpoint, method,
+      identity: user.email,
+      detail: `agent=${agentId}, scope=${requiredScope}, resolution=${result.resolution}, available=${result.availableScope}`,
+    });
+    await next();
+  };
+}

--- a/src/surface/mc/worker/src/user-auth/middleware/require-auth.ts
+++ b/src/surface/mc/worker/src/user-auth/middleware/require-auth.ts
@@ -1,0 +1,69 @@
+/**
+ * GA-1: requireAuth() — authentication-only middleware.
+ * Shared auth logic: CF Access JWT → D1 user lookup → set user.
+ * Used directly by authRoutes and internally by requireRole().
+ * Design: docs/design-auth-aaa.md v2
+ */
+
+import type { Context, Next } from "hono";
+import type { AuthBindings, UserRecord } from "../types";
+import { getCfAccessEmail } from "./cf-access";
+import { logAuditEvent, getClientIp } from "./audit";
+
+/** Look up a user in D1 by email. */
+export async function getUserByEmail(db: D1Database, email: string): Promise<UserRecord | null> {
+  return db.prepare("SELECT * FROM users WHERE email = ?").bind(email).first<UserRecord>();
+}
+
+/**
+ * Authenticate a user via CF Access JWT + D1 lookup.
+ * Pure logic — no side effects (no audit logging, no c.set).
+ */
+export async function authenticateUser(
+  env: AuthBindings,
+  req: { header(name: string): string | undefined },
+): Promise<
+  | { ok: true; user: UserRecord; email: string }
+  | { ok: false; error: string; email?: string }
+> {
+  const email = await getCfAccessEmail(env, req);
+  if (!email) {
+    return { ok: false, error: "no CF Access identity" };
+  }
+  const user = await getUserByEmail(env.GROVE_DB, email);
+  if (!user) {
+    return { ok: false, error: "user not provisioned", email };
+  }
+  return { ok: true, user, email };
+}
+
+/**
+ * Middleware that requires authentication via CF Access.
+ * Extracts email from CF Access JWT, looks up user in D1.
+ * Sets c.set("user", userRecord) on success for downstream use.
+ *
+ * Returns 401 if no CF Access identity or user not provisioned.
+ */
+export function requireAuth() {
+  return async function (c: Context<{ Bindings: AuthBindings; Variables: { user: UserRecord } }>, next: Next) {
+    const ip = getClientIp(c);
+    const endpoint = new URL(c.req.url).pathname;
+    const method = c.req.method;
+
+    const auth = await authenticateUser(c.env, c.req);
+    if (!auth.ok) {
+      logAuditEvent(c.env.GROVE_DB, {
+        eventType: "auth", result: "failure", ip, endpoint, method,
+        identity: auth.email, detail: auth.error,
+      });
+      return c.json({ error: "authentication required" }, 401);
+    }
+
+    logAuditEvent(c.env.GROVE_DB, {
+      eventType: "auth", result: "success", ip, endpoint, method,
+      identity: auth.email,
+    });
+    c.set("user", auth.user);
+    await next();
+  };
+}

--- a/src/surface/mc/worker/src/user-auth/middleware/require-role.ts
+++ b/src/surface/mc/worker/src/user-auth/middleware/require-role.ts
@@ -1,0 +1,52 @@
+/**
+ * GA-1: requireRole() — role-based authorization middleware.
+ * Uses authenticateUser() for auth, then checks role hierarchy.
+ * Design: docs/design-auth-aaa.md v2
+ */
+
+import type { Context, Next } from "hono";
+import type { AuthBindings, Role, UserRecord } from "../types";
+import { checkRole } from "../authorize";
+import { authenticateUser } from "./require-auth";
+import { logAuditEvent, getClientIp } from "./audit";
+
+/**
+ * Middleware factory that requires a minimum role level.
+ * Authenticates via CF Access JWT + D1 lookup, then checks role hierarchy.
+ * Sets c.set("user", userRecord) on success for downstream use.
+ *
+ * Returns 401 if no CF Access identity or user not provisioned.
+ * Returns 403 if user role is below the required minimum.
+ */
+export function requireRole(minRole: Role) {
+  return async function (c: Context<{ Bindings: AuthBindings; Variables: { user: UserRecord } }>, next: Next) {
+    const ip = getClientIp(c);
+    const endpoint = new URL(c.req.url).pathname;
+    const method = c.req.method;
+
+    const auth = await authenticateUser(c.env, c.req);
+    if (!auth.ok) {
+      logAuditEvent(c.env.GROVE_DB, {
+        eventType: "role_check", result: "failure", ip, endpoint, method,
+        identity: auth.email, detail: auth.error,
+      });
+      return c.json({ error: "authentication required" }, 401);
+    }
+
+    const result = checkRole(auth.user.role, minRole);
+    if (!result.allowed) {
+      logAuditEvent(c.env.GROVE_DB, {
+        eventType: "role_check", result: "failure", ip, endpoint, method,
+        identity: auth.email, detail: `insufficient_role: has ${auth.user.role}, needs ${minRole}`,
+      });
+      return c.json({ error: result.error, required: result.required, current: result.current }, 403);
+    }
+
+    logAuditEvent(c.env.GROVE_DB, {
+      eventType: "role_check", result: "success", ip, endpoint, method,
+      identity: auth.email, detail: `role=${auth.user.role} meets ${minRole}`,
+    });
+    c.set("user", auth.user);
+    await next();
+  };
+}

--- a/src/surface/mc/worker/src/user-auth/routes/auth.ts
+++ b/src/surface/mc/worker/src/user-auth/routes/auth.ts
@@ -1,0 +1,415 @@
+/**
+ * GA-1 (1.5): Auth API route group.
+ * Exported as a Hono app for mounting by the consuming Worker.
+ *
+ * Endpoints:
+ *   GET  /api/auth/me                    — current user profile + agents + grants
+ *   GET  /api/auth/users                 — list all users (admin)
+ *   PUT  /api/auth/users/:id/role        — change user role (admin)
+ *   GET  /api/auth/agents                — list agents (context-filtered)
+ *   GET  /api/auth/agents/:agentId       — agent detail (requires read access)
+ *   POST /api/auth/agents/:agentId/grants — create grant (owner/admin)
+ *   GET  /api/auth/agents/:agentId/grants — list grants for agent (requires read access)
+ *   DELETE /api/auth/grants/:grantId     — revoke grant
+ *
+ * Design: grove-auth/docs/design-auth-aaa.md v2
+ */
+
+import { Hono } from "hono";
+import type { Context } from "hono";
+import type { AuthBindings, AgentRecord, GrantScope, Role, UserRecord } from "../types";
+import { checkRole, checkAgentAccess } from "../authorize";
+import { logAuditEvent, getClientIp } from "../middleware/audit";
+import { requireAuth } from "../middleware/require-auth";
+
+const MAX_ID_LENGTH = 128;
+const DEFAULT_PAGE_LIMIT = 50;
+const MAX_PAGE_LIMIT = 200;
+
+type AuthEnv = { Bindings: AuthBindings; Variables: { user: UserRecord } };
+
+// ---------------------------------------------------------------------------
+// Pagination helper — extracts limit/offset from query params with bounds
+// ---------------------------------------------------------------------------
+
+function parsePagination(c: Context): { limit: number; offset: number } {
+  const rawLimit = parseInt(c.req.query("limit") ?? "", 10);
+  const rawOffset = parseInt(c.req.query("offset") ?? "", 10);
+  const limit = Math.min(
+    Number.isFinite(rawLimit) && rawLimit > 0 ? rawLimit : DEFAULT_PAGE_LIMIT,
+    MAX_PAGE_LIMIT,
+  );
+  const offset = Number.isFinite(rawOffset) && rawOffset >= 0 ? rawOffset : 0;
+  return { limit, offset };
+}
+
+// ---------------------------------------------------------------------------
+// Agent access resolution — shared by agent detail + grant listing endpoints
+// ---------------------------------------------------------------------------
+
+async function resolveAgentAccess(
+  c: Context<AuthEnv>,
+): Promise<{ agent: AgentRecord } | Response> {
+  const user = c.get("user");
+  const agentId = c.req.param("agentId");
+  const db = c.env.GROVE_DB;
+
+  const agent = await db.prepare("SELECT * FROM agents WHERE id = ?").bind(agentId).first<AgentRecord>();
+  if (!agent) {
+    return c.json({ error: "agent_not_found", agentId }, 404);
+  }
+
+  const grantRow = await db.prepare(`
+    SELECT scope FROM agent_grants
+    WHERE agent_id = ? AND grantee_id = ? AND revoked_at IS NULL
+    AND (expires_at IS NULL OR expires_at > datetime('now'))
+    ORDER BY CASE scope WHEN 'control' THEN 2 WHEN 'review' THEN 1 WHEN 'read' THEN 0 END DESC
+    LIMIT 1
+  `).bind(agentId, user.id).first<{ scope: GrantScope }>();
+
+  const access = checkAgentAccess({
+    userId: user.id,
+    userRole: user.role,
+    agentOwnerId: agent.owner_id,
+    agentClass: agent.class,
+    grantScope: grantRow?.scope ?? null,
+    requiredScope: "read",
+  });
+
+  if (!access.allowed) {
+    logAuditEvent(c.env.GROVE_DB, {
+      eventType: "agent_access", result: "failure",
+      ip: getClientIp(c), endpoint: new URL(c.req.url).pathname, method: c.req.method,
+      identity: user.email,
+      detail: `no_agent_access: agent=${agentId}, required=read`,
+    });
+    return c.json({ error: "no_agent_access", agentId }, 403);
+  }
+
+  return { agent };
+}
+
+export const authRoutes = new Hono<AuthEnv>();
+
+// ---------------------------------------------------------------------------
+// Auth middleware — uses shared requireAuth() (CF Access → D1 → set user)
+// ---------------------------------------------------------------------------
+
+authRoutes.use("/api/auth/*", requireAuth());
+
+// ---------------------------------------------------------------------------
+// GET /api/auth/me — current user profile
+// ---------------------------------------------------------------------------
+
+authRoutes.get("/api/auth/me", async (c) => {
+  const user = c.get("user");
+  const db = c.env.GROVE_DB;
+
+  const [ownedAgents, receivedGrants, givenGrants] = await Promise.all([
+    db.prepare("SELECT * FROM agents WHERE owner_id = ?").bind(user.id).all(),
+    db.prepare(`
+      SELECT g.*, a.display_name AS agent_name
+      FROM agent_grants g JOIN agents a ON g.agent_id = a.id
+      WHERE g.grantee_id = ? AND g.revoked_at IS NULL
+      AND (g.expires_at IS NULL OR g.expires_at > datetime('now'))
+    `).bind(user.id).all(),
+    db.prepare(`
+      SELECT g.*, a.display_name AS agent_name
+      FROM agent_grants g JOIN agents a ON g.agent_id = a.id
+      WHERE g.owner_id = ? AND g.revoked_at IS NULL
+    `).bind(user.id).all(),
+  ]);
+
+  return c.json({
+    user,
+    agents: ownedAgents.results,
+    grants: {
+      received: receivedGrants.results,
+      given: givenGrants.results,
+    },
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/auth/users — list all users (admin only)
+// ---------------------------------------------------------------------------
+
+authRoutes.get("/api/auth/users", async (c) => {
+  const user = c.get("user");
+  const result = checkRole(user.role, "admin");
+  if (!result.allowed) {
+    logAuditEvent(c.env.GROVE_DB, {
+      eventType: "role_check", result: "failure",
+      ip: getClientIp(c), endpoint: new URL(c.req.url).pathname, method: "GET",
+      identity: user.email,
+      detail: `insufficient_role: has ${user.role}, needs admin`,
+    });
+    return c.json({ error: result.error, required: result.required, current: result.current }, 403);
+  }
+
+  const { limit, offset } = parsePagination(c);
+  const users = await c.env.GROVE_DB.prepare(
+    "SELECT * FROM users ORDER BY created_at LIMIT ? OFFSET ?",
+  ).bind(limit, offset).all();
+  return c.json({ users: users.results, limit, offset });
+});
+
+// ---------------------------------------------------------------------------
+// PUT /api/auth/users/:id/role — change user role (admin only)
+// ---------------------------------------------------------------------------
+
+authRoutes.put("/api/auth/users/:id/role", async (c) => {
+  const caller = c.get("user");
+  const result = checkRole(caller.role, "admin");
+  if (!result.allowed) {
+    logAuditEvent(c.env.GROVE_DB, {
+      eventType: "role_check", result: "failure",
+      ip: getClientIp(c), endpoint: new URL(c.req.url).pathname, method: "PUT",
+      identity: caller.email,
+      detail: `insufficient_role: has ${caller.role}, needs admin`,
+    });
+    return c.json({ error: result.error, required: result.required, current: result.current }, 403);
+  }
+
+  const targetId = c.req.param("id");
+  const body = await c.req.json<{ role: Role }>().catch(() => null);
+  if (!body?.role || !["viewer", "operator", "admin"].includes(body.role)) {
+    return c.json({ error: "invalid role", valid: ["viewer", "operator", "admin"] }, 400);
+  }
+
+  const db = c.env.GROVE_DB;
+  const target = await db.prepare("SELECT * FROM users WHERE id = ?").bind(targetId).first<UserRecord>();
+  if (!target) {
+    return c.json({ error: "user_not_found", id: targetId }, 404);
+  }
+
+  // Guard: prevent demoting the last admin
+  if (target.role === "admin" && body.role !== "admin") {
+    const adminCount = await db.prepare(
+      "SELECT COUNT(*) as n FROM users WHERE role = 'admin'",
+    ).first<{ n: number }>();
+    if (adminCount && adminCount.n <= 1) {
+      return c.json({ error: "cannot_demote_last_admin" }, 409);
+    }
+  }
+
+  await db.prepare(
+    "UPDATE users SET role = ?, updated_at = datetime('now') WHERE id = ?",
+  ).bind(body.role, targetId).run();
+
+  logAuditEvent(db, {
+    eventType: "role_change", result: "success",
+    ip: getClientIp(c), endpoint: new URL(c.req.url).pathname, method: "PUT",
+    identity: caller.email,
+    detail: `${targetId}: ${target.role} → ${body.role}`,
+  });
+
+  return c.json({ ok: true, id: targetId, previous_role: target.role, new_role: body.role });
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/auth/agents — list agents (context-filtered by caller)
+// ---------------------------------------------------------------------------
+
+authRoutes.get("/api/auth/agents", async (c) => {
+  const user = c.get("user");
+  const db = c.env.GROVE_DB;
+
+  if (user.role === "admin") {
+    const { limit, offset } = parsePagination(c);
+    const agents = await db.prepare(
+      "SELECT * FROM agents ORDER BY created_at LIMIT ? OFFSET ?",
+    ).bind(limit, offset).all();
+    return c.json({ agents: agents.results, limit, offset });
+  }
+
+  // Operators/viewers: own agents + delegated + cattle
+  const [owned, delegated, cattle] = await Promise.all([
+    db.prepare("SELECT * FROM agents WHERE owner_id = ?").bind(user.id).all(),
+    db.prepare(`
+      SELECT a.*, g.scope AS grant_scope
+      FROM agents a JOIN agent_grants g ON g.agent_id = a.id
+      WHERE g.grantee_id = ? AND g.revoked_at IS NULL
+      AND (g.expires_at IS NULL OR g.expires_at > datetime('now'))
+    `).bind(user.id).all(),
+    db.prepare("SELECT * FROM agents WHERE class = 'cattle'").all(),
+  ]);
+
+  return c.json({
+    owned: owned.results,
+    delegated: delegated.results,
+    cattle: cattle.results,
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/auth/agents/:agentId — agent detail (requires read access)
+// ---------------------------------------------------------------------------
+
+authRoutes.get("/api/auth/agents/:agentId", async (c) => {
+  const result = await resolveAgentAccess(c);
+  if (result instanceof Response) return result;
+  const { agent } = result;
+
+  const agentId = c.req.param("agentId");
+  const db = c.env.GROVE_DB;
+
+  const [grants, owner] = await Promise.all([
+    db.prepare(`
+      SELECT g.*, u.display_name AS grantee_name, u.email AS grantee_email
+      FROM agent_grants g JOIN users u ON g.grantee_id = u.id
+      WHERE g.agent_id = ? AND g.revoked_at IS NULL
+    `).bind(agentId).all(),
+    db.prepare(
+      "SELECT id, display_name, email FROM users WHERE id = ?",
+    ).bind(agent.owner_id).first<{ id: string; display_name: string | null; email: string }>(),
+  ]);
+
+  return c.json({ agent, owner, grants: grants.results });
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/auth/agents/:agentId/grants — create grant (owner or admin)
+// ---------------------------------------------------------------------------
+
+authRoutes.post("/api/auth/agents/:agentId/grants", async (c) => {
+  const caller = c.get("user");
+  const agentId = c.req.param("agentId");
+  const db = c.env.GROVE_DB;
+
+  const agent = await db.prepare("SELECT * FROM agents WHERE id = ?").bind(agentId).first<AgentRecord>();
+  if (!agent) {
+    return c.json({ error: "agent_not_found", agentId }, 404);
+  }
+
+  // Only owner or admin can create grants
+  if (agent.owner_id !== caller.id && caller.role !== "admin") {
+    logAuditEvent(db, {
+      eventType: "grant_create", result: "failure",
+      ip: getClientIp(c), endpoint: new URL(c.req.url).pathname, method: "POST",
+      identity: caller.email,
+      detail: `unauthorized: agent=${agentId}, caller_role=${caller.role}`,
+    });
+    return c.json({ error: "only owner or admin can create grants" }, 403);
+  }
+
+  const body = await c.req.json<{
+    grantee_id: string;
+    scope: GrantScope;
+    requires_stepup?: boolean;
+    expires_at?: string;
+  }>().catch(() => null);
+
+  if (!body?.grantee_id || !body?.scope) {
+    return c.json({ error: "grantee_id and scope are required" }, 400);
+  }
+  if (!["read", "review", "control"].includes(body.scope)) {
+    return c.json({ error: "invalid scope", valid: ["read", "review", "control"] }, 400);
+  }
+  if (body.grantee_id.length > MAX_ID_LENGTH) {
+    return c.json({ error: "grantee_id too long" }, 400);
+  }
+  if (body.grantee_id === agent.owner_id) {
+    return c.json({ error: "cannot grant to agent owner" }, 400);
+  }
+  if (body.expires_at && isNaN(Date.parse(body.expires_at))) {
+    return c.json({ error: "invalid expires_at format" }, 400);
+  }
+
+  // Verify grantee exists
+  const grantee = await db.prepare("SELECT id FROM users WHERE id = ?").bind(body.grantee_id).first();
+  if (!grantee) {
+    return c.json({ error: "grantee_not_found", grantee_id: body.grantee_id }, 404);
+  }
+
+  const grantId = crypto.randomUUID();
+  await db.prepare(`
+    INSERT INTO agent_grants (id, agent_id, owner_id, grantee_id, scope, requires_stepup, expires_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?)
+  `).bind(
+    grantId,
+    agentId,
+    agent.owner_id,
+    body.grantee_id,
+    body.scope,
+    body.requires_stepup === false ? 0 : 1,
+    body.expires_at ?? null,
+  ).run();
+
+  logAuditEvent(db, {
+    eventType: "grant_create", result: "success",
+    ip: getClientIp(c), endpoint: new URL(c.req.url).pathname, method: "POST",
+    identity: caller.email,
+    detail: `grant=${grantId}, agent=${agentId}, grantee=${body.grantee_id}, scope=${body.scope}`,
+  });
+
+  return c.json({ ok: true, grant_id: grantId }, 201);
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/auth/agents/:agentId/grants — list grants for an agent
+// ---------------------------------------------------------------------------
+
+authRoutes.get("/api/auth/agents/:agentId/grants", async (c) => {
+  const result = await resolveAgentAccess(c);
+  if (result instanceof Response) return result;
+
+  const agentId = c.req.param("agentId");
+  const db = c.env.GROVE_DB;
+  const { limit, offset } = parsePagination(c);
+
+  const grants = await db.prepare(`
+    SELECT g.*, u.display_name AS grantee_name, u.email AS grantee_email
+    FROM agent_grants g JOIN users u ON g.grantee_id = u.id
+    WHERE g.agent_id = ?
+    ORDER BY g.created_at DESC
+    LIMIT ? OFFSET ?
+  `).bind(agentId, limit, offset).all();
+
+  return c.json({ grants: grants.results, limit, offset });
+});
+
+// ---------------------------------------------------------------------------
+// DELETE /api/auth/grants/:grantId — revoke grant (soft delete)
+// ---------------------------------------------------------------------------
+
+authRoutes.delete("/api/auth/grants/:grantId", async (c) => {
+  const caller = c.get("user");
+  const grantId = c.req.param("grantId");
+  const db = c.env.GROVE_DB;
+
+  const grant = await db.prepare(
+    "SELECT * FROM agent_grants WHERE id = ?",
+  ).bind(grantId).first<{ id: string; owner_id: string; revoked_at: string | null }>();
+
+  if (!grant) {
+    return c.json({ error: "grant_not_found", grantId }, 404);
+  }
+  if (grant.revoked_at) {
+    return c.json({ error: "grant_already_revoked", grantId }, 409);
+  }
+
+  // Only grant owner or admin can revoke
+  if (grant.owner_id !== caller.id && caller.role !== "admin") {
+    logAuditEvent(db, {
+      eventType: "grant_revoke", result: "failure",
+      ip: getClientIp(c), endpoint: new URL(c.req.url).pathname, method: "DELETE",
+      identity: caller.email,
+      detail: `unauthorized: grant=${grantId}, caller_role=${caller.role}`,
+    });
+    return c.json({ error: "only owner or admin can revoke grants" }, 403);
+  }
+
+  await db.prepare(
+    "UPDATE agent_grants SET revoked_at = datetime('now') WHERE id = ?",
+  ).bind(grantId).run();
+
+  logAuditEvent(db, {
+    eventType: "grant_revoke", result: "success",
+    ip: getClientIp(c), endpoint: new URL(c.req.url).pathname, method: "DELETE",
+    identity: caller.email,
+    detail: `grant=${grantId}`,
+  });
+
+  return c.json({ ok: true, grantId, revoked: true });
+});

--- a/src/surface/mc/worker/src/user-auth/types.ts
+++ b/src/surface/mc/worker/src/user-auth/types.ts
@@ -1,0 +1,51 @@
+/**
+ * GA-1: Auth types shared across middleware and consumers.
+ * Design: docs/design-auth-aaa.md v2
+ */
+
+export type Role = "viewer" | "operator" | "admin";
+export type AgentClass = "pet" | "cattle";
+export type GrantScope = "read" | "review" | "control";
+
+export const ROLE_HIERARCHY: Record<Role, number> = { viewer: 0, operator: 1, admin: 2 };
+export const SCOPE_HIERARCHY: Record<GrantScope, number> = { read: 0, review: 1, control: 2 };
+
+export interface UserRecord {
+  id: string;
+  email: string;
+  display_name: string | null;
+  role: Role;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface AgentRecord {
+  id: string;
+  display_name: string;
+  owner_id: string;
+  class: AgentClass;
+  backend: string | null;
+  spawn_profile: string | null;
+  created_at: string;
+}
+
+export interface GrantRecord {
+  id: string;
+  agent_id: string;
+  owner_id: string;
+  grantee_id: string;
+  scope: GrantScope;
+  requires_stepup: number;
+  expires_at: string | null;
+  created_at: string;
+  revoked_at: string | null;
+}
+
+/**
+ * Bindings required by grove-auth middleware.
+ * The consuming Worker's Env must extend this.
+ */
+export interface AuthBindings {
+  GROVE_DB: D1Database;
+  CF_ACCESS_AUD: string;
+}


### PR DESCRIPTION
## Summary

Fixes cortex#198 — the failing CI lint gate caused by \`\"grove-auth\": \"file:../grove-auth\"\` in cortex's package.json. The \`file:\` dep only resolves when grove-auth exists as a filesystem sibling, which it doesn't in the GitHub Actions runner.

Rather than pin grove-auth via a \`github:\` URL (the pattern \`@the-metafactory/myelin\` uses), we absorb the production source into the worker directly. Discussion with @mellanon surfaced that grove has been informally superseded by cortex, so treating the auth code as cortex-owned (no upstream sync relationship) matches the on-the-ground reality.

## What moved

\`\`\`
src/surface/mc/worker/src/user-auth/
├── index.ts          (public re-exports)
├── types.ts          (Role hierarchy, AuthBindings, UserRecord, AgentRecord, GrantRecord)
├── authorize.ts      (pure decision functions: checkRole, checkAgentAccess)
├── middleware/
│   ├── index.ts
│   ├── audit.ts             (logAuditEvent, getClientIp)
│   ├── cf-access.ts         (CF Access JWT validation)
│   ├── require-auth.ts      (CF Access JWT → D1 user)
│   ├── require-role.ts      (role-gate factory)
│   └── require-agent-access.ts
├── routes/auth.ts    (authRoutes Hono router)
└── README.md         (provenance + relationship to worker's existing auth.ts)
\`\`\`

958 LOC absorbed. Tests (\`*.test.ts\`) and SQL schema (\`src/schema/*.sql\`) from upstream were intentionally not absorbed — the worker doesn't run tests today, and the worker already has its own \`migrations/\` directory with the same tables (forked at similar time).

## Consumer changes

Two lines:

- \`src/surface/mc/worker/src/index.ts\` — \`import { authRoutes, type AuthBindings } from \"grove-auth\"\` → \`from \"./user-auth\"\`
- \`src/surface/mc/worker/src/routes/admin.ts\` — \`import { requireRole } from \"grove-auth\"\` → \`from \"../user-auth\"\`

## Coexistence with worker's existing auth.ts

The worker already has \`src/surface/mc/worker/src/auth.ts\` for operator API-key auth (\`requireApiKey\`, \`requireAdmin\`, \`OperatorKey\`). That's a different surface — operator/bot auth on \`/api/ingest\` vs user/role auth on the dashboard. Symbol-level check confirms no collisions. The README in \`user-auth/\` documents the split.

## Verification

Both CI gates pass locally:

\`\`\`
$ bun install --frozen-lockfile     # was failing per cortex#198
Done! Checked 175 packages (no changes) [36.00ms]

$ bun run lint:errors                # the blocking gate
$ eslint --quiet .
$ echo \$?
0
\`\`\`

bun.lock diff: removes the \`grove-auth\` line + the transitive \`@cloudflare/workers-types\` entry that grove-auth's root-level dep was pulling in (the worker has its own copy via its own package.json).

## What this PR does NOT do

- **Doesn't touch old grove.** \`~/Developer/grove\` and \`the-metafactory/grove\` still import grove-auth from 4 files. They aren't blocked by cortex's CI; if/when grove turns on its own lint gate, the same problem will surface there.
- **Doesn't archive the grove-auth repo.** Whether to wind it down is a separate decision; the file: dep is now cortex's problem-solved either way.
- **Doesn't restructure the worker tsconfig.** No build/deploy config changed.

## Provenance

Absorbed from \`the-metafactory/grove-auth\` at SHA \`5a0785766b52172d8a4e9091f9189a6096112d52\` (\"chore: bump to v0.4.1\", upstream commit dated 2026-04-03 + small follow-ups). Documented in \`user-auth/README.md\`.

Closes #198.

## Test plan

- [x] \`bun install --frozen-lockfile\` clean locally
- [x] \`bun run lint:errors\` exits 0 locally
- [ ] CI Lint job goes green on this PR
- [ ] CI Lint job goes green on subsequent main pushes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)