### PR TITLE
feat(cortex): C-388 PR-8 — consume new myelin envelope wire fields (R10+R11)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
         "@octokit/webhooks-methods": "^6.0.0",
         "@slack/socket-mode": "^2.0.7",
         "@slack/web-api": "^7.16.0",
-        "@the-metafactory/myelin": "github:the-metafactory/myelin#3ec0aceef960f16db41507d01df5849b0dc7744e",
+        "@the-metafactory/myelin": "github:the-metafactory/myelin#e37b347f222a433b9715510f0eb88fc7564dce92",
         "@xyflow/react": "^12.10.2",
         "ajv": "^8.20.0",
         "ajv-formats": "^3.0.1",
@@ -124,7 +124,7 @@
 
     "@slack/web-api": ["@slack/web-api@7.16.0", "", { "dependencies": { "@slack/logger": "^4.0.1", "@slack/types": "^2.21.0", "@types/node": ">=18", "@types/retry": "0.12.0", "axios": "^1.16.0", "eventemitter3": "^5.0.1", "form-data": "^4.0.4", "is-electron": "2.2.2", "is-stream": "^2", "p-queue": "^6", "p-retry": "^4", "retry": "^0.13.1" } }, "sha512-68SAV77uuGKuhyyaRytX8UijVnqSLsTSKslGXw17cjQYXn+jtNl7gbaEjHgC5x2rhCuFdahBrEC2VCLppbzReg=="],
 
-    "@the-metafactory/myelin": ["@the-metafactory/myelin@github:the-metafactory/myelin#3ec0ace", { "dependencies": { "@msgpack/msgpack": "^3.1.3", "@nats-io/jetstream": "^3.4.0", "@nats-io/kv": "^3.4.0", "@nats-io/transport-node": "^3.4.0", "@noble/ed25519": "^3.1.0", "ajv": "8.20.0", "ajv-formats": "3.0.1" } }, "the-metafactory-myelin-3ec0ace"],
+    "@the-metafactory/myelin": ["@the-metafactory/myelin@github:the-metafactory/myelin#e37b347", { "dependencies": { "@msgpack/msgpack": "^3.1.3", "@nats-io/jetstream": "^3.4.0", "@nats-io/kv": "^3.4.0", "@nats-io/transport-node": "^3.4.0", "@noble/ed25519": "^3.1.0", "ajv": "8.20.0", "ajv-formats": "3.0.1" } }, "the-metafactory-myelin-e37b347"],
 
     "@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
 

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@octokit/webhooks-methods": "^6.0.0",
     "@slack/socket-mode": "^2.0.7",
     "@slack/web-api": "^7.16.0",
-    "@the-metafactory/myelin": "github:the-metafactory/myelin#3ec0aceef960f16db41507d01df5849b0dc7744e",
+    "@the-metafactory/myelin": "github:the-metafactory/myelin#e37b347f222a433b9715510f0eb88fc7564dce92",
     "@xyflow/react": "^12.10.2",
     "ajv": "^8.20.0",
     "ajv-formats": "^3.0.1",

--- a/src/__tests__/iaw-phase-d-integration.test.ts
+++ b/src/__tests__/iaw-phase-d-integration.test.ts
@@ -471,12 +471,15 @@ describe("IAW Phase D.6.1 — cross-operator federated dispatch + reply (refs co
 
       // β's audit also preserves α's signed_by[] chain verbatim
       // (C.4.3 invariant). One stamp originally from α; α's DID on it.
+      // R2 (vocabulary migration 2026-05) — dual-read stamp DID:
+      // canonical `identity` wins; fall back to deprecated `principal`
+      // for pre-migration / JetStream-replayed stamps.
       const auditSignedBy = (
-        betaAllowed!.payload as { signed_by?: { principal: string }[] }
+        betaAllowed!.payload as { signed_by?: { identity?: string; principal?: string }[] }
       ).signed_by;
       expect(auditSignedBy).toBeDefined();
       expect(auditSignedBy!.length).toBeGreaterThanOrEqual(1);
-      expect(auditSignedBy![0]?.principal).toBe(alpha.signerPrincipalDid);
+      expect(auditSignedBy![0]?.identity ?? auditSignedBy![0]?.principal).toBe(alpha.signerPrincipalDid);
 
       // ─── β's reply is re-signed with β's stack key + replayed ────
       // The dispatch-listener publishes the harness's terminal envelope
@@ -538,7 +541,13 @@ describe("IAW Phase D.6.1 — cross-operator federated dispatch + reply (refs co
           ? [replyChain]
           : [];
       expect(replyStamps.length).toBe(1);
-      expect(replyStamps[0]?.principal).toBe(beta.signerPrincipalDid);
+      // R2 (vocabulary migration 2026-05) — myelin's signEnvelope emits
+      // the canonical `identity` key on every new stamp (PR-6 #169);
+      // the deprecated `principal` key would only appear on
+      // pre-migration / JetStream-replayed stamps. Dual-read keeps the
+      // test robust across the breaking-major drop.
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
+      expect(replyStamps[0]?.identity ?? replyStamps[0]?.principal).toBe(beta.signerPrincipalDid);
 
       // The originating dispatch carried α's stamp — assert that too
       // so the test docs both halves of the cross-operator audit trail.
@@ -549,7 +558,8 @@ describe("IAW Phase D.6.1 — cross-operator federated dispatch + reply (refs co
           ? [dispatchChain]
           : [];
       expect(dispatchStamps.length).toBe(1);
-      expect(dispatchStamps[0]?.principal).toBe(alpha.signerPrincipalDid);
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
+      expect(dispatchStamps[0]?.identity ?? dispatchStamps[0]?.principal).toBe(alpha.signerPrincipalDid);
     },
   );
 });

