### PR TITLE
fix(slack): tighten id regex bounds + ms timestamp precision (cortex#235 r1#6 + r1#9)

### DIFF
--- a/src/adapters/slack/__tests__/schema.test.ts
+++ b/src/adapters/slack/__tests__/schema.test.ts
@@ -15,7 +15,7 @@ const VALID_PRESENCE = {
   botToken: "xoxb-TEST-TOKEN-12345",
   appToken: "xapp-TEST-APP-12345",
   workspaceId: "T0WORKSPACE",
-  channels: [{ id: "C0CHAN1", name: "cortex" }],
+  channels: [{ id: "C0CHANNEL1", name: "cortex" }],
 };
 
 describe("SlackPresenceSchema", () => {
@@ -62,11 +62,38 @@ describe("SlackPresenceSchema", () => {
     const parsed = SlackPresenceSchema.parse({
       ...VALID_PRESENCE,
       channels: [
-        { id: "C0PUB", name: "pub" },
-        { id: "G0PRIV", name: "priv" },
+        { id: "C0PUBLIC01", name: "pub" },
+        { id: "G0PRIVATE1", name: "priv" },
       ],
     });
     expect(parsed.channels).toHaveLength(2);
+  });
+
+  test("rejects too-short channel id (cortex#235 r1#6)", () => {
+    expect(() =>
+      SlackPresenceSchema.parse({
+        ...VALID_PRESENCE,
+        channels: [{ id: "C0SHORT", name: "tooshort" }], // 7 chars after C, below 8 min
+      }),
+    ).toThrow(/8-16/);
+  });
+
+  test("rejects too-long channel id (cortex#235 r1#6)", () => {
+    expect(() =>
+      SlackPresenceSchema.parse({
+        ...VALID_PRESENCE,
+        channels: [{ id: "C" + "0".repeat(17), name: "toolong" }],
+      }),
+    ).toThrow(/8-16/);
+  });
+
+  test("rejects too-long workspaceId (cortex#235 r1#6)", () => {
+    expect(() =>
+      SlackPresenceSchema.parse({
+        ...VALID_PRESENCE,
+        workspaceId: "T" + "0".repeat(17),
+      }),
+    ).toThrow(/8-16/);
   });
 
   test("passes through optional surfaceFallbackChannelId", () => {

--- a/src/adapters/slack/__tests__/slack-adapter.test.ts
+++ b/src/adapters/slack/__tests__/slack-adapter.test.ts
@@ -131,7 +131,7 @@ function makePresence(overrides: Partial<SlackPresence> = {}): SlackPresence {
     botToken: "xoxb-TEST-TOKEN-12345",
     appToken: "xapp-TEST-APP-12345",
     workspaceId: "T0WORKSPACE",
-    channels: [{ id: "C0CHAN1", name: "cortex" }],
+    channels: [{ id: "C0CHANNEL1", name: "cortex" }],
     allowedUserIds: [],
     trustedBotIds: [],
     roles: [],
@@ -186,7 +186,7 @@ function makeSlackEvent(overrides: Partial<SlackInboundEvent> = {}): SlackInboun
     type: "message",
     user: "U0HUMAN",
     team: "T0WORKSPACE",
-    channel: "C0CHAN1",
+    channel: "C0CHANNEL1",
     text: "hello bot",
     ts: "1700000000.000123",
     ...overrides,
@@ -329,19 +329,34 @@ describe("SlackAdapter — lifecycle", () => {
 // ---------------------------------------------------------------------------
 
 describe("SlackAdapter — translateEvent", () => {
+  test("preserves millisecond precision on timestamp (cortex#235 r1#9)", async () => {
+    const { adapter, emit } = makeAdapter();
+    const cap = captureInbound();
+    await adapter.start(cap.onMessage);
+    // Slack ts: "1700000000.123456" = 1,700,000,000.123456 seconds.
+    // Old impl split on "." and dropped fractional → 1700000000000 ms.
+    // New impl multiplies float * 1000 + floor → 1700000000123 ms.
+    await emit(makeSlackEvent({ ts: "1700000000.123456" }));
+    expect(cap.received).toHaveLength(1);
+    const expectedMs = Math.floor(1700000000.123456 * 1000);
+    expect(cap.received[0]!.timestamp.getTime()).toBe(expectedMs);
+    // Sanity: NOT the second-resolution truncation the old impl produced.
+    expect(cap.received[0]!.timestamp.getTime()).not.toBe(1700000000 * 1000);
+  });
+
   test("translates a plain message into an InboundMessage", async () => {
     const { adapter, emit } = makeAdapter();
     const cap = captureInbound();
     await adapter.start(cap.onMessage);
 
-    await emit(makeSlackEvent({ user: "U0HUMAN", text: "hello", channel: "C0CHAN1" }));
+    await emit(makeSlackEvent({ user: "U0HUMAN", text: "hello", channel: "C0CHANNEL1" }));
 
     expect(cap.received).toHaveLength(1);
     const msg = cap.received[0]!;
     expect(msg.platform).toBe("slack");
     expect(msg.authorId).toBe("U0HUMAN");
     expect(msg.content).toBe("hello");
-    expect(msg.channelId).toBe("C0CHAN1");
+    expect(msg.channelId).toBe("C0CHANNEL1");
     expect(msg.channelName).toBe("cortex");
     expect(msg.guildId).toBe("T0WORKSPACE");
     expect(msg.threadId).toBeUndefined();
@@ -539,7 +554,7 @@ describe("SlackAdapter — resolveAccess", () => {
       authorId,
       authorName: authorId,
       content: "hi",
-      channelId: "C0CHAN1",
+      channelId: "C0CHANNEL1",
       attachments: [],
       timestamp: new Date(0),
     };
@@ -605,14 +620,14 @@ describe("SlackAdapter — resolveAccess", () => {
 describe("SlackAdapter — postResponse", () => {
   test("posts via the client with channel + text", async () => {
     const { adapter, state } = makeAdapter();
-    await adapter.postResponse({ instanceId: "slack-test", channelId: "C0CHAN1" }, "ok");
-    expect(state.postedMessages).toEqual([{ channel: "C0CHAN1", text: "ok" }]);
+    await adapter.postResponse({ instanceId: "slack-test", channelId: "C0CHANNEL1" }, "ok");
+    expect(state.postedMessages).toEqual([{ channel: "C0CHANNEL1", text: "ok" }]);
   });
 
   test("threads the response when threadId is set", async () => {
     const { adapter, state } = makeAdapter();
     await adapter.postResponse(
-      { instanceId: "slack-test", channelId: "C0CHAN1", threadId: "1700000000.000000" },
+      { instanceId: "slack-test", channelId: "C0CHANNEL1", threadId: "1700000000.000000" },
       "ok",
     );
     expect(state.postedMessages[0]?.threadTs).toBe("1700000000.000000");
@@ -621,7 +636,7 @@ describe("SlackAdapter — postResponse", () => {
   test("warns and drops file attachments (v1 text-only)", async () => {
     const { adapter, state } = makeAdapter();
     await adapter.postResponse(
-      { instanceId: "slack-test", channelId: "C0CHAN1" },
+      { instanceId: "slack-test", channelId: "C0CHANNEL1" },
       "see attached",
       [{ content: Buffer.from("data"), filename: "x.txt" }],
     );
@@ -638,7 +653,7 @@ describe("SlackAdapter — postResponse", () => {
 describe("SlackAdapter — sendProgress + createThread + notifyOperator", () => {
   test("sendProgress posts once and skips subsequent calls", async () => {
     const { adapter, state } = makeAdapter();
-    const target = { instanceId: "slack-test", channelId: "C0CHAN1", threadId: "T123" };
+    const target = { instanceId: "slack-test", channelId: "C0CHANNEL1", threadId: "T123" };
     await adapter.sendProgress(target, "step 1");
     await adapter.sendProgress(target, "step 2");
     expect(state.postedMessages).toHaveLength(1);
@@ -647,7 +662,7 @@ describe("SlackAdapter — sendProgress + createThread + notifyOperator", () => 
 
   test("clearProgress allows a subsequent sendProgress to post again", async () => {
     const { adapter, state } = makeAdapter();
-    const target = { instanceId: "slack-test", channelId: "C0CHAN1", threadId: "T123" };
+    const target = { instanceId: "slack-test", channelId: "C0CHANNEL1", threadId: "T123" };
     await adapter.sendProgress(target, "first");
     await adapter.clearProgress(target);
     await adapter.sendProgress(target, "second");
@@ -663,13 +678,13 @@ describe("SlackAdapter — sendProgress + createThread + notifyOperator", () => 
       authorId: "U0HUMAN",
       authorName: "U0HUMAN",
       content: "spawn a thread",
-      channelId: "C0CHAN1",
+      channelId: "C0CHANNEL1",
       attachments: [],
       timestamp: new Date(0),
       _native: makeSlackEvent({ ts: "1700000000.999999" }),
     };
     const target = await adapter.createThread(msg, "ignored-name");
-    expect(target.channelId).toBe("C0CHAN1");
+    expect(target.channelId).toBe("C0CHANNEL1");
     expect(target.threadId).toBe("1700000000.999999");
   });
 
@@ -687,13 +702,13 @@ describe("SlackAdapter — sendProgress + createThread + notifyOperator", () => 
       authorId: "U0HUMAN",
       authorName: "U0HUMAN",
       content: "no native event attached",
-      channelId: "C0CHAN1",
+      channelId: "C0CHANNEL1",
       attachments: [],
       timestamp: new Date(0),
       // intentionally no _native and no threadId
     };
     const target = await adapter.createThread(msg, "ignored-name");
-    expect(target.channelId).toBe("C0CHAN1");
+    expect(target.channelId).toBe("C0CHANNEL1");
     expect(target.threadId).toBeUndefined();
   });
 
@@ -708,7 +723,7 @@ describe("SlackAdapter — sendProgress + createThread + notifyOperator", () => 
       authorId: "U0HUMAN",
       authorName: "U0HUMAN",
       content: "reply in existing thread",
-      channelId: "C0CHAN1",
+      channelId: "C0CHANNEL1",
       attachments: [],
       timestamp: new Date(0),
       _native: makeSlackEvent({

--- a/src/adapters/slack/index.ts
+++ b/src/adapters/slack/index.ts
@@ -494,7 +494,15 @@ export class SlackAdapter implements PlatformAdapter {
         ...(f.mimetype !== undefined && { contentType: f.mimetype }),
         ...(f.size !== undefined && { size: f.size }),
       })),
-      timestamp: new Date(Number(event.ts.split(".")[0]) * 1000),
+      // cortex#235 r1#9 — preserve millisecond precision. Slack's
+      // event.ts is a string like "1700000000.000123" (seconds.micros).
+      // The old `split(".")[0]) * 1000` derivation dropped the
+      // fractional portion entirely, so the dedup ring + downstream
+      // ordering both saw second-resolution timestamps. Multiplying
+      // the full float by 1000 + flooring keeps millisecond precision
+      // (Slack doesn't fire enough events per ms for sub-ms detail to
+      // matter; Math.floor avoids the rounding edge cases on .5).
+      timestamp: new Date(Math.floor(Number(event.ts) * 1000)),
       _native: event,
     };
   }

--- a/src/common/types/cortex-config.ts
+++ b/src/common/types/cortex-config.ts
@@ -316,8 +316,12 @@ export const SlackPresenceSchema = z.object({
    * across workspaces the same way they do across Discord guilds.
    */
   workspaceId: z.coerce.string().regex(
-    /^T[A-Z0-9]+$/,
-    "slack.workspaceId must be a Slack team id (T...)",
+    // cortex#235 r1#6 — bound the regex. Real Slack team ids are
+    // 9-11 chars (T + 8-10 base32-ish). 16 gives Slack headroom for
+    // future expansion without admitting unbounded operator-pasted
+    // garbage that would bloat downstream subject strings.
+    /^T[A-Z0-9]{8,16}$/,
+    "slack.workspaceId must be a Slack team id (T... with 8-16 trailing chars)",
   ),
   /**
    * Channels the adapter listens on / posts to. `id` is the canonical
@@ -327,8 +331,10 @@ export const SlackPresenceSchema = z.object({
    */
   channels: z.array(z.object({
     id: z.string().regex(
-      /^[CG][A-Z0-9]+$/,
-      "slack channel id must be a Slack channel/group id (C... or G...)",
+      // cortex#235 r1#6 — same upper-bound logic as workspaceId.
+      // Real Slack channel/group ids are 11 chars; 16 leaves headroom.
+      /^[CG][A-Z0-9]{8,16}$/,
+      "slack channel id must be a Slack channel/group id (C... or G... with 8-16 trailing chars)",
     ),
     name: z.string().min(1),
   })).default([]),


### PR DESCRIPTION
## Summary

Two clustered hardening items from cortex#235:

- **r1#6** — Bound \`SlackPresenceSchema.workspaceId\` + \`channels[].id\` regexes to \`{8,16}\`. Real Slack ids are 9-11 chars; 8 leaves buffer; 16 leaves headroom. Operator-pasted garbage of arbitrary length no longer parses.
- **r1#9** — \`translateEvent\` now preserves ms precision: \`new Date(Math.floor(Number(event.ts) * 1000))\` instead of \`new Date(Number(event.ts.split(".")[0]) * 1000)\`. The old split-on-dot derivation dropped microseconds entirely, giving second-resolution timestamps to the dedup ring + downstream.

Also: **r1#10 audit closed in this PR** — grep across \`src/adapters/slack/\` confirms zero remaining \`JSON.stringify\`-on-API-response paths (only the documentary comment from the prior fix remains).

## Tests

- 3 new schema tests (short/long channel id + oversized workspaceId rejection)
- 1 new translateEvent test asserts ms precision (ts \"1700000000.123456\" → 1700000000123 ms, NOT 1700000000000)
- Test fixture rename: \`C0CHAN1\` → \`C0CHANNEL1\` (16 callsites updated to satisfy new lower bound)

3046/3047 full suite + tsc + lint green.

## Remaining cortex#235 items

r1#5 updateConfig hot-reload, r1#7 trust-resolver two-pass, r1#11 additional test coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)