### PR TITLE
feat(cortex): MC-worker principal cut — R2b + R2.J-wire (closes #447)

### DIFF
--- a/src/common/__tests__/event-processor.test.ts
+++ b/src/common/__tests__/event-processor.test.ts
@@ -32,7 +32,7 @@ describe("processSessionEvent — sovereignty propagation (IAW D.5)", () => {
       sovereignty: {
         classification: "federated",
         data_residency: "nz",
-        home_operator: "jcfischer",
+        home_principal: "jcfischer",
       },
     });
     const out = processSessionEvent("andreas", event);
@@ -41,7 +41,7 @@ describe("processSessionEvent — sovereignty propagation (IAW D.5)", () => {
     expect(out.session.sovereignty).toEqual({
       classification: "federated",
       dataResidency: "nz",
-      homeOperator: "jcfischer",
+      homePrincipal: "jcfischer",
     });
   });
 
@@ -51,7 +51,7 @@ describe("processSessionEvent — sovereignty propagation (IAW D.5)", () => {
       payload: { duration_ms: 1000 },
       sovereignty: {
         classification: "public",
-        home_operator: "ops-mesh",
+        home_principal: "ops-mesh",
       },
     });
     const out = processSessionEvent("andreas", event);
@@ -60,7 +60,7 @@ describe("processSessionEvent — sovereignty propagation (IAW D.5)", () => {
     expect(out.fallbackSession?.sovereignty).toEqual({
       classification: "public",
       dataResidency: null,
-      homeOperator: "ops-mesh",
+      homePrincipal: "ops-mesh",
     });
   });
 
@@ -70,7 +70,7 @@ describe("processSessionEvent — sovereignty propagation (IAW D.5)", () => {
       sovereignty: {
         classification: "local",
         data_residency: "eu",
-        home_operator: "andreas",
+        home_principal: "andreas",
       },
     });
     const out = processSessionEvent("andreas", event);
@@ -79,7 +79,7 @@ describe("processSessionEvent — sovereignty propagation (IAW D.5)", () => {
     expect(out.fallbackSession?.sovereignty).toEqual({
       classification: "local",
       dataResidency: "eu",
-      homeOperator: "andreas",
+      homePrincipal: "andreas",
     });
   });
 
@@ -114,7 +114,7 @@ describe("processSessionEvent — sovereignty propagation (IAW D.5)", () => {
     expect(out.session.sovereignty).toEqual({
       classification: null,
       dataResidency: "us-east",
-      homeOperator: null,
+      homePrincipal: null,
     });
   });
 });

--- a/src/common/event-processor.ts
+++ b/src/common/event-processor.ts
@@ -26,13 +26,13 @@ function extractSovereignty(event: IngestEvent): SessionSovereignty | undefined 
   const s = event.sovereignty;
   if (!s) return undefined;
   // At least one field must be present; otherwise treat as absent.
-  if (s.classification == null && s.data_residency == null && s.home_operator == null) {
+  if (s.classification == null && s.data_residency == null && s.home_principal == null) {
     return undefined;
   }
   return {
     classification: s.classification ?? null,
     dataResidency: s.data_residency ?? null,
-    homeOperator: s.home_operator ?? null,
+    homePrincipal: s.home_principal ?? null,
   };
 }
 

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -63,16 +63,16 @@ export interface PullRequestUpsertData {
  *     dashboard subscription split (D.5.1) and the badge colour (D.5.3).
  *   - `data_residency`  — free-form region tag (e.g. "nz", "eu"); rendered
  *     verbatim in the badge alongside the classification chip.
- *   - `home_operator`   — `signed_by[0].principal` operator segment with
+ *   - `home_principal`   — `signed_by[0].principal` operator segment with
  *     the `did:mf:` prefix stripped. Drives D.5.2 per-operator slicing.
  *     The cloud worker also keeps `sessions.operator_id` (the API-key
- *     owner) which is the *receiving* operator; `home_operator` is who
+ *     owner) which is the *receiving* operator; `home_principal` is who
  *     the work originated from. For purely-local traffic the two match.
  */
 export interface SessionSovereignty {
   classification: Classification | null;
   dataResidency: string | null;
-  homeOperator: string | null;
+  homePrincipal: string | null;
 }
 
 /** Data shape for upserting a session */
@@ -135,7 +135,7 @@ export interface IngestEvent {
   sovereignty?: {
     classification?: Classification;
     data_residency?: string;
-    home_operator?: string;
+    home_principal?: string;
   };
   payload: Record<string, unknown>;
 }

--- a/src/surface/mc/__tests__/api.test.ts
+++ b/src/surface/mc/__tests__/api.test.ts
@@ -267,7 +267,7 @@ describe("POST /api/sessions", () => {
     expect(t.pm.size).toBe(1);
   });
 
