### PR TITLE
feat(services): set CORTEX_POLICY_REQUIRE_UNVERIFIED_ACK=1 on bot plists (refs cortex#311)

### DIFF
--- a/src/services/ai.meta-factory.cortex.meta-factory.plist
+++ b/src/services/ai.meta-factory.cortex.meta-factory.plist
@@ -29,6 +29,17 @@
         <string>__HOME__/bin:/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin</string>
         <key>GROVE_CHANNEL</key>
         <string>__AGENT_NAME__</string>
+        <!--
+            v2.0.0 (cortex#297): the `policy:` block is now the sole
+            authorisation gate, but Phase B (cortex#114) verification of
+            `signed_by[0].principal` is not yet wired into the envelope
+            validator. The operator acknowledges via this env var that
+            principal claims authenticate at face value during the
+            pre-Phase-B window. Tracked as cortex#311 (retire the env-var
+            gate once cortex#114 ships).
+        -->
+        <key>CORTEX_POLICY_REQUIRE_UNVERIFIED_ACK</key>
+        <string>1</string>
     </dict>
 </dict>
 </plist>

--- a/src/services/ai.meta-factory.cortex.work.plist
+++ b/src/services/ai.meta-factory.cortex.work.plist
@@ -33,6 +33,17 @@
         <string>luna</string>
         <key>CORTEX_AGENT_ID</key>
         <string>luna-work</string>
+        <!--
+            v2.0.0 (cortex#297): the `policy:` block is now the sole
+            authorisation gate, but Phase B (cortex#114) verification of
+            `signed_by[0].principal` is not yet wired into the envelope
+            validator. The operator acknowledges via this env var that
+            principal claims authenticate at face value during the
+            pre-Phase-B window. Tracked as cortex#311 (retire the env-var
+            gate once cortex#114 ships).
+        -->
+        <key>CORTEX_POLICY_REQUIRE_UNVERIFIED_ACK</key>
+        <string>1</string>
     </dict>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary

v2.0.0 made the \`policy:\` block the sole authorisation gate. The pre-Phase-B env-var ack \`CORTEX_POLICY_REQUIRE_UNVERIFIED_ACK\` defaults to unset, meaning daemons booted post-upgrade with PolicyEngine OFF — exactly the M-3 split-brain Echo flagged on PR #310 and I filed as cortex#311.

This PR sets the env var to \`1\` in both bot plists so the operator's explicit acknowledgement ships baked into the launchd-managed daemon environment. PolicyEngine activates as designed.

## Why this is acceptable

- Risk: signed_by[0].principal claims authenticate at face value pre-Phase-B (cortex#114 wires the cryptographic verifier).
- Attack surface today: local-only NATS — only shell access on the operator's machine can fabricate a principal claim, which is already root-equivalent.
- cortex#311 tracks the proper fix (retire the env-var gate once cortex#114 ships).

## Files changed

- \`src/services/ai.meta-factory.cortex.meta-factory.plist\`
- \`src/services/ai.meta-factory.cortex.work.plist\`

Each plist gains the env var entry with an inline XML comment explaining the rationale. No render-script changes needed — \`scripts/lib/plist-render.sh\` copies the EnvironmentVariables dict verbatim through its template substitution.

## Verification

- \`plutil -lint\` passes on both modified plists
- Inline rationale comment in each plist points at cortex#297 (the cutover) and cortex#311 (the eventual retirement)
- No code path changes

## Operator action after merge

\`arc upgrade Cortex\` will re-render the plists with the new env var + reload daemons. PolicyEngine activates; the boot-log warning retires; humans can talk to bots again.

## Refs

- cortex#311 (the gate to retire entirely once cortex#114 lands)
- PR #310 round-1 M-3 finding
- cortex#220 (Echo C.2a sign-off where the env-var ack pattern was first introduced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)