### PR TITLE
feat(bus): substitute {stack}. in MyelinRuntime + renderer subscribe patterns

### DIFF
--- a/src/bus/myelin/__tests__/runtime.test.ts
+++ b/src/bus/myelin/__tests__/runtime.test.ts
@@ -223,6 +223,66 @@ describe("MyelinRuntime", () => {
     await runtime.stop();
   });
 
+  // cortex#269 — `{stack}.` token substitution. Operator-written narrow
+  // subscribe patterns can now reference the operator's stack identity
+  // alongside `{org}` and have it expanded at boot. The `.` is part of
+  // the placeholder so stack-less deployments collapse cleanly to the
+  // legacy 5-segment shape.
+  test("subjects placeholder {stack}. is substituted from options.stack", async () => {
+    const fake = makeFakeNatsConnection();
+    const config = makeConfig({
+      url: "nats://localhost:4222",
+      name: "grove-bot",
+      subjects: ["local.{org}.{stack}.attention.>"],
+    });
+    const runtime = await startMyelinRuntime(config, {
+      connectImpl: async () => fake.nc,
+      stack: "research",
+    });
+    expect(runtime.enabled).toBe(true);
+    expect(fake.subscribePatterns[0]).toBe(
+      "local.andreas.research.attention.>",
+    );
+    await runtime.stop();
+  });
+
+  test("subjects placeholder {stack}. collapses to empty when options.stack is omitted (legacy compat)", async () => {
+    const fake = makeFakeNatsConnection();
+    const config = makeConfig({
+      url: "nats://localhost:4222",
+      name: "grove-bot",
+      subjects: ["local.{org}.{stack}.attention.>"],
+    });
+    const runtime = await startMyelinRuntime(config, {
+      connectImpl: async () => fake.nc,
+      // no stack supplied
+    });
+    expect(runtime.enabled).toBe(true);
+    // `{stack}.` collapses; resulting pattern matches legacy 5-segment
+    // shape so pre-A.5 publishers stay observable.
+    expect(fake.subscribePatterns[0]).toBe("local.andreas.attention.>");
+    await runtime.stop();
+  });
+
+  test("subjects without {stack} placeholder are unchanged regardless of options.stack", async () => {
+    // Default `["local.{org}.>"]` pattern uses multi-segment wildcard
+    // — already matches both 5-seg and 6-seg emissions. No substitution
+    // needed; the runtime must NOT corrupt this pattern when stack is
+    // supplied (`local.{org}.>` → `local.andreas.>`, not `local.andreas.research.>`).
+    const fake = makeFakeNatsConnection();
+    const config = makeConfig({
+      url: "nats://localhost:4222",
+      name: "grove-bot",
+      subjects: ["local.{org}.>"],
+    });
+    const runtime = await startMyelinRuntime(config, {
+      connectImpl: async () => fake.nc,
+      stack: "research",
+    });
+    expect(fake.subscribePatterns[0]).toBe("local.andreas.>");
+    await runtime.stop();
+  });
+
   test("redacts token-form credentials from NATS URL in log output", async () => {
     const fake = makeFakeNatsConnection();
     const config = makeConfig({

--- a/src/bus/myelin/runtime.ts
+++ b/src/bus/myelin/runtime.ts
@@ -237,9 +237,18 @@ export async function startMyelinRuntime(
   // (subscribe `{org}` === publish `{org}` for envelopes this stack emits)
   // has a regression test at
   // `src/bus/myelin/__tests__/runtime-org-symmetry.test.ts`.
-  const subjects = nats.subjects.map((s) =>
-    s.replaceAll("{org}", orgFromConfig(config.agent.operatorId)),
-  );
+  //
+  // cortex#269 — `{stack}.` substituted alongside `{org}` via the shared
+  // `makeSubjectPlaceholderSubstituter` helper (defined above; also used
+  // by the renderer-config boot path in `src/cortex.ts`). Stack-less
+  // deployments collapse `{stack}.` to empty, preserving legacy 5-segment
+  // subscribe patterns. The default `["local.{org}.>"]` pattern is
+  // unaffected — multi-segment `>` wildcard already matches both shapes.
+  const substituter = makeSubjectPlaceholderSubstituter({
+    org: orgFromConfig(config.agent.operatorId),
+    stack: options?.stack,
+  });
+  const subjects = substituter(nats.subjects);
 
   if (subjects.length === 0) {
     // cortex#88 item 6: empty `subjects` is the typical state today —

--- a/src/bus/myelin/runtime.ts
+++ b/src/bus/myelin/runtime.ts
@@ -189,6 +189,31 @@ export interface BusEnvelopeSigner {
   principal: string;
 }
 
+/**
+ * Build a `{org}` + `{stack}.` placeholder substituter for operator-
+ * configured subject patterns (cortex#269 / cortex#279 cycle 2).
+ *
+ * Used by `MyelinRuntime.publish`'s `nats.subjects` resolution and by
+ * `cortex.ts`'s renderer-config boot path. Extracted so both call
+ * sites can't drift on the substitution rule (stack-less deployments
+ * collapse `{stack}.` to empty; stack-aware deployments emit
+ * `${stack}.`).
+ *
+ * Returns a closure so the resolved `(org, stack)` pair is captured
+ * once and applied to N pattern strings without reallocating the
+ * substitution rules per call.
+ */
+export function makeSubjectPlaceholderSubstituter(opts: {
+  org: string;
+  stack?: string;
+}): (subjects: readonly string[]) => string[] {
+  const stackToken = opts.stack !== undefined ? `${opts.stack}.` : "";
+  return (subjects: readonly string[]) =>
+    subjects.map((s) =>
+      s.replaceAll("{org}", opts.org).replaceAll("{stack}.", stackToken),
+    );
+}
+
 export async function startMyelinRuntime(
   config: BotConfig,
   options?: MyelinRuntimeOptions,
@@ -244,6 +269,9 @@ export async function startMyelinRuntime(
   // deployments collapse `{stack}.` to empty, preserving legacy 5-segment
   // subscribe patterns. The default `["local.{org}.>"]` pattern is
   // unaffected — multi-segment `>` wildcard already matches both shapes.
+  // A pattern like `local.{org}.{stack}.system.>` resolves to either
+  // `local.{org}.{stack}.system.>` (stack-aware) or `local.{org}.system.>`
+  // (legacy) depending on whether the boot path supplied a stack.
   const substituter = makeSubjectPlaceholderSubstituter({
     org: orgFromConfig(config.agent.operatorId),
     stack: options?.stack,

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -1089,6 +1089,21 @@ export async function startCortex(
   // classes covering `local.{org}.system.>` so an operational alert
   // reliably reaches the operator even if one sink is the thing that
   // broke. Renderers never publish on the bus (architecture §9.3).
+  // cortex#269 — substitute `{org}` AND `{stack}` in renderer subscribe
+  // patterns so they resolve against the same canonical shape that
+  // `MyelinRuntime` already substitutes for `nats.subjects`. Without
+  // this, an operator-written `local.{org}.{stack}.system.>` pattern
+  // never matches an actual envelope's wire subject. The `{stack}.`
+  // placeholder includes the trailing dot so stack-less deployments
+  // collapse cleanly to `local.{org}.system.>`.
+  const rendererOrgValue = config.agent.operatorId ?? "default";
+  const rendererStackToken = `${derivedStack.stack}.`;
+  function substituteRendererSubjects(subscribe: readonly string[]): string[] {
+    return subscribe.map((s) =>
+      s.replaceAll("{org}", rendererOrgValue).replaceAll("{stack}.", rendererStackToken),
+    );
+  }
+
   const renderers: Renderer[] = [];
   for (const raw of config.renderers ?? []) {
     // BotConfig types renderers as z.unknown() so legacy bot.yaml loads
@@ -1104,7 +1119,10 @@ export async function startCortex(
       );
       continue;
     }
-    const rendererConfig = parseResult.data;
+    const rendererConfig = {
+      ...parseResult.data,
+      subscribe: substituteRendererSubjects(parseResult.data.subscribe),
+    };
     try {
       const renderer = createRenderer(rendererConfig);
       await renderer.start();

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -33,6 +33,7 @@ import type { UsageStats } from "./runner/stream-parser";
 import { buildSecurityPreamble } from "./runner/security-preamble";
 import { DispatchHandler } from "./bus/dispatch-handler";
 import {
+  makeSubjectPlaceholderSubstituter,
   startMyelinRuntime,
   type BusEnvelopeSigner,
   type MyelinRuntime,
@@ -1096,13 +1097,18 @@ export async function startCortex(
   // never matches an actual envelope's wire subject. The `{stack}.`
   // placeholder includes the trailing dot so stack-less deployments
   // collapse cleanly to `local.{org}.system.>`.
-  const rendererOrgValue = config.agent.operatorId ?? "default";
-  const rendererStackToken = `${derivedStack.stack}.`;
-  function substituteRendererSubjects(subscribe: readonly string[]): string[] {
-    return subscribe.map((s) =>
-      s.replaceAll("{org}", rendererOrgValue).replaceAll("{stack}.", rendererStackToken),
-    );
-  }
+  //
+  // cortex#279 cycle 2 — extracted to a shared helper so renderer- and
+  // runtime-side substitution can't drift. The stack-less branch
+  // (`{stack}.` → empty) mirrors `MyelinRuntime.publish`'s same-named
+  // helper, satisfying Sage's "renderer stack-less collapse missing"
+  // finding even though `derivedStack.stack` is currently always
+  // defined in production. Symmetric logic keeps future refactors
+  // honest if the boot ever passes `undefined`.
+  const subjectPlaceholderSubstituter = makeSubjectPlaceholderSubstituter({
+    org: config.agent.operatorId ?? "default",
+    stack: options.stack !== undefined ? derivedStack.stack : undefined,
+  });
 
   const renderers: Renderer[] = [];
   for (const raw of config.renderers ?? []) {
@@ -1121,7 +1127,7 @@ export async function startCortex(
     }
     const rendererConfig = {
       ...parseResult.data,
-      subscribe: substituteRendererSubjects(parseResult.data.subscribe),
+      subscribe: subjectPlaceholderSubstituter(parseResult.data.subscribe),
     };
     try {
       const renderer = createRenderer(rendererConfig);


### PR DESCRIPTION
Closes #269. `{stack}.` placeholder substituted alongside `{org}` in runtime + renderer subscribe patterns. Tests: 25 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)