### PR TITLE
feat(cortex): C-2d — cloud-publisher wire rename (closes #449)

### DIFF
--- a/src/cli/cortex/commands/__tests__/cloud.test.ts
+++ b/src/cli/cortex/commands/__tests__/cloud.test.ts
@@ -169,15 +169,18 @@ CORS_ORIGIN = "*"
 // ---------------------------------------------------------------------------
 
 describe("buildBotYamlSnippet", () => {
-  test("generates correct yaml snippet for operator", () => {
+  test("generates correct yaml snippet for principal", () => {
     const snippet = buildBotYamlSnippet({
       endpoint: "https://grove-api.meta-factory.ai",
       apiKey: "grove_sk_abc123",
-      operatorId: "andreas",
+      principalId: "andreas",
     });
     expect(snippet).toContain("mode: cloud");
     expect(snippet).toContain("endpoint: https://grove-api.meta-factory.ai");
     expect(snippet).toContain("apiKey: grove_sk_abc123");
+    // bot.yaml's `operatorId:` YAML key is the NetworkCloudSchema field
+    // (R2.I — config-schema rename, separate PR). PR-R2d only renames
+    // the JSON wire field + CLI flag.
     expect(snippet).toContain("operatorId: andreas");
   });
 });
@@ -191,8 +194,8 @@ describe("buildCredentialsSummary", () => {
     const summary = buildCredentialsSummary({
       workerUrl: "https://grove-api.meta-factory.ai",
       adminSecret: "admin-secret-here",
-      operatorKey: "grove_sk_abc123",
-      operatorId: "andreas",
+      principalKey: "grove_sk_abc123",
+      principalId: "andreas",
       agentName: "Luna",
       d1DatabaseId: "d1-id",
       kvNamespaceId: "kv-id",

--- a/src/cli/cortex/commands/cloud.ts
+++ b/src/cli/cortex/commands/cloud.ts
@@ -4,7 +4,7 @@
  *
  * Subcommands:
  *   cloud setup          — Full Cloudflare infrastructure provisioning
- *   cloud add-operator   — Create a new operator API key
+ *   cloud add-operator   — Create a new principal API key
  *   cloud status         — Check deployed Worker health and state
  *   cloud webhooks       — Check webhook delivery health for all tracked repos
  *
@@ -73,18 +73,23 @@ export function updateWranglerToml(
 }
 
 /**
- * Build a bot.yaml snippet for a cloud-mode operator.
+ * Build a bot.yaml snippet for a cloud-mode principal.
+ *
+ * The `operatorId:` YAML key matches `NetworkCloudSchema.operatorId`
+ * in src/common/types/config.ts (rename owned by R2.I — the config
+ * schema field). PR-R2d renames the CLI flag + JSON wire field; the
+ * config-schema rename is the next breaking cut.
  */
 export function buildBotYamlSnippet(opts: {
   endpoint: string;
   apiKey: string;
-  operatorId: string;
+  principalId: string;
 }): string {
   return `api:
   mode: cloud
   endpoint: ${opts.endpoint}
   apiKey: ${opts.apiKey}
-  operatorId: ${opts.operatorId}`;
+  operatorId: ${opts.principalId}`;
 }
 
 /**
@@ -93,13 +98,13 @@ export function buildBotYamlSnippet(opts: {
 export function buildCredentialsSummary(opts: {
   workerUrl: string;
   adminSecret: string;
-  operatorKey: string;
-  operatorId: string;
+  principalKey: string;
+  principalId: string;
   agentName: string;
   d1DatabaseId: string;
   kvNamespaceId: string;
 }): string {
-  return `# Grove Cloud Credentials
+  return `# Cortex Cloud Credentials
 # Generated: ${new Date().toISOString()}
 # KEEP THIS FILE SAFE — contains admin secrets
 
@@ -108,16 +113,16 @@ Admin Secret:     ${opts.adminSecret}
 D1 Database ID:   ${opts.d1DatabaseId}
 KV Namespace ID:  ${opts.kvNamespaceId}
 
-## First Operator
-Operator ID:      ${opts.operatorId}
+## First Principal
+Principal ID:     ${opts.principalId}
 Agent Name:       ${opts.agentName}
-API Key:          ${opts.operatorKey}
+API Key:          ${opts.principalKey}
 
 ## bot.yaml snippet
 ${buildBotYamlSnippet({
   endpoint: opts.workerUrl,
-  apiKey: opts.operatorKey,
-  operatorId: opts.operatorId,
+  apiKey: opts.principalKey,
+  principalId: opts.principalId,
 })}
 `;
 }
@@ -439,17 +444,17 @@ async function cloudSetup(flags: Record<string, string>): Promise<void> {
     : "https://grove-api.<your-subdomain>.workers.dev";
   success(`Deployed to ${workerUrl}`);
 
-  // --- Step 10: Create first operator key ---
-  step(10, TOTAL_STEPS, "Creating first operator key...");
+  // --- Step 10: Create first principal key ---
+  step(10, TOTAL_STEPS, "Creating first principal key...");
 
-  // Default operator info
-  const operatorId = flags["operator-id"] ?? "admin";
+  // Default principal info
+  const principalId = flags["principal-id"] ?? "admin";
   const agentName = flags["agent-name"] ?? "Luna";
 
   // Wait a moment for the worker to be live
   await new Promise((r) => setTimeout(r, 2000));
 
-  let operatorKey = "";
+  let principalKey = "";
   try {
     const keyRes = await fetch(`${workerUrl}/admin/keys`, {
       method: "POST",
@@ -458,28 +463,28 @@ async function cloudSetup(flags: Record<string, string>): Promise<void> {
         Authorization: `Bearer ${adminSecret}`,
       },
       body: JSON.stringify({
-        operator_id: operatorId,
+        principal_id: principalId,
         name: agentName,
       }),
     });
 
     if (keyRes.ok) {
       const keyData = (await keyRes.json()) as { key: string };
-      operatorKey = keyData.key;
-      success(`Operator key created: ${operatorKey.slice(0, 20)}...`);
+      principalKey = keyData.key;
+      success(`Principal key created: ${principalKey.slice(0, 20)}...`);
     } else {
       const errText = await keyRes.text();
       fail(`Key creation failed: HTTP ${keyRes.status} — ${errText}`);
       console.error("You can create a key manually:");
       console.error(
-        `  curl -X POST ${workerUrl}/admin/keys -H "Authorization: Bearer ${adminSecret}" -H "Content-Type: application/json" -d '{"operator_id":"${operatorId}","name":"${agentName}"}'`,
+        `  curl -X POST ${workerUrl}/admin/keys -H "Authorization: Bearer ${adminSecret}" -H "Content-Type: application/json" -d '{"principal_id":"${principalId}","name":"${agentName}"}'`,
       );
     }
   } catch (err) {
     fail(`Could not reach worker: ${err instanceof Error ? err.message : String(err)}`);
     console.error("The worker may still be propagating. Try creating a key manually:");
     console.error(
-      `  curl -X POST ${workerUrl}/admin/keys -H "Authorization: Bearer ${adminSecret}" -H "Content-Type: application/json" -d '{"operator_id":"${operatorId}","name":"${agentName}"}'`,
+      `  curl -X POST ${workerUrl}/admin/keys -H "Authorization: Bearer ${adminSecret}" -H "Content-Type: application/json" -d '{"principal_id":"${principalId}","name":"${agentName}"}'`,
     );
   }
 
@@ -493,8 +498,8 @@ async function cloudSetup(flags: Record<string, string>): Promise<void> {
   const summary = buildCredentialsSummary({
     workerUrl,
     adminSecret,
-    operatorKey: operatorKey || "(create manually — see above)",
-    operatorId,
+    principalKey: principalKey || "(create manually — see above)",
+    principalId,
     agentName,
     d1DatabaseId: d1Id,
     kvNamespaceId: kvId,
@@ -509,19 +514,19 @@ async function cloudSetup(flags: Record<string, string>): Promise<void> {
     `Admin Secret:     ${adminSecret.slice(0, 8)}...REDACTED (see ${credPath})`,
   );
   console.log("\n" + "=".repeat(60));
-  console.log("  GROVE CLOUD SETUP COMPLETE");
+  console.log("  CORTEX CLOUD SETUP COMPLETE");
   console.log("=".repeat(60));
   console.log(redactedSummary);
   console.log("=".repeat(60));
 
-  if (operatorKey) {
+  if (principalKey) {
     console.log("\nAdd this to your bot.yaml:");
     console.log("─".repeat(40));
     console.log(
       buildBotYamlSnippet({
         endpoint: workerUrl,
-        apiKey: operatorKey,
-        operatorId,
+        apiKey: principalKey,
+        principalId,
       }),
     );
     console.log("─".repeat(40));
@@ -529,8 +534,8 @@ async function cloudSetup(flags: Record<string, string>): Promise<void> {
 
   console.log("\nNext steps:");
   console.log("  1. Add the bot.yaml snippet above to ~/.config/grove/bot.yaml");
-  console.log("  2. Restart grove-bot: grove-bot stop && grove-bot start");
-  console.log("  3. Add more operators: grove-bot cloud add-operator --name JC --agent-name Ivy --endpoint URL --admin-key SECRET");
+  console.log("  2. Restart cortex: cortex stop && cortex start");
+  console.log("  3. Add more principals: cortex cloud add-operator --name JC --agent-name Ivy --endpoint URL --admin-key SECRET");
 }
 
 // =============================================================================
@@ -545,13 +550,13 @@ async function cloudAddOperator(flags: Record<string, string>): Promise<void> {
 
   if (!name || !agentName || !endpoint || !adminKey) {
     throw new Error(
-      "Usage: grove-bot cloud add-operator --name <operator> --agent-name <agent> --endpoint <URL> --admin-key <SECRET>",
+      "Usage: cortex cloud add-operator --name <principal> --agent-name <agent> --endpoint <URL> --admin-key <SECRET>",
     );
   }
 
-  const operatorId = name.toLowerCase().replace(/[^a-z0-9-]/g, "");
+  const principalId = name.toLowerCase().replace(/[^a-z0-9-]/g, "");
 
-  console.log(`Creating operator key for ${name} (${agentName})...`);
+  console.log(`Creating principal key for ${name} (${agentName})...`);
 
   try {
     const res = await fetch(`${endpoint.replace(/\/+$/, "")}/admin/keys`, {
@@ -561,7 +566,7 @@ async function cloudAddOperator(flags: Record<string, string>): Promise<void> {
         Authorization: `Bearer ${adminKey}`,
       },
       body: JSON.stringify({
-        operator_id: operatorId,
+        principal_id: principalId,
         name: agentName,
       }),
     });
@@ -571,19 +576,19 @@ async function cloudAddOperator(flags: Record<string, string>): Promise<void> {
       throw new Error(`Failed: HTTP ${res.status} — ${errText}`);
     }
 
-    const data = (await res.json()) as { key: string; operator_id: string; name: string };
+    const data = (await res.json()) as { key: string; principal_id: string; name: string };
 
-    console.log("\nOperator key created successfully!");
-    console.log(`  Operator: ${name} (${operatorId})`);
-    console.log(`  Agent:    ${agentName}`);
-    console.log(`  Key:      ${data.key}`);
+    console.log("\nPrincipal key created successfully!");
+    console.log(`  Principal: ${name} (${principalId})`);
+    console.log(`  Agent:     ${agentName}`);
+    console.log(`  Key:       ${data.key}`);
     console.log("\nAdd this to their bot.yaml:");
     console.log("─".repeat(40));
     console.log(
       buildBotYamlSnippet({
         endpoint: endpoint.replace(/\/+$/, ""),
         apiKey: data.key,
-        operatorId,
+        principalId,
       }),
     );
     console.log("─".repeat(40));

--- a/src/surface/mc/worker/src/routes/admin.ts
+++ b/src/surface/mc/worker/src/routes/admin.ts
@@ -22,15 +22,19 @@ export const adminRoutes = new Hono<{ Bindings: Env }>();
 // ---------------------------------------------------------------------------
 
 adminRoutes.post("/admin/keys", requireAdmin, async (c) => {
-  let body: { operator_id: string; name: string };
+  // PR-R2d renames the request wire field to `principal_id`. The
+  // KV-stored `OperatorKey.operator_id` symbol stays pending PR-R2.D
+  // (MC API + auth-type rename — see plan §R2.D). The response wire
+  // mirrors the request shape.
+  let body: { principal_id: string; name: string };
   try {
-    body = await c.req.json<{ operator_id: string; name: string }>();
+    body = await c.req.json<{ principal_id: string; name: string }>();
   } catch {
     return c.json({ error: "invalid JSON body" }, 400);
   }
 
-  if (!body.operator_id || !body.name) {
-    return c.json({ error: "operator_id and name are required" }, 400);
+  if (!body.principal_id || !body.name) {
+    return c.json({ error: "principal_id and name are required" }, 400);
   }
 
   // Generate a key with grove_sk_ prefix + random hex
@@ -40,7 +44,7 @@ adminRoutes.post("/admin/keys", requireAdmin, async (c) => {
   const key = `grove_sk_${hex}`;
 
   const keyData: OperatorKey = {
-    operator_id: body.operator_id,
+    operator_id: body.principal_id,
     name: body.name,
     created_at: new Date().toISOString(),
   };
@@ -50,7 +54,7 @@ adminRoutes.post("/admin/keys", requireAdmin, async (c) => {
 
   return c.json({
     key,
-    operator_id: keyData.operator_id,
+    principal_id: keyData.operator_id,
     name: keyData.name,
     created_at: keyData.created_at,
   }, 201);

--- a/src/taps/cc-events/__tests__/cloud-publisher.test.ts
+++ b/src/taps/cc-events/__tests__/cloud-publisher.test.ts
@@ -26,13 +26,15 @@ function makeEvent(overrides: Partial<PublishedEvent> = {}): PublishedEvent {
 }
 
 /** G-501: Create a simple single-network resolver for tests */
-function createTestNetworkResolver(endpoint: string, apiKey: string, operatorId: string): NetworkResolver {
+function createTestNetworkResolver(endpoint: string, apiKey: string, principalId: string): NetworkResolver {
   return (networkId: string | undefined): NetworkConfig | null => {
     return {
       id: networkId ?? "default",
       endpoint,
       apiKey,
-      operatorId,
+      // `NetworkConfig.operatorId` is the TS field name pending R2.I;
+      // PR-R2d only renames the JSON wire field on the bus.
+      operatorId: principalId,
     };
   };
 }
@@ -117,7 +119,7 @@ describe("CloudPublisher", () => {
     expect(fetchCalls[0]!.url).toBe("https://grove-api.example.com/api/ingest");
 
     const body = JSON.parse(fetchCalls[0]!.init.body as string);
-    expect(body.operator_id).toBe("andreas");
+    expect(body.principal_id).toBe("andreas");
     expect(body.events).toHaveLength(2);
 
     pub.close();

--- a/src/taps/cc-events/cloud-publisher.ts
+++ b/src/taps/cc-events/cloud-publisher.ts
@@ -4,7 +4,7 @@
  *
  * G-501 Network-aware routing:
  * - Each event may have a network_id field
- * - NetworkResolver function looks up endpoint/apiKey/operatorId per network
+ * - NetworkResolver function looks up endpoint/apiKey/principal-id per network
  * - Events without network_id use default network from resolver
  * - Events with unknown network_id are logged and skipped
  *
@@ -197,7 +197,10 @@ export class CloudPublisher {
 
     const url = `${networkConfig.endpoint.replace(/\/+$/, "")}/api/ingest`;
     const body = JSON.stringify({
-      operator_id: networkConfig.operatorId,
+      // Wire field is `principal_id` per PR-R2d. The TypeScript field
+      // `NetworkConfig.operatorId` still reads as `operatorId` pending
+      // PR-R2.I (config-schema rename).
+      principal_id: networkConfig.operatorId,
       events,
     });
 


### PR DESCRIPTION
## Summary

Single-cut breaking rename of the `cloud-publisher` JSON wire field + CLI flag per [plan §R2.C + §R2.H](https://github.com/the-metafactory/cortex/blob/main/docs/migrations/0002-vocabulary-finish-2026-05.md) and §3 (Q3 RESOLVED: single-cut breaking, no transition shim).

### Wire-field rename
- `src/taps/cc-events/cloud-publisher.ts:200` — `operator_id: networkConfig.operatorId` → `principal_id: networkConfig.operatorId`. The JSON wire field renames; the TS field `NetworkConfig.operatorId` stays pending PR-R2.I (config-schema rename).
- `src/taps/cc-events/cloud-publisher.ts:7` — doc comment now reads `endpoint/apiKey/principal-id per network`.

### CLI flag rename
- `src/cli/cortex/commands/cloud.ts:446` — flag `--operator-id` → `--principal-id` (single-cut; old flag rejected post-merge).
- `src/cli/cortex/commands/cloud.ts:461,475,482,564` — POST body to MC `/admin/keys` uses `principal_id`.
- `src/cli/cortex/commands/cloud.ts:577` — `Operator: ${name} (${operatorId})` → `Principal: ${name} (${principalId})`.
- Internal helpers + types renamed: `buildBotYamlSnippet({ … operatorId })` → `…principalId`; `buildCredentialsSummary({ … operatorKey, operatorId })` → `…principalKey, principalId`.

### Bundled minimum: MC `/admin/keys` body field accepts `principal_id`
The CLI cloud subcommand is the producer of `/admin/keys` traffic. Without the receiver-side flip, the CLI would 400 on every call. `src/surface/mc/worker/src/routes/admin.ts` is updated to read `body.principal_id` (was `body.operator_id`) and to return `principal_id` in the response JSON. The KV-stored `OperatorKey { operator_id, name, created_at }` symbol stays pending PR-R2.D (MC API + auth-type rename) — only the wire-input/output shape flips here, the persistence shape is unchanged.

### Out of scope (deliberately)
- `NetworkConfig.operatorId` / `NetworkCloudSchema.operatorId` (TS field + Zod schema) — owned by PR-R2.I. The bot.yaml `operatorId:` YAML key continues to be emitted by `buildBotYamlSnippet` for that reason.
- `cc-events.ts` doc comments referencing `agent.operatorId` — the in-memory `AgentConfig.operatorId` field is still live (R7a only renamed `BotConfig` → `AgentConfig`; the `operatorId` field within remains). Rewriting the doc to `agent.principalId` would describe code that doesn't exist yet.
- `OperatorKey` symbol + `keyData.operator_id` — covered by PR-R2.D.

## ⚠️ LOCKSTEP-PAIR

**MUST merge alongside [cortex#469 (PR-R7c-network-registry)](https://github.com/the-metafactory/cortex/pull/469)** — both sides of the cloud-publisher ↔ network-registry wire must ship together. Single-cut breaking; no transition shim. Merging one without the other will break deserialization between cortex and the registry.

## Verification

- [x] `grep -rEn 'operator_id' src/taps/cc-events/cloud-publisher.ts src/cli/cortex/commands/cloud.ts` → 0 hits
- [x] CLI flag `--operator-id` no longer accepted; `--principal-id` accepted
- [x] CLI output prints `Principal: …` not `Operator: …`
- [x] curl examples in the cloud command body field use `principal_id`
- [x] `bun test src/taps/cc-events/__tests__/cloud-publisher.test.ts` — passes
- [x] `bun test` (whole repo) — 3545 pass, 2 skip, 0 fail
- [x] `bunx tsc --noEmit` — clean
- [x] `bun run lint:errors` — clean

## Files changed
5 files, +72 / −55.

## Operational impact
Breaking change for any external consumer of:
- the cloud-publisher event-batch wire (`operator_id` field on `/api/ingest` POST bodies)
- the MC worker `/admin/keys` POST endpoint
- the `cortex cloud setup` / `cortex cloud add-operator` CLI flags

Single-cut per Q3 decision.

Closes #449. Part of cortex#436. **Depends on** PR-R7a (cortex#438 — already merged) for the in-memory `AgentConfig` rename groundwork.