### PR TITLE
docs(cortex): PR-R13e — Mission Control doc → shipped v3 + architecture.md sweep (#451)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -428,7 +428,7 @@ The same applies for every M7 app: pilot has a contract, signal-collector has a 
 
 Each M7 app is a microservice in the architectural sense: independently deployable, owns its own data, communicates with peers async via the bus, fails independently.
 
-- **Independent deployment.** cortex and pilot ship via separate `arc` packages, separate version cadences. An principal can run pilot at a different version than cortex; if their envelope contracts are intersecting versions, they interoperate.
+- **Independent deployment.** cortex and pilot ship via separate `arc` packages, separate version cadences. A principal can run pilot at a different version than cortex; if their envelope contracts are intersecting versions, they interoperate.
 - **Data ownership.** Each M7 app owns its persistent state behind its own boundary. Cortex's Mission Control DB belongs to cortex; pilot's `errands.sqlite` belongs to pilot. No shared database, no foreign-key relationships across apps. State that needs to flow between apps flows as envelopes.
 - **Async-first communication.** Apps communicate via published envelopes (fire-and-forget), with M6 request/reply for synchronous needs. No app calls another app's HTTP endpoint as a primary integration mechanism. (CLI shell-outs for transitional integrations — e.g. `pilot fetch <PR>` — are tolerated short-term and tracked for removal.)
 - **Failure isolation.** An M7 app crashing degrades the system gracefully — its envelopes stop flowing, its surfaces go dark, but other apps keep running. The bus's `system.adapter.*` events make this visible per G-1111 §3.5 + §4.6.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -23,23 +23,23 @@
 For months we've operated as heavy Discord-and-dashboard users. The lived pattern:
 
 - **Discord** as the primary surface, with a channel-per-repo routing convention (`#grove`, `#arc`, `#compass`, `#myelin`, `#blueprint`, etc. — one channel per repo, threads for individual issues / PRs / features).
-- **Multiple agent personas** collaborating in those channels — Luna, Echo, Holly, Ivy, Forge — each with their own Discord identity, persona file, capability gates, and trust relationships. Operators ping a persona; the persona does work.
-- **The pilot review loop** running on top of those personas: open PR → ping reviewer-persona → reviewer reads, posts findings → operator/agent triages → fix or defer → re-ping → merge. Driven by the `pilot` CLI; foundational and backend support coming from compass SOPs, blueprint dependency tracking, and a cloud of CLAUDE.md files.
-- **The Grove dashboard** as the secondary surface — repository-organised activity feed, GitHub entities (releases / issues / PRs) visible inline, agent state per repo, F-7 attention view for "what needs me." The browser tab the operator left open all day.
+- **Multiple agent personas** collaborating in those channels — Luna, Echo, Holly, Ivy, Forge — each with their own Discord identity, persona file, capability gates, and trust relationships. Principals ping a persona; the persona does work.
+- **The pilot review loop** running on top of those personas: open PR → ping reviewer-persona → reviewer reads, posts findings → principal/agent triages → fix or defer → re-ping → merge. Driven by the `pilot` CLI; foundational and backend support coming from compass SOPs, blueprint dependency tracking, and a cloud of CLAUDE.md files.
+- **The Grove dashboard** as the secondary surface — repository-organised activity feed, GitHub entities (releases / issues / PRs) visible inline, agent state per repo, F-7 attention view for "what needs me." The browser tab the principal left open all day.
 - **Mattermost** as a parallel surface for flows that didn't live in Discord — same adapter pattern, different platform.
 
 The pattern worked. Send work in via chat; watch it progress on the dashboard; get pinged when human input is needed; merge.
 
 One specific consequence of this pattern shapes how cortex is designed: **today's Discord-only surface conflates three concerns onto one channel, producing two opposite visibility failures depending on what an agent is doing.**
 
-| Pattern | Symptom | Operator experience |
+| Pattern | Symptom | Principal experience |
 |---------|---------|---------------------|
-| **Tool-call flashing** — bots that emit per-tool worklog messages (e.g. cc-session-driven workflow runners) | The worklog thread scrolls with each `Read`, `Grep`, `Bash`, `Edit`, etc. | Operators skim, partly as work-tracking and partly as a "yes the bot is alive" signal. High noise, low intentionality. |
-| **Silent grinding** — agents that DON'T emit per-tool worklog messages (e.g. reviewer agents like Echo running a `/review-pr` skill) | No worklog. The agent just stops responding while CC processes internally. | Operators ping → wait. After ~9 minutes (the empirical pilot-loop cap of 540s), the loop concludes "agent stalled" and re-pings — even though the agent may still be working. **The opacity is the problem.** |
+| **Tool-call flashing** — bots that emit per-tool worklog messages (e.g. cc-session-driven workflow runners) | The worklog thread scrolls with each `Read`, `Grep`, `Bash`, `Edit`, etc. | Principals skim, partly as work-tracking and partly as a "yes the bot is alive" signal. High noise, low intentionality. |
+| **Silent grinding** — agents that DON'T emit per-tool worklog messages (e.g. reviewer agents like Echo running a `/review-pr` skill) | No worklog. The agent just stops responding while CC processes internally. | Principals ping → wait. After ~9 minutes (the empirical pilot-loop cap of 540s), the loop concludes "agent stalled" and re-pings — even though the agent may still be working. **The opacity is the problem.** |
 
-Both failures share one root cause: **a single Discord surface is the only place the bot's activity shows up**, so the choice is "flood the channel with detail" or "flood the channel with nothing." Neither answers the operator's actual questions ("is it alive?", "what's it working on?", "should I intervene?") well.
+Both failures share one root cause: **a single Discord surface is the only place the bot's activity shows up**, so the choice is "flood the channel with detail" or "flood the channel with nothing." Neither answers the principal's actual questions ("is it alive?", "what's it working on?", "should I intervene?") well.
 
-§3.6 below describes how cortex resolves this by splitting visibility into three tiers — Tier 1 (work management on the dashboard) answers "is it alive + what is it working on" without flooding chat; Tier 2 (cortex drill-down) answers "where is this specific agent in its lifecycle"; Tier 3 (signal observability) answers "what tools did it actually run" for the operator who wants to drill in. The pilot-loop's "ping → 540s silence → re-ping" cycle, encountered repeatedly during this design's authoring, is the empirical case study for why Tiers 1+2 are load-bearing.
+§3.6 below describes how cortex resolves this by splitting visibility into three tiers — Tier 1 (work management on the dashboard) answers "is it alive + what is it working on" without flooding chat; Tier 2 (cortex drill-down) answers "where is this specific agent in its lifecycle"; Tier 3 (signal observability) answers "what tools did it actually run" for the principal who wants to drill in. The pilot-loop's "ping → 540s silence → re-ping" cycle, encountered repeatedly during this design's authoring, is the empirical case study for why Tiers 1+2 are load-bearing.
 
 ### 1.2 What changed
 
@@ -49,7 +49,7 @@ The canonical layer model is **M1–M7 — the Myelin stack** (myelin#7, JC + An
 
 Once the bus appeared, the question "which layer owns which concern?" became operationally real. You can't have your transport client (M2), your envelope handling (M3), your dispatch handler, your workflow runner, *and* your Discord surface adapter all sharing the same `src/bot/` files anymore — M1–M6 are real now, with their own contracts owned by myelin, and the M7 application that consumes them needs its own home with a clean internal split.
 
-Cortex is that home. It is one M7 application — alongside pilot, signal-collector, and any future apps — that consumes the bus and presents the operator surface.
+Cortex is that home. It is one M7 application — alongside pilot, signal-collector, and any future apps — that consumes the bus and presents the principal surface.
 
 > **A note on naming.** Earlier drafts of the cortex framing referenced an "ecosystem seven-layer model" lifted from `design-collaboration-surface.md` §2 (transport / envelope / telemetry / coordination / process / knowledge-graph / surface). That artifact is a useful **concern map** — which sibling repo owns which architectural concern — but it is **not a layer model in the same sense as M1–M7**. Presenting both with `L1..L7` numbering was the source of confusion. M1–M7 is the canonical stack; the concern-map content survives as prose in §5 (M7 sibling apps and adjacent knowledge artefacts), without competing layer numbers.
 
@@ -62,7 +62,7 @@ The metafactory ecosystem uses a nervous-system family of names. Cortex slots in
 - **pilot** — rhythmic coordinator — an M7 app (the review loop)
 - **compass** — heading control — knowledge artefacts cortex consumes (SOPs)
 - **blueprint** — body plan / wiring diagram — knowledge artefacts cortex consumes (feature graph)
-- **cortex** — conscious processing surface where the operator perceives and acts — an M7 app (this design)
+- **cortex** — conscious processing surface where the principal perceives and acts — an M7 app (this design)
 
 ---
 
@@ -114,7 +114,7 @@ PRODUCERS                          NATS BUS                         CONSUMERS
 Agents (CC hooks)        ┌──→  mf.net-{op}.events.>                    Hot path
   emits agent.task.*     │       domain + process events            ┌─→ cortex subscriber
   + trace + metric + log │       (review, dispatch, attention,      │   → Kanban / Inbox / Cards
-                         │        gate, system)                     │   (operator-facing,
+                         │        gate, system)                     │   (principal-facing,
 Surfaces (cortex/pilot)  │       JetStream over events.>            │    latency-sensitive)
   emits review.*         │       fire-and-forget · sub-second
   dispatch.* attention.* │       no ack on hot path
@@ -136,7 +136,7 @@ webhooks, cron)         │     mf.net-{op}.log.>      structured logs │   (Ve
 
 | Class | Subject prefix | Carries | Audience | Retention |
 |-------|----------------|---------|----------|-----------|
-| **Events** | `mf.net-{op}.events.>` | Domain + process lifecycle: `review.*`, `dispatch.*`, `attention.*`, `gate.*`, `system.*` (G-1111 vocabulary) | Hot-path: cortex subscriber → operator surfaces | JetStream — durable, replayable, last_event_id checkpointable |
+| **Events** | `mf.net-{op}.events.>` | Domain + process lifecycle: `review.*`, `dispatch.*`, `attention.*`, `gate.*`, `system.*` (G-1111 vocabulary) | Hot-path: cortex subscriber → principal surfaces | JetStream — durable, replayable, last_event_id checkpointable |
 | **Trace** | `mf.net-{op}.trace.>` | OTLP spans (CC tool calls, skill invocations, subagent spawn, session lifecycle) | Cold-path: signal-collector → Tempo / Honeycomb / Datadog | Per OTLP backend; not on JetStream |
 | **Metric** | `mf.net-{op}.metric.>` | Counters / gauges | Cold-path: signal-collector → TSDB (VictoriaMetrics / Prometheus) | Per TSDB |
 | **Log** | `mf.net-{op}.log.>` | Structured logs | Cold-path: signal-collector → Loki | Per logger |
@@ -147,16 +147,16 @@ webhooks, cron)         │     mf.net-{op}.log.>      structured logs │   (Ve
 
 Two consumer classes live on the same transport but at different latency / durability tiers:
 
-**Hot path — operator-facing**
+**Hot path — principal-facing**
 - Cortex's surface-router subscribes to `mf.net-{op}.events.>` (filtered to relevant subjects per renderer/adapter).
 - JetStream gives durable replay, but the hot path renders fire-and-forget at sub-second latency. **No ack on the hot path.**
 - The dashboard projection ingests events into D1, checkpointing `last_event_id` per stream — **lost event ≠ lost state**: missed events on the hot path are recoverable from the JetStream stream up to the retention window.
 - Hot-path consumers (cortex, future M7 apps) MUST stay narrow on subject filters and avoid blocking on per-event work.
 
 **Cold path — observability**
-- signal-collector (Vector / otelcol) subscribes to `trace.>`, `metric.>`, `log.>` and forwards to operator-chosen OTLP/log/metric backends.
+- signal-collector (Vector / otelcol) subscribes to `trace.>`, `metric.>`, `log.>` and forwards to principal-chosen OTLP/log/metric backends.
 - High volume, high cardinality, longer retention horizons.
-- Cortex MUST NOT couple to the cold path. Operator-facing computations (cycle-time, PR-throughput, human-wait KPIs) are **PromQL queries on the TSDB, not computed in cortex.** The cold path owns aggregation; cortex just renders cards.
+- Cortex MUST NOT couple to the cold path. Principal-facing computations (cycle-time, PR-throughput, human-wait KPIs) are **PromQL queries on the TSDB, not computed in cortex.** The cold path owns aggregation; cortex just renders cards.
 
 ### 3.3 JetStream over events — durability for the things that matter
 
@@ -193,18 +193,18 @@ This is the M7 separation-of-concerns target from cortex#414 OSI corrections: pl
 
 ### 3.5 Namespace reconciliation — RESOLVED
 
-**Decision (2026-05-09):** The federated namespace `local.{org}.{domain}.{entity}.{action}` (per `myelin/specs/namespace.md`) is the canonical subject convention. The earlier `mf.net-{operator}.*` convention was a first iteration that appeared in documentation diagrams but was never adopted in implementation — cortex's runtime already publishes exclusively on `local.{org}.*` subjects.
+**Decision (2026-05-09):** The federated namespace `local.{org}.{domain}.{entity}.{action}` (per `myelin/specs/namespace.md`) is the canonical subject convention. The earlier `mf.net-{op}.*` convention was a first iteration that appeared in documentation diagrams but was never adopted in implementation — cortex's runtime already publishes exclusively on `local.{org}.*` subjects.
 
 The three-prefix model from myelin's namespace spec applies:
-- **`local.{org}.*`** — intra-operator semantic events (current scope)
-- **`federated.*`** — cross-operator task markets (requires sovereignty enforcement, [myelin#11](https://github.com/the-metafactory/myelin/issues/11))
+- **`local.{org}.*`** — intra-principal semantic events (current scope)
+- **`federated.*`** — cross-principal task markets (requires sovereignty enforcement, [myelin#11](https://github.com/the-metafactory/myelin/issues/11))
 - **`public.*`** — open discovery (future)
 
 **Migration:** Diagrams and tables in §3.1–§3.4 of this document still reference `mf.net-{op}.*` as a visual convention. These will be updated to `local.{org}.*` as part of [myelin#7](https://github.com/the-metafactory/myelin/issues/7) documentation convergence. The runtime requires no changes — it already uses the correct convention. See also: myelin task routing design doc, Decision #6.
 
-### 3.6 Operator visibility — three tiers
+### 3.6 Principal visibility — three tiers
 
-The hot/cold-path split in §3.2 plus signal's three-repo bundle (§5.2) gives the operator three distinct views of agent activity, each at a different level of detail and on a different surface. This is a deliberate design choice — collapsing them onto one surface is what made grove-v2's worklog thread scroll past as bots flashed every tool call (§1.1). Cortex separates the concerns.
+The hot/cold-path split in §3.2 plus signal's three-repo bundle (§5.2) gives the principal three distinct views of agent activity, each at a different level of detail and on a different surface. This is a deliberate design choice — collapsing them onto one surface is what made grove-v2's worklog thread scroll past as bots flashed every tool call (§1.1). Cortex separates the concerns.
 
 | Tier | Surface | Question it answers | Granularity | Source |
 |------|---------|---------------------|-------------|--------|
@@ -212,14 +212,14 @@ The hot/cold-path split in §3.2 plus signal's three-repo bundle (§5.2) gives t
 | **2. Agent activity** | Cortex drill-down (a card → an agent task) | "What is this specific agent doing right now? How far along? Did it get stuck?" | Medium — lifecycle envelopes (`dispatch.task.{started,progress,completed,failed,aborted}`) and high-level status updates | Same `events.>` class, narrower subject filter for one task's correlation_id |
 | **3. Tool-call detail** | Signal observability backend (Grafana / Honeycomb / Datadog / local-stack) | "Exactly what tool calls did the agent make? What were the arguments? Where did it spend time?" | Fine — every `Read`, `Bash`, `Edit`, subagent spawn, tool argument, span timing | `mf.net-{op}.trace.>` (OTLP spans) — cold path, signal-collector → backend |
 
-The dashboard renders Tier 1 by default. Drilling into a card opens Tier 2 (cortex's own surface, fed from the bus). A "view trace tree" link from Tier 2 deep-links into the operator's chosen signal backend for Tier 3. The operator chooses how deep to go; cortex doesn't force every tool call into the operator's eyeline.
+The dashboard renders Tier 1 by default. Drilling into a card opens Tier 2 (cortex's own surface, fed from the bus). A "view trace tree" link from Tier 2 deep-links into the principal's chosen signal backend for Tier 3. The principal chooses how deep to go; cortex doesn't force every tool call into the principal's eyeline.
 
 **Behavioural change from grove-v2 to cortex** (full migration coverage in `plan-cortex-migration.md`; sketched here because it shapes the design):
 
-- Today (grove-v2): every tool call flashes as a Discord message in the worklog thread. Tiers 1, 2, and 3 are all collapsed onto one surface — chat — and the operator skims for "is this alive" + "what's it doing" + "what tools did it run" all at once.
-- Tomorrow (cortex): chat carries collaboration (pings, decisions, results posted by agents); the dashboard carries work state at Tier 1; signal carries Tier 3 detail in whatever backend the operator chose. **Tool calls do not scroll past in chat by default.** If the operator wants the tool-call view they open the trace tree; otherwise the noise stays where it scales — in the observability backend.
+- Today (grove-v2): every tool call flashes as a Discord message in the worklog thread. Tiers 1, 2, and 3 are all collapsed onto one surface — chat — and the principal skims for "is this alive" + "what's it doing" + "what tools did it run" all at once.
+- Tomorrow (cortex): chat carries collaboration (pings, decisions, results posted by agents); the dashboard carries work state at Tier 1; signal carries Tier 3 detail in whatever backend the principal chose. **Tool calls do not scroll past in chat by default.** If the principal wants the tool-call view they open the trace tree; otherwise the noise stays where it scales — in the observability backend.
 
-This is the operator-facing payoff of the layered architecture: each tier of detail lives where it scales, on a surface that suits its grain. Chat scales poorly to high-frequency events; signal scales well. The dashboard scales well to coarse work-state; chat scales poorly to that too. Cortex makes the choice explicit instead of leaving it to scrollback.
+This is the principal-facing payoff of the layered architecture: each tier of detail lives where it scales, on a surface that suits its grain. Chat scales poorly to high-frequency events; signal scales well. The dashboard scales well to coarse work-state; chat scales poorly to that too. Cortex makes the choice explicit instead of leaving it to scrollback.
 
 ---
 
@@ -242,7 +242,7 @@ What cortex depends on, what cortex must not do, and what to read in each upstre
 | Spec home | `the-metafactory/myelin` — abstract bus interface; NATS is the v1 concrete implementation. |
 | Status | NATS pub/sub via `nats@2.x` JS client is operational; abstract transport interface (myelin-side spec) in flight. |
 | Cortex's dependency | `nats@2.x` JS client. Connection model: leaf node connecting to a hub. |
-| Cortex's contract | Cortex publishes on subjects under `local.{org}.>` (per myelin's M3 namespace spec) and `mf.net-{operator}.>` per the §3 event architecture. JetStream is **required** for `system.*` events per G-1111 §3.5.5; plain NATS Core suffices otherwise. |
+| Cortex's contract | Cortex publishes on subjects under `local.{org}.>` (per myelin's M3 namespace spec) and `mf.net-{op}.>` per the §3 event architecture. JetStream is **required** for `system.*` events per G-1111 §3.5.5; plain NATS Core suffices otherwise. |
 | Coupling discipline | Cortex MAY copy patterns from the bus client; cortex MUST NOT couple to NATS-specific surface area beyond what myelin's M2 abstraction exposes. |
 | Reading order | `~/Developer/myelin/specs/namespace.md` for subject grammar → upstream NATS client docs for the API. |
 
@@ -297,7 +297,7 @@ Multiple repos live at M7. Each consumes M2–M6 contracts; none impose on the o
 
 | App | Repo | Role |
 |-----|------|------|
-| **cortex** | `the-metafactory/cortex` | The operator's collaboration surface — Discord/Mattermost adapters, Mission Control dashboard, workflow runner spawning Claude Code, GitHub-webhook tap, CC-event tap. The M7 application this design is about. |
+| **cortex** | `the-metafactory/cortex` | The principal's collaboration surface — Discord/Mattermost adapters, Mission Control dashboard, workflow runner spawning Claude Code, GitHub-webhook tap, CC-event tap. The M7 application this design is about. |
 | **pilot** | `the-metafactory/pilot` | Review-loop coordinator. Manages errand state (ping → fetch → triage → apply); operates independently. Cortex projects pilot's errand events as cards in the surface. |
 | **signal bundle** | three repos — see §5.2 | Modular observability bundle: tap (host-agnostic) + collector (profile-driven) + optional self-hosted stack. Cortex hosts a signal tap; cortex eventually drills into traces by `correlation_id`. |
 | **future apps** | various | Anything else that connects to the bus — e.g. an inbox-only TUI, a Slack assistant, a metrics panel — counts as another M7 sibling. |
@@ -313,7 +313,7 @@ Multiple repos live at M7. Each consumes M2–M6 contracts; none impose on the o
 Reference: `~/Developer/signal/README.md` + signal's modular-bundle architecture diagram (in signal repo's `docs/`). Signal is **not one repo** — it's three, each independently installable, glued together by the bus and the OTLP contract.
 
 ```
-        AGENT HOST                         NATS bus              COLLECTOR (M7)         BACKENDS (operator's choice)
+        AGENT HOST                         NATS bus              COLLECTOR (M7)         BACKENDS (principal's choice)
         (cortex, PAI, CI, …)               (local leaf)                                  pick zero, one, or many
         ┌─────────────────────────┐                              ┌─────────────────┐    ┌──────────────────┐
         │ signal (tap) ─ metafac- │ publish OTLP envelopes       │ signal-         │    │ Grafana Cloud    │
@@ -345,13 +345,13 @@ Reference: `~/Developer/signal/README.md` + signal's modular-bundle architecture
 | Component | Repo | Bundle status | Role |
 |-----------|------|---------------|------|
 | **signal (tap)** | `the-metafactory/signal` | metafactory bundle — always installed | Host-agnostic CC instrumentation: 4 hooks (Pre / Post / Subagent / LoadContext), W3C trace context, OTLP envelope builder, NATS publisher |
-| **signal-collector** | `the-metafactory/signal-collector` *(planned, not yet a real repo)* | metafactory bundle — optional | Profile-driven Vector / otelcol wrapper. Subscribes to `mf.net-*.trace.>` etc., forwards via OTLP to operator-chosen backend(s) |
+| **signal-collector** | `the-metafactory/signal-collector` *(planned, not yet a real repo)* | metafactory bundle — optional | Profile-driven Vector / otelcol wrapper. Subscribes to `mf.net-*.trace.>` etc., forwards via OTLP to principal-chosen backend(s) |
 | **signal-stack** | `the-metafactory/signal-stack` *(planned, not yet a real repo)* | NOT a metafactory bundle — declared dependency of the `local-stack` collector profile | Self-hosted backend template. Docker Compose with VictoriaMetrics + Grafana. Optional. |
 
 **Cortex's relationship to the bundle:**
 
 - Cortex **hosts a signal tap**: the CC hooks (today's `src/hooks/EventLogger.hook.ts` etc., moving to `cortex/src/taps/cc-events/`) are an instance of signal's tap pattern. The tap publishes OTLP envelopes onto `mf.net-{op}.trace.>` whether or not signal-collector is installed.
-- Cortex does NOT bundle a collector or backend. Operators choose: SaaS-only (tap + collector → Grafana Cloud / Honeycomb / Datadog), local-first (tap + collector + signal-stack), or distributed (tap on laptop, collector on server, stack on a third box). The NATS bus + OTLP contract make all three topologies identical to the tap.
+- Cortex does NOT bundle a collector or backend. Principals choose: SaaS-only (tap + collector → Grafana Cloud / Honeycomb / Datadog), local-first (tap + collector + signal-stack), or distributed (tap on laptop, collector on server, stack on a third box). The NATS bus + OTLP contract make all three topologies identical to the tap.
 - Cortex MUST tolerate signal-collector being absent: the tap publishes; if no consumer is subscribing, NATS handles the no-op cleanly. Cortex's drill-down trace-tree feature degrades gracefully to "no telemetry available."
 - **Coupling rule (mirroring signal's own discipline):** Signal MUST NOT import from `cortex/src/`; cortex MUST NOT import from `signal/src/`. Both publish/subscribe on the shared transport.
 
@@ -371,13 +371,13 @@ These are real architectural concerns. They are NOT layers in M1–M7. The earli
 
 ### 5.4 arc — distribution and bundling
 
-Reference: `the-metafactory/arc` — the metafactory package manager. Like compass and blueprint, arc is **adjacent to the stack, not in it** — it's a distribution-layer concern that happens to install M7 apps + their dependencies onto operator hosts. Surfacing it explicitly because cortex's existence as a deployable thing depends on arc.
+Reference: `the-metafactory/arc` — the metafactory package manager. Like compass and blueprint, arc is **adjacent to the stack, not in it** — it's a distribution-layer concern that happens to install M7 apps + their dependencies onto principal hosts. Surfacing it explicitly because cortex's existence as a deployable thing depends on arc.
 
 **What arc does:**
 
 - **Bundles** metafactory things — myelin (the M2–M6 protocol bundle), signal (the observability tap), cortex (this M7 app), pilot, plus tools, skills, and CLIs. Each bundle declares itself in an `arc-manifest.yaml` with `name`, `version`, `description`, and a `provides:` list of files to install.
-- **Distributes** bundles across operator hosts via `arc upgrade <Name>`. The operator runs one command and gets the binary + hooks + skills + config templates installed at the right filesystem paths (`~/bin/`, `~/.claude/hooks/`, `~/.claude/skills/`, …).
-- **Configures** environment-specific things at install time — NATS identity keys (per myelin#8 / MY-400), CF Access secrets, per-host overrides. Templates live in the manifest; concrete values live in the operator's environment.
+- **Distributes** bundles across principal hosts via `arc upgrade <Name>`. The principal runs one command and gets the binary + hooks + skills + config templates installed at the right filesystem paths (`~/bin/`, `~/.claude/hooks/`, `~/.claude/skills/`, …).
+- **Configures** environment-specific things at install time — NATS identity keys (per myelin#8 / MY-400), CF Access secrets, per-host overrides. Templates live in the manifest; concrete values live in the principal's environment.
 - **Tracks** what's installed and at what version — `arc list` shows installed bundles, `arc upgrade` updates them.
 
 **Cortex's relationship to arc:**
@@ -385,15 +385,15 @@ Reference: `the-metafactory/arc` — the metafactory package manager. Like compa
 | Aspect | Detail |
 |--------|--------|
 | Cortex is a metafactory bundle | Installable via `arc upgrade Cortex` once MIG-7 lands. Pre-cutover the package name is `Grove`; the rename to `Cortex` happens at MIG-7.7. |
-| Cortex's `arc-manifest.yaml` | Declares `provides:` — `~/bin/cortex` (the bot binary), `~/bin/discord` (operator CLI), `~/bin/cldyo-live` (CC instrumentation wrapper), CC hooks, skills. The same shape grove-v2 has today. |
-| Cortex consumes other bundles indirectly | Operators install `myelin` (via arc) for the bus protocol; `signal` (via arc) for the observability tap; `cortex` (via arc) for the surface. Each is independently rolled out. |
+| Cortex's `arc-manifest.yaml` | Declares `provides:` — `~/bin/cortex` (the bot binary), `~/bin/discord` (principal CLI), `~/bin/cldyo-live` (CC instrumentation wrapper), CC hooks, skills. The same shape grove-v2 has today. |
+| Cortex consumes other bundles indirectly | Principals install `myelin` (via arc) for the bus protocol; `signal` (via arc) for the observability tap; `cortex` (via arc) for the surface. Each is independently rolled out. |
 | Cortex does NOT runtime-import arc | arc is a build/install-time tool. At runtime cortex doesn't know it was installed by arc — it just finds its config at the configured path and runs. |
-| Cross-bundle dependencies | Declared via the `arc-manifest.yaml` `dependsOn:` field. Cortex declares `myelin` (the schema is vendored, but operators need myelin's CLI for identity-key provisioning per MIG-7's `nats.identity` config). signal is *recommended* but not required (cortex tolerates absent collector). |
+| Cross-bundle dependencies | Declared via the `arc-manifest.yaml` `dependsOn:` field. Cortex declares `myelin` (the schema is vendored, but principals need myelin's CLI for identity-key provisioning per MIG-7's `nats.identity` config). signal is *recommended* but not required (cortex tolerates absent collector). |
 | Existing examples | `~/.config/metafactory/pkg/repos/` shows installed bundles today: `grove` (legacy bot), `compass` (SOPs + validators), `pilot`, etc. The same directory will hold `cortex` post-MIG-7. |
 
 **Why this matters for the design:**
 
-- Cortex's `provides:` list is the operator-facing API of the package, just as cortex's envelope set (§6.1) is the agent-facing API of the running app. Both are versioned, append-only, and form contracts cortex must honour across versions.
+- Cortex's `provides:` list is the principal-facing API of the package, just as cortex's envelope set (§6.1) is the agent-facing API of the running app. Both are versioned, append-only, and form contracts cortex must honour across versions.
 - arc's `dependsOn:` mechanism is the only place cross-bundle ordering shows up — at install time. At runtime, the bus mediates everything; arc has no runtime role.
 - The migration's MIG-6 (CLIs) and MIG-7 (top-level wiring) phases both spend significant time on arc-manifest changes. The plan tracks that explicitly.
 
@@ -403,7 +403,7 @@ Reference: `the-metafactory/arc` — the metafactory package manager. Like compa
 - Cortex's `arc-manifest.yaml` MUST be valid against arc's published manifest schema. Manifest validation runs in cortex's CI.
 - Cortex MAY shell out to `arc` for one-shot install-time steps (e.g. `arc identity provision` per JC's E2E NATS work) but never as a runtime dependency.
 
-**Reading order:** `~/Developer/arc/README.md` for the install model → `arc list` / `arc upgrade --help` for the operator-facing CLI → existing manifests in `~/.config/metafactory/pkg/repos/*/arc-manifest.yaml` as concrete examples.
+**Reading order:** `~/Developer/arc/README.md` for the install model → `arc list` / `arc upgrade --help` for the principal-facing CLI → existing manifests in `~/.config/metafactory/pkg/repos/*/arc-manifest.yaml` as concrete examples.
 
 ---
 
@@ -418,7 +418,7 @@ An M7 app's public surface is **the set of envelopes it publishes + the set it c
 For cortex, concretely:
 
 - **Inbound contract:** cortex consumes `local.{org}.{stack}.tasks.@{did-encoded-assistant}.{capability}` Direct/Delegate task envelopes (from adapters, taps, dashboards, or peer apps), `local.{org}.review.*` (from pilot), `local.{org}.attention.item.*` (from any source), `local.{org}.system.*` (operational events from any M7 app), and a few more. Each subject has a documented payload schema in cortex's domain catalogue.
-- **Outbound contract:** cortex publishes `local.{org}.dispatch.task.{started,progress,completed,failed,aborted}` (workflow runner emissions), `local.{org}.system.adapter.*` (per G-1111 §3.5), `local.{org}.review.*.decision` (operator decisions out of the surface).
+- **Outbound contract:** cortex publishes `local.{org}.dispatch.task.{started,progress,completed,failed,aborted}` (workflow runner emissions), `local.{org}.system.adapter.*` (per G-1111 §3.5), `local.{org}.review.*.decision` (principal decisions out of the surface).
 - The envelope schemas are versioned, append-only, and live in cortex's repo (`docs/api/` or `src/contracts/` — TBD; see open questions in the migration plan).
 - A consumer of cortex's contract can — in principle — replace cortex with a re-implementation that publishes/consumes the same envelopes, and the rest of the system doesn't notice. **That's the load-bearing property.**
 
@@ -428,7 +428,7 @@ The same applies for every M7 app: pilot has a contract, signal-collector has a 
 
 Each M7 app is a microservice in the architectural sense: independently deployable, owns its own data, communicates with peers async via the bus, fails independently.
 
-- **Independent deployment.** cortex and pilot ship via separate `arc` packages, separate version cadences. An operator can run pilot at a different version than cortex; if their envelope contracts are intersecting versions, they interoperate.
+- **Independent deployment.** cortex and pilot ship via separate `arc` packages, separate version cadences. An principal can run pilot at a different version than cortex; if their envelope contracts are intersecting versions, they interoperate.
 - **Data ownership.** Each M7 app owns its persistent state behind its own boundary. Cortex's Mission Control DB belongs to cortex; pilot's `errands.sqlite` belongs to pilot. No shared database, no foreign-key relationships across apps. State that needs to flow between apps flows as envelopes.
 - **Async-first communication.** Apps communicate via published envelopes (fire-and-forget), with M6 request/reply for synchronous needs. No app calls another app's HTTP endpoint as a primary integration mechanism. (CLI shell-outs for transitional integrations — e.g. `pilot fetch <PR>` — are tolerated short-term and tracked for removal.)
 - **Failure isolation.** An M7 app crashing degrades the system gracefully — its envelopes stop flowing, its surfaces go dark, but other apps keep running. The bus's `system.adapter.*` events make this visible per G-1111 §3.5 + §4.6.
@@ -443,7 +443,7 @@ Cortex's bounded context, roughly:
 
 | Concept | In cortex's bounded context? |
 |---------|------------------------------|
-| The operator's collaboration surface (Discord, Mattermost, Mission Control dashboard) | ✅ Yes — operator-collaboration is the core domain. |
+| The principal's collaboration surface (Discord, Mattermost, Mission Control dashboard) | ✅ Yes — principal-collaboration is the core domain. |
 | Workflow runner that spawns Claude Code on dispatch | ✅ Yes — dispatching work to Claude is part of the same bounded context. |
 | Worklog state per agent task | ✅ Yes — directly tied to dispatch lifecycle. |
 | GitHub webhook tap that publishes envelopes | ✅ Yes (probably) — thin shim that brings external events onto the bus where cortex's surface can render them. Could split out later. |
@@ -463,15 +463,15 @@ Reference: `~/Developer/myelin/docs/design-agent-task-routing.md` (myelin PR #36
 
 ### 7.1 Three distribution modes — what gets routed how
 
-The protocol carries three operator-facing modes, all on the same wire but with different operator contracts:
+The protocol carries three principal-facing modes, all on the same wire but with different principal contracts:
 
-| Mode | Operator says | Mechanism | Operator commits to |
+| Mode | Principal says | Mechanism | Principal commits to |
 |------|---------------|-----------|---------------------|
 | **Broadcast** | "someone do this" | competing consumers — any qualifying agent claims | a *task* (one unit of work) |
 | **Direct** | "Forge, cut a release" | named recipient — single agent, no competing | a *task* delivered to a known agent |
 | **Delegate** | "Pilot, drive PR #32 to merge" | same wire as Direct, but the receiving agent internally orchestrates a multi-step outcome | an *outcome* (not a task graph) |
 
-The cognitive-load argument for naming **Delegate** as a first-class mode: without it, the design implies all routing is open-market, and the operator-facing benefit (agents absorbing coordination overhead so the human commits to outcomes rather than task graphs) becomes invisible. Pilot's review loop is the canonical Delegate case — the operator says "drive this to merge," pilot internally decomposes that into ping/fetch/triage/apply/dispatch/sync.
+The cognitive-load argument for naming **Delegate** as a first-class mode: without it, the design implies all routing is open-market, and the principal-facing benefit (agents absorbing coordination overhead so the human commits to outcomes rather than task graphs) becomes invisible. Pilot's review loop is the canonical Delegate case — the principal says "drive this to merge," pilot internally decomposes that into ping/fetch/triage/apply/dispatch/sync.
 
 Delegate auditability rides on chain-of-stamps (myelin#31).
 
@@ -496,7 +496,7 @@ local.{org}.dispatch.task.started      ── agent began executing
 local.{org}.dispatch.task.progress     ── intermediate signal (Delegate sub-step, status update)
 local.{org}.dispatch.task.completed    ── ack outcome
 local.{org}.dispatch.task.failed       ── unrecoverable error; correlation_id for retry-thread join
-local.{org}.dispatch.task.aborted      ── operator-cancelled or system-aborted
+local.{org}.dispatch.task.aborted      ── principal-cancelled or system-aborted
 ```
 
 **Structured nak reasons** — when an agent rejects (naks) a Broadcast task, the reason MUST be one of:
@@ -524,12 +524,12 @@ myelin#36 draws an explicit boundary. Five concerns DO NOT live in the bus proto
 | Concern | Lives in | Cortex's home for it |
 |---------|----------|----------------------|
 | Agent capability declaration (tools, envs, creds, reach) | M7 deployment config | `cortex.yaml` `agents[].roles + .trust + .presence` per §9 |
-| Orchestrator translation of operator intent → task graph | M7 orchestrator agent | The Delegate-receiving agent's internal logic (e.g. pilot's review-loop logic — not in cortex; pilot is its own M7 app) |
+| Orchestrator translation of principal intent → task graph | M7 orchestrator agent | The Delegate-receiving agent's internal logic (e.g. pilot's review-loop logic — not in cortex; pilot is its own M7 app) |
 | Compliance attestation (e.g. Northpower STD-NPW-AI-001) | M7 deployment-time, signed at install | Cortex's `arc-manifest.yaml` + agent persona declarations; out of scope for v1 cortex but the slot exists |
 | Notification surface routing | M7 surface-router | `cortex/src/bus/surface-router.ts` (§8) — exactly this concern |
 | Sub-agent trust floor | M7 orchestrator policy + chain-of-stamps | Cortex's agent registry + chain-of-stamps verification (myelin#31) |
 
-The mistake to guard against: lifting any of the above into the bus. Each lift would couple the protocol to one operator's policy choices, break transport-independence, and create rot surface. Capability is too thin a primitive *if you put it in the bus*; rich enough *at M7*.
+The mistake to guard against: lifting any of the above into the bus. Each lift would couple the protocol to one principal's policy choices, break transport-independence, and create rot surface. Capability is too thin a primitive *if you put it in the bus*; rich enough *at M7*.
 
 ### 7.6 Cortex's responsibilities
 
@@ -538,7 +538,7 @@ Cortex's M7 dispatch handler — the runtime that takes inbound work (Discord pi
 1. **Publish** the lifecycle envelope sequence per §7.3 (`local.{org}.dispatch.task.{received,assigned,started,progress,completed,failed,aborted}`) on the `events.>` class. Every routed task is an event stream — the lifecycle is the protocol.
 2. **Tag mode** in envelope payload so consumers can distinguish Broadcast / Direct / Delegate. For Delegate, the receiving agent owns sub-step progress emission.
 3. **Consume** via JetStream pull consumers filtered to the agent's capabilities, **not** hardcoded by subject. Each cortex-hosted agent (Luna, Echo, Forge, …) subscribes through a pull consumer keyed on its declared capability set.
-4. **Respect nak semantics with structured reasons** (§7.3) — surface `cant_do` vs `wont_do` vs `not_now` vs `compliance_block` to operators rather than collapsing to a generic failure.
+4. **Respect nak semantics with structured reasons** (§7.3) — surface `cant_do` vs `wont_do` vs `not_now` vs `compliance_block` to principals rather than collapsing to a generic failure.
 5. **Register** each agent's capabilities into the KV bucket on startup with signed writes (myelin#31). The registry is the M5 Discovery seed; future myelin#9 spec consumes it.
 6. **Support sovereignty declaration** — each agent's config carries a `sovereignty:` field that determines its claim behaviour. Maps to the four modes in §7.4.
 7. **Honour stratification (§7.5)** — keep capability declaration, compliance attestation, surface routing, and orchestrator policy in cortex's M7 layer; never push them into bus envelopes.
@@ -570,7 +570,7 @@ cortex/
                           identity client (M4 when MY-400 lands), surface-router
                           (cortex-internal fan-out from bus to adapters/runner).
                           Loads ~/.config/cortex/cortex.yaml.
-    surface/          ── Operator surfaces — what humans see.
+    surface/          ── Principal surfaces — what humans see.
       mc/             ── Mission Control v3 (Hono + React, observed-session model).
       cli/            ── Future TUI / cli-tail surfaces. Empty in v1.
     adapters/         ── Platform-specific adapters (Discord, Mattermost, etc.).
@@ -587,7 +587,7 @@ cortex/
                           envelopes (so the surface-router and runner can act on them).
       gh-webhook/     ── GitHub webhook → NATS
       cc-events/      ── Claude Code hooks → NATS
-    cli/              ── Operator CLIs.
+    cli/              ── Principal CLIs.
       discord/        ── ~/bin/discord (subdir: discord.ts entry + lib/ + skill/)
       cldyo-live      ── CC instrumentation wrapper (single bash script, NOT a directory)
     common/           ── Shared types, utilities.
@@ -606,7 +606,7 @@ Internal module boundaries are TypeScript directory + import discipline, not pac
 
 ## 9. The agent + presence/renderer model
 
-A load-bearing concept from grove-v2 that cortex preserves and simplifies: each Discord-facing personality (Luna, Echo, Holly, Ivy, Forge) is a bundle of identity + persona + capabilities + platform credentials. Operators interact with these bundles by name — "ping Echo for review", "ask Luna to summarise", "Holly is JC's reviewer". That contract cannot break.
+A load-bearing concept from grove-v2 that cortex preserves and simplifies: each Discord-facing personality (Luna, Echo, Holly, Ivy, Forge) is a bundle of identity + persona + capabilities + platform credentials. Principals interact with these bundles by name — "ping Echo for review", "ask Luna to summarise", "Holly is JC's reviewer". That contract cannot break.
 
 ### 9.1 Agents own their presence (not the other way around)
 
@@ -622,7 +622,7 @@ Mental model: a human user connects to a server with their credentials; the serv
 Cortex config schema:
 
 ```yaml
-operator:                          # who is running this cortex instance
+principal:                          # who is running this cortex instance
   id: andreas
   discordId: "1134..."
 
@@ -705,9 +705,9 @@ Renderers organise around **events / work-items / cards**, not agents. A dashboa
 Two kinds of renderer config:
 
 1. **Static** (in YAML) — initial subscriptions, projection rules, paging rules, default columns. Deployment-time decisions.
-2. **Runtime / UX** (in the dashboard itself) — operator preferences: which columns to expand, which filters to pin, which agent's activity to highlight. Live in the renderer's own state (D1 / SQLite / browser localStorage), not in cortex.yaml.
+2. **Runtime / UX** (in the dashboard itself) — principal preferences: which columns to expand, which filters to pin, which agent's activity to highlight. Live in the renderer's own state (D1 / SQLite / browser localStorage), not in cortex.yaml.
 
-The split keeps cortex.yaml deterministic + reviewable while letting operators arrange their own view without a config edit + restart.
+The split keeps cortex.yaml deterministic + reviewable while letting principals arrange their own view without a config edit + restart.
 
 ### 9.3 Coupling discipline
 
@@ -717,7 +717,7 @@ The split keeps cortex.yaml deterministic + reviewable while letting operators a
 - Personas MUST be platform-neutral markdown — no Discord-specific formatting, no `<@id>` mentions baked in. The presence adapter translates logical mentions (`@echo`) into platform syntax at render time.
 - An agent's roles list defines its **maximum** capability set. A presence MAY further restrict (e.g., Luna's Slack presence in a public workspace may strip `team` mode). Presences never widen.
 - Cross-agent trust resolves at adapter startup: each presence adapter, on connect, learns its own platform user id (e.g. `discord.client.user.id`) and registers it in a process-wide `(platformId → agentId)` map. When an inbound message arrives from a known platform id, the receiving adapter looks up the source agent and consults its parent's `trust:` list.
-- **Renderers MUST NOT publish on the bus** as a side effect of rendering. Renderers are sinks: they subscribe and present. Operator-input emitted from a renderer (e.g., a dashboard "approve" click) goes through the bus as a logical envelope from the operator, not from any agent.
+- **Renderers MUST NOT publish on the bus** as a side effect of rendering. Renderers are sinks: they subscribe and present. Principal-input emitted from a renderer (e.g., a dashboard "approve" click) goes through the bus as a logical envelope from the principal, not from any agent.
 
 ---
 

--- a/docs/design-mission-control.md
+++ b/docs/design-mission-control.md
@@ -1,16 +1,10 @@
-# Grove Mission Control — v2
+# Cortex Mission Control — v3
 
-<!-- lifted-from-grove-v2-at-MIG-7.11 -->
-<!-- Original location: github.com/the-metafactory/grove-v2 docs/design-mission-control.md -->
-<!-- Lifted: 2026-05-11 — historical references to grove/grove-v2 retained for provenance. -->
+**Status:** Living design reference for the shipped Mission Control surface (`src/surface/mc/`). Describes what Mission Control IS today in cortex, reverse-engineered from the implementation. The grove-v2 design-process origins of this surface are preserved in the [History](#history--mission-control-v2-grove-v2-origins) appendix.
+**Surface:** M7 — `src/surface/mc/` (the principal's collaboration cockpit, per `docs/architecture.md` §9).
+**Updated:** 2026-05-27 (vocabulary-migration rewrite, cortex#436 / PR-R13e).
 
-**Status:** Design spec. Replaces the prior `design-mission-control.md` and supersedes `research-2026-04-12-mission-control-synthesis.md`.
-**Date:** 2026-04-15
-**Driver:** Andreas
-**Sprint artifacts:** `Plans/design-sprint-mc/00-plan.md` … `03-decisions.md`
-**Related docs:** `docs/design-spawn-integration.md` — preserved spawn-backed execution design, on ice until Spawn is ready.
-
-This document is the single source of truth for Grove Mission Control. Every claim in it traces back to either one of Andreas's 8 concerns or a cross-doc conflict resolution in `03-decisions.md`.
+> **Vocabulary note.** This surface is mid-way through the principal-vocabulary migration (cortex#436). This doc uses the **canonical `principal` terms** throughout. A handful of code symbols are still being renamed in lockstep PRs and may lag the doc until they land: the task / session owner columns → `principal_id` (PR-R2b, cortex#447), the sovereignty column → `home_principal` (PR-R2.J, cortex#448), and the curation / input event kinds → `principal.input` / `principal.curation` (producers in PR-R2b, frontend consumers in PR-R13d, cortex#450). Where this doc names those symbols it uses the post-rename canonical form.
 
 ---
 
@@ -18,120 +12,112 @@ This document is the single source of truth for Grove Mission Control. Every cla
 
 ### 1.1 Goal
 
-Cortex Mission Control is **the principal's cockpit for running many agents against a curated backlog**. One operator, many agents, many tasks, one dashboard. The core job of the dashboard is: **surface the agent that needs the operator right now, and let the operator unblock it without leaving the UI.**
+Cortex Mission Control is **the principal's cockpit for running many agents against a curated backlog**. One principal, many agents, many tasks, one dashboard. The core job of the dashboard is: **surface the agent that needs the principal right now, and let the principal unblock it without leaving the UI.**
 
 Three properties follow from that job:
 
-1. **Visibility.** The operator can see, at a glance, which agents need attention and which are making progress on their own.
+1. **Visibility.** The principal can see, at a glance, which agents need attention and which are making progress on their own.
 2. **Drill-down.** Any attention item opens into a rich view of the agent's current task: summary, time-descending event log, input affordance.
-3. **Action return.** The operator can respond from the UI — text and screenshot — and the agent continues. The operator never has to drop into the terminal to unblock an agent.
+3. **Action return.** The principal can respond from the UI — text and screenshot — and the agent continues. The principal never has to drop into the terminal to unblock an agent.
 
-Beyond the visible cockpit, mission control is also:
+Beyond the visible cockpit, Mission Control is also:
 
-- **A task funnel.** Source backlogs (GitHub issues, PRs, future Jira tickets) are upstream of a curated internal queue. Not every issue becomes agent work; the operator decides what enters the queue.
-- **A notification system.** When something exceptional happens outside the operator's current view, Discord gets pinged with a deep link back into the dashboard.
-- **A local-first service that is ready to become multi-operator.** v1 ships single-operator Tier 1 (local Bun + SQLite). The data model and access patterns are built so Tier 2 (cloud CF Worker + D1, multi-operator) is a runtime change, not a redesign.
+- **A task funnel.** Source backlogs (GitHub issues, PRs) are upstream of a curated internal queue. Not every issue becomes agent work; the principal decides what enters the queue.
+- **An iteration-planning kanban.** GitHub issues are imported into iterations and moved through planning columns (inbox → designing → ready → shipped).
+- **A notification system.** When something exceptional happens outside the principal's current view, Discord gets pinged with a deep link back into the dashboard.
+- **A local-first service with a cloud sibling.** Locally it runs as a single-process Bun app over SQLite; in the cloud the same data surface is served by a Cloudflare Worker over D1.
 
-### 1.2 Non-goals for v2
+### 1.2 Non-goals
 
-- **Multi-operator runtime.** v1 is single-operator. Schema and access paths must not preclude Tier 2 multi-operator, but the runtime is single-operator only (Concern 2 Q2.2, Concern 5 Q5.5).
-- **Spawn-backed execution.** v1 uses local `Bun.spawn` at Tier 1. Spawn (the metafactory execution engine) is not ready; its integration design is preserved in `docs/design-spawn-integration.md` and will be re-integrated once Spawn ships.
-- **Phone push notifications.** Tier 2 only (Concern 1 Q1.1).
-- **OS desktop notifications.** Future capability once event-back-in automations ship (Concern 1 Q1.1).
-- **TaskSource abstraction.** No pluggable interface in v2 — one concrete GitHub path via `sourceRef` (Conflict 4).
-- **Classifier service / notification router service.** Hardcoded ~10-line priority map in grove-bot (Concern 1 Q1.2, Conflict 1).
-- **Stale-task sweepers, retry budgets, DLQ.** No background reconciliation. Operator has manual move-along controls (Concern 2 Q2.5).
-- **LAN device hopping (reading Discord on phone/tablet at Tier 1).** Not supported; Tier 1 is local-desktop only (Concern 8 Q8.2, Q8.3).
-- **Pets/cattle vocabulary.** Dropped. Replaced by head/hands (Conflict 5).
-- **Luna as privileged orchestrator.** The operator is the orchestrator; Luna is one agent instance (Conflict 6).
+- **Multi-principal runtime as a first-class local feature.** The local surface is single-principal. The cloud (Worker + D1) surface carries `principal_id` / `home_principal` columns for multi-principal federation, but the local runtime is single-principal.
+- **Spawn-backed execution.** Local execution uses `Bun.spawn`. The preserved Spawn integration design lives in `docs/design-spawn-integration.md`.
+- **Phone push / OS desktop notifications.** Discord is the only notification sink.
+- **A pluggable `TaskSource` abstraction.** One concrete GitHub path via the `sourceRef` triple.
+- **A classifier / notification-router service.** A small hardcoded priority map decides what to notify.
+- **Stale-task sweepers, retry budgets, DLQ.** No background reconciliation — the principal has manual move-along controls (requeue / handoff / abandon).
 
 ---
 
-## 2. Core operator flow
+## 2. Core principal flow
 
 The dashboard is designed around one loop. Everything else serves it.
 
 ```
 ┌──────────────────────────────────────────────────────────────────┐
-│  1. Operator opens Grove dashboard                               │
+│  1. Principal opens the Mission Control dashboard                │
 │     ↓                                                            │
 │  2. Focus area: "who needs me right now"                         │
 │     ↓  (or Discord ping with deep link back into the dashboard)  │
-│  3. Operator clicks an attention card                            │
+│  3. Principal clicks an attention card                           │
 │     ↓                                                            │
-│  4. Attention view opens:                                        │
+│  4. Drill-down opens:                                            │
 │        ├─ Summary header  (which agent, which task, state)      │
 │        ├─ Event log       (time-descending, rich, scrollable)   │
-│        └─ Input affordance (text + screenshot)                   │
+│        └─ Input affordance (text + screenshot) + curation tools │
 │     ↓                                                            │
-│  5. Operator types / pastes response                             │
+│  5. Principal types / pastes a response (or curates)             │
 │     ↓                                                            │
 │  6. Input is delivered to the agent's session (queued if busy)   │
 │     ↓                                                            │
-│  7. Agent continues; event log updates live                      │
+│  7. Agent continues; event log updates live over the WebSocket   │
 │     ↓                                                            │
 │  8. Attention card clears when the agent moves on                │
 └──────────────────────────────────────────────────────────────────┘
 ```
 
-The critical primitive: **the attention view is scoped to one `agent_task_assignment` row** — the link between an agent (head) and a task. "Something needs my attention" is never "an agent needs me in the abstract" and never "a task needs me in the abstract." It is always "this agent, on this task, in this state." (Concern 4 framing, Concern 2 Q2.1/Q2.4.)
+The critical primitive: **the drill-down is scoped to one `agent_task_assignment` row** — the link between an agent (head) and a task. "Something needs my attention" is never "an agent needs me in the abstract" and never "a task needs me in the abstract." It is always "this agent, on this task, in this state."
 
 Three concrete examples of the loop, covering the common block shapes:
 
-- **Error.** Luna is running on task T-42 ("fix webhook HMAC verification"); a bash tool call fails. Assignment transitions `running → blocked` with `block_reason = { kind: 'tool.error', tool_name: 'tool.bash', message: 'permission denied', exit_code: 1 }`. Dashboard attention card for the Luna×T-42 assignment appears; Discord pings the operator. Operator clicks the card, sees the failed bash in the event log, types "try running it in the src/worker dir", submits. Assignment returns to `running`; card clears.
-- **Permission request.** An implementer agent running in default-permission CC mode on task T-17 ("refactor dashboard state hook") wants to edit `src/dashboard/use-grove-api.ts`. Assignment transitions `running → blocked` with `block_reason = { kind: 'permission.request', requested_action: 'tool.edit', target: 'src/dashboard/use-grove-api.ts', risk_hint: 'medium' }`. Dashboard attention card surfaces the exact edit target; Discord pings. Operator clicks card, sees the proposed edit inline, presses **Approve**. Assignment resumes; card clears.
-- **Review checkpoint.** An ephemeral implementer agent on task T-51 ("bump grove-bot to v0.23.0") has prepared a release draft and needs human sign-off that is not a CC permission prompt but a task-level gate the agent asked for. Assignment is `blocked` with `block_reason = { kind: 'review.checkpoint', note: 'release draft ready' }`. Operator opens the card, reads the release draft in the event log, pastes a screenshot of the changelog with a checkmark, types "approved, ship it", submits. Assignment goes `running`; agent merges; card clears.
+- **Error.** An agent is running on task T-42 ("fix webhook HMAC verification"); a bash tool call fails. The assignment transitions `running → blocked` with `block_reason = { kind: 'tool.error', tool_name: 'tool.bash', message: 'permission denied', exit_code: 1 }`. The focus-area card appears; Discord pings the principal. The principal opens the card, sees the failed bash in the event log, types "try running it in the src/worker dir", submits. The assignment returns to `running`; the card clears.
+- **Permission request.** An agent in default-permission CC mode on task T-17 wants to edit a file. The assignment transitions `running → blocked` with `block_reason = { kind: 'permission.request', requested_action: 'tool.edit', target: '<path>', risk_hint: 'medium' }`. The card surfaces the exact edit target; Discord pings. (Approve/Deny rendering ships, but is gated on CC's stream-json permission protocol — see §6.3.)
+- **Review checkpoint.** An agent on task T-51 has prepared a release draft and asks for human sign-off. The assignment is `blocked` with `block_reason = { kind: 'review.checkpoint', note: 'release draft ready' }`. The principal reads the draft in the event log, pastes a screenshot, types "approved, ship it", submits. The assignment goes `running`; the card clears.
 
-All three go through the same primitive: **assignment state change → attention item appears → drill-down shows context → operator action (input or approve/deny) → assignment state change.**
+All three go through the same primitive: **assignment state change → attention item appears → drill-down shows context → principal action (input or approve/deny) → assignment state change.**
 
 ---
 
 ## 3. The task funnel
 
-The task is the vessel for all orchestration in Grove. Everything else hangs off it.
+The task is the vessel for orchestration in Mission Control. Everything else hangs off it.
 
 ### 3.1 What a task is
 
-A task is a **first-class Grove object that references a source system** (Concern 2 framing, Concern 3 framing). Grove's orchestration history — the queue, the state machine, the sessions, the events — lives against the Grove task row. The source system (GitHub issue, PR, future Jira) is authoritative for its own state, but is not where Grove tracks orchestration.
+A task is a **first-class object that references a source system**. Mission Control's orchestration history — the queue, the state machine, the sessions, the events — lives against the task row. The source system (GitHub issue or PR) is authoritative for its own state, but is not where Mission Control tracks orchestration.
 
-### 3.2 Task schema
+### 3.2 Task schema (`tasks`, local SQLite)
 
-```
-tasks
-  id                     TEXT PRIMARY KEY          -- Grove-internal ID
-  title                  TEXT NOT NULL
-  description            TEXT
-  priority               INTEGER NOT NULL          -- P0..P3 (Concern 7 Q7.4 — NEW)
-  operator_id            TEXT                      -- nullable Tier 1, required Tier 2 (Q2.2)
-  source_system          TEXT NOT NULL             -- 'github' | 'internal'
-  source_url             TEXT                      -- canonical URL, nullable
-  source_external_id     TEXT                      -- issue number / PR number, nullable
-  related_refs_json      TEXT                      -- JSON array of {system, url, external_id} triples — display only (Q3.3)
-  created_at             INTEGER NOT NULL
-  updated_at             INTEGER NOT NULL
-```
+| Column | Type | Notes |
+|--------|------|-------|
+| `id` | TEXT PK | Mission Control-internal ID |
+| `title` | TEXT NOT NULL | |
+| `description` | TEXT | |
+| `priority` | INTEGER | P0..P3 |
+| `principal_id` | TEXT | the owning principal (see vocabulary note) |
+| `source_system` | TEXT | `'github'` \| `'internal'` |
+| `source_url` | TEXT | canonical URL, nullable |
+| `source_external_id` | TEXT | issue / PR number, nullable |
+| `related_refs_json` | TEXT | JSON array of `{system, url, external_id}` triples — display only |
+| `status` | TEXT | `'open'` \| `'in_progress'` \| `'done'` \| `'cancelled'` |
+| `iteration_id` | TEXT FK | nullable; links a task to an iteration (§3.5) |
+| `created_at` / `updated_at` | INTEGER | epoch ms |
 
-The `source_system`/`source_url`/`source_external_id` triple is the flat three-field `sourceRef` from Concern 3 Q3.1 — no nesting, no abstraction. Throughout this doc, "sourceRef" is the conceptual name for the triple; the physical columns are always the three separately named fields above. `related_refs_json` holds additional display-only refs (e.g., the PR that closes the issue) as a JSON array of the same three-field shape.
+The `source_system` / `source_url` / `source_external_id` triple is the flat `sourceRef`. Throughout this doc, "sourceRef" is the conceptual name for the triple; the physical columns are the three separately named fields above.
 
-**Reuse of existing grove schema.** Grove already tracks GitHub entities via `repos`, `issues`, `pull_requests`, and `github_events` in `src/worker/schema.sql`, updated by the webhook-proxy → grove-api pipeline. The task row does **not** duplicate issue or PR data — it joins to the existing tables via `source_external_id` for display (Concern 3 Q3.2, Conflict 4). No new reconciler is introduced.
+**Reuse of existing GitHub tables.** GitHub entities are tracked via `repos`, `issues`, `pull_requests`, and `github_events` (in the Worker D1 schema), updated by the webhook → ingest pipeline. The task row does **not** duplicate issue or PR data — it joins via `source_external_id` for display.
 
-### 3.3 Assignment schema
+### 3.3 Assignment schema (`agent_task_assignment`)
 
-```
-agent_task_assignment
-  id                     TEXT PRIMARY KEY
-  task_id                TEXT NOT NULL  → tasks.id
-  agent_id               TEXT NOT NULL  → agents.id
-  state                  TEXT NOT NULL  -- queued | dispatched | running | blocked | completed | failed
-  block_reason           TEXT           -- structured JSON when state=blocked
-  operator_id            TEXT           -- same nullable→required pattern
-  dispatched_at          INTEGER
-  completed_at           INTEGER
-  created_at             INTEGER NOT NULL
-  updated_at             INTEGER NOT NULL
-```
+| Column | Type | Notes |
+|--------|------|-------|
+| `id` | TEXT PK | |
+| `task_id` | TEXT FK → `tasks.id` | |
+| `agent_id` | TEXT FK → `agents.id` | |
+| `state` | TEXT | `queued` \| `dispatched` \| `running` \| `blocked` \| `completed` \| `failed` \| `cancelled` |
+| `block_reason` | TEXT (JSON) | structured, present when `state = blocked` (§6.3) |
+| `created_at` / `updated_at` | INTEGER | |
 
-Agent ↔ task is **many-to-many** (Concern 2 Q2.4). An agent can have assignments on multiple tasks; a task can have assignments from multiple agents (e.g., one analysing, one implementing). **The state machine lives on the assignment row, not on the task and not on the agent.**
+Agent ↔ task is **many-to-many**: an agent can hold assignments on multiple tasks; a task can carry assignments from multiple agents. **The state machine lives on the assignment row, not on the task and not on the agent.**
 
 ```
 agents ───┐                   ┌─── tasks
@@ -141,25 +127,7 @@ agents ───┐                   ┌─── tasks
                       └─► sessions (0..N per assignment)
 ```
 
-`sessions` is the existing grove session record (`src/bot/lib/session-manager.ts`, per-thread Claude Code session). A session now points up to an assignment rather than floating. Session lifecycle events mutate assignment state; they do not mutate task state directly.
-
-**State machine:**
-
-```
-queued ──dispatch──▶ dispatched ──start──▶ running ──block──▶ blocked
-                                              │
-                                              ├── complete ──▶ completed  (terminal)
-                                              │
-                                              └── fail ─────▶ failed
-```
-
-Transitions not drawn in the diagram (to keep it readable):
-
-- `blocked ──resume──▶ running` — the agent's block clears (tool call approved, error recovered, review checkpoint satisfied) and it continues.
-- `blocked ──operator_requeue──▶ queued` — the operator escape hatch from a stuck-blocked assignment (Concern 2 Q2.5).
-- `failed ──operator_requeue──▶ queued` — the operator retry escape hatch from a terminal-failed assignment.
-
-`completed` is terminal; there is no `operator_requeue` out of it (a re-run creates a new assignment row). `operator_requeue` is the only manual move-along in the model — there are no automatic timers. The operator is the only non-agent actor who can pull an assignment out of a stuck state.
+`sessions` rows point up to an assignment. Session lifecycle events mutate assignment state; they do not mutate task state directly.
 
 ### 3.4 The funnel
 
@@ -167,41 +135,34 @@ Transitions not drawn in the diagram (to keep it readable):
 source backlogs              curated queue            dispatch              work
 ────────────────────         ──────────────           ─────────────         ────────
 GitHub issues      ─┐        tasks                   agent_task_           sessions
-GitHub PRs          ├──▶     (operator curated)──▶   assignment       ──▶  (CC runs)
+GitHub PRs          ├──▶     (principal curated)─▶   assignment       ──▶  (CC runs)
 internal notes     ─┘        priority-ordered        state machine
-future: Jira etc.                                    link table
 ```
 
-**The operator decides what enters the queue.** Not every GitHub issue becomes a task. The issue view has an "add to queue" affordance that creates a task row with a `sourceRef` pointer into the existing `issues` table (Concern 2 Q2.3). The queue is a subset of the source backlog, curated by hand.
+**The principal decides what enters the queue.** Not every GitHub issue becomes a task. `POST /api/tasks/preview` then `POST /api/tasks` create a task row with a `sourceRef` pointer (the `+ Add task` affordance at the top of the task table; URL / `owner/repo#N` / `#N` shorthand accepted, GitHub fetched via the `gh` CLI). The queue is a subset of the source backlog, curated by hand.
 
-The "curation UX" is the task view itself. Opening a task opens the agent's attention view for that task's primary assignment (§5). Task opening and attention drill-down are the same interaction — the task is the context source.
+The "curation UX" is the task view itself. Opening a task opens the drill-down for that task's primary assignment (§5). Detailed feature designs: the task-table design (`docs/design-mc-f8-task-table.md`), the task-curation design covering manual dispatch / requeue / handoff / abandon, and the add-to-queue design.
 
-**Pre-implementation addendum:** `docs/design-mc-f12-task-curation.md` resolves ten open questions before F-12 lands — the F-12 / F-12b scope split (assignment-state verbs ship first; GitHub add-to-queue ships in a sibling PR), the curation toolbar living inside the F-7 drill-down (no side panel, no separate route), the per-state button-enablement matrix derived from the state machine, the agent-picker dropdown for Dispatch and Hand off, the assignment-vs-task branching for Abandon, the cancel-and-respawn semantics for Hand off, the 1-to-1 mirror of `operator_requeue` for Requeue, the confirmation gate posture (Abandon and Hand off prompt; Dispatch and Requeue do not), the `operator.curation` event family with `kind` discriminator (and a synthetic per-task shadow session for assignment-less curation events), and explicit deferral of bulk operations / templates / dependencies / tagging / slash-commands.
+### 3.5 Iterations (`iterations`)
 
-**Pre-implementation addendum:** `docs/design-mc-f12b-add-to-queue.md` resolves eleven open questions before F-12b lands — placement of the `+ Add task` affordance at the top of the F-8 task table (with ⌘K palette as a sibling shortcut once MIG-3 lands real palette commands), the input → preview → submit modal flow, GitHub access via the existing `gh` CLI / `Bun.spawn` shape (no `@octokit/rest` dependency), the URL/shorthand parser accepting full URL plus `owner/repo#N` plus `#N`-with-default-repo, dedup by reject-and-deeplink at preview time (no UNIQUE index in v1), the two-endpoint shape (`POST /api/tasks/preview` and `POST /api/tasks`) plus the F-12-inherited `POST /api/tasks/:taskId/abandon`, the empty-assignment Dispatch site rewire at `dashboard/index.html:2134`, the `task-shadow-{taskId}` synthetic-session helper using a `mc-shadow-agent` sentinel and `endpoint_kind='local.observed'`, the form-blocks-with-spinner UX during the GitHub fetch, the `operator.curation` event with new `kind: "task.imported"` variant, and explicit deferral of bulk import / scheduled imports / GitHub project boards / Linear-Jira-Asana / two-way sync / inbound-webhook auto-add.
+Mission Control also owns an **iteration-planning kanban** (detailed in `docs/design-mc-iteration-planning.md`). The `iterations` table carries `id`, `title`, `body`, `imported_body`, `priority`, a lifecycle `state` (`inbox` \| `designing` \| `queued` \| `in_flight` \| `blocked` \| `done` \| `cancelled`), `source_system` / `source_url` / `source_parent_ref`, and timestamps. Iterations are imported from GitHub (`POST /api/iterations/from-github`, plus a `POST /api/github/webhook` path); their lifecycle is owned locally and is not synced back upstream. Tasks attach to iterations via `tasks.iteration_id`.
 
 ---
 
 ## 4. Notification system
 
-**Pre-implementation addendum:** `docs/design-mc-f11-discord-notifications.md` resolves ten open questions before F-11 lands — the full transition × priority × block-reason-kind × risk notification matrix, DM-vs-channel-post split (one event, one surface; with role-ping escalation for high-risk P0/P1 blocks), the concrete deep-link URL shape with `from=dm` / `from=channel` param, channel-routing that reads the v1 SOP's config when present and falls through cleanly when it doesn't (no thread auto-creation in v2), the `grove.notifications.discord` toggle + `grove.baseUrl` + `discord.operatorRoleId` config keys with off-by-default posture, a three-layer dedup + coalesce + channel-throttle rate-limiting model, the single-event and coalesced payload shapes, reuse of the existing `DiscordAdapter` (no new bot / no new token), and explicit deferral of interactive buttons / slash-commands / additional channels / preferences UI / multi-operator fanout.
+Notifications are a **requirement layered on top of the dashboard attention core**. The dashboard visual attention indicator (§5, §8) is the foundation; push is additive. If push is paused or swapped, the core does not move. Detailed design: `docs/design-mc-f11-discord-notifications.md`.
 
-Notifications are a **requirement layered on top of the dashboard attention core**. The dashboard visual attention indicator (§5, §7) is the foundation. Push is additive. If push is ever paused or swapped, the core does not move. (Concern 1 framing.)
+### 4.1 Channels
 
-### 4.1 Channels in v1
-
-**Discord only** (DM + channel post). No OS desktop notifications. No phone push. (Concern 1 Q1.1.)
-
-Rationale: Discord is already shipped — zero new dependency. Grove already has `grove-bot` wired to Discord gateway; reuse it as the sink. OS desktop notifications may return later through the event pipeline once event-back-in enables arbitrary automations — that's a post-MVP capability, not v2 scope.
+**Discord only** (DM + channel post). No OS desktop notifications, no phone push. Rationale: Discord is already shipped — the existing `DiscordAdapter` is reused as the sink; no new bot, no new token.
 
 ### 4.2 Routing
 
-**Hardcoded priority map, ~10 lines, in grove-bot.** No classifier service. No router abstraction. (Concern 1 Q1.2, Conflict 1.)
+A **small hardcoded priority map** decides what to notify — no classifier service, no router abstraction. It branches on the assignment state transition and the `block_reason.kind`:
 
 ```ts
-// grove-bot, concrete, not abstract
 function shouldNotify(event: AssignmentStateChange): NotificationIntent | null {
-  // Permission requests are a distinct blocked-reason that the operator resolves via approve/deny (§5.3.1).
   if (event.to === 'blocked' && event.blockReason?.kind === 'permission.request') {
     const risk = event.blockReason.risk_hint;
     if (risk === 'high' || event.task.priority <= 1) return { channel: 'dm', urgency: 'high' };
@@ -215,754 +176,326 @@ function shouldNotify(event: AssignmentStateChange): NotificationIntent | null {
 }
 ```
 
-Only promote to a data-driven classifier when the map is observably wrong in interesting ways. "Don't build a traffic-shaping system before there is traffic" (Council §1.1).
+The map is promoted to a data-driven classifier only when it is observably wrong in interesting ways. "Don't build a traffic-shaping system before there is traffic."
 
-### 4.3 Channel opt-in
+### 4.3 Opt-in + deep links
 
-One-bit toggle in `bot.yaml`:
-
-```yaml
-grove:
-  notifications:
-    discord: true
-```
-
-Revisit only when a second channel lands. (Concern 1 Q1.3.)
-
-### 4.4 Deep links
-
-Every notification includes a deep link back into the dashboard. The link opens to the relevant attention card.
-
-**Base URL comes from `bot.yaml`:**
-
-```yaml
-grove:
-  baseUrl: http://localhost:8766   # Tier 1 default
-  # baseUrl: https://grove.meta-factory.ai  # Tier 2
-```
-
-Tier 1 defaults to `http://localhost:8766`. Tier 2 points at the cloud origin. No runtime base-URL detection. (Concern 8 Q8.1.)
-
-**Scope limits:**
-
-- **LAN:** not supported in v2. If Grove runs on one machine and Discord is read on another, the link will not work. (Concern 8 Q8.2.)
-- **Mobile at Tier 1:** not supported. If the operator reads a Tier 1 notification from their phone, the localhost link will not open. Tier 1 is a local-desktop experience. (Concern 8 Q8.3.)
-- **Mobile at Tier 2:** works natively because the base URL is a public origin.
-
-Deep-link format:
+Discord notifications are off by default and toggled in config. Every notification includes a deep link back into the dashboard, opening to the relevant attention card:
 
 ```
-{grove.baseUrl}/?focus=assignment/{assignment_id}
+{baseUrl}/?focus=assignment/{assignment_id}
 ```
+
+Locally `baseUrl` is the loopback origin; in the cloud it is the public origin (`grove.meta-factory.ai`). LAN / cross-device reading of a loopback link is not supported locally; the cloud surface is the path for phone access.
 
 ---
 
-## 5. Agent attention view
+## 5. Agent attention view (drill-down)
 
-**Pre-implementation addendum:** `docs/design-mc-f7-attention-view.md` resolves nine open questions from this section before F-7 lands — input-affordance placeholder posture, overlay-vs-route navigation, the events pagination endpoint, D/A/H classification at content-block granularity, operator-vs-tool `stream-json.user` disambiguation, Approve/Deny wire-up gate, summary header minimum viable content, hand-rolled virtualisation, and single-drill-down enforcement.
-
-The attention view is the **drill-down**. It is scoped to exactly one `agent_task_assignment` row (§3.3). It renders the head (agent), the task, the current hands run (session), and the operator's input affordance.
-
-**Reference implementation for rich-context rendering:** `~/Developer/miner` — metafactory's process-mining repo. Phase 4 borrowing targets are summarised in §5.4.
+The drill-down (`components/drill-down.tsx`, F-7) is scoped to exactly one `agent_task_assignment` row (§3.3). It renders the head (agent), the task, the current hands run (session), the event log, the curation toolbar (§3, §7), and the principal's input affordance (§6). Detailed design: `docs/design-mc-f7-attention-view.md`.
 
 ### 5.1 Layout
 
-Three vertical sections, top to bottom. (Concern 4 Q4.1.)
+Three vertical sections, top to bottom:
 
 ```
 ┌──────────────────────────────────────────────────┐
-│  ① Summary header  (collapsed by default)        │
-│     Luna × T-42 "fix webhook HMAC verification"  │
-│     State: blocked  ·  waiting on:  tool.bash    │
-│     Dispatch cycle: 3                            │
-│     [▾ expand]                                   │
+│  ① Summary header  (task + iteration chip)        │
+│     agent × T-42 "fix webhook HMAC verification"  │
+│     State: blocked  ·  waiting on: tool.bash      │
 ├──────────────────────────────────────────────────┤
-│  ② Time-descending event log  (virtualised)      │
-│     [newest]                                     │
-│     ├─ operator: "try running it in src/worker"  │
-│     ├─ tool.bash: exit 1 — "permission denied"   │
-│     ├─ tool.bash: cd src/worker && bun test      │
-│     ├─ assistant: "I'll run the tests next..."   │
-│     ├─ tool.read: src/worker/webhook.ts          │
-│     │  ⋯ scroll for older events ⋯               │
-│     [oldest]                                     │
+│  ② Time-descending event log  (virtualised)       │
+│     [newest]                                      │
+│     ├─ principal: "try running it in src/worker"  │
+│     ├─ tool.bash: exit 1 — "permission denied"    │
+│     ├─ assistant: "I'll run the tests next..."    │
+│     │  ⋯ scroll for older events ⋯                │
+│     [oldest]                                       │
 ├──────────────────────────────────────────────────┤
-│  ③ Input affordance                              │
+│  ③ Curation toolbar + input affordance            │
+│     [Dispatch] [Requeue] [Handoff] [Abandon]      │
 │     ┌──────────────────────────────────────────┐ │
-│     │ [text box — supports drag/drop/paste]   │ │
+│     │ [text box — drag/drop/paste images]      │ │
 │     └──────────────────────────────────────────┘ │
-│     [📎 attach]  [↩ submit]      queue: 0 items │
+│     [📎 attach]  [↩ submit]      queue: 0 items   │
 └──────────────────────────────────────────────────┘
 ```
 
+Global keys in the drill-down: `Esc` close, `]` / `[` cycle assignments, `f` toggle focus mode.
+
 ### 5.2 Summary header
 
-- **Collapsed default:** agent name, task title, current state, one-line block reason (if blocked), dispatch cycle number.
-- **Expanded:** adds the agent's own `block_reason` content, the task `sourceRef` context (issue title, PR number, etc.), any assignment metadata.
-
-**Source of the summary is hybrid.** When the assignment is `blocked`, the summary uses the agent's own explicit `block_reason` (required as part of the block protocol — no guessing). When the assignment is `running`, the summary is inferred from the last N events with simple "current phase" heuristics. (Concern 4 Q4.2.)
-
-The summary is **scaffolding, not a source of truth** — the event log below is authoritative. The summary just helps the operator orient in under a second.
+Collapsed default shows agent name, task title, current state, and a one-line block reason when blocked. When the assignment is `blocked`, the summary uses the agent's explicit `block_reason` (part of the block protocol — no guessing). When `running`, it is inferred from recent events. The summary is **scaffolding, not a source of truth** — the event log below is authoritative.
 
 ### 5.3 Event log
 
-Time-descending, newest at the top, full session history, virtualised scroll, no hard cap (Concern 4 Q4.3).
+Time-descending, newest at the top, full session history, hand-rolled virtualisation (default viewport renders the most recent events, older lazy-loaded on scroll). Events are rendered by `lib/event-rows.ts` and `components/drill-log.tsx`. Event rows carry a **D/A/H colour classification** (borrowed from the miner process-mining dashboard):
 
-**Prominence is not flat.** When an agent is making progress, the operator's primary signal is **what the agent reports back** — the assistant messages, the "I found X, I'm doing Y, here's the result" stream. Tool calls and tool results are secondary context for a progressing agent. But the event log must also render well for the **blocked** case, which is the other main reason to drill into an attention item — most commonly a permission denial where the agent needs explicit operator approval to use a tool, read a file, run a command, or edit a file.
+| Class | Colour | Sources |
+|-------|--------|---------|
+| **D — Deterministic** | purple | `stream-json.assistant` text blocks, non-blocking `state.transition` |
+| **A — Agentic** | blue | `tool_use`, `tool_result` |
+| **H — Human** | gold | `principal.input` |
 
-Event rows are therefore rendered at three visual weights, mirroring Maestro's `TerminalOutput` pattern (see "Reference implementation pins" at the end of this section for Maestro file anchors; line numbers drift, so pin by file + function name):
+Event-kind rendering, as implemented today:
 
-| Weight    | Event types                                   | Rendering                                                         |
-| --------- | --------------------------------------------- | ----------------------------------------------------------------- |
-| **Primary**   | `assistant.message`, `operator.input`, `block.reason`, `permission.request` | Full-width markdown bubble via `MarkdownRenderer`. Always expanded. Streams in chunks (per §5.3 streaming note). `permission.request` renders with an inline **approve / deny** affordance — see §5.3.1 below. |
-| **Secondary** | `tool.call`, `tool.result`                | Compact left-border accent row with tool name + status glyph. **Collapsed by default.** Click to expand arguments / output. Maestro's `ToolCallCard` is the reference. |
-| **Tertiary**  | `thinking.chunk`, `subagent.trace`, `state.change` | Thin inline marker with a badge. Thinking renders inline expanded (Maestro pattern); subagent traces collapsed; state changes as one-line chips. |
+- **`principal.input`** — the principal's authored turn; text rendered as markdown, images as a click-to-enlarge lightbox. (H, gold.)
+- **`stream-json.assistant`** — Claude message blocks: text (markdown), thinking (collapsible with preview), tool_use / tool_result (paired, collapsible).
+- **`stream-json.user`** — suppressed when a `principal.input` row is present (the `principal.input` row is the human source of truth).
+- **`state.transition`** — state changes; blocking transitions render the block reason (expandable), non-blocking render a "from → to" chip.
+- **`permission.request`** — renders the requested action / target / context / risk, with **Approve / Deny** buttons. The buttons are currently **disabled pending CC's stream-json permission protocol** (see §6.3).
+- Fallback `raw` row for unknown event types.
 
-Note: when a permission request *is* the reason the agent is blocked, the relevant `tool.call` is visually promoted to primary for that one row — it is what the operator is being asked to approve, so it must not be hidden behind a collapse.
+### 5.4 Multiple attention items
 
-**Streaming.** Assistant text arrives in chunks (not character-by-character) and is batched via requestAnimationFrame for paint cost, matching Maestro's stdout-batching pattern (see reference pins below). Grove's dashboard is multi-agent — events are routed to the right attention view by `assignment_id`, not a single active session like Maestro. Virtualisation is required for Grove (not present in Maestro); default viewport renders the last 20 events, older lazy-loaded on scroll.
-
-**Reference implementation pins (Maestro, `~/Developer/maestro`).** Line numbers are given for orientation only — they drift across commits. Pin by file + function name when in doubt.
-
-| Responsibility              | Maestro anchor                                                   |
-| --------------------------- | ---------------------------------------------------------------- |
-| Primary markdown bubble     | `src/renderer/components/TerminalOutput.tsx` — `MarkdownRenderer` usage around lines 637-648 at time of audit |
-| Secondary tool card         | `src/renderer/components/ToolCallCard.tsx` — component definition |
-| Streaming chunk batching    | `src/main/process-manager/handlers/StdoutHandler.ts` — `handleData` (line 118) dispatches to `handleStreamJsonData` (line 143) |
-| Renderer batched dispatch   | `src/renderer/hooks/agent/useAgentListeners.ts` — RAF-flushed thinking-chunk buffer inside the `onThinkingChunk` handler (RAF call ~line 1321) |
-| Client-side execution queue | `src/renderer/hooks/input/useInputProcessing.ts` — `executionQueue` ~lines 255-330 |
-| Paste / drag-drop handling  | `src/renderer/hooks/input/useInputHandlers.ts` — paste and drop handlers ~lines 484-552, 554-599 |
-
-#### 5.3.1 Permission / approval blocks are first-class
-
-Claude Code can be run in two postures: default (asks for approval on each new tool use, file read, edit, bash command, etc.) or `--dangerously-skip-permissions` (auto-accepts everything; the "YOLO" posture some operators prefer). **Grove must support both.** The default posture is common and is in fact one of the most frequent reasons an agent becomes blocked — it is stuck waiting for a human approve/deny decision, not on missing information.
-
-`block_reason` is a **tagged union on `kind`**. The `permission.request` kind is first-class; the other two kinds (tool error, review checkpoint) cover the remaining block cases from §2. The wire format schema — one Phase A deliverable (§11 item 6) — enumerates at least these three:
-
-```
-block_reason (tagged union, discriminated on `kind`)
-
-  kind = 'permission.request'          -- default CC posture asked for approval
-    requested_action                   -- e.g. 'tool.bash' | 'tool.edit' | 'tool.read' | 'tool.webfetch'
-    target                             -- command string / file path / URL
-    context                            -- one-line rationale from the agent
-    risk_hint                          -- 'low' | 'medium' | 'high' (from CC's own classification)
-
-  kind = 'tool.error'                  -- a tool call failed
-    tool_name                          -- e.g. 'tool.bash'
-    message                            -- error message returned by the tool
-    exit_code                          -- when applicable (bash etc.)
-
-  kind = 'review.checkpoint'           -- agent explicitly asked for human sign-off
-    note                               -- one-line rationale from the agent
-```
-
-`§4.2`'s `shouldNotify` routing branches on `event.blockReason?.kind`. `§2`'s three examples each use one of the three kinds. Adding a fourth kind is a single row in this table plus a new branch in `shouldNotify` — the schema stays open on purpose.
-
-When an assignment enters `blocked` because of a `permission.request`:
-
-1. The assignment's `block_reason` structured field carries the request payload (Concern 4 Q4.2).
-2. The summary header shows *exactly* what the agent is asking for — action, target, rationale — not a generic "waiting for operator".
-3. The `permission.request` row in the event log renders with **Approve** and **Deny** buttons inline. Approve resumes the assignment via the session endpoint (§6.1); deny sends a structured decline that the agent can route around. Text/screenshot input is still available as a third option for "deny with instructions to try differently".
-4. Discord push notification (§4) for permission blocks is sent at the urgency level appropriate to `risk_hint` — low/medium as a normal DM, high bumps to the same tier as a tool failure.
-
-**CC stream-json permission dependency.** The interactive approve/deny flow depends on CC emitting a structured `permission.request` event in its `--output-format stream-json` output and accepting an approval response via `--input-format stream-json` stdin — i.e., a non-TTY approval mechanism. Neither Maestro nor Paperclip (the two reference systems — see §7.6) has tested this path: both bypass permissions entirely (`--dangerously-skip-permissions` / yolo mode). **This is a Phase A verification task (§11 item 10).** If CC does not support structured permission events in stream-json mode, Grove ships with yolo mode as the default and the `permission.request` block_reason kind becomes a design-ready placeholder activated once CC gains support. The schema, the attention view rendering, and the shouldNotify routing all ship regardless — they cost nothing to carry and avoid a redesign when CC catches up.
-
-**Auth constraint.** Approve/deny is an operator action and is subject to the same single-operator-in-v1 auth posture (§6.5). In Tier 2, approve/deny is pinned to the authenticated operator identity on the WebSocket; Grove records *who* approved each request in the audit log.
-
-**Working vs blocked.** Same layout, different affordance state (Concern 4 Q4.4):
-
-- **Working:** event log is live-updating, assistant messages are the main thing the operator reads, input affordance is "interrupt / inject note" — present but quiet.
-- **Blocked on information / error:** summary header prominently shows the block reason; the text/screenshot input affordance becomes the primary action.
-- **Blocked on permission request:** summary header shows the requested action and target; **Approve / Deny** are the primary actions, text/screenshot input is still available as a secondary path.
-
-The view is usable on any agent, not just blocked ones. The operator's primary use case depends on the agent's CC posture: for auto-accept sessions, drill-down is mostly for watching progress; for default-permission sessions, drill-down is also the place where approval decisions happen.
-
-### 5.4 Borrowing from miner
-
-From inspection of `~/Developer/miner`:
-
-- **Three-panel rendering pattern.** Miner uses Matrix (raw event stream) + Analysis (live process DAG) + Signal Palette (operator annotations). Grove's attention view uses the **same layered pattern at single-assignment scope**: Summary ≈ Analysis, Event Log ≈ Matrix, Input Affordance ≈ Signal Palette.
-- **Colour classification.** D/A/H — Deterministic (green), Agentic (amber), Human (rose). Grove uses the same three colours to classify event rows so the operator can tell at a glance whether an event came from a tool (D), the agent's reasoning (A), or the operator (H).
-- **Intent extraction.** Miner uses post-hoc extractive summarisation (rule-based, not LLM) to truncate assistant intents to 8–16 words. Grove's summary header uses the same approach — no LLM call in the render path.
-- **Event schema shape.** Grove's event log types (above) align with miner's MinerEvent (`event_id`, `event_type`, `timestamp`, `session_id`, `source`, `payload`). Grove already captures most of what the attention view renders via the existing hook pipeline (`src/hooks/`, `src/relay/`), so most of the borrowing is rendering not capture. Any event types the attention view needs that are not yet in the published stream — in particular fine-grained `tool.call` / `tool.result` / `thinking.chunk` / `assistant.message` decomposition — are added in the Phase A `events` table schema, not at capture time.
-
-What is **not** borrowed: miner's DAG view (React Flow), Signal Palette annotation UI, or its capture pipeline (miner sits behind its own CC hook). Those belong to a separate process-mining use case.
-
-### 5.5 Multiple attention items
-
-**Multiple items exist concurrently; one drill-down is visible at a time.** (Concern 4 Q4.5.)
-
-The dashboard shows each attention item as a card in the focus area (§7). Each card has a high-level state-machine overview: agent name, task title, state, time in state, priority. Clicking a card opens its attention view as the foreground; other cards remain visible as context. Only one detailed view is foregrounded at a time to preserve operator focus. Plural instances, singular focus.
+Multiple items exist concurrently; one drill-down is foregrounded at a time. The focus area (§8) shows each as a card; clicking opens its drill-down as the foreground while other cards remain visible as context. Plural instances, singular focus.
 
 ---
 
-## 6. Operator input channel
+## 6. Principal input channel
 
-**Pre-implementation addendum:** `docs/design-mc-f10-operator-input.md` resolves ten open questions before F-10 lands — text-first scope with images deferred, Enter submit with Shift+Enter newline, reuse of the existing `POST /api/assignments/:id/input` endpoint rather than a new WS path, queue-depth surfacing in the drill-down, observed-session + ended-session UI gates, inline error banner with status-code-specific copy, and the v1 placeholder deferred-removal plan.
-
-The input affordance in §5.1 (③) is implemented by borrowing from **Maestro** (`~/Developer/maestro`), metafactory's Electron UI over agent harnesses. Grove copies Maestro's patterns verbatim where possible. No first-principles reinvention. (Concern 5 framing.)
+The input affordance (`components/drill-input.tsx`, F-10) lets the principal send a turn to the agent's session. Its transport pattern is borrowed from Maestro (long-lived CC process with `--output-format stream-json` + stdin-framed turns); see the [History](#history--mission-control-v2-grove-v2-origins) appendix for the original reference-implementation audit.
 
 ### 6.1 Transport
 
-**Pattern: stdin piping, IPC-mediated, abstracted behind a session endpoint.** (Concern 5 Q5.1.)
+The dashboard POSTs to `POST /api/assignments/:id/input` with `{ text?, images? }`. The backend resolves the `assignment_id` to a **session endpoint** and delivers the payload. Endpoint kinds (the `sessions.endpoint_kind` column):
 
-#### Verified Maestro invocation model (2026-04-16 code audit)
+- **`local.process.controlled`** — a long-lived CC child process spawned by Mission Control (via its API layer's process manager). `write()` frames a stream-json message and delivers it to the process's stdin. The process stays alive between turns; `--resume` is used only for compaction or reconnection.
+- **`local.observed`** — an external CC session (e.g. a `cldyo-live` terminal session) observed via the hook stream (§7.3). `write()` throws `NotControllable` — observed sessions are read-only.
+- **`local.process.autonomous`** — single-turn `--print` process placeholder (stubbed; see Deferred).
 
-Maestro does **not** use `claude --print`. It spawns `claude` normally with `--output-format stream-json` and keeps the process alive:
+The session endpoint is an abstraction boundary: every write is phrased as "look up the session endpoint for this assignment, deliver the payload," which keeps the call site stable when remote backends land.
 
-```
-Maestro renderer ──(IPC process:write)──▶ main ProcessManager ──(childProcess.stdin.write)──▶ claude
-                                                                                               │
-claude stdout (stream-json JSONL) ──▶ StdoutHandler.handleData ──▶ IPC process:data ──▶ renderer
-```
+### 6.2 Image input + queue
 
-Key details from Maestro's `src/main/process-manager/`:
+The input box accepts **text (≤ 50 KB UTF-8) plus images** by paste or drag-drop (PNG / JPEG / WebP / GIF, ≤ 5 MB each, ≤ 8 per message; the input endpoint allows up to 25 MB of body for image payloads). Images are sent as base64 content blocks. A small set of **canned actions** insert prompt text. Submissions are queued client-side per assignment; the next queued item is released on the assignment's `state.transition` WebSocket frame. The input is read-only in `observed`, `ended`, and `shadow` modes. Detailed designs cover the F-10 input return path and image input (`docs/design-mc-image-input.md`).
 
-- **Spawn:** `child_process.spawn()` with `--output-format stream-json` + `--input-format stream-json` (conditional). No `--print`. Process stays alive. (`ChildProcessSpawner.ts:316`)
-- **Multi-turn stdin:** Each operator turn is framed via `buildStreamJsonMessage()` (`streamJsonBuilder.ts`) and written to stdin with a newline delimiter. Stdin stays open between turns. (`ChildProcessSpawner.ts:501-515`)
-- **Process lifecycle:** `ProcessManager` holds a `Map<sessionId, ManagedProcess>`. Processes remain in the map, accepting new stdin writes, until explicitly killed or they exit naturally. (`ProcessManager.ts:31-47`)
-- **Session resume:** `--resume <sessionId>` is used only for reconnecting to a previously-exited session, not between turns of a live session. (`agent-args.ts:97-99`)
-- **Permission bypass:** Maestro uses `yoloModeArgs` (e.g., `--dangerously-bypass-approvals-and-sandbox`). No interactive approval UI. (See §5.3.1 CC stream-json permission dependency.)
+### 6.3 Permission / approval blocks
 
-#### Grove v2 adaptation
-
-Grove v2 replicates Maestro's model, replacing Electron IPC with WebSocket:
+`block_reason` is a **tagged union on `kind`**:
 
 ```
-browser ──(WebSocket)──▶ grove-bot ──(stdin.write via session endpoint)──▶ claude
-                                                                            │
-claude stdout (stream-json) ──▶ event parser ──▶ WebSocket ──▶ browser dashboard
+block_reason (discriminated on `kind`)
+  kind = 'permission.request'   → requested_action, target, context, risk_hint
+  kind = 'tool.error'           → tool_name, message, exit_code
+  kind = 'review.checkpoint'    → note
 ```
 
-- The dashboard is a browser app, not Electron, so the renderer↔main IPC becomes a WebSocket to grove-bot. The contract on the bot side mirrors Maestro's `process:write` IPC handler: `{ assignment_id, payload }`.
-- grove-bot resolves `assignment_id` to a **session endpoint** and writes the payload to it. For controlled sessions, "write" frames a stream-json message and delivers it to the CC process's stdin. For observed sessions (hook-ingested, read-only), "write" throws `NotControllable`.
-- **Sessions are long-lived.** The CC process stays alive for the duration of the operator's interaction. No cold-start between turns. Context stays hot in memory. `--resume` is used only for session compaction (see §6.6) or reconnection after a crash — never between operator turns of a live session.
-- **Session compaction.** Long-lived sessions eventually fill CC's context window. When context pressure is detected (from stream-json usage events), Grove gracefully ends the current CC process and starts a new one with `--resume`, preserving continuity. Compaction triggers (borrowed from Paperclip's session rotation policy): max operator turns, max input tokens, max session age. See §6.6.
-- **The session endpoint is an abstraction boundary.** Even at local Tier 1, the hands run may live in a different sandbox context from grove-bot (different cwd, container, mount namespace), which means the transport cannot assume in-process stdin forever. v2 ships the same-process implementation but phrases every write as "look up the session endpoint for this assignment, deliver the payload" — not "write to the local child process stdin". This keeps the data shape and the call site stable when Spawn, sandboxed local backends, or Tier 2 remote backends land later.
-
-#### Endpoint kinds
-
-v2 ships two endpoint kinds and stubs a third:
-
-- `local.process.controlled` — long-lived CC child process spawned by Grove. `write()` delivers stream-json-framed turns to stdin. (**v2 interactive sessions**)
-- `local.observed` — external CC session (e.g., `cldyo-live`) observed via the hook stream. `write()` throws `NotControllable`. (**v2 observed sessions**)
-- `local.process.autonomous` — single-turn CC child process (`--print` + `--dangerously-skip-permissions`), spawned by Grove for routine/trusted work, exits on completion. (**Future: heartbeat mode, see §10.**)
-
-Future kinds (preserved in `design-spawn-integration.md`):
-- `local.sandbox` — local sandbox (container / bwrap) over a unix socket
-- `remote.spawn` — Spawn-hosted hands run, over the authenticated RPC Spawn exposes
-
-At Tier 2 the WebSocket terminates at the CF Worker; the Worker still resolves `assignment_id` → endpoint, and the endpoint is remote. No new primitive, just a different resolution. See §7.3 and `design-spawn-integration.md` §5a for the full picture.
-
-### 6.2 Image and screenshot support
-
-**Pre-implementation addendum:** `docs/design-mc-image-input.md` resolves ten open questions before image-input code lands — paste + drag-drop ship together, `buildStreamJsonMessage` grows a content-block overload (backward-compatible), base64 stays embedded in events (blob storage deferred to Tier 2 revisit), `POST /api/assignments/:id/input` body grows an `images[]` field, per-image / per-message / per-body caps with media-type allowlist, thumbnail-chip UI above the textarea, F-7 renderer grows an `image` content-block case with a click-to-enlarge lightbox, observed/ended sessions inherit F-10's disable gate, and full test scope across framer + endpoint.
-
-**Borrowed from Maestro.** (Concern 5 Q5.2.)
-
-Maestro supports:
-
-- Paste images from clipboard (PNG base64 data URLs)
-- Drag-and-drop image files
-- Embedding in the stream-json message via Maestro's `buildStreamJsonMessage` helper
-
-Grove v1 ships the same three capabilities. Images are sent as base64 data URLs, embedded in the message written to the session's stdin. No temp files, no upload-to-cloud step.
-
-### 6.3 Input queue
-
-**Yes — client-side input queue, borrowed from Maestro.** (Concern 5 Q5.3.)
-
-Maestro's pattern:
-
-```ts
-// renderer state
-executionQueue: QueuedItem[]
-
-// when session.state === 'busy', new input is appended to the queue
-// when session.state transitions to 'idle', the queue drains into stdin
-```
-
-Grove v1 mirrors this. The dashboard state holds a per-assignment `executionQueue`. If the operator submits input while the assignment is `running` (i.e., the session is mid-tool-call), the input is queued and delivered at the next prompt cycle. The UI reflects the queue depth under the submit button.
-
-Queued items are **not** durable across dashboard reloads in v1 — they live in browser state. Durable queuing is a post-v2 capability. (The aggregated audit log §6.4 still records the input once it is delivered.)
-
-### 6.4 Audit log
-
-**Full audit log of operator ↔ agent interactions, across all agents.** (Concern 5 Q5.4.)
-
-Operator input is a first-class event — `operator.input` — written into the same event stream as agent events (tool calls, tool results, assistant messages). The mission control dashboard provides an **aggregated audit view** sitting on top of all agents, sliceable per agent, per task, or per assignment.
-
-Implementation: a single `events` table accessed through the new `src/common/grove-db/` shared layer (§7.3), with columns `assignment_id`, `event_type`, `payload`, `timestamp`. The existing per-agent detailed logging paths continue to exist; the aggregated view is a query against the new table, not a separate data model.
-
-### 6.5 Auth
-
-**Single operator only in v1.** No role-based access. (Concern 5 Q5.5.)
-
-Tier 2 multi-operator auth is out of scope for v2, but the data model (Concern 2 Q2.2 — `operator_id` from day one on tasks and assignments) does not preclude it. When Tier 2 ships, the WebSocket authenticates via CF Access and the operator identity is pinned to the connection.
-
-### 6.6 Session compaction
-
-**Long-lived interactive sessions fill CC's context window.** Grove must detect context pressure and gracefully rotate to a new session without losing continuity.
-
-**Triggers** (borrowed from Paperclip's session rotation policy in `server/src/services/heartbeat.ts:1641-1759`):
-
-- **Max operator turns.** After N turns (configurable, default ~50), rotate.
-- **Max input tokens.** When CC's stream-json usage event reports `inputTokens` approaching the model's context limit (e.g., 80% of capacity), rotate.
-- **Max session age.** After N hours (configurable, default ~4h), rotate regardless of token usage. Prevents unbounded session staleness.
-
-**Rotation sequence:**
-
-1. Grove detects a compaction trigger.
-2. Dashboard shows a brief "session rotating..." indicator.
-3. Grove sends a graceful close to the current CC process.
-4. Grove spawns a new CC process with `--resume <previousSessionId>`. CC loads the session history from disk and continues.
-5. The new process becomes the live session. The endpoint handle is updated in place.
-6. The assignment row does not change state — it stays `running`. The `sessions` table gains a new row for the new process.
-
-**This is infrequent** — every few hours or every ~50 turns, not every turn. The brief cold-start during rotation (~2-5s) is acceptable. Between rotations, the session stays hot.
-
-**Compaction is transparent to the operator.** The attention view shows a one-line "session rotated" state-change event in the event log. The operator does not need to take any action.
+When an assignment enters `blocked` on a `permission.request`, the summary shows exactly what is being asked, and the event-log row renders **Approve / Deny**. **These buttons are currently disabled**: the interactive flow depends on CC emitting a structured `permission.request` event in `--output-format stream-json` and accepting an approval via `--input-format stream-json` stdin. Until that protocol is verified, the schema, rendering, and routing all ship (they cost nothing to carry) but approve/deny is inert; the operational posture is yolo-mode sessions plus text-based redirection. The principal's manual requeue / handoff / abandon controls (§7) are the move-along path in the meantime.
 
 ---
 
-## 7. Architecture
+## 7. Curation + state machine
 
-### 7.1 Heads, hands, and the agent model
+### 7.1 The state machine
 
-Grove adopts **head / hands** as the agent model, taken from Anthropic's sandboxed-environment terminology. (Conflict 5.)
+The assignment state machine is a pure function (`state-machine.ts`) applied via `db/transitions.ts`:
 
-- **Head** = the agent's identity, persona, memory, skills, role, configuration. One row in the `agents` table per head. Persistent heads (e.g., Luna) retain memory, skills, and history across runs. Ephemeral heads do not — they exist only for the lifetime of their assignment.
-- **Hands** = the sandboxed execution run that carries out work on behalf of the head. Each `session` (the existing `cc-session.ts` mechanism) is one hands run. A head can spawn 0..N hands runs over its lifetime.
-- **Mapping to the schema:**
-  - `agents` row = head
-  - `agent_task_assignment` row = "this head is assigned to this task"
-  - `sessions` (0..N per assignment) = hands runs
-- **UI rendering:** persistent heads render as always-visible agent cards; ephemeral heads appear during an active assignment and fade out when the assignment completes. A single `persistent: bool` attribute on the `agents` row, not a taxonomy.
-- **No use of "pets" or "cattle" anywhere in the design.**
+| From | Action | To |
+|------|--------|-----|
+| `queued` | `dispatch` / `cancel` | `dispatched` / `cancelled` |
+| `dispatched` | `start` / `cancel` | `running` / `cancelled` |
+| `running` | `block` / `complete` / `fail` / `cancel` | `blocked` / `completed` / `failed` / `cancelled` |
+| `blocked` | `resume` / `requeue` / `cancel` | `running` / `queued` / `cancelled` |
+| `failed` | `requeue` | `queued` |
+| `completed`, `cancelled` | — | (terminal) |
 
-This framing is load-bearing for two reasons:
+`requeue` is the principal's manual move-along — there are no automatic timers. Applying a transition validates it, writes the new `state` (and `block_reason` JSON on `block`), inserts a transition event, and returns the from/to states for the WebSocket broadcast.
 
-1. It lets Grove talk cleanly about **backend-agnostic execution** later. Any execution backend — local `Bun.spawn` today, other backends once they ship — is just "a host for hands runs." The head doesn't care where its hands execute. The preserved backend design is in `docs/design-spawn-integration.md`.
-2. It naturally accommodates Luna's recursive sub-team pattern (`src/bot/lib/agent-team.ts`) — Luna's sub-agents are additional **hands runs within Luna's own assignment**, not new rows in `agents`.
+### 7.2 Curation toolbar
 
-### 7.2 Operator as orchestrator
+The curation toolbar (`components/curation-toolbar.tsx`, F-12) lives inside the drill-down. Its verbs are enabled per the assignment-state matrix above:
 
-**The operator is the orchestrator. Luna is one agent instance.** (Conflict 6.)
+- **Dispatch** → `POST /api/sessions { taskId }` — spawn an agent session for the task.
+- **Requeue** → `POST /api/assignments/:id/requeue` — re-enqueue (the UI mirror of the `requeue` action).
+- **Handoff** → `POST /api/assignments/:id/handoff` — cancel-and-respawn on a different agent (agent picker).
+- **Abandon** → `POST /api/assignments/:id/abandon` (assignment) or `POST /api/tasks/:taskId/abandon` (task-terminal).
 
-- The operator drives mission control: curates the task queue, reviews attention items, sends input, moves stuck tasks, approves dispatch. The operator is the orchestrator at Tier 1.
-- Luna is **one row in the `agents` table** — a persistent head. She has no privileged position in the schema, the attention model, or the UI.
-- Luna's agent-team capability (`src/bot/lib/agent-team.ts`) is preserved but **internal to her own assignment**. When Luna spawns sub-agents to get work done, those are recursive hands activity within her current hands run. They do not create rows in `agents` or `agent_task_assignment`. Sub-team work is an implementation detail of Luna's head, not a top-level architectural pattern.
-- The v2 dashboard is **agent-neutral**: it names Luna only as an example persistent head, never as the orchestrator or as a privileged dispatch surface.
-
-### 7.3 Tier 1 and Tier 2: shared model, different composition
-
-Earlier mission control drafts said "identical interface, only the transport changes." That statement is false in a way that matters. v2 says plainly: **shared data model and core domain logic; honestly different runtime composition.** (Conflict 2.)
-
-#### Ground truth: what is actually shared today
-
-Before describing the v2 target, this is what grove has today — not a claim, a file audit (2026-04-15):
-
-| Area                    | Bot (Tier 1)                                                    | Worker (Tier 2)                                              | Shared?                            |
-| ----------------------- | --------------------------------------------------------------- | ------------------------------------------------------------ | ---------------------------------- |
-| Database driver         | `bun:sqlite` via `DashboardDb` (`src/bot/lib/dashboard-db.ts`) | Raw D1 via `db.prepare()` in `src/worker/src/routes/*.ts`    | **No** — two separate drivers       |
-| Schema source-of-truth  | Inline TypeScript migrations in `DashboardDb.migrate()` (`dashboard-db.ts:127-247`) | `src/worker/schema.sql`                                      | **No** — drift: worker has `session_activity` and `audit_log` tables; bot does not. Both carry `operator_id` on `sessions` (bot at `dashboard-db.ts:246`), but worker also has `operator_id` on `github_events` and `audit_log`. |
-| Query logic             | `DashboardDb` methods (`handleState`, `handleRepos`, …)         | Route handlers in `routes/state.ts`, `routes/repos.ts`, …    | **No** — duplicated                 |
-| HTTP API surface        | `Bun.serve()` at `dashboard-api.ts:130`, same `/api/*` shape   | Hono at `src/worker/src/index.ts`, same `/api/*` shape       | **Same shape, two implementations** |
-| Event ingestion         | `POST /api/events/ingest` (`dashboard-api.ts:418-448`)          | `POST /api/ingest` (`src/worker/src/routes/ingest.ts:35-97`) | Shape shared; handlers duplicated   |
-| Event processing        | Bot's own path: `dashboard-api.handleEvent` + relay's `src/relay/lib/event-processor.ts` | Imports `src/common/event-processor.ts` | **No** — duplicated; `src/common/event-processor.ts` is consumed only by the worker. The bot's relay has its own parallel implementation at `src/relay/lib/event-processor.ts`. |
-| Domain types            | Bot does not import `src/common/types.ts` at all                | Imports `src/common/types.ts` (e.g. `routes/github.ts:22`, `routes/ingest.ts:23`) | **No** — worker-only |
-| Shared modules          | `common/github-events.ts` and `common/agent-detection.ts` via `src/bot/lib/github-webhook.ts:18-24` | Same two modules, plus `common/event-processor.ts`, `common/event-utils.ts`, `common/types.ts` | **Partial** — GitHub event shape + agent detection are the only modules both sides import today |
-| GitHub webhook handling | `GitHubWebhookHandler` (bot, opt-out in cloud mode)             | `routes/github.ts` (worker)                                  | Duplicated handlers, shared event shape via `common/github-events.ts` |
-| Discord gateway         | `DiscordAdapter` (bot)                                          | None                                                         | Bot-only                            |
-
-**Honest assessment.** Grove does not have a `GroveDb` today. What it has is:
-
-- Two separate database implementations (`bun:sqlite` via `DashboardDb` vs raw D1 bindings) that happen to expose the same REST shape.
-- Two separate event processing paths: the worker imports `src/common/event-processor.ts`; the bot does not, and its relay has its own parallel implementation at `src/relay/lib/event-processor.ts`.
-- Two `src/common/` modules that are genuinely shared by both sides: `common/github-events.ts` and `common/agent-detection.ts`. That is the entire shared surface today.
-- Schema drift between bot and worker — the bot is missing the worker's `session_activity` and `audit_log` tables, and several of the worker's new `operator_id` columns outside of `sessions`.
-
-**Bot is primary**: it owns Discord, the live event pipeline, and the dashboard frontend via `Bun.serve()`. **Worker is a read-replica snapshot** of the same data surface, cached with ETags (`src/worker/src/routes/state.ts:18-20`).
-
-#### What v2 introduces
-
-v2 Mission Control adds new tables: `tasks`, `agent_task_assignment`, a unified `events` table (§7.4). These tables do not exist today in either bot or worker. **The v2 design target is that new v2 tables land via a shared data-access layer** — not the existing duplicated path. Two options, one picked:
-
-- **(A)** Extract a `src/common/grove-db/` module with a thin interface (`getTask`, `getAssignment`, `appendEvent`, …) and two adapters: `SqliteAdapter` wrapping the bot's `bun:sqlite` and `D1Adapter` wrapping worker's D1 bindings. New tables live here from day one.
-- **(B)** Accept the duplication and write each new table twice — once in `dashboard-db.ts`, once in worker routes — enforcing consistency by contract tests.
-
-**Decision:** Option (A). Phase A (§9) **creates** the shared data-access layer as its first deliverable, not assumes it exists. This is the only correct interpretation of "SQLite at Tier 1, D1 at Tier 2, identical schema" — it has to be built; it is not free.
-
-**Migration posture for existing tables** (`sessions`, `github_events`, `repos`, `issues`, `pull_requests`, `audit_log`, `session_activity`): they stay where they are in v2. The new layer is introduced alongside, not instead of, the current duplicated path. Folding the existing tables into the shared layer is a follow-up cleanup, not a v2 commitment.
-
-**Genuinely shared at v2:**
-
-- `src/common/github-events.ts` and `src/common/agent-detection.ts` — the only modules both bot and worker import today (via `src/bot/lib/github-webhook.ts:18-24` and `src/worker/src/routes/github.ts:17` / `routes/sync.ts:101`). These stay as they are.
-- The new `src/common/grove-db/` shared layer (new in Phase A) — the v2 tables (`tasks`, `agent_task_assignment`, `events`) land through it from day one.
-- Core task / assignment / session state machines as pure functions in `src/common/`, consumed by both bot and worker.
-- Rendering logic for the attention view (§5) and the task list (§3).
-- The `operator.input` and `permission.request` event shapes and the audit-log schema.
-
-**Deliberately left as-is in v2.** `src/common/event-processor.ts` stays worker-only; the bot's relay keeps its own `src/relay/lib/event-processor.ts`. Unifying them is a post-v2 cleanup — not a Phase A commitment — because the relay's responsibilities (JSONL policy filter over filesystem events) and the worker's (HTTP-ingested session events into D1) differ enough that collapsing them now is scope creep.
-
-**Different between Tier 1 and Tier 2:**
-
-| Aspect         | Tier 1                                      | Tier 2                                            |
-| -------------- | ------------------------------------------- | ------------------------------------------------- |
-| Runtime        | Single-process Bun app                      | CF Worker + D1                                    |
-| DB adapter     | `SqliteAdapter` over `bun:sqlite`           | `D1Adapter` over D1 bindings                      |
-| Notifications  | In-process function call into grove-bot     | Per-operator routed path, identity-aware          |
-| Auth           | None (single-operator)                      | CF Access, operator-scoped                        |
-| Deep links     | `http://localhost:8766`                     | `https://grove.meta-factory.ai` (per `baseUrl`)   |
-| Consistency    | Local writes immediately visible            | D1 consistency semantics apply                    |
-| Fan-out        | One process, one listener                   | Per-operator scoped subscriptions                 |
-| Session endpoint resolution | Direct to in-process `cc-session.ts`  | Routed to remote hands run (§6.1, spawn doc)      |
-
-Other divergences (rate limiting, cross-operator conflict resolution, ordering across operators) are **parked in §11 Open questions**. They do not affect v2 single-operator scope.
-
-### 7.4 Data model summary
-
-```
-┌────────┐     ┌───────────────────────┐     ┌───────┐
-│ agents │────▶│ agent_task_assignment │◀────│ tasks │
-└────────┘     └───────────────────────┘     └───────┘
-    head            link row (STATE MACHINE)      │
-                            │                     │ joined to
-                            │                     ▼
-                            ▼                ┌──────────┐
-                       ┌──────────┐          │  issues  │  (existing
-                       │ sessions │          │pull_requ.│   src/worker
-                       └──────────┘          │  repos   │   schema.sql)
-                        hands runs            └──────────┘
-                            │
-                            ▼
-                       ┌──────────┐
-                       │  events  │  (unified stream:
-                       └──────────┘   tool.*, assistant.*,
-                         audit log    operator.input,
-                                      state.change, etc.)
-```
-
-- `tasks` — first-class Grove object, one primary `sourceRef`, `priority`, `operator_id`.
-- `agent_task_assignment` — many-to-many link, owns the state machine, 0..N sessions per assignment.
-- `sessions` — existing `cc-session.ts` record, one CC process per session.
-- `events` — unified stream powering the attention view event log and the aggregated audit log.
-- `issues`, `pull_requests`, `repos`, `github_events` — **existing** tables in `src/worker/schema.sql`, reused as the source-of-truth for GitHub entities. Joined to `tasks` via `source_external_id` for display.
-
-### 7.5 The components
-
-```
-┌─────────────────────────────┐
-│  Dashboard (browser)        │
-│  - Focus area (§7 below)    │
-│  - Attention view (§5)      │
-│  - Task list (§3)           │
-│  - Input affordance (§6)    │
-└──────────────┬──────────────┘
-               │ WebSocket (Tier 1: local; Tier 2: CF Access)
-               ▼
-┌─────────────────────────────┐     ┌──────────────────────┐
-│  grove-bot (Bun process)    │────▶│  Discord gateway     │
-│  - WebSocket server         │     │  (notifications)     │
-│  - cc-session.ts (hands)    │     └──────────────────────┘
-│  - session endpoint write   │
-│  - notification priority    │
-│    map (§4.2)               │
-│  - grove-db/SqliteAdapter   │────▶  bun:sqlite file
-│  - legacy DashboardDb*      │────▶  (unchanged today)
-└─────────────────────────────┘
-```
-
-`grove-bot` is the single backend at Tier 1. The dashboard is a browser app that talks to it over WebSocket. `cc-session.ts` is the hands runner for all agents running in-process.
-
-**Data access in v2:**
-- New v2 tables (`tasks`, `agent_task_assignment`, `events`) go through the new `src/common/grove-db/` layer (`SqliteAdapter` at Tier 1, `D1Adapter` at Tier 2).
-- Existing Grove tables (`sessions`, `github_events`, `repos`, `issues`, `pull_requests`, …) continue to live in the current duplicated path (`DashboardDb` bot-side; raw D1 SQL worker-side). Folding them into the shared layer is post-v2 cleanup.
-
-At Tier 2, the Bun-process box becomes a CF Worker, the WebSocket terminates at the Worker, the DB adapter swaps from `SqliteAdapter` to `D1Adapter`, and session endpoint resolution (§6.1) routes to a remote hands run. The dashboard code does not change. The dashboard↔bot protocol does not change. What changes is process boundary, auth, deep-link origin, and where hands runs live — the honestly-different-composition list from §7.3.
-
-### 7.6 Reference implementations
-
-Three external systems were audited during this design. Each contributed specific, citable patterns. This section records **what was borrowed and why**, so future implementers can trace the provenance and consult the source when edge cases arise.
-
-#### Maestro (Electron-based CC IDE — `~/Developer/maestro`)
-
-Audited 2026-04-16. Maestro is the closest architectural match: it runs long-lived CC processes with interactive operator input, exactly the execution model Grove v2 targets.
-
-| Pattern | Where it appears in this spec | Source location |
-|---------|-------------------------------|-----------------|
-| Long-lived CC process with `--output-format stream-json` (no `--print`) | §6.1 Transport | `src/main/process-manager/spawners/ChildProcessSpawner.ts:316` |
-| `ProcessManager` holding `Map<sessionId, ManagedProcess>` | §6.1 (session endpoint resolver) | `src/main/process-manager/ProcessManager.ts:31-47` |
-| Stdin write via `--input-format stream-json` for operator turns | §6.1, §6.2 | `src/main/process-manager/spawners/ChildProcessSpawner.ts:501-515` |
-| IPC bridge: renderer → main → stdin (WebSocket in Grove's case) | §6.2, §7.5 | `src/main/ipc/handlers/process.ts:574-585` |
-| `--resume <sessionId>` only for reconnection, not for turn continuity | §6.1, §6.6 | `src/main/utils/agent-args.ts:97-99` |
-
-**Not borrowed from Maestro:** permission prompt handling (Maestro uses yolo mode, same gap as Grove — §5.3.1), multi-agent orchestration (Maestro manages folders/workspaces, not agent teams).
-
-#### Paperclip (queue-based agent orchestrator — `~/Developer/paperclip`)
-
-Audited 2026-04-16. Paperclip's execution model is fundamentally different (single-turn heartbeat with `--print` and `stdin.end()`), so the _execution_ layer is not borrowed. But Paperclip's **operational patterns** for managing CC processes at scale contributed several ideas.
-
-| Pattern | Where it appears in this spec | Source location |
-|---------|-------------------------------|-----------------|
-| Session compaction (max turns, max tokens, max age) | §6.6 Session compaction | `server/src/services/heartbeat.ts:1641-1759` |
-| `assistant-ui/react` for rendering agent transcripts | §5 Attention view (rendering library candidate) | `packages/adapters/claude-local/` dependencies |
-| State-machine guards with `block_reason` decomposition | §5.3.1 (tagged-union block reasons) | Heartbeat service state transitions |
-| Cost tracking per session (token-level) | §10 Deferred — budget enforcement | Usage event parsing in heartbeat |
-| Workspace-scoped configuration | §7.3 Tier 1 config (`~/.config/grove/mission-control.yaml`) | `server/src/services/heartbeat.ts` workspace resolution |
-
-**Not borrowed from Paperclip:** heartbeat execution model (`--print`, stdin-close, queue-pull — fundamentally incompatible with Grove's interactive sessions), organisation-chart hierarchy (Grove uses flat head/hands, not org trees), `--dangerously-skip-permissions` as default (Grove keeps approve/deny as a requirement with yolo fallback — §5.3.1).
-
-#### Miner (PAI dashboard — `~/Developer/miner`)
-
-Previously audited during Phase 1 source mapping. Miner contributed the attention view rendering patterns.
-
-| Pattern | Where it appears in this spec |
-|---------|-------------------------------|
-| Three-section layout (summary / event log / input) | §5.1 |
-| D/A/H colour classification for event types | §5.2 |
-| Extractive summary header (not generative) | §5.1 |
+Dispatch and Requeue are fire-and-forget; Handoff and Abandon open an inline confirm. No manual refetch — `state.transition` and `principal.curation` WebSocket frames flip the button set. Curation actions are recorded as `principal.curation` events with a `kind` discriminator (e.g. `task.imported`, requeue, handoff); assignment-less curation events hang off a synthetic per-task shadow session.
 
 ---
 
-## 8. Primary attention focus (dashboard layout)
+## 8. Dashboard layout
 
-**Architectural migration:** The dashboard is being migrated from a monolithic inline-HTML file to a React + TypeScript component tree, per `docs/design-mc-dashboard-react-migration.md`. The migration is an incremental seven-PR sequence; the layout spec below remains the source of truth for behaviour. The vendored Claude Design handoff at `docs/design-artifacts/grove-mission-control/` is the visual reference.
+The dashboard is a React + TypeScript SPA under `src/surface/mc/dashboard-v2/`, built with `bun build src/surface/mc/dashboard-v2/index.html --outdir dist/dashboard-v2 --target browser` (the MIG-6 cutover deleted the legacy monolithic inline-HTML dashboard; the React tree is now the only dashboard). Entry is `index.html → main.tsx → app.tsx`. There is no router; view switching is `useState<DashboardView>` over `"default" | "metrics" | "iterations" | "kanban-detail"`. The visual reference is the vendored design handoff under `docs/design-artifacts/`.
 
-This section details the dashboard layout that §2's core operator flow steps through. (Concern 7.)
+### 8.1 The default view
 
-### 8.1 Structure
+Header (title + theme toggle + ⌘K hint) → nav (Focus/Working/Tasks · Metrics · Iterations) → main. The default view stacks four execution-side sections:
 
 ```
 ┌──────────────────────────────────────────────────────────────────┐
-│  GROVE MISSION CONTROL                   operator: andreas       │
+│  MISSION CONTROL                            principal: andreas    │
 ├──────────────────────────────────────────────────────────────────┤
-│                                                                  │
-│  ① FOCUS AREA — "who needs me"                                   │
-│     ┌──────────────┐  ┌──────────────┐  ┌──────────────┐         │
-│     │ Luna × T-42  │  │ impl × T-51  │  │ rev × T-33   │         │
-│     │ blocked      │  │ blocked      │  │ running      │         │
-│     │ tool.bash x1 │  │ approval     │  │ (review req) │         │
-│     │ P0 · 3m ago  │  │ P1 · 1m ago  │  │ P2 · 8m ago  │         │
-│     └──────────────┘  └──────────────┘  └──────────────┘         │
-│                                                                  │
-│  ② WORKING AGENTS — grid below (not in focus area)               │
-│     ┌────┐ ┌────┐ ┌────┐ ┌────┐ ┌────┐                           │
-│     │Luna│ │ Lu │ │impl│ │rev │ │ rp │                           │
-│     │run │ │idle│ │run │ │run │ │done│                           │
-│     └────┘ └────┘ └────┘ └────┘ └────┘                           │
-│                                                                  │
-│  ③ TASK TABLE — sliceable / sortable                             │
-│     ┌──────────────────────────────────────────────────────┐     │
-│     │ Priority │ Title           │ Agents │ State  │ Age  │     │
-│     ├──────────┼─────────────────┼────────┼────────┼──────┤     │
-│     │ P0       │ fix webhook HMAC│ Luna   │ block. │ 3m   │     │
-│     │ P1       │ bump v0.23.0    │ impl   │ block. │ 1m   │     │
-│     │ P2       │ review PR #195  │ rev    │ runnin │ 8m   │     │
-│     └──────────────────────────────────────────────────────┘     │
-│                                                                  │
+│  ① FOCUS AREA — "who needs me"                                    │
+│     ┌──────────────┐  ┌──────────────┐  ┌──────────────┐          │
+│     │ agent × T-42 │  │ agent × T-51 │  │ agent × T-33 │          │
+│     │ blocked      │  │ blocked      │  │ running      │          │
+│     │ tool.bash x1 │  │ approval     │  │ (review req) │          │
+│     │ P0 · 3m ago  │  │ P1 · 1m ago  │  │ P2 · 8m ago  │          │
+│     └──────────────┘  └──────────────┘  └──────────────┘          │
+│  ② WORKING AGENTS — grid below                                    │
+│  ③ TASK TABLE — sliceable / sortable                              │
 └──────────────────────────────────────────────────────────────────┘
 ```
 
-### 8.2 Focus area — "who needs me"
+| Panel | Component | Feature | Behaviour |
+|-------|-----------|---------|-----------|
+| **Focus area** | `focus-area.tsx` | F-6 | "Who needs me" — one card per blocked assignment (plus any with an input-requested signal), capped with an overflow chip. Keys `1`–`9` select, `Enter` opens drill-down. Empty state: "All clear" + most-active-agent line. Ordering is by **task priority**, not attention type. Served by `GET /api/focus-area`. |
+| **Working grid** | `working-grid.tsx` | F-9 | Tiles for agents with active non-blocked assignments (`running` / `dispatched` / `queued`). Tile click opens the drill-down. Hidden when the focus row has items and the grid is empty. Served by `GET /api/working-agents`. |
+| **Task table** | `task-table.tsx` | F-8 | All tasks with filters (priority bit-vector, min age, search, include-closed) and sort (priority / title / agents / state / age), persisted in URL hash (`#tasks?p=…&age=…&closed=…&q=…`, `replaceState` by default — `hooks/use-hash-state.ts`). Row click opens the drill-down on the primary assignment. |
+| **Drill-down** | `drill-down.tsx` | F-7 | The attention view (§5). |
 
-**Pre-implementation addendum:** `docs/design-mc-f6-focus-area.md` resolves three open questions from this section — the `operator.input.requested` event scope, time-in-state source field, and keyboard navigation split between F-6 and F-7.
+### 8.2 The other views
 
-**Content:** exclusively items that need the operator's input. `blocked` assignments, plus any assignment with an `operator.input.requested` event. (Concern 7 Q7.1, Q7.2.)
-
-**Empty state:** "All clear" heartbeat with one-line summary of the most active agent. Green indicator. Optional mute-for-N-minutes control.
-
-**Cards (not drill-downs):** each card shows agent name, task title, state, time in state, task priority, and one-line "what it needs". Cards are the high-level overview; clicking one opens the drill-down attention view (§5).
-
-**Ordering.** **Priority comes from the task, not from the attention type.** (Concern 7 Q7.4.) An error on a P0 task outranks an approval on a P2 task. The attention type (error / block / review / approval) is displayed as metadata on the card but does **not** drive ordering.
-
-**Presentation.** Default is a horizontal card row as illustrated. For more than ~6 active items, the operator switches to the table view (§8.4).
-
-**Keyboard navigation.** (Concern 7 Q7.3.)
-
-- `1`–`9` select focus-area cards by position.
-- `Enter` dives into the attention view for the selected card.
-- `Esc` returns to the focus area root.
-
-### 8.3 Working agents — grid below the focus area
-
-**Pre-implementation addendum:** `docs/design-mc-f9-working-grid.md` resolves ten open questions before F-9 lands — tile granularity (agent-keyed with +N badge for additional active assignments), which states count as "working" (`running`/`dispatched`/`queued`, excluding `blocked`), idle-persistent-agent handling, list endpoint shape, tile layout (160 × 80 CSS grid), tile click target, empty-state presentation, WS refetch filter, placement in the §8.1 layout, and the deliberate absence of grid-level sort/filter UI.
-
-Working-but-not-blocked agents render in the grid below. State-machine indicators, no attention prompts. Clicking a grid tile opens the attention view (§5) — same primitive, different entry point. Useful when the operator wants to check on progress proactively. (Concern 7 Q7.2.)
-
-### 8.4 Task table — sortable, filterable
-
-**Pre-implementation addendum:** `docs/design-mc-f8-task-table.md` resolves ten open questions before F-8 lands — list endpoint shape, "agents" column rendering (inline chips, oldest-first), filter persistence via `location.hash`, aggregate-state ordering, primary-active tie-break for drill-down entry, closed-task inclusion policy, empty-state copy, tie-break sort, inline-vs-route placement + keyboard bindings, and title-search scope.
-
-Table view of all tasks. v1 columns: `priority`, `title`, `agents` (assigned heads), `state` (worst-case across assignments), `age`. v1 sorts: `priority`, `age`. v1 filters: `priority`, `age`. (Concern 7 Q7.4.)
-
-Within a priority lane, default sort is oldest first (longest-waiting surfaces first). The operator can re-sort by any column.
-
-More filters (source system, agent type, task status) are added as the list grows. Not v1.
-
-### 8.5 Task detail == attention drill-down
-
-Opening a task from the table opens the attention view for that task's primary active assignment. If no active assignment exists, the task detail shows the task metadata + "[Dispatch]" button that creates an assignment to a chosen head. The task is the curation vessel (§3); the attention view is the drill-down; they share one entry point.
+- **Metrics** (`metrics-panel.tsx`, F-18) — cycle-time big-numbers + wait-time stacked bar + per-agent table; default 24h window; refetched on `state.transition`. Served by `GET /api/metrics/fleet` and `GET /api/metrics/assignment/:id`.
+- **Iterations** (`iteration-board.tsx`, F-14) — a drag-drop kanban with columns (backlog / designing / ready / shipped). Dragging an inbox item into "designing" creates an iteration; dragging between columns issues `PATCH /api/iterations/:id { state }`. A card opens the detail view.
+- **Iteration detail** (`iteration-detail.tsx`, F-15) — a single iteration's planning surface (title, description, task list, state chips).
+- **Command palette** (`command-palette.tsx`) — `⌘K`; current commands are theme toggle and help. **Toast** (`toast.tsx`) for transient messages.
 
 ---
 
-## 9. Phase order
+## 9. Architecture
 
-Capability groups delivered in dependency order, local-readiness first. Each phase is a named capability bundle, not a feature-ID list.
+### 9.1 Heads, hands, and the agent model
 
-### Phase A — Data foundation + local bot scaffold (no UI changes)
+Mission Control uses the **head / hands** agent model:
 
-**Development posture:** Phase A develops on the `v2` branch in a worktree (`Grove-v2`), entirely independent of v1 on `main`. The two share only the `claude` binary on PATH — zero runtime coupling, zero shared database, zero shared process. See `docs/v1-to-v2-cutover.md` for the full isolation model and deferred refactors.
+- **Head** = the agent's identity, persona, memory, skills, role. One row in the `agents` table per head (`type` is `head` or `hands`; a `persistent` flag distinguishes always-visible persistent heads from ephemeral ones).
+- **Hands** = the sandboxed execution run that carries out work. Each `sessions` row is one hands run. A head can spawn 0..N hands runs.
+- Mapping: `agents` row = head; `agent_task_assignment` row = "this head is assigned to this task"; `sessions` (0..N per assignment) = hands runs.
 
-**What ships:**
+This lets Mission Control talk cleanly about backend-agnostic execution (`Bun.spawn` today, other backends later — `docs/design-spawn-integration.md`) and accommodates an agent's recursive sub-team work as additional hands activity within its own assignment, not new `agents` rows.
 
-- **`src/mission-control/` module** — self-contained local bot that runs on `localhost:8767` (v1 uses `8766`). Bun process with HTTP + WebSocket server, `bun:sqlite` database at `~/.local/share/grove/mission-control.db`, config at `~/.config/grove/mission-control.yaml`.
-- **Schema** — `tasks`, `agent_task_assignment`, `agents`, `sessions`, `events` tables. No shared `grove-db` adapter layer in Phase A (that's a cutover concern — v2 is SQLite-only). Schema leaves room for `budget` fields and `blocked_by_task_id` dependency edges even though enforcement logic comes later.
-- Assignment state machine with `operator_requeue` escape hatch (pure function, tested independently).
-- `operator.input` as a first-class event type in `events`.
-- `permission.request` as a first-class event type (§5.3.1) with a structured payload — `requested_action`, `target`, `context`, `risk_hint`. Approve/deny are operator events that mutate assignment state via the session endpoint.
-- **Session endpoint resolver** (§6.1): given an `assignment_id`, return an endpoint handle `{ kind, write, close }`. Phase A implements two kinds: `local.process.controlled` (Grove-spawned CC processes) and `local.observed` (external `cldyo-live` sessions, hook-ingested, read-only — `write` throws `NotControllable`).
-- **Hook-stream reader** — reads `~/.claude/events/raw/` with its own cursor file, independent of v1's `grove-relay`. Ingests events from observed sessions into the `events` table.
+### 9.2 Principal as orchestrator
 
-**PR breakdown (5 PRs, dependency order):**
+**The principal is the orchestrator.** The principal curates the queue, reviews attention items, sends input, moves stuck assignments, and approves dispatch. No agent holds a privileged position in the schema, the attention model, or the UI; the dashboard is agent-neutral.
 
-1. **A1 — Bot scaffold + schema.** `src/mission-control/` directory, `package.json`, SQLite schema with all tables, config loading, `bun run dev` entry point that starts the HTTP server on `:8767`. No business logic.
-2. **A2 — State machine + events.** Assignment state machine (pure function + tests), event insertion, `operator.input` and `permission.request` event types.
-3. **A3 — Session endpoint resolver.** `resolveSessionEndpoint()` returning `{ kind, write, close }`. Two kinds: `local.process.controlled` (spawns CC with `--output-format stream-json`, holds process in a `Map<assignmentId, ManagedProcess>`), `local.observed` (read-only).
-4. **A4 — Hook-stream reader.** Cursor-based reader for `~/.claude/events/raw/`, ingestion into `events` table, correlation with observed sessions.
-5. **A5 — WebSocket server.** WS endpoint on `:8767/ws`, broadcasts state changes and events to connected dashboard clients. No dashboard yet — just the server side of the contract.
+### 9.3 Local + cloud composition
 
-**Why first:** every subsequent phase writes against this schema and these contracts. Ship the foundation before any UI binds to it.
+Mission Control runs in two compositions over **one shared data surface and shape**, with honestly-different runtime:
 
-### Phase B — Dashboard attention core
+| Aspect | Local | Cloud |
+|--------|-------|-------|
+| Runtime | single-process Bun app (`index.ts` → `server.ts`) on `127.0.0.1:8767` | Cloudflare Worker (`worker/`) at `grove.meta-factory.ai/api/*` |
+| Store | `bun:sqlite` (`~/.local/share/grove/mission-control.db`) | D1 (binding `GROVE_DB`) |
+| API | `/api/*` + `/ws` WebSocket (protocol v1) + `/health` on the Bun server | `/api/*` on the Worker (Hono); ingest via `POST /api/ingest` |
+| Auth | none (single-principal, loopback-only bind) | CF Access; principal-scoped |
+| Notifications | in-process Discord sink | per-principal routed |
 
-**What ships:**
+There is **no shared `grove-db` adapter layer** — the local server owns its `bun:sqlite` access directly (`db/`), the Worker owns raw D1 SQL (`worker/src/routes/*`); they share the `/api/*` shape, not an implementation. The Worker schema is a **denormalised snapshot** focused on dashboard rendering, not a mirror of the local schema (one-way ingest: local → cloud).
 
-- Focus area layout (§8.1, §8.2) binding to `agent_task_assignment` state.
-- Attention view (§5) rendering against the event log.
-- Miner-borrowed rendering: three-section layout, D/A/H colour classification, extractive summary header.
-- Task table (§8.4) with priority + age sort/filter.
-- Working-agent grid (§8.3).
+> **Path namespace.** The MC config and DB paths still use the legacy `grove` namespace (`~/.config/grove/mission-control.yaml`, `~/.local/share/grove/mission-control.db`, D1 binding `GROVE_DB`, host `grove.meta-factory.ai`). The grove→cortex namespace/DNS rename is a separate migration concern from the principal-vocabulary rename (cortex#436) and is tracked in `docs/plan-cortex-migration.md`; the paths above are accurate as of this writing.
 
-**Why next:** this is what the operator sees on day one. It is the new mental model the redesign exists for.
+### 9.4 Data model summary
 
-### Phase C — Operator input return
+```
+┌────────┐     ┌───────────────────────┐     ┌───────┐     ┌────────────┐
+│ agents │────▶│ agent_task_assignment │◀────│ tasks │────▶│ iterations │
+└────────┘     └───────────────────────┘     └───────┘     └────────────┘
+   head           link row (STATE MACHINE)       │ joined to GitHub
+                          │                       ▼  (issues / pull_requests /
+                          ▼                  ┌──────────┐  repos — Worker D1)
+                     ┌──────────┐            │  issues  │
+                     │ sessions │            │   ...    │
+                     └──────────┘            └──────────┘
+                      hands runs
+                          │
+                          ▼
+                     ┌──────────┐  unified stream: stream-json.*,
+                     │  events  │  principal.input, principal.curation,
+                     └──────────┘  state.transition, permission.request, …
+```
 
-**What ships:**
+Local tables: `tasks`, `agents`, `agent_task_assignment`, `sessions`, `events`, `iterations`. The Worker D1 adds the snapshot/GitHub/auth tables: `sessions` (denormalised, with `classification` / `data_residency` / `home_principal` sovereignty fields added by migration `0003_sovereignty.sql`), `github_events`, `repos`, `issues`, `pull_requests`, `usage_snapshots`, `session_activity`, `audit_log`, `users`, `agents`, `agent_grants`.
 
-- WebSocket `writeToSession` path in grove-bot (Maestro-borrowed contract).
-- Dashboard input affordance with paste/drag-drop image support.
-- Client-side `executionQueue` for busy-session queuing.
-- `operator.input` events flowing into the aggregated audit log.
+### 9.5 Components
 
-**Why third:** the attention view is usable read-only before this. Input-return turns the cockpit from a monitor into a console.
+```
+┌─────────────────────────────┐
+│  Dashboard (browser, React)  │  src/surface/mc/dashboard-v2/
+│  Focus · Working · Tasks ·   │
+│  Drill-down · Metrics ·      │
+│  Iterations                  │
+└──────────────┬──────────────┘
+               │ WebSocket /ws (protocol v1) + /api/*
+               ▼
+┌─────────────────────────────┐     ┌──────────────────────┐
+│  MC server (Bun)            │────▶│  Discord (sink)      │
+│  server.ts · API handlers   │     └──────────────────────┘
+│  ws/ (broadcast) ·          │
+│  state-machine.ts ·         │
+│  session/ (endpoint write)  │────▶  bun:sqlite (db/)
+│  hooks/ (event ingest)      │
+└─────────────────────────────┘
+```
 
-### Phase D — Discord notifications
+The WebSocket protocol (`ws/types.ts`, `WS_PROTOCOL_VERSION = 1`):
 
-**What ships:**
+- **Server → client:** `connected`, `state.transition`, `event`, `iteration.created` / `iteration.updated` / `iteration.detail_updated` / `iteration.state_changed`, `task.updated`, `subscribed`, `ping` / `pong`, `error`.
+- **Client → server:** `subscribe` (optional `assignmentIds[]`), `ping` / `pong`.
 
-- Hardcoded priority map in grove-bot (§4.2).
-- Discord DM + channel post for assignment state changes.
-- `bot.yaml` toggle and `grove.baseUrl` config.
-- Deep links from Discord into the focus area.
+The dashboard reconnects every ~2 s on disconnect; the server pings every ~30 s. JSON bodies are capped at 128 KB (25 MB on the input endpoint for images).
 
-**Why fourth:** the dashboard is already usable standalone. Push is additive — it drags operator attention into the existing cockpit, it does not provide new capability. Ship it last so operators pull rather than being pushed first.
+### 9.6 Event ingest
 
-### Phase E — Task curation UX
+Mission Control ingests events from CC sessions; it does **not** subscribe to the NATS bus directly (that integration lives in cortex's `src/bus/` + `src/taps/`).
 
-**Pre-implementation addendum:** `docs/design-mc-f12-task-curation.md` covers F-12 (manual dispatch + requeue + abandon + hand-off). Add-to-queue from GitHub issue is split into F-12b with its own addendum (`docs/design-mc-f12b-add-to-queue.md`) in the same iteration-tracker bullet — together the two close Phase E.
-
-**What ships:**
-
-- "Add to queue" affordance on the existing issue view.
-- Task creation from a GitHub issue (populating `sourceRef` into the existing schema).
-- Manual dispatch button (create `agent_task_assignment` row).
-- Manual `operator_requeue` / abandon / hand-off controls on stuck assignments.
-
-**Why last:** earlier phases can be exercised by tasks created programmatically or via a dev console. The curation UX makes the system usable by an operator who does not want to touch a CLI. It is the "day-two" delight, not the day-one foundation.
-
-**Tier 2 is not a phase.** It is a runtime-composition change applied across phases A–E once the data model and contracts are stable.
+- **Local:** a hook poller (`hooks/poller.ts`) reads JSONL from `~/.claude/events/raw/` on an interval (default 2000 ms) with its own cursor; the ingestor (`hooks/ingestor.ts`) groups events by `cc_session_id`, inserts them into `events`, and broadcasts. **F-20 auto-transitions** for `local.observed` sessions: the first event while `dispatched` fires `start` (→ `running`); a `Stop` / `SessionEnd` while `running` fires `complete` (→ `completed`). Detailed design: `docs/design-mc-f20-observe.md`.
+- **Cloud:** `POST /api/ingest` accepts `{ principal_id, events }`, normalises via the shared event-processor, and persists to D1; sovereignty fields (`classification`, `data_residency`, `home_principal`) are extracted from the myelin envelope when present.
 
 ---
 
 ## 10. Deferred capabilities
 
-Explicitly out of scope for v2, with the reason each is deferred:
-
-| Capability                       | Why deferred                                                   | When to revisit                               |
-| -------------------------------- | -------------------------------------------------------------- | --------------------------------------------- |
-| Phone push notifications         | Concern 1 Q1.1 — Tier 2 only                                   | With Tier 2 multi-operator runtime            |
-| OS desktop notifications         | Concern 1 Q1.1 — belongs to event-back-in automation capability | When event-back-in lands                      |
-| Multi-operator runtime           | Concern 2 Q2.2, Concern 5 Q5.5 — v1 single-operator            | Tier 2 rollout                                |
-| Spawn-backed execution           | Spawn is not ready — design preserved in `docs/design-spawn-integration.md` | When Spawn ships                |
-| Classifier / router services     | Concern 1 Q1.2, Conflict 1 — no traffic yet                    | When the ~10-line map is observably wrong     |
-| `TaskSource` interface           | Conflict 4 — one concrete source (GitHub)                      | When a second source (Linear/Jira) arrives    |
-| Stale-task sweepers / DLQ        | Concern 2 Q2.5 — operator has manual controls                  | When manual controls prove insufficient       |
-| LAN multi-device routing         | Concern 8 Q8.2 — niche                                         | When users ask                                |
-| Phone reading Tier 1 links       | Concern 8 Q8.3 — Tier 1 is local-desktop                       | Operators should use Tier 2 for phone access  |
-| Persistent (cross-reload) input queue | §6.3 — v1 queue is browser-state                          | When operators hit the limitation             |
-| Pets/cattle taxonomy             | Conflict 5 — replaced by `persistent: bool` + head/hands       | Never — dropped by design                     |
-| Heartbeat execution mode         | Paperclip pattern (`--print`, stdin-close, queue-pull) — useful for autonomous batch work but incompatible with interactive sessions. §6.1 defines the `local.process.autonomous` kind placeholder. | When Grove needs fire-and-forget batch dispatch |
-| Budget enforcement               | Paperclip pattern (hard-stop auto-pause per agent). Useful for multi-operator cost control and for sharing agent access with spending limits. Schema leaves room for budget fields from Phase A. | Grove Cloud / multi-operator rollout          |
-| Task dependency resolution       | Paperclip pattern (`blockedByIssueIds` with auto-wake). Useful even in Grove Local — manual queue curation doesn't scale past ~10 active tasks. Schema leaves room for `blocked_by_task_id` edges from Phase A. | Post-Phase A, before task list grows large    |
+| Capability | Why deferred |
+|------------|--------------|
+| Multi-principal local runtime | local is single-principal; cloud carries `principal_id` / `home_principal` for federation |
+| Spawn-backed execution | Spawn not ready — design preserved in `docs/design-spawn-integration.md` |
+| Phone push / OS desktop notifications | Discord-only sink |
+| `TaskSource` interface | one concrete GitHub path |
+| Classifier / router service | the hardcoded map suffices until observably wrong |
+| Stale-task sweepers / DLQ | manual requeue / handoff / abandon controls |
+| Interactive Approve/Deny | gated on CC's stream-json permission protocol (§6.3) |
+| `local.process.autonomous` heartbeat mode | stubbed endpoint kind; for future fire-and-forget batch dispatch |
+| Budget enforcement, task-dependency auto-wake | schema leaves room; not yet enforced |
+| Durable (cross-reload) input queue | the queue is browser state today |
 
 ---
 
 ## 11. Open questions
 
-Questions the design does not yet resolve. Each has a proposed owner and a phase gate.
-
-### Tier 2 semantic divergences (beyond v2 scope)
-
-1. **Cross-operator ordering.** When two operators act on the same task simultaneously at Tier 2, whose change wins? Not a v2 concern (single-operator v1), but the design must not preclude an answer.
-   - *Owner:* next designer. *Gate:* before Tier 2 multi-operator rollout.
-2. **Rate limiting at Tier 2.** Per-operator WebSocket throttling, D1 write backpressure.
-   - *Owner:* Tier 2 implementer. *Gate:* Tier 2 rollout.
-3. **Notification fan-out at Tier 2.** How a state change on a shared task fans out to multiple operators.
-   - *Owner:* Tier 2 implementer. *Gate:* Tier 2 rollout.
-
-### Implementation details that Phase 4 deferred to code
-
-4. **Exact WebSocket protocol** (message envelope, error semantics, reconnect backoff). Borrow from Maestro's IPC contract where shapes match.
-   - *Owner:* Phase C implementer. *Gate:* before Phase C code lands.
-5. **Event log virtualisation strategy** — rough heuristic is "last 20 events hot, lazy-load older on scroll", but library choice and pre-fetch sizing are code decisions.
-   - *Owner:* Phase B implementer. *Gate:* before Phase B code lands.
-6. **`block_reason` extensibility beyond the three kinds in §5.3.1.** The tagged union in §5.3.1 names `permission.request`, `tool.error`, and `review.checkpoint`. Additional block kinds (e.g., `quota.exceeded`, `subagent.handoff`) are not specified yet. Adding one is a single row in the §5.3.1 schema + a branch in §4.2's `shouldNotify`.
-   - *Owner:* Phase A implementer (schema), any later phase for new kinds. *Gate:* before the attention view binds to a new kind.
-
-### Open but not blocking
-
-7. **Task priority authority.** Who sets `priority`? Today, the operator types it when adding a task to the queue. Future: could be inherited from the source issue's label (`now`/`next`/`future`), or computed. Not v1 blocker.
-8. **Persistent input queue.** v1 queue is browser-state (§6.3). If an operator reloads mid-type, queued items are lost. Acceptable for v1; revisit if operators hit the limitation.
-9. **Attention-item dismissal semantics.** When an assignment transitions out of `blocked`, its card clears automatically. What if the operator wants to snooze a card without resolving the underlying block? No answer yet; no one has asked for it yet.
-10. **CC stream-json permission event support.** Does CC emit a structured `permission.request` event in `--output-format stream-json` output and accept an approval response via `--input-format stream-json` stdin? Neither Maestro nor Paperclip has tested this path — both bypass permissions entirely (§5.3.1, §7.6). **Phase A verification task:** spawn a CC process in stream-json mode, trigger a permission prompt (e.g., a `tool.bash` that needs approval), and inspect the output for a structured permission event. If CC does not support it, ship with yolo mode as default; the `permission.request` schema and UI rendering ship regardless as a placeholder.
-   - *Owner:* Phase A implementer (PR A3). *Gate:* before Phase C input-return code assumes permission events exist.
+1. **Cross-principal ordering / rate-limiting / fan-out (cloud).** When multiple principals act on a shared task at the cloud tier, the conflict, throttling, and notification-fan-out semantics are unspecified. Not a local-runtime concern.
+2. **CC stream-json permission support.** Does CC emit a structured `permission.request` event and accept an approval via stream-json stdin? Until verified, Approve/Deny is inert (§6.3).
+3. **`block_reason` extensibility.** Adding a fourth `kind` (e.g. `quota.exceeded`) is a single schema row plus a `shouldNotify` branch.
+4. **Task priority authority.** Today the principal sets `priority`; it could later be inherited from the source issue's label.
 
 ---
 
-## 12. Attribution
+## History — Mission Control v2 (grove-v2) origins
 
-Every major claim in this doc traces back to one of:
+<!-- historical: do not modernise -->
 
-- **A of Andreas's 8 concerns** (`Plans/design-sprint-mc/02-concerns.md`)
-- **A Phase 3 decision** (`Plans/design-sprint-mc/03-decisions.md`)
-- **A research source** from the Phase 1 source map (`01-source-map.md`)
-- **A cited reference implementation** (`~/Developer/miner`, `~/Developer/maestro`, `~/Developer/paperclip`)
+> This appendix preserves the provenance of the Mission Control surface. The text and design decisions below describe the system cortex migrated **from** — grove-v2's "Mission Control v2" design — and are retained for historical continuity. Do not modernise this section; the operator→principal and grove→cortex vocabularies are intentionally left in their original form here.
 
-Specific anchors:
+**Provenance.** This document descends from `the-metafactory/grove-v2` `docs/design-mission-control.md`, lifted into cortex at **MIG-7.11** of the grove-v2 → cortex migration (lifted 2026-05-11). The original was a design spec dated 2026-04-15, driven by Andreas, the single source of truth for **Grove Mission Control v2**, with every claim traced to one of Andreas's 8 concerns or a cross-doc conflict resolution in the design sprint's `03-decisions.md`. The body above is the current-tense Cortex Mission Control v3 description that replaces it; this appendix records where the design came from and how the shipped system diverged from the original v2 intentions.
 
-- §2 (Core operator flow) — Concerns 4, 5, 7
-- §3 (Task funnel) — Concerns 2, 3; Conflicts 3, 4
-- §4 (Notifications) — Concerns 1, 8; Conflict 1
-- §5 (Attention view) — Concern 4; miner inspection report; Paperclip `assistant-ui` library
-- §6 (Operator input) — Concern 5; Maestro inspection report (2026-04-16 code audit)
-- §6.6 (Session compaction) — Paperclip heartbeat service session rotation policy
-- §7 (Architecture) — Conflicts 2, 5, 6
-- §7.6 (Reference implementations) — Maestro, Paperclip, miner pattern audit (2026-04-16)
-- §8 (Dashboard layout) — Concern 7
-- §9 (Phase order) — all; local-only development posture from v1/v2 isolation decision
-- §10 (Deferred) — explicit non-goals across concerns; Paperclip-borrowed patterns deferred to post-Phase A
-- §11 (Open questions) — Phase 3 items intentionally parked; Q10 CC permission verification from Maestro/Paperclip audit
+**Original framing (grove-v2 v2 design).** Grove Mission Control was framed as "the operator's cockpit for running many agents against a curated backlog" — one operator, many agents, one dashboard. The v2 design was structured around two runtime tiers: **Tier 1** (local single-operator Bun + SQLite) and **Tier 2** (cloud multi-operator CF Worker + D1), with the explicit goal that Tier 2 be "a runtime change, not a redesign." The vocabulary throughout used "operator" for the human running the stack; cortex's vocabulary migration (cortex#436) renames that concept to "principal."
 
-This is the v2 contract. Phase 5 verifies every claim. Phase 6 commits the sprawl retirement.
+**Reference-implementation audits (2026-04-16).** The v2 design borrowed citable patterns from three external systems:
+
+- **Maestro** (`~/Developer/maestro`, Electron CC IDE) — the closest architectural match. Borrowed: long-lived CC process with `--output-format stream-json` (no `--print`); `ProcessManager` holding `Map<sessionId, ManagedProcess>`; stdin-framed multi-turn input via `buildStreamJsonMessage`; the renderer→main→stdin IPC bridge (a WebSocket in Mission Control's case); `--resume` only for reconnection, not turn continuity; paste / drag-drop image input; the client-side `executionQueue`. Not borrowed: permission-prompt handling (Maestro runs yolo-mode) and multi-agent orchestration.
+- **Paperclip** (`~/Developer/paperclip`, queue-based orchestrator) — its single-turn heartbeat execution model (`--print` + `stdin.end()`) was **not** borrowed, but its operational patterns were: session compaction (max turns / tokens / age), `block_reason` decomposition, per-session cost tracking, workspace-scoped config.
+- **Miner** (`~/Developer/miner`, PAI process-mining dashboard) — contributed the attention-view rendering patterns: the three-section layout (summary / event log / input), the **D/A/H colour classification** (Deterministic / Agentic / Human), and the extractive (non-generative) summary header.
+
+**Divergences — how the shipped v3 differs from the v2 design.** Several v2 design intentions did not ship as written; the body above reflects what actually exists:
+
+- **No `src/common/grove-db/` shared adapter layer.** The v2 design (its §7.3) chose "Option A": a shared data-access module with `SqliteAdapter` and `D1Adapter` so new tables would land through one layer. This was never built. The shipped system keeps direct `bun:sqlite` access locally and raw D1 SQL in the Worker, sharing only the `/api/*` shape — the duplication the v2 design hoped to avoid.
+- **`src/mission-control/` became `src/surface/mc/`.** The v2 design's standalone `src/mission-control/` module (developed on a `v2` branch in a `Grove-v2` worktree, isolated from v1 on `main` — see the archived `v1-to-v2-cutover.md`) was re-homed under cortex's M7 `src/surface/mc/` at the migration.
+- **The "Tier 1 / Tier 2" framing became "local / cloud."** The shipped split is the same in spirit (Bun+SQLite vs Worker+D1) but the cloud surface is a denormalised one-way snapshot, not the symmetric multi-operator runtime the v2 design anticipated.
+- **Features the v2 design did not include shipped anyway.** The iteration-planning kanban (`iterations` table, F-13/F-14/F-15), the metrics panel (F-18), the command palette, the explicit `cancelled` assignment state, and the F-20 observed-session auto-transitions are all part of v3 but post-date the original v2 spec.
+- **Interactive Approve/Deny never activated.** The v2 design made `permission.request` a first-class `block_reason` kind with inline approve/deny; the buttons ship but remain disabled pending CC's stream-json permission protocol (Phase A verification item that did not resolve).
+
+**Original phase plan (grove-v2 v2).** The v2 design sequenced delivery as Phase A (data foundation + local bot scaffold), Phase B (dashboard attention core), Phase C (operator input return), Phase D (Discord notifications), Phase E (task curation UX), with Tier 2 as a cross-phase runtime change rather than a phase. The shipped v3 covers all of these (the local surface, the attention/drill-down core, the input channel, Discord notifications, and the curation toolbar) plus the iteration/metrics surfaces noted above.
+
+**Attribution (original).** Every major claim in the original v2 doc traced to one of Andreas's 8 concerns (`Plans/design-sprint-mc/02-concerns.md`), a Phase 3 decision (`03-decisions.md`), a research source (`01-source-map.md`), or a cited reference implementation (miner / maestro / paperclip). The companion feature-level design docs (`docs/design-mc-f6-focus-area.md` through `docs/design-mc-f20-observe.md`, the React-migration doc, the image-input doc, and the F-10 input-return doc) carry the per-feature resolutions and remain the detailed source for each capability.


### PR DESCRIPTION
## Summary

Closes the `operator`→`principal` docs sweep for the two AC-pinned files in PR-R13e (cortex#436).

**`docs/architecture.md`** — operator→principal/network prose sweep (~41 hits).
**`docs/design-mission-control.md`** — full reverse-engineered rewrite to describe **shipped Cortex Mission Control v3**, plus a History appendix preserving its grove-v2 origins.

## Approach decision (please note)

The §9 plan said "full rewrite to current-tense cortex." On inspection, the doc was a **grove-v2 v2 *design* doc** that diverged from what cortex actually shipped (it specs a `src/common/grove-db/` adapter layer that never materialised, `src/mission-control/` paths, a Tier-1/Tier-2 framing). @jcfischer chose **reverse-engineer to v3** (2026-05-27): I audited the real `src/surface/mc/` implementation (138 files, ~29k LOC) and rewrote the body to describe what MC v3 *actually is* — real tables, state machine, API routes, WebSocket protocol v1, the dashboard-v2 component tree, the local(SQLite)+cloud(D1) split, hook-based ingest, and D/A/H event rendering. This is **larger in spirit than the planned ~500 LOC** (effectively a new design doc) but the diff is a net **−467 lines** (968 → 501) because the grove-v2 design-process scaffolding condensed into a single History appendix.

The grove-v2 provenance — the 8-concerns framing, the never-shipped `grove-db` layer, the Phase A–E plan, the Maestro/Paperclip/miner reference audits, attribution — moved into **`## History — Mission Control v2 (grove-v2) origins`**, marked `<!-- historical: do not modernise -->` with the MIG-7.11 provenance note. That appendix is where the divergences (grove-db, paths, inert Approve/Deny) are honestly recorded.

## architecture.md carve-outs (deliberate)

- `roles: [operator]` (line 633) — a **role-id literal** that mirrors the current `cortex-config.ts` schema example; role-ids aren't part of the vocab rename (that's R13a's track), so it stays.
- `mf.net-{op}` diagram convention — §3.5 explicitly defers the `mf.net`→`local` rename to myelin#7; left as-is. The spelled-out `mf.net-{operator}` placeholder was normalised to the doc's own `{op}` abbreviation (removes the word, preserves the historical namespace meaning).
- principal-vs-network: I used **principal** as the R4-sanctioned default (`{org}`→`{principal}`). Flagging for review in case a few sites read better as "network."

## Acceptance criteria

- [x] `grep -En '\boperator\b' docs/design-mission-control.md` → hits **only** inside the History appendix (0 before the banner)
- [x] MIG-7.11 provenance note preserved in the appendix
- [x] Internal links work — **no inbound `#anchor` links to this doc exist** (only bare file refs), and the doc's own `#history-…` anchor resolves. No anchor renames needed.
- [x] `grep -En '\boperator\b' docs/architecture.md` → only the `roles: [operator]` carve-out
- [x] `bunx tsc --noEmit` clean (docs-only)
- [ ] Echo + Luna review (extra-care, design ground-truth) — requested

## Out of scope (pre-flagged so it isn't flagged as a gap)

- **AC4 (`bun check:vocab` allowlist):** that tool **does not exist** in this branch (no `check:vocab` script, no checker in-tree). The `<!-- historical: do not modernise -->` banner is in place for when it lands; there is no allowlist to update today.
- **The ~48 other `design-*.md` docs** with `operator` hits (IAW, bus-addressing, cloud-api, the mc-fNN feature docs, etc.) are **not** swept here — no AC pins them, each hit needs principal-vs-network judgment, and several overlap other R-clusters (R3 `operator.id`, R4 myelin-lockstep). Stale `OperatorSchema`/`operator.id` references live in those sibling docs, not in the two files this PR owns.
- **`design-mc-f10-operator-input.md`** — I deliberately avoided embedding this sibling filename in the rewritten body (it would trip the `\boperator\b` AC, and #451 doesn't rename sibling files). F-10's content is described inline instead.
- **In-flight code symbols:** the doc uses the principal-canonical names (`principal_id`, `home_principal`, `principal.input`/`principal.curation`); the code still carries the `operator_*` forms until #447/#448/#450 land. A vocabulary note at the top of the doc states this explicitly.

## Test plan

- [x] `bunx tsc --noEmit` clean
- [x] AC greps verified (see above)

Closes #451