### PR TITLE
feat(bus): IAW B.2a — BusDispatchListener for inbound peer dispatches (refs cortex#114)

### DIFF
--- a/src/bus/__tests__/bus-dispatch-listener.test.ts
+++ b/src/bus/__tests__/bus-dispatch-listener.test.ts
@@ -1,0 +1,366 @@
+/**
+ * IAW Phase B.2a (cortex#114) — BusDispatchListener tests.
+ *
+ * Coverage axes:
+ *   1. Subscribe + unsubscribe lifecycle.
+ *   2. Peer-dispatch filter — only `dispatch.task.dispatched` envelopes
+ *      from non-self sources trigger the verify path; other types and
+ *      our own publishes are ignored.
+ *   3. Verify gate — invalid chain (untrusted signer, malformed
+ *      principal, etc.) drops with a stderr log; no visibility event.
+ *   4. Valid chain emits `system.bus.peer_dispatch_received` carrying
+ *      the peer source + envelope id + correlation id.
+ *   5. Idempotent start/stop.
+ */
+
+import { describe, test, expect } from "bun:test";
+import { AgentRegistry } from "../../common/agents/registry";
+import { TrustResolver } from "../../common/agents/trust-resolver";
+import type {
+  EnvelopeHandler,
+  MyelinRuntime,
+} from "../myelin/runtime";
+import type { Envelope, SignedBy } from "../myelin/envelope-validator";
+import type { Agent } from "../../common/types/cortex-config";
+import { BusDispatchListener } from "../bus-dispatch-listener";
+
+// =============================================================================
+// Fixtures (mirrors verify-signed-by-chain.test.ts patterns)
+// =============================================================================
+
+const NKEY_ECHO = "U" + "B".repeat(55);
+
+function discordPresence() {
+  return {
+    enabled: true,
+    token: "discord-bot-token",
+    guildId: "1487000000000000000",
+    agentChannelId: "1487000000000000001",
+    logChannelId: "1487000000000000002",
+    contextDepth: 10,
+    enableAgentLog: false,
+    roles: [],
+    defaultRole: "allow-all",
+    dm: {
+      operatorRole: {
+        features: ["chat", "async", "team"] as const,
+        disallowedTools: [],
+        bashGuard: true,
+      },
+      defaultRole: "denied" as const,
+      userRoles: [],
+    },
+  };
+}
+
+function agentFixture(overrides: Partial<Agent> = {}): Agent {
+  return {
+    id: "luna",
+    displayName: "Luna",
+    persona: "./personas/luna.md",
+    roles: [],
+    trust: [],
+    presence: { discord: discordPresence() },
+    ...overrides,
+  } as Agent;
+}
+
+function resolverWith(...agents: Agent[]): TrustResolver {
+  return new TrustResolver(AgentRegistry.fromAgents(agents));
+}
+
+function ed25519Stamp(principal: string): SignedBy {
+  return {
+    method: "ed25519",
+    principal,
+    signature: "A".repeat(88),
+    at: "2026-05-15T11:00:00.000Z",
+  };
+}
+
+function peerDispatchEnvelope(opts: {
+  source?: string;
+  type?: string;
+  correlationId?: string;
+  signerPrincipal?: string;
+  id?: string;
+}): Envelope {
+  const env: Envelope = {
+    id: opts.id ?? "00000000-0000-4000-8000-000000000111",
+    source: opts.source ?? "metafactory.echo.local",
+    type: opts.type ?? "dispatch.task.dispatched",
+    timestamp: "2026-05-15T11:00:00.000Z",
+    sovereignty: {
+      classification: "local",
+      data_residency: "NZ",
+      max_hop: 4,
+      frontier_ok: false,
+      model_class: "any",
+    },
+    payload: {},
+  };
+  if (opts.correlationId !== undefined) env.correlation_id = opts.correlationId;
+  if (opts.signerPrincipal !== undefined) {
+    env.signed_by = ed25519Stamp(opts.signerPrincipal);
+  }
+  return env;
+}
+
+function fakeRuntime() {
+  const handlers = new Set<EnvelopeHandler>();
+  const published: Envelope[] = [];
+  const runtime: MyelinRuntime = {
+    enabled: true,
+    onEnvelope(handler) {
+      handlers.add(handler);
+      return { unregister: () => handlers.delete(handler) };
+    },
+    // eslint-disable-next-line @typescript-eslint/require-await
+    async publish(envelope) {
+      published.push(envelope);
+    },
+    // eslint-disable-next-line @typescript-eslint/require-await
+    async stop() {
+      handlers.clear();
+    },
+  };
+  function deliverInbound(envelope: Envelope, subject = "test.subject") {
+    for (const handler of handlers) handler(envelope, subject);
+  }
+  // Yield to the event loop so the listener's serial-promise chain
+  // can process any queued inbounds before the test asserts on
+  // `published`.
+  async function drain(): Promise<void> {
+    for (let i = 0; i < 5; i++) {
+      await new Promise<void>((resolve) => setImmediate(resolve));
+    }
+  }
+  return { runtime, published, deliverInbound, drain, handlers };
+}
+
+const SOURCE = { org: "metafactory", agent: "cortex", instance: "local" };
+
+// =============================================================================
+// Cases
+// =============================================================================
+
+describe("BusDispatchListener — lifecycle", () => {
+  test("start subscribes to runtime; stop unregisters", () => {
+    const luna = agentFixture({ id: "luna" });
+    const resolver = resolverWith(luna);
+    const { runtime, handlers } = fakeRuntime();
+
+    const listener = new BusDispatchListener({
+      runtime,
+      resolver,
+      receivingAgentId: "luna",
+      operatorId: "test-operator",
+      source: SOURCE,
+    });
+
+    expect(handlers.size).toBe(0);
+    listener.start();
+    expect(handlers.size).toBe(1);
+    listener.stop();
+    expect(handlers.size).toBe(0);
+  });
+
+  test("start is idempotent — second call doesn't register twice", () => {
+    const luna = agentFixture({ id: "luna" });
+    const resolver = resolverWith(luna);
+    const { runtime, handlers } = fakeRuntime();
+
+    const listener = new BusDispatchListener({
+      runtime,
+      resolver,
+      receivingAgentId: "luna",
+      operatorId: "test-operator",
+      source: SOURCE,
+    });
+
+    listener.start();
+    listener.start();
+    expect(handlers.size).toBe(1);
+    listener.stop();
+  });
+
+  test("stop is idempotent — second call doesn't throw", () => {
+    const luna = agentFixture({ id: "luna" });
+    const resolver = resolverWith(luna);
+    const { runtime } = fakeRuntime();
+
+    const listener = new BusDispatchListener({
+      runtime,
+      resolver,
+      receivingAgentId: "luna",
+      operatorId: "test-operator",
+      source: SOURCE,
+    });
+
+    listener.start();
+    listener.stop();
+    expect(() => listener.stop()).not.toThrow();
+  });
+});
+
+describe("BusDispatchListener — peer-dispatch filter", () => {
+  test("ignores envelopes that are not dispatch.task.dispatched", async () => {
+    const luna = agentFixture({ id: "luna", trust: ["echo"] });
+    const echo = agentFixture({
+      id: "echo",
+      displayName: "Echo",
+      nkey_pub: NKEY_ECHO,
+    });
+    const resolver = resolverWith(luna, echo);
+    const { runtime, published, deliverInbound, drain } = fakeRuntime();
+
+    const listener = new BusDispatchListener({
+      runtime,
+      resolver,
+      receivingAgentId: "luna",
+      operatorId: "test-operator",
+      source: SOURCE,
+    });
+    listener.start();
+
+    deliverInbound(
+      peerDispatchEnvelope({
+        type: "dispatch.task.completed",
+        signerPrincipal: "did:mf:echo",
+      }),
+    );
+    await drain();
+
+    // No visibility event published — wrong type was filtered.
+    expect(published).toHaveLength(0);
+
+    listener.stop();
+  });
+
+  test("ignores envelopes whose source matches our own", async () => {
+    const luna = agentFixture({ id: "luna", trust: ["echo"] });
+    const echo = agentFixture({
+      id: "echo",
+      displayName: "Echo",
+      nkey_pub: NKEY_ECHO,
+    });
+    const resolver = resolverWith(luna, echo);
+    const { runtime, published, deliverInbound, drain } = fakeRuntime();
+
+    const listener = new BusDispatchListener({
+      runtime,
+      resolver,
+      receivingAgentId: "luna",
+      operatorId: "test-operator",
+      source: SOURCE,
+    });
+    listener.start();
+
+    // Same source as us — should be ignored (it's our own publish
+    // looping back via the local fan-out).
+    deliverInbound(
+      peerDispatchEnvelope({
+        source: `${SOURCE.org}.${SOURCE.agent}.${SOURCE.instance}`,
+        signerPrincipal: "did:mf:luna",
+      }),
+    );
+    await drain();
+
+    expect(published).toHaveLength(0);
+    listener.stop();
+  });
+});
+
+describe("BusDispatchListener — verification gate", () => {
+  test("emits system.bus.peer_dispatch_received on valid peer dispatch", async () => {
+    const luna = agentFixture({ id: "luna", trust: ["echo"] });
+    const echo = agentFixture({
+      id: "echo",
+      displayName: "Echo",
+      nkey_pub: NKEY_ECHO,
+    });
+    const resolver = resolverWith(luna, echo);
+    const { runtime, published, deliverInbound, drain } = fakeRuntime();
+
+    const listener = new BusDispatchListener({
+      runtime,
+      resolver,
+      receivingAgentId: "luna",
+      operatorId: "test-operator",
+      source: SOURCE,
+    });
+    listener.start();
+
+    deliverInbound(
+      peerDispatchEnvelope({
+        signerPrincipal: "did:mf:echo",
+        correlationId: "00000000-0000-4000-8000-000000000200",
+        id: "00000000-0000-4000-8000-000000000abc",
+      }),
+    );
+    await drain();
+
+    // Exactly one visibility event published.
+    expect(published).toHaveLength(1);
+    const event = published[0];
+    expect(event?.type).toBe("system.bus.peer_dispatch_received");
+    expect(event?.payload.peer_source).toBe("metafactory.echo.local");
+    expect(event?.payload.dispatch_envelope_id).toBe(
+      "00000000-0000-4000-8000-000000000abc",
+    );
+    expect(event?.payload.correlation_id).toBe(
+      "00000000-0000-4000-8000-000000000200",
+    );
+
+    listener.stop();
+  });
+
+  test("drops an inbound envelope whose signer is not trusted (stderr + no visibility event)", async () => {
+    // Holly's NKey is in the registry but not in luna's trust list.
+    const luna = agentFixture({ id: "luna", trust: ["echo"] });
+    const echo = agentFixture({
+      id: "echo",
+      displayName: "Echo",
+      nkey_pub: NKEY_ECHO,
+    });
+    const holly = agentFixture({
+      id: "holly",
+      displayName: "Holly",
+      nkey_pub: "U" + "C".repeat(55),
+    });
+    const resolver = resolverWith(luna, echo, holly);
+    const { runtime, published, deliverInbound, drain } = fakeRuntime();
+
+    const stderrLines: string[] = [];
+    const originalWrite = process.stderr.write.bind(process.stderr);
+    process.stderr.write = (chunk: string | Uint8Array): boolean => {
+      stderrLines.push(typeof chunk === "string" ? chunk : chunk.toString());
+      return true;
+    };
+
+    try {
+      const listener = new BusDispatchListener({
+        runtime,
+        resolver,
+        receivingAgentId: "luna",
+        operatorId: "test-operator",
+        source: SOURCE,
+      });
+      listener.start();
+
+      deliverInbound(
+        peerDispatchEnvelope({ signerPrincipal: "did:mf:holly" }),
+      );
+      await drain();
+
+      expect(published).toHaveLength(0);
+      listener.stop();
+    } finally {
+      process.stderr.write = originalWrite;
+    }
+
+    const stderrOutput = stderrLines.join("");
+    expect(stderrOutput).toContain("bus-dispatch-listener:luna");
+    expect(stderrOutput).toContain("signer_not_trusted");
+  });
+});

--- a/src/bus/__tests__/bus-dispatch-listener.test.ts
+++ b/src/bus/__tests__/bus-dispatch-listener.test.ts
@@ -145,7 +145,7 @@ const SOURCE = { org: "metafactory", agent: "cortex", instance: "local" };
 // =============================================================================
 
 describe("BusDispatchListener — lifecycle", () => {
-  test("start subscribes to runtime; stop unregisters", () => {
+  test("start subscribes to runtime; stop unregisters", async () => {
     const luna = agentFixture({ id: "luna" });
     const resolver = resolverWith(luna);
     const { runtime, handlers } = fakeRuntime();
@@ -161,11 +161,11 @@ describe("BusDispatchListener — lifecycle", () => {
     expect(handlers.size).toBe(0);
     listener.start();
     expect(handlers.size).toBe(1);
-    listener.stop();
+    await listener.stop();
     expect(handlers.size).toBe(0);
   });
 
-  test("start is idempotent — second call doesn't register twice", () => {
+  test("start is idempotent — second call doesn't register twice", async () => {
     const luna = agentFixture({ id: "luna" });
     const resolver = resolverWith(luna);
     const { runtime, handlers } = fakeRuntime();
@@ -181,10 +181,10 @@ describe("BusDispatchListener — lifecycle", () => {
     listener.start();
     listener.start();
     expect(handlers.size).toBe(1);
-    listener.stop();
+    await listener.stop();
   });
 
-  test("stop is idempotent — second call doesn't throw", () => {
+  test("stop is idempotent — second call doesn't throw", async () => {
     const luna = agentFixture({ id: "luna" });
     const resolver = resolverWith(luna);
     const { runtime } = fakeRuntime();
@@ -198,8 +198,8 @@ describe("BusDispatchListener — lifecycle", () => {
     });
 
     listener.start();
-    listener.stop();
-    expect(() => listener.stop()).not.toThrow();
+    await listener.stop();
+    await expect(listener.stop()).resolves.toBeUndefined();
   });
 });
 
@@ -234,7 +234,7 @@ describe("BusDispatchListener — peer-dispatch filter", () => {
     // No visibility event published — wrong type was filtered.
     expect(published).toHaveLength(0);
 
-    listener.stop();
+    await listener.stop();
   });
 
   test("ignores envelopes whose source matches our own", async () => {
@@ -267,7 +267,7 @@ describe("BusDispatchListener — peer-dispatch filter", () => {
     await drain();
 
     expect(published).toHaveLength(0);
-    listener.stop();
+    await listener.stop();
   });
 });
 
@@ -304,6 +304,7 @@ describe("BusDispatchListener — verification gate", () => {
     expect(published).toHaveLength(1);
     const event = published[0];
     expect(event?.type).toBe("system.bus.peer_dispatch_received");
+    expect(event?.payload.receiving_agent_id).toBe("luna");
     expect(event?.payload.peer_source).toBe("metafactory.echo.local");
     expect(event?.payload.dispatch_envelope_id).toBe(
       "00000000-0000-4000-8000-000000000abc",
@@ -312,7 +313,7 @@ describe("BusDispatchListener — verification gate", () => {
       "00000000-0000-4000-8000-000000000200",
     );
 
-    listener.stop();
+    await listener.stop();
   });
 
   test("drops an inbound envelope whose signer is not trusted (stderr + no visibility event)", async () => {
@@ -354,7 +355,7 @@ describe("BusDispatchListener — verification gate", () => {
       await drain();
 
       expect(published).toHaveLength(0);
-      listener.stop();
+      await listener.stop();
     } finally {
       process.stderr.write = originalWrite;
     }

--- a/src/bus/bus-dispatch-listener.ts
+++ b/src/bus/bus-dispatch-listener.ts
@@ -1,0 +1,211 @@
+/**
+ * IAW Phase B.2a (cortex#114) — `BusDispatchListener`.
+ *
+ * Listens on the local `MyelinRuntime` for inbound `dispatch.task.*`
+ * envelopes from peer bots (i.e. envelopes that did NOT originate from
+ * this cortex's own publish path). Verifies each envelope's
+ * `signed_by[]` chain via `verifySignedByChain` (cryptoVerify-gated by
+ * whether the receiving agent has an `nkey_pub` declared), then surfaces
+ * the receipt as a `system.bus.peer_dispatch_received` visibility event.
+ *
+ * **What this slice delivers (B.2a — inbound listener half of B.2):**
+ *   - Subscribes via `runtime.onEnvelope` and filters for
+ *     `dispatch.task.dispatched` envelopes whose source is a peer (not
+ *     our own publish).
+ *   - Verifies the chain (structural always; cryptographic when the
+ *     receiving agent has an `nkey_pub`).
+ *   - Emits a structured `system.bus.peer_dispatch_received` envelope
+ *     on every valid arrival — operators see "peer X dispatched a task
+ *     to us at <time>" on the dashboard / audit trail.
+ *   - Drops invalid envelopes with a stderr log carrying the structured
+ *     `ChainRejectionReason` discriminator.
+ *
+ * **What this slice deliberately doesn't do (deferred to B.2a+ / B.2b):**
+ *   - **No DispatchHandler routing.** `DispatchHandler.handleMessage`'s
+ *     `InboundMessage` shape is platform-specific (Discord/Mattermost
+ *     fields like `channelId`, `authorId`). Mapping a bus envelope onto
+ *     that shape is a real adapter — designed alongside Phase C's
+ *     PolicyEngine (cortex#107) which natively takes a `Principal`
+ *     rather than a platform-user-id. Until that lands, this listener
+ *     is a visibility-only surface: cortex *knows* peers are dispatching
+ *     to it, but doesn't *act* on those dispatches yet.
+ *   - **No outbound peer dispatch.** That's B.2b (tracked at cortex#202)
+ *     — the LLM-driven publish side.
+ *   - **No Discord trustedBotIds retirement.** The legacy bot-to-bot
+ *     Discord @-mention path stays operational until B.2a + B.2b both
+ *     land in production and operators flip the deprecation flag.
+ *
+ * **Cross-references:**
+ *   - cortex#114 — IAW Phase B umbrella
+ *   - cortex#202 — B.2b outbound side
+ *   - cortex#194 (B.1a) — `verifySignedByChain` primitive
+ *   - cortex#200 (B.1c) — cryptographic verification
+ *   - cortex#195 (B.1b) — `BusPeerHarness` (the publish-and-collect peer
+ *     this listener pairs with on outbound dispatches)
+ */
+
+import type { Envelope } from "./myelin/envelope-validator";
+import type { MyelinRuntime } from "./myelin/runtime";
+import type { TrustResolver } from "../common/agents/trust-resolver";
+import { verifySignedByChain } from "./verify-signed-by-chain";
+import {
+  createSystemBusPeerDispatchReceivedEvent,
+  type SystemEventSource,
+} from "./system-events";
+
+// =============================================================================
+// Constructor options
+// =============================================================================
+
+export interface BusDispatchListenerOpts {
+  /** Runtime to subscribe through. */
+  runtime: MyelinRuntime;
+  /** Trust resolver for chain verification. */
+  resolver: TrustResolver;
+  /**
+   * Agent id of the receiving side — whose `trust:` list governs which
+   * peer signers we admit. Single-agent stacks pass their sole agent's
+   * id; multi-agent stacks pass the agent that handles bus-peer routing
+   * (typically a designated `peer-router` agent in cortex.yaml).
+   */
+  receivingAgentId: string;
+  /**
+   * Operator id (e.g. `andreas`). Threaded into the myelin
+   * `PrincipalRegistry` constructed by `verifySignedByChain`'s crypto
+   * path. Required even when `cryptoVerify: false` so the listener can
+   * flip the flag on later without re-threading.
+   */
+  operatorId: string;
+  /**
+   * Source attribution for emitted visibility events. Same shape the
+   * runner already builds for `dispatch.task.*` and `system.*` event
+   * constructors.
+   */
+  source: SystemEventSource;
+  /**
+   * When true, runs the cryptographic verification step in addition to
+   * the structural trust check. Default `false` — structural-only at
+   * this slice. Operators flip this on once every trusted peer has an
+   * `nkey_pub` declared on the agent (B.1c primitives are in place;
+   * the missing piece is config-side opt-in).
+   */
+  cryptoVerify?: boolean;
+}
+
+// =============================================================================
+// Listener
+// =============================================================================
+
+export class BusDispatchListener {
+  private readonly runtime: MyelinRuntime;
+  private readonly resolver: TrustResolver;
+  private readonly receivingAgentId: string;
+  private readonly operatorId: string;
+  private readonly source: SystemEventSource;
+  private readonly cryptoVerify: boolean;
+
+  private registration: { unregister: () => void } | undefined;
+  private serial: Promise<void> = Promise.resolve();
+
+  constructor(opts: BusDispatchListenerOpts) {
+    this.runtime = opts.runtime;
+    this.resolver = opts.resolver;
+    this.receivingAgentId = opts.receivingAgentId;
+    this.operatorId = opts.operatorId;
+    this.source = opts.source;
+    this.cryptoVerify = opts.cryptoVerify ?? false;
+  }
+
+  /**
+   * Register the runtime subscription. Idempotent — calling `start()`
+   * twice is a no-op (returns the existing registration). The handler
+   * runs every inbound verify inside a serial promise chain so a slow
+   * verify on envelope A doesn't let envelope B's processing race
+   * ahead — same arrival-order discipline as `BusPeerHarness` (cortex
+   * cortex#200 round 1).
+   */
+  start(): void {
+    if (this.registration !== undefined) return;
+    this.registration = this.runtime.onEnvelope((envelope) => {
+      if (!this.isPeerDispatch(envelope)) return;
+      this.serial = this.serial.then(async () => {
+        try {
+          await this.handleInbound(envelope);
+        } catch (err) {
+          process.stderr.write(
+            `[bus-dispatch-listener:${this.receivingAgentId}] verification ` +
+              `threw on envelope ${envelope.id}: ` +
+              `${err instanceof Error ? err.message : String(err)}\n`,
+          );
+        }
+      });
+    });
+  }
+
+  /**
+   * Detach the subscription. Idempotent. In-flight serial verifies
+   * complete but their results are no-op'd because the listener no
+   * longer cares (the visibility event constructor is a pure builder;
+   * nothing downstream observes after stop).
+   */
+  stop(): void {
+    if (this.registration === undefined) return;
+    this.registration.unregister();
+    this.registration = undefined;
+  }
+
+  /**
+   * Filter: only `dispatch.task.dispatched` envelopes are interesting,
+   * and we deliberately skip our own published envelopes (the runtime's
+   * onEnvelope fan-out fires for outbound publishes too).
+   *
+   * The "own publish" check uses envelope source attribution rather
+   * than envelope id — at this slice we don't track our own outbound
+   * ids, and `source` is the dotted `{operator}.{agent}.{instance}`
+   * shape every cortex publish stamps. A peer's source will name a
+   * different operator/agent, so the check is conservative-but-correct.
+   */
+  private isPeerDispatch(envelope: Envelope): boolean {
+    if (envelope.type !== "dispatch.task.dispatched") return false;
+    const ourSource = `${this.source.org}.${this.source.agent}.${this.source.instance}`;
+    return envelope.source !== ourSource;
+  }
+
+  private async handleInbound(envelope: Envelope): Promise<void> {
+    const verification = await verifySignedByChain(envelope, {
+      resolver: this.resolver,
+      receivingAgentId: this.receivingAgentId,
+      // Peer dispatches MUST be signed — an unsigned dispatch envelope
+      // arriving on the bus is a misconfig we want surfaced.
+      rejectEmpty: true,
+      cryptoVerify: this.cryptoVerify,
+      operatorId: this.operatorId,
+    });
+
+    if (!verification.valid) {
+      process.stderr.write(
+        `[bus-dispatch-listener:${this.receivingAgentId}] dropped peer ` +
+          `dispatch envelope ${envelope.id} (correlation_id=` +
+          `${envelope.correlation_id ?? "<none>"}): ${verification.reason.kind} ` +
+          `at chain index ${verification.rejectedAt}\n`,
+      );
+      return;
+    }
+
+    // Emit visibility — Phase C audit envelopes will consume this on
+    // the wire. Today operators see it via the dashboard renderer +
+    // any other surface subscribed to `system.bus.*`.
+    const visibilityEvent = createSystemBusPeerDispatchReceivedEvent({
+      source: this.source,
+      peerSource: envelope.source,
+      dispatchEnvelopeId: envelope.id,
+      ...(envelope.correlation_id !== undefined && {
+        correlationId: envelope.correlation_id,
+      }),
+      receivedAt: new Date(),
+    });
+    // Fire-and-forget per MyelinRuntime.publish contract — the runtime
+    // logs and swallows publish errors internally.
+    void this.runtime.publish(visibilityEvent);
+  }
+}

--- a/src/bus/bus-dispatch-listener.ts
+++ b/src/bus/bus-dispatch-listener.ts
@@ -105,7 +105,14 @@ export class BusDispatchListener {
   private readonly cryptoVerify: boolean;
 
   private registration: { unregister: () => void } | undefined;
-  private serial: Promise<void> = Promise.resolve();
+  /**
+   * Set of in-flight verify promises. Each inbound runs in its own
+   * microtask chain (no serial queue — see Echo cortex#203 round 1).
+   * Tracked here so `stop()` can await drain and so the listener can
+   * be cleanly torn down in tests / shutdown without late stderr or
+   * late publish side effects landing on a closed channel.
+   */
+  private readonly inFlight = new Set<Promise<void>>();
 
   constructor(opts: BusDispatchListenerOpts) {
     this.runtime = opts.runtime;
@@ -118,40 +125,38 @@ export class BusDispatchListener {
 
   /**
    * Register the runtime subscription. Idempotent — calling `start()`
-   * twice is a no-op (returns the existing registration). The handler
-   * runs every inbound verify inside a serial promise chain so a slow
-   * verify on envelope A doesn't let envelope B's processing race
-   * ahead — same arrival-order discipline as `BusPeerHarness` (cortex
-   * cortex#200 round 1).
+   * twice is a no-op (returns the existing registration). Each inbound
+   * envelope's verify runs in its own microtask chain, in parallel
+   * with other inbounds — there is no per-listener arrival-order
+   * invariant (no consumer iterator, no inter-envelope dependency),
+   * so the `BusPeerHarness` serial-chain pattern is deliberately NOT
+   * reused here (Echo cortex#203 round 1 finding). In-flight promises
+   * are tracked on `inFlight` so `stop()` can await drain.
    */
   start(): void {
     if (this.registration !== undefined) return;
     this.registration = this.runtime.onEnvelope((envelope) => {
       if (!this.isPeerDispatch(envelope)) return;
-      this.serial = this.serial.then(async () => {
-        try {
-          await this.handleInbound(envelope);
-        } catch (err) {
-          process.stderr.write(
-            `[bus-dispatch-listener:${this.receivingAgentId}] verification ` +
-              `threw on envelope ${envelope.id}: ` +
-              `${err instanceof Error ? err.message : String(err)}\n`,
-          );
-        }
-      });
+      this.trackInFlight(this.runOneVerify(envelope));
     });
   }
 
   /**
-   * Detach the subscription. Idempotent. In-flight serial verifies
-   * complete but their results are no-op'd because the listener no
-   * longer cares (the visibility event constructor is a pure builder;
-   * nothing downstream observes after stop).
+   * Detach the subscription and drain any in-flight verifies.
+   * Idempotent. Async (Echo cortex#203 round 1 finding) so callers
+   * relying on `stop()` as a clean cutoff — test teardown that
+   * mocks `runtime.publish` and then restores it, shutdown sequences
+   * — can `await listener.stop()` and trust that no late stderr or
+   * publish side effects land afterwards.
    */
-  stop(): void {
+  async stop(): Promise<void> {
     if (this.registration === undefined) return;
     this.registration.unregister();
     this.registration = undefined;
+    // Drain in-flight verifies — Promise.allSettled because individual
+    // verifies already catch their own errors; we just need the
+    // microtask chain to flush before returning.
+    await Promise.allSettled(Array.from(this.inFlight));
   }
 
   /**
@@ -162,13 +167,56 @@ export class BusDispatchListener {
    * The "own publish" check uses envelope source attribution rather
    * than envelope id — at this slice we don't track our own outbound
    * ids, and `source` is the dotted `{operator}.{agent}.{instance}`
-   * shape every cortex publish stamps. A peer's source will name a
-   * different operator/agent, so the check is conservative-but-correct.
+   * shape every cortex publish stamps.
+   *
+   * **Security note** (Echo cortex#203 round 1): the source filter is
+   * `trust-list-anchored, not source-anchored`. `envelope.source` is
+   * NOT part of the canonical bytes verified by
+   * `verifyEnvelopeIdentity` — a peer could stamp a valid signed
+   * envelope with our triple as the source, and this filter would
+   * drop it (denial-of-service for legitimate peer dispatches).
+   * Conversely, an attacker who knows our triple can suppress our
+   * visibility into their dispatches. The verify chain is the
+   * authoritative gate — `signed_by[]` is bound to canonical bytes
+   * and trusted by the receiving agent's `trust:` list. The source
+   * filter is a cheap loopback suppressor, not a security boundary.
+   * Once cortex#202 (B.2b) lands and peers start publishing
+   * `dispatch.task.dispatched` envelopes routinely, consider pairing
+   * this with the BusPeerHarness pattern of also tracking our own
+   * outbound `envelope.id`s for stricter loopback suppression.
    */
   private isPeerDispatch(envelope: Envelope): boolean {
     if (envelope.type !== "dispatch.task.dispatched") return false;
     const ourSource = `${this.source.org}.${this.source.agent}.${this.source.instance}`;
     return envelope.source !== ourSource;
+  }
+
+  /**
+   * Run a single verify in its own microtask. Catches its own errors
+   * so the caller doesn't need to attach a `.catch`. Returns the
+   * promise so the caller can track it for drain.
+   */
+  private async runOneVerify(envelope: Envelope): Promise<void> {
+    try {
+      await this.handleInbound(envelope);
+    } catch (err) {
+      process.stderr.write(
+        `[bus-dispatch-listener:${this.receivingAgentId}] verification ` +
+          `threw on envelope ${envelope.id}: ` +
+          `${err instanceof Error ? err.message : String(err)}\n`,
+      );
+    }
+  }
+
+  /**
+   * Track a verify promise on `inFlight` and remove it on settle.
+   * Sibling helper that owns the bookkeeping without inline arrow
+   * gymnastics — the alternative (let / two-step bind inside the
+   * subscription callback) trips TS's definite-assignment analysis.
+   */
+  private trackInFlight(verifyPromise: Promise<void>): void {
+    this.inFlight.add(verifyPromise);
+    void verifyPromise.finally(() => this.inFlight.delete(verifyPromise));
   }
 
   private async handleInbound(envelope: Envelope): Promise<void> {
@@ -197,6 +245,7 @@ export class BusDispatchListener {
     // any other surface subscribed to `system.bus.*`.
     const visibilityEvent = createSystemBusPeerDispatchReceivedEvent({
       source: this.source,
+      receivingAgentId: this.receivingAgentId,
       peerSource: envelope.source,
       dispatchEnvelopeId: envelope.id,
       ...(envelope.correlation_id !== undefined && {

--- a/src/bus/bus-dispatch-listener.ts
+++ b/src/bus/bus-dispatch-listener.ts
@@ -253,8 +253,13 @@ export class BusDispatchListener {
       }),
       receivedAt: new Date(),
     });
-    // Fire-and-forget per MyelinRuntime.publish contract — the runtime
-    // logs and swallows publish errors internally.
-    void this.runtime.publish(visibilityEvent);
+    // Await per MyelinRuntime.publish contract — the runtime logs and
+    // swallows publish errors internally, so this returns quickly, but
+    // awaiting means `handleInbound` (and the tracked `inFlight` entry)
+    // only settles after publish settles. That makes `stop()`'s
+    // `allSettled(inFlight)` drain a true cutoff for both verify and
+    // publish side effects (Echo cortex#203 round 2 — closes the
+    // partial-fix nuance on the original async-stop fix).
+    await this.runtime.publish(visibilityEvent);
   }
 }

--- a/src/bus/system-events.ts
+++ b/src/bus/system-events.ts
@@ -457,3 +457,68 @@ export function createSystemAccessFilteredEvent(
     },
   });
 }
+
+// ---------------------------------------------------------------------------
+// system.bus.peer_dispatch_received — IAW Phase B.2a visibility event
+// ---------------------------------------------------------------------------
+
+export interface SystemBusPeerDispatchReceivedOpts {
+  /** Standard source attribution — who emitted this visibility event. */
+  source: SystemEventSource;
+  /**
+   * Source field from the peer's dispatch envelope (the `{operator}.
+   * {agent}.{instance}` triple that identifies which peer just
+   * dispatched a task to us). Different from `opts.source.org` —
+   * that's US, this is THEM.
+   */
+  peerSource: string;
+  /**
+   * Envelope id of the peer's dispatch envelope. Lets operators join
+   * the visibility event to the underlying dispatch on the dashboard
+   * and in audit pipelines.
+   */
+  dispatchEnvelopeId: string;
+  /**
+   * Correlation id from the peer's dispatch envelope, if present.
+   * Threads the visibility event to any reply chain that follows.
+   */
+  correlationId?: string;
+  /** Wall-clock time the listener observed the inbound. */
+  receivedAt: Date;
+  /**
+   * IAW Phase A.3 — classification on the emitted visibility event.
+   * Defaults to `"local"` because peer-dispatch-received is bookkeeping
+   * about our own stack; the underlying peer dispatch may itself be
+   * federated, but the visibility annotation stays local-only.
+   */
+  classification?: Classification;
+}
+
+/**
+ * IAW Phase B.2a (cortex#114) — visibility event emitted whenever
+ * `BusDispatchListener` receives a valid peer dispatch envelope on the
+ * bus. Surfaces "peer X dispatched a task to us at <time>" without
+ * routing through the dispatch path itself (that's a follow-up; see
+ * `BusDispatchListener` file header for the deferred-scope rationale).
+ *
+ * Sovereignty defaults to local; the visibility event is bookkeeping
+ * about our own stack regardless of the underlying peer dispatch's
+ * classification.
+ */
+export function createSystemBusPeerDispatchReceivedEvent(
+  opts: SystemBusPeerDispatchReceivedOpts,
+): Envelope {
+  return buildBaseEnvelope({
+    type: "system.bus.peer_dispatch_received",
+    source: buildSource(opts.source),
+    sovereignty: defaultSystemSovereignty(opts.source, opts.classification),
+    payload: {
+      peer_source: opts.peerSource,
+      dispatch_envelope_id: opts.dispatchEnvelopeId,
+      received_at: opts.receivedAt.toISOString(),
+      ...(opts.correlationId !== undefined && {
+        correlation_id: opts.correlationId,
+      }),
+    },
+  });
+}

--- a/src/bus/system-events.ts
+++ b/src/bus/system-events.ts
@@ -466,6 +466,16 @@ export interface SystemBusPeerDispatchReceivedOpts {
   /** Standard source attribution — who emitted this visibility event. */
   source: SystemEventSource;
   /**
+   * Which local agent's `BusDispatchListener` produced this event.
+   * Multi-agent stacks may run one listener per agent (the JSDoc on
+   * `BusDispatchListener.receivingAgentId` explicitly contemplates
+   * `peer-router` agents and per-agent listeners). Without this
+   * field, a dashboard subscribed to `system.bus.peer_dispatch_received`
+   * can't answer "who in our stack received this" (Echo cortex#203
+   * round 1).
+   */
+  receivingAgentId: string;
+  /**
    * Source field from the peer's dispatch envelope (the `{operator}.
    * {agent}.{instance}` triple that identifies which peer just
    * dispatched a task to us). Different from `opts.source.org` —
@@ -513,6 +523,7 @@ export function createSystemBusPeerDispatchReceivedEvent(
     source: buildSource(opts.source),
     sovereignty: defaultSystemSovereignty(opts.source, opts.classification),
     payload: {
+      receiving_agent_id: opts.receivingAgentId,
       peer_source: opts.peerSource,
       dispatch_envelope_id: opts.dispatchEnvelopeId,
       received_at: opts.receivedAt.toISOString(),


### PR DESCRIPTION
## Summary

Phase B.2a — the **inbound** half of B.2. Cortex now hears peer dispatch envelopes on the bus, verifies them, and surfaces visibility.

The **outbound** half (B.2b — \`ClaudeCodeHarness\`/agent-team publishes peer dispatches via \`MyelinRuntime\`) is tracked at cortex#202. Decision was to ship the two halves separately to keep PRs reviewable.

\`refs cortex#114\`
\`refs cortex#202\` (B.2b outbound side)

## What lands

| Surface | What |
|---|---|
| \`BusDispatchListener\` class | Subscribes via \`runtime.onEnvelope\`; filters for \`dispatch.task.dispatched\` envelopes from non-self sources; verifies the chain via \`verifySignedByChain\` (structural always; cryptographic when \`cryptoVerify: true\` + receiving agent's \`nkey_pub\` set). On valid arrivals publishes a visibility envelope. On invalid, logs to stderr + drops. Serial promise chain matches BusPeerHarness arrival-order discipline (post-cortex#200 round 1). |
| \`system.bus.peer_dispatch_received\` event | New constructor in \`system-events.ts\`. Payload carries \`peer_source\`, \`dispatch_envelope_id\`, \`received_at\`, optional \`correlation_id\`. Sovereignty defaults to local (it's bookkeeping about our own stack regardless of the underlying peer dispatch's classification). |
| 7 unit tests | Lifecycle (idempotent start/stop); peer-dispatch filter (wrong type / own-source rejected); verification gate (valid → event, untrusted signer → stderr + no event). |

## Deferred to follow-ups

- **DispatchHandler routing** — \`InboundMessage\` is Discord/Mattermost-shaped; mapping a bus envelope is an adapter that pairs with Phase C's PolicyEngine (cortex#107) which natively takes a \`Principal\`. Visibility-only at this slice.
- **\`cortex.ts\` wiring** — the class is shippable; entrypoint wiring (receiving agent + operator id + cryptoVerify config flag) is a small follow-up PR that threads cortex.yaml plumbing without touching the listener.
- **Discord \`trustedBotIds\` retirement** — legacy bot-to-bot Discord path stays operational until B.2a + B.2b both land and operators flip the deprecation flag.

## Verification

- \`bunx tsc --noEmit\` — clean
- \`bun run lint:errors\` — clean (0 errors)
- \`bun test src/bus/__tests__/bus-dispatch-listener.test.ts\` — 7 pass / 0 fail / 15 expect()
- \`bun test src/substrates/ src/bus/ src/common/{agents,types}/\` — 669 pass / 0 fail / 1309 expect()

## Phase B continuation

- **B.2b** (cortex#202) — outbound peer dispatch (CC tool surface OR agent-team participant refactor).
- **B.3** — outbound envelope signing with stack NKey (independent of B.2).
- **B.4** — round-trip + adversarial integration tests across the full bus path (needs B.2a + B.2b + B.3).