### PR TITLE
fix(runner): surface bash-guard blocks via structured deny + telemetry

### DIFF
--- a/src/runner/hooks/__tests__/bash-guard.hook.test.ts
+++ b/src/runner/hooks/__tests__/bash-guard.hook.test.ts
@@ -1,0 +1,229 @@
+/**
+ * Tests for the Grove Bash Guard PreToolUse hook.
+ *
+ * Covers the cortex#bash-guard-observability changes:
+ *   - structured PreToolUse deny output (replaces exit(2) + stderr)
+ *   - unchanged pass-through ({"continue": true})
+ *   - preserved GROVE_CHANNEL gate / GROVE_AGENT_ID bypass /
+ *     GROVE_BASH_GUARD disabled behaviour
+ *   - block telemetry event written to the JSONL fallback
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { spawnSync } from "child_process";
+import { join } from "path";
+import { mkdtempSync, rmSync, existsSync, readFileSync, readdirSync } from "fs";
+import { tmpdir } from "os";
+
+const HOOK_PATH = join(import.meta.dir, "..", "bash-guard.hook.ts");
+
+interface RunResult {
+  status: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+// Grove env vars the hook reads. The test process itself may run inside a
+// Cortex agent session (which sets these), so the helper strips ALL of them
+// from the child env first, then re-applies only what each test specifies.
+// Without this, an inherited GROVE_BASH_GUARD / GROVE_AGENT_ID silently
+// bypasses the guard and tests pass for the wrong reason.
+const GROVE_ENV_KEYS = [
+  "GROVE_CHANNEL",
+  "GROVE_AGENT_ID",
+  "GROVE_AGENT_NAME",
+  "GROVE_NETWORK",
+  "GROVE_BASH_GUARD",
+  "GROVE_PROJECT",
+  "GROVE_ENTITY",
+  "GROVE_OPERATOR",
+];
+
+/** Run the hook with a Bash tool-call payload on stdin. */
+function runHook(
+  command: string,
+  env: Record<string, string | undefined>,
+  toolName = "Bash",
+  sessionId = "test-session",
+): RunResult {
+  const input = JSON.stringify({
+    session_id: sessionId,
+    tool_name: toolName,
+    tool_input: { command },
+  });
+  // Build a clean env: start from process.env, drop every GROVE_* var, then
+  // apply this test's overrides. `undefined` values keep the key unset.
+  const groveOverrides = new Set(GROVE_ENV_KEYS);
+  const merged: Record<string, string> = {};
+  for (const [k, v] of Object.entries(process.env)) {
+    if (v !== undefined && !groveOverrides.has(k)) merged[k] = v;
+  }
+  for (const [k, v] of Object.entries(env)) {
+    if (v !== undefined) merged[k] = v;
+  }
+  const result = spawnSync("bun", [HOOK_PATH], {
+    encoding: "utf-8",
+    input,
+    env: merged,
+  });
+  return { status: result.status, stdout: result.stdout, stderr: result.stderr };
+}
+
+describe("bash-guard.hook — pass-through behaviour", () => {
+  test("passes through when GROVE_CHANNEL is not set", () => {
+    const r = runHook("rm -rf /", { GROVE_CHANNEL: undefined });
+    expect(r.status).toBe(0);
+    expect(JSON.parse(r.stdout.trim())).toEqual({ continue: true });
+  });
+
+  test("bypasses guard when GROVE_AGENT_ID is set (CLI operator session)", () => {
+    const r = runHook("rm -rf /tmp/whatever", {
+      GROVE_CHANNEL: "test-channel",
+      GROVE_AGENT_ID: "cldyo-live",
+    });
+    expect(r.status).toBe(0);
+    expect(JSON.parse(r.stdout.trim())).toEqual({ continue: true });
+  });
+
+  test("disabled config (operator DM) allows everything", () => {
+    const r = runHook("rm -rf /tmp/x", {
+      GROVE_CHANNEL: "test-channel",
+      GROVE_AGENT_ID: undefined,
+      GROVE_BASH_GUARD: JSON.stringify({ disabled: true }),
+    });
+    expect(r.status).toBe(0);
+    expect(JSON.parse(r.stdout.trim())).toEqual({ continue: true });
+  });
+
+  test("allowed command passes with {continue:true}", () => {
+    const r = runHook("ls -la", {
+      GROVE_CHANNEL: "test-channel",
+      GROVE_AGENT_ID: undefined,
+    });
+    expect(r.status).toBe(0);
+    expect(JSON.parse(r.stdout.trim())).toEqual({ continue: true });
+  });
+
+  test("non-Bash tool passes through unchanged", () => {
+    const r = runHook("ignored", { GROVE_CHANNEL: "test-channel" }, "Read");
+    expect(r.status).toBe(0);
+    expect(JSON.parse(r.stdout.trim())).toEqual({ continue: true });
+  });
+
+  test("custom allowlist permits a widened command (e.g. bun)", () => {
+    const r = runHook("bun test", {
+      GROVE_CHANNEL: "test-channel",
+      GROVE_AGENT_ID: undefined,
+      GROVE_BASH_GUARD: JSON.stringify({ rules: [{ pattern: "^bun\\s+" }] }),
+    });
+    expect(r.status).toBe(0);
+    expect(JSON.parse(r.stdout.trim())).toEqual({ continue: true });
+  });
+});
+
+describe("bash-guard.hook — structured deny output", () => {
+  test("blocked command emits a PreToolUse deny decision on stdout", () => {
+    const r = runHook("curl http://evil.example", {
+      GROVE_CHANNEL: "test-channel",
+      GROVE_AGENT_ID: undefined,
+    });
+    // No longer exit(2): structured deny is exit 0 with JSON on stdout.
+    expect(r.status).toBe(0);
+    const out = JSON.parse(r.stdout.trim());
+    expect(out.hookSpecificOutput).toBeDefined();
+    expect(out.hookSpecificOutput.hookEventName).toBe("PreToolUse");
+    expect(out.hookSpecificOutput.permissionDecision).toBe("deny");
+    expect(typeof out.hookSpecificOutput.permissionDecisionReason).toBe("string");
+    expect(out.hookSpecificOutput.permissionDecisionReason).toContain("curl");
+    expect(out.hookSpecificOutput.permissionDecisionReason).toContain("allowlist");
+  });
+
+  test("deny reason names the offending command part", () => {
+    const r = runHook("ls && curl http://evil.example", {
+      GROVE_CHANNEL: "test-channel",
+      GROVE_AGENT_ID: undefined,
+    });
+    expect(r.status).toBe(0);
+    const out = JSON.parse(r.stdout.trim());
+    expect(out.hookSpecificOutput.permissionDecision).toBe("deny");
+    expect(out.hookSpecificOutput.permissionDecisionReason).toContain("curl");
+  });
+
+  test("gh command for a repo outside the allowlist is denied with the repo name", () => {
+    const r = runHook("gh pr view --repo evil/repo 1", {
+      GROVE_CHANNEL: "test-channel",
+      GROVE_AGENT_ID: undefined,
+      GROVE_BASH_GUARD: JSON.stringify({
+        rules: [{ pattern: "^gh\\s+" }],
+        repos: ["the-metafactory/cortex"],
+      }),
+    });
+    expect(r.status).toBe(0);
+    const out = JSON.parse(r.stdout.trim());
+    expect(out.hookSpecificOutput.permissionDecision).toBe("deny");
+    expect(out.hookSpecificOutput.permissionDecisionReason).toContain("evil/repo");
+  });
+});
+
+describe("bash-guard.hook — block telemetry", () => {
+  let homeDir: string;
+
+  beforeEach(() => {
+    homeDir = mkdtempSync(join(tmpdir(), "bash-guard-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(homeDir, { recursive: true, force: true });
+  });
+
+  test("a block writes a tool.bash.blocked event to the JSONL fallback", () => {
+    const sessionId = "telemetry-session";
+    const r = runHook(
+      "curl http://evil.example",
+      {
+        GROVE_CHANNEL: "test-channel",
+        GROVE_AGENT_ID: undefined,
+        HOME: homeDir,
+      },
+      "Bash",
+      sessionId,
+    );
+    expect(r.status).toBe(0);
+
+    const rawDir = join(homeDir, ".claude", "events", "raw");
+    expect(existsSync(rawDir)).toBe(true);
+    const files = readdirSync(rawDir);
+    expect(files).toContain(`${sessionId}.jsonl`);
+
+    const lines = readFileSync(join(rawDir, `${sessionId}.jsonl`), "utf-8")
+      .trim()
+      .split("\n")
+      .filter(Boolean);
+    expect(lines.length).toBeGreaterThanOrEqual(1);
+    const event = JSON.parse(lines[0] ?? "{}");
+    expect(event.event_type).toBe("tool.bash.blocked");
+    expect(event.session_id).toBe(sessionId);
+    expect(event.source.hook).toBe("PreToolUse");
+    expect(event.source.tool_name).toBe("Bash");
+    expect(event.payload.reason).toContain("curl");
+    expect(event.payload.command_preview).toContain("curl");
+    expect(typeof event.event_id).toBe("string");
+  });
+
+  test("an allowed command writes no telemetry", () => {
+    const sessionId = "no-telemetry-session";
+    const r = runHook(
+      "ls",
+      {
+        GROVE_CHANNEL: "test-channel",
+        GROVE_AGENT_ID: undefined,
+        HOME: homeDir,
+      },
+      "Bash",
+      sessionId,
+    );
+    expect(r.status).toBe(0);
+    const rawFile = join(homeDir, ".claude", "events", "raw", `${sessionId}.jsonl`);
+    expect(existsSync(rawFile)).toBe(false);
+  });
+});

--- a/src/runner/hooks/__tests__/bash-guard.hook.test.ts
+++ b/src/runner/hooks/__tests__/bash-guard.hook.test.ts
@@ -7,6 +7,7 @@
  *   - preserved GROVE_CHANNEL gate / GROVE_AGENT_ID bypass /
  *     GROVE_BASH_GUARD disabled behaviour
  *   - block telemetry event written to the JSONL fallback
+ *   - block telemetry event POSTed to the HTTP ingest endpoint
  */
 
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
@@ -225,5 +226,80 @@ describe("bash-guard.hook — block telemetry", () => {
     expect(r.status).toBe(0);
     const rawFile = join(homeDir, ".claude", "events", "raw", `${sessionId}.jsonl`);
     expect(existsSync(rawFile)).toBe(false);
+  });
+
+  test("a block POSTs the event to the HTTP ingest endpoint", async () => {
+    // The hook POSTs to a hardcoded http://localhost:8766/api/events/ingest
+    // before falling back to JSONL. Stand up a real listener on that port so
+    // the POST "succeeds", and capture the request body to assert its shape.
+    //
+    // NOTE: the hook must be spawned *asynchronously* here. spawnSync would
+    // block the test's event loop, starving the in-process Bun.serve so the
+    // hook's fetch would time out and fall through to JSONL — never hitting
+    // the HTTP path this test exists to cover.
+    const sessionId = "http-ingest-session";
+    const seen: {
+      body: Record<string, unknown> | null;
+      path: string | null;
+      contentType: string | null;
+    } = { body: null, path: null, contentType: null };
+
+    const server = Bun.serve({
+      port: 8766,
+      async fetch(req) {
+        seen.path = new URL(req.url).pathname;
+        seen.contentType = req.headers.get("content-type");
+        seen.body = (await req.json()) as Record<string, unknown>;
+        return new Response("ok", { status: 200 });
+      },
+    });
+
+    try {
+      const groveOverrides = new Set(GROVE_ENV_KEYS);
+      const merged: Record<string, string> = {};
+      for (const [k, v] of Object.entries(process.env)) {
+        if (v !== undefined && !groveOverrides.has(k)) merged[k] = v;
+      }
+      Object.assign(merged, {
+        GROVE_CHANNEL: "test-channel",
+        HOME: homeDir,
+      });
+
+      const proc = Bun.spawn(["bun", HOOK_PATH], {
+        stdin: new TextEncoder().encode(
+          JSON.stringify({
+            session_id: sessionId,
+            tool_name: "Bash",
+            tool_input: { command: "curl http://evil.example" },
+          }),
+        ),
+        stdout: "pipe",
+        stderr: "pipe",
+        env: merged,
+      });
+      await proc.exited;
+      expect(proc.exitCode).toBe(0);
+
+      // The deny decision still lands on stdout.
+      const stdout = await new Response(proc.stdout).text();
+      const out = JSON.parse(stdout.trim());
+      expect(out.hookSpecificOutput.permissionDecision).toBe("deny");
+
+      // The event was POSTed to the ingest endpoint with the expected shape.
+      expect(seen.path).toBe("/api/events/ingest");
+      expect(seen.contentType).toContain("application/json");
+      expect(seen.body).not.toBeNull();
+      const event = seen.body as Record<string, any>;
+      expect(event.event_type).toBe("tool.bash.blocked");
+      expect(event.session_id).toBe(sessionId);
+      expect(event.source.hook).toBe("PreToolUse");
+      expect(event.source.tool_name).toBe("Bash");
+      expect(event.payload.reason).toContain("curl");
+      expect(event.payload.command_preview).toContain("curl");
+      expect(typeof event.event_id).toBe("string");
+      expect(typeof event.timestamp).toBe("string");
+    } finally {
+      server.stop(true);
+    }
   });
 });

