### PR TITLE
feat(runner): pi-dev substrate adapter for ReviewConsumer (Phase 1, refs #331)

### DIFF
--- a/src/__tests__/cortex.review-consumer.e2e.test.ts
+++ b/src/__tests__/cortex.review-consumer.e2e.test.ts
@@ -64,6 +64,11 @@ import type {
   ReviewPipelineOpts,
   ReviewPipelineResult,
 } from "../runner/review-pipeline";
+import {
+  makePiDevPipelineRunner,
+  type PiDevSpawnFn,
+  type PiDevSpawnResult,
+} from "../runner/substrate/pi-dev-runner";
 import type { CCSessionFactory } from "../substrates/claude-code/harness";
 
 // =============================================================================
@@ -722,5 +727,127 @@ describe("cortex#327 — signature verification gate", () => {
     const failed = emitted[0]!;
     const reason = (failed.payload as { reason: { kind: string; detail: string } }).reason;
     expect(reason.detail).toContain("signer_not_trusted");
+  });
+});
+
+// =============================================================================
+// cortex#331 Phase 1 — pi-dev substrate dispatch
+// =============================================================================
+//
+// Pins the cortex-side end-to-end round-trip for the `pi-dev` substrate
+// (sage). Uses the same in-process bus harness as the unsigned and signed
+// round-trips above, but injects `makePiDevPipelineRunner` (with a stubbed
+// subprocess spawn) instead of the test-only inline stub. This proves the
+// production factory wires into a real `ReviewConsumer` cleanly — same
+// shape that `src/cortex.ts:807` boots when an agent declares
+// `runtime.substrate: "pi-dev"`.
+//
+// Sub-cases (substrate-transient `not_now`, missing binary, etc.) are
+// covered at the unit level in `src/runner/substrate/__tests__/pi-dev-
+// runner.test.ts`. This file proves the *integration*: factory → consumer
+// → bus → ack.
+// =============================================================================
+
+describe("cortex#331 Phase 1 — pi-dev substrate dispatch (factory wired into ReviewConsumer)", () => {
+  let runtime: BusRuntime;
+  let consumer: ReviewConsumer;
+  const stdoutMarkdown = "## sage review\n\nblockers=0 majors=0 nits=0 — looks good";
+
+  beforeAll(async () => {
+    runtime = createBusRuntime();
+    const agent: ReviewConsumerAgent = {
+      id: "sage",
+      capabilities: ["code-review.typescript"],
+    };
+
+    // Stub spawn that returns a canned successful sage subprocess.
+    // Mirrors what the unit tests do but here it threads through the
+    // real `makePiDevPipelineRunner` factory.
+    const spawnFake: PiDevSpawnFn = (_argv, _opts): PiDevSpawnResult => ({
+      stdout: new Response(stdoutMarkdown).body!,
+      stderr: new Response("").body!,
+      exited: Promise.resolve(0),
+    });
+
+    const pipelineRunner = makePiDevPipelineRunner({
+      sageBin: "/usr/local/bin/sage",
+      spawn: spawnFake,
+    });
+
+    consumer = new ReviewConsumer({
+      agent,
+      source: SOURCE,
+      runtime,
+      // The CC factory stays wired even for pi-dev consumers — see
+      // `src/cortex.ts` boot wiring rationale. The pi-dev runner never
+      // touches it; STUB_CC_FACTORY throws if invoked so a regression
+      // that drops back to the CC path is loud.
+      ccSessionFactory: STUB_CC_FACTORY,
+      promptBuilder: ({ payload }) => `/review ${payload.repo}#${payload.pr}`,
+      pipelineRunner,
+    });
+
+    await consumer.start({
+      pattern: REVIEW_SUBJECT_PATTERN,
+      stream: REVIEW_STREAM,
+      durable: "cortex-review-consumer-metafactory-sage-pidev",
+    });
+  });
+
+  afterAll(async () => {
+    await consumer.stop();
+    await runtime.stop();
+  });
+
+  test("happy round-trip: tasks.code-review.typescript → sage stdout becomes verdict.commented envelope; correlation_id matches; JsMsg.ack() called", async () => {
+    const publishedBefore = runtime.published.length;
+    const request = makeRequest("typescript");
+    const requestSubject = subjectFor(request);
+
+    const { handlersCalled, decisions } = await runtime.deliver(
+      request,
+      requestSubject,
+    );
+
+    expect(handlersCalled).toBe(1);
+    expect(decisions[0]).toEqual({ kind: "ack" });
+
+    // started + verdict + completed, in §8.2 order.
+    const emitted = runtime.published.slice(publishedBefore);
+    expect(emitted.length).toBe(3);
+    expect(emitted[0]!.type).toBe("dispatch.task.started");
+    expect(emitted[1]!.type).toBe("review.verdict.commented");
+    expect(emitted[2]!.type).toBe("dispatch.task.completed");
+
+    // **THE HEADLINE CONTRACT** — verdict envelope's correlation_id is
+    // the request envelope's id (design §5.1). Phase 1's pi-dev runner
+    // preserves this; if a future refactor breaks it pilot's --wait
+    // would silently miss every sage verdict.
+    const verdict = emitted[1]!;
+    expect(verdict.correlation_id).toBe(request.id);
+
+    // Summary carries sage's stdout verbatim — Phase 2 will parse this
+    // into structured findings, but Phase 1 is a markdown pass-through.
+    const payload = verdict.payload as {
+      repo: string;
+      pr: number;
+      reviewer: string;
+      verdict: string;
+      summary: string;
+    };
+    expect(payload.summary).toBe(stdoutMarkdown);
+    expect(payload.repo).toBe(VALID_PAYLOAD.repo);
+    expect(payload.pr).toBe(VALID_PAYLOAD.pr);
+    expect(payload.reviewer).toBe("sage");
+    expect(payload.verdict).toBe("commented");
+
+    // Ack on JsMsg — round-trip ack semantics asserted at the
+    // pull-subscriber boundary.
+    const sub = runtime.subscriptions[0]!;
+    expect(sub.msgs.length).toBe(1);
+    const msg = sub.msgs[0]!;
+    expect(msg.ack).toHaveBeenCalledTimes(1);
+    expect(msg.nak).toHaveBeenCalledTimes(0);
+    expect(msg.term).toHaveBeenCalledTimes(0);
   });
 });

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -55,6 +55,7 @@ import {
 } from "./bus/review-consumer";
 import { verifySignedByChain } from "./bus/verify-signed-by-chain";
 import { CCSession } from "./runner/cc-session";
