### PR TITLE
feat(cortex): C-7a — BotConfig → AgentConfig + 38-importer cascade (closes #438)

### DIFF
--- a/src/__tests__/cortex.capability-boot.test.ts
+++ b/src/__tests__/cortex.capability-boot.test.ts
@@ -20,7 +20,7 @@
  *      bucket dedup is the consumer's job per §3.3).
  *
  * Test infrastructure mirrors `cortex.test.ts`:
- *   - `minimalConfig` factory for a NATS-absent BotConfig.
+ *   - `minimalConfig` factory for a NATS-absent AgentConfig.
  *   - `createRecordingRuntime` factory — same `Set<EnvelopeHandler>`-based
  *     fake the surface-router tests already use; `published` array captures
  *     every envelope that landed on `runtime.publish`.
@@ -34,7 +34,7 @@ import { describe, expect, test } from "bun:test";
 import { mkdtempSync, rmSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
-import { BotConfigSchema, type BotConfig } from "../common/types/config";
+import { AgentConfigSchema, type AgentConfig } from "../common/types/config";
 import type { Agent, AgentRuntime } from "../common/types/cortex-config";
 import { startCortex } from "../cortex";
 import { CAPABILITY_REGISTERED_EVENT_TYPE } from "../bus";
@@ -48,8 +48,8 @@ import type { EnvelopeHandler, MyelinRuntime } from "../bus/myelin/runtime";
 // independently editable).
 // ---------------------------------------------------------------------------
 
-function minimalConfig(overrides: Partial<Record<string, unknown>> = {}): BotConfig {
-  return BotConfigSchema.parse({
+function minimalConfig(overrides: Partial<Record<string, unknown>> = {}): AgentConfig {
+  return AgentConfigSchema.parse({
     agent: {
       name: "test-cortex",
       displayName: "TestCortex",

--- a/src/__tests__/cortex.review-consumer-boot.test.ts
+++ b/src/__tests__/cortex.review-consumer-boot.test.ts
@@ -23,7 +23,7 @@
  * subscription-deferral gap flagged by Architect REQUEST-CHANGES on PR-6).
  *
  * Test infrastructure mirrors `cortex.capability-boot.test.ts`:
- *   - `minimalConfig` factory for a NATS-absent BotConfig.
+ *   - `minimalConfig` factory for a NATS-absent AgentConfig.
  *   - `createRecordingRuntime` factory — same shape as the capability-boot
  *     test's recorder so reviewers see one pattern.
  *   - `inlineAgents` injected via `StartCortexOptions.inlineAgents`.
@@ -35,7 +35,7 @@ import { describe, expect, test } from "bun:test";
 import { mkdtempSync, rmSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
-import { BotConfigSchema, type BotConfig } from "../common/types/config";
+import { AgentConfigSchema, type AgentConfig } from "../common/types/config";
 import type { Agent, AgentRuntime } from "../common/types/cortex-config";
 import { startCortex } from "../cortex";
 import type { Envelope } from "../bus/myelin/envelope-validator";
@@ -52,8 +52,8 @@ import type { MyelinSubscriber } from "../bus/myelin/subscriber";
 // coupling per the same rationale documented in the capability-boot helper.
 // ---------------------------------------------------------------------------
 
-function minimalConfig(overrides: Partial<Record<string, unknown>> = {}): BotConfig {
-  return BotConfigSchema.parse({
+function minimalConfig(overrides: Partial<Record<string, unknown>> = {}): AgentConfig {
+  return AgentConfigSchema.parse({
     agent: {
       name: "test-cortex",
       displayName: "TestCortex",

--- a/src/__tests__/cortex.review-session-opts.test.ts
+++ b/src/__tests__/cortex.review-session-opts.test.ts
@@ -16,12 +16,12 @@
  */
 
 import { describe, expect, test } from "bun:test";
-import { BotConfigSchema, type BotConfig } from "../common/types/config";
+import { AgentConfigSchema, type AgentConfig } from "../common/types/config";
 import type { Agent } from "../common/types/cortex-config";
 import { buildReviewSessionOpts } from "../cortex";
 
-function configWith(claudeOverrides: Partial<BotConfig["claude"]>): BotConfig {
-  return BotConfigSchema.parse({
+function configWith(claudeOverrides: Partial<AgentConfig["claude"]>): AgentConfig {
+  return AgentConfigSchema.parse({
     agent: {
       name: "test-cortex",
       displayName: "TestCortex",

--- a/src/__tests__/cortex.stack-signing-boot.test.ts
+++ b/src/__tests__/cortex.stack-signing-boot.test.ts
@@ -24,7 +24,7 @@ import { join } from "path";
 import { tmpdir } from "os";
 import { createUser } from "nkeys.js";
 
-import { BotConfigSchema, type BotConfig } from "../common/types/config";
+import { AgentConfigSchema, type AgentConfig } from "../common/types/config";
 import { startCortex } from "../cortex";
 import type { Envelope } from "../bus/myelin/envelope-validator";
 import type { EnvelopeHandler, MyelinRuntime } from "../bus/myelin/runtime";
@@ -33,8 +33,8 @@ import type { EnvelopeHandler, MyelinRuntime } from "../bus/myelin/runtime";
 // Helpers — kept local-to-this-file so the test stays self-contained.
 // ---------------------------------------------------------------------------
 
-function minimalConfig(): BotConfig {
-  return BotConfigSchema.parse({
+function minimalConfig(): AgentConfig {
+  return AgentConfigSchema.parse({
     agent: {
       name: "test-cortex",
       displayName: "TestCortex",

--- a/src/__tests__/cortex.test.ts
+++ b/src/__tests__/cortex.test.ts
@@ -15,7 +15,7 @@
  *      observe the adapter's `render` is invoked, all without real I/O).
  *
  * No real Discord / Mattermost / NATS network is touched. Tests inject the
- * minimum BotConfig shape and rely on:
+ * minimum AgentConfig shape and rely on:
  *   - `nats?` absent → runtime starts in disabled mode (no socket).
  *   - `discord: []` and `mattermost: []` → no adapter `start()` calls.
  *   - `api.enabled: false` → no Hono server bound.
@@ -27,7 +27,7 @@ import { describe, expect, test } from "bun:test";
 import { mkdtempSync, writeFileSync, rmSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
-import { BotConfigSchema, type BotConfig } from "../common/types/config";
+import { AgentConfigSchema, type AgentConfig } from "../common/types/config";
 import type { Agent } from "../common/types/cortex-config";
 import { pidFileFor, runDryRun, startCortex } from "../cortex";
 import type { Envelope } from "../bus/myelin/envelope-validator";
@@ -38,14 +38,14 @@ import type { EnvelopeHandler, MyelinRuntime } from "../bus/myelin/runtime";
 // ---------------------------------------------------------------------------
 
 /**
- * Minimum BotConfig that passes Zod validation. Discord + Mattermost arrays
+ * Minimum AgentConfig that passes Zod validation. Discord + Mattermost arrays
  * are empty; networks is empty (so cloud publisher stays inactive); api is
  * disabled; nats is absent so the runtime stays in no-op mode.
  *
  * Tests that need extra fields layer them on with the spread argument.
  */
-function minimalConfig(overrides: Partial<Record<string, unknown>> = {}): BotConfig {
-  return BotConfigSchema.parse({
+function minimalConfig(overrides: Partial<Record<string, unknown>> = {}): AgentConfig {
+  return AgentConfigSchema.parse({
     agent: {
       name: "test-cortex",
       displayName: "TestCortex",
@@ -370,7 +370,7 @@ describe("startCortex — wire-up", () => {
     const runtime = createRecordingRuntime();
     const config = minimalConfig({
       mattermost: [
-        // Construct via cast: BotConfigSchema would reject a fully empty
+        // Construct via cast: AgentConfigSchema would reject a fully empty
         // instance, but loadConfig in the wild may receive partials from
         // legacy/typo'd YAML. We test the runtime guard rather than the
         // schema guard here.
@@ -529,7 +529,7 @@ describe("startCortex — error surface", () => {
 
 describe("startCortex — agent registry (cortex#67 prereq C)", () => {
   test("exposes an empty registry when no inline agents + agents.d/ is empty", async () => {
-    // Production callers today pass BotConfig (no inline agents) and may have
+    // Production callers today pass AgentConfig (no inline agents) and may have
     // no `agents.d/` directory yet. The registry must still construct cleanly
     // and the handle must surface it — the creds handler downstream will
     // simply gate itself off (`registry.size > 0` check).

--- a/src/__tests__/principal-identity-consistency.test.ts
+++ b/src/__tests__/principal-identity-consistency.test.ts
@@ -6,8 +6,8 @@
  * `{principal}` subject segment inside `src/cortex.ts` was sourced
  * independently from `config.agent.operatorId ?? "default"`. That
  * pattern survived the v3 vocabulary cutover (cortex#388 / v3.0.0
- * BREAKING) because the cortex.yaml → BotConfig loader synthesised
- * `agent.operatorId` from `principal.id` — so the BotConfig path "just
+ * BREAKING) because the cortex.yaml → AgentConfig loader synthesised
+ * `agent.operatorId` from `principal.id` — so the AgentConfig path "just
  * worked" while pretending the legacy field was still authoritative.
  *
  * The hidden failure mode: a single missed substitution (or a future
@@ -58,7 +58,7 @@
  */
 
 import { describe, expect, test } from "bun:test";
-import { BotConfigSchema, type BotConfig } from "../common/types/config";
+import { AgentConfigSchema, type AgentConfig } from "../common/types/config";
 import { startCortex } from "../cortex";
 import type { Envelope } from "../bus/myelin/envelope-validator";
 import type {
@@ -66,12 +66,12 @@ import type {
   MyelinRuntime,
 } from "../bus/myelin/runtime";
 
-// A minimal BotConfig — NATS absent so the runtime stays in no-op mode
+// A minimal AgentConfig — NATS absent so the runtime stays in no-op mode
 // and no real socket is opened. `agent.operatorId` is intentionally
 // DIFFERENT from the `options.operator.id` supplied below so the test
 // proves `resolvePrincipalId` prefers the v3 canonical path.
-function minimalConfig(overrides: Partial<Record<string, unknown>> = {}): BotConfig {
-  return BotConfigSchema.parse({
+function minimalConfig(overrides: Partial<Record<string, unknown>> = {}): AgentConfig {
+  return AgentConfigSchema.parse({
     agent: {
       name: "test-cortex",
       displayName: "TestCortex",
@@ -330,7 +330,7 @@ describe("principal-identity consistency (cortex#427 PR-A)", () => {
   });
 
   test("empty-string `agent.operatorId` is treated as missing (no silent `\"\"` subject)", async () => {
-    // BotConfig allows `agent.operatorId` to be omitted; some legacy
+    // AgentConfig allows `agent.operatorId` to be omitted; some legacy
     // configs may have it set to an empty string after a botched
     // migration. The resolver must treat `""` the same as undefined
     // — otherwise the subject would render as `local..tasks.*.>`

--- a/src/__tests__/review-roundtrip.integration.test.ts
+++ b/src/__tests__/review-roundtrip.integration.test.ts
@@ -20,7 +20,7 @@ import {
   type NatsConnection,
   type Subscription,
 } from "nats";
-import type { BotConfig } from "../common/types/config";
+import type { AgentConfig } from "../common/types/config";
 import type { Envelope } from "../bus/myelin/envelope-validator";
 import {
   startMyelinRuntime,
@@ -70,7 +70,7 @@ const VALID_PAYLOAD: ReviewRequestPayload = {
   cycle: 1,
 };
 
-function makeConfig(url: string): BotConfig {
+function makeConfig(url: string): AgentConfig {
   return {
     agent: {
       name: "cortex",
@@ -84,7 +84,7 @@ function makeConfig(url: string): BotConfig {
       name: "cortex-review-roundtrip-test",
       subjects: [],
     },
-  } as unknown as BotConfig;
+  } as unknown as AgentConfig;
 }
 
 const stubCcFactory: CCSessionFactory = () => {

--- a/src/adapters/discord/__tests__/update-config.test.ts
+++ b/src/adapters/discord/__tests__/update-config.test.ts
@@ -20,7 +20,7 @@
 
 import { describe, expect, test, beforeEach, afterEach } from "bun:test";
 import { DiscordAdapter, type DiscordAdapterInfra } from "../index";
-import type { BotConfig } from "../../../common/types/config";
+import type { AgentConfig } from "../../../common/types/config";
 import type { Agent, DiscordPresence } from "../../../common/types/cortex-config";
 
 let originalLog: typeof console.log;
@@ -64,14 +64,14 @@ function makeAgent(presence: DiscordPresence, overrides: Partial<Agent> = {}): A
   };
 }
 
-function makeBotConfig(overrides: Partial<{
+function makeAgentConfig(overrides: Partial<{
   name: string;
   displayName: string;
   guildId: string;
   contextDepth: number;
   defaultRole: string;
   token: string;
-}> = {}): BotConfig {
+}> = {}): AgentConfig {
   return {
     agent: {
       name: overrides.name ?? "luna",
@@ -88,7 +88,7 @@ function makeBotConfig(overrides: Partial<{
         defaultRole: overrides.defaultRole ?? "allow-all",
       },
     ],
-  } as unknown as BotConfig;
+  } as unknown as AgentConfig;
 }
 
 function makeAdapter(overrides: { presence?: Partial<DiscordPresence> } = {}) {
@@ -111,11 +111,11 @@ function getAgent(adapter: DiscordAdapter): Agent {
 describe("DiscordAdapter.updateConfig", () => {
   test("matches the live presence by guildId (not instanceId)", () => {
     // The adapter was constructed with instanceId="luna-discord-guild-1".
-    // A BotConfig whose discord[].instanceId is something else (or omitted)
+    // A AgentConfig whose discord[].instanceId is something else (or omitted)
     // but whose guildId matches MUST still hot-reload — the match key is
     // guildId, not instanceId.
     const adapter = makeAdapter();
-    const newConfig = makeBotConfig({ contextDepth: 99 });
+    const newConfig = makeAgentConfig({ contextDepth: 99 });
     // intentionally do NOT carry an `instanceId` field on the new entry.
     adapter.updateConfig(newConfig);
     expect(getPresence(adapter).contextDepth).toBe(99);
@@ -125,7 +125,7 @@ describe("DiscordAdapter.updateConfig", () => {
     const adapter = makeAdapter();
     const before = getPresence(adapter);
     // Update arrives for a different guild — must be ignored, no mutation.
-    adapter.updateConfig(makeBotConfig({ guildId: "guild-NOT-MATCHING", contextDepth: 99 }));
+    adapter.updateConfig(makeAgentConfig({ guildId: "guild-NOT-MATCHING", contextDepth: 99 }));
     expect(getPresence(adapter)).toBe(before);
     expect(getPresence(adapter).contextDepth).toBe(5);
   });
@@ -135,7 +135,7 @@ describe("DiscordAdapter.updateConfig", () => {
     // New config carries a different token + a different contextDepth.
     // contextDepth is hot-reload safe and must update; token is reconnect-only
     // and must NOT be overwritten in-place.
-    adapter.updateConfig(makeBotConfig({ token: "rotated-token", contextDepth: 42 }));
+    adapter.updateConfig(makeAgentConfig({ token: "rotated-token", contextDepth: 42 }));
     expect(getPresence(adapter).contextDepth).toBe(42);
     expect(getPresence(adapter).token).toBe("initial-token");
   });
@@ -143,7 +143,7 @@ describe("DiscordAdapter.updateConfig", () => {
   test("rebuilds presence via immutable spread (new object reference)", () => {
     const adapter = makeAdapter();
     const before = getPresence(adapter);
-    adapter.updateConfig(makeBotConfig({ contextDepth: 7 }));
+    adapter.updateConfig(makeAgentConfig({ contextDepth: 7 }));
     const after = getPresence(adapter);
     expect(after).not.toBe(before);
     // Reconnect-only fields preserved across the spread.
@@ -155,7 +155,7 @@ describe("DiscordAdapter.updateConfig", () => {
 
   test("rebuilds agent with fresh presence reference (Holly cycle 1 invariant)", () => {
     const adapter = makeAdapter();
-    adapter.updateConfig(makeBotConfig({ contextDepth: 11 }));
+    adapter.updateConfig(makeAgentConfig({ contextDepth: 11 }));
     const agentAfter = getAgent(adapter);
     const presenceAfter = getPresence(adapter);
     // agent.presence.discord must be the SAME object as this.presence,
@@ -166,7 +166,7 @@ describe("DiscordAdapter.updateConfig", () => {
 
   test("agent id + displayName reflect updated botConfig.agent", () => {
     const adapter = makeAdapter();
-    adapter.updateConfig(makeBotConfig({ name: "luna-rebranded", displayName: "Luna v2" }));
+    adapter.updateConfig(makeAgentConfig({ name: "luna-rebranded", displayName: "Luna v2" }));
     const agentAfter = getAgent(adapter);
     expect(agentAfter.id).toBe("luna-rebranded");
     expect(agentAfter.displayName).toBe("Luna v2");

--- a/src/adapters/discord/client.ts
+++ b/src/adapters/discord/client.ts
@@ -45,7 +45,7 @@ export interface DiscordClientResult {
 /**
  * Display-only metadata stamped into the connection-ready log lines.
  *
- * MIG-7.2c-discord-cleanup: replaces the previous `BotConfig` parameter so
+ * MIG-7.2c-discord-cleanup: replaces the previous `AgentConfig` parameter so
  * `createDiscordClient` no longer reaches across the whole config tree to
  * print a `Agent: …` / `Guild(s): …` line. The cortex-config agent /
  * presence model is one Discord presence per agent, so `guildId` is a

--- a/src/adapters/discord/index.ts
+++ b/src/adapters/discord/index.ts
@@ -14,7 +14,7 @@ import type {
   OutboundFile,
   ContextMessage,
 } from "../types";
-import type { BotConfig } from "../../common/types/config";
+import type { AgentConfig } from "../../common/types/config";
 import type { Agent, DiscordPresence } from "../../common/types/cortex-config";
 import { createDiscordClient, isMentionForBot, extractContent, type ConnectionHealth } from "./client";
 import { fetchContext } from "./context-fetcher";
@@ -62,7 +62,7 @@ import { parseReviewWireFormat, reviewThreadName } from "./wire-format";
  */
 export interface DiscordAdapterInfra {
   /** Surface-router + log-prefix key. Cortex derives `${agent.id}-discord-${guildId}` while
-   * BotConfig.discord[] still permits multiple entries per agent.name; collapses to
+   * AgentConfig.discord[] still permits multiple entries per agent.name; collapses to
    * `${agent.id}-discord` at MIG-7.2e when migrate-config emits a real agents[] array. */
   instanceId: string;
   /** Operator's platform identity. Architecture §9.1: the operator runs the cortex
@@ -638,14 +638,14 @@ export class DiscordAdapter implements PlatformAdapter {
    * F-092: Hot-reload safe config fields.
    * Only updates fields that don't require reconnection.
    *
-   * MIG-7.2c-discord-flip: still takes `BotConfig` since the bot.yaml watch
+   * MIG-7.2c-discord-flip: still takes `AgentConfig` since the bot.yaml watch
    * pipeline upstream of this method hasn't been migrated yet. The matching
    * key is the immutable `guildId` (token/agentChannelId/logChannelId are
    * reconnect-only and must not change in a hot-reload). Updates are applied
    * via immutable replacement so downstream readers can rely on
    * structural-identity changes signalling a config refresh.
    */
-  updateConfig(config: BotConfig): void {
+  updateConfig(config: AgentConfig): void {
     const newInstance = config.discord.find((inst) => inst.guildId === this.presence.guildId);
 
     if (!newInstance) {

--- a/src/adapters/mattermost/__tests__/update-config.test.ts
+++ b/src/adapters/mattermost/__tests__/update-config.test.ts
@@ -21,7 +21,7 @@
 
 import { describe, expect, test, beforeEach, afterEach } from "bun:test";
 import { MattermostAdapter, type MattermostAdapterInfra } from "../index";
-import type { BotConfig } from "../../../common/types/config";
+import type { AgentConfig } from "../../../common/types/config";
 import type { Agent, MattermostPresence } from "../../../common/types/cortex-config";
 
 let originalLog: typeof console.log;
@@ -62,7 +62,7 @@ function makeAgent(presence: MattermostPresence): Agent {
   };
 }
 
-function makeBotConfig(overrides: Partial<{
+function makeAgentConfig(overrides: Partial<{
   name: string;
   displayName: string;
   apiUrl: string;
@@ -72,7 +72,7 @@ function makeBotConfig(overrides: Partial<{
   defaultRole: string;
   allowedUsers: string[];
   triggerWord: string;
-}> = {}): BotConfig {
+}> = {}): AgentConfig {
   return {
     agent: {
       name: overrides.name ?? "luna",
@@ -89,7 +89,7 @@ function makeBotConfig(overrides: Partial<{
         ...(overrides.triggerWord !== undefined && { triggerWord: overrides.triggerWord }),
       },
     ],
-  } as unknown as BotConfig;
+  } as unknown as AgentConfig;
 }
 
 function makeAdapter(overrides: { presence?: Partial<MattermostPresence> } = {}) {
@@ -112,21 +112,21 @@ function getAgent(adapter: MattermostAdapter): Agent {
 describe("MattermostAdapter.updateConfig", () => {
   test("matches the live presence by apiUrl (the immutable disambiguator)", () => {
     const adapter = makeAdapter();
-    adapter.updateConfig(makeBotConfig({ channels: ["c-new"] }));
+    adapter.updateConfig(makeAgentConfig({ channels: ["c-new"] }));
     expect(getPresence(adapter).channels).toEqual(["c-new"]);
   });
 
   test("skips update when no mattermost entry matches the live apiUrl", () => {
     const adapter = makeAdapter();
     const before = getPresence(adapter);
-    adapter.updateConfig(makeBotConfig({ apiUrl: "https://OTHER.example", channels: ["c-new"] }));
+    adapter.updateConfig(makeAgentConfig({ apiUrl: "https://OTHER.example", channels: ["c-new"] }));
     expect(getPresence(adapter)).toBe(before);
     expect(getPresence(adapter).channels).toEqual(["c-initial"]);
   });
 
   test("applies only hot-reload-safe fields to presence (apiToken reconnect-only stays)", () => {
     const adapter = makeAdapter();
-    adapter.updateConfig(makeBotConfig({ apiToken: "rotated-token", channels: ["c-new"] }));
+    adapter.updateConfig(makeAgentConfig({ apiToken: "rotated-token", channels: ["c-new"] }));
     expect(getPresence(adapter).channels).toEqual(["c-new"]);
     // apiToken is reconnect-only — the presence still holds the initial value.
     expect(getPresence(adapter).apiToken).toBe("initial-token");
@@ -135,7 +135,7 @@ describe("MattermostAdapter.updateConfig", () => {
   test("rebuilds presence via immutable spread (new object reference)", () => {
     const adapter = makeAdapter();
     const before = getPresence(adapter);
-    adapter.updateConfig(makeBotConfig({ pollIntervalMs: 5000 }));
+    adapter.updateConfig(makeAgentConfig({ pollIntervalMs: 5000 }));
     const after = getPresence(adapter);
     expect(after).not.toBe(before);
     expect(after.apiUrl).toBe(before.apiUrl);
@@ -144,7 +144,7 @@ describe("MattermostAdapter.updateConfig", () => {
 
   test("rebuilds agent with fresh presence reference (Holly #46 cycle 1 invariant)", () => {
     const adapter = makeAdapter();
-    adapter.updateConfig(makeBotConfig({ pollIntervalMs: 7000 }));
+    adapter.updateConfig(makeAgentConfig({ pollIntervalMs: 7000 }));
     const agentAfter = getAgent(adapter);
     const presenceAfter = getPresence(adapter);
     expect(agentAfter.presence.mattermost).toBe(presenceAfter);
@@ -153,7 +153,7 @@ describe("MattermostAdapter.updateConfig", () => {
 
   test("agent id + displayName reflect updated botConfig.agent", () => {
     const adapter = makeAdapter();
-    adapter.updateConfig(makeBotConfig({ name: "luna-rebranded", displayName: "Luna v2" }));
+    adapter.updateConfig(makeAgentConfig({ name: "luna-rebranded", displayName: "Luna v2" }));
     const agentAfter = getAgent(adapter);
     expect(agentAfter.id).toBe("luna-rebranded");
     expect(agentAfter.displayName).toBe("Luna v2");
@@ -161,7 +161,7 @@ describe("MattermostAdapter.updateConfig", () => {
 
   test("triggerWord update propagates when set", () => {
     const adapter = makeAdapter();
-    adapter.updateConfig(makeBotConfig({ triggerWord: "@luna" }));
+    adapter.updateConfig(makeAgentConfig({ triggerWord: "@luna" }));
     expect(getPresence(adapter).triggerWord).toBe("@luna");
   });
 });

--- a/src/adapters/mattermost/index.ts
+++ b/src/adapters/mattermost/index.ts
@@ -13,7 +13,7 @@ import type {
   OutboundFile,
   ContextMessage,
 } from "../types";
-import type { BotConfig } from "../../common/types/config";
+import type { AgentConfig } from "../../common/types/config";
 import type { Agent, MattermostPresence } from "../../common/types/cortex-config";
 import type { MattermostInboundMessage } from "./server";
 import {
@@ -205,7 +205,7 @@ export class MattermostAdapter implements PlatformAdapter {
    * `apiUrl`/`apiToken`/`webhookUrl` are reconnect-only and intentionally
    * preserved across the immutable spread.
    */
-  updateConfig(config: BotConfig): void {
+  updateConfig(config: AgentConfig): void {
     const newInstance = config.mattermost.find((inst) => inst.apiUrl === this.apiUrl);
 
     if (!newInstance) {

--- a/src/adapters/mattermost/server.ts
+++ b/src/adapters/mattermost/server.ts
@@ -3,7 +3,7 @@
  * Receives outgoing webhook POSTs from Mattermost, extracts messages.
  */
 
-import type { BotConfig } from "../../common/types/config";
+import type { AgentConfig } from "../../common/types/config";
 import type { Server } from "bun";
 
 /**
@@ -93,7 +93,7 @@ export function parseWebhookPayload(
  * Returns a Bun server and a cleanup function.
  */
 export function createMattermostServer(
-  config: BotConfig,
+  config: AgentConfig,
   onMessage: (msg: MattermostInboundMessage) => Promise<string>
 ): { server: Server<unknown>; stop: () => void } {
   const mm = config.mattermost[0]; // Instance-scoped config

--- a/src/adapters/slack/__tests__/slack-adapter.test.ts
+++ b/src/adapters/slack/__tests__/slack-adapter.test.ts
@@ -1019,15 +1019,15 @@ describe("SlackAdapter — system.adapter.* envelopes (cortex#235 r1#4)", () => 
 // cortex#235 r1#5 — updateConfig hot-reload
 // ---------------------------------------------------------------------------
 
-import type { BotConfig } from "../../../common/types/config";
+import type { AgentConfig } from "../../../common/types/config";
 
 describe("SlackAdapter.updateConfig — F-092 hot-reload (cortex#235 r1#5)", () => {
   /**
-   * Minimal BotConfig fixture with a single Slack instance. Mirrors the
+   * Minimal AgentConfig fixture with a single Slack instance. Mirrors the
    * Discord/Mattermost test pattern. Only the fields we care about for
    * hot-reload need realistic values; others get cheap defaults.
    */
-  function makeBotConfig(slackOverrides: Partial<BotConfig["slack"][number]> = {}): BotConfig {
+  function makeAgentConfig(slackOverrides: Partial<AgentConfig["slack"][number]> = {}): AgentConfig {
     return {
       agent: { name: "luna", displayName: "Luna" },
       discord: [],
@@ -1044,17 +1044,17 @@ describe("SlackAdapter.updateConfig — F-092 hot-reload (cortex#235 r1#5)", () 
         surfaceSubjects: [],
         ...slackOverrides,
       }],
-      claude: {} as BotConfig["claude"],
+      claude: {} as AgentConfig["claude"],
     // Adapter's `updateConfig` only reads `config.slack[i]` and
-    // `config.agent`; the rest of the BotConfig surface
+    // `config.agent`; the rest of the AgentConfig surface
     // (attachments/execution/github/api/etc.) is unused here. Cast
     // through unknown for test ergonomics.
-    } as unknown as BotConfig;
+    } as unknown as AgentConfig;
   }
 
   test("matches the live presence by workspaceId and hot-reloads channels", () => {
     const { adapter } = makeAdapter();
-    const updated = makeBotConfig({
+    const updated = makeAgentConfig({
       channels: [
         { id: "C0CHANNEL1", name: "cortex" },
         { id: "C0CHANNEL2", name: "research" },
@@ -1074,7 +1074,7 @@ describe("SlackAdapter.updateConfig — F-092 hot-reload (cortex#235 r1#5)", () 
 
   test("hot-reloads allowedUserIds", () => {
     const { adapter } = makeAdapter();
-    const updated = makeBotConfig({ allowedUserIds: ["U0NEW1", "U0NEW2"] });
+    const updated = makeAgentConfig({ allowedUserIds: ["U0NEW1", "U0NEW2"] });
     adapter.updateConfig(updated);
     expect((adapter as unknown as { agent: Agent }).agent.presence.slack?.allowedUserIds).toEqual(["U0NEW1", "U0NEW2"]);
   });
@@ -1086,7 +1086,7 @@ describe("SlackAdapter.updateConfig — F-092 hot-reload (cortex#235 r1#5)", () 
     adapter.attachInboundDispatch();
     // Update to add a trusted bot id; verify the bot-id message no
     // longer trips the self-loop guard.
-    adapter.updateConfig(makeBotConfig({ trustedBotIds: ["B0PEERBOT"] }));
+    adapter.updateConfig(makeAgentConfig({ trustedBotIds: ["B0PEERBOT"] }));
     expect((adapter as unknown as { agent: Agent }).agent.presence.slack?.trustedBotIds).toEqual(["B0PEERBOT"]);
     // Smoke: send a message FROM the peer bot id; should be admitted
     // (no longer dropped as self-loop).
@@ -1101,7 +1101,7 @@ describe("SlackAdapter.updateConfig — F-092 hot-reload (cortex#235 r1#5)", () 
     const originalWorkspaceId = (adapter as unknown as { agent: Agent }).agent.presence.slack?.workspaceId;
     // Pass an instance with rotated tokens — the match-by-workspaceId
     // still works, and the presence's tokens carry through unchanged.
-    adapter.updateConfig(makeBotConfig({
+    adapter.updateConfig(makeAgentConfig({
       botToken: "xoxb-ROTATED-IGNORED",
       appToken: "xapp-ROTATED-IGNORED",
       channels: [{ id: "C0CHANNEL1", name: "cortex" }],
@@ -1121,7 +1121,7 @@ describe("SlackAdapter.updateConfig — F-092 hot-reload (cortex#235 r1#5)", () 
     console.warn = (...args: unknown[]) => { warnings.push(args.map(String).join(" ")); };
     try {
       // No slack[] instance with our workspaceId.
-      adapter.updateConfig(makeBotConfig({ workspaceId: "T0DIFFERENT" }));
+      adapter.updateConfig(makeAgentConfig({ workspaceId: "T0DIFFERENT" }));
       // Presence unchanged — update was ignored (channels is a proxy for
       // "the hot-reload didn't touch this presence").
       expect((adapter as unknown as { agent: Agent }).agent.presence.slack?.channels).toEqual(originalChannels);
@@ -1134,7 +1134,7 @@ describe("SlackAdapter.updateConfig — F-092 hot-reload (cortex#235 r1#5)", () 
 
   test("rebuilds agent.id + agent.displayName from new config", () => {
     const { adapter } = makeAdapter();
-    const updated = makeBotConfig();
+    const updated = makeAgentConfig();
     updated.agent.name = "luna-rebranded";
     updated.agent.displayName = "Luna v2";
     adapter.updateConfig(updated);

--- a/src/adapters/slack/index.ts
+++ b/src/adapters/slack/index.ts
@@ -22,7 +22,7 @@ import type {
   ContextMessage,
 } from "../types";
 import type { Agent, SlackPresence } from "../../common/types/cortex-config";
-import type { BotConfig } from "../../common/types/config";
+import type { AgentConfig } from "../../common/types/config";
 import type { Envelope } from "../../bus/myelin/envelope-validator";
 import type { MyelinRuntime } from "../../bus/myelin/runtime";
 import type { SurfaceAdapter } from "../../bus/surface-router";
@@ -426,7 +426,7 @@ export class SlackAdapter implements PlatformAdapter {
    * 1).
    */
   // eslint-disable-next-line @typescript-eslint/require-await
-  updateConfig(config: BotConfig): void {
+  updateConfig(config: AgentConfig): void {
     const newInstance = config.slack.find((inst) => inst.workspaceId === this.presence.workspaceId);
     if (!newInstance) {
       console.warn(

--- a/src/bus/__tests__/dispatch-handler.test.ts
+++ b/src/bus/__tests__/dispatch-handler.test.ts
@@ -2,7 +2,7 @@ import { test, expect, describe, beforeEach, afterEach } from "bun:test";
 import { MockAdapter } from "../../adapters/mock";
 import { DispatchHandler } from "../dispatch-handler";
 import type { InboundMessage } from "../../adapters/types";
-import type { BotConfig } from "../../common/types/config";
+import type { AgentConfig } from "../../common/types/config";
 import type { Envelope } from "../myelin/envelope-validator";
 import type { MyelinRuntime } from "../myelin/runtime";
 import type { DispatchSourcePublishResult } from "../dispatch-source-publisher";
@@ -13,8 +13,8 @@ import type {
 } from "../../substrates/claude-code/harness";
 import type { CCSessionResult, CCSessionOpts } from "../../runner/cc-session";
 
-// Minimal config that satisfies BotConfig shape for testing
-function makeConfig(overrides: Partial<BotConfig> = {}): BotConfig {
+// Minimal config that satisfies AgentConfig shape for testing
+function makeConfig(overrides: Partial<AgentConfig> = {}): AgentConfig {
   return {
     agent: {
       name: "test-agent",
@@ -57,7 +57,7 @@ function makeConfig(overrides: Partial<BotConfig> = {}): BotConfig {
       logDir: "/tmp/grove-test/logs",
     },
     // Test-fixture completion: the grove-v2 source test pre-dates the addition of
-    // `github` and `networks` to BotConfig and crashes at construction time
+    // `github` and `networks` to AgentConfig and crashes at construction time
     // (`getAllRepos(config.github.repos)` on undefined). Filling the minimum schema
     // here so the lift's tests run; the runtime code is byte-identical to source.
     github: {
@@ -71,7 +71,7 @@ function makeConfig(overrides: Partial<BotConfig> = {}): BotConfig {
     },
     networks: [],
     ...overrides,
-  } as BotConfig;
+  } as AgentConfig;
 }
 
 function makeMsg(overrides: Partial<InboundMessage> = {}): InboundMessage {

--- a/src/bus/__tests__/network-resolver.test.ts
+++ b/src/bus/__tests__/network-resolver.test.ts
@@ -10,7 +10,7 @@ import {
   getNetworkForChannel,
   buildNetworkLookups,
 } from "../network-resolver";
-import type { BotConfig } from "../../common/types/config";
+import type { AgentConfig } from "../../common/types/config";
 import type { NetworkFile } from "../../common/types/config";
 
 // ---------------------------------------------------------------------------
@@ -33,7 +33,7 @@ function makeNetwork(id: string, overrides: Partial<NetworkFile> = {}): NetworkF
   };
 }
 
-function makeConfig(networks: NetworkFile[]): BotConfig {
+function makeConfig(networks: NetworkFile[]): AgentConfig {
   return {
     agent: { name: "test", displayName: "Test" },
     discord: networks.flatMap(n => n.discord),

--- a/src/bus/dispatch-handler.ts
+++ b/src/bus/dispatch-handler.ts
@@ -10,7 +10,7 @@ import { EventEmitter } from "events";
 import { basename } from "path";
 import { randomUUID } from "crypto";
 import { readFileSync } from "fs";
-import { type BotConfig, getAllRepos } from "../common/types/config";
+import { type AgentConfig, getAllRepos } from "../common/types/config";
 import type {
   PlatformAdapter,
   InboundMessage,
@@ -82,7 +82,7 @@ function getGroveVersion(): string {
 }
 
 export interface DispatchHandlerOpts {
-  config: BotConfig;
+  config: AgentConfig;
   securityPreamble: string;
   /** G-300: Relaxed preamble for operator DM (no bash guard, no filesystem restriction) */
   operatorDMPreamble?: string;
@@ -180,7 +180,7 @@ function formatToolProgress(toolName: string, input: Record<string, unknown>): s
 export class DispatchHandler extends EventEmitter {
   private sessions: SessionManager;
   private taskTracker: TaskTracker;
-  private config: BotConfig;
+  private config: AgentConfig;
   private allRepos: string[];
   private securityPreamble: string;
   private operatorDMPreamble: string;
@@ -462,7 +462,7 @@ export class DispatchHandler extends EventEmitter {
    * Called by ConfigWatcher when safe fields change.
    * Active sessions continue with their original config until completion.
    */
-  updateConfig(newConfig: BotConfig, configPath?: string): void {
+  updateConfig(newConfig: AgentConfig, configPath?: string): void {
     this.config = newConfig;
     this.allRepos = getAllRepos(newConfig);
     this.securityPreamble = buildSecurityPreamble(newConfig, configPath);
@@ -474,7 +474,7 @@ export class DispatchHandler extends EventEmitter {
   }
 
   /** Get current config (for watcher initialization) */
-  getConfig(): BotConfig {
+  getConfig(): AgentConfig {
     return this.config;
   }
 

--- a/src/bus/myelin/__tests__/runtime.test.ts
+++ b/src/bus/myelin/__tests__/runtime.test.ts
@@ -9,10 +9,10 @@
 
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 import type { NatsConnection, Subscription, Status } from "nats";
-import type { BotConfig } from "../../../common/types/config";
+import type { AgentConfig } from "../../../common/types/config";
 import { startMyelinRuntime } from "../runtime";
 
-function makeConfig(natsBlock: BotConfig["nats"]): BotConfig {
+function makeConfig(natsBlock: AgentConfig["nats"]): AgentConfig {
   return {
     agent: {
       name: "luna",
@@ -21,7 +21,7 @@ function makeConfig(natsBlock: BotConfig["nats"]): BotConfig {
       operatorName: "Andreas",
     },
     nats: natsBlock,
-  } as unknown as BotConfig;
+  } as unknown as AgentConfig;
 }
 
 function makeFakeNatsConnection() {

--- a/src/bus/myelin/runtime.ts
+++ b/src/bus/myelin/runtime.ts
@@ -14,7 +14,7 @@
  */
 
 import type { ConnectionOptions, NatsConnection } from "nats";
-import type { BotConfig } from "../../common/types/config";
+import type { AgentConfig } from "../../common/types/config";
 import { NatsLink } from "../nats/connection";
 import {
   MyelinSubscriber,
@@ -341,7 +341,7 @@ export function makeSubjectPlaceholderSubstituter(opts: {
 }
 
 export async function startMyelinRuntime(
-  config: BotConfig,
+  config: AgentConfig,
   options?: MyelinRuntimeOptions,
 ): Promise<MyelinRuntime> {
   // Fan-out registry — populated regardless of whether NATS itself

--- a/src/bus/network-resolver.ts
+++ b/src/bus/network-resolver.ts
@@ -10,7 +10,7 @@
  * and rebuilt on config reload. Never rebuilt per-message.
  */
 
-import type { BotConfig, NetworkConfig, NetworkResolver, NetworkFile } from "../common/types/config";
+import type { AgentConfig, NetworkConfig, NetworkResolver, NetworkFile } from "../common/types/config";
 
 // =============================================================================
 // Lookup Tables
@@ -22,7 +22,7 @@ export interface NetworkLookupTables {
   networksById: Map<string, NetworkFile>;
 }
 
-export function buildNetworkLookups(config: BotConfig): NetworkLookupTables {
+export function buildNetworkLookups(config: AgentConfig): NetworkLookupTables {
   const guildToNetwork = new Map<string, string>();
   const channelToNetwork = new Map<string, string>();
   const networksById = new Map<string, NetworkFile>();
@@ -53,13 +53,13 @@ let cachedLookups: NetworkLookupTables = {
   channelToNetwork: new Map(),
   networksById: new Map(),
 };
-let cachedConfig: BotConfig | null = null;
+let cachedConfig: AgentConfig | null = null;
 
 /**
  * Initialize (or rebuild) the cached lookup tables.
  * Call at startup and on config reload.
  */
-export function initNetworkLookups(config: BotConfig): void {
+export function initNetworkLookups(config: AgentConfig): void {
   cachedLookups = buildNetworkLookups(config);
   cachedConfig = config;
 }
@@ -69,7 +69,7 @@ export function initNetworkLookups(config: BotConfig): void {
  * This ensures correctness even if initNetworkLookups wasn't called,
  * while avoiding per-message Map rebuilds in the hot path.
  */
-function getLookups(config: BotConfig): NetworkLookupTables {
+function getLookups(config: AgentConfig): NetworkLookupTables {
   if (config !== cachedConfig) {
     initNetworkLookups(config);
   }
@@ -80,15 +80,15 @@ function getLookups(config: BotConfig): NetworkLookupTables {
 // Resolution Functions
 // =============================================================================
 
-export function getNetworkForGuild(guildId: string, config: BotConfig): string | undefined {
+export function getNetworkForGuild(guildId: string, config: AgentConfig): string | undefined {
   return getLookups(config).guildToNetwork.get(guildId);
 }
 
-export function getNetworkForChannel(channelId: string, config: BotConfig): string | undefined {
+export function getNetworkForChannel(channelId: string, config: AgentConfig): string | undefined {
   return getLookups(config).channelToNetwork.get(channelId);
 }
 
-export function createNetworkResolver(config: BotConfig): NetworkResolver {
+export function createNetworkResolver(config: AgentConfig): NetworkResolver {
   const tables = getLookups(config);
 
   return (networkId: string | undefined): NetworkConfig | null => {

--- a/src/cli/cortex/commands/migrate-config-lib.ts
+++ b/src/cli/cortex/commands/migrate-config-lib.ts
@@ -7,7 +7,7 @@
  *
  * Coupling boundary: this module imports the cortex-config Zod schema and
  * verifies its output round-trips through `.parse()`. It does NOT import the
- * legacy `BotConfigSchema` — the legacy file in the wild may carry fields
+ * legacy `AgentConfigSchema` — the legacy file in the wild may carry fields
  * (`personaFile`, `trustedAgentBots`) that were dropped from the in-repo
  * schema, so we accept input permissively and validate output strictly.
  */
@@ -44,7 +44,7 @@ import {
 /**
  * Legacy `bot.yaml` fields we accept. Not a Zod schema: real grove-v2
  * deployments may carry historical fields (`personaFile`, `trustedAgentBots`)
- * that no longer exist in `BotConfigSchema`. Accepting them as `unknown` lets
+ * that no longer exist in `AgentConfigSchema`. Accepting them as `unknown` lets
  * the converter translate them rather than fail at the input gate.
  */
 export interface LegacyAgent {
@@ -1737,7 +1737,7 @@ function buildAgentsFromCortexShape(
  * `paths:` block to their cortex equivalents (`~/.config/cortex/...`).
  *
  * cortex#88 item 1: legacy `bot.yaml` carries `paths.logDir:
- * ~/.config/grove/logs` (the BotConfigSchema default in production grove-v2).
+ * ~/.config/grove/logs` (the AgentConfigSchema default in production grove-v2).
  * Without rewriting, the emitted cortex.yaml ships a stale grove path that
  * any consumer of `config.paths.logDir` will then write to — even though
  * the launchd plist's `StandardOutPath` already points at

--- a/src/common/config/__tests__/loader.test.ts
+++ b/src/common/config/__tests__/loader.test.ts
@@ -288,7 +288,7 @@ describe("error reporting", () => {
 //
 // `loadConfigWithAgents` accepts both legacy bot.yaml and cortex.yaml. The
 // detection is structural (operator: object + agents: non-empty array). For
-// cortex shape, the loader synthesizes a legacy-compatible BotConfig and
+// cortex shape, the loader synthesizes a legacy-compatible AgentConfig and
 // returns the rich agents[] alongside via `inlineAgents` so `startCortex`
 // can route per-instance identity correctly.
 
@@ -338,19 +338,19 @@ describe("MIG-7.2e — cortex-shape detection + transform", () => {
     expect(loaded.inlineAgents[0]!.trust).toEqual(["luna"]);
   });
 
-  test("synthesizes BotConfig.agent from operator + first agent", () => {
+  test("synthesizes AgentConfig.agent from operator + first agent", () => {
     const path = writeCortexConfig(testDir, minimalCortex());
     const { config, operator } = loadConfigWithAgents(path);
     expect(config.agent.name).toBe("ivy");
     expect(config.agent.displayName).toBe("Ivy");
     expect(config.agent.operatorId).toBe("jc");
     expect(config.agent.operatorName).toBe("Jens-Christian");
-    // v2.0.0 (cortex#297) — operator*Id retired from BotConfig.agent;
+    // v2.0.0 (cortex#297) — operator*Id retired from AgentConfig.agent;
     // surfaced through LoadedConfig.operator instead.
     expect(operator?.discordId).toBe("285727653603049472");
   });
 
-  test("flattens agents[*].presence.discord into BotConfig.discord[]", () => {
+  test("flattens agents[*].presence.discord into AgentConfig.discord[]", () => {
     const cfg = minimalCortex();
     (cfg.agents as Record<string, unknown>[]).push({
       id: "holly",
@@ -423,11 +423,11 @@ describe("MIG-7.2e — cortex-shape detection + transform", () => {
     expect(loaded.config.agent.name).toBeDefined();
   });
 
-  test("loadConfig backward-compat wrapper still returns BotConfig only", () => {
+  test("loadConfig backward-compat wrapper still returns AgentConfig only", () => {
     const path = writeCortexConfig(testDir, minimalCortex());
     const cfg = loadConfig(path);
     expect(cfg.agent.name).toBe("ivy");
-    // Type sanity — no inlineAgents on the BotConfig
+    // Type sanity — no inlineAgents on the AgentConfig
     expect((cfg as Record<string, unknown>).inlineAgents).toBeUndefined();
   });
 
@@ -455,7 +455,7 @@ describe("MIG-7.2e — cortex-shape detection + transform", () => {
   test("operator-only with no agents falls back to legacy parse (detection requires both)", () => {
     const partial = { operator: { id: "jc" } };
     const path = writeCortexConfig(testDir, partial);
-    // Falls into the legacy branch; BotConfigSchema rejects missing agent.name
+    // Falls into the legacy branch; AgentConfigSchema rejects missing agent.name
     expect(() => loadConfigWithAgents(path)).toThrow();
   });
 
@@ -466,7 +466,7 @@ describe("MIG-7.2e — cortex-shape detection + transform", () => {
   });
 
   // cortex#98 (part A) — schema parity: `presence.discord.trustedBotIds`
-  // is preserved through the cortex-shape → legacy BotConfig synthesizer.
+  // is preserved through the cortex-shape → legacy AgentConfig synthesizer.
   // Before this fix, DiscordPresenceSchema lacked the field entirely and
   // zod's default unknown-key-strip behaviour silently dropped the
   // operator-set value during `CortexConfigSchema.parse`, leaving the
@@ -489,7 +489,7 @@ describe("MIG-7.2e — cortex-shape detection + transform", () => {
   });
 
   // cortex#205 — schema parity: `presence.discord.surfaceSubjects` is
-  // preserved through the cortex-shape → legacy BotConfig synthesizer so
+  // preserved through the cortex-shape → legacy AgentConfig synthesizer so
   // operators can wire bus-envelope subjects into the Discord adapter's
   // surface-router match set. Before this fix, the field was absent from
   // both DiscordPresenceSchema and DiscordInstanceSchema, so zod's
@@ -620,7 +620,7 @@ describe("MIG-7.2e — cortex-shape detection + transform", () => {
   });
 
   test("IAW A.5.3 — legacy bot.yaml input leaves LoadedConfig.stack undefined", () => {
-    // BotConfigSchema has no `stack:` field during the MIG-7.2 overlap
+    // AgentConfigSchema has no `stack:` field during the MIG-7.2 overlap
     // window. The legacy branch of `loadConfigWithAgents` must produce a
     // `LoadedConfig` with `stack: undefined` so the boot path's destructure
     // (`const { stack } = ...`) stays safe.

--- a/src/common/config/__tests__/watcher.test.ts
+++ b/src/common/config/__tests__/watcher.test.ts
@@ -7,9 +7,9 @@ import { writeFileSync, unlinkSync, existsSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 import { ConfigWatcher } from "../watcher";
-import type { BotConfig } from "../../types/config";
+import type { AgentConfig } from "../../types/config";
 
-const TEST_CONFIG: BotConfig = {
+const TEST_CONFIG: AgentConfig = {
   agent: {
     name: "test",
     displayName: "Test Bot",
@@ -395,7 +395,7 @@ paths:
 
   test("removing a repo from github.repos also applies as a safe field", async () => {
     // Seed with one repo so removal is a real change.
-    const seededConfig: BotConfig = {
+    const seededConfig: AgentConfig = {
       ...TEST_CONFIG,
       github: {
         ...TEST_CONFIG.github,

--- a/src/common/config/account-signing-key.ts
+++ b/src/common/config/account-signing-key.ts
@@ -13,7 +13,7 @@
  * laptop / server filesystem, the next-best mitigation is to refuse to load
  * it unless the file is chmod 600 (owner-only read/write). This loader
  * enforces that gate; the schema field (`nats.accountSigningKeyPath`) is
- * MIRRORed across `BotConfigSchema.nats` + `NatsConfigSchema` so both the
+ * MIRRORed across `AgentConfigSchema.nats` + `NatsConfigSchema` so both the
  * legacy bot.yaml shape and the post-MIG-7.2e cortex-config shape carry it.
  *
  * Behavior:
@@ -37,7 +37,7 @@
  *   - Hardware-backed signing (yubikey / TPM). Future work; the
  *     `loadAccountSigningKey` signature is the seam.
  *
- * MIRROR: schema field carried in both `BotConfigSchema.nats` + the
+ * MIRROR: schema field carried in both `AgentConfigSchema.nats` + the
  * canonical `NatsConfigSchema`. Drop legacy on MIG-7.2e.
  */
 

--- a/src/common/config/loader.ts
+++ b/src/common/config/loader.ts
@@ -9,7 +9,7 @@
 import { readFileSync, readdirSync, existsSync, statSync } from "fs";
 import { join, dirname, resolve, isAbsolute, basename } from "path";
 import { parse as parseYaml } from "yaml";
-import { BotConfigSchema, NetworkFileSchema, type BotConfig, type NetworkFile } from "../types/config";
+import { AgentConfigSchema, NetworkFileSchema, type AgentConfig, type NetworkFile } from "../types/config";
 import {
   AgentSchema,
   CortexConfigSchema,
@@ -58,26 +58,26 @@ export function expandTilde(p: string): string {
  * Result of `loadConfigWithAgents`. `inlineAgents` is non-empty when the
  * loader detected cortex-shape config (architecture §9.1 — `principal:` +
  * `agents:[]` instead of legacy `agent:` + flat `discord:[]`). The `config`
- * field is always a BotConfig — for cortex-shape input it's a synthesized
+ * field is always an AgentConfig — for cortex-shape input it's a synthesized
  * legacy-compatible projection so downstream consumers stay unchanged
  * during MIG-7. Callers that need the rich cortex shape use `inlineAgents`.
  *
  * `stack` (IAW Phase A.5, cortex#113): the optional top-level `stack:` block
  * from cortex-shape input, surfaced raw so the boot path can call
  * `deriveStackId` without re-parsing the file. Undefined for legacy bot.yaml
- * input (the block lives on `CortexConfigSchema` only — `BotConfigSchema` has
+ * input (the block lives on `CortexConfigSchema` only — `AgentConfigSchema` has
  * no equivalent during the MIG-7.2 overlap window). When the principal
  * declares `stack: { id: andreas/research }`, this field carries the
  * validated object; when the block is omitted, the field stays undefined and
  * `deriveStackId` default-derives `${principal.id}/default`.
  */
 export interface LoadedConfig {
-  config: BotConfig;
+  config: AgentConfig;
   inlineAgents: Agent[];
   /**
    * v2.0.0 (cortex#297) — principal's platform-side ids surfaced through the
    * loader after `agent.operatorDiscordId/Mattermost/Slack` retired from
-   * BotConfig. Populated only for cortex-shape configs (legacy bot.yaml
+   * AgentConfig. Populated only for cortex-shape configs (legacy bot.yaml
    * input always yields `undefined`). The boot path reads these to wire
    * `DiscordAdapterInfra.operator.discordId` etc.
    */
@@ -119,7 +119,7 @@ export interface LoadedConfig {
  * The check is structural — must have a principal block (`principal:` or the
  * legacy `operator:`, object) AND `agents:` (non-empty array). Either field on
  * its own keeps the legacy path so a partially-migrated config surfaces the
- * relevant zod errors via BotConfigSchema (legacy) rather than
+ * relevant zod errors via AgentConfigSchema (legacy) rather than
  * CortexConfigSchema's anti-field rejections.
  */
 interface ZodLikeIssue {
@@ -221,10 +221,10 @@ function isCortexShape(raw: Record<string, unknown>): boolean {
 /**
  * Load bot.yaml + networks/*.yaml, validate, merge.
  *
- * Backwards-compatible wrapper that returns just the BotConfig — callers
+ * Backwards-compatible wrapper that returns just the AgentConfig — callers
  * that need cortex-shape `inlineAgents` should use `loadConfigWithAgents`.
  */
-export function loadConfig(path: string): BotConfig {
+export function loadConfig(path: string): AgentConfig {
   return loadConfigWithAgents(path).config;
 }
 
@@ -237,7 +237,7 @@ export function loadConfig(path: string): BotConfig {
  *     presence: blocks),
  *
  * and returns a `LoadedConfig` with:
- *   - `config`: a BotConfig (legacy shape, possibly synthesized from cortex
+ *   - `config`: an AgentConfig (legacy shape, possibly synthesized from cortex
  *      shape for downstream-consumer parity),
  *   - `inlineAgents`: the cortex-shape `agents[]` when present; empty for
  *      legacy input.
@@ -318,7 +318,7 @@ export function loadConfigWithAgents(path: string): LoadedConfig {
   };
 
   return {
-    config: BotConfigSchema.parse(merged),
+    config: AgentConfigSchema.parse(merged),
     inlineAgents: [],
   };
 }
@@ -331,11 +331,11 @@ export function loadConfigWithAgents(path: string): LoadedConfig {
  *      `agent:` / `discord:[]` / `mattermost:[]` / `trustedAgentBots:`
  *      blocks with principal-friendly migration errors.
  *   2. Flatten `agents[*].presence.{discord,mattermost}` into the legacy
- *      `BotConfig.{discord,mattermost}[]` arrays — each entry inherits
+ *      `AgentConfig.{discord,mattermost}[]` arrays — each entry inherits
  *      the parent agent's id as a synthesized `instanceId` matching the
  *      MIG-7.2c convention (`${agent.id}-{platform}`).
  *   3. Synthesize a singular `agent:` block from the principal block plus
- *      the first agent — this keeps the legacy BotConfig contract intact
+ *      the first agent — this keeps the legacy AgentConfig contract intact
  *      while the multi-agent identity routing flows via `inlineAgents`
  *      through `startCortex`.
  *   4. Pass renderers/claude/attachments/execution/github/paths/nats
@@ -424,7 +424,7 @@ function loadCortexShape(
     throw new Error("invariant: agents schema enforced .min(1) but [0] missing");
   }
 
-  // Synthesize the BotConfig `agent:` singular from principal + first agent.
+  // Synthesize the AgentConfig `agent:` singular from principal + first agent.
   // Downstream consumers that read `config.agent.name` get the first agent's
   // id; per-instance routing flows via `inlineAgents` so the multi-agent
   // case stays correct.
@@ -440,7 +440,7 @@ function loadCortexShape(
       operatorName: cortexConfig.principal.displayName,
     }),
     // v2.0.0 cutover (cortex#297) — `operator*Id` fields retired from
-    // BotConfig.agent. Principal's platform-side ids surface through
+    // AgentConfig.agent. Principal's platform-side ids surface through
     // `LoadedConfig.operator` (see return value below); the boot path in
     // cortex.ts reads them from there.
     dataResidency: cortexConfig.principal.dataResidency,
@@ -454,7 +454,7 @@ function loadCortexShape(
   const mattermost = flattenMattermostPresences(cortexConfig.agents);
   const slack = flattenSlackPresences(cortexConfig.agents);
 
-  // Build the merged BotConfig-shaped object. Networks behave the same
+  // Build the merged AgentConfig-shaped object. Networks behave the same
   // way they do in the legacy path; renderers + nats + the *Config blocks
   // are passthrough.
   const merged: Record<string, unknown> = {
@@ -474,7 +474,7 @@ function loadCortexShape(
   };
 
   return {
-    config: BotConfigSchema.parse(merged),
+    config: AgentConfigSchema.parse(merged),
     inlineAgents: [...cortexConfig.agents],
     // v2.0.0 (cortex#297) — surface principal platform ids for the boot path.
     operator: {
@@ -504,7 +504,7 @@ function loadCortexShape(
 }
 
 /**
- * Convert each agent's optional Discord presence into a flat BotConfig
+ * Convert each agent's optional Discord presence into a flat AgentConfig
  * discord entry. Empty when no agent has Discord presence.
  *
  * The synthesized `instanceId` matches the MIG-7.2c default convention —
@@ -534,7 +534,7 @@ function flattenMattermostPresences(agents: readonly Agent[]) {
 }
 
 /**
- * Convert each agent's optional Slack presence into a flat BotConfig
+ * Convert each agent's optional Slack presence into a flat AgentConfig
  * slack entry. Mirror of `flattenDiscordPresences` /
  * `flattenMattermostPresences` — empty when no agent declares a
  * `presence.slack` block.

--- a/src/common/config/watcher.ts
+++ b/src/common/config/watcher.ts
@@ -5,7 +5,7 @@
 
 import { watch, type FSWatcher, existsSync } from "fs";
 import { loadConfig, loadAgentsDirectory, FragmentLoadError, expandTilde } from "./loader";
-import type { BotConfig } from "../types/config";
+import type { AgentConfig } from "../types/config";
 import type { Agent } from "../types/cortex-config";
 
 export interface ConfigChangeEvent {
@@ -14,7 +14,7 @@ export interface ConfigChangeEvent {
   /** Fields that changed but require restart */
   requiresRestart: string[];
   /** New config (already applied to the watcher's internal state) */
-  config: BotConfig;
+  config: AgentConfig;
 }
 
 export type ConfigChangeHandler = (event: ConfigChangeEvent) => void;
@@ -111,7 +111,7 @@ const RESTART_FIELDS = new Set([
  * - applied: fields safe to hot-reload
  * - requiresRestart: fields requiring restart
  */
-function compareConfigs(oldConfig: BotConfig, newConfig: BotConfig): {
+function compareConfigs(oldConfig: AgentConfig, newConfig: AgentConfig): {
   applied: string[];
   requiresRestart: string[];
 } {
@@ -256,12 +256,12 @@ function compareConfigs(oldConfig: BotConfig, newConfig: BotConfig): {
  */
 export class ConfigWatcher {
   private configPath: string;
-  private config: BotConfig;
+  private config: AgentConfig;
   private handler: ConfigChangeHandler;
   private watcher: FSWatcher | null = null;
   private reloadTimeout: NodeJS.Timeout | null = null;
 
-  constructor(configPath: string, initialConfig: BotConfig, handler: ConfigChangeHandler) {
+  constructor(configPath: string, initialConfig: AgentConfig, handler: ConfigChangeHandler) {
     this.configPath = configPath.replace(/^~/, process.env.HOME ?? "~");
     this.config = initialConfig;
     this.handler = handler;
@@ -340,7 +340,7 @@ export class ConfigWatcher {
   }
 
   /** Get current config (reflects last successful reload) */
-  getConfig(): BotConfig {
+  getConfig(): AgentConfig {
     return this.config;
   }
 }

--- a/src/common/policy/factory.ts
+++ b/src/common/policy/factory.ts
@@ -10,7 +10,7 @@
  * Phase C.3 wires this factory into the cortex.ts boot path. C.2b
  * (later) removes the per-adapter `roles[]` legacy shape and makes
  * `policy:` the authoritative source — at which point this factory
- * always returns an engine for cortex.yaml configs (BotConfig stays
+ * always returns an engine for cortex.yaml configs (AgentConfig stays
  * as legacy without a policy block, mapping to `undefined` here).
  * Phase D.3 threads the `policy.federated` slice into the engine so
  * federated dispatches (`intent.source_network` set) get the

--- a/src/common/types/__tests__/cortex-config.test.ts
+++ b/src/common/types/__tests__/cortex-config.test.ts
@@ -14,7 +14,7 @@
 
 import { describe, test, expect } from "bun:test";
 
-import { BotConfigSchema } from "../config";
+import { AgentConfigSchema } from "../config";
 import {
   AgentDetectionSchema,
   AgentSchema,
@@ -507,16 +507,16 @@ describe("NatsConfigSchema", () => {
 });
 
 // =============================================================================
-// BotConfigSchema.nats.accountSigningKeyPath — MIRROR of cortex-config field
+// AgentConfigSchema.nats.accountSigningKeyPath — MIRROR of cortex-config field
 // =============================================================================
 //
 // We MIRROR the field across both schemas during the MIG-7.2 overlap window.
 // Asserting the legacy schema accepts it (and round-trips it) protects against
 // drift — if someone edits one schema and forgets the other, this test fails.
 
-describe("BotConfigSchema.nats.accountSigningKeyPath (MIRROR)", () => {
-  /** Minimal BotConfig shell to exercise the optional `nats` block. */
-  function minBotConfig(natsExtras: Record<string, unknown> = {}) {
+describe("AgentConfigSchema.nats.accountSigningKeyPath (MIRROR)", () => {
+  /** Minimal AgentConfig shell to exercise the optional `nats` block. */
+  function minAgentConfig(natsExtras: Record<string, unknown> = {}) {
     return {
       agent: { name: "test", displayName: "Test", operatorId: "op" },
       discord: [],
@@ -530,34 +530,34 @@ describe("BotConfigSchema.nats.accountSigningKeyPath (MIRROR)", () => {
     };
   }
 
-  test("absent on legacy BotConfig.nats → undefined", () => {
-    const parsed = BotConfigSchema.parse(minBotConfig());
+  test("absent on legacy AgentConfig.nats → undefined", () => {
+    const parsed = AgentConfigSchema.parse(minAgentConfig());
     expect(parsed.nats?.accountSigningKeyPath).toBeUndefined();
   });
 
-  test("accepts a string path on legacy BotConfig.nats", () => {
-    const parsed = BotConfigSchema.parse(
-      minBotConfig({ accountSigningKeyPath: "/etc/cortex/account-signing.nk" }),
+  test("accepts a string path on legacy AgentConfig.nats", () => {
+    const parsed = AgentConfigSchema.parse(
+      minAgentConfig({ accountSigningKeyPath: "/etc/cortex/account-signing.nk" }),
     );
     expect(parsed.nats?.accountSigningKeyPath).toBe("/etc/cortex/account-signing.nk");
   });
 
-  test("credsPath (cortex#86) mirrors onto BotConfig.nats", () => {
-    const parsed = BotConfigSchema.parse(
-      minBotConfig({ credsPath: "~/.config/nats/cortex.creds" }),
+  test("credsPath (cortex#86) mirrors onto AgentConfig.nats", () => {
+    const parsed = AgentConfigSchema.parse(
+      minAgentConfig({ credsPath: "~/.config/nats/cortex.creds" }),
     );
     expect(parsed.nats?.credsPath).toBe("~/.config/nats/cortex.creds");
   });
 
-  test("credsPath rejects non-string on legacy BotConfig.nats", () => {
+  test("credsPath rejects non-string on legacy AgentConfig.nats", () => {
     expect(() =>
-      BotConfigSchema.parse(minBotConfig({ credsPath: 42 })),
+      AgentConfigSchema.parse(minAgentConfig({ credsPath: 42 })),
     ).toThrow();
   });
 
-  test("rejects non-string on legacy BotConfig.nats", () => {
-    expect(() => BotConfigSchema.parse(
-      minBotConfig({ accountSigningKeyPath: 42 }),
+  test("rejects non-string on legacy AgentConfig.nats", () => {
+    expect(() => AgentConfigSchema.parse(
+      minAgentConfig({ accountSigningKeyPath: 42 }),
     )).toThrow();
   });
 });
@@ -786,18 +786,18 @@ describe("CortexConfigSchema", () => {
 });
 
 // =============================================================================
-// MIRROR sync — cortex cross-cutting schemas vs BotConfigSchema
+// MIRROR sync — cortex cross-cutting schemas vs AgentConfigSchema
 // =============================================================================
 //
 // Six cortex schemas (Claude / Attachments / Execution / Github + AgentDetection
 // / Paths) carry MIRROR breadcrumbs in their JSDoc pointing at the corresponding
-// BotConfigSchema block. The breadcrumb is a manual guard during the MIG-7.2
+// AgentConfigSchema block. The breadcrumb is a manual guard during the MIG-7.2
 // overlap window — a field added on one side must be added on the other side
-// too, otherwise downstream code that reads BotConfig and writes CortexConfig
+// too, otherwise downstream code that reads AgentConfig and writes CortexConfig
 // (or vice versa) silently drops data. These tests are the structural check
 // that fires automatically if the breadcrumbs are missed.
 //
-// Method: parse `{}` on each cortex schema, parse the minimum BotConfig
+// Method: parse `{}` on each cortex schema, parse the minimum AgentConfig
 // (which applies inner defaults to optional cross-cutting blocks), and compare.
 // Default-value equality is the strictest test because it catches both field
 // additions/removals AND default drift. Known divergence — `paths.logDir`
@@ -854,16 +854,16 @@ describe("PolicyFederatedRegistrySchema — IAW D.4.3", () => {
   });
 });
 
-describe("MIRROR sync — cortex cross-cutting schemas vs BotConfigSchema", () => {
-  // Minimum BotConfig that exposes inner defaults on every cross-cutting block.
+describe("MIRROR sync — cortex cross-cutting schemas vs AgentConfigSchema", () => {
+  // Minimum AgentConfig that exposes inner defaults on every cross-cutting block.
   //
-  // BotConfig pre-dates the cortex-side `emptyDefault` helper, so its outer
+  // AgentConfig pre-dates the cortex-side `emptyDefault` helper, so its outer
   // `.default({} as any)` wrappers exhibit the Zod v4 quirk documented on
   // `emptyDefault`: omitting the field returns the literal `{}` rather than
   // the inner-default-applied shape. To compare populated shapes against the
   // cortex side, pass each cross-cutting block as an explicit `{}` so Zod
   // re-parses it through the inner schema and the inner defaults apply.
-  const bot = BotConfigSchema.parse({
+  const bot = AgentConfigSchema.parse({
     agent: { name: "x", displayName: "x" },
     discord: [],
     claude: {},
@@ -905,9 +905,9 @@ describe("MIRROR sync — cortex cross-cutting schemas vs BotConfigSchema", () =
     expect(cortexPaths.publishedEventsDir).toBe(bot.paths.publishedEventsDir);
     // Documented divergence: cortex moved the default log directory off the
     // grove namespace as part of the rename. If this assertion ever stops
-    // holding, the BotConfig side has been re-pointed at cortex/ too and the
+    // holding, the AgentConfig side has been re-pointed at cortex/ too and the
     // MIRROR window is collapsing — drop both this assertion and the
-    // BotConfig.paths block (per the MIRROR-removal note in cortex-config.ts).
+    // AgentConfig.paths block (per the MIRROR-removal note in cortex-config.ts).
     expect(cortexPaths.logDir).toBe("~/.config/cortex/logs");
     expect(bot.paths.logDir).toBe("~/.config/grove/logs");
   });

--- a/src/common/types/config.ts
+++ b/src/common/types/config.ts
@@ -129,7 +129,7 @@ export const MattermostInstanceSchema = z.object({
 export type MattermostInstance = z.infer<typeof MattermostInstanceSchema>;
 
 /**
- * Slack instance (legacy BotConfig shape). Mirror of
+ * Slack instance (legacy AgentConfig shape). Mirror of
  * `SlackPresenceSchema` in `./cortex-config.ts` — `flattenSlackPresences`
  * in `src/common/config/loader.ts` threads cortex.yaml's
  * `agents[].presence.slack` blocks through to entries of this shape so
@@ -261,7 +261,7 @@ export type NetworkFile = z.infer<typeof NetworkFileSchema>;
 // Main config schema
 // =============================================================================
 
-export const BotConfigSchema = z.object({
+export const AgentConfigSchema = z.object({
   agent: z.object({
     name: z.string().min(1),
     displayName: z.string().min(1),
@@ -504,14 +504,14 @@ export const BotConfigSchema = z.object({
      * cortex#86 — path to a NATS user `.creds` file for operator-mode
      * connect auth. See `NatsConfigSchema.credsPath` in `./cortex-config.ts`
      * for the canonical docstring; this entry MIRRORS the field so that
-     * the migrate-config loader can synthesize a BotConfig from cortex.yaml
+     * the migrate-config loader can synthesize an AgentConfig from cortex.yaml
      * without stripping the creds path. Drop both on MIG-7.2e.
      */
     credsPath: z.string().optional(),
     /**
      * MIG-7.2e: NKey identity for envelope signing (MY-400). Optional.
      * Mirror of `NatsConfigSchema.identity` in `./cortex-config.ts` so the
-     * loader can synthesize a BotConfig from cortex.yaml without stripping
+     * loader can synthesize an AgentConfig from cortex.yaml without stripping
      * the identity block. Legacy bot.yaml deployments never set this;
      * cortex.yaml deployments always do.
      */
@@ -526,7 +526,7 @@ export const BotConfigSchema = z.object({
 
   /**
    * MIG-7.2d: optional `renderers[]` block for non-agent-bound surfaces
-   * (dashboard, pagerduty, …). Additive on the legacy `BotConfig` so an
+   * (dashboard, pagerduty, …). Additive on the legacy `AgentConfig` so an
    * existing `bot.yaml` keeps loading unchanged; cortex.yaml (post-7.2e
    * migrate-config) emits this field directly off the cortex-config
    * schema. The shape passes through Zod via `z.unknown()` and the
@@ -537,7 +537,7 @@ export const BotConfigSchema = z.object({
   renderers: z.array(z.unknown()).optional(),
 });
 
-export type BotConfig = z.infer<typeof BotConfigSchema>;
+export type AgentConfig = z.infer<typeof AgentConfigSchema>;
 
 // =============================================================================
 // G-501: Network-aware routing types
@@ -573,20 +573,20 @@ export type NetworkResolver = (networkId: string | undefined) => NetworkConfig |
 // =============================================================================
 
 /**
- * Build a "scoped" BotConfig where `discord` contains a single instance's config.
+ * Build a "scoped" AgentConfig where `discord` contains a single instance's config.
  * v2.0.0 (cortex#297) — the legacy role-resolver retired; this scoping helper
  * survives for adapters / discord-client code that reads `config.discord[0].guildId`
  * etc. Authorisation flows through `policy:` block now.
  */
-export function scopeConfigToDiscordInstance(config: BotConfig, instance: DiscordInstance): BotConfig {
+export function scopeConfigToDiscordInstance(config: AgentConfig, instance: DiscordInstance): AgentConfig {
   return { ...config, discord: [instance] };
 }
 
-export function scopeConfigToMattermostInstance(config: BotConfig, instance: MattermostInstance): BotConfig {
+export function scopeConfigToMattermostInstance(config: AgentConfig, instance: MattermostInstance): AgentConfig {
   return { ...config, mattermost: [instance] };
 }
 
-export function scopeConfigToSlackInstance(config: BotConfig, instance: SlackInstance): BotConfig {
+export function scopeConfigToSlackInstance(config: AgentConfig, instance: SlackInstance): AgentConfig {
   return { ...config, slack: [instance] };
 }
 
@@ -594,15 +594,15 @@ export function scopeConfigToSlackInstance(config: BotConfig, instance: SlackIns
  * Get the first Discord instance config (for backward-compat code that
  * expects `config.discord.*` as a flat object). Returns undefined if no instances.
  */
-export function getFirstDiscordInstance(config: BotConfig): DiscordInstance | undefined {
+export function getFirstDiscordInstance(config: AgentConfig): DiscordInstance | undefined {
   return config.discord[0];
 }
 
-export function getFirstMattermostInstance(config: BotConfig): MattermostInstance | undefined {
+export function getFirstMattermostInstance(config: AgentConfig): MattermostInstance | undefined {
   return config.mattermost[0];
 }
 
-export function getFirstSlackInstance(config: BotConfig): SlackInstance | undefined {
+export function getFirstSlackInstance(config: AgentConfig): SlackInstance | undefined {
   return config.slack[0];
 }
 
@@ -610,7 +610,7 @@ export function getFirstSlackInstance(config: BotConfig): SlackInstance | undefi
  * Aggregate GitHub repos from top-level config AND all network configs.
  * Returns a deduplicated array of "owner/repo" strings.
  */
-export function getAllRepos(config: BotConfig): string[] {
+export function getAllRepos(config: AgentConfig): string[] {
   const repos = new Set<string>(config.github.repos);
   for (const network of config.networks) {
     for (const repo of network.github.repos) {

--- a/src/common/types/cortex-config.ts
+++ b/src/common/types/cortex-config.ts
@@ -1,7 +1,7 @@
 /**
  * MIG-7.2 base — CortexConfig schema (the flipped model from architecture §9.1).
  *
- * Replaces grove-v2's `BotConfig` shape (`agent:` + `discord:[]` + `mattermost:[]` +
+ * Replaces grove-v2's `AgentConfig` shape (`agent:` + `discord:[]` + `mattermost:[]` +
  * `trustedAgentBots:`) with a first-class agent model:
  *
  *   operator:                  who is running this cortex instance
@@ -20,7 +20,7 @@
  *   github:                    GitHub webhook surface (taps)
  *   claude / paths / etc.      cross-cutting infra (unchanged shape)
  *
- * This file is **additive** — `BotConfig` in `./config.ts` continues to be the
+ * This file is **additive** — `AgentConfig` in `./config.ts` continues to be the
  * load-bearing config until MIG-7.2 sub-PRs (7.2a registry, 7.2b trust-resolver,
  * 7.2c adapter refactor, 7.2d renderers, 7.2e migrate-config) move call-sites
  * across. See `docs/plan-cortex-migration.md` §4 MIG-7.2*.
@@ -862,7 +862,7 @@ export const NatsIdentitySchema = z.object({
 export type NatsIdentity = z.infer<typeof NatsIdentitySchema>;
 
 /**
- * NATS / myelin subscriber configuration. Mirrors `BotConfig.nats` shape from
+ * NATS / myelin subscriber configuration. Mirrors `AgentConfig.nats` shape from
  * grove-v2 plus the new `identity` block.
  */
 export const NatsConfigSchema = z.object({
@@ -888,7 +888,7 @@ export const NatsConfigSchema = z.object({
    * the `NatsLink` loader enforces chmod 600 on POSIX. Wins over `token`
    * when both are set (warn log explains precedence).
    *
-   * MIRROR: `BotConfigSchema.nats.credsPath` in `./config.ts`. Drop both
+   * MIRROR: `AgentConfigSchema.nats.credsPath` in `./config.ts`. Drop both
    * on MIG-7.2e alongside `identity` and `accountSigningKeyPath`.
    */
   credsPath: z.string().optional(),
@@ -903,7 +903,7 @@ export const NatsConfigSchema = z.object({
    * to any renderer. See `src/common/config/account-signing-key.ts` for the
    * loader that enforces chmod 600 and SA-prefix.
    *
-   * MIRROR: `BotConfigSchema.nats.accountSigningKeyPath` in `./config.ts`.
+   * MIRROR: `AgentConfigSchema.nats.accountSigningKeyPath` in `./config.ts`.
    * Drop both on MIG-7.2e.
    */
   accountSigningKeyPath: z.string().optional(),
@@ -966,13 +966,13 @@ export type BusConfig = z.infer<typeof BusConfigSchema>;
 export type BusReviewConfig = z.infer<typeof BusReviewConfigSchema>;
 
 // =============================================================================
-// Cross-cutting infra blocks — carried forward in same shape as BotConfig
+// Cross-cutting infra blocks — carried forward in same shape as AgentConfig
 // =============================================================================
 //
 // MIRROR NOTE: during the MIG-7.2 overlap window, these schemas live in two
-// places: here as standalone exports, and inline inside `BotConfigSchema`
+// places: here as standalone exports, and inline inside `AgentConfigSchema`
 // in `./config.ts`. Field additions/changes MUST be applied to BOTH until
-// MIG-7.2e retires BotConfig. Each block below carries a `MIRROR:` breadcrumb
+// MIG-7.2e retires AgentConfig. Each block below carries a `MIRROR:` breadcrumb
 // pointing at the corresponding section in config.ts so a grep for `MIRROR:`
 // surfaces every overlap site.
 //
@@ -980,10 +980,10 @@ export type BusReviewConfig = z.infer<typeof BusReviewConfigSchema>;
 
 /**
  * Claude runtime config — passed to spawned CC sessions. Identical shape to
- * grove-v2's `BotConfig.claude` block; not refactored at MIG-7.2 because the
+ * grove-v2's `AgentConfig.claude` block; not refactored at MIG-7.2 because the
  * shape is already correct (no agent-bound coupling to break).
  *
- * MIRROR: see `BotConfigSchema.claude` in `./config.ts`. Drop both on 7.2e.
+ * MIRROR: see `AgentConfigSchema.claude` in `./config.ts`. Drop both on 7.2e.
  */
 export const ClaudeConfigSchema = z.object({
   timeoutMs: z.number().int().positive().default(120_000),
@@ -1005,8 +1005,8 @@ export const ClaudeConfigSchema = z.object({
 export type ClaudeConfig = z.infer<typeof ClaudeConfigSchema>;
 
 /**
- * Attachments config — identical shape to BotConfig.attachments.
- * MIRROR: see `BotConfigSchema.attachments` in `./config.ts`. Drop both on 7.2e.
+ * Attachments config — identical shape to AgentConfig.attachments.
+ * MIRROR: see `AgentConfigSchema.attachments` in `./config.ts`. Drop both on 7.2e.
  */
 export const AttachmentsConfigSchema = z.object({
   enabled: z.boolean().default(true),
@@ -1018,8 +1018,8 @@ export const AttachmentsConfigSchema = z.object({
 export type AttachmentsConfig = z.infer<typeof AttachmentsConfigSchema>;
 
 /**
- * Execution backends — identical shape to BotConfig.execution.
- * MIRROR: see `BotConfigSchema.execution` in `./config.ts`. Drop both on 7.2e.
+ * Execution backends — identical shape to AgentConfig.execution.
+ * MIRROR: see `AgentConfigSchema.execution` in `./config.ts`. Drop both on 7.2e.
  */
 export const ExecutionConfigSchema = z.object({
   default: z.string().default("local"),
@@ -1036,7 +1036,7 @@ export type ExecutionConfig = z.infer<typeof ExecutionConfigSchema>;
  * GitHub agent-detection heuristics — extracted from `GithubConfigSchema` so
  * it can use `emptyDefault` cleanly when nested. Identical defaults to grove-v2.
  *
- * MIRROR: see `BotConfigSchema.github.agentDetection` (inline) in `./config.ts`.
+ * MIRROR: see `AgentConfigSchema.github.agentDetection` (inline) in `./config.ts`.
  * Drop both on 7.2e.
  */
 export const AgentDetectionSchema = z.object({
@@ -1050,10 +1050,10 @@ export type AgentDetection = z.infer<typeof AgentDetectionSchema>;
 /**
  * MIG-5.6 (C-106): local GitHub-webhook receiver — extracted so it can
  * nest cleanly under `GithubConfigSchema` and stay MIRRORed with the
- * inline shape in `BotConfigSchema.github.receiver`. Defaults are
+ * inline shape in `AgentConfigSchema.github.receiver`. Defaults are
  * opt-in: `enabled=false`, `127.0.0.1:8770`.
  *
- * MIRROR: see `BotConfigSchema.github.receiver` (inline) in `./config.ts`.
+ * MIRROR: see `AgentConfigSchema.github.receiver` (inline) in `./config.ts`.
  * Drop both on 7.2e.
  */
 export const GithubReceiverSchema = z.object({
@@ -1065,8 +1065,8 @@ export const GithubReceiverSchema = z.object({
 export type GithubReceiver = z.infer<typeof GithubReceiverSchema>;
 
 /**
- * GitHub webhook surface — identical shape to BotConfig.github.
- * MIRROR: see `BotConfigSchema.github` in `./config.ts`. Drop both on 7.2e.
+ * GitHub webhook surface — identical shape to AgentConfig.github.
+ * MIRROR: see `AgentConfigSchema.github` in `./config.ts`. Drop both on 7.2e.
  */
 export const GithubConfigSchema = z.object({
   webhookSecret: z.string().default(""),
@@ -1078,9 +1078,9 @@ export const GithubConfigSchema = z.object({
 export type GithubConfig = z.infer<typeof GithubConfigSchema>;
 
 /**
- * Filesystem paths — identical shape to BotConfig.paths but cortex-named
+ * Filesystem paths — identical shape to AgentConfig.paths but cortex-named
  * (default logDir `~/.config/cortex/logs` vs grove-v2's `~/.config/grove/logs`).
- * MIRROR: see `BotConfigSchema.paths` in `./config.ts`. Drop both on 7.2e.
+ * MIRROR: see `AgentConfigSchema.paths` in `./config.ts`. Drop both on 7.2e.
  */
 export const PathsConfigSchema = z.object({
   publishedEventsDir: z.string().default("~/.claude/events/published"),

--- a/src/common/types/nkey.ts
+++ b/src/common/types/nkey.ts
@@ -18,7 +18,7 @@
  *   - `src/common/types/cortex-config.ts` — PolicyPrincipalSchema,
  *     PolicyFederatedPeerSchema, PolicyFederatedNetworkSchema.peers.
  *   - `src/common/types/stack.ts` — StackConfigSchema.nkey_pub.
- *   - `src/common/types/config.ts` — legacy BotConfig nkey field.
+ *   - `src/common/types/config.ts` — legacy AgentConfig nkey field.
  *
  * Closes cortex#143.
  */

--- a/src/common/types/stack.ts
+++ b/src/common/types/stack.ts
@@ -198,13 +198,13 @@ export interface DeriveStackIdInput {
  * Why this helper takes the narrowed `DeriveStackIdInput`, not `CortexConfig`:
  *   The `stack:` block lives on `CortexConfigSchema` only. The MIG-7.2
  *   loader (`loadCortexShape` in `src/common/config/loader.ts`) parses
- *   cortex-shape input via that schema, then projects to `BotConfig` for
+ *   cortex-shape input via that schema, then projects to `AgentConfig` for
  *   downstream legacy consumers — but the stack block isn't part of
- *   `BotConfig` (the MIG-7.2 anti-fields rule out adding it to the
+ *   `AgentConfig` (the MIG-7.2 anti-fields rule out adding it to the
  *   legacy shape). Callers wire `deriveStackId` in via the
  *   `LoadedConfig.stack` field the loader exposes (set when cortex shape
  *   was detected). The boot path constructs a small input object from the
- *   BotConfig projection's `agent.operatorId` (legacy field-name continuity)
+ *   AgentConfig projection's `agent.operatorId` (legacy field-name continuity)
  *   plus the optional `stack:` block — no second schema parse required.
  *
  * The return type is plain — no error path, no `null`. Boot code logs the

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -19,7 +19,7 @@ import type { TextChannel } from "discord.js";
 
 import { loadConfigWithAgents, loadAgentsDirectory, expandTilde, FragmentLoadError } from "./common/config/loader";
 import { ConfigWatcher } from "./common/config/watcher";
-import { type BotConfig, getAllRepos } from "./common/types/config";
+import { type AgentConfig, getAllRepos } from "./common/types/config";
 import { fetchWithTimeout } from "./common/timeout";
 import { UsageMonitor } from "./common/usage/monitor";
 import { AgentRegistry } from "./common/agents/registry";
@@ -154,7 +154,7 @@ export function pidFileFor(configPath: string | undefined): string {
  * integration harness.
  */
 export function buildReviewSessionOpts(
-  config: BotConfig,
+  config: AgentConfig,
   agent: Pick<Agent, "id" | "displayName">,
 ): Partial<Omit<CCSessionOpts, "prompt">> {
   return {
@@ -256,7 +256,7 @@ export interface StartCortexOptions {
    * the registry. Mirrors the cortex.yaml `agents[]` block (design §6.1):
    * inline entries win on id conflict with fragments.
    *
-   * BotConfig (today's legacy shape) carries no inline `agents[]` field, so
+   * AgentConfig (today's legacy shape) carries no inline `agents[]` field, so
    * production callers pass nothing and the registry is built purely from
    * fragments. The seam exists today so tests can assemble a registry
    * without writing fragment files, and so the cortex.yaml migration
@@ -309,7 +309,7 @@ export interface StartCortexOptions {
   /**
    * v2.0.0 cutover (cortex#297) — principal's platform-side ids surfaced
    * from `PrincipalConfigSchema` via `LoadedConfig.operator`. Replaces the
-   * `BotConfig.agent.operatorDiscordId/Mattermost/Slack` fields retired
+   * `AgentConfig.agent.operatorDiscordId/Mattermost/Slack` fields retired
    * in cortex#297. `undefined` for legacy `bot.yaml` input — adapters
    * then have no principal-DM target and `notifyOperator` is a no-op.
    *
@@ -328,7 +328,7 @@ export interface StartCortexOptions {
  * NATS subject, dashboard column, and `signed_by` chain inside the
  * cortex process. v3 vocabulary (cortex#388) made `principal.id` the
  * single source of truth on cortex.yaml; the loader synthesises a
- * legacy-compatible `BotConfig.agent.operatorId` for downstream code
+ * legacy-compatible `AgentConfig.agent.operatorId` for downstream code
  * AND surfaces the same value as `LoadedConfig.operator.id`. This
  * helper prefers the v3-canonical `LoadedConfig.operator` path so the
  * post-MIG-8 schema deletion (PR-C of cortex#426) is a single-line
@@ -345,7 +345,7 @@ export interface StartCortexOptions {
  *   is set — fail-fast at boot rather than masking the gap.
  */
 function resolvePrincipalId(
-  config: BotConfig,
+  config: AgentConfig,
   operator: StartCortexOptions["operator"],
 ): string {
   const fromLoadedOperator = operator?.id;
@@ -374,7 +374,7 @@ function resolvePrincipalId(
  * propagate so the principal sees them at the CLI exit.
  */
 export async function startCortex(
-  config: BotConfig,
+  config: AgentConfig,
   options: StartCortexOptions = {},
 ): Promise<CortexHandle> {
   const expandedConfigPath = options.configPath
@@ -573,7 +573,7 @@ export async function startCortex(
   // we fall back to `~/.config/cortex/agents.d/`.
   //
   // Fragment-load errors are non-fatal at this stage of the migration: the
-  // agent must keep starting in BotConfig mode even when a principal's
+  // agent must keep starting in AgentConfig mode even when a principal's
   // experimental fragment is malformed. Once the cortex.yaml migration is
   // complete (MIG-7.2e), the rule flips to strict per spec §FR-4.
   const agentsDir = options.agentsDir
@@ -583,13 +583,13 @@ export async function startCortex(
     fragmentAgents = loadAgentsDirectory(agentsDir);
   } catch (err) {
     if (err instanceof FragmentLoadError) {
-      console.error(`cortex: agents.d fragment load failed (non-fatal during BotConfig migration): ${err.message}`);
+      console.error(`cortex: agents.d fragment load failed (non-fatal during AgentConfig migration): ${err.message}`);
     } else {
       throw err;
     }
   }
 
-  // Merge: inline wins on id conflict (design §6.1). BotConfig today carries
+  // Merge: inline wins on id conflict (design §6.1). AgentConfig today carries
   // no inline `agents[]`, so production callers pass `inlineAgents: undefined`
   // and the merged list is just the fragments. The seam exists so tests can
   // exercise the merge rule without writing fragment files, and so MIG-7.2e
@@ -690,11 +690,11 @@ export async function startCortex(
   // entries re-emits envelopes with fresh ids/timestamps; the bucket
   // consumer keys on the payload `agent_id` and overwrites — see the
   // publisher's idempotency doc. So this boot-time call is safe under
-  // restart-and-replay; we do NOT wire a re-publish into the BotConfig
+  // restart-and-replay; we do NOT wire a re-publish into the AgentConfig
   // hot-reload path because (a) capabilities live on `Agent`, not
-  // `BotConfig`, and (b) cortex.ts does not currently run an agents.d/
+  // `AgentConfig`, and (b) cortex.ts does not currently run an agents.d/
   // fragment watcher at the daemon level — when one is wired, the
-  // re-publish belongs in its callback, not the BotConfig one.
+  // re-publish belongs in its callback, not the AgentConfig one.
   //
   // **Scope (per §10.1 PR-7).** Publish-only. No subscriber wiring here —
   // the consumer is principal-dashboard side and lands in a future PR.
@@ -1298,7 +1298,7 @@ export async function startCortex(
   interface StartedDiscord {
     adapter: DiscordAdapter;
     agent: Agent;
-    instance: BotConfig["discord"][number];
+    instance: AgentConfig["discord"][number];
     instanceId: string;
     explicitTrustedBotIds: ReadonlySet<string>;
   }
@@ -1333,7 +1333,7 @@ export async function startCortex(
     // collapses to plain `${agent.id}-discord`.
     const instanceId = instance.instanceId ?? `${config.agent.name}-discord-${instance.guildId}`;
     // Build the `DiscordPresence` from the bot.yaml discord[i] entry.
-    // Schema defaults already applied by `BotConfigSchema` at load time —
+    // Schema defaults already applied by `AgentConfigSchema` at load time —
     // this is a structural mapping, not a parse.
     //
     // cortex#98 (part A): `trustedBotIds` carries the principal-explicit
@@ -1596,7 +1596,7 @@ export async function startCortex(
   interface StartedSlack {
     adapter: SlackAdapter;
     agent: Agent;
-    instance: BotConfig["slack"][number];
+    instance: AgentConfig["slack"][number];
     instanceId: string;
     explicitTrustedBotIds: ReadonlySet<string>;
   }
@@ -1612,7 +1612,7 @@ export async function startCortex(
       ? `${config.agent.name}-slack-${slackIndex}`
       : `${config.agent.name}-slack`);
     // Build the `SlackPresence` from the legacy `SlackInstance` shape.
-    // Schema defaults have already been applied by `BotConfigSchema` —
+    // Schema defaults have already been applied by `AgentConfigSchema` —
     // this is a structural map, not a parse.
     const presence: SlackPresence = {
       enabled: instance.enabled,
@@ -1763,7 +1763,7 @@ export async function startCortex(
 
   const renderers: Renderer[] = [];
   for (const raw of config.renderers ?? []) {
-    // BotConfig types renderers as z.unknown() so legacy bot.yaml loads
+    // AgentConfig types renderers as z.unknown() so legacy bot.yaml loads
     // without breakage (the canonical shape lives on cortex-config's
     // RendererSchema). Parse each entry strictly here — a typo fails fast
     // with a Zod error rather than surfacing as a runtime cast failure
@@ -1874,7 +1874,7 @@ export async function startCortex(
     configWatcher = new ConfigWatcher(expandedConfigPath, config, (event) => {
       // cortex#237: capability-registry re-publish lands here once
       // AgentsDirectoryWatcher is wired — see boot block ~line 540 for
-      // rationale (BotConfig hot-reload's SAFE_FIELDS doesn't include
+      // rationale (AgentConfig hot-reload's SAFE_FIELDS doesn't include
       // capabilities; mergedAgents isn't re-built).
       dispatchHandler.updateConfig(event.config, expandedConfigPath);
       for (const adapter of adapters) adapter.updateConfig?.(event.config);
@@ -2129,7 +2129,7 @@ async function resolveReviewProvisioningJsm(
 }
 
 async function setupDashboard(
-  config: BotConfig,
+  config: AgentConfig,
   principalId: string,
   dispatchHandler: DispatchHandler,
   cloudPublisher: CloudPublisher | null,
@@ -2148,7 +2148,7 @@ async function setupDashboard(
     // `operator` column matches the `{principal}` segment of incoming
     // envelopes. `operatorName` falls back to `principalId` when the
     // principal hasn't declared a separate display name on
-    // `agent.operatorName` (legacy BotConfig field — PR-C retires).
+    // `agent.operatorName` (legacy AgentConfig field — PR-C retires).
     operatorId: principalId,
     operatorName: config.agent.operatorName ?? principalId,
     dashboardDir,
@@ -2198,7 +2198,7 @@ async function setupDashboard(
 function setupOutboundLog(
   discordAdapter: DiscordAdapter,
   instance: import("./common/types/config").DiscordInstance,
-  config: BotConfig,
+  config: AgentConfig,
   router: SurfaceRouter,
   systemEventSource: SystemEventSource,
 ): (() => void) | null {
@@ -2291,7 +2291,7 @@ function setupOutboundLog(
 /** G-204a + G-500: Issue startup `/api/sync` POST against each cloud-capable
  *  network; fall back to a local sync for any network that errors. */
 async function runStartupCloudSync(
-  cloudNetworks: BotConfig["networks"],
+  cloudNetworks: AgentConfig["networks"],
   api: { runStartupSync: () => unknown },
 ): Promise<void> {
   let anyFailed = false;
@@ -2363,7 +2363,7 @@ function checkSingleton(pidFile: string): void {
 // `scripts/postinstall.sh` already advertises `cortex start --config <path>
 // --dry-run` to operators as a post-migration sanity check. This helper
 // implements that contract: parse the file through the normal load path
-// (`loadConfigWithAgents`, which validates against both `BotConfigSchema`
+// (`loadConfigWithAgents`, which validates against both `AgentConfigSchema`
 // and `CortexConfigSchema` depending on shape), print a one-line OK
 // summary, exit 0. Schema parse failures surface verbatim with exit 2 so
 // the postinstall path stays distinguishable from "file unreadable" (1).
@@ -2451,7 +2451,7 @@ if (import.meta.main) {
       });
 
       // MIG-7.2e: detect cortex shape vs legacy bot.yaml. `loadConfigWithAgents`
-      // returns both the BotConfig projection (for downstream legacy consumers)
+      // returns both the AgentConfig projection (for downstream legacy consumers)
       // and the rich cortex `agents[]` so `startCortex` can route per-instance
       // identity correctly.
       //

--- a/src/renderers/types.ts
+++ b/src/renderers/types.ts
@@ -43,7 +43,7 @@ import type { RendererKind } from "../common/types/cortex-config";
  *      from the operator, not from any agent (architecture §9.3).
  *
  * **Renderers are static across hot-reload.** Unlike platform adapters
- * (which carry an `updateConfig(BotConfig)` hook that the
+ * (which carry an `updateConfig(AgentConfig)` hook that the
  * `ConfigWatcher` invokes on bot.yaml changes), renderers have no
  * config-update surface. A change to `renderers[]` — adding a
  * pagerduty integration, rotating a routing key, expanding the

--- a/src/runner/__tests__/dm-trust-chain.test.ts
+++ b/src/runner/__tests__/dm-trust-chain.test.ts
@@ -7,14 +7,14 @@
 
 import { test, expect, describe } from "bun:test";
 import { buildSecurityPreamble } from "../security-preamble";
-import type { BotConfig } from "../../common/types/config";
-import { BotConfigSchema } from "../../common/types/config";
+import type { AgentConfig } from "../../common/types/config";
+import { AgentConfigSchema } from "../../common/types/config";
 
 // Minimal valid config for tests
-function makeConfig(overrides: Record<string, unknown> = {}): BotConfig {
+function makeConfig(overrides: Record<string, unknown> = {}): AgentConfig {
   // v2.0.0 (cortex#297) — legacy `roles[]` / `dm` retired; the security
   // preamble + bash-guard tests below only need a minimal valid config.
-  return BotConfigSchema.parse({
+  return AgentConfigSchema.parse({
     agent: { name: "luna", displayName: "Luna" },
     discord: [{
       token: "test-token",

--- a/src/runner/__tests__/security-preamble.test.ts
+++ b/src/runner/__tests__/security-preamble.test.ts
@@ -1,8 +1,8 @@
 import { describe, test, expect } from "bun:test";
 import { buildSecurityPreamble } from "../security-preamble";
-import type { BotConfig } from "../../common/types/config";
+import type { AgentConfig } from "../../common/types/config";
 
-function makeConfig(overrides: Partial<BotConfig["claude"]> = {}): BotConfig {
+function makeConfig(overrides: Partial<AgentConfig["claude"]> = {}): AgentConfig {
   return {
     agent: { name: "test", displayName: "Test" },
     discord: {
@@ -29,7 +29,7 @@ function makeConfig(overrides: Partial<BotConfig["claude"]> = {}): BotConfig {
       publishedEventsDir: "~/.claude/events/published",
       claudeMdPath: "",
     },
-  } as unknown as BotConfig;
+  } as unknown as AgentConfig;
 }
 
 describe("buildSecurityPreamble", () => {

--- a/src/runner/security-preamble.ts
+++ b/src/runner/security-preamble.ts
@@ -3,7 +3,7 @@
  * Injects filesystem and behavior constraints based on the cortex agent config.
  */
 
-import type { BotConfig } from "../common/types/config";
+import type { AgentConfig } from "../common/types/config";
 
 /**
  * Options to relax the security preamble for trusted contexts.
@@ -29,7 +29,7 @@ export interface SecurityPreambleOpts {
  * Build a security preamble that gets prepended to every chat-invoked prompt.
  * Returns empty string if no restrictions are configured.
  */
-export function buildSecurityPreamble(config: BotConfig, configPath?: string, opts?: SecurityPreambleOpts): string {
+export function buildSecurityPreamble(config: AgentConfig, configPath?: string, opts?: SecurityPreambleOpts): string {
   const rules: string[] = [];
 
   // Verification rule — prevents hallucination of codebase knowledge

--- a/src/taps/gh-webhook-receiver/server.ts
+++ b/src/taps/gh-webhook-receiver/server.ts
@@ -34,7 +34,7 @@
  *     the receiver must not blindly trust forwarded headers.
  *   - Secret resolution: the receiver uses the secret passed at construction
  *     time. Cortex pulls it from `config.github.webhookSecret` (already part
- *     of the BotConfig schema — G-203b). When the secret is empty, the
+ *     of the AgentConfig schema — G-203b). When the secret is empty, the
  *     receiver responds 503 "not configured" rather than starting unsecured.
  *
  * **Hostname posture:**


### PR DESCRIPTION
## Summary

- Renamed Zod schema `BotConfigSchema` → `AgentConfigSchema` in `src/common/types/config.ts`
- Renamed inferred type `BotConfig` → `AgentConfig`
- 38 importer files updated across `src/{adapters,bus,cli,common,runner,surface,taps,renderers}` + `src/__tests__/` + `src/cortex.ts`
- Local test fixture helpers renamed (`makeBotConfig` → `makeAgentConfig`, `minBotConfig` → `minAgentConfig`)
- MIRROR breadcrumbs and prose references updated in `cortex-config.ts` + `config.ts`
- Grammar fix: "a AgentConfig" → "an AgentConfig"
- LOC: 39 files, +247 / -247
- Part of cortex#436; closes cortex#438

## Scope clarification

The plan §R7.B.i originally attributed `security-preamble.ts` **runtime-text** rewrite to R7a. That work shipped in **PR-R7b (cortex#458, commit b9664f1)** per the orchestrator comment on #438. This PR only touches the `BotConfig` type imports in `security-preamble.ts`; runtime strings already say "agent".

## Name-collision strategy

`AgentSchema` already exists in `src/common/types/cortex-config.ts` (the per-agent fragment under `CortexConfig.agents[]`). The new `AgentConfigSchema` here represents the legacy whole-bot shape — a distinct concept. The `Schema` suffix convention matches the existing `AgentSchema`, and the inferred-type names (`Agent` vs `AgentConfig`) are also distinct. No collision.

## Rebase note for @jcfischer (PR-R13d #450)

The `BotConfig` → `AgentConfig` rename will ripple into MC backend code that imports the type. PR-R13d should rebase on `main` after this lands.

## Verification

- [x] `bunx tsc --noEmit` clean (exit 0)
- [x] `bun test`: 3542 pass / 2 skip / 3 fail. The 3 failures are pre-existing on origin/main (SlackAdapter mid-drain — cortex#461; AgentsDirectoryWatcher fragment-watcher flakes — filesystem-watcher timing) and unrelated to the rename. Verified by `git stash && bun test <files>` on tip-of-main showing 5 fail before our changes.
- [x] `bun run lint:errors` clean (exit 0)
- [x] No security-preamble runtime-text re-work

Closes #438