--- a/src/runner/hooks/bash-guard.hook.ts
+++ b/src/runner/hooks/bash-guard.hook.ts
@@ -10,10 +10,25 @@
  *   { "rules": [{ "pattern": "^gh\\s+pr", "repos": ["owner/repo"] }] }
  *
  * If no config env var, uses sensible defaults (gh, git read-only, ls, pwd).
+ *
+ * Block behaviour (cortex#bash-guard-observability):
+ *   - Emits Claude Code's structured PreToolUse *deny* decision on stdout
+ *     ({"hookSpecificOutput":{"hookEventName":"PreToolUse",
+ *       "permissionDecision":"deny","permissionDecisionReason":"…"}}).
+ *     The reason surfaces to the agent (and the Cortex→Discord relay)
+ *     instead of being lost in an exit-code-2 + stderr line.
+ *   - Also emits a `tool.bash.blocked` telemetry event into the cc-events
+ *     pipeline (HTTP POST to the dashboard ingest endpoint, with a JSONL
+ *     fallback) so blocks are observable. Best-effort — never blocks the
+ *     deny decision.
  */
 
+import { appendFileSync, mkdirSync, chmodSync, existsSync } from "fs";
+import { join } from "path";
+import { EVENT_TYPES } from "../../taps/cc-events/hooks/lib/event-taxonomy";
+
 interface HookInput {
-  session_id: string;
+  session_id?: string;
   tool_name: string;
   tool_input: { command?: string } | string;
 }
@@ -94,10 +109,107 @@ function stripEnvPrefix(command: string): string {
   );
 }
 
