### PR TITLE
fix(boot): cortex#314 — first-install safety — yaml.example + boot warnings + validator wording

### DIFF
--- a/cortex.yaml.example
+++ b/cortex.yaml.example
@@ -1,0 +1,290 @@
+# cortex.yaml — example configuration for a fresh install
+#
+# Copy this file to one of the locations the cortex CLI scans (default:
+# `~/.config/cortex/cortex.yaml`) and replace every `<REPLACE_ME>` marker
+# below with your own values. The file parses cleanly out of the box —
+# replace markers gradually as you wire each surface.
+#
+# Refs: cortex#314 (first-install safety). See docs/architecture.md §9.1
+# for the full schema and docs/plan-cortex-migration.md for migration
+# context if you are coming from grove-v2 bot.yaml.
+#
+# IMPORTANT — capability-dispatch contract
+# ----------------------------------------
+# cortex has TWO related capability surfaces:
+#
+#   1. Top-level `capabilities[]` — the STACK CATALOG. This is the source
+#      of truth that the dispatch consumer + future network registry
+#      consult. Add an entry here for every capability your agents
+#      provide.
+#
+#   2. Per-agent `runtime.capabilities[]` — the AGENT's declaration of
+#      intent. Listing a capability on an agent is how the boot loop
+#      knows to instantiate a review consumer for that agent.
+#
+# The cross-validator at `src/common/types/cortex-config.ts` enforces
+# that every id in `agents[].runtime.capabilities[]` ALSO appears as an
+# `id:` in the top-level `capabilities[]` block. A reference that does
+# not resolve fails config load with a pointed error.
+#
+# The two surfaces are NOT symmetric: the top-level catalog is the
+# registry. Adding to the catalog is almost always the right fix when
+# the validator complains.
+
+# -----------------------------------------------------------------------------
+# operator — who is running this cortex instance
+# -----------------------------------------------------------------------------
+operator:
+  # Lowercase letter-prefixed id. Surfaces as the `{org}` segment in NATS
+  # subjects (`local.{org}.>`) and as the stack-id default. Must match
+  # `^[a-z][a-z0-9-]*$` — replace the placeholder below with your own
+  # short slug (e.g. `andreas`, `team-research`).
+  id: operator-name  # <REPLACE_ME>
+  # Human-readable display name shown on the dashboard.
+  displayName: Operator Name  # <REPLACE_ME>
+  # Your Discord snowflake (numeric string). Used by the policy block's
+  # `operator` principal so the bot recognises you as the operator on
+  # Discord. Remove the line if you are not using Discord.
+  discordId: "000000000000000000"  # <REPLACE_ME>: paste your numeric Discord id
+  # ISO-3166 country code stamped into `sovereignty.data_residency` on
+  # every emitted envelope. Defaults to "NZ" when omitted.
+  dataResidency: NZ
+
+# -----------------------------------------------------------------------------
+# stack — optional identity of this cortex deployment within the operator
+# -----------------------------------------------------------------------------
+# When omitted, `deriveStackId` defaults to `${operator.id}/default`. Declare
+# explicitly once you run more than one stack per operator.
+stack:
+  # Must match `{operator_id}/{stack_id}` grammar — both segments lowercase
+  # alphanumeric + hyphen/underscore, each starting with a letter. Keep the
+  # operator-id half in sync with `operator.id` above.
+  id: operator-name/meta-factory  # <REPLACE_ME>: keep operator-name half in sync with operator.id
+
+# -----------------------------------------------------------------------------
+# capabilities — STACK CATALOG (source of truth for capability-dispatch)
+# -----------------------------------------------------------------------------
+# Each entry is a constrained-schema declaration with `id`, `description`,
+# and `provided_by[]` (≥1 declared agent id). Optional fields are `tags`,
+# `rate`, `cost` — see `src/common/types/capability.ts` for the full grammar.
+#
+# The 8 code-review.* flavors below match the arc-skill-code-review skill
+# pack shipped with Echo. Pilot's `pilot request-review --capability X`
+# requests resolve against this catalog, so every `--capability X` value
+# an operator might invoke must have a matching entry here.
+capabilities:
+  - id: code-review.typescript
+    description: TypeScript code review (correctness, types, idioms)
+    provided_by: [echo]
+  - id: code-review.documentation
+    description: Documentation review (markdown specs, design docs, READMEs)
+    provided_by: [echo]
+  - id: code-review.security
+    description: Security review (auth, secrets, OWASP, defensive coding)
+    provided_by: [echo]
+  - id: code-review.architecture
+    description: Architecture review (layering, dependencies, design fit)
+    provided_by: [echo]
+  - id: code-review.performance
+    description: Performance review (algorithmic complexity, hot paths, allocations)
+    provided_by: [echo]
+  - id: code-review.ecosystem-compliance
+    description: Ecosystem compliance review (CLAUDE.md, SOP adherence, conventions)
+    provided_by: [echo]
+  - id: code-review.hardening
+    description: Hardening review (defensive boundaries, failure handling, error paths)
+    provided_by: [echo]
+  - id: code-review.skill-quality
+    description: Skill quality review (AGENTSKILLS.io structure, triggers, tests)
+    provided_by: [echo]
+
+# -----------------------------------------------------------------------------
+# policy — principal + role registry consumed by the PolicyEngine
+# -----------------------------------------------------------------------------
+# Minimal single-principal example: declare yourself as the operator so
+# the bot recognises your Discord identity. Extend with per-agent
+# principals (one entry per `agents[]` member) once you wire agent-side
+# trust + capability gating.
+policy:
+  principals:
+    - id: operator
+      # <REPLACE_ME>: keep both fields in sync with `operator.id` and `stack.id` above.
+      home_operator: operator-name
+      home_stack: operator-name/meta-factory
+      role:
+        - operator
+      trust: []
+      platform_ids:
+        discord:
+          - "000000000000000000"  # <REPLACE_ME>: your operator Discord id
+    - id: echo
+      home_operator: operator-name  # <REPLACE_ME>
+      home_stack: operator-name/meta-factory  # <REPLACE_ME>
+      role:
+        - agent-echo
+      trust: []
+      platform_ids: {}
+  roles:
+    - id: operator
+      capabilities:
+        - keyword.chat
+        - keyword.async
+        - keyword.team
+        - operator
+        - tool.bash
+        - tool.read
+        - tool.write
+        - tool.edit
+        - tool.glob
+        - tool.grep
+    - id: agent-echo
+      capabilities:
+        - keyword.chat
+        - tool.bash
+        - tool.read
+        - tool.glob
+        - tool.grep
+
+# -----------------------------------------------------------------------------
+# agents — first-class agents on this stack
+# -----------------------------------------------------------------------------
+# Each agent declares its platform presence (Discord/Mattermost/Slack —
+# all optional — declare `presence: {}` for a headless bus-only agent)
+# AND optionally a `runtime` block with capabilities[]. The capabilities
+# array on each agent MUST be a subset of the top-level capabilities[]
+# block ids declared above (cross-validator at
+# src/common/types/cortex-config.ts).
+agents:
+  - id: echo
+    displayName: Echo
+    persona: ./personas/echo.md
+    trust: []
+    runtime:
+      substrate: claude-code
+      mode: in-process
+      # Echo's declared code-review flavors. Every entry here MUST also
+      # appear in the top-level capabilities[] catalog above — that's
+      # the cross-validator's invariant. Remove an entry only if echo
+      # genuinely should NOT provide that capability; otherwise keep
+      # both surfaces in sync.
+      capabilities:
+        - code-review.typescript
+        - code-review.documentation
+        - code-review.security
+        - code-review.architecture
+        - code-review.performance
+        - code-review.ecosystem-compliance
+        - code-review.hardening
+        - code-review.skill-quality
+    presence:
+      discord:
+        enabled: true
+        token: <REPLACE_ME>
+        guildId: "<REPLACE_ME>"
+        agentChannelId: "<REPLACE_ME>"
+        logChannelId: "<REPLACE_ME>"
+        contextDepth: 10
+        enableAgentLog: false
+        trustedBotIds: []
+        # Bus-side subjects this agent subscribes to via the
+        # surface-router. The pattern below routes inbound code-review
+        # tasks at the stack level — the segment after `local.` is your
+        # operator id (substitute as you populate the file).
+        surfaceSubjects:
+          - local.operator-name.tasks.code-review.>  # <REPLACE_ME>: replace operator-name with your operator.id
+
+# -----------------------------------------------------------------------------
+# renderers — non-agent-bound surfaces (dashboards, pagerduty, etc.)
+# -----------------------------------------------------------------------------
+renderers:
+  - kind: dashboard
+    port: 8766
+    subscribe:
+      - local.{org}.>
+    projections: []
+
+# -----------------------------------------------------------------------------
+# claude — runtime config shared across all agents' dispatch sessions
+# -----------------------------------------------------------------------------
+claude:
+  timeoutMs: 300000
+  asyncTimeoutMs: 900000
+  additionalArgs: []
+  allowedTools: []
+  # Defense-in-depth — these tools are denied even when a session would
+  # otherwise have them. Remove an entry only if you accept the risk of
+  # the agent writing/editing files on this machine.
+  disallowedTools:
+    - Write
+    - Edit
+    - NotebookEdit
+  allowedDirs: []
+  readOnlyDirs: []
+
+# -----------------------------------------------------------------------------
+# attachments — shared by all platform presences
+# -----------------------------------------------------------------------------
+attachments:
+  enabled: true
+  maxFileSizeBytes: 10485760       # 10 MiB
+  maxTotalSizeBytes: 26214400      # 25 MiB
+  maxAttachmentsPerMessage: 10
+
+# -----------------------------------------------------------------------------
+# execution — local default, optional remote backends
+# -----------------------------------------------------------------------------
+execution:
+  default: local
+  backends: []
+
+# -----------------------------------------------------------------------------
+# github — webhook ingestion (the taps side)
+# -----------------------------------------------------------------------------
+# Leave `webhookSecret` empty to disable webhooks. Once you wire the
+# GitHub App, paste the HMAC secret here. The receiver block stays
+# disabled by default — opt in once you intend to expose the local
+# HTTP receiver.
+github:
+  webhookSecret: "<REPLACE_ME>"
+  repos: []
+  agentDetection:
+    commitTrailers:
+      - "Co-Authored-By: Claude"
+    branchPatterns:
+      - ^feat/(g|f|i)-\d+
+    commentPatterns:
+      - "^Starting:"
+      - "^Completed:"
+  receiver:
+    enabled: false
+    port: 8770
+    hostname: 127.0.0.1
+
+# -----------------------------------------------------------------------------
+# paths — filesystem locations used by the runner + taps
+# -----------------------------------------------------------------------------
+paths:
+  publishedEventsDir: ~/.claude/events/published
+  logDir: ~/.config/cortex/logs
+
+# -----------------------------------------------------------------------------
+# networks — optional cross-stack federation files (G-500)
+# -----------------------------------------------------------------------------
+networksDir: ./networks
+networks: []
+
+# -----------------------------------------------------------------------------
+# nats — myelin / NATS configuration (optional — cortex stays installable
+# without NATS; review-consumer-side wiring stays dormant until NATS is
+# configured AND at least one agent declares code-review capabilities).
+# -----------------------------------------------------------------------------
+# Uncomment + populate once you wire NATS:
+# nats:
+#   url: nats://127.0.0.1:4222
+#   name: cortex
+#   subjects:
+#     - local.<REPLACE_ME>.tasks.code-review.>
+#   identity:
+#     seedPath: ~/.config/nats/cortex.nk
+#     publicKey: <REPLACE_ME>
+#   accountSigningKeyPath: <REPLACE_ME>

