### PR TITLE
feat(cortex): C-11 — drop signed_by[].principal shim (closes #452)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
         "@octokit/webhooks-methods": "^6.0.0",
         "@slack/socket-mode": "^2.0.7",
         "@slack/web-api": "^7.16.0",
-        "@the-metafactory/myelin": "https://github.com/the-metafactory/myelin.git#9fc8476e03f530561e7985bb6c0b1adf20a06bb5",
+        "@the-metafactory/myelin": "https://github.com/the-metafactory/myelin.git#4c54b8e6e2157524099f4f01f13c044bcc3b9291",
         "@xyflow/react": "^12.10.2",
         "ajv": "^8.20.0",
         "ajv-formats": "^3.0.1",
@@ -124,7 +124,7 @@
 
     "@slack/web-api": ["@slack/web-api@7.16.0", "", { "dependencies": { "@slack/logger": "^4.0.1", "@slack/types": "^2.21.0", "@types/node": ">=18", "@types/retry": "0.12.0", "axios": "^1.16.0", "eventemitter3": "^5.0.1", "form-data": "^4.0.4", "is-electron": "2.2.2", "is-stream": "^2", "p-queue": "^6", "p-retry": "^4", "retry": "^0.13.1" } }, "sha512-68SAV77uuGKuhyyaRytX8UijVnqSLsTSKslGXw17cjQYXn+jtNl7gbaEjHgC5x2rhCuFdahBrEC2VCLppbzReg=="],
 
-    "@the-metafactory/myelin": ["@the-metafactory/myelin@github:the-metafactory/myelin#9fc8476", { "dependencies": { "@msgpack/msgpack": "^3.1.3", "@nats-io/jetstream": "^3.4.0", "@nats-io/kv": "^3.4.0", "@nats-io/transport-node": "^3.4.0", "@noble/ed25519": "^3.1.0", "ajv": "8.20.0", "ajv-formats": "3.0.1" } }, "the-metafactory-myelin-9fc8476"],
+    "@the-metafactory/myelin": ["@the-metafactory/myelin@github:the-metafactory/myelin#4c54b8e", { "dependencies": { "@msgpack/msgpack": "^3.1.3", "@nats-io/jetstream": "^3.4.0", "@nats-io/kv": "^3.4.0", "@nats-io/transport-node": "^3.4.0", "@noble/ed25519": "^3.1.0", "ajv": "8.20.0", "ajv-formats": "3.0.1" } }, "the-metafactory-myelin-4c54b8e"],
 
     "@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
 

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@octokit/webhooks-methods": "^6.0.0",
     "@slack/socket-mode": "^2.0.7",
     "@slack/web-api": "^7.16.0",
-    "@the-metafactory/myelin": "https://github.com/the-metafactory/myelin.git#9fc8476e03f530561e7985bb6c0b1adf20a06bb5",
+    "@the-metafactory/myelin": "https://github.com/the-metafactory/myelin.git#4c54b8e6e2157524099f4f01f13c044bcc3b9291",
     "@xyflow/react": "^12.10.2",
     "ajv": "^8.20.0",
     "ajv-formats": "^3.0.1",

--- a/src/__tests__/iaw-phase-d-integration.test.ts
+++ b/src/__tests__/iaw-phase-d-integration.test.ts
@@ -541,13 +541,12 @@ describe("IAW Phase D.6.1 — cross-operator federated dispatch + reply (refs co
           ? [replyChain]
           : [];
       expect(replyStamps.length).toBe(1);
-      // R2 (vocabulary migration 2026-05) — myelin's signEnvelope emits
-      // the canonical `identity` key on every new stamp (PR-6 #169);
-      // the deprecated `principal` key would only appear on
-      // pre-migration / JetStream-replayed stamps. Dual-read keeps the
-      // test robust across the breaking-major drop.
-      // eslint-disable-next-line @typescript-eslint/no-deprecated
-      expect(replyStamps[0]?.identity ?? replyStamps[0]?.principal).toBe(beta.signerPrincipalDid);
+      // R11 (vocabulary migration 2026-05, post-myelin#184) — myelin's
+      // signEnvelope emits the canonical `identity` key on every new
+      // stamp; the deprecated `principal` key has been retired from
+      // the wire schema (the validator now rejects it as
+      // `additionalProperties`).
+      expect(replyStamps[0]?.identity).toBe(beta.signerPrincipalDid);
 
       // The originating dispatch carried α's stamp — assert that too
       // so the test docs both halves of the cross-operator audit trail.
@@ -558,8 +557,7 @@ describe("IAW Phase D.6.1 — cross-operator federated dispatch + reply (refs co
           ? [dispatchChain]
           : [];
       expect(dispatchStamps.length).toBe(1);
-      // eslint-disable-next-line @typescript-eslint/no-deprecated
-      expect(dispatchStamps[0]?.identity ?? dispatchStamps[0]?.principal).toBe(alpha.signerPrincipalDid);
+      expect(dispatchStamps[0]?.identity).toBe(alpha.signerPrincipalDid);
     },
   );
 });

