### PR TITLE
feat(config): C2 PR-1+2 — operator→principal config schema + migrate-config (R1+R3)

### DIFF
--- a/src/cli/cortex/commands/__tests__/migrate-config.test.ts
+++ b/src/cli/cortex/commands/__tests__/migrate-config.test.ts
@@ -16,6 +16,7 @@ import {
   convertBotYaml,
   formatCheckReport,
   type LegacyBotYaml,
+  type MigratedCortexConfig,
 } from "../migrate-config-lib";
 import { parseArgs, runMigrateConfig } from "../migrate-config";
 import { CortexConfigSchema } from "../../../../common/types/cortex-config";
@@ -25,6 +26,22 @@ const FIXTURE_DIR = join(import.meta.dir, "fixtures");
 function loadFixture(name: string): LegacyBotYaml {
   const raw = readFileSync(join(FIXTURE_DIR, name), "utf-8");
   return YAML.parse(raw) as LegacyBotYaml;
+}
+
+/**
+ * R3 vocabulary migration (cortex#388) — `convertBotYaml` emits a
+ * `principal:`-keyed cortex.yaml. `CortexConfigSchema` still keys the block
+ * `operator:` during the transition release (the breaking flip is manifest
+ * PR-11 / v3.0.0). The cortex loader normalises `principal:` → `operator:`
+ * before its `CortexConfigSchema.parse`; this test helper mirrors that
+ * normalisation so round-trip "output validates against the schema" tests
+ * exercise the same path.
+ */
+function asSchemaShape(
+  migrated: MigratedCortexConfig | Record<string, unknown>,
+): Record<string, unknown> {
+  const { principal, ...rest } = migrated as Record<string, unknown>;
+  return { ...rest, operator: principal };
 }
 
 // ---------------------------------------------------------------------------
