### PR TITLE
feat(cortex): PR-R2.J (policy-half) — home_operator → home_principal policy schema (#448)

### DIFF
--- a/cortex.yaml.example
+++ b/cortex.yaml.example
@@ -131,7 +131,7 @@ policy:
   principals:
     - id: operator
       # <REPLACE_ME>: keep both fields in sync with `operator.id` and `stack.id` above.
-      home_operator: operator-name
+      home_principal: operator-name
       home_stack: operator-name/meta-factory
       role:
         - operator
@@ -140,7 +140,7 @@ policy:
         discord:
           - "000000000000000000"  # <REPLACE_ME>: your operator Discord id
     - id: echo
-      home_operator: operator-name  # <REPLACE_ME>
+      home_principal: operator-name  # <REPLACE_ME>
       home_stack: operator-name/meta-factory  # <REPLACE_ME>
       role:
         - agent-echo

--- a/docs/migration-examples/after-single-adapter.yaml
+++ b/docs/migration-examples/after-single-adapter.yaml
@@ -9,13 +9,13 @@ capabilities: []
 policy:
   principals:
     - id: anonymous-discord-luna
-      home_operator: andreas
+      home_principal: andreas
       home_stack: andreas/example
       role: []
       trust: []
       platform_ids: {}
     - id: echo
-      home_operator: unknown
+      home_principal: unknown
       home_stack: unknown/unknown
       role:
         - agent-echo
@@ -24,7 +24,7 @@ policy:
         discord:
           - "999000111"
     - id: operator
-      home_operator: andreas
+      home_principal: andreas
       home_stack: andreas/example
       role:
         - operator
@@ -40,7 +40,7 @@ policy:
             - ~/Developer
           bash_guard: true
     - id: user-d049472
-      home_operator: andreas
+      home_principal: andreas
       home_stack: andreas/example
       role:
         - user

--- a/src/__tests__/iaw-phase-d-integration.test.ts
+++ b/src/__tests__/iaw-phase-d-integration.test.ts
@@ -298,7 +298,7 @@ function betaEngine(alpha: StackHandle): PolicyEngine {
     principals: [
       {
         id: alpha.principalId,
-        home_operator: "alpha",
+        home_principal: "alpha",
         home_stack: alpha.homeStack,
         role: ["peer"],
         trust: [],
@@ -324,7 +324,7 @@ function alphaEngine(beta: StackHandle): PolicyEngine {
     principals: [
       {
         id: beta.principalId,
-        home_operator: "beta",
+        home_principal: "beta",
         home_stack: beta.homeStack,
         role: ["peer"],
         trust: [],

--- a/src/cli/cortex/commands/__tests__/migrate-config-policy.test.ts
+++ b/src/cli/cortex/commands/__tests__/migrate-config-policy.test.ts
@@ -16,7 +16,7 @@
  *   - DM userRoles[] → augments principal's session_config.dm
  *   - defaultRole: denied → synthetic anonymous principal with empty role[]
  *   - defaultRole: <named> → synthetic anonymous principal with that role
- *   - external peer (`agent-ivy` where ivy is not declared) → home_operator
+ *   - external peer (`agent-ivy` where ivy is not declared) → home_principal
  *     "unknown" + warning
  *   - idempotency: re-running emits byte-identical output
  *   - --labels override: principal id taken from labels file
@@ -147,7 +147,7 @@ agents:
     const operator = policy.principals.find((p) => p.id === "operator")!;
     expect(operator.platform_ids.discord).toContain("1134325176796987522");
     expect(operator.role).toContain("operator");
-    expect(operator.home_operator).toBe("andreas");
+    expect(operator.home_principal).toBe("andreas");
     expect(operator.home_stack).toBe("andreas/meta-factory");
 
     const user = policy.principals.find((p) => p.id === "user-d049472")!;
@@ -407,7 +407,7 @@ describe("defaultRole synthesis", () => {
 // ---------------------------------------------------------------------------
 
 describe("external peer principals", () => {
-  test("agent-ivy where ivy is not declared → home_operator: unknown + warning", () => {
+  test("agent-ivy where ivy is not declared → home_principal: unknown + warning", () => {
     const result = buildPolicy({
       operatorId: "andreas",
       homeStack: "andreas/meta-factory",
@@ -425,7 +425,7 @@ describe("external peer principals", () => {
     });
     const ivy = result.policy.principals.find((p) => p.id === "ivy")!;
     expect(ivy).toBeDefined();
-    expect(ivy.home_operator).toBe("unknown");
+    expect(ivy.home_principal).toBe("unknown");
     expect(ivy.home_stack).toBe("unknown/unknown");
     expect(ivy.platform_ids.discord).toContain("IVY_ID");
     const warn = result.warnings.find(
@@ -604,7 +604,7 @@ describe("bare-string capability rewriting", () => {
         principals: [
           {
             id: "luna",
-            home_operator: "andreas",
+            home_principal: "andreas",
             home_stack: "andreas/work",
             role: ["operator"],
             trust: [],
@@ -648,7 +648,7 @@ describe("nkey_pub round-trip (PR #306 r1 blocker fix)", () => {
         principals: [
           {
             id: "luna",
-            home_operator: "andreas",
+            home_principal: "andreas",
             home_stack: "andreas/work",
             role: ["operator"],
             trust: [],
@@ -680,7 +680,7 @@ describe("nkey_pub round-trip (PR #306 r1 blocker fix)", () => {
         principals: [
           {
             id: "luna",
-            home_operator: "andreas",
+            home_principal: "andreas",
             home_stack: "andreas/work",
             role: ["operator"],
             trust: [],

--- a/src/cli/cortex/commands/migrate-config-lib.ts
+++ b/src/cli/cortex/commands/migrate-config-lib.ts
@@ -1961,7 +1961,7 @@ export function formatCheckReport(result: ConversionResult): string {
         .map(([plat, ids]) => `${plat}=${ids.length}`)
         .join(", ");
       const dm = p.session_config?.dm ? " +dm" : "";
-      lines.push(`  - ${p.id} (home_operator=${p.home_operator}, home_stack=${p.home_stack}) roles=[${p.role.join(", ")}] platforms=[${platforms}]${dm}`);
+      lines.push(`  - ${p.id} (home_principal=${p.home_principal}, home_stack=${p.home_stack}) roles=[${p.role.join(", ")}] platforms=[${platforms}]${dm}`);
     }
     lines.push(`policy.roles: ${policy.roles.length}`);
     for (const r of policy.roles) {

--- a/src/cli/cortex/commands/migrate-config-policy.ts
+++ b/src/cli/cortex/commands/migrate-config-policy.ts
@@ -27,7 +27,7 @@
  *      bundles → warn + take the conservative UNION (preserves access;
  *      operator must tighten manually if they want to).
  *   7. External-peer principals (an `agent-<X>` role where `<X>` isn't a
- *      declared agent in this config) emit with `home_operator: "unknown"`
+ *      declared agent in this config) emit with `home_principal: "unknown"`
  *      and `home_stack: "unknown/unknown"` + a warning so operators see
  *      the gap.
  *
@@ -295,7 +295,7 @@ function capsForRoleBundle(
 
 interface PrincipalAccumulator {
   id: string;
-  home_operator: string;
+  home_principal: string;
   home_stack: string;
   platform_ids: Record<string, Set<string>>;
   roles: Set<string>;
@@ -411,7 +411,7 @@ export function buildPolicy(input: PolicyBuilderInput): PolicyBuilderOutput {
     }
     const acc: PrincipalAccumulator = {
       id: p.id,
-      home_operator: p.home_operator,
+      home_principal: p.home_principal,
       home_stack: p.home_stack,
       platform_ids: platformIds,
       roles: new Set(p.role),
@@ -553,7 +553,7 @@ export function buildPolicy(input: PolicyBuilderInput): PolicyBuilderOutput {
         if (principal === undefined) {
           principal = {
             id: principalId,
-            home_operator: isExternal ? "unknown" : input.operatorId,
+            home_principal: isExternal ? "unknown" : input.operatorId,
             home_stack: isExternal ? "unknown/unknown" : input.homeStack,
             platform_ids: {},
             roles: new Set(),
@@ -568,7 +568,7 @@ export function buildPolicy(input: PolicyBuilderInput): PolicyBuilderOutput {
               field: `policy.principals[${principalId}]`,
               message:
                 `external peer "${principalId}" found in agents[${view.agentId}].presence.${view.platform}.roles[].agent-${principalId}; ` +
-                `please set home_operator + home_stack manually in policy.principals[${principalId}] (currently "unknown"/"unknown/unknown")`,
+                `please set home_principal + home_stack manually in policy.principals[${principalId}] (currently "unknown"/"unknown/unknown")`,
             });
           }
           principals.set(principalId, principal);
@@ -592,7 +592,7 @@ export function buildPolicy(input: PolicyBuilderInput): PolicyBuilderOutput {
       const anonId = `anonymous-${view.platform}-${view.agentId}`;
       const acc: PrincipalAccumulator = {
         id: anonId,
-        home_operator: input.operatorId,
+        home_principal: input.operatorId,
         home_stack: input.homeStack,
         platform_ids: {},
         roles: new Set(),
@@ -638,7 +638,7 @@ export function buildPolicy(input: PolicyBuilderInput): PolicyBuilderOutput {
       } else {
         principals.set(anonId, {
           id: anonId,
-          home_operator: input.operatorId,
+          home_principal: input.operatorId,
           home_stack: input.homeStack,
           platform_ids: {},
           roles: new Set([allowAllRoleId]),
@@ -660,7 +660,7 @@ export function buildPolicy(input: PolicyBuilderInput): PolicyBuilderOutput {
       if (opPrincipal === undefined) {
         opPrincipal = {
           id: operatorPrincipalId,
-          home_operator: input.operatorId,
+          home_principal: input.operatorId,
           home_stack: input.homeStack,
           platform_ids: {},
           roles: new Set(["operator"]),
@@ -732,7 +732,7 @@ export function buildPolicy(input: PolicyBuilderInput): PolicyBuilderOutput {
           // to land. Their channel-context session config stays empty.
           principal = {
             id: principalId,
-            home_operator: input.operatorId,
+            home_principal: input.operatorId,
             home_stack: input.homeStack,
             platform_ids: {},
             roles: new Set(),
@@ -916,7 +916,7 @@ function serialisePolicy(
     }
     const p: PolicyPrincipal = {
       id: acc.id,
-      home_operator: acc.home_operator,
+      home_principal: acc.home_principal,
       home_stack: acc.home_stack,
       role: [...acc.roles].sort(),
       trust: [...acc.trust].sort(),

--- a/src/common/policy/__tests__/engine.test.ts
+++ b/src/common/policy/__tests__/engine.test.ts
@@ -37,7 +37,7 @@ import type {
 function principal(overrides: Partial<Principal> = {}): Principal {
   return {
     id: "luna",
-    home_operator: "andreas",
+    home_principal: "andreas",
     home_stack: "andreas/research",
     role: ["operator"],
     trust: [],

--- a/src/common/policy/__tests__/factory.test.ts
+++ b/src/common/policy/__tests__/factory.test.ts
@@ -40,7 +40,7 @@ describe("policyEngineFromConfig", () => {
       principals: [
         {
           id: "luna",
-          home_operator: "andreas",
+          home_principal: "andreas",
           home_stack: "andreas/research",
           role: ["operator"],
           trust: [],
@@ -61,7 +61,7 @@ describe("policyEngineFromConfig", () => {
       principals: [
         {
           id: "luna",
-          home_operator: "andreas",
+          home_principal: "andreas",
           home_stack: "andreas/research",
           role: ["operator"],
           trust: [],
@@ -130,14 +130,14 @@ describe("policyEngineFromConfig", () => {
       principals: [
         {
           id: "luna",
-          home_operator: "andreas",
+          home_principal: "andreas",
           home_stack: "andreas/research",
           role: ["operator", "code-reviewer"],
           trust: ["echo"],
         },
         {
           id: "echo",
-          home_operator: "andreas",
+          home_principal: "andreas",
           home_stack: "andreas/research",
           role: ["code-reviewer"],
           trust: [],
@@ -187,7 +187,7 @@ describe("PolicySchema cross-validation", () => {
         principals: [
           {
             id: "luna",
-            home_operator: "andreas",
+            home_principal: "andreas",
             home_stack: "andreas/research",
             role: ["nonexistent-role"],
             trust: [],
@@ -204,7 +204,7 @@ describe("PolicySchema cross-validation", () => {
         principals: [
           {
             id: "luna",
-            home_operator: "andreas",
+            home_principal: "andreas",
             home_stack: "andreas/research",
             role: [],
             trust: ["nonexistent-peer"],
@@ -221,14 +221,14 @@ describe("PolicySchema cross-validation", () => {
         principals: [
           {
             id: "luna",
-            home_operator: "andreas",
+            home_principal: "andreas",
             home_stack: "andreas/research",
             role: [],
             trust: [],
           },
           {
             id: "luna",
-            home_operator: "andreas",
+            home_principal: "andreas",
             home_stack: "andreas/research",
             role: [],
             trust: [],
@@ -257,14 +257,14 @@ describe("PolicySchema cross-validation", () => {
         principals: [
           {
             id: "luna",
-            home_operator: "andreas",
+            home_principal: "andreas",
             home_stack: "andreas/research",
             role: ["ghost-role-1"],
             trust: [],
           },
           {
             id: "echo",
-            home_operator: "andreas",
+            home_principal: "andreas",
             home_stack: "andreas/research",
             role: ["ghost-role-2"],
             trust: [],
@@ -289,7 +289,7 @@ describe("PolicySchema cross-validation", () => {
         principals: [
           {
             id: "2bad-prefix",
-            home_operator: "andreas",
+            home_principal: "andreas",
             home_stack: "andreas/research",
             role: [],
             trust: [],
@@ -322,7 +322,7 @@ describe("PolicyPrincipalSchema — cortex#243a schema extension", () => {
         principals: [
           {
             id: "luna",
-            home_operator: "andreas",
+            home_principal: "andreas",
             home_stack: "andreas/research",
             role: [],
             trust: [],
@@ -351,7 +351,7 @@ describe("PolicyPrincipalSchema — cortex#243a schema extension", () => {
         principals: [
           {
             id: "luna",
-            home_operator: "andreas",
+            home_principal: "andreas",
             home_stack: "andreas/research",
             role: [],
             trust: [],
@@ -368,7 +368,7 @@ describe("PolicyPrincipalSchema — cortex#243a schema extension", () => {
           principals: [
             {
               id: "luna",
-              home_operator: "andreas",
+              home_principal: "andreas",
               home_stack: "andreas/research",
               role: [],
               trust: [],
@@ -386,7 +386,7 @@ describe("PolicyPrincipalSchema — cortex#243a schema extension", () => {
           principals: [
             {
               id: "luna",
-              home_operator: "andreas",
+              home_principal: "andreas",
               home_stack: "andreas/research",
               role: [],
               trust: [],
@@ -405,7 +405,7 @@ describe("PolicyPrincipalSchema — cortex#243a schema extension", () => {
         principals: [
           {
             id: "luna",
-            home_operator: "andreas",
+            home_principal: "andreas",
             home_stack: "andreas/research",
             role: [],
             trust: [],
@@ -431,7 +431,7 @@ describe("PolicyPrincipalSchema — cortex#243a schema extension", () => {
         principals: [
           {
             id: "operator-andreas",
-            home_operator: "andreas",
+            home_principal: "andreas",
             home_stack: "andreas/research",
             role: [],
             trust: [],
@@ -477,7 +477,7 @@ describe("PolicyPrincipalSchema — cortex#243a schema extension", () => {
         principals: [
           {
             id: "luna",
-            home_operator: "andreas",
+            home_principal: "andreas",
             home_stack: "andreas/research",
             role: [],
             trust: [],
@@ -494,7 +494,7 @@ describe("PolicyPrincipalSchema — cortex#243a schema extension", () => {
         principals: [
           {
             id: "luna",
-            home_operator: "andreas",
+            home_principal: "andreas",
             home_stack: "andreas/research",
             role: [],
             trust: [],
@@ -512,14 +512,14 @@ describe("PolicyPrincipalSchema — cortex#243a schema extension", () => {
         principals: [
           {
             id: "luna",
-            home_operator: "andreas",
+            home_principal: "andreas",
             home_stack: "andreas/meta-factory",
             role: [],
             trust: [],
           },
           {
             id: "luna",
-            home_operator: "andreas",
+            home_principal: "andreas",
             home_stack: "andreas/work",
             role: [],
             trust: [],
@@ -540,14 +540,14 @@ describe("PolicyPrincipalSchema — cortex#243a schema extension", () => {
           principals: [
             {
               id: "luna",
-              home_operator: "andreas",
+              home_principal: "andreas",
               home_stack: "andreas/research",
               role: [],
               trust: [],
             },
             {
               id: "luna",
-              home_operator: "andreas",
+              home_principal: "andreas",
               home_stack: "andreas/research",
               role: [],
               trust: [],
@@ -566,7 +566,7 @@ describe("PolicyPrincipalSchema — cortex#243a schema extension", () => {
           principals: [
             {
               id: "luna",
-              home_operator: "andreas",
+              home_principal: "andreas",
               home_stack: "andreas/research",
               role: [],
               trust: [],
@@ -574,7 +574,7 @@ describe("PolicyPrincipalSchema — cortex#243a schema extension", () => {
             },
             {
               id: "echo",
-              home_operator: "andreas",
+              home_principal: "andreas",
               home_stack: "andreas/research",
               role: [],
               trust: [],
@@ -591,7 +591,7 @@ describe("PolicyPrincipalSchema — cortex#243a schema extension", () => {
         principals: [
           {
             id: "luna",
-            home_operator: "andreas",
+            home_principal: "andreas",
             home_stack: "andreas/research",
             role: [],
             trust: [],
@@ -599,7 +599,7 @@ describe("PolicyPrincipalSchema — cortex#243a schema extension", () => {
           },
           {
             id: "echo",
-            home_operator: "andreas",
+            home_principal: "andreas",
             home_stack: "andreas/research",
             role: [],
             trust: [],
@@ -616,7 +616,7 @@ describe("PolicyPrincipalSchema — cortex#243a schema extension", () => {
         principals: [
           {
             id: "luna",
-            home_operator: "andreas",
+            home_principal: "andreas",
             home_stack: "andreas/research",
             role: [],
             trust: [],
@@ -624,7 +624,7 @@ describe("PolicyPrincipalSchema — cortex#243a schema extension", () => {
           },
           {
             id: "echo",
-            home_operator: "andreas",
+            home_principal: "andreas",
             home_stack: "andreas/research",
             role: [],
             trust: [],
@@ -644,7 +644,7 @@ describe("PolicyPrincipalSchema — cortex#243a schema extension", () => {
         principals: [
           {
             id: "luna",
-            home_operator: "andreas",
+            home_principal: "andreas",
             home_stack: "andreas/research",
             role: ["operator"],
             trust: [],
@@ -956,7 +956,7 @@ describe("PolicyFederatedSchema cross-validation", () => {
   test("federated block plus principals + roles parses cleanly together", () => {
     const policy = PolicySchema.parse({
       principals: [{
-        id: "luna", home_operator: "andreas", home_stack: "andreas/research",
+        id: "luna", home_principal: "andreas", home_stack: "andreas/research",
         role: ["operator"], trust: [],
       }],
       roles: [{ id: "operator", capabilities: ["deploy.staging"] }],

--- a/src/common/policy/__tests__/policy-gate.test.ts
+++ b/src/common/policy/__tests__/policy-gate.test.ts
@@ -21,7 +21,7 @@ import type { Policy, PolicyPrincipal } from "../../types/cortex-config";
 function principal(overrides: Partial<PolicyPrincipal> = {}): PolicyPrincipal {
   return {
     id: "luna",
-    home_operator: "andreas",
+    home_principal: "andreas",
     home_stack: "andreas/meta-factory",
     role: [],
     trust: [],

--- a/src/common/policy/__tests__/resolve-access.test.ts
+++ b/src/common/policy/__tests__/resolve-access.test.ts
@@ -46,7 +46,7 @@ const OPERATOR_POLICY: Policy = {
   principals: [
     {
       id: "operator",
-      home_operator: "andreas",
+      home_principal: "andreas",
       home_stack: "andreas/meta-factory",
       role: ["operator"],
       trust: [],
@@ -74,7 +74,7 @@ const USER_POLICY: Policy = {
   principals: [
     {
       id: "mike",
-      home_operator: "andreas",
+      home_principal: "andreas",
       home_stack: "andreas/meta-factory",
       role: ["user"],
       trust: [],
@@ -274,7 +274,7 @@ describe("resolvePolicyAccess — lockout path", () => {
       principals: [
         {
           id: "guest",
-          home_operator: "andreas",
+          home_principal: "andreas",
           home_stack: "andreas/meta-factory",
           role: ["guest"],
           trust: [],

--- a/src/common/policy/factory.ts
+++ b/src/common/policy/factory.ts
@@ -67,7 +67,7 @@ export function policyEngineFromConfig(
   return new PolicyEngine({
     principals: policy.principals.map((p) => ({
       id: p.id,
-      home_operator: p.home_operator,
+      home_principal: p.home_principal,
       home_stack: p.home_stack,
       role: p.role,
       trust: p.trust,

--- a/src/common/policy/types.ts
+++ b/src/common/policy/types.ts
@@ -34,12 +34,11 @@ export interface Principal {
    */
   id: string;
   /**
-   * Operator that owns this principal. Same value across all
-   * principals in a single-operator deployment; varies across
-   * principals once Phase D federation lands and the registry
-   * spans multiple operators.
+   * The owning principal (the human running the stack). Same value
+   * across all entries in a single-principal deployment; varies once
+   * Phase D federation lands and the registry spans multiple principals.
    */
-  home_operator: string;
+  home_principal: string;
   /**
    * Stack identity in `{operator_id}/{stack_id}` form (Phase A.5
    * Q7 lock-in). The stack a principal calls "home" — bus

--- a/src/common/substrates/types.ts
+++ b/src/common/substrates/types.ts
@@ -411,7 +411,7 @@ export interface DispatchRequest {
    * Shape mirrors `src/common/policy/types.ts` Principal. We import
    * the type from there to keep the engine and the harness on one
    * definition of "who is acting" — the harness can read
-   * `principal.home_operator` / `home_stack` for sovereignty-aware
+   * `principal.home_principal` / `home_stack` for sovereignty-aware
    * substrate decisions without re-parsing the envelope.
    */
   principal?: Principal;

--- a/src/common/types/cortex-config.ts
+++ b/src/common/types/cortex-config.ts
@@ -1203,15 +1203,14 @@ export const PolicyPrincipalSchema = z.object({
     "principal id must be lowercase alphanumeric + hyphen, starting with a letter (e.g. 'luna', 'echo')",
   ),
   /**
-   * Operator that owns this principal. Same letter-prefix
-   * grammar — `PrincipalConfigSchema.id` enforces it at the operator
-   * level and we mirror here so a parsed principal can't carry
-   * a malformed home_operator that downstream code would have
-   * to defend against.
+   * The owning principal id. Same letter-prefix grammar as a
+   * principal id (mirrors `PrincipalConfigSchema.id`), so a parsed
+   * entry can't carry a malformed home_principal that downstream
+   * code would have to defend against.
    */
-  home_operator: z.string().regex(
+  home_principal: z.string().regex(
     LETTER_PREFIX_ID_REGEX,
-    "principal.home_operator must match the operator id grammar (lowercase alphanumeric + hyphen, starting with a letter)",
+    "principal.home_principal must match the principal id grammar (lowercase alphanumeric + hyphen, starting with a letter)",
   ),
   /**
    * Stack identity in `{operator_id}/{stack_id}` form — same shape

--- a/src/runner/__tests__/dispatch-listener.test.ts
+++ b/src/runner/__tests__/dispatch-listener.test.ts
@@ -1072,7 +1072,7 @@ function engineGranting(capabilities: readonly string[]): PolicyEngine {
     principals: [
       {
         id: "cortex",
-        home_operator: "andreas",
+        home_principal: "andreas",
         home_stack: "andreas/research",
         role: ["operator"],
         trust: [],
@@ -1226,7 +1226,7 @@ describe("dispatch-listener — policy gating (C.3.1)", () => {
       principals: [
         {
           id: "cortex",
-          home_operator: "andreas",
+          home_principal: "andreas",
           home_stack: "andreas/research",
           role: ["operator"],
           trust: [],
@@ -1443,7 +1443,7 @@ describe("dispatch-listener — policy gating (C.3.1)", () => {
       principals: [
         {
           id: "cortex",
-          home_operator: "andreas",
+          home_principal: "andreas",
           home_stack: homeStack,
           role: ["operator"],
           trust: [],
@@ -2179,7 +2179,7 @@ describe("dispatch-listener — originator (cortex#346 / myelin#161)", () => {
       principals: [
         {
           id: "alice",
-          home_operator: "andreas",
+          home_principal: "andreas",
           home_stack: "andreas/research",
           role: ["operator"],
           trust: [],
@@ -2241,7 +2241,7 @@ describe("dispatch-listener — originator (cortex#346 / myelin#161)", () => {
       principals: [
         {
           id: "cortex",
-          home_operator: "andreas",
+          home_principal: "andreas",
           home_stack: "andreas/research",
           role: ["operator"],
           trust: [],
@@ -2296,7 +2296,7 @@ describe("dispatch-listener — originator (cortex#346 / myelin#161)", () => {
       principals: [
         {
           id: "cortex",
-          home_operator: "andreas",
+          home_principal: "andreas",
           home_stack: "andreas/research",
           role: ["operator"],
           trust: [],


### PR DESCRIPTION
## Summary

The **policy-config half** of PR-R2.J (cortex#448): single-cut breaking rename of the `home_operator` field → `home_principal` in the policy schema and everything that emits/consumes it as config. **Cortex-internal — no wire or D1 change.** Part of cortex#436.

## Why this is split into two halves

There are **two distinct `home_operator` fields** in the codebase:

1. **Policy-config** (`PolicyPrincipal.home_operator`) — a `cortex.yaml` policy-schema field, validated by `cortex-config.ts`, emitted by `migrate-config-policy`, set in PolicyEngine fixtures. **This PR.**
2. **Ingest-sovereignty** (`SessionSovereignty.home_operator`) — `event-processor.ts` reads `event.sovereignty.home_operator`, which feeds the D1 `sessions.home_operator` column and the `?home_operator=` dashboard query-param. **Deferred** (see below).

They're independent structs that happen to share a name. Confirmed: `factory.ts` passes through the policy field; `dispatch-listener.test.ts` / `iaw-phase-d-integration.test.ts` build PolicyEngine `Principal` fixtures; the policy engine source never reads the field beyond declaration/validation.

## In scope (cluster A — renamed)

- `src/common/policy/types.ts` — `PolicyPrincipal.home_operator` → `home_principal` (+ docstring)
- `src/common/policy/factory.ts` — pass-through
- `src/common/types/cortex-config.ts` — Zod schema + doc comment + error message
- `src/cli/cortex/commands/migrate-config-policy.ts` + `migrate-config-lib.ts` — emit side + diagnostic
- Tests: `policy/__tests__/{factory,engine,resolve-access,policy-gate}.test.ts`, `runner/__tests__/dispatch-listener.test.ts`, `__tests__/iaw-phase-d-integration.test.ts`, `migrate-config-policy.test.ts`
- Doc-comments: `common/substrates/types.ts`, `services/network-registry/src/types.ts`

## Deferred to the #447 (PR-R2b) MC-worker single-cut

The **wire/D1 half** stays on `home_operator` in this PR and ships in the coordinated MC-worker cut with #447 (per the issue: *"Ships alongside PR-R2b for one coordinated MC-worker cut"*):

- `src/common/types.ts` (`SessionSovereignty`), `src/common/event-processor.ts`
- `src/surface/mc/worker/{schema.sql, migrations/0003 (historical), state.ts, ingest.ts}` + the new `0007_principal_rename.sql`

**Reason:** renaming the D1 column + the `?home_operator=` query-param now would break the dashboard before the frontend (#450 / R13d) and #447 land. #447 is currently gated on Luna's #438 (R7a, BotConfig→AgentConfig), so the MC-worker half waits with it.

## Cross-review

Per the issue, requesting cross-layer review from @mellanon on the policy-types portion.

## Acceptance criteria (this half)

- [x] `grep -rn home_operator src/` returns hits ONLY in the deferred cluster-B paths (`common/types.ts`, `event-processor.ts` + its test, `worker/*`)
- [x] `bun test src/common/policy/ migrate-config-policy.test dispatch-listener.test iaw-phase-d-integration.test` → 178 pass, 0 fail
- [x] `bunx tsc --noEmit` clean
- [ ] @mellanon policy-types cross-review

## Note

This is a **breaking config-schema change**: an existing `cortex.yaml` with `principal.home_operator` now fails Zod validation. `migrate-config` emits the new `home_principal` name; no runtime config-data migration (config is regenerated). The D1-data migration (`0007`) belongs to the deferred wire half.

**Part of #448 — policy-half only. #448 stays open for the wire/D1 half (ships with #447).**