### PR TITLE
feat(mc): C2 PR-6 — operatorId→principalId in Mission Control REST + server (R2)

### DIFF
--- a/src/surface/mc/__tests__/discord-sink.test.ts
+++ b/src/surface/mc/__tests__/discord-sink.test.ts
@@ -93,7 +93,7 @@ function ctx(overrides: Partial<NotificationContext> = {}): NotificationContext 
     taskTitle: "fix webhook HMAC",
     priority: 1,
     taskSourceUrl: null,
-    operatorId: "op-1",
+    principalId: "op-1",
     cycle: 3,
     observedAtMs: 1_700_000_000_000,
     ...overrides,

--- a/src/surface/mc/api/handlers.ts
+++ b/src/surface/mc/api/handlers.ts
@@ -625,7 +625,7 @@ export async function handleCreateSession(
   // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   const title = body.title?.trim() || "Untitled session";
   // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-  const operatorId = body.operatorId?.trim() || DEFAULT_OPERATOR_ID;
+  const principalId = body.principalId?.trim() || DEFAULT_OPERATOR_ID;
   // F-20 — when an observed session supplies an agentId we don't have on
   // file, register it on the spot using `agentName` as the display name.
   // Falls back to ensuring the default agent for unscoped controlled work.
@@ -682,7 +682,7 @@ export async function handleCreateSession(
       db.query(
         `INSERT INTO tasks (id, title, priority, operator_id, source_system)
          VALUES (?, ?, ?, ?, 'internal')`
-      ).run(taskId, title, DEFAULT_INTERNAL_TASK_PRIORITY, operatorId);
+      ).run(taskId, title, DEFAULT_INTERNAL_TASK_PRIORITY, principalId);
     }
 
     db.query(
@@ -841,7 +841,7 @@ export async function handleCreateSession(
         assignmentId,
         taskId,
         title,
-        operatorId
+        principalId
       );
       // Fire-and-forget — Discord errors must not block the API response.
       // The sink swallows + logs internally per Decision 9.
@@ -909,7 +909,7 @@ export async function handleCreateSession(
 /**
  * F-11: Build a `NotificationContext` for the freshly-created session.
  *
- * The handler only has `body.title` + `operatorId` + the generated ids in
+ * The handler only has `body.title` + `principalId` + the generated ids in
  * scope at hook time — the task row hasn't been re-read from the DB yet
  * (and we shouldn't take the round-trip on the hot path). This helper
  * reconstructs the minimum metadata `maybeNotifyDiscord` needs.
@@ -924,7 +924,7 @@ function buildNotificationContextFromCreate(
   assignmentId: string,
   taskId: string,
   taskTitle: string,
-  operatorId: string
+  principalId: string
 ): NotificationContext {
   return {
     assignmentId,
@@ -934,7 +934,7 @@ function buildNotificationContextFromCreate(
     taskTitle,
     priority: DEFAULT_INTERNAL_TASK_PRIORITY,
     taskSourceUrl: null, // 'internal' source for create-session.
-    operatorId,
+    principalId,
     observedAtMs: Date.now(),
   };
 }
@@ -1990,7 +1990,7 @@ export async function handleCreateTask(
   const taskId = generateId();
   const shadowAssignmentId = generateId();
   const shadowSessionId = generateId();
-  const operatorId = DEFAULT_OPERATOR_ID;
+  const principalId = DEFAULT_OPERATOR_ID;
 
   // All four writes (task + shadow assignment + shadow session + curation
   // event) land under one transaction so a partial failure leaves no
@@ -2010,7 +2010,7 @@ export async function handleCreateTask(
          (id, title, priority, operator_id,
           source_system, source_url, source_external_id)
        VALUES (?, ?, ?, ?, 'github', ?, ?)`
-    ).run(taskId, title, priority, operatorId, sourceUrl, canonical);
+    ).run(taskId, title, priority, principalId, sourceUrl, canonical);
 
     createShadowAssignmentAndSession(db, taskId, {
       assignmentId: shadowAssignmentId,

--- a/src/surface/mc/api/types.ts
+++ b/src/surface/mc/api/types.ts
@@ -85,7 +85,7 @@ export interface CreateSessionRequest {
   /** Display name for the agent — used when `agentId` is supplied for a
    *  not-yet-known agent (e.g. operator's `cldyo-live` invocation). */
   agentName?: string;
-  operatorId?: string;
+  principalId?: string;
   /**
    * Optional initial operator turn. If provided, it is written to the
    * controlled session after spawn and recorded as an operator.input event.

--- a/src/surface/mc/notifications/discord-sink.ts
+++ b/src/surface/mc/notifications/discord-sink.ts
@@ -100,7 +100,7 @@ export interface NotificationContext {
   /** `tasks.source_url`. May be null for `internal` tasks. */
   taskSourceUrl: string | null;
   /** `tasks.operator_id`. Coalescing keys off this. */
-  operatorId: string;
+  principalId: string;
   /**
    * Cycle / dispatch count for this assignment. Optional — the renderer
    * omits the line if absent.
@@ -416,7 +416,7 @@ function enqueueDM(
   nowMs: number,
   scheduler: FlushScheduler
 ): void {
-  const key = ctx.operatorId;
+  const key = ctx.principalId;
   let buffer = dmBuffers.get(key);
   if (!buffer) {
     buffer = {

--- a/src/surface/mc/session/stdout-dispatcher.ts
+++ b/src/surface/mc/session/stdout-dispatcher.ts
@@ -268,7 +268,7 @@ function loadNotificationContext(
     taskTitle: row.task_title,
     priority: row.task_priority,
     taskSourceUrl: row.source_url,
-    operatorId: row.operator_id,
+    principalId: row.operator_id,
     observedAtMs: Date.now(),
   };
 }


### PR DESCRIPTION
## C2 PR-6 — Mission Control REST + server: operatorId -> principalId (R2)

PR-6 of the cortex vocabulary migration (manifest cortex#389, tracked in cortex#388).

### Scope
Renames camelCase operatorId -> principalId across the Mission Control surface — REST API handlers, JSON request/response shapes, notification context, session dispatcher, and MC tests.

Producer/consumer JSON-contract pairs renamed together (no broken intermediate):
- CreateSessionRequest.principalId — api/types.ts (producer) + api/handlers.ts (consumer); MC-only, no external consumer.
- NotificationContext.principalId — handlers.ts + stdout-dispatcher.ts (producers) + discord-sink.ts (consumer).

### Scope decision — operator_id SQL column left intact
The snake_case operator_id is a persisted SQLite/D1 column (tasks table, worker schema.sql). Renaming it is an ALTER TABLE migration against live DBs — the same breaking class as the R3 config-schema flip, deferred to the v3.0.0 breaking release. R2 scopes to code/JSON, not DB schema. The column and the Task.operator_id row-shape that maps 1:1 to it are unchanged.

### CF Worker
Not affected — its only JSON field is snake_case operator_id (DB-backed); left untouched.

### Verification
- bunx tsc --noEmit — clean
- bun test src/surface/mc/ — 1137 pass / 0 fail
- bun run lint — 0 errors

Refs cortex#388.