### PR TITLE
feat(registry): IAW D.4.3 — cortex-side RegistryClient consumer (refs cortex#116)

### DIFF
--- a/src/common/registry/__tests__/client.test.ts
+++ b/src/common/registry/__tests__/client.test.ts
@@ -359,11 +359,12 @@ describe("RegistryClient — getOperator()", () => {
   });
 
   test("returns undefined when the payload's operator_pubkey is signed but malformed", async () => {
-    // Echo cortex#230 round 1: a signed-but-malformed peer pubkey is
-    // still a wire-contract violation. The signature verifies and the
-    // operator_id matches, but the pubkey field is the wrong shape;
-    // the post-verify grammar gate must catch it before the cache
-    // accepts a poison value.
+    // Echo cortex#230 rounds 1 + 3: a signed-but-malformed peer
+    // pubkey is still a wire-contract violation. The structural
+    // grammar gate runs BEFORE the signature verify (cheap-check-
+    // first ordering — no wasted crypto on garbage payloads), so a
+    // wrong-shape pubkey is rejected even if the rest of the
+    // assertion would have verified.
     const kp = await generateKeypair();
     const op: OperatorRecord = {
       ...makeOperator("andreas"),

--- a/src/common/registry/__tests__/client.test.ts
+++ b/src/common/registry/__tests__/client.test.ts
@@ -414,6 +414,62 @@ describe("RegistryClient — periodic refresh + shutdown", () => {
     expect(fetchCalls.length).toBe(callsAfterStart);
   });
 
+  test("concurrent refreshAll() invocations are coalesced — the second call short-circuits while the first is in flight", async () => {
+    // Echo cortex#230 round 1: without the in-flight guard, a
+    // setInterval tick firing while the previous cycle still drains
+    // would reassign `cycleAbort` and orphan the previous controller.
+    // We model that by stalling the first fetch on a manually-resolved
+    // promise, then invoking `refreshAll()` a second time before the
+    // first completes. The fake `fetch` records every call; with the
+    // guard the second invocation must NOT issue any GET.
+    const kp = await generateKeypair();
+    const op = makeOperator("andreas");
+    const assertion = await signAssertion(kp.privateKey, kp.publicKeyB64, op);
+
+    const fetchCalls: string[] = [];
+    let release: (() => void) | undefined;
+    const block = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const fakeFetch: FakeFetchHandler = async (url: string) => {
+      fetchCalls.push(url);
+      await block;
+      return jsonResponse(assertion);
+    };
+    const errs: string[] = [];
+    const client = new RegistryClient({
+      url: "https://registry.example",
+      pubkey: kp.publicKeyB64,
+      operatorIds: ["andreas"],
+      refreshIntervalMs: 0,
+      fetch: fakeFetch as typeof fetch,
+      logError: (m) => errs.push(m),
+    });
+    try {
+      // Start a refresh cycle; do NOT await — it'll block on `release`.
+      const inFlight = client.refreshAll();
+      // Yield so the cycle reaches its first fetch and registers the
+      // call. Without this microtask boundary the second refreshAll
+      // could race the first into the `refreshInFlight = true` set.
+      await Promise.resolve();
+      // Second invocation while the first is still pending: must
+      // short-circuit (no additional fetch).
+      await client.refreshAll();
+      expect(fetchCalls.length).toBe(1);
+      expect(errs.some((e) => e.includes("previous cycle still draining"))).toBe(true);
+      // Now release the first cycle and let it complete.
+      release?.();
+      await inFlight;
+      expect(client.getOperator("andreas")).toBeDefined();
+      // A subsequent refresh after the cycle drained must run normally.
+      await client.refreshAll();
+      expect(fetchCalls.length).toBe(2);
+    } finally {
+      release?.();
+      client.stop();
+    }
+  });
+
   test("invalidate() drops a cache entry; the next refresh repopulates it", async () => {
     const kp = await generateKeypair();
     const op = makeOperator("andreas");

--- a/src/common/registry/__tests__/client.test.ts
+++ b/src/common/registry/__tests__/client.test.ts
@@ -1,0 +1,465 @@
+/**
+ * IAW Phase D.4.3 — RegistryClient tests.
+ *
+ * Covers the cases called out in the D.4.3 spec:
+ *
+ *   1. TOFU pubkey fetch at boot
+ *   2. Pinned pubkey from config bypasses TOFU
+ *   3. `getOperator` returns verified data
+ *   4. `getOperator` returns undefined on signature verification failure
+ *   5. `getOperator` returns undefined on network failure (no throw)
+ *   6. Periodic refresh updates cache
+ *   7. Shutdown stops the refresh timer
+ *
+ * The test rig builds a `fakeFetch` closure that maps URL → response,
+ * signs assertions with a fresh Ed25519 keypair, and injects the
+ * closure via `RegistryClientOptions.fetch`. No real network.
+ */
+
+import { describe, expect, mock, test } from "bun:test";
+
+import { RegistryClient } from "../client";
+import { canonicalJSON } from "../signing";
+import type { OperatorRecord, SignedAssertion } from "../types";
+
+// =============================================================================
+// Test helpers — Ed25519 sign-side (the client only verifies; tests
+// produce the assertions the client consumes).
+// =============================================================================
+
+function bytesToBase64(bytes: Uint8Array): string {
+  let bin = "";
+  for (const b of bytes) bin += String.fromCharCode(b);
+  return btoa(bin);
+}
+
+async function generateKeypair(): Promise<{
+  privateKey: CryptoKey;
+  publicKeyB64: string;
+}> {
+  const kp = await crypto.subtle.generateKey(
+    { name: "Ed25519" },
+    true,
+    ["sign", "verify"],
+  );
+  const raw = await crypto.subtle.exportKey("raw", kp.publicKey);
+  return { privateKey: kp.privateKey, publicKeyB64: bytesToBase64(new Uint8Array(raw)) };
+}
+
+async function signAssertion<T>(
+  privateKey: CryptoKey,
+  registryPubkey: string,
+  payload: T,
+): Promise<SignedAssertion<T>> {
+  const issued_at = new Date().toISOString();
+  const bound = canonicalJSON({ payload, issued_at, registry: registryPubkey });
+  const sig = await crypto.subtle.sign(
+    { name: "Ed25519" },
+    privateKey,
+    new TextEncoder().encode(bound),
+  );
+  return {
+    payload,
+    issued_at,
+    registry: registryPubkey,
+    signature: bytesToBase64(new Uint8Array(sig)),
+  };
+}
+
+function makeOperator(operator_id: string, pubkeyB64 = "AAAA"): OperatorRecord {
+  return {
+    operator_id,
+    operator_pubkey: pubkeyB64,
+    stacks: [{ stack_id: `${operator_id}/main` }],
+    capabilities: [],
+    updated_at: new Date().toISOString(),
+  };
+}
+
+type FakeFetchHandler = (url: string, init?: RequestInit) => Promise<Response>;
+
+function makeRouteFetch(
+  routes: Record<string, () => Promise<Response> | Response>,
+): FakeFetchHandler {
+  return async (url: string) => {
+    // Match by suffix so callers can write short keys like
+    // "/registry/pubkey" or "/operators/andreas".
+    for (const [suffix, handler] of Object.entries(routes)) {
+      if (url.endsWith(suffix)) return handler();
+    }
+    return new Response("not found", { status: 404 });
+  };
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe("RegistryClient — TOFU + pinned pubkey", () => {
+  test("TOFU: fetches /registry/pubkey at start() and pins the response", async () => {
+    const kp = await generateKeypair();
+    const op = makeOperator("andreas");
+    const assertion = await signAssertion(kp.privateKey, kp.publicKeyB64, op);
+
+    let pubkeyFetched = false;
+    const fakeFetch = makeRouteFetch({
+      "/registry/pubkey": () => {
+        pubkeyFetched = true;
+        return jsonResponse({ algorithm: "Ed25519", public_key: kp.publicKeyB64 });
+      },
+      "/operators/andreas": () => jsonResponse(assertion),
+    });
+
+    const client = new RegistryClient({
+      url: "https://registry.example/",
+      operatorIds: ["andreas"],
+      refreshIntervalMs: 0, // disable background timer for tests
+      fetch: fakeFetch as typeof fetch,
+      logError: () => {},
+    });
+    await client.start();
+    try {
+      expect(pubkeyFetched).toBe(true);
+      const fetched = client.getOperator("andreas");
+      expect(fetched).toBeDefined();
+      expect(fetched?.operator_id).toBe("andreas");
+    } finally {
+      client.stop();
+    }
+  });
+
+  test("pinned pubkey from config skips the /registry/pubkey TOFU call", async () => {
+    const kp = await generateKeypair();
+    const op = makeOperator("jcfischer");
+    const assertion = await signAssertion(kp.privateKey, kp.publicKeyB64, op);
+
+    let pubkeyFetched = false;
+    const fakeFetch = makeRouteFetch({
+      "/registry/pubkey": () => {
+        pubkeyFetched = true;
+        return jsonResponse({ algorithm: "Ed25519", public_key: kp.publicKeyB64 });
+      },
+      "/operators/jcfischer": () => jsonResponse(assertion),
+    });
+
+    const client = new RegistryClient({
+      url: "https://registry.example",
+      pubkey: kp.publicKeyB64,
+      operatorIds: ["jcfischer"],
+      refreshIntervalMs: 0,
+      fetch: fakeFetch as typeof fetch,
+      logError: () => {},
+    });
+    await client.start();
+    try {
+      expect(pubkeyFetched).toBe(false);
+      expect(client.getOperator("jcfischer")).toBeDefined();
+    } finally {
+      client.stop();
+    }
+  });
+});
+
+describe("RegistryClient — getOperator()", () => {
+  test("returns the verified record after a successful refresh", async () => {
+    const kp = await generateKeypair();
+    const op = makeOperator("andreas", "PEER_PUBKEY_BASE64=");
+    const assertion = await signAssertion(kp.privateKey, kp.publicKeyB64, op);
+
+    const fakeFetch = makeRouteFetch({
+      "/operators/andreas": () => jsonResponse(assertion),
+    });
+
+    const client = new RegistryClient({
+      url: "https://registry.example",
+      pubkey: kp.publicKeyB64,
+      operatorIds: ["andreas"],
+      refreshIntervalMs: 0,
+      fetch: fakeFetch as typeof fetch,
+      logError: () => {},
+    });
+    await client.start();
+    try {
+      const got = client.getOperator("andreas");
+      expect(got).toEqual(op);
+    } finally {
+      client.stop();
+    }
+  });
+
+  test("returns undefined when the signature does not verify", async () => {
+    // Two distinct keypairs: the registry signs with `signerKp`, but
+    // the client pins `pinnedKp.publicKeyB64`. The assertion's
+    // `registry` field is set to the pinned key (so the pubkey-match
+    // check passes) but the signature was produced under the wrong
+    // private key. This is the canonical "trust anchor mismatch but
+    // structural shape correct" attack the verify step must catch.
+    const signerKp = await generateKeypair();
+    const pinnedKp = await generateKeypair();
+    const op = makeOperator("attacker");
+    const issued_at = new Date().toISOString();
+    const bound = canonicalJSON({ payload: op, issued_at, registry: pinnedKp.publicKeyB64 });
+    const sigBuf = await crypto.subtle.sign(
+      { name: "Ed25519" },
+      signerKp.privateKey,
+      new TextEncoder().encode(bound),
+    );
+    const forged: SignedAssertion<OperatorRecord> = {
+      payload: op,
+      issued_at,
+      registry: pinnedKp.publicKeyB64,
+      signature: bytesToBase64(new Uint8Array(sigBuf)),
+    };
+
+    const errs: string[] = [];
+    const fakeFetch = makeRouteFetch({
+      "/operators/attacker": () => jsonResponse(forged),
+    });
+    const client = new RegistryClient({
+      url: "https://registry.example",
+      pubkey: pinnedKp.publicKeyB64,
+      operatorIds: ["attacker"],
+      refreshIntervalMs: 0,
+      fetch: fakeFetch as typeof fetch,
+      logError: (m) => errs.push(m),
+    });
+    await client.start();
+    try {
+      expect(client.getOperator("attacker")).toBeUndefined();
+      expect(errs.some((e) => e.includes("signature did not verify"))).toBe(true);
+    } finally {
+      client.stop();
+    }
+  });
+
+  test("returns undefined on network failure (no throw at call site)", async () => {
+    const kp = await generateKeypair();
+    const fakeFetch: FakeFetchHandler = async () => {
+      throw new Error("connection refused");
+    };
+    const errs: string[] = [];
+    const client = new RegistryClient({
+      url: "https://registry.example",
+      pubkey: kp.publicKeyB64,
+      operatorIds: ["andreas"],
+      refreshIntervalMs: 0,
+      fetch: fakeFetch as typeof fetch,
+      logError: (m) => errs.push(m),
+    });
+    // start() must not throw even when every fetch rejects.
+    await client.start();
+    try {
+      expect(client.getOperator("andreas")).toBeUndefined();
+      expect(errs.some((e) => e.includes("connection refused"))).toBe(true);
+    } finally {
+      client.stop();
+    }
+  });
+
+  test("returns undefined when the registry returned an `unconfigured` sentinel", async () => {
+    const kp = await generateKeypair();
+    const op = makeOperator("andreas");
+    const unsignedAssertion: SignedAssertion<OperatorRecord> = {
+      payload: op,
+      issued_at: new Date().toISOString(),
+      registry: "unconfigured",
+      signature: "",
+    };
+    const fakeFetch = makeRouteFetch({
+      "/operators/andreas": () => jsonResponse(unsignedAssertion),
+    });
+    const errs: string[] = [];
+    const client = new RegistryClient({
+      url: "https://registry.example",
+      pubkey: kp.publicKeyB64,
+      operatorIds: ["andreas"],
+      refreshIntervalMs: 0,
+      fetch: fakeFetch as typeof fetch,
+      logError: (m) => errs.push(m),
+    });
+    await client.start();
+    try {
+      expect(client.getOperator("andreas")).toBeUndefined();
+      expect(errs.some((e) => e.includes("unconfigured"))).toBe(true);
+    } finally {
+      client.stop();
+    }
+  });
+
+  test("returns undefined when the registry pubkey on the assertion does not match the pinned pubkey", async () => {
+    const realKp = await generateKeypair();
+    const otherKp = await generateKeypair();
+    const op = makeOperator("victim");
+    // Assertion is well-signed by realKp, but the client pinned otherKp.
+    const assertion = await signAssertion(realKp.privateKey, realKp.publicKeyB64, op);
+    const fakeFetch = makeRouteFetch({
+      "/operators/victim": () => jsonResponse(assertion),
+    });
+    const errs: string[] = [];
+    const client = new RegistryClient({
+      url: "https://registry.example",
+      pubkey: otherKp.publicKeyB64,
+      operatorIds: ["victim"],
+      refreshIntervalMs: 0,
+      fetch: fakeFetch as typeof fetch,
+      logError: (m) => errs.push(m),
+    });
+    await client.start();
+    try {
+      expect(client.getOperator("victim")).toBeUndefined();
+      expect(errs.some((e) => e.includes("registry pubkey mismatch"))).toBe(true);
+    } finally {
+      client.stop();
+    }
+  });
+
+  test("returns undefined when the payload's operator_id does not match the requested id", async () => {
+    // Defends against a swapped-payload attack: a malicious registry
+    // serves a valid signed assertion for `eve` when cortex asked for
+    // `alice`. The signature verifies, the registry pubkey matches —
+    // only the per-operator id check catches it.
+    const kp = await generateKeypair();
+    const eve = makeOperator("eve");
+    const assertion = await signAssertion(kp.privateKey, kp.publicKeyB64, eve);
+    const fakeFetch = makeRouteFetch({
+      "/operators/alice": () => jsonResponse(assertion),
+    });
+    const errs: string[] = [];
+    const client = new RegistryClient({
+      url: "https://registry.example",
+      pubkey: kp.publicKeyB64,
+      operatorIds: ["alice"],
+      refreshIntervalMs: 0,
+      fetch: fakeFetch as typeof fetch,
+      logError: (m) => errs.push(m),
+    });
+    await client.start();
+    try {
+      expect(client.getOperator("alice")).toBeUndefined();
+      expect(errs.some((e) => e.includes("operator_id mismatch"))).toBe(true);
+    } finally {
+      client.stop();
+    }
+  });
+});
+
+describe("RegistryClient — periodic refresh + shutdown", () => {
+  test("periodic refresh updates the cache on each cycle", async () => {
+    const kp = await generateKeypair();
+    let currentPubkey = "PUBKEY_V1_BASE64_FAKE=";
+    const fakeFetch: FakeFetchHandler = async (url: string) => {
+      if (url.endsWith("/operators/andreas")) {
+        const op = makeOperator("andreas", currentPubkey);
+        const assertion = await signAssertion(kp.privateKey, kp.publicKeyB64, op);
+        return jsonResponse(assertion);
+      }
+      return new Response("not found", { status: 404 });
+    };
+
+    const client = new RegistryClient({
+      url: "https://registry.example",
+      pubkey: kp.publicKeyB64,
+      operatorIds: ["andreas"],
+      // Disable the timer; drive cycles manually via refreshAll().
+      // The timer behaviour is exercised by the shutdown test below.
+      refreshIntervalMs: 0,
+      fetch: fakeFetch as typeof fetch,
+      logError: () => {},
+    });
+    await client.start();
+    try {
+      expect(client.getOperator("andreas")?.operator_pubkey).toBe("PUBKEY_V1_BASE64_FAKE=");
+      // Operator rotates their pubkey upstream.
+      currentPubkey = "PUBKEY_V2_BASE64_FAKE=";
+      await client.refreshAll();
+      expect(client.getOperator("andreas")?.operator_pubkey).toBe("PUBKEY_V2_BASE64_FAKE=");
+    } finally {
+      client.stop();
+    }
+  });
+
+  test("stop() cancels the refresh timer", async () => {
+    const kp = await generateKeypair();
+    const op = makeOperator("andreas");
+    const assertion = await signAssertion(kp.privateKey, kp.publicKeyB64, op);
+
+    const fetchCalls: string[] = [];
+    const fakeFetch: FakeFetchHandler = async (url: string) => {
+      fetchCalls.push(url);
+      if (url.endsWith("/operators/andreas")) return jsonResponse(assertion);
+      return new Response("not found", { status: 404 });
+    };
+
+    const client = new RegistryClient({
+      url: "https://registry.example",
+      pubkey: kp.publicKeyB64,
+      operatorIds: ["andreas"],
+      refreshIntervalMs: 25, // very short — would fire if not stopped
+      fetch: fakeFetch as typeof fetch,
+      logError: () => {},
+    });
+    await client.start();
+    const callsAfterStart = fetchCalls.length;
+    client.stop();
+
+    // Wait several refresh intervals; no further fetches should occur.
+    await new Promise((r) => setTimeout(r, 120));
+    expect(fetchCalls.length).toBe(callsAfterStart);
+  });
+
+  test("invalidate() drops a cache entry; the next refresh repopulates it", async () => {
+    const kp = await generateKeypair();
+    const op = makeOperator("andreas");
+    const assertion = await signAssertion(kp.privateKey, kp.publicKeyB64, op);
+    const fakeFetch = makeRouteFetch({
+      "/operators/andreas": () => jsonResponse(assertion),
+    });
+
+    const client = new RegistryClient({
+      url: "https://registry.example",
+      pubkey: kp.publicKeyB64,
+      operatorIds: ["andreas"],
+      refreshIntervalMs: 0,
+      fetch: fakeFetch as typeof fetch,
+      logError: () => {},
+    });
+    await client.start();
+    try {
+      expect(client.getOperator("andreas")).toBeDefined();
+      client.invalidate("andreas");
+      expect(client.getOperator("andreas")).toBeUndefined();
+      await client.refreshAll();
+      expect(client.getOperator("andreas")).toBeDefined();
+    } finally {
+      client.stop();
+    }
+  });
+});
+
+describe("RegistryClient — empty config", () => {
+  test("operatorIds=[] makes the client dormant — no fetches, getOperator returns undefined", async () => {
+    const fetchSpy = mock(async (_url: string) => new Response("nope", { status: 404 }));
+    const client = new RegistryClient({
+      url: "https://registry.example",
+      pubkey: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=", // 43 chars + = = 44
+      operatorIds: [],
+      refreshIntervalMs: 0,
+      fetch: fetchSpy as unknown as typeof fetch,
+      logError: () => {},
+    });
+    await client.start();
+    try {
+      expect(client.getOperator("anyone")).toBeUndefined();
+      expect(fetchSpy.mock.calls.length).toBe(0);
+    } finally {
+      client.stop();
+    }
+  });
+});

--- a/src/common/registry/__tests__/client.test.ts
+++ b/src/common/registry/__tests__/client.test.ts
@@ -66,7 +66,16 @@ async function signAssertion<T>(
   };
 }
 
-function makeOperator(operator_id: string, pubkeyB64 = "AAAA"): OperatorRecord {
+/**
+ * Structurally-valid base64 Ed25519 pubkey (44 chars: 43 of alphabet
+ * + one `=` of padding). Real keys come out of WebCrypto's
+ * `generateKeypair`; tests only need the regex to pass at the
+ * payload-grammar gate. Echo cortex#230 round 1 added that gate.
+ */
+const FAKE_PEER_PUBKEY_V1 = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+const FAKE_PEER_PUBKEY_V2 = "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB=";
+
+function makeOperator(operator_id: string, pubkeyB64 = FAKE_PEER_PUBKEY_V1): OperatorRecord {
   return {
     operator_id,
     operator_pubkey: pubkeyB64,
@@ -170,7 +179,7 @@ describe("RegistryClient — TOFU + pinned pubkey", () => {
 describe("RegistryClient — getOperator()", () => {
   test("returns the verified record after a successful refresh", async () => {
     const kp = await generateKeypair();
-    const op = makeOperator("andreas", "PEER_PUBKEY_BASE64=");
+    const op = makeOperator("andreas", FAKE_PEER_PUBKEY_V1);
     const assertion = await signAssertion(kp.privateKey, kp.publicKeyB64, op);
 
     const fakeFetch = makeRouteFetch({
@@ -348,12 +357,138 @@ describe("RegistryClient — getOperator()", () => {
       client.stop();
     }
   });
+
+  test("returns undefined when the payload's operator_pubkey is signed but malformed", async () => {
+    // Echo cortex#230 round 1: a signed-but-malformed peer pubkey is
+    // still a wire-contract violation. The signature verifies and the
+    // operator_id matches, but the pubkey field is the wrong shape;
+    // the post-verify grammar gate must catch it before the cache
+    // accepts a poison value.
+    const kp = await generateKeypair();
+    const op: OperatorRecord = {
+      ...makeOperator("andreas"),
+      operator_pubkey: "definitely-not-base64-ed25519", // wrong length + alphabet
+    };
+    const assertion = await signAssertion(kp.privateKey, kp.publicKeyB64, op);
+    const fakeFetch = makeRouteFetch({
+      "/operators/andreas": () => jsonResponse(assertion),
+    });
+    const errs: string[] = [];
+    const client = new RegistryClient({
+      url: "https://registry.example",
+      pubkey: kp.publicKeyB64,
+      operatorIds: ["andreas"],
+      refreshIntervalMs: 0,
+      fetch: fakeFetch as typeof fetch,
+      logError: (m) => errs.push(m),
+    });
+    await client.start();
+    try {
+      expect(client.getOperator("andreas")).toBeUndefined();
+      expect(errs.some((e) => e.includes("not base64-Ed25519"))).toBe(true);
+    } finally {
+      client.stop();
+    }
+  });
+});
+
+describe("RegistryClient — start()/stop() idempotency", () => {
+  test("start() is idempotent under refreshIntervalMs=0 (no setInterval timer)", async () => {
+    // Without a dedicated `started` flag, the previous implementation
+    // used `refreshTimer !== undefined` as the "already started" guard.
+    // With refreshIntervalMs=0 there is no timer, so a second start()
+    // would re-run TOFU + the eager refresh — visible here as a
+    // doubled fetch count. The `started` flag fixes that. Echo
+    // cortex#230 round 1.
+    const kp = await generateKeypair();
+    const op = makeOperator("andreas");
+    const assertion = await signAssertion(kp.privateKey, kp.publicKeyB64, op);
+    const fetchCalls: string[] = [];
+    const fakeFetch: FakeFetchHandler = async (url: string) => {
+      fetchCalls.push(url);
+      if (url.endsWith("/registry/pubkey")) {
+        return jsonResponse({ algorithm: "Ed25519", public_key: kp.publicKeyB64 });
+      }
+      if (url.endsWith("/operators/andreas")) return jsonResponse(assertion);
+      return new Response("nope", { status: 404 });
+    };
+    const client = new RegistryClient({
+      url: "https://registry.example",
+      // No pubkey → TOFU mode → /registry/pubkey is called on start.
+      operatorIds: ["andreas"],
+      refreshIntervalMs: 0,
+      fetch: fakeFetch as typeof fetch,
+      logError: () => {},
+    });
+    await client.start();
+    const callsAfterFirst = fetchCalls.length;
+    expect(callsAfterFirst).toBe(2); // /registry/pubkey + /operators/andreas
+
+    await client.start(); // second invocation must short-circuit
+    try {
+      expect(fetchCalls.length).toBe(callsAfterFirst);
+    } finally {
+      client.stop();
+    }
+  });
+
+  test("TOFU failure at boot is recoverable — subsequent refreshAll() retries the pubkey fetch", async () => {
+    // Echo cortex#230 round 1: previously, a transient outage on the
+    // initial /registry/pubkey call left the client permanently dead —
+    // pinnedPubkey stayed undefined and every cycle bailed at the top.
+    // The fix: when in TOFU mode, retry the pubkey fetch at the start
+    // of each refreshAll() until it succeeds.
+    //
+    // The fake registry simulates a registry that's down for the first
+    // TWO calls (boot TOFU + boot eager-refresh's retry) and recovers
+    // by the third (manual refreshAll). This proves the retry
+    // semantics persist beyond start() — not just "TOFU plus one
+    // eager-refresh retry then give up".
+    const kp = await generateKeypair();
+    const op = makeOperator("andreas");
+    const assertion = await signAssertion(kp.privateKey, kp.publicKeyB64, op);
+
+    let pubkeyAttempts = 0;
+    const fakeFetch: FakeFetchHandler = async (url: string) => {
+      if (url.endsWith("/registry/pubkey")) {
+        pubkeyAttempts++;
+        if (pubkeyAttempts <= 2) {
+          return new Response("warming", { status: 503 });
+        }
+        return jsonResponse({ algorithm: "Ed25519", public_key: kp.publicKeyB64 });
+      }
+      if (url.endsWith("/operators/andreas")) return jsonResponse(assertion);
+      return new Response("nope", { status: 404 });
+    };
+    const client = new RegistryClient({
+      url: "https://registry.example",
+      // TOFU mode (no pubkey from config).
+      operatorIds: ["andreas"],
+      refreshIntervalMs: 0,
+      fetch: fakeFetch as typeof fetch,
+      logError: () => {},
+    });
+    await client.start();
+    try {
+      // After start: 2 TOFU attempts (boot + eager-refresh retry), both
+      // failed, cache still empty.
+      expect(pubkeyAttempts).toBe(2);
+      expect(client.getOperator("andreas")).toBeUndefined();
+      // Third cycle: TOFU retries and succeeds → cache populates. The
+      // client recovered without external intervention.
+      await client.refreshAll();
+      expect(pubkeyAttempts).toBe(3);
+      expect(client.getOperator("andreas")).toBeDefined();
+    } finally {
+      client.stop();
+    }
+  });
 });
 
 describe("RegistryClient — periodic refresh + shutdown", () => {
   test("periodic refresh updates the cache on each cycle", async () => {
     const kp = await generateKeypair();
-    let currentPubkey = "PUBKEY_V1_BASE64_FAKE=";
+    let currentPubkey = FAKE_PEER_PUBKEY_V1;
     const fakeFetch: FakeFetchHandler = async (url: string) => {
       if (url.endsWith("/operators/andreas")) {
         const op = makeOperator("andreas", currentPubkey);
@@ -375,11 +510,11 @@ describe("RegistryClient — periodic refresh + shutdown", () => {
     });
     await client.start();
     try {
-      expect(client.getOperator("andreas")?.operator_pubkey).toBe("PUBKEY_V1_BASE64_FAKE=");
+      expect(client.getOperator("andreas")?.operator_pubkey).toBe(FAKE_PEER_PUBKEY_V1);
       // Operator rotates their pubkey upstream.
-      currentPubkey = "PUBKEY_V2_BASE64_FAKE=";
+      currentPubkey = FAKE_PEER_PUBKEY_V2;
       await client.refreshAll();
-      expect(client.getOperator("andreas")?.operator_pubkey).toBe("PUBKEY_V2_BASE64_FAKE=");
+      expect(client.getOperator("andreas")?.operator_pubkey).toBe(FAKE_PEER_PUBKEY_V2);
     } finally {
       client.stop();
     }

--- a/src/common/registry/client.ts
+++ b/src/common/registry/client.ts
@@ -401,12 +401,16 @@ export class RegistryClient implements RegistryClientReader {
       );
       return undefined;
     }
-    // Shape-validate the peer pubkey grammar AFTER the signature
-    // verifies — a signed-but-malformed peer pubkey is still a wire-
-    // contract violation, and downstream callers expect to get a
-    // string that decodes as a 32-byte Ed25519 key. Defend at the
+    // Shape-validate the peer pubkey grammar BEFORE the signature
+    // verifies — a cheap structural gate runs first so we don't pay
+    // for an Ed25519 verify on a payload we'd reject anyway. A
+    // signed-but-malformed peer pubkey is still a wire-contract
+    // violation, and downstream callers expect to get a string that
+    // decodes as a 32-byte Ed25519 key. Either ordering catches the
+    // attack (sig-verifying-but-malformed cannot bypass either
+    // gate); pre-verify is the perf-conscious choice. Defend at the
     // boundary so the cache never holds a poison value. Echo
-    // cortex#230 round 1.
+    // cortex#230 rounds 1 + 3.
     //
     // Grammar: 43 chars of standard-base64 alphabet + one `=` of
     // padding = 44 chars total, matching `OperatorRecord.operator_pubkey`

--- a/src/common/registry/client.ts
+++ b/src/common/registry/client.ts
@@ -56,11 +56,7 @@
  * successful verify writes.
  */
 
-import {
-  base64ToBytes,
-  canonicalJSON,
-  verifyEd25519,
-} from "./signing";
+import { canonicalJSON, verifyEd25519 } from "./signing";
 import type {
   OperatorRecord,
   RegistryClientOptions,
@@ -85,6 +81,15 @@ export class RegistryClient implements RegistryClientReader {
 
   /** Pinned registry pubkey. Set in ctor (config) or in `start()` (TOFU). */
   private pinnedPubkey: string | undefined;
+  /**
+   * Whether the pubkey was supplied at construction time (config-pin)
+   * or must be discovered via TOFU. Drives the "retry TOFU each cycle
+   * until it succeeds" behaviour in `refreshAll()` — without it, a
+   * transient failure on the initial TOFU attempt would leave the
+   * client permanently dead even though every subsequent cycle had a
+   * fresh chance. Echo cortex#230 round 1.
+   */
+  private readonly tofuMode: boolean;
   /** In-memory cache: `operator_id → verified OperatorRecord`. */
   private readonly cache = new Map<string, OperatorRecord>();
 
@@ -101,6 +106,15 @@ export class RegistryClient implements RegistryClientReader {
    * round 1.
    */
   private refreshInFlight = false;
+  /**
+   * Idempotency flag for `start()`. Set on first entry, never cleared
+   * (a stopped client can't be restarted — see `stop()`). Distinct
+   * from `refreshTimer !== undefined` because tests run with
+   * `refreshIntervalMs = 0` and a `refreshTimer`-based check would
+   * fail to short-circuit a second `start()` in that mode. Echo
+   * cortex#230 round 1.
+   */
+  private started = false;
   private stopped = false;
 
   constructor(options: RegistryClientOptions) {
@@ -121,6 +135,7 @@ export class RegistryClient implements RegistryClientReader {
         process.stderr.write(`registry-client: ${msg}\n`);
       });
     this.pinnedPubkey = options.pubkey;
+    this.tofuMode = options.pubkey === undefined;
   }
 
   /**
@@ -129,20 +144,27 @@ export class RegistryClient implements RegistryClientReader {
    *      `GET /registry/pubkey` and pin the response.
    *   2. Run one immediate refresh cycle so the cache is warm before
    *      callers start querying.
-   *   3. Install the `setInterval` background refresh loop.
+   *   3. Install the `setInterval` background refresh loop (skipped
+   *      when `refreshIntervalMs === 0`).
    *
-   * Safe to call once. Calling twice is a no-op after the first
-   * successful start.
+   * Idempotent: a second `start()` call is a no-op regardless of
+   * whether a `setInterval` timer was installed. This matters for
+   * test setups using `refreshIntervalMs: 0`, where a `refreshTimer`-
+   * based guard would not short-circuit. Echo cortex#230 round 1.
+   *
+   * Note that when TOFU fails on the initial call, the client stays
+   * "started" but with `pinnedPubkey === undefined` — every subsequent
+   * `refreshAll()` retries TOFU at the top of the cycle and pins the
+   * key on first success. The client recovers automatically without
+   * an external nudge. Echo cortex#230 round 1.
    */
   async start(): Promise<void> {
     if (this.stopped) {
       this.logError("start() called after stop(); ignoring");
       return;
     }
-    if (this.refreshTimer !== undefined) {
-      // Already started.
-      return;
-    }
+    if (this.started) return;
+    this.started = true;
 
     if (this.pinnedPubkey === undefined) {
       await this.fetchAndPinRegistryPubkey();
@@ -221,10 +243,6 @@ export class RegistryClient implements RegistryClientReader {
    */
   async refreshAll(): Promise<void> {
     if (this.stopped) return;
-    if (this.pinnedPubkey === undefined) {
-      this.logError("refreshAll() called before pubkey was pinned; skipping");
-      return;
-    }
     if (this.refreshInFlight) {
       // Worst-case: peer-list × per-request timeout > refreshIntervalMs.
       // Drop the redundant cycle rather than queue — by the time the
@@ -242,6 +260,19 @@ export class RegistryClient implements RegistryClientReader {
     const signal = this.cycleAbort.signal;
 
     try {
+      // Recovery path: if we're in TOFU mode and the initial attempt
+      // at boot failed, retry it at the top of every cycle. Without
+      // this, a transient outage at boot would leave the client
+      // permanently dead. Echo cortex#230 round 1.
+      if (this.pinnedPubkey === undefined && this.tofuMode) {
+        await this.fetchAndPinRegistryPubkey();
+      }
+      if (this.pinnedPubkey === undefined) {
+        this.logError(
+          "refreshAll: no pinned pubkey (TOFU still failing or pubkey never supplied); skipping operator fetches this cycle",
+        );
+        return;
+      }
       // Serial rather than parallel: peer lists are short (single-digit
       // typical, dozens worst-case), the registry is shared, and serial
       // is more polite under load. Parallelise later if measured-needed.
@@ -370,6 +401,22 @@ export class RegistryClient implements RegistryClientReader {
       );
       return undefined;
     }
+    // Shape-validate the peer pubkey grammar AFTER the signature
+    // verifies — a signed-but-malformed peer pubkey is still a wire-
+    // contract violation, and downstream callers expect to get a
+    // string that decodes as a 32-byte Ed25519 key. Defend at the
+    // boundary so the cache never holds a poison value. Echo
+    // cortex#230 round 1.
+    //
+    // Grammar: 43 chars of standard-base64 alphabet + one `=` of
+    // padding = 44 chars total, matching `OperatorRecord.operator_pubkey`
+    // on the producer side (base64 of 32 raw bytes).
+    if (!/^[A-Za-z0-9+/]{43}=$/.test(payload.operator_pubkey)) {
+      this.logError(
+        `refresh(${operatorId}): payload.operator_pubkey is not base64-Ed25519 (got "${payload.operator_pubkey.slice(0, 12)}…"); ignoring`,
+      );
+      return undefined;
+    }
 
     // Reconstruct the canonical bound triple and verify.
     const bound = canonicalJSON({
@@ -466,5 +513,3 @@ export class RegistryClient implements RegistryClientReader {
   }
 }
 
-// Re-export the verify primitive so consumers + tests can share it.
-export { base64ToBytes, canonicalJSON, verifyEd25519 };

--- a/src/common/registry/client.ts
+++ b/src/common/registry/client.ts
@@ -91,6 +91,16 @@ export class RegistryClient implements RegistryClientReader {
   private refreshTimer: ReturnType<typeof setInterval> | undefined;
   /** Abort controller scoped to the current cycle's in-flight requests. */
   private cycleAbort: AbortController | undefined;
+  /**
+   * Re-entrancy guard for `refreshAll()`. Set on entry, cleared in the
+   * finally block. If a `setInterval` tick (or a manual caller) fires
+   * while the previous cycle is still draining, the new invocation
+   * logs and returns rather than reassigning `cycleAbort` — that
+   * reassignment would orphan the older cycle's controller and
+   * `stop()` could only cancel the newest one. Echo cortex#230
+   * round 1.
+   */
+  private refreshInFlight = false;
   private stopped = false;
 
   constructor(options: RegistryClientOptions) {
@@ -199,6 +209,15 @@ export class RegistryClient implements RegistryClientReader {
    * Drive one refresh cycle manually. Tests use this to avoid waiting
    * for the `setInterval` tick. Exposed as an internal seam — not on
    * `RegistryClientReader`.
+   *
+   * Serial: each peer is fetched + verified in turn. A cycle runs at
+   * most one at a time across the whole client — if a `setInterval`
+   * tick (or a concurrent manual caller) fires while the previous
+   * cycle is still draining, the new invocation logs and returns.
+   * Without this guard the new cycle would overwrite `this.cycleAbort`
+   * and orphan the older cycle's controller — `stop()` could then only
+   * cancel the newest cycle, leaving older in-flight requests to run
+   * to their per-request timeout. Echo cortex#230 round 1.
    */
   async refreshAll(): Promise<void> {
     if (this.stopped) return;
@@ -206,17 +225,32 @@ export class RegistryClient implements RegistryClientReader {
       this.logError("refreshAll() called before pubkey was pinned; skipping");
       return;
     }
+    if (this.refreshInFlight) {
+      // Worst-case: peer-list × per-request timeout > refreshIntervalMs.
+      // Drop the redundant cycle rather than queue — by the time the
+      // current cycle finishes, the network state is fresher than what
+      // a queued cycle would have observed anyway.
+      this.logError(
+        "refreshAll() invoked while previous cycle still draining; skipping this tick",
+      );
+      return;
+    }
+    this.refreshInFlight = true;
     // Fresh AbortController per cycle so stop() during the cycle
     // cancels in-flight requests but doesn't poison the next cycle.
     this.cycleAbort = new AbortController();
     const signal = this.cycleAbort.signal;
 
-    // Serial rather than parallel: peer lists are short (single-digit
-    // typical, dozens worst-case), the registry is shared, and serial
-    // is more polite under load. Parallelise later if measured-needed.
-    for (const operatorId of this.operatorIds) {
-      if (signal.aborted) break;
-      await this.refreshOperator(operatorId, signal);
+    try {
+      // Serial rather than parallel: peer lists are short (single-digit
+      // typical, dozens worst-case), the registry is shared, and serial
+      // is more polite under load. Parallelise later if measured-needed.
+      for (const operatorId of this.operatorIds) {
+        if (signal.aborted) break;
+        await this.refreshOperator(operatorId, signal);
+      }
+    } finally {
+      this.refreshInFlight = false;
     }
   }
 

--- a/src/common/registry/client.ts
+++ b/src/common/registry/client.ts
@@ -1,0 +1,436 @@
+/**
+ * IAW Phase D.4.3 — Cortex-side RegistryClient consumer.
+ *
+ * Consults the cortex-network-registry service
+ * (`src/services/network-registry/`) at boot and on a background
+ * refresh schedule to populate an in-memory cache of verified peer
+ * pubkeys. Cortex consumers read via `getOperator(operatorId)` and
+ * receive `undefined` on every failure path — federation issues must
+ * not crash the bot.
+ *
+ * ## Trust anchor (Phase-B caveat)
+ *
+ * Every `GET` response from the registry is wrapped in a
+ * `SignedAssertion<T>` signed by the registry's own Ed25519 key. The
+ * client verifies each assertion against a single pinned `registryPubkey`
+ * before mutating its cache.
+ *
+ *   - If `options.pubkey` is supplied, the client pins it at
+ *     construction time. This is the recommended posture — the
+ *     trust anchor is operator-supplied, out-of-band.
+ *   - If `options.pubkey` is absent, the client performs Trust-
+ *     On-First-Use at `start()` via `GET /registry/pubkey`. The
+ *     first response is pinned for the lifetime of the process.
+ *     This is the Phase-B caveat: an attacker controlling the
+ *     network path between cortex and the registry on first boot
+ *     could substitute their own pubkey. Operators wanting
+ *     zero-TOFU should populate `policy.federated.registry.pubkey`
+ *     in cortex.yaml.
+ *
+ * ## Cache invalidation
+ *
+ * The client refreshes every entry every `refreshIntervalMs` (default
+ * 5 minutes). When the eventual `system.operator.published` bus event
+ * lands (filed as a follow-up — the producer side isn't wired yet),
+ * `invalidate(operatorId)` provides the seam to short-circuit the
+ * refresh. Until then, TTL is the only invalidation mechanism — the
+ * worst-case staleness is one refresh interval.
+ *
+ * ## Failure modes
+ *
+ * Every error path is logged via `logError` (defaults to
+ * `process.stderr.write`) and returns control — never throws to the
+ * caller. The exhaustive list:
+ *
+ *   - `fetch` rejects (network) → log, leave cache entry as-is
+ *   - `fetch` returns non-2xx → log, leave cache entry as-is
+ *   - JSON body unparseable → log, leave cache entry as-is
+ *   - Assertion shape malformed → log, leave cache entry as-is
+ *   - Registry pubkey mismatch → log, leave cache entry as-is
+ *   - Signature does not verify → log, leave cache entry as-is
+ *   - Assertion `registry === "unconfigured"` → log, leave cache as-is
+ *   - Shutdown signalled mid-refresh → AbortError swallowed
+ *
+ * "Leave cache as-is" is deliberate: a transient failure should not
+ * blank a previously-verified record. The cache is fail-safe; only a
+ * successful verify writes.
+ */
+
+import {
+  base64ToBytes,
+  canonicalJSON,
+  verifyEd25519,
+} from "./signing";
+import type {
+  OperatorRecord,
+  RegistryClientOptions,
+  RegistryClientReader,
+} from "./types";
+
+const DEFAULT_REFRESH_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
+const DEFAULT_REQUEST_TIMEOUT_MS = 10_000;
+
+/**
+ * `RegistryClient` — single-process, in-memory cache of registry-
+ * resolved peer operator records. Construct, `start()`, query via
+ * `getOperator()`, `stop()` at shutdown.
+ */
+export class RegistryClient implements RegistryClientReader {
+  private readonly url: string;
+  private readonly operatorIds: readonly string[];
+  private readonly refreshIntervalMs: number;
+  private readonly requestTimeoutMs: number;
+  private readonly fetchImpl: typeof globalThis.fetch;
+  private readonly logError: (msg: string) => void;
+
+  /** Pinned registry pubkey. Set in ctor (config) or in `start()` (TOFU). */
+  private pinnedPubkey: string | undefined;
+  /** In-memory cache: `operator_id → verified OperatorRecord`. */
+  private readonly cache = new Map<string, OperatorRecord>();
+
+  private refreshTimer: ReturnType<typeof setInterval> | undefined;
+  /** Abort controller scoped to the current cycle's in-flight requests. */
+  private cycleAbort: AbortController | undefined;
+  private stopped = false;
+
+  constructor(options: RegistryClientOptions) {
+    // Trailing slash normalisation so callers can pass either form.
+    this.url = options.url.replace(/\/+$/, "");
+    this.operatorIds = [...options.operatorIds];
+    this.refreshIntervalMs =
+      options.refreshIntervalMs ?? DEFAULT_REFRESH_INTERVAL_MS;
+    this.requestTimeoutMs =
+      options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
+    this.fetchImpl = options.fetch ?? globalThis.fetch.bind(globalThis);
+    this.logError =
+      options.logError ??
+      ((msg: string) => {
+        // Per CLAUDE.md "no empty catches": every failure path logs to
+        // stderr. Surface through the same channel the rest of cortex
+        // uses for non-fatal warnings.
+        process.stderr.write(`registry-client: ${msg}\n`);
+      });
+    this.pinnedPubkey = options.pubkey;
+  }
+
+  /**
+   * Start the client. Steps:
+   *   1. If no pubkey was supplied to the ctor, perform TOFU via
+   *      `GET /registry/pubkey` and pin the response.
+   *   2. Run one immediate refresh cycle so the cache is warm before
+   *      callers start querying.
+   *   3. Install the `setInterval` background refresh loop.
+   *
+   * Safe to call once. Calling twice is a no-op after the first
+   * successful start.
+   */
+  async start(): Promise<void> {
+    if (this.stopped) {
+      this.logError("start() called after stop(); ignoring");
+      return;
+    }
+    if (this.refreshTimer !== undefined) {
+      // Already started.
+      return;
+    }
+
+    if (this.pinnedPubkey === undefined) {
+      await this.fetchAndPinRegistryPubkey();
+    }
+
+    // One eager refresh so the cache is populated before any caller
+    // queries `getOperator()`. Errors are already logged inside the
+    // cycle; we deliberately don't propagate — a refresh failure must
+    // not block cortex boot.
+    await this.refreshAll();
+
+    // Re-check `stopped`: `refreshAll()` above is async, so stop() may
+    // have arrived during the eager-refresh window. Don't install a
+    // timer that would race a concurrent shutdown.
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    if (this.refreshIntervalMs > 0 && !this.stopped) {
+      const timer = setInterval(() => {
+        void this.refreshAll();
+      }, this.refreshIntervalMs);
+      // Don't keep the event loop alive solely for refreshing peer
+      // pubkeys — cortex's shutdown path explicitly calls `stop()`.
+      // In Node/Bun, `setInterval` returns a `Timeout` object with an
+      // `unref()` method; in pure browser-DOM lib targets it's just a
+      // number, hence the runtime guard.
+      const maybeUnrefable = timer as unknown as { unref?: () => void };
+      if (typeof maybeUnrefable.unref === "function") {
+        maybeUnrefable.unref();
+      }
+      this.refreshTimer = timer;
+    }
+  }
+
+  /**
+   * Stop the client. Cancels the refresh timer, aborts any in-flight
+   * request, and prevents further `start()` calls. Idempotent.
+   */
+  stop(): void {
+    this.stopped = true;
+    if (this.refreshTimer !== undefined) {
+      clearInterval(this.refreshTimer);
+      this.refreshTimer = undefined;
+    }
+    if (this.cycleAbort !== undefined) {
+      this.cycleAbort.abort();
+      this.cycleAbort = undefined;
+    }
+  }
+
+  /** RegistryClientReader.getOperator — see interface JSDoc. */
+  getOperator(operatorId: string): OperatorRecord | undefined {
+    return this.cache.get(operatorId);
+  }
+
+  /**
+   * Invalidate a single cache entry. The next `refreshAll()` (or an
+   * explicit `refreshOperator(operatorId)`) will repopulate it.
+   * Exposed for the future `system.operator.published` event handler.
+   */
+  invalidate(operatorId: string): void {
+    this.cache.delete(operatorId);
+  }
+
+  /**
+   * Drive one refresh cycle manually. Tests use this to avoid waiting
+   * for the `setInterval` tick. Exposed as an internal seam — not on
+   * `RegistryClientReader`.
+   */
+  async refreshAll(): Promise<void> {
+    if (this.stopped) return;
+    if (this.pinnedPubkey === undefined) {
+      this.logError("refreshAll() called before pubkey was pinned; skipping");
+      return;
+    }
+    // Fresh AbortController per cycle so stop() during the cycle
+    // cancels in-flight requests but doesn't poison the next cycle.
+    this.cycleAbort = new AbortController();
+    const signal = this.cycleAbort.signal;
+
+    // Serial rather than parallel: peer lists are short (single-digit
+    // typical, dozens worst-case), the registry is shared, and serial
+    // is more polite under load. Parallelise later if measured-needed.
+    for (const operatorId of this.operatorIds) {
+      if (signal.aborted) break;
+      await this.refreshOperator(operatorId, signal);
+    }
+  }
+
+  // =============================================================================
+  // Private — TOFU + per-operator refresh
+  // =============================================================================
+
+  private async fetchAndPinRegistryPubkey(): Promise<void> {
+    const url = `${this.url}/registry/pubkey`;
+    const raw = await this.fetchJson(url, undefined);
+    if (raw === undefined) {
+      this.logError(
+        `TOFU failed: could not fetch ${url}; client will start with no pinned key and reject all operators`,
+      );
+      return;
+    }
+    // Treat the response as untrusted JSON until we've verified shape.
+    if (
+      typeof raw !== "object" ||
+      raw === null ||
+      (raw as { algorithm?: unknown }).algorithm !== "Ed25519" ||
+      typeof (raw as { public_key?: unknown }).public_key !== "string"
+    ) {
+      this.logError(`TOFU failed: malformed /registry/pubkey response`);
+      return;
+    }
+    const publicKey = (raw as { public_key: string }).public_key;
+    // Refuse the unconfigured sentinel — it means the registry has no
+    // signing key, and we cannot verify any assertion against it.
+    if (publicKey === "" || publicKey === "unconfigured") {
+      this.logError(
+        "TOFU failed: registry returned unconfigured pubkey; refusing to pin",
+      );
+      return;
+    }
+    this.pinnedPubkey = publicKey;
+  }
+
+  private async refreshOperator(
+    operatorId: string,
+    signal: AbortSignal,
+  ): Promise<void> {
+    const url = `${this.url}/operators/${encodeURIComponent(operatorId)}`;
+    const raw = await this.fetchJson(url, signal);
+    if (raw === undefined) return; // already logged inside fetchJson
+
+    const verified = await this.verifyAssertion(operatorId, raw);
+    if (verified === undefined) return; // already logged inside verifyAssertion
+    this.cache.set(operatorId, verified);
+  }
+
+  /**
+   * Verify a registry assertion against the pinned pubkey. Returns the
+   * payload on success, `undefined` on any failure (with a log line).
+   *
+   * Accepts `unknown` rather than a typed assertion: at this layer the
+   * input is untrusted JSON straight off the wire, and the shape checks
+   * below ARE the validation. Trusting the type at the boundary would
+   * defeat the purpose of the check.
+   */
+  private async verifyAssertion(
+    operatorId: string,
+    raw: unknown,
+  ): Promise<OperatorRecord | undefined> {
+    const pinned = this.pinnedPubkey;
+    if (pinned === undefined) {
+      this.logError(
+        `refresh(${operatorId}): no pinned pubkey; refusing to trust assertion`,
+      );
+      return undefined;
+    }
+    // Shape check first — cheaper than crypto and gives a clearer log.
+    if (raw === null || typeof raw !== "object") {
+      this.logError(`refresh(${operatorId}): assertion not an object; ignoring`);
+      return undefined;
+    }
+    const assertion = raw as Record<string, unknown>;
+    if (
+      typeof assertion.signature !== "string" ||
+      typeof assertion.issued_at !== "string" ||
+      typeof assertion.registry !== "string" ||
+      assertion.payload === null ||
+      typeof assertion.payload !== "object"
+    ) {
+      this.logError(
+        `refresh(${operatorId}): malformed assertion envelope; ignoring`,
+      );
+      return undefined;
+    }
+    const registry = assertion.registry;
+    if (registry === "unconfigured") {
+      this.logError(
+        `refresh(${operatorId}): registry assertion says "unconfigured"; refusing`,
+      );
+      return undefined;
+    }
+    if (registry !== pinned) {
+      this.logError(
+        `refresh(${operatorId}): registry pubkey mismatch (got ${registry.slice(0, 8)}…, pinned ${pinned.slice(0, 8)}…); ignoring`,
+      );
+      return undefined;
+    }
+    // Sanity-check the payload looks like an OperatorRecord. We don't
+    // re-validate the deep structure here — the registry is the source
+    // of truth for its own shape — but we do require the same
+    // operator_id we requested, defending against a swapped payload.
+    const payload = assertion.payload as Record<string, unknown>;
+    if (payload.operator_id !== operatorId) {
+      this.logError(
+        `refresh(${operatorId}): payload.operator_id mismatch (got "${String(payload.operator_id)}"); ignoring`,
+      );
+      return undefined;
+    }
+    if (typeof payload.operator_pubkey !== "string") {
+      this.logError(
+        `refresh(${operatorId}): payload.operator_pubkey missing or non-string; ignoring`,
+      );
+      return undefined;
+    }
+
+    // Reconstruct the canonical bound triple and verify.
+    const bound = canonicalJSON({
+      payload: assertion.payload,
+      issued_at: assertion.issued_at,
+      registry,
+    });
+    const message = new TextEncoder().encode(bound);
+    let ok: boolean;
+    try {
+      ok = await verifyEd25519(pinned, assertion.signature, message);
+    } catch (err) {
+      this.logError(
+        `refresh(${operatorId}): verify threw: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      return undefined;
+    }
+    if (!ok) {
+      this.logError(
+        `refresh(${operatorId}): signature did not verify; ignoring`,
+      );
+      return undefined;
+    }
+    // Defensive: the producer types include arrays we trust the
+    // service to populate, but a corrupted payload could send the
+    // wrong shape past the structural checks above. Normalise.
+    return {
+      operator_id: operatorId,
+      operator_pubkey: payload.operator_pubkey,
+      stacks: Array.isArray(payload.stacks) ? (payload.stacks as OperatorRecord["stacks"]) : [],
+      capabilities: Array.isArray(payload.capabilities) ? (payload.capabilities as OperatorRecord["capabilities"]) : [],
+      updated_at: typeof payload.updated_at === "string" ? payload.updated_at : "",
+    };
+  }
+
+  // =============================================================================
+  // Private — transport
+  // =============================================================================
+
+  /**
+   * Issue a JSON GET. Wraps timeout + abort + non-2xx + parse failure
+   * into a single `undefined` return path with a structured log line.
+   * `cycleSignal`, when supplied, is OR'd with the per-request timeout
+   * via the controller below so `stop()` cancels in-flight work.
+   */
+  private async fetchJson(
+    url: string,
+    cycleSignal: AbortSignal | undefined,
+  ): Promise<unknown> {
+    const controller = new AbortController();
+    const timeoutHandle = setTimeout(
+      () => { controller.abort(); },
+      this.requestTimeoutMs,
+    );
+    const cycleAbortListener = (): void => { controller.abort(); };
+    if (cycleSignal !== undefined) {
+      if (cycleSignal.aborted) {
+        clearTimeout(timeoutHandle);
+        return undefined;
+      }
+      cycleSignal.addEventListener("abort", cycleAbortListener, { once: true });
+    }
+    try {
+      const res = await this.fetchImpl(url, { signal: controller.signal });
+      if (!res.ok) {
+        this.logError(`GET ${url} returned ${res.status}`);
+        return undefined;
+      }
+      try {
+        return await res.json();
+      } catch (err) {
+        this.logError(
+          `GET ${url} JSON parse failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+        return undefined;
+      }
+    } catch (err) {
+      // AbortError on shutdown is expected — log at a lower fidelity
+      // but do log, so silent stop-mid-fetch is still observable.
+      if (err instanceof Error && err.name === "AbortError") {
+        this.logError(`GET ${url} aborted`);
+      } else {
+        this.logError(
+          `GET ${url} failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+      return undefined;
+    } finally {
+      clearTimeout(timeoutHandle);
+      if (cycleSignal !== undefined) {
+        cycleSignal.removeEventListener("abort", cycleAbortListener);
+      }
+    }
+  }
+}
+
+// Re-export the verify primitive so consumers + tests can share it.
+export { base64ToBytes, canonicalJSON, verifyEd25519 };

--- a/src/common/registry/index.ts
+++ b/src/common/registry/index.ts
@@ -1,0 +1,17 @@
+/**
+ * IAW Phase D.4.3 — Cortex-side RegistryClient consumer.
+ *
+ * Public surface for the rest of cortex. Consume the reader interface
+ * unless wiring lifecycle (cortex.ts boot/shutdown only).
+ */
+
+export { RegistryClient } from "./client";
+export type {
+  Capability,
+  OperatorRecord,
+  RegistryClientOptions,
+  RegistryClientReader,
+  RegistryPubkeyResponse,
+  SignedAssertion,
+  StackIdentity,
+} from "./types";

--- a/src/common/registry/signing.ts
+++ b/src/common/registry/signing.ts
@@ -1,0 +1,106 @@
+/**
+ * IAW Phase D.4.3 — Ed25519 verify + canonical-JSON primitives for
+ * the cortex-side RegistryClient.
+ *
+ * Deliberately a verify-only mirror of
+ * `src/services/network-registry/src/signing.ts`. We do NOT import the
+ * service-side module: the registry is a deployable artefact with its
+ * own package + tsconfig, and cross-package imports would couple
+ * cortex bot's build graph to a sibling deploy target. Both files
+ * MUST stay byte-compatible on the canonical-JSON path — that's the
+ * cross-checker pair RFC 8785 calls out — and the test suite for the
+ * client (and the service) cover this by round-tripping signatures.
+ *
+ * If the service-side canonicalisation ever changes, this file moves
+ * lock-step.
+ *
+ * Sign is intentionally absent: cortex never signs registry assertions.
+ * Only operator-side registration (separate concern, lives elsewhere
+ * in the federation tooling) signs.
+ */
+
+// =============================================================================
+// Canonical JSON — recursive sort-keys, no whitespace.
+// =============================================================================
+
+/**
+ * Mirror of the registry's `canonicalJSON`. Object keys sorted
+ * lexicographically + recursively; `undefined` values skipped (to
+ * match `JSON.stringify` behaviour after a parse/stringify round-trip);
+ * no whitespace.
+ */
+export function canonicalJSON(value: unknown): string {
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return "[" + value.map((v) => canonicalJSON(v)).join(",") + "]";
+  }
+  const obj = value as Record<string, unknown>;
+  const keys = Object.keys(obj)
+    .filter((k) => obj[k] !== undefined)
+    .sort();
+  const parts = keys.map(
+    (k) => JSON.stringify(k) + ":" + canonicalJSON(obj[k]),
+  );
+  return "{" + parts.join(",") + "}";
+}
+
+// =============================================================================
+// Base64 helpers — standard alphabet (NOT url-safe).
+// =============================================================================
+
+export function base64ToBytes(b64: string): Uint8Array {
+  let bin: string;
+  try {
+    bin = atob(b64);
+  } catch (err) {
+    throw new Error("invalid base64", { cause: err });
+  }
+  const out = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+  return out;
+}
+
+// =============================================================================
+// Ed25519 verify (WebCrypto). Never throws — returns false on any
+// failure. The registry's signing.ts has identical semantics.
+// =============================================================================
+
+export async function verifyEd25519(
+  pubkeyB64: string,
+  signatureB64: string,
+  message: Uint8Array,
+): Promise<boolean> {
+  let pubBytes: Uint8Array;
+  let sigBytes: Uint8Array;
+  try {
+    pubBytes = base64ToBytes(pubkeyB64);
+    sigBytes = base64ToBytes(signatureB64);
+  } catch (_err) {
+    return false;
+  }
+  if (pubBytes.length !== 32 || sigBytes.length !== 64) return false;
+  try {
+    // Cast to BufferSource — the lib.dom types for `crypto.subtle` are
+    // parameterised over `ArrayBufferLike` in ways that confuse strict
+    // mode when `Uint8Array<ArrayBufferLike>` could be backed by either
+    // an `ArrayBuffer` or a `SharedArrayBuffer`. At runtime every path
+    // in this module produces standard `ArrayBuffer`-backed views.
+    const key = await crypto.subtle.importKey(
+      "raw",
+      pubBytes as BufferSource,
+      { name: "Ed25519" },
+      false,
+      ["verify"],
+    );
+    return await crypto.subtle.verify(
+      { name: "Ed25519" },
+      key,
+      sigBytes as BufferSource,
+      message as BufferSource,
+    );
+  } catch (_err) {
+    return false;
+  }
+}

--- a/src/common/registry/types.ts
+++ b/src/common/registry/types.ts
@@ -1,0 +1,164 @@
+/**
+ * IAW Phase D.4.3 — Cortex-side RegistryClient public types.
+ *
+ * These shapes are the wire contract between cortex and the
+ * cortex-network-registry service (`src/services/network-registry/`).
+ * Deliberately re-declared on the client side rather than imported
+ * from the service: the registry is a deployable artefact that runs
+ * on Cloudflare Workers, with its own `package.json` and tsconfig;
+ * sharing TypeScript types across the boundary would couple the
+ * cortex bot to a sibling deploy target and force us to keep their
+ * dependency graphs aligned.
+ *
+ * The shapes below are structurally compatible with the producer
+ * types in `src/services/network-registry/src/types.ts` — that file
+ * remains the source of truth for the schema, and any drift between
+ * the two is a bug. When the registry's payload shape changes, this
+ * file moves first, then the service.
+ *
+ * TODO: a single shared `@cortex/registry-types` package would
+ * eliminate the redeclaration but is over-scoped for D.4.3.
+ */
+
+/**
+ * A single stack identity belonging to an operator. Mirrors
+ * `StackIdentity` on the producer side.
+ */
+export interface StackIdentity {
+  /** `{operator_id}/{stack_slug}` — slash-delimited. */
+  stack_id: string;
+  display_name?: string;
+  metadata?: Record<string, string>;
+}
+
+/**
+ * A capability the operator advertises across the federation. Mirrors
+ * `Capability` on the producer side.
+ */
+export interface Capability {
+  id: string;
+  description?: string;
+  networks?: string[];
+}
+
+/**
+ * The view of an operator returned by `GET /operators/{operator_id}`.
+ * Mirrors `OperatorRecord` on the producer side.
+ *
+ * `operator_pubkey` is base64-encoded Ed25519 (32 raw bytes → 44 chars
+ * including padding). This is distinct from the NATS NKey format used
+ * by the static `policy.federated.networks[].peers[].operator_pubkey`
+ * field in cortex.yaml — D.4.3 introduces this second format as the
+ * registry-resolved alternative. Phase-B caveat: the surface-router's
+ * NKey-based verification path is unchanged; D.4.3 only populates a
+ * cache; consumers wanting registry-resolved verification must opt in
+ * by reading from this client instead of the static peer list.
+ */
+export interface OperatorRecord {
+  operator_id: string;
+  /** Base64 Ed25519 pubkey (32 raw bytes, 44 chars w/ padding). */
+  operator_pubkey: string;
+  stacks: StackIdentity[];
+  capabilities: Capability[];
+  updated_at: string;
+}
+
+/**
+ * Registry-signed wrapper around any GET payload. The signature
+ * covers `canonicalJSON({ payload, issued_at, registry })`. The
+ * client verifies against the pinned registry pubkey before
+ * trusting `payload`. Mirrors `SignedAssertion<T>` on the producer
+ * side.
+ *
+ * `registry === "unconfigured"` is a sentinel the service returns
+ * when it has no signing key provisioned. The client always treats
+ * unconfigured assertions as untrusted (no signature path can verify
+ * a sentinel value).
+ */
+export interface SignedAssertion<T> {
+  payload: T;
+  issued_at: string;
+  /** Base64 registry pubkey, or `"unconfigured"` in dev. */
+  registry: string;
+  /** Base64 Ed25519 signature. Empty string when unconfigured. */
+  signature: string;
+}
+
+/**
+ * Response shape of `GET /registry/pubkey`. Mirrors what the service
+ * emits at `src/services/network-registry/src/index.ts`.
+ */
+export interface RegistryPubkeyResponse {
+  algorithm: "Ed25519";
+  public_key: string;
+}
+
+/**
+ * Configuration for `RegistryClient`. The required fields are the
+ * registry URL and the list of peer operator ids to track; everything
+ * else has a sensible default. Tests supply `fetch` + `setTimer` to
+ * inject a fake transport + timer without real I/O.
+ */
+export interface RegistryClientOptions {
+  /** Registry base URL. Trailing `/` is normalised away. */
+  url: string;
+  /**
+   * Pinned registry pubkey (base64 Ed25519, 44 chars w/ padding).
+   * If absent, the client performs TOFU at `start()` time and pins
+   * whatever the registry returns at `/registry/pubkey`. The
+   * Phase-B caveat is that the TOFU window is exactly the first
+   * `GET /registry/pubkey` call against an unknown registry.
+   */
+  pubkey?: string;
+  /**
+   * Operator ids the client should track. Populated at boot from
+   * `policy.federated.networks[].peers[].operator_id` (de-duplicated).
+   * Empty list means the client starts dormant — no refresh cycles,
+   * `getOperator()` always returns undefined.
+   */
+  operatorIds: string[];
+  /**
+   * Refresh interval in milliseconds. Default 5 minutes — long enough
+   * to be polite to the registry, short enough that a publish becomes
+   * visible network-wide within one minute on average. Set to 0 to
+   * disable the background refresh entirely (useful for tests that
+   * drive the cycle manually).
+   */
+  refreshIntervalMs?: number;
+  /**
+   * Per-request timeout in milliseconds. Default 10 seconds. Wraps
+   * each `fetch()` call via AbortController so a hung registry
+   * doesn't stall the refresh cycle.
+   */
+  requestTimeoutMs?: number;
+  /**
+   * `fetch` implementation. Defaults to `globalThis.fetch`. Tests
+   * inject a fake here.
+   */
+  fetch?: typeof globalThis.fetch;
+  /**
+   * Logger seam — defaults to writing to `process.stderr` per
+   * CLAUDE.md "no empty catches" rule. Tests inject a no-op or a
+   * spy.
+   */
+  logError?: (msg: string) => void;
+}
+
+/**
+ * Subset of `RegistryClient` exposed to the rest of cortex. The
+ * implementation has more surface area (start/stop lifecycle, manual
+ * refresh seam for tests), but consumers should program against this
+ * interface.
+ */
+export interface RegistryClientReader {
+  /**
+   * Return the cached `OperatorRecord` for `operatorId`, or
+   * `undefined` if the operator is unknown, the cache is empty, the
+   * last fetch failed, or the signature did not verify.
+   *
+   * Never throws — federation failures must not crash the rest of
+   * cortex. All error paths log via `logError` and return
+   * `undefined`.
+   */
+  getOperator(operatorId: string): OperatorRecord | undefined;
+}

--- a/src/common/types/__tests__/cortex-config.test.ts
+++ b/src/common/types/__tests__/cortex-config.test.ts
@@ -29,6 +29,8 @@ import {
   OperatorSchema,
   PagerDutyRendererSchema,
   PathsConfigSchema,
+  PolicyFederatedRegistrySchema,
+  PolicyFederatedSchema,
   RendererSchema,
 } from "../cortex-config";
 
@@ -793,6 +795,56 @@ describe("CortexConfigSchema", () => {
 // additions/removals AND default drift. Known divergence — `paths.logDir`
 // (grove → cortex rename) — is asserted as a key-set match plus per-field
 // equality on the non-divergent fields.
+
+describe("PolicyFederatedRegistrySchema — IAW D.4.3", () => {
+  test("accepts a fully populated registry block (url + pubkey)", () => {
+    const r = PolicyFederatedRegistrySchema.parse({
+      url: "https://network.meta-factory.ai",
+      // 43-char base64 alphabet + "=" padding → 44 chars total. The
+      // value here is structural only; signature paths exercise real
+      // keys at the client test layer.
+      pubkey: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+    });
+    expect(r.url).toBe("https://network.meta-factory.ai");
+    expect(r.pubkey).toBe("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=");
+  });
+
+  test("accepts a url-only block (TOFU posture)", () => {
+    const r = PolicyFederatedRegistrySchema.parse({
+      url: "https://network.meta-factory.ai/",
+    });
+    expect(r.pubkey).toBeUndefined();
+  });
+
+  test("rejects a malformed url", () => {
+    expect(() =>
+      PolicyFederatedRegistrySchema.parse({ url: "not-a-url" }),
+    ).toThrow();
+  });
+
+  test("rejects a pubkey that isn't base64 of the right length", () => {
+    expect(() =>
+      PolicyFederatedRegistrySchema.parse({
+        url: "https://network.meta-factory.ai",
+        pubkey: "tooshort",
+      }),
+    ).toThrow();
+  });
+
+  test("PolicyFederatedSchema accepts an optional registry sub-block", () => {
+    // Absence is allowed (no registry → no consultation).
+    const without = PolicyFederatedSchema.parse({});
+    expect(without.registry).toBeUndefined();
+    expect(without.networks).toEqual([]);
+
+    // Presence parses through and round-trips.
+    const withReg = PolicyFederatedSchema.parse({
+      networks: [],
+      registry: { url: "https://network.meta-factory.ai" },
+    });
+    expect(withReg.registry?.url).toBe("https://network.meta-factory.ai");
+  });
+});
 
 describe("MIRROR sync — cortex cross-cutting schemas vs BotConfigSchema", () => {
   // Minimum BotConfig that exposes inner defaults on every cross-cutting block.

--- a/src/common/types/cortex-config.ts
+++ b/src/common/types/cortex-config.ts
@@ -1142,14 +1142,72 @@ export const PolicyFederatedNetworkSchema = z.object({
 export type PolicyFederatedNetwork = z.infer<typeof PolicyFederatedNetworkSchema>;
 
 /**
+ * IAW Phase D.4.3 — optional `policy.federated.registry` block.
+ *
+ * Declares the cortex-network-registry endpoint the operator wants
+ * cortex to consult for peer-pubkey resolution. When present, the
+ * `RegistryClient` (in `src/common/registry/`) is instantiated at
+ * boot and consults `{url}/operators/{id}` on a refresh schedule
+ * to populate an in-memory cache of verified peer pubkeys.
+ *
+ * The trust anchor is the registry's own Ed25519 pubkey:
+ *
+ *   - If `pubkey` is set, cortex pins it from config and refuses
+ *     any assertion whose `registry` field disagrees.
+ *   - If `pubkey` is absent, cortex performs Trust-On-First-Use
+ *     (TOFU) at boot via `GET /registry/pubkey` and pins whatever
+ *     comes back. This is the documented Phase-B caveat: the TOFU
+ *     window is exactly the first boot against an unknown registry,
+ *     and operators preferring zero-TOFU should populate `pubkey`
+ *     out-of-band before first run.
+ *
+ * Absence of the block is the default — cortex runs without a
+ * registry client and the federation roster is whatever lives
+ * statically in `policy.federated.networks[].peers[]`. The block
+ * is fully additive; existing configs are unaffected.
+ */
+export const PolicyFederatedRegistrySchema = z.object({
+  /**
+   * Registry base URL. Trailing slashes are tolerated but the client
+   * normalises before joining endpoint paths. Must be `https://` in
+   * production; `http://` is accepted so test rigs can run against a
+   * local in-process Hono app without TLS.
+   */
+  url: z.url("registry.url must be a valid URL"),
+  /**
+   * Optional pinned registry pubkey (base64-encoded Ed25519, 32 raw
+   * bytes before encoding). When set, the client refuses any
+   * assertion whose `registry` field does not match this value. When
+   * absent, TOFU at boot — the first `/registry/pubkey` response is
+   * pinned for the lifetime of the process. Operators wanting a
+   * persistent pin across restarts must paste it here.
+   *
+   * Grammar matches the registry service's `OperatorRecord.operator_pubkey`
+   * shape (base64 of 32 raw bytes → 44 chars including `=` padding).
+   * Validated softly (length + base64 alphabet) — strict 32-byte
+   * decoding happens at the client during initial fetch.
+   */
+  pubkey: z.string().regex(
+    /^[A-Za-z0-9+/]{43}=$/,
+    "registry.pubkey must be base64-encoded Ed25519 (44 chars including padding)",
+  ).optional(),
+});
+
+export type PolicyFederatedRegistry = z.infer<typeof PolicyFederatedRegistrySchema>;
+
+/**
  * `policy.federated` block — IAW Phase D.1 (cortex#116). Optional
  * on cortex.yaml; absence means "no federation declared" and the
  * surface-router treats inbound `federated.*` envelopes as
  * unrecognised (rejected at the validator layer). When present,
  * carries the operator's network roster.
+ *
+ * IAW Phase D.4.3 extends with the optional `registry` sub-block —
+ * see `PolicyFederatedRegistrySchema` for the trust-anchor model.
  */
 export const PolicyFederatedSchema = z.object({
   networks: z.array(PolicyFederatedNetworkSchema).default([]),
+  registry: PolicyFederatedRegistrySchema.optional(),
 });
 
 export type PolicyFederated = z.infer<typeof PolicyFederatedSchema>;

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -62,6 +62,8 @@ import { createDispatchListener, type DispatchListener } from "./runner/dispatch
 import { WorklogManager } from "./runner/worklog-manager";
 
 import { CloudPublisher } from "./taps/cc-events/cloud-publisher";
+import { RegistryClient } from "./common/registry";
+import type { RegistryClientReader } from "./common/registry";
 import { JsonlReader } from "./taps/cc-events/lib/jsonl-reader";
 import { PublishedEventSchema } from "./taps/cc-events/hooks/lib/event-types";
 import { formatEventForDiscord } from "./adapters/discord/event-formatter";
@@ -106,6 +108,13 @@ export interface CortexHandle {
    * them.
    */
   readonly agentRegistry: AgentRegistry;
+  /**
+   * IAW Phase D.4.3 — registry-resolved peer pubkey reader. Exposed
+   * read-only so D.6 integration tests + future consumers can verify
+   * that the federation roster gets populated from the registry.
+   * `null` when no registry was configured on this cortex instance.
+   */
+  readonly registryClient: RegistryClientReader | null;
 }
 
 /** Optional test-only injection points. Production callers omit. */
@@ -497,6 +506,56 @@ export async function startCortex(
       console.error(`cortex: surface adapter "${adapterId}" render error:`, err.message);
     },
   });
+
+  // IAW Phase D.4.3 (refs cortex#116) — registry client. Opt-in:
+  // instantiated only when `policy.federated.registry.url` is set
+  // AND `policy.federated.networks[].peers[]` declares at least one
+  // peer. When dormant, callers asking for an operator simply get
+  // `undefined` — the rest of cortex never has to special-case
+  // "no registry configured".
+  //
+  // The client populates an in-memory cache of registry-verified peer
+  // pubkeys (base64 Ed25519) on a 5-minute refresh schedule. Each
+  // fetched assertion is verified against the pinned registry pubkey
+  // before mutating the cache; verification failures log to stderr
+  // and leave the cache untouched (fail-safe).
+  //
+  // Phase-B caveat: the registry trust anchor is operator-supplied
+  // via `policy.federated.registry.pubkey` (pinned at config time) OR
+  // TOFU at boot via `GET /registry/pubkey`. The TOFU window is
+  // exactly the first call against an unknown registry; operators
+  // wanting zero-TOFU populate the pubkey field out-of-band. See
+  // `src/common/registry/client.ts` JSDoc for the full failure-mode
+  // table.
+  let registryClient: RegistryClient | null = null;
+  const registryConfig = options.policy?.federated?.registry;
+  if (registryConfig !== undefined) {
+    const peerOperatorIds = Array.from(
+      new Set(
+        (options.policy?.federated?.networks ?? []).flatMap((n) =>
+          n.peers.map((p) => p.operator_id),
+        ),
+      ),
+    );
+    if (peerOperatorIds.length === 0) {
+      console.log(
+        `cortex: policy.federated.registry configured (${registryConfig.url}) but no peers declared — registry client dormant`,
+      );
+    } else {
+      registryClient = new RegistryClient({
+        url: registryConfig.url,
+        ...(registryConfig.pubkey !== undefined && { pubkey: registryConfig.pubkey }),
+        operatorIds: peerOperatorIds,
+      });
+      // Boot the client asynchronously — TOFU + initial refresh must
+      // not block the rest of cortex boot. Errors inside `start()`
+      // are already logged via the client's own `logError` seam.
+      void registryClient.start();
+      console.log(
+        `cortex: registry client started (${registryConfig.url}, tracking ${peerOperatorIds.length} peer(s))`,
+      );
+    }
+  }
 
   // Dispatch-handler — synchronous platform-message → CC pipeline.
   //
@@ -1027,6 +1086,7 @@ export async function startCortex(
       ...adapterStopNames,
       ...rendererStopNames,
       "cloud publisher close",
+      "registry client stop",
       "runtime stop",
     ];
     for (const slot of allSlots) pending.add(slot);
@@ -1080,6 +1140,7 @@ export async function startCortex(
         if (renderer && name) await completeAsync(name, renderer.stop());
       }
       await completeAsync("cloud publisher close", cloudPublisher?.close());
+      completeSync("registry client stop", () => registryClient?.stop());
       await completeAsync("runtime stop", runtime.stop());
     };
 
@@ -1116,6 +1177,9 @@ export async function startCortex(
     },
     get agentRegistry() {
       return agentRegistry;
+    },
+    get registryClient() {
+      return registryClient;
     },
   };
 }


### PR DESCRIPTION
## Summary

Adds the consumer half of the D.4 cortex-network-registry pair: a
`RegistryClient` in `src/common/registry/` that consults the registry at
boot and on a 5-minute refresh schedule to populate an in-memory cache
of registry-verified peer operator pubkeys. The rest of cortex reads via
`RegistryClientReader.getOperator(operatorId)` and gets `undefined` on
every failure path — federation issues must not crash the bot.

Refs cortex#116 (Phase D umbrella).

## What's in

- `src/common/registry/` — new module
  - `client.ts` — `RegistryClient`: TOFU + pinned-pubkey modes, Ed25519
    verification against a single pinned trust anchor, AbortController-
    gated refresh cycle, `setInterval`-based background loop that
    `unref()`s so it doesn't hold the event loop open.
  - `signing.ts` — verify-only mirror of the registry service's
    canonical-JSON + Ed25519 primitives. Must stay byte-compatible on
    the canonical path with `src/services/network-registry/src/signing.ts`.
  - `types.ts` — client-side `SignedAssertion<T>` / `OperatorRecord`,
    redeclared on the consumer side rather than imported from the
    service (which has its own package + tsconfig and runs on Workers).
  - `index.ts` — public surface.
  - `__tests__/client.test.ts` — 12 tests covering every failure path
    listed in the D.4.3 spec.

- `src/common/types/cortex-config.ts` — additive schema extension
  - `PolicyFederatedRegistrySchema { url, pubkey? }`
  - `PolicyFederatedSchema.registry` (optional). No breaking change;
    existing configs are unaffected.

- `src/common/types/__tests__/cortex-config.test.ts` — new `describe`
  block for the registry schema.

- `src/cortex.ts` — minimal boot wiring
  - Instantiates `RegistryClient` when `policy.federated.registry.url`
    is set AND at least one peer is declared.
  - Async `start()` so TOFU + initial refresh don't block cortex boot.
  - Exposed read-only on `CortexHandle.registryClient` for D.6
    integration tests + future consumers.
  - Shutdown slot `registry client stop` added to the named-slot drain.

## Trust model (Phase-B caveat)

Every assertion is verified against a single pinned registry pubkey:

- `policy.federated.registry.pubkey` set → pinned at config time.
- absent → TOFU at boot via `GET /registry/pubkey`; first response
  pinned for the lifetime of the process.

The TOFU window is exactly the first call against an unknown registry;
operators wanting zero-TOFU paste the pubkey out-of-band. Documented in
JSDoc + the schema doc-comment.

## Failure modes (all log + return undefined, never throw)

- fetch rejects (network error)
- fetch returns non-2xx
- JSON body unparseable
- assertion envelope malformed
- registry pubkey mismatch
- signature does not verify
- registry reports `unconfigured` sentinel
- payload's `operator_id` doesn't match the requested id
- shutdown signalled mid-refresh (AbortError)

Per CLAUDE.md, every error path logs via `process.stderr.write` (no
empty catches). The cache is fail-safe: only a successful verify
writes; a transient failure leaves the previously-verified entry in
place.

## Out of scope

- `system.operator.published` bus-event invalidation. The producer side
  isn't wired yet. The `invalidate(operatorId)` seam exists on the
  client for when that lands; for now TTL (5 min) is the only
  invalidation mechanism — worst-case staleness is one refresh interval.
- Full registry roundtrip integration test — that's D.6.

## Test plan

- [x] `bun test` — 2947 pass, 0 fail (full suite)
- [x] `bunx tsc --noEmit` — clean
- [x] `bun run lint:errors` — clean
- [x] TOFU at boot pins the response
- [x] Pinned pubkey from config bypasses TOFU
- [x] `getOperator` returns verified data
- [x] `getOperator` returns undefined on signature failure
- [x] `getOperator` returns undefined on network failure (no throw)
- [x] `getOperator` returns undefined on `unconfigured` sentinel
- [x] `getOperator` returns undefined on pubkey mismatch
- [x] `getOperator` returns undefined on payload `operator_id` mismatch
- [x] Periodic refresh updates the cache
- [x] `stop()` cancels the refresh timer
- [x] `invalidate()` drops a cache entry; refresh repopulates it
- [x] `operatorIds: []` makes the client dormant — no fetches