### PR TITLE
feat(slack): updateConfig hot-reload (cortex#235 r1#5)

### DIFF
--- a/src/adapters/slack/__tests__/slack-adapter.test.ts
+++ b/src/adapters/slack/__tests__/slack-adapter.test.ts
@@ -991,3 +991,138 @@ describe("SlackAdapter — system.adapter.* envelopes (cortex#235 r1#4)", () => 
     }
   });
 });
+
+// ---------------------------------------------------------------------------
+// cortex#235 r1#5 — updateConfig hot-reload
+// ---------------------------------------------------------------------------
+
+import type { BotConfig } from "../../../common/types/config";
+
+describe("SlackAdapter.updateConfig — F-092 hot-reload (cortex#235 r1#5)", () => {
+  /**
+   * Minimal BotConfig fixture with a single Slack instance. Mirrors the
+   * Discord/Mattermost test pattern. Only the fields we care about for
+   * hot-reload need realistic values; others get cheap defaults.
+   */
+  function makeBotConfig(slackOverrides: Partial<BotConfig["slack"][number]> = {}): BotConfig {
+    return {
+      agent: { name: "luna", displayName: "Luna" },
+      discord: [],
+      mattermost: [],
+      slack: [{
+        instanceId: "slack-test",
+        enabled: true,
+        botToken: "xoxb-TEST-TOKEN",
+        appToken: "xapp-TEST-APP",
+        workspaceId: "T0WORKSPACE",
+        channels: [{ id: "C0CHANNEL1", name: "cortex" }],
+        allowedUserIds: [],
+        trustedBotIds: [],
+        roles: [],
+        defaultRole: "allow-all",
+        surfaceSubjects: [],
+        ...slackOverrides,
+      }],
+      claude: {} as BotConfig["claude"],
+    // Adapter's `updateConfig` only reads `config.slack[i]` and
+    // `config.agent`; the rest of the BotConfig surface
+    // (attachments/execution/github/api/etc.) is unused here. Cast
+    // through unknown for test ergonomics.
+    } as unknown as BotConfig;
+  }
+
+  test("matches the live presence by workspaceId and hot-reloads channels", () => {
+    const { adapter } = makeAdapter();
+    const updated = makeBotConfig({
+      channels: [
+        { id: "C0CHANNEL1", name: "cortex" },
+        { id: "C0CHANNEL2", name: "research" },
+      ],
+    });
+    adapter.updateConfig(updated);
+    // Channels visible via surfaceConfig.subjects? No — easier check:
+    // updateConfig didn't throw and the workspaceId match succeeded.
+    // Detail-level assertion via the agent rebuild below.
+    expect((adapter as unknown as { agent: Agent }).agent.presence.slack?.channels).toHaveLength(2);
+    expect((adapter as unknown as { agent: Agent }).agent.presence.slack?.channels[1]?.name).toBe("research");
+  });
+
+  test("hot-reloads roles + defaultRole", () => {
+    const { adapter } = makeAdapter();
+    const updated = makeBotConfig({
+      roles: [{ name: "operator", users: ["U0OP"], features: ["chat"] }],
+      defaultRole: "denied",
+    });
+    adapter.updateConfig(updated);
+    expect((adapter as unknown as { agent: Agent }).agent.presence.slack?.roles).toHaveLength(1);
+    expect((adapter as unknown as { agent: Agent }).agent.presence.slack?.defaultRole).toBe("denied");
+  });
+
+  test("hot-reloads allowedUserIds", () => {
+    const { adapter } = makeAdapter();
+    const updated = makeBotConfig({ allowedUserIds: ["U0NEW1", "U0NEW2"] });
+    adapter.updateConfig(updated);
+    expect((adapter as unknown as { agent: Agent }).agent.presence.slack?.allowedUserIds).toEqual(["U0NEW1", "U0NEW2"]);
+  });
+
+  test("hot-reloads trustedBotIds (rebuilds the lookup set)", async () => {
+    const { adapter, emit } = makeAdapter();
+    const cap = captureInbound();
+    await adapter.start(cap.onMessage);
+    // Update to add a trusted bot id; verify the bot-id message no
+    // longer trips the self-loop guard.
+    adapter.updateConfig(makeBotConfig({ trustedBotIds: ["B0PEERBOT"] }));
+    expect((adapter as unknown as { agent: Agent }).agent.presence.slack?.trustedBotIds).toEqual(["B0PEERBOT"]);
+    // Smoke: send a message FROM the peer bot id; should be admitted
+    // (no longer dropped as self-loop).
+    await emit(makeSlackEvent({ bot_id: "B0PEERBOT", user: undefined, text: "peer hello" }));
+    expect(cap.received).toHaveLength(1);
+    expect(cap.received[0]!.authorId).toBe("B0PEERBOT");
+    await adapter.stop();
+  });
+
+  test("does not touch botToken/appToken/workspaceId (reconnect-only fields)", () => {
+    const { adapter } = makeAdapter();
+    const originalWorkspaceId = (adapter as unknown as { agent: Agent }).agent.presence.slack?.workspaceId;
+    // Pass an instance with rotated tokens — the match-by-workspaceId
+    // still works, and the presence's tokens carry through unchanged.
+    adapter.updateConfig(makeBotConfig({
+      botToken: "xoxb-ROTATED-IGNORED",
+      appToken: "xapp-ROTATED-IGNORED",
+      channels: [{ id: "C0CHANNEL1", name: "cortex" }],
+    }));
+    // workspaceId preserved (match key)
+    expect((adapter as unknown as { agent: Agent }).agent.presence.slack?.workspaceId).toBe(originalWorkspaceId);
+    // Tokens: preserved across spread (presence retains original).
+    expect((adapter as unknown as { agent: Agent }).agent.presence.slack?.botToken).toBe("xoxb-TEST-TOKEN-12345");
+    expect((adapter as unknown as { agent: Agent }).agent.presence.slack?.appToken).toBe("xapp-TEST-APP-12345");
+  });
+
+  test("warns and no-ops when workspaceId removed from config", () => {
+    const { adapter } = makeAdapter();
+    const originalRoles = (adapter as unknown as { agent: Agent }).agent.presence.slack?.roles ?? [];
+    const originalWarn = console.warn;
+    const warnings: string[] = [];
+    console.warn = (...args: unknown[]) => { warnings.push(args.map(String).join(" ")); };
+    try {
+      // No slack[] instance with our workspaceId.
+      adapter.updateConfig(makeBotConfig({ workspaceId: "T0DIFFERENT" }));
+      // Roles unchanged — update was ignored.
+      expect((adapter as unknown as { agent: Agent }).agent.presence.slack?.roles).toEqual(originalRoles);
+      // Warning emitted.
+      expect(warnings.some((w) => w.includes("instance removed from config"))).toBe(true);
+    } finally {
+      console.warn = originalWarn;
+    }
+  });
+
+  test("rebuilds agent.id + agent.displayName from new config", () => {
+    const { adapter } = makeAdapter();
+    const updated = makeBotConfig();
+    updated.agent.name = "luna-rebranded";
+    updated.agent.displayName = "Luna v2";
+    adapter.updateConfig(updated);
+    expect((adapter as unknown as { agent: Agent }).agent.id).toBe("luna-rebranded");
+    expect((adapter as unknown as { agent: Agent }).agent.displayName).toBe("Luna v2");
+  });
+});

