### PR TITLE
feat(slack): system.adapter.{disconnected,recovered} envelopes (cortex#235 r1#4)

### DIFF
--- a/src/adapters/slack/__tests__/slack-adapter.test.ts
+++ b/src/adapters/slack/__tests__/slack-adapter.test.ts
@@ -932,6 +932,28 @@ describe("SlackAdapter — system.adapter.* envelopes (cortex#235 r1#4)", () => 
     await adapter.stop();
   });
 
+  test("stop() → start() resets latches; next initial connect is silent (Echo cortex#254 r1 M2)", async () => {
+    const runtime = makeRecordingRuntime();
+    const { adapter, simulateConnect, simulateDisconnect } = makeAdapter({
+      infra: { runtime, systemEventSource: SOURCE },
+    });
+    // First session: initial connect (silent) → unclean disconnect →
+    // recovered. Two envelopes expected.
+    await adapter.start(async () => {});
+    simulateConnect();
+    simulateDisconnect({ wasClean: false });
+    simulateConnect();
+    expect(runtime.publishes).toHaveLength(2);
+    await adapter.stop();
+    // Second session: WITHOUT latch reset on stop(), the next initial
+    // connect would be classified as a "recovery" and emit a spurious
+    // `system.adapter.recovered`. Assert it stays at 2.
+    await adapter.start(async () => {});
+    simulateConnect();
+    expect(runtime.publishes).toHaveLength(2);
+    await adapter.stop();
+  });
+
   test("runtime present but systemEventSource missing → silent + one-time warning", async () => {
     const runtime = makeRecordingRuntime();
     const originalWarn = console.warn;

--- a/src/adapters/slack/__tests__/slack-adapter.test.ts
+++ b/src/adapters/slack/__tests__/slack-adapter.test.ts
@@ -44,6 +44,10 @@ function makeFakeClient(initial: Partial<FakeSlackClientState> = {}): {
   client: SlackClient;
   state: FakeSlackClientState;
   emit: (event: SlackInboundEvent) => Promise<void>;
+  /** cortex#235 r1#4 — drive the Socket Mode `connected` lifecycle callback. */
+  simulateConnect: () => void;
+  /** cortex#235 r1#4 — drive the Socket Mode `disconnected` lifecycle callback. */
+  simulateDisconnect: (info?: { wasClean?: boolean; closeReason?: string }) => void;
 } {
   const state: FakeSlackClientState = {
     postedMessages: [],
@@ -57,6 +61,8 @@ function makeFakeClient(initial: Partial<FakeSlackClientState> = {}): {
   };
 
   let onEvent: ((event: SlackInboundEvent) => Promise<void>) | null = null;
+  let onConnected: (() => void) | null = null;
+  let onDisconnected: ((info: { wasClean?: boolean; closeReason?: string }) => void) | null = null;
 
   const client: SlackClient = {
     // eslint-disable-next-line @typescript-eslint/require-await
@@ -64,6 +70,8 @@ function makeFakeClient(initial: Partial<FakeSlackClientState> = {}): {
       state.startCount++;
       state.callOrder.push("start");
       onEvent = opts.onEvent;
+      onConnected = opts.onConnected ?? null;
+      onDisconnected = opts.onDisconnected ?? null;
     },
     // eslint-disable-next-line @typescript-eslint/require-await
     async stop() {
@@ -104,7 +112,17 @@ function makeFakeClient(initial: Partial<FakeSlackClientState> = {}): {
     await onEvent(event);
   };
 
-  return { client, state, emit };
+  const simulateConnect = (): void => {
+    if (!onConnected) return;
+    onConnected();
+  };
+
+  const simulateDisconnect = (info: { wasClean?: boolean; closeReason?: string } = {}): void => {
+    if (!onDisconnected) return;
+    onDisconnected(info);
+  };
+
+  return { client, state, emit, simulateConnect, simulateDisconnect };
 }
 
 function makePresence(overrides: Partial<SlackPresence> = {}): SlackPresence {
@@ -792,5 +810,147 @@ describe("SlackAdapter.surfaceConfig", () => {
     await expect(
       adapter.surfaceConfig.render(makeEnvelope()),
     ).resolves.toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cortex#235 r1#4 — system.adapter.* envelope emission
+// ---------------------------------------------------------------------------
+
+describe("SlackAdapter — system.adapter.* envelopes (cortex#235 r1#4)", () => {
+  interface RecordingRuntime {
+    enabled: boolean;
+    onEnvelope: () => { unregister: () => void };
+    publish: (envelope: Envelope) => Promise<void>;
+    stop: () => Promise<void>;
+    publishes: Envelope[];
+  }
+  function makeRecordingRuntime(): RecordingRuntime {
+    const publishes: Envelope[] = [];
+    return {
+      enabled: true,
+      onEnvelope: () => ({ unregister: () => {} }),
+      publish: async (envelope: Envelope) => { publishes.push(envelope); },
+      stop: async () => {},
+      publishes,
+    };
+  }
+
+  const SOURCE = { org: "metafactory", agent: "luna", instance: "local" };
+
+  test("initial connect after start() is silent (no envelope emitted)", async () => {
+    const runtime = makeRecordingRuntime();
+    const { adapter, simulateConnect } = makeAdapter({
+      infra: { runtime, systemEventSource: SOURCE },
+    });
+    await adapter.start(async () => {});
+    simulateConnect();
+    expect(runtime.publishes).toHaveLength(0);
+    await adapter.stop();
+  });
+
+  test("disconnect emits system.adapter.disconnected with wasClean=false on unclean drop", async () => {
+    const runtime = makeRecordingRuntime();
+    const { adapter, simulateDisconnect } = makeAdapter({
+      infra: { runtime, systemEventSource: SOURCE },
+    });
+    await adapter.start(async () => {});
+    simulateDisconnect({ wasClean: false, closeReason: "network drop" });
+    expect(runtime.publishes).toHaveLength(1);
+    const env = runtime.publishes[0]!;
+    expect(env.type).toBe("system.adapter.disconnected");
+    expect(env.payload.platform).toBe("slack");
+    expect(env.payload.adapter_id).toBe("slack-test");
+    expect(env.payload.was_clean).toBe(false);
+    expect(env.payload.close_reason).toBe("network drop");
+    await adapter.stop();
+  });
+
+  test("disconnect followed by reconnect emits disconnected + recovered pair", async () => {
+    const runtime = makeRecordingRuntime();
+    const { adapter, simulateConnect, simulateDisconnect } = makeAdapter({
+      infra: { runtime, systemEventSource: SOURCE },
+    });
+    await adapter.start(async () => {});
+    // Initial connect — silent
+    simulateConnect();
+    expect(runtime.publishes).toHaveLength(0);
+    // Drop
+    simulateDisconnect({ wasClean: false });
+    expect(runtime.publishes).toHaveLength(1);
+    expect(runtime.publishes[0]!.type).toBe("system.adapter.disconnected");
+    // Reconnect — emits recovered
+    simulateConnect();
+    expect(runtime.publishes).toHaveLength(2);
+    const recovered = runtime.publishes[1]!;
+    expect(recovered.type).toBe("system.adapter.recovered");
+    expect(recovered.payload.platform).toBe("slack");
+    expect(recovered.payload.adapter_id).toBe("slack-test");
+    expect(typeof recovered.payload.degraded_for_ms).toBe("number");
+    expect(recovered.payload.degraded_for_ms as number).toBeGreaterThanOrEqual(0);
+    await adapter.stop();
+  });
+
+  test("recovered envelope carries the original disconnect timestamp", async () => {
+    const runtime = makeRecordingRuntime();
+    const { adapter, simulateConnect, simulateDisconnect } = makeAdapter({
+      infra: { runtime, systemEventSource: SOURCE },
+    });
+    await adapter.start(async () => {});
+    simulateConnect();
+    simulateDisconnect({ wasClean: false });
+    const disconnectedAt = (runtime.publishes[0]!.payload as { disconnected_since: string })
+      .disconnected_since;
+    simulateConnect();
+    const recovered = runtime.publishes[1]!;
+    expect(recovered.payload.disconnected_since).toBe(disconnectedAt);
+    await adapter.stop();
+  });
+
+  test("clean disconnect (stop() path) sets wasClean=true on envelope", async () => {
+    const runtime = makeRecordingRuntime();
+    const { adapter, simulateDisconnect } = makeAdapter({
+      infra: { runtime, systemEventSource: SOURCE },
+    });
+    await adapter.start(async () => {});
+    simulateDisconnect({ wasClean: true });
+    const env = runtime.publishes[0]!;
+    expect(env.payload.was_clean).toBe(true);
+    expect(env.payload.close_reason).toBeUndefined();
+    await adapter.stop();
+  });
+
+  test("no runtime configured → lifecycle silent (no crash)", async () => {
+    const { adapter, simulateConnect, simulateDisconnect } = makeAdapter({
+      // intentionally no runtime/systemEventSource
+    });
+    await adapter.start(async () => {});
+    simulateConnect();
+    simulateDisconnect({ wasClean: false });
+    simulateConnect();
+    // No throw; no publish observable from the outside.
+    await adapter.stop();
+  });
+
+  test("runtime present but systemEventSource missing → silent + one-time warning", async () => {
+    const runtime = makeRecordingRuntime();
+    const originalWarn = console.warn;
+    const warnings: string[] = [];
+    console.warn = (...args: unknown[]) => { warnings.push(args.map(String).join(" ")); };
+    try {
+      const { adapter, simulateConnect, simulateDisconnect } = makeAdapter({
+        infra: { runtime }, // no systemEventSource
+      });
+      await adapter.start(async () => {});
+      simulateDisconnect({ wasClean: false });
+      simulateConnect();
+      // First disconnect fires the warning; second wouldn't (latched).
+      simulateDisconnect({ wasClean: false });
+      expect(runtime.publishes).toHaveLength(0);
+      expect(warnings.filter((w) => w.includes("systemEventSource is missing"))).toHaveLength(1);
+      await adapter.stop();
+    } finally {
+      console.warn = originalWarn;
+    }
   });
 });

--- a/src/adapters/slack/client.ts
+++ b/src/adapters/slack/client.ts
@@ -131,6 +131,23 @@ export class RealSlackClient implements SlackClient {
   private readonly web: WebClient;
   private readonly instanceId: string;
   private cachedIdentity: SlackBotIdentity | null = null;
+  /**
+   * Tracks whether `stop()` initiated the next `disconnected` event,
+   * so the `wasClean` classification on `system.adapter.disconnected`
+   * is correct.
+   *
+   * Why explicit state rather than reading the event argument: as of
+   * `@slack/socket-mode` v2, the `disconnected` event emits with no
+   * arguments — the previous implementation's `(err?: Error)`
+   * derivation would always classify every disconnect as
+   * `wasClean=true`, which is exactly backwards. Echo cortex#254
+   * round 1 caught this.
+   *
+   * Set to true at the top of `stop()`; reset to false after the
+   * next `disconnected` event fires (so a subsequent unexpected
+   * drop classifies correctly).
+   */
+  private stopInitiated = false;
 
   constructor(opts: RealSlackClientOptions) {
     this.instanceId = opts.instanceId ?? "slack";
@@ -226,15 +243,22 @@ export class RealSlackClient implements SlackClient {
     }
     if (opts.onDisconnected !== undefined) {
       const onDisconnected = opts.onDisconnected;
-      this.socket.on("disconnected", (err?: Error) => {
+      this.socket.on("disconnected", () => {
+        // @slack/socket-mode v2 emits `disconnected` with NO
+        // arguments — earlier versions of this file took an
+        // `(err?: Error)` and derived `wasClean = err === undefined`,
+        // which classified every disconnect as clean. Echo
+        // cortex#254 round 1.
+        //
+        // Correct derivation: was THIS disconnect initiated by our
+        // own `stop()` call (clean), or did the socket drop on its
+        // own (unclean — Socket Mode will then trigger an internal
+        // reconnect; if that also fails, fires `disconnected`
+        // again with the same wasClean=false reading)?
+        const wasClean = this.stopInitiated;
+        this.stopInitiated = false;
         try {
-          // @slack/socket-mode `disconnected` event passes an Error
-          // when the disconnect was unexpected; absent for clean
-          // shutdowns (`stop()` path).
-          onDisconnected({
-            wasClean: err === undefined,
-            ...(err !== undefined && { closeReason: err.message }),
-          });
+          onDisconnected({ wasClean });
         } catch (cbErr) {
           console.warn(
             `slack-client[${this.instanceId}]: onDisconnected threw:`,
@@ -248,6 +272,7 @@ export class RealSlackClient implements SlackClient {
   }
 
   async stop(): Promise<void> {
+    this.stopInitiated = true;
     await this.socket.disconnect();
   }
 

--- a/src/adapters/slack/client.ts
+++ b/src/adapters/slack/client.ts
@@ -73,8 +73,33 @@ export interface SlackBotIdentity {
  * Pluggable Slack client surface. The real implementation wraps
  * `SocketModeClient` + `WebClient`; tests pass a mock.
  */
+/**
+ * Lifecycle info plumbed from Socket Mode's `disconnect` event onto
+ * the adapter-side handler. `closeReason` is best-effort — Socket
+ * Mode doesn't always supply it; the adapter falls back to a
+ * conservative default. cortex#235 r1#4.
+ */
+export interface SlackDisconnectInfo {
+  /** True if the disconnect was a clean shutdown (e.g. `stop()`); false on unexpected drops. */
+  wasClean?: boolean;
+  /** Human-readable close reason from the WebSocket layer, if Socket Mode supplies one. */
+  closeReason?: string;
+}
+
 export interface SlackClient {
-  start(opts: { onEvent: (event: SlackInboundEvent) => Promise<void> }): Promise<void>;
+  /**
+   * Open the Socket Mode connection and start delivering events to
+   * `onEvent`. The optional `onConnected` / `onDisconnected` hooks
+   * fire on every Socket Mode lifecycle transition — the adapter
+   * uses them to emit `system.adapter.*` envelopes (cortex#235
+   * r1#4). Mocks can invoke them at will for test coverage of the
+   * envelope path.
+   */
+  start(opts: {
+    onEvent: (event: SlackInboundEvent) => Promise<void>;
+    onConnected?: () => void;
+    onDisconnected?: (info: SlackDisconnectInfo) => void;
+  }): Promise<void>;
   stop(): Promise<void>;
   postMessage(channel: string, text: string, threadTs?: string): Promise<{ ts?: string }>;
   /** Convenience accessor for `userId`. Kept for adapter call-site brevity. */
@@ -113,7 +138,11 @@ export class RealSlackClient implements SlackClient {
     this.web = new WebClient(opts.botToken);
   }
 
-  async start(opts: { onEvent: (event: SlackInboundEvent) => Promise<void> }): Promise<void> {
+  async start(opts: {
+    onEvent: (event: SlackInboundEvent) => Promise<void>;
+    onConnected?: () => void;
+    onDisconnected?: (info: SlackDisconnectInfo) => void;
+  }): Promise<void> {
     // Slack's Socket Mode delivers `events_api` envelopes; the inner event
     // type (`message`, `app_mention`) is re-emitted by SocketModeClient as
     // a top-level event.
@@ -174,6 +203,47 @@ export class RealSlackClient implements SlackClient {
     };
     this.socket.on("message", dispatch);
     this.socket.on("app_mention", dispatch);
+
+    // cortex#235 r1#4 — Socket Mode lifecycle → adapter callbacks.
+    // SocketModeClient emits `connected` on every reconnect (initial
+    // + recoveries) and `disconnected` on every drop (clean or
+    // unclean). The adapter's `handleConnected` distinguishes
+    // initial-connect from recovery via a latch. Listeners are
+    // best-effort: any throw inside the callback is logged but does
+    // not interrupt the socket loop.
+    if (opts.onConnected !== undefined) {
+      const onConnected = opts.onConnected;
+      this.socket.on("connected", () => {
+        try {
+          onConnected();
+        } catch (err) {
+          console.warn(
+            `slack-client[${this.instanceId}]: onConnected threw:`,
+            err instanceof Error ? err.message : String(err),
+          );
+        }
+      });
+    }
+    if (opts.onDisconnected !== undefined) {
+      const onDisconnected = opts.onDisconnected;
+      this.socket.on("disconnected", (err?: Error) => {
+        try {
+          // @slack/socket-mode `disconnected` event passes an Error
+          // when the disconnect was unexpected; absent for clean
+          // shutdowns (`stop()` path).
+          onDisconnected({
+            wasClean: err === undefined,
+            ...(err !== undefined && { closeReason: err.message }),
+          });
+        } catch (cbErr) {
+          console.warn(
+            `slack-client[${this.instanceId}]: onDisconnected threw:`,
+            cbErr instanceof Error ? cbErr.message : String(cbErr),
+          );
+        }
+      });
+    }
+
     await this.socket.start();
   }
 

--- a/src/adapters/slack/index.ts
+++ b/src/adapters/slack/index.ts
@@ -23,8 +23,14 @@ import type {
 } from "../types";
 import type { Agent, SlackPresence } from "../../common/types/cortex-config";
 import type { Envelope } from "../../bus/myelin/envelope-validator";
+import type { MyelinRuntime } from "../../bus/myelin/runtime";
 import type { SurfaceAdapter } from "../../bus/surface-router";
 import type { PayloadFilter } from "../../bus/payload-filter";
+import {
+  type SystemEventSource,
+  createSystemAdapterDisconnectedEvent,
+  createSystemAdapterRecoveredEvent,
+} from "../../bus/system-events";
 import { resolveRole } from "../discord/role-resolver";
 import { formatEnvelopeAsMarkdown } from "../envelope-renderer";
 import { RealSlackClient, type SlackClient, type SlackInboundEvent, type SlackBotIdentity } from "./client";
@@ -45,6 +51,18 @@ export interface SlackAdapterInfra {
   instanceId: string;
   /** Operator's platform identity. */
   operator: { slackId?: string };
+  /**
+   * MyelinRuntime for `system.adapter.*` envelope emission (cortex#235
+   * r1#4). Optional — adapters started without NATS still track
+   * connection state locally; bus emission is additive.
+   */
+  runtime?: MyelinRuntime;
+  /**
+   * `{org}.{agent}.{instance}` source triple stamped onto emitted
+   * `system.*` envelopes. Required for any `system.adapter.*` envelope
+   * to fire — see `canPublishSystemEvent()`.
+   */
+  systemEventSource?: SystemEventSource;
   /** MIG-3b: NATS subject patterns this adapter renders to Slack. */
   surfaceSubjects?: string[];
   /** MIG-3b: optional payload filter applied AFTER subject match. */
@@ -100,11 +118,31 @@ export class SlackAdapter implements PlatformAdapter {
   private readonly seenTsOrder: string[] = [];
   private static readonly DEDUP_CAPACITY = 256;
 
+  /**
+   * cortex#235 r1#4 — connection-state tracking for `system.adapter.*`
+   * envelope emission. Slack's Socket Mode is a single connection (no
+   * shard concept), so this is simpler than Discord's per-shard health
+   * map.
+   *
+   * `lastDisconnectedAt` is set when `disconnected` fires; cleared
+   * after the next `connected` recovers. `connectedOnce` distinguishes
+   * the initial successful connect (no envelope emitted — matches
+   * Discord which doesn't emit `connected` either) from a recovery
+   * after a prior disconnect (emit `system.adapter.recovered`).
+   */
+  private lastDisconnectedAt: Date | null = null;
+  private connectedOnce = false;
+  private warnedMissingSource = false;
+  private readonly runtime: MyelinRuntime | undefined;
+  private readonly systemEventSource: SystemEventSource | undefined;
+
   constructor(agent: Agent, presence: SlackPresence, infra: SlackAdapterInfra) {
     this.agent = agent;
     this.presence = presence;
     this.infra = infra;
     this.instanceId = infra.instanceId;
+    this.runtime = infra.runtime;
+    this.systemEventSource = infra.systemEventSource;
     this.trustedBotIds = infra.trustedBotIds ?? new Set(presence.trustedBotIds);
     this.client = infra.client ?? new RealSlackClient({
       botToken: presence.botToken,
@@ -139,6 +177,16 @@ export class SlackAdapter implements PlatformAdapter {
         if (!msg) return;
         await onMessage(msg);
       },
+      // cortex#235 r1#4 — Socket Mode lifecycle hooks.
+      // - `onConnected` fires on EVERY Socket Mode reconnect, not just the
+      //   initial connect; the adapter's `connectedOnce` latch
+      //   distinguishes initial-connect (silent) from recovery
+      //   (emit system.adapter.recovered).
+      // - `onDisconnected` fires on every Socket Mode disconnect; emits
+      //   system.adapter.disconnected unconditionally (mirrors Discord's
+      //   per-shard disconnect emission).
+      onConnected: () => { this.handleConnected(); },
+      onDisconnected: (info) => { this.handleDisconnected(info); },
     });
   }
 
@@ -436,5 +484,96 @@ export class SlackAdapter implements PlatformAdapter {
       timestamp: new Date(Number(event.ts.split(".")[0]) * 1000),
       _native: event,
     };
+  }
+
+  // ---------------------------------------------------------------------------
+  // cortex#235 r1#4 — Socket Mode lifecycle → system.adapter.* envelopes.
+  //
+  // Mirror of Discord's per-shard emission pattern, simplified for
+  // Socket Mode's single-connection model:
+  //   - No shard_id field on emitted envelopes (Slack has no shards).
+  //   - No `degraded` event: degraded requires a wall-clock threshold
+  //     timer ("disconnected longer than X seconds"). Slack's Socket
+  //     Mode reconnect cadence is typically faster than any reasonable
+  //     threshold; the disconnected → recovered pair carries the
+  //     duration on `degraded_for_ms` directly.
+  //   - Initial connect is silent (matches Discord — no
+  //     `system.adapter.connected` envelope kind exists).
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Common gate for `system.adapter.*` emission. Returns the bound
+   * runtime + source pair when both are configured, or `null`
+   * otherwise. Mirrors Discord's `canPublishSystemEvent`.
+   */
+  private canPublishSystemEvent(): { runtime: MyelinRuntime; source: SystemEventSource } | null {
+    const runtime = this.runtime;
+    if (!runtime) return null;
+    const source = this.systemEventSource;
+    if (!source) {
+      if (!this.warnedMissingSource) {
+        console.warn(
+          `slack-${this.instanceId}: runtime is configured but systemEventSource is missing — system.* events will not be emitted`,
+        );
+        this.warnedMissingSource = true;
+      }
+      return null;
+    }
+    return { runtime, source };
+  }
+
+  /**
+   * Socket Mode `connected` event. First-ever connect is silent
+   * (matches Discord — initial connect is the expected steady state);
+   * any subsequent connect is a recovery from a prior disconnect and
+   * emits `system.adapter.recovered`.
+   */
+  private handleConnected(): void {
+    if (!this.connectedOnce) {
+      this.connectedOnce = true;
+      return;
+    }
+    const disconnectedSince = this.lastDisconnectedAt;
+    this.lastDisconnectedAt = null;
+    if (disconnectedSince === null) return;
+    const wiring = this.canPublishSystemEvent();
+    if (!wiring) return;
+    const env = createSystemAdapterRecoveredEvent({
+      source: wiring.source,
+      adapterId: this.instanceId,
+      platform: "slack",
+      degradedForMs: Date.now() - disconnectedSince.getTime(),
+      disconnectedSince,
+    });
+    void wiring.runtime.publish(env);
+  }
+
+  /**
+   * Socket Mode `disconnected` event. Emits `system.adapter.disconnected`
+   * unconditionally — mirrors Discord which emits on every shard
+   * disconnect (clean or unclean). Surfaces filter on `was_clean` to
+   * separate routine reconnects from genuine outages.
+   *
+   * `info.wasClean` is plumbed from Socket Mode's close reason; if
+   * the upstream event doesn't supply it, default to `false` (the
+   * conservative-for-incidents path — surfaces err on the alerting
+   * side).
+   */
+  private handleDisconnected(info: { wasClean?: boolean; closeReason?: string }): void {
+    const now = new Date();
+    this.lastDisconnectedAt = now;
+    const wiring = this.canPublishSystemEvent();
+    if (!wiring) return;
+    const env = createSystemAdapterDisconnectedEvent({
+      source: wiring.source,
+      adapterId: this.instanceId,
+      platform: "slack",
+      disconnectedSince: now,
+      wasClean: info.wasClean ?? false,
+      ...(info.closeReason !== undefined && info.closeReason !== "" && {
+        closeReason: info.closeReason,
+      }),
+    });
+    void wiring.runtime.publish(env);
   }
 }

--- a/src/adapters/slack/index.ts
+++ b/src/adapters/slack/index.ts
@@ -202,6 +202,19 @@ export class SlackAdapter implements PlatformAdapter {
     // dedup decisions that would silently drop legitimate messages.
     this.seenTs.clear();
     this.seenTsOrder.length = 0;
+    // Echo cortex#254 round 1 — reset system.adapter.* latches so a
+    // subsequent `start()` on the same instance has clean state:
+    //   - `connectedOnce` would otherwise treat the next initial
+    //     connect as a recovery, emitting a spurious `recovered`.
+    //   - `lastDisconnectedAt` could falsely pair with that
+    //     synthetic recovered.
+    //   - `warnedMissingSource` is process-lifetime in spirit but
+    //     resetting on stop()/start() boundaries is fine (operator
+    //     restarting an adapter probably wants the diagnostic again
+    //     if they fixed nothing in between).
+    this.connectedOnce = false;
+    this.lastDisconnectedAt = null;
+    this.warnedMissingSource = false;
   }
 
   async getPlatformUserId(): Promise<string> {

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -975,6 +975,12 @@ export async function startCortex(
           operator: {
             ...(config.agent.operatorSlackId !== undefined && { slackId: config.agent.operatorSlackId }),
           },
+          // cortex#235 r1#4 — wire runtime + source so the adapter
+          // can emit `system.adapter.{disconnected,recovered}` on
+          // Socket Mode lifecycle transitions. Same pattern as the
+          // Discord adapter above.
+          runtime,
+          systemEventSource,
           surfaceSubjects: presence.surfaceSubjects,
           ...(presence.surfaceFallbackChannelId !== undefined && {
             surfaceFallbackChannelId: presence.surfaceFallbackChannelId,


### PR DESCRIPTION
## Summary

Closes the r1#4 item on cortex#235. Slack adapter gains parity with Discord's observability envelopes: Socket Mode lifecycle (connected/disconnected) drives `system.adapter.*` emission through the same MyelinRuntime + SystemEventSource wiring.

## What ships

- \`SlackClient.start()\` opts extended with optional \`onConnected\` / \`onDisconnected\` callbacks. \`RealSlackClient\` wires them to \`SocketModeClient.on('connected'|'disconnected')\`. Test mocks expose \`simulateConnect/Disconnect\`.
- \`SlackAdapterInfra\` gains \`runtime\` + \`systemEventSource\` (mirrors \`DiscordAdapterInfra\`).
- \`handleConnected\` / \`handleDisconnected\` + \`canPublishSystemEvent\` helpers — same pattern + gating as Discord.
- cortex.ts boot passes \`runtime\` + \`systemEventSource\` into the Slack adapter's infra.

## What Slack does NOT emit (intentional)

- No \`system.adapter.degraded\` — Discord's degraded requires a wall-clock threshold timer; Socket Mode reconnects fast enough that the disconnected → recovered pair's \`degraded_for_ms\` carries the same information without ceremony.
- No \`shard_id\` — Slack Socket Mode is a single connection.

## Tests

7 new in \`slack-adapter.test.ts\`:
- Initial connect silent
- Unclean disconnect emits with \`was_clean=false\` + closeReason
- Disconnect → reconnect emits the pair
- Recovered carries original disconnect timestamp
- Clean disconnect → \`was_clean=true\`
- No runtime → silent (no crash)
- Runtime + no source → silent + one-time warn

54 → 61 Slack tests; 3040/3041 full suite + tsc + lint green.

## Remaining cortex#235 items (deferred to follow-up PRs)

r1#5 updateConfig hot-reload, r1#6 regex bounds, r1#7 trust-resolver two-pass, r1#9 ms precision, r1#10 audit, r1#11 test coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)