### PR TITLE
feat(cortex): D1 — wire signatureVerifier into ReviewConsumer boot (default-ON, fail-open)

### DIFF
--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -51,7 +51,9 @@ import {
 import {
   ReviewConsumer,
   type ReviewConsumerAgent,
+  type SignatureVerifier,
 } from "./bus/review-consumer";
+import { verifySignedByChain } from "./bus/verify-signed-by-chain";
 import { CCSession } from "./runner/cc-session";
 
 import { DiscordAdapter } from "./adapters/discord";
@@ -751,6 +753,46 @@ export async function startCortex(
           maxConcurrent: agent.runtime.maxConcurrent,
         }),
       };
+      // cortex#327 follow-up (D1) — build the per-agent signature verifier
+      // closure when this agent declares a non-empty `trust:[]` list.
+      //
+      // **Default-ON, fail-open posture.** Agents with `trust: []` (the
+      // shape that says "I accept anything from anyone the runtime
+      // delivered") get NO verifier — the gate in `ReviewConsumer.processEnvelope`
+      // is a no-op, matching the pre-#329 behaviour. Agents with at least
+      // one trusted peer get the verifier wired and the gate enforces.
+      // This is the one-way ratchet: as operators add `trust:` entries
+      // to their cortex.yaml, signature enforcement strengthens
+      // automatically without any flag toggling.
+      //
+      // The closure captures `trustResolver`, `agent.id`, and the
+      // configured operatorId — same triple the bus-peer harness
+      // (`src/substrates/bus-peer/harness.ts`) supplies to
+      // verifySignedByChain on its inbound path. `cryptoVerify: true`
+      // engages B.1c canonical-bytes verification on top of B.1a
+      // structural-trust resolution.
+      //
+      // Reason mapping: discriminated `ChainRejectionReason` → short
+      // grep-friendly string ("empty_chain", "signer_not_trusted",
+      // "crypto_verify_failed", etc.) so the structured stderr line
+      // landed in #329 carries the rejection class verbatim. The full
+      // myelin-side detail is logged separately by the trust resolver.
+      const agentTrustList = agent.trust ?? [];
+      const verifyOperatorId = reviewOperatorId;
+      const signatureVerifier: SignatureVerifier | undefined =
+        agentTrustList.length === 0
+          ? undefined
+          : async (envelope) => {
+              const r = await verifySignedByChain(envelope, {
+                resolver: trustResolver,
+                receivingAgentId: agent.id,
+                cryptoVerify: true,
+                operatorId: verifyOperatorId,
+              });
+              if (r.valid) return { valid: true } as const;
+              return { valid: false, reason: r.reason.kind } as const;
+            };
+
       const consumer = new ReviewConsumer({
         agent: consumerAgent,
         source: systemEventSource,
@@ -769,6 +811,7 @@ export async function startCortex(
           // Minimal prompt — the real skill-aware builder lands in PR-8.
           // Echo's skill consumes `/review <owner/repo>#<pr>` style today.
           `/review ${payload.repo}#${payload.pr}`,
+        ...(signatureVerifier !== undefined && { signatureVerifier }),
       });
       reviewConsumers.push(consumer);
       // Subscribe via the runtime's subscribePull helper. When the
@@ -784,8 +827,12 @@ export async function startCortex(
       });
       const flavorSummary =
         consumer.flavors.length > 0 ? consumer.flavors.join(",") : "(none)";
+      // D1 visibility: surface whether signature verification is enforced
+      // on this consumer so operators can grep `signed=on/off` to confirm
+      // their trust:[] config landed where they expected.
+      const signedTag = signatureVerifier !== undefined ? "on" : "off";
       console.log(
-        `cortex: review consumer ready for agent=${agent.id} flavors=[${flavorSummary}]`,
+        `cortex: review consumer ready for agent=${agent.id} flavors=[${flavorSummary}] signed=${signedTag}`,
       );
     } catch (err) {
       // Per CLAUDE.md: log every error. A single agent's consumer crash


### PR DESCRIPTION
## Summary

Wires \`signatureVerifier\` into \`src/cortex.ts\`'s ReviewConsumer boot path. Closes the follow-up deferred by #329.

**Decision D1** from P-VERIFY post-mortem: **default-ON, fail-open posture**. Per-agent rollout granularity comes from the existing \`agent.trust:[]\` list — no new flag.

| Agent config | Result |
|---|---|
| \`trust: []\` (default) | No verifier → gate no-op (pre-#329 behaviour) |
| \`trust: [\"pilot\", ...]\` | Verifier wired → gate enforces |

One-way ratchet: as operators add \`trust:\` entries, enforcement strengthens automatically.

## Why this posture

- **Opt-in flag (rejected)**: ceremony, easy to forget, two ways to express same intent.
- **Default-ON fail-closed (rejected)**: would break every existing operator whose cortex.yaml has bare \`trust: []\` agents (most of them today).
- **Default-ON fail-open (this PR)**: zero regression risk + automatic security upgrade as operators configure trust.

## What changed

\`src/cortex.ts\` review-consumer construction loop builds a per-agent verifier closure when \`agent.trust[].length > 0\`. Closure captures the boot-time \`trustResolver\` + \`agent.id\` + resolved \`operatorId\` + \`cryptoVerify: true\`. Reason mapping: cortex's discriminated \`ChainRejectionReason\` → short string (\"empty_chain\", \"signer_not_trusted\", \"crypto_verify_failed\") — same format #329's structured stderr + dispatch.task.failed.detail thread.

## Operator visibility

Boot log line now ends with \`signed=on/off\`:

\`\`\`
cortex: review consumer ready for agent=echo flavors=[code-review.typescript] signed=on
\`\`\`

## Test plan

- [x] \`bun test src/__tests__/\` — 65 pass / 0 fail (pre-existing fixtures have \`trust: []\` → gate stays off)
- [x] \`bun test\` full suite — 3348 pass / 2 skip / 1 fail (pre-existing CCSession flake, unrelated)
- [x] \`bunx tsc --noEmit\` — clean

## What this enables

- Wave 3 P-VERIFY ground-truth cycles can start
- Operators configuring \`trust:[]\` get enforcement
- Operators not configuring it keep working
- cortex#327 wiring now actually exercised on every boot

## Refs

- D1 decision from P-VERIFY post-mortem (2026-05-17)
- cortex#327 — verifier wiring closed by #329
- cortex#329 — opt-in surface this PR turns default-ON

🤖 Generated with [Claude Code](https://claude.com/claude-code)