### PR TITLE
fix(cortex): cortex#237 follow-up — boot-log accuracy + ConfigWatcher TODO

### DIFF
--- a/src/__tests__/cortex.capability-boot.test.ts
+++ b/src/__tests__/cortex.capability-boot.test.ts
@@ -180,6 +180,29 @@ function withCapturedStderr<T>(fn: () => Promise<T>): Promise<{ result: T; stder
     });
 }
 
+// cortex#288 follow-up — boot-log capture. The success/failure counter fix
+// reports via `console.log`. Mirror the stderr capture pattern so tests can
+// assert on the exact boot-log line. Restoring the original is critical:
+// without it, downstream tests would leak captured output and lose stdout.
+function withCapturedConsoleLog<T>(
+  fn: () => Promise<T>,
+): Promise<{ result: T; logs: string[] }> {
+  const original = console.log;
+  const logs: string[] = [];
+  console.log = (...args: unknown[]) => {
+    logs.push(args.map((a) => (typeof a === "string" ? a : String(a))).join(" "));
+  };
+  return fn()
+    .then((result) => {
+      console.log = original;
+      return { result, logs };
+    })
+    .catch((err: unknown) => {
+      console.log = original;
+      throw err;
+    });
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -251,15 +274,17 @@ describe("startCortex — capability-registry boot wiring (cortex#237 PR-7)", ()
       makeAgent("holly", ["research.web"]),
     ];
 
-    const { result: handle, stderr } = await withCapturedStderr(() =>
-      startCortex(minimalConfig(), {
-        disableConfigWatcher: true,
-        disableDashboard: true,
-        disableOutboundPoller: true,
-        agentsDir: tmpAgentsDir,
-        injectRuntime: runtime,
-        inlineAgents,
-      }),
+    const { result: { result: handle, logs }, stderr } = await withCapturedStderr(() =>
+      withCapturedConsoleLog(() =>
+        startCortex(minimalConfig(), {
+          disableConfigWatcher: true,
+          disableDashboard: true,
+          disableOutboundPoller: true,
+          agentsDir: tmpAgentsDir,
+          injectRuntime: runtime,
+          inlineAgents,
+        }),
+      ),
     );
 
     // The recording runtime only pushes envelopes onto `published` on
@@ -279,8 +304,59 @@ describe("startCortex — capability-registry boot wiring (cortex#237 PR-7)", ()
     expect(stderr).toContain("agent_id=echo");
     expect(stderr).toContain("simulated bus failure");
 
+    // cortex#288 follow-up — boot log must reflect wire-side reality, not
+    // the publisher's "calls invoked" count. With one publish throwing and
+    // one succeeding, the operator should see "1 ... (1 failure(s)) for 2".
+    // We grep the captured logs rather than asserting a single match: other
+    // boot-side `console.log` calls (router start, dispatch wiring) may
+    // also land in `logs`, but the capability line is unambiguously
+    // identified by its leading "cortex: published ... capability
+    // registration" substring.
+    const bootLog = logs.find((l) => l.startsWith("cortex: published") && l.includes("capability registration"));
+    expect(bootLog).toBeDefined();
+    expect(bootLog).toContain("1 capability registration(s)");
+    expect(bootLog).toContain("(1 failure(s))");
+    expect(bootLog).toContain("for 2 agent(s)");
+
     // Boot still produced a handle — the per-envelope failure must not
     // abort startup.
+    expect(handle).toBeDefined();
+    await handle.stop();
+    rmSync(tmpAgentsDir, { recursive: true, force: true });
+  });
+
+  test("cortex#288 follow-up — all publishes succeed → boot log shows success count, omits failure suffix", async () => {
+    // Counterpart to the per-envelope failure test: when nothing fails the
+    // failure suffix must be ABSENT from the boot log (architect's spec:
+    // "only show failure count if non-zero"). With no publishOutcomes
+    // entries, every publish resolves successfully.
+    const runtime = createRecordingRuntime();
+    const tmpAgentsDir = mkdtempSync(join(tmpdir(), "cortex-capboot-allok-"));
+    const inlineAgents: Agent[] = [
+      makeAgent("echo", ["code-review.typescript"]),
+      makeAgent("holly", ["research.web"]),
+    ];
+
+    const { result: handle, logs } = await withCapturedConsoleLog(() =>
+      startCortex(minimalConfig(), {
+        disableConfigWatcher: true,
+        disableDashboard: true,
+        disableOutboundPoller: true,
+        agentsDir: tmpAgentsDir,
+        injectRuntime: runtime,
+        inlineAgents,
+      }),
+    );
+
+    expect(runtime.published.length).toBe(2);
+
+    const bootLog = logs.find((l) => l.startsWith("cortex: published") && l.includes("capability registration"));
+    expect(bootLog).toBeDefined();
+    expect(bootLog).toContain("2 capability registration(s)");
+    expect(bootLog).toContain("for 2 agent(s)");
+    // The crux: no failure suffix in the all-success path.
+    expect(bootLog).not.toContain("failure");
+
     expect(handle).toBeDefined();
     await handle.stop();
     rmSync(tmpAgentsDir, { recursive: true, force: true });

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -551,15 +551,30 @@ export async function startCortex(
       capabilities: a.runtime.capabilities,
     }));
   if (capabilityEntries.length > 0) {
+    // cortex#288 follow-up — closure-scoped success/failure counters.
+    //
+    // `publishCapabilityRegistry`'s contract is "I called publish() for each
+    // envelope" — it pushes to its returned `published[]` *after* awaiting
+    // publish(), regardless of whether the boot site swallows the rejection.
+    // Our `wrappedPublish` below DOES swallow per-envelope failures (so one
+    // bad publish doesn't abort the loop), which means `published.length` is
+    // really "publishes that returned without throwing into the publisher",
+    // not "publishes that actually landed on the wire". The boot log should
+    // report wire-side reality. We count outcomes locally here; the publisher
+    // contract stays correct and unchanged.
+    let successfulPublishes = 0;
+    let failedPublishes = 0;
     const wrappedPublish = async (env: Parameters<typeof runtime.publish>[0]): Promise<void> => {
       try {
         await runtime.publish(env);
+        successfulPublishes++;
       } catch (err) {
         // Per CLAUDE.md "no empty catch blocks": log every error. We use
         // stderr (not the system-events pipeline) because the system-events
         // emitter shares the same runtime we just failed to publish on —
         // routing the error through it would be a credible re-failure loop.
         // Continue without rethrowing so sibling envelopes still emit.
+        failedPublishes++;
         process.stderr.write(
           `cortex: capability-registry publish failed for ${env.type} ` +
             `(agent_id=${(env.payload as { agent_id?: string }).agent_id ?? "?"}): ` +
@@ -568,13 +583,14 @@ export async function startCortex(
       }
     };
     try {
-      const published = await publishCapabilityRegistry({
+      await publishCapabilityRegistry({
         source: systemEventSource,
         entries: capabilityEntries,
         publish: wrappedPublish,
       });
+      const failureSuffix = failedPublishes > 0 ? ` (${failedPublishes} failure(s))` : "";
       console.log(
-        `cortex: published ${published.length} capability registration(s) ` +
+        `cortex: published ${successfulPublishes} capability registration(s)${failureSuffix} ` +
           `for ${capabilityEntries.length} agent(s)`,
       );
     } catch (err) {
@@ -1434,6 +1450,10 @@ export async function startCortex(
     && existsSync(expandedConfigPath)
   ) {
     configWatcher = new ConfigWatcher(expandedConfigPath, config, (event) => {
+      // cortex#237: capability-registry re-publish lands here once
+      // AgentsDirectoryWatcher is wired — see boot block ~line 540 for
+      // rationale (BotConfig hot-reload's SAFE_FIELDS doesn't include
+      // capabilities; mergedAgents isn't re-built).
       dispatchHandler.updateConfig(event.config, expandedConfigPath);
       for (const adapter of adapters) adapter.updateConfig?.(event.config);
       if (cloudPublisher) {


### PR DESCRIPTION
refs cortex#237 (cluster context; nits flagged in cortex#288 PR-7 review)

## What this fixes

Two non-blocking observability nits flagged by the Architect at the PR-7 review (see comments on https://github.com/the-metafactory/cortex/pull/288).

### 1. Boot-log overcount on swallowed failures

`src/cortex.ts` boot wiring logged `published.length capability registration(s) for K agent(s)`. But:

- `publishCapabilityRegistry` contract is "I called `publish()` for each envelope" — it pushes to `published[]` after `await publish()` regardless of outcome from the caller's perspective.
- The boot site's `wrappedPublish` swallows per-envelope failures (so one bad publish doesn't abort the loop and abort boot).
- Net effect: `published.length` overcounts on swallowed failures — it reports "publishes invoked", not "publishes that actually landed on the wire".

**Fix:** closure-scoped `successfulPublishes` / `failedPublishes` counters in `wrappedPublish`. Boot log now reads:

```
cortex: published N capability registration(s) (M failure(s)) for K agent(s)
```

Failure suffix is omitted when `M == 0` (all-success path is unchanged in shape).

`publishCapabilityRegistry` itself is **not touched** — its contract is correct and well-documented; the bug was the boot site's interpretation of `published.length`.

### 2. Missing inline TODO at ConfigWatcher callback

The capability-registry NOT-wired-to-config-reload deferral is documented in the publish block (~line 540): _"we do NOT wire a re-publish into the BotConfig hot-reload path because (a) capabilities live on Agent, not BotConfig, and (b) cortex.ts does not currently run an agents.d/ fragment watcher at the daemon level — when one is wired, the re-publish belongs in its callback, not the BotConfig one."_

A future engineer wiring `AgentsDirectoryWatcher` will land in the ConfigWatcher callback (~900 lines later) without seeing that rationale. Added a one-line breadcrumb at the callback that points back at the publish block.

## Tests

- **Extended** `src/__tests__/cortex.capability-boot.test.ts` "one publish throws → siblings still emit" — also asserts the boot log now reads `1 capability registration(s) (1 failure(s)) for 2 agent(s)` (was silently `2 capability registration(s) for 2 agent(s)` before the fix).
- **Added** "all publishes succeed → boot log shows success count, omits failure suffix" — guards the no-failure branch of the suffix.

Test count: **5 → 6** (1 new, 1 extended). Captures both branches of the new `failureSuffix` ternary.

## Acceptance

- `bunx tsc --noEmit` — clean
- `bun test src/__tests__/ src/bus/` — 499 pass, 0 fail
- `bun run lint` — 0 errors (21 pre-existing warnings, none from this change)

## Scope

Small additive fix per Architect's spec. No refactor of surrounding code. `capability-registry.ts` intentionally not touched.