### PR TITLE
fix(runner): stack-aware default subject + audit-envelope synthesis in dispatch-listener

### DIFF
--- a/src/runner/__tests__/dispatch-listener.test.ts
+++ b/src/runner/__tests__/dispatch-listener.test.ts
@@ -200,6 +200,59 @@ describe("createDispatchListener — surfaceConfig", () => {
     ]);
   });
 
+  // cortex#267 — stack-aware default subjects. When the boot path
+  // supplies `stack` (from `deriveStackId(loadedConfig).stack`), the
+  // listener subscribes on the 6-segment grammar matching sage's
+  // emit-side post-IAW A.5. Stack-less callers stay on the legacy
+  // 5-segment form.
+  test("default subjects use 6-segment grammar when stack is supplied (cortex#267)", () => {
+    const { runtime } = recordingRuntime();
+    const router = createSurfaceRouter(runtime);
+    const listener = createDispatchListener({
+      runtime,
+      router,
+      source: SOURCE,
+      stack: "default",
+      ccSessionFactory: fakeFactory(SUCCESS_RESULT).factory,
+    });
+    expect(listener.surfaceConfig.subjects).toEqual([
+      "local.metafactory.default.dispatch.task.received",
+    ]);
+  });
+
+  test("default subjects honour multi-stack operator config", () => {
+    const { runtime } = recordingRuntime();
+    const router = createSurfaceRouter(runtime);
+    const listener = createDispatchListener({
+      runtime,
+      router,
+      source: SOURCE,
+      stack: "research",
+      ccSessionFactory: fakeFactory(SUCCESS_RESULT).factory,
+    });
+    expect(listener.surfaceConfig.subjects).toEqual([
+      "local.metafactory.research.dispatch.task.received",
+    ]);
+  });
+
+  test("custom subjects bypass stack-aware default", () => {
+    // Operators supplying explicit `subjects` keep full control; the
+    // listener does not re-write their patterns.
+    const { runtime } = recordingRuntime();
+    const router = createSurfaceRouter(runtime);
+    const listener = createDispatchListener({
+      runtime,
+      router,
+      source: SOURCE,
+      stack: "default",
+      subjects: ["federated.{net}.dispatch.task.received"],
+      ccSessionFactory: fakeFactory(SUCCESS_RESULT).factory,
+    });
+    expect(listener.surfaceConfig.subjects).toEqual([
+      "federated.{net}.dispatch.task.received",
+    ]);
+  });
+
   test("adapter id defaults to runner-dispatch-listener", () => {
     const { runtime } = recordingRuntime();
     const router = createSurfaceRouter(runtime);

--- a/src/runner/dispatch-listener.ts
+++ b/src/runner/dispatch-listener.ts
@@ -223,22 +223,33 @@ export interface DispatchListener {
 // ---------------------------------------------------------------------------
 
 /**
+ * Build the canonical `dispatch.task.received` subject for `{org}`
+ * (+ optional `{stack}`). Used by both `defaultSubjects` (subscribe-side)
+ * and the audit-envelope fallback in `handleDispatchEnvelope`
+ * (synthesised when an inbound envelope arrived without a wire
+ * subject). Single source of truth so the next subject-shape change
+ * (e.g. cortex#264 underscore-regex resolution) updates both paths in
+ * lockstep — cortex#276 Maintainability finding cycle 2.
+ *
+ * IAW Phase A.5 (cortex#267): emits the 6-segment stack-aware grammar
+ * when `stack` is supplied; falls through to the legacy 5-segment form
+ * for backward compatibility with pre-A.5 deployments.
+ */
+function dispatchReceivedSubject(org: string, stack?: string): string {
+  if (stack === undefined) {
+    return `local.${org}.dispatch.task.received`;
+  }
+  return `local.${org}.${stack}.dispatch.task.received`;
+}
+
+/**
  * Default subject for the runner's bus subscription. The `{org}` segment
  * is substituted at registration time using `source.org` so a misconfigured
  * runner with no operator id can still subscribe (it'll match nothing
  * unless someone publishes under `local.default.dispatch.task.received`).
- *
- * IAW Phase A.5 (cortex#267): when `stack` is supplied, emits the
- * 6-segment stack-aware grammar `local.{org}.{stack}.dispatch.task.received`
- * matching sage's emit-side. When omitted, falls through to the legacy
- * 5-segment form for backward compatibility with operators on the
- * pre-A.5 deployment.
  */
 function defaultSubjects(org: string, stack?: string): string[] {
-  if (stack === undefined) {
-    return [`local.${org}.dispatch.task.received`];
-  }
-  return [`local.${org}.${stack}.dispatch.task.received`];
+  return [dispatchReceivedSubject(org, stack)];
 }
 
 export function createDispatchListener(
@@ -503,16 +514,11 @@ async function handleDispatchEnvelope(
     // callers / unit tests that don't pass a subject).
     //
     // IAW Phase A.5 (cortex#267): the synthesised fallback honours the
-    // operator's stack. Stack-aware deployments synthesise the 6-segment
-    // form `local.{org}.{stack}.dispatch.task.received` so audit
-    // consumers correlate against the same wire grammar the listener
-    // actually subscribes to. Stack-less deployments fall through to
-    // the legacy 5-segment form bit-identical to pre-cortex#267.
-    const synthesisedSubject =
-      stack === undefined
-        ? `local.${source.org}.dispatch.task.received`
-        : `local.${source.org}.${stack}.dispatch.task.received`;
-    const auditEnvelopeSubject = subject ?? synthesisedSubject;
+    // operator's stack via the shared `dispatchReceivedSubject` helper —
+    // single source of truth across the listener's subscribe-side
+    // default AND this audit-envelope synthesis path (cortex#276
+    // Maintainability finding cycle 2).
+    const auditEnvelopeSubject = subject ?? dispatchReceivedSubject(source.org, stack);
     const auditCommon = {
       source,
       principalId: decision.principalId,

--- a/src/runner/dispatch-listener.ts
+++ b/src/runner/dispatch-listener.ts
@@ -156,9 +156,23 @@ export interface DispatchListenerOptions {
   /** Source identity for the lifecycle envelopes the listener emits. */
   source: SystemEventSource;
   /**
-   * Subject pattern(s) to subscribe to. Defaults to
-   * `local.{org}.dispatch.task.received` per the plan §4.5. Tests can
-   * override with broader patterns (`local.test.dispatch.task.received`).
+   * Operator stack segment (IAW Phase A.5, cortex#267) used to build the
+   * subscription subject and the audit-envelope `dispatch.task.received`
+   * synthesis path. When supplied, both subjects land on the 6-segment
+   * stack-aware grammar `local.{org}.{stack}.dispatch.task.received`
+   * matching sage's emit-side post-IAW A.5. When omitted, the legacy
+   * 5-segment form is used — bit-identical to pre-cortex#267 output, so
+   * deployments without a `cortex.yaml stack:` block see no change.
+   *
+   * Production callers source this from `deriveStackId(loadedConfig).stack`
+   * — same value `MyelinRuntime.publish` receives post-cortex#262.
+   */
+  stack?: string;
+  /**
+   * Subject pattern(s) to subscribe to. When omitted, the listener
+   * derives the default from `source.org` + optional `stack` per
+   * the IAW A.5 grammar. Tests can override with broader patterns
+   * (`local.test.dispatch.task.received`).
    */
   subjects?: string[];
   /**
@@ -213,9 +227,18 @@ export interface DispatchListener {
  * is substituted at registration time using `source.org` so a misconfigured
  * runner with no operator id can still subscribe (it'll match nothing
  * unless someone publishes under `local.default.dispatch.task.received`).
+ *
+ * IAW Phase A.5 (cortex#267): when `stack` is supplied, emits the
+ * 6-segment stack-aware grammar `local.{org}.{stack}.dispatch.task.received`
+ * matching sage's emit-side. When omitted, falls through to the legacy
+ * 5-segment form for backward compatibility with operators on the
+ * pre-A.5 deployment.
  */
-function defaultSubjects(org: string): string[] {
-  return [`local.${org}.dispatch.task.received`];
+function defaultSubjects(org: string, stack?: string): string[] {
+  if (stack === undefined) {
+    return [`local.${org}.dispatch.task.received`];
+  }
+  return [`local.${org}.${stack}.dispatch.task.received`];
 }
 
 export function createDispatchListener(
@@ -229,7 +252,7 @@ export function createDispatchListener(
     policyEngine,
     adapterId = "runner-dispatch-listener",
   } = opts;
-  const subjects = opts.subjects ?? defaultSubjects(source.org);
+  const subjects = opts.subjects ?? defaultSubjects(source.org, opts.stack);
 
   let registration: { unregister: () => void } | null = null;
 
@@ -254,6 +277,7 @@ export function createDispatchListener(
         source,
         ccSessionFactory,
         policyEngine,
+        opts.stack,
       ),
   };
 
@@ -405,6 +429,7 @@ async function handleDispatchEnvelope(
   source: SystemEventSource,
   ccSessionFactory: CCSessionFactory | undefined,
   policyEngine: PolicyEngine | undefined,
+  stack: string | undefined,
 ): Promise<void> {
   const payload = parsePayload(envelope);
   if (!payload) {
@@ -476,8 +501,18 @@ async function handleDispatchEnvelope(
     // misrepresent the wire path on audit consumers. Fall back to the
     // synthesised local subject when `subject` is undefined (legacy
     // callers / unit tests that don't pass a subject).
-    const auditEnvelopeSubject =
-      subject ?? `local.${source.org}.dispatch.task.received`;
+    //
+    // IAW Phase A.5 (cortex#267): the synthesised fallback honours the
+    // operator's stack. Stack-aware deployments synthesise the 6-segment
+    // form `local.{org}.{stack}.dispatch.task.received` so audit
+    // consumers correlate against the same wire grammar the listener
+    // actually subscribes to. Stack-less deployments fall through to
+    // the legacy 5-segment form bit-identical to pre-cortex#267.
+    const synthesisedSubject =
+      stack === undefined
+        ? `local.${source.org}.dispatch.task.received`
+        : `local.${source.org}.${stack}.dispatch.task.received`;
+    const auditEnvelopeSubject = subject ?? synthesisedSubject;
     const auditCommon = {
       source,
       principalId: decision.principalId,

--- a/src/runner/dispatch-listener.ts
+++ b/src/runner/dispatch-listener.ts
@@ -281,15 +281,13 @@ export function createDispatchListener(
     // false })` so surface-router timeouts end the CC process eagerly
     // rather than waiting for cc-session's internal timer to fire.
     render: (envelope, _signal, subject) =>
-      handleDispatchEnvelope(
-        envelope,
-        subject,
+      handleDispatchEnvelope(envelope, subject, {
         runtime,
         source,
         ccSessionFactory,
         policyEngine,
-        opts.stack,
-      ),
+        stack: opts.stack,
+      }),
   };
 
   return {
@@ -433,15 +431,25 @@ function buildDispatchRequest(
  * worth the savings for A.1b. Shared infrastructure (the CC factory)
  * is threaded through via constructor opts.
  */
+/**
+ * Per-dispatch wiring grouped into one shape so the handler signature
+ * stays narrow (cortex#276 cycle 3 — Sage Maintainability suggestion).
+ * Mutates nothing — pure dependency injection.
+ */
+interface DispatchHandlerContext {
+  runtime: MyelinRuntime;
+  source: SystemEventSource;
+  ccSessionFactory: CCSessionFactory | undefined;
+  policyEngine: PolicyEngine | undefined;
+  stack: string | undefined;
+}
+
 async function handleDispatchEnvelope(
   envelope: Envelope,
   subject: string | undefined,
-  runtime: MyelinRuntime,
-  source: SystemEventSource,
-  ccSessionFactory: CCSessionFactory | undefined,
-  policyEngine: PolicyEngine | undefined,
-  stack: string | undefined,
+  ctx: DispatchHandlerContext,
 ): Promise<void> {
+  const { runtime, source, ccSessionFactory, policyEngine, stack } = ctx;
   const payload = parsePayload(envelope);
   if (!payload) {
     console.error(


### PR DESCRIPTION
Closes #267. Companion to cortex#262/#266. `DispatchListenerOptions.stack?` + `defaultSubjects(org, stack?)` + audit-envelope synthesis path. Tests: 38 pass. 

🤖 Generated with [Claude Code](https://claude.com/claude-code)