### PR TITLE
log(bus): distinguish DORMANT from ready review consumer (closes #334)

### DIFF
--- a/src/__tests__/cortex.review-consumer-boot.test.ts
+++ b/src/__tests__/cortex.review-consumer-boot.test.ts
@@ -445,4 +445,90 @@ describe("startCortex — review-consumer boot wiring (cortex#237 PR-6)", () => 
     await handle.stop();
     rmSync(tmpAgentsDir, { recursive: true, force: true });
   });
+
+  test("cortex#334 — dormant subscribePull → boot logs DORMANT, not ready", async () => {
+    // The disabled-runtime case: `MyelinRuntime.subscribePull` returns
+    // null when `cortex.yaml nats.subjects: []` (the default today)
+    // and the consumer stays dormant. Pre-#334 the boot path logged
+    // "review consumer ready" unconditionally, misleading operators
+    // into thinking the bus path was live. The fix branches the log
+    // line on `started.subscribed`.
+    //
+    // Test stands up a runtime whose `subscribePull` returns null
+    // synchronously — same shape as the production disabled path —
+    // and asserts the boot log carries DORMANT plus the actionable
+    // G-1111 hint, NOT the ready line.
+    const onEnvelopeHandlers = new Set<EnvelopeHandler>();
+    const published: Envelope[] = [];
+    const subscribePullCalls: MyelinSubscribePullOpts[] = [];
+    const dormantRuntime: RecordingRuntime = {
+      enabled: false,
+      onEnvelopeHandlers,
+      published,
+      subscribePullCalls,
+      onEnvelope(handler) {
+        onEnvelopeHandlers.add(handler);
+        return {
+          unregister: () => {
+            onEnvelopeHandlers.delete(handler);
+          },
+        };
+      },
+      publish: async (envelope: Envelope) => {
+        published.push(envelope);
+      },
+      subscribePull: (opts: MyelinSubscribePullOpts) => {
+        // Record the invocation so the test can still verify the boot
+        // path WOULD have subscribed if the runtime were live.
+        subscribePullCalls.push(opts);
+        // Mirror the production dormant path: hand null back. The
+        // `MyelinRuntime` interface widens `subscribePull` to
+        // `... => MyelinSubscriber | null` for exactly this case.
+        return null as unknown as MyelinSubscriber;
+      },
+      stop: async () => {},
+    };
+
+    const tmpAgentsDir = mkdtempSync(join(tmpdir(), "cortex-revboot-dormant-"));
+    const inlineAgents: Agent[] = [
+      makeAgent("sage", ["code-review.typescript"]),
+    ];
+
+    const { result: handle, logs } = await withCapturedConsoleLog(() =>
+      startCortex(minimalConfig(), {
+        disableConfigWatcher: true,
+        disableDashboard: true,
+        disableOutboundPoller: true,
+        agentsDir: tmpAgentsDir,
+        injectRuntime: dormantRuntime,
+        inlineAgents,
+      }),
+    );
+
+    const dormantLines = logs.filter((l) =>
+      l.includes("cortex: review consumer DORMANT"),
+    );
+    expect(dormantLines.length).toBe(1);
+    expect(dormantLines[0]!).toContain("agent=sage");
+    expect(dormantLines[0]!).toContain("flavors=[typescript]");
+    expect(dormantLines[0]!).toContain("G-1111 pending");
+    expect(dormantLines[0]!).toContain(
+      "tasks.code-review.* envelopes will not be claimed by this consumer",
+    );
+
+    // Anti-criterion: the misleading "ready" line MUST NOT appear for
+    // the dormant case. This is the regression guard.
+    const readyLines = logs.filter((l) =>
+      l.includes("cortex: review consumer ready"),
+    );
+    expect(readyLines.length).toBe(0);
+
+    // `subscribePull` was still invoked exactly once — the consumer
+    // attempted the subscription, the runtime declined. Logging
+    // changes don't alter the control flow.
+    expect(dormantRuntime.subscribePullCalls.length).toBe(1);
+
+    await handle.stop();
+    rmSync(tmpAgentsDir, { recursive: true, force: true });
+  });
 });

