### PR TITLE
fix(ops): derive PID file from --config to support multi-instance (closes cortex#246)

### DIFF
--- a/src/__tests__/cortex.test.ts
+++ b/src/__tests__/cortex.test.ts
@@ -29,7 +29,7 @@ import { join } from "path";
 import { tmpdir } from "os";
 import { BotConfigSchema, type BotConfig } from "../common/types/config";
 import type { Agent } from "../common/types/cortex-config";
-import { runDryRun, startCortex } from "../cortex";
+import { pidFileFor, runDryRun, startCortex } from "../cortex";
 import type { Envelope } from "../bus/myelin/envelope-validator";
 import type { EnvelopeHandler, MyelinRuntime } from "../bus/myelin/runtime";
 
@@ -776,5 +776,50 @@ describe("runDryRun — config validator (cortex#88 item 2)", () => {
     expect(result.stderr).toMatch(/has no agents — config invalid/);
     expect(result.stdout).toBe("");
     rmSync(dir, { recursive: true, force: true });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// pidFileFor — multi-instance support (cortex#246)
+// ---------------------------------------------------------------------------
+
+describe("pidFileFor — per-config PID file derivation", () => {
+  const DEFAULT_CONFIG = join(process.env.HOME ?? "~", ".config", "grove", "bot.yaml");
+  const LEGACY_PID = join(process.env.HOME ?? "~", ".config", "grove", "state", "cortex.pid");
+
+  test("undefined config → legacy cortex.pid (backward compat)", () => {
+    expect(pidFileFor(undefined)).toBe(LEGACY_PID);
+  });
+
+  test("default config path → legacy cortex.pid (no behaviour change)", () => {
+    expect(pidFileFor(DEFAULT_CONFIG)).toBe(LEGACY_PID);
+  });
+
+  test("custom config in same dir → derived from basename", () => {
+    const result = pidFileFor("/Users/andreas/.config/cortex/cortex.work.yaml");
+    expect(result).toBe(join(process.env.HOME ?? "~", ".config", "grove", "state", "cortex-cortex.work.pid"));
+  });
+
+  test("two distinct custom configs → two distinct PID files", () => {
+    const a = pidFileFor("/Users/andreas/.config/cortex/cortex.work.yaml");
+    const b = pidFileFor("/Users/andreas/.config/cortex/cortex.research.yaml");
+    expect(a).not.toBe(b);
+  });
+
+  test("config with .yml extension also normalises", () => {
+    const result = pidFileFor("/tmp/foo.yml");
+    expect(result).toBe(join(process.env.HOME ?? "~", ".config", "grove", "state", "cortex-foo.pid"));
+  });
+
+  test("config path moves don't change the PID file (basename-only derivation)", () => {
+    const a = pidFileFor("/somewhere/cortex.work.yaml");
+    const b = pidFileFor("/elsewhere/cortex.work.yaml");
+    expect(a).toBe(b);
+  });
+
+  test("relative config path → same PID file as absolute (basename match)", () => {
+    const rel = pidFileFor("./cortex.work.yaml");
+    const abs = pidFileFor("/Users/andreas/.config/cortex/cortex.work.yaml");
+    expect(rel).toBe(abs);
   });
 });

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -80,6 +80,40 @@ const STATE_DIR = join(process.env.HOME ?? "~", ".config", "grove", "state");
 const PID_FILE = join(STATE_DIR, "cortex.pid");
 const DEFAULT_CONFIG = join(process.env.HOME ?? "~", ".config", "grove", "bot.yaml");
 
+/**
+ * Resolve the PID file path for a given `--config` value.
+ *
+ * Operators running multiple cortex instances on a single machine (per
+ * Phase A.5's stack-aware namespace — e.g. `andreas/research` and
+ * `andreas/work` side-by-side) need distinct PID files so the
+ * singleton check in {@link checkSingleton} only blocks duplicates of
+ * the same stack, not unrelated stacks.
+ *
+ * Resolution:
+ *   - Default config (or unspecified) → legacy `cortex.pid` (preserves
+ *     single-instance backward compat — operators on the default path
+ *     see no behaviour change).
+ *   - Custom config → `cortex-<config-basename>.pid` (derived from the
+ *     config filename without the `.yaml`/`.yml` extension). Two stacks
+ *     with different `--config` paths get different PID files.
+ *
+ * The basename derivation deliberately omits the directory portion so
+ * `~/.config/cortex/cortex.work.yaml` and `./cortex.work.yaml` resolve
+ * to the same PID file — moving a config doesn't accidentally orphan
+ * the prior PID file.
+ */
+export function pidFileFor(configPath: string | undefined): string {
+  if (configPath === undefined || configPath === DEFAULT_CONFIG) {
+    return PID_FILE;
+  }
+  const base = configPath
+    .split("/")
+    .pop()
+    ?.replace(/\.ya?ml$/i, "");
+  if (base === undefined || base.length === 0) return PID_FILE;
+  return join(STATE_DIR, `cortex-${base}.pid`);
+}
+
 /** Lifecycle handle returned by `startCortex`. Capped at 15s — components
  *  that don't drain are abandoned (logged). */
 export interface CortexHandle {
@@ -1491,22 +1525,22 @@ function getVersion(): string {
   }
 }
 
-function checkSingleton(): void {
-  if (!existsSync(PID_FILE)) return;
-  const raw = readFileSync(PID_FILE, "utf-8").trim();
+function checkSingleton(pidFile: string): void {
+  if (!existsSync(pidFile)) return;
+  const raw = readFileSync(pidFile, "utf-8").trim();
   const pid = parseInt(raw, 10);
   if (isNaN(pid)) {
-    console.error(`cortex: removing invalid PID file (contents: "${raw}")`);
-    unlinkSync(PID_FILE);
+    console.error(`cortex: removing invalid PID file (${pidFile} contents: "${raw}")`);
+    unlinkSync(pidFile);
     return;
   }
   try {
     process.kill(pid, 0);
-    console.error(`cortex: already running (PID ${pid}). Stop it first with: cortex stop`);
+    console.error(`cortex: already running (PID ${pid}, ${pidFile}). Stop it first with: cortex stop`);
     process.exit(1);
   } catch {
-    console.error(`cortex: removing stale PID file (PID ${pid} not running)`);
-    unlinkSync(PID_FILE);
+    console.error(`cortex: removing stale PID file ${pidFile} (PID ${pid} not running)`);
+    unlinkSync(pidFile);
   }
 }
 
@@ -1591,8 +1625,9 @@ if (import.meta.main) {
       }
 
       mkdirSync(STATE_DIR, { recursive: true });
-      checkSingleton();
-      writeFileSync(PID_FILE, String(process.pid));
+      const pidFile = pidFileFor(options.config);
+      checkSingleton(pidFile);
+      writeFileSync(pidFile, String(process.pid));
 
       process.on("uncaughtException", (err) => {
         console.error("cortex: uncaught exception (non-fatal):", err.message);
@@ -1620,7 +1655,7 @@ if (import.meta.main) {
 
       const shutdown = async () => {
         await handle.stop();
-        if (existsSync(PID_FILE)) unlinkSync(PID_FILE);
+        if (existsSync(pidFile)) unlinkSync(pidFile);
         // Echo round-1 N2: surface dirty shutdown to launchd / operators
         // via a non-zero exit code. `lastShutdownAbandoned` is non-empty
         // only when the 15s drain timeout fired with subsystems still in
@@ -1635,37 +1670,41 @@ if (import.meta.main) {
   program
     .command("stop")
     .description("Stop the bot")
-    .action(() => {
-      if (!existsSync(PID_FILE)) {
-        console.log("cortex: not running");
+    .option("--config <path>", "Path to bot config YAML (selects which stack to stop)", DEFAULT_CONFIG)
+    .action((options: { config: string }) => {
+      const pidFile = pidFileFor(options.config);
+      if (!existsSync(pidFile)) {
+        console.log(`cortex: not running (${pidFile})`);
         return;
       }
-      const pid = parseInt(readFileSync(PID_FILE, "utf-8").trim());
+      const pid = parseInt(readFileSync(pidFile, "utf-8").trim());
       try {
         process.kill(pid, "SIGTERM");
-        unlinkSync(PID_FILE);
-        console.log(`cortex: stopped (PID ${pid})`);
+        unlinkSync(pidFile);
+        console.log(`cortex: stopped (PID ${pid}, ${pidFile})`);
       } catch {
-        console.log(`cortex: process ${pid} not found, cleaning up`);
-        unlinkSync(PID_FILE);
+        console.log(`cortex: process ${pid} not found, cleaning up ${pidFile}`);
+        unlinkSync(pidFile);
       }
     });
 
   program
     .command("status")
     .description("Check bot status")
-    .action(() => {
-      if (!existsSync(PID_FILE)) {
-        console.log("cortex: not running");
+    .option("--config <path>", "Path to bot config YAML (selects which stack to query)", DEFAULT_CONFIG)
+    .action((options: { config: string }) => {
+      const pidFile = pidFileFor(options.config);
+      if (!existsSync(pidFile)) {
+        console.log(`cortex: not running (${pidFile})`);
         return;
       }
-      const pid = parseInt(readFileSync(PID_FILE, "utf-8").trim());
+      const pid = parseInt(readFileSync(pidFile, "utf-8").trim());
       try {
         process.kill(pid, 0);
-        console.log(`cortex: running (PID ${pid})`);
+        console.log(`cortex: running (PID ${pid}, ${pidFile})`);
       } catch {
-        console.log("cortex: stale PID file");
-        unlinkSync(PID_FILE);
+        console.log(`cortex: stale PID file ${pidFile}`);
+        unlinkSync(pidFile);
       }
     });
 

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -13,7 +13,7 @@
 
 import { Command } from "commander";
 import { existsSync, writeFileSync, readFileSync, unlinkSync, mkdirSync, readdirSync } from "fs";
-import { join, dirname } from "path";
+import { basename, join, dirname } from "path";
 import { parse as parseYaml } from "yaml";
 import type { TextChannel } from "discord.js";
 
@@ -106,11 +106,8 @@ export function pidFileFor(configPath: string | undefined): string {
   if (configPath === undefined || configPath === DEFAULT_CONFIG) {
     return PID_FILE;
   }
-  const base = configPath
-    .split("/")
-    .pop()
-    ?.replace(/\.ya?ml$/i, "");
-  if (base === undefined || base.length === 0) return PID_FILE;
+  const base = basename(configPath).replace(/\.ya?ml$/i, "");
+  if (base.length === 0) return PID_FILE;
   return join(STATE_DIR, `cortex-${base}.pid`);
 }
 


### PR DESCRIPTION
## Summary

Cortex was written assuming one instance per machine. The global \`PID_FILE\` constant blocked the Phase A.5 multi-stack-per-machine use case: trying to run \`andreas/meta-factory\` and \`andreas/work\` simultaneously hits \`checkSingleton()\` on the second start with \"already running\".

## Fix

Derive the PID file path from the \`--config\` value:

- **Default config** (or unspecified) → legacy \`cortex.pid\` (preserves backward compat — no change for existing single-instance operators).
- **Custom config** → \`cortex-<config-basename>.pid\` (derived from filename without \`.yaml\`/\`.yml\` extension).

\`stop\` and \`status\` subcommands also gain \`--config\` so operators can target a specific stack.

## Discovered

Standing up the \`andreas/work\` stack alongside \`andreas/meta-factory\` (cortex#244). The work stack's launchd plist loaded but exited immediately with \"already running\". Logs at \`~/.config/cortex/work-logs/cortex-work-bot.error.log\`.

## Test plan

- [x] Existing 19 cortex tests pass unchanged (backward compat)
- [x] 7 new tests for \`pidFileFor()\`: undefined config, default config, custom config, basename normalisation, .yml extension, path-move invariance, relative-vs-absolute equivalence
- [x] Full suite 3020/3021 green (1 skip)
- [x] tsc clean (5 pre-existing errors in src/services/network-registry/ unrelated)
- [x] lint clean

## Closes

cortex#246

🤖 Generated with [Claude Code](https://claude.com/claude-code)