### PR TITLE
refactor(types): extract isUuid + isUuidLoose to shared module (closes cortex#196)

### DIFF
--- a/src/bus/github-events.ts
+++ b/src/bus/github-events.ts
@@ -63,6 +63,7 @@
 import type { Classification, Envelope } from "./myelin/envelope-validator";
 import { buildBaseEnvelope } from "./envelope-builder";
 import type { SystemEventSource } from "./system-events";
+import { isUuid } from "../common/types/uuid";
 
 /**
  * Re-export `SystemEventSource` under a domain-neutral alias so callers in
@@ -105,13 +106,9 @@ function defaultGithubSovereignty(
   };
 }
 
-/** UUID v4 pattern — same regex used by `taps/cc-events/cc-events.ts`. */
-const UUID_RE =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
-
-function isUuid(value: string): boolean {
-  return UUID_RE.test(value);
-}
+// cortex#196 — strict UUID check (`isUuid`) is shared in
+// `src/common/types/uuid.ts`. Same v1-v5 grammar previously
+// inlined here.
 
 /**
  * Sanitize a free-form segment for use inside `envelope.type`. The schema

--- a/src/common/types/__tests__/uuid.test.ts
+++ b/src/common/types/__tests__/uuid.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Unit tests for the shared UUID validators (cortex#196).
+ *
+ * Coverage: strict vs loose semantics + the canary cases
+ * (uppercase, malformed, empty, near-miss).
+ */
+
+import { describe, expect, test } from "bun:test";
+import { isUuid, isUuidLoose } from "../uuid";
+
+describe("isUuid — strict v1-v5", () => {
+  test("accepts canonical lowercase v4", () => {
+    expect(isUuid("9d2c4e8a-1b3f-4c5d-9e6f-7a8b9c0d1e2f")).toBe(true);
+  });
+
+  test("accepts uppercase via case-insensitive flag", () => {
+    expect(isUuid("9D2C4E8A-1B3F-4C5D-9E6F-7A8B9C0D1E2F")).toBe(true);
+  });
+
+  test("accepts canonical v1 (version=1 nibble)", () => {
+    expect(isUuid("9d2c4e8a-1b3f-1c5d-9e6f-7a8b9c0d1e2f")).toBe(true);
+  });
+
+  test("rejects v6 (version nibble outside 1-5)", () => {
+    expect(isUuid("9d2c4e8a-1b3f-6c5d-9e6f-7a8b9c0d1e2f")).toBe(false);
+  });
+
+  test("rejects v7 (version nibble outside 1-5)", () => {
+    expect(isUuid("9d2c4e8a-1b3f-7c5d-9e6f-7a8b9c0d1e2f")).toBe(false);
+  });
+
+  test("rejects bad variant nibble (c instead of 8/9/a/b)", () => {
+    expect(isUuid("9d2c4e8a-1b3f-4c5d-ce6f-7a8b9c0d1e2f")).toBe(false);
+  });
+
+  test("rejects non-hex characters", () => {
+    expect(isUuid("not-a-uuid-shape-string-here-at-all")).toBe(false);
+  });
+
+  test("rejects empty string", () => {
+    expect(isUuid("")).toBe(false);
+  });
+
+  test("rejects truncated UUID", () => {
+    expect(isUuid("9d2c4e8a-1b3f-4c5d-9e6f-7a8b9c0d1e2")).toBe(false);
+  });
+});
+
+describe("isUuidLoose — any hex 8-4-4-4-12", () => {
+  test("accepts canonical v4 (overlap with strict)", () => {
+    expect(isUuidLoose("9d2c4e8a-1b3f-4c5d-9e6f-7a8b9c0d1e2f")).toBe(true);
+  });
+
+  test("accepts v6 (the whole point — strict would reject)", () => {
+    expect(isUuidLoose("9d2c4e8a-1b3f-6c5d-9e6f-7a8b9c0d1e2f")).toBe(true);
+  });
+
+  test("accepts v7 (the whole point — strict would reject)", () => {
+    expect(isUuidLoose("9d2c4e8a-1b3f-7c5d-9e6f-7a8b9c0d1e2f")).toBe(true);
+  });
+
+  test("accepts bad-variant-nibble form (looser than strict)", () => {
+    expect(isUuidLoose("9d2c4e8a-1b3f-4c5d-ce6f-7a8b9c0d1e2f")).toBe(true);
+  });
+
+  test("rejects non-hex characters", () => {
+    expect(isUuidLoose("not-a-uuid-shape-string-here-at-all")).toBe(false);
+  });
+
+  test("rejects empty string", () => {
+    expect(isUuidLoose("")).toBe(false);
+  });
+
+  test("rejects wrong dash layout", () => {
+    expect(isUuidLoose("9d2c4e8a1b3f4c5d9e6f7a8b9c0d1e2f")).toBe(false);
+  });
+});

--- a/src/common/types/uuid.ts
+++ b/src/common/types/uuid.ts
@@ -1,0 +1,69 @@
+/**
+ * UUID validators — shared module for the two UUID-shaped checks
+ * cortex uses on inbound payloads.
+ *
+ * Why centralised: pre-cortex#196 the same regex pair appeared in
+ * 5+ callsites across `src/runner/`, `src/taps/cc-events/`,
+ * `src/bus/`, `src/substrates/`, and `src/surface/mc/api/`. Drift
+ * between independent copies was a real risk — particularly the
+ * STRICT-vs-LOOSE choice (whether to admit non-v1-v5 variants like
+ * v6/v7) which had no single source of truth.
+ *
+ * Cross-references:
+ *   - `src/runner/dispatch-listener.ts` — task_id strict check
+ *   - `src/taps/cc-events/cc-events.ts` — session_id strict check
+ *   - `src/bus/github-events.ts` — deliveryId strict check
+ *   - `src/substrates/claude-code/harness.ts` — requestId loose check
+ *   - `src/surface/mc/api/handlers.ts` — API param loose check
+ *
+ * Closes cortex#196.
+ */
+
+/**
+ * Strict UUID v1-v5 (RFC 4122) regex.
+ *
+ * Validates: 8-4-4-4-12 lowercase hex (case-insensitive via `i`
+ * flag), with the version nibble constrained to 1-5 and the
+ * variant nibble constrained to 8/9/a/b. Rejects v6/v7 and other
+ * non-RFC-4122 shapes.
+ *
+ * Use this for inputs that come from cortex-controlled producers
+ * — `runner/dispatch-listener.ts` task ids, `cc-events/cc-events.ts`
+ * session ids, `bus/github-events.ts` delivery ids. These are all
+ * minted via `crypto.randomUUID()` (which produces v4) and a
+ * non-v4 value indicates a bad payload, not a future variant.
+ */
+const STRICT_UUID_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+/**
+ * Loose hex-only UUID regex.
+ *
+ * Validates: 8-4-4-4-12 lowercase/uppercase hex. No version or
+ * variant nibble constraints — accepts v6, v7, and any other
+ * 36-char hex with the canonical dash positions.
+ *
+ * Use this for inputs from external/uncontrolled producers —
+ * `substrates/claude-code/harness.ts` request ids (Claude Code
+ * session ids aren't guaranteed v4), `surface/mc/api/handlers.ts`
+ * URL params (the API client may not be cortex). Trades stricter
+ * validation for cross-version compatibility.
+ */
+const LOOSE_UUID_REGEX =
+  /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+
+/**
+ * Strict UUID v1-v5 check. See {@link STRICT_UUID_REGEX} for the
+ * grammar + use-site guidance.
+ */
+export function isUuid(value: string): boolean {
+  return STRICT_UUID_REGEX.test(value);
+}
+
+/**
+ * Loose UUID check (any RFC-4122 dash layout, hex-only).
+ * See {@link LOOSE_UUID_REGEX} for the grammar + use-site guidance.
+ */
+export function isUuidLoose(value: string): boolean {
+  return LOOSE_UUID_REGEX.test(value);
+}

--- a/src/runner/dispatch-listener.ts
+++ b/src/runner/dispatch-listener.ts
@@ -79,6 +79,7 @@ import type {
 } from "../common/substrates/types";
 import type { PolicyEngine } from "../common/policy/engine";
 import { extractAgentIdFromDid } from "../common/policy/did";
+import { isUuid } from "../common/types/uuid";
 import type {
   Intent,
   PolicyDenyReason,
@@ -288,10 +289,9 @@ export function createDispatchListener(
  * (a producer that emits `received` and never sees `started` knows
  * something went wrong).
  */
-// UUID v1-v5 shape per RFC 4122 §3 — same regex used by the envelope
-// validator on `envelope.id`, applied here at the payload layer for
-// `payload.task_id`.
-const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+// cortex#196 — strict UUID v1-v5 check (`isUuid`) is now shared in
+// `src/common/types/uuid.ts`; the local `UUID_RE` regex was inlined
+// here pre-extraction.
 
 function parsePayload(envelope: Envelope): DispatchTaskReceivedPayload | null {
   const p = envelope.payload as Partial<DispatchTaskReceivedPayload> | undefined;
@@ -305,7 +305,7 @@ function parsePayload(envelope: Envelope): DispatchTaskReceivedPayload | null {
   // `started` / `completed` / `failed` envelopes downstream. Reject at
   // parse time so no envelopes are published and no CC process is
   // spawned for a bad id.
-  if (!UUID_RE.test(p.task_id)) {
+  if (!isUuid(p.task_id)) {
     console.warn(
       `dispatch-listener: rejecting envelope ${envelope.id} — task_id missing or not UUID-shaped`,
     );

--- a/src/substrates/claude-code/harness.ts
+++ b/src/substrates/claude-code/harness.ts
@@ -73,6 +73,7 @@
 import { randomUUID } from "crypto";
 
 import { CCSession, type CCSessionOpts, type CCSessionResult } from "../../runner/cc-session";
+import { isUuidLoose } from "../../common/types/uuid";
 import type { Envelope } from "../../bus/myelin/envelope-validator";
 import type {
   Capability,
@@ -389,7 +390,7 @@ export class ClaudeCodeHarness implements SessionHarness {
    * comparison across envelopes.
    */
   private correlationFor(req: DispatchRequest): string {
-    if (isUuid(req.requestId)) return req.requestId;
+    if (isUuidLoose(req.requestId)) return req.requestId;
     if (!this.warnedNonUuidRequestId) {
       console.warn(
         `claude-code-harness: requestId "${req.requestId}" is not UUID-shaped — substituting a generated correlation_id (this warning fires once per harness instance)`,
@@ -532,19 +533,11 @@ export class ClaudeCodeHarness implements SessionHarness {
 
 /**
  * Cheap UUID v4-ish validator. The envelope schema requires UUID-shaped
- * `correlation_id`; this check avoids minting a fresh UUID when the
- * caller already supplied a valid one as `requestId`.
- *
- * Pattern lifted verbatim from `bus/dispatch-events.ts` / `dispatch-
- * listener.ts` conventions — we match the same 8-4-4-4-12 hex layout
- * without enforcing the version/variant nibbles (the JSON Schema does
- * the strict check downstream).
- */
-function isUuid(s: string): boolean {
-  return /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/.test(
-    s,
-  );
-}
+// cortex#196 — loose UUID check (`isUuidLoose`) is shared in
+// `src/common/types/uuid.ts`. We match any 8-4-4-4-12 hex layout
+// without enforcing the version/variant nibbles (the JSON Schema
+// does the strict check downstream); v6/v7 session ids from CC
+// pass cleanly.
 
 /**
  * Trim error messages so a verbose stack doesn't blow the worklog limit

--- a/src/surface/mc/api/handlers.ts
+++ b/src/surface/mc/api/handlers.ts
@@ -17,6 +17,7 @@
 import type { Database } from "bun:sqlite";
 import type { ProcessManager } from "../session/process-manager";
 import type { SpawnFn } from "../session/endpoint-resolver";
+import { isUuidLoose } from "../../../common/types/uuid";
 import type { WsClientRegistry } from "../ws/client-registry";
 import type {
   ApiError,
@@ -580,7 +581,9 @@ export function _resetDispatchDebounceForTests(): void {
 // version bits — because the wrapper just needs *some* opaque string CC's
 // `--session-id` will accept and EventLogger will tag events with. Stricter
 // parsing has no operational benefit here.
-const UUID_RE = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+// cortex#196 — loose UUID check (`isUuidLoose`) is shared in
+// `src/common/types/uuid.ts`. Same 8-4-4-4-12 hex layout, no
+// version/variant constraint (matches the comment above).
 
 // eslint-disable-next-line @typescript-eslint/require-await
 export async function handleCreateSession(
@@ -608,7 +611,7 @@ export async function handleCreateSession(
   if (kind === "local.observed") {
     if (
       typeof body.ccSessionId !== "string" ||
-      !UUID_RE.test(body.ccSessionId)
+      !isUuidLoose(body.ccSessionId)
     ) {
       return error(
         `'ccSessionId' must be a UUID when kind='local.observed'`,

--- a/src/taps/cc-events/__tests__/cc-events.test.ts
+++ b/src/taps/cc-events/__tests__/cc-events.test.ts
@@ -10,8 +10,8 @@ import { describe, expect, test } from "bun:test";
 import {
   createCcEventEnvelope,
   createCcEventPublisher,
-  isUuid,
 } from "../cc-events";
+import { isUuid } from "../../../common/types/uuid";
 import type { PublishedEvent } from "../hooks/lib/event-types";
 import { validateEnvelope } from "../../../bus/myelin/envelope-validator";
 

--- a/src/taps/cc-events/cc-events.ts
+++ b/src/taps/cc-events/cc-events.ts
@@ -53,6 +53,7 @@ import {
   type Envelope,
 } from "../../bus/myelin/envelope-validator";
 import { buildBaseEnvelope } from "../../bus/envelope-builder";
+import { isUuid } from "../../common/types/uuid";
 import type { NatsLink } from "../../bus/nats/connection";
 import type { PublishedEvent } from "./hooks/lib/event-types";
 
@@ -118,18 +119,12 @@ function defaultCcSovereignty(
   };
 }
 
-/**
- * UUID v4 pattern — the envelope schema's `correlation_id` field constrains
- * to UUID format. CC sessions sometimes use UUID-shaped session_ids and
- * sometimes use shorter strings ("unknown", numeric ids); only UUID-shaped
- * values are propagated to envelope.correlation_id, the rest land in payload.
- */
-const UUID_RE =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
-
-export function isUuid(value: string): boolean {
-  return UUID_RE.test(value);
-}
+// cortex#196 — UUID v1-v5 check (`isUuid`) is shared in
+// `src/common/types/uuid.ts`. CC sessions sometimes use
+// UUID-shaped session_ids and sometimes use shorter strings
+// ("unknown", numeric ids); only UUID-shaped values are
+// propagated to envelope.correlation_id, the rest land in
+// payload.
 
 export interface CreateCcEventEnvelopeOpts {
   /**


### PR DESCRIPTION
## Summary

Closes cortex#196. Pre-PR the same UUID regex pair appeared in 5 callsites across \`runner/\`, \`taps/cc-events/\`, \`bus/\`, \`substrates/\`, and \`surface/mc/api/\`. New \`src/common/types/uuid.ts\` exports:

- \`isUuid(value)\` — strict v1-v5 RFC 4122
- \`isUuidLoose(value)\` — any hex 8-4-4-4-12

The strict/loose split (whether to admit v6/v7) is now documented in one place rather than implicit at each callsite.

## Callsites

| Site | Variant |
|---|---|
| \`runner/dispatch-listener.ts:294\` | strict |
| \`taps/cc-events/cc-events.ts:127\` | strict |
| \`bus/github-events.ts:109\` | strict |
| \`substrates/claude-code/harness.ts:543\` | loose |
| \`surface/mc/api/handlers.ts:583\` | loose |

Plus \`cc-events.test.ts\` import switch (was pulling \`isUuid\` from cc-events.ts; now from shared).

## Tests

16 new in \`src/common/types/__tests__/uuid.test.ts\` covering canonical v4, uppercase, v1, v6/v7 strict-rejection/loose-acceptance, bad variant nibble, non-hex, empty, truncated, wrong dash layout. 3070/3071 full suite + tsc + lint green.

## Out of scope

cortex#150 (AGENT_ID_REGEX) — 10+ callsites with variations; follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)