### PR TITLE
feat(config): cortex#237 PR-4 — AgentRuntimeSchema sovereignty + maxConcurrent

### DIFF
--- a/src/common/types/__tests__/capability.test.ts
+++ b/src/common/types/__tests__/capability.test.ts
@@ -684,6 +684,235 @@ describe("CortexConfigSchema — agents[].runtime.capabilities → catalog (A.6.
 });
 
 // =============================================================================
+// cortex#237 PR-4 — AgentRuntimeSchema sovereignty + maxConcurrent extension
+// =============================================================================
+//
+// Both new fields are OPTIONAL siblings on `agents[].runtime`. The load-bearing
+// invariant is back-compat: every cortex.yaml that parsed before PR-4 MUST
+// continue to parse byte-identically. The new fields add validation only when
+// the operator opts in.
+//
+// Runtime consumption of these values (sovereignty checks in the per-envelope
+// pipeline, maxConcurrent backpressure naks) is PR-5/PR-6's concern — these
+// tests assert schema parsing only.
+
+describe("AgentRuntimeSchema — cortex#237 PR-4 sovereignty + maxConcurrent", () => {
+  test("runtime without sovereignty/maxConcurrent parses unchanged (back-compat)", () => {
+    // THE load-bearing test: every existing cortex.yaml that omits the new
+    // fields parses with the same shape it did before PR-4.
+    const parsed = CortexConfigSchema.parse(
+      minConfig({
+        agents: [
+          minAgent({
+            id: "luna",
+            runtime: {
+              substrate: "claude-code",
+              mode: "in-process",
+              capabilities: [],
+            },
+          }),
+        ],
+      }),
+    );
+    const rt = parsed.agents[0]?.runtime;
+    expect(rt).toBeDefined();
+    expect(rt?.sovereignty).toBeUndefined();
+    expect(rt?.maxConcurrent).toBeUndefined();
+  });
+
+  test("runtime with sovereignty: selective parses", () => {
+    const parsed = CortexConfigSchema.parse(
+      minConfig({
+        agents: [
+          minAgent({
+            id: "luna",
+            runtime: {
+              substrate: "claude-code",
+              mode: "in-process",
+              capabilities: [],
+              sovereignty: "selective",
+            },
+          }),
+        ],
+      }),
+    );
+    expect(parsed.agents[0]?.runtime?.sovereignty).toBe("selective");
+  });
+
+  test("all four sovereignty modes are accepted (open/selective/strict/bidding)", () => {
+    // The enum mirrors myelin's `sovereignty_required` taxonomy (vendor
+    // envelope.schema.json:159, F-021 + F-10) and architecture §7.4. The test
+    // pins the full set so a future enum trim shows up here, not in runtime.
+    for (const mode of ["open", "selective", "strict", "bidding"] as const) {
+      const parsed = CortexConfigSchema.parse(
+        minConfig({
+          agents: [
+            minAgent({
+              id: "luna",
+              runtime: {
+                substrate: "claude-code",
+                mode: "in-process",
+                capabilities: [],
+                sovereignty: mode,
+              },
+            }),
+          ],
+        }),
+      );
+      expect(parsed.agents[0]?.runtime?.sovereignty).toBe(mode);
+    }
+  });
+
+  test("sovereignty with an unknown value is rejected", () => {
+    expect(() =>
+      CortexConfigSchema.parse(
+        minConfig({
+          agents: [
+            minAgent({
+              id: "luna",
+              runtime: {
+                substrate: "claude-code",
+                mode: "in-process",
+                capabilities: [],
+                sovereignty: "lenient", // not a valid mode
+              },
+            }),
+          ],
+        }),
+      ),
+    ).toThrow();
+  });
+
+  test("maxConcurrent: 5 parses", () => {
+    const parsed = CortexConfigSchema.parse(
+      minConfig({
+        agents: [
+          minAgent({
+            id: "luna",
+            runtime: {
+              substrate: "claude-code",
+              mode: "in-process",
+              capabilities: [],
+              maxConcurrent: 5,
+            },
+          }),
+        ],
+      }),
+    );
+    expect(parsed.agents[0]?.runtime?.maxConcurrent).toBe(5);
+  });
+
+  test("maxConcurrent: 1 parses (lower bound)", () => {
+    const parsed = CortexConfigSchema.parse(
+      minConfig({
+        agents: [
+          minAgent({
+            id: "luna",
+            runtime: {
+              substrate: "claude-code",
+              mode: "in-process",
+              capabilities: [],
+              maxConcurrent: 1,
+            },
+          }),
+        ],
+      }),
+    );
+    expect(parsed.agents[0]?.runtime?.maxConcurrent).toBe(1);
+  });
+
+  test("maxConcurrent: 0 is rejected with a helpful message", () => {
+    expect(() =>
+      CortexConfigSchema.parse(
+        minConfig({
+          agents: [
+            minAgent({
+              id: "luna",
+              runtime: {
+                substrate: "claude-code",
+                mode: "in-process",
+                capabilities: [],
+                maxConcurrent: 0,
+              },
+            }),
+          ],
+        }),
+      ),
+    ).toThrow(/positive integer/);
+  });
+
+  test("maxConcurrent: -1 is rejected", () => {
+    expect(() =>
+      CortexConfigSchema.parse(
+        minConfig({
+          agents: [
+            minAgent({
+              id: "luna",
+              runtime: {
+                substrate: "claude-code",
+                mode: "in-process",
+                capabilities: [],
+                maxConcurrent: -1,
+              },
+            }),
+          ],
+        }),
+      ),
+    ).toThrow(/positive integer/);
+  });
+
+  test("maxConcurrent: 1.5 is rejected (must be integer)", () => {
+    expect(() =>
+      CortexConfigSchema.parse(
+        minConfig({
+          agents: [
+            minAgent({
+              id: "luna",
+              runtime: {
+                substrate: "claude-code",
+                mode: "in-process",
+                capabilities: [],
+                maxConcurrent: 1.5,
+              },
+            }),
+          ],
+        }),
+      ),
+    ).toThrow(/integer/);
+  });
+
+  test("sovereignty + maxConcurrent compose with declared capabilities (full PR-4 shape)", () => {
+    // The shape the design spec uses in its cortex.yaml example (§3.4):
+    // capabilities[] + sovereignty + maxConcurrent as siblings under runtime.
+    const parsed = CortexConfigSchema.parse(
+      minConfig({
+        agents: [
+          minAgent({
+            id: "echo",
+            displayName: "Echo",
+            persona: "./personas/echo.md",
+            runtime: {
+              substrate: "claude-code",
+              mode: "in-process",
+              capabilities: ["code-review.typescript"],
+              sovereignty: "selective",
+              maxConcurrent: 3,
+            },
+          }),
+        ],
+        capabilities: [
+          minCapability({ id: "code-review.typescript", provided_by: ["echo"] }),
+        ],
+      }),
+    );
+    const rt = parsed.agents[0]?.runtime;
+    expect(rt?.capabilities).toEqual(["code-review.typescript"]);
+    expect(rt?.sovereignty).toBe("selective");
+    expect(rt?.maxConcurrent).toBe(3);
+  });
+});
+
+// =============================================================================
 // Type round-trip — exported type aliases match the schema
 // =============================================================================
 

