### PR TITLE
feat(config): IAW C.2a — policy: block schema + PolicyEngine factory (additive; refs cortex#115)

### DIFF
--- a/src/common/policy/__tests__/factory.test.ts
+++ b/src/common/policy/__tests__/factory.test.ts
@@ -111,7 +111,7 @@ describe("policyEngineFromConfig", () => {
 });
 
 describe("PolicySchema cross-validation", () => {
-  test("rejects dangling principal.role[] ref to undeclared role", () => {
+  test("rejects dangling principal.role[] ref to undeclared role (with per-offender path)", () => {
     expect(() =>
       parsePolicy({
         principals: [
@@ -125,7 +125,7 @@ describe("PolicySchema cross-validation", () => {
         ],
         roles: [{ id: "operator", capabilities: [] }],
       }),
-    ).toThrow(/principal\.role\[\] id must resolve/);
+    ).toThrow(/references undeclared role/);
   });
 
   test("rejects dangling principal.trust[] ref to undeclared principal", () => {
@@ -142,7 +142,75 @@ describe("PolicySchema cross-validation", () => {
         ],
         roles: [],
       }),
-    ).toThrow(/principal\.trust\[\] id must resolve/);
+    ).toThrow(/trusts undeclared peer/);
+  });
+
+  test("rejects duplicate principal id", () => {
+    expect(() =>
+      parsePolicy({
+        principals: [
+          {
+            id: "luna",
+            home_operator: "andreas",
+            home_stack: "andreas/research",
+            role: [],
+            trust: [],
+          },
+          {
+            id: "luna",
+            home_operator: "andreas",
+            home_stack: "andreas/research",
+            role: [],
+            trust: [],
+          },
+        ],
+        roles: [],
+      }),
+    ).toThrow(/principal id.*luna.*already declared/);
+  });
+
+  test("rejects duplicate role id", () => {
+    expect(() =>
+      parsePolicy({
+        principals: [],
+        roles: [
+          { id: "operator", capabilities: ["deploy.staging"] },
+          { id: "operator", capabilities: ["deploy.prod"] },
+        ],
+      }),
+    ).toThrow(/role id.*operator.*already declared/);
+  });
+
+  test("batches all dangling refs across multiple principals (not first-only)", () => {
+    try {
+      parsePolicy({
+        principals: [
+          {
+            id: "luna",
+            home_operator: "andreas",
+            home_stack: "andreas/research",
+            role: ["ghost-role-1"],
+            trust: [],
+          },
+          {
+            id: "echo",
+            home_operator: "andreas",
+            home_stack: "andreas/research",
+            role: ["ghost-role-2"],
+            trust: [],
+          },
+        ],
+        roles: [],
+      });
+      throw new Error("expected parse to throw");
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      // Both offenders surface in one parse pass (Echo cortex#219
+      // round 1 — superRefine batches issues rather than failing on
+      // the first one).
+      expect(message).toContain("ghost-role-1");
+      expect(message).toContain("ghost-role-2");
+    }
   });
 
   test("rejects malformed principal id grammar (digit prefix)", () => {

--- a/src/common/policy/__tests__/factory.test.ts
+++ b/src/common/policy/__tests__/factory.test.ts
@@ -8,9 +8,9 @@
  *   4. Round-trip: parsed `Policy` flows into the engine without
  *      mutation (id, role[], trust[] all preserved).
  *
- * Schema-side validation (dangling role/trust refs, malformed id
- * grammar) is covered in `cortex-config.test.ts` since the refines
- * live on `PolicySchema` there.
+ * Schema-side validation (dangling role/trust refs, duplicate ids,
+ * batched issues, malformed id grammar, empty defaults) is covered
+ * by the `PolicySchema cross-validation` describe block below.
  */
 
 import { describe, expect, test } from "bun:test";

--- a/src/common/policy/__tests__/factory.test.ts
+++ b/src/common/policy/__tests__/factory.test.ts
@@ -1,0 +1,170 @@
+/**
+ * IAW Phase C.2a (cortex#115) — `policyEngineFromConfig` factory tests.
+ *
+ * Coverage:
+ *   1. Undefined policy → undefined engine (no policy block).
+ *   2. Empty principals → undefined engine (no actor to authorise).
+ *   3. Populated policy → engine that allows expected combos.
+ *   4. Round-trip: parsed `Policy` flows into the engine without
+ *      mutation (id, role[], trust[] all preserved).
+ *
+ * Schema-side validation (dangling role/trust refs, malformed id
+ * grammar) is covered in `cortex-config.test.ts` since the refines
+ * live on `PolicySchema` there.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { policyEngineFromConfig } from "../factory";
+import { PolicyEngine } from "../engine";
+import { PolicySchema, type Policy } from "../../types/cortex-config";
+
+function parsePolicy(input: unknown): Policy {
+  return PolicySchema.parse(input);
+}
+
+describe("policyEngineFromConfig", () => {
+  test("returns undefined for undefined input (no policy block in cortex.yaml)", () => {
+    expect(policyEngineFromConfig(undefined)).toBeUndefined();
+  });
+
+  test("returns undefined for empty principals (no actor to authorise)", () => {
+    const policy = parsePolicy({
+      principals: [],
+      roles: [{ id: "operator", capabilities: ["deploy.staging"] }],
+    });
+    expect(policyEngineFromConfig(policy)).toBeUndefined();
+  });
+
+  test("builds a PolicyEngine when principals are declared", () => {
+    const policy = parsePolicy({
+      principals: [
+        {
+          id: "luna",
+          home_operator: "andreas",
+          home_stack: "andreas/research",
+          role: ["operator"],
+          trust: [],
+        },
+      ],
+      roles: [{ id: "operator", capabilities: ["code-review.typescript"] }],
+    });
+
+    const engine = policyEngineFromConfig(policy);
+    expect(engine).toBeInstanceOf(PolicyEngine);
+    expect(engine?.principalCount).toBe(1);
+    expect(engine?.roleCount).toBe(1);
+  });
+
+  test("round-trip: parsed Policy flows into engine and check() respects it", () => {
+    const policy = parsePolicy({
+      principals: [
+        {
+          id: "luna",
+          home_operator: "andreas",
+          home_stack: "andreas/research",
+          role: ["operator", "code-reviewer"],
+          trust: ["echo"],
+        },
+        {
+          id: "echo",
+          home_operator: "andreas",
+          home_stack: "andreas/research",
+          role: ["code-reviewer"],
+          trust: [],
+        },
+      ],
+      roles: [
+        { id: "operator", capabilities: ["deploy.staging"] },
+        { id: "code-reviewer", capabilities: ["code-review.typescript"] },
+      ],
+    });
+
+    const engine = policyEngineFromConfig(policy);
+    expect(engine).toBeDefined();
+    if (!engine) return;
+
+    // luna has operator + code-reviewer; check both capabilities.
+    const deployResult = engine.check("luna", {
+      capability: "deploy.staging",
+      sovereignty: {
+        classification: "local",
+        data_residency: "NZ",
+        max_hop: 0,
+        frontier_ok: false,
+        model_class: "any",
+      },
+    });
+    expect(deployResult.allow).toBe(true);
+
+    const reviewResult = engine.check("echo", {
+      capability: "code-review.typescript",
+      sovereignty: {
+        classification: "local",
+        data_residency: "NZ",
+        max_hop: 0,
+        frontier_ok: false,
+        model_class: "any",
+      },
+    });
+    expect(reviewResult.allow).toBe(true);
+  });
+});
+
+describe("PolicySchema cross-validation", () => {
+  test("rejects dangling principal.role[] ref to undeclared role", () => {
+    expect(() =>
+      parsePolicy({
+        principals: [
+          {
+            id: "luna",
+            home_operator: "andreas",
+            home_stack: "andreas/research",
+            role: ["nonexistent-role"],
+            trust: [],
+          },
+        ],
+        roles: [{ id: "operator", capabilities: [] }],
+      }),
+    ).toThrow(/principal\.role\[\] id must resolve/);
+  });
+
+  test("rejects dangling principal.trust[] ref to undeclared principal", () => {
+    expect(() =>
+      parsePolicy({
+        principals: [
+          {
+            id: "luna",
+            home_operator: "andreas",
+            home_stack: "andreas/research",
+            role: [],
+            trust: ["nonexistent-peer"],
+          },
+        ],
+        roles: [],
+      }),
+    ).toThrow(/principal\.trust\[\] id must resolve/);
+  });
+
+  test("rejects malformed principal id grammar (digit prefix)", () => {
+    expect(() =>
+      parsePolicy({
+        principals: [
+          {
+            id: "2bad-prefix",
+            home_operator: "andreas",
+            home_stack: "andreas/research",
+            role: [],
+            trust: [],
+          },
+        ],
+        roles: [],
+      }),
+    ).toThrow(/lowercase alphanumeric \+ hyphen/);
+  });
+
+  test("accepts empty defaults — no principals, no roles", () => {
+    const policy = parsePolicy({});
+    expect(policy.principals).toEqual([]);
+    expect(policy.roles).toEqual([]);
+  });
+});

--- a/src/common/policy/factory.ts
+++ b/src/common/policy/factory.ts
@@ -1,0 +1,60 @@
+/**
+ * IAW Phase C.2a (cortex#115) — PolicyEngine factory from CortexConfig.
+ *
+ * Builds a `PolicyEngine` from the optional `policy:` block on
+ * `CortexConfig`. Returns `undefined` when the block is absent OR
+ * empty (no principals declared) so callers can branch on engine
+ * presence without parsing the config shape themselves.
+ *
+ * Phase C.3 wires this factory into the cortex.ts boot path. C.2b
+ * (later) removes the per-adapter `roles[]` legacy shape and makes
+ * `policy:` the authoritative source — at which point this factory
+ * always returns an engine for cortex.yaml configs (BotConfig stays
+ * as legacy without a policy block, mapping to `undefined` here).
+ *
+ * Cross-references:
+ *   - `src/common/policy/engine.ts` — the engine this factory builds.
+ *   - `src/common/types/cortex-config.ts` — `PolicySchema` /
+ *     `Policy` / `PolicyPrincipal` / `PolicyRole`.
+ *   - `docs/design-internet-of-agentic-work.md` §cortex#107.
+ */
+
+import { PolicyEngine } from "./engine";
+import type { Policy } from "../types/cortex-config";
+
+/**
+ * Build a PolicyEngine from a parsed `policy:` block.
+ *
+ * - `undefined` policy → `undefined` engine (no policy declared in
+ *   cortex.yaml; callers fall back to per-adapter roles until C.2b
+ *   cuts that path).
+ * - Empty principals → `undefined` engine (a policy block with
+ *   only roles declared is structurally valid but has nothing to
+ *   authorise; treat as "no engine wanted").
+ * - Otherwise → engine with principals + roles bound.
+ *
+ * The Zod schema already validates cross-refs (every
+ * `principal.role[]` resolves to a declared role; every
+ * `principal.trust[]` resolves to a declared principal) — this
+ * factory assumes a validated `Policy` value and does no
+ * additional checking.
+ */
+export function policyEngineFromConfig(
+  policy: Policy | undefined,
+): PolicyEngine | undefined {
+  if (policy === undefined) return undefined;
+  if (policy.principals.length === 0) return undefined;
+  return new PolicyEngine({
+    principals: policy.principals.map((p) => ({
+      id: p.id,
+      home_operator: p.home_operator,
+      home_stack: p.home_stack,
+      role: p.role,
+      trust: p.trust,
+    })),
+    roles: policy.roles.map((r) => ({
+      id: r.id,
+      capabilities: r.capabilities,
+    })),
+  });
+}

--- a/src/common/policy/index.ts
+++ b/src/common/policy/index.ts
@@ -17,3 +17,4 @@ export type {
   Principal,
   RoleDefinition,
 } from "./types";
+export { policyEngineFromConfig } from "./factory";

--- a/src/common/types/cortex-config.ts
+++ b/src/common/types/cortex-config.ts
@@ -844,6 +844,159 @@ export const PathsConfigSchema = z.object({
 export type PathsConfig = z.infer<typeof PathsConfigSchema>;
 
 // =============================================================================
+// PolicySchema — IAW Phase C.2a (refs cortex#115)
+// =============================================================================
+
+/**
+ * A principal — identity-bearing actor the PolicyEngine authorises.
+ * Top-level on `cortex.yaml.policy.principals[]` post-C.2a; the
+ * PolicyEngine consumes the parsed shape via the
+ * `policyEngineFromConfig` factory.
+ *
+ * Mirrors the `Principal` type from `src/common/policy/types.ts`
+ * (C.1); kept as a Zod schema here so config parse validation is
+ * authoritative.
+ */
+export const PolicyPrincipalSchema = z.object({
+  /**
+   * Stable principal id. Letter-prefix lowercase alphanumeric +
+   * hyphen — matches the agent id grammar tightened in cortex#149
+   * (AgentSchema.id letter-prefix trilogy). A verified
+   * `signed_by[].principal` field with `did:mf:<name>` resolves to
+   * this id by stripping the prefix.
+   */
+  id: z.string().regex(
+    /^[a-z][a-z0-9-]*$/,
+    "principal id must be lowercase alphanumeric + hyphen, starting with a letter (e.g. 'luna', 'echo')",
+  ),
+  /**
+   * Operator that owns this principal. Same letter-prefix
+   * grammar — `OperatorSchema.id` enforces it at the operator
+   * level and we mirror here so a parsed principal can't carry
+   * a malformed home_operator that downstream code would have
+   * to defend against.
+   */
+  home_operator: z.string().regex(
+    /^[a-z][a-z0-9-]*$/,
+    "principal.home_operator must match the operator id grammar (lowercase alphanumeric + hyphen, starting with a letter)",
+  ),
+  /**
+   * Stack identity in `{operator_id}/{stack_id}` form — same shape
+   * as `StackConfigSchema.id` (Phase A.5).
+   */
+  home_stack: z.string().regex(
+    /^[a-z][a-z0-9_-]*\/[a-z][a-z0-9_-]*$/,
+    "principal.home_stack must match {operator_id}/{stack_id} format",
+  ),
+  /**
+   * Stack signing NKey public key. Optional — a principal without
+   * `nkey_pub` cannot be the signer of an inbound envelope (B.1c
+   * cryptoVerify rejects with `principal_has_no_nkey_pub`) but
+   * can still be authorised for local-only operations.
+   * Same regex as `StackConfigSchema.nkey_pub` (56-char U-prefixed
+   * base32).
+   */
+  nkey_pub: z.string().regex(
+    /^U[A-Z2-7]{55}$/,
+    "principal.nkey_pub must be a base32 NKey public key (U-prefixed, 56 chars total)",
+  ).optional(),
+  /**
+   * Role ids the principal holds. Each id must resolve to a
+   * `RoleDefinition` in the same policy block; cross-validation
+   * via `.refine()` below catches dangling refs at parse time.
+   */
+  role: z.array(
+    z.string().regex(
+      /^[a-z][a-z0-9-]*$/,
+      "principal.role[] entries must be role ids — lowercase alphanumeric + hyphen, starting with a letter",
+    ),
+  ).default([]),
+  /**
+   * Peer principal ids this principal trusts. Cross-validation
+   * via `.refine()` ensures every entry resolves to a known
+   * principal in the same block.
+   */
+  trust: z.array(
+    z.string().regex(
+      /^[a-z][a-z0-9-]*$/,
+      "principal.trust[] entries must be principal ids — same grammar as principal.id",
+    ),
+  ).default([]),
+});
+
+export type PolicyPrincipal = z.infer<typeof PolicyPrincipalSchema>;
+
+/**
+ * A role definition. Roles bind capability sets to a name that
+ * principals reference. The C.1 PolicyEngine computes a principal's
+ * effective capabilities as the union of all referenced roles'
+ * capabilities.
+ */
+export const PolicyRoleSchema = z.object({
+  id: z.string().regex(
+    /^[a-z][a-z0-9-]*$/,
+    "role id must be lowercase alphanumeric + hyphen, starting with a letter (e.g. 'operator', 'code-reviewer')",
+  ),
+  /**
+   * Capability ids granted by this role. Convention follows
+   * Phase A.6 capability ids — `<domain>.<entity>` dotted
+   * lowercase. The C.1 engine matches `Intent.capability`
+   * literally against this list; future PRs may add glob
+   * expansion.
+   */
+  capabilities: z.array(z.string().min(1)).default([]),
+});
+
+export type PolicyRole = z.infer<typeof PolicyRoleSchema>;
+
+/**
+ * Top-level policy block — `cortex.yaml.policy`. Replaces per-
+ * adapter `roles[]` post-C.2b (the cutover). At C.2a both shapes
+ * coexist; this block parses optionally and the PolicyEngine
+ * factory below builds an engine when the block is present and
+ * non-empty.
+ *
+ * Cross-validation at C.2a:
+ *   - Every `principal.role[]` id resolves to a declared role.
+ *   - Every `principal.trust[]` id resolves to a declared principal.
+ * Dangling refs fail at parse time with a clear pointer at the
+ * offending principal.
+ *
+ * Phase D extends with `policy.federated.networks[]` per the
+ * Q4 lock-in (`docs/design-internet-of-agentic-work.md` §3.4).
+ */
+export const PolicySchema = z.object({
+  principals: z.array(PolicyPrincipalSchema).default([]),
+  roles: z.array(PolicyRoleSchema).default([]),
+}).refine(
+  (policy) => {
+    const knownRoles = new Set(policy.roles.map((r) => r.id));
+    return policy.principals.every((p) =>
+      p.role.every((r) => knownRoles.has(r)),
+    );
+  },
+  {
+    message:
+      "every principal.role[] id must resolve to a declared role in policy.roles[]",
+    path: ["principals"],
+  },
+).refine(
+  (policy) => {
+    const knownPrincipals = new Set(policy.principals.map((p) => p.id));
+    return policy.principals.every((p) =>
+      p.trust.every((t) => knownPrincipals.has(t)),
+    );
+  },
+  {
+    message:
+      "every principal.trust[] id must resolve to a declared principal in policy.principals[]",
+    path: ["principals"],
+  },
+);
+
+export type Policy = z.infer<typeof PolicySchema>;
+
+// =============================================================================
 // CortexConfig — the top-level schema
 // =============================================================================
 
@@ -933,6 +1086,23 @@ export const CortexConfigSchema = z.object({
       "legacy `trustedAgentBots:` is not supported — express peer trust via " +
       "`agents[].trust: [<agent-id>, ...]` on each agent (architecture §9.3).",
   }).optional(),
+
+  /**
+   * IAW Phase C.2a (refs cortex#115) — top-level policy block. The
+   * single principal + role registry that the PolicyEngine consumes.
+   * Optional at C.2a (additive); C.2b removes the per-adapter
+   * `roles[]` legacy shape and makes `policy:` the authoritative
+   * source. Until C.2b lands, both shapes coexist and operators
+   * MAY declare `policy:` ahead of the cutover to validate their
+   * principal model without waiting on the full schema flip.
+   *
+   * Behaviour today (C.2a): schema-only. The dispatch-handler still
+   * reads per-adapter roles for authorisation; C.3 wires PolicyEngine
+   * into the dispatch path. Declaring `policy:` in cortex.yaml is
+   * forward-compatible — parses cleanly and is available via the
+   * `policyEngineFromConfig` factory for callers that opt in.
+   */
+  policy: PolicySchema.optional(),
 
   /** First-class agents — the canonical list. */
   agents: z.array(AgentSchema).min(1, "at least one agent is required"),

--- a/src/common/types/cortex-config.ts
+++ b/src/common/types/cortex-config.ts
@@ -889,10 +889,15 @@ export const PolicyPrincipalSchema = z.object({
     "principal.home_stack must match {operator_id}/{stack_id} format",
   ),
   /**
-   * Stack signing NKey public key. Optional — a principal without
-   * `nkey_pub` cannot be the signer of an inbound envelope (B.1c
-   * cryptoVerify rejects with `principal_has_no_nkey_pub`) but
-   * can still be authorised for local-only operations.
+   * Stack signing NKey public key. **Declared at C.2a for forward
+   * compat — not yet consumed by any verification path.** B.1c
+   * cryptoVerify currently reads `agents[].nkey_pub` from the
+   * agent registry (`src/bus/verify-signed-by-chain.ts`); C.2b/C.3
+   * will migrate the signature-verification lookup to
+   * `policy.principals[].nkey_pub` and retire the agent-side
+   * field. Until then, declaring `nkey_pub` on a principal parses
+   * cleanly but nothing gates on it (Echo cortex#219 round 1).
+   *
    * Same regex as `StackConfigSchema.nkey_pub` (56-char U-prefixed
    * base32).
    */
@@ -968,31 +973,72 @@ export type PolicyRole = z.infer<typeof PolicyRoleSchema>;
 export const PolicySchema = z.object({
   principals: z.array(PolicyPrincipalSchema).default([]),
   roles: z.array(PolicyRoleSchema).default([]),
-}).refine(
-  (policy) => {
-    const knownRoles = new Set(policy.roles.map((r) => r.id));
-    return policy.principals.every((p) =>
-      p.role.every((r) => knownRoles.has(r)),
-    );
-  },
-  {
-    message:
-      "every principal.role[] id must resolve to a declared role in policy.roles[]",
-    path: ["principals"],
-  },
-).refine(
-  (policy) => {
-    const knownPrincipals = new Set(policy.principals.map((p) => p.id));
-    return policy.principals.every((p) =>
-      p.trust.every((t) => knownPrincipals.has(t)),
-    );
-  },
-  {
-    message:
-      "every principal.trust[] id must resolve to a declared principal in policy.principals[]",
-    path: ["principals"],
-  },
-);
+}).superRefine((policy, ctx) => {
+  // Per-offender path emission so a YAML-aware loader can render
+  // the error inline at the bad token (Echo cortex#219 round 1).
+  // Capability-catalog precedent: `superRefine` with batch
+  // `ctx.addIssue` per offender at the same nesting depth.
+
+  // Uniqueness — principals[].id.
+  const seenPrincipal = new Map<string, number>();
+  policy.principals.forEach((p, i) => {
+    const dupAt = seenPrincipal.get(p.id);
+    if (dupAt !== undefined) {
+      ctx.addIssue({
+        code: "custom",
+        message: `principal id "${p.id}" already declared at principals[${dupAt}]`,
+        path: ["principals", i, "id"],
+      });
+    } else {
+      seenPrincipal.set(p.id, i);
+    }
+  });
+
+  // Uniqueness — roles[].id.
+  const seenRole = new Map<string, number>();
+  policy.roles.forEach((r, i) => {
+    const dupAt = seenRole.get(r.id);
+    if (dupAt !== undefined) {
+      ctx.addIssue({
+        code: "custom",
+        message: `role id "${r.id}" already declared at roles[${dupAt}]`,
+        path: ["roles", i, "id"],
+      });
+    } else {
+      seenRole.set(r.id, i);
+    }
+  });
+
+  // Cross-ref: every principal.role[] resolves to a declared role.
+  // Batch-emit (not first-failure) so an operator with multiple
+  // dangling refs sees all of them on one parse pass.
+  const knownRoles = new Set(policy.roles.map((r) => r.id));
+  policy.principals.forEach((p, principalIdx) => {
+    p.role.forEach((roleId, roleIdx) => {
+      if (!knownRoles.has(roleId)) {
+        ctx.addIssue({
+          code: "custom",
+          message: `principal "${p.id}" references undeclared role "${roleId}" — declare it in policy.roles[]`,
+          path: ["principals", principalIdx, "role", roleIdx],
+        });
+      }
+    });
+  });
+
+  // Cross-ref: every principal.trust[] resolves to a declared principal.
+  const knownPrincipals = new Set(policy.principals.map((p) => p.id));
+  policy.principals.forEach((p, principalIdx) => {
+    p.trust.forEach((peerId, trustIdx) => {
+      if (!knownPrincipals.has(peerId)) {
+        ctx.addIssue({
+          code: "custom",
+          message: `principal "${p.id}" trusts undeclared peer "${peerId}" — declare it in policy.principals[]`,
+          path: ["principals", principalIdx, "trust", trustIdx],
+        });
+      }
+    });
+  });
+});
 
 export type Policy = z.infer<typeof PolicySchema>;
 


### PR DESCRIPTION
## Summary

Phase C.2 sub-slice — **additive** schema for the \`policy:\` block on cortex.yaml + factory that builds a \`PolicyEngine\` (cortex#218) from a parsed config. No legacy shape removed yet; that's C.2b (the cutover). Operators MAY declare \`policy:\` ahead of C.2b.

\`refs cortex#115\`

## What lands

| Surface | What |
|---|---|
| \`PolicyPrincipalSchema\` | id (letter-prefix grammar), home_operator, home_stack ({op}/{stack}), optional nkey_pub (56-char U-prefixed), role[] ids, trust[] ids. |
| \`PolicyRoleSchema\` | id, capabilities[]. |
| \`PolicySchema\` | { principals[], roles[] } with cross-refines: every principal.role[] resolves to a declared role; every principal.trust[] resolves to a declared principal. |
| \`CortexConfigSchema.policy: PolicySchema.optional()\` | Additive — back-compat with all current cortex.yaml configs. |
| \`policyEngineFromConfig(policy?)\` | Returns undefined for missing or empty-principals policy; builds engine otherwise. |
| 8 new tests | Factory + schema cross-refine coverage (dangling role/trust refs, malformed id grammar, empty defaults). |

## Phase C continuation (split rationale)

C.2 is the only schema flip in the IoAW roadmap and pairs with a v2.0.0 bump. Splitting it into 3 sub-PRs keeps each reviewable:

- **C.2a (this PR)** — additive policy: schema + engine factory. No cutover.
- **C.2b (next)** — remove per-adapter \`roles[]\` from PresenceSchema. Bump to v2.0.0.
- **C.2c** — \`migrate-config\` CLI extension to lift legacy bot.yaml into the new \`policy:\` shape.
- **C.3** — wire \`policyEngineFromConfig\` into \`cortex.ts\` + call \`PolicyEngine.check\` from \`dispatch-handler\`.
- **C.4** — \`system.access.{allowed,denied}\` audit envelopes.

## Verification

- \`bunx tsc --noEmit\` — clean
- \`bun run lint:errors\` — clean (0 errors)
- \`bun test src/common/policy/\` — 16 pass / 0 fail / 29 expect()
- \`bun test src/common/ src/bus/ src/substrates/ src/__tests__/\` — 836 pass / 0 fail / 1665 expect()