### PR TITLE
feat(bus): cortex#237 PR-2 — review-events.ts envelope builders

### DIFF
--- a/src/bus/__tests__/review-events.test.ts
+++ b/src/bus/__tests__/review-events.test.ts
@@ -1,0 +1,512 @@
+/**
+ * cortex#237 PR-2 — tests for `review-events.ts` envelope constructors.
+ *
+ * Coverage axes mirror `dispatch-events.test.ts`:
+ *   1. Shape — fields match the spec verbatim, payload extras land in
+ *      payload (not envelope top-level), optional fields are omitted
+ *      (not `undefined`-valued) when callers don't pass them.
+ *   2. Validation — every constructed envelope passes the vendored
+ *      myelin schema. Catches regressions where someone adds a field
+ *      but forgets to keep the envelope shape (sovereignty, source
+ *      pattern, correlation UUID format).
+ *   3. Correlation — verdict envelopes echo the REQUEST envelope's `id`
+ *      as `correlation_id` (the load-bearing pilot contract per §5.1).
+ *   4. Discriminator alignment — verdict builder throws when `kind` and
+ *      `payload.verdict` disagree (§6.3 defensive guard).
+ *   5. Nak taxonomy — every `DispatchTaskFailedReason` variant round-trips
+ *      through the review-flavoured wrapper (cortex#249).
+ */
+
+import { describe, expect, test } from "bun:test";
+import { validateEnvelope, type Envelope } from "../myelin/envelope-validator";
+import {
+  createReviewRequestEvent,
+  createReviewTaskFailedEvent,
+  createReviewVerdictEvent,
+  type ReviewEventSource,
+  type ReviewVerdictPayload,
+} from "../review-events";
+
+const SOURCE: ReviewEventSource = {
+  org: "metafactory",
+  agent: "echo",
+  instance: "local",
+};
+
+const PILOT_SOURCE: ReviewEventSource = {
+  org: "metafactory",
+  agent: "pilot",
+  instance: "local",
+};
+
+const REQUEST_ENVELOPE_ID = "11111111-1111-4111-8111-111111111111";
+const TASK_ID = "22222222-2222-4222-8222-222222222222";
+const STARTED_AT = new Date("2026-05-16T09:42:00.000Z");
+const FAILED_AT = new Date("2026-05-16T09:42:30.000Z");
+
+// ---------------------------------------------------------------------------
+// createReviewRequestEvent
+// ---------------------------------------------------------------------------
+
+describe("createReviewRequestEvent", () => {
+  test("required fields populated; envelope passes schema validation", () => {
+    const env = createReviewRequestEvent({
+      source: PILOT_SOURCE,
+      flavor: "typescript",
+      payload: {
+        repo: "the-metafactory/cortex",
+        pr: 229,
+        reviewer: "echo",
+      },
+    });
+    expect(env.type).toBe("tasks.code-review.typescript");
+    expect(env.source).toBe("metafactory.pilot.local");
+    expect(env.payload).toMatchObject({
+      repo: "the-metafactory/cortex",
+      pr: 229,
+      reviewer: "echo",
+    });
+    // Optional fields omitted entirely when not passed
+    expect("feature" in env.payload).toBe(false);
+    expect("title" in env.payload).toBe(false);
+    expect("cycle" in env.payload).toBe(false);
+    expect("note" in env.payload).toBe(false);
+    // No correlation_id on request envelopes — `id` is the correlation root
+    expect(env.correlation_id).toBeUndefined();
+    expect(env.sovereignty).toEqual({
+      classification: "local",
+      data_residency: "NZ",
+      max_hop: 0,
+      frontier_ok: false,
+      model_class: "local-only",
+    });
+    expect(validateEnvelope(env).ok).toBe(true);
+  });
+
+  test("optional payload fields land in payload when provided", () => {
+    const env = createReviewRequestEvent({
+      source: PILOT_SOURCE,
+      flavor: "typescript",
+      payload: {
+        repo: "the-metafactory/cortex",
+        pr: 229,
+        reviewer: "echo",
+        feature: "C-237",
+        title: "feat(bus): Echo subscribes to tasks.code-review.*",
+        cycle: 1,
+        note: "second cycle after rebase",
+      },
+    });
+    expect(env.payload).toMatchObject({
+      feature: "C-237",
+      title: "feat(bus): Echo subscribes to tasks.code-review.*",
+      cycle: 1,
+      note: "second cycle after rebase",
+    });
+    expect(validateEnvelope(env).ok).toBe(true);
+  });
+
+  test("each invocation returns a fresh UUID id (envelope idempotency key)", () => {
+    const opts = {
+      source: PILOT_SOURCE,
+      flavor: "typescript" as const,
+      payload: {
+        repo: "the-metafactory/cortex",
+        pr: 229,
+        reviewer: "echo",
+      },
+    };
+    const a = createReviewRequestEvent(opts);
+    const b = createReviewRequestEvent(opts);
+    expect(a.id).not.toBe(b.id);
+    expect(a.id).toMatch(/^[0-9a-f-]{36}$/i);
+    expect(b.id).toMatch(/^[0-9a-f-]{36}$/i);
+  });
+
+  test("all flavor segments build a valid subject suffix", () => {
+    const flavors = [
+      "generic",
+      "typescript",
+      "python",
+      "rust",
+      "go",
+      "sql",
+      "docs",
+      "security",
+    ] as const;
+    for (const flavor of flavors) {
+      const env = createReviewRequestEvent({
+        source: PILOT_SOURCE,
+        flavor,
+        payload: { repo: "x/y", pr: 1, reviewer: "echo" },
+      });
+      expect(env.type).toBe(`tasks.code-review.${flavor}`);
+      expect(validateEnvelope(env).ok).toBe(true);
+    }
+  });
+
+  test("dataResidency override propagates into sovereignty", () => {
+    const env = createReviewRequestEvent({
+      source: { ...PILOT_SOURCE, dataResidency: "CH" },
+      flavor: "typescript",
+      payload: { repo: "x/y", pr: 1, reviewer: "echo" },
+    });
+    expect(env.sovereignty.data_residency).toBe("CH");
+    expect(validateEnvelope(env).ok).toBe(true);
+  });
+
+  test("classification=federated opt-in lands on envelope", () => {
+    const env = createReviewRequestEvent({
+      source: PILOT_SOURCE,
+      flavor: "typescript",
+      classification: "federated",
+      payload: { repo: "x/y", pr: 1, reviewer: "echo" },
+    });
+    expect(env.sovereignty.classification).toBe("federated");
+    expect(validateEnvelope(env).ok).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createReviewVerdictEvent
+// ---------------------------------------------------------------------------
+
+function makeVerdictPayload(
+  overrides: Partial<ReviewVerdictPayload> = {},
+): ReviewVerdictPayload {
+  return {
+    repo: "the-metafactory/cortex",
+    pr: 229,
+    reviewer: "echo",
+    verdict: "changes-requested",
+    summary: "verdict: blockers=0 majors=2 nits=3 — request-changes",
+    github_review_id: 2459183744,
+    github_review_url:
+      "https://github.com/the-metafactory/cortex/pull/229#pullrequestreview-2459183744",
+    submitted_at: "2026-05-16T09:51:30Z",
+    commit_id: "abc123def456789",
+    findings: { blockers: 0, majors: 2, nits: 3 },
+    inline_comments: 5,
+    ...overrides,
+  };
+}
+
+describe("createReviewVerdictEvent", () => {
+  test("changes-requested verdict — required fields populated; envelope passes schema validation", () => {
+    const payload = makeVerdictPayload();
+    const env = createReviewVerdictEvent({
+      source: SOURCE,
+      kind: "changes-requested",
+      correlationId: REQUEST_ENVELOPE_ID,
+      payload,
+    });
+    expect(env.type).toBe("review.verdict.changes-requested");
+    expect(env.source).toBe("metafactory.echo.local");
+    expect(env.correlation_id).toBe(REQUEST_ENVELOPE_ID);
+    expect(env.payload).toMatchObject({
+      repo: "the-metafactory/cortex",
+      pr: 229,
+      reviewer: "echo",
+      verdict: "changes-requested",
+      summary: payload.summary,
+      github_review_id: payload.github_review_id,
+      github_review_url: payload.github_review_url,
+      submitted_at: payload.submitted_at,
+      commit_id: payload.commit_id,
+      findings: { blockers: 0, majors: 2, nits: 3 },
+      inline_comments: 5,
+    });
+    expect(env.sovereignty).toEqual({
+      classification: "local",
+      data_residency: "NZ",
+      max_hop: 0,
+      frontier_ok: false,
+      model_class: "local-only",
+    });
+    expect(validateEnvelope(env).ok).toBe(true);
+  });
+
+  test("approved verdict — type suffix and payload discriminator agree", () => {
+    const env = createReviewVerdictEvent({
+      source: SOURCE,
+      kind: "approved",
+      correlationId: REQUEST_ENVELOPE_ID,
+      payload: makeVerdictPayload({
+        verdict: "approved",
+        summary: "verdict: blockers=0 majors=0 nits=0 — approve",
+        findings: { blockers: 0, majors: 0, nits: 0 },
+        inline_comments: 0,
+      }),
+    });
+    expect(env.type).toBe("review.verdict.approved");
+    expect((env.payload as { verdict: string }).verdict).toBe("approved");
+    expect(validateEnvelope(env).ok).toBe(true);
+  });
+
+  test("commented verdict — type suffix and payload discriminator agree", () => {
+    const env = createReviewVerdictEvent({
+      source: SOURCE,
+      kind: "commented",
+      correlationId: REQUEST_ENVELOPE_ID,
+      payload: makeVerdictPayload({
+        verdict: "commented",
+        summary: "verdict: blockers=0 majors=0 nits=2 — comment-only",
+        findings: { blockers: 0, majors: 0, nits: 2 },
+        inline_comments: 2,
+      }),
+    });
+    expect(env.type).toBe("review.verdict.commented");
+    expect((env.payload as { verdict: string }).verdict).toBe("commented");
+    expect(validateEnvelope(env).ok).toBe(true);
+  });
+
+  test("correlation_id matches the request envelope id verbatim", () => {
+    // Two verdict envelopes carrying the same correlation_id — pilot's
+    // wait-for-verdict groups by this exact value.
+    const env1 = createReviewVerdictEvent({
+      source: SOURCE,
+      kind: "approved",
+      correlationId: REQUEST_ENVELOPE_ID,
+      payload: makeVerdictPayload({ verdict: "approved" }),
+    });
+    const env2 = createReviewVerdictEvent({
+      source: SOURCE,
+      kind: "commented",
+      correlationId: REQUEST_ENVELOPE_ID,
+      payload: makeVerdictPayload({ verdict: "commented" }),
+    });
+    expect(env1.correlation_id).toBe(REQUEST_ENVELOPE_ID);
+    expect(env2.correlation_id).toBe(REQUEST_ENVELOPE_ID);
+    // ...but the envelope ids themselves are distinct
+    expect(env1.id).not.toBe(env2.id);
+  });
+
+  test("each invocation returns a fresh UUID id", () => {
+    const opts = {
+      source: SOURCE,
+      kind: "approved" as const,
+      correlationId: REQUEST_ENVELOPE_ID,
+      payload: makeVerdictPayload({ verdict: "approved" as const }),
+    };
+    const a = createReviewVerdictEvent(opts);
+    const b = createReviewVerdictEvent(opts);
+    expect(a.id).not.toBe(b.id);
+  });
+
+  test("throws when kind and payload.verdict disagree (defensive §6.3)", () => {
+    expect(() =>
+      createReviewVerdictEvent({
+        source: SOURCE,
+        kind: "approved",
+        correlationId: REQUEST_ENVELOPE_ID,
+        payload: makeVerdictPayload({ verdict: "commented" }),
+      }),
+    ).toThrow(/verdict-kind\/payload mismatch/);
+  });
+
+  test("classification=federated opt-in lands on envelope", () => {
+    const env = createReviewVerdictEvent({
+      source: SOURCE,
+      kind: "approved",
+      correlationId: REQUEST_ENVELOPE_ID,
+      classification: "federated",
+      payload: makeVerdictPayload({ verdict: "approved" }),
+    });
+    expect(env.sovereignty.classification).toBe("federated");
+    expect(validateEnvelope(env).ok).toBe(true);
+  });
+
+  test("payload.findings is a fresh literal — not aliased to caller's object", () => {
+    const findings = { blockers: 1, majors: 2, nits: 3 };
+    const env = createReviewVerdictEvent({
+      source: SOURCE,
+      kind: "changes-requested",
+      correlationId: REQUEST_ENVELOPE_ID,
+      payload: makeVerdictPayload({
+        verdict: "changes-requested",
+        findings,
+      }),
+    });
+    // Mutating the caller's object MUST NOT leak into the envelope.
+    findings.blockers = 99;
+    expect((env.payload as { findings: { blockers: number } }).findings.blockers).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createReviewTaskFailedEvent — nak taxonomy round-trip
+// ---------------------------------------------------------------------------
+
+describe("createReviewTaskFailedEvent", () => {
+  const baseOpts = {
+    source: SOURCE,
+    taskId: TASK_ID,
+    agentId: "echo",
+    startedAt: STARTED_AT,
+    failedAt: FAILED_AT,
+    errorSummary: "review pipeline failure",
+    // Per §5.2: review consumer passes the REQUEST envelope id, not taskId.
+    correlationId: REQUEST_ENVELOPE_ID,
+  } as const;
+
+  test("policy_denied — wraps dispatch-events.ts builder, preserves payload", () => {
+    const env = createReviewTaskFailedEvent({
+      ...baseOpts,
+      reason: {
+        kind: "policy_denied",
+        deny: { code: "unknown_principal", principal: "ghost" },
+      },
+    });
+    expect(env.type).toBe("dispatch.task.failed");
+    expect(env.correlation_id).toBe(REQUEST_ENVELOPE_ID);
+    const payload = env.payload as {
+      reason?: { kind: string; deny?: unknown };
+    };
+    expect(payload.reason?.kind).toBe("policy_denied");
+    expect(payload.reason?.deny).toEqual({
+      code: "unknown_principal",
+      principal: "ghost",
+    });
+    expect(validateEnvelope(env).ok).toBe(true);
+  });
+
+  test("cant_do — capability mismatch nak", () => {
+    const env = createReviewTaskFailedEvent({
+      ...baseOpts,
+      reason: {
+        kind: "cant_do",
+        detail: "no agent registered for code-review.rust",
+      },
+    });
+    const payload = env.payload as {
+      reason?: { kind: string; detail?: string };
+    };
+    expect(payload.reason?.kind).toBe("cant_do");
+    expect(payload.reason?.detail).toBe(
+      "no agent registered for code-review.rust",
+    );
+    expect(validateEnvelope(env).ok).toBe(true);
+  });
+
+  test("wont_do — sovereignty refusal nak", () => {
+    const env = createReviewTaskFailedEvent({
+      ...baseOpts,
+      reason: {
+        kind: "wont_do",
+        detail: "agent sovereignty: frontier model required but agent is selective",
+      },
+    });
+    const payload = env.payload as {
+      reason?: { kind: string; detail?: string };
+    };
+    expect(payload.reason?.kind).toBe("wont_do");
+    expect(payload.reason?.detail).toMatch(/sovereignty/);
+    expect(validateEnvelope(env).ok).toBe(true);
+  });
+
+  test("not_now — backpressure nak with retry_after_ms hint", () => {
+    const env = createReviewTaskFailedEvent({
+      ...baseOpts,
+      reason: {
+        kind: "not_now",
+        detail: "agent at maxConcurrent",
+        retry_after_ms: 15000,
+      },
+    });
+    const payload = env.payload as {
+      reason?: { kind: string; detail?: string; retry_after_ms?: number };
+    };
+    expect(payload.reason?.kind).toBe("not_now");
+    expect(payload.reason?.detail).toBe("agent at maxConcurrent");
+    expect(payload.reason?.retry_after_ms).toBe(15000);
+    expect(validateEnvelope(env).ok).toBe(true);
+  });
+
+  test("not_now — backpressure nak without retry_after_ms hint", () => {
+    const env = createReviewTaskFailedEvent({
+      ...baseOpts,
+      reason: {
+        kind: "not_now",
+        detail: "backpressure",
+      },
+    });
+    const payload = env.payload as {
+      reason?: { kind: string; retry_after_ms?: number };
+    };
+    expect(payload.reason?.kind).toBe("not_now");
+    expect(payload.reason?.retry_after_ms).toBeUndefined();
+    expect(validateEnvelope(env).ok).toBe(true);
+  });
+
+  test("compliance_block — declared but unwired-in-v1 per §7.4", () => {
+    // The builder accepts compliance_block (it's in the union) even though
+    // the consumer's nak switch omits it for v1 (Echo cortex#253 R1 Minor-5).
+    // This keeps the taxonomy ready when §13.5's attestation schema lands.
+    const env = createReviewTaskFailedEvent({
+      ...baseOpts,
+      reason: {
+        kind: "compliance_block",
+        detail: "STD-NPW-AI-001 gate: external review not attested",
+      },
+    });
+    const payload = env.payload as {
+      reason?: { kind: string; detail?: string };
+    };
+    expect(payload.reason?.kind).toBe("compliance_block");
+    expect(validateEnvelope(env).ok).toBe(true);
+  });
+
+  test("correlation_id defaults to request envelope id (review consumer contract §5.2)", () => {
+    // The review consumer MUST pass the request envelope's id explicitly
+    // — verify the wrapper honours that override (rather than falling back
+    // to taskId as the dispatch.task.* default would).
+    const env = createReviewTaskFailedEvent({
+      ...baseOpts,
+      reason: { kind: "cant_do", detail: "x" },
+    });
+    expect(env.correlation_id).toBe(REQUEST_ENVELOPE_ID);
+    expect(env.correlation_id).not.toBe(TASK_ID);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Type-level — builders return the canonical Envelope shape
+// ---------------------------------------------------------------------------
+
+describe("type-level envelope shape conformance", () => {
+  test("request, verdict, and failed builders all return the canonical Envelope type", () => {
+    // Compile-time assertions: assigning the builder return to a typed
+    // `Envelope` slot exercises the structural type. If the builder
+    // returns anything wider, this block fails `tsc --noEmit`.
+    const req: Envelope = createReviewRequestEvent({
+      source: PILOT_SOURCE,
+      flavor: "typescript",
+      payload: { repo: "x/y", pr: 1, reviewer: "echo" },
+    });
+    const verdict: Envelope = createReviewVerdictEvent({
+      source: SOURCE,
+      kind: "approved",
+      correlationId: REQUEST_ENVELOPE_ID,
+      payload: makeVerdictPayload({ verdict: "approved" }),
+    });
+    const failed: Envelope = createReviewTaskFailedEvent({
+      source: SOURCE,
+      taskId: TASK_ID,
+      agentId: "echo",
+      startedAt: STARTED_AT,
+      failedAt: FAILED_AT,
+      errorSummary: "x",
+      correlationId: REQUEST_ENVELOPE_ID,
+      reason: { kind: "cant_do", detail: "x" },
+    });
+    // Runtime sanity — every Envelope has these top-level fields.
+    for (const env of [req, verdict, failed]) {
+      expect(typeof env.id).toBe("string");
+      expect(typeof env.type).toBe("string");
+      expect(typeof env.source).toBe("string");
+      expect(typeof env.timestamp).toBe("string");
+      expect(env.sovereignty).toBeDefined();
+      expect(env.payload).toBeDefined();
+    }
+  });
+});

--- a/src/bus/index.ts
+++ b/src/bus/index.ts
@@ -45,3 +45,27 @@ export {
   type Classification,
   type ValidationResult,
 } from "./myelin/envelope-validator";
+
+// --- Review-pipeline envelope builders (cortex#237 PR-2) ---
+//
+// Producer-side helpers for the capability-dispatch review pipeline per
+// `docs/design-capability-dispatch-review-consumer.md` §6 and
+// `docs/design-pilot-restructure.md` §4.1–§4.2. Re-exported on the public
+// surface so pilot's caller-side (request publisher) and any external
+// review consumer share one symbol table. The builders themselves are
+// pure — no NATS, no I/O — so this barrel addition is safe to consume
+// from any context.
+export {
+  createReviewRequestEvent,
+  createReviewVerdictEvent,
+  createReviewTaskFailedEvent,
+  type ReviewEventSource,
+  type ReviewFlavor,
+  type ReviewVerdictKind,
+  type ReviewRequestPayload,
+  type ReviewVerdictPayload,
+  type CreateReviewRequestEventOpts,
+  type CreateReviewVerdictEventOpts,
+  type CreateReviewTaskFailedEventOpts,
+  type ReviewTaskFailedReason,
+} from "./review-events";

--- a/src/bus/review-events.ts
+++ b/src/bus/review-events.ts
@@ -1,0 +1,427 @@
+/**
+ * cortex#237 PR-2 — `review.verdict.*` + `tasks.code-review.*` envelope
+ * constructors for the capability-dispatch review pipeline.
+ *
+ * Per `docs/design-capability-dispatch-review-consumer.md` §6 and the
+ * pilot caller-side spec at `docs/design-pilot-restructure.md` §4.1–§4.2,
+ * the review pipeline emits two new envelope families plus an extension to
+ * the existing `dispatch.task.failed` lifecycle envelope. This file ships
+ * the producer-side builders. It is pure code — no NATS, no I/O, no
+ * subscription wiring; callers stay responsible for `MyelinRuntime.publish`.
+ *
+ * **Three builders:**
+ *   - `createReviewRequestEvent`  → `tasks.code-review.<flavor>` (pilot-side
+ *     producer; ratified pilot-side in `src/nats-publish.ts`. Cortex-side
+ *     helper added here so PR-5/PR-6 tests can synthesise request envelopes
+ *     without round-tripping through pilot. Mirrors the §4.1 payload shape.)
+ *   - `createReviewVerdictEvent`  → `review.verdict.{approved,changes-requested,commented}`
+ *     (cortex-side producer; the spec's §6 builder verbatim.)
+ *   - `createReviewTaskFailedEvent` → thin re-export wrapper around
+ *     `createDispatchTaskFailedEvent` for the four-way nak taxonomy
+ *     (cortex#249, already shipped in `dispatch-events.ts`). Re-exported
+ *     here for review-consumer ergonomics — review code imports one module.
+ *
+ * **Shape contract** (mirrors `dispatch-events.ts`):
+ *   - `id` is a fresh `crypto.randomUUID()` per call (envelope idempotency key).
+ *   - `timestamp` is the helper-call time. Domain-specific moments
+ *     (`submitted_at`) live in payload.
+ *   - `source` is the dotted `{org}.{agent}.{instance}` per the schema.
+ *   - `correlation_id` semantics differ per envelope family:
+ *       - Request envelopes: no correlation_id (the envelope's `id` is the
+ *         correlation root that the verdict envelope echoes — per §5.1).
+ *       - Verdict envelopes: REQUIRED, equals the request envelope's `id`
+ *         (the single load-bearing pilot contract per §5.1).
+ *       - Failed envelopes: per `dispatch-events.ts` semantics — defaults
+ *         to `task_id` unless the caller passes the request envelope's id
+ *         explicitly (which the review-consumer does per §5.2).
+ *   - `sovereignty` defaults to local-only / NZ / max_hop=0 / frontier_ok=false /
+ *     model_class=local-only — same posture as `dispatch.task.*`. Verdicts
+ *     reveal PR metadata + reviewer findings; default keeps them operator-local.
+ *     Federated reviews opt into `classification: "federated"` via the
+ *     optional `classification` field (IAW Phase A.3 parameterisation pattern).
+ *
+ * **Subject derivation:** envelope `type` is `tasks.code-review.<flavor>` or
+ * `review.verdict.<kind>`. The wire subject (`local.{org}.<type>` /
+ * `federated.{network}.<type>`) is derived publish-side by
+ * `MyelinRuntime.publish` via the namespace-derivation logic landed in
+ * IAW Phase A.3 (cortex#129). This builder produces the in-memory envelope
+ * only — the publisher computes the subject from `envelope.type` and the
+ * runtime's namespace configuration.
+ *
+ * **Discriminator alignment (defensive):** for the verdict builder, the
+ * `kind` argument MUST equal `payload.verdict` (§6.3). A mismatch is a
+ * caller bug — we throw rather than silently emit an envelope whose type
+ * suffix disagrees with its payload discriminator. This is the analogue
+ * of `validateSubjectEnvelopeAlignment` for the envelope-internal
+ * discriminator.
+ *
+ * **What this file is NOT:**
+ *   - NOT a publisher. No NATS calls; no `MyelinRuntime` import. Pure
+ *     envelope construction (failure mode of importing this in a hot
+ *     loop is zero — it's just object literals + `crypto.randomUUID()`).
+ *   - NOT a subscriber. The consumer that subscribes to
+ *     `tasks.code-review.>` lives in PR-6 (`src/runner/review-consumer.ts`).
+ *   - NOT a validator. Call `validateEnvelope` from the schema validator
+ *     if you need pre-publish validation; this builder produces a literal
+ *     that conforms to the type but doesn't run the JSON Schema (the
+ *     tests assert schema conformance).
+ *   - NOT a re-export of `DispatchTaskFailedReason`. The discriminated
+ *     union stays in `dispatch-events.ts` (single source of truth per
+ *     cortex#249); consumers import the type from there.
+ */
+
+import type { Classification, Envelope } from "./myelin/envelope-validator";
+import { buildBaseEnvelope as buildSharedEnvelope } from "./envelope-builder";
+import {
+  createDispatchTaskFailedEvent,
+  type DispatchTaskFailedOpts,
+  type DispatchTaskFailedReason,
+} from "./dispatch-events";
+import type { SystemEventSource } from "./system-events";
+
+// Re-export the source shape under a domain-neutral alias — mirrors the
+// `DispatchEventSource` pattern in `dispatch-events.ts`. Callers in the
+// review consumer / pilot import from one place.
+export type ReviewEventSource = SystemEventSource;
+
+function buildSource(src: SystemEventSource): string {
+  return `${src.org}.${src.agent}.${src.instance}`;
+}
+
+/**
+ * Default sovereignty for `tasks.code-review.*` and `review.verdict.*`
+ * envelopes. Same posture as `dispatch.task.*`: operator-local by default,
+ * local residency, no frontier, no hops.
+ *
+ * Returned as a fresh literal per call so a downstream mutation on one
+ * envelope's `sovereignty` cannot leak into a sibling envelope. Mirrors
+ * `dispatch-events.ts:defaultDispatchSovereignty`.
+ */
+function defaultReviewSovereignty(
+  source: SystemEventSource,
+  classification: Classification = "local",
+): Envelope["sovereignty"] {
+  return {
+    classification,
+    data_residency: source.dataResidency ?? "NZ",
+    max_hop: 0,
+    frontier_ok: false,
+    model_class: "local-only",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Re-exports — review consumer ergonomics
+// ---------------------------------------------------------------------------
+
+/**
+ * Re-exported from `dispatch-events.ts` so the review consumer (PR-6) and
+ * pilot's verdict subscriber import one module rather than two. The
+ * discriminated union itself stays defined in `dispatch-events.ts` per
+ * cortex#249 (single source of truth for the nak taxonomy).
+ */
+export type { DispatchTaskFailedReason } from "./dispatch-events";
+
+// ---------------------------------------------------------------------------
+// tasks.code-review.<flavor> — request envelope
+// ---------------------------------------------------------------------------
+
+/**
+ * Known review flavors per `design-pilot-restructure.md` §4.1's
+ * `KNOWN_SPECIALIZATIONS`. The wire grammar accepts any string (the
+ * subject `>` wildcard matches arbitrary segments), but pilot's
+ * publisher constrains to this set. We keep the type union narrow here
+ * so cortex-side test fixtures and PR-6 routing tables don't drift from
+ * pilot's vocabulary. New flavors land by extending this union in
+ * lockstep with pilot's `KNOWN_SPECIALIZATIONS`.
+ */
+export type ReviewFlavor =
+  | "generic"
+  | "typescript"
+  | "python"
+  | "rust"
+  | "go"
+  | "sql"
+  | "docs"
+  | "security";
+
+/**
+ * Request envelope payload per `design-pilot-restructure.md` §4.1.
+ *
+ * Mirrors `src/nats-publish.ts`'s pilot-side payload verbatim so the
+ * review consumer (PR-6) and pilot's publisher agree on the shape
+ * without a round-trip through a shared type module.
+ *
+ * Required fields are the load-bearing routing keys (`repo`, `pr`,
+ * `reviewer`). Optional fields are the operator-supplied context
+ * (`feature`, `title`, `cycle`, `note`) that surfaces render but do not
+ * branch on.
+ */
+export interface ReviewRequestPayload {
+  /** Owner/repo string, e.g. `"the-metafactory/cortex"`. */
+  repo: string;
+  /** PR number. Integer. */
+  pr: number;
+  /**
+   * Reviewer name. Informational — capability-dispatch routes by the
+   * `<flavor>` subject suffix, not by this field. Carried through so
+   * surfaces can render "review requested from {reviewer}". See
+   * `design-pilot-restructure.md` §5.1's `--reviewer` flag.
+   */
+  reviewer: string;
+  /** Optional feature ID (e.g. `"C-237"`). Surfaces render for context. */
+  feature?: string;
+  /** Optional human-readable PR title. */
+  title?: string;
+  /** Optional review cycle counter (1-indexed). */
+  cycle?: number;
+  /** Optional free-form note (defaults to empty string in pilot's publisher). */
+  note?: string;
+}
+
+/** Options for {@link createReviewRequestEvent}. */
+export interface CreateReviewRequestEventOpts {
+  source: ReviewEventSource;
+  /**
+   * Review flavor — becomes the `<flavor>` segment of `envelope.type`
+   * (`tasks.code-review.<flavor>`). Pilot constrains to
+   * `ReviewFlavor`; cortex-side builders accept the same union.
+   */
+  flavor: ReviewFlavor;
+  /**
+   * Optional sovereignty classification. Defaults to `"local"` (operator-
+   * private). Set to `"federated"` for cross-operator capability dispatch;
+   * `"public"` for global visibility. Mismatch with the publish-time
+   * subject is a protocol violation caught by
+   * `validateSubjectEnvelopeAlignment`.
+   */
+  classification?: Classification;
+  /** Payload per §4.1. */
+  payload: ReviewRequestPayload;
+}
+
+/**
+ * Construct a `tasks.code-review.<flavor>` request envelope per
+ * `design-pilot-restructure.md` §4.1.
+ *
+ * The envelope's `id` becomes the correlation root for the entire
+ * review pipeline (§5.1): the verdict envelope echoes this id as its
+ * `correlation_id`, and the lifecycle envelopes the review consumer
+ * emits use it explicitly via the `correlationId` option on
+ * `createDispatchTaskStartedEvent` / `Completed` / `Failed`.
+ *
+ * This is the cortex-side mirror of pilot's `publishReviewRequested`
+ * (`src/nats-publish.ts`). The cortex consumer (PR-6) does NOT publish
+ * request envelopes in production — pilot does — but cortex-side tests
+ * synthesise them to drive the consumer pipeline without spinning up a
+ * pilot harness.
+ *
+ * @returns a fresh `Envelope` literal with a new UUID id; safe to publish.
+ */
+export function createReviewRequestEvent(
+  opts: CreateReviewRequestEventOpts,
+): Envelope {
+  return buildSharedEnvelope({
+    type: `tasks.code-review.${opts.flavor}`,
+    source: buildSource(opts.source),
+    sovereignty: defaultReviewSovereignty(opts.source, opts.classification),
+    payload: {
+      repo: opts.payload.repo,
+      pr: opts.payload.pr,
+      reviewer: opts.payload.reviewer,
+      ...(opts.payload.feature !== undefined && { feature: opts.payload.feature }),
+      ...(opts.payload.title !== undefined && { title: opts.payload.title }),
+      ...(opts.payload.cycle !== undefined && { cycle: opts.payload.cycle }),
+      ...(opts.payload.note !== undefined && { note: opts.payload.note }),
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// review.verdict.<kind> — verdict envelope
+// ---------------------------------------------------------------------------
+
+/**
+ * The three verdict kinds per cortex#248 §4.2.1 and
+ * `design-pilot-restructure.md` §4.2. The wire subject is
+ * `local.{org}.review.verdict.<kind>`.
+ */
+export type ReviewVerdictKind =
+  | "approved"
+  | "changes-requested"
+  | "commented";
+
+/**
+ * Verdict envelope payload per cortex#248 §4.2.1 and
+ * `design-pilot-restructure.md` §4.2.
+ *
+ * Payload-shape compatibility with the legacy
+ * `nats-review-io.ts:ReviewCompletedPayload` is preserved so workflow-side
+ * consumers (the existing `runReviewCycle` ReviewCycleIO) don't need
+ * behavioural changes — only the subject and the `correlation_id` are new.
+ */
+export interface ReviewVerdictPayload {
+  /** Owner/repo string, echoed from the request envelope. */
+  repo: string;
+  /** PR number, echoed from the request envelope. */
+  pr: number;
+  /**
+   * Reviewer name — the agent that produced the verdict (`echo`,
+   * `luna`, etc.). Distinct from the request payload's `reviewer`
+   * field, which was advisory; this one is the *actual* agent.
+   */
+  reviewer: string;
+  /**
+   * The verdict discriminator. MUST equal the `kind` field of the
+   * containing options; mismatch throws — see §6.3.
+   */
+  verdict: ReviewVerdictKind;
+  /** Human-readable summary, e.g. `"verdict: blockers=0 majors=2 nits=3 — request-changes"`. */
+  summary: string;
+  /** GitHub's review id (numeric, from the `pulls/reviews` API). */
+  github_review_id: number;
+  /** Deep-link to the review on github.com. */
+  github_review_url: string;
+  /** ISO 8601 timestamp when GitHub recorded the review. */
+  submitted_at: string;
+  /** Commit SHA the review was submitted against. */
+  commit_id: string;
+  /** Structured findings count by severity. */
+  findings: {
+    blockers: number;
+    majors: number;
+    nits: number;
+  };
+  /** Total inline comments posted with the review. */
+  inline_comments: number;
+}
+
+/** Options for {@link createReviewVerdictEvent}. */
+export interface CreateReviewVerdictEventOpts {
+  source: ReviewEventSource;
+  /**
+   * Verdict kind — becomes the `<kind>` segment of `envelope.type`
+   * (`review.verdict.<kind>`). MUST equal `payload.verdict` (the
+   * builder throws otherwise — defensive against the discriminator
+   * drifting from the subject suffix per §6.3).
+   */
+  kind: ReviewVerdictKind;
+  /**
+   * The request envelope's `id`. REQUIRED — this is the single
+   * load-bearing pilot contract per §5.1. Pilot's `subscribe-verdict`
+   * filters on this value.
+   */
+  correlationId: string;
+  /**
+   * Optional sovereignty classification. Defaults to `"local"`.
+   * Federated reviews opt into `"federated"`; mirrors the
+   * `tasks.code-review.*` parameterisation.
+   */
+  classification?: Classification;
+  /** Payload per §4.2. */
+  payload: ReviewVerdictPayload;
+}
+
+/**
+ * Construct a `review.verdict.<kind>` envelope per cortex#248 §4.2.1
+ * and the design spec §6.2.
+ *
+ * **Discriminator-alignment guard:** throws if `opts.kind !== opts.payload.verdict`.
+ * A subject suffix that disagrees with its payload discriminator is a
+ * protocol violation that would silently break pilot's filter (pilot
+ * groups envelopes by the subject suffix; a `verdict.approved` envelope
+ * with `payload.verdict: "commented"` would be filed under "approved"
+ * but render as "commented" — operator-visible inconsistency). Fail
+ * loud at the producer instead.
+ *
+ * **Correlation:** the verdict envelope's `correlation_id` is the
+ * REQUEST envelope's `id` (NOT a fresh task UUID). See §5.1 for the
+ * load-bearing contract; see §5.2 for the mechanism (the consumer
+ * stashes the request envelope's id in a per-task closure).
+ *
+ * @throws `Error` if `opts.kind !== opts.payload.verdict`.
+ */
+export function createReviewVerdictEvent(
+  opts: CreateReviewVerdictEventOpts,
+): Envelope {
+  if (opts.kind !== opts.payload.verdict) {
+    throw new Error(
+      `review-events: verdict-kind/payload mismatch — ` +
+        `kind="${opts.kind}" but payload.verdict="${opts.payload.verdict}". ` +
+        `The subject suffix and payload discriminator MUST agree (cortex#248 §4.2.1).`,
+    );
+  }
+  return buildSharedEnvelope({
+    type: `review.verdict.${opts.kind}`,
+    source: buildSource(opts.source),
+    sovereignty: defaultReviewSovereignty(opts.source, opts.classification),
+    correlationId: opts.correlationId,
+    payload: {
+      repo: opts.payload.repo,
+      pr: opts.payload.pr,
+      reviewer: opts.payload.reviewer,
+      verdict: opts.payload.verdict,
+      summary: opts.payload.summary,
+      github_review_id: opts.payload.github_review_id,
+      github_review_url: opts.payload.github_review_url,
+      submitted_at: opts.payload.submitted_at,
+      commit_id: opts.payload.commit_id,
+      findings: {
+        blockers: opts.payload.findings.blockers,
+        majors: opts.payload.findings.majors,
+        nits: opts.payload.findings.nits,
+      },
+      inline_comments: opts.payload.inline_comments,
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// dispatch.task.failed — review-flavour wrapper
+// ---------------------------------------------------------------------------
+
+/**
+ * Options for {@link createReviewTaskFailedEvent}. Same shape as
+ * `DispatchTaskFailedOpts` from `dispatch-events.ts` — re-exported here
+ * for review-consumer ergonomics so the consumer imports one module.
+ *
+ * The `reason` field carries the four-way nak taxonomy
+ * (`cant_do` / `wont_do` / `not_now` / `compliance_block`) plus the
+ * existing `policy_denied` discriminator — see `DispatchTaskFailedReason`
+ * in `dispatch-events.ts`.
+ *
+ * **Correlation_id reminder:** per §5.2 the review consumer MUST pass
+ * the request envelope's `id` as `correlationId`, NOT rely on the
+ * `correlation_id ?? taskId` default in `dispatch-events.ts`. Pilot's
+ * `wait-for-verdict` filters on the request envelope id; using a fresh
+ * task UUID here would orphan the failed envelope from pilot's filter.
+ */
+export type CreateReviewTaskFailedEventOpts = DispatchTaskFailedOpts;
+
+/**
+ * Construct a `dispatch.task.failed` envelope for the review pipeline.
+ *
+ * Thin pass-through to `createDispatchTaskFailedEvent` — exists so the
+ * review consumer (PR-6) imports a single `review-events` module
+ * instead of mixing `review-events` and `dispatch-events` imports.
+ * The underlying envelope is byte-identical to one produced by
+ * `createDispatchTaskFailedEvent` directly; the wrapper exists for
+ * module-boundary hygiene only.
+ *
+ * The four nak `reason.kind` values (`cant_do`, `wont_do`, `not_now`,
+ * `compliance_block`) are the producer-side contract for pilot's nak
+ * handling per `design-pilot-restructure.md` §4.4 and architecture §7.3.
+ * `policy_denied` (the existing C.3.1 kind) is also supported for
+ * back-compat with non-review dispatch paths.
+ */
+export function createReviewTaskFailedEvent(
+  opts: CreateReviewTaskFailedEventOpts,
+): Envelope {
+  return createDispatchTaskFailedEvent(opts);
+}
+
+// Sanity export of the wrapped reason union for ergonomic re-import.
+// The type lives in `dispatch-events.ts` (cortex#249, single source of
+// truth); this is a value-free re-binding so review-consumer call sites
+// don't need to dual-import.
+export type ReviewTaskFailedReason = DispatchTaskFailedReason;


### PR DESCRIPTION
## Summary

Adds `src/bus/review-events.ts` — pure producer-side envelope builders for the capability-dispatch review pipeline. Per `docs/design-capability-dispatch-review-consumer.md` §10.1 PR phasing table, row **PR-2**.

Three builders:

- **`createReviewRequestEvent`** → `tasks.code-review.<flavor>` envelopes per `design-pilot-restructure.md` §4.1. Cortex-side mirror of pilot's `publishReviewRequested`. Used by PR-5/PR-6 test fixtures to synthesise request envelopes without spinning up a pilot harness.
- **`createReviewVerdictEvent`** → `review.verdict.{approved,changes-requested,commented}` envelopes per `design-capability-dispatch-review-consumer.md` §6.2. Throws when `kind` and `payload.verdict` disagree (defensive §6.3 guard — the subject suffix and payload discriminator MUST agree per cortex#248).
- **`createReviewTaskFailedEvent`** → thin wrapper around `createDispatchTaskFailedEvent` (cortex#249) so the review consumer imports a single module. Full four-way nak taxonomy supported (`cant_do`, `wont_do`, `not_now`, `compliance_block`) plus back-compat `policy_denied`. `DispatchTaskFailedReason` itself stays defined in `dispatch-events.ts` (single source of truth); re-exported here as `ReviewTaskFailedReason` for ergonomics.

Sovereignty default mirrors `dispatch.task.*`: `local-only` / `NZ` / `max_hop=0` / `frontier_ok=false` / `model_class=local-only`. Federated reviews opt into `classification: "federated"` via the IAW Phase A.3 parameterisation pattern.

22 new tests covering shape, schema-validation, the correlation_id contract (verdict envelope's `correlation_id` MUST equal the request envelope's `id` per §5.1 — the single load-bearing pilot contract), discriminator-alignment throwing, all four nak variants, and type-level `Envelope` conformance.

Public re-exports added to `src/bus/index.ts` so pilot and future M7 apps consume from the package barrel.

## Out of scope

- **No call-site wiring.** Nothing in cortex's runtime imports `review-events.ts` after this PR. The first consumer is PR-6 (`src/runner/review-consumer.ts`).
- **No NATS publish.** Pure envelope construction; no transport imports.
- **No subscriber registration.** The review consumer that subscribes to `tasks.code-review.>` is PR-6.
- **No prompt builder / verdict parser.** Those are PR-5 (`src/runner/review-pipeline.ts`).
- **No capability registry.** That is PR-3.
- **No config schema.** That is PR-4.

## In-line design decisions (with doc-comment anchors)

| Decision | Anchor (line in `src/bus/review-events.ts`) |
|---|---|
| Add `createReviewRequestEvent` even though §10.1 only mandates `createReviewVerdictEvent` | File header bullet "Three builders" + per-symbol doc on `createReviewRequestEvent` ("cortex-side mirror of pilot's `publishReviewRequested`") |
| `ReviewFlavor` union narrowed to pilot's `KNOWN_SPECIALIZATIONS` rather than `string` | Doc on `ReviewFlavor` type ("New flavors land by extending this union in lockstep with pilot's `KNOWN_SPECIALIZATIONS`") |
| Verdict builder throws (not warn-and-emit) when `kind !== payload.verdict` | Doc on `createReviewVerdictEvent` ("Fail loud at the producer instead") |
| Request envelope has no `correlation_id` (the `id` IS the correlation root) | File header bullet + `createReviewRequestEvent` test "No correlation_id on request envelopes" |
| `createReviewTaskFailedEvent` is a pass-through wrapper, not a re-implementation | Doc on `createReviewTaskFailedEvent` ("byte-identical to one produced by `createDispatchTaskFailedEvent` directly") |
| `compliance_block` is buildable here even though §7.4 omits it from the v1 consumer switch | Test "compliance_block — declared but unwired-in-v1 per §7.4" + commit body |

## Test plan

- [x] `bunx tsc --noEmit` — clean
- [x] `bun test src/bus/` — 410 pass / 0 fail (baseline 379 + 22 new + delta from intervening file additions; full bus suite clean)
- [x] `bun run lint` — 0 errors (21 pre-existing warnings unrelated to these files)
- [x] Every new envelope passes `validateEnvelope` (the vendored myelin schema check)
- [x] Discriminator-mismatch case throws (defensive §6.3)
- [x] Each `DispatchTaskFailedReason` variant round-trips through the review-flavoured wrapper

Refs cortex#237. Anchors: `docs/design-capability-dispatch-review-consumer.md` §6 + §10.1; `docs/design-pilot-restructure.md` §4.1–§4.2; cortex#248 (verdict payload ratification); cortex#249 (`DispatchTaskFailedReason` four-way nak taxonomy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)