### PR TITLE
docs(cortex): PR-R8a — principal cockpit literal sweep (#441)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -663,7 +663,7 @@ agents:                            # first-class agent bundles — the canonical
         guildId: "1487..."
 
 renderers:                          # multi-agent / non-agent-bound surfaces
-  - kind: dashboard                 # operator cockpit — Mission Control v3
+  - kind: dashboard                 # principal cockpit — Mission Control v3
     port: 8767
     publicUrl: https://cortex.meta-factory.ai
     subscribe: ["local.{org}.>"]

--- a/docs/design-mission-control.md
+++ b/docs/design-mission-control.md
@@ -18,7 +18,7 @@ This document is the single source of truth for Grove Mission Control. Every cla
 
 ### 1.1 Goal
 
-Grove Mission Control is **the operator's cockpit for running many agents against a curated backlog**. One operator, many agents, many tasks, one dashboard. The core job of the dashboard is: **surface the agent that needs the operator right now, and let the operator unblock it without leaving the UI.**
+Cortex Mission Control is **the principal's cockpit for running many agents against a curated backlog**. One operator, many agents, many tasks, one dashboard. The core job of the dashboard is: **surface the agent that needs the operator right now, and let the operator unblock it without leaving the UI.**
 
 Three properties follow from that job:
 


### PR DESCRIPTION
## Summary

Two literal phrase substitutions in pure docs — the lightweight pre-sweep half of R8 (operator→principal). No dashboard or wire coupling.

- `docs/architecture.md:666` — dashboard renderer YAML comment `# operator cockpit` → `# principal cockpit`
- `docs/design-mission-control.md:21` — §1.1 lead clause `Grove Mission Control is the operator's cockpit…` → `Cortex Mission Control is the principal's cockpit…`

Part of the cortex#436 vocabulary-migration-finish iteration (plan §R8, step 5).

## Out of scope (handled elsewhere — pre-flagged so it isn't flagged as a gap)

- The 4 dashboard-coupled `operator filter` hits (`use-hash-state.ts:47`, `state.ts:61/447`, `slack-adapter.test.ts:1403`) land in **PR-R13d (#450)** alongside the §6 eventKinds rename, so UI prose + wire stay coherent in one boundary.
- The remaining `operator` prose on `design-mission-control.md:21` and throughout that doc is overwritten by the full rewrite in **PR-R13e (#451)**. This 1-line touch only keeps the file consistent during the iteration so cross-reads don't drift.

## Acceptance criteria

- [x] `grep -n 'operator cockpit\|operator filter' docs/architecture.md docs/design-mission-control.md` returns 0 hits
- [x] PR body links cortex#436 and notes the 4 dashboard-coupled hits land in PR-R13d

## Test plan

- [x] `bunx tsc --noEmit` clean (no code touched; docs-only)

Closes #441