### PR TITLE
feat(config): IAW D.1 — policy.federated.networks[] schema (additive; refs cortex#116)

### DIFF
--- a/src/common/policy/__tests__/factory.test.ts
+++ b/src/common/policy/__tests__/factory.test.ts
@@ -236,3 +236,269 @@ describe("PolicySchema cross-validation", () => {
     expect(policy.roles).toEqual([]);
   });
 });
+
+// ---------------------------------------------------------------------------
+// IAW Phase D.1 (cortex#116) — federated network schema
+// ---------------------------------------------------------------------------
+
+const PEER_PUBKEY_A = "U" + "A".repeat(55);
+const PEER_PUBKEY_B = "U" + "B".repeat(55);
+const PEER_PUBKEY_C = "U" + "C".repeat(55);
+
+describe("PolicyFederatedSchema", () => {
+  test("accepts a fully-populated federated network", () => {
+    const policy = PolicySchema.parse({
+      federated: {
+        networks: [
+          {
+            id: "research-collab",
+            leaf_node: "nats-leaf-research",
+            peers: [
+              {
+                operator_id: "jcfischer",
+                stack_id: "jcfischer/sage-host",
+                operator_pubkey: PEER_PUBKEY_A,
+              },
+            ],
+            accept_subjects: ["federated.research-collab.tasks.code-review.*"],
+            deny_subjects: ["federated.research-collab.tasks.*.private.*"],
+            announce_capabilities: ["code-review.typescript", "security-scan.web"],
+            max_hop: 1,
+          },
+        ],
+      },
+    });
+    expect(policy.federated?.networks).toHaveLength(1);
+    expect(policy.federated?.networks[0]?.peers).toHaveLength(1);
+  });
+
+  test("federated block is optional — absence parses cleanly", () => {
+    const policy = PolicySchema.parse({});
+    expect(policy.federated).toBeUndefined();
+  });
+
+  test("networks[] defaults to empty when block present", () => {
+    const policy = PolicySchema.parse({ federated: {} });
+    expect(policy.federated?.networks).toEqual([]);
+  });
+
+  test("max_hop must be a non-negative integer", () => {
+    expect(() =>
+      PolicySchema.parse({
+        federated: {
+          networks: [{
+            id: "n", leaf_node: "leaf", peers: [],
+            accept_subjects: [], deny_subjects: [],
+            announce_capabilities: [], max_hop: -1,
+          }],
+        },
+      }),
+    ).toThrow();
+  });
+
+  test("rejects malformed network id grammar (digit prefix)", () => {
+    expect(() =>
+      PolicySchema.parse({
+        federated: {
+          networks: [{
+            id: "1bad", leaf_node: "leaf", peers: [],
+            accept_subjects: [], deny_subjects: [],
+            announce_capabilities: [], max_hop: 0,
+          }],
+        },
+      }),
+    ).toThrow(/network id must be lowercase alphanumeric/);
+  });
+
+  test("rejects malformed accept_subjects[] entry (uppercase segment)", () => {
+    expect(() =>
+      PolicySchema.parse({
+        federated: {
+          networks: [{
+            id: "n", leaf_node: "leaf", peers: [],
+            accept_subjects: ["federated.BAD-UPPERCASE.tasks.>"],
+            deny_subjects: [],
+            announce_capabilities: [], max_hop: 0,
+          }],
+        },
+      }),
+    ).toThrow(/accept_subjects/);
+  });
+
+  test("rejects malformed announce_capabilities[] (single segment)", () => {
+    expect(() =>
+      PolicySchema.parse({
+        federated: {
+          networks: [{
+            id: "n", leaf_node: "leaf", peers: [],
+            accept_subjects: [], deny_subjects: [],
+            announce_capabilities: ["bare-capability-no-dot"],
+            max_hop: 0,
+          }],
+        },
+      }),
+    ).toThrow(/<domain>\.<entity>/);
+  });
+
+  test("rejects peer.operator_pubkey that isn't a U-prefixed NKey", () => {
+    expect(() =>
+      PolicySchema.parse({
+        federated: {
+          networks: [{
+            id: "n", leaf_node: "leaf",
+            peers: [{
+              operator_id: "alpha", stack_id: "alpha/main",
+              operator_pubkey: "not-an-nkey",
+            }],
+            accept_subjects: [], deny_subjects: [],
+            announce_capabilities: [], max_hop: 0,
+          }],
+        },
+      }),
+    ).toThrow(/operator_pubkey must be a base32 NKey/);
+  });
+});
+
+describe("PolicyFederatedSchema cross-validation", () => {
+  test("rejects duplicate network id", () => {
+    expect(() =>
+      PolicySchema.parse({
+        federated: {
+          networks: [
+            { id: "n", leaf_node: "leaf", peers: [], accept_subjects: [], deny_subjects: [], announce_capabilities: [], max_hop: 0 },
+            { id: "n", leaf_node: "leaf", peers: [], accept_subjects: [], deny_subjects: [], announce_capabilities: [], max_hop: 0 },
+          ],
+        },
+      }),
+    ).toThrow(/network id.*n.*already declared/);
+  });
+
+  test("rejects peer.stack_id whose prefix doesn't match peer.operator_id", () => {
+    expect(() =>
+      PolicySchema.parse({
+        federated: {
+          networks: [{
+            id: "n", leaf_node: "leaf",
+            peers: [{
+              operator_id: "jcfischer",
+              // Drifted prefix — would let an operator forge attribution.
+              stack_id: "evil-actor/sage-host",
+              operator_pubkey: PEER_PUBKEY_A,
+            }],
+            accept_subjects: [], deny_subjects: [],
+            announce_capabilities: [], max_hop: 0,
+          }],
+        },
+      }),
+    ).toThrow(/must start with peer\.operator_id/);
+  });
+
+  test("rejects duplicate peer.stack_id within a network", () => {
+    expect(() =>
+      PolicySchema.parse({
+        federated: {
+          networks: [{
+            id: "n", leaf_node: "leaf",
+            peers: [
+              { operator_id: "alpha", stack_id: "alpha/main", operator_pubkey: PEER_PUBKEY_A },
+              { operator_id: "alpha", stack_id: "alpha/main", operator_pubkey: PEER_PUBKEY_B },
+            ],
+            accept_subjects: [], deny_subjects: [],
+            announce_capabilities: [], max_hop: 0,
+          }],
+        },
+      }),
+    ).toThrow(/peer\.stack_id.*already declared/);
+  });
+
+  test("rejects duplicate peer.operator_pubkey within a network (paste error)", () => {
+    expect(() =>
+      PolicySchema.parse({
+        federated: {
+          networks: [{
+            id: "n", leaf_node: "leaf",
+            peers: [
+              { operator_id: "alpha", stack_id: "alpha/main", operator_pubkey: PEER_PUBKEY_A },
+              { operator_id: "beta", stack_id: "beta/main", operator_pubkey: PEER_PUBKEY_A },
+            ],
+            accept_subjects: [], deny_subjects: [],
+            announce_capabilities: [], max_hop: 0,
+          }],
+        },
+      }),
+    ).toThrow(/operator_pubkey already declared.*pubkey collision/);
+  });
+
+  test("same operator_pubkey is allowed across DIFFERENT networks (cross-network dedup not enforced)", () => {
+    // Per-network uniqueness only — a single operator's stack may
+    // legitimately participate in multiple networks with the same
+    // pubkey. The schema doesn't reject this.
+    const policy = PolicySchema.parse({
+      federated: {
+        networks: [
+          {
+            id: "net-a", leaf_node: "leaf",
+            peers: [{ operator_id: "alpha", stack_id: "alpha/main", operator_pubkey: PEER_PUBKEY_A }],
+            accept_subjects: [], deny_subjects: [],
+            announce_capabilities: [], max_hop: 0,
+          },
+          {
+            id: "net-b", leaf_node: "leaf",
+            peers: [{ operator_id: "alpha", stack_id: "alpha/main", operator_pubkey: PEER_PUBKEY_A }],
+            accept_subjects: [], deny_subjects: [],
+            announce_capabilities: [], max_hop: 0,
+          },
+        ],
+      },
+    });
+    expect(policy.federated?.networks).toHaveLength(2);
+  });
+
+  test("batches multiple federation issues across networks", () => {
+    try {
+      PolicySchema.parse({
+        federated: {
+          networks: [
+            { id: "dup", leaf_node: "leaf", peers: [], accept_subjects: [], deny_subjects: [], announce_capabilities: [], max_hop: 0 },
+            { id: "dup", leaf_node: "leaf", peers: [], accept_subjects: [], deny_subjects: [], announce_capabilities: [], max_hop: 0 },
+            {
+              id: "other", leaf_node: "leaf",
+              peers: [
+                { operator_id: "alpha", stack_id: "wrong-prefix/main", operator_pubkey: PEER_PUBKEY_A },
+              ],
+              accept_subjects: [], deny_subjects: [],
+              announce_capabilities: [], max_hop: 0,
+            },
+          ],
+        },
+      });
+      throw new Error("expected parse to throw");
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      expect(message).toContain("dup");
+      expect(message).toContain("must start with peer.operator_id");
+    }
+  });
+
+  test("federated block plus principals + roles parses cleanly together", () => {
+    const policy = PolicySchema.parse({
+      principals: [{
+        id: "luna", home_operator: "andreas", home_stack: "andreas/research",
+        role: ["operator"], trust: [],
+      }],
+      roles: [{ id: "operator", capabilities: ["deploy.staging"] }],
+      federated: {
+        networks: [{
+          id: "research-collab", leaf_node: "leaf",
+          peers: [{ operator_id: "jcfischer", stack_id: "jcfischer/sage-host", operator_pubkey: PEER_PUBKEY_C }],
+          accept_subjects: ["federated.research-collab.>"],
+          deny_subjects: [],
+          announce_capabilities: ["code-review.typescript"],
+          max_hop: 1,
+        }],
+      },
+    });
+    expect(policy.principals).toHaveLength(1);
+    expect(policy.federated?.networks).toHaveLength(1);
+  });
+});

