### PR TITLE
docs(design): IAW A.0c — ratify review.verdict.* envelope payload contract (refs cortex#238)

### DIFF
--- a/docs/design-pi-dev-review-agent.md
+++ b/docs/design-pi-dev-review-agent.md
@@ -162,7 +162,7 @@ The three `review.verdict.*` subjects share a single payload shape. This is the 
   "github_review_id": 2459183744,
   "github_review_url": "https://github.com/the-metafactory/cortex/pull/229#pullrequestreview-2459183744",
   "submitted_at": "2026-05-16T09:51:30Z",
-  "commit_id": "abc123def456789",
+  "commit_id": "a1b2c3d4e5f6789012345678901234567890abcd",
   "findings": { "blockers": 0, "majors": 2, "nits": 3 },
   "inline_comments": 5
 }
@@ -177,7 +177,7 @@ The three `review.verdict.*` subjects share a single payload shape. This is the 
 | `reviewer` | string | GitHub login of the reviewer (e.g. `echo`). |
 | `verdict` | enum | Discriminator: `approved` \| `changes-requested` \| `commented`. MUST match the subject suffix. |
 | `summary` | string | Reviewer's one-line verdict text. Mirrors the verdict line in the reviewer's GitHub review body so the bus payload and the GitHub-side artefact stay in sync. |
-| `github_review_id` | integer | Numeric GitHub review ID. Used for GitHub API correlation (e.g. fetching inline comments, audit cross-reference). |
+| `github_review_id` | integer (int64-compatible; today's IDs are well below 2^53) | Numeric GitHub review ID. Used for GitHub API correlation (e.g. fetching inline comments, audit cross-reference). |
 | `github_review_url` | string | Direct GitHub URL to the review. For human navigation from dashboard / Discord / CLI output. |
 | `submitted_at` | string (ISO 8601) | Timestamp the reviewer submitted on GitHub. Distinct from the envelope's `timestamp`, which is the bus-publish moment. |
 | `commit_id` | string (SHA) | Commit SHA the review was conducted against. Lets consumers detect "review is stale" when subsequent commits land. |
@@ -191,6 +191,8 @@ The reviewer MUST set the verdict envelope's `correlation_id` to the **`id` of t
 **Payload-shape compatibility:** This shape deliberately mirrors `nats-review-io.ts`'s legacy `ReviewCompletedPayload` (the `mf.{network}.review.completed` shape from cortex's pre-capability-dispatch era). Workflow-side consumers (e.g. the existing `runReviewCycle` ReviewCycleIO) MUST NOT need behavioural changes when migrating from the legacy subject to the canonical `review.verdict.*` subjects — only the subject string and the `correlation_id` field are new.
 
 **Out of scope for this contract** (deliberately): retry semantics, multi-agent quorum, persistence. See `docs/design-pilot-restructure.md` §4.6 for what pilot's verdict subscriber does NOT do.
+
+**Follow-up:** `docs/design-pilot-restructure.md` §4 maturity table currently marks §4.2 as "Proposed — cortex#237 (or a companion PR to `design-pi-dev-review-agent.md`) must ratify." With this ratification merged at cortex#238, that row should flip to "Shipped — ratified at cortex#238 §4.2.1" in a follow-up pilot-spec PR.
 
 ---
 

--- a/docs/design-pi-dev-review-agent.md
+++ b/docs/design-pi-dev-review-agent.md
@@ -140,6 +140,58 @@ Same subjects, same envelopes as any cortex agent. The only difference is the so
 
 Nak reasons: `cant-do`, `wont-do`, `not-now`, `compliance-block` (unchanged per architecture §7.3).
 
