### PR TITLE
feat(adapters): C.2b-242a — adapter PolicyEngine wiring in parallel mode (closes cortex#296)

### DIFF
--- a/src/adapters/discord/__tests__/parallel-mode.test.ts
+++ b/src/adapters/discord/__tests__/parallel-mode.test.ts
@@ -1,0 +1,426 @@
+/**
+ * IAW Phase C.2b-242a (cortex#296) — DiscordAdapter parallel-mode tests.
+ *
+ * Pins the intersection-wins semantic from `docs/design-policy-cutover.md`
+ * §9.1: effective decision = legacy AND new. Verifies the
+ * `system.access.disagreement` envelope shape + graceful degradation
+ * when the parallel-mode wiring is incomplete.
+ *
+ * Tests exercise `DiscordAdapter.resolveAccess` directly — no Discord
+ * connection involved. The DM-context branch is exercised separately
+ * from the channel-context branch because each flows through a
+ * different legacy code path.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type { Envelope } from "../../../bus/myelin/envelope-validator";
+import type { MyelinRuntime } from "../../../bus/myelin/runtime";
+import { DMConfigSchema } from "../../../common/types/config";
+import type { Agent, DiscordPresence, PolicyPrincipal } from "../../../common/types/cortex-config";
+import { PolicyEngine, PlatformPrincipalIndex, type Principal, type RoleDefinition } from "../../../common/policy";
+import type { InboundMessage } from "../../types";
+import { DiscordAdapter, type DiscordAdapterInfra } from "../index";
+
+function makePresence(overrides: Partial<DiscordPresence> = {}): DiscordPresence {
+  return {
+    enabled: true,
+    token: "fake-token",
+    guildId: "g1",
+    agentChannelId: "ch1",
+    logChannelId: "ch2",
+    contextDepth: 5,
+    enableAgentLog: false,
+    // Legacy gate: grants `chat` to user `U123` via role `user`.
+    roles: [
+      {
+        name: "user",
+        users: ["U123"],
+        features: ["chat"],
+        disallowedTools: [],
+      },
+    ],
+    defaultRole: "denied",
+    dm: DMConfigSchema.parse({}),
+    trustedBotIds: [],
+    surfaceSubjects: [],
+    ...overrides,
+  };
+}
+
+function makeAgent(presence: DiscordPresence): Agent {
+  return {
+    id: "luna",
+    displayName: "Luna",
+    persona: "(test)",
+    roles: [],
+    trust: [],
+    presence: { discord: presence },
+  };
+}
+
+interface RecordingRuntime extends MyelinRuntime {
+  publishes: Envelope[];
+}
+
+function makeRecordingRuntime(): RecordingRuntime {
+  const publishes: Envelope[] = [];
+  return {
+    enabled: true,
+    onEnvelope: () => ({ unregister: () => {} }),
+    publish: async (envelope: Envelope) => {
+      publishes.push(envelope);
+    },
+    stop: async () => {},
+    publishes,
+  };
+}
+
+interface PolicyFixture {
+  engine: PolicyEngine;
+  index: PlatformPrincipalIndex;
+}
+
+/**
+ * Build a PolicyEngine + PlatformPrincipalIndex pair from a slim
+ * principal/role description. The full `PolicyPrincipal` shape from
+ * cortex-config.ts has extra fields (nkey_pub, session_config,
+ * platform_ids) the engine doesn't read; the index reads only
+ * platform_ids, so we feed each side what it needs.
+ */
+function makePolicy(opts: {
+  principals: (Principal & { platform_ids: Record<string, string[]> })[];
+  roles: RoleDefinition[];
+}): PolicyFixture {
+  const engine = new PolicyEngine({
+    principals: opts.principals.map((p) => ({
+      id: p.id,
+      home_operator: p.home_operator,
+      home_stack: p.home_stack,
+      role: p.role,
+      trust: p.trust,
+    })),
+    roles: opts.roles,
+  });
+  // PlatformPrincipalIndex reads from `PolicyPrincipal`-shape; pass
+  // the full record (it ignores the engine-only fields).
+  const index = new PlatformPrincipalIndex(
+    opts.principals.map(
+      (p): PolicyPrincipal => ({
+        id: p.id,
+        home_operator: p.home_operator,
+        home_stack: p.home_stack,
+        role: [...p.role],
+        trust: [...p.trust],
+        platform_ids: p.platform_ids,
+      }),
+    ),
+  );
+  return { engine, index };
+}
+
+function buildInboundMessage(authorId: string, overrides: Partial<InboundMessage> = {}): InboundMessage {
+  return {
+    platform: "discord",
+    instanceId: "discord-luna",
+    authorId,
+    authorName: "test",
+    content: "hi",
+    channelId: "ch1",
+    attachments: [],
+    timestamp: new Date("2026-05-17T00:00:00.000Z"),
+    ...overrides,
+  };
+}
+
+function makeAdapter(opts: {
+  presence?: DiscordPresence;
+  parallelModeEnabled?: boolean;
+  policy?: PolicyFixture;
+  runtime?: MyelinRuntime;
+  systemEventSource?: { org: string; agent: string; instance: string };
+}): DiscordAdapter {
+  const presence = opts.presence ?? makePresence();
+  const agent = makeAgent(presence);
+  const infra: DiscordAdapterInfra = {
+    instanceId: "discord-luna",
+    operator: { discordId: "U_OPERATOR" },
+    ...(opts.runtime !== undefined && { runtime: opts.runtime }),
+    ...(opts.systemEventSource !== undefined && { systemEventSource: opts.systemEventSource }),
+    ...(opts.parallelModeEnabled !== undefined && { parallelModeEnabled: opts.parallelModeEnabled }),
+    ...(opts.policy !== undefined && {
+      policyEngine: opts.policy.engine,
+      policyLookup: opts.policy.index,
+    }),
+  };
+  return new DiscordAdapter(agent, presence, infra);
+}
+
+let originalError: typeof console.error;
+beforeEach(() => {
+  originalError = console.error;
+  console.error = () => {};
+});
+afterEach(() => {
+  console.error = originalError;
+});
+
+describe("DiscordAdapter parallel-mode (§9.1 intersection-wins)", () => {
+  test("parallel_mode_enabled=false: only legacy runs, no PolicyEngine call", () => {
+    // Build a policy fixture that would DENY user U123 if consulted —
+    // proves the engine is NOT being consulted when the flag is off.
+    const policy = makePolicy({
+      principals: [],
+      roles: [],
+    });
+    const runtime = makeRecordingRuntime();
+    const adapter = makeAdapter({
+      parallelModeEnabled: false,
+      policy,
+      runtime,
+      systemEventSource: { org: "metafactory", agent: "cortex", instance: "local" },
+    });
+    const decision = adapter.resolveAccess(buildInboundMessage("U123"));
+    expect(decision.allowed).toBe(true);
+    expect(decision.features.chat).toBe(true);
+    // No disagreement envelopes — engine not consulted.
+    expect(runtime.publishes.length).toBe(0);
+  });
+
+  test("both gates allow: effective allow, no disagreement envelope", () => {
+    const policy = makePolicy({
+      principals: [
+        {
+          id: "mike",
+          home_operator: "andreas",
+          home_stack: "andreas/meta-factory",
+          role: ["user"],
+          trust: [],
+          platform_ids: { discord: ["U123"] },
+        },
+      ],
+      roles: [{ id: "user", capabilities: ["keyword.chat"] }],
+    });
+    const runtime = makeRecordingRuntime();
+    const adapter = makeAdapter({
+      parallelModeEnabled: true,
+      policy,
+      runtime,
+      systemEventSource: { org: "metafactory", agent: "cortex", instance: "local" },
+    });
+    const decision = adapter.resolveAccess(buildInboundMessage("U123"));
+    expect(decision.allowed).toBe(true);
+    expect(decision.features.chat).toBe(true);
+    expect(decision.features.async).toBe(false); // legacy denied async; new gate has no role grant for it either
+    // Legacy grants chat (allowed), denies async/team; new gate grants
+    // chat (allowed), denies async/team. Both AGREE on all three →
+    // no disagreement envelope.
+    expect(runtime.publishes.length).toBe(0);
+  });
+
+  test("both gates deny: effective deny, no disagreement envelope", () => {
+    // Legacy denies (user not in any role + defaultRole=denied).
+    // New gate denies (no principal claims platform_ids.discord=U999).
+    const policy = makePolicy({
+      principals: [],
+      roles: [],
+    });
+    const runtime = makeRecordingRuntime();
+    const adapter = makeAdapter({
+      parallelModeEnabled: true,
+      policy,
+      runtime,
+      systemEventSource: { org: "metafactory", agent: "cortex", instance: "local" },
+    });
+    const decision = adapter.resolveAccess(buildInboundMessage("U999"));
+    expect(decision.allowed).toBe(false);
+    // Both gates agree on the denial — no disagreement envelope.
+    expect(runtime.publishes.length).toBe(0);
+  });
+
+  test("legacy allow + new deny: effective DENY + disagreement envelope (dangerous direction)", () => {
+    // Legacy: U123 has role "user" with feature "chat" → allowed.
+    // New: no principal claims U123 → unknown_principal → deny.
+    // Effective: deny (intersection-wins). Disagreement envelope fires.
+    const policy = makePolicy({
+      principals: [],
+      roles: [],
+    });
+    const runtime = makeRecordingRuntime();
+    const adapter = makeAdapter({
+      parallelModeEnabled: true,
+      policy,
+      runtime,
+      systemEventSource: { org: "metafactory", agent: "cortex", instance: "local" },
+    });
+    const decision = adapter.resolveAccess(buildInboundMessage("U123"));
+    expect(decision.allowed).toBe(false);
+    expect(decision.features.chat).toBe(false);
+    expect(decision.denyReason).toBeDefined();
+    // Disagreement envelope on the keyword.chat capability (the one
+    // where legacy and new differ). Other capabilities (async, team)
+    // both denied → no envelope.
+    expect(runtime.publishes.length).toBeGreaterThanOrEqual(1);
+    const env = runtime.publishes.find(
+      (e) => e.type === "system.access.disagreement",
+    );
+    expect(env).toBeDefined();
+    expect(env?.type).toBe("system.access.disagreement");
+    expect(env?.payload).toMatchObject({
+      capability: "keyword.chat",
+      legacy_decision: "allow",
+      new_decision: "deny",
+      new_reason: "unknown_principal",
+      effective_decision: "deny",
+    });
+  });
+
+  test("legacy deny + new allow: effective DENY + disagreement envelope (breakage direction)", () => {
+    // Legacy denies (U999 is not in any role + defaultRole=denied).
+    // New gate would grant chat (principal mike claims U999, role user
+    // has keyword.chat). Effective: deny. Disagreement fires.
+    const policy = makePolicy({
+      principals: [
+        {
+          id: "mike",
+          home_operator: "andreas",
+          home_stack: "andreas/meta-factory",
+          role: ["user"],
+          trust: [],
+          platform_ids: { discord: ["U999"] },
+        },
+      ],
+      roles: [{ id: "user", capabilities: ["keyword.chat"] }],
+    });
+    const runtime = makeRecordingRuntime();
+    const adapter = makeAdapter({
+      parallelModeEnabled: true,
+      policy,
+      runtime,
+      systemEventSource: { org: "metafactory", agent: "cortex", instance: "local" },
+    });
+    const decision = adapter.resolveAccess(buildInboundMessage("U999"));
+    expect(decision.allowed).toBe(false);
+    const env = runtime.publishes.find(
+      (e) => e.type === "system.access.disagreement",
+    );
+    expect(env).toBeDefined();
+    expect(env?.payload).toMatchObject({
+      capability: "keyword.chat",
+      legacy_decision: "deny",
+      new_decision: "allow",
+      effective_decision: "deny",
+    });
+  });
+
+  test("parallel_mode_enabled=true but no policyEngine wired: ERROR log + fall back to legacy-only", () => {
+    const errors: string[] = [];
+    console.error = (...args: unknown[]) => {
+      errors.push(args.map(String).join(" "));
+    };
+    const runtime = makeRecordingRuntime();
+    const adapter = makeAdapter({
+      parallelModeEnabled: true,
+      // policy: omitted — engine/lookup are undefined
+      runtime,
+      systemEventSource: { org: "metafactory", agent: "cortex", instance: "local" },
+    });
+    const decision = adapter.resolveAccess(buildInboundMessage("U123"));
+    // Legacy allowed → effective allow (graceful degradation).
+    expect(decision.allowed).toBe(true);
+    expect(decision.features.chat).toBe(true);
+    // No disagreement envelope (engine never consulted).
+    expect(runtime.publishes.length).toBe(0);
+    // ERROR log fired (at most once across multiple calls).
+    expect(errors.some((e) => e.includes("parallel_mode_enabled=true but policyEngine/policyLookup not wired"))).toBe(true);
+    // Second call: same fallback, no second error.
+    const errorsBefore = errors.length;
+    adapter.resolveAccess(buildInboundMessage("U999"));
+    expect(errors.length).toBe(errorsBefore);
+  });
+
+  test("disagreement envelope carries the §9.1 schema fields", () => {
+    const policy = makePolicy({
+      principals: [],
+      roles: [],
+    });
+    const runtime = makeRecordingRuntime();
+    const adapter = makeAdapter({
+      parallelModeEnabled: true,
+      policy,
+      runtime,
+      systemEventSource: { org: "metafactory", agent: "cortex", instance: "local" },
+    });
+    adapter.resolveAccess(buildInboundMessage("U123"));
+    const env = runtime.publishes.find(
+      (e) => e.type === "system.access.disagreement",
+    );
+    expect(env).toBeDefined();
+    // §9.1 mandated wire fields.
+    expect(env?.payload).toMatchObject({
+      principal_id: expect.any(String),
+      capability: expect.any(String),
+      legacy_decision: expect.stringMatching(/^(allow|deny)$/),
+      legacy_reason: expect.any(String),
+      new_decision: expect.stringMatching(/^(allow|deny)$/),
+      new_reason: expect.any(String),
+      effective_decision: expect.stringMatching(/^(allow|deny)$/),
+    });
+    // Sovereignty + envelope-correlation fields mirror sibling
+    // `system.access.*` envelopes so dashboard renderers slot it in.
+    expect(env?.payload).toHaveProperty("intent_sovereignty");
+    expect(env?.payload).toHaveProperty("envelope_id");
+    expect(env?.payload).toHaveProperty("envelope_subject");
+    expect(env?.payload).toHaveProperty("signed_by");
+  });
+
+  test("unknown_principal envelope reason fires when no platform_ids match", () => {
+    const policy = makePolicy({
+      principals: [
+        {
+          id: "alice",
+          home_operator: "andreas",
+          home_stack: "andreas/meta-factory",
+          role: ["user"],
+          trust: [],
+          platform_ids: { discord: ["U_ALICE"] }, // different from U123
+        },
+      ],
+      roles: [{ id: "user", capabilities: ["keyword.chat"] }],
+    });
+    const runtime = makeRecordingRuntime();
+    const adapter = makeAdapter({
+      parallelModeEnabled: true,
+      policy,
+      runtime,
+      systemEventSource: { org: "metafactory", agent: "cortex", instance: "local" },
+    });
+    adapter.resolveAccess(buildInboundMessage("U123"));
+    const env = runtime.publishes.find(
+      (e) => e.type === "system.access.disagreement",
+    );
+    expect(env).toBeDefined();
+    expect((env?.payload as { new_reason?: string }).new_reason).toBe("unknown_principal");
+  });
+
+  test("emitted disagreement envelope passes myelin schema validation", async () => {
+    const policy = makePolicy({
+      principals: [],
+      roles: [],
+    });
+    const runtime = makeRecordingRuntime();
+    const adapter = makeAdapter({
+      parallelModeEnabled: true,
+      policy,
+      runtime,
+      systemEventSource: { org: "metafactory", agent: "cortex", instance: "local" },
+    });
+    adapter.resolveAccess(buildInboundMessage("U123"));
+    const env = runtime.publishes.find(
+      (e) => e.type === "system.access.disagreement",
+    );
+    expect(env).toBeDefined();
+    const { validateEnvelope } = await import("../../../bus/myelin/envelope-validator");
+    const result = validateEnvelope(env);
+    expect(result.ok).toBe(true);
+  });
+});

--- a/src/adapters/discord/index.ts
+++ b/src/adapters/discord/index.ts
@@ -30,7 +30,15 @@ import {
   createSystemAdapterDegradedEvent,
   createSystemAdapterDisconnectedEvent,
   createSystemAdapterRecoveredEvent,
+  createSystemAccessDisagreementEvent,
 } from "../../bus/system-events";
+import {
+  buildKeywordCapabilityChecks,
+  defaultParallelModeSovereignty,
+  runParallelModeChecks,
+  type PlatformPrincipalIndex,
+} from "../../common/policy";
+import type { PolicyEngine } from "../../common/policy";
 import { formatEnvelopeAsMarkdown } from "../envelope-renderer";
 import { parseReviewWireFormat, reviewThreadName } from "./wire-format";
 
@@ -92,6 +100,39 @@ export interface DiscordAdapterInfra {
    * `common/types/config.ts`.
    */
   trustedBotIds?: ReadonlySet<string>;
+  /**
+   * IAW Phase C.2b-242a (cortex#296) — PolicyEngine consulted alongside
+   * the legacy role-resolver when `parallelModeEnabled` is `true`.
+   * Resolved by `cortex.ts` from the parsed `policy:` block via
+   * `policyEngineFromConfig`. `undefined` when the deployment has not
+   * declared a `policy:` block yet — in that case parallel mode is
+   * inert regardless of the flag (graceful degradation: legacy gate
+   * remains the only authority, ERROR logged at first inbound message).
+   */
+  policyEngine?: PolicyEngine;
+  /**
+   * IAW Phase C.2b-242a (cortex#296) — `(platform, platformId) →
+   * principalId` lookup index built from `policy.principals[]`. Used
+   * by parallel mode to resolve inbound `message.author.id` to a
+   * principal id before consulting the engine. `undefined` follows
+   * the same conditions as `policyEngine` (no principals declared).
+   */
+  policyLookup?: PlatformPrincipalIndex;
+  /**
+   * IAW Phase C.2b-242a (cortex#296) — operator opt-in flag for the
+   * parallel-mode rollout. When `true`, every inbound message runs
+   * BOTH the legacy role-resolver AND the PolicyEngine; the
+   * effective decision is the most-restrictive intersection
+   * (`docs/design-policy-cutover.md` §9.1). When `false` (default),
+   * the adapter runs the legacy gate ONLY — pre-cutover behaviour.
+   *
+   * Sourced from `cortex.yaml.policy.parallel_mode_enabled`. Operator
+   * MUST run `migrate-config --check` (cortex#295) before flipping
+   * to `true` — without the pre-flight, intersection-wins denies
+   * every previously-authorised user not yet mapped to a
+   * `policy.principals[]` entry.
+   */
+  parallelModeEnabled?: boolean;
 }
 
 interface PendingResult {
@@ -642,6 +683,18 @@ export class DiscordAdapter implements PlatformAdapter {
   }
 
   resolveAccess(msg: InboundMessage): AccessDecision {
+    const legacy = this.legacyResolveAccess(msg);
+    return this.applyParallelMode(msg, legacy);
+  }
+
+  /**
+   * Legacy role-resolver gate — pre-cutover behaviour. cortex#297 (242b)
+   * deletes this method along with role-resolver.ts; for the C.2b-242a
+   * parallel-mode window it remains the SOLE authority when
+   * `parallelModeEnabled` is `false`, and runs alongside the new
+   * PolicyEngine when `true` (intersection-wins per §9.1).
+   */
+  private legacyResolveAccess(msg: InboundMessage): AccessDecision {
     // G-300: DM-specific role resolution
     if (msg.isDM) {
       return this.resolveDMAccess(msg);
@@ -670,6 +723,145 @@ export class DiscordAdapter implements PlatformAdapter {
       toolRestrictions: role.disallowedTools.length > 0 ? role.disallowedTools : undefined,
       dirRestrictions: role.allowedDirs,
       allowedSkills: role.allowedSkills,
+    };
+  }
+
+  /**
+   * cortex#296 — track whether we've already logged the "parallel mode
+   * enabled but no PolicyEngine wired" warning. Logged at most once
+   * per adapter lifetime so a misconfigured deployment doesn't spam
+   * the logs on every inbound message.
+   */
+  private warnedParallelModeUnwired = false;
+
+  /**
+   * IAW Phase C.2b-242a (cortex#296) — parallel-mode wrapper around
+   * the legacy `resolveAccess` result.
+   *
+   * When `parallelModeEnabled` is `false` (default), returns the
+   * legacy decision unchanged — pre-cutover behaviour preserved.
+   *
+   * When `parallelModeEnabled` is `true` AND a PolicyEngine + lookup
+   * index are wired, consults the engine for each keyword capability
+   * (`keyword.chat` / `keyword.async` / `keyword.team`), AND-merges
+   * with the legacy verdict per §9.1 intersection-wins, and emits a
+   * `system.access.disagreement` envelope per disagreement.
+   *
+   * When `parallelModeEnabled` is `true` but PolicyEngine or lookup
+   * is missing (deployment didn't declare a `policy:` block yet),
+   * logs an ERROR once and falls back to legacy-only — graceful
+   * degradation rather than blocking the deployment on a config gap.
+   *
+   * The DM-operator short-circuit (legacy fast path for `dm.operatorRole`)
+   * runs BEFORE this wrapper, so the operator's full-access semantic
+   * is preserved by the legacy verdict regardless of parallel-mode
+   * state. The parallel-mode check still runs on operator DMs so the
+   * disagreement envelope surfaces if the new gate is mis-configured
+   * (e.g. operator principal missing the `operator` capability).
+   */
+  private applyParallelMode(
+    msg: InboundMessage,
+    legacy: AccessDecision,
+  ): AccessDecision {
+    if (this.infra.parallelModeEnabled !== true) {
+      return legacy;
+    }
+    if (this.infra.policyEngine === undefined || this.infra.policyLookup === undefined) {
+      if (!this.warnedParallelModeUnwired) {
+        this.warnedParallelModeUnwired = true;
+        console.error(
+          `cortex-runner: discord-${this.instanceId}: parallel_mode_enabled=true but policyEngine/policyLookup not wired — falling back to legacy gate only`,
+        );
+      }
+      return legacy;
+    }
+
+    const checks = buildKeywordCapabilityChecks({
+      features: legacy.features,
+      isOperator: msg.dmType === "operator",
+    });
+    const sovereignty = defaultParallelModeSovereignty();
+    const { principalId, decisions } = runParallelModeChecks({
+      engine: this.infra.policyEngine,
+      index: this.infra.policyLookup,
+      platform: "discord",
+      platformAuthorId: msg.authorId,
+      sovereignty,
+      checks,
+    });
+
+    const source = this.systemEventSource;
+    const runtime = this.runtime;
+
+    for (const merged of decisions) {
+      if (merged.disagreement === undefined) continue;
+      if (runtime === undefined || source === undefined) {
+        // Bus wiring incomplete — surface a stderr line so the
+        // operator sees the disagreement event even when no
+        // subscriber is wired. Non-fatal: the effective (intersection)
+        // decision still applies below.
+        process.stderr.write(
+          `cortex-runner: discord-${this.instanceId}: parallel-mode disagreement (no runtime to publish) — capability=${merged.capability} legacy=${merged.disagreement.legacyDecision} new=${merged.disagreement.newDecision} effective=${merged.disagreement.effectiveDecision}\n`,
+        );
+        continue;
+      }
+      const envelope = createSystemAccessDisagreementEvent({
+        source,
+        principalId: principalId ?? "",
+        capability: merged.capability,
+        legacyDecision: merged.disagreement.legacyDecision,
+        legacyReason: merged.disagreement.legacyReason,
+        newDecision: merged.disagreement.newDecision,
+        newReason: merged.disagreement.newReason,
+        effectiveDecision: merged.disagreement.effectiveDecision,
+        sovereignty,
+        // `correlation_id` is UUID-only per envelope schema; omit and
+        // surface the platform-side message handle on `envelope_id`
+        // / `envelope_subject` instead. Subscribers join on
+        // `(payload.envelope_id, payload.envelope_subject)`.
+        signedBy: [],
+        envelopeSubject: `local.${source.org}.adapter.discord.${this.instanceId}.${msg.threadId ?? msg.channelId}.message.${msg.timestamp.toISOString()}`,
+        envelopeId: `${msg.channelId}:${msg.timestamp.toISOString()}:${msg.authorId}`,
+      });
+      void runtime.publish(envelope).catch((err: unknown) => {
+        process.stderr.write(
+          `cortex-runner: discord-${this.instanceId}: failed to publish system.access.disagreement — ${err instanceof Error ? err.message : String(err)}\n`,
+        );
+      });
+    }
+
+    // Intersection per §9.1 — a feature is effectively allowed only
+    // when BOTH gates allowed it. `merged.get(cap)` is `undefined`
+    // when parallel mode didn't consult that capability (shouldn't
+    // happen for keyword.* since `buildKeywordCapabilityChecks`
+    // always emits all three), in which case we fall back to the
+    // legacy verdict alone to avoid silent privilege loss.
+    const merged = new Map(decisions.map((d) => [d.capability, d.effective.allow] as const));
+    const effectiveFeatures = {
+      chat: legacy.features.chat && (merged.get("keyword.chat") ?? true),
+      async: legacy.features.async && (merged.get("keyword.async") ?? true),
+      team: legacy.features.team && (merged.get("keyword.team") ?? true),
+    };
+    // Lockout case: legacy allowed but the new gate denied every
+    // keyword feature → mirror a legacy-style deny so downstream
+    // callers (MessageRouter) behave the same as if role-resolver
+    // had denied. The disagreement envelope already fired above so
+    // the operator sees what happened on the dashboard.
+    const anyFeatureAllowed =
+      effectiveFeatures.chat || effectiveFeatures.async || effectiveFeatures.team;
+    if (legacy.allowed && !anyFeatureAllowed) {
+      return {
+        ...legacy,
+        allowed: false,
+        features: effectiveFeatures,
+        denyReason:
+          legacy.denyReason ??
+          "Sorry, your access was denied by the policy engine. Ask the operator to map your identity in policy.principals[].",
+      };
+    }
+    return {
+      ...legacy,
+      features: effectiveFeatures,
     };
   }
 

--- a/src/adapters/mattermost/__tests__/parallel-mode.test.ts
+++ b/src/adapters/mattermost/__tests__/parallel-mode.test.ts
@@ -1,0 +1,285 @@
+/**
+ * IAW Phase C.2b-242a (cortex#296) — MattermostAdapter parallel-mode tests.
+ *
+ * Mirror of `src/adapters/discord/__tests__/parallel-mode.test.ts` —
+ * pins the intersection-wins semantic + disagreement-envelope shape
+ * for the Mattermost adapter.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type { Envelope } from "../../../bus/myelin/envelope-validator";
+import type { MyelinRuntime } from "../../../bus/myelin/runtime";
+import type { Agent, MattermostPresence, PolicyPrincipal } from "../../../common/types/cortex-config";
+import {
+  PolicyEngine,
+  PlatformPrincipalIndex,
+  type Principal,
+  type RoleDefinition,
+} from "../../../common/policy";
+import type { InboundMessage } from "../../types";
+import { MattermostAdapter, type MattermostAdapterInfra } from "../index";
+
+function makePresence(overrides: Partial<MattermostPresence> = {}): MattermostPresence {
+  return {
+    enabled: true,
+    callbackPort: 8080,
+    apiUrl: "http://localhost:8065",
+    apiToken: "fake-token",
+    channels: [],
+    pollIntervalMs: 3000,
+    allowedUsers: [],
+    roles: [
+      {
+        name: "user",
+        users: ["U123"],
+        features: ["chat"],
+        disallowedTools: [],
+      },
+    ],
+    defaultRole: "denied",
+    ...overrides,
+  };
+}
+
+function makeAgent(presence: MattermostPresence): Agent {
+  return {
+    id: "luna",
+    displayName: "Luna",
+    persona: "(test)",
+    roles: [],
+    trust: [],
+    presence: { mattermost: presence },
+  };
+}
+
+interface RecordingRuntime extends MyelinRuntime {
+  publishes: Envelope[];
+}
+
+function makeRecordingRuntime(): RecordingRuntime {
+  const publishes: Envelope[] = [];
+  return {
+    enabled: true,
+    onEnvelope: () => ({ unregister: () => {} }),
+    publish: async (envelope: Envelope) => {
+      publishes.push(envelope);
+    },
+    stop: async () => {},
+    publishes,
+  };
+}
+
+interface PolicyFixture {
+  engine: PolicyEngine;
+  index: PlatformPrincipalIndex;
+}
+
+function makePolicy(opts: {
+  principals: (Principal & { platform_ids: Record<string, string[]> })[];
+  roles: RoleDefinition[];
+}): PolicyFixture {
+  const engine = new PolicyEngine({
+    principals: opts.principals.map((p) => ({
+      id: p.id,
+      home_operator: p.home_operator,
+      home_stack: p.home_stack,
+      role: p.role,
+      trust: p.trust,
+    })),
+    roles: opts.roles,
+  });
+  const index = new PlatformPrincipalIndex(
+    opts.principals.map(
+      (p): PolicyPrincipal => ({
+        id: p.id,
+        home_operator: p.home_operator,
+        home_stack: p.home_stack,
+        role: [...p.role],
+        trust: [...p.trust],
+        platform_ids: p.platform_ids,
+      }),
+    ),
+  );
+  return { engine, index };
+}
+
+function buildInboundMessage(authorId: string, overrides: Partial<InboundMessage> = {}): InboundMessage {
+  return {
+    platform: "mattermost",
+    instanceId: "mattermost-luna",
+    authorId,
+    authorName: "test",
+    content: "hi",
+    channelId: "ch1",
+    attachments: [],
+    timestamp: new Date("2026-05-17T00:00:00.000Z"),
+    ...overrides,
+  };
+}
+
+function makeAdapter(opts: {
+  presence?: MattermostPresence;
+  parallelModeEnabled?: boolean;
+  policy?: PolicyFixture;
+  runtime?: MyelinRuntime;
+  systemEventSource?: { org: string; agent: string; instance: string };
+}): MattermostAdapter {
+  const presence = opts.presence ?? makePresence();
+  const agent = makeAgent(presence);
+  const infra: MattermostAdapterInfra = {
+    instanceId: "mattermost-luna",
+    operator: { mattermostId: "U_OPERATOR" },
+    ...(opts.runtime !== undefined && { runtime: opts.runtime }),
+    ...(opts.systemEventSource !== undefined && { systemEventSource: opts.systemEventSource }),
+    ...(opts.parallelModeEnabled !== undefined && { parallelModeEnabled: opts.parallelModeEnabled }),
+    ...(opts.policy !== undefined && {
+      policyEngine: opts.policy.engine,
+      policyLookup: opts.policy.index,
+    }),
+  };
+  return new MattermostAdapter(agent, presence, infra);
+}
+
+let originalError: typeof console.error;
+let originalWarn: typeof console.warn;
+beforeEach(() => {
+  originalError = console.error;
+  originalWarn = console.warn;
+  console.error = () => {};
+  console.warn = () => {};
+});
+afterEach(() => {
+  console.error = originalError;
+  console.warn = originalWarn;
+});
+
+describe("MattermostAdapter parallel-mode (§9.1 intersection-wins)", () => {
+  test("parallel_mode_enabled=false: only legacy runs, no PolicyEngine call", () => {
+    const policy = makePolicy({ principals: [], roles: [] });
+    const runtime = makeRecordingRuntime();
+    const adapter = makeAdapter({
+      parallelModeEnabled: false,
+      policy,
+      runtime,
+      systemEventSource: { org: "metafactory", agent: "cortex", instance: "local" },
+    });
+    const decision = adapter.resolveAccess(buildInboundMessage("U123"));
+    expect(decision.allowed).toBe(true);
+    expect(runtime.publishes.length).toBe(0);
+  });
+
+  test("both gates allow: effective allow, no disagreement", () => {
+    const policy = makePolicy({
+      principals: [
+        {
+          id: "mike",
+          home_operator: "andreas",
+          home_stack: "andreas/meta-factory",
+          role: ["user"],
+          trust: [],
+          platform_ids: { mattermost: ["U123"] },
+        },
+      ],
+      roles: [{ id: "user", capabilities: ["keyword.chat"] }],
+    });
+    const runtime = makeRecordingRuntime();
+    const adapter = makeAdapter({
+      parallelModeEnabled: true,
+      policy,
+      runtime,
+      systemEventSource: { org: "metafactory", agent: "cortex", instance: "local" },
+    });
+    const decision = adapter.resolveAccess(buildInboundMessage("U123"));
+    expect(decision.allowed).toBe(true);
+    expect(decision.features.chat).toBe(true);
+    expect(runtime.publishes.length).toBe(0);
+  });
+
+  test("legacy allow + new deny (unknown_principal): effective DENY + disagreement", () => {
+    const policy = makePolicy({ principals: [], roles: [] });
+    const runtime = makeRecordingRuntime();
+    const adapter = makeAdapter({
+      parallelModeEnabled: true,
+      policy,
+      runtime,
+      systemEventSource: { org: "metafactory", agent: "cortex", instance: "local" },
+    });
+    const decision = adapter.resolveAccess(buildInboundMessage("U123"));
+    expect(decision.allowed).toBe(false);
+    const env = runtime.publishes.find((e) => e.type === "system.access.disagreement");
+    expect(env).toBeDefined();
+    expect(env?.payload).toMatchObject({
+      capability: "keyword.chat",
+      legacy_decision: "allow",
+      new_decision: "deny",
+      new_reason: "unknown_principal",
+      effective_decision: "deny",
+    });
+  });
+
+  test("legacy deny + new allow: effective DENY + disagreement", () => {
+    const policy = makePolicy({
+      principals: [
+        {
+          id: "mike",
+          home_operator: "andreas",
+          home_stack: "andreas/meta-factory",
+          role: ["user"],
+          trust: [],
+          platform_ids: { mattermost: ["U999"] },
+        },
+      ],
+      roles: [{ id: "user", capabilities: ["keyword.chat"] }],
+    });
+    const runtime = makeRecordingRuntime();
+    const adapter = makeAdapter({
+      parallelModeEnabled: true,
+      policy,
+      runtime,
+      systemEventSource: { org: "metafactory", agent: "cortex", instance: "local" },
+    });
+    const decision = adapter.resolveAccess(buildInboundMessage("U999"));
+    expect(decision.allowed).toBe(false);
+    const env = runtime.publishes.find((e) => e.type === "system.access.disagreement");
+    expect(env).toBeDefined();
+    expect(env?.payload).toMatchObject({
+      legacy_decision: "deny",
+      new_decision: "allow",
+      effective_decision: "deny",
+    });
+  });
+
+  test("parallel_mode_enabled=true but no policy wired: ERROR + legacy fallback", () => {
+    const errors: string[] = [];
+    console.error = (...args: unknown[]) => {
+      errors.push(args.map(String).join(" "));
+    };
+    const runtime = makeRecordingRuntime();
+    const adapter = makeAdapter({
+      parallelModeEnabled: true,
+      runtime,
+      systemEventSource: { org: "metafactory", agent: "cortex", instance: "local" },
+    });
+    const decision = adapter.resolveAccess(buildInboundMessage("U123"));
+    expect(decision.allowed).toBe(true);
+    expect(runtime.publishes.length).toBe(0);
+    expect(errors.some((e) => e.includes("parallel_mode_enabled=true but policyEngine/policyLookup not wired"))).toBe(true);
+  });
+
+  test("emitted disagreement envelope passes myelin schema validation", async () => {
+    const policy = makePolicy({ principals: [], roles: [] });
+    const runtime = makeRecordingRuntime();
+    const adapter = makeAdapter({
+      parallelModeEnabled: true,
+      policy,
+      runtime,
+      systemEventSource: { org: "metafactory", agent: "cortex", instance: "local" },
+    });
+    adapter.resolveAccess(buildInboundMessage("U123"));
+    const env = runtime.publishes.find((e) => e.type === "system.access.disagreement");
+    expect(env).toBeDefined();
+    const { validateEnvelope } = await import("../../../bus/myelin/envelope-validator");
+    const result = validateEnvelope(env);
+    expect(result.ok).toBe(true);
+  });
+});

--- a/src/adapters/mattermost/index.ts
+++ b/src/adapters/mattermost/index.ts
@@ -26,9 +26,21 @@ import { fetchMattermostContext } from "./context";
 import { fetchBotUserId } from "./bot-user";
 import { resolveRole } from "../discord/role-resolver";
 import type { Envelope } from "../../bus/myelin/envelope-validator";
+import type { MyelinRuntime } from "../../bus/myelin/runtime";
 import type { SurfaceAdapter } from "../../bus/surface-router";
 import type { PayloadFilter } from "../../bus/payload-filter";
 import { formatEnvelopeAsMarkdown } from "../envelope-renderer";
+import {
+  type SystemEventSource,
+  createSystemAccessDisagreementEvent,
+} from "../../bus/system-events";
+import {
+  buildKeywordCapabilityChecks,
+  defaultParallelModeSovereignty,
+  runParallelModeChecks,
+  type PlatformPrincipalIndex,
+  type PolicyEngine,
+} from "../../common/policy";
 
 /**
  * Cortex-deployment-level wiring passed alongside the agent + presence pair.
@@ -62,6 +74,37 @@ export interface MattermostAdapterInfra {
    * per-envelope routing rule applies. The 26-char channel ID, NOT a name.
    * Moves to Renderer at MIG-7.2d. */
   surfaceFallbackChannelId?: string;
+  /**
+   * IAW Phase C.2b-242a (cortex#296) — myelin runtime used to publish
+   * `system.access.disagreement` envelopes when parallel mode is
+   * active. Optional: when absent, disagreements log to stderr only.
+   * Mirrors `DiscordAdapterInfra.runtime`.
+   */
+  runtime?: MyelinRuntime;
+  /**
+   * IAW Phase C.2b-242a (cortex#296) — `{org}.{agent}.{instance}` source
+   * triple stamped onto emitted `system.access.disagreement` envelopes.
+   * Required when `runtime` is set + `parallelModeEnabled` is `true`.
+   */
+  systemEventSource?: SystemEventSource;
+  /**
+   * IAW Phase C.2b-242a (cortex#296) — PolicyEngine consulted alongside
+   * the legacy role-resolver when `parallelModeEnabled` is `true`.
+   * `undefined` when no `policy:` block is declared yet — graceful
+   * degradation to legacy-only.
+   */
+  policyEngine?: PolicyEngine;
+  /**
+   * IAW Phase C.2b-242a (cortex#296) — `(platform, platformId) →
+   * principalId` lookup index built from `policy.principals[]`.
+   */
+  policyLookup?: PlatformPrincipalIndex;
+  /**
+   * IAW Phase C.2b-242a (cortex#296) — operator opt-in flag for
+   * parallel-mode rollout. See `DiscordAdapterInfra.parallelModeEnabled`
+   * for the full semantic + operator pre-flight contract.
+   */
+  parallelModeEnabled?: boolean;
 }
 
 export class MattermostAdapter implements PlatformAdapter {
@@ -227,6 +270,15 @@ export class MattermostAdapter implements PlatformAdapter {
   }
 
   resolveAccess(msg: InboundMessage): AccessDecision {
+    const legacy = this.legacyResolveAccess(msg);
+    return this.applyParallelMode(msg, legacy);
+  }
+
+  /**
+   * Legacy role-resolver gate — pre-cutover behaviour. cortex#297
+   * (242b) deletes this method alongside role-resolver.ts.
+   */
+  private legacyResolveAccess(msg: InboundMessage): AccessDecision {
     const role = resolveRole(msg.authorId, {
       roles: this.presence.roles,
       defaultRole: this.presence.defaultRole,
@@ -250,6 +302,100 @@ export class MattermostAdapter implements PlatformAdapter {
       toolRestrictions: role.disallowedTools.length > 0 ? role.disallowedTools : undefined,
       dirRestrictions: role.allowedDirs,
       allowedSkills: role.allowedSkills,
+    };
+  }
+
+  /** cortex#296 — at-most-once parallel-mode misconfiguration warning. */
+  private warnedParallelModeUnwired = false;
+
+  /**
+   * IAW Phase C.2b-242a (cortex#296) — parallel-mode wrapper. See
+   * `DiscordAdapter.applyParallelMode` for the full contract; this
+   * is the mechanical Mattermost mirror.
+   */
+  private applyParallelMode(
+    msg: InboundMessage,
+    legacy: AccessDecision,
+  ): AccessDecision {
+    if (this.infra.parallelModeEnabled !== true) {
+      return legacy;
+    }
+    if (this.infra.policyEngine === undefined || this.infra.policyLookup === undefined) {
+      if (!this.warnedParallelModeUnwired) {
+        this.warnedParallelModeUnwired = true;
+        console.error(
+          `cortex-runner: mattermost-${this.instanceId}: parallel_mode_enabled=true but policyEngine/policyLookup not wired — falling back to legacy gate only`,
+        );
+      }
+      return legacy;
+    }
+
+    const isOperator = this.infra.operator.mattermostId !== undefined && msg.authorId === this.infra.operator.mattermostId;
+    const checks = buildKeywordCapabilityChecks({
+      features: legacy.features,
+      isOperator,
+    });
+    const sovereignty = defaultParallelModeSovereignty();
+    const { principalId, decisions } = runParallelModeChecks({
+      engine: this.infra.policyEngine,
+      index: this.infra.policyLookup,
+      platform: "mattermost",
+      platformAuthorId: msg.authorId,
+      sovereignty,
+      checks,
+    });
+
+    const source = this.infra.systemEventSource;
+    const runtime = this.infra.runtime;
+    for (const merged of decisions) {
+      if (merged.disagreement === undefined) continue;
+      if (runtime === undefined || source === undefined) {
+        process.stderr.write(
+          `cortex-runner: mattermost-${this.instanceId}: parallel-mode disagreement (no runtime to publish) — capability=${merged.capability} legacy=${merged.disagreement.legacyDecision} new=${merged.disagreement.newDecision} effective=${merged.disagreement.effectiveDecision}\n`,
+        );
+        continue;
+      }
+      const envelope = createSystemAccessDisagreementEvent({
+        source,
+        principalId: principalId ?? "",
+        capability: merged.capability,
+        legacyDecision: merged.disagreement.legacyDecision,
+        legacyReason: merged.disagreement.legacyReason,
+        newDecision: merged.disagreement.newDecision,
+        newReason: merged.disagreement.newReason,
+        effectiveDecision: merged.disagreement.effectiveDecision,
+        sovereignty,
+        signedBy: [],
+        envelopeSubject: `local.${source.org}.adapter.mattermost.${this.instanceId}.${msg.threadId ?? msg.channelId}.message.${msg.timestamp.toISOString()}`,
+        envelopeId: `${msg.channelId}:${msg.timestamp.toISOString()}:${msg.authorId}`,
+      });
+      void runtime.publish(envelope).catch((err: unknown) => {
+        process.stderr.write(
+          `cortex-runner: mattermost-${this.instanceId}: failed to publish system.access.disagreement — ${err instanceof Error ? err.message : String(err)}\n`,
+        );
+      });
+    }
+
+    const mergedMap = new Map(decisions.map((d) => [d.capability, d.effective.allow] as const));
+    const effectiveFeatures = {
+      chat: legacy.features.chat && (mergedMap.get("keyword.chat") ?? true),
+      async: legacy.features.async && (mergedMap.get("keyword.async") ?? true),
+      team: legacy.features.team && (mergedMap.get("keyword.team") ?? true),
+    };
+    const anyFeatureAllowed = effectiveFeatures.chat || effectiveFeatures.async || effectiveFeatures.team;
+    if (legacy.allowed && !anyFeatureAllowed) {
+      return {
+        ...legacy,
+        allowed: false,
+        features: effectiveFeatures,
+        denyReason:
+          legacy.denyReason ??
+          "Sorry, your access was denied by the policy engine. Ask the operator to map your identity in policy.principals[].",
+      };
+    }
+    return {
+      ...legacy,
+      features: effectiveFeatures,
     };
   }
 

--- a/src/adapters/slack/__tests__/parallel-mode.test.ts
+++ b/src/adapters/slack/__tests__/parallel-mode.test.ts
@@ -1,0 +1,341 @@
+/**
+ * IAW Phase C.2b-242a (cortex#296) — SlackAdapter parallel-mode tests.
+ *
+ * Mirror of the Discord + Mattermost parallel-mode suites. Pins the
+ * intersection-wins semantic from `docs/design-policy-cutover.md` §9.1
+ * and the disagreement-envelope shape for the Slack adapter.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type { Envelope } from "../../../bus/myelin/envelope-validator";
+import type { MyelinRuntime } from "../../../bus/myelin/runtime";
+import type { Agent, SlackPresence, PolicyPrincipal } from "../../../common/types/cortex-config";
+import {
+  PolicyEngine,
+  PlatformPrincipalIndex,
+  type Principal,
+  type RoleDefinition,
+} from "../../../common/policy";
+import type { InboundMessage } from "../../types";
+import type { SlackClient } from "../client";
+import { SlackAdapter, type SlackAdapterInfra } from "../index";
+
+function makePresence(overrides: Partial<SlackPresence> = {}): SlackPresence {
+  return {
+    enabled: true,
+    botToken: "xoxb-TEST-TOKEN-12345",
+    appToken: "xapp-TEST-APP-12345",
+    workspaceId: "T0WORKSPACE",
+    channels: [{ id: "C0CHANNEL1", name: "cortex" }],
+    allowedUserIds: [],
+    trustedBotIds: [],
+    roles: [
+      {
+        name: "user",
+        users: ["U123"],
+        features: ["chat"],
+        disallowedTools: [],
+      },
+    ],
+    defaultRole: "denied",
+    surfaceSubjects: [],
+    ...overrides,
+  };
+}
+
+function makeAgent(presence: SlackPresence): Agent {
+  return {
+    id: "luna",
+    displayName: "Luna",
+    persona: "(test)",
+    roles: [],
+    trust: [],
+    presence: { slack: presence },
+  };
+}
+
+interface RecordingRuntime extends MyelinRuntime {
+  publishes: Envelope[];
+}
+
+function makeRecordingRuntime(): RecordingRuntime {
+  const publishes: Envelope[] = [];
+  return {
+    enabled: true,
+    onEnvelope: () => ({ unregister: () => {} }),
+    publish: async (envelope: Envelope) => {
+      publishes.push(envelope);
+    },
+    stop: async () => {},
+    publishes,
+  };
+}
+
+function makeFakeClient(): SlackClient {
+  return {
+    // eslint-disable-next-line @typescript-eslint/require-await
+    async start() {},
+    // eslint-disable-next-line @typescript-eslint/require-await
+    async stop() {},
+    // eslint-disable-next-line @typescript-eslint/require-await
+    async postMessage() {
+      return { ts: "1700000000.000001" };
+    },
+    // eslint-disable-next-line @typescript-eslint/require-await
+    async getBotUserId() {
+      return "UBOT_LUNA";
+    },
+    // eslint-disable-next-line @typescript-eslint/require-await
+    async getBotIdentity() {
+      return { userId: "UBOT_LUNA", botId: "BBOT_LUNA" };
+    },
+  };
+}
+
+interface PolicyFixture {
+  engine: PolicyEngine;
+  index: PlatformPrincipalIndex;
+}
+
+function makePolicy(opts: {
+  principals: (Principal & { platform_ids: Record<string, string[]> })[];
+  roles: RoleDefinition[];
+}): PolicyFixture {
+  const engine = new PolicyEngine({
+    principals: opts.principals.map((p) => ({
+      id: p.id,
+      home_operator: p.home_operator,
+      home_stack: p.home_stack,
+      role: p.role,
+      trust: p.trust,
+    })),
+    roles: opts.roles,
+  });
+  const index = new PlatformPrincipalIndex(
+    opts.principals.map(
+      (p): PolicyPrincipal => ({
+        id: p.id,
+        home_operator: p.home_operator,
+        home_stack: p.home_stack,
+        role: [...p.role],
+        trust: [...p.trust],
+        platform_ids: p.platform_ids,
+      }),
+    ),
+  );
+  return { engine, index };
+}
+
+function buildInboundMessage(authorId: string, overrides: Partial<InboundMessage> = {}): InboundMessage {
+  return {
+    platform: "slack",
+    instanceId: "slack-luna",
+    authorId,
+    authorName: "test",
+    content: "hi",
+    channelId: "C0CHANNEL1",
+    attachments: [],
+    timestamp: new Date("2026-05-17T00:00:00.000Z"),
+    ...overrides,
+  };
+}
+
+function makeAdapter(opts: {
+  presence?: SlackPresence;
+  parallelModeEnabled?: boolean;
+  policy?: PolicyFixture;
+  runtime?: MyelinRuntime;
+  systemEventSource?: { org: string; agent: string; instance: string };
+}): SlackAdapter {
+  const presence = opts.presence ?? makePresence();
+  const agent = makeAgent(presence);
+  const infra: SlackAdapterInfra = {
+    instanceId: "slack-luna",
+    operator: { slackId: "U_OPERATOR" },
+    client: makeFakeClient(),
+    ...(opts.runtime !== undefined && { runtime: opts.runtime }),
+    ...(opts.systemEventSource !== undefined && { systemEventSource: opts.systemEventSource }),
+    ...(opts.parallelModeEnabled !== undefined && { parallelModeEnabled: opts.parallelModeEnabled }),
+    ...(opts.policy !== undefined && {
+      policyEngine: opts.policy.engine,
+      policyLookup: opts.policy.index,
+    }),
+  };
+  return new SlackAdapter(agent, presence, infra);
+}
+
+let originalError: typeof console.error;
+let originalWarn: typeof console.warn;
+beforeEach(() => {
+  originalError = console.error;
+  originalWarn = console.warn;
+  console.error = () => {};
+  console.warn = () => {};
+});
+afterEach(() => {
+  console.error = originalError;
+  console.warn = originalWarn;
+});
+
+describe("SlackAdapter parallel-mode (§9.1 intersection-wins)", () => {
+  test("parallel_mode_enabled=false: only legacy runs, no PolicyEngine call", () => {
+    const policy = makePolicy({ principals: [], roles: [] });
+    const runtime = makeRecordingRuntime();
+    const adapter = makeAdapter({
+      parallelModeEnabled: false,
+      policy,
+      runtime,
+      systemEventSource: { org: "metafactory", agent: "cortex", instance: "local" },
+    });
+    const decision = adapter.resolveAccess(buildInboundMessage("U123"));
+    expect(decision.allowed).toBe(true);
+    expect(runtime.publishes.length).toBe(0);
+  });
+
+  test("both gates allow: effective allow, no disagreement", () => {
+    const policy = makePolicy({
+      principals: [
+        {
+          id: "mike",
+          home_operator: "andreas",
+          home_stack: "andreas/meta-factory",
+          role: ["user"],
+          trust: [],
+          platform_ids: { slack: ["U123"] },
+        },
+      ],
+      roles: [{ id: "user", capabilities: ["keyword.chat"] }],
+    });
+    const runtime = makeRecordingRuntime();
+    const adapter = makeAdapter({
+      parallelModeEnabled: true,
+      policy,
+      runtime,
+      systemEventSource: { org: "metafactory", agent: "cortex", instance: "local" },
+    });
+    const decision = adapter.resolveAccess(buildInboundMessage("U123"));
+    expect(decision.allowed).toBe(true);
+    expect(decision.features.chat).toBe(true);
+    expect(runtime.publishes.length).toBe(0);
+  });
+
+  test("legacy allow + new deny: effective DENY + disagreement", () => {
+    const policy = makePolicy({ principals: [], roles: [] });
+    const runtime = makeRecordingRuntime();
+    const adapter = makeAdapter({
+      parallelModeEnabled: true,
+      policy,
+      runtime,
+      systemEventSource: { org: "metafactory", agent: "cortex", instance: "local" },
+    });
+    const decision = adapter.resolveAccess(buildInboundMessage("U123"));
+    expect(decision.allowed).toBe(false);
+    const env = runtime.publishes.find((e) => e.type === "system.access.disagreement");
+    expect(env).toBeDefined();
+    expect(env?.payload).toMatchObject({
+      capability: "keyword.chat",
+      legacy_decision: "allow",
+      new_decision: "deny",
+      new_reason: "unknown_principal",
+      effective_decision: "deny",
+    });
+  });
+
+  test("legacy deny + new allow: effective DENY + disagreement", () => {
+    const policy = makePolicy({
+      principals: [
+        {
+          id: "mike",
+          home_operator: "andreas",
+          home_stack: "andreas/meta-factory",
+          role: ["user"],
+          trust: [],
+          platform_ids: { slack: ["U999"] },
+        },
+      ],
+      roles: [{ id: "user", capabilities: ["keyword.chat"] }],
+    });
+    const runtime = makeRecordingRuntime();
+    const adapter = makeAdapter({
+      parallelModeEnabled: true,
+      policy,
+      runtime,
+      systemEventSource: { org: "metafactory", agent: "cortex", instance: "local" },
+    });
+    const decision = adapter.resolveAccess(buildInboundMessage("U999"));
+    expect(decision.allowed).toBe(false);
+    const env = runtime.publishes.find((e) => e.type === "system.access.disagreement");
+    expect(env).toBeDefined();
+    expect(env?.payload).toMatchObject({
+      legacy_decision: "deny",
+      new_decision: "allow",
+      effective_decision: "deny",
+    });
+  });
+
+  test("parallel_mode_enabled=true but no policy wired: ERROR + legacy fallback", () => {
+    const errors: string[] = [];
+    console.error = (...args: unknown[]) => {
+      errors.push(args.map(String).join(" "));
+    };
+    const runtime = makeRecordingRuntime();
+    const adapter = makeAdapter({
+      parallelModeEnabled: true,
+      runtime,
+      systemEventSource: { org: "metafactory", agent: "cortex", instance: "local" },
+    });
+    const decision = adapter.resolveAccess(buildInboundMessage("U123"));
+    expect(decision.allowed).toBe(true);
+    expect(runtime.publishes.length).toBe(0);
+    expect(errors.some((e) => e.includes("parallel_mode_enabled=true but policyEngine/policyLookup not wired"))).toBe(true);
+  });
+
+  test("emitted disagreement envelope passes myelin schema validation", async () => {
+    const policy = makePolicy({ principals: [], roles: [] });
+    const runtime = makeRecordingRuntime();
+    const adapter = makeAdapter({
+      parallelModeEnabled: true,
+      policy,
+      runtime,
+      systemEventSource: { org: "metafactory", agent: "cortex", instance: "local" },
+    });
+    adapter.resolveAccess(buildInboundMessage("U123"));
+    const env = runtime.publishes.find((e) => e.type === "system.access.disagreement");
+    expect(env).toBeDefined();
+    const { validateEnvelope } = await import("../../../bus/myelin/envelope-validator");
+    const result = validateEnvelope(env);
+    expect(result.ok).toBe(true);
+  });
+
+  test("hard-deny guards (self-loop, allowlist miss) short-circuit BEFORE parallel mode", () => {
+    // Configure presence with an allowlist that EXCLUDES the author —
+    // legacy gate hard-denies. Parallel mode must NOT fire for that
+    // message (the deny is platform-invariant, not policy-related).
+    const presence = makePresence({ allowedUserIds: ["U_ONLY_ALLOWED"] });
+    const policy = makePolicy({
+      principals: [
+        {
+          id: "mike",
+          home_operator: "andreas",
+          home_stack: "andreas/meta-factory",
+          role: ["user"],
+          trust: [],
+          platform_ids: { slack: ["U_RANDO"] },
+        },
+      ],
+      roles: [{ id: "user", capabilities: ["keyword.chat"] }],
+    });
+    const runtime = makeRecordingRuntime();
+    const adapter = makeAdapter({
+      presence,
+      parallelModeEnabled: true,
+      policy,
+      runtime,
+      systemEventSource: { org: "metafactory", agent: "cortex", instance: "local" },
+    });
+    const decision = adapter.resolveAccess(buildInboundMessage("U_RANDO"));
+    expect(decision.allowed).toBe(false);
+    // No disagreement envelope — hard-deny path skipped parallel mode.
+    expect(runtime.publishes.length).toBe(0);
+  });
+});

--- a/src/adapters/slack/index.ts
+++ b/src/adapters/slack/index.ts
@@ -31,8 +31,16 @@ import {
   type SystemEventSource,
   createSystemAdapterDisconnectedEvent,
   createSystemAdapterRecoveredEvent,
+  createSystemAccessDisagreementEvent,
 } from "../../bus/system-events";
 import { resolveRole } from "../discord/role-resolver";
+import {
+  buildKeywordCapabilityChecks,
+  defaultParallelModeSovereignty,
+  runParallelModeChecks,
+  type PlatformPrincipalIndex,
+  type PolicyEngine,
+} from "../../common/policy";
 import { formatEnvelopeAsMarkdown } from "../envelope-renderer";
 import { RealSlackClient, type SlackClient, type SlackInboundEvent, type SlackBotIdentity } from "./client";
 
@@ -78,6 +86,23 @@ export interface SlackAdapterInfra {
    * `presence.appToken`. Tests inject a fake.
    */
   client?: SlackClient;
+  /**
+   * IAW Phase C.2b-242a (cortex#296) — PolicyEngine consulted alongside
+   * the legacy role-resolver when `parallelModeEnabled` is `true`.
+   * See `DiscordAdapterInfra.policyEngine` for full semantic.
+   */
+  policyEngine?: PolicyEngine;
+  /**
+   * IAW Phase C.2b-242a (cortex#296) — `(platform, platformId) →
+   * principalId` lookup index built from `policy.principals[]`.
+   */
+  policyLookup?: PlatformPrincipalIndex;
+  /**
+   * IAW Phase C.2b-242a (cortex#296) — operator opt-in flag for the
+   * parallel-mode rollout. See `DiscordAdapterInfra.parallelModeEnabled`
+   * for operator pre-flight contract.
+   */
+  parallelModeEnabled?: boolean;
 }
 
 /**
@@ -469,6 +494,22 @@ export class SlackAdapter implements PlatformAdapter {
   }
 
   resolveAccess(msg: InboundMessage): AccessDecision {
+    const legacy = this.legacyResolveAccess(msg);
+    // Hard-deny guards (self-loop, allowlist miss) short-circuit
+    // before parallel mode — they're adapter-side invariants the
+    // PolicyEngine doesn't model. Only run parallel mode when the
+    // legacy gate produced a feature-gating decision.
+    if (!legacy.allowed && (legacy.denyReason?.startsWith("Self-loop") || legacy.denyReason?.startsWith("Sorry, I'm only configured to respond to specific users"))) {
+      return legacy;
+    }
+    return this.applyParallelMode(msg, legacy);
+  }
+
+  /**
+   * Legacy role-resolver gate — pre-cutover behaviour. cortex#297
+   * (242b) deletes this alongside role-resolver.ts.
+   */
+  private legacyResolveAccess(msg: InboundMessage): AccessDecision {
     // Self-loop guard: never act on messages authored by this bot.
     // Check both the user id and the bot id — `chat.postMessage` from
     // this bot can round-trip as a `bot_message` event where
@@ -519,6 +560,100 @@ export class SlackAdapter implements PlatformAdapter {
       toolRestrictions: role.disallowedTools.length > 0 ? role.disallowedTools : undefined,
       dirRestrictions: role.allowedDirs,
       allowedSkills: role.allowedSkills,
+    };
+  }
+
+  /** cortex#296 — at-most-once parallel-mode misconfiguration warning. */
+  private warnedParallelModeUnwired = false;
+
+  /**
+   * IAW Phase C.2b-242a (cortex#296) — parallel-mode wrapper. See
+   * `DiscordAdapter.applyParallelMode` for the full contract; this
+   * is the mechanical Slack mirror.
+   */
+  private applyParallelMode(
+    msg: InboundMessage,
+    legacy: AccessDecision,
+  ): AccessDecision {
+    if (this.infra.parallelModeEnabled !== true) {
+      return legacy;
+    }
+    if (this.infra.policyEngine === undefined || this.infra.policyLookup === undefined) {
+      if (!this.warnedParallelModeUnwired) {
+        this.warnedParallelModeUnwired = true;
+        console.error(
+          `cortex-runner: slack-${this.instanceId}: parallel_mode_enabled=true but policyEngine/policyLookup not wired — falling back to legacy gate only`,
+        );
+      }
+      return legacy;
+    }
+
+    const isOperator = this.infra.operator.slackId !== undefined && msg.authorId === this.infra.operator.slackId;
+    const checks = buildKeywordCapabilityChecks({
+      features: legacy.features,
+      isOperator,
+    });
+    const sovereignty = defaultParallelModeSovereignty();
+    const { principalId, decisions } = runParallelModeChecks({
+      engine: this.infra.policyEngine,
+      index: this.infra.policyLookup,
+      platform: "slack",
+      platformAuthorId: msg.authorId,
+      sovereignty,
+      checks,
+    });
+
+    const runtime = this.runtime;
+    const source = this.systemEventSource;
+    for (const merged of decisions) {
+      if (merged.disagreement === undefined) continue;
+      if (runtime === undefined || source === undefined) {
+        process.stderr.write(
+          `cortex-runner: slack-${this.instanceId}: parallel-mode disagreement (no runtime to publish) — capability=${merged.capability} legacy=${merged.disagreement.legacyDecision} new=${merged.disagreement.newDecision} effective=${merged.disagreement.effectiveDecision}\n`,
+        );
+        continue;
+      }
+      const envelope = createSystemAccessDisagreementEvent({
+        source,
+        principalId: principalId ?? "",
+        capability: merged.capability,
+        legacyDecision: merged.disagreement.legacyDecision,
+        legacyReason: merged.disagreement.legacyReason,
+        newDecision: merged.disagreement.newDecision,
+        newReason: merged.disagreement.newReason,
+        effectiveDecision: merged.disagreement.effectiveDecision,
+        sovereignty,
+        signedBy: [],
+        envelopeSubject: `local.${source.org}.adapter.slack.${this.instanceId}.${msg.threadId ?? msg.channelId}.message.${msg.timestamp.toISOString()}`,
+        envelopeId: `${msg.channelId}:${msg.timestamp.toISOString()}:${msg.authorId}`,
+      });
+      void runtime.publish(envelope).catch((err: unknown) => {
+        process.stderr.write(
+          `cortex-runner: slack-${this.instanceId}: failed to publish system.access.disagreement — ${err instanceof Error ? err.message : String(err)}\n`,
+        );
+      });
+    }
+
+    const mergedMap = new Map(decisions.map((d) => [d.capability, d.effective.allow] as const));
+    const effectiveFeatures = {
+      chat: legacy.features.chat && (mergedMap.get("keyword.chat") ?? true),
+      async: legacy.features.async && (mergedMap.get("keyword.async") ?? true),
+      team: legacy.features.team && (mergedMap.get("keyword.team") ?? true),
+    };
+    const anyFeatureAllowed = effectiveFeatures.chat || effectiveFeatures.async || effectiveFeatures.team;
+    if (legacy.allowed && !anyFeatureAllowed) {
+      return {
+        ...legacy,
+        allowed: false,
+        features: effectiveFeatures,
+        denyReason:
+          legacy.denyReason ??
+          "Sorry, your access was denied by the policy engine. Ask the operator to map your identity in policy.principals[].",
+      };
+    }
+    return {
+      ...legacy,
+      features: effectiveFeatures,
     };
   }
 

--- a/src/bus/__tests__/system-events.test.ts
+++ b/src/bus/__tests__/system-events.test.ts
@@ -15,6 +15,7 @@ import { describe, expect, test } from "bun:test";
 import { validateEnvelope } from "../myelin/envelope-validator";
 import {
   adapterCorrelationKey,
+  createSystemAccessDisagreementEvent,
   createSystemAccessFilteredEvent,
   createSystemAdapterDegradedEvent,
   createSystemAdapterDisconnectedEvent,
@@ -510,5 +511,86 @@ describe("createSystemAccessFilteredEvent", () => {
       reason: "residency_blocked",
     });
     expect(a.id).not.toBe(b.id);
+  });
+});
+
+describe("createSystemAccessDisagreementEvent (cortex#296)", () => {
+  const baseOpts = {
+    source: { org: "metafactory", agent: "cortex", instance: "local" },
+    principalId: "mike",
+    capability: "keyword.chat",
+    legacyDecision: "allow" as const,
+    legacyReason: "role.user.allows",
+    newDecision: "deny" as const,
+    newReason: "unknown_principal",
+    effectiveDecision: "deny" as const,
+    sovereignty: {
+      classification: "local" as const,
+      data_residency: "NZ",
+      max_hop: 0,
+      frontier_ok: false,
+      model_class: "local-only" as const,
+    },
+    signedBy: [],
+    envelopeSubject: "local.metafactory.adapter.discord.discord-luna.ch1.message.2026-05-17T00:00:00.000Z",
+    envelopeId: "ch1:2026-05-17T00:00:00.000Z:U123",
+  };
+
+  test("builds envelope with `system.access.disagreement` type and the §9.1 payload fields", () => {
+    const env = createSystemAccessDisagreementEvent(baseOpts);
+    expect(env.type).toBe("system.access.disagreement");
+    expect(env.source).toBe("metafactory.cortex.local");
+    expect(env.payload).toMatchObject({
+      principal_id: "mike",
+      capability: "keyword.chat",
+      legacy_decision: "allow",
+      legacy_reason: "role.user.allows",
+      new_decision: "deny",
+      new_reason: "unknown_principal",
+      effective_decision: "deny",
+    });
+    expect(env.payload).toHaveProperty("intent_sovereignty");
+    expect(env.payload).toHaveProperty("envelope_id");
+    expect(env.payload).toHaveProperty("envelope_subject");
+    expect(env.payload).toHaveProperty("signed_by");
+  });
+
+  test("envelope passes myelin schema validation (no correlation_id needed)", () => {
+    const env = createSystemAccessDisagreementEvent(baseOpts);
+    expect(validateEnvelope(env).ok).toBe(true);
+  });
+
+  test("stamps default sovereignty (local-only / NZ / max_hop=0)", () => {
+    const env = createSystemAccessDisagreementEvent(baseOpts);
+    expect(env.sovereignty).toEqual({
+      classification: "local",
+      data_residency: "NZ",
+      max_hop: 0,
+      frontier_ok: false,
+      model_class: "local-only",
+    });
+  });
+
+  test("source.dataResidency override flows through to sovereignty", () => {
+    const env = createSystemAccessDisagreementEvent({
+      ...baseOpts,
+      source: { ...baseOpts.source, dataResidency: "AU" },
+    });
+    expect(env.sovereignty.data_residency).toBe("AU");
+  });
+
+  test("each call returns a fresh envelope id", () => {
+    const a = createSystemAccessDisagreementEvent(baseOpts);
+    const b = createSystemAccessDisagreementEvent(baseOpts);
+    expect(a.id).not.toBe(b.id);
+  });
+
+  test("optional correlationId surfaces on the envelope when supplied as UUID", () => {
+    const env = createSystemAccessDisagreementEvent({
+      ...baseOpts,
+      correlationId: "f1381beb-1b5c-46d8-b5a7-f393f085ecf1",
+    });
+    expect(env.correlation_id).toBe("f1381beb-1b5c-46d8-b5a7-f393f085ecf1");
+    expect(validateEnvelope(env).ok).toBe(true);
   });
 });

--- a/src/bus/system-events.ts
+++ b/src/bus/system-events.ts
@@ -890,3 +890,199 @@ export function createSystemAccessFederationDeniedEvent(
     },
   });
 }
