### PR TITLE
feat(mc): C2 PR-5 — operator→principal in dashboard UI copy (R8)

### DIFF
--- a/src/surface/mc/dashboard-v2/components/drill-input.tsx
+++ b/src/surface/mc/dashboard-v2/components/drill-input.tsx
@@ -420,7 +420,7 @@ export function DrillInput({ assignmentId, assignment, ws, onSend }: DrillInputP
     <div
       className={wrapperCls}
       role="region"
-      aria-label="Operator input"
+      aria-label="Principal input"
       onDragEnter={onDragEnter}
       onDragOver={onDragOver}
       onDragLeave={onDragLeave}
@@ -472,7 +472,7 @@ export function DrillInput({ assignmentId, assignment, ws, onSend }: DrillInputP
         ref={textareaRef}
         rows={2}
         placeholder={placeholder}
-        aria-label="Operator message"
+        aria-label="Principal message"
         value={text}
         disabled={readonly}
         onChange={(e) => setText(e.target.value)}
@@ -481,7 +481,7 @@ export function DrillInput({ assignmentId, assignment, ws, onSend }: DrillInputP
       />
 
       {!readonly && (
-        <div className="canned-row" aria-label="Canned operator actions">
+        <div className="canned-row" aria-label="Canned principal actions">
           {CANNED_ACTIONS.map((c) => (
             <button
               key={c.label}

--- a/src/surface/mc/dashboard-v2/components/drill-log.tsx
+++ b/src/surface/mc/dashboard-v2/components/drill-log.tsx
@@ -150,8 +150,8 @@ function RowBody({ row, isExpanded, onToggle, onOpenImage }: DrillRowProps) {
                   <img
                     key={i}
                     src={src}
-                    alt={`operator attachment ${i + 1}`}
-                    onClick={() => onOpenImage(src, `operator attachment ${i + 1}`)}
+                    alt={`principal attachment ${i + 1}`}
+                    onClick={() => onOpenImage(src, `principal attachment ${i + 1}`)}
                   />
                 );
               })}


### PR DESCRIPTION
## C2 PR-5 — Mission Control dashboard UI copy (R8)

PR-5 of the cortex vocabulary migration (manifest cortex#389, tracked in cortex#388).

### Scope
Renames `operator` -> `principal` in user-facing dashboard-v2 strings (R8):
- `drill-input.tsx` — 3 aria-labels: "Operator input", "Operator message", "Canned operator actions"
- `drill-log.tsx` — 2 alt strings: "operator attachment"

UI text only. No code identifiers (`operatorId` etc. -> PR-6), no wire/schema changes.

### Note on R8 scope
The manifest's R8 row cites "operator cockpit" / "operator filter" as targets. A repo-wide grep confirms those phrases live only in `docs/` design docs (the flybridge-cockpit metaphor) — not dashboard UI. They belong to R12/PR-12 (docs cleanup). The actual user-facing `operator` strings in `dashboard-v2/` are the 5 above; the other ~90 `operator` occurrences there are code comments (R13 -> PR-4) and the `operator.input` event-kind (not R8).

### Verification
- `bunx tsc --noEmit` — clean
- `bun test src/surface/mc/dashboard-v2/` — 425 pass / 0 fail

Refs cortex#388.