### PR TITLE
fix(lint): clear 9 eslint errors blocking CI lint gate on main

### DIFF
--- a/src/bus/__tests__/dispatch-handler.test.ts
+++ b/src/bus/__tests__/dispatch-handler.test.ts
@@ -902,14 +902,14 @@ describe("DispatchHandler — chat-path CC failure retry (cortex#360)", () => {
 
 interface RecordingRuntimeWithSubject extends MyelinRuntime {
   publishes: Envelope[];
-  subjectPublishes: Array<{ envelope: Envelope; subject: string }>;
+  subjectPublishes: { envelope: Envelope; subject: string }[];
 }
 
 function makeRecordingRuntimeWithSubject(opts: {
   publishOnSubjectImpl?: (envelope: Envelope, subject: string) => Promise<void>;
 } = {}): RecordingRuntimeWithSubject {
   const publishes: Envelope[] = [];
-  const subjectPublishes: Array<{ envelope: Envelope; subject: string }> = [];
+  const subjectPublishes: { envelope: Envelope; subject: string }[] = [];
   return {
     enabled: true,
     onEnvelope: () => ({ unregister: () => {} }),
@@ -1038,7 +1038,7 @@ describe("DispatchHandler — Direction A Stage 4-B inbound envelope publish (co
     );
 
     // Payload mirrors DispatchTaskReceivedPayload shape.
-    const payload = envelope.payload as Record<string, unknown>;
+    const payload = envelope.payload;
     expect(payload.task_id).toBe("11111111-1111-4111-8111-111111111111");
     expect(payload.agent_id).toBe("test-agent");
     expect(payload.prompt).toBe("user prompt here");

--- a/src/bus/dispatch-source-publisher.ts
+++ b/src/bus/dispatch-source-publisher.ts
@@ -84,8 +84,7 @@ export async function publishInboundChatDispatchEnvelope(
   if (!opts.runtime || !opts.source) {
     return { published: false, reason: "missing-runtime" };
   }
-  const publishOnSubject = opts.runtime.publishOnSubject;
-  if (typeof publishOnSubject !== "function") {
+  if (typeof opts.runtime.publishOnSubject !== "function") {
     return { published: false, reason: "missing-publish-on-subject" };
   }
 
@@ -173,7 +172,7 @@ export async function publishInboundChatDispatchEnvelope(
   }
 
   try {
-    await publishOnSubject.call(opts.runtime, envelope, subject);
+    await opts.runtime.publishOnSubject(envelope, subject);
   } catch (err) {
     console.error(
       `dispatch-source: publishOnSubject(${subject}) failed:`,

--- a/src/bus/jetstream/provision.ts
+++ b/src/bus/jetstream/provision.ts
@@ -232,13 +232,13 @@ export async function provisionReviewConsumer(
     // is recreated. Update it in place when it doesn't match the desired
     // deadline so a redeploy fixes live durables without a manual
     // `nats consumer rm`. Other fields stay un-reconciled (v1 policy).
-    if (existing.config?.ack_wait !== ackWaitNs) {
+    if (existing.config.ack_wait !== ackWaitNs) {
       await opts.jsm.consumers.update(opts.stream, opts.durable, {
         ...existing.config,
         ack_wait: ackWaitNs,
       });
       log.info(
-        `jetstream-provision: updated consumer "${opts.durable}" ack_wait ${Math.round((existing.config?.ack_wait ?? 0) / 1_000_000_000)}s → ${Math.round(ackWaitNs / 1_000_000_000)}s (cortex#422)`,
+        `jetstream-provision: updated consumer "${opts.durable}" ack_wait ${Math.round((existing.config.ack_wait ?? 0) / 1_000_000_000)}s → ${Math.round(ackWaitNs / 1_000_000_000)}s (cortex#422)`,
       );
       return "updated";
     }

--- a/src/bus/review-consumer.ts
+++ b/src/bus/review-consumer.ts
@@ -904,7 +904,7 @@ function parsePrUrl(url: string): { repo: string; pr: number } | null {
     return null;
   }
 
-  const gh = parsed.pathname.match(/^\/([^/]+)\/([^/]+)\/pull\/(\d+)\/?$/);
+  const gh = /^\/([^/]+)\/([^/]+)\/pull\/(\d+)\/?$/.exec(parsed.pathname);
   if (gh) {
     const owner = gh[1];
     const repo = gh[2];
@@ -915,7 +915,7 @@ function parsePrUrl(url: string): { repo: string; pr: number } | null {
     return Number.isInteger(pr) && pr > 0 ? { repo: `${owner}/${repo}`, pr } : null;
   }
 
-  const gl = parsed.pathname.match(/^\/(.+)\/-\/merge_requests\/(\d+)\/?$/);
+  const gl = /^\/(.+)\/-\/merge_requests\/(\d+)\/?$/.exec(parsed.pathname);
   if (gl) {
     const projectPath = gl[1];
     const n = gl[2];

--- a/src/runner/dispatch-listener.ts
+++ b/src/runner/dispatch-listener.ts
@@ -1147,7 +1147,7 @@ function validateCanonicalTaskRecipient(
   const tasksIndex = parts.indexOf("tasks");
   if (tasksIndex === -1) return null;
   const assistantSegment = parts[tasksIndex + 1];
-  if (assistantSegment === undefined || !assistantSegment.startsWith("@")) {
+  if (!assistantSegment?.startsWith("@")) {
     return null;
   }
 


### PR DESCRIPTION
## Summary
The CI **Lint** job (`eslint --quiet .`) has been red on `main` — 9 errors across 5 files, blocking the gate for every PR. Typecheck/Test/governance were green; only Lint failed. This clears all 9.

- **6 autofixable** (`eslint --fix`): `array-type` ×2, `no-unnecessary-type-assertion` ×1, `prefer-regexp-exec` ×2, `prefer-optional-chain` ×1
- **3 fixed by hand**:
  - `dispatch-source-publisher.ts:87` — `unbound-method`: dropped the extracted `publishOnSubject` reference; call it as a method on `opts.runtime` (same `this`-binding the prior `.call(opts.runtime, …)` provided — no behavior change)
  - `provision.ts:235,241` — `no-unnecessary-condition`: `existing.config` is non-nullish per its type, so the optional chain on `.ack_wait` was unnecessary

## Scope
Only the 5 files that carried **errors**. `eslint --fix` also rewrites warning-level autofixes repo-wide; those were intentionally reverted to keep this PR atomic to the CI-blocking gate.

## Verification
- `bun run lint:errors` → exit 0 (clean)
- `bunx tsc --noEmit` → exit 0
- `bun test` → 3518 pass, 2 skip, 0 fail

## Out of Scope
- Warning-level lint cleanup (separate pass if wanted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)