### PR TITLE
feat(runner): consume myelin#161 originator field (closes #346) — v2.0.6

### DIFF
--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -2,7 +2,7 @@
 # See: https://github.com/the-metafactory/arc
 
 name: "Cortex"
-version: "2.0.5"
+version: "2.0.6"
 type: component
 tier: community
 description: "Layer-7 collaboration surface for the metafactory ecosystem — the M7 application that consumes the Myelin stack"

--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
         "@octokit/webhooks-methods": "^6.0.0",
         "@slack/socket-mode": "^2.0.7",
         "@slack/web-api": "^7.16.0",
-        "@the-metafactory/myelin": "github:the-metafactory/myelin#5a0e2619a4af5c91c78f552b88fafd3ad40a227f",
+        "@the-metafactory/myelin": "github:the-metafactory/myelin#3ec0aceef960f16db41507d01df5849b0dc7744e",
         "@xyflow/react": "^12.10.2",
         "ajv": "^8.20.0",
         "ajv-formats": "^3.0.1",
@@ -124,7 +124,7 @@
 
     "@slack/web-api": ["@slack/web-api@7.16.0", "", { "dependencies": { "@slack/logger": "^4.0.1", "@slack/types": "^2.21.0", "@types/node": ">=18", "@types/retry": "0.12.0", "axios": "^1.16.0", "eventemitter3": "^5.0.1", "form-data": "^4.0.4", "is-electron": "2.2.2", "is-stream": "^2", "p-queue": "^6", "p-retry": "^4", "retry": "^0.13.1" } }, "sha512-68SAV77uuGKuhyyaRytX8UijVnqSLsTSKslGXw17cjQYXn+jtNl7gbaEjHgC5x2rhCuFdahBrEC2VCLppbzReg=="],
 
-    "@the-metafactory/myelin": ["@the-metafactory/myelin@github:the-metafactory/myelin#5a0e261", { "dependencies": { "@msgpack/msgpack": "^3.1.3", "@nats-io/jetstream": "^3.4.0", "@nats-io/kv": "^3.4.0", "@nats-io/transport-node": "^3.4.0", "@noble/ed25519": "^3.1.0", "ajv": "8.20.0", "ajv-formats": "3.0.1" } }, "the-metafactory-myelin-5a0e261"],
+    "@the-metafactory/myelin": ["@the-metafactory/myelin@github:the-metafactory/myelin#3ec0ace", { "dependencies": { "@msgpack/msgpack": "^3.1.3", "@nats-io/jetstream": "^3.4.0", "@nats-io/kv": "^3.4.0", "@nats-io/transport-node": "^3.4.0", "@noble/ed25519": "^3.1.0", "ajv": "8.20.0", "ajv-formats": "3.0.1" } }, "the-metafactory-myelin-3ec0ace"],
 
     "@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
 

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@octokit/webhooks-methods": "^6.0.0",
     "@slack/socket-mode": "^2.0.7",
     "@slack/web-api": "^7.16.0",
-    "@the-metafactory/myelin": "github:the-metafactory/myelin#5a0e2619a4af5c91c78f552b88fafd3ad40a227f",
+    "@the-metafactory/myelin": "github:the-metafactory/myelin#3ec0aceef960f16db41507d01df5849b0dc7744e",
     "@xyflow/react": "^12.10.2",
     "ajv": "^8.20.0",
     "ajv-formats": "^3.0.1",

--- a/src/bus/myelin/__tests__/envelope-validator.test.ts
+++ b/src/bus/myelin/__tests__/envelope-validator.test.ts
@@ -524,6 +524,30 @@ describe("envelope-validator — chain helpers (IAW Phase A.2)", () => {
     expect(getActorPrincipal(env!)).toBeUndefined();
   });
 
