### PR TITLE
feat(cortex): C2 PR-3/4/7 — env-var shim + persona prose + bot→agent service (R9+R6+R7)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,10 +89,13 @@ CORTEX_CHANNEL=<name> CORTEX_AGENT_NAME=<display> CORTEX_AGENT_ID=<id> claude
 | `CORTEX_CHANNEL` | **Required.** Enables the EventLogger hook. Value is the channel/identity label. | `andreas` |
 | `CORTEX_AGENT_NAME` | Display name shown on dashboard agent cards. | `Andreas` |
 | `CORTEX_AGENT_ID` | Agent identifier for event correlation. | `andreas` |
+| `CORTEX_PRINCIPAL` | Principal (the human running the stack) stamped onto events for correlation. | `Andreas` |
 
 During the MIG-7 cutover window the legacy `GROVE_*` env vars remain accepted by the EventLogger for backward compatibility; new sessions should prefer the `CORTEX_*` names. The deprecation shim retires at MIG-8.
 
-**Event pipeline:** CC hooks → `~/.claude/events/raw/` → cortex-relay (policy filter) → `~/.claude/events/published/` → cortex-bot → bus → dashboard API → `cortex.meta-factory.ai`
+`CORTEX_PRINCIPAL` is the vocabulary-migration (R9) rename of the operator-the-human env var. During the transition release the EventLogger still accepts the legacy `CORTEX_OPERATOR` (emits a deprecation warning) and `GROVE_OPERATOR` names; both fallbacks are removed in the breaking v3.0.0.
+
+**Event pipeline:** CC hooks → `~/.claude/events/raw/` → cortex-relay (policy filter) → `~/.claude/events/published/` → cortex daemon (`ai.meta-factory.cortex.meta-factory` and/or `.work` plist) → bus → dashboard API → `cortex.meta-factory.ai`
 
 **Pre-configured wrapper:** `cldyo-live` (at `~/.local/bin/`) starts an instrumented Opus session. Plain `cldyo` stays dark (no events). Use `cldyo-live` when you want your work visible on the dashboard.
 

--- a/docs/agents-md/pai-integration.md
+++ b/docs/agents-md/pai-integration.md
@@ -15,8 +15,11 @@ CORTEX_CHANNEL=<name> CORTEX_AGENT_NAME=<display> CORTEX_AGENT_ID=<id> claude
 | `CORTEX_CHANNEL` | **Required.** Enables the EventLogger hook. Value is the channel/identity label. | `andreas` |
 | `CORTEX_AGENT_NAME` | Display name shown on dashboard agent cards. | `Andreas` |
 | `CORTEX_AGENT_ID` | Agent identifier for event correlation. | `andreas` |
+| `CORTEX_PRINCIPAL` | Principal (the human running the stack) stamped onto events for correlation. | `Andreas` |
 
 During the MIG-7 cutover window the legacy `GROVE_*` env vars remain accepted by the EventLogger for backward compatibility; new sessions should prefer the `CORTEX_*` names. The deprecation shim retires at MIG-8.
+
+`CORTEX_PRINCIPAL` is the vocabulary-migration (R9) rename of the operator-the-human env var. During the transition release the EventLogger still accepts the legacy `CORTEX_OPERATOR` (emits a deprecation warning) and `GROVE_OPERATOR` names; both fallbacks are removed in the breaking v3.0.0.
 
 **Event pipeline:** CC hooks → `~/.claude/events/raw/` → cortex-relay (policy filter) → `~/.claude/events/published/` → cortex daemon (`ai.meta-factory.cortex.meta-factory` and/or `.work` plist) → bus → dashboard API → `cortex.meta-factory.ai`
 

--- a/scripts/preupgrade.sh
+++ b/scripts/preupgrade.sh
@@ -9,7 +9,7 @@ echo "Stopping Cortex services for upgrade (${PAI_OLD_VERSION:-?} → ${PAI_NEW_
 if [ "$(uname)" = "Darwin" ]; then
   LAUNCH_DIR="${HOME}/Library/LaunchAgents"
 
-  # Kill running cortex bot processes before upgrading symlinks.
+  # Kill running cortex agent processes before upgrading symlinks.
   # Holly cortex#52 round 1 nit-3: previous `pgrep -f "cortex start"` matched
   # any commandline containing that substring (`grep cortex start`, vim
   # buffers, other users' editors on shared hosts). Constrain to the
