### PR TITLE
feat(dashboard): IAW D.5 — multi-operator slicing + sovereignty plumbing (refs cortex#116)

### DIFF
--- a/src/common/__tests__/event-processor.test.ts
+++ b/src/common/__tests__/event-processor.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, test } from "bun:test";
+import { processSessionEvent } from "../event-processor";
+import type { IngestEvent } from "../types";
+
+/**
+ * IAW D.5 — sovereignty propagation through the event-processor.
+ *
+ * The processor is the single funnel from wire `IngestEvent` into typed
+ * `SessionUpsertData` for the cloud worker's D1 layer. These tests pin the
+ * three sovereignty pathways (task_started, task_completed fallback,
+ * progress fallback) so a future refactor of the lifter (`extractSovereignty`)
+ * can't silently drop fields between wire and persistence.
+ */
+
+function baseEvent(overrides: Partial<IngestEvent> = {}): IngestEvent {
+  return {
+    event_id: "evt-1",
+    event_type: "agent.task.started",
+    timestamp: "2026-05-16T00:00:00.000Z",
+    session_id: "sess-1",
+    agent_id: "luna",
+    agent_name: "Luna",
+    payload: {},
+    ...overrides,
+  };
+}
+
+describe("processSessionEvent — sovereignty propagation (IAW D.5)", () => {
+  test("task_started lifts sovereignty into session upsert", () => {
+    const event = baseEvent({
+      event_type: "agent.task.started",
+      sovereignty: {
+        classification: "federated",
+        data_residency: "nz",
+        home_operator: "jcfischer",
+      },
+    });
+    const out = processSessionEvent("andreas", event);
+    expect(out.type).toBe("task_started");
+    if (out.type !== "task_started") return;
+    expect(out.session.sovereignty).toEqual({
+      classification: "federated",
+      dataResidency: "nz",
+      homeOperator: "jcfischer",
+    });
+  });
+
+  test("task_completed fallback session carries sovereignty", () => {
+    const event = baseEvent({
+      event_type: "agent.task.completed",
+      payload: { duration_ms: 1000 },
+      sovereignty: {
+        classification: "public",
+        home_operator: "ops-mesh",
+      },
+    });
+    const out = processSessionEvent("andreas", event);
+    expect(out.type).toBe("task_completed");
+    if (out.type !== "task_completed") return;
+    expect(out.fallbackSession?.sovereignty).toEqual({
+      classification: "public",
+      dataResidency: null,
+      homeOperator: "ops-mesh",
+    });
+  });
+
+  test("progress fallback session carries sovereignty", () => {
+    const event = baseEvent({
+      event_type: "agent.progress",
+      sovereignty: {
+        classification: "local",
+        data_residency: "eu",
+        home_operator: "andreas",
+      },
+    });
+    const out = processSessionEvent("andreas", event);
+    expect(out.type).toBe("progress");
+    if (out.type !== "progress") return;
+    expect(out.fallbackSession?.sovereignty).toEqual({
+      classification: "local",
+      dataResidency: "eu",
+      homeOperator: "andreas",
+    });
+  });
+
+  test("absent sovereignty block yields undefined (pre-IAW publisher path)", () => {
+    const event = baseEvent({ event_type: "agent.task.started" });
+    const out = processSessionEvent("andreas", event);
+    expect(out.type).toBe("task_started");
+    if (out.type !== "task_started") return;
+    expect(out.session.sovereignty).toBeUndefined();
+  });
+
+  test("empty sovereignty block yields undefined (all fields nullish)", () => {
+    // Defensive — relay publishes the field but no values landed. Treat
+    // as absent so the worker writes NULL across the columns rather than
+    // an empty placeholder.
+    const event = baseEvent({
+      event_type: "agent.task.started",
+      sovereignty: {},
+    });
+    const out = processSessionEvent("andreas", event);
+    if (out.type !== "task_started") throw new Error("wrong branch");
+    expect(out.session.sovereignty).toBeUndefined();
+  });
+
+  test("partial sovereignty (only data_residency) survives — classification null", () => {
+    const event = baseEvent({
+      event_type: "agent.task.started",
+      sovereignty: { data_residency: "us-east" },
+    });
+    const out = processSessionEvent("andreas", event);
+    if (out.type !== "task_started") throw new Error("wrong branch");
+    expect(out.session.sovereignty).toEqual({
+      classification: null,
+      dataResidency: "us-east",
+      homeOperator: null,
+    });
+  });
+});