+// =============================================================================
+// Pass / deny output — Claude Code PreToolUse hook protocol.
+// =============================================================================
+
+/** Emit the pass-through decision (unchanged contract). */
+function allow(): void {
+  console.log(JSON.stringify({ continue: true }));
+}
+
+/**
+ * Emit Claude Code's structured PreToolUse *deny* decision. The
+ * `permissionDecisionReason` surfaces back to the agent (and the
+ * Cortex→Discord relay) — it replaces the old `process.exit(2)` +
+ * stderr line, which got swallowed on the way to the operator.
+ */
+function deny(reason: string): void {
+  console.log(
+    JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "deny",
+        permissionDecisionReason: reason,
+      },
+    }),
+  );
+}
+
+// =============================================================================
+// Telemetry — emit a `tool.bash.blocked` event into the cc-events pipeline.
+// Mirrors EventLogger.hook.ts: HTTP POST to the dashboard ingest endpoint as
+// primary delivery, JSONL append as fallback/archive. Best-effort — a failure
+// here must never affect the deny decision.
+// =============================================================================
+
+const INGEST_URL = "http://localhost:8766/api/events/ingest";
+const EVENTS_DIR = join(process.env.HOME ?? "~", ".claude", "events");
+const RAW_DIR = join(EVENTS_DIR, "raw");
+
+/** Shape mirrors `RawEvent` from src/taps/cc-events/hooks/lib/event-types.ts. */
+function buildBlockEvent(
+  sessionId: string,
+  reason: string,
+  command: string,
+): Record<string, unknown> {
+  return {
+    event_id: crypto.randomUUID(),
+    event_type: EVENT_TYPES.BASH_BLOCKED,
+    timestamp: new Date().toISOString(),
+    session_id: sessionId,
+    grove_channel: process.env.GROVE_CHANNEL,
+    agent_id: process.env.GROVE_AGENT_ID,
+    agent_name: process.env.GROVE_AGENT_NAME,
+    network_id: process.env.GROVE_NETWORK,
+    source: { hook: "PreToolUse", tool_name: "Bash" },
+    payload: {
+      reason,
+      command_preview: command.slice(0, 200),
+      project: process.env.GROVE_PROJECT,
+      entity: process.env.GROVE_ENTITY,
+      operator: process.env.GROVE_OPERATOR,
+    },
+  };
+}
+
+/**
+ * Emit the block event. Never throws — telemetry is observability, not a
+ * gate. Returns once both the POST attempt and the JSONL append have been
+ * tried (each independently best-effort).
+ */
+async function emitBlockEvent(
+  sessionId: string,
+  reason: string,
+  command: string,
+): Promise<void> {
+  const event = buildBlockEvent(sessionId, reason, command);
+
+  // Primary: HTTP POST to the dashboard ingest endpoint (500ms cap).
+  try {
+    await fetch(INGEST_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(event),
+      signal: AbortSignal.timeout(500),
+    });
+  } catch { /* dashboard down / refused — fall through to JSONL */ }
+
+  // Fallback/archive: JSONL append next to the EventLogger's raw events.
+  try {
+    if (!existsSync(RAW_DIR)) {
+      mkdirSync(RAW_DIR, { recursive: true, mode: 0o700 });
+    }
+    const filePath = join(RAW_DIR, `${sessionId}.jsonl`);
+    appendFileSync(filePath, JSON.stringify(event) + "\n");
+    chmodSync(filePath, 0o600);
+  } catch { /* filesystem unavailable — give up silently */ }
+}
+
 async function main(): Promise<void> {
   // Not a Grove session — pass through silently
   if (!process.env.GROVE_CHANNEL) {
-    console.log(JSON.stringify({ continue: true }));
+    allow();
     return;
   }
 
@@ -105,7 +217,7 @@ async function main(): Promise<void> {
   // Bot sessions also set GROVE_AGENT_ID but override via GROVE_BASH_GUARD config,
   // so they still get guarded by the loadConfig() path below.
   if (process.env.GROVE_AGENT_ID) {
-    console.log(JSON.stringify({ continue: true }));
+    allow();
     return;
   }
 
@@ -126,18 +238,18 @@ async function main(): Promise<void> {
     await Promise.race([readLoop, new Promise<void>((r) => setTimeout(r, 200))]);
 
     if (!raw.trim()) {
-      console.log(JSON.stringify({ continue: true }));
+      allow();
       return;
     }
     input = JSON.parse(raw) as HookInput;
   } catch {
-    console.log(JSON.stringify({ continue: true }));
+    allow();
     return;
   }
 
   // Only guard Bash commands
   if (input.tool_name !== "Bash") {
-    console.log(JSON.stringify({ continue: true }));
+    allow();
     return;
   }
 
@@ -149,9 +261,12 @@ async function main(): Promise<void> {
   const command = stripEnvPrefix(rawCommand).trim();
 
   if (!command) {
-    console.log(JSON.stringify({ continue: true }));
+    allow();
     return;
   }
+
+  const sessionId =
+    input.session_id ?? process.env.CLAUDE_SESSION_ID ?? "unknown";
 
   // Handle chained commands: split on && ; || and check each part
   const parts = command.split(/\s*(?:&&|\|\||;)\s*/);
@@ -159,7 +274,7 @@ async function main(): Promise<void> {
 
   // G-300: Guard disabled (operator DM) — allow everything
   if (config === null) {
-    console.log(JSON.stringify({ continue: true }));
+    allow();
     return;
   }
 
@@ -178,10 +293,13 @@ async function main(): Promise<void> {
             if (repos.length > 0) {
               const repo = extractGhRepo(trimmed);
               if (repo && !repos.includes(repo)) {
-                console.error(
-                  `[GROVE BASH GUARD] Blocked: repo "${repo}" not in allowlist [${repos.join(", ")}]`,
-                );
-                process.exit(2);
+                const reason =
+                  `[Grove Bash Guard] Blocked "${trimmed.slice(0, 80)}": ` +
+                  `repo "${repo}" is not in the allowed repo list ` +
+                  `[${repos.join(", ")}].`;
+                await emitBlockEvent(sessionId, reason, command);
+                deny(reason);
+                return;
               }
             }
           }
@@ -192,17 +310,20 @@ async function main(): Promise<void> {
     }
 
     if (!matched) {
-      console.error(
-        `[GROVE BASH GUARD] Blocked: "${trimmed.slice(0, 80)}" not in allowlist`,
-      );
-      process.exit(2);
+      const reason =
+        `[Grove Bash Guard] Blocked "${trimmed.slice(0, 80)}": ` +
+        `command does not match any rule in the bash allowlist. ` +
+        `Ask the operator to widen the allowlist if this command is needed.`;
+      await emitBlockEvent(sessionId, reason, command);
+      deny(reason);
+      return;
     }
   }
 
   // All parts matched — allow
-  console.log(JSON.stringify({ continue: true }));
+  allow();
 }
 
 main().catch(() => {
-  console.log(JSON.stringify({ continue: true }));
+  allow();
 });

--- a/src/runner/hooks/bash-guard.hook.ts
+++ b/src/runner/hooks/bash-guard.hook.ts
@@ -297,8 +297,10 @@ async function main(): Promise<void> {
                   `[Grove Bash Guard] Blocked "${trimmed.slice(0, 80)}": ` +
                   `repo "${repo}" is not in the allowed repo list ` +
                   `[${repos.join(", ")}].`;
-                await emitBlockEvent(sessionId, reason, command);
+                // Write the security decision FIRST — telemetry I/O
+                // (a filesystem appendFileSync) must never delay a deny.
                 deny(reason);
+                await emitBlockEvent(sessionId, reason, command);
                 return;
               }
             }
@@ -314,8 +316,10 @@ async function main(): Promise<void> {
         `[Grove Bash Guard] Blocked "${trimmed.slice(0, 80)}": ` +
         `command does not match any rule in the bash allowlist. ` +
         `Ask the operator to widen the allowlist if this command is needed.`;
-      await emitBlockEvent(sessionId, reason, command);
+      // Write the security decision FIRST — telemetry I/O
+      // (a filesystem appendFileSync) must never delay a deny.
       deny(reason);
+      await emitBlockEvent(sessionId, reason, command);
       return;
     }
   }

