### PR TITLE
feat(bus): cortex#237 PR-3 — capability-registry.ts publisher

### DIFF
--- a/src/bus/__tests__/capability-registry.test.ts
+++ b/src/bus/__tests__/capability-registry.test.ts
@@ -1,0 +1,423 @@
+/**
+ * cortex#237 PR-3 — tests for `capability-registry.ts` publisher.
+ *
+ * Coverage axes (mirrors the rest of `bus/__tests__/`):
+ *
+ *   1. Cardinality — the publisher emits exactly one envelope per
+ *      agent×non-empty-capability-set. Zero agents → zero envelopes;
+ *      one agent × one capability → one envelope; two agents × three
+ *      capabilities each → two envelopes (NOT six — capabilities are
+ *      a payload list, not a per-capability fan-out per §3.2).
+ *
+ *   2. Filtering — agents with empty `capabilities[]` are skipped per
+ *      spec §3.4.
+ *
+ *   3. Shape — envelope `type` matches the §3.2 spec exactly; payload
+ *      carries `agent_id` + `capabilities` + `registered_at` + `instance`;
+ *      sovereignty defaults to local / NZ / hop=0 per §3.2; every
+ *      envelope validates against the vendored myelin schema.
+ *
+ *   4. Subject literal — the exported `CAPABILITY_REGISTERED_EVENT_TYPE`
+ *      constant matches the spec literal (so pilot Phase B's reader
+ *      and PR-7's boot wiring can subscribe against the same string).
+ *
+ *   5. Mockability — `publish` is a plain function the test supplies
+ *      via a recording array (no NATS client, no runtime, no fixture).
+ *
+ *   6. Idempotency — re-invoking with the same entries publishes the
+ *      same logical registrations (same `agent_id` + `capabilities`)
+ *      with fresh envelope ids.
+ *
+ * Note on PR-3 scope: no `sovereignty` / `max_concurrent` payload
+ * assertions — those fields land in PR-4 once `AgentRuntimeSchema`
+ * grows the corresponding knobs. PR-3 tests stay narrow to PR-3's
+ * surface.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { validateEnvelope, type Envelope } from "../myelin/envelope-validator";
+import {
+  CAPABILITY_REGISTERED_EVENT_TYPE,
+  buildCapabilityRegisteredEnvelope,
+  publishCapabilityRegistry,
+  type CapabilityRegistryEntry,
+  type CapabilityRegistrySource,
+  type PublishFn,
+} from "../capability-registry";
+
+const SOURCE: CapabilityRegistrySource = {
+  org: "metafactory",
+  agent: "cortex",
+  instance: "local",
+};
+
+const FIXED_AT = new Date("2026-05-16T09:42:11.000Z");
+const FIXED_CLOCK = () => FIXED_AT;
+
+/**
+ * Recording publisher — captures every envelope handed to `publish`.
+ * The function shape matches `MyelinRuntime.publish` exactly
+ * (`(Envelope) => Promise<void>`) so the same construction works in
+ * production once PR-7 wires the runtime in.
+ */
+function recordingPublisher(): { publish: PublishFn; sent: Envelope[] } {
+  const sent: Envelope[] = [];
+  const publish: PublishFn = async (envelope) => {
+    sent.push(envelope);
+  };
+  return { publish, sent };
+}
+
+describe("CAPABILITY_REGISTERED_EVENT_TYPE", () => {
+  test("matches the spec literal verbatim", () => {
+    // Pilot's deferred bucket reader (§13.1) and PR-7's boot wiring
+    // both filter by this exact string. A typo here is silent drift
+    // against the spec — assert the literal so a future rename has
+    // to update both this assertion and the spec at the same time.
+    expect(CAPABILITY_REGISTERED_EVENT_TYPE).toBe("agents.capabilities.registered");
+  });
+});
+
+describe("buildCapabilityRegisteredEnvelope", () => {
+  test("produces a schema-valid envelope with the §3.2 payload shape", () => {
+    const env = buildCapabilityRegisteredEnvelope({
+      source: SOURCE,
+      agentId: "echo",
+      capabilities: ["code-review.typescript"],
+      registeredAt: FIXED_AT,
+      instance: "andreas.cortex.local",
+    });
+    expect(env.type).toBe(CAPABILITY_REGISTERED_EVENT_TYPE);
+    expect(env.source).toBe("metafactory.cortex.local");
+    expect(env.payload).toEqual({
+      agent_id: "echo",
+      capabilities: ["code-review.typescript"],
+      registered_at: "2026-05-16T09:42:11.000Z",
+      instance: "andreas.cortex.local",
+    });
+    expect(env.sovereignty).toEqual({
+      classification: "local",
+      data_residency: "NZ",
+      max_hop: 0,
+      frontier_ok: false,
+      model_class: "local-only",
+    });
+    expect(validateEnvelope(env).ok).toBe(true);
+  });
+
+  test("each invocation produces a fresh envelope id", () => {
+    const a = buildCapabilityRegisteredEnvelope({
+      source: SOURCE,
+      agentId: "echo",
+      capabilities: ["code-review.typescript"],
+      registeredAt: FIXED_AT,
+      instance: "andreas.cortex.local",
+    });
+    const b = buildCapabilityRegisteredEnvelope({
+      source: SOURCE,
+      agentId: "echo",
+      capabilities: ["code-review.typescript"],
+      registeredAt: FIXED_AT,
+      instance: "andreas.cortex.local",
+    });
+    expect(a.id).not.toBe(b.id);
+    expect(a.id).toMatch(/^[0-9a-f-]{36}$/i);
+  });
+
+  test("non-default residency flows into sovereignty.data_residency", () => {
+    const env = buildCapabilityRegisteredEnvelope({
+      source: { ...SOURCE, dataResidency: "AU" },
+      agentId: "echo",
+      capabilities: ["code-review.typescript"],
+      registeredAt: FIXED_AT,
+      instance: "andreas.cortex.local",
+    });
+    expect(env.sovereignty.data_residency).toBe("AU");
+  });
+
+  test("federated classification flows through unchanged", () => {
+    const env = buildCapabilityRegisteredEnvelope({
+      source: SOURCE,
+      agentId: "echo",
+      capabilities: ["code-review.typescript"],
+      registeredAt: FIXED_AT,
+      instance: "andreas.cortex.local",
+      classification: "federated",
+    });
+    expect(env.sovereignty.classification).toBe("federated");
+    expect(validateEnvelope(env).ok).toBe(true);
+  });
+
+  test("capabilities array is copied (caller mutation can't leak in)", () => {
+    // Defensive — `[...opts.capabilities]` in the builder means a
+    // caller mutating their input array after construction doesn't
+    // shift the envelope's payload. Important for the boot path where
+    // the same `Agent.runtime.capabilities` reference is reused across
+    // multiple subsystems.
+    const input: string[] = ["code-review.typescript"];
+    const env = buildCapabilityRegisteredEnvelope({
+      source: SOURCE,
+      agentId: "echo",
+      capabilities: input,
+      registeredAt: FIXED_AT,
+      instance: "andreas.cortex.local",
+    });
+    input.push("code-review.bun");
+    expect((env.payload as { capabilities: string[] }).capabilities).toEqual([
+      "code-review.typescript",
+    ]);
+  });
+});
+
+describe("publishCapabilityRegistry", () => {
+  test("1 agent × 1 capability → 1 envelope", async () => {
+    const { publish, sent } = recordingPublisher();
+    const entries: CapabilityRegistryEntry[] = [
+      { agentId: "echo", capabilities: ["code-review.typescript"] },
+    ];
+
+    const published = await publishCapabilityRegistry({
+      source: SOURCE,
+      entries,
+      publish,
+      clock: FIXED_CLOCK,
+    });
+
+    expect(sent.length).toBe(1);
+    expect(published.length).toBe(1);
+    // The returned array IS the same envelopes the mock saw — boot
+    // path uses the return value for logging without re-deriving from
+    // the mock.
+    expect(published[0]).toBe(sent[0]);
+
+    const env = sent[0]!;
+    expect(env.type).toBe(CAPABILITY_REGISTERED_EVENT_TYPE);
+    expect(env.payload).toMatchObject({
+      agent_id: "echo",
+      capabilities: ["code-review.typescript"],
+      registered_at: "2026-05-16T09:42:11.000Z",
+      instance: "local",
+    });
+    expect(validateEnvelope(env).ok).toBe(true);
+  });
+
+  test("2 agents × 3 capabilities each → 2 envelopes (NOT 6)", async () => {
+    // Cardinality clarification per §3.2: one envelope per AGENT
+    // carries the agent's capability LIST in the payload — we do NOT
+    // fan out one envelope per capability. The "6" trap would be a
+    // shape regression that wastes wire traffic and confuses the
+    // bucket reader (the bucket is keyed by agent_id, not by
+    // capability id).
+    const { publish, sent } = recordingPublisher();
+    const entries: CapabilityRegistryEntry[] = [
+      {
+        agentId: "echo",
+        capabilities: [
+          "code-review.typescript",
+          "code-review.bun",
+          "code-review.generic",
+        ],
+      },
+      {
+        agentId: "luna",
+        capabilities: [
+          "design-review.figma",
+          "design-review.tailwind",
+          "design-review.generic",
+        ],
+      },
+    ];
+
+    const published = await publishCapabilityRegistry({
+      source: SOURCE,
+      entries,
+      publish,
+      clock: FIXED_CLOCK,
+    });
+
+    expect(sent.length).toBe(2);
+    expect(published.length).toBe(2);
+
+    const byAgent = new Map(
+      sent.map((env) => [
+        (env.payload as { agent_id: string }).agent_id,
+        env,
+      ]),
+    );
+
+    expect(byAgent.get("echo")?.payload).toMatchObject({
+      agent_id: "echo",
+      capabilities: [
+        "code-review.typescript",
+        "code-review.bun",
+        "code-review.generic",
+      ],
+    });
+    expect(byAgent.get("luna")?.payload).toMatchObject({
+      agent_id: "luna",
+      capabilities: [
+        "design-review.figma",
+        "design-review.tailwind",
+        "design-review.generic",
+      ],
+    });
+
+    // Every envelope is independently schema-valid.
+    for (const env of sent) {
+      expect(validateEnvelope(env).ok).toBe(true);
+    }
+  });
+
+  test("agent with empty capabilities → 0 envelopes for that agent", async () => {
+    // Per §3.4: only register agents with at least one capability.
+    // An agent whose `runtime.capabilities` is `[]` (or whose
+    // `runtime` is omitted entirely — projected to `[]` by the boot
+    // wiring) MUST emit zero envelopes. This protects against bucket
+    // pollution from in-process agents whose capabilities are
+    // declared via roles rather than `runtime.capabilities[]`.
+    const { publish, sent } = recordingPublisher();
+    const entries: CapabilityRegistryEntry[] = [
+      { agentId: "echo", capabilities: ["code-review.typescript"] },
+      { agentId: "ivy", capabilities: [] },
+      { agentId: "holly", capabilities: [] },
+    ];
+
+    const published = await publishCapabilityRegistry({
+      source: SOURCE,
+      entries,
+      publish,
+      clock: FIXED_CLOCK,
+    });
+
+    expect(sent.length).toBe(1);
+    expect(published.length).toBe(1);
+    expect((sent[0]!.payload as { agent_id: string }).agent_id).toBe("echo");
+  });
+
+  test("zero entries → zero envelopes", async () => {
+    const { publish, sent } = recordingPublisher();
+    const published = await publishCapabilityRegistry({
+      source: SOURCE,
+      entries: [],
+      publish,
+      clock: FIXED_CLOCK,
+    });
+    expect(sent.length).toBe(0);
+    expect(published.length).toBe(0);
+  });
+
+  test("subject derivation contract — type literal is exactly the spec string", async () => {
+    // The runtime derives the wire subject from
+    // `(envelope.type, envelope.sovereignty.classification)`. PR-3's
+    // contract is the `type` literal; the wire-side derivation lives
+    // in `myelin/runtime.ts` and has its own tests. This assertion
+    // anchors the contract so a future type rename surfaces here.
+    const { publish, sent } = recordingPublisher();
+    await publishCapabilityRegistry({
+      source: SOURCE,
+      entries: [{ agentId: "echo", capabilities: ["code-review.typescript"] }],
+      publish,
+      clock: FIXED_CLOCK,
+    });
+    expect(sent[0]!.type).toBe("agents.capabilities.registered");
+  });
+
+  test("instance override lands in the payload", async () => {
+    const { publish, sent } = recordingPublisher();
+    await publishCapabilityRegistry({
+      source: SOURCE,
+      entries: [{ agentId: "echo", capabilities: ["code-review.typescript"] }],
+      publish,
+      clock: FIXED_CLOCK,
+      instance: "andreas.cortex.local",
+    });
+    expect((sent[0]!.payload as { instance: string }).instance).toBe(
+      "andreas.cortex.local",
+    );
+  });
+
+  test("instance defaults to source.instance when not overridden", async () => {
+    const { publish, sent } = recordingPublisher();
+    await publishCapabilityRegistry({
+      source: SOURCE,
+      entries: [{ agentId: "echo", capabilities: ["code-review.typescript"] }],
+      publish,
+      clock: FIXED_CLOCK,
+    });
+    expect((sent[0]!.payload as { instance: string }).instance).toBe("local");
+  });
+
+  test("re-invocation with same entries is idempotent at payload level", async () => {
+    // Per the publisher's idempotency contract: re-publish produces
+    // the same logical registrations (same `agent_id` + `capabilities`
+    // payload) with fresh envelope ids. The bucket consumer keys on
+    // `agent_id` and overwrites — so re-publish is a bucket no-op even
+    // though the wire sees a second envelope.
+    const { publish, sent } = recordingPublisher();
+    const entries: CapabilityRegistryEntry[] = [
+      { agentId: "echo", capabilities: ["code-review.typescript"] },
+    ];
+
+    await publishCapabilityRegistry({
+      source: SOURCE,
+      entries,
+      publish,
+      clock: FIXED_CLOCK,
+    });
+    await publishCapabilityRegistry({
+      source: SOURCE,
+      entries,
+      publish,
+      clock: FIXED_CLOCK,
+    });
+
+    expect(sent.length).toBe(2);
+    // Fresh envelope ids per call (idempotency at the *bucket* not
+    // the *wire*).
+    expect(sent[0]!.id).not.toBe(sent[1]!.id);
+    // Same logical registration — payload is byte-identical (we
+    // pinned the clock above so `registered_at` is stable).
+    expect(sent[0]!.payload).toEqual(sent[1]!.payload);
+  });
+
+  test("publish errors propagate to the caller (no swallowing)", async () => {
+    // Per the publisher's error-handling contract: publish failures
+    // are real signals (bus unreachable, signer fault). Catching here
+    // would swallow boot-path diagnostics. Assert the propagation so
+    // a future "defensive try/catch" addition fails this test.
+    const failing: PublishFn = async () => {
+      throw new Error("simulated NATS publish failure");
+    };
+    await expect(
+      publishCapabilityRegistry({
+        source: SOURCE,
+        entries: [
+          { agentId: "echo", capabilities: ["code-review.typescript"] },
+        ],
+        publish: failing,
+        clock: FIXED_CLOCK,
+      }),
+    ).rejects.toThrow("simulated NATS publish failure");
+  });
+
+  test("envelopes publish in entry order (deterministic emission)", async () => {
+    // Per the publisher's concurrency rationale: sequential emission
+    // gives the boot path a deterministic order for log grepping and
+    // integration-test assertions. Assert the order matches `entries`.
+    const { publish, sent } = recordingPublisher();
+    await publishCapabilityRegistry({
+      source: SOURCE,
+      entries: [
+        { agentId: "echo", capabilities: ["code-review.typescript"] },
+        { agentId: "luna", capabilities: ["design-review.figma"] },
+        { agentId: "holly", capabilities: ["pr-review.generic"] },
+      ],
+      publish,
+      clock: FIXED_CLOCK,
+    });
+    const agentIds = sent.map(
+      (env) => (env.payload as { agent_id: string }).agent_id,
+    );
+    expect(agentIds).toEqual(["echo", "luna", "holly"]);
+  });
+});