+  // cortex#346 review-loop (Echo r1 architecture suggestion) — drift guard.
+  //
+  // The vendored `getActorPrincipal` mirrors `@the-metafactory/myelin`'s
+  // helper at `node_modules/@the-metafactory/myelin/src/envelope.ts`.
+  // `SCHEMA_SOURCE_COMMIT` pins the schema-string copy; the docstring
+  // `@see` breadcrumb on the local `getActorPrincipal` points future
+  // maintainers at the upstream definition with "keep this in sync".
+  //
+  // An upstream-helper parity test (importing myelin's getActorPrincipal
+  // and asserting identical output across the 3 precedence cases) was
+  // attempted but pulls myelin's `src/envelope.ts` into cortex's tsc
+  // surface, surfacing a pre-existing upstream strict-null gap
+  // (`envelope.ts:527` — `string | undefined` vs `string` on
+  // `envelope.source.split('.')[0]`) that's unrelated to this PR.
+  // Echo classified the upstream-parity test as a non-blocking
+  // suggestion and accepted the `@see` breadcrumb alone as sufficient
+  // for cortex#346. The full contract test belongs in a follow-up that
+  // can also patch the upstream gap (filed as a separate concern).
+  //
+  // The three local-precedence tests above plus the SCHEMA_SOURCE_COMMIT
+  // drift guard plus the `@see` breadcrumb together cover the maintainer-
+  // ergonomic side of Echo's suggestion without dragging upstream noise
+  // into this PR.
+
   test("schema source commit points at the post-myelin#161 originator pin", () => {
     // Lock the pin so future bumps surface in a code review.
     // Updated at cortex#346 — bump from 5a0e261 to 3ec0ace to pick up

--- a/src/bus/myelin/__tests__/envelope-validator.test.ts
+++ b/src/bus/myelin/__tests__/envelope-validator.test.ts
@@ -11,6 +11,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   deriveNatsSubject,
+  getActorPrincipal,
   getLastStampPrincipal,
   getSignedByChain,
   SCHEMA_SOURCE_COMMIT,
@@ -482,13 +483,54 @@ describe("envelope-validator — chain helpers (IAW Phase A.2)", () => {
     expect(getLastStampPrincipal(env!)).toBeUndefined();
   });
 
-  test("schema source commit points at the post-myelin#148 identity-strict pin", () => {
+  // cortex#346 / myelin#161 — vendored getActorPrincipal mirror
+  test("getActorPrincipal prefers originator.principal over signed_by chain", () => {
+    const env: Envelope = {
+      ...(validEnvelope as unknown as Envelope),
+      signed_by: [
+        {
+          method: "ed25519",
+          principal: "did:mf:cortex",
+          signature: ED25519_SIG,
+          at: "2026-05-08T09:00:00Z",
+        },
+      ],
+      originator: {
+        principal: "did:mf:alice",
+        attribution: "adapter-resolved",
+      },
+    };
+    expect(getActorPrincipal(env)).toBe("did:mf:alice");
+  });
+
+  test("getActorPrincipal falls back to signed_by[0].principal when originator absent", () => {
+    const env: Envelope = {
+      ...(validEnvelope as unknown as Envelope),
+      signed_by: [
+        {
+          method: "ed25519",
+          principal: "did:mf:cortex",
+          signature: ED25519_SIG,
+          at: "2026-05-08T09:00:00Z",
+        },
+      ],
+    };
+    expect(getActorPrincipal(env)).toBe("did:mf:cortex");
+  });
+
+  test("getActorPrincipal returns undefined for an unsigned envelope with no originator", () => {
+    const env = tryParseEnvelope(validEnvelope);
+    expect(env).not.toBeNull();
+    expect(getActorPrincipal(env!)).toBeUndefined();
+  });
+
+  test("schema source commit points at the post-myelin#161 originator pin", () => {
     // Lock the pin so future bumps surface in a code review.
-    // Updated at B.1c (cortex#114) — bump from b69c877 to 5a0e261 to
-    // pick up myelin#146 (./identity subpath export) + myelin#148
-    // (strict-null safety on identity submodule).
+    // Updated at cortex#346 — bump from 5a0e261 to 3ec0ace to pick up
+    // myelin#161 (Envelope.originator policy-attribution field +
+    // getActorPrincipal helper; originator added to SIGNABLE_FIELDS).
     expect(SCHEMA_SOURCE_COMMIT).toBe(
-      "5a0e2619a4af5c91c78f552b88fafd3ad40a227f",
+      "3ec0aceef960f16db41507d01df5849b0dc7744e",
     );
   });
 

--- a/src/bus/myelin/envelope-validator.ts
+++ b/src/bus/myelin/envelope-validator.ts
@@ -65,7 +65,16 @@ import {
 } from "@the-metafactory/myelin/subjects";
 import schema from "./vendor/envelope.schema.json" with { type: "json" };
 
-/** Pin so future maintainers know which myelin commit the schema was lifted from. */
+/**
+ * Pin so future maintainers know which myelin commit the schema was lifted from.
+ *
+ * Upstream issue/PR numbering note: myelin#160 is the design issue for the
+ * envelope `originator` field; myelin#161 is the merged PR. The vendored
+ * schema's description string preserves the `myelin#160:` reference
+ * verbatim (faithful vendoring of upstream wording); all cortex code +
+ * comments + tests use `myelin#161` to point at the merge that landed the
+ * feature — they're the same change, different ticket facets.
+ */
 export const SCHEMA_SOURCE_COMMIT = "3ec0aceef960f16db41507d01df5849b0dc7744e";
 
 /**
@@ -413,6 +422,18 @@ export function getLastStampPrincipal(envelope: Envelope): string | undefined {
  *      listener path).
  *
  * Pure function. No side effects.
+ *
+ * **Drift guard.** This is a vendored mirror of upstream:
+ *   {@link import("@the-metafactory/myelin").getActorPrincipal}
+ *   (definition at `node_modules/@the-metafactory/myelin/src/envelope.ts`).
+ * `SCHEMA_SOURCE_COMMIT` above pins the schema-string copy of myelin; the
+ * `getActorPrincipal upstream-parity contract` test in
+ * `__tests__/envelope-validator.test.ts` imports the upstream helper and
+ * asserts identical output across the three precedence cases — so a
+ * future myelin bump that changes precedence (e.g. adds delegated-chain
+ * walking) fails CI before the vendored copy silently diverges.
+ * If you update this function, update the upstream too (or the contract
+ * test will catch it).
  */
 export function getActorPrincipal(envelope: Envelope): string | undefined {
   if (envelope.originator?.principal) return envelope.originator.principal;

--- a/src/bus/myelin/envelope-validator.ts
+++ b/src/bus/myelin/envelope-validator.ts
@@ -426,14 +426,17 @@ export function getLastStampPrincipal(envelope: Envelope): string | undefined {
  * **Drift guard.** This is a vendored mirror of upstream:
  *   {@link import("@the-metafactory/myelin").getActorPrincipal}
  *   (definition at `node_modules/@the-metafactory/myelin/src/envelope.ts`).
- * `SCHEMA_SOURCE_COMMIT` above pins the schema-string copy of myelin; the
- * `getActorPrincipal upstream-parity contract` test in
- * `__tests__/envelope-validator.test.ts` imports the upstream helper and
- * asserts identical output across the three precedence cases — so a
- * future myelin bump that changes precedence (e.g. adds delegated-chain
- * walking) fails CI before the vendored copy silently diverges.
- * If you update this function, update the upstream too (or the contract
- * test will catch it).
+ * `SCHEMA_SOURCE_COMMIT` one screen above will surface a vendored-schema
+ * bump in code review; the three local-precedence tests in
+ * `__tests__/envelope-validator.test.ts` lock cortex's contract.
+ * **There is no upstream-parity contract test in this PR** — adding one
+ * is filed as a follow-up (blocked by a pre-existing upstream strict-null
+ * gap at `myelin/src/envelope.ts:527` unrelated to cortex#346; surfaces
+ * only when cortex's tsc walks myelin's `/envelope` subpath, which the
+ * runtime contract test would require).
+ * If you update this function, update myelin's `getActorPrincipal` too:
+ * the two implementations must agree on precedence, and nothing in CI
+ * will catch them if they diverge until that follow-up lands.
  */
 export function getActorPrincipal(envelope: Envelope): string | undefined {
   if (envelope.originator?.principal) return envelope.originator.principal;

--- a/src/bus/myelin/envelope-validator.ts
+++ b/src/bus/myelin/envelope-validator.ts
@@ -66,7 +66,7 @@ import {
 import schema from "./vendor/envelope.schema.json" with { type: "json" };
 
 /** Pin so future maintainers know which myelin commit the schema was lifted from. */
-export const SCHEMA_SOURCE_COMMIT = "5a0e2619a4af5c91c78f552b88fafd3ad40a227f";
+export const SCHEMA_SOURCE_COMMIT = "3ec0aceef960f16db41507d01df5849b0dc7744e";
 
 /**
  * Hand-typed Envelope shape matching the JSON Schema. We hand-write rather
@@ -160,7 +160,46 @@ export interface Envelope {
    * DID of the receiving agent (`did:mf:<name>`).
    */
   target_principal?: string;
+  /**
+   * myelin#161 — policy-level actor identity, separate from the
+   * cryptographic `signed_by[]` chain. The chain proves WHO signed; the
+   * originator names WHO the signer claims to be acting on behalf of.
+   *
+   * `originator` IS covered by the envelope signature (a signable field —
+   * see myelin canonicalize SIGNABLE_FIELDS). Tampering with `originator`
+   * invalidates every subsequent stamp.
+   *
+   * Cortex callers should resolve the policy actor via the upstream
+   * `getActorPrincipal(envelope)` helper rather than reading this field
+   * directly — that helper falls back to `signed_by[0].principal` for
+   * legacy envelopes that pre-date myelin#161.
+   */
+  originator?: Originator;
 }
+
+/**
+ * myelin#161 — policy-attribution claim that travels next to the
+ * `signed_by[]` chain. The signer commits to the attribution claim by
+ * including the field in the canonical signature input.
+ */
+export interface Originator {
+  /** DID of the actor whose capabilities this envelope asserts. */
+  principal: string;
+  /**
+   * How the signer learned the originator identity:
+   *   - `adapter-resolved` — adapter (Discord/Slack/Mattermost/HTTP/cc-events)
+   *     mapped a non-myelin identifier (platform id, OS user) to a myelin
+   *     principal at sign time.
+   *   - `federated` — the originator claim was relayed from another
+   *     operator; the chain proves the cross-operator hop.
+   *   - `delegated` — the signer holds delegation credentials for the
+   *     originator (service principal acting on behalf of an operator).
+   */
+  attribution: AttributionMode;
+}
+
+/** myelin#161 — see {@link Originator}. */
+export type AttributionMode = "adapter-resolved" | "federated" | "delegated";
 
 /**
  * Discriminated stamp shape — one entry in an envelope's `signed_by` chain.
@@ -352,6 +391,33 @@ export function getLastStampPrincipal(envelope: Envelope): string | undefined {
   if (chain.length === 0) return undefined;
   const last = chain[chain.length - 1];
   return last?.principal;
+}
+
+/**
+ * Resolve the policy-attribution principal for an envelope (myelin#161 /
+ * cortex#346). Returns the DID string the policy engine should resolve.
+ *
+ * Precedence (delegates to myelin's `getActorPrincipal` semantics — kept
+ * vendored here so cortex's `Envelope` type can be passed directly without
+ * a cross-package cast):
+ *
+ *   1. `envelope.originator?.principal` — explicit policy-attribution
+ *      claim, covered by the envelope signature (`originator` is in
+ *      myelin's SIGNABLE_FIELDS post-#161, so tampering invalidates the
+ *      chain).
+ *   2. `envelope.signed_by[0]?.principal` — first stamp in the chain.
+ *      Legacy-compat fallback for pre-#161 envelopes that never set an
+ *      `originator`.
+ *   3. `undefined` — unsigned envelope with no originator block. Callers
+ *      decide the fallback (e.g. `payload.agent_id` in the dispatch
+ *      listener path).
+ *
+ * Pure function. No side effects.
+ */
+export function getActorPrincipal(envelope: Envelope): string | undefined {
+  if (envelope.originator?.principal) return envelope.originator.principal;
+  const chain = getSignedByChain(envelope);
+  return chain[0]?.principal;
 }
 
 /**

--- a/src/bus/myelin/vendor/envelope.schema.json
+++ b/src/bus/myelin/vendor/envelope.schema.json
@@ -172,6 +172,24 @@
       "type": "string",
       "pattern": "^did:mf:[a-z](?:[a-z0-9._]|-(?!-))+$",
       "description": "F-021: required when distribution_mode is direct or delegate. DID of the receiving agent."
+    },
+    "originator": {
+      "type": "object",
+      "description": "myelin#160: policy-level actor identity, separate from the cryptographic signed_by chain. The chain proves WHO signed; originator names WHO the signer claims to be acting on behalf of. Covered by the signature (signer commits to the attribution claim). When absent, the signer is the actor.",
+      "required": ["principal", "attribution"],
+      "properties": {
+        "principal": {
+          "type": "string",
+          "pattern": "^did:mf:[a-z](?:[a-z0-9._]|-(?!-))+$",
+          "description": "DID of the actor whose capabilities this envelope asserts."
+        },
+        "attribution": {
+          "type": "string",
+          "enum": ["adapter-resolved", "federated", "delegated"],
+          "description": "How the signer learned the originator identity. adapter-resolved: external (Discord/Slack/HTTP) id mapped to principal. federated: relayed claim from another operator. delegated: signer holds delegation credentials for the originator."
+        }
+      },
+      "additionalProperties": false
     }
   },
   "allOf": [

--- a/src/runner/__tests__/dispatch-listener.test.ts
+++ b/src/runner/__tests__/dispatch-listener.test.ts
@@ -1873,3 +1873,257 @@ describe("dispatch-listener — chain verification (cortex#320)", () => {
     expect(optsCaptured).toHaveLength(0);
   });
 });
+
+// ---------------------------------------------------------------------------
+// cortex#346 — myelin#161 originator field consumed via getActorPrincipal
+// ---------------------------------------------------------------------------
+
+/**
+ * cortex#346 — runner consumes the new `Envelope.originator` field (myelin#161).
+ *
+ * Precedence rule we assert (delegates to myelin's `getActorPrincipal`):
+ *   1. `envelope.originator?.principal`  ← policy-attribution claim
+ *   2. `envelope.signed_by[0]?.principal` ← legacy compat for pre-#161 envelopes
+ *   3. `payload.agent_id`                 ← adapter-direct dispatches with no chain
+ *
+ * Tamper case is covered by the chain-verification suite above — `originator`
+ * is in myelin's SIGNABLE_FIELDS, so mutating either `principal` or
+ * `attribution` after signing invalidates the chain. We add one explicit
+ * tamper test here to pin the contract from cortex's side.
+ */
+describe("dispatch-listener — originator (cortex#346 / myelin#161)", () => {
+  test("originator.principal wins over signed_by[0].principal for engine lookup", async () => {
+    // When both are present, the policy engine must see the originator's
+    // principal id (the actor the signer is attesting on behalf of), NOT
+    // the signer's principal id. This decouples policy attribution from
+    // signer identity — the cortex-bot-as-relay case.
+    const captured: { principalId: string; intent: Intent }[] = [];
+    const engine = new PolicyEngine({
+      principals: [
+        {
+          id: "alice",
+          home_operator: "andreas",
+          home_stack: "andreas/research",
+          role: ["operator"],
+          trust: [],
+        },
+      ],
+      roles: [{ id: "operator", capabilities: ["dispatch.cortex"] }],
+    });
+    const origCheck = engine.check.bind(engine);
+    engine.check = (principalId, intent) => {
+      captured.push({ principalId, intent });
+      return origCheck(principalId, intent);
+    };
+
+    const r = recordingRuntime();
+    const router = createSurfaceRouter(r.runtime);
+    const { factory } = fakeFactory(SUCCESS_RESULT);
+    const listener = createDispatchListener({
+      runtime: r.runtime,
+      router,
+      source: SOURCE,
+      ccSessionFactory: factory,
+      policyEngine: engine,
+    });
+    await listener.start();
+    await router.start();
+
+    const env = makeReceivedEnvelope();
+    // Signer is cortex-bot; the originator is alice (the human the bot
+    // is acting on behalf of). Engine must resolve `alice`, not `cortex`.
+    env.signed_by = [
+      {
+        method: "ed25519",
+        principal: "did:mf:cortex",
+        signature: "a".repeat(88),
+        at: "2026-05-19T12:00:00Z",
+      },
+    ];
+    env.originator = {
+      principal: "did:mf:alice",
+      attribution: "adapter-resolved",
+    };
+
+    r.trigger(env, "local.metafactory.dispatch.task.received");
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0]!.principalId).toBe("alice");
+  });
+
+  test("originator absent + signed_by[0].principal present → falls back to signer (legacy compat)", async () => {
+    // Pre-myelin#161 envelopes have no `originator`. Behaviour must remain
+    // identical to the pre-#346 path: principal id is taken from the
+    // first stamp in the chain.
+    const captured: { principalId: string; intent: Intent }[] = [];
+    const engine = new PolicyEngine({
+      principals: [
+        {
+          id: "cortex",
+          home_operator: "andreas",
+          home_stack: "andreas/research",
+          role: ["operator"],
+          trust: [],
+        },
+      ],
+      roles: [{ id: "operator", capabilities: ["dispatch.cortex"] }],
+    });
+    const origCheck = engine.check.bind(engine);
+    engine.check = (principalId, intent) => {
+      captured.push({ principalId, intent });
+      return origCheck(principalId, intent);
+    };
+
+    const r = recordingRuntime();
+    const router = createSurfaceRouter(r.runtime);
+    const { factory } = fakeFactory(SUCCESS_RESULT);
+    const listener = createDispatchListener({
+      runtime: r.runtime,
+      router,
+      source: SOURCE,
+      ccSessionFactory: factory,
+      policyEngine: engine,
+    });
+    await listener.start();
+    await router.start();
+
+    const env = makeReceivedEnvelope();
+    env.signed_by = [
+      {
+        method: "ed25519",
+        principal: "did:mf:cortex",
+        signature: "a".repeat(88),
+        at: "2026-05-19T12:00:00Z",
+      },
+    ];
+    // No env.originator on purpose — legacy envelope.
+
+    r.trigger(env, "local.metafactory.dispatch.task.received");
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0]!.principalId).toBe("cortex");
+  });
+
+  test("originator + signed_by both absent → falls back to payload.agent_id", async () => {
+    // Adapter-direct (non-bus) dispatch path: no signed chain, no
+    // originator. Runner accepts the payload's `agent_id` as the
+    // principal id (belt-and-braces fallback called out in cortex#346
+    // "Out of scope" — keep behaviour).
+    const captured: { principalId: string; intent: Intent }[] = [];
+    const engine = new PolicyEngine({
+      principals: [
+        {
+          id: "cortex",
+          home_operator: "andreas",
+          home_stack: "andreas/research",
+          role: ["operator"],
+          trust: [],
+        },
+      ],
+      roles: [{ id: "operator", capabilities: ["dispatch.cortex"] }],
+    });
+    const origCheck = engine.check.bind(engine);
+    engine.check = (principalId, intent) => {
+      captured.push({ principalId, intent });
+      return origCheck(principalId, intent);
+    };
+
+    const r = recordingRuntime();
+    const router = createSurfaceRouter(r.runtime);
+    const { factory } = fakeFactory(SUCCESS_RESULT);
+    const listener = createDispatchListener({
+      runtime: r.runtime,
+      router,
+      source: SOURCE,
+      ccSessionFactory: factory,
+      policyEngine: engine,
+    });
+    await listener.start();
+    await router.start();
+
+    // makeReceivedEnvelope defaults `payload.agent_id = "cortex"` and
+    // adds no signed_by / no originator.
+    r.trigger(
+      makeReceivedEnvelope(),
+      "local.metafactory.dispatch.task.received",
+    );
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0]!.principalId).toBe("cortex");
+  });
+
+  test("cryptoVerify:true — tampered originator on signed envelope → chain_verification_failed deny", async () => {
+    // myelin#161 added `originator` to SIGNABLE_FIELDS. Mutating either
+    // sub-field (principal OR attribution) after signing must invalidate
+    // the chain — proving cortex inherits the protection automatically
+    // by delegating verification to myelin's canonicalize.
+    const { nkeyPub, privateKeyBase64 } = generateEd25519KeyPairForRunner();
+    const cortex = agentFixtureForRunner({
+      id: "cortex",
+      trust: ["cortex"],
+      nkey_pub: nkeyPub,
+    });
+    const resolver = runnerResolverWith(cortex);
+
+    const r = recordingRuntime();
+    const router = createSurfaceRouter(r.runtime);
+    const { factory, optsCaptured } = fakeFactory(SUCCESS_RESULT);
+    const listener = createDispatchListener({
+      runtime: r.runtime,
+      router,
+      source: SOURCE,
+      ccSessionFactory: factory,
+      policyEngine: engineGranting(["dispatch.cortex"]),
+      trustResolver: resolver,
+      receivingAgentId: "cortex",
+      operatorId: "andreas",
+      cryptoVerify: true,
+    });
+    await listener.start();
+    await router.start();
+
+    // Sign the envelope WITH originator → signature commits to it.
+    const base = makeReceivedEnvelope() as Parameters<typeof signEnvelope>[0];
+    const baseWithOriginator: Parameters<typeof signEnvelope>[0] = {
+      ...base,
+      originator: {
+        principal: "did:mf:cortex",
+        attribution: "adapter-resolved",
+      },
+    };
+    const signed = await signEnvelope(
+      baseWithOriginator,
+      privateKeyBase64,
+      "did:mf:cortex",
+    );
+
+    // Tamper: swap the originator principal to a different DID
+    // post-sign. Chain bytes no longer match the signature.
+    const tampered: Envelope = {
+      ...(signed as Envelope),
+      originator: {
+        principal: "did:mf:mallory",
+        attribution: "adapter-resolved",
+      },
+    };
+
+    r.trigger(tampered, "local.metafactory.dispatch.task.received");
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(r.published.map((e) => e.type)).toEqual([
+      "system.access.denied",
+      "dispatch.task.failed",
+    ]);
+    const denied = r.published[0]!;
+    const reason = denied.payload.reason as {
+      kind: string;
+      chain_reason?: { kind: string };
+    };
+    expect(reason.kind).toBe("chain_verification_failed");
+    expect(reason.chain_reason?.kind).toBe("crypto_verify_failed");
+    expect(optsCaptured).toHaveLength(0);
+  });
+});

--- a/src/runner/dispatch-listener.ts
+++ b/src/runner/dispatch-listener.ts
@@ -57,7 +57,10 @@
  */
 
 import type { Envelope } from "../bus/myelin/envelope-validator";
-import { getSignedByChain } from "../bus/myelin/envelope-validator";
+import {
+  getActorPrincipal,
+  getSignedByChain,
+} from "../bus/myelin/envelope-validator";
 import type { MyelinRuntime } from "../bus/myelin/runtime";
 import type {
   SurfaceAdapter,
@@ -955,23 +958,35 @@ function checkDispatchPolicy(
 }
 
 /**
- * Strip the `did:mf:` prefix from the originator stamp's principal
- * via the shared `extractAgentIdFromDid` helper (also used by
- * `verify-signed-by-chain.ts` — Echo cortex#220 round 2 S-1). Falls
- * back to `payload.agent_id` when the envelope has no chain, AND
- * surfaces the raw DID string when the parser rejects it (malformed
- * DID method, empty tail, multi-segment colon) so the engine
- * receives a deterministic `unknown_principal` rather than silent
- * coercion.
+ * Resolve the policy-attribution principal id for a dispatch envelope.
+ *
+ * cortex#346 / myelin#161 — defers to myelin's `getActorPrincipal()` so
+ * the precedence rule lives in ONE place (envelope schema owner):
+ *
+ *   1. `envelope.originator?.principal` ← policy-attribution claim,
+ *      covered by the envelope signature (SIGNABLE_FIELDS post-#161).
+ *      Tampering with `originator.principal` OR `originator.attribution`
+ *      invalidates the chain → caught by `verifySignedByChain` upstream.
+ *   2. `envelope.signed_by[0]?.principal` ← legacy compat for pre-#161
+ *      envelopes that never set an `originator`.
+ *   3. `payload.agent_id` ← adapter-direct (non-bus) dispatches with no
+ *      signed chain; belt-and-braces called out as out-of-scope-to-remove
+ *      in cortex#346.
+ *
+ * `getActorPrincipal` returns a DID (`did:mf:<name>`) for cases 1+2, so
+ * we still run the returned value through `extractAgentIdFromDid` to
+ * strip the `did:mf:` prefix. When the parser rejects the DID (malformed
+ * method, empty tail, multi-segment colon) we surface the raw string so
+ * the engine receives a deterministic `unknown_principal` rather than
+ * silent coercion (Echo cortex#220 round 2 S-1).
  */
 function resolvePrincipalId(
   envelope: Envelope,
   payload: DispatchTaskReceivedPayload,
 ): string {
-  const chain = getSignedByChain(envelope);
-  const origin = chain[0];
-  if (origin === undefined) return payload.agent_id;
-  return extractAgentIdFromDid(origin.principal) ?? origin.principal;
+  const actorDid = getActorPrincipal(envelope);
+  if (actorDid === undefined) return payload.agent_id;
+  return extractAgentIdFromDid(actorDid) ?? actorDid;
 }
 
 /**

--- a/src/taps/cc-events/__tests__/cc-events.test.ts
+++ b/src/taps/cc-events/__tests__/cc-events.test.ts
@@ -192,6 +192,43 @@ describe("createCcEventEnvelope", () => {
     }
     expect(result.ok).toBe(true);
   });
+
+  // cortex#346 / myelin#161 — originator field plumbing
+  test("originator omitted by default (backwards-compatible)", () => {
+    const env = createCcEventEnvelope({ event: makeEvent() });
+    expect(env.originator).toBeUndefined();
+  });
+
+  test("originator set when originatorPrincipal supplied → attribution=adapter-resolved", () => {
+    // cortex#346 — cc-events originates from the operator's own stack;
+    // the tap IS the adapter for the Claude-Code substrate. Attribution
+    // is `adapter-resolved` per the agreement to use that mode for all
+    // first-party in-process originators on cortex#346.
+    const env = createCcEventEnvelope({
+      event: makeEvent(),
+      source: { org: "metafactory" },
+      originatorPrincipal: "did:mf:cortex",
+    });
+    expect(env.originator).toEqual({
+      principal: "did:mf:cortex",
+      attribution: "adapter-resolved",
+    });
+  });
+
+  test("originator-bearing envelope passes Ajv validation against vendored schema", () => {
+    // Regression guard — the vendored schema for myelin#161 must accept
+    // the originator block as constructed here.
+    const env = createCcEventEnvelope({
+      event: makeEvent(),
+      source: { org: "metafactory" },
+      originatorPrincipal: "did:mf:cortex",
+    });
+    const result = validateEnvelope(env);
+    if (!result.ok) {
+      throw new Error(`envelope failed validation: ${JSON.stringify(result.errors)}`);
+    }
+    expect(result.ok).toBe(true);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -298,6 +335,35 @@ describe("createCcEventPublisher", () => {
     const pub = createCcEventPublisher({ link: link.stub, org: "default" });
     // Must not throw — the relay's primary path is JSONL append, not bus
     expect(() => pub(makeEvent())).not.toThrow();
+  });
+
+  // cortex#346 / myelin#161 — originator plumbing through the publisher
+  test("originatorPrincipal flows into every published envelope (cortex#346)", () => {
+    const link = makeLink();
+    const pub = createCcEventPublisher({
+      link: link.stub,
+      org: "metafactory",
+      stack: "default",
+      originatorPrincipal: "did:mf:cortex",
+    });
+    pub(makeEvent({ event_type: "tool.bash.executed" }));
+    pub(makeEvent({ event_type: "session.started" }));
+    expect(link.calls).toHaveLength(2);
+    for (const call of link.calls) {
+      const env = JSON.parse(call.payload);
+      expect(env.originator).toEqual({
+        principal: "did:mf:cortex",
+        attribution: "adapter-resolved",
+      });
+    }
+  });
+
+  test("originator omitted when originatorPrincipal not configured (default off)", () => {
+    const link = makeLink();
+    const pub = createCcEventPublisher({ link: link.stub, org: "metafactory" });
+    pub(makeEvent({ event_type: "tool.bash.executed" }));
+    const env = JSON.parse(link.calls[0]!.payload);
+    expect(env.originator).toBeUndefined();
   });
 
   test("buildEnvelope override is invoked per event", () => {

--- a/src/taps/cc-events/cc-events.ts
+++ b/src/taps/cc-events/cc-events.ts
@@ -149,6 +149,23 @@ export interface CreateCcEventEnvelopeOpts {
    * violation (see {@link validateSubjectEnvelopeAlignment}).
    */
   classification?: Classification;
+  /**
+   * cortex#346 / myelin#161 — optional originator principal DID
+   * (`did:mf:<name>`). When supplied, every emitted envelope carries
+   *
+   *   `originator: { principal, attribution: "adapter-resolved" }`
+   *
+   * The cc-events tap IS the adapter for the Claude-Code substrate: it
+   * lifts hook events from the operator's own stack into the bus.
+   * Attribution is always `"adapter-resolved"` because the relay maps the
+   * running CC session (a non-myelin identifier) to the stack's myelin
+   * principal at sign time.
+   *
+   * Omit (or pass `undefined`) to preserve pre-#346 behaviour — no
+   * `originator` field on the envelope. Legacy consumers that fall back
+   * to `signed_by[0].principal` keep working unchanged.
+   */
+  originatorPrincipal?: string;
 }
 
 /**
@@ -197,6 +214,16 @@ export function createCcEventEnvelope(
     },
   });
   envelope.timestamp = event.timestamp;
+  // cortex#346 / myelin#161 — attach the originator block when configured.
+  // Mutation-after-build is fine here: `buildBaseEnvelope` returns a fresh
+  // object per call (no aliasing risk), and the field lives at the top
+  // level so JSON serialisation picks it up downstream.
+  if (opts.originatorPrincipal !== undefined) {
+    envelope.originator = {
+      principal: opts.originatorPrincipal,
+      attribution: "adapter-resolved",
+    };
+  }
   return envelope;
 }
 
@@ -264,8 +291,29 @@ export interface CreateCcEventPublisherOpts {
    * configured via `opts.classification` — otherwise the subject
    * (derived from the envelope) and the operator-intended classification
    * can silently diverge (cortex#130 item 3, Echo's suggestion).
+   *
+   * **Caller also owns `originator` when overriding** — see
+   * `originatorPrincipal` below. The default helper applies it; an
+   * override must wire it through itself, otherwise published events
+   * silently drop the attribution claim.
    */
   buildEnvelope?: (event: PublishedEvent, source: CcEventSource) => Envelope;
+  /**
+   * cortex#346 / myelin#161 — optional originator principal DID. When set,
+   * every envelope this publisher emits carries
+   *
+   *   `originator: { principal: <originatorPrincipal>, attribution: "adapter-resolved" }`
+   *
+   * The cc-events tap IS the adapter for the Claude-Code substrate, and
+   * the relay maps the running CC session to the stack's myelin principal
+   * at sign time — hence the `adapter-resolved` attribution mode.
+   *
+   * Production callers source this from the operator's stack principal
+   * id (e.g. `did:mf:<stack-principal>` derived from cortex config).
+   * Omit to preserve pre-#346 behaviour (no originator field; receivers
+   * fall back to `signed_by[0].principal` for policy attribution).
+   */
+  originatorPrincipal?: string;
 }
 
 /**
@@ -302,10 +350,16 @@ export function createCcEventPublisher(
     ...(opts.dataResidency !== undefined && { dataResidency: opts.dataResidency }),
   };
   const classification: Classification = opts.classification ?? "local";
+  const originatorPrincipal = opts.originatorPrincipal;
   const buildEnvelope =
     opts.buildEnvelope ??
     ((event: PublishedEvent, src: CcEventSource) =>
-      createCcEventEnvelope({ event, source: src, classification }));
+      createCcEventEnvelope({
+        event,
+        source: src,
+        classification,
+        ...(originatorPrincipal !== undefined && { originatorPrincipal }),
+      }));
 
   return (event: PublishedEvent) => {
     const envelope = buildEnvelope(event, source);

--- a/src/taps/cc-events/relay.ts
+++ b/src/taps/cc-events/relay.ts
@@ -25,6 +25,7 @@ interface StartOptions {
   natsToken?: string;
   org?: string;
   stack?: string;
+  originatorPrincipal?: string;
 }
 interface TestOptions {
   policy: string;
@@ -167,6 +168,10 @@ program
     "--stack <stack>",
     "Operator stack segment for stack-aware subjects (local.{org}.{stack}.{type}). Matches the cortex.yaml stack: block. Falls back to env var CORTEX_STACK. When omitted, relay publishes on the legacy 5-segment form.",
   )
+  .option(
+    "--originator-principal <did>",
+    "cortex#346 / myelin#161 — DID (did:mf:<name>) stamped onto envelope.originator for every relay-lifted CC event. Attribution mode is fixed at 'adapter-resolved' (the relay maps the running CC session to the stack's myelin principal). Falls back to env var CORTEX_ORIGINATOR_PRINCIPAL. Omit to publish without an originator block (pre-#346 behaviour; receivers fall back to signed_by[0].principal).",
+  )
   .action(async (options: StartOptions) => {
     if (!existsSync(options.policy)) {
       console.error(`Policy file not found: ${options.policy}`);
@@ -198,6 +203,15 @@ program
     // cortex#266 — IAW A.5 stack segment for 6-segment publishes.
     const stack: string | undefined =
       options.stack ?? process.env.CORTEX_STACK ?? undefined;
+    // cortex#346 — myelin#161 originator principal stamped onto every
+    // relay-lifted CC envelope. Opt-in: omit to preserve pre-#346 wire
+    // format (no originator block). Validation of the DID format lives
+    // downstream in myelin's envelope validator — passing a malformed
+    // value fails AJV on first publish, surfacing the error in stderr.
+    const originatorPrincipal: string | undefined =
+      options.originatorPrincipal ??
+      process.env.CORTEX_ORIGINATOR_PRINCIPAL ??
+      undefined;
     // cortex#275 (Sage cycle 1) — fail-fast stack validation. If the
     // operator supplied a malformed stack value (`*`, `>`, empty,
     // uppercase, etc.), reject at startup with a clear error rather
@@ -228,11 +242,16 @@ program
           link: natsLink,
           org,
           ...(stack !== undefined && { stack }),
+          ...(originatorPrincipal !== undefined && { originatorPrincipal }),
         });
         const safeUrl = natsUrl.replace(/\/\/[^@/]+@/, "//***@");
         const stackSuffix = stack !== undefined ? ` stack="${stack}"` : "";
+        const originatorSuffix =
+          originatorPrincipal !== undefined
+            ? ` originator="${originatorPrincipal}"`
+            : "";
         console.log(
-          `cortex-relay: nats publishing enabled — ${safeUrl} (org="${org}"${stackSuffix})`,
+          `cortex-relay: nats publishing enabled — ${safeUrl} (org="${org}"${stackSuffix}${originatorSuffix})`,
         );
       } catch (err) {
         // Per the design rule: failed NATS startup must NOT crash the


### PR DESCRIPTION
## Summary

Closes #346. Bumps `@the-metafactory/myelin` to `3ec0aceef960f16db41507d01df5849b0dc7744e` (myelin#161) and wires the new `Envelope.originator` policy-attribution field through cortex's runner (consumer) and the cc-events tap (producer). Cuts v2.0.6.

Refs: the-metafactory/myelin#161

## Note on `Originator` shape

Task brief was written against a draft of myelin#161 that described `Originator = { principal, platform_id, platform }`. The merged contract on `3ec0ace…` is `Originator = { principal, attribution }` with `AttributionMode = 'adapter-resolved' | 'federated' | 'delegated'`. Confirmed with @mellanon before proceeding. Platform context is already on the wire (audit deny payload, NATS subject); originator's job is purely policy-attribution. All in-scope sites use `attribution: 'adapter-resolved'` — `federated` and `delegated` are out of scope for this PR.

## What landed

### Runner (consumer)

- `src/bus/myelin/envelope-validator.ts`: vendored `getActorPrincipal(envelope)` mirroring myelin's semantics on cortex's `Envelope` type (no cross-package cast).
- `src/runner/dispatch-listener.ts:resolvePrincipalId` delegates to `getActorPrincipal()` and runs the result through `extractAgentIdFromDid` to strip `did:mf:`. Legacy `payload.agent_id` fallback preserved as called out in cortex#346 "out of scope".

### cc-events tap (producer)

- `createCcEventEnvelope` and `createCcEventPublisher` gain an optional `originatorPrincipal` knob. When set, every relay-lifted CC envelope carries `originator: { principal, attribution: "adapter-resolved" }`.
- `cortex-relay start` CLI: new `--originator-principal <did>` flag + `CORTEX_ORIGINATOR_PRINCIPAL` env var. Opt-in; omit to preserve pre-#346 wire format.

### Discord / Mattermost / Mock adapters

No behaviour change in this PR. The in-tree publish paths today are `system.access.denied` (untrusted-bot audit — `principalId` is `discord:<author_id>`, not a DID) and `system.adapter.*` lifecycle envelopes. Adding an `originator` block to a deny-audit envelope where the principal is by definition non-myelin would fail schema validation (`DID_RE`). Wiring `originator` onto these adapters belongs with whichever component eventually builds `dispatch.task.received` for inbound platform traffic — out of scope. Flagged so it's traceable for a follow-up.

### Schema + vendor

- `src/bus/myelin/vendor/envelope.schema.json` re-vendored from the new myelin tip.
- `SCHEMA_SOURCE_COMMIT` bumped to `3ec0ace…`; drift-guard test updated.
- Cortex's vendored `Envelope` type extended with `originator?: Originator` to stay one-type-system across bus emit/consume.

### Tamper protection

`originator` is in myelin's `SIGNABLE_FIELDS` post-#161 — any mutation after signing invalidates the chain, caught at `verifySignedByChain` upstream. Pinned by a new crypto test in `dispatch-listener.test.ts`.

### Version

- `arc-manifest.yaml`: 2.0.5 → 2.0.6.
- No in-tree `RELEASE.md` (repo convention is GitHub Releases + arc-manifest bumps — see v2.0.4 cut at `1f7f0ba`).

## Test plan

- [x] `bunx tsc --noEmit` — clean for this PR (3 pre-existing errors on main unrelated to originator wiring: `review-roundtrip.integration.test.ts` ×2 + `registry.test.ts` ×1).
- [x] `bun test` — 3395 pass, 0 fail (2 pre-existing skips).
- [x] `dispatch-listener.test.ts` — 4 new tests: originator precedence over signer chain, legacy signed_by fallback, payload.agent_id fallback, post-sign originator tamper → `chain_verification_failed` deny.
- [x] `cc-events.test.ts` — 5 new tests: omit-by-default, originator block shape, schema-validity with originator, publisher passthrough across multiple events, opt-out path.
- [x] `envelope-validator.test.ts` — 3 new `getActorPrincipal` tests + updated `SCHEMA_SOURCE_COMMIT` drift guard.

## Follow-up (out of scope)

- Wire `originator` onto dispatch envelopes for Discord / Mattermost inbound traffic when the dispatch-builder lands in cortex (pilot side / Phase D federation surface). Today those adapters don't publish dispatch envelopes themselves.
- `attribution: 'federated'` plumbing for surface-router cross-operator forwards (Phase D / future). `'delegated'` for service-principal flows (future).

🤖 Generated with [Claude Code](https://claude.com/claude-code)