### PR TITLE
fix(security): restore originator signature coverage — stale myelin install (closes #366) — v2.0.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,3 +60,27 @@ jobs:
 
       - name: ESLint (errors only — blocking gate)
         run: bun run lint:errors
+
+  # ──────────────────────────────────────────────────────────────────
+  # Test — bun test suite. Added at cortex#366: the originator-signature
+  # regression incident (PR #358) merged green because CI never ran the
+  # test suite — only label-check + lint. `bun install --frozen-lockfile`
+  # resolves github-commit-pinned deps (e.g. @the-metafactory/myelin)
+  # from the locked SHA, so a stale dependency tree fails here rather
+  # than reaching production. Closes the enforcement gap cortex#366
+  # identifies.
+  # ──────────────────────────────────────────────────────────────────
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - run: bun install --frozen-lockfile
+
+      - name: bun test (blocking gate)
+        run: bun test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,27 +60,3 @@ jobs:
 
       - name: ESLint (errors only — blocking gate)
         run: bun run lint:errors
-
-  # ──────────────────────────────────────────────────────────────────
-  # Test — bun test suite. Added at cortex#366: the originator-signature
-  # regression incident (PR #358) merged green because CI never ran the
-  # test suite — only label-check + lint. `bun install --frozen-lockfile`
-  # resolves github-commit-pinned deps (e.g. @the-metafactory/myelin)
-  # from the locked SHA, so a stale dependency tree fails here rather
-  # than reaching production. Closes the enforcement gap cortex#366
-  # identifies.
-  # ──────────────────────────────────────────────────────────────────
-  test:
-    name: Test
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
-
-      - run: bun install --frozen-lockfile
-
-      - name: bun test (blocking gate)
-        run: bun test

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -22,11 +22,15 @@ not break the signature — a tamper to a known principal could impersonate
 that principal. A clean install resolves the dependency correctly and
 restores the property.
 
-This release adds a CI regression guard
+This release adds a regression guard
 (`envelope-validator.test.ts` — `originator is covered by the signature`)
 that signs an envelope carrying an `originator` block, tampers the
 principal post-sign, and asserts crypto-verify rejects. A stale install
-now fails CI here rather than being found in production. Closes cortex#366.
+now fails the test suite here rather than being found in production. The
+guard is TDD-proven — it fails against a simulated stale install and
+passes against a correct one. (cortex CI does not yet run `bun test`;
+wiring the suite into CI so this guard runs there is tracked in
+cortex#376.) Closes cortex#366.
 
 ## v2.0.7 — chat-path CC failure retry
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,33 @@
 # Cortex Release Notes
 
+## v2.0.9 — security: restore originator signature coverage
+
+Fixes a dependency-install staleness that left the envelope `originator`
+field outside the signed field set — restoring tamper-detection on the
+policy-attribution claim.
+
+PR #358 (cortex#346, v2.0.6) wired myelin#161's `Envelope.originator`
+policy-attribution field through cortex on the contract that `originator`
+is in myelin's `SIGNABLE_FIELDS`, so tampering it post-sign invalidates the
+stack signature and the receiver rejects with a crypto failure. That
+contract did not hold on `main`: a worktree `bun install` during an
+unrelated rebase resolved the github-commit-pinned myelin dependency to a
+cached older tree whose `SIGNABLE_FIELDS` stopped at `target_principal`.
+`package.json` and `bun.lock` both pinned the correct SHA the whole time —
+only an installed `node_modules/@the-metafactory/myelin` could be stale.
+
+Consequence while stale: `signEnvelope()` signed over the old field set,
+`originator` never entered the signed bytes, and tampering it post-sign did
+not break the signature — a tamper to a known principal could impersonate
+that principal. A clean install resolves the dependency correctly and
+restores the property.
+
+This release adds a CI regression guard
+(`envelope-validator.test.ts` — `originator is covered by the signature`)
+that signs an envelope carrying an `originator` block, tampers the
+principal post-sign, and asserts crypto-verify rejects. A stale install
+now fails CI here rather than being found in production. Closes cortex#366.
+
 ## v2.0.7 — chat-path CC failure retry
 
 Chat-dispatch (Discord / Mattermost `@mention` and DM) now retries transient

--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -2,7 +2,7 @@
 # See: https://github.com/the-metafactory/arc
 
 name: "Cortex"
-version: "2.0.8"
+version: "2.0.9"
 type: component
 tier: community
 description: "Layer-7 collaboration surface for the metafactory ecosystem — the M7 application that consumes the Myelin stack"

--- a/src/bus/myelin/__tests__/envelope-validator.test.ts
+++ b/src/bus/myelin/__tests__/envelope-validator.test.ts
@@ -9,6 +9,8 @@
  */
 
 import { describe, expect, test } from "bun:test";
+import { createUser } from "@nats-io/nkeys";
+import { signEnvelope } from "@the-metafactory/myelin/identity";
 import {
   deriveNatsSubject,
   getActorPrincipal,
@@ -20,6 +22,10 @@ import {
   validateSubjectEnvelopeAlignment,
   type Envelope,
 } from "../envelope-validator";
+import { verifySignedByChain } from "../../verify-signed-by-chain";
+import { AgentRegistry } from "../../../common/agents/registry";
+import { TrustResolver } from "../../../common/agents/trust-resolver";
+import type { Agent } from "../../../common/types/cortex-config";
 import validEnvelope from "../vendor/__fixtures__/valid-envelope.json" with { type: "json" };
 import invalidMissingSovereignty from "../vendor/__fixtures__/invalid-missing-sovereignty.json" with { type: "json" };
 
@@ -574,6 +580,152 @@ describe("envelope-validator — chain helpers (IAW Phase A.2)", () => {
     const match = /#([0-9a-f]{40})$/.exec(myelinDep!);
     expect(match).not.toBeNull();
     expect(match![1]).toBe(SCHEMA_SOURCE_COMMIT);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cortex#366 — stale-myelin-install regression guard.
+//
+// WHY THIS GUARD EXISTS — DO NOT DELETE AS REDUNDANT.
+//
+// PR #358 (cortex#346, v2.0.6) wired myelin#161's `Envelope.originator`
+// policy-attribution field through cortex on the security contract that
+// `originator` is in myelin's `SIGNABLE_FIELDS` — so tampering it post-sign
+// invalidates the stack signature and the receiver rejects with a crypto
+// failure.
+//
+// That contract silently did NOT hold on `main`: a worktree `bun install`
+// during an unrelated rebase resolved the github-commit-pinned myelin dep to
+// a cached OLDER tree whose `SIGNABLE_FIELDS` stopped at `target_principal`
+// and did not include `originator`. `package.json` and `bun.lock` both pinned
+// the correct SHA (3ec0ace) the whole time — only the installed
+// `node_modules/@the-metafactory/myelin` was stale. The result: `signEnvelope`
+// signed over the stale field set, `originator` never entered the signed
+// bytes, and tampering it post-sign did not break the signature. Tamper to a
+// KNOWN principal would have impersonated that principal. (cortex#366, P1.)
+//
+// The `SCHEMA_SOURCE_COMMIT` guards above pin the *schema string* copy and
+// the package.json *pin*. Neither catches a stale *installed signing path* —
+// they would both still pass while `node_modules` carried old bytes. THIS
+// test is the only one that exercises the actual installed `signEnvelope` +
+// crypto-verify round-trip against the `originator` field, so a stale install
+// fails CI here instead of being found by a security researcher in prod.
+// ---------------------------------------------------------------------------
+
+describe("envelope-validator — originator signature coverage (cortex#366)", () => {
+  // Minimal Discord presence block so the Agent fixture type-checks; the
+  // crypto round-trip below does not touch presence.
+  function discordPresence() {
+    return {
+      enabled: true,
+      token: "discord-bot-token",
+      guildId: "1487000000000000000",
+      agentChannelId: "1487000000000000001",
+      logChannelId: "1487000000000000002",
+      contextDepth: 10,
+      enableAgentLog: false,
+      roles: [],
+      defaultRole: "allow-all",
+      dm: {
+        operatorRole: {
+          features: ["chat", "async", "team"] as const,
+          disallowedTools: [],
+          bashGuard: true,
+        },
+        defaultRole: "denied" as const,
+        userRoles: [],
+      },
+    };
+  }
+
+  function agentFixture(overrides: Partial<Agent> = {}): Agent {
+    return {
+      id: "luna",
+      displayName: "Luna",
+      persona: "./personas/luna.md",
+      roles: [],
+      trust: [],
+      presence: { discord: discordPresence() },
+      ...overrides,
+    } as Agent;
+  }
+
+  // Fresh ed25519 NATS user keypair — `nkeyPub` (U-prefixed base32) for the
+  // agent registry, `privateKeyBase64` (raw 32-byte seed) for `signEnvelope`.
+  function generateEd25519KeyPair(): {
+    nkeyPub: string;
+    privateKeyBase64: string;
+  } {
+    const kp = createUser();
+    const nkeyPub = kp.getPublicKey();
+    const rawSeed = (
+      kp as unknown as { getRawSeed(): Uint8Array }
+    ).getRawSeed();
+    const privateKeyBase64 = Buffer.from(rawSeed).toString("base64");
+    return { nkeyPub, privateKeyBase64 };
+  }
+
+  test("originator is covered by the signature — stale myelin install regression guard (cortex#366)", async () => {
+    // Receiver "cortex" trusts sender "echo".
+    const { nkeyPub: echoNKey, privateKeyBase64: echoSeed } =
+      generateEd25519KeyPair();
+    const cortex = agentFixture({ id: "cortex", trust: ["echo"] });
+    const echo = agentFixture({
+      id: "echo",
+      displayName: "Echo",
+      nkey_pub: echoNKey,
+    });
+    const resolver = new TrustResolver(
+      AgentRegistry.fromAgents([cortex, echo]),
+    );
+
+    // Build an envelope that carries an `originator` block, then sign it.
+    // If `originator` is in myelin's SIGNABLE_FIELDS (correct install), the
+    // signer commits to it; the canonical bytes include `originator`.
+    const base = {
+      ...(validEnvelope as object),
+      originator: {
+        principal: "did:mf:echo",
+        attribution: "adapter-resolved",
+      },
+    } as Parameters<typeof signEnvelope>[0];
+    const signed = await signEnvelope(base, echoSeed, "did:mf:echo");
+
+    // Sanity: the happy path verifies. If this fails the fixture is broken,
+    // not the security property.
+    const ok = await verifySignedByChain(signed, {
+      resolver,
+      receivingAgentId: "cortex",
+      cryptoVerify: true,
+      operatorId: "test-operator",
+    });
+    expect(ok.valid).toBe(true);
+
+    // Tamper: swap `originator.principal` to a different DID post-sign.
+    // With a CORRECT myelin install, `originator` is a signable field, so the
+    // canonical bytes no longer match the signature → crypto verify rejects.
+    // With a STALE myelin install, `originator` is outside SIGNABLE_FIELDS,
+    // the tampered bytes still match the signature, and this assertion FAILS
+    // (the verify returns valid:true) — which is exactly the cortex#366 bug.
+    const tampered: Envelope = {
+      ...(signed as Envelope),
+      originator: {
+        principal: "did:mf:mallory",
+        attribution: "adapter-resolved",
+      },
+    };
+
+    const result = await verifySignedByChain(tampered, {
+      resolver,
+      receivingAgentId: "cortex",
+      cryptoVerify: true,
+      operatorId: "test-operator",
+    });
+
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.reason.kind).toBe("crypto_verify_failed");
+    }
   });
 });
 

--- a/src/bus/myelin/__tests__/envelope-validator.test.ts
+++ b/src/bus/myelin/__tests__/envelope-validator.test.ts
@@ -658,6 +658,11 @@ describe("envelope-validator — originator signature coverage (cortex#366)", ()
   } {
     const kp = createUser();
     const nkeyPub = kp.getPublicKey();
+    // `KP`'s concrete class exposes `getRawSeed()` returning the raw
+    // 32-byte ed25519 seed — the shape `signEnvelope` wants. The public
+    // `KeyPair` interface hides it (it only surfaces the wrapped 58-char
+    // NKey-encoded seed via `getSeed()`), so the double-cast reaches the
+    // concrete method. Test-only cast, mirrors verify-signed-by-chain.test.ts.
     const rawSeed = (
       kp as unknown as { getRawSeed(): Uint8Array }
     ).getRawSeed();
@@ -701,7 +706,12 @@ describe("envelope-validator — originator signature coverage (cortex#366)", ()
     });
     expect(ok.valid).toBe(true);
 
-    // Tamper: swap `originator.principal` to a different DID post-sign.
+    // Tamper: swap `originator.principal` to `did:mf:cortex` post-sign — a
+    // KNOWN, registered principal (cortex#366's acceptance criterion asks
+    // for a known principal specifically, because that is the precise
+    // impersonation loophole: an unknown principal would also be caught by
+    // the downstream policy layer, but a known one would not — only the
+    // signature covering `originator` stops it).
     // With a CORRECT myelin install, `originator` is a signable field, so the
     // canonical bytes no longer match the signature → crypto verify rejects.
     // With a STALE myelin install, `originator` is outside SIGNABLE_FIELDS,
@@ -710,7 +720,7 @@ describe("envelope-validator — originator signature coverage (cortex#366)", ()
     const tampered: Envelope = {
       ...(signed as Envelope),
       originator: {
-        principal: "did:mf:mallory",
+        principal: "did:mf:cortex",
         attribution: "adapter-resolved",
       },
     };

--- a/src/bus/myelin/__tests__/envelope-validator.test.ts
+++ b/src/bus/myelin/__tests__/envelope-validator.test.ts
@@ -609,7 +609,14 @@ describe("envelope-validator — chain helpers (IAW Phase A.2)", () => {
 // they would both still pass while `node_modules` carried old bytes. THIS
 // test is the only one that exercises the actual installed `signEnvelope` +
 // crypto-verify round-trip against the `originator` field, so a stale install
-// fails CI here instead of being found by a security researcher in prod.
+// fails the test suite here instead of being found by a security researcher
+// in prod.
+//
+// NOTE: cortex CI does not yet run `bun test` (only lint + label-check), so
+// this guard does not run in CI *yet* — wiring the test suite into CI is
+// tracked separately in cortex#376. Until then, the guard protects any
+// developer running the suite locally and is TDD-proven (it fails against a
+// stale install and passes against a correct one).
 // ---------------------------------------------------------------------------
 
 describe("envelope-validator — originator signature coverage (cortex#366)", () => {


### PR DESCRIPTION
## Summary

**P1 security fix.** Restores tamper-detection on the envelope `originator`
policy-attribution claim, and adds a TDD-proven regression guard for the
failure mode.

Closes #366.

## The bug

PR #358 (cortex#346, v2.0.6) wired myelin#161's `Envelope.originator`
policy-attribution field through cortex on a security contract: `originator`
is in myelin's `SIGNABLE_FIELDS`, so tampering it post-sign invalidates the
stack signature and the receiver rejects with `chain_verification_failed`.

That contract did not hold on `main`. The installed
`node_modules/@the-metafactory/myelin` `SIGNABLE_FIELDS` set stopped at
`target_principal` and did **not** include `originator` — a worktree
`bun install` during an unrelated rebase resolved the github-commit-pinned
dependency to a cached older tree. `package.json` and `bun.lock` both pinned
the correct SHA (`3ec0ace`) the whole time; only an installed
`node_modules` copy could be stale.

**Consequence while stale:** `signEnvelope()` signed over the old field set,
`originator` never entered the signed bytes, tampering it post-sign did not
break the signature, `verifySignedByChain` passed — a tamper to a *known*
principal would impersonate that principal.

## The fix (surgical — 3 files)

- **Dependency:** a clean install resolves myelin correctly. Verified the
  installed `canonicalize.ts` `SIGNABLE_FIELDS` now includes `originator`.
- **`bun.lock`:** already pinned `3ec0ace` correctly — re-resolve produced
  **no lockfile change**. The staleness was a `node_modules` tree, not the
  lockfile or `package.json`. Honest note: there is no lockfile diff in this
  PR because there was nothing wrong with the lockfile.
- **Regression guard:** new test in `src/bus/myelin/__tests__/envelope-validator.test.ts`
  — `originator is covered by the signature — stale myelin install regression
  guard (cortex#366)`. It signs an envelope carrying an `originator` block,
  tampers `originator.principal` to a **known, registered** principal
  post-sign (matching #366's acceptance criterion), and asserts crypto-verify
  rejects with `crypto_verify_failed`. A header comment explains the
  cortex#366 incident so a future reader does not delete it as redundant.
- **Version:** `arc-manifest.yaml` 2.0.8 → 2.0.9; v2.0.9 `RELEASE.md` entry.

## TDD ordering proof (the guard genuinely guards)

- Simulated a stale install (dropped `originator` from the installed
  `SIGNABLE_FIELDS`) → guard **FAILS**: `verifySignedByChain` returns
  `valid: true`, i.e. the tamper is not detected — exactly the cortex#366 bug.
- Restored the correct install → guard **PASSES**:
  `reason.kind === 'crypto_verify_failed'`.

## CI scope — cortex#376

Echo's review correctly noted that cortex CI runs only label-check + lint —
there is **no `bun test` job**, so this guard does not run in CI *yet*. That
is the same enforcement gap that let PR #358's regression merge green.

Naively adding a `test` job (attempted in an earlier commit on this branch)
exposed **7 pre-existing CI-incompatible tests** — `CCSession` + `AgentTeam`
spawn the real `claude` binary, absent on GitHub Actions runners — plus an
`api.test.ts` `EADDRINUSE` parallel-run flake. Properly wiring the test
suite into CI (including those 7 tests and 3 pre-existing `tsc` errors) is
its own problem, now filed as **cortex#376** (`now` priority, sub-issue of
the cortex#372 robustness umbrella). This PR reverts the `test` job so it
stays a surgical security fix; the guard is verified locally and
TDD-proven. The "fails CI" wording is softened to "fails the test suite"
in `RELEASE.md` and the guard's header comment, each pointing at cortex#376.

## Verification

- `bun test src/runner/__tests__/dispatch-listener.test.ts` — **49/49 pass**,
  including `tampered originator on signed envelope → chain_verification_failed`.
- `bun test src/bus/myelin/__tests__/envelope-validator.test.ts` — **57/57 pass**
  (56 prior + 1 new guard).
- Full suite: **3435 pass, 2 skip, 0 fail**.
- **Sibling-staleness audit:** only the originator-tamper test was affected.
  No other myelin-signable-field test (`requirements`, `target_principal`,
  etc.) failed — the staleness was exactly the myelin#161 delta.
- `bunx tsc --noEmit` — 3 errors, all pre-existing on `main` at `ab53710` in
  `review-roundtrip.integration.test.ts` and `registry.test.ts` (files this
  PR does not touch). Not introduced here — now in cortex#376's scope.

## Follow-ups filed

- **cortex#376** — wire `bun test` into CI; fix the 7 `claude`-binary
  CI-incompatible tests, the `api.test.ts` `EADDRINUSE` flake, the 3 `tsc`
  errors.
- **cortex#377** — extract shared ed25519 keypair / agent test scaffolding
  (Echo NIT-1).
- **cortex#378** — backfill the missing v2.0.8 `RELEASE.md` entry
  (Echo NIT-4, pre-existing drift).

## Test plan

- [x] Clean `bun install` resolves myelin with `originator` in `SIGNABLE_FIELDS`
- [x] `dispatch-listener.test.ts` 49/49 green
- [x] Guard FAILS on simulated stale install, PASSES on correct install
- [x] Full suite green
- [x] Version bumped + RELEASE.md entry added

🤖 Generated with [Claude Code](https://claude.com/claude-code)