### PR TITLE
feat(services): IAW D.4 — cloud network registry service (refs cortex#116)

### DIFF
--- a/docs/plan-internet-of-agentic-work.md
+++ b/docs/plan-internet-of-agentic-work.md
@@ -395,14 +395,14 @@ Pre-Phase-B caveat (Echo cortex#220 round 1): the dispatch-listener policy gate 
 
 ### D.4 Cloud-side network registry service
 
-- [ ] **D.4.1** New service alongside `grove-api` (renamed to `cortex-api` post-MIG-7); hosted at `network.meta-factory.ai` or similar. Hono REST API.
-- [ ] **D.4.2** Endpoints:
+- [x] **D.4.1** New service alongside `grove-api` (renamed to `cortex-api` post-MIG-7); hosted at `network.meta-factory.ai` or similar. Hono REST API. — `src/services/network-registry/` (this PR).
+- [x] **D.4.2** Endpoints:
   - `POST /operators/{operator_id}/register` — operator publishes their operator NKey + stack identities + capability declaration (signed assertion).
   - `GET /operators/{operator_id}` — peers query operator's current pubkey + stack list.
   - `GET /networks/{network_id}/roster` — query who's in this network.
   - `GET /capabilities?query=...` — capability search across networks.
-- [ ] **D.4.3** Cortex consults the registry at startup + on schedule to refresh peer pubkeys; in-memory cache invalidated on operator-publish events.
-- [ ] **D.4.4** Registry signs assertions; cortex verifies before trusting.
+- [ ] **D.4.3** Cortex consults the registry at startup + on schedule to refresh peer pubkeys; in-memory cache invalidated on operator-publish events. — consumer side (cortex-side `RegistryClient`) is a separate follow-up; this PR ships the producer surface.
+- [x] **D.4.4** Registry signs assertions; cortex verifies before trusting. — registry-side signing landed; cortex-side verification lands with D.4.3 consumer.
 
 ### D.5 Cloud dashboard multi-operator slicing (cortex#107 Step H)
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -128,6 +128,7 @@ export default tseslint.config(
       "src/worker/",
       "src/webhook-proxy/",
       "src/surface/mc/worker/",
+      "src/services/network-registry/",
       "src/taps/gh-webhook/",
       "src/surface/mc/dashboard-v2/",
       "**/*.bak.ts",

--- a/src/services/network-registry/README.md
+++ b/src/services/network-registry/README.md
@@ -1,0 +1,90 @@
+# cortex-network-registry
+
+IAW Phase D.4 — cloud-side network registry service. Hono REST API on
+Cloudflare Workers. Canonical pubkey directory for the IAW federation
+per Q3 lock-in (centralised, NOT NATS-gossiped). Cortex consults the
+registry at startup + on schedule to refresh peer pubkeys.
+
+Refs cortex#116 (Phase D umbrella) → `docs/plan-internet-of-agentic-work.md` §D.4.
+
+## Endpoints
+
+| Method | Path                                | Purpose                                           |
+|--------|-------------------------------------|---------------------------------------------------|
+| POST   | `/operators/{operator_id}/register` | Operator publishes signed assertion (D.4.2)       |
+| GET    | `/operators/{operator_id}`          | Peers query operator's current pubkey + stacks    |
+| GET    | `/networks/{network_id}/roster`     | Who's in this network                             |
+| GET    | `/capabilities?query=<substring>`   | Capability search across networks                 |
+| GET    | `/registry/pubkey`                  | Returns the registry's Ed25519 pubkey (pin this)  |
+| GET    | `/api/health`                       | Liveness probe                                    |
+
+## Trust model
+
+- **POST register**: open at the HTTP layer; authenticity enforced by
+  the signed assertion in the body. Operator signs canonical-JSON of
+  the `RegistrationClaim` with their operator Ed25519 NKey; the
+  registry verifies against the declared pubkey. TOFU on first sight.
+  Subsequent registers MUST sign with the on-record pubkey.
+- **GET responses**: wrapped in `SignedAssertion<T>` with a registry
+  Ed25519 signature over `{ payload, issued_at, registry }`. Cortex
+  peers pin the registry pubkey at config time and verify before
+  mutating their local cache (D.4.4).
+- **No CF Access bypass policies.** M2M traffic authenticates at the
+  application layer via Ed25519. Same defense-in-depth as grove-api S-058.
+
+## Storage (v1)
+
+In-memory per-isolate. Acceptable for the initial endpoint surface +
+test rig. **Persistence (D1 or KV) is a follow-up** before any
+production traffic — see "Roadmap" below.
+
+## Local dev
+
+```bash
+cd src/services/network-registry
+bun install
+bunx wrangler dev
+```
+
+## Tests
+
+```bash
+bun test
+```
+
+Test suite uses `app.fetch(...)` against an in-process Worker — no
+network. Generates fresh Ed25519 keypairs per test (WebCrypto) so
+real-world signature paths are exercised.
+
+## Deploy
+
+```bash
+# One-time per environment: provision the signing key.
+bunx wrangler secret put REGISTRY_SIGNING_KEY --env production
+# Paste a base64-encoded PKCS#8 Ed25519 private key.
+
+# Deploy
+bunx wrangler deploy --env production
+```
+
+DNS for `network.meta-factory.ai` is provisioned at first deploy time;
+the placeholder route in `wrangler.toml` is commented out and finalised
+then.
+
+## Roadmap (follow-ups)
+
+These are explicitly out of scope for D.4 v1 and tracked as separate
+issues (see cortex#116):
+
+1. **Durable persistence.** Swap `InMemoryRegistryStore` for a D1
+   implementation. Schema lives in `schema.sql`. The store interface
+   in `store.ts` is the single seam.
+2. **Pubkey rotation.** Accept a transition claim co-signed by the
+   previous key. Currently silent rotation is rejected with HTTP 409.
+3. **Pagination on `/capabilities`.** Hard-capped at 500 hits for v1.
+4. **Per-operator publish rate limiting.** Replay protection covers
+   one axis; throughput limiting is the other.
+5. **Cortex-side consumer.** A `RegistryClient` in `src/bus/registry/`
+   that consults the registry at startup + on schedule and invalidates
+   on `system.operator.published` events (D.4.3). Filed alongside the
+   D.2 / D.3 work — this service is the producer half.

--- a/src/services/network-registry/README.md
+++ b/src/services/network-registry/README.md
@@ -38,6 +38,25 @@ In-memory per-isolate. Acceptable for the initial endpoint surface +
 test rig. **Persistence (D1 or KV) is a follow-up** before any
 production traffic — see "Roadmap" below.
 
+The POST `/operators/.../register` handler returns **503** when the
+Worker is unconfigured (no `REGISTRY_SIGNING_KEY`) so mutation cannot
+happen without a producible signed receipt. GET endpoints degrade to
+an unsigned-but-structured response in the same condition; cortex
+peers refuse to trust assertions with `registry: "unconfigured"`.
+
+## Discovery vs. traffic gating
+
+Operators announce themselves into networks by listing the network in
+`capability.networks[]`. Anyone can announce into any network id —
+the registry treats `network_id` as a public namespace label, and
+attribution (operator A learns operator B exists in `secret-research`)
+is visible without a join handshake. **This is intentional for v1**:
+runtime gating (`accept_subjects` / `deny_subjects` from PR #223)
+protects the *traffic* path; the discovery surface is open by design
+to keep the registry an indexable directory rather than a sealed
+membership registry. A join handshake is filed as a follow-up if a
+deployment needs sealed namespaces.
+
 ## Local dev
 
 ```bash
@@ -77,14 +96,28 @@ These are explicitly out of scope for D.4 v1 and tracked as separate
 issues (see cortex#116):
 
 1. **Durable persistence.** Swap `InMemoryRegistryStore` for a D1
-   implementation. Schema lives in `schema.sql`. The store interface
-   in `store.ts` is the single seam.
-2. **Pubkey rotation.** Accept a transition claim co-signed by the
+   implementation. The store interface in `store.ts` is the single
+   seam; the SQL schema will land alongside the D1 implementation
+   (intentionally NOT shipped as an empty stub in this PR).
+2. **Durable nonce cache.** The per-isolate `InMemoryNonceCache`
+   protects against delayed replays via the 5-minute skew check, but
+   an in-flight replay against a different isolate within the skew
+   window CAN succeed. Move nonce storage into D1 (or a dedicated KV
+   namespace with strict consistency) at the same time as #1 so the
+   replay window collapses to the route-layer skew bound.
+3. **Pubkey rotation.** Accept a transition claim co-signed by the
    previous key. Currently silent rotation is rejected with HTTP 409.
-3. **Pagination on `/capabilities`.** Hard-capped at 500 hits for v1.
-4. **Per-operator publish rate limiting.** Replay protection covers
-   one axis; throughput limiting is the other.
-5. **Cortex-side consumer.** A `RegistryClient` in `src/bus/registry/`
+4. **Pagination on `/capabilities`.** Hard-capped at 500 hits for v1.
+5. **Per-operator publish rate limiting + CORS origin allowlist on
+   POST.** Replay protection covers one axis; throughput limiting +
+   tightening from `origin: "*"` to a known operator-tooling origin
+   list is the other. Bundled because both are about hardening the
+   mutation surface before public DNS goes live.
+6. **Cortex-side consumer.** A `RegistryClient` in `src/bus/registry/`
    that consults the registry at startup + on schedule and invalidates
    on `system.operator.published` events (D.4.3). Filed alongside the
    D.2 / D.3 work — this service is the producer half.
+7. **Sealed-network join handshake.** If a deployment needs network
+   membership to require explicit consent from existing members
+   (rather than open-announce), add a per-network join protocol with
+   an admission signature from a network admin's key.

--- a/src/services/network-registry/__tests__/capabilities.test.ts
+++ b/src/services/network-registry/__tests__/capabilities.test.ts
@@ -1,0 +1,107 @@
+/**
+ * IAW D.4 — Capability search route tests.
+ */
+
+import { describe, test, expect, beforeEach } from "bun:test";
+import app from "../src/index";
+import type { Env } from "../src/index";
+import {
+  makeOperatorKey,
+  makeRegistryKey,
+  makeSignedRegistration,
+  resetStores,
+} from "./helpers";
+import type { CapabilityHit, SignedAssertion } from "../src/types";
+
+let env: Env;
+
+async function post(path: string, body: unknown): Promise<Response> {
+  return app.fetch(
+    new Request(`http://localhost${path}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+    env,
+  );
+}
+
+async function get(path: string): Promise<Response> {
+  return app.fetch(new Request(`http://localhost${path}`), env);
+}
+
+beforeEach(async () => {
+  resetStores();
+  const reg = await makeRegistryKey();
+  env = {
+    REGISTRY_SIGNING_KEY: reg.signingKey,
+    REGISTRY_PUBLIC_KEY: reg.publicKey,
+    ENVIRONMENT: "test",
+  };
+});
+
+describe("GET /capabilities", () => {
+  test("rejects empty query", async () => {
+    const res = await get("/capabilities");
+    expect(res.status).toBe(400);
+  });
+
+  test("rejects overlong query", async () => {
+    const overlong = "x".repeat(200);
+    const res = await get(`/capabilities?query=${overlong}`);
+    expect(res.status).toBe(400);
+  });
+
+  test("returns hits matching the id substring", async () => {
+    const opA = await makeOperatorKey();
+    const opB = await makeOperatorKey();
+    await post(
+      "/operators/alpha/register",
+      await makeSignedRegistration("alpha", opA, {
+        capabilities: [
+          { id: "tasks.code-review", description: "TS + Rust", networks: ["n1"] },
+          { id: "tasks.docs-edit", networks: ["n1"] },
+        ],
+      }),
+    );
+    await post(
+      "/operators/beta/register",
+      await makeSignedRegistration("beta", opB, {
+        capabilities: [{ id: "infra.deploy", networks: ["n2"] }],
+      }),
+    );
+
+    const res = await get("/capabilities?query=tasks");
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as SignedAssertion<{ hits: CapabilityHit[]; truncated: boolean }>;
+    expect(json.payload.hits).toHaveLength(2);
+    expect(json.payload.truncated).toBe(false);
+    expect(json.payload.hits.map((h) => h.capability_id).sort()).toEqual([
+      "tasks.code-review",
+      "tasks.docs-edit",
+    ]);
+  });
+
+  test("matches description case-insensitively", async () => {
+    const op = await makeOperatorKey();
+    await post(
+      "/operators/alpha/register",
+      await makeSignedRegistration("alpha", op, {
+        capabilities: [
+          { id: "tasks.code-review", description: "TypeScript reviewer", networks: ["n1"] },
+        ],
+      }),
+    );
+    const res = await get("/capabilities?query=TYPESCRIPT");
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as SignedAssertion<{ hits: CapabilityHit[] }>;
+    expect(json.payload.hits).toHaveLength(1);
+  });
+
+  test("returns empty hits for no matches", async () => {
+    const res = await get("/capabilities?query=nothing-here");
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as SignedAssertion<{ hits: CapabilityHit[] }>;
+    expect(json.payload.hits).toEqual([]);
+  });
+});

--- a/src/services/network-registry/__tests__/helpers.ts
+++ b/src/services/network-registry/__tests__/helpers.ts
@@ -1,0 +1,84 @@
+/**
+ * Shared test helpers — operator-side signing rig + assertion helpers.
+ *
+ * The tests deliberately mint REAL Ed25519 keypairs via WebCrypto so the
+ * full verify path is exercised. Generating a fresh keypair per test
+ * isolates state and keeps the suite free of any test-only signing
+ * shortcut that might mask a regression in `signing.ts`.
+ */
+
+import { canonicalJSON, generateKeypair, signEd25519 } from "../src/signing";
+import type { Capability, RegistrationClaim, StackIdentity } from "../src/types";
+import { _setNonceCacheForTest, _setStoreForTest } from "../src/store";
+
+export interface OperatorKey {
+  privateKeyB64: string;
+  publicKeyB64: string;
+}
+
+/**
+ * Generate a per-test operator keypair. Awaited once per test in
+ * beforeEach, then used to sign multiple claims as the test needs.
+ */
+export async function makeOperatorKey(): Promise<OperatorKey> {
+  return generateKeypair();
+}
+
+/**
+ * Generate the registry's signing key. Returned PKCS#8 base64 +
+ * the raw pubkey. Bound into `env` in test setup.
+ */
+export async function makeRegistryKey(): Promise<{
+  signingKey: string;
+  publicKey: string;
+}> {
+  const kp = await generateKeypair();
+  return { signingKey: kp.privateKeyB64, publicKey: kp.publicKeyB64 };
+}
+
+/** Reset module-scoped store + nonce cache between tests. */
+export function resetStores(): void {
+  _setStoreForTest(undefined);
+  _setNonceCacheForTest(undefined);
+}
+
+/**
+ * Build a signed registration body for the given operator. Default
+ * stacks/capabilities are empty; tests override via opts.
+ */
+export async function makeSignedRegistration(
+  operatorId: string,
+  opKey: OperatorKey,
+  opts: {
+    stacks?: StackIdentity[];
+    capabilities?: Capability[];
+    /** Override issued_at — defaults to now. Useful for skew tests. */
+    issuedAt?: string;
+    /** Override nonce — defaults to a fresh random. Useful for replay tests. */
+    nonce?: string;
+    /** Override pubkey in the claim — useful for tampering tests. */
+    pubkeyOverride?: string;
+  } = {},
+): Promise<{ claim: RegistrationClaim; signature: string }> {
+  const claim: RegistrationClaim = {
+    operator_id: operatorId,
+    operator_pubkey: opts.pubkeyOverride ?? opKey.publicKeyB64,
+    stacks: opts.stacks ?? [],
+    capabilities: opts.capabilities ?? [],
+    issued_at: opts.issuedAt ?? new Date().toISOString(),
+    nonce: opts.nonce ?? randomNonce(),
+  };
+  const message = new TextEncoder().encode(canonicalJSON(claim));
+  const signature = await signEd25519(opKey.privateKeyB64, message);
+  return { claim, signature };
+}
+
+export function randomNonce(): string {
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  let out = "";
+  for (let i = 0; i < bytes.length; i++) {
+    out += bytes[i]!.toString(16).padStart(2, "0");
+  }
+  return out;
+}

--- a/src/services/network-registry/__tests__/helpers.ts
+++ b/src/services/network-registry/__tests__/helpers.ts
@@ -10,6 +10,7 @@
 import { canonicalJSON, generateKeypair, signEd25519 } from "../src/signing";
 import type { Capability, RegistrationClaim, StackIdentity } from "../src/types";
 import { _setNonceCacheForTest, _setStoreForTest } from "../src/store";
+import { _resetDerivedPublicKeyForTest } from "../src/index";
 
 export interface OperatorKey {
   privateKeyB64: string;
@@ -36,10 +37,11 @@ export async function makeRegistryKey(): Promise<{
   return { signingKey: kp.privateKeyB64, publicKey: kp.publicKeyB64 };
 }
 
-/** Reset module-scoped store + nonce cache between tests. */
+/** Reset all module-scoped state between tests (store, nonce cache, derived pubkey). */
 export function resetStores(): void {
   _setStoreForTest(undefined);
   _setNonceCacheForTest(undefined);
+  _resetDerivedPublicKeyForTest();
 }
 
 /**

--- a/src/services/network-registry/__tests__/networks.test.ts
+++ b/src/services/network-registry/__tests__/networks.test.ts
@@ -1,0 +1,103 @@
+/**
+ * IAW D.4 — Network roster route tests.
+ */
+
+import { describe, test, expect, beforeEach } from "bun:test";
+import app from "../src/index";
+import type { Env } from "../src/index";
+import {
+  makeOperatorKey,
+  makeRegistryKey,
+  makeSignedRegistration,
+  resetStores,
+  type OperatorKey,
+} from "./helpers";
+import type { NetworkRoster, SignedAssertion } from "../src/types";
+
+let env: Env;
+
+async function post(path: string, body: unknown): Promise<Response> {
+  return app.fetch(
+    new Request(`http://localhost${path}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+    env,
+  );
+}
+
+async function get(path: string): Promise<Response> {
+  return app.fetch(new Request(`http://localhost${path}`), env);
+}
+
+beforeEach(async () => {
+  resetStores();
+  const reg = await makeRegistryKey();
+  env = {
+    REGISTRY_SIGNING_KEY: reg.signingKey,
+    REGISTRY_PUBLIC_KEY: reg.publicKey,
+    ENVIRONMENT: "test",
+  };
+});
+
+describe("GET /networks/:id/roster", () => {
+  test("rejects invalid network_id", async () => {
+    const res = await get("/networks/INVALID_CAPS/roster");
+    expect(res.status).toBe(400);
+  });
+
+  test("returns empty roster when no operators are in the network", async () => {
+    const res = await get("/networks/research-collab/roster");
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as SignedAssertion<NetworkRoster>;
+    expect(json.payload.network_id).toBe("research-collab");
+    expect(json.payload.members).toEqual([]);
+  });
+
+  test("aggregates operators whose capabilities target the network", async () => {
+    const opA: OperatorKey = await makeOperatorKey();
+    const opB: OperatorKey = await makeOperatorKey();
+    const opC: OperatorKey = await makeOperatorKey();
+
+    await post(
+      "/operators/alpha/register",
+      await makeSignedRegistration("alpha", opA, {
+        capabilities: [
+          { id: "tasks.code-review", networks: ["research-collab"] },
+          { id: "tasks.docs-edit", networks: ["docs-net"] },
+        ],
+      }),
+    );
+    await post(
+      "/operators/beta/register",
+      await makeSignedRegistration("beta", opB, {
+        capabilities: [{ id: "tasks.code-review", networks: ["research-collab"] }],
+      }),
+    );
+    // Gamma announces to a different network only — should be excluded.
+    await post(
+      "/operators/gamma/register",
+      await makeSignedRegistration("gamma", opC, {
+        capabilities: [{ id: "tasks.code-review", networks: ["other-net"] }],
+      }),
+    );
+
+    const res = await get("/networks/research-collab/roster");
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as SignedAssertion<NetworkRoster>;
+    const ids = json.payload.members.map((m) => m.operator_id).sort();
+    expect(ids).toEqual(["alpha", "beta"]);
+    const alpha = json.payload.members.find((m) => m.operator_id === "alpha");
+    expect(alpha?.capabilities).toEqual(["tasks.code-review"]);
+    expect(alpha?.operator_pubkey).toBe(opA.publicKeyB64);
+  });
+
+  test("returns signed assertion verifiable with registry pubkey", async () => {
+    const res = await get("/networks/research-collab/roster");
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as SignedAssertion<NetworkRoster>;
+    expect(json.signature.length).toBeGreaterThan(0);
+    expect(json.registry).toBe(env.REGISTRY_PUBLIC_KEY ?? "");
+  });
+});

--- a/src/services/network-registry/__tests__/operators.test.ts
+++ b/src/services/network-registry/__tests__/operators.test.ts
@@ -200,8 +200,11 @@ describe("POST /operators/:id/register — auth failures", () => {
     expect(res2.status).toBe(409);
   });
 
-  test("permits re-register with same pubkey (update stacks)", async () => {
-    const body1 = await makeSignedRegistration("andreas", opKey);
+  test("permits re-register with same pubkey (replaces stacks, no leftover)", async () => {
+    // Echo cortex#225 nit: tighten the symmetric "old stacks gone" assertion.
+    const body1 = await makeSignedRegistration("andreas", opKey, {
+      stacks: [{ stack_id: "andreas/laptop" }],
+    });
     const res1 = await post("/operators/andreas/register", body1);
     expect(res1.status).toBe(201);
 
@@ -213,6 +216,38 @@ describe("POST /operators/:id/register — auth failures", () => {
     const json = (await res2.json()) as SignedAssertion<OperatorRecord>;
     expect(json.payload.stacks).toHaveLength(1);
     expect(json.payload.stacks[0]!.stack_id).toBe("andreas/server");
+    // Confirm the old `andreas/laptop` is fully gone — not just that
+    // the new list has length 1.
+    const ids = json.payload.stacks.map((s) => s.stack_id);
+    expect(ids).not.toContain("andreas/laptop");
+  });
+});
+
+describe("POST /operators/:id/register — unconfigured registry", () => {
+  // Echo cortex#225 issue #1: refuse to mutate state when the Worker
+  // cannot produce a signed receipt.
+  test("returns 503 and does not mutate state when REGISTRY_SIGNING_KEY is absent", async () => {
+    const body = await makeSignedRegistration("andreas", opKey);
+    const unconfigured: Env = { ENVIRONMENT: "test" };
+    const res = await app.fetch(
+      new Request("http://localhost/operators/andreas/register", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      }),
+      unconfigured,
+    );
+    expect(res.status).toBe(503);
+    const json = (await res.json()) as { error: string };
+    expect(json.error).toBe("registry_unconfigured");
+
+    // Switch to a configured env on the same module-shared store and
+    // confirm the operator was NOT silently persisted by the 503 path.
+    const getRes = await app.fetch(
+      new Request("http://localhost/operators/andreas"),
+      env,
+    );
+    expect(getRes.status).toBe(404);
   });
 });
 

--- a/src/services/network-registry/__tests__/operators.test.ts
+++ b/src/services/network-registry/__tests__/operators.test.ts
@@ -1,0 +1,280 @@
+/**
+ * IAW D.4 — Operator route tests (POST register + GET).
+ *
+ * Drives the Worker via `app.fetch(request, env)` so the full Hono
+ * pipeline + middleware + signing path are exercised. Each test resets
+ * module-scoped store/nonce-cache singletons in beforeEach.
+ */
+
+import { describe, test, expect, beforeEach } from "bun:test";
+import app from "../src/index";
+import type { Env } from "../src/index";
+import {
+  makeOperatorKey,
+  makeRegistryKey,
+  makeSignedRegistration,
+  randomNonce,
+  resetStores,
+  type OperatorKey,
+} from "./helpers";
+import {
+  canonicalJSON,
+  signEd25519,
+  verifyEd25519,
+} from "../src/signing";
+import type { SignedAssertion, OperatorRecord } from "../src/types";
+
+let env: Env;
+let opKey: OperatorKey;
+
+beforeEach(async () => {
+  resetStores();
+  const reg = await makeRegistryKey();
+  env = {
+    REGISTRY_SIGNING_KEY: reg.signingKey,
+    REGISTRY_PUBLIC_KEY: reg.publicKey,
+    ENVIRONMENT: "test",
+  };
+  opKey = await makeOperatorKey();
+});
+
+async function post(path: string, body: unknown): Promise<Response> {
+  return app.fetch(
+    new Request(`http://localhost${path}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    }),
+    env,
+  );
+}
+
+async function get(path: string): Promise<Response> {
+  return app.fetch(new Request(`http://localhost${path}`), env);
+}
+
+describe("POST /operators/:id/register — happy path", () => {
+  test("registers a new operator and returns signed assertion", async () => {
+    const body = await makeSignedRegistration("andreas", opKey, {
+      stacks: [{ stack_id: "andreas/laptop", display_name: "Laptop" }],
+      capabilities: [
+        { id: "tasks.code-review", description: "Reviews TS", networks: ["research-collab"] },
+      ],
+    });
+    const res = await post("/operators/andreas/register", body);
+    expect(res.status).toBe(201);
+    const json = (await res.json()) as SignedAssertion<OperatorRecord>;
+    expect(json.payload.operator_id).toBe("andreas");
+    expect(json.payload.operator_pubkey).toBe(opKey.publicKeyB64);
+    expect(json.payload.stacks).toHaveLength(1);
+    expect(json.payload.capabilities).toHaveLength(1);
+    expect(json.signature.length).toBeGreaterThan(0);
+    expect(json.registry).toBe(env.REGISTRY_PUBLIC_KEY ?? "");
+
+    // Verify the registry's signature is structurally correct.
+    const bound = canonicalJSON({
+      payload: json.payload,
+      issued_at: json.issued_at,
+      registry: json.registry,
+    });
+    const ok = await verifyEd25519(
+      env.REGISTRY_PUBLIC_KEY!,
+      json.signature,
+      new TextEncoder().encode(bound),
+    );
+    expect(ok).toBe(true);
+  });
+});
+
+describe("POST /operators/:id/register — validation failures", () => {
+  test("rejects invalid operator_id in path", async () => {
+    const body = await makeSignedRegistration("andreas", opKey);
+    const res = await post("/operators/INVALID_CAPS/register", body);
+    expect(res.status).toBe(400);
+  });
+
+  test("rejects body operator_id mismatch with path", async () => {
+    const body = await makeSignedRegistration("not-andreas", opKey);
+    const res = await post("/operators/andreas/register", body);
+    expect(res.status).toBe(400);
+    const json = (await res.json()) as { details: { field: string }[] };
+    expect(json.details.some((d) => d.field === "operator_id")).toBe(true);
+  });
+
+  test("rejects stack_id whose operator prefix doesn't match", async () => {
+    const body = await makeSignedRegistration("andreas", opKey, {
+      stacks: [{ stack_id: "someoneelse/laptop" }],
+    });
+    const res = await post("/operators/andreas/register", body);
+    expect(res.status).toBe(400);
+  });
+
+  test("rejects duplicate stack_id within same claim", async () => {
+    const body = await makeSignedRegistration("andreas", opKey, {
+      stacks: [{ stack_id: "andreas/laptop" }, { stack_id: "andreas/laptop" }],
+    });
+    const res = await post("/operators/andreas/register", body);
+    expect(res.status).toBe(400);
+  });
+
+  test("rejects malformed pubkey", async () => {
+    const body = await makeSignedRegistration("andreas", opKey, {
+      pubkeyOverride: "short",
+    });
+    const res = await post("/operators/andreas/register", body);
+    expect(res.status).toBe(400);
+  });
+
+  test("rejects capability id violating <domain>.<entity> grammar", async () => {
+    const body = await makeSignedRegistration("andreas", opKey, {
+      capabilities: [{ id: "no-dot-here" }],
+    });
+    const res = await post("/operators/andreas/register", body);
+    expect(res.status).toBe(400);
+  });
+
+  test("rejects missing nonce", async () => {
+    const body = await makeSignedRegistration("andreas", opKey, { nonce: "" });
+    const res = await post("/operators/andreas/register", body);
+    expect(res.status).toBe(400);
+  });
+
+  test("rejects invalid JSON body", async () => {
+    const res = await app.fetch(
+      new Request("http://localhost/operators/andreas/register", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "not json",
+      }),
+      env,
+    );
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("POST /operators/:id/register — auth failures", () => {
+  test("rejects signature signed by wrong key", async () => {
+    const otherKey = await makeOperatorKey();
+    const body = await makeSignedRegistration("andreas", otherKey, {
+      pubkeyOverride: opKey.publicKeyB64, // claim pubkey from someone else
+    });
+    const res = await post("/operators/andreas/register", body);
+    expect(res.status).toBe(401);
+  });
+
+  test("rejects tampered claim after signing", async () => {
+    const body = await makeSignedRegistration("andreas", opKey);
+    // Tamper: add an extra stack post-signature.
+    body.claim.stacks.push({ stack_id: "andreas/sneaked-in" });
+    const res = await post("/operators/andreas/register", body);
+    expect(res.status).toBe(401);
+  });
+
+  test("rejects issued_at outside skew window", async () => {
+    const old = new Date(Date.now() - 30 * 60 * 1000).toISOString();
+    const body = await makeSignedRegistration("andreas", opKey, { issuedAt: old });
+    const res = await post("/operators/andreas/register", body);
+    expect(res.status).toBe(400);
+  });
+
+  test("rejects replayed nonce", async () => {
+    const nonce = randomNonce();
+    const body1 = await makeSignedRegistration("andreas", opKey, { nonce });
+    const res1 = await post("/operators/andreas/register", body1);
+    expect(res1.status).toBe(201);
+
+    // Same nonce, different claim (different stacks list to bypass any other gates)
+    const body2 = await makeSignedRegistration("andreas", opKey, { nonce });
+    const res2 = await post("/operators/andreas/register", body2);
+    expect(res2.status).toBe(409);
+  });
+
+  test("rejects silent pubkey rotation", async () => {
+    const body1 = await makeSignedRegistration("andreas", opKey);
+    const res1 = await post("/operators/andreas/register", body1);
+    expect(res1.status).toBe(201);
+
+    const newKey = await makeOperatorKey();
+    const body2 = await makeSignedRegistration("andreas", newKey);
+    const res2 = await post("/operators/andreas/register", body2);
+    expect(res2.status).toBe(409);
+  });
+
+  test("permits re-register with same pubkey (update stacks)", async () => {
+    const body1 = await makeSignedRegistration("andreas", opKey);
+    const res1 = await post("/operators/andreas/register", body1);
+    expect(res1.status).toBe(201);
+
+    const body2 = await makeSignedRegistration("andreas", opKey, {
+      stacks: [{ stack_id: "andreas/server" }],
+    });
+    const res2 = await post("/operators/andreas/register", body2);
+    expect(res2.status).toBe(201);
+    const json = (await res2.json()) as SignedAssertion<OperatorRecord>;
+    expect(json.payload.stacks).toHaveLength(1);
+    expect(json.payload.stacks[0]!.stack_id).toBe("andreas/server");
+  });
+});
+
+describe("GET /operators/:id", () => {
+  test("returns 404 for unknown operator", async () => {
+    const res = await get("/operators/nobody");
+    expect(res.status).toBe(404);
+  });
+
+  test("returns signed assertion for registered operator", async () => {
+    const body = await makeSignedRegistration("andreas", opKey, {
+      stacks: [{ stack_id: "andreas/laptop" }],
+    });
+    await post("/operators/andreas/register", body);
+
+    const res = await get("/operators/andreas");
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as SignedAssertion<OperatorRecord>;
+    expect(json.payload.operator_pubkey).toBe(opKey.publicKeyB64);
+    expect(json.signature.length).toBeGreaterThan(0);
+
+    // Verify registry signature.
+    const bound = canonicalJSON({
+      payload: json.payload,
+      issued_at: json.issued_at,
+      registry: json.registry,
+    });
+    const ok = await verifyEd25519(
+      env.REGISTRY_PUBLIC_KEY!,
+      json.signature,
+      new TextEncoder().encode(bound),
+    );
+    expect(ok).toBe(true);
+  });
+
+  test("invalid operator_id in path returns 400", async () => {
+    const res = await get("/operators/CAPS_INVALID");
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("GET /registry/pubkey", () => {
+  test("returns registry pubkey", async () => {
+    const res = await get("/registry/pubkey");
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { algorithm: string; public_key: string };
+    expect(json.algorithm).toBe("Ed25519");
+    expect(json.public_key).toBe(env.REGISTRY_PUBLIC_KEY ?? "");
+  });
+
+  test("returns 503 when unconfigured", async () => {
+    const unconfigured: Env = { ENVIRONMENT: "test" };
+    const res = await app.fetch(new Request("http://localhost/registry/pubkey"), unconfigured);
+    expect(res.status).toBe(503);
+  });
+});
+
+describe("GET /api/health", () => {
+  test("returns ok", async () => {
+    const res = await get("/api/health");
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { status: string };
+    expect(json.status).toBe("ok");
+  });
+});

--- a/src/services/network-registry/__tests__/signing.test.ts
+++ b/src/services/network-registry/__tests__/signing.test.ts
@@ -1,0 +1,105 @@
+/**
+ * IAW D.4 — Crypto primitive tests.
+ *
+ * Exercises canonicalJSON determinism, Ed25519 sign/verify round-trip,
+ * and the PKCS#8 → raw pubkey derivation used at boot.
+ */
+
+import { describe, test, expect } from "bun:test";
+import {
+  base64ToBytes,
+  bytesToBase64,
+  canonicalJSON,
+  generateKeypair,
+  pubkeyFromPkcs8,
+  signEd25519,
+  verifyEd25519,
+} from "../src/signing";
+
+describe("canonicalJSON", () => {
+  test("sorts object keys recursively", () => {
+    const a = { b: 1, a: 2, nested: { y: 1, x: 2 } };
+    expect(canonicalJSON(a)).toBe('{"a":2,"b":1,"nested":{"x":2,"y":1}}');
+  });
+
+  test("preserves array order", () => {
+    expect(canonicalJSON([3, 1, 2])).toBe("[3,1,2]");
+  });
+
+  test("primitives round-trip", () => {
+    expect(canonicalJSON("hi")).toBe('"hi"');
+    expect(canonicalJSON(42)).toBe("42");
+    expect(canonicalJSON(null)).toBe("null");
+    expect(canonicalJSON(true)).toBe("true");
+  });
+
+  test("two equivalent objects produce the same string regardless of input key order", () => {
+    const a = { b: 1, a: { z: 1, q: 2 } };
+    const b = { a: { q: 2, z: 1 }, b: 1 };
+    expect(canonicalJSON(a)).toBe(canonicalJSON(b));
+  });
+});
+
+describe("base64 round-trip", () => {
+  test("encode/decode is identity", () => {
+    const original = new Uint8Array([0, 1, 2, 3, 4, 250, 251, 252]);
+    const round = base64ToBytes(bytesToBase64(original));
+    expect(round).toEqual(original);
+  });
+
+  test("rejects malformed base64", () => {
+    expect(() => base64ToBytes("not valid !@#$")).toThrow();
+  });
+});
+
+describe("Ed25519 sign/verify", () => {
+  test("valid signature verifies", async () => {
+    const kp = await generateKeypair();
+    const msg = new TextEncoder().encode("hello");
+    const sig = await signEd25519(kp.privateKeyB64, msg);
+    expect(await verifyEd25519(kp.publicKeyB64, sig, msg)).toBe(true);
+  });
+
+  test("tampered message fails verification", async () => {
+    const kp = await generateKeypair();
+    const msg = new TextEncoder().encode("hello");
+    const sig = await signEd25519(kp.privateKeyB64, msg);
+    const tampered = new TextEncoder().encode("hellp");
+    expect(await verifyEd25519(kp.publicKeyB64, sig, tampered)).toBe(false);
+  });
+
+  test("wrong pubkey fails verification", async () => {
+    const kp1 = await generateKeypair();
+    const kp2 = await generateKeypair();
+    const msg = new TextEncoder().encode("hello");
+    const sig = await signEd25519(kp1.privateKeyB64, msg);
+    expect(await verifyEd25519(kp2.publicKeyB64, sig, msg)).toBe(false);
+  });
+
+  test("malformed pubkey returns false (does not throw)", async () => {
+    const kp = await generateKeypair();
+    const msg = new TextEncoder().encode("hello");
+    const sig = await signEd25519(kp.privateKeyB64, msg);
+    expect(await verifyEd25519("not-base64-!!!", sig, msg)).toBe(false);
+  });
+
+  test("wrong-length pubkey returns false", async () => {
+    const kp = await generateKeypair();
+    const msg = new TextEncoder().encode("hello");
+    const sig = await signEd25519(kp.privateKeyB64, msg);
+    // 16 bytes base64
+    const shortPub = bytesToBase64(new Uint8Array(16));
+    expect(await verifyEd25519(shortPub, sig, msg)).toBe(false);
+  });
+});
+
+describe("pubkeyFromPkcs8", () => {
+  test("derives the same pubkey as generation", async () => {
+    const kp = await generateKeypair();
+    const derived = await pubkeyFromPkcs8(kp.privateKeyB64);
+    // Verify by signing with private key + checking derived pubkey accepts it.
+    const msg = new TextEncoder().encode("derive-check");
+    const sig = await signEd25519(kp.privateKeyB64, msg);
+    expect(await verifyEd25519(derived, sig, msg)).toBe(true);
+  });
+});

--- a/src/services/network-registry/bun.lock
+++ b/src/services/network-registry/bun.lock
@@ -1,0 +1,211 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "cortex-network-registry",
+      "dependencies": {
+        "hono": "4.12.10",
+      },
+      "devDependencies": {
+        "@cloudflare/workers-types": "4.20260404.1",
+        "@types/bun": "1.3.11",
+        "typescript": "5.9.3",
+        "wrangler": "4.80.0",
+      },
+    },
+  },
+  "packages": {
+    "@cloudflare/kv-asset-handler": ["@cloudflare/kv-asset-handler@0.4.2", "", {}, "sha512-SIOD2DxrRRwQ+jgzlXCqoEFiKOFqaPjhnNTGKXSRLvp1HiOvapLaFG2kEr9dYQTYe8rKrd9uvDUzmAITeNyaHQ=="],
+
+    "@cloudflare/unenv-preset": ["@cloudflare/unenv-preset@2.16.0", "", { "peerDependencies": { "unenv": "2.0.0-rc.24", "workerd": "1.20260301.1 || ~1.20260302.1 || ~1.20260303.1 || ~1.20260304.1 || >1.20260305.0 <2.0.0-0" }, "optionalPeers": ["workerd"] }, "sha512-8ovsRpwzPoEqPUzoErAYVv8l3FMZNeBVQfJTvtzP4AgLSRGZISRfuChFxHWUQd3n6cnrwkuTGxT+2cGo8EsyYg=="],
+
+    "@cloudflare/workerd-darwin-64": ["@cloudflare/workerd-darwin-64@1.20260401.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-ZSmceM70jH6k+/62VkEcmMNzrpr4kSctkX5Lsgqv38KktfhPY/hsh75y1lRoPWS3H3kgMa4p2pUSlidZR1u2hw=="],
+
+    "@cloudflare/workerd-darwin-arm64": ["@cloudflare/workerd-darwin-arm64@1.20260401.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-7UKWF+IUZ3NXMVPsDg8Cjg0r58b+uYlfvs5Yt8bvtU+geCtW4P2MxRHmRSEo8SryckXOJjb/b8tcncgCykFu8g=="],
+
+    "@cloudflare/workerd-linux-64": ["@cloudflare/workerd-linux-64@1.20260401.1", "", { "os": "linux", "cpu": "x64" }, "sha512-MDWUH/0bvL/l9aauN8zEddyYOXId1OueqrUCXXENNJ95R/lSmF6OgGVuXaYhoIhxQkNiEJ/0NOlnVYj9mJq4dw=="],
+
+    "@cloudflare/workerd-linux-arm64": ["@cloudflare/workerd-linux-arm64@1.20260401.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-UgkzpMzVWM/bwbo3vjCTg2aoKfGcUhiEoQoDdo6RGWvbHRJyLVZ4VQCG9ZcISiztkiS2ICCoYOtPy6M/lV6Gcw=="],
+
+    "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260401.1", "", { "os": "win32", "cpu": "x64" }, "sha512-HBLzcQF5iF4Qv20tQ++pG7xs3OsCnaIbc+GAi6fmhUKZhvmzvml/jwrQzLJ+MPm0cQo41K5OO/U3T4S8tvJetQ=="],
+
+    "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20260404.1", "", {}, "sha512-jfZfktdn3D0ceA59i4lkMgPUR9p5Wd6trtNLQR1RTgF59iVt9/yegkiEZv0TQvJPXlmQOU1D0pAYz7cMztqErg=="],
+
+    "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
+
+    "@emnapi/runtime": ["@emnapi/runtime@1.10.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA=="],
+
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.3", "", { "os": "aix", "cpu": "ppc64" }, "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.27.3", "", { "os": "android", "cpu": "arm" }, "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.3", "", { "os": "android", "cpu": "arm64" }, "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.27.3", "", { "os": "android", "cpu": "x64" }, "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.3", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.3", "", { "os": "freebsd", "cpu": "x64" }, "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.3", "", { "os": "linux", "cpu": "arm" }, "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.3", "", { "os": "linux", "cpu": "ia32" }, "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.3", "", { "os": "linux", "cpu": "none" }, "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.3", "", { "os": "linux", "cpu": "none" }, "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.3", "", { "os": "linux", "cpu": "ppc64" }, "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.3", "", { "os": "linux", "cpu": "none" }, "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.3", "", { "os": "linux", "cpu": "s390x" }, "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.3", "", { "os": "linux", "cpu": "x64" }, "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA=="],
+
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.3", "", { "os": "none", "cpu": "arm64" }, "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.3", "", { "os": "none", "cpu": "x64" }, "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA=="],
+
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.3", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.3", "", { "os": "openbsd", "cpu": "x64" }, "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ=="],
+
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.3", "", { "os": "none", "cpu": "arm64" }, "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.3", "", { "os": "sunos", "cpu": "x64" }, "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.3", "", { "os": "win32", "cpu": "ia32" }, "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.3", "", { "os": "win32", "cpu": "x64" }, "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA=="],
+
+    "@img/colour": ["@img/colour@1.1.0", "", {}, "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ=="],
+
+    "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.2.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w=="],
+
+    "@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.2.4" }, "os": "darwin", "cpu": "x64" }, "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw=="],
+
+    "@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.2.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g=="],
+
+    "@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.2.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg=="],
+
+    "@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.2.4", "", { "os": "linux", "cpu": "arm" }, "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A=="],
+
+    "@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw=="],
+
+    "@img/sharp-libvips-linux-ppc64": ["@img/sharp-libvips-linux-ppc64@1.2.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA=="],
+
+    "@img/sharp-libvips-linux-riscv64": ["@img/sharp-libvips-linux-riscv64@1.2.4", "", { "os": "linux", "cpu": "none" }, "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA=="],
+
+    "@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.2.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ=="],
+
+    "@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw=="],
+
+    "@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw=="],
+
+    "@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg=="],
+
+    "@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.2.4" }, "os": "linux", "cpu": "arm" }, "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw=="],
+
+    "@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg=="],
+
+    "@img/sharp-linux-ppc64": ["@img/sharp-linux-ppc64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-ppc64": "1.2.4" }, "os": "linux", "cpu": "ppc64" }, "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA=="],
+
+    "@img/sharp-linux-riscv64": ["@img/sharp-linux-riscv64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-riscv64": "1.2.4" }, "os": "linux", "cpu": "none" }, "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw=="],
+
+    "@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.2.4" }, "os": "linux", "cpu": "s390x" }, "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg=="],
+
+    "@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ=="],
+
+    "@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg=="],
+
+    "@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q=="],
+
+    "@img/sharp-wasm32": ["@img/sharp-wasm32@0.34.5", "", { "dependencies": { "@emnapi/runtime": "^1.7.0" }, "cpu": "none" }, "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw=="],
+
+    "@img/sharp-win32-arm64": ["@img/sharp-win32-arm64@0.34.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g=="],
+
+    "@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.34.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg=="],
+
+    "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw=="],
+
+    "@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.1.2", "", {}, "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="],
+
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.9", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.0.3", "@jridgewell/sourcemap-codec": "^1.4.10" } }, "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ=="],
+
+    "@poppinss/colors": ["@poppinss/colors@4.1.6", "", { "dependencies": { "kleur": "^4.1.5" } }, "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg=="],
+
+    "@poppinss/dumper": ["@poppinss/dumper@0.6.5", "", { "dependencies": { "@poppinss/colors": "^4.1.5", "@sindresorhus/is": "^7.0.2", "supports-color": "^10.0.0" } }, "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw=="],
+
+    "@poppinss/exception": ["@poppinss/exception@1.2.3", "", {}, "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw=="],
+
+    "@sindresorhus/is": ["@sindresorhus/is@7.2.0", "", {}, "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw=="],
+
+    "@speed-highlight/core": ["@speed-highlight/core@1.2.15", "", {}, "sha512-BMq1K3DsElxDWawkX6eLg9+CKJrTVGCBAWVuHXVUV2u0s2711qiChLSId6ikYPfxhdYocLNt3wWwSvDiTvFabw=="],
+
+    "@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
+
+    "@types/node": ["@types/node@25.8.0", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-TCFSk8IZh+iLX1xtksoBVtdmgL+1IX0fC9BeU4QqFSuNdN/K+HUlhqOzEmSYYpZUVsLYcPqc9KX+60iDuninSQ=="],
+
+    "blake3-wasm": ["blake3-wasm@2.1.5", "", {}, "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g=="],
+
+    "bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
+
+    "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
+
+    "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
+    "error-stack-parser-es": ["error-stack-parser-es@1.0.5", "", {}, "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA=="],
+
+    "esbuild": ["esbuild@0.27.3", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.3", "@esbuild/android-arm": "0.27.3", "@esbuild/android-arm64": "0.27.3", "@esbuild/android-x64": "0.27.3", "@esbuild/darwin-arm64": "0.27.3", "@esbuild/darwin-x64": "0.27.3", "@esbuild/freebsd-arm64": "0.27.3", "@esbuild/freebsd-x64": "0.27.3", "@esbuild/linux-arm": "0.27.3", "@esbuild/linux-arm64": "0.27.3", "@esbuild/linux-ia32": "0.27.3", "@esbuild/linux-loong64": "0.27.3", "@esbuild/linux-mips64el": "0.27.3", "@esbuild/linux-ppc64": "0.27.3", "@esbuild/linux-riscv64": "0.27.3", "@esbuild/linux-s390x": "0.27.3", "@esbuild/linux-x64": "0.27.3", "@esbuild/netbsd-arm64": "0.27.3", "@esbuild/netbsd-x64": "0.27.3", "@esbuild/openbsd-arm64": "0.27.3", "@esbuild/openbsd-x64": "0.27.3", "@esbuild/openharmony-arm64": "0.27.3", "@esbuild/sunos-x64": "0.27.3", "@esbuild/win32-arm64": "0.27.3", "@esbuild/win32-ia32": "0.27.3", "@esbuild/win32-x64": "0.27.3" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg=="],
+
+    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "hono": ["hono@4.12.10", "", {}, "sha512-mx/p18PLy5og9ufies2GOSUqep98Td9q4i/EF6X7yJgAiIopxqdfIO3jbqsi3jRgTgw88jMDEzVKi+V2EF+27w=="],
+
+    "kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
+
+    "miniflare": ["miniflare@4.20260401.0", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "sharp": "^0.34.5", "undici": "7.24.4", "workerd": "1.20260401.1", "ws": "8.18.0", "youch": "4.1.0-beta.10" }, "bin": { "miniflare": "bootstrap.js" } }, "sha512-lngHPzZFN9sxYG/mhzvnWiBMNVAN5MsO/7g32ttJ07rymtiK/ZBalODTKb8Od+BQdlU5DOR4CjVt9NydjnUyYg=="],
+
+    "path-to-regexp": ["path-to-regexp@6.3.0", "", {}, "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ=="],
+
+    "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
+
+    "semver": ["semver@7.8.0", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA=="],
+
+    "sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
+
+    "supports-color": ["supports-color@10.2.2", "", {}, "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g=="],
+
+    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici": ["undici@7.24.4", "", {}, "sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w=="],
+
+    "undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
+
+    "unenv": ["unenv@2.0.0-rc.24", "", { "dependencies": { "pathe": "^2.0.3" } }, "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw=="],
+
+    "workerd": ["workerd@1.20260401.1", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20260401.1", "@cloudflare/workerd-darwin-arm64": "1.20260401.1", "@cloudflare/workerd-linux-64": "1.20260401.1", "@cloudflare/workerd-linux-arm64": "1.20260401.1", "@cloudflare/workerd-windows-64": "1.20260401.1" }, "bin": { "workerd": "bin/workerd" } }, "sha512-mUYCd+ohaWJWF5nhDzxugWaAD/DM8Dw0ze3B7bu8JaA7S70+XQJXcvcvwE8C4qGcxSdCyqjsrFzqxKubECDwzg=="],
+
+    "wrangler": ["wrangler@4.80.0", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.4.2", "@cloudflare/unenv-preset": "2.16.0", "blake3-wasm": "2.1.5", "esbuild": "0.27.3", "miniflare": "4.20260401.0", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.24", "workerd": "1.20260401.1" }, "optionalDependencies": { "fsevents": "~2.3.2" }, "peerDependencies": { "@cloudflare/workers-types": "^4.20260401.1" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js" } }, "sha512-2ZKF7uPeOZy65BGk3YfvqBCPo/xH1MrAlMmH9mVP+tCNBrTUMnwOHSj1HrZHgR8LttkAqhko0fGz+I4ax1rzyQ=="],
+
+    "ws": ["ws@8.18.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw=="],
+
+    "youch": ["youch@4.1.0-beta.10", "", { "dependencies": { "@poppinss/colors": "^4.1.5", "@poppinss/dumper": "^0.6.4", "@speed-highlight/core": "^1.2.7", "cookie": "^1.0.2", "youch-core": "^0.3.3" } }, "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ=="],
+
+    "youch-core": ["youch-core@0.3.3", "", { "dependencies": { "@poppinss/exception": "^1.2.2", "error-stack-parser-es": "^1.0.5" } }, "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA=="],
+  }
+}

--- a/src/services/network-registry/package.json
+++ b/src/services/network-registry/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "cortex-network-registry",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy",
+    "test": "bun test"
+  },
+  "dependencies": {
+    "hono": "4.12.10"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "4.20260404.1",
+    "@types/bun": "1.3.11",
+    "typescript": "5.9.3",
+    "wrangler": "4.80.0"
+  }
+}