--- a/src/common/policy/__tests__/factory.test.ts
+++ b/src/common/policy/__tests__/factory.test.ts
@@ -480,6 +480,55 @@ describe("PolicyFederatedSchema cross-validation", () => {
     }
   });
 
+  test("rejects accept_subjects[] entry not prefixed with federated.{network.id}. (Echo cortex#223 round 1)", () => {
+    expect(() =>
+      PolicySchema.parse({
+        federated: {
+          networks: [{
+            id: "research-collab", leaf_node: "leaf", peers: [],
+            // Out-of-scope subject — surface-router would have to
+            // defend at runtime. Schema rejects.
+            accept_subjects: ["internal.private.>"],
+            deny_subjects: [],
+            announce_capabilities: [], max_hop: 0,
+          }],
+        },
+      }),
+    ).toThrow(/must begin with.*federated.*research-collab/);
+  });
+
+  test("rejects deny_subjects[] entry not prefixed with federated.{network.id}. (Echo cortex#223 round 1)", () => {
+    expect(() =>
+      PolicySchema.parse({
+        federated: {
+          networks: [{
+            id: "research-collab", leaf_node: "leaf", peers: [],
+            accept_subjects: ["federated.research-collab.>"],
+            deny_subjects: ["local.metafactory.>"],
+            announce_capabilities: [], max_hop: 0,
+          }],
+        },
+      }),
+    ).toThrow(/must begin with.*federated.*research-collab/);
+  });
+
+  test("accepts subject patterns within the network's own federated.{id}. scope", () => {
+    const policy = PolicySchema.parse({
+      federated: {
+        networks: [{
+          id: "research-collab", leaf_node: "leaf", peers: [],
+          accept_subjects: [
+            "federated.research-collab.tasks.code-review.*",
+            "federated.research-collab.>",
+          ],
+          deny_subjects: ["federated.research-collab.tasks.*.private.*"],
+          announce_capabilities: [], max_hop: 0,
+        }],
+      },
+    });
+    expect(policy.federated?.networks[0]?.accept_subjects).toHaveLength(2);
+  });
+
   test("federated block plus principals + roles parses cleanly together", () => {
     const policy = PolicySchema.parse({
       principals: [{

--- a/src/common/types/cortex-config.ts
+++ b/src/common/types/cortex-config.ts
@@ -970,9 +970,177 @@ export type PolicyRole = z.infer<typeof PolicyRoleSchema>;
  * Phase D extends with `policy.federated.networks[]` per the
  * Q4 lock-in (`docs/design-internet-of-agentic-work.md` §3.4).
  */
+/**
+ * A single peer in a federation network — IAW Phase D.1 (cortex#116).
+ *
+ * Every peer is a remote operator's stack-NKey identity that this
+ * operator's cortex will accept federated traffic from. The triple
+ * `{operator_id, stack_id, operator_pubkey}` is the verifiable
+ * attribution slot: incoming federated envelopes carry
+ * `signed_by[].principal = did:mf:<stack_id>` + a signature that
+ * verifies against `operator_pubkey`. Phase D verification wiring
+ * lands in D.2/D.3; the schema lands first so operators can declare
+ * their federation topology before the verification path is live.
+ */
+export const PolicyFederatedPeerSchema = z.object({
+  /**
+   * Peer operator id — same letter-prefix grammar as `OperatorSchema.id`.
+   * Distinct from the operator's local id; the local operator's id
+   * doesn't appear in `federated.networks[].peers[]` (the local
+   * operator IS the consumer of the peer list).
+   */
+  operator_id: z.string().regex(
+    /^[a-z][a-z0-9-]*$/,
+    "peer.operator_id must match the operator id grammar (lowercase alphanumeric + hyphen, starting with a letter)",
+  ),
+  /**
+   * Peer stack id in `{operator_id}/{stack_id}` form — same shape as
+   * `PolicyPrincipalSchema.home_stack`. The `operator_id` prefix MUST
+   * match the sibling `operator_id` field (cross-validated below);
+   * the redundancy is deliberate so operators can read the file and
+   * see "yes, this is jcfischer's sage-host stack" without splitting
+   * the identity across fields.
+   */
+  stack_id: z.string().regex(
+    /^[a-z][a-z0-9_-]*\/[a-z][a-z0-9_-]*$/,
+    "peer.stack_id must match {operator_id}/{stack_id} format",
+  ),
+  /**
+   * Peer operator's NKey public key — same 56-char U-prefixed base32
+   * grammar as every other NKey on the schema (StackConfigSchema,
+   * PolicyPrincipalSchema). Phase D.4 swaps this static declaration
+   * for a registry-resolved lookup; until then, operators paste the
+   * peer's pubkey directly into cortex.yaml.
+   */
+  operator_pubkey: z.string().regex(
+    /^U[A-Z2-7]{55}$/,
+    "peer.operator_pubkey must be a base32 NKey public key (U-prefixed, 56 chars total)",
+  ),
+});
+
+export type PolicyFederatedPeer = z.infer<typeof PolicyFederatedPeerSchema>;
+
+/**
+ * NATS subject pattern with `*` / `>` wildcards. Used for
+ * `accept_subjects[]` and `deny_subjects[]` lists on a federated
+ * network. Format: dotted lowercase-alphanumeric segments,
+ * optional `*` (single-segment wildcard) or `>` (trailing
+ * multi-segment wildcard, only as the final segment).
+ *
+ * Conservative grammar — matches what cortex actually produces +
+ * what the surface-router's `adapterMatches()` will gate against
+ * in D.2. Operators can always relax via additional patterns
+ * rather than building a regex string.
+ */
+const NATS_SUBJECT_PATTERN_RE = /^([a-z][a-z0-9_-]*|\*)(\.([a-z][a-z0-9_-]*|\*))*(\.>)?$/;
+
+/**
+ * A single federation network — IAW Phase D.1 (cortex#116).
+ *
+ * Networks are the unit of federation policy in cortex per Q4
+ * lock-in: a cortex instance participates in N networks; each
+ * network has its own peer roster, accept/deny lists, and hop
+ * budget. Multi-link transport (one MyelinRuntime per network)
+ * lands in Phase E; Phase D operates one network's leaf-node at a
+ * time, named via `leaf_node`.
+ */
+export const PolicyFederatedNetworkSchema = z.object({
+  /**
+   * Network id — same letter-prefix grammar as principal/role ids.
+   * Appears in NATS subject prefixes
+   * (`federated.{network_id}.<...>`); kept short and
+   * dash-separated for readability on the wire.
+   */
+  id: z.string().regex(
+    /^[a-z][a-z0-9-]*$/,
+    "network id must be lowercase alphanumeric + hyphen, starting with a letter (e.g. 'research-collab')",
+  ),
+  /**
+   * Reference to a named NATS leaf-node connection. In Phase D only
+   * one leaf-node is operable concurrently; the `leaf_node` field
+   * exists for forward compat with Phase E's multi-link
+   * MyelinRuntime. Field grammar matches the agent/network id
+   * pattern (letter-prefix lowercase alphanumeric + hyphen).
+   */
+  leaf_node: z.string().regex(
+    /^[a-z][a-z0-9-]*$/,
+    "network.leaf_node must match the connection id grammar (lowercase alphanumeric + hyphen, starting with a letter)",
+  ),
+  /**
+   * Peer operators reachable on this network. Each entry declares
+   * one peer stack's NKey identity. The list is the trust closure
+   * for the network: a `signed_by[].principal` not in this list
+   * fails verification on the inbound side.
+   */
+  peers: z.array(PolicyFederatedPeerSchema).default([]),
+  /**
+   * Accept-list of NATS subject patterns. An inbound `federated.*`
+   * envelope is dispatched only if its subject matches at least one
+   * entry here (and no entry in `deny_subjects[]`). Empty means
+   * "accept nothing" — operators must explicitly enumerate accepted
+   * subject patterns. D.2 wires the surface-router gate.
+   */
+  accept_subjects: z.array(
+    z.string().regex(
+      NATS_SUBJECT_PATTERN_RE,
+      "accept_subjects[] entries must be NATS subject patterns (dotted lowercase + optional * / > wildcards)",
+    ),
+  ).default([]),
+  /**
+   * Deny-list of NATS subject patterns. A match here overrides
+   * `accept_subjects[]` and rejects the inbound envelope with
+   * `peer_deny_list` (D.2 audit). Useful for "accept all
+   * code-review.* except *.private.*" patterns.
+   */
+  deny_subjects: z.array(
+    z.string().regex(
+      NATS_SUBJECT_PATTERN_RE,
+      "deny_subjects[] entries must be NATS subject patterns (dotted lowercase + optional * / > wildcards)",
+    ),
+  ).default([]),
+  /**
+   * Capability ids this stack announces on the network. Mirrors the
+   * Phase A.6 capability registry — the network publishes these on
+   * `system.capability.announced.<network_id>` so peers can route
+   * tasks by capability without having to know each operator's
+   * agent inventory. Empty = "announce nothing" (a silent
+   * participant — consumes but doesn't offer work).
+   */
+  announce_capabilities: z.array(
+    z.string().regex(
+      /^[a-z][a-z0-9-]*(\.[a-z][a-z0-9-]*)+$/,
+      "announce_capabilities[] entries must follow the <domain>.<entity> capability id grammar (e.g. 'code-review.typescript')",
+    ),
+  ).default([]),
+  /**
+   * Maximum chain length on inbound envelopes. `signed_by[].length`
+   * over this value rejects with `max_hop_exceeded` (D.2.3). Zero
+   * means "no hops" — accept only directly-signed envelopes, no
+   * relay. Hop budgets bound the federation graph and prevent
+   * unbounded forwarding loops.
+   */
+  max_hop: z.number().int().min(0),
+});
+
+export type PolicyFederatedNetwork = z.infer<typeof PolicyFederatedNetworkSchema>;
+
+/**
+ * `policy.federated` block — IAW Phase D.1 (cortex#116). Optional
+ * on cortex.yaml; absence means "no federation declared" and the
+ * surface-router treats inbound `federated.*` envelopes as
+ * unrecognised (rejected at the validator layer). When present,
+ * carries the operator's network roster.
+ */
+export const PolicyFederatedSchema = z.object({
+  networks: z.array(PolicyFederatedNetworkSchema).default([]),
+});
+
+export type PolicyFederated = z.infer<typeof PolicyFederatedSchema>;
+
 export const PolicySchema = z.object({
   principals: z.array(PolicyPrincipalSchema).default([]),
   roles: z.array(PolicyRoleSchema).default([]),
+  federated: PolicyFederatedSchema.optional(),
 }).superRefine((policy, ctx) => {
   // Per-offender path emission so a YAML-aware loader can render
   // the error inline at the bad token (Echo cortex#219 round 1).
@@ -1038,6 +1206,75 @@ export const PolicySchema = z.object({
       }
     });
   });
+
+  // IAW Phase D.1 — federation cross-validation. Same per-offender
+  // path pattern as the principal/role rules above; consistent
+  // failure shape across the policy block.
+  if (policy.federated !== undefined) {
+    // Uniqueness — networks[].id.
+    const seenNetwork = new Map<string, number>();
+    policy.federated.networks.forEach((n, networkIdx) => {
+      const dupAt = seenNetwork.get(n.id);
+      if (dupAt !== undefined) {
+        ctx.addIssue({
+          code: "custom",
+          message: `network id "${n.id}" already declared at federated.networks[${dupAt}]`,
+          path: ["federated", "networks", networkIdx, "id"],
+        });
+      } else {
+        seenNetwork.set(n.id, networkIdx);
+      }
+
+      // Per-network peer cross-validation.
+      const seenPeerStack = new Map<string, number>();
+      const seenPeerPubkey = new Map<string, number>();
+      n.peers.forEach((peer, peerIdx) => {
+        // stack_id prefix must match operator_id — the two fields
+        // are deliberately redundant so the file reads naturally,
+        // but they MUST agree. A drift between them would let an
+        // operator declare "peer X has stack Y" where Y belongs to
+        // a different operator — the surface-router would then
+        // accept federated traffic claiming a forged identity.
+        const expectedPrefix = `${peer.operator_id}/`;
+        if (!peer.stack_id.startsWith(expectedPrefix)) {
+          ctx.addIssue({
+            code: "custom",
+            message: `peer.stack_id "${peer.stack_id}" must start with peer.operator_id "${peer.operator_id}" — got prefix "${peer.stack_id.split("/")[0]}/" instead`,
+            path: ["federated", "networks", networkIdx, "peers", peerIdx, "stack_id"],
+          });
+        }
+
+        // Uniqueness — peer.stack_id within a network. Two
+        // declarations of the same stack are operator error; the
+        // schema rejects rather than silently dedup.
+        const dupStackAt = seenPeerStack.get(peer.stack_id);
+        if (dupStackAt !== undefined) {
+          ctx.addIssue({
+            code: "custom",
+            message: `peer.stack_id "${peer.stack_id}" already declared at federated.networks[${networkIdx}].peers[${dupStackAt}]`,
+            path: ["federated", "networks", networkIdx, "peers", peerIdx, "stack_id"],
+          });
+        } else {
+          seenPeerStack.set(peer.stack_id, peerIdx);
+        }
+
+        // Uniqueness — peer.operator_pubkey within a network. A
+        // single pubkey appearing twice signals a copy-paste error
+        // (operator pasted the same key into two peer entries with
+        // different stack_ids); the schema catches it.
+        const dupKeyAt = seenPeerPubkey.get(peer.operator_pubkey);
+        if (dupKeyAt !== undefined) {
+          ctx.addIssue({
+            code: "custom",
+            message: `peer.operator_pubkey already declared at federated.networks[${networkIdx}].peers[${dupKeyAt}] (pubkey collision — paste error?)`,
+            path: ["federated", "networks", networkIdx, "peers", peerIdx, "operator_pubkey"],
+          });
+        } else {
+          seenPeerPubkey.set(peer.operator_pubkey, peerIdx);
+        }
+      });
+    });
+  }
 });
 
 export type Policy = z.infer<typeof PolicySchema>;

--- a/src/common/types/cortex-config.ts
+++ b/src/common/types/cortex-config.ts
@@ -1031,6 +1031,14 @@ export type PolicyFederatedPeer = z.infer<typeof PolicyFederatedPeerSchema>;
  * what the surface-router's `adapterMatches()` will gate against
  * in D.2. Operators can always relax via additional patterns
  * rather than building a regex string.
+ *
+ * **Bare `>` is intentionally rejected** (Echo cortex#223 round 1).
+ * A naked top-level wildcard on `accept_subjects[]` would defeat
+ * the purpose of a federation accept-list; the maximal valid
+ * accept pattern is `federated.{network_id}.>`. The cross-validation
+ * below enforces the `federated.{network_id}.` prefix on every
+ * entry — this regex covers only the grammar of the trailing
+ * portion.
  */
 const NATS_SUBJECT_PATTERN_RE = /^([a-z][a-z0-9_-]*|\*)(\.([a-z][a-z0-9_-]*|\*))*(\.>)?$/;
 
@@ -1224,6 +1232,31 @@ export const PolicySchema = z.object({
       } else {
         seenNetwork.set(n.id, networkIdx);
       }
+
+      // Subject-pattern scope: every accept/deny pattern MUST begin
+      // with `federated.{network.id}.` so the network can't
+      // accidentally subscribe to or block out-of-scope subjects.
+      // Echo cortex#223 round 1 — without this guard, a typo like
+      // `accept_subjects: ["internal.private.>"]` parses cleanly
+      // and the surface-router gate (D.2) has to defend against it.
+      // Enforce at parse time instead.
+      const expectedSubjectPrefix = `federated.${n.id}.`;
+      const validateSubjectScope = (
+        list: readonly string[],
+        listName: "accept_subjects" | "deny_subjects",
+      ) => {
+        list.forEach((pattern, patternIdx) => {
+          if (!pattern.startsWith(expectedSubjectPrefix)) {
+            ctx.addIssue({
+              code: "custom",
+              message: `${listName}[${patternIdx}] "${pattern}" must begin with "federated.${n.id}." — the network's own subject scope`,
+              path: ["federated", "networks", networkIdx, listName, patternIdx],
+            });
+          }
+        });
+      };
+      validateSubjectScope(n.accept_subjects, "accept_subjects");
+      validateSubjectScope(n.deny_subjects, "deny_subjects");
 
       // Per-network peer cross-validation.
       const seenPeerStack = new Map<string, number>();

--- a/src/common/types/cortex-config.ts
+++ b/src/common/types/cortex-config.ts
@@ -1126,6 +1126,15 @@ export const PolicyFederatedNetworkSchema = z.object({
    * means "no hops" — accept only directly-signed envelopes, no
    * relay. Hop budgets bound the federation graph and prevent
    * unbounded forwarding loops.
+   *
+   * **No default — required field.** Every other list-shaped field
+   * on this schema defaults to `[]`, but `max_hop` is deliberately
+   * not defaulted: a hop budget MUST be a conscious operator
+   * choice. A silent `.default(0)` would let a typoed `max_hop:`
+   * line pass parse with the most-restrictive setting and confuse
+   * operators wondering why federated traffic stopped arriving;
+   * a missing line should fail loudly at config-load instead.
+   * Echo cortex#223 round 2.
    */
   max_hop: z.number().int().min(0),
 });


### PR DESCRIPTION
## Summary

Phase D, slice 1 — adds `policy.federated.networks[]` to `PolicySchema`. Additive schema work (no runtime consumer yet; D.2/D.3 wire surface-router + PolicyEngine extensions).

**New schemas:**
- `PolicyFederatedPeerSchema` — `operator_id`, `stack_id`, `operator_pubkey`
- `PolicyFederatedNetworkSchema` — `id`, `leaf_node`, `peers[]`, `accept_subjects[]`, `deny_subjects[]`, `announce_capabilities[]`, `max_hop`
- `PolicyFederatedSchema` — `networks[]`
- `PolicySchema.federated: optional`

**Cross-validation (`superRefine`):**
- Uniqueness — `networks[].id`
- Per-network: `peer.stack_id` prefix MUST match `peer.operator_id` (prevents forged-attribution drift)
- Per-network: `peer.stack_id` uniqueness
- Per-network: `peer.operator_pubkey` uniqueness (catches paste errors)
- Cross-network: same pubkey allowed across networks (a single stack legitimately participates in multiple networks)

**Field grammars:**
- NATS subject patterns — dotted lowercase + optional `*` / `>` wildcards
- Capability ids — Phase A.6 `<domain>.<entity>` convention
- `max_hop` — non-negative integer

## Test plan

- [x] Happy-path full network parses
- [x] Federated block optional + empty defaults
- [x] All field validators (id grammar, NKey grammar, subject pattern, capability id, max_hop)
- [x] All cross-validation rules (id dup, stack/op_id drift, stack dup, pubkey dup, cross-network OK)
- [x] Batched issues across multiple offenders
- [x] Integration with existing principals + roles
- [x] 26 policy tests + 2842/2843 full suite + lint + tsc green

Refs cortex#116. Mirrors the C.2a additive pattern (cortex#219).

🤖 Generated with [Claude Code](https://claude.com/claude-code)