### PR TITLE
fix(bus): parseReviewRequestPayload accepts Pilot/Sage payload shape

### DIFF
--- a/src/bus/__tests__/review-consumer.test.ts
+++ b/src/bus/__tests__/review-consumer.test.ts
@@ -39,7 +39,9 @@ import type {
 } from "../myelin/runtime";
 import {
   ReviewConsumer,
+  OFFER_DISPATCH_REVIEWER,
   failedReasonToAckDecision,
+  parseReviewRequestPayload,
   type ReviewConsumerAgent,
   type ReviewConsumerOpts,
 } from "../review-consumer";
@@ -794,4 +796,172 @@ describe("failedReasonToAckDecision (cortex#237 PR-6 — Architect Finding 2a)",
       expect(failedReasonToAckDecision(reason)).toEqual(expected);
     });
   }
+});
+
+// ---------------------------------------------------------------------------
+// cortex#384 — parseReviewRequestPayload accepts both wire shapes
+// ---------------------------------------------------------------------------
+//
+// The Offer-dispatch envelope a **principal**'s pilot stack publishes
+// onto `local.{principal}.{stack}.tasks.code-review.<flavor>` carries
+// the **payload** in one of two grilled-vocabulary shapes:
+//
+//   1. **Cortex legacy** — pre-cortex#384 builders (`createReviewRequestEvent`)
+//      flatten `repo` as `"owner/name"` plus `pr` (number) + non-empty
+//      `reviewer` string.
+//   2. **Pilot / Sage Offer dispatch** — `pilot request-review --pr
+//      OWNER/REPO#N` and `sage dispatch` envelopes split the repo into
+//      `owner` + `repo` segments and rename `pr` to `number`; the
+//      `reviewer` field is empty because the **capability** routes the
+//      envelope, not the field.
+//
+// Both shapes must yield the same normalised `{ repo, pr, reviewer }`
+// triple downstream.
+
+function makeRequestEnvelope(payload: unknown): Envelope {
+  return {
+    id: "00000000-0000-4000-8000-000000000001",
+    type: "tasks.code-review.typescript",
+    source: "metafactory.pilot.local",
+    timestamp: new Date().toISOString(),
+    correlation_id: "00000000-0000-4000-8000-000000000002",
+    signed_by: [],
+    sovereignty: { classification: "local" },
+    payload,
+  } as unknown as Envelope;
+}
+
+describe("parseReviewRequestPayload — cortex#384 dual-shape acceptance", () => {
+  test("cortex-legacy shape parses to the canonical triple", () => {
+    const env = makeRequestEnvelope({
+      repo: "the-metafactory/cortex",
+      pr: 385,
+      reviewer: "sage",
+    });
+    const parsed = parseReviewRequestPayload(env);
+    expect(parsed).toEqual({
+      repo: "the-metafactory/cortex",
+      pr: 385,
+      reviewer: "sage",
+    });
+  });
+
+  test("pilot/sage shape (owner+repo+number) folds into legacy form", () => {
+    const env = makeRequestEnvelope({
+      owner: "the-metafactory",
+      repo: "soma",
+      number: 169,
+      pr_url: "https://github.com/the-metafactory/soma/pull/169",
+      reviewer: "",
+    });
+    const parsed = parseReviewRequestPayload(env);
+    expect(parsed).toEqual({
+      repo: "the-metafactory/soma",
+      pr: 169,
+      reviewer: OFFER_DISPATCH_REVIEWER,
+    });
+  });
+
+  test("pilot shape with non-empty reviewer is preserved", () => {
+    const env = makeRequestEnvelope({
+      owner: "the-metafactory",
+      repo: "cortex",
+      number: 1,
+      reviewer: "echo",
+    });
+    expect(parseReviewRequestPayload(env)?.reviewer).toBe("echo");
+  });
+
+  test("empty reviewer in legacy shape collapses to OFFER_DISPATCH_REVIEWER", () => {
+    const env = makeRequestEnvelope({
+      repo: "the-metafactory/cortex",
+      pr: 42,
+      reviewer: "",
+    });
+    expect(parseReviewRequestPayload(env)?.reviewer).toBe(OFFER_DISPATCH_REVIEWER);
+  });
+
+  test("absent reviewer in pilot shape collapses to OFFER_DISPATCH_REVIEWER", () => {
+    const env = makeRequestEnvelope({
+      owner: "the-metafactory",
+      repo: "cortex",
+      number: 7,
+    });
+    expect(parseReviewRequestPayload(env)?.reviewer).toBe(OFFER_DISPATCH_REVIEWER);
+  });
+
+  test("null reviewer collapses to OFFER_DISPATCH_REVIEWER", () => {
+    const env = makeRequestEnvelope({
+      repo: "the-metafactory/cortex",
+      pr: 1,
+      reviewer: null,
+    });
+    expect(parseReviewRequestPayload(env)?.reviewer).toBe(OFFER_DISPATCH_REVIEWER);
+  });
+
+  test("optional fields (feature/title/cycle/note) flow through both shapes", () => {
+    const legacy = parseReviewRequestPayload(
+      makeRequestEnvelope({
+        repo: "the-metafactory/cortex",
+        pr: 100,
+        reviewer: "echo",
+        feature: "C-237",
+        title: "feat: x",
+        cycle: 3,
+        note: "round 3",
+      }),
+    );
+    expect(legacy).toMatchObject({ feature: "C-237", title: "feat: x", cycle: 3, note: "round 3" });
+
+    const pilot = parseReviewRequestPayload(
+      makeRequestEnvelope({
+        owner: "the-metafactory",
+        repo: "cortex",
+        number: 200,
+        feature: "C-238",
+        title: "fix: y",
+      }),
+    );
+    expect(pilot).toMatchObject({ feature: "C-238", title: "fix: y" });
+  });
+
+  test("invalid: neither shape present → null", () => {
+    expect(parseReviewRequestPayload(makeRequestEnvelope({}))).toBeNull();
+  });
+
+  test("invalid: pilot shape with bad owner segment → null", () => {
+    const env = makeRequestEnvelope({
+      owner: "bad/owner",
+      repo: "cortex",
+      number: 1,
+    });
+    expect(parseReviewRequestPayload(env)).toBeNull();
+  });
+
+  test("invalid: legacy shape with negative pr → null", () => {
+    const env = makeRequestEnvelope({
+      repo: "the-metafactory/cortex",
+      pr: -1,
+      reviewer: "echo",
+    });
+    expect(parseReviewRequestPayload(env)).toBeNull();
+  });
+
+  test("invalid: pilot shape with non-integer number → null", () => {
+    const env = makeRequestEnvelope({
+      owner: "the-metafactory",
+      repo: "cortex",
+      number: 1.5,
+    });
+    expect(parseReviewRequestPayload(env)).toBeNull();
+  });
+
+  test("invalid: non-string non-null reviewer → null", () => {
+    const env = makeRequestEnvelope({
+      repo: "the-metafactory/cortex",
+      pr: 1,
+      reviewer: 42,
+    });
+    expect(parseReviewRequestPayload(env)).toBeNull();
+  });
 });

