### PR TITLE
docs(adapter): pin setTrustedBotIds atomicity contract (closes cortex#108)

### DIFF
--- a/src/adapters/discord/index.ts
+++ b/src/adapters/discord/index.ts
@@ -557,6 +557,13 @@ export class DiscordAdapter implements PlatformAdapter {
    * id is never allowed regardless of what `next` contains.
    */
   setTrustedBotIds(next: ReadonlySet<string>): void {
+    // cortex#108 item 3: single reference reassignment — atomic in
+    // single-threaded JS, so the messageCreate hot path always observes
+    // either the pre-call or the post-call ReadonlySet (never a partially
+    // mutated set). If you extend this mutator to touch more than one
+    // field, replace the bare assignment with a coordinated swap (e.g.
+    // build the next state in a local + assign once) so the same
+    // atomicity property is preserved.
     this.trustedBotIds = next;
   }
 


### PR DESCRIPTION
## Summary

Tidy-up wrapping cortex#108 (Echo's A.3 follow-up review on cortex#105). Items 1, 2, and 4 are already addressed; this PR closes the only remaining item (3) with a one-line atomicity comment.

## Items disposition

| Item | Status | Location |
|---|---|---|
| **1 — TOCTOU window (major)** | Already shipped | Two-pass adapter pattern in \`DiscordAdapter.attachInboundDispatch()\` + Slack equivalent (PR #257); cortex.ts:482-490 calls in correct order |
| **2 — Pass-2 merge-semantics doc** | Already shipped | cortex.ts:475-490 (multi-line comment block) |
| **3 — \`setTrustedBotIds\` atomicity nit** | **This PR** | Adds 7-line comment on the Discord setTrustedBotIds documenting single-assignment atomicity + the constraint future maintainers preserve. Slack already had equivalent JSDoc (slack/index.ts:318-321); this brings Discord to parity. |
| **4 — Test factoring nit** | No action | Echo classified as "not material" |

## Verification

- \`bunx tsc --noEmit\` clean
- \`bun run lint:errors\` clean
- Comment-only — no behavioural change

## Refs

- closes cortex#108
- cortex#105 (Echo's original review)
- PR #257 (Slack two-pass — same pattern as item 1 closure)
- commit e0a24ef (Discord two-pass adapter shape)

🤖 Generated with [Claude Code](https://claude.com/claude-code)