### PR TITLE
fix(lint): clear 4 typescript-eslint errors blocking CI gate on main

### DIFF
--- a/src/cli/cortex/commands/migrate-config-lib.ts
+++ b/src/cli/cortex/commands/migrate-config-lib.ts
@@ -1012,7 +1012,7 @@ function synthesizeRuntimeCapabilities(
   if (!Array.isArray(agents)) return;
   const rawCatalog = Array.isArray(cortex.capabilities) ? cortex.capabilities : [];
   const catalog: CortexCapabilityMutable[] = rawCatalog.map((c) =>
-    c && typeof c === "object" ? { ...(c as CortexCapabilityMutable) } : ({ id: "" } as CortexCapabilityMutable),
+    c && typeof c === "object" ? { ...(c as CortexCapabilityMutable) } : { id: "" },
   );
   const catalogById = new Map<string, CortexCapabilityMutable>();
   for (const entry of catalog) {
@@ -1196,13 +1196,12 @@ function synthesizeSurfaceSubjects(
     if (!rawAgent || typeof rawAgent !== "object") continue;
     const agent = rawAgent as CortexAgentMutable;
     const presence = agent.presence;
-    if (!presence || typeof presence !== "object") continue;
     // mattermost intentionally omitted — MattermostPresenceSchema does not
     // declare surfaceSubjects yet (cortex#205-followup). Adding mattermost
     // here without the schema field produces a misleading warning because
     // Zod strips the synthesised value on parse. See doc-comment above.
     for (const platform of ["discord", "slack"] as const) {
-      const block = (presence as Record<string, unknown>)[platform];
+      const block = presence[platform];
       if (!block || typeof block !== "object") continue;
       const adapterBlock = block as Record<string, unknown>;
       const existing = adapterBlock.surfaceSubjects;
@@ -1942,7 +1941,7 @@ export function formatCheckReport(result: ConversionResult): string {
   }
   // cortex#428 — show the (possibly synthesised) top-level capability catalog
   // so operators reviewing `--check` output see the catalog augmentation.
-  if (result.cortex.capabilities && result.cortex.capabilities.length > 0) {
+  if (result.cortex.capabilities.length > 0) {
     lines.push(`capabilities: ${result.cortex.capabilities.length}`);
     for (const c of result.cortex.capabilities) {
       lines.push(`  - ${c.id} provided_by=[${c.provided_by.join(", ")}]`);


### PR DESCRIPTION
## Why

PR-B (#432, merged as `6a398bc`) introduced 4 ESLint errors that the lint blocking gate catches. Test + Typecheck + Compass governance all pass; only Lint fails. This blocks the lint gate on every subsequent PR (#434 already affected).

Same shape as cortex#425 from a few days ago — eslint blocking gate is strict and a small follow-up unblocks the whole pipeline.

## What changed

Four removals in `src/cli/cortex/commands/migrate-config-lib.ts`:

| Line | Error | Fix |
|---|---|---|
| 1015 | `@typescript-eslint/no-unnecessary-type-assertion` | drop `as CortexCapabilityMutable` cast on `{ id: "" }` literal |
| 1199 | `@typescript-eslint/no-unnecessary-condition` (always falsy) | remove dead `if (!presence || typeof presence !== "object") continue;` |
| 1205 | `@typescript-eslint/no-unnecessary-type-assertion` | drop `as Record<string, unknown>` cast on `presence[platform]` |
| 1945 | `@typescript-eslint/no-unnecessary-condition` (always truthy) | drop `result.cortex.capabilities && ` (field is always defined) |

## Verification

- `bun run lint:errors` (= `eslint --quiet .`) — clean exit
- Behaviour preserved: removing dead `if`-checks doesn't change control flow because the conditions were never true at runtime per TS's type system

## Refs

- cortex#426 (C-388 follow-up umbrella)
- cortex#428 (PR-B that introduced these)
- cortex#425 (prior precedent for "9 eslint errors blocking CI" fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)