### PR TITLE
feat(cortex): C-388 PR-10 — {org} → {principal} subject derivation (R4)

### DIFF
--- a/src/__tests__/cortex.review-consumer-boot.test.ts
+++ b/src/__tests__/cortex.review-consumer-boot.test.ts
@@ -247,7 +247,7 @@ describe("startCortex — review-consumer boot wiring (cortex#237 PR-6)", () => 
     expect(runtime.subscribePullCalls.length).toBe(2);
     const patterns = runtime.subscribePullCalls.map((c) => c.pattern);
     // cortex#318 — subscribe pattern includes the stack segment to match
-    // pilot's 6-segment publish grammar (`local.{org}.{stack}.tasks.code-
+    // pilot's 6-segment publish grammar (`local.{principal}.{stack}.tasks.code-
     // review.<flavor>`). Test config omits the stack: block so
     // `deriveStackId` default-derives `'default'`. Pre-cortex#318 this
     // was a 4-segment pattern that never matched stack-aware publishes.

--- a/src/__tests__/cortex.review-consumer.e2e.test.ts
+++ b/src/__tests__/cortex.review-consumer.e2e.test.ts
@@ -209,10 +209,10 @@ interface BusRuntime extends MyelinRuntime {
 /**
  * Derive a NATS subject from an envelope per
  * `src/bus/myelin/envelope-validator.ts:deriveNatsSubject` — for the
- * tests we use only `local.{org}.{type}` (no stack-id segment) which is
+ * tests we use only `local.{principal}.{type}` (no stack-id segment) which is
  * the legacy 5-segment shape Echo + cortex publish on today.
  *
- * `envelope.source` is the dotted triple `"{org}.{agent}.{instance}"`;
+ * `envelope.source` is the dotted triple `"{principal}.{agent}.{instance}"`;
  * pull the first segment as the org for the subject prefix.
  */
 function subjectFor(envelope: Envelope): string {
@@ -263,7 +263,7 @@ function createBusRuntime(): BusRuntime {
       // emits its verdict/lifecycle envelopes via runtime.publish; those
       // emissions must NOT loop back into the consumer's own pull
       // subscription (subject patterns differ: verdict goes to
-      // `local.{org}.review.verdict.*`, not `tasks.code-review.>`).
+      // `local.{principal}.review.verdict.*`, not `tasks.code-review.>`).
       // Still call the matched pull subscribers so a misrouted publish
       // is observable in the test.
       for (const sub of subscriptions) {

--- a/src/__tests__/cortex.test.ts
+++ b/src/__tests__/cortex.test.ts
@@ -268,7 +268,7 @@ describe("startCortex — wire-up", () => {
 
   test("dispatch-listener registers with the right org-derived subject", async () => {
     // Echo round-1 N1: the listener's `surfaceConfig.subjects` is
-    // `local.{org}.dispatch.task.received` where `{org}` comes from
+    // `local.{principal}.dispatch.task.received` where `{principal}` comes from
     // `agent.operatorId ?? "default"`. Verify the fallback path: with
     // operatorId absent, the runtime sees envelopes on `local.default.*`.
     const runtime = createRecordingRuntime();

--- a/src/adapters/discord/index.ts
+++ b/src/adapters/discord/index.ts
@@ -71,7 +71,7 @@ export interface DiscordAdapterInfra {
   /** Myelin runtime for `system.adapter.*` envelope emission. Optional — adapters started
    * without NATS still track degradation/reconnect locally. */
   runtime?: MyelinRuntime;
-  /** `{org}.{agent}.{instance}` source triple stamped onto emitted `system.*` envelopes
+  /** `{principal}.{agent}.{instance}` source triple stamped onto emitted `system.*` envelopes
    * (spec §3.6 names the agent, not the operator). */
   systemEventSource?: SystemEventSource;
   /** MIG-3b: NATS subject patterns this adapter renders to Discord. Empty/undefined → adapter

--- a/src/adapters/mattermost/index.ts
+++ b/src/adapters/mattermost/index.ts
@@ -77,7 +77,7 @@ export interface MattermostAdapterInfra {
    * is optional and the adapter still works when absent.
    */
   runtime?: MyelinRuntime;
-  /** v2.0.0 (cortex#297) — `{org}.{agent}.{instance}` source triple. */
+  /** v2.0.0 (cortex#297) — `{principal}.{agent}.{instance}` source triple. */
   systemEventSource?: SystemEventSource;
   /**
    * v2.0.0 cutover (cortex#297) — PolicyEngine is the sole authorisation

--- a/src/adapters/slack/index.ts
+++ b/src/adapters/slack/index.ts
@@ -65,7 +65,7 @@ export interface SlackAdapterInfra {
    */
   runtime?: MyelinRuntime;
   /**
-   * `{org}.{agent}.{instance}` source triple stamped onto emitted
+   * `{principal}.{agent}.{instance}` source triple stamped onto emitted
    * `system.*` envelopes. Required for any `system.adapter.*` envelope
    * to fire — see `canPublishSystemEvent()`.
    */

--- a/src/bus/capability-registry.ts
+++ b/src/bus/capability-registry.ts
@@ -51,10 +51,10 @@
  *   module independent of the connection layer and trivially testable.
  *
  * - NOT a KV-bucket primitive. Architecture §7.2 specifies
- *   `local.{org}.agents.capabilities.{agent_id}` as a NATS KV bucket;
+ *   `local.{principal}.agents.capabilities.{agent_id}` as a NATS KV bucket;
  *   myelin's signed-KV API (myelin#31) is the right home for that
  *   primitive and hasn't shipped. v1 publishes a wire envelope on the
- *   regular subject (`local.{org}.agents.capabilities.registered`, derived
+ *   regular subject (`local.{principal}.agents.capabilities.registered`, derived
  *   from the envelope type by the runtime's subject derivation per IAW
  *   Phase A.3). The KV-bucket write is a v2 layer on top.
  *
@@ -63,12 +63,12 @@
  * The runtime derives subjects from `(envelope.type, envelope.sovereignty.
  * classification, envelope.source's org segment)`:
  *
- *   - classification `"local"` → subject `local.{org}.{type}`
- *   - With stack segment (IAW A.5) → `local.{org}.{stack}.{type}`
+ *   - classification `"local"` → subject `local.{principal}.{type}`
+ *   - With stack segment (IAW A.5) → `local.{principal}.{stack}.{type}`
  *
  * So with `type: "agents.capabilities.registered"` and `classification:
  * "local"`, the published subject is
- * `local.{org}.agents.capabilities.registered` (or `local.{org}.{stack}.
+ * `local.{principal}.agents.capabilities.registered` (or `local.{principal}.{stack}.
  * agents.capabilities.registered` when a stack id is configured). The
  * `agent_id` discriminator lives in the **payload** (not the subject)
  * for v1; subscribers filter by payload field. The KV-bucket migration
@@ -94,7 +94,7 @@ import { buildBaseEnvelope } from "./envelope-builder";
 export type PublishFn = (envelope: Envelope) => Promise<void>;
 
 /**
- * Envelope source struct — `{org}.{agent}.{instance}` per
+ * Envelope source struct — `{principal}.{agent}.{instance}` per
  * `src/bus/system-events.ts:SystemEventSource`. Duplicated structurally
  * here rather than re-imported because the registry is an
  * `agents.*`-domain emitter; the structural identity with
@@ -194,8 +194,8 @@ export interface PublishCapabilityRegistryOptions {
  * "type: agents.capabilities.registered". The runtime derives the wire
  * subject from this (and from `sovereignty.classification`):
  *
- *   - local + no stack:  `local.{org}.agents.capabilities.registered`
- *   - local + stack:     `local.{org}.{stack}.agents.capabilities.registered`
+ *   - local + no stack:  `local.{principal}.agents.capabilities.registered`
+ *   - local + stack:     `local.{principal}.{stack}.agents.capabilities.registered`
  *   - federated:         `federated.{network}.agents.capabilities.registered`
  *
  * PR-7's subscriber matches against this constant rather than

--- a/src/bus/dispatch-events.ts
+++ b/src/bus/dispatch-events.ts
@@ -20,7 +20,7 @@
  *   - `id` is a fresh `crypto.randomUUID()` per call (envelope idempotency key).
  *   - `timestamp` is the helper-call time. Lifecycle moments distinct from
  *     emit time (`started_at`, `completed_at`, etc.) live in payload.
- *   - `source` is the dotted `{org}.{agent}.{instance}` per the schema.
+ *   - `source` is the dotted `{principal}.{agent}.{instance}` per the schema.
  *   - `correlation_id` is the **task UUID** when the caller provides one —
  *     the runner generates a UUID-shaped task_id at accept time so all four
  *     lifecycle events for a single task share one correlation_id. Surfaces

--- a/src/bus/dispatch-handler.ts
+++ b/src/bus/dispatch-handler.ts
@@ -97,7 +97,7 @@ export interface DispatchHandlerOpts {
    */
   runtime?: MyelinRuntime;
   /**
-   * `{org}.{agent}.{instance}` triple stamped onto emitted `system.*`
+   * `{principal}.{agent}.{instance}` triple stamped onto emitted `system.*`
    * envelopes (spec §3.6). Required-with-`runtime`: if a caller passes
    * `runtime` without `systemEventSource` the handler logs a one-shot warn
    * and skips publication (mirroring the DiscordAdapter `canPublishSystemEvent`

--- a/src/bus/github-events.ts
+++ b/src/bus/github-events.ts
@@ -2,21 +2,21 @@
  * MIG-5.6 (C-106) — `github.*` envelope constructor for GitHub webhook events.
  *
  * Per plan §4 MIG-5.6 + cortex#37: HMAC-validated GitHub webhooks must surface
- * on the bus as `local.{org}.github.{event}.{action}` envelopes so any sibling
+ * on the bus as `local.{principal}.github.{event}.{action}` envelopes so any sibling
  * agent / surface can subscribe (dashboard projection, pilot review router,
  * cortex worklog hints, future renderers).
  *
  * **Subject derivation** (mirrors `bus/system-events.ts` + `bus/dispatch-events.ts`):
  *   - `envelope.type` is the dotted `github.{event}.{action}` form.
- *   - `MyelinRuntime.publish` prepends `local.{org}.` at publish time, so the
- *     final NATS subject is `local.{org}.github.{event}.{action}` without
+ *   - `MyelinRuntime.publish` prepends `local.{principal}.` at publish time, so the
+ *     final NATS subject is `local.{principal}.github.{event}.{action}` without
  *     callers having to assemble it.
  *   - When the GitHub event has no natural `action` (e.g. `push`, `ping`,
  *     `release` payloads that don't carry an `action` field), the helper
  *     emits `github.{event}.received` so the type always has the
  *     `domain.entity.action` triplet the schema requires (pattern allows
  *     2-5 segments, but 3 is the canonical shape and keeps wildcard subs
- *     stable: `local.{org}.github.>` matches everything; `local.{org}.github.{event}.>`
+ *     stable: `local.{principal}.github.>` matches everything; `local.{principal}.github.{event}.>`
  *     matches all actions for an event).
  *
  * **Shape contract** (consistent with the rule-of-three established by
@@ -26,7 +26,7 @@
  *     timestamp (if available via `X-GitHub-Delivery` parsing or payload
  *     fields) lives in `payload` so envelope `timestamp` always reflects
  *     emit time — same convention as `system-events.ts`.
- *   - `source` is the dotted `{org}.{agent}.{instance}` form.
+ *   - `source` is the dotted `{principal}.{agent}.{instance}` form.
  *   - `correlation_id` is set to the GitHub delivery ID **only when it is
  *     UUID-shaped**. GitHub delivery IDs *are* UUIDs (e.g.
  *     `12345678-1234-1234-1234-123456789012`), so this is the normal path —
@@ -133,7 +133,7 @@ export function sanitizeTypeSegment(value: string): string {
 
 export interface CreateGithubEventEnvelopeOpts {
   /**
-   * Envelope source — `{org}.{agent}.{instance}` per schema. Callers (the
+   * Envelope source — `{principal}.{agent}.{instance}` per schema. Callers (the
    * webhook receiver wired in cortex.ts) pass the same `systemEventSource`
    * the rest of the bus uses, so all envelopes from one cortex process
    * carry identical `source` strings.
@@ -155,7 +155,7 @@ export interface CreateGithubEventEnvelopeOpts {
    * Optional: events without a natural action (e.g. `push`, `ping`) get
    * `"received"` as a synthetic action so the envelope type always carries
    * a 3-segment shape (`github.{event}.received`). This keeps the subject
-   * stable for subscribers — wildcard pattern `local.{org}.github.{event}.>`
+   * stable for subscribers — wildcard pattern `local.{principal}.github.{event}.>`
    * matches both action-bearing and action-less events.
    */
   action?: string;

--- a/src/bus/myelin/__tests__/envelope-validator.test.ts
+++ b/src/bus/myelin/__tests__/envelope-validator.test.ts
@@ -787,14 +787,14 @@ describe("deriveNatsSubject (IAW A.3)", () => {
     };
   }
 
-  test("local classification → local.{org}.{type}", () => {
+  test("local classification → local.{principal}.{type}", () => {
     const env = envWithClassification("local");
     expect(deriveNatsSubject(env)).toBe(
       "local.metafactory.system.adapter.degraded",
     );
   });
 
-  test("federated classification → federated.{org}.{type}", () => {
+  test("federated classification → federated.{principal}.{type}", () => {
     const env = envWithClassification("federated");
     expect(deriveNatsSubject(env)).toBe(
       "federated.metafactory.system.adapter.degraded",
@@ -806,7 +806,7 @@ describe("deriveNatsSubject (IAW A.3)", () => {
     expect(deriveNatsSubject(env)).toBe("public.system.adapter.degraded");
   });
 
-  test("derives {org} from envelope.source's first segment", () => {
+  test("derives {principal} from envelope.source's first segment", () => {
     // A different operator (`acme.*`) routes onto its own subject namespace
     // without any runtime-side configuration.
     const env = envWithClassification("local", "acme.cortex.prod-01");
@@ -816,14 +816,14 @@ describe("deriveNatsSubject (IAW A.3)", () => {
   });
 
   // IAW Phase A.5 — stack-aware subject emission (myelin#113 grammar).
-  test("local + stack → local.{org}.{stack}.{type}", () => {
+  test("local + stack → local.{principal}.{stack}.{type}", () => {
     const env = envWithClassification("local");
     expect(deriveNatsSubject(env, "research")).toBe(
       "local.metafactory.research.system.adapter.degraded",
     );
   });
 
-  test("federated + stack → federated.{org}.{stack}.{type}", () => {
+  test("federated + stack → federated.{principal}.{stack}.{type}", () => {
     const env = envWithClassification("federated");
     expect(deriveNatsSubject(env, "security")).toBe(
       "federated.metafactory.security.system.adapter.degraded",

--- a/src/bus/myelin/__tests__/runtime-org-symmetry.test.ts
+++ b/src/bus/myelin/__tests__/runtime-org-symmetry.test.ts
@@ -1,12 +1,12 @@
 /**
  * IAW Phase A.3 follow-up (cortex#130 item 1) — pin the subscribe/publish
- * `{org}` symmetry invariant.
+ * `{principal}` symmetry invariant.
  *
- * Subscribe-side substitutes `{org}` in NATS subject patterns from
+ * Subscribe-side substitutes `{principal}` in NATS subject patterns from
  * `config.agent.operatorId` at startup via `orgFromConfig`. Publish-side
- * extracts `{org}` from `envelope.source`'s first segment via
+ * extracts `{principal}` from `envelope.source`'s first segment via
  * `orgFromEnvelope`. For any envelope this stack emits via the system-event
- * helpers (which build `source` as `${org}.${agent}.${instance}`), the two
+ * helpers (which build `source` as `${principal}.${agent}.${instance}`), the two
  * MUST return identical strings — otherwise publish/subscribe subjects
  * diverge and round-trips break.
  */
@@ -18,7 +18,7 @@ import {
 } from "../envelope-validator";
 import { createSystemAdapterDegradedEvent } from "../../system-events";
 
-describe("MyelinRuntime — subscribe/publish {org} symmetry (cortex#130 item 1)", () => {
+describe("MyelinRuntime — subscribe/publish {principal} symmetry (cortex#130 item 1)", () => {
   test("orgFromConfig and orgFromEnvelope agree for stack-emitted envelopes", () => {
     const operatorId = "metafactory";
     const envelope = createSystemAdapterDegradedEvent({

--- a/src/bus/myelin/__tests__/runtime.test.ts
+++ b/src/bus/myelin/__tests__/runtime.test.ts
@@ -244,6 +244,27 @@ describe("MyelinRuntime", () => {
     await runtime.stop();
   });
 
+  // R4 (vocabulary migration 2026-05) — back-compat regression test.
+  // Pre-migration cortex.yaml configs (and migrate-config output that
+  // round-trips legacy bot.yaml verbatim) carry the deprecated `{org}`
+  // placeholder. The runtime substituter MUST resolve both tokens to
+  // the same principal slug so operators don't have to re-author
+  // their nats.subjects list mid-migration.
+  test("subjects placeholder {org} is also substituted (R4 back-compat)", async () => {
+    const fake = makeFakeNatsConnection();
+    const config = makeConfig({
+      url: "nats://localhost:4222",
+      name: "grove-bot",
+      subjects: ["local.{org}.attention.>"],
+    });
+    const runtime = await startMyelinRuntime(config, {
+      connectImpl: async () => fake.nc,
+    });
+    expect(runtime.enabled).toBe(true);
+    expect(fake.subscribePatterns[0]).toBe("local.andreas.attention.>");
+    await runtime.stop();
+  });
+
   // cortex#269 — `{stack}.` token substitution. Operator-written narrow
   // subscribe patterns can now reference the operator's stack identity
   // alongside `{principal}` and have it expanded at boot. The `.` is part of

--- a/src/bus/myelin/__tests__/runtime.test.ts
+++ b/src/bus/myelin/__tests__/runtime.test.ts
@@ -229,12 +229,12 @@ describe("MyelinRuntime", () => {
     expect(errored).toBe(true);
   });
 
-  test("subjects placeholder {org} is substituted from agent.operatorId", async () => {
+  test("subjects placeholder {principal} is substituted from agent.operatorId", async () => {
     const fake = makeFakeNatsConnection();
     const config = makeConfig({
       url: "nats://localhost:4222",
       name: "grove-bot",
-      subjects: ["local.{org}.attention.>"],
+      subjects: ["local.{principal}.attention.>"],
     });
     const runtime = await startMyelinRuntime(config, {
       connectImpl: async () => fake.nc,
@@ -246,7 +246,7 @@ describe("MyelinRuntime", () => {
 
   // cortex#269 — `{stack}.` token substitution. Operator-written narrow
   // subscribe patterns can now reference the operator's stack identity
-  // alongside `{org}` and have it expanded at boot. The `.` is part of
+  // alongside `{principal}` and have it expanded at boot. The `.` is part of
   // the placeholder so stack-less deployments collapse cleanly to the
   // legacy 5-segment shape.
   test("subjects placeholder {stack}. is substituted from options.stack", async () => {
@@ -254,7 +254,7 @@ describe("MyelinRuntime", () => {
     const config = makeConfig({
       url: "nats://localhost:4222",
       name: "grove-bot",
-      subjects: ["local.{org}.{stack}.attention.>"],
+      subjects: ["local.{principal}.{stack}.attention.>"],
     });
     const runtime = await startMyelinRuntime(config, {
       connectImpl: async () => fake.nc,
@@ -272,7 +272,7 @@ describe("MyelinRuntime", () => {
     const config = makeConfig({
       url: "nats://localhost:4222",
       name: "grove-bot",
-      subjects: ["local.{org}.{stack}.attention.>"],
+      subjects: ["local.{principal}.{stack}.attention.>"],
     });
     const runtime = await startMyelinRuntime(config, {
       connectImpl: async () => fake.nc,
@@ -286,15 +286,15 @@ describe("MyelinRuntime", () => {
   });
 
   test("subjects without {stack} placeholder are unchanged regardless of options.stack", async () => {
-    // Default `["local.{org}.>"]` pattern uses multi-segment wildcard
+    // Default `["local.{principal}.>"]` pattern uses multi-segment wildcard
     // — already matches both 5-seg and 6-seg emissions. No substitution
     // needed; the runtime must NOT corrupt this pattern when stack is
-    // supplied (`local.{org}.>` → `local.andreas.>`, not `local.andreas.research.>`).
+    // supplied (`local.{principal}.>` → `local.andreas.>`, not `local.andreas.research.>`).
     const fake = makeFakeNatsConnection();
     const config = makeConfig({
       url: "nats://localhost:4222",
       name: "grove-bot",
-      subjects: ["local.{org}.>"],
+      subjects: ["local.{principal}.>"],
     });
     const runtime = await startMyelinRuntime(config, {
       connectImpl: async () => fake.nc,
@@ -397,13 +397,13 @@ describe("MyelinRuntime", () => {
       await runtime.stop();
     });
 
-    test("enabled runtime: publish forwards to NATS with subject local.{org}.{type}", async () => {
+    test("enabled runtime: publish forwards to NATS with subject local.{principal}.{type}", async () => {
       const fake = makeFakeNatsConnection();
       const runtime = await startMyelinRuntime(
         makeConfig({
           url: "nats://localhost:4222",
           name: "grove-bot",
-          subjects: ["local.{org}.system.>"],
+          subjects: ["local.{principal}.system.>"],
         }),
         { connectImpl: async () => fake.nc },
       );
@@ -411,7 +411,7 @@ describe("MyelinRuntime", () => {
       const env = makeEnvelope({ type: "system.adapter.degraded" });
       await runtime.publish(env);
       expect(fake.publish).toHaveBeenCalledTimes(1);
-      // IAW Phase A.3: subject `{org}` comes from `envelope.source`'s first
+      // IAW Phase A.3: subject `{principal}` comes from `envelope.source`'s first
       // segment ("metafactory" here), NOT from `agent.operatorId`. Subject
       // prefix mirrors `envelope.sovereignty.classification` ("local" here),
       // satisfying `validateSubjectEnvelopeAlignment`. Emit-site helpers
@@ -428,7 +428,7 @@ describe("MyelinRuntime", () => {
       await runtime.stop();
     });
 
-    test("enabled runtime: publish derives federated.{org}.{type} subject", async () => {
+    test("enabled runtime: publish derives federated.{principal}.{type} subject", async () => {
       // IAW Phase A.3 — federation unblock. When an emit site opts into
       // `classification: "federated"`, the envelope's sovereignty AND the
       // runtime-derived subject move in lockstep onto the `federated.*`
@@ -439,7 +439,7 @@ describe("MyelinRuntime", () => {
         makeConfig({
           url: "nats://localhost:4222",
           name: "grove-bot",
-          subjects: ["local.{org}.>"],
+          subjects: ["local.{principal}.>"],
         }),
         { connectImpl: async () => fake.nc },
       );
@@ -457,7 +457,7 @@ describe("MyelinRuntime", () => {
     });
 
     test("enabled runtime: publish derives public.{type} subject (no org segment)", async () => {
-      // IAW Phase A.3 — public-tier envelopes drop the `{org}` segment per
+      // IAW Phase A.3 — public-tier envelopes drop the `{principal}` segment per
       // myelin's grammar (public is global). The runtime applies this
       // automatically via `deriveNatsSubject`.
       const fake = makeFakeNatsConnection();
@@ -465,7 +465,7 @@ describe("MyelinRuntime", () => {
         makeConfig({
           url: "nats://localhost:4222",
           name: "grove-bot",
-          subjects: ["local.{org}.>"],
+          subjects: ["local.{principal}.>"],
         }),
         { connectImpl: async () => fake.nc },
       );
@@ -493,7 +493,7 @@ describe("MyelinRuntime", () => {
         makeConfig({
           url: "nats://localhost:4222",
           name: "grove-bot",
-          subjects: ["local.{org}.>"],
+          subjects: ["local.{principal}.>"],
         }),
         { connectImpl: async () => fake.nc, stack: "default" },
       );
@@ -504,17 +504,17 @@ describe("MyelinRuntime", () => {
       await runtime.stop();
     });
 
-    test("IAW Phase A.5 (cortex#262): publish derives 6-segment local.{org}.{stack}.{type} when stack option is set", async () => {
+    test("IAW Phase A.5 (cortex#262): publish derives 6-segment local.{principal}.{stack}.{type} when stack option is set", async () => {
       // Stack-aware emit — operator config carries `stack: { id: andreas/research }`
       // and the entrypoint passes `stack: "research"` through to the runtime.
-      // The resulting subject lands inside sage's `local.{org}.{stack}.>`
+      // The resulting subject lands inside sage's `local.{principal}.{stack}.>`
       // subscription wildcard, closing the broadcast loop end-to-end.
       const fake = makeFakeNatsConnection();
       const runtime = await startMyelinRuntime(
         makeConfig({
           url: "nats://localhost:4222",
           name: "grove-bot",
-          subjects: ["local.{org}.>"],
+          subjects: ["local.{principal}.>"],
         }),
         { connectImpl: async () => fake.nc, stack: "research" },
       );
@@ -536,7 +536,7 @@ describe("MyelinRuntime", () => {
         makeConfig({
           url: "nats://localhost:4222",
           name: "grove-bot",
-          subjects: ["local.{org}.>"],
+          subjects: ["local.{principal}.>"],
         }),
         { connectImpl: async () => fake.nc },
       );
@@ -558,7 +558,7 @@ describe("MyelinRuntime", () => {
         makeConfig({
           url: "nats://localhost:4222",
           name: "grove-bot",
-          subjects: ["local.{org}.system.>"],
+          subjects: ["local.{principal}.system.>"],
         }),
         { connectImpl: async () => fake.nc },
       );
@@ -590,7 +590,7 @@ describe("MyelinRuntime", () => {
         makeConfig({
           url: "nats://localhost:4222",
           name: "grove-bot",
-          subjects: ["local.{org}.system.>"],
+          subjects: ["local.{principal}.system.>"],
         }),
         {
           connectImpl: async () => fake.nc,
@@ -660,7 +660,7 @@ describe("MyelinRuntime", () => {
         makeConfig({
           url: "nats://localhost:4222",
           name: "grove-bot",
-          subjects: ["local.{org}.system.>"],
+          subjects: ["local.{principal}.system.>"],
         }),
         {
           connectImpl: async () => fake.nc,
@@ -699,7 +699,7 @@ describe("MyelinRuntime", () => {
         makeConfig({
           url: "nats://localhost:4222",
           name: "grove-bot",
-          subjects: ["local.{org}.system.>"],
+          subjects: ["local.{principal}.system.>"],
         }),
         {
           connectImpl: async () => fake.nc,
@@ -739,7 +739,7 @@ describe("MyelinRuntime", () => {
         makeConfig({
           url: "nats://localhost:4222",
           name: "grove-bot",
-          subjects: ["local.{org}.system.>"],
+          subjects: ["local.{principal}.system.>"],
         }),
         {
           connectImpl: async () => fake.nc,
@@ -777,7 +777,7 @@ describe("MyelinRuntime", () => {
         makeConfig({
           url: "nats://localhost:4222",
           name: "grove-bot",
-          subjects: ["local.{org}.system.>"],
+          subjects: ["local.{principal}.system.>"],
         }),
         { connectImpl: async () => fake.nc },
       );

--- a/src/bus/myelin/envelope-validator.ts
+++ b/src/bus/myelin/envelope-validator.ts
@@ -34,7 +34,7 @@
  * - Schema unchanged on the wire — myelin#113/#115 added subject-grammar
  *   surface area without altering envelope JSON Schema.
  * - `deriveNatsSubject(envelope, stack?)` now accepts an optional `stack`
- *   segment, emitting the 6-segment `{prefix}.{org}.{stack}.{type}` form
+ *   segment, emitting the 6-segment `{prefix}.{principal}.{stack}.{type}` form
  *   when supplied (myelin#113 — IAW Phase A.5). Omitting `stack` preserves
  *   the legacy 5-segment shape; subscribers default-derive missing stack
  *   to `default` per `specs/namespace.md` § Backward compatibility.
@@ -566,12 +566,12 @@ export type Classification = Envelope["sovereignty"]["classification"];
  * 1:1 alignment myelin enforces with
  * {@link validateSubjectEnvelopeAlignment}:
  *
- *   - `classification === "local"`     → `local.{org}.{type}` (legacy)
- *                                      → `local.{org}.{stack}.{type}` when `stack` supplied (myelin#113)
- *   - `classification === "federated"` → `federated.{org}.{type}` / `federated.{org}.{stack}.{type}`
+ *   - `classification === "local"`     → `local.{principal}.{type}` (legacy)
+ *                                      → `local.{principal}.{stack}.{type}` when `stack` supplied (myelin#113)
+ *   - `classification === "federated"` → `federated.{principal}.{type}` / `federated.{principal}.{stack}.{type}`
  *   - `classification === "public"`    → `public.{type}` (no org, no stack — public is global)
  *
- * `{org}` is the first dotted segment of `envelope.source` (the same value
+ * `{principal}` is the first dotted segment of `envelope.source` (the same value
  * cortex's MyelinRuntime captures from `agent.operatorId` at startup, so
  * subject and source stay symmetrical). `{stack}` is the operator's stack
  * identity — supplied by the caller when in stack-aware mode (IAW A.5),
@@ -601,9 +601,9 @@ function firstSegment(s: string): string {
 }
 
 /**
- * IAW Phase A.3 follow-up (cortex#130 item 1) — symmetric `{org}` extractor
- * for the publish-side. Publish derives `{org}` from `envelope.source`'s
- * leading segment; subscribe substitutes `{org}` in subject patterns from
+ * IAW Phase A.3 follow-up (cortex#130 item 1) — symmetric `{principal}` extractor
+ * for the publish-side. Publish derives `{principal}` from `envelope.source`'s
+ * leading segment; subscribe substitutes `{principal}` in subject patterns from
  * `agent.operatorId` at startup. These two values MUST agree for any
  * envelope this stack emits, or subjects diverge between publish/subscribe.
  *
@@ -618,7 +618,7 @@ export function orgFromEnvelope(envelope: Envelope): string {
 }
 
 /**
- * Subscribe-side `{org}` resolver. See {@link orgFromEnvelope} for the
+ * Subscribe-side `{principal}` resolver. See {@link orgFromEnvelope} for the
  * symmetric publish-side helper and the invariant they jointly preserve.
  *
  * Falls back to `"default"` when `operatorId` is unset — matches the

--- a/src/bus/myelin/runtime.ts
+++ b/src/bus/myelin/runtime.ts
@@ -57,18 +57,18 @@ export interface MyelinRuntime {
    * Subject is derived from `envelope.sovereignty.classification` +
    * `envelope.type` per G-1111 §3.1 and the myelin grammar:
    *
-   *   - `classification === "local"`     → `local.{org}.{type}`
-   *   - `classification === "federated"` → `federated.{org}.{type}`
-   *   - `classification === "public"`    → `public.{type}` (no `{org}` segment)
+   *   - `classification === "local"`     → `local.{principal}.{type}`
+   *   - `classification === "federated"` → `federated.{principal}.{type}`
+   *   - `classification === "public"`    → `public.{type}` (no `{principal}` segment)
    *
-   * `{org}` is the first dotted segment of `envelope.source` (which
+   * `{principal}` is the first dotted segment of `envelope.source` (which
    * cortex's `system-events.ts` etc. populate from `agent.operatorId`).
    * The 1:1 alignment between subject prefix and `sovereignty.classification`
    * is myelin's protocol-level invariant — see
    * {@link validateSubjectEnvelopeAlignment}.
    *
    * **IAW Phase A.3:** prior to this slice the runtime hardcoded
-   * `local.{org}.{type}` here, making federated/public emission structurally
+   * `local.{principal}.{type}` here, making federated/public emission structurally
    * impossible. Subject derivation now mirrors classification, so an emit
    * site that opts into `classification: "federated"` flows end-to-end
    * (envelope + subject) without further runtime changes.
@@ -156,7 +156,7 @@ export interface MyelinRuntime {
  * resolve-as-ack default.
  */
 export interface MyelinSubscribePullOpts {
-  /** Subject pattern, e.g. `local.{org}.tasks.code-review.>`. */
+  /** Subject pattern, e.g. `local.{principal}.tasks.code-review.>`. */
   pattern: string;
   /** JetStream stream name carrying the bound consumer. */
   stream: string;
@@ -235,12 +235,12 @@ export interface MyelinRuntimeOptions {
   signFailureMode?: "fallback" | "drop";
   /**
    * IAW Phase A.5 (cortex#113 / closes cortex#262) — operator stack
-   * segment slotted into the published subject between `{org}` and
+   * segment slotted into the published subject between `{principal}` and
    * `{type}`. When set, `publish()` derives subjects in the 6-segment
-   * stack-aware shape `local.{org}.{stack}.{type}` matching post-myelin#113
+   * stack-aware shape `local.{principal}.{stack}.{type}` matching post-myelin#113
    * subscribers (sage's bridge, cedar's dispatch, pilot's review-request
    * subscriber). When undefined, `publish()` falls through to the legacy
-   * 5-segment form `local.{org}.{type}` — preserves identity for callers
+   * 5-segment form `local.{principal}.{type}` — preserves identity for callers
    * that haven't wired stack identity yet.
    *
    * The entrypoint (`src/cortex.ts` ~line 386) sources this from
@@ -274,7 +274,7 @@ export interface BusEnvelopeSigner {
 }
 
 /**
- * Build a `{org}` + `{stack}.` placeholder substituter for operator-
+ * Build a `{principal}` + `{stack}.` placeholder substituter for operator-
  * configured subject patterns (cortex#269 / cortex#279 cycle 2).
  *
  * Used by `MyelinRuntime.publish`'s `nats.subjects` resolution and by
@@ -294,7 +294,7 @@ export function makeSubjectPlaceholderSubstituter(opts: {
   const stackToken = opts.stack !== undefined ? `${opts.stack}.` : "";
   return (subjects: readonly string[]) =>
     subjects.map((s) =>
-      s.replaceAll("{org}", opts.org).replaceAll("{stack}.", stackToken),
+      s.replaceAll("{principal}", opts.org).replaceAll("{stack}.", stackToken),
     );
 }
 
@@ -355,23 +355,23 @@ export async function startMyelinRuntime(
   }
 
   const nats = config.nats;
-  // IAW Phase A.3 follow-up (cortex#130 item 1): subscribe-side `{org}` is
+  // IAW Phase A.3 follow-up (cortex#130 item 1): subscribe-side `{principal}` is
   // resolved via the shared `orgFromConfig` helper. The publish-side
   // (`deriveNatsSubject` → `orgFromEnvelope`) extracts the same segment
   // from `envelope.source` at emit time. Both helpers live in
   // `envelope-validator.ts` and the invariant they jointly preserve
-  // (subscribe `{org}` === publish `{org}` for envelopes this stack emits)
+  // (subscribe `{principal}` === publish `{principal}` for envelopes this stack emits)
   // has a regression test at
   // `src/bus/myelin/__tests__/runtime-org-symmetry.test.ts`.
   //
-  // cortex#269 — `{stack}.` substituted alongside `{org}` via the shared
+  // cortex#269 — `{stack}.` substituted alongside `{principal}` via the shared
   // `makeSubjectPlaceholderSubstituter` helper (defined above; also used
   // by the renderer-config boot path in `src/cortex.ts`). Stack-less
   // deployments collapse `{stack}.` to empty, preserving legacy 5-segment
-  // subscribe patterns. The default `["local.{org}.>"]` pattern is
+  // subscribe patterns. The default `["local.{principal}.>"]` pattern is
   // unaffected — multi-segment `>` wildcard already matches both shapes.
-  // A pattern like `local.{org}.{stack}.system.>` resolves to either
-  // `local.{org}.{stack}.system.>` (stack-aware) or `local.{org}.system.>`
+  // A pattern like `local.{principal}.{stack}.system.>` resolves to either
+  // `local.{principal}.{stack}.system.>` (stack-aware) or `local.{principal}.system.>`
   // (legacy) depending on whether the boot path supplied a stack.
   const substituter = makeSubjectPlaceholderSubstituter({
     org: orgFromConfig(config.agent.operatorId),
@@ -521,18 +521,18 @@ export async function startMyelinRuntime(
     }
     // IAW Phase A.3: subject derivation now mirrors
     // `envelope.sovereignty.classification`. Prior code hardcoded
-    // `local.{org}.{type}` here, making federated/public emission
-    // structurally impossible — `{org}` came from `config.agent.operatorId`
+    // `local.{principal}.{type}` here, making federated/public emission
+    // structurally impossible — `{principal}` came from `config.agent.operatorId`
     // and the classification prefix was always "local". `deriveNatsSubject`
-    // reads classification + extracts `{org}` from `envelope.source` so the
+    // reads classification + extracts `{principal}` from `envelope.source` so the
     // 1:1 subject↔classification invariant
     // (`validateSubjectEnvelopeAlignment`) holds for every emit site
     // without further changes. `envelope.source`'s first segment is the
     // same value `agent.operatorId` produces when emit-site helpers
-    // assemble it, so subscribe-side `{org}` substitution stays symmetric.
+    // assemble it, so subscribe-side `{principal}` substitution stays symmetric.
     //
     // IAW Phase A.5 (cortex#262 closes): pass `stack` so subjects land in
-    // the 6-segment `local.{org}.{stack}.{type}` grammar that sage's
+    // the 6-segment `local.{principal}.{stack}.{type}` grammar that sage's
     // bridge + pilot's review-request subscriber expect. When undefined,
     // `deriveNatsSubject` returns the legacy 5-segment shape — preserving
     // emit-site behavior for deployments that haven't wired stack identity.

--- a/src/bus/myelin/runtime.ts
+++ b/src/bus/myelin/runtime.ts
@@ -294,7 +294,18 @@ export function makeSubjectPlaceholderSubstituter(opts: {
   const stackToken = opts.stack !== undefined ? `${opts.stack}.` : "";
   return (subjects: readonly string[]) =>
     subjects.map((s) =>
-      s.replaceAll("{principal}", opts.org).replaceAll("{stack}.", stackToken),
+      // R4 (vocabulary migration 2026-05) — accept BOTH `{principal}` (the
+      // canonical post-R7 token) and `{org}` (the deprecated alias) during
+      // the transition window. Operators migrating cortex.yaml will see
+      // both tokens in the wild — pre-migration configs carry `{org}`,
+      // post-migration configs carry `{principal}`, and `migrate-config`
+      // converts bot.yaml → cortex.yaml passing nats config through
+      // verbatim (so `{org}` flows through). Both must resolve to the
+      // same principal slug at runtime.
+      s
+        .replaceAll("{principal}", opts.org)
+        .replaceAll("{org}", opts.org)
+        .replaceAll("{stack}.", stackToken),
     );
 }
 

--- a/src/bus/review-consumer.ts
+++ b/src/bus/review-consumer.ts
@@ -43,7 +43,7 @@
  * the redelivery.
  *
  * **Scope (per task spec + §10.1 PR-6):**
- *   - Subscribes pull-mode to `local.{org}.tasks.code-review.>`.
+ *   - Subscribes pull-mode to `local.{principal}.tasks.code-review.>`.
  *   - Looks up reviewer agent by the `<flavor>` capability segment.
  *   - Enforces per-agent `maxConcurrent` backpressure.
  *   - Hands valid envelopes to `runReviewPipeline` (PR-5).
@@ -184,7 +184,7 @@ export type SignatureVerifier = (envelope: Envelope) => Promise<SignatureVerifie
 export interface ReviewConsumerOpts {
   /** The agent this consumer serves. One consumer per agent (per task spec). */
   agent: ReviewConsumerAgent;
-  /** Envelope source (`{org}.{agent}.{instance}`) — same triple used by
+  /** Envelope source (`{principal}.{agent}.{instance}`) — same triple used by
    *  `system-events.ts` for `dispatch.task.*` lifecycle envelopes. */
   source: ReviewEventSource;
   /**
@@ -246,7 +246,7 @@ export interface ReviewConsumerOpts {
  * declare what they want subscribed and the runtime threads the link.
  */
 export interface ReviewConsumerStartOpts {
-  /** Subject pattern, e.g. `local.{org}.tasks.code-review.>`. */
+  /** Subject pattern, e.g. `local.{principal}.tasks.code-review.>`. */
   pattern: string;
   /** JetStream stream name carrying the bound consumer. */
   stream: string;
@@ -859,7 +859,7 @@ export function deriveFlavors(capabilities: readonly string[]): string[] {
  * `type` field. Returns `null` if the envelope isn't a review request.
  *
  * The envelope `type` (NOT the wire subject) is the canonical source —
- * the wire subject includes the namespace prefix (`local.{org}.`) and a
+ * the wire subject includes the namespace prefix (`local.{principal}.`) and a
  * malformed subject would falsely match a partial slice. Pull-mode
  * subjects pass through as-is in NATS but the type field is what the
  * validator-approved envelope carries.

--- a/src/bus/review-events.ts
+++ b/src/bus/review-events.ts
@@ -25,7 +25,7 @@
  *   - `id` is a fresh `crypto.randomUUID()` per call (envelope idempotency key).
  *   - `timestamp` is the helper-call time. Domain-specific moments
  *     (`submitted_at`) live in payload.
- *   - `source` is the dotted `{org}.{agent}.{instance}` per the schema.
+ *   - `source` is the dotted `{principal}.{agent}.{instance}` per the schema.
  *   - `correlation_id` semantics differ per envelope family:
  *       - Request envelopes: no correlation_id (the envelope's `id` is the
  *         correlation root that the verdict envelope echoes — per §5.1).
@@ -41,7 +41,7 @@
  *     optional `classification` field (IAW Phase A.3 parameterisation pattern).
  *
  * **Subject derivation:** envelope `type` is `tasks.code-review.<flavor>` or
- * `review.verdict.<kind>`. The wire subject (`local.{org}.<type>` /
+ * `review.verdict.<kind>`. The wire subject (`local.{principal}.<type>` /
  * `federated.{network}.<type>`) is derived publish-side by
  * `MyelinRuntime.publish` via the namespace-derivation logic landed in
  * IAW Phase A.3 (cortex#129). This builder produces the in-memory envelope
@@ -244,7 +244,7 @@ export function createReviewRequestEvent(
 /**
  * The three verdict kinds per cortex#248 §4.2.1 and
  * `design-pilot-restructure.md` §4.2. The wire subject is
- * `local.{org}.review.verdict.<kind>`.
+ * `local.{principal}.review.verdict.<kind>`.
  */
 export type ReviewVerdictKind =
   | "approved"

--- a/src/bus/system-events.ts
+++ b/src/bus/system-events.ts
@@ -18,7 +18,7 @@
  *   - `timestamp` is the helper-call time (ISO 8601). Callers should not back-fill
  *     this — if you need an event-of-fact timestamp distinct from emit time
  *     (e.g. `disconnected_since`), it lives in the payload.
- *   - `source` is the dotted `{org}.{agent}.{instance}` form required by the
+ *   - `source` is the dotted `{principal}.{agent}.{instance}` form required by the
  *     myelin envelope schema (G-1100.B) — e.g. `metafactory.grove.local`.
  *     The helpers take the three segments separately so callers don't string-
  *     concatenate by hand. This matches the spec §3.6 example envelopes.
@@ -146,7 +146,7 @@ export function adapterCorrelationKey(
 // ---------------------------------------------------------------------------
 
 export interface SystemAdapterDegradedOpts {
-  /** Envelope source — `{org}.{agent}.{instance}` per schema. */
+  /** Envelope source — `{principal}.{agent}.{instance}` per schema. */
   source: SystemEventSource;
   /** Stable adapter instance ID, e.g. `discord-luna`. Mandatory per §3.5.4. */
   adapterId: string;
@@ -164,7 +164,7 @@ export interface SystemAdapterDegradedOpts {
   /**
    * IAW Phase A.3 — optional sovereignty classification. Defaults to
    * `"local"` (operator-private). Set to `"federated"` to publish on
-   * `federated.{org}.system.adapter.degraded` so peer dashboards in the
+   * `federated.{principal}.system.adapter.degraded` so peer dashboards in the
    * operator's federation policy can render the event; `"public"` for
    * global visibility. Mismatch with the publish-time subject is a
    * protocol violation (see {@link validateSubjectEnvelopeAlignment}).
@@ -650,7 +650,7 @@ interface SystemAccessCommonOpts {
   /**
    * Subject of the originating envelope — lets surfaces filter audit
    * traffic by the wire path they care about (e.g. only audit
-   * `local.{org}.dispatch.task.received` decisions).
+   * `local.{principal}.dispatch.task.received` decisions).
    */
   envelopeSubject: string;
   /**
@@ -692,7 +692,7 @@ export interface SystemAccessDeniedOpts extends SystemAccessCommonOpts {
  * (substrate-side validation, federation hub stamps) will emit on
  * the same subject.
  *
- * Subject convention: `local.{org}.system.access.allowed` — surfaces
+ * Subject convention: `local.{principal}.system.access.allowed` — surfaces
  * subscribe to `system.access.>` for the full access stream.
  */
 export function createSystemAccessAllowedEvent(
@@ -726,7 +726,7 @@ export function createSystemAccessAllowedEvent(
  * verbatim so denied envelopes are still cryptographically
  * attributable (the rejection itself is part of the audit trail).
  *
- * Subject convention: `local.{org}.system.access.denied`.
+ * Subject convention: `local.{principal}.system.access.denied`.
  */
 export function createSystemAccessDeniedEvent(
   opts: SystemAccessDeniedOpts,
@@ -978,7 +978,7 @@ export interface SystemAgentHeartbeatOpts {
  * `runtime.publish` signing path).
  *
  * **Subject derivation.** The runtime's stack-aware `publish()` routes this
- * to `local.{org}.{stack}.system.agent.heartbeat` — operator-managed
+ * to `local.{principal}.{stack}.system.agent.heartbeat` — operator-managed
  * namespace, no upstream myelin schema entry required for the cortex-local
  * deployment. A myelin canonicalisation follow-up (filed against
  * `the-metafactory/myelin`) will lift this onto `federated.*` for cross-

--- a/src/cli/cortex/commands/__tests__/migrate-config.test.ts
+++ b/src/cli/cortex/commands/__tests__/migrate-config.test.ts
@@ -435,6 +435,11 @@ describe("convertBotYaml — full fixture", () => {
     const legacy = loadFixture("full.bot.yaml");
     const result = convertBotYaml(legacy, { configDir: FIXTURE_DIR });
     expect(result.cortex.nats?.url).toBe("nats://localhost:4222");
+    // Fixture carries the legacy `local.{org}.>` token verbatim — this
+    // test asserts the migrate-config converter passes nats config
+    // through UNCHANGED. The legacy bot.yaml fixture is intentionally
+    // NOT touched by the vocabulary migration (it's the source format
+    // migrate-config reads from).
     expect(result.cortex.nats?.subjects).toEqual(["local.{org}.>"]);
   });
 

--- a/src/common/types/__tests__/cortex-config.test.ts
+++ b/src/common/types/__tests__/cortex-config.test.ts
@@ -351,7 +351,7 @@ describe("RendererSchema", () => {
   test("dashboard renderer parses with kind + defaults", () => {
     const parsed = DashboardRendererSchema.parse({ kind: "dashboard" });
     expect(parsed.port).toBe(8767);
-    expect(parsed.subscribe).toEqual(["local.{org}.>"]);
+    expect(parsed.subscribe).toEqual(["local.{principal}.>"]);
     expect(parsed.projections).toEqual([]);
   });
 
@@ -360,7 +360,7 @@ describe("RendererSchema", () => {
     const parsed = PagerDutyRendererSchema.parse({
       kind: "pagerduty",
       routingKey: "PD-ROUTING-KEY",
-      subscribe: ["local.{org}.system.adapter.degraded"],
+      subscribe: ["local.{principal}.system.adapter.degraded"],
     });
     expect(parsed.routingKey).toBe("PD-ROUTING-KEY");
   });
@@ -677,12 +677,12 @@ describe("CortexConfigSchema", () => {
       ],
       renderers: [
         { kind: "dashboard", port: 8767, publicUrl: "https://cortex.meta-factory.ai" },
-        { kind: "pagerduty", routingKey: "PD-KEY", subscribe: ["local.{org}.system.>"] },
+        { kind: "pagerduty", routingKey: "PD-KEY", subscribe: ["local.{principal}.system.>"] },
       ],
       claude: {},
       nats: {
         url: "nats://localhost:4222",
-        subjects: ["local.{org}.>"],
+        subjects: ["local.{principal}.>"],
         identity: {
           seedPath: "/etc/cortex/andreas.nk",
           publicKey: VALID_NKEY,

--- a/src/common/types/agent-heartbeat.ts
+++ b/src/common/types/agent-heartbeat.ts
@@ -12,7 +12,7 @@
  * **Out of scope for this iteration** (filed as follow-ups on cortex / myelin):
  *   - Dashboard rendering of "Echo last seen 12s ago" — separate cortex issue.
  *   - Canonical myelin schema entry for `system.agent.heartbeat` — Path B per
- *     cortex#361 ships on the operator-managed `local.{org}.{stack}.*`
+ *     cortex#361 ships on the operator-managed `local.{principal}.{stack}.*`
  *     namespace; cross-operator (`federated.*`) propagation needs a myelin
  *     spec round. Tracked as a follow-up issue on `the-metafactory/myelin`.
  *   - cc-session inactivity-timer "respect heartbeat" — separate cortex issue
@@ -38,7 +38,7 @@
  * Payload shape for the `system.agent.heartbeat` envelope type. Lands on
  * `envelope.payload`; `envelope.type` carries the literal
  * `"system.agent.heartbeat"` string and the runtime's stack-aware subject
- * derivation routes it to `local.{org}.{stack}.system.agent.heartbeat`.
+ * derivation routes it to `local.{principal}.{stack}.system.agent.heartbeat`.
  */
 export interface AgentHeartbeatPayload {
   /**
@@ -114,7 +114,7 @@ export interface AgentHeartbeatPayload {
  * as a constant so subscribers (dashboard, future surface-router liveness
  * checks) can filter without re-typing the string.
  *
- * Matches the cortex-local subject prefix `local.{org}.{stack}.` — the
+ * Matches the cortex-local subject prefix `local.{principal}.{stack}.` — the
  * runtime's stack-aware subject derivation prepends those segments
  * automatically (see `MyelinRuntime.publish` and the `stack` config option).
  */

--- a/src/common/types/config.ts
+++ b/src/common/types/config.ts
@@ -374,7 +374,7 @@ export const BotConfigSchema = z.object({
     }).default(emptyDefault()),
     /**
      * MIG-5.6 (C-106): Local HTTP receiver that publishes webhook payloads
-     * as `local.{org}.github.{event}.{action}` envelopes onto the bus.
+     * as `local.{principal}.github.{event}.{action}` envelopes onto the bus.
      *
      * Opt-in: only started when `enabled: true` AND `webhookSecret` is set
      * (the secret is required for HMAC re-verification at the local hop).
@@ -469,7 +469,7 @@ export const BotConfigSchema = z.object({
    * remains installable without NATS configured (per design doc §9
    * coupling rules); when absent, no subscriber is started and grove
    * runs as before. When `url` is present, the bot subscribes to each
-   * pattern in `subjects` (default `local.{org}.>`) and logs received
+   * pattern in `subjects` (default `local.{principal}.>`) and logs received
    * envelopes. Fan-out to specific event handlers lands in subsequent
    * features (G-1101 pilot errand projection, etc.).
    */
@@ -486,7 +486,7 @@ export const BotConfigSchema = z.object({
     /**
      * Subject patterns to subscribe to. Default empty — caller must
      * provide at least one pattern when enabling NATS. The placeholder
-     * `{org}` is substituted with `agent.operatorId` at runtime so a
+     * `{principal}` is substituted with `agent.operatorId` at runtime so a
      * single template works across operators.
      */
     subjects: z.array(z.string().min(1)).default([]),

--- a/src/common/types/cortex-config.ts
+++ b/src/common/types/cortex-config.ts
@@ -645,7 +645,7 @@ export type Agent = z.infer<typeof AgentSchema>;
  * to known platform classes (dashboard, pagerduty, cli-tail, webhook-out).
  *
  * The G-1111 §4.6 fail-safe rule requires ≥2 distinct platform classes
- * covering `local.{org}.system.>` — that check fires at config-load (MIG-1.10),
+ * covering `local.{principal}.system.>` — that check fires at config-load (MIG-1.10),
  * not in the Zod schema.
  */
 export const RendererKindSchema = z.enum([
@@ -741,7 +741,7 @@ export const DashboardRendererSchema = z.object({
   kind: z.literal("dashboard"),
   port: z.number().int().positive().default(8767),
   publicUrl: z.url().optional(),
-  subscribe: z.array(z.string().min(1)).default(["local.{org}.>"]),
+  subscribe: z.array(z.string().min(1)).default(["local.{principal}.>"]),
   /**
    * Optional projection rules. Each entry maps an event source pattern to
    * a dashboard projection (kanban-card, inbox-row, status-banner, etc.).
@@ -788,7 +788,7 @@ export type PagerDutyRendererConfig = z.infer<typeof PagerDutyRendererSchema>;
  */
 export const CliTailRendererSchema = z.object({
   kind: z.literal("cli-tail"),
-  subscribe: z.array(z.string().min(1)).default(["local.{org}.>"]),
+  subscribe: z.array(z.string().min(1)).default(["local.{principal}.>"]),
   /**
    * IAW Phase A.4 — optional visibility guardrails. See
    * {@link RendererVisibilitySchema}.
@@ -883,7 +883,7 @@ export const NatsConfigSchema = z.object({
   /** Connection name surfaced on the server's varz endpoint. */
   name: z.string().default("cortex"),
   /**
-   * Subject patterns to subscribe to. Default empty. `{org}` is substituted
+   * Subject patterns to subscribe to. Default empty. `{principal}` is substituted
    * with `operator.id` at runtime.
    */
   subjects: z.array(z.string().min(1)).default([]),

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -311,7 +311,7 @@ export async function startCortex(
   // deployment's stack identity at boot. `deriveStackId` returns
   // `{operator, stack, id}`; the `stack` segment flows into
   // `MyelinRuntime.publish()` below so emitted envelopes land in the
-  // 6-segment `local.{org}.{stack}.{type}` grammar that sage's bridge
+  // 6-segment `local.{principal}.{stack}.{type}` grammar that sage's bridge
   // and pilot's review-request subscriber both expect.
   //
   // The helper accepts a narrow `DeriveStackIdInput` shape (operator?.id +
@@ -462,7 +462,7 @@ export async function startCortex(
     try {
       // IAW Phase A.5 (cortex#262) — surface the resolved stack identity
       // into the runtime so `publish()` emits 6-segment subjects matching
-      // sage's `local.{org}.{stack}.>` subscription. `derivedStack.stack`
+      // sage's `local.{principal}.{stack}.>` subscription. `derivedStack.stack`
       // is the second segment of the canonical `{operator}/{stack}` id;
       // when the operator omitted the `stack:` block, `deriveStackId`
       // default-derived it to `'default'` (cortex.ts:278-281). That value
@@ -580,7 +580,7 @@ export async function startCortex(
   //     (no-op stub when NATS is absent; production runtime when present),
   //   - `mergedAgents` is built (line ~439) so we know who claims what,
   //   - `systemEventSource` is built (immediately above) so we share the same
-  //     `{org}.cortex.{instance}` envelope source with `system.*` emissions.
+  //     `{principal}.cortex.{instance}` envelope source with `system.*` emissions.
   //
   // It runs BEFORE the bus-dispatch-listener + surface-router start so the
   // registry envelope is on the wire before any dispatch envelope can arrive
@@ -697,7 +697,7 @@ export async function startCortex(
   // PR-6: for each agent in `mergedAgents` that declares at least one
   // `code-review` / `code-review.<flavor>` capability, instantiate a
   // dedicated `ReviewConsumer` AND drive it through `start()` so it
-  // actually subscribes to the JetStream `local.{org}.tasks.code-review.>`
+  // actually subscribes to the JetStream `local.{principal}.tasks.code-review.>`
   // pull consumer. One consumer per agent — the spec's routing is
   // single-agent (the consumer's capability filter checks the owning
   // agent's claims only; multi-agent fan-out is the runtime's namespace
@@ -750,11 +750,11 @@ export async function startCortex(
   // cortex#318 — include the stack segment to match the 6-segment grammar
   // `deriveSubject` produces for stack-scoped publishes (cortex#262 / IAW
   // Phase A.5 + canonical helper at `@the-metafactory/myelin/subjects`).
-  // Pilot publishes to `local.{org}.{stack}.tasks.code-review.<flavor>`;
+  // Pilot publishes to `local.{principal}.{stack}.tasks.code-review.<flavor>`;
   // the consumer must subscribe to the same grammar or the wildcard
   // `>` never matches (NATS requires literal segments before the `>`).
   // Reuses `derivedStack.stack` resolved at boot (line 308) — same source
-  // sage's bridge subscription already uses for `local.{org}.{stack}.>`.
+  // sage's bridge subscription already uses for `local.{principal}.{stack}.>`.
   const reviewSubjectPattern = `local.${reviewOperatorId}.${derivedStack.stack}.tasks.code-review.>`;
   const reviewConfig = options.bus?.review;
   const reviewStream = reviewConfig?.stream.name ?? "CODE_REVIEW";
@@ -1627,16 +1627,16 @@ export async function startCortex(
   // Per architecture §9.2 these are activity-centric sinks that subscribe
   // to a slice of the bus and project envelopes into a UI / pager / log
   // stream. The G-1111 §4.6 fail-safe rule requires ≥2 distinct platform
-  // classes covering `local.{org}.system.>` so an operational alert
+  // classes covering `local.{principal}.system.>` so an operational alert
   // reliably reaches the operator even if one sink is the thing that
   // broke. Renderers never publish on the bus (architecture §9.3).
-  // cortex#269 — substitute `{org}` AND `{stack}` in renderer subscribe
+  // cortex#269 — substitute `{principal}` AND `{stack}` in renderer subscribe
   // patterns so they resolve against the same canonical shape that
   // `MyelinRuntime` already substitutes for `nats.subjects`. Without
-  // this, an operator-written `local.{org}.{stack}.system.>` pattern
+  // this, an operator-written `local.{principal}.{stack}.system.>` pattern
   // never matches an actual envelope's wire subject. The `{stack}.`
   // placeholder includes the trailing dot so stack-less deployments
-  // collapse cleanly to `local.{org}.system.>`.
+  // collapse cleanly to `local.{principal}.system.>`.
   //
   // cortex#279 cycle 2 — extracted to a shared helper so renderer- and
   // runtime-side substitution can't drift. The stack-less branch
@@ -1787,7 +1787,7 @@ export async function startCortex(
   }
 
   // MIG-5.6 (C-106): GitHub webhook receiver — opt-in via `github.receiver.enabled`
-  // AND a non-empty `github.webhookSecret`. Publishes `local.{org}.github.{event}.{action}`
+  // AND a non-empty `github.webhookSecret`. Publishes `local.{principal}.github.{event}.{action}`
   // envelopes via `runtime.publish`; that path is a no-op when NATS isn't configured
   // (see `myelin/runtime.ts`), so this block stays safe to run even without NATS.
   let githubReceiver: GithubWebhookReceiverHandle | null = null;

--- a/src/renderers/__tests__/dashboard.test.ts
+++ b/src/renderers/__tests__/dashboard.test.ts
@@ -31,7 +31,7 @@ function makeEnvelope(id: string): Envelope {
 
 describe("DashboardRenderer", () => {
   test("buffers rendered envelopes in insertion order", async () => {
-    const r = new DashboardRenderer({ kind: "dashboard", port: 8767, subscribe: ["local.{org}.>"], projections: [] });
+    const r = new DashboardRenderer({ kind: "dashboard", port: 8767, subscribe: ["local.{principal}.>"], projections: [] });
     await r.render(makeEnvelope("e1"));
     await r.render(makeEnvelope("e2"));
     await r.render(makeEnvelope("e3"));
@@ -40,7 +40,7 @@ describe("DashboardRenderer", () => {
 
   test("respects the bufferSize bound (drops oldest)", async () => {
     const r = new DashboardRenderer(
-      { kind: "dashboard", port: 8767, subscribe: ["local.{org}.>"], projections: [] },
+      { kind: "dashboard", port: 8767, subscribe: ["local.{principal}.>"], projections: [] },
       { bufferSize: 3 },
     );
     await r.render(makeEnvelope("e1"));
@@ -51,7 +51,7 @@ describe("DashboardRenderer", () => {
   });
 
   test("getRecent() returns a snapshot copy — caller mutation does not leak", async () => {
-    const r = new DashboardRenderer({ kind: "dashboard", port: 8767, subscribe: ["local.{org}.>"], projections: [] });
+    const r = new DashboardRenderer({ kind: "dashboard", port: 8767, subscribe: ["local.{principal}.>"], projections: [] });
     await r.render(makeEnvelope("e1"));
     const snap = r.getRecent() as Envelope[];
     // Try to mutate the snapshot.
@@ -60,7 +60,7 @@ describe("DashboardRenderer", () => {
   });
 
   test("stop() drops the buffer", async () => {
-    const r = new DashboardRenderer({ kind: "dashboard", port: 8767, subscribe: ["local.{org}.>"], projections: [] });
+    const r = new DashboardRenderer({ kind: "dashboard", port: 8767, subscribe: ["local.{principal}.>"], projections: [] });
     await r.render(makeEnvelope("e1"));
     await r.render(makeEnvelope("e2"));
     await r.stop();
@@ -68,7 +68,7 @@ describe("DashboardRenderer", () => {
   });
 
   test("render() never throws even on absurd input", async () => {
-    const r = new DashboardRenderer({ kind: "dashboard", port: 8767, subscribe: ["local.{org}.>"], projections: [] });
+    const r = new DashboardRenderer({ kind: "dashboard", port: 8767, subscribe: ["local.{principal}.>"], projections: [] });
     // Cast to bypass type checking — simulates a malformed envelope leaking
     // past the router's validator (defense-in-depth on the renderer contract).
     const badEnv = null as unknown as Envelope;
@@ -76,7 +76,7 @@ describe("DashboardRenderer", () => {
   });
 
   test("render() silently drops null/non-object envelopes (does not leak into buffer)", async () => {
-    const r = new DashboardRenderer({ kind: "dashboard", port: 8767, subscribe: ["local.{org}.>"], projections: [] });
+    const r = new DashboardRenderer({ kind: "dashboard", port: 8767, subscribe: ["local.{principal}.>"], projections: [] });
     await r.render(makeEnvelope("e1"));
     // Malformed values must not corrupt the buffer — Holly cycle 1 W2.
     await r.render(null as unknown as Envelope);
@@ -92,7 +92,7 @@ describe("DashboardRenderer", () => {
     // ring buffer is the only state — re-filling after stop() is harmless
     // and matches the lifecycle (a fresh start() returns to the same
     // empty-buffer state). Tests can rely on this for clean iteration.
-    const r = new DashboardRenderer({ kind: "dashboard", port: 8767, subscribe: ["local.{org}.>"], projections: [] });
+    const r = new DashboardRenderer({ kind: "dashboard", port: 8767, subscribe: ["local.{principal}.>"], projections: [] });
     await r.render(makeEnvelope("e1"));
     await r.stop();
     expect(r.getRecent()).toEqual([]);
@@ -104,15 +104,15 @@ describe("DashboardRenderer", () => {
     const r = new DashboardRenderer({
       kind: "dashboard",
       port: 8767,
-      subscribe: ["local.{org}.review.>", "local.{org}.attention.>"],
+      subscribe: ["local.{principal}.review.>", "local.{principal}.attention.>"],
       projections: [],
     });
     expect(r.surfaceConfig.id).toBe("dashboard");
-    expect(r.surfaceConfig.subjects).toEqual(["local.{org}.review.>", "local.{org}.attention.>"]);
+    expect(r.surfaceConfig.subjects).toEqual(["local.{principal}.review.>", "local.{principal}.attention.>"]);
   });
 
   test("start() is a no-op (idempotent, fast)", async () => {
-    const r = new DashboardRenderer({ kind: "dashboard", port: 8767, subscribe: ["local.{org}.>"], projections: [] });
+    const r = new DashboardRenderer({ kind: "dashboard", port: 8767, subscribe: ["local.{principal}.>"], projections: [] });
     await r.start();
     await r.start(); // idempotent
     expect(r.getRecent()).toEqual([]);

--- a/src/renderers/__tests__/factory.test.ts
+++ b/src/renderers/__tests__/factory.test.ts
@@ -15,7 +15,7 @@ describe("createRenderer", () => {
     const r = createRenderer({
       kind: "dashboard",
       port: 8767,
-      subscribe: ["local.{org}.>"],
+      subscribe: ["local.{principal}.>"],
       projections: [],
     });
     expect(r).toBeInstanceOf(DashboardRenderer);
@@ -26,7 +26,7 @@ describe("createRenderer", () => {
     const r = createRenderer({
       kind: "pagerduty",
       routingKey: "rk-test",
-      subscribe: ["local.{org}.system.>"],
+      subscribe: ["local.{principal}.system.>"],
     });
     expect(r).toBeInstanceOf(PagerDutyRenderer);
     expect(r.kind).toBe("pagerduty");
@@ -34,7 +34,7 @@ describe("createRenderer", () => {
 
   test("kind=cli-tail throws UnimplementedRendererKindError (deferred)", () => {
     expect(() =>
-      createRenderer({ kind: "cli-tail", subscribe: ["local.{org}.>"] }),
+      createRenderer({ kind: "cli-tail", subscribe: ["local.{principal}.>"] }),
     ).toThrow(UnimplementedRendererKindError);
   });
 
@@ -43,7 +43,7 @@ describe("createRenderer", () => {
       createRenderer({
         kind: "webhook-out",
         url: "https://example.com/hook",
-        subscribe: ["local.{org}.>"],
+        subscribe: ["local.{principal}.>"],
       }),
     ).toThrow(UnimplementedRendererKindError);
   });

--- a/src/renderers/__tests__/pagerduty.test.ts
+++ b/src/renderers/__tests__/pagerduty.test.ts
@@ -69,7 +69,7 @@ describe("PagerDutyRenderer", () => {
   test("POSTs to the events-v2 endpoint with the routing key in the body", async () => {
     const { fetchImpl, calls } = makeFetch(() => new Response("", { status: 202 }));
     const renderer = new PagerDutyRenderer(
-      { kind: "pagerduty", routingKey: "rk-test-123", subscribe: ["local.{org}.system.>"] },
+      { kind: "pagerduty", routingKey: "rk-test-123", subscribe: ["local.{principal}.system.>"] },
       { fetchImpl },
     );
     await renderer.render(makeEnvelope());
@@ -179,10 +179,10 @@ describe("PagerDutyRenderer", () => {
 
   test("surfaceConfig exposes the configured subjects and renderer id", () => {
     const renderer = new PagerDutyRenderer(
-      { kind: "pagerduty", routingKey: "rk", subscribe: ["local.{org}.system.>"] },
+      { kind: "pagerduty", routingKey: "rk", subscribe: ["local.{principal}.system.>"] },
     );
     expect(renderer.surfaceConfig.id).toBe("pagerduty");
-    expect(renderer.surfaceConfig.subjects).toEqual(["local.{org}.system.>"]);
+    expect(renderer.surfaceConfig.subjects).toEqual(["local.{principal}.system.>"]);
   });
 
   test("custom endpoint override is honoured (for staging / tests)", async () => {

--- a/src/renderers/dashboard.ts
+++ b/src/renderers/dashboard.ts
@@ -11,7 +11,7 @@
  * For this slice the dashboard renderer is the *sink* that satisfies the
  * G-1111 §4.6 fail-safe rule's pairing requirement alongside
  * `PagerDutyRenderer` — operationally distinct platform classes both
- * subscribed to `local.{org}.system.>` so a degraded NATS subscription
+ * subscribed to `local.{principal}.system.>` so a degraded NATS subscription
  * for one doesn't blind the operator on the other.
  *
  * Implementation: a bounded ring buffer over the last N envelopes the

--- a/src/renderers/pagerduty.ts
+++ b/src/renderers/pagerduty.ts
@@ -4,7 +4,7 @@
  * Forwards bus envelopes to PagerDuty's events-v2 API
  * (`https://events.pagerduty.com/v2/enqueue`). The G-1111 §4.6 fail-safe
  * rule recommends PagerDuty as one of the two distinct platform classes
- * subscribed to `local.{org}.system.>` so an operational alert reliably
+ * subscribed to `local.{principal}.system.>` so an operational alert reliably
  * pages even if the dashboard is the thing that broke.
  *
  * Operator chooses what counts as page-worthy via the `subscribe` patterns
@@ -13,9 +13,9 @@
  *     - kind: pagerduty
  *       routingKey: ${PAGERDUTY_ROUTING_KEY}
  *       subscribe:
- *         - "local.{org}.system.adapter.degraded"
- *         - "local.{org}.system.process.crashed"
- *         - "local.{org}.system.subscription.dropped"
+ *         - "local.{principal}.system.adapter.degraded"
+ *         - "local.{principal}.system.process.crashed"
+ *         - "local.{principal}.system.subscription.dropped"
  *
  * Mapping rules (events-v2 §payload):
  *   - `event_action` is always `"trigger"` for now. Future iteration could

--- a/src/renderers/types.ts
+++ b/src/renderers/types.ts
@@ -13,7 +13,7 @@
  * shutdown.
  *
  * The G-1111 §4.6 fail-safe rule requires ≥2 distinct platform classes
- * covering `local.{org}.system.>` — dashboard + pagerduty is the
+ * covering `local.{principal}.system.>` — dashboard + pagerduty is the
  * "recommended pair" the plan-cortex-migration.md §4 MIG-7.2d step calls
  * for. cli-tail and webhook-out kinds round out the discriminated union
  * for v1 completeness, though only dashboard + pagerduty are implemented

--- a/src/runner/__tests__/dispatch-listener.test.ts
+++ b/src/runner/__tests__/dispatch-listener.test.ts
@@ -1217,7 +1217,7 @@ describe("dispatch-listener — policy gating (C.3.1)", () => {
       "dispatch.task.completed",
     ]);
     // The audit envelope carries the federated wire subject verbatim
-    // — pre-D.3 synthesised `local.{org}...` regardless.
+    // — pre-D.3 synthesised `local.{principal}...` regardless.
     const allowed = r.published[0]!;
     expect(allowed.payload.envelope_subject).toBe(
       "federated.research-collab.dispatch.task.received",

--- a/src/runner/dispatch-listener.ts
+++ b/src/runner/dispatch-listener.ts
@@ -12,7 +12,7 @@
  *   runner adapter to drain the bus during integration tests.
  *
  * Lifecycle (per plan-cortex-migration.md §4.5–4.6, IAW Phase A.1b):
- *   1. Envelope arrives on `local.{org}.dispatch.task.received`.
+ *   1. Envelope arrives on `local.{principal}.dispatch.task.received`.
  *   2. Listener parses payload → builds a `DispatchRequest`.
  *   3. Listener instantiates a per-dispatch `ClaudeCodeHarness` and
  *      iterates `harness.dispatch(req)`.
@@ -186,7 +186,7 @@ export interface DispatchListenerOptions {
    * Operator stack segment (IAW Phase A.5, cortex#267) used to build the
    * subscription subject and the audit-envelope `dispatch.task.received`
    * synthesis path. When supplied, both subjects land on the 6-segment
-   * stack-aware grammar `local.{org}.{stack}.dispatch.task.received`
+   * stack-aware grammar `local.{principal}.{stack}.dispatch.task.received`
    * matching sage's emit-side post-IAW A.5. When omitted, the legacy
    * 5-segment form is used — bit-identical to pre-cortex#267 output, so
    * deployments without a `cortex.yaml stack:` block see no change.
@@ -301,7 +301,7 @@ export interface DispatchListener {
 // ---------------------------------------------------------------------------
 
 /**
- * Build the canonical `dispatch.task.received` subject for `{org}`
+ * Build the canonical `dispatch.task.received` subject for `{principal}`
  * (+ optional `{stack}`). Used by both `defaultSubjects` (subscribe-side)
  * and the audit-envelope fallback in `handleDispatchEnvelope`
  * (synthesised when an inbound envelope arrived without a wire
@@ -321,7 +321,7 @@ function dispatchReceivedSubject(org: string, stack?: string): string {
 }
 
 /**
- * Default subject for the runner's bus subscription. The `{org}` segment
+ * Default subject for the runner's bus subscription. The `{principal}` segment
  * is substituted at registration time using `source.org` so a misconfigured
  * runner with no operator id can still subscribe (it'll match nothing
  * unless someone publishes under `local.default.dispatch.task.received`).
@@ -687,7 +687,7 @@ async function handleDispatchEnvelope(
   //
   // IAW Phase D.3 — derive `source_network` from the matched
   // subject when the envelope arrived via `federated.{id}.>`. Local
-  // dispatches (subjects like `local.{org}.dispatch.task.received`)
+  // dispatches (subjects like `local.{principal}.dispatch.task.received`)
   // leave it `undefined` so the engine skips the federation branch.
   const sourceNetwork = extractSourceNetwork(subject);
   let gatedPrincipal: Principal | undefined;
@@ -736,7 +736,7 @@ async function handleDispatchEnvelope(
     // `defaultSystemSovereignty` — the originating envelope's
     // classification rides on `payload.intent_sovereignty` only.
     // Once federated dispatch is gated by this same surface,
-    // consumers subscribing to `federated.{org}.system.access.>`
+    // consumers subscribing to `federated.{principal}.system.access.>`
     // will miss federated denials. Decide then whether to (a)
     // mirror `intent_sovereignty.classification` onto the audit
     // envelope itself, (b) emit two envelopes (local + federated),
@@ -755,7 +755,7 @@ async function handleDispatchEnvelope(
     // IAW Phase D.3 — when the inbound envelope's subject was a real
     // wire subject (the surface-router forwards it on `render`), use
     // it verbatim on the audit envelope. The pre-D.3 path always
-    // synthesised `local.{org}.dispatch.task.received` regardless of
+    // synthesised `local.{principal}.dispatch.task.received` regardless of
     // whether the envelope arrived locally or on `federated.{net}.*`.
     // Synthesising the local subject on federated traffic would
     // misrepresent the wire path on audit consumers. Fall back to the

--- a/src/runner/worklog-manager.ts
+++ b/src/runner/worklog-manager.ts
@@ -268,7 +268,7 @@ export class WorklogManager {
    *   clean (no config import here).
    * @param stack — optional operator stack segment (IAW Phase A.5,
    *   cortex#268). When supplied, the manager subscribes on the 6-segment
-   *   grammar `local.{org}.{stack}.dispatch.task.>` matching sage's
+   *   grammar `local.{principal}.{stack}.dispatch.task.>` matching sage's
    *   emit-side post-A.5. When omitted, falls through to the legacy
    *   5-segment form — bit-identical to pre-cortex#268.
    *

--- a/src/taps/cc-events/__tests__/cc-events.test.ts
+++ b/src/taps/cc-events/__tests__/cc-events.test.ts
@@ -257,7 +257,7 @@ describe("createCcEventPublisher", () => {
     };
   }
 
-  test("publishes legacy 5-segment local.{org}.{type} when stack is omitted", () => {
+  test("publishes legacy 5-segment local.{principal}.{type} when stack is omitted", () => {
     const link = makeLink();
     const pub = createCcEventPublisher({ link: link.stub, org: "metafactory" });
     pub(makeEvent({ event_type: "tool.bash.executed" }));
@@ -269,7 +269,7 @@ describe("createCcEventPublisher", () => {
   // `stack` (sourced from `deriveStackId(loadedConfig).stack`), the relay
   // emits the 6-segment subject form matching `MyelinRuntime.publish`
   // post-cortex#262 and sage's bridge subscription.
-  test("publishes stack-aware 6-segment local.{org}.{stack}.{type} when stack is supplied (cortex#266)", () => {
+  test("publishes stack-aware 6-segment local.{principal}.{stack}.{type} when stack is supplied (cortex#266)", () => {
     const link = makeLink();
     const pub = createCcEventPublisher({
       link: link.stub,
@@ -449,9 +449,9 @@ describe("cc-events classification parameterisation (IAW A.3)", () => {
     expect(validateEnvelope(env).ok).toBe(true);
   });
 
-  test("createCcEventPublisher: federated classification yields federated.{org}.{type} subject", () => {
+  test("createCcEventPublisher: federated classification yields federated.{principal}.{type} subject", () => {
     // The end-to-end federation unblock for the cc-events tap. Prior code
-    // hardcoded `local.{org}.{type}` regardless of classification, leaving
+    // hardcoded `local.{principal}.{type}` regardless of classification, leaving
     // the relay unable to emit on `federated.*` even if the caller wanted
     // it. Now the subject mirrors the envelope's classification.
     const link = makeLink();
@@ -478,7 +478,7 @@ describe("cc-events classification parameterisation (IAW A.3)", () => {
     });
     pub(makeEvent({ event_type: "tool.bash.executed" }));
     expect(link.calls).toHaveLength(1);
-    // Public is global — no `{org}` segment per myelin grammar.
+    // Public is global — no `{principal}` segment per myelin grammar.
     expect(link.calls[0]!.subject).toBe("public.tool.bash.executed");
     const env = JSON.parse(link.calls[0]!.payload);
     expect(env.sovereignty.classification).toBe("public");
@@ -486,7 +486,7 @@ describe("cc-events classification parameterisation (IAW A.3)", () => {
 
   test("createCcEventPublisher: default classification 'local' preserves prior subject behaviour", () => {
     // Back-compat: omitting `classification` gives the same subject the
-    // pre-A.3 code path produced. Subscribers under `local.{org}.>` keep
+    // pre-A.3 code path produced. Subscribers under `local.{principal}.>` keep
     // seeing the events untouched.
     const link = makeLink();
     const pub = createCcEventPublisher({

--- a/src/taps/cc-events/cc-events.ts
+++ b/src/taps/cc-events/cc-events.ts
@@ -12,7 +12,7 @@
  * `~/.claude/events/raw/`, applies the relay policy, writes published
  * events to `~/.claude/events/published/`, and ALSO — when a
  * `MyelinRuntime` is attached — wraps each published event in a Myelin
- * envelope and publishes it to `local.{org}.{type}`.
+ * envelope and publishes it to `local.{principal}.{type}`.
  *
  * **Why the relay (and not the hook)?** Hooks run as standalone Bun
  * processes spawned by Claude Code (`~/.claude/hooks/EventLogger.hook.ts`).
@@ -29,8 +29,8 @@
  *   - `timestamp` mirrors the PublishedEvent's `timestamp` so an envelope's
  *     ts equals the moment the hook fired, not the moment the relay published.
  *     Surfaces ordering hooks chronologically rather than by relay batch order.
- *   - `source` is the dotted `{org}.{agent}.{instance}` per the schema.
- *     For relay-emitted cc-events: `{org}.cortex.relay`.
+ *   - `source` is the dotted `{principal}.{agent}.{instance}` per the schema.
+ *     For relay-emitted cc-events: `{principal}.cortex.relay`.
  *   - `correlation_id` is the **session_id** when it's UUID-shaped — surfaces
  *     join all events from one CC session on this key. Non-UUID session ids
  *     (CC's defaults) cause the field to be omitted entirely; the
@@ -134,7 +134,7 @@ export interface CreateCcEventEnvelopeOpts {
    */
   event: PublishedEvent;
   /**
-   * Envelope source — `{org}.{agent}.{instance}` per schema. All fields
+   * Envelope source — `{principal}.{agent}.{instance}` per schema. All fields
    * have sensible defaults. Callers (the relay) typically override `org`
    * to match the bot's `agent.operatorId`.
    */
@@ -170,7 +170,7 @@ export interface CreateCcEventEnvelopeOpts {
 
 /**
  * Wrap a PublishedEvent in a Myelin envelope suitable for publishing on
- * `local.{org}.{type}`. The MyelinRuntime.publish contract (G-1100.E)
+ * `local.{principal}.{type}`. The MyelinRuntime.publish contract (G-1100.E)
  * expects the type field to be the dotted `domain.entity.action` form;
  * PublishedEvent's `event_type` already conforms.
  *
@@ -242,12 +242,12 @@ export interface CreateCcEventPublisherOpts {
    */
   org?: string;
   /**
-   * Operator stack segment slotted between `{org}` and `{type}` on the
+   * Operator stack segment slotted between `{principal}` and `{type}` on the
    * derived NATS subject (myelin#113 — IAW Phase A.5; closes cortex#266).
    * When supplied, relay-lifted cc-events publish on the 6-segment shape
-   * `local.{org}.{stack}.{type}` matching sage's bridge subscription
+   * `local.{principal}.{stack}.{type}` matching sage's bridge subscription
    * and the MyelinRuntime.publish path post-cortex#262. When undefined,
-   * the legacy 5-segment form `local.{org}.{type}` is emitted —
+   * the legacy 5-segment form `local.{principal}.{type}` is emitted —
    * bit-identical to today's output, so callers that haven't wired
    * stack identity see no change.
    *
@@ -328,11 +328,11 @@ export interface CreateCcEventPublisherOpts {
  * **IAW Phase A.3:** subject derivation now mirrors
  * `envelope.sovereignty.classification` via `deriveNatsSubject`:
  *
- *   - `classification === "local"`     → `local.{org}.{type}`
- *   - `classification === "federated"` → `federated.{org}.{type}`
- *   - `classification === "public"`    → `public.{type}` (no `{org}` segment)
+ *   - `classification === "local"`     → `local.{principal}.{type}`
+ *   - `classification === "federated"` → `federated.{principal}.{type}`
+ *   - `classification === "public"`    → `public.{type}` (no `{principal}` segment)
  *
- * Prior code hardcoded `local.{org}.{type}` here regardless of
+ * Prior code hardcoded `local.{principal}.{type}` here regardless of
  * classification. The 1:1 subject↔classification invariant
  * ({@link validateSubjectEnvelopeAlignment}) now holds for relay-lifted
  * CC events too. The default `classification: "local"` keeps existing

--- a/src/taps/cc-events/relay.ts
+++ b/src/taps/cc-events/relay.ts
@@ -155,7 +155,7 @@ program
   .option("--foreground", "Run in foreground (don't daemonize)")
   .option(
     "--nats-url <url>",
-    "Optional NATS URL — when set, the relay publishes filtered events as Myelin envelopes on local.{org}.{type}. Falls back to env var NATS_URL.",
+    "Optional NATS URL — when set, the relay publishes filtered events as Myelin envelopes on local.{principal}.{type}. Falls back to env var NATS_URL.",
   )
   .option(
     "--nats-token <token>",
@@ -163,11 +163,11 @@ program
   )
   .option(
     "--org <org>",
-    "Operator/org segment for published subjects (local.{org}.{type}). Falls back to env var CORTEX_PRINCIPAL (legacy: CORTEX_OPERATOR, GROVE_OPERATOR) or NATS_ORG.",
+    "Operator/org segment for published subjects (local.{principal}.{type}). Falls back to env var CORTEX_PRINCIPAL (legacy: CORTEX_OPERATOR, GROVE_OPERATOR) or NATS_ORG.",
   )
   .option(
     "--stack <stack>",
-    "Operator stack segment for stack-aware subjects (local.{org}.{stack}.{type}). Matches the cortex.yaml stack: block. Falls back to env var CORTEX_STACK. When omitted, relay publishes on the legacy 5-segment form.",
+    "Operator stack segment for stack-aware subjects (local.{principal}.{stack}.{type}). Matches the cortex.yaml stack: block. Falls back to env var CORTEX_STACK. When omitted, relay publishes on the legacy 5-segment form.",
   )
   .option(
     "--originator-principal <did>",

--- a/src/taps/gh-webhook-receiver/server.ts
+++ b/src/taps/gh-webhook-receiver/server.ts
@@ -49,7 +49,7 @@
  *     and is bundled separately (`wrangler deploy`). This receiver runs
  *     inside the cortex process.
  *   - NOT a GitHub event router. Subscribers consume envelopes from
- *     `local.{org}.github.*` via the surface-router; this file's job ends
+ *     `local.{principal}.github.*` via the surface-router; this file's job ends
  *     once the envelope is on the bus.
  *   - NOT a CF Worker → cortex forwarder. The actual cross-network glue
  *     (how the Worker reaches `127.0.0.1` on the operator's laptop)
@@ -130,7 +130,7 @@ export interface GithubWebhookReceiverOptions {
    */
   hostname?: string;
   /**
-   * Envelope source identifier (`{org}.{agent}.{instance}`). Passed
+   * Envelope source identifier (`{principal}.{agent}.{instance}`). Passed
    * through to `createGithubEventEnvelope`; identical to the
    * `systemEventSource` cortex uses for `system.*` envelopes so all
    * envelopes from one cortex process carry the same source segments.

--- a/src/taps/gh-webhook/src/index.ts
+++ b/src/taps/gh-webhook/src/index.ts
@@ -51,7 +51,7 @@ interface Env {
    * `gh-webhook-receiver` (typically a tunnel exposing `127.0.0.1:8770`).
    * When set, the Worker forwards each validated webhook to this URL in
    * addition to `GROVE_API` so cortex can publish the
-   * `local.{org}.github.{event}.{action}` envelope onto the bus.
+   * `local.{principal}.github.{event}.{action}` envelope onto the bus.
    *
    * Posture:
    *   - The forward is best-effort: a failure here does NOT change the
@@ -174,7 +174,7 @@ app.post("/github", async (c) => {
 
   // 5b. MIG-5.6 (cortex#37): if a cortex forwarder URL is configured,
   //     additionally fire-and-forget the webhook at the local cortex
-  //     receiver so it can publish `local.{org}.github.{event}.{action}`
+  //     receiver so it can publish `local.{principal}.github.{event}.{action}`
   //     onto the bus. Failures are logged but never affect the response
   //     returned to GitHub — `GROVE_API` remains the authoritative store.
   const cortexUrl = c.env.CORTEX_FORWARDER_URL;


### PR DESCRIPTION
## Summary

Vocabulary migration 2026-05, **cortex PR-10** — cascade the R7 `{org}` → `{principal}` subject-grammar rename Luna shipped in myelin PR-2..PR-11 (#166..#175). Lockstep with myelin R7.

Per manifest at `docs/migrations/0001-vocabulary-grilled-2026-05.md` §PR-10 (L167–168).

## Scope (cortex's R4 = consumed cascade of myelin's R7)

**Subject-grammar JSDoc placeholders across 38 files**: every `{org}` token in doc-comments / template literals' inline documentation / test-name strings / subject-pattern examples → `{principal}`. Driven by a single mechanical `sed 's|{org}|{principal}|g'` then carefully reverted at the three sites where `${org}` was a template-literal expression referencing a destructured `org` parameter (not a placeholder token):

- `src/runner/dispatch-listener.ts:dispatchReceivedSubject` (param `org` kept for back-compat OPTIONS pattern)
- `src/taps/cc-events/relay.ts:258` (log-line `org="${org}"`)
- `src/__tests__/cortex.review-consumer.e2e.test.ts:221` (test-helper `subjectFor`)

**Migration-config fixture round-trip** — `migrate-config.test.ts` "passes nats config through unchanged" expects `local.{org}.>` verbatim because the LEGACY bot.yaml fixture carries it; inline comment notes the fixture is intentionally NOT touched by the vocab migration (it's the source format).

## Out of scope

- OPTIONS surfaces (`org: string` parameter on `LifecycleEmitterOptions`, `OrchestratorOptions`, `BiddingPublisherOptions`) — kept for in-window back-compat. Same labels-vs-code split as F1/F2 + myelin PR-7. Removed at I1 (v3.0.0 BREAKING).
- `src/surface/mc/*` "broadcast" references describe WebSocket-broadcast (the mechanism), not the named dispatch mode — R12a decision.

## Wire-safety

No wire-bytes change. Subject derivation produces bit-identical strings under positional invocation. JetStream-replayed envelopes continue to match cortex subscription patterns unchanged.

## Test plan

- [x] `bunx tsc --noEmit` clean
- [x] `bun test` → **3478 pass, 2 skip, 0 fail** across 185 files
- [x] `bun run lint` clean (0 errors; 26 pre-existing unused-disable warnings out of scope)

## Vocab-alignment plan

G3 step from `~/.claude/PAI/MEMORY/WORK/vocab-alignment/PLAN-CONTINUATION.md`. Completes the cortex G-phase; only I1+I2 (v3.0.0 BREAKING, gated on JC sign-off) remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)