### PR TITLE
fix(tests): clean up persona dirs leaked into $HOME + clear pre-existing TS errors

### DIFF
--- a/src/__tests__/review-roundtrip.integration.test.ts
+++ b/src/__tests__/review-roundtrip.integration.test.ts
@@ -87,9 +87,9 @@ function makeConfig(url: string): BotConfig {
   } as unknown as BotConfig;
 }
 
-function stubCcFactory(): CCSessionFactory {
+const stubCcFactory: CCSessionFactory = () => {
   throw new Error("integration test pipelineRunner should not spawn Claude Code");
-}
+};
 
 function buildVerdictEnvelope(request: Envelope): Envelope {
   return createReviewVerdictEvent({
@@ -102,6 +102,9 @@ function buildVerdictEnvelope(request: Envelope): Envelope {
       reviewer: "echo",
       verdict: "approved",
       summary: "integration smoke approved",
+      github_review_id: 1,
+      github_review_url: "https://github.com/example/repo/pull/1#pullrequestreview-1",
+      commit_id: "0000000000000000000000000000000000000000",
       findings: { blockers: 0, majors: 0, nits: 0 },
       inline_comments: 0,
       submitted_at: "2026-05-19T00:00:00Z",

--- a/src/bus/myelin/__tests__/envelope-validator.test.ts
+++ b/src/bus/myelin/__tests__/envelope-validator.test.ts
@@ -700,7 +700,7 @@ describe("envelope-validator — originator signature coverage (cortex#366)", ()
         principal: "did:mf:echo",
         attribution: "adapter-resolved",
       },
-    } as Parameters<typeof signEnvelope>[0];
+    } as unknown as Parameters<typeof signEnvelope>[0];
     const signed = await signEnvelope(base, echoSeed, "did:mf:echo");
 
     // Sanity: the happy path verifies. If this fails the fixture is broken,

--- a/src/cli/cortex/commands/__tests__/agents.test.ts
+++ b/src/cli/cortex/commands/__tests__/agents.test.ts
@@ -1,7 +1,7 @@
 // F-3 — cortex agents reload/list CLI tests.
 
 import { describe, expect, test } from "bun:test";
-import { mkdtempSync, writeFileSync, copyFileSync, mkdirSync, readdirSync, readFileSync } from "fs";
+import { mkdtempSync, writeFileSync, copyFileSync, mkdirSync, readdirSync, readFileSync, rmSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 
@@ -207,14 +207,16 @@ describe("runAgentsReload", () => {
     const home = process.env.HOME;
     if (!home) return; // skip if HOME unset (CI rarity)
     const personaHomeRel = `f3-b1-persona-${Date.now()}`;
-    const personaAbs = join(home, personaHomeRel, "echo.md");
-    mkdirSync(join(home, personaHomeRel), { recursive: true });
-    writeFileSync(personaAbs, `---\ndisplayName: Echo\n---\n`);
+    const personaHomeAbs = join(home, personaHomeRel);
+    const personaAbs = join(personaHomeAbs, "echo.md");
+    mkdirSync(personaHomeAbs, { recursive: true });
+    try {
+      writeFileSync(personaAbs, `---\ndisplayName: Echo\n---\n`);
 
-    const fragmentDir = mkdtempSync(join(tmpdir(), "f3-b1-frag-"));
-    writeFileSync(
-      join(fragmentDir, "echo.yaml"),
-      `id: echo
+      const fragmentDir = mkdtempSync(join(tmpdir(), "f3-b1-frag-"));
+      writeFileSync(
+        join(fragmentDir, "echo.yaml"),
+        `id: echo
 displayName: Echo
 persona: "~/${personaHomeRel}/echo.md"
 roles: [agent-restricted]
@@ -226,13 +228,16 @@ presence:
     agentChannelId: "1"
     logChannelId: "2"
 `,
-    );
+      );
 
-    const r = runAgentsReload(
-      parseAgentsArgs(["reload", "--fragment", join(fragmentDir, "echo.yaml")]),
-    );
-    expect(r.exitCode).toBe(0);
-    expect(r.stdout).toContain("echo");
+      const r = runAgentsReload(
+        parseAgentsArgs(["reload", "--fragment", join(fragmentDir, "echo.yaml")]),
+      );
+      expect(r.exitCode).toBe(0);
+      expect(r.stdout).toContain("echo");
+    } finally {
+      rmSync(personaHomeAbs, { recursive: true, force: true });
+    }
   });
 
   test("--fragment routes a schema-validation failure (not just YAML-parse) — m3 nit", () => {

--- a/src/common/agents/__tests__/registry.test.ts
+++ b/src/common/agents/__tests__/registry.test.ts
@@ -63,6 +63,16 @@ function cortexConfigFixture(agents: Agent[]): CortexConfig {
       id: "andreas",
       dataResidency: "NZ",
     },
+    bus: {
+      review: {
+        stream: {
+          name: "CODE_REVIEW",
+          maxAgeSeconds: 86_400,
+          maxBytes: 512 * 1024 * 1024,
+        },
+        consumer: { maxDeliver: 5 },
+      },
+    },
     agents,
     renderers: [],
     claude: {

--- a/src/common/config/__tests__/fragment-loader.test.ts
+++ b/src/common/config/__tests__/fragment-loader.test.ts
@@ -5,7 +5,7 @@
 // `../loader` — pure function, no side effects beyond reading disk.
 
 import { describe, expect, test } from "bun:test";
-import { mkdtempSync, writeFileSync } from "fs";
+import { mkdtempSync, writeFileSync, rmSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 
@@ -388,20 +388,24 @@ runtime:
       }
       const dir = mkdtempSync(join(tmpdir(), "agents-d-tilde-"));
       const homeRelDir = mkdtempSync(join(home, "tilde-persona-"));
-      const personaName = "echo.md";
-      writeFileSync(
-        join(homeRelDir, personaName),
-        `---\ndisplayName: Echo\n---\n`,
-      );
-      // homeRelDir is e.g. /Users/x/tilde-persona-abc — strip $HOME to get the
-      // tilde-relative path: ~/tilde-persona-abc/echo.md
-      const tildePath = `~${homeRelDir.slice(home.length)}/${personaName}`;
-      writeFileSync(
-        join(dir, "echo.yaml"),
-        validFragmentYaml("echo", "Echo", tildePath),
-      );
-      const agents = loadAgentsDirectory(dir);
-      expect(agents[0]!.persona.startsWith(home)).toBe(true);
+      try {
+        const personaName = "echo.md";
+        writeFileSync(
+          join(homeRelDir, personaName),
+          `---\ndisplayName: Echo\n---\n`,
+        );
+        // homeRelDir is e.g. /Users/x/tilde-persona-abc — strip $HOME to get
+        // the tilde-relative path: ~/tilde-persona-abc/echo.md
+        const tildePath = `~${homeRelDir.slice(home.length)}/${personaName}`;
+        writeFileSync(
+          join(dir, "echo.yaml"),
+          validFragmentYaml("echo", "Echo", tildePath),
+        );
+        const agents = loadAgentsDirectory(dir);
+        expect(agents[0]!.persona.startsWith(home)).toBe(true);
+      } finally {
+        rmSync(homeRelDir, { recursive: true, force: true });
+      }
     });
   });
 });

--- a/src/runner/__tests__/dispatch-listener.test.ts
+++ b/src/runner/__tests__/dispatch-listener.test.ts
@@ -2087,13 +2087,13 @@ describe("dispatch-listener — originator (cortex#346 / myelin#161)", () => {
 
     // Sign the envelope WITH originator → signature commits to it.
     const base = makeReceivedEnvelope() as Parameters<typeof signEnvelope>[0];
-    const baseWithOriginator: Parameters<typeof signEnvelope>[0] = {
+    const baseWithOriginator = {
       ...base,
       originator: {
         principal: "did:mf:cortex",
         attribution: "adapter-resolved",
       },
-    };
+    } as unknown as Parameters<typeof signEnvelope>[0];
     const signed = await signEnvelope(
       baseWithOriginator,
       privateKeyBase64,


### PR DESCRIPTION
## Summary

- Two test suites scaffolded persona dirs under `\$HOME` (`f3-b1-persona-*` and `tilde-persona-*`) without cleanup — 144 leftover dirs had accumulated locally. Wrap each test body in `try/finally` + `rmSync` so the dir is removed even on assertion failure.
- Clear 5 pre-existing TypeScript errors on `main` that were blocking the pre-push smoke gate (Ladder EX-00003). All type-only — no runtime behavior changes.

## What changed

### Test-fixture cleanup
- `src/cli/cortex/commands/__tests__/agents.test.ts` — `--fragment with ~-prefixed persona path` (Echo B1)
- `src/common/config/__tests__/fragment-loader.test.ts` — `expands ~ in persona path to \$HOME`

### TS-error fixes
- `src/__tests__/review-roundtrip.integration.test.ts`
  - `ReviewVerdictPayload`: add the three fields the spec made required (`github_review_id`, `github_review_url`, `commit_id`).
  - `stubCcFactory`: was typed as `(): CCSessionFactory` but used as a `CCSessionFactory`. Switched to the form the other suites use.
- `src/bus/myelin/__tests__/envelope-validator.test.ts` + `src/runner/__tests__/dispatch-listener.test.ts`
  - The `originator` block is added to `MyelinEnvelope` for the cortex#366 regression guards. Current myelin type doesn't yet expose `originator`, so cast through `unknown` — exactly what the TS error message recommends and consistent with the test intent.
- `src/common/agents/__tests__/registry.test.ts`
  - `cortexConfigFixture` was missing the `bus:` field that became required after `BusConfigSchema` was added to `CortexConfigSchema`. Fill in the documented defaults explicitly.

## Test plan

- [x] `bunx tsc --noEmit` — 0 errors (was 5)
- [x] `bun test src/cli/cortex/commands/__tests__/agents.test.ts src/common/config/__tests__/fragment-loader.test.ts` — 72 pass / 0 fail
- [x] `bun test` on all 6 touched files — 206 pass / 2 fail. The 2 failures are the pre-existing cortex#366 stale-myelin-install regression guards (myelin install on disk doesn't expose `originator` in `SIGNABLE_FIELDS`). Not introduced or worsened here.
- [x] Verified locally that re-running the patched tests does not leak new `~/f3-b1-persona-*` or `~/tilde-persona-*` dirs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)