-  it("writes the initial prompt as an principal.input event", async () => {
+  it("writes the initial prompt as a principal.input event", async () => {
     const res = await fetch(`${t.baseUrl}/api/sessions`, {
       method: "POST",
       headers: { "content-type": "application/json" },
@@ -304,7 +304,7 @@ describe("POST /api/sessions", () => {
   // the principal.curation event family with `kind: "dispatch"`; without an
   // emitter here the type union + dashboard renderer are dead code and
   // manual dispatches don't show up in the audit view.
-  it("emits an principal.curation event with kind=dispatch on successful create", async () => {
+  it("emits a principal.curation event with kind=dispatch on successful create", async () => {
     const res = await fetch(`${t.baseUrl}/api/sessions`, {
       method: "POST",
       headers: { "content-type": "application/json" },

--- a/src/surface/mc/__tests__/api.test.ts
+++ b/src/surface/mc/__tests__/api.test.ts
@@ -100,7 +100,7 @@ describe("GET /api/assignments", () => {
 
   it("lists assignments with joined task and most-recent session", async () => {
     t.db.exec(
-      `INSERT INTO tasks (id, title, priority, operator_id, source_system)
+      `INSERT INTO tasks (id, title, priority, principal_id, source_system)
        VALUES ('t-1', 'Do a thing', 1, 'op', 'internal')`
     );
     t.db.exec(`INSERT INTO agents (id, name, type) VALUES ('a-1', 'Agent', 'hands')`);
@@ -152,7 +152,7 @@ describe("GET /api/focus-area", () => {
     ).run();
     t.db
       .query(
-        `INSERT INTO tasks (id, title, priority, operator_id, source_system)
+        `INSERT INTO tasks (id, title, priority, principal_id, source_system)
          VALUES (?, ?, ?, 'op', 'internal')`
       )
       .run(`task-${id}`, `Task ${id}`, priority);
@@ -267,7 +267,7 @@ describe("POST /api/sessions", () => {
     expect(t.pm.size).toBe(1);
   });
 
-  it("writes the initial prompt as an operator.input event", async () => {
+  it("writes the initial prompt as an principal.input event", async () => {
     const res = await fetch(`${t.baseUrl}/api/sessions`, {
       method: "POST",
       headers: { "content-type": "application/json" },
@@ -280,7 +280,7 @@ describe("POST /api/sessions", () => {
     const events = t.db
       .query("SELECT type, payload FROM events WHERE session_id = ? ORDER BY timestamp")
       .all(body.sessionId) as { type: string; payload: string }[];
-    const operatorInputs = events.filter((e) => e.type === "operator.input");
+    const operatorInputs = events.filter((e) => e.type === "principal.input");
     expect(operatorInputs).toHaveLength(1);
     const first = operatorInputs[0]!;
     expect(JSON.parse(first.payload).text).toBe("hello there");
@@ -301,10 +301,10 @@ describe("POST /api/sessions", () => {
   });
 
   // PR #30 W1 — the manual-dispatch audit trail. F-12 Decision 9 defines
-  // the operator.curation event family with `kind: "dispatch"`; without an
+  // the principal.curation event family with `kind: "dispatch"`; without an
   // emitter here the type union + dashboard renderer are dead code and
   // manual dispatches don't show up in the audit view.
-  it("emits an operator.curation event with kind=dispatch on successful create", async () => {
+  it("emits an principal.curation event with kind=dispatch on successful create", async () => {
     const res = await fetch(`${t.baseUrl}/api/sessions`, {
       method: "POST",
       headers: { "content-type": "application/json" },
@@ -315,7 +315,7 @@ describe("POST /api/sessions", () => {
 
     const events = t.db
       .query(
-        "SELECT payload FROM events WHERE session_id = ? AND type = 'operator.curation'"
+        "SELECT payload FROM events WHERE session_id = ? AND type = 'principal.curation'"
       )
       .all(body.sessionId) as { payload: string }[];
     expect(events).toHaveLength(1);
@@ -333,7 +333,7 @@ describe("POST /api/sessions", () => {
     // Create a task row up front so the second POST goes through the
     // debounce path (debounce only fires when body.taskId is provided).
     t.db.exec(
-      `INSERT INTO tasks (id, title, priority, operator_id, source_system)
+      `INSERT INTO tasks (id, title, priority, principal_id, source_system)
        VALUES ('t-debounce', 'task', 1, 'op', 'internal')`
     );
 
@@ -385,7 +385,7 @@ describe("POST /api/sessions", () => {
   // both passed CHECK before either SET and both spawned.
   it("concurrent same-taskId dispatches: exactly one 201, the other 409", async () => {
     t.db.exec(
-      `INSERT INTO tasks (id, title, priority, operator_id, source_system)
+      `INSERT INTO tasks (id, title, priority, principal_id, source_system)
        VALUES ('t-race', 'task', 1, 'op', 'internal')`
     );
     const [a, b] = await Promise.all([
@@ -680,7 +680,7 @@ describe("POST /api/assignments/:id/input", () => {
     expect(typeof body.eventId).toBe("string");
 
     const events = t.db
-      .query("SELECT type, payload FROM events WHERE session_id = ? AND type = 'operator.input'")
+      .query("SELECT type, payload FROM events WHERE session_id = ? AND type = 'principal.input'")
       .all(sessionId) as { payload: string }[];
     const texts = events.map((e) => JSON.parse(e.payload).text as string);
     expect(texts).toContain("second turn");
@@ -689,7 +689,7 @@ describe("POST /api/assignments/:id/input", () => {
   it("returns 404 when the assignment has no active session", async () => {
     // Set up assignment with no session.
     t.db.exec(
-      `INSERT INTO tasks (id, title, priority, operator_id, source_system)
+      `INSERT INTO tasks (id, title, priority, principal_id, source_system)
        VALUES ('t-x', 'Orphan', 2, 'op', 'internal')`
     );
     t.db.exec(`INSERT INTO agents (id, name, type) VALUES ('a-x', 'X', 'hands')`);
@@ -708,7 +708,7 @@ describe("POST /api/assignments/:id/input", () => {
 
   it("returns 409 when the session is observed (not controllable)", async () => {
     t.db.exec(
-      `INSERT INTO tasks (id, title, priority, operator_id, source_system)
+      `INSERT INTO tasks (id, title, priority, principal_id, source_system)
        VALUES ('t-obs', 'Observed', 2, 'op', 'internal')`
     );
     t.db.exec(`INSERT INTO agents (id, name, type) VALUES ('a-obs', 'Obs', 'hands')`);
@@ -862,7 +862,7 @@ describe("POST /api/assignments/:id/input", () => {
     expect(body.ok).toBe(true);
   });
 
-  it("accepts image-only body (text absent) and stores images on operator.input", async () => {
+  it("accepts image-only body (text absent) and stores images on principal.input", async () => {
     const id = await createAssignment();
     const res = await fetch(`${t.baseUrl}/api/assignments/${id}/input`, {
       method: "POST",
@@ -875,7 +875,7 @@ describe("POST /api/assignments/:id/input", () => {
     // Verify the stored event payload carries images but not text.
     const stored = t.db
       .query(
-        "SELECT payload FROM events WHERE type = 'operator.input' ORDER BY id DESC LIMIT 1"
+        "SELECT payload FROM events WHERE type = 'principal.input' ORDER BY id DESC LIMIT 1"
       )
       .get() as { payload: string };
     const parsed = JSON.parse(stored.payload) as {
@@ -1002,7 +1002,7 @@ describe("POST /api/assignments/:id/input", () => {
     // Seed an observed session explicitly — observed sessions never accept
     // writes regardless of payload shape (Decision 8 belt-and-braces).
     t.db.exec(
-      `INSERT INTO tasks (id, title, priority, operator_id, source_system)
+      `INSERT INTO tasks (id, title, priority, principal_id, source_system)
        VALUES ('t-obs', 'Observed', 2, 'op', 'internal')`
     );
     t.db.exec(
@@ -1053,7 +1053,7 @@ describe("GET /api/assignments/:id/events", () => {
       `INSERT INTO agents (id, name, type, persistent) VALUES ('agent-evt', 'Evt', 'hands', 1)`
     );
     t.db.run(
-      `INSERT INTO tasks (id, title, priority, operator_id, source_system)
+      `INSERT INTO tasks (id, title, priority, principal_id, source_system)
        VALUES ('task-evt', 'Events task', 2, 'op', 'internal')`
     );
     const assignmentId = "ata-evt";
@@ -1093,7 +1093,7 @@ describe("GET /api/assignments/:id/events", () => {
       `INSERT INTO agents (id, name, type, persistent) VALUES ('a-ns', 'Ns', 'hands', 1)`
     );
     t.db.run(
-      `INSERT INTO tasks (id, title, priority, operator_id, source_system)
+      `INSERT INTO tasks (id, title, priority, principal_id, source_system)
        VALUES ('t-ns', 'No session', 2, 'op', 'internal')`
     );
     t.db.run(
@@ -1259,7 +1259,7 @@ describe("GET /api/tasks", () => {
     t.db
       .query(
         `INSERT INTO tasks
-           (id, title, priority, operator_id, source_system, source_url,
+           (id, title, priority, principal_id, source_system, source_url,
             source_external_id, status, created_at, updated_at)
          VALUES (?, ?, ?, 'op', ?, ?, ?, ?,
                  unixepoch() - ?, unixepoch() - ?)`
@@ -1434,7 +1434,7 @@ describe("GET /api/tasks", () => {
         t.db
           .query(
             `INSERT INTO tasks
-               (id, title, priority, operator_id, source_system, status,
+               (id, title, priority, principal_id, source_system, status,
                 created_at, updated_at)
              VALUES (?, ?, ?, 'op', 'internal', 'open',
                      unixepoch(), unixepoch() - ?)`
@@ -1496,7 +1496,7 @@ describe("GET /api/working-agents", () => {
   function seedTask(id: string, priority = 2): void {
     t.db
       .query(
-        `INSERT OR IGNORE INTO tasks (id, title, priority, operator_id, source_system)
+        `INSERT OR IGNORE INTO tasks (id, title, priority, principal_id, source_system)
          VALUES (?, ?, ?, 'op', 'internal')`
       )
       .run(id, `Task ${id}`, priority);
@@ -1631,7 +1631,7 @@ describe("GET /api/iterations", () => {
       `INSERT INTO iterations (id, title, state, priority) VALUES ('it-1', 'First', 'designing', 1)`
     );
     t.db.exec(
-      `INSERT INTO tasks (id, title, priority, operator_id, source_system, iteration_id)
+      `INSERT INTO tasks (id, title, priority, principal_id, source_system, iteration_id)
        VALUES ('t-1', 'A', 2, 'op', 'github', 'it-1')`
     );
     const res = await fetch(`${t.baseUrl}/api/iterations`);
@@ -1681,7 +1681,7 @@ describe("GET /api/inbox", () => {
 
   it("returns upstream-imported tasks not attached to any iteration", async () => {
     t.db.exec(
-      `INSERT INTO tasks (id, title, priority, operator_id, source_system, source_external_id, iteration_id)
+      `INSERT INTO tasks (id, title, priority, principal_id, source_system, source_external_id, iteration_id)
        VALUES ('t-gh', 'GH issue', 2, 'op', 'github', 'github:x/y#1', NULL),
               ('t-int', 'Internal', 2, 'op', 'internal', NULL, NULL)`
     );
@@ -1695,7 +1695,7 @@ describe("GET /api/inbox", () => {
 
   it("?source=github filters to a single source", async () => {
     t.db.exec(
-      `INSERT INTO tasks (id, title, priority, operator_id, source_system)
+      `INSERT INTO tasks (id, title, priority, principal_id, source_system)
        VALUES ('t-gh', 'GH', 2, 'op', 'github')`
     );
     const res = await fetch(`${t.baseUrl}/api/inbox?source=github`);
@@ -1706,7 +1706,7 @@ describe("GET /api/inbox", () => {
   it("?limit=5 caps the result count", async () => {
     for (let i = 0; i < 12; i++) {
       t.db.exec(
-        `INSERT INTO tasks (id, title, priority, operator_id, source_system)
+        `INSERT INTO tasks (id, title, priority, principal_id, source_system)
          VALUES ('t-${i}', 'X', 2, 'op', 'github')`
       );
     }
@@ -1769,7 +1769,7 @@ describe("GET /api/iterations/:id", () => {
       `INSERT INTO iterations (id, title, body, state, priority) VALUES ('it-1', 'Iter one', 'design notes', 'designing', 1)`
     );
     t.db.exec(
-      `INSERT INTO tasks (id, title, priority, operator_id, source_system, iteration_id)
+      `INSERT INTO tasks (id, title, priority, principal_id, source_system, iteration_id)
        VALUES ('task-a', 'Task A', 0, 'op', 'github', 'it-1'),
               ('task-b', 'Task B', 2, 'op', 'github', 'it-1')`
     );
@@ -1983,7 +1983,7 @@ describe("POST /api/iterations/:id/tasks (attach existing OR create+attach)", ()
   }
   function seedTask(id: string, iterationId: string | null = null): void {
     t.db.query(
-      `INSERT INTO tasks (id, title, priority, operator_id, source_system, iteration_id)
+      `INSERT INTO tasks (id, title, priority, principal_id, source_system, iteration_id)
        VALUES (?, ?, 2, 'op', 'github', ?)`
     ).run(id, `T ${id}`, iterationId);
   }
@@ -2152,7 +2152,7 @@ describe("DELETE /api/iterations/:id/tasks/:taskId", () => {
   }
   function seedTask(id: string, iterationId: string | null = null): void {
     t.db.query(
-      `INSERT INTO tasks (id, title, priority, operator_id, source_system, iteration_id)
+      `INSERT INTO tasks (id, title, priority, principal_id, source_system, iteration_id)
        VALUES (?, ?, 2, 'op', 'github', ?)`
     ).run(id, `T ${id}`, iterationId);
   }
@@ -2248,7 +2248,7 @@ describe("F-16 — GET /api/tasks `iteration` denormalisation", () => {
   function seedTaskWithIter(id: string, iterationId: string | null): void {
     t.db
       .query(
-        `INSERT INTO tasks (id, title, priority, operator_id, source_system, iteration_id)
+        `INSERT INTO tasks (id, title, priority, principal_id, source_system, iteration_id)
          VALUES (?, ?, 2, 'op', 'internal', ?)`
       )
       .run(id, `Task ${id}`, iterationId);
@@ -2365,7 +2365,7 @@ describe("F-16 — GET /api/assignments `iteration` denormalisation", () => {
     }
     t.db
       .query(
-        `INSERT INTO tasks (id, title, priority, operator_id, source_system, iteration_id)
+        `INSERT INTO tasks (id, title, priority, principal_id, source_system, iteration_id)
          VALUES ('t-1', 'task', 1, 'op', 'internal', ?)`
       )
       .run(iterationId);
@@ -2425,7 +2425,7 @@ describe("F-16 — GET /api/focus-area `iteration` denormalisation", () => {
       `INSERT INTO iterations (id, title, state, priority) VALUES ('it-1', 'Block iter', 'in_flight', 1)`
     );
     t.db.exec(
-      `INSERT INTO tasks (id, title, priority, operator_id, source_system, iteration_id)
+      `INSERT INTO tasks (id, title, priority, principal_id, source_system, iteration_id)
        VALUES ('t-1', 'blocked task', 0, 'op', 'internal', 'it-1')`
     );
     t.db.exec(

--- a/src/surface/mc/__tests__/curation-endpoints.test.ts
+++ b/src/surface/mc/__tests__/curation-endpoints.test.ts
@@ -10,7 +10,7 @@
  *     assignment; terminal assignment → cancel task.
  *   - Decision 6 hand-off semantics: in-flight cancels-then-spawns; failed
  *     spawns only.
- *   - Decision 9 operator.curation events are inserted with the correct
+ *   - Decision 9 principal.curation events are inserted with the correct
  *     `kind` discriminator and broadcast via the WS surface.
  *   - Decision 11 observer side effects (process-kill on cancelled / requeue
  *     from blocked) are exercised with a fake `cat` spawn.
@@ -98,7 +98,7 @@ function seedAssignment(
     `INSERT OR IGNORE INTO agents (id, name, type) VALUES (?, ?, 'hands')`
   ).run(agentId, "Test agent");
   db.query(
-    `INSERT OR IGNORE INTO tasks (id, title, priority, operator_id, source_system)
+    `INSERT OR IGNORE INTO tasks (id, title, priority, principal_id, source_system)
      VALUES (?, ?, 1, 'op', 'internal')`
   ).run(taskId, "Test task");
   db.query(
@@ -133,7 +133,7 @@ describe("POST /api/assignments/:id/requeue", () => {
     await teardown(t);
   });
 
-  it("requeues from blocked → queued and inserts operator.curation kind=requeue", async () => {
+  it("requeues from blocked → queued and inserts principal.curation kind=requeue", async () => {
     const blockReason = JSON.stringify({
       kind: "permission.request",
       payload: { requested_action: "tool.edit" },
@@ -162,10 +162,10 @@ describe("POST /api/assignments/:id/requeue", () => {
     expect(row.state).toBe("queued");
     expect(row.block_reason).toBeNull();
 
-    // operator.curation event present with kind=requeue.
+    // principal.curation event present with kind=requeue.
     const events = t.db
       .query(
-        "SELECT type, payload FROM events WHERE session_id = ? AND type = 'operator.curation'"
+        "SELECT type, payload FROM events WHERE session_id = ? AND type = 'principal.curation'"
       )
       .all(sessionId) as { type: string; payload: string }[];
     expect(events).toHaveLength(1);
@@ -198,7 +198,7 @@ describe("POST /api/assignments/:id/requeue", () => {
     expect(res.status).toBe(200);
     const events = t.db
       .query(
-        "SELECT payload FROM events WHERE session_id = ? AND type = 'operator.curation'"
+        "SELECT payload FROM events WHERE session_id = ? AND type = 'principal.curation'"
       )
       .all(sessionId) as { payload: string }[];
     expect(events).toHaveLength(1);
@@ -306,7 +306,7 @@ describe("POST /api/assignments/:id/abandon", () => {
     // Curation event with kind=abandon, targetKind=assignment.
     const events = t.db
       .query(
-        "SELECT payload FROM events WHERE session_id = ? AND type = 'operator.curation'"
+        "SELECT payload FROM events WHERE session_id = ? AND type = 'principal.curation'"
       )
       .all(sessionId) as { payload: string }[];
     expect(events).toHaveLength(1);
@@ -339,7 +339,7 @@ describe("POST /api/assignments/:id/abandon", () => {
     // Curation event landed on the latest (terminal) session.
     const events = t.db
       .query(
-        "SELECT payload FROM events WHERE session_id = ? AND type = 'operator.curation'"
+        "SELECT payload FROM events WHERE session_id = ? AND type = 'principal.curation'"
       )
       .all(sessionId) as { payload: string }[];
     expect(events).toHaveLength(1);
@@ -504,7 +504,7 @@ describe("POST /api/assignments/:id/handoff", () => {
     // Curation event on the NEW session with kind=handoff.
     const events = t.db
       .query(
-        "SELECT payload FROM events WHERE session_id = ? AND type = 'operator.curation'"
+        "SELECT payload FROM events WHERE session_id = ? AND type = 'principal.curation'"
       )
       .all(body.newSessionId) as { payload: string }[];
     expect(events).toHaveLength(1);

--- a/src/surface/mc/__tests__/curation-events.test.ts
+++ b/src/surface/mc/__tests__/curation-events.test.ts
@@ -1,9 +1,9 @@
 /**
- * Grove Mission Control v2 — F-12 operator.curation event helper.
+ * Grove Mission Control v2 — F-12 principal.curation event helper.
  *
  * Pins the four payload variants (Decision 9) round-trip through the events
- * table and that the helper writes the type column verbatim ("operator.curation",
- * sibling of "operator.input"). Pure DB-level test — no HTTP, no spawn.
+ * table and that the helper writes the type column verbatim ("principal.curation",
+ * sibling of "principal.input"). Pure DB-level test — no HTTP, no spawn.
  */
 
 import { describe, it, expect, beforeEach, afterEach } from "bun:test";
@@ -39,7 +39,7 @@ function teardown(t: TestContext): void {
 function seed(db: Database): { assignmentId: string; sessionId: string } {
   db.exec(`
     INSERT INTO agents (id, name, type) VALUES ('a-1', 'Test agent', 'hands');
-    INSERT INTO tasks (id, title, priority, operator_id, source_system)
+    INSERT INTO tasks (id, title, priority, principal_id, source_system)
       VALUES ('t-1', 'Test task', 1, 'op', 'internal');
     INSERT INTO agent_task_assignment (id, agent_id, task_id, state)
       VALUES ('ata-1', 'a-1', 't-1', 'queued');
@@ -60,7 +60,7 @@ describe("createOperatorCurationEvent", () => {
     teardown(t);
   });
 
-  it("writes type='operator.curation' with the dispatch payload", () => {
+  it("writes type='principal.curation' with the dispatch payload", () => {
     const { sessionId } = seed(t.db);
     const payload: OperatorCurationPayload = {
       kind: "dispatch",
@@ -69,13 +69,13 @@ describe("createOperatorCurationEvent", () => {
       newAssignmentId: "ata-2",
     };
     const ev = createOperatorCurationEvent(t.db, sessionId, payload);
-    expect(ev.type).toBe("operator.curation");
+    expect(ev.type).toBe("principal.curation");
     expect(ev.session_id).toBe(sessionId);
 
     const row = t.db
       .query("SELECT type, payload FROM events WHERE id = ?")
       .get(ev.id) as { type: string; payload: string };
-    expect(row.type).toBe("operator.curation");
+    expect(row.type).toBe("principal.curation");
     expect(JSON.parse(row.payload)).toEqual(
       payload as unknown as Record<string, unknown>
     );
@@ -166,7 +166,7 @@ describe("createOperatorCurationEvent", () => {
       type: "issue",
     };
     const ev = createOperatorCurationEvent(t.db, sessionId, payload);
-    expect(ev.type).toBe("operator.curation");
+    expect(ev.type).toBe("principal.curation");
     const row = t.db
       .query("SELECT payload FROM events WHERE id = ?")
       .get(ev.id) as { payload: string };

--- a/src/surface/mc/__tests__/curation-events.test.ts
+++ b/src/surface/mc/__tests__/curation-events.test.ts
@@ -14,8 +14,8 @@ import { rmSync } from "fs";
 
 import { initDatabase } from "../db/init";
 import {
-  createOperatorCurationEvent,
-  type OperatorCurationPayload,
+  createPrincipalCurationEvent,
+  type PrincipalCurationPayload,
 } from "../db/events";
 import { createSession } from "../db/sessions";
 import { findLatestSessionForAssignment } from "../db/sessions";
@@ -51,7 +51,7 @@ function seed(db: Database): { assignmentId: string; sessionId: string } {
   return { assignmentId: "ata-1", sessionId: session.id };
 }
 
-describe("createOperatorCurationEvent", () => {
+describe("createPrincipalCurationEvent", () => {
   let t: TestContext;
   beforeEach(() => {
     t = setup();
@@ -62,13 +62,13 @@ describe("createOperatorCurationEvent", () => {
 
   it("writes type='principal.curation' with the dispatch payload", () => {
     const { sessionId } = seed(t.db);
-    const payload: OperatorCurationPayload = {
+    const payload: PrincipalCurationPayload = {
       kind: "dispatch",
       agentId: "a-2",
       reason: "fresh start",
       newAssignmentId: "ata-2",
     };
-    const ev = createOperatorCurationEvent(t.db, sessionId, payload);
+    const ev = createPrincipalCurationEvent(t.db, sessionId, payload);
     expect(ev.type).toBe("principal.curation");
     expect(ev.session_id).toBe(sessionId);
 
@@ -83,7 +83,7 @@ describe("createOperatorCurationEvent", () => {
 
   it("round-trips the requeue payload", () => {
     const { sessionId } = seed(t.db);
-    const ev = createOperatorCurationEvent(t.db, sessionId, {
+    const ev = createPrincipalCurationEvent(t.db, sessionId, {
       kind: "requeue",
       reason: "external dep recovered",
     });
@@ -97,14 +97,14 @@ describe("createOperatorCurationEvent", () => {
 
   it("round-trips the handoff payload with all fields", () => {
     const { sessionId } = seed(t.db);
-    const payload: OperatorCurationPayload = {
+    const payload: PrincipalCurationPayload = {
       kind: "handoff",
       fromAgentId: "a-1",
       toAgentId: "a-2",
       reason: "swap",
       newAssignmentId: "ata-3",
     };
-    const ev = createOperatorCurationEvent(t.db, sessionId, payload);
+    const ev = createPrincipalCurationEvent(t.db, sessionId, payload);
     const row = t.db
       .query("SELECT payload FROM events WHERE id = ?")
       .get(ev.id) as { payload: string };
@@ -115,11 +115,11 @@ describe("createOperatorCurationEvent", () => {
 
   it("round-trips the abandon payload (assignment / task target kinds)", () => {
     const { sessionId } = seed(t.db);
-    const ev1 = createOperatorCurationEvent(t.db, sessionId, {
+    const ev1 = createPrincipalCurationEvent(t.db, sessionId, {
       kind: "abandon",
       targetKind: "assignment",
     });
-    const ev2 = createOperatorCurationEvent(t.db, sessionId, {
+    const ev2 = createPrincipalCurationEvent(t.db, sessionId, {
       kind: "abandon",
       targetKind: "task",
       reason: "no longer relevant",
@@ -158,14 +158,14 @@ describe("createOperatorCurationEvent", () => {
   // every field (kind, source, ref, url, type).
   it("round-trips the task.imported payload (F-12b)", () => {
     const { sessionId } = seed(t.db);
-    const payload: OperatorCurationPayload = {
+    const payload: PrincipalCurationPayload = {
       kind: "task.imported",
       source: "github",
       ref: "the-metafactory/grove-v2#42",
       url: "https://github.com/the-metafactory/grove-v2/issues/42",
       type: "issue",
     };
-    const ev = createOperatorCurationEvent(t.db, sessionId, payload);
+    const ev = createPrincipalCurationEvent(t.db, sessionId, payload);
     expect(ev.type).toBe("principal.curation");
     const row = t.db
       .query("SELECT payload FROM events WHERE id = ?")

--- a/src/surface/mc/__tests__/endpoint-resolver.test.ts
+++ b/src/surface/mc/__tests__/endpoint-resolver.test.ts
@@ -19,7 +19,7 @@ function setupDb(): Database {
   db.exec("PRAGMA foreign_keys = ON");
   for (const sql of SCHEMA_SQL) db.exec(sql);
 
-  db.exec(`INSERT INTO tasks (id, title, priority, operator_id, source_system) VALUES ('t-1', 'Task', 0, 'op', 'internal')`);
+  db.exec(`INSERT INTO tasks (id, title, priority, principal_id, source_system) VALUES ('t-1', 'Task', 0, 'op', 'internal')`);
   db.exec(`INSERT INTO agents (id, name, type) VALUES ('a-1', 'Agent', 'hands')`);
   db.exec(`INSERT INTO agent_task_assignment (id, agent_id, task_id) VALUES ('ata-1', 'a-1', 't-1')`);
 
@@ -298,7 +298,7 @@ describe("spawnControlledSession", () => {
     const ep1 = spawnControlledSession(db, pm, "ata-1", { spawn: fakeCatSpawn });
 
     // Add a second assignment for coverage
-    db.exec(`INSERT INTO tasks (id, title, priority, operator_id, source_system) VALUES ('t-2', 'Task 2', 0, 'op', 'internal')`);
+    db.exec(`INSERT INTO tasks (id, title, priority, principal_id, source_system) VALUES ('t-2', 'Task 2', 0, 'op', 'internal')`);
     db.exec(`INSERT INTO agent_task_assignment (id, agent_id, task_id) VALUES ('ata-2', 'a-1', 't-2')`);
     const ep2 = spawnControlledSession(db, pm, "ata-2", { spawn: fakeCatSpawn });
 

--- a/src/surface/mc/__tests__/events.test.ts
+++ b/src/surface/mc/__tests__/events.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "bun:test";
 import { Database } from "bun:sqlite";
 import { SCHEMA_SQL } from "../db/schema";
-import { insertEvent, createOperatorInputEvent, createPermissionRequestEvent, generateId } from "../db/events";
+import { insertEvent, createPrincipalInputEvent, createPermissionRequestEvent, generateId } from "../db/events";
 
 function setupDb(): Database {
   const db = new Database(":memory:");
@@ -89,7 +89,7 @@ describe("insertEvent", () => {
   });
 });
 
-describe("createOperatorInputEvent", () => {
+describe("createPrincipalInputEvent", () => {
   let db: Database;
 
   beforeEach(() => {
@@ -101,7 +101,7 @@ describe("createOperatorInputEvent", () => {
   });
 
   it("creates an principal.input event with text payload", () => {
-    const event = createOperatorInputEvent(db, "s-1", {
+    const event = createPrincipalInputEvent(db, "s-1", {
       text: "Please use the v2 API instead",
     });
 
@@ -110,7 +110,7 @@ describe("createOperatorInputEvent", () => {
   });
 
   it("creates an principal.input event with attachments", () => {
-    const event = createOperatorInputEvent(db, "s-1", {
+    const event = createPrincipalInputEvent(db, "s-1", {
       text: "See screenshot",
       attachments: ["/tmp/screenshot.png"],
     });

--- a/src/surface/mc/__tests__/events.test.ts
+++ b/src/surface/mc/__tests__/events.test.ts
@@ -100,7 +100,7 @@ describe("createPrincipalInputEvent", () => {
     db.close();
   });
 
-  it("creates an principal.input event with text payload", () => {
+  it("creates a principal.input event with text payload", () => {
     const event = createPrincipalInputEvent(db, "s-1", {
       text: "Please use the v2 API instead",
     });
@@ -109,7 +109,7 @@ describe("createPrincipalInputEvent", () => {
     expect(event.payload).toEqual({ text: "Please use the v2 API instead" });
   });
 
-  it("creates an principal.input event with attachments", () => {
+  it("creates a principal.input event with attachments", () => {
     const event = createPrincipalInputEvent(db, "s-1", {
       text: "See screenshot",
       attachments: ["/tmp/screenshot.png"],

--- a/src/surface/mc/__tests__/events.test.ts
+++ b/src/surface/mc/__tests__/events.test.ts
@@ -10,7 +10,7 @@ function setupDb(): Database {
   for (const sql of SCHEMA_SQL) db.exec(sql);
 
   // seed required parent rows
-  db.exec(`INSERT INTO tasks (id, title, priority, operator_id, source_system) VALUES ('t-1', 'Task', 0, 'op', 'internal')`);
+  db.exec(`INSERT INTO tasks (id, title, priority, principal_id, source_system) VALUES ('t-1', 'Task', 0, 'op', 'internal')`);
   db.exec(`INSERT INTO agents (id, name, type) VALUES ('a-1', 'Agent', 'hands')`);
   db.exec(`INSERT INTO agent_task_assignment (id, agent_id, task_id) VALUES ('ata-1', 'a-1', 't-1')`);
   db.exec(`INSERT INTO sessions (id, assignment_id, endpoint_kind) VALUES ('s-1', 'ata-1', 'local.process.controlled')`);
@@ -100,22 +100,22 @@ describe("createOperatorInputEvent", () => {
     db.close();
   });
 
-  it("creates an operator.input event with text payload", () => {
+  it("creates an principal.input event with text payload", () => {
     const event = createOperatorInputEvent(db, "s-1", {
       text: "Please use the v2 API instead",
     });
 
-    expect(event.type).toBe("operator.input");
+    expect(event.type).toBe("principal.input");
     expect(event.payload).toEqual({ text: "Please use the v2 API instead" });
   });
 
-  it("creates an operator.input event with attachments", () => {
+  it("creates an principal.input event with attachments", () => {
     const event = createOperatorInputEvent(db, "s-1", {
       text: "See screenshot",
       attachments: ["/tmp/screenshot.png"],
     });
 
-    expect(event.type).toBe("operator.input");
+    expect(event.type).toBe("principal.input");
     expect(event.payload).toEqual({
       text: "See screenshot",
       attachments: ["/tmp/screenshot.png"],

--- a/src/surface/mc/__tests__/focus-area-ws.test.ts
+++ b/src/surface/mc/__tests__/focus-area-ws.test.ts
@@ -115,7 +115,7 @@ describe("F-6 focus-area WS→refetch integration", () => {
     // Seed an assignment in `running` state with a session so we have
     // something to block → unblock.
     db.exec(
-      `INSERT INTO tasks (id, title, priority, operator_id, source_system)
+      `INSERT INTO tasks (id, title, priority, principal_id, source_system)
        VALUES ('t-1', 'F-6 WS test task', 0, 'op', 'internal')`
     );
     db.exec(

--- a/src/surface/mc/__tests__/ingestor.test.ts
+++ b/src/surface/mc/__tests__/ingestor.test.ts
@@ -11,7 +11,7 @@ function setupDb(): Database {
   for (const sql of SCHEMA_SQL) db.exec(sql);
 
   // Seed: task → agent → assignment → observed session with cc_session_id
-  db.exec(`INSERT INTO tasks (id, title, priority, operator_id, source_system) VALUES ('t-1', 'Task', 0, 'op', 'internal')`);
+  db.exec(`INSERT INTO tasks (id, title, priority, principal_id, source_system) VALUES ('t-1', 'Task', 0, 'op', 'internal')`);
   db.exec(`INSERT INTO agents (id, name, type) VALUES ('a-1', 'Luna', 'head')`);
   db.exec(`INSERT INTO agent_task_assignment (id, agent_id, task_id) VALUES ('ata-1', 'a-1', 't-1')`);
   db.exec(

--- a/src/surface/mc/__tests__/iterations.test.ts
+++ b/src/surface/mc/__tests__/iterations.test.ts
@@ -69,7 +69,7 @@ function insertTask(
 ): void {
   db.query(
     `INSERT INTO tasks
-       (id, title, priority, operator_id,
+       (id, title, priority, principal_id,
         source_system, source_url, source_external_id, status, iteration_id)
      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
   ).run(

--- a/src/surface/mc/__tests__/metrics-endpoints.test.ts
+++ b/src/surface/mc/__tests__/metrics-endpoints.test.ts
@@ -75,7 +75,7 @@ function seedAssignment(
   }
 ): void {
   db.exec(
-    `INSERT OR IGNORE INTO tasks (id, title, priority, operator_id, source_system) VALUES ('${opts.taskId}', 'Task', 0, 'op', 'internal')`
+    `INSERT OR IGNORE INTO tasks (id, title, priority, principal_id, source_system) VALUES ('${opts.taskId}', 'Task', 0, 'op', 'internal')`
   );
   db.exec(
     `INSERT OR IGNORE INTO agents (id, name, type, persistent) VALUES ('${opts.agentId}', '${opts.agentName}', 'head', 1)`

--- a/src/surface/mc/__tests__/metrics.test.ts
+++ b/src/surface/mc/__tests__/metrics.test.ts
@@ -69,7 +69,7 @@ function seed(db: Database, assignments: SeedAssignment[]) {
   // Tasks (one per assignment for simplicity).
   for (const a of assignments) {
     db.exec(
-      `INSERT OR IGNORE INTO tasks (id, title, priority, operator_id, source_system) VALUES ('${a.taskId}', 'Task ${a.taskId}', 0, 'op', 'internal')`
+      `INSERT OR IGNORE INTO tasks (id, title, priority, principal_id, source_system) VALUES ('${a.taskId}', 'Task ${a.taskId}', 0, 'op', 'internal')`
     );
     db.exec(
       `INSERT OR IGNORE INTO agents (id, name, type, persistent) VALUES ('${a.agentId}', '${a.agentName}', 'head', 1)`

--- a/src/surface/mc/__tests__/poller.test.ts
+++ b/src/surface/mc/__tests__/poller.test.ts
@@ -33,7 +33,7 @@ function setupDb(): Database {
   db.exec("PRAGMA foreign_keys = ON");
   for (const sql of SCHEMA_SQL) db.exec(sql);
 
-  db.exec(`INSERT INTO tasks (id, title, priority, operator_id, source_system) VALUES ('t-1', 'Task', 0, 'op', 'internal')`);
+  db.exec(`INSERT INTO tasks (id, title, priority, principal_id, source_system) VALUES ('t-1', 'Task', 0, 'op', 'internal')`);
   db.exec(`INSERT INTO agents (id, name, type) VALUES ('a-1', 'Luna', 'head')`);
   db.exec(`INSERT INTO agent_task_assignment (id, agent_id, task_id) VALUES ('ata-1', 'a-1', 't-1')`);
   db.exec(

--- a/src/surface/mc/__tests__/schema.test.ts
+++ b/src/surface/mc/__tests__/schema.test.ts
@@ -31,7 +31,7 @@ describe("mission-control schema", () => {
 
   it("inserts and reads a task", () => {
     db.exec(`
-      INSERT INTO tasks (id, title, priority, operator_id, source_system, status)
+      INSERT INTO tasks (id, title, priority, principal_id, source_system, status)
       VALUES ('t-1', 'Fix webhook', 0, 'andreas', 'github', 'open')
     `);
     const row = db.query("SELECT * FROM tasks WHERE id = 't-1'").get() as any;
@@ -52,7 +52,7 @@ describe("mission-control schema", () => {
   });
 
   it("inserts and reads an assignment with FK to agent and task", () => {
-    db.exec(`INSERT INTO tasks (id, title, priority, operator_id, source_system) VALUES ('t-1', 'Task', 0, 'op', 'internal')`);
+    db.exec(`INSERT INTO tasks (id, title, priority, principal_id, source_system) VALUES ('t-1', 'Task', 0, 'op', 'internal')`);
     db.exec(`INSERT INTO agents (id, name, type) VALUES ('a-1', 'Agent', 'hands')`);
     db.exec(`
       INSERT INTO agent_task_assignment (id, agent_id, task_id, state)
@@ -65,7 +65,7 @@ describe("mission-control schema", () => {
   });
 
   it("inserts and reads a session with FK to assignment", () => {
-    db.exec(`INSERT INTO tasks (id, title, priority, operator_id, source_system) VALUES ('t-1', 'Task', 0, 'op', 'internal')`);
+    db.exec(`INSERT INTO tasks (id, title, priority, principal_id, source_system) VALUES ('t-1', 'Task', 0, 'op', 'internal')`);
     db.exec(`INSERT INTO agents (id, name, type) VALUES ('a-1', 'Agent', 'hands')`);
     db.exec(`INSERT INTO agent_task_assignment (id, agent_id, task_id) VALUES ('ata-1', 'a-1', 't-1')`);
     db.exec(`
@@ -78,7 +78,7 @@ describe("mission-control schema", () => {
   });
 
   it("inserts and reads an event with FK to session", () => {
-    db.exec(`INSERT INTO tasks (id, title, priority, operator_id, source_system) VALUES ('t-1', 'Task', 0, 'op', 'internal')`);
+    db.exec(`INSERT INTO tasks (id, title, priority, principal_id, source_system) VALUES ('t-1', 'Task', 0, 'op', 'internal')`);
     db.exec(`INSERT INTO agents (id, name, type) VALUES ('a-1', 'Agent', 'hands')`);
     db.exec(`INSERT INTO agent_task_assignment (id, agent_id, task_id) VALUES ('ata-1', 'a-1', 't-1')`);
     db.exec(`INSERT INTO sessions (id, assignment_id, endpoint_kind) VALUES ('s-1', 'ata-1', 'local.process.controlled')`);
@@ -92,7 +92,7 @@ describe("mission-control schema", () => {
   });
 
   it("enforces state CHECK constraint on assignments", () => {
-    db.exec(`INSERT INTO tasks (id, title, priority, operator_id, source_system) VALUES ('t-1', 'Task', 0, 'op', 'internal')`);
+    db.exec(`INSERT INTO tasks (id, title, priority, principal_id, source_system) VALUES ('t-1', 'Task', 0, 'op', 'internal')`);
     db.exec(`INSERT INTO agents (id, name, type) VALUES ('a-1', 'Agent', 'hands')`);
     expect(() => {
       db.exec(`
@@ -103,7 +103,7 @@ describe("mission-control schema", () => {
   });
 
   it("enforces endpoint_kind CHECK constraint on sessions", () => {
-    db.exec(`INSERT INTO tasks (id, title, priority, operator_id, source_system) VALUES ('t-1', 'Task', 0, 'op', 'internal')`);
+    db.exec(`INSERT INTO tasks (id, title, priority, principal_id, source_system) VALUES ('t-1', 'Task', 0, 'op', 'internal')`);
     db.exec(`INSERT INTO agents (id, name, type) VALUES ('a-1', 'Agent', 'hands')`);
     db.exec(`INSERT INTO agent_task_assignment (id, agent_id, task_id) VALUES ('ata-1', 'a-1', 't-1')`);
     expect(() => {
@@ -146,7 +146,7 @@ describe("mission-control schema", () => {
   });
 
   it("rejects assignment with nonexistent agent_id", () => {
-    db.exec(`INSERT INTO tasks (id, title, priority, operator_id, source_system) VALUES ('t-1', 'Task', 0, 'op', 'internal')`);
+    db.exec(`INSERT INTO tasks (id, title, priority, principal_id, source_system) VALUES ('t-1', 'Task', 0, 'op', 'internal')`);
     expect(() => {
       db.exec(`INSERT INTO agent_task_assignment (id, agent_id, task_id) VALUES ('ata-1', 'ghost', 't-1')`);
     }).toThrow();
@@ -177,7 +177,7 @@ describe("mission-control schema", () => {
   // any future writer that bypasses the state machine is caught.
 
   it("rejects state='blocked' with NULL block_reason", () => {
-    db.exec(`INSERT INTO tasks (id, title, priority, operator_id, source_system) VALUES ('t-1', 'Task', 0, 'op', 'internal')`);
+    db.exec(`INSERT INTO tasks (id, title, priority, principal_id, source_system) VALUES ('t-1', 'Task', 0, 'op', 'internal')`);
     db.exec(`INSERT INTO agents (id, name, type) VALUES ('a-1', 'Agent', 'hands')`);
     expect(() => {
       db.exec(`INSERT INTO agent_task_assignment (id, agent_id, task_id, state, block_reason) VALUES ('ata-1', 'a-1', 't-1', 'blocked', NULL)`);
@@ -185,7 +185,7 @@ describe("mission-control schema", () => {
   });
 
   it("rejects non-blocked state with non-NULL block_reason", () => {
-    db.exec(`INSERT INTO tasks (id, title, priority, operator_id, source_system) VALUES ('t-1', 'Task', 0, 'op', 'internal')`);
+    db.exec(`INSERT INTO tasks (id, title, priority, principal_id, source_system) VALUES ('t-1', 'Task', 0, 'op', 'internal')`);
     db.exec(`INSERT INTO agents (id, name, type) VALUES ('a-1', 'Agent', 'hands')`);
     const reason = JSON.stringify({ kind: "permission.request", payload: { requested_action: "tool.bash" } });
     expect(() => {
@@ -195,7 +195,7 @@ describe("mission-control schema", () => {
   });
 
   it("rejects malformed JSON in block_reason", () => {
-    db.exec(`INSERT INTO tasks (id, title, priority, operator_id, source_system) VALUES ('t-1', 'Task', 0, 'op', 'internal')`);
+    db.exec(`INSERT INTO tasks (id, title, priority, principal_id, source_system) VALUES ('t-1', 'Task', 0, 'op', 'internal')`);
     db.exec(`INSERT INTO agents (id, name, type) VALUES ('a-1', 'Agent', 'hands')`);
     expect(() => {
       db.exec(`INSERT INTO agent_task_assignment (id, agent_id, task_id, state, block_reason) VALUES ('ata-1', 'a-1', 't-1', 'blocked', 'not json')`);
@@ -203,7 +203,7 @@ describe("mission-control schema", () => {
   });
 
   it("accepts state='blocked' with valid JSON block_reason", () => {
-    db.exec(`INSERT INTO tasks (id, title, priority, operator_id, source_system) VALUES ('t-1', 'Task', 0, 'op', 'internal')`);
+    db.exec(`INSERT INTO tasks (id, title, priority, principal_id, source_system) VALUES ('t-1', 'Task', 0, 'op', 'internal')`);
     db.exec(`INSERT INTO agents (id, name, type) VALUES ('a-1', 'Agent', 'hands')`);
     const reason = JSON.stringify({ kind: "permission.request", payload: { requested_action: "tool.bash" } });
     db.query(`INSERT INTO agent_task_assignment (id, agent_id, task_id, state, block_reason) VALUES (?, ?, ?, ?, ?)`)
@@ -218,7 +218,7 @@ describe("mission-control schema", () => {
   // assignment->task: cannot drop a parent that still has live work.
 
   function seedFullChain() {
-    db.exec(`INSERT INTO tasks (id, title, priority, operator_id, source_system) VALUES ('t-1', 'Task', 0, 'op', 'internal')`);
+    db.exec(`INSERT INTO tasks (id, title, priority, principal_id, source_system) VALUES ('t-1', 'Task', 0, 'op', 'internal')`);
     db.exec(`INSERT INTO agents (id, name, type) VALUES ('a-1', 'Agent', 'hands')`);
     db.exec(`INSERT INTO agent_task_assignment (id, agent_id, task_id) VALUES ('ata-1', 'a-1', 't-1')`);
     db.exec(`INSERT INTO sessions (id, assignment_id, endpoint_kind) VALUES ('s-1', 'ata-1', 'local.process.controlled')`);

--- a/src/surface/mc/__tests__/sessions-db.test.ts
+++ b/src/surface/mc/__tests__/sessions-db.test.ts
@@ -9,7 +9,7 @@ function setupDb(): Database {
   db.exec("PRAGMA foreign_keys = ON");
   for (const sql of SCHEMA_SQL) db.exec(sql);
 
-  db.exec(`INSERT INTO tasks (id, title, priority, operator_id, source_system) VALUES ('t-1', 'Task', 0, 'op', 'internal')`);
+  db.exec(`INSERT INTO tasks (id, title, priority, principal_id, source_system) VALUES ('t-1', 'Task', 0, 'op', 'internal')`);
   db.exec(`INSERT INTO agents (id, name, type) VALUES ('a-1', 'Agent', 'hands')`);
   db.exec(`INSERT INTO agent_task_assignment (id, agent_id, task_id) VALUES ('ata-1', 'a-1', 't-1')`);
 

--- a/src/surface/mc/__tests__/should-notify.test.ts
+++ b/src/surface/mc/__tests__/should-notify.test.ts
@@ -301,6 +301,6 @@ describe("shouldNotify — defensive fallbacks", () => {
 });
 
 // `shouldNotifyInputRequested` was removed alongside `maybeNotifyInputRequested`
-// (W2 in PR #23 review) — the `operator.input.requested` event is contemplated
+// (W2 in PR #23 review) — the `principal.input.requested` event is contemplated
 // by Decision 1's matrix but not yet emitted by Mission Control v2. When the
 // emitter lands in a follow-up F-1?, restore both functions and a matching test.

--- a/src/surface/mc/__tests__/stdout-dispatcher.test.ts
+++ b/src/surface/mc/__tests__/stdout-dispatcher.test.ts
@@ -13,7 +13,7 @@ function setupDb(): Database {
   db.exec("PRAGMA foreign_keys = ON");
   for (const sql of SCHEMA_SQL) db.exec(sql);
   db.exec(
-    `INSERT INTO tasks (id, title, priority, operator_id, source_system) VALUES ('t-1', 'Task', 0, 'op', 'internal')`
+    `INSERT INTO tasks (id, title, priority, principal_id, source_system) VALUES ('t-1', 'Task', 0, 'op', 'internal')`
   );
   db.exec(`INSERT INTO agents (id, name, type) VALUES ('a-1', 'A', 'hands')`);
   db.exec(

--- a/src/surface/mc/__tests__/task-create-endpoints.test.ts
+++ b/src/surface/mc/__tests__/task-create-endpoints.test.ts
@@ -11,7 +11,7 @@
  *   D5 — application-level dedup at preview, 409 + deeplink shape
  *   D6 — endpoint shapes (status codes + body keys)
  *   D8 — shadow assignment + session created in the same transaction
- *   D10 — operator.curation event with kind: "task.imported"
+ *   D10 — principal.curation event with kind: "task.imported"
  */
 
 import {
@@ -210,7 +210,7 @@ describe("POST /api/tasks/preview", () => {
   it("returns 409 conflict + deeplink shape when an existing task tracks the same ref", async () => {
     // Seed an existing GitHub-source task with the canonical ref.
     t.db.exec(`
-      INSERT INTO tasks (id, title, priority, operator_id, source_system,
+      INSERT INTO tasks (id, title, priority, principal_id, source_system,
                          source_url, source_external_id, status)
       VALUES ('T-existing', 'old title', 2, 'op-1', 'github',
               'https://github.com/the-metafactory/grove-v2/issues/42',
@@ -391,10 +391,10 @@ describe("POST /api/tasks", () => {
     expect(sess.endpoint_kind).toBe("local.observed");
     expect(sess.ended_at).not.toBeNull();
 
-    // operator.curation event with kind='task.imported' on the shadow session.
+    // principal.curation event with kind='task.imported' on the shadow session.
     const events = t.db
       .query(
-        "SELECT type, payload FROM events WHERE session_id = ? AND type = 'operator.curation'"
+        "SELECT type, payload FROM events WHERE session_id = ? AND type = 'principal.curation'"
       )
       .all(body.shadowSessionId) as { type: string; payload: string }[];
     expect(events).toHaveLength(1);
@@ -427,7 +427,7 @@ describe("POST /api/tasks", () => {
   it("returns 409 conflict when racing the dedup window after preview", async () => {
     // Seed dedup target.
     t.db.exec(`
-      INSERT INTO tasks (id, title, priority, operator_id, source_system,
+      INSERT INTO tasks (id, title, priority, principal_id, source_system,
                          source_url, source_external_id, status)
       VALUES ('T-prev', 'prev', 2, 'op', 'github',
               'https://github.com/x/y/issues/3', 'x/y#3', 'open');
@@ -533,7 +533,7 @@ describe("POST /api/tasks/:taskId/abandon", () => {
     // Curation event lands on the shadow session.
     const events = t.db
       .query(
-        "SELECT payload FROM events WHERE session_id = ? AND type = 'operator.curation' ORDER BY id DESC"
+        "SELECT payload FROM events WHERE session_id = ? AND type = 'principal.curation' ORDER BY id DESC"
       )
       .all(shadowSessionId) as { payload: string }[];
     // First event was task.imported (from create); this is the abandon.
@@ -574,7 +574,7 @@ describe("POST /api/tasks/:taskId/abandon", () => {
 
     const events = t.db
       .query(
-        "SELECT payload FROM events WHERE session_id = ? AND type = 'operator.curation' ORDER BY id DESC"
+        "SELECT payload FROM events WHERE session_id = ? AND type = 'principal.curation' ORDER BY id DESC"
       )
       .all(shadowSessionId) as { payload: string }[];
     const last = JSON.parse(events[0]!.payload);
@@ -700,7 +700,7 @@ describe("GET /api/tasks projection", () => {
   it("shadow_assignment_id is null for internal-source tasks", async () => {
     // Insert a task with no shadow assignment.
     t.db.exec(`
-      INSERT INTO tasks (id, title, priority, operator_id, source_system, status)
+      INSERT INTO tasks (id, title, priority, principal_id, source_system, status)
       VALUES ('T-internal', 'plain', 2, 'op', 'internal', 'open');
     `);
     const res = await fetch(`${t.baseUrl}/api/tasks`);

--- a/src/surface/mc/__tests__/tasks.test.ts
+++ b/src/surface/mc/__tests__/tasks.test.ts
@@ -72,7 +72,7 @@ describe("listTasks aggregate_state", () => {
 
   function seedTaskWithAssignmentStates(id: string, states: string[]): void {
     db.query(
-      `INSERT INTO tasks (id, title, priority, operator_id, source_system)
+      `INSERT INTO tasks (id, title, priority, principal_id, source_system)
        VALUES (?, ?, 2, 'op', 'internal')`
     ).run(id, `Task ${id}`);
     for (let i = 0; i < states.length; i++) {
@@ -129,7 +129,7 @@ describe("listTasks aggregate_state", () => {
 
   it("returns null when the task has no assignments", () => {
     db.query(
-      `INSERT INTO tasks (id, title, priority, operator_id, source_system)
+      `INSERT INTO tasks (id, title, priority, principal_id, source_system)
        VALUES ('t-empty', 'Empty task', 2, 'op', 'internal')`
     ).run();
     const [row] = listTasks(db);
@@ -166,7 +166,7 @@ describe("listTasks iteration denormalisation", () => {
   }
   function seedTask(id: string, iterationId: string | null): void {
     db.query(
-      `INSERT INTO tasks (id, title, priority, operator_id, source_system, iteration_id)
+      `INSERT INTO tasks (id, title, priority, principal_id, source_system, iteration_id)
        VALUES (?, ?, 2, 'op', 'internal', ?)`
     ).run(id, `Task ${id}`, iterationId);
   }
@@ -256,7 +256,7 @@ describe("getTaskById", () => {
   }
   function seedTask(id: string, iter: string | null = null): void {
     db.query(
-      `INSERT INTO tasks (id, title, priority, operator_id, source_system, iteration_id)
+      `INSERT INTO tasks (id, title, priority, principal_id, source_system, iteration_id)
        VALUES (?, ?, 2, 'op', 'github', ?)`
     ).run(id, `T ${id}`, iter);
   }

--- a/src/surface/mc/__tests__/transitions.test.ts
+++ b/src/surface/mc/__tests__/transitions.test.ts
@@ -11,7 +11,7 @@ function setupDb(): Database {
   for (const sql of SCHEMA_SQL) db.exec(sql);
 
   // seed required parent rows
-  db.exec(`INSERT INTO tasks (id, title, priority, operator_id, source_system) VALUES ('t-1', 'Task', 0, 'op', 'internal')`);
+  db.exec(`INSERT INTO tasks (id, title, priority, principal_id, source_system) VALUES ('t-1', 'Task', 0, 'op', 'internal')`);
   db.exec(`INSERT INTO agents (id, name, type) VALUES ('a-1', 'Agent', 'hands')`);
   db.exec(`INSERT INTO agent_task_assignment (id, agent_id, task_id, state) VALUES ('ata-1', 'a-1', 't-1', 'queued')`);
   db.exec(`INSERT INTO sessions (id, assignment_id, endpoint_kind) VALUES ('s-1', 'ata-1', 'local.process.controlled')`);

--- a/src/surface/mc/__tests__/types.test.ts
+++ b/src/surface/mc/__tests__/types.test.ts
@@ -21,7 +21,7 @@ describe("mission-control types", () => {
       title: "Fix webhook",
       description: null,
       priority: 0,
-      operator_id: "andreas",
+      principal_id: "andreas",
       source_system: "github",
       source_url: "https://github.com/the-metafactory/grove/issues/190",
       source_external_id: "grove#190",

--- a/src/surface/mc/__tests__/working-agents.test.ts
+++ b/src/surface/mc/__tests__/working-agents.test.ts
@@ -32,7 +32,7 @@ function seedAgent(db: Database, id: string, name = `Agent ${id}`): void {
 
 function seedTask(db: Database, id: string, priority = 2): void {
   db.query(
-    `INSERT OR IGNORE INTO tasks (id, title, priority, operator_id, source_system)
+    `INSERT OR IGNORE INTO tasks (id, title, priority, principal_id, source_system)
      VALUES (?, ?, ?, 'op', 'internal')`
   ).run(id, `Task ${id}`, priority);
 }

--- a/src/surface/mc/__tests__/ws-server.test.ts
+++ b/src/surface/mc/__tests__/ws-server.test.ts
@@ -115,7 +115,7 @@ describe("WebSocket server", () => {
     expect(typeof msgs[0].clientId).toBe("string");
     expect(msgs[0].clientId.length).toBe(26);
     expect(msgs[0].serverVersion).toBe("0.1.0");
-    expect(msgs[0].protocolVersion).toBe(1);
+    expect(msgs[0].protocolVersion).toBe(2);
 
     await closeAndWait(client.ws);
     await waitUntil(() => wsRegistry.size === 0);

--- a/src/surface/mc/api/handlers.ts
+++ b/src/surface/mc/api/handlers.ts
@@ -680,7 +680,7 @@ export async function handleCreateSession(
   const insertRows = db.transaction(() => {
     if (!body.taskId) {
       db.query(
-        `INSERT INTO tasks (id, title, priority, operator_id, source_system)
+        `INSERT INTO tasks (id, title, priority, principal_id, source_system)
          VALUES (?, ?, ?, ?, 'internal')`
       ).run(taskId, title, DEFAULT_INTERNAL_TASK_PRIORITY, principalId);
     }
@@ -854,7 +854,7 @@ export async function handleCreateSession(
     }
   }
 
-  // F-12 Decision 9 + Scope Summary — emit an `operator.curation` event with
+  // F-12 Decision 9 + Scope Summary — emit an `principal.curation` event with
   // `kind: "dispatch"` so the manual-dispatch path (POST /api/sessions) lands
   // in the audit trail alongside requeue / handoff / abandon. The event
   // anchors to the newly-spawned session and captures the agent the operator
@@ -1144,7 +1144,7 @@ export function handleSendInput(
 //   D5  — abandon branches on context (assignment vs task)
 //   D6  — handoff: cancel-and-respawn (in-flight) / new-only (failed)
 //   D7  — requeue: 1-to-1 mirror of state-machine's operator_requeue
-//   D9  — operator.curation event family with `kind` discriminator
+//   D9  — principal.curation event family with `kind` discriminator
 //   D11 — state.transition observer that calls endpoint.close() for the
 //         {→ cancelled, operator_requeue from blocked} transitions
 
@@ -1194,7 +1194,7 @@ function readReason(rawBody: unknown): {
   if (typeof reason !== "string") {
     return { err: error("'reason' must be a string", 400) };
   }
-  // Same 50 KB cap operator.input uses — operator-authored free-text.
+  // Same 50 KB cap principal.input uses — operator-authored free-text.
   if (Buffer.byteLength(reason, "utf8") > DRILL_INPUT_MAX_BYTES) {
     return { err: error("'reason' exceeds the 50 KB limit", 413) };
   }
@@ -1337,7 +1337,7 @@ export function handleRequeueAssignment(
     db
   );
 
-  // Decision 9 — sibling operator.curation event with `kind: "requeue"`.
+  // Decision 9 — sibling principal.curation event with `kind: "requeue"`.
   const curationEvent = createOperatorCurationEvent(db, sessionId, {
     kind: "requeue",
     ...(reason ? { reason } : {}),
@@ -1567,7 +1567,7 @@ export async function handleHandoffAssignment(
 
   // Decision 6 — a hand-off to the same agent is a no-op at best and a
   // misleading audit trail at worst (cancel-and-respawn to the same
-  // destination emits a `handoff` operator.curation event pointing nowhere
+  // destination emits a `handoff` principal.curation event pointing nowhere
   // meaningful). Reject explicitly rather than silently doing the wrong
   // thing.
   if (newAgentId === row.agent_id) {
@@ -1712,7 +1712,7 @@ export async function handleHandoffAssignment(
     broadcastEvent(deps.wsRegistry, endpoint.sessionId, result.event);
   }
 
-  // Decision 9 — operator.curation event with `kind: "handoff"` on the NEW
+  // Decision 9 — principal.curation event with `kind: "handoff"` on the NEW
   // session. The cancel of the old assignment has its own `state.transition`
   // event on the OLD session; this curation event captures the operator
   // rationale for the hand-off as a whole.
@@ -1752,7 +1752,7 @@ export async function handleHandoffAssignment(
 //   Decision 5 — application-level dedup at preview time, 409 response
 //   Decision 6 — endpoint shapes
 //   Decision 8 — task-shadow-{taskId} helper in ../db/sessions.ts
-//   Decision 10 — `operator.curation` with kind: "task.imported"
+//   Decision 10 — `principal.curation` with kind: "task.imported"
 
 const TITLE_OVERRIDE_MAX_LEN = 500;
 
@@ -2007,7 +2007,7 @@ export async function handleCreateTask(
   const insertAll = db.transaction(() => {
     db.query(
       `INSERT INTO tasks
-         (id, title, priority, operator_id,
+         (id, title, priority, principal_id,
           source_system, source_url, source_external_id)
        VALUES (?, ?, ?, ?, 'github', ?, ?)`
     ).run(taskId, title, priority, principalId, sourceUrl, canonical);
@@ -2728,7 +2728,7 @@ export function handleAttachTaskToIteration(
       db.transaction(() => {
         db.query(
           `INSERT INTO tasks
-             (id, title, priority, operator_id, source_system, iteration_id)
+             (id, title, priority, principal_id, source_system, iteration_id)
            VALUES (?, ?, ?, ?, 'internal', ?)`
         ).run(newTaskId, newTitle, prio, DEFAULT_OPERATOR_ID, iterationId);
         touchIteration(db, iterationId);

--- a/src/surface/mc/api/handlers.ts
+++ b/src/surface/mc/api/handlers.ts
@@ -61,8 +61,8 @@ import {
 } from "../db/iterations";
 import {
   generateId,
-  createOperatorCurationEvent,
-  createOperatorInputEvent,
+  createPrincipalCurationEvent,
+  createPrincipalInputEvent,
   listEventsForSession,
   EVENTS_LIST_MAX_LIMIT,
 } from "../db/events";
@@ -860,7 +860,7 @@ export async function handleCreateSession(
   // anchors to the newly-spawned session and captures the agent the operator
   // dispatched to; `newAssignmentId` is included for symmetry with the
   // handoff variant (the "assignment this spawn created").
-  const dispatchCurationEvent = createOperatorCurationEvent(
+  const dispatchCurationEvent = createPrincipalCurationEvent(
     db,
     endpoint.sessionId,
     {
@@ -882,7 +882,7 @@ export async function handleCreateSession(
   ) {
     try {
       endpoint.write(body.prompt);
-      const event = createOperatorInputEvent(db, endpoint.sessionId, {
+      const event = createPrincipalInputEvent(db, endpoint.sessionId, {
         text: body.prompt,
       });
       broadcastEvent(deps.wsRegistry, endpoint.sessionId, event);
@@ -1117,7 +1117,7 @@ export function handleSendInput(
     return error(`Write failed: ${(err as Error).message}`, 500);
   }
 
-  const event = createOperatorInputEvent(db, endpoint.sessionId, {
+  const event = createPrincipalInputEvent(db, endpoint.sessionId, {
     ...(textByteLength > 0 ? { text } : {}),
     ...(images.length > 0
       ? {
@@ -1338,7 +1338,7 @@ export function handleRequeueAssignment(
   );
 
   // Decision 9 — sibling principal.curation event with `kind: "requeue"`.
-  const curationEvent = createOperatorCurationEvent(db, sessionId, {
+  const curationEvent = createPrincipalCurationEvent(db, sessionId, {
     kind: "requeue",
     ...(reason ? { reason } : {}),
   });
@@ -1438,7 +1438,7 @@ export function handleAbandonAssignment(
       db
     );
 
-    const curationEvent = createOperatorCurationEvent(db, sessionId, {
+    const curationEvent = createPrincipalCurationEvent(db, sessionId, {
       kind: "abandon",
       targetKind: "assignment",
       ...(reason ? { reason } : {}),
@@ -1503,7 +1503,7 @@ export function handleAbandonAssignment(
     );
   }
 
-  const curationEvent = createOperatorCurationEvent(db, sessionId, {
+  const curationEvent = createPrincipalCurationEvent(db, sessionId, {
     kind: "abandon",
     targetKind: "task",
     ...(reason ? { reason } : {}),
@@ -1716,7 +1716,7 @@ export async function handleHandoffAssignment(
   // session. The cancel of the old assignment has its own `state.transition`
   // event on the OLD session; this curation event captures the operator
   // rationale for the hand-off as a whole.
-  const curationEvent = createOperatorCurationEvent(db, endpoint.sessionId, {
+  const curationEvent = createPrincipalCurationEvent(db, endpoint.sessionId, {
     kind: "handoff",
     fromAgentId: row.agent_id,
     toAgentId: newAgentId,
@@ -2001,7 +2001,7 @@ export async function handleCreateTask(
   // the caller can `broadcastEvent` after the transaction commits (the
   // event insert is inside the tx, but WS broadcast happens post-commit
   // so subscribers don't see a write-then-rollback ghost).
-  const holder: { event: ReturnType<typeof createOperatorCurationEvent> | null } =
+  const holder: { event: ReturnType<typeof createPrincipalCurationEvent> | null } =
     { event: null };
 
   const insertAll = db.transaction(() => {
@@ -2017,7 +2017,7 @@ export async function handleCreateTask(
       sessionId: shadowSessionId,
     });
 
-    holder.event = createOperatorCurationEvent(db, shadowSessionId, {
+    holder.event = createPrincipalCurationEvent(db, shadowSessionId, {
       kind: "task.imported",
       source: "github",
       ref: canonical,
@@ -2145,14 +2145,14 @@ export function handleAbandonTask(
   // transaction closure. See the create-task handler above for the same
   // pattern; duplicated here rather than extracted because the pair of
   // inserts is short enough that a helper would be more ceremony.
-  const holder: { event: ReturnType<typeof createOperatorCurationEvent> | null } =
+  const holder: { event: ReturnType<typeof createPrincipalCurationEvent> | null } =
     { event: null };
   const tx = db.transaction(() => {
     db.query(
       `UPDATE tasks SET status = 'cancelled', updated_at = unixepoch() WHERE id = ?`
     ).run(taskId);
 
-    holder.event = createOperatorCurationEvent(db, sessionRow.id, {
+    holder.event = createPrincipalCurationEvent(db, sessionRow.id, {
       kind: "abandon",
       targetKind: "task",
       ...(reason ? { reason } : {}),

--- a/src/surface/mc/api/iteration-import.ts
+++ b/src/surface/mc/api/iteration-import.ts
@@ -447,7 +447,7 @@ export function importSubIssueFromMetadata(
   const DEFAULT_OPERATOR_ID = "mc-default-operator";
   db.query(
     `INSERT INTO tasks
-       (id, title, priority, operator_id,
+       (id, title, priority, principal_id,
         source_system, source_url, source_external_id,
         status, iteration_id)
      VALUES (?, ?, 2, ?, 'github', ?, ?, ?, ?)`

--- a/src/surface/mc/api/types.ts
+++ b/src/surface/mc/api/types.ts
@@ -88,7 +88,7 @@ export interface CreateSessionRequest {
   principalId?: string;
   /**
    * Optional initial operator turn. If provided, it is written to the
-   * controlled session after spawn and recorded as an operator.input event.
+   * controlled session after spawn and recorded as an principal.input event.
    * Ignored for `kind: 'local.observed'` (no stdin to write to).
    */
   prompt?: string;
@@ -164,7 +164,7 @@ export interface SendInputResponse {
 // 409 with the state-machine's error string.
 
 export interface RequeueRequest {
-  /** Optional free-text reason captured in the operator.curation event. */
+  /** Optional free-text reason captured in the principal.curation event. */
   reason?: string;
 }
 

--- a/src/surface/mc/api/types.ts
+++ b/src/surface/mc/api/types.ts
@@ -88,7 +88,7 @@ export interface CreateSessionRequest {
   principalId?: string;
   /**
    * Optional initial operator turn. If provided, it is written to the
-   * controlled session after spawn and recorded as an principal.input event.
+   * controlled session after spawn and recorded as a principal.input event.
    * Ignored for `kind: 'local.observed'` (no stdin to write to).
    */
   prompt?: string;

--- a/src/surface/mc/dashboard-v2/__tests__/event-rows.test.ts
+++ b/src/surface/mc/dashboard-v2/__tests__/event-rows.test.ts
@@ -3,7 +3,7 @@
  *
  * Verifies the per-event-type row expansion, tool_use ↔ tool_result
  * pairing by `tool_use_id`, and the suppression of `stream-json.user`
- * text blocks (operator.input is the authoritative H-source).
+ * text blocks (principal.input is the authoritative H-source).
  */
 
 import { describe, it, expect } from "bun:test";
@@ -33,7 +33,7 @@ describe("lib/event-rows — eventToRows", () => {
     expect((rows[2] as { name: string }).name).toBe("Read");
   });
 
-  it("suppresses stream-json.user text blocks (operator.input is authoritative)", () => {
+  it("suppresses stream-json.user text blocks (principal.input is authoritative)", () => {
     const rows = eventToRows(ev("stream-json.user", {
       message: {
         content: [
@@ -77,12 +77,12 @@ describe("lib/event-rows — eventToRows", () => {
     expect(row.weight).toBe("tertiary");
   });
 
-  it("emits operator.input row preserving images", () => {
-    const row = eventToRows(ev("operator.input", {
+  it("emits principal.input row preserving images", () => {
+    const row = eventToRows(ev("principal.input", {
       text: "hi",
       images: [{ media_type: "image/png", data: "abc" }],
     }))[0] as { kind: string; text: string; images?: unknown[] };
-    expect(row.kind).toBe("operator.input");
+    expect(row.kind).toBe("principal.input");
     expect(row.text).toBe("hi");
     expect(row.images).toHaveLength(1);
   });

--- a/src/surface/mc/dashboard-v2/components/curation-toolbar.tsx
+++ b/src/surface/mc/dashboard-v2/components/curation-toolbar.tsx
@@ -8,7 +8,7 @@
  * Dispatch and Requeue fire-and-forget.
  *
  * The toolbar does NOT trigger refetches — it relies on the WS
- * `state.transition` and `operator.curation` frames to flip the parent's
+ * `state.transition` and `principal.curation` frames to flip the parent's
  * `assignment.state`, which re-renders the buttons with the new
  * enablement set (no manual round-trip).
  *

--- a/src/surface/mc/dashboard-v2/components/drill-down.tsx
+++ b/src/surface/mc/dashboard-v2/components/drill-down.tsx
@@ -118,7 +118,7 @@ export function DrillDown({
         {/*
           F-12 curation toolbar — Decision 2 places it between the log
           and the input. Verb enablement is a pure function of
-          `assignment.state`; WS state.transition + operator.curation
+          `assignment.state`; WS state.transition + principal.curation
           frames flip the button set without manual round-trips.
         */}
         <CurationToolbar assignment={assignment} />

--- a/src/surface/mc/dashboard-v2/components/drill-log.tsx
+++ b/src/surface/mc/dashboard-v2/components/drill-log.tsx
@@ -137,10 +137,10 @@ function RowBody({ row, isExpanded, onToggle, onOpenImage }: DrillRowProps) {
       );
     }
 
-    case "operator.input":
+    case "principal.input":
       return (
         <>
-          <div className="kind">operator.input</div>
+          <div className="kind">principal.input</div>
           {row.text && <div className="text">{renderMarkdown(row.text)}</div>}
           {row.images && row.images.length > 0 && (
             <div className="images-row">

--- a/src/surface/mc/dashboard-v2/components/image-lightbox.tsx
+++ b/src/surface/mc/dashboard-v2/components/image-lightbox.tsx
@@ -2,7 +2,7 @@
  * Image lightbox modal.
  *
  * Click-outside or Esc dismisses. Used by F-7's drill-log (MIG-3) for
- * inline `operator.input` image previews and by MIG-3's drill-input chip
+ * inline `principal.input` image previews and by MIG-3's drill-input chip
  * row for staged-image expansion.
  *
  * CSS lives in styles/global.css under .lightbox / .lightbox-backdrop /

--- a/src/surface/mc/dashboard-v2/hooks/use-artefacts.ts
+++ b/src/surface/mc/dashboard-v2/hooks/use-artefacts.ts
@@ -82,7 +82,7 @@ function serialiseSearchableText(ev: McEvent): string {
     }
     return parts.join("\n");
   }
-  if (ev.type === "operator.input") {
+  if (ev.type === "principal.input") {
     const text = (ev.payload as { text?: string })?.text;
     return typeof text === "string" ? text : "";
   }

--- a/src/surface/mc/dashboard-v2/lib/event-rows.ts
+++ b/src/surface/mc/dashboard-v2/lib/event-rows.ts
@@ -20,7 +20,7 @@ export type LogRow =
   | ThinkingRow
   | ToolUseRow
   | ToolResultRow
-  | OperatorInputRow
+  | PrincipalInputRow
   | PermissionRow
   | StateTransitionRow
   | ResultRow
@@ -63,7 +63,7 @@ export interface ToolResultRow extends RowBase {
   byteSize: number;
 }
 
-export interface OperatorInputRow extends RowBase {
+export interface PrincipalInputRow extends RowBase {
   kind: "principal.input";
   text: string;
   images?: Array<{ media_type: string; data: string }>;
@@ -121,7 +121,7 @@ export function eventToRows(ev: McEvent): LogRow[] {
     case "stream-json.user":
       return userToRows(ev);
     case "principal.input":
-      return [operatorInputRow(ev)];
+      return [principalInputRow(ev)];
     case "permission.request":
       return [permissionRow(ev)];
     case "state.transition":
@@ -236,14 +236,14 @@ function userToRows(ev: McEvent): LogRow[] {
   return out;
 }
 
-function operatorInputRow(ev: McEvent): OperatorInputRow {
+function principalInputRow(ev: McEvent): PrincipalInputRow {
   const text = typeof (ev.payload as { text?: string })?.text === "string"
     ? (ev.payload as { text: string }).text : "";
   const imagesRaw = (ev.payload as { images?: unknown }).images;
   const images = Array.isArray(imagesRaw)
     ? (imagesRaw as Array<{ media_type: string; data: string }>)
     : undefined;
-  const row: OperatorInputRow = {
+  const row: PrincipalInputRow = {
     id: ev.id, ts: ev.timestamp, color: "h", weight: "primary",
     kind: "principal.input", text,
   };

--- a/src/surface/mc/dashboard-v2/lib/event-rows.ts
+++ b/src/surface/mc/dashboard-v2/lib/event-rows.ts
@@ -64,7 +64,7 @@ export interface ToolResultRow extends RowBase {
 }
 
 export interface OperatorInputRow extends RowBase {
-  kind: "operator.input";
+  kind: "principal.input";
   text: string;
   images?: Array<{ media_type: string; data: string }>;
 }
@@ -120,7 +120,7 @@ export function eventToRows(ev: McEvent): LogRow[] {
       return assistantToRows(ev);
     case "stream-json.user":
       return userToRows(ev);
-    case "operator.input":
+    case "principal.input":
       return [operatorInputRow(ev)];
     case "permission.request":
       return [permissionRow(ev)];
@@ -231,7 +231,7 @@ function userToRows(ev: McEvent): LogRow[] {
       out.push(row);
     }
     // text blocks on user messages are SUPPRESSED per Decision 11
-    // (operator.input is the authoritative H-source).
+    // (principal.input is the authoritative H-source).
   }
   return out;
 }
@@ -245,7 +245,7 @@ function operatorInputRow(ev: McEvent): OperatorInputRow {
     : undefined;
   const row: OperatorInputRow = {
     id: ev.id, ts: ev.timestamp, color: "h", weight: "primary",
-    kind: "operator.input", text,
+    kind: "principal.input", text,
   };
   if (images) row.images = images;
   return row;

--- a/src/surface/mc/db/assignments.ts
+++ b/src/surface/mc/db/assignments.ts
@@ -163,7 +163,7 @@ export function listAssignments(db: Database): AssignmentListItem[] {
  *
  * F-6 v1: blocked-only. The three BlockReason kinds (permission.request,
  * tool.error, review.checkpoint) all land the assignment in `blocked`, so this
- * covers 100% of attention signals until F-10 adds `operator.input.requested`
+ * covers 100% of attention signals until F-10 adds `principal.input.requested`
  * events for the soft-prompt path.
  *
  * Ordering: task.priority ASC (P0 first), then updated_at ASC (oldest-waiting

--- a/src/surface/mc/db/events.ts
+++ b/src/surface/mc/db/events.ts
@@ -181,7 +181,7 @@ export function listEventsForSession(
  * Decision 3: principal.input is the authoritative H-source, including
  * for image content; stream-json.user is suppressed on the renderer.
  */
-export interface OperatorInputEventPayload {
+export interface PrincipalInputEventPayload {
   text?: string;
   attachments?: string[];
   images?: {
@@ -191,10 +191,10 @@ export interface OperatorInputEventPayload {
   }[];
 }
 
-export function createOperatorInputEvent(
+export function createPrincipalInputEvent(
   db: Database,
   sessionId: string,
-  payload: OperatorInputEventPayload
+  payload: PrincipalInputEventPayload
 ): McEvent {
   // insertEvent takes Record<string, unknown>; the shape-typed payload is
   // widened at the call-site — the stored JSON is the authoritative truth,
@@ -217,7 +217,7 @@ export function createOperatorInputEvent(
  * variants ship in F-12: dispatch, requeue, handoff, abandon. F-12b will
  * add `kind: "import"` for the GitHub-issue-add-to-queue verb.
  */
-export type OperatorCurationPayload =
+export type PrincipalCurationPayload =
   | {
       kind: "dispatch";
       agentId: string;
@@ -253,10 +253,10 @@ export type OperatorCurationPayload =
       type: "issue" | "pr";
     };
 
-export function createOperatorCurationEvent(
+export function createPrincipalCurationEvent(
   db: Database,
   sessionId: string,
-  payload: OperatorCurationPayload
+  payload: PrincipalCurationPayload
 ): McEvent {
   // The tagged-union narrowing happens at the call site; the storage layer
   // widens to the generic event-payload shape.

--- a/src/surface/mc/db/events.ts
+++ b/src/surface/mc/db/events.ts
@@ -172,13 +172,13 @@ export function listEventsForSession(
 }
 
 /**
- * Insert an operator.input event.
+ * Insert an principal.input event.
  *
  * `text` and `images` are both optional at the type level — the caller
  * enforces "at least one of text or images must be present" for the
  * POST /input endpoint (see handlers.ts). Storing images inline here
  * matches the canonical-store rule from `docs/design-mc-image-input.md`
- * Decision 3: operator.input is the authoritative H-source, including
+ * Decision 3: principal.input is the authoritative H-source, including
  * for image content; stream-json.user is suppressed on the renderer.
  */
 export interface OperatorInputEventPayload {
@@ -202,16 +202,16 @@ export function createOperatorInputEvent(
   // insertEvent signature for all callers.
   return insertEvent(db, {
     sessionId,
-    type: "operator.input",
+    type: "principal.input",
     payload: payload as Record<string, unknown>,
   });
 }
 
 /**
- * Insert an operator.curation event (F-12 Decision 9).
+ * Insert an principal.curation event (F-12 Decision 9).
  *
- * Sibling family of `operator.input` — see addendum Decision 9 for the
- * rationale on why curation verbs are NOT folded into operator.input.
+ * Sibling family of `principal.input` — see addendum Decision 9 for the
+ * rationale on why curation verbs are NOT folded into principal.input.
  *
  * The payload follows a tagged-union shape discriminated by `kind`. Four
  * variants ship in F-12: dispatch, requeue, handoff, abandon. F-12b will
@@ -262,7 +262,7 @@ export function createOperatorCurationEvent(
   // widens to the generic event-payload shape.
   return insertEvent(db, {
     sessionId,
-    type: "operator.curation",
+    type: "principal.curation",
     payload,
   });
 }

--- a/src/surface/mc/db/events.ts
+++ b/src/surface/mc/db/events.ts
@@ -172,7 +172,7 @@ export function listEventsForSession(
 }
 
 /**
- * Insert an principal.input event.
+ * Insert a principal.input event.
  *
  * `text` and `images` are both optional at the type level — the caller
  * enforces "at least one of text or images must be present" for the
@@ -208,7 +208,7 @@ export function createPrincipalInputEvent(
 }
 
 /**
- * Insert an principal.curation event (F-12 Decision 9).
+ * Insert a principal.curation event (F-12 Decision 9).
  *
  * Sibling family of `principal.input` — see addendum Decision 9 for the
  * rationale on why curation verbs are NOT folded into principal.input.

--- a/src/surface/mc/db/schema.ts
+++ b/src/surface/mc/db/schema.ts
@@ -24,7 +24,7 @@ export const SCHEMA_SQL: string[] = [
     title TEXT NOT NULL,
     description TEXT,
     priority INTEGER NOT NULL DEFAULT 2,
-    operator_id TEXT NOT NULL,
+    principal_id TEXT NOT NULL,
     source_system TEXT NOT NULL CHECK(source_system IN ('github','internal')),
     source_url TEXT,
     source_external_id TEXT,

--- a/src/surface/mc/notifications/discord-sink.ts
+++ b/src/surface/mc/notifications/discord-sink.ts
@@ -99,7 +99,7 @@ export interface NotificationContext {
   priority: number;
   /** `tasks.source_url`. May be null for `internal` tasks. */
   taskSourceUrl: string | null;
-  /** `tasks.operator_id`. Coalescing keys off this. */
+  /** `tasks.principal_id`. Coalescing keys off this. */
   principalId: string;
   /**
    * Cycle / dispatch count for this assignment. Optional — the renderer
@@ -240,7 +240,7 @@ interface CoalesceBuffer {
   scheduler: FlushScheduler;
 }
 
-/** Per-operator coalesce buffer: `operator_id → buffer`. */
+/** Per-operator coalesce buffer: `principal_id → buffer`. */
 const dmBuffers = new Map<string, CoalesceBuffer>();
 /** Per-channel coalesce buffer: `channel_id → buffer`. */
 const channelBuffers = new Map<string, CoalesceBuffer>();

--- a/src/surface/mc/notifications/should-notify.ts
+++ b/src/surface/mc/notifications/should-notify.ts
@@ -226,9 +226,9 @@ export function shouldNotify(input: ShouldNotifyInput): NotificationIntent | nul
   }
 }
 
-// `operator.input.requested` is contemplated by Decision 1 (last row of
+// `principal.input.requested` is contemplated by Decision 1 (last row of
 // the matrix) but the event is not yet emitted by Mission Control v2 (no
-// caller writes the `operator.input.requested` event type). When the
+// caller writes the `principal.input.requested` event type). When the
 // emitter lands in a follow-up F-1?, restore `maybeNotifyInputRequested`
 // in `discord-sink.ts` and a matching `shouldNotifyInputRequested` here,
 // wired from the new emitter call site. Removed for now to keep this PR

--- a/src/surface/mc/session/stdout-dispatcher.ts
+++ b/src/surface/mc/session/stdout-dispatcher.ts
@@ -233,7 +233,7 @@ function loadNotificationContext(
          t.id           AS task_id,
          t.title        AS task_title,
          t.priority     AS task_priority,
-         t.operator_id  AS operator_id,
+         t.principal_id  AS principal_id,
          t.source_url   AS source_url,
          t.source_external_id AS source_external_id,
          a.name         AS agent_name
@@ -247,7 +247,7 @@ function loadNotificationContext(
         task_id: string;
         task_title: string;
         task_priority: number;
-        operator_id: string;
+        principal_id: string;
         source_url: string | null;
         source_external_id: string | null;
         agent_name: string;
@@ -268,7 +268,7 @@ function loadNotificationContext(
     taskTitle: row.task_title,
     priority: row.task_priority,
     taskSourceUrl: row.source_url,
-    principalId: row.operator_id,
+    principalId: row.principal_id,
     observedAtMs: Date.now(),
   };
 }

--- a/src/surface/mc/types.ts
+++ b/src/surface/mc/types.ts
@@ -65,7 +65,7 @@ export interface Task {
   title: string;
   description: string | null;
   priority: number;
-  operator_id: string;
+  principal_id: string;
   source_system: TaskSourceSystem;
   source_url: string | null;
   source_external_id: string | null;

--- a/src/surface/mc/worker/migrations/0004_principal_rename.sql
+++ b/src/surface/mc/worker/migrations/0004_principal_rename.sql
@@ -1,0 +1,34 @@
+-- R2b / R2.J — vocabulary migration (cortex#436): operator → principal on the D1 (cloud) snapshot.
+--
+-- Renames the wire/storage identity columns on the deployed D1 database to match
+-- the post-migration schema in ../schema.sql:
+--   - sessions.operator_id        → principal_id
+--   - github_events.operator_id   → principal_id
+--   - usage_snapshots.operator_id → principal_id
+--   - sessions.home_operator      → home_principal   (IAW D.5 sovereignty column)
+-- and recreates the affected indexes.
+--
+-- Apply: wrangler d1 execute grove-events --file=./migrations/0004_principal_rename.sql
+--
+-- Single-cut breaking change — no transition shim (cortex#436 §2/§8). Run once on a
+-- deployed D1; RENAME COLUMN errors if already applied.
+--
+-- Scope note: the local SQLite tables (tasks.operator_id, events with type
+-- 'operator.input'/'operator.curation') are created fresh from db/schema.ts and need
+-- no migration here — D1 carries no events/tasks tables. The historical
+-- 0003_sovereignty.sql DDL is left untouched (it must keep adding home_operator on a
+-- fresh D1; this migration then renames it).
+
+ALTER TABLE sessions RENAME COLUMN operator_id TO principal_id;
+ALTER TABLE github_events RENAME COLUMN operator_id TO principal_id;
+ALTER TABLE usage_snapshots RENAME COLUMN operator_id TO principal_id;
+ALTER TABLE sessions RENAME COLUMN home_operator TO home_principal;
+
+DROP INDEX IF EXISTS idx_sessions_operator;
+CREATE INDEX IF NOT EXISTS idx_sessions_operator ON sessions(principal_id);
+
+DROP INDEX IF EXISTS idx_github_operator;
+CREATE INDEX IF NOT EXISTS idx_github_operator ON github_events(principal_id);
+
+DROP INDEX IF EXISTS idx_sessions_home_operator;
+CREATE INDEX IF NOT EXISTS idx_sessions_home_principal ON sessions(home_principal) WHERE home_principal IS NOT NULL;

--- a/src/surface/mc/worker/schema.sql
+++ b/src/surface/mc/worker/schema.sql
@@ -1,5 +1,5 @@
 -- Grove Cloud API — D1 Schema
--- Derived from dashboard-db.ts, with operator_id for multi-operator attribution.
+-- Derived from dashboard-db.ts, with principal_id for multi-operator attribution.
 
 CREATE TABLE IF NOT EXISTS schema_version (
   version INTEGER PRIMARY KEY,
@@ -9,7 +9,7 @@ INSERT OR IGNORE INTO schema_version (version) VALUES (1);
 
 CREATE TABLE IF NOT EXISTS sessions (
   session_id TEXT PRIMARY KEY,
-  operator_id TEXT,
+  principal_id TEXT,
   agent_id TEXT NOT NULL,
   agent_name TEXT NOT NULL,
   project TEXT,
@@ -33,13 +33,13 @@ CREATE TABLE IF NOT EXISTS sessions (
   -- All three are NULL for pre-IAW publishers. See migrations/0003_sovereignty.sql.
   classification TEXT,        -- 'local' | 'federated' | 'public' | NULL
   data_residency TEXT,        -- e.g. 'nz', 'eu', NULL
-  home_operator TEXT          -- principal.home_operator (post-`did:mf:` strip)
+  home_principal TEXT          -- principal.home_principal (post-`did:mf:` strip)
 );
 
 CREATE TABLE IF NOT EXISTS github_events (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
   event_id TEXT UNIQUE,
-  operator_id TEXT,
+  principal_id TEXT,
   repo TEXT NOT NULL,
   event_type TEXT NOT NULL,
   title TEXT,
@@ -95,7 +95,7 @@ CREATE TABLE IF NOT EXISTS pull_requests (
 
 CREATE TABLE IF NOT EXISTS usage_snapshots (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
-  operator_id TEXT,
+  principal_id TEXT,
   source TEXT NOT NULL,
   five_hour_pct REAL,
   five_hour_resets TEXT,
@@ -126,7 +126,7 @@ CREATE TABLE IF NOT EXISTS audit_log (
   ip TEXT,
   endpoint TEXT,
   method TEXT,
-  identity TEXT,                   -- operator_id, email, or admin
+  identity TEXT,                   -- principal_id, email, or admin
   detail TEXT                      -- failure reason or extra context
 );
 
@@ -136,12 +136,12 @@ CREATE INDEX IF NOT EXISTS idx_audit_event_type ON audit_log(event_type, timesta
 CREATE INDEX IF NOT EXISTS idx_session_activity_session ON session_activity(session_id, timestamp);
 CREATE INDEX IF NOT EXISTS idx_sessions_status ON sessions(status);
 CREATE INDEX IF NOT EXISTS idx_sessions_completed ON sessions(completed_at);
-CREATE INDEX IF NOT EXISTS idx_sessions_operator ON sessions(operator_id);
--- IAW D.5 — slicing the dashboard snapshot by home_operator on every poll
-CREATE INDEX IF NOT EXISTS idx_sessions_home_operator ON sessions(home_operator) WHERE home_operator IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_sessions_operator ON sessions(principal_id);
+-- IAW D.5 — slicing the dashboard snapshot by home_principal on every poll
+CREATE INDEX IF NOT EXISTS idx_sessions_home_principal ON sessions(home_principal) WHERE home_principal IS NOT NULL;
 CREATE INDEX IF NOT EXISTS idx_github_repo ON github_events(repo, created_at);
 CREATE INDEX IF NOT EXISTS idx_github_agent ON github_events(agent_authored, created_at);
-CREATE INDEX IF NOT EXISTS idx_github_operator ON github_events(operator_id);
+CREATE INDEX IF NOT EXISTS idx_github_operator ON github_events(principal_id);
 CREATE INDEX IF NOT EXISTS idx_issues_repo_state ON issues(repo, state);
 CREATE INDEX IF NOT EXISTS idx_prs_repo_state ON pull_requests(repo, state);
 CREATE INDEX IF NOT EXISTS idx_usage_recorded ON usage_snapshots(recorded_at);

--- a/src/surface/mc/worker/src/auth.ts
+++ b/src/surface/mc/worker/src/auth.ts
@@ -1,7 +1,7 @@
 /**
  * G-400/G-402: API Key Authentication Middleware
  * Validates Bearer tokens against Workers KV.
- * Keys are stored as: key => { operator_id, name, created_at }
+ * Keys are stored as: key => { principal_id, name, created_at }
  *
  * S-001: CF Access JWT validation for read endpoints.
  * Dashboard users authenticate via CF Access; the JWT is passed as CF_Authorization cookie.
@@ -51,18 +51,18 @@ function getClientIp(c: Context): string {
     ?? "unknown";
 }
 
-export interface OperatorKey {
-  operator_id: string;
+export interface PrincipalKey {
+  principal_id: string;
   name: string;
   created_at: string;
 }
 
 /**
  * Middleware that validates the Authorization: Bearer header against KV.
- * On success, sets c.set("operatorId", ...) and c.set("operatorKey", ...).
+ * On success, sets c.set("principalId", ...) and c.set("operatorKey", ...).
  * On failure, returns 401.
  */
-export async function requireApiKey(c: Context<{ Bindings: Env; Variables: { operatorId: string; operatorKey: OperatorKey } }>, next: Next) {
+export async function requireApiKey(c: Context<{ Bindings: Env; Variables: { principalId: string; operatorKey: PrincipalKey } }>, next: Next) {
   const ip = getClientIp(c);
   const endpoint = new URL(c.req.url).pathname;
   const method = c.req.method;
@@ -79,15 +79,15 @@ export async function requireApiKey(c: Context<{ Bindings: Env; Variables: { ope
     return c.json({ error: "empty bearer token" }, 401);
   }
 
-  const keyData = await c.env.GROVE_KEYS.get(token, "json") as OperatorKey | null;
+  const keyData = await c.env.GROVE_KEYS.get(token, "json") as PrincipalKey | null;
   if (!keyData) {
     logAuditEvent(c.env.GROVE_DB, { eventType: "api_key_auth", result: "failure", ip, endpoint, method, detail: "invalid or revoked key" });
     return c.json({ error: "invalid or revoked API key" }, 401);
   }
 
-  const operatorId = keyData.operator_id ?? (keyData as any).operatorId ?? "";
-  logAuditEvent(c.env.GROVE_DB, { eventType: "api_key_auth", result: "success", ip, endpoint, method, identity: operatorId });
-  c.set("operatorId", operatorId);
+  const principalId = keyData.principal_id ?? (keyData as any).principalId ?? "";
+  logAuditEvent(c.env.GROVE_DB, { eventType: "api_key_auth", result: "success", ip, endpoint, method, identity: principalId });
+  c.set("principalId", principalId);
   c.set("operatorKey", keyData);
   await next();
 }

--- a/src/surface/mc/worker/src/auth.ts
+++ b/src/surface/mc/worker/src/auth.ts
@@ -59,10 +59,10 @@ export interface PrincipalKey {
 
 /**
  * Middleware that validates the Authorization: Bearer header against KV.
- * On success, sets c.set("principalId", ...) and c.set("operatorKey", ...).
+ * On success, sets c.set("principalId", ...) and c.set("principalKey", ...).
  * On failure, returns 401.
  */
-export async function requireApiKey(c: Context<{ Bindings: Env; Variables: { principalId: string; operatorKey: PrincipalKey } }>, next: Next) {
+export async function requireApiKey(c: Context<{ Bindings: Env; Variables: { principalId: string; principalKey: PrincipalKey } }>, next: Next) {
   const ip = getClientIp(c);
   const endpoint = new URL(c.req.url).pathname;
   const method = c.req.method;
@@ -85,10 +85,17 @@ export async function requireApiKey(c: Context<{ Bindings: Env; Variables: { pri
     return c.json({ error: "invalid or revoked API key" }, 401);
   }
 
-  const principalId = keyData.principal_id ?? (keyData as any).principalId ?? "";
+  // Single-cut (cortex#436 §2): keys must carry `principal_id`. No empty/legacy
+  // fallback — a key missing it fails closed rather than authenticating with an
+  // empty principal that ingest would then trust as the attribution identity.
+  const principalId = keyData.principal_id;
+  if (!principalId) {
+    logAuditEvent(c.env.GROVE_DB, { eventType: "api_key_auth", result: "failure", ip, endpoint, method, detail: "key missing principal_id" });
+    return c.json({ error: "API key missing principal identity" }, 401);
+  }
   logAuditEvent(c.env.GROVE_DB, { eventType: "api_key_auth", result: "success", ip, endpoint, method, identity: principalId });
   c.set("principalId", principalId);
-  c.set("operatorKey", keyData);
+  c.set("principalKey", keyData);
   await next();
 }
 

--- a/src/surface/mc/worker/src/routes/admin.ts
+++ b/src/surface/mc/worker/src/routes/admin.ts
@@ -12,7 +12,7 @@
 
 import { Hono } from "hono";
 import type { Env } from "../index";
-import { requireAdmin, type OperatorKey } from "../auth";
+import { requireAdmin, type PrincipalKey } from "../auth";
 import { requireRole } from "../user-auth";
 
 export const adminRoutes = new Hono<{ Bindings: Env }>();
@@ -23,7 +23,7 @@ export const adminRoutes = new Hono<{ Bindings: Env }>();
 
 adminRoutes.post("/admin/keys", requireAdmin, async (c) => {
   // PR-R2d renames the request wire field to `principal_id`. The
-  // KV-stored `OperatorKey.operator_id` symbol stays pending PR-R2.D
+  // KV-stored `PrincipalKey.principal_id` symbol stays pending PR-R2.D
   // (MC API + auth-type rename — see plan §R2.D). The response wire
   // mirrors the request shape.
   let body: { principal_id: string; name: string };
@@ -43,8 +43,8 @@ adminRoutes.post("/admin/keys", requireAdmin, async (c) => {
   const hex = Array.from(random).map((b) => b.toString(16).padStart(2, "0")).join("");
   const key = `grove_sk_${hex}`;
 
-  const keyData: OperatorKey = {
-    operator_id: body.principal_id,
+  const keyData: PrincipalKey = {
+    principal_id: body.principal_id,
     name: body.name,
     created_at: new Date().toISOString(),
   };
@@ -54,7 +54,7 @@ adminRoutes.post("/admin/keys", requireAdmin, async (c) => {
 
   return c.json({
     key,
-    principal_id: keyData.operator_id,
+    principal_id: keyData.principal_id,
     name: keyData.name,
     created_at: keyData.created_at,
   }, 201);

--- a/src/surface/mc/worker/src/routes/ingest.ts
+++ b/src/surface/mc/worker/src/routes/ingest.ts
@@ -5,14 +5,14 @@
  *
  * Request body:
  * {
- *   "operator_id": "andreas",
+ *   "principal_id": "andreas",
  *   "events": [{ event_id, event_type, timestamp, session_id, ... }]
  * }
  */
 
 import { Hono } from "hono";
 import type { Env } from "../index";
-import { requireApiKey, type OperatorKey } from "../auth";
+import { requireApiKey, type PrincipalKey } from "../auth";
 import { processSessionEvent, type ProcessedSessionEvent } from "../../../../../common/event-processor";
 import { extractActivityEntry } from "../../../../../common/event-utils";
 import type {
@@ -23,17 +23,17 @@ import type {
 } from "../../../../../common/types";
 import { invalidateCache } from "./state";
 
-type Variables = { operatorId: string; operatorKey: OperatorKey };
+type Variables = { principalId: string; operatorKey: PrincipalKey };
 
 export const ingestRoutes = new Hono<{ Bindings: Env; Variables: Variables }>();
 
 interface IngestBody {
-  operator_id: string;
+  principal_id: string;
   events: IngestEvent[];
 }
 
 ingestRoutes.post("/api/ingest", requireApiKey, async (c) => {
-  const operatorId = c.get("operatorId");
+  const principalId = c.get("principalId");
 
   let body: IngestBody;
   try {
@@ -50,8 +50,8 @@ ingestRoutes.post("/api/ingest", requireApiKey, async (c) => {
     return c.json({ ok: true, ingested: 0, skipped: 0 });
   }
 
-  // Use the operator_id from the API key, not the request body (trust the key)
-  const effectiveOperatorId = operatorId;
+  // Use the principal_id from the API key, not the request body (trust the key)
+  const effectiveOperatorId = principalId;
 
   let ingested = 0;
   let skipped = 0;
@@ -136,13 +136,13 @@ async function upsertSession(db: D1Database, session: SessionUpsertData): Promis
   const sov = session.sovereignty;
   await db.prepare(`
     INSERT INTO sessions
-    (session_id, operator_id, agent_id, agent_name, project, description, github_issue,
+    (session_id, principal_id, agent_id, agent_name, project, description, github_issue,
      started_at, status, events_count, last_event, last_event_at,
-     classification, data_residency, home_operator)
+     classification, data_residency, home_principal)
     VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'active', 1, ?, ?, ?, ?, ?)
     ON CONFLICT(session_id) DO UPDATE SET
       status = 'active',
-      operator_id = COALESCE(excluded.operator_id, operator_id),
+      principal_id = COALESCE(excluded.principal_id, principal_id),
       agent_name = excluded.agent_name,
       project = COALESCE(excluded.project, project),
       description = COALESCE(excluded.description, description),
@@ -152,10 +152,10 @@ async function upsertSession(db: D1Database, session: SessionUpsertData): Promis
       events_count = events_count + 1,
       classification = COALESCE(excluded.classification, classification),
       data_residency = COALESCE(excluded.data_residency, data_residency),
-      home_operator = COALESCE(excluded.home_operator, home_operator)
+      home_principal = COALESCE(excluded.home_principal, home_principal)
   `).bind(
     session.sessionId,
-    session.operatorId ?? null,
+    session.principalId ?? null,
     session.agentId,
     session.agentName,
     session.project,
@@ -166,7 +166,7 @@ async function upsertSession(db: D1Database, session: SessionUpsertData): Promis
     session.lastEventAt,
     sov?.classification ?? null,
     sov?.dataResidency ?? null,
-    sov?.homeOperator ?? null,
+    sov?.homePrincipal ?? null,
   ).run();
 }
 
@@ -208,13 +208,13 @@ async function insertSessionDirect(
   const sov = session.sovereignty;
   await db.prepare(`
     INSERT OR IGNORE INTO sessions
-    (session_id, operator_id, agent_id, agent_name, project, description, github_issue,
+    (session_id, principal_id, agent_id, agent_name, project, description, github_issue,
      started_at, completed_at, duration_ms, pr_url, status, last_event, last_event_at,
-     classification, data_residency, home_operator)
+     classification, data_residency, home_principal)
     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   `).bind(
     session.sessionId,
-    session.operatorId ?? null,
+    session.principalId ?? null,
     session.agentId,
     session.agentName,
     session.project,
@@ -229,7 +229,7 @@ async function insertSessionDirect(
     session.lastEventAt,
     sov?.classification ?? null,
     sov?.dataResidency ?? null,
-    sov?.homeOperator ?? null,
+    sov?.homePrincipal ?? null,
   ).run();
 }
 
@@ -294,11 +294,11 @@ async function trimActivity(db: D1Database, sessionId: string, keep: number): Pr
 async function insertUsageSnapshot(db: D1Database, snapshot: UsageSnapshotData): Promise<void> {
   await db.prepare(`
     INSERT INTO usage_snapshots
-    (operator_id, source, five_hour_pct, five_hour_resets, seven_day_pct, seven_day_resets,
+    (principal_id, source, five_hour_pct, five_hour_resets, seven_day_pct, seven_day_resets,
      seven_day_opus_pct, seven_day_sonnet_pct, extra_usage_enabled)
     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
   `).bind(
-    snapshot.operatorId ?? null,
+    snapshot.principalId ?? null,
     snapshot.source,
     snapshot.fiveHourPct,
     snapshot.fiveHourResets,

--- a/src/surface/mc/worker/src/routes/ingest.ts
+++ b/src/surface/mc/worker/src/routes/ingest.ts
@@ -23,7 +23,7 @@ import type {
 } from "../../../../../common/types";
 import { invalidateCache } from "./state";
 
-type Variables = { principalId: string; operatorKey: PrincipalKey };
+type Variables = { principalId: string; principalKey: PrincipalKey };
 
 export const ingestRoutes = new Hono<{ Bindings: Env; Variables: Variables }>();
 
@@ -155,7 +155,7 @@ async function upsertSession(db: D1Database, session: SessionUpsertData): Promis
       home_principal = COALESCE(excluded.home_principal, home_principal)
   `).bind(
     session.sessionId,
-    session.principalId ?? null,
+    session.operatorId ?? null,
     session.agentId,
     session.agentName,
     session.project,
@@ -214,7 +214,7 @@ async function insertSessionDirect(
     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   `).bind(
     session.sessionId,
-    session.principalId ?? null,
+    session.operatorId ?? null,
     session.agentId,
     session.agentName,
     session.project,
@@ -298,7 +298,7 @@ async function insertUsageSnapshot(db: D1Database, snapshot: UsageSnapshotData):
      seven_day_opus_pct, seven_day_sonnet_pct, extra_usage_enabled)
     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
   `).bind(
-    snapshot.principalId ?? null,
+    snapshot.operatorId ?? null,
     snapshot.source,
     snapshot.fiveHourPct,
     snapshot.fiveHourResets,

--- a/src/surface/mc/worker/src/routes/ingest.ts
+++ b/src/surface/mc/worker/src/routes/ingest.ts
@@ -51,7 +51,7 @@ ingestRoutes.post("/api/ingest", requireApiKey, async (c) => {
   }
 
   // Use the principal_id from the API key, not the request body (trust the key)
-  const effectiveOperatorId = principalId;
+  const effectivePrincipalId = principalId;
 
   let ingested = 0;
   let skipped = 0;
@@ -66,7 +66,7 @@ ingestRoutes.post("/api/ingest", requireApiKey, async (c) => {
     }
 
     try {
-      const processed = processSessionEvent(effectiveOperatorId, event);
+      const processed = processSessionEvent(effectivePrincipalId, event);
       await persistProcessedEvent(db, processed);
 
       // G-410: Extract and persist activity entry for this event

--- a/src/surface/mc/worker/src/routes/state.ts
+++ b/src/surface/mc/worker/src/routes/state.ts
@@ -34,14 +34,14 @@ export async function buildSnapshot(
   project?: string | null,
   homePrincipal?: string | null,
 ) {
-  const [agents, completions, activity, dailyStats, projects, accountUsage, operatorUsage, homePrincipals] = await Promise.all([
+  const [agents, completions, activity, dailyStats, projects, accountUsage, principalUsage, homePrincipals] = await Promise.all([
     getActiveAgents(db, project, homePrincipal),
     getRecentCompletions(db, project, undefined, homePrincipal),
     getRecentActivity(db, project),
     getDailyStats(db),
     getProjects(db),
     getLatestAccountUsage(db),
-    getPerOperatorUsage(db),
+    getPerPrincipalUsage(db),
     getKnownHomePrincipals(db),
   ]);
 
@@ -55,7 +55,7 @@ export async function buildSnapshot(
     recentActivity: activity,
     stats: { today: dailyStats },
     accountUsage,
-    operatorUsage,
+    principalUsage,
     /**
      * IAW D.5.2 — distinct `home_principal` values observed in recent
      * sessions. The frontend uses this to populate the operator filter
@@ -628,7 +628,7 @@ async function getLatestAccountUsage(db: D1Database) {
   };
 }
 
-async function getPerOperatorUsage(db: D1Database): Promise<Record<string, ReturnType<typeof formatUsageRow>>> {
+async function getPerPrincipalUsage(db: D1Database): Promise<Record<string, ReturnType<typeof formatUsageRow>>> {
   const { results } = await db.prepare(`
     SELECT u.principal_id, u.source, u.five_hour_pct, u.five_hour_resets,
            u.seven_day_pct, u.seven_day_resets, u.seven_day_opus_pct,
@@ -644,8 +644,8 @@ async function getPerOperatorUsage(db: D1Database): Promise<Record<string, Retur
 
   const map: Record<string, ReturnType<typeof formatUsageRow>> = {};
   for (const row of results ?? []) {
-    const opId = row.principal_id as string;
-    map[opId] = formatUsageRow(row);
+    const principalId = row.principal_id as string;
+    map[principalId] = formatUsageRow(row);
   }
   return map;
 }

--- a/src/surface/mc/worker/src/routes/state.ts
+++ b/src/surface/mc/worker/src/routes/state.ts
@@ -23,7 +23,7 @@ const CACHE_TTL_MS = 5_000; // 5s TTL — prevents stale reads across isolates
 /**
  * Build a full (unfiltered) snapshot object from D1.
  *
- * IAW D.5 — `homeOperator` (when supplied) slices the snapshot's `agents`
+ * IAW D.5 — `homePrincipal` (when supplied) slices the snapshot's `agents`
  * and `recentCompletions` lists by the originating operator. The other
  * derived sections (stats, repos, heatmap) stay global because they reflect
  * the receiving operator's totals; per-operator stats are a future slice
@@ -32,17 +32,17 @@ const CACHE_TTL_MS = 5_000; // 5s TTL — prevents stale reads across isolates
 export async function buildSnapshot(
   db: D1Database,
   project?: string | null,
-  homeOperator?: string | null,
+  homePrincipal?: string | null,
 ) {
-  const [agents, completions, activity, dailyStats, projects, accountUsage, operatorUsage, homeOperators] = await Promise.all([
-    getActiveAgents(db, project, homeOperator),
-    getRecentCompletions(db, project, undefined, homeOperator),
+  const [agents, completions, activity, dailyStats, projects, accountUsage, operatorUsage, homePrincipals] = await Promise.all([
+    getActiveAgents(db, project, homePrincipal),
+    getRecentCompletions(db, project, undefined, homePrincipal),
     getRecentActivity(db, project),
     getDailyStats(db),
     getProjects(db),
     getLatestAccountUsage(db),
     getPerOperatorUsage(db),
-    getKnownHomeOperators(db),
+    getKnownHomePrincipals(db),
   ]);
 
   return {
@@ -57,11 +57,11 @@ export async function buildSnapshot(
     accountUsage,
     operatorUsage,
     /**
-     * IAW D.5.2 — distinct `home_operator` values observed in recent
+     * IAW D.5.2 — distinct `home_principal` values observed in recent
      * sessions. The frontend uses this to populate the operator filter
      * dropdown; "Local only" (the default) corresponds to `null` here.
      */
-    homeOperators,
+    homePrincipals,
     updatedAt: new Date().toISOString(),
   };
 }
@@ -208,17 +208,17 @@ export const stateRoutes = new Hono<{ Bindings: Env }>();
 stateRoutes.get("/api/state", async (c) => {
   const db = c.env.GROVE_DB;
   const project = c.req.query("project");
-  // IAW D.5.2 — `?home_operator=<id>` slices the snapshot to a single
-  // originating operator. Sentinel `"local"` means "null home_operator
+  // IAW D.5.2 — `?home_principal=<id>` slices the snapshot to a single
+  // originating operator. Sentinel `"local"` means "null home_principal
   // only" (purely local traffic, no federated stamps) and matches the
   // dashboard's default filter chip.
-  const homeOperator = c.req.query("home_operator");
+  const homePrincipal = c.req.query("home_principal");
 
   // Project-filtered or operator-filtered requests bypass cache (rare).
-  // The cache key would need to grow per-(project, home_operator) tuple
+  // The cache key would need to grow per-(project, home_principal) tuple
   // otherwise; not worth the complexity for the slow path.
-  if (project || homeOperator) {
-    const snapshot = await buildSnapshot(db, project, homeOperator);
+  if (project || homePrincipal) {
+    const snapshot = await buildSnapshot(db, project, homePrincipal);
     return c.json(snapshot);
   }
 
@@ -237,14 +237,14 @@ stateRoutes.get("/api/state", async (c) => {
 async function getActiveAgents(
   db: D1Database,
   project?: string | null,
-  homeOperator?: string | null,
+  homePrincipal?: string | null,
 ) {
   let sql = `
-    SELECT session_id, operator_id, agent_id, agent_name, project, description,
+    SELECT session_id, principal_id, agent_id, agent_name, project, description,
            github_issue, started_at, completed_at, duration_ms, status, pr_url,
            events_count, last_event, last_event_at, progress_completed, progress_total,
            input_tokens, output_tokens, cache_read_tokens, cost_usd,
-           classification, data_residency, home_operator
+           classification, data_residency, home_principal
     FROM sessions
     WHERE (status = 'active' AND last_event_at >= strftime('%Y-%m-%dT%H:%M:%fZ', 'now', '-3 hours'))
       OR (status IN ('completed', 'failed') AND completed_at >= strftime('%Y-%m-%dT%H:%M:%fZ', 'now', '-30 minutes'))
@@ -256,7 +256,7 @@ async function getActiveAgents(
     params.push(project);
   }
 
-  const homeFilter = applyHomeOperatorFilter(homeOperator);
+  const homeFilter = applyHomePrincipalFilter(homePrincipal);
   sql += homeFilter.sql;
   params.push(...homeFilter.params);
 
@@ -271,12 +271,12 @@ async function getActiveAgents(
   return (results ?? []).map((r: Record<string, unknown>) => ({
     id: r.agent_id as string,
     name: r.agent_name as string,
-    operatorId: r.operator_id as string | null,
-    // IAW D.5.3 — surface sovereignty + homeOperator on each agent card.
-    // `homeOperator` defaults to null (purely local traffic); the frontend
+    principalId: r.principal_id as string | null,
+    // IAW D.5.3 — surface sovereignty + homePrincipal on each agent card.
+    // `homePrincipal` defaults to null (purely local traffic); the frontend
     // renders nothing rather than a "local" chip for the null case so the
     // 99% pre-IAW path stays visually unchanged.
-    homeOperator: (r.home_operator as string | null) ?? null,
+    homePrincipal: (r.home_principal as string | null) ?? null,
     sovereignty: buildSovereignty(r),
     status: r.status === "active" ? "active" as const : "completed" as const,
     currentTask: {
@@ -310,13 +310,13 @@ async function getActiveAgents(
 }
 
 /**
- * IAW D.5.2 — translate the `home_operator` query param into a parameterised
+ * IAW D.5.2 — translate the `home_principal` query param into a parameterised
  * SQL fragment for chaining onto a `sessions` WHERE clause.
  *
  *   - `undefined` / `null` / `""` → no slicing (snapshot covers all rows).
- *   - `"local"`                   → `home_operator IS NULL` (purely local
+ *   - `"local"`                   → `home_principal IS NULL` (purely local
  *                                   traffic, the dashboard default chip).
- *   - any other string            → `home_operator = ?` (specific operator).
+ *   - any other string            → `home_principal = ?` (specific operator).
  *
  * Returns `{ sql, params }` rather than mutating in place so the caller's
  * SELECT is constructible without hidden side-effects on a shared array.
@@ -326,15 +326,15 @@ async function getActiveAgents(
  * one place. Adding `"federated"` (all stamped traffic) or `"public"` (a
  * specific classification cut) becomes a one-file change.
  */
-function applyHomeOperatorFilter(homeOperator?: string | null): {
+function applyHomePrincipalFilter(homePrincipal?: string | null): {
   sql: string;
   params: unknown[];
 } {
-  if (homeOperator === "local") {
-    return { sql: ` AND home_operator IS NULL`, params: [] };
+  if (homePrincipal === "local") {
+    return { sql: ` AND home_principal IS NULL`, params: [] };
   }
-  if (homeOperator) {
-    return { sql: ` AND home_operator = ?`, params: [homeOperator] };
+  if (homePrincipal) {
+    return { sql: ` AND home_principal = ?`, params: [homePrincipal] };
   }
   return { sql: "", params: [] };
 }
@@ -348,18 +348,18 @@ function applyHomeOperatorFilter(homeOperator?: string | null): {
 function buildSovereignty(r: Record<string, unknown>): {
   classification: Classification | null;
   dataResidency: string | null;
-  homeOperator: string | null;
+  homePrincipal: string | null;
 } | null {
   const classification = r.classification as Classification | null | undefined;
   const dataResidency = r.data_residency as string | null | undefined;
-  const homeOperator = r.home_operator as string | null | undefined;
-  if (classification == null && dataResidency == null && homeOperator == null) {
+  const homePrincipal = r.home_principal as string | null | undefined;
+  if (classification == null && dataResidency == null && homePrincipal == null) {
     return null;
   }
   return {
     classification: classification ?? null,
     dataResidency: dataResidency ?? null,
-    homeOperator: homeOperator ?? null,
+    homePrincipal: homePrincipal ?? null,
   };
 }
 
@@ -400,12 +400,12 @@ async function getRecentCompletions(
   db: D1Database,
   project?: string | null,
   limit = 50,
-  homeOperator?: string | null,
+  homePrincipal?: string | null,
 ) {
   let sql = `
-    SELECT agent_id, agent_name, operator_id, project, description, duration_ms,
+    SELECT agent_id, agent_name, principal_id, project, description, duration_ms,
            completed_at, pr_url, github_issue, status,
-           classification, data_residency, home_operator
+           classification, data_residency, home_principal
     FROM sessions
     WHERE status IN ('completed', 'failed')
   `;
@@ -416,7 +416,7 @@ async function getRecentCompletions(
     params.push(project);
   }
 
-  const homeFilter = applyHomeOperatorFilter(homeOperator);
+  const homeFilter = applyHomePrincipalFilter(homePrincipal);
   sql += homeFilter.sql;
   params.push(...homeFilter.params);
 
@@ -428,7 +428,7 @@ async function getRecentCompletions(
   return (results ?? []).map((r: Record<string, unknown>) => ({
     agentId: r.agent_id as string,
     agentName: r.agent_name as string,
-    operatorId: r.operator_id as string | null,
+    principalId: r.principal_id as string | null,
     project: r.project as string | null,
     description: r.description as string,
     durationMs: r.duration_ms as number | null,
@@ -437,29 +437,29 @@ async function getRecentCompletions(
     githubIssue: r.github_issue as string | null,
     status: r.status as "completed" | "failed",
     // IAW D.5.3 — sovereignty surface on completions row.
-    homeOperator: (r.home_operator as string | null) ?? null,
+    homePrincipal: (r.home_principal as string | null) ?? null,
     sovereignty: buildSovereignty(r),
   }));
 }
 
 /**
- * IAW D.5.2 — return the distinct, non-null `home_operator` values seen in
+ * IAW D.5.2 — return the distinct, non-null `home_principal` values seen in
  * recent sessions. Powers the dashboard's operator filter dropdown — the
  * frontend prepends "Local only" (default) + "All operators" to this list.
  *
  * Window: same 7-day horizon the heatmap uses, so the dropdown doesn't grow
  * unboundedly with historical federated peers that have gone dark.
  */
-async function getKnownHomeOperators(db: D1Database): Promise<string[]> {
+async function getKnownHomePrincipals(db: D1Database): Promise<string[]> {
   const { results } = await db.prepare(`
-    SELECT DISTINCT home_operator
+    SELECT DISTINCT home_principal
     FROM sessions
-    WHERE home_operator IS NOT NULL
+    WHERE home_principal IS NOT NULL
       AND (last_event_at >= strftime('%Y-%m-%dT%H:%M:%fZ', 'now', '-7 days')
            OR completed_at >= strftime('%Y-%m-%dT%H:%M:%fZ', 'now', '-7 days'))
-    ORDER BY home_operator ASC
+    ORDER BY home_principal ASC
   `).all();
-  return (results ?? []).map((r) => r.home_operator as string);
+  return (results ?? []).map((r) => r.home_principal as string);
 }
 
 async function getRecentActivity(db: D1Database, project?: string | null, limit = 500) {
@@ -630,21 +630,21 @@ async function getLatestAccountUsage(db: D1Database) {
 
 async function getPerOperatorUsage(db: D1Database): Promise<Record<string, ReturnType<typeof formatUsageRow>>> {
   const { results } = await db.prepare(`
-    SELECT u.operator_id, u.source, u.five_hour_pct, u.five_hour_resets,
+    SELECT u.principal_id, u.source, u.five_hour_pct, u.five_hour_resets,
            u.seven_day_pct, u.seven_day_resets, u.seven_day_opus_pct,
            u.seven_day_sonnet_pct, u.extra_usage_enabled, u.recorded_at
     FROM usage_snapshots u
     INNER JOIN (
-      SELECT operator_id, MAX(recorded_at) as max_recorded
+      SELECT principal_id, MAX(recorded_at) as max_recorded
       FROM usage_snapshots
-      WHERE operator_id IS NOT NULL
-      GROUP BY operator_id
-    ) latest ON u.operator_id = latest.operator_id AND u.recorded_at = latest.max_recorded
+      WHERE principal_id IS NOT NULL
+      GROUP BY principal_id
+    ) latest ON u.principal_id = latest.principal_id AND u.recorded_at = latest.max_recorded
   `).all();
 
   const map: Record<string, ReturnType<typeof formatUsageRow>> = {};
   for (const row of results ?? []) {
-    const opId = row.operator_id as string;
+    const opId = row.principal_id as string;
     map[opId] = formatUsageRow(row);
   }
   return map;

--- a/src/surface/mc/worker/src/routes/sync.ts
+++ b/src/surface/mc/worker/src/routes/sync.ts
@@ -9,7 +9,7 @@ import { Hono } from "hono";
 import type { Env } from "../index";
 import { requireApiKey, type PrincipalKey } from "../auth";
 
-type Variables = { principalId: string; operatorKey: PrincipalKey };
+type Variables = { principalId: string; principalKey: PrincipalKey };
 
 export const syncRoutes = new Hono<{ Bindings: Env; Variables: Variables }>();
 

--- a/src/surface/mc/worker/src/routes/sync.ts
+++ b/src/surface/mc/worker/src/routes/sync.ts
@@ -7,9 +7,9 @@
 
 import { Hono } from "hono";
 import type { Env } from "../index";
-import { requireApiKey, type OperatorKey } from "../auth";
+import { requireApiKey, type PrincipalKey } from "../auth";
 
-type Variables = { operatorId: string; operatorKey: OperatorKey };
+type Variables = { principalId: string; operatorKey: PrincipalKey };
 
 export const syncRoutes = new Hono<{ Bindings: Env; Variables: Variables }>();
 

--- a/src/surface/mc/worker/src/user-auth/README.md
+++ b/src/surface/mc/worker/src/user-auth/README.md
@@ -40,7 +40,7 @@ relationship — edit it like any other worker code.
 ## Relationship to the worker's existing `auth.ts`
 
 `src/auth.ts` in the worker is a different surface — operator API-key auth
-(`requireApiKey`, `requireAdmin`, `OperatorKey`) for bot operators posting
+(`requireApiKey`, `requireAdmin`, `PrincipalKey`) for bot operators posting
 to `/api/ingest`. It does not overlap with anything here. The two coexist:
 operator-key auth gates the ingest path; user-auth gates the dashboard
 read path.

--- a/src/surface/mc/ws/types.ts
+++ b/src/surface/mc/ws/types.ts
@@ -1,9 +1,13 @@
 /**
  * Grove Mission Control v2 — WebSocket protocol types.
  *
- * Protocol version: 1. Bumped when breaking changes are made to message
+ * Protocol version: 2. Bumped when breaking changes are made to message
  * shapes. Clients check `protocolVersion` on the `connected` handshake to
  * detect incompatibility.
+ *
+ * v2 (cortex#436): event kinds `operator.input` / `operator.curation` renamed
+ * to `principal.input` / `principal.curation`; identity field `operatorId`
+ * renamed to `principalId`. Clients must read the principal.* kinds.
  */
 
 import type { AssignmentState, BlockReason, McEvent } from "../types";
@@ -14,7 +18,7 @@ import type {
 } from "../db/iterations";
 import type { TaskListItem } from "../db/tasks";
 
-export const WS_PROTOCOL_VERSION = 1;
+export const WS_PROTOCOL_VERSION = 2;
 
 // Data attached to each WebSocket connection
 export interface WsData {


### PR DESCRIPTION
## Summary

The coordinated **Mission Control worker cut** — the breaking, lockstep vocabulary pieces that must ship atomically so the dashboard and backend stay coherent. Closes #447 (PR-R2b), completes the **#448 wire/D1 half** (policy-half is #464), and lands the **§6 eventKinds consumer rename** that is the lockstep part of #450.

Part of cortex#436.

## Why one branch

#447, the #448 wire-half, and #450's eventKinds-consumer rename all touch the same worker files (`state.ts`, `ingest.ts`, `schema.sql`) and **must merge atomically** — if the frontend reads `principal.*` eventKinds the backend doesn't emit yet, the dashboard breaks. Doing them as separate branches would self-conflict.

## What's in scope

**R2b (#447):**
- `operatorId` → `principalId` (worker `state`/`ingest`/`sync` routes + `auth.ts`; JSON wire + vars)
- `operator_id` → `principal_id` (`db/schema.ts`, `worker/schema.sql`, `api/handlers`, `iteration-import`, `types`, `discord-sink`, `stdout-dispatcher`, ~20 MC tests)
- `OperatorKey` → `PrincipalKey` (worker `auth`/`admin`/`ingest`/`sync` + `user-auth/README`)
- eventKinds `operator.input`/`operator.curation` → `principal.input`/`principal.curation` — **producers AND frontend consumers** (the §6 lockstep part of #450)
- **WS protocol bumped v1 → v2** (`ws/types.ts`) — clients must read `principal.*`
- **D1 migration `0004_principal_rename.sql`** — `sessions`/`github_events`/`usage_snapshots` column renames + index recreation. `events`/`tasks` are local SQLite (created fresh from `db/schema.ts`), so no D1 migration for those.

**R2.J wire-half (#448):**
- `SessionSovereignty.home_operator` / `homeOperator` → `home_principal` / `homePrincipal` (`common/types.ts`, `event-processor.ts`, worker `state`/`ingest`/`schema` + `0004`)
- Historical `0003_sovereignty.sql` DDL **left untouched** (it must keep adding `home_operator` on a fresh D1; `0004` then renames it).
- The cluster-A **policy-config** `home_operator` (`policy/types.ts`, `cortex-config`, `migrate-config`) is **NOT** here — that's #464.

## Acceptance criteria

- [x] `grep -rE '\bOperatorKey\b' src/surface/mc/` → 0
- [x] `operator_id` only in historical `0003_sovereignty.sql` + index-name identifiers
- [x] `operator.input`/`operator.curation` → 0 in non-historical paths; no dual-read shape
- [x] `homeOperator` in-memory field → 0 (renamed `homePrincipal`)
- [x] `0004_principal_rename.sql` idempotent-once on a deployed D1
- [x] `bun test src/surface/mc + event-processor` → 1143 pass, 0 fail
- [x] `bunx tsc --noEmit` clean

## Out of scope (pre-flagged)

- **#450 prose sweep** (operator→principal in comments/UI copy across `surface/mc/`, ~286 hits, **non-breaking**) follows as a **separate PR** — kept out so this breaking cut stays reviewable. The lockstep eventKinds-consumer part of #450 is already here.
- **#448 policy-half** is #464 (awaiting @mellanon). #448 closes when both #464 + this land.
- D1 index names `idx_sessions_operator` / `idx_github_operator` kept as-is (cosmetic identifiers indexing `principal_id`; renaming would need no functional change).

## Test plan

- [x] `bunx tsc --noEmit` clean
- [x] `bun test src/surface/mc/` 1143 pass
- [ ] dashboard build (`bun build src/surface/mc/dashboard-v2/index.html …`) — reviewer/deploy step

Closes #447