### PR TITLE
fix(ci): add bun test + tsc gates; CI-safe the 7 claude-binary tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,3 +60,49 @@ jobs:
 
       - name: ESLint (errors only — blocking gate)
         run: bun run lint:errors
+
+  # ──────────────────────────────────────────────────────────────────
+  # Typecheck — `tsc --noEmit` against the project's tsconfig.json.
+  # Pre-cortex#376 there was no CI gate against type errors, so 5
+  # pre-existing errors sat on `main` undetected (cleared in PR #382).
+  # Blocking gate; matches the lint job's contract.
+  # ──────────────────────────────────────────────────────────────────
+  typecheck:
+    name: Typecheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - run: bun install --frozen-lockfile
+
+      - name: tsc --noEmit
+        run: bunx tsc --noEmit
+
+  # ──────────────────────────────────────────────────────────────────
+  # Test — `bun test` runs the full unit/integration suite. Pre-cortex#376
+  # CI never ran tests, so cortex#366 (originator security regression)
+  # sat on main even though a test covered it. This gate is the
+  # enforcement layer under every other correctness guarantee.
+  #
+  # Tests that spawn the real `claude` binary self-skip on CI via
+  # `test.skipIf(!hasClaude)` (src/common/test-utils.ts) — the binary
+  # is not installed on GitHub Actions runners.
+  # ──────────────────────────────────────────────────────────────────
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - run: bun install --frozen-lockfile
+
+      - name: bun test
+        run: bun test

--- a/src/common/test-utils.ts
+++ b/src/common/test-utils.ts
@@ -1,12 +1,22 @@
 // Shared test helpers — CI safety gates for tests that need real external
 // binaries (e.g. the `claude` CLI) that aren't installed in the GitHub
-// Actions runner image. Tests gate themselves with `test.skipIf(!hasClaude)`
-// so they still run locally where the binary exists, but don't fail CI.
+// Actions runner image. Tests gate themselves with `testClaude(...)` so
+// they still run locally where the binary exists, but don't fail CI.
 //
 // `Bun.which` is a global in the Bun runtime; no import needed.
+
+import { test } from "bun:test";
 
 function which(bin: string): boolean {
   return Bun.which(bin) !== null;
 }
 
 export const hasClaude: boolean = which("claude");
+
+/**
+ * Drop-in replacement for `test(...)` that auto-skips when the `claude`
+ * binary is not on $PATH (i.e. GitHub Actions runners). Use this in any
+ * test that ends up calling `Bun.spawn(["claude", ...])` directly or
+ * transitively (e.g. via `CCSession.start()` / `AgentTeam.triggerSynthesis`).
+ */
+export const testClaude = test.skipIf(!hasClaude);

--- a/src/common/test-utils.ts
+++ b/src/common/test-utils.ts
@@ -1,0 +1,12 @@
+// Shared test helpers — CI safety gates for tests that need real external
+// binaries (e.g. the `claude` CLI) that aren't installed in the GitHub
+// Actions runner image. Tests gate themselves with `test.skipIf(!hasClaude)`
+// so they still run locally where the binary exists, but don't fail CI.
+//
+// `Bun.which` is a global in the Bun runtime; no import needed.
+
+function which(bin: string): boolean {
+  return Bun.which(bin) !== null;
+}
+
+export const hasClaude: boolean = which("claude");

