### PR TITLE
fix(routing): defensive .catch() on audit-envelope publishes (closes cortex#137)

### DIFF
--- a/src/bus/__tests__/surface-router.test.ts
+++ b/src/bus/__tests__/surface-router.test.ts
@@ -1945,3 +1945,59 @@ describe("createSurfaceRouter — D.2 federation gating end-to-end", () => {
     expect(published[0]!.payload.principal_id).toBe("unknown");
   });
 });
+
+// ---------------------------------------------------------------------------
+// cortex#137 — defensive .catch() on emitAccessFiltered runtime.publish
+// ---------------------------------------------------------------------------
+
+describe("emitAccessFiltered — defensive .catch on publish failure (cortex#137)", () => {
+  test("a rejecting runtime.publish surfaces stderr instead of unhandled rejection", async () => {
+    // Build a runtime whose publish() REJECTS — simulates a future
+    // regression of the "never throws" contract on MyelinRuntime.
+    const rejectingRuntime: MyelinRuntime = {
+      enabled: true,
+      onEnvelope: () => ({ unregister: () => {} }),
+      publish: async () => { throw new Error("simulated publish failure"); },
+      stop: async () => {},
+    };
+    // Capture stderr writes.
+    const originalWrite = process.stderr.write.bind(process.stderr);
+    const captured: string[] = [];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (process.stderr as { write: (chunk: unknown) => boolean }).write = (chunk) => {
+      captured.push(typeof chunk === "string" ? chunk : String(chunk));
+      return true;
+    };
+    try {
+      const router = createSurfaceRouter(rejectingRuntime, {
+        systemEventSource: TEST_SYSTEM_EVENT_SOURCE,
+      });
+      const a = recordingAdapter({
+        id: "dashboard",
+        subjects: [">"],
+        visibility: { hide_residency_outside: ["CH", "DE"] },
+      });
+      router.register(a.adapter);
+      await router.dispatch(
+        makeEnvelope({
+          sovereignty: {
+            classification: "federated", data_residency: "US", max_hop: 1,
+            frontier_ok: true, model_class: "any",
+          },
+        }),
+        "federated.metafactory.x.y.z",
+      );
+      // Yield so the catch fires.
+      await new Promise((r) => setTimeout(r, 0));
+      // Adapter was filtered (no render).
+      expect(a.calls).toHaveLength(0);
+      // Stderr got the audit-failure alert — operator-visible signal
+      // instead of silent drop.
+      const alert = captured.find((c) => c.includes("system.access.filtered"));
+      expect(alert).toBeDefined();
+      expect(alert).toContain("simulated publish failure");
+    } finally {
+      (process.stderr as { write: typeof originalWrite }).write = originalWrite;
+    }
+  });
+});

--- a/src/bus/surface-router.ts
+++ b/src/bus/surface-router.ts
@@ -587,7 +587,18 @@ function emitAccessFiltered(
     // Fire-and-forget: runtime.publish is async but its contract is that it
     // never throws (errors are logged + swallowed internally). The floating
     // Promise resolves cleanly when the next event-loop tick runs.
-    void runtime.publish(env);
+    //
+    // cortex#137 — defensive .catch() so a regression of the
+    // "never throws" contract (refactor, new pluggable transport,
+    // unhandled async path) surfaces an operator-visible signal
+    // instead of silently dropping the audit envelope. Goes to
+    // stderr directly rather than another bus publish so a broken
+    // runtime can't swallow the alert about itself.
+    runtime.publish(env).catch((publishErr: unknown) => {
+      process.stderr.write(
+        `[surface-router] failed to emit system.access.filtered audit envelope: ${publishErr instanceof Error ? publishErr.message : String(publishErr)}\n`,
+      );
+    });
   } catch (err) {
     // Defensive: createSystemAccessFilteredEvent shouldn't throw on
     // schema-valid inputs, but a future change could surface a synchronous
@@ -832,7 +843,17 @@ function emitFederationDenied(
       networkId: decision.networkId,
       reason,
     });
-    void runtime.publish(env);
+    // cortex#137 — defensive .catch() so a regression of the
+    // runtime.publish "never throws" contract surfaces an
+    // operator-visible signal instead of dropping the federation
+    // audit envelope silently. Same pattern as
+    // `emitAccessFiltered` above. Direct stderr — a broken
+    // runtime can't swallow alerts about itself.
+    runtime.publish(env).catch((publishErr: unknown) => {
+      process.stderr.write(
+        `[surface-router] failed to emit system.access.federation_denied audit envelope: ${publishErr instanceof Error ? publishErr.message : String(publishErr)}\n`,
+      );
+    });
   } catch (err) {
     // Defensive — buildBaseEnvelope shouldn't throw on schema-valid
     // inputs, but if a future refactor makes it synchronous-throwing


### PR DESCRIPTION
## Summary

Closes cortex#137. \`emitAccessFiltered()\` + the federation-denied emit path in \`surface-router.ts\` previously fired audit envelopes as floating promises, relying on \`MyelinRuntime.publish()\`'s "never throws" contract. A regression would silently drop audit-trail envelopes.

Both call sites now wrap publish in a \`.catch()\` that writes directly to \`process.stderr\` — bypasses the runtime so a broken runtime can't swallow the alert about itself.

## Tests

1 new test asserts the catch fires + writes to stderr when \`runtime.publish\` rejects (simulated). 100 → 101 surface-router tests; 3069/3070 full suite + tsc + lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)