### PR TITLE
fix(taps): pass stack to deriveNatsSubject in cc-events relay (cortex#266)

### DIFF
--- a/src/taps/cc-events/__tests__/cc-events.test.ts
+++ b/src/taps/cc-events/__tests__/cc-events.test.ts
@@ -220,12 +220,46 @@ describe("createCcEventPublisher", () => {
     };
   }
 
-  test("publishes to local.{org}.{type}", () => {
+  test("publishes legacy 5-segment local.{org}.{type} when stack is omitted", () => {
     const link = makeLink();
     const pub = createCcEventPublisher({ link: link.stub, org: "metafactory" });
     pub(makeEvent({ event_type: "tool.bash.executed" }));
     expect(link.calls).toHaveLength(1);
     expect(link.calls[0]!.subject).toBe("local.metafactory.tool.bash.executed");
+  });
+
+  // cortex#266 — stack-aware publish path. When the boot path supplies
+  // `stack` (sourced from `deriveStackId(loadedConfig).stack`), the relay
+  // emits the 6-segment subject form matching `MyelinRuntime.publish`
+  // post-cortex#262 and sage's bridge subscription.
+  test("publishes stack-aware 6-segment local.{org}.{stack}.{type} when stack is supplied (cortex#266)", () => {
+    const link = makeLink();
+    const pub = createCcEventPublisher({
+      link: link.stub,
+      org: "metafactory",
+      stack: "default",
+    });
+    pub(makeEvent({ event_type: "tool.bash.executed" }));
+    expect(link.calls).toHaveLength(1);
+    expect(link.calls[0]!.subject).toBe(
+      "local.metafactory.default.tool.bash.executed",
+    );
+  });
+
+  test("stack-aware emit honours multi-stack operator config", () => {
+    // Different stack value routes to a different subscriber wildcard.
+    // Multi-stack operators (`andreas/research`, `andreas/production`)
+    // depend on this isolation.
+    const link = makeLink();
+    const pub = createCcEventPublisher({
+      link: link.stub,
+      org: "andreas",
+      stack: "research",
+    });
+    pub(makeEvent({ event_type: "session.started" }));
+    expect(link.calls[0]!.subject).toBe(
+      "local.andreas.research.session.started",
+    );
   });
 
   test("default org is 'default' when omitted", () => {

--- a/src/taps/cc-events/cc-events.ts
+++ b/src/taps/cc-events/cc-events.ts
@@ -215,6 +215,25 @@ export interface CreateCcEventPublisherOpts {
    */
   org?: string;
   /**
+   * Operator stack segment slotted between `{org}` and `{type}` on the
+   * derived NATS subject (myelin#113 — IAW Phase A.5; closes cortex#266).
+   * When supplied, relay-lifted cc-events publish on the 6-segment shape
+   * `local.{org}.{stack}.{type}` matching sage's bridge subscription
+   * and the MyelinRuntime.publish path post-cortex#262. When undefined,
+   * the legacy 5-segment form `local.{org}.{type}` is emitted —
+   * bit-identical to today's output, so callers that haven't wired
+   * stack identity see no change.
+   *
+   * Production callers (the cortex boot path in `src/cortex.ts`) source
+   * this from `deriveStackId(loadedConfig).stack` — the same value
+   * `MyelinRuntime.publish` receives, so the runtime path and the
+   * cc-events relay agree on the wire grammar for one operator instance.
+   * `public.` classification ignores `stack` (per myelin's
+   * `deriveNatsSubject` semantics — `public` subjects carry no org or
+   * stack segments).
+   */
+  stack?: string;
+  /**
    * Override the envelope `source.agent` segment. Defaults to `"cortex"`.
    */
   agent?: string;
@@ -267,6 +286,7 @@ export function createCcEventPublisher(
   opts: CreateCcEventPublisherOpts,
 ): (event: PublishedEvent) => void {
   const org = opts.org ?? "default";
+  const stack = opts.stack;
   const source: CcEventSource = {
     org,
     agent: opts.agent ?? "cortex",
@@ -281,8 +301,14 @@ export function createCcEventPublisher(
 
   return (event: PublishedEvent) => {
     const envelope = buildEnvelope(event, source);
-    // Subject mirrors envelope classification per IAW A.3.
-    const subject = deriveNatsSubject(envelope);
+    // Subject mirrors envelope classification per IAW A.3 AND the
+    // operator stack per IAW A.5 (cortex#266). `stack` is undefined
+    // when the operator omitted the `cortex.yaml stack:` block; in
+    // that case `deriveNatsSubject` returns the legacy 5-segment form
+    // (bit-identical to pre-cortex#266 output). When supplied, the
+    // 6-segment form `local.{org}.{stack}.{type}` is emitted so this
+    // relay's wire grammar matches MyelinRuntime.publish post-#262.
+    const subject = deriveNatsSubject(envelope, stack);
     try {
       opts.link.publish(subject, JSON.stringify(envelope));
     } catch (err) {

--- a/src/taps/cc-events/cc-events.ts
+++ b/src/taps/cc-events/cc-events.ts
@@ -301,13 +301,7 @@ export function createCcEventPublisher(
 
   return (event: PublishedEvent) => {
     const envelope = buildEnvelope(event, source);
-    // Subject mirrors envelope classification per IAW A.3 AND the
-    // operator stack per IAW A.5 (cortex#266). `stack` is undefined
-    // when the operator omitted the `cortex.yaml stack:` block; in
-    // that case `deriveNatsSubject` returns the legacy 5-segment form
-    // (bit-identical to pre-cortex#266 output). When supplied, the
-    // 6-segment form `local.{org}.{stack}.{type}` is emitted so this
-    // relay's wire grammar matches MyelinRuntime.publish post-#262.
+    // IAW A.3 classification + A.5 stack — see `CreateCcEventPublisherOpts.stack`.
     const subject = deriveNatsSubject(envelope, stack);
     try {
       opts.link.publish(subject, JSON.stringify(envelope));

--- a/src/taps/cc-events/relay.ts
+++ b/src/taps/cc-events/relay.ts
@@ -195,12 +195,24 @@ program
       options.natsToken ?? process.env.NATS_TOKEN;
     const org: string =
       options.org ?? process.env.GROVE_OPERATOR ?? process.env.NATS_ORG ?? "default";
-    // cortex#266 — stack segment (IAW A.5). When supplied, the relay
-    // publishes on the 6-segment subject form matching
-    // MyelinRuntime.publish post-cortex#262 (and sage's bridge
-    // subscription). When omitted, falls through to legacy 5-segment.
+    // cortex#266 — IAW A.5 stack segment for 6-segment publishes.
     const stack: string | undefined =
       options.stack ?? process.env.CORTEX_STACK ?? undefined;
+    // cortex#275 (Sage cycle 1) — fail-fast stack validation. If the
+    // operator supplied a malformed stack value (`*`, `>`, empty,
+    // uppercase, etc.), reject at startup with a clear error rather
+    // than letting the bad value reach `deriveNatsSubject` per-event
+    // and producing a stream of stderr lines. Mirrors the same regex
+    // myelin's `assertSegment` uses; inlined here so the relay doesn't
+    // depend on a non-barreled internal export.
+    if (stack !== undefined && !/^[a-z][a-z0-9-]{0,62}$/.test(stack)) {
+      console.error(
+        `cortex-relay: invalid --stack / CORTEX_STACK value ${JSON.stringify(stack)} — ` +
+          `must match /^[a-z][a-z0-9-]{0,62}$/ (lowercase alphanumeric + hyphens, ` +
+          `start with letter, 1–63 chars)`,
+      );
+      process.exit(1);
+    }
 
     let natsLink: NatsLink | undefined;
     let onPublished: ((e: import("./hooks/lib/event-types").PublishedEvent) => void) | undefined;

--- a/src/taps/cc-events/relay.ts
+++ b/src/taps/cc-events/relay.ts
@@ -24,6 +24,7 @@ interface StartOptions {
   natsUrl?: string;
   natsToken?: string;
   org?: string;
+  stack?: string;
 }
 interface TestOptions {
   policy: string;
@@ -162,6 +163,10 @@ program
     "--org <org>",
     "Operator/org segment for published subjects (local.{org}.{type}). Falls back to env var GROVE_OPERATOR or NATS_ORG.",
   )
+  .option(
+    "--stack <stack>",
+    "Operator stack segment for stack-aware subjects (local.{org}.{stack}.{type}). Matches the cortex.yaml stack: block. Falls back to env var CORTEX_STACK. When omitted, relay publishes on the legacy 5-segment form.",
+  )
   .action(async (options: StartOptions) => {
     if (!existsSync(options.policy)) {
       console.error(`Policy file not found: ${options.policy}`);
@@ -190,6 +195,12 @@ program
       options.natsToken ?? process.env.NATS_TOKEN;
     const org: string =
       options.org ?? process.env.GROVE_OPERATOR ?? process.env.NATS_ORG ?? "default";
+    // cortex#266 — stack segment (IAW A.5). When supplied, the relay
+    // publishes on the 6-segment subject form matching
+    // MyelinRuntime.publish post-cortex#262 (and sage's bridge
+    // subscription). When omitted, falls through to legacy 5-segment.
+    const stack: string | undefined =
+      options.stack ?? process.env.CORTEX_STACK ?? undefined;
 
     let natsLink: NatsLink | undefined;
     let onPublished: ((e: import("./hooks/lib/event-types").PublishedEvent) => void) | undefined;
@@ -204,10 +215,12 @@ program
         onPublished = createCcEventPublisher({
           link: natsLink,
           org,
+          ...(stack !== undefined && { stack }),
         });
         const safeUrl = natsUrl.replace(/\/\/[^@/]+@/, "//***@");
+        const stackSuffix = stack !== undefined ? ` stack="${stack}"` : "";
         console.log(
-          `cortex-relay: nats publishing enabled — ${safeUrl} (org="${org}")`,
+          `cortex-relay: nats publishing enabled — ${safeUrl} (org="${org}"${stackSuffix})`,
         );
       } catch (err) {
         // Per the design rule: failed NATS startup must NOT crash the


### PR DESCRIPTION
Closes #266. Companion to cortex#262 (PR #265). cc-events relay was bypassing the 6-segment cutover. `CreateCcEventPublisherOpts.stack` added; CLI gains `--stack` flag with `$CORTEX_STACK` env fallback. Tests: 32 pass, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)