### PR TITLE
feat(cortex): C-13b — runner/bus prose sweep (closes #443)

### DIFF
--- a/src/bus/__tests__/dispatch-handler.test.ts
+++ b/src/bus/__tests__/dispatch-handler.test.ts
@@ -335,7 +335,7 @@ describe("DispatchHandler — system.inbound.aborted emission (MIG-3.8 / C-104)"
       phase: "pre_dispatch",
     });
     // Drift-detection: any change in the helper that violates the vendored
-    // myelin schema must fail here, not at runtime on a live operator alert.
+    // myelin schema must fail here, not at runtime on a live principal alert.
     expect(validateEnvelope(env).ok).toBe(true);
 
     await handler.shutdown();
@@ -670,7 +670,7 @@ describe("DispatchHandler — chat-path CC failure retry (cortex#360)", () => {
     // Two CC spawns: the failing first attempt and the recovering second.
     expect(spawnCount()).toBe(2);
 
-    // Operator-visible messages: one "Still working… (attempt 2/3)" then the
+    // Principal-visible messages: one "Still working… (attempt 2/3)" then the
     // final response. No apology message.
     const texts = adapter.sentMessages.map((m) => m.text);
     expect(texts.length).toBe(2);
@@ -783,7 +783,7 @@ describe("DispatchHandler — chat-path CC failure retry (cortex#360)", () => {
     // (retryable). To exercise the terminal-failure-immediate-exit path we
     // need a result whose classifier returns null — e.g. `success === true`
     // but `!response`. That's the "cc exited cleanly but skill misbehaved"
-    // case — the chat-path treats it as cant_do (operator action needed)
+    // case — the chat-path treats it as cant_do (principal action needed)
     // and surfaces the apology after attempt 1.
     const runtime = makeRecordingRuntime();
     const { factory, spawnCount } = makeStubFactory([

--- a/src/bus/__tests__/github-events.test.ts
+++ b/src/bus/__tests__/github-events.test.ts
@@ -167,7 +167,7 @@ describe("createGithubEventEnvelope", () => {
     expect(() => new Date(a.timestamp).toISOString()).not.toThrow();
   });
 
-  test("sovereignty defaults are operator-only / NZ when source has no override", () => {
+  test("sovereignty defaults are principal-only / NZ when source has no override", () => {
     const env = createGithubEventEnvelope({
       source: SRC,
       event: "push",
@@ -266,7 +266,7 @@ describe("github.* — classification parameterisation (IAW A.3)", () => {
     payload: { number: 42 },
   };
 
-  test("omitting classification defaults to local (operator-private)", () => {
+  test("omitting classification defaults to local (principal-private)", () => {
     const env = createGithubEventEnvelope(baseOpts);
     expect(env.sovereignty.classification).toBe("local");
     expect(validateEnvelope(env).ok).toBe(true);

--- a/src/bus/__tests__/surface-router.test.ts
+++ b/src/bus/__tests__/surface-router.test.ts
@@ -1622,7 +1622,7 @@ describe("evaluateFederationGate — max_hop", () => {
 
   test("deny-list precedence: hop overage on a deny-listed subject reports peer_deny_list", () => {
     // Deny-list runs before hop counting; the deny reason is what
-    // the operator sees, not the hop fact.
+    // the principal sees, not the hop fact.
     const decision = evaluateFederationGate(
       "federated.research-collab.tasks.private.secret",
       makeFederatedEnvelope({
@@ -1773,7 +1773,7 @@ describe("createSurfaceRouter — D.2 federation gating end-to-end", () => {
     const { runtime, published } = fakeRuntimeWithPublishLog();
     const router = createSurfaceRouter(runtime, {
       systemEventSource: TEST_SYSTEM_EVENT_SOURCE,
-      // No `federated:` block — operator hasn't declared any networks.
+      // No `federated:` block — principal hasn't declared any networks.
     });
     const a = recordingAdapter({
       id: "fed-adapter",
@@ -1991,7 +1991,7 @@ describe("emitAccessFiltered — defensive .catch on publish failure (cortex#137
       await new Promise((r) => setTimeout(r, 0));
       // Adapter was filtered (no render).
       expect(a.calls).toHaveLength(0);
-      // Stderr got the audit-failure alert — operator-visible signal
+      // Stderr got the audit-failure alert — principal-visible signal
       // instead of silent drop.
       const alert = captured.find((c) => c.includes("system.access.filtered"));
       expect(alert).toBeDefined();

--- a/src/bus/__tests__/system-events.test.ts
+++ b/src/bus/__tests__/system-events.test.ts
@@ -52,7 +52,7 @@ describe("createSystemAdapterDegradedEvent", () => {
     });
     // No correlation_id (see file header — known spec gap).
     expect(env.correlation_id).toBeUndefined();
-    // Sovereignty defaults match operator-only / no frontier.
+    // Sovereignty defaults match principal-only / no frontier.
     expect(env.sovereignty).toEqual({
       classification: "local",
       data_residency: "NZ",
@@ -438,7 +438,7 @@ describe("createSystemAccessFilteredEvent", () => {
     });
     // No correlation_id by default — access decisions are independent events.
     expect(env.correlation_id).toBeUndefined();
-    // Sovereignty defaults match the rest of system.* — operator-only, local.
+    // Sovereignty defaults match the rest of system.* — principal-only, local.
     expect(env.sovereignty).toEqual({
       classification: "local",
       data_residency: "NZ",
@@ -484,7 +484,7 @@ describe("createSystemAccessFilteredEvent", () => {
 
   test("explicit classification override propagates to sovereignty", () => {
     // Mirrors the Phase A.3 pattern on the other system.* helpers — an
-    // operator may opt the access-decision stream into federated reach so
+    // principal may opt the access-decision stream into federated reach so
     // peer dashboards can observe drops too.
     const env = createSystemAccessFilteredEvent({
       source: { org: "metafactory", agent: "cortex", instance: "local" },
@@ -546,7 +546,7 @@ describe("createAgentHeartbeatEvent", () => {
       last_activity_ms_ago: 1500,
       iteration: 7,
     });
-    // Sovereignty defaults match operator-only / no frontier.
+    // Sovereignty defaults match principal-only / no frontier.
     expect(env.sovereignty).toEqual({
       classification: "local",
       data_residency: "NZ",
@@ -579,7 +579,7 @@ describe("createAgentHeartbeatEvent", () => {
     expect(a.id).not.toBe(b.id);
   });
 
-  test("federated classification opt-in for future cross-operator heartbeats", () => {
+  test("federated classification opt-in for future cross-principal heartbeats", () => {
     const env = createAgentHeartbeatEvent({
       source: { org: "metafactory", agent: "cortex", instance: "local" },
       agentId: "echo",

--- a/src/bus/bus-dispatch-listener.ts
+++ b/src/bus/bus-dispatch-listener.ts
@@ -166,7 +166,7 @@ export class BusDispatchListener {
    *
    * The "own publish" check uses envelope source attribution rather
    * than envelope id — at this slice we don't track our own outbound
-   * ids, and `source` is the dotted `{operator}.{agent}.{instance}`
+   * ids, and `source` is the dotted `{principal}.{agent}.{instance}`
    * shape every cortex publish stamps.
    *
    * **Security note** (Echo cortex#203 round 1): the source filter is

--- a/src/bus/capability-registry.ts
+++ b/src/bus/capability-registry.ts
@@ -103,14 +103,14 @@ export type PublishFn = (envelope: Envelope) => Promise<void>;
  * registry).
  */
 export interface CapabilityRegistrySource {
-  /** Operator id — first dotted segment of `envelope.source`. */
+  /** Principal id — first dotted segment of `envelope.source`. */
   org: string;
   /** Logical agent label for the *publisher* (typically `"cortex"`). */
   agent: string;
   /** Stable instance label — usually `"local"` for in-process emission. */
   instance: string;
   /**
-   * Operator residency code for `envelope.sovereignty.data_residency`.
+   * Principal residency code for `envelope.sovereignty.data_residency`.
    * Defaults to `"NZ"` when omitted (matches the original cortex
    * deployment). Mirrors the same field on `SystemEventSource`.
    */
@@ -139,7 +139,7 @@ export interface CapabilityRegistryEntry {
 /**
  * Options for `publishCapabilityRegistry()`. The boot wiring (PR-7)
  * builds this from the parsed cortex.yaml's `agents[]` (mapped to
- * `entries[]` by lifting `runtime.capabilities`) plus the operator's
+ * `entries[]` by lifting `runtime.capabilities`) plus the principal's
  * source identity.
  *
  * `clock` + `instance` are injection seams so tests can assert exact
@@ -161,8 +161,8 @@ export interface PublishCapabilityRegistryOptions {
   publish: PublishFn;
   /**
    * Optional instance label baked into the payload (`instance` field
-   * per §3.2). Defaults to `source.instance` — operators running
-   * multiple cortex daemons in the same operator namespace override
+   * per §3.2). Defaults to `source.instance` — principals running
+   * multiple cortex daemons in the same principal namespace override
    * this to disambiguate.
    */
   instance?: string;
@@ -214,7 +214,7 @@ function buildSource(src: CapabilityRegistrySource): string {
 
 /**
  * Default sovereignty posture for capability-registration envelopes.
- * Matches §3.2 verbatim: `classification: local` (operator-private
+ * Matches §3.2 verbatim: `classification: local` (principal-private
  * unless overridden), residency from `source.dataResidency` (defaulting
  * to `"NZ"`), max_hop 0, no frontier, local-only model class.
  *

--- a/src/bus/dispatch-events.ts
+++ b/src/bus/dispatch-events.ts
@@ -2,7 +2,7 @@
  * MIG-4.6 — `dispatch.task.*` envelope constructors.
  *
  * Per G-1111 §3.4 the `dispatch.task` domain captures the lifecycle of a
- * task that an operator (or a sibling agent) dispatched to a runner-style
+ * task that a principal (or a sibling agent) dispatched to a runner-style
  * agent: `dispatched`, `accepted`, `rejected`, `started`, `completed`,
  * `failed`. This file ships the four lifecycle helpers cortex's runner
  * needs end-to-end (`started`, `completed`, `failed`, `aborted`).
@@ -10,7 +10,7 @@
  * Note on §3.4 vs §6: the spec's §3.4 summary table omits `aborted`
  * (only lists `failed`) but the natural runtime distinction between
  * "the task failed under its own power" and "the task was killed by an
- * outside force (timeout, operator cancel, shutdown)" is load-bearing
+ * outside force (timeout, principal cancel, shutdown)" is load-bearing
  * for surfaces — a worklog rendering "aborted: timeout" reads very
  * differently from "failed: assertion error". We therefore add
  * `aborted` as a non-breaking sibling to `failed` per §3.1's
@@ -57,10 +57,10 @@ function buildSource(src: SystemEventSource): string {
 
 /**
  * Default sovereignty for `dispatch.task.*` events. Same posture as
- * `system.*`: operator-only by default, local residency, no frontier.
+ * `system.*`: principal-only by default, local residency, no frontier.
  *
  * `data_residency` is sourced from `source.dataResidency` (defaulting to
- * `"NZ"` for the original cortex deployment) so a non-NZ operator gets
+ * `"NZ"` for the original cortex deployment) so a non-NZ principal gets
  * envelopes stamped with their actual residency. Mirrors the parameterisation
  * pattern in `system-events.ts` so both event domains read the same field
  * off the same source struct.
@@ -68,7 +68,7 @@ function buildSource(src: SystemEventSource): string {
  * **IAW Phase A.3:** `classification` is now an optional parameter
  * (defaulting to `"local"` for back-compat). Callers may opt into
  * `"federated"` or `"public"` when dispatch lifecycle events need to cross
- * operator boundaries (e.g. a federated multi-org dispatch). The default
+ * principal boundaries (e.g. a federated multi-org dispatch). The default
  * keeps every existing call site behaving identically.
  *
  * Returned as a fresh literal per call so a downstream mutation on one
@@ -126,8 +126,8 @@ export interface DispatchTaskCommonOpts {
   correlationId?: string;
   /**
    * IAW Phase A.3 — optional sovereignty classification. Defaults to
-   * `"local"` (operator-private). Set to `"federated"` when a dispatch
-   * lifecycle event needs to reach peer operators (e.g. a multi-org task
+   * `"local"` (principal-private). Set to `"federated"` when a dispatch
+   * lifecycle event needs to reach peer principals (e.g. a multi-org task
    * pipeline whose progress should surface on federated dashboards);
    * `"public"` for global visibility. Mismatch with the publish-time
    * subject is a protocol violation (see
@@ -284,7 +284,7 @@ export interface DispatchTaskFailedOpts extends DispatchTaskCommonOpts {
  *                           (capability mismatch; persistent until a
  *                           consumer registers).
  *   - `wont_do`           — sovereignty policy refused (agent could but
- *                           policy says no; persistent — operator action
+ *                           policy says no; persistent — principal action
  *                           needed).
  *   - `not_now`           — backpressure (capability is registered, just
  *                           busy; transient, retry safe). Optional
@@ -330,7 +330,7 @@ export type DispatchTaskFailedReason =
       detail: string;
       /**
        * Optional backpressure hint: producer may suggest a retry window
-       * in milliseconds. Operator-facing; pilot's CLI translates to its
+       * in milliseconds. Principal-facing; pilot's CLI translates to its
        * own retry semantics (exit 4 = transient, retry safe).
        */
       retry_after_ms?: number;

--- a/src/bus/dispatch-handler.ts
+++ b/src/bus/dispatch-handler.ts
@@ -128,7 +128,7 @@ export interface DispatchHandlerOpts {
     maxTotalMs?: number;
   };
   /**
-   * Direction A Stage 4-B (cortex#409) — operator stack segment used
+   * Direction A Stage 4-B (cortex#409) — principal stack segment used
    * to build the canonical `local.{principal}.{stack}.tasks.@{did}.{capability}`
    * subject in the envelope-mode publish path. Same value the
    * `MyelinRuntime` and `DispatchListener` receive — production
@@ -211,7 +211,7 @@ export class DispatchHandler extends EventEmitter {
   private readonly retryMaxAttempts: number;
   private readonly retryMaxTotalMs: number;
   /**
-   * Direction A Stage 4-B (cortex#409) — operator stack segment for
+   * Direction A Stage 4-B (cortex#409) — principal stack segment for
    * canonical-subject composition in the envelope-mode publish path.
    * See `DispatchHandlerOpts.stack`.
    */
@@ -332,7 +332,7 @@ export class DispatchHandler extends EventEmitter {
    *
    * Fire-and-forget: errors from `runtime.publish` are swallowed + logged
    * so a bus outage can't break the apology-to-Discord response path.
-   * The operator still sees "Sorry, I couldn't process that" — the
+   * The principal still sees "Sorry, I couldn't process that" — the
    * envelope is the structured-observability sibling.
    */
   private publishDispatchTaskFailed(opts: {
@@ -777,7 +777,7 @@ export class DispatchHandler extends EventEmitter {
     // on the first CC inactivity timeout, surfacing a single apology
     // with no retry. We now retry transient (`not_now`) failures up to
     // `retryMaxAttempts` times within a `retryMaxTotalMs` wall-clock
-    // budget, posting "Still working…" between attempts so the operator
+    // budget, posting "Still working…" between attempts so the principal
     // sees the bot didn't ghost. Terminal failures (any non-`not_now`
     // reason, or the final retry) emit `dispatch.task.failed` for
     // failure-path observability parity with the review-consumer path.
@@ -789,7 +789,7 @@ export class DispatchHandler extends EventEmitter {
     const startedAt = new Date();
 
     // Typing indicator — shared across attempts; the bot is "still
-    // typing" for the whole retry window from the operator's POV.
+    // typing" for the whole retry window from the principal's POV.
     await adapter.sendTyping(target);
     const typingInterval = setInterval(() => {
       adapter.sendTyping(target).catch(() => {
@@ -964,7 +964,7 @@ export class DispatchHandler extends EventEmitter {
         // substrate failure detected" — e.g. `success && !response`
         // or `!success && response.trim() !== ""`. Treat as terminal
         // `cant_do` (skill exited without giving us output to forward
-        // or got partway and crashed); no retry — operator action
+        // or got partway and crashed); no retry — principal action
         // needed (re-prompt with different inputs).
         const classified = classifyCcFailure(result);
         if (classified === null) {
@@ -1054,7 +1054,7 @@ export class DispatchHandler extends EventEmitter {
 
   /**
    * cortex#360 — Post a "Still working… (attempt N/M)" status to the
-   * adapter before each retry so the operator sees the bot is still
+   * adapter before each retry so the principal sees the bot is still
    * alive. Uses the same `postResponse` surface as the final apology;
    * adapters render these as ordinary messages (Discord follow-ups,
    * Mattermost replies) so there's no special channel.

--- a/src/bus/dispatch-lifecycle-summary.ts
+++ b/src/bus/dispatch-lifecycle-summary.ts
@@ -3,7 +3,7 @@
  *
  * The envelope constructors deliberately accept caller-provided strings:
  * each harness knows its substrate result shape. These helpers keep the
- * operator-facing lifecycle summaries consistent across harnesses.
+ * principal-facing lifecycle summaries consistent across harnesses.
  */
 
 /**

--- a/src/bus/envelope-builder.ts
+++ b/src/bus/envelope-builder.ts
@@ -5,7 +5,7 @@
  * `id / source / type / timestamp / correlation_id / sovereignty / payload`
  * skeleton:
  *
- *   - `bus/system-events.ts`     — `system.*`     (operator-only system signals)
+ *   - `bus/system-events.ts`     — `system.*`     (principal-only system signals)
  *   - `bus/dispatch-events.ts`   — `dispatch.task.*` (task lifecycle)
  *   - `taps/cc-events/cc-events.ts` — `cc.*` (relay-lifted CC hooks)
  *

--- a/src/bus/github-events.ts
+++ b/src/bus/github-events.ts
@@ -37,10 +37,10 @@
  *   - `sovereignty` defaults to `local-only / max_hop=0 / frontier_ok=false /
  *     model_class=local-only`. Same rationale as `system.*` and `dispatch.*`:
  *     a webhook payload includes repo names, commit messages, PR titles,
- *     issue bodies — operator-relevant content that has no business being
+ *     issue bodies — principal-relevant content that has no business being
  *     federated outside the org or processed by frontier models without an
  *     explicit upgrade decision. `data_residency` is parameterised on the
- *     source struct so non-NZ operators get accurate residency stamps.
+ *     source struct so non-NZ principals get accurate residency stamps.
  *
  * **What this file is NOT:**
  *   - NOT a webhook receiver. The HTTP entry-point that calls this helper
@@ -77,13 +77,13 @@ function buildSource(src: SystemEventSource): string {
 }
 
 /**
- * Default sovereignty for `github.*` events. Operator-only by default / local
+ * Default sovereignty for `github.*` events. Principal-only by default / local
  * residency / no frontier — webhook payloads may carry PII (committer email,
  * issue bodies) and federating them outside the org is an explicit decision,
  * not a default.
  *
  * `data_residency` is sourced from `source.dataResidency` (defaulting to
- * `"NZ"`) so a non-NZ operator gets envelopes stamped with their actual
+ * `"NZ"`) so a non-NZ principal gets envelopes stamped with their actual
  * residency without per-call overrides.
  *
  * **IAW Phase A.3:** `classification` is now an optional parameter
@@ -91,7 +91,7 @@ function buildSource(src: SystemEventSource): string {
  * `"federated"` or `"public"` when a GitHub event has been explicitly
  * deemed shareable beyond the org boundary (e.g. a public-repo PR-merged
  * event that powers a cross-org community dashboard). Default preserves
- * the prior operator-private posture.
+ * the prior principal-private posture.
  */
 function defaultGithubSovereignty(
   source: SystemEventSource,
@@ -192,8 +192,8 @@ export interface CreateGithubEventEnvelopeOpts {
   /**
    * IAW Phase A.3 — optional sovereignty classification. Defaults to
    * `"local"`. GitHub webhook payloads can carry user-authored content
-   * (PR titles, issue bodies, committer emails); operator-private is the
-   * sensible default. Set `"federated"` only when an explicit operator
+   * (PR titles, issue bodies, committer emails); principal-private is the
+   * sensible default. Set `"federated"` only when an explicit principal
    * decision has scoped the event for cross-org consumption (e.g. an
    * open-source repo's release event powering a federated changelog
    * dashboard). Mismatch with the publish-time subject is a protocol

--- a/src/bus/jetstream/provision.ts
+++ b/src/bus/jetstream/provision.ts
@@ -61,8 +61,8 @@ export type ProvisionStreamOutcome = "created" | "exists" | "config-drift-warnin
 /**
  * Outcome of `provisionReviewConsumer`. Narrower than the stream
  * outcome by design — v1 doesn't drift-check consumer configs (the
- * surface is small enough that operators rarely tune it; the
- * subtler-than-stream drift modes are best surfaced when an operator
+ * surface is small enough that principals rarely tune it; the
+ * subtler-than-stream drift modes are best surfaced when a principal
  * hits one).
  */
 export type ProvisionConsumerOutcome = "created" | "exists" | "updated";

--- a/src/bus/myelin/__tests__/envelope-validator.test.ts
+++ b/src/bus/myelin/__tests__/envelope-validator.test.ts
@@ -815,7 +815,7 @@ describe("deriveNatsSubject (IAW A.3)", () => {
   });
 
   test("derives {principal} from envelope.source's first segment", () => {
-    // A different operator (`acme.*`) routes onto its own subject namespace
+    // A different principal (`acme.*`) routes onto its own subject namespace
     // without any runtime-side configuration.
     const env = envWithClassification("local", "acme.cortex.prod-01");
     expect(deriveNatsSubject(env)).toBe(
@@ -898,7 +898,7 @@ describe("validateSubjectEnvelopeAlignment (IAW A.3)", () => {
 
   test("misaligned subject is detected — federated envelope on local subject", () => {
     // The protocol violation IAW A.3 guards against: a federated envelope
-    // accidentally published on a `local.*` subject would leak operator-
+    // accidentally published on a `local.*` subject would leak principal-
     // private semantics onto the federated bus, or vice versa.
     const env = envWithClassification("federated");
     const result = validateSubjectEnvelopeAlignment(

--- a/src/bus/myelin/__tests__/runtime-org-symmetry.test.ts
+++ b/src/bus/myelin/__tests__/runtime-org-symmetry.test.ts
@@ -50,7 +50,7 @@ describe("MyelinRuntime — subscribe/publish {principal} symmetry (cortex#130 i
     expect(envelope.source).toBe("andreas.luna.work");
   });
 
-  test("symmetry holds when operator changes — second stack identity", () => {
+  test("symmetry holds when principal changes — second stack identity", () => {
     const operatorId = "the-metafactory";
     const envelope = createSystemAdapterDegradedEvent({
       source: { org: operatorId, agent: "echo", instance: "local" },

--- a/src/bus/myelin/__tests__/runtime.test.ts
+++ b/src/bus/myelin/__tests__/runtime.test.ts
@@ -265,8 +265,8 @@ describe("MyelinRuntime", () => {
     await runtime.stop();
   });
 
-  // cortex#269 — `{stack}.` token substitution. Operator-written narrow
-  // subscribe patterns can now reference the operator's stack identity
+  // cortex#269 — `{stack}.` token substitution. Principal-written narrow
+  // subscribe patterns can now reference the principal's stack identity
   // alongside `{principal}` and have it expanded at boot. The `.` is part of
   // the placeholder so stack-less deployments collapse cleanly to the
   // legacy 5-segment shape.
@@ -526,10 +526,10 @@ describe("MyelinRuntime", () => {
     });
 
     test("IAW Phase A.5 (cortex#262): publish derives 6-segment local.{principal}.{stack}.{type} when stack option is set", async () => {
-      // Stack-aware emit — operator config carries `stack: { id: andreas/research }`
+      // Stack-aware emit — principal config carries `stack: { id: andreas/research }`
       // and the entrypoint passes `stack: "research"` through to the runtime.
       // The resulting subject lands inside sage's `local.{principal}.{stack}.>`
-      // subscription wildcard, closing the broadcast loop end-to-end.
+      // subscription wildcard, closing the Offer loop end-to-end.
       const fake = makeFakeNatsConnection();
       const runtime = await startMyelinRuntime(
         makeConfig({

--- a/src/bus/myelin/__tests__/subscriber.pull-mode.test.ts
+++ b/src/bus/myelin/__tests__/subscriber.pull-mode.test.ts
@@ -573,7 +573,7 @@ describe("MyelinSubscriber — pull mode", () => {
     // path threads `retry_after_ms` through the AckDecision return
     // channel; if the delayMs is dropped on the floor here, JetStream
     // redelivers on its server-paced default and pilot's exit-code
-    // mapping silently desyncs from the operator-visible delay.
+    // mapping silently desyncs from the principal-visible delay.
     expect(m.nak).toHaveBeenCalledTimes(1);
     expect(m.nak.mock.calls[0]).toEqual([1500]);
     expect(m.ack).not.toHaveBeenCalled();

--- a/src/bus/myelin/envelope-validator.ts
+++ b/src/bus/myelin/envelope-validator.ts
@@ -223,9 +223,9 @@ export interface Originator {
    *     mapped a non-myelin identifier (platform id, OS user) to a myelin
    *     principal at sign time.
    *   - `federated` — the originator claim was relayed from another
-   *     operator; the chain proves the cross-operator hop.
+   *     principal; the chain proves the cross-principal hop.
    *   - `delegated` — the signer holds delegation credentials for the
-   *     originator (service principal acting on behalf of an operator).
+   *     originator (service principal acting on behalf of a principal).
    */
   attribution: AttributionMode;
 }
@@ -573,7 +573,7 @@ export type Classification = Envelope["sovereignty"]["classification"];
  *
  * `{principal}` is the first dotted segment of `envelope.source` (the same value
  * cortex's MyelinRuntime captures from `agent.operatorId` at startup, so
- * subject and source stay symmetrical). `{stack}` is the operator's stack
+ * subject and source stay symmetrical). `{stack}` is the principal's stack
  * identity — supplied by the caller when in stack-aware mode (IAW A.5),
  * omitted in the legacy migration window.
  *

--- a/src/bus/myelin/runtime.ts
+++ b/src/bus/myelin/runtime.ts
@@ -76,7 +76,7 @@ export interface MyelinRuntime {
    * **No-op when the runtime is disabled** (no NATS configured) so callers
    * can fire-and-forget without checking `enabled` first. This matters at
    * the adapter layer, where `runtime.publish(...)` may run on every shard
-   * disconnect / recover regardless of operator NATS configuration.
+   * disconnect / recover regardless of principal NATS configuration.
    *
    * Errors at publish time are logged and swallowed — emitting an
    * operational `system.*` event must not crash the bot, especially when
@@ -265,7 +265,7 @@ export interface MyelinRuntimeOptions {
    */
   signFailureMode?: "fallback" | "drop";
   /**
-   * IAW Phase A.5 (cortex#113 / closes cortex#262) — operator stack
+   * IAW Phase A.5 (cortex#113 / closes cortex#262) — principal stack
    * segment slotted into the published subject between `{principal}` and
    * `{type}`. When set, `publish()` derives subjects in the 6-segment
    * stack-aware shape `local.{principal}.{stack}.{type}` matching post-myelin#113
@@ -277,9 +277,9 @@ export interface MyelinRuntimeOptions {
    * The entrypoint (`src/cortex.ts` ~line 386) sources this from
    * `deriveStackId(loadedConfig)` so a multi-stack deployment routes
    * envelopes through the right wildcard. The `'default'` fallback that
-   * `deriveStackId` provides is what arrives here when the operator
+   * `deriveStackId` provides is what arrives here when the principal
    * omits the `stack:` block — that matches sage's bridge default
-   * (`SAGE_STACK=default`) so the broadcast loop closes end-to-end.
+   * (`SAGE_STACK=default`) so the Offer loop closes end-to-end.
    */
   stack?: string;
 }
@@ -305,7 +305,7 @@ export interface BusEnvelopeSigner {
 }
 
 /**
- * Build a `{principal}` + `{stack}.` placeholder substituter for operator-
+ * Build a `{principal}` + `{stack}.` placeholder substituter for principal-
  * configured subject patterns (cortex#269 / cortex#279 cycle 2).
  *
  * Used by `MyelinRuntime.publish`'s `nats.subjects` resolution and by
@@ -506,7 +506,7 @@ export async function startMyelinRuntime(
   // subscribe collapsed back to the disabled path. Preserve that
   // safety net: when push-mode subscribers were configured but none
   // came up, the link is closed and the runtime returns disabled —
-  // there is no operator intent for a pull-only path here, just a
+  // there is no principal intent for a pull-only path here, just a
   // broken subscribe. Pull-only mode (empty subjects → enabled link)
   // is the new path; failed push subscribers are still treated as a
   // boot failure for that configuration shape.
@@ -615,8 +615,8 @@ export async function startMyelinRuntime(
         // function constructs error strings from inputs (e.g.
         // "Invalid private key: expected 32-byte Ed25519 seed, got N
         // bytes") and we don't want even partial seed-shape facts
-        // landing in operator logs. The error class + envelope id
-        // gives operators enough to triage.
+        // landing in principal logs. The error class + envelope id
+        // gives principals enough to triage.
         const reason = err instanceof Error ? err.name : "unknown";
         if (signFailureMode === "drop") {
           console.error(
@@ -710,7 +710,7 @@ export async function startMyelinRuntime(
     if (stopped) {
       // Post-stop subscribe attempts are a contract violation — the
       // runtime is no longer servicing new subscriptions. Throw rather
-      // than silently return a dormant subscriber so the operator-
+      // than silently return a dormant subscriber so the principal-
       // facing call site (consumer.start) surfaces the misuse via its
       // own try/catch + stderr path.
       throw new Error(
@@ -776,7 +776,7 @@ export async function startMyelinRuntime(
 
 /**
  * Default envelope handler for G-1100.E — log enough context that an
- * operator triaging a missing-message complaint can find the envelope
+ * principal triaging a missing-message complaint can find the envelope
  * in the bus. Fan-out to specific event handlers (pilot errand
  * projection, signal alert ingestion, etc.) is the next iteration's
  * work and uses the same Envelope type from this layer.

--- a/src/bus/nats/__tests__/connection.test.ts
+++ b/src/bus/nats/__tests__/connection.test.ts
@@ -277,7 +277,7 @@ describe("NatsLink", () => {
   // does that at the server) — they verify that:
   //   - `credsPath` set → connectImpl receives `authenticator` (not token)
   //   - chmod gate refuses anything looser than 600
-  //   - operator-readable error on missing file
+  //   - principal-readable error on missing file
   //   - `token` + `credsPath` together: credsPath wins, warn logged
   //   - leading `~/` expands to $HOME (production cortex.yaml uses this)
   // ─────────────────────────────────────────────────────────────────────
@@ -314,7 +314,7 @@ describe("NatsLink", () => {
       await link.close();
     });
 
-    test("credsPath rejects chmod 644 with operator-readable error", async () => {
+    test("credsPath rejects chmod 644 with principal-readable error", async () => {
       // POSIX-only: NTFS chmod is meaningless and the loader skips the gate.
       if (process.platform === "win32") return;
       chmodSync(credsFile, 0o644);
@@ -413,7 +413,7 @@ describe("NatsLink", () => {
       } finally {
         process.stderr.write = originalStderrWrite;
       }
-      // Warning emitted on stderr with operator-actionable text.
+      // Warning emitted on stderr with principal-actionable text.
       const warning = stderrWrites.find((w) =>
         w.includes("status loop exceeded"),
       );

--- a/src/bus/nats/connection.ts
+++ b/src/bus/nats/connection.ts
@@ -58,7 +58,7 @@ export interface NatsLinkOptions {
  * `common/config/file-permissions.ts` (same policy as the operator
  * account signing-key loader — Echo cortex#87 round-1 extraction).
  *
- * Throws with an operator-readable message when:
+ * Throws with a principal-readable message when:
  *   - `expandTilde` rejects (no `$HOME` set).
  *   - The file is missing / unreadable (ENOENT / EACCES propagate).
  *   - The file mode is not exactly `0o600` on POSIX.
@@ -195,7 +195,7 @@ export class NatsLink {
     // Bounded by `statusTimeoutMs` so a hung `for await (... status())`
     // (cortex#317 — pilot#129 root cause: nats.js status iterator doesn't
     // end promptly under reconnect:true) can't pin downstream `await
-    // link.close()` callers. On budget miss, emit an operator-actionable
+    // link.close()` callers. On budget miss, emit a principal-actionable
     // stderr warning and let the loop drain in the background — process
     // exit cleans up the orphaned iterator regardless.
     let statusTimer: ReturnType<typeof setTimeout> | undefined;

--- a/src/bus/review-consumer.ts
+++ b/src/bus/review-consumer.ts
@@ -138,7 +138,7 @@ export type ReviewPromptBuilder = (input: {
  *
  * `reason` carries a human-readable summary destined for both the
  * structured stderr log line and the `dispatch.task.failed` `reason.detail`
- * field — short enough to scan, specific enough that an operator can
+ * field — short enough to scan, specific enough that a principal can
  * grep `pilot/cortex stderr` and identify the rejection class without
  * cross-referencing internal tables.
  */
@@ -635,7 +635,7 @@ export class ReviewConsumer {
   /**
    * Pipeline executor. Returns the `AckDecision` for the surrounding
    * envelope. Captures pipeline throws and maps to defensive `nak(0)`
-   * (transient — operator-recoverable per §7.6).
+   * (transient — principal-recoverable per §7.6).
    *
    * On success/failure result, this method publishes the terminal
    * envelope (verdict or failed) AND, on the verdict path, the

--- a/src/bus/review-events.ts
+++ b/src/bus/review-events.ts
@@ -36,7 +36,7 @@
  *         explicitly (which the review-consumer does per §5.2).
  *   - `sovereignty` defaults to local-only / NZ / max_hop=0 / frontier_ok=false /
  *     model_class=local-only — same posture as `dispatch.task.*`. Verdicts
- *     reveal PR metadata + reviewer findings; default keeps them operator-local.
+ *     reveal PR metadata + reviewer findings; default keeps them principal-local.
  *     Federated reviews opt into `classification: "federated"` via the
  *     optional `classification` field (IAW Phase A.3 parameterisation pattern).
  *
@@ -90,7 +90,7 @@ function buildSource(src: SystemEventSource): string {
 
 /**
  * Default sovereignty for `tasks.code-review.*` and `review.verdict.*`
- * envelopes. Same posture as `dispatch.task.*`: operator-local by default,
+ * envelopes. Same posture as `dispatch.task.*`: principal-local by default,
  * local residency, no frontier, no hops.
  *
  * Returned as a fresh literal per call so a downstream mutation on one
@@ -153,7 +153,7 @@ export type ReviewFlavor =
  * without a round-trip through a shared type module.
  *
  * Required fields are the load-bearing routing keys (`repo`, `pr`,
- * `reviewer`). Optional fields are the operator-supplied context
+ * `reviewer`). Optional fields are the principal-supplied context
  * (`feature`, `title`, `cycle`, `note`) that surfaces render but do not
  * branch on.
  */
@@ -196,8 +196,8 @@ export interface CreateReviewRequestEventOpts {
    */
   flavor: ReviewFlavor;
   /**
-   * Optional sovereignty classification. Defaults to `"local"` (operator-
-   * private). Set to `"federated"` for cross-operator capability dispatch;
+   * Optional sovereignty classification. Defaults to `"local"` (principal-
+   * private). Set to `"federated"` for cross-principal capability dispatch;
    * `"public"` for global visibility. Mismatch with the publish-time
    * subject is a protocol violation caught by
    * `validateSubjectEnvelopeAlignment`.
@@ -338,7 +338,7 @@ export interface CreateReviewVerdictEventOpts {
  * protocol violation that would silently break pilot's filter (pilot
  * groups envelopes by the subject suffix; a `verdict.approved` envelope
  * with `payload.verdict: "commented"` would be filed under "approved"
- * but render as "commented" — operator-visible inconsistency). Fail
+ * but render as "commented" — principal-visible inconsistency). Fail
  * loud at the producer instead.
  *
  * **Correlation:** the verdict envelope's `correlation_id` is the

--- a/src/bus/surface-router.ts
+++ b/src/bus/surface-router.ts
@@ -130,7 +130,7 @@ export interface SurfaceRouterOptions {
    * paths where `SystemEventSource` isn't constructed yet. Production
    * callers (cortex.ts) SHOULD pass the same struct used by the rest of
    * the `system.*` emit sites so the access-decision stream stamps the
-   * correct operator/agent/instance segments.
+   * correct principal/agent/instance segments.
    */
   systemEventSource?: SystemEventSource;
   /**
@@ -257,7 +257,7 @@ export function createSurfaceRouter(
   const renderTimeoutMs = opts?.renderTimeoutMs ?? DEFAULT_RENDER_TIMEOUT_MS;
   // Captured as a plain function reference. unbound-method fires here
   // because the type tree sees this as a method that *might* read `this`;
-  // for cortex's use case (callbacks supplied by the operator config),
+  // for cortex's use case (callbacks supplied by the principal config),
   // unbound is the intended shape.
   // eslint-disable-next-line @typescript-eslint/unbound-method
   const onAdapterError = opts?.onAdapterError;
@@ -330,10 +330,10 @@ export function createSurfaceRouter(
       // individual adapters are a per-renderer concern that only
       // matters once the envelope has been admitted.
       //
-      // Gate engages only when the operator has declared a
+      // Gate engages only when the principal has declared a
       // `policy.federated.networks[]` block. Mirror of the C.3.1
       // policy-engine pattern: an unconfigured gate is a no-op (the
-      // operator opted out). This keeps cortex.yaml without a
+      // principal opted out). This keeps cortex.yaml without a
       // `federated:` block fully back-compat with pre-D.2 behaviour
       // — existing renderers continue to receive whatever traffic
       // happened to land on `federated.*` subjects via classification
@@ -364,7 +364,7 @@ export function createSurfaceRouter(
             decision,
           );
           // Hard drop — denied envelopes never reach adapters. The
-          // audit envelope above is the operator's only signal that
+          // audit envelope above is the principal's only signal that
           // this dispatch was attempted; without it the deny is
           // silent.
           return;
@@ -569,7 +569,7 @@ function emitAccessFiltered(
   reason: SystemAccessFilteredReason,
 ): void {
   if (!source) {
-    // No source struct configured — log so an operator triaging silence
+    // No source struct configured — log so a principal triaging silence
     // gets a hint, but don't try to construct a half-formed envelope.
     console.info(
       `surface-router: visibility drop renderer="${rendererId}" subject="${envelopeSubject}" reason=${reason} ` +
@@ -590,7 +590,7 @@ function emitAccessFiltered(
     //
     // cortex#137 — defensive .catch() so a regression of the
     // "never throws" contract (refactor, new pluggable transport,
-    // unhandled async path) surfaces an operator-visible signal
+    // unhandled async path) surfaces a principal-visible signal
     // instead of silently dropping the audit envelope. Goes to
     // stderr directly rather than another bus publish so a broken
     // runtime can't swallow the alert about itself.
@@ -661,7 +661,7 @@ type FederationGateDecision =
  *   2. The network id must be in `policy.federated.networks[]`.
  *      Missing → same deny kind with `unknown_network: true`.
  *   3. `deny_subjects[]` is checked BEFORE `accept_subjects[]` —
- *      operator intent on the deny list overrides any accept hit.
+ *      principal intent on the deny list overrides any accept hit.
  *      D.2 spec: "A match here overrides accept_subjects[]".
  *   4. `accept_subjects[]` must contain a matching pattern. Empty
  *      accept list means "accept nothing" (D.1 schema doc); the
@@ -845,7 +845,7 @@ function emitFederationDenied(
     });
     // cortex#137 — defensive .catch() so a regression of the
     // runtime.publish "never throws" contract surfaces an
-    // operator-visible signal instead of dropping the federation
+    // principal-visible signal instead of dropping the federation
     // audit envelope silently. Same pattern as
     // `emitAccessFiltered` above. Direct stderr — a broken
     // runtime can't swallow alerts about itself.

--- a/src/bus/system-events.ts
+++ b/src/bus/system-events.ts
@@ -27,7 +27,7 @@
  *     pattern; the dotted form is the schema-compatible carrier.)
  *   - `sovereignty` defaults to `local-only / NZ / max_hop=0 / frontier_ok=false / model_class=local-only`
  *     because `system.*` events expose internal failure modes (adapter IDs,
- *     buffer caps, error class names). They're operator-only — no federation,
+ *     buffer caps, error class names). They're principal-only — no federation,
  *     no frontier-model processing.
  *
  * **Known spec gap — correlation_id format:**
@@ -74,9 +74,9 @@ export interface SystemEventSource {
   /** Stable instance name — usually `local` for in-process emission. */
   instance: string;
   /**
-   * Operator residency code stamped into `envelope.sovereignty.data_residency`.
+   * Principal residency code stamped into `envelope.sovereignty.data_residency`.
    * Defaults to `"NZ"` when omitted — matches the original cortex deployment.
-   * Operators in other jurisdictions (AU, EU, US) pass their own ISO-3166-style
+   * Principals in other jurisdictions (AU, EU, US) pass their own ISO-3166-style
    * code so envelopes accurately reflect data residency for compliance audits.
    * The field is only used when constructing the default sovereignty object;
    * callers that override `sovereignty` directly bypass it entirely.
@@ -93,15 +93,15 @@ function buildSource(src: SystemEventSource): string {
  * callers receive a fresh object literal (no aliasing risk if a caller
  * mutates the returned envelope's `sovereignty`).
  *
- * `system.*` events expose internal grove state — operator-only by default,
+ * `system.*` events expose internal grove state — principal-only by default,
  * never sent to frontier models. The `data_residency` field is sourced from
- * `source.dataResidency` (defaulting to `"NZ"`) so a non-NZ operator gets
+ * `source.dataResidency` (defaulting to `"NZ"`) so a non-NZ principal gets
  * envelopes stamped with their actual residency without having to override
  * the entire sovereignty object at every call site.
  *
  * **IAW Phase A.3:** `classification` is now an optional parameter
  * (defaulting to `"local"` for back-compat). Callers may opt into
- * `"federated"` or `"public"` when an operator-side decision determines the
+ * `"federated"` or `"public"` when a principal-side decision determines the
  * envelope's reach. The default keeps every existing call site behaving
  * identically.
  */
@@ -163,9 +163,9 @@ export interface SystemAdapterDegradedOpts {
   shardId?: number;
   /**
    * IAW Phase A.3 — optional sovereignty classification. Defaults to
-   * `"local"` (operator-private). Set to `"federated"` to publish on
+   * `"local"` (principal-private). Set to `"federated"` to publish on
    * `federated.{principal}.system.adapter.degraded` so peer dashboards in the
-   * operator's federation policy can render the event; `"public"` for
+   * principal's federation policy can render the event; `"public"` for
    * global visibility. Mismatch with the publish-time subject is a
    * protocol violation (see {@link validateSubjectEnvelopeAlignment}).
    */
@@ -176,7 +176,7 @@ export interface SystemAdapterDegradedOpts {
  * Construct a `system.adapter.degraded` envelope per G-1111 §3.5.4.
  *
  * Emitted once when an adapter has been disconnected long enough to cross
- * the operator-configured threshold (default 60 s). Mandatory paging event
+ * the principal-configured threshold (default 60 s). Mandatory paging event
  * for any `system.*` subscriber that includes the `paging` platform class.
  */
 export function createSystemAdapterDegradedEvent(
@@ -365,12 +365,12 @@ export interface SystemInboundAbortedOpts {
  * Construct a `system.inbound.aborted` envelope per G-1111 §3.5.4.
  *
  * Replaces the bare `AbortError` log of the 2026-05-09 incident with a
- * structured envelope carrying the `timeout_source` enum, so an operator
+ * structured envelope carrying the `timeout_source` enum, so a principal
  * triaging an incident can see *which* timeout fired without parsing
  * launchd logs.
  *
  * Note: spec §3.5 renames this from the older `system.dispatch.aborted` —
- * "dispatch" is now reserved for the `dispatch` *domain* (operator-dispatching-
+ * "dispatch" is now reserved for the `dispatch` *domain* (principal-dispatching-
  * work-to-agents). The migration plan still references the old name; this
  * helper uses the spec name and the old name should be considered an alias
  * in any plan-doc updates.
@@ -425,7 +425,7 @@ export interface SystemAccessFilteredOpts {
   /**
    * Optional sovereignty classification of THIS event (the `filtered`
    * notification itself, not the envelope it describes). Defaults to
-   * `"local"` — access decisions are operator-internal. Mirror of the
+   * `"local"` — access decisions are principal-internal. Mirror of the
    * Phase A.3 `classification` parameter on the rest of the system.*
    * helpers.
    */
@@ -478,7 +478,7 @@ export interface SystemBusPeerDispatchReceivedOpts {
    */
   receivingAgentId: string;
   /**
-   * Source field from the peer's dispatch envelope (the `{operator}.
+   * Source field from the peer's dispatch envelope (the `{principal}.
    * {agent}.{instance}` triple that identifies which peer just
    * dispatched a task to us). Different from `opts.source.org` —
    * that's US, this is THEM.
@@ -770,7 +770,7 @@ export function createSystemAccessDeniedEvent(
  *     allowed" without re-parsing the envelope.
  *
  * Subjects (the actual `deny_subjects` / `accept_subjects` patterns
- * are operator data, not enum values — they ride on `reason.subject`
+ * are principal data, not enum values — they ride on `reason.subject`
  * as free-form strings).
  */
 export type SystemAccessFederationDeniedReasonKind =
@@ -958,8 +958,8 @@ export interface SystemAgentHeartbeatOpts {
   iteration: number;
   /**
    * IAW Phase A.3 — optional sovereignty classification. Defaults to
-   * `"local"` (operator-private), matching the rest of `system.*`.
-   * Cross-operator heartbeats over `federated.*` are out of scope for
+   * `"local"` (principal-private), matching the rest of `system.*`.
+   * Cross-principal heartbeats over `federated.*` are out of scope for
    * cortex#361 (see file: `agent-heartbeat.ts` "Out of scope"); when
    * that ships in a future iteration callers will opt into
    * `"federated"` here.
@@ -978,11 +978,11 @@ export interface SystemAgentHeartbeatOpts {
  * `runtime.publish` signing path).
  *
  * **Subject derivation.** The runtime's stack-aware `publish()` routes this
- * to `local.{principal}.{stack}.system.agent.heartbeat` — operator-managed
+ * to `local.{principal}.{stack}.system.agent.heartbeat` — principal-managed
  * namespace, no upstream myelin schema entry required for the cortex-local
  * deployment. A myelin canonicalisation follow-up (filed against
  * `the-metafactory/myelin`) will lift this onto `federated.*` for cross-
- * operator use.
+ * principal use.
  */
 export function createAgentHeartbeatEvent(
   opts: SystemAgentHeartbeatOpts,

--- a/src/bus/verify-signed-by-chain.ts
+++ b/src/bus/verify-signed-by-chain.ts
@@ -22,7 +22,7 @@
  *
  * **Why two layers, both gated by trust:** the structural check alone is
  * not safe to wire into a production inbound path — a stamp can lie
- * about its principal, and a sloppy operator copying an unknown agent's
+ * about its principal, and a sloppy principal copying an unknown agent's
  * NKey into their own `trust:` list would accept the forgery. The crypto
  * check alone is not enough either — a verified signer the receiver
  * doesn't trust shouldn't be admitted. The two checks compose: structural

--- a/src/runner/__tests__/dispatch-listener.test.ts
+++ b/src/runner/__tests__/dispatch-listener.test.ts
@@ -227,7 +227,7 @@ describe("createDispatchListener — surfaceConfig", () => {
     });
     // Direction A Stage 4-B (cortex#409) — production defaults subscribe
     // to the canonical Tasks Domain pattern. Legacy subjects remain
-    // available only through explicit test/operator overrides.
+    // available only through explicit test/principal overrides.
     expect(listener.surfaceConfig.subjects).toEqual([
       "local.metafactory.tasks.*.>",
     ]);
@@ -269,7 +269,7 @@ describe("createDispatchListener — surfaceConfig", () => {
     ]);
   });
 
-  test("default subjects honour multi-stack operator config", () => {
+  test("default subjects honour multi-stack principal config", () => {
     const { runtime } = recordingRuntime();
     const router = createSurfaceRouter(runtime);
     const listener = createDispatchListener({
@@ -1946,7 +1946,7 @@ describe("dispatch-listener — chain verification (cortex#320)", () => {
 
   test("PR #322 r1 M-1 — trustResolver wired but receivingAgentId undefined → fail-closed deny", async () => {
     // Echo PR #322 r1 caught: when cortex.ts builds the listener with
-    // `mergedAgents` empty (operator's config declares no agents), the
+    // `mergedAgents` empty (principal's config declares no agents), the
     // call site spreads `receivingAgentId` conditionally and the prior
     // bypass branch silently skipped verification while the boot log
     // claimed `signed_by chain verified` — re-opening cortex#220 r1's

--- a/src/runner/__tests__/dm-trust-chain.test.ts
+++ b/src/runner/__tests__/dm-trust-chain.test.ts
@@ -47,7 +47,7 @@ describe("DM trust chain", () => {
       expect(preamble).toContain("CONFIG IMMUTABILITY");
     });
 
-    test("operator DM preamble skips filesystem and bash guidance", () => {
+    test("principal DM preamble skips filesystem and bash guidance", () => {
       const config = makeConfig();
       const preamble = buildSecurityPreamble(config, undefined, {
         skipBashGuard: true,
@@ -56,7 +56,7 @@ describe("DM trust chain", () => {
 
       expect(preamble).not.toContain("FILESYSTEM RESTRICTION");
       expect(preamble).not.toContain("BASH COMMANDS");
-      // These are always enforced, even for operator DM
+      // These are always enforced, even for principal DM
       expect(preamble).toContain("VERIFICATION RULE");
       expect(preamble).toContain("CONFIG IMMUTABILITY");
     });
@@ -132,7 +132,7 @@ describe("DM trust chain", () => {
       expect(isAllowed("rm -rf /tmp/test", defaultConfig)).toBe(false);
       expect(isAllowed("ls /tmp", defaultConfig)).toBe(true);
 
-      // Disabled guard (operator DM) allows rm
+      // Disabled guard (principal DM) allows rm
       const disabledConfig = loadConfig(JSON.stringify({ disabled: true }));
       expect(isAllowed("rm -rf /tmp/test", disabledConfig)).toBe(true);
       expect(isAllowed("curl https://example.com", disabledConfig)).toBe(true);

--- a/src/runner/__tests__/skill-verdict-block.contract.test.ts
+++ b/src/runner/__tests__/skill-verdict-block.contract.test.ts
@@ -12,11 +12,11 @@
  * shape PR-5 expects (e.g. a property is renamed, a typo creeps into the
  * verdict enum, a required field disappears), the parser will refuse the
  * block and emit `dispatch.task.failed` with `cant_do` — pilot then
- * stalls and operators have to figure out what changed. This test is the
+ * stalls and principals have to figure out what changed. This test is the
  * tripwire: it embeds **canonical example outputs that the skill is
  * expected to emit** and round-trips them through the real
  * `runReviewPipeline` to prove the parser still accepts them. When the
- * skill is intentionally updated, the operator updates the fixtures here
+ * skill is intentionally updated, the principal updates the fixtures here
  * to match — that's the explicit synchronisation point between the two
  * repos.
  *
@@ -24,7 +24,7 @@
  *   - PR-5 parser regressions (a future refactor narrows the accepted
  *     shape; this test fails before pilot stalls in production).
  *   - Skill drift (the skill markdown is updated; these fixtures no
- *     longer reflect what the skill emits → operator must reconcile).
+ *     longer reflect what the skill emits → principal must reconcile).
  *
  * **What this does NOT catch:**
  *   - That the skill ACTUALLY emits these fixtures (the skill lives in
@@ -39,7 +39,7 @@
  * `~/.claude/skills/code-review/SKILL.md` (and the per-workflow files
  * under `Workflows/`) must be updated to emit a fenced ```json block as
  * the FINAL element of the CC response, matching the shape used in the
- * APPROVED_FIXTURE constant below. The operator owns that edit; this
+ * APPROVED_FIXTURE constant below. The principal owns that edit; this
  * test file is purely the cortex-side contract.
  *
  * The fixture style is deliberately CC-prose-shaped (a short summary
@@ -119,7 +119,7 @@ function stubFactory(result: CCSessionResult): CCSessionFactory {
 }
 
 // ---------------------------------------------------------------------------
-// Canonical fixtures — these are the skill-emission examples the operator
+// Canonical fixtures — these are the skill-emission examples the principal
 // must keep in sync with `~/.claude/skills/code-review/SKILL.md`. Each
 // fixture is a complete CC-style response: a short prose summary above a
 // fenced ```json block. The block is the LAST fenced block in the string
@@ -130,7 +130,7 @@ function stubFactory(result: CCSessionResult): CCSessionFactory {
  * Fixture 1 — `approved` verdict, zero findings across all severities.
  * Represents the "clean PR" path: skill ran every lens, found nothing
  * actionable, approves via `gh pr review --approve`. This is the SHAPE
- * the operator should paste into the skill markdown's "structured
+ * the principal should paste into the skill markdown's "structured
  * output" section as the worked example.
  */
 const APPROVED_FIXTURE = [

--- a/src/runner/__tests__/worklog-manager-surface.test.ts
+++ b/src/runner/__tests__/worklog-manager-surface.test.ts
@@ -170,7 +170,7 @@ describe("WorklogManager.surfaceConfig — shape", () => {
     ]);
   });
 
-  test("subscribe pattern honours multi-stack operator config", () => {
+  test("subscribe pattern honours multi-stack principal config", () => {
     const { client } = makeFakeClient("worklog-channel-id");
     const wlm = new WorklogManager(client, "worklog-channel-id");
     const cfg = wlm.surfaceConfig({ org: "andreas", stack: "research" });

--- a/src/runner/cc-failure-classifier.ts
+++ b/src/runner/cc-failure-classifier.ts
@@ -10,7 +10,7 @@
  *   2. `dispatch-handler.ts` — the chat dispatch path that adapters
  *      (Discord, Mattermost) drive on inbound `@mention` / DM. This
  *      path now retries `not_now` failures up to 3 attempts before
- *      surfacing the apology to the operator (cortex#360 acceptance
+ *      surfacing the apology to the principal (cortex#360 acceptance
  *      criteria).
  *
  * **What this module IS:**
@@ -102,7 +102,7 @@ export function classifyCcFailure(
  * Classify a synchronous-throw or async-rejection from the CC session
  * factory (e.g. spawn failed, binary missing, immediate API rejection).
  * Always maps to `not_now` per §7.3 — these are transient infrastructure
- * failures, operator-recoverable.
+ * failures, principal-recoverable.
  *
  * Separate entry point because `classifyCcFailure` operates on a
  * `CCSessionResult` shape; this one operates on an unknown thrown value
@@ -127,7 +127,7 @@ export function classifyCcSpawnError(err: unknown): DispatchTaskFailedReason {
  * surface the apology immediately.
  *
  * `not_now` is the ONLY retryable kind — `cant_do`, `wont_do`,
- * `policy_denied`, and `compliance_block` are all terminal (operator
+ * `policy_denied`, and `compliance_block` are all terminal (principal
  * action needed; retry would just re-fail).
  */
 export function isTransientFailure(

--- a/src/runner/cc-session.ts
+++ b/src/runner/cc-session.ts
@@ -28,7 +28,7 @@ export interface CCSessionOpts {
   additionalArgs?: string[];
   /** Bash allowlist config — passed to bash-guard.hook.ts via GROVE_BASH_GUARD env var. */
   bashAllowlist?: { rules: { pattern: string; repos?: string[] }[]; repos: string[] };
-  /** G-300: When true, disables bash guard entirely (operator DM). */
+  /** G-300: When true, disables bash guard entirely (principal DM). */
   bashGuardDisabled?: boolean;
   /** H-001: Explicit project context (e.g., "grove", "meta-factory") */
   project?: string;
@@ -60,7 +60,7 @@ export interface CCSessionResult {
   /**
    * Reason for the abort, when `aborted === true`. Currently the only
    * value emitted is `"timeout"` (inactivity timer fired); the field is
-   * left open-ended so future kill paths (operator cancel, runner
+   * left open-ended so future kill paths (principal cancel, runner
    * shutdown) can populate it without a breaking change.
    */
   abortReason?: "timeout";

--- a/src/runner/dispatch-listener.ts
+++ b/src/runner/dispatch-listener.ts
@@ -189,7 +189,7 @@ export interface DispatchListenerOptions {
   /** Source identity for the lifecycle envelopes the listener emits. */
   source: SystemEventSource;
   /**
-   * Operator stack segment (IAW Phase A.5, cortex#267) used to build the
+   * Principal stack segment (IAW Phase A.5, cortex#267) used to build the
    * subscription subject and the audit-envelope `dispatch.task.received`
    * synthesis path. When supplied, both subjects land on the 6-segment
    * stack-aware grammar `local.{principal}.{stack}.dispatch.task.received`
@@ -222,7 +222,7 @@ export interface DispatchListenerOptions {
   /**
    * Adapter ID for surface-router error reporting. Defaults to
    * `runner-dispatch-listener`. Configurable so multiple runner instances
-   * (a future operator-controlled fleet) can disambiguate.
+   * (a future principal-controlled fleet) can disambiguate.
    */
   adapterId?: string;
   /**
@@ -235,7 +235,7 @@ export interface DispatchListenerOptions {
    *
    * When the option is `undefined` the listener falls back to the
    * pre-C.3 path: every envelope reaches a harness. This preserves
-   * the legacy single-operator/dev-mode boot (no `policy:` block in
+   * the legacy single-principal/dev-mode boot (no `policy:` block in
    * cortex.yaml → `policyEngineFromConfig` returns `undefined` →
    * passed through verbatim here).
    */
@@ -256,7 +256,7 @@ export interface DispatchListenerOptions {
   /**
    * When `true` (default, v2.0.2), the chain verifier runs both the
    * structural trust check AND myelin's ed25519 verification over
-   * the JCS-canonical envelope bytes. Operators with `signed_by[]`
+   * the JCS-canonical envelope bytes. Principals with `signed_by[]`
    * peers on the bus need `nkey_pub` declared on those principals
    * for the crypto layer to admit them.
    *
@@ -359,11 +359,11 @@ function canonicalTasksDirectSubject(org: string, stack?: string): string {
 /**
  * Default subject(s) for the runner's bus subscription. The `{principal}`
  * segment is substituted at registration time using `source.org` so a
- * misconfigured runner with no operator id can still subscribe (it'll match
+ * misconfigured runner with no principal id can still subscribe (it'll match
  * nothing unless someone publishes under `local.default.…`).
  *
  * Direction A Stage 4-B — canonical Tasks Domain dispatch is now the
- * default subscription. Tests and explicit operator overrides can still
+ * default subscription. Tests and explicit principal overrides can still
  * pass `subjects` for legacy/federated fixtures, but production defaults
  * no longer subscribe to the pre-spec `dispatch.task.received` subject.
  */
@@ -647,7 +647,7 @@ async function handleDispatchEnvelope(
   //
   // **Fail-closed when `trustResolver` is wired but `receivingAgentId`
   // is not.** PR #322 round-1 caught this: `cortex.ts:mergedAgents` is
-  // empty when the operator's config declares no agents (or when an
+  // empty when the principal's config declares no agents (or when an
   // intermediate boot stage hasn't populated yet), `receivingAgentId`
   // becomes `undefined`, and the prior bypass-branch silently skipped
   // verification while the boot log claimed `signed_by chain verified`
@@ -746,7 +746,7 @@ async function handleDispatchEnvelope(
   // v2.0.0 (cortex#297) + v2.0.1 (cortex#311): the schema requires a
   // `policy:` block at boot, AND `cortex.ts` no longer re-binds the
   // engine to undefined via env-var ack. So `policyEngine` here is
-  // undefined ONLY when the operator declared `policy: { principals: [] }`
+  // undefined ONLY when the principal declared `policy: { principals: [] }`
   // — an explicit "no auth surface" deployment. We fail closed in that
   // case: deny every dispatch with a clear reason so audit consumers
   // see the misconfiguration immediately rather than every dispatch
@@ -760,7 +760,7 @@ async function handleDispatchEnvelope(
   let gatedPrincipal: Principal | undefined;
   if (policyEngine === undefined) {
     // v2.0.1 (cortex#311): fail-closed when policy engine is unavailable.
-    // In v2.0.0+ this only happens when operator declared empty
+    // In v2.0.0+ this only happens when principal declared empty
     // principals[]; cortex.ts has already emitted a boot warning, so we
     // just deny + emit a terminal failure for any dispatch that arrives.
     console.error(
@@ -778,7 +778,7 @@ async function handleDispatchEnvelope(
         kind: "policy_denied",
         deny: {
           kind: "policy_engine_uninitialised",
-          detail: "operator declared empty policy.principals[]; declare at least one principal to engage the authorisation gate",
+          detail: "principal declared empty policy.principals[]; declare at least one principal to engage the authorisation gate",
         },
       },
     });
@@ -830,7 +830,7 @@ async function handleDispatchEnvelope(
     // callers / unit tests that don't pass a subject).
     //
     // IAW Phase A.5 (cortex#267): the synthesised fallback honours the
-    // operator's stack via the shared `dispatchReceivedSubject` helper —
+    // principal's stack via the shared `dispatchReceivedSubject` helper —
     // single source of truth across the listener's subscribe-side
     // default AND this audit-envelope synthesis path (cortex#276
     // Maintainability finding cycle 2).
@@ -960,7 +960,7 @@ type DispatchPolicyResult =
  * chain-verified by `handleDispatchEnvelope` BEFORE this function is
  * called: `signed_by[]` is structurally trust-checked against the
  * receiving agent's `trust:` list, and (by default) cryptographically
- * verified against the operator's NKey roster via myelin's
+ * verified against the principal's NKey roster via myelin's
  * `verifyEnvelopeIdentity`. Empty chains — produced today by all
  * adapter-originated dispatches (Discord/Mattermost/Slack/cc-events) —
  * are accepted and fall through to this gate; signed chains must
@@ -1074,7 +1074,7 @@ function resolvePrincipalId(
  * `PolicyDenyReason` discriminated union — additive fields like
  * `source_network` can land on the wire without forcing every audit
  * consumer to update its types. Keeping the enrichment in one place
- * gives operators a single function to inspect when reasoning about
+ * gives principals a single function to inspect when reasoning about
  * "what shape does a deny envelope land with for federated traffic?"
  *
  * D.3 federation-specific reasons (`unknown_network`,
@@ -1293,10 +1293,10 @@ async function emitChainVerificationDeny(
  * Emit the deny pair when verification is wired but `receivingAgentId`
  * is unconfigured — a runner-level config error, not a chain-content
  * rejection. PR #322 round-1 M-1 fix: the prior bypass branch silently
- * skipped verification when the operator's config produced no local
+ * skipped verification when the principal's config produced no local
  * agents (mergedAgents empty), re-opening cortex#220 round-1's gap.
  * Fail-closed here so the contract is enforced regardless of upstream
- * wiring; operators see the deny on the audit surface and the
+ * wiring; principals see the deny on the audit surface and the
  * dispatch fails loudly rather than slipping through unverified.
  */
 async function emitReceivingAgentUnconfiguredDeny(

--- a/src/runner/heartbeat-ticker.ts
+++ b/src/runner/heartbeat-ticker.ts
@@ -16,7 +16,7 @@
  * `Date.now()` call.
  *
  * **Failure mode.** A failing `runtime.publish` (NATS hiccup, signer
- * fault) MUST NOT bubble back to the dispatch path. Operator pings that
+ * fault) MUST NOT bubble back to the dispatch path. Principal pings that
  * happen to coincide with a bus outage must still complete their CC
  * session and reply on Discord. The ticker logs publish failures to
  * `process.stderr` and continues ticking; the next tick may succeed.

--- a/src/runner/hooks/__tests__/bash-guard.hook.test.ts
+++ b/src/runner/hooks/__tests__/bash-guard.hook.test.ts
@@ -77,7 +77,7 @@ describe("bash-guard.hook — pass-through behaviour", () => {
     expect(JSON.parse(r.stdout.trim())).toEqual({ continue: true });
   });
 
-  test("bypasses guard when GROVE_AGENT_ID is set (CLI operator session)", () => {
+  test("bypasses guard when GROVE_AGENT_ID is set (CLI principal session)", () => {
     const r = runHook("rm -rf /tmp/whatever", {
       GROVE_CHANNEL: "test-channel",
       GROVE_AGENT_ID: "cldyo-live",
@@ -86,7 +86,7 @@ describe("bash-guard.hook — pass-through behaviour", () => {
     expect(JSON.parse(r.stdout.trim())).toEqual({ continue: true });
   });
 
-  test("disabled config (operator DM) allows everything", () => {
+  test("disabled config (principal DM) allows everything", () => {
     const r = runHook("rm -rf /tmp/x", {
       GROVE_CHANNEL: "test-channel",
       GROVE_AGENT_ID: undefined,

--- a/src/runner/hooks/bash-guard.hook.ts
+++ b/src/runner/hooks/bash-guard.hook.ts
@@ -73,7 +73,7 @@ function loadConfig(): GuardConfig | null {
   if (raw) {
     try {
       const parsed = JSON.parse(raw) as GuardConfigRaw;
-      // G-300: Operator DM disables bash guard entirely
+      // G-300: Principal DM disables bash guard entirely
       if (parsed.disabled) return null;
       return {
         rules: parsed.rules ?? DEFAULT_CONFIG.rules,
@@ -122,7 +122,7 @@ function allow(): void {
  * Emit Claude Code's structured PreToolUse *deny* decision. The
  * `permissionDecisionReason` surfaces back to the agent (and the
  * Cortex→Discord relay) — it replaces the old `process.exit(2)` +
- * stderr line, which got swallowed on the way to the operator.
+ * stderr line, which got swallowed on the way to the principal.
  */
 function deny(reason: string): void {
   console.log(
@@ -213,7 +213,7 @@ async function main(): Promise<void> {
     return;
   }
 
-  // CLI operator session (cldyo-live sets GROVE_AGENT_ID) — full trust, bypass guard.
+  // CLI principal session (cldyo-live sets GROVE_AGENT_ID) — full trust, bypass guard.
   // Bot sessions also set GROVE_AGENT_ID but override via GROVE_BASH_GUARD config,
   // so they still get guarded by the loadConfig() path below.
   if (process.env.GROVE_AGENT_ID) {
@@ -272,7 +272,7 @@ async function main(): Promise<void> {
   const parts = command.split(/\s*(?:&&|\|\||;)\s*/);
   const config = loadConfig();
 
-  // G-300: Guard disabled (operator DM) — allow everything
+  // G-300: Guard disabled (principal DM) — allow everything
   if (config === null) {
     allow();
     return;

--- a/src/runner/learning-store.ts
+++ b/src/runner/learning-store.ts
@@ -1,6 +1,6 @@
 /**
  * Issue #49: Learning Store
- * Operator-submitted learnings that persist across sessions.
+ * Principal-submitted learnings that persist across sessions.
  * Uses bun:sqlite for storage and relevance scoring for context injection.
  */
 

--- a/src/runner/prompt-filter.ts
+++ b/src/runner/prompt-filter.ts
@@ -23,7 +23,7 @@ type FilterContentString = (
 let filterContentString: FilterContentString | null = null;
 
 // Load @metafactory/content-filter at module init. This is a required security
-// control — if the package fails to load we log loudly so operators notice.
+// control — if the package fails to load we log loudly so principals notice.
 // Previously this was silently fail-open (grove#173).
 try {
   const mod = await import("@metafactory/content-filter");
@@ -56,7 +56,7 @@ export interface PromptFilterResult {
  * Format note: we pass "mixed" (free-text) because chat prompts aren't
  * structured. "mixed" format returns HUMAN_REVIEW for clean content and
  * BLOCKED for content matching a block-severity pattern. We only reject on
- * BLOCKED — HUMAN_REVIEW is treated as allowed because there's no operator
+ * BLOCKED — HUMAN_REVIEW is treated as allowed because there's no principal
  * in the loop on every Discord/Mattermost message.
  */
 export function scanPrompt(prompt: string, source: string): PromptFilterResult {

--- a/src/runner/review-pipeline.ts
+++ b/src/runner/review-pipeline.ts
@@ -51,7 +51,7 @@
  *
  * | Outcome                                              | reason.kind | rationale                                                  |
  * |------------------------------------------------------|-------------|------------------------------------------------------------|
- * | CC factory throws synchronously (binary missing)     | `not_now`   | Transient substrate failure (§7.3); operator-recoverable.   |
+ * | CC factory throws synchronously (binary missing)     | `not_now`   | Transient substrate failure (§7.3); principal-recoverable. |
  * | CC session `kill()` / inactivity timeout / abort     | `not_now`   | Substrate-side crash (§7.6) — pilot maps to exit 4.        |
  * | CC session exits non-zero with no parseable block    | `not_now`   | Substrate-side crash (§7.6).                                |
  * | CC session exits clean (0) but no verdict block      | `cant_do`   | Skill didn't fulfil its contract (§4.5).                    |
@@ -326,7 +326,7 @@ export async function runReviewPipeline(
     }
   } catch (err) {
     // §7.3 not_now bucket — "transient infrastructure failure (CC binary
-    // not found; etc.). Operator-recoverable." Pilot maps to exit 4
+    // not found; etc.). Principal-recoverable." Pilot maps to exit 4
     // (transient, retry safe) per design-pilot-restructure.md §4.4.
     // `classifyCcSpawnError` always returns a `not_now` reason; the
     // union narrowing here exists to keep TypeScript happy when the
@@ -372,7 +372,7 @@ export async function runReviewPipeline(
 
   // §4.5 — extract the structured-verdict JSON block from the CC stream's
   // last assistant message. Absent block on a clean exit = skill didn't
-  // honour the contract (`cant_do`, permanent — operator must fix the
+  // honour the contract (`cant_do`, permanent — principal must fix the
   // skill, not retry the request).
   const block = extractVerdictBlock(result.response);
   if (block === null) {
@@ -533,7 +533,7 @@ type ParseResult<T> =
  * Parse + validate the verdict block JSON. Returns a structured error
  * detail for any failure mode (JSON parse, missing field, wrong type,
  * out-of-enum verdict). The detail flows into the `cant_do` envelope's
- * `reason.detail` so operators can see which field tripped on the
+ * `reason.detail` so principals can see which field tripped on the
  * dashboard.
  *
  * Validation is hand-rolled (no Zod) to keep PR-5 dependency-free and

--- a/src/runner/security-preamble.ts
+++ b/src/runner/security-preamble.ts
@@ -8,7 +8,7 @@ import type { AgentConfig } from "../common/types/config";
 /**
  * Options to relax the security preamble for trusted contexts.
  *
- * Threat model: These skips are only used for operator DM sessions (G-300),
+ * Threat model: These skips are only used for principal DM sessions (G-300),
  * where identity is verified by Discord user ID matching operatorDiscordId in
  * cortex.yaml. The DM channel is 1:1 — no other users can inject messages or
  * read the conversation. Verification and config-immutability rules remain
@@ -17,11 +17,11 @@ import type { AgentConfig } from "../common/types/config";
  * See G-301 (issue #42) for planned additional authentication controls.
  */
 export interface SecurityPreambleOpts {
-  /** Skip bash guard guidance (operator DM mode) */
+  /** Skip bash guard guidance (principal DM mode) */
   skipBashGuard?: boolean;
-  /** Override allowed dirs (operator DM uses full dir list) */
+  /** Override allowed dirs (principal DM uses full dir list) */
   overrideDirs?: string[];
-  /** Skip filesystem restriction (operator DM with unrestricted dirs) */
+  /** Skip filesystem restriction (principal DM with unrestricted dirs) */
   skipFilesystemRestriction?: boolean;
 }
 
@@ -77,7 +77,7 @@ export function buildSecurityPreamble(config: AgentConfig, configPath?: string, 
   }
 
   // Bash allowlist guidance — tell the model what shell commands are available
-  // Skipped for operator DM (no bash guard)
+  // Skipped for principal DM (no bash guard)
   if (!opts?.skipBashGuard) {
     const bashAllowlist = config.claude.bashAllowlist;
     if (bashAllowlist && bashAllowlist.rules.length > 0) {

--- a/src/runner/substrate/__tests__/pi-dev-runner.test.ts
+++ b/src/runner/substrate/__tests__/pi-dev-runner.test.ts
@@ -10,7 +10,7 @@
  *   2. Failure path: non-zero exit + stderr → `{ kind: "failed", envelope }`
  *      with `reason.kind: "cant_do"` carrying stderr verbatim.
  *   3. Binary not found: `which` returns undefined → `{ kind: "failed",
- *      envelope }` with a useful operator-facing detail string. Boot path
+ *      envelope }` with a useful principal-facing detail string. Boot path
  *      is structurally identical for all three — the runner never throws.
  *
  * The four-way nak taxonomy (`cant_do` / `wont_do` / `not_now` /
@@ -206,7 +206,7 @@ describe("cortex#331 Phase 1 — makePiDevPipelineRunner", () => {
     expect(envelope.correlation_id).toBe(opts.requestEnvelope.id);
 
     // Reason — Phase 1 collapses every non-happy outcome to `cant_do`
-    // (see module docblock). Detail must carry stderr so operators can
+    // (see module docblock). Detail must carry stderr so principals can
     // grep `nats consumer info` for the actual sage error.
     const reason = (envelope.payload as { reason: { kind: string; detail: string } })
       .reason;
@@ -215,7 +215,7 @@ describe("cortex#331 Phase 1 — makePiDevPipelineRunner", () => {
     expect(reason.detail).toContain(stderr);
   });
 
-  test("binary not found: which returns undefined → failed envelope with operator-actionable detail, NEVER throws", async () => {
+  test("binary not found: which returns undefined → failed envelope with principal-actionable detail, NEVER throws", async () => {
     // No spawn call should happen — the runner must short-circuit before
     // any subprocess work when the binary is missing. We still pass a
     // spawn that would throw if invoked to pin that no-call invariant.
@@ -246,7 +246,7 @@ describe("cortex#331 Phase 1 — makePiDevPipelineRunner", () => {
       const reason = (envelope.payload as { reason: { kind: string; detail: string } })
         .reason;
       expect(reason.kind).toBe("cant_do");
-      // Operator-actionable message — names the env var and PATH hint.
+      // Principal-actionable message — names the env var and PATH hint.
       expect(reason.detail).toContain("sage binary not found");
       expect(reason.detail).toContain("SAGE_BIN");
     } finally {

--- a/src/runner/substrate/pi-dev-runner.ts
+++ b/src/runner/substrate/pi-dev-runner.ts
@@ -50,7 +50,7 @@
  * **Binary resolution.** Sage's CLI is looked up in this order:
  *
  *   1. `opts.sageBin` — explicit override, primarily a test seam.
- *   2. `process.env.SAGE_BIN` — operator override; lets the user pin
+ *   2. `process.env.SAGE_BIN` — principal override; lets the user pin
  *      a specific sage build without editing cortex.yaml.
  *   3. `Bun.which("sage")` — falls back to `$PATH`.
  *
@@ -147,7 +147,7 @@ export type PiDevWhichFn = (cmd: string) => string | undefined;
  *   - Resolve sage binary via `SAGE_BIN` env then `Bun.which("sage")`.
  *   - Use `Bun.spawn` for the subprocess.
  *   - Use the current process env (no scrubbing — sage piggybacks on the
- *     operator's `gh` auth and `GITHUB_TOKEN` via inherited env).
+ *     principal's `gh` auth and `GITHUB_TOKEN` via inherited env).
  */
 export interface MakePiDevRunnerOpts {
   /**
@@ -223,7 +223,7 @@ export function makePiDevPipelineRunner(
     // directly — no separate owner field on the cortex-side payload.
     const prRef = `${payload.repo}#${payload.pr}`;
     // cortex#402 — substrate is overridable via `SAGE_SUBSTRATE` env so
-    // operators without a pi.dev model provider configured (e.g. no
+    // principals without a pi.dev model provider configured (e.g. no
     // DeepSeek API key) can route sage's lens execution through
     // `claude` or `codex` instead. Defaults to `pi` to preserve the
     // pre-#402 behaviour. Sage's CLI accepts `{pi|claude|codex}` per
@@ -386,7 +386,7 @@ function verdict(
       // Placeholder fields Phase 1 doesn't have access to without a
       // structured verdict block. The verdict envelope schema requires
       // these fields; we surface zeros / empty strings so pilot's
-      // subscriber still sees a well-formed envelope and operators can
+      // subscriber still sees a well-formed envelope and principals can
       // grep the markdown summary for the actual values. Phase 2
       // populates these from sage's `--format json` block.
       github_review_id: 0,

--- a/src/runner/worklog-manager.ts
+++ b/src/runner/worklog-manager.ts
@@ -262,11 +262,11 @@ export class WorklogManager {
    *
    * @param adapterId — defaults to `worklog-manager`. Configurable so a
    *   future multi-channel worklog (one channel per repo) can disambiguate.
-   * @param org — operator id segment. Worklog-manager doesn't store it (the
+   * @param org — principal id segment. Worklog-manager doesn't store it (the
    *   manager is constructed with a Discord client + channel ID, not a
    *   bot config). Passing it explicitly keeps the dependency direction
    *   clean (no config import here).
-   * @param stack — optional operator stack segment (IAW Phase A.5,
+   * @param stack — optional principal stack segment (IAW Phase A.5,
    *   cortex#268). When supplied, the manager subscribes on the 6-segment
    *   grammar `local.{principal}.{stack}.dispatch.task.>` matching sage's
    *   emit-side post-A.5. When omitted, falls through to the legacy
@@ -352,7 +352,7 @@ export class WorklogManager {
     // means new sub-types arrive over time; we tolerate them rather than
     // crashing. Warn rather than log because an unknown sub-type usually
     // means the worklog renderer is behind the producers and ought to be
-    // updated — the operator should see this in stderr filters.
+    // updated — the principal should see this in stderr filters.
     console.warn(`worklog: ignoring unknown dispatch envelope type ${envelope.type}`);
   }
 
@@ -364,7 +364,7 @@ export class WorklogManager {
     const payload = envelope.payload;
     const agentId = typeof payload.agent_id === "string" ? payload.agent_id : "agent";
     // Compact thread name — task_id prefix is enough to disambiguate for
-    // operators eyeballing the channel feed.
+    // principals eyeballing the channel feed.
     const threadName = `${agentId} — task ${taskId.slice(0, 8)}`;
 
     try {


### PR DESCRIPTION
## Summary

PR-R13b from the 0002 vocabulary-finish manifest: a mechanical prose sweep over `src/runner/` + `src/bus/` replacing legacy "operator" vocabulary with the canonical "principal" per CONTEXT.md, plus two CONTEXT.md-authority "broadcast loop" → "Offer loop" rewrites (Major 5).

**Plan ref:** [`docs/migrations/0002-vocabulary-finish-2026-05.md`](https://github.com/the-metafactory/cortex/blob/main/docs/migrations/0002-vocabulary-finish-2026-05.md) §R13.C + §R5 + recommended-sequence step 7.

**Parent umbrella:** cortex#436. **Was blocked by:** PR-R2a (#439 → merged as #457).

## Scope

PROSE ONLY — doc-comments, JSDoc, inline comments, test names, test prose. No symbol renames, no field renames, no type/signature changes. ~250 LOC envelope; landed at **42 files / 173 insertions / 173 deletions** (1:1 mechanical substitutions).

### R5 — CONTEXT.md authority rewrites

- `src/bus/myelin/runtime.ts:282` — `"broadcast loop"` → `"Offer loop"` (NOT LOCKSTEP-myelin-gated — independent of myelin R11 per plan §R5).
- `src/bus/myelin/__tests__/runtime.test.ts:532` — same wording fix in matching test.

Per CONTEXT.md §"Dispatch authority": *"Never call the Offer mode 'broadcast' — exactly one assistant claims an offered task, not all."*

### R13b — "operator" → "principal" prose

Hot files swept:

- `src/runner/dispatch-listener.ts` — large prose blocks (R11/R2 cascades).
- `src/runner/security-preamble.ts` — non-prompt-string comments (prompts already in PR-R7a).
- `src/bus/system-events.ts` — sovereignty + heartbeat doc-comments.
- `src/bus/dispatch-handler.ts` — retry-loop + apology-path comments.
- `src/bus/surface-router.ts` — federation-gate + audit-emit comments.
- `src/bus/myelin/envelope-validator.ts` — Originator attribution doc.
- `src/bus/myelin/runtime.ts` — runtime + publish doc-comments.
- Plus tests across `src/runner/__tests__/` + `src/bus/__tests__/` + `src/bus/myelin/__tests__/` + `src/bus/nats/__tests__/`.

## Carve-outs preserved (PROSE ONLY, surface-respecting)

- **`src/bus/payload-filter.ts`** — `"operator"` here means EventBridge filter-grammar operator (`prefix`, `equals`, `anything-but`, etc.). Different domain meaning; untouched.
- **`src/bus/myelin/envelope-validator.ts:152`** — `bidding` mode prose using "broadcast" as English fanout-then-collect language (genuine many-to-many, not Offer-mode). Untouched per plan §R5.
- **`src/surface/mc/notifications.ts`** — WebSocket broadcast method names + comments. Out of scope (PR-R13d territory) and different domain meaning.
- **`dmType === "operator"` literal + `notifyOperator*` method-name-coupled prose** — those are R6/R8 capability-rename territory; the prose tracks the symbol until that cluster ships.
- **`payload.operator` / `.operator` field-name references** — R2 territory, already shipped in PR-R2a (#457).
- **`GROVE_OPERATOR` env var, `operatorId`, `operatorDiscordId` field names** — symbol references.
- **NATS "operator-mode auth"** — domain term from NATS protocol vocabulary (operator account, signed JWT).
- **`verify-signed-by-chain.ts:437`** — historical rename comment ("// renamed `operator` → `network` (Luna's PR-5/PR-8 …)"). Stays per the `// historical:` carve-out.
- **`principalId: "test-operator"` test data string literals** — test fixture values, not prose.
- **User-facing deny strings** ("Ask the operator to widen the allowlist", "Ask the operator to add you to a role") — separate user-message cluster.
- **`"operator-cancel"` reason string** in `dispatch-events.ts:372` and matching test fixture — documented as a conventional value of the free-form reason string; symbol-coupled.

## Acceptance criteria

- [x] `grep -En 'broadcast loop' src/bus/` returns 0 hits.
- [x] Remaining `\boperator\b` hits in `src/runner/` + `src/bus/` are ONLY in transition-shim back-compat arms, `// historical:` lines, symbol references (field names, env vars, NATS-domain terms), policy-capability literal coupling, fuzz/test fixture values, and the documented carve-outs.
- [x] `bun test` passes (3545 pass / 2 skip / 0 fail).
- [x] `bunx tsc --noEmit` clean.
- [x] `bun run lint:errors` clean.
- [x] Carve-outs preserved (verified by grep + spot-checks above).

## Verification

```
$ bunx tsc --noEmit
(clean)

$ bun test
3545 pass, 2 skip, 0 fail (153.58s, 8601 expect() calls, 188 files)

$ bun run lint:errors
(clean)
```

## Test plan

- [x] Type-check passes
- [x] Full bun test suite passes
- [x] Lint clean
- [x] `grep -En 'broadcast loop' src/bus/` returns 0 hits
- [x] Spot-check carve-outs preserved (`payload-filter.ts`, `notifications.ts`, `envelope-validator.ts:152`, `verify-signed-by-chain.ts:437`)

Closes #443.

🤖 Generated with [Claude Code](https://claude.com/claude-code)