### PR TITLE
feat(bus): IAW B.3 — outbound envelope signing with stack NKey (refs cortex#114)

### DIFF
--- a/src/bus/myelin/__tests__/runtime.test.ts
+++ b/src/bus/myelin/__tests__/runtime.test.ts
@@ -425,6 +425,157 @@ describe("MyelinRuntime", () => {
       await runtime.stop();
     });
 
+    test("IAW B.3 — publish signs outbound when signer option is set", async () => {
+      // Round-trip: start the runtime with a signer; publish an
+      // unsigned envelope; assert the published JSON carries a fresh
+      // `signed_by[]` array with one ed25519 stamp whose principal +
+      // signature shape match the signer config. The actual bytes
+      // verify is exercised indirectly via the `signEnvelope` →
+      // `verifyEnvelopeIdentity` round-trip already covered in
+      // `verify-signed-by-chain.test.ts`'s cryptoVerify happy-path.
+      const { createUser } = await import("@nats-io/nkeys");
+      const kp = createUser();
+      const rawSeedBytes = (
+        kp as unknown as { getRawSeed(): Uint8Array }
+      ).getRawSeed();
+
+      const fake = makeFakeNatsConnection();
+      const runtime = await startMyelinRuntime(
+        makeConfig({
+          url: "nats://localhost:4222",
+          name: "grove-bot",
+          subjects: ["local.{org}.system.>"],
+        }),
+        {
+          connectImpl: async () => fake.nc,
+          signer: {
+            rawSeedBytes,
+            principal: "did:mf:test-stack",
+          },
+        },
+      );
+      expect(runtime.enabled).toBe(true);
+
+      const env = makeEnvelope();
+      await runtime.publish(env);
+
+      // Exactly one publish forwarded.
+      expect(fake.publish).toHaveBeenCalledTimes(1);
+      const payload = fake.publishes[0]?.payload as string;
+      const published = JSON.parse(payload) as {
+        signed_by?: { method: string; principal: string; signature: string; at: string }[];
+        id: string;
+      };
+
+      // Original envelope was unsigned; published envelope carries a
+      // fresh chain with one ed25519 stamp matching the signer config.
+      expect(published.id).toBe(env.id);
+      expect(Array.isArray(published.signed_by)).toBe(true);
+      expect(published.signed_by).toHaveLength(1);
+      const stamp = published.signed_by?.[0];
+      expect(stamp?.method).toBe("ed25519");
+      expect(stamp?.principal).toBe("did:mf:test-stack");
+      // Signature shape: base64 of 64 raw bytes ≈ 88 chars.
+      expect(stamp?.signature.length).toBeGreaterThanOrEqual(86);
+
+      await runtime.stop();
+    });
+
+    test("IAW B.3 — publish appends to existing signed_by chain (multi-hop)", async () => {
+      // Forwarding scenario: an envelope arrives already signed by
+      // peer X; we forward it via this runtime; the publish must
+      // APPEND our stamp rather than replace the prior chain. This is
+      // the chain-of-stamps property that makes cross-stack
+      // verification possible.
+      const { createUser } = await import("@nats-io/nkeys");
+      const priorSigner = createUser();
+      const ourSigner = createUser();
+      const ourRawSeed = (
+        ourSigner as unknown as { getRawSeed(): Uint8Array }
+      ).getRawSeed();
+
+      // Sign a "prior" stamp directly via myelin to seed the chain.
+      const { signEnvelope } = await import("@the-metafactory/myelin/identity");
+      const priorRawSeed = (
+        priorSigner as unknown as { getRawSeed(): Uint8Array }
+      ).getRawSeed();
+      const priorSeedBase64 = Buffer.from(priorRawSeed).toString("base64");
+      const incoming = await signEnvelope(
+        makeEnvelope(),
+        priorSeedBase64,
+        "did:mf:peer-x",
+      );
+
+      const fake = makeFakeNatsConnection();
+      const runtime = await startMyelinRuntime(
+        makeConfig({
+          url: "nats://localhost:4222",
+          name: "grove-bot",
+          subjects: ["local.{org}.system.>"],
+        }),
+        {
+          connectImpl: async () => fake.nc,
+          signer: {
+            rawSeedBytes: ourRawSeed,
+            principal: "did:mf:our-stack",
+          },
+        },
+      );
+      expect(runtime.enabled).toBe(true);
+
+      await runtime.publish(incoming);
+
+      const payload = fake.publishes[0]?.payload as string;
+      const published = JSON.parse(payload) as {
+        signed_by: { principal: string }[];
+      };
+
+      // Two stamps in arrival order: peer-x first, then us.
+      expect(published.signed_by).toHaveLength(2);
+      expect(published.signed_by[0]?.principal).toBe("did:mf:peer-x");
+      expect(published.signed_by[1]?.principal).toBe("did:mf:our-stack");
+
+      await runtime.stop();
+    });
+
+    test("IAW B.3 — sign failure falls back to publishing unsigned (logs, doesn't throw)", async () => {
+      // Defensive: a malformed signer (bad seed shape) shouldn't
+      // crash the publish path. The runtime logs and publishes the
+      // original envelope unchanged so observability stays intact.
+      const fake = makeFakeNatsConnection();
+      const runtime = await startMyelinRuntime(
+        makeConfig({
+          url: "nats://localhost:4222",
+          name: "grove-bot",
+          subjects: ["local.{org}.system.>"],
+        }),
+        {
+          connectImpl: async () => fake.nc,
+          signer: {
+            // Wrong length — myelin's signEnvelope expects 32 bytes.
+            rawSeedBytes: new Uint8Array(16),
+            principal: "did:mf:test-stack",
+          },
+        },
+      );
+
+      const env = makeEnvelope();
+      // Must not throw.
+      await runtime.publish(env);
+
+      // Publish still happened — unsigned fallback.
+      expect(fake.publish).toHaveBeenCalledTimes(1);
+      const payload = fake.publishes[0]?.payload as string;
+      const published = JSON.parse(payload) as { signed_by?: unknown };
+      expect(published.signed_by).toBeUndefined();
+
+      // Error was logged for visibility.
+      const errLines = logs.filter((l) => l.kind === "error");
+      expect(errLines.some((l) => l.msg.includes("sign failed"))).toBe(true);
+
+      await runtime.stop();
+    });
+
     test("publish after stop() is a no-op (no late publishes after drain)", async () => {
       // Pins the post-stop semantic documented on `publishEnabled` in
       // runtime.ts: once `stop()` returns, calls to `runtime.publish(...)`

--- a/src/bus/myelin/__tests__/runtime.test.ts
+++ b/src/bus/myelin/__tests__/runtime.test.ts
@@ -572,6 +572,44 @@ describe("MyelinRuntime", () => {
       // Error was logged for visibility.
       const errLines = logs.filter((l) => l.kind === "error");
       expect(errLines.some((l) => l.msg.includes("sign failed"))).toBe(true);
+      expect(
+        errLines.some((l) => l.msg.includes("signFailureMode=fallback")),
+      ).toBe(true);
+
+      await runtime.stop();
+    });
+
+    test("IAW B.3 — signFailureMode: 'drop' skips publish on sign failure", async () => {
+      // Echo cortex#209 round 1 — explicit fail-closed mode for the
+      // window after subscribe-side verification becomes enforcing.
+      const fake = makeFakeNatsConnection();
+      const runtime = await startMyelinRuntime(
+        makeConfig({
+          url: "nats://localhost:4222",
+          name: "grove-bot",
+          subjects: ["local.{org}.system.>"],
+        }),
+        {
+          connectImpl: async () => fake.nc,
+          signer: {
+            rawSeedBytes: new Uint8Array(16),
+            principal: "did:mf:test-stack",
+          },
+          signFailureMode: "drop",
+        },
+      );
+
+      await runtime.publish(makeEnvelope());
+
+      // Publish was DROPPED — never reaches the wire.
+      expect(fake.publish).not.toHaveBeenCalled();
+
+      // Drop is logged with the explicit mode.
+      const errLines = logs.filter((l) => l.kind === "error");
+      expect(errLines.some((l) => l.msg.includes("DROPPING"))).toBe(true);
+      expect(errLines.some((l) => l.msg.includes("signFailureMode=drop"))).toBe(
+        true,
+      );
 
       await runtime.stop();
     });

--- a/src/bus/myelin/runtime.ts
+++ b/src/bus/myelin/runtime.ts
@@ -311,8 +311,11 @@ export async function startMyelinRuntime(
 
   let stopped = false;
 
-  // Signature stays Promise<void> for symmetry with `publishDisabled` and
-  // the MyelinRuntime contract; the body is sync-by-design today (NatsLink
+  // `publishEnabled` is async because we await `signEnvelope` when a
+  // signer is configured (B.3). `NatsLink.publish` itself is fire-and-
+  // forget at the Core NATS client layer; the awaitable surface is
+  // preserved for symmetry with `publishDisabled` and the
+  // `MyelinRuntime.publish: (env) => Promise<void>` contract.
   const signer = options?.signer;
   const signFailureMode = options?.signFailureMode ?? "fallback";
   // Pre-encode the seed to the base64 shape myelin's `signEnvelope`

--- a/src/bus/myelin/runtime.ts
+++ b/src/bus/myelin/runtime.ts
@@ -120,6 +120,31 @@ export interface MyelinRuntimeOptions {
    * DID-shaped principal into this option.
    */
   signer?: BusEnvelopeSigner;
+  /**
+   * IAW Phase B.3 (cortex#114) — behaviour when the signer is
+   * configured but `signEnvelope` itself throws (malformed seed,
+   * unsupported principal DID format, etc.).
+   *
+   * - `'fallback'` (default) — log the error, publish the envelope
+   *   UNSIGNED. Acceptable while the receive side
+   *   (`verifyEnvelopeIdentity`) is not yet enforcing on the
+   *   subscribe path (B.3 ships in that window). The bus tolerates
+   *   unsigned envelopes today; a transient sign failure doesn't
+   *   crash the publish path or drop the operational signal.
+   *
+   * - `'drop'` — log the error and SKIP the publish entirely. The
+   *   envelope never reaches the wire. Use this once the receive
+   *   side becomes enforcing — at that point publishing unsigned is
+   *   a silent downgrade attack surface (an attacker who can fault-
+   *   inject the signer would otherwise get the daemon to emit
+   *   unsigned envelopes; peers in a rollout window that tolerate
+   *   unsigned would accept the bypass). Flip to `'drop'` is
+   *   tracked at cortex#210.
+   *
+   * Ignored when `signer` is undefined (no signer means no failure
+   * mode to choose).
+   */
+  signFailureMode?: "fallback" | "drop";
 }
 
 /**
@@ -289,6 +314,7 @@ export async function startMyelinRuntime(
   // Signature stays Promise<void> for symmetry with `publishDisabled` and
   // the MyelinRuntime contract; the body is sync-by-design today (NatsLink
   const signer = options?.signer;
+  const signFailureMode = options?.signFailureMode ?? "fallback";
   // Pre-encode the seed to the base64 shape myelin's `signEnvelope`
   // consumes — done once at runtime init rather than per-publish so
   // every call doesn't reallocate the encoding. Tests can pass a
@@ -356,9 +382,27 @@ export async function startMyelinRuntime(
           signer.principal,
         );
       } catch (err) {
+        // Sign failure handling — see `MyelinRuntimeOptions.signFailureMode`
+        // for the full rationale. `fallback` publishes unsigned (safe
+        // while subscribe side is non-enforcing); `drop` skips publish
+        // entirely (safe once subscribe side enforces verification).
+        //
+        // Log message deliberately omits `err.message` interpolation
+        // when the error origin is myelin's `signEnvelope` — that
+        // function constructs error strings from inputs (e.g.
+        // "Invalid private key: expected 32-byte Ed25519 seed, got N
+        // bytes") and we don't want even partial seed-shape facts
+        // landing in operator logs. The error class + envelope id
+        // gives operators enough to triage.
+        const reason = err instanceof Error ? err.name : "unknown";
+        if (signFailureMode === "drop") {
+          console.error(
+            `myelin-runtime: sign failed for id=${envelope.id} type=${envelope.type} reason=${reason} — DROPPING (signFailureMode=drop)`,
+          );
+          return;
+        }
         console.error(
-          `myelin-runtime: sign failed for id=${envelope.id} type=${envelope.type} — publishing unsigned:`,
-          err instanceof Error ? err.message : err,
+          `myelin-runtime: sign failed for id=${envelope.id} type=${envelope.type} reason=${reason} — publishing unsigned (signFailureMode=fallback)`,
         );
       }
     }

--- a/src/bus/myelin/runtime.ts
+++ b/src/bus/myelin/runtime.ts
@@ -18,6 +18,10 @@ import type { BotConfig } from "../../common/types/config";
 import { NatsLink } from "../nats/connection";
 import { MyelinSubscriber } from "./subscriber";
 import { deriveNatsSubject, type Envelope } from "./envelope-validator";
+// IAW Phase B.3 — sign outbound envelopes via myelin's chain-aware
+// signer. Import discipline matches B.1c: the constrained `/identity`
+// subpath keeps tsc out of myelin's full source tree.
+import { signEnvelope } from "@the-metafactory/myelin/identity";
 
 /**
  * Per-envelope handler. Receives validated envelopes from any active
@@ -99,6 +103,43 @@ export interface MyelinRuntime {
  */
 export interface MyelinRuntimeOptions {
   connectImpl?: (opts: ConnectionOptions) => Promise<NatsConnection>;
+  /**
+   * IAW Phase B.3 (cortex#114) — outbound envelope signer. When set,
+   * `publish()` signs every outbound envelope via myelin's
+   * `signEnvelope` before NATS publish; the envelope's `signed_by[]`
+   * gains a fresh ed25519 stamp committed to the JCS-canonical bytes
+   * of `{...envelope, signed_by: [...prior, newStamp]}`. Multi-hop
+   * envelopes (forwarded across stacks) append rather than replace —
+   * the prior chain is preserved.
+   *
+   * When undefined, `publish()` emits envelopes verbatim — same shape
+   * as today, unchanged for callers that haven't opted in. Operators
+   * stage the keypair via `cortex.yaml.stack.nkey_seed_path` + the
+   * `loadStackSigningKey` loader (chmod 600 gated; `SU` prefix
+   * required); the entrypoint wires the loaded keypair + the stack's
+   * DID-shaped principal into this option.
+   */
+  signer?: BusEnvelopeSigner;
+}
+
+/**
+ * Outbound envelope signer surface — what `MyelinRuntime` needs to
+ * sign a single envelope. Kept narrow so test doubles + future
+ * hardware-backed signers (yubikey / TPM) can implement without
+ * leaking the `nkeys.js` KeyPair shape across module boundaries.
+ *
+ * `rawSeedBytes` is the 32-byte ed25519 seed — what myelin's
+ * `signEnvelope` consumes after base64-encoding. Production callers
+ * pass `keyPair.getRawSeed()` directly; tests construct from a
+ * generated keypair.
+ *
+ * `principal` is the DID-shaped string that lands on the new stamp's
+ * `signed_by[].principal` field. Convention: `did:mf:<name>` per
+ * myelin spec.
+ */
+export interface BusEnvelopeSigner {
+  rawSeedBytes: Uint8Array;
+  principal: string;
 }
 
 export async function startMyelinRuntime(
@@ -247,8 +288,16 @@ export async function startMyelinRuntime(
 
   // Signature stays Promise<void> for symmetry with `publishDisabled` and
   // the MyelinRuntime contract; the body is sync-by-design today (NatsLink
-  // .publish is fire-and-forget). Future implementations may await.
-  // eslint-disable-next-line @typescript-eslint/require-await
+  const signer = options?.signer;
+  // Pre-encode the seed to the base64 shape myelin's `signEnvelope`
+  // consumes — done once at runtime init rather than per-publish so
+  // every call doesn't reallocate the encoding. Tests can pass a
+  // synthetic seed via `MyelinRuntimeOptions.signer.rawSeedBytes`
+  // without going through the file loader.
+  const signerSeedBase64 = signer
+    ? Buffer.from(signer.rawSeedBytes).toString("base64")
+    : undefined;
+
   const publishEnabled = async (envelope: Envelope): Promise<void> => {
     if (stopped) {
       // Post-stop publish: short-circuit. The runtime's `link.drain()`
@@ -274,8 +323,48 @@ export async function startMyelinRuntime(
     // same value `agent.operatorId` produces when emit-site helpers
     // assemble it, so subscribe-side `{org}` substitution stays symmetric.
     const subject = deriveNatsSubject(envelope);
+
+    // IAW Phase B.3: sign before publish if the runtime was started
+    // with a signer. The chain-aware `signEnvelope` appends to any
+    // existing `signed_by[]` rather than overwriting — so a multi-hop
+    // envelope forwarded through this stack picks up an additional
+    // stamp committed to the prior chain. Failure to sign falls back
+    // to the original envelope plus a log — we don't want a transient
+    // crypto failure (extremely rare; bad seed bytes typically fail
+    // at `loadStackSigningKey` time) to crash the publish path.
+    let envelopeToPublish: Envelope = envelope;
+    if (signer !== undefined && signerSeedBase64 !== undefined) {
+      try {
+        // Normalize signed_by to the array shape myelin's
+        // `signEnvelope` expects (MyelinEnvelope tightens
+        // `signed_by` to `SignedBy[] | undefined` whereas cortex's
+        // back-compat Envelope still allows a single stamp). The
+        // signer appends to the existing chain when present.
+        const priorChain =
+          envelope.signed_by === undefined
+            ? undefined
+            : Array.isArray(envelope.signed_by)
+              ? envelope.signed_by
+              : [envelope.signed_by];
+        const envelopeForSigner = {
+          ...envelope,
+          ...(priorChain !== undefined && { signed_by: priorChain }),
+        };
+        envelopeToPublish = await signEnvelope(
+          envelopeForSigner as Parameters<typeof signEnvelope>[0],
+          signerSeedBase64,
+          signer.principal,
+        );
+      } catch (err) {
+        console.error(
+          `myelin-runtime: sign failed for id=${envelope.id} type=${envelope.type} — publishing unsigned:`,
+          err instanceof Error ? err.message : err,
+        );
+      }
+    }
+
     try {
-      link.publish(subject, JSON.stringify(envelope));
+      link.publish(subject, JSON.stringify(envelopeToPublish));
     } catch (err) {
       // Swallow + log per the contract on `MyelinRuntime.publish`. A failing
       // operational event must NOT escalate into a crash, particularly since

--- a/src/common/config/__tests__/stack-signing-key.test.ts
+++ b/src/common/config/__tests__/stack-signing-key.test.ts
@@ -1,0 +1,115 @@
+/**
+ * IAW Phase B.3 (cortex#114) — tests for `loadStackSigningKey`.
+ *
+ * Mirrors `account-signing-key.test.ts` deliberately — same load
+ * discipline, different prefix gate:
+ *   1. Valid `SU`-prefixed user seed at chmod 600 → succeeds.
+ *   2. chmod 644 → throws "must be chmod 600".
+ *   3. Wrong prefix (`SA`, `SO`) → throws "expected SU...".
+ *   4. Missing file → throws ENOENT.
+ *
+ * Plus a public-key round-trip cross-check (loaded keypair's pubkey
+ * matches a fresh `fromSeed()` on the same bytes — i.e. no silent
+ * read/trim mangling).
+ *
+ * Seeds are generated fresh per-test via `createUser()` so no real
+ * key material lands in the repo.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { chmodSync, mkdirSync, rmSync, writeFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { createAccount, createOperator, createUser, fromSeed } from "nkeys.js";
+import { loadStackSigningKey } from "../stack-signing-key";
+
+let testDir: string;
+
+beforeEach(() => {
+  testDir = join(
+    tmpdir(),
+    `cortex-stack-signing-key-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(testDir, { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(testDir, { recursive: true, force: true });
+});
+
+function writeSeedFile(
+  filename: string,
+  seed: string,
+  mode: number,
+): { path: string; seed: string } {
+  const path = join(testDir, filename);
+  writeFileSync(path, seed);
+  chmodSync(path, mode);
+  return { path, seed };
+}
+
+function newUserSeed(): string {
+  return new TextDecoder().decode(createUser().getSeed());
+}
+
+function newAccountSeed(): string {
+  return new TextDecoder().decode(createAccount().getSeed());
+}
+
+function newOperatorSeed(): string {
+  return new TextDecoder().decode(createOperator().getSeed());
+}
+
+describe("loadStackSigningKey", () => {
+  test("loads a valid SU-prefixed user seed at chmod 600", async () => {
+    const seed = newUserSeed();
+    const { path } = writeSeedFile("stack.nk", seed, 0o600);
+
+    const kp = await loadStackSigningKey(path);
+    expect(kp).toBeDefined();
+    expect(kp.getPublicKey()).toMatch(/^U[A-Z2-7]{55}$/);
+  });
+
+  test("rejects chmod 644 (the gate is exact)", async () => {
+    const seed = newUserSeed();
+    const { path } = writeSeedFile("stack.nk", seed, 0o644);
+
+    // The shared `enforceChmod600` helper throws with "must be chmod 600"
+    // (or equivalent platform-aware language). The exact wording is
+    // owned by file-permissions.ts; we assert on the operator-actionable
+    // fragment "chmod 600".
+    await expect(loadStackSigningKey(path)).rejects.toThrow(/chmod 600/);
+  });
+
+  test("rejects SA-prefixed (account) seed with a clear error", async () => {
+    const seed = newAccountSeed();
+    const { path } = writeSeedFile("wrong-prefix.nk", seed, 0o600);
+
+    await expect(loadStackSigningKey(path)).rejects.toThrow(/expected stack signing key/);
+    await expect(loadStackSigningKey(path)).rejects.toThrow(/SA\.\.\./);
+  });
+
+  test("rejects SO-prefixed (operator) seed with a clear error", async () => {
+    const seed = newOperatorSeed();
+    const { path } = writeSeedFile("wrong-prefix.nk", seed, 0o600);
+
+    await expect(loadStackSigningKey(path)).rejects.toThrow(/expected stack signing key/);
+    await expect(loadStackSigningKey(path)).rejects.toThrow(/SO\.\.\./);
+  });
+
+  test("throws ENOENT on missing file", async () => {
+    const missingPath = join(testDir, "does-not-exist.nk");
+    await expect(loadStackSigningKey(missingPath)).rejects.toThrow(/ENOENT|no such file/);
+  });
+
+  test("trimming preserves the seed identity (no silent mangling)", async () => {
+    const seed = newUserSeed();
+    // Operators commonly leave a trailing newline (`nsc ... > stack.nk`).
+    // The loader must trim without changing which pubkey gets derived.
+    const { path } = writeSeedFile("with-newline.nk", seed + "\n", 0o600);
+
+    const loaded = await loadStackSigningKey(path);
+    const reference = fromSeed(new TextEncoder().encode(seed));
+    expect(loaded.getPublicKey()).toBe(reference.getPublicKey());
+  });
+});

--- a/src/common/config/stack-signing-key.ts
+++ b/src/common/config/stack-signing-key.ts
@@ -1,0 +1,98 @@
+/**
+ * IAW Phase B.3 (cortex#114) — stack signing key loader.
+ *
+ * The stack's signing key (NATS `SU`-prefixed nkey seed — user-class
+ * key) is what cortex uses to sign outbound `dispatch.task.*` and
+ * other peer-visible envelopes via myelin's `signEnvelope`. The
+ * matching public key (`U` + 55 base32) is declared on
+ * `cortex.yaml.stack.nkey_pub`; this loader is the seed side.
+ *
+ * Threat model: a leaked stack seed lets an attacker mint signed
+ * envelopes that look like they came from this stack — every peer on
+ * the bus that trusts this stack's public key would accept the
+ * forgery. Less catastrophic than the operator account signing key
+ * (which mints USER JWTs), but still load-bearing for the
+ * `signed_by[]` chain's integrity. The chmod 600 gate is the same
+ * mitigation pattern as `account-signing-key.ts`; the prefix gate
+ * rejects seeds that don't match the user-class (`SU`) we expect.
+ *
+ * Mirrors `src/common/config/account-signing-key.ts` deliberately —
+ * different prefix (`SU` vs `SA`), different threat scope, identical
+ * loading discipline.
+ *
+ * NOT covered here (forward work):
+ *   - In-memory zeroization. The KeyPair lives for the daemon
+ *     lifetime; revisit when credential rotation lands.
+ *   - Hardware-backed signing (yubikey / TPM). Future work; this
+ *     function's signature is the seam — a `loadStackSigningKey`
+ *     replacement could return a KeyPair-shaped facade that delegates
+ *     to a hardware backend without changing call sites.
+ *
+ * Cross-references:
+ *   - cortex#114 — IAW Phase B umbrella
+ *   - cortex#200 (B.1c) — myelin `signEnvelope` consumer pattern
+ *   - cortex#102 — design: bot↔bot via bus envelopes (NKey identity)
+ *   - `src/bus/myelin/runtime.ts` — call site that consumes the loaded
+ *     keypair to sign outbound envelopes
+ */
+
+import { promises as fsp } from "fs";
+import { fromSeed, type KeyPair } from "nkeys.js";
+import { enforceChmod600 } from "./file-permissions";
+
+/**
+ * Stack signing key seed prefix. NATS nkey seeds for a *user* always
+ * start with `SU` (Seed + User prefix bytes, base32-encoded). The
+ * stack's public key (`U...`) is the user-class pair, so the seed
+ * matches.
+ */
+const STACK_SEED_PREFIX = "SU";
+
+/**
+ * Load + validate the stack signing nkey from disk.
+ *
+ * Throws (with a clear, operator-facing message) on:
+ *   - File missing / unreadable (propagates ENOENT / EACCES).
+ *   - chmod not exactly `0600` on POSIX (no group / world access).
+ *   - Seed not prefixed `SU` (i.e. not a user-class seed).
+ *   - Seed bytes that `nkeys.fromSeed` rejects as malformed.
+ *
+ * @param path Absolute or process-relative path to the seed file.
+ * @returns A KeyPair ready for `sign(input)` calls + `getPublicKey()`
+ *          inspection. Production call sites pair this with
+ *          `cortex.yaml.stack.nkey_pub` and assert the two agree —
+ *          a mismatch indicates the seed file points at a different
+ *          identity than the declared public key.
+ */
+export async function loadStackSigningKey(path: string): Promise<KeyPair> {
+  // 1. Permission gate. Shared helper backs both account-signing-key
+  //    and this loader — policy changes ripple to both consumers.
+  enforceChmod600(path);
+
+  // 2. Read + trim. `nsc generate nkey -u > stack.nk` leaves a
+  //    trailing newline that `fromSeed` would reject as malformed.
+  const raw = await fsp.readFile(path, "utf-8");
+  const seed = raw.trim();
+
+  // 3. Prefix gate. Reject early with a clear error that tells the
+  //    operator which kind of key they handed us. Operator account
+  //    keys (`SA`), operator root keys (`SO`), server keys (`SN`),
+  //    and curve keys (`SC`) all fail this check.
+  if (!seed.startsWith(STACK_SEED_PREFIX)) {
+    const actualPrefix = seed.slice(0, 2);
+    throw new Error(
+      `expected stack signing key (prefix ${STACK_SEED_PREFIX}...), got ${actualPrefix}... at ${path}`,
+    );
+  }
+
+  // 4. Parse. `fromSeed` expects Uint8Array; the trimmed string is
+  //    pure ASCII (NKey base32 alphabet) so UTF-8 encoding is
+  //    byte-identical.
+  const seedBytes = new TextEncoder().encode(seed);
+  try {
+    return fromSeed(seedBytes);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(`failed to parse stack signing key at ${path}: ${message}`, { cause: err });
+  }
+}

--- a/src/common/types/stack.ts
+++ b/src/common/types/stack.ts
@@ -105,6 +105,30 @@ export const StackConfigSchema = z.object({
     /^U[A-Z2-7]{55}$/,
     "stack.nkey_pub must be a base32 NKey public key (U-prefixed, 56 chars total)",
   ).optional(),
+  /**
+   * IAW Phase B.3 (cortex#114) — path to the stack's private signing
+   * seed file. NATS NKey seed (`SU` + 57 base32 chars) — same shape
+   * `nsc generate nkey -u` produces. The file MUST be chmod 600 on
+   * POSIX; the loader (`src/common/config/stack-signing-key.ts`)
+   * enforces that gate before reading.
+   *
+   * Optional at config schema level so operators can stage `nkey_pub`
+   * without immediately wiring the seed (e.g. on a dry run, or when
+   * the bot is structurally configured but not yet expected to sign
+   * outbound envelopes). When BOTH `nkey_pub` and `nkey_seed_path`
+   * are set, `MyelinRuntime.publish()` signs every outbound envelope
+   * with this stack's NKey; when only `nkey_pub` is set, the bot
+   * publishes unsigned (B.1a / B.1b consume the `signed_by[]` only
+   * structurally so unsigned envelopes still flow).
+   *
+   * Threat model: the seed is the most sensitive key material the
+   * stack holds — possessing it lets an attacker mint signed
+   * envelopes claiming this stack's identity. The chmod 600 gate is
+   * the operator-laptop / server-filesystem mitigation; hardware-
+   * backed signing (yubikey / TPM) is future work tracked by the
+   * `loadStackSigningKey` seam.
+   */
+  nkey_seed_path: z.string().optional(),
 });
 
 export type StackConfig = z.infer<typeof StackConfigSchema>;


### PR DESCRIPTION
## Summary

Phase B.3 — \`MyelinRuntime.publish()\` now signs every outbound envelope with the stack's NKey when an operator-supplied signer is wired in. Multi-hop envelopes (forwarded across stacks) append a fresh ed25519 stamp committed to the prior chain rather than overwriting it.

\`refs cortex#114\`
\`refs cortex#202\` (B.2b outbound side will consume the wire signing infra this PR provides)

## What lands

| Surface | What |
|---|---|
| \`StackConfigSchema.nkey_seed_path\` | Optional config field. Path to the stack's private signing seed (SU-prefixed NATS user-class nkey). |
| \`src/common/config/stack-signing-key.ts\` | \`loadStackSigningKey\` loader — mirrors \`account-signing-key.ts\` discipline (chmod 600 gate, prefix gate, trimming preserves seed identity). |
| \`MyelinRuntimeOptions.signer\` | New optional \`BusEnvelopeSigner\` shape carrying raw 32-byte seed bytes + DID-shaped principal. When set, \`publishEnabled\` calls myelin's \`signEnvelope\` (constrained \`/identity\` subpath) before NATS publish. |
| Multi-hop append semantics | When an envelope arrives already signed, the prior chain is preserved and our stamp appends after — the chain-of-stamps property that makes cross-stack verification possible. |
| Defensive fallback | A sign failure (malformed seed shape, etc.) logs and publishes the original envelope unchanged rather than crashing the publish path. |
| 9 new tests | 3 runtime publish-signer tests + 6 loader tests. |

## Deferred to follow-ups

- **\`cortex.ts\` entrypoint wiring** — same plumbing-only follow-up shape as B.2a. The loaded keypair needs to thread from cortex.yaml through to \`startMyelinRuntime\`'s \`signer\` option.
- **\`buildPrincipalRegistry\` extension** — once the stack signs with its own DID, B.1c's registry builder needs to also include the stack's principal so \`verifyEnvelopeIdentity\` on the receiving side can resolve it.
- **B.4 round-trip + adversarial integration tests** — exercises the full publish→subscribe→verify path across two cortex instances. Depends on the wiring above + cortex#202 (B.2b outbound).

## Verification

- \`bunx tsc --noEmit\` — clean
- \`bun run lint:errors\` — clean (0 errors)
- \`bun test src/bus/myelin/__tests__/runtime.test.ts src/common/config/__tests__/stack-signing-key.test.ts\` — 24 pass / 0 fail / 64 expect()
- \`bun test src/substrates/ src/bus/ src/common/{agents,types,config}/\` — 779 pass / 0 fail / 1525 expect()

## Looking for in review

- \`BusEnvelopeSigner\` shape — raw bytes + principal vs. an opaque \`sign\` callback (future hardware-backed signing).
- \`signed_by\` normalisation at the publish boundary (single-stamp back-compat shim → array form via \`signEnvelope\`).
- Sign-failure-falls-back-to-unsigned behaviour vs. fail-closed (currently fail-open per "operational event must not crash the bot" pattern; debatable for security-critical signing).
- Acceptable to defer the cortex.yaml entrypoint wiring to a follow-up (same pattern as B.2a's deferred wiring)?