--- a/src/services/network-registry/src/index.ts
+++ b/src/services/network-registry/src/index.ts
@@ -74,33 +74,57 @@ app.use(
 // ---------------------------------------------------------------------------
 // On-boot: derive the registry pubkey from the signing key if not provided
 // explicitly. We piggyback on a request-scoped initialiser to keep the
-// global state simple — the derived key is cached at module scope.
+// global state simple — the derived key is cached at module scope and
+// read by `signAssertion` without mutating `c.env`.
+//
+// Echo cortex#225 issue #4: previously we patched `c.env.REGISTRY_PUBLIC_KEY`
+// per-request. Treating `env` as mutable works on Bun (plain object) but is
+// a footgun on real Workers, where `env` is frozen-ish and the runtime may
+// snapshot it. Module-scoped cache + explicit getter is the safer shape.
 // ---------------------------------------------------------------------------
 
 let derivedPublicKey: string | undefined;
 let derivedFromKey: string | undefined;
 
 async function ensurePublicKey(env: Env): Promise<void> {
-  if (env.REGISTRY_PUBLIC_KEY) return;
-  if (!env.REGISTRY_SIGNING_KEY) return;
-  if (derivedFromKey === env.REGISTRY_SIGNING_KEY && derivedPublicKey) {
-    // Already derived for this signing key — patch env (per-request) and exit.
-    env.REGISTRY_PUBLIC_KEY = derivedPublicKey;
+  if (env.REGISTRY_PUBLIC_KEY) {
+    // Caller-provided pubkey wins; mirror into the module cache so
+    // `getRegistryPublicKey` short-circuits without re-checking env.
+    if (derivedFromKey !== env.REGISTRY_SIGNING_KEY) {
+      derivedPublicKey = env.REGISTRY_PUBLIC_KEY;
+      derivedFromKey = env.REGISTRY_SIGNING_KEY ?? "explicit";
+    }
     return;
   }
+  if (!env.REGISTRY_SIGNING_KEY) return;
+  if (derivedFromKey === env.REGISTRY_SIGNING_KEY && derivedPublicKey) return;
   try {
     const pub = await pubkeyFromPkcs8(env.REGISTRY_SIGNING_KEY);
     derivedPublicKey = pub;
     derivedFromKey = env.REGISTRY_SIGNING_KEY;
-    env.REGISTRY_PUBLIC_KEY = pub;
   } catch (err) {
     // Surface as a 500 once a request lands; do not throw at boot
     // because the Worker would crash-loop and lose the diagnostic.
     // The pubkey route emits the structured error.
-    process.stderr.write(
-      `[network-registry] failed to derive pubkey: ${err instanceof Error ? err.message : String(err)}\n`,
+    console.error(
+      `[network-registry] failed to derive pubkey: ${err instanceof Error ? err.message : String(err)}`,
     );
   }
+}
+
+/**
+ * Read the registry public key without mutating `env`. Routes that need
+ * the pubkey at request time call this; `signAssertion` resolves it via
+ * the same path. Returns `undefined` if the Worker is unconfigured.
+ */
+export function getRegistryPublicKey(env: Env): string | undefined {
+  return env.REGISTRY_PUBLIC_KEY ?? derivedPublicKey;
+}
+
+/** Test-only — reset module-scoped derivation cache between cases. */
+export function _resetDerivedPublicKeyForTest(): void {
+  derivedPublicKey = undefined;
+  derivedFromKey = undefined;
 }
 
 app.use("*", async (c, next) => {
@@ -123,7 +147,8 @@ app.get("/api/health", (c) =>
 );
 
 app.get("/registry/pubkey", (c) => {
-  if (!c.env.REGISTRY_PUBLIC_KEY) {
+  const pub = getRegistryPublicKey(c.env);
+  if (!pub) {
     return c.json(
       {
         error: "registry_unconfigured",
@@ -133,7 +158,7 @@ app.get("/registry/pubkey", (c) => {
       503,
     );
   }
-  return c.json({ algorithm: "Ed25519", public_key: c.env.REGISTRY_PUBLIC_KEY });
+  return c.json({ algorithm: "Ed25519", public_key: pub });
 });
 
 // ---------------------------------------------------------------------------
@@ -155,7 +180,7 @@ app.notFound((c) => c.json({ error: "not_found" }, 404));
 // ---------------------------------------------------------------------------
 
 app.onError((err, c) => {
-  process.stderr.write(`[network-registry] unhandled error: ${err.message}\n${err.stack ?? ""}\n`);
+  console.error(`[network-registry] unhandled error: ${err.message}\n${err.stack ?? ""}`);
   return c.json({ error: "internal_error" }, 500);
 });
 

--- a/src/services/network-registry/src/index.ts
+++ b/src/services/network-registry/src/index.ts
@@ -1,0 +1,162 @@
+/**
+ * IAW D.4 — Cortex network registry service (Cloudflare Worker).
+ *
+ * Hono REST API. Canonical pubkey directory for the IAW federation
+ * (Q3 lock-in: centralised, NOT NATS-gossiped). Cortex consults the
+ * registry at startup + on schedule to refresh peer pubkeys.
+ *
+ * Endpoints (D.4.2):
+ *   POST /operators/{operator_id}/register
+ *   GET  /operators/{operator_id}
+ *   GET  /networks/{network_id}/roster
+ *   GET  /capabilities?query=<substring>
+ *   GET  /registry/pubkey                 — pin this client-side
+ *   GET  /api/health                      — liveness probe
+ *
+ * Trust model
+ * ───────────
+ * - POST /operators/.../register is open at the HTTP layer; authenticity
+ *   is enforced by the signed assertion in the body (operator Ed25519
+ *   signature over canonical-JSON of the claim, verified against the
+ *   declared pubkey). First-sight is TOFU; subsequent registers MUST
+ *   sign with the on-record pubkey. Rotation (transition claim co-signed
+ *   by the previous key) is a v2 follow-up.
+ * - GET responses are wrapped in a `SignedAssertion` carrying the
+ *   registry's own Ed25519 signature over `{ payload, issued_at,
+ *   registry }`. Cortex peers MUST pin the registry pubkey at config
+ *   time and verify before mutating their local cache (D.4.4).
+ *
+ * No CF Access bypass policies. M2M traffic authenticates at the
+ * application layer via Ed25519 — same defense-in-depth model as
+ * grove-api S-058.
+ */
+
+import { Hono } from "hono";
+import { cors } from "hono/cors";
+import { operatorRoutes } from "./routes/operators";
+import { networkRoutes } from "./routes/networks";
+import { capabilityRoutes } from "./routes/capabilities";
+import { pubkeyFromPkcs8 } from "./signing";
+
+export interface Env {
+  /**
+   * Base64-encoded PKCS#8 Ed25519 private key used to sign GET
+   * responses. Provisioned via `wrangler secret put` per the
+   * wrangler.toml header. Absent in dev — see `signAssertion` for
+   * the "unconfigured" fallback behaviour.
+   */
+  REGISTRY_SIGNING_KEY?: string;
+  /**
+   * Base64-encoded Ed25519 public key matching REGISTRY_SIGNING_KEY.
+   * Computed at boot from the private key if unset — kept as a
+   * separate env var so the lookup path through `signAssertion`
+   * stays synchronous on the hot path.
+   */
+  REGISTRY_PUBLIC_KEY?: string;
+  ENVIRONMENT?: string;
+}
+
+const app = new Hono<{ Bindings: Env }>();
+
+// ---------------------------------------------------------------------------
+// CORS — registry is read-public by design; lock origins as deployment grows.
+// ---------------------------------------------------------------------------
+
+app.use(
+  "*",
+  cors({
+    origin: "*", // OK for v1 — responses are signed; reads are non-sensitive.
+    allowMethods: ["GET", "POST", "OPTIONS"],
+    allowHeaders: ["Content-Type"],
+  }),
+);
+
+// ---------------------------------------------------------------------------
+// On-boot: derive the registry pubkey from the signing key if not provided
+// explicitly. We piggyback on a request-scoped initialiser to keep the
+// global state simple — the derived key is cached at module scope.
+// ---------------------------------------------------------------------------
+
+let derivedPublicKey: string | undefined;
+let derivedFromKey: string | undefined;
+
+async function ensurePublicKey(env: Env): Promise<void> {
+  if (env.REGISTRY_PUBLIC_KEY) return;
+  if (!env.REGISTRY_SIGNING_KEY) return;
+  if (derivedFromKey === env.REGISTRY_SIGNING_KEY && derivedPublicKey) {
+    // Already derived for this signing key — patch env (per-request) and exit.
+    env.REGISTRY_PUBLIC_KEY = derivedPublicKey;
+    return;
+  }
+  try {
+    const pub = await pubkeyFromPkcs8(env.REGISTRY_SIGNING_KEY);
+    derivedPublicKey = pub;
+    derivedFromKey = env.REGISTRY_SIGNING_KEY;
+    env.REGISTRY_PUBLIC_KEY = pub;
+  } catch (err) {
+    // Surface as a 500 once a request lands; do not throw at boot
+    // because the Worker would crash-loop and lose the diagnostic.
+    // The pubkey route emits the structured error.
+    process.stderr.write(
+      `[network-registry] failed to derive pubkey: ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+  }
+}
+
+app.use("*", async (c, next) => {
+  await ensurePublicKey(c.env);
+  await next();
+});
+
+// ---------------------------------------------------------------------------
+// Health + pubkey
+// ---------------------------------------------------------------------------
+
+app.get("/api/health", (c) =>
+  c.json({
+    status: "ok",
+    service: "cortex-network-registry",
+    runtime: "cloudflare-workers",
+    environment: c.env.ENVIRONMENT ?? "unknown",
+    api_version: 1,
+  }),
+);
+
+app.get("/registry/pubkey", (c) => {
+  if (!c.env.REGISTRY_PUBLIC_KEY) {
+    return c.json(
+      {
+        error: "registry_unconfigured",
+        details:
+          "REGISTRY_SIGNING_KEY not provisioned; this Worker is running in dev/no-key mode and cannot produce signed assertions",
+      },
+      503,
+    );
+  }
+  return c.json({ algorithm: "Ed25519", public_key: c.env.REGISTRY_PUBLIC_KEY });
+});
+
+// ---------------------------------------------------------------------------
+// Mount route groups
+// ---------------------------------------------------------------------------
+
+app.route("/", operatorRoutes());
+app.route("/", networkRoutes());
+app.route("/", capabilityRoutes());
+
+// ---------------------------------------------------------------------------
+// 404
+// ---------------------------------------------------------------------------
+
+app.notFound((c) => c.json({ error: "not_found" }, 404));
+
+// ---------------------------------------------------------------------------
+// Error handler — log and return a structured 500 so peers don't get HTML.
+// ---------------------------------------------------------------------------
+
+app.onError((err, c) => {
+  process.stderr.write(`[network-registry] unhandled error: ${err.message}\n${err.stack ?? ""}\n`);
+  return c.json({ error: "internal_error" }, 500);
+});
+
+export default app;

--- a/src/services/network-registry/src/routes/capabilities.ts
+++ b/src/services/network-registry/src/routes/capabilities.ts
@@ -1,0 +1,39 @@
+/**
+ * IAW D.4.2 — Capability search.
+ *
+ *   GET /capabilities?query=<substring>
+ *     Capability search across networks. Substring match against
+ *     `capability.id` and `capability.description` (case-insensitive).
+ *     Response wrapped in a registry-signed assertion. v1 returns
+ *     unsorted, unpaginated hits — pagination is a follow-up.
+ */
+
+import { Hono } from "hono";
+import type { Env } from "../index";
+import { signAssertion } from "./operators";
+import { getStore, searchCapabilities } from "../store";
+
+/** Hard cap on result count so pathological queries don't blow up. */
+const MAX_HITS = 500;
+
+export function capabilityRoutes(): Hono<{ Bindings: Env }> {
+  const app = new Hono<{ Bindings: Env }>();
+
+  app.get("/capabilities", async (c) => {
+    const query = c.req.query("query") ?? "";
+    if (query.length === 0) {
+      return c.json({ error: "missing required query parameter 'query'" }, 400);
+    }
+    if (query.length > 128) {
+      return c.json({ error: "query parameter too long (max 128 chars)" }, 400);
+    }
+    const store = getStore();
+    const operators = await store.listOperators();
+    const allHits = searchCapabilities(operators, query);
+    const hits = allHits.slice(0, MAX_HITS);
+    const assertion = await signAssertion(c.env, { query, hits, truncated: allHits.length > MAX_HITS });
+    return c.json(assertion);
+  });
+
+  return app;
+}

--- a/src/services/network-registry/src/routes/networks.ts
+++ b/src/services/network-registry/src/routes/networks.ts
@@ -1,0 +1,34 @@
+/**
+ * IAW D.4.2 — Network endpoints.
+ *
+ *   GET /networks/{network_id}/roster
+ *     Query who's in this network. Membership is implicit: an operator
+ *     is "in" a network if any of their announced capabilities lists
+ *     that network. Returns a registry-signed assertion so the caller
+ *     can pin the registry pubkey and verify the chain before
+ *     mutating its local peer registry.
+ */
+
+import { Hono } from "hono";
+import type { Env } from "../index";
+import { signAssertion } from "./operators";
+import { getStore, rosterFromOperators } from "../store";
+import { isValidNetworkId } from "../validate";
+
+export function networkRoutes(): Hono<{ Bindings: Env }> {
+  const app = new Hono<{ Bindings: Env }>();
+
+  app.get("/networks/:network_id/roster", async (c) => {
+    const networkId = c.req.param("network_id");
+    if (!isValidNetworkId(networkId)) {
+      return c.json({ error: "invalid network_id in path" }, 400);
+    }
+    const store = getStore();
+    const operators = await store.listOperators();
+    const roster = rosterFromOperators(operators, networkId);
+    const assertion = await signAssertion(c.env, roster);
+    return c.json(assertion);
+  });
+
+  return app;
+}

--- a/src/services/network-registry/src/routes/operators.ts
+++ b/src/services/network-registry/src/routes/operators.ts
@@ -1,0 +1,179 @@
+/**
+ * IAW D.4.2 — Operator endpoints.
+ *
+ *   POST /operators/{operator_id}/register
+ *     Operator publishes a signed assertion containing their pubkey,
+ *     stack identities, and capability declaration. The registry
+ *     verifies the signature, checks the nonce, applies clock-skew
+ *     bounds, and upserts the record.
+ *
+ *   GET /operators/{operator_id}
+ *     Peers query an operator's current pubkey + stack list. Response
+ *     is wrapped in a `SignedAssertion` carrying the registry's
+ *     signature so the caller can verify before caching.
+ */
+
+import { Hono } from "hono";
+import type { Env } from "../index";
+import { signEd25519, verifyEd25519, canonicalJSON } from "../signing";
+import { getNonceCache, getStore } from "../store";
+import type { OperatorRecord, SignedAssertion } from "../types";
+import {
+  isValidOperatorId,
+  validateRegistrationClaim,
+  validateSignedRegistration,
+} from "../validate";
+
+/** Maximum clock skew accepted between operator's `issued_at` and registry now. */
+const CLOCK_SKEW_MS = 5 * 60 * 1000; // 5 minutes
+
+export function operatorRoutes(): Hono<{ Bindings: Env }> {
+  const app = new Hono<{ Bindings: Env }>();
+
+  app.post("/operators/:operator_id/register", async (c) => {
+    const operatorId = c.req.param("operator_id");
+    if (!isValidOperatorId(operatorId)) {
+      return c.json({ error: "invalid operator_id in path" }, 400);
+    }
+
+    let body: unknown;
+    try {
+      body = await c.req.json();
+    } catch (_err) {
+      return c.json({ error: "body must be valid JSON" }, 400);
+    }
+
+    const envelopeCheck = validateSignedRegistration(body);
+    if (!envelopeCheck.ok) {
+      return c.json({ error: "validation_failed", details: envelopeCheck.errors }, 400);
+    }
+    const { signed } = envelopeCheck;
+
+    const claimCheck = validateRegistrationClaim(signed.claim, operatorId);
+    if (!claimCheck.ok) {
+      return c.json({ error: "validation_failed", details: claimCheck.errors }, 400);
+    }
+    const { claim } = claimCheck;
+
+    // Clock-skew check — reject claims dated too far in the past or future.
+    // Past-bound is the replay window; future-bound stops an attacker
+    // pre-signing claims for later replay against a known nonce-cache miss.
+    const issued = Date.parse(claim.issued_at);
+    const now = Date.now();
+    if (Math.abs(now - issued) > CLOCK_SKEW_MS) {
+      return c.json(
+        {
+          error: "issued_at out of skew window",
+          details: { skew_ms: now - issued, max_ms: CLOCK_SKEW_MS },
+        },
+        400,
+      );
+    }
+
+    // Replay check.
+    const nonceCache = getNonceCache();
+    const fresh = await nonceCache.recordIfFresh(claim.nonce, now);
+    if (!fresh) {
+      return c.json({ error: "nonce_replayed" }, 409);
+    }
+
+    // Signature verification. The operator signs canonical-JSON(claim)
+    // with their declared pubkey. TOFU on first register (the claim
+    // tells us which key to verify against); rotation requires the
+    // previous key to sign a transition claim — out of scope for v1,
+    // tracked as a follow-up.
+    const message = new TextEncoder().encode(canonicalJSON(claim));
+    const valid = await verifyEd25519(claim.operator_pubkey, signed.signature, message);
+    if (!valid) {
+      return c.json({ error: "signature_invalid" }, 401);
+    }
+
+    // Pubkey rotation policy for v1:
+    //   - First register for an operator_id: accept any pubkey.
+    //   - Subsequent registers MUST sign with the same pubkey already
+    //     on record. We reject silent key swaps to protect the chain
+    //     of trust peers have already cached. Rotation comes back in
+    //     a follow-up that accepts a transition claim co-signed by
+    //     the previous key.
+    const store = getStore();
+    const existing = await store.getOperator(operatorId);
+    if (existing && existing.operator_pubkey !== claim.operator_pubkey) {
+      return c.json(
+        {
+          error: "pubkey_rotation_not_supported",
+          details: "rotation requires a transition claim co-signed by the previous key (v2 feature)",
+        },
+        409,
+      );
+    }
+
+    const record = await store.putOperator(
+      operatorId,
+      claim.operator_pubkey,
+      claim.stacks,
+      claim.capabilities,
+    );
+
+    // Sign + return the canonical view so the operator gets the same
+    // signed assertion shape peers will see.
+    const assertion = await signAssertion(c.env, record);
+    return c.json(assertion, 201);
+  });
+
+  app.get("/operators/:operator_id", async (c) => {
+    const operatorId = c.req.param("operator_id");
+    if (!isValidOperatorId(operatorId)) {
+      return c.json({ error: "invalid operator_id in path" }, 400);
+    }
+    const store = getStore();
+    const record = await store.getOperator(operatorId);
+    if (!record) {
+      return c.json({ error: "not_found" }, 404);
+    }
+    const assertion = await signAssertion(c.env, record);
+    return c.json(assertion);
+  });
+
+  return app;
+}
+
+// =============================================================================
+// Internal — signed-assertion helper
+// =============================================================================
+
+/**
+ * Wrap any GET payload in a `SignedAssertion`. The signature covers
+ * the canonical-JSON of `{ payload, issued_at, registry }`, so peers
+ * cannot lift one signature onto a different payload without breaking
+ * verification.
+ *
+ * Exported via the module-internal seam so `networks.ts` and
+ * `capabilities.ts` reuse it without duplicating signing logic.
+ */
+export async function signAssertion<T>(
+  env: Env,
+  payload: T,
+): Promise<SignedAssertion<T>> {
+  const issued_at = new Date().toISOString();
+  const registry = env.REGISTRY_PUBLIC_KEY;
+  if (!env.REGISTRY_SIGNING_KEY || !registry) {
+    // No key configured — return an unsigned-but-structured response.
+    // The registry pubkey field is required by the type, so we set it
+    // to a sentinel string clients can detect ("unconfigured"). Cortex
+    // peers MUST refuse to trust a sentinel-keyed assertion; the bot
+    // logs this loudly via the audit channel. In dev/local this is
+    // expected (no real key); in production wrangler secrets gate the
+    // deploy.
+    return {
+      payload,
+      issued_at,
+      registry: registry ?? "unconfigured",
+      signature: "",
+    };
+  }
+  const bound = canonicalJSON({ payload, issued_at, registry });
+  const sig = await signEd25519(env.REGISTRY_SIGNING_KEY, new TextEncoder().encode(bound));
+  return { payload, issued_at, registry, signature: sig };
+}
+
+export type { OperatorRecord };

--- a/src/services/network-registry/src/routes/operators.ts
+++ b/src/services/network-registry/src/routes/operators.ts
@@ -14,7 +14,7 @@
  */
 
 import { Hono } from "hono";
-import type { Env } from "../index";
+import { getRegistryPublicKey, type Env } from "../index";
 import { signEd25519, verifyEd25519, canonicalJSON } from "../signing";
 import { getNonceCache, getStore } from "../store";
 import type { OperatorRecord, SignedAssertion } from "../types";
@@ -31,6 +31,24 @@ export function operatorRoutes(): Hono<{ Bindings: Env }> {
   const app = new Hono<{ Bindings: Env }>();
 
   app.post("/operators/:operator_id/register", async (c) => {
+    // Echo cortex#225 issue #1: refuse to mutate state when we can't
+    // produce a signed receipt. The GET surface already returns 503
+    // for `/registry/pubkey` when unconfigured; without this guard
+    // POST silently accepts registrations with an empty signature and
+    // burns TOFU slots, blocking the next legitimate register with
+    // HTTP 409. The unsigned-fallback path remains in `signAssertion`
+    // only so that GET responses can degrade gracefully in dev — POST
+    // is the mutation surface and gets stricter handling.
+    if (!c.env.REGISTRY_SIGNING_KEY || !getRegistryPublicKey(c.env)) {
+      return c.json(
+        {
+          error: "registry_unconfigured",
+          details:
+            "REGISTRY_SIGNING_KEY not provisioned; cannot accept registrations without producing a signed receipt",
+        },
+        503,
+      );
+    }
     const operatorId = c.req.param("operator_id");
     if (!isValidOperatorId(operatorId)) {
       return c.json({ error: "invalid operator_id in path" }, 400);
@@ -155,15 +173,17 @@ export async function signAssertion<T>(
   payload: T,
 ): Promise<SignedAssertion<T>> {
   const issued_at = new Date().toISOString();
-  const registry = env.REGISTRY_PUBLIC_KEY;
+  const registry = getRegistryPublicKey(env);
   if (!env.REGISTRY_SIGNING_KEY || !registry) {
-    // No key configured — return an unsigned-but-structured response.
-    // The registry pubkey field is required by the type, so we set it
-    // to a sentinel string clients can detect ("unconfigured"). Cortex
-    // peers MUST refuse to trust a sentinel-keyed assertion; the bot
-    // logs this loudly via the audit channel. In dev/local this is
-    // expected (no real key); in production wrangler secrets gate the
-    // deploy.
+    // No key configured — return an unsigned-but-structured response
+    // ONLY for GET-path callers; POST `/operators/.../register` rejects
+    // before reaching here (see the 503 guard in the register handler,
+    // Echo cortex#225 issue #1). The registry pubkey field is required
+    // by the type, so set it to a sentinel string clients can detect
+    // ("unconfigured"). Cortex peers MUST refuse to trust a sentinel-
+    // keyed assertion; the bot logs this loudly via the audit channel.
+    // In dev/local this is the documented degradation; in production
+    // wrangler secrets gate the deploy.
     return {
       payload,
       issued_at,

--- a/src/services/network-registry/src/signing.ts
+++ b/src/services/network-registry/src/signing.ts
@@ -1,0 +1,204 @@
+/**
+ * IAW D.4 — Ed25519 sign/verify primitives for the network registry.
+ *
+ * Uses WebCrypto (`crypto.subtle`) so the code runs unchanged on
+ * Cloudflare Workers, Bun (tests), and Node 20+. We deliberately do
+ * NOT pull in `tweetnacl` / `noble-curves` — WebCrypto's Ed25519
+ * support landed in Workers in 2023 and Bun in 2024, and skipping
+ * a polyfill keeps the Worker bundle small.
+ *
+ * Canonical JSON
+ * ──────────────
+ * Both sides need to agree byte-for-byte on what was signed. We use
+ * a recursive sort-keys canonicalisation: object keys are emitted in
+ * lexicographic order, arrays preserve their order, no whitespace.
+ * This is the same scheme RFC 8785 (JCS) specifies for primitive
+ * cases. We do NOT need RFC 8785's full numeric handling because
+ * the registry only ever signs strings and small integer-valued
+ * timestamps; if that changes, swap in a JCS lib at this seam.
+ */
+
+// =============================================================================
+// Canonical JSON
+// =============================================================================
+
+/**
+ * Deterministic JSON: object keys sorted recursively, no whitespace.
+ * Arrays preserve their order. Throws on cycles (JSON.stringify behaviour).
+ */
+export function canonicalJSON(value: unknown): string {
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return "[" + value.map((v) => canonicalJSON(v)).join(",") + "]";
+  }
+  const obj = value as Record<string, unknown>;
+  // Mirror JSON.stringify's handling of `undefined`: skip object keys
+  // whose value is `undefined`. Without this, a producer that builds a
+  // claim by spread-with-optionals (`{ ...base, metadata: undefined }`)
+  // would canonicalize differently from the same claim after a
+  // round-trip through `JSON.parse(JSON.stringify(...))`, breaking
+  // signature verification at the receiver.
+  const keys = Object.keys(obj)
+    .filter((k) => obj[k] !== undefined)
+    .sort();
+  const parts = keys.map((k) => JSON.stringify(k) + ":" + canonicalJSON(obj[k]));
+  return "{" + parts.join(",") + "}";
+}
+
+// =============================================================================
+// Base64 (URL-safe NOT used — operators paste standard base64)
+// =============================================================================
+
+export function base64ToBytes(b64: string): Uint8Array {
+  // Workers + Bun + modern Node all have atob(). Wrap so a malformed input
+  // surfaces as a recognisable Error rather than a DOMException.
+  let bin: string;
+  try {
+    bin = atob(b64);
+  } catch (_err) {
+    throw new Error("invalid base64");
+  }
+  const out = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+  return out;
+}
+
+export function bytesToBase64(bytes: Uint8Array): string {
+  let bin = "";
+  for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i]!);
+  return btoa(bin);
+}
+
+// =============================================================================
+// Ed25519 sign / verify
+// =============================================================================
+
+/**
+ * Verify an Ed25519 signature.
+ *
+ * @param pubkeyB64 32-byte raw public key, base64-encoded.
+ * @param signatureB64 64-byte raw signature, base64-encoded.
+ * @param message Bytes that were signed. Caller is responsible for
+ *                canonicalisation (use `canonicalJSON` then TextEncoder).
+ *
+ * Returns `false` on any failure (bad key, bad signature, crypto error)
+ * — we never throw to the caller, because verify failures are part of
+ * the normal control flow at the route layer (deny + audit), not
+ * exceptional paths.
+ */
+export async function verifyEd25519(
+  pubkeyB64: string,
+  signatureB64: string,
+  message: Uint8Array,
+): Promise<boolean> {
+  let pubBytes: Uint8Array;
+  let sigBytes: Uint8Array;
+  try {
+    pubBytes = base64ToBytes(pubkeyB64);
+    sigBytes = base64ToBytes(signatureB64);
+  } catch (_err) {
+    return false;
+  }
+  if (pubBytes.length !== 32 || sigBytes.length !== 64) return false;
+
+  try {
+    const key = await crypto.subtle.importKey(
+      "raw",
+      pubBytes,
+      { name: "Ed25519" },
+      false,
+      ["verify"],
+    );
+    return await crypto.subtle.verify({ name: "Ed25519" }, key, sigBytes, message);
+  } catch (_err) {
+    return false;
+  }
+}
+
+/**
+ * Sign a message with the registry's Ed25519 private key.
+ *
+ * @param privateKeyB64 The PKCS#8-encoded Ed25519 private key, base64.
+ *                      We use PKCS#8 (not raw 32-byte seed) because
+ *                      WebCrypto's `importKey('pkcs8', …)` is the path
+ *                      that works uniformly across Workers / Bun / Node.
+ *                      Generation helper is provided in this file.
+ * @param message Bytes to sign.
+ *
+ * Returns the 64-byte raw signature, base64-encoded.
+ */
+export async function signEd25519(
+  privateKeyB64: string,
+  message: Uint8Array,
+): Promise<string> {
+  const pkcs8 = base64ToBytes(privateKeyB64);
+  const key = await crypto.subtle.importKey(
+    "pkcs8",
+    pkcs8,
+    { name: "Ed25519" },
+    false,
+    ["sign"],
+  );
+  const sig = await crypto.subtle.sign({ name: "Ed25519" }, key, message);
+  return bytesToBase64(new Uint8Array(sig));
+}
+
+/**
+ * Derive the raw 32-byte Ed25519 public key from a PKCS#8 private key.
+ * Used at boot to surface the registry's pubkey at GET /registry/pubkey
+ * without the operator having to maintain two secrets.
+ *
+ * Approach: import the PKCS#8 key, export it as JWK, then base64-decode
+ * the `x` field (which is the raw public key in url-safe base64).
+ */
+export async function pubkeyFromPkcs8(privateKeyB64: string): Promise<string> {
+  const pkcs8 = base64ToBytes(privateKeyB64);
+  const key = await crypto.subtle.importKey(
+    "pkcs8",
+    pkcs8,
+    { name: "Ed25519" },
+    true, // extractable so we can read .x
+    ["sign"],
+  );
+  // `exportKey("jwk", …)` returns `JsonWebKey` at runtime, but the TS
+  // lib types it as `ArrayBuffer | JsonWebKey` because the format
+  // parameter is a string literal union. Narrow explicitly.
+  const exported = (await crypto.subtle.exportKey("jwk", key)) as JsonWebKey;
+  if (typeof exported.x !== "string") {
+    throw new Error("exported JWK missing x coordinate");
+  }
+  // JWK uses base64url; convert to standard base64.
+  const b64 = exported.x.replace(/-/g, "+").replace(/_/g, "/");
+  // Pad to multiple of 4.
+  const padded = b64 + "=".repeat((4 - (b64.length % 4)) % 4);
+  return padded;
+}
+
+/**
+ * Generate a fresh Ed25519 keypair (test helper). Returns the PKCS#8
+ * private key + the raw public key, both base64-encoded.
+ *
+ * NOT used at runtime — production deployments provision the registry
+ * key out-of-band via `wrangler secret put`. Kept here so tests have a
+ * one-call way to mint operator credentials.
+ */
+export async function generateKeypair(): Promise<{
+  privateKeyB64: string;
+  publicKeyB64: string;
+}> {
+  const keypair = (await crypto.subtle.generateKey(
+    { name: "Ed25519" },
+    true,
+    ["sign", "verify"],
+  )) as CryptoKeyPair;
+  // Both formats return ArrayBuffer at runtime, but TS types it as
+  // `ArrayBuffer | JsonWebKey` because of the union signature. Cast.
+  const pkcs8 = (await crypto.subtle.exportKey("pkcs8", keypair.privateKey)) as ArrayBuffer;
+  const raw = (await crypto.subtle.exportKey("raw", keypair.publicKey)) as ArrayBuffer;
+  return {
+    privateKeyB64: bytesToBase64(new Uint8Array(pkcs8)),
+    publicKeyB64: bytesToBase64(new Uint8Array(raw)),
+  };
+}

--- a/src/services/network-registry/src/store.ts
+++ b/src/services/network-registry/src/store.ts
@@ -68,15 +68,21 @@ export interface RegistryStore {
  * signed registration; the registry refuses any nonce it has seen
  * inside the configured window.
  *
- * The window is shorter than the practical clock-skew tolerance
- * (10 minutes here vs. 5-minute skew check at the route layer), so
- * a replay caught by the nonce check necessarily falls outside the
- * skew window too — defense-in-depth.
+ * The nonce window (10 minutes) is wider than the route-layer skew
+ * window (5 minutes) so that the nonce cache is the FIRST line of
+ * defense against in-window replays and the skew check is the
+ * fallback against delayed/captured-and-replayed claims.
  *
- * Storage is in-memory per isolate; like the operator store, this
- * is acceptable for v1 because a successful replay would also need
- * a fresh-enough timestamp, which the skew check enforces independent
- * of the nonce cache.
+ * Caveat (Echo cortex#225 issue #2): storage is in-memory per isolate.
+ * A captured-in-flight registration replayed within the 5-minute skew
+ * window CAN succeed against a different isolate / colo whose nonce
+ * map is empty for that key. Defense-in-depth only holds for delayed
+ * replays here, not in-window ones. The fix is to pull nonce storage
+ * into the same durable layer as operators when D1 lands — see the
+ * README §Roadmap "Durable nonce cache" follow-up. v1 ships as-is
+ * because (a) the operator's private key is still the gate and (b)
+ * a successful in-window replay only re-applies the same claim, with
+ * no privilege escalation versus the original.
  */
 export interface NonceCache {
   /** Returns true if the nonce was fresh (and is now recorded). */
@@ -89,12 +95,19 @@ export const NONCE_WINDOW_MS = 10 * 60 * 1000; // 10 minutes
 class InMemoryNonceCache implements NonceCache {
   private readonly seen = new Map<string, number>();
 
+  /** Sweep threshold — only walk the map when it grows past this. */
+  private static readonly SWEEP_THRESHOLD = 64;
+
   async recordIfFresh(nonce: string, now: number): Promise<boolean> {
-    // Sweep expired entries opportunistically — bounded by O(n) but
-    // n is the number of registrations in the last 10 minutes, which
-    // is tiny in federation traffic patterns.
-    for (const [key, ts] of this.seen) {
-      if (now - ts > NONCE_WINDOW_MS) this.seen.delete(key);
+    // Threshold-gated sweep (Echo cortex#225 issue #7). At federation
+    // scale (hundreds of operators), the per-call O(n) sweep was fine,
+    // but gating on size keeps the steady-state cost flat regardless
+    // of bursty traffic. We sweep only when the map grows past the
+    // threshold; the 10-minute eviction window is unchanged.
+    if (this.seen.size > InMemoryNonceCache.SWEEP_THRESHOLD) {
+      for (const [key, ts] of this.seen) {
+        if (now - ts > NONCE_WINDOW_MS) this.seen.delete(key);
+      }
     }
     if (this.seen.has(nonce)) return false;
     this.seen.set(nonce, now);

--- a/src/services/network-registry/src/store.ts
+++ b/src/services/network-registry/src/store.ts
@@ -1,0 +1,236 @@
+/**
+ * IAW D.4 — Storage interface + in-memory v1 implementation.
+ *
+ * V1 ships with an in-memory store so the endpoint surface, signing,
+ * and tests are exercised end-to-end without provisioning D1. The
+ * persistence wiring (D1 or KV) is a follow-up: see README §Roadmap
+ * and the cortex#116 D.4 checklist. The store interface is the seam
+ * — a D1Store implementation can drop in without touching routes.
+ *
+ * Concurrency model
+ * ─────────────────
+ * Cloudflare Workers run each request in an isolate. Module-scoped
+ * Map state inside an isolate is per-instance; the InMemoryStore is
+ * therefore NOT durable across deploys, restarts, or even across
+ * isolates that the colo spins up under load. This is acceptable for
+ * a dev/staging surface and for the test suite — production rollout
+ * MUST swap in a durable backend. The store is constructed inside
+ * the request handler (via `getStore(env)`) so dependency injection
+ * is straightforward.
+ */
+
+import type {
+  Capability,
+  CapabilityHit,
+  NetworkRoster,
+  OperatorRecord,
+  StackIdentity,
+} from "./types";
+
+// =============================================================================
+// Store interface
+// =============================================================================
+
+export interface RegistryStore {
+  /**
+   * Upsert an operator record. Returns the post-write view. The
+   * `validate` step at the route layer has already enforced grammar
+   * + signature; the store only worries about persistence.
+   */
+  putOperator(
+    operatorId: string,
+    pubkey: string,
+    stacks: StackIdentity[],
+    capabilities: Capability[],
+  ): Promise<OperatorRecord>;
+
+  getOperator(operatorId: string): Promise<OperatorRecord | undefined>;
+
+  /**
+   * List all operators (used by `/networks/{id}/roster` to compute
+   * implicit membership and by `/capabilities` for search). Bounded
+   * by federation size — hundreds, not millions — so an O(n) scan
+   * is fine for v1. A D1 implementation would push the filter into
+   * SQL.
+   */
+  listOperators(): Promise<OperatorRecord[]>;
+
+  /** Test/admin helper. Not exposed via HTTP. */
+  reset(): Promise<void>;
+}
+
+// =============================================================================
+// Nonce cache (replay protection)
+// =============================================================================
+
+/**
+ * Replay-protection cache. Operators include a `nonce` in every
+ * signed registration; the registry refuses any nonce it has seen
+ * inside the configured window.
+ *
+ * The window is shorter than the practical clock-skew tolerance
+ * (10 minutes here vs. 5-minute skew check at the route layer), so
+ * a replay caught by the nonce check necessarily falls outside the
+ * skew window too — defense-in-depth.
+ *
+ * Storage is in-memory per isolate; like the operator store, this
+ * is acceptable for v1 because a successful replay would also need
+ * a fresh-enough timestamp, which the skew check enforces independent
+ * of the nonce cache.
+ */
+export interface NonceCache {
+  /** Returns true if the nonce was fresh (and is now recorded). */
+  recordIfFresh(nonce: string, now: number): Promise<boolean>;
+  reset(): Promise<void>;
+}
+
+export const NONCE_WINDOW_MS = 10 * 60 * 1000; // 10 minutes
+
+class InMemoryNonceCache implements NonceCache {
+  private readonly seen = new Map<string, number>();
+
+  async recordIfFresh(nonce: string, now: number): Promise<boolean> {
+    // Sweep expired entries opportunistically — bounded by O(n) but
+    // n is the number of registrations in the last 10 minutes, which
+    // is tiny in federation traffic patterns.
+    for (const [key, ts] of this.seen) {
+      if (now - ts > NONCE_WINDOW_MS) this.seen.delete(key);
+    }
+    if (this.seen.has(nonce)) return false;
+    this.seen.set(nonce, now);
+    return true;
+  }
+
+  async reset(): Promise<void> {
+    this.seen.clear();
+  }
+}
+
+// =============================================================================
+// In-memory store (v1)
+// =============================================================================
+
+export class InMemoryRegistryStore implements RegistryStore {
+  private readonly operators = new Map<string, OperatorRecord>();
+
+  async putOperator(
+    operatorId: string,
+    pubkey: string,
+    stacks: StackIdentity[],
+    capabilities: Capability[],
+  ): Promise<OperatorRecord> {
+    const record: OperatorRecord = {
+      operator_id: operatorId,
+      operator_pubkey: pubkey,
+      stacks,
+      capabilities,
+      updated_at: new Date().toISOString(),
+    };
+    this.operators.set(operatorId, record);
+    return record;
+  }
+
+  async getOperator(operatorId: string): Promise<OperatorRecord | undefined> {
+    return this.operators.get(operatorId);
+  }
+
+  async listOperators(): Promise<OperatorRecord[]> {
+    return [...this.operators.values()];
+  }
+
+  async reset(): Promise<void> {
+    this.operators.clear();
+  }
+}
+
+// =============================================================================
+// Singleton accessors per isolate
+// =============================================================================
+
+/**
+ * The Worker entry point doesn't see the test harness — it just sees
+ * `env`. We attach the store to a module-scoped slot so request handlers
+ * share state within an isolate. Tests reset between cases via
+ * `getStore().reset()`.
+ */
+let storeSingleton: RegistryStore | undefined;
+let nonceSingleton: NonceCache | undefined;
+
+export function getStore(): RegistryStore {
+  if (!storeSingleton) storeSingleton = new InMemoryRegistryStore();
+  return storeSingleton;
+}
+
+export function getNonceCache(): NonceCache {
+  if (!nonceSingleton) nonceSingleton = new InMemoryNonceCache();
+  return nonceSingleton;
+}
+
+/** Test-only — swap stores between cases. Not exported via index.ts. */
+export function _setStoreForTest(s: RegistryStore | undefined): void {
+  storeSingleton = s;
+}
+
+export function _setNonceCacheForTest(c: NonceCache | undefined): void {
+  nonceSingleton = c;
+}
+
+// =============================================================================
+// Derived queries
+// =============================================================================
+
+/**
+ * Compute a network's roster from the flat operator list. Membership
+ * is implicit: an operator is "in" network X if any of their
+ * capabilities lists X in `capability.networks[]`. We collapse the
+ * matching capabilities back to the per-operator level for the
+ * response shape.
+ */
+export function rosterFromOperators(
+  operators: OperatorRecord[],
+  networkId: string,
+): NetworkRoster {
+  const members: NetworkRoster["members"] = [];
+  for (const op of operators) {
+    const matched = op.capabilities
+      .filter((c) => (c.networks ?? []).includes(networkId))
+      .map((c) => c.id);
+    if (matched.length > 0) {
+      members.push({
+        operator_id: op.operator_id,
+        operator_pubkey: op.operator_pubkey,
+        capabilities: matched,
+      });
+    }
+  }
+  return { network_id: networkId, members };
+}
+
+/**
+ * Search capabilities across all operators. The query is a substring
+ * match against `capability.id` (lowercase, dotted) and against
+ * `description`. v1 returns all hits unsorted — pagination is a
+ * follow-up when the registry has enough capabilities to need it.
+ */
+export function searchCapabilities(
+  operators: OperatorRecord[],
+  query: string,
+): CapabilityHit[] {
+  const q = query.toLowerCase();
+  const hits: CapabilityHit[] = [];
+  for (const op of operators) {
+    for (const cap of op.capabilities) {
+      const idMatch = cap.id.toLowerCase().includes(q);
+      const descMatch = (cap.description ?? "").toLowerCase().includes(q);
+      if (idMatch || descMatch) {
+        hits.push({
+          capability_id: cap.id,
+          operator_id: op.operator_id,
+          networks: cap.networks ?? [],
+          description: cap.description,
+        });
+      }
+    }
+  }
+  return hits;
+}

--- a/src/services/network-registry/src/types.ts
+++ b/src/services/network-registry/src/types.ts
@@ -1,0 +1,157 @@
+/**
+ * IAW D.4 — Network registry public types.
+ *
+ * These shapes are the wire contract between the registry and any cortex
+ * peer that consults it. Kept narrow and JSON-only so the same shapes
+ * round-trip through D1 / KV / in-memory stores without coupling.
+ *
+ * Grammar conventions (mirrors `src/common/types/cortex-config.ts`):
+ *   - operator_id    : lowercase alphanumeric + hyphen, letter-prefixed
+ *                      (cortex#141 invariant — segments starting with a
+ *                      digit interact badly with NATS subject matchers).
+ *   - stack_id       : `{operator_id}/{stack_slug}` — the slash form is
+ *                      load-bearing because the surface-router and
+ *                      PolicyEngine derive `home_operator` by splitting
+ *                      on the first `/`. Forged-attribution drift is
+ *                      blocked at register time (see `validateOperator`).
+ *   - operator_pubkey: base64-encoded Ed25519 public key (32 raw bytes
+ *                      before encoding). Matches `PolicyFederatedPeerSchema`
+ *                      shape in PR #223 — the schema we are about to feed.
+ *   - capability_id  : Phase A.6 grammar — `<domain>.<entity>` (e.g.
+ *                      `tasks.code-review`). Lowercase + dots + hyphens.
+ */
+
+/**
+ * A single stack identity belonging to an operator. An operator can
+ * declare multiple stacks (e.g. `andreas/laptop`, `andreas/server`)
+ * and the registry stores them as a flat list keyed by operator.
+ */
+export interface StackIdentity {
+  /** `{operator_id}/{stack_slug}` — slash-delimited. */
+  stack_id: string;
+  /** Human-readable label for dashboards. */
+  display_name?: string;
+  /**
+   * Optional per-stack metadata. Free-form JSON map; the registry
+   * does not interpret it. Useful for `region`, `data_residency`,
+   * `tier`, etc. — but those are advisory, not enforced here.
+   */
+  metadata?: Record<string, string>;
+}
+
+/**
+ * A capability the operator wants discoverable across the federation.
+ * Mirrors the announce_capabilities[] list on `PolicyFederatedNetworkSchema`
+ * in PR #223. The registry treats this as a search-only index — it
+ * never executes capabilities, only advertises them.
+ */
+export interface Capability {
+  /** Phase A.6 grammar — `<domain>.<entity>`. */
+  id: string;
+  /** Free-text description shown in capability search results. */
+  description?: string;
+  /**
+   * Networks (by id) this capability is announced into. Empty array
+   * means "default network only"; the operator's announce policy
+   * still gates whether traffic actually reaches the stack.
+   */
+  networks?: string[];
+}
+
+/**
+ * The body an operator posts to `POST /operators/{operator_id}/register`.
+ * Wrapped by `SignedRegistration` (below) — the signature covers a
+ * canonical JSON serialisation of this object plus a nonce + timestamp,
+ * so the registry can verify before mutating any state.
+ */
+export interface RegistrationClaim {
+  /** Must match the URL path parameter. Echoed for canonicalisation. */
+  operator_id: string;
+  /** Base64 Ed25519 pubkey the operator wants on record. */
+  operator_pubkey: string;
+  /** All stacks the operator is publishing. Empty list is permitted. */
+  stacks: StackIdentity[];
+  /** Capabilities the operator wants advertised. */
+  capabilities: Capability[];
+  /** ISO-8601 UTC timestamp at which the operator signed this claim. */
+  issued_at: string;
+  /**
+   * Random nonce included in the signed payload to prevent replay.
+   * The registry rejects nonces seen within the configured window.
+   */
+  nonce: string;
+}
+
+/**
+ * The on-wire envelope around a `RegistrationClaim`. The operator
+ * signs the canonical JSON of `claim` with their operator NKey;
+ * the registry verifies the signature against `claim.operator_pubkey`
+ * (TOFU on first sight; rotation is a follow-up, see README §Roadmap).
+ */
+export interface SignedRegistration {
+  claim: RegistrationClaim;
+  /** Base64-encoded Ed25519 signature over canonical-JSON(claim). */
+  signature: string;
+}
+
+/**
+ * The view of an operator returned by `GET /operators/{operator_id}`.
+ * Includes the registry's own signed assertion so peers can verify
+ * before caching. Cortex callers MUST verify the assertion against
+ * the registry pubkey they pinned at config time before trusting
+ * `operator_pubkey` — that is the chain D.4.4 mandates.
+ */
+export interface OperatorRecord {
+  operator_id: string;
+  operator_pubkey: string;
+  stacks: StackIdentity[];
+  capabilities: Capability[];
+  /** When the operator last successfully (re-)registered. */
+  updated_at: string;
+}
+
+/**
+ * A registry-signed assertion wrapping any payload returned by a GET.
+ * The signature covers canonical-JSON({ payload, issued_at, registry })
+ * so the bound payload, the issuance time, and the registry identity
+ * are all integrity-protected — re-signing one without the others is
+ * not possible without the registry's secret key.
+ */
+export interface SignedAssertion<T> {
+  payload: T;
+  issued_at: string;
+  /** The registry's own pubkey (base64). Pin this client-side. */
+  registry: string;
+  /** Base64 Ed25519 signature over canonical-JSON of the bound triple. */
+  signature: string;
+}
+
+/**
+ * `GET /networks/{network_id}/roster` — operators that have announced
+ * capabilities into this network. Roster membership is implicit:
+ * an operator is "in" a network if any of their capabilities lists
+ * that network in `capability.networks[]`. There is no separate
+ * join/leave handshake in v1 — the operator's next register call
+ * mutates membership atomically.
+ */
+export interface NetworkRoster {
+  network_id: string;
+  members: {
+    operator_id: string;
+    operator_pubkey: string;
+    capabilities: string[];
+  }[];
+}
+
+/**
+ * A capability search hit. `GET /capabilities?query=foo` returns the
+ * matching capability ids alongside the operator that announced
+ * them. The caller resolves operator → pubkey via a follow-up
+ * `GET /operators/{operator_id}` if they need the chain.
+ */
+export interface CapabilityHit {
+  capability_id: string;
+  operator_id: string;
+  networks: string[];
+  description?: string;
+}

--- a/src/services/network-registry/src/validate.ts
+++ b/src/services/network-registry/src/validate.ts
@@ -127,7 +127,7 @@ export function validateRegistrationClaim(
   }
 
   // stacks
-  let stacks: StackIdentity[] = [];
+  const stacks: StackIdentity[] = [];
   if (!Array.isArray(c.stacks)) {
     errors.push({ field: "stacks", message: "must be an array (possibly empty)" });
   } else {
@@ -206,7 +206,7 @@ export function validateRegistrationClaim(
   }
 
   // capabilities
-  let capabilities: Capability[] = [];
+  const capabilities: Capability[] = [];
   if (!Array.isArray(c.capabilities)) {
     errors.push({ field: "capabilities", message: "must be an array (possibly empty)" });
   } else {
@@ -239,7 +239,7 @@ export function validateRegistrationClaim(
         });
         return;
       }
-      let networks: string[] = [];
+      const networks: string[] = [];
       if (capObj.networks !== undefined) {
         if (!Array.isArray(capObj.networks)) {
           errors.push({

--- a/src/services/network-registry/src/validate.ts
+++ b/src/services/network-registry/src/validate.ts
@@ -1,0 +1,321 @@
+/**
+ * IAW D.4 — Request validation for the registry service.
+ *
+ * Centralised because every route needs to reject malformed input before
+ * touching the store or the crypto layer. We deliberately do NOT pull in
+ * Zod here: this Worker is excluded from the root `tsconfig.json` along
+ * with the other CF Workers, and shipping Zod with the Worker bundle
+ * adds ~50KB to the cold-start binary without buying us anything the
+ * hand-rolled validators here don't already enforce. The shapes are
+ * narrow (5 fields on `RegistrationClaim`) so the maintenance cost is
+ * a few dozen lines.
+ *
+ * Grammar choices mirror `src/common/types/cortex-config.ts` so that
+ * a value rejected here would also be rejected by the cortex-side
+ * `PolicyFederatedNetworkSchema` once PR #223 lands — register-then-
+ * load loops can't smuggle in a value that the consumer would reject.
+ */
+
+import type {
+  Capability,
+  RegistrationClaim,
+  SignedRegistration,
+  StackIdentity,
+} from "./types";
+
+// =============================================================================
+// Grammar regexes
+// =============================================================================
+
+/** Same shape as `OperatorSchema.id` — letter-prefixed (cortex#141). */
+const OPERATOR_ID_RE = /^[a-z][a-z0-9-]*$/;
+
+/** `{operator_id}/{stack_slug}` — both parts follow operator grammar. */
+const STACK_ID_RE = /^[a-z][a-z0-9-]*\/[a-z][a-z0-9-]*$/;
+
+/** Phase A.6 capability grammar — `<domain>.<entity>`. */
+const CAPABILITY_ID_RE = /^[a-z][a-z0-9-]*\.[a-z][a-z0-9-]*$/;
+
+/** Standard base64 alphabet + padding. We don't accept URL-safe here. */
+const BASE64_RE = /^[A-Za-z0-9+/]+={0,2}$/;
+
+/** Network id — same grammar as operator id. */
+const NETWORK_ID_RE = /^[a-z][a-z0-9-]*$/;
+
+// =============================================================================
+// Public validators
+// =============================================================================
+
+export function isValidOperatorId(id: string): boolean {
+  return typeof id === "string" && id.length > 0 && id.length <= 64 && OPERATOR_ID_RE.test(id);
+}
+
+export function isValidNetworkId(id: string): boolean {
+  return typeof id === "string" && id.length > 0 && id.length <= 64 && NETWORK_ID_RE.test(id);
+}
+
+export function isValidStackId(id: string): boolean {
+  return typeof id === "string" && id.length <= 128 && STACK_ID_RE.test(id);
+}
+
+export function isValidCapabilityId(id: string): boolean {
+  return typeof id === "string" && id.length <= 64 && CAPABILITY_ID_RE.test(id);
+}
+
+/**
+ * 32-byte Ed25519 pubkey, base64. We do a structural check here and
+ * defer the cryptographic "is this a valid curve point" question to
+ * `verifyEd25519` — WebCrypto rejects malformed keys at importKey
+ * time. The pre-flight check is just to fail fast on shape errors.
+ */
+export function isValidPubkey(b64: string): boolean {
+  if (typeof b64 !== "string") return false;
+  if (!BASE64_RE.test(b64)) return false;
+  // 32 raw bytes → 44 base64 chars (with `=` padding). 43 unpadded is
+  // also accepted by atob() but standardise on padded form.
+  return b64.length === 44;
+}
+
+// =============================================================================
+// Composite claim validation
+// =============================================================================
+
+export interface ValidationError {
+  field: string;
+  message: string;
+}
+
+/**
+ * Validate the full registration body before signature verification.
+ * Returns the list of errors; an empty array means the claim is
+ * structurally valid and ready for the crypto step.
+ *
+ * Cross-field rules enforced here (matching the schema in PR #223):
+ *   - `claim.operator_id` MUST equal the URL path param (passed in
+ *     `expectedOperatorId`). Mismatch is a forged-attribution attempt.
+ *   - Every `stack_id` MUST be prefixed by `{operator_id}/`. Same
+ *     reason — prevents operator A claiming a stack id under operator B.
+ *   - Stack ids unique within the claim.
+ *   - Capability ids unique within the claim.
+ *   - All declared networks in `capabilities[].networks[]` follow the
+ *     network-id grammar (free declaration; no central network registry).
+ */
+export function validateRegistrationClaim(
+  claim: unknown,
+  expectedOperatorId: string,
+): { ok: true; claim: RegistrationClaim } | { ok: false; errors: ValidationError[] } {
+  const errors: ValidationError[] = [];
+
+  if (typeof claim !== "object" || claim === null || Array.isArray(claim)) {
+    return { ok: false, errors: [{ field: "claim", message: "must be an object" }] };
+  }
+  const c = claim as Record<string, unknown>;
+
+  // operator_id
+  if (typeof c.operator_id !== "string" || !isValidOperatorId(c.operator_id)) {
+    errors.push({ field: "operator_id", message: "must be lowercase alphanumeric + hyphen, letter-prefixed" });
+  } else if (c.operator_id !== expectedOperatorId) {
+    errors.push({
+      field: "operator_id",
+      message: `body operator_id "${c.operator_id}" does not match path "${expectedOperatorId}"`,
+    });
+  }
+
+  // operator_pubkey
+  if (typeof c.operator_pubkey !== "string" || !isValidPubkey(c.operator_pubkey)) {
+    errors.push({ field: "operator_pubkey", message: "must be a 32-byte Ed25519 pubkey, base64-encoded (44 chars)" });
+  }
+
+  // stacks
+  let stacks: StackIdentity[] = [];
+  if (!Array.isArray(c.stacks)) {
+    errors.push({ field: "stacks", message: "must be an array (possibly empty)" });
+  } else {
+    const seenIds = new Set<string>();
+    c.stacks.forEach((s, i) => {
+      if (typeof s !== "object" || s === null || Array.isArray(s)) {
+        errors.push({ field: `stacks[${i.toString()}]`, message: "must be an object" });
+        return;
+      }
+      const sObj = s as Record<string, unknown>;
+      if (typeof sObj.stack_id !== "string" || !isValidStackId(sObj.stack_id)) {
+        errors.push({
+          field: `stacks[${i.toString()}].stack_id`,
+          message: "must be {operator_id}/{stack_slug}, both letter-prefixed",
+        });
+        return;
+      }
+      const opPrefix = sObj.stack_id.split("/")[0] ?? "";
+      if (typeof c.operator_id === "string" && opPrefix !== c.operator_id) {
+        errors.push({
+          field: `stacks[${i.toString()}].stack_id`,
+          message: `stack_id prefix "${opPrefix}" must match operator_id "${c.operator_id.toString()}"`,
+        });
+        return;
+      }
+      if (seenIds.has(sObj.stack_id)) {
+        errors.push({
+          field: `stacks[${i.toString()}].stack_id`,
+          message: `duplicate stack_id "${sObj.stack_id}"`,
+        });
+        return;
+      }
+      seenIds.add(sObj.stack_id);
+      // display_name + metadata are optional and free-form; we only
+      // type-check them.
+      if (sObj.display_name !== undefined && typeof sObj.display_name !== "string") {
+        errors.push({
+          field: `stacks[${i.toString()}].display_name`,
+          message: "must be a string if provided",
+        });
+        return;
+      }
+      if (sObj.metadata !== undefined) {
+        if (typeof sObj.metadata !== "object" || sObj.metadata === null || Array.isArray(sObj.metadata)) {
+          errors.push({
+            field: `stacks[${i.toString()}].metadata`,
+            message: "must be an object map of strings if provided",
+          });
+          return;
+        }
+        for (const [k, v] of Object.entries(sObj.metadata)) {
+          if (typeof v !== "string") {
+            errors.push({
+              field: `stacks[${i.toString()}].metadata.${k}`,
+              message: "metadata values must be strings",
+            });
+            return;
+          }
+        }
+      }
+      // Build the canonical stack record. Only include optional keys
+      // when they are actually defined — `canonicalJSON` is structural
+      // and treats `metadata: undefined` as different from "no metadata".
+      // The operator-side signing rig also omits these keys when unset
+      // (the helper builds the claim from spread defaults), so the
+      // canonical bytes must match here.
+      const stackRecord: StackIdentity = { stack_id: sObj.stack_id };
+      if (typeof sObj.display_name === "string") {
+        stackRecord.display_name = sObj.display_name;
+      }
+      if (sObj.metadata !== undefined) {
+        stackRecord.metadata = sObj.metadata as Record<string, string>;
+      }
+      stacks.push(stackRecord);
+    });
+  }
+
+  // capabilities
+  let capabilities: Capability[] = [];
+  if (!Array.isArray(c.capabilities)) {
+    errors.push({ field: "capabilities", message: "must be an array (possibly empty)" });
+  } else {
+    const seenIds = new Set<string>();
+    c.capabilities.forEach((cap, i) => {
+      if (typeof cap !== "object" || cap === null || Array.isArray(cap)) {
+        errors.push({ field: `capabilities[${i.toString()}]`, message: "must be an object" });
+        return;
+      }
+      const capObj = cap as Record<string, unknown>;
+      if (typeof capObj.id !== "string" || !isValidCapabilityId(capObj.id)) {
+        errors.push({
+          field: `capabilities[${i.toString()}].id`,
+          message: "must be <domain>.<entity>, both letter-prefixed",
+        });
+        return;
+      }
+      if (seenIds.has(capObj.id)) {
+        errors.push({
+          field: `capabilities[${i.toString()}].id`,
+          message: `duplicate capability id "${capObj.id}"`,
+        });
+        return;
+      }
+      seenIds.add(capObj.id);
+      if (capObj.description !== undefined && typeof capObj.description !== "string") {
+        errors.push({
+          field: `capabilities[${i.toString()}].description`,
+          message: "must be a string if provided",
+        });
+        return;
+      }
+      let networks: string[] = [];
+      if (capObj.networks !== undefined) {
+        if (!Array.isArray(capObj.networks)) {
+          errors.push({
+            field: `capabilities[${i.toString()}].networks`,
+            message: "must be an array of network ids if provided",
+          });
+          return;
+        }
+        for (let j = 0; j < capObj.networks.length; j++) {
+          const n = capObj.networks[j];
+          if (typeof n !== "string" || !isValidNetworkId(n)) {
+            errors.push({
+              field: `capabilities[${i.toString()}].networks[${j.toString()}]`,
+              message: "must be a valid network id (lowercase alphanumeric + hyphen, letter-prefixed)",
+            });
+            return;
+          }
+          networks.push(n);
+        }
+      }
+      // Same canonical-form discipline as the stack record above.
+      const capRecord: Capability = { id: capObj.id };
+      if (typeof capObj.description === "string") {
+        capRecord.description = capObj.description;
+      }
+      if (capObj.networks !== undefined) {
+        capRecord.networks = networks;
+      }
+      capabilities.push(capRecord);
+    });
+  }
+
+  // issued_at — ISO-8601 UTC. Parsing back through Date catches gross
+  // garbage; the route layer also enforces a clock-skew window.
+  if (typeof c.issued_at !== "string" || Number.isNaN(Date.parse(c.issued_at))) {
+    errors.push({ field: "issued_at", message: "must be an ISO-8601 timestamp" });
+  }
+
+  // nonce
+  if (typeof c.nonce !== "string" || c.nonce.length < 8 || c.nonce.length > 128) {
+    errors.push({ field: "nonce", message: "must be a string between 8 and 128 chars" });
+  }
+
+  if (errors.length > 0) return { ok: false, errors };
+
+  return {
+    ok: true,
+    claim: {
+      operator_id: c.operator_id as string,
+      operator_pubkey: c.operator_pubkey as string,
+      stacks,
+      capabilities,
+      issued_at: c.issued_at as string,
+      nonce: c.nonce as string,
+    },
+  };
+}
+
+export function validateSignedRegistration(
+  body: unknown,
+): { ok: true; signed: SignedRegistration } | { ok: false; errors: ValidationError[] } {
+  if (typeof body !== "object" || body === null || Array.isArray(body)) {
+    return { ok: false, errors: [{ field: "body", message: "must be an object" }] };
+  }
+  const b = body as Record<string, unknown>;
+  if (typeof b.signature !== "string" || b.signature.length === 0) {
+    return { ok: false, errors: [{ field: "signature", message: "missing" }] };
+  }
+  if (!BASE64_RE.test(b.signature)) {
+    return { ok: false, errors: [{ field: "signature", message: "must be base64" }] };
+  }
+  if (typeof b.claim !== "object" || b.claim === null) {
+    return { ok: false, errors: [{ field: "claim", message: "missing" }] };
+  }
+  return {
+    ok: true,
+    signed: { claim: b.claim as RegistrationClaim, signature: b.signature },
+  };
+}

--- a/src/services/network-registry/tsconfig.json
+++ b/src/services/network-registry/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "types": ["@cloudflare/workers-types", "bun"],
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noUncheckedIndexedAccess": true
+  },
+  "include": ["src/**/*.ts", "__tests__/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/src/services/network-registry/wrangler.toml
+++ b/src/services/network-registry/wrangler.toml
@@ -1,0 +1,72 @@
+name = "cortex-network-registry"
+main = "src/index.ts"
+compatibility_date = "2026-05-01"
+compatibility_flags = ["nodejs_compat"]
+
+# IAW D.4 — cloud-side network registry service. Public REST surface
+# at network.meta-factory.ai (per the plan; the operational DNS choice
+# is finalised at deploy time). Auth model:
+#
+#   POST /operators/{operator_id}/register
+#     — open endpoint. Authenticity is enforced by the request BODY
+#     carrying a signed assertion: the operator signs their own
+#     registration with their operator NKey. The registry verifies the
+#     signature against the operator's CURRENT pubkey (or, on first
+#     register, trust-on-first-use; rotation requires the previous key
+#     to sign the new one — out of scope for v1, follow-up).
+#
+#   GET endpoints
+#     — public read. Responses are SIGNED ASSERTIONS produced by the
+#     registry's own Ed25519 key (REGISTRY_SIGNING_KEY) so that cortex
+#     peers verify the chain before trusting cached pubkeys.
+#
+# No CF Access bypass policies on this Worker. M2M traffic (operator
+# cortex publishing their pubkey, peer cortex querying) authenticates
+# at the application layer via Ed25519 signatures — same defense-in-
+# depth pattern as S-058 in grove-api.
+workers_dev = false
+
+# Base vars for local dev (wrangler dev)
+[vars]
+ENVIRONMENT = "local"
+
+# ──────────────────────────────────────────────────────────────────
+# Environment: Development
+# ──────────────────────────────────────────────────────────────────
+[env.dev]
+name = "cortex-network-registry-dev"
+workers_dev = false
+
+# Routes for dev are TBD — typically network-dev.meta-factory.ai once
+# DNS is provisioned. Listed here as placeholder; uncomment + tune at
+# deploy time. Same-zone TLS + CF Access still apply.
+# routes = [
+#   { pattern = "network-dev.meta-factory.ai/*", zone_name = "meta-factory.ai" }
+# ]
+
+[env.dev.vars]
+ENVIRONMENT = "development"
+
+# ──────────────────────────────────────────────────────────────────
+# Environment: Production (network.meta-factory.ai)
+# ──────────────────────────────────────────────────────────────────
+[env.production]
+name = "cortex-network-registry"
+workers_dev = false
+
+# routes = [
+#   { pattern = "network.meta-factory.ai/*", zone_name = "meta-factory.ai" }
+# ]
+
+[env.production.vars]
+ENVIRONMENT = "production"
+
+# Secrets (set via `wrangler secret put --env production`):
+#   REGISTRY_SIGNING_KEY  — base64-encoded Ed25519 private key used to
+#                           sign GET responses (registry assertions).
+#                           Generate with:
+#                             bunx wrangler secret put REGISTRY_SIGNING_KEY
+#                           Format: 64 raw bytes (seed + pubkey),
+#                           base64-encoded. The corresponding public key
+#                           is exposed at GET /registry/pubkey so peers
+#                           can pin it at config time.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,6 +30,7 @@
     "src/worker",
     "src/webhook-proxy",
     "src/surface/mc/worker",
+    "src/services/network-registry",
     "src/taps/gh-webhook",
     "../grove-auth"
   ]


### PR DESCRIPTION
## Summary

IAW Phase D.4 — new Hono Cloudflare Worker at `src/services/network-registry/` providing the centralised pubkey directory peers consult to refresh operator NKeys + stack identities + capability declarations. Q3 lock-in: centralised, NOT NATS-gossiped.

This PR ships the **producer surface**. The cortex-side `RegistryClient` consumer (D.4.3) is filed alongside D.2/D.3.

Refs cortex#116.

## Endpoints (D.4.2)

| Method | Path                                | Purpose                                           |
|--------|-------------------------------------|---------------------------------------------------|
| POST   | `/operators/{operator_id}/register` | Operator publishes signed assertion               |
| GET    | `/operators/{operator_id}`          | Peers query pubkey + stacks                       |
| GET    | `/networks/{network_id}/roster`     | Who's in this network                             |
| GET    | `/capabilities?query=<substring>`   | Substring search                                  |
| GET    | `/registry/pubkey`                  | Returns registry pubkey (pin client-side)         |
| GET    | `/api/health`                       | Liveness                                          |

## Trust model

- **Operator-side**: Ed25519 signature over canonical-JSON(claim). TOFU on first register; silent rotation rejected with HTTP 409. Transition claims co-signed by previous key are a v2 follow-up.
- **Registry-side**: every GET wrapped in `SignedAssertion<T>` carrying a registry Ed25519 signature over `{ payload, issued_at, registry }`. Cortex peers pin the registry pubkey at config time and verify before trusting (D.4.4).
- **Replay protection**: 10-minute nonce cache + 5-minute clock-skew window.
- **No CF Access bypass policies.** M2M authenticates at the application layer via Ed25519 — same defense-in-depth as grove-api S-058.

## Storage (v1)

In-memory per-isolate via `InMemoryRegistryStore`. The `RegistryStore` interface in `store.ts` is the single seam for the D1/KV follow-up before any production traffic.

## File layout

```
src/services/network-registry/
  package.json
  tsconfig.json
  wrangler.toml
  README.md
  src/
    index.ts                  Hono app + middleware + routes wiring
    types.ts                  Operator / StackIdentity / Capability / Assertion shapes
    signing.ts                canonicalJSON + Ed25519 sign/verify (WebCrypto)
    store.ts                  RegistryStore interface + InMemoryStore + NonceCache
    validate.ts               Hand-rolled validators (mirrors PolicyFederatedSchema grammar)
    routes/
      operators.ts            POST register + GET operator + signAssertion helper
      networks.ts             GET roster
      capabilities.ts         GET capability search
  __tests__/
    helpers.ts                Per-test keypair generation, signed registration helper
    signing.test.ts
    operators.test.ts
    networks.test.ts
    capabilities.test.ts
```

Mirrors the existing CF Worker pattern (`src/taps/gh-webhook/`, `src/surface/mc/worker/`) — own `package.json` / `tsconfig.json` / `wrangler.toml`, excluded from root `tsconfig` + `eslint`.

## Plan checkbox updates

- [x] D.4.1 — service skeleton + Hono routes wired
- [x] D.4.2 — all four endpoint shapes land
- [ ] D.4.3 — cortex-side consumer (deferred to follow-up; producer ready)
- [x] D.4.4 — registry signs every GET assertion

## Test plan

- [x] 42 new tests (canonicalJSON determinism, Ed25519 sign/verify, base64 round-trip)
- [x] POST happy path: signed assertion verified end-to-end
- [x] Validation: bad operator_id, mismatched body/path operator_id, forged stack_id, dup stack_id, malformed pubkey, capability grammar, missing nonce, bad JSON
- [x] Auth: wrong-key signature, post-sign tampering, skew window, replay (nonce cache), silent rotation (409), permitted re-register
- [x] GET happy path + 404 + invalid path + registry-pubkey 503 when unconfigured
- [x] Network roster aggregation across multiple operators + signed wrapper
- [x] Capability substring + case-insensitive description search
- [x] Full repo suite: 2869 pass, lint quiet, tsc clean

## Follow-ups (filed against cortex#116)

1. Durable persistence (D1 or KV) — swap `InMemoryRegistryStore` via the store interface
2. Pubkey rotation via transition claims (currently HTTP 409)
3. Pagination on `/capabilities` (currently capped at 500 hits)
4. Per-operator publish rate limiting
5. Cortex-side `RegistryClient` (D.4.3 consumer) — startup + scheduled refresh + invalidation on `system.operator.published`

🤖 Generated with [Claude Code](https://claude.com/claude-code)