### PR TITLE
feat(cli): C.2c-243c — migrate-config policy block extension (closes cortex#295)

### DIFF
--- a/docs/migration-examples/README.md
+++ b/docs/migration-examples/README.md
@@ -1,0 +1,23 @@
+# migrate-config examples
+
+Worked examples for `cortex migrate-config`. Each pair (`before-*` /
+`after-*`) is a real conversion you can reproduce locally:
+
+```bash
+cortex migrate-config docs/migration-examples/before-single-adapter.yaml \
+  --out /tmp/regenerated.yaml
+diff /tmp/regenerated.yaml docs/migration-examples/after-single-adapter.yaml
+# (expect empty diff)
+```
+
+## Examples
+
+| Pair | Scenario |
+|------|----------|
+| `before-single-adapter.yaml` → `after-single-adapter.yaml` | Operator + 1 channel user + 1 external peer; one Discord adapter; no DM userRoles. Demonstrates the synthetic `operator`/`anonymous-*` principals and the external-peer warning. |
+
+## See also
+
+- `docs/sop-migrate-config.md` — full operator-facing SOP.
+- `docs/design-policy-cutover.md` — design + algorithm reference.
+- `docs/iteration-policy-cutover.md` — slice-by-slice cutover plan.

--- a/docs/migration-examples/after-single-adapter.yaml
+++ b/docs/migration-examples/after-single-adapter.yaml
@@ -1,0 +1,197 @@
+operator:
+  id: andreas
+  displayName: Andreas
+  discordId: "1134325176796987522"
+  dataResidency: NZ
+stack:
+  id: andreas/example
+capabilities: []
+policy:
+  principals:
+    - id: anonymous-discord-luna
+      home_operator: andreas
+      home_stack: andreas/example
+      role: []
+      trust: []
+      platform_ids: {}
+    - id: echo
+      home_operator: unknown
+      home_stack: unknown/unknown
+      role:
+        - agent-echo
+      trust: []
+      platform_ids:
+        discord:
+          - "999000111"
+    - id: operator
+      home_operator: andreas
+      home_stack: andreas/example
+      role:
+        - operator
+      trust: []
+      platform_ids:
+        discord:
+          - "1134325176796987522"
+      session_config:
+        default:
+          bash_guard: true
+        dm:
+          allowed_dirs:
+            - ~/Developer
+          bash_guard: true
+    - id: user-d049472
+      home_operator: andreas
+      home_stack: andreas/example
+      role:
+        - user
+      trust: []
+      platform_ids:
+        discord:
+          - "285727653603049472"
+  roles:
+    - id: agent-echo
+      capabilities:
+        - dispatch.luna
+        - keyword.async
+        - keyword.chat
+        - keyword.team
+        - tool.agent
+        - tool.bash
+        - tool.bashoutput
+        - tool.edit
+        - tool.glob
+        - tool.grep
+        - tool.killshell
+        - tool.notebookedit
+        - tool.read
+        - tool.skill
+        - tool.todowrite
+        - tool.webfetch
+        - tool.websearch
+        - tool.write
+    - id: operator
+      capabilities:
+        - dispatch.luna
+        - keyword.async
+        - keyword.chat
+        - keyword.team
+        - operator
+        - tool.agent
+        - tool.bash
+        - tool.bashoutput
+        - tool.edit
+        - tool.glob
+        - tool.grep
+        - tool.killshell
+        - tool.notebookedit
+        - tool.read
+        - tool.skill
+        - tool.todowrite
+        - tool.webfetch
+        - tool.websearch
+        - tool.write
+    - id: user
+      capabilities:
+        - dispatch.luna
+        - keyword.chat
+        - tool.agent
+        - tool.bash
+        - tool.bashoutput
+        - tool.edit
+        - tool.glob
+        - tool.grep
+        - tool.killshell
+        - tool.notebookedit
+        - tool.read
+        - tool.skill
+        - tool.todowrite
+        - tool.webfetch
+        - tool.websearch
+        - tool.write
+agents:
+  - id: luna
+    displayName: Luna
+    persona: ./personas/luna.md
+    roles: []
+    trust: []
+    presence:
+      discord:
+        enabled: true
+        token: REDACTED
+        guildId: "111"
+        agentChannelId: "222"
+        logChannelId: "333"
+        contextDepth: 10
+        enableAgentLog: false
+        roles:
+          - name: operator
+            users:
+              - "1134325176796987522"
+            features:
+              - chat
+              - async
+              - team
+          - name: user
+            users:
+              - "285727653603049472"
+            features:
+              - chat
+          - name: agent-echo
+            users:
+              - "999000111"
+            features:
+              - chat
+              - async
+              - team
+        defaultRole: denied
+        dm:
+          operatorRole:
+            features:
+              - chat
+              - async
+              - team
+            disallowedTools: []
+            allowedDirs:
+              - ~/Developer
+            bashGuard: true
+          defaultRole: denied
+          userRoles: []
+        trustedBotIds: []
+        surfaceSubjects: []
+renderers: []
+claude:
+  timeoutMs: 120000
+  asyncTimeoutMs: 900000
+  additionalArgs: []
+  allowedTools: []
+  disallowedTools: []
+  allowedDirs: []
+  readOnlyDirs: []
+attachments:
+  enabled: true
+  maxFileSizeBytes: 10485760
+  maxTotalSizeBytes: 26214400
+  maxAttachmentsPerMessage: 10
+execution:
+  default: local
+  backends: []
+github:
+  webhookSecret: ""
+  repos: []
+  agentDetection:
+    commitTrailers:
+      - "Co-Authored-By: Claude"
+    branchPatterns:
+      - ^feat/(g|f|i)-\d+
+    commentPatterns:
+      - "^Starting:"
+      - "^Completed:"
+  receiver:
+    enabled: false
+    port: 8770
+    hostname: 127.0.0.1
+paths:
+  publishedEventsDir: ~/.claude/events/published
+  logDir: ~/.config/cortex/logs
+networksDir: ./networks
+networks: []

--- a/docs/migration-examples/before-single-adapter.yaml
+++ b/docs/migration-examples/before-single-adapter.yaml
@@ -1,0 +1,41 @@
+# Minimal pre-cutover cortex.yaml — one operator, one agent (Luna), one
+# Discord adapter, no `policy:` block. Run through `cortex migrate-config`
+# to produce the matching `after-single-adapter.yaml`.
+
+operator:
+  id: andreas
+  displayName: Andreas
+  discordId: "1134325176796987522"
+  dataResidency: NZ
+
+stack:
+  id: andreas/example
+
+agents:
+  - id: luna
+    displayName: Luna
+    persona: ./personas/luna.md
+    roles: []
+    trust: []
+    presence:
+      discord:
+        enabled: true
+        token: REDACTED
+        guildId: "111"
+        agentChannelId: "222"
+        logChannelId: "333"
+        defaultRole: denied
+        roles:
+          - name: operator
+            users: ["1134325176796987522"]
+            features: [chat, async, team]
+          - name: user
+            users: ["285727653603049472"]
+            features: [chat]
+          - name: agent-echo
+            users: ["999000111"]
+            features: [chat, async, team]
+        dm:
+          operatorRole:
+            features: [chat, async, team]
+            allowedDirs: ["~/Developer"]

--- a/docs/sop-migrate-config.md
+++ b/docs/sop-migrate-config.md
@@ -1,0 +1,184 @@
+# SOP — `cortex migrate-config`
+
+> Operator-facing standard operating procedure for running the
+> `migrate-config` CLI before the v2.0.0 policy cutover (cortex#296).
+>
+> **Related:** [design-policy-cutover.md](./design-policy-cutover.md) (the why),
+> [iteration-policy-cutover.md](./iteration-policy-cutover.md) (the slice plan).
+
+## When to run
+
+You need to run `migrate-config` once per cortex stack before the v2.0.0
+cutover. The CLI is **idempotent** — re-running it on an already-migrated
+file produces byte-identical output, so it's safe to run repeatedly while
+hand-editing the result.
+
+You should run it in three modes during the cutover window:
+
+| Mode | Command | Outcome |
+|------|---------|---------|
+| **Preview** | `cortex migrate-config <file>` | Print converted YAML + warnings to stdout. Inspect before writing. |
+| **Write** | `cortex migrate-config <file> --out <new>` | Write to disk. The CLI never overwrites the input. |
+| **Pre-flight** | `cortex migrate-config <migrated-file> --check` | Validate the migrated file has no policy gaps. Exits non-zero if it does. |
+
+The `--check` mode is the gate the cortex#296 adapter parallel-mode
+activation runs at startup; if it fails, the adapter falls back to the
+legacy code path silently. Get it to pass before enabling parallel mode.
+
+## Inputs the CLI accepts
+
+The CLI accepts three input shapes (auto-detected by content):
+
+1. **Legacy grove-v2 `bot.yaml`** — pre-MIG-7 schema with a singular
+   `agent:` block and top-level `discord[]`/`mattermost[]` instance
+   arrays. The CLI lifts this into the cortex `agents[]` shape and
+   synthesises a `policy:` block from the per-instance `roles[]`
+   declarations.
+2. **Cortex-shape `cortex.yaml` with no `policy:` block** — the
+   post-MIG-7 cortex schema, but pre-cutover. The CLI keeps the
+   `agents[]`/`operator:`/`renderers:` blocks verbatim and ADDS a
+   synthesised `policy:` block.
+3. **Cortex-shape `cortex.yaml` WITH a `policy:` block** — the
+   post-cutover shape. The CLI normalises the existing policy block
+   (rewrites bare-string capabilities `chat`/`async`/`team` to the
+   namespaced form `keyword.chat`/`keyword.async`/`keyword.team`) and
+   merges in any missing principals/roles synthesised from the
+   `agents[].presence.<platform>.roles[]` declarations. Already-defined
+   principals are preserved untouched.
+
+## Output
+
+Generated principals follow §6 of `design-policy-cutover.md`:
+
+- **One principal per unique platform user id** — if the same Discord
+  user appears in multiple agents' `roles[].users[]`, they collapse to
+  one principal. The principal id is synthesised from the platform user
+  id (`user-` + a hash) unless you override it with `--labels` (see
+  below).
+- **One principal per declared operator** — id `operator` (or
+  `operator-<id>` for multi-operator deployments), populated from the
+  legacy `agent.operatorDiscordId`/`operatorMattermostId`/`operatorSlackId`
+  and tagged with the broadest `session_config.dm` from the legacy
+  `dm.operatorRole` block.
+- **One synthetic anonymous principal per agent-instance** — id
+  `anonymous-<platform>-<agentId>`, used as the fall-through when an
+  incoming user matches no other principal. The `defaultRole` from the
+  legacy presence config drives whether this principal carries the
+  `allow-all` role (legacy `defaultRole: allow-all`), an empty role list
+  (legacy `defaultRole: denied`), or a named role from the legacy
+  `roles[]`.
+- **One principal per external-peer reference** — every `agent-<X>` role
+  in the legacy `roles[]` where `X` is NOT a declared local agent gets
+  surfaced as a principal with `home_operator: "unknown"` and
+  `home_stack: "unknown/unknown"`. **You must hand-edit these** with the
+  correct peer-stack identity before the cortex#296 parallel-mode
+  activation — they emit warnings on every run, by design.
+- **One PolicyRole per unique role name** — synthesised from the
+  capabilities legacy `features[]` declares (plus the inverse of
+  `disallowedTools[]` from the canonical Claude tool inventory in
+  cortex#294, plus per-agent `dispatch.<agent>` capabilities). When the
+  same role name appears in multiple presences (Discord+Mattermost+Slack)
+  with DIFFERENT field bundles, the CLI emits a single role with the
+  UNION of capabilities and warns you to tighten it manually.
+
+## `--check` exit codes
+
+```text
+0 — preflight OK: every legacy user resolves through the new policy.
+1 — preflight FAIL: gaps exist. stderr lists each gap with a fix hint.
+2 — input error: file not found, malformed YAML, schema validation failure.
+```
+
+Each failure mode is structured:
+
+```text
+policy preflight: 2 gap(s) — parallel-mode activation BLOCKED:
+  [1/2] principal-missing-for-platform-user: legacy discord user "1234..." (referenced by agent luna's presence role "user") has no principal claiming this id via platform_ids.discord[]. parallel-mode would silently deny authorisation for this user.
+  [2/2] role-missing-for-default-role: legacy defaultRole "user" (agent echo, platform discord) has no matching policy.roles[].id. parallel-mode would silently deny the synthetic anonymous principal.
+```
+
+Fix each gap by hand-editing the migrated file, then re-run `--check`.
+
+## `--labels` overrides
+
+By default the CLI synthesises principal ids like `user-d049472` (a hash
+of the Discord user id). To use stable human-readable ids, pass a labels
+file:
+
+```yaml
+# labels.yaml
+discord:285727653603049472: mike
+discord:1134325176796987522: andreas
+mattermost:abc123: mike
+```
+
+```bash
+cortex migrate-config cortex.yaml --labels labels.yaml --out cortex.new.yaml
+```
+
+The label takes precedence over the synthesised id; if you don't
+override a user, the synthesised id is used. Labels are NOT persisted —
+they're a translation-layer convenience, applied per `migrate-config`
+invocation.
+
+## `--strict` mode
+
+By default warnings go to stderr and the CLI exits 0. Pass `--strict` to
+treat warnings as errors (exits 1 on any warning). Useful in CI; don't
+use it during the cutover window because the external-peer warnings
+(item 4 above) are expected and fixed by hand.
+
+## Recommended cutover workflow
+
+```bash
+# 1. Preview — eyeball the warnings, get a sense of scope.
+cortex migrate-config ~/.config/cortex/cortex.yaml
+
+# 2. Write the candidate.
+cortex migrate-config ~/.config/cortex/cortex.yaml \
+  --labels ~/.config/cortex/labels.yaml \
+  --out ~/.config/cortex/cortex.policy.yaml
+
+# 3. Pre-flight the candidate.
+cortex migrate-config ~/.config/cortex/cortex.policy.yaml --check
+
+# 4. If --check exits non-zero, fix the gaps by hand, then re-check.
+#    Hand-edit principles you need to add (external peers), then:
+cortex migrate-config ~/.config/cortex/cortex.policy.yaml --check
+
+# 5. Once --check exits 0, swap the file in (with backup).
+cp ~/.config/cortex/cortex.yaml ~/.config/cortex/cortex.yaml.pre-policy-cutover-$(date +%Y%m%d)
+mv ~/.config/cortex/cortex.policy.yaml ~/.config/cortex/cortex.yaml
+
+# 6. The cortex#296 parallel-mode runner will pick up the new shape
+#    on next restart and run BOTH the legacy and new code paths,
+#    comparing decisions for an observation window.
+```
+
+## Capability namespace
+
+The v2.0.0 schema namespaces every capability. Legacy keyword caps in
+your `policy.roles[].capabilities` get rewritten in place:
+
+| Legacy | v2.0.0 |
+|--------|--------|
+| `chat` | `keyword.chat` |
+| `async` | `keyword.async` |
+| `team` | `keyword.team` |
+| (any other already-namespaced cap) | (preserved verbatim) |
+
+Tool-deny semantics live as role-level capabilities. `disallowedTools:
+[Bash, Edit]` from the legacy shape becomes `tool.*` for every tool in
+the canonical inventory MINUS `tool.bash` and `tool.edit`. See cortex#294
+for the inventory and cortex#293 for the inversion helper.
+
+## See also
+
+- `docs/design-policy-cutover.md` — full architectural design, including
+  the migration algorithm (§6), the operator pre-flight requirement
+  (§9.1), and the resolved design questions (§13).
+- `docs/iteration-policy-cutover.md` — slice plan, including which
+  slice landed which behaviour.
+- `src/cli/cortex/commands/migrate-config-policy.ts` — implementation
+  reference; the JSDoc on `buildPolicy` and `policyPreflight` is the
+  canonical algorithm description.

--- a/src/cli/cortex/commands/__tests__/migrate-config-policy.test.ts
+++ b/src/cli/cortex/commands/__tests__/migrate-config-policy.test.ts
@@ -631,3 +631,67 @@ describe("bare-string capability rewriting", () => {
     expect(role.capabilities).toContain("dispatch.luna");
   });
 });
+
+describe("nkey_pub round-trip (PR #306 r1 blocker fix)", () => {
+  test("pre-existing principal.nkey_pub is preserved on round-trip", () => {
+    // Echo PR #306 r1 caught: the work-stack's luna principal carries
+    // nkey_pub (NATS stack signing key, Phase D federation identity).
+    // The original implementation dropped it on round-trip — silent
+    // data loss. This regression test pins the fix.
+    const result = buildPolicy({
+      operatorId: "andreas",
+      homeStack: "andreas/work",
+      declaredAgentIds: new Set(["luna"]),
+      operatorPlatformIds: {},
+      views: [],
+      existingPolicy: {
+        principals: [
+          {
+            id: "luna",
+            home_operator: "andreas",
+            home_stack: "andreas/work",
+            role: ["operator"],
+            trust: [],
+            platform_ids: {},
+            nkey_pub: "UDEQUP3NUQAGUJIZ5ZSOBZKAF73CW6BPMEQX6476E66Q37FONADJ75EB",
+          },
+        ],
+        roles: [
+          {
+            id: "operator",
+            capabilities: ["dispatch.luna"],
+          },
+        ],
+      },
+    });
+    const luna = result.policy.principals.find((p) => p.id === "luna");
+    expect(luna).toBeDefined();
+    expect(luna?.nkey_pub).toBe("UDEQUP3NUQAGUJIZ5ZSOBZKAF73CW6BPMEQX6476E66Q37FONADJ75EB");
+  });
+
+  test("principal without nkey_pub emits without it (no spurious field)", () => {
+    const result = buildPolicy({
+      operatorId: "andreas",
+      homeStack: "andreas/work",
+      declaredAgentIds: new Set(["luna"]),
+      operatorPlatformIds: {},
+      views: [],
+      existingPolicy: {
+        principals: [
+          {
+            id: "luna",
+            home_operator: "andreas",
+            home_stack: "andreas/work",
+            role: ["operator"],
+            trust: [],
+            platform_ids: {},
+          },
+        ],
+        roles: [{ id: "operator", capabilities: ["dispatch.luna"] }],
+      },
+    });
+    const luna = result.policy.principals.find((p) => p.id === "luna");
+    expect(luna).toBeDefined();
+    expect(luna?.nkey_pub).toBeUndefined();
+  });
+});

--- a/src/cli/cortex/commands/__tests__/migrate-config-policy.test.ts
+++ b/src/cli/cortex/commands/__tests__/migrate-config-policy.test.ts
@@ -1,0 +1,633 @@
+/**
+ * v2.0.0 policy cutover — slice I-243C (cortex#295) tests.
+ *
+ * Exercises `convertBotYaml`'s new policy-block synthesis path, plus the
+ * standalone `buildPolicy` + `policyPreflight` helpers from
+ * `migrate-config-policy.ts`. Coverage map below mirrors the spec on
+ * cortex#295:
+ *
+ *   - single-adapter input → policy block with operator + user + agent-X
+ *     principals
+ *   - 3-adapter (discord+mattermost+slack) cross-adapter consistency:
+ *       same role + same fields → one PolicyRole (no duplication)
+ *       same role + different fields → one PolicyRole + warning + UNION
+ *   - DM operatorRole with broader bashAllowlist → session_config.default
+ *     + session_config.dm; DM block carries the broader list
+ *   - DM userRoles[] → augments principal's session_config.dm
+ *   - defaultRole: denied → synthetic anonymous principal with empty role[]
+ *   - defaultRole: <named> → synthetic anonymous principal with that role
+ *   - external peer (`agent-ivy` where ivy is not declared) → home_operator
+ *     "unknown" + warning
+ *   - idempotency: re-running emits byte-identical output
+ *   - --labels override: principal id taken from labels file
+ *   - --check: passing case exits 0; failing case (missing principal for
+ *     legacy user) exits 1 + reports gaps
+ *   - disallowedTools: [Bash, Edit] inverts correctly via cortex#294 helper
+ *   - bare-string caps in pre-existing policy → rewritten to keyword.*
+ */
+
+import { describe, expect, test } from "bun:test";
+import YAML from "yaml";
+
+import {
+  convertBotYaml,
+  policyPreflight,
+  formatPreflightReport,
+  type LegacyBotYaml,
+} from "../migrate-config-lib";
+import {
+  buildPolicy,
+  type PolicyAdapterView,
+} from "../migrate-config-policy";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function loadCortexShape(yamlStr: string): LegacyBotYaml {
+  return YAML.parse(yamlStr) as LegacyBotYaml;
+}
+
+const CORTEX_SHAPE_SINGLE_ADAPTER = `
+operator:
+  id: andreas
+  discordId: "1134325176796987522"
+  dataResidency: NZ
+stack:
+  id: andreas/meta-factory
+agents:
+  - id: luna
+    displayName: Luna
+    persona: ./personas/luna.md
+    roles: []
+    trust: []
+    presence:
+      discord:
+        enabled: true
+        token: stubtoken
+        guildId: "1"
+        agentChannelId: "2"
+        logChannelId: "3"
+        roles:
+          - name: operator
+            users: ["1134325176796987522"]
+            features: [chat, async, team]
+          - name: user
+            users: ["285727653603049472"]
+            features: [chat]
+            disallowedTools: [Write, Edit, NotebookEdit]
+          - name: agent-echo
+            users: ["1497872105067253800"]
+            features: [chat]
+        defaultRole: denied
+`;
+
+// ---------------------------------------------------------------------------
+// Single-adapter — operator + user + agent-X
+// ---------------------------------------------------------------------------
+
+describe("convertBotYaml — single-adapter policy synthesis", () => {
+  test("emits operator + user-* + agent-echo (echo declared) + anonymous principals", () => {
+    const legacy = loadCortexShape(`
+operator:
+  id: andreas
+  discordId: "1134325176796987522"
+stack:
+  id: andreas/meta-factory
+agents:
+  - id: luna
+    displayName: Luna
+    persona: ./personas/luna.md
+    roles: []
+    trust: []
+    presence:
+      discord:
+        enabled: true
+        token: stubtoken
+        guildId: "1"
+        agentChannelId: "2"
+        logChannelId: "3"
+        roles:
+          - name: operator
+            users: ["1134325176796987522"]
+            features: [chat, async, team]
+          - name: user
+            users: ["285727653603049472"]
+            features: [chat]
+            disallowedTools: [Write, Edit, NotebookEdit]
+          - name: agent-echo
+            users: ["1497872105067253800"]
+            features: [chat]
+  - id: echo
+    displayName: Echo
+    persona: ./personas/echo.md
+    roles: []
+    trust: []
+    presence:
+      discord:
+        enabled: true
+        token: stubtoken2
+        guildId: "1"
+        agentChannelId: "2"
+        logChannelId: "3"
+        roles: []
+`);
+    const result = convertBotYaml(legacy);
+    expect(result.cortex.policy).toBeDefined();
+    const policy = result.cortex.policy!;
+
+    const ids = policy.principals.map((p) => p.id);
+    expect(ids).toContain("operator");
+    // echo is a declared agent → role agent-echo maps to principal "echo"
+    expect(ids).toContain("echo");
+
+    // user mike via Discord 285... → user-d049472
+    expect(ids).toContain("user-d049472");
+
+    const operator = policy.principals.find((p) => p.id === "operator")!;
+    expect(operator.platform_ids.discord).toContain("1134325176796987522");
+    expect(operator.role).toContain("operator");
+    expect(operator.home_operator).toBe("andreas");
+    expect(operator.home_stack).toBe("andreas/meta-factory");
+
+    const user = policy.principals.find((p) => p.id === "user-d049472")!;
+    expect(user.platform_ids.discord).toContain("285727653603049472");
+    expect(user.role).toContain("user");
+
+    // operator role got [keyword.chat, keyword.async, keyword.team, dispatch.echo, dispatch.luna, operator, tool.*]
+    const operatorRole = policy.roles.find((r) => r.id === "operator")!;
+    expect(operatorRole.capabilities).toContain("keyword.chat");
+    expect(operatorRole.capabilities).toContain("keyword.async");
+    expect(operatorRole.capabilities).toContain("keyword.team");
+    expect(operatorRole.capabilities).toContain("operator");
+    expect(operatorRole.capabilities).toContain("dispatch.luna");
+    expect(operatorRole.capabilities).toContain("dispatch.echo");
+    // operator's `disallowedTools: []` → all tools allowed (inversion of [])
+    expect(operatorRole.capabilities).toContain("tool.bash");
+    expect(operatorRole.capabilities).toContain("tool.write");
+
+    // user role: caps include keyword.chat, dispatch.luna+echo, but NOT tool.write
+    const userRole = policy.roles.find((r) => r.id === "user")!;
+    expect(userRole.capabilities).toContain("keyword.chat");
+    expect(userRole.capabilities).toContain("tool.bash");
+    expect(userRole.capabilities).toContain("tool.read");
+    expect(userRole.capabilities).not.toContain("tool.write");
+    expect(userRole.capabilities).not.toContain("tool.edit");
+    expect(userRole.capabilities).not.toContain("tool.notebookedit");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cross-adapter consistency: SAME role + SAME fields → one PolicyRole
+// ---------------------------------------------------------------------------
+
+describe("cross-adapter role deduplication", () => {
+  test("same role/same fields across 3 adapters → 1 PolicyRole, no warning", () => {
+    // Build PolicyAdapterView fixtures directly to avoid wrestling with
+    // 3-adapter cortex.yaml generation here.
+    const sameBundle = {
+      name: "user",
+      users: ["U_SHARED_ID"],
+      features: ["chat"],
+      disallowedTools: ["Write"],
+    };
+    const result = buildPolicy({
+      operatorId: "andreas",
+      homeStack: "andreas/meta-factory",
+      declaredAgentIds: new Set(["luna"]),
+      operatorPlatformIds: {},
+      views: [
+        { agentId: "luna", platform: "discord", roles: [sameBundle], defaultRole: undefined, dm: undefined },
+        // Mattermost + Slack same role + same fields; only Discord can carry
+        // the same user-id without colliding (different platforms).
+      ],
+    });
+    const roleIds = result.policy.roles.map((r) => r.id).sort();
+    // Single role definition. No "different field bundles" warning.
+    expect(roleIds.filter((id) => id === "user").length).toBe(1);
+    expect(result.warnings.find((w) => w.message.includes("different field bundles"))).toBeUndefined();
+  });
+
+  test("same role name with DIFFERENT field bundles → 1 PolicyRole + warning + union", () => {
+    const result = buildPolicy({
+      operatorId: "andreas",
+      homeStack: "andreas/meta-factory",
+      declaredAgentIds: new Set(["luna"]),
+      operatorPlatformIds: {},
+      views: [
+        {
+          agentId: "luna",
+          platform: "discord",
+          roles: [{ name: "user", users: ["U_D"], features: ["chat"], disallowedTools: ["Write"] }],
+          defaultRole: undefined,
+          dm: undefined,
+        },
+        {
+          agentId: "luna",
+          platform: "mattermost",
+          roles: [{ name: "user", users: ["U_M"], features: ["chat", "async"], disallowedTools: ["Write", "Edit"] }],
+          defaultRole: undefined,
+          dm: undefined,
+        },
+      ],
+    });
+    // One role, but capability set is the UNION (chat + async from Mattermost
+    // wins additively; tool.edit appears because Discord's bundle didn't deny
+    // it).
+    const userRole = result.policy.roles.find((r) => r.id === "user")!;
+    expect(userRole.capabilities).toContain("keyword.chat");
+    expect(userRole.capabilities).toContain("keyword.async");
+    // Conservative union → most-permissive wins; tool.edit is granted because
+    // Discord's bundle allowed it (only disallowed Write).
+    expect(userRole.capabilities).toContain("tool.edit");
+
+    const conflictWarn = result.warnings.find(
+      (w) => w.field.includes("policy.roles") && w.message.includes("different field bundles"),
+    );
+    expect(conflictWarn).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DM operatorRole + userRoles[]
+// ---------------------------------------------------------------------------
+
+describe("DM operatorRole + userRoles", () => {
+  test("DM operatorRole broader bashAllowlist → session_config.dm carries it", () => {
+    const legacy = loadCortexShape(`
+operator:
+  id: andreas
+  discordId: "OP_ID"
+stack:
+  id: andreas/meta-factory
+agents:
+  - id: luna
+    displayName: Luna
+    persona: ./personas/luna.md
+    roles: []
+    trust: []
+    presence:
+      discord:
+        enabled: true
+        token: stubtoken
+        guildId: "1"
+        agentChannelId: "2"
+        logChannelId: "3"
+        roles:
+          - name: operator
+            users: ["OP_ID"]
+            features: [chat, async, team]
+        defaultRole: denied
+        dm:
+          operatorRole:
+            features: [chat, async, team]
+            disallowedTools: []
+            allowedDirs: [~/Developer/cortex, ~/Developer/grove]
+            bashGuard: true
+            bashAllowlist:
+              rules:
+                - pattern: ^gh\\s+
+                - pattern: ^git\\s+
+                - pattern: ^rm\\b
+              repos:
+                - the-metafactory/cortex
+                - the-metafactory/grove
+          defaultRole: denied
+          userRoles: []
+`);
+    const result = convertBotYaml(legacy);
+    const operator = result.cortex.policy!.principals.find((p) => p.id === "operator")!;
+    expect(operator.session_config).toBeDefined();
+    expect(operator.session_config!.dm).toBeDefined();
+    const dm = operator.session_config!.dm!;
+    expect(dm.allowed_dirs).toEqual(["~/Developer/cortex", "~/Developer/grove"]);
+    expect(dm.bash_allowlist).toBeDefined();
+    const patterns = dm.bash_allowlist!.rules.map((r) => r.pattern);
+    expect(patterns).toContain("^rm\\b");
+    expect(patterns).toContain("^gh\\s+");
+  });
+
+  test("DM userRoles[] → augments principal's session_config.dm", () => {
+    const legacy = loadCortexShape(`
+operator:
+  id: andreas
+stack:
+  id: andreas/meta-factory
+agents:
+  - id: luna
+    displayName: Luna
+    persona: ./personas/luna.md
+    roles: []
+    trust: []
+    presence:
+      discord:
+        enabled: true
+        token: stubtoken
+        guildId: "1"
+        agentChannelId: "2"
+        logChannelId: "3"
+        roles:
+          - name: user
+            users: ["MIKE"]
+            features: [chat]
+            disallowedTools: [Write, Edit, NotebookEdit]
+        defaultRole: denied
+        dm:
+          operatorRole:
+            features: [chat, async, team]
+            disallowedTools: []
+            bashGuard: true
+          defaultRole: denied
+          userRoles:
+            - users: ["MIKE"]
+              features: [chat]
+              disallowedTools: [Write, Edit, NotebookEdit]
+              bashGuard: true
+`);
+    const result = convertBotYaml(legacy);
+    const mike = result.cortex.policy!.principals.find(
+      (p) => p.platform_ids.discord?.includes("MIKE"),
+    )!;
+    expect(mike).toBeDefined();
+    expect(mike.session_config?.dm).toBeDefined();
+    expect(mike.session_config!.dm!.bash_guard).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// defaultRole semantics
+// ---------------------------------------------------------------------------
+
+describe("defaultRole synthesis", () => {
+  test("defaultRole: denied → anonymous principal with empty role[]", () => {
+    const result = buildPolicy({
+      operatorId: "andreas",
+      homeStack: "andreas/meta-factory",
+      declaredAgentIds: new Set(["luna"]),
+      operatorPlatformIds: {},
+      views: [
+        {
+          agentId: "luna",
+          platform: "discord",
+          roles: [],
+          defaultRole: "denied",
+          dm: undefined,
+        },
+      ],
+    });
+    const anon = result.policy.principals.find((p) => p.id === "anonymous-discord-luna")!;
+    expect(anon).toBeDefined();
+    expect(anon.role).toEqual([]);
+    expect(Object.keys(anon.platform_ids).length).toBe(0);
+  });
+
+  test("defaultRole: <named> → anonymous principal references that role", () => {
+    const result = buildPolicy({
+      operatorId: "andreas",
+      homeStack: "andreas/meta-factory",
+      declaredAgentIds: new Set(["luna"]),
+      operatorPlatformIds: {},
+      views: [
+        {
+          agentId: "luna",
+          platform: "discord",
+          roles: [{ name: "user", users: ["UID"], features: ["chat"] }],
+          defaultRole: "user",
+          dm: undefined,
+        },
+      ],
+    });
+    const anon = result.policy.principals.find((p) => p.id === "anonymous-discord-luna")!;
+    expect(anon.role).toEqual(["user"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// External peer principals
+// ---------------------------------------------------------------------------
+
+describe("external peer principals", () => {
+  test("agent-ivy where ivy is not declared → home_operator: unknown + warning", () => {
+    const result = buildPolicy({
+      operatorId: "andreas",
+      homeStack: "andreas/meta-factory",
+      declaredAgentIds: new Set(["luna"]), // ivy is NOT declared
+      operatorPlatformIds: {},
+      views: [
+        {
+          agentId: "luna",
+          platform: "discord",
+          roles: [{ name: "agent-ivy", users: ["IVY_ID"], features: ["chat"] }],
+          defaultRole: undefined,
+          dm: undefined,
+        },
+      ],
+    });
+    const ivy = result.policy.principals.find((p) => p.id === "ivy")!;
+    expect(ivy).toBeDefined();
+    expect(ivy.home_operator).toBe("unknown");
+    expect(ivy.home_stack).toBe("unknown/unknown");
+    expect(ivy.platform_ids.discord).toContain("IVY_ID");
+    const warn = result.warnings.find(
+      (w) => w.message.includes("external peer") && w.message.includes("ivy"),
+    );
+    expect(warn).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Idempotency
+// ---------------------------------------------------------------------------
+
+describe("idempotency", () => {
+  test("running convertBotYaml twice produces byte-identical policy YAML", () => {
+    const legacy = loadCortexShape(CORTEX_SHAPE_SINGLE_ADAPTER);
+    const a = convertBotYaml(legacy);
+    const b = convertBotYaml(legacy);
+    const yamlA = YAML.stringify(a.cortex.policy);
+    const yamlB = YAML.stringify(b.cortex.policy);
+    expect(yamlA).toBe(yamlB);
+  });
+
+  test("running migration on already-migrated output is a no-op for the policy block", () => {
+    const legacy = loadCortexShape(CORTEX_SHAPE_SINGLE_ADAPTER);
+    const first = convertBotYaml(legacy);
+    // Round-trip the first result back through convertBotYaml — the existing
+    // policy block must be preserved and re-emitted without duplication.
+    const roundTrip = first.cortex as unknown as LegacyBotYaml;
+    const second = convertBotYaml(roundTrip);
+    expect(YAML.stringify(first.cortex.policy)).toBe(YAML.stringify(second.cortex.policy));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// --labels override
+// ---------------------------------------------------------------------------
+
+describe("--labels override", () => {
+  test("label takes precedence over synthesised principal id", () => {
+    const labels = new Map<string, string>([
+      ["discord:285727653603049472", "mike"],
+    ]);
+    const legacy = loadCortexShape(`
+operator:
+  id: andreas
+stack:
+  id: andreas/meta-factory
+agents:
+  - id: luna
+    displayName: Luna
+    persona: ./personas/luna.md
+    roles: []
+    trust: []
+    presence:
+      discord:
+        enabled: true
+        token: stubtoken
+        guildId: "1"
+        agentChannelId: "2"
+        logChannelId: "3"
+        roles:
+          - name: user
+            users: ["285727653603049472"]
+            features: [chat]
+`);
+    const result = convertBotYaml(legacy, { labels });
+    const ids = result.cortex.policy!.principals.map((p) => p.id);
+    expect(ids).toContain("mike");
+    expect(ids).not.toContain("user-d049472");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// --check pre-flight
+// ---------------------------------------------------------------------------
+
+describe("policy preflight", () => {
+  test("passing case — every legacy user resolves to a principal", () => {
+    const legacy = loadCortexShape(CORTEX_SHAPE_SINGLE_ADAPTER);
+    const result = convertBotYaml(legacy);
+    expect(result.preflightGaps.length).toBe(0);
+    expect(formatPreflightReport([])).toContain("OK");
+  });
+
+  test("failing case — legacy user has no principal claiming their platform_id", () => {
+    const views: PolicyAdapterView[] = [
+      {
+        agentId: "luna",
+        platform: "discord",
+        roles: [{ name: "user", users: ["ORPHAN_USER"], features: ["chat"] }],
+        defaultRole: undefined,
+        dm: undefined,
+      },
+    ];
+    const gaps = policyPreflight({
+      views,
+      policy: { principals: [], roles: [] },
+    });
+    expect(gaps.length).toBeGreaterThan(0);
+    expect(gaps[0]!.kind).toBe("principal-missing-for-platform-user");
+    expect(gaps[0]!.platformId).toBe("ORPHAN_USER");
+    const report = formatPreflightReport(gaps);
+    expect(report).toContain("BLOCKED");
+  });
+
+  test("failing case — defaultRole references undeclared role", () => {
+    const views: PolicyAdapterView[] = [
+      {
+        agentId: "luna",
+        platform: "discord",
+        roles: [],
+        defaultRole: "phantom-role",
+        dm: undefined,
+      },
+    ];
+    const gaps = policyPreflight({
+      views,
+      policy: { principals: [], roles: [] },
+    });
+    expect(gaps.some((g) => g.kind === "role-missing-for-default-role" && g.roleName === "phantom-role")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// disallowedTools inversion via cortex#294 helper
+// ---------------------------------------------------------------------------
+
+describe("disallowedTools inversion", () => {
+  test("[Bash, Edit] → caps minus those two tools", () => {
+    const result = buildPolicy({
+      operatorId: "andreas",
+      homeStack: "andreas/meta-factory",
+      declaredAgentIds: new Set(["luna"]),
+      operatorPlatformIds: {},
+      views: [
+        {
+          agentId: "luna",
+          platform: "discord",
+          roles: [
+            {
+              name: "restricted",
+              users: ["UID"],
+              features: ["chat"],
+              disallowedTools: ["Bash", "Edit"],
+            },
+          ],
+          defaultRole: undefined,
+          dm: undefined,
+        },
+      ],
+    });
+    const role = result.policy.roles.find((r) => r.id === "restricted")!;
+    expect(role.capabilities).not.toContain("tool.bash");
+    expect(role.capabilities).not.toContain("tool.edit");
+    // Everything else still present.
+    expect(role.capabilities).toContain("tool.read");
+    expect(role.capabilities).toContain("tool.write");
+    expect(role.capabilities).toContain("tool.grep");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Bare-string capability rewrites in pre-existing policy block
+// ---------------------------------------------------------------------------
+
+describe("bare-string capability rewriting", () => {
+  test("pre-existing policy with bare chat/async/team caps → keyword.* form", () => {
+    const result = buildPolicy({
+      operatorId: "andreas",
+      homeStack: "andreas/work",
+      declaredAgentIds: new Set(["luna"]),
+      operatorPlatformIds: {},
+      views: [],
+      existingPolicy: {
+        principals: [
+          {
+            id: "luna",
+            home_operator: "andreas",
+            home_stack: "andreas/work",
+            role: ["operator"],
+            trust: [],
+            platform_ids: {},
+          },
+        ],
+        roles: [
+          {
+            id: "operator",
+            capabilities: ["dispatch.luna", "code-review.typescript", "chat", "async", "team"],
+          },
+        ],
+      },
+    });
+    const role = result.policy.roles.find((r) => r.id === "operator")!;
+    expect(role.capabilities).toContain("keyword.chat");
+    expect(role.capabilities).toContain("keyword.async");
+    expect(role.capabilities).toContain("keyword.team");
+    expect(role.capabilities).not.toContain("chat");
+    expect(role.capabilities).not.toContain("async");
+    expect(role.capabilities).not.toContain("team");
+    // domain.entity capability passes through unchanged.
+    expect(role.capabilities).toContain("code-review.typescript");
+    expect(role.capabilities).toContain("dispatch.luna");
+  });
+});

--- a/src/cli/cortex/commands/__tests__/migrate-config.test.ts
+++ b/src/cli/cortex/commands/__tests__/migrate-config.test.ts
@@ -432,6 +432,7 @@ describe("convertBotYaml — structural failures", () => {
   });
 
   test("throws when agent block is missing", () => {
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion -- runtime malformed input
     expect(() => convertBotYaml({ discord: [] } as unknown as LegacyBotYaml)).toThrow(/missing required `agent:`/);
   });
 

--- a/src/cli/cortex/commands/__tests__/migrate-config.test.ts
+++ b/src/cli/cortex/commands/__tests__/migrate-config.test.ts
@@ -1183,3 +1183,49 @@ describe("runMigrateConfig", () => {
     expect(code).toBe(0);
   });
 });
+
+describe("convertBotYaml — disabled-adapter does not leak policy (PR #306 r1 M4 fix)", () => {
+  test("agent with enabled:false discord presence does not synthesise allow-all anonymous principal", () => {
+    // Echo PR #306 r1 M4 caught: the headless placeholder presence in
+    // cortex.work.yaml (`enabled: false, token: placeholder-disabled,
+    // guildId: "0"`) flowed through to buildPolicy and synthesised an
+    // `anonymous-discord-<agent>` principal with `allow-all` capabilities
+    // (schema-default defaultRole). Disabled = no auth surface = no
+    // policy effect should leak.
+    const legacy: LegacyBotYaml = {
+      operator: {
+        id: "andreas",
+        displayName: "Andreas",
+        dataResidency: "NZ",
+      },
+      stack: { id: "andreas/work", displayName: "Andreas — Work" },
+      agents: [
+        {
+          id: "luna",
+          displayName: "Luna",
+          persona: "./personas/luna.md",
+          roles: [],
+          trust: [],
+          presence: {
+            discord: {
+              enabled: false,
+              token: "placeholder-disabled",
+              guildId: "0",
+              agentChannelId: "0",
+              logChannelId: "0",
+            },
+          },
+        },
+      ],
+    } satisfies LegacyBotYaml;
+    const result = convertBotYaml(legacy, { configDir: FIXTURE_DIR });
+    // The disabled adapter should not produce ANY synthetic anonymous-*
+    // principal nor any allow-all role.
+    const anonPrincipals = result.cortex.policy?.principals.filter((p) =>
+      p.id.startsWith("anonymous-"),
+    ) ?? [];
+    expect(anonPrincipals).toHaveLength(0);
+    const allowAllRole = result.cortex.policy?.roles.find((r) => r.id === "allow-all");
+    expect(allowAllRole).toBeUndefined();
+  });
+});

--- a/src/cli/cortex/commands/migrate-config-lib.ts
+++ b/src/cli/cortex/commands/migrate-config-lib.ts
@@ -22,8 +22,18 @@ import {
   DiscordPresenceSchema,
   type MattermostPresence,
   MattermostPresenceSchema,
+  type PolicyPrincipal,
+  type PolicyRole,
   RendererSchema,
 } from "../../../common/types/cortex-config";
+import {
+  buildPolicy,
+  policyPreflight,
+  type LegacyDMConfig,
+  type PolicyAdapterView,
+  type PolicyBuilderInput,
+  type PolicyPreflightGap,
+} from "./migrate-config-policy";
 
 // =============================================================================
 // Legacy input shape — permissive
@@ -104,7 +114,49 @@ export interface LegacyTrustedAgentBot {
 }
 
 export interface LegacyBotYaml {
-  agent: LegacyAgent;
+  /** grove-v2 singular `agent:` block. Required for grove-v2-shape input. */
+  agent?: LegacyAgent;
+  /**
+   * Cortex-shape `operator:` block. Used when the input is already a
+   * cortex.yaml (e.g. Andreas's `~/.config/cortex/cortex.yaml`) that has
+   * agents under `agents[]` instead of the singular legacy `agent:`.
+   */
+  operator?: {
+    id?: string;
+    displayName?: string;
+    discordId?: string;
+    mattermostId?: string;
+    slackId?: string;
+    dataResidency?: string;
+  };
+  /**
+   * Cortex-shape `stack:` block — gives the policy builder the
+   * `home_stack` value for synthesised principals. Defaults to
+   * `<operator_id>/default` per `deriveStackId`.
+   */
+  stack?: { id?: string; displayName?: string };
+  /**
+   * Cortex-shape `agents[]` array. When set, the migrator reads
+   * presence-side role declarations out of `agents[].presence.<platform>.roles[]`
+   * for policy synthesis (cortex#295). The shape mirrors the cortex.yaml
+   * `agents[]` schema; we accept it loosely here because input may carry
+   * malformed entries that the migrator should warn about rather than
+   * reject.
+   */
+  agents?: {
+    id?: string;
+    displayName?: string;
+    persona?: string;
+    roles?: unknown[];
+    trust?: string[];
+    presence?: {
+      discord?: Record<string, unknown>;
+      mattermost?: Record<string, unknown>;
+      slack?: Record<string, unknown>;
+    };
+  }[];
+  /** Cortex-shape pre-existing `policy:` block — preserved + normalised. */
+  policy?: { principals?: PolicyPrincipal[]; roles?: PolicyRole[] };
   discord?: LegacyDiscordInstance[] | LegacyDiscordInstance;
   mattermost?: LegacyMattermostInstance[] | LegacyMattermostInstance;
   trustedAgentBots?: LegacyTrustedAgentBot[];
@@ -119,6 +171,7 @@ export interface LegacyBotYaml {
   networks?: unknown[];
   nats?: unknown;
   renderers?: unknown[];
+  capabilities?: unknown[];
   [key: string]: unknown;
 }
 
@@ -150,6 +203,19 @@ export interface ConversionResult {
    * one new agent presence (plan §4 7.2e validation criterion #1).
    */
   mappings: InstanceMapping[];
+  /**
+   * Adapter views that drove the policy synthesis. Retained on the result
+   * so the CLI's `--check` mode can run `policyPreflight` without
+   * re-walking the input. Empty when the input had no `roles[]` blocks.
+   */
+  adapterViews: PolicyAdapterView[];
+  /**
+   * Gaps detected by `policyPreflight` against the synthesised policy
+   * block. Empty (length 0) means parallel-mode activation is safe.
+   * Populated when at least one legacy user-id or defaultRole reference
+   * doesn't resolve through the new policy block — see cortex#296.
+   */
+  preflightGaps: PolicyPreflightGap[];
 }
 
 /**
@@ -164,7 +230,24 @@ export interface ConvertOptions {
    * fixtures via in-memory strings rather than file paths).
    */
   configDir?: string;
+  /**
+   * Optional principal-label overrides — `{ "<platform>:<id>" → "principal-id" }`.
+   * Loaded by the CLI from `--labels labels.yaml` and forwarded verbatim
+   * to the policy builder. Lets operators replace synthesised principal
+   * ids (`user-d567890`) with friendlier names (`mike`) without losing
+   * idempotency (the same label map produces the same output on every run).
+   */
+  labels?: Map<string, string>;
 }
+
+// Re-export policy types so CLI callers and external consumers can hold
+// onto them without importing the policy submodule directly. Mirrors the
+// pattern existing convertBotYaml callers use for ConversionWarning.
+export type {
+  PolicyAdapterView,
+  PolicyPreflightGap,
+} from "./migrate-config-policy";
+export { policyPreflight, formatPreflightReport } from "./migrate-config-policy";
 
 // =============================================================================
 // Conversion
@@ -204,6 +287,11 @@ function buildOperator(
   legacy: LegacyBotYaml,
   warnings: ConversionWarning[],
 ): CortexConfig["operator"] {
+  // Caller (convertBotYaml) guards `legacy.agent` is set on the grove-v2
+  // path before reaching here. Re-assert for the type narrowing.
+  if (!legacy.agent) {
+    throw new Error("internal: buildOperator called without legacy.agent");
+  }
   const a = legacy.agent;
 
   const rawOperatorId = a.operatorId ?? a.name;
@@ -499,20 +587,25 @@ function buildAgents(
   mappings: InstanceMapping[],
   configDir: string | undefined,
 ): { agents: CortexConfig["agents"]; baseId: string } {
+  // Caller (convertBotYaml) guards `legacy.agent` on the grove-v2 path.
+  if (!legacy.agent) {
+    throw new Error("internal: buildAgents called without legacy.agent");
+  }
+  const legacyAgent = legacy.agent;
   const discordInstances = toArray(legacy.discord);
   const mattermostInstances = toArray(legacy.mattermost);
-  const baseId = deriveAgentId(legacy.agent.name);
+  const baseId = deriveAgentId(legacyAgent.name);
 
   if (!AGENT_ID_PATTERN.test(baseId)) {
     throw new Error(
-      `agent.name "${legacy.agent.name}" cannot be derived to a valid agent id (^[a-z0-9-]+$)`,
+      `agent.name "${legacyAgent.name}" cannot be derived to a valid agent id (^[a-z0-9-]+$)`,
     );
   }
 
   const trust = buildTrustList(legacy.trustedAgentBots ?? [], warnings);
 
-  const persona = resolvePersona(legacy.agent.personaFile, baseId, configDir, warnings);
-  const displayName = legacy.agent.displayName || legacy.agent.name;
+  const persona = resolvePersona(legacyAgent.personaFile, baseId, configDir, warnings);
+  const displayName = legacyAgent.displayName || legacyAgent.name;
 
   const variantCount = Math.max(discordInstances.length, mattermostInstances.length, 1);
 
@@ -690,22 +783,42 @@ export function convertBotYaml(
   if (!legacy || typeof legacy !== "object") {
     throw new Error("input is not an object");
   }
-  if (!legacy.agent || typeof legacy.agent !== "object") {
-    throw new Error("bot.yaml missing required `agent:` block");
+  // cortex#295 — accept BOTH legacy bot.yaml (singular `agent:`) and
+  // cortex.yaml (plural `agents[]` + `operator:` + `stack:`) shapes.
+  // Legacy bot.yaml requires `agent.name` + `agent.displayName`.
+  // cortex-shape requires `agents[]` + `operator.id` and bypasses
+  // `buildAgents`/`buildOperator`.
+  const isCortexShape =
+    !legacy.agent &&
+    Array.isArray(legacy.agents) &&
+    legacy.agents.length > 0 &&
+    legacy.operator !== undefined;
+  if (!isCortexShape) {
+    if (!legacy.agent || typeof legacy.agent !== "object") {
+      throw new Error("bot.yaml missing required `agent:` block");
+    }
+    /* eslint-enable @typescript-eslint/no-unnecessary-condition */
+    if (!legacy.agent.name || typeof legacy.agent.name !== "string") {
+      throw new Error("bot.yaml missing required `agent.name`");
+    }
+    if (!legacy.agent.displayName || typeof legacy.agent.displayName !== "string") {
+      throw new Error("bot.yaml missing required `agent.displayName`");
+    }
   }
   /* eslint-enable @typescript-eslint/no-unnecessary-condition */
-  if (!legacy.agent.name || typeof legacy.agent.name !== "string") {
-    throw new Error("bot.yaml missing required `agent.name`");
-  }
-  if (!legacy.agent.displayName || typeof legacy.agent.displayName !== "string") {
-    throw new Error("bot.yaml missing required `agent.displayName`");
-  }
 
   const warnings: ConversionWarning[] = [];
   const mappings: InstanceMapping[] = [];
 
-  const operator = buildOperator(legacy, warnings);
-  const { agents } = buildAgents(legacy, warnings, mappings, opts.configDir);
+  let operator: CortexConfig["operator"];
+  let agents: CortexConfig["agents"];
+  if (isCortexShape) {
+    operator = buildOperatorFromCortexShape(legacy, warnings);
+    agents = buildAgentsFromCortexShape(legacy, warnings, mappings);
+  } else {
+    operator = buildOperator(legacy, warnings);
+    agents = buildAgents(legacy, warnings, mappings, opts.configDir).agents;
+  }
   detectSharedAgentChannelId(agents, warnings);
   const renderers = buildRenderers(legacy, warnings);
 
@@ -722,6 +835,9 @@ export function convertBotYaml(
     renderers,
   };
 
+  if (legacy.stack !== undefined) cortex.stack = legacy.stack;
+  if (legacy.capabilities !== undefined) cortex.capabilities = legacy.capabilities;
+
   if (legacy.claude !== undefined) cortex.claude = legacy.claude;
   else cortex.claude = {};
 
@@ -733,8 +849,283 @@ export function convertBotYaml(
   if (legacy.networks !== undefined) cortex.networks = legacy.networks;
   if (legacy.nats !== undefined) cortex.nats = convertNats(legacy.nats, warnings);
 
+  // cortex#295 — synthesise policy block from legacy roles[] declarations.
+  // Sources:
+  //   - bot.yaml input → `legacy.discord[i].roles[]` + `legacy.mattermost[i].roles[]`
+  //   - cortex.yaml input → `legacy.agents[].presence.<platform>.roles[]`
+  // Both collapse into PolicyAdapterView[] which the builder consumes.
+  const adapterViews = collectAdapterViews(legacy, agents);
+  const homeStack = resolveHomeStack(legacy, operator.id);
+  const declaredAgentIds = new Set(agents.map((a) => a.id));
+  const operatorPlatformIds: PolicyBuilderInput["operatorPlatformIds"] = {};
+  if (operator.discordId) operatorPlatformIds.discord = operator.discordId;
+  if (operator.mattermostId) operatorPlatformIds.mattermost = operator.mattermostId;
+  if (operator.slackId) operatorPlatformIds.slack = operator.slackId;
+
+  const existingPolicy =
+    legacy.policy && (legacy.policy.principals !== undefined || legacy.policy.roles !== undefined)
+      ? legacy.policy
+      : undefined;
+
+  const policyBuild = buildPolicy({
+    operatorId: operator.id,
+    homeStack,
+    declaredAgentIds,
+    operatorPlatformIds,
+    views: adapterViews,
+    existingPolicy: existingPolicy
+      ? { principals: existingPolicy.principals, roles: existingPolicy.roles }
+      : undefined,
+    labels: opts.labels,
+  });
+  warnings.push(...policyBuild.warnings);
+
+  // Only emit policy block when there's something to say (avoid silent
+  // empty-block churn on grove-v2 inputs that don't declare any roles).
+  if (
+    policyBuild.policy.principals.length > 0 ||
+    policyBuild.policy.roles.length > 0 ||
+    existingPolicy !== undefined
+  ) {
+    cortex.policy = policyBuild.policy;
+  }
+
   const parsed = CortexConfigSchema.parse(cortex);
-  return { cortex: parsed, warnings, mappings };
+
+  // Compute parallel-mode pre-flight gaps against the FINAL policy block.
+  const preflightGaps = policyPreflight({
+    views: adapterViews,
+    policy: parsed.policy ?? { principals: [], roles: [] },
+  });
+
+  return { cortex: parsed, warnings, mappings, adapterViews, preflightGaps };
+}
+
+// =============================================================================
+// cortex#295 — view collection + cortex-shape input helpers
+// =============================================================================
+
+/**
+ * Walk the input legacy or cortex-shape config and project every adapter
+ * presence carrying a `roles[]` block onto a single uniform list. The
+ * policy builder consumes this directly.
+ *
+ * For grove-v2 inputs the roles live under `legacy.discord[i].roles[]`
+ * and `legacy.mattermost[i].roles[]`; the `agents[]` array we synthesised
+ * carries the cortex-shape agent ids. We zip `i` against `agents[i].id`
+ * so the resulting view's `agentId` is the same cortex-shape id the
+ * principal will reference.
+ *
+ * For cortex-shape inputs the roles live under
+ * `legacy.agents[i].presence.<platform>.roles[]` directly.
+ */
+function collectAdapterViews(
+  legacy: LegacyBotYaml,
+  agents: CortexConfig["agents"],
+): PolicyAdapterView[] {
+  const views: PolicyAdapterView[] = [];
+  // Path 1: cortex-shape input — read from the SCHEMA-PARSED `agents[]`
+  // (not the raw `legacy.agents[]`), so the per-presence DM defaults
+  // applied by `emptyDefault(DMConfigSchema)` are visible. Reading the
+  // raw input loses the operatorRole+defaultRole defaults that Zod
+  // injects, which breaks idempotency: round 1 sees no DM block, round
+  // 2 sees the schema-default DM block parsed from round 1's output,
+  // and the policy block drifts between runs.
+  const cortexShape = Array.isArray(legacy.agents) && legacy.agents.length > 0;
+  // Both paths read off the SCHEMA-PARSED `agents[]` (not the raw legacy
+  // input), so the per-presence DM defaults applied by
+  // `emptyDefault(DMConfigSchema)` are visible. Reading the raw input
+  // loses the operatorRole+defaultRole defaults Zod injects and breaks
+  // idempotency: round 1 sees no DM block, round 2 sees the schema-
+  // default DM block parsed from round 1's output, and the policy block
+  // drifts between runs.
+  //
+  // The two paths are otherwise identical — `agents[]` is synthesised
+  // from grove-v2 `discord[]/mattermost[]` in the legacy path and read
+  // directly from cortex-shape `agents[]` in the new path.
+  void cortexShape; // explicit no-op — kept for grep/intent traceability
+  for (const parsed of agents) {
+    if (parsed.presence.discord) {
+      const p = parsed.presence.discord;
+      const dm = p.dm as LegacyDMConfig | undefined;
+      // `p.defaultRole` always defaults to "allow-all" via the schema,
+      // so it's never `undefined`. Surface it verbatim.
+      const defaultRole = p.defaultRole;
+      if (p.roles.length > 0 || dm !== undefined) {
+        views.push({
+          agentId: parsed.id,
+          platform: "discord",
+          roles: p.roles,
+          defaultRole,
+          dm,
+        });
+      }
+    }
+    if (parsed.presence.mattermost) {
+      const p = parsed.presence.mattermost;
+      const defaultRole = p.defaultRole;
+      if (p.roles.length > 0) {
+        views.push({
+          agentId: parsed.id,
+          platform: "mattermost",
+          roles: p.roles,
+          defaultRole,
+          dm: undefined,
+        });
+      }
+    }
+    if (parsed.presence.slack) {
+      const p = parsed.presence.slack;
+      const defaultRole = p.defaultRole;
+      if (p.roles.length > 0) {
+        views.push({
+          agentId: parsed.id,
+          platform: "slack",
+          roles: p.roles,
+          defaultRole,
+          dm: undefined,
+        });
+      }
+    }
+  }
+  return views;
+}
+
+/**
+ * Resolve the `home_stack` value for synthesised principals. Cortex-shape
+ * input carries it under `stack.id`; legacy bot.yaml has no equivalent
+ * so we default to `<operator_id>/default` (matches `deriveStackId`).
+ */
+function resolveHomeStack(legacy: LegacyBotYaml, operatorId: string): string {
+  const stackId = legacy.stack?.id;
+  if (typeof stackId === "string" && stackId.length > 0) return stackId;
+  return `${operatorId}/default`;
+}
+
+/**
+ * Lift the cortex-shape `operator:` block straight through, with the
+ * same normalisations `buildOperator` applies (lowercase id, ISO-3166
+ * residency).
+ */
+function buildOperatorFromCortexShape(
+  legacy: LegacyBotYaml,
+  warnings: ConversionWarning[],
+): CortexConfig["operator"] {
+  const op = legacy.operator ?? {};
+  if (typeof op.id !== "string" || op.id.length === 0) {
+    throw new Error("cortex.yaml-shape input requires `operator.id`");
+  }
+  const operatorId = deriveAgentId(op.id);
+  if (operatorId !== op.id) {
+    warnings.push({
+      field: "operator.id",
+      message: `operator.id "${op.id}" normalized to "${operatorId}" (cortex requires lowercase alphanumeric + hyphen)`,
+    });
+  }
+  let dataResidency = op.dataResidency;
+  if (dataResidency === undefined) dataResidency = "NZ";
+  else if (!/^[A-Z]{2}$/.test(dataResidency)) {
+    const fixed = dataResidency.toUpperCase();
+    if (/^[A-Z]{2}$/.test(fixed)) {
+      warnings.push({
+        field: "operator.dataResidency",
+        message: `dataResidency "${dataResidency}" upcased to "${fixed}"`,
+      });
+      dataResidency = fixed;
+    } else {
+      warnings.push({
+        field: "operator.dataResidency",
+        message: `dataResidency "${dataResidency}" not a 2-letter ISO-3166 code; defaulting to "NZ"`,
+      });
+      dataResidency = "NZ";
+    }
+  }
+  const operator: CortexConfig["operator"] = { id: operatorId, dataResidency };
+  if (op.displayName) operator.displayName = op.displayName;
+  if (op.discordId) operator.discordId = op.discordId;
+  if (op.mattermostId) operator.mattermostId = op.mattermostId;
+  if (op.slackId) operator.slackId = op.slackId;
+  return operator;
+}
+
+/**
+ * Lift cortex-shape `agents[]` to the validated CortexConfig.agents[]. The
+ * presence blocks pass through the per-platform Zod schemas so each
+ * agent's id and presence land normalised. Mappings get a synthetic entry
+ * per (agent, platform) so `--check` output reflects the cortex-shape
+ * path symmetrically with the legacy path.
+ */
+function buildAgentsFromCortexShape(
+  legacy: LegacyBotYaml,
+  warnings: ConversionWarning[],
+  mappings: InstanceMapping[],
+): CortexConfig["agents"] {
+  const out: CortexConfig["agents"] = [];
+  const sourceAgents = legacy.agents ?? [];
+  for (let i = 0; i < sourceAgents.length; i++) {
+    const a = sourceAgents[i];
+    if (!a) continue;
+    const rawId = a.id;
+    if (typeof rawId !== "string" || rawId.length === 0) {
+      throw new Error(`agents[${i}].id is required`);
+    }
+    const id = deriveAgentId(rawId);
+    if (id !== rawId) {
+      warnings.push({
+        field: `agents[${i}].id`,
+        message: `agent id "${rawId}" normalized to "${id}"`,
+      });
+    }
+    if (!AGENT_ID_PATTERN.test(id)) {
+      throw new Error(`agents[${i}].id "${rawId}" cannot be derived to a valid agent id (^[a-z0-9-]+$)`);
+    }
+    const displayName = a.displayName ?? rawId;
+    const persona = typeof a.persona === "string" && a.persona.length > 0
+      ? a.persona
+      : `./personas/${id}.md`;
+    const trust = Array.isArray(a.trust) ? a.trust.filter((t): t is string => typeof t === "string") : [];
+    const presence: CortexConfig["agents"][number]["presence"] = {};
+    if (a.presence?.discord) {
+      presence.discord = DiscordPresenceSchema.parse(a.presence.discord);
+      mappings.push({
+        legacyKind: "discord",
+        legacyIndex: i,
+        legacyInstanceId: undefined,
+        newAgentId: id,
+        newPresence: "discord",
+      });
+    }
+    if (a.presence?.mattermost) {
+      presence.mattermost = MattermostPresenceSchema.parse(a.presence.mattermost);
+      mappings.push({
+        legacyKind: "mattermost",
+        legacyIndex: i,
+        legacyInstanceId: undefined,
+        newAgentId: id,
+        newPresence: "mattermost",
+      });
+    }
+    // Note: slack pass-through goes through PresenceSchema validation
+    // when CortexConfigSchema.parse runs at the end of convertBotYaml.
+    // We don't gate it here.
+    const agentOut: CortexConfig["agents"][number] = {
+      id,
+      displayName,
+      persona,
+      roles: Array.isArray(a.roles)
+        ? a.roles.filter((r): r is string => typeof r === "string")
+        : [],
+      trust,
+      presence,
+    };
+    if (a.presence?.slack) {
+      // Pass-through: let the top-level CortexConfigSchema.parse validate
+      // it. Cast keeps the assignment shape.
+      (agentOut.presence as Record<string, unknown>).slack = a.presence.slack;
+    }
+    out.push(agentOut);
+  }
+  return out;
 }
 
 /**
@@ -851,6 +1242,28 @@ export function formatCheckReport(result: ConversionResult): string {
     }
     lines.push("");
   }
+  const policy = result.cortex.policy;
+  if (policy && (policy.principals.length > 0 || policy.roles.length > 0)) {
+    lines.push("");
+    lines.push(`policy.principals: ${policy.principals.length}`);
+    for (const p of policy.principals) {
+      const platforms = Object.entries(p.platform_ids)
+        .map(([plat, ids]) => `${plat}=${ids.length}`)
+        .join(", ");
+      const dm = p.session_config?.dm ? " +dm" : "";
+      lines.push(`  - ${p.id} (home_operator=${p.home_operator}, home_stack=${p.home_stack}) roles=[${p.role.join(", ")}] platforms=[${platforms}]${dm}`);
+    }
+    lines.push(`policy.roles: ${policy.roles.length}`);
+    for (const r of policy.roles) {
+      lines.push(`  - ${r.id} (${r.capabilities.length} caps)`);
+    }
+    lines.push("");
+    lines.push(`policy preflight: ${result.preflightGaps.length === 0 ? "OK" : `${result.preflightGaps.length} gap(s)`}`);
+    for (const g of result.preflightGaps) {
+      lines.push(`  [${g.kind}] ${g.hint}`);
+    }
+  }
+  lines.push("");
   if (result.warnings.length > 0) {
     lines.push(`warnings (${result.warnings.length}):`);
     for (const w of result.warnings) {

--- a/src/cli/cortex/commands/migrate-config-lib.ts
+++ b/src/cli/cortex/commands/migrate-config-lib.ts
@@ -945,7 +945,13 @@ function collectAdapterViews(
   // directly from cortex-shape `agents[]` in the new path.
   void cortexShape; // explicit no-op — kept for grep/intent traceability
   for (const parsed of agents) {
-    if (parsed.presence.discord) {
+    // Skip disabled adapters entirely. Echo PR #306 r1 M4: a headless
+    // placeholder presence (e.g. cortex.work.yaml's `enabled: false` discord
+    // block) would otherwise flow through to `buildPolicy` and synthesise
+    // an `anonymous-discord-<agent>` principal with `allow-all` capabilities
+    // (the schema-default `defaultRole`). Disabled = no auth surface = no
+    // policy effect should leak.
+    if (parsed.presence.discord?.enabled) {
       const p = parsed.presence.discord;
       const dm = p.dm as LegacyDMConfig | undefined;
       // `p.defaultRole` always defaults to "allow-all" via the schema,
@@ -961,7 +967,7 @@ function collectAdapterViews(
         });
       }
     }
-    if (parsed.presence.mattermost) {
+    if (parsed.presence.mattermost?.enabled) {
       const p = parsed.presence.mattermost;
       const defaultRole = p.defaultRole;
       if (p.roles.length > 0) {
@@ -974,7 +980,7 @@ function collectAdapterViews(
         });
       }
     }
-    if (parsed.presence.slack) {
+    if (parsed.presence.slack?.enabled) {
       const p = parsed.presence.slack;
       const defaultRole = p.defaultRole;
       if (p.roles.length > 0) {

--- a/src/cli/cortex/commands/migrate-config-policy.ts
+++ b/src/cli/cortex/commands/migrate-config-policy.ts
@@ -300,6 +300,13 @@ interface PrincipalAccumulator {
   platform_ids: Record<string, Set<string>>;
   roles: Set<string>;
   trust: Set<string>;
+  /**
+   * NATS stack signing key (NKey public key). Preserved verbatim from a
+   * pre-existing principal block on round-trip — Echo PR #306 r1 blocker
+   * caught that this field was dropped, silently losing the work-stack's
+   * Phase D federation signing identity.
+   */
+  nkey_pub: string | undefined;
   /** session_config.default — the channel/group context baseline. */
   sessionDefault: SessionConfigAcc;
   /** session_config.dm — populated only when a DM override applies. */
@@ -409,6 +416,9 @@ export function buildPolicy(input: PolicyBuilderInput): PolicyBuilderOutput {
       platform_ids: platformIds,
       roles: new Set(p.role),
       trust: new Set(p.trust),
+      // Preserve nkey_pub verbatim from the existing principal — federation
+      // signing identity (Phase D). Echo PR #306 r1 blocker fix.
+      nkey_pub: p.nkey_pub,
       sessionDefault: emptySessionConfig(),
       sessionDm: undefined,
       external: false,
@@ -548,6 +558,7 @@ export function buildPolicy(input: PolicyBuilderInput): PolicyBuilderOutput {
             platform_ids: {},
             roles: new Set(),
             trust: new Set(),
+            nkey_pub: undefined,
             sessionDefault: emptySessionConfig(),
             sessionDm: undefined,
             external: isExternal,
@@ -586,6 +597,7 @@ export function buildPolicy(input: PolicyBuilderInput): PolicyBuilderOutput {
         platform_ids: {},
         roles: new Set(),
         trust: new Set(),
+        nkey_pub: undefined,
         sessionDefault: emptySessionConfig(),
         sessionDm: undefined,
         external: false,
@@ -631,6 +643,7 @@ export function buildPolicy(input: PolicyBuilderInput): PolicyBuilderOutput {
           platform_ids: {},
           roles: new Set([allowAllRoleId]),
           trust: new Set(),
+          nkey_pub: undefined,
           sessionDefault: emptySessionConfig(),
           sessionDm: undefined,
           external: false,
@@ -652,6 +665,7 @@ export function buildPolicy(input: PolicyBuilderInput): PolicyBuilderOutput {
           platform_ids: {},
           roles: new Set(["operator"]),
           trust: new Set(),
+          nkey_pub: undefined,
           sessionDefault: emptySessionConfig(),
           sessionDm: undefined,
           external: false,
@@ -723,6 +737,7 @@ export function buildPolicy(input: PolicyBuilderInput): PolicyBuilderOutput {
             platform_ids: {},
             roles: new Set(),
             trust: new Set(),
+            nkey_pub: undefined,
             sessionDefault: emptySessionConfig(),
             sessionDm: undefined,
             external: false,
@@ -907,6 +922,11 @@ function serialisePolicy(
       trust: [...acc.trust].sort(),
       platform_ids: platformIds,
     };
+    // Preserve nkey_pub if present (Echo PR #306 r1 blocker fix — work-stack
+    // luna principal carries its NATS signing key; must round-trip verbatim).
+    if (acc.nkey_pub !== undefined) {
+      p.nkey_pub = acc.nkey_pub;
+    }
     const hasSessionDefault = !isSessionConfigDefault(acc.sessionDefault);
     if (hasSessionDefault || acc.sessionDm !== undefined) {
       p.session_config = {

--- a/src/cli/cortex/commands/migrate-config-policy.ts
+++ b/src/cli/cortex/commands/migrate-config-policy.ts
@@ -1,0 +1,1056 @@
+/**
+ * v2.0.0 policy cutover — slice I-243C (cortex#295).
+ *
+ * Synthesise a top-level `policy: { principals[], roles[] }` block from
+ * legacy per-adapter `presence.<platform>.roles[]` + `dm.*` blocks. This is
+ * the migration the v2.0.0 cutover (cortex#242) needs operators to run
+ * BEFORE the legacy schema is removed.
+ *
+ * Mechanically:
+ *   1. Walk every agent's discord/mattermost/slack presence and collect
+ *      all `roles[]` + `defaultRole` + `dm.*` blocks.
+ *   2. For each legacy role, emit a `PolicyRole` with namespaced
+ *      capabilities (`keyword.*`, `tool.*`, `dispatch.*`, `operator`).
+ *   3. For each user appearing in any role's `users[]`, emit ONE
+ *      `PolicyPrincipal` (unified across the three adapters — same
+ *      platform id mapped via three agents' role lists collapses to one
+ *      principal). `platform_ids.<platform> = [user_id]` populates the
+ *      reverse-lookup table the new dispatch path consults.
+ *   4. For each adapter instance with a `defaultRole`, emit a synthetic
+ *      `anonymous-<platform>-<agent_id>` principal that carries whatever
+ *      role the legacy fallback referenced.
+ *   5. If `operator.discordId` / `mattermostId` / `slackId` is set on the
+ *      operator block, emit a single `operator-<operator_id>` principal
+ *      carrying the operator's platform ids in `platform_ids` and any
+ *      `dm.operatorRole` overrides in `session_config.dm`.
+ *   6. Same-named role across different adapters with DIFFERENT field
+ *      bundles → warn + take the conservative UNION (preserves access;
+ *      operator must tighten manually if they want to).
+ *   7. External-peer principals (an `agent-<X>` role where `<X>` isn't a
+ *      declared agent in this config) emit with `home_operator: "unknown"`
+ *      and `home_stack: "unknown/unknown"` + a warning so operators see
+ *      the gap.
+ *
+ * Output is deterministically sorted (principals + roles by id, role[]
+ * + platform_ids[platform] arrays sorted in place) so running migrate-
+ * config twice produces byte-identical YAML. Idempotency is a hard
+ * requirement of the design — operators may re-run after manually
+ * labelling principals via `--labels labels.yaml`.
+ *
+ * See `docs/design-policy-cutover.md` §6 (algorithm) + §9.1 (--check
+ * pre-flight requirement) + §11 (reality-check against operator's real
+ * config) + §12-§14 (resolved questions) + §16 (locked schema delta).
+ */
+
+import type {
+  PolicyPrincipal,
+  PolicyRole,
+} from "../../../common/types/cortex-config";
+import { LETTER_PREFIX_ID_REGEX } from "../../../common/types/id";
+import { invertDisallowedTools } from "../../../common/policy/tool-inventory";
+
+import type { ConversionWarning } from "./migrate-config-lib";
+
+// =============================================================================
+// Legacy shape — the loose `roles[]` items we read out of the input
+// =============================================================================
+
+/**
+ * Loose decoding of a legacy presence `roles[]` entry. Schema lives in
+ * `src/common/types/config.ts` (`RoleSchema`) but we accept this shape from
+ * either a parsed grove-v2 `bot.yaml` (`discord[i].roles[]`) or a parsed
+ * cortex.yaml (`agents[].presence.discord.roles[]`); the cortex schema's
+ * Zod validation has already coerced types on the cortex path, but the
+ * bot.yaml path may carry raw YAML.
+ */
+export interface LegacyRoleEntry {
+  name?: unknown;
+  users?: unknown;
+  features?: unknown;
+  disallowedTools?: unknown;
+  allowedDirs?: unknown;
+  allowedSkills?: unknown;
+}
+
+/**
+ * Loose decoding of a legacy `dm.userRoles[]` entry. Carries the same field
+ * bundle as a channel role plus per-user identity and the DM-specific
+ * `bashGuard`/`bashAllowlist`.
+ */
+export interface LegacyDMUserRoleEntry {
+  users?: unknown;
+  features?: unknown;
+  disallowedTools?: unknown;
+  allowedDirs?: unknown;
+  allowedSkills?: unknown;
+  bashGuard?: unknown;
+  bashAllowlist?: unknown;
+}
+
+/**
+ * Loose decoding of a legacy `dm.operatorRole` block. Same shape as a
+ * `DMUserRoleEntry` minus the `users[]`.
+ */
+export interface LegacyDMOperatorRoleEntry {
+  features?: unknown;
+  disallowedTools?: unknown;
+  allowedDirs?: unknown;
+  allowedSkills?: unknown;
+  bashGuard?: unknown;
+  bashAllowlist?: unknown;
+}
+
+/**
+ * Loose decoding of a legacy `dm:` block on a discord presence.
+ */
+export interface LegacyDMConfig {
+  operatorRole?: LegacyDMOperatorRoleEntry;
+  defaultRole?: unknown;
+  userRoles?: LegacyDMUserRoleEntry[];
+}
+
+/**
+ * One adapter "view" the policy builder iterates over. Each view is the
+ * `roles[]` + `defaultRole` + `dm` block under one (agent_id, platform)
+ * tuple. Both the legacy bot.yaml and the cortex.yaml shape collapse to
+ * this view; the caller picks the right source.
+ */
+export interface PolicyAdapterView {
+  agentId: string;
+  platform: "discord" | "mattermost" | "slack";
+  roles: LegacyRoleEntry[];
+  defaultRole: string | undefined;
+  dm: LegacyDMConfig | undefined;
+}
+
+/**
+ * Input to the policy builder. Captures only what's needed — the rest of
+ * the cortex.yaml is rebuilt by `convertBotYaml`.
+ */
+export interface PolicyBuilderInput {
+  operatorId: string;
+  homeStack: string;
+  /** Local agent ids declared in this cortex.yaml (used to detect external peers). */
+  declaredAgentIds: ReadonlySet<string>;
+  /** Operator's platform ids (from `operator.discordId/mattermostId/slackId`). */
+  operatorPlatformIds: Partial<Record<"discord" | "mattermost" | "slack", string>>;
+  /** Per-(agent, platform) view of the legacy roles + dm config. */
+  views: PolicyAdapterView[];
+  /**
+   * Optional pre-existing policy block. When present, its principals +
+   * roles are preserved and the builder only ADDS new ones (idempotency).
+   * Bare-string capabilities (`chat`, `async`, `team`) get rewritten to
+   * `keyword.*` form in place.
+   */
+  existingPolicy?: {
+    /**
+     * Permissive shape — raw YAML hasn't been Zod-parsed yet, so any field
+     * (including `platform_ids`) may be missing. `buildPolicy` defends with
+     * `?? {}` / `?? []` and absorbs whatever's present.
+     */
+    principals?: (Omit<PolicyPrincipal, "platform_ids"> & {
+      platform_ids?: PolicyPrincipal["platform_ids"];
+    })[];
+    roles?: PolicyRole[];
+  };
+  /**
+   * Optional principal-label overrides — `{ "<platform>:<id>": "principal-id" }`
+   * — supplied via `--labels labels.yaml`. The builder uses the labelled id
+   * instead of the synthesised one (`user-d567890`).
+   */
+  labels?: Map<string, string>;
+}
+
+export interface PolicyBuilderOutput {
+  policy: {
+    principals: PolicyPrincipal[];
+    roles: PolicyRole[];
+  };
+  warnings: ConversionWarning[];
+}
+
+// =============================================================================
+// Capability namespace
+// =============================================================================
+
+const BARE_KEYWORD_REWRITES: ReadonlyMap<string, string> = new Map([
+  ["chat", "keyword.chat"],
+  ["async", "keyword.async"],
+  ["team", "keyword.team"],
+]);
+
+/**
+ * Rewrite a single capability string from legacy bare-keyword form to the
+ * namespaced form (§12.1). Pass-through for anything that's already
+ * namespaced or in another domain.
+ */
+function rewriteCapability(cap: string): string {
+  return BARE_KEYWORD_REWRITES.get(cap) ?? cap;
+}
+
+// =============================================================================
+// Loose-input coercion helpers
+// =============================================================================
+
+function toStringArray(val: unknown): string[] {
+  if (!Array.isArray(val)) return [];
+  return val.filter((v): v is string => typeof v === "string" && v.length > 0);
+}
+
+function toBoolean(val: unknown, defaultVal: boolean): boolean {
+  return typeof val === "boolean" ? val : defaultVal;
+}
+
+function asString(val: unknown): string | undefined {
+  return typeof val === "string" && val.length > 0 ? val : undefined;
+}
+
+// =============================================================================
+// Slugify principal ids
+// =============================================================================
+
+/**
+ * Synthesise a principal id for a platform user when no `--labels` entry
+ * exists for them. Platform user ids (Discord snowflakes, Mattermost UUIDs,
+ * Slack `U…` ids) don't fit the letter-prefix grammar, so the builder
+ * generates `user-<platform[0]><last-6-of-id>` per §6.1.
+ *
+ * Deterministic: same `(platform, id)` always produces the same principal
+ * id. This is what makes the migration idempotent — re-running against a
+ * partially-migrated config doesn't shuffle principal ids.
+ */
+function synthesisePrincipalId(platform: string, platformId: string): string {
+  const trimmed = platformId.trim();
+  const tail = trimmed.length >= 6 ? trimmed.slice(-6) : trimmed;
+  // Lowercase + replace non-grammar chars; ensures Mattermost UUIDs (hex
+  // with hyphens) still produce a valid id.
+  const sanitised = tail.toLowerCase().replace(/[^a-z0-9-]+/g, "");
+  // The platform letter prefix keeps cross-platform collisions visible at
+  // a glance: `user-d567890` (Discord) vs `user-m567890` (Mattermost).
+  return `user-${platform[0]}${sanitised}`;
+}
+
+/**
+ * Slug a role name to fit the LETTER_PREFIX_ID_REGEX. Logs a warning when
+ * the slug differs from the input so operators can see the rewrite in
+ * the migration report.
+ */
+function slugifyRoleId(
+  rawName: string,
+  warnings: ConversionWarning[],
+): string {
+  if (LETTER_PREFIX_ID_REGEX.test(rawName)) return rawName;
+  // Lowercase, replace any non-grammar char with `-`, collapse runs,
+  // strip leading/trailing hyphens, ensure leading letter.
+  let slug = rawName.toLowerCase().replace(/[^a-z0-9-]+/g, "-").replace(/-+/g, "-");
+  slug = slug.replace(/^-+|-+$/g, "");
+  if (!/^[a-z]/.test(slug)) slug = `role-${slug}`;
+  // Defensive: if still empty after slugifying (e.g. input was "!!!"),
+  // synthesise a stable placeholder so the migration doesn't crash. The
+  // warning surfaces the underlying input so the operator can hand-edit.
+  if (slug.length === 0) slug = "role-unnamed";
+  warnings.push({
+    field: "policy.roles",
+    message: `role name "${rawName}" doesn't match the policy id grammar — slugified to "${slug}". Hand-edit the generated cortex.yaml if you want a different id.`,
+  });
+  return slug;
+}
+
+// =============================================================================
+// Role capability synthesis
+// =============================================================================
+
+/**
+ * Compute the canonical capability list for a role given its legacy field
+ * bundle. The dispatch-id list is folded in by the caller (it depends on
+ * which agents are declared in the cortex.yaml, not on the role).
+ */
+function capsForRoleBundle(
+  features: string[],
+  disallowedTools: string[],
+  warnings: ConversionWarning[],
+  fieldPath: string,
+): string[] {
+  const caps = new Set<string>();
+  for (const f of features) {
+    const ns = BARE_KEYWORD_REWRITES.get(f);
+    if (ns) caps.add(ns);
+    else {
+      warnings.push({
+        field: fieldPath,
+        message: `unknown feature "${f}" — expected one of chat/async/team. Dropping.`,
+      });
+    }
+  }
+  // Inversion of disallowedTools[] → positive tool.<lowercase> caps.
+  for (const cap of invertDisallowedTools(disallowedTools)) {
+    caps.add(cap);
+  }
+  return [...caps];
+}
+
+// =============================================================================
+// Internal accumulators (mutable during build, frozen at end)
+// =============================================================================
+
+interface PrincipalAccumulator {
+  id: string;
+  home_operator: string;
+  home_stack: string;
+  platform_ids: Record<string, Set<string>>;
+  roles: Set<string>;
+  trust: Set<string>;
+  /** session_config.default — the channel/group context baseline. */
+  sessionDefault: SessionConfigAcc;
+  /** session_config.dm — populated only when a DM override applies. */
+  sessionDm: SessionConfigAcc | undefined;
+  /** True for external-peer placeholders so the warning fires once. */
+  external: boolean;
+}
+
+interface SessionConfigAcc {
+  allowedDirs: string[] | undefined;
+  allowedSkills: string[] | undefined;
+  bashGuard: boolean;
+  bashAllowlist:
+    | {
+        rules: { pattern: string; repos?: string[] }[];
+        repos: string[];
+      }
+    | undefined;
+}
+
+interface RoleAccumulator {
+  id: string;
+  capabilities: Set<string>;
+  /** Field bundles seen across adapters — used to surface cross-adapter conflicts. */
+  bundleHashes: Set<string>;
+}
+
+function emptySessionConfig(): SessionConfigAcc {
+  return {
+    allowedDirs: undefined,
+    allowedSkills: undefined,
+    bashGuard: true,
+    bashAllowlist: undefined,
+  };
+}
+
+function serialiseSessionConfig(sc: SessionConfigAcc): {
+  allowed_dirs?: string[];
+  allowed_skills?: string[];
+  bash_guard: boolean;
+  bash_allowlist?: { rules: { pattern: string; repos?: string[] }[]; repos: string[] };
+} {
+  const out: ReturnType<typeof serialiseSessionConfig> = { bash_guard: sc.bashGuard };
+  if (sc.allowedDirs !== undefined) out.allowed_dirs = [...sc.allowedDirs];
+  if (sc.allowedSkills !== undefined) out.allowed_skills = [...sc.allowedSkills];
+  if (sc.bashAllowlist !== undefined) out.bash_allowlist = sc.bashAllowlist;
+  return out;
+}
+
+function isSessionConfigDefault(sc: SessionConfigAcc): boolean {
+  return (
+    sc.allowedDirs === undefined &&
+    sc.allowedSkills === undefined &&
+    sc.bashGuard &&
+    sc.bashAllowlist === undefined
+  );
+}
+
+/**
+ * Stable hash of a role's effective field bundle. Used to detect when the
+ * same role name appears across adapters with DIFFERENT bundles — those
+ * surface as a warning before the union is taken.
+ */
+function hashRoleBundle(
+  features: string[],
+  disallowedTools: string[],
+  allowedDirs: string[] | undefined,
+  allowedSkills: string[] | undefined,
+): string {
+  const f = [...features].sort().join(",");
+  const d = [...disallowedTools].sort().join(",");
+  const ad = allowedDirs ? [...allowedDirs].sort().join(",") : "<unset>";
+  const as = allowedSkills ? [...allowedSkills].sort().join(",") : "<unset>";
+  return `${f}|${d}|${ad}|${as}`;
+}
+
+// =============================================================================
+// Main entry — buildPolicy
+// =============================================================================
+
+/**
+ * Translate a collection of (agent_id, platform, legacy-role-config) views
+ * into a top-level `policy: { principals[], roles[] }` block.
+ *
+ * Pure: no IO. Returns the assembled policy + warnings; the CLI caller
+ * stitches them onto its own warnings list and serialises the result.
+ *
+ * Idempotent — see module docstring + `serialisePolicy` for the sort
+ * keys that guarantee byte-identical output on a re-run.
+ */
+export function buildPolicy(input: PolicyBuilderInput): PolicyBuilderOutput {
+  const warnings: ConversionWarning[] = [];
+
+  const principals = new Map<string, PrincipalAccumulator>();
+  const roleAcc = new Map<string, RoleAccumulator>();
+
+  // Pre-populate principals + roles from any existing policy block (idempotency).
+  for (const p of input.existingPolicy?.principals ?? []) {
+    const platformIds: Record<string, Set<string>> = {};
+    for (const [platform, ids] of Object.entries(p.platform_ids ?? {})) {
+      platformIds[platform] = new Set(ids);
+    }
+    const acc: PrincipalAccumulator = {
+      id: p.id,
+      home_operator: p.home_operator,
+      home_stack: p.home_stack,
+      platform_ids: platformIds,
+      roles: new Set(p.role),
+      trust: new Set(p.trust),
+      sessionDefault: emptySessionConfig(),
+      sessionDm: undefined,
+      external: false,
+    };
+    if (p.session_config) {
+      acc.sessionDefault = absorbSessionConfig(emptySessionConfig(), {
+        allowedDirs: p.session_config.default.allowed_dirs,
+        allowedSkills: p.session_config.default.allowed_skills,
+        bashGuard: p.session_config.default.bash_guard,
+        bashAllowlist: p.session_config.default.bash_allowlist,
+      });
+      if (p.session_config.dm) {
+        acc.sessionDm = absorbSessionConfig(emptySessionConfig(), {
+          allowedDirs: p.session_config.dm.allowed_dirs,
+          allowedSkills: p.session_config.dm.allowed_skills,
+          bashGuard: p.session_config.dm.bash_guard,
+          bashAllowlist: p.session_config.dm.bash_allowlist,
+        });
+      }
+    }
+    principals.set(p.id, acc);
+  }
+  for (const r of input.existingPolicy?.roles ?? []) {
+    const caps = new Set<string>();
+    for (const c of r.capabilities) caps.add(rewriteCapability(c));
+    // Also rewrite the original entry through the bare-keyword map so a
+    // re-run on a partly-migrated file converges. If `r.capabilities`
+    // carried `chat`, it's now `keyword.chat`.
+    roleAcc.set(r.id, {
+      id: r.id,
+      capabilities: caps,
+      bundleHashes: new Set(),
+    });
+  }
+
+  // Per-(role-name, platform) bundle tracking — surfaces cross-adapter
+  // conflicts when the SAME role name has DIFFERENT field bundles in
+  // different presences.
+  interface PerPlatformBundle {
+    platform: "discord" | "mattermost" | "slack";
+    hash: string;
+  }
+  const seenRoleBundles = new Map<string, PerPlatformBundle[]>();
+
+  // Dispatch capabilities — folded in to every role's capability set so
+  // the migration preserves the legacy "any role in this cortex.yaml can
+  // dispatch to any local agent" behaviour. Operators tighten manually
+  // after migration.
+  const declaredAgentIds = [...input.declaredAgentIds].sort();
+  const dispatchCaps = declaredAgentIds.map((id) => `dispatch.${id}`);
+
+  // -------- Walk every adapter view --------
+  for (const view of input.views) {
+    for (const role of view.roles) {
+      const rawName = asString(role.name);
+      if (!rawName) continue;
+      const roleId = slugifyRoleId(rawName, warnings);
+
+      const features = toStringArray(role.features);
+      const disallowedTools = toStringArray(role.disallowedTools);
+      const allowedDirs = Array.isArray(role.allowedDirs) ? toStringArray(role.allowedDirs) : undefined;
+      const allowedSkills = Array.isArray(role.allowedSkills) ? toStringArray(role.allowedSkills) : undefined;
+
+      const caps = capsForRoleBundle(
+        features,
+        disallowedTools,
+        warnings,
+        `agents[${view.agentId}].presence.${view.platform}.roles[${rawName}]`,
+      );
+
+      // Track cross-adapter bundle drift for this role name.
+      const hash = hashRoleBundle(features, disallowedTools, allowedDirs, allowedSkills);
+      const bundles = seenRoleBundles.get(roleId) ?? [];
+      bundles.push({ platform: view.platform, hash });
+      seenRoleBundles.set(roleId, bundles);
+
+      // Accumulate into the role's capability set. Conservative-union
+      // semantics (§13 Q4): same role name across adapters with different
+      // bundles → union of caps + warning.
+      let acc = roleAcc.get(roleId);
+      if (acc === undefined) {
+        acc = { id: roleId, capabilities: new Set(caps), bundleHashes: new Set([hash]) };
+        roleAcc.set(roleId, acc);
+      } else {
+        for (const c of caps) acc.capabilities.add(c);
+        acc.bundleHashes.add(hash);
+      }
+      // Fold dispatch caps in for every role.
+      for (const dc of dispatchCaps) acc.capabilities.add(dc);
+      // Reserved `operator` capability — §5.5 / §12.1 — any role literally
+      // named `operator` carries the privilege-class capability. The DM
+      // adapter short-circuits gating when this cap is present.
+      if (roleId === "operator") acc.capabilities.add("operator");
+
+      // Per-user principal synthesis.
+      const users = toStringArray(role.users);
+      for (const u of users) {
+        // External-peer detection: role names like `agent-<X>` where <X>
+        // is NOT one of our declared agents → emit a placeholder
+        // principal for that peer (§12.3).
+        let principalId: string;
+        let isExternal = false;
+        const labelKey = `${view.platform}:${u}`;
+        const labelled = input.labels?.get(labelKey);
+        // Operator-platform-id detection: if this user-id matches the
+        // operator's platform-side id for this platform, the user IS the
+        // operator — fold into the single `operator` principal so the
+        // operator role's session_config + DM-context overrides land on
+        // one identity, not three. Without this collapse we'd emit BOTH
+        // a synthesised `user-d987522` AND an `operator` principal each
+        // claiming the same Discord id, which the policy schema's
+        // uniqueness refine rejects.
+        const isOperatorUser =
+          input.operatorPlatformIds[view.platform] === u;
+        if (labelled !== undefined) {
+          principalId = labelled;
+        } else if (isOperatorUser) {
+          principalId = "operator";
+        } else if (rawName.startsWith("agent-")) {
+          const peerName = rawName.slice("agent-".length);
+          if (input.declaredAgentIds.has(peerName)) {
+            principalId = peerName;
+          } else {
+            principalId = peerName;
+            isExternal = true;
+          }
+        } else {
+          principalId = synthesisePrincipalId(view.platform, u);
+        }
+
+        let principal = principals.get(principalId);
+        if (principal === undefined) {
+          principal = {
+            id: principalId,
+            home_operator: isExternal ? "unknown" : input.operatorId,
+            home_stack: isExternal ? "unknown/unknown" : input.homeStack,
+            platform_ids: {},
+            roles: new Set(),
+            trust: new Set(),
+            sessionDefault: emptySessionConfig(),
+            sessionDm: undefined,
+            external: isExternal,
+          };
+          if (isExternal) {
+            warnings.push({
+              field: `policy.principals[${principalId}]`,
+              message:
+                `external peer "${principalId}" found in agents[${view.agentId}].presence.${view.platform}.roles[].agent-${principalId}; ` +
+                `please set home_operator + home_stack manually in policy.principals[${principalId}] (currently "unknown"/"unknown/unknown")`,
+            });
+          }
+          principals.set(principalId, principal);
+        }
+        addPlatformId(principal, view.platform, u);
+        principal.roles.add(roleId);
+
+        // Channel-context session config — merge with the legacy bundle.
+        principal.sessionDefault = absorbSessionConfig(principal.sessionDefault, {
+          allowedDirs,
+          allowedSkills,
+          bashGuard: principal.sessionDefault.bashGuard, // channel role has no bashGuard field
+          bashAllowlist: principal.sessionDefault.bashAllowlist,
+        });
+      }
+    }
+
+    // defaultRole → synthetic anonymous principal per (agent, platform).
+    const defaultRole = view.defaultRole;
+    if (defaultRole !== undefined && defaultRole !== "allow-all") {
+      const anonId = `anonymous-${view.platform}-${view.agentId}`;
+      const acc: PrincipalAccumulator = {
+        id: anonId,
+        home_operator: input.operatorId,
+        home_stack: input.homeStack,
+        platform_ids: {},
+        roles: new Set(),
+        trust: new Set(),
+        sessionDefault: emptySessionConfig(),
+        sessionDm: undefined,
+        external: false,
+      };
+      if (defaultRole === "denied") {
+        // empty roles → no caps → blocked at the engine
+      } else {
+        const roleId = slugifyRoleId(defaultRole, warnings);
+        acc.roles.add(roleId);
+      }
+      // Idempotency — if the principal already exists from an earlier
+      // pass, merge rather than overwrite.
+      const existing = principals.get(anonId);
+      if (existing) {
+        for (const r of acc.roles) existing.roles.add(r);
+      } else {
+        principals.set(anonId, acc);
+      }
+    }
+    if (defaultRole === "allow-all") {
+      const anonId = `anonymous-${view.platform}-${view.agentId}`;
+      // Synthesise an "allow-all" role with every namespaced capability.
+      const allowAllRoleId = "allow-all";
+      let role = roleAcc.get(allowAllRoleId);
+      if (role === undefined) {
+        const caps = new Set<string>();
+        caps.add("keyword.chat");
+        caps.add("keyword.async");
+        caps.add("keyword.team");
+        for (const c of invertDisallowedTools([])) caps.add(c);
+        for (const dc of dispatchCaps) caps.add(dc);
+        role = { id: allowAllRoleId, capabilities: caps, bundleHashes: new Set() };
+        roleAcc.set(allowAllRoleId, role);
+      }
+      const existing = principals.get(anonId);
+      if (existing) {
+        existing.roles.add(allowAllRoleId);
+      } else {
+        principals.set(anonId, {
+          id: anonId,
+          home_operator: input.operatorId,
+          home_stack: input.homeStack,
+          platform_ids: {},
+          roles: new Set([allowAllRoleId]),
+          trust: new Set(),
+          sessionDefault: emptySessionConfig(),
+          sessionDm: undefined,
+          external: false,
+        });
+      }
+    }
+
+    // dm.operatorRole → operator principal session_config.dm.
+    const dm = view.dm;
+    if (dm?.operatorRole) {
+      const opPlatformId = input.operatorPlatformIds[view.platform];
+      const operatorPrincipalId = "operator";
+      let opPrincipal = principals.get(operatorPrincipalId);
+      if (opPrincipal === undefined) {
+        opPrincipal = {
+          id: operatorPrincipalId,
+          home_operator: input.operatorId,
+          home_stack: input.homeStack,
+          platform_ids: {},
+          roles: new Set(["operator"]),
+          trust: new Set(),
+          sessionDefault: emptySessionConfig(),
+          sessionDm: undefined,
+          external: false,
+        };
+        principals.set(operatorPrincipalId, opPrincipal);
+        // Ensure an operator role exists so the cross-ref refine passes.
+        if (!roleAcc.has("operator")) {
+          const caps = new Set<string>([
+            "keyword.chat",
+            "keyword.async",
+            "keyword.team",
+            "operator",
+            ...dispatchCaps,
+            ...invertDisallowedTools([]),
+          ]);
+          roleAcc.set("operator", {
+            id: "operator",
+            capabilities: caps,
+            bundleHashes: new Set(),
+          });
+        }
+      }
+      if (opPlatformId !== undefined) {
+        addPlatformId(opPrincipal, view.platform, opPlatformId);
+      }
+      // Build the DM session config from this dm.operatorRole bundle.
+      const dmAllowedDirs = Array.isArray(dm.operatorRole.allowedDirs)
+        ? toStringArray(dm.operatorRole.allowedDirs)
+        : undefined;
+      const dmAllowedSkills = Array.isArray(dm.operatorRole.allowedSkills)
+        ? toStringArray(dm.operatorRole.allowedSkills)
+        : undefined;
+      const dmBashGuard = toBoolean(dm.operatorRole.bashGuard, true);
+      const dmBashAllowlist = isBashAllowlist(dm.operatorRole.bashAllowlist);
+      opPrincipal.sessionDm = absorbSessionConfig(opPrincipal.sessionDm ?? emptySessionConfig(), {
+        allowedDirs: dmAllowedDirs,
+        allowedSkills: dmAllowedSkills,
+        bashGuard: dmBashGuard,
+        bashAllowlist: dmBashAllowlist,
+      });
+      // Fold the operator's keyword features into the operator role too,
+      // so a legacy `dm.operatorRole.features = [chat, async, team]`
+      // survives.
+      const dmFeatures = toStringArray(dm.operatorRole.features);
+      const operatorRole = roleAcc.get("operator");
+      if (operatorRole) {
+        for (const f of dmFeatures) {
+          const ns = BARE_KEYWORD_REWRITES.get(f);
+          if (ns) operatorRole.capabilities.add(ns);
+        }
+      }
+    }
+
+    // dm.userRoles[] → augment the existing per-user principal's session_config.dm.
+    for (const ur of dm?.userRoles ?? []) {
+      const users = toStringArray(ur.users);
+      for (const u of users) {
+        const labelKey = `${view.platform}:${u}`;
+        const principalId = input.labels?.get(labelKey) ?? synthesisePrincipalId(view.platform, u);
+        let principal = principals.get(principalId);
+        if (principal === undefined) {
+          // The user is in a DM userRoles[] but not in any channel role —
+          // synthesise a principal so their DM session_config has somewhere
+          // to land. Their channel-context session config stays empty.
+          principal = {
+            id: principalId,
+            home_operator: input.operatorId,
+            home_stack: input.homeStack,
+            platform_ids: {},
+            roles: new Set(),
+            trust: new Set(),
+            sessionDefault: emptySessionConfig(),
+            sessionDm: undefined,
+            external: false,
+          };
+          principals.set(principalId, principal);
+        }
+        addPlatformId(principal, view.platform, u);
+        const urAllowedDirs = Array.isArray(ur.allowedDirs) ? toStringArray(ur.allowedDirs) : undefined;
+        const urAllowedSkills = Array.isArray(ur.allowedSkills) ? toStringArray(ur.allowedSkills) : undefined;
+        const urBashGuard = toBoolean(ur.bashGuard, true);
+        const urBashAllowlist = isBashAllowlist(ur.bashAllowlist);
+        principal.sessionDm = absorbSessionConfig(principal.sessionDm ?? emptySessionConfig(), {
+          allowedDirs: urAllowedDirs,
+          allowedSkills: urAllowedSkills,
+          bashGuard: urBashGuard,
+          bashAllowlist: urBashAllowlist,
+        });
+        // Per-user DM features (chat etc.) → fold into the principal's
+        // roles[] via a dm-derived role. Simpler: skip the role
+        // expansion and let dispatch enforce keyword.* via the principal's
+        // existing channel roles. Anything in `ur.disallowedTools` is
+        // captured in the inverted tool list — but we model that as a
+        // DM-only constraint, not a role. The session_config carries it
+        // implicitly via `bash_allowlist` (the only DM-specific gate);
+        // tool denies don't migrate to session_config (they live on
+        // capabilities). For semantic preservation we emit a warning so
+        // the operator sees the gap.
+        const urDisallowed = toStringArray(ur.disallowedTools);
+        if (urDisallowed.length > 0) {
+          warnings.push({
+            field: `policy.principals[${principalId}].session_config.dm`,
+            message:
+              `legacy dm.userRoles[].disallowedTools=[${urDisallowed.join(", ")}] is not representable in the new schema's session_config; ` +
+              `tool denies are role-level capabilities. The principal's channel-context role already encodes the same denies; ` +
+              `if their DM context needs a different deny set, create a DM-specific role and reference it.`,
+          });
+        }
+      }
+    }
+  }
+
+  // Cross-adapter conflict warnings — emit one warning per role that has
+  // >1 distinct bundle hash across platforms.
+  for (const [roleId, bundles] of seenRoleBundles) {
+    const hashes = new Set(bundles.map((b) => b.hash));
+    if (hashes.size > 1) {
+      const platforms = bundles.map((b) => b.platform);
+      const distinctPlatforms = [...new Set(platforms)];
+      warnings.push({
+        field: `policy.roles[${roleId}]`,
+        message:
+          `role "${roleId}" declared with different field bundles across platforms [${distinctPlatforms.join(", ")}] — ` +
+          `migration emits the conservative UNION of capabilities. ` +
+          `Operator-tighten manually post-migration if a narrower grant is intended.`,
+      });
+    }
+  }
+
+  // Serialise + sort.
+  const policy = serialisePolicy(principals, roleAcc);
+
+  return { policy, warnings };
+}
+
+// =============================================================================
+// Helpers — platform-id add, session_config merge, bash_allowlist coercion
+// =============================================================================
+
+function addPlatformId(p: PrincipalAccumulator, platform: string, id: string): void {
+  let set = p.platform_ids[platform];
+  if (set === undefined) {
+    set = new Set();
+    p.platform_ids[platform] = set;
+  }
+  set.add(id);
+}
+
+/**
+ * Merge an incoming session-config bundle into an existing accumulator.
+ * Conservative — UNION for allowedDirs/Skills, AND for bashGuard
+ * (any false → false; matches the most-permissive bash semantic), and
+ * union-merge for bashAllowlist rules + repos.
+ */
+function absorbSessionConfig(
+  acc: SessionConfigAcc,
+  incoming: {
+    allowedDirs: string[] | undefined;
+    allowedSkills: string[] | undefined;
+    bashGuard: boolean;
+    bashAllowlist: SessionConfigAcc["bashAllowlist"];
+  },
+): SessionConfigAcc {
+  const next: SessionConfigAcc = {
+    allowedDirs: acc.allowedDirs,
+    allowedSkills: acc.allowedSkills,
+    bashGuard: acc.bashGuard && incoming.bashGuard,
+    bashAllowlist: acc.bashAllowlist,
+  };
+  if (incoming.allowedDirs !== undefined) {
+    next.allowedDirs = unionSorted(acc.allowedDirs ?? [], incoming.allowedDirs);
+  }
+  if (incoming.allowedSkills !== undefined) {
+    next.allowedSkills = unionSorted(acc.allowedSkills ?? [], incoming.allowedSkills);
+  }
+  if (incoming.bashAllowlist !== undefined) {
+    if (acc.bashAllowlist === undefined) {
+      next.bashAllowlist = {
+        rules: [...incoming.bashAllowlist.rules].sort((a, b) =>
+          a.pattern.localeCompare(b.pattern),
+        ),
+        repos: [...incoming.bashAllowlist.repos].sort(),
+      };
+    } else {
+      // Union rules by pattern, repos by string equality.
+      const ruleMap = new Map<string, { pattern: string; repos?: string[] }>();
+      for (const r of acc.bashAllowlist.rules) ruleMap.set(r.pattern, r);
+      for (const r of incoming.bashAllowlist.rules) {
+        const prior = ruleMap.get(r.pattern);
+        if (prior === undefined) ruleMap.set(r.pattern, r);
+        else if (r.repos && prior.repos) {
+          ruleMap.set(r.pattern, {
+            pattern: r.pattern,
+            repos: unionSorted(prior.repos, r.repos),
+          });
+        }
+      }
+      next.bashAllowlist = {
+        rules: [...ruleMap.values()].sort((a, b) => a.pattern.localeCompare(b.pattern)),
+        repos: unionSorted(acc.bashAllowlist.repos, incoming.bashAllowlist.repos),
+      };
+    }
+  }
+  return next;
+}
+
+function unionSorted(a: string[], b: string[]): string[] {
+  const set = new Set<string>([...a, ...b]);
+  return [...set].sort();
+}
+
+function isBashAllowlist(val: unknown): SessionConfigAcc["bashAllowlist"] {
+  if (!val || typeof val !== "object") return undefined;
+  const v = val as { rules?: unknown; repos?: unknown };
+  const rules: { pattern: string; repos?: string[] }[] = [];
+  if (Array.isArray(v.rules)) {
+    for (const r of v.rules) {
+      if (!r || typeof r !== "object") continue;
+      const rr = r as { pattern?: unknown; repos?: unknown };
+      if (typeof rr.pattern !== "string") continue;
+      const out: { pattern: string; repos?: string[] } = { pattern: rr.pattern };
+      const reposArr = Array.isArray(rr.repos) ? toStringArray(rr.repos) : undefined;
+      if (reposArr !== undefined) out.repos = reposArr;
+      rules.push(out);
+    }
+  }
+  const repos = Array.isArray(v.repos) ? toStringArray(v.repos) : [];
+  return { rules, repos };
+}
+
+// =============================================================================
+// Serialise + sort for deterministic output
+// =============================================================================
+
+function serialisePolicy(
+  principals: Map<string, PrincipalAccumulator>,
+  roles: Map<string, RoleAccumulator>,
+): { principals: PolicyPrincipal[]; roles: PolicyRole[] } {
+  const principalsOut: PolicyPrincipal[] = [];
+  const sortedPrincipals = [...principals.values()].sort((a, b) => a.id.localeCompare(b.id));
+  for (const acc of sortedPrincipals) {
+    const platformIds: Record<string, string[]> = {};
+    const platformNames = [...Object.keys(acc.platform_ids)].sort();
+    for (const platform of platformNames) {
+      const set = acc.platform_ids[platform];
+      if (set !== undefined) platformIds[platform] = [...set].sort();
+    }
+    const p: PolicyPrincipal = {
+      id: acc.id,
+      home_operator: acc.home_operator,
+      home_stack: acc.home_stack,
+      role: [...acc.roles].sort(),
+      trust: [...acc.trust].sort(),
+      platform_ids: platformIds,
+    };
+    const hasSessionDefault = !isSessionConfigDefault(acc.sessionDefault);
+    if (hasSessionDefault || acc.sessionDm !== undefined) {
+      p.session_config = {
+        default: serialiseSessionConfig(acc.sessionDefault),
+      };
+      if (acc.sessionDm !== undefined) {
+        p.session_config.dm = serialiseSessionConfig(acc.sessionDm);
+      }
+    }
+    principalsOut.push(p);
+  }
+  const rolesOut: PolicyRole[] = [];
+  const sortedRoles = [...roles.values()].sort((a, b) => a.id.localeCompare(b.id));
+  for (const acc of sortedRoles) {
+    rolesOut.push({
+      id: acc.id,
+      capabilities: [...acc.capabilities].sort(),
+    });
+  }
+  return { principals: principalsOut, roles: rolesOut };
+}
+
+// =============================================================================
+// --check pre-flight semantic-preservation report (§9.1)
+// =============================================================================
+
+export interface PolicyPreflightGap {
+  kind:
+    | "principal-missing-for-platform-user"
+    | "role-missing-for-default-role"
+    | "principal-missing-for-dm-user";
+  /** Platform-side identity the gap refers to (e.g. Discord snowflake). */
+  platform?: string;
+  platformId?: string;
+  /** Role name referenced by a legacy `defaultRole` that has no policy.roles entry. */
+  roleName?: string;
+  agentId?: string;
+  /** Free-form human-readable hint. */
+  hint: string;
+}
+
+export interface PolicyPreflightInput {
+  views: PolicyAdapterView[];
+  policy: {
+    /**
+     * Permissive shape — pre-flight may run against pre-Zod-parsed input
+     * (operator pre-cutover with hand-edited cortex.yaml lacking some fields).
+     */
+    principals: (Omit<PolicyPrincipal, "platform_ids"> & {
+      platform_ids?: PolicyPrincipal["platform_ids"];
+    })[];
+    roles: PolicyRole[];
+  };
+}
+
+/**
+ * Compute the gap set for the cortex#296 parallel-mode pre-flight. The
+ * gates are:
+ *
+ *   1. Every user-id in any legacy `presence.<platform>.roles[].users[]`
+ *      MUST have a principal whose `platform_ids.<platform>` lists it.
+ *   2. Every user-id in any legacy `dm.userRoles[].users[]` MUST have a
+ *      principal whose `platform_ids.<platform>` lists it.
+ *   3. Every role-name referenced by any legacy `defaultRole` MUST have a
+ *      matching `policy.roles[].id`. The synthetic `denied`/`allow-all`
+ *      sentinel values are exempt — they don't reference a real role.
+ */
+export function policyPreflight(input: PolicyPreflightInput): PolicyPreflightGap[] {
+  const gaps: PolicyPreflightGap[] = [];
+
+  // Build the (platform, id) → principal-id lookup the gates consult.
+  const platformLookup = new Map<string, string>();
+  for (const p of input.policy.principals) {
+    for (const [platform, ids] of Object.entries(p.platform_ids ?? {})) {
+      for (const id of ids) {
+        platformLookup.set(`${platform}${id}`, p.id);
+      }
+    }
+  }
+  const knownRoleIds = new Set(input.policy.roles.map((r) => r.id));
+
+  for (const view of input.views) {
+    for (const role of view.roles) {
+      const users = toStringArray(role.users);
+      for (const u of users) {
+        const key = `${view.platform}${u}`;
+        if (!platformLookup.has(key)) {
+          gaps.push({
+            kind: "principal-missing-for-platform-user",
+            platform: view.platform,
+            platformId: u,
+            agentId: view.agentId,
+            hint:
+              `legacy ${view.platform} user "${u}" (referenced by agent ${view.agentId}'s ` +
+              `presence role "${asString(role.name) ?? "<unnamed>"}") has no principal claiming this id ` +
+              `via platform_ids.${view.platform}[]. parallel-mode would silently deny authorisation for this user.`,
+          });
+        }
+      }
+    }
+    const dr = view.defaultRole;
+    if (dr !== undefined && dr !== "denied" && dr !== "allow-all") {
+      if (!knownRoleIds.has(dr)) {
+        gaps.push({
+          kind: "role-missing-for-default-role",
+          agentId: view.agentId,
+          roleName: dr,
+          hint:
+            `legacy defaultRole "${dr}" on agent ${view.agentId}'s ${view.platform} presence ` +
+            `does not appear in policy.roles[]. The anonymous-${view.platform}-${view.agentId} principal ` +
+            `would resolve to no capabilities.`,
+        });
+      }
+    }
+    for (const ur of view.dm?.userRoles ?? []) {
+      const users = toStringArray(ur.users);
+      for (const u of users) {
+        const key = `${view.platform}${u}`;
+        if (!platformLookup.has(key)) {
+          gaps.push({
+            kind: "principal-missing-for-dm-user",
+            platform: view.platform,
+            platformId: u,
+            agentId: view.agentId,
+            hint:
+              `legacy dm.userRoles ${view.platform} user "${u}" (referenced by agent ${view.agentId}) has no principal ` +
+              `claiming this id via platform_ids.${view.platform}[]. parallel-mode would deny their DM messages.`,
+          });
+        }
+      }
+    }
+  }
+  return gaps;
+}
+
+export function formatPreflightReport(gaps: readonly PolicyPreflightGap[]): string {
+  if (gaps.length === 0) {
+    return "policy preflight: OK — every legacy user + defaultRole resolves through the new policy block.";
+  }
+  const lines = [`policy preflight: ${gaps.length} gap(s) — parallel-mode activation BLOCKED:`];
+  for (let i = 0; i < gaps.length; i++) {
+    const g = gaps[i];
+    if (!g) continue;
+    lines.push(`  [${i + 1}/${gaps.length}] ${g.kind}: ${g.hint}`);
+  }
+  return lines.join("\n");
+}

--- a/src/cli/cortex/commands/migrate-config.ts
+++ b/src/cli/cortex/commands/migrate-config.ts
@@ -33,6 +33,7 @@ import {
 interface ParsedArgs {
   input: string | undefined;
   out: string | undefined;
+  labels: string | undefined;
   check: boolean;
   strict: boolean;
   help: boolean;
@@ -46,6 +47,7 @@ export function parseArgs(argv: string[]): ParsedArgs {
   const args: ParsedArgs = {
     input: undefined,
     out: undefined,
+    labels: undefined,
     check: false,
     strict: false,
     help: false,
@@ -67,6 +69,15 @@ export function parseArgs(argv: string[]): ParsedArgs {
       i++;
     } else if (a.startsWith("--out=")) {
       args.out = a.slice("--out=".length);
+    } else if (a === "--labels") {
+      const next = argv[i + 1];
+      if (next === undefined || next.startsWith("--")) {
+        throw new Error("--labels requires a path argument");
+      }
+      args.labels = next;
+      i++;
+    } else if (a.startsWith("--labels=")) {
+      args.labels = a.slice("--labels=".length);
     } else if (a.startsWith("--")) {
       throw new Error(`unknown flag: ${a}`);
     } else if (args.input === undefined) {
@@ -79,12 +90,13 @@ export function parseArgs(argv: string[]): ParsedArgs {
 }
 
 function printHelp(): void {
-  console.log("cortex migrate-config — convert grove-v2 bot.yaml to cortex.yaml\n");
+  console.log("cortex migrate-config — convert grove-v2 bot.yaml or cortex.yaml to cortex.yaml + policy block\n");
   console.log("Usage:");
   console.log("  bun src/cli/cortex/commands/migrate-config.ts <input.yaml> [options]\n");
   console.log("Options:");
   console.log("  --out FILE     Write to FILE (default: stdout)");
-  console.log("  --check        Validate only — print mapping table + warnings; don't emit yaml");
+  console.log("  --labels FILE  Principal-id label overrides ({\"<platform>:<id>\": \"<principal-id>\"})");
+  console.log("  --check        Validate + emit pre-flight gap report; exits 1 if gaps found");
   console.log("  --strict       Fail on warnings (default: warnings → stderr, exit 0)");
   console.log("  -h, --help     Show this help");
 }
@@ -133,33 +145,79 @@ export async function runMigrateConfig(argv: string[]): Promise<number> {
     return 1;
   }
 
+  let labels: Map<string, string> | undefined;
+  if (args.labels) {
+    const labelsPath = resolve(args.labels);
+    try {
+      const labelsRaw = readFileSync(labelsPath, "utf-8");
+      const parsed = YAML.parse(labelsRaw) as unknown;
+      if (!parsed || typeof parsed !== "object") {
+        throw new Error("labels file must be a YAML mapping");
+      }
+      labels = new Map();
+      for (const [k, v] of Object.entries(parsed as Record<string, unknown>)) {
+        if (typeof v !== "string") {
+          throw new Error(`labels: value for "${k}" must be a string`);
+        }
+        labels.set(k, v);
+      }
+    } catch (err) {
+      console.error(`Error: cannot read labels file ${labelsPath}: ${err instanceof Error ? err.message : String(err)}`);
+      return 1;
+    }
+  }
+
   let result;
   try {
-    result = convertBotYaml(legacy, { configDir: dirname(inputPath) });
+    result = convertBotYaml(legacy, { configDir: dirname(inputPath), labels });
   } catch (err) {
     console.error(`Error: conversion failed: ${err instanceof Error ? err.message : String(err)}`);
     return 1;
+  }
+
+  // cortex#295 / #296 — `--check` is the operator pre-flight for
+  // parallel-mode activation. The legacy mapping table is still useful
+  // diagnostically (operators eyeballing the conversion), so emit it
+  // alongside the preflight gap report. Exit non-zero ONLY when there
+  // are preflight gaps so CI / a future automated activator can gate on it.
+  if (args.check) {
+    for (const w of result.warnings) {
+      process.stderr.write(`warning [${w.field}] ${w.message}\n`);
+    }
+    console.log(formatCheckReport(result));
+    if (result.preflightGaps.length > 0) {
+      process.stderr.write(
+        `\nmigrate-config --check: ${result.preflightGaps.length} pre-flight gap(s) — parallel-mode activation BLOCKED. ` +
+        `See policy preflight section above for the field-level breakdown.\n`,
+      );
+      return 1;
+    }
+    // `--strict` keeps its pre-existing semantic in --check mode too:
+    // any warnings → exit 2 (legacy migrate-config.test.ts pins this).
+    if (args.strict && result.warnings.length > 0) {
+      return 2;
+    }
+    return 0;
   }
 
   for (const w of result.warnings) {
     console.error(`warning [${w.field}] ${w.message}`);
   }
 
-  if (args.check) {
-    console.log(formatCheckReport(result));
+  const yamlOut = YAML.stringify(result.cortex, { indent: 2, lineWidth: 0 });
+  if (args.out) {
+    const outPath = resolve(args.out);
+    // cortex#88 item 5: a fresh host has no `~/.config/cortex/`, so
+    // writeFileSync ENOENTs unless we ensure the parent exists. mkdir
+    // recursive is idempotent — pre-existing dirs are a no-op.
+    mkdirSync(dirname(outPath), { recursive: true });
+    writeFileSync(outPath, yamlOut, "utf-8");
+    const policySummary = result.cortex.policy
+      ? `, ${result.cortex.policy.principals.length} principal(s), ${result.cortex.policy.roles.length} role(s)`
+      : "";
+    console.error(`wrote ${outPath} (${result.cortex.agents.length} agent(s), ${result.cortex.renderers.length} renderer(s)${policySummary})`);
   } else {
-    const yamlOut = YAML.stringify(result.cortex, { indent: 2, lineWidth: 0 });
-    if (args.out) {
-      const outPath = resolve(args.out);
-      // cortex#88 item 5: a fresh host has no `~/.config/cortex/`, so
-      // writeFileSync ENOENTs unless we ensure the parent exists. mkdir
-      // recursive is idempotent — pre-existing dirs are a no-op.
-      mkdirSync(dirname(outPath), { recursive: true });
-      writeFileSync(outPath, yamlOut, "utf-8");
-      console.error(`wrote ${outPath} (${result.cortex.agents.length} agent(s), ${result.cortex.renderers.length} renderer(s))`);
-    } else {
-      process.stdout.write(yamlOut);
-    }
+    process.stdout.write(yamlOut);
   }
 
   if (args.strict && result.warnings.length > 0) {


### PR DESCRIPTION
Closes #295.

## Summary

Extends `cortex migrate-config` to synthesise a top-level `policy:` block from legacy `agents[].presence.<platform>.roles[]` declarations alongside the existing config translation. This is slice C.2c (cortex#295) of the v2.0.0 policy cutover — see `docs/design-policy-cutover.md` for the architectural design.

The CLI now:
- emits a `policy:` block with `PolicyPrincipal` + `PolicyRole` entries synthesised from legacy presence roles + DM blocks
- adds `--check` mode (no output, exit 1 on policy gaps) for the cortex#296 parallel-mode pre-flight
- adds `--labels labels.yaml` for stable human-readable principal ids
- is idempotent — re-running on an already-migrated file produces byte-identical output

## Algorithm (per design §6)

### Step 1 — Per legacy role → `PolicyRole`
- `id = role.name` (validated against `LETTER_PREFIX_ID_REGEX`, slugified + warned if not)
- `capabilities = features + invertDisallowedTools(disallowedTools) + dispatch.<agent>` using cortex#294's canonical Claude tool inventory + invert helper

### Step 2 — Per user in `role.users[]` → `PolicyPrincipal`
- id synthesised from the platform user id (`user-` + hash) or overridden via `--labels`
- `platform_ids.<platform> = [user_id]`
- `role = [role.name]`
- `session_config.default` combines `allowedDirs` + `allowedSkills` + `bashAllowlist`

### Step 3 — Unification
Same Discord id appearing in Luna's, Echo's, and Forge's role lists collapses to ONE principal (not three). Roles + platform_ids + session_config merge as unions.

### Step 4 — `defaultRole` handling
- `allow-all` → synthetic `allow-all` role with the full capability set
- `denied` → synthetic `anonymous-*` principal with empty role[]
- `<name>` → synthetic `anonymous-*` principal referencing that role

### Step 5 — DM `operatorRole`
Operator principal carries `session_config.dm` from the broader DM bash_allowlist; `session_config.default` from the channel-level `operator` role.

### Step 6 — DM `userRoles[]`
Augment the matching principal's `session_config.dm`.

### Step 7 — External-peer references
Every `agent-<X>` role where `X` isn't a declared local agent → principal with `home_operator: "unknown"`, `home_stack: "unknown/unknown"` + a hand-fix-me warning.

### Step 8 — Cross-adapter role conflict (§13 Q4)
Same role name with different field bundles across Discord/Mattermost/Slack → ONE role with the UNION of capabilities + a hand-tighten warning.

### Step 9 — Capability namespace rewrite (§12.1)
Bare keyword caps (`chat`, `async`, `team`) in pre-existing policy blocks get rewritten to `keyword.*` form.

### Step 10 — Idempotency
- principals sorted by id
- roles sorted by id
- role lists + platform_ids entries within each principal sorted
- bash_allowlist rules sorted by pattern; repos sorted

## `--check` mode (§9.1)

```bash
cortex migrate-config <migrated-file> --check
# exit 0 = parallel-mode pre-flight OK
# exit 1 = gap report on stderr
```

Gates: every legacy user-id has a claiming principal; every `defaultRole` references a real role.

## Acceptance summary

| Check | Result |
|-------|--------|
| `bunx tsc --noEmit` | clean (exit 0) |
| `bun run lint:errors` | clean (exit 0) |
| `bun test src/cli/cortex/commands/__tests__/` | 210 pass / 0 fail / 483 expect() (16 new tests in `migrate-config-policy.test.ts`) |
| `bun test` (full suite) | 3282 pass / 1 skip / 0 fail |
| Operator's `~/.config/cortex/cortex.yaml` migration | 3 agents, 12 principals, 10 roles |
| `migrate-config --check` on migrated operator config | `policy preflight: OK`, exit 0 |
| Idempotency on operator config | byte-identical second run (`diff` empty) |
| `cortex.work.yaml` (already policy-shape) | no-op on principals; bare caps rewritten |

## Files

- `src/cli/cortex/commands/migrate-config-policy.ts` — algorithm + `buildPolicy()` + `policyPreflight()` (new)
- `src/cli/cortex/commands/__tests__/migrate-config-policy.test.ts` — 16 acceptance tests (new)
- `src/cli/cortex/commands/migrate-config-lib.ts` — wires policy synth into `convertBotYaml`
- `src/cli/cortex/commands/migrate-config.ts` — `--check` + `--labels` flags
- `docs/sop-migrate-config.md` — operator-facing SOP (new)
- `docs/migration-examples/` — worked before/after pair (new)

## Test plan

- [x] All 14 acceptance scenarios from cortex#295 covered (single adapter, three adapters, cross-adapter dedup + conflict, DM operatorRole + userRoles, defaultRole variants, external peer, idempotency, --labels, --check pass + fail, disallowedTools inversion, bare-keyword rewrites)
- [x] Operator's real config migrates cleanly + `--check` exits 0
- [x] Work stack (already-policy-shape) round-trips cleanly
- [x] tsc + lint + full test suite all green