### PR TITLE
feat(cortex): C-388 PR-9 — Broadcast → Offer cascade (R5)

### DIFF
--- a/src/bus/myelin/__tests__/envelope-validator.test.ts
+++ b/src/bus/myelin/__tests__/envelope-validator.test.ts
@@ -320,7 +320,20 @@ describe("envelope-validator — F-021 task envelope fields (IAW Phase A.2)", ()
     }
   });
 
-  test("accepts a broadcast envelope with no target_principal", () => {
+  test("accepts an offer envelope with no target_assistant (canonical R11)", () => {
+    const env = {
+      ...(validEnvelope as object),
+      distribution_mode: "offer",
+      sovereignty_required: "open",
+    };
+    const result = validateEnvelope(env);
+    expect(result.ok).toBe(true);
+  });
+
+  test("accepts a broadcast envelope (deprecated alias, R11 back-compat)", () => {
+    // Vocabulary migration 2026-05 — `broadcast` is the deprecated alias
+    // of `offer`. The transition schema still accepts it on read so
+    // JetStream-replayed pre-migration envelopes route through unchanged.
     const env = {
       ...(validEnvelope as object),
       distribution_mode: "broadcast",
@@ -379,10 +392,13 @@ describe("envelope-validator — F-021 task envelope fields (IAW Phase A.2)", ()
   });
 
   test("accepts an envelope with the F-021 bidding sovereignty mode", () => {
+    // R11 (vocabulary migration 2026-05) — bidding sovereignty uses the
+    // canonical `offer` distribution_mode; the deprecated `broadcast`
+    // alias is exercised in the separate back-compat test above.
     const env = {
       ...(validEnvelope as object),
       sovereignty_required: "bidding",
-      distribution_mode: "broadcast",
+      distribution_mode: "offer",
     };
     const result = validateEnvelope(env);
     expect(result.ok).toBe(true);

--- a/src/common/types/cortex-config.ts
+++ b/src/common/types/cortex-config.ts
@@ -221,9 +221,10 @@ export const DiscordPresenceSchema = z.object({
    * configs).
    *
    * Common values:
-   *   - `local.{org}.tasks.code-review.>` — pilot review-requests (IoAW
-   *     Broadcast grammar per myelin/specs/namespace.md §Tasks Domain).
-   *   - `local.{org}.code.pr.review.>`    — sage review outcomes.
+   *   - `local.{principal}.tasks.code-review.>` — pilot review-requests (IoAW
+   *     Offer grammar per myelin/specs/namespace.md §Tasks Domain;
+   *     renamed from Broadcast — vocabulary migration 2026-05, R11).
+   *   - `local.{principal}.code.pr.review.>`    — sage review outcomes.
    *
    * Moves to per-renderer config at MIG-7.2d; for v1 the whole-adapter
    * subscription list is enough to unblock the bus→Discord render path.


### PR DESCRIPTION
## Summary

Vocabulary migration 2026-05, **cortex PR-9** — cascade the R11 `Broadcast` → `Offer` dispatch-mode rename Luna shipped in myelin PR-6 #169 + ecosystem-wide F-phase landings. Lockstep with myelin's R11 surface.

Per manifest at `docs/migrations/0001-vocabulary-grilled-2026-05.md` §PR-9 (L165–166).

## Scope (cortex's R5 = consumed cascade of myelin's R11)

- **Test surface** — `src/bus/myelin/__tests__/envelope-validator.test.ts`:
  - The "accepts a broadcast envelope with no target_principal" test split into two: a NEW "accepts an offer envelope with no target_assistant (canonical R11)" + a renamed "accepts a broadcast envelope (deprecated alias, R11 back-compat)". Together they lock both wire forms.
  - "accepts an envelope with the F-021 bidding sovereignty mode" flips to `distribution_mode: "offer"`.
- **Doc-comment surface** — `src/common/types/cortex-config.ts:225`: example flipped + Broadcast → Offer grammar tag.

## Out of scope

- `DistributionMode` union already extended at PR-8 #396; no change here.
- Vendored schema already re-vendored at PR-8; no change here.
- `src/surface/mc/*` "broadcast" references describe WebSocket broadcast (different concept; R12a mechanism-not-mode decision).

## Wire-safety

Net behaviour identical: schema accepts BOTH `"offer"` and `"broadcast"` so JetStream-replayed pre-migration envelopes route through unchanged.

## Test plan

- [x] `bunx tsc --noEmit` clean
- [x] `bun test src/bus/myelin/__tests__/envelope-validator.test.ts` → **58 pass, 0 fail** (57 before + 1 new "offer canonical")
- [x] `bun run lint` clean

## Vocab-alignment plan

G2 step from `~/.claude/PAI/MEMORY/WORK/vocab-alignment/PLAN-CONTINUATION.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)