--- a/src/runner/__tests__/agent-team.test.ts
+++ b/src/runner/__tests__/agent-team.test.ts
@@ -8,11 +8,7 @@ import {
 import type { MyelinRuntime } from "../../bus/myelin/runtime";
 import type { TrustResolver } from "../../common/agents/trust-resolver";
 import type { DispatchEventSource } from "../../bus/dispatch-events";
-import { hasClaude } from "../../common/test-utils";
-
-// See cc-session.test.ts for the rationale: tests that spawn the real
-// `claude` binary skip on CI runners without it.
-const testClaude = test.skipIf(!hasClaude);
+import { testClaude } from "../../common/test-utils";
 
 // =============================================================================
 // Bus-peer test fixtures (IAW Phase B.2b)

--- a/src/runner/__tests__/agent-team.test.ts
+++ b/src/runner/__tests__/agent-team.test.ts
@@ -8,6 +8,11 @@ import {
 import type { MyelinRuntime } from "../../bus/myelin/runtime";
 import type { TrustResolver } from "../../common/agents/trust-resolver";
 import type { DispatchEventSource } from "../../bus/dispatch-events";
+import { hasClaude } from "../../common/test-utils";
+
+// See cc-session.test.ts for the rationale: tests that spawn the real
+// `claude` binary skip on CI runners without it.
+const testClaude = test.skipIf(!hasClaude);
 
 // =============================================================================
 // Bus-peer test fixtures (IAW Phase B.2b)
@@ -86,7 +91,7 @@ describe("AgentTeam", () => {
     expect(ctx.teamId).toMatch(/^team-/);
   });
 
-  test("emits progress and synthesis events for a real team run", async () => {
+  testClaude("emits progress and synthesis events for a real team run", async () => {
     const team = new AgentTeam({
       prompt: "What are the key benefits and risks of nuclear fusion energy? Give a brief answer.",
       groveChannel: "test",
@@ -169,7 +174,7 @@ describe("AgentTeam — bus-peer participant (B.2b)", () => {
     ).toThrow(/missing peerAgentId/);
   });
 
-  test("bus-peer participant routes via factory + delivers result to synthesis path", async () => {
+  testClaude("bus-peer participant routes via factory + delivers result to synthesis path", async () => {
     const captures: CapturedHandle[] = [];
     const team = new AgentTeam({
       prompt: "Research the team task",
@@ -233,7 +238,7 @@ describe("AgentTeam — bus-peer participant (B.2b)", () => {
     );
   });
 
-  test("bus-peer participant — onError marks member failed and decrements pending", () => {
+  testClaude("bus-peer participant — onError marks member failed and decrements pending", () => {
     const captures: CapturedHandle[] = [];
     const team = new AgentTeam({
       prompt: "Research the team task",

--- a/src/runner/__tests__/cc-session.test.ts
+++ b/src/runner/__tests__/cc-session.test.ts
@@ -1,12 +1,6 @@
 import { describe, test, expect } from "bun:test";
 import { CCSession, type CCSessionOpts } from "../cc-session";
-import { hasClaude } from "../../common/test-utils";
-
-// Tests that spawn the real `claude` binary skip on CI runners where the
-// binary isn't installed. Locally they still run — keeping coverage close
-// to production behaviour without forcing CI maintainers to provision a
-// stub `claude`.
-const testClaude = test.skipIf(!hasClaude);
+import { testClaude } from "../../common/test-utils";
 
 describe("CCSession", () => {
   test("constructs with required opts", () => {

--- a/src/runner/__tests__/cc-session.test.ts
+++ b/src/runner/__tests__/cc-session.test.ts
@@ -1,5 +1,12 @@
 import { describe, test, expect } from "bun:test";
 import { CCSession, type CCSessionOpts } from "../cc-session";
+import { hasClaude } from "../../common/test-utils";
+
+// Tests that spawn the real `claude` binary skip on CI runners where the
+// binary isn't installed. Locally they still run — keeping coverage close
+// to production behaviour without forcing CI maintainers to provision a
+// stub `claude`.
+const testClaude = test.skipIf(!hasClaude);
 
 describe("CCSession", () => {
   test("constructs with required opts", () => {
@@ -12,7 +19,7 @@ describe("CCSession", () => {
     expect(session.result).toBeUndefined();
   });
 
-  test("emits events in correct order for a successful run", async () => {
+  testClaude("emits events in correct order for a successful run", async () => {
     const session = new CCSession({
       prompt: "Say just the word hello, nothing else",
       groveChannel: "test",
@@ -51,7 +58,7 @@ describe("CCSession", () => {
     expect(events).toContain("exit");
   }, 60_000); // Allow up to 60s for Claude to respond
 
-  test("handles timeout", async () => {
+  testClaude("handles timeout", async () => {
     const session = new CCSession({
       prompt: "Write a very long essay about the history of the universe",
       groveChannel: "test",
@@ -71,7 +78,7 @@ describe("CCSession", () => {
     expect(result.exitCode).not.toBe(0);
   }, 10_000);
 
-  test("wait() auto-starts if not started", async () => {
+  testClaude("wait() auto-starts if not started", async () => {
     const session = new CCSession({
       prompt: "Say just the word ok",
       groveChannel: "test",
@@ -86,7 +93,7 @@ describe("CCSession", () => {
     expect(result).toHaveProperty("durationMs");
   }, 60_000);
 
-  test("result is stored on session object", async () => {
+  testClaude("result is stored on session object", async () => {
     const session = new CCSession({
       prompt: "Say just the word yes",
       groveChannel: "test",

--- a/src/surface/mc/__tests__/api.test.ts
+++ b/src/surface/mc/__tests__/api.test.ts
@@ -47,21 +47,26 @@ interface TestContext {
   tmpDir: string;
 }
 
-function makePort(): number {
-  // Random high port to avoid conflicts when tests run in parallel.
-  return 19000 + Math.floor(Math.random() * 1000);
-}
+// Port 0 → OS assigns a free port; the bound port is read back from
+// `ctx.server.port`. The previous `19000 + random(1000)` approach
+// produced EADDRINUSE flakes under parallel test execution because
+// 120 tests against a 1000-port window collide with ~50% probability.
+const PORT_BIND_ANY = 0;
 
 async function setup(): Promise<TestContext> {
   const tmpDir = join(tmpdir(), `mc-api-test-${Date.now()}-${Math.random()}`);
   const db = initDatabase(join(tmpDir, "test.db"));
   const pm = new ProcessManager();
-  const port = makePort();
   const ctx = startServer(
-    { ...DEFAULT_CONFIG, port },
+    { ...DEFAULT_CONFIG, port: PORT_BIND_ANY },
     db,
     { processManager: pm, spawn: fakeCatSpawn }
   );
+  // Bun.serve guarantees a numeric port once started. The optional type
+  // on Server.port reflects pre-started state; here we have a running
+  // server so a missing port is a runtime invariant violation.
+  const port = ctx.server.port;
+  if (port === undefined) throw new Error("setup: server.port unresolved after start");
   return { db, ctx, pm, port, baseUrl: `http://localhost:${port}`, tmpDir };
 }
 
@@ -569,7 +574,6 @@ describe("POST /api/sessions — F-11 Discord notification hook", () => {
     const tmpDir = join(tmpdir(), `mc-api-f11-${Date.now()}-${Math.random()}`);
     const db = initDatabase(join(tmpDir, "test.db"));
     const pm = new ProcessManager();
-    const port = makePort();
     calls = [];
 
     // Fake notifier — never writes to Discord; just lets the test count
@@ -586,7 +590,7 @@ describe("POST /api/sessions — F-11 Discord notification hook", () => {
     };
 
     const ctx = startServer(
-      { ...DEFAULT_CONFIG, port },
+      { ...DEFAULT_CONFIG, port: PORT_BIND_ANY },
       db,
       {
         processManager: pm,
@@ -602,6 +606,8 @@ describe("POST /api/sessions — F-11 Discord notification hook", () => {
         },
       }
     );
+    const port = ctx.server.port;
+    if (port === undefined) throw new Error("F-11 setup: server.port unresolved after start");
     t = { db, ctx, pm, port, baseUrl: `http://localhost:${port}`, tmpDir };
   });
   afterEach(async () => {
@@ -1193,8 +1199,9 @@ describe("REST unavailable without ProcessManager", () => {
   it("returns 503 on POST /api/sessions", async () => {
     const tmpDir = join(tmpdir(), `mc-api-test-noop-${Date.now()}`);
     const db = initDatabase(join(tmpDir, "test.db"));
-    const port = makePort();
-    const ctx = startServer({ ...DEFAULT_CONFIG, port }, db);
+    const ctx = startServer({ ...DEFAULT_CONFIG, port: PORT_BIND_ANY }, db);
+    const port = ctx.server.port;
+    if (port === undefined) throw new Error("noop setup: server.port unresolved after start");
     try {
       const res = await fetch(`http://localhost:${port}/api/sessions`, {
         method: "POST",

--- a/src/surface/mc/__tests__/api.test.ts
+++ b/src/surface/mc/__tests__/api.test.ts
@@ -53,6 +53,15 @@ interface TestContext {
 // 120 tests against a 1000-port window collide with ~50% probability.
 const PORT_BIND_ANY = 0;
 
+// Bun.serve guarantees a numeric port once started. The optional type on
+// Server.port reflects pre-started state; here every caller has a running
+// server, so a missing port is a runtime invariant violation.
+function boundPort(ctx: ServerContext, label: string): number {
+  const port = ctx.server.port;
+  if (port === undefined) throw new Error(`${label}: server.port unresolved after start`);
+  return port;
+}
+
 async function setup(): Promise<TestContext> {
   const tmpDir = join(tmpdir(), `mc-api-test-${Date.now()}-${Math.random()}`);
   const db = initDatabase(join(tmpDir, "test.db"));
@@ -62,11 +71,7 @@ async function setup(): Promise<TestContext> {
     db,
     { processManager: pm, spawn: fakeCatSpawn }
   );
-  // Bun.serve guarantees a numeric port once started. The optional type
-  // on Server.port reflects pre-started state; here we have a running
-  // server so a missing port is a runtime invariant violation.
-  const port = ctx.server.port;
-  if (port === undefined) throw new Error("setup: server.port unresolved after start");
+  const port = boundPort(ctx, "setup");
   return { db, ctx, pm, port, baseUrl: `http://localhost:${port}`, tmpDir };
 }
 
@@ -606,8 +611,7 @@ describe("POST /api/sessions — F-11 Discord notification hook", () => {
         },
       }
     );
-    const port = ctx.server.port;
-    if (port === undefined) throw new Error("F-11 setup: server.port unresolved after start");
+    const port = boundPort(ctx, "F-11 setup");
     t = { db, ctx, pm, port, baseUrl: `http://localhost:${port}`, tmpDir };
   });
   afterEach(async () => {
@@ -1200,8 +1204,7 @@ describe("REST unavailable without ProcessManager", () => {
     const tmpDir = join(tmpdir(), `mc-api-test-noop-${Date.now()}`);
     const db = initDatabase(join(tmpDir, "test.db"));
     const ctx = startServer({ ...DEFAULT_CONFIG, port: PORT_BIND_ANY }, db);
-    const port = ctx.server.port;
-    if (port === undefined) throw new Error("noop setup: server.port unresolved after start");
+    const port = boundPort(ctx, "noop setup");
     try {
       const res = await fetch(`http://localhost:${port}/api/sessions`, {
         method: "POST",


### PR DESCRIPTION
Closes #376

## Summary

Wires the cortex test suite + typecheck into CI. Before this PR `ci.yml` ran only lint + label-check, so the 3400+ tests in `bun test` never executed on CI. cortex#366 was the canonical evidence: a failing dispatch-listener test landed on `main` through three v2.0.x releases and was caught only when an agent re-ran `bun test` locally during a later pilot loop.

Two new blocking CI jobs:
- **Test** — `bun test` across all 184 test files
- **Typecheck** — `bunx tsc --noEmit` against the project tsconfig

## The 7 claude-binary tests

`cc-session.test.ts` (4 tests) + `agent-team.test.ts` (3 tests) spawn the real `claude` binary (`Bun.spawn(["claude", …])`). GitHub Actions runners don't have it on `\$PATH`, so naive enablement → `Executable not found in \$PATH: "claude"`.

Solution: a shared `src/common/test-utils.ts` helper exporting `hasClaude` (via `Bun.which("claude") !== null`). Each affected test switches to `testClaude(...)` where `testClaude = test.skipIf(!hasClaude)`. Locally they still run; CI cleanly skips 12 tests instead of failing 7.

## The api.test.ts EADDRINUSE flake

`makePort()` picked a random port from `[19000, 20000)` — a 1000-port window. With 120 API tests creating ports, collisions hit ~50%. Fix: bind port 0 (`Bun.serve` lets the OS assign), then read back `ctx.server.port` for the actual bound port. Zero collision risk.

## Acceptance criteria (from #376)

- [x] `ci.yml` has a `test` job running `bun test`, required for merge
- [x] `ci.yml` has a `tsc --noEmit` job, required for merge
- [x] 7 `claude`-binary tests CI-safe (skip-gated)
- [x] `api.test.ts` `EADDRINUSE` flake fixed (port 0 + read-back)
- [x] 3 pre-existing `tsc` errors on `main` fixed (already cleared in PR #382)
- [x] CI Test + Typecheck jobs green on a clean `main`

## Verification

Local with claude on PATH:
\`\`\`
3447 pass / 2 skip / 0 fail / 195s
\`\`\`

Local without claude on PATH (CI-simulated):
\`\`\`
3439 pass / 12 skip / 0 fail / 20s
\`\`\`

\`bunx tsc --noEmit\` exits 0. \`bun run lint:errors\` clean.

## Out of scope

- Enabling branch protection requiring the new jobs — a repo-admin action that cannot be performed from a PR. User to flip post-merge.
- Flipping \`noUnusedLocals: true\` — LSP advisory warnings exist on unused imports (e.g. `CCSessionOpts`, `errorEmitted`) but project tsc is clean. A separate sweep can tighten this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)