--- a/src/bus/myelin/__tests__/envelope-validator.test.ts
+++ b/src/bus/myelin/__tests__/envelope-validator.test.ts
@@ -554,13 +554,17 @@ describe("envelope-validator — chain helpers (IAW Phase A.2)", () => {
   // ergonomic side of Echo's suggestion without dragging upstream noise
   // into this PR.
 
-  test("schema source commit points at the post-myelin#161 originator pin", () => {
+  test("schema source commit points at the vocabulary-migration transition pin", () => {
     // Lock the pin so future bumps surface in a code review.
-    // Updated at cortex#346 — bump from 5a0e261 to 3ec0ace to pick up
-    // myelin#161 (Envelope.originator policy-attribution field +
-    // getActorPrincipal helper; originator added to SIGNABLE_FIELDS).
+    // Updated at cortex G1 (PR-8) — bump from 3ec0ace to e37b347 to pick
+    // up the myelin vocabulary migration 2026-05 transition release:
+    //   • PR-6 (#169) envelope wire transition (signed_by[].identity,
+    //     originator.identity, target_assistant, distribution_mode "offer")
+    //   • PR-7..PR-13 (#170–#176) the per-cluster downstream landings
+    // The transition schema accepts BOTH the deprecated and the renamed
+    // form so pre-migration / JetStream-replayed envelopes still validate.
     expect(SCHEMA_SOURCE_COMMIT).toBe(
-      "3ec0aceef960f16db41507d01df5849b0dc7744e",
+      "e37b347f222a433b9715510f0eb88fc7564dce92",
     );
   });
 

--- a/src/bus/myelin/__tests__/runtime.test.ts
+++ b/src/bus/myelin/__tests__/runtime.test.ts
@@ -609,7 +609,7 @@ describe("MyelinRuntime", () => {
       expect(fake.publish).toHaveBeenCalledTimes(1);
       const payload = fake.publishes[0]?.payload as string;
       const published = JSON.parse(payload) as {
-        signed_by?: { method: string; principal: string; signature: string; at: string }[];
+        signed_by?: { method: string; identity?: string; principal?: string; signature: string; at: string }[];
         id: string;
       };
 
@@ -620,7 +620,10 @@ describe("MyelinRuntime", () => {
       expect(published.signed_by).toHaveLength(1);
       const stamp = published.signed_by?.[0];
       expect(stamp?.method).toBe("ed25519");
-      expect(stamp?.principal).toBe("did:mf:test-stack");
+      // R2 (vocabulary migration 2026-05) — myelin emits the canonical
+      // `identity` key now (PR-6 #169); the deprecated `principal` key
+      // would only appear on pre-migration / JetStream-replayed stamps.
+      expect(stamp?.identity ?? stamp?.principal).toBe("did:mf:test-stack");
       // Signature shape: base64 of 64 raw bytes ≈ 88 chars.
       expect(stamp?.signature.length).toBeGreaterThanOrEqual(86);
 
@@ -673,13 +676,16 @@ describe("MyelinRuntime", () => {
 
       const payload = fake.publishes[0]?.payload as string;
       const published = JSON.parse(payload) as {
-        signed_by: { principal: string }[];
+        signed_by: { identity?: string; principal?: string }[];
       };
 
-      // Two stamps in arrival order: peer-x first, then us.
+      // R2 (vocabulary migration 2026-05) — both stamps now emit the
+      // canonical `identity` key (myelin's signEnvelope writes `identity`
+      // post PR-6). The dual-read `identity ?? principal` keeps the test
+      // robust against the future breaking-major drop of `principal`.
       expect(published.signed_by).toHaveLength(2);
-      expect(published.signed_by[0]?.principal).toBe("did:mf:peer-x");
-      expect(published.signed_by[1]?.principal).toBe("did:mf:our-stack");
+      expect(published.signed_by[0]?.identity ?? published.signed_by[0]?.principal).toBe("did:mf:peer-x");
+      expect(published.signed_by[1]?.identity ?? published.signed_by[1]?.principal).toBe("did:mf:our-stack");
 
       await runtime.stop();
     });

--- a/src/bus/myelin/envelope-validator.ts
+++ b/src/bus/myelin/envelope-validator.ts
@@ -75,7 +75,7 @@ import schema from "./vendor/envelope.schema.json" with { type: "json" };
  * comments + tests use `myelin#161` to point at the merge that landed the
  * feature — they're the same change, different ticket facets.
  */
-export const SCHEMA_SOURCE_COMMIT = "3ec0aceef960f16db41507d01df5849b0dc7744e";
+export const SCHEMA_SOURCE_COMMIT = "e37b347f222a433b9715510f0eb88fc7564dce92";
 
 /**
  * Hand-typed Envelope shape matching the JSON Schema. We hand-write rather
@@ -155,18 +155,30 @@ export interface Envelope {
   /** F-021 — ISO-8601 absolute soft deadline. Informs nak `not-now` decisions. */
   deadline?: string;
   /**
-   * F-021 — operator-facing routing semantics.
+   * F-021 — principal-facing routing semantics. Vocabulary migration
+   * 2026-05 R11 renamed `broadcast` → `offer` on the wire; the transition
+   * schema accepts both. New publishers emit `offer`.
    *
    * | mode | semantics |
    * |---|---|
-   * | `broadcast` | competing consumers — first ack wins |
-   * | `direct` | named recipient — requires `target_principal` |
-   * | `delegate` | outcome handoff (multi-step orchestration) — requires `target_principal` |
+   * | `offer` | competing consumers — first ack wins (R11 canonical) |
+   * | `broadcast` | deprecated alias of `offer` (accepted on read) |
+   * | `direct` | named recipient — requires `target_assistant` |
+   * | `delegate` | outcome handoff (multi-step orchestration) — requires `target_assistant` |
    */
   distribution_mode?: DistributionMode;
   /**
    * F-021 — required when `distribution_mode` is `direct` or `delegate`.
-   * DID of the receiving agent (`did:mf:<name>`).
+   * DID of the receiving assistant (`did:mf:<name>`). Vocabulary migration
+   * 2026-05 R13 renamed from `target_principal`; the transition schema
+   * accepts both names — readers should prefer `target_assistant` and
+   * fall back to `target_principal` via {@link getTargetAssistant}.
+   */
+  target_assistant?: string;
+  /**
+   * @deprecated Renamed to `target_assistant` (vocabulary migration
+   * 2026-05, R13). Pre-migration envelopes carry this key; accepted on
+   * read through the transition window. Removed in the breaking major.
    */
   target_principal?: string;
   /**
@@ -192,8 +204,19 @@ export interface Envelope {
  * including the field in the canonical signature input.
  */
 export interface Originator {
-  /** DID of the actor whose capabilities this envelope asserts. */
-  principal: string;
+  /**
+   * DID of the actor whose capabilities this envelope asserts.
+   * Vocabulary migration 2026-05 R2 — canonical key is `identity`;
+   * the transition schema accepts `principal` too. Readers should use
+   * {@link getActorPrincipal} which dual-reads.
+   */
+  identity?: string;
+  /**
+   * @deprecated Renamed to `identity` (vocabulary migration 2026-05, R2).
+   * Pre-migration envelopes carry this key; accepted on read through the
+   * transition window. Removed in the breaking major.
+   */
+  principal?: string;
   /**
    * How the signer learned the originator identity:
    *   - `adapter-resolved` — adapter (Discord/Slack/Mattermost/HTTP/cc-events)
@@ -230,8 +253,20 @@ export type SignedBy = SignedByEd25519 | SignedByHubStamp;
  */
 export interface SignedByEd25519 {
   method: "ed25519";
-  /** Principal DID — `did:mf:<name>` per myelin convention. */
-  principal: string;
+  /**
+   * Stamp DID — `did:mf:<name>` per myelin convention. Vocabulary
+   * migration 2026-05 R2 — canonical key is `identity`; the transition
+   * schema accepts `principal` too. Readers should use
+   * {@link getLastStampPrincipal} or {@link stampIdentityDid} which
+   * dual-read.
+   */
+  identity?: string;
+  /**
+   * @deprecated Renamed to `identity` (vocabulary migration 2026-05, R2).
+   * Pre-migration / JetStream-replayed stamps carry this key; accepted
+   * on read through the transition window. Removed in the breaking major.
+   */
+  principal?: string;
   /** Base64-encoded ed25519 signature (88+ chars). */
   signature: string;
   /** ISO-8601 timestamp the signature was produced. */
@@ -247,9 +282,18 @@ export interface SignedByEd25519 {
  */
 export interface SignedByHubStamp {
   method: "hub-stamp";
-  /** Originating principal — `did:mf:<name>`. */
-  principal: string;
-  /** Hub principal that re-signed — `did:mf:<hub-name>`. */
+  /**
+   * Originating identity — `did:mf:<name>`. Vocabulary migration 2026-05
+   * R2 — canonical key is `identity`; transition schema accepts both.
+   */
+  identity?: string;
+  /**
+   * @deprecated Renamed to `identity` (vocabulary migration 2026-05, R2).
+   * Pre-migration / JetStream-replayed stamps carry this key; accepted
+   * on read through the transition window. Removed in the breaking major.
+   */
+  principal?: string;
+  /** Hub identity that re-signed — `did:mf:<hub-name>`. */
   stamped_by: string;
   /** Base64-encoded ed25519 signature from the hub. */
   signature: string;
@@ -281,8 +325,13 @@ export type SovereigntyRequirement =
   | "strict"
   | "bidding";
 
-/** F-021 — `distribution_mode` enum. */
-export type DistributionMode = "broadcast" | "direct" | "delegate";
+/**
+ * F-021 — `distribution_mode` enum. Vocabulary migration 2026-05 R11
+ * renamed `broadcast` → `offer` on the wire; the transition schema
+ * accepts both. Emitters publish `offer`; readers tolerate `broadcast`
+ * for JetStream replay of pre-migration envelopes.
+ */
+export type DistributionMode = "broadcast" | "offer" | "direct" | "delegate";
 
 /**
  * F-15 economics — token budget, actual usage, billing attribution.
@@ -399,7 +448,14 @@ export function getLastStampPrincipal(envelope: Envelope): string | undefined {
   const chain = getSignedByChain(envelope);
   if (chain.length === 0) return undefined;
   const last = chain[chain.length - 1];
-  return last?.principal;
+  if (!last) return undefined;
+  // R2 (vocabulary migration 2026-05) — dual-read: canonical `identity`
+  // wins, fall back to the deprecated `principal` for pre-migration /
+  // JetStream-replayed stamps. The validator's conflict-rejection rule
+  // (both keys present) fires upstream at envelope validation, so by
+  // the time this helper runs at most one key is set.
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
+  return last.identity ?? last.principal;
 }
 
 /**
@@ -439,9 +495,35 @@ export function getLastStampPrincipal(envelope: Envelope): string | undefined {
  * will catch them if they diverge until that follow-up lands.
  */
 export function getActorPrincipal(envelope: Envelope): string | undefined {
-  if (envelope.originator?.principal) return envelope.originator.principal;
+  // R2 (vocabulary migration 2026-05) — dual-read at both surfaces: the
+  // originator's actor DID and the first stamp's DID. Canonical key is
+  // `identity`; falls back to the deprecated `principal` for
+  // pre-migration / JetStream-replayed envelopes. The validator's
+  // conflict-rejection rule (both keys present) fires upstream.
+  if (envelope.originator) {
+    // eslint-disable-next-line @typescript-eslint/no-deprecated
+    const orig = envelope.originator.identity ?? envelope.originator.principal;
+    if (orig) return orig;
+  }
   const chain = getSignedByChain(envelope);
-  return chain[0]?.principal;
+  const first = chain[0];
+  if (!first) return undefined;
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
+  return first.identity ?? first.principal;
+}
+
+/**
+ * Resolve the `target_assistant` of a Direct/Delegate envelope across the
+ * R13 transition window (vocabulary migration 2026-05). Canonical key is
+ * `target_assistant`; falls back to the deprecated `target_principal`
+ * for pre-migration / JetStream-replayed envelopes.
+ *
+ * Returns `undefined` for envelopes that carry neither key (e.g. an
+ * Offer / broadcast dispatch).
+ */
+export function getTargetAssistant(envelope: Envelope): string | undefined {
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
+  return envelope.target_assistant ?? envelope.target_principal;
 }
 
 /**

--- a/src/bus/myelin/envelope-validator.ts
+++ b/src/bus/myelin/envelope-validator.ts
@@ -527,6 +527,29 @@ export function getTargetAssistant(envelope: Envelope): string | undefined {
 }
 
 /**
+ * Resolve the FIRST stamp's DID across the R2 transition window
+ * (vocabulary migration 2026-05). Canonical key is `identity`; falls
+ * back to the deprecated `principal` for pre-migration / JetStream-
+ * replayed stamps. Returns `fallback` when the chain is empty or the
+ * first stamp has neither key set.
+ *
+ * Audit emitters (`createSystemAccessFederationDeniedEvent`,
+ * `dispatch-listener` denial paths) use this so the same dual-read
+ * lives in one place — the next rename/drop touches one helper rather
+ * than every audit call-site.
+ */
+export function getFirstStampPrincipal(
+  envelope: Envelope,
+  fallback = "<unverified>",
+): string {
+  const chain = getSignedByChain(envelope);
+  const first = chain[0];
+  if (!first) return fallback;
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
+  return first.identity ?? first.principal ?? fallback;
+}
+
+/**
  * Sovereignty classification values per the myelin envelope schema. Exported
  * so emit-site helpers (`system-events.ts`, `dispatch-events.ts`,
  * `github-events.ts`, `taps/cc-events/cc-events.ts`) can accept an optional

--- a/src/bus/myelin/vendor/envelope.schema.json
+++ b/src/bus/myelin/vendor/envelope.schema.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://myelin.metafactory.ai/schemas/envelope/v1",
+  "$id": "https://myelin.metafactory.ai/schemas/envelope/v2",
   "title": "Myelin Envelope",
-  "description": "Universal message envelope for the agentic nervous system. One schema for all signals — sovereignty travels with the message.",
+  "description": "Universal message envelope for the agentic nervous system. One schema for all signals — sovereignty travels with the message. v2 (vocabulary migration 2026-05, transition release): wire fields renamed — signed_by[].principal→identity, originator.principal→identity, target_principal→target_assistant, distribution_mode broadcast→offer, source grammar org.agent.instance→{principal}.{stack}.{assistant}. This transition schema accepts BOTH the deprecated and the renamed form so pre-migration / JetStream-replayed envelopes still validate; the breaking major drops the deprecated forms. v1 stays published for consumers pinned to the old grammar.",
   "type": "object",
   "required": ["id", "source", "type", "timestamp", "sovereignty", "payload"],
   "properties": {
@@ -14,8 +14,8 @@
     "source": {
       "type": "string",
       "pattern": "^[a-z][a-z0-9-]*(\\.[a-z][a-z0-9-]*){2,4}$",
-      "description": "Origin address. Minimum 3 segments (org.agent.instance), up to 5 for domain-scoped agents (org.domain.agent.instance.replica).",
-      "examples": ["acme.monitor.prod-01", "metafactory.pilot.local", "acme.security.scanner.prod-01"]
+      "description": "Origin address. Canonical grammar (R6, vocabulary migration 2026-05) is the fixed-3 form {principal}.{stack}.{assistant}. This transition schema keeps the legacy {2,4} pattern (3-5 segments, org.agent.instance) so pre-migration / JetStream-replayed envelopes still validate — the fixed-3 form is a strict subset. The breaking major tightens the pattern to exactly 3 segments.",
+      "examples": ["metafactory.security.luna", "metafactory.pilot.local", "acme.monitor.prod-01"]
     },
     "type": {
       "type": "string",
@@ -165,28 +165,41 @@
     },
     "distribution_mode": {
       "type": "string",
-      "enum": ["broadcast", "direct", "delegate"],
-      "description": "F-021: operator-facing routing semantics. broadcast = competing consumers; direct = named recipient; delegate = outcome handoff (multi-step orchestration)."
+      "enum": ["broadcast", "offer", "direct", "delegate"],
+      "description": "F-021: routing semantics. offer = competing consumers; direct = named recipient; delegate = outcome handoff (multi-step orchestration). R11 (vocabulary migration 2026-05): 'broadcast' renamed to 'offer'. Transition release accepts BOTH; 'broadcast' is deprecated and dropped in the breaking major."
+    },
+    "target_assistant": {
+      "type": "string",
+      "pattern": "^did:mf:[a-z](?:[a-z0-9._]|-(?!-))+$",
+      "description": "F-021: required when distribution_mode is direct or delegate. DID of the receiving assistant. R13 (vocabulary migration 2026-05): renamed from 'target_principal'."
     },
     "target_principal": {
       "type": "string",
       "pattern": "^did:mf:[a-z](?:[a-z0-9._]|-(?!-))+$",
-      "description": "F-021: required when distribution_mode is direct or delegate. DID of the receiving agent."
+      "description": "DEPRECATED (vocabulary migration 2026-05, R13) — renamed to 'target_assistant'. Accepted on read through the transition window for pre-migration / JetStream-replayed envelopes; an envelope carrying BOTH keys is rejected (dual_field_conflict). Removed in the breaking major."
     },
     "originator": {
       "type": "object",
-      "description": "myelin#160: policy-level actor identity, separate from the cryptographic signed_by chain. The chain proves WHO signed; originator names WHO the signer claims to be acting on behalf of. Covered by the signature (signer commits to the attribution claim). When absent, the signer is the actor.",
-      "required": ["principal", "attribution"],
+      "description": "myelin#160: policy-level actor identity, separate from the cryptographic signed_by chain. The chain proves WHO signed; originator names WHO the signer claims to be acting on behalf of. Covered by the signature (signer commits to the attribution claim). When absent, the signer is the actor. R2 (vocabulary migration 2026-05): the actor-DID field renamed 'principal'→'identity'; transition release accepts either, rejects both.",
+      "oneOf": [
+        { "required": ["identity", "attribution"] },
+        { "required": ["principal", "attribution"] }
+      ],
       "properties": {
+        "identity": {
+          "type": "string",
+          "pattern": "^did:mf:[a-z](?:[a-z0-9._]|-(?!-))+$",
+          "description": "DID of the actor whose capabilities this envelope asserts (R2 — renamed from 'principal')."
+        },
         "principal": {
           "type": "string",
           "pattern": "^did:mf:[a-z](?:[a-z0-9._]|-(?!-))+$",
-          "description": "DID of the actor whose capabilities this envelope asserts."
+          "description": "DEPRECATED (R2) — renamed to 'identity'. Accepted on read through the transition window; an originator carrying BOTH keys is rejected (dual_field_conflict)."
         },
         "attribution": {
           "type": "string",
           "enum": ["adapter-resolved", "federated", "delegated"],
-          "description": "How the signer learned the originator identity. adapter-resolved: external (Discord/Slack/HTTP) id mapped to principal. federated: relayed claim from another operator. delegated: signer holds delegation credentials for the originator."
+          "description": "How the signer learned the originator identity. adapter-resolved: external (Discord/Slack/HTTP) id mapped to an identity. federated: relayed claim from another network. delegated: signer holds delegation credentials for the originator."
         }
       },
       "additionalProperties": false
@@ -198,37 +211,59 @@
         "properties": { "distribution_mode": { "enum": ["direct", "delegate"] } },
         "required": ["distribution_mode"]
       },
-      "then": { "required": ["target_principal"] }
+      "then": {
+        "anyOf": [
+          { "required": ["target_assistant"] },
+          { "required": ["target_principal"] }
+        ]
+      }
+    },
+    {
+      "comment": "R13 dual_field_conflict — direct/delegate routing target must not carry BOTH the deprecated and renamed key.",
+      "not": { "required": ["target_principal", "target_assistant"] }
     }
   ],
   "additionalProperties": false,
   "$defs": {
     "signedByStamp": {
       "type": "object",
-      "description": "A single identity attestation in the chain (myelin#31). Discriminated on method.",
-      "oneOf": [
+      "description": "A single identity attestation in the chain (myelin#31). Discriminated on method. R2 (vocabulary migration 2026-05): the stamp DID field renamed 'principal'→'identity'. This transition schema accepts EITHER key (each method branch requires exactly one of them) and rejects a stamp carrying BOTH via the dualKeyExclusion constraint.",
+      "allOf": [
         {
-          "required": ["method", "principal", "signature", "at"],
-          "properties": {
-            "method": { "const": "ed25519" },
-            "principal": { "type": "string", "pattern": "^did:mf:[a-z](?:[a-z0-9._]|-(?!-))+$" },
-            "signature": { "type": "string", "minLength": 88, "pattern": "^[A-Za-z0-9+/]+=*$" },
-            "at": { "type": "string", "format": "date-time" },
-            "role": { "$ref": "#/$defs/stampRole" }
-          },
-          "additionalProperties": false
+          "oneOf": [
+            {
+              "required": ["method", "signature", "at"],
+              "properties": {
+                "method": { "const": "ed25519" },
+                "identity": { "type": "string", "pattern": "^did:mf:[a-z](?:[a-z0-9._]|-(?!-))+$" },
+                "principal": { "type": "string", "pattern": "^did:mf:[a-z](?:[a-z0-9._]|-(?!-))+$" },
+                "signature": { "type": "string", "minLength": 88, "pattern": "^[A-Za-z0-9+/]+=*$" },
+                "at": { "type": "string", "format": "date-time" },
+                "role": { "$ref": "#/$defs/stampRole" }
+              },
+              "additionalProperties": false
+            },
+            {
+              "required": ["method", "stamped_by", "signature", "at"],
+              "properties": {
+                "method": { "const": "hub-stamp" },
+                "identity": { "type": "string", "pattern": "^did:mf:[a-z](?:[a-z0-9._]|-(?!-))+$" },
+                "principal": { "type": "string", "pattern": "^did:mf:[a-z](?:[a-z0-9._]|-(?!-))+$" },
+                "stamped_by": { "type": "string", "pattern": "^did:mf:[a-z](?:[a-z0-9._]|-(?!-))+$" },
+                "signature": { "type": "string", "minLength": 88, "pattern": "^[A-Za-z0-9+/]+=*$" },
+                "at": { "type": "string", "format": "date-time" },
+                "role": { "$ref": "#/$defs/stampRole" }
+              },
+              "additionalProperties": false
+            }
+          ]
         },
         {
-          "required": ["method", "principal", "stamped_by", "signature", "at"],
-          "properties": {
-            "method": { "const": "hub-stamp" },
-            "principal": { "type": "string", "pattern": "^did:mf:[a-z](?:[a-z0-9._]|-(?!-))+$" },
-            "stamped_by": { "type": "string", "pattern": "^did:mf:[a-z](?:[a-z0-9._]|-(?!-))+$" },
-            "signature": { "type": "string", "minLength": 88, "pattern": "^[A-Za-z0-9+/]+=*$" },
-            "at": { "type": "string", "format": "date-time" },
-            "role": { "$ref": "#/$defs/stampRole" }
-          },
-          "additionalProperties": false
+          "comment": "R2 — a stamp must carry exactly one DID key: 'identity' (canonical) or 'principal' (deprecated). Neither-present and both-present are both rejected.",
+          "oneOf": [
+            { "required": ["identity"], "not": { "required": ["principal"] } },
+            { "required": ["principal"], "not": { "required": ["identity"] } }
+          ]
         }
       ]
     },

--- a/src/bus/system-events.ts
+++ b/src/bus/system-events.ts
@@ -567,8 +567,20 @@ export interface SystemAccessSovereignty {
  * audit one without re-parsing either.
  */
 export interface SystemAccessSignedBy {
-  /** Originating principal — `did:mf:<name>` per myelin convention. */
-  principal: string;
+  /**
+   * Originating stamp DID — `did:mf:<name>` per myelin convention.
+   * Vocabulary migration 2026-05 R2 — canonical key is `identity`;
+   * the transition schema accepts `principal` too. Both are optional
+   * here so the audit pipeline can carry whichever the wire stamp
+   * actually shipped.
+   */
+  identity?: string;
+  /**
+   * @deprecated Renamed to `identity` (vocabulary migration 2026-05, R2).
+   * Pre-migration / JetStream-replayed stamps carry this key; accepted
+   * on read through the transition window. Removed in the breaking major.
+   */
+  principal?: string;
   /** Stamp method — `"ed25519"` | `"hub-stamp"` today; extensible. */
   method?: string;
   /** ISO-8601 timestamp the signature was produced. */
@@ -874,7 +886,10 @@ export interface SystemAccessFederationDeniedOpts {
 export function createSystemAccessFederationDeniedEvent(
   opts: SystemAccessFederationDeniedOpts,
 ): Envelope {
-  const principalId = opts.signedBy[0]?.principal ?? "unknown";
+  // R2 (vocabulary migration 2026-05) — dual-read stamp DID: canonical
+  // `identity` wins, fall back to deprecated `principal`.
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
+  const principalId = opts.signedBy[0]?.identity ?? opts.signedBy[0]?.principal ?? "unknown";
   return buildBaseEnvelope({
     type: "system.access.denied",
     source: buildSource(opts.source),

--- a/src/bus/verify-signed-by-chain.ts
+++ b/src/bus/verify-signed-by-chain.ts
@@ -46,7 +46,7 @@
 import {
   verifyEnvelopeIdentity,
   createInMemoryRegistry,
-  type PrincipalRegistry,
+  type IdentityRegistry,
 } from "@the-metafactory/myelin/identity";
 import { Prefix } from "@nats-io/nkeys";
 // `Codec` is the internal NKey base32 + CRC + prefix-byte decoder.
@@ -175,7 +175,7 @@ export interface VerifySignedByChainOptions {
    * call sites keep their behaviour unchanged until they opt in.
    *
    * When `cryptoVerify: true`, the caller must also pass `operatorId`
-   * so the helper can build a myelin `PrincipalRegistry` from the
+   * so the helper can build a myelin `IdentityRegistry` from the
    * `TrustResolver`'s underlying `AgentRegistry`. Each agent with an
    * `nkey_pub` becomes a Principal whose `public_key` is the
    * base64-encoded raw ed25519 pubkey derived from the NATS NKey.
@@ -266,17 +266,24 @@ export async function verifySignedByChain(
           "myelin's Principal shape needs the operator field populated.",
       );
     }
-    const registry = buildPrincipalRegistry(
+    const registry = buildIdentityRegistry(
       opts.resolver.getRegistry(),
       opts.operatorId,
     );
     // Myelin's verifier expects `signed_by` normalised to array form;
     // cortex's `Envelope` keeps the back-compat shim of single-stamp
     // OR array. Normalise here before handing off.
+    //
+    // R2 (vocabulary migration 2026-05) — the cortex vendored SignedBy
+    // declares `identity?` AND `principal?` as optional so the transition
+    // window can carry either; upstream myelin's discriminated union
+    // requires exactly one. The runtime guarantee is identical (the
+    // envelope validator's `dual_field_conflict` check fires before this
+    // helper runs), so cast through `unknown` at the type boundary.
     const myelinEnvelope = {
       ...envelope,
       signed_by: chain,
-    };
+    } as unknown as Parameters<typeof verifyEnvelopeIdentity>[0];
     const myelinResult = await verifyEnvelopeIdentity(
       myelinEnvelope,
       registry,
@@ -327,7 +334,18 @@ function verifyOneStamp(
   }
   // Discriminated union — narrows to SignedByEd25519 once hub-stamp is out.
 
-  const principal = stamp.principal;
+  // R2 (vocabulary migration 2026-05) — dual-read the stamp DID:
+  // canonical `identity` wins, fall back to deprecated `principal`
+  // for pre-migration / JetStream-replayed stamps. The envelope-level
+  // dual_field_conflict check fires upstream at envelope validation.
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
+  const principal = stamp.identity ?? stamp.principal;
+  if (principal === undefined) {
+    return {
+      kind: "reject",
+      reason: { kind: "malformed_principal", principal: "<missing>" },
+    };
+  }
   const agentId = extractAgentIdFromDid(principal);
   if (agentId === undefined) {
     return {
@@ -376,7 +394,7 @@ function verifyOneStamp(
 // =============================================================================
 
 /**
- * Bridge cortex's `AgentRegistry` to myelin's `PrincipalRegistry` for the
+ * Bridge cortex's `AgentRegistry` to myelin's `IdentityRegistry` for the
  * crypto-verification step. Every agent with a declared `nkey_pub` becomes
  * a Principal whose `public_key` is the base64-encoded raw ed25519 pubkey
  * extracted from the NATS NKey via `@nats-io/nkeys`'s `fromPublic`.
@@ -398,10 +416,10 @@ function verifyOneStamp(
  * the caller has a stable agent set (future caching is a separate
  * concern — at B.1c, every cryptoVerify call rebuilds).
  */
-export function buildPrincipalRegistry(
+export function buildIdentityRegistry(
   agentRegistry: AgentRegistry,
   operatorId: string,
-): PrincipalRegistry {
+): IdentityRegistry {
   const registry = createInMemoryRegistry();
   const createdAt = new Date(0).toISOString();
   for (const agent of agentRegistry.getAll()) {
@@ -415,7 +433,11 @@ export function buildPrincipalRegistry(
     registry.add({
       id: `did:mf:${agent.id}`,
       display_name: agent.displayName,
-      operator: operatorId,
+      // R4 (vocabulary migration 2026-05) — myelin's `Identity` interface
+      // renamed `operator` → `network` (Luna's PR-5/PR-8 in #168/#171).
+      // `operatorId` is still cortex's variable name — it stores the
+      // network slug per the bus-addressing model.
+      network: operatorId,
       public_key: publicKey,
       type: "agent",
       created_at: createdAt,

--- a/src/runner/dispatch-listener.ts
+++ b/src/runner/dispatch-listener.ts
@@ -60,6 +60,7 @@ import type { Envelope } from "../bus/myelin/envelope-validator";
 import {
   getActorPrincipal,
   getSignedByChain,
+  getFirstStampPrincipal,
 } from "../bus/myelin/envelope-validator";
 import type { MyelinRuntime } from "../bus/myelin/runtime";
 import type {
@@ -1087,9 +1088,10 @@ async function emitChainVerificationDeny(
   chainReason: ChainRejectionReason,
 ): Promise<void> {
   const chain = getSignedByChain(envelope);
-  // R2 (vocabulary migration 2026-05) — dual-read stamp DID.
-  // eslint-disable-next-line @typescript-eslint/no-deprecated
-  const claimedPrincipal = chain[0]?.identity ?? chain[0]?.principal ?? "<unverified>";
+  // R2 (vocabulary migration 2026-05) — dual-read via the shared
+  // `getFirstStampPrincipal` helper so the transition logic lives in
+  // one place. Sage cortex#396 maintainability suggestion.
+  const claimedPrincipal = getFirstStampPrincipal(envelope);
   // Strip did:mf: prefix when present so audit consumers see a bare id
   // shape consistent with the engine's principal-id idiom; fall through
   // to the raw DID otherwise (preserves the wire claim verbatim).
@@ -1163,9 +1165,8 @@ async function emitReceivingAgentUnconfiguredDeny(
   stack: string | undefined,
 ): Promise<void> {
   const chain = getSignedByChain(envelope);
-  // R2 (vocabulary migration 2026-05) — dual-read stamp DID.
-  // eslint-disable-next-line @typescript-eslint/no-deprecated
-  const claimedPrincipal = chain[0]?.identity ?? chain[0]?.principal ?? "<unverified>";
+  // R2 (vocabulary migration 2026-05) — same shared dual-read helper.
+  const claimedPrincipal = getFirstStampPrincipal(envelope);
   const principalId =
     extractAgentIdFromDid(claimedPrincipal) ?? claimedPrincipal;
 

--- a/src/runner/dispatch-listener.ts
+++ b/src/runner/dispatch-listener.ts
@@ -1087,7 +1087,9 @@ async function emitChainVerificationDeny(
   chainReason: ChainRejectionReason,
 ): Promise<void> {
   const chain = getSignedByChain(envelope);
-  const claimedPrincipal = chain[0]?.principal ?? "<unverified>";
+  // R2 (vocabulary migration 2026-05) — dual-read stamp DID.
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
+  const claimedPrincipal = chain[0]?.identity ?? chain[0]?.principal ?? "<unverified>";
   // Strip did:mf: prefix when present so audit consumers see a bare id
   // shape consistent with the engine's principal-id idiom; fall through
   // to the raw DID otherwise (preserves the wire claim verbatim).
@@ -1161,7 +1163,9 @@ async function emitReceivingAgentUnconfiguredDeny(
   stack: string | undefined,
 ): Promise<void> {
   const chain = getSignedByChain(envelope);
-  const claimedPrincipal = chain[0]?.principal ?? "<unverified>";
+  // R2 (vocabulary migration 2026-05) — dual-read stamp DID.
+  // eslint-disable-next-line @typescript-eslint/no-deprecated
+  const claimedPrincipal = chain[0]?.identity ?? chain[0]?.principal ?? "<unverified>";
   const principalId =
     extractAgentIdFromDid(claimedPrincipal) ?? claimedPrincipal;
 


### PR DESCRIPTION
## Summary

Vocabulary migration 2026-05, **cortex PR-8** — consume the wire-field renames Luna shipped in myelin#168..#176 (post-vocab-migration transition release). Lockstep with the F-phase myelin landings.

Per manifest at `docs/migrations/0001-vocabulary-grilled-2026-05.md` §PR-8 (L162–164).

## Cascade scope

- **R10** — `target_principal` (consumed wire field) → `target_assistant`
- **R11** — `signed_by[].principal` / `originator.principal` (consumed wire fields) → `.identity`

## What changed

- **Dep bump** — `@the-metafactory/myelin` github ref → `e37b347` (head of main post #173..#176)
- **Vendored schema** — re-vendored from upstream `schemas/envelope.schema.json` at the bumped commit. New `$id` is `…/envelope/v2`; transition schema accepts both deprecated and renamed forms.
- **Envelope-validator TS surface** — `Envelope.target_assistant?`, `Originator.identity?`, `SignedByEd25519.identity?`, `SignedByHubStamp.identity?` added; old names kept as `@deprecated`. `DistributionMode` union adds `"offer"`. New `getTargetAssistant(envelope)` helper. `getActorPrincipal` + `getLastStampPrincipal` dual-read.
- **Direct-reader sites** updated to dual-read with inline R2 citations: `verify-signed-by-chain.ts:verifyOneStamp` (+ `buildPrincipalRegistry → buildIdentityRegistry` + `operator → network` on Identity), `system-events.ts:createSystemAccessFederationDeniedEvent`, `dispatch-listener.ts` (two sites).
- **`SystemAccessSignedBy`** interface declares both keys so audit pipeline carries whichever the wire shipped.
- **Tests** — schema-pin assertion bumped; `runtime.test.ts` + `iaw-phase-d-integration.test.ts` dual-read JSON-parsed stamp DIDs to cover the canonical+deprecated wire path.

## Wire-safety

The PR-6 #169 envelope validator's `dual_field_conflict` rule still fires upstream of EVERY cortex consumer. Cortex never re-keys before canonicalization. The transition schema's bytes-as-received guarantee carries through. JetStream-replayed envelopes (CODE_REVIEW + EVENTS streams) carrying pre-migration field names still verify and route through cortex unchanged.

## Test plan

- [x] `bunx tsc --noEmit` clean
- [x] `bun test` → **3477 pass, 2 skip, 0 fail** across 185 files (4 pre-existing fails from migration impact resolved by this PR's dual-read updates)
- [x] `bun run lint` clean (0 errors; 26 pre-existing unused-disable warnings out of scope)

## Vocab-alignment plan

G1 step from `~/.claude/PAI/MEMORY/WORK/vocab-alignment/PLAN-CONTINUATION.md`. Unblocks G2 + G3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)