--- a/src/common/types/cortex-config.ts
+++ b/src/common/types/cortex-config.ts
@@ -439,6 +439,53 @@ export const AgentRuntimeSchema = z.object({
    *  declared elsewhere (e.g. inferred from `roles`); for `standalone`
    *  agents, at least one capability is required — see refine below. */
   capabilities: z.array(z.string().min(1)).default([]),
+  /**
+   * cortex#237 PR-4 — per-agent sovereignty mode declaration. One of the
+   * four modes from `docs/architecture.md` §7.4:
+   *
+   *   - `open`      — auto-ack all matching tasks (no per-envelope evaluation).
+   *   - `selective` — agent evaluates each envelope's sovereignty axes
+   *                   (`classification`, `data_residency`, `model_class`) and
+   *                   may nak with `wont_do` per design §7.2.
+   *   - `strict`    — explicit capability + sovereignty match required;
+   *                   any mismatch on any axis naks.
+   *   - `bidding`   — triggers a request/reply (M6 pattern) for selection
+   *                   optimisation. Reserved for future bidding rollout.
+   *
+   * **Optional.** When unset the runtime consumer (PR-6) applies a
+   * deployment-wide default — schema does not pick a default here so an
+   * absent value remains observable downstream. Existing cortex.yaml
+   * configs that pre-date this field continue to parse unchanged.
+   *
+   * Enum lifted verbatim from myelin's `sovereignty_required` (vendor
+   * `envelope.schema.json:159` — F-021 + F-10 bidding) so the agent-side
+   * declaration and the envelope-side requirement share one taxonomy.
+   * Runtime consumption is PR-5/PR-6's concern; this PR is schema-only.
+   */
+  sovereignty: z.enum(["open", "selective", "strict", "bidding"]).optional(),
+  /**
+   * cortex#237 PR-4 — upper bound on the number of concurrent dispatched
+   * tasks this agent will admit. When the in-flight count reaches this
+   * value the consumer (PR-6) emits `dispatch.task.failed` with
+   * `reason.kind = "not_now"` and naks the JetStream message per design
+   * §7.3 (backpressure). The retry_after_ms hint is consumer-side
+   * derived — this schema only carries the bound itself.
+   *
+   * **Optional.** Treated as "unbounded" by downstream consumers when
+   * absent. A value of `0` is rejected (zero would mean "never accept
+   * any work", which is more clearly expressed by omitting the agent
+   * from the capability catalog entirely). Non-integer and negative
+   * values are rejected at parse time so a typo (`maxConcurrent: 1.5`,
+   * `maxConcurrent: -1`) surfaces immediately at config load rather
+   * than as a runtime error on first dispatch.
+   *
+   * Runtime consumption is PR-5/PR-6's concern; this PR is schema-only.
+   */
+  maxConcurrent: z
+    .number()
+    .int("agent.runtime.maxConcurrent must be an integer (got a fractional number)")
+    .positive("agent.runtime.maxConcurrent must be a positive integer (omit the field for unbounded concurrency)")
+    .optional(),
 }).refine(
   // Echo M2 on cortex#62 — a `standalone` agent with zero capabilities parses
   // fine but routes zero work. The daemon connects to NATS, publishes nothing


### PR DESCRIPTION
## Summary

Extends `AgentRuntimeSchema` (`src/common/types/cortex-config.ts:429`) with two new **optional** sibling fields per the design spec at [`docs/design-capability-dispatch-review-consumer.md`](https://github.com/the-metafactory/cortex/blob/main/docs/design-capability-dispatch-review-consumer.md) §3.4 + §10.1:

- **`sovereignty`** — enum (`open` | `selective` | `strict` | `bidding`), lifted verbatim from myelin's `sovereignty_required` taxonomy (`src/bus/myelin/vendor/envelope.schema.json:159`, F-021 + F-10 bidding) and architecture.md §7.4. Operators declare per-agent claim behaviour.
- **`maxConcurrent`** — positive integer. Upper bound on dispatched tasks the agent will admit concurrently before backpressure-naks per design §7.3.

Both fields are **optional with no schema default** — absent values stay observable downstream so the consumer (PR-6) can apply a deployment-wide policy. `maxConcurrent: 0`, negative, and fractional values are rejected at parse time with operator-friendly messages.

## Back-compat

THE load-bearing invariant: every existing `cortex.yaml` that pre-dates this PR continues to parse byte-identically. Verified by an explicit test (`runtime without sovereignty/maxConcurrent parses unchanged`) plus the full test suite (3132/3132 passing, including the entire pre-existing `cortex-config.test.ts` and `capability.test.ts` corpus).

## Cross-validator

**No update required.** Both fields are per-agent runtime knobs validated by the Zod object itself (enum + positive integer). Neither references any other config block, so no `superRefine` document-level invariant is needed — inline validation on the field schemas is sufficient and consistent with how `substrate` / `mode` are already validated (also no doc-level refines for those).

## Out of scope

- **Runtime consumption** of `sovereignty` — PR-5/PR-6's concern. This PR only adds the schema; the per-envelope sovereignty-check pipeline (design §7.2 `wont_do` nak path) is not wired here.
- **Runtime consumption** of `maxConcurrent` — PR-5/PR-6's concern. The in-flight counter, the `not_now` nak emission with `retry_after_ms` hints (design §7.3), and the JetStream nak wiring are not in this PR. Downstream consumers will treat absent as "unbounded".
- **No rename or removal** of existing `AgentRuntimeSchema` fields (`substrate`, `mode`, `capabilities`). PR-4 is strictly additive.
- **`agents[].runtime.capabilities[]`** — already shipped at Phase A.6 (`cortex-config.ts:441`). This PR does NOT touch it. Echo cortex#253 R1 caught the original draft's schema-drift proposal — we honour that fix.

## Test plan

- [x] `bunx tsc --noEmit` — clean
- [x] `bun test src/common/types/` — 226/226 pass (+10 from PR-4)
- [x] `bun test src/common/config/` — 334/335 pass (1 pre-existing flake in `watcher.test.ts:462` unrelated to PR-4; passes in isolation)
- [x] `bun test src/` (full suite) — 3132 pass / 1 skip / 0 fail
- [x] `bun run lint` — 0 errors (21 pre-existing warnings, all `unused eslint-disable directive` in files unrelated to this PR)

New test coverage in `src/common/types/__tests__/capability.test.ts`:

1. Runtime without sovereignty/maxConcurrent parses unchanged (**back-compat — load-bearing**)
2. `sovereignty: "selective"` parses correctly
3. All four sovereignty modes accepted (`open` / `selective` / `strict` / `bidding`)
4. Unknown sovereignty value rejected
5. `maxConcurrent: 5` parses
6. `maxConcurrent: 1` parses (lower bound)
7. `maxConcurrent: 0` rejected with `/positive integer/` message
8. `maxConcurrent: -1` rejected
9. `maxConcurrent: 1.5` rejected with `/integer/` message
10. Full PR-4 shape composition (`capabilities[] + sovereignty + maxConcurrent`)

refs cortex#237

🤖 Generated with [Claude Code](https://claude.com/claude-code)