+#### 4.2.1 `review.verdict.*` envelope payload — canonical contract
+
+The three `review.verdict.*` subjects share a single payload shape. This is the **canonical contract** that any review-capable agent (Echo, future reviewers) MUST emit, and any caller (pilot, dashboard, future review consumers) MAY rely on. Originating proposal: `docs/design-pilot-restructure.md` §4.2; ratified here as the authoritative spec per Wave 0 PR-A.0c (refs cortex#238).
+
+**Subjects** (one per verdict kind):
+
+- `local.{org}.review.verdict.approved`
+- `local.{org}.review.verdict.changes-requested`
+- `local.{org}.review.verdict.commented`
+
+**Envelope payload (`payload.*`):**
+
+```json
+{
+  "repo": "the-metafactory/cortex",
+  "pr": 229,
+  "reviewer": "echo",
+  "verdict": "changes-requested",
+  "summary": "verdict: blockers=0 majors=2 nits=3 — recommend: request-changes",
+  "github_review_id": 2459183744,
+  "github_review_url": "https://github.com/the-metafactory/cortex/pull/229#pullrequestreview-2459183744",
+  "submitted_at": "2026-05-16T09:51:30Z",
+  "commit_id": "abc123def456789",
+  "findings": { "blockers": 0, "majors": 2, "nits": 3 },
+  "inline_comments": 5
+}
+```
+
+**Field semantics:**
+
+| Field | Type | Semantics |
+|-------|------|-----------|
+| `repo` | string | `owner/repo` GitHub form (e.g. `the-metafactory/cortex`). |
+| `pr` | integer | PR number on the GitHub repo. |
+| `reviewer` | string | GitHub login of the reviewer (e.g. `echo`). |
+| `verdict` | enum | Discriminator: `approved` \| `changes-requested` \| `commented`. MUST match the subject suffix. |
+| `summary` | string | Reviewer's one-line verdict text. Mirrors the verdict line in the reviewer's GitHub review body so the bus payload and the GitHub-side artefact stay in sync. |
+| `github_review_id` | integer | Numeric GitHub review ID. Used for GitHub API correlation (e.g. fetching inline comments, audit cross-reference). |
+| `github_review_url` | string | Direct GitHub URL to the review. For human navigation from dashboard / Discord / CLI output. |
+| `submitted_at` | string (ISO 8601) | Timestamp the reviewer submitted on GitHub. Distinct from the envelope's `timestamp`, which is the bus-publish moment. |
+| `commit_id` | string (SHA) | Commit SHA the review was conducted against. Lets consumers detect "review is stale" when subsequent commits land. |
+| `findings` | object | Counts by severity (`blockers`, `majors`, `nits`). The machine-parsed form of the numbers in `summary`. |
+| `inline_comments` | integer | Number of inline comments posted on the PR as part of this review. |
+
+**Envelope-level requirement — `correlation_id`:**
+
+The reviewer MUST set the verdict envelope's `correlation_id` to the **`id` of the originating request envelope** (the envelope that asked for the review — typically a `dispatch.task.requested` or capability-dispatch request). Pilot's `pilot wait-for-verdict --correlation-id <uuid>` relies on this to filter unambiguously across N parallel reviews in flight on the same `review.verdict.>` subject. Without this, parallel callers cannot disambiguate which verdict belongs to which request.
+
+**Payload-shape compatibility:** This shape deliberately mirrors `nats-review-io.ts`'s legacy `ReviewCompletedPayload` (the `mf.{network}.review.completed` shape from cortex's pre-capability-dispatch era). Workflow-side consumers (e.g. the existing `runReviewCycle` ReviewCycleIO) MUST NOT need behavioural changes when migrating from the legacy subject to the canonical `review.verdict.*` subjects — only the subject string and the `correlation_id` field are new.
+
+**Out of scope for this contract** (deliberately): retry semantics, multi-agent quorum, persistence. See `docs/design-pilot-restructure.md` §4.6 for what pilot's verdict subscriber does NOT do.
+
 ---
 
 ## 5. Implementation — PAI-pi Extension (two layers)


### PR DESCRIPTION
## Summary

Wave 0 **PR-A.0c** of the pilot restructure (`docs/design-pilot-restructure.md` §6.2). Promotes the `review.verdict.*` envelope payload shape proposed in `design-pilot-restructure.md` §4.2 to **canonical contract** in the anchor doc (`docs/design-pi-dev-review-agent.md` §4.2).

This is a docs-only ratification — no behavioural change, no code. It locks the contract so Echo (cortex#237) and pilot (separate repo) can build against the same authoritative spec rather than each tracking the proposal independently.

## What lands

- New **§4.2.1** in the anchor doc, containing:
  - The three verdict subjects (`local.{org}.review.verdict.{approved,changes-requested,commented}`)
  - The full canonical `payload.*` JSON shape
  - Per-field semantics table (11 fields) — `repo`, `pr`, `reviewer`, `verdict`, `summary`, `github_review_id`, `github_review_url`, `submitted_at`, `commit_id`, `findings`, `inline_comments`
  - **Envelope-level `correlation_id` requirement** — reviewer MUST set the verdict envelope's `correlation_id` to the originating request envelope's `id`, so `pilot wait-for-verdict --correlation-id <uuid>` can disambiguate across N parallel reviews on the same `review.verdict.>` subject
  - Payload-shape compatibility note vs the legacy `nats-review-io.ts` `ReviewCompletedPayload` — workflow consumers (e.g. `runReviewCycle` ReviewCycleIO) don't need behavioural changes when migrating from `mf.{network}.review.completed` → `review.verdict.*`, only the subject + new `correlation_id` field
  - Out-of-scope pointer (retry, quorum, persistence) to `design-pilot-restructure.md` §4.6

## Option chosen — A (in-place expansion of anchor §4.2)

The brief offered Option A (expand anchor doc) or Option B (sibling doc). Picked **A** because:

- Anchor doc's existing §4.2 was a thin outbound subject table — the perfect anchor point to attach the payload contract.
- No structural content displaced; the table stays at the top, the new contract subsection (§4.2.1) hangs off it.
- Fewer docs to maintain; future readers find the spec where they're already reading about outbound contracts.

Option B would have made sense only if §4.2 already had rich structural content. It didn't.

## Citing the proposal

§4.2.1 explicitly cites `docs/design-pilot-restructure.md` §4.2 as the originating proposal and references this PR (Wave 0 PR-A.0c, refs cortex#238) as the ratification step.

## Scope discipline

- Pure docs PR. One file modified, 52 insertions.
- No code, no tests, no architecture overhaul.
- No edits to other §s of the anchor doc — even where minor improvements were noted, surfaced separately on cortex#232 rather than scope-creeping this PR.

## What I did NOT do (per brief)

- No Echo ping.
- No `pilot-review-loop`.
- Main agent runs the review loop in-session via sub-agents.

## Test plan

- [x] Docs render cleanly in GitHub markdown preview
- [x] All JSON fenced blocks parse as valid JSON
- [x] Field-semantics table aligns 1:1 with the proposed payload (no invented fields, no missing fields)
- [x] `correlation_id` rationale explicit (parallel-review disambiguation)
- [x] No code or test diffs in this PR

Refs: cortex#238, Wave 0 PR-A.0c
Originating proposal: `docs/design-pilot-restructure.md` §4.2