### PR TITLE
docs(cortex): C-405 OSI corrections + Scenario 4 + Scenario 5 + IoAW linkage

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -18,6 +18,8 @@ _Avoid_: deployment, instance, node. Never use `stack` for the M1–M7 architect
 
 **Network**:
 A federation of **principals** whose **stacks** interconnect at the NATS leaf-node layer — `metafactory` is the network this ecosystem runs on. A network is **not a subject segment**: it is deployment topology. Cross-principal reach is the `federated.` **scope** prefix, never a network name on the wire. A principal may belong to more than one network.
+
+**Federation is the default for multi-principal collaboration**, not the exception. When two principals' bots interact (e.g. Andreas's assistant replies to a message JC's user posted), the dispatch envelope MUST publish on `federated.{principal}.{stack}.…` — `local.` never crosses the principal boundary. This is the OSI/L3 routing equivalent: `local.` is one broadcast domain, `federated.` is cross-network routing. A shared platform channel (Discord, Mattermost, Slack) does NOT make cross-principal traffic intra-principal — the surface is L7; the routing happens at L1–L3 on the bus.
 _Avoid_: federation (that is the relationship, not the thing), mesh, fabric, org, cluster
 
 ### Assistants & agents
@@ -57,19 +59,27 @@ The inner content body of an **envelope** — the domain data, distinct from the
 _Avoid_: message, body, data
 
 **Capability**:
-A declared, bus-routable ability — e.g. `code-review.typescript`. An **assistant** declares the capabilities it offers; the `tasks.{capability}.{subcapability}` **subject** routes on it; an **agent**'s JetStream consumer filters by it. A capability may be *fulfilled by* a soma skill, but the capability is the wire-facing ability, not the implementation.
+A declared, bus-routable ability — e.g. `code-review.typescript`, `chat`, `release`, `security-scan`. An **assistant** declares the capabilities it offers; the `tasks.{capability}.{subcapability}` **subject** routes on it (for Offer mode); for Direct/Delegate mode the capability appears as the trailing segment after `tasks.@{assistant}` (e.g. `tasks.@luna.chat`). An **agent**'s JetStream consumer filters by capability. A capability may be *fulfilled by* a soma skill, but the capability is the wire-facing ability, not the implementation.
+
+**`chat` is the canonical capability for free-form conversational dispatches — bus-native, not surface-bound.** An assistant declaring `chat` accepts conversational envelopes from ANY dispatch source: a platform adapter (human→bot via Discord/Mattermost/Slack), another assistant's runtime (bot→bot direct), a delegation re-issue, the MC dashboard, or a tap/webhook. The wire grammar is the same (`tasks.@{assistant}.chat`); only the `originator` field and the scope (`local.` / `federated.`) vary by source. Discord (and other platforms) are sources and/or sinks for chat envelopes — they are not the medium of communication. **The bus is the medium.**
 _Avoid_: skill (that is the SOMA implementation term), ability, function, command, tool
 
 **Dispatch**:
-The act of routing a unit of work to an **assistant** over the bus. Three modes, by how the recipient is chosen — **Offer**: published to a **capability**, any capable assistant *claims* it (competing consumers, exactly-one delivery); **Direct**: sent to one named assistant (`@{assistant}`), one-shot; **Delegate**: sent to one named assistant that orchestrates a multi-step outcome. Unclaimed work escalates to **dead-letter**.
+The act of routing a unit of work to an **assistant** over the bus. Three modes, by how the recipient is chosen — **Offer**: published to a **capability**, any capable assistant *claims* it (competing consumers, exactly-one delivery); **Direct**: sent to one named assistant (`@{assistant}`), one-shot; **Delegate**: sent to one named assistant that orchestrates a multi-step outcome via the **`agent-team` substrate harness**. Unclaimed work escalates to **dead-letter**.
 
-Inbound subjects per mode:
-- **Offer** → `tasks.{capability}.{subcapability}` (capability routing, competing consumers)
-- **Direct, intra-stack** → `dispatch.task.received` (local **dispatch source** publishes; the stack-local listener consumes)
-- **Direct, peer-to-peer** → `dispatch.task.dispatched` (peer stack publishes via a bus-peer bridge)
-- **Delegate** → currently undefined; under design as part of the AgentTeam **substrate harness** work
+The wire-level mode bit lives in the envelope's top-level `distribution_mode` field (myelin enum: `'broadcast' | 'direct' | 'delegate'`; cortex maps `'broadcast'` → Offer at the boundary). Direct and Delegate share the same subject shape (`tasks.@{assistant}.{capability}`); the listener distinguishes them by reading `distribution_mode`.
 
