### PR TITLE
feat(cortex): IAW Phase B entrypoint wiring — load stack signer + start bus-dispatch-listener (refs cortex#114)

### DIFF
--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -39,6 +39,7 @@ import {
 } from "./bus/myelin/runtime";
 import { loadStackSigningKey } from "./common/config/stack-signing-key";
 import { BusDispatchListener } from "./bus/bus-dispatch-listener";
+import { DID_RE } from "@the-metafactory/myelin/identity";
 import { createSurfaceRouter, type SurfaceRouter } from "./bus/surface-router";
 import { createNetworkResolver } from "./bus/network-resolver";
 import type { SystemEventSource } from "./bus/system-events";
@@ -240,16 +241,62 @@ export async function startCortex(
   let signer: BusEnvelopeSigner | undefined;
   if (options.stack?.nkey_seed_path) {
     try {
-      const kp = await loadStackSigningKey(options.stack.nkey_seed_path);
+      // `expandTilde` matches `NatsLink.connect`'s treatment of
+      // `credsPath` + the agents.d/ fallback below — operators writing
+      // `~/.config/cortex/stack.nk` should not silently ENOENT into
+      // the unsigned-publish fallback (Echo cortex#211 round 1).
+      const seedPath = expandTilde(options.stack.nkey_seed_path);
+      const kp = await loadStackSigningKey(seedPath);
+
+      // Consistency check: if `stack.nkey_pub` is also declared, the
+      // loaded keypair's public key MUST match. A mismatch is the
+      // operator-rotation split-brain hazard — peers' `trust:`
+      // lookups would reject every signature without explaining why.
+      // Throw and let the existing catch surface the failure (Echo
+      // cortex#211 round 1).
+      if (
+        options.stack.nkey_pub !== undefined &&
+        kp.getPublicKey() !== options.stack.nkey_pub
+      ) {
+        throw new Error(
+          `seed file pubkey ${kp.getPublicKey()} does not match declared ` +
+            `stack.nkey_pub ${options.stack.nkey_pub} — rotation split-brain hazard`,
+        );
+      }
+
       // KP class exposes getRawSeed() returning the 32-byte ed25519
       // seed; that's the shape myelin's signEnvelope consumes (after
       // base64-encoding, done inside MyelinRuntime). See B.3 PR #209.
       const rawSeedBytes = (
         kp as unknown as { getRawSeed(): Uint8Array }
       ).getRawSeed();
-      const principal = `did:mf:${derivedStack.id.replace("/", "-")}`;
+
+      // Derive the principal DID. `stack.id` shape is `{op}/{stack}`
+      // (Phase A.5 lock-in); myelin's DID_RE rejects slashes but
+      // accepts hyphens, so we canonicalize. The schema regex allows
+      // trailing hyphens in each segment (`my-op-/foo`) which after
+      // replacement becomes `my-op--foo`, breaking DID_RE's
+      // consecutive-hyphen guard. Collapse `--` runs to avoid the
+      // silent per-publish sign failure that would otherwise downgrade
+      // every outbound envelope to unsigned (Echo cortex#211 round 1).
+      const principal = `did:mf:${derivedStack.id
+        .replace("/", "-")
+        .replace(/-+/g, "-")}`;
+      if (!DID_RE.test(principal)) {
+        throw new Error(
+          `derived DID "${principal}" does not match myelin DID_RE — ` +
+            `check stack.id segments for trailing-hyphen edge cases`,
+        );
+      }
+
       signer = { rawSeedBytes, principal };
-      console.log(`cortex: stack signing key loaded — principal=${principal}`);
+      // Soften wording: the runtime may still fail to start; the
+      // signer is only "active" once `startMyelinRuntime` returns an
+      // enabled runtime. Boot-log clarity matters more than terseness
+      // here (Echo cortex#211 round 1).
+      console.log(
+        `cortex: stack signing key staged — principal=${principal} (active once myelin runtime starts)`,
+      );
     } catch (err) {
       console.error(
         "cortex: stack signing key load failed (non-fatal — publish will be unsigned):",

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -32,7 +32,13 @@ import type { UsageStats } from "./runner/stream-parser";
 
 import { buildSecurityPreamble } from "./runner/security-preamble";
 import { DispatchHandler } from "./bus/dispatch-handler";
-import { startMyelinRuntime, type MyelinRuntime } from "./bus/myelin/runtime";
+import {
+  startMyelinRuntime,
+  type BusEnvelopeSigner,
+  type MyelinRuntime,
+} from "./bus/myelin/runtime";
+import { loadStackSigningKey } from "./common/config/stack-signing-key";
+import { BusDispatchListener } from "./bus/bus-dispatch-listener";
 import { createSurfaceRouter, type SurfaceRouter } from "./bus/surface-router";
 import { createNetworkResolver } from "./bus/network-resolver";
 import type { SystemEventSource } from "./bus/system-events";
@@ -216,6 +222,42 @@ export async function startCortex(
     `  Stack: ${derivedStack.id}${options.stack === undefined ? " (default-derived)" : ""}`,
   );
 
+  // IAW Phase B.3 (refs cortex#114) — load the stack signing keypair
+  // if the operator has declared `stack.nkey_seed_path`. The signer is
+  // optional; when absent, MyelinRuntime publishes envelopes unsigned
+  // (same shape as today). When present, MyelinRuntime.publish signs
+  // every outbound envelope via myelin's chain-aware signEnvelope.
+  //
+  // Principal derivation: `did:mf:${stack.id.replace("/", "-")}`. The
+  // `stack.id` shape is `{operator_id}/{stack_id}` (Phase A.5 lock-in);
+  // myelin's DID_RE rejects slashes but accepts hyphens, so we
+  // canonicalize the slash. Operators see `did:mf:andreas-research`
+  // on the wire for `stack.id = "andreas/research"`.
+  //
+  // Load failures are non-fatal — the daemon keeps starting and the
+  // runtime publishes unsigned. The error surfaces to operator logs
+  // so they can fix the seed file and restart.
+  let signer: BusEnvelopeSigner | undefined;
+  if (options.stack?.nkey_seed_path) {
+    try {
+      const kp = await loadStackSigningKey(options.stack.nkey_seed_path);
+      // KP class exposes getRawSeed() returning the 32-byte ed25519
+      // seed; that's the shape myelin's signEnvelope consumes (after
+      // base64-encoding, done inside MyelinRuntime). See B.3 PR #209.
+      const rawSeedBytes = (
+        kp as unknown as { getRawSeed(): Uint8Array }
+      ).getRawSeed();
+      const principal = `did:mf:${derivedStack.id.replace("/", "-")}`;
+      signer = { rawSeedBytes, principal };
+      console.log(`cortex: stack signing key loaded — principal=${principal}`);
+    } catch (err) {
+      console.error(
+        "cortex: stack signing key load failed (non-fatal — publish will be unsigned):",
+        err instanceof Error ? err.message : String(err),
+      );
+    }
+  }
+
   // Bus runtime (M2-M6) — no-op when `config.nats?` is absent. Tests inject
   // a recording fake via `options.injectRuntime` to assert observable
   // wire-up side-effects without standing up a real NATS server.
@@ -234,7 +276,10 @@ export async function startCortex(
     runtime = options.injectRuntime;
   } else {
     try {
-      runtime = await startMyelinRuntime(config);
+      runtime = await startMyelinRuntime(
+        config,
+        signer !== undefined ? { signer } : undefined,
+      );
     } catch (err) {
       console.error("cortex: myelin runtime startup error (non-fatal):", err instanceof Error ? err.message : err);
     }
@@ -330,6 +375,43 @@ export async function startCortex(
       dataResidency: config.agent.dataResidency,
     }),
   };
+
+  // IAW Phase B.2a (refs cortex#114) — inbound peer-dispatch listener.
+  // Subscribes via the runtime's onEnvelope fan-out, filters for
+  // `dispatch.task.dispatched` envelopes from non-self sources, runs
+  // verifySignedByChain, emits `system.bus.peer_dispatch_received`
+  // visibility envelopes on valid arrivals. Listener is bound to the
+  // FIRST registered agent today — multi-agent stacks may eventually
+  // want one listener per agent (each receiver's `trust:` list is
+  // distinct), but at this slice a single binding is sufficient for
+  // the inbound visibility surface. When the registry is empty (no
+  // inline agents AND no fragments — e.g. legacy bot.yaml with
+  // `trust: []`), the listener is skipped entirely.
+  //
+  // `cryptoVerify` is hard-coded off at this slice — the structural
+  // check alone is the B.1a contract and operators flip to crypto
+  // verify once every trusted peer has an `nkey_pub` declared. The
+  // flag is a small follow-up plumbing (cortex.yaml flag → option) once
+  // the rollout window closes.
+  let busDispatchListener: BusDispatchListener | undefined;
+  const firstAgent = mergedAgents[0];
+  if (firstAgent !== undefined) {
+    busDispatchListener = new BusDispatchListener({
+      runtime,
+      resolver: trustResolver,
+      receivingAgentId: firstAgent.id,
+      operatorId: config.agent.operatorId ?? "default",
+      source: systemEventSource,
+    });
+    busDispatchListener.start();
+    console.log(
+      `cortex: bus-dispatch-listener started — receivingAgentId=${firstAgent.id}`,
+    );
+  } else {
+    console.log(
+      "cortex: bus-dispatch-listener skipped — no agents in registry",
+    );
+  }
 
   // Surface router (in-process fan-out).
   // Receives `systemEventSource` so visibility-config drops produce
@@ -852,6 +934,17 @@ export async function startCortex(
         if (cleanup) completeSync(`outbound poller stop[${i}]`, cleanup);
       }
       await completeAsync("dispatch-listener stop", dispatchListener.stop());
+      // IAW B.2a — bus-dispatch-listener drain runs after the dispatch
+      // listener (which feeds dispatch-handler) but before the
+      // surface-router stop. The listener's `stop()` awaits its
+      // in-flight verify chain so late stderr / publish side-effects
+      // don't land after the runtime closes.
+      if (busDispatchListener !== undefined) {
+        await completeAsync(
+          "bus-dispatch-listener stop",
+          busDispatchListener.stop(),
+        );
+      }
       await completeAsync("surface-router stop", router.stop());
       await completeAsync("dispatch-handler shutdown", dispatchHandler.shutdown());
       for (let i = 0; i < adapters.length; i++) {


### PR DESCRIPTION
## Summary

Ships the **deferred plumbing** from cortex#203 (B.2a) and cortex#209 (B.3): cortex.ts now loads the stack signing keypair from \`stack.nkey_seed_path\` and threads it into \`startMyelinRuntime\`'s signer option; cortex.ts also instantiates \`BusDispatchListener\` bound to the first registered agent and starts it during boot, with a clean shutdown drain.

\`refs cortex#114\`
\`refs cortex#203\` (B.2a deferred wiring)
\`refs cortex#209\` (B.3 deferred wiring)

## What lands

| Surface | What |
|---|---|
| **Outbound signing wiring** (B.3 deferred) | When \`options.stack.nkey_seed_path\` is set, cortex calls \`loadStackSigningKey\` (chmod 600 + \`SU\`-prefix gated), extracts the raw 32-byte ed25519 seed via \`getRawSeed()\`, derives the stack DID as \`did:mf:\${stack.id.replace(\"/\", \"-\")}\`, and passes a \`BusEnvelopeSigner\` into \`startMyelinRuntime\`. Load failures are non-fatal — daemon keeps starting, publishes unsigned with a clear log line. |
| **Inbound listener wiring** (B.2a deferred) | After \`AgentRegistry\` + \`TrustResolver\` are assembled, cortex instantiates \`BusDispatchListener\` bound to the FIRST registered agent. Skipped when the registry is empty. |
| **Clean shutdown drain** | Listener stop is added to the shutdown sequence, ordered after \`dispatch-listener stop\` and before \`surface-router stop\`. \`BusDispatchListener.stop()\` awaits its in-flight verify chain via \`Promise.allSettled\` so late stderr / publish side-effects don't land after the runtime closes (round-2 fix from cortex#203). |

## DID derivation rationale

Myelin's \`DID_RE\` accepts hyphens but rejects slashes. \`stack.id\` lives in \`{operator_id}/{stack_id}\` shape per Phase A.5. Canonicalizing the slash to a hyphen gives a valid DID without ambiguity. Operators see \`did:mf:andreas-research\` on the wire for \`stack.id = \"andreas/research\"\`.

## Verification

- \`bunx tsc --noEmit\` — clean
- \`bun run lint:errors\` — clean (0 errors)
- \`bun test src/__tests__/cortex.test.ts\` — 19 pass / 0 fail
- \`bun test src/substrates/ src/bus/ src/common/{agents,types,config}/ src/__tests__/\` — 799 pass / 0 fail / 1581 expect()

## What's still deferred

- \`cryptoVerify: true\` opt-in (small cortex.yaml flag → option plumbing).
- Per-agent listener fan-out for multi-agent stacks (today: first-agent binding).
- B.2b outbound peer dispatch (tracked at cortex#202).
- B.4 round-trip + adversarial integration tests across the full path.

## Looking for in review

- DID-derivation slash→hyphen — accept, or thread something explicit through cortex.yaml (\`stack.did_principal\`)?
- First-agent binding policy — accept, or surface a config opt for which agent receives bus dispatches?
- Cryptoverify-off default — accept, or surface a flag (\`stack.crypto_verify_inbound\`) in this PR?