--- a/src/adapters/slack/index.ts
+++ b/src/adapters/slack/index.ts
@@ -22,6 +22,7 @@ import type {
   ContextMessage,
 } from "../types";
 import type { Agent, SlackPresence } from "../../common/types/cortex-config";
+import type { BotConfig } from "../../common/types/config";
 import type { Envelope } from "../../bus/myelin/envelope-validator";
 import type { MyelinRuntime } from "../../bus/myelin/runtime";
 import type { SurfaceAdapter } from "../../bus/surface-router";
@@ -88,8 +89,11 @@ export class SlackAdapter implements PlatformAdapter {
   readonly platform = "slack";
   readonly instanceId: string;
 
-  private readonly agent: Agent;
-  private readonly presence: SlackPresence;
+  // cortex#235 r1#5 — agent + presence are reassigned by
+  // `updateConfig` to reflect hot-reload state. Same pattern as
+  // Discord + Mattermost adapters.
+  private agent: Agent;
+  private presence: SlackPresence;
   private readonly infra: SlackAdapterInfra;
   private readonly client: SlackClient;
   /**
@@ -102,7 +106,11 @@ export class SlackAdapter implements PlatformAdapter {
    */
   private botIdentity: SlackBotIdentity | null = null;
   /** Operator-explicit + adapter-side anti-self-loop set. */
-  private readonly trustedBotIds: ReadonlySet<string>;
+  // cortex#235 r1#5 — mutable to support hot-reload of the trusted
+  // bot ids set via `updateConfig`. The runtime is still read-only:
+  // every consumer treats it as a `ReadonlySet<string>`. Only
+  // `updateConfig` reassigns the reference.
+  private trustedBotIds: ReadonlySet<string>;
   /**
    * Echo cortex#233: bounded FIFO dedup ring of recently-seen Slack
    * message `ts` values. Slack's Socket Mode fires BOTH the `message`
@@ -222,6 +230,74 @@ export class SlackAdapter implements PlatformAdapter {
     const identity = await this.client.getBotIdentity();
     this.botIdentity = identity;
     return identity.userId;
+  }
+
+  /**
+   * F-092 hot-reload (cortex#235 r1#5). Match the live presence by
+   * the immutable `workspaceId` (Slack's analogue to Mattermost's
+   * `apiUrl` and Discord's `guildId` — the operator-paste-stable
+   * identifier within `config.slack[]`).
+   *
+   * Hot-reload-safe fields (no socket reconnect required):
+   *   - channels[]               (router targets — pure data)
+   *   - roles[] / defaultRole    (access control — adapter-local)
+   *   - allowedUserIds[]         (access control — adapter-local)
+   *   - trustedBotIds            (self-loop guard — adapter-local)
+   *
+   * NOT reloaded (would require dropping + reopening Socket Mode):
+   *   - botToken, appToken       (auth — needs new Socket Mode session)
+   *   - workspaceId              (immutable identity — used as match key)
+   *
+   * Mirrors the Discord (`adapters/discord/index.ts:583`) and
+   * Mattermost (`adapters/mattermost/index.ts:182`) implementations
+   * — same shape, same invariants. The agent reference is rebuilt
+   * so `agent.presence.slack` reflects the post-reload state (the
+   * stale-agent invariant Holly flagged at MIG-7.2c-internal cycle
+   * 1).
+   */
+  // eslint-disable-next-line @typescript-eslint/require-await
+  updateConfig(config: BotConfig): void {
+    const newInstance = config.slack.find((inst) => inst.workspaceId === this.presence.workspaceId);
+    if (!newInstance) {
+      console.warn(
+        `slack-adapter[${this.instanceId}]: instance removed from config (workspaceId=${this.presence.workspaceId}), ignoring update`,
+      );
+      return;
+    }
+
+    this.presence = {
+      ...this.presence,
+      channels: newInstance.channels,
+      roles: newInstance.roles,
+      defaultRole: newInstance.defaultRole,
+      allowedUserIds: newInstance.allowedUserIds,
+      // The PresenceSchema field is `trustedBotIds: string[]` but the
+      // adapter caches a `ReadonlySet<string>` for O(1) lookup at the
+      // self-loop guard. Keep the schema-shape value on `presence`
+      // and rebuild the set below.
+      trustedBotIds: newInstance.trustedBotIds,
+    };
+
+    // Rebuild the trusted-bot-ids set the self-loop guard consults.
+    // Note: `infra.trustedBotIds` (the Pass-2 resolver-merged set)
+    // wins over `presence.trustedBotIds` at construction time per
+    // cortex#108 item 1; on hot-reload we go back to the
+    // presence-only set, which matches the Mattermost behaviour and
+    // is the operator-intent surface a config edit speaks to.
+    // Two-pass trust resolver merge is a separate follow-up (r1#7).
+    this.trustedBotIds = new Set(newInstance.trustedBotIds);
+
+    // Rebuild agent so `agent.presence.slack` + `agent.id` /
+    // `agent.displayName` reflect the post-reload state. Same
+    // invariant Holly flagged for Discord + Mattermost.
+    this.agent = {
+      ...this.agent,
+      id: config.agent.name,
+      displayName: config.agent.displayName,
+      presence: { ...this.agent.presence, slack: this.presence },
+    };
+
+    console.log(`slack-adapter[${this.instanceId}]: config updated`);
   }
 
   // eslint-disable-next-line @typescript-eslint/require-await


### PR DESCRIPTION
## Summary

Slack adapter gains F-092 parity with Discord + Mattermost: \`updateConfig(config: BotConfig)\` so the ConfigWatcher hot-reloads roles/channels/allowedUserIds/trustedBotIds when cortex.yaml changes — no bot restart.

Matched by immutable \`workspaceId\`. Hot-reload-safe fields: \`channels\`, \`roles\`, \`defaultRole\`, \`allowedUserIds\`, \`trustedBotIds\`. Reconnect-required (preserved across spread): \`botToken\`, \`appToken\`, \`workspaceId\`.

## Class shape changes

- \`agent\` + \`presence\` lose \`readonly\` (both reassigned — Holly W3 invariant matches Discord/Mattermost)
- \`trustedBotIds\` loses \`readonly\` (runtime is still set-like; only \`updateConfig\` reassigns the reference)

## Tests

7 new in \`slack-adapter.test.ts\` (66 → 73 Slack tests). Full suite 3053/3054 + tsc + lint green.

## Remaining cortex#235

r1#7 trust-resolver two-pass merge, r1#11 additional test coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)