### PR TITLE
fix(bus): cortex#317 — NatsLink.close() bounded statusLoop join

### DIFF
--- a/src/bus/nats/__tests__/connection.test.ts
+++ b/src/bus/nats/__tests__/connection.test.ts
@@ -361,6 +361,112 @@ describe("NatsLink", () => {
       await link.close();
     });
 
+    // (skip — bounded-statusLoop tests below)
+    test.skip("__bounded-statusLoop-tests-placeholder__", async () => {});
+  });
+
+  describe("bounded statusLoop (cortex#317)", () => {
+    // Builds a fake where drain() succeeds but the status iterator NEVER
+    // closes — simulates the pilot#129 root cause where nats.js
+    // `for await (... status())` doesn't end promptly under
+    // `reconnect: true`. Pre-fix `close()` would await statusLoop forever;
+    // post-fix it bounds with statusTimeoutMs and emits a stderr warning.
+    function makeHungStatusConnection() {
+      const statusIterator = (async function* () {
+        // Hang on a promise that never resolves — mimics the unresponsive
+        // status iterator from pilot#129's diagnostic trace.
+        await new Promise<never>(() => {});
+        yield { type: "x", data: null };
+      })();
+      const drain = mock(async () => {
+        // Drain itself succeeds — only statusLoop is hung.
+      });
+      const publish = mock(() => {});
+      const fakeNc = {
+        status: () => statusIterator,
+        drain,
+        publish,
+      } as unknown as NatsConnection;
+      return { nc: fakeNc, drain };
+    }
+
+    test("close() resolves within statusTimeoutMs when status loop hangs", async () => {
+      const fake = makeHungStatusConnection();
+      const link = await NatsLink.connect({
+        url: "nats://localhost:4222",
+        connectImpl: async () => fake.nc,
+      });
+      const stderrWrites: string[] = [];
+      const originalStderrWrite = process.stderr.write;
+      process.stderr.write = (chunk: unknown) => {
+        stderrWrites.push(String(chunk));
+        return true;
+      };
+      try {
+        const start = Date.now();
+        await link.close(/* drainTimeoutMs */ 100, /* statusTimeoutMs */ 100);
+        const elapsed = Date.now() - start;
+        // Drain returns immediately (mock resolves sync); status loop is
+        // bounded at 100ms. Total budget: ~100ms + slack. Pre-fix this
+        // would hang forever — we assert <500ms to leave generous CI slack.
+        expect(elapsed).toBeLessThan(500);
+      } finally {
+        process.stderr.write = originalStderrWrite;
+      }
+      // Warning emitted on stderr with operator-actionable text.
+      const warning = stderrWrites.find((w) =>
+        w.includes("status loop exceeded"),
+      );
+      expect(warning).toBeDefined();
+      expect(warning).toContain("WARNING");
+      expect(warning).toContain("continuing in background");
+    });
+
+    test("close() is fast (no warning) when status loop drains promptly", async () => {
+      // Healthy case: makeFakeConnection's drain calls closeStatus(), which
+      // makes the iterator return null → statusLoop completes immediately.
+      // This is the 99% path — we verify the new bounded-race doesn't add
+      // a perceptible delay or spurious warning.
+      const fake = makeFakeConnection();
+      const link = await NatsLink.connect({
+        url: "nats://localhost:4222",
+        connectImpl: async () => fake.nc,
+      });
+      const stderrWrites: string[] = [];
+      const originalStderrWrite = process.stderr.write;
+      process.stderr.write = (chunk: unknown) => {
+        stderrWrites.push(String(chunk));
+        return true;
+      };
+      try {
+        const start = Date.now();
+        await link.close();
+        const elapsed = Date.now() - start;
+        expect(elapsed).toBeLessThan(100);
+      } finally {
+        process.stderr.write = originalStderrWrite;
+      }
+      // Zero stderr warnings on the healthy path.
+      const warnings = stderrWrites.filter((w) =>
+        w.includes("status loop exceeded"),
+      );
+      expect(warnings).toEqual([]);
+    });
+  });
+
+  describe("creds-auth tilde (re-opened, was nested in creds-auth block above)", () => {
+    let tmpDir: string;
+    let credsFile: string;
+    beforeEach(() => {
+      tmpDir = mkdtempSync(join(tmpdir(), "natslink-creds-bound-"));
+      credsFile = join(tmpDir, "user.creds");
+      writeFileSync(credsFile, FAKE_CREDS_CONTENT, "utf8");
+      chmodSync(credsFile, 0o600);
+    });
+    afterEach(() => {
+      rmSync(tmpDir, { recursive: true, force: true });
+    });
+
     test("leading ~ in credsPath expands to homedir", async () => {
       // Place a creds file directly under $HOME so the ~-relative path
       // resolves to a real existing file. Cleanup at teardown.

--- a/src/bus/nats/connection.ts
+++ b/src/bus/nats/connection.ts
@@ -157,11 +157,21 @@ export class NatsLink {
 
   /**
    * Close the connection cleanly. Drains in-flight subscriptions before
-   * disconnecting (per nats.js convention). Idempotent. Drain is bounded
-   * by `drainTimeoutMs` (default 5 s) so an unreachable server can't hang
-   * process exit.
+   * disconnecting (per nats.js convention). Idempotent.
+   *
+   * Both the `drain()` AND the `statusLoop` join are bounded by their own
+   * timeouts so an unreachable server can't hang process exit. The status
+   * loop is the load-bearing one — `for await (... status())` doesn't
+   * always end promptly under `reconnect: true` (pilot#129 root cause:
+   * status iteration kept the loop pinned through reconnects, blocking
+   * every downstream `await link.close()`). Bounding both keeps the
+   * close() contract — "resolves within (drainTimeout + statusTimeout)
+   * worst case, regardless of network state" — visible at the type level.
    */
-  async close(drainTimeoutMs = 5_000): Promise<void> {
+  async close(
+    drainTimeoutMs = 5_000,
+    statusTimeoutMs = 2_000,
+  ): Promise<void> {
     if (this.closed) return;
     this.closed = true;
     try {
@@ -182,10 +192,29 @@ export class NatsLink {
       );
     }
     // Wait for the status loop to drain so close() is deterministic.
+    // Bounded by `statusTimeoutMs` so a hung `for await (... status())`
+    // (cortex#317 — pilot#129 root cause: nats.js status iterator doesn't
+    // end promptly under reconnect:true) can't pin downstream `await
+    // link.close()` callers. On budget miss, emit an operator-actionable
+    // stderr warning and let the loop drain in the background — process
+    // exit cleans up the orphaned iterator regardless.
+    let statusTimer: ReturnType<typeof setTimeout> | undefined;
     try {
-      await this.statusLoop;
+      await Promise.race([
+        this.statusLoop,
+        new Promise<void>((resolve) => {
+          statusTimer = setTimeout(() => {
+            process.stderr.write(
+              `WARNING: nats-connection: "${this.name}" status loop exceeded ${statusTimeoutMs}ms during close() — continuing in background; result not held up\n`,
+            );
+            resolve();
+          }, statusTimeoutMs);
+        }),
+      ]);
     } catch {
       // Status loop logs its own errors; close() shouldn't fail because of them.
+    } finally {
+      if (statusTimer !== undefined) clearTimeout(statusTimer);
     }
   }
 


### PR DESCRIPTION
## Summary

\`NatsLink.close()\` already bounded the drain() side with a 5s timeout race, but the statusLoop join at the end was UNBOUNDED. Under \`reconnect: true\` the underlying \`for await (... status())\` iterator doesn't always end promptly when close() is called — pinning every downstream \`await link.close()\` caller.

This is the architectural root cause of pilot#129 (silent exit-0). Pilot#130 patched symptomatically with cleanupWithTimeout(); this PR fixes it at the cortex layer so every NatsLink consumer benefits.

## Fix

\`close()\` now takes an additional \`statusTimeoutMs = 2000\` parameter and races \`await this.statusLoop\` against that budget. On budget miss, emit:

\`\`\`
WARNING: nats-connection: "{name}" status loop exceeded {N}ms during close() — continuing in background; result not held up
\`\`\`

setTimeout handle is cleared via finally so we don't leak a timer when the drain wins the race.

## Tests

Two new tests in \`src/bus/nats/__tests__/connection.test.ts\` under \`describe(\"bounded statusLoop (cortex#317)\")\`:

1. **Hang scenario** — fake connection whose status iterator awaits a never-resolving promise. close() resolves within budget (asserted <500ms with slack), WARNING text on stderr observed.
2. **Healthy scenario** — existing fake connection where drain triggers status close. close() resolves <100ms; zero spurious WARNING.

Full suite: 3326 pass / 0 fail / 2 skip (+ 1 placeholder skip + 2 new tests).

## Impact

- pilot's cleanupWithTimeout (pilot#130) becomes pure defence-in-depth
- sage, future M7 surfaces, the cortex bot itself all inherit the bounded close()
- pilot#129 silent-exit-0 root cause closed

## Refs

- pilot#129 (the original symptom)
- pilot#130 (pilot's symptomatic fix — cleanupWithTimeout helper)
- cortex/src/bus/nats/connection.ts:164 (the bounded close() method)

Closes cortex#317.