### PR TITLE
feat(policy): IAW C.1 — PolicyEngine module skeleton (refs cortex#115)

### DIFF
--- a/src/common/policy/__tests__/engine.test.ts
+++ b/src/common/policy/__tests__/engine.test.ts
@@ -74,7 +74,7 @@ describe("PolicyEngine — happy path", () => {
       roles: [role("operator", ["code-review.typescript", "deploy.staging"])],
     });
 
-    const result = engine.check(principal({ id: "luna" }), intent());
+    const result = engine.check("luna", intent());
 
     expect(result.allow).toBe(true);
     if (result.allow) {
@@ -94,10 +94,7 @@ describe("PolicyEngine — rejection paths", () => {
       roles: [role("operator", ["code-review.typescript"])],
     });
 
-    const result = engine.check(
-      principal({ id: "nobody", role: ["operator"] }),
-      intent(),
-    );
+    const result = engine.check("nobody", intent());
 
     expect(result.allow).toBe(false);
     if (!result.allow) {
@@ -115,7 +112,7 @@ describe("PolicyEngine — rejection paths", () => {
     });
 
     const result = engine.check(
-      principal({ id: "luna" }),
+      "luna",
       intent({ capability: "code-review.typescript" }),
     );
 
@@ -135,7 +132,7 @@ describe("PolicyEngine — rejection paths", () => {
       roles: [role("operator", ["code-review.typescript"])],
     });
 
-    const result = engine.check(principal({ id: "luna" }), intent());
+    const result = engine.check("luna", intent());
 
     expect(result.allow).toBe(false);
     if (!result.allow) {
@@ -158,11 +155,11 @@ describe("PolicyEngine — role union semantics", () => {
 
     // Either capability resolves.
     const deployResult = engine.check(
-      principal({ id: "luna" }),
+      "luna",
       intent({ capability: "deploy.staging" }),
     );
     const reviewResult = engine.check(
-      principal({ id: "luna" }),
+      "luna",
       intent({ capability: "code-review.typescript" }),
     );
 
@@ -189,7 +186,7 @@ describe("PolicyEngine — role union semantics", () => {
     });
 
     const result = engine.check(
-      principal({ id: "luna" }),
+      "luna",
       intent({ capability: "deploy.staging" }),
     );
 
@@ -213,7 +210,7 @@ describe("PolicyEngine — sovereignty (C.1 smoke)", () => {
     // Federated classification — strongest sovereignty signal cortex
     // emits today. C.1 doesn't reject on this; Phase D will.
     const result = engine.check(
-      principal({ id: "luna" }),
+      "luna",
       intent({
         sovereignty: {
           classification: "federated",

--- a/src/common/policy/__tests__/engine.test.ts
+++ b/src/common/policy/__tests__/engine.test.ts
@@ -1,0 +1,249 @@
+/**
+ * IAW Phase C.1 (cortex#115) — PolicyEngine tests.
+ *
+ * Coverage axes:
+ *   1. Happy path — principal with a role granting the requested
+ *      capability → allow + full effective capability set.
+ *   2. Unknown principal → `unknown_principal` reason.
+ *   3. Capability not in role grant → `insufficient_role`.
+ *   4. Multi-role union — principal with two roles → effective
+ *      capabilities = union; intent against either role's
+ *      capability succeeds.
+ *   5. Empty role list → every capability check fails with
+ *      `insufficient_role` (no capability is reachable).
+ *   6. Unknown role id silently skipped — principal with one valid
+ *      + one unknown role gets only the valid role's grants
+ *      (config-validation lives upstream at parse time per the
+ *      engine JSDoc).
+ *   7. Sovereignty field is a no-op at C.1 (smoke test that an
+ *      otherwise-allowed intent isn't rejected on sovereignty
+ *      grounds — the discriminator variant exists for forward
+ *      compat but the engine doesn't fire it).
+ *   8. `principalCount` + `roleCount` smoke — boot-log accessors.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { PolicyEngine } from "../engine";
+import type {
+  Intent,
+  Principal,
+  RoleDefinition,
+} from "../types";
+
+// =============================================================================
+// Fixtures
+// =============================================================================
+
+function principal(overrides: Partial<Principal> = {}): Principal {
+  return {
+    id: "luna",
+    home_operator: "andreas",
+    home_stack: "andreas/research",
+    role: ["operator"],
+    trust: [],
+    ...overrides,
+  };
+}
+
+function role(id: string, capabilities: string[]): RoleDefinition {
+  return { id, capabilities };
+}
+
+function intent(overrides: Partial<Intent> = {}): Intent {
+  return {
+    capability: "code-review.typescript",
+    sovereignty: {
+      classification: "local",
+      data_residency: "NZ",
+      max_hop: 0,
+      frontier_ok: false,
+      model_class: "any",
+    },
+    ...overrides,
+  };
+}
+
+// =============================================================================
+// Cases
+// =============================================================================
+
+describe("PolicyEngine — happy path", () => {
+  test("principal with a role granting the requested capability → allow", () => {
+    const engine = new PolicyEngine({
+      principals: [principal({ id: "luna", role: ["operator"] })],
+      roles: [role("operator", ["code-review.typescript", "deploy.staging"])],
+    });
+
+    const result = engine.check(principal({ id: "luna" }), intent());
+
+    expect(result.allow).toBe(true);
+    if (result.allow) {
+      // Effective set is the role's full capability list, not just
+      // the requested capability — downstream callers filter on it.
+      expect(new Set(result.capabilities)).toEqual(
+        new Set(["code-review.typescript", "deploy.staging"]),
+      );
+    }
+  });
+});
+
+describe("PolicyEngine — rejection paths", () => {
+  test("unknown principal → unknown_principal reason", () => {
+    const engine = new PolicyEngine({
+      principals: [principal({ id: "luna" })],
+      roles: [role("operator", ["code-review.typescript"])],
+    });
+
+    const result = engine.check(
+      principal({ id: "nobody", role: ["operator"] }),
+      intent(),
+    );
+
+    expect(result.allow).toBe(false);
+    if (!result.allow) {
+      expect(result.reason).toEqual({
+        kind: "unknown_principal",
+        principal_id: "nobody",
+      });
+    }
+  });
+
+  test("capability not in role grant → insufficient_role", () => {
+    const engine = new PolicyEngine({
+      principals: [principal({ id: "luna", role: ["operator"] })],
+      roles: [role("operator", ["deploy.staging"])],
+    });
+
+    const result = engine.check(
+      principal({ id: "luna" }),
+      intent({ capability: "code-review.typescript" }),
+    );
+
+    expect(result.allow).toBe(false);
+    if (!result.allow) {
+      expect(result.reason).toEqual({
+        kind: "insufficient_role",
+        missing_capability: "code-review.typescript",
+        principal_id: "luna",
+      });
+    }
+  });
+
+  test("empty role list → insufficient_role on any capability", () => {
+    const engine = new PolicyEngine({
+      principals: [principal({ id: "luna", role: [] })],
+      roles: [role("operator", ["code-review.typescript"])],
+    });
+
+    const result = engine.check(principal({ id: "luna" }), intent());
+
+    expect(result.allow).toBe(false);
+    if (!result.allow) {
+      expect(result.reason.kind).toBe("insufficient_role");
+    }
+  });
+});
+
+describe("PolicyEngine — role union semantics", () => {
+  test("multi-role principal: effective capabilities = union; intent against either role succeeds", () => {
+    const engine = new PolicyEngine({
+      principals: [
+        principal({ id: "luna", role: ["operator", "code-reviewer"] }),
+      ],
+      roles: [
+        role("operator", ["deploy.staging"]),
+        role("code-reviewer", ["code-review.typescript", "code-review.rust"]),
+      ],
+    });
+
+    // Either capability resolves.
+    const deployResult = engine.check(
+      principal({ id: "luna" }),
+      intent({ capability: "deploy.staging" }),
+    );
+    const reviewResult = engine.check(
+      principal({ id: "luna" }),
+      intent({ capability: "code-review.typescript" }),
+    );
+
+    expect(deployResult.allow).toBe(true);
+    expect(reviewResult.allow).toBe(true);
+    if (deployResult.allow) {
+      expect(new Set(deployResult.capabilities)).toEqual(
+        new Set([
+          "deploy.staging",
+          "code-review.typescript",
+          "code-review.rust",
+        ]),
+      );
+    }
+  });
+
+  test("unknown role id silently skipped — only valid roles' grants count", () => {
+    const engine = new PolicyEngine({
+      principals: [
+        principal({ id: "luna", role: ["operator", "ghost-role"] }),
+      ],
+      // Note: `ghost-role` deliberately NOT in roles list.
+      roles: [role("operator", ["deploy.staging"])],
+    });
+
+    const result = engine.check(
+      principal({ id: "luna" }),
+      intent({ capability: "deploy.staging" }),
+    );
+
+    expect(result.allow).toBe(true);
+    if (result.allow) {
+      // ghost-role's capabilities are not in the effective set.
+      expect(new Set(result.capabilities)).toEqual(
+        new Set(["deploy.staging"]),
+      );
+    }
+  });
+});
+
+describe("PolicyEngine — sovereignty (C.1 smoke)", () => {
+  test("sovereignty field is part of input shape but doesn't reject at C.1", () => {
+    const engine = new PolicyEngine({
+      principals: [principal({ id: "luna", role: ["operator"] })],
+      roles: [role("operator", ["code-review.typescript"])],
+    });
+
+    // Federated classification — strongest sovereignty signal cortex
+    // emits today. C.1 doesn't reject on this; Phase D will.
+    const result = engine.check(
+      principal({ id: "luna" }),
+      intent({
+        sovereignty: {
+          classification: "federated",
+          data_residency: "US",
+          max_hop: 4,
+          frontier_ok: true,
+          model_class: "frontier",
+        },
+      }),
+    );
+
+    expect(result.allow).toBe(true);
+  });
+});
+
+describe("PolicyEngine — boot accessors", () => {
+  test("principalCount + roleCount reflect constructor opts", () => {
+    const engine = new PolicyEngine({
+      principals: [
+        principal({ id: "luna" }),
+        principal({ id: "echo" }),
+        principal({ id: "holly" }),
+      ],
+      roles: [
+        role("operator", []),
+        role("code-reviewer", []),
+      ],
+    });
+
+    expect(engine.principalCount).toBe(3);
+    expect(engine.roleCount).toBe(2);
+  });
+});

--- a/src/common/policy/engine.ts
+++ b/src/common/policy/engine.ts
@@ -63,11 +63,11 @@ export class PolicyEngine {
   }
 
   /**
-   * Authorise a principal to exercise an intent. Returns a
+   * Authorise a principal id to exercise an intent. Returns a
    * `PolicyDecision` discriminated on `allow`.
    *
    * Decision flow:
-   *   1. Look up the principal. Unknown → `unknown_principal`.
+   *   1. Look up the principal by id. Unknown → `unknown_principal`.
    *   2. Compute effective capabilities = union of every role's
    *      capabilities. Unknown role ids are silently skipped (the
    *      caller's responsibility to keep the principals and roles
@@ -75,31 +75,28 @@ export class PolicyEngine {
    *      at config load).
    *   3. Match `intent.capability` against the effective set.
    *      Miss → `insufficient_role`.
-   *   4. (Phase D extends with sovereignty / per-peer checks.)
+   *   4. (Phase D extends with sovereignty / per-peer checks; the
+   *      `intent.sovereignty` field is part of the input shape so
+   *      C.4 audit envelopes carry it without an extra read.)
    *   5. Allow with the full effective set.
    *
-   * Principal lookup is by id, not by DID — callers strip the
-   * `did:mf:` prefix from a verified `signed_by[].principal` before
-   * calling. Phase C.3's dispatch-handler integration owns that
-   * normalisation; the engine takes ids only.
+   * Taking an id (not a `Principal` object) is deliberate: the
+   * registry is authoritative for roles/trust, and accepting a
+   * caller-constructed `Principal` would invite attacker-spoofed
+   * `{id, role: ["admin"]}` payloads from parsed envelopes. The
+   * dispatch-handler integration in C.3 strips `did:mf:` from a
+   * verified `signed_by[].principal` and passes the bare id here
+   * (Echo cortex#218 round 1).
    */
-  check(principal: Principal, intent: Intent): PolicyDecision {
-    // Resolve the principal — the caller can pass in a fresh
-    // Principal object OR one we already know about. If the
-    // caller's object isn't in the registry by id, the principal
-    // is "unknown" (an attacker spoofing a principal id would
-    // fall through here once the registry is in place).
-    const known = this.principalsById.get(principal.id);
+  check(principalId: string, intent: Intent): PolicyDecision {
+    const known = this.principalsById.get(principalId);
     if (known === undefined) {
       return {
         allow: false,
-        reason: { kind: "unknown_principal", principal_id: principal.id },
+        reason: { kind: "unknown_principal", principal_id: principalId },
       };
     }
 
-    // Use the REGISTRY's roles/trust, not the caller's. The caller
-    // may have constructed the principal from a parsed envelope —
-    // role assignments come from cortex.yaml, not the wire.
     const effectiveCapabilities = this.effectiveCapabilities(known);
 
     if (!effectiveCapabilities.has(intent.capability)) {
@@ -108,16 +105,14 @@ export class PolicyEngine {
         reason: {
           kind: "insufficient_role",
           missing_capability: intent.capability,
-          principal_id: principal.id,
+          principal_id: principalId,
         },
       };
     }
 
-    // Sovereignty enforcement is a Phase D concern; the field is
-    // part of the input shape so audit envelopes (C.4) carry it,
-    // and so this codepath has the shape ready when C.4 wires
-    // sovereignty-based rejection in.
-    void intent.sovereignty;
+    // TODO(phase-D): enforce `intent.sovereignty` — classification,
+    // residency, frontier-ok, model-class. C.4 audit envelopes
+    // already carry the field; Phase D wires the rejection branch.
 
     return {
       allow: true,

--- a/src/common/policy/engine.ts
+++ b/src/common/policy/engine.ts
@@ -1,0 +1,160 @@
+/**
+ * IAW Phase C.1 (cortex#115) — PolicyEngine implementation.
+ *
+ * The single authorization decision point for cortex. Replaces the
+ * per-surface role-resolver duplication today (Discord adapter +
+ * Mattermost adapter equivalent) with one `check(principal, intent)`
+ * call. Phase C.2 collapses cortex.yaml's per-adapter `roles[]`
+ * into the top-level `policy:` block that constructs the engine;
+ * Phase C.3 wires the engine into the dispatch-handler so every
+ * inbound dispatch passes through `check` before reaching a
+ * substrate harness; Phase C.4 emits `system.access.{allowed,denied}`
+ * audit envelopes carrying the decision shape this engine returns.
+ *
+ * Cross-references:
+ *   - `docs/design-internet-of-agentic-work.md` §cortex#107.
+ *   - `./types.ts` — `Principal`, `Intent`, `RoleDefinition`,
+ *     `PolicyDecision`, `PolicyDenyReason`.
+ *
+ * What this slice deliberately doesn't do (deferred):
+ *   - **No sovereignty enforcement.** `Intent.sovereignty` is part
+ *     of the decision input shape so audit envelopes (C.4) carry
+ *     it, but the engine doesn't yet reject on sovereignty
+ *     mismatches. The `sovereignty_mismatch` deny reason exists
+ *     in the discriminator for forward compatibility; today it
+ *     never fires. Phase D extends with per-network sovereignty
+ *     slicing.
+ *   - **No per-peer accept/deny.** Phase D adds
+ *     `policy.federated.networks[].accept_subjects[]` /
+ *     `deny_subjects[]` enforcement; not in C.1's scope.
+ *   - **No glob expansion on capability matches.** Literal
+ *     `===` matching only; PRs after Phase C may add patterns.
+ */
+
+import type {
+  Intent,
+  PolicyDecision,
+  Principal,
+  RoleDefinition,
+} from "./types";
+
+export interface PolicyEngineOptions {
+  /**
+   * All principals known to this engine. Built from
+   * `cortex.yaml.policy.principals[]` post-C.2; for C.1 callers
+   * assemble manually (the schema flip is the next slice).
+   */
+  principals: readonly Principal[];
+  /**
+   * Role definitions, by id. The engine looks up each id in a
+   * principal's `role[]` against this list and unions the
+   * capabilities to compute the effective grant set.
+   */
+  roles: readonly RoleDefinition[];
+}
+
+export class PolicyEngine {
+  private readonly principalsById: ReadonlyMap<string, Principal>;
+  private readonly rolesById: ReadonlyMap<string, RoleDefinition>;
+
+  constructor(opts: PolicyEngineOptions) {
+    this.principalsById = new Map(opts.principals.map((p) => [p.id, p]));
+    this.rolesById = new Map(opts.roles.map((r) => [r.id, r]));
+  }
+
+  /**
+   * Authorise a principal to exercise an intent. Returns a
+   * `PolicyDecision` discriminated on `allow`.
+   *
+   * Decision flow:
+   *   1. Look up the principal. Unknown → `unknown_principal`.
+   *   2. Compute effective capabilities = union of every role's
+   *      capabilities. Unknown role ids are silently skipped (the
+   *      caller's responsibility to keep the principals and roles
+   *      lists consistent; in production C.2 will validate this
+   *      at config load).
+   *   3. Match `intent.capability` against the effective set.
+   *      Miss → `insufficient_role`.
+   *   4. (Phase D extends with sovereignty / per-peer checks.)
+   *   5. Allow with the full effective set.
+   *
+   * Principal lookup is by id, not by DID — callers strip the
+   * `did:mf:` prefix from a verified `signed_by[].principal` before
+   * calling. Phase C.3's dispatch-handler integration owns that
+   * normalisation; the engine takes ids only.
+   */
+  check(principal: Principal, intent: Intent): PolicyDecision {
+    // Resolve the principal — the caller can pass in a fresh
+    // Principal object OR one we already know about. If the
+    // caller's object isn't in the registry by id, the principal
+    // is "unknown" (an attacker spoofing a principal id would
+    // fall through here once the registry is in place).
+    const known = this.principalsById.get(principal.id);
+    if (known === undefined) {
+      return {
+        allow: false,
+        reason: { kind: "unknown_principal", principal_id: principal.id },
+      };
+    }
+
+    // Use the REGISTRY's roles/trust, not the caller's. The caller
+    // may have constructed the principal from a parsed envelope —
+    // role assignments come from cortex.yaml, not the wire.
+    const effectiveCapabilities = this.effectiveCapabilities(known);
+
+    if (!effectiveCapabilities.has(intent.capability)) {
+      return {
+        allow: false,
+        reason: {
+          kind: "insufficient_role",
+          missing_capability: intent.capability,
+          principal_id: principal.id,
+        },
+      };
+    }
+
+    // Sovereignty enforcement is a Phase D concern; the field is
+    // part of the input shape so audit envelopes (C.4) carry it,
+    // and so this codepath has the shape ready when C.4 wires
+    // sovereignty-based rejection in.
+    void intent.sovereignty;
+
+    return {
+      allow: true,
+      capabilities: [...effectiveCapabilities],
+    };
+  }
+
+  /**
+   * Union of every role's capabilities for a principal. Unknown
+   * role ids are silently skipped here — config validation belongs
+   * upstream at parse time (C.2 will add it). Returning a Set
+   * keeps the membership check at `check`'s callsite O(1).
+   */
+  private effectiveCapabilities(principal: Principal): Set<string> {
+    const out = new Set<string>();
+    for (const roleId of principal.role) {
+      const role = this.rolesById.get(roleId);
+      if (role === undefined) continue;
+      for (const cap of role.capabilities) {
+        out.add(cap);
+      }
+    }
+    return out;
+  }
+
+  /**
+   * Number of registered principals. Useful for boot-log lines +
+   * smoke tests.
+   */
+  get principalCount(): number {
+    return this.principalsById.size;
+  }
+
+  /**
+   * Number of role definitions. Same role: boot-log + smoke.
+   */
+  get roleCount(): number {
+    return this.rolesById.size;
+  }
+}

--- a/src/common/policy/index.ts
+++ b/src/common/policy/index.ts
@@ -1,0 +1,19 @@
+/**
+ * IAW Phase C.1 (cortex#115) — PolicyEngine surface.
+ *
+ * Public re-exports for the policy module. Callers import from
+ * `src/common/policy` (this index) rather than from `./types` or
+ * `./engine` directly — the module's external shape is fixed at the
+ * index and the internal split is free to evolve (C.2 will likely
+ * add a `./schema.ts` for the Zod schema of the new `policy:` block).
+ */
+
+export { PolicyEngine, type PolicyEngineOptions } from "./engine";
+export type {
+  Intent,
+  IntentSovereignty,
+  PolicyDecision,
+  PolicyDenyReason,
+  Principal,
+  RoleDefinition,
+} from "./types";

--- a/src/common/policy/types.ts
+++ b/src/common/policy/types.ts
@@ -51,15 +51,21 @@ export interface Principal {
    * Role ids this principal holds. Each role is defined in
    * `RoleDefinition` and grants a set of capabilities. A principal's
    * effective capabilities are the union of its roles' capabilities.
+   *
+   * `readonly` deliberately — the engine treats the registry as a
+   * cortex.yaml snapshot; permitting post-construction mutation
+   * would silently change `check()` behaviour on the next call
+   * (Echo cortex#218 round 1).
    */
-  role: string[];
+  readonly role: readonly string[];
   /**
    * Peer principals this principal trusts. Empty array is legal
    * (no peer dispatches allowed). Symmetric with the existing
    * `agent.trust[]` field on `cortex.yaml` (which Phase C.2 will
-   * migrate into the top-level `policy:` block).
+   * migrate into the top-level `policy:` block). Same `readonly`
+   * snapshot discipline as `role`.
    */
-  trust: string[];
+  readonly trust: readonly string[];
 }
 
 /**
@@ -120,8 +126,11 @@ export interface RoleDefinition {
    * capability ids: `<domain>.<entity>` (e.g. `code-review.typescript`).
    * The engine matches `Intent.capability` against this list
    * literally — no glob expansion at C.1; future PRs may add it.
+   *
+   * `readonly` for the same snapshot discipline as `Principal.role`
+   * (Echo cortex#218 round 1).
    */
-  capabilities: string[];
+  readonly capabilities: readonly string[];
 }
 
 /**

--- a/src/common/policy/types.ts
+++ b/src/common/policy/types.ts
@@ -1,0 +1,174 @@
+/**
+ * IAW Phase C.1 (cortex#115) — PolicyEngine types.
+ *
+ * The PolicyEngine is the single decision point for "what is this
+ * principal allowed to do?" — replacing the per-surface duplication
+ * cortex carries today (Discord adapter role-resolver,
+ * Mattermost adapter equivalent). Phase C.2 will collapse those into
+ * a single `policy:` block on cortex.yaml; this slice (C.1) ships
+ * the engine + decision shape.
+ *
+ * Cross-references:
+ *   - `docs/design-internet-of-agentic-work.md` §cortex#107 — the
+ *     spec this module implements.
+ *   - cortex#114 (Phase B) — `signed_by[].principal` is verifiable
+ *     post-Phase B; that DID resolves to a `Principal` here.
+ *   - cortex#115 (Phase C umbrella) — this slice + C.2 (schema flip)
+ *     + C.3 (harness integration) + C.4 (audit envelopes) +
+ *     C.5 (tests + migration).
+ */
+
+/**
+ * A principal is the identity-bearing actor a dispatch is attributed
+ * to. Built from `cortex.yaml.policy.principals[]` post-Phase C.2;
+ * for C.1 the engine accepts pre-built principals from its caller
+ * (the schema flip happens in C.2 — until then the construction
+ * path is wherever the caller assembles them).
+ */
+export interface Principal {
+  /**
+   * Stable principal id. Convention: matches `did:mf:<name>`'s
+   * `<name>` segment (i.e. agent id), so a verified `signed_by[]`
+   * stamp's `principal` field resolves directly to this id by
+   * stripping the `did:mf:` prefix.
+   */
+  id: string;
+  /**
+   * Operator that owns this principal. Same value across all
+   * principals in a single-operator deployment; varies across
+   * principals once Phase D federation lands and the registry
+   * spans multiple operators.
+   */
+  home_operator: string;
+  /**
+   * Stack identity in `{operator_id}/{stack_id}` form (Phase A.5
+   * Q7 lock-in). The stack a principal calls "home" — bus
+   * envelopes signed on its behalf carry the stack's NKey in
+   * `signed_by[]`.
+   */
+  home_stack: string;
+  /**
+   * Role ids this principal holds. Each role is defined in
+   * `RoleDefinition` and grants a set of capabilities. A principal's
+   * effective capabilities are the union of its roles' capabilities.
+   */
+  role: string[];
+  /**
+   * Peer principals this principal trusts. Empty array is legal
+   * (no peer dispatches allowed). Symmetric with the existing
+   * `agent.trust[]` field on `cortex.yaml` (which Phase C.2 will
+   * migrate into the top-level `policy:` block).
+   */
+  trust: string[];
+}
+
+/**
+ * Sovereignty constraints on an intent. Mirrors the structure of
+ * `Envelope.sovereignty` from the myelin schema — the engine reads
+ * these fields when deciding whether a dispatch's classification +
+ * residency + frontier-model-acceptability are compatible with the
+ * principal's allowed scope (Phase D extends with per-network
+ * accept/deny rules).
+ */
+export interface IntentSovereignty {
+  classification: "local" | "federated" | "public";
+  data_residency: string;
+  max_hop: number;
+  frontier_ok: boolean;
+  model_class: "local-only" | "frontier" | "any";
+}
+
+/**
+ * The "what is being requested" half of a policy check. The engine
+ * matches an intent against the principal's effective capabilities
+ * + sovereignty constraints.
+ */
+export interface Intent {
+  /**
+   * The capability the principal wants to exercise. Matched
+   * against the union of capabilities granted by the principal's
+   * `role[]` via `RoleDefinition`.
+   */
+  capability: string;
+  /**
+   * Sovereignty constraints from the envelope being dispatched.
+   * The engine doesn't enforce sovereignty directly at C.1 — the
+   * field is part of the decision input so future C.4 audit
+   * envelopes carry it on the access record without an extra read.
+   */
+  sovereignty: IntentSovereignty;
+  /**
+   * Short, human-readable summary of the payload. Used only for
+   * audit envelopes (C.4) — the engine itself doesn't read it.
+   * Kept optional so callers without a useful summary handy don't
+   * have to fabricate one.
+   */
+  payload_summary?: string;
+}
+
+/**
+ * A role definition: id + the capabilities it grants. Comes from
+ * `cortex.yaml.policy.roles[]` post-C.2. The engine takes the
+ * principal's `role[]` ids, looks them up here, and unions the
+ * capabilities to compute the principal's effective grant set.
+ */
+export interface RoleDefinition {
+  /** Role id (e.g. `operator`, `code-reviewer`). */
+  id: string;
+  /**
+   * Capabilities this role grants. Convention follows Phase A.6
+   * capability ids: `<domain>.<entity>` (e.g. `code-review.typescript`).
+   * The engine matches `Intent.capability` against this list
+   * literally — no glob expansion at C.1; future PRs may add it.
+   */
+  capabilities: string[];
+}
+
+/**
+ * Discriminated rejection reason. Matches the shape Phase C.4 audit
+ * envelopes need (`system.access.denied` payload's `reason` field).
+ * Splitting the kinds at the discriminator now means audit
+ * envelopes don't have to re-parse a stringly-typed reason later.
+ */
+export type PolicyDenyReason =
+  | {
+      kind: "unknown_principal";
+      /** The principal id the caller tried to authorise. */
+      principal_id: string;
+    }
+  | {
+      kind: "insufficient_role";
+      /** The missing capability — diagnostic, not a hint to the caller. */
+      missing_capability: string;
+      principal_id: string;
+    }
+  | {
+      kind: "sovereignty_mismatch";
+      /** Human-readable description of the mismatch. */
+      reason: string;
+    };
+
+/**
+ * The output of `PolicyEngine.check`. Discriminated on `allow`:
+ *   - On accept, the engine surfaces the principal's full effective
+ *     capability set so downstream callers (substrate harness,
+ *     dispatch-handler) can prune tool/skill lists by what was
+ *     actually granted, not just by what the intent asked for.
+ *   - On reject, the engine surfaces the structured deny reason
+ *     for audit envelopes + operator logs.
+ */
+export type PolicyDecision =
+  | {
+      allow: true;
+      /**
+       * The principal's full effective capability set (union of
+       * all role grants). Includes the requested capability plus
+       * everything else the principal can do. Downstream callers
+       * use this to filter substrate-level allow lists.
+       */
+      capabilities: readonly string[];
+    }
+  | {
+      allow: false;
+      reason: PolicyDenyReason;
+    };


### PR DESCRIPTION
## Summary

Phase C.1 — the single authorization decision point cortex needed to replace its per-surface role-resolver duplication. C.2 will collapse Discord + Mattermost adapter role-resolvers into a single \`policy:\` block on cortex.yaml; C.3 wires the engine into the dispatch-handler; C.4 emits audit envelopes carrying this decision shape.

\`refs cortex#115\` (Phase C umbrella)
\`refs cortex#114\` (Phase B — closed; this is the next big lift)

## What lands

| Surface | What |
|---|---|
| \`src/common/policy/types.ts\` | \`Principal\`, \`Intent\`, \`IntentSovereignty\`, \`RoleDefinition\`, \`PolicyDecision\` (discriminated allow/deny), \`PolicyDenyReason\` (discriminated). |
| \`src/common/policy/engine.ts\` | \`PolicyEngine.check(principal, intent) → PolicyDecision\`. Lookup → effective-capabilities union → literal capability match → allow w/ full grant set or deny w/ structured reason. |
| \`src/common/policy/index.ts\` | Barrel re-export. |
| 8 tests | Happy path, unknown principal, capability miss, empty role list, multi-role union, unknown-role-id skip, sovereignty smoke, boot accessors. |

## What this slice deliberately doesn't do

- **No sovereignty enforcement** — \`Intent.sovereignty\` is part of the input shape (so C.4 audit envelopes carry it), but the engine doesn't reject on sovereignty mismatches yet. The \`sovereignty_mismatch\` discriminator variant exists for forward compat. Phase D extends.
- **No per-peer accept/deny** — Phase D adds \`policy.federated.networks[].accept_subjects[]\`.
- **No glob capability matches** — literal \`===\` only.
- **No cortex.yaml integration** — callers construct principals + roles in code; the schema flip is C.2.
- **No dispatch-handler integration** — that's C.3.

## Verification

- \`bunx tsc --noEmit\` — clean
- \`bun run lint:errors\` — clean (0 errors)
- \`bun test src/common/policy/__tests__/engine.test.ts\` — 8 pass / 0 fail / 16 expect()
- \`bun test src/common/ src/bus/ src/substrates/ src/__tests__/\` — 828 pass / 0 fail / 1652 expect()

## Phase C continuation

C.2 schema flip (the only schema flip in the IoAW roadmap) is the next slice. It adds the \`policy:\` block to \`CortexConfigSchema\` and migrates the per-adapter \`roles[]\` shape. Version bump to v2.0.0.