### PR TITLE
test(bus): pin publish-routing audit across verdict variants (closes #340)

### DIFF
--- a/src/bus/__tests__/review-consumer.test.ts
+++ b/src/bus/__tests__/review-consumer.test.ts
@@ -641,6 +641,57 @@ describe("ReviewConsumer.processEnvelope — cortex#237 PR-6", () => {
     expect(d3).toEqual({ kind: "ack" });
   });
 
+  // cortex#340 — publish-routing audit. Pins the contract that EVERY
+  // verdict variant emits exactly three envelopes via runtime.publish in
+  // the same order: started → review.verdict.<variant> → completed. The
+  // existing tests cover `approved` directly (test 1) and `commented`
+  // indirectly via the redelivery path (test 7); this parametric test
+  // adds `changes-requested` and locks the invariant across all three so
+  // a future change that bypasses safePublish for one verdict variant
+  // can't slip through unnoticed.
+  for (const variant of ["approved", "changes-requested", "commented"] as const) {
+    test(`cortex#340 — verdict=${variant} publishes exactly 3 envelopes via runtime.publish`, async () => {
+      const runtime = createRecordingRuntime();
+      const request = makeRequest("typescript");
+      const verdict = buildVerdictEnvelope(request, variant);
+
+      const consumer = new ReviewConsumer(
+        baseOpts({
+          runtime,
+          pipelineRunner: fixedPipeline(() => ({ kind: "verdict", envelope: verdict })),
+        }),
+      );
+
+      const decision = await consumer.processEnvelope(
+        request,
+        "local.metafactory.tasks.code-review.typescript",
+        null,
+      );
+
+      expect(decision).toEqual({ kind: "ack" });
+
+      // Exactly three envelopes — anti-criterion: any silent additional
+      // emit would either bypass runtime.publish (won't be captured)
+      // or land here as an unexpected fourth entry.
+      expect(runtime.published.length).toBe(3);
+      expect(runtime.published[0]!.type).toBe("dispatch.task.started");
+      expect(runtime.published[1]!.type).toBe(`review.verdict.${variant}`);
+      expect(runtime.published[2]!.type).toBe("dispatch.task.completed");
+
+      // The verdict envelope is the EXACT one the pipeline returned —
+      // not a copy, not a re-built envelope. Catches a regression that
+      // rebuilds the verdict on the way out (which would silently drop
+      // the pipeline's correlation_id / signed_by chain).
+      expect(runtime.published[1]!).toBe(verdict);
+
+      // Correlation id flows onto every lifecycle envelope so pilot's
+      // wait can filter consistently across the three.
+      for (const env of runtime.published) {
+        expect(env.correlation_id).toBe(request.id);
+      }
+    });
+  }
+
   test("10. compliance_block variant → term with documented v1 message", async () => {
     const runtime = createRecordingRuntime();
     const request = makeRequest("typescript");

--- a/src/bus/review-consumer.ts
+++ b/src/bus/review-consumer.ts
@@ -761,6 +761,16 @@ export class ReviewConsumer {
    * own builders should already satisfy this; the assertion catches
    * regressions early rather than producing orphan envelopes pilot
    * silently fails to filter.
+   *
+   * **SINGLE PUBLISH PATH (cortex#340).** Every lifecycle + verdict
+   * envelope ReviewConsumer emits routes through this method —
+   * `runtime.publish` is the only legitimate exit. Adding a direct
+   * `link.publish` or `nc.publish` call would bypass the error trap
+   * AND the recording-runtime test fixture, both of which we rely on
+   * for the publish-routing audit covered by parametric tests in
+   * `__tests__/review-consumer.test.ts`. If a future feature needs a
+   * publish from inside this class, extend `safePublish` rather than
+   * introducing a sibling path.
    */
   private async safePublish(
     envelope: Envelope,


### PR DESCRIPTION
## Summary

Closes #340 (G-1111d audit). Verification-only PR — confirms every lifecycle + verdict emit site already routes through \`safePublish\` → \`runtime.publish\` (no bypass).

## Audit

Grep + manual walk of \`src/bus/review-consumer.ts\` and \`src/runner/review-pipeline.ts\`:

- 6 emit sites in ReviewConsumer (lines 437, 559, 703-704, 721, 750) — all call \`this.safePublish\`
- \`safePublish\` is the single path; it calls \`this.runtime.publish\`
- No \`link.publish\` / \`nc.publish\` calls in review-consumer.ts or review-pipeline.ts

Audit conclusion: wiring is correct. Two gaps closed in this PR for regression-guard hygiene.

## What changes

**1. Parametric tests** for all three verdict variants (\`approved\`, \`changes-requested\`, \`commented\`):

- \`approved\` had direct coverage (test 1)
- \`commented\` had indirect coverage via redelivery (test 7)
- \`changes-requested\` had no publish-chain coverage — closed here

Each asserts:
- Exactly 3 envelopes published via \`runtime.published\`
- Order: \`dispatch.task.started\` → \`review.verdict.<variant>\` → \`dispatch.task.completed\`
- Verdict envelope on the wire is the SAME instance the pipeline returned
- correlation_id flows to all three

**2. Doc-comment audit anchor** on \`safePublish\` — pins the contract inline so future developers see the constraint before reaching for direct \`link.publish\` calls.

## Test plan

- [x] \`bunx tsc --noEmit\` clean
- [x] \`bun test src/bus/__tests__/review-consumer.test.ts\`: 21 pass / 0 fail (was 18 → +3 new)
- [x] Full suite: 3358 pass / 0 fail / 2 skip across 1555 files
- [ ] CI green

## Part of

- #335 umbrella (G-1111)
- Follows #342 (#337 G-1111a — opened NATS link in pull-only mode)
- Independent of #338 (G-1111b stream provisioning) — verifiable in isolation

🤖 Generated with [Claude Code](https://claude.com/claude-code)