--- a/src/taps/cc-events/hooks/lib/event-taxonomy.ts
+++ b/src/taps/cc-events/hooks/lib/event-taxonomy.ts
@@ -16,6 +16,10 @@ export const EVENT_TYPES = {
 
   // Tool usage
   BASH_EXECUTED: "tool.bash.executed",
+  // Emitted by the Grove bash-guard hook when a command is denied. Carries
+  // `reason` + `command_preview` in the payload so blocks are observable
+  // on the dashboard instead of being lost in the Cortex→Discord relay.
+  BASH_BLOCKED: "tool.bash.blocked",
   FILE_CHANGED: "tool.file.changed",
   FILE_READ: "tool.file.read",
   AGENT_SPAWNED: "tool.agent.spawned",

--- a/src/taps/cc-events/hooks/lib/event-types.ts
+++ b/src/taps/cc-events/hooks/lib/event-types.ts
@@ -19,7 +19,13 @@ export const RawEventSchema = z.object({
   agent_name: z.string().optional(),
   network_id: z.string().optional(),
   source: z.object({
-    hook: z.enum(["PostToolUse", "Stop", "UserPromptSubmit", "SessionStart"]),
+    hook: z.enum([
+      "PreToolUse",
+      "PostToolUse",
+      "Stop",
+      "UserPromptSubmit",
+      "SessionStart",
+    ]),
     tool_name: z.string().optional(),
   }),
   payload: z.record(z.string(), z.unknown()),


### PR DESCRIPTION
## Summary

The Grove bash-guard PreToolUse hook (`src/runner/hooks/bash-guard.hook.ts`) blocked disallowed commands with `process.exit(2)` + a `console.error` line. That reason was lost in the Cortex→Discord relay — the operator saw a blocked command but never *why*. This PR makes blocks observable on two channels.

### Task B — observability for the bash-guard

1. **Structured PreToolUse deny.** The hook now emits Claude Code's structured deny decision on stdout:
   ```json
   {"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"<which command, which rule/repo failed>"}}
   ```
   instead of `exit(2)` + stderr. The `permissionDecisionReason` names the offending command part and whether it failed the allowlist or a repo restriction, so it surfaces back to the agent (and the relay). The pass-through contract (`{"continue":true}`) is unchanged. Schema confirmed against the official `hook-development` skill (`hookSpecificOutput.permissionDecision`) and the task spec.

2. **Telemetry emission.** Every block also emits a `tool.bash.blocked` event into the cc-events pipeline — HTTP POST to the dashboard ingest endpoint (`localhost:8766/api/events/ingest`) with a JSONL fallback, mirroring `EventLogger.hook.ts` exactly. Best-effort: a telemetry failure never affects the deny decision. `RawEventSchema.source.hook` gains `"PreToolUse"` and the taxonomy gains a `BASH_BLOCKED` entry so the event validates through `relay.ts`.

3. **Gates preserved.** The `GROVE_CHANNEL` activation gate, `GROVE_AGENT_ID` bypass, and `GROVE_BASH_GUARD` disabled-config behaviour are all unchanged.

### Follow-up (not in this PR)

The telemetry emission reuses the cc-events HTTP+JSONL path (the established, non-invasive route). A deeper integration — emitting block events onto the NATS bus as first-class system events alongside heartbeats — would be a larger change to `src/bus/system-events.ts` and is left as a follow-up.

### Task A (separate, not a code change)

Widening Luna's bash allowlist is a change to the hand-maintained runtime file `~/.config/cortex/cortex.yaml` (gitignored — not in this repo). It adds `policy.principals[luna].session_config.default.bash_allowlist`. Verified that `resolvePolicyAccess` (`src/common/policy/resolve-access.ts:138-147`) reads `session_config.default` for bot/channel sessions (`msg.isDM` is false), so the widen is effective. Details in the agent report.

## Test plan

- [x] `bun test src/runner/hooks/__tests__/bash-guard.hook.test.ts` — 11 new tests (pass-through, structured deny, block telemetry)
- [x] `bun test src/runner/ src/taps/` — 474 pass, 0 fail
- [x] `bunx eslint` clean on changed files
- [x] `bunx tsc --noEmit` — no errors in changed files (pre-existing errors in unrelated test files only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)