### PR TITLE
fix(adapter): plumb surfaceFallbackChannelId from cortex.yaml to Discord adapter (closes #207)

### DIFF
--- a/src/common/config/__tests__/loader.test.ts
+++ b/src/common/config/__tests__/loader.test.ts
@@ -514,17 +514,37 @@ describe("MIG-7.2e — cortex-shape detection + transform", () => {
     expect(config.discord[0]!.surfaceFallbackChannelId).toBeUndefined();
   });
 
-  test("surfaceFallbackChannelId coerces numeric snowflake to string", () => {
-    // Discord snowflakes are large integers that yaml may parse as numbers
-    // when unquoted. The z.coerce.string() schema coerces, matching the
-    // surrounding fields' pattern (agentChannelId, logChannelId).
+  test("surfaceFallbackChannelId coerces a safely-representable numeric to a string", () => {
+    // Discord snowflakes are 64-bit IDs that exceed Number.MAX_SAFE_INTEGER —
+    // testing with a real snowflake as a JS Number literal silently rounds
+    // at source-parse time and proves nothing about round-trip safety. Use
+    // a small numeric to demonstrate ONLY the z.coerce.string() behavior:
+    // operator passes a number, schema returns a string of that number.
+    // The separate "preserves quoted snowflake string verbatim" test below
+    // exercises the realistic path (operator quotes the snowflake in yaml).
     const cfg = minimalCortex();
     const firstAgent = (cfg.agents as Record<string, unknown>[])[0]!;
     const discordPresence = (firstAgent.presence as Record<string, unknown>).discord as Record<string, unknown>;
-    discordPresence.surfaceFallbackChannelId = 1487029848164536361 as unknown as string;
+    discordPresence.surfaceFallbackChannelId = 12345 as unknown as string;
     const path = writeCortexConfig(testDir, cfg);
     const { config } = loadConfigWithAgents(path);
     expect(typeof config.discord[0]!.surfaceFallbackChannelId).toBe("string");
+    expect(config.discord[0]!.surfaceFallbackChannelId).toBe("12345");
+  });
+
+  test("surfaceFallbackChannelId preserves a quoted snowflake string verbatim", () => {
+    // The realistic operator path: yaml configs surrounding `agentChannelId`,
+    // `logChannelId`, etc. all quote Discord snowflakes as strings. Verify
+    // a quoted snowflake survives the round-trip without any digit-loss
+    // from JS Number precision.
+    const snowflake = "1487029848164536361"; // Echo's actual agent-channel snowflake
+    const cfg = minimalCortex();
+    const firstAgent = (cfg.agents as Record<string, unknown>[])[0]!;
+    const discordPresence = (firstAgent.presence as Record<string, unknown>).discord as Record<string, unknown>;
+    discordPresence.surfaceFallbackChannelId = snowflake;
+    const path = writeCortexConfig(testDir, cfg);
+    const { config } = loadConfigWithAgents(path);
+    expect(config.discord[0]!.surfaceFallbackChannelId).toBe(snowflake);
   });
 
   // ---------------------------------------------------------------------------

--- a/src/common/config/__tests__/loader.test.ts
+++ b/src/common/config/__tests__/loader.test.ts
@@ -525,7 +525,9 @@ describe("MIG-7.2e — cortex-shape detection + transform", () => {
     const cfg = minimalCortex();
     const firstAgent = (cfg.agents as Record<string, unknown>[])[0]!;
     const discordPresence = (firstAgent.presence as Record<string, unknown>).discord as Record<string, unknown>;
-    discordPresence.surfaceFallbackChannelId = 12345 as unknown as string;
+    // discordPresence is typed `Record<string, unknown>`, so a numeric
+    // assignment doesn't need a cast — `unknown` accepts any value.
+    discordPresence.surfaceFallbackChannelId = 12345;
     const path = writeCortexConfig(testDir, cfg);
     const { config } = loadConfigWithAgents(path);
     expect(typeof config.discord[0]!.surfaceFallbackChannelId).toBe("string");

--- a/src/common/config/__tests__/loader.test.ts
+++ b/src/common/config/__tests__/loader.test.ts
@@ -491,6 +491,42 @@ describe("MIG-7.2e — cortex-shape detection + transform", () => {
     expect(config.discord[0]!.surfaceSubjects).toEqual([]);
   });
 
+  // cortex#207 — companion field to surfaceSubjects: where the adapter
+  // posts inbound bus envelopes. Without this, surfaceSubjects matches
+  // but renderEnvelope drops the envelope with a one-shot warning.
+  test("threads agents[].presence.discord.surfaceFallbackChannelId through to DiscordInstance.surfaceFallbackChannelId", () => {
+    const cfg = minimalCortex();
+    const firstAgent = (cfg.agents as Record<string, unknown>[])[0]!;
+    const discordPresence = (firstAgent.presence as Record<string, unknown>).discord as Record<string, unknown>;
+    discordPresence.surfaceFallbackChannelId = "1234567890";
+    const path = writeCortexConfig(testDir, cfg);
+    const { config } = loadConfigWithAgents(path);
+    expect(config.discord).toHaveLength(1);
+    expect(config.discord[0]!.surfaceFallbackChannelId).toBe("1234567890");
+  });
+
+  test("surfaceFallbackChannelId is undefined when omitted from presence.discord", () => {
+    const path = writeCortexConfig(testDir, minimalCortex());
+    const { config } = loadConfigWithAgents(path);
+    // Optional field — omission round-trips as undefined, not empty string.
+    // The adapter's runtime guard discriminates on `=== undefined` to fire
+    // the drop-with-warning path (preserves v0 behaviour for legacy configs).
+    expect(config.discord[0]!.surfaceFallbackChannelId).toBeUndefined();
+  });
+
+  test("surfaceFallbackChannelId coerces numeric snowflake to string", () => {
+    // Discord snowflakes are large integers that yaml may parse as numbers
+    // when unquoted. The z.coerce.string() schema coerces, matching the
+    // surrounding fields' pattern (agentChannelId, logChannelId).
+    const cfg = minimalCortex();
+    const firstAgent = (cfg.agents as Record<string, unknown>[])[0]!;
+    const discordPresence = (firstAgent.presence as Record<string, unknown>).discord as Record<string, unknown>;
+    discordPresence.surfaceFallbackChannelId = 1487029848164536361 as unknown as string;
+    const path = writeCortexConfig(testDir, cfg);
+    const { config } = loadConfigWithAgents(path);
+    expect(typeof config.discord[0]!.surfaceFallbackChannelId).toBe("string");
+  });
+
   // ---------------------------------------------------------------------------
   // IAW Phase A.5 (refs cortex#113) — cortex-shape `stack:` block plumbed
   // through to `LoadedConfig.stack`. The boot path (`startCortex`) calls

--- a/src/common/types/config.ts
+++ b/src/common/types/config.ts
@@ -171,6 +171,15 @@ export const DiscordInstanceSchema = z.object({
    * canonical operator-facing description, IoAW examples, and contract.
    */
   surfaceSubjects: z.array(z.string().min(1)).default([]),
+  /**
+   * MIG-3b / cortex#207: Discord channel id for the bus → chat render
+   * fallback. Mirror of the cortex-shape field — `flattenDiscordPresences`
+   * threads it through verbatim.
+   *
+   * @see DiscordPresenceSchema.surfaceFallbackChannelId in `cortex-config.ts`
+   * for the canonical operator-facing description.
+   */
+  surfaceFallbackChannelId: z.coerce.string().optional(),
 });
 
 export type DiscordInstance = z.infer<typeof DiscordInstanceSchema>;

--- a/src/common/types/cortex-config.ts
+++ b/src/common/types/cortex-config.ts
@@ -216,6 +216,26 @@ export const DiscordPresenceSchema = z.object({
    * subscription list is enough to unblock the bus→Discord render path.
    */
   surfaceSubjects: z.array(z.string().min(1)).default([]),
+  /**
+   * MIG-3b / cortex#207: Discord channel id where `renderEnvelope` posts
+   * inbound bus envelopes that don't carry their own channel routing.
+   * Threaded into `DiscordAdapterInfra.surfaceFallbackChannelId` at
+   * construction.
+   *
+   * Unset (default) → the adapter receives matching envelopes (per
+   * `surfaceSubjects`) but drops each one with a one-shot warning
+   * (`discord-{instanceId}: has no surfaceFallbackChannelId configured
+   * — dropping envelope ...`). This is the v0 behaviour preserved for
+   * configs that subscribe-without-render (e.g. observability-only
+   * deployments that log envelope receipts but don't post to chat).
+   *
+   * Operators typically set this to `agentChannelId` so review-requests
+   * and similar bus events land in the agent's primary channel.
+   * Future per-event-type routing (MIG-7.2d Renderer model) will
+   * override on a per-envelope basis; this remains the fallback when
+   * no per-event rule matches.
+   */
+  surfaceFallbackChannelId: z.coerce.string().optional(),
 });
 
 export type DiscordPresence = z.infer<typeof DiscordPresenceSchema>;

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -450,6 +450,9 @@ export async function startCortex(
       ...(instance.operatorRoleId !== undefined && { operatorRoleId: instance.operatorRoleId }),
       trustedBotIds: instance.trustedBotIds,
       surfaceSubjects: instance.surfaceSubjects,
+      ...(instance.surfaceFallbackChannelId !== undefined && {
+        surfaceFallbackChannelId: instance.surfaceFallbackChannelId,
+      }),
     };
     // MIG-7.2e: prefer the cortex-shape `inlineAgents` lookup when present —
     // per-instance identity (real id, persona, roles, trust) flows from
@@ -493,6 +496,13 @@ export async function startCortex(
           // `["local.metafactory.tasks.code-review.>"]` wires pilot's
           // IoAW review-requests into the Discord render path.
           surfaceSubjects: presence.surfaceSubjects,
+          // cortex#207: fallback channel for envelopes that don't carry
+          // their own routing. Spread-conditionally because the field
+          // is optional and `renderEnvelope` discriminates on its
+          // presence (undefined → drop-with-warning, configured → post).
+          ...(presence.surfaceFallbackChannelId !== undefined && {
+            surfaceFallbackChannelId: presence.surfaceFallbackChannelId,
+          }),
         },
       );
       // Register the adapter's surface-router face. Empty `surfaceSubjects`


### PR DESCRIPTION
## Summary

Closes #207. Last-mile companion to cortex#206 — exposes \`surfaceFallbackChannelId\` in \`DiscordPresenceSchema\` so operators can wire bus → Discord rendering to a concrete channel.

Verified live: with cortex#206 merged and envelopes reaching adapter receipt (pipeline confirmed by envelope id \`0776cc2c-b35e-414d-a358-96327adf9c2c\` arriving at MyelinRuntime), every render attempt dropped with \`has no surfaceFallbackChannelId configured — dropping envelope\`. This PR is the schema field that closes that gap.

## Changes

Same shape as cortex#206:

1. \`DiscordPresenceSchema\` — adds \`surfaceFallbackChannelId: z.coerce.string().optional()\` (cortex-shape side).
2. \`DiscordInstanceSchema\` — mirror on legacy BotConfig side so \`flattenDiscordPresences\` preserves the field.
3. \`cortex.ts\` — threads it spread-conditionally into \`DiscordAdapterInfra\` (matches existing optional-field pattern).
4. 3 new loader tests: round-trip, default-undefined, snowflake coercion.

## Operator recipe (after merge)

\`\`\`yaml
agents:
  - id: echo
    presence:
      discord:
        ...
        surfaceSubjects:
          - "local.metafactory.tasks.code-review.>"
        surfaceFallbackChannelId: "1487029848164536361"
\`\`\`

## Test plan

- [x] \`bun test\` — 2773 pass, 1 skip, 0 fail (was 2770; +3 new)
- [x] \`bunx tsc --noEmit\` — clean
- [ ] After merge: update cortex.yaml + reload daemon + re-publish the same envelope shape → adapter posts to configured channel instead of dropping.

## Out of scope

- v2 per-event-type channel routing (MIG-7.2d). \`surfaceFallbackChannelId\` is the v1 fallback; v2 overrides per-envelope.
- Mattermost parity — same asymmetry as cortex#206 noted; same follow-up.

## Related

- Closes #207
- Companion: cortex#206 (upstream subscribe path)
- Verified failure mode (live): envelope id \`0776cc2c-b35e-414d-a358-96327adf9c2c\` dropped at the render boundary because of this missing field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)