### PR TITLE
feat(cortex): cortex#237 PR-7 — capability-registry boot wiring

### DIFF
--- a/src/__tests__/cortex.capability-boot.test.ts
+++ b/src/__tests__/cortex.capability-boot.test.ts
@@ -1,0 +1,392 @@
+/**
+ * cortex#237 PR-7 — capability-registry boot wiring tests.
+ *
+ * Asserts the §3.4 boot loop:
+ *
+ *   for each agent in mergedAgents:
+ *     if agent.runtime?.capabilities?.length > 0:
+ *       publishCapabilityRegistry → one envelope per such agent
+ *
+ * Covers:
+ *
+ *   1. N agents-with-capabilities → N publishes (per-agent ordering, payload
+ *      shape, type constant, classification default).
+ *   2. Per-envelope publish failure → log to stderr; sibling envelopes still
+ *      emit; boot completes.
+ *   3. Zero agents-with-capabilities → zero publishes; boot completes.
+ *   4. Agents WITHOUT `runtime.capabilities` (or with empty array) are
+ *      silently skipped — `mergedAgents` may contain a mix.
+ *   5. Idempotency under double-boot: same logical agent_ids re-emit (the
+ *      bucket dedup is the consumer's job per §3.3).
+ *
+ * Test infrastructure mirrors `cortex.test.ts`:
+ *   - `minimalConfig` factory for a NATS-absent BotConfig.
+ *   - `createRecordingRuntime` factory — same `Set<EnvelopeHandler>`-based
+ *     fake the surface-router tests already use; `published` array captures
+ *     every envelope that landed on `runtime.publish`.
+ *   - `inlineAgents` injected via `StartCortexOptions.inlineAgents` so the
+ *     test can construct the agent mix without writing fragments to disk.
+ *
+ * No real NATS, Discord, or filesystem-watcher I/O.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { BotConfigSchema, type BotConfig } from "../common/types/config";
+import type { Agent, AgentRuntime } from "../common/types/cortex-config";
+import { startCortex } from "../cortex";
+import { CAPABILITY_REGISTERED_EVENT_TYPE } from "../bus";
+import type { Envelope } from "../bus/myelin/envelope-validator";
+import type { EnvelopeHandler, MyelinRuntime } from "../bus/myelin/runtime";
+
+// ---------------------------------------------------------------------------
+// Test helpers — kept local rather than re-imported from cortex.test.ts to
+// avoid cross-test-file coupling (the existing test deliberately keeps its
+// helpers private; mirroring the shape here is cheap and keeps both files
+// independently editable).
+// ---------------------------------------------------------------------------
+
+function minimalConfig(overrides: Partial<Record<string, unknown>> = {}): BotConfig {
+  return BotConfigSchema.parse({
+    agent: {
+      name: "test-cortex",
+      displayName: "TestCortex",
+      operatorId: "test-op",
+    },
+    discord: [],
+    mattermost: [],
+    claude: { timeoutMs: 120_000 },
+    paths: { publishedEventsDir: "/tmp/grove-cortex-test-published" },
+    ...overrides,
+  });
+}
+
+interface PublishResult {
+  ok: boolean;
+  error?: Error;
+}
+
+interface RecordingRuntime extends MyelinRuntime {
+  onEnvelopeHandlers: Set<EnvelopeHandler>;
+  published: Envelope[];
+  /**
+   * Per-call publish behaviour control. When set, the i-th `publish` call
+   * resolves with the i-th entry: `{ok: true}` resolves, `{ok: false}`
+   * rejects with `entry.error`. Indices beyond the list use the default
+   * `{ok: true}` behaviour. The error path tests use this to surface a
+   * mid-loop failure without breaking the runtime's contract.
+   */
+  publishOutcomes: PublishResult[];
+}
+
+function createRecordingRuntime(): RecordingRuntime {
+  const onEnvelopeHandlers = new Set<EnvelopeHandler>();
+  const published: Envelope[] = [];
+  const publishOutcomes: PublishResult[] = [];
+  let publishCallIndex = 0;
+  return {
+    enabled: false,
+    onEnvelopeHandlers,
+    published,
+    publishOutcomes,
+    onEnvelope(handler) {
+      onEnvelopeHandlers.add(handler);
+      return {
+        unregister: () => {
+          onEnvelopeHandlers.delete(handler);
+        },
+      };
+    },
+    publish: async (envelope: Envelope) => {
+      const idx = publishCallIndex++;
+      const outcome = publishOutcomes[idx];
+      if (outcome && !outcome.ok) {
+        throw outcome.error ?? new Error("publish failed");
+      }
+      // Only record successful publishes — matches "what landed on the wire"
+      // semantics (an exception means nothing reached the bus). The boot
+      // wiring's wrapped-publish swallows the error, so the test cares
+      // about (a) the publish-call count via outcomes, and (b) the
+      // recorded-envelope count for successful publishes.
+      published.push(envelope);
+    },
+    stop: async () => {},
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Agent fixture — keeps the per-test inline-agent block compact. Builds an
+// Agent matching AgentSchema with the requested id + capabilities (and the
+// minimum presence shape so the parser doesn't reject downstream).
+// ---------------------------------------------------------------------------
+
+function makeAgent(id: string, capabilities: readonly string[] | undefined): Agent {
+  // Build a minimal headless presence (cortex#245) so no Discord/Slack/MM
+  // adapter wiring kicks in. `runtime` is omitted when `capabilities` is
+  // `undefined`, set to a complete `AgentRuntime` (with the requested
+  // `capabilities[]`) when an array is supplied (including the empty array
+  // — the boot loop's "≥1 capability" filter is what we want to exercise).
+  const runtime: AgentRuntime | undefined =
+    capabilities === undefined
+      ? undefined
+      : {
+          substrate: "claude-code",
+          mode: "in-process",
+          capabilities: [...capabilities],
+        };
+
+  return {
+    id,
+    displayName: id.charAt(0).toUpperCase() + id.slice(1),
+    // Persona path is read-checked only when an adapter starts; for our
+    // headless boot path nothing tries to open it.
+    persona: `/tmp/${id}-persona.md`,
+    roles: [],
+    trust: [],
+    presence: {},
+    ...(runtime !== undefined && { runtime }),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// stderr capture — the wrapped-publish error path writes to
+// `process.stderr.write`. Bun's test runtime doesn't isolate stderr per
+// test, so we temporarily monkey-patch `process.stderr.write` for the
+// duration of the assertion and restore it after. The patched writer
+// captures the chunk verbatim into a string buffer.
+// ---------------------------------------------------------------------------
+
+function withCapturedStderr<T>(fn: () => Promise<T>): Promise<{ result: T; stderr: string }> {
+  const original = process.stderr.write.bind(process.stderr);
+  let buf = "";
+  // Match the overload signature `(chunk, encoding?, callback?) => boolean`
+  // loosely — the only call site we care about (`process.stderr.write(string)`)
+  // hits the single-arg form. TS infers the overload directly from the
+  // assignment target's type without a cast.
+  process.stderr.write = (chunk: unknown): boolean => {
+    buf += typeof chunk === "string" ? chunk : String(chunk);
+    return true;
+  };
+  return fn()
+    .then((result) => {
+      process.stderr.write = original;
+      return { result, stderr: buf };
+    })
+    .catch((err: unknown) => {
+      process.stderr.write = original;
+      throw err;
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("startCortex — capability-registry boot wiring (cortex#237 PR-7)", () => {
+  test("N agents with capabilities → N publish calls; each carries the right type + payload", async () => {
+    const runtime = createRecordingRuntime();
+    const tmpAgentsDir = mkdtempSync(join(tmpdir(), "cortex-capboot-N-"));
+    const inlineAgents: Agent[] = [
+      makeAgent("echo", ["code-review.typescript", "code-review.bun"]),
+      makeAgent("holly", ["research.web"]),
+    ];
+
+    const handle = await startCortex(minimalConfig(), {
+      disableConfigWatcher: true,
+      disableDashboard: true,
+      disableOutboundPoller: true,
+      agentsDir: tmpAgentsDir,
+      injectRuntime: runtime,
+      inlineAgents,
+    });
+
+    // One envelope per agent-with-capabilities. The capabilities list is
+    // a payload field on the per-agent envelope — NOT one envelope per
+    // capability (matches §3.2 example: one registration envelope per
+    // agent carrying that agent's `capabilities[]` array).
+    expect(runtime.published.length).toBe(2);
+
+    const types = new Set(runtime.published.map((e) => e.type));
+    expect(types.size).toBe(1);
+    expect([...types][0]).toBe(CAPABILITY_REGISTERED_EVENT_TYPE);
+
+    // Sovereignty defaults per §3.2 — classification: local.
+    for (const env of runtime.published) {
+      expect(env.sovereignty.classification).toBe("local");
+    }
+
+    // Per-agent payload assertions. The publisher emits in agent-list order
+    // (sequential per the publisher's concurrency doc). `noUncheckedIndexedAccess`
+    // gives us `T | undefined` on positional lookups; the prior length
+    // assertion narrows the run-time shape but not the type, so the
+    // non-null assertion is the cleanest local fix.
+    const echoEnv = runtime.published[0]!;
+    const hollyEnv = runtime.published[1]!;
+    expect(echoEnv.payload).toMatchObject({
+      agent_id: "echo",
+      capabilities: ["code-review.typescript", "code-review.bun"],
+      instance: "local",
+    });
+    expect(hollyEnv.payload).toMatchObject({
+      agent_id: "holly",
+      capabilities: ["research.web"],
+      instance: "local",
+    });
+
+    await handle.stop();
+    rmSync(tmpAgentsDir, { recursive: true, force: true });
+  });
+
+  test("one publish throws → sibling envelopes still emit; error is logged to stderr; boot completes", async () => {
+    const runtime = createRecordingRuntime();
+    // Force the FIRST publish (echo's registration) to reject. The boot
+    // wiring's wrapped-publish must trap this and continue with holly.
+    runtime.publishOutcomes.push({ ok: false, error: new Error("simulated bus failure") });
+
+    const tmpAgentsDir = mkdtempSync(join(tmpdir(), "cortex-capboot-fail-"));
+    const inlineAgents: Agent[] = [
+      makeAgent("echo", ["code-review.typescript"]),
+      makeAgent("holly", ["research.web"]),
+    ];
+
+    const { result: handle, stderr } = await withCapturedStderr(() =>
+      startCortex(minimalConfig(), {
+        disableConfigWatcher: true,
+        disableDashboard: true,
+        disableOutboundPoller: true,
+        agentsDir: tmpAgentsDir,
+        injectRuntime: runtime,
+        inlineAgents,
+      }),
+    );
+
+    // The recording runtime only pushes envelopes onto `published` on
+    // SUCCESS — so only holly's envelope is recorded. The publish call
+    // count is what proves both attempts happened: this is observable
+    // via `publishOutcomes` consumption (the runtime increments its
+    // internal index per call). One simpler witness: holly's envelope
+    // landed AND the stderr log carries echo's agent_id.
+    expect(runtime.published.length).toBe(1);
+    expect(runtime.published[0]!.payload).toMatchObject({ agent_id: "holly" });
+
+    // The error log path must mention the failing agent + the underlying
+    // message. Per the wiring's stderr format ("…agent_id=X…: <msg>") we
+    // assert on both substrings, not the full template — the exact
+    // wording can drift without breaking the contract.
+    expect(stderr).toContain("capability-registry publish failed");
+    expect(stderr).toContain("agent_id=echo");
+    expect(stderr).toContain("simulated bus failure");
+
+    // Boot still produced a handle — the per-envelope failure must not
+    // abort startup.
+    expect(handle).toBeDefined();
+    await handle.stop();
+    rmSync(tmpAgentsDir, { recursive: true, force: true });
+  });
+
+  test("zero agents-with-capabilities → zero publishes; boot still completes", async () => {
+    const runtime = createRecordingRuntime();
+    const tmpAgentsDir = mkdtempSync(join(tmpdir(), "cortex-capboot-zero-"));
+    // Mix of agents that should NOT trigger a publish:
+    //   - luna: no `runtime` block at all (the §3.4 "runtime?." guard
+    //     short-circuits).
+    //   - holly: `runtime.capabilities` is the empty array (the publisher's
+    //     "≥1 capability" guard skips silently).
+    const inlineAgents: Agent[] = [
+      makeAgent("luna", undefined),
+      makeAgent("holly", []),
+    ];
+
+    const handle = await startCortex(minimalConfig(), {
+      disableConfigWatcher: true,
+      disableDashboard: true,
+      disableOutboundPoller: true,
+      agentsDir: tmpAgentsDir,
+      injectRuntime: runtime,
+      inlineAgents,
+    });
+
+    expect(runtime.published.length).toBe(0);
+    expect(handle).toBeDefined();
+    await handle.stop();
+    rmSync(tmpAgentsDir, { recursive: true, force: true });
+  });
+
+  test("mixed roster — only agents with capabilities publish; others silently skipped", async () => {
+    const runtime = createRecordingRuntime();
+    const tmpAgentsDir = mkdtempSync(join(tmpdir(), "cortex-capboot-mix-"));
+    const inlineAgents: Agent[] = [
+      makeAgent("luna", undefined), // skipped (no runtime)
+      makeAgent("echo", ["code-review.typescript"]), // emits
+      makeAgent("holly", []), // skipped (empty array)
+      makeAgent("ivy", ["research.web", "research.papers"]), // emits
+    ];
+
+    const handle = await startCortex(minimalConfig(), {
+      disableConfigWatcher: true,
+      disableDashboard: true,
+      disableOutboundPoller: true,
+      agentsDir: tmpAgentsDir,
+      injectRuntime: runtime,
+      inlineAgents,
+    });
+
+    expect(runtime.published.length).toBe(2);
+    const agentIds = runtime.published.map((e) => (e.payload as { agent_id: string }).agent_id);
+    expect(agentIds).toEqual(["echo", "ivy"]);
+
+    await handle.stop();
+    rmSync(tmpAgentsDir, { recursive: true, force: true });
+  });
+
+  test("idempotency under double-boot — second startCortex re-publishes the same logical agent_ids (KV bucket dedup is the consumer's contract per §3.3)", async () => {
+    // Two back-to-back boots against the SAME injected runtime model the
+    // restart-and-replay case: the daemon stops and starts again, the
+    // bucket already has entries from the previous boot, and the consumer
+    // is expected to overwrite-on-same-key. The wire side may see
+    // duplicates — that's the §3.3 contract, restated in the boot wiring's
+    // comment. We assert the duplicate emission rather than guard against
+    // it (a guard here would obscure the wire-level reality).
+    const inlineAgents: Agent[] = [
+      makeAgent("echo", ["code-review.typescript"]),
+    ];
+
+    const runtimeA = createRecordingRuntime();
+    const tmpAgentsDirA = mkdtempSync(join(tmpdir(), "cortex-capboot-idemp-A-"));
+    const handleA = await startCortex(minimalConfig(), {
+      disableConfigWatcher: true,
+      disableDashboard: true,
+      disableOutboundPoller: true,
+      agentsDir: tmpAgentsDirA,
+      injectRuntime: runtimeA,
+      inlineAgents,
+    });
+    await handleA.stop();
+    rmSync(tmpAgentsDirA, { recursive: true, force: true });
+    expect(runtimeA.published.length).toBe(1);
+    const firstAgentId = (runtimeA.published[0]!.payload as { agent_id: string }).agent_id;
+
+    const runtimeB = createRecordingRuntime();
+    const tmpAgentsDirB = mkdtempSync(join(tmpdir(), "cortex-capboot-idemp-B-"));
+    const handleB = await startCortex(minimalConfig(), {
+      disableConfigWatcher: true,
+      disableDashboard: true,
+      disableOutboundPoller: true,
+      agentsDir: tmpAgentsDirB,
+      injectRuntime: runtimeB,
+      inlineAgents,
+    });
+    await handleB.stop();
+    rmSync(tmpAgentsDirB, { recursive: true, force: true });
+    expect(runtimeB.published.length).toBe(1);
+    const secondAgentId = (runtimeB.published[0]!.payload as { agent_id: string }).agent_id;
+
+    // Same logical key — different envelope (fresh id/timestamp per the
+    // publisher doc). The KV bucket would overwrite the slot; the wire
+    // saw it twice.
+    expect(firstAgentId).toBe(secondAgentId);
+    expect(runtimeA.published[0]!.id).not.toBe(runtimeB.published[0]!.id);
+  });
+});

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -44,6 +44,10 @@ import { DID_RE } from "@the-metafactory/myelin/identity";
 import { createSurfaceRouter, type SurfaceRouter } from "./bus/surface-router";
 import { createNetworkResolver } from "./bus/network-resolver";
 import type { SystemEventSource } from "./bus/system-events";
+import {
+  publishCapabilityRegistry,
+  type CapabilityRegistryEntry,
+} from "./bus";
 
 import { DiscordAdapter } from "./adapters/discord";
 import { createRenderer, type Renderer } from "./renderers";
@@ -491,6 +495,99 @@ export async function startCortex(
       dataResidency: config.agent.dataResidency,
     }),
   };
+
+  // cortex#237 PR-7 — capability-registry boot wiring.
+  //
+  // Per `docs/design-capability-dispatch-review-consumer.md` §3.4: for each
+  // agent in `mergedAgents` with at least one `runtime.capabilities[]` entry,
+  // publish one `agents.capabilities.registered` envelope so the rest of the
+  // network (today: pilot's deferred bucket reader per §13.1; tomorrow: the
+  // operator-side dashboard) can discover what each agent claims to do.
+  //
+  // **Ordering rationale.** This block runs AFTER:
+  //   - the runtime is constructed (line ~395) so `runtime.publish` is wired
+  //     (no-op stub when NATS is absent; production runtime when present),
+  //   - `mergedAgents` is built (line ~439) so we know who claims what,
+  //   - `systemEventSource` is built (immediately above) so we share the same
+  //     `{org}.cortex.{instance}` envelope source with `system.*` emissions.
+  //
+  // It runs BEFORE the bus-dispatch-listener + surface-router start so the
+  // registry envelope is on the wire before any dispatch envelope can arrive
+  // — peers that gate on "is the registration there yet?" (pilot Phase B.4,
+  // deferred per §13.1) see it before the first `tasks.code-review.*` is
+  // accepted. Even though pilot's reader doesn't exist yet, putting the
+  // emission first keeps the future ordering contract obvious.
+  //
+  // **Error handling (per task spec + CLAUDE.md "no empty catch blocks").**
+  // `publishCapabilityRegistry` itself does NOT catch publish errors — its
+  // doc explicitly says they propagate to the caller. So we wrap the
+  // injected `publish` here and trap per-envelope failures with a
+  // `process.stderr.write` log + a non-throw resolve. Net effect: one bad
+  // publish doesn't abort the rest of the loop OR abort boot.
+  //
+  // **Idempotency.** Re-invoking `publishCapabilityRegistry` with the same
+  // entries re-emits envelopes with fresh ids/timestamps; the bucket
+  // consumer keys on the payload `agent_id` and overwrites — see the
+  // publisher's idempotency doc. So this boot-time call is safe under
+  // restart-and-replay; we do NOT wire a re-publish into the BotConfig
+  // hot-reload path because (a) capabilities live on `Agent`, not
+  // `BotConfig`, and (b) cortex.ts does not currently run an agents.d/
+  // fragment watcher at the daemon level — when one is wired, the
+  // re-publish belongs in its callback, not the BotConfig one.
+  //
+  // **Scope (per §10.1 PR-7).** Publish-only. No subscriber wiring here —
+  // the consumer is operator-dashboard side and lands in a future PR.
+  const capabilityEntries: CapabilityRegistryEntry[] = mergedAgents
+    .filter((a): a is Agent & { runtime: { capabilities: readonly string[] } } =>
+      (a.runtime?.capabilities.length ?? 0) > 0,
+    )
+    .map((a) => ({
+      agentId: a.id,
+      capabilities: a.runtime.capabilities,
+    }));
+  if (capabilityEntries.length > 0) {
+    const wrappedPublish = async (env: Parameters<typeof runtime.publish>[0]): Promise<void> => {
+      try {
+        await runtime.publish(env);
+      } catch (err) {
+        // Per CLAUDE.md "no empty catch blocks": log every error. We use
+        // stderr (not the system-events pipeline) because the system-events
+        // emitter shares the same runtime we just failed to publish on —
+        // routing the error through it would be a credible re-failure loop.
+        // Continue without rethrowing so sibling envelopes still emit.
+        process.stderr.write(
+          `cortex: capability-registry publish failed for ${env.type} ` +
+            `(agent_id=${(env.payload as { agent_id?: string }).agent_id ?? "?"}): ` +
+            `${err instanceof Error ? err.message : String(err)}\n`,
+        );
+      }
+    };
+    try {
+      const published = await publishCapabilityRegistry({
+        source: systemEventSource,
+        entries: capabilityEntries,
+        publish: wrappedPublish,
+      });
+      console.log(
+        `cortex: published ${published.length} capability registration(s) ` +
+          `for ${capabilityEntries.length} agent(s)`,
+      );
+    } catch (err) {
+      // Defensive — `publishCapabilityRegistry` is pure orchestration and
+      // shouldn't throw once `wrappedPublish` traps per-envelope failures,
+      // but a `clock()` or `buildBaseEnvelope` throw would still surface
+      // here. Boot continues; the bucket simply stays unpopulated until
+      // the next restart.
+      console.error(
+        "cortex: capability-registry boot wiring failed (non-fatal — boot continues):",
+        err instanceof Error ? err.message : String(err),
+      );
+    }
+  } else {
+    console.log(
+      "cortex: capability-registry skipped — 0 agents declare runtime.capabilities[]",
+    );
+  }
 
   // IAW Phase B.2a (refs cortex#114) — inbound peer-dispatch listener.
   // Subscribes via the runtime's onEnvelope fan-out, filters for


### PR DESCRIPTION
refs cortex#237

Wires `publishCapabilityRegistry` (shipped in PR-3, #284) into
`startCortex`'s boot sequence per
[`docs/design-capability-dispatch-review-consumer.md`][spec] §3.4
(boot loop) and §10.1 PR-7 (per-PR scope row).

[spec]: https://github.com/the-metafactory/cortex/blob/main/docs/design-capability-dispatch-review-consumer.md

## Summary

- New block in `src/cortex.ts:495-589` (after `mergedAgents` + `systemEventSource`, before `BusDispatchListener.start()`):
  - Projects `mergedAgents` → `CapabilityRegistryEntry[]` keeping only agents whose `runtime.capabilities[]` is non-empty.
  - When the list is non-empty: invokes `publishCapabilityRegistry` with the `systemEventSource` shape (identical to `CapabilityRegistrySource`) and a wrapped publisher that traps per-envelope errors via `process.stderr.write` and continues.
  - When the list is empty: logs `cortex: capability-registry skipped — 0 agents declare runtime.capabilities[]` and emits nothing.
- New test file `src/__tests__/cortex.capability-boot.test.ts` (5 cases): happy-path N publishes, per-envelope failure with stderr capture + sibling envelope still emits, zero-agents-with-capabilities, mixed roster, double-boot idempotency (re-emission with same `agent_id` per §3.3's bucket-overwrite contract).

## Wiring details

- **Where:** `src/cortex.ts:495` — immediately after `systemEventSource` is declared and before any other subsystem that consumes the runtime starts publishing/subscribing. Re-uses the same source struct (structural `{org, agent, instance, dataResidency?}` shape).
- **Error handling:** the publisher's own JSDoc states it does NOT catch publish errors; they propagate. The wiring wraps the injected `publish` so per-envelope failures log to stderr with the failing `agent_id` + message and continue the loop. Boot never aborts on a bus glitch.
- **Boot log:** `cortex: published N capability registration(s) for M agent(s)` (or the skip variant), matching the existing boot-log style.
- **Idempotency:** the publisher contract (per PR-3) is that re-invocation emits fresh envelopes but identical payload `agent_id` keys; the bucket consumer overwrites the slot. Double-boot test exercises this on the wire.

## Out of scope

- **Consumer / subscriber wiring** for the registry. The future consumer is the **operator-side dashboard** (deferred per §13.1 / §10.1's "future PR" note). This PR is publish-only.
- **Config-reload re-publish.** Capabilities live on `Agent.runtime.capabilities[]`, sourced from `inlineAgents` + the `agents.d/` fragments — NOT in `BotConfig`'s `SAFE_FIELDS` set. The BotConfig hot-reload callback at `cortex.ts:~1303` does not mutate the agent set. There is no agents.d/ fragment watcher running at the daemon level today; when one is wired, the re-publish belongs in that callback (documented inline at the call site).
- **KV bucket primitive.** §3.5 v1 is publish-only — the bucket reader ships when pilot Phase B.4 needs it.
- **PR-4's payload fields** (`sovereignty`, `max_concurrent`) — schema landed (#285), but PR-3's envelope builder doesn't yet carry them on the payload. That's a future small follow-up against `capability-registry.ts`, independent of this wiring.

## Acceptance gates

```
bunx tsc --noEmit         # clean
bun test src/             # 3183 pass / 0 fail (+5 new vs. main)
bun run lint              # 0 errors; 21 pre-existing warnings (unchanged)
```

## Test plan

- [x] Type-check passes
- [x] Full repo test suite passes (3183 pass / 0 fail)
- [x] Lint clean (0 new errors)
- [x] New tests pass: 5/5 in `cortex.capability-boot.test.ts`
- [x] Rebased on origin/main (merge-base `01a133b`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)