+
+// ---------------------------------------------------------------------------
+// system.access.disagreement — C.2b-242a parallel-mode validation envelope
+// ---------------------------------------------------------------------------
+
+/**
+ * Per-decision verdict shape used on `system.access.disagreement`
+ * envelopes. The two gates (legacy role-resolver, new PolicyEngine)
+ * surface their decision + a short reason string, and the envelope
+ * carries both verbatim so dashboard consumers don't have to re-run
+ * either gate to render the disagreement.
+ *
+ * Wire format note: kept loose (`string` rather than a discriminated
+ * union) because the legacy gate's reasons are free-form ("user not
+ * in any role", "defaultRole = denied", etc.) and the new gate's
+ * reasons come from `PolicyDenyReason.kind` — surfaces can branch on
+ * the `kind:`-prefixed string when it's available without coupling
+ * system-events.ts to either gate's internal types.
+ *
+ * Echo cortex#221 round 1 precedent — same shape pattern as
+ * `SystemAccessSignedBy` (loose-but-typed wire form).
+ */
+export type SystemAccessDecision = "allow" | "deny";
+
+/**
+ * Options for `createSystemAccessDisagreementEvent` — the C.2b-242a
+ * parallel-mode validation envelope.
+ *
+ * Emitted by adapter-side parallel mode (cortex#296) when the legacy
+ * role-resolver and the new PolicyEngine reach different verdicts for
+ * the same `(principal, capability)` pair. The effective decision is
+ * always the most-restrictive intersection (§9.1 — security default;
+ * NOT new-system-wins). The envelope's purpose is operator-visible
+ * validation: surface every gate-divergence so the operator can spot
+ * mis-migrations BEFORE cortex#297 retires the legacy gate.
+ *
+ * Cross-references:
+ *   - `docs/design-policy-cutover.md` §9.1 — intersection-wins
+ *     conflict resolution + operator pre-flight contract.
+ *   - `docs/iteration-policy-cutover.md` cortex#296 — slice scope.
+ *   - {@link SystemAccessAllowedOpts} / {@link SystemAccessDeniedOpts}
+ *     — the C.4 sibling envelopes that the dashboard's existing
+ *     handlers render; this envelope is shaped to slot into the same
+ *     `system.access.>` subject family so the dashboard wiring lifts
+ *     across with minimal change.
+ *
+ * Wire-contract notes:
+ *   - `effective_decision` MUST equal the AND of `legacy_decision`
+ *     and `new_decision` (allow only if both allow). Adapters compute
+ *     this before constructing the envelope.
+ *   - `legacy_reason` / `new_reason` are short strings — usually a
+ *     `PolicyDenyReason.kind` from the new gate and a free-form
+ *     reason from the legacy gate ("user not in any role", etc.).
+ *   - The envelope retires entirely when cortex#297 (242b) lands
+ *     and removes the parallel mode.
+ */
+export interface SystemAccessDisagreementOpts {
+  source: SystemEventSource;
+  /**
+   * Principal id the gates evaluated (bare, no `did:mf:` prefix).
+   * For the legacy gate this is the synthesised lookup id (the
+   * adapter resolves `(platform, message.author.id)` → principal
+   * via the new `platform_ids` index even when running the legacy
+   * gate, so both gates speak the same id).
+   *
+   * When the new gate failed at principal resolution (no
+   * `platform_ids` entry matched), the envelope carries the empty
+   * string here and `new_reason: "unknown_principal"`; surfaces
+   * render the case with the platform-side author id from
+   * `envelope_subject` for triage.
+   */
+  principalId: string;
+  /**
+   * The capability claim the gates evaluated (e.g. `keyword.chat`,
+   * `tool.bash`). One disagreement envelope per capability checked
+   * — adapters that check multiple capabilities on the same inbound
+   * message emit multiple disagreement envelopes (one per gate that
+   * actually disagreed).
+   */
+  capability: string;
+  /** Legacy role-resolver's verdict for this `(principal, capability)`. */
+  legacyDecision: SystemAccessDecision;
+  /**
+   * Short string describing the legacy verdict. Free-form — typical
+   * values are `"role.{name}.allows"`, `"role.{name}.denies"`,
+   * `"defaultRole.denied"`, `"defaultRole.allow-all"`, `"no_role_matched"`.
+   * Used only for operator triage; surfaces don't branch on it.
+   */
+  legacyReason: string;
+  /** New PolicyEngine's verdict for this `(principal, capability)`. */
+  newDecision: SystemAccessDecision;
+  /**
+   * Short string describing the new gate's verdict. When the new
+   * gate denied, this is typically the `PolicyDenyReason.kind` value
+   * (`"unknown_principal"`, `"insufficient_role"`); when it allowed,
+   * `"capability_granted"`. Surfaces may branch on the deny-kind
+   * prefix when triaging.
+   */
+  newReason: string;
+  /**
+   * The applied decision — always equals `legacyDecision &&
+   * newDecision` (intersection-wins). Carried explicitly on the
+   * envelope so dashboard consumers don't have to recompute.
+   */
+  effectiveDecision: SystemAccessDecision;
+  /**
+   * Sovereignty constraints carried verbatim from the originating
+   * envelope/message. For adapter-side disagreements there's no
+   * originating bus envelope yet (the disagreement fires on the
+   * inbound platform message BEFORE dispatch), so adapters
+   * synthesise the default `system.*` sovereignty (local-only / NZ
+   * / max_hop=0 / frontier_ok=false / model_class=local-only).
+   */
+  sovereignty: SystemAccessSovereignty;
+  /**
+   * Correlation id — MUST be UUID-format per the myelin envelope
+   * schema's `correlation_id` constraint. Adapters generate a fresh
+   * UUID per disagreement envelope and stash the platform-side
+   * message handle on the payload (`envelope_id` field) for triage.
+   *
+   * Optional: when omitted, the envelope's `correlation_id` is left
+   * unset and surfaces join by `(payload.envelope_id,
+   * payload.envelope_subject)` instead. Mirrors the
+   * `adapterCorrelationKey` accommodation in the `system.adapter.*`
+   * envelopes (see file-level "Known spec gap" note).
+   */
+  correlationId?: string;
+  /**
+   * `signed_by[]` chain. Empty for adapter-side disagreements — the
+   * inbound message is not a bus envelope and carries no signature.
+   * The field is preserved for shape compatibility with sibling
+   * `system.access.*` envelopes so dashboard renderers don't need a
+   * branch.
+   */
+  signedBy: SystemAccessSignedBy[];
+  /**
+   * Synthetic subject for the inbound platform message — adapters
+   * use `local.{org}.adapter.{platform}.{instanceId}.message` so
+   * subscribers can filter disagreements by platform-side origin.
+   */
+  envelopeSubject: string;
+  /**
+   * Synthetic envelope id — adapters typically use the platform
+   * message id directly (Discord snowflake / Mattermost post id /
+   * Slack ts), which is already globally unique within its
+   * platform. Surfaces can join the disagreement back to the
+   * inbound message by this id when investigating.
+   */
+  envelopeId: string;
+  /** Classification override; defaults to local per system.* convention. */
+  classification?: Classification;
+}
+
+/**
+ * Construct a `system.access.disagreement` envelope (C.2b-242a).
+ *
+ * Emitted by adapter-side parallel mode (cortex#296) when the legacy
+ * role-resolver and the new PolicyEngine disagree on a capability
+ * decision. The envelope's wire shape mirrors `system.access.allowed`
+ * / `system.access.denied` (same `principal_id` / `capability` /
+ * `intent_sovereignty` / `envelope_id` / `envelope_subject` /
+ * `signed_by` payload fields) so dashboard renderers handling the
+ * `system.access.>` subject family can slot this in with minimal
+ * branching.
+ *
+ * Subject convention: `local.{org}.system.access.disagreement` —
+ * surfaces subscribe to `system.access.>` for the full access stream
+ * and branch on `envelope.type`.
+ *
+ * Retirement: this envelope lives only for the parallel-mode
+ * validation window. cortex#297 (242b) deletes role-resolver.ts and
+ * with it the only producer of this envelope.
+ */
+export function createSystemAccessDisagreementEvent(
+  opts: SystemAccessDisagreementOpts,
+): Envelope {
+  return buildBaseEnvelope({
+    type: "system.access.disagreement",
+    source: buildSource(opts.source),
+    sovereignty: defaultSystemSovereignty(opts.source, opts.classification),
+    ...(opts.correlationId !== undefined && { correlationId: opts.correlationId }),
+    payload: {
+      principal_id: opts.principalId,
+      capability: opts.capability,
+      legacy_decision: opts.legacyDecision,
+      legacy_reason: opts.legacyReason,
+      new_decision: opts.newDecision,
+      new_reason: opts.newReason,
+      effective_decision: opts.effectiveDecision,
+      intent_sovereignty: opts.sovereignty,
+      envelope_id: opts.envelopeId,
+      envelope_subject: opts.envelopeSubject,
+      signed_by: opts.signedBy,
+    },
+  });
+}