@@ -73,9 +90,9 @@ describe("convertBotYaml — minimal single-agent", () => {
     const legacy = loadFixture("minimal.bot.yaml");
     const result = convertBotYaml(legacy, { configDir: FIXTURE_DIR });
 
-    expect(result.cortex.operator.id).toBe("jc");
-    expect(result.cortex.operator.discordId).toBe("112233445566778899");
-    expect(result.cortex.operator.dataResidency).toBe("NZ");
+    expect(result.cortex.principal.id).toBe("jc");
+    expect(result.cortex.principal.discordId).toBe("112233445566778899");
+    expect(result.cortex.principal.dataResidency).toBe("NZ");
 
     expect(result.cortex.agents).toHaveLength(1);
     const agent = result.cortex.agents[0]!;
@@ -94,7 +111,7 @@ describe("convertBotYaml — minimal single-agent", () => {
     // convertBotYaml already calls schema.parse internally, but re-parsing the
     // returned object verifies the result is structurally complete (no fields
     // dropped by the strict refine).
-    expect(() => CortexConfigSchema.parse(result.cortex)).not.toThrow();
+    expect(() => CortexConfigSchema.parse(asSchemaShape(result.cortex))).not.toThrow();
   });
 
   test("produces a mapping entry for the single discord instance", () => {
@@ -369,13 +386,13 @@ describe("convertBotYaml — full fixture", () => {
   test("output passes CortexConfigSchema validation", () => {
     const legacy = loadFixture("full.bot.yaml");
     const result = convertBotYaml(legacy, { configDir: FIXTURE_DIR });
-    expect(() => CortexConfigSchema.parse(result.cortex)).not.toThrow();
+    expect(() => CortexConfigSchema.parse(asSchemaShape(result.cortex))).not.toThrow();
   });
 
   test("operator block carries discord + mattermost + dataResidency", () => {
     const legacy = loadFixture("full.bot.yaml");
     const result = convertBotYaml(legacy, { configDir: FIXTURE_DIR });
-    expect(result.cortex.operator).toEqual({
+    expect(result.cortex.principal).toEqual({
       id: "jc",
       displayName: "Jens-Christian",
       discordId: "112233445566778899",
@@ -492,8 +509,8 @@ describe("convertBotYaml — operator id normalization", () => {
       discord: [{ token: "t", guildId: "1", agentChannelId: "2", logChannelId: "3" }],
     };
     const result = convertBotYaml(legacy, { configDir: FIXTURE_DIR });
-    expect(result.cortex.operator.dataResidency).toBe("CH");
-    expect(result.warnings.some((w) => w.field === "operator.dataResidency")).toBe(true);
+    expect(result.cortex.principal.dataResidency).toBe("CH");
+    expect(result.warnings.some((w) => w.field === "principal.dataResidency")).toBe(true);
   });
 
   test("falls back to NZ when dataResidency is malformed", () => {
@@ -508,7 +525,7 @@ describe("convertBotYaml — operator id normalization", () => {
       discord: [{ token: "t", guildId: "1", agentChannelId: "2", logChannelId: "3" }],
     };
     const result = convertBotYaml(legacy, { configDir: FIXTURE_DIR });
-    expect(result.cortex.operator.dataResidency).toBe("NZ");
+    expect(result.cortex.principal.dataResidency).toBe("NZ");
   });
 
   test("normalizes mixed-case operatorId with a warning", () => {
@@ -522,8 +539,8 @@ describe("convertBotYaml — operator id normalization", () => {
       discord: [{ token: "t", guildId: "1", agentChannelId: "2", logChannelId: "3" }],
     };
     const result = convertBotYaml(legacy, { configDir: FIXTURE_DIR });
-    expect(result.cortex.operator.id).toBe("jc");
-    expect(result.warnings.some((w) => w.field === "operator.id")).toBe(true);
+    expect(result.cortex.principal.id).toBe("jc");
+    expect(result.warnings.some((w) => w.field === "principal.id")).toBe(true);
   });
 
   test("falls back operator.id to agent.name when operatorId unset", () => {
@@ -536,7 +553,7 @@ describe("convertBotYaml — operator id normalization", () => {
       discord: [{ token: "t", guildId: "1", agentChannelId: "2", logChannelId: "3" }],
     };
     const result = convertBotYaml(legacy, { configDir: FIXTURE_DIR });
-    expect(result.cortex.operator.id).toBe("luna");
+    expect(result.cortex.principal.id).toBe("luna");
   });
 });
 
@@ -589,7 +606,7 @@ describe("convertBotYaml — mismatched discord/mattermost lengths", () => {
   test("output round-trips through CortexConfigSchema", () => {
     const legacy = loadFixture("mismatched-lengths.bot.yaml");
     const result = convertBotYaml(legacy, { configDir: FIXTURE_DIR });
-    expect(() => CortexConfigSchema.parse(result.cortex)).not.toThrow();
+    expect(() => CortexConfigSchema.parse(asSchemaShape(result.cortex))).not.toThrow();
   });
 });
 
@@ -1114,11 +1131,12 @@ describe("convertBotYaml — shared agentChannelId warning (cortex#88 item 4)", 
 // ---------------------------------------------------------------------------
 
 describe("formatCheckReport", () => {
-  test("lists operator, agents, renderers, mappings and warnings", () => {
+  test("lists principal, agents, renderers, mappings and warnings", () => {
     const legacy = loadFixture("full.bot.yaml");
     const result = convertBotYaml(legacy, { configDir: FIXTURE_DIR });
     const report = formatCheckReport(result);
-    expect(report).toMatch(/operator: jc/);
+    // R3 (cortex#388) — the report header is keyed `principal:` now.
+    expect(report).toMatch(/principal: jc/);
     expect(report).toMatch(/agents: +1/);
     expect(report).toMatch(/instance mappings:/);
     expect(report).toMatch(/warnings/);
@@ -1159,7 +1177,7 @@ describe("runMigrateConfig", () => {
     expect(existsSync(out)).toBe(true);
     const written = YAML.parse(readFileSync(out, "utf-8"));
     // Re-parse via the schema to confirm the file is a valid cortex.yaml
-    expect(() => CortexConfigSchema.parse(written)).not.toThrow();
+    expect(() => CortexConfigSchema.parse(asSchemaShape(written as Record<string, unknown>))).not.toThrow();
   });
 
   test("cortex#88 item 5: creates missing parent dir before writing --out", async () => {
@@ -1373,5 +1391,131 @@ describe("parseArgs — --auto-stack-key (cortex#324)", () => {
   test("default is false", () => {
     const args = parseArgs(["in.yaml"]);
     expect(args.autoStackKey).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// R3 vocabulary migration (cortex#388) — migrate-config emits `principal:`
+// ---------------------------------------------------------------------------
+
+describe("convertBotYaml — R3 principal block emission (cortex#388)", () => {
+  test("emits a `principal:` block, not a legacy `operator:` block", () => {
+    const legacy = loadFixture("minimal.bot.yaml");
+    const result = convertBotYaml(legacy, { configDir: FIXTURE_DIR });
+    // The emitted object carries the new canonical key.
+    expect(result.cortex.principal).toBeDefined();
+    expect(result.cortex.principal.id).toBe("jc");
+    // The legacy `operator:` key is gone from the emitted shape.
+    expect((result.cortex as Record<string, unknown>).operator).toBeUndefined();
+  });
+
+  test("the emitted `principal:`-shaped YAML loads through CortexConfigSchema after normalisation", () => {
+    const legacy = loadFixture("full.bot.yaml");
+    const result = convertBotYaml(legacy, { configDir: FIXTURE_DIR });
+    // YAML round-trip: stringify → parse → normalise principal→operator →
+    // schema-validate (mirrors what the cortex loader does at startup).
+    const yamlText = YAML.stringify(result.cortex);
+    const reparsed = YAML.parse(yamlText) as Record<string, unknown>;
+    expect(reparsed.principal).toBeDefined();
+    expect(reparsed.operator).toBeUndefined();
+    expect(() =>
+      CortexConfigSchema.parse(asSchemaShape(reparsed)),
+    ).not.toThrow();
+  });
+
+  test("round-trips a legacy `operator:`-shaped cortex.yaml into a `principal:`-shaped one", () => {
+    // Completion-signal #4: migrate-config takes a v2 `operator:`-shaped
+    // cortex.yaml as input and emits a v3 `principal:`-shaped one without
+    // losing fields.
+    const operatorShapedInput: LegacyBotYaml = {
+      operator: {
+        id: "andreas",
+        displayName: "Andreas",
+        discordId: "112233445566778899",
+        dataResidency: "NZ",
+      },
+      stack: { id: "andreas/work" },
+      agents: [
+        {
+          id: "luna",
+          displayName: "Luna",
+          persona: "./personas/luna.md",
+          trust: [],
+          presence: {
+            discord: {
+              token: "discord-token-xxxx",
+              guildId: "100000000000000001",
+              agentChannelId: "100000000000000002",
+              logChannelId: "100000000000000003",
+            },
+          },
+        },
+      ],
+    };
+    const result = convertBotYaml(operatorShapedInput, { configDir: FIXTURE_DIR });
+    expect(result.cortex.principal.id).toBe("andreas");
+    expect(result.cortex.principal.displayName).toBe("Andreas");
+    expect(result.cortex.principal.discordId).toBe("112233445566778899");
+    expect(result.cortex.principal.dataResidency).toBe("NZ");
+    expect((result.cortex as Record<string, unknown>).operator).toBeUndefined();
+    expect(result.cortex.agents).toHaveLength(1);
+    expect(result.cortex.agents[0]!.id).toBe("luna");
+  });
+
+  test("round-trips an already-migrated `principal:`-shaped cortex.yaml (idempotent)", () => {
+    const principalShapedInput: LegacyBotYaml = {
+      principal: {
+        id: "andreas",
+        displayName: "Andreas",
+        dataResidency: "NZ",
+      },
+      agents: [
+        {
+          id: "luna",
+          displayName: "Luna",
+          persona: "./personas/luna.md",
+          trust: [],
+          presence: {
+            discord: {
+              token: "discord-token-xxxx",
+              guildId: "100000000000000001",
+              agentChannelId: "100000000000000002",
+              logChannelId: "100000000000000003",
+            },
+          },
+        },
+      ],
+    };
+    const result = convertBotYaml(principalShapedInput, { configDir: FIXTURE_DIR });
+    expect(result.cortex.principal.id).toBe("andreas");
+    expect((result.cortex as Record<string, unknown>).operator).toBeUndefined();
+  });
+
+  test("rejects input carrying BOTH a `principal:` and a legacy `operator:` block", () => {
+    // Trust-boundary regression — a config with two principal blocks is
+    // ambiguous and must be rejected before any conversion work.
+    const dualBlockInput = {
+      principal: { id: "andreas" },
+      operator: { id: "someone-else" },
+      agents: [
+        {
+          id: "luna",
+          displayName: "Luna",
+          persona: "./personas/luna.md",
+          trust: [],
+          presence: {
+            discord: {
+              token: "t",
+              guildId: "1",
+              agentChannelId: "2",
+              logChannelId: "3",
+            },
+          },
+        },
+      ],
+    } as unknown as LegacyBotYaml;
+    expect(() => convertBotYaml(dualBlockInput, { configDir: FIXTURE_DIR })).toThrow(
+      /BOTH a `principal:` block and a legacy `operator:` block/,
+    );
   });
 });

--- a/src/cli/cortex/commands/migrate-config-lib.ts
+++ b/src/cli/cortex/commands/migrate-config-lib.ts
@@ -137,9 +137,12 @@ export interface LegacyBotYaml {
     dataResidency?: string;
   };
   /**
-   * @deprecated R3 vocabulary migration (cortex#388) — legacy alias for
-   * `principal`. Still read on input for round-trip migration of pre-R3
-   * cortex.yaml files; the migrator always EMITS the `principal:` key.
+   * Legacy pre-R3 alias for `principal` (cortex#388 vocabulary migration).
+   * Still accepted on input so the migrator can round-trip a pre-R3
+   * cortex.yaml; the migrator always EMITS the `principal:` key. Deliberately
+   * NOT `@deprecated`-tagged — reading the legacy key is this migrator's whole
+   * job, so the tag would only fight `no-deprecated`; the rename nudge belongs
+   * on the canonical config types, not on this legacy-input shape.
    */
   operator?: {
     id?: string;
@@ -876,7 +879,6 @@ export function convertBotYaml(
       throw new Error("bot.yaml missing required `agent.displayName`");
     }
   }
-  /* eslint-enable @typescript-eslint/no-unnecessary-condition */
 
   const warnings: ConversionWarning[] = [];
   const mappings: InstanceMapping[] = [];

--- a/src/cli/cortex/commands/migrate-config-lib.ts
+++ b/src/cli/cortex/commands/migrate-config-lib.ts
@@ -846,7 +846,6 @@ export function convertBotYaml(
   // `principal:` block and a legacy `operator:` block is a deployment-config
   // trust boundary. Reject it BEFORE any conversion work; the migrator must
   // never silently pick one. Mirrors the loader's `dual_field_conflict`.
-  /* eslint-disable @typescript-eslint/no-unnecessary-condition */
   if (legacy.principal !== undefined && legacy.operator !== undefined) {
     throw new Error(
       "input declares BOTH a `principal:` block and a legacy `operator:` " +

--- a/src/cli/cortex/commands/migrate-config-lib.ts
+++ b/src/cli/cortex/commands/migrate-config-lib.ts
@@ -118,9 +118,28 @@ export interface LegacyBotYaml {
   /** grove-v2 singular `agent:` block. Required for grove-v2-shape input. */
   agent?: LegacyAgent;
   /**
-   * Cortex-shape `operator:` block. Used when the input is already a
+   * Cortex-shape principal block. Used when the input is already a
    * cortex.yaml (e.g. Andreas's `~/.config/cortex/cortex.yaml`) that has
    * agents under `agents[]` instead of the singular legacy `agent:`.
+   *
+   * R3 vocabulary migration (cortex#388) — the canonical key is now
+   * `principal:`; the legacy `operator:` key is still accepted on input so
+   * the migrator can round-trip a pre-R3 cortex.yaml. The two share an
+   * identical inner shape. A config carrying BOTH keys is a deployment-config
+   * trust boundary — `convertBotYaml` rejects it (see the dual-block guard).
+   */
+  principal?: {
+    id?: string;
+    displayName?: string;
+    discordId?: string;
+    mattermostId?: string;
+    slackId?: string;
+    dataResidency?: string;
+  };
+  /**
+   * @deprecated R3 vocabulary migration (cortex#388) — legacy alias for
+   * `principal`. Still read on input for round-trip migration of pre-R3
+   * cortex.yaml files; the migrator always EMITS the `principal:` key.
    */
   operator?: {
     id?: string;
@@ -193,9 +212,27 @@ export interface InstanceMapping {
   newPresence: "discord" | "mattermost";
 }
 
+/**
+ * R3 vocabulary migration (cortex#388) — the emitted `cortex.yaml` shape.
+ *
+ * Identical to `CortexConfig` except the principal block is keyed `principal:`
+ * (the new canonical key) rather than the legacy `operator:`. The block's
+ * inner shape is unchanged — only the top-level key is renamed.
+ *
+ * `convertBotYaml` validates its output through `CortexConfigSchema` (which
+ * still keys the block `operator:` during the transition release — the
+ * breaking schema flip is manifest PR-11 / v3.0.0), then re-keys the
+ * validated result to `principal:` for emission. The cortex loader's
+ * `resolvePrincipalBlock` accepts both keys, so a `principal:`-shaped file
+ * loads cleanly.
+ */
+export type MigratedCortexConfig = Omit<CortexConfig, "operator"> & {
+  principal: CortexConfig["operator"];
+};
+
 export interface ConversionResult {
   /** The cortex.yaml-shaped object, ready to YAML.stringify and write. */
-  cortex: CortexConfig;
+  cortex: MigratedCortexConfig;
   /** Non-fatal warnings — surfaced to stderr by the CLI. */
   warnings: ConversionWarning[];
   /**
@@ -308,12 +345,17 @@ function buildOperator(
   }
   const a = legacy.agent;
 
-  const rawOperatorId = a.operatorId ?? a.name;
-  const operatorId = deriveAgentId(rawOperatorId);
-  if (operatorId !== rawOperatorId) {
+  // `a.operatorId` reads the legacy grove-v2 `bot.yaml` `agent.operatorId`
+  // field — a historical input shape, intentionally NOT renamed (R2 covers
+  // live cortex code; bot.yaml legacy-config paths are the migration
+  // allow-list carve-out). The warning `field:` below names the OUTPUT
+  // cortex.yaml key, which is `principal:` after R3.
+  const rawPrincipalId = a.operatorId ?? a.name;
+  const principalId = deriveAgentId(rawPrincipalId);
+  if (principalId !== rawPrincipalId) {
     warnings.push({
-      field: "operator.id",
-      message: `operatorId "${rawOperatorId}" normalized to "${operatorId}" (cortex requires lowercase alphanumeric + hyphen)`,
+      field: "principal.id",
+      message: `principal id "${rawPrincipalId}" normalized to "${principalId}" (cortex requires lowercase alphanumeric + hyphen)`,
     });
   }
 
@@ -324,20 +366,23 @@ function buildOperator(
     const fixed = dataResidency.toUpperCase();
     if (/^[A-Z]{2}$/.test(fixed)) {
       warnings.push({
-        field: "operator.dataResidency",
+        field: "principal.dataResidency",
         message: `dataResidency "${dataResidency}" upcased to "${fixed}"`,
       });
       dataResidency = fixed;
     } else {
       warnings.push({
-        field: "operator.dataResidency",
+        field: "principal.dataResidency",
         message: `dataResidency "${dataResidency}" not a 2-letter ISO-3166 code; defaulting to "NZ"`,
       });
       dataResidency = "NZ";
     }
   }
 
-  const operator: CortexConfig["operator"] = { id: operatorId, dataResidency };
+  // The local is keyed `operator` because `CortexConfig` still uses that key
+  // during the transition release; `convertBotYaml` re-keys the validated
+  // block to `principal:` for emission (R3, cortex#388).
+  const operator: CortexConfig["operator"] = { id: principalId, dataResidency };
   if (a.operatorName) operator.displayName = a.operatorName;
   if (a.operatorDiscordId) operator.discordId = a.operatorDiscordId;
   if (a.operatorMattermostId) operator.mattermostId = a.operatorMattermostId;
@@ -797,16 +842,29 @@ export function convertBotYaml(
   if (!legacy || typeof legacy !== "object") {
     throw new Error("input is not an object");
   }
+  // R3 vocabulary migration (cortex#388) — a cortex.yaml that carries BOTH a
+  // `principal:` block and a legacy `operator:` block is a deployment-config
+  // trust boundary. Reject it BEFORE any conversion work; the migrator must
+  // never silently pick one. Mirrors the loader's `dual_field_conflict`.
+  /* eslint-disable @typescript-eslint/no-unnecessary-condition */
+  if (legacy.principal !== undefined && legacy.operator !== undefined) {
+    throw new Error(
+      "input declares BOTH a `principal:` block and a legacy `operator:` " +
+        "block — ambiguous. Keep `principal:` (the canonical key) and delete " +
+        "the legacy `operator:` block, then re-run migrate-config.",
+    );
+  }
   // cortex#295 — accept BOTH legacy bot.yaml (singular `agent:`) and
-  // cortex.yaml (plural `agents[]` + `operator:` + `stack:`) shapes.
+  // cortex.yaml (plural `agents[]` + principal block + `stack:`) shapes.
   // Legacy bot.yaml requires `agent.name` + `agent.displayName`.
-  // cortex-shape requires `agents[]` + `operator.id` and bypasses
-  // `buildAgents`/`buildOperator`.
+  // cortex-shape requires `agents[]` + a principal block (`principal:` or
+  // the legacy `operator:`) and bypasses `buildAgents`/`buildOperator`.
+  const cortexPrincipalBlock = legacy.principal ?? legacy.operator;
   const isCortexShape =
     !legacy.agent &&
     Array.isArray(legacy.agents) &&
     legacy.agents.length > 0 &&
-    legacy.operator !== undefined;
+    cortexPrincipalBlock !== undefined;
   if (!isCortexShape) {
     if (!legacy.agent || typeof legacy.agent !== "object") {
       throw new Error("bot.yaml missing required `agent:` block");
@@ -843,6 +901,11 @@ export function convertBotYaml(
     });
   }
 
+  // The conversion object is keyed `operator:` for the `CortexConfigSchema`
+  // parse below — the schema still uses that key during the transition
+  // release (the breaking flip to `principal:` is manifest PR-11 / v3.0.0).
+  // After the parse the validated block is re-keyed to `principal:` so the
+  // EMITTED cortex.yaml carries the new canonical key (R3, cortex#388).
   const cortex: Record<string, unknown> = {
     operator,
     agents,
@@ -919,13 +982,23 @@ export function convertBotYaml(
 
   const parsed = CortexConfigSchema.parse(cortex);
 
+  // R3 vocabulary migration (cortex#388) — re-key the validated block from
+  // `operator:` to `principal:` for emission. The inner shape is unchanged;
+  // only the top-level key is renamed. The cortex loader's
+  // `resolvePrincipalBlock` accepts both keys, so the emitted file loads
+  // cleanly on the transition release. `operator` is non-optional on
+  // `CortexConfig` (required by the schema), so the destructured value is
+  // always defined.
+  const { operator: principal, ...restOfCortex } = parsed;
+  const migrated: MigratedCortexConfig = { principal, ...restOfCortex };
+
   // Compute parallel-mode pre-flight gaps against the FINAL policy block.
   const preflightGaps = policyPreflight({
     views: adapterViews,
     policy: parsed.policy ?? { principals: [], roles: [] },
   });
 
-  return { cortex: parsed, warnings, mappings, adapterViews, preflightGaps };
+  return { cortex: migrated, warnings, mappings, adapterViews, preflightGaps };
 }
 
 // =============================================================================
@@ -1064,23 +1137,29 @@ function resolveHomeStack(legacy: LegacyBotYaml, operatorId: string): string {
 }
 
 /**
- * Lift the cortex-shape `operator:` block straight through, with the
+ * Lift the cortex-shape principal block straight through, with the
  * same normalisations `buildOperator` applies (lowercase id, ISO-3166
  * residency).
+ *
+ * R3 vocabulary migration (cortex#388) — reads either the new `principal:`
+ * key or the legacy `operator:` key (the caller has already rejected configs
+ * carrying both). The returned object is keyed `operator:` because the
+ * `CortexConfig` type still uses that key during the transition release;
+ * `convertBotYaml` re-keys it to `principal:` for emission.
  */
 function buildOperatorFromCortexShape(
   legacy: LegacyBotYaml,
   warnings: ConversionWarning[],
 ): CortexConfig["operator"] {
-  const op = legacy.operator ?? {};
+  const op = legacy.principal ?? legacy.operator ?? {};
   if (typeof op.id !== "string" || op.id.length === 0) {
-    throw new Error("cortex.yaml-shape input requires `operator.id`");
+    throw new Error("cortex.yaml-shape input requires `principal.id`");
   }
   const operatorId = deriveAgentId(op.id);
   if (operatorId !== op.id) {
     warnings.push({
-      field: "operator.id",
-      message: `operator.id "${op.id}" normalized to "${operatorId}" (cortex requires lowercase alphanumeric + hyphen)`,
+      field: "principal.id",
+      message: `principal.id "${op.id}" normalized to "${operatorId}" (cortex requires lowercase alphanumeric + hyphen)`,
     });
   }
   let dataResidency = op.dataResidency;
@@ -1089,13 +1168,13 @@ function buildOperatorFromCortexShape(
     const fixed = dataResidency.toUpperCase();
     if (/^[A-Z]{2}$/.test(fixed)) {
       warnings.push({
-        field: "operator.dataResidency",
+        field: "principal.dataResidency",
         message: `dataResidency "${dataResidency}" upcased to "${fixed}"`,
       });
       dataResidency = fixed;
     } else {
       warnings.push({
-        field: "operator.dataResidency",
+        field: "principal.dataResidency",
         message: `dataResidency "${dataResidency}" not a 2-letter ISO-3166 code; defaulting to "NZ"`,
       });
       dataResidency = "NZ";
@@ -1367,7 +1446,7 @@ export function formatCheckReport(result: ConversionResult): string {
   const lines: string[] = [];
   lines.push("cortex migrate-config — dry-run report");
   lines.push("");
-  lines.push(`operator: ${result.cortex.operator.id} (dataResidency=${result.cortex.operator.dataResidency})`);
+  lines.push(`principal: ${result.cortex.principal.id} (dataResidency=${result.cortex.principal.dataResidency})`);
   lines.push(`agents:   ${result.cortex.agents.length}`);
   for (const a of result.cortex.agents) {
     const platforms = [

--- a/src/common/config/__tests__/loader.test.ts
+++ b/src/common/config/__tests__/loader.test.ts
@@ -292,7 +292,7 @@ describe("error reporting", () => {
 // returns the rich agents[] alongside via `inlineAgents` so `startCortex`
 // can route per-instance identity correctly.
 
-import { loadConfigWithAgents } from "../loader";
+import { loadConfigWithAgents, DualBlockConflictError } from "../loader";
 
 describe("MIG-7.2e — cortex-shape detection + transform", () => {
   function writeCortexConfig(dir: string, config: Record<string, unknown>): string {
@@ -726,5 +726,90 @@ describe("MIG-7.2e — cortex-shape detection + transform", () => {
     // Positive case — minimal cortex-shape with no auth fields parses OK.
     const path = writeCortexConfig(testDir, minimalCortex());
     expect(() => loadConfigWithAgents(path)).not.toThrow();
+  });
+
+  // ---------------------------------------------------------------------------
+  // R3 vocabulary migration (cortex#388) — `operator:` → `principal:`
+  //
+  // The transition release accepts BOTH a legacy `operator:` block and the
+  // new `principal:` block (prefer `principal:`). A config carrying BOTH is
+  // a deployment-config trust boundary and is rejected with a typed
+  // `dual_field_conflict` BEFORE any membership / capability decision. The
+  // `operator:` reader removal is the future breaking PR-11 / v3.0.0.
+  // ---------------------------------------------------------------------------
+
+  /** minimalCortex() keyed by `principal:` instead of the legacy `operator:`. */
+  function minimalCortexPrincipalShape(): Record<string, unknown> {
+    const cfg = minimalCortex();
+    const { operator, ...rest } = cfg;
+    return { principal: operator, ...rest };
+  }
+
+  test("R3 — loads a `principal:`-shaped cortex.yaml (new canonical key)", () => {
+    const path = writeCortexConfig(testDir, minimalCortexPrincipalShape());
+    const loaded = loadConfigWithAgents(path);
+    expect(loaded.inlineAgents).toHaveLength(1);
+    expect(loaded.inlineAgents[0]!.id).toBe("ivy");
+    // The principal block is normalised onto LoadedConfig.operator.
+    expect(loaded.operator?.id).toBe("jc");
+    expect(loaded.operator?.discordId).toBe("285727653603049472");
+    expect(loaded.config.agent.operatorId).toBe("jc");
+  });
+
+  test("R3 — still loads a legacy `operator:`-shaped cortex.yaml (back-compat)", () => {
+    // The transition release keeps the `operator:` reader. Removal is PR-11.
+    const path = writeCortexConfig(testDir, minimalCortex());
+    const loaded = loadConfigWithAgents(path);
+    expect(loaded.operator?.id).toBe("jc");
+  });
+
+  test("R3 — `principal:` and `operator:` produce an identical LoadedConfig", () => {
+    const principalPath = join(testDir, "cortex-principal.yaml");
+    writeFileSync(principalPath, stringify(minimalCortexPrincipalShape()));
+    const operatorPath = join(testDir, "cortex-operator.yaml");
+    writeFileSync(operatorPath, stringify(minimalCortex()));
+
+    const fromPrincipal = loadConfigWithAgents(principalPath);
+    const fromOperator = loadConfigWithAgents(operatorPath);
+    expect(fromPrincipal.operator).toEqual(fromOperator.operator);
+    expect(fromPrincipal.inlineAgents).toEqual(fromOperator.inlineAgents);
+  });
+
+  test("R3 — rejects a cortex.yaml carrying BOTH `principal:` and `operator:` with dual_field_conflict", () => {
+    // Trust-boundary regression: a hand-edited config mid-migration that
+    // kept the old block while adding the new one MUST be rejected, not
+    // silently resolved to one block.
+    const cfg = minimalCortexPrincipalShape();
+    cfg.operator = { id: "someone-else", discordId: "999" };
+    const path = writeCortexConfig(testDir, cfg);
+
+    expect(() => loadConfigWithAgents(path)).toThrow(DualBlockConflictError);
+    expect(() => loadConfigWithAgents(path)).toThrow(/dual|BOTH/i);
+  });
+
+  test("R3 — the dual-block error carries the `dual_field_conflict` code", () => {
+    const cfg = minimalCortexPrincipalShape();
+    cfg.operator = { id: "someone-else" };
+    const path = writeCortexConfig(testDir, cfg);
+    try {
+      loadConfigWithAgents(path);
+      throw new Error("expected loadConfigWithAgents to throw");
+    } catch (e) {
+      expect(e).toBeInstanceOf(DualBlockConflictError);
+      expect((e as DualBlockConflictError).code).toBe("dual_field_conflict");
+    }
+  });
+
+  test("R3 — dual-block conflict fires even when `agents:` is absent (trust boundary, not shape-gated)", () => {
+    // The conflict is a deployment-config trust boundary — it must surface
+    // regardless of whether the rest of the config is structurally
+    // cortex-shape. A config with both blocks and no agents must not fall
+    // through to the legacy bot.yaml path.
+    const cfg: Record<string, unknown> = {
+      principal: { id: "jc" },
+      operator: { id: "jc" },
+    };
+    const path = writeCortexConfig(testDir, cfg);
+    expect(() => loadConfigWithAgents(path)).toThrow(DualBlockConflictError);
   });
 });

--- a/src/common/config/loader.ts
+++ b/src/common/config/loader.ts
@@ -113,14 +113,14 @@ export interface LoadedConfig {
 }
 
 /**
- * Detect whether `raw` is a cortex-shape config (operator + agents[]) vs
- * the legacy grove-v2 `bot.yaml` shape (singular agent + flat discord[]).
+ * Detect whether `raw` is a cortex-shape config (principal/operator + agents[])
+ * vs the legacy grove-v2 `bot.yaml` shape (singular agent + flat discord[]).
  *
- * The check is structural — must have `operator:` (object) AND `agents:`
- * (non-empty array). Either field on its own keeps the legacy path so a
- * partially-migrated config surfaces the relevant zod errors via
- * BotConfigSchema (legacy) rather than CortexConfigSchema's anti-field
- * rejections.
+ * The check is structural — must have a principal block (`principal:` or the
+ * legacy `operator:`, object) AND `agents:` (non-empty array). Either field on
+ * its own keeps the legacy path so a partially-migrated config surfaces the
+ * relevant zod errors via BotConfigSchema (legacy) rather than
+ * CortexConfigSchema's anti-field rejections.
  */
 interface ZodLikeIssue {
   path?: (string | number)[];
@@ -141,10 +141,81 @@ function isZodLikeError(err: unknown): err is ZodLikeError {
   return Array.isArray(e.issues) || Array.isArray(e.errors);
 }
 
+/**
+ * R3 vocabulary migration (cortex#388) — typed error raised when a single
+ * `cortex.yaml` carries BOTH a legacy `operator:` block AND the new
+ * `principal:` block.
+ *
+ * The principal block is a deployment-config trust boundary: it carries the
+ * principal id used as the `{principal}` subject segment, the platform-side
+ * ids that drive DM-elevation, and the data-residency stamp. If two blocks
+ * disagree, every downstream membership / capability decision becomes
+ * ambiguous. The loader MUST reject the config outright BEFORE any such
+ * decision is made rather than silently picking one block.
+ *
+ * The breaking v3.0.0 major (manifest PR-11) removes the `operator:` reader
+ * entirely; until then this conflict is the safe failure mode for a config
+ * that was hand-edited mid-migration.
+ */
+export class DualBlockConflictError extends Error {
+  /** Stable discriminator for programmatic handling by callers / tests. */
+  public readonly code = "dual_field_conflict" as const;
+
+  constructor(message: string) {
+    super(message);
+    this.name = "DualBlockConflictError";
+  }
+}
+
+/**
+ * R3 transition (cortex#388) — resolve the principal block from a cortex-shape
+ * config, accepting BOTH the new `principal:` key and the legacy `operator:`
+ * key.
+ *
+ * Precedence: `principal:` is preferred. The legacy `operator:` key still
+ * works for the transition release.
+ *
+ * Trust-boundary rule: if BOTH keys are present, raise `DualBlockConflictError`
+ * (a typed `dual_field_conflict`) — this runs BEFORE any membership /
+ * capability decision so an ambiguous deployment config can never be acted on.
+ *
+ * Returns `undefined` when neither key carries an object (the caller's
+ * structural `isCortexShape` gate has usually already excluded that case).
+ */
+function resolvePrincipalBlock(
+  raw: Record<string, unknown>,
+): Record<string, unknown> | undefined {
+  const hasPrincipal =
+    raw.principal !== null && typeof raw.principal === "object";
+  const hasOperator =
+    raw.operator !== null && typeof raw.operator === "object";
+
+  if (hasPrincipal && hasOperator) {
+    throw new DualBlockConflictError(
+      "cortex.yaml declares BOTH a `principal:` block and a legacy " +
+        "`operator:` block. The principal block is a deployment-config trust " +
+        "boundary — having two is ambiguous and is rejected before any " +
+        "membership/capability decision is made. Keep `principal:` (the " +
+        "canonical key) and delete the legacy `operator:` block. Run " +
+        "`cortex migrate-config <your-config.yaml>` to regenerate a clean " +
+        "`principal:`-shaped config.",
+    );
+  }
+
+  if (hasPrincipal) return raw.principal as Record<string, unknown>;
+  if (hasOperator) return raw.operator as Record<string, unknown>;
+  return undefined;
+}
+
 function isCortexShape(raw: Record<string, unknown>): boolean {
+  // R3 transition (cortex#388) — accept EITHER a `principal:` block (new
+  // canonical key) or a legacy `operator:` block. resolvePrincipalBlock
+  // raises `dual_field_conflict` when both are present; that throw is
+  // intentional — a config carrying both blocks is cortex-shape but
+  // unloadable, and the conflict must surface rather than fall through to
+  // the legacy bot.yaml path.
   return (
-    raw.operator !== null &&
-    typeof raw.operator === "object" &&
+    resolvePrincipalBlock(raw) !== undefined &&
     Array.isArray(raw.agents) &&
     raw.agents.length > 0
   );
@@ -324,10 +395,28 @@ function loadCortexShape(
   raw: Record<string, unknown>,
   networks: NetworkFile[],
 ): LoadedConfig {
+  // R3 transition (cortex#388) — resolve the principal block, accepting both
+  // the new `principal:` key and the legacy `operator:` key. Raises a typed
+  // `dual_field_conflict` (DualBlockConflictError) when both are present.
+  // This runs FIRST, before any other validation, because a config with two
+  // principal blocks is a deployment-config trust boundary and must never be
+  // partially acted on.
+  //
+  // CortexConfigSchema still keys the block as `operator:` during the
+  // transition release (the breaking flip to `principal:` is manifest PR-11
+  // / v3.0.0). We normalise the resolved block onto `operator:` here so the
+  // schema layer downstream stays untouched.
+  const principalBlock = resolvePrincipalBlock(raw);
+  const normalised: Record<string, unknown> = { ...raw };
+  delete normalised.principal;
+  if (principalBlock !== undefined) {
+    normalised.operator = principalBlock;
+  }
+
   // v2.0.0 cutover (cortex#297) — reject legacy authorisation fields with a
   // clear pointer at the migrate-config CLI BEFORE Zod's strip-by-default
   // semantics silently drop them.
-  const legacyOffenders = detectLegacyAuthorisationFields(raw);
+  const legacyOffenders = detectLegacyAuthorisationFields(normalised);
   if (legacyOffenders.length > 0) {
     throw new Error(
       `cortex.yaml carries legacy v1.x authorisation fields no longer supported in v2.0.0:\n` +
@@ -338,8 +427,8 @@ function loadCortexShape(
     );
   }
   // Schema-strict parse. Any legacy field at the top level fails here with
-  // the operator-friendly migration message baked into CortexConfigSchema.
-  const cortexConfig: CortexConfig = CortexConfigSchema.parse(raw);
+  // the principal-friendly migration message baked into CortexConfigSchema.
+  const cortexConfig: CortexConfig = CortexConfigSchema.parse(normalised);
 
   // CortexConfigSchema guarantees `agents.min(1)`, so [0] is always defined
   // at runtime; noUncheckedIndexedAccess still types it as possibly undefined.

--- a/src/common/types/cortex-config.ts
+++ b/src/common/types/cortex-config.ts
@@ -76,18 +76,24 @@ function emptyDefault<T extends z.ZodObject<z.ZodRawShape>>(schema: T) {
 }
 
 // =============================================================================
-// Operator — who is running this cortex instance
+// Principal — who is running this cortex instance
 // =============================================================================
 
 /**
- * The operator is the human (or team) running this cortex deployment. Replaces
+ * The principal is the human (or team) running this cortex deployment. Replaces
  * grove-v2's `agent.operatorId` + `agent.operatorDiscordId` + `agent.operatorMattermostId`
  * fields by lifting them out of the (now removed) singular `agent:` block.
+ *
+ * R1 vocabulary migration (cortex#388) — formerly `OperatorSchema`. The
+ * `principal:` block in `cortex.yaml` is the new canonical key; the loader
+ * still accepts a legacy `operator:` block during the transition release
+ * (see `src/common/config/loader.ts`).
  */
-export const OperatorSchema = z.object({
+export const PrincipalConfigSchema = z.object({
   /**
-   * Operator identifier — used as the `{org}` subject segment on the bus
-   * (`local.{org}.…`). Must be safe to embed verbatim in NATS subjects.
+   * Principal identifier — used as the `{principal}` subject segment on the
+   * bus (`local.{principal}.…`). Must be safe to embed verbatim in NATS
+   * subjects.
    *
    * Grammar: lowercase alphanumeric + hyphen, **first character must be a
    * letter**. The letter-prefix rule mirrors `StackConfigSchema.id` segments
@@ -95,28 +101,28 @@ export const OperatorSchema = z.object({
    * with downstream pattern-matchers that treat segments as numeric literals.
    * Letter-prefix is the safe boundary.
    *
-   * Closing cortex#141 — the round-trip invariant `OperatorSchema.id →
+   * Closing cortex#141 — the round-trip invariant `PrincipalConfigSchema.id →
    * deriveStackId → StackConfigSchema.id` now holds for every value the
-   * upstream gate accepts. Migration hint for an operator hitting this rule:
+   * upstream gate accepts. Migration hint for a principal hitting this rule:
    * rename `2andreas` → `team2andreas` or `andreas-2026` (prepend / wrap the
    * digits with a letter-prefixed token).
    */
   id: z.string().min(1).regex(
     LETTER_PREFIX_ID_REGEX,
-    "operator id must be lowercase alphanumeric + hyphen, starting with a letter (e.g. 'andreas', 'team-research'); rename digit-prefixed ids like '2andreas' to 'team2andreas' or 'andreas-2026'",
+    "principal id must be lowercase alphanumeric + hyphen, starting with a letter (e.g. 'andreas', 'team-research'); rename digit-prefixed ids like '2andreas' to 'team2andreas' or 'andreas-2026'",
   ),
   /** Display name shown on the dashboard. Defaults to `id`. */
   displayName: z.string().optional(),
-  /** Operator's Discord user id — receives DM notifications from agents. */
+  /** Principal's Discord user id — receives DM notifications from agents. */
   discordId: z.string().optional(),
-  /** Operator's Mattermost user id — same purpose, Mattermost-side. */
+  /** Principal's Mattermost user id — same purpose, Mattermost-side. */
   mattermostId: z.string().optional(),
-  /** Operator's Slack user id (`U...`) — same purpose, Slack-side. */
+  /** Principal's Slack user id (`U...`) — same purpose, Slack-side. */
   slackId: z.string().optional(),
   /**
    * Data residency stamped into `sovereignty.data_residency` on emitted
    * envelopes. ISO-3166-1 alpha-2 country code (two uppercase ASCII letters).
-   * Defaults to "NZ" when omitted. Operators in AU/EU/US/etc. set this to
+   * Defaults to "NZ" when omitted. Principals in AU/EU/US/etc. set this to
    * match their jurisdiction.
    *
    * Format-enforced so a typo at config time fails fast rather than emitting
@@ -128,7 +134,23 @@ export const OperatorSchema = z.object({
     .default("NZ"),
 });
 
-export type Operator = z.infer<typeof OperatorSchema>;
+export type PrincipalConfig = z.infer<typeof PrincipalConfigSchema>;
+
+/**
+ * @deprecated R1 vocabulary migration (cortex#388) — renamed to
+ * `PrincipalConfigSchema`. This alias keeps the transition release
+ * source-compatible for any external importer; it is removed in the
+ * breaking v3.0.0 major (manifest PR-11).
+ */
+export const OperatorSchema = PrincipalConfigSchema;
+
+/**
+ * @deprecated R1 vocabulary migration (cortex#388) — renamed to
+ * `PrincipalConfig`. This alias keeps the transition release
+ * source-compatible for any external importer; it is removed in the
+ * breaking v3.0.0 major (manifest PR-11).
+ */
+export type Operator = PrincipalConfig;
 
 // =============================================================================
 // Agent presence — one block per platform an agent shows up on
@@ -1795,7 +1817,7 @@ export type Policy = z.infer<typeof PolicySchema>;
  */
 export const CortexConfigSchema = z.object({
   /** Who is running this cortex instance. */
-  operator: OperatorSchema,
+  operator: PrincipalConfigSchema,
   /**
    * IAW Phase A.5 (refs cortex#113) — optional stack identity. When set,
    * declares `{operator_id}/{stack_id}` for the deployment and the


### PR DESCRIPTION
## C2 PR-1+2 — config schema + migrate-config (R1 + R3)

Combined PR-1 + PR-2 of the cortex vocabulary migration (manifest cortex#389, tracked in cortex#388). The manifest splits these but calls them companion PRs — PR-2's principal:-shaped output is unloadable without PR-1's loader change, so they ship together to avoid a broken intermediate.

This is the TRANSITION release — not the breaking v3.0.0. The loader stays backward-compatible (still reads operator:).

### R1 — OperatorConfig -> PrincipalConfig
- src/common/types/cortex-config.ts — OperatorSchema -> PrincipalConfigSchema, type Operator -> PrincipalConfig. @deprecated re-export aliases kept for the transition (matches myelin#165 pattern).

### R3 — loader dual-block read + migrate-config rewriter
- src/common/config/loader.ts — new DualBlockConflictError (code: dual_field_conflict). resolvePrincipalBlock() accepts both principal: and legacy operator:, prefers principal:, and rejects when BOTH blocks are present — a deployment-config trust boundary, before any membership/capability decision.
- src/cli/cortex/commands/migrate-config-lib.ts — convertBotYaml now emits a principal: block; accepts principal: input (deprecated operator: alias) for round-tripping.
- Tests: dual_field_conflict regression suite + principal-emission / operator->principal round-trip / dual-block-rejection.

### Verification
- bunx tsc --noEmit — clean
- bun test src/common/config/ src/cli/cortex/commands/ — 396 pass / 0 fail (623/623 full relevant suite)

Refs cortex#388.