### PR TITLE
fix(bus): pass stack to deriveNatsSubject in MyelinRuntime.publish()

### DIFF
--- a/src/bus/myelin/__tests__/runtime.test.ts
+++ b/src/bus/myelin/__tests__/runtime.test.ts
@@ -401,6 +401,71 @@ describe("MyelinRuntime", () => {
       await runtime.stop();
     });
 
+    test("IAW Phase A.5 (cortex#262): tasks.* envelopes land in sage's 6-segment subscribe wildcard", async () => {
+      // Literal cortex#262 AC#3 — `Published subjects are 6-segment on
+      // tasks.* domain`. This is the wire shape pilot's `request-review`
+      // publish + sage's bridge subscribe both depend on; the test pins
+      // the exact subject so a future regression in either side surfaces
+      // here before the cross-repo loop breaks silently.
+      const fake = makeFakeNatsConnection();
+      const runtime = await startMyelinRuntime(
+        makeConfig({
+          url: "nats://localhost:4222",
+          name: "grove-bot",
+          subjects: ["local.{org}.>"],
+        }),
+        { connectImpl: async () => fake.nc, stack: "default" },
+      );
+      await runtime.publish(makeEnvelope({ type: "tasks.review.requested" }));
+      expect(fake.publishes[0]?.subject).toBe(
+        "local.metafactory.default.tasks.review.requested",
+      );
+      await runtime.stop();
+    });
+
+    test("IAW Phase A.5 (cortex#262): publish derives 6-segment local.{org}.{stack}.{type} when stack option is set", async () => {
+      // Stack-aware emit — operator config carries `stack: { id: andreas/research }`
+      // and the entrypoint passes `stack: "research"` through to the runtime.
+      // The resulting subject lands inside sage's `local.{org}.{stack}.>`
+      // subscription wildcard, closing the broadcast loop end-to-end.
+      const fake = makeFakeNatsConnection();
+      const runtime = await startMyelinRuntime(
+        makeConfig({
+          url: "nats://localhost:4222",
+          name: "grove-bot",
+          subjects: ["local.{org}.>"],
+        }),
+        { connectImpl: async () => fake.nc, stack: "research" },
+      );
+      await runtime.publish(makeEnvelope({ type: "system.adapter.degraded" }));
+      expect(fake.publish).toHaveBeenCalledTimes(1);
+      expect(fake.publishes[0]?.subject).toBe(
+        "local.metafactory.research.system.adapter.degraded",
+      );
+      await runtime.stop();
+    });
+
+    test("IAW Phase A.5 (cortex#262): publish falls through to legacy 5-segment when stack option is omitted", async () => {
+      // Backward compat — deployments that haven't wired stack identity
+      // continue to emit the legacy 5-segment shape. The runtime relays
+      // `stack: undefined` to `deriveNatsSubject` which short-circuits
+      // back to the pre-A.5 grammar. No behavior change for these callers.
+      const fake = makeFakeNatsConnection();
+      const runtime = await startMyelinRuntime(
+        makeConfig({
+          url: "nats://localhost:4222",
+          name: "grove-bot",
+          subjects: ["local.{org}.>"],
+        }),
+        { connectImpl: async () => fake.nc },
+      );
+      await runtime.publish(makeEnvelope({ type: "system.adapter.degraded" }));
+      expect(fake.publishes[0]?.subject).toBe(
+        "local.metafactory.system.adapter.degraded",
+      );
+      await runtime.stop();
+    });
+
     test("publish swallows underlying NATS errors (logs, never throws)", async () => {
       const fake = makeFakeNatsConnection();
       // Force the underlying nc.publish to throw — simulates connection-closed

--- a/src/bus/myelin/runtime.ts
+++ b/src/bus/myelin/runtime.ts
@@ -145,6 +145,24 @@ export interface MyelinRuntimeOptions {
    * mode to choose).
    */
   signFailureMode?: "fallback" | "drop";
+  /**
+   * IAW Phase A.5 (cortex#113 / closes cortex#262) — operator stack
+   * segment slotted into the published subject between `{org}` and
+   * `{type}`. When set, `publish()` derives subjects in the 6-segment
+   * stack-aware shape `local.{org}.{stack}.{type}` matching post-myelin#113
+   * subscribers (sage's bridge, cedar's dispatch, pilot's review-request
+   * subscriber). When undefined, `publish()` falls through to the legacy
+   * 5-segment form `local.{org}.{type}` — preserves identity for callers
+   * that haven't wired stack identity yet.
+   *
+   * The entrypoint (`src/cortex.ts` ~line 386) sources this from
+   * `deriveStackId(loadedConfig)` so a multi-stack deployment routes
+   * envelopes through the right wildcard. The `'default'` fallback that
+   * `deriveStackId` provides is what arrives here when the operator
+   * omits the `stack:` block — that matches sage's bridge default
+   * (`SAGE_STACK=default`) so the broadcast loop closes end-to-end.
+   */
+  stack?: string;
 }
 
 /**
@@ -318,6 +336,12 @@ export async function startMyelinRuntime(
   // `MyelinRuntime.publish: (env) => Promise<void>` contract.
   const signer = options?.signer;
   const signFailureMode = options?.signFailureMode ?? "fallback";
+  // Stack identity (cortex#262) — captured at runtime init so per-publish
+  // `deriveNatsSubject` calls don't re-read options on every emit. When
+  // undefined the publish path falls through to the legacy 5-segment
+  // grammar via `deriveNatsSubject(envelope)`; explicit stack flows
+  // through as `deriveNatsSubject(envelope, stack)`.
+  const stack = options?.stack;
   // Pre-encode the seed to the base64 shape myelin's `signEnvelope`
   // consumes — done once at runtime init rather than per-publish so
   // every call doesn't reallocate the encoding. Tests can pass a
@@ -351,7 +375,13 @@ export async function startMyelinRuntime(
     // without further changes. `envelope.source`'s first segment is the
     // same value `agent.operatorId` produces when emit-site helpers
     // assemble it, so subscribe-side `{org}` substitution stays symmetric.
-    const subject = deriveNatsSubject(envelope);
+    //
+    // IAW Phase A.5 (cortex#262 closes): pass `stack` so subjects land in
+    // the 6-segment `local.{org}.{stack}.{type}` grammar that sage's
+    // bridge + pilot's review-request subscriber expect. When undefined,
+    // `deriveNatsSubject` returns the legacy 5-segment shape — preserving
+    // emit-site behavior for deployments that haven't wired stack identity.
+    const subject = deriveNatsSubject(envelope, stack);
 
     // IAW Phase B.3: sign before publish if the runtime was started
     // with a signer. The chain-aware `signEnvelope` appends to any

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -262,19 +262,20 @@ export async function startCortex(
   console.log(`  Config: ${options.configPath ?? "(in-memory)"}`);
   console.log(`  PID: ${process.pid}`);
 
-  // IAW Phase A.5 (refs cortex#113) — resolve the deployment's stack identity
-  // at boot. `deriveStackId` returns `{operator, stack, id}`; today we only
-  // log the canonical id and stash nothing on the runtime. Once myelin#113
-  // lands and A.5.5 wires the stack segment into envelope subject derivation,
-  // the resolved value flows into `MyelinRuntime.publish()` — until then this
-  // is observational only (no behaviour change on emitted subjects).
+  // IAW Phase A.5 (refs cortex#113, closes cortex#262) — resolve the
+  // deployment's stack identity at boot. `deriveStackId` returns
+  // `{operator, stack, id}`; the `stack` segment flows into
+  // `MyelinRuntime.publish()` below so emitted envelopes land in the
+  // 6-segment `local.{org}.{stack}.{type}` grammar that sage's bridge
+  // and pilot's review-request subscriber both expect.
   //
   // The helper accepts a narrow `DeriveStackIdInput` shape (operator?.id +
   // optional stack.id) — we synthesise it from the loader-passed
   // `options.stack` (the top-level cortex.yaml `stack:` block, when present)
   // plus an `operator.id` derived from the BotConfig projection. The
   // fallback path (no `options.stack`, no `agent.operatorId`) returns
-  // `default/default` and the helper never throws.
+  // `default/default` and the helper never throws — that default matches
+  // sage's bridge default (`SAGE_STACK=default`).
   const derivedStack = deriveStackId({
     operator: { id: config.agent.operatorId ?? "default" },
     ...(options.stack !== undefined && { stack: options.stack }),
@@ -383,10 +384,17 @@ export async function startCortex(
     runtime = options.injectRuntime;
   } else {
     try {
-      runtime = await startMyelinRuntime(
-        config,
-        signer !== undefined ? { signer } : undefined,
-      );
+      // IAW Phase A.5 (cortex#262) — surface the resolved stack identity
+      // into the runtime so `publish()` emits 6-segment subjects matching
+      // sage's `local.{org}.{stack}.>` subscription. `derivedStack.stack`
+      // is the second segment of the canonical `{operator}/{stack}` id;
+      // when the operator omitted the `stack:` block, `deriveStackId`
+      // default-derived it to `'default'` (cortex.ts:278-281). That value
+      // is what sage's bridge listens for by default (`SAGE_STACK=default`).
+      runtime = await startMyelinRuntime(config, {
+        ...(signer !== undefined && { signer }),
+        stack: derivedStack.stack,
+      });
     } catch (err) {
       console.error("cortex: myelin runtime startup error (non-fatal):", err instanceof Error ? err.message : err);
     }

--- a/src/services/network-registry/src/signing.ts
+++ b/src/services/network-registry/src/signing.ts
@@ -51,16 +51,23 @@ export function canonicalJSON(value: unknown): string {
 // Base64 (URL-safe NOT used — operators paste standard base64)
 // =============================================================================
 
-export function base64ToBytes(b64: string): Uint8Array {
+export function base64ToBytes(b64: string): Uint8Array<ArrayBuffer> {
   // Workers + Bun + modern Node all have atob(). Wrap so a malformed input
   // surfaces as a recognisable Error rather than a DOMException.
+  //
+  // Return type is narrowed to `Uint8Array<ArrayBuffer>` (not the default
+  // `Uint8Array<ArrayBufferLike>`) so the result satisfies `BufferSource`
+  // for `crypto.subtle.importKey` / `sign` / `verify` under TS 5.7+ strict
+  // typings. `new Uint8Array(length)` always allocates an `ArrayBuffer`
+  // backing store, never `SharedArrayBuffer`, so the narrowing is sound.
   let bin: string;
   try {
     bin = atob(b64);
   } catch (_err) {
     throw new Error("invalid base64");
   }
-  const out = new Uint8Array(bin.length);
+  const buf = new ArrayBuffer(bin.length);
+  const out = new Uint8Array(buf);
   for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
   return out;
 }
@@ -91,10 +98,10 @@ export function bytesToBase64(bytes: Uint8Array): string {
 export async function verifyEd25519(
   pubkeyB64: string,
   signatureB64: string,
-  message: Uint8Array,
+  message: Uint8Array<ArrayBuffer>,
 ): Promise<boolean> {
-  let pubBytes: Uint8Array;
-  let sigBytes: Uint8Array;
+  let pubBytes: Uint8Array<ArrayBuffer>;
+  let sigBytes: Uint8Array<ArrayBuffer>;
   try {
     pubBytes = base64ToBytes(pubkeyB64);
     sigBytes = base64ToBytes(signatureB64);
@@ -131,7 +138,7 @@ export async function verifyEd25519(
  */
 export async function signEd25519(
   privateKeyB64: string,
-  message: Uint8Array,
+  message: Uint8Array<ArrayBuffer>,
 ): Promise<string> {
   const pkcs8 = base64ToBytes(privateKeyB64);
   const key = await crypto.subtle.importKey(


### PR DESCRIPTION
## Summary

Closes #262.

`MyelinRuntime.publish()` (`src/bus/myelin/runtime.ts:354`) called `deriveNatsSubject(envelope)` without the optional `stack` parameter, emitting 5-segment subjects. Post-IAW A.5 (myelin#113), the canonical grammar is 6-segment `local.{org}.{stack}.{type}` — what sage's bridge subscribes to and what pilot now publishes on (pilot#110). This PR closes the cortex-side gap.

## Changes

- **`src/bus/myelin/runtime.ts`** — `MyelinRuntimeOptions.stack?: string` added. Captured once at runtime init; passed to `deriveNatsSubject(envelope, stack)` on every publish. When undefined, `deriveNatsSubject` falls through to the legacy 5-segment grammar — bit-identical to today for deployments that haven't wired stack identity.

- **`src/cortex.ts`** — `startMyelinRuntime` boot path now sources `stack` from the already-resolved `derivedStack.stack` (output of `deriveStackId` from earlier in boot). When the operator omits the cortex.yaml `stack:` block, `deriveStackId` default-derives `"default"` — matching sage's bridge default (`SAGE_STACK=default`), closing the broadcast loop end-to-end without operator config. Refreshed the boot-path comment that previously called stack identity "observational only."

- **`src/services/network-registry/src/signing.ts`** — drive-by fix. Five pre-existing tsc errors blocking the pre-push smoke gate (recent strict typings tightened `crypto.subtle.importKey` / `sign` / `verify` to require `Uint8Array<ArrayBuffer>` over the default `Uint8Array<ArrayBufferLike>`). `base64ToBytes` always allocates fresh via `new ArrayBuffer(...)`, so the narrowed return type is sound; matching annotations propagate to call sites. Unrelated to NATS subject grammar but required to push past the gate.

## Tests

`src/bus/myelin/__tests__/runtime.test.ts`:
- `tasks.*` envelopes land in sage's 6-segment subscribe wildcard (literal cortex#262 AC#3) — `tasks.review.requested` → `local.metafactory.default.tasks.review.requested`.
- 6-segment derivation when `stack: "research"` option set.
- 5-segment fallback when `stack` option omitted (backward compat).

Full suite: **3088 pass, 1 skip, 0 fail**.

## Cross-repo drift (filed separately)

Holly's review surfaced **cortex#264** — `StackConfigSchema.id` regex permits underscores while myelin's `STACK_SEGMENT_REGEX` rejects them. Latent before this PR; live now. Filed; needs either cortex tightening or a myelin coordination PR.

## Refs

- myelin#113 (closed by myelin PR #114) — stack-aware subject grammar
- pilot#110 + #113 — companion fix on pilot's publish-review path
- myelin#152 + PR #153 — companion fix on `taskSubject` / `broadcastTaskSubject`
- cortex#264 — follow-up regex drift

## Test plan

- [x] `bun test` — 3088 pass, 0 fail
- [x] `bunx tsc --noEmit` — clean
- [x] Subject grammar verified by tests: `tasks.*` types emit 6-segment under stack, legacy path bit-identical when stack omitted
- [x] Local Holly review applied (1 major filed as cortex#264, 2 nits addressed in code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)