### PR TITLE
fix(migrate-config): terminate collision-fallback loop (closes cortex#119)

### DIFF
--- a/src/cli/cortex/commands/__tests__/migrate-config.test.ts
+++ b/src/cli/cortex/commands/__tests__/migrate-config.test.ts
@@ -830,6 +830,67 @@ describe("convertBotYaml — agent id detection (cortex#88 item 3)", () => {
 // cortex#106 items 1 + 2 — collision-fallback off-by-one + duplicate-hint warn
 // ---------------------------------------------------------------------------
 
+describe("convertBotYaml — collision fallback termination (cortex#119)", () => {
+  test("numeric-fallback collision with earlier hint claim terminates (no infinite loop)", () => {
+    // Pre-cortex#119: the while-loop body re-computed
+    // `${baseId}-${variantIds.length + 1}` on every iteration without
+    // advancing the counter. If that candidate was itself already
+    // claimed — e.g. adapter[0]'s `agent-luna-2` hint claims `luna-2`,
+    // then adapter[1] falls to numeric and also computes `luna-2` —
+    // the loop spun forever.
+    //
+    // Post-fix: a local `n` counter advances inside the loop, so the
+    // candidate space is strictly monotonic and termination is
+    // guaranteed regardless of which ids `claimedIds` already holds.
+    //
+    // Concretely: adapter[0] hints `agent-luna-2` (id=`luna-2`),
+    // adapter[1] has NO hint so falls to numeric (`luna-${1+1}` =
+    // `luna-2`) which collides, the loop must walk to `luna-3`.
+    const legacy: LegacyBotYaml = {
+      agent: {
+        name: "luna",
+        displayName: "Luna",
+        personaFile: "./personas/luna.md",
+      },
+      discord: [
+        {
+          token: "t1",
+          guildId: "1",
+          agentChannelId: "2",
+          logChannelId: "3",
+          // adapter[0] uses a role-resolver hint claiming `luna-2`
+          // explicitly (operator-labelled, atypical but legal).
+          roles: [
+            {
+              name: "agent-luna-2",
+              users: ["100000000000000001"],
+              features: ["chat"],
+            },
+          ],
+        },
+        {
+          token: "t2",
+          guildId: "10",
+          agentChannelId: "20",
+          logChannelId: "30",
+          // adapter[1] has no `agent-*` hint — falls to numeric.
+          // Numeric formula yields `luna-2` which is already claimed
+          // by adapter[0]. Without the cortex#119 fix this hangs.
+        },
+      ],
+    };
+
+    // Termination check — pre-fix this assertion never gets reached
+    // because convertBotYaml would not return. With the fix it
+    // resolves the collision to `luna-3`.
+    const result = convertBotYaml(legacy, {});
+    expect(result.cortex.agents.map((a) => a.id)).toEqual([
+      "luna-2",
+      "luna-3",
+    ]);
+  });
+});
+
 describe("convertBotYaml — collision fallback numbering (cortex#106 item 1)", () => {
   test("three adapters all hinting the same id walk luna, luna-2, luna-3", () => {
     // Pathological config: three adapters all carry `agent-luna` hints. The

--- a/src/cli/cortex/commands/migrate-config-lib.ts
+++ b/src/cli/cortex/commands/migrate-config-lib.ts
@@ -558,8 +558,18 @@ function buildAgents(
     // cortex#106 item 1: drop the off-by-one — `variantIds.length` is the
     // index of the variant being assigned, so `+1` yields the right suffix
     // (`luna-2` at i=1, `luna-3` at i=2), not `luna-3`/`luna-4`.
+    //
+    // cortex#119 fix: advance the counter inside the loop. The pre-fix
+    // body re-computed `${baseId}-${variantIds.length + 1}` on every
+    // iteration without advancing the counter, so if that candidate was
+    // also already claimed (e.g. an earlier adapter's hint claimed
+    // `luna-2`, then this adapter's numeric-fallback also picks `luna-2`),
+    // the loop spun forever. Using a local counter that advances guarantees
+    // termination — the candidate space is strictly monotonic in `n` and
+    // `claimedIds` is finite.
+    let n = variantIds.length + 1;
     while (claimedIds.has(id)) {
-      id = `${baseId}-${variantIds.length + 1}`;
+      id = `${baseId}-${n++}`;
     }
     // cortex#106 item 2: duplicate `agent-<X>` hint across adapters —
     // operator misconfigured two adapters to both claim the same identity.


### PR DESCRIPTION
## Summary

Pre-existing infinite-loop pathology in \`resolveAgentIds\` flagged by Echo on cortex#118 round 2. The collision-fallback while-loop re-computed the same candidate every iteration without advancing the counter, so if that candidate was itself already claimed (operator config quirk: explicit \`agent-luna-2\` hint + later numeric fallback that also yields \`luna-2\`), the loop spun forever.

## Fix

\`\`\`diff
- while (claimedIds.has(id)) {
-   id = \`\${baseId}-\${variantIds.length + 1}\`;
- }
+ let n = variantIds.length + 1;
+ while (claimedIds.has(id)) {
+   id = \`\${baseId}-\${n++}\`;
+ }
\`\`\`

The candidate space is now strictly monotonic in \`n\` and \`claimedIds\` is finite — termination is guaranteed.

## Regression test

New test \`convertBotYaml — collision fallback termination (cortex#119)\`:

- adapter[0] hints \`agent-luna-2\` → claims \`luna-2\`
- adapter[1] no hint → numeric fallback computes \`luna-2\` → collides
- post-fix: loop walks to \`luna-3\`; result agents = \`["luna-2", "luna-3"]\`
- pre-fix: \`convertBotYaml\` hangs and the test times out

## Mutation verification

Reverting the loop body to \`id = \${baseId}-\${variantIds.length + 1}\` (the bug):

\`\`\`
$ timeout 5 bun test src/cli/cortex/commands/__tests__/migrate-config.test.ts -t "cortex#119"
exit: 124
\`\`\`

Restoring the fix returns exit 0 / 1 pass / 0 fail.

## Verification

- 3153/3154 full suite green (1 unrelated skip)
- \`bunx tsc --noEmit\` clean
- \`bun run lint:errors\` clean

## Refs

- closes cortex#119
- cortex#118 (Echo's round-2 review where this surfaced)
- Touches the same file as cortex#243 (C.2c migrate-config policy extension) — landing this first keeps that PR focused on the policy-block feature without bundling the loop fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)