### PR TITLE
feat(bus): chat-path CC failure retry (closes #360) — v2.0.7

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,13 @@
+# Cortex Release Notes
+
+## v2.0.7 — chat-path CC failure retry
+
+Chat-dispatch (Discord / Mattermost `@mention` and DM) now retries transient
+CC failures up to 3 total attempts before surfacing the apology message,
+mirroring the `not_now` / `cant_do` / `wont_do` / `policy_denied` nak
+taxonomy that the review-consumer path already enforced. Failure
+classification is lifted out of `review-pipeline.ts` into a shared
+`cc-failure-classifier.ts` helper; review-consumer behaviour is preserved
+byte-for-byte. Operator sees `Still working… (attempt N/3)` between retries
+and a `dispatch.task.failed` envelope is emitted on terminal failure for
+cross-path observability parity. Closes cortex#360.

--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -2,11 +2,7 @@
 # See: https://github.com/the-metafactory/arc
 
 name: "Cortex"
-<<<<<<< HEAD
-version: "2.0.6"
-=======
 version: "2.0.7"
->>>>>>> 52ddcb8 (feat(bus): chat-path CC failure retry (closes #360) — v2.0.7)
 type: component
 tier: community
 description: "Layer-7 collaboration surface for the metafactory ecosystem — the M7 application that consumes the Myelin stack"

--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -2,7 +2,11 @@
 # See: https://github.com/the-metafactory/arc
 
 name: "Cortex"
+<<<<<<< HEAD
 version: "2.0.6"
+=======
+version: "2.0.7"
+>>>>>>> 52ddcb8 (feat(bus): chat-path CC failure retry (closes #360) — v2.0.7)
 type: component
 tier: community
 description: "Layer-7 collaboration surface for the metafactory ecosystem — the M7 application that consumes the Myelin stack"

--- a/src/bus/__tests__/dispatch-handler.test.ts
+++ b/src/bus/__tests__/dispatch-handler.test.ts
@@ -6,6 +6,11 @@ import type { BotConfig } from "../../common/types/config";
 import type { Envelope } from "../myelin/envelope-validator";
 import type { MyelinRuntime } from "../myelin/runtime";
 import { validateEnvelope } from "../myelin/envelope-validator";
+import type {
+  CCSessionFactory,
+  CCSessionLike,
+} from "../../substrates/claude-code/harness";
+import type { CCSessionResult, CCSessionOpts } from "../../runner/cc-session";
 
 // Minimal config that satisfies BotConfig shape for testing
 function makeConfig(overrides: Partial<BotConfig> = {}): BotConfig {
@@ -549,6 +554,336 @@ describe("DispatchHandler — system.inbound.aborted emission (MIG-3.8 / C-104)"
     for (const env of runtime.publishes) {
       expect(validateEnvelope(env).ok).toBe(true);
     }
+
+    await handler.shutdown();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cortex#360 — Chat-path CC failure retry. The dispatch-handler's sync path
+// used to die on the first CC timeout, surfacing a single apology with no
+// retry. We now retry transient (`not_now`) failures up to 3 attempts within
+// a 20-minute wall-clock budget, posting "Still working…" between attempts.
+// Terminal failures emit a `dispatch.task.failed` envelope for cross-path
+// observability parity with the review-consumer path.
+// ---------------------------------------------------------------------------
+
+/** Build a CCSessionLike fake that resolves to a fixed CCSessionResult. */
+function makeFakeSession(result: CCSessionResult): CCSessionLike {
+  const fake: CCSessionLike = {
+    start() {
+      return fake;
+    },
+    wait() {
+      return Promise.resolve(result);
+    },
+  };
+  return fake;
+}
+
+/** Factory that yields a different CCSessionResult per attempt. */
+function makeStubFactory(results: CCSessionResult[]): {
+  factory: CCSessionFactory;
+  spawnCount: () => number;
+  optsLog: () => CCSessionOpts[];
+} {
+  let index = 0;
+  const log: CCSessionOpts[] = [];
+  const factory: CCSessionFactory = (opts) => {
+    log.push(opts);
+    const result = results[index] ?? results[results.length - 1];
+    if (!result) {
+      throw new Error("makeStubFactory: results array is empty");
+    }
+    index++;
+    return makeFakeSession(result);
+  };
+  return {
+    factory,
+    spawnCount: () => index,
+    optsLog: () => log,
+  };
+}
+
+function abortedResult(overrides: Partial<CCSessionResult> = {}): CCSessionResult {
+  return {
+    success: false,
+    response: "",
+    exitCode: 1,
+    durationMs: 5_000,
+    aborted: true,
+    abortReason: "timeout",
+    ...overrides,
+  };
+}
+
+function successResult(overrides: Partial<CCSessionResult> = {}): CCSessionResult {
+  return {
+    success: true,
+    response: "All good — here's your answer.",
+    exitCode: 0,
+    durationMs: 1_000,
+    sessionId: "sess-123",
+    ...overrides,
+  };
+}
+
+describe("DispatchHandler — chat-path CC failure retry (cortex#360)", () => {
+  let originalWarn: typeof console.warn;
+  let originalError: typeof console.error;
+  let originalLog: typeof console.log;
+
+  beforeEach(() => {
+    originalWarn = console.warn;
+    originalError = console.error;
+    originalLog = console.log;
+    console.warn = () => {};
+    console.error = () => {};
+    console.log = () => {};
+  });
+
+  afterEach(() => {
+    console.warn = originalWarn;
+    console.error = originalError;
+    console.log = originalLog;
+  });
+
+  test("retry-then-success: aborts on attempt 1, succeeds on attempt 2", async () => {
+    const runtime = makeRecordingRuntime();
+    const { factory, spawnCount } = makeStubFactory([
+      abortedResult(),
+      successResult({ response: "Recovered on retry — here's your answer." }),
+    ]);
+
+    const adapter = new MockAdapter();
+    const handler = new DispatchHandler({
+      config: makeConfig(),
+      securityPreamble: "",
+      runtime,
+      systemEventSource: { org: "metafactory", agent: "cortex", instance: "local" },
+      ccSessionFactory: factory,
+    });
+
+    await handler.handleMessage(adapter, makeMsg({ content: "do the thing" }));
+
+    // Two CC spawns: the failing first attempt and the recovering second.
+    expect(spawnCount()).toBe(2);
+
+    // Operator-visible messages: one "Still working… (attempt 2/3)" then the
+    // final response. No apology message.
+    const texts = adapter.sentMessages.map((m) => m.text);
+    expect(texts.length).toBe(2);
+    expect(texts[0]).toBe("Still working… (attempt 2/3)");
+    expect(texts[1]).toBe("Recovered on retry — here's your answer.");
+    expect(texts.some((t) => t.startsWith("Sorry, I couldn't process"))).toBe(false);
+
+    // No dispatch.task.failed envelope on a recovered run.
+    const failed = runtime.publishes.filter(
+      (e) => e.type === "dispatch.task.failed",
+    );
+    expect(failed.length).toBe(0);
+
+    await handler.shutdown();
+  });
+
+  test("all-three-attempts-fail: emits dispatch.task.failed with kind=not_now", async () => {
+    const runtime = makeRecordingRuntime();
+    const { factory, spawnCount } = makeStubFactory([
+      abortedResult(),
+      abortedResult(),
+      abortedResult(),
+    ]);
+
+    const adapter = new MockAdapter();
+    const handler = new DispatchHandler({
+      config: makeConfig(),
+      securityPreamble: "",
+      runtime,
+      systemEventSource: { org: "metafactory", agent: "cortex", instance: "local" },
+      ccSessionFactory: factory,
+    });
+
+    await handler.handleMessage(adapter, makeMsg({ content: "do the thing" }));
+
+    // Three CC spawns total.
+    expect(spawnCount()).toBe(3);
+
+    const texts = adapter.sentMessages.map((m) => m.text);
+    // Two "Still working…" status messages (before attempts 2 and 3), then
+    // the final apology. No success message.
+    expect(texts).toEqual([
+      "Still working… (attempt 2/3)",
+      "Still working… (attempt 3/3)",
+      "Sorry, I couldn't process that. (exit code: 1)",
+    ]);
+
+    // Exactly one dispatch.task.failed envelope on the bus.
+    const failed = runtime.publishes.filter(
+      (e) => e.type === "dispatch.task.failed",
+    );
+    expect(failed.length).toBe(1);
+    const env = failed[0]!;
+    expect(env.source).toBe("metafactory.cortex.local");
+    const payload = env.payload as {
+      task_id: string;
+      agent_id: string;
+      reason: { kind: string; detail?: string };
+      error_summary: string;
+    };
+    expect(payload.agent_id).toBe("test-agent");
+    expect(payload.reason.kind).toBe("not_now");
+    expect(payload.reason.detail).toContain("aborted");
+    // Stable correlation_id across the retry chain — the envelope's
+    // correlation_id is the retry chain's load-bearing observability key.
+    expect(typeof env.correlation_id).toBe("string");
+    expect(env.correlation_id?.length ?? 0).toBeGreaterThan(0);
+    // Schema-valid envelope (drift-detection against vendored myelin schema).
+    expect(validateEnvelope(env).ok).toBe(true);
+
+    await handler.shutdown();
+  });
+
+  test("clean-success-attempt-1: no retry, no extra messages, no failed envelope", async () => {
+    const runtime = makeRecordingRuntime();
+    const { factory, spawnCount } = makeStubFactory([
+      successResult({ response: "Done — no drama." }),
+    ]);
+
+    const adapter = new MockAdapter();
+    const handler = new DispatchHandler({
+      config: makeConfig(),
+      securityPreamble: "",
+      runtime,
+      systemEventSource: { org: "metafactory", agent: "cortex", instance: "local" },
+      ccSessionFactory: factory,
+    });
+
+    await handler.handleMessage(adapter, makeMsg({ content: "do the thing" }));
+
+    // Exactly one CC spawn.
+    expect(spawnCount()).toBe(1);
+
+    // Exactly one Discord message: the success response. No "Still working…",
+    // no apology.
+    expect(adapter.sentMessages.length).toBe(1);
+    expect(adapter.sentMessages[0]!.text).toBe("Done — no drama.");
+
+    // No dispatch.task.failed envelope on a clean run.
+    const failed = runtime.publishes.filter(
+      (e) => e.type === "dispatch.task.failed",
+    );
+    expect(failed.length).toBe(0);
+
+    await handler.shutdown();
+  });
+
+  test("terminal failure (cant_do) bails immediately — no retry", async () => {
+    // A non-zero exit WITH no captured response is classified as not_now
+    // (retryable). To exercise the terminal-failure-immediate-exit path we
+    // need a result whose classifier returns null — e.g. `success === true`
+    // but `!response`. That's the "cc exited cleanly but skill misbehaved"
+    // case — the chat-path treats it as cant_do (operator action needed)
+    // and surfaces the apology after attempt 1.
+    const runtime = makeRecordingRuntime();
+    const { factory, spawnCount } = makeStubFactory([
+      { success: true, response: "", exitCode: 0, durationMs: 1_000 },
+    ]);
+
+    const adapter = new MockAdapter();
+    const handler = new DispatchHandler({
+      config: makeConfig(),
+      securityPreamble: "",
+      runtime,
+      systemEventSource: { org: "metafactory", agent: "cortex", instance: "local" },
+      ccSessionFactory: factory,
+    });
+
+    await handler.handleMessage(adapter, makeMsg({ content: "do the thing" }));
+
+    // Single CC spawn — no retry on terminal failure.
+    expect(spawnCount()).toBe(1);
+
+    const texts = adapter.sentMessages.map((m) => m.text);
+    expect(texts.length).toBe(1);
+    expect(texts[0]).toBe("Sorry, I couldn't process that. (exit code: 0)");
+
+    // dispatch.task.failed with kind=cant_do.
+    const failed = runtime.publishes.filter(
+      (e) => e.type === "dispatch.task.failed",
+    );
+    expect(failed.length).toBe(1);
+    const payload = failed[0]!.payload as {
+      reason: { kind: string };
+    };
+    expect(payload.reason.kind).toBe("cant_do");
+
+    await handler.shutdown();
+  });
+
+  test("factory throws on spawn — treated as not_now, retries up to limit", async () => {
+    const runtime = makeRecordingRuntime();
+    let spawnAttempts = 0;
+    const factory: CCSessionFactory = () => {
+      spawnAttempts++;
+      throw new Error("CC binary missing");
+    };
+
+    const adapter = new MockAdapter();
+    const handler = new DispatchHandler({
+      config: makeConfig(),
+      securityPreamble: "",
+      runtime,
+      systemEventSource: { org: "metafactory", agent: "cortex", instance: "local" },
+      ccSessionFactory: factory,
+    });
+
+    await handler.handleMessage(adapter, makeMsg({ content: "do the thing" }));
+
+    // All three attempts blow up on factory spawn.
+    expect(spawnAttempts).toBe(3);
+
+    const texts = adapter.sentMessages.map((m) => m.text);
+    // Two retry-status lines + final apology.
+    expect(texts).toEqual([
+      "Still working… (attempt 2/3)",
+      "Still working… (attempt 3/3)",
+      "Sorry, I couldn't process that. (exit code: 1)",
+    ]);
+
+    // dispatch.task.failed emitted, kind=not_now.
+    const failed = runtime.publishes.filter(
+      (e) => e.type === "dispatch.task.failed",
+    );
+    expect(failed.length).toBe(1);
+    const payload = failed[0]!.payload as {
+      reason: { kind: string; detail?: string };
+    };
+    expect(payload.reason.kind).toBe("not_now");
+    expect(payload.reason.detail).toContain("CC binary missing");
+
+    await handler.shutdown();
+  });
+
+  test("maxAttempts=1 override disables retry — one attempt, immediate apology", async () => {
+    const runtime = makeRecordingRuntime();
+    const { factory, spawnCount } = makeStubFactory([abortedResult()]);
+
+    const adapter = new MockAdapter();
+    const handler = new DispatchHandler({
+      config: makeConfig(),
+      securityPreamble: "",
+      runtime,
+      systemEventSource: { org: "metafactory", agent: "cortex", instance: "local" },
+      ccSessionFactory: factory,
+      retry: { maxAttempts: 1 },
+    });
+
+    await handler.handleMessage(adapter, makeMsg({ content: "do the thing" }));
+
+    expect(spawnCount()).toBe(1);
+    const texts = adapter.sentMessages.map((m) => m.text);
+    expect(texts.length).toBe(1);
+    expect(texts[0]).toBe("Sorry, I couldn't process that. (exit code: 1)");
 
     await handler.shutdown();
   });

--- a/src/bus/dispatch-handler.ts
+++ b/src/bus/dispatch-handler.ts
@@ -26,7 +26,19 @@ import type { AttachmentInfo } from "../adapters/discord/attachment-types";
 import { parseMessageKeywords } from "../runner/message-parser";
 import { buildPrompt } from "../runner/prompt-builder";
 import { scanPrompt } from "../runner/prompt-filter";
-import { CCSession, type CCSessionOpts } from "../runner/cc-session";
+import { CCSession, type CCSessionOpts, type CCSessionResult } from "../runner/cc-session";
+import type {
+  CCSessionFactory,
+  CCSessionLike,
+} from "../substrates/claude-code/harness";
+import {
+  classifyCcFailure,
+  classifyCcSpawnError,
+} from "../runner/cc-failure-classifier";
+import {
+  createDispatchTaskFailedEvent,
+  type DispatchTaskFailedReason,
+} from "./dispatch-events";
 import { AgentTeam } from "../runner/agent-team";
 import { SessionManager } from "../runner/session-manager";
 import { TaskTracker } from "../runner/task-tracker";
@@ -91,7 +103,34 @@ export interface DispatchHandlerOpts {
    * contract).
    */
   systemEventSource?: SystemEventSource;
+  /**
+   * cortex#360 — Optional CC session factory injection. Default
+   * constructs a real `CCSession`. Tests inject a deterministic fake to
+   * drive the chat-path retry loop without spawning the real `claude`
+   * binary. Mirrors the `ClaudeCodeHarness` factory-injection pattern.
+   */
+  ccSessionFactory?: CCSessionFactory;
+  /**
+   * cortex#360 — Optional chat-path retry tuning. Default 3 total
+   * attempts (initial + 2 retries) bounded by a 20-minute wall-clock
+   * cap. Tests override the maxAttempts to shrink to 1 (no retry) or
+   * exercise specific retry counts.
+   */
+  retry?: {
+    /** Maximum total CC attempts before surfacing the apology. Default 3. */
+    maxAttempts?: number;
+    /** Total wall-clock budget in ms across all attempts. Default 20min. */
+    maxTotalMs?: number;
+  };
 }
+
+/**
+ * cortex#360 — Default retry posture for the chat dispatch path. Three
+ * total attempts (initial + 2 retries) bounded by a 20-minute wall-clock
+ * cap so a wedged CC binary can't pile up retries indefinitely.
+ */
+const DEFAULT_RETRY_MAX_ATTEMPTS = 3;
+const DEFAULT_RETRY_MAX_TOTAL_MS = 20 * 60 * 1000;
 
 /** Format a tool-use event into a human-readable progress line */
 function formatToolProgress(toolName: string, input: Record<string, unknown>): string {
@@ -144,6 +183,16 @@ export class DispatchHandler extends EventEmitter {
    * `warnedMissingSource` pattern.
    */
   private warnedMissingSource = false;
+  /**
+   * cortex#360 — CC session factory. Default constructs a real CCSession
+   * that spawns `claude`. Tests inject a fake for deterministic retry
+   * loop behaviour. Stable across attempts so each retry uses the same
+   * factory (only the `CCSession` instance is fresh per attempt).
+   */
+  private readonly ccSessionFactory: CCSessionFactory;
+  /** cortex#360 — Chat-path retry config (maxAttempts + wall-clock cap). */
+  private readonly retryMaxAttempts: number;
+  private readonly retryMaxTotalMs: number;
 
   constructor(opts: DispatchHandlerOpts) {
     super();
@@ -157,6 +206,9 @@ export class DispatchHandler extends EventEmitter {
         });
     this.runtime = opts.runtime;
     this.systemEventSource = opts.systemEventSource;
+    this.ccSessionFactory = opts.ccSessionFactory ?? ((sessionOpts) => new CCSession(sessionOpts));
+    this.retryMaxAttempts = opts.retry?.maxAttempts ?? DEFAULT_RETRY_MAX_ATTEMPTS;
+    this.retryMaxTotalMs = opts.retry?.maxTotalMs ?? DEFAULT_RETRY_MAX_TOTAL_MS;
     this.sessions = new SessionManager({ idleTimeoutMs: 10 * 60 * 1000 });
     this.taskTracker = new TaskTracker();
 
@@ -235,6 +287,54 @@ export class DispatchHandler extends EventEmitter {
     void wiring.runtime.publish(env).catch((err: unknown) => {
       console.error(
         "dispatch-handler: publish(system.inbound.aborted) failed:",
+        err instanceof Error ? err.message : String(err),
+      );
+    });
+  }
+
+  /**
+   * cortex#360 — Publish a `dispatch.task.failed` envelope for the chat
+   * dispatch path after all retry attempts have been exhausted (or the
+   * failure was terminal-on-first-attempt). Mirrors the review-consumer
+   * path's failure-envelope emission so observers (worklog-manager,
+   * dashboard, pilot-side subscribers) get the same cross-path observability.
+   *
+   * Fire-and-forget: errors from `runtime.publish` are swallowed + logged
+   * so a bus outage can't break the apology-to-Discord response path.
+   * The operator still sees "Sorry, I couldn't process that" — the
+   * envelope is the structured-observability sibling.
+   */
+  private publishDispatchTaskFailed(opts: {
+    taskId: string;
+    correlationId: string;
+    startedAt: Date;
+    reason: DispatchTaskFailedReason;
+    errorSummary: string;
+  }): void {
+    const wiring = this.canPublishSystemEvent();
+    if (!wiring) return;
+    let env;
+    try {
+      env = createDispatchTaskFailedEvent({
+        source: wiring.source,
+        taskId: opts.taskId,
+        agentId: this.config.agent.name,
+        correlationId: opts.correlationId,
+        startedAt: opts.startedAt,
+        failedAt: new Date(),
+        errorSummary: opts.errorSummary,
+        reason: opts.reason,
+      });
+    } catch (err) {
+      console.error(
+        "dispatch-handler: createDispatchTaskFailedEvent threw:",
+        err instanceof Error ? err.message : String(err),
+      );
+      return;
+    }
+    void wiring.runtime.publish(env).catch((err: unknown) => {
+      console.error(
+        "dispatch-handler: publish(dispatch.task.failed) failed:",
         err instanceof Error ? err.message : String(err),
       );
     });
@@ -525,7 +625,30 @@ export class DispatchHandler extends EventEmitter {
   ): Promise<void> {
     const target = this.targetFromMsg(adapter, msg);
 
-    const session = new CCSession({
+    // cortex#360 — Chat-path retry loop. The CC failure-classification +
+    // retry plumbing previously lived only in the review-consumer path
+    // (JetStream-pull with `max_deliver=5`). Chat dispatches used to die
+    // on the first CC inactivity timeout, surfacing a single apology
+    // with no retry. We now retry transient (`not_now`) failures up to
+    // `retryMaxAttempts` times within a `retryMaxTotalMs` wall-clock
+    // budget, posting "Still working…" between attempts so the operator
+    // sees the bot didn't ghost. Terminal failures (any non-`not_now`
+    // reason, or the final retry) emit `dispatch.task.failed` for
+    // cross-path observability parity.
+    const taskId = randomUUID();
+    const correlationId = randomUUID();
+    const startedAt = new Date();
+
+    // Typing indicator — shared across attempts; the bot is "still
+    // typing" for the whole retry window from the operator's POV.
+    await adapter.sendTyping(target);
+    const typingInterval = setInterval(() => {
+      adapter.sendTyping(target).catch(() => {
+        // best-effort typing indicator; swallow Discord API errors
+      });
+    }, 8_000);
+
+    const sessionOpts: CCSessionOpts = {
       prompt,
       groveChannel: groveChannel,
       groveNetwork: groveNetwork,
@@ -543,29 +666,128 @@ export class DispatchHandler extends EventEmitter {
       project: groveProject,
       entity: groveEntity,
       operator: groveOperator,
-    });
+    };
 
-    // Typing indicator
-    await adapter.sendTyping(target);
-    const typingInterval = setInterval(() => {
-      adapter.sendTyping(target).catch(() => {
-        // best-effort typing indicator; swallow Discord API errors
-      });
-    }, 8_000);
+    let finalResult: CCSessionResult | null = null;
+    let finalReason: DispatchTaskFailedReason | null = null;
+    let attemptsConsumed = 0;
 
-    // Tool-use progress (single edit-in-place message, cleared on result)
-    session.on("tool-use", (toolName: string, toolInput: Record<string, unknown>) => {
-      void (async () => {
-        const detail = formatToolProgress(toolName, toolInput);
-        await adapter.sendProgress(target, detail);
-      })();
-    });
+    try {
+      for (let attempt = 1; attempt <= this.retryMaxAttempts; attempt++) {
+        attemptsConsumed = attempt;
 
-    const result = await session.start().wait();
-    clearInterval(typingInterval);
-    await adapter.clearProgress(target);
+        // Wall-clock guard — once we've burnt the total budget, stop
+        // even if attempts remain. Bounds the wedged-binary case so a
+        // retry storm can't pile up indefinitely.
+        const elapsed = Date.now() - startedAt.getTime();
+        if (elapsed > this.retryMaxTotalMs) {
+          finalReason = {
+            kind: "not_now",
+            detail: `retry budget exhausted: ${elapsed}ms > ${this.retryMaxTotalMs}ms (attempt ${attempt}/${this.retryMaxAttempts})`,
+            retry_after_ms: 0,
+          };
+          break;
+        }
 
-    if (result.success && result.response) {
+        // Build a fresh CC session per attempt. Each retry uses the
+        // same correlation_id (stable for observers stitching the
+        // retry chain) but a brand new substrate process.
+        let session: CCSessionLike;
+        try {
+          session = this.ccSessionFactory(sessionOpts);
+        } catch (err) {
+          finalReason = classifyCcSpawnError(err);
+          console.warn(
+            `dispatch-handler: cc spawn failed on attempt ${attempt}/${this.retryMaxAttempts} (correlation_id=${correlationId}): ${finalReason.kind === "not_now" ? finalReason.detail : String(err)}`,
+          );
+          if (finalReason.kind === "not_now" && attempt < this.retryMaxAttempts) {
+            await this.postRetryStatus(adapter, target, attempt + 1);
+            continue;
+          }
+          break;
+        }
+
+        // Tool-use progress (single edit-in-place message, cleared on
+        // result). Attached per-attempt because each session is fresh.
+        // CCSessionLike's optional EventEmitter shape is exposed via
+        // the substrate harness contract — only attach when present.
+        const sessionAsEmitter = session as unknown as {
+          on?: (event: string, listener: (...args: unknown[]) => void) => void;
+        };
+        if (typeof sessionAsEmitter.on === "function") {
+          sessionAsEmitter.on("tool-use", (toolName: unknown, toolInput: unknown) => {
+            const name = typeof toolName === "string" ? toolName : "tool";
+            const input = (typeof toolInput === "object" && toolInput !== null)
+              ? toolInput as Record<string, unknown>
+              : {};
+            void (async () => {
+              const detail = formatToolProgress(name, input);
+              await adapter.sendProgress(target, detail);
+            })();
+          });
+        }
+
+        let result: CCSessionResult;
+        try {
+          result = await session.start().wait();
+        } catch (err) {
+          // Async rejection from wait() — same not_now bucket as
+          // synchronous spawn throw per `cc-failure-classifier`.
+          finalReason = classifyCcSpawnError(err);
+          console.warn(
+            `dispatch-handler: cc wait() rejected on attempt ${attempt}/${this.retryMaxAttempts} (correlation_id=${correlationId}): ${finalReason.kind === "not_now" ? finalReason.detail : String(err)}`,
+          );
+          if (finalReason.kind === "not_now" && attempt < this.retryMaxAttempts) {
+            await this.postRetryStatus(adapter, target, attempt + 1);
+            continue;
+          }
+          break;
+        }
+
+        finalResult = result;
+
+        // Success path — clean response. Reset any failure reason so
+        // we emit no `dispatch.task.failed` envelope.
+        if (result.success && result.response) {
+          finalReason = null;
+          break;
+        }
+
+        // Classify the failure. `null` from the classifier means "no
+        // substrate failure detected" — e.g. `success && !response`
+        // or `!success && response.trim() !== ""`. Treat as terminal
+        // `cant_do` (skill exited without giving us output to forward
+        // or got partway and crashed); no retry — operator action
+        // needed (re-prompt with different inputs).
+        const classified = classifyCcFailure(result);
+        if (classified === null) {
+          finalReason = {
+            kind: "cant_do",
+            detail: `cc session exited ${result.exitCode} without a clean response`,
+          };
+          break;
+        }
+        finalReason = classified;
+
+        if (finalReason.kind === "not_now" && attempt < this.retryMaxAttempts) {
+          console.log(
+            `dispatch-handler: cc transient failure on attempt ${attempt}/${this.retryMaxAttempts} (correlation_id=${correlationId}): ${finalReason.detail}`,
+          );
+          await this.postRetryStatus(adapter, target, attempt + 1);
+          continue;
+        }
+
+        // Terminal failure (non-not_now kind, or last attempt). Fall
+        // through to the post-loop apology + envelope emission.
+        break;
+      }
+    } finally {
+      clearInterval(typingInterval);
+      await adapter.clearProgress(target);
+    }
+
+    // Terminal success — post the response and forward usage.
+    if (finalResult && finalResult.success && finalResult.response && finalReason === null) {
       const outputFiles = collectOutputFiles(attachmentSessionId);
       const files = outputFiles.length > 0
         ? await Promise.all(outputFiles.map(async (p) => ({
@@ -573,24 +795,75 @@ export class DispatchHandler extends EventEmitter {
             filename: basename(p),
           })))
         : undefined;
-      await adapter.postResponse(target, result.response, files);
+      await adapter.postResponse(target, finalResult.response, files);
 
-      if (useSession && result.sessionId) {
-        this.sessions.setSession(sessionKey, result.sessionId);
-        console.log(`dispatch-handler: ${resumeSessionId ? "resumed" : "new"} session ${result.sessionId} for ${sessionKey}`);
+      if (useSession && finalResult.sessionId) {
+        this.sessions.setSession(sessionKey, finalResult.sessionId);
+        console.log(`dispatch-handler: ${resumeSessionId ? "resumed" : "new"} session ${finalResult.sessionId} for ${sessionKey}`);
       }
-    } else {
-      await adapter.postResponse(target, `Sorry, I couldn't process that. (exit code: ${result.exitCode})`);
+
+      if (finalResult.usage) {
+        console.log(`dispatch-handler: responded in ${finalResult.durationMs}ms (${finalResult.usage.inputTokens}in/${finalResult.usage.outputTokens}out${finalResult.usage.costUsd ? ` $${finalResult.usage.costUsd.toFixed(4)}` : ""})${attemptsConsumed > 1 ? ` after ${attemptsConsumed} attempts` : ""}`);
+        // G-206: Forward usage to dashboard state
+        if (finalResult.sessionId) {
+          this.emit("session-usage", finalResult.sessionId, finalResult.usage);
+        }
+      } else {
+        console.log(`dispatch-handler: responded in ${finalResult.durationMs}ms${attemptsConsumed > 1 ? ` after ${attemptsConsumed} attempts` : ""}`);
+      }
+      return;
     }
 
-    if (result.usage) {
-      console.log(`dispatch-handler: responded in ${result.durationMs}ms (${result.usage.inputTokens}in/${result.usage.outputTokens}out${result.usage.costUsd ? ` $${result.usage.costUsd.toFixed(4)}` : ""})`);
-      // G-206: Forward usage to dashboard state
-      if (result.sessionId) {
-        this.emit("session-usage", result.sessionId, result.usage);
-      }
-    } else {
-      console.log(`dispatch-handler: responded in ${result.durationMs}ms`);
+    // Terminal failure — post apology + emit dispatch.task.failed.
+    const exitCode = finalResult?.exitCode ?? 1;
+    await adapter.postResponse(target, `Sorry, I couldn't process that. (exit code: ${exitCode})`);
+
+    // Build a reason if we have none (defensive — every loop exit sets
+    // finalReason on a failure path, but TypeScript can't prove it).
+    const reasonForEnvelope: DispatchTaskFailedReason = finalReason ?? {
+      kind: "not_now",
+      detail: `cc session failed (exit ${exitCode}, attempts ${attemptsConsumed}/${this.retryMaxAttempts})`,
+      retry_after_ms: 0,
+    };
+    const errorSummary =
+      reasonForEnvelope.kind === "policy_denied"
+        ? `chat-path policy denied after ${attemptsConsumed} attempt(s)`
+        : `${reasonForEnvelope.detail} (after ${attemptsConsumed}/${this.retryMaxAttempts} attempts)`;
+    this.publishDispatchTaskFailed({
+      taskId,
+      correlationId,
+      startedAt,
+      reason: reasonForEnvelope,
+      errorSummary,
+    });
+  }
+
+  /**
+   * cortex#360 — Post a "Still working… (attempt N/M)" status to the
+   * adapter before each retry so the operator sees the bot is still
+   * alive. Uses the same `postResponse` surface as the final apology;
+   * adapters render these as ordinary messages (Discord follow-ups,
+   * Mattermost replies) so there's no special channel.
+   *
+   * Failures from `postResponse` are logged but not propagated — the
+   * retry loop continues even if the status message fails to post
+   * (Discord 5xx, rate limit, etc.).
+   */
+  private async postRetryStatus(
+    adapter: PlatformAdapter,
+    target: ResponseTarget,
+    nextAttempt: number,
+  ): Promise<void> {
+    try {
+      await adapter.postResponse(
+        target,
+        `Still working… (attempt ${nextAttempt}/${this.retryMaxAttempts})`,
+      );
+    } catch (err) {
+      console.warn(
+        "dispatch-handler: postRetryStatus failed:",
+        err instanceof Error ? err.message : String(err),
+      );
     }
   }
 

--- a/src/bus/dispatch-handler.ts
+++ b/src/bus/dispatch-handler.ts
@@ -296,8 +296,15 @@ export class DispatchHandler extends EventEmitter {
    * cortex#360 — Publish a `dispatch.task.failed` envelope for the chat
    * dispatch path after all retry attempts have been exhausted (or the
    * failure was terminal-on-first-attempt). Mirrors the review-consumer
-   * path's failure-envelope emission so observers (worklog-manager,
-   * dashboard, pilot-side subscribers) get the same cross-path observability.
+   * path's `dispatch.task.failed` emission so observers (worklog-manager,
+   * dashboard, pilot-side subscribers) see the same structured failure
+   * shape regardless of which path produced it.
+   *
+   * **Scope honestly stated:** this is **failure-path observability
+   * parity**, NOT full lifecycle parity. The chat-dispatch path does not
+   * (yet) emit `dispatch.task.started` / `.completed` / `.aborted` —
+   * those are tracked in cortex#365 as a separate feature. Successful
+   * chat dispatches remain invisible on the bus until that lands.
    *
    * Fire-and-forget: errors from `runtime.publish` are swallowed + logged
    * so a bus outage can't break the apology-to-Discord response path.
@@ -634,7 +641,10 @@ export class DispatchHandler extends EventEmitter {
     // budget, posting "Still working…" between attempts so the operator
     // sees the bot didn't ghost. Terminal failures (any non-`not_now`
     // reason, or the final retry) emit `dispatch.task.failed` for
-    // cross-path observability parity.
+    // failure-path observability parity with the review-consumer path.
+    // Full lifecycle parity (`.started` / `.completed` / `.aborted`) is
+    // tracked separately in cortex#365 — successful chat dispatches
+    // remain invisible on the bus until that ships.
     const taskId = randomUUID();
     const correlationId = randomUUID();
     const startedAt = new Date();

--- a/src/bus/dispatch-handler.ts
+++ b/src/bus/dispatch-handler.ts
@@ -719,8 +719,14 @@ export class DispatchHandler extends EventEmitter {
 
         // Tool-use progress (single edit-in-place message, cleared on
         // result). Attached per-attempt because each session is fresh.
-        // CCSessionLike's optional EventEmitter shape is exposed via
-        // the substrate harness contract — only attach when present.
+        // The `on()` shape is NOT declared on `CCSessionLike` (see
+        // cortex#364 for the planned widening); the real `CCSession`
+        // extends EventEmitter and emits `tool-use`, but the substrate
+        // contract is currently silent on this — the double-cast below
+        // bridges that gap. Only attach when present.
+        // TODO(cortex#364): remove double-cast once CCSessionLike
+        // declares optional `on()` — see #364 for the two proposed shapes
+        // (extend interface vs. emitter-shape adapter helper).
         const sessionAsEmitter = session as unknown as {
           on?: (event: string, listener: (...args: unknown[]) => void) => void;
         };

--- a/src/runner/__tests__/cc-failure-classifier.test.ts
+++ b/src/runner/__tests__/cc-failure-classifier.test.ts
@@ -1,0 +1,151 @@
+import { describe, test, expect } from "bun:test";
+import {
+  classifyCcFailure,
+  classifyCcSpawnError,
+} from "../cc-failure-classifier";
+import type { CCSessionResult } from "../cc-session";
+
+/**
+ * cortex#360 — Unit tests for the shared CC failure classifier.
+ *
+ * The classifier is the lifted-and-shared form of the four-way nak
+ * mapping that previously lived inline in `review-pipeline.ts:244-298`.
+ * Both the review-consumer path (JetStream pull) and the chat dispatch
+ * path (Discord/Mattermost adapter) now consume it; tests here pin the
+ * mapping table from `review-pipeline.ts`'s file header so any future
+ * change to the taxonomy fails loudly at this seam rather than silently
+ * diverging across the two paths.
+ */
+
+function successResult(overrides: Partial<CCSessionResult> = {}): CCSessionResult {
+  return {
+    success: true,
+    response: "verdict body",
+    exitCode: 0,
+    durationMs: 1000,
+    ...overrides,
+  };
+}
+
+describe("classifyCcFailure", () => {
+  test("clean success returns null (no classification needed)", () => {
+    const result = successResult();
+    expect(classifyCcFailure(result)).toBeNull();
+  });
+
+  test("aborted (inactivity timeout) maps to not_now", () => {
+    const result: CCSessionResult = {
+      success: false,
+      response: "",
+      exitCode: 1,
+      durationMs: 5_000,
+      aborted: true,
+      abortReason: "timeout",
+    };
+    const reason = classifyCcFailure(result);
+    expect(reason).not.toBeNull();
+    expect(reason?.kind).toBe("not_now");
+    if (reason?.kind === "not_now") {
+      expect(reason.detail).toContain("aborted");
+      expect(reason.detail).toContain("timeout");
+      expect(reason.retry_after_ms).toBe(0);
+    }
+  });
+
+  test("aborted without explicit abortReason still maps to not_now with default reason", () => {
+    const result: CCSessionResult = {
+      success: false,
+      response: "",
+      exitCode: 1,
+      durationMs: 5_000,
+      aborted: true,
+    };
+    const reason = classifyCcFailure(result);
+    expect(reason?.kind).toBe("not_now");
+    if (reason?.kind === "not_now") {
+      expect(reason.detail).toContain("aborted");
+    }
+  });
+
+  test("non-zero exit with no response maps to not_now", () => {
+    const result: CCSessionResult = {
+      success: false,
+      response: "",
+      exitCode: 1,
+      durationMs: 5_000,
+    };
+    const reason = classifyCcFailure(result);
+    expect(reason?.kind).toBe("not_now");
+    if (reason?.kind === "not_now") {
+      expect(reason.detail).toContain("exited 1");
+      expect(reason.detail).toContain("no output");
+      expect(reason.retry_after_ms).toBe(0);
+    }
+  });
+
+  test("non-zero exit with response treated as clean (classifier returns null)", () => {
+    // Skill emitted a verdict block then crashed late; review-pipeline §4.5
+    // treats this as a parseable-verdict path, so the classifier should not
+    // claim a substrate failure. The downstream caller decides what to do
+    // with the body.
+    const result: CCSessionResult = {
+      success: false,
+      response: "some text",
+      exitCode: 1,
+      durationMs: 5_000,
+    };
+    expect(classifyCcFailure(result)).toBeNull();
+  });
+
+  test("aborted takes precedence over success flag", () => {
+    // Defensive: success=true + aborted=true would be a CCSession bug, but
+    // the classifier should still detect the abort.
+    const result: CCSessionResult = {
+      success: true,
+      response: "",
+      exitCode: 0,
+      durationMs: 5_000,
+      aborted: true,
+      abortReason: "timeout",
+    };
+    const reason = classifyCcFailure(result);
+    expect(reason?.kind).toBe("not_now");
+  });
+});
+
+describe("classifyCcSpawnError", () => {
+  test("Error instance maps to not_now with message in detail", () => {
+    const reason = classifyCcSpawnError(new Error("CC binary not found"));
+    expect(reason.kind).toBe("not_now");
+    if (reason.kind === "not_now") {
+      expect(reason.detail).toContain("cc session error");
+      expect(reason.detail).toContain("CC binary not found");
+      expect(reason.retry_after_ms).toBe(0);
+    }
+  });
+
+  test("non-Error throwable stringified into detail", () => {
+    const reason = classifyCcSpawnError("oops");
+    expect(reason.kind).toBe("not_now");
+    if (reason.kind === "not_now") {
+      expect(reason.detail).toContain("oops");
+    }
+  });
+});
+
+describe("classification stability", () => {
+  test("isTransient helper agrees with classifier kind", () => {
+    // The retry-eligible kind is not_now; everything else is terminal.
+    // This pins the contract that the chat-path retry loop consumes.
+    const transientResult: CCSessionResult = {
+      success: false,
+      response: "",
+      exitCode: 1,
+      durationMs: 5_000,
+      aborted: true,
+      abortReason: "timeout",
+    };
+    const reason = classifyCcFailure(transientResult);
+    expect(reason?.kind).toBe("not_now");
+  });
+});

--- a/src/runner/__tests__/cc-failure-classifier.test.ts
+++ b/src/runner/__tests__/cc-failure-classifier.test.ts
@@ -2,6 +2,7 @@ import { describe, test, expect } from "bun:test";
 import {
   classifyCcFailure,
   classifyCcSpawnError,
+  isTransientFailure,
 } from "../cc-failure-classifier";
 import type { CCSessionResult } from "../cc-session";
 
@@ -134,9 +135,15 @@ describe("classifyCcSpawnError", () => {
 });
 
 describe("classification stability", () => {
-  test("isTransient helper agrees with classifier kind", () => {
+  test("isTransientFailure helper agrees with classifier kind", () => {
     // The retry-eligible kind is not_now; everything else is terminal.
     // This pins the contract that the chat-path retry loop consumes.
+    // Echo r3 review on cortex#360: the previous shape of this test
+    // asserted only the classifier output and never actually called
+    // `isTransientFailure`, which left the helper-classifier coupling
+    // untested. We now call BOTH so a future divergence between the
+    // classifier and the helper (e.g. adding a new transient kind to
+    // one but not the other) fails here loudly.
     const transientResult: CCSessionResult = {
       success: false,
       response: "",
@@ -146,6 +153,26 @@ describe("classification stability", () => {
       abortReason: "timeout",
     };
     const reason = classifyCcFailure(transientResult);
+    expect(reason).not.toBeNull();
     expect(reason?.kind).toBe("not_now");
+    // Helper agrees: transient classification → retryable.
+    if (reason !== null) {
+      expect(isTransientFailure(reason)).toBe(true);
+    }
+  });
+
+  test("isTransientFailure returns false for terminal kinds", () => {
+    // Pins the inverse direction: every non-`not_now` kind is terminal.
+    // Mirrors the four-way nak taxonomy from `architecture.md` §7.3.
+    expect(isTransientFailure({ kind: "cant_do", detail: "skill misbehaved" })).toBe(false);
+    expect(isTransientFailure({ kind: "wont_do", detail: "policy refused" })).toBe(false);
+    expect(isTransientFailure({ kind: "compliance_block", detail: "attestation forbidden" })).toBe(false);
+    expect(isTransientFailure({ kind: "policy_denied", deny: { reason: "unknown_principal" } })).toBe(false);
+  });
+
+  test("isTransientFailure returns true for spawn-error classifications", () => {
+    // classifyCcSpawnError always returns not_now → the helper agrees.
+    const reason = classifyCcSpawnError(new Error("CC binary missing"));
+    expect(isTransientFailure(reason)).toBe(true);
   });
 });

--- a/src/runner/cc-failure-classifier.ts
+++ b/src/runner/cc-failure-classifier.ts
@@ -1,0 +1,137 @@
+/**
+ * cortex#360 — Shared CC failure classifier.
+ *
+ * Lifts the four-way nak taxonomy mapping previously inlined in
+ * `review-pipeline.ts:244-298` into a single shared helper. Two call
+ * sites consume it:
+ *
+ *   1. `review-pipeline.ts` — the JetStream-pull `tasks.code-review.*`
+ *      consumer path (review-consumer path).
+ *   2. `dispatch-handler.ts` — the chat dispatch path that adapters
+ *      (Discord, Mattermost) drive on inbound `@mention` / DM. This
+ *      path now retries `not_now` failures up to 3 attempts before
+ *      surfacing the apology to the operator (cortex#360 acceptance
+ *      criteria).
+ *
+ * **What this module IS:**
+ *   - A pure function. No I/O, no state, no side effects.
+ *   - The canonical mapping from `CCSessionResult` shape to
+ *     `DispatchTaskFailedReason` for the substrate-side error modes
+ *     (`aborted`, `exit non-zero with no output`, factory-throw on spawn).
+ *
+ * **What this module is NOT:**
+ *   - NOT a verdict-block parser. That stays in `review-pipeline.ts`
+ *     where the `cant_do` cases (skill didn't emit a block, JSON parse
+ *     failed, schema violations) are decided.
+ *   - NOT a policy gate. `wont_do` decisions come from the optional
+ *     `policyCheck` hook in `review-pipeline.ts`, not from the result
+ *     shape.
+ *   - NOT a retry executor. The chat-path retry loop lives in
+ *     `dispatch-handler.ts`; this module just answers "is this failure
+ *     retryable?" via `reason.kind === 'not_now'`.
+ *
+ * **Anchors:**
+ *   - `docs/architecture.md` §7.3 — canonical nak vocabulary.
+ *   - `docs/design-pilot-restructure.md` §4.4 — pilot-side nak consumption.
+ *   - `review-pipeline.ts` file header — original mapping table.
+ *
+ * **Spec preservation:** The body of this module is the verbatim logic
+ * from `review-pipeline.ts:244-298`. The review-consumer path's
+ * behaviour MUST NOT change as a result of this lift (cortex#360
+ * critical rule: migration moves preserve behaviour). The corresponding
+ * review-consumer / review-pipeline tests assert exactly this.
+ */
+
+import type { CCSessionResult } from "./cc-session";
+import type { DispatchTaskFailedReason } from "../bus/dispatch-events";
+
+/**
+ * Classify a `CCSessionResult` into a `DispatchTaskFailedReason`, or
+ * return `null` when the result represents a clean outcome that the
+ * downstream caller should continue processing (verdict-block parsing,
+ * direct response forwarding, etc.).
+ *
+ * **Mapping table** (verbatim from `review-pipeline.ts:244-298`):
+ *
+ * | CCSessionResult shape                              | Returned reason  |
+ * |----------------------------------------------------|------------------|
+ * | `aborted === true` (inactivity timeout / kill)     | `not_now`        |
+ * | `!success` AND `response.trim() === ""`            | `not_now`        |
+ * | any other shape (success, or failure WITH output)  | `null`           |
+ *
+ * The "failure with output" case is intentionally null — the
+ * review-pipeline path treats a non-zero exit with captured output as a
+ * candidate for verdict-block parsing (the skill emitted a block then
+ * crashed late). The dispatch-handler path treats it as success-like:
+ * the user sees the response text, not the apology message.
+ *
+ * `retry_after_ms: 0` per architecture §7.3 — the producer signals
+ * "no specific backpressure hint, retry whenever you like." Pilot
+ * translates this to exit 4 (transient, retry safe).
+ */
+export function classifyCcFailure(
+  result: CCSessionResult,
+): DispatchTaskFailedReason | null {
+  // §7.6 — substrate-side abort / crash paths. `aborted` covers the
+  // inactivity-timeout case (the canonical signature from cc-session.ts
+  // is `exitCode: 1 + aborted: true`, not `exitCode: 143`).
+  if (result.aborted) {
+    const reason = result.abortReason ?? "aborted";
+    return {
+      kind: "not_now",
+      detail: `cc session aborted: ${reason}`,
+      retry_after_ms: 0,
+    };
+  }
+  // A non-zero exit with no captured response is the "CC crashed mid-
+  // stream" case. Note: review-pipeline.ts pre-#360 also checked
+  // `!result.success` here — kept for behaviour parity.
+  if (!result.success && !result.response.trim()) {
+    return {
+      kind: "not_now",
+      detail: `cc session exited ${result.exitCode} with no output`,
+      retry_after_ms: 0,
+    };
+  }
+  // Clean exit, or failure that produced output — downstream caller's
+  // problem (verdict-block parse / direct user response).
+  return null;
+}
+
+/**
+ * Classify a synchronous-throw or async-rejection from the CC session
+ * factory (e.g. spawn failed, binary missing, immediate API rejection).
+ * Always maps to `not_now` per §7.3 — these are transient infrastructure
+ * failures, operator-recoverable.
+ *
+ * Separate entry point because `classifyCcFailure` operates on a
+ * `CCSessionResult` shape; this one operates on an unknown thrown value
+ * (caller's `try`/`catch`).
+ *
+ * **No null return** — every spawn-error is by definition a failure
+ * classification. The caller must always handle the reason.
+ */
+export function classifyCcSpawnError(err: unknown): DispatchTaskFailedReason {
+  const detail = err instanceof Error ? err.message : String(err);
+  return {
+    kind: "not_now",
+    detail: `cc session error: ${detail}`,
+    retry_after_ms: 0,
+  };
+}
+
+/**
+ * Convenience predicate: is this failure reason retry-eligible per the
+ * `not_now` semantics? Used by the chat-path retry loop in
+ * `dispatch-handler.ts` to decide whether to spawn another attempt or
+ * surface the apology immediately.
+ *
+ * `not_now` is the ONLY retryable kind — `cant_do`, `wont_do`,
+ * `policy_denied`, and `compliance_block` are all terminal (operator
+ * action needed; retry would just re-fail).
+ */
+export function isTransientFailure(
+  reason: DispatchTaskFailedReason,
+): boolean {
+  return reason.kind === "not_now";
+}

--- a/src/runner/review-pipeline.ts
+++ b/src/runner/review-pipeline.ts
@@ -89,6 +89,10 @@ import type {
   CCSessionLike,
 } from "../substrates/claude-code/harness";
 import type { CCSessionOpts, CCSessionResult } from "./cc-session";
+import {
+  classifyCcFailure,
+  classifyCcSpawnError,
+} from "./cc-failure-classifier";
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -244,6 +248,9 @@ export async function runReviewPipeline(
   // Spawn + await the CC session. Wrap factory + wait() in a single try
   // so any synchronous factory throw, async wait() rejection, or
   // mid-stream substrate crash collapses to the §7.6 not_now path.
+  // cortex#360: the factory-throw + result-classification logic is lifted
+  // into `cc-failure-classifier.ts` so the chat-path (dispatch-handler)
+  // can share the same taxonomy. Behaviour preserved byte-for-byte.
   let result: CCSessionResult;
   try {
     const session: CCSessionLike = opts.ccSessionFactory({
@@ -253,16 +260,21 @@ export async function runReviewPipeline(
     session.start();
     result = await session.wait();
   } catch (err) {
-    const detail = err instanceof Error ? err.message : String(err);
     // §7.3 not_now bucket — "transient infrastructure failure (CC binary
     // not found; etc.). Operator-recoverable." Pilot maps to exit 4
     // (transient, retry safe) per design-pilot-restructure.md §4.4.
+    // `classifyCcSpawnError` always returns a `not_now` reason; the
+    // union narrowing here exists to keep TypeScript happy when the
+    // classifier signature gains other kinds in future.
+    const reason = classifyCcSpawnError(err);
+    const errorSummary =
+      reason.kind === "not_now" ? reason.detail : `cc session error: ${reason.kind}`;
     return failed(
       opts,
       correlationId,
       startedAt,
-      { kind: "not_now", detail: `cc session error: ${detail}`, retry_after_ms: 0 },
-      `cc session error: ${detail}`,
+      reason,
+      errorSummary,
     );
   }
 
@@ -270,31 +282,19 @@ export async function runReviewPipeline(
   // inactivity-timeout case (the canonical signature from cc-session.ts
   // is `exitCode: 1 + aborted: true`, not `exitCode: 143`). A non-zero
   // exit with no captured response is the "CC crashed mid-stream" case.
-  if (result.aborted) {
-    const reason = result.abortReason ?? "aborted";
+  // Classification lives in `cc-failure-classifier.classifyCcFailure`;
+  // `null` return means "no substrate failure, continue to verdict
+  // parsing below."
+  const substrateFailure = classifyCcFailure(result);
+  if (substrateFailure !== null) {
     return failed(
       opts,
       correlationId,
       startedAt,
-      {
-        kind: "not_now",
-        detail: `cc session aborted: ${reason}`,
-        retry_after_ms: 0,
-      },
-      `cc session aborted: ${reason}`,
-    );
-  }
-  if (!result.success && !result.response.trim()) {
-    return failed(
-      opts,
-      correlationId,
-      startedAt,
-      {
-        kind: "not_now",
-        detail: `cc session exited ${result.exitCode} with no output`,
-        retry_after_ms: 0,
-      },
-      `cc session exited ${result.exitCode} with no output`,
+      substrateFailure,
+      substrateFailure.kind === "not_now"
+        ? substrateFailure.detail
+        : `cc session failure: ${substrateFailure.kind}`,
     );
   }
 


### PR DESCRIPTION
## Summary

Chat-dispatch (Discord / Mattermost `@mention` + DM) now retries transient CC failures before surfacing the apology. Lifts the four-way nak taxonomy from `review-pipeline.ts:244-298` into a shared `src/runner/cc-failure-classifier.ts` helper consumed by both the review-consumer path (unchanged behaviour) and the new chat-path retry loop.

Closes #360.

## What changed

- **New helper:** `src/runner/cc-failure-classifier.ts` — `classifyCcFailure(result)` returns the `DispatchTaskFailedReason` four-way taxonomy (`cant_do | wont_do | not_now | policy_denied`) or `null` for clean results; `classifyCcSpawnError(err)` covers the synchronous factory-throw case (always `not_now`); `isTransientFailure(reason)` is the retry-eligibility predicate the chat loop consumes.
- **Review-pipeline refactor:** `runReviewPipeline` now calls the shared classifier instead of inlining the mapping. Behaviour preserved byte-for-byte — review-consumer tests stay green.
- **Dispatch-handler retry loop (`handleSync`):**
  - Up to **3 total attempts** (initial + 2 retries) before surfacing `Sorry, I couldn't process that.` Default tunable via `DispatchHandlerOpts.retry.maxAttempts`.
  - **20-minute wall-clock cap** bounds the wedged-binary case.
  - Posts `Still working… (attempt N/3)` to the adapter before each retry so the operator sees the bot didn't ghost.
  - Stable `correlation_id` across the retry chain — observers can stitch the chain through the `dispatch.task.failed` envelope's correlation key.
  - Emits `dispatch.task.failed` on terminal failure (any non-`not_now` reason, or final retry) for **failure-path** observability parity with the review-consumer path. Full lifecycle parity (`.started` / `.completed` / `.aborted` on chat) is tracked separately in cortex#365.
  - `ccSessionFactory` injection added to `DispatchHandlerOpts` for test determinism (default factory constructs the real `CCSession`).
- **Tests:** 6 new dispatch-handler retry tests + 11 classifier unit tests (9 original + 2 r3-added covering `isTransientFailure` terminal-kind and spawn-error coverage). All review-consumer / review-pipeline tests stay green (zero behavioural change on that path).
- **Bump:** `arc-manifest.yaml` 2.0.6 → 2.0.7 (post-rebase). New `RELEASE.md` entry citing #360.

## Follow-ups filed

- **cortex#364** — `refactor(bus): replace double-cast session-as-emitter pattern in dispatch-handler` (r1 deferred nit, now properly tracked per Echo r3 finding). Label: `infrastructure`, `future`.
- **cortex#365** — `feat(bus): emit dispatch.task.started + .completed on chat-path dispatches` (full lifecycle parity, surfaced by Echo r3). Label: `feature`, `future`.

## Test plan

- [x] `bun test src/runner/__tests__/cc-failure-classifier.test.ts` — 11 pass (classifier mapping table pinned; `isTransientFailure` exercised across transient, terminal, and spawn-error cases).
- [x] `bun test src/bus/__tests__/dispatch-handler.test.ts` — 24 pass (18 original + 6 new). Covers: retry-then-success on attempt 2 / all-three-attempts-fail / clean-success-attempt-1 / terminal `cant_do` bails immediately / factory-throw retries / `maxAttempts=1` override disables retry.
- [x] `bun test src/runner/__tests__/review-pipeline.test.ts` — review-pipeline tests pass after the classifier lift; review-consumer path semantics unchanged.
- [x] `bun test` — full repo suite: **3411 pass, 1 fail** across 182 files.
  - The 1 fail (`dispatch-listener — originator (cortex#346 / myelin#161) > cryptoVerify:true — tampered originator on signed envelope → chain_verification_failed deny`) is a **pre-existing regression from PR #358 / v2.0.6 merge**, not introduced by this PR. My diff does NOT touch `dispatch-listener.ts` (verified: `git diff origin/main --stat` shows only `cc-failure-classifier.ts`, `dispatch-handler.ts`, `review-pipeline.ts`, the two test files, `arc-manifest.yaml`, and `RELEASE.md`). The failing test asserts `reason.kind === "chain_verification_failed"` but receives `"unknown_principal"` — a deny-path label drift independent of cortex#360's scope.
- [x] `bun run lint:errors` — clean.

## Critical-rules adherence

- Migration moves preserve behaviour — review-consumer path is byte-identical for cortex#360's diff.
- No `--no-verify` / `--no-gpg-sign`.
- No empty catches — every error path logs via `console.warn` / `console.error` with the failure detail.
- Hooks stay non-blocking (no changes to hook code).
- Version bump stays patch (2.0.6 → 2.0.7).

## Ironic note

This is the PR that fixes the bug that crashed Echo on PR #358's review (and again on this PR's round-2 re-review). Echo's path is the very path being fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)