--- a/src/bus/capability-registry.ts
+++ b/src/bus/capability-registry.ts
@@ -1,0 +1,373 @@
+/**
+ * cortex#237 PR-3 — capability-registry publisher.
+ *
+ * Per `docs/design-capability-dispatch-review-consumer.md` §3 +
+ * §10.1 PR-3, this module is the **publisher half** of the runtime
+ * capability registry: it reads the parsed cortex.yaml (the Phase A.6
+ * schema substrate already in place at `cortex-config.ts:429-456` +
+ * `cortex-config.ts:1582` + the A.6.3 cross-validation at
+ * `cortex-config.ts:1765-1787`) and emits one
+ * `agents.capabilities.registered` envelope per agent×capability slice.
+ *
+ * **What this module is:**
+ *
+ * - A pure publisher: given a `(publish: PublishFn)` injected dependency
+ *   and the parsed config (the `CortexConfig.agents[]` slice is the
+ *   minimum required surface), iterate the agents and publish a
+ *   registration envelope per agent that declares at least one
+ *   capability via `agents[].runtime.capabilities[]`.
+ *
+ * - Idempotent across calls: re-invoking with the same config produces
+ *   envelopes with the same `agent_id` payload key. The bucket consumer
+ *   (pilot's pre-publish gate, deferred per §13.1) reads the registry
+ *   keyed by `agent_id`; duplicate registrations overwrite the same
+ *   logical slot rather than accumulating. Envelope `id` + `timestamp`
+ *   are fresh per call (idempotency at the *bucket* not the *wire*).
+ *
+ * **What this module is NOT (deliberately, per §10.1 PR boundaries):**
+ *
+ * - NOT the schema. The `agents[].runtime.capabilities[]` field already
+ *   ships at Phase A.6 (`cortex-config.ts:429-456` for the schema,
+ *   `cortex-config.ts:1582` for the top-level catalog, cross-validation
+ *   at `cortex-config.ts:1765-1787`). PR-3 consumes that shape verbatim.
+ *
+ * - NOT the schema extension for `sovereignty` + `maxConcurrent`. Those
+ *   are PR-4's job (extend `AgentRuntimeSchema` with two sibling
+ *   fields). When PR-4 lands, the publisher gains those fields on the
+ *   payload without a wire break — both are optional today (omitted
+ *   when undefined).
+ *
+ * - NOT the boot wiring. PR-7 wires `publishCapabilityRegistry()` into
+ *   `src/cortex.ts`'s startup sequence after `mergedAgents` is built.
+ *   PR-3 only ships the function; nothing imports it yet.
+ *
+ * - NOT a bucket reader. v1 is publish-only per §3.5; the bucket reader
+ *   ships when pilot Phase B.4 needs it (open question §13.1, dedicated
+ *   follow-up).
+ *
+ * - NOT a NATS client. The publisher takes a `(envelope) => Promise<void>`
+ *   shape — the same shape as `MyelinRuntime.publish`. Tests inject a
+ *   recording mock; production wires the real runtime. This keeps the
+ *   module independent of the connection layer and trivially testable.
+ *
+ * - NOT a KV-bucket primitive. Architecture §7.2 specifies
+ *   `local.{org}.agents.capabilities.{agent_id}` as a NATS KV bucket;
+ *   myelin's signed-KV API (myelin#31) is the right home for that
+ *   primitive and hasn't shipped. v1 publishes a wire envelope on the
+ *   regular subject (`local.{org}.agents.capabilities.registered`, derived
+ *   from the envelope type by the runtime's subject derivation per IAW
+ *   Phase A.3). The KV-bucket write is a v2 layer on top.
+ *
+ * **Subject derivation (load-bearing for PR-7 wiring + pilot Phase B):**
+ *
+ * The runtime derives subjects from `(envelope.type, envelope.sovereignty.
+ * classification, envelope.source's org segment)`:
+ *
+ *   - classification `"local"` → subject `local.{org}.{type}`
+ *   - With stack segment (IAW A.5) → `local.{org}.{stack}.{type}`
+ *
+ * So with `type: "agents.capabilities.registered"` and `classification:
+ * "local"`, the published subject is
+ * `local.{org}.agents.capabilities.registered` (or `local.{org}.{stack}.
+ * agents.capabilities.registered` when a stack id is configured). The
+ * `agent_id` discriminator lives in the **payload** (not the subject)
+ * for v1; subscribers filter by payload field. The KV-bucket migration
+ * in v2 moves the discriminator onto the subject as the bucket key.
+ */
+
+import type { Classification, Envelope } from "./myelin/envelope-validator";
+import { buildBaseEnvelope } from "./envelope-builder";
+
+// ---------------------------------------------------------------------------
+// Public types — kept narrow so the publisher composes cleanly with both
+// the real `MyelinRuntime.publish` and a recording mock.
+// ---------------------------------------------------------------------------
+
+/**
+ * Publish injection — same shape as `MyelinRuntime.publish`. The
+ * publisher does not instantiate a NATS client; the caller passes a
+ * function that knows how to land the envelope on the wire.
+ *
+ * Production: `runtime.publish.bind(runtime)`.
+ * Tests: `const sent: Envelope[] = []; const publish = async (e) => { sent.push(e); };`
+ */
+export type PublishFn = (envelope: Envelope) => Promise<void>;
+
+/**
+ * Envelope source struct — `{org}.{agent}.{instance}` per
+ * `src/bus/system-events.ts:SystemEventSource`. Duplicated structurally
+ * here rather than re-imported because the registry is an
+ * `agents.*`-domain emitter; the structural identity with
+ * `SystemEventSource` is incidental, not a coupling we want to inherit
+ * (a future change to `SystemEventSource` shouldn't ripple into the
+ * registry).
+ */
+export interface CapabilityRegistrySource {
+  /** Operator id — first dotted segment of `envelope.source`. */
+  org: string;
+  /** Logical agent label for the *publisher* (typically `"cortex"`). */
+  agent: string;
+  /** Stable instance label — usually `"local"` for in-process emission. */
+  instance: string;
+  /**
+   * Operator residency code for `envelope.sovereignty.data_residency`.
+   * Defaults to `"NZ"` when omitted (matches the original cortex
+   * deployment). Mirrors the same field on `SystemEventSource`.
+   */
+  dataResidency?: string;
+}
+
+/**
+ * One agent's registration input — the *minimum* surface PR-3 needs
+ * from the parsed config. Designed so the boot wiring (PR-7) can
+ * project `Agent` → `CapabilityRegistryEntry` without re-importing the
+ * full `CortexConfig` type into this module.
+ */
+export interface CapabilityRegistryEntry {
+  /** Logical agent id (matches `Agent.id`). */
+  agentId: string;
+  /**
+   * Capability ids the agent claims. Mirrors
+   * `Agent.runtime.capabilities` from the Phase A.6 schema. An empty
+   * array means "this agent has no capabilities to advertise" — the
+   * publisher emits ZERO envelopes for such an agent (per spec §3.4:
+   * "if agent.runtime?.capabilities?.length > 0").
+   */
+  capabilities: readonly string[];
+}
+
+/**
+ * Options for `publishCapabilityRegistry()`. The boot wiring (PR-7)
+ * builds this from the parsed cortex.yaml's `agents[]` (mapped to
+ * `entries[]` by lifting `runtime.capabilities`) plus the operator's
+ * source identity.
+ *
+ * `clock` + `instance` are injection seams so tests can assert exact
+ * payload fields without time/host flakiness.
+ */
+export interface PublishCapabilityRegistryOptions {
+  /** Source identity for `envelope.source` + sovereignty defaults. */
+  source: CapabilityRegistrySource;
+  /**
+   * One entry per agent in the merged agents list. Agents with empty
+   * `capabilities` are silently skipped (zero envelopes for them — see
+   * `CapabilityRegistryEntry.capabilities` doc).
+   */
+  entries: readonly CapabilityRegistryEntry[];
+  /**
+   * Publisher injection — typically `runtime.publish.bind(runtime)`
+   * in production, a recording mock in tests.
+   */
+  publish: PublishFn;
+  /**
+   * Optional instance label baked into the payload (`instance` field
+   * per §3.2). Defaults to `source.instance` — operators running
+   * multiple cortex daemons in the same operator namespace override
+   * this to disambiguate.
+   */
+  instance?: string;
+  /**
+   * Optional clock injection — defaults to `() => new Date()`. Tests
+   * inject a fixed clock to assert `registered_at` exactly without
+   * tolerating ISO-string jitter.
+   */
+  clock?: () => Date;
+  /**
+   * Optional classification override. Defaults to `"local"` per
+   * §3.2 ("sovereignty.classification: local"). Operators on a
+   * federation policy may opt into `"federated"` to publish the
+   * capability registry on `federated.{network}.agents.capabilities.
+   * registered` so peer dashboards can render it; today the default is
+   * the only call site. Mirror of the IAW Phase A.3 classification
+   * parameter on the `system.*` + `dispatch.*` event helpers.
+   */
+  classification?: Classification;
+}
+
+// ---------------------------------------------------------------------------
+// Constants — exported so PR-7 (boot wiring) and the future pilot-side
+// reader can subscribe / route against the same string literals.
+// ---------------------------------------------------------------------------
+
+/**
+ * Envelope `type` for a capability registration. Matches §3.2's spec:
+ * "type: agents.capabilities.registered". The runtime derives the wire
+ * subject from this (and from `sovereignty.classification`):
+ *
+ *   - local + no stack:  `local.{org}.agents.capabilities.registered`
+ *   - local + stack:     `local.{org}.{stack}.agents.capabilities.registered`
+ *   - federated:         `federated.{network}.agents.capabilities.registered`
+ *
+ * PR-7's subscriber matches against this constant rather than
+ * stringly-typed literals; pilot's deferred bucket reader (§13.1) does
+ * the same.
+ */
+export const CAPABILITY_REGISTERED_EVENT_TYPE = "agents.capabilities.registered" as const;
+
+// ---------------------------------------------------------------------------
+// Defaults
+// ---------------------------------------------------------------------------
+
+function buildSource(src: CapabilityRegistrySource): string {
+  return `${src.org}.${src.agent}.${src.instance}`;
+}
+
+/**
+ * Default sovereignty posture for capability-registration envelopes.
+ * Matches §3.2 verbatim: `classification: local` (operator-private
+ * unless overridden), residency from `source.dataResidency` (defaulting
+ * to `"NZ"`), max_hop 0, no frontier, local-only model class.
+ *
+ * Returned as a fresh literal per call so downstream mutation on one
+ * envelope's `sovereignty` can't leak into a sibling.
+ */
+function defaultRegistrySovereignty(
+  source: CapabilityRegistrySource,
+  classification: Classification = "local",
+): Envelope["sovereignty"] {
+  return {
+    classification,
+    data_residency: source.dataResidency ?? "NZ",
+    max_hop: 0,
+    frontier_ok: false,
+    model_class: "local-only",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Envelope builder — pure, no side effects. Useful in tests that want
+// to assert envelope shape without going through the publisher mock.
+// ---------------------------------------------------------------------------
+
+/**
+ * Inputs to `buildCapabilityRegisteredEnvelope`. Shape mirrors the
+ * payload fields from §3.2 (plus the source/sovereignty plumbing).
+ */
+export interface BuildCapabilityRegisteredEnvelopeOpts {
+  source: CapabilityRegistrySource;
+  agentId: string;
+  /** Capability ids — emitted verbatim into the `capabilities` payload field. */
+  capabilities: readonly string[];
+  /** ISO-8601 registration moment (the `registered_at` payload field). */
+  registeredAt: Date;
+  /** Instance label (the `instance` payload field). */
+  instance: string;
+  /** Optional classification override; defaults to `"local"`. */
+  classification?: Classification;
+}
+
+/**
+ * Construct one `agents.capabilities.registered` envelope per §3.2.
+ *
+ * Pure function — no I/O. The publisher (`publishCapabilityRegistry`)
+ * calls this once per agent-with-capabilities and hands the result to
+ * the injected `publish` function.
+ *
+ * Payload fields per §3.2 (in source-spec order so a future field
+ * addition lands in the same row):
+ *
+ *   - `agent_id`       — discriminator for the per-agent bucket slot.
+ *   - `capabilities`   — verbatim from the input (string[]).
+ *   - `registered_at`  — ISO timestamp the registration was emitted at.
+ *   - `instance`       — host/instance label (per §3.2 example
+ *                        `"andreas.cortex.local"`).
+ *
+ * **Deliberately absent from PR-3:** `sovereignty` + `max_concurrent`
+ * payload fields. Those are PR-4's job (extends `AgentRuntimeSchema`
+ * with the two knobs); the publisher gains those payload fields in PR-4
+ * once the schema can carry them. Adding placeholder fields here would
+ * be schema-drift in the other direction (advertising capacity we don't
+ * have).
+ */
+export function buildCapabilityRegisteredEnvelope(
+  opts: BuildCapabilityRegisteredEnvelopeOpts,
+): Envelope {
+  return buildBaseEnvelope({
+    type: CAPABILITY_REGISTERED_EVENT_TYPE,
+    source: buildSource(opts.source),
+    sovereignty: defaultRegistrySovereignty(opts.source, opts.classification),
+    payload: {
+      agent_id: opts.agentId,
+      capabilities: [...opts.capabilities],
+      registered_at: opts.registeredAt.toISOString(),
+      instance: opts.instance,
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Publisher — iterates the merged agents list and emits one envelope
+// per agent that has at least one capability.
+// ---------------------------------------------------------------------------
+
+/**
+ * Publish one `agents.capabilities.registered` envelope per agent in
+ * `opts.entries` whose `capabilities` array is non-empty.
+ *
+ * Per §3.4:
+ *
+ *   for each agent in mergedAgents:
+ *     if agent.runtime?.capabilities?.length > 0:
+ *       capabilityRegistry.register({ agentId, capabilities, ... })
+ *
+ * **Concurrency:** envelopes are published sequentially (not in
+ * parallel). The cortex runtime's `publish()` is fire-and-forget at
+ * the NATS layer (`Promise<void>` resolves immediately for Core NATS),
+ * so sequential ordering doesn't cost wall-clock latency and gives the
+ * boot path a deterministic emission order — useful for log grepping
+ * and integration-test assertions. If the underlying publish ever
+ * upgrades to `JetStream.publish` (per the comment on
+ * `MyelinRuntime.publish`), sequential emission preserves at-least-once
+ * ordering without needing a separate ack-coordinator.
+ *
+ * **Error handling:** the publisher does NOT catch errors thrown by
+ * `publish` — those propagate to the caller (boot path in PR-7).
+ * Rationale: a publish failure during startup is a real signal (the
+ * runtime is misconfigured or the bus is unreachable) and the boot
+ * path is the right place to decide whether to fail loud or downgrade
+ * to a `system.*` event. Catching here would silently swallow that
+ * signal and violate the "no empty catch blocks" rule.
+ *
+ * **Idempotency:** invoking twice with the same `entries` re-publishes
+ * the same logical registrations with fresh envelope ids/timestamps.
+ * Bucket consumers (the deferred reader per §13.1) key by `agent_id`
+ * payload field and overwrite on re-receive — so re-publish is a no-op
+ * at the bucket layer. The wire side may see duplicates; subscribers
+ * deduplicate by `agent_id` per §3.3 contract.
+ *
+ * Returns the array of envelopes that were published, in emission
+ * order. Useful for boot-path logging ("registered N capabilities for
+ * M agents") without re-deriving the count from the publish mock.
+ */
+export async function publishCapabilityRegistry(
+  opts: PublishCapabilityRegistryOptions,
+): Promise<Envelope[]> {
+  const clock = opts.clock ?? (() => new Date());
+  const instance = opts.instance ?? opts.source.instance;
+  const published: Envelope[] = [];
+
+  for (const entry of opts.entries) {
+    if (entry.capabilities.length === 0) {
+      // Spec §3.4: only register agents with at least one capability.
+      // Skipping silently is the right move — an inline agent
+      // declaring `runtime.capabilities: []` (or omitting `runtime`
+      // entirely) is a valid config; it just doesn't participate in
+      // capability dispatch.
+      continue;
+    }
+
+    const envelope = buildCapabilityRegisteredEnvelope({
+      source: opts.source,
+      agentId: entry.agentId,
+      capabilities: entry.capabilities,
+      registeredAt: clock(),
+      instance,
+      ...(opts.classification !== undefined && { classification: opts.classification }),
+    });
+
+    await opts.publish(envelope);
+    published.push(envelope);
+  }
+
+  return published;
+}

--- a/src/bus/index.ts
+++ b/src/bus/index.ts
@@ -69,3 +69,26 @@ export {
   type CreateReviewTaskFailedEventOpts,
   type ReviewTaskFailedReason,
 } from "./review-events";
+
+// --- Capability registry publisher (cortex#237 PR-3) ---
+//
+// Per `docs/design-capability-dispatch-review-consumer.md` §3 + §10.1
+// PR-3. Re-exported here so PR-7's boot wiring (in `src/cortex.ts`) and
+// pilot's deferred bucket reader (§13.1) consume the publisher + its
+// constant from one place. The event-type constant
+// (`CAPABILITY_REGISTERED_EVENT_TYPE`) is the load-bearing string both
+// the publisher and any future subscriber filter against.
+//
+// PR-7 will additionally export the verdict + pull-subscriber types
+// alongside these; until then the capability-registry surface lands
+// here on its own per PR-3's brief.
+export {
+  CAPABILITY_REGISTERED_EVENT_TYPE,
+  buildCapabilityRegisteredEnvelope,
+  publishCapabilityRegistry,
+  type BuildCapabilityRegisteredEnvelopeOpts,
+  type CapabilityRegistryEntry,
+  type CapabilityRegistrySource,
+  type PublishCapabilityRegistryOptions,
+  type PublishFn,
+} from "./capability-registry";


### PR DESCRIPTION
## Summary

Adds the publisher half of the runtime capability registry per [`docs/design-capability-dispatch-review-consumer.md`](https://github.com/the-metafactory/cortex/blob/main/docs/design-capability-dispatch-review-consumer.md) §3 + §10.1 PR-3.

Reads the parsed cortex.yaml's `agents[].runtime.capabilities[]` (the Phase A.6 schema substrate **already in place** at `cortex-config.ts:429-456` for `AgentRuntimeSchema`, `cortex-config.ts:1582` for the top-level catalog, and the A.6.3 cross-validation at `cortex-config.ts:1765-1787`) and emits one `agents.capabilities.registered` envelope per agent×non-empty-capability-set via an injected publish function.

refs cortex#237

## What this PR ships

- `src/bus/capability-registry.ts` (~330 LoC including comments) — three exports:
  - `buildCapabilityRegisteredEnvelope({ source, agentId, capabilities, registeredAt, instance, classification? })` — pure envelope constructor matching §3.2 payload shape.
  - `publishCapabilityRegistry({ source, entries, publish, instance?, clock?, classification? })` — iterates entries, emits sequentially, skips agents with empty `capabilities[]`. Returns the published envelopes for boot-path logging.
  - `CAPABILITY_REGISTERED_EVENT_TYPE = "agents.capabilities.registered"` — exported constant. PR-7 (boot wiring) and pilot's deferred bucket reader filter against the same literal.
- `src/bus/__tests__/capability-registry.test.ts` (16 tests) covering cardinality, empty-skipping, envelope shape, schema validity, subject literal, mockability, idempotency, error propagation, and deterministic emission order.
- `src/bus/index.ts` — re-exports the new surface so PR-7's boot wiring (and pilot's downstream reader) consume from one place.

## Subject string (for PR-7 to match on the subscriber side)

Wire envelope `type`: **`agents.capabilities.registered`**

Runtime-derived subject (per `myelin/runtime.ts` IAW Phase A.3 derivation):

- classification `local`, no stack: `local.{org}.agents.capabilities.registered`
- classification `local`, with stack: `local.{org}.{stack}.agents.capabilities.registered`
- classification `federated`: `federated.{network}.agents.capabilities.registered`

The `agent_id` discriminator lives in the **payload**, not the subject (v1 publish-only; the §13.1 bucket reader migration moves the discriminator onto the subject as the KV bucket key).

## Design conformance

- Publisher takes `(publish: PublishFn)` injection — no NATS client instantiated inside the module. Tests inject a recording mock; PR-7 will pass `runtime.publish.bind(runtime)`.
- Idempotency: re-invocation produces same logical registrations (same `agent_id` + `capabilities` payload) with fresh envelope ids — bucket consumer deduplicates by `agent_id`.
- Error handling: publish errors propagate to the caller (boot path decides whether to fail loud or downgrade to `system.*`). No empty catch blocks.
- Sovereignty defaults: `local` / NZ / `max_hop: 0` / no frontier / `local-only` model class — matches §3.2 verbatim.
- All envelopes pass `validateEnvelope` from the vendored myelin schema.

## Out of scope

- **No schema changes.** `agents[].runtime.capabilities[]` already exists from Phase A.6. PR-4 owns the additive `sovereignty` + `maxConcurrent` siblings on `AgentRuntimeSchema`.
- **No boot wiring.** PR-7 wires `publishCapabilityRegistry` into `src/cortex.ts`'s startup sequence after `mergedAgents` is built.
- **No KV-bucket primitive.** Architecture §7.2's bucket needs myelin#31 (signed-KV API). v1 publishes a wire envelope on the regular subject; v2 layers the bucket write on top.
- **No bucket reader.** Publish-only per §3.5; reader is deferred per §13.1 (pilot Phase B.4 dependency).

## Acceptance gates

```
bunx tsc --noEmit   # passes (no output)
bun test src/bus/   # 404 pass / 0 fail (+16 new from capability-registry)
bun run lint        # exit 0 (0 errors)
```

## Test plan

- [x] `bunx tsc --noEmit` passes
- [x] `bun test src/bus/__tests__/capability-registry.test.ts` — 16 pass / 0 fail
- [x] `bun test src/bus/` — 404 pass / 0 fail (no regressions to neighbouring suites)
- [x] `bun run lint` — exit 0 (0 errors; warnings are pre-existing unused eslint-disable directives in unrelated files)
- [x] Manual: confirmed `CAPABILITY_REGISTERED_EVENT_TYPE` literal matches the spec string in §3.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)