### PR TITLE
feat(cortex): C-13c — adapters prose (closes #444)

### DIFF
--- a/src/adapters/discord/__tests__/auto-thread.test.ts
+++ b/src/adapters/discord/__tests__/auto-thread.test.ts
@@ -494,7 +494,7 @@ describe("messageCreate auto-thread (cortex#120)", () => {
         channel,
         // Still passes the adapter's `isMentionForBot` filter because the
         // mocked `mentions.has` returns true for SELF_ID; in practice an
-        // operator could @-mention multiple bots in one message and only
+        // principal could @-mention multiple bots in one message and only
         // one of them should auto-thread.
       }),
     );

--- a/src/adapters/discord/attachments.ts
+++ b/src/adapters/discord/attachments.ts
@@ -111,7 +111,7 @@ function validateSize(
  * a `TimeoutSourceError` (the adapter-outbound abort case), the handler is
  * fired BEFORE this function returns its `{ ok: false }` error result. The
  * download still degrades gracefully — the user keeps seeing "Download
- * error: …" — but the operator gets a structured `system.inbound.aborted`
+ * error: …" — but the principal gets a structured `system.inbound.aborted`
  * publish on the bus. Non-timeout errors (network failures, HTTP errors)
  * are unchanged; we only intercept the named-timeout case.
  */
@@ -145,7 +145,7 @@ export async function processAttachment(
     // MIG-3.8: TimeoutSourceError from fetchWithTimeout — fire the structured
     // hook (system.inbound.aborted) BEFORE we degrade the result. The fetch
     // result still returns gracefully so the user gets "Download error: …";
-    // the operator-side observability is the additive change.
+    // the principal-side observability is the additive change.
     if (error instanceof TimeoutSourceError && onTimeoutAbort) {
       try {
         onTimeoutAbort({ err: error, attachment: info });

--- a/src/adapters/discord/index.ts
+++ b/src/adapters/discord/index.ts
@@ -44,7 +44,7 @@ import { parseReviewWireFormat, reviewThreadName } from "./wire-format";
 /**
  * Cortex-deployment-level wiring passed alongside the agent + presence pair.
  * Bundles the deployment-scoped concerns the agent/presence model itself
- * doesn't carry: the routing/log-prefix `instanceId`, the operator's
+ * doesn't carry: the routing/log-prefix `instanceId`, the principal's
  * platform identity, bus wiring for `system.adapter.*` envelope emission,
  * and the MIG-3b surface-router fields.
  *
@@ -72,7 +72,7 @@ export interface DiscordAdapterInfra {
    * without NATS still track degradation/reconnect locally. */
   runtime?: MyelinRuntime;
   /** `{principal}.{agent}.{instance}` source triple stamped onto emitted `system.*` envelopes
-   * (spec §3.6 names the agent, not the operator). */
+   * (spec §3.6 names the agent, not the principal). */
   systemEventSource?: SystemEventSource;
   /** MIG-3b: NATS subject patterns this adapter renders to Discord. Empty/undefined → adapter
    * never matches in the surface-router (still subscribes for messages, just doesn't render
@@ -104,7 +104,7 @@ export interface DiscordAdapterInfra {
    * gate. Resolved by `cortex.ts` from the parsed `policy:` block via
    * `policyEngineFromConfig`. `undefined` only when the deployment has
    * not declared a `policy:` block — in that case every inbound message
-   * is denied with a pointer at `migrate-config`. Operators upgrading
+   * is denied with a pointer at `migrate-config`. Principals upgrading
    * from <v2.0.0 MUST run the CLI first.
    */
   policyEngine?: PolicyEngine;
@@ -359,8 +359,8 @@ export class DiscordAdapter implements PlatformAdapter {
         // Self-loop guard — never respond to our own DMs, regardless of
         // any trustedBotIds entry (the bot's own id is never allowed).
         if (message.author.id === this.client.user?.id) return;
-        // cortex#84: drop bot-authored DMs unless the author is an
-        // operator-blessed peer in `trustedBotIds`. The role-resolver
+        // cortex#84: drop bot-authored DMs unless the author is a
+        // principal-blessed peer in `trustedBotIds`. The role-resolver
         // (resolveDMAccess) then makes the final allow/deny call on
         // the message, so listing a bot here is necessary-but-not-
         // sufficient to elicit a response.
@@ -542,7 +542,7 @@ export class DiscordAdapter implements PlatformAdapter {
           } else {
             // Thread create failed — leave inboundMsg as channel-level
             // and let the agent reply at channel scope. The user sees
-            // a normal reply; the operator sees the warn log from
+            // a normal reply; the principal sees the warn log from
             // `findOrCreateThreadByName`. Graceful degradation rather
             // than silently dropping the message.
             console.warn(
@@ -595,7 +595,7 @@ export class DiscordAdapter implements PlatformAdapter {
    * cortex#98 (part B): replace the trusted-peer-bot allowlist after
    * construction. Cortex.ts uses this to merge in-process peer bot ids
    * (resolved via `TrustResolver.lookupPlatformIdByAgent`) on top of the
-   * operator-explicit `presence.discord.trustedBotIds` once all adapters
+   * principal-explicit `presence.discord.trustedBotIds` once all adapters
    * have logged in and registered their `client.user.id` in the resolver.
    *
    * Atomic reference swap — hot-path `messageCreate` readers see either
@@ -603,7 +603,7 @@ export class DiscordAdapter implements PlatformAdapter {
    * to call any time after construction; cortex.ts calls it once during
    * its second adapter-start pass.
    *
-   * The caller is responsible for including any prior operator-explicit
+   * The caller is responsible for including any prior principal-explicit
    * ids in `next`; this method does NOT merge with the existing set —
    * it replaces it. The intent is to surface "the allowlist as
    * cortex.ts computes it" as a single, well-defined value rather than
@@ -1204,7 +1204,7 @@ export class DiscordAdapter implements PlatformAdapter {
    * Common gate for `system.adapter.*` emission. Returns the bound runtime +
    * source pair when both are configured, or `null` otherwise. Splits the "no
    * runtime configured" case (silent — bot was started without NATS) from the
-   * "no source configured but runtime present" case (warn once — operator
+   * "no source configured but runtime present" case (warn once — the principal
    * wired NATS but forgot to pass `systemEventSource`, which is a config bug
    * worth surfacing).
    *
@@ -1219,7 +1219,7 @@ export class DiscordAdapter implements PlatformAdapter {
     if (!source) {
       if (!this.warnedMissingSource) {
         // Warn once per process — without the source, we'd emit envelopes
-        // that fail schema validation on the receiver side. The operator
+        // that fail schema validation on the receiver side. The principal
         // needs this signal at start time, not flooded across every shard
         // disconnect during a real outage.
         console.warn(

--- a/src/adapters/discord/wire-format.ts
+++ b/src/adapters/discord/wire-format.ts
@@ -16,7 +16,7 @@
  *
  * The regex requires a leading `<@mention>` so we don't auto-thread on
  * casual messages like "what's the status on review cortex#118?". The
- * @-mention is the operator's explicit "this is for the bot" signal.
+ * @-mention is the principal's explicit "this is for the bot" signal.
  *
  * Repo-short charset: lower-case ASCII letter to start, then letters /
  * digits / underscore / hyphen. Matches the GitHub repo-name policy that

--- a/src/adapters/envelope-renderer.ts
+++ b/src/adapters/envelope-renderer.ts
@@ -25,7 +25,7 @@ import type { Envelope } from "../bus/myelin/envelope-validator";
  *   {payload}
  *   ```
  *
- * The correlation_id is included when present so an operator scanning
+ * The correlation_id is included when present so a principal scanning
  * the channel can correlate envelopes across a workflow without opening
  * the envelope details.
  */

--- a/src/adapters/mattermost/index.ts
+++ b/src/adapters/mattermost/index.ts
@@ -41,7 +41,7 @@ import {
 /**
  * Cortex-deployment-level wiring passed alongside the agent + presence pair.
  * Mirrors `DiscordAdapterInfra` (see cortex#48 / MIG-7.2c-discord-cleanup)
- * with Mattermost-specific bits: the operator's Mattermost user id lives
+ * with Mattermost-specific bits: the principal's Mattermost user id lives
  * here, not on the agent block.
  *
  * The surface-router fields park here transitionally — architecture §9.2

--- a/src/adapters/slack/__tests__/schema.test.ts
+++ b/src/adapters/slack/__tests__/schema.test.ts
@@ -1,7 +1,7 @@
 /**
  * F-slack: SlackPresenceSchema / SlackInstanceSchema parse tests.
  *
- * The schemas are the contract between cortex.yaml (operator-facing) and
+ * The schemas are the contract between cortex.yaml (principal-facing) and
  * the adapter. Lock in the field-level invariants so a schema regression
  * surfaces immediately at config-load rather than as a runtime stack trace
  * inside the adapter.

--- a/src/adapters/slack/__tests__/slack-adapter.test.ts
+++ b/src/adapters/slack/__tests__/slack-adapter.test.ts
@@ -1267,7 +1267,7 @@ describe("SlackAdapter — two-pass dispatch gate (cortex#235 r1#7)", () => {
     const { adapter, emit } = makeAdapter();
     const cap = captureInbound();
     await adapter.start(cap.onMessage);
-    // Pre-merge: adapter has the operator-explicit set (empty).
+    // Pre-merge: adapter has the principal-explicit set (empty).
     // A peer-bot message would trip the self-loop guard / role check.
     adapter.setTrustedBotIds(new Set(["B0PEERMERGED"]));
     adapter.attachInboundDispatch();

--- a/src/adapters/slack/client.ts
+++ b/src/adapters/slack/client.ts
@@ -296,7 +296,7 @@ export class RealSlackClient implements SlackClient {
    * Error path intentionally omits `JSON.stringify(res)`: the
    * `auth.test` response shape includes workspace metadata (`team`,
    * `team_id`, `enterprise_id`, `url`) that, while not credentials,
-   * is operator-environment-identifying. Log only the missing-field
+   * is principal-environment-identifying. Log only the missing-field
    * diagnosis (Echo cortex#233 round-1 r1#10, deferred but worth
    * fixing the new error path while we're here).
    */

--- a/src/adapters/slack/index.ts
+++ b/src/adapters/slack/index.ts
@@ -76,7 +76,7 @@ export interface SlackAdapterInfra {
   surfaceFilter?: PayloadFilter;
   /** MIG-3b: fallback Slack channel id for envelope rendering. */
   surfaceFallbackChannelId?: string;
-  /** Operator-set trusted peer bot user ids (`U...`). */
+  /** Principal-set trusted peer bot user ids (`U...`). */
   trustedBotIds?: ReadonlySet<string>;
   /**
    * Pluggable client implementation. Production callers omit this and
@@ -117,7 +117,7 @@ export class SlackAdapter implements PlatformAdapter {
    * (Echo cortex#233 round-2 N1).
    */
   private botIdentity: SlackBotIdentity | null = null;
-  /** Operator-explicit + adapter-side anti-self-loop set. */
+  /** Principal-explicit + adapter-side anti-self-loop set. */
   // cortex#235 r1#5 — mutable to support hot-reload of the trusted
   // bot ids set via `updateConfig`. The runtime is still read-only:
   // every consumer treats it as a `ReadonlySet<string>`. Only
@@ -224,7 +224,7 @@ export class SlackAdapter implements PlatformAdapter {
     // attach. This is the Slack equivalent of discord.js's
     // gateway-buffered events. Without this gate, cortex.ts's Pass-2
     // trust-resolver merge happens AFTER inbound events have already
-    // been delivered with the operator-only `trustedBotIds` set —
+    // been delivered with the principal-only `trustedBotIds` set —
     // bot-to-bot traffic at boot time would be silently rejected
     // until the merge lands (the [major/security] bug Echo flagged
     // on cortex#105 for Discord, ported here for Slack parity).
@@ -266,7 +266,7 @@ export class SlackAdapter implements PlatformAdapter {
    *
    * The caller MUST call this AFTER `setTrustedBotIds(merged)` has
    * populated the resolver-merged allowlist. Otherwise queued events
-   * would dispatch against the operator-only set and bot-to-bot
+   * would dispatch against the principal-only set and bot-to-bot
    * traffic that arrived during the start→attach window would be
    * silently dropped at `resolveAccess`. Mirrors the TOCTOU
    * invariant Echo round-1 on cortex#105 locked in for Discord.
@@ -313,7 +313,7 @@ export class SlackAdapter implements PlatformAdapter {
           // console.warn (matches the `ack failed:` and `onEvent
           // threw:` patterns in client.ts; the `system.error`
           // envelope path is reserved for state machine violations
-          // operators should page on).
+          // principals should page on).
           console.warn(
             `slack-adapter[${this.instanceId}]: drain of queued message threw:`,
             err instanceof Error ? err.message : String(err),
@@ -376,7 +376,7 @@ export class SlackAdapter implements PlatformAdapter {
     //   - `lastDisconnectedAt` could falsely pair with that
     //     synthetic recovered.
     //   - `warnedMissingSource` is process-lifetime in spirit but
-    //     resetting on stop()/start() boundaries is fine (operator
+    //     resetting on stop()/start() boundaries is fine (principal
     //     restarting an adapter probably wants the diagnostic again
     //     if they fixed nothing in between).
     this.connectedOnce = false;
@@ -405,7 +405,7 @@ export class SlackAdapter implements PlatformAdapter {
   /**
    * F-092 hot-reload (cortex#235 r1#5). Match the live presence by
    * the immutable `workspaceId` (Slack's analogue to Mattermost's
-   * `apiUrl` and Discord's `guildId` — the operator-paste-stable
+   * `apiUrl` and Discord's `guildId` — the principal-paste-stable
    * identifier within `config.slack[]`).
    *
    * Hot-reload-safe fields (no socket reconnect required):
@@ -452,7 +452,7 @@ export class SlackAdapter implements PlatformAdapter {
     // wins over `presence.trustedBotIds` at construction time per
     // cortex#108 item 1; on hot-reload we go back to the
     // presence-only set, which matches the Mattermost behaviour and
-    // is the operator-intent surface a config edit speaks to.
+    // is the principal-intent surface a config edit speaks to.
     // Two-pass trust resolver merge is a separate follow-up (r1#7).
     this.trustedBotIds = new Set(newInstance.trustedBotIds);
 
@@ -560,7 +560,7 @@ export class SlackAdapter implements PlatformAdapter {
     const key = target.threadId ?? target.channelId;
     // Like Mattermost, we can't edit posts easily without tracking ts +
     // calling chat.update. v1: send once, skip subsequent — matches the
-    // Mattermost adapter's shape so operators get consistent UX.
+    // Mattermost adapter's shape so principals get consistent UX.
     if (this.progressSent.has(key)) return;
     this.progressSent.add(key);
     await this.client.postMessage(target.channelId, `> ${text}`, target.threadId);


### PR DESCRIPTION
## Summary

PR-R13c — mechanical prose sweep over `src/adapters/` per cortex#444 + plan §R13.C (Wave 4, ~50 LOC).

Doc-comments + JSDoc + inline comments that referenced legacy `operator` vocabulary where canonical `principal` applies (CONTEXT.md authority). Prose only — no functional code changes, no symbol renames, no wire-shape changes.

## Files touched

| File | Sites |
|---|---|
| `src/adapters/discord/attachments.ts` | 2 |
| `src/adapters/discord/index.ts` | 7 |
| `src/adapters/discord/wire-format.ts` | 1 |
| `src/adapters/discord/__tests__/auto-thread.test.ts` | 1 |
| `src/adapters/envelope-renderer.ts` | 1 |
| `src/adapters/slack/index.ts` | 6 |
| `src/adapters/slack/client.ts` | 1 |
| `src/adapters/slack/__tests__/schema.test.ts` | 1 |
| `src/adapters/slack/__tests__/slack-adapter.test.ts` | 1 |
| `src/adapters/mattermost/index.ts` | 1 |
| **Total** | **22 prose sites / 10 files / 28 lines** |

## Carve-outs preserved (per plan §R13.C + R13b precedent)

- `trustedBotIds` field name — platform term, plan carve-out #7.
- `botUserId` field name — platform term, plan carve-out #7.
- `messageCreate bot-author gate` — Discord adapter platform vocabulary.
- `notifyOperator` / `bufferOperatorDM` / `drainPendingOperatorDMs` method names + coupled log strings + coupled prose — R13.B territory.
- `dmType === "operator"` literal + interface shape (`"operator" | "user"`) + coupled comments — R6/R8 runtime-token territory.
- `operatorDiscordId` field/symbol references — R2 territory (retired in PR-R2c; comments documenting the retirement preserved).
- `"operator"` policy-capability token + coupled comments — R2 runtime token.
- PayloadFilter `"operator"` (EventBridge filter-grammar operator, payload-filter.ts carve-out — same as R13b).
- User-facing deny string in `mattermost/poller.ts:372` — separate cluster.
- `operator-dm-buffer.test.ts` filename + body — function-name coupled.

## Verification

- `bunx tsc --noEmit` — clean.
- `bun test` — 3545 pass / 0 fail / 2 skip (no flakes).
- `bun run lint:errors` — clean.
- `grep -rEn '\boperator\b' src/adapters/` — 40 remaining hits, all enumerated carve-outs (notifyOperator-coupled, `dmType:"operator"` token, `"operator"` capability token, EventBridge filter-grammar, deny string, `operator-dm-buffer.test.ts` filename).

## Acceptance criteria (cortex#444)

- [x] `grep -rEn '\boperator\b' src/adapters/` returns hits ONLY in: comments referring to platform-bot users (kept), function-name coupled prose, runtime tokens, and historical references.
- [x] No platform-term hits regressed (`trustedBotIds`, `botUserId`).
- [x] `bun test` passes.
- [x] `bunx tsc --noEmit` clean.

Refs cortex#436.

Closes #444.