--- a/src/common/event-processor.ts
+++ b/src/common/event-processor.ts
@@ -1,5 +1,6 @@
 import type {
   IngestEvent,
+  SessionSovereignty,
   SessionUpsertData,
   SessionCompleteData,
   UsageSnapshotData,
@@ -9,6 +10,31 @@ import {
   extractProgress,
   extractGitHubIssue,
 } from "./event-utils";
+
+/**
+ * IAW D.5 — lift sovereignty fields off an ingest event into the
+ * normalised `SessionSovereignty` shape persisted on `sessions`. Returns
+ * `undefined` when no sovereignty fields are present so the worker can
+ * leave the D1 columns as NULL rather than inserting empty strings.
+ *
+ * The relay is responsible for hoisting `envelope.sovereignty.*` and
+ * `signed_by[0].principal` (after `did:mf:` strip → operator segment) onto
+ * the ingest event before publishing. This processor is purely defensive —
+ * it never invents sovereignty data, only reflects what arrived.
+ */
+function extractSovereignty(event: IngestEvent): SessionSovereignty | undefined {
+  const s = event.sovereignty;
+  if (!s) return undefined;
+  // At least one field must be present; otherwise treat as absent.
+  if (s.classification == null && s.data_residency == null && s.home_operator == null) {
+    return undefined;
+  }
+  return {
+    classification: s.classification ?? null,
+    dataResidency: s.data_residency ?? null,
+    homeOperator: s.home_operator ?? null,
+  };
+}
 
 function asString(v: unknown): string {
   return typeof v === "string" ? v : "";
@@ -90,6 +116,7 @@ function processTaskStarted(
       lastEventAt: event.timestamp,
       progressCompleted: null,
       progressTotal: null,
+      sovereignty: extractSovereignty(event),
     },
   };
 }
@@ -136,6 +163,7 @@ function processTaskCompleted(
       lastEventAt: event.timestamp,
       progressCompleted: null,
       progressTotal: null,
+      sovereignty: extractSovereignty(event),
     },
   };
 }
@@ -216,6 +244,7 @@ function processProgressEvent(
       lastEventAt: event.timestamp,
       progressCompleted: progress?.completed ?? null,
       progressTotal: progress?.total ?? null,
+      sovereignty: extractSovereignty(event),
     },
   };
 }

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -45,6 +45,28 @@ export interface PullRequestUpsertData {
   mergedAt: string | null;
 }
 
