### PR TITLE
fix(cortex): wire config.claude into review-consumer sessionOpts

### DIFF
--- a/src/__tests__/cortex.review-session-opts.test.ts
+++ b/src/__tests__/cortex.review-session-opts.test.ts
@@ -1,0 +1,117 @@
+/**
+ * cortex#400 — unit tests for `buildReviewSessionOpts`.
+ *
+ * The boot wiring at `cortex.ts:894` (per-agent ReviewConsumer
+ * instantiation loop) hands the per-agent `sessionOpts` to the
+ * review-consumer; the consumer forwards them through PR-5's pipeline
+ * into `CCSession`. Without these opts the spawned CC sees neither
+ * `--permission-mode bypassPermissions` nor `allowedTools/allowedDirs`,
+ * and the `/review owner/repo#N` slash command refuses with "I don't
+ * have access to GitHub CLI tools" (root cause of #400).
+ *
+ * The boot test (`cortex.review-consumer-boot.test.ts`) asserts the
+ * subscribePull + ready-log surface but never inspects sessionOpts —
+ * deleting the wiring leaves all six boot tests green. This file
+ * closes that regression gap by asserting the projection directly.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { BotConfigSchema, type BotConfig } from "../common/types/config";
+import type { Agent } from "../common/types/cortex-config";
+import { buildReviewSessionOpts } from "../cortex";
+
+function configWith(claudeOverrides: Partial<BotConfig["claude"]>): BotConfig {
+  return BotConfigSchema.parse({
+    agent: {
+      name: "test-cortex",
+      displayName: "TestCortex",
+      operatorId: "test-op",
+    },
+    discord: [],
+    mattermost: [],
+    claude: {
+      timeoutMs: 120_000,
+      asyncTimeoutMs: 900_000,
+      additionalArgs: [],
+      allowedTools: [],
+      disallowedTools: [],
+      allowedDirs: [],
+      readOnlyDirs: [],
+      ...claudeOverrides,
+    },
+    paths: { publishedEventsDir: "/tmp/grove-cortex-test-published" },
+  });
+}
+
+function agent(
+  overrides: Partial<Pick<Agent, "id" | "displayName">> = {},
+): Pick<Agent, "id" | "displayName"> {
+  return {
+    id: overrides.id ?? "holly",
+    displayName: overrides.displayName ?? "Holly",
+  };
+}
+
+describe("buildReviewSessionOpts — bus-side review-consumer CC opts", () => {
+  test("projects config.claude.additionalArgs verbatim (the bypassPermissions vehicle)", () => {
+    const config = configWith({
+      additionalArgs: ["--permission-mode", "bypassPermissions"],
+    });
+    const opts = buildReviewSessionOpts(config, agent());
+    expect(opts.additionalArgs).toEqual([
+      "--permission-mode",
+      "bypassPermissions",
+    ]);
+  });
+
+  test("projects allowedTools / disallowedTools / allowedDirs verbatim", () => {
+    const config = configWith({
+      allowedTools: ["Bash", "Read"],
+      disallowedTools: ["Write"],
+      allowedDirs: ["/home/clawbox/code"],
+    });
+    const opts = buildReviewSessionOpts(config, agent());
+    expect(opts.allowedTools).toEqual(["Bash", "Read"]);
+    expect(opts.disallowedTools).toEqual(["Write"]);
+    expect(opts.allowedDirs).toEqual(["/home/clawbox/code"]);
+  });
+
+  test("uses asyncTimeoutMs (review work is async — matches the Discord path)", () => {
+    const config = configWith({ asyncTimeoutMs: 1_800_000 });
+    const opts = buildReviewSessionOpts(config, agent());
+    expect(opts.timeoutMs).toBe(1_800_000);
+  });
+
+  test("threads the agent id + displayName so CC sets GROVE_AGENT_* env vars", () => {
+    const opts = buildReviewSessionOpts(
+      configWith({}),
+      agent({ id: "holly", displayName: "Holly" }),
+    );
+    expect(opts.agentId).toBe("holly");
+    expect(opts.agentName).toBe("Holly");
+  });
+
+  test("sets cwd to process.cwd() so the spawned CC inherits the daemon's working dir", () => {
+    const opts = buildReviewSessionOpts(configWith({}), agent());
+    expect(opts.cwd).toBe(process.cwd());
+  });
+
+  test("propagates bashAllowlist when present", () => {
+    const config = configWith({
+      bashAllowlist: {
+        rules: [{ pattern: "^git ", repos: ["cortex"] }],
+        repos: ["cortex"],
+      },
+    });
+    const opts = buildReviewSessionOpts(config, agent());
+    expect(opts.bashAllowlist).toEqual({
+      rules: [{ pattern: "^git ", repos: ["cortex"] }],
+      repos: ["cortex"],
+    });
+  });
+
+  test("omits bashAllowlist when config.claude.bashAllowlist is undefined", () => {
+    const opts = buildReviewSessionOpts(configWith({}), agent());
+    expect("bashAllowlist" in opts).toBe(false);
+  });
+});

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -890,6 +890,34 @@ export async function startCortex(
       const pipelineRunner =
         substrate === "pi-dev" ? makePiDevPipelineRunner({}) : undefined;
 
+      // cortex#400 — propagate `config.claude` into the per-agent
+      // review-consumer's `sessionOpts` so the bus-side CC spawn
+      // mirrors the Discord path (`src/bus/dispatch-handler.ts`
+      // line ~1014). Without this, `runReviewPipeline → new
+      // CCSession({prompt})` boots CC with empty defaults — no
+      // `--permission-mode bypassPermissions`, no `allowedTools`,
+      // no `cwd`, no `additionalArgs` — and the spawned model sees
+      // only globally-configured MCP tools (no Bash/Read/gh), so a
+      // `/review owner/repo#N` slash command politely refuses with
+      // "I don't have access to GitHub CLI tools". `asyncTimeoutMs`
+      // matches the Discord path's choice (review work is async).
+      // `allowedDirs` collapses an empty array to `undefined` so the
+      // claude-invoker omits the flag entirely (passing `[]` would
+      // forbid every directory).
+      const reviewSessionOpts = {
+        agentName: agent.displayName,
+        agentId: agent.id,
+        additionalArgs: config.claude.additionalArgs,
+        allowedTools: config.claude.allowedTools,
+        disallowedTools: config.claude.disallowedTools,
+        allowedDirs:
+          config.claude.allowedDirs.length > 0
+            ? config.claude.allowedDirs
+            : undefined,
+        timeoutMs: config.claude.asyncTimeoutMs,
+        cwd: process.cwd(),
+      };
+
       const consumer = new ReviewConsumer({
         agent: consumerAgent,
         source: systemEventSource,
@@ -911,6 +939,7 @@ export async function startCortex(
           // Minimal prompt — the real skill-aware builder lands in PR-8.
           // Echo's skill consumes `/review <owner/repo>#<pr>` style today.
           `/review ${payload.repo}#${payload.pr}`,
+        sessionOpts: reviewSessionOpts,
         ...(pipelineRunner !== undefined && { pipelineRunner }),
         ...(signatureVerifier !== undefined && { signatureVerifier }),
       });

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -58,7 +58,7 @@ import {
   provisionReviewConsumer,
 } from "./bus/jetstream/provision";
 import { verifySignedByChain } from "./bus/verify-signed-by-chain";
-import { CCSession } from "./runner/cc-session";
+import { CCSession, type CCSessionOpts } from "./runner/cc-session";
 import { makePiDevPipelineRunner } from "./runner/substrate/pi-dev-runner";
 
 import { DiscordAdapter } from "./adapters/discord";
@@ -131,6 +131,45 @@ export function pidFileFor(configPath: string | undefined): string {
   const base = basename(configPath).replace(/\.ya?ml$/i, "");
   if (base.length === 0) return PID_FILE;
   return join(STATE_DIR, `cortex-${base}.pid`);
+}
+
+/**
+ * cortex#400 — derive the per-agent CC session opts handed to the
+ * bus-side review-consumer. Mirrors the Discord path's wiring at
+ * `src/bus/dispatch-handler.ts:1014` so a `/review owner/repo#N`
+ * dispatch over the bus spawns CC with the same toolset (Bash/Read/gh
+ * + `bypassPermissions`) the Discord path uses. Without this, the
+ * spawned CC sees only globally-configured MCP tools and politely
+ * refuses with "I don't have access to GitHub CLI tools".
+ *
+ * `asyncTimeoutMs` matches the Discord path's choice (review work
+ * is async). `bashAllowlist` is propagated when present; the runtime
+ * gate at `src/runner/hooks/bash-guard.hook.ts:218` currently
+ * short-circuits to `allow()` whenever `GROVE_AGENT_ID` is set (a
+ * pre-existing scope of the agent-trust model that affects the
+ * Discord path too — tracked as a follow-up issue).
+ *
+ * Exported so `src/__tests__/cortex.review-session-opts.test.ts` can
+ * assert the projection without standing up the full `startCortex`
+ * integration harness.
+ */
+export function buildReviewSessionOpts(
+  config: BotConfig,
+  agent: Pick<Agent, "id" | "displayName">,
+): Partial<Omit<CCSessionOpts, "prompt">> {
+  return {
+    agentName: agent.displayName,
+    agentId: agent.id,
+    additionalArgs: config.claude.additionalArgs,
+    allowedTools: config.claude.allowedTools,
+    disallowedTools: config.claude.disallowedTools,
+    allowedDirs: config.claude.allowedDirs,
+    timeoutMs: config.claude.asyncTimeoutMs,
+    cwd: process.cwd(),
+    ...(config.claude.bashAllowlist !== undefined && {
+      bashAllowlist: config.claude.bashAllowlist,
+    }),
+  };
 }
 
 /** Lifecycle handle returned by `startCortex`. Capped at 15s — components
@@ -890,33 +929,7 @@ export async function startCortex(
       const pipelineRunner =
         substrate === "pi-dev" ? makePiDevPipelineRunner({}) : undefined;
 
-      // cortex#400 — propagate `config.claude` into the per-agent
-      // review-consumer's `sessionOpts` so the bus-side CC spawn
-      // mirrors the Discord path (`src/bus/dispatch-handler.ts`
-      // line ~1014). Without this, `runReviewPipeline → new
-      // CCSession({prompt})` boots CC with empty defaults — no
-      // `--permission-mode bypassPermissions`, no `allowedTools`,
-      // no `cwd`, no `additionalArgs` — and the spawned model sees
-      // only globally-configured MCP tools (no Bash/Read/gh), so a
-      // `/review owner/repo#N` slash command politely refuses with
-      // "I don't have access to GitHub CLI tools". `asyncTimeoutMs`
-      // matches the Discord path's choice (review work is async).
-      // `allowedDirs` collapses an empty array to `undefined` so the
-      // claude-invoker omits the flag entirely (passing `[]` would
-      // forbid every directory).
-      const reviewSessionOpts = {
-        agentName: agent.displayName,
-        agentId: agent.id,
-        additionalArgs: config.claude.additionalArgs,
-        allowedTools: config.claude.allowedTools,
-        disallowedTools: config.claude.disallowedTools,
-        allowedDirs:
-          config.claude.allowedDirs.length > 0
-            ? config.claude.allowedDirs
-            : undefined,
-        timeoutMs: config.claude.asyncTimeoutMs,
-        cwd: process.cwd(),
-      };
+      const reviewSessionOpts = buildReviewSessionOpts(config, agent);
 
       const consumer = new ReviewConsumer({
         agent: consumerAgent,


### PR DESCRIPTION
## Summary

- Holly's bus-side code-review path spawned CC with **no** `additionalArgs`, `allowedTools`, `cwd`, or `allowedDirs` — only the prompt. CC defaulted to Haiku with the globally-configured MCP tools (Gmail/Calendar/Drive) visible and **no** Bash/Read/`gh`, so `/review owner/repo#N` returned a polite "I don't have access to GitHub CLI tools" refusal instead of a verdict.
- Discord path at `src/bus/dispatch-handler.ts:1014` already wires `config.claude.{additionalArgs,allowedTools,disallowedTools,allowedDirs,bashAllowlist}` + `asyncTimeoutMs` + `cwd` per CCSession — that's why Holly's `@holly` chat path works end-to-end.
- This patch mirrors that pattern at the bus-side ReviewConsumer instantiation (`src/cortex.ts:894`): per-agent `sessionOpts` built from `config.claude` via the new exported `buildReviewSessionOpts(config, agent)` helper, with 7-case unit-test coverage.

## Symptom (pre-fix)

Holly ack'd envelope 540fdcc3, chain verification passed, but no verdict, no failed envelope, no log. CC JSONL at `~/.claude/projects/.../689f210d-*.jsonl` showed:

```
model: claude-haiku-4-5-20251001
attachment: command_permissions { allowedTools: [] }
assistant: "I don't have access to GitHub CLI tools or PR review
capabilities. The tools I have access to are: Gmail, Google Calendar,
Google Drive."
```

## Test plan

- [x] `bun test src/__tests__/cortex.review-session-opts.test.ts` — 7 pass (NEW)
- [x] `bun test src/__tests__/cortex.review-consumer-boot.test.ts` — 6 pass
- [x] `bun test src/bus/__tests__/review-consumer.test.ts src/runner/__tests__/review-pipeline.test.ts` — 58 pass
- [x] `bun tsc --noEmit` clean
- [ ] Post-merge: redeploy clawbox, `sage dispatch the-metafactory/cortex#400 --post`, verify Holly emits a verdict envelope (not silence, not refusal)

## Out of scope

- **Per-payload `cwd`** (so Holly clones / `cd`s into `payload.repo` before review). Today `cwd = process.cwd()` (the cortex daemon's working dir, which on clawbox is the cortex checkout itself). Cross-repo reviews still work because `/review` uses `gh` API calls, not local filesystem inspection — but a follow-up issue should consider a per-task workspace.
- **bash-guard short-circuit on `GROVE_AGENT_ID`** (cortex#401). This PR propagates `bashAllowlist` defensively, but `src/runner/hooks/bash-guard.hook.ts:218` currently `allow()`s every bot session whose CC inherits `GROVE_AGENT_ID` — the Discord path is structurally bypassed today too. **Interim consequence**: review-consumer CC sessions run with allow-all bash. Tracked separately because the fix touches both the bus-side and Discord paths and the agent-trust model deserves an explicit design call.
- **`bashGuardDisabled` per-message** propagation (Discord-only today; operator-DM scoped — review-consumer is long-lived per-agent, no message-scoped override surface yet).
- Sage's pi-dev substrate adapter (selected before the CC fallthrough) is unaffected — it never touches `sessionOpts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)