### PR TITLE
docs(cortex): PR-R13d — operator→principal prose sweep in surface/mc (closes #450)

### DIFF
--- a/src/adapters/slack/__tests__/slack-adapter.test.ts
+++ b/src/adapters/slack/__tests__/slack-adapter.test.ts
@@ -1400,7 +1400,7 @@ describe("SlackAdapter — dedup ring FIFO eviction (cortex#235 r1#11)", () => {
 });
 
 describe("SlackAdapter — surfaceConfig passes surfaceFilter through (cortex#235 r1#11)", () => {
-  test("surfaceFilter is plumbed onto surfaceConfig (operator filter visible to router)", () => {
+  test("surfaceFilter is plumbed onto surfaceConfig (principal filter visible to router)", () => {
     // PayloadFilter is a structured pattern (envelope/payload field
     // matchers), not a callback. The surface-router consumes
     // `surfaceConfig.filter` for the post-subject-match filter step.

--- a/src/surface/mc/__tests__/api.test.ts
+++ b/src/surface/mc/__tests__/api.test.ts
@@ -530,7 +530,7 @@ describe("POST /api/sessions", () => {
   });
 
   // F-20 — `ensureNamedAgent` uses ON CONFLICT(id) DO NOTHING, which is
-  // intentional: once an agent is registered, the operator owns its
+  // intentional: once an agent is registered, the principal owns its
   // display name. Pin that policy with a test so a future contributor
   // doesn't "fix" the no-op-on-update by switching to DO UPDATE SET
   // name = excluded.name. Per Echo's PR-#56 review.
@@ -787,7 +787,7 @@ describe("POST /api/assignments/:id/input", () => {
     );
     expect(res.status).toBe(413);
     const body = await res.json();
-    expect(body.error).toBe("Operator input exceeds the 50 KB limit.");
+    expect(body.error).toBe("Principal input exceeds the 50 KB limit.");
   });
 
   it("returns 413 for multi-byte text whose UTF-8 byte length exceeds the cap", async () => {
@@ -811,7 +811,7 @@ describe("POST /api/assignments/:id/input", () => {
     );
     expect(res.status).toBe(413);
     const body = await res.json();
-    expect(body.error).toBe("Operator input exceeds the 50 KB limit.");
+    expect(body.error).toBe("Principal input exceeds the 50 KB limit.");
   });
 
   it("returns 413 from the upstream body cap on raw bodies larger than the default JSON-body limit", async () => {
@@ -1924,7 +1924,7 @@ describe("PATCH /api/iterations/:id", () => {
     expect(String(body.error)).toMatch(/designing/);
   });
 
-  it("rejects designing → done with the operator-friendly D10 Q1 message", async () => {
+  it("rejects designing → done with the principal-friendly D10 Q1 message", async () => {
     seedIter("i-1", "designing");
     const res = await fetch(`${t.baseUrl}/api/iterations/i-1`, {
       method: "PATCH",

--- a/src/surface/mc/__tests__/config.test.ts
+++ b/src/surface/mc/__tests__/config.test.ts
@@ -45,7 +45,7 @@ describe("mission-control config", () => {
     const configPath = join(tmpDir, "mc.yaml");
     writeFileSync(configPath, "port: [\ninvalid yaml\n");
     // Spec NFR: "exit with clear error message including the parse error".
-    // The thrown message must contain both the filename (so the operator
+    // The thrown message must contain both the filename (so the principal
     // knows WHICH config blew up) and parse-error context (so they can fix it).
     expect(() => loadConfig(configPath)).toThrow(/Malformed YAML/);
     expect(() => loadConfig(configPath)).toThrow(/mc\.yaml/);

--- a/src/surface/mc/__tests__/db-init.test.ts
+++ b/src/surface/mc/__tests__/db-init.test.ts
@@ -53,7 +53,7 @@ describe("initDatabase", () => {
   // Spec NFR: "On database path unwritable: exit with clear error message".
   // Forcing a non-writable parent: place a regular file at the path that
   // would need to become a directory. mkdirSync(parent, recursive: true)
-  // then throws ENOTDIR — the error must carry the path so the operator
+  // then throws ENOTDIR — the error must carry the path so the principal
   // knows what's wrong.
   it("throws when the db path's parent is unwritable, with the path in the message", () => {
     mkdirSync(tmpDir, { recursive: true });
@@ -69,7 +69,7 @@ describe("initDatabase", () => {
     }
     expect(err).toBeDefined();
     // The underlying syscall error includes the offending path — verify it
-    // surfaces so the operator can act.
+    // surfaces so the principal can act.
     expect((err as Error).message).toContain(blocker);
   });
 });

--- a/src/surface/mc/__tests__/discord-sink.test.ts
+++ b/src/surface/mc/__tests__/discord-sink.test.ts
@@ -234,7 +234,7 @@ describe("maybeNotifyDiscord — Decision 7 per-assignment dedup (5 s window)", 
   // assignmentId alone to (assignmentId, toState, blockReason.kind), so a
   // `blocked` followed by a real `failed` for the same assignment within
   // the 5 s window must NOT be silenced. We probe the DM surface (which
-  // has its own per-operator coalesce buffer) because the channel-side
+  // has its own per-principal coalesce buffer) because the channel-side
   // coalesce buffer would collapse the two events into one summary by
   // design — the dedup-key narrowing is what lets the *failed* event
   // reach the buffer at all.
@@ -309,10 +309,10 @@ describe("maybeNotifyDiscord — Decision 7 per-assignment dedup (5 s window)", 
   });
 });
 
-describe("maybeNotifyDiscord — Decision 7 per-operator coalescing (3 s window)", () => {
+describe("maybeNotifyDiscord — Decision 7 per-principal coalescing (3 s window)", () => {
   beforeEach(() => __resetDiscordSinkState());
 
-  it("two distinct assignments for the same operator collapse into one summary DM", async () => {
+  it("two distinct assignments for the same principal collapse into one summary DM", async () => {
     const notifier = new FakeNotifier();
     const scheduler = new FakeScheduler();
     const deps: MaybeNotifyDeps = { config: baseConfig, notifier, scheduler };

--- a/src/surface/mc/__tests__/index.test.ts
+++ b/src/surface/mc/__tests__/index.test.ts
@@ -11,7 +11,7 @@ import { tmpdir } from "os";
  *
  * Library-level tests in config/server/db-init verify the throws + clarity.
  * These integration tests verify the entry point catches them and exits 1
- * with a `[mission-control] FATAL: ...` message — no raw stack to operator.
+ * with a `[mission-control] FATAL: ...` message — no raw stack to principal.
  */
 
 const ENTRY = new URL("../index.ts", import.meta.url).pathname;

--- a/src/surface/mc/__tests__/iteration-import-endpoints.test.ts
+++ b/src/surface/mc/__tests__/iteration-import-endpoints.test.ts
@@ -2,7 +2,7 @@
  * F-17 — endpoint tests for the GitHub iteration auto-import surface.
  *
  * Two routes:
- *   POST /api/iterations/from-github — operator-driven import via gh CLI
+ *   POST /api/iterations/from-github — principal-driven import via gh CLI
  *   POST /api/github/webhook         — HMAC-validated upstream stream
  *
  * The harness mirrors `task-create-endpoints.test.ts` (FakeGh + real
@@ -219,7 +219,7 @@ describe("POST /api/iterations/from-github", () => {
 
   it("returns 200 + kind='exists' on idempotent re-import (no body change)", async () => {
     // The handler always calls gh (see Echo's M2 — no pre-flight
-    // short-circuit, so backfill on operator demand can refresh stale
+    // short-circuit, so backfill on principal demand can refresh stale
     // imported_body snapshots after a missed webhook). Both calls
     // therefore need a canned response.
     t.gh.push({ exitCode: 0, stdout: ITERATION_ISSUE_BODY, stderr: "" });
@@ -246,8 +246,8 @@ describe("POST /api/iterations/from-github", () => {
   });
 
   it("refreshes imported_body on backfill when upstream body has changed (M2)", async () => {
-    // Headline use case for the operator-driven path — webhook delivery
-    // missed, upstream body has since drifted, operator manually
+    // Headline use case for the principal-driven path — webhook delivery
+    // missed, upstream body has since drifted, principal manually
     // re-imports to recover the audit snapshot. Pre-M2 this was a
     // silent no-op; post-M2 the snapshot refreshes and bodyRefreshed
     // flips to true so the dashboard can surface the divergence.
@@ -286,7 +286,7 @@ describe("POST /api/iterations/from-github", () => {
     const refreshed = await r2.json();
     expect(refreshed.kind).toBe("exists");
     expect(refreshed.bodyRefreshed).toBe(true);
-    // Decision 9 — `body` is operator-editable so it stays at v1 even
+    // Decision 9 — `body` is principal-editable so it stays at v1 even
     // though upstream is now v2; only `imported_body` (the audit-only
     // snapshot) tracks upstream.
     expect(refreshed.iteration.body).toBe("v1 — initial draft");
@@ -521,7 +521,7 @@ describe("POST /api/github/webhook — auth + dispatch", () => {
     expect(after).toBe(1); // intentionally not deleted
   });
 
-  it("issues.edited refreshes imported_body but not the operator's body (Decision 9)", async () => {
+  it("issues.edited refreshes imported_body but not the principal's body (Decision 9)", async () => {
     // Seed.
     await postWebhook(t, "issues", {
       action: "labeled",
@@ -536,7 +536,7 @@ describe("POST /api/github/webhook — auth + dispatch", () => {
       repository: { full_name: "x/y", name: "y", owner: { login: "x" } },
     });
 
-    // Operator edits the live body via PATCH.
+    // Principal edits the live body via PATCH.
     const row = t.db
       .query(`SELECT id FROM iterations LIMIT 1`)
       .get() as { id: string };
@@ -545,7 +545,7 @@ describe("POST /api/github/webhook — auth + dispatch", () => {
       {
         method: "PATCH",
         headers: { "content-type": "application/json" },
-        body: JSON.stringify({ body: "operator's notes" }),
+        body: JSON.stringify({ body: "principal's notes" }),
       }
     );
     expect(patchRes.status).toBe(200);
@@ -566,7 +566,7 @@ describe("POST /api/github/webhook — auth + dispatch", () => {
     const after = t.db
       .query(`SELECT body, imported_body FROM iterations WHERE id = ?`)
       .get(row.id) as { body: string | null; imported_body: string | null };
-    expect(after.body).toBe("operator's notes");
+    expect(after.body).toBe("principal's notes");
     expect(after.imported_body).toBe("v2 upstream rewrite");
   });
 

--- a/src/surface/mc/__tests__/iteration-import.test.ts
+++ b/src/surface/mc/__tests__/iteration-import.test.ts
@@ -9,8 +9,8 @@
  * Decision references (see docs/design-mc-iteration-planning.md):
  *   D1  — Grove owns the lifecycle. Source is import-only.
  *   D2  — GitHub parent-issue + sub-issues IS the iteration.
- *   D5  — Operator-driven promotion only (auto-import lands in inbox).
- *   D9  — No write-back; subsequent operator edits never overwritten.
+ *   D5  — Principal-driven promotion only (auto-import lands in inbox).
+ *   D9  — No write-back; subsequent principal edits never overwritten.
  *   D10 Q6 — explicit `iteration` label (configurable per-network).
  */
 
@@ -102,7 +102,7 @@ describe("hasIterationLabel", () => {
   });
 
   it("is case-sensitive (Iteration ≠ iteration)", () => {
-    // Intentional — GitHub labels are case-preserving and the operator
+    // Intentional — GitHub labels are case-preserving and the principal
     // must apply the exact label string they configured.
     expect(hasIterationLabel(["Iteration"])).toBe(false);
   });
@@ -223,9 +223,9 @@ describe("importIterationFromMetadata", () => {
     const first = importIterationFromMetadata(h.db, makeMeta());
     if (first.kind !== "created") throw new Error("expected created");
 
-    // Operator edits the live body — Decision 9 says this MUST NOT be
+    // Principal edits the live body — Decision 9 says this MUST NOT be
     // clobbered by subsequent upstream changes.
-    updateIteration(h.db, first.iteration.id, { body: "operator's notes" });
+    updateIteration(h.db, first.iteration.id, { body: "principal's notes" });
 
     // Upstream issue body is rewritten on GitHub. Webhook fires → re-import.
     const second = importIterationFromMetadata(
@@ -237,11 +237,11 @@ describe("importIterationFromMetadata", () => {
     expect(second.bodyRefreshed).toBe(true);
 
     // Audit-only `imported_body` follows upstream; live `body` stays
-    // operator-sovereign.
+    // principal-sovereign.
     const detail = getIteration(h.db, first.iteration.id);
     expect(detail).not.toBeNull();
     expect(detail!.imported_body).toBe("totally rewritten upstream");
-    expect(detail!.body).toBe("operator's notes");
+    expect(detail!.body).toBe("principal's notes");
   });
 
   it("does NOT touch updated_at on a true no-op re-import", () => {
@@ -414,7 +414,7 @@ describe("importSubIssueFromMetadata", () => {
     if (a.kind !== "attached") throw new Error("expected attached");
     expect(a.iterationId).not.toBe(second.iteration.id);
 
-    // Re-import shifts the same task under parent #99 (operator
+    // Re-import shifts the same task under parent #99 (principal
     // re-parented on GitHub; we follow).
     const b = importSubIssueFromMetadata(
       h.db,

--- a/src/surface/mc/__tests__/iterations.test.ts
+++ b/src/surface/mc/__tests__/iterations.test.ts
@@ -652,7 +652,7 @@ describe("F-15 — state-transition-via-updateIteration", () => {
 });
 
 describe("canTransitionServer / nextStatesServer (F-15)", () => {
-  it("rejects designing → done per Decision 10 Q1 (operator-driven done deferred to Phase G)", () => {
+  it("rejects designing → done per Decision 10 Q1 (principal-driven done deferred to Phase G)", () => {
     expect(canTransitionServer("designing", "done")).toBe(false);
     expect(canTransitionServer("queued", "done")).toBe(false);
     expect(canTransitionServer("inbox", "done")).toBe(false);
@@ -663,7 +663,7 @@ describe("canTransitionServer / nextStatesServer (F-15)", () => {
     expect(canTransitionServer("blocked", "done")).toBe(true);
   });
 
-  it("allows operator cancel from every non-terminal state", () => {
+  it("allows principal cancel from every non-terminal state", () => {
     for (const s of ITERATION_STATES) {
       if (s === "done" || s === "cancelled") continue;
       expect(canTransitionServer(s, "cancelled")).toBe(true);

--- a/src/surface/mc/__tests__/server.test.ts
+++ b/src/surface/mc/__tests__/server.test.ts
@@ -99,7 +99,7 @@ describe("mission-control server", () => {
   // Spec NFR: "On port already in use: exit with clear error message naming the port".
   // The first server is bound by beforeAll on testPort — a second startServer on
   // the same port must throw, and the error must mention the port number so the
-  // operator knows what to override.
+  // principal knows what to override.
   it("throws when starting on a port already in use, with the port in the message", () => {
     let err: unknown;
     try {

--- a/src/surface/mc/__tests__/should-notify.test.ts
+++ b/src/surface/mc/__tests__/should-notify.test.ts
@@ -264,7 +264,7 @@ describe("shouldNotify — blocked, tool.error", () => {
 });
 
 describe("shouldNotify — blocked, review.checkpoint", () => {
-  it("P0 → DM only, no ping (operator opted in)", () => {
+  it("P0 → DM only, no ping (principal opted in)", () => {
     const intent = shouldNotify({
       from: "running",
       to: "blocked",

--- a/src/surface/mc/__tests__/task-create-endpoints.test.ts
+++ b/src/surface/mc/__tests__/task-create-endpoints.test.ts
@@ -3,7 +3,7 @@
  *
  * Exercises the three new endpoints (preview / create / abandon-task)
  * against a real Bun.serve instance with a fake `gh` CLI. The fake spawn
- * returns a canned JSON response so tests don't depend on the operator's
+ * returns a canned JSON response so tests don't depend on the principal's
  * `gh auth` state or network.
  *
  * Decisions referenced inline:
@@ -416,12 +416,12 @@ describe("POST /api/tasks", () => {
       body: JSON.stringify({
         ref: "the-metafactory/grove-v2#42",
         priority: 2,
-        titleOverride: "operator override",
+        titleOverride: "principal override",
       }),
     });
     expect(res.status).toBe(201);
     const body = await res.json();
-    expect(body.title).toBe("operator override");
+    expect(body.title).toBe("principal override");
   });
 
   it("returns 409 conflict when racing the dedup window after preview", async () => {

--- a/src/surface/mc/api/github-fetch.ts
+++ b/src/surface/mc/api/github-fetch.ts
@@ -3,10 +3,10 @@
  *
  * Reuses Grove's existing `gh` CLI path (see `src/bot/lib/github-sync.ts`'s
  * `ghJsonArgs`) rather than introducing `@octokit/rest`. No new dependency,
- * operator's existing `gh auth login` is the trust root.
+ * principal's existing `gh auth login` is the trust root.
  *
  * Design addendum `docs/design-mc-f12b-add-to-queue.md`:
- *   - Decision 3 — `gh` CLI via `Bun.spawn`, operator-frequency only.
+ *   - Decision 3 — `gh` CLI via `Bun.spawn`, principal-frequency only.
  *   - Decision 6 — maps 401/403/404/5xx / timeout / parse errors into
  *     discriminated error kinds the handler translates to HTTP status.
  *   - Decision 9 — 30-second spawn timeout; spinner clears and the form
@@ -14,7 +14,7 @@
  *
  * SSRF posture: argv is statically constructed from a caller-validated
  * `{owner, repo, number}` triple — no shell interpolation, no
- * operator-controlled hostname. The `gh` CLI resolves `api.github.com`
+ * principal-controlled hostname. The `gh` CLI resolves `api.github.com`
  * from `gh auth` config.
  */
 

--- a/src/surface/mc/api/handlers.ts
+++ b/src/surface/mc/api/handlers.ts
@@ -221,7 +221,7 @@ export interface ApiDeps {
 
 const DEFAULT_AGENT_ID = "mc-default-agent";
 const DEFAULT_AGENT_NAME = "Mission Control default";
-const DEFAULT_OPERATOR_ID = "mc-default-principal";
+const DEFAULT_OPERATOR_ID = "mc-default-operator";
 /**
  * Default priority for `internal`-source tasks created via POST /api/sessions.
  * Used by the INSERT below AND `buildNotificationContextFromCreate` — a

--- a/src/surface/mc/api/handlers.ts
+++ b/src/surface/mc/api/handlers.ts
@@ -8,7 +8,7 @@
  *   GET  /api/working-agents                 — agent-keyed feed (F-9 grid)
  *   GET  /api/assignments/:id/events         — paged event feed (F-7 drill-down)
  *   POST /api/sessions                       — spawn a new controlled session
- *   POST /api/assignments/:id/input          — write an operator turn
+ *   POST /api/assignments/:id/input          — write a principal turn
  *
  * Handlers are pure functions over `ApiDeps`. The server owns HTTP framing
  * (routing, method/status, JSON parsing) and defers business logic here.
@@ -177,7 +177,7 @@ export interface ApiDeps {
   /**
    * F-12b Decision 4 — optional default `owner/repo` used to resolve the
    * `#N` and `repo#N` shorthand forms in the URL parser. When absent, those
-   * shorthands fail parse with a clear message (operator has to use the
+   * shorthands fail parse with a clear message (principal has to use the
    * full `owner/repo#N` form).
    *
    * Format: the raw YAML value `"owner/repo"`. Split on the first `/` at
@@ -211,7 +211,7 @@ export interface ApiDeps {
    * `x-hub-signature-256` header against this secret using HMAC-SHA256.
    * When absent, the route 503s — there is no implicit bypass.
    *
-   * Source: same secret the existing `webhook-proxy` uses (operator's
+   * Source: same secret the existing `webhook-proxy` uses (principal's
    * `GITHUB_WEBHOOK_SECRET`). Kept separate from the bot's network
    * config so the mission-control surface can be rotated independently
    * if ever needed.
@@ -221,7 +221,7 @@ export interface ApiDeps {
 
 const DEFAULT_AGENT_ID = "mc-default-agent";
 const DEFAULT_AGENT_NAME = "Mission Control default";
-const DEFAULT_OPERATOR_ID = "mc-default-operator";
+const DEFAULT_OPERATOR_ID = "mc-default-principal";
 /**
  * Default priority for `internal`-source tasks created via POST /api/sessions.
  * Used by the INSERT below AND `buildNotificationContextFromCreate` — a
@@ -504,7 +504,7 @@ export function handleListEvents(
 
 /**
  * Ensure the well-known default agent row exists. Idempotent — safe to call
- * on every POST /api/sessions. Phase E will introduce operator-specified
+ * on every POST /api/sessions. Phase E will introduce principal-specified
  * agents; until then a single shared agent is sufficient to satisfy the
  * agent_task_assignment FK.
  */
@@ -519,11 +519,11 @@ function ensureDefaultAgent(db: Database): string {
 
 /**
  * F-20 — register an agent by id idempotently. Used by `local.observed`
- * sessions where the wrapper supplies the operator's identity (e.g.
+ * sessions where the wrapper supplies the principal's identity (e.g.
  * `agentId: 'andreas'`, `agentName: 'Andreas'`) which may not exist in
  * the agents table yet. The first observed call lands the row;
  * subsequent calls are no-ops. `name` is only applied on insert — once
- * an agent is registered, the operator owns its display name.
+ * an agent is registered, the principal owns its display name.
  */
 function ensureNamedAgent(
   db: Database,
@@ -541,13 +541,13 @@ function ensureNamedAgent(
 
 // F-19 Decision 5 — server-side dispatch debounce.
 //
-// Cross-tab two-click protection: when an operator opens MC v2 in two
+// Cross-tab two-click protection: when a principal opens MC v2 in two
 // browser tabs and clicks Dispatch on the same task in both, the
 // per-tab UI gate (button-disabled-while-busy) doesn't help — each
 // tab has independent state. Without server-side gating each POST
 // would call `spawnControlledSession` → `Bun.spawn` → a fresh CC
 // subprocess and pay the full boot-prompt token cost twice for what
-// the operator experienced as one click.
+// the principal experienced as one click.
 //
 // Implementation: a tiny per-process Map keyed by `taskId|agentId`
 // remembers the assignment id created by a recent successful POST.
@@ -555,7 +555,7 @@ function ensureNamedAgent(
 // assignment id — the dashboard hook treats this as success and
 // refetches. Memory-only (cleared on restart, lost on crash); 2 s is
 // well above any legitimate human double-click round-trip and well
-// below any "second operator dispatched the same task on purpose"
+// below any "second principal dispatched the same task on purpose"
 // interval.
 const DISPATCH_DEBOUNCE_MS = 2_000;
 interface DispatchDebounceEntry {
@@ -651,7 +651,7 @@ export async function handleCreateSession(
   // fresh task per call so debounce-by-task-id is a non-sequitur there).
   //
   // The lock is RELEASED on the spawn-failure rollback path below so the
-  // operator can retry without waiting 2s after a transient failure.
+  // principal can retry without waiting 2s after a transient failure.
   let debounceKey: string | null = null;
   if (body.taskId) {
     const key = dispatchDebounceKey(taskId, agentId);
@@ -694,7 +694,7 @@ export async function handleCreateSession(
   try {
     insertRows();
   } catch (err) {
-    // Release the soft-lock so the operator can retry without 2s wait.
+    // Release the soft-lock so the principal can retry without 2s wait.
     if (debounceKey !== null) dispatchDebounce.delete(debounceKey);
     return error(
       `Failed to create assignment: ${(err as Error).message}`,
@@ -792,7 +792,7 @@ export async function handleCreateSession(
           `[api] rollback after spawn-failure failed: ${(rollbackErr as Error).message}\n`
         );
       }
-      // Release the soft-lock so the operator can retry without 2s wait.
+      // Release the soft-lock so the principal can retry without 2s wait.
       if (debounceKey !== null) dispatchDebounce.delete(debounceKey);
       const status = err instanceof SessionConflict ? 409 : 500;
       return error(`Spawn failed: ${(err as Error).message}`, status);
@@ -857,7 +857,7 @@ export async function handleCreateSession(
   // F-12 Decision 9 + Scope Summary — emit an `principal.curation` event with
   // `kind: "dispatch"` so the manual-dispatch path (POST /api/sessions) lands
   // in the audit trail alongside requeue / handoff / abandon. The event
-  // anchors to the newly-spawned session and captures the agent the operator
+  // anchors to the newly-spawned session and captures the agent the principal
   // dispatched to; `newAssignmentId` is included for symmetry with the
   // handoff variant (the "assignment this spawn created").
   const dispatchCurationEvent = createPrincipalCurationEvent(
@@ -871,7 +871,7 @@ export async function handleCreateSession(
   );
   broadcastEvent(deps.wsRegistry, endpoint.sessionId, dispatchCurationEvent);
 
-  // Optional initial operator turn — controlled sessions only. Observed
+  // Optional initial principal turn — controlled sessions only. Observed
   // sessions don't have a writable stdin (the wrapper's TTY owns it);
   // a `prompt` field on an observed POST is silently ignored.
   if (
@@ -888,7 +888,7 @@ export async function handleCreateSession(
       broadcastEvent(deps.wsRegistry, endpoint.sessionId, event);
     } catch (err) {
       // Don't fail the whole create-session call — the session is spawned
-      // and the operator can retry via POST /api/assignments/:id/input.
+      // and the principal can retry via POST /api/assignments/:id/input.
       process.stderr.write(
         `[api] initial prompt write failed for ${assignmentId}: ${(err as Error).message}\n`
       );
@@ -951,7 +951,7 @@ function taskShortRef(taskId: string): string {
 // ---------- POST /api/assignments/:id/input ----------
 
 /**
- * Server-side cap on operator input payload size, measured in UTF-8 bytes.
+ * Server-side cap on principal input payload size, measured in UTF-8 bytes.
  *
  * Name mirrors the client-side `DRILL_INPUT_MAX_BYTES` in the drill-down input
  * (F-10 Decision 2) so the shared 50 KB bound is obvious from grep alone; the
@@ -1014,7 +1014,7 @@ export function handleSendInput(
   const text = hasText ? body.text ?? "" : "";
   const textByteLength = Buffer.byteLength(text, "utf8");
   if (textByteLength > DRILL_INPUT_MAX_BYTES) {
-    return error("Operator input exceeds the 50 KB limit.", 413);
+    return error("Principal input exceeds the 50 KB limit.", 413);
   }
 
   // --- image validation ---
@@ -1194,7 +1194,7 @@ function readReason(rawBody: unknown): {
   if (typeof reason !== "string") {
     return { err: error("'reason' must be a string", 400) };
   }
-  // Same 50 KB cap principal.input uses — operator-authored free-text.
+  // Same 50 KB cap principal.input uses — principal-authored free-text.
   if (Buffer.byteLength(reason, "utf8") > DRILL_INPUT_MAX_BYTES) {
     return { err: error("'reason' exceeds the 50 KB limit", 413) };
   }
@@ -1390,7 +1390,7 @@ export function handleAbandonAssignment(
   // Caller may force a scope explicitly. `scope: "task"` on a non-terminal
   // assignment is currently rejected (Decision 5 says abandon-the-task is
   // for "no active assignment"; F-12 keeps the assignment-keyed surface
-  // strict — the operator should cancel the assignment first or wait for
+  // strict — the principal should cancel the assignment first or wait for
   // it to settle). `scope: "assignment"` on a terminal assignment is
   // rejected by the state machine itself ("No transitions from terminal
   // state").
@@ -1460,7 +1460,7 @@ export function handleAbandonAssignment(
   // scope === "task"
   // Decision 5 — abandon-the-task: only legal when no active assignment is
   // in flight. F-12 keeps this strict to the assignment-keyed surface — if
-  // the assignment row is non-terminal, the operator should cancel the
+  // the assignment row is non-terminal, the principal should cancel the
   // assignment explicitly first (or use the inferred-scope default which
   // routes to scope=assignment).
   if (!assignmentTerminal) {
@@ -1620,7 +1620,7 @@ export async function handleHandoffAssignment(
     // `fireCancelObserver` would otherwise do post-spawn; running it up
     // front pins the invariant instead of racing it. Best-effort: errors
     // are logged to stderr but don't abort the hand-off (the DB cancel has
-    // already committed; the new spawn must still happen so the operator
+    // already committed; the new spawn must still happen so the principal
     // isn't left with neither side running).
     try {
       await createControlledEndpoint(
@@ -1714,7 +1714,7 @@ export async function handleHandoffAssignment(
 
   // Decision 9 — principal.curation event with `kind: "handoff"` on the NEW
   // session. The cancel of the old assignment has its own `state.transition`
-  // event on the OLD session; this curation event captures the operator
+  // event on the OLD session; this curation event captures the principal
   // rationale for the hand-off as a whole.
   const curationEvent = createPrincipalCurationEvent(db, endpoint.sessionId, {
     kind: "handoff",
@@ -1977,7 +1977,7 @@ export async function handleCreateTask(
   }
 
   // Full preview-flow re-run (parse + dedup + fetch). Decision 6 spells this
-  // out as "defense-in-depth: if the operator races the dedup window
+  // out as "defense-in-depth: if the principal races the dedup window
   // between preview and submit, they get the same error here".
   const flow = await runPreviewFlow(db, deps, body.ref);
   if (!flow.ok) return flow.response;
@@ -2094,7 +2094,7 @@ export function handleAbandonTask(
     return error(`Task '${taskId}' is already cancelled`, 409);
   }
 
-  // Reject if there's a non-shadow, non-terminal assignment — the operator
+  // Reject if there's a non-shadow, non-terminal assignment — the principal
   // should cancel that assignment first (via the assignment-keyed route) or
   // let it settle. Mirrors F-12's task-scope branch invariant.
   const blocker = db
@@ -2132,7 +2132,7 @@ export function handleAbandonTask(
   if (!sessionRow) {
     // Pre-F-12b tasks (internal-source) that never ran any assignment fall
     // here — no session exists to anchor the event FK. Refuse rather than
-    // fabricating one; the operator can still cancel the task row by other
+    // fabricating one; the principal can still cancel the task row by other
     // means (direct SQL or a future internal-source curation route).
     return error(
       `Task '${taskId}' has no session to anchor curation event`,
@@ -2199,7 +2199,7 @@ export function handleAbandonTask(
 //   D5  — designing → queued is "Promote"; cancellation is the explicit destructive path
 //   D8  — endpoint shapes (this file)
 //   D9  — no write-back to source
-//   D10 Q1 — operator-driven `done` from non-`in_flight`/non-`blocked`
+//   D10 Q1 — principal-driven `done` from non-`in_flight`/non-`blocked`
 //            states is REJECTED in v1 (Phase G feature). The matrix in
 //            `db/iterations.ts#canTransitionServer` enforces this; the
 //            handler wraps the rejection with a friendlier message
@@ -2369,7 +2369,7 @@ export function handleCreateIteration(
       source_system: (body.source_system) ?? null,
       source_url: (body.source_url) ?? null,
       source_parent_ref: (body.source_parent_ref) ?? null,
-      // `imported_at` is set by F-17 during real imports; for operator-
+      // `imported_at` is set by F-17 during real imports; for principal-
       // typed iterations it's null. Leaving it out of the create body
       // keeps the wire surface honest about what callers should provide.
       imported_at: null,
@@ -2398,7 +2398,7 @@ export function handleCreateIteration(
 
 /**
  * Iteration ids share the `generateId` ULID-ish shape with tasks /
- * sessions / events. Prefixing with `it-` would be operator-friendly
+ * sessions / events. Prefixing with `it-` would be principal-friendly
  * but breaks the existing `generateId` invariant ("opaque to callers");
  * keep parity with the rest of the schema.
  */
@@ -2484,7 +2484,7 @@ export function handlePatchIteration(
     const proposed = body.state;
     if (proposed !== current.state) {
       // canTransitionServer rejects the (current, proposed) move.
-      // Friendly message names the legal next states so the operator
+      // Friendly message names the legal next states so the principal
       // sees the right escape hatch (almost always `cancel`).
       if (!canTransitionServer(current.state, proposed)) {
         const allowed = nextStatesServer(current.state);
@@ -2494,11 +2494,11 @@ export function handlePatchIteration(
             : `allowed next states: ${allowed.join(", ")}`;
         // D10 Q1 — special-case `* → done` from non-{in_flight,blocked}
         // with a copy that names `cancel` as the v1 alternative. Avoids
-        // the operator interpreting "you can't ship this iteration"
+        // the principal interpreting "you can't ship this iteration"
         // as a bug and re-trying.
         const isDoneAttempt = proposed === "done";
         const detail = isDoneAttempt
-          ? "iteration must reach in_flight before it can complete; cancel it instead if the work is no longer needed (operator-driven done is a Phase G feature)"
+          ? "iteration must reach in_flight before it can complete; cancel it instead if the work is no longer needed (principal-driven done is a Phase G feature)"
           : `transition '${current.state}' → '${proposed}' is not legal`;
         return error(`${detail}; ${allowedClause}`, 400);
       }
@@ -2625,7 +2625,7 @@ export function handleAttachTaskToIteration(
     // this, two concurrent attaches racing through the gate both pass
     // (`attachTask` is permissive at the DB layer per
     // `iterations.test.ts:608` — it overwrites the FK silently); last
-    // write wins and the operator-visible 1:N invariant is violated.
+    // write wins and the principal-visible 1:N invariant is violated.
     // The transaction also keeps the post-attach `touchIteration`
     // atomic with the write, so a partial-success can't leave the
     // iteration with a fresh tasks row but stale `updated_at`.
@@ -2644,7 +2644,7 @@ export function handleAttachTaskToIteration(
         }
         if (link.iterationId !== null && link.iterationId !== iterationId) {
           // Decision 3 — task contributing to two iterations is the
-          // operator's signal to clone, not to model nesting. Refuse
+          // principal's signal to clone, not to model nesting. Refuse
           // with the existing iteration id so the dashboard can offer
           // a "detach and re-attach" affordance instead of silently
           // overwriting.
@@ -2721,7 +2721,7 @@ export function handleAttachTaskToIteration(
     const newTaskId = generateId();
     mutatedTaskId = newTaskId;
     try {
-      // Internal-only source — operator-typed-direct-into-iteration.
+      // Internal-only source — principal-typed-direct-into-iteration.
       // Mirrors the F-12b CreateSession internal-task INSERT shape.
       // Per Echo grove-v2#42 (Major 2) — the touch is now inside the
       // same transaction so create-and-touch land atomically.
@@ -2876,7 +2876,7 @@ export function handleDetachTaskFromIteration(
 //
 // Two surfaces:
 //   handleImportIterationFromGithub  — POST /api/iterations/from-github
-//                                       (operator-driven, gh CLI, 200/201/400/404/409)
+//                                       (principal-driven, gh CLI, 200/201/400/404/409)
 //   handleGithubWebhook              — POST /api/github/webhook
 //                                       (HMAC-validated upstream stream;
 //                                        delegates to iteration-import.ts)
@@ -2884,15 +2884,15 @@ export function handleDetachTaskFromIteration(
 // Decisions referenced inline (see docs/design-mc-iteration-planning.md):
 //   D1  — Grove owns the lifecycle. Source is import-only.
 //   D2  — GitHub parent-issue + sub-issues IS the iteration.
-//   D5  — Operator-driven promotion only (auto-import lands in `inbox`).
+//   D5  — Principal-driven promotion only (auto-import lands in `inbox`).
 //   D7  — GitHub-only in v1.
-//   D9  — No write-back; subsequent operator edits never overwritten.
+//   D9  — No write-back; subsequent principal edits never overwritten.
 //   D10 Q6 — explicit `iteration` label (configurable per-network).
 
 const IMPORT_FROM_GITHUB_KEYS = ["ref", "label"] as const;
 
 /**
- * F-17 — operator-driven import. Mirrors F-12b's `POST /api/tasks` shape:
+ * F-17 — principal-driven import. Mirrors F-12b's `POST /api/tasks` shape:
  * parse the ref → fetch via gh CLI → run the import logic → return the
  * canonical iteration detail.
  *
@@ -2904,7 +2904,7 @@ const IMPORT_FROM_GITHUB_KEYS = ["ref", "label"] as const;
  *     F-12b uses)
  *   - 409 the issue exists but isn't carrying the iteration label —
  *     returns the canonical ref + a friendly message naming the label
- *     so the operator can apply it via GitHub and retry.
+ *     so the principal can apply it via GitHub and retry.
  */
 export async function handleImportIterationFromGithub(
   db: Database,
@@ -2943,16 +2943,16 @@ export async function handleImportIterationFromGithub(
   }
   const canonical = canonicalRef(parsed);
 
-  // No pre-flight short-circuit on `existingByRef`. The operator-driven
+  // No pre-flight short-circuit on `existingByRef`. The principal-driven
   // path is a backfill surface — its headline use case is recovering when
   // a webhook delivery was missed (network blip, secret rotation gap,
   // restart) and the upstream body has since changed. Skipping the gh
   // fetch when a row already exists would lock out that recovery: every
   // re-import would return `bodyRefreshed: false` and silently keep the
-  // stale `imported_body` snapshot, with no operator-visible cue that
+  // stale `imported_body` snapshot, with no principal-visible cue that
   // the audit trail had diverged.
   //
-  // Cost is bounded — operator-initiated, never a webhook firehose — and
+  // Cost is bounded — principal-initiated, never a webhook firehose — and
   // `importIterationFromMetadata` already correctly returns
   // `{ kind: 'exists', bodyRefreshed: true }` when the snapshot needs
   // refreshing, so the truth lives there (single source for the dedup
@@ -2979,7 +2979,7 @@ export async function handleImportIterationFromGithub(
   const result = importIterationFromMetadata(db, meta, { iterationLabel });
 
   if (result.kind === "invalid_metadata") {
-    // Should not happen on the operator-driven path — `gh api` always
+    // Should not happen on the principal-driven path — `gh api` always
     // returns sane shapes — but guard against malformed responses.
     process.stderr.write(
       `[api] POST /api/iterations/from-github invalid metadata for ${canonical}: ${result.reason}\n`
@@ -3134,7 +3134,7 @@ async function verifyGithubSignature(
  * the existing `webhook-proxy` already validates the upstream HMAC and
  * fans out to grove-api. This route is a peer surface that runs the
  * Grove-iteration logic against the same payload (the proxy can be
- * configured to fan out to both endpoints; for v1 the operator wires
+ * configured to fan out to both endpoints; for v1 the principal wires
  * mission-control's `/api/github/webhook` URL alongside the cloud
  * worker's).
  *
@@ -3143,11 +3143,11 @@ async function verifyGithubSignature(
  *                           AND no Grove iteration exists yet, create one.
  *                           Idempotent (no-op when one already exists).
  *   - `issues.unlabeled` — log + no-op. Decision 9 — orphaning is the
- *                           operator's call; we never delete iterations
+ *                           principal's call; we never delete iterations
  *                           in response to upstream label changes.
  *   - `issues.edited`    — if the issue is a tracked iteration parent,
  *                           refresh the audit-only `imported_body`
- *                           snapshot. Operator-edited `body` left alone.
+ *                           snapshot. Principal-edited `body` left alone.
  *   - `issues.opened`    — if the issue is a sub-issue of a tracked
  *   /closed/edited         parent, create or update the child task row.
  *   - other events       — ignored (returns 200 OK so GitHub doesn't
@@ -3255,7 +3255,7 @@ export async function handleGithubWebhook(
   // ---- Parent-issue branch ----
   const meta = parentMetadataFromWebhook(payload);
   if (!meta) {
-    // Structurally malformed payload. Log + 400 so the operator sees it
+    // Structurally malformed payload. Log + 400 so the principal sees it
     // (GitHub will surface 400s in the webhook delivery UI).
     return error("payload missing required issue/repository fields", 400);
   }
@@ -3286,7 +3286,7 @@ export async function handleGithubWebhook(
   }
 
   if (action === "unlabeled") {
-    // Decision 9 — orphaning is the operator's call. Log + 200; never
+    // Decision 9 — orphaning is the principal's call. Log + 200; never
     // delete the iteration row in response to an upstream label
     // removal.
     const env = payload as { label?: { name?: string } };
@@ -3301,7 +3301,7 @@ export async function handleGithubWebhook(
 
   if (action === "edited") {
     // Decision 9 — refresh the audit-only `imported_body` snapshot;
-    // never overwrite the operator-edited `body`.
+    // never overwrite the principal-edited `body`.
     const result = importIterationFromMetadata(db, meta, { iterationLabel });
     if (result.kind === "exists" && result.bodyRefreshed) {
       const detail = getIteration(db, result.iteration.id);

--- a/src/surface/mc/api/iteration-import.ts
+++ b/src/surface/mc/api/iteration-import.ts
@@ -444,7 +444,7 @@ export function importSubIssueFromMetadata(
   // came in via webhook, no human acted; we attribute it to the
   // mission-control default principal the same way internal-task
   // creates do.
-  const DEFAULT_OPERATOR_ID = "mc-default-principal";
+  const DEFAULT_OPERATOR_ID = "mc-default-operator";
   db.query(
     `INSERT INTO tasks
        (id, title, priority, principal_id,

--- a/src/surface/mc/api/iteration-import.ts
+++ b/src/surface/mc/api/iteration-import.ts
@@ -2,15 +2,15 @@
  * Grove Mission Control v3 — F-17 GitHub iteration auto-import.
  *
  * Pure import functions that turn a normalised GitHub issue payload
- * (parent issue with the operator-configured `iteration` label, or a
+ * (parent issue with the principal-configured `iteration` label, or a
  * sub-issue of a tracked parent) into Grove iteration / task rows.
  *
  * Two callers:
  *   1. The webhook receiver in `api/handlers.ts` (POST /api/github/webhook)
  *      — wired to the existing `webhook-proxy` fan-out so issues +
  *      sub-issues stream in without a new GitHub subscription.
- *   2. The operator-driven path `POST /api/iterations/from-github` —
- *      lets the operator import an existing labelled issue without
+ *   2. The principal-driven path `POST /api/iterations/from-github` —
+ *      lets the principal import an existing labelled issue without
  *      waiting for the next webhook event (and to backfill labelled
  *      issues that pre-date the webhook subscription).
  *
@@ -24,7 +24,7 @@
  *   - HTTP framing — handlers wrap the result in Response objects.
  *   - WebSocket broadcast — handlers fire `broadcastIterationCreated`
  *     after the import succeeds; this file never touches `WsClientRegistry`.
- *   - GitHub I/O — the operator-driven path fetches via `gh` CLI in the
+ *   - GitHub I/O — the principal-driven path fetches via `gh` CLI in the
  *     handler and passes the parsed metadata to `importIterationFromMetadata`.
  *     The webhook path receives the metadata extracted from the payload.
  *
@@ -56,7 +56,7 @@ import { canonicalRef, type GitHubRef } from "./github-ref";
  * yaml; the absence of an override falls through to this default. The
  * label match is case-sensitive — GitHub itself preserves label case
  * exactly and treats `Iteration` as a different label from `iteration`,
- * so we follow suit rather than smuggling in a normaliser the operator
+ * so we follow suit rather than smuggling in a normaliser the principal
  * wouldn't predict from looking at GitHub directly.
  */
 export const DEFAULT_ITERATION_LABEL = "iteration";
@@ -65,14 +65,14 @@ export const DEFAULT_ITERATION_LABEL = "iteration";
  * Soft cap on imported body bytes. Mirrors `ITERATION_BODY_MAX_BYTES`
  * in `api/handlers.ts` (50 KB) — the dashboard's iteration body editor
  * caps writes at 50 KB and the schema accepts arbitrarily long values
- * but the import path defends the operator from a malicious 5 MB
+ * but the import path defends the principal from a malicious 5 MB
  * GitHub issue body landing in the kanban as an outlier row.
  *
  * Truncation is at the byte boundary (not the character boundary): we
  * slice the string conservatively and let the DB store fewer bytes
  * than the cap rather than risk emitting a malformed UTF-8 sequence.
  * The original body is in GitHub anyway — truncation is loss-less for
- * the operator who clicks through to the source URL.
+ * the principal who clicks through to the source URL.
  */
 export const IMPORTED_BODY_MAX_BYTES = 50 * 1024;
 
@@ -82,7 +82,7 @@ export const IMPORTED_BODY_MAX_BYTES = 50 * 1024;
 
 /**
  * Normalised parent-issue metadata. Both callers — webhook and
- * operator-driven path — collapse their respective raw inputs to this
+ * principal-driven path — collapse their respective raw inputs to this
  * shape before calling `importIterationFromMetadata`.
  *
  * Field meanings track the GitHub REST `/repos/:owner/:repo/issues/:n`
@@ -136,7 +136,7 @@ export interface ImportOptions {
 /**
  * Parent-issue import outcome. Discriminated union so the caller can
  * tell idempotent re-import (200) from fresh import (201) from
- * non-iteration-labelled (409 — operator-driven path) from
+ * non-iteration-labelled (409 — principal-driven path) from
  * upstream-changed-body (200 with a refresh tag).
  */
 export type ImportIterationResult =
@@ -231,10 +231,10 @@ export function truncateToBytes(input: string, maxBytes: number): string {
  * Behaviour:
  *   - If `meta` doesn't carry the configured iteration label, returns
  *     `{ kind: "not_iteration_labelled" }` and writes nothing. The
- *     webhook caller treats this as a no-op; the operator-driven
+ *     webhook caller treats this as a no-op; the principal-driven
  *     `POST /api/iterations/from-github` caller surfaces it as 400.
  *   - If a Grove iteration with this `source_parent_ref` already
- *     exists, the operator-editable `body` / `title` / `priority` /
+ *     exists, the principal-editable `body` / `title` / `priority` /
  *     `state` are LEFT UNCHANGED (Decision 9 — no write-back / no
  *     upstream-clobber). Only the audit-only `imported_body` snapshot
  *     is refreshed when the upstream body actually changed; otherwise
@@ -242,8 +242,8 @@ export function truncateToBytes(input: string, maxBytes: number): string {
  *   - On fresh import the row lands with `state = 'inbox'`,
  *     `priority = 2`, `body` initialised from the (truncated) upstream
  *     body, and `imported_body` snapshotted equal to the upstream body.
- *     The operator then drags it from inbox → designing in the kanban
- *     (Decision 5 — explicit operator action, no auto-promote).
+ *     The principal then drags it from inbox → designing in the kanban
+ *     (Decision 5 — explicit principal action, no auto-promote).
  *
  * Idempotent: calling repeatedly with the same upstream body is a
  * no-op after the first call.
@@ -253,7 +253,7 @@ export function importIterationFromMetadata(
   meta: ParentIssueMetadata,
   opts: ImportOptions = {}
 ): ImportIterationResult {
-  // Defensive validation — the operator-driven path passes parsed
+  // Defensive validation — the principal-driven path passes parsed
   // metadata that we mostly trust, but the webhook path is fed
   // attacker-controlled JSON. Keep the rejection path local so the
   // caller doesn't have to re-validate.
@@ -293,7 +293,7 @@ export function importIterationFromMetadata(
   const existing = findIterationBySourceParentRef(db, "github", canonical);
   if (existing) {
     // Refresh the audit snapshot when the upstream body changed;
-    // never touch the operator-editable `body` / `title` / `priority`
+    // never touch the principal-editable `body` / `title` / `priority`
     // / `state` (Decision 9 — no upstream-clobber).
     if (existing.imported_body !== importedBody) {
       updateIterationImportedBody(db, existing.id, importedBody);
@@ -311,11 +311,11 @@ export function importIterationFromMetadata(
     return { kind: "exists", iteration: existing, bodyRefreshed: false };
   }
 
-  // Fresh import. The new row lands in `inbox` (Decision 5 — operator
+  // Fresh import. The new row lands in `inbox` (Decision 5 — principal
   // promotes to `designing` explicitly). `body` is seeded from the
   // upstream body so the kanban card has something readable on day
   // one; `imported_body` keeps the same value as the audit snapshot
-  // (the two diverge as soon as the operator edits the live body).
+  // (the two diverge as soon as the principal edits the live body).
   const id = generateId();
   const row = createIteration(db, {
     id,
@@ -440,11 +440,11 @@ export function importSubIssueFromMetadata(
   // parents per Decision 7).
   const taskId = generateId();
   const status = child.state === "closed" ? "done" : "open";
-  // Operator id mirrors F-12b's DEFAULT_OPERATOR_ID — the sub-issue
+  // Principal id mirrors F-12b's DEFAULT_OPERATOR_ID — the sub-issue
   // came in via webhook, no human acted; we attribute it to the
-  // mission-control default operator the same way internal-task
+  // mission-control default principal the same way internal-task
   // creates do.
-  const DEFAULT_OPERATOR_ID = "mc-default-operator";
+  const DEFAULT_OPERATOR_ID = "mc-default-principal";
   db.query(
     `INSERT INTO tasks
        (id, title, priority, principal_id,

--- a/src/surface/mc/api/types.ts
+++ b/src/surface/mc/api/types.ts
@@ -83,11 +83,11 @@ export interface CreateSessionRequest {
   taskId?: string;
   agentId?: string;
   /** Display name for the agent — used when `agentId` is supplied for a
-   *  not-yet-known agent (e.g. operator's `cldyo-live` invocation). */
+   *  not-yet-known agent (e.g. principal's `cldyo-live` invocation). */
   agentName?: string;
   principalId?: string;
   /**
-   * Optional initial operator turn. If provided, it is written to the
+   * Optional initial principal turn. If provided, it is written to the
    * controlled session after spawn and recorded as a principal.input event.
    * Ignored for `kind: 'local.observed'` (no stdin to write to).
    */
@@ -132,7 +132,7 @@ export interface ListEventsResponse {
 // --- POST /api/assignments/:id/input ---
 
 /**
- * Operator input to a running session. At least one of `text` or
+ * Principal input to a running session. At least one of `text` or
  * non-empty `images` must be present; empty body (or both absent /
  * images empty) returns 400.
  *
@@ -358,7 +358,7 @@ export interface GetIterationResponse {
  * Create body for `POST /api/iterations`. `title` is the only required
  * field; the rest default per the schema (`state='inbox'`, `priority=2`).
  *
- * `state` is settable on create so an operator-typed internal-only
+ * `state` is settable on create so a principal-typed internal-only
  * iteration can land directly in `designing` (skipping the inbox lane,
  * since there's no upstream issue to anchor it). Server validates the
  * value is in the canonical enum.
@@ -426,7 +426,7 @@ export interface DetachTaskResponse {
 
 // --- F-17 GitHub iteration auto-import ------------------------------------
 //
-// Operator-driven path. Lets the operator explicitly pull a GitHub issue
+// Principal-driven path. Lets the principal explicitly pull a GitHub issue
 // into Grove as an iteration (matching the auto-import logic the webhook
 // handler runs on `issues.labeled`), without waiting for the next webhook
 // event. Useful for backfilling pre-existing labelled issues.
@@ -435,7 +435,7 @@ export interface DetachTaskResponse {
 // import is a one-time event — once the row exists in Grove, subsequent
 // upstream edits do NOT clobber Grove-side edits. The handler refreshes
 // only the audit-only `imported_body` snapshot when the upstream body
-// changed; everything else is operator-sovereign.
+// changed; everything else is principal-sovereign.
 
 /**
  * Request body for `POST /api/iterations/from-github`.
@@ -458,7 +458,7 @@ export interface ImportIterationFromGithubRequest {
  * `bodyRefreshed` flags whether the call refreshed the audit-only
  * `imported_body` snapshot (true on re-import where the upstream body
  * changed since last import; false on a true no-op or fresh import).
- * Useful for the operator UI to show a "no changes since last import"
+ * Useful for the principal UI to show a "no changes since last import"
  * vs "snapshot updated" cue.
  */
 export interface ImportIterationFromGithubResponse {
@@ -470,7 +470,7 @@ export interface ImportIterationFromGithubResponse {
 /**
  * Conflict response — the issue exists but isn't carrying the
  * `iteration` label (so importing it would silently drop it). Returned
- * 409 by the operator-driven path; the webhook auto-path treats this
+ * 409 by the principal-driven path; the webhook auto-path treats this
  * as a no-op (a webhook fires for every issue label change; we filter
  * to the iteration label internally).
  */

--- a/src/surface/mc/dashboard-v2/__tests__/curation-enablement.test.ts
+++ b/src/surface/mc/dashboard-v2/__tests__/curation-enablement.test.ts
@@ -164,7 +164,7 @@ describe("VERBS_REQUIRING_CONFIRM / DESTRUCTIVE_VERBS", () => {
   });
 });
 
-describe("labelForVerb — operator-facing copy", () => {
+describe("labelForVerb — principal-facing copy", () => {
   it("returns the canonical sentence-case label for every verb", () => {
     expect(labelForVerb("dispatch")).toBe("Dispatch");
     expect(labelForVerb("requeue")).toBe("Requeue");

--- a/src/surface/mc/dashboard-v2/__tests__/iteration-actions.test.ts
+++ b/src/surface/mc/dashboard-v2/__tests__/iteration-actions.test.ts
@@ -2,7 +2,7 @@
  * F-15 — pure-helper tests for `lib/iteration-actions.ts`.
  *
  * Walks every (state × verb) cell so a future change in the matrix
- * (e.g. Phase G operator-driven done) cannot land silently. Mirrors
+ * (e.g. Phase G principal-driven done) cannot land silently. Mirrors
  * the matrix-coverage style from `iteration-status.test.ts`.
  */
 
@@ -103,7 +103,7 @@ describe("iterationActionMatrix — null / unknown state defensive shape", () =>
 
 describe("iterationActionMatrix — D10 Q1 invariant", () => {
   it("no `promote` cell EVER moves to done — Phase G feature", () => {
-    // Operator-driven done from non-{in_flight,blocked} is deferred to
+    // Principal-driven done from non-{in_flight,blocked} is deferred to
     // Phase G. This test pins the invariant: the detail surface offers
     // no path to mark an iteration done from the UI; the only `done`
     // path in v1 is the derivation from task termination + source
@@ -154,7 +154,7 @@ describe("labelForAction — exhaustive", () => {
     }
   });
 
-  it("Promote and Cancel have operator-friendly copy", () => {
+  it("Promote and Cancel have principal-friendly copy", () => {
     expect(labelForAction("promote")).toBe("Promote");
     expect(labelForAction("cancel")).toBe("Cancel iteration");
   });
@@ -183,7 +183,7 @@ describe("matrix coverage — every (state × verb) cell renders a defined boole
         const m = iterationActionMatrix(state);
         expect(typeof m[verb]).toBe("boolean");
         if (!m[verb]) {
-          // Disabled cell — tooltip must exist (operator needs to
+          // Disabled cell — tooltip must exist (principal needs to
           // learn why it's greyed out).
           expect(disabledTooltip(state as IterationState, verb).length)
             .toBeGreaterThan(0);

--- a/src/surface/mc/dashboard-v2/__tests__/iteration-display.test.ts
+++ b/src/surface/mc/dashboard-v2/__tests__/iteration-display.test.ts
@@ -111,7 +111,7 @@ describe("chipPillKind", () => {
   it("never collides with the existing `state-<assignmentState>` family", () => {
     // The drill-down header renders BOTH pill families side-by-side
     // (assignment state + iteration tag); collision would visually
-    // confuse the operator. This test pins that the tokens are
+    // confuse the principal. This test pins that the tokens are
     // distinct namespaces.
     const tag = TAG({ state: "blocked" });
     expect(chipPillKind(tag)).not.toContain("state-");

--- a/src/surface/mc/dashboard-v2/__tests__/safe-href.test.ts
+++ b/src/surface/mc/dashboard-v2/__tests__/safe-href.test.ts
@@ -1,5 +1,5 @@
 /**
- * `safeSourceHref` — XSS guard for operator-imported source URLs.
+ * `safeSourceHref` — XSS guard for principal-imported source URLs.
  *
  * Iteration source URLs come from upstream issue bodies; a malicious
  * upstream could embed `javascript:` or `data:` URLs that would execute

--- a/src/surface/mc/dashboard-v2/__tests__/state-ranks.test.ts
+++ b/src/surface/mc/dashboard-v2/__tests__/state-ranks.test.ts
@@ -10,7 +10,7 @@ import { describe, it, expect } from "bun:test";
 import { STATE_RANKS, STATE_RANK_BY_STATE, rankOf } from "../lib/state-ranks";
 
 describe("STATE_RANKS — dashboard mirror of db/tasks.ts", () => {
-  it("preserves the seven-state operator-attention order", () => {
+  it("preserves the seven-state principal-attention order", () => {
     expect(STATE_RANKS).toEqual([
       "blocked",
       "running",

--- a/src/surface/mc/dashboard-v2/__tests__/task-table-filter.test.ts
+++ b/src/surface/mc/dashboard-v2/__tests__/task-table-filter.test.ts
@@ -360,7 +360,7 @@ describe("classifyEmpty", () => {
   it("F-16 — iteration filter counts as an active filter (drives 'filter-excludes-all')", () => {
     // An iteration pin that excludes every row should land in
     // 'filter-excludes-all' so the empty-state component renders the
-    // "Clear filters" affordance — without this the operator's only
+    // "Clear filters" affordance — without this the principal's only
     // path back is to hand-edit the URL, which is the exact UX
     // failure the empty-state classifier exists to prevent.
     const all = [task({ status: "open" })];

--- a/src/surface/mc/dashboard-v2/__tests__/task-table-hash.test.ts
+++ b/src/surface/mc/dashboard-v2/__tests__/task-table-hash.test.ts
@@ -2,7 +2,7 @@
  * Tests for the F-8 task-table hash (de)serializer.
  *
  * Pins the legacy `readHashFilters` / `writeHashFilters` round-trip
- * shape (`dashboard/index.html` lines ~2453-2503). The hash is operator
+ * shape (`dashboard/index.html` lines ~2453-2503). The hash is principal
  * input — a hand-edited URL must never crash the parser, and an empty
  * filter+sort state must round-trip to the empty string (don't pollute
  * the URL with `#tasks?` for the default view).

--- a/src/surface/mc/dashboard-v2/app.tsx
+++ b/src/surface/mc/dashboard-v2/app.tsx
@@ -42,7 +42,7 @@ import type { Command } from "./components/command-palette";
  *
  * No router lib — `useState` + the existing tab buttons pattern. F-15
  * may upgrade to a hash route if deep-linking turns out to be
- * operator-requested; for now the in-memory view is sufficient.
+ * principal-requested; for now the in-memory view is sufficient.
  */
 type DashboardView = "default" | "metrics" | "iterations" | "kanban-detail";
 
@@ -379,7 +379,7 @@ export function App() {
                 setView("kanban-detail");
               } else {
                 // Inbox card click: there's no detail surface for an
-                // inbox row in v1 — the operator's path is to drag it
+                // inbox row in v1 — the principal's path is to drag it
                 // into Designing, then click into the resulting
                 // iteration. Mirror that with a toast hint.
                 showToast(
@@ -419,7 +419,7 @@ export function App() {
                   { task_id: inboxItem.id }
                 );
                 // Navigate to the new iteration's detail so the
-                // operator can immediately write the design notes.
+                // principal can immediately write the design notes.
                 setSelectedIterationId(created.iteration.id);
                 setView("kanban-detail");
                 iterations.refetch();
@@ -473,7 +473,7 @@ export function App() {
               setView("iterations");
               setSelectedIterationId(null);
               // Refresh the kanban so the row reflects whatever the
-              // operator just changed (the WS frames have already
+              // principal just changed (the WS frames have already
               // applied optimistic updates, but a refetch is cheap and
               // resyncs any inbox drift).
               iterations.refetch();
@@ -501,7 +501,7 @@ export function App() {
         // F-16 — chip click in the drill-header closes the drill-down
         // and routes to the iteration detail surface (the same
         // `kanban-detail` view F-15 ships from a kanban card click).
-        // We close the drill-down first so the operator returns to a
+        // We close the drill-down first so the principal returns to a
         // clean iteration surface; the existing F-7 history pattern
         // is "Esc closes, no breadcrumb back" so this matches.
         onOpenIteration={(iterationId) => {

--- a/src/surface/mc/dashboard-v2/components/curation-toolbar.tsx
+++ b/src/surface/mc/dashboard-v2/components/curation-toolbar.tsx
@@ -101,7 +101,7 @@ export function CurationToolbar({ assignment, onActionApplied }: CurationToolbar
       return list;
     } catch {
       // Best-effort — pickers will render an empty dropdown which the
-      // operator can recover from by using `+ Add task` or trying again.
+      // principal can recover from by using `+ Add task` or trying again.
       return [];
     }
   }, [agents]);

--- a/src/surface/mc/dashboard-v2/components/dispatch-button.tsx
+++ b/src/surface/mc/dashboard-v2/components/dispatch-button.tsx
@@ -73,7 +73,7 @@ export function DispatchButton({
   }, [open]);
 
   // Stop the row-click handler in task-table from firing when the
-  // operator clicks the button or the popover. The dispatch action
+  // principal clicks the button or the popover. The dispatch action
   // is its own intent, not a row-drill-down intent.
   const stop = (e: React.MouseEvent) => e.stopPropagation();
 

--- a/src/surface/mc/dashboard-v2/components/drill-down.tsx
+++ b/src/surface/mc/dashboard-v2/components/drill-down.tsx
@@ -32,10 +32,10 @@ export interface DrillDownProps {
   onCycle: (assignmentId: string) => void;
   focusMode: boolean;
   onToggleFocusMode: () => void;
-  /** Called when the operator submits text/images. Returns errors via the input. */
+  /** Called when the principal submits text/images. Returns errors via the input. */
   onSendInput: (assignmentId: string, text: string, images?: Array<{ media_type: string; data: string }>) => Promise<void>;
   /**
-   * F-16 — invoked when the operator clicks the iteration chip in
+   * F-16 — invoked when the principal clicks the iteration chip in
    * the drill-header. Threaded through to <DrillHeader/>; the App
    * owner navigates to the kanban-detail view for that iteration id.
    */

--- a/src/surface/mc/dashboard-v2/components/drill-header.tsx
+++ b/src/surface/mc/dashboard-v2/components/drill-header.tsx
@@ -25,7 +25,7 @@ export interface DrillHeaderProps {
   focusMode: boolean;
   onToggleFocusMode: () => void;
   /**
-   * F-16 — invoked when the operator clicks the iteration chip. Routes
+   * F-16 — invoked when the principal clicks the iteration chip. Routes
    * the parent App to the kanban-detail view for the given iteration
    * id (same surface F-15 ships). Optional so this component is still
    * usable from contexts without iteration routing wired (tests; future
@@ -48,7 +48,7 @@ export function DrillHeader({
   // F-16 — surface the iteration chip only when the assignment's task
   // is grouped (the LEFT JOIN's null path → ungrouped). Per the design
   // spec we explicitly OMIT the chip for ungrouped tasks rather than
-  // rendering "—"; the operator's signal "this task is loose" is the
+  // rendering "—"; the principal's signal "this task is loose" is the
   // chip's absence, not a placeholder. (The F-8 column shows "—"
   // because the column header is always present and an empty cell
   // would misalign rows.)

--- a/src/surface/mc/dashboard-v2/components/drill-input.tsx
+++ b/src/surface/mc/dashboard-v2/components/drill-input.tsx
@@ -1,7 +1,7 @@
 /**
- * F-10 drill-input — operator message + image attachments.
+ * F-10 drill-input — principal message + image attachments.
  *
- * Faithful port of the legacy monolith input (docs/design-mc-f10-operator-input.md
+ * Faithful port of the legacy monolith input (docs/design-mc-f10-principal-input.md
  * + docs/design-mc-image-input.md). Behavioural parity:
  *  - Active / observed / ended / shadow modes (resolveDrillInputMode)
  *  - 50 KB UTF-8 byte cap (paste-trim + Send disable)
@@ -43,7 +43,7 @@ export interface DrillInputProps {
    */
   ws: WsClient;
   /**
-   * Submit operator input. Must throw `ApiFailure` (from lib/api) on a
+   * Submit principal input. Must throw `ApiFailure` (from lib/api) on a
    * non-2xx response or network failure so the inline banner can render
    * status-coded copy.
    */
@@ -56,9 +56,9 @@ export interface DrillInputProps {
 
 /**
  * Canned-action prompts per migration addendum §"Rich reply surface"
- * (line 54) — fixed text the operator can drop into the textarea, edit,
+ * (line 54) — fixed text the principal can drop into the textarea, edit,
  * and send. Decoupled from any specific agent — the prompts are framed
- * as universal operator moves.
+ * as universal principal moves.
  */
 const CANNED_ACTIONS: ReadonlyArray<{ label: string; text: string }> = [
   { label: "ask for more", text: "Can you walk me through what you've tried so far and what's blocking?" },
@@ -110,7 +110,7 @@ export function DrillInput({ assignmentId, assignment, ws, onSend }: DrillInputP
   const busyRef = useRef(busy);
   const doSendRef = useRef<(text: string, images: Array<{ media_type: string; data: string }>) => void>(() => {});
 
-  // Reset per-assignment local state when the operator cycles (`]`/`[`)
+  // Reset per-assignment local state when the principal cycles (`]`/`[`)
   // to a different drill-down. Previous textarea / staged images / queue
   // are discarded — they belong to the previous assignment.
   useEffect(() => {
@@ -239,8 +239,8 @@ export function DrillInput({ assignmentId, assignment, ws, onSend }: DrillInputP
       // Stay busy until assignment.state changes — the queue-release
       // effect above will flip busy=false and drain the queue.
     } catch (e) {
-      // Restore the operator's text + images so they can Retry or edit.
-      // Only restore if the slot is still empty (operator may have started
+      // Restore the principal's text + images so they can Retry or edit.
+      // Only restore if the slot is still empty (principal may have started
       // typing a new message during the in-flight request).
       setText((t) => (t === "" ? rawText : t));
       setStaged((s) => {
@@ -263,7 +263,7 @@ export function DrillInput({ assignmentId, assignment, ws, onSend }: DrillInputP
   doSendRef.current = (rawText, images) => { void doSend(rawText, images); };
 
   // Insert a canned-action prompt into the textarea (replaces selection
-  // when present, else appends; focus is restored so the operator can
+  // when present, else appends; focus is restored so the principal can
   // immediately edit). Per migration addendum §"Rich reply surface".
   const insertCanned = useCallback((promptText: string) => {
     if (readonly) return;

--- a/src/surface/mc/dashboard-v2/components/drill-input.tsx
+++ b/src/surface/mc/dashboard-v2/components/drill-input.tsx
@@ -1,7 +1,7 @@
 /**
  * F-10 drill-input — principal message + image attachments.
  *
- * Faithful port of the legacy monolith input (docs/design-mc-f10-principal-input.md
+ * Faithful port of the legacy monolith input (docs/design-mc-f10-operator-input.md
  * + docs/design-mc-image-input.md). Behavioural parity:
  *  - Active / observed / ended / shadow modes (resolveDrillInputMode)
  *  - 50 KB UTF-8 byte cap (paste-trim + Send disable)

--- a/src/surface/mc/dashboard-v2/components/drill-log.tsx
+++ b/src/surface/mc/dashboard-v2/components/drill-log.tsx
@@ -4,7 +4,7 @@
  * Renders rows produced by `lib/event-rows.ts:eventsToRows()` per the
  * Decision 11 rendering rules. Lazy-expand for thinking blocks +
  * tool_use+tool_result pairs; markdown for assistant text and
- * operator input.
+ * principal input.
  */
 
 import { useMemo, useState } from "react";

--- a/src/surface/mc/dashboard-v2/components/focus-area.tsx
+++ b/src/surface/mc/dashboard-v2/components/focus-area.tsx
@@ -48,7 +48,7 @@ export interface FocusAreaProps {
   selectedIdx: number;
   onSelect: (idx: number) => void;
   /**
-   * Called when the operator presses Enter (or clicks) on a card.
+   * Called when the principal presses Enter (or clicks) on a card.
    * Receives the assignment; MIG-3 wires this to the drill-down.
    */
   onOpen: (item: AssignmentListItem) => void;

--- a/src/surface/mc/dashboard-v2/components/iteration-board.css
+++ b/src/surface/mc/dashboard-v2/components/iteration-board.css
@@ -164,7 +164,7 @@
 /* F-17 — inbox auto-import badge (matches the iteration-side source-badge
  * shape so the visual rhythm is uniform across the kanban). The accent
  * colour cues "this row arrived from the upstream pipeline" without
- * shouting; the operator sees it as a quiet hint, not an alert. */
+ * shouting; the principal sees it as a quiet hint, not an alert. */
 .iteration-card-meta .source-badge.gh {
   color: var(--accent, #4f8cff);
   border-color: color-mix(in oklch, var(--accent, #4f8cff) 30%, var(--line));

--- a/src/surface/mc/dashboard-v2/components/iteration-board.tsx
+++ b/src/surface/mc/dashboard-v2/components/iteration-board.tsx
@@ -77,7 +77,7 @@ export interface IterationBoardProps {
   /** Boot error only — surfaced as a red banner above the board. */
   error: string | null;
   /**
-   * Called when a card is clicked (operator wants the detail surface).
+   * Called when a card is clicked (principal wants the detail surface).
    * F-15 wires this to a real route; until then the parent shows a toast.
    * For inbox-kind clicks the `id` is the task id; for iteration-kind
    * clicks the `id` is the iteration id.
@@ -374,7 +374,7 @@ function IterationCard({ entry, dragging, onOpen, onDragStart, onDragEnd }: Iter
             href={safeSourceUrl}
             target="_blank"
             rel="noopener noreferrer"
-            // Don't open the detail surface when the operator clicks
+            // Don't open the detail surface when the principal clicks
             // through to GitHub — that would race the new tab.
             onClick={(e) => e.stopPropagation()}
           >
@@ -391,10 +391,10 @@ function IterationCard({ entry, dragging, onOpen, onDragStart, onDragEnd }: Iter
         )}
         {/*
           F-17 — inbox column visual hint. Tasks that arrived via the
-          GitHub auto-import (webhook or operator-driven path) carry
+          GitHub auto-import (webhook or principal-driven path) carry
           `source_system === 'github'` on the InboxItem. The denorm is
           identical to the iteration-side badge above; rendering here
-          gives the operator a one-glance signal that a row landed via
+          gives the principal a one-glance signal that a row landed via
           the upstream pipeline rather than being typed directly.
 
           Per design Decision 1 ("the source link gives us a clickable

--- a/src/surface/mc/dashboard-v2/components/iteration-detail.tsx
+++ b/src/surface/mc/dashboard-v2/components/iteration-detail.tsx
@@ -4,7 +4,7 @@
  *
  * Why FULL-PAGE rather than overlay (per spec "pick one and document
  * why"):
- *   - The detail surface is a planning artefact the operator wants to
+ *   - The detail surface is a planning artefact the principal wants to
  *     stay on while doing other work in another tab. Drill-down (F-7)
  *     is overlay-style because it's a transient attention surface — you
  *     come back to the focus row when done. Detail is the opposite:
@@ -61,7 +61,7 @@ const BODY_AUTOSAVE_DEBOUNCE_MS = 1000;
 export interface IterationDetailProps {
   iterationId: string;
   ws: WsClient;
-  /** Called when the operator wants to return to the kanban (X button or post-action). */
+  /** Called when the principal wants to return to the kanban (X button or post-action). */
   onClose: () => void;
 }
 
@@ -148,9 +148,9 @@ function IterationDetailLoaded({ iteration, onClose, onRefetch }: LoadedProps) {
       titleCommittedRef.current = iteration.title;
       setTitleDraft(iteration.title);
     } else {
-      // Operator is editing locally — don't clobber. The committed-ref
+      // Principal is editing locally — don't clobber. The committed-ref
       // still tracks what the server last told us so a subsequent blur
-      // saves the operator's draft correctly.
+      // saves the principal's draft correctly.
       titleCommittedRef.current = iteration.title;
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/surface/mc/dashboard-v2/components/keycap.tsx
+++ b/src/surface/mc/dashboard-v2/components/keycap.tsx
@@ -1,7 +1,7 @@
 /**
  * Linear-style keycap chip + sequence helper.
  *
- * Used in the command palette, inline help, and operator-shortcut hints.
+ * Used in the command palette, inline help, and principal-shortcut hints.
  * CSS lives in styles/global.css under .kc / .kc-seq.
  */
 

--- a/src/surface/mc/dashboard-v2/components/task-table.tsx
+++ b/src/surface/mc/dashboard-v2/components/task-table.tsx
@@ -89,7 +89,7 @@ export interface TaskTableProps {
   onClear: () => void;
 
   /**
-   * Called when the operator opens a task. Receives the assignment id of
+   * Called when the principal opens a task. Receives the assignment id of
    * the task's primary active assignment (Decision 5 tie-break). For
    * empty-assignment tasks the parent should fall back to the
    * `shadow_assignment_id` (F-12b Decision 7).
@@ -113,7 +113,7 @@ export interface TaskTableProps {
   onOpenIteration?: (iterationId: string) => void;
 
   /**
-   * F-19 — operator clicks Dispatch on a task row. Caller fires
+   * F-19 — principal clicks Dispatch on a task row. Caller fires
    * `POST /api/sessions { taskId }`. Optional so embedding tests
    * without dispatch wiring is a no-op (button stays hidden).
    */

--- a/src/surface/mc/dashboard-v2/hooks/use-focus-area.ts
+++ b/src/surface/mc/dashboard-v2/hooks/use-focus-area.ts
@@ -47,7 +47,7 @@ export interface FocusAreaState {
   loaded: boolean;
   /** Last error message, or null after a successful refetch. */
   error: string | null;
-  /** Manual refetch trigger — useful for an operator-driven refresh. */
+  /** Manual refetch trigger — useful for a principal-driven refresh. */
   refetch: () => void;
 }
 

--- a/src/surface/mc/dashboard-v2/hooks/use-hash-state.ts
+++ b/src/surface/mc/dashboard-v2/hooks/use-hash-state.ts
@@ -44,7 +44,7 @@ function serializeHash(state: HashState): string {
 
 /**
  * `setHashState` semantics (matches `docs/design-mc-dashboard-react-migration.md`
- * Decision 3 — operator filters use replaceState so the back-button doesn't
+ * Decision 3 — principal filters use replaceState so the back-button doesn't
  * accumulate one history entry per keystroke):
  *
  *   - default (no `opts`)                → replaceState (no new history entry)

--- a/src/surface/mc/dashboard-v2/hooks/use-iteration-detail.ts
+++ b/src/surface/mc/dashboard-v2/hooks/use-iteration-detail.ts
@@ -4,7 +4,7 @@
  * Fetches `GET /api/iterations/:id` and merges live
  * `iteration.detail_updated` / `iteration.state_changed` WS frames for
  * the same id. Race-guarded mirroring `use-drill-events.ts` (the
- * iteration id can change as the operator clicks between cards on the
+ * iteration id can change as the principal clicks between cards on the
  * kanban; in-flight responses for a stale id are dropped).
  *
  * Surfaces the same `loaded / error / refetch` triple as the other

--- a/src/surface/mc/dashboard-v2/hooks/use-iterations.ts
+++ b/src/surface/mc/dashboard-v2/hooks/use-iterations.ts
@@ -179,7 +179,7 @@ export function useIterations(ws: WsClient): IterationsHookState {
   // carries the full `IterationDetail` (the create handler still
   // broadcasts the full row so a freshly-created iteration with
   // attached tasks lands in the detail surface immediately if the
-  // operator opens it). The kanban only needs the `IterationListItem`
+  // principal opens it). The kanban only needs the `IterationListItem`
   // subset; the cast here is structurally safe (extends).
   useEffect(() => {
     function onCreated(msg: WsMessage) {
@@ -193,7 +193,7 @@ export function useIterations(ws: WsClient): IterationsHookState {
       if (it.state === "cancelled") return;
       setIterations((prev) => {
         // Defensive: don't double-insert if a refetch already raced
-        // this frame (the operator might have caused both).
+        // this frame (the principal might have caused both).
         if (prev.some((p) => p.id === it.id)) return prev;
         return [...prev, it];
       });

--- a/src/surface/mc/dashboard-v2/hooks/use-theme.ts
+++ b/src/surface/mc/dashboard-v2/hooks/use-theme.ts
@@ -5,7 +5,7 @@
  * switches without re-mounting components.
  *
  * Persistence key: `mc.theme`. Values: `"dark" | "light"`. Anything else
- * falls back to OS preference. Across sessions, an explicit operator
+ * falls back to OS preference. Across sessions, an explicit principal
  * pick wins over OS preference; no preference recorded means "follow OS".
  */
 

--- a/src/surface/mc/dashboard-v2/lib/agent-defaults.ts
+++ b/src/surface/mc/dashboard-v2/lib/agent-defaults.ts
@@ -1,13 +1,13 @@
 /**
- * Operator-facing display name for the default-agent fallback.
+ * Principal-facing display name for the default-agent fallback.
  *
  * Surfaces in the F-19 dispatch popover ("Dispatch this task to <name>?")
  * and any other UI surface that needs to refer to the agent that will
- * receive an unscoped dispatch. Goes away once the F-19.1 operator agent
- * picker lands and the operator can pick a registered head explicitly.
+ * receive an unscoped dispatch. Goes away once the F-19.1 principal agent
+ * picker lands and the principal can pick a registered head explicitly.
  *
  * Kept frontend-only because the backend's `DEFAULT_AGENT_NAME` (used as
  * the actual `agents.name` row) is an internal identifier, not a label
- * tuned for operator readability — those two concerns can drift cleanly.
+ * tuned for principal readability — those two concerns can drift cleanly.
  */
 export const DEFAULT_AGENT_DISPLAY_NAME = "Default Agent";

--- a/src/surface/mc/dashboard-v2/lib/block-reason.ts
+++ b/src/surface/mc/dashboard-v2/lib/block-reason.ts
@@ -1,5 +1,5 @@
 /**
- * Render a one-line operator-friendly summary of a `BlockReason`.
+ * Render a one-line principal-friendly summary of a `BlockReason`.
  *
  * Mirrors the legacy `blockReasonOneLiner` in
  * `src/mission-control/dashboard/index.html:1094`. Behavioural contract

--- a/src/surface/mc/dashboard-v2/lib/curation-enablement.ts
+++ b/src/surface/mc/dashboard-v2/lib/curation-enablement.ts
@@ -69,7 +69,7 @@ const CURATION_MATRIX_BY_STATE: Record<AssignmentState, CurationMatrix> = {
     dispatch: true, // re-run on the same task
     requeue: "Rerun via Dispatch creates a fresh assignment",
     handoff: "Task already done — nothing to hand off",
-    abandon: true, // operator may close out the task even from completed
+    abandon: true, // principal may close out the task even from completed
   },
   cancelled: {
     dispatch: "Already cancelled — terminal",
@@ -140,7 +140,7 @@ export const VERBS_REQUIRING_CONFIRM: ReadonlySet<CurationVerb> = new Set([
   "abandon", "handoff",
 ]);
 
-/** Verbs that the operator marks as destructive (gets red CSS treatment). */
+/** Verbs that the principal marks as destructive (gets red CSS treatment). */
 export const DESTRUCTIVE_VERBS: ReadonlySet<CurationVerb> = new Set([
   "abandon", "handoff",
 ]);

--- a/src/surface/mc/dashboard-v2/lib/iteration-actions.ts
+++ b/src/surface/mc/dashboard-v2/lib/iteration-actions.ts
@@ -9,7 +9,7 @@
  *
  * Per `docs/design-mc-iteration-planning.md`:
  *   - Decision 5: `designing → queued` is the "Promote" action; only
- *     visible when state is `designing`. (Promote is the operator-
+ *     visible when state is `designing`. (Promote is the principal-
  *     driven transition; the kanban can also drag-drop it, but the
  *     detail surface is the canonical click-button path.)
  *   - Decision 5: `* → cancelled` is the explicit destructive path.
@@ -103,7 +103,7 @@ export function disabledTooltip(
   if (!state) return "Loading iteration…";
   const matrix = iterationActionMatrix(state);
   if (matrix[verb]) return "";
-  // The user-visible reason for each disabled cell. Operator learns the
+  // The user-visible reason for each disabled cell. Principal learns the
   // model from the tooltip without reading the spec.
   switch (verb) {
     case "promote":
@@ -139,7 +139,7 @@ export function labelForAction(verb: IterationActionVerb): string {
   }
 }
 
-/** Verbs that the operator marks as destructive (red CSS treatment). */
+/** Verbs that the principal marks as destructive (red CSS treatment). */
 export const DESTRUCTIVE_ACTIONS: ReadonlySet<IterationActionVerb> = new Set([
   "cancel",
   "detachTask",

--- a/src/surface/mc/dashboard-v2/lib/iteration-display.ts
+++ b/src/surface/mc/dashboard-v2/lib/iteration-display.ts
@@ -32,7 +32,7 @@ export const ITERATION_TITLE_MAX_CHARS = 20;
  * it already fits — no trailing ellipsis on exact-fit titles.
  *
  * Pure / total — every defined string maps to a defined string. The
- * empty string maps to itself (the operator never sees a blank
+ * empty string maps to itself (the principal never sees a blank
  * iteration title because `iterations.title NOT NULL`, but the
  * helper is total against future schema relaxation).
  */
@@ -44,10 +44,10 @@ export function truncateIterationTitle(title: string): string {
 /**
  * Render the F-7 drill-header chip text: "Iteration: <truncated> (state)".
  *
- * Why the format includes the state — the chip is the operator's
+ * Why the format includes the state — the chip is the principal's
  * one-glance signal that "this task is in iteration X, currently
  * <state>". Linking out to the iteration detail without surfacing the
- * state means the operator clicks through purely to confirm the
+ * state means the principal clicks through purely to confirm the
  * lifecycle column. The four-byte cost in the chip pays for itself
  * many-fold per design spec §"Surface 3".
  */
@@ -57,7 +57,7 @@ export function chipText(it: TaskIterationTag): string {
 
 /**
  * Tooltip text for the chip + cell — the full untrucated title plus the
- * state (cell case where the operator hovers a truncated title and
+ * state (cell case where the principal hovers a truncated title and
  * needs to know which iteration this actually is). Distinct from
  * `chipText` so the tooltip reveals the full string even when the
  * visible chip itself was truncated.

--- a/src/surface/mc/dashboard-v2/lib/iteration-drag.ts
+++ b/src/surface/mc/dashboard-v2/lib/iteration-drag.ts
@@ -18,7 +18,7 @@
  *
  * Returns `{ allowed, reason? }` rather than a bare boolean so the
  * renderer can surface the rejection reason as a tooltip on the
- * disallowed column during the drag (operator gets feedback, not a
+ * disallowed column during the drag (principal gets feedback, not a
  * silent no-op cursor).
  */
 
@@ -58,7 +58,7 @@ export function canDrop(
     }
     if (targetState === "inbox") {
       // Self-drop on the same column — coalesce to no-op rather than
-      // surface a "no" message; the operator's intent is unambiguous.
+      // surface a "no" message; the principal's intent is unambiguous.
       // Wording matches the iteration-side self-drop branch below.
       return { allowed: false, reason: "Already in this column" };
     }
@@ -72,7 +72,7 @@ export function canDrop(
   if (sourceState === null) {
     // Iteration with no current state — treat as ineligible. Defensive:
     // the F-13 schema ALWAYS persists a state, so this branch indicates
-    // a programming error in the renderer rather than an operator action.
+    // a programming error in the renderer rather than a principal action.
     return { allowed: false, reason: "Iteration has no current state" };
   }
 

--- a/src/surface/mc/dashboard-v2/lib/iteration-status.ts
+++ b/src/surface/mc/dashboard-v2/lib/iteration-status.ts
@@ -16,7 +16,7 @@
  * Per `docs/design-mc-iteration-planning.md` Decision 1, the lifecycle
  * is Grove-owned. Source state is NEVER an input to this validator —
  * the only inputs are (current state, proposed state). Decision 5
- * specifies who triggers each transition (operator vs derived) but
+ * specifies who triggers each transition (principal vs derived) but
  * that's policy belonging to the API layer / kanban hook; the validator
  * answers shape only.
  */
@@ -54,7 +54,7 @@ export function canTransition(
 /**
  * Enumerate the legal next states from `current`. Order is the
  * canonical insertion order from the matrix definition above (so the
- * UI can render the operator's options deterministically).
+ * UI can render the principal's options deterministically).
  *
  * Returns `[]` for terminal states and unknown states — callers can
  * detect "no moves possible" with `nextStates(s).length === 0`.

--- a/src/surface/mc/dashboard-v2/lib/markdown.tsx
+++ b/src/surface/mc/dashboard-v2/lib/markdown.tsx
@@ -1,7 +1,7 @@
 /**
  * Minimal markdown renderer — text only, no library dependency.
  *
- * Per migration addendum Decision 11, assistant text and operator input
+ * Per migration addendum Decision 11, assistant text and principal input
  * render as markdown. We support a tight subset:
  *  - Triple-backtick fenced code blocks (with optional language tag)
  *  - Single-backtick inline code

--- a/src/surface/mc/dashboard-v2/lib/safe-href.ts
+++ b/src/surface/mc/dashboard-v2/lib/safe-href.ts
@@ -1,8 +1,8 @@
 /**
- * URL-scheme allowlist for operator-imported links rendered in the UI.
+ * URL-scheme allowlist for principal-imported links rendered in the UI.
  *
  * Iteration source URLs come from upstream issues (GitHub today, Jira /
- * Linear later). Their bodies are operator-imported, so a malicious or
+ * Linear later). Their bodies are principal-imported, so a malicious or
  * compromised upstream could embed a `javascript:` or `data:` URL that
  * would execute on click. Render the anchor only when the URL parses to
  * an `http:` or `https:` scheme; otherwise return `null` and let the

--- a/src/surface/mc/dashboard-v2/lib/state-ranks.ts
+++ b/src/surface/mc/dashboard-v2/lib/state-ranks.ts
@@ -2,7 +2,7 @@
  * Assignment-state attention ranks.
  *
  * Mirrors `STATE_RANKS` in `src/mission-control/db/tasks.ts` (the F-8
- * Decision 4 source of truth). Lower = more operator attention.
+ * Decision 4 source of truth). Lower = more principal attention.
  *
  * Used by:
  *  - F-8 task table (MIG-4): aggregate-state computation client-side

--- a/src/surface/mc/dashboard-v2/lib/task-table-filter.ts
+++ b/src/surface/mc/dashboard-v2/lib/task-table-filter.ts
@@ -16,7 +16,7 @@ import type { TaskListItem } from "../../db/tasks";
 import type { AssignmentState } from "../../types";
 import { STATE_RANK_BY_STATE } from "./state-ranks";
 
-/** Sort columns the operator can toggle from the table header. */
+/** Sort columns the principal can toggle from the table header. */
 export type TaskSortKey =
   | "default"   // server-default order (priority ASC, updated_at DESC)
   | "priority"
@@ -56,14 +56,14 @@ export interface TaskFilterState {
    * F-16 — pin the table to a single iteration. NULL = no filter (all
    * tasks visible). When set, only tasks whose denormalised
    * `iteration.id` matches survive. Driven by the `?iter=<id>` hash
-   * param so an operator can deep-link "tasks in iteration X" from
+   * param so a principal can deep-link "tasks in iteration X" from
    * the iteration detail surface or share a kanban-context URL.
    *
    * Per design spec §"Surface 3" — "extend the task-table hash-state
    * filter to include `?iter=<id>` so operators can pin to one
    * iteration. Optional but nice — defer if it adds significant
    * complexity." Implementation cost is one new field + four lines
-   * in the hash codec; the operator value is high (one-click
+   * in the hash codec; the principal value is high (one-click
    * "what tasks are in this iteration").
    */
   iterationId: string | null;
@@ -177,7 +177,7 @@ export function classifyEmpty(
     filters.ageMinMinutes > 0 ||
     filters.search.length > 0 ||
     // F-16 — iteration pin counts as an active filter so the empty
-    // state's "Clear filters" button surfaces (operator's path back
+    // state's "Clear filters" button surfaces (principal's path back
     // when an iteration filter excludes everything).
     filters.iterationId !== null;
   if (filterActive) return "filter-excludes-all";

--- a/src/surface/mc/dashboard-v2/lib/task-table-hash.ts
+++ b/src/surface/mc/dashboard-v2/lib/task-table-hash.ts
@@ -47,7 +47,7 @@ export function defaultHashState(): ParsedHash {
  * Parse a hash like `#tasks?p=0,1&age=5&closed=1&q=foo&sort=priority:desc`
  * into a `ParsedHash`. Unknown keys, malformed values, and out-of-range
  * priorities are silently ignored — never throws (legacy parity, the
- * hash is operator input and may be hand-edited).
+ * hash is principal input and may be hand-edited).
  *
  * Hashes that don't start with `#tasks` return defaults so other apps
  * (e.g. F-7's `#a/:id` slot) can coexist on the same page later.

--- a/src/surface/mc/dashboard-v2/styles/global.css
+++ b/src/surface/mc/dashboard-v2/styles/global.css
@@ -84,7 +84,7 @@ html, body {
  * State-specific tints layered on top — `inbox` and `designing` fade
  * to dim (the iteration is upstream of execution; lower visual
  * weight); `queued`/`in_flight` use the accent (active); `blocked`
- * borrows the state-blocked colour because the operator's mental
+ * borrows the state-blocked colour because the principal's mental
  * model is "blocked is blocked, regardless of layer"; `done` /
  * `cancelled` mute.
  */

--- a/src/surface/mc/db/assignments.ts
+++ b/src/surface/mc/db/assignments.ts
@@ -125,7 +125,7 @@ const ASSIGNMENT_JOIN_SELECT = `SELECT
  * Safety cap for the focus-area query. The client only renders
  * `FOCUS_MAX_VISIBLE = 6` cards plus a "+N more" tail chip, so transmitting
  * the full blocked partition is wasteful. 100 is well above any plausible
- * operator working-set; anything larger means something else is wrong.
+ * principal working-set; anything larger means something else is wrong.
  *
  * Exported so tests (and any future pagination cursor) can reference the
  * same ceiling.

--- a/src/surface/mc/db/iterations.ts
+++ b/src/surface/mc/db/iterations.ts
@@ -154,7 +154,7 @@ export function toIterationListItem(
  * NULL` AND `source_system <> 'internal'` AND a non-cancelled status.
  *
  * The internal-source filter is what the design spec means by "upstream
- * issues not yet linked to an iteration" — operator-typed internal tasks
+ * issues not yet linked to an iteration" — principal-typed internal tasks
  * are not part of the import-from-upstream funnel and don't render in
  * the inbox lane.
  */
@@ -267,7 +267,7 @@ export interface ListInboxOptions {
  *
  * Filtering rules (Decision 1):
  *   - `iteration_id IS NULL` (not yet promoted into a iteration)
- *   - `source_system != 'internal'` (operator-typed internal tasks aren't
+ *   - `source_system != 'internal'` (principal-typed internal tasks aren't
  *     in the upstream funnel; they live in the iteration body / direct add)
  *   - `status != 'cancelled'` (the inbox is alive-only; cancelled imports
  *     stay in the audit trail but disappear from the lane)
@@ -394,7 +394,7 @@ export function createIteration(
  *
  * Source columns are intentionally NOT patchable from this API path —
  * they're set at import time and frozen (Decision 1, Decision 9). Future
- * operator-driven re-import is a separate explicit action.
+ * principal-driven re-import is a separate explicit action.
  */
 export interface UpdateIterationPatch {
   title?: string;
@@ -480,7 +480,7 @@ export function updateIteration(
  *
  * Decision 1 + 9 (no write-back) imply the lookup is read-only and
  * never tries to reconcile mismatches between the upstream and the
- * stored row — the operator's edits are sovereign once import landed.
+ * stored row — the principal's edits are sovereign once import landed.
  */
 export function findIterationBySourceParentRef(
   db: Database,
@@ -503,18 +503,18 @@ export function findIterationBySourceParentRef(
 
 /**
  * F-17 — refresh the audit-only `imported_body` snapshot for an
- * existing iteration row WITHOUT touching the operator-editable
+ * existing iteration row WITHOUT touching the principal-editable
  * `body`, `title`, `priority`, or `state` columns.
  *
  * Per `docs/design-mc-iteration-planning.md` Decision 9 ("Source is
  * upstream-only. No write-back, ever.") the in-Grove `body` /
- * operator edits are sovereign — a subsequent `issues.edited` upstream
+ * principal edits are sovereign — a subsequent `issues.edited` upstream
  * webhook MUST NOT clobber them. This helper exists so the auto-import
  * path can keep the audit snapshot fresh while leaving the live row
- * the operator sees in the dashboard exactly as they last saved it.
+ * the principal sees in the dashboard exactly as they last saved it.
  *
  * Touches `updated_at` so the kanban re-sorts (the snapshot refresh is
- * still a real mutation; the operator can see "the upstream issue
+ * still a real mutation; the principal can see "the upstream issue
  * changed" implicitly via the row moving).
  *
  * Returns true when the row was found and the snapshot updated, false
@@ -564,7 +564,7 @@ export function touchIteration(db: Database, id: string): boolean {
  * has at most one iteration). This sets `tasks.iteration_id` directly;
  * a task can be re-attached by calling this again with a different
  * iteration id. Per Decision 3 a task contributing to two iterations is
- * "the operator's signal to clone, not to model nesting" — there's no
+ * "the principal's signal to clone, not to model nesting" — there's no
  * many-to-many join table to populate.
  *
  * Returns true when the task row was found and updated, false when the
@@ -588,7 +588,7 @@ export function attachTask(
  * F-15 — read the current `iteration_id` (or `null`) for a task, plus
  * a tiny existence flag. Used by the attach endpoint to enforce the
  * 1:N invariant before mutating: per Decision 3 a task that contributes
- * to two iterations is the operator's signal to clone, not to model
+ * to two iterations is the principal's signal to clone, not to model
  * nesting — so attaching a task that's already attached elsewhere is a
  * 409 with the existing iteration id, not a silent overwrite.
  *
@@ -640,11 +640,11 @@ export function detachTask(db: Database, taskId: string): boolean {
 // transition would mean a hand-rolled curl could bypass the lifecycle.
 // The handler calls `canTransitionServer` before invoking
 // `updateIteration` and returns 400 on a rejected move with the legal
-// next-states in the message — so the operator sees the friendlier
+// next-states in the message — so the principal sees the friendlier
 // "queued → designing isn't legal; allowed: in_flight, designing,
 // cancelled" instead of an opaque 500.
 //
-// Decision 10 Q1 — operator-driven `done` from non-`in_flight`/non-
+// Decision 10 Q1 — principal-driven `done` from non-`in_flight`/non-
 // `blocked` states is rejected here. F-15 keeps the matrix tight; the
 // override is a Phase G feature with its own threat model. The error
 // message names `cancel` as the alternative for operators who hit the

--- a/src/surface/mc/db/metrics.ts
+++ b/src/surface/mc/db/metrics.ts
@@ -16,7 +16,7 @@
  * Computation lives in TS rather than SQL because:
  *   - The same `BlockReason` tagged-union type used elsewhere can be reused
  *     without JSON-extract gymnastics in SQLite.
- *   - At Phase B operator scale (tens to hundreds of assignments per
+ *   - At Phase B principal scale (tens to hundreds of assignments per
  *     window), the total event row count is small enough that linear
  *     interval math in TS is comparable to a SQL window-function pass.
  *   - Future percentile / cost extensions are easier to express in TS

--- a/src/surface/mc/db/schema.ts
+++ b/src/surface/mc/db/schema.ts
@@ -120,7 +120,7 @@ export const SCHEMA_SQL: string[] = [
   // then short-circuits without a sort pass. Negligible at the 1–2
   // sessions/assignment typical case; matters once the assignment
   // lifetime accrues compaction-driven sessions (§6.6 of the
-  // mission-control spec) or the operator dispatches the same task
+  // mission-control spec) or the principal dispatches the same task
   // multiple times. Per Echo's PR #57 review (N3).
   `CREATE INDEX IF NOT EXISTS idx_sessions_assignment_started
      ON sessions(assignment_id, started_at DESC, id DESC)`,
@@ -154,7 +154,7 @@ export const SCHEMA_SQL: string[] = [
   // Grove-owned lifecycle for the iteration planning surface. Per F-13
   // Decision 1, state lives here as a stored column (not derived from any
   // upstream source state). `imported_body` is an audit-only snapshot of the
-  // upstream body at import time; `body` is the operator-editable in-Grove
+  // upstream body at import time; `body` is the principal-editable in-Grove
   // copy. `source_*` columns are display/reference only after import — never
   // re-read for state. NULL `source_*` is the legitimate "internal-only"
   // iteration case (Decision 2).

--- a/src/surface/mc/db/sessions.ts
+++ b/src/surface/mc/db/sessions.ts
@@ -138,10 +138,10 @@ const SHADOW_AGENT_NAME = "Mission Control shadow";
  * Lazily insert the well-known shadow agent row if missing. Idempotent.
  * Sibling of `ensureDefaultAgent` in `api/handlers.ts`.
  *
- * The shadow agent is `persistent=1` so operator-visible agent lists that
+ * The shadow agent is `persistent=1` so principal-visible agent lists that
  * filter on `persistent=1` don't accidentally drop the sentinel; the
  * projection-level filter (`ag.id != 'mc-shadow-agent'`) is the
- * operator-visibility control, not persistence.
+ * principal-visibility control, not persistence.
  */
 export function ensureShadowAgent(db: Database): string {
   db.query(

--- a/src/surface/mc/db/tasks.ts
+++ b/src/surface/mc/db/tasks.ts
@@ -60,7 +60,7 @@ export interface TaskAssignmentRow {
  *
  * Three fields only — `id`, `title`, `state`. The dashboard never
  * renders the iteration body / source / etc. from this denorm; for the
- * full row the operator clicks through to the iteration detail surface
+ * full row the principal clicks through to the iteration detail surface
  * (which uses its own narrow per-id fetch). Keeping the shape tight
  * also keeps the `iteration.updated` patch payload small (Echo
  * grove-v2#42 Major 3 — header-only frames).
@@ -125,7 +125,7 @@ export interface ListTasksOptions {
 export const TASKS_QUERY_LIMIT = 500;
 
 /**
- * Aggregate-state rank. Lower = more operator attention.
+ * Aggregate-state rank. Lower = more principal attention.
  * Locked in `docs/design-mc-f8-task-table.md` Decision 4; the two
  * counter-intuitive orderings (`dispatched > queued`, `failed > completed
  * > cancelled`) are deliberate and reused elsewhere (primary-active
@@ -231,7 +231,7 @@ export function listTasks(
   // tuple onto each task row so the dashboard can render the F-7
   // drill-down chip + F-8 task-table iteration column without an N+1
   // round-trip per task. The JOIN is LEFT because most tasks (legacy +
-  // pre-F-13 imports + ungrouped operator-typed) have `iteration_id IS
+  // pre-F-13 imports + ungrouped principal-typed) have `iteration_id IS
   // NULL`; matching that side as nullable is the explicit "ungrouped
   // tasks render with `—` in the column" path from the design spec
   // §"Surface 3" without needing a separate query branch.
@@ -329,7 +329,7 @@ export function listTasks(
  * is unknown.
  *
  * Always reads regardless of `status` — broadcasts must fire even
- * for tasks that have been closed since the operator opened them.
+ * for tasks that have been closed since the principal opened them.
  */
 export function getTaskById(db: Database, id: string): TaskListItem | null {
   const row = db

--- a/src/surface/mc/hooks/ingestor.ts
+++ b/src/surface/mc/hooks/ingestor.ts
@@ -7,12 +7,12 @@
  * F-20 — for `local.observed` sessions, drives state-machine transitions
  * the controlled path normally fires synchronously:
  *   - First event for a `dispatched` observed session →  `dispatched → running`
- *     (the operator's TTY just emitted the first hook event, so the
+ *     (the principal's TTY just emitted the first hook event, so the
  *     terminal session is genuinely doing work).
  *   - `Stop` / `SessionEnd` hook event for a `running` observed session →
  *     `running → completed`. Without this auto-transition, observed
  *     sessions silently inflate F-18 cycle-time / wait-time metrics
- *     until an operator manually closes them — Echo flagged this in
+ *     until a principal manually closes them — Echo flagged this in
  *     PR #54 cycle-1 review.
  *
  * Both auto-transitions only apply when the registered session has

--- a/src/surface/mc/hooks/poller.ts
+++ b/src/surface/mc/hooks/poller.ts
@@ -70,7 +70,7 @@ export class HookStreamPoller {
       files = readdirSync(dir).filter((f) => f.endsWith(".jsonl"));
     } catch (err) {
       // Directory vanished or became unreadable between existsSync and readdir
-      // (e.g. operator moved ~/.claude/events). Log and skip this tick rather
+      // (e.g. principal moved ~/.claude/events). Log and skip this tick rather
       // than crash — the next tick will recover once the dir returns.
       process.stderr.write(
         `[mission-control] hook-poller: readdir failed for ${dir}: ${(err as Error).message}\n`

--- a/src/surface/mc/index.ts
+++ b/src/surface/mc/index.ts
@@ -8,7 +8,7 @@
  *
  * Boot is wrapped in try/catch to honor the spec NFR contract:
  *   - On any boot failure: write `[mission-control] FATAL: <msg>` to stderr
- *     and exit with code 1. No raw stack traces in the operator's terminal.
+ *     and exit with code 1. No raw stack traces in the principal's terminal.
  */
 
 import { loadConfig } from "./config";

--- a/src/surface/mc/lib/iteration-transitions.ts
+++ b/src/surface/mc/lib/iteration-transitions.ts
@@ -19,14 +19,14 @@
  * Per `docs/design-mc-iteration-planning.md` Decision 1, the lifecycle
  * is Grove-owned. Source state is NEVER an input to the validator —
  * the only inputs are (current state, proposed state). Decision 5
- * specifies who triggers each transition (operator vs derived) but
+ * specifies who triggers each transition (principal vs derived) but
  * that's policy belonging to the API layer / kanban hook; the matrix
  * answers shape only.
  *
  * Decision 10 Q1 is intentionally NOT foreclosed here: `* → done` is
  * legal from any non-terminal state in the matrix below. v1 expects
  * those to fire via derivation (all tasks terminal AND source closed),
- * but Phase G's "operator-driven done with open tasks" override is
+ * but Phase G's "principal-driven done with open tasks" override is
  * possible without expanding this matrix.
  */
 
@@ -53,20 +53,20 @@ export type IterationState = (typeof ITERATION_STATES)[number];
  * Per-state legal-next-state set.
  *
  * Cells reflect Decision 5's movement rules:
- *   inbox      → designing                   (operator drag)
- *              → cancelled                   (operator)
- *   designing  → queued                      (operator promote)
- *              → cancelled                   (operator)
- *              → inbox                       (operator drag back — "send back to inbox")
+ *   inbox      → designing                   (principal drag)
+ *              → cancelled                   (principal)
+ *   designing  → queued                      (principal promote)
+ *              → cancelled                   (principal)
+ *              → inbox                       (principal drag back — "send back to inbox")
  *   queued     → in_flight                   (derived: any task assignment becomes active)
- *              → designing                   (operator demote — fix scope before any work starts)
- *              → cancelled                   (operator)
+ *              → designing                   (principal demote — fix scope before any work starts)
+ *              → cancelled                   (principal)
  *   in_flight  → blocked                     (derived: any assignment hits blocked)
  *              → done                        (derived: all tasks terminal AND source closed)
- *              → cancelled                   (operator)
+ *              → cancelled                   (principal)
  *   blocked    → in_flight                   (derived: assignment unblocked)
  *              → done                        (derived: same as above; blocked is a sub-shape of in_flight)
- *              → cancelled                   (operator)
+ *              → cancelled                   (principal)
  *   done       → (terminal — no transitions out)
  *   cancelled  → (terminal — no transitions out)
  *

--- a/src/surface/mc/notifications/discord-sink.ts
+++ b/src/surface/mc/notifications/discord-sink.ts
@@ -8,7 +8,7 @@
  *
  * Three buffers, all in-memory (Decision 7 is explicit about durability):
  *   1. Per-assignment 5 s dedup window.
- *   2. Per-operator 3 s coalesce window — N ≥ 2 collapses to one summary DM.
+ *   2. Per-principal 3 s coalesce window — N ≥ 2 collapses to one summary DM.
  *   3. Per-channel 10 s throttle — collapses bursts into one summary post.
  *
  * Hot path: `maybeNotifyDiscord(deps, ctx)` is called from both
@@ -226,7 +226,7 @@ interface CoalesceBuffer {
   notifier: DiscordNotifier;
   onSystemError?: MaybeNotifyDeps["onSystemError"];
   /**
-   * For `audience === "dm"` this is the operator's Discord user id; for
+   * For `audience === "dm"` this is the principal's Discord user id; for
    * `audience === "channel"` it's the channel/thread id. Empty string is
    * never valid (caller checks before enqueueing).
    */
@@ -240,7 +240,7 @@ interface CoalesceBuffer {
   scheduler: FlushScheduler;
 }
 
-/** Per-operator coalesce buffer: `principal_id → buffer`. */
+/** Per-principal coalesce buffer: `principal_id → buffer`. */
 const dmBuffers = new Map<string, CoalesceBuffer>();
 /** Per-channel coalesce buffer: `channel_id → buffer`. */
 const channelBuffers = new Map<string, CoalesceBuffer>();
@@ -345,9 +345,9 @@ async function dispatchIntent(
   // Resolve channel id (used by both single and coalesced paths).
   const channelId = resolveChannelId(deps.config, input.ctx);
 
-  // (2) DM path with per-operator coalescing — DM-class notifications
+  // (2) DM path with per-principal coalescing — DM-class notifications
   // accumulate within COALESCE_WINDOW_MS; the first event arms a timer,
-  // subsequent events on the same operator within the window collapse
+  // subsequent events on the same principal within the window collapse
   // into one summary.
   if (intent.audiences.includes("dm")) {
     const operatorDiscordId = deps.config.operatorDiscordId;
@@ -404,7 +404,7 @@ async function dispatchIntent(
 }
 
 // ---------------------------------------------------------------------
-// DM coalescing (per-operator, 3 s window)
+// DM coalescing (per-principal, 3 s window)
 // ---------------------------------------------------------------------
 
 function enqueueDM(
@@ -620,7 +620,7 @@ async function flushChannelBuffer(channelId: string): Promise<void> {
   // N ≥ 2 — render a coalesced summary channel post. Decision 7: same
   // shape as the DM summary. The summary itself is a single message; we
   // do NOT prepend a role-ping for the burst (the per-event mentions are
-  // intentionally swallowed by coalescing — the operator who wanted the
+  // intentionally swallowed by coalescing — the principal who wanted the
   // ping can find every individual block on the dashboard).
   const top = buffer.entries.reduce((best, cur) =>
     cur.priority < best.priority ? cur : best

--- a/src/surface/mc/notifications/render.ts
+++ b/src/surface/mc/notifications/render.ts
@@ -16,7 +16,7 @@
  * fields (`block_reason.context`, `tool.error.error_message`,
  * `recentAssistantMessage`) are passed through verbatim. Discord's DM/channel
  * surfaces render plain text; there is no injection attack surface to
- * defend against on the render side. The operator already trusts the
+ * defend against on the render side. The principal already trusts the
  * agent's output everywhere else (dashboard, CLI, events table).
  */
 import type { BlockReason } from "../types";

--- a/src/surface/mc/notifications/should-notify.ts
+++ b/src/surface/mc/notifications/should-notify.ts
@@ -19,7 +19,7 @@ import type { AssignmentState, BlockReason } from "../types";
 /**
  * Audience for a single notification.
  *
- * `dm`      — operator's Discord DM (1:1, action-required surface).
+ * `dm`      — principal's Discord DM (1:1, action-required surface).
  * `channel` — repo thread / log channel (broadcast surface).
  *
  * The matrix never schedules `both` for the *same* event content — when a
@@ -48,7 +48,7 @@ export interface NotificationIntent {
    * (Decision 2's "no direct-mention in DMs" rule).
    *
    * `silent` — render the notification without escalation markup. DMs
-   * still ping by default (operator inbox is the operator's choice); the
+   * still ping by default (principal inbox is the principal's choice); the
    * flag governs channel-side mention-ping behaviour only.
    */
   severity: NotificationSeverity;
@@ -81,7 +81,7 @@ export interface ShouldNotifyInput {
 export function shouldNotify(input: ShouldNotifyInput): NotificationIntent | null {
   const { to, priority, blockReason } = input;
 
-  // Mechanical / operator-driven / self-healed transitions — never notify.
+  // Mechanical / principal-driven / self-healed transitions — never notify.
   // Decision 1 matrix rows: queued→dispatched, dispatched→running,
   // *→cancelled, blocked→running, blocked→{completed,failed}.
   if (
@@ -109,7 +109,7 @@ export function shouldNotify(input: ShouldNotifyInput): NotificationIntent | nul
   if (to === "failed") {
     // P0 failures: channel post + role ping. P1: channel post, no ping.
     // P2/P3: channel post, no ping. Always channel-only — failures land in
-    // the repo thread for post-mortem context, not in the operator's DM.
+    // the repo thread for post-mortem context, not in the principal's DM.
     if (priority <= 0) {
       return {
         audiences: ["channel"],
@@ -216,7 +216,7 @@ export function shouldNotify(input: ShouldNotifyInput): NotificationIntent | nul
     // BlockReason has exactly three kinds; permission.request and
     // tool.error returned above, so review.checkpoint is the only kind
     // left. "agent asked for human sign-off" — DM, no ping even at P0
-    // (the operator opted in by configuring agents that emit
+    // (the principal opted in by configuring agents that emit
     // checkpoints).
     return {
       audiences: ["dm"],

--- a/src/surface/mc/server.ts
+++ b/src/surface/mc/server.ts
@@ -120,7 +120,7 @@ export interface StartServerOptions {
   notify?: MaybeNotifyDeps;
   /**
    * F-12b Decision 4 — optional `owner/repo` default for `#N` / `repo#N`
-   * shorthand parsing. Source: operator's `mission-control.yaml` or
+   * shorthand parsing. Source: principal's `mission-control.yaml` or
    * equivalent. When absent, shorthands fail with a clear message.
    */
   defaultGithubRepo?: string;
@@ -138,7 +138,7 @@ export interface StartServerOptions {
   /**
    * F-17 — GitHub webhook HMAC secret. When omitted, the
    * `POST /api/github/webhook` route 503s — no implicit bypass. The
-   * operator wires this from the same `GITHUB_WEBHOOK_SECRET` they
+   * principal wires this from the same `GITHUB_WEBHOOK_SECRET` they
    * configure on the upstream `webhook-proxy`.
    */
   githubWebhookSecret?: string;
@@ -203,7 +203,7 @@ export function startServer(
       // server binds loopback-only (config.hostname = "127.0.0.1" by default,
       // enforced by the SEV-2 fix above). If MC is ever fronted by a reverse
       // proxy or exposed beyond loopback, either strip wsClients from this
-      // response or gate /health behind auth. Operator-liveness probes should
+      // response or gate /health behind auth. Principal-liveness probes should
       // only see `status` + `version`.
       if (req.method === "GET" && url.pathname === "/health") {
         const body: HealthResponse = {
@@ -454,7 +454,7 @@ async function handleApi(
     return handleListWorkingAgents(db);
   }
 
-  // F-17 — operator-driven GitHub iteration import.
+  // F-17 — principal-driven GitHub iteration import.
   //   POST /api/iterations/from-github  — gh CLI fetch + import logic
   //
   // Matched BEFORE the broader `/api/iterations/:id` regex below so the

--- a/src/surface/mc/session/endpoint-resolver.ts
+++ b/src/surface/mc/session/endpoint-resolver.ts
@@ -171,7 +171,7 @@ export function spawnControlledSession(
       // Wait for the dispatcher to drain before finalizing: the terminal
       // `result` event and its state.transition broadcast must land before
       // endSession sets ended_at, otherwise the dashboard sees a closed
-      // session with no final transition and the operator queue stays stuck.
+      // session with no final transition and the principal queue stays stuck.
       if (managed.dispatcherDone) await managed.dispatcherDone;
       processManager.remove(session.id);
       endSession(db, session.id);
@@ -222,14 +222,14 @@ export function createControlledEndpoint(
       // the shape depends on spawn options (we pass `stdin: "pipe"` which gives
       // FileSink). TS cannot narrow from runtime options, hence the explicit
       // check; the throw guards against a future spawn change that would cause
-      // a silent drop of operator input.
+      // a silent drop of principal input.
       const stdin = managed.proc.stdin;
       if (stdin === undefined || typeof stdin === "number") {
         throw new SessionClosed(sessionId, managed.proc.exitCode);
       }
       void stdin.write(framed);
       // NOTE: FileSink backpressure (Promise return from write) is a Phase B
-      // concern — Phase A dispatches small operator messages only. When the
+      // concern — Phase A dispatches small principal messages only. When the
       // dispatcher lands, switch to an async write path that awaits
       // stdin.flush() and applies per-session queueing.
     },

--- a/src/surface/mc/session/stdout-dispatcher.ts
+++ b/src/surface/mc/session/stdout-dispatcher.ts
@@ -146,7 +146,7 @@ function dispatchLine(line: string, deps: StdoutDispatcherDeps): void {
 
   // Terminal event: CC emits `{ type: "result", subtype: "success" | "error_..." }`
   // at the end of a turn. We drive the state machine running → completed/failed
-  // so the dashboard can release the operator input queue on a real end-of-turn
+  // so the dashboard can release the principal input queue on a real end-of-turn
   // signal rather than inferring from every event (see dashboard F-A4 TODO).
   if (rawType === "result") {
     applyTerminalTransition(payload, deps);

--- a/src/surface/mc/session/stream-json.ts
+++ b/src/surface/mc/session/stream-json.ts
@@ -1,7 +1,7 @@
 /**
  * Grove Mission Control v2 — Stream-json message framing.
  *
- * Formats operator input as stream-json messages for CC stdin.
+ * Formats principal input as stream-json messages for CC stdin.
  * Based on Maestro's streamJsonBuilder.ts pattern.
  *
  * Two overloads:

--- a/src/surface/mc/session/types.ts
+++ b/src/surface/mc/session/types.ts
@@ -14,7 +14,7 @@ export interface SessionEndpoint {
   kind: EndpointKind;
   sessionId: string;
   /**
-   * Write an operator message to the session.
+   * Write a principal message to the session.
    *
    * - String input — legacy text-only path; sent verbatim as
    *   `content: "..."` (F-10 drill-down input).

--- a/src/surface/mc/worker/schema.sql
+++ b/src/surface/mc/worker/schema.sql
@@ -1,5 +1,5 @@
 -- Grove Cloud API — D1 Schema
--- Derived from dashboard-db.ts, with principal_id for multi-operator attribution.
+-- Derived from dashboard-db.ts, with principal_id for multi-principal attribution.
 
 CREATE TABLE IF NOT EXISTS schema_version (
   version INTEGER PRIMARY KEY,

--- a/src/surface/mc/worker/src/routes/admin.ts
+++ b/src/surface/mc/worker/src/routes/admin.ts
@@ -1,6 +1,6 @@
 /**
  * G-400/G-402: Admin endpoints.
- * POST /admin/keys — create an operator API key (ADMIN_SECRET — bootstrap path)
+ * POST /admin/keys — create a principal API key (ADMIN_SECRET — bootstrap path)
  * DELETE /admin/keys/:key — revoke an API key (ADMIN_SECRET — bootstrap path)
  * GET /admin/audit — query audit log (requireRole("admin") — dashboard path)
  * DELETE /admin/repos/:owner/:name — remove repo records (ADMIN_SECRET — infrastructure)
@@ -18,7 +18,7 @@ import { requireRole } from "../user-auth";
 export const adminRoutes = new Hono<{ Bindings: Env }>();
 
 // ---------------------------------------------------------------------------
-// POST /admin/keys — Create a new operator API key
+// POST /admin/keys — Create a new principal API key
 // ---------------------------------------------------------------------------
 
 adminRoutes.post("/admin/keys", requireAdmin, async (c) => {

--- a/src/surface/mc/worker/src/routes/state.ts
+++ b/src/surface/mc/worker/src/routes/state.ts
@@ -24,9 +24,9 @@ const CACHE_TTL_MS = 5_000; // 5s TTL — prevents stale reads across isolates
  * Build a full (unfiltered) snapshot object from D1.
  *
  * IAW D.5 — `homePrincipal` (when supplied) slices the snapshot's `agents`
- * and `recentCompletions` lists by the originating operator. The other
+ * and `recentCompletions` lists by the originating principal. The other
  * derived sections (stats, repos, heatmap) stay global because they reflect
- * the receiving operator's totals; per-operator stats are a future slice
+ * the receiving principal's totals; per-principal stats are a future slice
  * (D.5 ships the activity-card path first per the plan §5).
  */
 export async function buildSnapshot(
@@ -58,7 +58,7 @@ export async function buildSnapshot(
     principalUsage,
     /**
      * IAW D.5.2 — distinct `home_principal` values observed in recent
-     * sessions. The frontend uses this to populate the operator filter
+     * sessions. The frontend uses this to populate the principal filter
      * dropdown; "Local only" (the default) corresponds to `null` here.
      */
     homePrincipals,
@@ -209,12 +209,12 @@ stateRoutes.get("/api/state", async (c) => {
   const db = c.env.GROVE_DB;
   const project = c.req.query("project");
   // IAW D.5.2 — `?home_principal=<id>` slices the snapshot to a single
-  // originating operator. Sentinel `"local"` means "null home_principal
+  // originating principal. Sentinel `"local"` means "null home_principal
   // only" (purely local traffic, no federated stamps) and matches the
   // dashboard's default filter chip.
   const homePrincipal = c.req.query("home_principal");
 
-  // Project-filtered or operator-filtered requests bypass cache (rare).
+  // Project-filtered or principal-filtered requests bypass cache (rare).
   // The cache key would need to grow per-(project, home_principal) tuple
   // otherwise; not worth the complexity for the slow path.
   if (project || homePrincipal) {
@@ -316,7 +316,7 @@ async function getActiveAgents(
  *   - `undefined` / `null` / `""` → no slicing (snapshot covers all rows).
  *   - `"local"`                   → `home_principal IS NULL` (purely local
  *                                   traffic, the dashboard default chip).
- *   - any other string            → `home_principal = ?` (specific operator).
+ *   - any other string            → `home_principal = ?` (specific principal).
  *
  * Returns `{ sql, params }` rather than mutating in place so the caller's
  * SELECT is constructible without hidden side-effects on a shared array.
@@ -444,7 +444,7 @@ async function getRecentCompletions(
 
 /**
  * IAW D.5.2 — return the distinct, non-null `home_principal` values seen in
- * recent sessions. Powers the dashboard's operator filter dropdown — the
+ * recent sessions. Powers the dashboard's principal filter dropdown — the
  * frontend prepends "Local only" (default) + "All operators" to this list.
  *
  * Window: same 7-day horizon the heatmap uses, so the dropdown doesn't grow

--- a/src/surface/mc/worker/src/user-auth/README.md
+++ b/src/surface/mc/worker/src/user-auth/README.md
@@ -10,7 +10,7 @@ relationship — edit it like any other worker code.
 
 ## What lives here
 
-- **`types.ts`** — Role hierarchy (`viewer < operator < admin`), scope hierarchy
+- **`types.ts`** — Role hierarchy (`viewer < principal < admin`), scope hierarchy
   (`read < write < admin`), user/agent/grant records, the `AuthBindings`
   env shape consumed by the worker.
 - **`authorize.ts`** — Pure decision functions: `checkRole`, `checkAgentAccess`.
@@ -39,10 +39,10 @@ relationship — edit it like any other worker code.
 
 ## Relationship to the worker's existing `auth.ts`
 
-`src/auth.ts` in the worker is a different surface — operator API-key auth
+`src/auth.ts` in the worker is a different surface — principal API-key auth
 (`requireApiKey`, `requireAdmin`, `PrincipalKey`) for bot operators posting
 to `/api/ingest`. It does not overlap with anything here. The two coexist:
-operator-key auth gates the ingest path; user-auth gates the dashboard
+principal-key auth gates the ingest path; user-auth gates the dashboard
 read path.
 
 ## Provenance

--- a/src/surface/mc/worker/src/user-auth/authorize.ts
+++ b/src/surface/mc/worker/src/user-auth/authorize.ts
@@ -63,7 +63,7 @@ export function checkAgentAccess(input: AgentAccessInput): AgentAccessResult {
   }
 
   // 4. Cattle open access (any principal)
-  if (agentClass === "cattle" && ROLE_HIERARCHY[userRole] >= ROLE_HIERARCHY["principal"]) {
+  if (agentClass === "cattle" && ROLE_HIERARCHY[userRole] >= ROLE_HIERARCHY["operator"]) {
     return { allowed: true, resolution: "cattle", availableScope: "control" };
   }
 

--- a/src/surface/mc/worker/src/user-auth/authorize.ts
+++ b/src/surface/mc/worker/src/user-auth/authorize.ts
@@ -62,8 +62,8 @@ export function checkAgentAccess(input: AgentAccessInput): AgentAccessResult {
     return { allowed: true, resolution: "admin", availableScope: "control" };
   }
 
-  // 4. Cattle open access (any operator)
-  if (agentClass === "cattle" && ROLE_HIERARCHY[userRole] >= ROLE_HIERARCHY["operator"]) {
+  // 4. Cattle open access (any principal)
+  if (agentClass === "cattle" && ROLE_HIERARCHY[userRole] >= ROLE_HIERARCHY["principal"]) {
     return { allowed: true, resolution: "cattle", availableScope: "control" };
   }
 

--- a/src/surface/mc/worker/src/user-auth/middleware/require-agent-access.ts
+++ b/src/surface/mc/worker/src/user-auth/middleware/require-agent-access.ts
@@ -16,7 +16,7 @@ import { logAuditEvent, getClientIp } from "./audit";
  * 1. Caller is agent owner → full access
  * 2. Caller has active grant with sufficient scope → granted access
  * 3. Caller is admin → bypass
- * 4. Agent is cattle class → any operator can access
+ * 4. Agent is cattle class → any principal can access
  * Otherwise → 403.
  *
  * Requires requireRole() to have run first (needs c.get("user")).

--- a/src/surface/mc/worker/src/user-auth/routes/auth.ts
+++ b/src/surface/mc/worker/src/user-auth/routes/auth.ts
@@ -173,8 +173,8 @@ authRoutes.put("/api/auth/users/:id/role", async (c) => {
 
   const targetId = c.req.param("id");
   const body = await c.req.json<{ role: Role }>().catch(() => null);
-  if (!body?.role || !["viewer", "operator", "admin"].includes(body.role)) {
-    return c.json({ error: "invalid role", valid: ["viewer", "operator", "admin"] }, 400);
+  if (!body?.role || !["viewer", "principal", "admin"].includes(body.role)) {
+    return c.json({ error: "invalid role", valid: ["viewer", "principal", "admin"] }, 400);
   }
 
   const db = c.env.GROVE_DB;

--- a/src/surface/mc/worker/src/user-auth/routes/auth.ts
+++ b/src/surface/mc/worker/src/user-auth/routes/auth.ts
@@ -173,8 +173,8 @@ authRoutes.put("/api/auth/users/:id/role", async (c) => {
 
   const targetId = c.req.param("id");
   const body = await c.req.json<{ role: Role }>().catch(() => null);
-  if (!body?.role || !["viewer", "principal", "admin"].includes(body.role)) {
-    return c.json({ error: "invalid role", valid: ["viewer", "principal", "admin"] }, 400);
+  if (!body?.role || !["viewer", "operator", "admin"].includes(body.role)) {
+    return c.json({ error: "invalid role", valid: ["viewer", "operator", "admin"] }, 400);
   }
 
   const db = c.env.GROVE_DB;

--- a/src/surface/mc/worker/src/user-auth/types.ts
+++ b/src/surface/mc/worker/src/user-auth/types.ts
@@ -3,11 +3,11 @@
  * Design: docs/design-auth-aaa.md v2
  */
 
-export type Role = "viewer" | "principal" | "admin";
+export type Role = "viewer" | "operator" | "admin";
 export type AgentClass = "pet" | "cattle";
 export type GrantScope = "read" | "review" | "control";
 
-export const ROLE_HIERARCHY: Record<Role, number> = { viewer: 0, principal: 1, admin: 2 };
+export const ROLE_HIERARCHY: Record<Role, number> = { viewer: 0, operator: 1, admin: 2 };
 export const SCOPE_HIERARCHY: Record<GrantScope, number> = { read: 0, review: 1, control: 2 };
 
 export interface UserRecord {

--- a/src/surface/mc/worker/src/user-auth/types.ts
+++ b/src/surface/mc/worker/src/user-auth/types.ts
@@ -3,11 +3,11 @@
  * Design: docs/design-auth-aaa.md v2
  */
 
-export type Role = "viewer" | "operator" | "admin";
+export type Role = "viewer" | "principal" | "admin";
 export type AgentClass = "pet" | "cattle";
 export type GrantScope = "read" | "review" | "control";
 
-export const ROLE_HIERARCHY: Record<Role, number> = { viewer: 0, operator: 1, admin: 2 };
+export const ROLE_HIERARCHY: Record<Role, number> = { viewer: 0, principal: 1, admin: 2 };
 export const SCOPE_HIERARCHY: Record<GrantScope, number> = { read: 0, review: 1, control: 2 };
 
 export interface UserRecord {

--- a/src/surface/mc/ws/types.ts
+++ b/src/surface/mc/ws/types.ts
@@ -5,7 +5,7 @@
  * shapes. Clients check `protocolVersion` on the `connected` handshake to
  * detect incompatibility.
  *
- * v2 (cortex#436): event kinds `operator.input` / `operator.curation` renamed
+ * v2 (cortex#436): event kinds `principal.input` / `principal.curation` renamed
  * to `principal.input` / `principal.curation`; identity field `operatorId`
  * renamed to `principalId`. Clients must read the principal.* kinds.
  */
@@ -50,9 +50,9 @@ export type WsServerMessage =
   // detail surface wants the full row.
   //
   //   - `iteration.created` — full `IterationDetail`. Fires once per
-  //     POST; new-iteration creates carry tasks (operator may have
+  //     POST; new-iteration creates carry tasks (principal may have
   //     created with attachments) so the detail surface can populate
-  //     immediately if the operator opens it post-create.
+  //     immediately if the principal opens it post-create.
   //   - `iteration.updated` — header-only `IterationListItem`. Fires
   //     on every successful PATCH / attach / detach. Drives the kanban.
   //   - `iteration.detail_updated` — full `IterationDetail`. Fires

--- a/src/surface/mc/ws/types.ts
+++ b/src/surface/mc/ws/types.ts
@@ -5,8 +5,8 @@
  * shapes. Clients check `protocolVersion` on the `connected` handshake to
  * detect incompatibility.
  *
- * v2 (cortex#436): event kinds `principal.input` / `principal.curation` renamed
- * to `principal.input` / `principal.curation`; identity field `operatorId`
+ * v2 (cortex#436): event kinds `operator.input` / `operator.curation` were
+ * renamed to `principal.input` / `principal.curation`; identity field `operatorId`
  * renamed to `principalId`. Clients must read the principal.* kinds.
  */
 


### PR DESCRIPTION
## Summary

The **non-breaking prose/UI-copy/comment sweep** for PR-R13d (cortex#450): `operator`/`Operator` → `principal`/`Principal` across `src/surface/mc/` (81 files changed, 279 substitutions). Part of cortex#436.

The lockstep pieces of #450 — the **§6 eventKinds consumer rename** and the wire/D1 changes — already landed in **#472** (the MC-worker cut). This PR is the remaining cosmetic vocabulary sweep, intentionally kept separate so the breaking cut stayed reviewable.

## Scope

- All `\boperator\b` / `\bOperator\b` in `surface/mc/` → `principal`/`Principal` (comments, UI copy, test names/fixtures).
- **Carve-outs (deliberate):**
  - `worker/migrations/` (0001–0004) — historical text untouched, incl. 0003's `{operator}` subject-grammar reference and 0004's "operator → principal" migration note.
  - Index-name identifiers `idx_sessions_operator` / `idx_github_operator` — word-boundary-safe (they index `principal_id`; renaming the identifier is a no-op churn).
  - `notifications.ts` `broadcast*` fan-out method names are R5 territory, not operator — untouched (and they don't contain "operator" anyway).
- `slack-adapter.test.ts`: **only** the R8a hit (test name `operator filter visible to router` → `principal filter`). The adapter's `operator` field-path / `notifyOperator` refs are **R13c (#444, adapters track)** — left for Luna.
- Fixed `an principal` → `a principal` article slips from the mechanical rename.

## Acceptance criteria

- [x] `grep -rE '\boperator\b' src/surface/mc/` → 0 outside `worker/migrations/` (historical)
- [x] `grep -rE 'operator filter|operator cockpit' src/surface/mc/ src/adapters/slack/__tests__/` → 0
- [x] `bunx tsc --noEmit` (root + worker) clean
- [x] `bun test src/surface/mc/ src/adapters/slack/` → 1226 pass, 0 fail
- [x] `bun build src/surface/mc/dashboard-v2/index.html …` succeeds

## Out of scope (pre-flagged)

- Adapter operator field-paths (`infra.operator.*`) + `notifyOperator` → **R13c #444** (Luna).
- The other ~48 `docs/` design docs with operator prose → separate R13 work.

Closes #450