+import { makePiDevPipelineRunner } from "./runner/substrate/pi-dev-runner";
 
 import { DiscordAdapter } from "./adapters/discord";
 import { createRenderer, type Renderer } from "./renderers";
@@ -793,6 +794,24 @@ export async function startCortex(
               return { valid: false, reason: r.reason.kind } as const;
             };
 
+      // cortex#331 Phase 1 — substrate-aware pipelineRunner selection.
+      //
+      // Agents that declare `runtime.substrate: "pi-dev"` get the sage
+      // adapter wired in via `makePiDevPipelineRunner`. Every other agent
+      // (including those with the substrate field unset, which defaults
+      // to claude-code semantics) gets no `pipelineRunner` opt so the
+      // ReviewConsumer falls through to the existing `runReviewPipeline`
+      // → CC path (`ccSessionFactory` stays wired for that path; we do
+      // NOT remove it — see the issue's "out of scope" list).
+      //
+      // The pi-dev runner resolves its sage binary lazily at first use
+      // (see `pi-dev-runner.ts`'s lifetime note), so a missing sage on
+      // boot does not crash this loop — review requests surface the
+      // failure as `dispatch.task.failed` envelopes instead.
+      const substrate = agent.runtime?.substrate ?? "claude-code";
+      const pipelineRunner =
+        substrate === "pi-dev" ? makePiDevPipelineRunner({}) : undefined;
+
       const consumer = new ReviewConsumer({
         agent: consumerAgent,
         source: systemEventSource,
@@ -803,7 +822,10 @@ export async function startCortex(
         // into the public bus surface). Tests don't reach the factory
         // unless `processEnvelope` is invoked; the boot test in
         // `src/__tests__/cortex.review-consumer-boot.test.ts` only
-        // exercises instantiation + subscribe.
+        // exercises instantiation + subscribe. Stays wired even when a
+        // non-CC pipelineRunner is selected — the consumer's type still
+        // requires the factory, and the CC path remains the default
+        // fallthrough for non-pi-dev substrates.
         ccSessionFactory: (opts) => new CCSession(opts),
         // PR-6 has no policy hook — that's a future PR (sovereignty /
         // compliance gate). Until then the pipeline goes straight to CC.
@@ -811,6 +833,7 @@ export async function startCortex(
           // Minimal prompt — the real skill-aware builder lands in PR-8.
           // Echo's skill consumes `/review <owner/repo>#<pr>` style today.
           `/review ${payload.repo}#${payload.pr}`,
+        ...(pipelineRunner !== undefined && { pipelineRunner }),
         ...(signatureVerifier !== undefined && { signatureVerifier }),
       });
       reviewConsumers.push(consumer);
@@ -831,8 +854,13 @@ export async function startCortex(
       // on this consumer so operators can grep `signed=on/off` to confirm
       // their trust:[] config landed where they expected.
       const signedTag = signatureVerifier !== undefined ? "on" : "off";
+      // cortex#331 Phase 1 — surface the dispatching substrate so
+      // operators can grep `substrate=pi-dev` / `substrate=claude-code`
+      // to confirm sage agents (or any future substrate) actually
+      // received the substrate-aware factory. Unset substrate defaults
+      // to `claude-code` in the log (matches the runtime fallthrough).
       console.log(
-        `cortex: review consumer ready for agent=${agent.id} flavors=[${flavorSummary}] signed=${signedTag}`,
+        `cortex: review consumer ready for agent=${agent.id} flavors=[${flavorSummary}] signed=${signedTag} substrate=${substrate}`,
       );
     } catch (err) {
       // Per CLAUDE.md: log every error. A single agent's consumer crash

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -796,6 +796,18 @@ export async function startCortex(
 
       // cortex#331 Phase 1 — substrate-aware pipelineRunner selection.
       //
+      // **Why this lives in cortex (not sage).** Sage went in-process at
+      // sage#41 — its standalone launchd daemon and standalone NATS
+      // subscribe path are retired. Cortex's review-consumer is now the
+      // sole receiver for sage-owned review flavors. The cross-repo scope
+      // split (sage#40 / sage#41 / cortex#331) deliberately puts
+      // cortex-side wiring HERE in cortex#331, NOT in sage's Phase 1 —
+      // sage stepped DOWN from owning its own bus subscription, cortex
+      // stepped UP to own substrate dispatch for in-process agents. The
+      // selection below is the substrate-dispatch fork that closes the
+      // round-trip; the adapter itself lives in
+      // `src/runner/substrate/pi-dev-runner.ts`.
+      //
       // Agents that declare `runtime.substrate: "pi-dev"` get the sage
       // adapter wired in via `makePiDevPipelineRunner`. Every other agent
       // (including those with the substrate field unset, which defaults

--- a/src/runner/substrate/__tests__/pi-dev-runner.test.ts
+++ b/src/runner/substrate/__tests__/pi-dev-runner.test.ts
@@ -1,0 +1,293 @@
+/**
+ * cortex#331 Phase 1 — `pi-dev-runner.ts` unit tests.
+ *
+ * Drives the runner via injected `spawn` + `which` seams so no real
+ * `sage` binary is invoked in CI. Pins the three load-bearing branches
+ * from the issue:
+ *
+ *   1. Happy path: exit 0 + stdout → `{ kind: "verdict", envelope }` with
+ *      `payload.summary === stdout`, `correlation_id === requestEnvelope.id`.
+ *   2. Failure path: non-zero exit + stderr → `{ kind: "failed", envelope }`
+ *      with `reason.kind: "cant_do"` carrying stderr verbatim.
+ *   3. Binary not found: `which` returns undefined → `{ kind: "failed",
+ *      envelope }` with a useful operator-facing detail string. Boot path
+ *      is structurally identical for all three — the runner never throws.
+ *
+ * The four-way nak taxonomy (`cant_do` / `wont_do` / `not_now` /
+ * `compliance_block`) is intentionally collapsed to `cant_do` in Phase 1
+ * (see module docblock); when Phase 2's `--format json` lands, expand
+ * these cases to cover the substrate-transient `not_now` paths too.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { Envelope } from "../../../bus/myelin/envelope-validator";
+import {
+  createReviewRequestEvent,
+  type ReviewEventSource,
+  type ReviewRequestPayload,
+} from "../../../bus/review-events";
+import type { ReviewPipelineOpts } from "../../review-pipeline";
+import type { CCSessionFactory } from "../../../substrates/claude-code/harness";
+import {
+  makePiDevPipelineRunner,
+  type PiDevSpawnFn,
+  type PiDevSpawnResult,
+  type PiDevWhichFn,
+} from "../pi-dev-runner";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const SOURCE: ReviewEventSource = {
+  org: "metafactory",
+  agent: "cortex",
+  instance: "local",
+};
+
+const VALID_PAYLOAD: ReviewRequestPayload = {
+  repo: "the-metafactory/cortex",
+  pr: 331,
+  reviewer: "sage",
+  feature: "C-331",
+  title: "feat: pi-dev substrate adapter",
+};
+
+/** Build a ReviewPipelineOpts for the runner. The CC factory is a stub
+ *  that throws if invoked — the pi-dev runner MUST NOT touch it. */
+function makePipelineOpts(): ReviewPipelineOpts {
+  const requestEnvelope = createReviewRequestEvent({
+    source: SOURCE,
+    flavor: "typescript",
+    payload: VALID_PAYLOAD,
+  });
+  const stubCCFactory: CCSessionFactory = () => {
+    throw new Error(
+      "pi-dev-runner test: CC factory must NEVER be called by the pi-dev runner",
+    );
+  };
+  return {
+    requestEnvelope,
+    payload: VALID_PAYLOAD,
+    agentId: "sage",
+    source: SOURCE,
+    ccSessionFactory: stubCCFactory,
+    prompt: "(unused by pi-dev runner)",
+  };
+}
+
+/**
+ * Build a `PiDevSpawnResult` from a canned stdout, stderr, and exit code.
+ * Uses `Response.body` to turn strings into the same `ReadableStream<Uint8Array>`
+ * shape `Bun.spawn` returns — same trick the production runner uses to
+ * drain via `new Response(stream).text()`.
+ */
+function makeSpawnResult(
+  stdout: string,
+  stderr: string,
+  exitCode: number,
+): PiDevSpawnResult {
+  const stdoutStream = new Response(stdout).body!;
+  const stderrStream = new Response(stderr).body!;
+  return {
+    stdout: stdoutStream,
+    stderr: stderrStream,
+    exited: Promise.resolve(exitCode),
+  };
+}
+
+/**
+ * Make a spawn fake that captures every argv it sees and returns the
+ * given `PiDevSpawnResult`. Pins the argv shape the runner builds
+ * (`sage review owner/repo#N --substrate pi`).
+ */
+function makeRecordingSpawn(
+  result: PiDevSpawnResult,
+): { fn: PiDevSpawnFn; calls: string[][] } {
+  const calls: string[][] = [];
+  const fn: PiDevSpawnFn = (argv, _opts) => {
+    calls.push([...argv]);
+    return result;
+  };
+  return { fn, calls };
+}
+
+/** `which` stub that returns a fixed sage binary path. */
+const FAKE_SAGE_BIN = "/usr/local/bin/sage";
+const whichSuccess: PiDevWhichFn = (cmd) =>
+  cmd === "sage" ? FAKE_SAGE_BIN : undefined;
+const whichMissing: PiDevWhichFn = () => undefined;
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("cortex#331 Phase 1 — makePiDevPipelineRunner", () => {
+  test("happy path: sage exit 0 + stdout → verdict envelope with summary=stdout, correlation_id=requestEnvelope.id", async () => {
+    const stdout = "## review body\n\nverdict: commented";
+    const spawn = makeRecordingSpawn(makeSpawnResult(stdout, "", 0));
+    const runner = makePiDevPipelineRunner({
+      spawn: spawn.fn,
+      which: whichSuccess,
+    });
+
+    const opts = makePipelineOpts();
+    const result = await runner(opts);
+
+    // Result shape — verdict, not failed.
+    expect(result.kind).toBe("verdict");
+    if (result.kind !== "verdict") return; // narrow
+
+    // Envelope wiring — correlation_id is the request envelope's id (the
+    // single load-bearing pilot contract per design §5.1).
+    const envelope: Envelope = result.envelope;
+    expect(envelope.type).toBe("review.verdict.commented");
+    expect(envelope.correlation_id).toBe(opts.requestEnvelope.id);
+
+    // Payload shape — summary echoes sage's stdout verbatim, repo/pr
+    // echo the request payload, reviewer is the Phase 1 default "sage".
+    const payload = envelope.payload as {
+      repo: string;
+      pr: number;
+      reviewer: string;
+      verdict: string;
+      summary: string;
+    };
+    expect(payload.summary).toBe(stdout);
+    expect(payload.repo).toBe(VALID_PAYLOAD.repo);
+    expect(payload.pr).toBe(VALID_PAYLOAD.pr);
+    expect(payload.reviewer).toBe("sage");
+    expect(payload.verdict).toBe("commented");
+
+    // Argv pin — `sage review owner/repo#N --substrate pi`, with the
+    // resolved binary path as argv[0].
+    expect(spawn.calls.length).toBe(1);
+    expect(spawn.calls[0]).toEqual([
+      FAKE_SAGE_BIN,
+      "review",
+      `${VALID_PAYLOAD.repo}#${VALID_PAYLOAD.pr}`,
+      "--substrate",
+      "pi",
+    ]);
+  });
+
+  test("failure path: sage exit != 0 + stderr → failed envelope with reason.kind=cant_do carrying stderr in detail", async () => {
+    const stderr = "sage: PR not found";
+    const spawn = makeRecordingSpawn(makeSpawnResult("", stderr, 2));
+    const runner = makePiDevPipelineRunner({
+      spawn: spawn.fn,
+      which: whichSuccess,
+    });
+
+    const opts = makePipelineOpts();
+    const result = await runner(opts);
+
+    // Result shape — failed, not verdict.
+    expect(result.kind).toBe("failed");
+    if (result.kind !== "failed") return; // narrow
+
+    // Envelope wiring — correlation_id is the request envelope's id
+    // (failed-path contract per design §5.2).
+    const envelope: Envelope = result.envelope;
+    expect(envelope.type).toBe("dispatch.task.failed");
+    expect(envelope.correlation_id).toBe(opts.requestEnvelope.id);
+
+    // Reason — Phase 1 collapses every non-happy outcome to `cant_do`
+    // (see module docblock). Detail must carry stderr so operators can
+    // grep `nats consumer info` for the actual sage error.
+    const reason = (envelope.payload as { reason: { kind: string; detail: string } })
+      .reason;
+    expect(reason.kind).toBe("cant_do");
+    expect(reason.detail).toContain("sage review exited 2");
+    expect(reason.detail).toContain(stderr);
+  });
+
+  test("binary not found: which returns undefined → failed envelope with operator-actionable detail, NEVER throws", async () => {
+    // No spawn call should happen — the runner must short-circuit before
+    // any subprocess work when the binary is missing. We still pass a
+    // spawn that would throw if invoked to pin that no-call invariant.
+    const spawnThatMustNotRun: PiDevSpawnFn = () => {
+      throw new Error("pi-dev-runner test: spawn must not be called when sage is missing");
+    };
+
+    // Clear SAGE_BIN for this test so the env fallback can't accidentally
+    // resolve a real sage on the dev box.
+    const previousSageBin = process.env.SAGE_BIN;
+    delete process.env.SAGE_BIN;
+    try {
+      const runner = makePiDevPipelineRunner({
+        spawn: spawnThatMustNotRun,
+        which: whichMissing,
+      });
+
+      const opts = makePipelineOpts();
+      // CRITICAL: this must not throw — the consumer assumes
+      // pipelineRunner is non-throwing (see review-pipeline.ts contract).
+      const result = await runner(opts);
+
+      expect(result.kind).toBe("failed");
+      if (result.kind !== "failed") return;
+
+      const envelope = result.envelope;
+      expect(envelope.correlation_id).toBe(opts.requestEnvelope.id);
+      const reason = (envelope.payload as { reason: { kind: string; detail: string } })
+        .reason;
+      expect(reason.kind).toBe("cant_do");
+      // Operator-actionable message — names the env var and PATH hint.
+      expect(reason.detail).toContain("sage binary not found");
+      expect(reason.detail).toContain("SAGE_BIN");
+    } finally {
+      if (previousSageBin !== undefined) {
+        process.env.SAGE_BIN = previousSageBin;
+      }
+    }
+  });
+
+  test("explicit sageBin option wins over both env and PATH lookup", async () => {
+    // Verify the resolution-order contract from the module docblock:
+    //   1. opts.sageBin → 2. process.env.SAGE_BIN → 3. Bun.which("sage")
+    const explicitBin = "/opt/custom/sage";
+    const spawn = makeRecordingSpawn(makeSpawnResult("ok", "", 0));
+    // Set SAGE_BIN to a different path; the explicit opt should still win.
+    const previousSageBin = process.env.SAGE_BIN;
+    process.env.SAGE_BIN = "/different/env/sage";
+    try {
+      const runner = makePiDevPipelineRunner({
+        sageBin: explicitBin,
+        spawn: spawn.fn,
+        which: whichSuccess, // returns yet another path — also overridden
+      });
+
+      await runner(makePipelineOpts());
+      expect(spawn.calls.length).toBe(1);
+      expect(spawn.calls[0]?.[0]).toBe(explicitBin);
+    } finally {
+      if (previousSageBin === undefined) {
+        delete process.env.SAGE_BIN;
+      } else {
+        process.env.SAGE_BIN = previousSageBin;
+      }
+    }
+  });
+
+  test("spawn throw (e.g. ENOENT mid-spawn) is caught and surfaces as a failed envelope, not an unhandled rejection", async () => {
+    const spawnThatThrows: PiDevSpawnFn = () => {
+      throw new Error("ENOENT: no such file or directory");
+    };
+    const runner = makePiDevPipelineRunner({
+      spawn: spawnThatThrows,
+      which: whichSuccess,
+    });
+
+    const opts = makePipelineOpts();
+    const result = await runner(opts);
+
+    expect(result.kind).toBe("failed");
+    if (result.kind !== "failed") return;
+    const reason = (result.envelope.payload as { reason: { kind: string; detail: string } })
+      .reason;
+    expect(reason.kind).toBe("cant_do");
+    expect(reason.detail).toContain("sage spawn failed");
+    expect(reason.detail).toContain("ENOENT");
+  });
+});

--- a/src/runner/substrate/pi-dev-runner.ts
+++ b/src/runner/substrate/pi-dev-runner.ts
@@ -1,0 +1,356 @@
+/**
+ * cortex#331 Phase 1 — `pi-dev` substrate pipeline runner.
+ *
+ * **What this module is.** A `ReviewPipelineRunner` factory that targets
+ * sage's `pi-dev` substrate. Returns an async function with the same
+ * signature `runReviewPipeline` exposes (see `src/runner/review-pipeline.ts`),
+ * so it slots into `ReviewConsumerOpts.pipelineRunner` without any consumer
+ * code changes. The boot wire in `src/cortex.ts` picks this factory for
+ * agents that declare `runtime.substrate: "pi-dev"`; everything else
+ * continues to fall through to the default CC pipeline.
+ *
+ * **What this module does NOT do (Phase 1 scope per issue #331).**
+ *
+ *   - NO structured JSON verdict parsing — sage's `sage review` emits
+ *     markdown today. We pass the markdown through as `payload.summary`
+ *     and hardcode `verdict: "commented"` so pilot's verdict-subscriber
+ *     still sees a correlated envelope. Phase 2 swaps to `--format json`
+ *     and parses approved/changes-requested/commented from the verdict
+ *     block.
+ *   - NO library import of sage modules — we shell out via `sage review`.
+ *     Phase 2 considers `import { runSageReview } from "@the-metafactory/sage"`
+ *     once sage's `package.json` declares `exports`.
+ *   - NO Claude Code substrate path — that stays at `runReviewPipeline`
+ *     in `src/runner/review-pipeline.ts`. Phase 1 is purely additive.
+ *
+ * **Binary resolution.** Sage's CLI is looked up in this order:
+ *
+ *   1. `opts.sageBin` — explicit override, primarily a test seam.
+ *   2. `process.env.SAGE_BIN` — operator override; lets the user pin
+ *      a specific sage build without editing cortex.yaml.
+ *   3. `Bun.which("sage")` — falls back to `$PATH`.
+ *
+ * If none of these resolve, we surface a typed `dispatch.task.failed`
+ * envelope with `reason.kind: "cant_do"` rather than throwing — keeping
+ * the boot path identical to the CC factory's contract (the consumer
+ * never has to try/catch around `pipelineRunner`).
+ *
+ * **Failure shape.** Mirrors `runReviewPipeline`'s contract:
+ *
+ *   | Outcome                          | result.kind | reason.kind |
+ *   |----------------------------------|-------------|-------------|
+ *   | sage exit 0                      | `verdict`   | (none)      |
+ *   | sage exit != 0                   | `failed`    | `cant_do`   |
+ *   | sage binary not found            | `failed`    | `cant_do`   |
+ *   | spawn throw (env / sandbox bug)  | `failed`    | `cant_do`   |
+ *
+ * Phase 1 maps every non-happy outcome to `cant_do` because we don't yet
+ * distinguish substrate-transient (`not_now`) from skill-permanent
+ * (`cant_do`) at this layer — sage's exit codes aren't documented as a
+ * taxonomy yet. Phase 2 (sage#TBD: structured `--format json` exit codes)
+ * splits this into the four-way nak taxonomy.
+ *
+ * **Subprocess shape.** We spawn `sage review <owner>/<repo>#<n>
+ * --substrate pi`. Stdout is captured to a single string and used as
+ * `payload.summary`. Stderr is captured separately and fed into the
+ * failed envelope's `reason.detail` when sage exits non-zero. Both pipes
+ * are drained via `new Response(stream).text()` in parallel with the
+ * `exited` promise so a large markdown blob can't deadlock on the OS
+ * pipe buffer (same pattern as `src/surface/mc/api/github-fetch.ts`).
+ */
+
+import type { Envelope } from "../../bus/myelin/envelope-validator";
+import {
+  createReviewTaskFailedEvent,
+  createReviewVerdictEvent,
+  type ReviewEventSource,
+  type ReviewRequestPayload,
+} from "../../bus/review-events";
+import type {
+  ReviewPipelineOpts,
+  ReviewPipelineResult,
+} from "../review-pipeline";
+
+// ---------------------------------------------------------------------------
+// Spawn-injection types — narrowed surface of `Bun.spawn`
+// ---------------------------------------------------------------------------
+//
+// We don't take `typeof Bun.spawn` directly because that type is wide
+// (overloads + many options) and brittle across Bun versions. The
+// `pi-dev-runner` only needs three handles per child process — stdout,
+// stderr, and `exited` — plus the option bag we pass on the spawn call.
+// Narrowing the type makes the test seam trivial to satisfy (the unit
+// tests build a fake that returns three Response-shaped readables and a
+// fixed exit code) and lets us evolve internal spawn flags without
+// breaking callers.
+
+/** The handle the runner needs from `Bun.spawn`. */
+export interface PiDevSpawnResult {
+  stdout: ReadableStream<Uint8Array>;
+  stderr: ReadableStream<Uint8Array>;
+  exited: Promise<number>;
+}
+
+/**
+ * Spawn function signature. Production wires `Bun.spawn`; tests inject a
+ * deterministic fake (see `pi-dev-runner.test.ts`).
+ *
+ * `argv[0]` is the resolved sage binary path; subsequent entries are the
+ * `review <pr-ref> --substrate pi` arguments.
+ */
+export type PiDevSpawnFn = (
+  argv: string[],
+  opts: { stdout: "pipe"; stderr: "pipe" },
+) => PiDevSpawnResult;
+
+/**
+ * Binary resolver — returns the absolute path to the sage CLI, or
+ * `undefined` if no binary is found. Production wires `Bun.which`; tests
+ * stub this to simulate missing-binary cases.
+ */
+export type PiDevWhichFn = (cmd: string) => string | undefined;
+
+// ---------------------------------------------------------------------------
+// Public factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Options for {@link makePiDevPipelineRunner}.
+ *
+ * All fields are optional; the default behaviour is:
+ *
+ *   - Resolve sage binary via `SAGE_BIN` env then `Bun.which("sage")`.
+ *   - Use `Bun.spawn` for the subprocess.
+ *   - Use the current process env (no scrubbing — sage piggybacks on the
+ *     operator's `gh` auth and `GITHUB_TOKEN` via inherited env).
+ */
+export interface MakePiDevRunnerOpts {
+  /**
+   * Explicit sage binary path. Highest-priority resolution (skips env +
+   * PATH lookup). Primarily a test seam; production callers typically
+   * leave this undefined.
+   */
+  sageBin?: string;
+  /**
+   * Spawn function — defaults to `Bun.spawn`. Tests inject a fake that
+   * yields a canned `PiDevSpawnResult`.
+   */
+  spawn?: PiDevSpawnFn;
+  /**
+   * `which`-style lookup — defaults to `Bun.which`. Tests stub this to
+   * simulate the binary-not-found path without touching `$PATH`.
+   */
+  which?: PiDevWhichFn;
+}
+
+/**
+ * Build a pipeline runner that dispatches to sage's `pi-dev` substrate.
+ *
+ * The returned function has the exact signature
+ * `(opts: ReviewPipelineOpts) => Promise<ReviewPipelineResult>` —
+ * structurally identical to `runReviewPipeline`, so it drops straight
+ * into `ReviewConsumerOpts.pipelineRunner`.
+ *
+ * **Lifetime.** Binary resolution happens lazily on every invocation,
+ * NOT at factory-construction time. This means:
+ *
+ *   - Boot never fails on a missing sage binary — the consumer comes up
+ *     fine and individual review requests surface the failure as a
+ *     `dispatch.task.failed` envelope. Operators can install sage after
+ *     boot without restarting cortex.
+ *   - A sage install/upgrade is picked up on the next review request
+ *     (no stale binary path cached).
+ *
+ * **No side effects at construction.** The factory just closes over
+ * `opts`; no spawn, no I/O. Safe to call at boot time.
+ */
+export function makePiDevPipelineRunner(
+  opts: MakePiDevRunnerOpts = {},
+): (pipeline: ReviewPipelineOpts) => Promise<ReviewPipelineResult> {
+  const spawn = opts.spawn ?? defaultSpawn;
+  const which = opts.which ?? defaultWhich;
+  const explicitBin = opts.sageBin;
+
+  return async (pipeline: ReviewPipelineOpts): Promise<ReviewPipelineResult> => {
+    const correlationId = pipeline.requestEnvelope.id;
+    const startedAt = new Date();
+
+    // Coerce the payload — review-consumer already validated the shape
+    // before handing it to the pipeline runner, but the type on
+    // `Envelope.payload` is `unknown` so we narrow once here.
+    const payload = pipeline.payload as ReviewRequestPayload;
+
+    // Resolve the sage binary. Priority: explicit > env > $PATH.
+    const sageBin =
+      explicitBin ?? process.env.SAGE_BIN ?? which("sage") ?? undefined;
+    if (sageBin === undefined) {
+      return failed(
+        pipeline,
+        correlationId,
+        startedAt,
+        "pi-dev: sage binary not found (set SAGE_BIN env or install sage on PATH)",
+      );
+    }
+
+    // Build the pr-ref string from the request payload. `payload.repo`
+    // is already `owner/repo` (per ReviewRequestPayload in
+    // src/bus/review-events.ts §4.1), so we concatenate with `#<pr>`
+    // directly — no separate owner field on the cortex-side payload.
+    const prRef = `${payload.repo}#${payload.pr}`;
+    const argv = [sageBin, "review", prRef, "--substrate", "pi"];
+
+    let proc: PiDevSpawnResult;
+    try {
+      proc = spawn(argv, { stdout: "pipe", stderr: "pipe" });
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
+      return failed(
+        pipeline,
+        correlationId,
+        startedAt,
+        `pi-dev: sage spawn failed: ${detail}`,
+      );
+    }
+
+    // Drain stdout + stderr in parallel with `exited` so a large markdown
+    // blob can't deadlock on the OS pipe buffer (same pattern as
+    // `src/surface/mc/api/github-fetch.ts`).
+    let stdout: string;
+    let stderr: string;
+    let exitCode: number;
+    try {
+      const [so, se, code] = await Promise.all([
+        new Response(proc.stdout).text(),
+        new Response(proc.stderr).text(),
+        proc.exited,
+      ]);
+      stdout = so;
+      stderr = se;
+      exitCode = code;
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
+      return failed(
+        pipeline,
+        correlationId,
+        startedAt,
+        `pi-dev: sage subprocess stream error: ${detail}`,
+      );
+    }
+
+    if (exitCode !== 0) {
+      return failed(
+        pipeline,
+        correlationId,
+        startedAt,
+        `sage review exited ${exitCode}: ${stderr.trim()}`,
+      );
+    }
+
+    // Phase 1: pass the full markdown through as the verdict summary.
+    // Verdict kind is hardcoded to `commented` — Phase 2 (sage emits
+    // structured JSON) replaces this with parsed approved /
+    // changes-requested / commented from sage's verdict block.
+    return verdict(pipeline, correlationId, stdout);
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Production spawn — `Bun.spawn`. */
+function defaultSpawn(
+  argv: string[],
+  opts: { stdout: "pipe"; stderr: "pipe" },
+): PiDevSpawnResult {
+  const proc = Bun.spawn(argv, {
+    stdout: opts.stdout,
+    stderr: opts.stderr,
+  });
+  return {
+    stdout: proc.stdout as ReadableStream<Uint8Array>,
+    stderr: proc.stderr as ReadableStream<Uint8Array>,
+    exited: proc.exited,
+  };
+}
+
+/** Production binary resolution — `Bun.which`. */
+function defaultWhich(cmd: string): string | undefined {
+  return Bun.which(cmd) ?? undefined;
+}
+
+/**
+ * Build a `dispatch.task.failed` envelope with `reason.kind: "cant_do"`
+ * for any non-happy substrate outcome. Phase 1 collapses every failure
+ * to `cant_do` (see module docblock). Phase 2 splits substrate-transient
+ * from skill-permanent.
+ */
+function failed(
+  pipeline: ReviewPipelineOpts,
+  correlationId: string,
+  startedAt: Date,
+  errorSummary: string,
+): ReviewPipelineResult {
+  const source = pipeline.source as ReviewEventSource;
+  const envelope = createReviewTaskFailedEvent({
+    source,
+    taskId: crypto.randomUUID(),
+    agentId: pipeline.agentId,
+    correlationId,
+    startedAt,
+    failedAt: new Date(),
+    errorSummary,
+    reason: { kind: "cant_do", detail: errorSummary },
+  });
+  return { kind: "failed", envelope };
+}
+
+/**
+ * Build a `review.verdict.commented` envelope carrying sage's markdown
+ * stdout as `payload.summary`. Phase 1 hardcodes `verdict: "commented"`
+ * + `reviewer: "sage"`; Phase 2 derives both from sage's structured
+ * verdict block.
+ */
+function verdict(
+  pipeline: ReviewPipelineOpts,
+  correlationId: string,
+  stdout: string,
+): ReviewPipelineResult {
+  const payload = pipeline.payload as ReviewRequestPayload;
+  const source = pipeline.source as ReviewEventSource;
+  const envelope: Envelope = createReviewVerdictEvent({
+    source,
+    kind: "commented",
+    correlationId,
+    payload: {
+      repo: payload.repo,
+      pr: payload.pr,
+      // Phase 1 default — sage is the substrate doing the review.
+      // Phase 2 reads the reviewer agent identity from sage's
+      // structured verdict block.
+      reviewer: "sage",
+      verdict: "commented",
+      summary: stdout,
+      // Placeholder fields Phase 1 doesn't have access to without a
+      // structured verdict block. The verdict envelope schema requires
+      // these fields; we surface zeros / empty strings so pilot's
+      // subscriber still sees a well-formed envelope and operators can
+      // grep the markdown summary for the actual values. Phase 2
+      // populates these from sage's `--format json` block.
+      github_review_id: 0,
+      github_review_url: "",
+      submitted_at: new Date().toISOString(),
+      commit_id: "",
+      findings: { blockers: 0, majors: 0, nits: 0 },
+      inline_comments: 0,
+    },
+  });
+  // Surface the startedAt anchor in close range so a future refactor
+  // adding `dispatch.task.completed` emission here has the timestamp
+  // ready. (Review-consumer emits `started`/`completed` around the
+  // pipelineRunner call; this runner emits only the terminal verdict /
+  // failed envelope per `ReviewPipelineResult`'s contract.)
+  void pipeline;
+  void correlationId;
+  return { kind: "verdict", envelope };
+}

--- a/src/runner/substrate/pi-dev-runner.ts
+++ b/src/runner/substrate/pi-dev-runner.ts
@@ -1,6 +1,29 @@
 /**
  * cortex#331 Phase 1 — `pi-dev` substrate pipeline runner.
  *
+ * **Cross-repo scope split (sage#40 / sage#41 / cortex#331).** Sage's local
+ * ISA referred to "zero cortex changes" within the SAGE repo's Phase 1 —
+ * that scope is preserved: no cortex edits land in sage#41 (sage's
+ * in-process migration). cortex#331 is the separate, parallel issue that
+ * owns the cortex-side wiring; this file implements its Phase 1.
+ *
+ * **Architectural shift.** Sage went in-process (sage#41) — its standalone
+ * launchd daemon and standalone NATS subscribe path are retired. Cortex's
+ * review-consumer is now the sole receiver for sage-owned review flavors.
+ * That is the load-bearing change: sage stepped DOWN from owning its own
+ * bus subscription; cortex stepped UP to own substrate dispatch for
+ * in-process agents. This runner is the cortex-side adapter that closes
+ * the round-trip.
+ *
+ * **Topology after sage#41 + cortex#331 ship:**
+ *
+ *   pilot publishes `tasks.code-review.<flavor>` envelope
+ *     → cortex's `ReviewConsumer` for sage receives + verifies signature (cortex#330)
+ *     → this runner spawns `sage review <pr-ref> --substrate pi` subprocess
+ *     → captures sage stdout, builds `review.verdict.commented` envelope
+ *     → cortex publishes verdict back to bus
+ *     → pilot's `--wait` catches it
+ *
  * **What this module is.** A `ReviewPipelineRunner` factory that targets
  * sage's `pi-dev` substrate. Returns an async function with the same
  * signature `runReviewPipeline` exposes (see `src/runner/review-pipeline.ts`),
@@ -345,12 +368,5 @@ function verdict(
       inline_comments: 0,
     },
   });
-  // Surface the startedAt anchor in close range so a future refactor
-  // adding `dispatch.task.completed` emission here has the timestamp
-  // ready. (Review-consumer emits `started`/`completed` around the
-  // pipelineRunner call; this runner emits only the terminal verdict /
-  // failed envelope per `ReviewPipelineResult`'s contract.)
-  void pipeline;
-  void correlationId;
   return { kind: "verdict", envelope };
 }


### PR DESCRIPTION
## Summary

Phase 1 of cortex#331 — wires sage's `pi-dev` substrate into the per-agent ReviewConsumer boot loop. Purely additive: the existing claude-code path stays exactly as-is.

Closes #331 (Phase 1 scope).

## What changed

- **New module** `src/runner/substrate/pi-dev-runner.ts` exporting `makePiDevPipelineRunner(opts)`. Returns a `(opts: ReviewPipelineOpts) => Promise<ReviewPipelineResult>` factory that:
  - Spawns `sage review <owner>/<repo>#<n> --substrate pi` via `Bun.spawn` (async, not spawnSync)
  - Resolution order for the sage binary: `opts.sageBin` → `process.env.SAGE_BIN` → `Bun.which("sage")`
  - On exit 0: builds a `review.verdict.commented` envelope with `payload.summary = stdout`, `correlation_id = requestEnvelope.id`, `reviewer: "sage"`
  - On non-zero exit / spawn throw / missing binary: builds a `dispatch.task.failed` envelope with `reason.kind: "cant_do"` and stderr (or operator-actionable detail) in `reason.detail` — never throws, mirroring `runReviewPipeline`'s non-throwing contract

- **Boot wire** `src/cortex.ts:807` — per-agent ReviewConsumer construction now selects pipelineRunner based on `agent.runtime?.substrate`:
  - `"pi-dev"` → `pipelineRunner: makePiDevPipelineRunner({})` (resolves sage binary lazily on first review request, NOT at boot — boot never fails on missing sage)
  - everything else (including missing/undefined) → no `pipelineRunner` opt → falls through to `runReviewPipeline` + `ccSessionFactory`
  - `ccSessionFactory` stays wired everywhere — see issue's "out of scope" list

- **Boot log update** — `signed=on/off` line now also includes `substrate=<name>` (defaults to `claude-code` when unset). Operators grep `substrate=pi-dev` to confirm dispatch wiring.

- **Tests:**
  - `src/runner/substrate/__tests__/pi-dev-runner.test.ts` — 5 unit tests covering: happy path (exit 0 + stdout → verdict), failure path (exit != 0 + stderr → cant_do with stderr in detail), missing binary (which returns undefined → cant_do with operator hint, no spawn call), explicit `sageBin` resolution order, spawn-throw catch.
  - `src/__tests__/cortex.review-consumer.e2e.test.ts` — new describe block proving `makePiDevPipelineRunner` wires into a real `ReviewConsumer` and round-trips a `tasks.code-review.typescript` envelope to a `review.verdict.commented` with matching `correlation_id`.

## Out of scope (deferred to Phase 2)

- Structured JSON verdict parsing (Phase 1 hardcodes `verdict: "commented"`; the markdown summary preserves the actual sage verdict for now)
- Library import of `@the-metafactory/sage` (sage's `package.json` doesn't yet declare `exports`)
- Cedar's code-write substrate (separate issue)
- Removal of `ccSessionFactory` — stays wired for the claude-code fallthrough

## Test plan

- [x] `bunx tsc --noEmit` clean
- [x] `bun test` full suite: 3354 pass / 2 skip / 1 fail (the 1 fail is the pre-existing CCSession flake; baseline before this PR was 3348 pass / 2 skip / 1 fail — same flake)
- [x] New unit tests: 5/5 pass
- [x] E2E test extension: pi-dev round-trip passes alongside existing CC + signed cases
- [ ] Manual smoke (once sage is installed locally): boot cortex with a sage-flavored agent, confirm `cortex: review consumer ready for agent=sage flavors=[typescript] signed=off substrate=pi-dev` lands in the boot log

🤖 Generated with [Claude Code](https://claude.com/claude-code)