### PR TITLE
feat(runner): SAGE_SUBSTRATE env override for pi-dev runner

### DIFF
--- a/src/runner/substrate/__tests__/pi-dev-runner.test.ts
+++ b/src/runner/substrate/__tests__/pi-dev-runner.test.ts
@@ -124,51 +124,64 @@ const whichMissing: PiDevWhichFn = () => undefined;
 
 describe("cortex#331 Phase 1 — makePiDevPipelineRunner", () => {
   test("happy path: sage exit 0 + stdout → verdict envelope with summary=stdout, correlation_id=requestEnvelope.id", async () => {
-    const stdout = "## review body\n\nverdict: commented";
-    const spawn = makeRecordingSpawn(makeSpawnResult(stdout, "", 0));
-    const runner = makePiDevPipelineRunner({
-      spawn: spawn.fn,
-      which: whichSuccess,
-    });
+    // cortex#402 — guard the argv pin against an ambient SAGE_SUBSTRATE
+    // env value. Before #402 the env var was inert; after #402 a
+    // developer machine carrying e.g. `SAGE_SUBSTRATE=claude` would
+    // flip the argv assertion below from the documented default
+    // (`pi`) and break this hermetic test. The two #402 tests below
+    // own the env-override semantics; this test just pins the
+    // default-path argv.
+    const prior = process.env.SAGE_SUBSTRATE;
+    delete process.env.SAGE_SUBSTRATE;
+    try {
+      const stdout = "## review body\n\nverdict: commented";
+      const spawn = makeRecordingSpawn(makeSpawnResult(stdout, "", 0));
+      const runner = makePiDevPipelineRunner({
+        spawn: spawn.fn,
+        which: whichSuccess,
+      });
 
-    const opts = makePipelineOpts();
-    const result = await runner(opts);
+      const opts = makePipelineOpts();
+      const result = await runner(opts);
 
-    // Result shape — verdict, not failed.
-    expect(result.kind).toBe("verdict");
-    if (result.kind !== "verdict") return; // narrow
+      // Result shape — verdict, not failed.
+      expect(result.kind).toBe("verdict");
+      if (result.kind !== "verdict") return; // narrow
 
-    // Envelope wiring — correlation_id is the request envelope's id (the
-    // single load-bearing pilot contract per design §5.1).
-    const envelope: Envelope = result.envelope;
-    expect(envelope.type).toBe("review.verdict.commented");
-    expect(envelope.correlation_id).toBe(opts.requestEnvelope.id);
+      // Envelope wiring — correlation_id is the request envelope's id (the
+      // single load-bearing pilot contract per design §5.1).
+      const envelope: Envelope = result.envelope;
+      expect(envelope.type).toBe("review.verdict.commented");
+      expect(envelope.correlation_id).toBe(opts.requestEnvelope.id);
 
-    // Payload shape — summary echoes sage's stdout verbatim, repo/pr
-    // echo the request payload, reviewer is the Phase 1 default "sage".
-    const payload = envelope.payload as {
-      repo: string;
-      pr: number;
-      reviewer: string;
-      verdict: string;
-      summary: string;
-    };
-    expect(payload.summary).toBe(stdout);
-    expect(payload.repo).toBe(VALID_PAYLOAD.repo);
-    expect(payload.pr).toBe(VALID_PAYLOAD.pr);
-    expect(payload.reviewer).toBe("sage");
-    expect(payload.verdict).toBe("commented");
+      // Payload shape — summary echoes sage's stdout verbatim, repo/pr
+      // echo the request payload, reviewer is the Phase 1 default "sage".
+      const payload = envelope.payload as {
+        repo: string;
+        pr: number;
+        reviewer: string;
+        verdict: string;
+        summary: string;
+      };
+      expect(payload.summary).toBe(stdout);
+      expect(payload.repo).toBe(VALID_PAYLOAD.repo);
+      expect(payload.pr).toBe(VALID_PAYLOAD.pr);
+      expect(payload.reviewer).toBe("sage");
+      expect(payload.verdict).toBe("commented");
 
-    // Argv pin — `sage review owner/repo#N --substrate pi`, with the
-    // resolved binary path as argv[0].
-    expect(spawn.calls.length).toBe(1);
-    expect(spawn.calls[0]).toEqual([
-      FAKE_SAGE_BIN,
-      "review",
-      `${VALID_PAYLOAD.repo}#${VALID_PAYLOAD.pr}`,
-      "--substrate",
-      "pi",
-    ]);
+      // Argv pin — `sage review owner/repo#N --substrate pi`, with the
+      // resolved binary path as argv[0].
+      expect(spawn.calls.length).toBe(1);
+      expect(spawn.calls[0]).toEqual([
+        FAKE_SAGE_BIN,
+        "review",
+        `${VALID_PAYLOAD.repo}#${VALID_PAYLOAD.pr}`,
+        "--substrate",
+        "pi",
+      ]);
+    } finally {
+      if (prior !== undefined) process.env.SAGE_SUBSTRATE = prior;
+    }
   });
 
   test("failure path: sage exit != 0 + stderr → failed envelope with reason.kind=cant_do carrying stderr in detail", async () => {

--- a/src/runner/substrate/__tests__/pi-dev-runner.test.ts
+++ b/src/runner/substrate/__tests__/pi-dev-runner.test.ts
@@ -290,4 +290,47 @@ describe("cortex#331 Phase 1 — makePiDevPipelineRunner", () => {
     expect(reason.detail).toContain("sage spawn failed");
     expect(reason.detail).toContain("ENOENT");
   });
+
+  // cortex#402 — `SAGE_SUBSTRATE` env override
+  // ---------------------------------------------------------------------
+  // Operators without a pi.dev model provider configured (e.g. no
+  // DeepSeek API key) need a way to route sage's lens execution through
+  // `claude` or `codex` instead. The runner reads `SAGE_SUBSTRATE`
+  // verbatim and threads it into argv; sage's own CLI validates the
+  // value. Unset → `pi` (preserves pre-#402 behaviour).
+
+  test("cortex#402 — SAGE_SUBSTRATE env overrides argv[4]", async () => {
+    const prior = process.env.SAGE_SUBSTRATE;
+    process.env.SAGE_SUBSTRATE = "claude";
+    try {
+      const spawn = makeRecordingSpawn(makeSpawnResult("## review\n", "", 0));
+      const runner = makePiDevPipelineRunner({
+        spawn: spawn.fn,
+        which: whichSuccess,
+      });
+      const result = await runner(makePipelineOpts());
+      expect(result.kind).toBe("verdict");
+      expect(spawn.calls.length).toBe(1);
+      expect(spawn.calls[0]!.slice(-2)).toEqual(["--substrate", "claude"]);
+    } finally {
+      if (prior === undefined) delete process.env.SAGE_SUBSTRATE;
+      else process.env.SAGE_SUBSTRATE = prior;
+    }
+  });
+
+  test("cortex#402 — unset SAGE_SUBSTRATE defaults to `pi` (pre-#402 behaviour)", async () => {
+    const prior = process.env.SAGE_SUBSTRATE;
+    delete process.env.SAGE_SUBSTRATE;
+    try {
+      const spawn = makeRecordingSpawn(makeSpawnResult("## review\n", "", 0));
+      const runner = makePiDevPipelineRunner({
+        spawn: spawn.fn,
+        which: whichSuccess,
+      });
+      await runner(makePipelineOpts());
+      expect(spawn.calls[0]!.slice(-2)).toEqual(["--substrate", "pi"]);
+    } finally {
+      if (prior !== undefined) process.env.SAGE_SUBSTRATE = prior;
+    }
+  });
 });

--- a/src/runner/substrate/pi-dev-runner.ts
+++ b/src/runner/substrate/pi-dev-runner.ts
@@ -218,7 +218,16 @@ export function makePiDevPipelineRunner(
     // src/bus/review-events.ts §4.1), so we concatenate with `#<pr>`
     // directly — no separate owner field on the cortex-side payload.
     const prRef = `${payload.repo}#${payload.pr}`;
-    const argv = [sageBin, "review", prRef, "--substrate", "pi"];
+    // cortex#402 — substrate is overridable via `SAGE_SUBSTRATE` env so
+    // operators without a pi.dev model provider configured (e.g. no
+    // DeepSeek API key) can route sage's lens execution through
+    // `claude` or `codex` instead. Defaults to `pi` to preserve the
+    // pre-#402 behaviour. Sage's CLI accepts `{pi|claude|codex}` per
+    // `sage review --help`; values outside that set surface as a sage-
+    // side `--substrate` parse error (which the failure-mapping table
+    // below maps to `cant_do`).
+    const substrate = process.env.SAGE_SUBSTRATE ?? "pi";
+    const argv = [sageBin, "review", prRef, "--substrate", substrate];
 
     let proc: PiDevSpawnResult;
     try {

--- a/src/runner/substrate/pi-dev-runner.ts
+++ b/src/runner/substrate/pi-dev-runner.ts
@@ -19,7 +19,8 @@
  *
  *   pilot publishes `tasks.code-review.<flavor>` envelope
  *     → cortex's `ReviewConsumer` for sage receives + verifies signature (cortex#330)
- *     → this runner spawns `sage review <pr-ref> --substrate pi` subprocess
+ *     → this runner spawns `sage review <pr-ref> --substrate <pi|claude|codex>` subprocess
+ *       (substrate value from `SAGE_SUBSTRATE` env, defaults to `pi`)
  *     → captures sage stdout, builds `review.verdict.commented` envelope
  *     → cortex publishes verdict back to bus
  *     → pilot's `--wait` catches it
@@ -74,7 +75,8 @@
  * splits this into the four-way nak taxonomy.
  *
  * **Subprocess shape.** We spawn `sage review <owner>/<repo>#<n>
- * --substrate pi`. Stdout is captured to a single string and used as
+ * --substrate <pi|claude|codex>` (substrate value resolved from the
+ * `SAGE_SUBSTRATE` env var, defaults to `pi` — cortex#402). Stdout is captured to a single string and used as
  * `payload.summary`. Stderr is captured separately and fed into the
  * failed envelope's `reason.detail` when sage exits non-zero. Both pipes
  * are drained via `new Response(stream).text()` in parallel with the
@@ -117,7 +119,8 @@ export interface PiDevSpawnResult {
  * deterministic fake (see `pi-dev-runner.test.ts`).
  *
  * `argv[0]` is the resolved sage binary path; subsequent entries are the
- * `review <pr-ref> --substrate pi` arguments.
+ * `review <pr-ref> --substrate <pi|claude|codex>` arguments (substrate
+ * value resolved from `SAGE_SUBSTRATE` env, defaults to `pi`).
  */
 export type PiDevSpawnFn = (
   argv: string[],


### PR DESCRIPTION
## Summary

- Pi-dev substrate runner (`src/runner/substrate/pi-dev-runner.ts:221`) hard-coded `sage review … --substrate pi`. Without a pi.dev-side model provider configured (e.g. no DeepSeek API key), every lens fails with `No API key found for deepseek. Use /login to log into a provider…`, sage exits 1, and the pipeline emits `dispatch.task.failed` with `reason.kind=cant_do`. The bus-side review path is unusable for any operator who isn't a pi.dev customer.
- Sage's own CLI already supports `{pi|claude|codex}` for the lens substrate (`sage review --help`). Pipe that surface through: substrate is now overridable via `SAGE_SUBSTRATE` env, default `pi`.
- Operators set the env on cortex-bot's service unit (launchd plist `EnvironmentVariables` block, or systemd `EnvironmentFile`). The agent's `runtime.substrate: pi-dev` remains the dispatch-side discriminator; only the lens-execution substrate inside sage is reconfigured.

## Symptom (pre-fix)

```
[sage] reviewing the-metafactory/cortex#400 via github (ref) on pi.dev (flag, …)
[sage] Maintainability lens substrate/extraction failed — synthesizing errored report
[sage] Architecture lens substrate/extraction failed — synthesizing errored report
[sage] CodeQuality lens substrate/extraction failed — synthesizing errored report
[sage] Security lens substrate/extraction failed — synthesizing errored report
[sage] verdict: changes-requested (posted=false)
…
substrate exited with code 1: No API key found for deepseek.
```

## Test plan

- [x] `bun test src/runner/substrate/__tests__/pi-dev-runner.test.ts` — 7 pass (5 existing + 2 new: env-set + env-unset default)
- [x] `bun tsc --noEmit` clean
- [ ] Post-merge: redeploy local cortex with `SAGE_SUBSTRATE=claude` in launchd plist, run `pilot request-review --pr the-metafactory/cortex#400 --capability code-review.typescript --wait`, verify sage produces a real verdict (not all-lenses-errored).

## Out of scope

- The agent's `runtime.substrate: pi-dev` discriminator name. A future PR could rename to `sage-cli` or similar since the dispatch is "spawn sage CLI" regardless of which lens substrate sage internally uses — but that's a rename PR, separate scope.
- Validating SAGE_SUBSTRATE values cortex-side. Sage's CLI already rejects unknown values with a parse error which surfaces here as `cant_do`. Defense-in-depth validation can land as a follow-up if false-substrate-name typos become a real footgun.

🤖 Generated with [Claude Code](https://claude.com/claude-code)