### PR TITLE
docs(iteration): v2.0.0 policy cutover iteration plan + IoAW master plan update

### DIFF
--- a/docs/iteration-policy-cutover.md
+++ b/docs/iteration-policy-cutover.md
@@ -1,0 +1,126 @@
+# Iteration — v2.0.0 policy cutover
+
+**Design spec:** [`docs/design-policy-cutover.md`](./design-policy-cutover.md)
+**Parents:** [cortex#243](https://github.com/the-metafactory/cortex/issues/243) (CLI work) + [cortex#242](https://github.com/the-metafactory/cortex/issues/242) (breaking removal)
+**Target version:** v2.0.0
+
+## Goal
+
+Retire the legacy per-adapter `roles[]` blocks from `DiscordPresenceSchema` / `MattermostPresenceSchema` / `SlackPresenceSchema`. Make the top-level `policy: { principals[], roles[] }` block the authoritative source for all authorization decisions. PolicyEngine becomes the single decision point; adapters become thin lookup-and-call shells.
+
+## Why this iteration exists
+
+Phase C.2a (PR #219) shipped the additive `policy:` block. The legacy per-adapter `roles[]` schema has remained in place since — both shapes coexist. v2.0.0 is the cleanup: drop the legacy, commit to PolicyEngine-only, give operators a `migrate-config` path to lift their existing configs.
+
+Naive framing of cortex#242/#243 is "lift roles[] into policy:". The design spec (PR #291, ratified through 3 review rounds) surfaces why this understates the work and locks in the schema + 5-PR sequence below.
+
+## Dependency DAG
+
+```
+243a  ──┬──►  243c  ──┐
+        │             │
+243b  ──┘             ├──►  242b  (v2.0.0 bump)
+                      │
+        243a  ──►  242a  ──┘
+```
+
+- **243a + 243b** are parallelisable (no dependency between them)
+- **243c** depends on both (CLI uses schema + tool inventory)
+- **242a** depends only on 243a (parallel mode runs against legacy configs)
+- **242b** depends on 243c (operators have migration path) AND 242a (parallel validated)
+
+## Slices
+
+### cortex#243a — Schema extension (additive, non-breaking)
+
+Add to `PolicyPrincipalSchema` in `src/common/types/cortex-config.ts`:
+
+- [ ] `platform_ids: z.record(z.string().regex(LETTER_PREFIX_ID_REGEX), z.array(z.string()))` (open record, not closed enum — pressure-test §15.5 finding)
+- [ ] `session_config: { default: SessionConfigShape, dm?: SessionConfigShape }` with `SessionConfigShape = { allowed_dirs, allowed_skills, bash_guard, bash_allowlist }`
+- [ ] Principal-id uniqueness scoped to `(id, home_stack)` — replaces existing `id`-only uniqueness in the `.refine()` validator (per §15.4 multi-stack collision resolution)
+- [ ] `(platform_name, platform_id)` tuple uniqueness across all principals
+- [ ] Convention note in JSDoc: federation-peer principals SHOULD NOT carry `platform_ids` (identity asserted via `signed_by` chain's stack NKey)
+- [ ] Unit tests for all of the above
+- [ ] Cross-link the schema JSDoc back to `docs/design-policy-cutover.md` §16
+
+**Scope:** ~150 LOC + tests. Single PR. Purely additive — no consumer changes, no migration involved.
+
+### cortex#243b — Canonical tool inventory (parallelisable with 243a)
+
+- [ ] New file `src/common/policy/tool-inventory.ts` exporting canonical list of Claude tool names (`Bash`, `Edit`, `Write`, `NotebookEdit`, `Read`, `Glob`, `Grep`, `Task`, `TodoWrite`, etc.)
+- [ ] Helper `invertDisallowedTools(disallowed: string[]): string[]` returning the complement set as `tool.<name>` capability ids
+- [ ] Unit tests pinning the canonical list against the current Claude SDK shape
+- [ ] No consumers yet — 243c will be the first
+
+**Scope:** ~50 LOC + tests. Single PR. Independent of 243a; can ship in parallel.
+
+### cortex#243c — migrate-config CLI extension
+
+In `src/cli/cortex/commands/migrate-config.ts` + `migrate-config-lib.ts`:
+
+- [ ] Read legacy `agents[].presence.<discord|mattermost|slack>.roles[]` from input `cortex.yaml`
+- [ ] Unify per-user across the three adapter copies (§11.3 — 3 agents × 10 roles → 12 distinct principals + 3 synthetic anonymous + 1 template)
+- [ ] Emit top-level `policy.principals[]` per §6 algorithm — synthesise principal IDs from platform user IDs (or read from optional `--labels labels.yaml`)
+- [ ] Emit top-level `policy.roles[]` with namespaced capabilities (`keyword.{chat,async,team}`, `tool.<name>` via 243b's `invertDisallowedTools`, `operator`, `dispatch.<agent_id>`)
+- [ ] Synthesise anonymous-per-instance principals for `defaultRole` semantic (§5.4)
+- [ ] Synthesise operator principal from `agent.operatorDiscordId/Mattermost/Slack` + DM `operatorRole` → `session_config.dm`
+- [ ] Emit external-peer principals with `home_operator: "unknown"` + warning per §12.3
+- [ ] Cross-adapter role-conflict handling — warn + conservative union (§13 Q4)
+- [ ] **New `--check` mode** for the 242a operator pre-flight: fail when legacy role-resolver's principal set is not a subset of the new `policy.principals[]` lookup space (§9.1)
+- [ ] Idempotent: running twice produces identical output
+- [ ] Operator-facing SOP at `docs/sop-migrate-config.md`
+- [ ] Sample inputs + expected outputs in `docs/migration-examples/`
+- [ ] Migration test against operator's actual `cortex.yaml` (snapshot test)
+
+**Scope:** ~400 LOC + tests + docs. Single PR but the biggest of the five.
+
+### cortex#242a — Adapter PolicyEngine wiring (parallel mode)
+
+In `src/adapters/discord/index.ts`, `src/adapters/mattermost/index.ts`, `src/adapters/slack/index.ts`:
+
+- [ ] Add PolicyEngine consultation alongside (not replacing) the legacy role-resolver
+- [ ] Lookup principal by `(platform, message.author.id) → principal` using the new `platform_ids` index
+- [ ] For each gating decision (keyword feature, tool, allowedDirs, allowedSkills, bashGuard), call `policyEngine.check(principalId, intent)`
+- [ ] **Resolution semantic:** most-restrictive intersection of legacy + new gates (§9.1 — security default, NOT new-system-wins)
+- [ ] Emit `system.access.disagreement` envelopes when legacy and new disagree (audit + dashboard visibility)
+- [ ] Add `system.access.disagreement` to `src/bus/system-events.ts` envelope builders
+- [ ] Add `cortex.yaml` flag `policy.parallel_mode_enabled` to gate the parallel-mode rollout per-deployment (default off until operator opts in)
+- [ ] Integration tests pinning intersection semantics for: both-allow, both-deny, legacy-allow-new-deny, legacy-deny-new-allow
+- [ ] Operator pre-flight doc note: `migrate-config --check` MUST pass before enabling parallel mode
+
+**Scope:** ~250 LOC + tests. Single PR. Adapter changes touch 3 files but mechanically similar.
+
+### cortex#242b — Legacy schema removal + v2.0.0 bump
+
+- [ ] Drop `DiscordInstanceSchema.roles[]` + `defaultRole`
+- [ ] Drop `MattermostInstanceSchema.roles[]` + `defaultRole`
+- [ ] Drop `SlackInstanceSchema.roles[]` + `defaultRole`
+- [ ] Drop entire `DMConfigSchema`
+- [ ] Drop `AgentSchema.operatorDiscordId/Mattermost/Slack` + `AgentSchema.roles[]`
+- [ ] Delete `src/adapters/discord/role-resolver.ts`
+- [ ] Remove parallel-mode plumbing added in 242a — PolicyEngine is the sole gate
+- [ ] Strict-mode parse error on legacy configs with pointer to `migrate-config`
+- [ ] Bump `arc-manifest.yaml` → `v2.0.0`
+- [ ] Update `docs/design-policy-cutover.md` status: "ratified" → "shipped"
+- [ ] Migration test: every existing test that previously seeded `presence.discord.roles[]` now seeds `policy.principals[] + policy.roles[]` (~30 tests touched)
+
+**Scope:** ~300 LOC removed + ~30 tests updated. Single PR. The breaking change.
+
+## Acceptance — when is this iteration done?
+
+- [ ] All 5 sub-issues merged
+- [ ] `arc-manifest.yaml` at v2.0.0
+- [ ] Operator's `~/.config/cortex/cortex.yaml` migrated via `migrate-config` and running cleanly
+- [ ] `~/.config/cortex/cortex.work.yaml` rewritten by `migrate-config` to namespaced capabilities (`keyword.chat` etc.)
+- [ ] PolicyEngine is the sole authorization decision point — no role-resolver code anywhere
+- [ ] Phase E gaps explicitly tracked in their own follow-up issues (per-principal federated caps; Q2 `capabilities:` block)
+
+## What this iteration deliberately does NOT do
+
+- **Per-principal capability checks on federated dispatches.** Today's federation gate (Phase D) is network-level (`accept_subjects[]` + peer roster). Per-principal capability checking on inbound federated traffic is Phase E follow-up. The v2.0.0 schema doesn't block any approach.
+- **Q2 stack capability advertisement** (`capabilities:` block for the cloud network registry). Distinct namespace from `PolicyRole.capabilities[]` (auth vs. advertisement). Lands as Phase E additive work.
+- **Cloud-side network registry service** for cross-operator discovery. Phase E.
+
+## Status tracking
+
+This iteration's checkboxes ARE the status. As each slice ships, tick its sub-issue's items here AND in the parent issue (cortex#242 or cortex#243). When all five are merged, this file's "Acceptance" section ticks fully and the iteration closes.

--- a/docs/plan-internet-of-agentic-work.md
+++ b/docs/plan-internet-of-agentic-work.md
@@ -281,32 +281,15 @@ Most of Phase C is paper until B.4 ships, but the paper can be drafted now:
 - [x] **C.1.4** Decision logic: principal's role grants → effective capabilities; sovereignty fields surfaced on `intent` for C.4 carry-through (sovereignty enforcement deferred to Phase D per design). — cortex#218
 - [x] **C.1.5** Audit emission: implemented in C.4 (cortex#221), not C.1 — engine is pure, audit envelopes emitted by the dispatch-listener with the engine's structured decision.
 
-### C.2 cortex.yaml schema flip — C.2a DONE (cortex#219); C.2b/C.2c DEFERRED (post-MIG-8 v2.0.0)
+### C.2 cortex.yaml schema flip — C.2a DONE (cortex#219); C.2b/C.2c ratified, execution NEXT
 
-- [x] **C.2.1 (additive — C.2a)** Top-level `policy: { principals[], roles[] }` added; schema cross-refines uniqueness + role/trust referential integrity. Legacy per-adapter `roles[]` retained for backward compatibility (removal in C.2b). — cortex#219
-- [ ] **C.2.1.b (breaking — C.2b)** Per-adapter `roles[]` removed from `DiscordPresenceSchema` + `MattermostPresenceSchema` + adapter role-resolver code; v2.0.0 bump. — deferred (out of Phase C scope; expands adapter surface; tracked separately).
-- [ ] **C.2.2** `policy.principals[]` schema:
-  ```yaml
-  policy:
-    principals:
-      - id: agent-luna
-        home_operator: andreas
-        home_stack: andreas/research
-        nkey_pub: SAA…
-        role: [chat, async]
-        trust: [agent-echo, agent-holly]
-      - id: agent-echo
-        home_operator: andreas
-        home_stack: andreas/code
-        ...
-    roles:
-      - id: chat
-        capabilities: [...]
-        sovereignty:
-          max_classification: federated
-  ```
-- [ ] **C.2.3** Discord/Mattermost adapters thin to ~30 LOC: translate inbound event → `Principal`; call `PolicyEngine.check`; act on result. No role-resolver logic in adapter. — deferred with C.2b.
-- [ ] **C.2.4 (C.2c)** `migrate-config` CLI extension: lift existing per-adapter roles into top-level `policy:` with warnings on inconsistencies between adapters. — deferred with C.2b.
+**Status as of 2026-05-16:** Design ratified in [PR #291](https://github.com/the-metafactory/cortex/pull/291). See [`docs/design-policy-cutover.md`](./design-policy-cutover.md) for the locked schema + 5-PR sequence and [`docs/iteration-policy-cutover.md`](./iteration-policy-cutover.md) for the operator-facing iteration checklist.
+
+- [x] **C.2.1 (additive — C.2a)** Top-level `policy: { principals[], roles[] }` added; schema cross-refines uniqueness + role/trust referential integrity. Legacy per-adapter `roles[]` retained for backward compatibility. — cortex#219
+- [ ] **C.2.1.b (breaking — C.2b)** Per-adapter `roles[]` removed from `DiscordPresenceSchema` + `MattermostPresenceSchema` + `SlackPresenceSchema`; adapter role-resolver retired; v2.0.0 bump. — cortex#242 umbrella (split into 242a parallel-mode + 242b breaking removal per design §9).
+- [ ] **C.2.2** `policy.principals[]` schema extended — adds `platform_ids` (open record), `session_config: {default, dm?}`, multi-stack `(id, home_stack)` uniqueness scoping. Capability namespace adopted: `keyword.{chat,async,team}`, `tool.<name>`, `dispatch.<agent>`, `operator`, `<domain>.<entity>`. — cortex#243a (schema extension)
+- [ ] **C.2.3** Discord/Mattermost/Slack adapters call `PolicyEngine.check()` directly; role-resolver retired. Wired in parallel mode first (most-restrictive intersection), then exclusive at v2.0.0. — cortex#242a → cortex#242b
+- [ ] **C.2.4 (C.2c)** `migrate-config` CLI extension: lift legacy per-adapter `roles[]` into top-level `policy:`. Idempotent, with `--check` mode for the 242a operator pre-flight. Canonical tool inventory via cortex#243b. SOP + migration examples. — cortex#243c
 
 ### C.3 Integration with substrate harness — DONE (cortex#220)
 
@@ -323,16 +306,16 @@ Most of Phase C is paper until B.4 ships, but the paper can be drafted now:
 ### C.5 Tests + migration
 
 - [x] **C.5.1** PolicyEngine unit tests cover allow/deny matrix (engine.test.ts + factory.test.ts in C.1/C.2a). — cortex#218, cortex#219
-- [ ] **C.5.2** Migration test: a representative grove-v2 `bot.yaml` flips to cortex-shaped `cortex.yaml` with the new `policy:` block; round-trip identity (same auth decisions). — DEFERRED (gated on C.2b — without removing legacy per-adapter `roles[]` the migration story isn't load-bearing yet).
+- [ ] **C.5.2** Migration-fidelity test: a representative `cortex.yaml` flips to `policy:`-only with `migrate-config`; round-trip identity (same auth decisions). — lands with cortex#243c.
 - [x] **C.5.3** Integration test: end-to-end inbound `dispatch.task.received` → dispatch-listener → PolicyEngine → harness → lifecycle envelopes + audit envelopes asserted. Implemented as 29 listener tests in `src/runner/__tests__/dispatch-listener.test.ts` exercising allow/deny paths, signed_by single + multi-stamp, sovereignty flow, audit payload shape, double-emit ordering on deny. (Note: Discord adapter still uses the legacy role-resolver path; full adapter→engine wiring lands with C.2b.) — cortex#220, cortex#221
 
 ### Phase C acceptance criteria
 
 - [x] `src/common/policy/` module exists with `PolicyEngine.check()`. — cortex#218
-- [ ] Discord/Mattermost adapters reduced to ~30 LOC each. — DEFERRED with C.2b.
+- [ ] Discord/Mattermost/Slack adapters call `PolicyEngine.check()` directly; role-resolver retired. — cortex#242a (parallel) → cortex#242b (exclusive)
 - [x] cortex.yaml schema has `policy: { principals[], roles[] }` at top level (additive). — cortex#219
-- [ ] Per-adapter `roles[]` removed. — DEFERRED with C.2b.
-- [ ] `migrate-config` CLI lifts existing per-surface roles into top-level `policy:`. — DEFERRED with C.2c.
+- [ ] Per-adapter `roles[]` removed. — cortex#242b
+- [ ] `migrate-config` CLI lifts existing per-surface roles into top-level `policy:`. — cortex#243c
 - [x] `system.access.{allowed,denied}` envelopes emitted by dispatch-listener (with engine decision). — cortex#221
 - cortex.yaml schema migration is one-way (post-flip, no rollback in v1). — C.2b breaking change pending.
 
@@ -340,7 +323,7 @@ Most of Phase C is paper until B.4 ships, but the paper can be drafted now:
 
 Phase C primary objective — *PolicyEngine as the single AAA decision point with audit envelopes* — is **DONE** (C.1 + C.2a + C.3 + C.4 + C.5.1 + C.5.3 all merged). What ships as Phase C of IAW closes cortex#115.
 
-What's **DEFERRED to v2.0.0 cleanup** (C.2b/C.2c/C.5.2): the breaking removal of per-adapter `roles[]` from `DiscordPresenceSchema` / `MattermostPresenceSchema`, the adapter role-resolver refactor (~30 LOC), the `migrate-config` CLI extension, and the migration-fidelity round-trip test. The legacy per-adapter path is parallel to (not in conflict with) the new top-level `policy:` block; both shapes coexist until v2.0.0 cuts.
+**v2.0.0 cleanup (C.2b/C.2c/C.5.2) — ratified, execution NEXT.** The breaking removal of per-adapter `roles[]`, adapter role-resolver retirement, `migrate-config` CLI extension, and migration-fidelity round-trip test have a ratified design in [PR #291](https://github.com/the-metafactory/cortex/pull/291) and a 5-PR iteration plan in [`docs/iteration-policy-cutover.md`](./iteration-policy-cutover.md). The 5 sub-issues (cortex#243a/b/c, cortex#242a/b) execute in the dependency order documented there.
 
 Pre-Phase-B caveat (Echo cortex#220 round 1): the dispatch-listener policy gate authorises on an unverified `signed_by[0].principal` claim until cortex#114 (Phase B verification) wires the verifier into the envelope-validator. The gate is `CORTEX_POLICY_REQUIRE_UNVERIFIED_ACK=1` opt-in until that closes.
 


### PR DESCRIPTION
## Summary

Operator-facing iteration plan for the v2.0.0 policy cutover, paired with an update to the IoAW master plan reflecting the ratified design from PR #291.

## New file: \`docs/iteration-policy-cutover.md\`

- **Dependency DAG** for the 5-PR sequence (243a + 243b parallel → 243c; 243a → 242a; 243c + 242a → 242b)
- **Per-slice checklist** with concrete acceptance criteria drawn from §16 of the design spec
- **Operator pre-flight requirement** for 242a parallel-mode activation (\`migrate-config --check\` must pass)
- **Phase E gaps** explicitly noted as out-of-scope follow-ups (per-principal federated capability checks; Q2 stack capability advertisement block)

## Updates: \`docs/plan-internet-of-agentic-work.md\` §C.2 + acceptance

- Status flipped from "DEFERRED (post-MIG-8 v2.0.0)" → "ratified, execution NEXT"
- Cross-links to the design spec (PR #291) and the new iteration plan
- Sub-issue references (cortex#243a/b/c, cortex#242a/b) populate previously-bare "deferred" placeholders

## Why this PR is doc-only

The execution starts tomorrow. This PR + the design spec (already merged) + the issue stock-take (parent issues #242/#243 updated with sub-issue checklists in a follow-up) form the complete planning surface. Code lands in cortex#243a onwards.

## Refs

- \`docs/design-policy-cutover.md\` (merged via PR #291)
- cortex#243 (CLI umbrella) + cortex#242 (breaking-removal umbrella) — both updated with sub-issue checklists separately

🤖 Generated with [Claude Code](https://claude.com/claude-code)