### PR TITLE
feat(adapters): Slack adapter (refs cortex#231)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -9,6 +9,8 @@
         "@nats-io/jwt": "^0.0.11",
         "@octokit/webhooks": "^14.2.0",
         "@octokit/webhooks-methods": "^6.0.0",
+        "@slack/socket-mode": "^2.0.7",
+        "@slack/web-api": "^7.16.0",
         "@the-metafactory/myelin": "github:the-metafactory/myelin#5a0e2619a4af5c91c78f552b88fafd3ad40a227f",
         "@xyflow/react": "^12.10.2",
         "ajv": "^8.20.0",
@@ -114,6 +116,14 @@
 
     "@sapphire/snowflake": ["@sapphire/snowflake@3.5.3", "", {}, "sha512-jjmJywLAFoWeBi1W7994zZyiNWPIiqRRNAmSERxyg93xRGzNYvGjlZ0gR6x0F4gPRi2+0O6S71kOZYyr3cxaIQ=="],
 
+    "@slack/logger": ["@slack/logger@4.0.1", "", { "dependencies": { "@types/node": ">=18" } }, "sha512-6cmdPrV/RYfd2U0mDGiMK8S7OJqpCTm7enMLRR3edccsPX8j7zXTLnaEF4fhxxJJTAIOil6+qZrnUPTuaLvwrQ=="],
+
+    "@slack/socket-mode": ["@slack/socket-mode@2.0.7", "", { "dependencies": { "@slack/logger": "^4.0.1", "@slack/web-api": "^7.15.0", "@types/node": ">=18", "@types/ws": "^8", "eventemitter3": "^5", "ws": "^8" } }, "sha512-qYy07je71WnEHgRwmw12DlAnZLi5HXmdlI2WUzUK2LH/rYXQpP6uEg462S5CwfE8FoCKUdIigHtYnOOfzZH1lQ=="],
+
+    "@slack/types": ["@slack/types@2.21.1", "", {}, "sha512-I8vmSjNYWsaxuWPx6dz4yeh0h7vRBWbgAMK14LEmblbZ404BtrPbXs6jDPx4cYgGf8msDGF4A9opLZBu21FViQ=="],
+
+    "@slack/web-api": ["@slack/web-api@7.16.0", "", { "dependencies": { "@slack/logger": "^4.0.1", "@slack/types": "^2.21.0", "@types/node": ">=18", "@types/retry": "0.12.0", "axios": "^1.16.0", "eventemitter3": "^5.0.1", "form-data": "^4.0.4", "is-electron": "2.2.2", "is-stream": "^2", "p-queue": "^6", "p-retry": "^4", "retry": "^0.13.1" } }, "sha512-68SAV77uuGKuhyyaRytX8UijVnqSLsTSKslGXw17cjQYXn+jtNl7gbaEjHgC5x2rhCuFdahBrEC2VCLppbzReg=="],
+
     "@the-metafactory/myelin": ["@the-metafactory/myelin@github:the-metafactory/myelin#5a0e261", { "dependencies": { "@msgpack/msgpack": "^3.1.3", "@nats-io/jetstream": "^3.4.0", "@nats-io/kv": "^3.4.0", "@nats-io/transport-node": "^3.4.0", "@noble/ed25519": "^3.1.0", "ajv": "8.20.0", "ajv-formats": "3.0.1" } }, "the-metafactory-myelin-5a0e261"],
 
     "@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
@@ -141,6 +151,8 @@
     "@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
+
+    "@types/retry": ["@types/retry@0.12.0", "", {}, "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA=="],
 
     "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
@@ -174,9 +186,15 @@
 
     "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
 
+    "agent-base": ["agent-base@6.0.2", "", { "dependencies": { "debug": "4" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
+
     "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
 
     "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
+
+    "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
+
+    "axios": ["axios@1.16.1", "", { "dependencies": { "follow-redirects": "^1.16.0", "form-data": "^4.0.5", "https-proxy-agent": "^5.0.1", "proxy-from-env": "^2.1.0" } }, "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A=="],
 
     "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
@@ -184,9 +202,13 @@
 
     "bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
 
+    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
     "chokidar": ["chokidar@5.0.0", "", { "dependencies": { "readdirp": "^5.0.0" } }, "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw=="],
 
     "classcat": ["classcat@5.0.5", "", {}, "sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w=="],
+
+    "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
 
     "commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
 
@@ -216,11 +238,23 @@
 
     "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
 
+    "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
+
     "discord-api-types": ["discord-api-types@0.38.42", "", {}, "sha512-qs1kya7S84r5RR8m9kgttywGrmmoHaRifU1askAoi+wkoSefLpZP6aGXusjNw5b0jD3zOg3LTwUa3Tf2iHIceQ=="],
 
     "discord.js": ["discord.js@14.25.1", "", { "dependencies": { "@discordjs/builders": "^1.13.0", "@discordjs/collection": "1.5.3", "@discordjs/formatters": "^0.6.2", "@discordjs/rest": "^2.6.0", "@discordjs/util": "^1.2.0", "@discordjs/ws": "^1.2.3", "@sapphire/snowflake": "3.5.3", "discord-api-types": "^0.38.33", "fast-deep-equal": "3.1.3", "lodash.snakecase": "4.1.1", "magic-bytes.js": "^1.10.0", "tslib": "^2.6.3", "undici": "6.21.3" } }, "sha512-2l0gsPOLPs5t6GFZfQZKnL1OJNYFcuC/ETWsW4VtKVD/tg4ICa9x+jb9bkPffkMdRpRpuUaO/fKkHCBeiCKh8g=="],
 
+    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
     "elkjs": ["elkjs@0.11.1", "", {}, "sha512-zxxR9k+rx5ktMwT/FwyLdPCrq7xN6e4VGGHH8hA01vVYKjTFik7nHOxBnAYtrgYUB1RpAiLvA1/U2YraWxyKKg=="],
+
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
+
+    "es-set-tostringtag": ["es-set-tostringtag@2.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA=="],
 
     "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
 
@@ -240,6 +274,8 @@
 
     "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
 
+    "eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
+
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
     "fast-json-stable-stringify": ["fast-json-stable-stringify@2.1.0", "", {}, "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="],
@@ -258,17 +294,41 @@
 
     "flatted": ["flatted@3.4.2", "", {}, "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA=="],
 
+    "follow-redirects": ["follow-redirects@1.16.0", "", {}, "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw=="],
+
+    "form-data": ["form-data@4.0.5", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.12" } }, "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w=="],
+
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
+    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
+    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
+
     "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
 
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
+    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
+
+    "has-tostringtag": ["has-tostringtag@1.0.2", "", { "dependencies": { "has-symbols": "^1.0.3" } }, "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw=="],
+
+    "hasown": ["hasown@2.0.3", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg=="],
+
     "hono": ["hono@4.12.10", "", {}, "sha512-mx/p18PLy5og9ufies2GOSUqep98Td9q4i/EF6X7yJgAiIopxqdfIO3jbqsi3jRgTgw88jMDEzVKi+V2EF+27w=="],
+
+    "https-proxy-agent": ["https-proxy-agent@5.0.1", "", { "dependencies": { "agent-base": "6", "debug": "4" } }, "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA=="],
 
     "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
     "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
 
+    "is-electron": ["is-electron@2.2.2", "", {}, "sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg=="],
+
     "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
 
     "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
+
+    "is-stream": ["is-stream@2.0.1", "", {}, "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="],
 
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
@@ -290,6 +350,12 @@
 
     "magic-bytes.js": ["magic-bytes.js@1.13.0", "", {}, "sha512-afO2mnxW7GDTXMm5/AoN1WuOcdoKhtgXjIvHmobqTD1grNplhGdv3PFOyjCVmrnOZBIT/gD/koDKpYG+0mvHcg=="],
 
+    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
+
+    "mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
+
     "minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
@@ -302,9 +368,17 @@
 
     "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
 
+    "p-finally": ["p-finally@1.0.0", "", {}, "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow=="],
+
     "p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
 
     "p-locate": ["p-locate@5.0.0", "", { "dependencies": { "p-limit": "^3.0.2" } }, "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw=="],
+
+    "p-queue": ["p-queue@6.6.2", "", { "dependencies": { "eventemitter3": "^4.0.4", "p-timeout": "^3.2.0" } }, "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ=="],
+
+    "p-retry": ["p-retry@4.6.2", "", { "dependencies": { "@types/retry": "0.12.0", "retry": "^0.13.1" } }, "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ=="],
+
+    "p-timeout": ["p-timeout@3.2.0", "", { "dependencies": { "p-finally": "^1.0.0" } }, "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg=="],
 
     "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
 
@@ -313,6 +387,8 @@
     "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
+
+    "proxy-from-env": ["proxy-from-env@2.1.0", "", {}, "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA=="],
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
@@ -323,6 +399,8 @@
     "readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
 
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
+    "retry": ["retry@0.13.1", "", {}, "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="],
 
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
@@ -385,6 +463,8 @@
     "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
     "eslint/ajv": ["ajv@6.15.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw=="],
+
+    "p-queue/eventemitter3": ["eventemitter3@4.0.7", "", {}, "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="],
 
     "eslint/ajv/json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
   }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
     "@nats-io/jwt": "^0.0.11",
     "@octokit/webhooks": "^14.2.0",
     "@octokit/webhooks-methods": "^6.0.0",
+    "@slack/socket-mode": "^2.0.7",
+    "@slack/web-api": "^7.16.0",
     "@the-metafactory/myelin": "github:the-metafactory/myelin#5a0e2619a4af5c91c78f552b88fafd3ad40a227f",
     "@xyflow/react": "^12.10.2",
     "ajv": "^8.20.0",

--- a/src/adapters/slack/__tests__/schema.test.ts
+++ b/src/adapters/slack/__tests__/schema.test.ts
@@ -1,0 +1,106 @@
+/**
+ * F-slack: SlackPresenceSchema / SlackInstanceSchema parse tests.
+ *
+ * The schemas are the contract between cortex.yaml (operator-facing) and
+ * the adapter. Lock in the field-level invariants so a schema regression
+ * surfaces immediately at config-load rather than as a runtime stack trace
+ * inside the adapter.
+ */
+
+import { test, expect, describe } from "bun:test";
+import { SlackPresenceSchema } from "../../../common/types/cortex-config";
+import { SlackInstanceSchema } from "../../../common/types/config";
+
+const VALID_PRESENCE = {
+  botToken: "xoxb-TEST-TOKEN-12345",
+  appToken: "xapp-TEST-APP-12345",
+  workspaceId: "T0WORKSPACE",
+  channels: [{ id: "C0CHAN1", name: "cortex" }],
+};
+
+describe("SlackPresenceSchema", () => {
+  test("parses a minimal valid presence", () => {
+    const parsed = SlackPresenceSchema.parse(VALID_PRESENCE);
+    expect(parsed.botToken).toBe("xoxb-TEST-TOKEN-12345");
+    expect(parsed.appToken).toBe("xapp-TEST-APP-12345");
+    expect(parsed.workspaceId).toBe("T0WORKSPACE");
+    expect(parsed.enabled).toBe(true);
+    expect(parsed.defaultRole).toBe("allow-all");
+    expect(parsed.allowedUserIds).toEqual([]);
+    expect(parsed.trustedBotIds).toEqual([]);
+    expect(parsed.surfaceSubjects).toEqual([]);
+  });
+
+  test("rejects botToken without xoxb- prefix", () => {
+    expect(() =>
+      SlackPresenceSchema.parse({ ...VALID_PRESENCE, botToken: "not-a-bot-token" }),
+    ).toThrow(/xoxb-/);
+  });
+
+  test("rejects appToken without xapp- prefix", () => {
+    expect(() =>
+      SlackPresenceSchema.parse({ ...VALID_PRESENCE, appToken: "xoxb-wrong-kind" }),
+    ).toThrow(/xapp-/);
+  });
+
+  test("rejects workspaceId without T-prefix", () => {
+    expect(() =>
+      SlackPresenceSchema.parse({ ...VALID_PRESENCE, workspaceId: "U0WRONG" }),
+    ).toThrow(/T\.\.\./);
+  });
+
+  test("rejects channel id with wrong prefix", () => {
+    expect(() =>
+      SlackPresenceSchema.parse({
+        ...VALID_PRESENCE,
+        channels: [{ id: "U0WRONG", name: "nope" }],
+      }),
+    ).toThrow();
+  });
+
+  test("accepts both C- and G-prefixed channel ids", () => {
+    const parsed = SlackPresenceSchema.parse({
+      ...VALID_PRESENCE,
+      channels: [
+        { id: "C0PUB", name: "pub" },
+        { id: "G0PRIV", name: "priv" },
+      ],
+    });
+    expect(parsed.channels).toHaveLength(2);
+  });
+
+  test("passes through optional surfaceFallbackChannelId", () => {
+    const parsed = SlackPresenceSchema.parse({
+      ...VALID_PRESENCE,
+      surfaceFallbackChannelId: "C0FALLBACK",
+    });
+    expect(parsed.surfaceFallbackChannelId).toBe("C0FALLBACK");
+  });
+
+  test("preserves surfaceSubjects when set", () => {
+    const parsed = SlackPresenceSchema.parse({
+      ...VALID_PRESENCE,
+      surfaceSubjects: ["local.metafactory.review.>"],
+    });
+    expect(parsed.surfaceSubjects).toEqual(["local.metafactory.review.>"]);
+  });
+});
+
+describe("SlackInstanceSchema", () => {
+  test("parses the legacy-shaped instance with auto-defaults", () => {
+    const parsed = SlackInstanceSchema.parse(VALID_PRESENCE);
+    expect(parsed.enabled).toBe(true);
+    expect(parsed.channels).toHaveLength(1);
+    expect(parsed.defaultRole).toBe("allow-all");
+  });
+
+  test("instanceId is optional", () => {
+    const parsed = SlackInstanceSchema.parse(VALID_PRESENCE);
+    expect(parsed.instanceId).toBeUndefined();
+  });
+
+  test("instanceId pass-through when provided", () => {
+    const parsed = SlackInstanceSchema.parse({ ...VALID_PRESENCE, instanceId: "luna-slack" });
+    expect(parsed.instanceId).toBe("luna-slack");
+  });
+});

--- a/src/adapters/slack/__tests__/slack-adapter.test.ts
+++ b/src/adapters/slack/__tests__/slack-adapter.test.ts
@@ -542,6 +542,53 @@ describe("SlackAdapter — sendProgress + createThread + notifyOperator", () => 
     expect(target.threadId).toBe("1700000000.999999");
   });
 
+  test("createThread returns threadId undefined when no ts is available (Echo r2)", async () => {
+    // Echo cortex#233 round-2: the previous fallback chain ended in
+    // `msg.channelId`, which is a `C...`/`G...` id, not a `thread_ts`
+    // (`1700000000.123456`). `chat.postMessage` silently treated the
+    // channel id as "no thread" — bug masked. Lock in the new
+    // behaviour: if no legitimate ts source is available, return
+    // `threadId: undefined` and let the caller post top-level.
+    const { adapter } = makeAdapter();
+    const msg: InboundMessage = {
+      platform: "slack",
+      instanceId: "slack-test",
+      authorId: "U0HUMAN",
+      authorName: "U0HUMAN",
+      content: "no native event attached",
+      channelId: "C0CHAN1",
+      attachments: [],
+      timestamp: new Date(0),
+      // intentionally no _native and no threadId
+    };
+    const target = await adapter.createThread(msg, "ignored-name");
+    expect(target.channelId).toBe("C0CHAN1");
+    expect(target.threadId).toBeUndefined();
+  });
+
+  test("createThread prefers _native.thread_ts over _native.ts", async () => {
+    // If we're already in a thread (`thread_ts` set), new replies stay
+    // in the parent thread rather than spawning a sub-thread under our
+    // own ts. Slack doesn't support nested threads anyway.
+    const { adapter } = makeAdapter();
+    const msg: InboundMessage = {
+      platform: "slack",
+      instanceId: "slack-test",
+      authorId: "U0HUMAN",
+      authorName: "U0HUMAN",
+      content: "reply in existing thread",
+      channelId: "C0CHAN1",
+      attachments: [],
+      timestamp: new Date(0),
+      _native: makeSlackEvent({
+        ts: "1700000000.222222",
+        thread_ts: "1700000000.111111",
+      }),
+    };
+    const target = await adapter.createThread(msg, "ignored");
+    expect(target.threadId).toBe("1700000000.111111");
+  });
+
   test("notifyOperator no-ops when operator.slackId is not configured", async () => {
     const { adapter, state } = makeAdapter();
     await adapter.notifyOperator("ping");

--- a/src/adapters/slack/__tests__/slack-adapter.test.ts
+++ b/src/adapters/slack/__tests__/slack-adapter.test.ts
@@ -28,6 +28,14 @@ interface FakeSlackClientState {
   botUserId: string;
   /** Throw on next postMessage when set. */
   postMessageError?: Error;
+  /**
+   * Sequence of client-method calls in invocation order — used to
+   * assert that `getBotUserId` resolves BEFORE `start` opens the
+   * socket (Echo cortex#233 self-loop TOCTOU fix).
+   */
+  callOrder: ("start" | "stop" | "postMessage" | "getBotUserId")[];
+  /** When set, the next `getBotUserId` call rejects with this error. */
+  getBotUserIdError?: Error;
 }
 
 function makeFakeClient(initial: Partial<FakeSlackClientState> = {}): {
@@ -40,22 +48,29 @@ function makeFakeClient(initial: Partial<FakeSlackClientState> = {}): {
     startCount: 0,
     stopCount: 0,
     botUserId: initial.botUserId ?? "UBOT123",
+    callOrder: [],
     ...(initial.postMessageError !== undefined && { postMessageError: initial.postMessageError }),
+    ...(initial.getBotUserIdError !== undefined && { getBotUserIdError: initial.getBotUserIdError }),
   };
 
   let onEvent: ((event: SlackInboundEvent) => Promise<void>) | null = null;
 
   const client: SlackClient = {
+    // eslint-disable-next-line @typescript-eslint/require-await
     async start(opts) {
       state.startCount++;
+      state.callOrder.push("start");
       onEvent = opts.onEvent;
     },
+    // eslint-disable-next-line @typescript-eslint/require-await
     async stop() {
       state.stopCount++;
+      state.callOrder.push("stop");
       onEvent = null;
     },
     // eslint-disable-next-line @typescript-eslint/require-await
     async postMessage(channel, text, threadTs) {
+      state.callOrder.push("postMessage");
       if (state.postMessageError) throw state.postMessageError;
       state.postedMessages.push({
         channel,
@@ -66,6 +81,8 @@ function makeFakeClient(initial: Partial<FakeSlackClientState> = {}): {
     },
     // eslint-disable-next-line @typescript-eslint/require-await
     async getBotUserId() {
+      state.callOrder.push("getBotUserId");
+      if (state.getBotUserIdError) throw state.getBotUserIdError;
       return state.botUserId;
     },
   };
@@ -225,6 +242,35 @@ describe("SlackAdapter — lifecycle", () => {
     const id = await adapter.getPlatformUserId();
     expect(id).toBe("UFRESH");
   });
+
+  test("start fetches getBotUserId BEFORE opening the socket (TOCTOU fix)", async () => {
+    // Echo cortex#233 (review #2): the self-loop guard depends on
+    // `botUserId` being non-null at the moment any inbound event is
+    // translated. Before this fix, `client.start()` was awaited first
+    // and `getBotUserId()` second — opening a ~auth.test-round-trip
+    // window where events could arrive with the cache still null. Lock
+    // in the new ordering: getBotUserId → start.
+    const { adapter, state } = makeAdapter();
+    const cap = captureInbound();
+    await adapter.start(cap.onMessage);
+    const getIdx = state.callOrder.indexOf("getBotUserId");
+    const startIdx = state.callOrder.indexOf("start");
+    expect(getIdx).toBeGreaterThanOrEqual(0);
+    expect(startIdx).toBeGreaterThanOrEqual(0);
+    expect(getIdx).toBeLessThan(startIdx);
+  });
+
+  test("start aborts (fail-closed) when getBotUserId rejects", async () => {
+    // Fail-closed companion to the TOCTOU fix: if we can't resolve our
+    // own bot id, opening the socket is unsafe — any self-echo would
+    // dispatch as a real message. Surface the error to the caller.
+    const { adapter, state } = makeAdapter({
+      clientState: { getBotUserIdError: new Error("auth.test 403") },
+    });
+    const cap = captureInbound();
+    await expect(adapter.start(cap.onMessage)).rejects.toThrow(/auth\.test/);
+    expect(state.startCount).toBe(0); // socket never opened
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -311,6 +357,37 @@ describe("SlackAdapter — translateEvent", () => {
     expect(cap.received).toHaveLength(1);
     expect(cap.received[0]?.authorId).toBe("BPEER");
     expect(cap.received[0]?.content).toBe("from peer");
+  });
+
+  test("dedups when the same ts arrives twice (message + app_mention)", async () => {
+    // Echo cortex#233 (review #1): Slack fires BOTH `message` and
+    // `app_mention` for the same user message when the bot is a
+    // channel member. The client subscribes to both for coverage; the
+    // adapter must collapse them by `ts` so the dispatch pipeline only
+    // sees one InboundMessage.
+    const { adapter, emit } = makeAdapter();
+    const cap = captureInbound();
+    await adapter.start(cap.onMessage);
+
+    const sharedTs = "1700000000.555555";
+    await emit(makeSlackEvent({ type: "message", ts: sharedTs, text: "@bot hi" }));
+    await emit(makeSlackEvent({ type: "app_mention", ts: sharedTs, text: "@bot hi" }));
+
+    expect(cap.received).toHaveLength(1);
+    expect(cap.received[0]?.content).toBe("@bot hi");
+  });
+
+  test("does NOT dedup distinct ts values", async () => {
+    // Sanity check on the dedup gate — different messages must both
+    // dispatch even when they share other fields.
+    const { adapter, emit } = makeAdapter();
+    const cap = captureInbound();
+    await adapter.start(cap.onMessage);
+
+    await emit(makeSlackEvent({ ts: "1700000000.111111", text: "first" }));
+    await emit(makeSlackEvent({ ts: "1700000000.222222", text: "second" }));
+
+    expect(cap.received).toHaveLength(2);
   });
 
   test("maps Slack files to InboundMessage attachments", async () => {

--- a/src/adapters/slack/__tests__/slack-adapter.test.ts
+++ b/src/adapters/slack/__tests__/slack-adapter.test.ts
@@ -1,0 +1,559 @@
+/**
+ * F-slack: SlackAdapter unit tests.
+ *
+ * Mirror of the Mattermost / Discord adapter test patterns. We inject a
+ * fake `SlackClient` via the adapter's infra so no real Socket Mode
+ * connection is opened and no Slack API is hit. Each test exercises one
+ * adapter responsibility: translateEvent, resolveAccess, postResponse,
+ * createThread, notifyOperator, surfaceConfig.render.
+ */
+
+import { test, expect, describe, beforeEach, afterEach } from "bun:test";
+import { SlackAdapter, type SlackAdapterInfra } from "../index";
+import type { SlackClient, SlackInboundEvent } from "../client";
+import type { Agent, SlackPresence } from "../../../common/types/cortex-config";
+import type { InboundMessage } from "../../types";
+import type { Envelope } from "../../../bus/myelin/envelope-validator";
+
+// ---------------------------------------------------------------------------
+// Fake SlackClient — records calls and exposes a hook to simulate inbound
+// events. Tests assert against `postedMessages` / `wasStopped` and drive
+// events via `emitEvent`.
+// ---------------------------------------------------------------------------
+
+interface FakeSlackClientState {
+  postedMessages: { channel: string; text: string; threadTs?: string }[];
+  startCount: number;
+  stopCount: number;
+  botUserId: string;
+  /** Throw on next postMessage when set. */
+  postMessageError?: Error;
+}
+
+function makeFakeClient(initial: Partial<FakeSlackClientState> = {}): {
+  client: SlackClient;
+  state: FakeSlackClientState;
+  emit: (event: SlackInboundEvent) => Promise<void>;
+} {
+  const state: FakeSlackClientState = {
+    postedMessages: [],
+    startCount: 0,
+    stopCount: 0,
+    botUserId: initial.botUserId ?? "UBOT123",
+    ...(initial.postMessageError !== undefined && { postMessageError: initial.postMessageError }),
+  };
+
+  let onEvent: ((event: SlackInboundEvent) => Promise<void>) | null = null;
+
+  const client: SlackClient = {
+    async start(opts) {
+      state.startCount++;
+      onEvent = opts.onEvent;
+    },
+    async stop() {
+      state.stopCount++;
+      onEvent = null;
+    },
+    // eslint-disable-next-line @typescript-eslint/require-await
+    async postMessage(channel, text, threadTs) {
+      if (state.postMessageError) throw state.postMessageError;
+      state.postedMessages.push({
+        channel,
+        text,
+        ...(threadTs !== undefined && { threadTs }),
+      });
+      return { ts: "1700000000.000001" };
+    },
+    // eslint-disable-next-line @typescript-eslint/require-await
+    async getBotUserId() {
+      return state.botUserId;
+    },
+  };
+
+  const emit = async (event: SlackInboundEvent) => {
+    if (!onEvent) throw new Error("client.start() not called");
+    await onEvent(event);
+  };
+
+  return { client, state, emit };
+}
+
+function makePresence(overrides: Partial<SlackPresence> = {}): SlackPresence {
+  return {
+    enabled: true,
+    botToken: "xoxb-TEST-TOKEN-12345",
+    appToken: "xapp-TEST-APP-12345",
+    workspaceId: "T0WORKSPACE",
+    channels: [{ id: "C0CHAN1", name: "cortex" }],
+    allowedUserIds: [],
+    trustedBotIds: [],
+    roles: [],
+    defaultRole: "allow-all",
+    surfaceSubjects: [],
+    ...overrides,
+  };
+}
+
+function makeAgent(presence: SlackPresence): Agent {
+  return {
+    id: "luna",
+    displayName: "Luna",
+    persona: "(test)",
+    roles: [],
+    trust: [],
+    presence: { slack: presence },
+  };
+}
+
+function makeAdapter(opts: {
+  presence?: Partial<SlackPresence>;
+  infra?: Partial<SlackAdapterInfra>;
+  clientState?: Partial<FakeSlackClientState>;
+} = {}) {
+  const presence = makePresence(opts.presence);
+  const agent = makeAgent(presence);
+  const fake = makeFakeClient(opts.clientState);
+  const infra: SlackAdapterInfra = {
+    instanceId: "slack-test",
+    operator: {},
+    client: fake.client,
+    ...opts.infra,
+  };
+  const adapter = new SlackAdapter(agent, presence, infra);
+  return { adapter, ...fake };
+}
+
+// Helpers for asserting captured inbound messages from `start(onMessage)`.
+function captureInbound() {
+  const received: InboundMessage[] = [];
+  return {
+    received,
+    onMessage: async (msg: InboundMessage) => {
+      received.push(msg);
+    },
+  };
+}
+
+function makeSlackEvent(overrides: Partial<SlackInboundEvent> = {}): SlackInboundEvent {
+  return {
+    type: "message",
+    user: "U0HUMAN",
+    team: "T0WORKSPACE",
+    channel: "C0CHAN1",
+    text: "hello bot",
+    ts: "1700000000.000123",
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Console suppression for warning-emitting tests.
+// ---------------------------------------------------------------------------
+
+let originalWarn: typeof console.warn;
+let originalError: typeof console.error;
+const warnings: string[] = [];
+
+beforeEach(() => {
+  warnings.length = 0;
+  originalWarn = console.warn;
+  originalError = console.error;
+  console.warn = (...args: unknown[]) => {
+    warnings.push(args.map(String).join(" "));
+  };
+  console.error = () => {};
+});
+
+afterEach(() => {
+  console.warn = originalWarn;
+  console.error = originalError;
+});
+
+// ---------------------------------------------------------------------------
+// Construction
+// ---------------------------------------------------------------------------
+
+describe("SlackAdapter — construction", () => {
+  test("platform is 'slack'", () => {
+    const { adapter } = makeAdapter();
+    expect(adapter.platform).toBe("slack");
+  });
+
+  test("instanceId mirrors infra.instanceId", () => {
+    const { adapter } = makeAdapter({ infra: { instanceId: "luna-slack" } });
+    expect(adapter.instanceId).toBe("luna-slack");
+  });
+
+  test("warns at construction when surfaceSubjects is explicitly []", () => {
+    makeAdapter({ infra: { surfaceSubjects: [] } });
+    expect(
+      warnings.some((w) => w.includes("surfaceSubjects is empty")),
+    ).toBe(true);
+  });
+
+  test("does NOT warn when surfaceSubjects is undefined", () => {
+    makeAdapter();
+    expect(warnings.some((w) => w.includes("surfaceSubjects is empty"))).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Lifecycle: start / stop / getPlatformUserId
+// ---------------------------------------------------------------------------
+
+describe("SlackAdapter — lifecycle", () => {
+  test("start opens the client and caches bot user id", async () => {
+    const { adapter, state } = makeAdapter({ clientState: { botUserId: "UBOTLUNA" } });
+    const cap = captureInbound();
+    await adapter.start(cap.onMessage);
+    expect(state.startCount).toBe(1);
+    expect(await adapter.getPlatformUserId()).toBe("UBOTLUNA");
+  });
+
+  test("stop closes the client and drops the cached id", async () => {
+    const { adapter, state } = makeAdapter();
+    const cap = captureInbound();
+    await adapter.start(cap.onMessage);
+    await adapter.stop();
+    expect(state.stopCount).toBe(1);
+  });
+
+  test("getPlatformUserId fetches on demand when not yet cached", async () => {
+    const { adapter, state } = makeAdapter({ clientState: { botUserId: "UFRESH" } });
+    // Don't start — call getPlatformUserId directly.
+    expect(state.startCount).toBe(0);
+    const id = await adapter.getPlatformUserId();
+    expect(id).toBe("UFRESH");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// translateEvent — via the start(onMessage) seam
+// ---------------------------------------------------------------------------
+
+describe("SlackAdapter — translateEvent", () => {
+  test("translates a plain message into an InboundMessage", async () => {
+    const { adapter, emit } = makeAdapter();
+    const cap = captureInbound();
+    await adapter.start(cap.onMessage);
+
+    await emit(makeSlackEvent({ user: "U0HUMAN", text: "hello", channel: "C0CHAN1" }));
+
+    expect(cap.received).toHaveLength(1);
+    const msg = cap.received[0]!;
+    expect(msg.platform).toBe("slack");
+    expect(msg.authorId).toBe("U0HUMAN");
+    expect(msg.content).toBe("hello");
+    expect(msg.channelId).toBe("C0CHAN1");
+    expect(msg.channelName).toBe("cortex");
+    expect(msg.guildId).toBe("T0WORKSPACE");
+    expect(msg.threadId).toBeUndefined();
+  });
+
+  test("populates threadId from thread_ts when present", async () => {
+    const { adapter, emit } = makeAdapter();
+    const cap = captureInbound();
+    await adapter.start(cap.onMessage);
+
+    await emit(makeSlackEvent({ thread_ts: "1700000000.000000" }));
+
+    expect(cap.received[0]?.threadId).toBe("1700000000.000000");
+  });
+
+  test("drops self-authored messages (botUserId matches)", async () => {
+    const { adapter, emit } = makeAdapter({ clientState: { botUserId: "UBOTSELF" } });
+    const cap = captureInbound();
+    await adapter.start(cap.onMessage);
+
+    await emit(makeSlackEvent({ user: "UBOTSELF" }));
+
+    expect(cap.received).toHaveLength(0);
+  });
+
+  test("drops system subtypes like channel_join", async () => {
+    const { adapter, emit } = makeAdapter();
+    const cap = captureInbound();
+    await adapter.start(cap.onMessage);
+
+    await emit(makeSlackEvent({ subtype: "channel_join" }));
+
+    expect(cap.received).toHaveLength(0);
+  });
+
+  test("drops bot_message when the bot id is not in trustedBotIds", async () => {
+    const { adapter, emit } = makeAdapter();
+    const cap = captureInbound();
+    await adapter.start(cap.onMessage);
+
+    await emit(makeSlackEvent({
+      subtype: "bot_message",
+      user: undefined,
+      bot_id: "BPEER",
+    }));
+
+    expect(cap.received).toHaveLength(0);
+  });
+
+  test("accepts bot_message when the bot id is in trustedBotIds", async () => {
+    const { adapter, emit } = makeAdapter({
+      infra: { trustedBotIds: new Set(["BPEER"]) },
+    });
+    const cap = captureInbound();
+    await adapter.start(cap.onMessage);
+
+    await emit(makeSlackEvent({
+      subtype: "bot_message",
+      user: undefined,
+      bot_id: "BPEER",
+      text: "from peer",
+    }));
+
+    expect(cap.received).toHaveLength(1);
+    expect(cap.received[0]?.authorId).toBe("BPEER");
+    expect(cap.received[0]?.content).toBe("from peer");
+  });
+
+  test("maps Slack files to InboundMessage attachments", async () => {
+    const { adapter, emit } = makeAdapter();
+    const cap = captureInbound();
+    await adapter.start(cap.onMessage);
+
+    await emit(makeSlackEvent({
+      files: [
+        { url_private: "https://files.slack.com/x.png", name: "x.png", mimetype: "image/png", size: 42 },
+      ],
+    }));
+
+    expect(cap.received[0]?.attachments).toEqual([{
+      url: "https://files.slack.com/x.png",
+      filename: "x.png",
+      contentType: "image/png",
+      size: 42,
+    }]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveAccess
+// ---------------------------------------------------------------------------
+
+describe("SlackAdapter — resolveAccess", () => {
+  function makeInbound(authorId: string): InboundMessage {
+    return {
+      platform: "slack",
+      instanceId: "slack-test",
+      authorId,
+      authorName: authorId,
+      content: "hi",
+      channelId: "C0CHAN1",
+      attachments: [],
+      timestamp: new Date(0),
+    };
+  }
+
+  test("allow-all role grants all features when no roles configured", () => {
+    const { adapter } = makeAdapter();
+    const decision = adapter.resolveAccess(makeInbound("U0HUMAN"));
+    expect(decision.allowed).toBe(true);
+    expect(decision.features.chat).toBe(true);
+    expect(decision.features.async).toBe(true);
+    expect(decision.features.team).toBe(true);
+  });
+
+  test("denies when allowedUserIds is set and user is not in it", () => {
+    const { adapter } = makeAdapter({
+      presence: { allowedUserIds: ["UOPERATOR"] },
+    });
+    const decision = adapter.resolveAccess(makeInbound("U0RANDO"));
+    expect(decision.allowed).toBe(false);
+    expect(decision.denyReason).toContain("specific users");
+  });
+
+  test("allows when allowedUserIds is set and user is in it", () => {
+    const { adapter } = makeAdapter({
+      presence: { allowedUserIds: ["UOPERATOR"] },
+    });
+    const decision = adapter.resolveAccess(makeInbound("UOPERATOR"));
+    expect(decision.allowed).toBe(true);
+  });
+
+  test("denies a self-loop message even if the user is in allowedUserIds", async () => {
+    const { adapter } = makeAdapter({
+      presence: { allowedUserIds: ["UBOTSELF"] },
+      clientState: { botUserId: "UBOTSELF" },
+    });
+    // start() to populate the cached bot user id.
+    await adapter.start(captureInbound().onMessage);
+    const decision = adapter.resolveAccess(makeInbound("UBOTSELF"));
+    expect(decision.allowed).toBe(false);
+    expect(decision.denyReason).toContain("Self-loop");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// postResponse
+// ---------------------------------------------------------------------------
+
+describe("SlackAdapter — postResponse", () => {
+  test("posts via the client with channel + text", async () => {
+    const { adapter, state } = makeAdapter();
+    await adapter.postResponse({ instanceId: "slack-test", channelId: "C0CHAN1" }, "ok");
+    expect(state.postedMessages).toEqual([{ channel: "C0CHAN1", text: "ok" }]);
+  });
+
+  test("threads the response when threadId is set", async () => {
+    const { adapter, state } = makeAdapter();
+    await adapter.postResponse(
+      { instanceId: "slack-test", channelId: "C0CHAN1", threadId: "1700000000.000000" },
+      "ok",
+    );
+    expect(state.postedMessages[0]?.threadTs).toBe("1700000000.000000");
+  });
+
+  test("warns and drops file attachments (v1 text-only)", async () => {
+    const { adapter, state } = makeAdapter();
+    await adapter.postResponse(
+      { instanceId: "slack-test", channelId: "C0CHAN1" },
+      "see attached",
+      [{ content: Buffer.from("data"), filename: "x.txt" }],
+    );
+    expect(warnings.some((w) => w.includes("file attachments not yet supported"))).toBe(true);
+    // Text still posts.
+    expect(state.postedMessages).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sendProgress / createThread / notifyOperator
+// ---------------------------------------------------------------------------
+
+describe("SlackAdapter — sendProgress + createThread + notifyOperator", () => {
+  test("sendProgress posts once and skips subsequent calls", async () => {
+    const { adapter, state } = makeAdapter();
+    const target = { instanceId: "slack-test", channelId: "C0CHAN1", threadId: "T123" };
+    await adapter.sendProgress(target, "step 1");
+    await adapter.sendProgress(target, "step 2");
+    expect(state.postedMessages).toHaveLength(1);
+    expect(state.postedMessages[0]?.text).toBe("> step 1");
+  });
+
+  test("clearProgress allows a subsequent sendProgress to post again", async () => {
+    const { adapter, state } = makeAdapter();
+    const target = { instanceId: "slack-test", channelId: "C0CHAN1", threadId: "T123" };
+    await adapter.sendProgress(target, "first");
+    await adapter.clearProgress(target);
+    await adapter.sendProgress(target, "second");
+    expect(state.postedMessages).toHaveLength(2);
+    expect(state.postedMessages[1]?.text).toBe("> second");
+  });
+
+  test("createThread returns threadId rooted on the source message's ts", async () => {
+    const { adapter } = makeAdapter();
+    const msg: InboundMessage = {
+      platform: "slack",
+      instanceId: "slack-test",
+      authorId: "U0HUMAN",
+      authorName: "U0HUMAN",
+      content: "spawn a thread",
+      channelId: "C0CHAN1",
+      attachments: [],
+      timestamp: new Date(0),
+      _native: makeSlackEvent({ ts: "1700000000.999999" }),
+    };
+    const target = await adapter.createThread(msg, "ignored-name");
+    expect(target.channelId).toBe("C0CHAN1");
+    expect(target.threadId).toBe("1700000000.999999");
+  });
+
+  test("notifyOperator no-ops when operator.slackId is not configured", async () => {
+    const { adapter, state } = makeAdapter();
+    await adapter.notifyOperator("ping");
+    expect(state.postedMessages).toHaveLength(0);
+  });
+
+  test("notifyOperator DMs the operator when slackId is configured", async () => {
+    const { adapter, state } = makeAdapter({
+      infra: { operator: { slackId: "UOPERATOR" } },
+    });
+    await adapter.notifyOperator("ping");
+    expect(state.postedMessages).toEqual([{ channel: "UOPERATOR", text: "ping" }]);
+  });
+
+  test("notifyOperator swallows post errors (log + drop)", async () => {
+    const { adapter } = makeAdapter({
+      infra: { operator: { slackId: "UOPERATOR" } },
+      clientState: { postMessageError: new Error("403 not_in_channel") },
+    });
+    // Must not throw — the operator's notification path is best-effort.
+    await expect(adapter.notifyOperator("ping")).resolves.toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// surfaceConfig.render — bus envelope rendering
+// ---------------------------------------------------------------------------
+
+describe("SlackAdapter.surfaceConfig", () => {
+  function makeEnvelope(overrides: Partial<Envelope> = {}): Envelope {
+    return {
+      id: "00000000-0000-4000-8000-000000000099",
+      source: "metafactory.pilot.local",
+      type: "review.cycle.completed",
+      timestamp: "2026-05-09T12:00:00Z",
+      sovereignty: {
+        classification: "local",
+        data_residency: "NZ",
+        max_hop: 0,
+        frontier_ok: true,
+        model_class: "any",
+      },
+      payload: { repo: "cortex" },
+      ...overrides,
+    };
+  }
+
+  test("id matches instanceId, subjects mirror surfaceSubjects", () => {
+    const { adapter } = makeAdapter({
+      infra: { surfaceSubjects: ["local.metafactory.review.>"] },
+    });
+    expect(adapter.surfaceConfig.id).toBe("slack-test");
+    expect(adapter.surfaceConfig.subjects).toEqual(["local.metafactory.review.>"]);
+  });
+
+  test("renders the envelope to the fallback channel when configured", async () => {
+    const { adapter, state } = makeAdapter({
+      infra: { surfaceFallbackChannelId: "C0FALLBACK" },
+    });
+    await adapter.surfaceConfig.render(makeEnvelope());
+    expect(state.postedMessages).toHaveLength(1);
+    expect(state.postedMessages[0]?.channel).toBe("C0FALLBACK");
+    expect(state.postedMessages[0]?.text).toContain("**review.cycle.completed**");
+  });
+
+  test("renders top-level (no threading) when posting bus envelopes", async () => {
+    const { adapter, state } = makeAdapter({
+      infra: { surfaceFallbackChannelId: "C0FALLBACK" },
+    });
+    await adapter.surfaceConfig.render(makeEnvelope());
+    expect(state.postedMessages[0]?.threadTs).toBeUndefined();
+  });
+
+  test("drops + warns when no surfaceFallbackChannelId is configured", async () => {
+    const { adapter, state } = makeAdapter();
+    await adapter.surfaceConfig.render(makeEnvelope());
+    expect(state.postedMessages).toHaveLength(0);
+    expect(
+      warnings.some((w) => w.includes("no surfaceFallbackChannelId configured")),
+    ).toBe(true);
+  });
+
+  test("does not throw when postMessage fails (log + drop)", async () => {
+    const { adapter } = makeAdapter({
+      infra: { surfaceFallbackChannelId: "C0FALLBACK" },
+      clientState: { postMessageError: new Error("rate limited") },
+    });
+    await expect(
+      adapter.surfaceConfig.render(makeEnvelope()),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/src/adapters/slack/__tests__/slack-adapter.test.ts
+++ b/src/adapters/slack/__tests__/slack-adapter.test.ts
@@ -10,7 +10,7 @@
 
 import { test, expect, describe, beforeEach, afterEach } from "bun:test";
 import { SlackAdapter, type SlackAdapterInfra } from "../index";
-import type { SlackClient, SlackInboundEvent } from "../client";
+import type { SlackClient, SlackInboundEvent, SlackBotIdentity } from "../client";
 import type { Agent, SlackPresence } from "../../../common/types/cortex-config";
 import type { InboundMessage } from "../../types";
 import type { Envelope } from "../../../bus/myelin/envelope-validator";
@@ -26,15 +26,17 @@ interface FakeSlackClientState {
   startCount: number;
   stopCount: number;
   botUserId: string;
+  /** Optional bot id (`B…`) returned alongside the user id by `getBotIdentity`. */
+  botId?: string;
   /** Throw on next postMessage when set. */
   postMessageError?: Error;
   /**
    * Sequence of client-method calls in invocation order — used to
-   * assert that `getBotUserId` resolves BEFORE `start` opens the
+   * assert that `getBotIdentity` resolves BEFORE `start` opens the
    * socket (Echo cortex#233 self-loop TOCTOU fix).
    */
-  callOrder: ("start" | "stop" | "postMessage" | "getBotUserId")[];
-  /** When set, the next `getBotUserId` call rejects with this error. */
+  callOrder: ("start" | "stop" | "postMessage" | "getBotUserId" | "getBotIdentity")[];
+  /** When set, the next identity call rejects with this error. */
   getBotUserIdError?: Error;
 }
 
@@ -49,6 +51,7 @@ function makeFakeClient(initial: Partial<FakeSlackClientState> = {}): {
     stopCount: 0,
     botUserId: initial.botUserId ?? "UBOT123",
     callOrder: [],
+    ...(initial.botId !== undefined && { botId: initial.botId }),
     ...(initial.postMessageError !== undefined && { postMessageError: initial.postMessageError }),
     ...(initial.getBotUserIdError !== undefined && { getBotUserIdError: initial.getBotUserIdError }),
   };
@@ -84,6 +87,15 @@ function makeFakeClient(initial: Partial<FakeSlackClientState> = {}): {
       state.callOrder.push("getBotUserId");
       if (state.getBotUserIdError) throw state.getBotUserIdError;
       return state.botUserId;
+    },
+    // eslint-disable-next-line @typescript-eslint/require-await
+    async getBotIdentity(): Promise<SlackBotIdentity> {
+      state.callOrder.push("getBotIdentity");
+      if (state.getBotUserIdError) throw state.getBotUserIdError;
+      return {
+        userId: state.botUserId,
+        ...(state.botId !== undefined && { botId: state.botId }),
+      };
     },
   };
 
@@ -235,6 +247,27 @@ describe("SlackAdapter — lifecycle", () => {
     expect(state.stopCount).toBe(1);
   });
 
+  test("stop clears the dedup ring so a re-started adapter sees fresh ts (Echo r2 N4)", async () => {
+    // Echo r2 N4: without clearing the ring on stop(), a hot-restart
+    // (config watcher / test fixture reuse) would carry over `ts`
+    // values from the prior session, silently dropping legitimate
+    // messages whose ts happened to match.
+    const { adapter, emit } = makeAdapter();
+    const cap = captureInbound();
+    await adapter.start(cap.onMessage);
+    await emit(makeSlackEvent({ ts: "1700000000.111111", text: "first" }));
+    expect(cap.received).toHaveLength(1);
+
+    await adapter.stop();
+    await adapter.start(cap.onMessage);
+
+    // Same ts replayed AFTER stop+start — must NOT be dropped by the
+    // ring, because stop() cleared it.
+    await emit(makeSlackEvent({ ts: "1700000000.111111", text: "first-replay" }));
+    expect(cap.received).toHaveLength(2);
+    expect(cap.received[1]?.content).toBe("first-replay");
+  });
+
   test("getPlatformUserId fetches on demand when not yet cached", async () => {
     const { adapter, state } = makeAdapter({ clientState: { botUserId: "UFRESH" } });
     // Don't start — call getPlatformUserId directly.
@@ -243,24 +276,24 @@ describe("SlackAdapter — lifecycle", () => {
     expect(id).toBe("UFRESH");
   });
 
-  test("start fetches getBotUserId BEFORE opening the socket (TOCTOU fix)", async () => {
+  test("start fetches getBotIdentity BEFORE opening the socket (TOCTOU fix)", async () => {
     // Echo cortex#233 (review #2): the self-loop guard depends on
-    // `botUserId` being non-null at the moment any inbound event is
+    // identity being non-null at the moment any inbound event is
     // translated. Before this fix, `client.start()` was awaited first
-    // and `getBotUserId()` second — opening a ~auth.test-round-trip
-    // window where events could arrive with the cache still null. Lock
-    // in the new ordering: getBotUserId → start.
+    // and identity second — opening a ~auth.test-round-trip window
+    // where events could arrive with the cache still null. Lock in
+    // the new ordering: getBotIdentity → start.
     const { adapter, state } = makeAdapter();
     const cap = captureInbound();
     await adapter.start(cap.onMessage);
-    const getIdx = state.callOrder.indexOf("getBotUserId");
+    const getIdx = state.callOrder.indexOf("getBotIdentity");
     const startIdx = state.callOrder.indexOf("start");
     expect(getIdx).toBeGreaterThanOrEqual(0);
     expect(startIdx).toBeGreaterThanOrEqual(0);
     expect(getIdx).toBeLessThan(startIdx);
   });
 
-  test("start aborts (fail-closed) when getBotUserId rejects", async () => {
+  test("start aborts (fail-closed) when getBotIdentity rejects", async () => {
     // Fail-closed companion to the TOCTOU fix: if we can't resolve our
     // own bot id, opening the socket is unsafe — any self-echo would
     // dispatch as a real message. Surface the error to the caller.
@@ -312,6 +345,72 @@ describe("SlackAdapter — translateEvent", () => {
     await adapter.start(cap.onMessage);
 
     await emit(makeSlackEvent({ user: "UBOTSELF" }));
+
+    expect(cap.received).toHaveLength(0);
+  });
+
+  test("drops self-echo via bot_id path (Echo r2 N1)", async () => {
+    // When this bot's own `chat.postMessage` round-trips as a
+    // `bot_message` subtype event, the author is `event.bot_id` (`B…`),
+    // NOT `event.user`. The self-loop guard must catch that path too
+    // or the bot will echo itself.
+    const { adapter, emit } = makeAdapter({
+      clientState: { botUserId: "UBOTSELF", botId: "BSELF" },
+    });
+    const cap = captureInbound();
+    await adapter.start(cap.onMessage);
+
+    await emit(makeSlackEvent({
+      subtype: "bot_message",
+      user: undefined,
+      bot_id: "BSELF",
+      text: "self echo",
+    }));
+
+    expect(cap.received).toHaveLength(0);
+  });
+
+  test("accepts a peer bot when trustedBotIds contains its B-id (Echo r2 N2)", async () => {
+    // Echo r2 N2 contract: trustedBotIds is `B…` (bot ids), NOT `U…`
+    // (user ids). A peer bot's bot_message event arrives with
+    // `bot_id: B…` and must be matched against the B-id list.
+    const { adapter, emit } = makeAdapter({
+      infra: { trustedBotIds: new Set(["BPEER"]) },
+      clientState: { botUserId: "UBOTSELF", botId: "BSELF" },
+    });
+    const cap = captureInbound();
+    await adapter.start(cap.onMessage);
+
+    await emit(makeSlackEvent({
+      subtype: "bot_message",
+      user: undefined,
+      bot_id: "BPEER",
+      text: "trusted peer",
+    }));
+
+    expect(cap.received).toHaveLength(1);
+    expect(cap.received[0]?.authorId).toBe("BPEER");
+  });
+
+  test("rejects peer bot when only its U-id (not B-id) is in trustedBotIds (Echo r2 N2)", async () => {
+    // Operators following the OLD doc would populate trustedBotIds with
+    // a `U…` value. The runtime check against `event.bot_id` (a `B…`)
+    // never matches → trust silently fails to take effect. After the
+    // r2 fix, the documented contract is `B…`; populating `U…` no
+    // longer matches anything in the bot_message path, by design.
+    const { adapter, emit } = makeAdapter({
+      infra: { trustedBotIds: new Set(["UPEER"]) }, // wrong shape per new doc
+      clientState: { botUserId: "UBOTSELF", botId: "BSELF" },
+    });
+    const cap = captureInbound();
+    await adapter.start(cap.onMessage);
+
+    await emit(makeSlackEvent({
+      subtype: "bot_message",
+      user: undefined,
+      bot_id: "BPEER",
+      text: "would-be peer",
+    }));
 
     expect(cap.received).toHaveLength(0);
   });
@@ -462,6 +561,20 @@ describe("SlackAdapter — resolveAccess", () => {
     // start() to populate the cached bot user id.
     await adapter.start(captureInbound().onMessage);
     const decision = adapter.resolveAccess(makeInbound("UBOTSELF"));
+    expect(decision.allowed).toBe(false);
+    expect(decision.denyReason).toContain("Self-loop");
+  });
+
+  test("self-loop denial also fires for the bot_id (B-id) path (Echo r2 N1)", async () => {
+    // resolveAccess sees the post-translate InboundMessage where
+    // authorId may be either the U-id or the B-id depending on the
+    // event subtype. Both must trigger the self-loop deny so a
+    // late-stage echo can't slip through.
+    const { adapter } = makeAdapter({
+      clientState: { botUserId: "UBOTSELF", botId: "BSELF" },
+    });
+    await adapter.start(captureInbound().onMessage);
+    const decision = adapter.resolveAccess(makeInbound("BSELF"));
     expect(decision.allowed).toBe(false);
     expect(decision.denyReason).toContain("Self-loop");
   });

--- a/src/adapters/slack/client.ts
+++ b/src/adapters/slack/client.ts
@@ -57,6 +57,19 @@ export interface SlackInboundEvent {
 }
 
 /**
+ * Bot identity resolved via `auth.test`. Slack messages identify the bot
+ * via either the user id (`U…`, on normal messages) or the bot id (`B…`,
+ * on `bot_message` subtype events) — the self-loop guard has to know
+ * both. See Echo cortex#233 round-2 N1.
+ */
+export interface SlackBotIdentity {
+  /** Slack user id of the bot (`U…`). */
+  userId: string;
+  /** Slack bot id (`B…`). May be undefined on older app installs. */
+  botId?: string;
+}
+
+/**
  * Pluggable Slack client surface. The real implementation wraps
  * `SocketModeClient` + `WebClient`; tests pass a mock.
  */
@@ -64,7 +77,10 @@ export interface SlackClient {
   start(opts: { onEvent: (event: SlackInboundEvent) => Promise<void> }): Promise<void>;
   stop(): Promise<void>;
   postMessage(channel: string, text: string, threadTs?: string): Promise<{ ts?: string }>;
+  /** Convenience accessor for `userId`. Kept for adapter call-site brevity. */
   getBotUserId(): Promise<string>;
+  /** Full identity (both `userId` and `botId`). Used by the self-loop guard. */
+  getBotIdentity(): Promise<SlackBotIdentity>;
 }
 
 export interface RealSlackClientOptions {
@@ -89,7 +105,7 @@ export class RealSlackClient implements SlackClient {
   private readonly socket: SocketModeClient;
   private readonly web: WebClient;
   private readonly instanceId: string;
-  private cachedBotUserId: string | null = null;
+  private cachedIdentity: SlackBotIdentity | null = null;
 
   constructor(opts: RealSlackClientOptions) {
     this.instanceId = opts.instanceId ?? "slack";
@@ -121,8 +137,11 @@ export class RealSlackClient implements SlackClient {
       try {
         await payload.ack();
       } catch (err) {
-        process.stderr.write(
-          `slack-client[${this.instanceId}]: ack failed: ${err instanceof Error ? err.message : String(err)}\n`,
+        // Echo cortex#233 r1#8: use `console.warn` consistently across
+        // the Slack module to match Discord + Mattermost adapters.
+        console.warn(
+          `slack-client[${this.instanceId}]: ack failed:`,
+          err instanceof Error ? err.message : String(err),
         );
       }
       try {
@@ -131,8 +150,9 @@ export class RealSlackClient implements SlackClient {
         // Adapters are expected to swallow per-message errors so the
         // event stream doesn't tear down on one bad message; log and
         // continue.
-        process.stderr.write(
-          `slack-client[${this.instanceId}]: onEvent threw: ${err instanceof Error ? err.message : String(err)}\n`,
+        console.warn(
+          `slack-client[${this.instanceId}]: onEvent threw:`,
+          err instanceof Error ? err.message : String(err),
         );
       }
     };
@@ -146,8 +166,9 @@ export class RealSlackClient implements SlackClient {
     // promise rejection in the listener wrapper).
     const dispatch = (payload: { ack: () => Promise<void>; event: SlackInboundEvent }): void => {
       handle(payload).catch((err: unknown) => {
-        process.stderr.write(
-          `slack-client[${this.instanceId}]: dispatch threw: ${err instanceof Error ? err.message : String(err)}\n`,
+        console.warn(
+          `slack-client[${this.instanceId}]: dispatch threw:`,
+          err instanceof Error ? err.message : String(err),
         );
       });
     };
@@ -170,20 +191,38 @@ export class RealSlackClient implements SlackClient {
   }
 
   /**
-   * Fetch the bot user id via `auth.test` and cache. The cortex
-   * `TrustResolver` (cortex#76) requires the platform user id of every
-   * bot adapter so peer agents resolve cleanly across processes.
+   * Fetch the full bot identity (userId + botId) via `auth.test` and
+   * cache. The cortex `TrustResolver` (cortex#76) requires the platform
+   * user id of every bot adapter so peer agents resolve cleanly across
+   * processes; the adapter additionally needs the `bot_id` so the
+   * self-loop guard catches `bot_message` subtype echoes (Echo
+   * cortex#233 round-2 N1).
+   *
+   * Error path intentionally omits `JSON.stringify(res)`: the
+   * `auth.test` response shape includes workspace metadata (`team`,
+   * `team_id`, `enterprise_id`, `url`) that, while not credentials,
+   * is operator-environment-identifying. Log only the missing-field
+   * diagnosis (Echo cortex#233 round-1 r1#10, deferred but worth
+   * fixing the new error path while we're here).
    */
-  async getBotUserId(): Promise<string> {
-    if (this.cachedBotUserId) return this.cachedBotUserId;
+  async getBotIdentity(): Promise<SlackBotIdentity> {
+    if (this.cachedIdentity) return this.cachedIdentity;
     const res = await this.web.auth.test();
-    const id = typeof res.user_id === "string" ? res.user_id : "";
-    if (!id) {
+    const userId = typeof res.user_id === "string" ? res.user_id : "";
+    if (!userId) {
       throw new Error(
-        `slack-client[${this.instanceId}]: auth.test returned no user_id (response: ${JSON.stringify(res)})`,
+        `slack-client[${this.instanceId}]: auth.test returned no user_id`,
       );
     }
-    this.cachedBotUserId = id;
-    return id;
+    const identity: SlackBotIdentity = {
+      userId,
+      ...(typeof res.bot_id === "string" && res.bot_id.length > 0 && { botId: res.bot_id }),
+    };
+    this.cachedIdentity = identity;
+    return identity;
+  }
+
+  async getBotUserId(): Promise<string> {
+    return (await this.getBotIdentity()).userId;
   }
 }

--- a/src/adapters/slack/client.ts
+++ b/src/adapters/slack/client.ts
@@ -1,0 +1,182 @@
+/**
+ * F-slack: Slack client wrapper.
+ *
+ * Thin abstraction over `@slack/socket-mode` (inbound events) and
+ * `@slack/web-api` (outbound message posting + auth check). The goal is to
+ * keep `SlackAdapter` free of direct SDK imports so unit tests can inject a
+ * mock client without monkey-patching globals.
+ *
+ * The interface is intentionally tiny — exactly the operations the adapter
+ * uses today:
+ *
+ *   - `start({ onMessage })`            — open Socket Mode, deliver events
+ *   - `stop()`                          — close the websocket cleanly
+ *   - `postMessage(channel, text, thread_ts?)`
+ *   - `getBotUserId()`                  — `auth.test` once, cached
+ *
+ * Future extensions (file uploads, reactions, conversations.history for
+ * context fetch) get bolted onto this interface without touching the
+ * adapter's outer surface.
+ */
+
+import { SocketModeClient } from "@slack/socket-mode";
+import { WebClient } from "@slack/web-api";
+
+/**
+ * Subset of the Slack `message` / `app_mention` event shape we actually
+ * consume. The Slack SDK types these as wide unions across many subtypes;
+ * we narrow to the fields cortex's `InboundMessage` mapping needs and let
+ * the rest flow through `_native`.
+ */
+export interface SlackInboundEvent {
+  /** Slack event type — `message` or `app_mention`. */
+  type: string;
+  /** Slack user id of the author, `U...`. May be undefined for bot/system messages. */
+  user?: string;
+  /** Slack bot id (`B...`) when the author is a bot. */
+  bot_id?: string;
+  /** Workspace id, `T...`. */
+  team?: string;
+  /** Channel id where the message was posted. */
+  channel: string;
+  /** Message text. */
+  text?: string;
+  /** Slack timestamp (`1234567890.123456`) — used both as message id and reply target. */
+  ts: string;
+  /** When set, the message is in a thread. The root message's `ts`. */
+  thread_ts?: string;
+  /** Message subtype (`bot_message`, `channel_join`, etc.) — used to filter system noise. */
+  subtype?: string;
+  /** File attachments, if any. */
+  files?: {
+    url_private?: string;
+    name?: string;
+    mimetype?: string;
+    size?: number;
+  }[];
+}
+
+/**
+ * Pluggable Slack client surface. The real implementation wraps
+ * `SocketModeClient` + `WebClient`; tests pass a mock.
+ */
+export interface SlackClient {
+  start(opts: { onEvent: (event: SlackInboundEvent) => Promise<void> }): Promise<void>;
+  stop(): Promise<void>;
+  postMessage(channel: string, text: string, threadTs?: string): Promise<{ ts?: string }>;
+  getBotUserId(): Promise<string>;
+}
+
+export interface RealSlackClientOptions {
+  botToken: string;
+  appToken: string;
+  /** Tag for log-prefixing. Defaults to `slack`. */
+  instanceId?: string;
+}
+
+/**
+ * Default Slack client: opens a Socket Mode connection, surfaces `message`
+ * + `app_mention` events to the adapter, and routes outbound posts through
+ * a `WebClient`. The `botToken` (xoxb-) authorises Web API calls; the
+ * `appToken` (xapp-) authorises the Socket Mode session.
+ *
+ * Acknowledgement: Slack's Socket Mode requires every inbound event to be
+ * `ack()`'d so the server stops redelivering. We `ack()` as the first
+ * action inside the event listener — well before invoking `onEvent` — so
+ * a slow downstream handler can never trigger a redelivery storm.
+ */
+export class RealSlackClient implements SlackClient {
+  private readonly socket: SocketModeClient;
+  private readonly web: WebClient;
+  private readonly instanceId: string;
+  private cachedBotUserId: string | null = null;
+
+  constructor(opts: RealSlackClientOptions) {
+    this.instanceId = opts.instanceId ?? "slack";
+    this.socket = new SocketModeClient({ appToken: opts.appToken });
+    this.web = new WebClient(opts.botToken);
+  }
+
+  async start(opts: { onEvent: (event: SlackInboundEvent) => Promise<void> }): Promise<void> {
+    // Slack's Socket Mode delivers `events_api` envelopes; the inner event
+    // type (`message`, `app_mention`) is re-emitted by SocketModeClient as
+    // a top-level event. We listen for both since `app_mention` events
+    // ALSO arrive as `message` events with a mention in the text — we want
+    // to handle them once, via the `message` channel, with the
+    // `app_mention` listener acting as a safety net for DMs/channels
+    // where the bot is mentioned without being a member.
+    const handle = async (
+      payload: { ack: () => Promise<void>; event: SlackInboundEvent },
+    ): Promise<void> => {
+      // Ack first — the Slack contract is "ack within 3 seconds" and our
+      // downstream pipeline can run much longer. A delayed ack triggers
+      // duplicate redelivery.
+      try {
+        await payload.ack();
+      } catch (err) {
+        process.stderr.write(
+          `slack-client[${this.instanceId}]: ack failed: ${err instanceof Error ? err.message : String(err)}\n`,
+        );
+      }
+      try {
+        await opts.onEvent(payload.event);
+      } catch (err) {
+        // Adapters are expected to swallow per-message errors so the
+        // event stream doesn't tear down on one bad message; log and
+        // continue.
+        process.stderr.write(
+          `slack-client[${this.instanceId}]: onEvent threw: ${err instanceof Error ? err.message : String(err)}\n`,
+        );
+      }
+    };
+
+    // `socket.on` expects a void-returning listener. `handle` is async
+    // (returns Promise<void>) because it has to await `payload.ack()` +
+    // the user callback; wrap it in a fire-and-forget dispatcher so the
+    // emitter contract is satisfied without losing async error logging.
+    // Errors are caught inside `handle` itself; this `.catch` is a
+    // belt-and-braces guard for truly unexpected throws (e.g. a synthetic
+    // promise rejection in the listener wrapper).
+    const dispatch = (payload: { ack: () => Promise<void>; event: SlackInboundEvent }): void => {
+      handle(payload).catch((err: unknown) => {
+        process.stderr.write(
+          `slack-client[${this.instanceId}]: dispatch threw: ${err instanceof Error ? err.message : String(err)}\n`,
+        );
+      });
+    };
+    this.socket.on("message", dispatch);
+    this.socket.on("app_mention", dispatch);
+    await this.socket.start();
+  }
+
+  async stop(): Promise<void> {
+    await this.socket.disconnect();
+  }
+
+  async postMessage(channel: string, text: string, threadTs?: string): Promise<{ ts?: string }> {
+    const res = await this.web.chat.postMessage({
+      channel,
+      text,
+      ...(threadTs !== undefined && { thread_ts: threadTs }),
+    });
+    return { ts: res.ts };
+  }
+
+  /**
+   * Fetch the bot user id via `auth.test` and cache. The cortex
+   * `TrustResolver` (cortex#76) requires the platform user id of every
+   * bot adapter so peer agents resolve cleanly across processes.
+   */
+  async getBotUserId(): Promise<string> {
+    if (this.cachedBotUserId) return this.cachedBotUserId;
+    const res = await this.web.auth.test();
+    const id = typeof res.user_id === "string" ? res.user_id : "";
+    if (!id) {
+      throw new Error(
+        `slack-client[${this.instanceId}]: auth.test returned no user_id (response: ${JSON.stringify(res)})`,
+      );
+    }
+    this.cachedBotUserId = id;
+    return id;
+  }
+}

--- a/src/adapters/slack/client.ts
+++ b/src/adapters/slack/client.ts
@@ -100,17 +100,24 @@ export class RealSlackClient implements SlackClient {
   async start(opts: { onEvent: (event: SlackInboundEvent) => Promise<void> }): Promise<void> {
     // Slack's Socket Mode delivers `events_api` envelopes; the inner event
     // type (`message`, `app_mention`) is re-emitted by SocketModeClient as
-    // a top-level event. We listen for both since `app_mention` events
-    // ALSO arrive as `message` events with a mention in the text — we want
-    // to handle them once, via the `message` channel, with the
-    // `app_mention` listener acting as a safety net for DMs/channels
-    // where the bot is mentioned without being a member.
+    // a top-level event.
+    //
+    // Subscribe to BOTH `message` and `app_mention` because:
+    //   - `message` covers DMs + posts in channels the bot is a member of
+    //   - `app_mention` covers mentions in channels where the bot is NOT
+    //     a member (Slack still delivers an app_mention there as a
+    //     conversation-starter)
+    // When the bot IS a member of the channel AND is mentioned, Slack
+    // fires BOTH events for the same message — the dedup ring below
+    // collapses them to a single dispatch keyed on `event.ts`.
     const handle = async (
       payload: { ack: () => Promise<void>; event: SlackInboundEvent },
     ): Promise<void> => {
       // Ack first — the Slack contract is "ack within 3 seconds" and our
       // downstream pipeline can run much longer. A delayed ack triggers
-      // duplicate redelivery.
+      // duplicate redelivery. Dedup of `message`/`app_mention`
+      // double-dispatch lives in `SlackAdapter.translateEvent` (one
+      // place to test, mock-friendly).
       try {
         await payload.ack();
       } catch (err) {

--- a/src/adapters/slack/index.ts
+++ b/src/adapters/slack/index.ts
@@ -77,7 +77,21 @@ export class SlackAdapter implements PlatformAdapter {
   /** Resolved bot user id, fetched on first `start()`. Used for self-loop guards. */
   private botUserId: string | null = null;
   /** Operator-explicit + adapter-side anti-self-loop set. */
-  private trustedBotIds: ReadonlySet<string>;
+  private readonly trustedBotIds: ReadonlySet<string>;
+  /**
+   * Echo cortex#233: bounded FIFO dedup ring of recently-seen Slack
+   * message `ts` values. Slack's Socket Mode fires BOTH the `message`
+   * and `app_mention` events for a single user message when the bot is
+   * a member of the channel where it was mentioned — the client
+   * subscribes to both events (so DMs + outside-channel mentions still
+   * arrive), and this set collapses the duplicate at the adapter layer
+   * before the dispatch pipeline sees it. Capacity 256 is generous
+   * versus the bot's effective ingest rate (one human + a few trusted
+   * bots) and is small enough to be irrelevant for memory.
+   */
+  private readonly seenTs = new Set<string>();
+  private readonly seenTsOrder: string[] = [];
+  private static readonly DEDUP_CAPACITY = 256;
 
   constructor(agent: Agent, presence: SlackPresence, infra: SlackAdapterInfra) {
     this.agent = agent;
@@ -102,6 +116,17 @@ export class SlackAdapter implements PlatformAdapter {
   }
 
   async start(onMessage: (msg: InboundMessage) => Promise<void>): Promise<void> {
+    // Echo cortex#233 (review #2): close the self-loop TOCTOU window by
+    // resolving `botUserId` BEFORE opening the Socket Mode connection.
+    // `auth.test` uses the bot token (xoxb-) — it does NOT need a live
+    // Socket Mode session. If we fetched the id after `client.start()`,
+    // any inbound event arriving in the millisecond gap between
+    // socket-connected and auth.test-resolved would pass through
+    // `translateEvent` with `botUserId === null`, silently failing-open
+    // on the self-loop guard. Fail-closed: if `getBotUserId()` rejects,
+    // abort startup rather than open a socket whose self-echo will be
+    // dispatched as a real message.
+    this.botUserId = await this.client.getBotUserId();
     await this.client.start({
       onEvent: async (event) => {
         const msg = this.translateEvent(event);
@@ -109,18 +134,6 @@ export class SlackAdapter implements PlatformAdapter {
         await onMessage(msg);
       },
     });
-    // Resolve the bot user id after start so subsequent
-    // `getPlatformUserId()` calls are zero-RPC. Best-effort: if auth.test
-    // fails we leave `botUserId` null and let `getPlatformUserId()` retry
-    // on demand — better than aborting startup.
-    try {
-      this.botUserId = await this.client.getBotUserId();
-    } catch (err) {
-      process.stderr.write(
-        `slack-${this.instanceId}: getBotUserId failed during start (will retry on demand): ` +
-          `${err instanceof Error ? err.message : String(err)}\n`,
-      );
-    }
   }
 
   async stop(): Promise<void> {
@@ -319,6 +332,26 @@ export class SlackAdapter implements PlatformAdapter {
    * keep the dispatch pipeline focused on actual chat content.
    */
   private translateEvent(event: SlackInboundEvent): InboundMessage | null {
+    // Echo cortex#233 (review #1): collapse the `message`/`app_mention`
+    // double-dispatch by ts BEFORE doing any other work. Events without
+    // a `ts` (defensive — real Slack messages always carry one) skip
+    // dedup and pass through. See `seenTs` field docstring for the
+    // ring's capacity rationale.
+    if (event.ts) {
+      if (this.seenTs.has(event.ts)) {
+        // Second sighting — drop. This is the expected path for a
+        // channel-member mention, where Slack fires both the
+        // `message` and `app_mention` events for the same `ts`.
+        return null;
+      }
+      this.seenTs.add(event.ts);
+      this.seenTsOrder.push(event.ts);
+      if (this.seenTsOrder.length > SlackAdapter.DEDUP_CAPACITY) {
+        const evicted = this.seenTsOrder.shift();
+        if (evicted !== undefined) this.seenTs.delete(evicted);
+      }
+    }
+
     // Drop self-authored messages at the source — both via user id
     // (when we know our own id) and via the bot_id-shaped subtype path
     // (when Slack doesn't include `user`).

--- a/src/adapters/slack/index.ts
+++ b/src/adapters/slack/index.ts
@@ -1,0 +1,369 @@
+/**
+ * F-slack: Slack Platform Adapter.
+ *
+ * Sibling to `DiscordAdapter` + `MattermostAdapter`. Wraps a pluggable
+ * `SlackClient` into the `PlatformAdapter` interface so the
+ * MessageRouter / dispatch-handler can dispatch Slack messages uniformly
+ * with Discord + Mattermost. Pure I/O wrapper — every pipeline concern
+ * (access control, context fetch, response posting, surface-router
+ * envelope rendering) lives at the same layer the other adapters use.
+ *
+ * Transport choice: Socket Mode (xoxb- bot token + xapp- app-level
+ * token). No public webhook URL needed — fits cortex's single-machine
+ * deployment model. HTTP / Events API mode is deferred.
+ */
+
+import type {
+  PlatformAdapter,
+  InboundMessage,
+  AccessDecision,
+  ResponseTarget,
+  OutboundFile,
+  ContextMessage,
+} from "../types";
+import type { Agent, SlackPresence } from "../../common/types/cortex-config";
+import type { Envelope } from "../../bus/myelin/envelope-validator";
+import type { SurfaceAdapter } from "../../bus/surface-router";
+import type { PayloadFilter } from "../../bus/payload-filter";
+import { resolveRole } from "../discord/role-resolver";
+import { formatEnvelopeAsMarkdown } from "../envelope-renderer";
+import { RealSlackClient, type SlackClient, type SlackInboundEvent } from "./client";
+
+/**
+ * Cortex-deployment-level wiring passed alongside the agent + presence
+ * pair. Mirror of `DiscordAdapterInfra` / `MattermostAdapterInfra`.
+ *
+ * `operator.slackId` is the operator's Slack user id (`U...`), used to
+ * route `notifyOperator` DMs the same way the Discord/Mattermost
+ * variants route theirs.
+ *
+ * `client` is the pluggable Slack client surface — defaults to
+ * `RealSlackClient` in production, mocked in unit tests.
+ */
+export interface SlackAdapterInfra {
+  /** Surface-router + log-prefix key. Cortex derives `${agent.id}-slack`. */
+  instanceId: string;
+  /** Operator's platform identity. */
+  operator: { slackId?: string };
+  /** MIG-3b: NATS subject patterns this adapter renders to Slack. */
+  surfaceSubjects?: string[];
+  /** MIG-3b: optional payload filter applied AFTER subject match. */
+  surfaceFilter?: PayloadFilter;
+  /** MIG-3b: fallback Slack channel id for envelope rendering. */
+  surfaceFallbackChannelId?: string;
+  /** Operator-set trusted peer bot user ids (`U...`). */
+  trustedBotIds?: ReadonlySet<string>;
+  /**
+   * Pluggable client implementation. Production callers omit this and
+   * get a `RealSlackClient` built from `presence.botToken` +
+   * `presence.appToken`. Tests inject a fake.
+   */
+  client?: SlackClient;
+}
+
+/**
+ * Slack adapter. Constructor wires the agent + presence + infra and
+ * either instantiates `RealSlackClient` (production) or accepts the
+ * caller's mock (tests).
+ */
+export class SlackAdapter implements PlatformAdapter {
+  readonly platform = "slack";
+  readonly instanceId: string;
+
+  private readonly agent: Agent;
+  private readonly presence: SlackPresence;
+  private readonly infra: SlackAdapterInfra;
+  private readonly client: SlackClient;
+  /** Resolved bot user id, fetched on first `start()`. Used for self-loop guards. */
+  private botUserId: string | null = null;
+  /** Operator-explicit + adapter-side anti-self-loop set. */
+  private trustedBotIds: ReadonlySet<string>;
+
+  constructor(agent: Agent, presence: SlackPresence, infra: SlackAdapterInfra) {
+    this.agent = agent;
+    this.presence = presence;
+    this.infra = infra;
+    this.instanceId = infra.instanceId;
+    this.trustedBotIds = infra.trustedBotIds ?? new Set(presence.trustedBotIds);
+    this.client = infra.client ?? new RealSlackClient({
+      botToken: presence.botToken,
+      appToken: presence.appToken,
+      instanceId: this.instanceId,
+    });
+
+    // Same one-shot warning the Discord + Mattermost adapters emit when
+    // surfaceSubjects is explicitly empty — an `undefined` is silent
+    // (opted out), `[]` is the config-typo signal worth surfacing.
+    if (infra.surfaceSubjects?.length === 0) {
+      console.warn(
+        `slack-${this.instanceId}: surfaceSubjects is empty — adapter will never render bus envelopes`,
+      );
+    }
+  }
+
+  async start(onMessage: (msg: InboundMessage) => Promise<void>): Promise<void> {
+    await this.client.start({
+      onEvent: async (event) => {
+        const msg = this.translateEvent(event);
+        if (!msg) return;
+        await onMessage(msg);
+      },
+    });
+    // Resolve the bot user id after start so subsequent
+    // `getPlatformUserId()` calls are zero-RPC. Best-effort: if auth.test
+    // fails we leave `botUserId` null and let `getPlatformUserId()` retry
+    // on demand — better than aborting startup.
+    try {
+      this.botUserId = await this.client.getBotUserId();
+    } catch (err) {
+      process.stderr.write(
+        `slack-${this.instanceId}: getBotUserId failed during start (will retry on demand): ` +
+          `${err instanceof Error ? err.message : String(err)}\n`,
+      );
+    }
+  }
+
+  async stop(): Promise<void> {
+    await this.client.stop();
+    // Drop the cached bot id so a subsequent `start()` re-fetches —
+    // guards against a token swap between sessions.
+    this.botUserId = null;
+  }
+
+  async getPlatformUserId(): Promise<string> {
+    if (this.botUserId) return this.botUserId;
+    const id = await this.client.getBotUserId();
+    this.botUserId = id;
+    return id;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/require-await
+  async fetchContext(_msg: InboundMessage, _depth: number): Promise<ContextMessage[]> {
+    // v1: no thread/channel context fetch yet. The dispatch pipeline can
+    // operate on the direct message alone; thread context via
+    // `conversations.replies` lands as a follow-up. Returning [] matches
+    // the contract for "no context available" without forcing the
+    // pipeline to special-case Slack.
+    return [];
+  }
+
+  resolveAccess(msg: InboundMessage): AccessDecision {
+    // Self-loop guard: never act on messages authored by this bot.
+    if (this.botUserId && msg.authorId === this.botUserId) {
+      return {
+        allowed: false,
+        features: { chat: false, async: false, team: false },
+        denyReason: "Self-loop guard: message authored by this bot.",
+      };
+    }
+
+    // allowedUserIds gate (mirror of MattermostAdapter.allowedUsers).
+    // Empty list = "no allowlist" = fall through to role resolution.
+    if (
+      this.presence.allowedUserIds.length > 0 &&
+      !this.presence.allowedUserIds.includes(msg.authorId)
+    ) {
+      return {
+        allowed: false,
+        features: { chat: false, async: false, team: false },
+        denyReason: "Sorry, I'm only configured to respond to specific users.",
+      };
+    }
+
+    const role = resolveRole(msg.authorId, {
+      roles: this.presence.roles,
+      defaultRole: this.presence.defaultRole,
+    });
+
+    if (role.denied) {
+      return {
+        allowed: false,
+        features: { chat: false, async: false, team: false },
+        denyReason: "Sorry, I'm only configured to respond to my operator.",
+      };
+    }
+
+    return {
+      allowed: true,
+      features: {
+        chat: role.features.has("chat"),
+        async: role.features.has("async"),
+        team: role.features.has("team"),
+      },
+      toolRestrictions: role.disallowedTools.length > 0 ? role.disallowedTools : undefined,
+      dirRestrictions: role.allowedDirs,
+      allowedSkills: role.allowedSkills,
+    };
+  }
+
+  async postResponse(target: ResponseTarget, text: string, files?: OutboundFile[]): Promise<void> {
+    if (files && files.length > 0) {
+      // File upload via files.upload / files.uploadV2 deferred to a
+      // follow-up — v1 of the Slack adapter is text-only. Flag the
+      // limitation so it surfaces in logs rather than silently dropping.
+      console.warn(
+        `slack-${this.instanceId}: file attachments not yet supported on Slack — ` +
+          `dropping ${files.length} file(s) and posting text only`,
+      );
+    }
+    await this.client.postMessage(target.channelId, text, target.threadId);
+  }
+
+  // eslint-disable-next-line @typescript-eslint/require-await
+  async sendTyping(_target: ResponseTarget): Promise<void> {
+    // Slack has no public typing-indicator API for Socket Mode bots — no-op.
+  }
+
+  private progressSent = new Set<string>();
+
+  async sendProgress(target: ResponseTarget, text: string): Promise<void> {
+    const key = target.threadId ?? target.channelId;
+    // Like Mattermost, we can't edit posts easily without tracking ts +
+    // calling chat.update. v1: send once, skip subsequent — matches the
+    // Mattermost adapter's shape so operators get consistent UX.
+    if (this.progressSent.has(key)) return;
+    this.progressSent.add(key);
+    await this.client.postMessage(target.channelId, `> ${text}`, target.threadId);
+  }
+
+  // eslint-disable-next-line @typescript-eslint/require-await
+  async clearProgress(target: ResponseTarget): Promise<void> {
+    const key = target.threadId ?? target.channelId;
+    this.progressSent.delete(key);
+    // Slack: no delete in v1 — leave the single progress message in place.
+  }
+
+  // eslint-disable-next-line @typescript-eslint/require-await
+  async createThread(msg: InboundMessage, _name: string): Promise<ResponseTarget> {
+    // Slack threads are implicit: post with `thread_ts` set to the parent
+    // message's ts and the reply lands in that thread. Same pattern as
+    // Mattermost's rootId. The "thread name" parameter is irrelevant on
+    // Slack (no thread titles) — we mirror Mattermost's behaviour of
+    // returning a target keyed on the original message's id.
+    const ev = msg._native as SlackInboundEvent | undefined;
+    const threadTs = ev?.thread_ts ?? ev?.ts ?? msg.threadId ?? msg.channelId;
+    return {
+      instanceId: this.instanceId,
+      channelId: msg.channelId,
+      threadId: threadTs,
+    };
+  }
+
+  async notifyOperator(text: string): Promise<void> {
+    const operatorId = this.infra.operator.slackId;
+    if (!operatorId) return;
+    try {
+      // For DMs, Slack accepts the user id directly as `channel`. The
+      // Web API opens (or reuses) the IM channel implicitly.
+      await this.client.postMessage(operatorId, text);
+    } catch (err) {
+      // Match the Mattermost/Discord notifyOperator pattern: log + drop.
+      // A failed DM should never tear down the adapter; the operator can
+      // see the same content on the dashboard / agent-log path.
+      console.warn(
+        `slack-${this.instanceId}: failed to notify operator:`,
+        err instanceof Error ? err.message : err,
+      );
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // MIG-3b: Surface-router integration
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Surface-adapter face for the surface-router. Mirror of
+   * `DiscordAdapter.surfaceConfig` / `MattermostAdapter.surfaceConfig` —
+   * same shape, same render contract, same failure mode (log + drop;
+   * JetStream replay handles recovery per architecture §3.3).
+   */
+  get surfaceConfig(): SurfaceAdapter {
+    return {
+      id: this.instanceId,
+      subjects: this.infra.surfaceSubjects ?? [],
+      ...(this.infra.surfaceFilter ? { filter: this.infra.surfaceFilter } : {}),
+      render: (envelope, signal) => this.renderEnvelope(envelope, signal),
+    };
+  }
+
+  private async renderEnvelope(envelope: Envelope, _signal?: AbortSignal): Promise<void> {
+    const channelId = this.infra.surfaceFallbackChannelId;
+    if (!channelId) {
+      console.warn(
+        `slack-${this.instanceId}: has no surfaceFallbackChannelId configured — dropping envelope ${envelope.id}`,
+      );
+      return;
+    }
+    try {
+      await this.client.postMessage(channelId, formatEnvelopeAsMarkdown(envelope));
+    } catch (err) {
+      console.warn(
+        `slack-${this.instanceId}: renderEnvelope failed for envelope ${envelope.id}:`,
+        err instanceof Error ? err.message : err,
+      );
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Translate a raw Slack event into a cortex `InboundMessage`. Returns
+   * `null` for events we intentionally ignore (system subtypes like
+   * `channel_join`, bot-authored messages not on the trusted list, etc.).
+   *
+   * Subtype filtering: real human messages have `subtype === undefined`.
+   * `bot_message` is the only subtype we conditionally accept — and only
+   * when the author is in `trustedBotIds`. Everything else is dropped to
+   * keep the dispatch pipeline focused on actual chat content.
+   */
+  private translateEvent(event: SlackInboundEvent): InboundMessage | null {
+    // Drop self-authored messages at the source — both via user id
+    // (when we know our own id) and via the bot_id-shaped subtype path
+    // (when Slack doesn't include `user`).
+    if (this.botUserId && event.user === this.botUserId) return null;
+
+    // Subtype gate: accept only "real" messages and trusted bot
+    // messages. System notices like `channel_join`, `channel_leave`,
+    // `message_changed` are noise for cortex's dispatch path.
+    if (event.subtype !== undefined && event.subtype !== "bot_message") {
+      return null;
+    }
+    if (event.subtype === "bot_message") {
+      // bot_message events authenticate via `bot_id` instead of `user`.
+      // Require the operator to opt the bot in via `trustedBotIds`.
+      const author = event.user ?? event.bot_id ?? "";
+      if (!author || !this.trustedBotIds.has(author)) return null;
+    }
+
+    const authorId = event.user ?? event.bot_id ?? "";
+    if (!authorId) return null;
+
+    const channelName = this.presence.channels.find((c) => c.id === event.channel)?.name;
+
+    return {
+      platform: "slack",
+      instanceId: this.instanceId,
+      authorId,
+      // v1: we don't resolve users.info for display names — Slack user
+      // ids are already stable identifiers, and the dispatch pipeline
+      // tolerates an id-as-name. Display-name resolution is a
+      // straightforward follow-up via `users.info`.
+      authorName: authorId,
+      content: event.text ?? "",
+      channelId: event.channel,
+      ...(event.thread_ts !== undefined && { threadId: event.thread_ts }),
+      ...(channelName !== undefined && { channelName }),
+      ...(event.team !== undefined && { guildId: event.team }),
+      attachments: (event.files ?? []).map((f) => ({
+        url: f.url_private ?? "",
+        filename: f.name ?? "unnamed",
+        ...(f.mimetype !== undefined && { contentType: f.mimetype }),
+        ...(f.size !== undefined && { size: f.size }),
+      })),
+      timestamp: new Date(Number(event.ts.split(".")[0]) * 1000),
+      _native: event,
+    };
+  }
+}

--- a/src/adapters/slack/index.ts
+++ b/src/adapters/slack/index.ts
@@ -249,16 +249,26 @@ export class SlackAdapter implements PlatformAdapter {
   // eslint-disable-next-line @typescript-eslint/require-await
   async createThread(msg: InboundMessage, _name: string): Promise<ResponseTarget> {
     // Slack threads are implicit: post with `thread_ts` set to the parent
-    // message's ts and the reply lands in that thread. Same pattern as
-    // Mattermost's rootId. The "thread name" parameter is irrelevant on
-    // Slack (no thread titles) — we mirror Mattermost's behaviour of
-    // returning a target keyed on the original message's id.
+    // message's ts and the reply lands in that thread. The "thread name"
+    // parameter is irrelevant on Slack (no thread titles).
+    //
+    // Echo cortex#233 round-2: `thread_ts` is a Slack message timestamp
+    // (`1700000000.123456`), NEVER a channel id (`C...`/`G...`). The
+    // legitimate sources are, in order:
+    //   1. `_native.thread_ts` — message arrived inside a thread
+    //   2. `_native.ts`         — root of a new thread (this message)
+    //   3. `msg.threadId`       — already-translated thread id
+    // If none of these are available we cannot synthesise a thread root;
+    // return `threadId: undefined` so the caller posts top-level. (The
+    // old fallback used `msg.channelId`, which `chat.postMessage`
+    // silently treated as "no thread" — same effect, but masked the
+    // bug.)
     const ev = msg._native as SlackInboundEvent | undefined;
-    const threadTs = ev?.thread_ts ?? ev?.ts ?? msg.threadId ?? msg.channelId;
+    const threadTs = ev?.thread_ts ?? ev?.ts ?? msg.threadId;
     return {
       instanceId: this.instanceId,
       channelId: msg.channelId,
-      threadId: threadTs,
+      ...(threadTs !== undefined && { threadId: threadTs }),
     };
   }
 

--- a/src/adapters/slack/index.ts
+++ b/src/adapters/slack/index.ts
@@ -27,7 +27,7 @@ import type { SurfaceAdapter } from "../../bus/surface-router";
 import type { PayloadFilter } from "../../bus/payload-filter";
 import { resolveRole } from "../discord/role-resolver";
 import { formatEnvelopeAsMarkdown } from "../envelope-renderer";
-import { RealSlackClient, type SlackClient, type SlackInboundEvent } from "./client";
+import { RealSlackClient, type SlackClient, type SlackInboundEvent, type SlackBotIdentity } from "./client";
 
 /**
  * Cortex-deployment-level wiring passed alongside the agent + presence
@@ -74,8 +74,15 @@ export class SlackAdapter implements PlatformAdapter {
   private readonly presence: SlackPresence;
   private readonly infra: SlackAdapterInfra;
   private readonly client: SlackClient;
-  /** Resolved bot user id, fetched on first `start()`. Used for self-loop guards. */
-  private botUserId: string | null = null;
+  /**
+   * Resolved bot identity, fetched in `start()` BEFORE the socket opens
+   * (Echo cortex#233 round-1 TOCTOU fix). `userId` is the `U…` carried
+   * on normal messages; `botId` is the `B…` carried on `bot_message`
+   * subtype events. The self-loop guard checks BOTH so a `chat.postMessage`
+   * that round-trips through Slack as a `bot_message` cannot echo
+   * (Echo cortex#233 round-2 N1).
+   */
+  private botIdentity: SlackBotIdentity | null = null;
   /** Operator-explicit + adapter-side anti-self-loop set. */
   private readonly trustedBotIds: ReadonlySet<string>;
   /**
@@ -117,16 +124,15 @@ export class SlackAdapter implements PlatformAdapter {
 
   async start(onMessage: (msg: InboundMessage) => Promise<void>): Promise<void> {
     // Echo cortex#233 (review #2): close the self-loop TOCTOU window by
-    // resolving `botUserId` BEFORE opening the Socket Mode connection.
-    // `auth.test` uses the bot token (xoxb-) — it does NOT need a live
-    // Socket Mode session. If we fetched the id after `client.start()`,
-    // any inbound event arriving in the millisecond gap between
-    // socket-connected and auth.test-resolved would pass through
-    // `translateEvent` with `botUserId === null`, silently failing-open
-    // on the self-loop guard. Fail-closed: if `getBotUserId()` rejects,
-    // abort startup rather than open a socket whose self-echo will be
-    // dispatched as a real message.
-    this.botUserId = await this.client.getBotUserId();
+    // resolving the bot identity BEFORE opening the Socket Mode
+    // connection. `auth.test` uses the bot token (xoxb-) — it does NOT
+    // need a live Socket Mode session. Fetching identity after
+    // `client.start()` opens a ~one-round-trip gap where inbound events
+    // would pass through `translateEvent` with the cache null, silently
+    // failing-open on the self-loop guard. Fail-closed: if
+    // `getBotIdentity()` rejects, abort startup rather than open a
+    // socket whose self-echo will be dispatched as a real message.
+    this.botIdentity = await this.client.getBotIdentity();
     await this.client.start({
       onEvent: async (event) => {
         const msg = this.translateEvent(event);
@@ -138,16 +144,23 @@ export class SlackAdapter implements PlatformAdapter {
 
   async stop(): Promise<void> {
     await this.client.stop();
-    // Drop the cached bot id so a subsequent `start()` re-fetches —
+    // Drop the cached bot identity so a subsequent `start()` re-fetches —
     // guards against a token swap between sessions.
-    this.botUserId = null;
+    this.botIdentity = null;
+    // Echo cortex#233 round-2 N4: clear the dedup ring so a reused
+    // adapter instance doesn't carry over `ts` values from a prior run.
+    // For long-lived processes this is academic (the cap bounds memory),
+    // but for hot-restart and test-fixture reuse it prevents stale
+    // dedup decisions that would silently drop legitimate messages.
+    this.seenTs.clear();
+    this.seenTsOrder.length = 0;
   }
 
   async getPlatformUserId(): Promise<string> {
-    if (this.botUserId) return this.botUserId;
-    const id = await this.client.getBotUserId();
-    this.botUserId = id;
-    return id;
+    if (this.botIdentity) return this.botIdentity.userId;
+    const identity = await this.client.getBotIdentity();
+    this.botIdentity = identity;
+    return identity.userId;
   }
 
   // eslint-disable-next-line @typescript-eslint/require-await
@@ -162,7 +175,12 @@ export class SlackAdapter implements PlatformAdapter {
 
   resolveAccess(msg: InboundMessage): AccessDecision {
     // Self-loop guard: never act on messages authored by this bot.
-    if (this.botUserId && msg.authorId === this.botUserId) {
+    // Check both the user id and the bot id — `chat.postMessage` from
+    // this bot can round-trip as a `bot_message` event where
+    // `authorId === botId`, not `botUserId` (Echo cortex#233 round-2 N1).
+    const isSelfUser = this.botIdentity?.userId === msg.authorId;
+    const isSelfBot = this.botIdentity?.botId !== undefined && this.botIdentity.botId === msg.authorId;
+    if (this.botIdentity && (isSelfUser || isSelfBot)) {
       return {
         allowed: false,
         features: { chat: false, async: false, team: false },
@@ -362,10 +380,14 @@ export class SlackAdapter implements PlatformAdapter {
       }
     }
 
-    // Drop self-authored messages at the source — both via user id
-    // (when we know our own id) and via the bot_id-shaped subtype path
-    // (when Slack doesn't include `user`).
-    if (this.botUserId && event.user === this.botUserId) return null;
+    // Self-loop drop at the source. Echo cortex#233 round-2 N1:
+    // `auth.test` exposes BOTH `user_id` (`U…`) and `bot_id` (`B…`);
+    // Slack delivers self-echoed `chat.postMessage` calls as either
+    // shape depending on subtype. Match both.
+    if (this.botIdentity) {
+      if (event.user === this.botIdentity.userId) return null;
+      if (event.bot_id !== undefined && event.bot_id === this.botIdentity.botId) return null;
+    }
 
     // Subtype gate: accept only "real" messages and trusted bot
     // messages. System notices like `channel_join`, `channel_leave`,
@@ -374,9 +396,15 @@ export class SlackAdapter implements PlatformAdapter {
       return null;
     }
     if (event.subtype === "bot_message") {
-      // bot_message events authenticate via `bot_id` instead of `user`.
-      // Require the operator to opt the bot in via `trustedBotIds`.
-      const author = event.user ?? event.bot_id ?? "";
+      // bot_message events authenticate via `bot_id` (`B…`) — NOT the
+      // `user_id` (`U…`) shape carried on normal messages. Echo
+      // cortex#233 round-2 N2: the schema doc previously said "user
+      // ids (`U…`)" while the runtime checked `event.user ?? event.bot_id`,
+      // which silently never matched the `B…` shape Slack actually
+      // delivers for bot_message events. Match `event.bot_id`
+      // explicitly; operators populate `trustedBotIds` with `B…`
+      // values (schema doc updated to reflect this).
+      const author = event.bot_id ?? "";
       if (!author || !this.trustedBotIds.has(author)) return null;
     }
 

--- a/src/bus/__tests__/network-resolver.test.ts
+++ b/src/bus/__tests__/network-resolver.test.ts
@@ -27,6 +27,7 @@ function makeNetwork(id: string, overrides: Partial<NetworkFile> = {}): NetworkF
     },
     discord: [],
     mattermost: [],
+    slack: [],
     github: { repos: [], webhookSecret: "", iterationLabel: "iteration", agentDetection: { commitTrailers: [], branchPatterns: [], commentPatterns: [] } },
     ...overrides,
   };
@@ -37,6 +38,7 @@ function makeConfig(networks: NetworkFile[]): BotConfig {
     agent: { name: "test", displayName: "Test" },
     discord: networks.flatMap(n => n.discord),
     mattermost: networks.flatMap(n => n.mattermost),
+    slack: networks.flatMap(n => n.slack),
     claude: {
       timeoutMs: 120000,
       asyncTimeoutMs: 900000,

--- a/src/common/agents/__tests__/presence-binding.test.ts
+++ b/src/common/agents/__tests__/presence-binding.test.ts
@@ -174,15 +174,18 @@ describe("PresenceBinding — construction", () => {
   });
 
   test("UnsupportedPlatformError carries the offending platform and known list", () => {
-    const adapter = new FakeAdapter({ platform: "slack" });
+    // Pick a platform name that is NOT in the `Platform` union — `mock` is
+    // the standing placeholder used by the test adapter (was `slack`
+    // before the Slack adapter landed and `slack` joined the union).
+    const adapter = new FakeAdapter({ platform: "mock" });
     try {
       new PresenceBinding("luna", adapter, resolver);
       throw new Error("should have thrown");
     } catch (err) {
       expect(err).toBeInstanceOf(UnsupportedPlatformError);
       const e = err as UnsupportedPlatformError;
-      expect(e.platform).toBe("slack");
-      expect(e.knownPlatforms).toEqual(["discord", "mattermost"]);
+      expect(e.platform).toBe("mock");
+      expect(e.knownPlatforms).toEqual(["discord", "mattermost", "slack"]);
     }
   });
 });

--- a/src/common/agents/presence-binding.ts
+++ b/src/common/agents/presence-binding.ts
@@ -64,6 +64,7 @@ import { type Platform, type TrustResolver } from "./trust-resolver";
 const KNOWN_PLATFORMS = {
   discord: true,
   mattermost: true,
+  slack: true,
 } as const satisfies Record<Platform, true>;
 
 const KNOWN_PLATFORM_LIST: readonly Platform[] = Object.keys(KNOWN_PLATFORMS) as Platform[];

--- a/src/common/agents/trust-resolver.ts
+++ b/src/common/agents/trust-resolver.ts
@@ -73,7 +73,7 @@ import { AgentNotFoundError, AgentRegistry } from "./registry";
  * — adding a new platform requires adding the value here AND a presence-block
  * variant in `cortex-config.ts`.
  */
-export type Platform = "discord" | "mattermost";
+export type Platform = "discord" | "mattermost" | "slack";
 
 /** A `(platform, platformId)` pair that uniquely identifies a connected presence. */
 export interface PlatformIdentity {

--- a/src/common/config/__tests__/watcher.test.ts
+++ b/src/common/config/__tests__/watcher.test.ts
@@ -16,6 +16,7 @@ const TEST_CONFIG: BotConfig = {
   },
   discord: [],
   mattermost: [],
+  slack: [],
   claude: {
     timeoutMs: 120_000,
     asyncTimeoutMs: 900_000,

--- a/src/common/config/loader.ts
+++ b/src/common/config/loader.ts
@@ -18,6 +18,7 @@ import {
   type DiscordPresence,
   type MattermostPresence,
   type Policy,
+  type SlackPresence,
   type StackConfig,
 } from "../types/cortex-config";
 
@@ -290,6 +291,9 @@ function loadCortexShape(
     ...(cortexConfig.operator.mattermostId !== undefined && {
       operatorMattermostId: cortexConfig.operator.mattermostId,
     }),
+    ...(cortexConfig.operator.slackId !== undefined && {
+      operatorSlackId: cortexConfig.operator.slackId,
+    }),
     dataResidency: cortexConfig.operator.dataResidency,
     personaFile: firstAgent.persona,
   };
@@ -299,6 +303,7 @@ function loadCortexShape(
   // convention so `system.adapter.*` envelope ids stay stable.
   const discord = flattenDiscordPresences(cortexConfig.agents);
   const mattermost = flattenMattermostPresences(cortexConfig.agents);
+  const slack = flattenSlackPresences(cortexConfig.agents);
 
   // Build the merged BotConfig-shaped object. Networks behave the same
   // way they do in the legacy path; renderers + nats + the *Config blocks
@@ -307,6 +312,7 @@ function loadCortexShape(
     agent: synthesizedAgent,
     discord,
     mattermost,
+    slack,
     networks,
     networksDir: cortexConfig.networksDir,
     renderers: cortexConfig.renderers,
@@ -360,6 +366,22 @@ function flattenMattermostPresences(agents: readonly Agent[]) {
     const p = a.presence.mattermost;
     if (!p) continue;
     out.push({ ...p, instanceId: `${a.id}-mattermost` });
+  }
+  return out;
+}
+
+/**
+ * Convert each agent's optional Slack presence into a flat BotConfig
+ * slack entry. Mirror of `flattenDiscordPresences` /
+ * `flattenMattermostPresences` — empty when no agent declares a
+ * `presence.slack` block.
+ */
+function flattenSlackPresences(agents: readonly Agent[]) {
+  const out: (SlackPresence & { instanceId: string })[] = [];
+  for (const a of agents) {
+    const p = a.presence.slack;
+    if (!p) continue;
+    out.push({ ...p, instanceId: `${a.id}-slack` });
   }
   return out;
 }

--- a/src/common/types/config.ts
+++ b/src/common/types/config.ts
@@ -208,6 +208,38 @@ export const MattermostInstanceSchema = z.object({
 
 export type MattermostInstance = z.infer<typeof MattermostInstanceSchema>;
 
+/**
+ * Slack instance (legacy BotConfig shape). Mirror of
+ * `SlackPresenceSchema` in `./cortex-config.ts` — `flattenSlackPresences`
+ * in `src/common/config/loader.ts` threads cortex.yaml's
+ * `agents[].presence.slack` blocks through to entries of this shape so
+ * the boot path in `src/cortex.ts` can iterate `config.slack` uniformly
+ * with `config.discord` and `config.mattermost`.
+ *
+ * See `SlackPresenceSchema` for the canonical field docstrings.
+ */
+export const SlackInstanceSchema = z.object({
+  /** Unique instance ID. Auto-generated if not provided. */
+  instanceId: z.string().optional(),
+  /** Whether this instance is active. Default: true. */
+  enabled: z.boolean().default(true),
+  botToken: z.string().regex(/^xoxb-/),
+  appToken: z.string().regex(/^xapp-/),
+  workspaceId: z.coerce.string().regex(/^T[A-Z0-9]+$/),
+  channels: z.array(z.object({
+    id: z.string().regex(/^[CG][A-Z0-9]+$/),
+    name: z.string().min(1),
+  })).default([]),
+  allowedUserIds: z.array(z.string()).default([]),
+  trustedBotIds: z.array(z.coerce.string()).default([]),
+  roles: z.array(RoleSchema).default([]),
+  defaultRole: z.string().default("allow-all"),
+  surfaceSubjects: z.array(z.string().min(1)).default([]),
+  surfaceFallbackChannelId: z.coerce.string().optional(),
+});
+
+export type SlackInstance = z.infer<typeof SlackInstanceSchema>;
+
 // =============================================================================
 // Preprocessing: upgrade legacy flat format → instance arrays
 // =============================================================================
@@ -295,11 +327,13 @@ export const NetworkFileSchema = z.object({
   cloud: NetworkCloudSchema.optional(),
   discord: z.preprocess(normalizeToArray, z.array(DiscordInstanceSchema)).default([]),
   mattermost: z.preprocess(normalizeToArray, z.array(MattermostInstanceSchema)).default([]),
+  slack: z.preprocess(normalizeToArray, z.array(SlackInstanceSchema)).default([]),
   github: NetworkGithubSchema,
   claude: NetworkClaudeSchema.optional(),
   operator: z.object({
     operatorDiscordId: z.string().optional(),
     operatorMattermostId: z.string().optional(),
+    operatorSlackId: z.string().optional(),
   }).optional(),
 });
 
@@ -321,6 +355,8 @@ export const BotConfigSchema = z.object({
     operatorDiscordId: z.string().optional(),
     /** Operator's Mattermost user ID — receives DM notifications when others talk to the bot */
     operatorMattermostId: z.string().optional(),
+    /** Operator's Slack user ID (`U...`) — receives DM notifications when others talk to the bot */
+    operatorSlackId: z.string().optional(),
     /** Operator data residency stamped into `sovereignty.data_residency` on emitted
      *  envelopes (system.*, dispatch.task.*, cc.*). ISO-3166 country code; defaults
      *  to "NZ" when omitted. Operators in AU/EU/US/etc. set this to match their
@@ -338,6 +374,16 @@ export const BotConfigSchema = z.object({
   mattermost: z.preprocess(
     normalizeToArray,
     z.array(MattermostInstanceSchema).default([]),
+  ),
+
+  /**
+   * Slack instances — synthesized from `agents[].presence.slack` by the
+   * cortex.yaml loader. Empty by default so legacy bot.yaml deployments
+   * (which never declared Slack) keep parsing unchanged.
+   */
+  slack: z.preprocess(
+    normalizeToArray,
+    z.array(SlackInstanceSchema).default([]),
   ),
 
   claude: z.object({
@@ -624,6 +670,10 @@ export function scopeConfigToMattermostInstance(config: BotConfig, instance: Mat
   return { ...config, mattermost: [instance] };
 }
 
+export function scopeConfigToSlackInstance(config: BotConfig, instance: SlackInstance): BotConfig {
+  return { ...config, slack: [instance] };
+}
+
 /**
  * Get the first Discord instance config (for backward-compat code that
  * expects `config.discord.*` as a flat object). Returns undefined if no instances.
@@ -634,6 +684,10 @@ export function getFirstDiscordInstance(config: BotConfig): DiscordInstance | un
 
 export function getFirstMattermostInstance(config: BotConfig): MattermostInstance | undefined {
   return config.mattermost[0];
+}
+
+export function getFirstSlackInstance(config: BotConfig): SlackInstance | undefined {
+  return config.slack[0];
 }
 
 /**

--- a/src/common/types/cortex-config.ts
+++ b/src/common/types/cortex-config.ts
@@ -111,6 +111,8 @@ export const OperatorSchema = z.object({
   discordId: z.string().optional(),
   /** Operator's Mattermost user id — same purpose, Mattermost-side. */
   mattermostId: z.string().optional(),
+  /** Operator's Slack user id (`U...`) — same purpose, Slack-side. */
+  slackId: z.string().optional(),
   /**
    * Data residency stamped into `sovereignty.data_residency` on emitted
    * envelopes. ISO-3166-1 alpha-2 country code (two uppercase ASCII letters).
@@ -272,6 +274,99 @@ export const MattermostPresenceSchema = z.object({
 export type MattermostPresence = z.infer<typeof MattermostPresenceSchema>;
 
 /**
+ * Slack presence — an agent's identity in a Slack workspace. Mirrors the
+ * Discord/Mattermost presence shape: tokens + workspace id + channels +
+ * trusted user/bot ids + platform-side role allowlists.
+ *
+ * Transport choice: Socket Mode (`xapp-` app-level token paired with the
+ * `xoxb-` bot token). Socket Mode keeps cortex behind NAT without needing a
+ * public webhook URL — the same fit as Mattermost's outgoing-webhook
+ * polling model and unlike Discord's gateway-with-public-bot path. HTTP /
+ * Events API mode is deferred until a deployment actually needs it.
+ *
+ * Architecture §9.3 coupling rules: no `persona` or `roles` overrides at
+ * this layer — those live on the parent agent. `roles` here is the
+ * platform-side allowlist that maps the agent's cortex-wide capability
+ * set onto Slack user ids.
+ */
+export const SlackPresenceSchema = z.object({
+  /** Whether this presence is active. Default: true. */
+  enabled: z.boolean().default(true),
+  /**
+   * Bot user OAuth token (`xoxb-...`). Required. Used by the Web API
+   * client for `chat.postMessage`, `conversations.replies`, etc.
+   */
+  botToken: z.string().regex(
+    /^xoxb-/,
+    "slack.botToken must be a bot user OAuth token (xoxb-...)",
+  ),
+  /**
+   * App-level token (`xapp-...`) with `connections:write`. Required for
+   * Socket Mode — the adapter opens a WebSocket connection to Slack using
+   * this token. Distinct from `botToken`: `xoxb-` posts as the bot,
+   * `xapp-` opens the events stream.
+   */
+  appToken: z.string().regex(
+    /^xapp-/,
+    "slack.appToken must be an app-level token (xapp-...)",
+  ),
+  /**
+   * Slack workspace (team) id, `T...`. Stamped into the inbound message's
+   * `guildId` field so network resolution and trust paths can disambiguate
+   * across workspaces the same way they do across Discord guilds.
+   */
+  workspaceId: z.coerce.string().regex(
+    /^T[A-Z0-9]+$/,
+    "slack.workspaceId must be a Slack team id (T...)",
+  ),
+  /**
+   * Channels the adapter listens on / posts to. `id` is the canonical
+   * `C...` channel id used by Slack APIs; `name` is the human-readable
+   * label (no leading `#`) carried into `InboundMessage.channelName` for
+   * routing.
+   */
+  channels: z.array(z.object({
+    id: z.string().regex(
+      /^[CG][A-Z0-9]+$/,
+      "slack channel id must be a Slack channel/group id (C... or G...)",
+    ),
+    name: z.string().min(1),
+  })).default([]),
+  /**
+   * Slack user ids (`U...`) allowed to trigger the bot. Empty = allow all
+   * (subject to the platform-side `roles` allowlist below). Mirrors
+   * `MattermostPresenceSchema.allowedUsers`.
+   */
+  allowedUserIds: z.array(z.string()).default([]),
+  /**
+   * Operator-set Slack bot user ids (`U...`) of peer bots permitted to
+   * trigger this presence. Mirrors `DiscordPresenceSchema.trustedBotIds`
+   * — same cross-process bridge semantics. The bot's own user id is
+   * never allowed regardless of this list (anti-self-loop guard in
+   * `SlackAdapter`).
+   */
+  trustedBotIds: z.array(z.coerce.string()).default([]),
+  /** Platform-side role config (see DiscordPresenceSchema.roles). */
+  roles: z.array(RoleSchema).default([]),
+  defaultRole: z.string().default("allow-all"),
+  /**
+   * MIG-3b mirror: NATS subject patterns this Slack adapter renders to
+   * chat. Empty/undefined → adapter never matches in the surface-router.
+   * See `DiscordPresenceSchema.surfaceSubjects` for the canonical
+   * docstring and IoAW examples.
+   */
+  surfaceSubjects: z.array(z.string().min(1)).default([]),
+  /**
+   * MIG-3b mirror: Slack channel id where `renderEnvelope` posts
+   * inbound bus envelopes that don't carry their own channel routing.
+   * Unset → drop-with-warning per the Discord/Mattermost pattern.
+   */
+  surfaceFallbackChannelId: z.coerce.string().optional(),
+});
+
+export type SlackPresence = z.infer<typeof SlackPresenceSchema>;
+
+/**
  * An agent's presence map — keyed by platform. Architecture §9.1 puts
  * presence under the parent agent, not the other way around. Adding a new
  * platform (Slack, etc.) adds a new optional key here at the time the
@@ -280,6 +375,7 @@ export type MattermostPresence = z.infer<typeof MattermostPresenceSchema>;
 export const PresenceSchema = z.object({
   discord: DiscordPresenceSchema.optional(),
   mattermost: MattermostPresenceSchema.optional(),
+  slack: SlackPresenceSchema.optional(),
 });
 
 export type Presence = z.infer<typeof PresenceSchema>;

--- a/src/common/types/cortex-config.ts
+++ b/src/common/types/cortex-config.ts
@@ -339,11 +339,21 @@ export const SlackPresenceSchema = z.object({
    */
   allowedUserIds: z.array(z.string()).default([]),
   /**
-   * Operator-set Slack bot user ids (`U...`) of peer bots permitted to
+   * Operator-set Slack **bot ids** (`B…`) of peer bots permitted to
    * trigger this presence. Mirrors `DiscordPresenceSchema.trustedBotIds`
-   * — same cross-process bridge semantics. The bot's own user id is
-   * never allowed regardless of this list (anti-self-loop guard in
-   * `SlackAdapter`).
+   * — same cross-process bridge semantics.
+   *
+   * Echo cortex#233 round-2 N2: this field used to say "user ids (`U…`)"
+   * but Slack delivers peer-bot messages as the `bot_message` subtype
+   * with author identified by `event.bot_id` (`B…`), NOT `event.user`.
+   * Operators populating `U…` values would silently never see their
+   * trust take effect. Always use the `B…` value Slack reports for
+   * the peer bot — visible in the peer bot's `auth.test.bot_id`, or
+   * on the peer's app manifest under "Bot User".
+   *
+   * The bot's own ids (`auth.test.user_id` AND `auth.test.bot_id`)
+   * are never allowed regardless of this list (anti-self-loop guard
+   * in `SlackAdapter`).
    */
   trustedBotIds: z.array(z.coerce.string()).default([]),
   /** Platform-side role config (see DiscordPresenceSchema.roles). */

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -52,10 +52,12 @@ import type {
   DiscordPresence,
   MattermostPresence,
   Policy,
+  SlackPresence,
   StackConfig,
 } from "./common/types/cortex-config";
 import { policyEngineFromConfig } from "./common/policy/factory";
 import { MattermostAdapter } from "./adapters/mattermost";
+import { SlackAdapter } from "./adapters/slack";
 import type { PlatformAdapter } from "./adapters/types";
 
 import { createDispatchListener, type DispatchListener } from "./runner/dispatch-listener";
@@ -601,10 +603,14 @@ export async function startCortex(
   // `presence.mattermost.apiToken` for Mattermost.
   const agentByDiscordToken = new Map<string, Agent>();
   const agentByMattermostApiToken = new Map<string, Agent>();
+  const agentBySlackBotToken = new Map<string, Agent>();
   for (const a of mergedAgents) {
     if (a.presence.discord?.token) agentByDiscordToken.set(a.presence.discord.token, a);
     if (a.presence.mattermost?.apiToken) {
       agentByMattermostApiToken.set(a.presence.mattermost.apiToken, a);
+    }
+    if (a.presence.slack?.botToken) {
+      agentBySlackBotToken.set(a.presence.slack.botToken, a);
     }
   }
 
@@ -885,6 +891,89 @@ export async function startCortex(
     } catch (err) {
       console.error(`cortex: mattermost adapter ${instanceId} failed to start:`, err instanceof Error ? err.message : err);
     }
+  }
+
+  // F-slack: Slack adapter boot — sibling to Discord + Mattermost above.
+  // Same shape: iterate `config.slack` (synthesized from `agents[].presence.slack`
+  // by `flattenSlackPresences` in the loader), build a `SlackPresence`, look up
+  // the declaring agent by bot token, instantiate the adapter, register its
+  // surface-router face, and start it. Errors during start are logged
+  // per-instance so one bad workspace doesn't block the rest of the boot.
+  for (const instance of config.slack) {
+    if (!instance.enabled) {
+      console.log(`cortex: slack instance ${instance.instanceId ?? instance.workspaceId} disabled — skipping`);
+      continue;
+    }
+    const slackIndex = config.slack.indexOf(instance);
+    const instanceId = instance.instanceId ?? (config.slack.length > 1
+      ? `${config.agent.name}-slack-${slackIndex}`
+      : `${config.agent.name}-slack`);
+    // Build the `SlackPresence` from the legacy `SlackInstance` shape.
+    // Schema defaults have already been applied by `BotConfigSchema` —
+    // this is a structural map, not a parse.
+    const presence: SlackPresence = {
+      enabled: instance.enabled,
+      botToken: instance.botToken,
+      appToken: instance.appToken,
+      workspaceId: instance.workspaceId,
+      channels: instance.channels,
+      allowedUserIds: instance.allowedUserIds,
+      trustedBotIds: instance.trustedBotIds,
+      roles: instance.roles,
+      defaultRole: instance.defaultRole,
+      surfaceSubjects: instance.surfaceSubjects,
+      ...(instance.surfaceFallbackChannelId !== undefined && {
+        surfaceFallbackChannelId: instance.surfaceFallbackChannelId,
+      }),
+    };
+    const matchedAgent = agentBySlackBotToken.get(instance.botToken);
+    const agent: Agent = matchedAgent ?? {
+      id: config.agent.name,
+      displayName: config.agent.displayName,
+      persona: "(deferred-mig-7.2e)",
+      roles: [],
+      trust: [],
+      presence: { slack: presence },
+    };
+    try {
+      const adapter = new SlackAdapter(
+        agent,
+        presence,
+        {
+          instanceId,
+          operator: {
+            ...(config.agent.operatorSlackId !== undefined && { slackId: config.agent.operatorSlackId }),
+          },
+          surfaceSubjects: presence.surfaceSubjects,
+          ...(presence.surfaceFallbackChannelId !== undefined && {
+            surfaceFallbackChannelId: presence.surfaceFallbackChannelId,
+          }),
+          trustedBotIds: new Set(instance.trustedBotIds),
+        },
+      );
+      router.register(adapter.surfaceConfig);
+      await adapter.start((msg) => dispatchHandler.handleMessage(adapter, msg));
+      adapters.push(adapter);
+      // Best-effort trust-resolver registration matches the Discord pattern.
+      if (agentRegistry.tryGetById(agent.id)) {
+        try {
+          const botUserId = await adapter.getPlatformUserId();
+          trustResolver.register("slack", botUserId, agent.id);
+        } catch (err) {
+          console.error(
+            `cortex: trust-resolver register for "${agent.id}" (slack) failed (non-fatal):`,
+            err instanceof Error ? err.message : err,
+          );
+        }
+      }
+      console.log(`cortex: slack adapter started (instance: ${instanceId}, workspace: ${instance.workspaceId}, ${instance.channels.length} channel(s))`);
+    } catch (err) {
+      console.error(`cortex: slack adapter ${instanceId} failed to start:`, err instanceof Error ? err.message : err);
+    }
+  }
+
+  if (config.slack.length === 0) {
+    console.log("cortex: no slack instances configured");
   }
 
   // MIG-7.2d: non-agent-bound renderers (dashboard, pagerduty, …).


### PR DESCRIPTION
## Summary

Adds a Slack platform adapter as a sibling to Discord + Mattermost so a cortex agent can declare `presence.slack` in `cortex.yaml` and show up in a Slack workspace. Closes #231.

Motivating use case: the `andreas/work` stack (config drafted at `~/.config/cortex/cortex.work.yaml.draft`) needs a Slack presence for its work-side Luna instance. The work-stack runbook explicitly defers Slack wiring until this adapter lands; after merge, the operator pastes a `presence.slack: { botToken, appToken, workspaceId, ... }` block and restarts.

## Scope

**Schema**
- `SlackPresenceSchema` in `src/common/types/cortex-config.ts` mirroring the Discord + Mattermost presence shapes: `botToken` (xoxb-), `appToken` (xapp-), `workspaceId` (T...), `channels[]` (id + name), `allowedUserIds`, `trustedBotIds`, `roles[]`, `defaultRole`, `surfaceSubjects[]`, `surfaceFallbackChannelId`.
- `SlackInstanceSchema` in `src/common/types/config.ts` (legacy BotConfig shape) + `slack: []` added to `BotConfigSchema` + `NetworkFileSchema`.
- `slack?: SlackPresenceSchema` added to `PresenceSchema`.
- `operator.slackId` added to `OperatorSchema`; `operatorSlackId` added to BotConfig agent + NetworkFile operator blocks.

**Adapter** (`src/adapters/slack/`)
- `client.ts` — pluggable `SlackClient` surface + `RealSlackClient` wrapping `@slack/socket-mode` (inbound) + `@slack/web-api` (outbound). Acks Socket Mode events as the first action inside the listener so a slow downstream pipeline cannot trigger redelivery.
- `index.ts` — `SlackAdapter` implementing `PlatformAdapter`. Subtype filtering (drops `channel_join` et al; conditionally accepts `bot_message` only when the bot id is in `trustedBotIds`), self-loop guard via cached bot user id, `allowedUserIds` gate, role-based access via shared `resolveRole`, thread-aware `postResponse`, surface-router `renderEnvelope` mirroring the Mattermost pattern.
- `__tests__/` — 43 unit tests across schema + adapter (construction, lifecycle, event translation, resolveAccess incl. self-loop + allowedUserIds, postResponse incl. file-attachment warning, sendProgress idempotence, createThread, notifyOperator, surface envelope render happy + failure paths).

**Boot wiring**
- `src/cortex.ts` iterates `config.slack` after Discord + Mattermost, builds the `SlackPresence`, looks up the declaring agent by bot token, instantiates `SlackAdapter`, registers the surface-router face, starts, and registers the bot user id with the `TrustResolver`. Per-instance error handling matches the existing pattern.

**Loader**
- `flattenSlackPresences` in `src/common/config/loader.ts` synthesizes a legacy `slack[]` array from each agent's `presence.slack`.

**Trust resolver**
- `Platform` union extended to include `"slack"`; `KNOWN_PLATFORMS` literal in `presence-binding.ts` extended in step.

## Dependency choice

`@slack/web-api` + `@slack/socket-mode` (preferred over `@slack/bolt` for the slimmer footprint — we don't need bolt's framework layer; Socket Mode + WebClient is exactly the operations the adapter performs).

## Transport choice

Socket Mode (`xapp-` app-level token + `xoxb-` bot token). No public webhook URL needed — fits cortex's single-machine deployment model. HTTP / Events API mode is deferred until a deployment needs it.

## Out of scope / v1 limitations (called out in code)

- **File uploads** — `postResponse` warns and drops attachments. `files.uploadV2` lands as a follow-up.
- **`fetchContext`** returns `[]` — thread / channel context via `conversations.replies` is a clean follow-up.
- **Display names** — `authorName` carries the Slack user id rather than resolving via `users.info`. The dispatch pipeline tolerates id-as-name.
- **Slash commands / interactive components** — out of scope; v1 is message in / message out only.

## Test plan

- [x] `bun test src/adapters/slack` — 43 pass
- [x] `bun test` — 3002 pass, 0 fail (1 skip)
- [x] `bunx tsc --noEmit` — clean for all touched files (pre-existing `signing.ts` ArrayBuffer errors in `src/services/network-registry/` are unrelated and untouched per the surgical-fix rule)
- [x] `bun run lint:errors` — clean
- [ ] Manual: paste `presence.slack` block into `cortex.work.yaml`, restart cortex, verify Luna comes up on Slack (runbook-driven, post-merge)

## Definition of done

After merge, the operator pastes a `presence.slack` block into `cortex.work.yaml` (per the work-stack runbook) and restarts the work stack to bring Luna live on Slack. No further work-stack file edits required from this PR.