### PR TITLE
feat(cortex): C-7c — network-registry symbol+wire rename (closes #446)

### DIFF
--- a/src/__tests__/iaw-phase-d-integration.test.ts
+++ b/src/__tests__/iaw-phase-d-integration.test.ts
@@ -23,7 +23,7 @@
  *      stamps.
  *
  *   2. **D.6.2 — registry register + query.** Alpha registers with the
- *      D.4 network-registry service; beta queries `GET /operators/alpha`
+ *      D.4 network-registry service; beta queries `GET /principals/alpha`
  *      and verifies the registry's signed assertion against the pinned
  *      registry pubkey. The cortex-side `RegistryClient` (D.4.3) is a
  *      separate parallel slice; this test scopes to the producer
@@ -76,7 +76,7 @@ import {
   canonicalJSON,
 } from "../services/network-registry/src/signing";
 import type {
-  OperatorRecord,
+  PrincipalRecord,
   RegistrationClaim,
   SignedAssertion,
 } from "../services/network-registry/src/types";
@@ -583,11 +583,11 @@ describe("IAW Phase D.6.2 — network-registry register + cross-operator query (
         ENVIRONMENT: "test",
       };
 
-      // α mints its operator key + signs a registration claim.
+      // α mints its principal key + signs a registration claim.
       const alphaOpKey = await generateKeypair();
       const claim: RegistrationClaim = {
-        operator_id: "alpha",
-        operator_pubkey: alphaOpKey.publicKeyB64,
+        principal_id: "alpha",
+        principal_pubkey: alphaOpKey.publicKeyB64,
         stacks: [
           { stack_id: "alpha/research", display_name: "Alpha research stack" },
         ],
@@ -605,7 +605,7 @@ describe("IAW Phase D.6.2 — network-registry register + cross-operator query (
       const signature = await signEd25519(alphaOpKey.privateKeyB64, message);
 
       const registerRes = await registryApp.fetch(
-        new Request("http://localhost/operators/alpha/register", {
+        new Request("http://localhost/principals/alpha/register", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ claim, signature }),
@@ -614,19 +614,19 @@ describe("IAW Phase D.6.2 — network-registry register + cross-operator query (
       );
       expect(registerRes.status).toBe(201);
 
-      // β-side query: GET /operators/alpha. The response is a
-      // SignedAssertion<OperatorRecord> carrying the registry's own
+      // β-side query: GET /principals/alpha. The response is a
+      // SignedAssertion<PrincipalRecord> carrying the registry's own
       // signature over canonical-JSON({payload, issued_at, registry}).
       const queryRes = await registryApp.fetch(
-        new Request("http://localhost/operators/alpha"),
+        new Request("http://localhost/principals/alpha"),
         env,
       );
       expect(queryRes.status).toBe(200);
-      const assertion = (await queryRes.json()) as SignedAssertion<OperatorRecord>;
+      const assertion = (await queryRes.json()) as SignedAssertion<PrincipalRecord>;
 
       // Payload shape — β sees α's pubkey + capability declaration.
-      expect(assertion.payload.operator_id).toBe("alpha");
-      expect(assertion.payload.operator_pubkey).toBe(alphaOpKey.publicKeyB64);
+      expect(assertion.payload.principal_id).toBe("alpha");
+      expect(assertion.payload.principal_pubkey).toBe(alphaOpKey.publicKeyB64);
       expect(assertion.payload.stacks).toHaveLength(1);
       expect(assertion.payload.stacks[0]!.stack_id).toBe("alpha/research");
       expect(assertion.payload.capabilities).toHaveLength(1);
@@ -651,7 +651,7 @@ describe("IAW Phase D.6.2 — network-registry register + cross-operator query (
       const tamperedBound = canonicalJSON({
         payload: {
           ...assertion.payload,
-          operator_pubkey: "AAAA" + assertion.payload.operator_pubkey.slice(4),
+          principal_pubkey: "AAAA" + assertion.payload.principal_pubkey.slice(4),
         },
         issued_at: assertion.issued_at,
         registry: assertion.registry,

--- a/src/common/registry/__tests__/client.test.ts
+++ b/src/common/registry/__tests__/client.test.ts
@@ -75,11 +75,28 @@ async function signAssertion<T>(
 const FAKE_PEER_PUBKEY_V1 = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
 const FAKE_PEER_PUBKEY_V2 = "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB=";
 
-function makeOperator(operator_id: string, pubkeyB64 = FAKE_PEER_PUBKEY_V1): OperatorRecord {
+/**
+ * Build a wire-shape payload — the JSON the registry emits and the
+ * client deserializes. Wire fields are `principal_id` / `principal_pubkey`
+ * per PR-R7c-network-registry; cortex's internal `OperatorRecord`
+ * cache type uses different field names and the client maps between
+ * them. Tests assert against the in-memory `OperatorRecord` view, so
+ * the fixture is left as `unknown`-typed wire bytes.
+ */
+function makeOperator(
+  principal_id: string,
+  pubkeyB64 = FAKE_PEER_PUBKEY_V1,
+): {
+  principal_id: string;
+  principal_pubkey: string;
+  stacks: { stack_id: string }[];
+  capabilities: never[];
+  updated_at: string;
+} {
   return {
-    operator_id,
-    operator_pubkey: pubkeyB64,
-    stacks: [{ stack_id: `${operator_id}/main` }],
+    principal_id,
+    principal_pubkey: pubkeyB64,
+    stacks: [{ stack_id: `${principal_id}/main` }],
     capabilities: [],
     updated_at: new Date().toISOString(),
   };
@@ -92,7 +109,7 @@ function makeRouteFetch(
 ): FakeFetchHandler {
   return async (url: string) => {
     // Match by suffix so callers can write short keys like
-    // "/registry/pubkey" or "/operators/andreas".
+    // "/registry/pubkey" or "/principals/andreas".
     for (const [suffix, handler] of Object.entries(routes)) {
       if (url.endsWith(suffix)) return handler();
     }
@@ -123,7 +140,7 @@ describe("RegistryClient — TOFU + pinned pubkey", () => {
         pubkeyFetched = true;
         return jsonResponse({ algorithm: "Ed25519", public_key: kp.publicKeyB64 });
       },
-      "/operators/andreas": () => jsonResponse(assertion),
+      "/principals/andreas": () => jsonResponse(assertion),
     });
 
     const client = new RegistryClient({
@@ -155,7 +172,7 @@ describe("RegistryClient — TOFU + pinned pubkey", () => {
         pubkeyFetched = true;
         return jsonResponse({ algorithm: "Ed25519", public_key: kp.publicKeyB64 });
       },
-      "/operators/jcfischer": () => jsonResponse(assertion),
+      "/principals/jcfischer": () => jsonResponse(assertion),
     });
 
     const client = new RegistryClient({
@@ -183,7 +200,7 @@ describe("RegistryClient — getPrincipal()", () => {
     const assertion = await signAssertion(kp.privateKey, kp.publicKeyB64, op);
 
     const fakeFetch = makeRouteFetch({
-      "/operators/andreas": () => jsonResponse(assertion),
+      "/principals/andreas": () => jsonResponse(assertion),
     });
 
     const client = new RegistryClient({
@@ -197,7 +214,17 @@ describe("RegistryClient — getPrincipal()", () => {
     await client.start();
     try {
       const got = client.getPrincipal("andreas");
-      expect(got).toEqual(op);
+      // The cache is keyed on the cortex-internal `OperatorRecord`
+      // shape (`operator_id`/`operator_pubkey`), built from the wire
+      // payload (`principal_id`/`principal_pubkey`) per PR-R7c.
+      const expected: OperatorRecord = {
+        operator_id: op.principal_id,
+        operator_pubkey: op.principal_pubkey,
+        stacks: op.stacks,
+        capabilities: op.capabilities,
+        updated_at: op.updated_at,
+      };
+      expect(got).toEqual(expected);
     } finally {
       client.stop();
     }
@@ -220,7 +247,7 @@ describe("RegistryClient — getPrincipal()", () => {
       signerKp.privateKey,
       new TextEncoder().encode(bound),
     );
-    const forged: SignedAssertion<OperatorRecord> = {
+    const forged: SignedAssertion<ReturnType<typeof makeOperator>> = {
       payload: op,
       issued_at,
       registry: pinnedKp.publicKeyB64,
@@ -229,7 +256,7 @@ describe("RegistryClient — getPrincipal()", () => {
 
     const errs: string[] = [];
     const fakeFetch = makeRouteFetch({
-      "/operators/attacker": () => jsonResponse(forged),
+      "/principals/attacker": () => jsonResponse(forged),
     });
     const client = new RegistryClient({
       url: "https://registry.example",
@@ -275,14 +302,14 @@ describe("RegistryClient — getPrincipal()", () => {
   test("returns undefined when the registry returned an `unconfigured` sentinel", async () => {
     const kp = await generateKeypair();
     const op = makeOperator("andreas");
-    const unsignedAssertion: SignedAssertion<OperatorRecord> = {
+    const unsignedAssertion: SignedAssertion<ReturnType<typeof makeOperator>> = {
       payload: op,
       issued_at: new Date().toISOString(),
       registry: "unconfigured",
       signature: "",
     };
     const fakeFetch = makeRouteFetch({
-      "/operators/andreas": () => jsonResponse(unsignedAssertion),
+      "/principals/andreas": () => jsonResponse(unsignedAssertion),
     });
     const errs: string[] = [];
     const client = new RegistryClient({
@@ -309,7 +336,7 @@ describe("RegistryClient — getPrincipal()", () => {
     // Assertion is well-signed by realKp, but the client pinned otherKp.
     const assertion = await signAssertion(realKp.privateKey, realKp.publicKeyB64, op);
     const fakeFetch = makeRouteFetch({
-      "/operators/victim": () => jsonResponse(assertion),
+      "/principals/victim": () => jsonResponse(assertion),
     });
     const errs: string[] = [];
     const client = new RegistryClient({
@@ -329,16 +356,16 @@ describe("RegistryClient — getPrincipal()", () => {
     }
   });
 
-  test("returns undefined when the payload's operator_id does not match the requested id", async () => {
+  test("returns undefined when the payload's principal_id does not match the requested id", async () => {
     // Defends against a swapped-payload attack: a malicious registry
     // serves a valid signed assertion for `eve` when cortex asked for
     // `alice`. The signature verifies, the registry pubkey matches —
-    // only the per-operator id check catches it.
+    // only the per-principal id check catches it.
     const kp = await generateKeypair();
     const eve = makeOperator("eve");
     const assertion = await signAssertion(kp.privateKey, kp.publicKeyB64, eve);
     const fakeFetch = makeRouteFetch({
-      "/operators/alice": () => jsonResponse(assertion),
+      "/principals/alice": () => jsonResponse(assertion),
     });
     const errs: string[] = [];
     const client = new RegistryClient({
@@ -352,13 +379,13 @@ describe("RegistryClient — getPrincipal()", () => {
     await client.start();
     try {
       expect(client.getPrincipal("alice")).toBeUndefined();
-      expect(errs.some((e) => e.includes("operator_id mismatch"))).toBe(true);
+      expect(errs.some((e) => e.includes("principal_id mismatch"))).toBe(true);
     } finally {
       client.stop();
     }
   });
 
-  test("returns undefined when the payload's operator_pubkey is signed but malformed", async () => {
+  test("returns undefined when the payload's principal_pubkey is signed but malformed", async () => {
     // Echo cortex#230 rounds 1 + 3: a signed-but-malformed peer
     // pubkey is still a wire-contract violation. The structural
     // grammar gate runs BEFORE the signature verify (cheap-check-
@@ -366,13 +393,13 @@ describe("RegistryClient — getPrincipal()", () => {
     // wrong-shape pubkey is rejected even if the rest of the
     // assertion would have verified.
     const kp = await generateKeypair();
-    const op: OperatorRecord = {
+    const op = {
       ...makeOperator("andreas"),
-      operator_pubkey: "definitely-not-base64-ed25519", // wrong length + alphabet
+      principal_pubkey: "definitely-not-base64-ed25519", // wrong length + alphabet
     };
     const assertion = await signAssertion(kp.privateKey, kp.publicKeyB64, op);
     const fakeFetch = makeRouteFetch({
-      "/operators/andreas": () => jsonResponse(assertion),
+      "/principals/andreas": () => jsonResponse(assertion),
     });
     const errs: string[] = [];
     const client = new RegistryClient({
@@ -410,7 +437,7 @@ describe("RegistryClient — start()/stop() idempotency", () => {
       if (url.endsWith("/registry/pubkey")) {
         return jsonResponse({ algorithm: "Ed25519", public_key: kp.publicKeyB64 });
       }
-      if (url.endsWith("/operators/andreas")) return jsonResponse(assertion);
+      if (url.endsWith("/principals/andreas")) return jsonResponse(assertion);
       return new Response("nope", { status: 404 });
     };
     const client = new RegistryClient({
@@ -423,7 +450,7 @@ describe("RegistryClient — start()/stop() idempotency", () => {
     });
     await client.start();
     const callsAfterFirst = fetchCalls.length;
-    expect(callsAfterFirst).toBe(2); // /registry/pubkey + /operators/andreas
+    expect(callsAfterFirst).toBe(2); // /registry/pubkey + /principals/andreas
 
     await client.start(); // second invocation must short-circuit
     try {
@@ -458,7 +485,7 @@ describe("RegistryClient — start()/stop() idempotency", () => {
         }
         return jsonResponse({ algorithm: "Ed25519", public_key: kp.publicKeyB64 });
       }
-      if (url.endsWith("/operators/andreas")) return jsonResponse(assertion);
+      if (url.endsWith("/principals/andreas")) return jsonResponse(assertion);
       return new Response("nope", { status: 404 });
     };
     const client = new RegistryClient({
@@ -491,7 +518,7 @@ describe("RegistryClient — periodic refresh + shutdown", () => {
     const kp = await generateKeypair();
     let currentPubkey = FAKE_PEER_PUBKEY_V1;
     const fakeFetch: FakeFetchHandler = async (url: string) => {
-      if (url.endsWith("/operators/andreas")) {
+      if (url.endsWith("/principals/andreas")) {
         const op = makeOperator("andreas", currentPubkey);
         const assertion = await signAssertion(kp.privateKey, kp.publicKeyB64, op);
         return jsonResponse(assertion);
@@ -529,7 +556,7 @@ describe("RegistryClient — periodic refresh + shutdown", () => {
     const fetchCalls: string[] = [];
     const fakeFetch: FakeFetchHandler = async (url: string) => {
       fetchCalls.push(url);
-      if (url.endsWith("/operators/andreas")) return jsonResponse(assertion);
+      if (url.endsWith("/principals/andreas")) return jsonResponse(assertion);
       return new Response("not found", { status: 404 });
     };
 
@@ -611,7 +638,7 @@ describe("RegistryClient — periodic refresh + shutdown", () => {
     const op = makeOperator("andreas");
     const assertion = await signAssertion(kp.privateKey, kp.publicKeyB64, op);
     const fakeFetch = makeRouteFetch({
-      "/operators/andreas": () => jsonResponse(assertion),
+      "/principals/andreas": () => jsonResponse(assertion),
     });
 
     const client = new RegistryClient({

--- a/src/common/registry/client.ts
+++ b/src/common/registry/client.ts
@@ -324,9 +324,10 @@ export class RegistryClient implements RegistryClientReader {
     principalId: string,
     signal: AbortSignal,
   ): Promise<void> {
-    // Wire path stays `/operators/:operator_id` until PR-R7c-network-registry
-    // renames the registry service.
-    const url = `${this.url}/operators/${encodeURIComponent(principalId)}`;
+    // Wire path is `/principals/:principal_id` per PR-R7c-network-registry.
+    // The cortex-internal cache type (`OperatorRecord`) keeps its symbol
+    // pending PR-R2.G; only the wire path + field reads flip here.
+    const url = `${this.url}/principals/${encodeURIComponent(principalId)}`;
     const raw = await this.fetchJson(url, signal);
     if (raw === undefined) return; // already logged inside fetchJson
 
@@ -386,22 +387,22 @@ export class RegistryClient implements RegistryClientReader {
       );
       return undefined;
     }
-    // Sanity-check the payload looks like an OperatorRecord. We don't
+    // Sanity-check the payload looks like a PrincipalRecord. We don't
     // re-validate the deep structure here — the registry is the source
     // of truth for its own shape — but we do require the same
-    // operator_id we requested, defending against a swapped payload.
-    // Wire-field reads (`payload.operator_id`, `payload.operator_pubkey`)
-    // stay until PR-R7c-network-registry renames the registry service.
+    // principal_id we requested, defending against a swapped payload.
+    // Wire-field reads (`payload.principal_id`, `payload.principal_pubkey`)
+    // mirror PR-R7c-network-registry's wire-shape.
     const payload = assertion.payload as Record<string, unknown>;
-    if (payload.operator_id !== principalId) {
+    if (payload.principal_id !== principalId) {
       this.logError(
-        `refresh(${principalId}): payload.operator_id mismatch (got "${String(payload.operator_id)}"); ignoring`,
+        `refresh(${principalId}): payload.principal_id mismatch (got "${String(payload.principal_id)}"); ignoring`,
       );
       return undefined;
     }
-    if (typeof payload.operator_pubkey !== "string") {
+    if (typeof payload.principal_pubkey !== "string") {
       this.logError(
-        `refresh(${principalId}): payload.operator_pubkey missing or non-string; ignoring`,
+        `refresh(${principalId}): payload.principal_pubkey missing or non-string; ignoring`,
       );
       return undefined;
     }
@@ -417,11 +418,11 @@ export class RegistryClient implements RegistryClientReader {
     // cortex#230 rounds 1 + 3.
     //
     // Grammar: 43 chars of standard-base64 alphabet + one `=` of
-    // padding = 44 chars total, matching `OperatorRecord.operator_pubkey`
+    // padding = 44 chars total, matching `PrincipalRecord.principal_pubkey`
     // on the producer side (base64 of 32 raw bytes).
-    if (!/^[A-Za-z0-9+/]{43}=$/.test(payload.operator_pubkey)) {
+    if (!/^[A-Za-z0-9+/]{43}=$/.test(payload.principal_pubkey)) {
       this.logError(
-        `refresh(${principalId}): payload.operator_pubkey is not base64-Ed25519 (got "${payload.operator_pubkey.slice(0, 12)}…"); ignoring`,
+        `refresh(${principalId}): payload.principal_pubkey is not base64-Ed25519 (got "${payload.principal_pubkey.slice(0, 12)}…"); ignoring`,
       );
       return undefined;
     }
@@ -450,10 +451,12 @@ export class RegistryClient implements RegistryClientReader {
     }
     // Defensive: the producer types include arrays we trust the
     // service to populate, but a corrupted payload could send the
-    // wrong shape past the structural checks above. Normalise.
+    // wrong shape past the structural checks above. Normalise. The
+    // cortex-internal cache type (`OperatorRecord`) keeps its symbol
+    // pending PR-R2.G; wire fields read as `principal_*` per R7c.
     return {
       operator_id: principalId,
-      operator_pubkey: payload.operator_pubkey,
+      operator_pubkey: payload.principal_pubkey,
       stacks: Array.isArray(payload.stacks) ? (payload.stacks as OperatorRecord["stacks"]) : [],
       capabilities: Array.isArray(payload.capabilities) ? (payload.capabilities as OperatorRecord["capabilities"]) : [],
       updated_at: typeof payload.updated_at === "string" ? payload.updated_at : "",

--- a/src/services/network-registry/README.md
+++ b/src/services/network-registry/README.md
@@ -9,20 +9,20 @@ Refs cortex#116 (Phase D umbrella) → `docs/plan-internet-of-agentic-work.md` �
 
 ## Endpoints
 
-| Method | Path                                | Purpose                                           |
-|--------|-------------------------------------|---------------------------------------------------|
-| POST   | `/operators/{operator_id}/register` | Operator publishes signed assertion (D.4.2)       |
-| GET    | `/operators/{operator_id}`          | Peers query operator's current pubkey + stacks    |
-| GET    | `/networks/{network_id}/roster`     | Who's in this network                             |
-| GET    | `/capabilities?query=<substring>`   | Capability search across networks                 |
-| GET    | `/registry/pubkey`                  | Returns the registry's Ed25519 pubkey (pin this)  |
-| GET    | `/api/health`                       | Liveness probe                                    |
+| Method | Path                                  | Purpose                                           |
+|--------|---------------------------------------|---------------------------------------------------|
+| POST   | `/principals/{principal_id}/register` | Principal publishes signed assertion (D.4.2)      |
+| GET    | `/principals/{principal_id}`          | Peers query principal's current pubkey + stacks   |
+| GET    | `/networks/{network_id}/roster`       | Who's in this network                             |
+| GET    | `/capabilities?query=<substring>`     | Capability search across networks                 |
+| GET    | `/registry/pubkey`                    | Returns the registry's Ed25519 pubkey (pin this)  |
+| GET    | `/api/health`                         | Liveness probe                                    |
 
 ## Trust model
 
 - **POST register**: open at the HTTP layer; authenticity enforced by
-  the signed assertion in the body. Operator signs canonical-JSON of
-  the `RegistrationClaim` with their operator Ed25519 NKey; the
+  the signed assertion in the body. Principal signs canonical-JSON of
+  the `RegistrationClaim` with their principal Ed25519 NKey; the
   registry verifies against the declared pubkey. TOFU on first sight.
   Subsequent registers MUST sign with the on-record pubkey.
 - **GET responses**: wrapped in `SignedAssertion<T>` with a registry
@@ -38,7 +38,7 @@ In-memory per-isolate. Acceptable for the initial endpoint surface +
 test rig. **Persistence (D1 or KV) is a follow-up** before any
 production traffic — see "Roadmap" below.
 
-The POST `/operators/.../register` handler returns **503** when the
+The POST `/principals/.../register` handler returns **503** when the
 Worker is unconfigured (no `REGISTRY_SIGNING_KEY`) so mutation cannot
 happen without a producible signed receipt. GET endpoints degrade to
 an unsigned-but-structured response in the same condition; cortex
@@ -46,10 +46,10 @@ peers refuse to trust assertions with `registry: "unconfigured"`.
 
 ## Discovery vs. traffic gating
 
-Operators announce themselves into networks by listing the network in
+Principals announce themselves into networks by listing the network in
 `capability.networks[]`. Anyone can announce into any network id —
 the registry treats `network_id` as a public namespace label, and
-attribution (operator A learns operator B exists in `secret-research`)
+attribution (principal A learns principal B exists in `secret-research`)
 is visible without a join handshake. **This is intentional for v1**:
 runtime gating (`accept_subjects` / `deny_subjects` from PR #223)
 protects the *traffic* path; the discovery surface is open by design
@@ -108,14 +108,14 @@ issues (see cortex#116):
 3. **Pubkey rotation.** Accept a transition claim co-signed by the
    previous key. Currently silent rotation is rejected with HTTP 409.
 4. **Pagination on `/capabilities`.** Hard-capped at 500 hits for v1.
-5. **Per-operator publish rate limiting + CORS origin allowlist on
+5. **Per-principal publish rate limiting + CORS origin allowlist on
    POST.** Replay protection covers one axis; throughput limiting +
-   tightening from `origin: "*"` to a known operator-tooling origin
+   tightening from `origin: "*"` to a known principal-tooling origin
    list is the other. Bundled because both are about hardening the
    mutation surface before public DNS goes live.
 6. **Cortex-side consumer.** A `RegistryClient` in `src/bus/registry/`
    that consults the registry at startup + on schedule and invalidates
-   on `system.operator.published` events (D.4.3). Filed alongside the
+   on `system.principal.published` events (D.4.3). Filed alongside the
    D.2 / D.3 work — this service is the producer half.
 7. **Sealed-network join handshake.** If a deployment needs network
    membership to require explicit consent from existing members

--- a/src/services/network-registry/__tests__/capabilities.test.ts
+++ b/src/services/network-registry/__tests__/capabilities.test.ts
@@ -6,7 +6,7 @@ import { describe, test, expect, beforeEach } from "bun:test";
 import app from "../src/index";
 import type { Env } from "../src/index";
 import {
-  makeOperatorKey,
+  makePrincipalKey,
   makeRegistryKey,
   makeSignedRegistration,
   resetStores,
@@ -53,11 +53,11 @@ describe("GET /capabilities", () => {
   });
 
   test("returns hits matching the id substring", async () => {
-    const opA = await makeOperatorKey();
-    const opB = await makeOperatorKey();
+    const pA = await makePrincipalKey();
+    const pB = await makePrincipalKey();
     await post(
-      "/operators/alpha/register",
-      await makeSignedRegistration("alpha", opA, {
+      "/principals/alpha/register",
+      await makeSignedRegistration("alpha", pA, {
         capabilities: [
           { id: "tasks.code-review", description: "TS + Rust", networks: ["n1"] },
           { id: "tasks.docs-edit", networks: ["n1"] },
@@ -65,8 +65,8 @@ describe("GET /capabilities", () => {
       }),
     );
     await post(
-      "/operators/beta/register",
-      await makeSignedRegistration("beta", opB, {
+      "/principals/beta/register",
+      await makeSignedRegistration("beta", pB, {
         capabilities: [{ id: "infra.deploy", networks: ["n2"] }],
       }),
     );
@@ -83,10 +83,10 @@ describe("GET /capabilities", () => {
   });
 
   test("matches description case-insensitively", async () => {
-    const op = await makeOperatorKey();
+    const p = await makePrincipalKey();
     await post(
-      "/operators/alpha/register",
-      await makeSignedRegistration("alpha", op, {
+      "/principals/alpha/register",
+      await makeSignedRegistration("alpha", p, {
         capabilities: [
           { id: "tasks.code-review", description: "TypeScript reviewer", networks: ["n1"] },
         ],

--- a/src/services/network-registry/__tests__/helpers.ts
+++ b/src/services/network-registry/__tests__/helpers.ts
@@ -1,5 +1,5 @@
 /**
- * Shared test helpers — operator-side signing rig + assertion helpers.
+ * Shared test helpers — principal-side signing rig + assertion helpers.
  *
  * The tests deliberately mint REAL Ed25519 keypairs via WebCrypto so the
  * full verify path is exercised. Generating a fresh keypair per test
@@ -12,16 +12,16 @@ import type { Capability, RegistrationClaim, StackIdentity } from "../src/types"
 import { _setNonceCacheForTest, _setStoreForTest } from "../src/store";
 import { _resetDerivedPublicKeyForTest } from "../src/index";
 
-export interface OperatorKey {
+export interface PrincipalKey {
   privateKeyB64: string;
   publicKeyB64: string;
 }
 
 /**
- * Generate a per-test operator keypair. Awaited once per test in
+ * Generate a per-test principal keypair. Awaited once per test in
  * beforeEach, then used to sign multiple claims as the test needs.
  */
-export async function makeOperatorKey(): Promise<OperatorKey> {
+export async function makePrincipalKey(): Promise<PrincipalKey> {
   return generateKeypair();
 }
 
@@ -45,12 +45,12 @@ export function resetStores(): void {
 }
 
 /**
- * Build a signed registration body for the given operator. Default
+ * Build a signed registration body for the given principal. Default
  * stacks/capabilities are empty; tests override via opts.
  */
 export async function makeSignedRegistration(
-  operatorId: string,
-  opKey: OperatorKey,
+  principalId: string,
+  pKey: PrincipalKey,
   opts: {
     stacks?: StackIdentity[];
     capabilities?: Capability[];
@@ -63,15 +63,15 @@ export async function makeSignedRegistration(
   } = {},
 ): Promise<{ claim: RegistrationClaim; signature: string }> {
   const claim: RegistrationClaim = {
-    operator_id: operatorId,
-    operator_pubkey: opts.pubkeyOverride ?? opKey.publicKeyB64,
+    principal_id: principalId,
+    principal_pubkey: opts.pubkeyOverride ?? pKey.publicKeyB64,
     stacks: opts.stacks ?? [],
     capabilities: opts.capabilities ?? [],
     issued_at: opts.issuedAt ?? new Date().toISOString(),
     nonce: opts.nonce ?? randomNonce(),
   };
   const message = new TextEncoder().encode(canonicalJSON(claim));
-  const signature = await signEd25519(opKey.privateKeyB64, message);
+  const signature = await signEd25519(pKey.privateKeyB64, message);
   return { claim, signature };
 }
 

--- a/src/services/network-registry/__tests__/networks.test.ts
+++ b/src/services/network-registry/__tests__/networks.test.ts
@@ -6,11 +6,11 @@ import { describe, test, expect, beforeEach } from "bun:test";
 import app from "../src/index";
 import type { Env } from "../src/index";
 import {
-  makeOperatorKey,
+  makePrincipalKey,
   makeRegistryKey,
   makeSignedRegistration,
   resetStores,
-  type OperatorKey,
+  type PrincipalKey,
 } from "./helpers";
 import type { NetworkRoster, SignedAssertion } from "../src/types";
 
@@ -47,7 +47,7 @@ describe("GET /networks/:id/roster", () => {
     expect(res.status).toBe(400);
   });
 
-  test("returns empty roster when no operators are in the network", async () => {
+  test("returns empty roster when no principals are in the network", async () => {
     const res = await get("/networks/research-collab/roster");
     expect(res.status).toBe(200);
     const json = (await res.json()) as SignedAssertion<NetworkRoster>;
@@ -55,14 +55,14 @@ describe("GET /networks/:id/roster", () => {
     expect(json.payload.members).toEqual([]);
   });
 
-  test("aggregates operators whose capabilities target the network", async () => {
-    const opA: OperatorKey = await makeOperatorKey();
-    const opB: OperatorKey = await makeOperatorKey();
-    const opC: OperatorKey = await makeOperatorKey();
+  test("aggregates principals whose capabilities target the network", async () => {
+    const pA: PrincipalKey = await makePrincipalKey();
+    const pB: PrincipalKey = await makePrincipalKey();
+    const pC: PrincipalKey = await makePrincipalKey();
 
     await post(
-      "/operators/alpha/register",
-      await makeSignedRegistration("alpha", opA, {
+      "/principals/alpha/register",
+      await makeSignedRegistration("alpha", pA, {
         capabilities: [
           { id: "tasks.code-review", networks: ["research-collab"] },
           { id: "tasks.docs-edit", networks: ["docs-net"] },
@@ -70,15 +70,15 @@ describe("GET /networks/:id/roster", () => {
       }),
     );
     await post(
-      "/operators/beta/register",
-      await makeSignedRegistration("beta", opB, {
+      "/principals/beta/register",
+      await makeSignedRegistration("beta", pB, {
         capabilities: [{ id: "tasks.code-review", networks: ["research-collab"] }],
       }),
     );
     // Gamma announces to a different network only — should be excluded.
     await post(
-      "/operators/gamma/register",
-      await makeSignedRegistration("gamma", opC, {
+      "/principals/gamma/register",
+      await makeSignedRegistration("gamma", pC, {
         capabilities: [{ id: "tasks.code-review", networks: ["other-net"] }],
       }),
     );
@@ -86,11 +86,11 @@ describe("GET /networks/:id/roster", () => {
     const res = await get("/networks/research-collab/roster");
     expect(res.status).toBe(200);
     const json = (await res.json()) as SignedAssertion<NetworkRoster>;
-    const ids = json.payload.members.map((m) => m.operator_id).sort();
+    const ids = json.payload.members.map((m) => m.principal_id).sort();
     expect(ids).toEqual(["alpha", "beta"]);
-    const alpha = json.payload.members.find((m) => m.operator_id === "alpha");
+    const alpha = json.payload.members.find((m) => m.principal_id === "alpha");
     expect(alpha?.capabilities).toEqual(["tasks.code-review"]);
-    expect(alpha?.operator_pubkey).toBe(opA.publicKeyB64);
+    expect(alpha?.principal_pubkey).toBe(pA.publicKeyB64);
   });
 
   test("returns signed assertion verifiable with registry pubkey", async () => {

--- a/src/services/network-registry/__tests__/principals.test.ts
+++ b/src/services/network-registry/__tests__/principals.test.ts
@@ -1,5 +1,5 @@
 /**
- * IAW D.4 — Operator route tests (POST register + GET).
+ * IAW D.4 — Principal route tests (POST register + GET).
  *
  * Drives the Worker via `app.fetch(request, env)` so the full Hono
  * pipeline + middleware + signing path are exercised. Each test resets
@@ -10,22 +10,21 @@ import { describe, test, expect, beforeEach } from "bun:test";
 import app from "../src/index";
 import type { Env } from "../src/index";
 import {
-  makeOperatorKey,
+  makePrincipalKey,
   makeRegistryKey,
   makeSignedRegistration,
   randomNonce,
   resetStores,
-  type OperatorKey,
+  type PrincipalKey,
 } from "./helpers";
 import {
   canonicalJSON,
-  signEd25519,
   verifyEd25519,
 } from "../src/signing";
-import type { SignedAssertion, OperatorRecord } from "../src/types";
+import type { SignedAssertion, PrincipalRecord } from "../src/types";
 
 let env: Env;
-let opKey: OperatorKey;
+let pKey: PrincipalKey;
 
 beforeEach(async () => {
   resetStores();
@@ -35,7 +34,7 @@ beforeEach(async () => {
     REGISTRY_PUBLIC_KEY: reg.publicKey,
     ENVIRONMENT: "test",
   };
-  opKey = await makeOperatorKey();
+  pKey = await makePrincipalKey();
 });
 
 async function post(path: string, body: unknown): Promise<Response> {
@@ -53,19 +52,19 @@ async function get(path: string): Promise<Response> {
   return app.fetch(new Request(`http://localhost${path}`), env);
 }
 
-describe("POST /operators/:id/register — happy path", () => {
-  test("registers a new operator and returns signed assertion", async () => {
-    const body = await makeSignedRegistration("andreas", opKey, {
+describe("POST /principals/:id/register — happy path", () => {
+  test("registers a new principal and returns signed assertion", async () => {
+    const body = await makeSignedRegistration("andreas", pKey, {
       stacks: [{ stack_id: "andreas/laptop", display_name: "Laptop" }],
       capabilities: [
         { id: "tasks.code-review", description: "Reviews TS", networks: ["research-collab"] },
       ],
     });
-    const res = await post("/operators/andreas/register", body);
+    const res = await post("/principals/andreas/register", body);
     expect(res.status).toBe(201);
-    const json = (await res.json()) as SignedAssertion<OperatorRecord>;
-    expect(json.payload.operator_id).toBe("andreas");
-    expect(json.payload.operator_pubkey).toBe(opKey.publicKeyB64);
+    const json = (await res.json()) as SignedAssertion<PrincipalRecord>;
+    expect(json.payload.principal_id).toBe("andreas");
+    expect(json.payload.principal_pubkey).toBe(pKey.publicKeyB64);
     expect(json.payload.stacks).toHaveLength(1);
     expect(json.payload.capabilities).toHaveLength(1);
     expect(json.signature.length).toBeGreaterThan(0);
@@ -86,62 +85,62 @@ describe("POST /operators/:id/register — happy path", () => {
   });
 });
 
-describe("POST /operators/:id/register — validation failures", () => {
-  test("rejects invalid operator_id in path", async () => {
-    const body = await makeSignedRegistration("andreas", opKey);
-    const res = await post("/operators/INVALID_CAPS/register", body);
+describe("POST /principals/:id/register — validation failures", () => {
+  test("rejects invalid principal_id in path", async () => {
+    const body = await makeSignedRegistration("andreas", pKey);
+    const res = await post("/principals/INVALID_CAPS/register", body);
     expect(res.status).toBe(400);
   });
 
-  test("rejects body operator_id mismatch with path", async () => {
-    const body = await makeSignedRegistration("not-andreas", opKey);
-    const res = await post("/operators/andreas/register", body);
+  test("rejects body principal_id mismatch with path", async () => {
+    const body = await makeSignedRegistration("not-andreas", pKey);
+    const res = await post("/principals/andreas/register", body);
     expect(res.status).toBe(400);
     const json = (await res.json()) as { details: { field: string }[] };
-    expect(json.details.some((d) => d.field === "operator_id")).toBe(true);
+    expect(json.details.some((d) => d.field === "principal_id")).toBe(true);
   });
 
-  test("rejects stack_id whose operator prefix doesn't match", async () => {
-    const body = await makeSignedRegistration("andreas", opKey, {
+  test("rejects stack_id whose principal prefix doesn't match", async () => {
+    const body = await makeSignedRegistration("andreas", pKey, {
       stacks: [{ stack_id: "someoneelse/laptop" }],
     });
-    const res = await post("/operators/andreas/register", body);
+    const res = await post("/principals/andreas/register", body);
     expect(res.status).toBe(400);
   });
 
   test("rejects duplicate stack_id within same claim", async () => {
-    const body = await makeSignedRegistration("andreas", opKey, {
+    const body = await makeSignedRegistration("andreas", pKey, {
       stacks: [{ stack_id: "andreas/laptop" }, { stack_id: "andreas/laptop" }],
     });
-    const res = await post("/operators/andreas/register", body);
+    const res = await post("/principals/andreas/register", body);
     expect(res.status).toBe(400);
   });
 
   test("rejects malformed pubkey", async () => {
-    const body = await makeSignedRegistration("andreas", opKey, {
+    const body = await makeSignedRegistration("andreas", pKey, {
       pubkeyOverride: "short",
     });
-    const res = await post("/operators/andreas/register", body);
+    const res = await post("/principals/andreas/register", body);
     expect(res.status).toBe(400);
   });
 
   test("rejects capability id violating <domain>.<entity> grammar", async () => {
-    const body = await makeSignedRegistration("andreas", opKey, {
+    const body = await makeSignedRegistration("andreas", pKey, {
       capabilities: [{ id: "no-dot-here" }],
     });
-    const res = await post("/operators/andreas/register", body);
+    const res = await post("/principals/andreas/register", body);
     expect(res.status).toBe(400);
   });
 
   test("rejects missing nonce", async () => {
-    const body = await makeSignedRegistration("andreas", opKey, { nonce: "" });
-    const res = await post("/operators/andreas/register", body);
+    const body = await makeSignedRegistration("andreas", pKey, { nonce: "" });
+    const res = await post("/principals/andreas/register", body);
     expect(res.status).toBe(400);
   });
 
   test("rejects invalid JSON body", async () => {
     const res = await app.fetch(
-      new Request("http://localhost/operators/andreas/register", {
+      new Request("http://localhost/principals/andreas/register", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: "not json",
@@ -152,68 +151,68 @@ describe("POST /operators/:id/register — validation failures", () => {
   });
 });
 
-describe("POST /operators/:id/register — auth failures", () => {
+describe("POST /principals/:id/register — auth failures", () => {
   test("rejects signature signed by wrong key", async () => {
-    const otherKey = await makeOperatorKey();
+    const otherKey = await makePrincipalKey();
     const body = await makeSignedRegistration("andreas", otherKey, {
-      pubkeyOverride: opKey.publicKeyB64, // claim pubkey from someone else
+      pubkeyOverride: pKey.publicKeyB64, // claim pubkey from someone else
     });
-    const res = await post("/operators/andreas/register", body);
+    const res = await post("/principals/andreas/register", body);
     expect(res.status).toBe(401);
   });
 
   test("rejects tampered claim after signing", async () => {
-    const body = await makeSignedRegistration("andreas", opKey);
+    const body = await makeSignedRegistration("andreas", pKey);
     // Tamper: add an extra stack post-signature.
     body.claim.stacks.push({ stack_id: "andreas/sneaked-in" });
-    const res = await post("/operators/andreas/register", body);
+    const res = await post("/principals/andreas/register", body);
     expect(res.status).toBe(401);
   });
 
   test("rejects issued_at outside skew window", async () => {
     const old = new Date(Date.now() - 30 * 60 * 1000).toISOString();
-    const body = await makeSignedRegistration("andreas", opKey, { issuedAt: old });
-    const res = await post("/operators/andreas/register", body);
+    const body = await makeSignedRegistration("andreas", pKey, { issuedAt: old });
+    const res = await post("/principals/andreas/register", body);
     expect(res.status).toBe(400);
   });
 
   test("rejects replayed nonce", async () => {
     const nonce = randomNonce();
-    const body1 = await makeSignedRegistration("andreas", opKey, { nonce });
-    const res1 = await post("/operators/andreas/register", body1);
+    const body1 = await makeSignedRegistration("andreas", pKey, { nonce });
+    const res1 = await post("/principals/andreas/register", body1);
     expect(res1.status).toBe(201);
 
     // Same nonce, different claim (different stacks list to bypass any other gates)
-    const body2 = await makeSignedRegistration("andreas", opKey, { nonce });
-    const res2 = await post("/operators/andreas/register", body2);
+    const body2 = await makeSignedRegistration("andreas", pKey, { nonce });
+    const res2 = await post("/principals/andreas/register", body2);
     expect(res2.status).toBe(409);
   });
 
   test("rejects silent pubkey rotation", async () => {
-    const body1 = await makeSignedRegistration("andreas", opKey);
-    const res1 = await post("/operators/andreas/register", body1);
+    const body1 = await makeSignedRegistration("andreas", pKey);
+    const res1 = await post("/principals/andreas/register", body1);
     expect(res1.status).toBe(201);
 
-    const newKey = await makeOperatorKey();
+    const newKey = await makePrincipalKey();
     const body2 = await makeSignedRegistration("andreas", newKey);
-    const res2 = await post("/operators/andreas/register", body2);
+    const res2 = await post("/principals/andreas/register", body2);
     expect(res2.status).toBe(409);
   });
 
   test("permits re-register with same pubkey (replaces stacks, no leftover)", async () => {
     // Echo cortex#225 nit: tighten the symmetric "old stacks gone" assertion.
-    const body1 = await makeSignedRegistration("andreas", opKey, {
+    const body1 = await makeSignedRegistration("andreas", pKey, {
       stacks: [{ stack_id: "andreas/laptop" }],
     });
-    const res1 = await post("/operators/andreas/register", body1);
+    const res1 = await post("/principals/andreas/register", body1);
     expect(res1.status).toBe(201);
 
-    const body2 = await makeSignedRegistration("andreas", opKey, {
+    const body2 = await makeSignedRegistration("andreas", pKey, {
       stacks: [{ stack_id: "andreas/server" }],
     });
-    const res2 = await post("/operators/andreas/register", body2);
+    const res2 = await post("/principals/andreas/register", body2);
     expect(res2.status).toBe(201);
-    const json = (await res2.json()) as SignedAssertion<OperatorRecord>;
+    const json = (await res2.json()) as SignedAssertion<PrincipalRecord>;
     expect(json.payload.stacks).toHaveLength(1);
     expect(json.payload.stacks[0]!.stack_id).toBe("andreas/server");
     // Confirm the old `andreas/laptop` is fully gone — not just that
@@ -223,14 +222,14 @@ describe("POST /operators/:id/register — auth failures", () => {
   });
 });
 
-describe("POST /operators/:id/register — unconfigured registry", () => {
+describe("POST /principals/:id/register — unconfigured registry", () => {
   // Echo cortex#225 issue #1: refuse to mutate state when the Worker
   // cannot produce a signed receipt.
   test("returns 503 and does not mutate state when REGISTRY_SIGNING_KEY is absent", async () => {
-    const body = await makeSignedRegistration("andreas", opKey);
+    const body = await makeSignedRegistration("andreas", pKey);
     const unconfigured: Env = { ENVIRONMENT: "test" };
     const res = await app.fetch(
-      new Request("http://localhost/operators/andreas/register", {
+      new Request("http://localhost/principals/andreas/register", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(body),
@@ -242,31 +241,31 @@ describe("POST /operators/:id/register — unconfigured registry", () => {
     expect(json.error).toBe("registry_unconfigured");
 
     // Switch to a configured env on the same module-shared store and
-    // confirm the operator was NOT silently persisted by the 503 path.
+    // confirm the principal was NOT silently persisted by the 503 path.
     const getRes = await app.fetch(
-      new Request("http://localhost/operators/andreas"),
+      new Request("http://localhost/principals/andreas"),
       env,
     );
     expect(getRes.status).toBe(404);
   });
 });
 
-describe("GET /operators/:id", () => {
-  test("returns 404 for unknown operator", async () => {
-    const res = await get("/operators/nobody");
+describe("GET /principals/:id", () => {
+  test("returns 404 for unknown principal", async () => {
+    const res = await get("/principals/nobody");
     expect(res.status).toBe(404);
   });
 
-  test("returns signed assertion for registered operator", async () => {
-    const body = await makeSignedRegistration("andreas", opKey, {
+  test("returns signed assertion for registered principal", async () => {
+    const body = await makeSignedRegistration("andreas", pKey, {
       stacks: [{ stack_id: "andreas/laptop" }],
     });
-    await post("/operators/andreas/register", body);
+    await post("/principals/andreas/register", body);
 
-    const res = await get("/operators/andreas");
+    const res = await get("/principals/andreas");
     expect(res.status).toBe(200);
-    const json = (await res.json()) as SignedAssertion<OperatorRecord>;
-    expect(json.payload.operator_pubkey).toBe(opKey.publicKeyB64);
+    const json = (await res.json()) as SignedAssertion<PrincipalRecord>;
+    expect(json.payload.principal_pubkey).toBe(pKey.publicKeyB64);
     expect(json.signature.length).toBeGreaterThan(0);
 
     // Verify registry signature.
@@ -283,8 +282,8 @@ describe("GET /operators/:id", () => {
     expect(ok).toBe(true);
   });
 
-  test("invalid operator_id in path returns 400", async () => {
-    const res = await get("/operators/CAPS_INVALID");
+  test("invalid principal_id in path returns 400", async () => {
+    const res = await get("/principals/CAPS_INVALID");
     expect(res.status).toBe(400);
   });
 });

--- a/src/services/network-registry/src/index.ts
+++ b/src/services/network-registry/src/index.ts
@@ -6,8 +6,8 @@
  * registry at startup + on schedule to refresh peer pubkeys.
  *
  * Endpoints (D.4.2):
- *   POST /operators/{operator_id}/register
- *   GET  /operators/{operator_id}
+ *   POST /principals/{principal_id}/register
+ *   GET  /principals/{principal_id}
  *   GET  /networks/{network_id}/roster
  *   GET  /capabilities?query=<substring>
  *   GET  /registry/pubkey                 — pin this client-side
@@ -15,8 +15,8 @@
  *
  * Trust model
  * ───────────
- * - POST /operators/.../register is open at the HTTP layer; authenticity
- *   is enforced by the signed assertion in the body (operator Ed25519
+ * - POST /principals/.../register is open at the HTTP layer; authenticity
+ *   is enforced by the signed assertion in the body (principal Ed25519
  *   signature over canonical-JSON of the claim, verified against the
  *   declared pubkey). First-sight is TOFU; subsequent registers MUST
  *   sign with the on-record pubkey. Rotation (transition claim co-signed
@@ -33,7 +33,7 @@
 
 import { Hono } from "hono";
 import { cors } from "hono/cors";
-import { operatorRoutes } from "./routes/operators";
+import { principalRoutes } from "./routes/principals";
 import { networkRoutes } from "./routes/networks";
 import { capabilityRoutes } from "./routes/capabilities";
 import { pubkeyFromPkcs8 } from "./signing";
@@ -165,7 +165,7 @@ app.get("/registry/pubkey", (c) => {
 // Mount route groups
 // ---------------------------------------------------------------------------
 
-app.route("/", operatorRoutes());
+app.route("/", principalRoutes());
 app.route("/", networkRoutes());
 app.route("/", capabilityRoutes());
 

--- a/src/services/network-registry/src/routes/capabilities.ts
+++ b/src/services/network-registry/src/routes/capabilities.ts
@@ -10,7 +10,7 @@
 
 import { Hono } from "hono";
 import type { Env } from "../index";
-import { signAssertion } from "./operators";
+import { signAssertion } from "./principals";
 import { getStore, searchCapabilities } from "../store";
 
 /** Hard cap on result count so pathological queries don't blow up. */
@@ -28,8 +28,8 @@ export function capabilityRoutes(): Hono<{ Bindings: Env }> {
       return c.json({ error: "query parameter too long (max 128 chars)" }, 400);
     }
     const store = getStore();
-    const operators = await store.listOperators();
-    const allHits = searchCapabilities(operators, query);
+    const principals = await store.listPrincipals();
+    const allHits = searchCapabilities(principals, query);
     const hits = allHits.slice(0, MAX_HITS);
     const assertion = await signAssertion(c.env, { query, hits, truncated: allHits.length > MAX_HITS });
     return c.json(assertion);

--- a/src/services/network-registry/src/routes/networks.ts
+++ b/src/services/network-registry/src/routes/networks.ts
@@ -2,7 +2,7 @@
  * IAW D.4.2 — Network endpoints.
  *
  *   GET /networks/{network_id}/roster
- *     Query who's in this network. Membership is implicit: an operator
+ *     Query who's in this network. Membership is implicit: a principal
  *     is "in" a network if any of their announced capabilities lists
  *     that network. Returns a registry-signed assertion so the caller
  *     can pin the registry pubkey and verify the chain before
@@ -11,8 +11,8 @@
 
 import { Hono } from "hono";
 import type { Env } from "../index";
-import { signAssertion } from "./operators";
-import { getStore, rosterFromOperators } from "../store";
+import { signAssertion } from "./principals";
+import { getStore, rosterFromPrincipals } from "../store";
 import { isValidNetworkId } from "../validate";
 
 export function networkRoutes(): Hono<{ Bindings: Env }> {
@@ -24,8 +24,8 @@ export function networkRoutes(): Hono<{ Bindings: Env }> {
       return c.json({ error: "invalid network_id in path" }, 400);
     }
     const store = getStore();
-    const operators = await store.listOperators();
-    const roster = rosterFromOperators(operators, networkId);
+    const principals = await store.listPrincipals();
+    const roster = rosterFromPrincipals(principals, networkId);
     const assertion = await signAssertion(c.env, roster);
     return c.json(assertion);
   });

--- a/src/services/network-registry/src/routes/principals.ts
+++ b/src/services/network-registry/src/routes/principals.ts
@@ -1,14 +1,14 @@
 /**
- * IAW D.4.2 — Operator endpoints.
+ * IAW D.4.2 — Principal endpoints.
  *
- *   POST /operators/{operator_id}/register
- *     Operator publishes a signed assertion containing their pubkey,
+ *   POST /principals/{principal_id}/register
+ *     Principal publishes a signed assertion containing their pubkey,
  *     stack identities, and capability declaration. The registry
  *     verifies the signature, checks the nonce, applies clock-skew
  *     bounds, and upserts the record.
  *
- *   GET /operators/{operator_id}
- *     Peers query an operator's current pubkey + stack list. Response
+ *   GET /principals/{principal_id}
+ *     Peers query a principal's current pubkey + stack list. Response
  *     is wrapped in a `SignedAssertion` carrying the registry's
  *     signature so the caller can verify before caching.
  */
@@ -17,20 +17,20 @@ import { Hono } from "hono";
 import { getRegistryPublicKey, type Env } from "../index";
 import { signEd25519, verifyEd25519, canonicalJSON } from "../signing";
 import { getNonceCache, getStore } from "../store";
-import type { OperatorRecord, SignedAssertion } from "../types";
+import type { PrincipalRecord, SignedAssertion } from "../types";
 import {
-  isValidOperatorId,
+  isValidPrincipalId,
   validateRegistrationClaim,
   validateSignedRegistration,
 } from "../validate";
 
-/** Maximum clock skew accepted between operator's `issued_at` and registry now. */
+/** Maximum clock skew accepted between principal's `issued_at` and registry now. */
 const CLOCK_SKEW_MS = 5 * 60 * 1000; // 5 minutes
 
-export function operatorRoutes(): Hono<{ Bindings: Env }> {
+export function principalRoutes(): Hono<{ Bindings: Env }> {
   const app = new Hono<{ Bindings: Env }>();
 
-  app.post("/operators/:operator_id/register", async (c) => {
+  app.post("/principals/:principal_id/register", async (c) => {
     // Echo cortex#225 issue #1: refuse to mutate state when we can't
     // produce a signed receipt. The GET surface already returns 503
     // for `/registry/pubkey` when unconfigured; without this guard
@@ -49,9 +49,9 @@ export function operatorRoutes(): Hono<{ Bindings: Env }> {
         503,
       );
     }
-    const operatorId = c.req.param("operator_id");
-    if (!isValidOperatorId(operatorId)) {
-      return c.json({ error: "invalid operator_id in path" }, 400);
+    const principalId = c.req.param("principal_id");
+    if (!isValidPrincipalId(principalId)) {
+      return c.json({ error: "invalid principal_id in path" }, 400);
     }
 
     let body: unknown;
@@ -67,7 +67,7 @@ export function operatorRoutes(): Hono<{ Bindings: Env }> {
     }
     const { signed } = envelopeCheck;
 
-    const claimCheck = validateRegistrationClaim(signed.claim, operatorId);
+    const claimCheck = validateRegistrationClaim(signed.claim, principalId);
     if (!claimCheck.ok) {
       return c.json({ error: "validation_failed", details: claimCheck.errors }, 400);
     }
@@ -95,27 +95,27 @@ export function operatorRoutes(): Hono<{ Bindings: Env }> {
       return c.json({ error: "nonce_replayed" }, 409);
     }
 
-    // Signature verification. The operator signs canonical-JSON(claim)
+    // Signature verification. The principal signs canonical-JSON(claim)
     // with their declared pubkey. TOFU on first register (the claim
     // tells us which key to verify against); rotation requires the
     // previous key to sign a transition claim — out of scope for v1,
     // tracked as a follow-up.
     const message = new TextEncoder().encode(canonicalJSON(claim));
-    const valid = await verifyEd25519(claim.operator_pubkey, signed.signature, message);
+    const valid = await verifyEd25519(claim.principal_pubkey, signed.signature, message);
     if (!valid) {
       return c.json({ error: "signature_invalid" }, 401);
     }
 
     // Pubkey rotation policy for v1:
-    //   - First register for an operator_id: accept any pubkey.
+    //   - First register for a principal_id: accept any pubkey.
     //   - Subsequent registers MUST sign with the same pubkey already
     //     on record. We reject silent key swaps to protect the chain
     //     of trust peers have already cached. Rotation comes back in
     //     a follow-up that accepts a transition claim co-signed by
     //     the previous key.
     const store = getStore();
-    const existing = await store.getOperator(operatorId);
-    if (existing && existing.operator_pubkey !== claim.operator_pubkey) {
+    const existing = await store.getPrincipal(principalId);
+    if (existing && existing.principal_pubkey !== claim.principal_pubkey) {
       return c.json(
         {
           error: "pubkey_rotation_not_supported",
@@ -125,26 +125,26 @@ export function operatorRoutes(): Hono<{ Bindings: Env }> {
       );
     }
 
-    const record = await store.putOperator(
-      operatorId,
-      claim.operator_pubkey,
+    const record = await store.putPrincipal(
+      principalId,
+      claim.principal_pubkey,
       claim.stacks,
       claim.capabilities,
     );
 
-    // Sign + return the canonical view so the operator gets the same
+    // Sign + return the canonical view so the principal gets the same
     // signed assertion shape peers will see.
     const assertion = await signAssertion(c.env, record);
     return c.json(assertion, 201);
   });
 
-  app.get("/operators/:operator_id", async (c) => {
-    const operatorId = c.req.param("operator_id");
-    if (!isValidOperatorId(operatorId)) {
-      return c.json({ error: "invalid operator_id in path" }, 400);
+  app.get("/principals/:principal_id", async (c) => {
+    const principalId = c.req.param("principal_id");
+    if (!isValidPrincipalId(principalId)) {
+      return c.json({ error: "invalid principal_id in path" }, 400);
     }
     const store = getStore();
-    const record = await store.getOperator(operatorId);
+    const record = await store.getPrincipal(principalId);
     if (!record) {
       return c.json({ error: "not_found" }, 404);
     }
@@ -176,12 +176,12 @@ export async function signAssertion<T>(
   const registry = getRegistryPublicKey(env);
   if (!env.REGISTRY_SIGNING_KEY || !registry) {
     // No key configured — return an unsigned-but-structured response
-    // ONLY for GET-path callers; POST `/operators/.../register` rejects
+    // ONLY for GET-path callers; POST `/principals/.../register` rejects
     // before reaching here (see the 503 guard in the register handler,
     // Echo cortex#225 issue #1). The registry pubkey field is required
     // by the type, so set it to a sentinel string clients can detect
     // ("unconfigured"). Cortex peers MUST refuse to trust a sentinel-
-    // keyed assertion; the bot logs this loudly via the audit channel.
+    // keyed assertion; the agent logs this loudly via the audit channel.
     // In dev/local this is the documented degradation; in production
     // wrangler secrets gate the deploy.
     return {
@@ -196,4 +196,4 @@ export async function signAssertion<T>(
   return { payload, issued_at, registry, signature: sig };
 }
 
-export type { OperatorRecord };
+export type { PrincipalRecord };

--- a/src/services/network-registry/src/store.ts
+++ b/src/services/network-registry/src/store.ts
@@ -23,7 +23,7 @@ import type {
   Capability,
   CapabilityHit,
   NetworkRoster,
-  OperatorRecord,
+  PrincipalRecord,
   StackIdentity,
 } from "./types";
 
@@ -33,27 +33,27 @@ import type {
 
 export interface RegistryStore {
   /**
-   * Upsert an operator record. Returns the post-write view. The
+   * Upsert a principal record. Returns the post-write view. The
    * `validate` step at the route layer has already enforced grammar
    * + signature; the store only worries about persistence.
    */
-  putOperator(
-    operatorId: string,
+  putPrincipal(
+    principalId: string,
     pubkey: string,
     stacks: StackIdentity[],
     capabilities: Capability[],
-  ): Promise<OperatorRecord>;
+  ): Promise<PrincipalRecord>;
 
-  getOperator(operatorId: string): Promise<OperatorRecord | undefined>;
+  getPrincipal(principalId: string): Promise<PrincipalRecord | undefined>;
 
   /**
-   * List all operators (used by `/networks/{id}/roster` to compute
+   * List all principals (used by `/networks/{id}/roster` to compute
    * implicit membership and by `/capabilities` for search). Bounded
    * by federation size — hundreds, not millions — so an O(n) scan
    * is fine for v1. A D1 implementation would push the filter into
    * SQL.
    */
-  listOperators(): Promise<OperatorRecord[]>;
+  listPrincipals(): Promise<PrincipalRecord[]>;
 
   /** Test/admin helper. Not exposed via HTTP. */
   reset(): Promise<void>;
@@ -64,7 +64,7 @@ export interface RegistryStore {
 // =============================================================================
 
 /**
- * Replay-protection cache. Operators include a `nonce` in every
+ * Replay-protection cache. Principals include a `nonce` in every
  * signed registration; the registry refuses any nonce it has seen
  * inside the configured window.
  *
@@ -78,9 +78,9 @@ export interface RegistryStore {
  * window CAN succeed against a different isolate / colo whose nonce
  * map is empty for that key. Defense-in-depth only holds for delayed
  * replays here, not in-window ones. The fix is to pull nonce storage
- * into the same durable layer as operators when D1 lands — see the
+ * into the same durable layer as principals when D1 lands — see the
  * README §Roadmap "Durable nonce cache" follow-up. v1 ships as-is
- * because (a) the operator's private key is still the gate and (b)
+ * because (a) the principal's private key is still the gate and (b)
  * a successful in-window replay only re-applies the same claim, with
  * no privilege escalation versus the original.
  */
@@ -100,7 +100,7 @@ class InMemoryNonceCache implements NonceCache {
 
   async recordIfFresh(nonce: string, now: number): Promise<boolean> {
     // Threshold-gated sweep (Echo cortex#225 issue #7). At federation
-    // scale (hundreds of operators), the per-call O(n) sweep was fine,
+    // scale (hundreds of principals), the per-call O(n) sweep was fine,
     // but gating on size keeps the steady-state cost flat regardless
     // of bursty traffic. We sweep only when the map grows past the
     // threshold; the 10-minute eviction window is unchanged.
@@ -124,35 +124,35 @@ class InMemoryNonceCache implements NonceCache {
 // =============================================================================
 
 export class InMemoryRegistryStore implements RegistryStore {
-  private readonly operators = new Map<string, OperatorRecord>();
+  private readonly principals = new Map<string, PrincipalRecord>();
 
-  async putOperator(
-    operatorId: string,
+  async putPrincipal(
+    principalId: string,
     pubkey: string,
     stacks: StackIdentity[],
     capabilities: Capability[],
-  ): Promise<OperatorRecord> {
-    const record: OperatorRecord = {
-      operator_id: operatorId,
-      operator_pubkey: pubkey,
+  ): Promise<PrincipalRecord> {
+    const record: PrincipalRecord = {
+      principal_id: principalId,
+      principal_pubkey: pubkey,
       stacks,
       capabilities,
       updated_at: new Date().toISOString(),
     };
-    this.operators.set(operatorId, record);
+    this.principals.set(principalId, record);
     return record;
   }
 
-  async getOperator(operatorId: string): Promise<OperatorRecord | undefined> {
-    return this.operators.get(operatorId);
+  async getPrincipal(principalId: string): Promise<PrincipalRecord | undefined> {
+    return this.principals.get(principalId);
   }
 
-  async listOperators(): Promise<OperatorRecord[]> {
-    return [...this.operators.values()];
+  async listPrincipals(): Promise<PrincipalRecord[]> {
+    return [...this.principals.values()];
   }
 
   async reset(): Promise<void> {
-    this.operators.clear();
+    this.principals.clear();
   }
 }
 
@@ -193,25 +193,25 @@ export function _setNonceCacheForTest(c: NonceCache | undefined): void {
 // =============================================================================
 
 /**
- * Compute a network's roster from the flat operator list. Membership
- * is implicit: an operator is "in" network X if any of their
+ * Compute a network's roster from the flat principal list. Membership
+ * is implicit: a principal is "in" network X if any of their
  * capabilities lists X in `capability.networks[]`. We collapse the
- * matching capabilities back to the per-operator level for the
+ * matching capabilities back to the per-principal level for the
  * response shape.
  */
-export function rosterFromOperators(
-  operators: OperatorRecord[],
+export function rosterFromPrincipals(
+  principals: PrincipalRecord[],
   networkId: string,
 ): NetworkRoster {
   const members: NetworkRoster["members"] = [];
-  for (const op of operators) {
-    const matched = op.capabilities
+  for (const p of principals) {
+    const matched = p.capabilities
       .filter((c) => (c.networks ?? []).includes(networkId))
       .map((c) => c.id);
     if (matched.length > 0) {
       members.push({
-        operator_id: op.operator_id,
-        operator_pubkey: op.operator_pubkey,
+        principal_id: p.principal_id,
+        principal_pubkey: p.principal_pubkey,
         capabilities: matched,
       });
     }
@@ -220,25 +220,25 @@ export function rosterFromOperators(
 }
 
 /**
- * Search capabilities across all operators. The query is a substring
+ * Search capabilities across all principals. The query is a substring
  * match against `capability.id` (lowercase, dotted) and against
  * `description`. v1 returns all hits unsorted — pagination is a
  * follow-up when the registry has enough capabilities to need it.
  */
 export function searchCapabilities(
-  operators: OperatorRecord[],
+  principals: PrincipalRecord[],
   query: string,
 ): CapabilityHit[] {
   const q = query.toLowerCase();
   const hits: CapabilityHit[] = [];
-  for (const op of operators) {
-    for (const cap of op.capabilities) {
+  for (const p of principals) {
+    for (const cap of p.capabilities) {
       const idMatch = cap.id.toLowerCase().includes(q);
       const descMatch = (cap.description ?? "").toLowerCase().includes(q);
       if (idMatch || descMatch) {
         hits.push({
           capability_id: cap.id,
-          operator_id: op.operator_id,
+          principal_id: p.principal_id,
           networks: cap.networks ?? [],
           description: cap.description,
         });

--- a/src/services/network-registry/src/types.ts
+++ b/src/services/network-registry/src/types.ts
@@ -6,15 +6,15 @@
  * round-trip through D1 / KV / in-memory stores without coupling.
  *
  * Grammar conventions (mirrors `src/common/types/cortex-config.ts`):
- *   - operator_id    : lowercase alphanumeric + hyphen, letter-prefixed
+ *   - principal_id   : lowercase alphanumeric + hyphen, letter-prefixed
  *                      (cortex#141 invariant — segments starting with a
  *                      digit interact badly with NATS subject matchers).
- *   - stack_id       : `{operator_id}/{stack_slug}` — the slash form is
+ *   - stack_id       : `{principal_id}/{stack_slug}` — the slash form is
  *                      load-bearing because the surface-router and
- *                      PolicyEngine derive `home_operator` by splitting
+ *                      PolicyEngine derive `home_principal` by splitting
  *                      on the first `/`. Forged-attribution drift is
- *                      blocked at register time (see `validateOperator`).
- *   - operator_pubkey: base64-encoded Ed25519 public key (32 raw bytes
+ *                      blocked at register time (see `validatePrincipal`).
+ *   - principal_pubkey: base64-encoded Ed25519 public key (32 raw bytes
  *                      before encoding). Matches `PolicyFederatedPeerSchema`
  *                      shape in PR #223 — the schema we are about to feed.
  *   - capability_id  : Phase A.6 grammar — `<domain>.<entity>` (e.g.
@@ -22,12 +22,12 @@
  */
 
 /**
- * A single stack identity belonging to an operator. An operator can
+ * A single stack identity belonging to a principal. A principal can
  * declare multiple stacks (e.g. `andreas/laptop`, `andreas/server`)
- * and the registry stores them as a flat list keyed by operator.
+ * and the registry stores them as a flat list keyed by principal.
  */
 export interface StackIdentity {
-  /** `{operator_id}/{stack_slug}` — slash-delimited. */
+  /** `{principal_id}/{stack_slug}` — slash-delimited. */
   stack_id: string;
   /** Human-readable label for dashboards. */
   display_name?: string;
@@ -40,7 +40,7 @@ export interface StackIdentity {
 }
 
 /**
- * A capability the operator wants discoverable across the federation.
+ * A capability the principal wants discoverable across the federation.
  * Mirrors the announce_capabilities[] list on `PolicyFederatedNetworkSchema`
  * in PR #223. The registry treats this as a search-only index — it
  * never executes capabilities, only advertises them.
@@ -52,28 +52,28 @@ export interface Capability {
   description?: string;
   /**
    * Networks (by id) this capability is announced into. Empty array
-   * means "default network only"; the operator's announce policy
+   * means "default network only"; the principal's announce policy
    * still gates whether traffic actually reaches the stack.
    */
   networks?: string[];
 }
 
 /**
- * The body an operator posts to `POST /operators/{operator_id}/register`.
+ * The body a principal posts to `POST /principals/{principal_id}/register`.
  * Wrapped by `SignedRegistration` (below) — the signature covers a
  * canonical JSON serialisation of this object plus a nonce + timestamp,
  * so the registry can verify before mutating any state.
  */
 export interface RegistrationClaim {
   /** Must match the URL path parameter. Echoed for canonicalisation. */
-  operator_id: string;
-  /** Base64 Ed25519 pubkey the operator wants on record. */
-  operator_pubkey: string;
-  /** All stacks the operator is publishing. Empty list is permitted. */
+  principal_id: string;
+  /** Base64 Ed25519 pubkey the principal wants on record. */
+  principal_pubkey: string;
+  /** All stacks the principal is publishing. Empty list is permitted. */
   stacks: StackIdentity[];
-  /** Capabilities the operator wants advertised. */
+  /** Capabilities the principal wants advertised. */
   capabilities: Capability[];
-  /** ISO-8601 UTC timestamp at which the operator signed this claim. */
+  /** ISO-8601 UTC timestamp at which the principal signed this claim. */
   issued_at: string;
   /**
    * Random nonce included in the signed payload to prevent replay.
@@ -83,9 +83,9 @@ export interface RegistrationClaim {
 }
 
 /**
- * The on-wire envelope around a `RegistrationClaim`. The operator
- * signs the canonical JSON of `claim` with their operator NKey;
- * the registry verifies the signature against `claim.operator_pubkey`
+ * The on-wire envelope around a `RegistrationClaim`. The principal
+ * signs the canonical JSON of `claim` with their principal NKey;
+ * the registry verifies the signature against `claim.principal_pubkey`
  * (TOFU on first sight; rotation is a follow-up, see README §Roadmap).
  */
 export interface SignedRegistration {
@@ -95,18 +95,18 @@ export interface SignedRegistration {
 }
 
 /**
- * The view of an operator returned by `GET /operators/{operator_id}`.
+ * The view of a principal returned by `GET /principals/{principal_id}`.
  * Includes the registry's own signed assertion so peers can verify
  * before caching. Cortex callers MUST verify the assertion against
  * the registry pubkey they pinned at config time before trusting
- * `operator_pubkey` — that is the chain D.4.4 mandates.
+ * `principal_pubkey` — that is the chain D.4.4 mandates.
  */
-export interface OperatorRecord {
-  operator_id: string;
-  operator_pubkey: string;
+export interface PrincipalRecord {
+  principal_id: string;
+  principal_pubkey: string;
   stacks: StackIdentity[];
   capabilities: Capability[];
-  /** When the operator last successfully (re-)registered. */
+  /** When the principal last successfully (re-)registered. */
   updated_at: string;
 }
 
@@ -127,31 +127,31 @@ export interface SignedAssertion<T> {
 }
 
 /**
- * `GET /networks/{network_id}/roster` — operators that have announced
+ * `GET /networks/{network_id}/roster` — principals that have announced
  * capabilities into this network. Roster membership is implicit:
- * an operator is "in" a network if any of their capabilities lists
+ * a principal is "in" a network if any of their capabilities lists
  * that network in `capability.networks[]`. There is no separate
- * join/leave handshake in v1 — the operator's next register call
+ * join/leave handshake in v1 — the principal's next register call
  * mutates membership atomically.
  */
 export interface NetworkRoster {
   network_id: string;
   members: {
-    operator_id: string;
-    operator_pubkey: string;
+    principal_id: string;
+    principal_pubkey: string;
     capabilities: string[];
   }[];
 }
 
 /**
  * A capability search hit. `GET /capabilities?query=foo` returns the
- * matching capability ids alongside the operator that announced
- * them. The caller resolves operator → pubkey via a follow-up
- * `GET /operators/{operator_id}` if they need the chain.
+ * matching capability ids alongside the principal that announced
+ * them. The caller resolves principal → pubkey via a follow-up
+ * `GET /principals/{principal_id}` if they need the chain.
  */
 export interface CapabilityHit {
   capability_id: string;
-  operator_id: string;
+  principal_id: string;
   networks: string[];
   description?: string;
 }

--- a/src/services/network-registry/src/validate.ts
+++ b/src/services/network-registry/src/validate.ts
@@ -27,10 +27,10 @@ import type {
 // Grammar regexes
 // =============================================================================
 
-/** Same shape as `OperatorSchema.id` — letter-prefixed (cortex#141). */
-const OPERATOR_ID_RE = /^[a-z][a-z0-9-]*$/;
+/** Same shape as `PrincipalConfigSchema.id` — letter-prefixed (cortex#141). */
+const PRINCIPAL_ID_RE = /^[a-z][a-z0-9-]*$/;
 
-/** `{operator_id}/{stack_slug}` — both parts follow operator grammar. */
+/** `{principal_id}/{stack_slug}` — both parts follow principal grammar. */
 const STACK_ID_RE = /^[a-z][a-z0-9-]*\/[a-z][a-z0-9-]*$/;
 
 /** Phase A.6 capability grammar — `<domain>.<entity>`. */
@@ -39,15 +39,15 @@ const CAPABILITY_ID_RE = /^[a-z][a-z0-9-]*\.[a-z][a-z0-9-]*$/;
 /** Standard base64 alphabet + padding. We don't accept URL-safe here. */
 const BASE64_RE = /^[A-Za-z0-9+/]+={0,2}$/;
 
-/** Network id — same grammar as operator id. */
+/** Network id — same grammar as principal id. */
 const NETWORK_ID_RE = /^[a-z][a-z0-9-]*$/;
 
 // =============================================================================
 // Public validators
 // =============================================================================
 
-export function isValidOperatorId(id: string): boolean {
-  return typeof id === "string" && id.length > 0 && id.length <= 64 && OPERATOR_ID_RE.test(id);
+export function isValidPrincipalId(id: string): boolean {
+  return typeof id === "string" && id.length > 0 && id.length <= 64 && PRINCIPAL_ID_RE.test(id);
 }
 
 export function isValidNetworkId(id: string): boolean {
@@ -91,10 +91,10 @@ export interface ValidationError {
  * structurally valid and ready for the crypto step.
  *
  * Cross-field rules enforced here (matching the schema in PR #223):
- *   - `claim.operator_id` MUST equal the URL path param (passed in
- *     `expectedOperatorId`). Mismatch is a forged-attribution attempt.
- *   - Every `stack_id` MUST be prefixed by `{operator_id}/`. Same
- *     reason — prevents operator A claiming a stack id under operator B.
+ *   - `claim.principal_id` MUST equal the URL path param (passed in
+ *     `expectedPrincipalId`). Mismatch is a forged-attribution attempt.
+ *   - Every `stack_id` MUST be prefixed by `{principal_id}/`. Same
+ *     reason — prevents principal A claiming a stack id under principal B.
  *   - Stack ids unique within the claim.
  *   - Capability ids unique within the claim.
  *   - All declared networks in `capabilities[].networks[]` follow the
@@ -102,7 +102,7 @@ export interface ValidationError {
  */
 export function validateRegistrationClaim(
   claim: unknown,
-  expectedOperatorId: string,
+  expectedPrincipalId: string,
 ): { ok: true; claim: RegistrationClaim } | { ok: false; errors: ValidationError[] } {
   const errors: ValidationError[] = [];
 
@@ -111,19 +111,19 @@ export function validateRegistrationClaim(
   }
   const c = claim as Record<string, unknown>;
 
-  // operator_id
-  if (typeof c.operator_id !== "string" || !isValidOperatorId(c.operator_id)) {
-    errors.push({ field: "operator_id", message: "must be lowercase alphanumeric + hyphen, letter-prefixed" });
-  } else if (c.operator_id !== expectedOperatorId) {
+  // principal_id
+  if (typeof c.principal_id !== "string" || !isValidPrincipalId(c.principal_id)) {
+    errors.push({ field: "principal_id", message: "must be lowercase alphanumeric + hyphen, letter-prefixed" });
+  } else if (c.principal_id !== expectedPrincipalId) {
     errors.push({
-      field: "operator_id",
-      message: `body operator_id "${c.operator_id}" does not match path "${expectedOperatorId}"`,
+      field: "principal_id",
+      message: `body principal_id "${c.principal_id}" does not match path "${expectedPrincipalId}"`,
     });
   }
 
-  // operator_pubkey
-  if (typeof c.operator_pubkey !== "string" || !isValidPubkey(c.operator_pubkey)) {
-    errors.push({ field: "operator_pubkey", message: "must be a 32-byte Ed25519 pubkey, base64-encoded (44 chars)" });
+  // principal_pubkey
+  if (typeof c.principal_pubkey !== "string" || !isValidPubkey(c.principal_pubkey)) {
+    errors.push({ field: "principal_pubkey", message: "must be a 32-byte Ed25519 pubkey, base64-encoded (44 chars)" });
   }
 
   // stacks
@@ -141,15 +141,15 @@ export function validateRegistrationClaim(
       if (typeof sObj.stack_id !== "string" || !isValidStackId(sObj.stack_id)) {
         errors.push({
           field: `stacks[${i.toString()}].stack_id`,
-          message: "must be {operator_id}/{stack_slug}, both letter-prefixed",
+          message: "must be {principal_id}/{stack_slug}, both letter-prefixed",
         });
         return;
       }
-      const opPrefix = sObj.stack_id.split("/")[0] ?? "";
-      if (typeof c.operator_id === "string" && opPrefix !== c.operator_id) {
+      const principalPrefix = sObj.stack_id.split("/")[0] ?? "";
+      if (typeof c.principal_id === "string" && principalPrefix !== c.principal_id) {
         errors.push({
           field: `stacks[${i.toString()}].stack_id`,
-          message: `stack_id prefix "${opPrefix}" must match operator_id "${c.operator_id.toString()}"`,
+          message: `stack_id prefix "${principalPrefix}" must match principal_id "${c.principal_id.toString()}"`,
         });
         return;
       }
@@ -288,8 +288,8 @@ export function validateRegistrationClaim(
   return {
     ok: true,
     claim: {
-      operator_id: c.operator_id as string,
-      operator_pubkey: c.operator_pubkey as string,
+      principal_id: c.principal_id as string,
+      principal_pubkey: c.principal_pubkey as string,
       stacks,
       capabilities,
       issued_at: c.issued_at as string,

--- a/src/services/network-registry/wrangler.toml
+++ b/src/services/network-registry/wrangler.toml
@@ -7,11 +7,11 @@ compatibility_flags = ["nodejs_compat"]
 # at network.meta-factory.ai (per the plan; the operational DNS choice
 # is finalised at deploy time). Auth model:
 #
-#   POST /operators/{operator_id}/register
+#   POST /principals/{principal_id}/register
 #     — open endpoint. Authenticity is enforced by the request BODY
-#     carrying a signed assertion: the operator signs their own
-#     registration with their operator NKey. The registry verifies the
-#     signature against the operator's CURRENT pubkey (or, on first
+#     carrying a signed assertion: the principal signs their own
+#     registration with their principal NKey. The registry verifies the
+#     signature against the principal's CURRENT pubkey (or, on first
 #     register, trust-on-first-use; rotation requires the previous key
 #     to sign the new one — out of scope for v1, follow-up).
 #
@@ -20,7 +20,7 @@ compatibility_flags = ["nodejs_compat"]
 #     registry's own Ed25519 key (REGISTRY_SIGNING_KEY) so that cortex
 #     peers verify the chain before trusting cached pubkeys.
 #
-# No CF Access bypass policies on this Worker. M2M traffic (operator
+# No CF Access bypass policies on this Worker. M2M traffic (principal
 # cortex publishing their pubkey, peer cortex querying) authenticates
 # at the application layer via Ed25519 signatures — same defense-in-
 # depth pattern as S-058 in grove-api.


### PR DESCRIPTION
## Summary

Single-cut breaking rename of the `network-registry/` sub-service (Cloudflare Worker inside the cortex repo) per [plan §R2.F](https://github.com/the-metafactory/cortex/blob/main/docs/migrations/0002-vocabulary-finish-2026-05.md) and §1 (Q1 RESOLVED: IN scope, lockstep rename).

### Symbol renames
- `OperatorRecord` → `PrincipalRecord` (producer-side type)
- `RegistryStore.{put,get,list}Operator(s)` → `.{put,get,list}Principal(s)`
- `isValidOperatorId` → `isValidPrincipalId`
- `rosterFromOperators` → `rosterFromPrincipals`
- File `src/services/network-registry/src/routes/operators.ts` → `principals.ts` (and the test mirror) — via `git mv` so history is preserved
- Test helpers `OperatorKey` → `PrincipalKey`, `makeOperatorKey` → `makePrincipalKey`

### Wire-shape renames
- JSON field `operator_id` → `principal_id`
- JSON field `operator_pubkey` → `principal_pubkey`
- REST path `/operators/:operator_id` → `/principals/:principal_id`

### Cortex-side consumer
- `src/common/registry/client.ts` — GET `/principals/:principal_id`; reads `payload.principal_id` / `payload.principal_pubkey` from the wire. The in-memory cache type `OperatorRecord { operator_id, operator_pubkey, … }` stays pending PR-R2.G (cortex-side mirror-symbol rename — separate slice).
- `src/__tests__/iaw-phase-d-integration.test.ts` — updated to drive the new endpoints and assert the new payload fields.

### Out of scope (deliberately)
- `PolicyFederatedPeer.operator_id` / `operator_pubkey` — the cortex.yaml policy-block field. Different domain; lives in a separate R-cluster.
- `src/common/registry/types.ts` `OperatorRecord` symbol — covered by PR-R2.G (cortex-side mirror).

## ⚠️ LOCKSTEP-PAIR

**MUST merge alongside [cortex#470 (PR-R2d cloud-publisher wire rename)](https://github.com/the-metafactory/cortex/pull/470)** — both sides of the cloud-publisher ↔ network-registry wire must ship together. Single-cut breaking; no transition shim (per Q1 + Q3 RESOLVED in the plan). Merging one without the other will break deserialization on the wire.

## Verification

- [x] `grep -rEn '\bOperatorRecord\b|\boperator_id\b|\boperator_pubkey\b' src/services/network-registry/` → 0 hits
- [x] File `src/services/network-registry/src/routes/operators.ts` no longer exists; replaced by `principals.ts`
- [x] REST routes `/operators/:operator_id` no longer exposed; `/principals/:principal_id` exposed instead
- [x] `RegistryStore` interface methods all use `*Principal` naming
- [x] `bun test src/services/network-registry/` — 43 pass, 0 fail
- [x] `bun test` (whole repo) — 3545 pass, 2 skip, 0 fail
- [x] `bunx tsc --noEmit` — clean
- [x] `bun run lint:errors` — clean

## Files changed
16 files, +359 / −330. Out of those, 2 are `git mv` renames (operators.ts → principals.ts on src + test).

## Operational impact
Breaking change for any external consumer of the network-registry HTTP API. Single-cut per Q1 + Q3 decisions. The internal-to-cortex consumer (`cloud-publisher` via the registry client) is in the lockstep PR cortex#470.

Closes #446. Part of cortex#436.