### PR TITLE
feat(runner): add AgentTeamHarness for delegate dispatch

### DIFF
--- a/src/bus/dispatch-lifecycle-summary.ts
+++ b/src/bus/dispatch-lifecycle-summary.ts
@@ -1,0 +1,24 @@
+/**
+ * Shared presentation caps for dispatch.task terminal envelopes.
+ *
+ * The envelope constructors deliberately accept caller-provided strings:
+ * each harness knows its substrate result shape. These helpers keep the
+ * operator-facing lifecycle summaries consistent across harnesses.
+ */
+
+/**
+ * Trim error messages so verbose stacks do not blow downstream worklog
+ * limits. 500 chars matches the `system.inbound.failed` convention.
+ */
+export function truncateDispatchErrorSummary(msg: string): string {
+  return msg.length > 500 ? msg.slice(0, 497) + "..." : msg;
+}
+
+/**
+ * Trim result summaries to the first line. Surfaces typically render this
+ * inline next to a task label, so cap at 1000 chars to leave room for chrome.
+ */
+export function truncateDispatchResultSummary(text: string): string {
+  const first = text.split("\n", 1)[0] ?? text;
+  return first.length > 1000 ? first.slice(0, 997) + "..." : first;
+}

--- a/src/common/substrates/__tests__/types.test.ts
+++ b/src/common/substrates/__tests__/types.test.ts
@@ -7,7 +7,7 @@
  * rather than at downstream import sites.
  *
  * **Coverage axes:**
