### PR TITLE
fix(bus): finite max_bytes default for CODE_REVIEW stream

### DIFF
--- a/src/bus/jetstream/__tests__/provision.test.ts
+++ b/src/bus/jetstream/__tests__/provision.test.ts
@@ -214,6 +214,22 @@ describe("provisionReviewStream", () => {
     expect(String(cfg.retention)).toBe("interest");
     expect(String(cfg.storage)).toBe("file");
     expect(cfg.max_age).toBe(24 * 3600 * 1e9);
+    // Finite max_bytes default — live deployment surfaced that NATS
+    // accounts with storage-reservation caps reject max_bytes=-1
+    // (unlimited) with "insufficient storage resources available".
+    expect(cfg.max_bytes).toBe(512 * 1024 * 1024);
+  });
+
+  test("honors maxBytes override", async () => {
+    const { jsm, state } = makeJsm({ existingStream: "not-found" });
+    await provisionReviewStream({
+      jsm,
+      name: "CODE_REVIEW",
+      subjects: ["x.>"],
+      maxBytes: 128 * 1024 * 1024,
+      log: silentLog(),
+    });
+    expect(state.streamAddCalls[0]!.max_bytes).toBe(128 * 1024 * 1024);
   });
 
   test("idempotent — exists path returns 'exists' without calling add", async () => {

--- a/src/bus/jetstream/provision.ts
+++ b/src/bus/jetstream/provision.ts
@@ -89,6 +89,18 @@ export interface ProvisionStreamOpts {
    */
   maxAgeNs?: number;
   /**
+   * Stream `max_bytes` cap. Default 512 MiB. Live deployment of #338
+   * surfaced that NATS servers running with an account-level storage
+   * reservation cap reject `max_bytes: -1` (unlimited) with
+   * "insufficient storage resources available" even when raw disk is
+   * abundant. The 512 MiB default matches sibling stream sizing on
+   * JC's laptop (GROVE_EVENTS) and is large enough to absorb ~100k
+   * typical review-task envelopes; operators can override via
+   * `cortex.yaml` `bus.review.maxBytes` once that surface lands
+   * (G-1111e / #341).
+   */
+  maxBytes?: number;
+  /**
    * Optional logger. Defaults to `console`. Surfacing this lets tests
    * pin the boot-log shape and lets future deployments swap in a
    * structured logger.
@@ -116,6 +128,7 @@ export interface ProvisionConsumerOpts {
 }
 
 const DEFAULT_MAX_AGE_NS = 24 * 3600 * 1_000_000_000;
+const DEFAULT_MAX_BYTES = 512 * 1024 * 1024;
 const DEFAULT_MAX_DELIVER = 5;
 
 /**
@@ -128,6 +141,7 @@ export async function provisionReviewStream(
 ): Promise<ProvisionStreamOutcome> {
   const log = opts.log ?? console;
   const maxAgeNs = opts.maxAgeNs ?? DEFAULT_MAX_AGE_NS;
+  const maxBytes = opts.maxBytes ?? DEFAULT_MAX_BYTES;
 
   let existing: StreamInfo | null = null;
   try {
@@ -173,11 +187,11 @@ export async function provisionReviewStream(
     storage: StorageType.File,
     max_age: maxAgeNs,
     max_msgs: -1,
-    max_bytes: -1,
+    max_bytes: maxBytes,
     num_replicas: 1,
   });
   log.info(
-    `jetstream-provision: created stream "${opts.name}" (subjects=[${opts.subjects.join(", ")}], retention=interest, max_age=${Math.round(maxAgeNs / 1_000_000_000)}s)`,
+    `jetstream-provision: created stream "${opts.name}" (subjects=[${opts.subjects.join(", ")}], retention=interest, max_age=${Math.round(maxAgeNs / 1_000_000_000)}s, max_bytes=${Math.round(maxBytes / 1024 / 1024)}MiB)`,
   );
   return "created";
 }


### PR DESCRIPTION
## Summary

Live deployment regression from #344. After restarting cortex post-#338-merge:

\`\`\`
cortex: provisionReviewStream failed for \"CODE_REVIEW\": insufficient storage resources available
cortex: provisionReviewConsumer failed for \"cortex-review-consumer-jc-fern\": stream not found
cortex: review consumer init failed for agent=fern: stream not found
\`\`\`

NATS server account-level storage reservation caps reject \`max_bytes: -1\` even when raw disk is abundant. Switch to a finite 512 MiB default (matching sibling GROVE_EVENTS stream on JC's laptop).

## Test plan

- [x] \`bunx tsc --noEmit\` clean
- [x] \`bun test\` provision tests: 20 pass / 0 fail (was 19 → +1 override test)
- [ ] Local restart confirms stream + per-agent durables provision (in-progress, post-merge)
- [ ] CI green

Operator override available via \`maxBytes\` param; cortex.yaml surface lands with #341.

🤖 Generated with [Claude Code](https://claude.com/claude-code)