### PR TITLE
feat(schema): C.2b-243a — PolicyPrincipal schema extension (closes cortex#293)

### DIFF
--- a/src/common/policy/__tests__/factory.test.ts
+++ b/src/common/policy/__tests__/factory.test.ts
@@ -308,6 +308,360 @@ describe("PolicySchema cross-validation", () => {
 });
 
 // ---------------------------------------------------------------------------
+// IAW Phase C.2b — cortex#243a schema extension
+// `PolicyPrincipal.platform_ids` (open record) + `session_config`
+// ({default, dm?}) + multi-stack id uniqueness + platform-tuple
+// uniqueness. See `docs/design-policy-cutover.md` §16 for the
+// locked-in schema delta.
+// ---------------------------------------------------------------------------
+
+describe("PolicyPrincipalSchema — cortex#243a schema extension", () => {
+  describe("platform_ids (open record, §15.5)", () => {
+    test("parses with multiple platform names (discord, slack, email, mcp, http)", () => {
+      const policy = PolicySchema.parse({
+        principals: [
+          {
+            id: "luna",
+            home_operator: "andreas",
+            home_stack: "andreas/research",
+            role: [],
+            trust: [],
+            platform_ids: {
+              discord: ["1487123456789012345"],
+              slack: ["U01ABCDEF"],
+              email: ["luna@meta-factory.ai"],
+              mcp: ["mcp://luna/inbox"],
+              http: ["bearer:abc123"],
+            },
+          },
+        ],
+        roles: [],
+      });
+      expect(policy.principals[0]?.platform_ids).toEqual({
+        discord: ["1487123456789012345"],
+        slack: ["U01ABCDEF"],
+        email: ["luna@meta-factory.ai"],
+        mcp: ["mcp://luna/inbox"],
+        http: ["bearer:abc123"],
+      });
+    });
+
+    test("defaults to empty object when omitted", () => {
+      const policy = PolicySchema.parse({
+        principals: [
+          {
+            id: "luna",
+            home_operator: "andreas",
+            home_stack: "andreas/research",
+            role: [],
+            trust: [],
+          },
+        ],
+        roles: [],
+      });
+      expect(policy.principals[0]?.platform_ids).toEqual({});
+    });
+
+    test("rejects platform name with uppercase (must match LETTER_PREFIX_ID_REGEX)", () => {
+      expect(() =>
+        PolicySchema.parse({
+          principals: [
+            {
+              id: "luna",
+              home_operator: "andreas",
+              home_stack: "andreas/research",
+              role: [],
+              trust: [],
+              platform_ids: { Discord: ["1487"] },
+            },
+          ],
+          roles: [],
+        }),
+      ).toThrow(/lowercase alphanumeric \+ hyphen/);
+    });
+
+    test("rejects platform name with digit prefix", () => {
+      expect(() =>
+        PolicySchema.parse({
+          principals: [
+            {
+              id: "luna",
+              home_operator: "andreas",
+              home_stack: "andreas/research",
+              role: [],
+              trust: [],
+              platform_ids: { "2chat": ["abc"] },
+            },
+          ],
+          roles: [],
+        }),
+      ).toThrow(/lowercase alphanumeric \+ hyphen/);
+    });
+  });
+
+  describe("session_config (§5.3 + §12.2)", () => {
+    test("session_config.default alone parses", () => {
+      const policy = PolicySchema.parse({
+        principals: [
+          {
+            id: "luna",
+            home_operator: "andreas",
+            home_stack: "andreas/research",
+            role: [],
+            trust: [],
+            session_config: {
+              default: {
+                allowed_dirs: ["~/Developer/cortex"],
+                allowed_skills: ["code-review"],
+                bash_guard: true,
+              },
+            },
+          },
+        ],
+        roles: [],
+      });
+      expect(policy.principals[0]?.session_config?.default.allowed_dirs).toEqual([
+        "~/Developer/cortex",
+      ]);
+      expect(policy.principals[0]?.session_config?.dm).toBeUndefined();
+    });
+
+    test("session_config.{default, dm} both parse with bash_allowlist", () => {
+      const policy = PolicySchema.parse({
+        principals: [
+          {
+            id: "operator-andreas",
+            home_operator: "andreas",
+            home_stack: "andreas/research",
+            role: [],
+            trust: [],
+            session_config: {
+              default: {
+                bash_guard: true,
+                bash_allowlist: {
+                  rules: [{ pattern: "^git status", repos: ["cortex"] }],
+                  repos: ["cortex"],
+                },
+              },
+              dm: {
+                bash_guard: false,
+                allowed_dirs: ["~/Developer", "~/Documents/andreas_brain"],
+                bash_allowlist: {
+                  rules: [
+                    { pattern: "^git " },
+                    { pattern: "^gh " },
+                    { pattern: "^bun " },
+                  ],
+                  repos: [
+                    "cortex",
+                    "pilot",
+                    "signal-collector",
+                    "myelin",
+                  ],
+                },
+              },
+            },
+          },
+        ],
+        roles: [],
+      });
+      const sc = policy.principals[0]?.session_config;
+      expect(sc?.default.bash_guard).toBe(true);
+      expect(sc?.dm?.bash_guard).toBe(false);
+      expect(sc?.dm?.bash_allowlist?.rules).toHaveLength(3);
+      expect(sc?.dm?.bash_allowlist?.repos).toContain("pilot");
+    });
+
+    test("session_config.default.bash_guard defaults to true when omitted", () => {
+      const policy = PolicySchema.parse({
+        principals: [
+          {
+            id: "luna",
+            home_operator: "andreas",
+            home_stack: "andreas/research",
+            role: [],
+            trust: [],
+            session_config: { default: {} },
+          },
+        ],
+        roles: [],
+      });
+      expect(policy.principals[0]?.session_config?.default.bash_guard).toBe(true);
+    });
+
+    test("session_config is optional — omission parses cleanly", () => {
+      const policy = PolicySchema.parse({
+        principals: [
+          {
+            id: "luna",
+            home_operator: "andreas",
+            home_stack: "andreas/research",
+            role: [],
+            trust: [],
+          },
+        ],
+        roles: [],
+      });
+      expect(policy.principals[0]?.session_config).toBeUndefined();
+    });
+  });
+
+  describe("multi-stack principal-id uniqueness (§15.4)", () => {
+    test("accepts same id on different home_stacks (federated multi-stack peer)", () => {
+      const policy = PolicySchema.parse({
+        principals: [
+          {
+            id: "luna",
+            home_operator: "andreas",
+            home_stack: "andreas/meta-factory",
+            role: [],
+            trust: [],
+          },
+          {
+            id: "luna",
+            home_operator: "andreas",
+            home_stack: "andreas/work",
+            role: [],
+            trust: [],
+          },
+        ],
+        roles: [],
+      });
+      expect(policy.principals).toHaveLength(2);
+      expect(policy.principals.map((p) => p.home_stack)).toEqual([
+        "andreas/meta-factory",
+        "andreas/work",
+      ]);
+    });
+
+    test("rejects same id on same home_stack (intra-stack collision)", () => {
+      expect(() =>
+        PolicySchema.parse({
+          principals: [
+            {
+              id: "luna",
+              home_operator: "andreas",
+              home_stack: "andreas/research",
+              role: [],
+              trust: [],
+            },
+            {
+              id: "luna",
+              home_operator: "andreas",
+              home_stack: "andreas/research",
+              role: [],
+              trust: [],
+            },
+          ],
+          roles: [],
+        }),
+      ).toThrow(/principal id.*luna.*already declared for home_stack.*andreas\/research/);
+    });
+  });
+
+  describe("(platform_name, platform_id) tuple uniqueness (§16)", () => {
+    test("rejects same (platform, id) tuple on two principals", () => {
+      expect(() =>
+        PolicySchema.parse({
+          principals: [
+            {
+              id: "luna",
+              home_operator: "andreas",
+              home_stack: "andreas/research",
+              role: [],
+              trust: [],
+              platform_ids: { discord: ["1487123456789012345"] },
+            },
+            {
+              id: "echo",
+              home_operator: "andreas",
+              home_stack: "andreas/research",
+              role: [],
+              trust: [],
+              platform_ids: { discord: ["1487123456789012345"] },
+            },
+          ],
+          roles: [],
+        }),
+      ).toThrow(/platform_ids\.discord entry.*1487123456789012345.*already claimed by principal.*luna/);
+    });
+
+    test("accepts same id under different platforms (no cross-platform collision)", () => {
+      const policy = PolicySchema.parse({
+        principals: [
+          {
+            id: "luna",
+            home_operator: "andreas",
+            home_stack: "andreas/research",
+            role: [],
+            trust: [],
+            platform_ids: { discord: ["1487"] },
+          },
+          {
+            id: "echo",
+            home_operator: "andreas",
+            home_stack: "andreas/research",
+            role: [],
+            trust: [],
+            platform_ids: { slack: ["1487"] },
+          },
+        ],
+        roles: [],
+      });
+      expect(policy.principals).toHaveLength(2);
+    });
+
+    test("accepts disjoint platform_ids across principals on the same platform", () => {
+      const policy = PolicySchema.parse({
+        principals: [
+          {
+            id: "luna",
+            home_operator: "andreas",
+            home_stack: "andreas/research",
+            role: [],
+            trust: [],
+            platform_ids: { discord: ["1487123"] },
+          },
+          {
+            id: "echo",
+            home_operator: "andreas",
+            home_stack: "andreas/research",
+            role: [],
+            trust: [],
+            platform_ids: { discord: ["1487999"] },
+          },
+        ],
+        roles: [],
+      });
+      expect(policy.principals[0]?.platform_ids.discord).toEqual(["1487123"]);
+      expect(policy.principals[1]?.platform_ids.discord).toEqual(["1487999"]);
+    });
+  });
+
+  describe("backward compatibility", () => {
+    test("pre-cutover policy block (no platform_ids, no session_config) parses cleanly", () => {
+      const policy = PolicySchema.parse({
+        principals: [
+          {
+            id: "luna",
+            home_operator: "andreas",
+            home_stack: "andreas/research",
+            role: ["operator"],
+            trust: [],
+          },
+        ],
+        roles: [{ id: "operator", capabilities: ["code-review.typescript"] }],
+      });
+      expect(policy.principals[0]?.platform_ids).toEqual({});
+      expect(policy.principals[0]?.session_config).toBeUndefined();
+      // Existing fields preserved.
+      expect(policy.principals[0]?.role).toEqual(["operator"]);
+      expect(policy.principals[0]?.id).toBe("luna");
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
 // IAW Phase D.1 (cortex#116) — federated network schema
 // ---------------------------------------------------------------------------
 

--- a/src/common/types/cortex-config.ts
+++ b/src/common/types/cortex-config.ts
@@ -1548,7 +1548,7 @@ export const PolicySchema = z.object({
   // homonyms.
   const seenPrincipal = new Map<string, number>();
   policy.principals.forEach((p, i) => {
-    const key = `${p.id} ${p.home_stack}`;
+    const key = `${p.id}\u0001${p.home_stack}`;
     const dupAt = seenPrincipal.get(key);
     if (dupAt !== undefined) {
       ctx.addIssue({
@@ -1575,12 +1575,12 @@ export const PolicySchema = z.object({
   policy.principals.forEach((p, principalIdx) => {
     for (const [platformName, ids] of Object.entries(p.platform_ids)) {
       ids.forEach((platformId, idIdx) => {
-        const key = `${platformName} ${platformId}`;
+        const key = `${platformName}\u0001${platformId}`;
         const prior = seenPlatformTuple.get(key);
         if (prior !== undefined) {
           ctx.addIssue({
             code: "custom",
-            message: `platform_ids.${platformName} entry "${platformId}" already claimed by principal "${prior.principalId}" at principals[${prior.principalIdx}] — a platform-side identity may belong to only one principal`,
+            message: `platform_ids.${platformName} entry "${platformId}" already claimed by principal "${prior.principalId}" at principals[${prior.principalIdx}] — a platform-side identity may belong to only one principal. Note: federation-peer principals should not carry platform_ids; their identity is asserted via the signed_by chain's stack NKey (see PolicyPrincipalSchema JSDoc + docs/design-policy-cutover.md §16)`,
             path: ["principals", principalIdx, "platform_ids", platformName, idIdx],
           });
         } else {

--- a/src/common/types/cortex-config.ts
+++ b/src/common/types/cortex-config.ts
@@ -1035,6 +1035,64 @@ export type PathsConfig = z.infer<typeof PathsConfigSchema>;
 // =============================================================================
 
 /**
+ * Session-construction parameters attached to a principal.
+ *
+ * IAW Phase C.2b — schema extension (cortex#243a). Carries the
+ * legacy `allowedDirs`, `allowedSkills`, `bashGuard`, and
+ * `bashAllowlist` knobs that grove-v2 hung off `presence.discord.dm`
+ * + `presence.discord.roles[].users[]`. The cutover moves these
+ * onto the principal so the dispatch path — not the adapter — picks
+ * them up when a CC session is constructed.
+ *
+ * Used by `PolicyPrincipalSchema.session_config.{default,dm}`
+ * (see `docs/design-policy-cutover.md` §5.3 + §12.2). Splitting
+ * `default` vs `dm` lets a principal carry a broader bash
+ * allowlist in 1:1 DMs than they get in channels — the divergence
+ * Andreas's live config exercises today.
+ */
+const SessionConfigShape = z.object({
+  /**
+   * Absolute or `~/`-prefixed directory paths the principal may
+   * touch in a CC session. The dispatch path expands `~/` and
+   * passes the result to `claude --add-dir`. Unset → no
+   * per-principal restriction; the global default applies.
+   */
+  allowed_dirs: z.array(z.string()).optional(),
+  /**
+   * Skill ids the principal is allowed to load into a CC session.
+   * Matches the runner's skill-resolution pass. Unset → no
+   * per-principal restriction.
+   */
+  allowed_skills: z.array(z.string()).optional(),
+  /**
+   * Whether the cortex bash-guard hook is active for this
+   * principal's sessions. Defaults to `true` — guard ON unless
+   * an operator explicitly opts out (e.g. for their own `operator`
+   * principal in a DM). Preserves the legacy `bashGuard` default.
+   */
+  bash_guard: z.boolean().default(true),
+  /**
+   * Optional bash command allowlist. Each rule pairs a regex
+   * `pattern` with an optional `repos[]` scope; if `repos` is
+   * present the rule only matches when the session is anchored
+   * to one of those repos. Top-level `repos[]` carries the
+   * always-allowed repo set (e.g. operator's own work tree).
+   *
+   * Shape mirrors grove-v2's `presence.discord.dm.operatorRole.
+   * bashAllowlist` so the cortex#243 migration CLI can copy
+   * values across without re-shaping. The runner-side guard
+   * consumes this directly post-C.2b (cortex#244).
+   */
+  bash_allowlist: z.object({
+    rules: z.array(z.object({
+      pattern: z.string(),
+      repos: z.array(z.string()).optional(),
+    })).default([]),
+    repos: z.array(z.string()).default([]),
+  }).optional(),
+});
+
+/**
  * A principal — identity-bearing actor the PolicyEngine authorises.
  * Top-level on `cortex.yaml.policy.principals[]` post-C.2a; the
  * PolicyEngine consumes the parsed shape via the
@@ -1043,6 +1101,35 @@ export type PathsConfig = z.infer<typeof PathsConfigSchema>;
  * Mirrors the `Principal` type from `src/common/policy/types.ts`
  * (C.1); kept as a Zod schema here so config parse validation is
  * authoritative.
+ *
+ * IAW Phase C.2b — schema extension (cortex#243a). Two additive
+ * fields land here:
+ *
+ *   - `platform_ids` — open record of `<platform_name>: string[]`,
+ *     letting any current or future adapter (Discord, Mattermost,
+ *     Slack, MCP, HTTP, email, voice, cron, webhook, …) attach a
+ *     list of platform-native user ids to a principal. The
+ *     pressure-test §15.5 finding flips this to an open `z.record`
+ *     so adding a new adapter never requires a schema bump.
+ *   - `session_config` — split `{ default, dm? }` carrying CC
+ *     session construction parameters (§5.3 + §12.2). `default`
+ *     is the channel/group context baseline; optional `dm` overrides
+ *     when the message arrived via a 1:1 DM. The dispatch path picks
+ *     the right one so adapters stop deciding this.
+ *
+ * **Convention — federation peers do NOT carry `platform_ids`.**
+ * A principal that represents a remote operator's stack (a
+ * federation peer) is authenticated by the `signed_by[]` chain's
+ * stack NKey, not by any platform-side identity. Setting
+ * `platform_ids` on such a principal is meaningless at best and
+ * misleading at worst; the schema does not refuse it (operators
+ * may carry both during transition) but the migration CLI
+ * (cortex#243) emits peer principals with empty `platform_ids`
+ * and the dispatch path never consults the field for federated
+ * traffic.
+ *
+ * See `docs/design-policy-cutover.md` §16 for the locked-in schema
+ * delta this implements.
  */
 export const PolicyPrincipalSchema = z.object({
   /**
@@ -1114,6 +1201,47 @@ export const PolicyPrincipalSchema = z.object({
       "principal.trust[] entries must be principal ids — same grammar as principal.id",
     ),
   ).default([]),
+  /**
+   * Platform-native user ids this principal answers for, keyed by
+   * platform name. **Open record by deliberate design (§15.5)** —
+   * any letter-prefix lowercase platform name is accepted, so
+   * adding a new adapter (Discord, Mattermost, Slack, MCP, HTTP,
+   * email, voice, cron, webhook, …) does not require a schema
+   * change. Values are platform-native string ids (e.g. Discord
+   * snowflakes), opaque to cortex; the adapter that owns the
+   * platform decides what they mean.
+   *
+   * Uniqueness across the policy block is enforced by
+   * `PolicySchema.superRefine` below: no `(platform_name, platform_id)`
+   * tuple may appear in two principals.
+   *
+   * **Convention — federation peer principals SHOULD NOT carry
+   * `platform_ids`.** Their identity is asserted via the
+   * `signed_by[]` chain's stack NKey, not via platform ids. The
+   * schema does not enforce this (operators may carry transition
+   * state); the migration CLI and dispatch path simply do not
+   * populate or consult it for peers.
+   */
+  platform_ids: z.record(
+    z.string().regex(
+      LETTER_PREFIX_ID_REGEX,
+      "platform name must be lowercase alphanumeric + hyphen, starting with a letter (e.g. 'discord', 'mattermost', 'mcp', 'email')",
+    ),
+    z.array(z.string()).default([]),
+  ).default({}),
+  /**
+   * CC session construction parameters, split between the
+   * channel/group context (`default`) and an optional 1:1 DM
+   * override (`dm`). The dispatch-listener picks the right block
+   * when constructing a session for a verified principal; adapters
+   * no longer decide this. See `docs/design-policy-cutover.md`
+   * §5.3 + §12.2 for the channel-vs-DM divergence Andreas's
+   * config exercises.
+   */
+  session_config: z.object({
+    default: SessionConfigShape,
+    dm: SessionConfigShape.optional(),
+  }).optional(),
 });
 
 export type PolicyPrincipal = z.infer<typeof PolicyPrincipalSchema>;
@@ -1409,18 +1537,56 @@ export const PolicySchema = z.object({
   // Capability-catalog precedent: `superRefine` with batch
   // `ctx.addIssue` per offender at the same nesting depth.
 
-  // Uniqueness — principals[].id.
+  // Uniqueness — principals[] keyed on `(id, home_stack)` (§15.4,
+  // cortex#243a). Federated peers in multi-stack deployments may
+  // legitimately register two principals with the same id but
+  // different home_stacks — e.g. sage records both
+  // `luna@andreas/meta-factory` and `luna@andreas/work`. The pre-
+  // cutover key was `id` alone, which rejected that pattern. The
+  // tuple key preserves the original intent (no two principals
+  // collide within a stack) while permitting cross-stack
+  // homonyms.
   const seenPrincipal = new Map<string, number>();
   policy.principals.forEach((p, i) => {
-    const dupAt = seenPrincipal.get(p.id);
+    const key = `${p.id} ${p.home_stack}`;
+    const dupAt = seenPrincipal.get(key);
     if (dupAt !== undefined) {
       ctx.addIssue({
         code: "custom",
-        message: `principal id "${p.id}" already declared at principals[${dupAt}]`,
+        message: `principal id "${p.id}" already declared for home_stack "${p.home_stack}" at principals[${dupAt}] — multi-stack peers may share an id only if their home_stack differs`,
         path: ["principals", i, "id"],
       });
     } else {
-      seenPrincipal.set(p.id, i);
+      seenPrincipal.set(key, i);
+    }
+  });
+
+  // Uniqueness — `(platform_name, platform_id)` tuple across all
+  // principals (§16, cortex#243a). No platform-side identity may
+  // be claimed by two principals; that would let the dispatch path
+  // resolve an inbound platform message to either of them
+  // non-deterministically. Caught at parse time with a per-offender
+  // path so operators see the second declaration as the offender.
+  // Federation peer principals SHOULD NOT carry platform_ids (see
+  // PolicyPrincipalSchema JSDoc); when they do, this rule still
+  // applies — the convention is operator-side, the uniqueness
+  // rule is schema-side.
+  const seenPlatformTuple = new Map<string, { principalIdx: number; principalId: string }>();
+  policy.principals.forEach((p, principalIdx) => {
+    for (const [platformName, ids] of Object.entries(p.platform_ids)) {
+      ids.forEach((platformId, idIdx) => {
+        const key = `${platformName} ${platformId}`;
+        const prior = seenPlatformTuple.get(key);
+        if (prior !== undefined) {
+          ctx.addIssue({
+            code: "custom",
+            message: `platform_ids.${platformName} entry "${platformId}" already claimed by principal "${prior.principalId}" at principals[${prior.principalIdx}] — a platform-side identity may belong to only one principal`,
+            path: ["principals", principalIdx, "platform_ids", platformName, idIdx],
+          });
+        } else {
+          seenPlatformTuple.set(key, { principalIdx, principalId: p.id });
+        }
+      });
     }
   });
 


### PR DESCRIPTION
## Summary

IAW Phase C.2b — first slice of the v2.0.0 policy cutover (cortex#243a).
Additive, schema-only. No consumer code touched.

## Schema additions to `PolicyPrincipalSchema`

- **`platform_ids`** — open `z.record(platform_name, string[])` per
  §15.5. Open record (not closed enum) so adding a new adapter
  (MCP, HTTP, email, voice, cron, webhook, …) never requires a
  schema bump.
- **`session_config`** — split `{ default, dm? }` per §5.3 + §12.2.
  Carries the legacy `allowedDirs` / `allowedSkills` / `bashGuard` /
  `bashAllowlist` knobs onto the principal so the dispatch path
  picks them up when constructing CC sessions. Operator's Luna will
  carry the broader DM `bashAllowlist` via `session_config.dm`.

## Cross-validation changes in `PolicySchema.superRefine`

- Principal-id uniqueness rescoped to `(id, home_stack)` per §15.4 —
  federated peers in multi-stack deployments may legitimately share
  an id across stacks (`luna@andreas/meta-factory` vs.
  `luna@andreas/work`).
- New `(platform_name, platform_id)` tuple uniqueness — no
  platform-native id may be claimed by two principals.

## Convention

JSDoc on `PolicyPrincipalSchema` notes federation-peer principals
SHOULD NOT carry `platform_ids` (authenticated via the `signed_by[]`
chain's stack NKey instead). Schema permits both during transition;
the migration CLI and dispatch path simply don't populate or consult
the field for peers.

## Tests (14 new in `src/common/policy/__tests__/factory.test.ts`)

- `platform_ids` parses multi-platform values; rejects bad grammar
  (uppercase, digit prefix).
- `session_config.default` alone parses; `{default, dm}` both parse
  with `bash_allowlist`; `bash_guard` defaults to `true`; absent
  `session_config` parses cleanly.
- Multi-stack id uniqueness: positive accepted, intra-stack collision
  rejected.
- Tuple uniqueness: collision rejected; same id under different
  platforms accepted; disjoint ids on same platform accepted.
- Backward-compat: pre-cutover policy block (no `platform_ids`, no
  `session_config`) parses with sensible defaults.

## Verification

- `bunx tsc --noEmit` → exit 0
- `bun run lint:errors` → exit 0
- `bun test` → 3248 pass / 0 fail / 1 skip across 170 files

## Test plan

- [x] Schema additions parse on representative cortex.yaml shapes
- [x] All existing tests still green (no consumer-side regressions)
- [x] New cross-validation rules emit per-offender path on collision
- [x] `tsc --noEmit` clean, lint clean

## Cross-refs

- Design: `docs/design-policy-cutover.md` §16 (locked schema delta), §5.1, §5.3, §12.2, §15.4, §15.5
- Closes #293

🤖 Generated with [Claude Code](https://claude.com/claude-code)