-Lifecycle envelopes for any mode flow on `dispatch.task.{started|completed|failed|aborted}`, joined by `correlation_id`.
+Inbound subjects per mode (myelin canonical, per `myelin/specs/namespace.md` §Tasks Domain):
+- **Offer** → `local.{principal}.{stack}.tasks.{capability}.{subcapability}` (capability routing; JetStream consumer group claims exactly-once)
+- **Direct, intra-principal** → `local.{principal}.{stack}.tasks.@{did-encoded-assistant}.{capability}`
+- **Direct, cross-principal** → `federated.{principal}.{stack}.tasks.@{did-encoded-assistant}.{capability}` (any cross-principal traffic, including bot-replies on shared platform channels — see Network entry)
+- **Delegate** → identical subject to Direct (`tasks.@{did-encoded-assistant}.{capability}`); mode encoded in `envelope.distribution_mode === 'delegate'` (top-level field)
+
+DID-segment encoding (`:` → `-`, `.` → `--`) via myelin's `encodeDidSegment` helper.
+
+Lifecycle envelopes for any mode flow on `dispatch.task.{started|completed|failed|aborted}`, joined by `correlation_id`. Lifecycle envelopes mirror the inbound scope (intra-principal → `local.…dispatch.task.*`; cross-principal → `federated.…dispatch.task.*`).
+
+**Legacy:** cortex code (`src/runner/dispatch-listener.ts` + IAW Phase D integration tests) subscribes to `dispatch.task.received` as a pre-namespace-finalisation convention. The Direction A migration (C-405 + #406–#412) flips publishers to canonical `tasks.@{assistant}.{capability}` subjects and removes the legacy subscription in Stage 7.
 _Avoid_: routing, assignment, hand-off. Never call the Offer mode "broadcast" — exactly one assistant claims an offered task, not all.
 
 ### Surfaces, substrates, dispatch routing
@@ -79,7 +89,7 @@ The M6 runtime layer that executes a single **dispatch** on one execution substr
 _Avoid_: backend, executor, engine, runtime (overloaded with `MyelinRuntime`)
 
 **Dispatch source**:
-Anything that creates and publishes an inbound dispatch **envelope** onto the bus. A platform adapter (Discord, Mattermost, Slack) is a dispatch source: it turns a platform message into a `dispatch.task.received` envelope signed by the hosted **agent**. The GitHub webhook tap is a dispatch source. The MC dashboard's "send task" action is a dispatch source. Future peer-stack agents publishing Offers cross-federation are dispatch sources. A dispatch source is the only thing that signs an envelope into existence; it carries the originating agent's signing key.
+Anything that creates and publishes an inbound dispatch **envelope** onto the bus. A platform adapter (Discord, Mattermost, Slack) is a dispatch source: it turns a platform message into a `tasks.@{did-encoded-assistant}.{capability}` envelope (canonical) — adapter populates `originator.identity` with the resolved human/agent DID and `originator.attribution = "adapter-resolved"`; the **stack** then signs the envelope via `runtime.publish` using the stack NKey. The GitHub webhook tap is a dispatch source. The MC dashboard's "send task" action is a dispatch source. Future peer-stack agents publishing Offers cross-federation are dispatch sources. The dispatch source is the locus of policy-actor attribution (via `originator`); the **stack** is the cryptographic signer.
 _Avoid_: producer, ingress, intake
 
 **Dispatch sink**:
@@ -127,7 +137,10 @@ _Avoid_: callback, return-address, reply-to
 - **`broadcast` → `Offer`.** A broadcast reaches everyone; that dispatch mode is claimed by exactly one assistant. The modes are **Offer / Direct / Delegate**.
 - **`tasks` and `dispatch` are distinct domains**, not aliases. `tasks` = work-request namespace (Offer-mode subject convention). `dispatch` = task-lifecycle namespace (events about an active task). Both will continue to exist.
 - **`renderer` vs `dispatch sink`.** The cortex-internal interface is `Renderer` (`src/renderers/types.ts`); the architectural role is **dispatch sink**. Same thing from different angles — code says `Renderer`; design discussion says `dispatch sink`.
-- **Adapter-originated Direct subject (`tasks.@{assistant}.chat`) is a future seam.** The example dialogue above shows the intended subject grammar; cortex code today publishes adapter-originated Direct dispatches to `dispatch.task.received` (the existing intra-stack inbound subject). Migration to subject-level mode encoding (Direct = `tasks.@{assistant}.…`) is deferred — payload-level mode field carries the information today.
+- **Adapter-originated Direct subject — resolved by Direction A (C-405).** Canonical wire grammar (per `myelin/specs/namespace.md` §Tasks Domain) is `tasks.@{did-encoded-assistant}.{capability}`. cortex code today still subscribes on the pre-spec `dispatch.task.received` subject in `src/runner/dispatch-listener.ts`; Direction A Stages 4–7 (cortex#409–#412) flip publishers to canonical subjects and retire the legacy subscription. The `chat` capability is the canonical capability for free-form `@assistant` interactions.
+- **Delegate dispatch — resolved by Direction A (C-405).** Subject is identical to Direct (`tasks.@{did-encoded-assistant}.{capability}`); mode encoded in the envelope's top-level `distribution_mode` field (myelin enum value `'delegate'`). Listener routes to the `agent-team` substrate harness when `envelope.distribution_mode === 'delegate'`.
+- **Adapter signs as agent → stack signs, adapter populates originator (C-405 correction).** Originally Direction A Q1a pinned "adapter holds agent NKey and signs as the hosted agent". Corrected per myelin#160 (CLOSED): the **stack** signs via `runtime.publish` using the stack NKey; the **adapter** populates `originator.identity` (resolved DID) + `originator.attribution = "adapter-resolved"`. Cryptographic signer (stack) and policy actor (originator) are cleanly separated — both attestable, both inside the signature.
+- **myelin `DistributionMode` enum still ships `'broadcast'`.** cortex CONTEXT.md canonicalised that mode to **Offer**. Pending myelin-side rename (filed as a separate myelin issue). cortex maps `'broadcast'` → Offer at the boundary until myelin renames.
 
 ## Boundary with adjacent contexts
 

--- a/docs/design-myelin-osi-scenarios.md
+++ b/docs/design-myelin-osi-scenarios.md
@@ -5,7 +5,8 @@
 **Driver:** Andreas (pushback in #myelin → §10/§11 locked answers) + Jens-Christian (Direction A grilling)
 **Related:**
 - `the-metafactory/myelin` — canonical seven-layer model + namespace spec (`docs/architecture.md`, `specs/namespace.md`); `src/types.ts` ships `DistributionMode` + `AttributionMode` enums; `schemas/envelope.schema.json` carries the `originator` field
-- `docs/design-platform-adapter-dispatch-publishing.md` — Direction A design (this doc supersedes Q2's grammar split; §11 supersedes Q1 signing model and §10 open questions)
+- `docs/design-platform-adapter-dispatch-publishing.md` — Direction A design (this doc supersedes Q2's grammar split; §12 supersedes Q1 signing model and the original §10 open questions)
+- `docs/design-internet-of-agentic-work.md` + `docs/plan-internet-of-agentic-work.md` — **the IoAW architectural baseline** for cortex federation (cortex#110 META; cortex#117 Phase E: multi-network bridges + delegation). The OSI scenarios in this doc assume the federation primitives from IoAW §3.3 (`stack → network → multi-network`, NATS leaf-node federation, peer registry, accept-rules) — see §13 below for the open seams that tie Scenarios 3/4/5 to IoAW phases.
 - `CONTEXT.md` — cortex vocabulary
 - myelin#160 — Originator field (policy attribution vs crypto provenance; **closed** — shipped as envelope-level `originator: { principal, attribution }`)
 
@@ -517,7 +518,8 @@ The mode bit lives in the envelope as a top-level `distribution_mode` field (NOT
 ## 13. Open seams (post-§12 resolution)
 
 - **Channel-topology config for Scenario 4 model B.** Adapter needs to know which Discord/Mattermost/Slack channels span principals. Open seam — filed as a separate cortex issue. Until resolved, Stage 4 ships with model A default (preserve Discord-as-bridge for cross-principal channels) and a per-channel opt-in for model B.
-- **NATS leaf-node federation preconditions.** Model B (and Scenario 5 cross-principal) require federated leaf nodes between principal pairs. Out of cortex's scope — covered by network operations work.
+- **NATS leaf-node federation preconditions — owned by IoAW Phase D/E (cortex#110, cortex#117).** Model B (and Scenario 5 cross-principal) require federated leaf nodes between principal pairs. This is NOT a design gap — `design-internet-of-agentic-work.md` §3.3 specifies the `stack → network → multi-network` composition; peer registry; accept-rules; the multi-`NatsLink` runtime extension. Direction A Stage 4 cutover for cross-principal traffic depends on IoAW Phase E being operationally available for the relevant principal pairs.
+- **Connection establishment + discovery is wider than a per-pair leaf-node link.** Per Andreas (2026-05-23): "principals + bots can be members of many deployments and networks". The IoAW design covers single-network and multi-network bridging; capability discovery (myelin#9 — L5) is acknowledged-open. Direction A doesn't introduce new requirements here — it consumes the IoAW federation primitives wherever they land.
 - **myelin `DistributionMode` rename (`'broadcast'` → `'offer'`).** Filed as a myelin-side issue (proposed in the C-405 corrections batch). cortex wraps the legacy spelling at the boundary until then.
 - **Originating-runtime self-subscription pattern for Scenario 5.** Luna initiates a chat to Echo and needs to consume Echo's reply (a `dispatch.task.completed` envelope with `correlation_id` matching her initial dispatch). The mechanism — subscribe-by-correlation_id vs subscribe-by-source-DID vs explicit `response_routing` populated with Luna's own address — is not yet codified. Filed as a follow-up.
 

--- a/docs/design-myelin-osi-scenarios.md
+++ b/docs/design-myelin-osi-scenarios.md
@@ -1,14 +1,13 @@
 # Myelin OSI Layer Model — Dispatch Scenarios
 
-**Status:** Pressure-test of the Direction A Q2 proposal against myelin's seven-layer protocol stack. Surfaces two corrections to `docs/design-platform-adapter-dispatch-publishing.md`.
-**Date:** 2026-05-22
-**Driver:** Andreas (pushback in #myelin) + Jens-Christian
+**Status:** Pressure-test of the Direction A Q2 proposal against myelin's seven-layer protocol stack. Surfaces four corrections to `docs/design-platform-adapter-dispatch-publishing.md`, adds Scenario 4 (cross-principal via shared platform surface) and Scenario 5 (bot-to-bot direct chat — the bus-native baseline). §12 has the locked answers for all four original §10 questions (Andreas, 2026-05-23 review); §14 captures the multi-subscriber / multi-surface pub-sub model.
+**Date:** 2026-05-22 (Scenarios 1–3 + §1–§9); 2026-05-23 (Scenario 4, §11 locked answers)
+**Driver:** Andreas (pushback in #myelin → §10/§11 locked answers) + Jens-Christian (Direction A grilling)
 **Related:**
-- `~/work/mf/myelin/docs/architecture.md` — canonical seven-layer model
-- `~/work/mf/myelin/specs/namespace.md` — subject grammar (Tasks Domain §, Originator §)
-- `docs/design-platform-adapter-dispatch-publishing.md` — Direction A design (this doc supersedes Q2's grammar split)
+- `the-metafactory/myelin` — canonical seven-layer model + namespace spec (`docs/architecture.md`, `specs/namespace.md`); `src/types.ts` ships `DistributionMode` + `AttributionMode` enums; `schemas/envelope.schema.json` carries the `originator` field
+- `docs/design-platform-adapter-dispatch-publishing.md` — Direction A design (this doc supersedes Q2's grammar split; §11 supersedes Q1 signing model and §10 open questions)
 - `CONTEXT.md` — cortex vocabulary
-- myelin#160 — Originator field (policy attribution vs crypto provenance)
+- myelin#160 — Originator field (policy attribution vs crypto provenance; **closed** — shipped as envelope-level `originator: { principal, attribution }`)
 
 ---
 
@@ -64,9 +63,9 @@ Source: `~/work/mf/myelin/docs/architecture.md` §2.
 
 ---
 
-## 4. Two corrections to Direction A
+## 4. Framing corrections to Direction A
 
-Surfaced by this exercise. Both update `docs/design-platform-adapter-dispatch-publishing.md`.
+Surfaced by this exercise. All three update `docs/design-platform-adapter-dispatch-publishing.md`: (4.1) the canonical wire grammar for Direct; (4.2) the conceptual framing that dispatch sources are pluggable and surfaces are not the medium; (4.3) the signing model (stack signs; adapter populates originator).
 
 ### 4.1 Subject grammar — Direct mode uses `tasks.@{assistant}.{capability}` not `dispatch.task.received`
 
@@ -82,7 +81,25 @@ This is the canonical wire grammar. `dispatch.task.received` is NOT a myelin-spe
 
 `dispatch.task.{action}` survives as lifecycle observability (started/completed/failed/aborted) — that's still cortex-owned vocabulary at M7.
 
-### 4.2 Signing — stack signs; adapter populates `originator.identity`
+### 4.2 Dispatch source is pluggable — surfaces are not the medium
+
+The original Direction A doc reads as if "platform adapter" is the canonical dispatch source. That is a framing error. **The bus is the medium; the platform surface (Discord, Mattermost, Slack, dashboard, PagerDuty) is a sink, optionally also a source.** A dispatch source is anything that publishes onto a `tasks.@{assistant}.{capability}` subject with a properly-signed envelope. Five concrete source classes:
+
+| Source class | Originator field | Scope picker | Typical capability |
+|---|---|---|---|
+| Platform adapter (human→bot, e.g. Discord/Mattermost/Slack) | `principal = did:mf:<human-did>`, `attribution = "adapter-resolved"` | adapter chooses `local.` or `federated.` per channel topology | `chat`, plus typed workloads (`code-review`, …) |
+| Another assistant's runtime (bot→bot autonomous) | **omitted** — signer IS the actor (myelin spec: peer-to-peer envelopes omit `originator`) | runtime picks scope from target principal: same → `local.`; different → `federated.` | `chat`, `code-review.*`, `release`, … any |
+| Another assistant via delegation chain (bot→bot re-issued) | preserved from upstream envelope, `attribution = "delegated"` | follows target principal as above | any |
+| MC dashboard "send task" action | adapter-resolved (the principal at the console) | dashboard's adapter picks | any |
+| Tap / webhook (e.g. `gh-webhook` for GitHub events) | adapter-resolved (the platform identity bound to the tap) | tap's config | `code-review`, `release`, … |
+
+**The `chat` capability is bus-native, not surface-bound.** An assistant declaring `chat` is saying "I accept free-form conversational dispatches"; it doesn't care which class of source originated the envelope. The signer is always the stack (per §4.3); originator + scope vary by source class.
+
+`dispatch-handler.ts` (legacy) only addressed one path — adapter→handler in-process — and conflated medium with surface. Direction A makes the bus-native path canonical for ALL source classes.
+
+---
+
+### 4.3 Signing — stack signs; adapter populates `originator.identity`
 
 The Direction A grilling pinned Q1a as *"adapter signs envelopes as the hosted agent (uses agent's nkey)"*. Per myelin#160 and Andreas's 2026-05-22 channel post, this is **the wrong model**. The canonical chain is:
 
@@ -96,9 +113,9 @@ Cortex Q1a updates: **stack signs; adapter populates `originator`**. The adapter
 
 ---
 
-## 5. Scenario 1 — Discord user → Luna (intra-stack Direct)
+## 5. Scenario 1 — Human-originated Direct via platform adapter (Discord example)
 
-A Discord user mentions Luna in #cortex. Luna runs as an assistant on the same stack (`andreas/meta-factory`).
+**One source class of many** (see §4.3). A Discord user mentions Luna in #cortex; the Discord adapter is the dispatch source. Same shape applies to Mattermost/Slack/MC dashboard adapters when a human originates. Luna runs as an assistant on the same stack (`andreas/meta-factory`).
 
 ```mermaid
 sequenceDiagram
@@ -256,7 +273,184 @@ sequenceDiagram
 
 ---
 
-## 8. Restated Q2
+## 8. Scenario 4 — Cross-principal via shared platform surface (Discord example)
+
+**This scenario covers the legacy bridging pattern that Direction A retires.** Scenario 3 above covers _explicit_ cross-principal Direct dispatch (a bot on andreas explicitly addresses a bot on metafactory). What Direction A's original grilling missed was the pre-Direction-A reality: **shared platform channels (Discord) were the de-facto federation bridge for multi-principal collaboration**. Scenario 5 below covers the canonical post-Direction-A pattern (bot-to-bot direct on the bus, no surface in the middle).
+
+### 8.1 The problem
+
+Today (pre-Direction-A), Andreas and Jens-Christian collaborate in shared Discord channels. Each runs their own cortex stack (`andreas/meta-factory`, `jcfischer/meta-factory` — two principals, two stacks). Both of their adapter instances subscribe to the same Discord channel. Discord IS the federation bridge — the platform smuggles cross-principal traffic across as an application-layer side-channel.
+
+Direction A removes the smuggling: adapters become **dispatch sources** publishing onto the bus. But `local.{principal}.{stack}.…` by definition NEVER leaves the principal. So under Direction A, when JC posts `@luna hello` in a shared channel:
+
+- Andreas's adapter publishes `local.andreas.meta-factory.tasks.@did-mf-luna.chat` — invisible to JC's stack
+- JC's adapter publishes `local.jcfischer.meta-factory.tasks.@did-mf-luna.chat` — invisible to Andreas's stack
+
+If `@luna` is hosted on Andreas's stack only, JC's bot can't reach her. The bus is two separate islands. The OSI lens makes this obvious: `local.` is per-deployment, like a private subnet. Cross-principal traffic MUST be `federated.` to route at all — that's the L3-routing equivalent ("the MAC addresses aren't on the same network").
+
+### 8.2 Three candidate models
+
+| Model | Where federation lives | Trade-off |
+|-------|------------------------|-----------|
+| **A. Surface-as-federation (status quo carried forward)** | Discord stays the bridge. Each adapter publishes `local.…` for its own stack only. Cross-principal collaboration happens on Discord, never on the bus. | Zero new infra. Direction A's premise (bus owns dispatch routing) is partly negated — the bus doesn't replace Discord-as-bridge for the common case. |
+| **B. Federation by default for multi-principal channels (RECOMMENDED)** | Adapter knows channel topology. For any channel that includes peer-principal assistants, the adapter publishes on `federated.{principal}.{stack}.tasks.@{assistant}.{capability}` instead of `local.…`. Trust roots span. NATS leaf-nodes federate. | The bus genuinely owns dispatch routing. Requires (i) NATS leaf-node federation between participating principals (M1), (ii) cross-principal trust roots (M4), (iii) channel-topology config in the adapter (M7), (iv) per-channel scope decision logic in the adapter (M7). |
+| **C. Asymmetric host** | One principal "owns" the shared channel adapter; other principals' bots subscribe via `federated.…` to that adapter's published tasks. | Asymmetric, conflicts with peer-collaboration model. Wrong for the JC↔Andreas case where both contribute bots. |
+
+### 8.3 Recommended model B — federation by default
+
+```mermaid
+sequenceDiagram
+  autonumber
+  participant U as JC (Discord user, did:mf:jc)
+  participant DJC as Discord adapter — jcfischer stack (M7)
+  participant Eb as Envelope build (M3, jcfischer side)
+  participant Ib as Stack signer — jcfischer-stack (M4)
+  participant Nb as NATS leaf — jcfischer (M1)
+  participant FED as Federation bridge (M1)
+  participant Na as NATS leaf — andreas (M1)
+  participant SOV as Sovereignty enforcer (M3, andreas)
+  participant V as Chain verifier — andreas (M4)
+  participant La as dispatch-listener — andreas (M7)
+  participant H as Luna's harness (M6, andreas)
+  participant DA as Discord adapter — andreas stack (M7)
+
+  U->>DJC: @luna hello (Discord message in #shared)
+  DJC->>DJC: lookup channel topology<br/>#shared includes peer-principal assistants<br/>→ scope = federated
+  DJC->>Eb: build envelope<br/>type: tasks.chat<br/>target_assistant: did:mf:luna<br/>originator.identity: did:mf:jc<br/>originator.attribution: adapter-resolved<br/>classification: federated<br/>sovereignty: { data_residency, max_hop }
+  Eb->>Eb: derive subject:<br/>federated.jcfischer.meta-factory.tasks.@did-mf-luna.chat
+  Eb->>Ib: runtime.publish
+  Ib->>Ib: stack signs<br/>signed_by[0].identity: did:mf:jcfischer-stack<br/>signature covers originator
+  Ib->>Nb: NATS publish
+  Nb->>FED: federation export (federated.* prefix)
+  FED->>Na: federation import
+  Na->>SOV: sovereignty check<br/>(does andreas accept jcfischer's classification?)
+  SOV-->>Na: ok
+  Na->>V: deliver to subscribers matching<br/>federated.*.*.tasks.@did-mf-luna.>
+  V->>V: verify signed_by chain<br/>against andreas's trust roots<br/>(jcfischer-stack key trusted by andreas)
+  V->>La: deliver envelope
+  La->>La: policy gate<br/>originator = did:mf:jc<br/>capability check against jc's caps
+  La->>H: harness.dispatch(req)
+  H-->>La: yield dispatch.task.started, …, dispatch.task.completed
+  La->>Ib: publish lifecycle on federated.andreas.meta-factory.dispatch.task.*
+  Note over La,DA: BOTH adapters (jcfischer's + andreas's) subscribe to<br/>federated.*.*.dispatch.task.{started|completed|failed|aborted}<br/>filtered by response_routing.adapter_instance + correlation_id<br/>→ JC's adapter posts Luna's response back to #shared
+  DA->>DA: (silent — response_routing.adapter_instance doesn't match)
+  DJC->>U: postResponse(#shared, Luna's reply)
+```
+
+### 8.4 Layer summary for Scenario 4 (model B)
+
+| Step | Layer | Concern |
+|------|-------|---------|
+| 1 | M7 (platform) | User posts in shared Discord channel |
+| 2 | M7 (adapter) | **Channel-topology lookup is the key new step.** Adapter knows which channels span principals and chooses `federated.` accordingly. |
+| 3–4 | M3 | Envelope built with `federated.` classification; sovereignty populated |
+| 5–6 | M4 | jcfischer stack signs; `originator.identity = did:mf:jc, attribution = adapter-resolved` |
+| 7–9 | M1 | Federation bridge routes across principal boundary (the actual L3 hop) |
+| 10 | M3 | Receiving principal enforces sovereignty rules |
+| 11–12 | M4 | Cross-principal chain verify (different trust roots than intra-principal) |
+| 13 | M7 | Policy gate on receiving principal — does JC's identity have capabilities here? |
+| 14 | M6 | Luna's harness executes on andreas's stack |
+| 15–16 | M7 / M1 | Lifecycle envelopes federate back to originator's principal |
+| 17 | M7 (sink) | Each principal's dispatch sinks subscribe to `federated.*.*.dispatch.task.*` and filter by `response_routing.adapter_instance` to deliver back to the originating surface |
+
+### 8.5 Implications
+
+- **Federation is the norm, not the exception, for multi-principal collaboration.** Every chat involving a peer-principal assistant must publish `federated.` from the start. The current Direction A design defaults to `local.` — incomplete.
+- **Channel-topology config is a new M7 concern.** The adapter must know which channels include peer-principal assistants. Two viable shapes: (i) explicit `cortex.yaml` per-channel config; (ii) Discord guild/role lookup that resolves to a peer-principal mapping. Open seam — see §10 below.
+- **Trust roots must span.** Andreas's verify path must trust JC's stack key (and vice versa) — `TrustResolver` configuration that follows the network membership graph. The mechanism already exists for Scenario 3; Scenario 4 just exercises it as a hot path.
+- **NATS leaf-node federation is a prerequisite.** Pre-condition for model B: the leaf nodes for participating principals are actually federated (config-level NATS work, not cortex work). If federation isn't configured between two principals, Direction A Stage 4 falls back to model A for that pair (Discord stays the bridge for them).
+- **Stage 4 in Direction A migration sequence needs both modes.** Default model A (preserve today's behavior); enable model B per-channel once federation is configured for the relevant principal pair. Sub-issue #409 (Stage 4) is updated accordingly.
+
+### 8.6 Why model B over model A
+
+Model A (Discord-as-federation) is the safe v0 — zero new infrastructure. But it contradicts Direction A's stated premise: that the bus owns dispatch routing and platforms are reduced to UI surfaces. Under model A, the surface is still smuggling traffic the bus refuses to carry, which means cortex's federation guarantees (sovereignty, attestable trust chains, cross-principal policy enforcement) don't apply to the most common cross-principal flow.
+
+The OSI discipline makes this stark: **`local.` is L2 (one broadcast domain); `federated.` is L3 (cross-network routing).** Pretending peer-to-peer traffic is L2 because it shares an L7 channel (Discord) is exactly the layering violation the OSI exercise was meant to surface.
+
+Model B is the only model that delivers what Direction A claims. Model A is the fallback for principal pairs whose federation isn't configured yet — explicit "this is incomplete" not a permanent design.
+
+---
+
+## 9. Scenario 5 — Bot-to-bot direct chat (bus-native, no surface)
+
+**The canonical case for post-Direction-A multi-assistant collaboration.** No platform adapter. No Discord. One assistant decides to start a conversation with another assistant; its runtime publishes onto the bus directly; the target assistant's harness processes it; lifecycle envelopes flow back to whichever sinks happen to be subscribed (a dashboard, a logger, possibly the originating runtime, possibly nothing at all).
+
+This is what §4.3 calls "another assistant's runtime" as a dispatch source. The bus does not require a surface to be involved.
+
+### 9.1 The setup
+
+Luna runs on `andreas/meta-factory`. She's working on a PR and decides she wants Echo's read on the security boundary. Echo runs on `jcfischer/meta-factory` (different principal). Luna's runtime initiates a chat dispatch to Echo. No human in the loop; no Discord channel; the only surface that renders anything is the Mission Control dashboard on each principal, which subscribes broadly to lifecycle envelopes.
+
+### 9.2 The flow
+
+```mermaid
+sequenceDiagram
+  autonumber
+  participant LA as Luna's harness (M6, andreas)
+  participant LR as Luna's runtime (M7, andreas — initiator)
+  participant Eb as Envelope build (M3)
+  participant Ib as Stack signer — andreas-stack (M4)
+  participant Na as NATS leaf — andreas (M1)
+  participant FED as Federation bridge (M1)
+  participant Nb as NATS leaf — jcfischer (M1)
+  participant V as Chain verifier — jcfischer (M4)
+  participant Lb as dispatch-listener — jcfischer (M7)
+  participant EH as Echo's harness (M6, jcfischer)
+  participant DA as MC dashboard sink — andreas (M7, observer)
+  participant DB as MC dashboard sink — jcfischer (M7, observer)
+
+  LA->>LR: yield envelope:<br/>"want Echo's read on the security boundary"
+  LR->>Eb: build envelope<br/>type: tasks.chat<br/>target_principal: did:mf:echo<br/>distribution_mode: direct<br/>originator: omitted (signer = actor)<br/>classification: federated
+  Eb->>Eb: derive subject:<br/>federated.andreas.meta-factory.tasks.@did-mf-echo.chat
+  Eb->>Ib: runtime.publish
+  Ib->>Ib: stack signs<br/>signed_by[0].principal: did:mf:andreas-stack
+  Ib->>Na: NATS publish
+  Na->>FED: federation export (federated.* prefix)
+  FED->>Nb: federation import
+  Nb->>V: deliver to subscribers matching<br/>federated.*.*.tasks.@did-mf-echo.>
+  V->>V: verify chain against jcfischer trust roots<br/>(andreas-stack key trusted by jcfischer)
+  V->>Lb: deliver envelope
+  Lb->>Lb: policy gate<br/>signer = andreas-stack (originator omitted, signer IS actor)<br/>capability check against andreas-stack's caps
+  Lb->>EH: harness.dispatch(req)
+  EH-->>Lb: yield dispatch.task.started, …, dispatch.task.completed (with Echo's chat reply)
+  Lb->>Ib: publish lifecycle on federated.jcfischer.meta-factory.dispatch.task.*
+  Note over Lb,DA: Lifecycle envelopes fan out via NATS pub/sub<br/>to ALL subscribers matching the subject pattern
+  Lb->>DB: jcfischer dashboard renders the response
+  Lb->>DA: federation bridge → andreas dashboard renders the response
+  Lb->>LR: federation bridge → Luna's runtime consumes the reply<br/>(she subscribes to dispatch.task.completed filtered by correlation_id<br/>= the dispatch she initiated)
+  LR->>LA: feed reply back into Luna's session<br/>(she continues working with Echo's input)
+```
+
+### 9.3 Layer summary for Scenario 5
+
+| Step | Layer | Concern |
+|------|-------|---------|
+| 1 | M7 | Luna's harness decides to initiate — application-layer choice |
+| 2–3 | M3 | Envelope built with `federated.` classification; **`originator` omitted** because Luna's stack IS the policy actor (peer-to-peer rule per myelin spec) |
+| 4 | M2 | Publish onto NATS |
+| 5 | M4 | Stack signs |
+| 6–8 | M1 | Federation bridge — cross-principal routing |
+| 9–10 | M4 | Cross-principal chain verify |
+| 11 | M7 | Policy gate — recipient principal decides whether andreas-stack's caps apply here |
+| 12 | M6 | Echo's harness executes |
+| 13–14 | M7 / M1 | Lifecycle envelopes federate back; pub/sub fans out to N subscribers |
+| 15 | M7 (sink) | Originating runtime consumes the reply via `correlation_id` filter |
+
+### 9.4 What's NOT in this flow
+
+- **No platform adapter.** No Discord adapter publishes; no Discord adapter subscribes.
+- **No `originator` field.** Luna's stack is the actor; the spec omits originator when signer = actor.
+- **No special bot-to-bot wire form.** Same subject (`tasks.@{assistant}.chat`); same envelope schema; same chain verify. The runtime is just another dispatch source class (§4.3).
+
+### 9.5 Why this is the architectural baseline
+
+Direction A's original framing reads as "platform adapter → bus → listener → harness". That's a real path (Scenario 1) but it's the *humans entering the bus* path. **The bus's existence is justified by Scenario 5** — bots talking to bots, surfaces optional. If the only thing the bus ever did was forward Discord messages to harnesses, you wouldn't need a bus; you'd just call functions in-process (which is exactly what legacy `dispatch-handler.ts` does).
+
+The `chat` capability is the assistant's bus-native interface for free-form conversation. Adapters bridge humans onto it. Bots use it directly. Same wire grammar in both cases.
+
+---
+
+## 10. Restated Q2
 
 | Question | Old answer (incorrect) | New answer |
 |----------|-------------------------|------------|
@@ -265,7 +459,7 @@ sequenceDiagram
 
 ---
 
-## 9. Implications for Direction A
+## 11. Implications for Direction A
 
 The migration sequence in `docs/design-platform-adapter-dispatch-publishing.md` §7 needs updates:
 
@@ -288,9 +482,76 @@ Lifecycle subjects (`dispatch.task.{action}`) are unchanged — those are cortex
 
 ---
 
-## 10. Open questions for Andreas / Luna
+## 12. Locked answers to the four original §10 questions (Andreas, 2026-05-23)
 
-1. **Cortex's existing `dispatch.task.received` subscription** — is this legacy pre-spec, or is there a reason the listener subscribes there instead of `tasks.>`? Affects whether Stage 7 of Direction A also deletes the existing subscription.
-2. **Capability token for free-form chat** — myelin's seed taxonomy lists `code-review`, `security-scan`, `deploy`, `release`. For a Discord `@cortex hello` message, we need a `chat` capability or a `conversation` capability. Cortex-side extension; check naming.
-3. **`originator.attribution` enum** — myelin#160 mentions `"adapter-resolved"`. Are other values defined? (e.g. `"self"` for peer-to-peer, `"delegated"` for re-issued envelopes?)
-4. **`Delegate` vs `Direct` at the wire** — namespace.md says they share the same subject shape; mode difference is principal-facing. Where does the mode bit live — payload or sovereignty block? Affects whether the listener can route to AgentTeamHarness via subject filter or must inspect payload.
+The original §10 raised four open questions. Three were already settled in shipped myelin code; the fourth is a cortex-side decision. All four are locked here so Direction A can move past Stage 0.
+
+### Q1 — Cortex's existing `dispatch.task.received` subscription
+**Verdict: LEGACY.** Treated as pre-spec. The listener's `dispatch.task.received` subscription was canonical pre-namespace-finalisation; the canonical wire grammar (per `myelin/specs/namespace.md` §Tasks Domain) is `tasks.@{did-encoded-assistant}.{capability}` for Direct. Tests under `src/__tests__/iaw-phase-d-integration.test.ts` and `src/__tests__/cortex.test.ts` are load-bearing on the legacy subject and must be updated as part of Stage 7. **Path forward (Stage 7):** add `tasks.>` subscription alongside the legacy one for one release; flip adapter-side publishing to canonical subjects (Stages 4–6); remove the legacy subscription + update the IAW Phase D tests; release notes flag the wire-grammar change.
+
+### Q2 — Capability token for free-form chat
+**Verdict: ADD `chat`.** Free-form Discord/Mattermost/Slack `@assistant <message>` interactions publish on `tasks.@{did-encoded-assistant}.chat`. `chat` becomes a first-class capability in myelin's seed taxonomy (alongside `code-review`, `security-scan`, `deploy`, `release`). Cortex (the metafactory team _is_ the myelin team) lands the taxonomy extension as part of the next myelin release — not an external blocker.
+
+### Q3 — `originator.attribution` enum values
+**Verdict: ALREADY SHIPPED.** `myelin/src/types.ts:28` already declares:
+```ts
+export type AttributionMode = 'adapter-resolved' | 'federated' | 'delegated';
+```
+And `myelin/src/envelope.ts:50` enforces the closed set at validation:
+```ts
+const ATTRIBUTION_MODES = new Set(['adapter-resolved', 'federated', 'delegated']);
+```
+Direction A Stage 4 uses `adapter-resolved` for adapter-originated dispatches; Scenario 4 (federated-by-default) uses the same value (the originator is still resolved by an adapter — the federation is a transport concern, not an attribution concern). `federated` and `delegated` are the values that apply when re-issuing or forwarding envelopes; not in scope for Direction A v1.
+
+### Q4 — Direct vs Delegate at the wire
+**Verdict: ALREADY SHIPPED in `distribution_mode` field.** `myelin/src/types.ts:13`:
+```ts
+export type DistributionMode = 'broadcast' | 'direct' | 'delegate';
+```
+The mode bit lives in the envelope as a top-level `distribution_mode` field (NOT in the subject, NOT in the sovereignty block). The validator (`myelin/src/envelope.ts:210`) enforces `target_principal` required when `distribution_mode ∈ {direct, delegate}`. Direct and Delegate share subject shape (`tasks.@{assistant}.{capability}`); the listener routes to `AgentTeamHarness` for `delegate` after the subject + assistant-DID filter has already matched. One field read on the listener side; no payload introspection beyond what is already in place.
+
+**Terminology note (cross-repo):** `DistributionMode` enum still ships `'broadcast'` as its first value. cortex `CONTEXT.md` (Flagged Ambiguities) explicitly canonicalised this concept to `Offer` and says "never call the Offer mode 'broadcast'". This is a pending myelin-side rename, filed separately. cortex code that consumes `distribution_mode` should map `'broadcast'` → cortex's `Offer` at the boundary until myelin renames.
+
+---
+
+## 13. Open seams (post-§12 resolution)
+
+- **Channel-topology config for Scenario 4 model B.** Adapter needs to know which Discord/Mattermost/Slack channels span principals. Open seam — filed as a separate cortex issue. Until resolved, Stage 4 ships with model A default (preserve Discord-as-bridge for cross-principal channels) and a per-channel opt-in for model B.
+- **NATS leaf-node federation preconditions.** Model B (and Scenario 5 cross-principal) require federated leaf nodes between principal pairs. Out of cortex's scope — covered by network operations work.
+- **myelin `DistributionMode` rename (`'broadcast'` → `'offer'`).** Filed as a myelin-side issue (proposed in the C-405 corrections batch). cortex wraps the legacy spelling at the boundary until then.
+- **Originating-runtime self-subscription pattern for Scenario 5.** Luna initiates a chat to Echo and needs to consume Echo's reply (a `dispatch.task.completed` envelope with `correlation_id` matching her initial dispatch). The mechanism — subscribe-by-correlation_id vs subscribe-by-source-DID vs explicit `response_routing` populated with Luna's own address — is not yet codified. Filed as a follow-up.
+
+---
+
+## 14. Multi-subscriber / multi-surface delivery model
+
+The OSI scenarios all draw a single sink consuming each lifecycle envelope. **In NATS this is incidental** — subject delivery is pub/sub by default. Every subscriber whose subject filter matches receives every envelope independently. This has direct consequences for cortex's surface model.
+
+### 14.1 Routed vs observer subscribers
+
+Two classes of dispatch sink, by intent:
+
+| Class | Subject filter | Behaviour |
+|---|---|---|
+| **Routed sink** | `dispatch.task.{action}` filtered by `response_routing.adapter_instance` matching its own instance ID | Renders only the envelopes it originated. The Discord adapter that sourced a chat posts the reply back to the originating channel; other Discord adapter instances see the envelope but their filter doesn't match — they no-op. |
+| **Observer sink** | broad subscription (e.g. `dispatch.task.completed` for everything; or `tasks.>` for everything; or scoped to a principal/stack) — no `response_routing` filter | Always reacts. Mission Control dashboard renders every dispatch on its principal. A logging tap captures everything. A PagerDuty sink only reacts to `dispatch.task.failed`. |
+
+**The same lifecycle envelope can have N subscribers of both classes simultaneously.** A bot-originated chat (Scenario 5) reaches both the originating runtime (via routed-by-correlation_id subscription) AND both principals' dashboards (observer subscription) AND any tap that happens to be active. No fan-out is configured at the publisher — fan-out happens at NATS subject delivery.
+
+### 14.2 Multi-surface primary delivery (deferred design seam)
+
+A separate question — surfaced by Andreas during the C-405 review — is whether ONE dispatch should produce primary delivery to MULTIPLE surfaces. Example: a chat originates on Discord channel A, but the operator also wants the reply to render in Mattermost channel B (because the team uses Mattermost for archival and Discord for live chat). The bus already supports this via observer subscriptions, but observer mode is "always render"; what the operator wants is "for THIS dispatch, also primary-deliver to these other places".
+
+Three viable mechanisms:
+
+| Mechanism | How | Cost |
+|---|---|---|
+| **A. `response_routing` becomes a list of channel addresses** | Inbound envelope payload carries `response_routing: ChannelAddress[]`. Each routed sink subscribes to its instance-ID slot. | Schema change to `response_routing`. Adapter-side fan-out logic. |
+| **B. Per-dispatch `mirror_to` field** | Originating dispatch source declares `mirror_to: [addr1, addr2]`. Sinks subscribe by mirror declaration. | New envelope field. Requires every source to know about mirrors. |
+| **C. Observer sinks with subject-derived rendering rules** | Mirror configuration lives in the sink, not the envelope. Mattermost adapter is configured to render every `tasks.@luna.>` from `andreas/meta-factory` (regardless of source). | Configuration grows; cleaner separation of concerns. Risk of accidental over-rendering. |
+
+**Recommendation: C for v1.** Don't change the envelope schema; let sinks self-subscribe with rendering rules. Revisit A or B if sink-side configuration proves too distributed to manage. Not blocking Direction A — every adapter today does single-primary-delivery just fine.
+
+### 14.3 Implication for Stage 4 / Stage 5
+
+Stage 4 (adapter publishes inbound) and Stage 5 (adapter subscribes to lifecycle) don't need to change to support the multi-subscriber model — NATS already provides fan-out. What WOULD change for multi-surface primary delivery is a future Stage 8+ that lands rendering rules on the sinks. Not in scope for the v1 cutover.

--- a/docs/design-platform-adapter-dispatch-publishing.md
+++ b/docs/design-platform-adapter-dispatch-publishing.md
@@ -9,6 +9,7 @@
 - `src/common/substrates/types.ts` — `SessionHarness` interface (already in place)
 - `docs/architecture.md` — M1–M7 stack model
 - `docs/plan-cortex-migration.md` — migration phase plan
+- `docs/design-internet-of-agentic-work.md` + `docs/plan-internet-of-agentic-work.md` — **federation baseline** (cortex#110 META; cortex#117 Phase E). Direction A's `federated.` publishing depends on the IoAW peer-registry + leaf-node primitives; channel-topology config (Stage 4 model B) is the cortex-side UX that decides when an adapter publishes federated vs local.
 
 ---
 

--- a/docs/design-platform-adapter-dispatch-publishing.md
+++ b/docs/design-platform-adapter-dispatch-publishing.md
@@ -1,8 +1,8 @@
 # Platform Adapter Dispatch Publishing — Design Spec
 
-**Status:** Skeleton — surfaced from `/improve-codebase-architecture` grilling on the dispatch-handler / dispatch-listener seam (2026-05-22).
-**Date:** 2026-05-22
-**Driver:** Jens-Christian
+**Status:** Direction A locked. Skeleton surfaced from `/improve-codebase-architecture` grilling on the dispatch-handler / dispatch-listener seam (2026-05-22). Q1, Q2, signing model, and all four §10 questions corrected via [`docs/design-myelin-osi-scenarios.md`](./design-myelin-osi-scenarios.md) §11 (Andreas, 2026-05-23). See §11 of that doc for the locked answers; this doc has been edited inline to reflect them.
+**Date:** 2026-05-22 (original); 2026-05-23 (OSI corrections + Scenario 4)
+**Driver:** Jens-Christian (original); Andreas (OSI corrections)
 **Scope:** Cortex `src/adapters/*`, `src/bus/dispatch-handler.ts`, `src/runner/dispatch-listener.ts`, `src/substrates/*`, `src/renderers/*`. Touches MIG-7.2 (agent identity model) as pre-requisite.
 **Related:**
 - `CONTEXT.md` — dispatch source / dispatch sink / substrate harness / response routing
@@ -21,25 +21,31 @@ Today two parallel code paths drive Claude Code dispatches:
 
 Same word ("dispatch") in both files, different roles, different generation. The listener already lives behind the substrate-harness seam (`SessionHarness`). The handler does not — it still spawns `CCSession` directly and owns `AgentTeam` / `SessionManager` / `TaskTracker` / heartbeat inline.
 
-This spec proposes **Direction A**: platform adapters become **dispatch sources** that publish inbound dispatch envelopes onto the bus. The existing `dispatch-listener` consumes all dispatches regardless of origin (platform message or peer bot). `dispatch-handler.ts` retires.
+This spec proposes **Direction A**: platform adapters become **dispatch sources** that publish inbound dispatch envelopes onto the bus. The existing `dispatch-listener` consumes all dispatches regardless of origin. `dispatch-handler.ts` retires.
+
+**Framing note (per OSI §4.2):** "platform adapter" is one class of dispatch source — the one this spec is named after — but it is not the only one. Five source classes coexist on the bus: (1) platform adapters (human→bot, Discord/Mattermost/Slack/etc.), (2) other assistants' runtimes (bot→bot autonomous; OSI Scenario 5 is the canonical case), (3) other assistants via delegation chain (bot→bot re-issued), (4) MC dashboard "send task" actions, (5) taps/webhooks (e.g. `gh-webhook`). The bus is the medium; surfaces are pluggable sources and/or sinks. Direction A retires the adapter-specific legacy in-process path (`dispatch-handler.ts`) and makes the bus-native path canonical for ALL source classes — including the ones that don't involve a platform surface at all.
 
 ---
 
 ## 2. Direction A in one diagram
 
 ```
-            Discord/Mattermost/Slack message
-                       │
-                       ▼
-              ┌─────────────────────┐
-              │ Platform adapter    │  ◄── dispatch source (CONTEXT.md)
-              │ (signs as agent)    │
-              └──────────┬──────────┘
-                         │ publishes
-                         ▼
-       local.{principal}.{stack}.dispatch.task.received
-                         │
-                         ▼
+   ┌─────────────────────────────────────────────────────────────────────────┐
+   │ Dispatch source (any of):                                                │
+   │   • Platform adapter — Discord / Mattermost / Slack message (human→bot)  │
+   │   • Another assistant's runtime — bot→bot direct (OSI Scenario 5)        │
+   │   • Delegation re-issue — bot→bot with preserved originator              │
+   │   • MC dashboard "send task" action                                      │
+   │   • Tap / webhook (e.g. gh-webhook for GitHub events)                    │
+   └────────────────────────────────┬────────────────────────────────────────┘
+                                    │ stack signs;
+                                    │ source populates originator (or omits)
+                                    ▼
+       local.{principal}.{stack}.tasks.@{did-encoded-assistant}.{capability}
+            (or federated.{principal}.{stack}.tasks.@…
+             for cross-principal — see OSI Scenarios 3, 4, 5)
+                                    │
+                                    ▼
               ┌─────────────────────┐
               │ dispatch-listener   │  ◄── existing
               │ (policy + trust)    │
@@ -52,19 +58,22 @@ This spec proposes **Direction A**: platform adapters become **dispatch sources*
                          │ yields lifecycle envelopes
                          ▼
        local.{principal}.{stack}.dispatch.task.{started|completed|failed|aborted}
-                         │
-                         ▼
-              ┌─────────────────────┐
-              │ Platform adapter    │  ◄── dispatch sink (CONTEXT.md)
-              │ (subscribes by      │
-              │  response_routing)  │
-              └─────────────────────┘
-                         │
-                         ▼
-            Platform response (postResponse / sendProgress)
+                                    │
+                                    │ NATS pub/sub fan-out — N subscribers
+                                    ▼
+   ┌─────────────────────────────────────────────────────────────────────────┐
+   │ Dispatch sinks (any subset of):                                          │
+   │   • Originating platform adapter — filtered by response_routing.adapter  │
+   │     _instance + correlation_id → renders reply to originating channel    │
+   │   • Originating runtime — for bot-originated chats, consumes reply by    │
+   │     correlation_id to continue its session                               │
+   │   • MC dashboard — observer; always renders                              │
+   │   • Logging tap, audit tap, PagerDuty (on failed) — observers            │
+   │   • Cross-principal mirror — federation bridge fans envelopes out        │
+   └─────────────────────────────────────────────────────────────────────────┘
 ```
 
-Adapter plays two roles: **dispatch source** (inbound) and **dispatch sink** (outbound).
+**Routed sinks** filter by `response_routing` (only react when targeted); **observer sinks** subscribe broadly (always render). The same envelope can have N of each. See OSI §14 for the multi-subscriber model. A platform adapter typically plays both source (inbound) and routed-sink (outbound) roles; bus-native bot sources subscribe to lifecycle envelopes by `correlation_id` rather than `response_routing`.
 
 ---
 
@@ -108,28 +117,31 @@ Adapter registers a SurfaceAdapter on `dispatch.task.{started|completed|failed|a
 
 | # | Decision | Rationale |
 |---|----------|-----------|
-| Q1a | Adapter signs envelopes as the hosted agent | Matches existing trust model; first signer = hosted agent's nkey. Pre-requisite: MIG-7.2 (adapter holds an `agent` not legacy BotConfig). |
-| Q2 | Cortex owns M7 dispatch subject grammar; myelin owns transport grammar | Subject *segments* `dispatch.task.{action}` and `tasks.{capability}` are application-layer (cortex M7). Subject *prefix* `{scope}.{principal}.{stack}` + signed_by + envelope schema are myelin. Confirm with myelin team. |
+| **Q1 (corrected)** | **Stack signs the envelope via `runtime.publish` (using stack NKey). Adapter populates `originator.identity` with the resolved human/agent DID and `originator.attribution = "adapter-resolved"`.** | Per myelin#160 (CLOSED) and OSI Scenario 1. Cryptographic signer (stack) and policy actor (originator) are cleanly separated — both attestable, both inside the signature. Supersedes the original Q1a "adapter signs as hosted agent" decision. |
+| **Q2 (corrected)** | **Myelin owns the subject grammar at every layer M1–M6, including the Tasks-domain subgrammar (`tasks.@{assistant}.{capability}` for Direct/Delegate; `tasks.{capability}.{subcapability}` for Offer). Cortex owns the VALUES it populates (capability tokens, dispatch mode choice per workload, persona) and the SEMANTICS of cortex-specific application events (`dispatch.task.{action}` lifecycle envelopes).** | Per `myelin/specs/namespace.md` §Tasks Domain. cortex's prior `dispatch.task.received` inbound subject was pre-spec; canonical is `tasks.@{did-encoded-assistant}.{capability}`. Supersedes the original Q2 "cortex owns M7 dispatch subject grammar" decision. |
 | Q3a | Stateless response routing on the wire | Inbound envelope payload carries `response_routing`. Listener echoes onto all lifecycle envelopes. Dispatch sink reads routing → posts. No in-memory `correlation_id → ResponseTarget` map. |
 | Q4a | Inline base64 attachments in envelope payload | Federation-friendly (info flows back across stacks). Accepted cost: envelope bloat. Q4b (federated CAS) deferred. |
 | Q5c | Two-pass access: adapter coarse + listener fine-grained | Adapter retains "may this principal speak at all" guard. Listener's policy-engine owns "what tools may this dispatch use". Q5b (policy-engine sole authority) is the long-term destination — filed as follow-up. |
-| Q6c | AgentTeam-as-harness (new `HarnessId = "agent-team"`) | Delegate dispatch mode maps onto a meta-harness that composes single-agent harnesses. Listener stays substrate-agnostic. |
+| Q6c | AgentTeam-as-harness (`HarnessId = "agent-team"`) | Delegate dispatch mode maps onto a meta-harness that composes single-agent harnesses. Listener stays substrate-agnostic. Mode routing reads `envelope.distribution_mode === 'delegate'` (top-level field, already in myelin shipped enum) — see OSI §11 Q4. |
 | Q7a + Q7c | Phased: Discord first behind a base class | Build envelope-publishing helpers into an adapter base; Discord adopts envelope mode behind a feature flag; mattermost + slack follow once Discord is stable. |
+| **Federation default (new — OSI Scenario 4)** | **Stage 4 ships with model A default (Discord-as-bridge for cross-principal channels); per-channel opt-in to model B (federation-by-default) for principal pairs whose NATS leaf nodes are federated.** | Per OSI Scenario 4 §8.3 / §8.5. `local.` is per-deployment; cross-principal traffic MUST use `federated.` to route. Channel-topology config in adapter resolves which channels publish federated. Filed as separate cortex issue (precondition for full Stage 4 rollout). |
 
 ---
 
 ## 5. Subject grammar
 
-Per `CONTEXT.md` updates from this grilling:
+Per myelin canonical grammar (`myelin/specs/namespace.md` §Tasks Domain) and `CONTEXT.md`:
 
 | Mode | Inbound subject | Lifecycle subject |
 |------|-----------------|--------------------|
-| Direct (intra-stack) | `dispatch.task.received` | `dispatch.task.{started|completed|failed|aborted}` |
-| Direct (peer-to-peer) | `dispatch.task.dispatched` | same |
-| Offer | `tasks.{capability}.{subcapability}` | same |
-| Delegate | (undefined; see §8) | same |
+| Direct (intra-principal) | `local.{principal}.{stack}.tasks.@{did-encoded-assistant}.{capability}` | `local.{principal}.{stack}.dispatch.task.{started\|completed\|failed\|aborted}` |
+| Direct (cross-principal — OSI Scenario 4 model B) | `federated.{principal}.{stack}.tasks.@{did-encoded-assistant}.{capability}` | `federated.{principal}.{stack}.dispatch.task.{started\|completed\|failed\|aborted}` |
+| Delegate | Same subject as Direct (`tasks.@{did-encoded-assistant}.{capability}`); mode bit lives in top-level `envelope.distribution_mode === 'delegate'` field — myelin spec doesn't separate Direct/Delegate at the wire | same |
+| Offer | `local.{principal}.{stack}.tasks.{capability}.{subcapability}` (no `@{assistant}` segment; JetStream consumer group claims exactly-once) | same |
 
-All prefixed by `local.{principal}.{stack}.`. Lifecycle envelopes joined to inbound by `correlation_id`.
+Lifecycle envelopes joined to inbound by `correlation_id`. **Free-form Discord/Mattermost/Slack `@assistant <message>` interactions publish with `capability = chat` — a first-class capability in myelin's seed taxonomy as of the C-405 corrections (see myelin issue for the taxonomy extension).**
+
+**Legacy:** the existing `dispatch.task.received` subscription in `src/runner/dispatch-listener.ts` is pre-spec. Stage 7 adds `tasks.>` subscription alongside it for one release; flip happens in Stages 4–6; removal of the legacy subscription + IAW Phase D test updates land in Stage 7 (see OSI §11 Q1).
 
 `response_routing` field on the inbound envelope payload — shape TBD; sketch:
 
@@ -150,27 +162,35 @@ Listener echoes this onto every `dispatch.task.{action}` lifecycle envelope.
 
 ## 6. signed_by chain examples
 
-### 6.1 Discord-originated Direct dispatch
+### 6.1 Discord-originated Direct dispatch (corrected per OSI Scenario 1)
 
-Adapter is hosted by `agent:luna` on stack `andreas/meta-factory`. Inbound envelope:
+Adapter sees `@luna hello` from Discord user resolved as `did:mf:jc`. Stack-signing model:
 
 ```
-source: andreas.luna.meta-factory
-signed_by: [
-  { kid: "agent:luna", alg: "ed25519", sig: "…" }
-]
-type: dispatch.task.received
+subject: local.andreas.meta-factory.tasks.@did-mf-luna.chat
+envelope:
+  type: tasks.chat
+  target_principal: did:mf:luna       # myelin spec calls this target_principal; cortex CONTEXT.md routes-to-an-assistant
+  distribution_mode: direct           # top-level enum; bridges to cortex "Direct" mode
+  originator:
+    principal: did:mf:jc              # resolved by adapter from Discord user id
+    attribution: adapter-resolved
+  signed_by:
+    - principal: did:mf:andreas-stack # stack key signs; covers originator
+      method: ed25519
+      signature: "…"
+      at: "2026-05-23T…"
 ```
 
-Listener verifies the chain via `verifySignedByChain` against `TrustResolver`. Single-signer envelopes pass when the kid resolves to a known agent on the local stack.
+Listener verifies the chain against `TrustResolver`. `getActorPrincipal(envelope)` returns `originator.principal` (`did:mf:jc`) for policy attribution. The adapter does NOT hold an agent NKey — it only resolves the Discord user to a DID and fills `originator`.
 
-### 6.2 Peer-to-peer Direct (cross-stack)
+### 6.2 Cross-principal Direct (OSI Scenarios 3 & 4)
 
-Sender (cortex on `andreas/work` stack, agent `pilot`) publishes a `dispatch.task.dispatched` envelope. Recipient stack's bus-peer harness picks it up. signed_by carries the originating agent only — recipient stack signs *outbound* lifecycle envelopes with its own agent identity.
+Same envelope shape, with `classification: federated` and the `federated.…` subject prefix. Stack on the sending principal signs; chain verify on the receiving principal runs against trust roots that span the network. The originator is preserved end-to-end; intermediaries that need to override attribution MUST re-sign (cannot mutate `originator` silently — myelin spec §Originator).
 
 ### 6.3 Delegate dispatch (AgentTeam harness)
 
-Inbound looks identical to Direct (`dispatch.task.received`). Listener routes to `agent-team` harness based on payload `mode = "delegate"`. Sub-dispatches the team initiates carry the team-harness as additional signer in their `signed_by` chain.
+Inbound subject identical to Direct (`tasks.@{did-encoded-assistant}.{capability}`); the mode bit lives in `envelope.distribution_mode === 'delegate'` (top-level field, myelin spec). Listener routes to `agent-team` harness via the `distribution_mode` field after the subject + assistant-DID filter matches. Sub-dispatches the team initiates re-sign with the team-harness's stack key as their first signer.
 
 ---
 
@@ -178,24 +198,29 @@ Inbound looks identical to Direct (`dispatch.task.received`). Listener routes to
 
 | Stage | Work | Pre-requisite |
 |-------|------|----------------|
-| 0 | This design doc; ADR equivalent recorded | — |
+| 0 | This design doc + OSI corrections doc; ADR equivalent recorded | — |
 | 1 | Finish MIG-7.2 — adapter holds an `agent` not legacy `BotConfig.agent.discord[]` | — |
-| 2 | Confirm Q2 with myelin team; pin signed_by chain rules for adapter-signs-as-agent | Stage 1 |
-| 3 | Build `EnvelopePublishingAdapterBase` — shared dispatch-source helpers (sign, derive subject, payload schema, response_routing). Add `AgentTeamHarness` (Q6c). | Stages 1–2 |
-| 4 | Discord adapter adopts envelope mode behind feature flag (`CORTEX_DISCORD_ENVELOPE_MODE=1`). Both paths coexist. | Stage 3 |
-| 5 | Discord adapter dispatch-sink — subscribe to `dispatch.task.{started\|completed\|failed\|aborted}` filtered by routing; render via existing `postResponse` / `sendProgress`. Verify parity with handler path. | Stage 4 |
+| 2 | **Implement against existing myelin spec (no negotiation needed).** Wire up `encodeDidSegment` helper from `@the-metafactory/myelin/subjects`; confirm `verifySignedByChain` reads `originator.principal` via `getActorPrincipal` for policy attribution. Land myelin taxonomy extension adding `chat` as a first-class capability. | Stage 1 |
+| 3 | Build `EnvelopePublishingAdapterBase` — shared dispatch-source helpers. Subject derivation uses `tasks.@{did-encoded-assistant}.{capability}`. Adapter populates `originator.identity` from `resolveAccess` output + sets `attribution = "adapter-resolved"`. Hand to `runtime.publish` for stack-signing. Add `AgentTeamHarness` (Q6c). Listener selects on `envelope.distribution_mode === 'delegate'` for AgentTeam routing. | Stages 1–2 |
+| 4 | Discord adapter adopts envelope mode behind feature flag (`CORTEX_DISCORD_ENVELOPE_MODE=1`). Publishes onto `tasks.@{did-encoded-assistant}.chat` (free-form) or capability-specific (`code-review`, `release`, …) for typed workloads. **Defaults to model A (Discord-as-bridge for cross-principal channels)**; per-channel opt-in for model B (federation-by-default) once peer-principal NATS federation + trust roots are configured for that pair. Both legacy `dispatch.task.received` and canonical `tasks.>` listener subscriptions coexist during this stage. | Stage 3 + cortex federation-as-default issue |
+| 5 | Discord adapter dispatch-sink — subscribe to `dispatch.task.{started\|completed\|failed\|aborted}` filtered by `response_routing.adapter_instance` + `correlation_id`; render via existing `postResponse` / `sendProgress`. Verify parity with handler path. | Stage 4 |
 | 6 | Mattermost + Slack flip. Feature flag removed once all three on envelope mode in prod for a stable period. | Stage 5 |
-| 7 | Delete `src/bus/dispatch-handler.ts`. Rename `dispatch-listener.ts` if a better name surfaces (likely `dispatch-runtime.ts` or similar). Update `docs/architecture.md`. | Stage 6 |
+| 7 | **Cutover.** Delete `src/bus/dispatch-handler.ts`. Remove legacy `dispatch.task.received` subscription from `dispatch-listener.ts`. **Update IAW Phase D integration test (`src/__tests__/iaw-phase-d-integration.test.ts`) + `src/__tests__/cortex.test.ts`** to use canonical `tasks.@{did}.{capability}` subjects. Rename `dispatch-listener.ts` if a better name surfaces (likely `dispatch-runtime.ts`). Update `docs/architecture.md`. | Stage 6 |
 
 ---
 
 ## 8. Open seams
 
-- **Delegate inbound subject grammar.** `dispatch.task.received` works for v1 (mode in payload). Long-term: subject-level encoding (`tasks.@{assistant}.delegate.…`) is the CONTEXT.md-aligned destination. File as follow-up.
+- **Channel-topology config for OSI Scenario 4 (model B).** Adapter needs to know which Discord/Mattermost/Slack channels span principals. Two viable shapes: (i) explicit `cortex.yaml` per-channel config; (ii) Discord guild/role lookup that resolves to a peer-principal mapping. Filed as a separate cortex issue ("Federation as default for multi-principal collaboration"); pre-condition for full Stage 4 rollout.
+- **NATS leaf-node federation between principal pairs.** Pre-condition for Scenario 4 model B; out of cortex's scope, covered by network operations work.
+- **myelin `DistributionMode` rename (`'broadcast'` → `'offer'`).** cortex CONTEXT.md (Flagged Ambiguities) canonicalised the Offer mode and rejects `broadcast`. myelin's shipped enum still uses `'broadcast'`. Filed as a separate myelin issue; cortex wraps the legacy spelling at the boundary in the meantime.
 - **Q5b — policy-engine sole access authority.** Adapter retains coarse-access today (Q5c). Long-term: adapter holds only identity; listener's policy-engine computes everything. Filed as separate issue.
 - **Q4b — federated CAS for attachments.** Inline base64 works v1; will blow up envelope size for video / large dumps. Replace with hash-addressed blob store keyed by `correlation_id`. Filed as separate issue.
-- **Adapter-originated Direct to `tasks.@{assistant}.chat`.** CONTEXT.md example dialogue shows the intended grammar; today's `dispatch.task.received` is the pragmatic v1. Future seam.
 - **Where AgentTeam lives during migration.** Today inside `dispatch-handler.ts` as a direct import. Stage 3 lifts it into a harness. The pre-harness path (handler's `team:` keyword) must be cut over with the rest in Stages 4–6.
+
+**Resolved by the OSI corrections batch (formerly listed here):**
+- ~~Delegate inbound subject grammar undefined~~ → OSI §11 Q4: `envelope.distribution_mode === 'delegate'` (top-level field); subject shape identical to Direct.
+- ~~Adapter-originated Direct to `tasks.@{assistant}.chat` is a future seam~~ → Direction A Stage 4 IS the landing; `chat` capability added to myelin seed taxonomy via cortex.
 
 ---
 
@@ -214,7 +239,7 @@ Plus reconciliation: `tasks` and `dispatch` are distinct, coexisting domains. No
 
 ## 10. Out of scope
 
-- Any change to `myelin/` envelope schema beyond confirming the adapter-signs-as-agent rule
+- Any change to `myelin/` envelope schema (the `originator` field is already shipped via myelin#160)
 - Mission Control dashboard changes (dashboard remains a dispatch sink; only the consumer side may need a render-completion subscriber update)
 - Renaming `src/renderers/` to `src/dispatch-sinks/` (code-name is `Renderer`; design term is `dispatch sink` — both stay)
-- Q2 reconciliation with myelin's namespace.md if conflicts arise — out-of-band conversation with myelin team
+- Channel-topology mechanism design (Scenario 4 model B) — handled in the federation-as-default cortex issue, not this spec


### PR DESCRIPTION
Refs umbrella #405 (Direction A). Refs JC's handover (\`docs/handover-2026-05-22-direction-a.md\`).

## Why

JC's 2026-05-22 \`/improve-codebase-architecture\` grilling produced Direction A (platform adapters become dispatch sources publishing onto the bus) and the OSI pressure-test doc, which surfaced two corrections needing Andreas's call. Andreas reviewed 2026-05-23 and the corrections cascaded into:

- Two **technical corrections** to Direction A (wire grammar; signing model) — both already in shipped myelin code per \`namespace.md\` + myelin#160.
- One **framing correction** — dispatch source is pluggable; platform adapters are one of five source classes; the bus is the medium, not Discord.
- One **new scenario** (Scenario 4) — cross-principal collaboration via shared platform surfaces; legacy bridging pattern + model A / B / C analysis.
- One **new scenario** (Scenario 5) — bot-to-bot direct chat (no surface); the bus-native baseline; included to make the architectural baseline explicit.
- One **new section** (OSI §14) — multi-subscriber / multi-surface delivery model. NATS pub/sub already does fan-out; routed sinks vs observer sinks; deferred multi-primary-surface design.
- **IoAW linkage** — federation establishment is NOT a Direction A design gap; \`docs/design-internet-of-agentic-work.md\` §3.3 + Phase E (#117) own the primitives. Direction A consumes them.

## What changes

| File | Change |
|---|---|
| \`CONTEXT.md\` | Federation-as-default note in Network entry; canonical \`tasks.@{assistant}.{capability}\` subjects in Dispatch entry; \`chat\` capability framing recast as bus-native; Dispatch source updated for stack-signs / adapter-populates-originator; 4 flagged ambiguities flipped from future-seam to resolved-by-C-405 |
| \`docs/design-myelin-osi-scenarios.md\` | §4 framing corrections (subject grammar; dispatch source pluggable; signing); reframed Scenario 1 + 4 headers; added Scenario 4 (cross-principal shared surface) + Scenario 5 (bot-to-bot direct chat); §11 implications; §12 locked answers for all four original §10 questions; §13 open seams (incl. IoAW linkage); §14 multi-subscriber model |
| \`docs/design-platform-adapter-dispatch-publishing.md\` | §1 framing note (dispatch source classes); §2 diagram redrawn with pluggable source/sink boxes; Q1 + Q2 corrected in §4; §5 subject grammar table canonicalised; §6 chain examples updated for stack-signing; §7 Stage 2/3/4/7 descriptions locked; §8 open seams revised; \`Related\` section links to IoAW |
| \`docs/handover-2026-05-22-direction-a.md\` | (unchanged — historical record of JC's handover) |

## Related work landed alongside

- **Sub-issues #406–#412 bodies updated** with C-405 corrections callouts + stage-specific updates (canonical subjects in #408–#412; \`chat\` capability in #407; OSI Scenario 4 model A/B in #409; legacy subscription + IAW Phase D test cutover in #412).
- **New myelin issue: myelin#180** — DistributionMode enum \`'broadcast'\` → \`'offer'\` rename (boundary clash with cortex CONTEXT.md). Backward-compat path recommended.
- **New cortex issue: #413** — Channel-topology config for adapter (Scenario 4 model B mechanism). 4 candidate options; awaiting decision. Pre-req for Stage 4 model B opt-in.

## Locked answers (from OSI §12)

| Q | Answer |
|---|--------|
| Q1 — \`dispatch.task.received\` subscription | **Legacy** — retire in Stage 7 + flip IAW Phase D integration tests |
| Q2 — \`chat\` capability token | **Add \`chat\` to myelin seed taxonomy** (cortex IS the myelin team — no external block) |
| Q3 — \`originator.attribution\` enum | **Already shipped**: \`'adapter-resolved' \| 'federated' \| 'delegated'\` |
| Q4 — Direct vs Delegate at the wire | **Already shipped**: \`envelope.distribution_mode\` top-level field; same subject shape for both modes |

## Review focus

- §4.2 Dispatch source is pluggable — is the five-class table right? Anything missing?
- Scenario 5 — does the originator-omitted (signer-IS-actor) pattern match how you'd want autonomous bot dispatches to attribute?
- §14 — is sink-side rendering rules (Option C) the right call for v1 multi-surface delivery? Or do we need an envelope-schema change now (Option A — \`response_routing\` list)?
- IoAW cross-ref — is the linkage to \`design-internet-of-agentic-work.md\` §3.3 + #117 the right place to anchor federation establishment, or does it warrant its own design doc?

## Out of scope

- Code changes — this is the design layer; implementation lands per stage (#406–#412)
- myelin enum rename — filed as myelin#180; cortex maps at the boundary in the meantime
- Channel-topology mechanism design — filed as #413; decision needed before Stage 4 model B opt-in ships

🤖 Generated with [Claude Code](https://claude.com/claude-code)