### PR TITLE
docs: cortex CONTEXT.md glossary + bus-addressing model

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,109 @@
+# Cortex — Context
+
+Cortex is the M7 collaboration surface of the metafactory Myelin layer model: it consumes the bus, runs agents, dispatches work, and presents activity to the principal through Mission Control and chat adapters.
+
+This is the canonical domain glossary for the **cortex** bounded context — one canonical term per concept; aliases are listed under _Avoid_. Boundary terms shared with soma, myelin, and signal are reconciled in `compass/ecosystem/CONTEXT-MAP.md`. Resolved by a `grill-with-docs` session (Q1–Q14).
+
+## Language
+
+### Principals, stacks, networks
+
+**Principal**:
+The human who owns and runs Cortex stacks — root of the trust and policy model, and the identity that scopes every subject the principal's stacks emit. One principal runs one or more **stacks** (e.g. `andreas` runs `andreas/meta-factory`, `andreas/work`, `andreas/halden`).
+_Avoid_: operator, user, owner, human, org
+
+**Stack**:
+One running cortex deployment under a **principal** — its own `cortex.yaml`, signing identity, subject sub-namespace, and JetStream consumers. A principal runs one or more stacks side by side, purpose-named. The second subject segment: `local.{principal}.{stack}.…`.
+_Avoid_: deployment, instance, node. Never use `stack` for the M1–M7 architecture — that is the **Myelin layer model**.
+
+**Network**:
+A federation of **principals** whose **stacks** interconnect at the NATS leaf-node layer — `metafactory` is the network this ecosystem runs on. A network is **not a subject segment**: it is deployment topology. Cross-principal reach is the `federated.` **scope** prefix, never a network name on the wire. A principal may belong to more than one network.
+_Avoid_: federation (that is the relationship, not the thing), mesh, fabric, org, cluster
+
+### Assistants & agents
+
+**Assistant**:
+The named being cortex runs — Luna, Echo, Forge, Pilot. Has a persona, a voice, and continuity of identity. An assistant is hosted by an **agent**. The assistant name is what the bus routes to: the `@{assistant}` segment in Direct/Delegate **dispatch** (`@forge`, `@pilot`).
+_Avoid_: persona, bot, DA, character
+
+**Agent**:
+The stack-local, long-lived runtime identity (daemon) that hosts an **assistant** on the bus — its own NKey signing identity and a JetStream consumer. An agent has **no independent name**: it is reached via the **assistant** it hosts plus the **stack** it runs on. The same assistant may be hosted by different agents on different stacks ("same assistant, different agent surfaces").
+_Avoid_: bot, persona, daemon (as the domain term)
+
+**Sub-agent**:
+A short-lived task spawned via Claude Code's `Agent` tool — e.g. the Engineer or Explore sub-agents the pilot loop uses. Not an **agent**: no bus identity, no persistence. Always carries the `sub-` qualifier; never bare `agent`.
+_Avoid_: agent (bare), worker, helper
+
+### The bus
+
+**Subject**:
+The dotted NATS routing string a message is published to or subscribed on — `{scope}.{principal}.{stack}.{domain}.{entity}.{action}`. Routing lives in the subject, not in code. Subscribers match with NATS wildcards (`*`, `>`).
+_Avoid_: topic (the Kafka/MQTT word — NATS subjects have different semantics), channel, path
+
+**Scope**:
+How far a **subject** may travel, set by its prefix — exactly three values: `local` (never leaves the **principal** boundary), `federated` (crosses to peer principals in a **network**), `public` (unrestricted; carries no principal/stack segment).
+_Avoid_: reach, visibility, tier, level
+
+**Domain**:
+The functional-domain segment of a **subject** — groups related signals. Values: `tasks`, `agent`, `system`, `code`, `review`, `dispatch`. Always the segment ("the tasks domain").
+_Avoid_: channel, category — and never use `domain` for the DDD bounded-context sense (that is always written **bounded context**).
+
+**Envelope**:
+The signed wrapper that travels on a **subject** — metadata (`sovereignty`, `signed_by[]`, `correlation_id`, `source`, `type`) around a **payload**. Every bus message is an envelope.
+_Avoid_: message (too loose — say envelope for the wrapper, payload for the content), packet
+
+**Payload**:
+The inner content body of an **envelope** — the domain data, distinct from the envelope's routing/trust metadata.
+_Avoid_: message, body, data
+
+**Capability**:
+A declared, bus-routable ability — e.g. `code-review.typescript`. An **assistant** declares the capabilities it offers; the `tasks.{capability}.{subcapability}` **subject** routes on it; an **agent**'s JetStream consumer filters by it. A capability may be *fulfilled by* a soma skill, but the capability is the wire-facing ability, not the implementation.
+_Avoid_: skill (that is the SOMA implementation term), ability, function, command, tool
+
+**Dispatch**:
+The act of routing a unit of work to an **assistant** over the bus. Three modes, by how the recipient is chosen — **Offer**: published to a **capability**, any capable assistant *claims* it (competing consumers, exactly-one delivery); **Direct**: sent to one named assistant (`@{assistant}`), one-shot; **Delegate**: sent to one named assistant that orchestrates a multi-step outcome. Unclaimed work escalates to **dead-letter**.
+_Avoid_: routing, assignment, hand-off. Never call the Offer mode "broadcast" — exactly one assistant claims an offered task, not all.
+
+## Relationships
+
+- A **principal** runs one or more **stacks**, and belongs to one or more **networks**.
+- A **stack** hosts one or more **agents**.
+- An **agent** hosts exactly one **assistant**; the same assistant may be hosted by different agents on different stacks.
+- An **agent** may spawn zero or more **sub-agents**.
+- An **assistant** declares one or more **capabilities**.
+- Work is **dispatched** to an **assistant** as an **envelope** published on a **subject**.
+- A **subject** = `{scope}.{principal}.{stack}.{domain}.…`; its **scope** sets how far it travels.
+
+## Example dialogue
+
+> **Dev:** Pilot timed out asking for a code review. Where did it go?
+> **Domain expert:** Pilot is an **assistant** — it ran an **Offer** **dispatch**: published a review task to a **capability**, `code-review.typescript`, on the **subject** `local.andreas.meta-factory.tasks.code-review.typescript`.
+> **Dev:** So any reviewer could claim it?
+> **Expert:** Right — Offer mode. Any **agent** whose **assistant** declares that **capability** can claim the **envelope**. Echo's agent on the `andreas/meta-factory` **stack** should have.
+> **Dev:** It didn't. The subject said `local.metafactory.meta-factory.…`.
+> **Expert:** There's the bug. The second segment is the **principal** — `andreas`. `metafactory` is the **network**, not a principal; it must never be a subject segment. Pilot built the subject with the wrong **principal**, so Echo's agent never saw the envelope.
+> **Dev:** And if I want *only* Echo to review it?
+> **Expert:** Then it's a **Direct** dispatch — `local.andreas.meta-factory.tasks.@echo.code-review.typescript`. `@echo` is the **assistant**. If Echo had to drive it to merge across several steps, that'd be **Delegate**.
+
+## Flagged ambiguities
+
+- **`operator` → `principal`.** cortex historically said `operator` (`operator.id`, "operator cockpit", the `{org}` segment). Resolved: **`principal`** ecosystem-wide, matching `soma:principal`. Carries into `cortex.yaml` schema, subject derivation, Mission Control copy.
+- **`agent` was overloaded** — the named being, the runtime identity, *and* a Claude Code spawned task. Resolved into **assistant** / **agent** / **sub-agent**.
+- **`persona` → `assistant`.** `persona` is not a domain entity. `personas/luna.md` stays a valid filename ("the assistant's persona file").
+- **The `@`-segment names an `assistant`** — `@{assistant}`. myelin's `namespace.md` calls it a "principal address"; its examples ("Forge", "Pilot") are assistants. The hosting **agent** is resolved from `(stack, assistant)`; it carries no wire name.
+- **`stack` meant two things** — the M1–M7 layering *and* a deployment unit. Resolved: `stack` is the **deployment unit**; the M1–M7 layering is the **Myelin layer model**.
+- **`domain` meant two things** — the `{domain}` subject segment *and* the DDD sense. Resolved: bare `domain` is only the segment; the DDD concept is always **bounded context**.
+- **`topic` → `subject`.** "Topic" is the Kafka/MQTT word; NATS uses **subject**.
+- **`reach` → `scope`.** myelin's `namespace.md` heads the prefix column "Reach"; canonical is **scope**.
+- **`broadcast` → `Offer`.** A broadcast reaches everyone; that dispatch mode is claimed by exactly one assistant. The modes are **Offer / Direct / Delegate**.
+
+## Boundary with adjacent contexts
+
+Reconciled in full in `compass/ecosystem/CONTEXT-MAP.md`:
+
+- `cortex:principal` **≡** `soma:principal` — identical concept, identical term (Q2).
+- `cortex:assistant` **≡** `soma:assistant` — the named being.
+- `cortex:agent` **≡** `soma:"Cortex agent"` — SOMA always qualifies `agent`; within cortex's own bounded context bare `agent` is canonical.
+- `cortex:sub-agent` **≡** `soma:"Claude Code sub-agent"`.
+- `cortex:capability` is **distinct from** `soma:skill` — a capability is the bus-routable ability tag; a skill is the packaged implementation that may fulfil it.
+- **myelin** owns the **subject** grammar (a published language cortex consumes). Pending myelin alignment, filed as a namespace.md issue: `{org}` → `{principal}`, the `@`-segment relabelled an *assistant address*, "Reach" → "Scope".

