### PR TITLE
feat(cortex): C-2c — registry/adapters local-vars + LoadedConfig.operator (closes #440)

### DIFF
--- a/src/adapters/discord/__tests__/auto-thread.test.ts
+++ b/src/adapters/discord/__tests__/auto-thread.test.ts
@@ -205,7 +205,7 @@ function makeAdapterWithInfra(
   };
   const infra: DiscordAdapterInfra = {
     instanceId: "discord-cortex120",
-    operator: {},
+    principal: {},
     ...infraOverrides,
   };
   const adapter = new DiscordAdapter(agent, presence, infra);

--- a/src/adapters/discord/__tests__/operator-dm-buffer.test.ts
+++ b/src/adapters/discord/__tests__/operator-dm-buffer.test.ts
@@ -75,7 +75,7 @@ function makeAdapter(opts: {
   };
   const infra: DiscordAdapterInfra = {
     instanceId: "discord-test",
-    operator: { discordId: "operator-123" },
+    principal: { discordId: "operator-123" },
   };
   const adapter = new DiscordAdapter(agent, presence, infra);
 

--- a/src/adapters/discord/__tests__/render-envelope.test.ts
+++ b/src/adapters/discord/__tests__/render-envelope.test.ts
@@ -96,7 +96,7 @@ function makeAdapter(opts: {
   };
   const infra: DiscordAdapterInfra = {
     instanceId: "discord-renderer",
-    operator: {},
+    principal: {},
     ...(opts.surfaceSubjects !== undefined && { surfaceSubjects: opts.surfaceSubjects }),
     ...(opts.surfaceFallbackChannelId !== undefined && { surfaceFallbackChannelId: opts.surfaceFallbackChannelId }),
     ...(opts.surfaceFilter !== undefined && { surfaceFilter: opts.surfaceFilter }),

--- a/src/adapters/discord/__tests__/start-attach-separation.test.ts
+++ b/src/adapters/discord/__tests__/start-attach-separation.test.ts
@@ -103,7 +103,7 @@ function makeAdapter(instanceId = "discord-test"): {
   };
   const infra: DiscordAdapterInfra = {
     instanceId,
-    operator: {},
+    principal: {},
   };
   const adapter = new DiscordAdapter(agent, presence, infra);
 
@@ -194,7 +194,7 @@ describe("DiscordAdapter.attachInboundDispatch: pre-start guard (cortex#108)", (
     };
     const adapter = new DiscordAdapter(agent, presence, {
       instanceId: "discord-pre-start",
-      operator: {},
+      principal: {},
     });
     // No client injected, no onMessage stashed — should throw with a
     // clear message instructing the caller to await start() first.

--- a/src/adapters/discord/__tests__/system-events.test.ts
+++ b/src/adapters/discord/__tests__/system-events.test.ts
@@ -85,7 +85,7 @@ async function buildStartedAdapter(opts: {
   const agent = makeAgent(presence);
   const infra: DiscordAdapterInfra = {
     instanceId: "discord-test",
-    operator: {},
+    principal: {},
     ...(opts.runtime !== undefined && { runtime: opts.runtime }),
     ...(opts.systemEventSource !== undefined && { systemEventSource: opts.systemEventSource }),
   };

--- a/src/adapters/discord/__tests__/update-config.test.ts
+++ b/src/adapters/discord/__tests__/update-config.test.ts
@@ -96,7 +96,7 @@ function makeAdapter(overrides: { presence?: Partial<DiscordPresence> } = {}) {
   const agent = makeAgent(presence);
   const infra: DiscordAdapterInfra = {
     instanceId: "luna-discord-guild-1",
-    operator: {},
+    principal: {},
   };
   return new DiscordAdapter(agent, presence, infra);
 }

--- a/src/adapters/discord/index.ts
+++ b/src/adapters/discord/index.ts
@@ -65,9 +65,9 @@ export interface DiscordAdapterInfra {
    * AgentConfig.discord[] still permits multiple entries per agent.name; collapses to
    * `${agent.id}-discord` at MIG-7.2e when migrate-config emits a real agents[] array. */
   instanceId: string;
-  /** Operator's platform identity. Architecture §9.1: the operator runs the cortex
+  /** Principal's platform identity. Architecture §9.1: the principal runs the cortex
    * deployment, distinct from the agents they host. */
-  operator: { discordId?: string };
+  principal: { discordId?: string };
   /** Myelin runtime for `system.adapter.*` envelope emission. Optional — adapters started
    * without NATS still track degradation/reconnect locally. */
   runtime?: MyelinRuntime;
@@ -416,7 +416,7 @@ export class DiscordAdapter implements PlatformAdapter {
       // `operatorDiscordId` comparison is retired; the operator
       // classification now flows through the PolicyEngine `operator`
       // capability. A principal that holds `operator` short-circuits to
-      // full DM access in `resolvePolicyAccess`. The `infra.operator.discordId`
+      // full DM access in `resolvePolicyAccess`. The `infra.principal.discordId`
       // field is preserved for the `notifyOperator` / `bufferOperatorDM`
       // paths which still need a Discord-side mailbox.
       let dmType: "operator" | "user" | undefined;
@@ -911,8 +911,8 @@ export class DiscordAdapter implements PlatformAdapter {
   }
 
   async notifyOperator(text: string): Promise<void> {
-    const operatorId = this.infra.operator.discordId;
-    if (!operatorId || !this.client) return;
+    const principalDiscordId = this.infra.principal.discordId;
+    if (!principalDiscordId || !this.client) return;
 
     if (!this.connectionHealth?.currentlyConnected) {
       this.bufferOperatorDM(text);
@@ -920,8 +920,8 @@ export class DiscordAdapter implements PlatformAdapter {
     }
 
     try {
-      const operator = await this.client.users.fetch(operatorId);
-      await operator.send(text);
+      const principalUser = await this.client.users.fetch(principalDiscordId);
+      await principalUser.send(text);
     } catch (err) {
       // TOCTOU: connection may have flipped between the check above and here.
       // Classify the error so we don't buffer permanently-undeliverable DMs:
@@ -1005,8 +1005,8 @@ export class DiscordAdapter implements PlatformAdapter {
     // bufferOperatorDM. Anything still in the buffer afterwards is fresh.
     this.cleanExpiredOperatorDMs();
     if (this.pendingOperatorDMs.length === 0) return;
-    const operatorId = this.infra.operator.discordId;
-    if (!operatorId || !this.client) {
+    const principalDiscordId = this.infra.principal.discordId;
+    if (!principalDiscordId || !this.client) {
       this.pendingOperatorDMs = [];
       return;
     }
@@ -1015,10 +1015,10 @@ export class DiscordAdapter implements PlatformAdapter {
 
     console.log(`discord-${this.instanceId}: draining ${toDeliver.length} pending operator DM(s)`);
     try {
-      const operator = await this.client.users.fetch(operatorId);
+      const principalUser = await this.client.users.fetch(principalDiscordId);
       for (const pending of toDeliver) {
         try {
-          await operator.send(pending.text);
+          await principalUser.send(pending.text);
         } catch (err) {
           console.error(
             `discord-${this.instanceId}: failed to deliver buffered operator DM:`,

--- a/src/adapters/mattermost/__tests__/render-envelope.test.ts
+++ b/src/adapters/mattermost/__tests__/render-envelope.test.ts
@@ -107,7 +107,7 @@ function makeAdapter(opts: {
   };
   const infra: MattermostAdapterInfra = {
     instanceId: "mm-renderer",
-    operator: {},
+    principal: {},
     ...(opts.surfaceSubjects !== undefined && { surfaceSubjects: opts.surfaceSubjects }),
     ...(opts.surfaceFallbackChannelId !== undefined && { surfaceFallbackChannelId: opts.surfaceFallbackChannelId }),
     ...(opts.surfaceFilter !== undefined && { surfaceFilter: opts.surfaceFilter }),

--- a/src/adapters/mattermost/__tests__/update-config.test.ts
+++ b/src/adapters/mattermost/__tests__/update-config.test.ts
@@ -97,7 +97,7 @@ function makeAdapter(overrides: { presence?: Partial<MattermostPresence> } = {})
   const agent = makeAgent(presence);
   const infra: MattermostAdapterInfra = {
     instanceId: "luna-mattermost",
-    operator: {},
+    principal: {},
   };
   return new MattermostAdapter(agent, presence, infra);
 }

--- a/src/adapters/mattermost/index.ts
+++ b/src/adapters/mattermost/index.ts
@@ -56,9 +56,9 @@ export interface MattermostAdapterInfra {
    * `${agent.id}-mattermost` at MIG-7.2e when migrate-config emits a real
    * agents[] array. */
   instanceId: string;
-  /** Operator's platform identity. Architecture §9.1: the operator runs the
+  /** Principal's platform identity. Architecture §9.1: the principal runs the
    * cortex deployment, distinct from the agents they host. */
-  operator: { mattermostId?: string };
+  principal: { mattermostId?: string };
   /** MIG-3b: NATS subject patterns this adapter renders to Mattermost.
    * Empty/undefined → adapter never matches in the surface-router. Moves to
    * Renderer config at MIG-7.2d. */
@@ -340,8 +340,8 @@ export class MattermostAdapter implements PlatformAdapter {
   }
 
   async notifyOperator(text: string): Promise<void> {
-    const operatorId = this.infra.operator.mattermostId;
-    if (!operatorId) return;
+    const principalMattermostId = this.infra.principal.mattermostId;
+    if (!principalMattermostId) return;
 
     try {
       // MIG-7.2c-mattermost (Holly cycle 1 W1+S1): use the cached bot user
@@ -358,7 +358,7 @@ export class MattermostAdapter implements PlatformAdapter {
           Authorization: `Bearer ${this.apiToken}`,
           "Content-Type": "application/json",
         },
-        body: JSON.stringify([botUserId, operatorId]),
+        body: JSON.stringify([botUserId, principalMattermostId]),
       });
 
       if (dmRes.ok) {

--- a/src/adapters/slack/__tests__/slack-adapter.test.ts
+++ b/src/adapters/slack/__tests__/slack-adapter.test.ts
@@ -159,7 +159,7 @@ function makeAdapter(opts: {
   const fake = makeFakeClient(opts.clientState);
   const infra: SlackAdapterInfra = {
     instanceId: "slack-test",
-    operator: {},
+    principal: {},
     client: fake.client,
     ...opts.infra,
   };
@@ -766,7 +766,7 @@ describe("SlackAdapter — sendProgress + createThread + notifyOperator", () => 
 
   test("notifyOperator DMs the operator when slackId is configured", async () => {
     const { adapter, state } = makeAdapter({
-      infra: { operator: { slackId: "UOPERATOR" } },
+      infra: { principal: { slackId: "UOPERATOR" } },
     });
     await adapter.notifyOperator("ping");
     expect(state.postedMessages).toEqual([{ channel: "UOPERATOR", text: "ping" }]);
@@ -774,7 +774,7 @@ describe("SlackAdapter — sendProgress + createThread + notifyOperator", () => 
 
   test("notifyOperator swallows post errors (log + drop)", async () => {
     const { adapter } = makeAdapter({
-      infra: { operator: { slackId: "UOPERATOR" } },
+      infra: { principal: { slackId: "UOPERATOR" } },
       clientState: { postMessageError: new Error("403 not_in_channel") },
     });
     // Must not throw — the operator's notification path is best-effort.
@@ -1412,7 +1412,7 @@ describe("SlackAdapter — surfaceConfig passes surfaceFilter through (cortex#23
     const fake = makeFakeClient();
     const adapter = new SlackAdapter(agent, presence, {
       instanceId: "slack-test",
-      operator: {},
+      principal: {},
       client: fake.client,
       surfaceSubjects: presence.surfaceSubjects,
       surfaceFilter: filter,

--- a/src/adapters/slack/index.ts
+++ b/src/adapters/slack/index.ts
@@ -46,7 +46,7 @@ import { RealSlackClient, type SlackClient, type SlackInboundEvent, type SlackBo
  * Cortex-deployment-level wiring passed alongside the agent + presence
  * pair. Mirror of `DiscordAdapterInfra` / `MattermostAdapterInfra`.
  *
- * `operator.slackId` is the operator's Slack user id (`U...`), used to
+ * `principal.slackId` is the principal's Slack user id (`U...`), used to
  * route `notifyOperator` DMs the same way the Discord/Mattermost
  * variants route theirs.
  *
@@ -56,8 +56,8 @@ import { RealSlackClient, type SlackClient, type SlackInboundEvent, type SlackBo
 export interface SlackAdapterInfra {
   /** Surface-router + log-prefix key. Cortex derives `${agent.id}-slack`. */
   instanceId: string;
-  /** Operator's platform identity. */
-  operator: { slackId?: string };
+  /** Principal's platform identity. */
+  principal: { slackId?: string };
   /**
    * MyelinRuntime for `system.adapter.*` envelope emission (cortex#235
    * r1#4). Optional — adapters started without NATS still track
@@ -525,7 +525,7 @@ export class SlackAdapter implements PlatformAdapter {
   /**
    * v2.0.0 (cortex#297) — operator detection via the policy `operator`
    * capability. Kept for adapter-internal use; the `notifyOperator`
-   * path still routes by `infra.operator.slackId`.
+   * path still routes by `infra.principal.slackId`.
    */
   protected isOperator(authorId: string): boolean {
     return isOperatorPrincipal(
@@ -600,12 +600,12 @@ export class SlackAdapter implements PlatformAdapter {
   }
 
   async notifyOperator(text: string): Promise<void> {
-    const operatorId = this.infra.operator.slackId;
-    if (!operatorId) return;
+    const principalSlackId = this.infra.principal.slackId;
+    if (!principalSlackId) return;
     try {
       // For DMs, Slack accepts the user id directly as `channel`. The
       // Web API opens (or reuses) the IM channel implicitly.
-      await this.client.postMessage(operatorId, text);
+      await this.client.postMessage(principalSlackId, text);
     } catch (err) {
       // Match the Mattermost/Discord notifyOperator pattern: log + drop.
       // A failed DM should never tear down the adapter; the operator can

--- a/src/common/config/__tests__/loader.test.ts
+++ b/src/common/config/__tests__/loader.test.ts
@@ -340,14 +340,14 @@ describe("MIG-7.2e — cortex-shape detection + transform", () => {
 
   test("synthesizes AgentConfig.agent from operator + first agent", () => {
     const path = writeCortexConfig(testDir, minimalCortex());
-    const { config, operator } = loadConfigWithAgents(path);
+    const { config, principal } = loadConfigWithAgents(path);
     expect(config.agent.name).toBe("ivy");
     expect(config.agent.displayName).toBe("Ivy");
     expect(config.agent.operatorId).toBe("jc");
     expect(config.agent.operatorName).toBe("Jens-Christian");
     // v2.0.0 (cortex#297) — operator*Id retired from AgentConfig.agent;
-    // surfaced through LoadedConfig.operator instead.
-    expect(operator?.discordId).toBe("285727653603049472");
+    // surfaced through LoadedConfig.principal instead.
+    expect(principal?.discordId).toBe("285727653603049472");
   });
 
   test("flattens agents[*].presence.discord into AgentConfig.discord[]", () => {
@@ -748,9 +748,9 @@ describe("MIG-7.2e — cortex-shape detection + transform", () => {
     const loaded = loadConfigWithAgents(path);
     expect(loaded.inlineAgents).toHaveLength(1);
     expect(loaded.inlineAgents[0]!.id).toBe("ivy");
-    // The principal block is normalised onto LoadedConfig.operator.
-    expect(loaded.operator?.id).toBe("jc");
-    expect(loaded.operator?.discordId).toBe("285727653603049472");
+    // The principal block is normalised onto LoadedConfig.principal.
+    expect(loaded.principal?.id).toBe("jc");
+    expect(loaded.principal?.discordId).toBe("285727653603049472");
     expect(loaded.config.agent.operatorId).toBe("jc");
   });
 

--- a/src/common/config/loader.ts
+++ b/src/common/config/loader.ts
@@ -79,9 +79,9 @@ export interface LoadedConfig {
    * loader after `agent.operatorDiscordId/Mattermost/Slack` retired from
    * AgentConfig. Populated only for cortex-shape configs (legacy bot.yaml
    * input always yields `undefined`). The boot path reads these to wire
-   * `DiscordAdapterInfra.operator.discordId` etc.
+   * `DiscordAdapterInfra.principal.discordId` etc.
    */
-  operator?: {
+  principal?: {
     id: string;
     discordId?: string;
     mattermostId?: string;
@@ -441,7 +441,7 @@ function loadCortexShape(
     }),
     // v2.0.0 cutover (cortex#297) — `operator*Id` fields retired from
     // AgentConfig.agent. Principal's platform-side ids surface through
-    // `LoadedConfig.operator` (see return value below); the boot path in
+    // `LoadedConfig.principal` (see return value below); the boot path in
     // cortex.ts reads them from there.
     dataResidency: cortexConfig.principal.dataResidency,
     personaFile: firstAgent.persona,
@@ -477,7 +477,7 @@ function loadCortexShape(
     config: AgentConfigSchema.parse(merged),
     inlineAgents: [...cortexConfig.agents],
     // v2.0.0 (cortex#297) — surface principal platform ids for the boot path.
-    operator: {
+    principal: {
       id: cortexConfig.principal.id,
       ...(cortexConfig.principal.discordId !== undefined && {
         discordId: cortexConfig.principal.discordId,

--- a/src/common/policy/resolve-access.ts
+++ b/src/common/policy/resolve-access.ts
@@ -176,7 +176,7 @@ export function resolvePolicyAccess(input: ResolvePolicyAccessInput): AccessDeci
 /**
  * Test whether the `(platform, platformId)` tuple maps to a principal
  * whose effective capabilities include `operator`. Used by adapters to
- * classify `msg.dmType` post-cutover (legacy `infra.operator.discordId`
+ * classify `msg.dmType` post-cutover (legacy `infra.principal.discordId`
  * comparison retired in favour of the policy-driven check).
  */
 export function isOperatorPrincipal(

--- a/src/common/registry/__tests__/client.test.ts
+++ b/src/common/registry/__tests__/client.test.ts
@@ -5,9 +5,9 @@
  *
  *   1. TOFU pubkey fetch at boot
  *   2. Pinned pubkey from config bypasses TOFU
- *   3. `getOperator` returns verified data
- *   4. `getOperator` returns undefined on signature verification failure
- *   5. `getOperator` returns undefined on network failure (no throw)
+ *   3. `getPrincipal` returns verified data
+ *   4. `getPrincipal` returns undefined on signature verification failure
+ *   5. `getPrincipal` returns undefined on network failure (no throw)
  *   6. Periodic refresh updates cache
  *   7. Shutdown stops the refresh timer
  *
@@ -128,7 +128,7 @@ describe("RegistryClient — TOFU + pinned pubkey", () => {
 
     const client = new RegistryClient({
       url: "https://registry.example/",
-      operatorIds: ["andreas"],
+      principalIds: ["andreas"],
       refreshIntervalMs: 0, // disable background timer for tests
       fetch: fakeFetch as typeof fetch,
       logError: () => {},
@@ -136,7 +136,7 @@ describe("RegistryClient — TOFU + pinned pubkey", () => {
     await client.start();
     try {
       expect(pubkeyFetched).toBe(true);
-      const fetched = client.getOperator("andreas");
+      const fetched = client.getPrincipal("andreas");
       expect(fetched).toBeDefined();
       expect(fetched?.operator_id).toBe("andreas");
     } finally {
@@ -161,7 +161,7 @@ describe("RegistryClient — TOFU + pinned pubkey", () => {
     const client = new RegistryClient({
       url: "https://registry.example",
       pubkey: kp.publicKeyB64,
-      operatorIds: ["jcfischer"],
+      principalIds: ["jcfischer"],
       refreshIntervalMs: 0,
       fetch: fakeFetch as typeof fetch,
       logError: () => {},
@@ -169,14 +169,14 @@ describe("RegistryClient — TOFU + pinned pubkey", () => {
     await client.start();
     try {
       expect(pubkeyFetched).toBe(false);
-      expect(client.getOperator("jcfischer")).toBeDefined();
+      expect(client.getPrincipal("jcfischer")).toBeDefined();
     } finally {
       client.stop();
     }
   });
 });
 
-describe("RegistryClient — getOperator()", () => {
+describe("RegistryClient — getPrincipal()", () => {
   test("returns the verified record after a successful refresh", async () => {
     const kp = await generateKeypair();
     const op = makeOperator("andreas", FAKE_PEER_PUBKEY_V1);
@@ -189,14 +189,14 @@ describe("RegistryClient — getOperator()", () => {
     const client = new RegistryClient({
       url: "https://registry.example",
       pubkey: kp.publicKeyB64,
-      operatorIds: ["andreas"],
+      principalIds: ["andreas"],
       refreshIntervalMs: 0,
       fetch: fakeFetch as typeof fetch,
       logError: () => {},
     });
     await client.start();
     try {
-      const got = client.getOperator("andreas");
+      const got = client.getPrincipal("andreas");
       expect(got).toEqual(op);
     } finally {
       client.stop();
@@ -234,14 +234,14 @@ describe("RegistryClient — getOperator()", () => {
     const client = new RegistryClient({
       url: "https://registry.example",
       pubkey: pinnedKp.publicKeyB64,
-      operatorIds: ["attacker"],
+      principalIds: ["attacker"],
       refreshIntervalMs: 0,
       fetch: fakeFetch as typeof fetch,
       logError: (m) => errs.push(m),
     });
     await client.start();
     try {
-      expect(client.getOperator("attacker")).toBeUndefined();
+      expect(client.getPrincipal("attacker")).toBeUndefined();
       expect(errs.some((e) => e.includes("signature did not verify"))).toBe(true);
     } finally {
       client.stop();
@@ -257,7 +257,7 @@ describe("RegistryClient — getOperator()", () => {
     const client = new RegistryClient({
       url: "https://registry.example",
       pubkey: kp.publicKeyB64,
-      operatorIds: ["andreas"],
+      principalIds: ["andreas"],
       refreshIntervalMs: 0,
       fetch: fakeFetch as typeof fetch,
       logError: (m) => errs.push(m),
@@ -265,7 +265,7 @@ describe("RegistryClient — getOperator()", () => {
     // start() must not throw even when every fetch rejects.
     await client.start();
     try {
-      expect(client.getOperator("andreas")).toBeUndefined();
+      expect(client.getPrincipal("andreas")).toBeUndefined();
       expect(errs.some((e) => e.includes("connection refused"))).toBe(true);
     } finally {
       client.stop();
@@ -288,14 +288,14 @@ describe("RegistryClient — getOperator()", () => {
     const client = new RegistryClient({
       url: "https://registry.example",
       pubkey: kp.publicKeyB64,
-      operatorIds: ["andreas"],
+      principalIds: ["andreas"],
       refreshIntervalMs: 0,
       fetch: fakeFetch as typeof fetch,
       logError: (m) => errs.push(m),
     });
     await client.start();
     try {
-      expect(client.getOperator("andreas")).toBeUndefined();
+      expect(client.getPrincipal("andreas")).toBeUndefined();
       expect(errs.some((e) => e.includes("unconfigured"))).toBe(true);
     } finally {
       client.stop();
@@ -315,14 +315,14 @@ describe("RegistryClient — getOperator()", () => {
     const client = new RegistryClient({
       url: "https://registry.example",
       pubkey: otherKp.publicKeyB64,
-      operatorIds: ["victim"],
+      principalIds: ["victim"],
       refreshIntervalMs: 0,
       fetch: fakeFetch as typeof fetch,
       logError: (m) => errs.push(m),
     });
     await client.start();
     try {
-      expect(client.getOperator("victim")).toBeUndefined();
+      expect(client.getPrincipal("victim")).toBeUndefined();
       expect(errs.some((e) => e.includes("registry pubkey mismatch"))).toBe(true);
     } finally {
       client.stop();
@@ -344,14 +344,14 @@ describe("RegistryClient — getOperator()", () => {
     const client = new RegistryClient({
       url: "https://registry.example",
       pubkey: kp.publicKeyB64,
-      operatorIds: ["alice"],
+      principalIds: ["alice"],
       refreshIntervalMs: 0,
       fetch: fakeFetch as typeof fetch,
       logError: (m) => errs.push(m),
     });
     await client.start();
     try {
-      expect(client.getOperator("alice")).toBeUndefined();
+      expect(client.getPrincipal("alice")).toBeUndefined();
       expect(errs.some((e) => e.includes("operator_id mismatch"))).toBe(true);
     } finally {
       client.stop();
@@ -378,14 +378,14 @@ describe("RegistryClient — getOperator()", () => {
     const client = new RegistryClient({
       url: "https://registry.example",
       pubkey: kp.publicKeyB64,
-      operatorIds: ["andreas"],
+      principalIds: ["andreas"],
       refreshIntervalMs: 0,
       fetch: fakeFetch as typeof fetch,
       logError: (m) => errs.push(m),
     });
     await client.start();
     try {
-      expect(client.getOperator("andreas")).toBeUndefined();
+      expect(client.getPrincipal("andreas")).toBeUndefined();
       expect(errs.some((e) => e.includes("not base64-Ed25519"))).toBe(true);
     } finally {
       client.stop();
@@ -416,7 +416,7 @@ describe("RegistryClient — start()/stop() idempotency", () => {
     const client = new RegistryClient({
       url: "https://registry.example",
       // No pubkey → TOFU mode → /registry/pubkey is called on start.
-      operatorIds: ["andreas"],
+      principalIds: ["andreas"],
       refreshIntervalMs: 0,
       fetch: fakeFetch as typeof fetch,
       logError: () => {},
@@ -464,7 +464,7 @@ describe("RegistryClient — start()/stop() idempotency", () => {
     const client = new RegistryClient({
       url: "https://registry.example",
       // TOFU mode (no pubkey from config).
-      operatorIds: ["andreas"],
+      principalIds: ["andreas"],
       refreshIntervalMs: 0,
       fetch: fakeFetch as typeof fetch,
       logError: () => {},
@@ -474,12 +474,12 @@ describe("RegistryClient — start()/stop() idempotency", () => {
       // After start: 2 TOFU attempts (boot + eager-refresh retry), both
       // failed, cache still empty.
       expect(pubkeyAttempts).toBe(2);
-      expect(client.getOperator("andreas")).toBeUndefined();
+      expect(client.getPrincipal("andreas")).toBeUndefined();
       // Third cycle: TOFU retries and succeeds → cache populates. The
       // client recovered without external intervention.
       await client.refreshAll();
       expect(pubkeyAttempts).toBe(3);
-      expect(client.getOperator("andreas")).toBeDefined();
+      expect(client.getPrincipal("andreas")).toBeDefined();
     } finally {
       client.stop();
     }
@@ -502,7 +502,7 @@ describe("RegistryClient — periodic refresh + shutdown", () => {
     const client = new RegistryClient({
       url: "https://registry.example",
       pubkey: kp.publicKeyB64,
-      operatorIds: ["andreas"],
+      principalIds: ["andreas"],
       // Disable the timer; drive cycles manually via refreshAll().
       // The timer behaviour is exercised by the shutdown test below.
       refreshIntervalMs: 0,
@@ -511,11 +511,11 @@ describe("RegistryClient — periodic refresh + shutdown", () => {
     });
     await client.start();
     try {
-      expect(client.getOperator("andreas")?.operator_pubkey).toBe(FAKE_PEER_PUBKEY_V1);
+      expect(client.getPrincipal("andreas")?.operator_pubkey).toBe(FAKE_PEER_PUBKEY_V1);
       // Operator rotates their pubkey upstream.
       currentPubkey = FAKE_PEER_PUBKEY_V2;
       await client.refreshAll();
-      expect(client.getOperator("andreas")?.operator_pubkey).toBe(FAKE_PEER_PUBKEY_V2);
+      expect(client.getPrincipal("andreas")?.operator_pubkey).toBe(FAKE_PEER_PUBKEY_V2);
     } finally {
       client.stop();
     }
@@ -536,7 +536,7 @@ describe("RegistryClient — periodic refresh + shutdown", () => {
     const client = new RegistryClient({
       url: "https://registry.example",
       pubkey: kp.publicKeyB64,
-      operatorIds: ["andreas"],
+      principalIds: ["andreas"],
       refreshIntervalMs: 25, // very short — would fire if not stopped
       fetch: fakeFetch as typeof fetch,
       logError: () => {},
@@ -576,7 +576,7 @@ describe("RegistryClient — periodic refresh + shutdown", () => {
     const client = new RegistryClient({
       url: "https://registry.example",
       pubkey: kp.publicKeyB64,
-      operatorIds: ["andreas"],
+      principalIds: ["andreas"],
       refreshIntervalMs: 0,
       fetch: fakeFetch as typeof fetch,
       logError: (m) => errs.push(m),
@@ -596,7 +596,7 @@ describe("RegistryClient — periodic refresh + shutdown", () => {
       // Now release the first cycle and let it complete.
       release?.();
       await inFlight;
-      expect(client.getOperator("andreas")).toBeDefined();
+      expect(client.getPrincipal("andreas")).toBeDefined();
       // A subsequent refresh after the cycle drained must run normally.
       await client.refreshAll();
       expect(fetchCalls.length).toBe(2);
@@ -617,18 +617,18 @@ describe("RegistryClient — periodic refresh + shutdown", () => {
     const client = new RegistryClient({
       url: "https://registry.example",
       pubkey: kp.publicKeyB64,
-      operatorIds: ["andreas"],
+      principalIds: ["andreas"],
       refreshIntervalMs: 0,
       fetch: fakeFetch as typeof fetch,
       logError: () => {},
     });
     await client.start();
     try {
-      expect(client.getOperator("andreas")).toBeDefined();
+      expect(client.getPrincipal("andreas")).toBeDefined();
       client.invalidate("andreas");
-      expect(client.getOperator("andreas")).toBeUndefined();
+      expect(client.getPrincipal("andreas")).toBeUndefined();
       await client.refreshAll();
-      expect(client.getOperator("andreas")).toBeDefined();
+      expect(client.getPrincipal("andreas")).toBeDefined();
     } finally {
       client.stop();
     }
@@ -636,19 +636,19 @@ describe("RegistryClient — periodic refresh + shutdown", () => {
 });
 
 describe("RegistryClient — empty config", () => {
-  test("operatorIds=[] makes the client dormant — no fetches, getOperator returns undefined", async () => {
+  test("principalIds=[] makes the client dormant — no fetches, getPrincipal returns undefined", async () => {
     const fetchSpy = mock(async (_url: string) => new Response("nope", { status: 404 }));
     const client = new RegistryClient({
       url: "https://registry.example",
       pubkey: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=", // 43 chars + = = 44
-      operatorIds: [],
+      principalIds: [],
       refreshIntervalMs: 0,
       fetch: fetchSpy as unknown as typeof fetch,
       logError: () => {},
     });
     await client.start();
     try {
-      expect(client.getOperator("anyone")).toBeUndefined();
+      expect(client.getPrincipal("anyone")).toBeUndefined();
       expect(fetchSpy.mock.calls.length).toBe(0);
     } finally {
       client.stop();

--- a/src/common/registry/client.ts
+++ b/src/common/registry/client.ts
@@ -4,7 +4,7 @@
  * Consults the cortex-network-registry service
  * (`src/services/network-registry/`) at boot and on a background
  * refresh schedule to populate an in-memory cache of verified peer
- * pubkeys. Cortex consumers read via `getOperator(operatorId)` and
+ * pubkeys. Cortex consumers read via `getPrincipal(principalId)` and
  * receive `undefined` on every failure path — federation issues must
  * not crash the bot.
  *
@@ -32,7 +32,7 @@
  * The client refreshes every entry every `refreshIntervalMs` (default
  * 5 minutes). When the eventual `system.operator.published` bus event
  * lands (filed as a follow-up — the producer side isn't wired yet),
- * `invalidate(operatorId)` provides the seam to short-circuit the
+ * `invalidate(principalId)` provides the seam to short-circuit the
  * refresh. Until then, TTL is the only invalidation mechanism — the
  * worst-case staleness is one refresh interval.
  *
@@ -68,12 +68,12 @@ const DEFAULT_REQUEST_TIMEOUT_MS = 10_000;
 
 /**
  * `RegistryClient` — single-process, in-memory cache of registry-
- * resolved peer operator records. Construct, `start()`, query via
- * `getOperator()`, `stop()` at shutdown.
+ * resolved peer principal records. Construct, `start()`, query via
+ * `getPrincipal()`, `stop()` at shutdown.
  */
 export class RegistryClient implements RegistryClientReader {
   private readonly url: string;
-  private readonly operatorIds: readonly string[];
+  private readonly principalIds: readonly string[];
   private readonly refreshIntervalMs: number;
   private readonly requestTimeoutMs: number;
   private readonly fetchImpl: typeof globalThis.fetch;
@@ -120,7 +120,7 @@ export class RegistryClient implements RegistryClientReader {
   constructor(options: RegistryClientOptions) {
     // Trailing slash normalisation so callers can pass either form.
     this.url = options.url.replace(/\/+$/, "");
-    this.operatorIds = [...options.operatorIds];
+    this.principalIds = [...options.principalIds];
     this.refreshIntervalMs =
       options.refreshIntervalMs ?? DEFAULT_REFRESH_INTERVAL_MS;
     this.requestTimeoutMs =
@@ -171,7 +171,7 @@ export class RegistryClient implements RegistryClientReader {
     }
 
     // One eager refresh so the cache is populated before any caller
-    // queries `getOperator()`. Errors are already logged inside the
+    // queries `getPrincipal()`. Errors are already logged inside the
     // cycle; we deliberately don't propagate — a refresh failure must
     // not block cortex boot.
     await this.refreshAll();
@@ -213,18 +213,18 @@ export class RegistryClient implements RegistryClientReader {
     }
   }
 
-  /** RegistryClientReader.getOperator — see interface JSDoc. */
-  getOperator(operatorId: string): OperatorRecord | undefined {
-    return this.cache.get(operatorId);
+  /** RegistryClientReader.getPrincipal — see interface JSDoc. */
+  getPrincipal(principalId: string): OperatorRecord | undefined {
+    return this.cache.get(principalId);
   }
 
   /**
    * Invalidate a single cache entry. The next `refreshAll()` (or an
-   * explicit `refreshOperator(operatorId)`) will repopulate it.
+   * explicit `refreshPrincipal(principalId)`) will repopulate it.
    * Exposed for the future `system.operator.published` event handler.
    */
-  invalidate(operatorId: string): void {
-    this.cache.delete(operatorId);
+  invalidate(principalId: string): void {
+    this.cache.delete(principalId);
   }
 
   /**
@@ -276,9 +276,9 @@ export class RegistryClient implements RegistryClientReader {
       // Serial rather than parallel: peer lists are short (single-digit
       // typical, dozens worst-case), the registry is shared, and serial
       // is more polite under load. Parallelise later if measured-needed.
-      for (const operatorId of this.operatorIds) {
+      for (const principalId of this.principalIds) {
         if (signal.aborted) break;
-        await this.refreshOperator(operatorId, signal);
+        await this.refreshPrincipal(principalId, signal);
       }
     } finally {
       this.refreshInFlight = false;
@@ -286,7 +286,7 @@ export class RegistryClient implements RegistryClientReader {
   }
 
   // =============================================================================
-  // Private — TOFU + per-operator refresh
+  // Private — TOFU + per-principal refresh
   // =============================================================================
 
   private async fetchAndPinRegistryPubkey(): Promise<void> {
@@ -320,17 +320,19 @@ export class RegistryClient implements RegistryClientReader {
     this.pinnedPubkey = publicKey;
   }
 
-  private async refreshOperator(
-    operatorId: string,
+  private async refreshPrincipal(
+    principalId: string,
     signal: AbortSignal,
   ): Promise<void> {
-    const url = `${this.url}/operators/${encodeURIComponent(operatorId)}`;
+    // Wire path stays `/operators/:operator_id` until PR-R7c-network-registry
+    // renames the registry service.
+    const url = `${this.url}/operators/${encodeURIComponent(principalId)}`;
     const raw = await this.fetchJson(url, signal);
     if (raw === undefined) return; // already logged inside fetchJson
 
-    const verified = await this.verifyAssertion(operatorId, raw);
+    const verified = await this.verifyAssertion(principalId, raw);
     if (verified === undefined) return; // already logged inside verifyAssertion
-    this.cache.set(operatorId, verified);
+    this.cache.set(principalId, verified);
   }
 
   /**
@@ -343,19 +345,19 @@ export class RegistryClient implements RegistryClientReader {
    * defeat the purpose of the check.
    */
   private async verifyAssertion(
-    operatorId: string,
+    principalId: string,
     raw: unknown,
   ): Promise<OperatorRecord | undefined> {
     const pinned = this.pinnedPubkey;
     if (pinned === undefined) {
       this.logError(
-        `refresh(${operatorId}): no pinned pubkey; refusing to trust assertion`,
+        `refresh(${principalId}): no pinned pubkey; refusing to trust assertion`,
       );
       return undefined;
     }
     // Shape check first — cheaper than crypto and gives a clearer log.
     if (raw === null || typeof raw !== "object") {
-      this.logError(`refresh(${operatorId}): assertion not an object; ignoring`);
+      this.logError(`refresh(${principalId}): assertion not an object; ignoring`);
       return undefined;
     }
     const assertion = raw as Record<string, unknown>;
@@ -367,20 +369,20 @@ export class RegistryClient implements RegistryClientReader {
       typeof assertion.payload !== "object"
     ) {
       this.logError(
-        `refresh(${operatorId}): malformed assertion envelope; ignoring`,
+        `refresh(${principalId}): malformed assertion envelope; ignoring`,
       );
       return undefined;
     }
     const registry = assertion.registry;
     if (registry === "unconfigured") {
       this.logError(
-        `refresh(${operatorId}): registry assertion says "unconfigured"; refusing`,
+        `refresh(${principalId}): registry assertion says "unconfigured"; refusing`,
       );
       return undefined;
     }
     if (registry !== pinned) {
       this.logError(
-        `refresh(${operatorId}): registry pubkey mismatch (got ${registry.slice(0, 8)}…, pinned ${pinned.slice(0, 8)}…); ignoring`,
+        `refresh(${principalId}): registry pubkey mismatch (got ${registry.slice(0, 8)}…, pinned ${pinned.slice(0, 8)}…); ignoring`,
       );
       return undefined;
     }
@@ -388,16 +390,18 @@ export class RegistryClient implements RegistryClientReader {
     // re-validate the deep structure here — the registry is the source
     // of truth for its own shape — but we do require the same
     // operator_id we requested, defending against a swapped payload.
+    // Wire-field reads (`payload.operator_id`, `payload.operator_pubkey`)
+    // stay until PR-R7c-network-registry renames the registry service.
     const payload = assertion.payload as Record<string, unknown>;
-    if (payload.operator_id !== operatorId) {
+    if (payload.operator_id !== principalId) {
       this.logError(
-        `refresh(${operatorId}): payload.operator_id mismatch (got "${String(payload.operator_id)}"); ignoring`,
+        `refresh(${principalId}): payload.operator_id mismatch (got "${String(payload.operator_id)}"); ignoring`,
       );
       return undefined;
     }
     if (typeof payload.operator_pubkey !== "string") {
       this.logError(
-        `refresh(${operatorId}): payload.operator_pubkey missing or non-string; ignoring`,
+        `refresh(${principalId}): payload.operator_pubkey missing or non-string; ignoring`,
       );
       return undefined;
     }
@@ -417,7 +421,7 @@ export class RegistryClient implements RegistryClientReader {
     // on the producer side (base64 of 32 raw bytes).
     if (!/^[A-Za-z0-9+/]{43}=$/.test(payload.operator_pubkey)) {
       this.logError(
-        `refresh(${operatorId}): payload.operator_pubkey is not base64-Ed25519 (got "${payload.operator_pubkey.slice(0, 12)}…"); ignoring`,
+        `refresh(${principalId}): payload.operator_pubkey is not base64-Ed25519 (got "${payload.operator_pubkey.slice(0, 12)}…"); ignoring`,
       );
       return undefined;
     }
@@ -434,13 +438,13 @@ export class RegistryClient implements RegistryClientReader {
       ok = await verifyEd25519(pinned, assertion.signature, message);
     } catch (err) {
       this.logError(
-        `refresh(${operatorId}): verify threw: ${err instanceof Error ? err.message : String(err)}`,
+        `refresh(${principalId}): verify threw: ${err instanceof Error ? err.message : String(err)}`,
       );
       return undefined;
     }
     if (!ok) {
       this.logError(
-        `refresh(${operatorId}): signature did not verify; ignoring`,
+        `refresh(${principalId}): signature did not verify; ignoring`,
       );
       return undefined;
     }
@@ -448,7 +452,7 @@ export class RegistryClient implements RegistryClientReader {
     // service to populate, but a corrupted payload could send the
     // wrong shape past the structural checks above. Normalise.
     return {
-      operator_id: operatorId,
+      operator_id: principalId,
       operator_pubkey: payload.operator_pubkey,
       stacks: Array.isArray(payload.stacks) ? (payload.stacks as OperatorRecord["stacks"]) : [],
       capabilities: Array.isArray(payload.capabilities) ? (payload.capabilities as OperatorRecord["capabilities"]) : [],

--- a/src/common/registry/types.ts
+++ b/src/common/registry/types.ts
@@ -95,7 +95,7 @@ export interface RegistryPubkeyResponse {
 
 /**
  * Configuration for `RegistryClient`. The required fields are the
- * registry URL and the list of peer operator ids to track; everything
+ * registry URL and the list of peer principal ids to track; everything
  * else has a sensible default. Tests supply `fetch` + `setTimer` to
  * inject a fake transport + timer without real I/O.
  */
@@ -111,12 +111,14 @@ export interface RegistryClientOptions {
    */
   pubkey?: string;
   /**
-   * Operator ids the client should track. Populated at boot from
-   * `policy.federated.networks[].peers[].operator_id` (de-duplicated).
+   * Principal ids the client should track. Populated at boot from
+   * `policy.federated.networks[].peers[].operator_id` (de-duplicated;
+   * wire field stays `operator_id` until PR-R7c-network-registry
+   * renames the registry service).
    * Empty list means the client starts dormant — no refresh cycles,
-   * `getOperator()` always returns undefined.
+   * `getPrincipal()` always returns undefined.
    */
-  operatorIds: string[];
+  principalIds: string[];
   /**
    * Refresh interval in milliseconds. Default 5 minutes — long enough
    * to be polite to the registry, short enough that a publish becomes
@@ -152,13 +154,16 @@ export interface RegistryClientOptions {
  */
 export interface RegistryClientReader {
   /**
-   * Return the cached `OperatorRecord` for `operatorId`, or
-   * `undefined` if the operator is unknown, the cache is empty, the
+   * Return the cached `OperatorRecord` for `principalId`, or
+   * `undefined` if the principal is unknown, the cache is empty, the
    * last fetch failed, or the signature did not verify.
+   *
+   * The return type stays `OperatorRecord` until PR-R7c-network-registry
+   * renames the registry service's wire-shape symbol.
    *
    * Never throws — federation failures must not crash the rest of
    * cortex. All error paths log via `logError` and return
    * `undefined`.
    */
-  getOperator(operatorId: string): OperatorRecord | undefined;
+  getPrincipal(principalId: string): OperatorRecord | undefined;
 }

--- a/src/common/types/config.ts
+++ b/src/common/types/config.ts
@@ -272,7 +272,7 @@ export const AgentConfigSchema = z.object({
     /**
      * v2.0.0 cutover (cortex#297) — `operatorDiscordId/Mattermost/Slack` retired.
      * The principal's platform-side ids live on `PrincipalConfigSchema.discordId/mattermostId/slackId`
-     * in cortex-config.ts and are surfaced through `LoadedConfig.operator` for the
+     * in cortex-config.ts and are surfaced through `LoadedConfig.principal` for the
      * boot path. Runtime "is this principal an operator?" decisions consult the
      * PolicyEngine via the `operator` capability per the new model.
      */

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -308,7 +308,7 @@ export interface StartCortexOptions {
   bus?: BusConfig;
   /**
    * v2.0.0 cutover (cortex#297) — principal's platform-side ids surfaced
-   * from `PrincipalConfigSchema` via `LoadedConfig.operator`. Replaces the
+   * from `PrincipalConfigSchema` via `LoadedConfig.principal`. Replaces the
    * `AgentConfig.agent.operatorDiscordId/Mattermost/Slack` fields retired
    * in cortex#297. `undefined` for legacy `bot.yaml` input — adapters
    * then have no principal-DM target and `notifyOperator` is a no-op.
@@ -329,8 +329,8 @@ export interface StartCortexOptions {
  * cortex process. v3 vocabulary (cortex#388) made `principal.id` the
  * single source of truth on cortex.yaml; the loader synthesises a
  * legacy-compatible `AgentConfig.agent.operatorId` for downstream code
- * AND surfaces the same value as `LoadedConfig.operator.id`. This
- * helper prefers the v3-canonical `LoadedConfig.operator` path so the
+ * AND surfaces the same value as `LoadedConfig.principal.id`. This
+ * helper prefers the v3-canonical `LoadedConfig.principal` path so the
  * post-MIG-8 schema deletion (PR-C of cortex#426) is a single-line
  * change here — drop the `agent.operatorId` fallback.
  *
@@ -1213,7 +1213,7 @@ export async function startCortex(
       registryClient = new RegistryClient({
         url: registryConfig.url,
         ...(registryConfig.pubkey !== undefined && { pubkey: registryConfig.pubkey }),
-        operatorIds: peerOperatorIds,
+        principalIds: peerOperatorIds,
       });
       // Boot the client asynchronously — TOFU + initial refresh must
       // not block the rest of cortex boot. Errors inside `start()`
@@ -1381,7 +1381,7 @@ export async function startCortex(
         presence,
         {
           instanceId,
-          operator: {
+          principal: {
             ...(options.operator?.discordId !== undefined && { discordId: options.operator.discordId }),
           },
           runtime,
@@ -1561,7 +1561,7 @@ export async function startCortex(
         presence,
         {
           instanceId,
-          operator: {
+          principal: {
             ...(options.operator?.mattermostId !== undefined && { mattermostId: options.operator.mattermostId }),
           },
           ...(adapterPolicyEngine !== undefined && { policyEngine: adapterPolicyEngine }),
@@ -1642,7 +1642,7 @@ export async function startCortex(
         presence,
         {
           instanceId,
-          operator: {
+          principal: {
             ...(options.operator?.slackId !== undefined && { slackId: options.operator.slackId }),
           },
           ...(adapterPolicyEngine !== undefined && { policyEngine: adapterPolicyEngine }),
@@ -2459,13 +2459,16 @@ if (import.meta.main) {
       // block when the principal declared one — `startCortex` calls
       // `deriveStackId` and logs the resolved stack id. Today this is
       // observational only; emit subjects are unchanged.
-      const { config, inlineAgents, stack, policy, operator, bus } = loadConfigWithAgents(options.config);
+      const { config, inlineAgents, stack, policy, principal, bus } = loadConfigWithAgents(options.config);
       const handle = await startCortex(config, {
         configPath: options.config,
         ...(inlineAgents.length > 0 && { inlineAgents }),
         ...(stack !== undefined && { stack }),
         ...(policy !== undefined && { policy }),
-        ...(operator !== undefined && { operator }),
+        // PR-R13.B.i: LoadedConfig field is `.principal`; the
+        // StartCortexOptions field is still `.operator` (renames in
+        // PR-R13.B). Map between them here until that PR lands.
+        ...(principal !== undefined && { operator: principal }),
         ...(bus !== undefined && { bus }),
       });
 


### PR DESCRIPTION
## Summary

PR-R2c per 0002 vocabulary-finish plan + cortex#440. Ships two coupled renames together (Major 3 coupling — adapters get one coherent edit per file):

- **R2.G** — Registry client surface (`getOperator` → `getPrincipal`, `operatorIds` → `principalIds`) + adapter local-vars (`operatorId` → `principalDiscordId/SlackId/MattermostId`)
- **R13.B.i** — `LoadedConfig.operator` and `*AdapterInfra.operator` runtime-field renames to `.principal`

Wire-shape symbol `OperatorRecord` and wire fields `operator_id`/`operator_pubkey` are preserved — they rename together with the registry service in **PR-R7c-network-registry** (step 10 of the recommended sequence). Same applies to `StartCortexOptions.operator?` (R13.B), `notifyOperator` function name + adapter prose (R13c), and the `options.operator.*` test references.

## Scope

Files changed (20):

```
src/common/registry/types.ts                       | 21 +++---
src/common/registry/client.ts                      | 72 ++++++++++----------
src/common/registry/__tests__/client.test.ts       | 78 +++++++++++-----------
src/cortex.ts                                      | 21 +++---
src/common/config/loader.ts                        |  8 +--
src/common/config/__tests__/loader.test.ts         | 12 ++--
src/common/types/config.ts                         |  2 +-
src/common/policy/resolve-access.ts                |  2 +-
src/adapters/discord/index.ts                      | 22 +++---
src/adapters/discord/__tests__/*.ts                | (6 files)
src/adapters/mattermost/index.ts                   | 10 +--
src/adapters/mattermost/__tests__/*.ts             | (2 files)
src/adapters/slack/index.ts                        | 14 ++--
src/adapters/slack/__tests__/slack-adapter.test.ts |  8 +--
```

288 LOC churn (~150 insertions, ~138 deletions).

## Acceptance criteria (from cortex#440)

- [x] `grep -rEn '\binfra\.operator\.' src/` returns 0 hits.
- [x] `grep -rEn '\bgetOperator\b|\bputOperator\b|\blistOperators\b' src/common/registry/` returns 0 hits (renamed to `*Principal`).
- [x] Discord/Slack/Mattermost adapter local-var renames complete (no `const operatorId =` in those three files).
- [x] `bun test` passes — 3545 pass, 2 skip, 0 fail.
- [x] `bunx tsc --noEmit` clean.
- [x] Carve-outs preserved.

## Notes on the LoadedConfig ↔ StartCortexOptions mismatch

After this PR, `LoadedConfig.principal` and `StartCortexOptions.operator?` differ on the field name during the partial-migration window. The boot path in `cortex.ts:2462` explicitly maps `principal` → `operator` at the call site:

```ts
const { config, inlineAgents, stack, policy, principal, bus } = loadConfigWithAgents(options.config);
const handle = await startCortex(config, {
  ...
  ...(principal !== undefined && { operator: principal }), // PR-R13.B closes this
  ...
});
```

PR-R13.B will rename `StartCortexOptions.operator` → `.principal` and remove the explicit map.

## Test plan

- [ ] Verify `bun test` passes on CI (locally: 3545 pass, 2 skip, 0 fail)
- [ ] Verify `bunx tsc --noEmit` clean on CI
- [ ] Verify `bun run lint:errors` clean on CI
- [ ] Manual smoke: re-run `grep -rEn 'infra\.operator\.|this\.infra\.operator\.|config\.operator\.|loadedConfig\.operator\.|\.operator\.(id|discordId|mattermostId|slackId)\b' src/` and confirm only `options.operator.*` (StartCortexOptions, R13.B scope) hits remain.

Refs cortex#436.
Closes cortex#440.