+/**
+ * IAW D.5 — Sovereignty fields lifted off the myelin envelope when an
+ * ingest event was minted from one. Optional everywhere: events emitted
+ * from pre-IAW pipelines carry no envelope and these stay `null` end-to-end.
+ *
+ * Field semantics mirror `myelin/docs/envelope.md` §sovereignty:
+ *   - `classification` — "local" | "federated" | "public"; drives the
+ *     dashboard subscription split (D.5.1) and the badge colour (D.5.3).
+ *   - `data_residency`  — free-form region tag (e.g. "nz", "eu"); rendered
+ *     verbatim in the badge alongside the classification chip.
+ *   - `home_operator`   — `signed_by[0].principal` operator segment with
+ *     the `did:mf:` prefix stripped. Drives D.5.2 per-operator slicing.
+ *     The cloud worker also keeps `sessions.operator_id` (the API-key
+ *     owner) which is the *receiving* operator; `home_operator` is who
+ *     the work originated from. For purely-local traffic the two match.
+ */
+export interface SessionSovereignty {
+  classification: "local" | "federated" | "public" | null;
+  dataResidency: string | null;
+  homeOperator: string | null;
+}
+
 /** Data shape for upserting a session */
 export interface SessionUpsertData {
   sessionId: string;
@@ -60,6 +82,8 @@ export interface SessionUpsertData {
   lastEventAt: string;
   progressCompleted: number | null;
   progressTotal: number | null;
+  /** IAW D.5 — sovereignty lifted from the originating envelope, if any. */
+  sovereignty?: SessionSovereignty;
 }
 
 /** Data for completing a session */
@@ -92,6 +116,19 @@ export interface IngestEvent {
   agent_id?: string;
   agent_name?: string;
   grove_channel?: string;
+  /**
+   * IAW D.5 — sovereignty fields hoisted onto the event envelope by the
+   * relay when the originating myelin envelope carried `sovereignty.*` +
+   * `signed_by[]`. Wire-shape uses snake_case to match the rest of the
+   * ingest contract; the worker normalises to camelCase before persist.
+   * All three fields are optional — pre-IAW publishers omit them and the
+   * cloud worker stores nulls. See `SessionSovereignty` for semantics.
+   */
+  sovereignty?: {
+    classification?: "local" | "federated" | "public";
+    data_residency?: string;
+    home_operator?: string;
+  };
   payload: Record<string, unknown>;
 }
 

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -1,3 +1,11 @@
+// IAW D.5 — `Classification` is the canonical sovereignty-classification
+// union, exported by the envelope validator. Re-exported here as a type-only
+// import so consumers of `IngestEvent` / `SessionSovereignty` don't need to
+// reach into `bus/myelin/` for a one-token union, and so a future widening
+// of the union (e.g. adding `"restricted"`) flows from one definition.
+// The import is type-only — `common/types.ts` stays runtime-dep-free.
+import type { Classification } from "../bus/myelin/envelope-validator";
+
 /** Data shape for inserting a GitHub event into the store */
 export interface GitHubEventData {
   eventId: string;
@@ -62,7 +70,7 @@ export interface PullRequestUpsertData {
  *     the work originated from. For purely-local traffic the two match.
  */
 export interface SessionSovereignty {
-  classification: "local" | "federated" | "public" | null;
+  classification: Classification | null;
   dataResidency: string | null;
   homeOperator: string | null;
 }
@@ -125,7 +133,7 @@ export interface IngestEvent {
    * cloud worker stores nulls. See `SessionSovereignty` for semantics.
    */
   sovereignty?: {
-    classification?: "local" | "federated" | "public";
+    classification?: Classification;
     data_residency?: string;
     home_operator?: string;
   };

--- a/src/surface/mc/worker/migrations/0003_sovereignty.sql
+++ b/src/surface/mc/worker/migrations/0003_sovereignty.sql
@@ -1,0 +1,27 @@
+-- IAW D.5 — add sovereignty columns to sessions for multi-operator dashboard slicing.
+--
+-- Apply: wrangler d1 execute grove-events --file=./migrations/0003_sovereignty.sql
+--
+-- Background: cortex#116 (IAW Phase D — federation) lands the surface-router
+-- gate on federated.{operator}.{stack}.> subjects. The cloud dashboard is the
+-- multi-operator surface where this traffic surfaces; per the IAW plan §5
+-- D.5.2 the dashboard slices on `principal.home_operator` and per D.5.3
+-- renders sovereignty + classification on every activity card.
+--
+-- The ingest pipeline (cortex-relay → cloud-publisher → /api/ingest) hoists
+-- `envelope.sovereignty.classification`, `envelope.sovereignty.data_residency`,
+-- and `signed_by[0].principal` (operator segment after `did:mf:` strip) onto
+-- the event payload when the originating event was minted from a myelin
+-- envelope. Pre-IAW publishers omit these fields and the columns stay NULL.
+--
+-- All three columns are nullable and additive — pre-existing rows keep
+-- behaving exactly as today; new rows pick up sovereignty when present.
+
+ALTER TABLE sessions ADD COLUMN classification TEXT;        -- 'local' | 'federated' | 'public' | NULL
+ALTER TABLE sessions ADD COLUMN data_residency TEXT;        -- e.g. 'nz', 'eu', NULL
+ALTER TABLE sessions ADD COLUMN home_operator TEXT;         -- principal.home_operator (post-`did:mf:` strip)
+
+-- Index `home_operator` because the dashboard filter chip slices the snapshot
+-- by it on every poll (D.5.2). Index is partial (NULL excluded) to keep it
+-- small — pre-IAW rows never hit this lookup.
+CREATE INDEX IF NOT EXISTS idx_sessions_home_operator ON sessions(home_operator) WHERE home_operator IS NOT NULL;

--- a/src/surface/mc/worker/schema.sql
+++ b/src/surface/mc/worker/schema.sql
@@ -28,7 +28,12 @@ CREATE TABLE IF NOT EXISTS sessions (
   input_tokens INTEGER,
   output_tokens INTEGER,
   cache_read_tokens INTEGER,
-  cost_usd REAL
+  cost_usd REAL,
+  -- IAW D.5: sovereignty fields lifted off the originating myelin envelope.
+  -- All three are NULL for pre-IAW publishers. See migrations/0003_sovereignty.sql.
+  classification TEXT,        -- 'local' | 'federated' | 'public' | NULL
+  data_residency TEXT,        -- e.g. 'nz', 'eu', NULL
+  home_operator TEXT          -- principal.home_operator (post-`did:mf:` strip)
 );
 
 CREATE TABLE IF NOT EXISTS github_events (
@@ -132,6 +137,8 @@ CREATE INDEX IF NOT EXISTS idx_session_activity_session ON session_activity(sess
 CREATE INDEX IF NOT EXISTS idx_sessions_status ON sessions(status);
 CREATE INDEX IF NOT EXISTS idx_sessions_completed ON sessions(completed_at);
 CREATE INDEX IF NOT EXISTS idx_sessions_operator ON sessions(operator_id);
+-- IAW D.5 — slicing the dashboard snapshot by home_operator on every poll
+CREATE INDEX IF NOT EXISTS idx_sessions_home_operator ON sessions(home_operator) WHERE home_operator IS NOT NULL;
 CREATE INDEX IF NOT EXISTS idx_github_repo ON github_events(repo, created_at);
 CREATE INDEX IF NOT EXISTS idx_github_agent ON github_events(agent_authored, created_at);
 CREATE INDEX IF NOT EXISTS idx_github_operator ON github_events(operator_id);

--- a/src/surface/mc/worker/src/routes/ingest.ts
+++ b/src/surface/mc/worker/src/routes/ingest.ts
@@ -129,11 +129,17 @@ async function persistProcessedEvent(db: D1Database, processed: ProcessedSession
 }
 
 async function upsertSession(db: D1Database, session: SessionUpsertData): Promise<void> {
+  // IAW D.5 — sovereignty fields are optional; pre-IAW publishers omit them
+  // and the D1 columns stay NULL. On conflict we COALESCE so later events
+  // for the same session can backfill (e.g. task_started without envelope,
+  // then a progress event from a federated source carries sovereignty).
+  const sov = session.sovereignty;
   await db.prepare(`
     INSERT INTO sessions
     (session_id, operator_id, agent_id, agent_name, project, description, github_issue,
-     started_at, status, events_count, last_event, last_event_at)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'active', 1, ?, ?)
+     started_at, status, events_count, last_event, last_event_at,
+     classification, data_residency, home_operator)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'active', 1, ?, ?, ?, ?, ?)
     ON CONFLICT(session_id) DO UPDATE SET
       status = 'active',
       operator_id = COALESCE(excluded.operator_id, operator_id),
@@ -143,7 +149,10 @@ async function upsertSession(db: D1Database, session: SessionUpsertData): Promis
       github_issue = COALESCE(excluded.github_issue, github_issue),
       last_event = excluded.last_event,
       last_event_at = excluded.last_event_at,
-      events_count = events_count + 1
+      events_count = events_count + 1,
+      classification = COALESCE(excluded.classification, classification),
+      data_residency = COALESCE(excluded.data_residency, data_residency),
+      home_operator = COALESCE(excluded.home_operator, home_operator)
   `).bind(
     session.sessionId,
     session.operatorId ?? null,
@@ -155,6 +164,9 @@ async function upsertSession(db: D1Database, session: SessionUpsertData): Promis
     session.startedAt,
     session.lastEvent,
     session.lastEventAt,
+    sov?.classification ?? null,
+    sov?.dataResidency ?? null,
+    sov?.homeOperator ?? null,
   ).run();
 }
 
@@ -190,11 +202,16 @@ async function insertSessionDirect(
   session: SessionUpsertData,
   completion: SessionCompleteData,
 ): Promise<void> {
+  // IAW D.5 — same late-join semantics as upsertSession but on a fresh row,
+  // so we insert sovereignty straight (no COALESCE needed; there's nothing
+  // to merge with).
+  const sov = session.sovereignty;
   await db.prepare(`
     INSERT OR IGNORE INTO sessions
     (session_id, operator_id, agent_id, agent_name, project, description, github_issue,
-     started_at, completed_at, duration_ms, pr_url, status, last_event, last_event_at)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+     started_at, completed_at, duration_ms, pr_url, status, last_event, last_event_at,
+     classification, data_residency, home_operator)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   `).bind(
     session.sessionId,
     session.operatorId ?? null,
@@ -210,6 +227,9 @@ async function insertSessionDirect(
     completion.status,
     session.lastEvent,
     session.lastEventAt,
+    sov?.classification ?? null,
+    sov?.dataResidency ?? null,
+    sov?.homeOperator ?? null,
   ).run();
 }
 

--- a/src/surface/mc/worker/src/routes/state.ts
+++ b/src/surface/mc/worker/src/routes/state.ts
@@ -9,6 +9,7 @@
 
 import { Hono } from "hono";
 import type { Env } from "../index";
+import type { Classification } from "../../../../bus/myelin/envelope-validator";
 
 // ---------------------------------------------------------------------------
 // G-406: Module-level cache
@@ -255,17 +256,9 @@ async function getActiveAgents(
     params.push(project);
   }
 
-  // IAW D.5.2 — `home_operator=local` is the dashboard default and
-  // matches sessions with NULL home_operator (purely local traffic). Any
-  // other value matches that operator's federated traffic. We deliberately
-  // do NOT collapse local + federated by default; the operator opts in to
-  // cross-operator visibility via the filter chip.
-  if (homeOperator === "local") {
-    sql += ` AND home_operator IS NULL`;
-  } else if (homeOperator) {
-    sql += ` AND home_operator = ?`;
-    params.push(homeOperator);
-  }
+  const homeFilter = applyHomeOperatorFilter(homeOperator);
+  sql += homeFilter.sql;
+  params.push(...homeFilter.params);
 
   sql += ` ORDER BY started_at DESC`;
 
@@ -317,17 +310,47 @@ async function getActiveAgents(
 }
 
 /**
+ * IAW D.5.2 — translate the `home_operator` query param into a parameterised
+ * SQL fragment for chaining onto a `sessions` WHERE clause.
+ *
+ *   - `undefined` / `null` / `""` → no slicing (snapshot covers all rows).
+ *   - `"local"`                   → `home_operator IS NULL` (purely local
+ *                                   traffic, the dashboard default chip).
+ *   - any other string            → `home_operator = ?` (specific operator).
+ *
+ * Returns `{ sql, params }` rather than mutating in place so the caller's
+ * SELECT is constructible without hidden side-effects on a shared array.
+ *
+ * Echo cortex#224 round 1 — extracted to fold three (and eventually more)
+ * `getActiveAgents` / `getRecentCompletions` / future-helper copies through
+ * one place. Adding `"federated"` (all stamped traffic) or `"public"` (a
+ * specific classification cut) becomes a one-file change.
+ */
+function applyHomeOperatorFilter(homeOperator?: string | null): {
+  sql: string;
+  params: unknown[];
+} {
+  if (homeOperator === "local") {
+    return { sql: ` AND home_operator IS NULL`, params: [] };
+  }
+  if (homeOperator) {
+    return { sql: ` AND home_operator = ?`, params: [homeOperator] };
+  }
+  return { sql: "", params: [] };
+}
+
+/**
  * IAW D.5.3 — build the snapshot's `sovereignty` block from a session row.
  * Returns `null` when none of the three sovereignty fields are populated so
  * the frontend can fast-path the "pre-IAW row, render nothing" case without
  * a per-field truthy check.
  */
 function buildSovereignty(r: Record<string, unknown>): {
-  classification: "local" | "federated" | "public" | null;
+  classification: Classification | null;
   dataResidency: string | null;
   homeOperator: string | null;
 } | null {
-  const classification = r.classification as "local" | "federated" | "public" | null | undefined;
+  const classification = r.classification as Classification | null | undefined;
   const dataResidency = r.data_residency as string | null | undefined;
   const homeOperator = r.home_operator as string | null | undefined;
   if (classification == null && dataResidency == null && homeOperator == null) {
@@ -393,13 +416,9 @@ async function getRecentCompletions(
     params.push(project);
   }
 
-  // IAW D.5.2 — mirror the home_operator slicing applied to active agents.
-  if (homeOperator === "local") {
-    sql += ` AND home_operator IS NULL`;
-  } else if (homeOperator) {
-    sql += ` AND home_operator = ?`;
-    params.push(homeOperator);
-  }
+  const homeFilter = applyHomeOperatorFilter(homeOperator);
+  sql += homeFilter.sql;
+  params.push(...homeFilter.params);
 
   sql += ` ORDER BY completed_at DESC LIMIT ?`;
   params.push(limit);

--- a/src/surface/mc/worker/src/routes/state.ts
+++ b/src/surface/mc/worker/src/routes/state.ts
@@ -19,16 +19,29 @@ let cachedETag: string | null = null;
 let cachedAt = 0;
 const CACHE_TTL_MS = 5_000; // 5s TTL — prevents stale reads across isolates
 
-/** Build a full (unfiltered) snapshot object from D1. */
-export async function buildSnapshot(db: D1Database, project?: string | null) {
-  const [agents, completions, activity, dailyStats, projects, accountUsage, operatorUsage] = await Promise.all([
-    getActiveAgents(db, project),
-    getRecentCompletions(db, project),
+/**
+ * Build a full (unfiltered) snapshot object from D1.
+ *
+ * IAW D.5 — `homeOperator` (when supplied) slices the snapshot's `agents`
+ * and `recentCompletions` lists by the originating operator. The other
+ * derived sections (stats, repos, heatmap) stay global because they reflect
+ * the receiving operator's totals; per-operator stats are a future slice
+ * (D.5 ships the activity-card path first per the plan §5).
+ */
+export async function buildSnapshot(
+  db: D1Database,
+  project?: string | null,
+  homeOperator?: string | null,
+) {
+  const [agents, completions, activity, dailyStats, projects, accountUsage, operatorUsage, homeOperators] = await Promise.all([
+    getActiveAgents(db, project, homeOperator),
+    getRecentCompletions(db, project, undefined, homeOperator),
     getRecentActivity(db, project),
     getDailyStats(db),
     getProjects(db),
     getLatestAccountUsage(db),
     getPerOperatorUsage(db),
+    getKnownHomeOperators(db),
   ]);
 
   return {
@@ -42,6 +55,12 @@ export async function buildSnapshot(db: D1Database, project?: string | null) {
     stats: { today: dailyStats },
     accountUsage,
     operatorUsage,
+    /**
+     * IAW D.5.2 — distinct `home_operator` values observed in recent
+     * sessions. The frontend uses this to populate the operator filter
+     * dropdown; "Local only" (the default) corresponds to `null` here.
+     */
+    homeOperators,
     updatedAt: new Date().toISOString(),
   };
 }
@@ -188,10 +207,17 @@ export const stateRoutes = new Hono<{ Bindings: Env }>();
 stateRoutes.get("/api/state", async (c) => {
   const db = c.env.GROVE_DB;
   const project = c.req.query("project");
+  // IAW D.5.2 — `?home_operator=<id>` slices the snapshot to a single
+  // originating operator. Sentinel `"local"` means "null home_operator
+  // only" (purely local traffic, no federated stamps) and matches the
+  // dashboard's default filter chip.
+  const homeOperator = c.req.query("home_operator");
 
-  // Project-filtered requests bypass cache (rare)
-  if (project) {
-    const snapshot = await buildSnapshot(db, project);
+  // Project-filtered or operator-filtered requests bypass cache (rare).
+  // The cache key would need to grow per-(project, home_operator) tuple
+  // otherwise; not worth the complexity for the slow path.
+  if (project || homeOperator) {
+    const snapshot = await buildSnapshot(db, project, homeOperator);
     return c.json(snapshot);
   }
 
@@ -207,12 +233,17 @@ stateRoutes.get("/api/state", async (c) => {
 // Query helpers
 // ---------------------------------------------------------------------------
 
-async function getActiveAgents(db: D1Database, project?: string | null) {
+async function getActiveAgents(
+  db: D1Database,
+  project?: string | null,
+  homeOperator?: string | null,
+) {
   let sql = `
     SELECT session_id, operator_id, agent_id, agent_name, project, description,
            github_issue, started_at, completed_at, duration_ms, status, pr_url,
            events_count, last_event, last_event_at, progress_completed, progress_total,
-           input_tokens, output_tokens, cache_read_tokens, cost_usd
+           input_tokens, output_tokens, cache_read_tokens, cost_usd,
+           classification, data_residency, home_operator
     FROM sessions
     WHERE (status = 'active' AND last_event_at >= strftime('%Y-%m-%dT%H:%M:%fZ', 'now', '-3 hours'))
       OR (status IN ('completed', 'failed') AND completed_at >= strftime('%Y-%m-%dT%H:%M:%fZ', 'now', '-30 minutes'))
@@ -222,6 +253,18 @@ async function getActiveAgents(db: D1Database, project?: string | null) {
   if (project) {
     sql += ` AND project = ?`;
     params.push(project);
+  }
+
+  // IAW D.5.2 — `home_operator=local` is the dashboard default and
+  // matches sessions with NULL home_operator (purely local traffic). Any
+  // other value matches that operator's federated traffic. We deliberately
+  // do NOT collapse local + federated by default; the operator opts in to
+  // cross-operator visibility via the filter chip.
+  if (homeOperator === "local") {
+    sql += ` AND home_operator IS NULL`;
+  } else if (homeOperator) {
+    sql += ` AND home_operator = ?`;
+    params.push(homeOperator);
   }
 
   sql += ` ORDER BY started_at DESC`;
@@ -236,6 +279,12 @@ async function getActiveAgents(db: D1Database, project?: string | null) {
     id: r.agent_id as string,
     name: r.agent_name as string,
     operatorId: r.operator_id as string | null,
+    // IAW D.5.3 — surface sovereignty + homeOperator on each agent card.
+    // `homeOperator` defaults to null (purely local traffic); the frontend
+    // renders nothing rather than a "local" chip for the null case so the
+    // 99% pre-IAW path stays visually unchanged.
+    homeOperator: (r.home_operator as string | null) ?? null,
+    sovereignty: buildSovereignty(r),
     status: r.status === "active" ? "active" as const : "completed" as const,
     currentTask: {
       sessionId: r.session_id as string,
@@ -265,6 +314,30 @@ async function getActiveAgents(db: D1Database, project?: string | null) {
       durationMs: r.duration_ms as number | null | undefined,
     },
   }));
+}
+
+/**
+ * IAW D.5.3 — build the snapshot's `sovereignty` block from a session row.
+ * Returns `null` when none of the three sovereignty fields are populated so
+ * the frontend can fast-path the "pre-IAW row, render nothing" case without
+ * a per-field truthy check.
+ */
+function buildSovereignty(r: Record<string, unknown>): {
+  classification: "local" | "federated" | "public" | null;
+  dataResidency: string | null;
+  homeOperator: string | null;
+} | null {
+  const classification = r.classification as "local" | "federated" | "public" | null | undefined;
+  const dataResidency = r.data_residency as string | null | undefined;
+  const homeOperator = r.home_operator as string | null | undefined;
+  if (classification == null && dataResidency == null && homeOperator == null) {
+    return null;
+  }
+  return {
+    classification: classification ?? null,
+    dataResidency: dataResidency ?? null,
+    homeOperator: homeOperator ?? null,
+  };
 }
 
 /** G-410: Fetch last 50 activity entries for each session ID. */
@@ -300,10 +373,16 @@ async function getSessionActivities(
   return map;
 }
 
-async function getRecentCompletions(db: D1Database, project?: string | null, limit = 50) {
+async function getRecentCompletions(
+  db: D1Database,
+  project?: string | null,
+  limit = 50,
+  homeOperator?: string | null,
+) {
   let sql = `
     SELECT agent_id, agent_name, operator_id, project, description, duration_ms,
-           completed_at, pr_url, github_issue, status
+           completed_at, pr_url, github_issue, status,
+           classification, data_residency, home_operator
     FROM sessions
     WHERE status IN ('completed', 'failed')
   `;
@@ -314,6 +393,14 @@ async function getRecentCompletions(db: D1Database, project?: string | null, lim
     params.push(project);
   }
 
+  // IAW D.5.2 — mirror the home_operator slicing applied to active agents.
+  if (homeOperator === "local") {
+    sql += ` AND home_operator IS NULL`;
+  } else if (homeOperator) {
+    sql += ` AND home_operator = ?`;
+    params.push(homeOperator);
+  }
+
   sql += ` ORDER BY completed_at DESC LIMIT ?`;
   params.push(limit);
 
@@ -322,7 +409,7 @@ async function getRecentCompletions(db: D1Database, project?: string | null, lim
   return (results ?? []).map((r: Record<string, unknown>) => ({
     agentId: r.agent_id as string,
     agentName: r.agent_name as string,
-    operatorId: (r as any).operator_id as string | null,
+    operatorId: r.operator_id as string | null,
     project: r.project as string | null,
     description: r.description as string,
     durationMs: r.duration_ms as number | null,
@@ -330,7 +417,30 @@ async function getRecentCompletions(db: D1Database, project?: string | null, lim
     prUrl: r.pr_url as string | null,
     githubIssue: r.github_issue as string | null,
     status: r.status as "completed" | "failed",
+    // IAW D.5.3 — sovereignty surface on completions row.
+    homeOperator: (r.home_operator as string | null) ?? null,
+    sovereignty: buildSovereignty(r),
   }));
+}
+
+/**
+ * IAW D.5.2 — return the distinct, non-null `home_operator` values seen in
+ * recent sessions. Powers the dashboard's operator filter dropdown — the
+ * frontend prepends "Local only" (default) + "All operators" to this list.
+ *
+ * Window: same 7-day horizon the heatmap uses, so the dropdown doesn't grow
+ * unboundedly with historical federated peers that have gone dark.
+ */
+async function getKnownHomeOperators(db: D1Database): Promise<string[]> {
+  const { results } = await db.prepare(`
+    SELECT DISTINCT home_operator
+    FROM sessions
+    WHERE home_operator IS NOT NULL
+      AND (last_event_at >= strftime('%Y-%m-%dT%H:%M:%fZ', 'now', '-7 days')
+           OR completed_at >= strftime('%Y-%m-%dT%H:%M:%fZ', 'now', '-7 days'))
+    ORDER BY home_operator ASC
+  `).all();
+  return (results ?? []).map((r) => r.home_operator as string);
 }
 
 async function getRecentActivity(db: D1Database, project?: string | null, limit = 500) {


### PR DESCRIPTION
## Summary

D.5 backend slice for the cloud dashboard's multi-operator surface (cortex#116, plan §5):

- **D.5.1 wire** — `IngestEvent.sovereignty?: { classification, data_residency, home_operator }` carries fields lifted off the originating myelin envelope.
- **D.5.2 slicing** — `GET /api/state?home_operator=<id>` filters the snapshot's active agents + recent completions by originating operator. Sentinel `"local"` matches `home_operator IS NULL` (purely local traffic, the dashboard default).
- **D.5.3 data** — every activity card in the snapshot now carries `homeOperator` + `sovereignty: { classification, dataResidency, homeOperator }`. New `homeOperators[]` block enumerates distinct observed values for the frontend filter dropdown.

The D1 schema gains `classification`, `data_residency`, `home_operator` columns on `sessions` with a partial index on `home_operator` for filter-chip queries. Pre-IAW publishers omit the wire field and the columns stay `NULL` — no behaviour change for current operators.

## Changes

- `src/common/types.ts` — `SessionSovereignty`, `IngestEvent.sovereignty`, `SessionUpsertData.sovereignty`.
- `src/common/event-processor.ts` — `extractSovereignty()` lifts wire fields through all three session-upsert branches (task_started, task_completed fallback, progress fallback).
- `src/surface/mc/worker/migrations/0003_sovereignty.sql` — additive ALTER TABLE + partial index. Apply via `wrangler d1 execute grove-events --file=...`.
- `src/surface/mc/worker/schema.sql` — canonical schema updated in lockstep.
- `src/surface/mc/worker/src/routes/ingest.ts` — sessions upsert + insert persist sovereignty; conflict path COALESCEs so later envelope-bearing events can backfill earlier nulls.
- `src/surface/mc/worker/src/routes/state.ts` — \`buildSnapshot\` slices by \`home_operator\`, surfaces sovereignty on every row, returns \`homeOperators[]\` for the filter dropdown.
- `src/common/__tests__/event-processor.test.ts` — 6 new tests pin the sovereignty pathways + absent/empty/partial defensive branches.

## Deliberately deferred (follow-up issue)

**D.5.3 UI surface** — the badge component + operator filter chip in \`dashboard-v2/components/\`. The dashboard-v2 React tree currently consumes \`/api/focus-area\`, \`/api/tasks\`, \`/api/working-agents\` (the local API surface, single-operator). Wiring the cloud-worker \`/api/state\` shape into dashboard-v2 is a refactor that belongs with the cortex#107 Step H cloud-dashboard cutover, not in this slice. The badge component + filter chip will land once that cutover is in flight; the data is ready to consume the moment it is.

This is also the split called out in the D.5 spec ("worker-side subscription + tagging first; UI filter + badges as a follow-up").

## Out of scope

- D.4 (cloud-side network registry) — sibling agent PR.
- D.1 (`policy.federated.networks[]` config schema) — PR #223 (in flight).
- Live browser verification — this agent has no browser session; the changes are wire-format + D1 SQL + JSON-shape, all covered by tsc + tests.

## Test plan

- [x] \`bunx tsc --noEmit\` clean across the worktree
- [x] \`bun test src/common/\` — 6 new tests green, 0 regressions
- [x] \`bun test src/common/ src/surface/mc/\` — 1591 pass, 0 fail
- [x] \`bun run lint:errors\` clean
- [x] \`bun build src/surface/mc/dashboard-v2/...\` clean (no UI changes; build is identical to main)
- [ ] **Manual post-merge**: \`wrangler d1 execute grove-events --file=src/surface/mc/worker/migrations/0003_sovereignty.sql\` against prod D1.
- [ ] **Manual post-merge**: no \`wrangler pages deploy\` needed (no dashboard-v2 file changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)