### PR TITLE
feat(v2.0.1): retire CORTEX_POLICY_REQUIRE_UNVERIFIED_ACK env-var gate (closes cortex#311)

### DIFF
--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -2,7 +2,7 @@
 # See: https://github.com/the-metafactory/arc
 
 name: "Cortex"
-version: "2.0.0"
+version: "2.0.1"
 type: component
 tier: community
 description: "Layer-7 collaboration surface for the metafactory ecosystem — the M7 application that consumes the Myelin stack"

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -939,17 +939,16 @@ export async function startCortex(
   // ONCE so the three adapter loops below share the same instances. The
   // policy block is parsed at config-load time; the factory + index
   // builders are idempotent over the same input.
-  // SECURITY GATE: same `CORTEX_POLICY_REQUIRE_UNVERIFIED_ACK` env var as
-  // the dispatch-listener gate below — we refuse to build the engine in
-  // production without explicit operator ack of the pre-Phase-B
-  // verification trade-off. The check is duplicated here (rather than
-  // re-using the value built below) because adapter wiring runs BEFORE
-  // the dispatch-listener engine builder; consolidating the gate into a
-  // single block is a follow-up.
-  const adapterPolicyEngine =
-    process.env.CORTEX_POLICY_REQUIRE_UNVERIFIED_ACK === "1"
-      ? policyEngineFromConfig(options.policy)
-      : undefined;
+  //
+  // v2.0.1 (cortex#311): retired the `CORTEX_POLICY_REQUIRE_UNVERIFIED_ACK`
+  // env-var gate. PolicyEngine activates whenever a `policy:` block is
+  // declared (which v2.0.0's schema already enforces for boot). The
+  // pre-Phase-B unverified-principal-claim trade-off is now an
+  // informational boot-log notice from the dispatch-listener builder
+  // below — gating it behind an env var created an M-3 split-brain where
+  // adapters denied every inbound while bus dispatches bypassed auth
+  // entirely (Echo PR #310 r1 finding, cortex#311).
+  const adapterPolicyEngine = policyEngineFromConfig(options.policy);
   const adapterPolicyLookup = buildPlatformPrincipalIndex(options.policy);
   const adapterPolicyRegistry = buildPrincipalRegistry(options.policy);
 
@@ -1430,40 +1429,37 @@ export async function startCortex(
   // the dispatch-listener falls back to the legacy unauthenticated
   // path in that case (C.2b removes the legacy path).
   //
-  // SECURITY GATE (Echo cortex#220 round 1): until Phase B (cortex#114)
-  // makes signature verification mandatory at the envelope-validator
-  // layer, the dispatch-listener's policy gate authorises on an
-  // unverified `signed_by[0].principal` claim. Acceptable for
-  // single-operator / dev-mode deployments where the bus is local
-  // and every publisher is trusted; NOT acceptable for multi-
-  // principal trust over a federated bus. We refuse to build the
-  // engine unless the operator explicitly acknowledges this trade-
-  // off via the env var below — making the limitation impossible to
-  // adopt accidentally. The variable can be retired together with
-  // C.2b once Phase B verification is wired.
-  // Echo cortex#220 round 2 S-2 — surface the silent-degradation case
-  // (policy: block present but principals[] empty → factory returns
-  // undefined → legacy unauthenticated path) so operators editing
-  // cortex.yaml see it in the boot log rather than guessing why the
-  // gate didn't engage.
+  // v2.0.0 (cortex#297): the schema requires a `policy:` block at boot.
+  // PolicyEngine activates unconditionally when at least one principal
+  // is declared (`policyEngineFromConfig` returns undefined for an empty
+  // `policy.principals[]` — the M-1 silent-degradation case captured in
+  // the warning below).
+  //
+  // v2.0.1 (cortex#311): retired the `CORTEX_POLICY_REQUIRE_UNVERIFIED_ACK`
+  // env-var gate. The gate was Echo's cortex#220 round-1 safeguard against
+  // pre-Phase-B (cortex#114) unverified `signed_by[0].principal` claims —
+  // but in v2.0.0 (where role-resolver is gone and PolicyEngine is the
+  // sole gate) the gate created an M-3 split-brain: with the env var
+  // unset, adapters denied every inbound message while bus dispatches
+  // bypassed auth entirely. The pre-Phase-B trade-off is now an
+  // informational boot-log notice rather than an opt-in gate — operators
+  // running v2.0.0+ accept it by deploying.
+  //
+  // The eventual hardening is Phase B's cryptographic verifier
+  // (cortex#114) wired into envelope-validator so `signed_by[0].principal`
+  // claims authenticate against the operator's NKey registry. Until that
+  // wiring lands on the dispatch-listener inbound path, the policy gate
+  // here is authorisation-without-authentication; bus access is the
+  // attack surface.
   if (options.policy?.principals.length === 0) {
     console.warn(
       `cortex: policy: block declared with empty principals[] — no authorisation gate engages; the dispatch-listener stays on the legacy path.`,
     );
   }
-  const UNVERIFIED_ACK = "CORTEX_POLICY_REQUIRE_UNVERIFIED_ACK";
-  let policyEngine = policyEngineFromConfig(options.policy);
-  if (policyEngine !== undefined && process.env[UNVERIFIED_ACK] !== "1") {
-    console.warn(
-      `cortex: policy: block declared in cortex.yaml but ${UNVERIFIED_ACK}=1 not set — ignoring the block.\n` +
-        `        Pre-Phase-B verification (cortex#114) the gate authorises on an unverified signed_by[0].principal claim;\n` +
-        `        any bus publisher can fabricate principal identity. Set ${UNVERIFIED_ACK}=1 in the cortex env\n` +
-        `        to acknowledge the trade-off and enable the engine. See dispatch-listener.ts checkDispatchPolicy() docs.`,
-    );
-    policyEngine = undefined;
-  } else if (policyEngine !== undefined) {
+  const policyEngine = policyEngineFromConfig(options.policy);
+  if (policyEngine !== undefined) {
     console.log(
-      `cortex: policy-engine active — principals=${policyEngine.principalCount} roles=${policyEngine.roleCount} (${UNVERIFIED_ACK}=1; pre-Phase-B unverified-principal mode)`,
+      `cortex: policy-engine active — principals=${policyEngine.principalCount} roles=${policyEngine.roleCount} (pre-Phase-B unverified-principal mode: signed_by[0].principal claims authenticate at face value until cortex#114 ships)`,
     );
   }
 

--- a/src/runner/__tests__/dispatch-listener.test.ts
+++ b/src/runner/__tests__/dispatch-listener.test.ts
@@ -293,6 +293,7 @@ describe("dispatch-listener — success path", () => {
       router,
       source: SOURCE,
       ccSessionFactory: factory,
+      policyEngine: engineGranting(["dispatch.cortex"]),
     });
     await listener.start();
     await router.start();
@@ -303,16 +304,21 @@ describe("dispatch-listener — success path", () => {
     // Wait briefly for async render to complete
     await new Promise((resolve) => setTimeout(resolve, 10));
 
-    // Should have emitted exactly two lifecycle events
-    expect(r.published).toHaveLength(2);
+    // v2.0.1: policy engine is active, so an audit envelope precedes lifecycle.
+    expect(r.published).toHaveLength(3);
     const types = r.published.map((e) => e.type);
     expect(types).toEqual([
+      "system.access.allowed",
       "dispatch.task.started",
       "dispatch.task.completed",
     ]);
-    // All share one correlation_id (the task_id)
+    // All envelopes share one correlation_id (the task_id).
     for (const env of r.published) {
       expect(env.correlation_id).toBe(TASK_ID);
+    }
+    // task_id/agent_id only appear on the lifecycle envelopes (the audit
+    // envelope's payload shape is different per C.4 SystemAccessAllowed).
+    for (const env of r.published.slice(1)) {
       expect(env.payload.task_id).toBe(TASK_ID);
       expect(env.payload.agent_id).toBe("cortex");
     }
@@ -327,6 +333,7 @@ describe("dispatch-listener — success path", () => {
       router,
       source: SOURCE,
       ccSessionFactory: factory,
+      policyEngine: engineGranting(["dispatch.cortex"]),
     });
     await listener.start();
     await router.start();
@@ -348,6 +355,7 @@ describe("dispatch-listener — success path", () => {
       router,
       source: SOURCE,
       ccSessionFactory: factory,
+      policyEngine: engineGranting(["dispatch.cortex"]),
     });
     await listener.start();
     await router.start();
@@ -406,6 +414,7 @@ describe("dispatch-listener — success path", () => {
       router,
       source: SOURCE,
       ccSessionFactory: factory,
+      policyEngine: engineGranting(["dispatch.cortex"]),
     });
     await listener.start();
     await router.start();
@@ -434,6 +443,7 @@ describe("dispatch-listener — success path", () => {
       router,
       source: SOURCE,
       ccSessionFactory: factory,
+      policyEngine: engineGranting(["dispatch.cortex"]),
     });
     await listener.start();
     await router.start();
@@ -473,6 +483,7 @@ describe("dispatch-listener — failure paths", () => {
       router,
       source: SOURCE,
       ccSessionFactory: fakeFactory(FAIL_RESULT).factory,
+      policyEngine: engineGranting(["dispatch.cortex"]),
     });
     await listener.start();
     await router.start();
@@ -481,10 +492,11 @@ describe("dispatch-listener — failure paths", () => {
     await new Promise((resolve) => setTimeout(resolve, 10));
 
     expect(r.published.map((e) => e.type)).toEqual([
+      "system.access.allowed",
       "dispatch.task.started",
       "dispatch.task.failed",
     ]);
-    const failed = r.published[1]!;
+    const failed = r.published[2]!;
     expect(failed.payload.error_summary).toBe("claude exited 1");
     expect(failed.correlation_id).toBe(TASK_ID);
   });
@@ -497,6 +509,7 @@ describe("dispatch-listener — failure paths", () => {
       router,
       source: SOURCE,
       ccSessionFactory: fakeFactory(TIMEOUT_RESULT).factory,
+      policyEngine: engineGranting(["dispatch.cortex"]),
     });
     await listener.start();
     await router.start();
@@ -505,10 +518,11 @@ describe("dispatch-listener — failure paths", () => {
     await new Promise((resolve) => setTimeout(resolve, 10));
 
     expect(r.published.map((e) => e.type)).toEqual([
+      "system.access.allowed",
       "dispatch.task.started",
       "dispatch.task.aborted",
     ]);
-    expect(r.published[1]!.payload.reason).toBe("timeout");
+    expect(r.published[2]!.payload.reason).toBe("timeout");
   });
 
   test("aborted=true + exitCode=1 (canonical inactivity timeout) → started → aborted", async () => {
@@ -522,6 +536,7 @@ describe("dispatch-listener — failure paths", () => {
       router,
       source: SOURCE,
       ccSessionFactory: fakeFactory(ABORTED_BY_FLAG_RESULT).factory,
+      policyEngine: engineGranting(["dispatch.cortex"]),
     });
     await listener.start();
     await router.start();
@@ -530,10 +545,11 @@ describe("dispatch-listener — failure paths", () => {
     await new Promise((resolve) => setTimeout(resolve, 10));
 
     expect(r.published.map((e) => e.type)).toEqual([
+      "system.access.allowed",
       "dispatch.task.started",
       "dispatch.task.aborted",
     ]);
-    expect(r.published[1]!.payload.reason).toBe("timeout");
+    expect(r.published[2]!.payload.reason).toBe("timeout");
   });
 
   test("factory throws → started → failed", async () => {
@@ -547,6 +563,7 @@ describe("dispatch-listener — failure paths", () => {
       router,
       source: SOURCE,
       ccSessionFactory: throwingFactory,
+      policyEngine: engineGranting(["dispatch.cortex"]),
     });
     await listener.start();
     await router.start();
@@ -555,10 +572,11 @@ describe("dispatch-listener — failure paths", () => {
     await new Promise((resolve) => setTimeout(resolve, 10));
 
     expect(r.published.map((e) => e.type)).toEqual([
+      "system.access.allowed",
       "dispatch.task.started",
       "dispatch.task.failed",
     ]);
-    expect(r.published[1]!.payload.error_summary).toContain("session spawn failed");
+    expect(r.published[2]!.payload.error_summary).toContain("session spawn failed");
   });
 });
 
@@ -684,6 +702,7 @@ describe("dispatch-listener — start/stop", () => {
       router,
       source: SOURCE,
       ccSessionFactory: fakeFactory(SUCCESS_RESULT).factory,
+      policyEngine: engineGranting(["dispatch.cortex"]),
     });
     await listener.start();
     await listener.start(); // should be a no-op
@@ -694,6 +713,7 @@ describe("dispatch-listener — start/stop", () => {
 
     // Single registration → exactly one started + one completed (not double)
     expect(r.published.map((e) => e.type)).toEqual([
+      "system.access.allowed",
       "dispatch.task.started",
       "dispatch.task.completed",
     ]);
@@ -707,6 +727,7 @@ describe("dispatch-listener — start/stop", () => {
       router,
       source: SOURCE,
       ccSessionFactory: fakeFactory(SUCCESS_RESULT).factory,
+      policyEngine: engineGranting(["dispatch.cortex"]),
     });
     await listener.start();
     await router.start();
@@ -726,6 +747,7 @@ describe("dispatch-listener — start/stop", () => {
       router,
       source: SOURCE,
       ccSessionFactory: fakeFactory(SUCCESS_RESULT).factory,
+      policyEngine: engineGranting(["dispatch.cortex"]),
     });
     await listener.start();
     await listener.stop();
@@ -783,7 +805,12 @@ function engineGranting(capabilities: readonly string[]): PolicyEngine {
 }
 
 describe("dispatch-listener — policy gating (C.3.1)", () => {
-  test("no engine → legacy pass-through (dispatch proceeds, started+completed)", async () => {
+  test("no engine → fail-closed (denied with policy_engine_uninitialised — v2.0.1 cortex#311)", async () => {
+    // v2.0.1 (cortex#311): the legacy `if (policyEngine !== undefined)`
+    // pass-through is retired. When the listener is constructed without
+    // an engine (deployment declared empty `policy.principals[]`), every
+    // dispatch fails closed with a clear deny reason — there's no
+    // authorisation surface to consult.
     const r = recordingRuntime();
     const router = createSurfaceRouter(r.runtime);
     const { factory } = fakeFactory(SUCCESS_RESULT);
@@ -792,7 +819,7 @@ describe("dispatch-listener — policy gating (C.3.1)", () => {
       router,
       source: SOURCE,
       ccSessionFactory: factory,
-      // no policyEngine → legacy path
+      // no policyEngine → fail-closed deny
     });
     await listener.start();
     await router.start();
@@ -800,10 +827,11 @@ describe("dispatch-listener — policy gating (C.3.1)", () => {
     r.trigger(makeReceivedEnvelope(), "local.metafactory.dispatch.task.received");
     await new Promise((resolve) => setTimeout(resolve, 10));
 
-    expect(r.published.map((e) => e.type)).toEqual([
-      "dispatch.task.started",
-      "dispatch.task.completed",
-    ]);
+    expect(r.published.map((e) => e.type)).toEqual(["dispatch.task.failed"]);
+    const failed = r.published[0]!;
+    const reason = failed.payload.reason as { kind: string; deny: { kind: string } };
+    expect(reason.kind).toBe("policy_denied");
+    expect(reason.deny.kind).toBe("policy_engine_uninitialised");
   });
 
   test("engine + allow → dispatch proceeds normally", async () => {

--- a/src/runner/dispatch-listener.ts
+++ b/src/runner/dispatch-listener.ts
@@ -475,27 +475,61 @@ async function handleDispatchEnvelope(
     return;
   }
 
-  // IAW Phase C.3.1 — policy gate. When the engine is configured we
-  // resolve the originating principal from `envelope.signed_by[0]`
-  // (the first stamp is the originator per myelin#31 chain ordering;
-  // hub-stamps later in the chain re-attest but don't replace
-  // origin). The capability claim is a placeholder
-  // `dispatch.<agent_id>` derived from the dispatch target — until
-  // C.2b carries an explicit capability tag on the payload, the
-  // dispatch surface is "may principal X invoke agent Y on this
-  // stack?". Sovereignty flows through verbatim so audit envelopes
-  // (C.4) carry the same constraints the engine saw.
+  // IAW Phase C.3.1 — policy gate. The engine resolves the originating
+  // principal from `envelope.signed_by[0]` (the first stamp is the
+  // originator per myelin#31 chain ordering; hub-stamps later in the
+  // chain re-attest but don't replace origin). The capability claim is
+  // a placeholder `dispatch.<agent_id>` derived from the dispatch
+  // target — until cortex#237's review-consumer surface carries an
+  // explicit capability tag on the payload, the dispatch surface is
+  // "may principal X invoke agent Y on this stack?". Sovereignty flows
+  // through verbatim so audit envelopes (C.4) carry the same
+  // constraints the engine saw.
   //
-  // When the engine is undefined the listener falls back to the
-  // legacy unauthenticated path — the runner is booted without a
-  // `policy:` block. C.2b removes the legacy path entirely.
+  // v2.0.0 (cortex#297) + v2.0.1 (cortex#311): the schema requires a
+  // `policy:` block at boot, AND `cortex.ts` no longer re-binds the
+  // engine to undefined via env-var ack. So `policyEngine` here is
+  // undefined ONLY when the operator declared `policy: { principals: [] }`
+  // — an explicit "no auth surface" deployment. We fail closed in that
+  // case: deny every dispatch with a clear reason so audit consumers
+  // see the misconfiguration immediately rather than every dispatch
+  // succeeding silently.
+  //
   // IAW Phase D.3 — derive `source_network` from the matched
   // subject when the envelope arrived via `federated.{id}.>`. Local
   // dispatches (subjects like `local.{org}.dispatch.task.received`)
   // leave it `undefined` so the engine skips the federation branch.
   const sourceNetwork = extractSourceNetwork(subject);
   let gatedPrincipal: Principal | undefined;
-  if (policyEngine !== undefined) {
+  if (policyEngine === undefined) {
+    // v2.0.1 (cortex#311): fail-closed when policy engine is unavailable.
+    // In v2.0.0+ this only happens when operator declared empty
+    // principals[]; cortex.ts has already emitted a boot warning, so we
+    // just deny + emit a terminal failure for any dispatch that arrives.
+    console.error(
+      `cortex-runner: dispatch-listener: policy engine uninitialised (empty principals[]?) — denying envelope id=${envelope.id} task_id=${payload.task_id} agent=${payload.agent_id}`,
+    );
+    const now = new Date();
+    const failed = createDispatchTaskFailedEvent({
+      source,
+      taskId: payload.task_id,
+      agentId: payload.agent_id,
+      startedAt: now,
+      failedAt: now,
+      errorSummary: "policy engine uninitialised — declare at least one principal in policy.principals[] to enable the authorisation gate",
+      reason: {
+        kind: "policy_denied",
+        deny: {
+          kind: "policy_engine_uninitialised",
+          detail: "operator declared empty policy.principals[]; declare at least one principal to engage the authorisation gate",
+        },
+      },
+    });
+    await runtime.publish(failed);
+    return;
+  }
+
+  {
     const decision = checkDispatchPolicy(
       policyEngine,
       envelope,
@@ -683,9 +717,12 @@ type DispatchPolicyResult =
  *   - Federation across operators (Phase D) — verification is
  *     mandatory there.
  *
- * The `CORTEX_POLICY_REQUIRE_UNVERIFIED_ACK=1` opt-in below makes
- * this trade-off explicit at boot. Phase B (cortex#114) wires the
- * verifier into the validator and closes the gap.
+ * v2.0.1 (cortex#311) — the `CORTEX_POLICY_REQUIRE_UNVERIFIED_ACK`
+ * env-var opt-in that previously made this trade-off explicit at boot
+ * has been retired. Operators running v2.0.0+ accept the trade-off by
+ * deploying; cortex.ts emits an informational boot-log line naming the
+ * pre-Phase-B mode rather than gating the engine. Phase B (cortex#114)
+ * wires the verifier into the validator and closes the gap entirely.
  *
  * **Principal resolution.** Read `envelope.signed_by[0].principal`
  * (originator stamp per myelin#31 chain semantics). Strip the

--- a/src/services/ai.meta-factory.cortex.meta-factory.plist
+++ b/src/services/ai.meta-factory.cortex.meta-factory.plist
@@ -29,17 +29,6 @@
         <string>__HOME__/bin:/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin</string>
         <key>GROVE_CHANNEL</key>
         <string>__AGENT_NAME__</string>
-        <!--
-            v2.0.0 (cortex#297): the `policy:` block is now the sole
-            authorisation gate, but Phase B (cortex#114) verification of
-            `signed_by[0].principal` is not yet wired into the envelope
-            validator. The operator acknowledges via this env var that
-            principal claims authenticate at face value during the
-            pre-Phase-B window. Tracked as cortex#311 (retire the env-var
-            gate once cortex#114 ships).
-        -->
-        <key>CORTEX_POLICY_REQUIRE_UNVERIFIED_ACK</key>
-        <string>1</string>
     </dict>
 </dict>
 </plist>

--- a/src/services/ai.meta-factory.cortex.work.plist
+++ b/src/services/ai.meta-factory.cortex.work.plist
@@ -33,17 +33,6 @@
         <string>luna</string>
         <key>CORTEX_AGENT_ID</key>
         <string>luna-work</string>
-        <!--
-            v2.0.0 (cortex#297): the `policy:` block is now the sole
-            authorisation gate, but Phase B (cortex#114) verification of
-            `signed_by[0].principal` is not yet wired into the envelope
-            validator. The operator acknowledges via this env var that
-            principal claims authenticate at face value during the
-            pre-Phase-B window. Tracked as cortex#311 (retire the env-var
-            gate once cortex#114 ships).
-        -->
-        <key>CORTEX_POLICY_REQUIRE_UNVERIFIED_ACK</key>
-        <string>1</string>
     </dict>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary

Retires the \`CORTEX_POLICY_REQUIRE_UNVERIFIED_ACK\` env-var gate that Echo introduced as the C.2a pre-Phase-B safeguard. After PR #310 made the \`policy:\` block the sole authorisation gate, the env var became an operator-hostile footgun — \`cortex.ts\` re-bound \`policyEngine = undefined\` on both adapter-side AND dispatch-listener-side when unset, creating the M-3 split-brain (humans denied, bus dispatches bypassed auth) that bit Andreas's production deployment right after \`arc upgrade Cortex\` to v2.0.0.

## Changes

### Code
- **\`src/cortex.ts\`**: removed the env-var rebind blocks at adapter-side (~line 949) and dispatch-listener-side (~line 1454). PolicyEngine activates unconditionally when a \`policy:\` block is declared. Boot log emits an **informational** notice about pre-Phase-B unverified principal claims rather than gating.
- **\`src/runner/dispatch-listener.ts:498\`**: flipped the guard from \"if engine defined: gate, else bypass\" to \"if engine undefined: fail-closed deny\". The only v2.0.1 path that yields \`policyEngine === undefined\` is operator declaring empty \`policy.principals[]\` — a misconfiguration that now surfaces immediately via \`dispatch.task.failed\` with \`reason.deny.kind = \"policy_engine_uninitialised\"\`.

### Plist templates
- **\`src/services/ai.meta-factory.cortex.meta-factory.plist\`** + **\`src/services/ai.meta-factory.cortex.work.plist\`**: retire the \`CORTEX_POLICY_REQUIRE_UNVERIFIED_ACK=1\` entries added in PR #313. The env var no longer gates anything.

### Version
- **\`arc-manifest.yaml\`** bumped to \`v2.0.1\`. Semver patch — no schema or wire-format changes.

### Tests
9 tests in \`dispatch-listener.test.ts\` updated to reflect the new invariants:
- Tests in \"success path\" + \"failure paths\" + \"start/stop\" describe blocks gain a permissive \`engineGranting([\"dispatch.cortex\"])\` since the default fixture relied on the bypass
- Assertions prepend \`\"system.access.allowed\"\` to expected envelope sequences (audit envelope now precedes lifecycle)
- The \"no engine → legacy pass-through\" test renamed + flipped to assert fail-closed deny

## What this commits us to

Pre-Phase-B verification (cortex#114, ed25519 + JCS canonicalization) is still the eventual hardening. When that wires the verifier into the envelope-validator's inbound path, the \"principals authenticate at face value\" caveat retires entirely. v2.0.1 just removes the env-var gymnastics that made the limitation operator-hostile and forced split-brain failure mode on every fresh upgrade.

## Operator action after merge

\`arc upgrade Cortex\` will re-render plists (without the now-unused env var) + reload daemons. PolicyEngine activates; boot warning retires; humans + bus dispatches both flow through the engine.

## Verification

- \`bunx tsc --noEmit\` clean
- \`bun run lint:errors\` clean
- Full suite: 3319/3320 pass, 1 unrelated skip
- All 38 dispatch-listener tests pass with updated fixtures

## Refs

- closes cortex#311
- PR #310 round-1 M-3 finding (the split-brain this resolves)
- PR #313 (the temporary env-var ack in plists — retired here)
- cortex#114 (Phase B — wires the eventual cryptographic verifier)
- cortex#220 (Echo C.2a sign-off where the env-var ack pattern was introduced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)