--- a/src/common/policy/__tests__/parallel-mode-schema.test.ts
+++ b/src/common/policy/__tests__/parallel-mode-schema.test.ts
@@ -1,0 +1,47 @@
+/**
+ * IAW Phase C.2b-242a (cortex#296) — `policy.parallel_mode_enabled`
+ * schema field tests. Pins the default-off behaviour so existing
+ * operator configs continue to parse cleanly without an explicit
+ * flag.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { PolicySchema } from "../../types/cortex-config";
+
+describe("policy.parallel_mode_enabled (cortex#296)", () => {
+  test("defaults to false when omitted", () => {
+    const policy = PolicySchema.parse({
+      principals: [],
+      roles: [],
+    });
+    expect(policy.parallel_mode_enabled).toBe(false);
+  });
+
+  test("accepts explicit true", () => {
+    const policy = PolicySchema.parse({
+      principals: [],
+      roles: [],
+      parallel_mode_enabled: true,
+    });
+    expect(policy.parallel_mode_enabled).toBe(true);
+  });
+
+  test("accepts explicit false", () => {
+    const policy = PolicySchema.parse({
+      principals: [],
+      roles: [],
+      parallel_mode_enabled: false,
+    });
+    expect(policy.parallel_mode_enabled).toBe(false);
+  });
+
+  test("rejects non-boolean", () => {
+    expect(() =>
+      PolicySchema.parse({
+        principals: [],
+        roles: [],
+        parallel_mode_enabled: "yes",
+      }),
+    ).toThrow();
+  });
+});

--- a/src/common/policy/__tests__/parallel-mode.test.ts
+++ b/src/common/policy/__tests__/parallel-mode.test.ts
@@ -1,0 +1,272 @@
+/**
+ * IAW Phase C.2b-242a (cortex#296) — parallel-mode plumbing tests.
+ *
+ * Unit-tests the `PlatformPrincipalIndex` + `runParallelModeChecks`
+ * helpers in `src/common/policy/parallel-mode.ts`. The adapter-side
+ * tests (discord/mattermost/slack) cover the same surface through
+ * the adapter; these tests pin the module's behaviour in isolation.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { PolicyEngine } from "../engine";
+import {
+  PlatformPrincipalIndex,
+  buildKeywordCapabilityChecks,
+  buildPlatformPrincipalIndex,
+  buildToolCapabilityChecks,
+  checkCapabilityViaEngine,
+  defaultParallelModeSovereignty,
+  mergeCapabilityDecision,
+  runParallelModeChecks,
+} from "../parallel-mode";
+import { PolicySchema } from "../../types/cortex-config";
+
+describe("PlatformPrincipalIndex", () => {
+  test("resolves a (platform, id) tuple to the declaring principal id", () => {
+    const policy = PolicySchema.parse({
+      principals: [
+        {
+          id: "mike",
+          home_operator: "andreas",
+          home_stack: "andreas/meta-factory",
+          role: ["user"],
+          trust: [],
+          platform_ids: { discord: ["123", "456"], slack: ["U_MIKE"] },
+        },
+        {
+          id: "alice",
+          home_operator: "andreas",
+          home_stack: "andreas/meta-factory",
+          role: ["user"],
+          trust: [],
+          platform_ids: { discord: ["789"] },
+        },
+      ],
+      roles: [{ id: "user", capabilities: ["keyword.chat"] }],
+    });
+    const index = new PlatformPrincipalIndex(policy.principals);
+    expect(index.resolve("discord", "123")).toBe("mike");
+    expect(index.resolve("discord", "456")).toBe("mike");
+    expect(index.resolve("slack", "U_MIKE")).toBe("mike");
+    expect(index.resolve("discord", "789")).toBe("alice");
+    expect(index.resolve("discord", "nonexistent")).toBeUndefined();
+    expect(index.size).toBe(4);
+  });
+
+  test("buildPlatformPrincipalIndex returns undefined for empty policy", () => {
+    expect(buildPlatformPrincipalIndex(undefined)).toBeUndefined();
+    const empty = PolicySchema.parse({ principals: [], roles: [] });
+    expect(buildPlatformPrincipalIndex(empty)).toBeUndefined();
+  });
+
+  test("buildPlatformPrincipalIndex returns index when principals declared", () => {
+    const policy = PolicySchema.parse({
+      principals: [
+        {
+          id: "luna",
+          home_operator: "andreas",
+          home_stack: "andreas/meta-factory",
+          role: ["operator"],
+          trust: [],
+          platform_ids: { discord: ["BOT_LUNA"] },
+        },
+      ],
+      roles: [{ id: "operator", capabilities: ["operator"] }],
+    });
+    const index = buildPlatformPrincipalIndex(policy);
+    expect(index?.resolve("discord", "BOT_LUNA")).toBe("luna");
+  });
+});
+
+describe("checkCapabilityViaEngine", () => {
+  const engine = new PolicyEngine({
+    principals: [
+      {
+        id: "mike",
+        home_operator: "andreas",
+        home_stack: "andreas/meta-factory",
+        role: ["user"],
+        trust: [],
+      },
+    ],
+    roles: [{ id: "user", capabilities: ["keyword.chat"] }],
+  });
+  const sov = defaultParallelModeSovereignty();
+
+  test("returns allow when capability granted", () => {
+    expect(checkCapabilityViaEngine(engine, "mike", "keyword.chat", sov)).toEqual({
+      allow: true,
+      reason: "capability_granted",
+    });
+  });
+
+  test("returns deny with insufficient_role when missing capability", () => {
+    expect(checkCapabilityViaEngine(engine, "mike", "keyword.team", sov)).toEqual({
+      allow: false,
+      reason: "insufficient_role:keyword.team",
+    });
+  });
+
+  test("returns deny with unknown_principal when principalId is undefined", () => {
+    expect(checkCapabilityViaEngine(engine, undefined, "keyword.chat", sov)).toEqual({
+      allow: false,
+      reason: "unknown_principal",
+    });
+  });
+
+  test("returns deny with unknown_principal when principal not in engine", () => {
+    expect(checkCapabilityViaEngine(engine, "ghost", "keyword.chat", sov)).toEqual({
+      allow: false,
+      reason: "unknown_principal",
+    });
+  });
+});
+
+describe("mergeCapabilityDecision (§9.1 intersection-wins)", () => {
+  test("both allow → effective allow, no disagreement", () => {
+    const merged = mergeCapabilityDecision(
+      "keyword.chat",
+      { allow: true, reason: "legacy_allow" },
+      { allow: true, reason: "capability_granted" },
+    );
+    expect(merged.effective.allow).toBe(true);
+    expect(merged.disagreement).toBeUndefined();
+  });
+
+  test("both deny → effective deny, no disagreement", () => {
+    const merged = mergeCapabilityDecision(
+      "keyword.chat",
+      { allow: false, reason: "legacy_deny" },
+      { allow: false, reason: "unknown_principal" },
+    );
+    expect(merged.effective.allow).toBe(false);
+    expect(merged.disagreement).toBeUndefined();
+  });
+
+  test("legacy allow + new deny → effective deny + disagreement", () => {
+    const merged = mergeCapabilityDecision(
+      "keyword.chat",
+      { allow: true, reason: "legacy_allow" },
+      { allow: false, reason: "unknown_principal" },
+    );
+    expect(merged.effective.allow).toBe(false);
+    expect(merged.disagreement).toEqual({
+      legacyDecision: "allow",
+      legacyReason: "legacy_allow",
+      newDecision: "deny",
+      newReason: "unknown_principal",
+      effectiveDecision: "deny",
+    });
+  });
+
+  test("legacy deny + new allow → effective deny + disagreement", () => {
+    const merged = mergeCapabilityDecision(
+      "keyword.chat",
+      { allow: false, reason: "legacy_deny" },
+      { allow: true, reason: "capability_granted" },
+    );
+    expect(merged.effective.allow).toBe(false);
+    expect(merged.disagreement?.effectiveDecision).toBe("deny");
+  });
+});
+
+describe("runParallelModeChecks", () => {
+  test("emits one merged decision per check, in input order", () => {
+    const policy = PolicySchema.parse({
+      principals: [
+        {
+          id: "mike",
+          home_operator: "andreas",
+          home_stack: "andreas/meta-factory",
+          role: ["user"],
+          trust: [],
+          platform_ids: { discord: ["U123"] },
+        },
+      ],
+      roles: [{ id: "user", capabilities: ["keyword.chat"] }],
+    });
+    const engine = new PolicyEngine({
+      principals: policy.principals.map((p) => ({
+        id: p.id,
+        home_operator: p.home_operator,
+        home_stack: p.home_stack,
+        role: p.role,
+        trust: p.trust,
+      })),
+      roles: policy.roles,
+    });
+    const index = new PlatformPrincipalIndex(policy.principals);
+    const checks = buildKeywordCapabilityChecks({
+      features: { chat: true, async: true, team: false },
+    });
+    const result = runParallelModeChecks({
+      engine,
+      index,
+      platform: "discord",
+      platformAuthorId: "U123",
+      sovereignty: defaultParallelModeSovereignty(),
+      checks,
+    });
+    expect(result.principalId).toBe("mike");
+    expect(result.decisions.length).toBe(3);
+    expect(result.decisions.map((d) => d.capability)).toEqual([
+      "keyword.chat",
+      "keyword.async",
+      "keyword.team",
+    ]);
+    // keyword.chat: legacy allow, new allow → no disagreement
+    expect(result.decisions[0]?.disagreement).toBeUndefined();
+    // keyword.async: legacy allow, new deny (no grant) → DISAGREEMENT
+    expect(result.decisions[1]?.disagreement?.effectiveDecision).toBe("deny");
+    // keyword.team: legacy deny, new deny → no disagreement
+    expect(result.decisions[2]?.disagreement).toBeUndefined();
+  });
+});
+
+describe("buildKeywordCapabilityChecks", () => {
+  test("emits one check per feature; includes operator when supplied", () => {
+    const checks = buildKeywordCapabilityChecks({
+      features: { chat: true, async: false, team: true },
+      isOperator: true,
+    });
+    expect(checks.map((c) => c.capability)).toEqual([
+      "keyword.chat",
+      "keyword.async",
+      "keyword.team",
+      "operator",
+    ]);
+    expect(checks[0]?.legacy.allow).toBe(true);
+    expect(checks[1]?.legacy.allow).toBe(false);
+    expect(checks[3]?.legacy.allow).toBe(true);
+  });
+
+  test("omits operator check when isOperator is undefined", () => {
+    const checks = buildKeywordCapabilityChecks({
+      features: { chat: true, async: false, team: false },
+    });
+    expect(checks.length).toBe(3);
+    expect(checks.find((c) => c.capability === "operator")).toBeUndefined();
+  });
+});
+
+describe("buildToolCapabilityChecks", () => {
+  test("inverts deny-list against canonical tool inventory", () => {
+    const inv = ["Bash", "Edit", "Write", "Read"];
+    const checks = buildToolCapabilityChecks(inv, ["Edit", "Write"]);
+    expect(checks.map((c) => c.capability)).toEqual([
+      "tool.bash",
+      "tool.edit",
+      "tool.write",
+      "tool.read",
+    ]);
+    expect(checks[0]?.legacy.allow).toBe(true); // bash allowed
+    expect(checks[1]?.legacy.allow).toBe(false); // edit denied
+    expect(checks[2]?.legacy.allow).toBe(false); // write denied
+    expect(checks[3]?.legacy.allow).toBe(true); // read allowed
+  });
+
+  test("undefined deny-list → all tools allowed", () => {
+    const checks = buildToolCapabilityChecks(["Bash", "Read"], undefined);
+    expect(checks.every((c) => c.legacy.allow)).toBe(true);
+  });
+});

--- a/src/common/policy/index.ts
+++ b/src/common/policy/index.ts
@@ -23,3 +23,17 @@ export type {
   RoleDefinition,
 } from "./types";
 export { policyEngineFromConfig } from "./factory";
+export {
+  PlatformPrincipalIndex,
+  buildPlatformPrincipalIndex,
+  buildKeywordCapabilityChecks,
+  buildToolCapabilityChecks,
+  checkCapabilityViaEngine,
+  defaultParallelModeSovereignty,
+  mergeCapabilityDecision,
+  runParallelModeChecks,
+  type CapabilityCheck,
+  type GateDecision,
+  type MergedCapabilityDecision,
+  type ParallelModeSovereignty,
+} from "./parallel-mode";

--- a/src/common/policy/parallel-mode.ts
+++ b/src/common/policy/parallel-mode.ts
@@ -1,0 +1,427 @@
+/**
+ * IAW Phase C.2b-242a (cortex#296) — adapter-side parallel-mode plumbing.
+ *
+ * Wires the legacy role-resolver and the new PolicyEngine side-by-
+ * side on every inbound platform message, computes the most-restrictive
+ * intersection of their decisions (§9.1 security default — NOT
+ * new-system-wins), and surfaces disagreements as
+ * `system.access.disagreement` envelopes for operator-visible
+ * validation BEFORE cortex#297 retires the legacy gate.
+ *
+ * The module is deliberately platform-agnostic: Discord, Mattermost,
+ * and Slack adapters all consume the same `PlatformPrincipalIndex`
+ * lookup + `runParallelModeChecks` helper. The adapters supply the
+ * platform name (`"discord"` / `"mattermost"` / `"slack"`) and the
+ * legacy `AccessDecision` they already computed; this module performs
+ * the per-capability AND-merge and returns the effective decision +
+ * the list of disagreement envelopes to publish.
+ *
+ * Cross-references:
+ *   - `docs/design-policy-cutover.md` §9.1 — intersection-wins
+ *     conflict resolution + operator pre-flight contract.
+ *   - `docs/iteration-policy-cutover.md` cortex#296 — slice scope.
+ *   - {@link createSystemAccessDisagreementEvent} — the envelope this
+ *     module emits.
+ *
+ * Retirement: cortex#297 (242b) deletes role-resolver.ts and removes
+ * the only caller of this module — the file then retires alongside
+ * the legacy gate.
+ */
+
+import type { Policy, PolicyPrincipal } from "../types/cortex-config";
+import type { Intent, PolicyDenyReason } from "./types";
+import type { PolicyEngine } from "./engine";
+
+/**
+ * `(platform_name, platform_id) → principal_id` lookup index built
+ * from a parsed `policy.principals[]` array. The schema validates
+ * tuple-uniqueness across all principals at parse time (cortex#243a
+ * `PolicySchema.superRefine`), so the lookup is deterministic — at
+ * most one principal claims any given platform identity.
+ *
+ * Built once at adapter construction time and re-built on hot-reload
+ * (out of scope here; F-092 covers updateConfig). The index is read-
+ * only at runtime so a `ReadonlyMap` is the natural representation.
+ */
+export class PlatformPrincipalIndex {
+  private readonly map: ReadonlyMap<string, string>;
+
+  constructor(principals: readonly PolicyPrincipal[]) {
+    const m = new Map<string, string>();
+    for (const p of principals) {
+      for (const [platformName, ids] of Object.entries(p.platform_ids)) {
+        for (const platformId of ids) {
+          // Schema-side uniqueness guarantees no collision; if a
+          // duplicate slips through (caller bypassed parse), prefer
+          // the first-declared principal (the deterministic choice).
+          const key = `${platformName}${platformId}`;
+          if (!m.has(key)) m.set(key, p.id);
+        }
+      }
+    }
+    this.map = m;
+  }
+
+  /**
+   * Resolve a `(platform, platformId)` tuple to a principal id.
+   * Returns `undefined` when no principal claims that platform
+   * identity — the new gate then surfaces `unknown_principal` in
+   * the disagreement envelope's `new_reason`.
+   */
+  resolve(platform: string, platformId: string): string | undefined {
+    return this.map.get(`${platform}${platformId}`);
+  }
+
+  /** Number of `(platform, id)` tuples in the index. Useful for boot logs. */
+  get size(): number {
+    return this.map.size;
+  }
+}
+
+/**
+ * Build a {@link PlatformPrincipalIndex} from the optional `policy:`
+ * block on the parsed config. Returns `undefined` when no policy is
+ * declared OR no principals are declared — adapters then never run
+ * parallel mode regardless of the `parallel_mode_enabled` flag (no
+ * principals to look up against).
+ */
+export function buildPlatformPrincipalIndex(
+  policy: Policy | undefined,
+): PlatformPrincipalIndex | undefined {
+  if (policy === undefined) return undefined;
+  if (policy.principals.length === 0) return undefined;
+  return new PlatformPrincipalIndex(policy.principals);
+}
+
+/**
+ * Per-capability gate decision. Both gates produce one of these for
+ * each capability the adapter wants to check; the orchestrator
+ * AND-merges them and emits a disagreement envelope when the pair
+ * differs.
+ */
+export interface GateDecision {
+  /** `true` when this gate authorised the capability. */
+  allow: boolean;
+  /**
+   * Short human-readable reason. For the legacy gate, free-form
+   * strings like `"role.user.allows"`, `"defaultRole.denied"`,
+   * `"no_role_matched"`. For the new gate, typically the
+   * `PolicyDenyReason.kind` value on deny, `"capability_granted"`
+   * on allow. Used only for disagreement-envelope triage.
+   */
+  reason: string;
+}
+
+/**
+ * Sovereignty shape this module needs from a caller. Mirrors
+ * {@link Intent.sovereignty} structurally — adapters that synthesise
+ * an intent for the new gate pass the same default sovereignty here
+ * for the disagreement envelope.
+ */
+export interface ParallelModeSovereignty {
+  classification: "local" | "federated" | "public";
+  data_residency: string;
+  max_hop: number;
+  frontier_ok: boolean;
+  model_class: "local-only" | "frontier" | "any";
+}
+
+/**
+ * Default sovereignty for adapter-side parallel-mode intents.
+ * `local-only` / NZ / max_hop=0 / frontier_ok=false / model_class=local-only.
+ * Adapters override only when the inbound platform message carries
+ * sovereignty context (none do today — that's a future surface).
+ *
+ * Mirrors `defaultSystemSovereignty` in `src/bus/system-events.ts` so
+ * disagreement envelopes match sibling `system.access.*` envelopes
+ * verbatim on the sovereignty axis.
+ */
+export function defaultParallelModeSovereignty(
+  dataResidency = "NZ",
+): ParallelModeSovereignty {
+  return {
+    classification: "local",
+    data_residency: dataResidency,
+    max_hop: 0,
+    frontier_ok: false,
+    model_class: "local-only",
+  };
+}
+
+/**
+ * Translate a deny reason from the engine into the short string the
+ * disagreement envelope's `new_reason` carries. Surfaces a single,
+ * dotted, kind-prefixed token per kind so dashboard renderers can
+ * branch on the prefix.
+ */
+function describeDenyReason(reason: PolicyDenyReason): string {
+  switch (reason.kind) {
+    case "unknown_principal":
+      return "unknown_principal";
+    case "insufficient_role":
+      return `insufficient_role:${reason.missing_capability}`;
+    case "sovereignty_mismatch":
+      return "sovereignty_mismatch";
+    case "unknown_network":
+      return `unknown_network:${reason.source_network}`;
+    case "stack_not_in_network":
+      return `stack_not_in_network:${reason.source_network}`;
+    case "unknown_federated_peer":
+      return `unknown_federated_peer:${reason.source_network}`;
+    /* istanbul ignore next — exhaustiveness guard */
+    default:
+      return "denied";
+  }
+}
+
+/**
+ * Ask the new gate (PolicyEngine) for a verdict on a single
+ * capability for a resolved principal. Returns the gate decision +
+ * the short reason string the disagreement envelope's `new_reason`
+ * carries.
+ *
+ * Resolution failure is treated as a deny with kind
+ * `"unknown_principal"` — the engine itself returns that kind when
+ * the principal isn't in the registry; this helper mirrors the
+ * behaviour for the pre-resolution case (no `platform_ids` match) so
+ * adapter call-sites have one branch to handle.
+ */
+export function checkCapabilityViaEngine(
+  engine: PolicyEngine,
+  principalId: string | undefined,
+  capability: string,
+  sovereignty: ParallelModeSovereignty,
+): GateDecision {
+  if (principalId === undefined) {
+    // No `platform_ids` entry matched — the new gate can't authorise
+    // an actor it can't identify. Mirrors engine's
+    // `unknown_principal` deny shape so the disagreement reason is
+    // consistent across the resolution-miss vs. registry-miss cases.
+    return { allow: false, reason: "unknown_principal" };
+  }
+  const intent: Intent = {
+    capability,
+    sovereignty,
+  };
+  const decision = engine.check(principalId, intent);
+  if (decision.allow) {
+    return { allow: true, reason: "capability_granted" };
+  }
+  return { allow: false, reason: describeDenyReason(decision.reason) };
+}
+
+/**
+ * One capability the adapter wants both gates to weigh in on. The
+ * `legacy` decision is the adapter's existing role-resolver verdict
+ * for that capability; the orchestrator computes the new gate
+ * verdict via the engine + emits a disagreement record when they
+ * differ.
+ */
+export interface CapabilityCheck {
+  /**
+   * Capability id matching the new schema's namespace conventions
+   * (`keyword.chat`, `tool.bash`, `operator`, etc.). The new gate
+   * matches this literally against the principal's effective
+   * capability set.
+   */
+  capability: string;
+  /** The legacy role-resolver's verdict for this capability. */
+  legacy: GateDecision;
+}
+
+/**
+ * Result of merging legacy + new decisions for a single capability.
+ * `effective` is the AND-merge (allow only if both gates allow).
+ * `disagreement` is `undefined` when the gates agreed.
+ */
+export interface MergedCapabilityDecision {
+  capability: string;
+  legacy: GateDecision;
+  /** The new gate's verdict — may be `undefined` if parallel mode is off. */
+  new?: GateDecision;
+  effective: GateDecision;
+  /**
+   * Populated only when legacy and new disagreed. When present,
+   * carries the intersection verdict + the two reasons so adapter
+   * call-sites can hand it to `createSystemAccessDisagreementEvent`
+   * without re-merging.
+   */
+  disagreement?: {
+    legacyDecision: "allow" | "deny";
+    legacyReason: string;
+    newDecision: "allow" | "deny";
+    newReason: string;
+    effectiveDecision: "allow" | "deny";
+  };
+}
+
+/**
+ * Merge a single capability's legacy + new gate decisions per §9.1
+ * intersection-wins semantics. Returns the effective decision + a
+ * disagreement record when the gates differ.
+ */
+export function mergeCapabilityDecision(
+  capability: string,
+  legacy: GateDecision,
+  newGate: GateDecision,
+): MergedCapabilityDecision {
+  const effectiveAllow = legacy.allow && newGate.allow;
+  const effective: GateDecision = {
+    allow: effectiveAllow,
+    reason: effectiveAllow
+      ? "intersection_allow"
+      : `intersection_deny:${legacy.allow ? "new" : "legacy"}_denied`,
+  };
+  if (legacy.allow === newGate.allow) {
+    return { capability, legacy, new: newGate, effective };
+  }
+  return {
+    capability,
+    legacy,
+    new: newGate,
+    effective,
+    disagreement: {
+      legacyDecision: legacy.allow ? "allow" : "deny",
+      legacyReason: legacy.reason,
+      newDecision: newGate.allow ? "allow" : "deny",
+      newReason: newGate.reason,
+      effectiveDecision: effectiveAllow ? "allow" : "deny",
+    },
+  };
+}
+
+/**
+ * Orchestrator entry point — runs the new gate for each
+ * {@link CapabilityCheck} and merges with the supplied legacy
+ * verdict. Returns one {@link MergedCapabilityDecision} per check,
+ * in input order.
+ *
+ * The principal id is resolved once up-front via the
+ * `PlatformPrincipalIndex` — every per-capability call to the engine
+ * uses the same resolution. When no principal matches the
+ * `(platform, platformId)` tuple, every check returns
+ * `unknown_principal` from the new gate; the merge produces a
+ * disagreement record per capability the legacy gate allowed
+ * (because legacy-allow + new-deny = the dangerous direction the
+ * envelope exists to surface).
+ */
+export function runParallelModeChecks(opts: {
+  engine: PolicyEngine;
+  index: PlatformPrincipalIndex;
+  platform: string;
+  platformAuthorId: string;
+  sovereignty: ParallelModeSovereignty;
+  checks: readonly CapabilityCheck[];
+}): {
+  principalId: string | undefined;
+  decisions: MergedCapabilityDecision[];
+} {
+  const principalId = opts.index.resolve(opts.platform, opts.platformAuthorId);
+  const decisions = opts.checks.map((check) => {
+    const newGate = checkCapabilityViaEngine(
+      opts.engine,
+      principalId,
+      check.capability,
+      opts.sovereignty,
+    );
+    return mergeCapabilityDecision(check.capability, check.legacy, newGate);
+  });
+  return { principalId, decisions };
+}
+
+/**
+ * Translate a legacy `AccessDecision`-shaped feature/tool bundle into
+ * the {@link CapabilityCheck}[] the orchestrator consumes. Adapters
+ * call this with the decision their existing role-resolver produced;
+ * the helper emits one check per capability the legacy gate has an
+ * opinion on:
+ *
+ *   - `keyword.chat` / `keyword.async` / `keyword.team` — one per
+ *     `features.*` boolean
+ *   - `operator` — one check, gated by `isOperator`
+ *
+ * NOT translated (per §5.3 + task spec): `allowedDirs`, `allowedSkills`,
+ * `bashAllowlist`, `bashGuard` — these are session-construction
+ * parameters, not authorisation capabilities. The orchestrator
+ * deliberately doesn't gate on them; cortex#297 verifies they MATCH
+ * between legacy + new but doesn't run them through the engine.
+ *
+ * Tool capability checks (`tool.<name>`) require the canonical Claude
+ * tool inventory from cortex#294 (`src/common/policy/tool-inventory.ts`)
+ * — for each tool in the inventory, the legacy gate's
+ * `toolRestrictions` deny-list inverts to a per-tool capability check.
+ * Adapters that want tool-level parallel-mode validation pass them
+ * via {@link buildToolCapabilityChecks} as additional checks
+ * alongside the keyword/operator checks built here.
+ */
+export function buildKeywordCapabilityChecks(legacy: {
+  features: { chat: boolean; async: boolean; team: boolean };
+  isOperator?: boolean;
+}): CapabilityCheck[] {
+  const out: CapabilityCheck[] = [
+    {
+      capability: "keyword.chat",
+      legacy: {
+        allow: legacy.features.chat,
+        reason: legacy.features.chat ? "feature_chat_allowed" : "feature_chat_denied",
+      },
+    },
+    {
+      capability: "keyword.async",
+      legacy: {
+        allow: legacy.features.async,
+        reason: legacy.features.async ? "feature_async_allowed" : "feature_async_denied",
+      },
+    },
+    {
+      capability: "keyword.team",
+      legacy: {
+        allow: legacy.features.team,
+        reason: legacy.features.team ? "feature_team_allowed" : "feature_team_denied",
+      },
+    },
+  ];
+  if (legacy.isOperator !== undefined) {
+    out.push({
+      capability: "operator",
+      legacy: {
+        allow: legacy.isOperator,
+        reason: legacy.isOperator ? "operator_short_circuit" : "non_operator",
+      },
+    });
+  }
+  return out;
+}
+
+/**
+ * Build per-tool {@link CapabilityCheck}[] from the legacy gate's
+ * `toolRestrictions` deny-list against the canonical Claude tool
+ * inventory.
+ *
+ * Each inventory tool produces one check: `tool.<lowercase-name>`,
+ * with the legacy verdict = `!toolRestrictions.includes(toolName)`.
+ * The new gate evaluates the same capability literally against the
+ * principal's role grants (per §5.2 — `tool.bash` granted means bash
+ * is allowed; absent means denied).
+ *
+ * Passed as a separate helper so adapters can opt-in to tool-level
+ * disagreement surfacing (chatty during the validation window — most
+ * deployments will rely on the keyword checks alone until cortex#297
+ * removes the parallel mode).
+ */
+export function buildToolCapabilityChecks(
+  toolInventory: readonly string[],
+  toolRestrictions: readonly string[] | undefined,
+): CapabilityCheck[] {
+  const denied = new Set(toolRestrictions ?? []);
+  return toolInventory.map((toolName) => {
+    const isAllowed = !denied.has(toolName);
+    return {
+      capability: `tool.${toolName.toLowerCase()}`,
+      legacy: {
+        allow: isAllowed,
+        reason: isAllowed ? `tool_${toolName}_allowed` : `tool_${toolName}_restricted`,
+      },
+    };
+  });
+}

