### PR TITLE
feat(policy): IAW D.3 — PolicyEngine per-network slicing (refs cortex#116)

### DIFF
--- a/src/bus/surface-router.ts
+++ b/src/bus/surface-router.ts
@@ -83,8 +83,21 @@ export interface SurfaceAdapter {
    * but synchronous CPU (mocks, formatters) MAY accept the parameter and
    * ignore it; the contract is opt-in for backwards compatibility with
    * existing render functions.
+   *
+   * **IAW Phase D.3 (cortex#116) — `subject`.** Optional third argument
+   * carrying the matched NATS subject. Adapters that need to derive
+   * federation context from the wire path (e.g. the dispatch-listener
+   * deriving `source_network` from `federated.{network_id}.>`) read
+   * this directly rather than re-parsing the envelope. Existing
+   * adapters that match `(envelope, signal)` continue to work — the
+   * parameter is additive and ignored by adapters that don't accept
+   * it.
    */
-  render(envelope: Envelope, signal?: AbortSignal): Promise<void>;
+  render(
+    envelope: Envelope,
+    signal?: AbortSignal,
+    subject?: string,
+  ): Promise<void>;
   /** Optional liveness probe. Currently unused by the router; reserved
    *  for the dashboard's adapter-health panel (G-1111.E follow-on). */
   health?(): Promise<{ ok: boolean; lag?: number }>;
@@ -295,7 +308,15 @@ export function createSurfaceRouter(
       if (matched.length === 0) return;
 
       const settled = await Promise.allSettled(
-        matched.map((a) => renderWithIsolation(a, envelope, renderTimeoutMs, onAdapterError)),
+        matched.map((a) =>
+          renderWithIsolation(
+            a,
+            envelope,
+            effectiveSubject,
+            renderTimeoutMs,
+            onAdapterError,
+          ),
+        ),
       );
 
       // `renderWithIsolation` already swallows; the allSettled here is
@@ -510,6 +531,7 @@ function emitAccessFiltered(
 async function renderWithIsolation(
   adapter: SurfaceAdapter,
   envelope: Envelope,
+  subject: string,
   timeoutMs: number,
   onAdapterError: SurfaceRouterOptions["onAdapterError"],
 ): Promise<void> {
@@ -525,8 +547,12 @@ async function renderWithIsolation(
     });
 
     // Defensively wrap the render call in case it throws synchronously
-    // before returning a promise.
-    const renderPromise = (async () => adapter.render(envelope, ac.signal))();
+    // before returning a promise. The third positional argument is the
+    // IAW Phase D.3 (cortex#116) `subject` channel — adapters that
+    // don't declare it on their render signature ignore the value
+    // (positional-args extension is backward-compatible).
+    const renderPromise = (async () =>
+      adapter.render(envelope, ac.signal, subject))();
 
     await Promise.race([renderPromise, timeoutPromise]);
   } catch (err) {

--- a/src/common/policy/__tests__/engine.test.ts
+++ b/src/common/policy/__tests__/engine.test.ts
@@ -244,3 +244,263 @@ describe("PolicyEngine — boot accessors", () => {
     expect(engine.roleCount).toBe(2);
   });
 });
+
+// =============================================================================
+// IAW Phase D.3 (cortex#116) — per-network policy slicing
+// =============================================================================
+
+describe("PolicyEngine — federation slicing (D.3)", () => {
+  test("local dispatch (no source_network) → C.3 behaviour unchanged: federation branch inert", () => {
+    // Engine has a federated config, but the intent doesn't reference
+    // a source_network — the federation branch must not fire. This is
+    // the backward-compatibility check: pre-D.3 callers (everyone
+    // dispatching locally) see no behaviour change.
+    const engine = new PolicyEngine({
+      principals: [principal({ id: "luna", role: ["operator"] })],
+      roles: [role("operator", ["code-review.typescript"])],
+      federated: {
+        networks: [
+          { id: "research-collab", peers: [{ stack_id: "andreas/research" }] },
+        ],
+      },
+    });
+
+    const result = engine.check("luna", intent());
+    expect(result.allow).toBe(true);
+  });
+
+  test("federated dispatch + principal in peer roster → allow (capability check still applies)", () => {
+    const engine = new PolicyEngine({
+      principals: [
+        principal({
+          id: "luna",
+          home_stack: "andreas/research",
+          role: ["operator"],
+        }),
+      ],
+      roles: [role("operator", ["code-review.typescript"])],
+      federated: {
+        networks: [
+          {
+            id: "research-collab",
+            peers: [{ stack_id: "andreas/research" }],
+          },
+        ],
+      },
+    });
+
+    const result = engine.check(
+      "luna",
+      intent({ source_network: "research-collab" }),
+    );
+    expect(result.allow).toBe(true);
+    if (result.allow) {
+      expect(new Set(result.capabilities)).toEqual(
+        new Set(["code-review.typescript"]),
+      );
+    }
+  });
+
+  test("federated dispatch + unknown network id → unknown_network deny", () => {
+    const engine = new PolicyEngine({
+      principals: [
+        principal({
+          id: "luna",
+          home_stack: "andreas/research",
+          role: ["operator"],
+        }),
+      ],
+      roles: [role("operator", ["code-review.typescript"])],
+      federated: {
+        networks: [
+          {
+            id: "research-collab",
+            peers: [{ stack_id: "andreas/research" }],
+          },
+        ],
+      },
+    });
+
+    const result = engine.check(
+      "luna",
+      intent({ source_network: "phantom-network" }),
+    );
+
+    expect(result.allow).toBe(false);
+    if (!result.allow) {
+      expect(result.reason).toEqual({
+        kind: "unknown_network",
+        source_network: "phantom-network",
+        principal_id: "luna",
+      });
+    }
+  });
+
+  test("federated dispatch + principal's home_stack not in peer roster → stack_not_in_network deny", () => {
+    const engine = new PolicyEngine({
+      principals: [
+        // luna's home_stack is `andreas/research`...
+        principal({
+          id: "luna",
+          home_stack: "andreas/research",
+          role: ["operator"],
+        }),
+      ],
+      roles: [role("operator", ["code-review.typescript"])],
+      federated: {
+        networks: [
+          {
+            id: "partner-only",
+            // ...but `partner-only` lists only `jcfischer/sage-host`.
+            peers: [{ stack_id: "jcfischer/sage-host" }],
+          },
+        ],
+      },
+    });
+
+    const result = engine.check(
+      "luna",
+      intent({ source_network: "partner-only" }),
+    );
+
+    expect(result.allow).toBe(false);
+    if (!result.allow) {
+      expect(result.reason).toEqual({
+        kind: "stack_not_in_network",
+        principal_id: "luna",
+        source_network: "partner-only",
+        home_stack: "andreas/research",
+      });
+    }
+  });
+
+  test("federation deny fires AFTER capability check — insufficient_role wins on a federated dispatch with capability miss", () => {
+    // Closest-miss principle: a principal who lacks the capability
+    // AND is not in the network's peer roster should see
+    // `insufficient_role` (the local issue) rather than
+    // `stack_not_in_network` (the federation issue). Operators
+    // triaging deny logs see the nearest failure first.
+    const engine = new PolicyEngine({
+      principals: [
+        principal({
+          id: "luna",
+          home_stack: "andreas/research",
+          role: ["operator"],
+        }),
+      ],
+      // operator role has NO capabilities — capability check misses.
+      roles: [role("operator", [])],
+      federated: {
+        networks: [
+          { id: "partner-only", peers: [{ stack_id: "jcfischer/sage-host" }] },
+        ],
+      },
+    });
+
+    const result = engine.check(
+      "luna",
+      intent({
+        capability: "code-review.typescript",
+        source_network: "partner-only",
+      }),
+    );
+
+    expect(result.allow).toBe(false);
+    if (!result.allow) {
+      // Capability check (C.3) fires before the federation branch (D.3).
+      expect(result.reason.kind).toBe("insufficient_role");
+    }
+  });
+
+  test("federated dispatch + engine has no federated config → unknown_network (federated config absent === network undeclared)", () => {
+    // Without a federated config, every federated dispatch denies
+    // with `unknown_network`. This matches the policy intent: if the
+    // operator hasn't declared any networks, no inbound federated
+    // traffic should be authorised regardless of the principal.
+    const engine = new PolicyEngine({
+      principals: [
+        principal({
+          id: "luna",
+          home_stack: "andreas/research",
+          role: ["operator"],
+        }),
+      ],
+      roles: [role("operator", ["code-review.typescript"])],
+      // No `federated` field — engine has no networks.
+    });
+
+    const result = engine.check(
+      "luna",
+      intent({ source_network: "research-collab" }),
+    );
+
+    expect(result.allow).toBe(false);
+    if (!result.allow) {
+      expect(result.reason).toEqual({
+        kind: "unknown_network",
+        source_network: "research-collab",
+        principal_id: "luna",
+      });
+    }
+  });
+
+  test("unknown_principal still fires before the federation branch on a federated dispatch", () => {
+    // Sanity: an envelope arriving on a federated subject whose
+    // signed_by[0].principal isn't a declared local principal denies
+    // at the very first gate — the federation branch never runs.
+    const engine = new PolicyEngine({
+      principals: [],
+      roles: [],
+      federated: {
+        networks: [
+          { id: "research-collab", peers: [{ stack_id: "andreas/research" }] },
+        ],
+      },
+    });
+
+    const result = engine.check(
+      "ghost",
+      intent({ source_network: "research-collab" }),
+    );
+
+    expect(result.allow).toBe(false);
+    if (!result.allow) {
+      expect(result.reason).toEqual({
+        kind: "unknown_principal",
+        principal_id: "ghost",
+      });
+    }
+  });
+
+  test("multiple peers in a network — match against any peer stack_id allows", () => {
+    const engine = new PolicyEngine({
+      principals: [
+        principal({
+          id: "luna",
+          home_stack: "andreas/research",
+          role: ["operator"],
+        }),
+      ],
+      roles: [role("operator", ["code-review.typescript"])],
+      federated: {
+        networks: [
+          {
+            id: "research-collab",
+            peers: [
+              { stack_id: "jcfischer/sage-host" },
+              { stack_id: "andreas/research" },
+              { stack_id: "ben/atlas" },
+            ],
+          },
+        ],
+      },
+    });
+
+    const result = engine.check(
+      "luna",
+      intent({ source_network: "research-collab" }),
+    );
+
+    expect(result.allow).toBe(true);
+  });
+});

--- a/src/common/policy/__tests__/factory.test.ts
+++ b/src/common/policy/__tests__/factory.test.ts
@@ -55,6 +55,76 @@ describe("policyEngineFromConfig", () => {
     expect(engine?.roleCount).toBe(1);
   });
 
+  test("D.3 — parsed federated block round-trips into engine; federated check() honours peer roster", () => {
+    const pubkey = "U" + "D".repeat(55);
+    const policy = parsePolicy({
+      principals: [
+        {
+          id: "luna",
+          home_operator: "andreas",
+          home_stack: "andreas/research",
+          role: ["operator"],
+          trust: [],
+        },
+      ],
+      roles: [{ id: "operator", capabilities: ["code-review.typescript"] }],
+      federated: {
+        networks: [
+          {
+            id: "research-collab",
+            leaf_node: "leaf",
+            peers: [
+              {
+                operator_id: "andreas",
+                stack_id: "andreas/research",
+                operator_pubkey: pubkey,
+              },
+            ],
+            accept_subjects: ["federated.research-collab.>"],
+            deny_subjects: [],
+            announce_capabilities: [],
+            max_hop: 0,
+          },
+        ],
+      },
+    });
+    const engine = policyEngineFromConfig(policy);
+    expect(engine).toBeDefined();
+    if (!engine) return;
+
+    // Federated dispatch — principal's home_stack is in the network's
+    // peer roster; allow.
+    const allowResult = engine.check("luna", {
+      capability: "code-review.typescript",
+      sovereignty: {
+        classification: "federated",
+        data_residency: "NZ",
+        max_hop: 1,
+        frontier_ok: false,
+        model_class: "any",
+      },
+      source_network: "research-collab",
+    });
+    expect(allowResult.allow).toBe(true);
+
+    // Federated dispatch — unknown network id; deny.
+    const unknownNetworkResult = engine.check("luna", {
+      capability: "code-review.typescript",
+      sovereignty: {
+        classification: "federated",
+        data_residency: "NZ",
+        max_hop: 1,
+        frontier_ok: false,
+        model_class: "any",
+      },
+      source_network: "phantom",
+    });
+    expect(unknownNetworkResult.allow).toBe(false);
+    if (!unknownNetworkResult.allow) {
+      expect(unknownNetworkResult.reason.kind).toBe("unknown_network");
+    }
+  });
+
   test("round-trip: parsed Policy flows into engine and check() respects it", () => {
     const policy = parsePolicy({
       principals: [

--- a/src/common/policy/engine.ts
+++ b/src/common/policy/engine.ts
@@ -1,5 +1,6 @@
 /**
  * IAW Phase C.1 (cortex#115) — PolicyEngine implementation.
+ * IAW Phase D.3 (cortex#116) — per-network slicing on federated dispatches.
  *
  * The single authorization decision point for cortex. Replaces the
  * per-surface role-resolver duplication today (Discord adapter +
@@ -10,9 +11,14 @@
  * inbound dispatch passes through `check` before reaching a
  * substrate harness; Phase C.4 emits `system.access.{allowed,denied}`
  * audit envelopes carrying the decision shape this engine returns.
+ * Phase D.3 extends `check()` with per-network policy slicing — when
+ * `intent.source_network` is set, the engine consults the matching
+ * `policy.federated.networks[]` entry and rejects principals that
+ * aren't peers of the named network.
  *
  * Cross-references:
  *   - `docs/design-internet-of-agentic-work.md` §cortex#107.
+ *   - `docs/plan-internet-of-agentic-work.md` §D.3.
  *   - `./types.ts` — `Principal`, `Intent`, `RoleDefinition`,
  *     `PolicyDecision`, `PolicyDenyReason`.
  *
@@ -22,11 +28,14 @@
  *     it, but the engine doesn't yet reject on sovereignty
  *     mismatches. The `sovereignty_mismatch` deny reason exists
  *     in the discriminator for forward compatibility; today it
- *     never fires. Phase D extends with per-network sovereignty
- *     slicing.
- *   - **No per-peer accept/deny.** Phase D adds
+ *     never fires.
+ *   - **No subject-level accept/deny.** Phase D.2 gates inbound
+ *     `federated.*` envelopes at the surface-router by
  *     `policy.federated.networks[].accept_subjects[]` /
- *     `deny_subjects[]` enforcement; not in C.1's scope.
+ *     `deny_subjects[]` BEFORE they reach this engine. D.3 runs
+ *     after that gate and answers the residual question: "now that
+ *     the envelope was admitted by the router, is the originating
+ *     principal actually authorised to act on this network?"
  *   - **No glob expansion on capability matches.** Literal
  *     `===` matching only; PRs after Phase C may add patterns.
  */
@@ -37,6 +46,42 @@ import type {
   Principal,
   RoleDefinition,
 } from "./types";
+
+/**
+ * IAW Phase D.3 (cortex#116) — slim federation slice the engine
+ * consumes for per-network membership checks.
+ *
+ * Structurally compatible with `PolicyFederated` from
+ * `src/common/types/cortex-config.ts` (the Zod-parsed shape) — the
+ * factory passes the parsed `Policy.federated` through verbatim.
+ * Declared here as a local type so the engine module stays
+ * independent of the config schema's module graph (avoids
+ * `engine.ts` importing from `common/types/`, which today imports
+ * from elsewhere in `common/`).
+ *
+ * Only the fields D.3 actually reads are typed; the wider federated
+ * config carries `accept_subjects` / `deny_subjects` / `max_hop` etc.
+ * which are surface-router concerns (D.2), not engine concerns.
+ */
+export interface FederatedPolicy {
+  /** Networks this operator participates in. */
+  readonly networks: readonly FederatedNetwork[];
+}
+
+export interface FederatedNetwork {
+  /** Network id — matches `intent.source_network`. */
+  readonly id: string;
+  /**
+   * Peer stacks declared on this network. The engine reads
+   * `stack_id` to validate that an incoming principal's
+   * `home_stack` belongs to the network's peer roster.
+   *
+   * Other peer fields (`operator_id`, `operator_pubkey`) are
+   * consumed elsewhere (verifier, registry); the engine doesn't
+   * read them.
+   */
+  readonly peers: readonly { readonly stack_id: string }[];
+}
 
 export interface PolicyEngineOptions {
   /**
@@ -51,15 +96,39 @@ export interface PolicyEngineOptions {
    * capabilities to compute the effective grant set.
    */
   roles: readonly RoleDefinition[];
+  /**
+   * IAW Phase D.3 (cortex#116) — optional federation slice. When
+   * present, the engine evaluates `intent.source_network` against
+   * the matching network's peer roster on every `check()` call.
+   * When absent, the federation branch is inert — federated
+   * dispatches (those with `intent.source_network` set) reject
+   * with `unknown_network` because nothing is declared.
+   *
+   * The default-undefined shape preserves backward compatibility:
+   * a caller that doesn't pass `federated` gets the C.3 behaviour
+   * for every check (no federation gate, no federation deny
+   * reasons).
+   */
+  federated?: FederatedPolicy;
 }
 
 export class PolicyEngine {
   private readonly principalsById: ReadonlyMap<string, Principal>;
   private readonly rolesById: ReadonlyMap<string, RoleDefinition>;
+  /**
+   * IAW Phase D.3 — networks indexed by id for O(1) lookup on the
+   * federation branch. `undefined` when no federated policy was
+   * passed at construction; callers see `unknown_network` deny on
+   * any federated `check()` in that case.
+   */
+  private readonly networksById: ReadonlyMap<string, FederatedNetwork> | undefined;
 
   constructor(opts: PolicyEngineOptions) {
     this.principalsById = new Map(opts.principals.map((p) => [p.id, p]));
     this.rolesById = new Map(opts.roles.map((r) => [r.id, r]));
+    this.networksById = opts.federated
+      ? new Map(opts.federated.networks.map((n) => [n.id, n]))
+      : undefined;
   }
 
   /**
@@ -75,10 +144,26 @@ export class PolicyEngine {
    *      at config load).
    *   3. Match `intent.capability` against the effective set.
    *      Miss → `insufficient_role`.
-   *   4. (Phase D extends with sovereignty / per-peer checks; the
-   *      `intent.sovereignty` field is part of the input shape so
-   *      C.4 audit envelopes carry it without an extra read.)
-   *   5. Allow with the full effective set.
+   *   4. **(D.3)** When `intent.source_network` is set, evaluate the
+   *      federation slice:
+   *        - Network not declared in `policy.federated.networks[]`
+   *          → `unknown_network`.
+   *        - Principal known locally but `home_stack` not in the
+   *          network's `peers[].stack_id` roster →
+   *          `stack_not_in_network`.
+   *      Local dispatches (`source_network === undefined`) skip
+   *      this branch entirely and preserve C.3 behaviour.
+   *   5. (Future phase) Sovereignty rejection. `intent.sovereignty`
+   *      is on the input shape today for audit envelopes; the
+   *      rejection branch is deferred.
+   *   6. Allow with the full effective set.
+   *
+   * The federation branch is placed AFTER capability matching so
+   * the deny reason surfaces the most-specific failure: a principal
+   * that lacks the capability gets `insufficient_role` (the local
+   * issue) rather than `stack_not_in_network` (the federation
+   * issue). Operators triaging deny logs see the closest miss
+   * first.
    *
    * Taking an id (not a `Principal` object) is deliberate: the
    * registry is authoritative for roles/trust, and accepting a
@@ -87,6 +172,15 @@ export class PolicyEngine {
    * dispatch-handler integration in C.3 strips `did:mf:` from a
    * verified `signed_by[].principal` and passes the bare id here
    * (Echo cortex#218 round 1).
+   *
+   * **⚠ Pre-Phase-B caveat (federation branch).** The principal
+   * claim resolved from `signed_by[0].principal` is NOT yet
+   * cryptographically verified at the validator (cortex#114). The
+   * D.3 federation gate inherits this: a forged
+   * `signed_by[0].principal` matching a declared local principal
+   * would pass `home_stack`-vs-`peers[].stack_id` check until
+   * Phase B's signature verification is mandatory. Defence in
+   * depth, not authentication.
    */
   check(principalId: string, intent: Intent): PolicyDecision {
     const known = this.principalsById.get(principalId);
@@ -110,14 +204,84 @@ export class PolicyEngine {
       };
     }
 
-    // TODO(phase-D): enforce `intent.sovereignty` — classification,
-    // residency, frontier-ok, model-class. C.4 audit envelopes
-    // already carry the field; Phase D wires the rejection branch.
+    // IAW Phase D.3 — federation slice. Inert for local dispatches.
+    if (intent.source_network !== undefined) {
+      const networkDecision = this.checkFederation(
+        principalId,
+        known,
+        intent.source_network,
+      );
+      if (networkDecision !== undefined) {
+        return networkDecision;
+      }
+    }
+
+    // TODO(phase-D, sovereignty): enforce `intent.sovereignty` —
+    // classification, residency, frontier-ok, model-class. C.4 audit
+    // envelopes already carry the field; the rejection branch is
+    // deferred until the sovereignty taxonomy stabilises across
+    // myelin#31 + cortex#109.
 
     return {
       allow: true,
       capabilities: [...effectiveCapabilities],
     };
+  }
+
+  /**
+   * IAW Phase D.3 — federation membership check. Returns a deny
+   * decision when the source network rejects the principal, or
+   * `undefined` to pass through to the allow branch.
+   *
+   * Two failure modes:
+   *   - Network not in `policy.federated.networks[]` (either no
+   *     federated slice configured, or this network id isn't
+   *     declared) → `unknown_network`.
+   *   - Network declared but principal's `home_stack` doesn't
+   *     appear in the network's `peers[].stack_id` roster →
+   *     `stack_not_in_network`.
+   *
+   * The "unknown principal on a federated edge"
+   * (`unknown_federated_peer`) path doesn't fire here — that case
+   * is already caught by the `unknown_principal` branch at the top
+   * of `check()`, which runs before the federation slice. The deny
+   * reason is in the discriminator for forward-compat with future
+   * federation paths that resolve principals directly from peer
+   * rosters (D.4 cloud registry) without a local
+   * `policy.principals[]` entry.
+   */
+  private checkFederation(
+    principalId: string,
+    principal: Principal,
+    sourceNetwork: string,
+  ): PolicyDecision | undefined {
+    const network = this.networksById?.get(sourceNetwork);
+    if (network === undefined) {
+      return {
+        allow: false,
+        reason: {
+          kind: "unknown_network",
+          source_network: sourceNetwork,
+          principal_id: principalId,
+        },
+      };
+    }
+
+    const stackInNetwork = network.peers.some(
+      (peer) => peer.stack_id === principal.home_stack,
+    );
+    if (!stackInNetwork) {
+      return {
+        allow: false,
+        reason: {
+          kind: "stack_not_in_network",
+          principal_id: principalId,
+          source_network: sourceNetwork,
+          home_stack: principal.home_stack,
+        },
+      };
+    }
+    return undefined;
   }
 
   /**

--- a/src/common/policy/factory.ts
+++ b/src/common/policy/factory.ts
@@ -1,5 +1,6 @@
 /**
  * IAW Phase C.2a (cortex#115) — PolicyEngine factory from CortexConfig.
+ * IAW Phase D.3 (cortex#116) — passes the federation slice through.
  *
  * Builds a `PolicyEngine` from the optional `policy:` block on
  * `CortexConfig`. Returns `undefined` when the block is absent OR
@@ -11,15 +12,20 @@
  * `policy:` the authoritative source — at which point this factory
  * always returns an engine for cortex.yaml configs (BotConfig stays
  * as legacy without a policy block, mapping to `undefined` here).
+ * Phase D.3 threads the `policy.federated` slice into the engine so
+ * federated dispatches (`intent.source_network` set) get the
+ * per-network membership check.
  *
  * Cross-references:
  *   - `src/common/policy/engine.ts` — the engine this factory builds.
  *   - `src/common/types/cortex-config.ts` — `PolicySchema` /
- *     `Policy` / `PolicyPrincipal` / `PolicyRole`.
+ *     `Policy` / `PolicyPrincipal` / `PolicyRole` /
+ *     `PolicyFederated`.
  *   - `docs/design-internet-of-agentic-work.md` §cortex#107.
+ *   - `docs/plan-internet-of-agentic-work.md` §D.3.
  */
 
-import { PolicyEngine } from "./engine";
+import { PolicyEngine, type FederatedPolicy } from "./engine";
 import type { Policy } from "../types/cortex-config";
 
 /**
@@ -44,6 +50,20 @@ export function policyEngineFromConfig(
 ): PolicyEngine | undefined {
   if (policy === undefined) return undefined;
   if (policy.principals.length === 0) return undefined;
+  // IAW Phase D.3 — narrow the parsed federated block to the engine's
+  // slim `FederatedPolicy` shape. The engine only reads `id` +
+  // `peers[].stack_id`; other fields (`accept_subjects`,
+  // `deny_subjects`, `max_hop`, `announce_capabilities`,
+  // `operator_pubkey`, `operator_id`, `leaf_node`) are consumed
+  // elsewhere (surface-router D.2, verifier, registry D.4).
+  const federated: FederatedPolicy | undefined = policy.federated
+    ? {
+        networks: policy.federated.networks.map((n) => ({
+          id: n.id,
+          peers: n.peers.map((p) => ({ stack_id: p.stack_id })),
+        })),
+      }
+    : undefined;
   return new PolicyEngine({
     principals: policy.principals.map((p) => ({
       id: p.id,
@@ -56,5 +76,6 @@ export function policyEngineFromConfig(
       id: r.id,
       capabilities: r.capabilities,
     })),
+    ...(federated !== undefined && { federated }),
   });
 }

--- a/src/common/policy/index.ts
+++ b/src/common/policy/index.ts
@@ -8,7 +8,12 @@
  * add a `./schema.ts` for the Zod schema of the new `policy:` block).
  */
 
-export { PolicyEngine, type PolicyEngineOptions } from "./engine";
+export {
+  PolicyEngine,
+  type PolicyEngineOptions,
+  type FederatedPolicy,
+  type FederatedNetwork,
+} from "./engine";
 export type {
   Intent,
   IntentSovereignty,

--- a/src/common/policy/types.ts
+++ b/src/common/policy/types.ts
@@ -110,6 +110,34 @@ export interface Intent {
    * have to fabricate one.
    */
   payload_summary?: string;
+  /**
+   * IAW Phase D.3 (cortex#116) — federation source-network id.
+   *
+   * When the inbound envelope arrived via a `federated.{network_id}.>`
+   * subject, the caller sets `source_network` to the matched
+   * `{network_id}` segment. The engine then consults
+   * `policy.federated.networks[]` by id and applies that network's
+   * policy slice: the principal MUST be a declared peer on the
+   * network, AND the principal's `home_stack` MUST appear in the
+   * network's `peers[].stack_id` roster. Either miss → deny with
+   * the network-scoped reason kinds (`unknown_network`,
+   * `unknown_federated_peer`, `stack_not_in_network`).
+   *
+   * `undefined` (local dispatch) leaves the engine's C.3 behaviour
+   * unchanged — the federation branch is skipped entirely.
+   *
+   * **⚠ Pre-Phase-B caveat.** The principal claim on
+   * `signed_by[0].principal` (which the dispatch-listener strips to
+   * derive the principal id passed to `check()`) is NOT yet
+   * cryptographically verified at the envelope-validator layer
+   * (cortex#114). Until Phase B wires verification, the federation
+   * branch is authorisation-without-authentication: a forged
+   * `signed_by[0].principal` would let an attacker pose as a
+   * declared peer. The check is still useful as defence-in-depth
+   * against misconfigured peers, but operators MUST treat the
+   * federation gate as binding only after cortex#114 lands.
+   */
+  source_network?: string;
 }
 
 /**
@@ -155,6 +183,54 @@ export type PolicyDenyReason =
       kind: "sovereignty_mismatch";
       /** Human-readable description of the mismatch. */
       reason: string;
+    }
+  | {
+      /**
+       * IAW Phase D.3 (cortex#116) — `intent.source_network` referenced
+       * a network id that is not declared in `policy.federated.networks[]`.
+       * Indicates either a misconfigured peer (the inbound envelope
+       * names a network this operator doesn't participate in) or a
+       * stale config snapshot. Distinct from `unknown_federated_peer`
+       * (the network IS declared but the principal isn't a member).
+       */
+      kind: "unknown_network";
+      /** The network id the caller tried to dispatch on. */
+      source_network: string;
+      principal_id: string;
+    }
+  | {
+      /**
+       * IAW Phase D.3 (cortex#116) — principal id resolved locally but
+       * the principal's `home_stack` does not appear in the source
+       * network's `peers[].stack_id` roster. Indicates a principal who
+       * exists in `policy.principals[]` but is not authorised to act on
+       * the federated network the envelope arrived on (e.g. an internal
+       * agent attempting to dispatch on a partner-only network).
+       */
+      kind: "stack_not_in_network";
+      principal_id: string;
+      /** The network id the dispatch arrived on. */
+      source_network: string;
+      /** The principal's local `home_stack` — diagnostic for operators. */
+      home_stack: string;
+    }
+  | {
+      /**
+       * IAW Phase D.3 (cortex#116) — reserved for future federation
+       * paths that resolve principals directly from a peer roster
+       * (e.g. D.4's cloud registry) without requiring a local
+       * `policy.principals[]` entry. The D.3 engine doesn't emit
+       * this kind today: an unknown principal on a federated edge
+       * is caught by `unknown_principal` at the top of `check()`,
+       * which fires before the federation branch. The variant lives
+       * in the discriminator now so audit consumers (dashboard,
+       * pipeline) can compile against the full set without a wire-
+       * schema bump when D.4 lands.
+       */
+      kind: "unknown_federated_peer";
+      principal_id: string;
+      /** The network id the dispatch arrived on. */
+      source_network: string;
     };
 
 /**

--- a/src/runner/__tests__/dispatch-listener.test.ts
+++ b/src/runner/__tests__/dispatch-listener.test.ts
@@ -1060,6 +1060,291 @@ describe("dispatch-listener — policy gating (C.3.1)", () => {
     expect(signedBy[1]!.role).toBe("accountability");
   });
 
+  // -------------------------------------------------------------------------
+  // IAW Phase D.3 (cortex#116) — per-network slicing on federated dispatches
+  // -------------------------------------------------------------------------
+
+  /**
+   * Engine for D.3 tests — declares one principal (`cortex` with
+   * `home_stack=andreas/research`) and one federated network
+   * (`research-collab`) whose peer roster includes that home_stack.
+   * Capability set is parameterised so individual tests can flip
+   * allow/deny on the role grant.
+   */
+  function engineWithFederation(opts: {
+    capabilities: readonly string[];
+    networkId?: string;
+    peerStackIds?: readonly string[];
+    homeStack?: string;
+  }): PolicyEngine {
+    const networkId = opts.networkId ?? "research-collab";
+    const peerStackIds = opts.peerStackIds ?? ["andreas/research"];
+    const homeStack = opts.homeStack ?? "andreas/research";
+    return new PolicyEngine({
+      principals: [
+        {
+          id: "cortex",
+          home_operator: "andreas",
+          home_stack: homeStack,
+          role: ["operator"],
+          trust: [],
+        },
+      ],
+      roles: [{ id: "operator", capabilities: opts.capabilities }],
+      federated: {
+        networks: [
+          {
+            id: networkId,
+            peers: peerStackIds.map((stack_id) => ({ stack_id })),
+          },
+        ],
+      },
+    });
+  }
+
+  test("D.3 — federated dispatch + principal in peer roster → allow path matches local C.3 behaviour", async () => {
+    const r = recordingRuntime();
+    const router = createSurfaceRouter(r.runtime);
+    const { factory } = fakeFactory(SUCCESS_RESULT);
+    const listener = createDispatchListener({
+      runtime: r.runtime,
+      router,
+      source: SOURCE,
+      // Subscribe to the federated subject so the router fans the
+      // envelope to this listener.
+      subjects: ["federated.research-collab.dispatch.task.received"],
+      ccSessionFactory: factory,
+      policyEngine: engineWithFederation({ capabilities: ["dispatch.cortex"] }),
+    });
+    await listener.start();
+    await router.start();
+
+    r.trigger(
+      makeReceivedEnvelope(),
+      "federated.research-collab.dispatch.task.received",
+    );
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(r.published.map((e) => e.type)).toEqual([
+      "system.access.allowed",
+      "dispatch.task.started",
+      "dispatch.task.completed",
+    ]);
+    // The audit envelope carries the federated wire subject verbatim
+    // — pre-D.3 synthesised `local.{org}...` regardless.
+    const allowed = r.published[0]!;
+    expect(allowed.payload.envelope_subject).toBe(
+      "federated.research-collab.dispatch.task.received",
+    );
+  });
+
+  test("D.3 — federated dispatch + principal NOT in peer roster → stack_not_in_network deny", async () => {
+    const r = recordingRuntime();
+    const router = createSurfaceRouter(r.runtime);
+    const { factory, optsCaptured } = fakeFactory(SUCCESS_RESULT);
+    const listener = createDispatchListener({
+      runtime: r.runtime,
+      router,
+      source: SOURCE,
+      subjects: ["federated.partner-only.dispatch.task.received"],
+      ccSessionFactory: factory,
+      policyEngine: engineWithFederation({
+        capabilities: ["dispatch.cortex"],
+        networkId: "partner-only",
+        // Network's peers do NOT include andreas/research — cortex's
+        // home_stack misses.
+        peerStackIds: ["jcfischer/sage-host"],
+      }),
+    });
+    await listener.start();
+    await router.start();
+
+    r.trigger(
+      makeReceivedEnvelope(),
+      "federated.partner-only.dispatch.task.received",
+    );
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(r.published.map((e) => e.type)).toEqual([
+      "system.access.denied",
+      "dispatch.task.failed",
+    ]);
+    const denied = r.published[0]!;
+    const reason = denied.payload.reason as {
+      kind: string;
+      principal_id?: string;
+      source_network?: string;
+      home_stack?: string;
+    };
+    expect(reason.kind).toBe("stack_not_in_network");
+    expect(reason.principal_id).toBe("cortex");
+    expect(reason.source_network).toBe("partner-only");
+    expect(reason.home_stack).toBe("andreas/research");
+    // Harness never constructed.
+    expect(optsCaptured).toHaveLength(0);
+  });
+
+  test("D.3 — federated dispatch + unknown network id → unknown_network deny", async () => {
+    const r = recordingRuntime();
+    const router = createSurfaceRouter(r.runtime);
+    const { factory } = fakeFactory(SUCCESS_RESULT);
+    const listener = createDispatchListener({
+      runtime: r.runtime,
+      router,
+      source: SOURCE,
+      // Subscribe to the catch-all federated dispatch pattern so the
+      // listener receives envelopes from networks it doesn't know.
+      subjects: ["federated.>"],
+      ccSessionFactory: factory,
+      policyEngine: engineWithFederation({
+        capabilities: ["dispatch.cortex"],
+        networkId: "research-collab",
+      }),
+    });
+    await listener.start();
+    await router.start();
+
+    // Envelope arrives on a federated subject whose network id isn't
+    // declared in policy.federated.networks[].
+    r.trigger(
+      makeReceivedEnvelope(),
+      "federated.phantom-network.dispatch.task.received",
+    );
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(r.published.map((e) => e.type)).toEqual([
+      "system.access.denied",
+      "dispatch.task.failed",
+    ]);
+    const denied = r.published[0]!;
+    const reason = denied.payload.reason as {
+      kind: string;
+      source_network?: string;
+      principal_id?: string;
+    };
+    expect(reason.kind).toBe("unknown_network");
+    expect(reason.source_network).toBe("phantom-network");
+    expect(reason.principal_id).toBe("cortex");
+  });
+
+  test("D.3.2 — source_network is stamped onto reason for non-federation deny kinds too (insufficient_role on a federated dispatch)", async () => {
+    // The capability check fires before the federation branch, so a
+    // federated dispatch whose principal lacks the capability denies
+    // with `insufficient_role` (the C.3 reason kind). D.3.2 still
+    // requires the audit envelope to carry `source_network` so
+    // operators can see which network the deny came from.
+    const r = recordingRuntime();
+    const router = createSurfaceRouter(r.runtime);
+    const { factory } = fakeFactory(SUCCESS_RESULT);
+    const listener = createDispatchListener({
+      runtime: r.runtime,
+      router,
+      source: SOURCE,
+      subjects: ["federated.research-collab.dispatch.task.received"],
+      ccSessionFactory: factory,
+      policyEngine: engineWithFederation({
+        // No dispatch.cortex grant — capability check misses.
+        capabilities: ["other.cap"],
+      }),
+    });
+    await listener.start();
+    await router.start();
+
+    r.trigger(
+      makeReceivedEnvelope(),
+      "federated.research-collab.dispatch.task.received",
+    );
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    const denied = r.published.find((e) => e.type === "system.access.denied");
+    expect(denied).toBeDefined();
+    if (!denied) return;
+    const reason = denied.payload.reason as {
+      kind: string;
+      missing_capability?: string;
+      source_network?: string;
+    };
+    expect(reason.kind).toBe("insufficient_role");
+    expect(reason.missing_capability).toBe("dispatch.cortex");
+    // D.3.2 — source_network rides on the reason payload even for
+    // non-federation deny kinds.
+    expect(reason.source_network).toBe("research-collab");
+  });
+
+  test("D.3 — local dispatch path is unaffected even when federated config is present (no source_network on intent)", async () => {
+    // Belt-and-braces: a fully-configured federated engine must still
+    // pass-through local dispatches. The federation branch is gated
+    // on `intent.source_network`; subjects starting with `local.>`
+    // yield `undefined` and skip the branch.
+    const r = recordingRuntime();
+    const router = createSurfaceRouter(r.runtime);
+    const { factory } = fakeFactory(SUCCESS_RESULT);
+    const listener = createDispatchListener({
+      runtime: r.runtime,
+      router,
+      source: SOURCE,
+      ccSessionFactory: factory,
+      policyEngine: engineWithFederation({
+        capabilities: ["dispatch.cortex"],
+        // No peer matches cortex's home_stack — would deny on the
+        // federation branch IF the dispatch was federated.
+        peerStackIds: ["jcfischer/sage-host"],
+      }),
+    });
+    await listener.start();
+    await router.start();
+
+    r.trigger(makeReceivedEnvelope(), "local.metafactory.dispatch.task.received");
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(r.published.map((e) => e.type)).toEqual([
+      "system.access.allowed",
+      "dispatch.task.started",
+      "dispatch.task.completed",
+    ]);
+    // Audit envelope carries the original local subject, no
+    // source_network stamped on the allow path (it's a deny-side
+    // concern for audit consumers correlating denied federated
+    // traffic).
+    const allowed = r.published[0]!;
+    expect(allowed.payload.envelope_subject).toBe(
+      "local.metafactory.dispatch.task.received",
+    );
+  });
+
+  test("D.3 — engine sees source_network on Intent when dispatch arrives via federated subject (S-3 analogue)", async () => {
+    const captured: { principalId: string; intent: Intent }[] = [];
+    const engine = engineWithFederation({ capabilities: ["dispatch.cortex"] });
+    const origCheck = engine.check.bind(engine);
+    engine.check = (principalId, intent) => {
+      captured.push({ principalId, intent });
+      return origCheck(principalId, intent);
+    };
+
+    const r = recordingRuntime();
+    const router = createSurfaceRouter(r.runtime);
+    const { factory } = fakeFactory(SUCCESS_RESULT);
+    const listener = createDispatchListener({
+      runtime: r.runtime,
+      router,
+      source: SOURCE,
+      subjects: ["federated.research-collab.dispatch.task.received"],
+      ccSessionFactory: factory,
+      policyEngine: engine,
+    });
+    await listener.start();
+    await router.start();
+
+    r.trigger(
+      makeReceivedEnvelope(),
+      "federated.research-collab.dispatch.task.received",
+    );
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0]!.intent.source_network).toBe("research-collab");
+  });
+
   test("C.4.2 — system.access.denied carries structured reason + signed_by", async () => {
     const r = recordingRuntime();
     const router = createSurfaceRouter(r.runtime);

--- a/src/runner/dispatch-listener.ts
+++ b/src/runner/dispatch-listener.ts
@@ -64,6 +64,7 @@ import type {
   SurfaceRouter,
 } from "../bus/surface-router";
 import type {
+  SystemAccessDeniedReason,
   SystemAccessSignedBy,
   SystemAccessSovereignty,
   SystemEventSource,
@@ -243,8 +244,15 @@ export function createDispatchListener(
     // iteration can wire `signal.aborted` to `harness.shutdown({ graceful:
     // false })` so surface-router timeouts end the CC process eagerly
     // rather than waiting for cc-session's internal timer to fire.
-    render: (envelope, _signal) =>
-      handleDispatchEnvelope(envelope, runtime, source, ccSessionFactory, policyEngine),
+    render: (envelope, _signal, subject) =>
+      handleDispatchEnvelope(
+        envelope,
+        subject,
+        runtime,
+        source,
+        ccSessionFactory,
+        policyEngine,
+      ),
   };
 
   return {
@@ -391,6 +399,7 @@ function buildDispatchRequest(
  */
 async function handleDispatchEnvelope(
   envelope: Envelope,
+  subject: string | undefined,
   runtime: MyelinRuntime,
   source: SystemEventSource,
   ccSessionFactory: CCSessionFactory | undefined,
@@ -418,9 +427,19 @@ async function handleDispatchEnvelope(
   // When the engine is undefined the listener falls back to the
   // legacy unauthenticated path — the runner is booted without a
   // `policy:` block. C.2b removes the legacy path entirely.
+  // IAW Phase D.3 — derive `source_network` from the matched
+  // subject when the envelope arrived via `federated.{id}.>`. Local
+  // dispatches (subjects like `local.{org}.dispatch.task.received`)
+  // leave it `undefined` so the engine skips the federation branch.
+  const sourceNetwork = extractSourceNetwork(subject);
   let gatedPrincipal: Principal | undefined;
   if (policyEngine !== undefined) {
-    const decision = checkDispatchPolicy(policyEngine, envelope, payload);
+    const decision = checkDispatchPolicy(
+      policyEngine,
+      envelope,
+      payload,
+      sourceNetwork,
+    );
     // C.4.3 — carry `signed_by[]` from the originating envelope
     // verbatim so the audit record is cryptographically attributable
     // (even on deny). Normalised to an array via `getSignedByChain`;
@@ -447,6 +466,17 @@ async function handleDispatchEnvelope(
       frontier_ok: envelope.sovereignty.frontier_ok,
       model_class: envelope.sovereignty.model_class,
     };
+    // IAW Phase D.3 — when the inbound envelope's subject was a real
+    // wire subject (the surface-router forwards it on `render`), use
+    // it verbatim on the audit envelope. The pre-D.3 path always
+    // synthesised `local.{org}.dispatch.task.received` regardless of
+    // whether the envelope arrived locally or on `federated.{net}.*`.
+    // Synthesising the local subject on federated traffic would
+    // misrepresent the wire path on audit consumers. Fall back to the
+    // synthesised local subject when `subject` is undefined (legacy
+    // callers / unit tests that don't pass a subject).
+    const auditEnvelopeSubject =
+      subject ?? `local.${source.org}.dispatch.task.received`;
     const auditCommon = {
       source,
       principalId: decision.principalId,
@@ -454,21 +484,44 @@ async function handleDispatchEnvelope(
       sovereignty: auditSovereignty,
       correlationId: envelope.correlation_id ?? payload.task_id,
       envelopeId: envelope.id,
-      envelopeSubject: `local.${source.org}.dispatch.task.received`,
+      envelopeSubject: auditEnvelopeSubject,
       signedBy,
     };
 
     if (!decision.allow) {
       console.error(
-        `cortex-runner: dispatch-listener: denied envelope id=${envelope.id} task_id=${payload.task_id} agent=${payload.agent_id} — reason=${decision.reason.kind}`,
+        `cortex-runner: dispatch-listener: denied envelope id=${envelope.id} task_id=${payload.task_id} agent=${payload.agent_id} — reason=${decision.reason.kind}${
+          sourceNetwork !== undefined ? ` source_network=${sourceNetwork}` : ""
+        }`,
       );
-      // C.4.2 — emit `system.access.denied` carrying the structured
-      // engine deny reason + signed_by chain. Lives on a different
-      // subject than the dispatch.task.* lifecycle so audit consumers
-      // (dashboard, pipeline) get a stable wire path.
+      // C.4.2 / D.3.2 — emit `system.access.denied` carrying the
+      // structured engine deny reason + signed_by chain. Lives on a
+      // different subject than the dispatch.task.* lifecycle so audit
+      // consumers (dashboard, pipeline) get a stable wire path.
+      //
+      // IAW Phase D.3.2 — stamp `source_network` onto the audit
+      // reason payload whenever the dispatch arrived on a federated
+      // subject, even when the deny kind isn't one of the D.3
+      // federation-specific variants (e.g. `insufficient_role` on a
+      // federated dispatch). Audit consumers branching on
+      // `reason.kind` can read `reason.source_network` uniformly and
+      // render which network the deny came from. D.3 federation-
+      // specific reasons already carry the field via the
+      // discriminator; the merge is a no-op for those.
+      //
+      // The audit reason rides on `SystemAccessDeniedReason` whose
+      // `[k: string]: unknown` index allows additive fields without
+      // a wire-schema bump — distinct from `PolicyDenyReason` which
+      // is a tight discriminated union and would reject the spread.
+      // Echo cortex#221 round 1 carved the audit/policy split for
+      // exactly this kind of audit-only enrichment.
+      const auditReason: Record<string, unknown> = {
+        ...(decision.reason as unknown as Record<string, unknown>),
+        ...(sourceNetwork !== undefined && { source_network: sourceNetwork }),
+      };
       const denied = createSystemAccessDeniedEvent({
         ...auditCommon,
-        reason: { ...decision.reason },
+        reason: auditReason as unknown as SystemAccessDeniedReason,
       });
       await runtime.publish(denied);
       // Echo cortex#220 round 2 M-1 — also synthesise a terminal
@@ -601,9 +654,15 @@ function checkDispatchPolicy(
   engine: PolicyEngine,
   envelope: Envelope,
   payload: DispatchTaskReceivedPayload,
+  sourceNetwork: string | undefined,
 ): DispatchPolicyResult {
   const principalId = resolvePrincipalId(envelope, payload);
 
+  // IAW Phase D.3 — surface `source_network` onto the intent when the
+  // inbound wire subject was `federated.{network_id}.>`. The engine
+  // uses it to evaluate the per-network policy slice; local
+  // dispatches leave it `undefined` so the federation branch stays
+  // inert (preserves C.3 behaviour for the legacy path).
   const intent: Intent = {
     capability: `dispatch.${payload.agent_id}`,
     sovereignty: {
@@ -614,6 +673,7 @@ function checkDispatchPolicy(
       model_class: envelope.sovereignty.model_class,
     },
     payload_summary: `dispatch agent=${payload.agent_id} task_id=${payload.task_id}`,
+    ...(sourceNetwork !== undefined && { source_network: sourceNetwork }),
   };
 
   const decision = engine.check(principalId, intent);
@@ -658,5 +718,36 @@ function resolvePrincipalId(
   const origin = chain[0];
   if (origin === undefined) return payload.agent_id;
   return extractAgentIdFromDid(origin.principal) ?? origin.principal;
+}
+
+/**
+ * IAW Phase D.3 (cortex#116) — derive the federation network id from
+ * a NATS subject of the form `federated.{network_id}.<...>`. Returns
+ * `undefined` for any other subject shape (including local dispatches
+ * and undefined inputs).
+ *
+ * The `{network_id}` grammar matches `PolicyFederatedNetworkSchema.id`
+ * — lowercase alphanumeric + hyphen, starting with a letter. A
+ * subject whose second segment doesn't match this grammar yields
+ * `undefined` (defensive — the schema rejects malformed network ids
+ * at config-load, but the wire path could still surface unexpected
+ * subjects).
+ *
+ * Examples:
+ *   `federated.research-collab.tasks.code-review` → `"research-collab"`
+ *   `federated.research-collab` → `undefined` (no trailing segments,
+ *     not a dispatch subject)
+ *   `local.metafactory.dispatch.task.received` → `undefined`
+ *   `undefined` → `undefined`
+ */
+function extractSourceNetwork(subject: string | undefined): string | undefined {
+  if (subject === undefined) return undefined;
+  const parts = subject.split(".");
+  if (parts.length < 3) return undefined;
+  if (parts[0] !== "federated") return undefined;
+  const networkId = parts[1];
+  if (networkId === undefined || networkId.length === 0) return undefined;
+  if (!/^[a-z][a-z0-9-]*$/.test(networkId)) return undefined;
+  return networkId;
 }
 

--- a/src/runner/dispatch-listener.ts
+++ b/src/runner/dispatch-listener.ts
@@ -497,31 +497,15 @@ async function handleDispatchEnvelope(
       // C.4.2 / D.3.2 — emit `system.access.denied` carrying the
       // structured engine deny reason + signed_by chain. Lives on a
       // different subject than the dispatch.task.* lifecycle so audit
-      // consumers (dashboard, pipeline) get a stable wire path.
-      //
-      // IAW Phase D.3.2 — stamp `source_network` onto the audit
-      // reason payload whenever the dispatch arrived on a federated
-      // subject, even when the deny kind isn't one of the D.3
-      // federation-specific variants (e.g. `insufficient_role` on a
-      // federated dispatch). Audit consumers branching on
-      // `reason.kind` can read `reason.source_network` uniformly and
-      // render which network the deny came from. D.3 federation-
-      // specific reasons already carry the field via the
-      // discriminator; the merge is a no-op for those.
-      //
-      // The audit reason rides on `SystemAccessDeniedReason` whose
-      // `[k: string]: unknown` index allows additive fields without
-      // a wire-schema bump — distinct from `PolicyDenyReason` which
-      // is a tight discriminated union and would reject the spread.
-      // Echo cortex#221 round 1 carved the audit/policy split for
-      // exactly this kind of audit-only enrichment.
-      const auditReason: Record<string, unknown> = {
-        ...(decision.reason as unknown as Record<string, unknown>),
-        ...(sourceNetwork !== undefined && { source_network: sourceNetwork }),
-      };
+      // consumers (dashboard, pipeline) get a stable wire path. The
+      // `source_network` enrichment is delegated to `enrichDenyReason`
+      // so the cast that bridges `PolicyDenyReason` (tight discriminated
+      // union) → `SystemAccessDeniedReason` (`[k: string]: unknown`
+      // open record) lives in one localised helper rather than on the
+      // dispatch path (Echo cortex#227 round 1).
       const denied = createSystemAccessDeniedEvent({
         ...auditCommon,
-        reason: auditReason as unknown as SystemAccessDeniedReason,
+        reason: enrichDenyReason(decision.reason, sourceNetwork),
       });
       await runtime.publish(denied);
       // Echo cortex#220 round 2 M-1 — also synthesise a terminal
@@ -718,6 +702,44 @@ function resolvePrincipalId(
   const origin = chain[0];
   if (origin === undefined) return payload.agent_id;
   return extractAgentIdFromDid(origin.principal) ?? origin.principal;
+}
+
+/**
+ * IAW Phase D.3.2 (cortex#116, Echo cortex#227 round 1) — produce the
+ * `SystemAccessDeniedReason` payload for a deny audit envelope from
+ * an engine `PolicyDenyReason`, optionally enriched with the
+ * `source_network` that the dispatch arrived on.
+ *
+ * The audit reason rides on `SystemAccessDeniedReason` whose `kind:
+ * string` + `[k: string]: unknown` shape was carved by Echo cortex#221
+ * round 1 to decouple the audit surface from the tighter
+ * `PolicyDenyReason` discriminated union — additive fields like
+ * `source_network` can land on the wire without forcing every audit
+ * consumer to update its types. Keeping the enrichment in one place
+ * gives operators a single function to inspect when reasoning about
+ * "what shape does a deny envelope land with for federated traffic?"
+ *
+ * D.3 federation-specific reasons (`unknown_network`,
+ * `stack_not_in_network`) already carry `source_network` via the
+ * discriminator — the merge is a no-op for those; the value lives on
+ * the same field name and the spread overwrites with an identical
+ * literal.
+ */
+function enrichDenyReason(
+  reason: PolicyDenyReason,
+  source_network: string | undefined,
+): SystemAccessDeniedReason {
+  // `SystemAccessDeniedReason` is structurally `{ kind: string; [k:
+  // string]: unknown }` — open enough to accept any spread of a
+  // `PolicyDenyReason` discriminated-union member directly. No cast
+  // needed (Echo cortex#227 round 1 — kept the helper for the
+  // localisation reasons in the JSDoc, even though the cast that
+  // motivated extraction is no longer required at the assignment
+  // site).
+  return {
+    ...reason,
+    ...(source_network !== undefined && { source_network }),
+  };
 }
 
 /**


### PR DESCRIPTION
## Summary

IAW Phase D.3 — extends the PolicyEngine (C.1) with per-network policy slicing on federated dispatches. Builds on D.1's `policy.federated.networks[]` schema (#223).

- **D.3.1** — `Intent.source_network?: string`. When set (envelope arrived via `federated.{network_id}.>`), the engine consults the matching network's peer roster. Principals whose `home_stack` isn't in `peers[].stack_id` deny with one of three new reason kinds: `unknown_network`, `stack_not_in_network`, `unknown_federated_peer` (last reserved for D.4 cloud-registry resolution).
- **D.3.2** — `system.access.denied` audit envelopes stamp `source_network` onto the reason payload whenever the dispatch arrived on a federated subject, even for non-federation deny kinds (e.g. `insufficient_role` on a federated dispatch). Audit consumers can render which network the deny came from without re-parsing the wire path.

## Design

- **Federation slice on the engine.** `PolicyEngineOptions.federated` takes a slim `FederatedPolicy` view (id + `peers[].stack_id`); the factory narrows the Zod-parsed `policy.federated` to this shape. Other fields on the wider schema (`accept_subjects`/`deny_subjects`/`max_hop`) are surface-router concerns (D.2), not engine concerns.
- **Federation branch fires AFTER capability check.** Closest-miss principle: an underprivileged principal sees `insufficient_role` (the local issue) rather than `stack_not_in_network` (the federation issue). Operators triaging deny logs see the nearest failure first.
- **`SurfaceAdapter.render(envelope, signal?, subject?)`** — additive third positional argument carrying the matched NATS subject. The dispatch-listener uses it to derive `source_network`; existing adapters that match `(envelope, signal)` continue to work unchanged.
- **Local dispatches are unchanged.** `intent.source_network === undefined` skips the federation branch entirely — pre-D.3 behaviour preserved.

## Pre-Phase-B caveat

The principal claim on `signed_by[0].principal` is not yet cryptographically verified at the envelope-validator (cortex#114). The D.3 federation gate inherits this caveat — defence in depth against misconfigured peers, not authentication. Documented inline on `Intent.source_network` JSDoc + on `PolicyEngine.check` JSDoc.

## Test plan

- [x] Engine: local dispatch (no source_network) → C.3 behaviour unchanged
- [x] Engine: federated dispatch + principal in peer roster → allow
- [x] Engine: federated dispatch + unknown network id → `unknown_network` deny
- [x] Engine: federated dispatch + principal's home_stack not in roster → `stack_not_in_network` deny
- [x] Engine: capability check fires before federation branch (closest-miss)
- [x] Engine: federated dispatch + no federated config → `unknown_network`
- [x] Engine: `unknown_principal` still fires before the federation branch
- [x] Factory: round-trip parsed `policy.federated` flows into engine; federated check honours roster
- [x] Dispatch-listener: federated allow path matches local C.3 behaviour; audit envelope carries the federated wire subject verbatim
- [x] Dispatch-listener: federated `stack_not_in_network` deny — emits `system.access.denied` + `dispatch.task.failed`; harness not constructed
- [x] Dispatch-listener: federated `unknown_network` deny (listener subscribed to `federated.>`, network id not declared)
- [x] Dispatch-listener: D.3.2 — `source_network` stamped onto reason payload even for `insufficient_role` on a federated dispatch
- [x] Dispatch-listener: local dispatch path is unaffected when federated config is present
- [x] Dispatch-listener: engine sees `source_network` on `Intent` (S-3 analogue)
- [x] `bunx tsc --noEmit` clean
- [x] `bun run lint:errors` clean
- [x] Full `bun test` suite green (2860 pass, 1 skip, 0 fail)

## Files touched

- `src/common/policy/types.ts` — `Intent.source_network`, three new `PolicyDenyReason` variants
- `src/common/policy/engine.ts` — `FederatedPolicy` / `FederatedNetwork` slim types; federation branch in `check()`
- `src/common/policy/factory.ts` — narrow Zod-parsed federated block to engine's slim shape
- `src/common/policy/index.ts` — re-export federation types
- `src/bus/surface-router.ts` — `SurfaceAdapter.render` gains optional `subject` arg
- `src/runner/dispatch-listener.ts` — `extractSourceNetwork(subject)`; threaded onto `Intent` + audit reason
- Tests: `src/common/policy/__tests__/{engine,factory}.test.ts`, `src/runner/__tests__/dispatch-listener.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)