### PR TITLE
feat(policy): C.2b-243b — canonical Claude tool inventory (closes cortex#294)

### DIFF
--- a/src/common/policy/__tests__/tool-inventory.test.ts
+++ b/src/common/policy/__tests__/tool-inventory.test.ts
@@ -1,0 +1,180 @@
+/**
+ * v2.0.0 policy cutover — slice I-243B (cortex#294) tests.
+ *
+ * Pins the canonical Claude tool inventory + verifies the two
+ * helpers (`toolCapability` + `invertDisallowedTools`) the migrator
+ * (cortex#295) will call.
+ *
+ * The inventory pin is deliberate: adding a tool to
+ * {@link CLAUDE_TOOL_INVENTORY} also requires updating this test —
+ * otherwise the migrator inversion silently changes shape for
+ * every operator on the next migration run. See the JSDoc on the
+ * inventory constant for the rationale.
+ *
+ * Cross-references:
+ *   - `docs/design-policy-cutover.md` §5.2 — `tool.<lowercase>`
+ *     capability namespace convention.
+ *   - `docs/persona-format.md` §"Frontmatter (v1.0)" — the
+ *     authoritative source for the pinned list.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  CLAUDE_TOOL_INVENTORY,
+  invertDisallowedTools,
+  toolCapability,
+} from "../tool-inventory";
+
+describe("CLAUDE_TOOL_INVENTORY", () => {
+  test("includes the four tool names operators reference in cortex.yaml today", () => {
+    // These four appear in `~/.config/cortex/cortex.yaml` `disallowedTools`
+    // lists (multiple times across Discord/Mattermost role blocks). If
+    // any of these drops out of the inventory the migrator will fail to
+    // invert them and operators will silently lose enforcement on those
+    // tools post-cutover.
+    expect(CLAUDE_TOOL_INVENTORY).toContain("Bash");
+    expect(CLAUDE_TOOL_INVENTORY).toContain("Edit");
+    expect(CLAUDE_TOOL_INVENTORY).toContain("Write");
+    expect(CLAUDE_TOOL_INVENTORY).toContain("NotebookEdit");
+  });
+
+  test("does NOT contain legacy `Task` (renamed to `Agent` in the v1.0 canonical list)", () => {
+    // `Task` is the pre-rename name of the agent-spawn tool. At least
+    // one role in `~/.config/cortex/cortex.yaml` denies it (Echo's
+    // restricted role: `disallowedTools: [Edit, Write, NotebookEdit, Task]`).
+    // The v1.0 canonical list in `docs/persona-format.md` carries the
+    // post-rename name (`Agent`) instead. The migrator (cortex#295) is
+    // responsible for handling legacy `Task` references — either by
+    // also denying `Agent` on the migrated role, or by warning. Pinning
+    // the absence here prevents accidentally adding both names to the
+    // inventory in the future (which would let the inversion silently
+    // double-grant the agent-spawn capability).
+    const inventoryStrings: string[] = [...CLAUDE_TOOL_INVENTORY];
+    expect(inventoryStrings).not.toContain("Task");
+    expect(inventoryStrings).toContain("Agent");
+  });
+
+  test("pins the v1.0 canonical tool set (changes require deliberate sign-off)", () => {
+    // Lifted from `docs/persona-format.md` §"Frontmatter — optional
+    // fields (v1.0)" → the `allowedTools` row. If you're adding a tool,
+    // update BOTH the inventory AND this pin — the failure on a
+    // mismatch is the safety interlock.
+    expect([...CLAUDE_TOOL_INVENTORY]).toEqual([
+      "Read",
+      "Edit",
+      "Write",
+      "Grep",
+      "Bash",
+      "Glob",
+      "Agent",
+      "Skill",
+      "WebFetch",
+      "WebSearch",
+      "NotebookEdit",
+      "TodoWrite",
+      "BashOutput",
+      "KillShell",
+    ]);
+  });
+
+  test("contains no duplicates (Set size equals array length)", () => {
+    expect(new Set(CLAUDE_TOOL_INVENTORY).size).toBe(
+      CLAUDE_TOOL_INVENTORY.length,
+    );
+  });
+});
+
+describe("toolCapability", () => {
+  test("converts a CamelCase tool name to lowercase tool.<name>", () => {
+    expect(toolCapability("Bash")).toBe("tool.bash");
+  });
+
+  test("lower-cases multi-segment CamelCase as one run (no dotting)", () => {
+    // `NotebookEdit` → `tool.notebookedit`, NOT `tool.notebook.edit`.
+    // The namespace convention is `tool.<full-lowercased-name>`; the
+    // capability id segment count is always 2.
+    expect(toolCapability("NotebookEdit")).toBe("tool.notebookedit");
+    expect(toolCapability("TodoWrite")).toBe("tool.todowrite");
+    expect(toolCapability("WebFetch")).toBe("tool.webfetch");
+    expect(toolCapability("WebSearch")).toBe("tool.websearch");
+    expect(toolCapability("BashOutput")).toBe("tool.bashoutput");
+    expect(toolCapability("KillShell")).toBe("tool.killshell");
+  });
+
+  test("is idempotent under repeated application of lowercase input", () => {
+    // Operators have historically written `bash` and `Bash` both —
+    // calling toolCapability on the already-lowercased form must
+    // produce the same capability id.
+    expect(toolCapability("bash")).toBe(toolCapability("Bash"));
+  });
+
+  test("does not validate input (unknown names still produce a syntactic capability)", () => {
+    // The helper is a string transform, not an inventory gate. The
+    // migrator is responsible for warning on unknown names; we just
+    // transform whatever we're handed.
+    expect(toolCapability("MysteryTool")).toBe("tool.mysterytool");
+  });
+});
+
+describe("invertDisallowedTools", () => {
+  test("empty disallowed list returns the full inventory as tool.* capabilities", () => {
+    const result = invertDisallowedTools([]);
+    expect(result).toHaveLength(CLAUDE_TOOL_INVENTORY.length);
+    // Every inventory entry maps to its tool.<lowercased> capability.
+    expect(result).toEqual(
+      CLAUDE_TOOL_INVENTORY.map((t) => `tool.${t.toLowerCase()}`),
+    );
+  });
+
+  test("denying Bash + Edit drops exactly those two and preserves the rest", () => {
+    const result = invertDisallowedTools(["Bash", "Edit"]);
+    expect(result).toHaveLength(CLAUDE_TOOL_INVENTORY.length - 2);
+    expect(result).not.toContain("tool.bash");
+    expect(result).not.toContain("tool.edit");
+    // Spot-check the remaining set contains other tools.
+    expect(result).toContain("tool.read");
+    expect(result).toContain("tool.write");
+    expect(result).toContain("tool.notebookedit");
+  });
+
+  test("lowercase legacy input still denies the matching tool (case-insensitive)", () => {
+    // Operators have written `bash` in YAML (lowercase) more than
+    // once. Case-sensitive matching here would silently keep
+    // `tool.bash` in the grant set — a security regression at
+    // migration time.
+    const result = invertDisallowedTools(["bash"]);
+    expect(result).not.toContain("tool.bash");
+  });
+
+  test("mixed casing on input is normalised before matching", () => {
+    const result = invertDisallowedTools(["NoTeBoOkEdIt"]);
+    expect(result).not.toContain("tool.notebookedit");
+    expect(result).toHaveLength(CLAUDE_TOOL_INVENTORY.length - 1);
+  });
+
+  test("unknown legacy tool names are inert (full inventory is returned)", () => {
+    // Legacy configs may reference tools cortex v2 doesn't track —
+    // e.g. third-party substrate tools or typos. The inversion
+    // ignores them; the migrator is responsible for warning. Output
+    // length matches the empty-input case exactly.
+    const result = invertDisallowedTools(["NonExistent", "AlsoFake"]);
+    expect(result).toEqual(invertDisallowedTools([]));
+  });
+
+  test("output order matches CLAUDE_TOOL_INVENTORY declaration order (deterministic diff)", () => {
+    // The migrator writes the resulting capability list into the new
+    // policy block and operators eyeball the diff. Set-iteration
+    // order would scramble the list every run — the assertion locks
+    // in the declaration order.
+    const result = invertDisallowedTools(["Bash"]);
+    const expected = CLAUDE_TOOL_INVENTORY
+      .filter((t) => t !== "Bash")
+      .map((t) => `tool.${t.toLowerCase()}`);
+    expect(result).toEqual(expected);
+  });
+
+  test("denying every inventory tool produces an empty grant set", () => {
+    const all = [...CLAUDE_TOOL_INVENTORY];
+    expect(invertDisallowedTools(all)).toEqual([]);
+  });
+});

--- a/src/common/policy/tool-inventory.ts
+++ b/src/common/policy/tool-inventory.ts
@@ -1,0 +1,131 @@
+/**
+ * v2.0.0 policy cutover — slice I-243B (cortex#294).
+ *
+ * Canonical inventory of Claude Code tool names that cortex knows
+ * about at this version. Used by `migrate-config` (cortex#295, slice
+ * I-243C) to invert legacy presence-side
+ * `presence.<platform>.roles[].disallowedTools[]` lists into the
+ * positive `tool.<lowercase-name>` capability grants the new
+ * top-level `policy:` block carries on roles.
+ *
+ * Source of truth for the list: `docs/persona-format.md` §"Frontmatter
+ * — optional fields (v1.0)" → the `allowedTools` row, which is the
+ * documented canonical v1.0 tool set cortex recognises. That table is
+ * the cross-referenced authoritative list operators read; pinning
+ * here keeps the migrator inversion grounded in something a human
+ * can audit rather than something fabricated at coding time.
+ *
+ * Adding a new Claude tool means BOTH:
+ *   1. Append the canonical CamelCase name to {@link CLAUDE_TOOL_INVENTORY},
+ *      AND
+ *   2. Update the corresponding pin in `tool-inventory.test.ts`.
+ *
+ * Without (2), the test fails — which is intentional. The migrator
+ * is destructive (legacy `disallowedTools[]` becomes a positive
+ * grant set) and silently dropping a capability for a newly-added
+ * tool would mean every operator's role suddenly under-grants
+ * relative to legacy behaviour. The pin test forces a deliberate
+ * sign-off on inventory churn.
+ *
+ * Cross-references:
+ *   - `docs/design-policy-cutover.md` §5.2 — `tool.<lowercase>`
+ *     capability namespace convention this module emits.
+ *   - `docs/design-policy-cutover.md` §3 — `disallowedTools` →
+ *     capabilities migration semantics (deny-by-omission of the
+ *     `tool.<name>` capability).
+ *   - `docs/persona-format.md` §"Frontmatter (v1.0)" — the table
+ *     this inventory was lifted from.
+ *
+ * NOTE on completeness: the persona-format table is documented as
+ * a non-closed enum ("Free-form string list in v1") — operators
+ * MAY reference tool names outside this list (e.g. third-party
+ * substrate tools), and v1 cortex does not reject them. The
+ * migrator MUST treat any name in a legacy `disallowedTools[]`
+ * that is NOT in this inventory as an inert reference (no
+ * capability is granted or denied for it on the new role) and log
+ * a warning rather than failing the migration. The inversion in
+ * {@link invertDisallowedTools} below mirrors that semantic:
+ * unknown names in the input set drop out, the known inventory is
+ * what's projected onto `tool.<name>` capabilities.
+ */
+export const CLAUDE_TOOL_INVENTORY = [
+  "Read",
+  "Edit",
+  "Write",
+  "Grep",
+  "Bash",
+  "Glob",
+  "Agent",
+  "Skill",
+  "WebFetch",
+  "WebSearch",
+  "NotebookEdit",
+  "TodoWrite",
+  "BashOutput",
+  "KillShell",
+] as const;
+
+/**
+ * Compile-time union of canonical tool names. Callers that want to
+ * constrain a string to a known tool can type against this; the
+ * migrator itself takes `string[]` for the legacy input because
+ * legacy configs are not type-checked.
+ */
+export type ClaudeToolName = (typeof CLAUDE_TOOL_INVENTORY)[number];
+
+/**
+ * Convert a single Claude tool name to its policy capability id.
+ *
+ * Per `docs/design-policy-cutover.md` §5.2, the namespace is
+ * `tool.<lowercase-tool-name>` — the tool name is lower-cased
+ * exactly once at this boundary so callers building capability
+ * strings don't have to remember the casing rule.
+ *
+ * No validation: `toolName` outside {@link CLAUDE_TOOL_INVENTORY}
+ * still produces a syntactically valid capability id (the policy
+ * schema rejects malformed ids at parse time, not here). This
+ * makes the helper safe to call on legacy strings whose canonical
+ * casing operators got wrong.
+ */
+export function toolCapability(toolName: string): string {
+  return `tool.${toolName.toLowerCase()}`;
+}
+
+/**
+ * Invert a legacy `disallowedTools[]` list into the positive set of
+ * `tool.<lowercase>` capabilities a role should be granted.
+ *
+ * The semantics mirror legacy presence-side enforcement:
+ *   legacy: "role has access to every tool EXCEPT these"
+ *   v2:     "role has the capability `tool.X` for every tool not denied"
+ *
+ * Matching is case-insensitive on the input side — operators have
+ * historically written `Bash` and `bash` interchangeably in YAML,
+ * and silently keeping a tool because the casing didn't match the
+ * inventory would be a security regression at migration time.
+ *
+ * Unknown names in `disallowed` (not in {@link CLAUDE_TOOL_INVENTORY})
+ * are ignored — they couldn't have denied any inventory tool, so
+ * they have no effect on the inversion. This is intentionally
+ * permissive: the migrator runs once per operator config and
+ * should not refuse to migrate because of a legacy typo. Surfacing
+ * the warning is the migrator's job (cortex#295), not this helper.
+ *
+ * Example:
+ *   invertDisallowedTools(["Bash", "Edit"])
+ *   → ["tool.read", "tool.write", "tool.grep", "tool.glob",
+ *      "tool.agent", "tool.skill", "tool.webfetch",
+ *      "tool.websearch", "tool.notebookedit", "tool.todowrite",
+ *      "tool.bashoutput", "tool.killshell"]
+ *
+ * Order matches {@link CLAUDE_TOOL_INVENTORY} declaration order so
+ * the migrator's output diff is stable across runs (operators
+ * eyeballing the generated config see a deterministic list, not a
+ * Set-iteration-order shuffle).
+ */
+export function invertDisallowedTools(disallowed: string[]): string[] {
+  const denySet = new Set(disallowed.map((t) => t.toLowerCase()));
+  return CLAUDE_TOOL_INVENTORY.filter(
+    (t) => !denySet.has(t.toLowerCase()),
+  ).map(toolCapability);
+}


### PR DESCRIPTION
## Summary

Slice **I-243B** of the v2.0.0 policy cutover (cortex#294). Adds the canonical Claude tool inventory + two helpers the migrator (cortex#295) will use to invert legacy presence-side `disallowedTools[]` lists into positive `tool.<lowercase-name>` capability grants on the new top-level `policy:` block.

This is a self-contained additive PR — two new files, no consumers modified.

## Files added

- `src/common/policy/tool-inventory.ts` — `CLAUDE_TOOL_INVENTORY`, `toolCapability()`, `invertDisallowedTools()`
- `src/common/policy/__tests__/tool-inventory.test.ts` — 15 tests pinning the inventory and verifying both helpers

## Canonical tool list (and its source)

Lifted verbatim from **`docs/persona-format.md` §"Frontmatter — optional fields (v1.0)"** → the `allowedTools` row, which is the documented authoritative v1.0 tool set cortex recognises:

```
Read, Edit, Write, Grep, Bash, Glob, Agent, Skill,
WebFetch, WebSearch, NotebookEdit, TodoWrite,
BashOutput, KillShell
```

Cross-referenced against:

- `src/taps/cc-events/hooks/lib/event-taxonomy.ts` (`TOOL_EVENT_MAP`: Bash, Edit, Write, Read, Agent, TodoWrite)
- `src/bus/dispatch-handler.ts` `formatToolProgress` switch (Read, Glob, Grep, Bash, Write, Edit, WebSearch, WebFetch, Agent, Skill)
- `src/runner/event-utils.ts` + `src/common/event-utils.ts` (Grep, Glob, WebSearch, WebFetch)
- `~/.config/cortex/cortex.yaml` `disallowedTools` lists (Write, Edit, NotebookEdit, Task, Bash)

The persona-format table is the only place that calls a list "canonical v1.0" — all other references are partial. The inventory pin in the test ensures adding a new tool requires deliberate sign-off (otherwise the migrator silently drops the capability for that tool on the next migration run).

## Notable design decisions

- **`Task` is intentionally absent** from the inventory. It appears in at least one legacy `disallowedTools` entry (Echo's restricted role: `[Edit, Write, NotebookEdit, Task]`) but the v1.0 canonical list uses the post-rename name `Agent`. The migrator (cortex#295) is responsible for handling the rename — either by also denying `Agent` on the migrated role or by emitting a warning. Pinning the absence here prevents accidental double-grant (both names landing in inventory and inverting twice).
- **Case-insensitive matching on the legacy input side** — operators have written `bash` and `Bash` interchangeably in YAML. Case-sensitive matching at migration time would silently keep `tool.bash` in the grant set when the operator meant to deny it.
- **Unknown legacy names are inert** — `invertDisallowedTools(["NonExistent"])` returns the full inventory unchanged. The migrator (not this helper) is responsible for warning on unknown names; a single migrate-config run shouldn't refuse to migrate because of a legacy typo.
- **Output order matches declaration order** — deterministic diffs so operators eyeballing the generated config see a stable list across migration runs.

## Acceptance

- `bunx tsc --noEmit` — clean
- `bun run lint:errors` — clean (`$ eslint --quiet .` exits 0)
- `bun test src/common/policy/__tests__/tool-inventory.test.ts` — **15 pass / 0 fail / 31 expect() calls / 11ms**

## Test plan

- [x] Inventory contains Bash, Edit, Write, NotebookEdit (operator-config floor)
- [x] Inventory does NOT contain `Task` (renamed) but DOES contain `Agent`
- [x] Inventory pin (exact ordered list) matches the persona-format §v1.0 row
- [x] No duplicate tool names in the inventory
- [x] `toolCapability("Bash")` → `"tool.bash"`
- [x] `toolCapability("NotebookEdit")` → `"tool.notebookedit"` (single segment, not dotted)
- [x] `toolCapability` is idempotent under lowercase input
- [x] `toolCapability` doesn't validate (unknown names still transform syntactically)
- [x] `invertDisallowedTools([])` returns full inventory as `tool.*` capabilities
- [x] `invertDisallowedTools(["Bash", "Edit"])` drops exactly those two
- [x] `invertDisallowedTools(["bash"])` (lowercase) correctly excludes Bash
- [x] `invertDisallowedTools(["NoTeBoOkEdIt"])` (mixed case) correctly excludes NotebookEdit
- [x] `invertDisallowedTools(["NonExistent", "AlsoFake"])` returns full inventory (unknowns are inert)
- [x] Output order is deterministic (matches inventory declaration order)
- [x] Denying every inventory tool produces an empty grant set

Closes #294

🤖 Generated with [Claude Code](https://claude.com/claude-code)