### PR TITLE
fix(bus): set review-consumer ack_wait above review wall-time (closes #422)

### DIFF
--- a/src/bus/jetstream/__tests__/provision.test.ts
+++ b/src/bus/jetstream/__tests__/provision.test.ts
@@ -10,6 +10,7 @@
 
 import { describe, expect, test } from "bun:test";
 import {
+  DEFAULT_ACK_WAIT_NS,
   describeStreamDrift,
   isNotFoundError,
   provisionReviewConsumer,
@@ -27,6 +28,7 @@ interface RecorderState {
   streamAddCalls: Partial<StreamInfo["config"]>[];
   consumerInfoCalls: { stream: string; durable: string }[];
   consumerAddCalls: { stream: string; cfg: Record<string, unknown> }[];
+  consumerUpdateCalls: { stream: string; durable: string; cfg: Record<string, unknown> }[];
 }
 
 function makeJsm(opts: {
@@ -38,6 +40,7 @@ function makeJsm(opts: {
     streamAddCalls: [],
     consumerInfoCalls: [],
     consumerAddCalls: [],
+    consumerUpdateCalls: [],
   };
   const jsm: ProvisionJsm = {
     streams: {
@@ -73,6 +76,10 @@ function makeJsm(opts: {
       add: async (stream, cfg) => {
         state.consumerAddCalls.push({ stream, cfg });
         return { name: cfg.durable_name } as unknown as ConsumerInfo;
+      },
+      update: async (stream, durable, cfg) => {
+        state.consumerUpdateCalls.push({ stream, durable, cfg });
+        return { name: durable, config: cfg } as unknown as ConsumerInfo;
       },
     },
   };
@@ -318,12 +325,18 @@ describe("provisionReviewConsumer", () => {
     expect(cfg.ack_policy).toBe("explicit");
     expect(cfg.deliver_policy).toBe("all");
     expect(cfg.max_deliver).toBe(5);
+    // cortex#422 — ack_wait must be set on create (else JetStream's 30s
+    // default redelivers mid-review → duplicate review + post).
+    expect(cfg.ack_wait).toBe(DEFAULT_ACK_WAIT_NS);
     // No filter subject when not requested.
     expect("filter_subject" in cfg).toBe(false);
   });
 
-  test("idempotent — exists path returns 'exists' without calling add", async () => {
-    const existing = { name: "cortex-review-consumer-jc-sage" } as unknown as ConsumerInfo;
+  test("idempotent — exists path with matching ack_wait returns 'exists' without add/update", async () => {
+    const existing = {
+      name: "cortex-review-consumer-jc-sage",
+      config: { ack_wait: DEFAULT_ACK_WAIT_NS },
+    } as unknown as ConsumerInfo;
     const { jsm, state } = makeJsm({ existingConsumer: existing });
     const outcome = await provisionReviewConsumer({
       jsm,
@@ -333,6 +346,44 @@ describe("provisionReviewConsumer", () => {
     });
     expect(outcome).toBe("exists");
     expect(state.consumerAddCalls.length).toBe(0);
+    expect(state.consumerUpdateCalls.length).toBe(0);
+  });
+
+  test("cortex#422 — exists with drifted ack_wait returns 'updated' and reconciles in place", async () => {
+    // Simulate the pre-fix durable: created without ack_wait → JetStream's
+    // 30s default (30_000_000_000 ns).
+    const existing = {
+      name: "cortex-review-consumer-jc-sage",
+      config: { ack_wait: 30_000_000_000, max_deliver: 5 },
+    } as unknown as ConsumerInfo;
+    const { jsm, state } = makeJsm({ existingConsumer: existing });
+    const outcome = await provisionReviewConsumer({
+      jsm,
+      stream: "CODE_REVIEW",
+      durable: "cortex-review-consumer-jc-sage",
+      log: silentLog(),
+    });
+    expect(outcome).toBe("updated");
+    expect(state.consumerAddCalls.length).toBe(0);
+    expect(state.consumerUpdateCalls.length).toBe(1);
+    const upd = state.consumerUpdateCalls[0]!;
+    expect(upd.stream).toBe("CODE_REVIEW");
+    expect(upd.durable).toBe("cortex-review-consumer-jc-sage");
+    expect(upd.cfg.ack_wait).toBe(DEFAULT_ACK_WAIT_NS);
+    // Existing config fields are preserved through the update spread.
+    expect(upd.cfg.max_deliver).toBe(5);
+  });
+
+  test("cortex#422 — custom ackWaitNs is honored on create", async () => {
+    const { jsm, state } = makeJsm({ existingConsumer: "not-found" });
+    await provisionReviewConsumer({
+      jsm,
+      stream: "CODE_REVIEW",
+      durable: "x",
+      ackWaitNs: 90_000_000_000,
+      log: silentLog(),
+    });
+    expect(state.consumerAddCalls[0]!.cfg.ack_wait).toBe(90_000_000_000);
   });
 
   test("filter_subject is set when supplied", async () => {

--- a/src/bus/jetstream/provision.ts
+++ b/src/bus/jetstream/provision.ts
@@ -65,7 +65,7 @@ export type ProvisionStreamOutcome = "created" | "exists" | "config-drift-warnin
  * subtler-than-stream drift modes are best surfaced when an operator
  * hits one).
  */
-export type ProvisionConsumerOutcome = "created" | "exists";
+export type ProvisionConsumerOutcome = "created" | "exists" | "updated";
 
 /**
  * @deprecated Use `ProvisionStreamOutcome` or `ProvisionConsumerOutcome`
@@ -124,12 +124,29 @@ export interface ProvisionConsumerOpts {
    * Max delivery attempts before JetStream terms the message. Default 5.
    */
   maxDeliver?: number;
+  /**
+   * Per-message ack deadline in NANOSECONDS. JetStream redelivers a message
+   * that isn't acked within this window. Defaults to {@link DEFAULT_ACK_WAIT_NS}
+   * (20 min) — comfortably above a review's wall-time so a healthy in-flight
+   * review never triggers a redelivery (cortex#422). Left to the JetStream
+   * default of 30s, a ~100s review redelivers mid-run and the consumer
+   * re-runs the pipeline → duplicate review + duplicate forge post.
+   */
+  ackWaitNs?: number;
   log?: { info: (msg: string) => void; warn: (msg: string) => void };
 }
 
 const DEFAULT_MAX_AGE_NS = 24 * 3600 * 1_000_000_000;
 const DEFAULT_MAX_BYTES = 512 * 1024 * 1024;
 const DEFAULT_MAX_DELIVER = 5;
+/**
+ * Default per-message ack deadline: 20 minutes in nanoseconds. Sized well
+ * above a review's wall-time (sage's per-lens timeout is 600s; the pipeline
+ * self-terminates long before this) so a healthy in-flight review never
+ * redelivers. The JetStream default is 30s — far below a ~100s review — which
+ * caused the duplicate-review/duplicate-post bug (cortex#422).
+ */
+export const DEFAULT_ACK_WAIT_NS = 20 * 60 * 1_000_000_000;
 
 /**
  * Provision (or assert presence of) the JetStream stream that carries
@@ -205,12 +222,26 @@ export async function provisionReviewConsumer(
 ): Promise<ProvisionConsumerOutcome> {
   const log = opts.log ?? console;
   const maxDeliver = opts.maxDeliver ?? DEFAULT_MAX_DELIVER;
+  const ackWaitNs = opts.ackWaitNs ?? DEFAULT_ACK_WAIT_NS;
 
   try {
-    await opts.jsm.consumers.info(opts.stream, opts.durable);
-    // No drift check on consumers in v1 — the surface is small enough
-    // that operators rarely tune it, and pull-consumer drift is more
-    // subtle than stream drift. Add when an operator hits the gap.
+    const existing = await opts.jsm.consumers.info(opts.stream, opts.durable);
+    // cortex#422 — `ack_wait` is the one consumer field we DO reconcile on
+    // drift. The original durable was created without it (JetStream default
+    // 30s), so already-provisioned brokers carry the bug until the consumer
+    // is recreated. Update it in place when it doesn't match the desired
+    // deadline so a redeploy fixes live durables without a manual
+    // `nats consumer rm`. Other fields stay un-reconciled (v1 policy).
+    if (existing.config?.ack_wait !== ackWaitNs) {
+      await opts.jsm.consumers.update(opts.stream, opts.durable, {
+        ...existing.config,
+        ack_wait: ackWaitNs,
+      });
+      log.info(
+        `jetstream-provision: updated consumer "${opts.durable}" ack_wait ${Math.round((existing.config?.ack_wait ?? 0) / 1_000_000_000)}s → ${Math.round(ackWaitNs / 1_000_000_000)}s (cortex#422)`,
+      );
+      return "updated";
+    }
     return "exists";
   } catch (err) {
     if (!isNotFoundError(err)) {
@@ -223,13 +254,14 @@ export async function provisionReviewConsumer(
     ack_policy: AckPolicy.Explicit,
     deliver_policy: DeliverPolicy.All,
     max_deliver: maxDeliver,
+    ack_wait: ackWaitNs,
   };
   if (opts.filterSubject !== undefined) {
     cfg.filter_subject = opts.filterSubject;
   }
   await opts.jsm.consumers.add(opts.stream, cfg);
   log.info(
-    `jetstream-provision: created consumer "${opts.durable}" on stream "${opts.stream}" (ack=explicit, max_deliver=${maxDeliver}${opts.filterSubject ? `, filter=${opts.filterSubject}` : ""})`,
+    `jetstream-provision: created consumer "${opts.durable}" on stream "${opts.stream}" (ack=explicit, max_deliver=${maxDeliver}, ack_wait=${Math.round(ackWaitNs / 1_000_000_000)}s${opts.filterSubject ? `, filter=${opts.filterSubject}` : ""})`,
   );
   return "created";
 }

--- a/src/bus/jetstream/types.ts
+++ b/src/bus/jetstream/types.ts
@@ -31,5 +31,10 @@ export interface ProvisionJsm {
   consumers: {
     info(stream: string, durable: string): Promise<ConsumerInfo>;
     add(stream: string, cfg: Partial<ConsumerConfig>): Promise<ConsumerInfo>;
+    update(
+      stream: string,
+      durable: string,
+      cfg: Partial<ConsumerConfig>,
+    ): Promise<ConsumerInfo>;
   };
 }

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -982,6 +982,10 @@ export async function startCortex(
             console.log(
               `cortex: provisioned JetStream durable "${durable}" on stream "${reviewStream}"`,
             );
+          } else if (outcome === "updated") {
+            console.log(
+              `cortex: reconciled JetStream durable "${durable}" ack_wait (cortex#422) on stream "${reviewStream}"`,
+            );
           }
         } catch (provisionErr) {
           // Don't abort — let consumer.start surface the bind failure


### PR DESCRIPTION
## Summary

Fixes the duplicate-review / duplicate-forge-post bug (#422). The review JetStream durable was created without `ack_wait`, so it used JetStream's **30s** default while a sage review runs **~100s** — the ack deadline expired mid-review, JetStream redelivered, and `ReviewConsumer` re-ran the whole pipeline → a second review + a second GitHub post on every `--post` dispatch.

## Changes

- `provision.ts` — provision the review consumer with `ack_wait` = **20 min** (default, configurable via `ackWaitNs`). Comfortably above the pipeline's own 600s self-timeout, so a healthy in-flight review never redelivers; a genuinely crashed one still redelivers after the deadline.
- `provision.ts` — the `exists` path now **reconciles `ack_wait` in place** (new `update` on the narrow `ProvisionJsm`) instead of short-circuiting. Already-provisioned brokers (carrying the 30s default) get fixed on the next boot/redeploy — no manual `nats consumer rm`. New `"updated"` outcome.
- `cortex.ts` — log the `updated` outcome at boot.
- tests — create sets `ack_wait`; exists+matching → `exists` (no update); exists+drift → `updated` (reconciles in place, preserves other fields); custom `ackWaitNs` honored.

## Verification

- `bunx tsc --noEmit` — clean
- `bun test src/bus/jetstream/` — 22 pass (4 new)
- `bun test src/bus/` — 524 pass / 0 fail
- `bun test src/__tests__/cortex.review-consumer-boot.test.ts` — 6 pass

## Out of scope (follow-ups)

- `working()` ack-heartbeats for unbounded-length reviews (a hung sage subprocess past 20min would still redeliver). pi-dev-runner lacks a subprocess timeout — separate hardening.
- Idempotency on `correlation_id` for the post-then-crash edge (review posts, then crashes before ack → legitimate redelivery re-posts). Rare; not the observed bug.

Closes #422.

🤖 Generated with [Claude Code](https://claude.com/claude-code)