### PR TITLE
feat(v2.0.3): walk the talk — stack signing ON by default (closes cortex#324)

### DIFF
--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -2,7 +2,7 @@
 # See: https://github.com/the-metafactory/arc
 
 name: "Cortex"
-version: "2.0.2"
+version: "2.0.3"
 type: component
 tier: community
 description: "Layer-7 collaboration surface for the metafactory ecosystem — the M7 application that consumes the Myelin stack"

--- a/cortex.yaml.example
+++ b/cortex.yaml.example
@@ -51,15 +51,35 @@ operator:
   dataResidency: NZ
 
 # -----------------------------------------------------------------------------
-# stack — optional identity of this cortex deployment within the operator
+# stack — identity of this cortex deployment within the operator
 # -----------------------------------------------------------------------------
+# v2.0.3 (cortex#324) — stack signing is ON by default. `arc upgrade Cortex`
+# auto-provisions `nkey_seed_path` + `nkey_pub` if you don't declare them;
+# the values below are the worked example a fresh install renders. Without
+# a `nkey_seed_path`, cortex emits a stderr WARNING and publishes envelopes
+# UNSIGNED — peers running `verifySignedByChain` (cortex#320 / v2.0.2) will
+# reject those messages. See docs/sop-stack-identity.md for rotation +
+# threat-model background.
+#
 # When omitted, `deriveStackId` defaults to `${operator.id}/default`. Declare
-# explicitly once you run more than one stack per operator.
+# `stack:` explicitly once you run more than one stack per operator.
 stack:
   # Must match `{operator_id}/{stack_id}` grammar — both segments lowercase
   # alphanumeric + hyphen/underscore, each starting with a letter. Keep the
   # operator-id half in sync with `operator.id` above.
   id: operator-name/meta-factory  # <REPLACE_ME>: keep operator-name half in sync with operator.id
+  # NKey seed file (NATS user-class, `SU…`-prefixed). Must be chmod 600.
+  # `arc upgrade Cortex` provisions one at this path if missing. Rotate
+  # by regenerating the seed + updating `nkey_pub` below; see SOP.
+  nkey_seed_path: ~/.config/nats/cortex.nk  # <REPLACE_ME or rely on arc upgrade auto-provision>
+  # 56-char base32 NKey public key (`U…`-prefixed). Optional but
+  # recommended — cortex pins the loaded seed against this value at
+  # boot to catch operator-rotation split-brain (seed file rotated but
+  # peers' trust: list still references the old pubkey). Omit on first
+  # install; copy from the cortex log line (`stack signing key staged —
+  # principal=…`) into the field after first boot for the consistency
+  # check to kick in.
+  nkey_pub: UAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA  # <REPLACE_ME>: paste the U-prefixed pubkey from the seed
 
 # -----------------------------------------------------------------------------
 # capabilities — STACK CATALOG (source of truth for capability-dispatch)

--- a/docs/sop-stack-identity.md
+++ b/docs/sop-stack-identity.md
@@ -1,0 +1,121 @@
+# SOP — Stack Identity (NKey signing key)
+
+**Status:** active (v2.0.3 — cortex#324)
+**Owner:** operator
+**Audience:** anyone running a cortex stack on the metafactory bus
+
+---
+
+## What is the stack NKey?
+
+Every cortex stack on the metafactory bus has a **signing identity** — a NATS NKey keypair (`SU…` seed + `U…` public key) that cortex uses to sign every outbound envelope via myelin's `signEnvelope`. Peers on the bus that trust this stack's public key verify the signature via `verifySignedByChain` (cortex#320 / v2.0.2) before accepting the message.
+
+The stack NKey is **different** from:
+
+| Key | Purpose | Prefix | Threat scope |
+|---|---|---|---|
+| **Operator root** | Signs operator JWT, mints account JWTs | `SO` | Catastrophic — full bus control |
+| **Account signing** | Mints user JWTs | `SA` | High — mint arbitrary identities under the account |
+| **Stack signing** (this doc) | Signs outbound envelopes | `SU` | Medium — forge envelopes from this stack |
+| **NATS auth user** | Authenticates with NATS server | `SU` | Medium — connect as this user |
+
+In practice, single-operator deployments can reuse one user-class (`SU`) NKey for both stack signing and NATS auth — that's what `arc upgrade Cortex` provisions by default, and what `migrate-config --auto-stack-key` migrates legacy configs onto.
+
+## Why ON by default?
+
+cortex#320 (v2.0.2) wired the verification side: every peer running cortex now calls `verifySignedByChain` on inbound peer-dispatch envelopes. If the publisher didn't sign, every consumer rejects.
+
+Through cortex#314 (v2.0.0) and earlier, `stack.nkey_seed_path` was **opt-in**: operators had to know to declare it, generate a key, chmod 600 it, and update their config. The dominant install shape was unsigned — including the operator's own deployment.
+
+cortex#324 (v2.0.3) flips the default. Stack signing is ON. `arc upgrade Cortex` auto-provisions the key; cortex.ts emits a loud stderr WARNING when the field is missing; cortex.yaml.example ships the worked example. Operators upgrading from v2.0.2 either get auto-provisioned (recommended) or see the warning on first boot.
+
+v2.0.4 will promote the missing-field condition to a refuse-to-boot.
+
+## Where does the seed live?
+
+Canonical path: `~/.config/nats/cortex.nk` for the main stack, `~/.config/nats/cortex-work.nk` for the secondary work stack.
+
+Permissions: **chmod 600** (the loader enforces this — anything more permissive fails closed at boot).
+
+The seed file format is whatever `nsc generate nkey -u` produces — a single line of base32 starting with `SU`, optionally followed by a trailing newline (the loader trims).
+
+## How does arc provision it?
+
+On every `arc upgrade Cortex`, `scripts/postupgrade.sh` sources `scripts/lib/stack-identity-provision.sh` and calls `provision_stack_identity`:
+
+1. **Idempotency check** — if `cortex.yaml` already declares `stack.nkey_seed_path`, skip. No edits.
+2. **NKey existence check** — if `~/.config/nats/cortex.nk` is present, reuse it. Otherwise generate a fresh `SU`-prefixed seed via `nsc` (preferred) or via `bun` + `nkeys.js` (fallback).
+3. **Backup** — copy the existing config to `cortex.yaml.pre-stack-identity-${timestamp}` before any edit. Operator can roll back trivially.
+4. **Edit** — append `nkey_seed_path` (and `nkey_pub` when the pubkey can be derived) into the existing `stack:` block, or create a `stack:` block if none exists.
+
+The same flow runs for `cortex.work.yaml` against `~/.config/nats/cortex-work.nk` when the secondary work stack config exists.
+
+## How does cortex.ts use it?
+
+At boot (`src/cortex.ts` lines 316–428):
+
+1. Load the seed file (chmod 600 gate, `SU` prefix gate, `nkeys.fromSeed` parse).
+2. If `stack.nkey_pub` is also declared, assert the loaded keypair's pubkey matches the declared value. A mismatch throws — the operator-rotation split-brain hazard.
+3. Derive the principal DID: `did:mf:${stack.id.replace("/", "-")}`.
+4. Stage the signer onto `MyelinRuntime.publish()` — every outbound envelope gets stamped with `signed_by[0]` carrying the DID + signature.
+
+Boot log line on success:
+
+```
+cortex: stack signing key staged — principal=did:mf:andreas-meta-factory (active once myelin runtime starts)
+```
+
+Boot log line on missing-field:
+
+```
+WARNING: stack identity not configured — cortex will publish unsigned envelopes.
+  Peers that verify signed_by[] will reject these messages.
+  Run `arc upgrade Cortex --force` to auto-provision, or add
+  `stack.nkey_seed_path` (+ optionally `stack.nkey_pub`) to cortex.yaml.
+  See docs/sop-stack-identity.md for the full SOP.
+```
+
+## How do I rotate?
+
+Stack-NKey rotation is a coordinated change across (a) this stack and (b) every peer that trusts this stack's pubkey.
+
+1. **Generate a new seed:**
+   ```bash
+   nsc generate nkey -u > ~/.config/nats/cortex.nk.new
+   chmod 600 ~/.config/nats/cortex.nk.new
+   ```
+2. **Derive the new pubkey:**
+   ```bash
+   bun -e 'import { fromSeed } from "nkeys.js"; import { readFileSync } from "fs"; console.log(fromSeed(new TextEncoder().encode(readFileSync(process.argv[2], "utf-8").trim())).getPublicKey())' ~/.config/nats/cortex.nk.new
+   ```
+3. **Update peers' `trust:` lists.** Every cortex stack that consumes envelopes from this stack must add the new pubkey to its `policy.principals[].trust[]` (or wherever the trust anchor lives in their config). Until peers have the new pubkey, they will reject your envelopes.
+4. **Swap the seed atomically:**
+   ```bash
+   mv ~/.config/nats/cortex.nk ~/.config/nats/cortex.nk.old
+   mv ~/.config/nats/cortex.nk.new ~/.config/nats/cortex.nk
+   ```
+5. **Update `stack.nkey_pub` in cortex.yaml** to the new value. (If you leave the old `nkey_pub`, cortex.ts boot will throw `seed file pubkey ... does not match declared stack.nkey_pub ...` — the split-brain guard.)
+6. **Restart cortex** — `launchctl unload && launchctl load` the meta-factory plist.
+7. **Verify** — peers' logs should show successful chain verification on the new envelopes. The cortex boot log should show the new principal DID's pubkey.
+
+When everything is verified working, delete `cortex.nk.old`.
+
+## Threat model
+
+- **Seed leak (catastrophic).** Anyone with the seed can mint envelopes that any peer trusting this stack's pubkey will accept. Mitigations: chmod 600, never commit, rotate on suspicion.
+- **Operator rotation split-brain.** Seed file rotated but peers still trust the old pubkey — every outbound envelope rejected. Mitigation: `stack.nkey_pub` consistency-pin at boot (catches the mismatch); SOP step 3 above (update peers BEFORE swap).
+- **Hardware backing.** Not yet — the loader's signature is the seam where a Yubikey/TPM-backed signer can replace the in-memory keypair without changing call sites. Forward work.
+
+## Cross-references
+
+- **cortex#114** — IAW Phase B umbrella (signing umbrella)
+- **cortex#200** — myelin `signEnvelope` consumer pattern (Phase B.1c)
+- **cortex#262** — Phase A.5 stack-id grammar (`{operator}/{stack}`)
+- **cortex#314** — `cortex.yaml.example` first-install safety (v2.0.0)
+- **cortex#320 / PR #322** — runner-side `verifySignedByChain` wired (v2.0.2)
+- **cortex#324** — this PR (v2.0.3 — walk-the-talk default)
+- **`src/common/config/stack-signing-key.ts`** — loader (chmod 600 + `SU` prefix gate)
+- **`src/cortex.ts`** lines 316–428 — boot-time staging
+- **`scripts/lib/stack-identity-provision.sh`** — arc upgrade auto-provisioner
+- **`docs/design-policy-cutover.md`** — policy-side cutover that consumes the signed envelopes
+- **`docs/design-internet-of-agentic-work.md`** §3.1 — IAW federation context

--- a/scripts/lib/stack-identity-provision.sh
+++ b/scripts/lib/stack-identity-provision.sh
@@ -1,0 +1,206 @@
+#!/bin/bash
+# cortex#324 (v2.0.3) — stack identity auto-provisioning for arc upgrade.
+#
+# Walk-the-talk: stack signing should be ON by default. When an operator
+# runs `arc upgrade Cortex` and their cortex.yaml lacks
+# `stack.nkey_seed_path`, this helper:
+#
+#   1. Detects the canonical NKey path for the stack (default
+#      `~/.config/nats/cortex.nk` for the main config,
+#      `~/.config/nats/cortex-work.nk` for the work stack).
+#   2. If the NKey file is missing, generates one via `nsc` (or skips
+#      with a warning when nsc is not installed).
+#   3. Appends `nkey_seed_path` + (when derivable) `nkey_pub` to the
+#      existing `stack:` block — or creates a new `stack:` block when
+#      none exists.
+#   4. Idempotent: skipped entirely if `stack.nkey_seed_path` is already
+#      declared in the file.
+#
+# Backup: before any edit, the script copies the config to
+# `${config}.pre-stack-identity-$(date +%Y%m%dT%H%M%S)`. Operator can roll
+# back by restoring the backup.
+#
+# Usage (in postupgrade.sh):
+#   source "${SCRIPT_DIR}/lib/stack-identity-provision.sh"
+#   provision_stack_identity "${CONFIG_DIR}/cortex.yaml"      "cortex"
+#   provision_stack_identity "${CONFIG_DIR}/cortex.work.yaml" "cortex-work"
+#
+# Args:
+#   $1 config file path (e.g. ~/.config/cortex/cortex.yaml)
+#   $2 NKey basename — `cortex` → ~/.config/nats/cortex.nk
+#
+# Exit code: always 0 (provisioning is best-effort; failures emit a
+# warning and the boot path's stderr WARNING surfaces the gap).
+
+# Resolve a canonical NKey path under ~/.config/nats/ for a given basename.
+# Centralised so callers can mirror the convention without hardcoding paths.
+nkey_path_for() {
+  local basename="$1"
+  echo "${HOME}/.config/nats/${basename}.nk"
+}
+
+# Detect whether the config already declares stack.nkey_seed_path. Uses awk
+# to walk the file line by line; the gate is intentionally conservative —
+# it only matches the literal `nkey_seed_path:` key under a top-level
+# `stack:` block (no nested stack: blocks in our schema, so this is safe).
+has_stack_seed_path() {
+  local config="$1"
+  [ -f "${config}" ] || return 1
+  awk '
+    /^stack:/ { in_stack = 1; next }
+    /^[a-zA-Z]/ && !/^stack:/ { in_stack = 0 }
+    in_stack && /^[ \t]+nkey_seed_path:/ { found = 1; exit }
+    END { exit (found ? 0 : 1) }
+  ' "${config}"
+}
+
+# Derive the U-prefixed public key from a seed file.
+# Strategy: run `nsc inbox-keys` is heavy; we use bun + nkeys.js if
+# available, otherwise return empty and skip the nkey_pub field.
+# (Operator can copy from cortex boot log later.)
+derive_pubkey_from_seed() {
+  local seed_path="$1"
+  [ -f "${seed_path}" ] || return 1
+  local bun_path
+  bun_path="$(command -v bun 2>/dev/null || true)"
+  if [ -z "${bun_path}" ]; then
+    return 1
+  fi
+  # Run a tiny bun one-liner that reads the seed and prints the pubkey.
+  # All output is captured; on parse failure (wrong prefix etc.) bun
+  # exits non-zero and we return empty.
+  "${bun_path}" -e "
+    import { fromSeed } from 'nkeys.js';
+    import { readFileSync } from 'fs';
+    const seed = readFileSync('${seed_path}', 'utf-8').trim();
+    const kp = fromSeed(new TextEncoder().encode(seed));
+    process.stdout.write(kp.getPublicKey());
+  " 2>/dev/null
+}
+
+# Generate a fresh SU-prefixed NKey at the given path, chmod 600.
+# Returns 0 on success, 1 if nsc is not installed (caller skips).
+generate_nkey_seed() {
+  local seed_path="$1"
+  local nsc_path
+  nsc_path="$(command -v nsc 2>/dev/null || true)"
+  if [ -z "${nsc_path}" ]; then
+    # Fallback: try bun + nkeys.js to generate a user-class seed.
+    local bun_path
+    bun_path="$(command -v bun 2>/dev/null || true)"
+    if [ -z "${bun_path}" ]; then
+      return 1
+    fi
+    mkdir -p "$(dirname "${seed_path}")"
+    "${bun_path}" -e "
+      import { createUser } from 'nkeys.js';
+      import { writeFileSync, chmodSync } from 'fs';
+      const kp = createUser();
+      const seed = new TextDecoder().decode(kp.getSeed());
+      writeFileSync('${seed_path}', seed);
+      chmodSync('${seed_path}', 0o600);
+    " 2>/dev/null || return 1
+    return 0
+  fi
+  mkdir -p "$(dirname "${seed_path}")"
+  # nsc generate nkey -u prints the seed on stdout.
+  "${nsc_path}" generate nkey -u > "${seed_path}" 2>/dev/null || return 1
+  chmod 600 "${seed_path}" 2>/dev/null
+  return 0
+}
+
+# Main entrypoint. Idempotent — multiple runs leave the config unchanged
+# once the first run wired up the field.
+provision_stack_identity() {
+  local config="$1"
+  local nkey_basename="$2"
+
+  if [ ! -f "${config}" ]; then
+    # No config yet — first-install case. Nothing to annotate.
+    return 0
+  fi
+
+  if has_stack_seed_path "${config}"; then
+    echo "  ⊘ Stack identity already configured in ${config##*/}"
+    return 0
+  fi
+
+  local seed_path
+  seed_path="$(nkey_path_for "${nkey_basename}")"
+
+  # Generate the NKey if missing. Skip-with-warning when neither nsc nor
+  # bun+nkeys.js can produce one (extremely unlikely — bun is a hard
+  # cortex dep so it's always there in practice).
+  if [ ! -f "${seed_path}" ]; then
+    echo "  ⊕ Generating stack signing NKey at ${seed_path}..."
+    if ! generate_nkey_seed "${seed_path}"; then
+      echo "  ⚠ Could not generate NKey (install nsc or ensure bun is in PATH)" >&2
+      echo "    Falling back to boot-time WARNING; cortex will publish unsigned." >&2
+      return 0
+    fi
+    echo "  ✓ NKey generated (chmod 600)"
+  else
+    echo "  ⊘ NKey already exists at ${seed_path} — reusing"
+  fi
+
+  # Best-effort pubkey derivation. Empty result means we skip nkey_pub
+  # and let cortex log it at boot for the operator to copy in manually.
+  local pubkey
+  pubkey="$(derive_pubkey_from_seed "${seed_path}" || true)"
+
+  # Backup before edit.
+  local backup
+  backup="${config}.pre-stack-identity-$(date +%Y%m%dT%H%M%S)"
+  cp "${config}" "${backup}"
+  echo "  ✓ Config backup → ${backup##*/}"
+
+  # Edit: append fields under existing stack: block, or create one.
+  # Use awk so the rewrite is deterministic regardless of yaml lib presence.
+  local tmpfile
+  tmpfile="$(mktemp)"
+  local seed_path_value="${seed_path/#${HOME}/~}"
+  awk -v seed="${seed_path_value}" -v pub="${pubkey}" '
+    BEGIN { in_stack = 0; injected = 0 }
+    /^stack:/ {
+      in_stack = 1
+      print
+      next
+    }
+    # Leaving the stack block — inject before the next top-level key.
+    /^[a-zA-Z]/ && in_stack && !injected {
+      print "  nkey_seed_path: " seed
+      if (pub != "") {
+        print "  nkey_pub: " pub
+      }
+      injected = 1
+      in_stack = 0
+    }
+    { print }
+    END {
+      # File ended while we were still inside stack:.
+      if (in_stack && !injected) {
+        print "  nkey_seed_path: " seed
+        if (pub != "") {
+          print "  nkey_pub: " pub
+        }
+        injected = 1
+      }
+      # No stack: block existed at all — append one.
+      if (!injected) {
+        print ""
+        print "stack:"
+        print "  nkey_seed_path: " seed
+        if (pub != "") {
+          print "  nkey_pub: " pub
+        }
+      }
+    }
+  ' "${config}" > "${tmpfile}"
+
+  mv "${tmpfile}" "${config}"
+  if [ -n "${pubkey}" ]; then
+    echo "  ✓ Stack identity wired: nkey_seed_path + nkey_pub (${pubkey:0:8}…)"
+  else
+    echo "  ✓ Stack identity wired: nkey_seed_path (nkey_pub will be logged at next boot)"
+  fi
+}

--- a/scripts/postupgrade.sh
+++ b/scripts/postupgrade.sh
@@ -29,13 +29,25 @@ ln -sf "${CORTEX_DIR}/src/taps/cc-events"          "${CLAUDE_DIR}/relay/cortex"
 ln -sf "${CORTEX_DIR}/src/cli/discord/skill"       "${CLAUDE_DIR}/skills/Discord"
 echo "  ✓ Nested symlinks refreshed"
 
-# ─── 2. Re-template launchd plists (shared with postinstall.sh) ──
+# ─── 2. Auto-provision stack signing identity (cortex#324 / v2.0.3) ──
+# Walk-the-talk: stack signing is ON by default. When the operator's
+# cortex.yaml (or cortex.work.yaml) lacks `stack.nkey_seed_path`, the
+# helper generates an NKey at the canonical path and wires the field
+# into the config. Idempotent — skipped when the field is already set.
+echo "  Provisioning stack signing identity..."
+source "${SCRIPT_DIR}/lib/stack-identity-provision.sh"
+provision_stack_identity "${CONFIG_DIR}/cortex.yaml"      "cortex" || true
+if [ -f "${CONFIG_DIR}/cortex.work.yaml" ]; then
+  provision_stack_identity "${CONFIG_DIR}/cortex.work.yaml" "cortex-work" || true
+fi
+
+# ─── 3. Re-template launchd plists (shared with postinstall.sh) ──
 source "${SCRIPT_DIR}/lib/plist-render.sh"
 if [ "$(uname)" = "Darwin" ]; then
   LAUNCH_DIR="${HOME}/Library/LaunchAgents"
   render_cortex_plists "${CORTEX_DIR}" "${LAUNCH_DIR}" "${CONFIG_DIR}"
 
-  # ─── 3. Restart daemons ─────────────────────────────────────────
+  # ─── 4. Restart daemons ─────────────────────────────────────────
   # `|| true` keeps a partial upgrade non-fatal — if a daemon was already
   # unloaded by preupgrade.sh, load just re-loads cleanly.
   launchctl load "${LAUNCH_DIR}/ai.meta-factory.cortex.relay.plist" 2>/dev/null || true

--- a/src/__tests__/cortex.stack-signing-boot.test.ts
+++ b/src/__tests__/cortex.stack-signing-boot.test.ts
@@ -1,0 +1,219 @@
+/**
+ * cortex#324 (v2.0.3) — boot-time WARNING when stack signing is not
+ * configured.
+ *
+ * Walk-the-talk: stack signing is ON by default. When the operator's
+ * config lacks `stack.nkey_seed_path`, cortex publishes UNSIGNED envelopes
+ * (same shape as today) but emits a loud stderr WARNING with the
+ * actionable fix-path. This test pins the contract:
+ *
+ *   - WARN appears on stderr when `options.stack.nkey_seed_path` is absent.
+ *   - WARN includes the `arc upgrade Cortex` fix-path AND the manual
+ *     `stack.nkey_seed_path` fix-path AND the SOP doc cross-link.
+ *   - The pre-existing info-level `console.log` line stays (operability).
+ *   - When `nkey_seed_path` IS set with a valid seed, no WARN appears.
+ *
+ * Mirror of the cortex#314 review-consumer-boot test
+ * (`cortex.review-consumer-boot.test.ts` lines 321+): same stderr/console
+ * capture pattern, same WARNING-is-additive shape.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { createUser } from "nkeys.js";
+
+import { BotConfigSchema, type BotConfig } from "../common/types/config";
+import { startCortex } from "../cortex";
+import type { Envelope } from "../bus/myelin/envelope-validator";
+import type { EnvelopeHandler, MyelinRuntime } from "../bus/myelin/runtime";
+
+// ---------------------------------------------------------------------------
+// Helpers — kept local-to-this-file so the test stays self-contained.
+// ---------------------------------------------------------------------------
+
+function minimalConfig(): BotConfig {
+  return BotConfigSchema.parse({
+    agent: {
+      name: "test-cortex",
+      displayName: "TestCortex",
+      operatorId: "test-op",
+    },
+    discord: [],
+    mattermost: [],
+    claude: { timeoutMs: 120_000 },
+    paths: { publishedEventsDir: "/tmp/grove-cortex-test-published" },
+  });
+}
+
+interface RecordingRuntime extends MyelinRuntime {
+  published: Envelope[];
+}
+
+function createRecordingRuntime(): RecordingRuntime {
+  const published: Envelope[] = [];
+  return {
+    enabled: false,
+    published,
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    onEnvelope(_handler: EnvelopeHandler) {
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      return { unregister: () => {} };
+    },
+    publish: async (envelope: Envelope) => {
+      published.push(envelope);
+    },
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    stop: async () => {},
+  };
+}
+
+function withCapturedStderr<T>(fn: () => Promise<T>): Promise<{ result: T; stderr: string }> {
+  const original = process.stderr.write.bind(process.stderr);
+  let buf = "";
+  process.stderr.write = (chunk: unknown): boolean => {
+    buf += typeof chunk === "string" ? chunk : String(chunk);
+    return true;
+  };
+  return fn()
+    .then((result) => {
+      process.stderr.write = original;
+      return { result, stderr: buf };
+    })
+    .catch((err: unknown) => {
+      process.stderr.write = original;
+      throw err;
+    });
+}
+
+function withCapturedConsoleLog<T>(fn: () => Promise<T>): Promise<{ result: T; logs: string[] }> {
+  const original = console.log.bind(console);
+  const logs: string[] = [];
+  console.log = (...args: unknown[]): void => {
+    logs.push(args.map((a) => String(a)).join(" "));
+  };
+  return fn()
+    .then((result) => {
+      console.log = original;
+      return { result, logs };
+    })
+    .catch((err: unknown) => {
+      console.log = original;
+      throw err;
+    });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("startCortex — stack-signing boot warning (cortex#324)", () => {
+  test("no stack.nkey_seed_path → stderr carries the WARNING with the actionable fix-path", async () => {
+    // No `options.stack` at all — the legacy opt-in shape that's the
+    // dominant install state pre-v2.0.3. Boot must surface the WARN.
+    const runtime = createRecordingRuntime();
+    const { result: bootResult, stderr } = await withCapturedStderr(() =>
+      withCapturedConsoleLog(() =>
+        startCortex(minimalConfig(), {
+          disableConfigWatcher: true,
+          disableDashboard: true,
+          disableOutboundPoller: true,
+          injectRuntime: runtime,
+        }),
+      ),
+    );
+    const { result: handle, logs } = bootResult;
+
+    // Info-level log line stays — daemon log shippers + structured log
+    // handlers benefit from the info entry. The WARN is additive.
+    const infoLines = logs.filter((l) =>
+      l.includes("cortex: stack signing key not configured"),
+    );
+    expect(infoLines.length).toBe(1);
+
+    // stderr carries the WARNING tag.
+    expect(stderr).toContain("WARNING: stack identity not configured");
+    // …and the runtime consequence so operators understand the impact.
+    expect(stderr).toContain("unsigned envelopes");
+    expect(stderr).toContain("verify signed_by");
+    // …and BOTH fix-paths so operators see auto-provision + manual edit.
+    expect(stderr).toContain("arc upgrade Cortex");
+    expect(stderr).toContain("stack.nkey_seed_path");
+    // …and the SOP cross-link.
+    expect(stderr).toContain("docs/sop-stack-identity.md");
+
+    expect(handle).toBeDefined();
+    await handle.stop();
+  });
+
+  test("stack: {id} declared but no nkey_seed_path → WARN still fires (id alone is not enough)", async () => {
+    // Operators on Phase A.5 wired `stack.id` for namespace routing but
+    // never declared `stack.nkey_seed_path` (B.3 was opt-in). The WARN
+    // must still fire — the id alone doesn't enable signing.
+    const runtime = createRecordingRuntime();
+    const { result: bootResult, stderr } = await withCapturedStderr(() =>
+      withCapturedConsoleLog(() =>
+        startCortex(minimalConfig(), {
+          stack: { id: "test-op/research" },
+          disableConfigWatcher: true,
+          disableDashboard: true,
+          disableOutboundPoller: true,
+          injectRuntime: runtime,
+        }),
+      ),
+    );
+    const { result: handle } = bootResult;
+
+    expect(stderr).toContain("WARNING: stack identity not configured");
+    expect(stderr).toContain("arc upgrade Cortex");
+
+    await handle.stop();
+  });
+
+  test("stack.nkey_seed_path SET with a valid SU seed → no WARN, info log absent", async () => {
+    // Happy path: operator (or arc) wired the field, seed exists at
+    // chmod 600 with `SU` prefix. The signer stages cleanly and the
+    // WARN does NOT fire.
+    const tmp = mkdtempSync(join(tmpdir(), "cortex-stack-signing-warn-test-"));
+    const seedPath = join(tmp, "stack.nk");
+    const seed = new TextDecoder().decode(createUser().getSeed());
+    writeFileSync(seedPath, seed);
+    chmodSync(seedPath, 0o600);
+
+    try {
+      const runtime = createRecordingRuntime();
+      const { result: bootResult, stderr } = await withCapturedStderr(() =>
+        withCapturedConsoleLog(() =>
+          startCortex(minimalConfig(), {
+            stack: { id: "test-op/research", nkey_seed_path: seedPath },
+            disableConfigWatcher: true,
+            disableDashboard: true,
+            disableOutboundPoller: true,
+            injectRuntime: runtime,
+          }),
+        ),
+      );
+      const { result: handle, logs } = bootResult;
+
+      // Boot's positive log line for the staged signer.
+      const stagedLines = logs.filter((l) =>
+        l.includes("cortex: stack signing key staged"),
+      );
+      expect(stagedLines.length).toBe(1);
+      expect(stagedLines[0]!).toContain("principal=did:mf:test-op-research");
+
+      // No WARN — the field is set + valid.
+      expect(stderr).not.toContain("WARNING: stack identity not configured");
+      // No "not configured" info log either.
+      const skipLines = logs.filter((l) =>
+        l.includes("cortex: stack signing key not configured"),
+      );
+      expect(skipLines.length).toBe(0);
+
+      await handle.stop();
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/cli/cortex/commands/__tests__/migrate-config.test.ts
+++ b/src/cli/cortex/commands/__tests__/migrate-config.test.ts
@@ -1253,3 +1253,125 @@ describe("convertBotYaml — disabled-adapter does not leak policy (PR #306 r1 M
     expect(allowAllRole).toBeUndefined();
   });
 });
+
+// ---------------------------------------------------------------------------
+// cortex#324 (v2.0.3) — stack signing default-on
+// ---------------------------------------------------------------------------
+
+describe("convertBotYaml — stack signing (cortex#324)", () => {
+  test("no stack.nkey_seed_path on input → emits warning suggesting the field be set", () => {
+    const legacy = loadFixture("minimal.bot.yaml");
+    const result = convertBotYaml(legacy, { configDir: FIXTURE_DIR });
+    const w = result.warnings.find((w) => w.field === "stack.nkey_seed_path");
+    expect(w).toBeDefined();
+    expect(w!.message).toContain("UNSIGNED");
+    expect(w!.message).toContain("docs/sop-stack-identity.md");
+  });
+
+  test("autoStackKey + legacy nats.identity present → reuses seedPath + publicKey", () => {
+    // full.bot.yaml's nats.identity is in the legacy {did, keyPath} shape,
+    // which gets stripped by convertNats. Use a cortex-shape input where
+    // nats.identity already carries seedPath + publicKey.
+    const legacy: LegacyBotYaml = {
+      agent: {
+        name: "test-agent",
+        displayName: "Test",
+        operatorId: "test-op",
+      },
+      discord: [
+        {
+          token: "discord-token-xxxx",
+          guildId: "100000000000000001",
+          agentChannelId: "100000000000000002",
+          logChannelId: "100000000000000003",
+        },
+      ],
+      stack: { id: "test-op/research" },
+      nats: {
+        url: "nats://localhost:4222",
+        identity: {
+          seedPath: "~/.config/nats/cortex.nk",
+          publicKey: "UD7OGEVBNJAUQ57H5NHSPJZOKKOXOZ4DEUJVAO5URHBIUAVSVTJGL4QV",
+        },
+      },
+    };
+    const result = convertBotYaml(legacy, {
+      configDir: FIXTURE_DIR,
+      autoStackKey: true,
+    });
+    expect(result.cortex.stack).toBeDefined();
+    expect(result.cortex.stack?.nkey_seed_path).toBe("~/.config/nats/cortex.nk");
+    expect(result.cortex.stack?.nkey_pub).toBe(
+      "UD7OGEVBNJAUQ57H5NHSPJZOKKOXOZ4DEUJVAO5URHBIUAVSVTJGL4QV",
+    );
+    const w = result.warnings.find((w) => w.field === "stack.nkey_seed_path");
+    expect(w).toBeDefined();
+    expect(w!.message).toContain("auto-populated");
+  });
+
+  test("autoStackKey but no legacy nats.identity → falls through to warning, no field added", () => {
+    const legacy = loadFixture("minimal.bot.yaml");
+    const result = convertBotYaml(legacy, {
+      configDir: FIXTURE_DIR,
+      autoStackKey: true,
+    });
+    // No seedPath to reuse — stack stays untouched (or absent), warning fires.
+    expect(result.cortex.stack?.nkey_seed_path).toBeUndefined();
+    const w = result.warnings.find((w) => w.field === "stack.nkey_seed_path");
+    expect(w).toBeDefined();
+    expect(w!.message).toContain("UNSIGNED");
+  });
+
+  test("idempotent — input already has stack.nkey_seed_path → no warning, no overwrite", () => {
+    const legacy: LegacyBotYaml = {
+      agent: {
+        name: "test-agent",
+        displayName: "Test",
+        operatorId: "test-op",
+      },
+      discord: [
+        {
+          token: "discord-token-xxxx",
+          guildId: "100000000000000001",
+          agentChannelId: "100000000000000002",
+          logChannelId: "100000000000000003",
+        },
+      ],
+      stack: {
+        id: "test-op/research",
+        nkey_seed_path: "~/.config/nats/pre-existing.nk",
+        nkey_pub: "UD7OGEVBNJAUQ57H5NHSPJZOKKOXOZ4DEUJVAO5URHBIUAVSVTJGL4QV",
+      } as unknown as LegacyBotYaml["stack"],
+      nats: {
+        url: "nats://localhost:4222",
+        identity: {
+          seedPath: "~/.config/nats/different.nk",
+          publicKey: "UDEQUP3NUQAGUJIZ5ZSOBZKAF73CW6BPMEQX6476E66Q37FONADJ75EB",
+        },
+      },
+    };
+    const result = convertBotYaml(legacy, {
+      configDir: FIXTURE_DIR,
+      autoStackKey: true,
+    });
+    // Pre-existing field preserved verbatim — NOT overwritten by autoStackKey.
+    expect(result.cortex.stack?.nkey_seed_path).toBe(
+      "~/.config/nats/pre-existing.nk",
+    );
+    // No new warning — the field was already set, idempotent no-op.
+    const w = result.warnings.find((w) => w.field === "stack.nkey_seed_path");
+    expect(w).toBeUndefined();
+  });
+});
+
+describe("parseArgs — --auto-stack-key (cortex#324)", () => {
+  test("parses --auto-stack-key flag", () => {
+    const args = parseArgs(["in.yaml", "--auto-stack-key"]);
+    expect(args.autoStackKey).toBe(true);
+  });
+
+  test("default is false", () => {
+    const args = parseArgs(["in.yaml"]);
+    expect(args.autoStackKey).toBe(false);
+  });
+});

--- a/src/cli/cortex/commands/migrate-config-lib.ts
+++ b/src/cli/cortex/commands/migrate-config-lib.ts
@@ -239,6 +239,19 @@ export interface ConvertOptions {
    * idempotency (the same label map produces the same output on every run).
    */
   labels?: Map<string, string>;
+  /**
+   * cortex#324 (v2.0.3) — when `true`, the migrator auto-populates
+   * `stack.nkey_seed_path` (and `stack.nkey_pub` when derivable) from
+   * the legacy `nats.identity` block, on the theory that the operator
+   * is already using one NKey for NATS auth and is happy to reuse it
+   * for stack-envelope signing too. Idempotent: if the input already
+   * declared `stack.nkey_seed_path`, no-op.
+   *
+   * Off by default. The CLI flag is `--auto-stack-key`; without it,
+   * the migrator emits a warning suggesting the operator add the field
+   * (or re-run with the flag).
+   */
+  autoStackKey?: boolean;
 }
 
 // Re-export policy types so CLI callers and external consumers can hold
@@ -837,6 +850,19 @@ export function convertBotYaml(
   };
 
   if (legacy.stack !== undefined) cortex.stack = legacy.stack;
+  // cortex#324 (v2.0.3) — walk-the-talk: stack signing should be ON by
+  // default. Surface a warning when the migrated config lacks
+  // `stack.nkey_seed_path`. With `--auto-stack-key`, reuse the legacy
+  // `nats.identity.seedPath` + `nats.identity.publicKey` for the stack
+  // signing identity (single-NKey deployment — same key signs envelopes
+  // it already authenticates with). Idempotent: skipped if the input
+  // already declared `stack.nkey_seed_path`.
+  cortex.stack = annotateStackSigning(
+    cortex.stack as Record<string, unknown> | undefined,
+    legacy,
+    opts.autoStackKey ?? false,
+    warnings,
+  );
   if (legacy.capabilities !== undefined) cortex.capabilities = legacy.capabilities;
 
   if (legacy.claude !== undefined) cortex.claude = legacy.claude;
@@ -1219,6 +1245,92 @@ function rewritePaths(legacyPaths: unknown, warnings: ConversionWarning[]): unkn
  * Any other unknown fields under `nats` pass through; only the
  * shape-mismatched identity block is stripped.
  */
+/**
+ * cortex#324 (v2.0.3) — annotate the migrated `stack:` block with signing
+ * material so cortex defaults to publishing signed envelopes.
+ *
+ * Three branches:
+ *   1. `stack.nkey_seed_path` already set on the input → no-op (idempotent).
+ *      The operator hand-managed signing; the migrator preserves it.
+ *   2. `autoStackKey=true` AND legacy `nats.identity.seedPath` is set →
+ *      reuse the NATS auth NKey for stack signing. Cortex's NKey loader
+ *      enforces a `SU` (user-class) prefix gate (see
+ *      `src/common/config/stack-signing-key.ts`); operators running NATS
+ *      with a user-class NKey for auth pass that gate automatically.
+ *      `nats.identity.publicKey` (when present) carries forward as
+ *      `stack.nkey_pub` for the consistency pin.
+ *   3. Neither — emit a warning telling the operator to set
+ *      `stack.nkey_seed_path` (or re-run with `--auto-stack-key` when the
+ *      legacy config already has a NATS NKey).
+ *
+ * Returns the (possibly updated) stack block, or `undefined` when the
+ * input had no stack block AND no auto-population was performed. The
+ * caller stores the return value back onto `cortex.stack`.
+ */
+function annotateStackSigning(
+  existingStack: Record<string, unknown> | undefined,
+  legacy: LegacyBotYaml,
+  autoStackKey: boolean,
+  warnings: ConversionWarning[],
+): Record<string, unknown> | undefined {
+  // Branch 1: nkey_seed_path already declared — idempotent no-op.
+  if (
+    existingStack !== undefined &&
+    typeof existingStack.nkey_seed_path === "string" &&
+    existingStack.nkey_seed_path.length > 0
+  ) {
+    return existingStack;
+  }
+
+  // Extract the NATS-side identity (used by branches 2 + 3 messaging).
+  const natsIdentity =
+    legacy.nats && typeof legacy.nats === "object"
+      ? (legacy.nats as Record<string, unknown>).identity
+      : undefined;
+  const natsSeedPath =
+    natsIdentity && typeof natsIdentity === "object"
+      ? typeof (natsIdentity as Record<string, unknown>).seedPath === "string"
+        ? ((natsIdentity as Record<string, unknown>).seedPath as string)
+        : undefined
+      : undefined;
+  const natsPublicKey =
+    natsIdentity && typeof natsIdentity === "object"
+      ? typeof (natsIdentity as Record<string, unknown>).publicKey === "string"
+        ? ((natsIdentity as Record<string, unknown>).publicKey as string)
+        : undefined
+      : undefined;
+
+  // Branch 2: --auto-stack-key + NATS NKey available → reuse it.
+  if (autoStackKey && natsSeedPath !== undefined) {
+    const next: Record<string, unknown> = { ...(existingStack ?? {}) };
+    next.nkey_seed_path = natsSeedPath;
+    if (natsPublicKey !== undefined) next.nkey_pub = natsPublicKey;
+    warnings.push({
+      field: "stack.nkey_seed_path",
+      message:
+        `auto-populated stack.nkey_seed_path from nats.identity.seedPath (${natsSeedPath}) — ` +
+        `cortex will sign outbound envelopes with the NATS auth NKey. ` +
+        `Verify the seed is user-class (SU-prefixed) — operator/account NKeys (SO/SA) will fail at boot.`,
+    });
+    return next;
+  }
+
+  // Branch 3: warn — stack signing will stay off until the operator
+  // declares the field. Wording mirrors the cortex.ts boot WARNING so
+  // operators see consistent fix-paths across migrate-config + boot.
+  const hint = natsSeedPath
+    ? ` Re-run with \`--auto-stack-key\` to reuse \`${natsSeedPath}\` (NATS auth NKey) for stack signing.`
+    : " Generate one via `nsc generate nkey -u > ~/.config/nats/cortex.nk && chmod 600 ~/.config/nats/cortex.nk` and add the path to cortex.yaml.";
+  warnings.push({
+    field: "stack.nkey_seed_path",
+    message:
+      "stack.nkey_seed_path is not set — cortex will publish UNSIGNED envelopes (peers running " +
+      "verifySignedByChain will reject them). See docs/sop-stack-identity.md." +
+      hint,
+  });
+  return existingStack;
+}
+
 function convertNats(legacyNats: unknown, warnings: ConversionWarning[]): unknown {
   if (!legacyNats || typeof legacyNats !== "object") return legacyNats;
   const nats = { ...(legacyNats as Record<string, unknown>) };

--- a/src/cli/cortex/commands/migrate-config.ts
+++ b/src/cli/cortex/commands/migrate-config.ts
@@ -36,6 +36,13 @@ interface ParsedArgs {
   labels: string | undefined;
   check: boolean;
   strict: boolean;
+  /**
+   * cortex#324 (v2.0.3) — when set, the migrator reuses the legacy
+   * `nats.identity` block (seedPath + publicKey) for `stack.nkey_seed_path`
+   * + `stack.nkey_pub`. Off by default; without the flag, the migrator
+   * only emits a warning that stack signing is not configured.
+   */
+  autoStackKey: boolean;
   help: boolean;
 }
 
@@ -50,6 +57,7 @@ export function parseArgs(argv: string[]): ParsedArgs {
     labels: undefined,
     check: false,
     strict: false,
+    autoStackKey: false,
     help: false,
   };
   for (let i = 0; i < argv.length; i++) {
@@ -60,6 +68,8 @@ export function parseArgs(argv: string[]): ParsedArgs {
       args.check = true;
     } else if (a === "--strict") {
       args.strict = true;
+    } else if (a === "--auto-stack-key") {
+      args.autoStackKey = true;
     } else if (a === "--out") {
       const next = argv[i + 1];
       if (next === undefined || next.startsWith("--")) {
@@ -98,6 +108,7 @@ function printHelp(): void {
   console.log("  --labels FILE  Principal-id label overrides ({\"<platform>:<id>\": \"<principal-id>\"})");
   console.log("  --check        Validate + emit pre-flight gap report; exits 1 if gaps found");
   console.log("  --strict       Fail on warnings (default: warnings → stderr, exit 0)");
+  console.log("  --auto-stack-key  Reuse nats.identity NKey for stack.nkey_seed_path (cortex#324)");
   console.log("  -h, --help     Show this help");
 }
 
@@ -169,7 +180,11 @@ export async function runMigrateConfig(argv: string[]): Promise<number> {
 
   let result;
   try {
-    result = convertBotYaml(legacy, { configDir: dirname(inputPath), labels });
+    result = convertBotYaml(legacy, {
+      configDir: dirname(inputPath),
+      labels,
+      autoStackKey: args.autoStackKey,
+    });
   } catch (err) {
     console.error(`Error: conversion failed: ${err instanceof Error ? err.message : String(err)}`);
     return 1;

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -393,6 +393,37 @@ export async function startCortex(
         err instanceof Error ? err.message : String(err),
       );
     }
+  } else {
+    // cortex#324 (v2.0.3) — walk the talk: stack signing should be ON by
+    // default. When the operator hasn't declared `stack.nkey_seed_path`,
+    // every outbound envelope is published UNSIGNED, which means peers
+    // on the bus that run `verifySignedByChain` (cortex#320 / v2.0.2)
+    // will reject the messages — silently for plain `dispatch.*`, loudly
+    // once federation is on. The opt-in default is a footgun: operators
+    // upgrade from a working unsigned deployment, don't notice the
+    // missing field, and traffic looks fine until a peer enforces.
+    //
+    // For v2.0.3 we emit a LOUD stderr WARNING so operators tailing logs
+    // OR running interactively see the actionable fix-path. Boot stays
+    // non-fatal — existing deployments degrade gracefully (same shape as
+    // today's unsigned publish), and v2.0.4 promotes this to a refuse-to-
+    // boot once arc upgrade auto-provisions the field on every install.
+    //
+    // Same wording pattern as the cortex#314 capability-registry and
+    // review-consumer skip warnings (`src/cortex.ts:~640, ~774`): info
+    // log + stderr WARNING with the `arc upgrade Cortex` fix-path AND
+    // the manual cortex.yaml fix-path, plus a docs/sop-stack-identity.md
+    // cross-link for the rotation / threat-model background.
+    console.log(
+      "cortex: stack signing key not configured — outbound envelopes will be unsigned",
+    );
+    process.stderr.write(
+      "WARNING: stack identity not configured — cortex will publish unsigned envelopes.\n" +
+        "  Peers that verify signed_by[] will reject these messages.\n" +
+        "  Run `arc upgrade Cortex --force` to auto-provision, or add\n" +
+        "  `stack.nkey_seed_path` (+ optionally `stack.nkey_pub`) to cortex.yaml.\n" +
+        "  See docs/sop-stack-identity.md for the full SOP.\n",
+    );
   }
 
   // Bus runtime (M2-M6) — no-op when `config.nats?` is absent. Tests inject


### PR DESCRIPTION
## Summary

After cortex#320 (v2.0.2) wired runner-side `verifySignedByChain`, peers on the bus that enforce verification reject UNSIGNED envelopes. The opt-in `stack.nkey_seed_path` default left operators (including this one) silently publishing unsigned because the field never made it into their cortex.yaml. This change flips the default so cortex walks the talk.

Closes #324.

## What changes

Six coordinated changes:

1. **`src/cortex.ts`** — when `options.stack?.nkey_seed_path` is undefined, emit a loud stderr WARNING with both fix-paths (auto-provision via arc OR manual cortex.yaml edit) and a `docs/sop-stack-identity.md` cross-link. Boot stays non-fatal — v2.0.4 promotes to refuse-to-boot. Mirrors the cortex#314 capability-registry / review-consumer warning pattern (`src/cortex.ts:~640, ~774`).
2. **`cortex.yaml.example`** — populated `stack:` block with `nkey_seed_path` + `nkey_pub` placeholders + comment cross-linking the SOP and explaining what arc auto-provisions.
3. **`src/cli/cortex/commands/migrate-config-lib.ts`** + **`migrate-config.ts`** — new `--auto-stack-key` flag. When set, the migrator reuses the legacy `nats.identity.seedPath` + `publicKey` for stack signing (single-NKey deployment). Idempotent — pre-existing `stack.nkey_seed_path` is preserved. Without the flag, the migrator emits a warning suggesting the field be set.
4. **`scripts/lib/stack-identity-provision.sh`** (new) — arc upgrade auto-provisioner. Generates an `SU`-prefixed NKey at the canonical path (`~/.config/nats/cortex.nk` for main, `cortex-work.nk` for work) via nsc or bun+nkeys.js. Backs up the config before edit (`cortex.yaml.pre-stack-identity-${timestamp}`). Idempotent — no-op when the field is already set. Hooked into `scripts/postupgrade.sh` between the symlink refresh and plist render.
5. **`docs/sop-stack-identity.md`** (new) — operator-facing SOP. What the stack NKey is, where it lives, threat model, how arc provisions it, rotation procedure, cross-links to design docs.
6. **`arc-manifest.yaml`** — version bump v2.0.2 → v2.0.3.

## Operator pre-flight

- The operator's two stacks (`~/.config/cortex/cortex.yaml` + `cortex.work.yaml`) have been updated in-place with the existing NATS auth NKey reused for stack signing (both verified `SU`-prefixed at chmod 600 with the pubkey already declared as `nats.identity.publicKey`).
- Pre-edit backups: `~/.config/cortex/cortex.yaml.pre-v2.0.3-${timestamp}` and `cortex.work.yaml.pre-v2.0.3-${timestamp}`. Roll back trivially if needed.
- After this PR merges + `arc upgrade Cortex`, daemon boot should show `cortex: stack signing key staged — principal=did:mf:andreas-meta-factory (active once myelin runtime starts)`.

## Tests

- `src/__tests__/cortex.stack-signing-boot.test.ts` (new) — 3 tests pinning boot WARN behavior: WARN fires when seed_path absent, WARN fires when only stack.id declared, no WARN when seed_path is set with a valid `SU` seed.
- `src/cli/cortex/commands/__tests__/migrate-config.test.ts` — 5 new tests pinning the migrator behavior: warning on missing field, auto-populate from nats.identity, fall-through when no NATS NKey, idempotent pre-existing field, parseArgs for --auto-stack-key.

## Acceptance

- [x] `bunx tsc --noEmit` clean (exit 0)
- [x] `bun run lint:errors` clean (exit 0)
- [x] Full suite: **3342 pass, 2 skip, 0 fail** across 177 files
- [x] Operator's two configs round-trip through `CortexConfigSchema.parse`
- [x] `has_stack_seed_path` idempotency check confirmed on operator configs
- [x] `arc-manifest.yaml` → `v2.0.3`

## Scope NOT included (per issue)

- **User-level attribution on signed_by[0]** — myelin#160 (schema design).
- **Federation between operators** — already wired in Phase D.
- **Refuse-to-boot when signer missing** — v2.0.4 follow-up. v2.0.3 is loud-warning only so existing deployments degrade gracefully.

## Test plan

- [ ] Run `arc upgrade Cortex --force` on a fresh install (no `stack.nkey_seed_path` in cortex.yaml) → verify auto-provisioning fires and field appears in cortex.yaml.
- [ ] Operator daemons boot post-merge → verify `signer staged` log line.
- [ ] Capture bus traffic via `nats sub` → verify `signed_by[0]` stamps signed by the stack key.
- [ ] Re-run `arc upgrade Cortex` → idempotent skip ("Stack identity already configured").

🤖 Generated with [Claude Code](https://claude.com/claude-code)