### PR TITLE
fix(bus): cortex#318 — review-consumer subscribes to stack-aware subject (last P-VERIFY blocker)

### DIFF
--- a/src/__tests__/cortex.review-consumer-boot.test.ts
+++ b/src/__tests__/cortex.review-consumer-boot.test.ts
@@ -246,9 +246,14 @@ describe("startCortex — review-consumer boot wiring (cortex#237 PR-6)", () => 
     // boot wiring's design-doc-aligned convention.
     expect(runtime.subscribePullCalls.length).toBe(2);
     const patterns = runtime.subscribePullCalls.map((c) => c.pattern);
+    // cortex#318 — subscribe pattern includes the stack segment to match
+    // pilot's 6-segment publish grammar (`local.{org}.{stack}.tasks.code-
+    // review.<flavor>`). Test config omits the stack: block so
+    // `deriveStackId` default-derives `'default'`. Pre-cortex#318 this
+    // was a 4-segment pattern that never matched stack-aware publishes.
     expect(patterns).toEqual([
-      "local.test-op.tasks.code-review.>",
-      "local.test-op.tasks.code-review.>",
+      "local.test-op.default.tasks.code-review.>",
+      "local.test-op.default.tasks.code-review.>",
     ]);
     const durables = runtime.subscribePullCalls.map((c) => c.durable).sort();
     expect(durables).toEqual([

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -700,7 +700,15 @@ export async function startCortex(
   // share competing-consumer semantics and a daemon restart resumes from
   // the same JetStream offset.
   const reviewOperatorId = config.agent.operatorId ?? "default";
-  const reviewSubjectPattern = `local.${reviewOperatorId}.tasks.code-review.>`;
+  // cortex#318 — include the stack segment to match the 6-segment grammar
+  // `deriveSubject` produces for stack-scoped publishes (cortex#262 / IAW
+  // Phase A.5 + canonical helper at `@the-metafactory/myelin/subjects`).
+  // Pilot publishes to `local.{org}.{stack}.tasks.code-review.<flavor>`;
+  // the consumer must subscribe to the same grammar or the wildcard
+  // `>` never matches (NATS requires literal segments before the `>`).
+  // Reuses `derivedStack.stack` resolved at boot (line 308) — same source
+  // sage's bridge subscription already uses for `local.{org}.{stack}.>`.
+  const reviewSubjectPattern = `local.${reviewOperatorId}.${derivedStack.stack}.tasks.code-review.>`;
   const reviewStream = "CODE_REVIEW";
   for (const agent of reviewCapableAgents) {
     try {


### PR DESCRIPTION
## Summary

Pre-fix, the review-consumer boot wiring built a 4-segment subscribe pattern (\`local.{org}.tasks.code-review.>\`) but pilot's publisher derives 6-segment subjects (\`local.{org}.{stack}.{type}\`) when the stack: block is set. NATS literal-segment matching meant the wildcard never matched — every request silently timed out.

## Concrete repro (captured tonight against running bot)

- Pilot published to: \`local.metafactory.meta-factory.tasks.code-review.documentation\`
- Cortex subscribed to: \`local.metafactory.tasks.code-review.>\`
- Mismatch on segment 3 (\`meta-factory\` vs \`tasks\`) — NATS wildcard expects literal \`tasks\` immediately after \`metafactory\`.

This was the LAST blocker for real Wave 3 P-VERIFY round-trips after pilot#130 (silent exit-0 fix) and cortex#321 (NatsLink.close bounded drain) restored observability.

## Fix

One-line change at \`src/cortex.ts:711\`:

\`\`\`diff
-const reviewSubjectPattern = \`local.\${reviewOperatorId}.tasks.code-review.>\`;
+const reviewSubjectPattern = \`local.\${reviewOperatorId}.\${derivedStack.stack}.tasks.code-review.>\`;
\`\`\`

\`derivedStack.stack\` was already resolved at boot (line 308) — same source sage's existing bridge subscription already uses for \`local.{org}.{stack}.>\`. The review-consumer was the outlier.

## Tests

Updated existing assertion in \`src/__tests__/cortex.review-consumer-boot.test.ts:249-256\` to expect the new pattern shape:

\`\`\`
local.test-op.default.tasks.code-review.>
\`\`\`

(test config omits a stack: block so \`deriveStackId\` default-derives \`'default'\`).

Full suite: 3324 pass / 0 fail.

## Refs

- cortex#290 (PR-6 review-consumer wiring — built before stack-aware grammar landed)
- cortex#262 (IAW Phase A.5 — stack-aware grammar)
- pilot#129 + pilot#130 (silent-exit fix that made this visible)
- cortex#317 (NatsLink.close bounded drain — sibling cleanup)

Closes cortex#318.