--- a/src/bus/review-consumer.ts
+++ b/src/bus/review-consumer.ts
@@ -873,28 +873,78 @@ export function extractFlavor(envelope: Envelope, _subject: string): string | nu
 }
 
 /**
- * Minimal payload parse — re-uses the spec's invariants (`repo` matches
- * `owner/name`; `pr` is a positive integer). Returns `null` on any shape
- * violation. The pipeline (PR-5) trusts an already-parsed payload, so
- * the validation must happen here.
+ * Sentinel reviewer name for Offer-dispatch envelopes that omit the
+ * `reviewer` field. The bus picks the assistant by capability +
+ * subject; the reviewer field is informational for surfaces only.
+ * Per cortex/CONTEXT.md the receiving being is the **assistant**;
+ * this constant stands in when the publisher hasn't named one.
+ */
+export const OFFER_DISPATCH_REVIEWER = "capability-dispatch";
+
+const SEGMENT_RE = /^[A-Za-z0-9][\w.-]*$/;
+const OWNER_REPO_RE = /^[A-Za-z0-9][\w.-]*\/[A-Za-z0-9][\w.-]*$/;
+
+/**
+ * Parse a review-request envelope payload into the canonical
+ * {@link ReviewRequestPayload}. Two wire shapes are accepted:
+ *
+ * 1. **Cortex legacy** (`tasks.code-review.<flavor>` builders prior to
+ *    cortex#346 / pilot#121): `{ repo: "owner/name", pr: number,
+ *    reviewer: string }`.
+ * 2. **Pilot / Sage Offer dispatch** (current `pilot request-review
+ *    --pr OWNER/REPO#N` shape and Sage's `sage dispatch` envelopes):
+ *    `{ owner: string, repo: string, number: number, pr_url?: string }`.
+ *    `pr_url` is ignored once `owner`/`repo`/`number` are present.
+ *
+ * Both shapes normalise to the canonical `{ repo, pr, reviewer }`
+ * triple before returning. An empty/absent `reviewer` is treated as
+ * an Offer-dispatch signal — the capability + subject pick the
+ * **assistant**, and the reviewer field is filled with
+ * {@link OFFER_DISPATCH_REVIEWER}. (cortex#384.)
+ *
+ * Returns `null` on any shape violation. The pipeline (PR-5) trusts
+ * an already-parsed payload, so the validation must happen here.
  */
 export function parseReviewRequestPayload(
   envelope: Envelope,
 ): ReviewRequestPayload | null {
   const p = envelope.payload as Record<string, unknown> | undefined;
   if (!p || typeof p !== "object") return null;
-  const repo = p.repo;
-  const pr = p.pr;
-  const reviewer = p.reviewer;
-  if (typeof repo !== "string" || !/^[A-Za-z0-9][\w.-]*\/[A-Za-z0-9][\w.-]*$/.test(repo)) {
+
+  let repo: string;
+  let pr: number;
+
+  if (typeof p.owner === "string" && typeof p.number === "number") {
+    // Pilot/Sage shape — fold `owner` + `repo` into the legacy
+    // `owner/name` form before downstream consumers see the payload.
+    if (typeof p.repo !== "string") return null;
+    if (!SEGMENT_RE.test(p.owner) || !SEGMENT_RE.test(p.repo)) return null;
+    repo = `${p.owner}/${p.repo}`;
+    pr = p.number;
+  } else {
+    // Cortex legacy shape.
+    if (typeof p.repo !== "string" || !OWNER_REPO_RE.test(p.repo)) return null;
+    if (typeof p.pr !== "number") return null;
+    repo = p.repo;
+    pr = p.pr;
+  }
+
+  if (!Number.isInteger(pr) || pr <= 0) return null;
+
+  // Reviewer is informational on Offer dispatch — the capability
+  // routes the envelope, not this field. Empty / absent / null all
+  // collapse to the OFFER_DISPATCH_REVIEWER sentinel so the downstream
+  // payload shape stays uniform.
+  const reviewerRaw = p.reviewer;
+  let reviewer: string;
+  if (reviewerRaw === undefined || reviewerRaw === null || reviewerRaw === "") {
+    reviewer = OFFER_DISPATCH_REVIEWER;
+  } else if (typeof reviewerRaw === "string") {
+    reviewer = reviewerRaw;
+  } else {
     return null;
   }
-  if (typeof pr !== "number" || !Number.isInteger(pr) || pr <= 0) {
-    return null;
-  }
-  if (typeof reviewer !== "string" || reviewer.length === 0) {
-    return null;
-  }
+
   const out: ReviewRequestPayload = { repo, pr, reviewer };
   if (typeof p.feature === "string") out.feature = p.feature;
   if (typeof p.title === "string") out.title = p.title;


### PR DESCRIPTION
Closes #384

## Summary

The Offer-dispatch envelope from \`pilot request-review --pr OWNER/REPO#N\` and from \`sage dispatch\` splits the repo into \`owner\` + \`repo\` segments and renames \`pr\` to \`number\`. Cortex's pre-#384 parser only accepted the legacy \`{repo: "owner/name", pr, reviewer}\` shape, so live Pilot review requests were rejected with:

\`\`\`
dispatch.task.failed
reason.kind=cant_do
detail="payload validation failed (missing/invalid repo or pr)"
\`\`\`

This PR teaches \`parseReviewRequestPayload\` to accept both shapes and normalise them to the canonical \`{ repo, pr, reviewer }\` triple before downstream consumers see the payload.

## Two accepted wire shapes

1. **Cortex legacy** (pre-#384 builders): \`{ repo: "owner/name", pr: number, reviewer: string }\`
2. **Pilot / Sage Offer dispatch** (current): \`{ owner: string, repo: string, number: number, pr_url?: string, reviewer?: string }\`

The Pilot/Sage shape is detected by the presence of \`owner\` (string) + \`number\` (number); the legacy shape continues to work unchanged. \`pr_url\` is accepted and ignored once the structured fields resolve.

## Empty reviewer → OFFER_DISPATCH_REVIEWER sentinel

Empty / absent / null \`reviewer\` collapses to a new \`OFFER_DISPATCH_REVIEWER = "capability-dispatch"\` sentinel. Per [\`CONTEXT.md\`](https://github.com/the-metafactory/cortex/blob/main/CONTEXT.md), Offer dispatch routes by **capability** + **subject**, not by the \`reviewer\` field — the field is informational for surfaces that render "review requested from {reviewer}". Pilot publishes an empty reviewer; the sentinel keeps the downstream payload shape uniform.

## Tests

11 new unit tests in \`src/bus/__tests__/review-consumer.test.ts\` under the \`parseReviewRequestPayload — cortex#384 dual-shape acceptance\` describe block:
- Both wire shapes normalise to the same triple
- Empty / absent / null reviewer → sentinel
- Optional fields (\`feature\`/\`title\`/\`cycle\`/\`note\`) flow through both shapes
- Invalid shapes (bad regex / negative pr / non-integer number / non-string reviewer / neither shape present) → null

## Acceptance (from #384)

- [x] \`parseReviewRequestPayload\` accepts both payload shapes
- [x] Empty \`reviewer\` is acceptable for Offer dispatch
- [x] Code comments use \`CONTEXT.md\` vocab (principal, stack, assistant, capability, Offer dispatch, subject, envelope, payload, stamp/signed_by)
- [x] Tests cover both shapes + empty reviewer
- [ ] Stamped-envelope assistants do not claim unstamped Pilot offers — **config-side gate, not parser change**. Pre-flagged in Out-of-Scope below.

## Verification

- \`bun test src/bus/__tests__/review-consumer.test.ts\` → 33 pass / 0 fail
- Full suite: 3459 pass / 2 skip / 0 fail
- \`bunx tsc --noEmit\` → exit 0
- \`bun run lint:errors\` → clean

## Out of Scope

- **Schema field rename** \`operator.id\` → \`principal.id\` — deferred to Phase C of the vocab-alignment plan; needs a separate v3.0.0 breaking-change PR
- **Trust-chain config gate** preventing stamped-only assistants from claiming Pilot's current unstamped envelopes — config + trust-resolver work that lives outside the parser. File a follow-up if not already tracked elsewhere
- **\`ReviewRequestPayload\` interface field names** — kept as-is; downstream consumers still use \`repo\`/\`pr\`/\`reviewer\`. The wire-shape normalisation happens in the parser, not on the internal type

🤖 Generated with [Claude Code](https://claude.com/claude-code)