--- a/src/bus/review-consumer.ts
+++ b/src/bus/review-consumer.ts
@@ -261,10 +261,18 @@ export interface ReviewConsumerStartOpts {
  * Boot/log entries the consumer produces. Surfaced so the boot wiring in
  * `src/cortex.ts` can render a uniform `cortex: review consumer ready for
  * agent={id} flavors=[...]` line without re-deriving the data.
+ *
+ * `subscribed` distinguishes the two structurally-valid `start()` outcomes
+ * (cortex#334): `true` when the pull subscription actually opened on the
+ * NATS broker; `false` when `MyelinRuntime.subscribePull` returned null
+ * (disabled runtime / empty `nats.subjects` / G-1111 pending). The boot
+ * path uses this to log "ready" vs "DORMANT" honestly instead of always
+ * claiming readiness while the consumer is silently dormant.
  */
 export interface ReviewConsumerStartedInfo {
   agentId: string;
   flavors: readonly string[];
+  subscribed: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -388,13 +396,14 @@ export class ReviewConsumer {
       // subscribePull helper. Either way this is a structurally-valid
       // no-op for capability-side features — the consumer stays
       // dormant and shutdown drain works against the empty `inFlight`
-      // set. The boot path logs the disabled-runtime case once at
-      // startup; we don't double-log here.
-      return { agentId: this.agent.id, flavors: this.flavors };
+      // set. The boot path branches its log line on `subscribed: false`
+      // so operators see "DORMANT" instead of a misleading "ready"
+      // (cortex#334).
+      return { agentId: this.agent.id, flavors: this.flavors, subscribed: false };
     }
     this.subscriber = sub;
     await this.subscriber.ready;
-    return { agentId: this.agent.id, flavors: this.flavors };
+    return { agentId: this.agent.id, flavors: this.flavors, subscribed: true };
   }
 
   /**

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -851,11 +851,11 @@ export async function startCortex(
       reviewConsumers.push(consumer);
       // Subscribe via the runtime's subscribePull helper. When the
       // runtime is disabled the helper returns null inside start() and
-      // the consumer stays dormant — boot continues with the
-      // instantiation logged as ready (the disabled-runtime case is the
-      // typical state for cortex deployments that haven't wired NATS).
+      // the consumer stays dormant — `started.subscribed` distinguishes
+      // the two cases so the boot log can be honest (cortex#334)
+      // instead of unconditionally claiming "ready".
       const durable = `cortex-review-consumer-${reviewOperatorId}-${agent.id}`;
-      await consumer.start({
+      const started = await consumer.start({
         pattern: reviewSubjectPattern,
         stream: reviewStream,
         durable,
@@ -871,9 +871,20 @@ export async function startCortex(
       // to confirm sage agents (or any future substrate) actually
       // received the substrate-aware factory. Unset substrate defaults
       // to `claude-code` in the log (matches the runtime fallthrough).
-      console.log(
-        `cortex: review consumer ready for agent=${agent.id} flavors=[${flavorSummary}] signed=${signedTag} substrate=${substrate}`,
-      );
+      //
+      // cortex#334 — distinguish "ready" (subscription open) from
+      // "DORMANT" (subscribePull returned null; G-1111 pending or
+      // nats.subjects empty). The previous unconditional "ready" line
+      // misled operators into chasing phantom misconfigs.
+      if (started.subscribed) {
+        console.log(
+          `cortex: review consumer ready for agent=${agent.id} flavors=[${flavorSummary}] signed=${signedTag} substrate=${substrate}`,
+        );
+      } else {
+        console.log(
+          `cortex: review consumer DORMANT for agent=${agent.id} flavors=[${flavorSummary}] signed=${signedTag} substrate=${substrate} — cortex MyelinRuntime subscriptions disabled (G-1111 pending; tasks.code-review.* envelopes will not be claimed by this consumer)`,
+        );
+      }
     } catch (err) {
       // Per CLAUDE.md: log every error. A single agent's consumer crash
       // does NOT abort boot — siblings still get wired. Boot keeps the


### PR DESCRIPTION
## Summary

Closes #334. The boot log unconditionally claimed \`cortex: review consumer ready\` even when \`MyelinRuntime.subscribePull\` returned null and the consumer stayed dormant. With \`cortex.yaml nats.subjects: []\` (the documented default until G-1111 / #335), that's the state every shipping cortex install actually runs in. Operators read \"ready\" and chase phantom misconfigs.

Surface dormancy honestly.

## What changes

- \`ReviewConsumerStartedInfo\` gains \`subscribed: boolean\` — additive, source-compatible
- Boot wiring branches the log on \`started.subscribed\`:
  - **subscribed**: \`cortex: review consumer ready for agent=X flavors=[…] signed=Y substrate=Z\` (unchanged shape; log shippers grepping the existing prefix keep working)
  - **dormant**: \`cortex: review consumer DORMANT for agent=X flavors=[…] signed=Y substrate=Z — cortex MyelinRuntime subscriptions disabled (G-1111 pending; tasks.code-review.* envelopes will not be claimed by this consumer)\`

## Test

New test in \`cortex.review-consumer-boot.test.ts\`: dormant-runtime fixture asserts the DORMANT line + G-1111 hint appear AND the \`ready\` line does NOT. Anti-criterion regression guard.

## Test plan

- [x] \`bunx tsc --noEmit\` clean
- [x] \`bun test\`: 3356 pass / 0 fail / 2 skip (vs main 3355 → +1 new)
- [ ] CI green

## Related

- #335 — G-1111 subscription routing (the underlying gap; this is the diagnostic hygiene companion)
- sage#43 follow-up diagnosis where this log misled cross-agent sessions today

🤖 Generated with [Claude Code](https://claude.com/claude-code)