--- a/src/bus/__tests__/bus-dispatch-listener.test.ts
+++ b/src/bus/__tests__/bus-dispatch-listener.test.ts
@@ -72,7 +72,8 @@ function resolverWith(...agents: Agent[]): TrustResolver {
 function ed25519Stamp(principal: string): SignedBy {
   return {
     method: "ed25519",
-    principal,
+    // R11 — stamp DID key is `identity` post-myelin#184.
+    identity: principal,
     signature: "A".repeat(88),
     at: "2026-05-15T11:00:00.000Z",
   };

--- a/src/bus/__tests__/surface-router.test.ts
+++ b/src/bus/__tests__/surface-router.test.ts
@@ -1425,7 +1425,8 @@ function makeFederatedEnvelope(overrides: Partial<Envelope> = {}): Envelope {
 function makeSignedByChain(principals: string[]): SignedBy[] {
   return principals.map((principal, i) => ({
     method: "ed25519" as const,
-    principal,
+    // R11 — stamp DID key is `identity` post-myelin#184.
+    identity: principal,
     signature: `sig-${i}`,
     at: "2026-05-09T12:00:00Z",
   }));
@@ -1885,7 +1886,7 @@ describe("createSurfaceRouter — D.2 federation gating end-to-end", () => {
     const payload = denied.payload;
     expect(payload.principal_id).toBe("did:mf:alpha-stack");
     expect(payload.signed_by).toHaveLength(2);
-    expect((payload.signed_by as { principal: string }[])[0]?.principal).toBe(
+    expect((payload.signed_by as { identity: string }[])[0]?.identity).toBe(
       "did:mf:alpha-stack",
     );
   });

--- a/src/bus/__tests__/verify-signed-by-chain.test.ts
+++ b/src/bus/__tests__/verify-signed-by-chain.test.ts
@@ -78,7 +78,10 @@ function agentFixture(overrides: Partial<Agent> = {}): Agent {
 function ed25519Stamp(principal: string): SignedBy {
   return {
     method: "ed25519",
-    principal,
+    // R11 — stamp DID key is `identity` (post-myelin#184); `principal`
+    // is no longer accepted on the wire. Parameter name kept as
+    // `principal` to keep test call-sites readable.
+    identity: principal,
     // 88-char base64 placeholder — the structural slice doesn't verify
     // signature bytes; B.1c will. Any string of the right rough shape.
     signature: "A".repeat(88),
@@ -89,7 +92,8 @@ function ed25519Stamp(principal: string): SignedBy {
 function hubStamp(principal: string, hub: string): SignedBy {
   return {
     method: "hub-stamp",
-    principal,
+    // R11 — stamp DID key is `identity` post-myelin#184.
+    identity: principal,
     stamped_by: hub,
     signature: "B".repeat(88),
     at: "2026-05-15T08:00:00.000Z",

--- a/src/bus/myelin/__tests__/envelope-validator.test.ts
+++ b/src/bus/myelin/__tests__/envelope-validator.test.ts
@@ -121,7 +121,7 @@ describe("envelope-validator", () => {
       ...(validEnvelope as object),
       signed_by: {
         method: "ed25519",
-        principal: "did:mf:luna",
+        identity: "did:mf:luna",
         signature: ED25519_SIG,
         at: "2026-05-08T09:00:00Z",
       },
@@ -143,7 +143,7 @@ describe("envelope-validator", () => {
       ...(validEnvelope as object),
       signed_by: {
         method: "hub-stamp",
-        principal: "did:mf:luna",
+        identity: "did:mf:luna",
         stamped_by: "did:mf:hub-eu-1",
         signature: ED25519_SIG,
         at: "2026-05-08T09:00:00Z",
@@ -166,7 +166,7 @@ describe("envelope-validator", () => {
       ...(validEnvelope as object),
       signed_by: {
         method: "ed25519",
-        principal: "did:mf:luna",
+        identity: "did:mf:luna",
         // signature: missing
         at: "2026-05-08T09:00:00Z",
       },
@@ -180,7 +180,7 @@ describe("envelope-validator", () => {
       ...(validEnvelope as object),
       signed_by: {
         method: "hub-stamp",
-        principal: "did:mf:luna",
+        identity: "did:mf:luna",
         // stamped_by: missing — required for hub-stamp shape
         signature: ED25519_SIG,
         at: "2026-05-08T09:00:00Z",
@@ -190,12 +190,12 @@ describe("envelope-validator", () => {
     expect(result.ok).toBe(false);
   });
 
-  test("rejects a signed_by with non-DID principal", () => {
+  test("rejects a signed_by with non-DID identity", () => {
     const env = {
       ...(validEnvelope as object),
       signed_by: {
         method: "ed25519",
-        principal: "not-a-did",
+        identity: "not-a-did",
         signature: ED25519_SIG,
         at: "2026-05-08T09:00:00Z",
       },
@@ -215,14 +215,14 @@ describe("envelope-validator", () => {
       signed_by: [
         {
           method: "ed25519",
-          principal: "did:mf:luna",
+          identity: "did:mf:luna",
           signature: ED25519_SIG,
           at: "2026-05-08T09:00:00Z",
           role: "origin",
         },
         {
           method: "hub-stamp",
-          principal: "did:mf:luna",
+          identity: "did:mf:luna",
           stamped_by: "did:mf:hub-eu-1",
           signature: ED25519_SIG,
           at: "2026-05-08T09:00:01Z",
@@ -250,13 +250,13 @@ describe("envelope-validator", () => {
       signed_by: [
         {
           method: "ed25519",
-          principal: "did:mf:luna",
+          identity: "did:mf:luna",
           signature: ED25519_SIG,
           at: "2026-05-08T09:00:00Z",
         },
         {
           method: "ed25519",
-          principal: "did:mf:luna",
+          identity: "did:mf:luna",
           // signature: missing — second stamp is malformed
           at: "2026-05-08T09:00:01Z",
         },
@@ -283,7 +283,7 @@ describe("envelope-validator", () => {
       signed_by: [
         {
           method: "ed25519",
-          principal: "did:mf:luna",
+          identity: "did:mf:luna",
           signature: ED25519_SIG,
           at: "2026-05-08T09:00:00Z",
           role: "notary",
@@ -441,7 +441,7 @@ describe("envelope-validator — chain helpers (IAW Phase A.2)", () => {
       ...(validEnvelope as unknown as Envelope),
       signed_by: {
         method: "ed25519",
-        principal: "did:mf:luna",
+        identity: "did:mf:luna",
         signature: ED25519_SIG,
         at: "2026-05-08T09:00:00Z",
       },
@@ -457,14 +457,14 @@ describe("envelope-validator — chain helpers (IAW Phase A.2)", () => {
       signed_by: [
         {
           method: "ed25519",
-          principal: "did:mf:luna",
+          identity: "did:mf:luna",
           signature: ED25519_SIG,
           at: "2026-05-08T09:00:00Z",
           role: "origin",
         },
         {
           method: "hub-stamp",
-          principal: "did:mf:luna",
+          identity: "did:mf:luna",
           stamped_by: "did:mf:hub-eu-1",
           signature: ED25519_SIG,
           at: "2026-05-08T09:00:01Z",
@@ -483,13 +483,13 @@ describe("envelope-validator — chain helpers (IAW Phase A.2)", () => {
       signed_by: [
         {
           method: "ed25519",
-          principal: "did:mf:luna",
+          identity: "did:mf:luna",
           signature: ED25519_SIG,
           at: "2026-05-08T09:00:00Z",
         },
         {
           method: "hub-stamp",
-          principal: "did:mf:luna",
+          identity: "did:mf:luna",
           stamped_by: "did:mf:hub-eu-1",
           signature: ED25519_SIG,
           at: "2026-05-08T09:00:01Z",
@@ -506,17 +506,19 @@ describe("envelope-validator — chain helpers (IAW Phase A.2)", () => {
   });
 
   // cortex#346 / myelin#161 — vendored getActorPrincipal mirror
-  test("getActorPrincipal prefers originator.principal over signed_by chain", () => {
+  test("getActorPrincipal prefers originator over signed_by chain", () => {
     const env: Envelope = {
       ...(validEnvelope as unknown as Envelope),
       signed_by: [
         {
           method: "ed25519",
-          principal: "did:mf:cortex",
+          identity: "did:mf:cortex",
           signature: ED25519_SIG,
           at: "2026-05-08T09:00:00Z",
         },
       ],
+      // R2 originator dual-read still active — `principal` key remains
+      // accepted alongside `identity` until the originator lockstep PR.
       originator: {
         principal: "did:mf:alice",
         attribution: "adapter-resolved",
@@ -525,13 +527,13 @@ describe("envelope-validator — chain helpers (IAW Phase A.2)", () => {
     expect(getActorPrincipal(env)).toBe("did:mf:alice");
   });
 
-  test("getActorPrincipal falls back to signed_by[0].principal when originator absent", () => {
+  test("getActorPrincipal falls back to signed_by[0].identity when originator absent", () => {
     const env: Envelope = {
       ...(validEnvelope as unknown as Envelope),
       signed_by: [
         {
           method: "ed25519",
-          principal: "did:mf:cortex",
+          identity: "did:mf:cortex",
           signature: ED25519_SIG,
           at: "2026-05-08T09:00:00Z",
         },
@@ -580,15 +582,16 @@ describe("envelope-validator — chain helpers (IAW Phase A.2)", () => {
     // The transition schema accepts BOTH the deprecated and the renamed
     // form so pre-migration / JetStream-replayed envelopes still validate.
     //
-    // cortex#409 — bumped e37b347 → 9fc8476 (latest myelin main) to align
-    // cortex and sage on a single myelin commit. The OLD sage pin (3ec0ace)
-    // predated the vocabulary migration and validated signed_by[].principal
-    // only, so it rejected cortex's renamed signed_by[].identity stamps over
-    // the bus. The envelope JSON Schema is byte-identical between e37b347 and
-    // 9fc8476 (the bump only adds myelin#181's 'chat' seed-taxonomy entry),
-    // so the vendored schema is unchanged — only this pin moves.
+    // cortex#452 / PR-R11 — bumped 9fc8476 → 4c54b8e (myelin main post-#184)
+    // to land the breaking cut on stamp DIDs: `signed_by[].principal` is no
+    // longer accepted on the wire (the deprecated key is now rejected as
+    // `additionalProperties`). The vendored schema picks up the v3 `$id`
+    // (`/schemas/envelope/v3`) and the source-grammar tightening to the
+    // fixed-3 form `{principal}.{stack}.{assistant}` (myelin#183). The
+    // matching cortex-side reader shim drop ships here per
+    // docs/migrations/0002-vocabulary-finish-2026-05.md §PR-R11.
     expect(SCHEMA_SOURCE_COMMIT).toBe(
-      "9fc8476e03f530561e7985bb6c0b1adf20a06bb5",
+      "4c54b8e6e2157524099f4f01f13c044bcc3b9291",
     );
   });
 

--- a/src/bus/myelin/__tests__/runtime.test.ts
+++ b/src/bus/myelin/__tests__/runtime.test.ts
@@ -673,10 +673,10 @@ describe("MyelinRuntime", () => {
       expect(published.signed_by).toHaveLength(1);
       const stamp = published.signed_by?.[0];
       expect(stamp?.method).toBe("ed25519");
-      // R2 (vocabulary migration 2026-05) — myelin emits the canonical
-      // `identity` key now (PR-6 #169); the deprecated `principal` key
-      // would only appear on pre-migration / JetStream-replayed stamps.
-      expect(stamp?.identity ?? stamp?.principal).toBe("did:mf:test-stack");
+      // R11 (vocabulary migration 2026-05, post-myelin#184) — stamps
+      // emit `identity` only; the deprecated `principal` key has been
+      // retired from the wire schema.
+      expect(stamp?.identity).toBe("did:mf:test-stack");
       // Signature shape: base64 of 64 raw bytes ≈ 88 chars.
       expect(stamp?.signature.length).toBeGreaterThanOrEqual(86);
 
@@ -729,16 +729,15 @@ describe("MyelinRuntime", () => {
 
       const payload = fake.publishes[0]?.payload as string;
       const published = JSON.parse(payload) as {
-        signed_by: { identity?: string; principal?: string }[];
+        signed_by: { identity: string }[];
       };
 
-      // R2 (vocabulary migration 2026-05) — both stamps now emit the
-      // canonical `identity` key (myelin's signEnvelope writes `identity`
-      // post PR-6). The dual-read `identity ?? principal` keeps the test
-      // robust against the future breaking-major drop of `principal`.
+      // R11 (vocabulary migration 2026-05, post-myelin#184) — stamps
+      // emit `identity` only; the deprecated `principal` key was
+      // retired from the wire schema in myelin#184.
       expect(published.signed_by).toHaveLength(2);
-      expect(published.signed_by[0]?.identity ?? published.signed_by[0]?.principal).toBe("did:mf:peer-x");
-      expect(published.signed_by[1]?.identity ?? published.signed_by[1]?.principal).toBe("did:mf:our-stack");
+      expect(published.signed_by[0]?.identity).toBe("did:mf:peer-x");
+      expect(published.signed_by[1]?.identity).toBe("did:mf:our-stack");
 
       await runtime.stop();
     });

--- a/src/bus/myelin/envelope-validator.ts
+++ b/src/bus/myelin/envelope-validator.ts
@@ -75,7 +75,7 @@ import schema from "./vendor/envelope.schema.json" with { type: "json" };
  * comments + tests use `myelin#161` to point at the merge that landed the
  * feature — they're the same change, different ticket facets.
  */
-export const SCHEMA_SOURCE_COMMIT = "9fc8476e03f530561e7985bb6c0b1adf20a06bb5";
+export const SCHEMA_SOURCE_COMMIT = "4c54b8e6e2157524099f4f01f13c044bcc3b9291";
 
 /**
  * Hand-typed Envelope shape matching the JSON Schema. We hand-write rather
@@ -192,7 +192,7 @@ export interface Envelope {
    *
    * Cortex callers should resolve the policy actor via the upstream
    * `getActorPrincipal(envelope)` helper rather than reading this field
-   * directly — that helper falls back to `signed_by[0].principal` for
+   * directly — that helper falls back to `signed_by[0].identity` for
    * legacy envelopes that pre-date myelin#161.
    */
   originator?: Originator;
@@ -449,13 +449,12 @@ export function getLastStampPrincipal(envelope: Envelope): string | undefined {
   if (chain.length === 0) return undefined;
   const last = chain[chain.length - 1];
   if (!last) return undefined;
-  // R2 (vocabulary migration 2026-05) — dual-read: canonical `identity`
-  // wins, fall back to the deprecated `principal` for pre-migration /
-  // JetStream-replayed stamps. The validator's conflict-rejection rule
-  // (both keys present) fires upstream at envelope validation, so by
-  // the time this helper runs at most one key is set.
-  // eslint-disable-next-line @typescript-eslint/no-deprecated
-  return last.identity ?? last.principal;
+  // R11 (vocabulary migration 2026-05, post-myelin#184): stamps emit
+  // `identity` only — the `?? principal` fallback that handled pre-cut
+  // peers is retired per docs/migrations/0002-vocabulary-finish-2026-05.md
+  // §PR-R11. JetStream-replayed pre-migration stamps are rejected upstream
+  // by the envelope validator (the `principal` key is now `additionalProperties: false`).
+  return last.identity;
 }
 
 /**
@@ -466,13 +465,15 @@ export function getLastStampPrincipal(envelope: Envelope): string | undefined {
  * vendored here so cortex's `Envelope` type can be passed directly without
  * a cross-package cast):
  *
- *   1. `envelope.originator?.principal` — explicit policy-attribution
+ *   1. `envelope.originator?.identity` — explicit policy-attribution
  *      claim, covered by the envelope signature (`originator` is in
  *      myelin's SIGNABLE_FIELDS post-#161, so tampering invalidates the
- *      chain).
- *   2. `envelope.signed_by[0]?.principal` — first stamp in the chain.
+ *      chain). Still dual-reads the deprecated `principal` key during
+ *      the R2 transition window (myelin canonicalizes either form).
+ *   2. `envelope.signed_by[0]?.identity` — first stamp in the chain.
  *      Legacy-compat fallback for pre-#161 envelopes that never set an
- *      `originator`.
+ *      `originator`. The `principal` key was retired from stamps in
+ *      myelin#184 (R11), so this reads `identity` only.
  *   3. `undefined` — unsigned envelope with no originator block. Callers
  *      decide the fallback (e.g. `payload.agent_id` in the dispatch
  *      listener path).
@@ -495,11 +496,13 @@ export function getLastStampPrincipal(envelope: Envelope): string | undefined {
  * will catch them if they diverge until that follow-up lands.
  */
 export function getActorPrincipal(envelope: Envelope): string | undefined {
-  // R2 (vocabulary migration 2026-05) — dual-read at both surfaces: the
-  // originator's actor DID and the first stamp's DID. Canonical key is
-  // `identity`; falls back to the deprecated `principal` for
-  // pre-migration / JetStream-replayed envelopes. The validator's
-  // conflict-rejection rule (both keys present) fires upstream.
+  // R11 (vocabulary migration 2026-05, post-myelin#184): stamps emit
+  // `identity` only — the signed_by-side `?? principal` fallback has
+  // been dropped per docs/migrations/0002-vocabulary-finish-2026-05.md
+  // §PR-R11. The originator-side dual-read remains: myelin's R2
+  // transition is still active for the originator block, so we accept
+  // either `originator.identity` (canonical) or `originator.principal`
+  // (deprecated) until the originator R2 lockstep PR.
   if (envelope.originator) {
     // eslint-disable-next-line @typescript-eslint/no-deprecated
     const orig = envelope.originator.identity ?? envelope.originator.principal;
@@ -508,8 +511,7 @@ export function getActorPrincipal(envelope: Envelope): string | undefined {
   const chain = getSignedByChain(envelope);
   const first = chain[0];
   if (!first) return undefined;
-  // eslint-disable-next-line @typescript-eslint/no-deprecated
-  return first.identity ?? first.principal;
+  return first.identity;
 }
 
 /**
@@ -545,8 +547,9 @@ export function getFirstStampPrincipal(
   const chain = getSignedByChain(envelope);
   const first = chain[0];
   if (!first) return fallback;
-  // eslint-disable-next-line @typescript-eslint/no-deprecated
-  return first.identity ?? first.principal ?? fallback;
+  // R11 (vocabulary migration 2026-05, post-myelin#184): stamps emit
+  // `identity` only — the `?? principal` fallback has been dropped.
+  return first.identity ?? fallback;
 }
 
 /**

--- a/src/bus/myelin/runtime.ts
+++ b/src/bus/myelin/runtime.ts
@@ -296,8 +296,8 @@ export interface MyelinRuntimeOptions {
  * generated keypair.
  *
  * `principal` is the DID-shaped string that lands on the new stamp's
- * `signed_by[].principal` field. Convention: `did:mf:<name>` per
- * myelin spec.
+ * `signed_by[].identity` field (R11 — renamed from `principal` per
+ * myelin#184). Convention: `did:mf:<name>` per myelin spec.
  */
 export interface BusEnvelopeSigner {
   rawSeedBytes: Uint8Array;

--- a/src/bus/myelin/vendor/envelope.schema.json
+++ b/src/bus/myelin/vendor/envelope.schema.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://myelin.metafactory.ai/schemas/envelope/v2",
+  "$id": "https://myelin.metafactory.ai/schemas/envelope/v3",
   "title": "Myelin Envelope",
-  "description": "Universal message envelope for the agentic nervous system. One schema for all signals — sovereignty travels with the message. v2 (vocabulary migration 2026-05, transition release): wire fields renamed — signed_by[].principal→identity, originator.principal→identity, target_principal→target_assistant, distribution_mode broadcast→offer, source grammar org.agent.instance→{principal}.{stack}.{assistant}. This transition schema accepts BOTH the deprecated and the renamed form so pre-migration / JetStream-replayed envelopes still validate; the breaking major drops the deprecated forms. v1 stays published for consumers pinned to the old grammar.",
+  "description": "Universal message envelope for the agentic nervous system. One schema for all signals — sovereignty travels with the message. v3 (vocabulary migration 2026-05, breaking cuts myelin#182 + myelin#183): `signed_by[].principal` → `identity` (myelin#182 — old key dropped from the wire) and `{org}` → `{principal}` with the `source` grammar tightened to the fixed-3 form `{principal}.{stack}.{assistant}` (myelin#183 — legacy 3–5 segment `org.agent.instance` shape no longer accepted; that was the shape the pilot review-loop bug exploited, see CONTEXT.md line 99). The schema still accepts the deprecated form for the remaining transition fields (originator, target_principal, distribution_mode broadcast) so pre-migration / JetStream-replayed envelopes validate; subsequent breaking cuts drop those. v2 stays published for consumers pinned to the transition grammar; v1 stays published for consumers pinned to the pre-migration grammar.",
   "type": "object",
   "required": ["id", "source", "type", "timestamp", "sovereignty", "payload"],
   "properties": {
@@ -13,8 +13,8 @@
     },
     "source": {
       "type": "string",
-      "pattern": "^[a-z][a-z0-9-]*(\\.[a-z][a-z0-9-]*){2,4}$",
-      "description": "Origin address. Canonical grammar (R6, vocabulary migration 2026-05) is the fixed-3 form {principal}.{stack}.{assistant}. This transition schema keeps the legacy {2,4} pattern (3-5 segments, org.agent.instance) so pre-migration / JetStream-replayed envelopes still validate — the fixed-3 form is a strict subset. The breaking major tightens the pattern to exactly 3 segments.",
+      "pattern": "^[a-z][a-z0-9-]*(\\.[a-z][a-z0-9-]*){2}$",
+      "description": "Origin address. Canonical grammar (R6 + myelin#183) is the fixed-3 form {principal}.{stack}.{assistant} — exactly 3 segments. The legacy `org.agent.instance` 3–5 segment shape is no longer accepted (the breaking cut; CONTEXT.md line 99).",
       "examples": ["metafactory.security.luna", "metafactory.pilot.local", "acme.monitor.prod-01"]
     },
     "type": {
@@ -227,43 +227,31 @@
   "$defs": {
     "signedByStamp": {
       "type": "object",
-      "description": "A single identity attestation in the chain (myelin#31). Discriminated on method. R2 (vocabulary migration 2026-05): the stamp DID field renamed 'principal'→'identity'. This transition schema accepts EITHER key (each method branch requires exactly one of them) and rejects a stamp carrying BOTH via the dualKeyExclusion constraint.",
-      "allOf": [
+      "description": "A single identity attestation in the chain (myelin#31). Discriminated on method. R2 (vocabulary migration 2026-05, myelin#182 breaking cut): the stamp DID field is canonical 'identity'. The deprecated 'principal' key was removed from the wire in v0.3.0 — stamps carrying it are rejected by `additionalProperties: false`.",
+      "required": ["identity"],
+      "oneOf": [
         {
-          "oneOf": [
-            {
-              "required": ["method", "signature", "at"],
-              "properties": {
-                "method": { "const": "ed25519" },
-                "identity": { "type": "string", "pattern": "^did:mf:[a-z](?:[a-z0-9._]|-(?!-))+$" },
-                "principal": { "type": "string", "pattern": "^did:mf:[a-z](?:[a-z0-9._]|-(?!-))+$" },
-                "signature": { "type": "string", "minLength": 88, "pattern": "^[A-Za-z0-9+/]+=*$" },
-                "at": { "type": "string", "format": "date-time" },
-                "role": { "$ref": "#/$defs/stampRole" }
-              },
-              "additionalProperties": false
-            },
-            {
-              "required": ["method", "stamped_by", "signature", "at"],
-              "properties": {
-                "method": { "const": "hub-stamp" },
-                "identity": { "type": "string", "pattern": "^did:mf:[a-z](?:[a-z0-9._]|-(?!-))+$" },
-                "principal": { "type": "string", "pattern": "^did:mf:[a-z](?:[a-z0-9._]|-(?!-))+$" },
-                "stamped_by": { "type": "string", "pattern": "^did:mf:[a-z](?:[a-z0-9._]|-(?!-))+$" },
-                "signature": { "type": "string", "minLength": 88, "pattern": "^[A-Za-z0-9+/]+=*$" },
-                "at": { "type": "string", "format": "date-time" },
-                "role": { "$ref": "#/$defs/stampRole" }
-              },
-              "additionalProperties": false
-            }
-          ]
+          "required": ["method", "signature", "at"],
+          "properties": {
+            "method": { "const": "ed25519" },
+            "identity": { "type": "string", "pattern": "^did:mf:[a-z](?:[a-z0-9._]|-(?!-))+$" },
+            "signature": { "type": "string", "minLength": 88, "pattern": "^[A-Za-z0-9+/]+=*$" },
+            "at": { "type": "string", "format": "date-time" },
+            "role": { "$ref": "#/$defs/stampRole" }
+          },
+          "additionalProperties": false
         },
         {
-          "comment": "R2 — a stamp must carry exactly one DID key: 'identity' (canonical) or 'principal' (deprecated). Neither-present and both-present are both rejected.",
-          "oneOf": [
-            { "required": ["identity"], "not": { "required": ["principal"] } },
-            { "required": ["principal"], "not": { "required": ["identity"] } }
-          ]
+          "required": ["method", "stamped_by", "signature", "at"],
+          "properties": {
+            "method": { "const": "hub-stamp" },
+            "identity": { "type": "string", "pattern": "^did:mf:[a-z](?:[a-z0-9._]|-(?!-))+$" },
+            "stamped_by": { "type": "string", "pattern": "^did:mf:[a-z](?:[a-z0-9._]|-(?!-))+$" },
+            "signature": { "type": "string", "minLength": 88, "pattern": "^[A-Za-z0-9+/]+=*$" },
+            "at": { "type": "string", "format": "date-time" },
+            "role": { "$ref": "#/$defs/stampRole" }
+          },
+          "additionalProperties": false
         }
       ]
     },

--- a/src/bus/system-events.ts
+++ b/src/bus/system-events.ts
@@ -886,10 +886,10 @@ export interface SystemAccessFederationDeniedOpts {
 export function createSystemAccessFederationDeniedEvent(
   opts: SystemAccessFederationDeniedOpts,
 ): Envelope {
-  // R2 (vocabulary migration 2026-05) — dual-read stamp DID: canonical
-  // `identity` wins, fall back to deprecated `principal`.
-  // eslint-disable-next-line @typescript-eslint/no-deprecated
-  const principalId = opts.signedBy[0]?.identity ?? opts.signedBy[0]?.principal ?? "unknown";
+  // R11 (vocabulary migration 2026-05, post-myelin#184): stamps emit
+  // `identity` only — the `?? principal` fallback has been dropped per
+  // docs/migrations/0002-vocabulary-finish-2026-05.md §PR-R11.
+  const principalId = opts.signedBy[0]?.identity ?? "unknown";
   return buildBaseEnvelope({
     type: "system.access.denied",
     source: buildSource(opts.source),

--- a/src/bus/verify-signed-by-chain.ts
+++ b/src/bus/verify-signed-by-chain.ts
@@ -334,12 +334,12 @@ function verifyOneStamp(
   }
   // Discriminated union — narrows to SignedByEd25519 once hub-stamp is out.
 
-  // R2 (vocabulary migration 2026-05) — dual-read the stamp DID:
-  // canonical `identity` wins, fall back to deprecated `principal`
-  // for pre-migration / JetStream-replayed stamps. The envelope-level
-  // dual_field_conflict check fires upstream at envelope validation.
-  // eslint-disable-next-line @typescript-eslint/no-deprecated
-  const principal = stamp.identity ?? stamp.principal;
+  // R11 (vocabulary migration 2026-05, post-myelin#184): myelin no
+  // longer emits `signed_by[].principal` on the wire — read `identity`
+  // directly. The dual-read shim that handled JetStream-replayed
+  // pre-migration stamps has been retired per docs/migrations/
+  // 0002-vocabulary-finish-2026-05.md §PR-R11.
+  const principal = stamp.identity;
   if (principal === undefined) {
     return {
       kind: "reject",

--- a/src/runner/__tests__/dispatch-listener.test.ts
+++ b/src/runner/__tests__/dispatch-listener.test.ts
@@ -1120,7 +1120,7 @@ describe("dispatch-listener — policy gating (C.3.1)", () => {
     });
   });
 
-  test("engine + signed_by[0].principal as did:mf:NAME → prefix stripped, principal resolved", async () => {
+  test("engine + signed_by[0].identity as did:mf:NAME → prefix stripped, principal resolved", async () => {
     const r = recordingRuntime();
     const router = createSurfaceRouter(r.runtime);
     const { factory } = fakeFactory(SUCCESS_RESULT);
@@ -1138,7 +1138,7 @@ describe("dispatch-listener — policy gating (C.3.1)", () => {
     env.signed_by = [
       {
         method: "ed25519",
-        principal: "did:mf:cortex",
+        identity: "did:mf:cortex",
         signature: "a".repeat(88),
         at: "2026-05-15T12:00:00Z",
       },
@@ -1155,9 +1155,9 @@ describe("dispatch-listener — policy gating (C.3.1)", () => {
     // C.4.3 — system.access.allowed carries signed_by from the
     // originating envelope verbatim.
     const allowed = r.published[0]!;
-    const signedBy = allowed.payload.signed_by as { principal: string }[];
+    const signedBy = allowed.payload.signed_by as { identity: string }[];
     expect(signedBy).toHaveLength(1);
-    expect(signedBy[0]!.principal).toBe("did:mf:cortex");
+    expect(signedBy[0]!.identity).toBe("did:mf:cortex");
   });
 
   test("C.4.1 — system.access.allowed payload shape (capability, capabilities, sovereignty, signed_by)", async () => {
@@ -1224,14 +1224,14 @@ describe("dispatch-listener — policy gating (C.3.1)", () => {
     env.signed_by = [
       {
         method: "ed25519",
-        principal: "did:mf:cortex",
+        identity: "did:mf:cortex",
         signature: "a".repeat(88),
         at: "2026-05-15T12:00:00Z",
         role: "origin",
       },
       {
         method: "hub-stamp",
-        principal: "did:mf:cortex",
+        identity: "did:mf:cortex",
         stamped_by: "did:mf:metafactory-hub",
         signature: "b".repeat(88),
         at: "2026-05-15T12:00:01Z",
@@ -1561,7 +1561,7 @@ describe("dispatch-listener — policy gating (C.3.1)", () => {
     env.signed_by = [
       {
         method: "ed25519",
-        principal: "did:mf:cortex",
+        identity: "did:mf:cortex",
         signature: "a".repeat(88),
         at: "2026-05-15T12:00:00Z",
       },
@@ -1582,9 +1582,9 @@ describe("dispatch-listener — policy gating (C.3.1)", () => {
     expect(reason.kind).toBe("insufficient_role");
     expect(reason.missing_capability).toBe("dispatch.cortex");
     // C.4.3 — signed_by chain carried verbatim from originating envelope.
-    const signedBy = denied.payload.signed_by as { principal: string }[];
+    const signedBy = denied.payload.signed_by as { identity: string }[];
     expect(signedBy).toHaveLength(1);
-    expect(signedBy[0]!.principal).toBe("did:mf:cortex");
+    expect(signedBy[0]!.identity).toBe("did:mf:cortex");
   });
 });
 
@@ -1641,7 +1641,8 @@ function runnerResolverWith(...agents: Agent[]): TrustResolver {
 function runnerEd25519Stamp(principal: string) {
   return {
     method: "ed25519" as const,
-    principal,
+    // R11 — stamp DID key is `identity` post-myelin#184.
+    identity: principal,
     signature: "A".repeat(88),
     at: "2026-05-15T12:00:00.000Z",
   };
@@ -1994,17 +1995,20 @@ describe("dispatch-listener — chain verification (cortex#320)", () => {
  * cortex#346 — runner consumes the new `Envelope.originator` field (myelin#161).
  *
  * Precedence rule we assert (delegates to myelin's `getActorPrincipal`):
- *   1. `envelope.originator?.principal`  ← policy-attribution claim
- *   2. `envelope.signed_by[0]?.principal` ← legacy compat for pre-#161 envelopes
+ *   1. `envelope.originator?.identity`  ← policy-attribution claim
+ *      (originator still dual-reads the deprecated `principal` key
+ *      during the R2 transition window)
+ *   2. `envelope.signed_by[0]?.identity` ← legacy compat for pre-#161 envelopes
+ *      (stamp-level `principal` was retired in myelin#184 / R11)
  *   3. `payload.agent_id`                 ← adapter-direct dispatches with no chain
  *
  * Tamper case is covered by the chain-verification suite above — `originator`
- * is in myelin's SIGNABLE_FIELDS, so mutating either `principal` or
- * `attribution` after signing invalidates the chain. We add one explicit
+ * is in myelin's SIGNABLE_FIELDS, so mutating either `identity`/`principal`
+ * or `attribution` after signing invalidates the chain. We add one explicit
  * tamper test here to pin the contract from cortex's side.
  */
 describe("dispatch-listener — originator (cortex#346 / myelin#161)", () => {
-  test("originator.principal wins over signed_by[0].principal for engine lookup", async () => {
+  test("originator.principal wins over signed_by[0].identity for engine lookup", async () => {
     // When both are present, the policy engine must see the originator's
     // principal id (the actor the signer is attesting on behalf of), NOT
     // the signer's principal id. This decouples policy attribution from
@@ -2047,12 +2051,15 @@ describe("dispatch-listener — originator (cortex#346 / myelin#161)", () => {
     env.signed_by = [
       {
         method: "ed25519",
-        principal: "did:mf:cortex",
+        identity: "did:mf:cortex",
         signature: "a".repeat(88),
         at: "2026-05-19T12:00:00Z",
       },
     ];
     env.originator = {
+      // R2 (originator dual-read still active): the `principal` key is
+      // accepted alongside `identity` until the originator R2 lockstep
+      // PR. Stamp-level `principal` was retired in myelin#184 / R11.
       principal: "did:mf:alice",
       attribution: "adapter-resolved",
     };
@@ -2064,7 +2071,7 @@ describe("dispatch-listener — originator (cortex#346 / myelin#161)", () => {
     expect(captured[0]!.principalId).toBe("alice");
   });
 
-  test("originator absent + signed_by[0].principal present → falls back to signer (legacy compat)", async () => {
+  test("originator absent + signed_by[0].identity present → falls back to signer (legacy compat)", async () => {
     // Pre-myelin#161 envelopes have no `originator`. Behaviour must remain
     // identical to the pre-#346 path: principal id is taken from the
     // first stamp in the chain.
@@ -2104,7 +2111,7 @@ describe("dispatch-listener — originator (cortex#346 / myelin#161)", () => {
     env.signed_by = [
       {
         method: "ed25519",
-        principal: "did:mf:cortex",
+        identity: "did:mf:cortex",
         signature: "a".repeat(88),
         at: "2026-05-19T12:00:00Z",
       },

--- a/src/runner/dispatch-listener.ts
+++ b/src/runner/dispatch-listener.ts
@@ -635,8 +635,9 @@ async function handleDispatchEnvelope(
 
   // IAW Phase B wiring (cortex#320, v2.0.2) — verify the envelope's
   // `signed_by[]` chain BEFORE resolving the principal. The runner used
-  // to read `signed_by[0].principal` at face value (cortex#220 round 1's
-  // "authorization-without-authentication" gap). Now we structurally
+  // to read `signed_by[0].identity` at face value (cortex#220 round 1's
+  // "authorization-without-authentication" gap; the field was named
+  // `principal` pre-myelin#184). Now we structurally
   // trust-check every ed25519 stamp and, by default, also cryptographically
   // verify each stamp's signature over the JCS-canonical envelope bytes.
   //
@@ -967,12 +968,13 @@ type DispatchPolicyResult =
  * verify. This closes the cortex#220 round-1
  * "authorization-without-authentication" gap that lived here pre-Phase-B.
  *
- * **Principal resolution.** Read `envelope.signed_by[0].principal`
- * (originator stamp per myelin#31 chain semantics). Strip the
- * `did:mf:` prefix to match `Principal.id`. If no chain is present
- * (legitimate for adapter-originated dispatches), fall back to
- * `payload.agent_id` — the engine will reject with `unknown_principal`
- * unless the agent is also a declared principal in the policy block.
+ * **Principal resolution.** Read `envelope.signed_by[0].identity`
+ * (originator stamp per myelin#31 chain semantics; renamed from
+ * `principal` in myelin#184 / R11). Strip the `did:mf:` prefix to
+ * match `Principal.id`. If no chain is present (legitimate for
+ * adapter-originated dispatches), fall back to `payload.agent_id` —
+ * the engine will reject with `unknown_principal` unless the agent
+ * is also a declared principal in the policy block.
  *
  * **Capability claim.** `dispatch.<agent_id>` — the dispatch surface
  * is "may principal X invoke agent Y on this stack?". C.2b will let
@@ -1036,11 +1038,14 @@ function checkDispatchPolicy(
  * cortex#346 / myelin#161 — defers to myelin's `getActorPrincipal()` so
  * the precedence rule lives in ONE place (envelope schema owner):
  *
- *   1. `envelope.originator?.principal` ← policy-attribution claim,
+ *   1. `envelope.originator?.identity` ← policy-attribution claim,
  *      covered by the envelope signature (SIGNABLE_FIELDS post-#161).
- *      Tampering with `originator.principal` OR `originator.attribution`
+ *      Tampering with `originator.identity` OR `originator.attribution`
  *      invalidates the chain → caught by `verifySignedByChain` upstream.
- *   2. `envelope.signed_by[0]?.principal` ← legacy compat for pre-#161
+ *      (Originator block still dual-reads the deprecated `principal`
+ *      key during the R2 transition window; stamp-level `principal`
+ *      was retired in myelin#184 / R11.)
+ *   2. `envelope.signed_by[0]?.identity` ← legacy compat for pre-#161
  *      envelopes that never set an `originator`.
  *   3. `payload.agent_id` ← adapter-direct (non-bus) dispatches with no
  *      signed chain; belt-and-braces called out as out-of-scope-to-remove
@@ -1216,7 +1221,7 @@ async function emitCanonicalRecipientMismatch(
  * legitimate principal failing the policy gate.
  *
  * The `principalId` on the audit envelope is set to the raw
- * `signed_by[0].principal` (or `"<unverified>"` for empty chains)
+ * `signed_by[0].identity` (or `"<unverified>"` for empty chains)
  * deliberately — the chain didn't verify, so we don't claim a
  * resolved principal. Subscribers correlating on principal id
  * branch on `reason.kind === "chain_verification_failed"` first.

--- a/src/substrates/bus-peer/__tests__/harness.test.ts
+++ b/src/substrates/bus-peer/__tests__/harness.test.ts
@@ -146,7 +146,8 @@ function inboundEnvelope(opts: {
     ...(opts.signerPrincipal !== undefined && {
       signed_by: {
         method: "ed25519" as const,
-        principal: opts.signerPrincipal,
+        // R11 — stamp DID key is `identity` post-myelin#184.
+        identity: opts.signerPrincipal,
         signature: "A".repeat(88),
         at: "2026-05-15T08:30:00.000Z",
       },
@@ -283,7 +284,7 @@ describe("BusPeerHarness — round-trip + verification gate", () => {
         // The yielded envelope's signer must be echo, not holly.
         const signedBy = next.value.signed_by;
         const stamp = Array.isArray(signedBy) ? signedBy[0] : signedBy;
-        expect(stamp?.principal).toBe("did:mf:echo");
+        expect(stamp?.identity).toBe("did:mf:echo");
       }
 
       const done = await iterator.next();
@@ -392,7 +393,7 @@ describe("BusPeerHarness — round-trip + verification gate", () => {
       payload: { step: 1 },
       signed_by: {
         method: "ed25519",
-        principal: "did:mf:echo",
+        identity: "did:mf:echo",
         signature: "A".repeat(88),
         at: "2026-05-15T10:30:00.000Z",
       },
@@ -701,7 +702,7 @@ describe("BusPeerHarness — round-trip + verification gate", () => {
         // Must be the signed envelope, not the unsigned one.
         const signedBy = next.value.signed_by;
         const stamp = Array.isArray(signedBy) ? signedBy[0] : signedBy;
-        expect(stamp?.principal).toBe("did:mf:echo");
+        expect(stamp?.identity).toBe("did:mf:echo");
       }
 
       const closed = await iterator.next();


### PR DESCRIPTION
## Summary

LOCKSTEP PR-R11 — single-cut drop of the `signed_by[].principal` reader shim across cortex now that myelin no longer emits `.principal` on the wire.

Per [docs/migrations/0002-vocabulary-finish-2026-05.md §7 + §PR-R11](../tree/main/docs/migrations/0002-vocabulary-finish-2026-05.md): no permanent fallback period. myelin#184 retired the deprecated key (the v3 envelope schema now rejects `principal` on stamps as `additionalProperties: false`), so every peer emits `.identity` — keeping the fallback hides drift bugs.

## Changes

**Dep bump:** `@the-metafactory/myelin` `9fc8476` → `4c54b8e` (myelin main post-#184). Vendored schema (`src/bus/myelin/vendor/envelope.schema.json`) re-synced from upstream; `SCHEMA_SOURCE_COMMIT` bumped to match.

**Reader-side (drop the `?? stamp.principal` fallback):**
- `src/bus/verify-signed-by-chain.ts:342`
- `src/bus/myelin/envelope-validator.ts` — `getLastStampPrincipal`, `getActorPrincipal` (signed_by side only), `getFirstStampPrincipal`
- `src/bus/system-events.ts:892` — `createSystemAccessFederationDeniedEvent` payload `principal_id`

**Doc comments:** long-form prose in `src/runner/dispatch-listener.ts` (638, 970, 1039–1043, 1219) and `src/bus/myelin/runtime.ts:299` rewritten to reflect the new shape.

**Test cascades (§PR-R11):** stamp fixtures + assertions migrated `.principal` → `.identity` across `dispatch-listener.test.ts`, `envelope-validator.test.ts`, `runtime.test.ts`, `surface-router.test.ts`, `verify-signed-by-chain.test.ts`, `bus-dispatch-listener.test.ts`, `harness.test.ts`, `iaw-phase-d-integration.test.ts`. Originator-block fixtures (`originator.principal`) left untouched — that side is still on dual-read (R2 originator transition stays active until its own lockstep PR; same for R13 `target_principal`).

## Scope boundary

This PR only drops the **stamp-level** `signed_by[].principal` reader shim, matching what myelin#184 actually cut on the wire. The originator block and `target_principal` field stay on dual-read. Per the migration plan, R11 splits along that boundary on purpose.

## Test plan

- [x] `bunx tsc --noEmit` → clean
- [x] `bun test` → **3545 pass / 0 fail**
- [x] `bun run lint:errors` → clean
- [x] `grep -rEn '\.identity\s*\?\?\s*[a-zA-Z_.?]*\.principal' src/` → only the originator-side dual-read remains (in-scope keep)
- [x] `grep -rEn 'stamp\.principal|signedBy\[\d+\][!.?]*\.principal' src/` → zero hits

Closes #452. Refs cortex#436 (umbrella).

🤖 Generated with [Claude Code](https://claude.com/claude-code)