### PR TITLE
feat(bus): provision CODE_REVIEW stream + per-agent durables (closes #338)

### DIFF
--- a/src/__tests__/cortex.review-consumer-boot.test.ts
+++ b/src/__tests__/cortex.review-consumer-boot.test.ts
@@ -531,4 +531,90 @@ describe("startCortex — review-consumer boot wiring (cortex#237 PR-6)", () => 
     await handle.stop();
     rmSync(tmpAgentsDir, { recursive: true, force: true });
   });
+
+  test("cortex#338 — jetstreamManager() throw is contained, boot completes, stderr explains", async () => {
+    // sage review on #338 round 2 (CodeQuality, important): the
+    // `await runtime.jetstreamManager()` call itself can throw (e.g.
+    // a transient JS request failure mid-boot); pre-fix that propagated
+    // out of startCortex and aborted boot, even though the downstream
+    // `provisionReviewStream` / `provisionReviewConsumer` calls were
+    // already wrapped in try/catch. The fix wraps the await inside
+    // `resolveReviewProvisioningJsm` so the resolution failure is
+    // contained — boot continues with provisioning skipped, and
+    // operator-actionable stderr explains.
+    //
+    // Test stands up a runtime whose `jetstreamManager()` rejects, and
+    // asserts: (a) startCortex completes (no thrown error), (b) the
+    // expected stderr line appears, (c) the review consumer is still
+    // wired (boot didn't bail out before that step).
+    const onEnvelopeHandlers = new Set<EnvelopeHandler>();
+    const published: Envelope[] = [];
+    const subscribePullCalls: MyelinSubscribePullOpts[] = [];
+    const throwingRuntime: RecordingRuntime = {
+      enabled: true,
+      onEnvelopeHandlers,
+      published,
+      subscribePullCalls,
+      onEnvelope(handler) {
+        onEnvelopeHandlers.add(handler);
+        return {
+          unregister: () => {
+            onEnvelopeHandlers.delete(handler);
+          },
+        };
+      },
+      publish: async (envelope: Envelope) => {
+        published.push(envelope);
+      },
+      subscribePull: (opts: MyelinSubscribePullOpts): MyelinSubscriber => {
+        subscribePullCalls.push(opts);
+        return {
+          pattern: opts.pattern,
+          ready: Promise.resolve(),
+          stop: async () => {},
+        } as unknown as MyelinSubscriber;
+      },
+      jetstreamManager: async () => {
+        throw new Error("simulated JSM round-trip failure");
+      },
+      stop: async () => {},
+    };
+
+    const tmpAgentsDir = mkdtempSync(join(tmpdir(), "cortex-revboot-jsmthrow-"));
+    const inlineAgents: Agent[] = [
+      makeAgent("sage", ["code-review.typescript"]),
+    ];
+
+    let booted = false;
+    const { result: bootResult, stderr } = await withCapturedStderr(() =>
+      withCapturedConsoleLog(async () => {
+        const h = await startCortex(minimalConfig(), {
+          disableConfigWatcher: true,
+          disableDashboard: true,
+          disableOutboundPoller: true,
+          agentsDir: tmpAgentsDir,
+          injectRuntime: throwingRuntime,
+          inlineAgents,
+        });
+        booted = true;
+        return h;
+      }),
+    );
+
+    // (a) boot completed despite the JSM throw
+    expect(booted).toBe(true);
+    expect(bootResult.result).toBeDefined();
+
+    // (b) actionable stderr line surfaced
+    expect(stderr).toContain("jetstreamManager() resolution failed");
+    expect(stderr).toContain("review provisioning skipped");
+
+    // (c) the review consumer was still wired downstream — boot didn't
+    // bail before that step. `subscribePullCalls` is the witness; one
+    // call = one consumer attempted to subscribe.
+    expect(throwingRuntime.subscribePullCalls.length).toBe(1);
+
+    await bootResult.result.stop();
+    rmSync(tmpAgentsDir, { recursive: true, force: true });
+  });
 });

--- a/src/bus/jetstream/__tests__/provision.test.ts
+++ b/src/bus/jetstream/__tests__/provision.test.ts
@@ -146,6 +146,19 @@ describe("describeStreamDrift", () => {
     ).toBeNull();
   });
 