- *   1. `HarnessId` enumerates all 7 known substrates (cortex#91 §F).
+ *   1. `HarnessId` enumerates all 8 known substrates (cortex#91 §F).
  *      Adding/removing a value is a typed change that fails this test
  *      until the test list is updated — forcing the author to think
  *      about which downstream switch statements need updating.
@@ -47,13 +47,14 @@ describe("HarnessId", () => {
     "gemini",
     "mistral",
     "pi-dev",
+    "agent-team",
   ];
 
-  test("includes all seven known substrates", () => {
-    expect(ALL_HARNESS_IDS).toHaveLength(7);
+  test("includes all eight known substrates", () => {
+    expect(ALL_HARNESS_IDS).toHaveLength(8);
   });
 
-  test("exhaustive switch compiles for all seven values", () => {
+  test("exhaustive switch compiles for all eight values", () => {
     // If a new HarnessId is added without updating this switch, tsc fails
     // (the `never` assignment becomes ill-typed). Compile-time proof that
     // every downstream switch must enumerate the union exhaustively.
@@ -66,6 +67,7 @@ describe("HarnessId", () => {
         case "gemini": return "gemini";
         case "mistral": return "mistral";
         case "pi-dev": return "pi";
+        case "agent-team": return "team";
         default: {
           const _exhaustive: never = id;
           return _exhaustive;

--- a/src/common/substrates/types.ts
+++ b/src/common/substrates/types.ts
@@ -92,7 +92,7 @@ export type MyelinEnvelope = Envelope;
  * checking from `tsc`. Adding a new substrate is a typed change at every
  * dispatch decision point — the compiler enumerates the work for you.
  *
- * The seven known substrates (per cortex#91 §"Implementations" and
+ * The eight known substrates (per cortex#91 §"Implementations" and
  * §"Future harnesses"):
  *
  *   - `"claude-code"`   — in-process child via `claude --print
@@ -108,6 +108,8 @@ export type MyelinEnvelope = Envelope;
  *   - `"mistral"`       — Mistral CLI / API.
  *   - `"pi-dev"`        — direct pi.dev call without bus indirection;
  *                         used for cortex-co-located agents.
+ *   - `"agent-team"`    — meta-harness that coordinates a moderator plus
+ *                         multiple participant harnesses for delegate mode.
  *
  * **Why not `string`?** Because the runtime needs to refuse the unknown.
  * A new harness must be a typed registration, not a free-form string,
@@ -120,7 +122,8 @@ export type HarnessId =
   | "cursor"
   | "gemini"
   | "mistral"
-  | "pi-dev";
+  | "pi-dev"
+  | "agent-team";
 
 // ---------------------------------------------------------------------------
 // Capability

--- a/src/runner/__tests__/agent-team-harness.test.ts
+++ b/src/runner/__tests__/agent-team-harness.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, test } from "bun:test";
+import {
+  AgentTeamHarness,
+  type AgentTeamFactory,
+  type AgentTeamOpts,
+} from "../agent-team";
+import type { DispatchRequest } from "../../common/substrates/types";
+import type { DispatchEventSource } from "../../bus/dispatch-events";
+
+const SOURCE: DispatchEventSource = {
+  org: "metafactory",
+  agent: "cortex",
+  instance: "local",
+};
+
+const REQUEST: DispatchRequest = {
+  prompt: "Review the Direction A plan",
+  tools: { allow: ["Read"], deny: ["Bash"] },
+  context: [
+    {
+      kind: "env",
+      data: {
+        operator: "andreas",
+        entity: "cortex#408",
+        project: "cortex",
+      },
+    },
+  ],
+  agent: { id: "cortex", displayName: "Cortex" },
+  requestId: "11111111-1111-4111-8111-111111111111",
+  timeoutMs: 60_000,
+  runtime: {
+    groveChannel: "codex",
+    groveNetwork: "direction-a",
+    additionalArgs: ["--model", "sonnet"],
+    allowedDirs: ["/tmp/work"],
+  },
+};
+
+function collectFactory(result: string): {
+  factory: AgentTeamFactory;
+  opts: AgentTeamOpts[];
+  starts: number;
+} {
+  const opts: AgentTeamOpts[] = [];
+  const state = {
+    starts: 0,
+  };
+  return {
+    opts,
+    get starts() {
+      return state.starts;
+    },
+    factory: (teamOpts) => {
+      opts.push(teamOpts);
+      return {
+        start() {
+          state.starts += 1;
+        },
+        async wait() {
+          return result;
+        },
+        on() {
+          return undefined;
+        },
+        getTraceContext() {
+          return {
+            traceId: "trace-test",
+            teamId: "team-test",
+          };
+        },
+      };
+    },
+  };
+}
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (err: Error) => void;
+} {
+  let resolve!: (value: T) => void;
+  let reject!: (err: Error) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("AgentTeamHarness", () => {
+  test("implements SessionHarness identity", () => {
+    const harness = new AgentTeamHarness({ source: SOURCE });
+    expect(harness.id).toBe("agent-team");
+    expect(harness.capabilities).toEqual([]);
+  });
+
+  test("yields started → completed and maps request into default team opts", async () => {
+    const captured = collectFactory("Synthesized team answer");
+    const harness = new AgentTeamHarness({
+      source: SOURCE,
+      agentTeamFactory: captured.factory,
+    });
+
+    const envelopes = [];
+    for await (const env of harness.dispatch(REQUEST)) {
+      envelopes.push(env);
+    }
+
+    expect(envelopes.map((e) => e.type)).toEqual([
+      "dispatch.task.started",
+      "dispatch.task.completed",
+    ]);
+    expect(envelopes.every((e) => e.correlation_id === REQUEST.requestId)).toBe(true);
+    expect(envelopes.at(-1)?.payload.result_summary).toBe("Synthesized team answer");
+    expect(captured.starts).toBe(1);
+    expect(captured.opts).toHaveLength(1);
+
+    const opts = captured.opts[0];
+    expect(opts?.prompt).toBe(REQUEST.prompt);
+    expect(opts?.participants.map((p) => p.name)).toEqual([
+      "analyst",
+      "creative",
+      "critic",
+    ]);
+    expect(opts?.participants.length).toBeGreaterThanOrEqual(2);
+    expect(opts?.allowedTools).toEqual(["Read"]);
+    expect(opts?.disallowedTools).toEqual(["Bash"]);
+    expect(opts?.allowedDirs).toEqual(["/tmp/work"]);
+    expect(opts?.timeoutMs).toBe(60_000);
+    expect(opts?.groveChannel).toBe("codex");
+    expect(opts?.groveNetwork).toBe("direction-a");
+    expect(opts?.additionalArgs).toEqual(["--model", "sonnet"]);
+    expect(opts?.operator).toBe("andreas");
+    expect(opts?.entity).toBe("cortex#408");
+    expect(opts?.project).toBe("cortex");
+  });
+
+  test("truncates completed result_summary to the first line", async () => {
+    const captured = collectFactory(`First line\n${"x".repeat(2_000)}`);
+    const harness = new AgentTeamHarness({
+      source: SOURCE,
+      agentTeamFactory: captured.factory,
+    });
+
+    const envelopes = [];
+    for await (const env of harness.dispatch(REQUEST)) {
+      envelopes.push(env);
+    }
+
+    expect(envelopes.at(-1)?.payload.result_summary).toBe("First line");
+  });
+
+  test("yields started → failed when the team factory throws", async () => {
+    const harness = new AgentTeamHarness({
+      source: SOURCE,
+      agentTeamFactory: () => {
+        throw new Error("team unavailable");
+      },
+    });
+
+    const envelopes = [];
+    for await (const env of harness.dispatch(REQUEST)) {
+      envelopes.push(env);
+    }
+
+    expect(envelopes.map((e) => e.type)).toEqual([
+      "dispatch.task.started",
+      "dispatch.task.failed",
+    ]);
+    expect(envelopes.at(-1)?.payload.error_summary).toBe("team unavailable");
+  });
+
+  test("hard shutdown aborts an active team", async () => {
+    const wait = deferred<string>();
+    let abortCalls = 0;
+    const harness = new AgentTeamHarness({
+      source: SOURCE,
+      agentTeamFactory: () => ({
+        start() {
+          return undefined;
+        },
+        wait() {
+          return wait.promise;
+        },
+        abort() {
+          abortCalls += 1;
+          wait.reject(new Error("aborted by shutdown"));
+        },
+        on() {
+          return undefined;
+        },
+        getTraceContext() {
+          return {
+            traceId: "trace-test",
+            teamId: "team-test",
+          };
+        },
+      }),
+    });
+
+    const iterator = harness.dispatch(REQUEST)[Symbol.asyncIterator]();
+    expect((await iterator.next()).value.type).toBe("dispatch.task.started");
+
+    const terminal = iterator.next();
+    await Promise.resolve();
+    await harness.shutdown({ graceful: false });
+
+    expect(abortCalls).toBe(1);
+    const next = await terminal;
+    expect(next.value.type).toBe("dispatch.task.failed");
+    expect(next.value.payload.error_summary).toBe("aborted by shutdown");
+  });
+});

--- a/src/runner/__tests__/dispatch-listener.test.ts
+++ b/src/runner/__tests__/dispatch-listener.test.ts
@@ -30,6 +30,7 @@ import {
   type CCSessionFactory,
   type DispatchTaskReceivedPayload,
 } from "../dispatch-listener";
+import type { AgentTeamFactory, AgentTeamOpts } from "../agent-team";
 import type { CCSessionResult } from "../cc-session";
 import { PolicyEngine } from "../../common/policy/engine";
 import type { Intent } from "../../common/policy/types";
@@ -128,6 +129,34 @@ function fakeFactory(result: CCSessionResult): {
       async wait() { return result; },
     };
     return session;
+  };
+  return { factory, optsCaptured };
+}
+
+function fakeAgentTeamFactory(result: string): {
+  factory: AgentTeamFactory;
+  optsCaptured: AgentTeamOpts[];
+} {
+  const optsCaptured: AgentTeamOpts[] = [];
+  const factory: AgentTeamFactory = (opts) => {
+    optsCaptured.push(opts);
+    return {
+      start() {
+        return undefined;
+      },
+      async wait() {
+        return result;
+      },
+      on() {
+        return undefined;
+      },
+      getTraceContext() {
+        return {
+          traceId: "trace-dispatch-listener-test",
+          teamId: "team-dispatch-listener-test",
+        };
+      },
+    };
   };
   return { factory, optsCaptured };
 }
@@ -472,6 +501,43 @@ describe("dispatch-listener — success path", () => {
     expect(opts.project).toBeUndefined();
     expect(opts.allowedTools).toBeUndefined();
     expect(opts.disallowedTools).toBeUndefined();
+  });
+
+  test("delegate distribution mode routes to AgentTeamHarness", async () => {
+    const r = recordingRuntime();
+    const router = createSurfaceRouter(r.runtime);
+    const cc = fakeFactory(SUCCESS_RESULT);
+    const team = fakeAgentTeamFactory("Team answer");
+    const listener = createDispatchListener({
+      runtime: r.runtime,
+      router,
+      source: SOURCE,
+      ccSessionFactory: cc.factory,
+      agentTeamFactory: team.factory,
+      policyEngine: engineGranting(["dispatch.cortex"]),
+    });
+    await listener.start();
+    await router.start();
+
+    r.trigger(
+      {
+        ...makeReceivedEnvelope(),
+        distribution_mode: "delegate",
+        target_assistant: "did:mf:cortex",
+      },
+      "local.metafactory.dispatch.task.received",
+    );
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(cc.optsCaptured).toHaveLength(0);
+    expect(team.optsCaptured).toHaveLength(1);
+    expect(team.optsCaptured[0]?.participants.length).toBeGreaterThanOrEqual(2);
+    expect(r.published.map((e) => e.type)).toEqual([
+      "system.access.allowed",
+      "dispatch.task.started",
+      "dispatch.task.completed",
+    ]);
+    expect(r.published.at(-1)?.payload.result_summary).toBe("Team answer");
   });
 });
 

--- a/src/runner/agent-team.ts
+++ b/src/runner/agent-team.ts
@@ -14,10 +14,21 @@ import { randomUUID } from "crypto";
 import type { MyelinRuntime } from "../bus/myelin/runtime";
 import type { TrustResolver } from "../common/agents/trust-resolver";
 import type { DispatchEventSource } from "../bus/dispatch-events";
+import {
+  createDispatchTaskCompletedEvent,
+  createDispatchTaskFailedEvent,
+  createDispatchTaskStartedEvent,
+} from "../bus/dispatch-events";
+import {
+  truncateDispatchErrorSummary,
+  truncateDispatchResultSummary,
+} from "../bus/dispatch-lifecycle-summary";
 import { BusPeerHarness } from "../substrates/bus-peer/harness";
 import type {
+  Capability,
   DispatchRequest,
   MyelinEnvelope,
+  SessionHarness,
 } from "../common/substrates/types";
 
 export interface TeamMember {
@@ -137,6 +148,169 @@ export interface AgentTeamOpts {
    * @internal — not part of the public API.
    */
   busPeerHandleFactory?: BusPeerHandleFactory;
+}
+
+export interface AgentTeamLike {
+  start(): unknown;
+  wait(): Promise<string>;
+  abort?(): void;
+  on(event: "progress", listener: (member: string, text: string) => void): unknown;
+  on(event: "error", listener: (err: Error) => void): unknown;
+  getTraceContext(): { traceId: string; teamId: string };
+}
+
+export type AgentTeamFactory = (opts: AgentTeamOpts) => AgentTeamLike;
+
+export interface AgentTeamHarnessOpts {
+  source: DispatchEventSource;
+  capabilities?: Capability[];
+  participants?: TeamParticipantConfig[];
+  agentTeamFactory?: AgentTeamFactory;
+}
+
+const DEFAULT_TEAM_PARTICIPANTS: TeamParticipantConfig[] = [
+  {
+    name: "analyst",
+    prompt: "Deep analytical perspective — examine evidence, data, and logical implications",
+  },
+  {
+    name: "creative",
+    prompt: "Creative and lateral thinking — explore unconventional angles and connections",
+  },
+  {
+    name: "critic",
+    prompt: "Critical evaluation — identify weaknesses, counterarguments, and risks",
+  },
+];
+
+const defaultAgentTeamFactory: AgentTeamFactory = (opts) => new AgentTeam(opts);
+
+/**
+ * Delegate-mode meta-harness. It wraps the existing moderator +
+ * participant AgentTeam orchestration behind the same SessionHarness
+ * lifecycle contract as single-substrate harnesses.
+ */
+export class AgentTeamHarness implements SessionHarness {
+  readonly id = "agent-team" as const;
+  readonly capabilities: Capability[];
+
+  private readonly source: DispatchEventSource;
+  private readonly participants: TeamParticipantConfig[];
+  private readonly factory: AgentTeamFactory;
+  private readonly activeTeams = new Set<AgentTeamLike>();
+  private shuttingDown = false;
+
+  constructor(opts: AgentTeamHarnessOpts) {
+    this.source = opts.source;
+    this.capabilities = opts.capabilities ?? [];
+    this.participants = opts.participants ?? DEFAULT_TEAM_PARTICIPANTS;
+    this.factory = opts.agentTeamFactory ?? defaultAgentTeamFactory;
+  }
+
+  async *dispatch(req: DispatchRequest): AsyncIterable<MyelinEnvelope> {
+    const startedAt = new Date();
+    const correlationId = req.requestId;
+
+    yield createDispatchTaskStartedEvent({
+      source: this.source,
+      taskId: req.requestId,
+      agentId: req.agent.id,
+      startedAt,
+      correlationId,
+    });
+
+    if (this.shuttingDown) {
+      yield createDispatchTaskFailedEvent({
+        source: this.source,
+        taskId: req.requestId,
+        agentId: req.agent.id,
+        startedAt,
+        failedAt: new Date(),
+        errorSummary: "agent-team harness shutting down",
+        correlationId,
+      });
+      return;
+    }
+
+    let team: AgentTeamLike | null = null;
+    try {
+      team = this.factory(this.buildTeamOpts(req));
+      this.activeTeams.add(team);
+      const waitForResult = team.wait();
+      team.start();
+      const result = await waitForResult;
+      yield createDispatchTaskCompletedEvent({
+        source: this.source,
+        taskId: req.requestId,
+        agentId: req.agent.id,
+        startedAt,
+        completedAt: new Date(),
+        resultSummary: truncateDispatchResultSummary(result),
+        correlationId,
+      });
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      yield createDispatchTaskFailedEvent({
+        source: this.source,
+        taskId: req.requestId,
+        agentId: req.agent.id,
+        startedAt,
+        failedAt: new Date(),
+        errorSummary: truncateDispatchErrorSummary(error.message),
+        correlationId,
+      });
+    } finally {
+      if (team !== null) {
+        this.activeTeams.delete(team);
+      }
+    }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/require-await
+  async shutdown(opts: { graceful: boolean }): Promise<void> {
+    this.shuttingDown = true;
+    if (opts.graceful) return;
+    for (const team of this.activeTeams) {
+      team.abort?.();
+    }
+  }
+
+  private buildTeamOpts(req: DispatchRequest): AgentTeamOpts {
+    const env = this.envContext(req);
+    return {
+      prompt: req.prompt,
+      participants: this.participants.map((p) => ({ ...p })),
+      ...(req.runtime?.groveChannel !== undefined && { groveChannel: req.runtime.groveChannel }),
+      ...(req.runtime?.groveNetwork !== undefined && { groveNetwork: req.runtime.groveNetwork }),
+      ...(req.runtime?.additionalArgs !== undefined && { additionalArgs: req.runtime.additionalArgs }),
+      ...(req.tools.allow.length > 0 && { allowedTools: [...req.tools.allow] }),
+      ...(req.tools.deny !== undefined && { disallowedTools: [...req.tools.deny] }),
+      ...(req.runtime?.allowedDirs !== undefined && { allowedDirs: req.runtime.allowedDirs }),
+      ...(req.timeoutMs !== undefined && { timeoutMs: req.timeoutMs }),
+      ...(env.project !== undefined && { project: env.project }),
+      ...(env.entity !== undefined && { entity: env.entity }),
+      ...(env.operator !== undefined && { operator: env.operator }),
+    };
+  }
+
+  private envContext(req: DispatchRequest): {
+    project?: string;
+    entity?: string;
+    operator?: string;
+  } {
+    for (const ctx of req.context) {
+      if (ctx.kind !== "env" || typeof ctx.data !== "object" || ctx.data === null) {
+        continue;
+      }
+      const env = ctx.data as Record<string, unknown>;
+      return {
+        ...(typeof env.project === "string" && { project: env.project }),
+        ...(typeof env.entity === "string" && { entity: env.entity }),
+        ...(typeof env.operator === "string" && { operator: env.operator }),
+      };
+    }
+    return {};
+  }
 }
 
 /**
@@ -345,6 +519,7 @@ function extractMentions(text: string, knownNames: string[]): string[] {
 export class AgentTeam extends EventEmitter {
   private members = new Map<string, TeamMember>();
   private moderator?: CCSession;
+  private synthesis?: CCSession;
   private traceId: string;
   private teamId: string;
   private pendingParticipants = new Set<string>();
@@ -432,6 +607,21 @@ export class AgentTeam extends EventEmitter {
   /** Get trace context for observability. */
   getTraceContext(): { traceId: string; teamId: string } {
     return { traceId: this.traceId, teamId: this.teamId };
+  }
+
+  abort(): void {
+    this.moderator?.kill();
+    this.synthesis?.kill();
+    for (const member of this.members.values()) {
+      if (member.session instanceof CCSession) {
+        member.session.kill();
+      } else {
+        member.session.abort();
+      }
+    }
+    if (this.listenerCount("error") > 0) {
+      this.emit("error", new Error("AgentTeam aborted"));
+    }
   }
 
   private handleModeratorResponse(text: string): void {
@@ -664,6 +854,7 @@ export class AgentTeam extends EventEmitter {
       entity: this.opts.entity,
       operator: this.opts.operator,
     });
+    this.synthesis = synthSession;
 
     synthSession.on("result", (text: string) => {
       this.emit("synthesis", text);

--- a/src/runner/dispatch-listener.ts
+++ b/src/runner/dispatch-listener.ts
@@ -101,6 +101,10 @@ import {
   ClaudeCodeHarness,
   type CCSessionFactory as ClaudeCodeFactory,
 } from "../substrates/claude-code/harness";
+import {
+  AgentTeamHarness,
+  type AgentTeamFactory,
+} from "./agent-team";
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -207,6 +211,12 @@ export interface DispatchListenerOptions {
    * Tests pass a fake to drive lifecycles without spawning processes.
    */
   ccSessionFactory?: CCSessionFactory;
+  /**
+   * Optional AgentTeam factory for delegate-mode dispatches. Production
+   * omits this; tests inject a fake to prove routing without spawning
+   * moderator/participant CC sessions.
+   */
+  agentTeamFactory?: AgentTeamFactory;
   /**
    * Adapter ID for surface-router error reporting. Defaults to
    * `runner-dispatch-listener`. Configurable so multiple runner instances
@@ -338,6 +348,7 @@ export function createDispatchListener(
     router,
     source,
     ccSessionFactory,
+    agentTeamFactory,
     policyEngine,
     trustResolver,
     receivingAgentId,
@@ -370,6 +381,7 @@ export function createDispatchListener(
         runtime,
         source,
         ccSessionFactory,
+        agentTeamFactory,
         policyEngine,
         stack: opts.stack,
         trustResolver,
@@ -529,6 +541,7 @@ interface DispatchHandlerContext {
   runtime: MyelinRuntime;
   source: SystemEventSource;
   ccSessionFactory: CCSessionFactory | undefined;
+  agentTeamFactory: AgentTeamFactory | undefined;
   policyEngine: PolicyEngine | undefined;
   stack: string | undefined;
   /**
@@ -551,6 +564,7 @@ async function handleDispatchEnvelope(
     runtime,
     source,
     ccSessionFactory,
+    agentTeamFactory,
     policyEngine,
     stack,
     trustResolver,
@@ -836,12 +850,17 @@ async function handleDispatchEnvelope(
   // Per-dispatch harness — see fn-doc above for rationale. `source` is
   // structurally compatible between `SystemEventSource` and the harness's
   // `DispatchEventSource` (both alias the same shape in `dispatch-events.ts`).
-  const harness: SessionHarness = new ClaudeCodeHarness({
-    source,
-    ...(ccSessionFactory !== undefined && { ccSessionFactory }),
-  });
-
   const req = buildDispatchRequest(payload, gatedPrincipal);
+  const harness: SessionHarness =
+    envelope.distribution_mode === "delegate"
+      ? new AgentTeamHarness({
+          source,
+          ...(agentTeamFactory !== undefined && { agentTeamFactory }),
+        })
+      : new ClaudeCodeHarness({
+          source,
+          ...(ccSessionFactory !== undefined && { ccSessionFactory }),
+        });
 
   // Drain the harness's lifecycle stream onto the bus. The harness
   // guarantees at least one terminal envelope; we publish whatever it
@@ -1220,4 +1239,3 @@ async function emitReceivingAgentUnconfiguredDeny(
   });
   await runtime.publish(failed);
 }
-

--- a/src/substrates/claude-code/harness.ts
+++ b/src/substrates/claude-code/harness.ts
@@ -88,6 +88,10 @@ import {
   createDispatchTaskStartedEvent,
   type DispatchEventSource,
 } from "../../bus/dispatch-events";
+import {
+  truncateDispatchErrorSummary,
+  truncateDispatchResultSummary,
+} from "../../bus/dispatch-lifecycle-summary";
 
 // ---------------------------------------------------------------------------
 // Session factory — same shape as dispatch-listener uses
@@ -463,7 +467,7 @@ export class ClaudeCodeHarness implements SessionHarness {
       correlationId,
       startedAt,
       failedAt: new Date(),
-      errorSummary: truncateError(errorSummary),
+      errorSummary: truncateDispatchErrorSummary(errorSummary),
     });
   }
 
@@ -519,7 +523,7 @@ export class ClaudeCodeHarness implements SessionHarness {
         startedAt,
         correlationId,
         new Date(),
-        result.response ? truncateSummary(result.response) : undefined,
+        result.response ? truncateDispatchResultSummary(result.response) : undefined,
       );
     }
 
@@ -543,36 +547,4 @@ export class ClaudeCodeHarness implements SessionHarness {
       `claude exited ${result.exitCode}`,
     );
   }
-}
-
-// ---------------------------------------------------------------------------
-// Local helpers
-// ---------------------------------------------------------------------------
-
-/**
- * Cheap UUID v4-ish validator. The envelope schema requires UUID-shaped
-// cortex#196 — loose UUID check (`isUuidLoose`) is shared in
-// `src/common/types/uuid.ts`. We match any 8-4-4-4-12 hex layout
-// without enforcing the version/variant nibbles (the JSON Schema
-// does the strict check downstream); v6/v7 session ids from CC
-// pass cleanly.
-
-/**
- * Trim error messages so a verbose stack doesn't blow the worklog limit
- * downstream. 500 chars matches the `system.inbound.failed` convention
- * (system-events §3.5.4). Copied from dispatch-listener.ts:419 — same
- * cap, same rationale.
- */
-function truncateError(msg: string): string {
-  return msg.length > 500 ? msg.slice(0, 497) + "..." : msg;
-}
-
-/**
- * Trim CC response summaries. Surfaces typically render the first line +
- * "(more)..." — cap at 1000 chars to leave room for a label prefix
- * without truncation surprises. Copied from dispatch-listener.ts:428.
- */
-function truncateSummary(text: string): string {
-  const first = text.split("\n", 1)[0] ?? text;
-  return first.length > 1000 ? first.slice(0, 997) + "..." : first;
 }


### PR DESCRIPTION
Closes #408.

## Summary
- add the agent-team HarnessId and SessionHarness wrapper around AgentTeam
- route delegate-mode dispatch envelopes through AgentTeamHarness
- keep direct dispatches on ClaudeCodeHarness
- add focused harness and listener routing coverage

## Verification
- bun test src/common/substrates/__tests__/types.test.ts
- bun test src/runner/__tests__/agent-team-harness.test.ts
- bun test src/runner/__tests__/dispatch-listener.test.ts
- bunx tsc --noEmit
- git diff --check

## Notes
- bun test src/runner/ currently has two local/environmental failures unrelated to this patch: a real Claude smoke test returns unsuccessful, and bash-guard HTTP ingest test collides on hardcoded port 8766.