--- a/src/common/types/cortex-config.ts
+++ b/src/common/types/cortex-config.ts
@@ -1531,6 +1531,37 @@ export const PolicySchema = z.object({
   principals: z.array(PolicyPrincipalSchema).default([]),
   roles: z.array(PolicyRoleSchema).default([]),
   federated: PolicyFederatedSchema.optional(),
+  /**
+   * IAW Phase C.2b-242a (cortex#296) — parallel-mode opt-in flag for
+   * the policy cutover validation window.
+   *
+   * When `false` (default), adapters run the legacy role-resolver
+   * gate ONLY. This preserves pre-cutover behaviour for every
+   * deployment that hasn't yet run `migrate-config` (cortex#295) —
+   * the new PolicyEngine is constructed but not consulted on the
+   * adapter side.
+   *
+   * When `true`, each adapter consults BOTH the legacy role-resolver
+   * AND the PolicyEngine on every inbound message. The effective
+   * decision is the most-restrictive intersection (allow only if
+   * both gates allow — `docs/design-policy-cutover.md` §9.1 security
+   * default). Disagreements emit `system.access.disagreement`
+   * envelopes carrying both verdicts, surfacing mis-migrations on
+   * the dashboard before cortex#297 (242b) retires the legacy gate.
+   *
+   * Operator pre-flight (§9.1): `migrate-config --check` (cortex#295)
+   * MUST pass before flipping this to `true`. Without the pre-flight
+   * every previously-authorised user the legacy gate knew about but
+   * isn't mapped to a `policy.principals[]` entry yet would be
+   * denied by intersection-wins. The flag is opt-in deliberately so
+   * operators commit to parallel-mode rollout after they've validated
+   * the migration locally.
+   *
+   * Retirement: cortex#297 (242b) removes both the flag AND the
+   * parallel-mode plumbing in adapters — PolicyEngine becomes the
+   * sole gate and this knob's surface disappears.
+   */
+  parallel_mode_enabled: z.boolean().default(false),
 }).superRefine((policy, ctx) => {
   // Per-offender path emission so a YAML-aware loader can render
   // the error inline at the bad token (Echo cortex#219 round 1).


### PR DESCRIPTION
## Summary

Wires the new PolicyEngine alongside the legacy role-resolver in Discord/Mattermost/Slack adapters. Effective decision = **most-restrictive intersection** of both gates per `docs/design-policy-cutover.md` §9.1 (security default, NOT new-system-wins). Disagreements emit `system.access.disagreement` envelopes so the operator can validate the migration on the dashboard BEFORE cortex#297 retires the legacy gate.

Closes #296

## Intersection-wins contract (§9.1)

For each capability the legacy gate decides on (currently `keyword.{chat,async,team}` + optional `operator` short-circuit), parallel mode ALSO consults `PolicyEngine.check(principalId, intent)`. Effective decision = `legacy.allow && new.allow`. When the two gates disagree, a `system.access.disagreement` envelope is published with both verdicts, both reasons, and the effective (intersection) decision. The dangerous direction (legacy-allow + new-deny → effective deny) and the breakage direction (legacy-deny + new-allow → effective deny) are both surfaced for operator visibility.

## Operator pre-flight requirement

`policy.parallel_mode_enabled` defaults to `false` so existing deployments behave exactly as before. Operators MUST run `migrate-config --check` (cortex#295) before flipping to `true` — without the pre-flight, intersection-wins denies every previously-authorised user not yet mapped to a `policy.principals[]` entry. The flag is opt-in deliberately so operators commit to parallel-mode rollout after they've validated the migration locally.

§9.1 explicitly states 242a depends on 243a only — parallel mode is testable against LEGACY-only configs. The operator's `~/.config/cortex/cortex.yaml` continues to boot cleanly with the flag defaulted off.

## New envelope type

`system.access.disagreement` lives in `src/bus/system-events.ts` alongside the C.4 `system.access.{allowed,denied}` siblings. Wire shape mirrors the C.4 envelopes (same `principal_id` / `capability` / `intent_sovereignty` / `envelope_id` / `envelope_subject` / `signed_by` payload fields plus `legacy_decision` / `legacy_reason` / `new_decision` / `new_reason` / `effective_decision`) so dashboard renderers handling the `system.access.>` subject family can slot this in with minimal branching.

## Schema delta

One additive flag: `PolicySchema.parallel_mode_enabled: z.boolean().default(false)`. No removals. No changes to existing principal/role schemas. `migrate-config` and operator configs are unaffected.

## Capability mapping (per §12.1)

- `features.{chat,async,team}` → `keyword.{chat,async,team}` capability
- DM-operator short-circuit → `operator` capability
- `allowedDirs` / `allowedSkills` / `bashAllowlist` deliberately **NOT** gated by PolicyEngine — those are session-construction concerns that live on `session_config` per §5.3. **Note for cortex#297's implementer:** session_config field MATCHING between legacy + new is part of cutover validation but is intentionally out of scope for parallel-mode (this PR). Parallel mode only validates capabilities, not session shape.

## Graceful degradation

When `parallel_mode_enabled: true` but `policyEngine`/`policyLookup` is unwired (deployment hasn't declared a `policy:` block yet), the adapter logs a one-time ERROR and falls back to legacy-only — no deployment is blocked on a config gap.

## Ambiguity-resolution notes

These judgment calls were made (per task spec, surfacing for review):

- **Principal resolution with empty `platform_ids`:** Principals without a `platform_ids` entry for the inbound platform cannot be resolved via `(platform, message.author.id)` lookup. The lookup returns `undefined`, the new gate returns `unknown_principal`, and parallel mode emits a disagreement envelope per capability the legacy gate allowed. Operator pre-flight (`migrate-config --check`) catches this case, but parallel mode still surfaces it post-activation in case operators skip the pre-flight.
- **No principal at all in `policy.principals[]`:** Same as above — `unknown_principal` deny + disagreement envelope for every legacy-allowed capability.
- **DM-operator short-circuit:** The legacy fast path for `dm.operatorRole` runs in `legacyResolveAccess` and produces the full-features decision. Parallel mode wraps it so the disagreement envelope still fires if the new gate is mis-configured (e.g. operator principal missing the `operator` capability).
- **Tool-level checks:** Helper `buildToolCapabilityChecks` is exported for future use but not wired into adapters today. Keyword-level disagreement surfacing is sufficient validation for the parallel-mode window; tool-level would be chatty (~30 capabilities × every message).

## Test plan

- [x] `bunx tsc --noEmit` clean (exit 0)
- [x] `bun run lint:errors` clean (exit 0)
- [x] `bun test` — 3314 pass, 1 skip, 0 fail (full suite)
- [x] `bun test src/adapters/ src/common/policy/ src/bus/__tests__/system-events.test.ts` — 442 pass
- [x] Operator's `~/.config/cortex/cortex.yaml` boots cleanly with `parallel_mode_enabled` defaulted off (no `policy:` block required)
- [x] Both-allow → effective allow, no disagreement envelope (Discord/MM/Slack)
- [x] Both-deny → effective deny, no disagreement envelope (Discord/MM/Slack)
- [x] Legacy-allow + new-deny → effective deny + disagreement envelope (Discord/MM/Slack)
- [x] Legacy-deny + new-allow → effective deny + disagreement envelope (Discord/MM/Slack)
- [x] `parallel_mode_enabled: false` → no PolicyEngine call (Discord/MM/Slack)
- [x] `parallel_mode_enabled: true` but no engine wired → ERROR log + legacy fallback (Discord/MM/Slack)
- [x] Disagreement envelope schema fields populated correctly (Discord)
- [x] Emitted envelope passes myelin schema validation (Discord/MM/Slack)
- [x] Unit tests on `PlatformPrincipalIndex`, `runParallelModeChecks`, `mergeCapabilityDecision`
- [x] Schema test pins `parallel_mode_enabled` default-off + type-rejection of non-boolean

## Retirement

cortex#297 (C.2b-242b) removes both the flag AND the parallel-mode plumbing — PolicyEngine becomes the sole gate; this envelope type and `src/common/policy/parallel-mode.ts` retire alongside `src/adapters/discord/role-resolver.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)