@@ -20,7 +20,7 @@ if [ "$(uname)" = "Darwin" ]; then
     kill ${CORTEX_PIDS} 2>/dev/null || true
     sleep 1
     kill -9 ${CORTEX_PIDS} 2>/dev/null || true
-    echo "  ✓ Old cortex bot processes terminated"
+    echo "  ✓ Old cortex agent processes terminated"
   fi
 
   # Kill running cortex-relay processes — anchor to ~/bin path for the same

--- a/src/cli/cldyo-live
+++ b/src/cli/cldyo-live
@@ -34,6 +34,11 @@ export CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1
 export GROVE_CHANNEL="${1:-${LIVE_ID}}"
 export GROVE_AGENT_NAME="${BOT_NAME}"
 export GROVE_AGENT_ID="${LIVE_ID}"
+# R9 (cortex#388 PR-3): the operator-the-human concept is now `principal`.
+# Export the canonical CORTEX_PRINCIPAL name; keep the legacy GROVE_OPERATOR
+# export too during the transition so any unmigrated consumer still resolves.
+# The legacy export is removed in v3.0.0 (PR-11).
+export CORTEX_PRINCIPAL="${LIVE_NAME}"
 export GROVE_OPERATOR="${LIVE_NAME}"
 export GROVE_BASH_GUARD='{"disabled":true}'
 TASK_LABEL="${1:-${LIVE_ID}}"

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -487,7 +487,7 @@ export async function startCortex(
   // we fall back to `~/.config/cortex/agents.d/`.
   //
   // Fragment-load errors are non-fatal at this stage of the migration: the
-  // bot must keep starting in BotConfig mode even when an operator's
+  // agent must keep starting in BotConfig mode even when an operator's
   // experimental fragment is malformed. Once the cortex.yaml migration is
   // complete (MIG-7.2e), the rule flips to strict per spec §FR-4.
   const agentsDir = options.agentsDir
@@ -2298,13 +2298,13 @@ export function runDryRun(configPath: string): DryRunResult {
 if (import.meta.main) {
   const program = new Command()
     .name("cortex")
-    .description("Cortex — PAI Discord bot, the M7 conscious processing surface")
+    .description("Cortex — the M7 conscious processing surface agent")
     .version(getVersion());
 
   program
     .command("start")
-    .description("Start the bot")
-    .option("--config <path>", "Path to bot config YAML", DEFAULT_CONFIG)
+    .description("Start the agent")
+    .option("--config <path>", "Path to agent config YAML", DEFAULT_CONFIG)
     .option("--dry-run", "Validate config file and exit (no adapter / NATS / daemon startup)")
     .action(async (options: { config: string; dryRun?: boolean }) => {
       // cortex#88 item 2 — short-circuit: skip PID file, signal handlers,
@@ -2363,8 +2363,8 @@ if (import.meta.main) {
 
   program
     .command("stop")
-    .description("Stop the bot")
-    .option("--config <path>", "Path to bot config YAML (selects which stack to stop)", DEFAULT_CONFIG)
+    .description("Stop the agent")
+    .option("--config <path>", "Path to agent config YAML (selects which stack to stop)", DEFAULT_CONFIG)
     .action((options: { config: string }) => {
       const pidFile = pidFileFor(options.config);
       if (!existsSync(pidFile)) {
@@ -2384,8 +2384,8 @@ if (import.meta.main) {
 
   program
     .command("status")
-    .description("Check bot status")
-    .option("--config <path>", "Path to bot config YAML (selects which stack to query)", DEFAULT_CONFIG)
+    .description("Check agent status")
+    .option("--config <path>", "Path to agent config YAML (selects which stack to query)", DEFAULT_CONFIG)
     .action((options: { config: string }) => {
       const pidFile = pidFileFor(options.config);
       if (!existsSync(pidFile)) {

--- a/src/services/ai.meta-factory.cortex.work.plist
+++ b/src/services/ai.meta-factory.cortex.work.plist
@@ -18,9 +18,9 @@
     <key>KeepAlive</key>
     <true/>
     <key>StandardOutPath</key>
-    <string>__HOME__/.config/cortex/work-logs/cortex-work-bot.log</string>
+    <string>__HOME__/.config/cortex/work-logs/cortex-work-agent.log</string>
     <key>StandardErrorPath</key>
-    <string>__HOME__/.config/cortex/work-logs/cortex-work-bot.error.log</string>
+    <string>__HOME__/.config/cortex/work-logs/cortex-work-agent.error.log</string>
     <key>EnvironmentVariables</key>
     <dict>
         <key>HOME</key>

--- a/src/taps/cc-events/hooks/EventLogger.hook.ts
+++ b/src/taps/cc-events/hooks/EventLogger.hook.ts
@@ -9,6 +9,7 @@ import { appendFileSync, mkdirSync, chmodSync, existsSync, readFileSync } from "
 import { join } from "path";
 import { createRawEvent, type RawEvent } from "./lib/event-types";
 import { mapHookToEventType, EVENT_TYPES } from "./lib/event-taxonomy";
+import { resolvePrincipalEnv } from "./lib/principal-env";
 
 // =============================================================================
 // Hook input shape — what Claude Code writes to stdin per hook firing.
@@ -87,7 +88,10 @@ if (!groveChannel) {
 const groveNetwork = process.env.GROVE_NETWORK;
 const groveProject = process.env.GROVE_PROJECT;
 const groveEntity = process.env.GROVE_ENTITY;
-const groveOperator = process.env.GROVE_OPERATOR;
+// R9 (cortex#388 PR-3): the operator-the-human concept is now `principal`.
+// Read `CORTEX_PRINCIPAL` with a compat fallback to the legacy
+// `CORTEX_OPERATOR` / `GROVE_OPERATOR` names (see principal-env.ts).
+const principal = resolvePrincipalEnv();
 
 // =============================================================================
 // Directory Setup (T-2.3)
@@ -200,10 +204,12 @@ async function main() {
       payload.command_preview = hookInput.tool_input.command.slice(0, 200);
     }
 
-    // H-001: Explicit metadata from spawn boundary
+    // H-001: Explicit metadata from spawn boundary. The `operator` payload
+    // key is a wire field (relay policy + dashboard read it) and is renamed
+    // separately under R2 — only the env-var source is `principal` here.
     if (groveProject !== undefined) payload.project = groveProject;
     if (groveEntity !== undefined) payload.entity = groveEntity;
-    if (groveOperator !== undefined) payload.operator = groveOperator;
+    if (principal !== undefined) payload.operator = principal;
 
     // TodoWrite payload: extract task names and statuses
     if (toolName === "TodoWrite" && hookInput.tool_input?.todos !== undefined) {
@@ -247,7 +253,7 @@ async function main() {
       const heartbeat = createRawEvent(
         EVENT_TYPES.SESSION_HEARTBEAT,
         hookType,
-        { project: groveProject, entity: groveEntity, operator: groveOperator },
+        { project: groveProject, entity: groveEntity, operator: principal },
         { sessionId, networkId: groveNetwork }
       );
       await postEvent(heartbeat);

--- a/src/taps/cc-events/hooks/lib/__tests__/principal-env.test.ts
+++ b/src/taps/cc-events/hooks/lib/__tests__/principal-env.test.ts
@@ -1,0 +1,64 @@
+import { test, expect, describe, spyOn, afterEach } from "bun:test";
+import { resolvePrincipalEnv } from "../principal-env";
+
+describe("resolvePrincipalEnv — R9 (cortex#388 PR-3) compat shim", () => {
+  afterEach(() => {
+    // Restore any stderr spy installed by a test.
+    spyOn(process.stderr, "write").mockRestore?.();
+  });
+
+  test("returns the canonical CORTEX_PRINCIPAL value when set", () => {
+    const env = { CORTEX_PRINCIPAL: "andreas" };
+    expect(resolvePrincipalEnv("", env)).toBe("andreas");
+  });
+
+  test("canonical name wins over both legacy names", () => {
+    const env = {
+      CORTEX_PRINCIPAL: "andreas",
+      CORTEX_OPERATOR: "legacy-cortex",
+      GROVE_OPERATOR: "legacy-grove",
+    };
+    expect(resolvePrincipalEnv("", env)).toBe("andreas");
+  });
+
+  test("falls back to legacy CORTEX_OPERATOR and emits a deprecation warning", () => {
+    const stderr = spyOn(process.stderr, "write").mockImplementation(() => true);
+    const env = { CORTEX_OPERATOR: "legacy-cortex" };
+
+    expect(resolvePrincipalEnv("", env)).toBe("legacy-cortex");
+
+    expect(stderr).toHaveBeenCalledTimes(1);
+    const msg = String(stderr.mock.calls[0]![0]);
+    expect(msg).toContain("CORTEX_OPERATOR is deprecated");
+    expect(msg).toContain("CORTEX_PRINCIPAL");
+  });
+
+  test("falls back to pre-cortex GROVE_OPERATOR without a warning", () => {
+    const stderr = spyOn(process.stderr, "write").mockImplementation(() => true);
+    const env = { GROVE_OPERATOR: "legacy-grove" };
+
+    expect(resolvePrincipalEnv("", env)).toBe("legacy-grove");
+    // No warning: the GROVE_* → CORTEX_* namespace rename is a separate
+    // migration with its own deprecation window.
+    expect(stderr).not.toHaveBeenCalled();
+  });
+
+  test("returns undefined when no tier is set", () => {
+    expect(resolvePrincipalEnv("", {})).toBeUndefined();
+  });
+
+  test("honours a suffix for *_PRINCIPAL-family variables", () => {
+    const env = { CORTEX_PRINCIPAL_ID: "andreas" };
+    expect(resolvePrincipalEnv("_ID", env)).toBe("andreas");
+  });
+
+  test("suffix fallback resolves the legacy CORTEX_OPERATOR_<suffix>", () => {
+    const stderr = spyOn(process.stderr, "write").mockImplementation(() => true);
+    const env = { CORTEX_OPERATOR_ID: "legacy" };
+
+    expect(resolvePrincipalEnv("_ID", env)).toBe("legacy");
+    const msg = String(stderr.mock.calls[0]![0]);
+    expect(msg).toContain("CORTEX_OPERATOR_ID is deprecated");
+    expect(msg).toContain("CORTEX_PRINCIPAL_ID");
+  });
+});

--- a/src/taps/cc-events/hooks/lib/principal-env.ts
+++ b/src/taps/cc-events/hooks/lib/principal-env.ts
@@ -1,0 +1,56 @@
+/**
+ * R9 (cortex#388 PR-3) — principal env-var compat shim.
+ *
+ * The vocabulary migration renames the `operator`-the-human concept to
+ * `principal`. On the env-var surface that means `CORTEX_OPERATOR_*` →
+ * `CORTEX_PRINCIPAL_*`.
+ *
+ * This is the TRANSITION release: code reads the new `CORTEX_PRINCIPAL_*`
+ * name and falls back to the legacy `CORTEX_OPERATOR_*` when only the old
+ * one is set, emitting a one-line deprecation notice to stderr so the
+ * operator knows to update their environment. The legacy fallback is
+ * removed in the breaking v3.0.0 (PR-11) per the migration manifest.
+ *
+ * The deepest tier (`GROVE_OPERATOR`) is the pre-cortex name. It stays as
+ * the last-resort fallback here because the separate `GROVE_*` → `CORTEX_*`
+ * namespace migration (postinstall.sh notes; retires at MIG-8) owns its
+ * removal — this shim does not pull that rename forward.
+ */
+
+/**
+ * Resolve a `*_PRINCIPAL`-suffixed env var with a compat fallback chain.
+ *
+ * Lookup order (first defined wins):
+ *   1. `CORTEX_PRINCIPAL{suffix}` — the canonical post-migration name.
+ *   2. `CORTEX_OPERATOR{suffix}`  — legacy transitional name (deprecated;
+ *      emits a one-line stderr warning when it is what supplied the value).
+ *   3. `GROVE_OPERATOR{suffix}`   — pre-cortex name; owned by the separate
+ *      `GROVE_*` → `CORTEX_*` namespace migration.
+ *
+ * @param suffix the variable suffix after the `CORTEX_PRINCIPAL` /
+ *   `CORTEX_OPERATOR` / `GROVE_OPERATOR` stem, e.g. `""` for the bare
+ *   name or `"_ID"` for `CORTEX_PRINCIPAL_ID`.
+ * @param env the environment to read; defaults to `process.env`. Injectable
+ *   for tests.
+ * @returns the resolved value, or `undefined` when no tier is set.
+ */
+export function resolvePrincipalEnv(
+  suffix = "",
+  env: Record<string, string | undefined> = process.env,
+): string | undefined {
+  const canonical = env[`CORTEX_PRINCIPAL${suffix}`];
+  if (canonical !== undefined) return canonical;
+
+  const legacyCortex = env[`CORTEX_OPERATOR${suffix}`];
+  if (legacyCortex !== undefined) {
+    process.stderr.write(
+      `cortex: env var CORTEX_OPERATOR${suffix} is deprecated — ` +
+        `rename it to CORTEX_PRINCIPAL${suffix} (the legacy name is removed in v3.0.0)\n`,
+    );
+    return legacyCortex;
+  }
+
+  // Pre-cortex tier. No warning here: the GROVE_* → CORTEX_* namespace
+  // rename is a separate migration with its own deprecation window.
+  return env[`GROVE_OPERATOR${suffix}`];
+}

--- a/src/taps/cc-events/relay.ts
+++ b/src/taps/cc-events/relay.ts
@@ -13,6 +13,7 @@ import { processEvent } from "./lib/policy-engine";
 import { EventProcessor } from "./lib/event-processor";
 import { watchRawEvents } from "./lib/file-watcher";
 import { RawEventSchema } from "./hooks/lib/event-types";
+import { resolvePrincipalEnv } from "./hooks/lib/principal-env";
 import { NatsLink } from "../../bus/nats/connection";
 import { createCcEventPublisher } from "./cc-events";
 
@@ -162,7 +163,7 @@ program
   )
   .option(
     "--org <org>",
-    "Operator/org segment for published subjects (local.{org}.{type}). Falls back to env var GROVE_OPERATOR or NATS_ORG.",
+    "Operator/org segment for published subjects (local.{org}.{type}). Falls back to env var CORTEX_PRINCIPAL (legacy: CORTEX_OPERATOR, GROVE_OPERATOR) or NATS_ORG.",
   )
   .option(
     "--stack <stack>",
@@ -198,8 +199,11 @@ program
     const natsUrl: string | undefined = options.natsUrl ?? process.env.NATS_URL;
     const natsToken: string | undefined =
       options.natsToken ?? process.env.NATS_TOKEN;
+    // R9 (cortex#388 PR-3): the org/operator segment resolves through the
+    // principal env-var compat shim — CORTEX_PRINCIPAL with a fallback to
+    // the legacy CORTEX_OPERATOR / GROVE_OPERATOR names.
     const org: string =
-      options.org ?? process.env.GROVE_OPERATOR ?? process.env.NATS_ORG ?? "default";
+      options.org ?? resolvePrincipalEnv() ?? process.env.NATS_ORG ?? "default";
     // cortex#266 — IAW A.5 stack segment for 6-segment publishes.
     const stack: string | undefined =
       options.stack ?? process.env.CORTEX_STACK ?? undefined;


### PR DESCRIPTION
## C2 PR-3/4/7 — env-var shim + persona prose + bot->agent service

Combined PR-3 + PR-4 + PR-7 of the cortex vocabulary migration (manifest cortex#389, tracked in cortex#388). Transition release — not the breaking v3.0.0.

### PR-3 / R9 — env-var compat shim
The codebase has NO CORTEX_OPERATOR_* env vars — the manifest assumed a name that does not exist yet. The only operator-identity env var is the pre-cortex GROVE_OPERATOR (its GROVE_*->CORTEX_* namespace rename is a separate, deferred migration). Shipped R9's intent without conflating the two: a new resolvePrincipalEnv() shim reading canonical CORTEX_PRINCIPAL, falling back to legacy CORTEX_OPERATOR (stderr deprecation warning), then GROVE_OPERATOR (deepest tier). Wired into EventLogger.hook.ts + relay.ts; cldyo-live exports CORTEX_PRINCIPAL. 7-test shim suite added.

### PR-4 / R6 — persona prose: documented no-op
Reviewed every persona occurrence in src/ — zero denote the named being; all are the markdown file, the schema field (Agent.persona, DispatchRequest.persona), or the persona-format spec — every one explicitly carved out by the manifest. cortex already uses 'agent' for the being. R6 has no safe rename surface here; forcing it would break the schema. Deliberate no-op per the manifest's flagged ambiguity.

### PR-7 / R7 — bot->agent (daemon sense)
Daemon-sense renames: .work plist log files (cortex-work-bot.log -> cortex-work-agent.log), cortex CLI start/stop/status descriptions + help, comments. Carve-outs kept: bot.yaml legacy filename, grove-bot / com.grove.bot historical labels, arc NATS add-bot/reissue-bot/remove-bot subcommands, Discord/Slack bot-user references. Architecture/plan doc prose deferred to PR-12 (docs-cleanup PR).

### Verification
- bunx tsc --noEmit — clean
- bun test — 3466 pass / 2 skip / 0 fail
- bun run lint — 0 errors / 25 warnings (baseline)

10 files, +160/-19. Refs cortex#388.