--- a/docs/design-bus-addressing.md
+++ b/docs/design-bus-addressing.md
@@ -2,8 +2,9 @@
 
 **Status:** canonical reference — draft for review
 **Owners:** Andreas + Soma
-**Audience:** anyone building or operating a tool that publishes to or subscribes on the metafactory NATS bus — cortex, pilot, arc, signal, future M7 apps
-**Grammar authority:** [`myelin/specs/namespace.md`](https://github.com/the-metafactory/myelin/blob/main/specs/namespace.md) defines the wire grammar; this doc resolves *what the segments mean* and *how every tool must derive them consistently*.
+**Audience:** anyone building or operating a tool that publishes to or subscribes on the metafactory NATS bus — cortex, pilot, arc, signal, future L7 surfaces
+**Grammar authority:** [`myelin/specs/namespace.md`](https://github.com/the-metafactory/myelin/blob/main/specs/namespace.md) defines the wire grammar.
+**Vocabulary authority:** every term here is defined canonically in [`cortex/CONTEXT.md`](../CONTEXT.md), [`myelin/CONTEXT.md`](https://github.com/the-metafactory/myelin/blob/main/CONTEXT.md), and `soma/CONTEXT.md`, reconciled in `compass/ecosystem/CONTEXT-MAP.md`. This document *uses* those terms; it does not redefine them.
 
 ---
 
@@ -16,112 +17,76 @@ The same class of bug keeps recurring:
 - **cortex#318** — pilot published 6-segment subjects, cortex subscribed 4-segment
 - **2026-05-20** — `pilot request-review` times out: pilot publishes review tasks to `local.metafactory.meta-factory.tasks.code-review.*` but the cortex bot consumes `local.andreas.meta-factory.tasks.code-review.*`. The tasks land in a JetStream consumer no bot polls.
 
-Every instance is the same underlying defect: **tools disagree on what the segments of a NATS subject mean, because the meaning was never written down canonically.** The myelin spec defines the *grammar* but its own examples are ambiguous (it shows both `local.andreas.research.*` and `local.metafactory.default.*` as valid — implying the first segment could be a person *or* an organisation).
-
-This document ends the ambiguity. It is the canonical statement. When a tool's behaviour disagrees with this doc, the tool is wrong.
+Every instance is the same underlying defect: **tools disagreed on what the segments of a NATS subject mean, because the meaning was never written down canonically.** A `grill-with-docs` session (2026-05) resolved the vocabulary into three `CONTEXT.md` glossaries; this document is the addressing/routing spec built on them. When a tool's behaviour disagrees with this doc, the tool is wrong.
 
 ## 2. The verified root cause (2026-05-20 investigation)
 
-| Tool | How it derives the first subject segment (`{org}`) | Result for this deployment |
+The first segment after the scope prefix is the **principal** — the human who owns the stack. Three tools derived it three ways (field names below are the pre-grill names; `operator.id` is being renamed `principal.id`):
+
+| Tool | How it derived the first segment | Result for this deployment |
 |---|---|---|
-| **cortex** | From `operator.id` in `cortex.yaml` (`src/common/types/cortex-config.ts` — "Operator identifier — used as the `{org}` subject segment"). Review-consumer subscribes `local.${operator.id}.${stack}.tasks.code-review.>`. | `local.andreas.meta-factory.…` |
-| **pilot** | **Hardcoded.** `publish-review-request.ts` sets envelope `source: "metafactory.pilot.${network}"`; myelin's `deriveNatsSubject()` takes `source.split('.')[0]` → `metafactory`. Pilot never reads `operator.id`. | `local.metafactory.meta-factory.…` |
-| **arc** | `arc nats provision-streams --network <X>` mints the consumer filter with `{org} = <X>`. `--network metafactory` → consumer filters `local.metafactory.…` | `cortex-review-consumer-metafactory-echo` |
+| **cortex** | from `operator.id` in `cortex.yaml` — the principal identity. Review-consumer subscribes `local.{principal}.{stack}.tasks.code-review.>`. | `local.andreas.meta-factory.…` |
+| **pilot** | **hardcoded.** `publish-review-request.ts` sets envelope `source: "metafactory.pilot.{network}"`; myelin's `deriveNatsSubject()` takes `source.split('.')[0]` → `metafactory`. pilot never reads the principal. | `local.metafactory.meta-factory.…` |
+| **arc** | `arc nats provision-streams --network <X>` mints the consumer filter with the first segment = `<X>`. `--network metafactory` → `local.metafactory.…` | `cortex-review-consumer-metafactory-echo` |
 
-**The mismatch:** cortex says `{org} = andreas`. pilot and arc say `{org} = metafactory`. Pilot's publish lands in the `metafactory`-org consumer; the cortex bot polls the `andreas`-org consumer. They never meet.
+**The mismatch:** cortex says the first segment is `andreas` (the **principal**). pilot and arc say `metafactory` (a **network**). pilot's publish lands in the network-named consumer; the cortex bot polls the principal-named consumer. They never meet.
 
-This is not a grammar bug (cortex#318 genuinely fixed the segment *count*). It is a **semantic bug**: the first segment's *meaning* is contested. pilot treats it as the organisation/network name; cortex treats it as the operator. Both cannot be right.
+Not a grammar bug (cortex#318 fixed the segment *count*). A **semantic bug**: the first segment's meaning was contested — pilot/arc treated it as the network, cortex as the principal. The grill settled it: **the first segment is the principal. A network is never a subject segment.**
 
-## 3. Core vocabulary — definitions are canonical
+## 3. Vocabulary
 
-Five identifiers. They are **not interchangeable**. Most of the recurring pain comes from treating two of them as one.
+This document does not redefine terms — the three `CONTEXT.md` glossaries do. Quick reference for the addressing terms, and which glossary owns each:
 
-### 3.1 Operator
-
-A **human or team** that runs one or more Cortex stacks. Identified by a short slug: `andreas`, `team-research`, `acme-platform`.
-
-The operator is the **unit of sovereignty**. `local.` signals never cross an operator boundary. Trust, signing identity, and policy principals are all scoped to an operator.
-
-> **The operator IS the `{org}` subject segment.** myelin's spec calls the segment `{org}` and says stacks are "under the operator identified by `{org}`" — i.e. the spec's own prose equates `{org}` with the operator. For a solo operator there is no separate "organisation"; `andreas` is both. This doc makes the equivalence explicit and binding: **`{org}` ::= operator id**, always, in every tool.
-
-### 3.2 Network
-
-A **federation of operators** connected at the NATS layer via leaf nodes. `metafactory` is a network. So is a hypothetical `acme-clients` network.
-
-> **A network is NOT a subject segment.** It is deployment topology — which leaf nodes peer with which. An operator participates in a network by connecting their NATS leaf node to it. Cross-operator reach is expressed by the **`federated.` prefix**, never by putting a network name in the subject.
->
-> This is the single most important correction in this document. `metafactory` must never appear as the first segment of a subject. pilot doing so is the bug.
-
-An operator may belong to **more than one** network (see §9). The network name lives in deployment config (NATS leaf-node config, `arc` provisioning), not on the wire.
-
-### 3.3 Stack
-
-A **deployment unit** under an operator — one running Cortex process, one `cortex.{stack}.yaml`, one signing identity, one subject sub-namespace. Identified `{operator}/{stack}`: `andreas/meta-factory`, `andreas/work`, `andreas/halden`.
-
-The stack is the second subject segment. An operator runs many stacks side by side; the `{stack}` segment lets subscribers, JetStream consumers, audit trails, and federation routers tell them apart without payload inspection.
-
-### 3.4 Principal
-
-An **addressable agent identity** — `@echo`, `@luna`, `@forge`, `@cortex-halden`. Carried in the `@`-prefixed segment of the `tasks` domain (and the `agent` domain, per G-1114). Used for **point-to-point** routing: "this envelope is for *that specific agent*."
-
-A principal is backed by an NKey / DID and verified via the `signed_by[]` chain. Principals are how Direct and Delegate routing target one recipient instead of a competing-consumer pool.
-
-### 3.5 Scope
-
-The **reach** of a signal — one of three, set by the subject prefix:
-
-| Scope | Prefix | Reach |
+| Term | One-line meaning | Owner glossary |
 |---|---|---|
-| **internal** | `local.` | never leaves the operator boundary |
-| **federated** | `federated.` | crosses to peer operators in the same network, subject to envelope sovereignty rules |
-| **public** | `public.` | unrestricted; no `{org}` or `{stack}` segment at all |
+| **principal** | the human who owns and runs stacks — the `{principal}` subject segment | soma / cortex / myelin (aligned) |
+| **identity** | any authenticatable entity (DID + keypair) — principals, agents, services, hubs | myelin |
+| **network** | a federation of principals at the NATS leaf-node layer (`metafactory`) — **never a subject segment** | cortex / myelin |
+| **hub** | a network's trust-anchor identity | myelin |
+| **stack** | one running cortex deployment under a principal — the `{stack}` subject segment | cortex |
+| **assistant** | the named being (Luna, Echo, Forge, Pilot) — the `@{assistant}` routing segment | soma / cortex |
+| **agent** | the stack-local runtime daemon hosting an assistant — no wire name; resolved from `(stack, assistant)` | cortex |
+| **scope** | how far a subject travels — `local` / `federated` / `public` (the prefix) | cortex |
+| **subject / domain / envelope / capability / dispatch** | the wire grammar + message + work-routing vocabulary | myelin (grammar), cortex (dispatch) |
 
-### 3.6 Summary — the five-identifier model
-
-```
-operator   andreas              the human/team — the {org} segment, the sovereignty boundary
-network    metafactory          a federation of operators — NATS topology, NOT on the wire
-stack      meta-factory         a deployment under the operator — the {stack} segment
-principal  @echo                an addressable agent — the @{principal} segment
-scope      local/federated/public   reach — the subject prefix
-```
+The single most important rule, stated once: **the principal is the first subject segment; the network is deployment topology and never appears on the wire.**
 
 ## 4. The canonical subject grammar
 
-Per `myelin/specs/namespace.md`, with this doc binding the segment meanings:
+Per `myelin/specs/namespace.md`, with the grill's segment-meaning resolutions applied:
 
 ```
-local.{operator}.{stack}.{domain}.{entity}.{action}
-federated.{operator}.{stack}.{domain}.{entity}.{action}
+local.{principal}.{stack}.{domain}.{entity}.{action}
+federated.{principal}.{stack}.{domain}.{entity}.{action}
 public.{domain}.{entity}.{action}
 ```
 
-- `{operator}` — the operator slug. **Derived from one source of truth per stack** (see §10). Never hardcoded, never a network name.
-- `{stack}` — the stack slug (second half of `{operator}/{stack}`). `default` for single-stack operators.
-- `{domain}` — functional domain: `tasks`, `code`, `agent`, `system`, `review`, `dispatch`, …
-- `{entity}.{action}` — the signal, or for the `tasks`/`agent` domains the capability/action grammar below.
-- `public.` carries **no operator/stack** — public signals are not operator-scoped.
+- `{principal}` — the principal slug. **Derived from one source of truth per stack** (§10). Never hardcoded, never a network name.
+- `{stack}` — the stack slug (second half of `{principal}/{stack}`). `default` for single-stack principals.
+- `{domain}` — the functional-domain segment: `tasks`, `agent`, `system`, `code`, `review`, `dispatch`.
+- `{entity}.{action}` — the signal; or the capability / routing grammar below for the `tasks` and `agent` domains.
+- `public.` carries **no principal/stack** — public signals are not principal-scoped.
 
-### 4.1 The `tasks` domain — routed work
+### 4.1 The `tasks` domain — dispatched work
 
 ```
-local.{operator}.{stack}.tasks.{capability}.{subcapability}      ← Broadcast
-local.{operator}.{stack}.tasks.@{principal}.{capability}         ← Direct / Delegate
-local.{operator}.{stack}.tasks.dead-letter.{capability}          ← unclaimable escalation
+local.{principal}.{stack}.tasks.{capability}.{subcapability}     ← Offer
+local.{principal}.{stack}.tasks.@{assistant}.{capability}        ← Direct / Delegate
+local.{principal}.{stack}.tasks.dead-letter.{capability}         ← unclaimable escalation
 ```
 
 ### 4.2 The `agent` domain — presence + lifecycle (G-1114)
 
 ```
-local.{operator}.{stack}.agent.{action}.@{principal}
-federated.{operator}.{stack}.agent.{action}.@{principal}
+local.{principal}.{stack}.agent.{action}.@{assistant}
+federated.{principal}.{stack}.agent.{action}.@{assistant}
 ```
 
-where `{action}` ∈ `online | heartbeat | offline | capabilities-changed`. This is the grammar G-1114 (Agent Network Topology) builds on — consistent with this model: operator is `{org}`, network is not on the wire, federation via the `federated.` prefix.
+where `{action}` ∈ `online | heartbeat | offline | capabilities-changed`. The `@{assistant}` segment names the assistant whose hosting agent the lifecycle event is about.
 
-## 5. Worked example — operator `andreas`, network `metafactory`, three stacks
+## 5. Worked example — principal `andreas`, network `metafactory`, three stacks
 
-Operator `andreas` belongs to the `metafactory` network and runs three stacks:
+Principal `andreas` belongs to the `metafactory` network and runs three stacks:
 
 | Stack | FQSI | `local.` prefix | `federated.` prefix |
 |---|---|---|---|
@@ -129,169 +94,127 @@ Operator `andreas` belongs to the `metafactory` network and runs three stacks:
 | work | `andreas/work` | `local.andreas.work.>` | `federated.andreas.work.>` |
 | halden | `andreas/halden` | `local.andreas.halden.>` | `federated.andreas.halden.>` |
 
-Note what is **absent**: the word `metafactory` appears nowhere in any subject. It is the network — the leaf-node federation `andreas` participates in. It is config, not wire-form.
+What is **absent**: `metafactory` appears in no subject. It is the network — the leaf-node federation `andreas` participates in. Config, not wire-form.
 
-A code-review request for a PR, dispatched by pilot from the meta-factory stack, broadcast to any qualified reviewer:
+A code-review task **Offered** to any qualified assistant from the meta-factory stack:
 
 ```
 local.andreas.meta-factory.tasks.code-review.typescript
 ```
 
-The same request, directed point-to-point to Echo:
+The same task **Directed** point-to-point to the assistant Echo:
 
 ```
 local.andreas.meta-factory.tasks.@echo.code-review.typescript
 ```
 
-Echo announcing itself on the bus (G-1114):
+Echo's agent announcing the assistant online (G-1114):
 
 ```
 local.andreas.meta-factory.agent.online.@echo
 ```
 
+The envelope `source` for that announcement is `andreas.meta-factory.echo` — `{principal}.{stack}.{assistant}` (myelin grill-Q3).
+
 ## 6. Scopes in practice
 
-- **internal (`local.`)** — the default. Everything within one operator's stacks. Cross-*stack* but same-*operator* traffic is still `local.` — e.g. the meta-factory stack observing the work stack uses `local.andreas.work.>` (a wildcard the operator owns end-to-end). Leaf-node config prevents `local.>` from replicating off the operator's cluster.
+- **`local.`** — the default. Everything within one principal's stacks. Cross-*stack* but same-*principal* traffic is still `local.` — the meta-factory stack observing the work stack uses `local.andreas.work.>`, a wildcard the principal owns end-to-end. Leaf-node config prevents `local.>` from replicating off the principal's cluster.
+- **`federated.`** — cross-*principal*, same network. When `andreas` and another principal both peer into `metafactory`, a task `andreas` is willing to send to an external assistant goes on `federated.andreas.meta-factory.tasks.code-review.typescript`. The receiving principal's leaf node validates the envelope `sovereignty` block before accepting.
+- **`public.`** — unrestricted, no principal scoping. Registry announcements, network heartbeats. Deferred for cortex's own use (G-1114 §4.3).
 
-- **federated (`federated.`)** — cross-*operator*, same network. When `andreas` and another operator both peer into the `metafactory` network, a review request `andreas` is willing to send to an external reviewer goes on `federated.andreas.meta-factory.tasks.code-review.typescript`. The receiving operator's leaf node validates the envelope `sovereignty` block before accepting.
+## 7. Dispatch & routing
 
-- **public (`public.`)** — unrestricted, no operator scoping. Registry announcements, network heartbeats, `public.community.agent.registered`. Deferred for cortex's own use (see G-1114 §4.3); listed here for completeness.
+**Dispatch** is the act of routing a unit of work to an **assistant** over the bus. Three modes, by how the recipient is chosen:
 
-## 7. Routing patterns
-
-Two axes: **how many recipients** and **chosen how**.
-
-| Pattern | Subject shape | Semantics |
+| Mode | Subject shape | Semantics |
 |---|---|---|
-| **Broadcast** (one-to-many, open market) | `…tasks.{capability}.{sub}` | Any agent that declared `{capability}` may claim. JetStream queue-group gives exactly-one delivery per consumer group. The dispatcher does not pick the worker; the qualified pool competes. |
-| **Direct** (point-to-point) | `…tasks.@{principal}.{capability}` | Routed to exactly one named agent. "Forge, cut a release." Broker-side filter on the `@{principal}` segment — no payload inspection. |
-| **Delegate** (point-to-point, orchestrating) | `…tasks.@{principal}.{capability}` | Same wire shape as Direct; the difference is operator-facing — the recipient internally orchestrates a multi-step outcome and emits a `dispatch.*` lifecycle stream. "Pilot, drive PR #32 to merge." |
-| **Dead-letter** | `…tasks.dead-letter.{capability}` | A task that exhausted `max_deliver` without a claim, or hit a compliance block, escalates here for operator review. Capability segment preserved for per-capability monitoring. |
+| **Offer** | `…tasks.{capability}.{sub}` | Published to a **capability**; any assistant whose agent declared it may **claim** it. JetStream queue-group → exactly-one delivery. The dispatcher does not pick the worker; the qualified pool competes. *Not a broadcast — exactly one claims it.* |
+| **Direct** | `…tasks.@{assistant}.{capability}` | Routed to one named assistant, one-shot. "Forge, cut a release." Broker-side filter on `@{assistant}` — no payload inspection. |
+| **Delegate** | `…tasks.@{assistant}.{capability}` | Same wire shape as Direct; the recipient orchestrates a multi-step outcome and emits a `dispatch.*` lifecycle stream. "Pilot, drive PR #32 to merge." |
+| **dead-letter** | `…tasks.dead-letter.{capability}` | A task that exhausted `max_deliver` without a claim, or hit a compliance block, escalates here. Capability segment preserved for per-capability monitoring. |
 
-The choice is the **publisher's**: broadcast when any qualified agent will do; direct/delegate when a specific agent is wanted. Both are first-class; both are already in the myelin grammar.
+The mode is the **publisher's** choice: Offer when any qualified assistant will do; Direct/Delegate when a specific one is wanted.
 
-## 8. Multi-stack (one operator, many stacks)
+## 8. Multi-stack (one principal, many stacks)
 
 `andreas` runs three stacks. Consequences:
 
-- **`{operator}` is constant** across all three (`andreas`); `{stack}` varies. One operator, one sovereignty boundary, one `local.` namespace `local.andreas.>`.
-- **Cross-stack visibility is cheap and internal.** A Mission Control instance on the meta-factory stack can subscribe `local.andreas.>` to see all three stacks — same operator, no federation needed.
-- **Each stack has its own signing identity** (NKey) and its own JetStream consumers, named `(operator, stack, agent)` — e.g. `cortex-review-consumer-andreas-meta-factory-echo`. The consumer name MUST encode operator + stack, not a network.
-- **Per-stack `context.md`** (see §11) is how each stack's addressing identity is declared once and read by every tool.
+- **`{principal}` is constant** across all three (`andreas`); `{stack}` varies. One principal, one sovereignty boundary, one `local.andreas.>` namespace.
+- **Cross-stack visibility is cheap and internal.** A Mission Control instance on the meta-factory stack subscribes `local.andreas.>` to see all three — same principal, no federation needed.
+- **Each stack has its own signing identity** and JetStream consumers, named `(principal, stack, assistant)` — e.g. `cortex-review-consumer-andreas-meta-factory-echo`. The consumer name MUST encode principal + stack, never a network.
 
-## 9. Multi-network (one operator, many networks)
+## 9. Multi-network (one principal, many networks)
 
-An operator may peer into more than one network — e.g. `andreas` in `metafactory` and also in a client network `acme-clients`.
+A principal may peer into more than one network — `andreas` in `metafactory` and also in a client network `acme-clients`.
 
 - The network is **still not on the wire.** Both networks see `andreas`'s subjects as `local.andreas.{stack}.>` / `federated.andreas.{stack}.>`.
-- Networks are kept apart at the **NATS leaf-node layer** — which leaf nodes peer with which cluster. A `federated.` subject reaches only the operators whose leaf nodes are peered into the *same* network.
-- If the same operator slug must mean different things in two networks, that is an **operator-naming collision** and must be resolved by namespacing the operator slug (`andreas-mf`, `andreas-acme`) — not by adding a network segment. (Open question §13.1.)
+- Networks are kept apart at the **NATS leaf-node layer** — which leaf nodes peer with which cluster. A `federated.` subject reaches only the principals whose leaf nodes peer into the *same* network.
+- If the same principal slug must mean different things in two networks, that is a **principal-slug collision** — resolve by globally-unique principal slugs (`andreas-mf`, `andreas-acme`), never by adding a network segment (§13.1).
 
 ## 10. Conformance rules — binding on every tool
 
-1. **`{org}` ::= operator id. Always.** Every tool that builds a subject MUST set the first post-prefix segment to the operator identity. No hardcoded literals. No network names.
+1. **The first subject segment ::= principal id. Always.** Every tool that builds a subject sets the first post-scope segment to the principal identity. No hardcoded literals. No network names.
+2. **One source of truth per stack.** A stack's principal + stack + network are declared once, in `cortex.{stack}.yaml`. Tools READ that source — never re-derive the principal from their own config, an env var, or a literal.
+3. **A subject is derivable from a single stack's config.** Building a subject needs only: scope + that stack's principal + that stack's stack-slug + the domain/action. It never needs knowledge of the whole network — federation reach is the `federated.` prefix's job.
+4. **Network is provisioning input, never wire-form.** `arc nats` and leaf-node config consume a network name; the bus never sees it. An `arc nats` flag that places a value in the first subject segment must take the *principal*, not the *network*.
+5. **Consumer names encode `(principal, stack, assistant)`.** Never `(network, …)`. A consumer named `cortex-review-consumer-metafactory-echo` is malformed — `metafactory` is a network.
 
-2. **One source of truth per stack.** The operator + stack + network for a deployment are declared once, in that stack's `cortex.{stack}.yaml` (`operator.id`, `stack.id`) and surfaced in its `context.md` (§11). Tools READ that source. They never re-derive the operator from their own config, an env var, or a literal.
+## 11. The per-stack descriptor
 
-3. **A subject is derivable from a single stack's context.** Building a subject requires only: scope + that stack's operator + that stack's stack-slug + the domain/action. It never requires knowledge of the whole network. (Federation reach is the `federated.` prefix's job.)
+A convenience artefact (not the source of truth — `cortex.{stack}.yaml` is): a rendered, human- and agent-readable card declaring a stack's bus-addressing identity — "where am I, what subjects do I own." One per stack, at `~/.config/cortex/stack-{name}.md`.
 
-4. **Network is provisioning input, never wire-form.** `arc nats` and leaf-node config consume a network name; the bus never sees it. An `arc nats provision-streams` flag that places a value in the `{org}` segment must take the *operator*, not the *network*.
-
-5. **Consumer names encode `(operator, stack, agent)`.** Never `(network, agent)`. A consumer named `cortex-review-consumer-metafactory-echo` is malformed under this model — `metafactory` is a network.
-
-## 11. The per-stack `context.md` standard
-
-Every Cortex stack carries a **`context.md`** — the human- and agent-readable declaration of that stack's bus-addressing identity. It is the artefact a tool (or an agent at session start) reads to answer "where am I, and what subjects do I own?"
-
-`context.md` is **rendered from `cortex.{stack}.yaml`** — `cortex.yaml` stays the single machine source of truth (rule §10.2); `context.md` is its readable projection. It lives beside the config: `~/.config/cortex/context-{stack}.md`.
-
-### 11.1 Standard template
+> **Distinct from `CONTEXT.md`.** `CONTEXT.md` (repo root, uppercase) is the bounded-context *glossary*. The per-stack descriptor is a *runtime identity card* for one deployment. Different artefacts; do not conflate.
 
 ```markdown
-# Stack Context — {operator}/{stack}
+# Stack — andreas/meta-factory
 
 | Field | Value |
 |---|---|
-| operator | {operator} |
-| stack | {stack} |
-| network(s) | {network[, network…]} |
-| fully-qualified stack identity | {operator}/{stack} |
-| signing identity (NKey pub) | {nkey_pub} |
-
-## Subject namespace this stack owns
-
-- internal:   `local.{operator}.{stack}.>`
-- federated:  `federated.{operator}.{stack}.>`
-
-## Principals on this stack
-
-- `@{agent}` — {displayName}, capabilities: {…}
-
-## Routing into this stack
-
-- broadcast a task:  `local.{operator}.{stack}.tasks.{capability}.{sub}`
-- direct to an agent: `local.{operator}.{stack}.tasks.@{principal}.{capability}`
-
-## Conformance
-
-Any tool publishing toward this stack MUST set the operator segment to
-`{operator}` — read it from here or from cortex.{stack}.yaml. Never
-hardcode; never substitute a network name. See docs/design-bus-addressing.md.
-```
-
-### 11.2 Worked example — `andreas/meta-factory`
-
-```markdown
-# Stack Context — andreas/meta-factory
-
-| Field | Value |
-|---|---|
-| operator | andreas |
+| principal | andreas |
 | stack | meta-factory |
 | network(s) | metafactory |
-| fully-qualified stack identity | andreas/meta-factory |
-| signing identity (NKey pub) | UD7OGEVBNJAUQ57H5NHSPJZOKKOXOZ4DEUJVAO5URHBIUAVSVTJGL4QV |
+| signing identity (NKey pub) | UD7OGEV…L4QV |
 
 ## Subject namespace this stack owns
-
-- internal:   `local.andreas.meta-factory.>`
+- local:      `local.andreas.meta-factory.>`
 - federated:  `federated.andreas.meta-factory.>`
 
-## Principals on this stack
-
-- `@echo`  — Echo, capabilities: code-review.{typescript,documentation,security,…}
-- `@luna`  — Luna
+## Assistants on this stack
+- `@echo` — Echo · capabilities: code-review.{typescript,documentation,security,…}
+- `@luna` — Luna
 - `@forge` — Forge
 
-## Routing into this stack
-
-- broadcast a review:  `local.andreas.meta-factory.tasks.code-review.typescript`
-- direct to Echo:      `local.andreas.meta-factory.tasks.@echo.code-review.typescript`
+## Dispatching into this stack
+- Offer:  `local.andreas.meta-factory.tasks.code-review.typescript`
+- Direct: `local.andreas.meta-factory.tasks.@echo.code-review.typescript`
 ```
+
+Rendered from `cortex.{stack}.yaml`; any tool publishing toward a stack sets the principal segment from here or from `cortex.{stack}.yaml` — never a hardcode, never a network name.
 
 ## 12. Remediation — the concrete defects this model exposes
 
 | # | Defect | Fix | Owner |
 |---|---|---|---|
-| R1 | **pilot hardcodes `source: "metafactory.pilot.{network}"`** (`publish-review-request.ts`) → every published subject has `{org}=metafactory`. | pilot must derive the envelope `source` operator segment from the target stack's `operator.id` (read from `cortex.{stack}.yaml` / `context.md`). This is what pilot#133 ("derive envelope source from `agent.operatorId`, no more `metafactory.*` hardcode") was meant to do — verify it actually landed for the `request-review` path; the current repo still shows the hardcode. | pilot |
-| R2 | **`arc nats provision-streams --network <X>`** places `<X>` in the consumer's `{org}` filter segment. | The flag that determines the `{org}` segment must be the **operator**, not the network. Rename/repurpose: `--operator` derives the org segment; `--network` (if kept) only selects NATS topology. Existing `cortex-review-consumer-metafactory-*` consumers are malformed and should be re-provisioned as `…-andreas-{stack}-…`. | arc |
-| R3 | **myelin namespace spec ambiguity** — examples show both `local.andreas.*` and `local.metafactory.*` without stating that the segment is the operator. | Add a normative sentence to `myelin/specs/namespace.md`: "`{org}` is the operator identity. A network/federation name never appears as a subject segment." Cross-link this doc. | myelin |
-| R4 | **No per-stack source of truth that tools agree to read.** | Adopt the `context.md` standard (§11). Render one per stack; point pilot/arc/cortex at it. | cortex |
+| R1 | **pilot hardcodes `source: "metafactory.pilot.{network}"`** → every published subject's first segment is `metafactory`. | pilot derives the envelope `source` from the target stack's `cortex.{stack}.yaml` — `source` = `{principal}.{stack}.{assistant}` (myelin grill-Q3). Verify pilot#133 ("derive envelope source from the principal, no more `metafactory.*` hardcode") actually landed for the `request-review` path; the repo still shows the hardcode. | pilot |
+| R2 | **`arc nats provision-streams --network <X>`** places `<X>` in the consumer's first-segment filter. | The flag that determines the first segment must be the **principal**, not the network. Re-provision the malformed `cortex-review-consumer-metafactory-*` consumers as `…-andreas-{stack}-…`. | arc |
+| R3 | **myelin `namespace.md` grammar** uses the pre-grill vocabulary. | Apply the grill resolutions to `namespace.md`: rename the `{org}` token → `{principal}`; relabel the `@`-segment an *assistant address* (`@{assistant}`); "Reach" → "Scope". Filed as a myelin grammar issue. | myelin |
+| R4 | **`operator` / `Principal` / `source` rename** across myelin + cortex. | myelin: `Principal` interface → `Identity`, `signed_by[].principal` → `.identity`, `Identity.operator` → `.network`, `source` grammar → `{principal}.{stack}.{assistant}`. cortex: `operator.id` → `principal.id` in `cortex.yaml` schema + subject derivation + Mission Control copy. Tracked features. | myelin, cortex |
 
-Until R1 lands, the pilot review loop cannot deliver verdicts on this deployment (arc#182, compass#65 are blocked on exactly this). The interim path is in-session sub-agent review.
+Until R1 lands, the pilot review loop cannot deliver verdicts on this deployment (arc#182, compass#65 are blocked on exactly this). Interim path: in-session sub-agent review.
 
 ## 13. Open questions
 
-1. **Operator-slug collisions across networks.** If `andreas` peers into two networks and a *different* `andreas` exists in the second, the operator slug collides. Resolve by globally-unique operator slugs, or by a network-scoped operator registry? (§9.)
-2. **`context.md` generation + drift.** Should `arc` render `context.md` on `arc upgrade Cortex`? A drift check (rendered ≠ committed) in CI? (Mirrors the compass CLAUDE.md generation question — arc#181.)
-3. **Federation principal mapping.** When a `federated.` task is claimed by an agent from another operator, whose principal scope does it carry? (myelin#43 territory — cross-ref, don't re-solve here.)
-4. **Should the network ever be observable?** A diagnostic case for "which network did this reach" — but per §3.2 it must not be a subject segment. An envelope metadata field, perhaps. Deferred.
+1. **Principal-slug collisions across networks.** If `andreas` peers into two networks and a *different* `andreas` exists in the second, the slug collides. Globally-unique principal slugs, or a network-scoped principal registry? (§9.)
+2. **Per-stack descriptor generation + drift.** Should `arc` render `stack-{name}.md` on `arc upgrade Cortex`? A drift check in CI? (Mirrors the compass `CLAUDE.md` generation question — arc#181.)
+3. **Federation identity mapping.** When a `federated.` task is claimed by an agent from another principal, whose policy scope does it carry? (myelin#43 territory — cross-ref, don't re-solve here.)
+4. **Should the network ever be observable?** A diagnostic case for "which network did this reach" — but per §3 it must never be a subject segment. An envelope metadata field, perhaps. Deferred.
 
 ---
 
 ## Relationship to other docs
 
-- **`myelin/specs/namespace.md`** — the wire grammar authority. This doc binds the segment *meanings* that spec leaves ambiguous.
-- **`docs/architecture.md` §3.5** — the existing namespace-reconciliation note; this doc supersedes it with the canonical model.
+- **`cortex/CONTEXT.md`, `myelin/CONTEXT.md`, `soma/CONTEXT.md`** — the bounded-context glossaries. This doc uses their terms; `compass/ecosystem/CONTEXT-MAP.md` reconciles the boundaries.
+- **`myelin/specs/namespace.md`** — the wire-grammar authority. R3 aligns it with the grilled vocabulary.
+- **`docs/architecture.md` §3.5** — the existing namespace-reconciliation note; this doc supersedes it.
 - **`docs/design-agent-network-topology.md` (G-1114)** — consumes this model for the `agent` domain.
 - **`docs/design-mission-control-cortex-cockpit.md` (G-1113)** — the Network view renders the topology this model defines.

--- a/docs/design-bus-addressing.md
+++ b/docs/design-bus-addressing.md
@@ -1,0 +1,297 @@
+# Design — Bus Addressing & Routing Model
+
+**Status:** canonical reference — draft for review
+**Owners:** Andreas + Soma
+**Audience:** anyone building or operating a tool that publishes to or subscribes on the metafactory NATS bus — cortex, pilot, arc, signal, future M7 apps
+**Grammar authority:** [`myelin/specs/namespace.md`](https://github.com/the-metafactory/myelin/blob/main/specs/namespace.md) defines the wire grammar; this doc resolves *what the segments mean* and *how every tool must derive them consistently*.
+
+---
+
+## 1. Why this document exists
+
+The same class of bug keeps recurring:
+
+- **cortex#262** — stack-aware subject grammar landed
+- **cortex#317** — `NatsLink.close()` drain
+- **cortex#318** — pilot published 6-segment subjects, cortex subscribed 4-segment
+- **2026-05-20** — `pilot request-review` times out: pilot publishes review tasks to `local.metafactory.meta-factory.tasks.code-review.*` but the cortex bot consumes `local.andreas.meta-factory.tasks.code-review.*`. The tasks land in a JetStream consumer no bot polls.
+
+Every instance is the same underlying defect: **tools disagree on what the segments of a NATS subject mean, because the meaning was never written down canonically.** The myelin spec defines the *grammar* but its own examples are ambiguous (it shows both `local.andreas.research.*` and `local.metafactory.default.*` as valid — implying the first segment could be a person *or* an organisation).
+
+This document ends the ambiguity. It is the canonical statement. When a tool's behaviour disagrees with this doc, the tool is wrong.
+
+## 2. The verified root cause (2026-05-20 investigation)
+
+| Tool | How it derives the first subject segment (`{org}`) | Result for this deployment |
+|---|---|---|
+| **cortex** | From `operator.id` in `cortex.yaml` (`src/common/types/cortex-config.ts` — "Operator identifier — used as the `{org}` subject segment"). Review-consumer subscribes `local.${operator.id}.${stack}.tasks.code-review.>`. | `local.andreas.meta-factory.…` |
+| **pilot** | **Hardcoded.** `publish-review-request.ts` sets envelope `source: "metafactory.pilot.${network}"`; myelin's `deriveNatsSubject()` takes `source.split('.')[0]` → `metafactory`. Pilot never reads `operator.id`. | `local.metafactory.meta-factory.…` |
+| **arc** | `arc nats provision-streams --network <X>` mints the consumer filter with `{org} = <X>`. `--network metafactory` → consumer filters `local.metafactory.…` | `cortex-review-consumer-metafactory-echo` |
+
+**The mismatch:** cortex says `{org} = andreas`. pilot and arc say `{org} = metafactory`. Pilot's publish lands in the `metafactory`-org consumer; the cortex bot polls the `andreas`-org consumer. They never meet.
+
+This is not a grammar bug (cortex#318 genuinely fixed the segment *count*). It is a **semantic bug**: the first segment's *meaning* is contested. pilot treats it as the organisation/network name; cortex treats it as the operator. Both cannot be right.
+
+## 3. Core vocabulary — definitions are canonical
+
+Five identifiers. They are **not interchangeable**. Most of the recurring pain comes from treating two of them as one.
+
+### 3.1 Operator
+
+A **human or team** that runs one or more Cortex stacks. Identified by a short slug: `andreas`, `team-research`, `acme-platform`.
+
+The operator is the **unit of sovereignty**. `local.` signals never cross an operator boundary. Trust, signing identity, and policy principals are all scoped to an operator.
+
+> **The operator IS the `{org}` subject segment.** myelin's spec calls the segment `{org}` and says stacks are "under the operator identified by `{org}`" — i.e. the spec's own prose equates `{org}` with the operator. For a solo operator there is no separate "organisation"; `andreas` is both. This doc makes the equivalence explicit and binding: **`{org}` ::= operator id**, always, in every tool.
+
+### 3.2 Network
+
+A **federation of operators** connected at the NATS layer via leaf nodes. `metafactory` is a network. So is a hypothetical `acme-clients` network.
+
+> **A network is NOT a subject segment.** It is deployment topology — which leaf nodes peer with which. An operator participates in a network by connecting their NATS leaf node to it. Cross-operator reach is expressed by the **`federated.` prefix**, never by putting a network name in the subject.
+>
+> This is the single most important correction in this document. `metafactory` must never appear as the first segment of a subject. pilot doing so is the bug.
+
+An operator may belong to **more than one** network (see §9). The network name lives in deployment config (NATS leaf-node config, `arc` provisioning), not on the wire.
+
+### 3.3 Stack
+
+A **deployment unit** under an operator — one running Cortex process, one `cortex.{stack}.yaml`, one signing identity, one subject sub-namespace. Identified `{operator}/{stack}`: `andreas/meta-factory`, `andreas/work`, `andreas/halden`.
+
+The stack is the second subject segment. An operator runs many stacks side by side; the `{stack}` segment lets subscribers, JetStream consumers, audit trails, and federation routers tell them apart without payload inspection.
+
+### 3.4 Principal
+
+An **addressable agent identity** — `@echo`, `@luna`, `@forge`, `@cortex-halden`. Carried in the `@`-prefixed segment of the `tasks` domain (and the `agent` domain, per G-1114). Used for **point-to-point** routing: "this envelope is for *that specific agent*."
+
+A principal is backed by an NKey / DID and verified via the `signed_by[]` chain. Principals are how Direct and Delegate routing target one recipient instead of a competing-consumer pool.
+
+### 3.5 Scope
+
+The **reach** of a signal — one of three, set by the subject prefix:
+
+| Scope | Prefix | Reach |
+|---|---|---|
+| **internal** | `local.` | never leaves the operator boundary |
+| **federated** | `federated.` | crosses to peer operators in the same network, subject to envelope sovereignty rules |
+| **public** | `public.` | unrestricted; no `{org}` or `{stack}` segment at all |
+
+### 3.6 Summary — the five-identifier model
+
+```
+operator   andreas              the human/team — the {org} segment, the sovereignty boundary
+network    metafactory          a federation of operators — NATS topology, NOT on the wire
+stack      meta-factory         a deployment under the operator — the {stack} segment
+principal  @echo                an addressable agent — the @{principal} segment
+scope      local/federated/public   reach — the subject prefix
+```
+
+## 4. The canonical subject grammar
+
+Per `myelin/specs/namespace.md`, with this doc binding the segment meanings:
+
+```
+local.{operator}.{stack}.{domain}.{entity}.{action}
+federated.{operator}.{stack}.{domain}.{entity}.{action}
+public.{domain}.{entity}.{action}
+```
+
+- `{operator}` — the operator slug. **Derived from one source of truth per stack** (see §10). Never hardcoded, never a network name.
+- `{stack}` — the stack slug (second half of `{operator}/{stack}`). `default` for single-stack operators.
+- `{domain}` — functional domain: `tasks`, `code`, `agent`, `system`, `review`, `dispatch`, …
+- `{entity}.{action}` — the signal, or for the `tasks`/`agent` domains the capability/action grammar below.
+- `public.` carries **no operator/stack** — public signals are not operator-scoped.
+
+### 4.1 The `tasks` domain — routed work
+
+```
+local.{operator}.{stack}.tasks.{capability}.{subcapability}      ← Broadcast
+local.{operator}.{stack}.tasks.@{principal}.{capability}         ← Direct / Delegate
+local.{operator}.{stack}.tasks.dead-letter.{capability}          ← unclaimable escalation
+```
+
+### 4.2 The `agent` domain — presence + lifecycle (G-1114)
+
+```
+local.{operator}.{stack}.agent.{action}.@{principal}
+federated.{operator}.{stack}.agent.{action}.@{principal}
+```
+
+where `{action}` ∈ `online | heartbeat | offline | capabilities-changed`. This is the grammar G-1114 (Agent Network Topology) builds on — consistent with this model: operator is `{org}`, network is not on the wire, federation via the `federated.` prefix.
+
+## 5. Worked example — operator `andreas`, network `metafactory`, three stacks
+
+Operator `andreas` belongs to the `metafactory` network and runs three stacks:
+
+| Stack | FQSI | `local.` prefix | `federated.` prefix |
+|---|---|---|---|
+| meta-factory | `andreas/meta-factory` | `local.andreas.meta-factory.>` | `federated.andreas.meta-factory.>` |
+| work | `andreas/work` | `local.andreas.work.>` | `federated.andreas.work.>` |
+| halden | `andreas/halden` | `local.andreas.halden.>` | `federated.andreas.halden.>` |
+
+Note what is **absent**: the word `metafactory` appears nowhere in any subject. It is the network — the leaf-node federation `andreas` participates in. It is config, not wire-form.
+
+A code-review request for a PR, dispatched by pilot from the meta-factory stack, broadcast to any qualified reviewer:
+
+```
+local.andreas.meta-factory.tasks.code-review.typescript
+```
+
+The same request, directed point-to-point to Echo:
+
+```
+local.andreas.meta-factory.tasks.@echo.code-review.typescript
+```
+
+Echo announcing itself on the bus (G-1114):
+
+```
+local.andreas.meta-factory.agent.online.@echo
+```
+
+## 6. Scopes in practice
+
+- **internal (`local.`)** — the default. Everything within one operator's stacks. Cross-*stack* but same-*operator* traffic is still `local.` — e.g. the meta-factory stack observing the work stack uses `local.andreas.work.>` (a wildcard the operator owns end-to-end). Leaf-node config prevents `local.>` from replicating off the operator's cluster.
+
+- **federated (`federated.`)** — cross-*operator*, same network. When `andreas` and another operator both peer into the `metafactory` network, a review request `andreas` is willing to send to an external reviewer goes on `federated.andreas.meta-factory.tasks.code-review.typescript`. The receiving operator's leaf node validates the envelope `sovereignty` block before accepting.
+
+- **public (`public.`)** — unrestricted, no operator scoping. Registry announcements, network heartbeats, `public.community.agent.registered`. Deferred for cortex's own use (see G-1114 §4.3); listed here for completeness.
+
+## 7. Routing patterns
+
+Two axes: **how many recipients** and **chosen how**.
+
+| Pattern | Subject shape | Semantics |
+|---|---|---|
+| **Broadcast** (one-to-many, open market) | `…tasks.{capability}.{sub}` | Any agent that declared `{capability}` may claim. JetStream queue-group gives exactly-one delivery per consumer group. The dispatcher does not pick the worker; the qualified pool competes. |
+| **Direct** (point-to-point) | `…tasks.@{principal}.{capability}` | Routed to exactly one named agent. "Forge, cut a release." Broker-side filter on the `@{principal}` segment — no payload inspection. |
+| **Delegate** (point-to-point, orchestrating) | `…tasks.@{principal}.{capability}` | Same wire shape as Direct; the difference is operator-facing — the recipient internally orchestrates a multi-step outcome and emits a `dispatch.*` lifecycle stream. "Pilot, drive PR #32 to merge." |
+| **Dead-letter** | `…tasks.dead-letter.{capability}` | A task that exhausted `max_deliver` without a claim, or hit a compliance block, escalates here for operator review. Capability segment preserved for per-capability monitoring. |
+
+The choice is the **publisher's**: broadcast when any qualified agent will do; direct/delegate when a specific agent is wanted. Both are first-class; both are already in the myelin grammar.
+
+## 8. Multi-stack (one operator, many stacks)
+
+`andreas` runs three stacks. Consequences:
+
+- **`{operator}` is constant** across all three (`andreas`); `{stack}` varies. One operator, one sovereignty boundary, one `local.` namespace `local.andreas.>`.
+- **Cross-stack visibility is cheap and internal.** A Mission Control instance on the meta-factory stack can subscribe `local.andreas.>` to see all three stacks — same operator, no federation needed.
+- **Each stack has its own signing identity** (NKey) and its own JetStream consumers, named `(operator, stack, agent)` — e.g. `cortex-review-consumer-andreas-meta-factory-echo`. The consumer name MUST encode operator + stack, not a network.
+- **Per-stack `context.md`** (see §11) is how each stack's addressing identity is declared once and read by every tool.
+
+## 9. Multi-network (one operator, many networks)
+
+An operator may peer into more than one network — e.g. `andreas` in `metafactory` and also in a client network `acme-clients`.
+
+- The network is **still not on the wire.** Both networks see `andreas`'s subjects as `local.andreas.{stack}.>` / `federated.andreas.{stack}.>`.
+- Networks are kept apart at the **NATS leaf-node layer** — which leaf nodes peer with which cluster. A `federated.` subject reaches only the operators whose leaf nodes are peered into the *same* network.
+- If the same operator slug must mean different things in two networks, that is an **operator-naming collision** and must be resolved by namespacing the operator slug (`andreas-mf`, `andreas-acme`) — not by adding a network segment. (Open question §13.1.)
+
+## 10. Conformance rules — binding on every tool
+
+1. **`{org}` ::= operator id. Always.** Every tool that builds a subject MUST set the first post-prefix segment to the operator identity. No hardcoded literals. No network names.
+
+2. **One source of truth per stack.** The operator + stack + network for a deployment are declared once, in that stack's `cortex.{stack}.yaml` (`operator.id`, `stack.id`) and surfaced in its `context.md` (§11). Tools READ that source. They never re-derive the operator from their own config, an env var, or a literal.
+
+3. **A subject is derivable from a single stack's context.** Building a subject requires only: scope + that stack's operator + that stack's stack-slug + the domain/action. It never requires knowledge of the whole network. (Federation reach is the `federated.` prefix's job.)
+
+4. **Network is provisioning input, never wire-form.** `arc nats` and leaf-node config consume a network name; the bus never sees it. An `arc nats provision-streams` flag that places a value in the `{org}` segment must take the *operator*, not the *network*.
+
+5. **Consumer names encode `(operator, stack, agent)`.** Never `(network, agent)`. A consumer named `cortex-review-consumer-metafactory-echo` is malformed under this model — `metafactory` is a network.
+
+## 11. The per-stack `context.md` standard
+
+Every Cortex stack carries a **`context.md`** — the human- and agent-readable declaration of that stack's bus-addressing identity. It is the artefact a tool (or an agent at session start) reads to answer "where am I, and what subjects do I own?"
+
+`context.md` is **rendered from `cortex.{stack}.yaml`** — `cortex.yaml` stays the single machine source of truth (rule §10.2); `context.md` is its readable projection. It lives beside the config: `~/.config/cortex/context-{stack}.md`.
+
+### 11.1 Standard template
+
+```markdown
+# Stack Context — {operator}/{stack}
+
+| Field | Value |
+|---|---|
+| operator | {operator} |
+| stack | {stack} |
+| network(s) | {network[, network…]} |
+| fully-qualified stack identity | {operator}/{stack} |
+| signing identity (NKey pub) | {nkey_pub} |
+
+## Subject namespace this stack owns
+
+- internal:   `local.{operator}.{stack}.>`
+- federated:  `federated.{operator}.{stack}.>`
+
+## Principals on this stack
+
+- `@{agent}` — {displayName}, capabilities: {…}
+
+## Routing into this stack
+
+- broadcast a task:  `local.{operator}.{stack}.tasks.{capability}.{sub}`
+- direct to an agent: `local.{operator}.{stack}.tasks.@{principal}.{capability}`
+
+## Conformance
+
+Any tool publishing toward this stack MUST set the operator segment to
+`{operator}` — read it from here or from cortex.{stack}.yaml. Never
+hardcode; never substitute a network name. See docs/design-bus-addressing.md.
+```
+
+### 11.2 Worked example — `andreas/meta-factory`
+
+```markdown
+# Stack Context — andreas/meta-factory
+
+| Field | Value |
+|---|---|
+| operator | andreas |
+| stack | meta-factory |
+| network(s) | metafactory |
+| fully-qualified stack identity | andreas/meta-factory |
+| signing identity (NKey pub) | UD7OGEVBNJAUQ57H5NHSPJZOKKOXOZ4DEUJVAO5URHBIUAVSVTJGL4QV |
+
+## Subject namespace this stack owns
+
+- internal:   `local.andreas.meta-factory.>`
+- federated:  `federated.andreas.meta-factory.>`
+
+## Principals on this stack
+
+- `@echo`  — Echo, capabilities: code-review.{typescript,documentation,security,…}
+- `@luna`  — Luna
+- `@forge` — Forge
+
+## Routing into this stack
+
+- broadcast a review:  `local.andreas.meta-factory.tasks.code-review.typescript`
+- direct to Echo:      `local.andreas.meta-factory.tasks.@echo.code-review.typescript`
+```
+
+## 12. Remediation — the concrete defects this model exposes
+
+| # | Defect | Fix | Owner |
+|---|---|---|---|
+| R1 | **pilot hardcodes `source: "metafactory.pilot.{network}"`** (`publish-review-request.ts`) → every published subject has `{org}=metafactory`. | pilot must derive the envelope `source` operator segment from the target stack's `operator.id` (read from `cortex.{stack}.yaml` / `context.md`). This is what pilot#133 ("derive envelope source from `agent.operatorId`, no more `metafactory.*` hardcode") was meant to do — verify it actually landed for the `request-review` path; the current repo still shows the hardcode. | pilot |
+| R2 | **`arc nats provision-streams --network <X>`** places `<X>` in the consumer's `{org}` filter segment. | The flag that determines the `{org}` segment must be the **operator**, not the network. Rename/repurpose: `--operator` derives the org segment; `--network` (if kept) only selects NATS topology. Existing `cortex-review-consumer-metafactory-*` consumers are malformed and should be re-provisioned as `…-andreas-{stack}-…`. | arc |
+| R3 | **myelin namespace spec ambiguity** — examples show both `local.andreas.*` and `local.metafactory.*` without stating that the segment is the operator. | Add a normative sentence to `myelin/specs/namespace.md`: "`{org}` is the operator identity. A network/federation name never appears as a subject segment." Cross-link this doc. | myelin |
+| R4 | **No per-stack source of truth that tools agree to read.** | Adopt the `context.md` standard (§11). Render one per stack; point pilot/arc/cortex at it. | cortex |
+
+Until R1 lands, the pilot review loop cannot deliver verdicts on this deployment (arc#182, compass#65 are blocked on exactly this). The interim path is in-session sub-agent review.
+
+## 13. Open questions
+
+1. **Operator-slug collisions across networks.** If `andreas` peers into two networks and a *different* `andreas` exists in the second, the operator slug collides. Resolve by globally-unique operator slugs, or by a network-scoped operator registry? (§9.)
+2. **`context.md` generation + drift.** Should `arc` render `context.md` on `arc upgrade Cortex`? A drift check (rendered ≠ committed) in CI? (Mirrors the compass CLAUDE.md generation question — arc#181.)
+3. **Federation principal mapping.** When a `federated.` task is claimed by an agent from another operator, whose principal scope does it carry? (myelin#43 territory — cross-ref, don't re-solve here.)
+4. **Should the network ever be observable?** A diagnostic case for "which network did this reach" — but per §3.2 it must not be a subject segment. An envelope metadata field, perhaps. Deferred.
+
+---
+
+## Relationship to other docs
+
+- **`myelin/specs/namespace.md`** — the wire grammar authority. This doc binds the segment *meanings* that spec leaves ambiguous.
+- **`docs/architecture.md` §3.5** — the existing namespace-reconciliation note; this doc supersedes it with the canonical model.
+- **`docs/design-agent-network-topology.md` (G-1114)** — consumes this model for the `agent` domain.
+- **`docs/design-mission-control-cortex-cockpit.md` (G-1113)** — the Network view renders the topology this model defines.


### PR DESCRIPTION
## Summary

The foundation layer. Two paired documents from a `grill-with-docs` session that resolved the recurring operator/org/network/topic terminology confusion:

- **`CONTEXT.md`** (repo root) — the canonical **cortex bounded-context glossary**. 14 terms, one canonical word per concept, aliases to avoid, relationships, an example dialogue, flagged ambiguities, and a boundary section reconciling cortex terms with soma + myelin.
- **`docs/design-bus-addressing.md`** — the bus addressing & routing spec, built on the glossary. Resolves the cortex#318 / 2026-05-20 pilot-timeout class of bug: tools disagreed on what the first subject segment means.

## Why this matters

This is the foundation for everything downstream — G-1113 (Mission Control cockpit), G-1114 (Agent Network Topology), the pilot review loop, every tool that touches the bus. The recurring "topic mismatch" bugs (cortex#262, #317, #318, the pilot org-segment timeout) were all one defect: **the meaning of the subject segments was never written down.** Now it is.

## Key resolutions

- `operator` → **`principal`** (the human) — killed `operator` ecosystem-wide
- the first subject segment is the **principal**; a **network** (`metafactory`) is *never* a subject segment
- **assistant** / **agent** / **sub-agent** — the three-layer being / runtime / spawned-task split
- the `@`-segment names an **assistant** (`@{assistant}`)
- dispatch modes **Offer / Direct / Delegate** ("Broadcast" was a misnomer — exactly one assistant claims)
- `subject` (not topic), `scope` (not reach), `domain` = subject segment only

## JC — input wanted

This is meant to be the canonical reference, so I want your eyes before it lands. Specifically:
- Does the **principal / network / stack / assistant / agent** model match how you think about the bus?
- The §12 remediation (R1 pilot hardcode, R2 arc `--network`, R3 myelin grammar, R4 the renames) — agree with the ownership + scope?
- Anything in the glossary that contradicts how the deployed stacks actually behave?

Paired PRs: myelin `CONTEXT.md` + compass `CONTEXT-MAP.md` / template auto-load (linked once filed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)