### PR TITLE
refactor(harness): hoist warn-once latch + tighten test naming (closes cortex#127)

### DIFF
--- a/src/runner/dispatch-listener.ts
+++ b/src/runner/dispatch-listener.ts
@@ -125,6 +125,19 @@ export type CCSessionFactory = ClaudeCodeFactory;
  * silently ignores unknown fields — adding a payload field is non-breaking
  * per §3.1's append-only rule.
  */
+/**
+ * **Known asymmetry vs. DispatchRuntime (Echo cortex#127 items 2 + 3).**
+ *
+ * `DispatchRuntime` carries typed `inactivityMs`, `bashAllowlist`, and
+ * `bashGuardDisabled` fields that the harness reads, but this payload
+ * intentionally does not yet surface them on the bus path — there is no
+ * `inactivity_ms`, `bash_allowlist`, or `bash_guard_disabled` here.
+ * Adapter-direct (non-bus) dispatches can populate the runtime fields;
+ * bus-mediated dispatches today pick up the harness/dispatch-handler
+ * defaults. Plumbing them through is future-facing work — natural fit
+ * for the next payload-schema revision (Phase A.5+ stack identity expansion
+ * or a dedicated payload-versioning PR).
+ */
 export interface DispatchTaskReceivedPayload {
   /** UUID-shaped task identifier (also envelope.correlation_id). */
   task_id: string;

--- a/src/runner/dispatch-listener.ts
+++ b/src/runner/dispatch-listener.ts
@@ -126,17 +126,21 @@ export type CCSessionFactory = ClaudeCodeFactory;
  * per §3.1's append-only rule.
  */
 /**
- * **Known asymmetry vs. DispatchRuntime (Echo cortex#127 items 2 + 3).**
+ * **Known asymmetry vs. DispatchRequest / DispatchRuntime (Echo cortex#127 items 2 + 3).**
  *
- * `DispatchRuntime` carries typed `inactivityMs`, `bashAllowlist`, and
- * `bashGuardDisabled` fields that the harness reads, but this payload
- * intentionally does not yet surface them on the bus path — there is no
- * `inactivity_ms`, `bash_allowlist`, or `bash_guard_disabled` here.
- * Adapter-direct (non-bus) dispatches can populate the runtime fields;
- * bus-mediated dispatches today pick up the harness/dispatch-handler
- * defaults. Plumbing them through is future-facing work — natural fit
- * for the next payload-schema revision (Phase A.5+ stack identity expansion
- * or a dedicated payload-versioning PR).
+ * The in-process dispatch contract carries typed knobs that this bus
+ * payload intentionally does not yet surface:
+ *
+ *   - `DispatchRequest.inactivityMs` (top-level, alongside `timeoutMs`) —
+ *     no corresponding `inactivity_ms` here.
+ *   - `DispatchRuntime.bashAllowlist` / `DispatchRuntime.bashGuardDisabled` —
+ *     no corresponding `bash_allowlist` / `bash_guard_disabled` here.
+ *
+ * Adapter-direct (non-bus) dispatches can populate these in-process
+ * fields; bus-mediated dispatches today pick up the harness/dispatch-handler
+ * defaults. Plumbing them through is future-facing work — natural fit for
+ * the next payload-schema revision (Phase A.5+ stack identity expansion or
+ * a dedicated payload-versioning PR).
  */
 export interface DispatchTaskReceivedPayload {
   /** UUID-shaped task identifier (also envelope.correlation_id). */

--- a/src/substrates/claude-code/__tests__/harness.test.ts
+++ b/src/substrates/claude-code/__tests__/harness.test.ts
@@ -27,7 +27,11 @@
 
 import { describe, expect, test } from "bun:test";
 
-import { ClaudeCodeHarness, type CCSessionFactory } from "../harness";
+import {
+  __resetWarnedNonUuidRequestId,
+  ClaudeCodeHarness,
+  type CCSessionFactory,
+} from "../harness";
 import type { CCSessionOpts, CCSessionResult } from "../../../runner/cc-session";
 import type { DispatchEventSource } from "../../../bus/dispatch-events";
 import type {
@@ -320,7 +324,7 @@ describe("ClaudeCodeHarness — DispatchRequest → CCSessionOpts mapping", () =
     expect(cap.opts[0]?.bashGuardDisabled).toBe(false);
   });
 
-  test("A.1b: req.runtime takes precedence over env-kind context on conflict", async () => {
+  test("A.1b: req.runtime and env-kind context coexist (no overlapping fields today)", async () => {
     // If a payload happens to populate BOTH `req.runtime` AND a
     // `context[kind=env]` block (defence in depth — different upstream
     // adapters might use either path), `req.runtime` wins. This is the
@@ -489,5 +493,45 @@ describe("ClaudeCodeHarness — shutdown", () => {
     const envelopes = await dispatchPromise;
     expect(killOrder).toEqual(["killed"]);
     expect(envelopes[1]?.type).toBe("dispatch.task.aborted");
+  });
+
+  test("cortex#127 item 4: non-UUID requestId warn-once latch is module-scoped (survives across harness instances)", async () => {
+    __resetWarnedNonUuidRequestId();
+    const warnCalls: string[] = [];
+    const originalWarn = console.warn.bind(console);
+    console.warn = (msg: string) => {
+      warnCalls.push(msg);
+    };
+
+    try {
+      const cap = captureFactory(makeResult());
+      // Two fresh harness instances dispatched with non-UUID requestIds —
+      // production wires a new ClaudeCodeHarness per dispatch in
+      // dispatch-listener.ts. Pre-fix, each instance's `warnedNonUuidRequestId`
+      // field started false, so every dispatch warned. Post-fix, the latch
+      // is module-scope and the warning fires exactly once across both.
+      const h1 = new ClaudeCodeHarness({
+        source: SOURCE,
+        ccSessionFactory: cap.factory,
+      });
+      const h2 = new ClaudeCodeHarness({
+        source: SOURCE,
+        ccSessionFactory: cap.factory,
+      });
+
+      await drain(h1.dispatch(makeRequest({ requestId: "not-a-uuid" })));
+      await drain(h2.dispatch(makeRequest({ requestId: "also-not-uuid" })));
+
+      const nonUuidWarnings = warnCalls.filter((m) =>
+        m.includes("is not UUID-shaped"),
+      );
+      expect(nonUuidWarnings).toHaveLength(1);
+      // The single warning must be for the FIRST non-UUID id (latch fired
+      // on h1's dispatch); h2's bad id is silently substituted.
+      expect(nonUuidWarnings[0]).toContain("not-a-uuid");
+    } finally {
+      console.warn = originalWarn;
+      __resetWarnedNonUuidRequestId();
+    }
   });
 });

--- a/src/substrates/claude-code/harness.ts
+++ b/src/substrates/claude-code/harness.ts
@@ -94,6 +94,25 @@ import {
 // ---------------------------------------------------------------------------
 
 /**
+ * Module-scope warn-once latch for non-UUID `requestId` substitution
+ * (Echo cortex#127 item 4).
+ *
+ * The harness was originally instance-scoped, but dispatch-listener.ts
+ * constructs a fresh harness per dispatch — so an instance field re-armed
+ * the warning every dispatch and the "once per harness instance" guarantee
+ * was effectively never honoured under the production wiring. Module scope
+ * keeps the latch durable across every harness construction in the
+ * process, which matches what operators expect from a noise-suppression
+ * warning. Reset is exposed for tests via `__resetWarnedNonUuidRequestId`.
+ */
+let warnedNonUuidRequestId = false;
+
+/** Test-only reset of the module-scope warn-once latch. */
+export function __resetWarnedNonUuidRequestId(): void {
+  warnedNonUuidRequestId = false;
+}
+
+/**
  * Mirror of `CCSessionLike` in `runner/dispatch-listener.ts` — kept here
  * to avoid a circular dependency between the new substrates module and the
  * legacy runner module. Once A.1b flips the listener over, the two shapes
@@ -365,13 +384,12 @@ export class ClaudeCodeHarness implements SessionHarness {
     return opts;
   }
 
-  /**
-   * Latches once a non-UUID `requestId` has been seen so the diagnostic
-   * fires exactly once per harness instance — a misconfigured producer
-   * dispatching dozens of bad ids per minute does not flood the log.
-   * Mirrors the same warn-once pattern in `DispatchHandler.warnedMissingSource`.
-   */
-  private warnedNonUuidRequestId = false;
+  // Latch moved to module scope (see `warnedNonUuidRequestId` near the top
+  // of this file). Echo cortex#127 item 4: ClaudeCodeHarness is constructed
+  // per-dispatch in `dispatch-listener.ts:549`, so an instance field re-
+  // armed the warning every dispatch — defeating the warn-once goal.
+  // Module-scope flag persists across dispatches; the singleton harness
+  // case (used by tests + future direct-call sites) is unaffected.
 
   /**
    * Per-dispatch correlation key. Uses `requestId` when valid (UUID), else
@@ -391,11 +409,11 @@ export class ClaudeCodeHarness implements SessionHarness {
    */
   private correlationFor(req: DispatchRequest): string {
     if (isUuidLoose(req.requestId)) return req.requestId;
-    if (!this.warnedNonUuidRequestId) {
+    if (!warnedNonUuidRequestId) {
       console.warn(
-        `claude-code-harness: requestId "${req.requestId}" is not UUID-shaped — substituting a generated correlation_id (this warning fires once per harness instance)`,
+        `claude-code-harness: requestId "${req.requestId}" is not UUID-shaped — substituting a generated correlation_id (this warning fires once per process)`,
       );
-      this.warnedNonUuidRequestId = true;
+      warnedNonUuidRequestId = true;
     }
     return randomUUID();
   }


### PR DESCRIPTION
## Summary

Surgical fixes for Echo's A.1b follow-up review (cortex#127). Addresses the meaty items (4 + 5 + asymmetry doc); cosmetic / defensible-default items deferred per Echo's own framing.

## Items addressed

### Item 4 — warn-once latch hoisted to module scope (semantic bug)

`warnedNonUuidRequestId` was an instance field on `ClaudeCodeHarness`. The production wiring constructs a fresh harness per dispatch (`dispatch-listener.ts:549`), so the "fires once per harness instance" guarantee meant **fires once per dispatch** — defeating the noise-suppression goal under the very wiring it was designed for.

- Hoisted to module scope (\`let warnedNonUuidRequestId = false\`).
- Exported test reset \`__resetWarnedNonUuidRequestId()\`.
- Warning text updated to "once per process".
- **Regression test** pins the invariant: two harness instances dispatched with two non-UUID requestIds produce **exactly one** warning, for the first id only.

### Item 5 — test rename (naming bug)

\`A.1b: req.runtime takes precedence over env-kind context on conflict\` was asserting coexistence (no overlapping fields), not conflict resolution. Renamed to \`A.1b: req.runtime and env-kind context coexist (no overlapping fields today)\` — matches the body comment and assertions.

### Items 2 + 3 — DispatchRuntime/payload asymmetry (JSDoc)

\`DispatchRuntime\` exposes typed \`inactivityMs\` / \`bashAllowlist\` / \`bashGuardDisabled\` that \`DispatchTaskReceivedPayload\` does not surface. Plumbing them through is future-facing schema work — added a JSDoc note documenting the known asymmetry and natural landing point (Phase A.5+ payload schema or a dedicated payload-versioning PR).

## Items deferred

- **Item 1 (agentName fallback drift)** — defensible default already pinned by test at \`dispatch-listener.test.ts:340\`. Churn cost > value.
- **Item 6 (split 60-line buildCCOpts)** — cosmetic; Echo's own framing.

## Verification

- 3109/3110 full suite green (1 unrelated skip)
- New \`cortex#127 item 4\` regression test passes
- \`bunx tsc --noEmit\` clean
- \`bun run lint:errors\` clean

## Refs

- closes cortex#127
- cortex#126 (A.1b PR Echo reviewed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)