### PR TITLE
feat(cortex): C-6 — persona semantic sweep (closes #442)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -23,8 +23,8 @@
 For months we've operated as heavy Discord-and-dashboard users. The lived pattern:
 
 - **Discord** as the primary surface, with a channel-per-repo routing convention (`#grove`, `#arc`, `#compass`, `#myelin`, `#blueprint`, etc. — one channel per repo, threads for individual issues / PRs / features).
-- **Multiple agent personas** collaborating in those channels — Luna, Echo, Holly, Ivy, Forge — each with their own Discord identity, persona file, capability gates, and trust relationships. Principals ping a persona; the persona does work.
-- **The pilot review loop** running on top of those personas: open PR → ping reviewer-persona → reviewer reads, posts findings → principal/agent triages → fix or defer → re-ping → merge. Driven by the `pilot` CLI; foundational and backend support coming from compass SOPs, blueprint dependency tracking, and a cloud of CLAUDE.md files.
+- **Multiple assistants** collaborating in those channels — Luna, Echo, Holly, Ivy, Forge — each with their own Discord identity, assistant prompt file, capability gates, and trust relationships. Principals ping an assistant; the assistant does work.
+- **The pilot review loop** running on top of those assistants: open PR → ping reviewer-assistant → reviewer reads, posts findings → principal/agent triages → fix or defer → re-ping → merge. Driven by the `pilot` CLI; foundational and backend support coming from compass SOPs, blueprint dependency tracking, and a cloud of CLAUDE.md files.
 - **The Grove dashboard** as the secondary surface — repository-organised activity feed, GitHub entities (releases / issues / PRs) visible inline, agent state per repo, F-7 attention view for "what needs me." The browser tab the principal left open all day.
 - **Mattermost** as a parallel surface for flows that didn't live in Discord — same adapter pattern, different platform.
 

--- a/src/bus/review-consumer.ts
+++ b/src/bus/review-consumer.ts
@@ -120,7 +120,7 @@ export interface ReviewConsumerAgent {
 /**
  * Build the CC prompt for a single review request. Production callers
  * pass a function that assembles the security preamble + skill
- * invocation + persona prefix; tests pass a deterministic stub.
+ * invocation + assistant prefix; tests pass a deterministic stub.
  *
  * Returning a string (not a {@link CCSessionOpts}) keeps the consumer
  * free of skill-allowlist + cwd + timeout policy — those flow through

--- a/src/cli/cortex/commands/__tests__/migrate-config.test.ts
+++ b/src/cli/cortex/commands/__tests__/migrate-config.test.ts
@@ -347,16 +347,16 @@ describe("convertBotYaml — nats.identity shape divergence", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Conversion: persona-file validation
+// Conversion: assistant-prompt-file validation
 // ---------------------------------------------------------------------------
 
-describe("convertBotYaml — persona-file validation", () => {
+describe("convertBotYaml — assistant-prompt-file validation", () => {
   test("warns when personaFile path does not exist on disk", () => {
     const legacy = loadFixture("missing-persona.bot.yaml");
     const result = convertBotYaml(legacy, { configDir: FIXTURE_DIR });
     const personaWarn = result.warnings.find((w) => w.field === "agents[ghost].persona");
     expect(personaWarn).toBeDefined();
-    expect(personaWarn!.message).toMatch(/persona file not found/);
+    expect(personaWarn!.message).toMatch(/assistant prompt file not found/);
   });
 
   test("skips file-existence check when configDir is omitted", () => {
@@ -1205,7 +1205,7 @@ describe("runMigrateConfig", () => {
   });
 
   test("--strict returns exit code 2 when warnings present", async () => {
-    // missing-persona fixture produces a persona-file-not-found warning
+    // missing-persona fixture produces an assistant-prompt-file-not-found warning
     const code = await runMigrateConfig([
       join(FIXTURE_DIR, "missing-persona.bot.yaml"),
       "--check",
@@ -1549,7 +1549,7 @@ describe("convertBotYaml — cortex#428 PR-B runtime.capabilities synthesis", ()
     expect(agent.runtime!.capabilities).toEqual(["chat"]);
   });
 
-  test("persona-heuristic adds code-review.typescript at exactly the 2-match floor", () => {
+  test("assistant-prompt heuristic adds code-review.typescript at exactly the 2-match floor", () => {
     // Boundary test: the regex `/code[- ]review|reviewer|reviewing/gi`
     // must match EXACTLY 2 times to land on the floor and trip the
     // heuristic. The fixture below contains "Code review" and
@@ -1584,7 +1584,7 @@ describe("convertBotYaml — cortex#428 PR-B runtime.capabilities synthesis", ()
     );
   });
 
-  test("persona-heuristic stays at [chat] with exactly 1 keyword match (below floor)", () => {
+  test("assistant-prompt heuristic stays at [chat] with exactly 1 keyword match (below floor)", () => {
     // The complement of the floor test above: matches=1 must NOT add
     // code-review.typescript. Together the two tests pin the floor at
     // the regex boundary instead of via the loose "Forge deflector"
@@ -1616,9 +1616,9 @@ describe("convertBotYaml — cortex#428 PR-B runtime.capabilities synthesis", ()
     expect(result.cortex.agents[0]!.runtime!.capabilities).toEqual(["chat"]);
   });
 
-  test("persona with only one review-keyword mention stays at [chat] (deflector test)", () => {
-    // Production-bug repro: Forge's persona on Andreas's deployment mentions
-    // "code review" once while DEFLECTING review work to Echo
+  test("assistant prompt with only one review-keyword mention stays at [chat] (deflector test)", () => {
+    // Production-bug repro: Forge's assistant prompt on Andreas's deployment
+    // mentions "code review" once while DEFLECTING review work to Echo
     // ("Code review. That's Echo. If anyone asks you for a review,
     // redirect"). A single mention must NOT trip the heuristic.
     const tmp = mkdtempSync(join(tmpdir(), "cortex-mig-428-deflect-"));
@@ -1647,11 +1647,11 @@ describe("convertBotYaml — cortex#428 PR-B runtime.capabilities synthesis", ()
     expect(result.cortex.agents[0]!.runtime!.capabilities).toEqual(["chat"]);
   });
 
-  test("persona-heuristic skips oversized files with a warning (defence-in-depth size cap)", () => {
+  test("assistant-prompt heuristic skips oversized files with a warning (defence-in-depth size cap)", () => {
     // Defence-in-depth regression for the cortex#432 nit-3 size cap. A
-    // hostile or accidental large persona (`persona: /dev/zero`, stray
-    // huge fixture) must NOT OOM the migrator. The 1 MiB cap is well
-    // above any realistic persona; we synthesise a file just over the
+    // hostile or accidental large assistant prompt file (`persona: /dev/zero`,
+    // stray huge fixture) must NOT OOM the migrator. The 1 MiB cap is well
+    // above any realistic assistant prompt; we synthesise a file just over the
     // cap and assert (a) the heuristic short-circuits to [chat] and
     // (b) a ConversionWarning surfaces so the operator sees the skip.
     const tmp = mkdtempSync(join(tmpdir(), "cortex-mig-428-cap-oversize-"));
@@ -1686,7 +1686,7 @@ describe("convertBotYaml — cortex#428 PR-B runtime.capabilities synthesis", ()
       (w) =>
         w.field === "agents[huge].persona" &&
         w.message.includes("byte cap") &&
-        w.message.includes("skipping persona-driven capability heuristic"),
+        w.message.includes("skipping assistant-prompt-driven capability heuristic"),
     );
     expect(sizeWarning).toBeDefined();
   });
@@ -1817,7 +1817,7 @@ describe("convertBotYaml — cortex#428 PR-B runtime.capabilities synthesis", ()
 
   test("catalog merge — pre-existing entry survives, provided_by unioned", () => {
     // Existing catalog has code-review.typescript with one provider (echo).
-    // Echo's runtime claims it; another agent's persona heuristic also
+    // Echo's runtime claims it; another agent's assistant-prompt heuristic also
     // would, BUT the heuristic only fires when no caps were declared. So
     // the test exercises the unconditional `chat` cap append + the
     // preserve-existing-catalog-entry path.

--- a/src/cli/cortex/commands/migrate-config-lib.ts
+++ b/src/cli/cortex/commands/migrate-config-lib.ts
@@ -277,8 +277,8 @@ export interface ConvertOptions {
   /**
    * Directory the input `bot.yaml` was loaded from. Used to resolve
    * `personaFile` paths for the file-exists validation. Optional — when
-   * omitted, persona files are not checked on disk (e.g. when tests parse
-   * fixtures via in-memory strings rather than file paths).
+   * omitted, assistant prompt files are not checked on disk (e.g. when
+   * tests parse fixtures via in-memory strings rather than file paths).
    */
   configDir?: string;
   /**
@@ -460,39 +460,39 @@ function convertMattermostPresence(inst: LegacyMattermostInstance): MattermostPr
 }
 
 /**
- * Resolve the persona file path for a converted agent. Returns the path the
- * cortex.yaml should carry plus an optional warning when the file doesn't
- * exist on disk (only checked when `configDir` is supplied).
+ * Resolve the assistant prompt file path for a converted agent. Returns the
+ * path the cortex.yaml should carry plus an optional warning when the file
+ * doesn't exist on disk (only checked when `configDir` is supplied).
  *
  * Fallback when `personaFile` is unset: `./personas/${agentId}.md`. The
  * cortex schema requires a non-empty string here; the warning surfaces the
  * fact that the file may need to be created.
  */
-function resolvePersona(
+function resolveAssistantPath(
   legacyPersonaFile: string | undefined,
   agentId: string,
   configDir: string | undefined,
   warnings: ConversionWarning[],
 ): string {
   // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-  const personaPath = legacyPersonaFile?.trim() || `./personas/${agentId}.md`;
+  const assistantPath = legacyPersonaFile?.trim() || `./personas/${agentId}.md`;
 
   if (configDir) {
-    const abs = isAbsolute(personaPath) ? personaPath : resolve(configDir, personaPath);
+    const abs = isAbsolute(assistantPath) ? assistantPath : resolve(configDir, assistantPath);
     if (!existsSync(abs)) {
       warnings.push({
         field: `agents[${agentId}].persona`,
-        message: `persona file not found at ${abs}${legacyPersonaFile ? "" : " (defaulted from agent name)"}`,
+        message: `assistant prompt file not found at ${abs}${legacyPersonaFile ? "" : " (defaulted from agent name)"}`,
       });
     }
   } else if (!legacyPersonaFile) {
     warnings.push({
       field: `agents[${agentId}].persona`,
-      message: `agent.personaFile not set; defaulted to ${personaPath}`,
+      message: `agent.personaFile not set; defaulted to ${assistantPath}`,
     });
   }
 
-  return personaPath;
+  return assistantPath;
 }
 
 /**
@@ -653,7 +653,7 @@ function detectSharedAgentChannelId(
  *   - LAST-RESORT fallback: numeric variant (`luna-2`, `luna-3`) when
  *     neither hint nor agent.name produces a distinct id and the operator
  *     has multiple adapters. Matches pre-#88 behaviour for parity.
- *   - Trust list and persona path propagate to every variant.
+ *   - Trust list and assistant prompt path propagate to every variant.
  */
 function buildAgents(
   legacy: LegacyBotYaml,
@@ -678,7 +678,7 @@ function buildAgents(
 
   const trust = buildTrustList(legacy.trustedAgentBots ?? [], warnings);
 
-  const persona = resolvePersona(legacyAgent.personaFile, baseId, configDir, warnings);
+  const persona = resolveAssistantPath(legacyAgent.personaFile, baseId, configDir, warnings);
   const displayName = legacyAgent.displayName || legacyAgent.name;
 
   const variantCount = Math.max(discordInstances.length, mattermostInstances.length, 1);
@@ -864,33 +864,35 @@ function buildRenderers(legacy: LegacyBotYaml, warnings: ConversionWarning[]): C
 const CHAT_CAPABILITY_ID = "chat";
 const CODE_REVIEW_CAPABILITY_ID = "code-review.typescript";
 /**
- * Heuristic: match agents whose persona file content suggests code-review
- * work. Conservative — false negatives are safer than false positives, since
- * a synthesised `code-review.typescript` capability that the agent doesn't
- * actually fulfil would surface a dispatch.task.failed reason later.
+ * Heuristic: match agents whose assistant prompt content suggests
+ * code-review work. Conservative — false negatives are safer than false
+ * positives, since a synthesised `code-review.typescript` capability that
+ * the agent doesn't actually fulfil would surface a dispatch.task.failed
+ * reason later.
  *
- * Threshold: ≥2 occurrences of the pattern in the persona body. Single
- * mentions are common in non-reviewer personas that DEFLECT review work
- * to a reviewer agent ("Code review — that's Echo's job, redirect there").
- * The two-occurrence floor cleanly separates Echo (actual reviewer,
- * mentions review multiple times) from Forge (deflector, mentions review
- * once while pointing at Echo) on Andreas's production deployment. The
- * pattern itself is intentionally loose — the count gate does the
+ * Threshold: ≥2 occurrences of the pattern in the assistant prompt body.
+ * Single mentions are common in non-reviewer assistants that DEFLECT review
+ * work to a reviewer agent ("Code review — that's Echo's job, redirect
+ * there"). The two-occurrence floor cleanly separates Echo (actual
+ * reviewer, mentions review multiple times) from Forge (deflector, mentions
+ * review once while pointing at Echo) on Andreas's production deployment.
+ * The pattern itself is intentionally loose — the count gate does the
  * specificity work.
  */
-const CODE_REVIEW_PERSONA_PATTERN = /code[- ]review|reviewer|reviewing/gi;
+const CODE_REVIEW_ASSISTANT_PATTERN = /code[- ]review|reviewer|reviewing/gi;
 const CODE_REVIEW_OCCURRENCE_FLOOR = 2;
 
 /**
- * Defence-in-depth size cap on persona file reads. Persona markdown files
- * are operator-authored under their own config dir (no untrusted input),
- * but a stray symlink to `/dev/zero` or a multi-GB markdown file in a bad
- * fixture dir would OOM the migrator. 1 MiB is two orders of magnitude
- * above any reasonable persona (real personas in andreas's deployment run
- * <10 KiB). Files above the cap skip the heuristic, default to ["chat"],
- * and emit a ConversionWarning so the operator notices.
+ * Defence-in-depth size cap on assistant prompt file reads. Assistant
+ * prompt markdown files are operator-authored under their own config dir
+ * (no untrusted input), but a stray symlink to `/dev/zero` or a multi-GB
+ * markdown file in a bad fixture dir would OOM the migrator. 1 MiB is two
+ * orders of magnitude above any reasonable assistant prompt (real prompts
+ * in andreas's deployment run <10 KiB). Files above the cap skip the
+ * heuristic, default to ["chat"], and emit a ConversionWarning so the
+ * operator notices.
  */
-const PERSONA_MAX_BYTES = 1 * 1024 * 1024;
+const ASSISTANT_PROMPT_MAX_BYTES = 1 * 1024 * 1024;
 
 interface CortexAgentMutable {
   id: string;
@@ -910,30 +912,31 @@ interface CortexCapabilityMutable {
 }
 
 /**
- * Read a persona file (if it exists on disk) and return a hint set: which of
- * the heuristic capability ids it suggests the agent provides. Off-disk or
- * unreadable persona files yield an empty set — the migrator falls back to
- * the safe default (`["chat"]`) without crashing on a missing persona path.
+ * Read an assistant prompt file (if it exists on disk) and return a hint
+ * set: which of the heuristic capability ids it suggests the agent
+ * provides. Off-disk or unreadable assistant prompt files yield an empty
+ * set — the migrator falls back to the safe default (`["chat"]`) without
+ * crashing on a missing assistant prompt path.
  *
- * The persona path on the migrated agent block is resolved relative to the
- * config dir at `resolvePersona` time; we apply the same convention here so
- * a relative `./personas/echo.md` reads off the same directory the operator
- * pointed the migrator at via `--out`.
+ * The assistant prompt path on the migrated agent block is resolved
+ * relative to the config dir at `resolveAssistantPath` time; we apply the
+ * same convention here so a relative `./personas/echo.md` reads off the
+ * same directory the operator pointed the migrator at via `--out`.
  */
-function detectCapabilityHintsFromPersona(
-  personaPath: string,
+function detectCapabilityHintsFromAssistantPrompt(
+  assistantPath: string,
   configDir: string | undefined,
   agentId: string,
   warnings: ConversionWarning[],
 ): Set<string> {
   const hints = new Set<string>();
-  // The persona path is required by `AgentSchema.persona` (`min(1)`), but a
-  // freshly-migrated config may carry a default-derived path
-  // (`./personas/{id}.md`) where the file has not yet been created. Treat
-  // missing files as "no hint" — the default `chat` capability still gets
-  // synthesised; we just don't speculatively add `code-review.typescript`.
+  // The assistant prompt path is required by `AgentSchema.persona`
+  // (`min(1)`), but a freshly-migrated config may carry a default-derived
+  // path (`./personas/{id}.md`) where the file has not yet been created.
+  // Treat missing files as "no hint" — the default `chat` capability still
+  // gets synthesised; we just don't speculatively add `code-review.typescript`.
   if (!configDir) return hints;
-  const abs = isAbsolute(personaPath) ? personaPath : resolve(configDir, personaPath);
+  const abs = isAbsolute(assistantPath) ? assistantPath : resolve(configDir, assistantPath);
   if (!existsSync(abs)) return hints;
   // Defence-in-depth size cap. statSync is cheap (one inode lookup); the
   // gate keeps a stray symlink (`persona: /dev/zero`) or an accidentally-
@@ -949,12 +952,12 @@ function detectCapabilityHintsFromPersona(
     // soft-skip just like the readFileSync catch below.
     return hints;
   }
-  if (size > PERSONA_MAX_BYTES) {
+  if (size > ASSISTANT_PROMPT_MAX_BYTES) {
     warnings.push({
       field: `agents[${agentId}].persona`,
       message:
-        `persona file at ${personaPath} is ${size} bytes (> ${PERSONA_MAX_BYTES} byte cap); ` +
-        `skipping persona-driven capability heuristic. If the file is legitimately this large, ` +
+        `assistant prompt file at ${assistantPath} is ${size} bytes (> ${ASSISTANT_PROMPT_MAX_BYTES} byte cap); ` +
+        `skipping assistant-prompt-driven capability heuristic. If the file is legitimately this large, ` +
         `declare runtime.capabilities explicitly on the agent in cortex.yaml.`,
     });
     return hints;
@@ -963,12 +966,12 @@ function detectCapabilityHintsFromPersona(
   try {
     body = readFileSync(abs, "utf-8");
   } catch {
-    // Persona file exists but is unreadable (permissions, …). The migrator
-    // already warns about file-existence elsewhere; treat the read failure
-    // as a soft skip rather than a fatal error.
+    // Assistant prompt file exists but is unreadable (permissions, …). The
+    // migrator already warns about file-existence elsewhere; treat the read
+    // failure as a soft skip rather than a fatal error.
     return hints;
   }
-  const matches = body.match(CODE_REVIEW_PERSONA_PATTERN);
+  const matches = body.match(CODE_REVIEW_ASSISTANT_PATTERN);
   if (matches && matches.length >= CODE_REVIEW_OCCURRENCE_FLOOR) {
     hints.add(CODE_REVIEW_CAPABILITY_ID);
   }
@@ -987,8 +990,8 @@ function detectCapabilityHintsFromPersona(
  *     documented on `AgentRuntimeSchema` (the in-cortex default).
  *   - `mode: in-process`       — same.
  *   - `capabilities: ["chat"]` — myelin#181 canonical conversational
- *     capability. Persona-driven heuristic may add `code-review.typescript`
- *     when the persona body matches `CODE_REVIEW_PERSONA_PATTERN`.
+ *     capability. Assistant-prompt-driven heuristic may add `code-review.typescript`
+ *     when the assistant prompt body matches `CODE_REVIEW_ASSISTANT_PATTERN`.
  *
  * Catalog merge invariant: an existing `capabilities[]` entry with the same
  * id is preserved verbatim (description, rate, cost — operators may have
@@ -1062,11 +1065,11 @@ function synthesizeRuntimeCapabilities(
       addedByMigrator.push(CHAT_CAPABILITY_ID);
     }
     if (existingCaps.length === 0) {
-      // Only run the persona heuristic when the agent had no caps declared.
-      // An operator that already declared `["chat"]` explicitly opted into
-      // a minimal capability surface — adding `code-review.typescript`
+      // Only run the assistant-prompt heuristic when the agent had no caps
+      // declared. An operator that already declared `["chat"]` explicitly
+      // opted into a minimal capability surface — adding `code-review.typescript`
       // behind their back would be presumptuous.
-      const hints = detectCapabilityHintsFromPersona(agent.persona, configDir, agent.id, warnings);
+      const hints = detectCapabilityHintsFromAssistantPrompt(agent.persona, configDir, agent.id, warnings);
       for (const hint of hints) {
         if (!synthesised.has(hint)) {
           synthesised.add(hint);
@@ -1103,8 +1106,8 @@ function synthesizeRuntimeCapabilities(
         message:
           existingCaps.length === 0
             ? `synthesised agent.runtime.capabilities = [${addedByMigrator.join(", ")}] ` +
-              `(default: chat per myelin#181; persona-heuristic adds code-review.typescript when ` +
-              `the persona body matches /code[- ]review|reviewer|reviewing/i 2+ times). ` +
+              `(default: chat per myelin#181; assistant-prompt heuristic adds code-review.typescript when ` +
+              `the assistant prompt body matches /code[- ]review|reviewer|reviewing/i 2+ times). ` +
               `Edit cortex.yaml to refine.`
             : `appended [${addedByMigrator.join(", ")}] to agent.runtime.capabilities ` +
               `(pre-existing claims preserved). Edit cortex.yaml to refine.`,
@@ -1255,7 +1258,7 @@ function synthesizeOperatorIdBackCompat(
 
 /**
  * Convert a legacy bot.yaml-shaped object to cortex.yaml-shape. Pure: no IO
- * apart from optional `existsSync` for persona-file validation.
+ * apart from optional `existsSync` for assistant-prompt-file validation.
  *
  * Throws on structurally invalid input (e.g. missing `agent.name`). Returns
  * the converted object plus warnings + mappings. The caller (CLI) decides

--- a/src/common/types/cortex-config.ts
+++ b/src/common/types/cortex-config.ts
@@ -27,8 +27,8 @@
  *
  * Coupling rules from architecture §9.3 enforced by this schema:
  *   - agents never reference other agents' platform user IDs (trust is by agent id)
- *   - presence blocks carry only credentials, not persona/roles overrides
- *   - personas are platform-neutral (just a markdown file path)
+ *   - presence blocks carry only credentials, not assistant-prompt or role overrides
+ *   - the assistant prompt is platform-neutral (just a markdown file path)
  *   - renderers never publish on the bus (kind enum constrains the choice set)
  */
 
@@ -150,8 +150,9 @@ export type PrincipalConfig = z.infer<typeof PrincipalConfigSchema>;
  * Discord presence — an agent's identity on a Discord guild. The full grove-v2
  * `DiscordInstanceSchema` carries channel ids, role config, DM rules, etc.;
  * we keep them here in the same shape so adapter code can move with minimal
- * field renames. The architecture §9.3 coupling rules forbid `persona` or
- * `roles` overrides in a presence block — those live on the parent agent.
+ * field renames. The architecture §9.3 coupling rules forbid overriding the
+ * parent agent's assistant or roles in a presence block — those live on the
+ * parent agent.
  */
 export const DiscordPresenceSchema = z.object({
   /** Whether this presence is active. Default: true. */
@@ -287,8 +288,9 @@ export type MattermostPresence = z.infer<typeof MattermostPresenceSchema>;
  * polling model and unlike Discord's gateway-with-public-bot path. HTTP /
  * Events API mode is deferred until a deployment actually needs it.
  *
- * Architecture §9.3 coupling rules: no `persona` or `roles` overrides at
- * this layer — those live on the parent agent. `roles` here is the
+ * Architecture §9.3 coupling rules: no overrides of the parent agent's
+ * assistant or roles at this layer — those live on the parent agent.
+ * `roles` here is the
  * platform-side allowlist that maps the agent's cortex-wide capability
  * set onto Slack user ids.
  */
@@ -412,7 +414,7 @@ export type Presence = z.infer<typeof PresenceSchema>;
 // =============================================================================
 
 /**
- * An agent bundles identity + persona + capability set + platform credentials.
+ * An agent bundles identity + assistant + capability set + platform credentials.
  * Architecture §9.1: agents are principals; platforms are servers; the agent's
  * credentials are how the agent shows up on a platform.
  *

--- a/src/runner/dispatch-listener.ts
+++ b/src/runner/dispatch-listener.ts
@@ -496,11 +496,11 @@ function parsePayload(envelope: Envelope): DispatchTaskReceivedPayload | null {
  * see a clean separation: dispatch-contract on top, substrate-specific
  * knobs in the `runtime` block. CC reads what it needs; others ignore.
  *
- * **persona absence.** The legacy bus-driven path does NOT carry persona
- * file data on the payload (persona injection happens at the dispatch-
- * handler layer via the prompt-builder). We therefore omit `persona`
- * from the request — the harness handles `persona === undefined` per
- * the A.1b spec (optional field).
+ * **assistant prompt file absence.** The legacy bus-driven path does NOT
+ * carry assistant prompt-file data on the payload (prompt injection happens
+ * at the dispatch-handler layer via the prompt-builder). We therefore omit
+ * `persona` from the request — the harness handles `persona === undefined`
+ * per the A.1b spec (optional field).
  */
 function buildDispatchRequest(
   payload: DispatchTaskReceivedPayload,

--- a/src/surface/mc/__tests__/iteration-import.test.ts
+++ b/src/surface/mc/__tests__/iteration-import.test.ts
@@ -76,7 +76,7 @@ function makeSub(over: Partial<SubIssueMetadata> = {}): SubIssueMetadata {
     owner: "the-metafactory",
     repo: "grove-v2",
     number: 100,
-    title: "Sub: define PM agent persona",
+    title: "Sub: define PM assistant",
     state: "open",
     htmlUrl: "https://github.com/the-metafactory/grove-v2/issues/100",
     ...over,
@@ -326,7 +326,7 @@ describe("importSubIssueFromMetadata", () => {
          FROM tasks WHERE id = ?`
       )
       .get(result.taskId) as Record<string, unknown>;
-    expect(task.title).toBe("Sub: define PM agent persona");
+    expect(task.title).toBe("Sub: define PM assistant");
     expect(task.status).toBe("open");
     expect(task.source_system).toBe("github");
     expect(task.source_external_id).toBe("the-metafactory/grove-v2#100");


### PR DESCRIPTION
## Summary

Per cortex#442 + `docs/migrations/0002-vocabulary-finish-2026-05.md` §R6. Renames `persona` → `assistant` in domain-prose and internal helper names, leaving the schema field name, the `personas/` directory, the legacy `personaFile` migration-input field, and the `DispatchRequest.persona` substrate contract field untouched.

### Changes

- `src/runner/dispatch-listener.ts` — "persona absence" doc comment rewritten ("assistant prompt file absence").
- `src/bus/review-consumer.ts` — "persona prefix" → "assistant prefix" in `ReviewPromptBuilder` doc.
- `src/common/types/cortex-config.ts` — §9.3 coupling-rule prose at lines 30-31, 153, 290, 415. Field-description comments at :421/:533/:534 (describing the `persona` field itself) untouched.
- `src/cli/cortex/commands/migrate-config-lib.ts` — internal helpers + constants renamed:
  - `resolvePersona` → `resolveAssistantPath`
  - `detectCapabilityHintsFromPersona` → `detectCapabilityHintsFromAssistantPrompt`
  - `PERSONA_MAX_BYTES` → `ASSISTANT_PROMPT_MAX_BYTES`
  - `CODE_REVIEW_PERSONA_PATTERN` → `CODE_REVIEW_ASSISTANT_PATTERN`
  - Warning messages updated ("persona file not found" → "assistant prompt file not found"; "persona-driven capability heuristic" → "assistant-prompt-driven capability heuristic").
- `docs/architecture.md` — "those personas" → "those assistants" (and "Multiple agent personas" → "Multiple agents" at the matching line).
- Test files updated for matching `describe()`/`test()` names + message assertions.

### Carve-outs preserved

| Carve-out | Why | Status |
|-----------|-----|--------|
| `personaFile` (legacy migrate-config input field) | Per cortex#442 + Major 2 of pass-1 review on the parent | preserved |
| `~/.config/cortex/personas/` directory references | Plan §R6 — filenames stay | preserved |
| `AgentSchema.persona` schema field | Plan §R6 — field name carve-out | preserved |
| `AgentSchema.persona` field-description comments at cortex-config.ts:421, 533, 534 | Plan §R6 — describes the field itself | preserved |
| `DispatchRequest.persona` (substrate contract field) | Schema field on the dispatch request; same carve-out shape as `AgentSchema.persona` | preserved |
| `docs/persona-format.md` + `src/common/types/persona-format.ts` | Separate spec module — out of PR-R6 scope (~15 files / ~80 LOC budget) | deferred |
| `docs/plan-cortex-migration.md` historical legacy-grove references | Migration plan describing legacy code being retired | deferred |

### Test plan

- [x] `bunx tsc --noEmit` — clean.
- [x] `bun run lint:errors` — clean.
- [x] `bun test` — 3544 pass, 0 fail (one fragment-watcher flake in initial run was pre-existing fs-watcher timing; passes on isolated re-run and on second full-suite run).
- [x] Targeted suites (`migrate-config.test.ts`, `agents.test.ts`, `iteration-import.test.ts`) — 183 pass.
- [x] `grep -rEn '\bpersona\b' src/` — remaining hits all in the carve-out set (schema field, `personaFile`, `personas/` directory, persona-format spec module, field-description comments, fixture filenames).

Part of cortex#436.

Closes #442.

🤖 Generated with [Claude Code](https://claude.com/claude-code)