+  test("null when subjects match as a set (order doesn't matter)", () => {
+    // JetStream stream subjects are semantically a set — order is
+    // implementation-detail on the wire. A live config that returns
+    // the same set in a different order MUST NOT false-warn.
+    expect(
+      describeStreamDrift(
+        streamInfo(["b.>", "a.>"], 24 * 3600 * 1e9),
+        ["a.>", "b.>"],
+        24 * 3600 * 1e9,
+      ),
+    ).toBeNull();
+  });
+
   test("non-null when subjects differ", () => {
     expect(
       describeStreamDrift(

--- a/src/bus/jetstream/__tests__/provision.test.ts
+++ b/src/bus/jetstream/__tests__/provision.test.ts
@@ -1,0 +1,350 @@
+/**
+ * cortex#338 (G-1111b) — provisioning helpers tests.
+ *
+ * The provisioning helpers wrap a narrow `ProvisionJsm` surface — tests
+ * pass a recording stub so the idempotency, drift-detection, and
+ * not-found-recovery contracts are pinned without standing up a real
+ * JetStream broker. The full round-trip against a real broker is
+ * #339's concern; this file owns the per-call shape.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  describeStreamDrift,
+  isNotFoundError,
+  provisionReviewConsumer,
+  provisionReviewStream,
+  type ProvisionJsm,
+} from "../provision";
+import type { ConsumerInfo, StreamInfo } from "nats";
+
+// ---------------------------------------------------------------------------
+// Test stubs
+// ---------------------------------------------------------------------------
+
+interface RecorderState {
+  streamInfoCalls: string[];
+  streamAddCalls: Partial<StreamInfo["config"]>[];
+  consumerInfoCalls: { stream: string; durable: string }[];
+  consumerAddCalls: { stream: string; cfg: Record<string, unknown> }[];
+}
+
+function makeJsm(opts: {
+  existingStream?: StreamInfo | "not-found";
+  existingConsumer?: ConsumerInfo | "not-found";
+}): { jsm: ProvisionJsm; state: RecorderState } {
+  const state: RecorderState = {
+    streamInfoCalls: [],
+    streamAddCalls: [],
+    consumerInfoCalls: [],
+    consumerAddCalls: [],
+  };
+  const jsm: ProvisionJsm = {
+    streams: {
+      info: async (name) => {
+        state.streamInfoCalls.push(name);
+        if (opts.existingStream === "not-found" || opts.existingStream === undefined) {
+          // Mirror nats.js's 404 shape so isNotFoundError catches it.
+          const err = new Error("stream not found");
+          (err as unknown as { api_error: { err_code: number } }).api_error = {
+            err_code: 10059,
+          };
+          throw err;
+        }
+        return opts.existingStream;
+      },
+      add: async (cfg) => {
+        state.streamAddCalls.push(cfg as Partial<StreamInfo["config"]>);
+        return { config: cfg } as unknown as StreamInfo;
+      },
+    },
+    consumers: {
+      info: async (stream, durable) => {
+        state.consumerInfoCalls.push({ stream, durable });
+        if (opts.existingConsumer === "not-found" || opts.existingConsumer === undefined) {
+          const err = new Error("consumer not found");
+          (err as unknown as { api_error: { err_code: number } }).api_error = {
+            err_code: 10014,
+          };
+          throw err;
+        }
+        return opts.existingConsumer;
+      },
+      add: async (stream, cfg) => {
+        state.consumerAddCalls.push({ stream, cfg: cfg as Record<string, unknown> });
+        return { name: cfg.durable_name } as unknown as ConsumerInfo;
+      },
+    },
+  };
+  return { jsm, state };
+}
+
+function silentLog() {
+  return { info: (_: string) => {}, warn: (_: string) => {} };
+}
+
+// ---------------------------------------------------------------------------
+// isNotFoundError
+// ---------------------------------------------------------------------------
+
+describe("isNotFoundError", () => {
+  test("recognises nats.js api_error.err_code 10059 (stream not found)", () => {
+    expect(
+      isNotFoundError({
+        api_error: { err_code: 10059 },
+        message: "stream not found",
+      }),
+    ).toBe(true);
+  });
+
+  test("recognises nats.js api_error.err_code 10014 (consumer not found)", () => {
+    expect(
+      isNotFoundError({
+        api_error: { err_code: 10014 },
+        message: "consumer not found",
+      }),
+    ).toBe(true);
+  });
+
+  test("recognises message-string fallback `not found`", () => {
+    expect(isNotFoundError(new Error("stream foo not found"))).toBe(true);
+  });
+
+  test("does NOT match transient errors that should propagate", () => {
+    expect(isNotFoundError(new Error("connection refused"))).toBe(false);
+    expect(isNotFoundError(new Error("auth failed"))).toBe(false);
+  });
+
+  test("returns false on non-error values (defensive)", () => {
+    expect(isNotFoundError(null)).toBe(false);
+    expect(isNotFoundError(undefined)).toBe(false);
+    expect(isNotFoundError("string")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// describeStreamDrift
+// ---------------------------------------------------------------------------
+
+describe("describeStreamDrift", () => {
+  function streamInfo(subjects: string[], maxAgeNs: number): StreamInfo {
+    return {
+      config: {
+        subjects,
+        max_age: maxAgeNs,
+      },
+    } as unknown as StreamInfo;
+  }
+
+  test("null when subjects and max_age match", () => {
+    expect(
+      describeStreamDrift(
+        streamInfo(["a.b.>"], 24 * 3600 * 1e9),
+        ["a.b.>"],
+        24 * 3600 * 1e9,
+      ),
+    ).toBeNull();
+  });
+
+  test("non-null when subjects differ", () => {
+    expect(
+      describeStreamDrift(
+        streamInfo(["a.>"], 24 * 3600 * 1e9),
+        ["b.>"],
+        24 * 3600 * 1e9,
+      ),
+    ).toContain("subjects differ");
+  });
+
+  test("non-null when max_age drifts beyond 1s slack", () => {
+    expect(
+      describeStreamDrift(
+        streamInfo(["a.>"], 24 * 3600 * 1e9),
+        ["a.>"],
+        12 * 3600 * 1e9, // half — drift far exceeds 1s slack
+      ),
+    ).toContain("max_age differs");
+  });
+
+  test("null when max_age drift is within 1s slack (wire-JSON rounding)", () => {
+    // 500ms drift — should NOT trigger a warning, otherwise every
+    // boot would warn on the same config.
+    expect(
+      describeStreamDrift(
+        streamInfo(["a.>"], 24 * 3600 * 1e9 + 5e8),
+        ["a.>"],
+        24 * 3600 * 1e9,
+      ),
+    ).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// provisionReviewStream
+// ---------------------------------------------------------------------------
+
+describe("provisionReviewStream", () => {
+  test("creates the stream when absent (returns 'created')", async () => {
+    const { jsm, state } = makeJsm({ existingStream: "not-found" });
+    const outcome = await provisionReviewStream({
+      jsm,
+      name: "CODE_REVIEW",
+      subjects: ["local.jc.default.tasks.code-review.>"],
+      log: silentLog(),
+    });
+    expect(outcome).toBe("created");
+    expect(state.streamInfoCalls).toEqual(["CODE_REVIEW"]);
+    expect(state.streamAddCalls.length).toBe(1);
+    const cfg = state.streamAddCalls[0]!;
+    expect(cfg.name).toBe("CODE_REVIEW");
+    expect(cfg.subjects).toEqual(["local.jc.default.tasks.code-review.>"]);
+    expect(String(cfg.retention)).toBe("workqueue");
+    expect(String(cfg.storage)).toBe("file");
+    expect(cfg.max_age).toBe(24 * 3600 * 1e9);
+  });
+
+  test("idempotent — exists path returns 'exists' without calling add", async () => {
+    const existing = {
+      config: {
+        name: "CODE_REVIEW",
+        subjects: ["local.jc.default.tasks.code-review.>"],
+        max_age: 24 * 3600 * 1e9,
+      },
+    } as unknown as StreamInfo;
+    const { jsm, state } = makeJsm({ existingStream: existing });
+    const outcome = await provisionReviewStream({
+      jsm,
+      name: "CODE_REVIEW",
+      subjects: ["local.jc.default.tasks.code-review.>"],
+      log: silentLog(),
+    });
+    expect(outcome).toBe("exists");
+    expect(state.streamAddCalls.length).toBe(0);
+  });
+
+  test("config drift warns + leaves alone (v1 no-auto-update policy)", async () => {
+    const existing = {
+      config: {
+        name: "CODE_REVIEW",
+        subjects: ["local.OLD.default.tasks.code-review.>"], // diverged
+        max_age: 24 * 3600 * 1e9,
+      },
+    } as unknown as StreamInfo;
+    const warns: string[] = [];
+    const { jsm, state } = makeJsm({ existingStream: existing });
+    const outcome = await provisionReviewStream({
+      jsm,
+      name: "CODE_REVIEW",
+      subjects: ["local.jc.default.tasks.code-review.>"],
+      log: {
+        info: () => {},
+        warn: (msg) => {
+          warns.push(msg);
+        },
+      },
+    });
+    expect(outcome).toBe("config-drift-warning");
+    expect(state.streamAddCalls.length).toBe(0);
+    expect(warns.length).toBe(1);
+    expect(warns[0]).toContain("config drifts");
+    expect(warns[0]).toContain("nats stream edit"); // actionable hint
+  });
+
+  test("propagates non-404 errors (auth / network)", async () => {
+    const { jsm } = makeJsm({});
+    jsm.streams.info = async () => {
+      throw new Error("auth required");
+    };
+    await expect(
+      provisionReviewStream({
+        jsm,
+        name: "CODE_REVIEW",
+        subjects: ["x.>"],
+        log: silentLog(),
+      }),
+    ).rejects.toThrow(/auth required/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// provisionReviewConsumer
+// ---------------------------------------------------------------------------
+
+describe("provisionReviewConsumer", () => {
+  test("creates the durable when absent (returns 'created')", async () => {
+    const { jsm, state } = makeJsm({ existingConsumer: "not-found" });
+    const outcome = await provisionReviewConsumer({
+      jsm,
+      stream: "CODE_REVIEW",
+      durable: "cortex-review-consumer-jc-sage",
+      log: silentLog(),
+    });
+    expect(outcome).toBe("created");
+    expect(state.consumerInfoCalls).toEqual([
+      { stream: "CODE_REVIEW", durable: "cortex-review-consumer-jc-sage" },
+    ]);
+    expect(state.consumerAddCalls.length).toBe(1);
+    const cfg = state.consumerAddCalls[0]!.cfg;
+    expect(cfg.durable_name).toBe("cortex-review-consumer-jc-sage");
+    expect(cfg.ack_policy).toBe("explicit");
+    expect(cfg.deliver_policy).toBe("all");
+    expect(cfg.max_deliver).toBe(5);
+    // No filter subject when not requested.
+    expect("filter_subject" in cfg).toBe(false);
+  });
+
+  test("idempotent — exists path returns 'exists' without calling add", async () => {
+    const existing = { name: "cortex-review-consumer-jc-sage" } as unknown as ConsumerInfo;
+    const { jsm, state } = makeJsm({ existingConsumer: existing });
+    const outcome = await provisionReviewConsumer({
+      jsm,
+      stream: "CODE_REVIEW",
+      durable: "cortex-review-consumer-jc-sage",
+      log: silentLog(),
+    });
+    expect(outcome).toBe("exists");
+    expect(state.consumerAddCalls.length).toBe(0);
+  });
+
+  test("filter_subject is set when supplied", async () => {
+    const { jsm, state } = makeJsm({ existingConsumer: "not-found" });
+    await provisionReviewConsumer({
+      jsm,
+      stream: "CODE_REVIEW",
+      durable: "cortex-review-consumer-jc-sage",
+      filterSubject: "local.jc.default.tasks.code-review.typescript",
+      log: silentLog(),
+    });
+    const cfg = state.consumerAddCalls[0]!.cfg;
+    expect(cfg.filter_subject).toBe(
+      "local.jc.default.tasks.code-review.typescript",
+    );
+  });
+
+  test("maxDeliver override is honored", async () => {
+    const { jsm, state } = makeJsm({ existingConsumer: "not-found" });
+    await provisionReviewConsumer({
+      jsm,
+      stream: "CODE_REVIEW",
+      durable: "x",
+      maxDeliver: 10,
+      log: silentLog(),
+    });
+    expect(state.consumerAddCalls[0]!.cfg.max_deliver).toBe(10);
+  });
+
+  test("propagates non-404 errors", async () => {
+    const { jsm } = makeJsm({});
+    jsm.consumers.info = async () => {
+      throw new Error("network down");
+    };
+    await expect(
+      provisionReviewConsumer({
+        jsm,
+        stream: "CODE_REVIEW",
+        durable: "x",
+        log: silentLog(),
+      }),
+    ).rejects.toThrow(/network down/);
+  });
+});

--- a/src/bus/jetstream/__tests__/provision.test.ts
+++ b/src/bus/jetstream/__tests__/provision.test.ts
@@ -198,7 +198,7 @@ describe("provisionReviewStream", () => {
     const cfg = state.streamAddCalls[0]!;
     expect(cfg.name).toBe("CODE_REVIEW");
     expect(cfg.subjects).toEqual(["local.jc.default.tasks.code-review.>"]);
-    expect(String(cfg.retention)).toBe("workqueue");
+    expect(String(cfg.retention)).toBe("interest");
     expect(String(cfg.storage)).toBe("file");
     expect(cfg.max_age).toBe(24 * 3600 * 1e9);
   });

--- a/src/bus/jetstream/provision.ts
+++ b/src/bus/jetstream/provision.ts
@@ -139,7 +139,20 @@ export async function provisionReviewStream(
   await opts.jsm.streams.add({
     name: opts.name,
     subjects: [...opts.subjects],
-    retention: RetentionPolicy.Workqueue,
+    // `Interest` retention (not Workqueue): JetStream keeps a message
+    // only while at least one consumer has unacked interest in it.
+    // Workqueue would block the per-agent-durable model — each new
+    // unfiltered durable on the same subject space conflicts with the
+    // first under Workqueue semantics. Interest lets sage / fern /
+    // future reviewers each maintain their own durable on the same
+    // stream without provisioning collisions. Competing-consumer
+    // semantics (one of N agents claims a given task) are layered at
+    // the consumer level by sharing a durable name; cortex#237's
+    // current per-agent durable model is fan-out per agent, which is
+    // the intended shape for sage#43 + fern routing (each agent sees
+    // every task it claims a capability for, then the routing layer
+    // decides via the cortex.yaml `provided_by` table).
+    retention: RetentionPolicy.Interest,
     storage: StorageType.File,
     max_age: maxAgeNs,
     max_msgs: -1,
@@ -147,7 +160,7 @@ export async function provisionReviewStream(
     num_replicas: 1,
   });
   log.info(
-    `jetstream-provision: created stream "${opts.name}" (subjects=[${opts.subjects.join(", ")}], retention=workqueue, max_age=${Math.round(maxAgeNs / 1_000_000_000)}s)`,
+    `jetstream-provision: created stream "${opts.name}" (subjects=[${opts.subjects.join(", ")}], retention=interest, max_age=${Math.round(maxAgeNs / 1_000_000_000)}s)`,
   );
   return "created";
 }

--- a/src/bus/jetstream/provision.ts
+++ b/src/bus/jetstream/provision.ts
@@ -49,7 +49,32 @@ import type { ConsumerConfig, StreamInfo } from "nats";
 export type { ProvisionJsm } from "./types";
 import type { ProvisionJsm } from "./types";
 
-export type ProvisionOutcome = "created" | "exists" | "config-drift-warning";
+/**
+ * Outcome of `provisionReviewStream`. Includes `config-drift-warning`
+ * for the case where the live stream exists but its config differs
+ * from what we'd create — see `describeStreamDrift`. Consumer
+ * provisioning has no analogous drift surface in v1, so its outcome
+ * is the narrower `ProvisionConsumerOutcome`.
+ */
+export type ProvisionStreamOutcome = "created" | "exists" | "config-drift-warning";
+
+/**
+ * Outcome of `provisionReviewConsumer`. Narrower than the stream
+ * outcome by design — v1 doesn't drift-check consumer configs (the
+ * surface is small enough that operators rarely tune it; the
+ * subtler-than-stream drift modes are best surfaced when an operator
+ * hits one).
+ */
+export type ProvisionConsumerOutcome = "created" | "exists";
+
+/**
+ * @deprecated Use `ProvisionStreamOutcome` or `ProvisionConsumerOutcome`
+ * — the union here is wider than either helper actually returns and
+ * forces callers to handle impossible cases (sage review on #338
+ * round 4 — Maintainability). Kept as a transitional alias; remove
+ * once no internal callers reference it.
+ */
+export type ProvisionOutcome = ProvisionStreamOutcome;
 
 export interface ProvisionStreamOpts {
   jsm: ProvisionJsm;
@@ -100,7 +125,7 @@ const DEFAULT_MAX_DELIVER = 5;
  */
 export async function provisionReviewStream(
   opts: ProvisionStreamOpts,
-): Promise<ProvisionOutcome> {
+): Promise<ProvisionStreamOutcome> {
   const log = opts.log ?? console;
   const maxAgeNs = opts.maxAgeNs ?? DEFAULT_MAX_AGE_NS;
 
@@ -163,7 +188,7 @@ export async function provisionReviewStream(
  */
 export async function provisionReviewConsumer(
   opts: ProvisionConsumerOpts,
-): Promise<ProvisionOutcome> {
+): Promise<ProvisionConsumerOutcome> {
   const log = opts.log ?? console;
   const maxDeliver = opts.maxDeliver ?? DEFAULT_MAX_DELIVER;
 

--- a/src/bus/jetstream/provision.ts
+++ b/src/bus/jetstream/provision.ts
@@ -39,23 +39,15 @@
 // values keeps the wire-config strings centralised in nats.js rather
 // than duplicating literals here.
 import { AckPolicy, DeliverPolicy, RetentionPolicy, StorageType } from "nats";
-import type { ConsumerConfig, StreamConfig, StreamInfo, ConsumerInfo } from "nats";
+import type { ConsumerConfig, StreamInfo } from "nats";
 
-/**
- * Narrow JetStreamManager surface — the operations we use. Mirror of
- * `nats.JetStreamManager` minus everything we don't touch. Tests stub
- * this; production wires it via `link.raw.jetstreamManager()`.
- */
-export interface ProvisionJsm {
-  streams: {
-    info(name: string): Promise<StreamInfo>;
-    add(cfg: Partial<StreamConfig>): Promise<StreamInfo>;
-  };
-  consumers: {
-    info(stream: string, durable: string): Promise<ConsumerInfo>;
-    add(stream: string, cfg: Partial<ConsumerConfig>): Promise<ConsumerInfo>;
-  };
-}
+// Re-exported from the neutral types module so existing callers
+// importing `ProvisionJsm` from this file keep working AND new
+// callers (MyelinRuntime, future bus consumers) can import from
+// `./types` without dragging review-specific code with them.
+// Background: sage review on #338 round 3 (architecture).
+export type { ProvisionJsm } from "./types";
+import type { ProvisionJsm } from "./types";
 
 export type ProvisionOutcome = "created" | "exists" | "config-drift-warning";
 
@@ -242,11 +234,17 @@ export function describeStreamDrift(
 ): string | null {
   const cfg = existing.config;
   const actualSubjects = cfg.subjects ?? [];
+  // JetStream stream subjects are semantically a set — order on the
+  // wire is implementation-detail. Compare as sets so a re-ordered live
+  // config doesn't false-warn on every boot (sage review on #338
+  // round 3 — CodeQuality suggestion).
+  const actualSet = new Set(actualSubjects);
+  const expectedSet = new Set(expectedSubjects);
   const subjectsEqual =
-    actualSubjects.length === expectedSubjects.length &&
-    actualSubjects.every((s, i) => s === expectedSubjects[i]);
+    actualSet.size === expectedSet.size &&
+    [...expectedSet].every((s) => actualSet.has(s));
   if (!subjectsEqual) {
-    return `subjects differ (expected [${expectedSubjects.join(", ")}], got [${actualSubjects.join(", ")}])`;
+    return `subjects differ (expected {${[...expectedSet].sort().join(", ")}}, got {${[...actualSet].sort().join(", ")}})`;
   }
   // Allow ±1s slack on max_age to absorb floating-point round-trips
   // through the wire JSON.

--- a/src/bus/jetstream/provision.ts
+++ b/src/bus/jetstream/provision.ts
@@ -1,0 +1,244 @@
+/**
+ * G-1111b — idempotent JetStream provisioning for cortex's ReviewConsumer
+ * pull subscriptions (cortex#338).
+ *
+ * After cortex#337 (G-1111a) the MyelinRuntime opens a NATS link even
+ * when `nats.subjects: []`, so `subscribePull` returns a real subscriber.
+ * That subscriber binds to a JetStream pull consumer via
+ * `js.consumers.get(stream, durable)` — which throws if the stream OR
+ * the durable doesn't exist server-side.
+ *
+ * Before #338 nothing in cortex provisioned either. Operators ran
+ * `nats stream add` / `nats consumer add` by hand or deployed an
+ * ops tool. Both are reproducible failure points.
+ *
+ * This module:
+ *
+ *   - `provisionReviewStream({ jsm, name, subjects, … })` — `info` then
+ *     `add` on 404. Returns `"created"` / `"exists"` so the caller can
+ *     log differently. Does NOT auto-update on config drift — logs a
+ *     warning instead. Auto-update is too magic for the first cut.
+ *
+ *   - `provisionReviewConsumer({ jsm, stream, durable, … })` — same
+ *     pattern for the per-agent durable pull consumer.
+ *
+ * Anti-criteria:
+ *
+ *   - Don't drop streams/consumers on shutdown — JetStream state
+ *     outlives the process.
+ *   - Don't auto-update on config drift in v1 — log + leave alone.
+ *   - Disabled runtime → caller skips provisioning entirely (no JSM to
+ *     call against).
+ *
+ * The two helpers accept a narrow `ProvisionJsm` shape — the subset of
+ * nats.js's `JetStreamManager` we touch — so tests can pass a stub
+ * without instantiating the full nats.js JS layer.
+ */
+
+// `node_modules/nats` enums are runtime values; importing them as
+// values keeps the wire-config strings centralised in nats.js rather
+// than duplicating literals here.
+import { AckPolicy, DeliverPolicy, RetentionPolicy, StorageType } from "nats";
+import type { ConsumerConfig, StreamConfig, StreamInfo, ConsumerInfo } from "nats";
+
+/**
+ * Narrow JetStreamManager surface — the operations we use. Mirror of
+ * `nats.JetStreamManager` minus everything we don't touch. Tests stub
+ * this; production wires it via `link.raw.jetstreamManager()`.
+ */
+export interface ProvisionJsm {
+  streams: {
+    info(name: string): Promise<StreamInfo>;
+    add(cfg: Partial<StreamConfig>): Promise<StreamInfo>;
+  };
+  consumers: {
+    info(stream: string, durable: string): Promise<ConsumerInfo>;
+    add(stream: string, cfg: Partial<ConsumerConfig>): Promise<ConsumerInfo>;
+  };
+}
+
+export type ProvisionOutcome = "created" | "exists" | "config-drift-warning";
+
+export interface ProvisionStreamOpts {
+  jsm: ProvisionJsm;
+  /** Stream name. ReviewConsumer always binds to `"CODE_REVIEW"`. */
+  name: string;
+  /** Subject filter list. e.g. `["local.jc.default.tasks.code-review.>"]`. */
+  subjects: readonly string[];
+  /**
+   * Max age in nanoseconds. Default 24h (`24 * 3600 * 1e9`). Stale
+   * review tasks past this age are dropped — picks up the work-queue
+   * semantic that an unclaimed task is effectively lost after a day.
+   */
+  maxAgeNs?: number;
+  /**
+   * Optional logger. Defaults to `console`. Surfacing this lets tests
+   * pin the boot-log shape and lets future deployments swap in a
+   * structured logger.
+   */
+  log?: { info: (msg: string) => void; warn: (msg: string) => void };
+}
+
+export interface ProvisionConsumerOpts {
+  jsm: ProvisionJsm;
+  /** Stream the consumer binds to. */
+  stream: string;
+  /** Durable consumer name, e.g. `"cortex-review-consumer-jc-sage"`. */
+  durable: string;
+  /**
+   * Optional narrow filter subject. Omitted → consumer claims every
+   * message on the stream. Set to per-flavor subject if cortex
+   * eventually wants per-flavor durables (#335 follow-up).
+   */
+  filterSubject?: string;
+  /**
+   * Max delivery attempts before JetStream terms the message. Default 5.
+   */
+  maxDeliver?: number;
+  log?: { info: (msg: string) => void; warn: (msg: string) => void };
+}
+
+const DEFAULT_MAX_AGE_NS = 24 * 3600 * 1_000_000_000;
+const DEFAULT_MAX_DELIVER = 5;
+
+/**
+ * Provision (or assert presence of) the JetStream stream that carries
+ * `tasks.code-review.*` envelopes. Idempotent — safe to call on every
+ * boot.
+ */
+export async function provisionReviewStream(
+  opts: ProvisionStreamOpts,
+): Promise<ProvisionOutcome> {
+  const log = opts.log ?? console;
+  const maxAgeNs = opts.maxAgeNs ?? DEFAULT_MAX_AGE_NS;
+
+  let existing: StreamInfo | null = null;
+  try {
+    existing = await opts.jsm.streams.info(opts.name);
+  } catch (err) {
+    // nats.js surfaces "stream not found" as a thrown error with
+    // api_error.code === 404 OR a message containing "not found".
+    // Anything else (auth, network) should propagate so the caller
+    // can decide whether to abort boot or continue degraded.
+    if (!isNotFoundError(err)) {
+      throw err;
+    }
+  }
+
+  if (existing) {
+    const drift = describeStreamDrift(existing, opts.subjects, maxAgeNs);
+    if (drift !== null) {
+      log.warn(
+        `jetstream-provision: stream "${opts.name}" exists but config drifts (${drift}); leaving alone (v1 policy — no auto-update). Update manually with \`nats stream edit\` if intentional.`,
+      );
+      return "config-drift-warning";
+    }
+    return "exists";
+  }
+
+  await opts.jsm.streams.add({
+    name: opts.name,
+    subjects: [...opts.subjects],
+    retention: RetentionPolicy.Workqueue,
+    storage: StorageType.File,
+    max_age: maxAgeNs,
+    max_msgs: -1,
+    max_bytes: -1,
+    num_replicas: 1,
+  });
+  log.info(
+    `jetstream-provision: created stream "${opts.name}" (subjects=[${opts.subjects.join(", ")}], retention=workqueue, max_age=${Math.round(maxAgeNs / 1_000_000_000)}s)`,
+  );
+  return "created";
+}
+
+/**
+ * Provision (or assert presence of) a per-agent durable pull consumer on
+ * the given stream. Idempotent — safe on every boot.
+ */
+export async function provisionReviewConsumer(
+  opts: ProvisionConsumerOpts,
+): Promise<ProvisionOutcome> {
+  const log = opts.log ?? console;
+  const maxDeliver = opts.maxDeliver ?? DEFAULT_MAX_DELIVER;
+
+  try {
+    await opts.jsm.consumers.info(opts.stream, opts.durable);
+    // No drift check on consumers in v1 — the surface is small enough
+    // that operators rarely tune it, and pull-consumer drift is more
+    // subtle than stream drift. Add when an operator hits the gap.
+    return "exists";
+  } catch (err) {
+    if (!isNotFoundError(err)) {
+      throw err;
+    }
+  }
+
+  const cfg: Partial<ConsumerConfig> = {
+    durable_name: opts.durable,
+    ack_policy: AckPolicy.Explicit,
+    deliver_policy: DeliverPolicy.All,
+    max_deliver: maxDeliver,
+  };
+  if (opts.filterSubject !== undefined) {
+    cfg.filter_subject = opts.filterSubject;
+  }
+  await opts.jsm.consumers.add(opts.stream, cfg);
+  log.info(
+    `jetstream-provision: created consumer "${opts.durable}" on stream "${opts.stream}" (ack=explicit, max_deliver=${maxDeliver}${opts.filterSubject ? `, filter=${opts.filterSubject}` : ""})`,
+  );
+  return "created";
+}
+
+/**
+ * Recognise a JetStream "not found" error across the nats.js shapes we
+ * see in this codebase. Exported for tests that simulate the no-stream
+ * / no-consumer paths via a stub jsm.
+ *
+ * - nats.js 2.x throws errors whose `.api_error?.err_code === 10059`
+ *   (stream not found) or `10014` (consumer not found). The message
+ *   forms also include "stream not found" / "consumer not found".
+ * - Recogniser is permissive on the message string so a future nats.js
+ *   error-class refactor doesn't silently break the recogniser; the
+ *   `err_code` path is the authoritative recognition.
+ */
+export function isNotFoundError(err: unknown): boolean {
+  if (typeof err !== "object" || err === null) return false;
+  const apiError = (err as { api_error?: { err_code?: number; code?: number } })
+    .api_error;
+  const code = apiError?.err_code ?? apiError?.code;
+  if (code === 10059 || code === 10014 || code === 404) return true;
+  const msg = err instanceof Error ? err.message : String(err);
+  return /not found|no.*stream.*matched|404/i.test(msg);
+}
+
+/**
+ * Describe stream-config drift between the live `StreamInfo` and the
+ * config we'd have created. Returns `null` when the relevant fields
+ * match, otherwise a short human-readable string for the log line.
+ *
+ * Drift detection is deliberately narrow — only the fields that
+ * meaningfully affect routing (`subjects`) and retention (`max_age`).
+ * Operators tuning `max_bytes` / `num_replicas` for their own reasons
+ * should NOT see a drift warning every boot.
+ */
+export function describeStreamDrift(
+  existing: StreamInfo,
+  expectedSubjects: readonly string[],
+  expectedMaxAgeNs: number,
+): string | null {
+  const cfg = existing.config;
+  const actualSubjects = cfg.subjects ?? [];
+  const subjectsEqual =
+    actualSubjects.length === expectedSubjects.length &&
+    actualSubjects.every((s, i) => s === expectedSubjects[i]);
+  if (!subjectsEqual) {
+    return `subjects differ (expected [${expectedSubjects.join(", ")}], got [${actualSubjects.join(", ")}])`;
+  }
+  // Allow ±1s slack on max_age to absorb floating-point round-trips
+  // through the wire JSON.
+  if (Math.abs((cfg.max_age ?? 0) - expectedMaxAgeNs) > 1_000_000_000) {
+    return `max_age differs (expected ${expectedMaxAgeNs}ns, got ${cfg.max_age}ns)`;
+  }
+  return null;
+}

--- a/src/bus/jetstream/types.ts
+++ b/src/bus/jetstream/types.ts
@@ -1,0 +1,35 @@
+/**
+ * cortex#338 — neutral JetStream type module.
+ *
+ * Holds the narrow `ProvisionJsm` shape — the subset of nats.js's
+ * `JetStreamManager` we use across the codebase — so both the
+ * MyelinRuntime (which exposes a `jetstreamManager()` capability) and
+ * the review-provisioning helpers can import the type without the
+ * runtime needing to depend on the review-specific `provision.ts`
+ * module (per sage review on #338 round 3 — Architecture).
+ *
+ * Keep this file dependency-free apart from `nats` type imports. Any
+ * future JetStream capability that needs a narrower / wider subset of
+ * the JSM surface can add a sibling alias here without dragging
+ * review-specific concerns into the boundary.
+ */
+
+import type { ConsumerConfig, StreamConfig, StreamInfo, ConsumerInfo } from "nats";
+
+/**
+ * Narrow JetStreamManager surface — the operations the provisioning
+ * helpers (and any consumer of `MyelinRuntime.jetstreamManager()`)
+ * touch. Mirror of `nats.JetStreamManager` minus everything we don't
+ * call. Tests stub this; production wires it via the runtime helper
+ * which delegates to `nc.jetstreamManager()`.
+ */
+export interface ProvisionJsm {
+  streams: {
+    info(name: string): Promise<StreamInfo>;
+    add(cfg: Partial<StreamConfig>): Promise<StreamInfo>;
+  };
+  consumers: {
+    info(stream: string, durable: string): Promise<ConsumerInfo>;
+    add(stream: string, cfg: Partial<ConsumerConfig>): Promise<ConsumerInfo>;
+  };
+}

--- a/src/bus/myelin/runtime.ts
+++ b/src/bus/myelin/runtime.ts
@@ -135,7 +135,7 @@ export interface MyelinRuntime {
    * shape — the first call does a server round-trip; subsequent calls
    * are cached.
    */
-  jetstreamManager?(): Promise<import("../jetstream/provision").ProvisionJsm | null>;
+  jetstreamManager?(): Promise<import("../jetstream/types").ProvisionJsm | null>;
   /** Best-effort shutdown — drains subscribers, closes the link. */
   stop(): Promise<void>;
 }

--- a/src/bus/myelin/runtime.ts
+++ b/src/bus/myelin/runtime.ts
@@ -115,20 +115,27 @@ export interface MyelinRuntime {
    */
   subscribePull?(opts: MyelinSubscribePullOpts): MyelinSubscriber | null;
   /**
-   * Resolve the JetStreamManager for the underlying link, or `null` when
-   * the runtime is disabled (no NATS configured or connect failed).
+   * Resolve a narrow provisioning capability against the underlying
+   * link, or `null` when the runtime is disabled (no NATS configured
+   * or connect failed).
    *
    * Used by the boot path to provision streams + per-agent durables
-   * (cortex#338) before `ReviewConsumer.start` binds to them. Like
-   * `subscribePull`, this is OPTIONAL on the interface so existing
-   * fake-runtime stubs in tests stay byte-identical until each test
-   * file opts in.
+   * (cortex#338) before `ReviewConsumer.start` binds to them. The
+   * return type is the narrow `ProvisionJsm` interface (subset of
+   * nats.js's `JetStreamManager` we actually use) rather than the
+   * concrete manager — the runtime stays decoupled from nats.js's
+   * full surface, and tests can pass a stub satisfying the same
+   * narrow shape (sage review on #338 → architecture).
+   *
+   * Like `subscribePull`, this is OPTIONAL on the interface so
+   * existing fake-runtime stubs in tests stay byte-identical until
+   * each test file opts in.
    *
    * Returns a Promise to match nats.js's `nc.jetstreamManager()`
    * shape — the first call does a server round-trip; subsequent calls
    * are cached.
    */
-  jetstreamManager?(): Promise<import("nats").JetStreamManager | null>;
+  jetstreamManager?(): Promise<import("../jetstream/provision").ProvisionJsm | null>;
   /** Best-effort shutdown — drains subscribers, closes the link. */
   stop(): Promise<void>;
 }

--- a/src/bus/myelin/runtime.ts
+++ b/src/bus/myelin/runtime.ts
@@ -114,6 +114,21 @@ export interface MyelinRuntime {
    * pull subscriptions wired" — and stay dormant.
    */
   subscribePull?(opts: MyelinSubscribePullOpts): MyelinSubscriber | null;
+  /**
+   * Resolve the JetStreamManager for the underlying link, or `null` when
+   * the runtime is disabled (no NATS configured or connect failed).
+   *
+   * Used by the boot path to provision streams + per-agent durables
+   * (cortex#338) before `ReviewConsumer.start` binds to them. Like
+   * `subscribePull`, this is OPTIONAL on the interface so existing
+   * fake-runtime stubs in tests stay byte-identical until each test
+   * file opts in.
+   *
+   * Returns a Promise to match nats.js's `nc.jetstreamManager()`
+   * shape — the first call does a server round-trip; subsequent calls
+   * are cached.
+   */
+  jetstreamManager?(): Promise<import("nats").JetStreamManager | null>;
   /** Best-effort shutdown — drains subscribers, closes the link. */
   stop(): Promise<void>;
 }
@@ -314,12 +329,20 @@ export async function startMyelinRuntime(
   // eslint-disable-next-line @typescript-eslint/no-empty-function, @typescript-eslint/require-await
   const stopDisabled = async () => {};
 
+  // cortex#338 — disabled JSM helper mirrors `subscribePullDisabled`.
+  // Boot path calls `runtime.jetstreamManager()` to provision streams /
+  // consumers; a null resolution means "no link, no provisioning" and
+  // the caller must skip.
+  // eslint-disable-next-line @typescript-eslint/require-await
+  const jetstreamManagerDisabled = async (): Promise<null> => null;
+
   if (!config.nats?.url) {
     return {
       enabled: false,
       onEnvelope,
       publish: publishDisabled,
       subscribePull: subscribePullDisabled,
+      jetstreamManager: jetstreamManagerDisabled,
       stop: stopDisabled,
     };
   }
@@ -392,6 +415,7 @@ export async function startMyelinRuntime(
       onEnvelope,
       publish: publishDisabled,
       subscribePull: subscribePullDisabled,
+      jetstreamManager: jetstreamManagerDisabled,
       stop: stopDisabled,
     };
   }
@@ -446,6 +470,7 @@ export async function startMyelinRuntime(
       onEnvelope,
       publish: publishDisabled,
       subscribePull: subscribePullDisabled,
+      jetstreamManager: jetstreamManagerDisabled,
       stop: stopDisabled,
     };
   }
@@ -620,11 +645,24 @@ export async function startMyelinRuntime(
     return sub;
   };
 
+  // cortex#338 — expose the live JetStreamManager so the boot path can
+  // provision streams + per-agent durables before `ReviewConsumer.start`
+  // binds to them. Cached on first call so the boot path doesn't pay a
+  // server round-trip per per-agent provisioning call.
+  let jsmCache: Promise<import("nats").JetStreamManager> | null = null;
+  const jetstreamManagerEnabled = (): Promise<import("nats").JetStreamManager> => {
+    if (jsmCache === null) {
+      jsmCache = link.raw.jetstreamManager();
+    }
+    return jsmCache;
+  };
+
   return {
     enabled: true,
     onEnvelope,
     publish: publishEnabled,
     subscribePull: subscribePullEnabled,
+    jetstreamManager: jetstreamManagerEnabled,
     stop: async () => {
       if (stopped) return;
       stopped = true;

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -53,6 +53,10 @@ import {
   type ReviewConsumerAgent,
   type SignatureVerifier,
 } from "./bus/review-consumer";
+import {
+  provisionReviewStream,
+  provisionReviewConsumer,
+} from "./bus/jetstream/provision";
 import { verifySignedByChain } from "./bus/verify-signed-by-chain";
 import { CCSession } from "./runner/cc-session";
 import { makePiDevPipelineRunner } from "./runner/substrate/pi-dev-runner";
@@ -744,6 +748,45 @@ export async function startCortex(
   // sage's bridge subscription already uses for `local.{org}.{stack}.>`.
   const reviewSubjectPattern = `local.${reviewOperatorId}.${derivedStack.stack}.tasks.code-review.>`;
   const reviewStream = "CODE_REVIEW";
+
+  // cortex#338 — provision the CODE_REVIEW stream up-front so the
+  // per-agent `ReviewConsumer.start` calls below can bind without
+  // hitting "stream not found" against a virgin broker. Idempotent —
+  // safe across restarts. Skipped when the runtime is dormant (no NATS
+  // configured / connect failed); the consumer loop also stays dormant
+  // in that case.
+  if (reviewCapableAgents.length > 0 && runtime.jetstreamManager) {
+    const jsm = await runtime.jetstreamManager();
+    if (jsm !== null) {
+      try {
+        const outcome = await provisionReviewStream({
+          jsm,
+          name: reviewStream,
+          subjects: [reviewSubjectPattern],
+        });
+        if (outcome === "created") {
+          console.log(
+            `cortex: provisioned JetStream stream "${reviewStream}" (subjects=[${reviewSubjectPattern}])`,
+          );
+        } else if (outcome === "exists") {
+          console.log(
+            `cortex: JetStream stream "${reviewStream}" already present — binding existing config`,
+          );
+        }
+        // config-drift-warning is already logged by the helper.
+      } catch (err) {
+        // A provisioning failure does NOT abort boot — siblings still
+        // wire, and the per-agent `consumer.start()` below will surface
+        // the binding failure via its existing try/catch + stderr line.
+        // We log here so operators see provisioning was even attempted.
+        process.stderr.write(
+          `cortex: provisionReviewStream failed for "${reviewStream}": ` +
+            `${err instanceof Error ? err.message : String(err)}\n`,
+        );
+      }
+    }
+  }
+
   for (const agent of reviewCapableAgents) {
     try {
       const caps = agent.runtime?.capabilities ?? [];
@@ -855,6 +898,39 @@ export async function startCortex(
       // the two cases so the boot log can be honest (cortex#334)
       // instead of unconditionally claiming "ready".
       const durable = `cortex-review-consumer-${reviewOperatorId}-${agent.id}`;
+
+      // cortex#338 — provision the per-agent durable consumer up-front
+      // so `consumer.start()` below binds successfully against a virgin
+      // broker. Idempotent — safe across restarts. Skipped when JSM
+      // isn't available (runtime dormant / no NATS configured); the
+      // subsequent `consumer.start()` will then stay dormant too.
+      if (runtime.jetstreamManager) {
+        const jsm = await runtime.jetstreamManager();
+        if (jsm !== null) {
+          try {
+            const outcome = await provisionReviewConsumer({
+              jsm,
+              stream: reviewStream,
+              durable,
+            });
+            if (outcome === "created") {
+              console.log(
+                `cortex: provisioned JetStream durable "${durable}" on stream "${reviewStream}"`,
+              );
+            }
+          } catch (provisionErr) {
+            // Don't abort — let consumer.start surface the bind failure
+            // through its own error path so the operator sees the same
+            // stderr shape they'd see if the consumer existed but bind
+            // failed for another reason.
+            process.stderr.write(
+              `cortex: provisionReviewConsumer failed for "${durable}": ` +
+                `${provisionErr instanceof Error ? provisionErr.message : String(provisionErr)}\n`,
+            );
+          }
+        }
+      }
+
       const started = await consumer.start({
         pattern: reviewSubjectPattern,
         stream: reviewStream,

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -1979,7 +1979,7 @@ export async function startCortex(
 async function resolveReviewProvisioningJsm(
   runtime: MyelinRuntime,
   reviewCapableAgents: readonly Agent[],
-): Promise<import("./bus/jetstream/provision").ProvisionJsm | null> {
+): Promise<import("./bus/jetstream/types").ProvisionJsm | null> {
   if (reviewCapableAgents.length === 0 || !runtime.jetstreamManager) {
     return null;
   }

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -749,21 +749,21 @@ export async function startCortex(
   const reviewSubjectPattern = `local.${reviewOperatorId}.${derivedStack.stack}.tasks.code-review.>`;
   const reviewStream = "CODE_REVIEW";
 
-  // cortex#338 — resolve the provisioning JSM once. Reused by the
-  // up-front stream provisioning AND the per-agent durable
-  // provisioning inside the loop below. `null` means the runtime is
-  // dormant (no NATS configured / connect failed / runtime stub
-  // omits jetstreamManager); provisioning is skipped in that case
-  // and the consumer loop also stays dormant.
-  const reviewJsm =
-    reviewCapableAgents.length > 0 && runtime.jetstreamManager
-      ? await runtime.jetstreamManager()
-      : null;
+  // cortex#338 — resolve the provisioning JSM and provision the
+  // CODE_REVIEW stream up-front so the per-agent `ReviewConsumer.start`
+  // calls below can bind without hitting "stream not found" against a
+  // virgin broker. `reviewJsm = null` means the runtime is dormant
+  // (no NATS / connect failed / `runtime.jetstreamManager()` itself
+  // threw / runtime stub omits the helper) — provisioning is skipped
+  // and the consumer loop stays dormant in lockstep.
+  //
+  // Extracted into `resolveReviewProvisioningJsm` so the JSM-
+  // resolution failure path is covered by the same boot-survives-
+  // provisioning-failure contract as the stream-add path. Pre-fix
+  // an `await runtime.jetstreamManager()` throw bypassed the inner
+  // try/catch and aborted boot (sage review on #338, round 2).
+  const reviewJsm = await resolveReviewProvisioningJsm(runtime, reviewCapableAgents);
 
-  // cortex#338 — provision the CODE_REVIEW stream up-front so the
-  // per-agent `ReviewConsumer.start` calls below can bind without
-  // hitting "stream not found" against a virgin broker. Idempotent —
-  // safe across restarts.
   if (reviewJsm !== null) {
     try {
       const outcome = await provisionReviewStream({
@@ -1962,6 +1962,38 @@ export async function startCortex(
  * the boundary; production callers see the typed return signature.
  */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unnecessary-type-assertion */
+/**
+ * cortex#338 — resolve the JetStreamManager-shaped provisioning
+ * capability needed by the review-stream + per-agent durable boot
+ * wiring. Returns `null` when the runtime is dormant (no NATS / connect
+ * failed / runtime stub omits the helper / the JSM resolution itself
+ * throws). Logging the resolution failure here keeps the boot path
+ * survives-provisioning-failure contract intact — the inner
+ * `provisionReviewStream` + `provisionReviewConsumer` try/catches alone
+ * can't catch a throw from `runtime.jetstreamManager()` itself.
+ *
+ * Extracted from `startCortex` so the resolution surface stays a single
+ * place to read on review and a single place to test going forward
+ * (per sage review on #338 round 2 — Maintainability).
+ */
+async function resolveReviewProvisioningJsm(
+  runtime: MyelinRuntime,
+  reviewCapableAgents: readonly Agent[],
+): Promise<import("./bus/jetstream/provision").ProvisionJsm | null> {
+  if (reviewCapableAgents.length === 0 || !runtime.jetstreamManager) {
+    return null;
+  }
+  try {
+    return await runtime.jetstreamManager();
+  } catch (err) {
+    process.stderr.write(
+      `cortex: jetstreamManager() resolution failed — review provisioning skipped: ` +
+        `${err instanceof Error ? err.message : String(err)}\n`,
+    );
+    return null;
+  }
+}
+
 async function setupDashboard(
   config: BotConfig,
   dispatchHandler: DispatchHandler,

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -749,41 +749,47 @@ export async function startCortex(
   const reviewSubjectPattern = `local.${reviewOperatorId}.${derivedStack.stack}.tasks.code-review.>`;
   const reviewStream = "CODE_REVIEW";
 
+  // cortex#338 — resolve the provisioning JSM once. Reused by the
+  // up-front stream provisioning AND the per-agent durable
+  // provisioning inside the loop below. `null` means the runtime is
+  // dormant (no NATS configured / connect failed / runtime stub
+  // omits jetstreamManager); provisioning is skipped in that case
+  // and the consumer loop also stays dormant.
+  const reviewJsm =
+    reviewCapableAgents.length > 0 && runtime.jetstreamManager
+      ? await runtime.jetstreamManager()
+      : null;
+
   // cortex#338 — provision the CODE_REVIEW stream up-front so the
   // per-agent `ReviewConsumer.start` calls below can bind without
   // hitting "stream not found" against a virgin broker. Idempotent —
-  // safe across restarts. Skipped when the runtime is dormant (no NATS
-  // configured / connect failed); the consumer loop also stays dormant
-  // in that case.
-  if (reviewCapableAgents.length > 0 && runtime.jetstreamManager) {
-    const jsm = await runtime.jetstreamManager();
-    if (jsm !== null) {
-      try {
-        const outcome = await provisionReviewStream({
-          jsm,
-          name: reviewStream,
-          subjects: [reviewSubjectPattern],
-        });
-        if (outcome === "created") {
-          console.log(
-            `cortex: provisioned JetStream stream "${reviewStream}" (subjects=[${reviewSubjectPattern}])`,
-          );
-        } else if (outcome === "exists") {
-          console.log(
-            `cortex: JetStream stream "${reviewStream}" already present — binding existing config`,
-          );
-        }
-        // config-drift-warning is already logged by the helper.
-      } catch (err) {
-        // A provisioning failure does NOT abort boot — siblings still
-        // wire, and the per-agent `consumer.start()` below will surface
-        // the binding failure via its existing try/catch + stderr line.
-        // We log here so operators see provisioning was even attempted.
-        process.stderr.write(
-          `cortex: provisionReviewStream failed for "${reviewStream}": ` +
-            `${err instanceof Error ? err.message : String(err)}\n`,
+  // safe across restarts.
+  if (reviewJsm !== null) {
+    try {
+      const outcome = await provisionReviewStream({
+        jsm: reviewJsm,
+        name: reviewStream,
+        subjects: [reviewSubjectPattern],
+      });
+      if (outcome === "created") {
+        console.log(
+          `cortex: provisioned JetStream stream "${reviewStream}" (subjects=[${reviewSubjectPattern}])`,
+        );
+      } else if (outcome === "exists") {
+        console.log(
+          `cortex: JetStream stream "${reviewStream}" already present — binding existing config`,
         );
       }
+      // config-drift-warning is already logged by the helper.
+    } catch (err) {
+      // A provisioning failure does NOT abort boot — siblings still
+      // wire, and the per-agent `consumer.start()` below will surface
+      // the binding failure via its existing try/catch + stderr line.
+      // We log here so operators see provisioning was even attempted.
+      process.stderr.write(
+        `cortex: provisionReviewStream failed for "${reviewStream}": ` +
+          `${err instanceof Error ? err.message : String(err)}\n`,
+      );
     }
   }
 
@@ -901,33 +907,31 @@ export async function startCortex(
 
       // cortex#338 — provision the per-agent durable consumer up-front
       // so `consumer.start()` below binds successfully against a virgin
-      // broker. Idempotent — safe across restarts. Skipped when JSM
-      // isn't available (runtime dormant / no NATS configured); the
-      // subsequent `consumer.start()` will then stay dormant too.
-      if (runtime.jetstreamManager) {
-        const jsm = await runtime.jetstreamManager();
-        if (jsm !== null) {
-          try {
-            const outcome = await provisionReviewConsumer({
-              jsm,
-              stream: reviewStream,
-              durable,
-            });
-            if (outcome === "created") {
-              console.log(
-                `cortex: provisioned JetStream durable "${durable}" on stream "${reviewStream}"`,
-              );
-            }
-          } catch (provisionErr) {
-            // Don't abort — let consumer.start surface the bind failure
-            // through its own error path so the operator sees the same
-            // stderr shape they'd see if the consumer existed but bind
-            // failed for another reason.
-            process.stderr.write(
-              `cortex: provisionReviewConsumer failed for "${durable}": ` +
-                `${provisionErr instanceof Error ? provisionErr.message : String(provisionErr)}\n`,
+      // broker. Reuses `reviewJsm` resolved once before this loop.
+      // Idempotent — safe across restarts. Skipped when JSM isn't
+      // available (runtime dormant); the subsequent `consumer.start()`
+      // will then stay dormant too.
+      if (reviewJsm !== null) {
+        try {
+          const outcome = await provisionReviewConsumer({
+            jsm: reviewJsm,
+            stream: reviewStream,
+            durable,
+          });
+          if (outcome === "created") {
+            console.log(
+              `cortex: provisioned JetStream durable "${durable}" on stream "${reviewStream}"`,
             );
           }
+        } catch (provisionErr) {
+          // Don't abort — let consumer.start surface the bind failure
+          // through its own error path so the operator sees the same
+          // stderr shape they'd see if the consumer existed but bind
+          // failed for another reason.
+          process.stderr.write(
+            `cortex: provisionReviewConsumer failed for "${durable}": ` +
+              `${provisionErr instanceof Error ? provisionErr.message : String(provisionErr)}\n`,
+          );
         }
       }
 


### PR DESCRIPTION
## Summary

Closes #338 (G-1111b). Foundation step pairing with #342 (#337 G-1111a).

After #337 the MyelinRuntime opens a NATS link even with \`nats.subjects: []\`, so \`subscribePull\` returns a real subscriber. That subscriber binds to a JetStream pull consumer via \`js.consumers.get(stream, durable)\` — which throws if the stream OR durable doesn't exist. Pre-#338 nothing provisioned them. Operators with the default cortex.yaml would now fail at \`ReviewConsumer.start\`.

## What changes

**New \`src/bus/jetstream/provision.ts\`** — idempotent helpers:

\`\`\`ts
provisionReviewStream({ jsm, name, subjects, maxAgeNs? })
  → \"created\" | \"exists\" | \"config-drift-warning\"

provisionReviewConsumer({ jsm, stream, durable, filterSubject?, maxDeliver? })
  → \"created\" | \"exists\"
\`\`\`

- Both \`info\` first; \`add\` on recognised \"not found\"
- Sane defaults (workqueue + file storage + 24h max_age for stream; explicit ack + max_deliver=5 for consumer)
- Config-drift warns but doesn't auto-update (v1 policy — too magic for first cut)
- Narrow \`ProvisionJsm\` interface for testability

**Runtime interface** — \`MyelinRuntime\` gains optional \`jetstreamManager?()\`:

\`\`\`ts
jetstreamManager?(): Promise<JetStreamManager | null>
\`\`\`

Cached on first call. Disabled paths return null. Mirror of \`subscribePull\`'s disabled semantic.

**Boot wiring** — \`cortex.ts\` provisions the stream once (before per-agent loop) + the per-agent durable inside each iteration before \`ReviewConsumer.start\`. Failures log stderr but don't abort boot.

## Tests (18 new, all green)

- \`provisionReviewStream\`: created / exists / drift-warning / error-propagation
- \`provisionReviewConsumer\`: created / exists / filter_subject / maxDeliver / error-propagation
- \`isNotFoundError\`: nats.js \`api_error.err_code\` (10059, 10014), message fallback, defensive cases
- \`describeStreamDrift\`: subjects match/differ, max_age within/beyond 1s slack

Existing review-consumer boot tests stayed green — recording-runtime fixture doesn't expose \`jetstreamManager\` (optional field), so the new boot block guards via \`if (runtime.jetstreamManager)\` and skips provisioning when absent.

## Test plan

- [x] \`bunx tsc --noEmit\` clean
- [x] \`bun test\` — 3377 pass / 0 fail / 2 skip (vs main 3358 → +18 new + 1 file)
- [ ] CI green
- [ ] Real broker round-trip — that's #339's job

## Part of

- #335 umbrella (G-1111)
- Pairs with #342 (#337 — opened NATS link)
- Unblocks #339 (round-trip integration test) — once this lands the chain works end-to-end on a virgin broker
- Parallel with #343 (#340 — publish audit)
- Precedes #341 (docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)