### PR TITLE
feat(bus): IAW B.1c — ed25519 + JCS crypto verification + myelin pin bump (refs cortex#114)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -9,7 +9,7 @@
         "@nats-io/jwt": "^0.0.11",
         "@octokit/webhooks": "^14.2.0",
         "@octokit/webhooks-methods": "^6.0.0",
-        "@the-metafactory/myelin": "github:the-metafactory/myelin#b69c877e23a2696040561c2d832fdc75aa83f73e",
+        "@the-metafactory/myelin": "github:the-metafactory/myelin#5a0e2619a4af5c91c78f552b88fafd3ad40a227f",
         "@xyflow/react": "^12.10.2",
         "ajv": "^8.20.0",
         "ajv-formats": "^3.0.1",
@@ -117,7 +117,7 @@
 
     "@sapphire/snowflake": ["@sapphire/snowflake@3.5.3", "", {}, "sha512-jjmJywLAFoWeBi1W7994zZyiNWPIiqRRNAmSERxyg93xRGzNYvGjlZ0gR6x0F4gPRi2+0O6S71kOZYyr3cxaIQ=="],
 
-    "@the-metafactory/myelin": ["@the-metafactory/myelin@github:the-metafactory/myelin#b69c877", { "dependencies": { "@msgpack/msgpack": "^3.1.3", "@nats-io/jetstream": "^3.4.0", "@nats-io/kv": "^3.4.0", "@nats-io/transport-node": "^3.4.0", "@noble/ed25519": "^3.1.0", "ajv": "8.20.0", "ajv-formats": "3.0.1" } }, "the-metafactory-myelin-b69c877"],
+    "@the-metafactory/myelin": ["@the-metafactory/myelin@github:the-metafactory/myelin#5a0e261", { "dependencies": { "@msgpack/msgpack": "^3.1.3", "@nats-io/jetstream": "^3.4.0", "@nats-io/kv": "^3.4.0", "@nats-io/transport-node": "^3.4.0", "@noble/ed25519": "^3.1.0", "ajv": "8.20.0", "ajv-formats": "3.0.1" } }, "the-metafactory-myelin-5a0e261"],
 
     "@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@nats-io/jwt": "^0.0.11",
     "@octokit/webhooks": "^14.2.0",
     "@octokit/webhooks-methods": "^6.0.0",
-    "@the-metafactory/myelin": "github:the-metafactory/myelin#b69c877e23a2696040561c2d832fdc75aa83f73e",
+    "@the-metafactory/myelin": "github:the-metafactory/myelin#5a0e2619a4af5c91c78f552b88fafd3ad40a227f",
     "@xyflow/react": "^12.10.2",
     "ajv": "^8.20.0",
     "ajv-formats": "^3.0.1",

--- a/src/bus/__tests__/verify-signed-by-chain.test.ts
+++ b/src/bus/__tests__/verify-signed-by-chain.test.ts
@@ -17,6 +17,8 @@
  */
 
 import { describe, test, expect } from "bun:test";
+import { createUser } from "@nats-io/nkeys";
+import { signEnvelope } from "@the-metafactory/myelin/identity";
 import { AgentRegistry } from "../../common/agents/registry";
 import { TrustResolver } from "../../common/agents/trust-resolver";
 import {
@@ -124,7 +126,7 @@ function resolverWith(...agents: Agent[]): TrustResolver {
 // =============================================================================
 
 describe("verifySignedByChain — happy path + skipped semantics", () => {
-  test("[1] single trusted ed25519 stamp → valid with empty skipped", () => {
+  test("[1] single trusted ed25519 stamp → valid with empty skipped", async () => {
     // Receiver "luna" trusts sender "echo" with known nkey.
     const luna = agentFixture({ id: "luna", trust: ["echo"] });
     const echo = agentFixture({
@@ -135,7 +137,7 @@ describe("verifySignedByChain — happy path + skipped semantics", () => {
     const resolver = resolverWith(luna, echo);
 
     const env = envelopeWithChain([ed25519Stamp("did:mf:echo")]);
-    const result: ChainVerificationResult = verifySignedByChain(env, {
+    const result = await verifySignedByChain(env, {
       resolver,
       receivingAgentId: "luna",
     });
@@ -146,7 +148,7 @@ describe("verifySignedByChain — happy path + skipped semantics", () => {
     }
   });
 
-  test("[8] mixed chain — hub-stamp at index 0 (skipped), trusted ed25519 at index 1 → valid w/ skipped:[0]", () => {
+  test("[8] mixed chain — hub-stamp at index 0 (skipped), trusted ed25519 at index 1 → valid w/ skipped:[0]", async () => {
     const luna = agentFixture({ id: "luna", trust: ["echo"] });
     const echo = agentFixture({
       id: "echo",
@@ -159,7 +161,7 @@ describe("verifySignedByChain — happy path + skipped semantics", () => {
       hubStamp("did:mf:echo", "did:mf:hub-alpha"),
       ed25519Stamp("did:mf:echo"),
     ]);
-    const result = verifySignedByChain(env, {
+    const result = await verifySignedByChain(env, {
       resolver,
       receivingAgentId: "luna",
     });
@@ -172,12 +174,12 @@ describe("verifySignedByChain — happy path + skipped semantics", () => {
 });
 
 describe("verifySignedByChain — empty chain semantics", () => {
-  test("[2] empty chain, rejectEmpty defaults to true → empty_chain rejection", () => {
+  test("[2] empty chain, rejectEmpty defaults to true → empty_chain rejection", async () => {
     const luna = agentFixture({ id: "luna" });
     const resolver = resolverWith(luna);
     const env = envelopeWithChain(undefined);
 
-    const result = verifySignedByChain(env, {
+    const result = await verifySignedByChain(env, {
       resolver,
       receivingAgentId: "luna",
     });
@@ -190,12 +192,12 @@ describe("verifySignedByChain — empty chain semantics", () => {
     }
   });
 
-  test("[3] empty chain, rejectEmpty explicit false → valid w/ empty skipped", () => {
+  test("[3] empty chain, rejectEmpty explicit false → valid w/ empty skipped", async () => {
     const luna = agentFixture({ id: "luna" });
     const resolver = resolverWith(luna);
     const env = envelopeWithChain(undefined);
 
-    const result = verifySignedByChain(env, {
+    const result = await verifySignedByChain(env, {
       resolver,
       receivingAgentId: "luna",
       rejectEmpty: false,
@@ -209,12 +211,12 @@ describe("verifySignedByChain — empty chain semantics", () => {
 });
 
 describe("verifySignedByChain — split rejection reasons", () => {
-  test("[4] malformed principal (did:key:…) → malformed_principal", () => {
+  test("[4] malformed principal (did:key:…) → malformed_principal", async () => {
     const luna = agentFixture({ id: "luna" });
     const resolver = resolverWith(luna);
     const env = envelopeWithChain([ed25519Stamp("did:key:abc123")]);
 
-    const result = verifySignedByChain(env, {
+    const result = await verifySignedByChain(env, {
       resolver,
       receivingAgentId: "luna",
     });
@@ -229,12 +231,12 @@ describe("verifySignedByChain — split rejection reasons", () => {
     }
   });
 
-  test("[5] well-formed did:mf but agent not registered → unknown_agent", () => {
+  test("[5] well-formed did:mf but agent not registered → unknown_agent", async () => {
     const luna = agentFixture({ id: "luna" });
     const resolver = resolverWith(luna);
     const env = envelopeWithChain([ed25519Stamp("did:mf:nobody")]);
 
-    const result = verifySignedByChain(env, {
+    const result = await verifySignedByChain(env, {
       resolver,
       receivingAgentId: "luna",
     });
@@ -250,14 +252,14 @@ describe("verifySignedByChain — split rejection reasons", () => {
     }
   });
 
-  test("[6] agent registered but no nkey_pub → principal_has_no_nkey_pub", () => {
+  test("[6] agent registered but no nkey_pub → principal_has_no_nkey_pub", async () => {
     const luna = agentFixture({ id: "luna", trust: ["echo"] });
     // echo has no nkey_pub — intentional.
     const echo = agentFixture({ id: "echo", displayName: "Echo" });
     const resolver = resolverWith(luna, echo);
 
     const env = envelopeWithChain([ed25519Stamp("did:mf:echo")]);
-    const result = verifySignedByChain(env, {
+    const result = await verifySignedByChain(env, {
       resolver,
       receivingAgentId: "luna",
     });
@@ -273,7 +275,7 @@ describe("verifySignedByChain — split rejection reasons", () => {
     }
   });
 
-  test("[7] signer's NKey known but receiver doesn't trust them → signer_not_trusted", () => {
+  test("[7] signer's NKey known but receiver doesn't trust them → signer_not_trusted", async () => {
     // luna does NOT include echo in `trust:`.
     const luna = agentFixture({ id: "luna", trust: [] });
     const echo = agentFixture({
@@ -284,7 +286,7 @@ describe("verifySignedByChain — split rejection reasons", () => {
     const resolver = resolverWith(luna, echo);
 
     const env = envelopeWithChain([ed25519Stamp("did:mf:echo")]);
-    const result = verifySignedByChain(env, {
+    const result = await verifySignedByChain(env, {
       resolver,
       receivingAgentId: "luna",
     });
@@ -302,7 +304,7 @@ describe("verifySignedByChain — split rejection reasons", () => {
 });
 
 describe("verifySignedByChain — multi-stamp rejection", () => {
-  test("[9] valid stamp at index 0, untrusted stamp at index 1 → rejectedAt:1, skipped:[]", () => {
+  test("[9] valid stamp at index 0, untrusted stamp at index 1 → rejectedAt:1, skipped:[]", async () => {
     // luna trusts echo (NKey present) but not holly. Chain has echo first
     // (accepted), holly second (rejected — signer_not_trusted). Verify
     // that `rejectedAt: 1` carries the per-stamp index, and that the
@@ -325,7 +327,7 @@ describe("verifySignedByChain — multi-stamp rejection", () => {
       ed25519Stamp("did:mf:echo"),
       ed25519Stamp("did:mf:holly"),
     ]);
-    const result = verifySignedByChain(env, {
+    const result = await verifySignedByChain(env, {
       resolver,
       receivingAgentId: "luna",
     });
@@ -342,7 +344,7 @@ describe("verifySignedByChain — multi-stamp rejection", () => {
     }
   });
 
-  test("rejection on stamp 2 with hub-stamp at index 0 → skipped:[0] preserved", () => {
+  test("rejection on stamp 2 with hub-stamp at index 0 → skipped:[0] preserved", async () => {
     // Extra coverage on the new `skipped` carry-through behaviour for
     // failure variants: hub-stamp at 0 was skipped before the rejection
     // at index 2 fires, so the failure result must surface skipped:[0].
@@ -359,7 +361,7 @@ describe("verifySignedByChain — multi-stamp rejection", () => {
       ed25519Stamp("did:mf:echo"),
       ed25519Stamp("did:mf:nobody"),
     ]);
-    const result = verifySignedByChain(env, {
+    const result = await verifySignedByChain(env, {
       resolver,
       receivingAgentId: "luna",
     });
@@ -370,5 +372,166 @@ describe("verifySignedByChain — multi-stamp rejection", () => {
       expect(result.reason.kind).toBe("unknown_agent");
       expect(result.skipped).toEqual([0]);
     }
+  });
+});
+
+// =============================================================================
+// Crypto-verify (B.1c)
+// =============================================================================
+
+/**
+ * Generate a fresh ed25519 NATS user keypair for tests. Returns both
+ * encodings cortex/myelin care about:
+ *   - `nkeyPub`: the U-prefixed base32 NATS NKey shape — fed into
+ *     `AgentSchema.nkey_pub` so `buildPrincipalRegistry` can derive
+ *     the matching base64 ed25519 pubkey via `@nats-io/nkeys`.
+ *   - `privateKeyBase64`: the 32-byte ed25519 seed encoded as base64 —
+ *     what `signEnvelope` expects for the signing key argument.
+ *
+ * The seed returned by `getSeed()` is the 58-char NKey-encoded seed
+ * (`SU...`). To get the raw 32-byte ed25519 seed `signEnvelope` wants,
+ * we extract via the `_seed` field on the concrete `KP` class. This is
+ * a test-only cast — production-side signing (B.3) will use a
+ * cortex-controlled path that owns its own private-key storage shape.
+ */
+function generateEd25519KeyPair(): {
+  nkeyPub: string;
+  privateKeyBase64: string;
+} {
+  const kp = createUser();
+  const nkeyPub = kp.getPublicKey();
+  // KP's concrete class exposes `getRawSeed()` returning the 32-byte
+  // ed25519 seed — that's the shape signEnvelope wants (which calls
+  // bytesFromBase64 then expects 32 bytes). `getSeed()` returns the
+  // wrapped 58-char NKey-encoded seed (`SU...`) which is the wrong
+  // shape for crypto consumption.
+  const rawSeed = (kp as unknown as { getRawSeed(): Uint8Array }).getRawSeed();
+  const privateKeyBase64 = Buffer.from(rawSeed).toString("base64");
+  return { nkeyPub, privateKeyBase64 };
+}
+
+describe("verifySignedByChain — cryptoVerify (B.1c)", () => {
+  test("cryptoVerify accepts an envelope signed by a trusted agent's NKey", async () => {
+    const { nkeyPub: echoNKey, privateKeyBase64: echoSeed } =
+      generateEd25519KeyPair();
+    const luna = agentFixture({ id: "luna", trust: ["echo"] });
+    const echo = agentFixture({
+      id: "echo",
+      displayName: "Echo",
+      nkey_pub: echoNKey,
+    });
+    const resolver = resolverWith(luna, echo);
+
+    // Build an envelope WITHOUT signed_by, then have echo sign it via
+    // myelin's signEnvelope. That produces a canonically-signed chain
+    // that verifyEnvelopeIdentity will accept.
+    // Cast through Parameters because cortex's Envelope.signed_by is
+    // the back-compat union `SignedBy | SignedBy[] | undefined` while
+    // myelin's MyelinEnvelope tightens to `SignedBy[] | undefined`.
+    // For this test the envelope has no signed_by yet, so the cast
+    // is structurally safe.
+    const base = envelopeWithChain(undefined) as Parameters<
+      typeof signEnvelope
+    >[0];
+    const signed = await signEnvelope(base, echoSeed, "did:mf:echo");
+
+    const result: ChainVerificationResult = await verifySignedByChain(
+      signed,
+      {
+        resolver,
+        receivingAgentId: "luna",
+        cryptoVerify: true,
+        operatorId: "test-operator",
+      },
+    );
+
+    expect(result.valid).toBe(true);
+    if (result.valid) {
+      expect(result.skipped).toEqual([]);
+    }
+  });
+
+  test("cryptoVerify rejects an envelope whose signature was tampered post-signing", async () => {
+    const { nkeyPub: echoNKey, privateKeyBase64: echoSeed } =
+      generateEd25519KeyPair();
+    const luna = agentFixture({ id: "luna", trust: ["echo"] });
+    const echo = agentFixture({
+      id: "echo",
+      displayName: "Echo",
+      nkey_pub: echoNKey,
+    });
+    const resolver = resolverWith(luna, echo);
+
+    const base = envelopeWithChain(undefined) as Parameters<
+      typeof signEnvelope
+    >[0];
+    const signed = await signEnvelope(base, echoSeed, "did:mf:echo");
+
+    // Tamper: flip the signature so the bytes no longer match the
+    // canonical envelope. Structurally the stamp still looks valid
+    // (the principal is echo, NKey is registered, trust list includes
+    // echo); only the bytes-check exposes the forgery.
+    const chain = Array.isArray(signed.signed_by)
+      ? signed.signed_by
+      : signed.signed_by
+        ? [signed.signed_by]
+        : [];
+    const firstStamp = chain[0];
+    if (firstStamp?.method !== "ed25519") {
+      throw new Error("test fixture: expected ed25519 stamp at index 0");
+    }
+    const tamperedSig = firstStamp.signature.startsWith("A")
+      ? "B" + firstStamp.signature.slice(1)
+      : "A" + firstStamp.signature.slice(1);
+    const tamperedEnvelope: Envelope = {
+      ...signed,
+      signed_by: [{ ...firstStamp, signature: tamperedSig }],
+    };
+
+    const result = await verifySignedByChain(tamperedEnvelope, {
+      resolver,
+      receivingAgentId: "luna",
+      cryptoVerify: true,
+      operatorId: "test-operator",
+    });
+
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.reason.kind).toBe("crypto_verify_failed");
+      if (result.reason.kind === "crypto_verify_failed") {
+        // myelin's reason string carries the specific failure class
+        // (signature mismatch vs. timestamp drift vs. principal lookup).
+        // We don't pin the exact text — myelin may rephrase — but we
+        // assert it isn't an empty / placeholder string.
+        expect(result.reason.myelinReason.length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  test("cryptoVerify throws when operatorId is missing", async () => {
+    // Agent must have an nkey_pub + be self-trusted so the structural
+    // check passes and the cryptoVerify-without-operatorId branch is
+    // reached. (A structural rejection would mask the operatorId guard.)
+    const { nkeyPub: lunaNKey } = generateEd25519KeyPair();
+    const luna = agentFixture({
+      id: "luna",
+      trust: ["luna"],
+      nkey_pub: lunaNKey,
+    });
+    const resolver = resolverWith(luna);
+    const env = envelopeWithChain([ed25519Stamp("did:mf:luna")]);
+
+    // bun's `expect(promise).rejects.toThrow` is the canonical pattern
+    // for promise-rejection assertions; `expect(async fn).toThrow`
+    // doesn't await the inner async call before checking, which silently
+    // passes the test even when the function does throw.
+    await expect(
+      verifySignedByChain(env, {
+        resolver,
+        receivingAgentId: "luna",
+        cryptoVerify: true,
+        // operatorId omitted — must throw.
+      }),
+    ).rejects.toThrow(/operatorId/);
   });
 });

--- a/src/bus/myelin/__tests__/envelope-validator.test.ts
+++ b/src/bus/myelin/__tests__/envelope-validator.test.ts
@@ -482,10 +482,13 @@ describe("envelope-validator — chain helpers (IAW Phase A.2)", () => {
     expect(getLastStampPrincipal(env!)).toBeUndefined();
   });
 
-  test("schema source commit points at the post-myelin#115 stack-aware pin", () => {
+  test("schema source commit points at the post-myelin#148 identity-strict pin", () => {
     // Lock the pin so future bumps surface in a code review.
+    // Updated at B.1c (cortex#114) — bump from b69c877 to 5a0e261 to
+    // pick up myelin#146 (./identity subpath export) + myelin#148
+    // (strict-null safety on identity submodule).
     expect(SCHEMA_SOURCE_COMMIT).toBe(
-      "b69c877e23a2696040561c2d832fdc75aa83f73e",
+      "5a0e2619a4af5c91c78f552b88fafd3ad40a227f",
     );
   });
 

--- a/src/bus/myelin/envelope-validator.ts
+++ b/src/bus/myelin/envelope-validator.ts
@@ -66,7 +66,7 @@ import {
 import schema from "./vendor/envelope.schema.json" with { type: "json" };
 
 /** Pin so future maintainers know which myelin commit the schema was lifted from. */
-export const SCHEMA_SOURCE_COMMIT = "b69c877e23a2696040561c2d832fdc75aa83f73e";
+export const SCHEMA_SOURCE_COMMIT = "5a0e2619a4af5c91c78f552b88fafd3ad40a227f";
 
 /**
  * Hand-typed Envelope shape matching the JSON Schema. We hand-write rather

--- a/src/bus/verify-signed-by-chain.ts
+++ b/src/bus/verify-signed-by-chain.ts
@@ -1,31 +1,62 @@
 /**
- * IAW Phase B.1a (cortex#114) — structural verification of an envelope's
- * `signed_by[]` chain against the local trust registry.
+ * IAW Phase B.1a/B.1c (cortex#114) — verification of an envelope's
+ * `signed_by[]` chain against the local trust registry, optionally
+ * including cryptographic verification of each stamp's ed25519 signature.
  *
- * "Structural" because this slice does NOT verify the ed25519 signature
- * bytes. It checks that every stamp's claimed principal:
- *   1. Resolves to a known agent in the local registry
- *   2. Has an `nkey_pub` declared (the agent intends to sign on the bus)
- *   3. Passes `TrustResolver.trustsByNKey(receivingAgentId, agent.nkey_pub)`
- *      — i.e. the receiving agent's `trust:` list includes this signer
+ * Two layered checks:
  *
- * Phase B.1c extends this helper to also verify the signature bytes via
- * ed25519 + JCS canonicalization. The structural rejection paths in this
- * slice catch the failure modes that don't require the crypto check:
- * unknown signer, signer-not-configured-for-bus, peer-not-in-trust-list.
- * Adding the bytes check in B.1c collapses the "signer claims X but
- * controls a different key" attack surface; until then a stamp can lie
- * about its principal and a sloppy operator who copy-pasted an unknown
- * agent's NKey into their own agent's `trust:` list would accept it.
- * That's why B.1c is part of Phase B — the structural check alone is
- * not safe to wire into a production inbound path.
+ *   1. **Structural trust** (B.1a, always on). For every ed25519 stamp,
+ *      checks that the claimed principal:
+ *        a. Resolves to a known agent in the local registry
+ *        b. Has an `nkey_pub` declared (the agent intends to sign on bus)
+ *        c. Passes `TrustResolver.trustsByNKey(receivingAgentId, nkey_pub)`
+ *           — i.e. the receiving agent's `trust:` list includes this signer
  *
- * Hub-stamp variants (`method === "hub-stamp"`) pass through this slice
- * structurally — they're a Phase D concern (federation hub trust). B.1a
- * neither rejects nor verifies them; they're surfaced as "unverified" in
- * the result so a strict caller can opt to reject all non-bare-ed25519
- * chains.
+ *   2. **Cryptographic verification** (B.1c, opt-in via `cryptoVerify: true`).
+ *      After structural pass, calls myelin's `verifyEnvelopeIdentity` which:
+ *        a. Canonicalizes the envelope per JCS (RFC 8785)
+ *        b. Verifies every stamp's ed25519 signature over the canonical bytes
+ *        c. Checks timestamp freshness (clock-skew window)
+ *      Failure surfaces as `crypto_verify_failed` with the underlying
+ *      myelin rejection reason carried through.
+ *
+ * **Why two layers, both gated by trust:** the structural check alone is
+ * not safe to wire into a production inbound path — a stamp can lie
+ * about its principal, and a sloppy operator copying an unknown agent's
+ * NKey into their own `trust:` list would accept the forgery. The crypto
+ * check alone is not enough either — a verified signer the receiver
+ * doesn't trust shouldn't be admitted. The two checks compose: structural
+ * fails closed on unknown/untrusted; crypto fails closed on forged bytes.
+ *
+ * Hub-stamp variants (`method === "hub-stamp"`) pass through this helper
+ * structurally — they're a Phase D concern (federation hub trust).
+ * They're surfaced as `skipped` indices so a strict caller can opt to
+ * reject all non-bare-ed25519 chains.
+ *
+ * **Import discipline.** Crypto helpers come from
+ * `@the-metafactory/myelin/identity` — the constrained subpath added by
+ * myelin#146 (closes myelin#145), tightened to strict-null safety by
+ * myelin#148 (closes myelin#147). Importing from the top-level
+ * `@the-metafactory/myelin` package pulls myelin's full source tree into
+ * tsc analysis and surfaces strict-null violations in modules cortex
+ * doesn't consume; the `./identity` subpath limits resolution to
+ * myelin's identity submodule + its transitive deps.
  */
+
+import {
+  verifyEnvelopeIdentity,
+  createInMemoryRegistry,
+  type PrincipalRegistry,
+} from "@the-metafactory/myelin/identity";
+import { Prefix } from "@nats-io/nkeys";
+// `Codec` is the internal NKey base32 + CRC + prefix-byte decoder.
+// Marked `@ignore` in @nats-io/nkeys but stable; the public `fromPublic`
+// helper stores only the ASCII bytes of the NKey string on its returned
+// `PublicKey.publicKey` field, not the raw 32-byte ed25519 pubkey. We
+// need the raw bytes to bridge to myelin's `Principal.public_key`
+// (base64-encoded raw ed25519), so this subpath import is the narrow
+// way in without re-implementing crockford base32 + CRC16 inline.
+import { Codec } from "@nats-io/nkeys/lib/codec";
 
 import {
   getSignedByChain,
@@ -33,6 +64,7 @@ import {
   type SignedBy,
 } from "./myelin/envelope-validator";
 import { TrustResolver } from "../common/agents/trust-resolver";
+import type { AgentRegistry } from "../common/agents/registry";
 
 // =============================================================================
 // Result types
@@ -68,7 +100,22 @@ export type ChainRejectionReason =
   | { kind: "malformed_principal"; principal: string }
   | { kind: "unknown_agent"; principal: string; agentId: string }
   | { kind: "principal_has_no_nkey_pub"; principal: string; agentId: string }
-  | { kind: "signer_not_trusted"; principal: string; agentId: string };
+  | { kind: "signer_not_trusted"; principal: string; agentId: string }
+  | {
+      /**
+       * Cryptographic verification failed — the bytes don't match the
+       * claimed signature, OR the timestamp is outside the freshness
+       * window, OR myelin's principal-registry lookup failed for the
+       * stamp's DID (when the structural check accepted the agent but
+       * the per-stamp Principal lookup inside myelin's verify did not).
+       *
+       * `myelinReason` carries myelin's own rejection text verbatim so
+       * audit envelopes (Phase C) can surface "ed25519 verify failed"
+       * vs. "timestamp outside freshness window" without recomputing.
+       */
+      kind: "crypto_verify_failed";
+      myelinReason: string;
+    };
 
 /**
  * Discriminated outcome of `verifySignedByChain`.
@@ -119,6 +166,33 @@ export interface VerifySignedByChainOptions {
    * tooling that legitimately accept unsigned envelopes pass `false`.
    */
   rejectEmpty?: boolean;
+  /**
+   * When true (B.1c), runs myelin's `verifyEnvelopeIdentity` after the
+   * structural pass to verify each stamp's ed25519 signature over the
+   * JCS-canonical envelope bytes. Default `false` for back-compat: the
+   * structural check alone is the B.1a contract and existing B.1b
+   * call sites keep their behaviour unchanged until they opt in.
+   *
+   * When `cryptoVerify: true`, the caller must also pass `operatorId`
+   * so the helper can build a myelin `PrincipalRegistry` from the
+   * `TrustResolver`'s underlying `AgentRegistry`. Each agent with an
+   * `nkey_pub` becomes a Principal whose `public_key` is the
+   * base64-encoded raw ed25519 pubkey derived from the NATS NKey.
+   */
+  cryptoVerify?: boolean;
+  /**
+   * Operator id (e.g. `andreas`). Required when `cryptoVerify: true` —
+   * threaded into each constructed Principal so myelin's verification
+   * has the operator field populated. Ignored when `cryptoVerify` is
+   * false / undefined.
+   */
+  operatorId?: string;
+  /**
+   * Optional clock-skew tolerance for myelin's timestamp-freshness
+   * check (passed through to `verifyEnvelopeIdentity`). Default per
+   * myelin: 5 minutes.
+   */
+  clockSkewMs?: number;
 }
 
 // =============================================================================
@@ -127,20 +201,26 @@ export interface VerifySignedByChainOptions {
 
 /**
  * Walk `envelope.signed_by` chain (normalised via `getSignedByChain`) and
- * structurally verify each ed25519 stamp against the local trust registry.
+ * verify each ed25519 stamp against the local trust registry.
  *
- * **Cryptographic signature verification is NOT performed at this slice.**
- * See file header for rationale. Phase B.1c extends this helper.
+ * Two layered checks: structural trust (always), then cryptographic
+ * verification (when `opts.cryptoVerify === true`). See file header.
  *
- * Iteration short-circuits on the first failure (terminal rejection). Chain
- * length is bounded by myelin's envelope schema (max_hop cap) so a linear
- * scan is cheap; no early-exit optimisation needed beyond the natural
- * `return` on rejection.
+ * Iteration short-circuits on the first structural failure. The crypto
+ * check is invoked once at the end, on the full chain, because myelin's
+ * `verifyEnvelopeIdentity` itself walks the chain and threads canonical-
+ * bytes commitment from one stamp to the next (myelin#31).
+ *
+ * `verifySignedByChain` is async because `verifyEnvelopeIdentity` is
+ * async (@noble/ed25519's `verifyAsync`). When `cryptoVerify: false`
+ * (default), the helper still returns a Promise to keep one signature
+ * for both modes — a sync/async split based on an option flag would
+ * force every call site to handle both branches.
  */
-export function verifySignedByChain(
+export async function verifySignedByChain(
   envelope: Envelope,
   opts: VerifySignedByChainOptions,
-): ChainVerificationResult {
+): Promise<ChainVerificationResult> {
   const chain = getSignedByChain(envelope);
   const rejectEmpty = opts.rejectEmpty ?? true;
 
@@ -173,6 +253,51 @@ export function verifySignedByChain(
       };
     }
     // stampResult.kind === "accept" — continue to next stamp
+  }
+
+  // Crypto layer (B.1c) — opt-in. Structural check has already passed
+  // for every ed25519 stamp at this point; myelin's verifier runs the
+  // canonical-bytes + signature + freshness check on top.
+  if (opts.cryptoVerify === true) {
+    if (opts.operatorId === undefined) {
+      throw new Error(
+        "verifySignedByChain: cryptoVerify requires opts.operatorId — " +
+          "myelin's Principal shape needs the operator field populated.",
+      );
+    }
+    const registry = buildPrincipalRegistry(
+      opts.resolver.getRegistry(),
+      opts.operatorId,
+    );
+    // Myelin's verifier expects `signed_by` normalised to array form;
+    // cortex's `Envelope` keeps the back-compat shim of single-stamp
+    // OR array. Normalise here before handing off.
+    const myelinEnvelope = {
+      ...envelope,
+      signed_by: chain,
+    };
+    const myelinResult = await verifyEnvelopeIdentity(
+      myelinEnvelope,
+      registry,
+      opts.clockSkewMs !== undefined
+        ? { clockSkewMs: opts.clockSkewMs }
+        : undefined,
+    );
+    if (myelinResult.status !== "verified") {
+      return {
+        valid: false,
+        // The structural walk accepted every stamp; the crypto failure
+        // is a chain-level rejection rather than a per-stamp index.
+        // Surface as rejectedAt: 0 (the first stamp) with the myelin
+        // reason carried verbatim.
+        rejectedAt: 0,
+        reason: {
+          kind: "crypto_verify_failed",
+          myelinReason: myelinResult.reason,
+        },
+        skipped: [...skipped],
+      };
+    }
   }
 
   return { valid: true, skipped };
@@ -261,4 +386,86 @@ function extractAgentIdFromDid(principal: string): string | undefined {
   // a colon in the tail signals an unsupported DID variant.
   if (tail.includes(":")) return undefined;
   return tail;
+}
+
+// =============================================================================
+// Principal-registry bridge (B.1c)
+// =============================================================================
+
+/**
+ * Bridge cortex's `AgentRegistry` to myelin's `PrincipalRegistry` for the
+ * crypto-verification step. Every agent with a declared `nkey_pub` becomes
+ * a Principal whose `public_key` is the base64-encoded raw ed25519 pubkey
+ * extracted from the NATS NKey via `@nats-io/nkeys`'s `fromPublic`.
+ *
+ * Why the decode is needed: cortex stores agent signing keys in NATS NKey
+ * format (`U` + 55 base32 chars) for parity with `StackConfigSchema.nkey_pub`.
+ * Myelin's verify pipeline consumes raw ed25519 pubkeys encoded as base64.
+ * The two encodings cover the same 32-byte ed25519 pubkey underneath —
+ * `fromPublic` gives us a `KeyPair` whose underlying concrete class
+ * stores the raw `Uint8Array` which we base64-encode for myelin.
+ *
+ * Agents without `nkey_pub` are skipped — the structural check will have
+ * already rejected stamps claiming those principals before crypto verify
+ * runs.
+ *
+ * Exported so callers (tests, future tooling) can construct a registry
+ * independently and pass it through; this also keeps the
+ * verifySignedByChain hot path from rebuilding a registry per call when
+ * the caller has a stable agent set (future caching is a separate
+ * concern — at B.1c, every cryptoVerify call rebuilds).
+ */
+export function buildPrincipalRegistry(
+  agentRegistry: AgentRegistry,
+  operatorId: string,
+): PrincipalRegistry {
+  const registry = createInMemoryRegistry();
+  const createdAt = new Date(0).toISOString();
+  for (const agent of agentRegistry.getAll()) {
+    if (agent.nkey_pub === undefined) continue;
+    const publicKey = nkeyToBase64Pubkey(agent.nkey_pub);
+    if (publicKey === undefined) {
+      // Malformed NKey at this point would already have failed the
+      // AgentSchema regex on config load — defensive only.
+      continue;
+    }
+    registry.add({
+      id: `did:mf:${agent.id}`,
+      display_name: agent.displayName,
+      operator: operatorId,
+      public_key: publicKey,
+      type: "agent",
+      created_at: createdAt,
+    });
+  }
+  return registry;
+}
+
+/**
+ * Convert a NATS NKey public-key (e.g. `UA...`, 56 chars) to the
+ * base64-encoded 32-byte raw ed25519 pubkey shape myelin expects on
+ * `Principal.public_key`. Returns `undefined` if `@nats-io/nkeys`
+ * rejects the input — defensive against drift between AgentSchema's
+ * regex and the on-the-wire decode.
+ *
+ * `Codec.decode(Prefix.User, asciiBytes)` from `@nats-io/nkeys`:
+ *   1. Base32-decodes the NKey ASCII (`UA...` 56 chars → 35 raw bytes)
+ *   2. Validates the leading prefix byte matches `Prefix.User` (0xa0)
+ *   3. Strips the prefix + trailing 2-byte CRC
+ *   4. Returns the 32-byte raw ed25519 pubkey
+ *
+ * The public `fromPublic` helper does the same decode internally for
+ * validation, but stores only the ASCII bytes of the NKey string on
+ * its returned `PublicKey.publicKey` field — not the raw 32 bytes we
+ * want. The `Codec` subpath import is the narrow way to the decoded
+ * payload without re-implementing crockford base32 + CRC16 inline.
+ */
+function nkeyToBase64Pubkey(nkey: string): string | undefined {
+  try {
+    const asciiBytes = new TextEncoder().encode(nkey);
+    const raw = Codec.decode(Prefix.User, asciiBytes);
+    return Buffer.from(raw).toString("base64");
+  } catch {
+    return undefined;
+  }
 }

--- a/src/substrates/bus-peer/__tests__/harness.test.ts
+++ b/src/substrates/bus-peer/__tests__/harness.test.ts
@@ -340,6 +340,85 @@ describe("BusPeerHarness — round-trip + verification gate", () => {
     expect(handlers.size).toBe(0);
   });
 
+  test("preserves arrival order across progress + terminal (Echo cortex#200 race regression)", async () => {
+    // Regression for Echo's B.1c finding #1+#2: with the async-IIFE
+    // pattern, a later-arriving terminal envelope's verify could
+    // resolve BEFORE an earlier progress envelope's verify, dropping
+    // the progress from the consumer's view (queue closed before
+    // pushInbound ran). Serialisation via the `inFlight` chain pins
+    // arrival order — the race is hard to deterministically trigger
+    // in a unit test, but this case proves that progress + terminal
+    // both reach the consumer in arrival order even when delivered
+    // back-to-back into the same chain.
+    const luna = agentFixture({ id: "luna", trust: ["echo"] });
+    const echo = agentFixture({
+      id: "echo",
+      displayName: "Echo",
+      nkey_pub: NKEY_ECHO,
+    });
+    const resolver = resolverWith(luna, echo);
+    const { runtime, deliverInbound } = fakeRuntime();
+
+    const harness = new BusPeerHarness({
+      runtime,
+      resolver,
+      receivingAgentId: "luna",
+      source: SOURCE,
+    });
+
+    const req = dispatchRequest();
+    const yielded: MyelinEnvelope[] = [];
+
+    const iterator = harness.dispatch(req)[Symbol.asyncIterator]();
+    const started = await iterator.next();
+    if (!started.done) yielded.push(started.value);
+
+    // Deliver progress + terminal back-to-back. The serialised
+    // verify chain must push both before close fires, and in arrival
+    // order.
+    deliverInbound({
+      id: "11111111-1111-4111-8111-111111111111",
+      source: "metafactory.echo.local",
+      type: "dispatch.task.progress",
+      timestamp: "2026-05-15T10:30:00.000Z",
+      correlation_id: req.requestId,
+      sovereignty: {
+        classification: "local",
+        data_residency: "NZ",
+        max_hop: 4,
+        frontier_ok: false,
+        model_class: "any",
+      },
+      payload: { step: 1 },
+      signed_by: {
+        method: "ed25519",
+        principal: "did:mf:echo",
+        signature: "A".repeat(88),
+        at: "2026-05-15T10:30:00.000Z",
+      },
+    });
+    deliverInbound(
+      inboundEnvelope({
+        correlationId: req.requestId,
+        type: "dispatch.task.completed",
+        signerPrincipal: "did:mf:echo",
+      }),
+    );
+
+    // Drain the iterator — both envelopes must yield in arrival order
+    // (progress first, terminal second), then the iterator closes.
+    while (true) {
+      const next = await iterator.next();
+      if (next.done) break;
+      yielded.push(next.value);
+    }
+
+    expect(yielded).toHaveLength(3);
+    expect(yielded[0]?.type).toBe("dispatch.task.started");
+    expect(yielded[1]?.type).toBe("dispatch.task.progress");
+    expect(yielded[2]?.type).toBe("dispatch.task.completed");
+  });
+
   test("ignores envelopes whose correlation_id does not match this dispatch", async () => {
     const luna = agentFixture({ id: "luna", trust: ["echo"] });
     const echo = agentFixture({

--- a/src/substrates/bus-peer/harness.ts
+++ b/src/substrates/bus-peer/harness.ts
@@ -239,6 +239,12 @@ export class BusPeerHarness implements SessionHarness {
       }
     }
 
+    // Serial-verification chain. Each inbound envelope's verify is
+    // appended via `.then(...)` so verifies run in arrival order and
+    // the terminal-envelope detection fires only after every prior
+    // envelope has pushed. Echo cortex#200 round 1, findings #1+#2.
+    let inFlight: Promise<void> = Promise.resolve();
+
     // Register the handler BEFORE the try block so envelopes arriving
     // between registration and the first yield are captured; the
     // unregister in `finally` (which wraps the publish + every yield
@@ -260,49 +266,70 @@ export class BusPeerHarness implements SessionHarness {
       if (envelope.id === requestEnvelope.id) return;
 
       // verifySignedByChain is async (B.1c) but onEnvelope's handler
-      // is sync. Run the verify in a separate microtask; when it
-      // resolves, decide whether to admit the envelope to the queue.
-      // The IIFE return is `void`-ed so an unhandled rejection here
-      // would surface via the process unhandled-rejection handler —
-      // verifySignedByChain returns structured results rather than
-      // throwing, so this is belt-and-braces for future-me.
-      void (async (): Promise<void> => {
-        const verification = await verifySignedByChain(envelope, {
-          resolver: this.resolver,
-          receivingAgentId: this.receivingAgentId,
-          // Peers always sign at least the bare ed25519 stamp; an
-          // unsigned envelope on the bus-peer path is a misconfig
-          // we want surfaced.
-          rejectEmpty: true,
-        });
+      // is sync. Chain each verify onto `inFlight` so:
+      //   1. Verifies run in arrival order (Echo cortex#200 finding #1
+      //      — bare IIFE would let later-arrived B's verify resolve
+      //      before A's, breaking the dispatch progress→terminal
+      //      arrival-order invariant the SessionHarness contract
+      //      implicitly relies on).
+      //   2. Terminal-envelope detection runs AFTER every prior
+      //      envelope has pushed (Echo finding #2 — without
+      //      serialisation, terminal-detection on B could close the
+      //      queue while A's verify was still pending, dropping A
+      //      from the consumer's view).
+      // The chain swallows rejections (try/catch + stderr log) so an
+      // unexpected throw from verifySignedByChain (e.g. the
+      // operatorId-missing guard once a follow-up flips cryptoVerify
+      // on without threading operatorId — Echo finding #3) doesn't
+      // surface as an unhandled rejection on the process.
+      inFlight = inFlight.then(async () => {
+        try {
+          const verification = await verifySignedByChain(envelope, {
+            resolver: this.resolver,
+            receivingAgentId: this.receivingAgentId,
+            // Peers always sign at least the bare ed25519 stamp; an
+            // unsigned envelope on the bus-peer path is a misconfig
+            // we want surfaced.
+            rejectEmpty: true,
+          });
 
-        if (!verification.valid) {
-          // Phase C wires audit envelopes; for now stderr is the
-          // visibility surface. Format the reason discriminator
-          // inline so an operator grepping stderr gets the structural
-          // class without consulting code.
-          const reason = verification.reason;
+          if (!verification.valid) {
+            // Phase C wires audit envelopes; for now stderr is the
+            // visibility surface. Format the reason discriminator
+            // inline so an operator grepping stderr gets the
+            // structural class without consulting code.
+            const reason = verification.reason;
+            process.stderr.write(
+              `[bus-peer:${this.receivingAgentId}] dropped inbound envelope ` +
+                `${envelope.id} (correlation_id=${correlationId}): ` +
+                `${reason.kind} at chain index ${verification.rejectedAt}\n`,
+            );
+            return;
+          }
+
+          pushInbound(envelope);
+
+          // Terminal-envelope detection — when the peer signals end of
+          // the dispatch, close the inbound queue so the generator
+          // can exit cleanly. Conventional terminal types per
+          // G-1111 §3.4. Runs INSIDE the same chain link as the
+          // preceding push, so the queue contains every prior
+          // envelope before close fires (Echo finding #2 fix).
+          if (
+            envelope.type === "dispatch.task.completed" ||
+            envelope.type === "dispatch.task.failed" ||
+            envelope.type === "dispatch.task.aborted"
+          ) {
+            signalClosed();
+          }
+        } catch (err) {
           process.stderr.write(
-            `[bus-peer:${this.receivingAgentId}] dropped inbound envelope ` +
-              `${envelope.id} (correlation_id=${correlationId}): ` +
-              `${reason.kind} at chain index ${verification.rejectedAt}\n`,
+            `[bus-peer:${this.receivingAgentId}] verification threw on ` +
+              `envelope ${envelope.id} (correlation_id=${correlationId}): ` +
+              `${err instanceof Error ? err.message : String(err)}\n`,
           );
-          return;
         }
-
-        pushInbound(envelope);
-
-        // Terminal-envelope detection — when the peer signals end of
-        // the dispatch, close the inbound queue so the generator can
-        // exit cleanly. Conventional terminal types per G-1111 §3.4.
-        if (
-          envelope.type === "dispatch.task.completed" ||
-          envelope.type === "dispatch.task.failed" ||
-          envelope.type === "dispatch.task.aborted"
-        ) {
-          signalClosed();
-        }
-      })();
+      });
     });
 
     // ----------------------------------------------------------------

--- a/src/substrates/bus-peer/harness.ts
+++ b/src/substrates/bus-peer/harness.ts
@@ -63,10 +63,7 @@ import { randomUUID } from "crypto";
 import type { Envelope } from "../../bus/myelin/envelope-validator";
 import type { MyelinRuntime } from "../../bus/myelin/runtime";
 import type { TrustResolver } from "../../common/agents/trust-resolver";
-import {
-  verifySignedByChain,
-  type ChainVerificationResult,
-} from "../../bus/verify-signed-by-chain";
+import { verifySignedByChain } from "../../bus/verify-signed-by-chain";
 import type {
   Capability,
   DispatchRequest,
@@ -262,44 +259,50 @@ export class BusPeerHarness implements SessionHarness {
       // this harness just published.
       if (envelope.id === requestEnvelope.id) return;
 
-      const verification: ChainVerificationResult = verifySignedByChain(
-        envelope,
-        {
+      // verifySignedByChain is async (B.1c) but onEnvelope's handler
+      // is sync. Run the verify in a separate microtask; when it
+      // resolves, decide whether to admit the envelope to the queue.
+      // The IIFE return is `void`-ed so an unhandled rejection here
+      // would surface via the process unhandled-rejection handler —
+      // verifySignedByChain returns structured results rather than
+      // throwing, so this is belt-and-braces for future-me.
+      void (async (): Promise<void> => {
+        const verification = await verifySignedByChain(envelope, {
           resolver: this.resolver,
           receivingAgentId: this.receivingAgentId,
           // Peers always sign at least the bare ed25519 stamp; an
           // unsigned envelope on the bus-peer path is a misconfig
           // we want surfaced.
           rejectEmpty: true,
-        },
-      );
+        });
 
-      if (!verification.valid) {
-        // Phase C wires audit envelopes; for now stderr is the
-        // visibility surface. Format the reason discriminator inline
-        // so an operator grepping stderr gets the structural class
-        // without consulting code.
-        const reason = verification.reason;
-        process.stderr.write(
-          `[bus-peer:${this.receivingAgentId}] dropped inbound envelope ` +
-            `${envelope.id} (correlation_id=${correlationId}): ` +
-            `${reason.kind} at chain index ${verification.rejectedAt}\n`,
-        );
-        return;
-      }
+        if (!verification.valid) {
+          // Phase C wires audit envelopes; for now stderr is the
+          // visibility surface. Format the reason discriminator
+          // inline so an operator grepping stderr gets the structural
+          // class without consulting code.
+          const reason = verification.reason;
+          process.stderr.write(
+            `[bus-peer:${this.receivingAgentId}] dropped inbound envelope ` +
+              `${envelope.id} (correlation_id=${correlationId}): ` +
+              `${reason.kind} at chain index ${verification.rejectedAt}\n`,
+          );
+          return;
+        }
 
-      pushInbound(envelope);
+        pushInbound(envelope);
 
-      // Terminal-envelope detection — when the peer signals end of
-      // the dispatch, close the inbound queue so the generator can
-      // exit cleanly. Conventional terminal types per G-1111 §3.4.
-      if (
-        envelope.type === "dispatch.task.completed" ||
-        envelope.type === "dispatch.task.failed" ||
-        envelope.type === "dispatch.task.aborted"
-      ) {
-        signalClosed();
-      }
+        // Terminal-envelope detection — when the peer signals end of
+        // the dispatch, close the inbound queue so the generator can
+        // exit cleanly. Conventional terminal types per G-1111 §3.4.
+        if (
+          envelope.type === "dispatch.task.completed" ||
+          envelope.type === "dispatch.task.failed" ||
+          envelope.type === "dispatch.task.aborted"
+        ) {
+          signalClosed();
+        }
+      })();
     });
 
     // ----------------------------------------------------------------


### PR DESCRIPTION
## Summary

Phase B.1c — cryptographic verification of \`signed_by[]\` chains, on top of B.1a's structural primitives. Closes the \"signer claims X but controls a different key\" attack surface that B.1a alone couldn't catch.

\`refs cortex#114\`

## What lands

- **\`verifySignedByChain\` gains \`cryptoVerify\` mode.** Opt-in via \`opts.cryptoVerify: true\` + \`opts.operatorId\`. Default off — existing B.1b callers (\`BusPeerHarness\`) behave identically.
- **\`crypto_verify_failed\` rejection reason** carrying \`myelinReason\` verbatim for Phase C audit envelopes.
- **\`buildPrincipalRegistry(agentRegistry, operatorId)\` bridge** — walks agents, decodes each \`nkey_pub\` from NATS NKey base32 to raw 32-byte ed25519 pubkey, base64-encodes for myelin's \`Principal.public_key\` shape.
- **Myelin pin bump** \`b69c877\` → \`5a0e261\` to pick up myelin#146 (\`./identity\` subpath export) + myelin#148 (strict-null safety on identity submodule). Cortex's \`SCHEMA_SOURCE_COMMIT\` + snapshot-lock test updated to match.
- **\`BusPeerHarness.dispatch\`** verify call now wrapped in async IIFE inside the sync \`onEnvelope\` handler.
- **3 new tests:** happy-path (signed via myelin's \`signEnvelope\` → accepted), tampered-signature → \`crypto_verify_failed\`, missing-operatorId → async-rejects.

## What this slice deliberately doesn't do

- **\`BusPeerHarness\` doesn't opt INTO cryptoVerify yet** — left at structural-only default. The flip needs to thread \`operatorId\` from cortex config into the harness; small follow-up PR.
- **Phase B.3 outbound signing** — needs the same JCS canonicalization helper from myelin; separate slice.
- **B.4 round-trip integration tests** — wait for B.3.
- **cortex#196 isUuid shield + cortex#197 BusPeerHarness coverage gaps** — Echo's deferred B.1b findings, tracked separately.

## Verification

- \`bunx tsc --noEmit\` — clean
- \`bun run lint:errors\` — clean (0 errors)
- \`bun test src/substrates/ src/bus/ src/common/{agents,types}/\` — 661 pass / 0 fail / 1290 expect()
- The 3 new cryptoVerify cases pin: happy-path signed envelope verifies, tampered signature surfaces \`crypto_verify_failed\` with non-empty \`myelinReason\`, missing-operatorId throws with \`/operatorId/\` matcher.

## Looking for in review

- Decision-discriminator naming (\`crypto_verify_failed\` vs. a more specific shape that pre-splits ed25519-bytes / timestamp-drift / principal-lookup classes — currently we delegate to \`myelinReason\`).
- The \`Codec\` subpath import from \`@nats-io/nkeys/lib/codec\` (marked \`@ignore\` upstream, but the public \`fromPublic\` stores ASCII bytes rather than the raw 32-byte payload we need — see inline comment).
- The async IIFE pattern inside \`onEnvelope\` for the BusPeerHarness verify call.
- Acceptable to defer the BusPeerHarness opt-in flip to a follow-up vs. landing it in this PR?