--- a/src/__tests__/cortex.capability-boot.test.ts
+++ b/src/__tests__/cortex.capability-boot.test.ts
@@ -389,6 +389,56 @@ describe("startCortex — capability-registry boot wiring (cortex#237 PR-7)", ()
     rmSync(tmpAgentsDir, { recursive: true, force: true });
   });
 
+  test("cortex#314 — zero agents-with-capabilities → stderr carries an operator-actionable WARNING (not just info-level log)", async () => {
+    // First-install safety regression guard. The boot wiring used to log
+    // a single info-level `console.log("…skipped…")` line, which an
+    // operator running interactively (or tailing a non-debug log) does
+    // NOT notice. The capability-dispatch consumer then rejects every
+    // inbound request with `cant_do` and the operator has no surface
+    // signal pointing at the missing capabilities[] block in cortex.yaml.
+    //
+    // cortex#314's fix promotes the skip to a stderr WARNING with
+    // actionable fix-path text. This test pins the contract: when zero
+    // agents declare runtime.capabilities[], stderr MUST carry the
+    // WARNING tag AND the actionable hint pointing at cortex.yaml.
+    const runtime = createRecordingRuntime();
+    const tmpAgentsDir = mkdtempSync(join(tmpdir(), "cortex-capboot-warn-"));
+    const inlineAgents: Agent[] = [
+      makeAgent("luna", undefined),
+      makeAgent("holly", []),
+    ];
+
+    const { result: { result: handle, logs }, stderr } = await withCapturedStderr(() =>
+      withCapturedConsoleLog(() =>
+        startCortex(minimalConfig(), {
+          disableConfigWatcher: true,
+          disableDashboard: true,
+          disableOutboundPoller: true,
+          agentsDir: tmpAgentsDir,
+          injectRuntime: runtime,
+          inlineAgents,
+        }),
+      ),
+    );
+
+    // Info-level log line stays (operability — daemon-side log shipping
+    // still benefits from the structured info entry). The WARNING is
+    // additive, not a replacement.
+    const infoSkipLines = logs.filter((l) =>
+      l.includes("cortex: capability-registry skipped"),
+    );
+    expect(infoSkipLines.length).toBe(1);
+
+    // stderr carries the WARNING + the actionable fix-path text.
+    expect(stderr).toContain("WARNING: capability-registry skipped");
+    expect(stderr).toContain("0 agents declare runtime.capabilities[]");
+    expect(stderr).toContain("cant_do");
+    expect(stderr).toContain("cortex.yaml");
+
+    await handle.stop();
+    rmSync(tmpAgentsDir, { recursive: true, force: true });
+  });
+
   test("mixed roster — only agents with capabilities publish; others silently skipped", async () => {
     const runtime = createRecordingRuntime();
     const tmpAgentsDir = mkdtempSync(join(tmpdir(), "cortex-capboot-mix-"));

--- a/src/__tests__/cortex.review-consumer-boot.test.ts
+++ b/src/__tests__/cortex.review-consumer-boot.test.ts
@@ -313,6 +313,59 @@ describe("startCortex — review-consumer boot wiring (cortex#237 PR-6)", () => 
     rmSync(tmpAgentsDir, { recursive: true, force: true });
   });
 
+  test("cortex#314 — zero code-review-capable agents → stderr carries an operator-actionable WARNING (not just info-level log)", async () => {
+    // First-install safety regression guard. Mirror of the capability-
+    // registry-side test in `cortex.capability-boot.test.ts`. The
+    // review-consumer wiring used to log a single info-level
+    // `console.log("…skipped…")` line, which an operator running
+    // interactively (or with a non-debug log handler) does NOT notice.
+    // The result was a fresh `pilot request-review --wait` silently
+    // exiting 0 with no review having happened.
+    //
+    // cortex#314's fix promotes the skip to a stderr WARNING with
+    // actionable fix-path text. This test pins the contract: when zero
+    // agents declare code-review capabilities, stderr MUST carry the
+    // WARNING tag AND the actionable hint pointing at cortex.yaml.
+    const runtime = createRecordingRuntime();
+    const tmpAgentsDir = mkdtempSync(join(tmpdir(), "cortex-revboot-warn-"));
+    const inlineAgents: Agent[] = [
+      makeAgent("luna", undefined),
+      makeAgent("holly", ["research.web"]),
+      makeAgent("ivy", []),
+    ];
+
+    const { result: bootResult, stderr } = await withCapturedStderr(() =>
+      withCapturedConsoleLog(() =>
+        startCortex(minimalConfig(), {
+          disableConfigWatcher: true,
+          disableDashboard: true,
+          disableOutboundPoller: true,
+          agentsDir: tmpAgentsDir,
+          injectRuntime: runtime,
+          inlineAgents,
+        }),
+      ),
+    );
+    const { result: handle, logs } = bootResult;
+
+    // Info-level log line stays (operability — daemon-side log shipping
+    // still benefits from the structured info entry). The WARNING is
+    // additive, not a replacement.
+    const infoSkipLines = logs.filter((l) =>
+      l.includes("cortex: review-consumer skipped"),
+    );
+    expect(infoSkipLines.length).toBe(1);
+
+    // stderr carries the WARNING + the actionable fix-path text.
+    expect(stderr).toContain("WARNING: review-consumer skipped");
+    expect(stderr).toContain("0 agents declare code-review capabilities");
+    expect(stderr).toContain("pilot request-review");
+    expect(stderr).toContain("cortex.yaml");
+
+    await handle.stop();
+    rmSync(tmpAgentsDir, { recursive: true, force: true });
+  });
+
   test("one consumer init throws → siblings still wire; boot completes; stderr logged with failing agent id", async () => {
     // The boot wiring filters `mergedAgents` by `a.runtime?.capabilities`
     // (reads `capabilities`) and then, inside a try/catch, reads

--- a/src/__tests__/cortex.yaml-example.test.ts
+++ b/src/__tests__/cortex.yaml-example.test.ts
@@ -1,0 +1,74 @@
+/**
+ * cortex#314 — `cortex.yaml.example` parse test.
+ *
+ * The example file at the repo root is the first thing a fresh operator
+ * copies and edits. If it drifts from `CortexConfigSchema` (a field
+ * renamed, a required key added, a regex tightened), copying it would
+ * surface a confusing schema error during the operator's first boot.
+ *
+ * This test parses the on-disk file through `CortexConfigSchema.parse`
+ * and asserts the schema accepts it without errors. Any future schema
+ * change that breaks the example will fail here, forcing the example
+ * to be updated in the same PR.
+ *
+ * The test does NOT spin up the runtime — it's a pure schema-level
+ * gate. Boot-time wiring is covered by `cortex.capability-boot.test.ts`
+ * and `cortex.review-consumer-boot.test.ts`.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "fs";
+import { join } from "path";
+import { parse as parseYaml } from "yaml";
+import { CortexConfigSchema } from "../common/types/cortex-config";
+
+describe("cortex.yaml.example — first-install starter config (cortex#314)", () => {
+  test("parses cleanly through CortexConfigSchema with zero errors", () => {
+    // Resolve relative to the repo root. `import.meta.dir` points at
+    // `src/__tests__/`; the example sits two levels up next to package.json.
+    const examplePath = join(import.meta.dir, "..", "..", "cortex.yaml.example");
+    const raw = readFileSync(examplePath, "utf-8");
+    const yamlObj: unknown = parseYaml(raw);
+    // `parse` throws on schema violations — the assertion is the absence
+    // of a throw. We also assert the parse returns a populated config so
+    // a future "everything optional" regression doesn't pass trivially.
+    const parsed = CortexConfigSchema.parse(yamlObj);
+    expect(parsed.operator.id).toBeDefined();
+    expect(parsed.agents.length).toBeGreaterThan(0);
+  });
+
+  test("declares the 8 code-review.* capability flavors echo provides", () => {
+    // The capability-dispatch design has 8 canonical code-review flavors
+    // that arc-skill-code-review v0.4.0 ships with. The example MUST
+    // declare all 8 in the top-level catalog (and reference all 8 from
+    // the echo agent's runtime.capabilities[]) so a fresh operator
+    // copying the file does not have to know the flavor list to wire
+    // capability-dispatch end-to-end.
+    const examplePath = join(import.meta.dir, "..", "..", "cortex.yaml.example");
+    const raw = readFileSync(examplePath, "utf-8");
+    const yamlObj: unknown = parseYaml(raw);
+    const parsed = CortexConfigSchema.parse(yamlObj);
+
+    const catalogIds = new Set(parsed.capabilities.map((c) => c.id));
+    const expected = [
+      "code-review.typescript",
+      "code-review.documentation",
+      "code-review.security",
+      "code-review.architecture",
+      "code-review.performance",
+      "code-review.ecosystem-compliance",
+      "code-review.hardening",
+      "code-review.skill-quality",
+    ];
+    for (const id of expected) {
+      expect(catalogIds.has(id)).toBe(true);
+    }
+
+    const echo = parsed.agents.find((a) => a.id === "echo");
+    expect(echo).toBeDefined();
+    const echoCaps = new Set(echo?.runtime?.capabilities ?? []);
+    for (const id of expected) {
+      expect(echoCaps.has(id)).toBe(true);
+    }
+  });
+});

--- a/src/common/types/__tests__/capability.test.ts
+++ b/src/common/types/__tests__/capability.test.ts
@@ -595,6 +595,62 @@ describe("CortexConfigSchema — agents[].runtime.capabilities → catalog (A.6.
     }
   });
 
+  test("cortex#314 — error message points at 'Fix:' add-to-catalog asymmetry, not symmetric 'Either…or…' framing", () => {
+    // First-install safety regression guard. The previous error wording
+    // was "Either add ... or remove ..." which implied symmetric choice.
+    // In practice the right fix (especially for code-review.* flavors
+    // pilot dispatches against) is almost always to add the capability
+    // to the top-level catalog — the catalog is the source of truth.
+    //
+    // The reworded message:
+    //   - Leads with the verb "Fix:" so an operator scanning the error
+    //     finds the actionable line immediately.
+    //   - Spells out the asymmetry between catalog (registry consumed
+    //     by the dispatch consumer) and runtime.capabilities[] (agent
+    //     declaration of intent).
+    //   - Includes a copy-pasteable minimal capability entry naming
+    //     the offending capability id AND the offending agent id (the
+    //     agent becomes the catalog entry's provided_by[]).
+    //   - Keeps a parenthetical pointing at the remove-from-agent
+    //     escape hatch as the rarer fix.
+    try {
+      CortexConfigSchema.parse(
+        minConfig({
+          agents: [
+            minAgent({
+              id: "echo",
+              runtime: {
+                substrate: "claude-code",
+                mode: "in-process",
+                capabilities: ["code-review.typescript"],
+              },
+            }),
+          ],
+          // capabilities: omitted → defaults to []
+        }),
+      );
+      throw new Error("expected parse to throw");
+    } catch (e) {
+      const msg = (e as Error).message;
+      // Leads with the actionable verb + the catalog as target.
+      expect(msg).toContain("Fix:");
+      expect(msg).toContain("add a");
+      expect(msg).toContain("entry to capabilities[] at the top level of cortex.yaml");
+      // Spells out the asymmetry rather than the previous "Either…or…".
+      expect(msg).toContain("source of truth");
+      expect(msg).toContain("declaration of intent");
+      // Carries the copy-pasteable example block naming the offender +
+      // provider in their canonical YAML shape.
+      expect(msg).toContain("Example minimal entry");
+      expect(msg).toContain("- id: code-review.typescript");
+      expect(msg).toContain("provided_by: [echo]");
+      // Keeps the remove-from-agent escape hatch as the rarer fix.
+      expect(msg).toContain("Only remove from agent");
+      // Does NOT carry the old symmetric "Either…or…" framing.
+      expect(msg).not.toContain("Either add");
+    }
+  });
+
   test("empty catalog + empty agent runtime.capabilities parses cleanly", () => {
     // Backward-compat path: deployments not yet declaring any capabilities
     // continue to parse without surfacing a refine error.

--- a/src/common/types/cortex-config.ts
+++ b/src/common/types/cortex-config.ts
@@ -1978,13 +1978,30 @@ export const CortexConfigSchema = z.object({
       for (let claimIdx = 0; claimIdx < claimed.length; claimIdx++) {
         const capId = claimed[claimIdx];
         if (capId !== undefined && !catalogIds.has(capId)) {
+          // cortex#314 — reworded for first-install safety. The previous
+          // "Either add ... or remove ..." framing implied symmetric
+          // choice; in practice (especially for code-review.* flavors)
+          // the right fix is almost always to add the capability to the
+          // top-level catalog. The catalog is the source of truth that
+          // the dispatch consumer + future network registry consult;
+          // the agent's runtime.capabilities[] is the agent's
+          // declaration of intent. Spell that asymmetry out so a fresh
+          // operator hitting this error knows which surface to edit.
           ctx.addIssue({
             code: "custom",
             message:
               `agent "${agent.id}" claims capability "${capId}" in runtime.capabilities[], ` +
               `but no matching entry exists in the top-level capabilities[] catalog ` +
-              `(declared capability ids: ${declaredCatalog}). ` +
-              `Either add a "${capId}" entry to capabilities[] or remove the reference from agent "${agent.id}".`,
+              `(declared capability ids: ${declaredCatalog}).\n\n` +
+              `Fix: add a "${capId}" entry to capabilities[] at the top level of cortex.yaml. ` +
+              `The top-level capabilities[] is the source of truth that the dispatch consumer ` +
+              `consults; the agent's runtime.capabilities[] is the agent's declaration of intent.\n\n` +
+              `Example minimal entry:\n` +
+              `  - id: ${capId}\n` +
+              `    description: <one-line description>\n` +
+              `    provided_by: [${agent.id}]\n\n` +
+              `(Only remove from agent "${agent.id}" runtime.capabilities[] if the agent should NOT ` +
+              `actually provide that capability.)`,
             path: ["agents", agentIdx, "runtime", "capabilities", claimIdx],
           });
         }

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -624,8 +624,23 @@ export async function startCortex(
       );
     }
   } else {
+    // cortex#314 — promote skipped notice to stderr WARNING with
+    // operator-actionable text. The capability-dispatch consumer rejects
+    // every inbound request with `cant_do` until at least one agent
+    // declares runtime.capabilities[], so the boot-time silence was a
+    // first-install footgun (fresh `pilot request-review --wait` exits 0
+    // with no review having happened). Keep the original info-level
+    // `console.log` for normal observability AND emit a stderr WARNING
+    // so operators tailing logs OR running interactively see the
+    // actionable fix-path.
     console.log(
       "cortex: capability-registry skipped — 0 agents declare runtime.capabilities[]",
+    );
+    process.stderr.write(
+      "WARNING: capability-registry skipped — 0 agents declare runtime.capabilities[].\n" +
+        "  The capability-dispatch consumer will reject every request with cant_do.\n" +
+        "  Add runtime.capabilities[] to at least one agent in cortex.yaml.\n" +
+        "  See cortex.yaml.example for a working configuration.\n",
     );
   }
 
@@ -745,8 +760,21 @@ export async function startCortex(
     }
   }
   if (reviewConsumers.length === 0) {
+    // cortex#314 — same first-install-safety promotion as the
+    // capability-registry skip above. Zero code-review-capable agents
+    // means inbound `tasks.code-review.>` envelopes have no consumer
+    // listening; pilot's `request-review --wait` will eventually
+    // time out (or, worse, silently exit 0 pre-pilot#129). Keep the
+    // info-level log AND emit a stderr WARNING with the actionable
+    // fix-path.
     console.log(
       "cortex: review-consumer skipped — 0 agents declare code-review capabilities",
+    );
+    process.stderr.write(
+      "WARNING: review-consumer skipped — 0 agents declare code-review capabilities.\n" +
+        "  Inbound code-review tasks have no consumer; pilot request-review will not be serviced.\n" +
+        "  Add code-review.* entries to an agent's runtime.capabilities[] in cortex.yaml.\n" +
+        "  See cortex.yaml.example for a working configuration.\n",
     );
   }
 


### PR DESCRIPTION
Closes cortex#314.

## What this fixes

Three orthogonal first-install gaps any one of which causes the
"`pilot request-review --wait` silently exits 0 with no review
having happened" failure mode that bit Wave 3 P-VERIFY tonight.

1. **No `cortex.yaml.example`.** Fresh operators had to reverse-engineer
   the schema from `src/common/types/cortex-config.ts`.
2. **Silent "skipped" log lines at boot.** When 0 agents declared
   `runtime.capabilities[]`, the boot wiring logged a single
   info-level line — invisible to an operator running interactively or
   with a non-debug log handler. The capability-dispatch consumer
   then rejected every inbound request with `cant_do` and the
   operator had no surface signal.
3. **Cross-validator's error wording implied symmetric choice.** The
   "Either add ... or remove ..." framing on the agent→catalog
   dangling-reference error mis-led operators toward removing the
   capability from the agent. In practice (especially for
   `code-review.*` flavors pilot dispatches against) the right fix
   is almost always to add the capability to the top-level
   catalog — the catalog is the source of truth.

## Files changed

- `cortex.yaml.example` (new) — complete, parseable starter config.
  Operator/stack/policy/agents wired with sensible defaults; the 8
  canonical `code-review.*` flavors declared in both the top-level
  catalog AND echo's `runtime.capabilities[]` (cross-validator
  satisfied out of the box). Placeholders use schema-valid example
  values (`operator-name`, `000000000000000000`) with `<REPLACE_ME>`
  hint comments — the file parses cleanly straight after copy.
- `src/cortex.ts` — promote `cortex: capability-registry skipped …`
  (line ~640) and `cortex: review-consumer skipped …` (line ~774) to
  additive `process.stderr.write("WARNING: …\n")`. Info-level
  `console.log` stays for structured log shipping; the WARNING is
  purely additive so an operator running interactively or tailing
  logs sees the actionable fix-path pointing at `cortex.yaml.example`.
- `src/common/types/cortex-config.ts` — reword the agent→catalog
  dangling-reference error (line ~1981). New wording leads with
  `Fix:`, spells out the catalog (source of truth) vs.
  `runtime.capabilities[]` (declaration of intent) asymmetry, and
  embeds a copy-pasteable minimal capability YAML block naming the
  offending capability id + agent.
- `src/__tests__/cortex.yaml-example.test.ts` (new) — parse the
  example file through `CortexConfigSchema` and assert the 8
  `code-review.*` flavors are declared on both surfaces. Schema
  drift now fails CI.
- `src/__tests__/cortex.capability-boot.test.ts` — new regression
  test asserting the WARNING reaches stderr (not just stdout) when
  0 agents declare `runtime.capabilities[]`.
- `src/__tests__/cortex.review-consumer-boot.test.ts` — mirror
  regression test for the review-consumer-side WARNING.
- `src/common/types/__tests__/capability.test.ts` — new test
  pinning the reworded error's "Fix:" lead, the asymmetry text, and
  the copy-pasteable example block.

## What this unlocks

A fresh operator can:

```bash
git clone the-metafactory/cortex
arc install Cortex
cp cortex.yaml.example ~/.config/cortex/cortex.yaml
# edit `<REPLACE_ME>` placeholders
cortex start
```

…and have capability-dispatch work end-to-end without reading
`docs/architecture.md` or `docs/design-capability-dispatch-review-consumer.md`.
If they get the config wrong, stderr WARNINGs surface the gap; if
they typo a capability id, the cross-validator points at the right
fix.

## Test plan

- [x] `bunx tsc --noEmit` — clean.
- [x] `bun test` — 3324 pass / 0 fail / 1 skip across 176 files.
- [x] `bun run lint` — 0 errors (22 pre-existing warnings unrelated to
  this PR's files).
- [x] New `cortex.yaml.example` parses cleanly through
  `CortexConfigSchema` (assertion in
  `src/__tests__/cortex.yaml-example.test.ts`).
- [x] Boot-time WARNING fires on stderr in both
  capability-registry-skipped and review-consumer-skipped paths
  (`cortex.capability-boot.test.ts` + `cortex.review-consumer-boot.test.ts`).
- [x] Reworded cross-validator error pins all the new wording
  contracts (`capability.test.ts`).

## Related

- pilot#129 — companion silent-exit-0 fix on `pilot request-review --wait`.
  Even with cortex#314's boot-time WARNINGs, pilot should surface a
  typed `cant_do` failure instead of silent success; pilot#129 closes
  that gap on the requester side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)