### PR TITLE
feat(bus): open NATS link in pull-only mode when subjects=[] (closes #337)

### DIFF
--- a/src/bus/myelin/__tests__/runtime.test.ts
+++ b/src/bus/myelin/__tests__/runtime.test.ts
@@ -166,28 +166,49 @@ describe("MyelinRuntime", () => {
     await runtime.stop();
   });
 
-  test("cortex#88 item 6: emits info (not warn) when nats.url set but subjects empty", async () => {
-    // The publish-only case (typical cortex deployment today). Returning
-    // `enabled: false` is preserved — only the log level changes — so
-    // callers gated on `runtime.enabled` continue to behave identically.
+  test("cortex#337 — connects + enables runtime when nats.url set even if subjects empty (pull-only mode)", async () => {
+    // Pre-#337 cortex.yaml's default `nats.subjects: []` returned a
+    // fully-disabled runtime, including a no-op `subscribePull` — so the
+    // bus dispatch path was structurally non-functional even on installs
+    // that DID configure NATS. With #337 the runtime treats empty
+    // `subjects` as "pull-only / publish-only mode": open the link, skip
+    // push-mode subscribers, expose a live `subscribePull` and `publish`.
+    const fake = makeFakeNatsConnection();
     const config = makeConfig({
       url: "nats://localhost:4222",
       name: "grove-bot",
       subjects: [],
     });
-    const runtime = await startMyelinRuntime(config);
-    expect(runtime.enabled).toBe(false);
+    const runtime = await startMyelinRuntime(config, {
+      connectImpl: async () => fake.nc,
+    });
+    // Runtime is now ENABLED (the inverted invariant of the pre-#337
+    // test). Callers gated on `runtime.enabled` to skip publish should
+    // now see publish flow through.
+    expect(runtime.enabled).toBe(true);
+    // No push-mode subscribers started — the empty subjects list means
+    // nothing to subscribe to broadly.
+    expect(fake.subscribePatterns).toEqual([]);
+    // The info log shape is preserved for log shippers that already
+    // grep on the "no push subscribers" signal, but the wording is
+    // updated to say "pull-only mode" so operators no longer read it
+    // as "everything is disabled".
+    const informed = logs.some(
+      (l) => l.kind === "info" && l.msg.includes("pull-only mode"),
+    );
+    expect(informed).toBe(true);
     const warned = logs.some(
       (l) => l.kind === "warn" && l.msg.includes("subjects"),
     );
     expect(warned).toBe(false);
-    const informed = logs.some(
-      (l) =>
-        l.kind === "info" &&
-        l.msg.includes("nats.subjects empty") &&
-        l.msg.includes("no subscriptions started"),
-    );
-    expect(informed).toBe(true);
+
+    // Anti-criterion: subscribePull MUST be a real wired helper now
+    // (not the subscribePullDisabled no-op). The exact return value is
+    // a MyelinSubscriber stub when the fake NATS connection accepts
+    // the pull bind; the shape contract is "non-null helper present".
+    expect(typeof runtime.subscribePull).toBe("function");
+
+    await runtime.stop();
   });
 
   test("returns disabled when NATS connect fails (logs error, doesn't throw)", async () => {

--- a/src/bus/myelin/runtime.ts
+++ b/src/bus/myelin/runtime.ts
@@ -349,27 +349,21 @@ export async function startMyelinRuntime(
   });
   const subjects = substituter(nats.subjects);
 
-  if (subjects.length === 0) {
-    // cortex#88 item 6: empty `subjects` is the typical state today —
-    // cortex publishes envelopes but doesn't subscribe (subscription
-    // routing is G-1111+ territory). Demoted from `console.warn` to
-    // `console.info`: the prior wording ("no subscriptions started")
-    // misled every operator into chasing a phantom misconfiguration on
-    // every boot. The runtime IS still considered disabled here because
-    // `publish` from this branch requires the same connect-and-subscribe
-    // path the populated case takes — keeping the early-return preserves
-    // the existing publish-disabled contract until G-1111 wires the
-    // publish-only mode end-to-end.
+  // cortex#337 — empty `nats.subjects` is the documented default
+  // today. Pre-#337 this branch returned a fully-disabled runtime
+  // (publish: publishDisabled, subscribePull: subscribePullDisabled),
+  // which left capability-side consumers (ReviewConsumer) structurally
+  // dormant even when NATS was configured. The runtime now opens the
+  // link unconditionally (any url-configured case → live link), skips
+  // push-mode subscribers when `subjects` is empty, and exposes a real
+  // `publish` + `subscribePull`. Pull-mode capability consumers can
+  // wire themselves; push-mode broad-pattern subscribers stay absent
+  // by design.
+  const pushSubscribersConfigured = subjects.length > 0;
+  if (!pushSubscribersConfigured) {
     console.info(
-      "myelin-runtime: nats.url configured, nats.subjects empty — no subscriptions started (this is normal for current cortex deployments; subscription routing lands in G-1111)",
+      "myelin-runtime: nats.url configured, nats.subjects empty — entering pull-only mode (capability consumers may subscribe via subscribePull; no push-mode broad-pattern subscribers will start)",
     );
-    return {
-      enabled: false,
-      onEnvelope,
-      publish: publishDisabled,
-      subscribePull: subscribePullDisabled,
-      stop: stopDisabled,
-    };
   }
 
   let link: NatsLink;
@@ -435,9 +429,15 @@ export async function startMyelinRuntime(
     }
   }
 
-  if (subscribers.length === 0) {
-    // Nothing actually subscribed — close the link so we don't hold a
-    // socket open for nothing.
+  // cortex#337 — pre-#337 a non-empty `subjects[]` that ALL failed to
+  // subscribe collapsed back to the disabled path. Preserve that
+  // safety net: when push-mode subscribers were configured but none
+  // came up, the link is closed and the runtime returns disabled —
+  // there is no operator intent for a pull-only path here, just a
+  // broken subscribe. Pull-only mode (empty subjects → enabled link)
+  // is the new path; failed push subscribers are still treated as a
+  // boot failure for that configuration shape.
+  if (pushSubscribersConfigured && subscribers.length === 0) {
     await link.close().catch(() => {
       // best-effort close on no-subscribers path; ignore errors
     });


### PR DESCRIPTION
## Summary

Closes #337 (G-1111a). Foundation step of the #335 umbrella.

Pre-#337 \`MyelinRuntime\` early-returned a fully-disabled runtime when \`nats.subjects: []\`. With \`subjects: []\` as the documented default, every shipping cortex install had \`publish: publishDisabled\` + \`subscribePull: subscribePullDisabled\` + \`enabled: false\` — the bus dispatch path was structurally non-functional. Sage dispatches and pilot \`request-review\` hung silently.

## What changes

- Empty \`subjects\` no longer short-circuits to disabled when \`nats.url\` is set
- Runtime connects, exposes real \`publish\` + \`subscribePull\`, emits \`enabled: true\`
- Push-mode broad-pattern subscribers stay absent by design (operator opt-in via \`subjects\`)
- Log updated: \"entering pull-only mode\" (was \"no subscriptions started\")
- Safety net preserved: push-subscribers-all-failed → close link + return disabled (genuine boot failure path, distinct from new pull-only-by-design case)

## TDD

Test written first (red), implementation followed (green):

\`\`\`
- 1 fail  ← initial state after test added
- 0 fail  ← after runtime.ts patch
\`\`\`

Updated assertion on \`cortex#88 item 6\` test:
- \`expect(runtime.enabled).toBe(false)\` → \`expect(runtime.enabled).toBe(true)\`
- Added: \`expect(fake.subscribePatterns).toEqual([])\` (anti-criterion: no push subscribers started)
- Added: \`expect(typeof runtime.subscribePull).toBe(\"function\")\` (real helper present)

Disabled-runtime tests for \`nats.url\` ABSENT keep their \`enabled: false\` assertions — that path is unchanged.

## Test plan

- [x] \`bunx tsc --noEmit\` clean
- [x] \`bun test\` — 3356 pass / 0 fail / 2 skip across 1555 files
- [ ] CI green

## Part of

- #335 umbrella
- #338 land next (provision CODE_REVIEW stream) — without it the new \`subscribePull\` will fail to bind at JetStream because the stream doesn't exist
- #339 round-trip integration test (proves #337 + #338 together)
- #340 verdict/lifecycle emit audit
- #341 docs (closes #335)

🤖 Generated with [Claude Code](https://claude.com/claude-code)