### PR TITLE
feat(cortex): C-4 — drop {org} placeholder + rename org→principal (closes #453)

### DIFF
--- a/src/__tests__/cortex.review-consumer.e2e.test.ts
+++ b/src/__tests__/cortex.review-consumer.e2e.test.ts
@@ -315,7 +315,7 @@ function createBusRuntime(): BusRuntime {
 // =============================================================================
 
 const SOURCE: ReviewEventSource = {
-  org: "metafactory",
+  principal: "metafactory",
   agent: "cortex",
   instance: "local",
 };

--- a/src/__tests__/cortex.review-consumer.e2e.test.ts
+++ b/src/__tests__/cortex.review-consumer.e2e.test.ts
@@ -213,12 +213,12 @@ interface BusRuntime extends MyelinRuntime {
  * the legacy 5-segment shape Echo + cortex publish on today.
  *
  * `envelope.source` is the dotted triple `"{principal}.{agent}.{instance}"`;
- * pull the first segment as the org for the subject prefix.
+ * pull the first segment as the principal for the subject prefix.
  */
 function subjectFor(envelope: Envelope): string {
   const sov = envelope.sovereignty.classification;
-  const org = envelope.source.split(".")[0] ?? "metafactory";
-  return `${sov}.${org}.${envelope.type}`;
+  const principal = envelope.source.split(".")[0] ?? "metafactory";
+  return `${sov}.${principal}.${envelope.type}`;
 }
 
 function createBusRuntime(): BusRuntime {

--- a/src/__tests__/iaw-phase-b-integration.test.ts
+++ b/src/__tests__/iaw-phase-b-integration.test.ts
@@ -245,7 +245,7 @@ describe("IAW Phase B.4 — cross-stack inbound integration (refs cortex#114)", 
       resolver: new TrustResolver(alphaRegistry),
       receivingAgentId: "alpha-agent",
       principalId: "alpha",
-      source: { org: "alpha", agent: "cortex", instance: "local" },
+      source: { principal: "alpha", agent: "cortex", instance: "local" },
       cryptoVerify: true,
     });
     const betaListener = new BusDispatchListener({
@@ -253,7 +253,7 @@ describe("IAW Phase B.4 — cross-stack inbound integration (refs cortex#114)", 
       resolver: new TrustResolver(betaRegistry),
       receivingAgentId: "beta-agent",
       principalId: "beta",
-      source: { org: "beta", agent: "cortex", instance: "local" },
+      source: { principal: "beta", agent: "cortex", instance: "local" },
       cryptoVerify: true,
     });
 
@@ -324,7 +324,7 @@ describe("IAW Phase B.4 — cross-stack inbound integration (refs cortex#114)", 
       resolver: new TrustResolver(betaRegistry),
       receivingAgentId: "beta-agent",
       principalId: "beta",
-      source: { org: "beta", agent: "cortex", instance: "local" },
+      source: { principal: "beta", agent: "cortex", instance: "local" },
       cryptoVerify: true,
     });
     betaListener.start();
@@ -406,7 +406,7 @@ describe("IAW Phase B.4 — cross-stack inbound integration (refs cortex#114)", 
       resolver: new TrustResolver(betaRegistry),
       receivingAgentId: "beta-agent",
       principalId: "beta",
-      source: { org: "beta", agent: "cortex", instance: "local" },
+      source: { principal: "beta", agent: "cortex", instance: "local" },
       cryptoVerify: true,
     });
     betaListener.start();
@@ -467,7 +467,7 @@ describe("IAW Phase B.4 — cross-stack inbound integration (refs cortex#114)", 
       resolver: new TrustResolver(betaRegistry),
       receivingAgentId: "beta-agent",
       principalId: "beta",
-      source: { org: "beta", agent: "cortex", instance: "local" },
+      source: { principal: "beta", agent: "cortex", instance: "local" },
       cryptoVerify: true,
     });
     betaListener.start();

--- a/src/__tests__/iaw-phase-d-integration.test.ts
+++ b/src/__tests__/iaw-phase-d-integration.test.ts
@@ -158,7 +158,7 @@ function buildStack(opts: {
 
   const runtime = buildStackRuntime();
   const source: SystemEventSource = {
-    org: opts.operatorId,
+    principal: opts.operatorId,
     agent: "cortex",
     instance: "local",
   };

--- a/src/__tests__/principal-identity-consistency.test.ts
+++ b/src/__tests__/principal-identity-consistency.test.ts
@@ -20,7 +20,7 @@
  *
  * **What this test directly asserts vs what the suite proves as a whole.**
  *
- * Direct assertion (this test, "publish-side `source.org` equals
+ * Direct assertion (this test, "publish-side `source.principal` equals
  * listener-side `{principal}` subject segment"): when boot succeeds
  * via the unified `resolvePrincipalId` path, the dispatch-listener
  * registers exactly one envelope handler on the runtime
@@ -39,7 +39,7 @@
  * resolved value flows through every observable subject segment
  * cortex builds against:
  *
- *   - the `systemEventSource.org` baked into every `system.*` envelope
+ *   - the `systemEventSource.principal` baked into every `system.*` envelope
  *   - the `surfaceConfig.subjects[0]` the dispatch-listener subscribes
  *     on (canonical `local.{principal}.{stack}.tasks.*.>` pattern)
  *   - the per-agent durable-consumer name baked into the review-stream
@@ -117,7 +117,7 @@ function createRecordingRuntime(): RecordingRuntime {
 }
 
 describe("principal-identity consistency (cortex#427 PR-A)", () => {
-  test("publish-side `source.org` equals listener-side `{principal}` subject segment", async () => {
+  test("publish-side `source.principal` equals listener-side `{principal}` subject segment", async () => {
     // Setup: the v3 canonical path supplies the principal id via
     // `options.operator.id` (sourced from `cortexConfig.principal.id`
     // by the loader). The legacy `config.agent.operatorId` carries a
@@ -145,8 +145,8 @@ describe("principal-identity consistency (cortex#427 PR-A)", () => {
 
     try {
       // PUBLISH SIDE: every `system.*` envelope emitted at boot
-      // (`system.adapter.connected`, etc.) carries the source-org
-      // baked from `systemEventSource.org` in cortex.ts. With
+      // (`system.adapter.connected`, etc.) carries the source-principal
+      // baked from `systemEventSource.principal` in cortex.ts. With
       // adapters disabled in this minimal config, the listener
       // doesn't emit anything at boot — so we synthesise a publish
       // through the runtime to capture the canonical envelope shape
@@ -194,9 +194,9 @@ describe("principal-identity consistency (cortex#427 PR-A)", () => {
       // ----------------------------------------------------------------
       // Cross-check via `system.*` emission path.
       //
-      // `systemEventSource.org` is what every `system.*` envelope
+      // `systemEventSource.principal` is what every `system.*` envelope
       // built inside cortex.ts uses for its `source` field
-      // (`{org}.{agent}.{instance}`). We can't easily force a
+      // (`{principal}.{agent}.{instance}`). We can't easily force a
       // boot-time system event without standing up an adapter, so
       // we make the assertion via a controlled emission: build a
       // `dispatch.task.received` shape and dispatch it through the

--- a/src/__tests__/review-roundtrip.integration.test.ts
+++ b/src/__tests__/review-roundtrip.integration.test.ts
@@ -56,7 +56,7 @@ interface NatsServerHandle {
 }
 
 const SOURCE: ReviewEventSource = {
-  org: "test-op",
+  principal: "test-op",
   agent: "cortex",
   instance: "integration",
 };
@@ -305,7 +305,7 @@ maybeDescribe("cortex#339 — live JetStream review round-trip", () => {
       "cortex-review-consumer-test-op-echo",
     );
     const request = createReviewRequestEvent({
-      source: { org: "test-op", agent: "sage", instance: "dispatch" },
+      source: { principal: "test-op", agent: "sage", instance: "dispatch" },
       flavor: "typescript",
       payload: VALID_PAYLOAD,
     });

--- a/src/__tests__/signed-pilot-roundtrip.test.ts
+++ b/src/__tests__/signed-pilot-roundtrip.test.ts
@@ -106,7 +106,7 @@ function agentFixture(overrides: Partial<Agent> = {}): Agent {
 }
 
 const PILOT_SOURCE: ReviewEventSource = {
-  org: "metafactory",
+  principal: "metafactory",
   agent: "pilot",
   instance: "local",
 };

--- a/src/adapters/discord/__tests__/auto-thread.test.ts
+++ b/src/adapters/discord/__tests__/auto-thread.test.ts
@@ -344,7 +344,7 @@ describe("messageCreate auto-thread (cortex#120)", () => {
     const { adapter, client } = makeAdapterWithInfra({
       runtime,
       systemEventSource: {
-        org: "metafactory",
+        principal: "metafactory",
         agent: "cortex",
         instance: "discord-cortex120",
       },

--- a/src/adapters/discord/__tests__/system-events.test.ts
+++ b/src/adapters/discord/__tests__/system-events.test.ts
@@ -75,7 +75,7 @@ function makeRecordingRuntime(): RecordingRuntime {
  */
 async function buildStartedAdapter(opts: {
   runtime?: MyelinRuntime;
-  systemEventSource?: { org: string; agent: string; instance: string };
+  systemEventSource?: { principal: string; agent: string; instance: string };
   degradedThresholdMs?: number;
 } = {}) {
   // discord.js Client is constructed inside start(); the only way to skip
@@ -133,7 +133,7 @@ describe("DiscordAdapter system.adapter.* emission", () => {
     const runtime = makeRecordingRuntime();
     const adapter = await buildStartedAdapter({
       runtime,
-      systemEventSource: { org: "metafactory", agent: "cortex", instance: "local" },
+      systemEventSource: { principal: "metafactory", agent: "cortex", instance: "local" },
     });
     const client = adapter.getClient()!;
     // Emit a non-clean disconnect (1006 = abnormal closure)
@@ -162,7 +162,7 @@ describe("DiscordAdapter system.adapter.* emission", () => {
     const runtime = makeRecordingRuntime();
     const adapter = await buildStartedAdapter({
       runtime,
-      systemEventSource: { org: "metafactory", agent: "cortex", instance: "local" },
+      systemEventSource: { principal: "metafactory", agent: "cortex", instance: "local" },
     });
     const client = adapter.getClient()!;
     (client as unknown as { emit: (event: string, ...args: unknown[]) => boolean }).emit(
@@ -186,7 +186,7 @@ describe("DiscordAdapter system.adapter.* emission", () => {
     const runtime = makeRecordingRuntime();
     const adapter = await buildStartedAdapter({
       runtime,
-      systemEventSource: { org: "metafactory", agent: "cortex", instance: "local" },
+      systemEventSource: { principal: "metafactory", agent: "cortex", instance: "local" },
     });
     // Exercise the wired callback. `publishAdapterDegraded` is private; the
     // bracket access is the standard escape hatch for adapter-internal tests.
@@ -220,7 +220,7 @@ describe("DiscordAdapter system.adapter.* emission", () => {
     const runtime = makeRecordingRuntime();
     const adapter = await buildStartedAdapter({
       runtime,
-      systemEventSource: { org: "metafactory", agent: "cortex", instance: "local" },
+      systemEventSource: { principal: "metafactory", agent: "cortex", instance: "local" },
     });
     (
       adapter as unknown as {
@@ -287,7 +287,7 @@ describe("DiscordAdapter system.adapter.* emission", () => {
     const runtime = makeRecordingRuntime();
     const adapter = await buildStartedAdapter({
       runtime,
-      systemEventSource: { org: "metafactory", agent: "cortex", instance: "local" },
+      systemEventSource: { principal: "metafactory", agent: "cortex", instance: "local" },
     });
     const client = adapter.getClient()!;
     (client as unknown as { emit: (event: string, ...args: unknown[]) => boolean }).emit(

--- a/src/adapters/discord/index.ts
+++ b/src/adapters/discord/index.ts
@@ -1310,7 +1310,7 @@ export class DiscordAdapter implements PlatformAdapter {
       capability: "discord.inbound",
       sovereignty: {
         classification: "local",
-        data_residency: wiring.source.org,
+        data_residency: wiring.source.principal,
         max_hop: 0,
         frontier_ok: false,
         model_class: "local-only",

--- a/src/adapters/slack/__tests__/slack-adapter.test.ts
+++ b/src/adapters/slack/__tests__/slack-adapter.test.ts
@@ -874,7 +874,7 @@ describe("SlackAdapter — system.adapter.* envelopes (cortex#235 r1#4)", () => 
     };
   }
 
-  const SOURCE = { org: "metafactory", agent: "luna", instance: "local" };
+  const SOURCE = { principal: "metafactory", agent: "luna", instance: "local" };
 
   test("initial connect after start() is silent (no envelope emitted)", async () => {
     const runtime = makeRecordingRuntime();

--- a/src/bus/__tests__/bus-dispatch-listener.test.ts
+++ b/src/bus/__tests__/bus-dispatch-listener.test.ts
@@ -139,7 +139,7 @@ function fakeRuntime() {
   return { runtime, published, deliverInbound, drain, handlers };
 }
 
-const SOURCE = { org: "metafactory", agent: "cortex", instance: "local" };
+const SOURCE = { principal: "metafactory", agent: "cortex", instance: "local" };
 
 // =============================================================================
 // Cases
@@ -261,7 +261,7 @@ describe("BusDispatchListener — peer-dispatch filter", () => {
     // looping back via the local fan-out).
     deliverInbound(
       peerDispatchEnvelope({
-        source: `${SOURCE.org}.${SOURCE.agent}.${SOURCE.instance}`,
+        source: `${SOURCE.principal}.${SOURCE.agent}.${SOURCE.instance}`,
         signerPrincipal: "did:mf:luna",
       }),
     );

--- a/src/bus/__tests__/capability-registry.test.ts
+++ b/src/bus/__tests__/capability-registry.test.ts
@@ -46,7 +46,7 @@ import {
 } from "../capability-registry";
 
 const SOURCE: CapabilityRegistrySource = {
-  org: "metafactory",
+  principal: "metafactory",
   agent: "cortex",
   instance: "local",
 };

--- a/src/bus/__tests__/dispatch-events.test.ts
+++ b/src/bus/__tests__/dispatch-events.test.ts
@@ -25,7 +25,7 @@ import {
 } from "../dispatch-events";
 
 const SOURCE: DispatchEventSource = {
-  org: "metafactory",
+  principal: "metafactory",
   agent: "cortex",
   instance: "local",
 };

--- a/src/bus/__tests__/dispatch-handler.test.ts
+++ b/src/bus/__tests__/dispatch-handler.test.ts
@@ -311,7 +311,7 @@ describe("DispatchHandler — system.inbound.aborted emission (MIG-3.8 / C-104)"
       config: makeConfig(),
       securityPreamble: "",
       runtime,
-      systemEventSource: { org: "metafactory", agent: "cortex", instance: "local" },
+      systemEventSource: { principal: "metafactory", agent: "cortex", instance: "local" },
     });
 
     callPublishInboundAborted(handler, {
@@ -420,7 +420,7 @@ describe("DispatchHandler — system.inbound.aborted emission (MIG-3.8 / C-104)"
       config: makeConfig(),
       securityPreamble: "",
       runtime,
-      systemEventSource: { org: "metafactory", agent: "cortex", instance: "local" },
+      systemEventSource: { principal: "metafactory", agent: "cortex", instance: "local" },
     });
 
     callPublishInboundAborted(handler, {
@@ -446,7 +446,7 @@ describe("DispatchHandler — system.inbound.aborted emission (MIG-3.8 / C-104)"
       config: makeConfig(),
       securityPreamble: "",
       runtime,
-      systemEventSource: { org: "metafactory", agent: "cortex", instance: "local", dataResidency: "AU" },
+      systemEventSource: { principal: "metafactory", agent: "cortex", instance: "local", dataResidency: "AU" },
     });
 
     callPublishInboundAborted(handler, {
@@ -482,7 +482,7 @@ describe("DispatchHandler — system.inbound.aborted emission (MIG-3.8 / C-104)"
       config: makeConfig(),
       securityPreamble: "",
       runtime,
-      systemEventSource: { org: "metafactory", agent: "cortex", instance: "local" },
+      systemEventSource: { principal: "metafactory", agent: "cortex", instance: "local" },
     });
 
     // Simulate the exact call shape handleMessage builds (cf. dispatch-handler.ts
@@ -530,7 +530,7 @@ describe("DispatchHandler — system.inbound.aborted emission (MIG-3.8 / C-104)"
       config: makeConfig(),
       securityPreamble: "",
       runtime,
-      systemEventSource: { org: "metafactory", agent: "cortex", instance: "local" },
+      systemEventSource: { principal: "metafactory", agent: "cortex", instance: "local" },
     });
 
     const sources = [
@@ -661,7 +661,7 @@ describe("DispatchHandler — chat-path CC failure retry (cortex#360)", () => {
       config: makeConfig(),
       securityPreamble: "",
       runtime,
-      systemEventSource: { org: "metafactory", agent: "cortex", instance: "local" },
+      systemEventSource: { principal: "metafactory", agent: "cortex", instance: "local" },
       ccSessionFactory: factory,
     });
 
@@ -700,7 +700,7 @@ describe("DispatchHandler — chat-path CC failure retry (cortex#360)", () => {
       config: makeConfig(),
       securityPreamble: "",
       runtime,
-      systemEventSource: { org: "metafactory", agent: "cortex", instance: "local" },
+      systemEventSource: { principal: "metafactory", agent: "cortex", instance: "local" },
       ccSessionFactory: factory,
     });
 
@@ -755,7 +755,7 @@ describe("DispatchHandler — chat-path CC failure retry (cortex#360)", () => {
       config: makeConfig(),
       securityPreamble: "",
       runtime,
-      systemEventSource: { org: "metafactory", agent: "cortex", instance: "local" },
+      systemEventSource: { principal: "metafactory", agent: "cortex", instance: "local" },
       ccSessionFactory: factory,
     });
 
@@ -795,7 +795,7 @@ describe("DispatchHandler — chat-path CC failure retry (cortex#360)", () => {
       config: makeConfig(),
       securityPreamble: "",
       runtime,
-      systemEventSource: { org: "metafactory", agent: "cortex", instance: "local" },
+      systemEventSource: { principal: "metafactory", agent: "cortex", instance: "local" },
       ccSessionFactory: factory,
     });
 
@@ -834,7 +834,7 @@ describe("DispatchHandler — chat-path CC failure retry (cortex#360)", () => {
       config: makeConfig(),
       securityPreamble: "",
       runtime,
-      systemEventSource: { org: "metafactory", agent: "cortex", instance: "local" },
+      systemEventSource: { principal: "metafactory", agent: "cortex", instance: "local" },
       ccSessionFactory: factory,
     });
 
@@ -874,7 +874,7 @@ describe("DispatchHandler — chat-path CC failure retry (cortex#360)", () => {
       config: makeConfig(),
       securityPreamble: "",
       runtime,
-      systemEventSource: { org: "metafactory", agent: "cortex", instance: "local" },
+      systemEventSource: { principal: "metafactory", agent: "cortex", instance: "local" },
       ccSessionFactory: factory,
       retry: { maxAttempts: 1 },
     });
@@ -1001,7 +1001,7 @@ describe("DispatchHandler — Direction A Stage 4-B inbound envelope publish (co
       securityPreamble: "",
       runtime,
       systemEventSource: {
-        org: "andreas",
+        principal: "andreas",
         agent: "cortex",
         instance: "local",
       },
@@ -1069,7 +1069,7 @@ describe("DispatchHandler — Direction A Stage 4-B inbound envelope publish (co
       securityPreamble: "",
       runtime,
       systemEventSource: {
-        org: "andreas",
+        principal: "andreas",
         agent: "cortex",
         instance: "local",
       },
@@ -1096,7 +1096,7 @@ describe("DispatchHandler — Direction A Stage 4-B inbound envelope publish (co
       securityPreamble: "",
       runtime,
       systemEventSource: {
-        org: "andreas",
+        principal: "andreas",
         agent: "cortex",
         instance: "local",
         dataResidency: "AU",
@@ -1138,7 +1138,7 @@ describe("DispatchHandler — Direction A Stage 4-B inbound envelope publish (co
       securityPreamble: "",
       runtime,
       systemEventSource: {
-        org: "andreas",
+        principal: "andreas",
         agent: "cortex",
         instance: "local",
       },
@@ -1163,7 +1163,7 @@ describe("DispatchHandler — Direction A Stage 4-B inbound envelope publish (co
       securityPreamble: "",
       runtime,
       systemEventSource: {
-        org: "andreas",
+        principal: "andreas",
         agent: "cortex",
         instance: "local",
       },
@@ -1184,7 +1184,7 @@ describe("DispatchHandler — Direction A Stage 4-B inbound envelope publish (co
       securityPreamble: "",
       runtime,
       systemEventSource: {
-        org: "andreas",
+        principal: "andreas",
         agent: "cortex",
         instance: "local",
       },
@@ -1221,7 +1221,7 @@ describe("DispatchHandler — Direction A Stage 4-B inbound envelope publish (co
       securityPreamble: "",
       runtime,
       systemEventSource: {
-        org: "andreas",
+        principal: "andreas",
         agent: "cortex",
         instance: "local",
       },
@@ -1276,7 +1276,7 @@ describe("DispatchHandler — Direction A Stage 4-B inbound envelope publish (co
       securityPreamble: "",
       runtime,
       systemEventSource: {
-        org: "andreas",
+        principal: "andreas",
         agent: "cortex",
         instance: "local",
       },
@@ -1327,7 +1327,7 @@ describe("DispatchHandler — Direction A Stage 4-B inbound envelope publish (co
       securityPreamble: "",
       runtime,
       systemEventSource: {
-        org: "andreas",
+        principal: "andreas",
         agent: "cortex",
         instance: "local",
       },
@@ -1381,7 +1381,7 @@ describe("DispatchHandler — Direction A Stage 4-B inbound envelope publish (co
       securityPreamble: "",
       runtime,
       systemEventSource: {
-        org: "andreas",
+        principal: "andreas",
         agent: "cortex",
         instance: "local",
       },

--- a/src/bus/__tests__/github-events.test.ts
+++ b/src/bus/__tests__/github-events.test.ts
@@ -18,7 +18,7 @@ import {
   sanitizeTypeSegment,
 } from "../github-events";
 
-const SRC = { org: "metafactory", agent: "cortex", instance: "local" };
+const SRC = { principal: "metafactory", agent: "cortex", instance: "local" };
 
 describe("sanitizeTypeSegment", () => {
   test("lowercases input", () => {

--- a/src/bus/__tests__/review-consumer.test.ts
+++ b/src/bus/__tests__/review-consumer.test.ts
@@ -68,7 +68,7 @@ import type { CCSessionFactory } from "../../substrates/claude-code/harness";
 // ---------------------------------------------------------------------------
 
 const SOURCE: ReviewEventSource = {
-  org: "metafactory",
+  principal: "metafactory",
   agent: "cortex",
   instance: "local",
 };

--- a/src/bus/__tests__/review-events.test.ts
+++ b/src/bus/__tests__/review-events.test.ts
@@ -28,13 +28,13 @@ import {
 } from "../review-events";
 
 const SOURCE: ReviewEventSource = {
-  org: "metafactory",
+  principal: "metafactory",
   agent: "echo",
   instance: "local",
 };
 
 const PILOT_SOURCE: ReviewEventSource = {
-  org: "metafactory",
+  principal: "metafactory",
   agent: "pilot",
   instance: "local",
 };

--- a/src/bus/__tests__/surface-router.test.ts
+++ b/src/bus/__tests__/surface-router.test.ts
@@ -74,7 +74,7 @@ function fakeRuntimeWithPublishLog(): {
 }
 
 const TEST_SYSTEM_EVENT_SOURCE: SystemEventSource = {
-  org: "metafactory",
+  principal: "metafactory",
   agent: "cortex",
   instance: "local",
 };

--- a/src/bus/__tests__/system-events.test.ts
+++ b/src/bus/__tests__/system-events.test.ts
@@ -36,7 +36,7 @@ describe("adapterCorrelationKey", () => {
 describe("createSystemAdapterDegradedEvent", () => {
   test("required fields populated; envelope passes schema validation", () => {
     const env = createSystemAdapterDegradedEvent({
-      source: { org: "metafactory", agent: "cortex", instance: "local" },
+      source: { principal: "metafactory", agent: "cortex", instance: "local" },
       adapterId: "discord-luna",
       platform: "discord",
       disconnectedSince: new Date("2026-05-09T12:00:00.000Z"),
@@ -66,7 +66,7 @@ describe("createSystemAdapterDegradedEvent", () => {
 
   test("optional fields land in payload when provided, omitted otherwise", () => {
     const withOpts = createSystemAdapterDegradedEvent({
-      source: { org: "metafactory", agent: "cortex", instance: "local" },
+      source: { principal: "metafactory", agent: "cortex", instance: "local" },
       adapterId: "discord-luna",
       platform: "discord",
       disconnectedSince: new Date("2026-05-09T12:00:00.000Z"),
@@ -82,7 +82,7 @@ describe("createSystemAdapterDegradedEvent", () => {
     });
 
     const withoutOpts = createSystemAdapterDegradedEvent({
-      source: { org: "metafactory", agent: "cortex", instance: "local" },
+      source: { principal: "metafactory", agent: "cortex", instance: "local" },
       adapterId: "discord-luna",
       platform: "discord",
       disconnectedSince: new Date("2026-05-09T12:00:00.000Z"),
@@ -95,14 +95,14 @@ describe("createSystemAdapterDegradedEvent", () => {
 
   test("each invocation returns a fresh UUID id", () => {
     const a = createSystemAdapterDegradedEvent({
-      source: { org: "metafactory", agent: "cortex", instance: "local" },
+      source: { principal: "metafactory", agent: "cortex", instance: "local" },
       adapterId: "x",
       platform: "discord",
       disconnectedSince: new Date(),
       thresholdMs: 60_000,
     });
     const b = createSystemAdapterDegradedEvent({
-      source: { org: "metafactory", agent: "cortex", instance: "local" },
+      source: { principal: "metafactory", agent: "cortex", instance: "local" },
       adapterId: "x",
       platform: "discord",
       disconnectedSince: new Date(),
@@ -117,7 +117,7 @@ describe("createSystemAdapterDegradedEvent", () => {
 describe("createSystemAdapterRecoveredEvent", () => {
   test("required fields populated; envelope passes schema validation", () => {
     const env = createSystemAdapterRecoveredEvent({
-      source: { org: "metafactory", agent: "cortex", instance: "local" },
+      source: { principal: "metafactory", agent: "cortex", instance: "local" },
       adapterId: "discord-luna",
       platform: "discord",
       degradedForMs: 14_200,
@@ -133,7 +133,7 @@ describe("createSystemAdapterRecoveredEvent", () => {
 
   test("disconnected_since lands in payload (used by surfaces to join the pair)", () => {
     const env = createSystemAdapterRecoveredEvent({
-      source: { org: "metafactory", agent: "cortex", instance: "local" },
+      source: { principal: "metafactory", agent: "cortex", instance: "local" },
       adapterId: "discord-luna",
       platform: "discord",
       degradedForMs: 14_200,
@@ -148,7 +148,7 @@ describe("createSystemAdapterRecoveredEvent", () => {
 describe("createSystemAdapterDisconnectedEvent", () => {
   test("required fields populated; envelope passes schema validation", () => {
     const env = createSystemAdapterDisconnectedEvent({
-      source: { org: "metafactory", agent: "cortex", instance: "local" },
+      source: { principal: "metafactory", agent: "cortex", instance: "local" },
       adapterId: "discord-luna",
       platform: "discord",
       disconnectedSince: new Date("2026-05-09T12:00:00.000Z"),
@@ -166,7 +166,7 @@ describe("createSystemAdapterDisconnectedEvent", () => {
 
   test("close metadata lands in payload when provided", () => {
     const env = createSystemAdapterDisconnectedEvent({
-      source: { org: "metafactory", agent: "cortex", instance: "local" },
+      source: { principal: "metafactory", agent: "cortex", instance: "local" },
       adapterId: "discord-luna",
       platform: "discord",
       disconnectedSince: new Date(),
@@ -186,7 +186,7 @@ describe("createSystemAdapterDisconnectedEvent", () => {
 describe("createSystemInboundAbortedEvent", () => {
   test("required fields populated; envelope passes schema validation", () => {
     const env = createSystemInboundAbortedEvent({
-      source: { org: "metafactory", agent: "cortex", instance: "local" },
+      source: { principal: "metafactory", agent: "cortex", instance: "local" },
       adapterId: "discord-luna",
       inboundMessageId: "1234567890123456789",
       timeoutSource: "attachment_fetch",
@@ -208,7 +208,7 @@ describe("createSystemInboundAbortedEvent", () => {
 
   test("correlation_id passed through when caller provides a UUID-format value", () => {
     const env = createSystemInboundAbortedEvent({
-      source: { org: "metafactory", agent: "cortex", instance: "local" },
+      source: { principal: "metafactory", agent: "cortex", instance: "local" },
       adapterId: "discord-luna",
       inboundMessageId: "1234567890123456789",
       correlationId: "11111111-1111-4111-8111-111111111111",
@@ -223,7 +223,7 @@ describe("createSystemInboundAbortedEvent", () => {
 
   test("correlation_id omitted when caller does not provide one", () => {
     const env = createSystemInboundAbortedEvent({
-      source: { org: "metafactory", agent: "cortex", instance: "local" },
+      source: { principal: "metafactory", agent: "cortex", instance: "local" },
       adapterId: "discord-luna",
       inboundMessageId: "1234567890123456789",
       timeoutSource: "unknown",
@@ -246,7 +246,7 @@ describe("createSystemInboundAbortedEvent", () => {
     ] as const;
     for (const source of sources) {
       const env = createSystemInboundAbortedEvent({
-        source: { org: "metafactory", agent: "cortex", instance: "local" },
+        source: { principal: "metafactory", agent: "cortex", instance: "local" },
         adapterId: "discord-luna",
         inboundMessageId: "id",
         timeoutSource: source,
@@ -261,7 +261,7 @@ describe("createSystemInboundAbortedEvent", () => {
 
 describe("data_residency parameterisation", () => {
   test("omitting source.dataResidency defaults to NZ across all helpers", () => {
-    const sourceNoRes = { org: "metafactory", agent: "cortex", instance: "local" };
+    const sourceNoRes = { principal: "metafactory", agent: "cortex", instance: "local" };
     const degraded = createSystemAdapterDegradedEvent({
       source: sourceNoRes,
       adapterId: "x", platform: "discord",
@@ -288,7 +288,7 @@ describe("data_residency parameterisation", () => {
   });
 
   test("source.dataResidency overrides the default in every helper", () => {
-    const sourceAU = { org: "metafactory", agent: "cortex", instance: "local", dataResidency: "AU" };
+    const sourceAU = { principal: "metafactory", agent: "cortex", instance: "local", dataResidency: "AU" };
     const degraded = createSystemAdapterDegradedEvent({
       source: sourceAU,
       adapterId: "x", platform: "discord",
@@ -324,7 +324,7 @@ describe("classification parameterisation (IAW A.3)", () => {
   // `"public"` lets cortex emit envelopes that match myelin's namespace
   // grammar (and pass `validateSubjectEnvelopeAlignment` when paired with
   // the runtime's subject derivation).
-  const source = { org: "metafactory", agent: "cortex", instance: "local" };
+  const source = { principal: "metafactory", agent: "cortex", instance: "local" };
 
   test("omitting classification defaults to local across all helpers", () => {
     const degraded = createSystemAdapterDegradedEvent({
@@ -424,7 +424,7 @@ describe("classification parameterisation (IAW A.3)", () => {
 describe("createSystemAccessFilteredEvent", () => {
   test("required fields populated; envelope passes schema validation", () => {
     const env = createSystemAccessFilteredEvent({
-      source: { org: "metafactory", agent: "cortex", instance: "local" },
+      source: { principal: "metafactory", agent: "cortex", instance: "local" },
       rendererId: "dashboard",
       envelopeSubject: "federated.metafactory.review.cycle.completed",
       reason: "residency_blocked",
@@ -457,7 +457,7 @@ describe("createSystemAccessFilteredEvent", () => {
     ] as const;
     for (const reason of reasons) {
       const env = createSystemAccessFilteredEvent({
-        source: { org: "metafactory", agent: "cortex", instance: "local" },
+        source: { principal: "metafactory", agent: "cortex", instance: "local" },
         rendererId: "dashboard",
         envelopeSubject: "local.metafactory.x.y.z",
         reason,
@@ -470,7 +470,7 @@ describe("createSystemAccessFilteredEvent", () => {
   test("source.dataResidency overrides the default residency stamp", () => {
     const env = createSystemAccessFilteredEvent({
       source: {
-        org: "metafactory",
+        principal: "metafactory",
         agent: "cortex",
         instance: "local",
         dataResidency: "DE",
@@ -487,7 +487,7 @@ describe("createSystemAccessFilteredEvent", () => {
     // principal may opt the access-decision stream into federated reach so
     // peer dashboards can observe drops too.
     const env = createSystemAccessFilteredEvent({
-      source: { org: "metafactory", agent: "cortex", instance: "local" },
+      source: { principal: "metafactory", agent: "cortex", instance: "local" },
       rendererId: "dashboard",
       envelopeSubject: "federated.metafactory.foo.bar.baz",
       reason: "model_class_blocked",
@@ -499,13 +499,13 @@ describe("createSystemAccessFilteredEvent", () => {
 
   test("each invocation returns a fresh UUID id", () => {
     const a = createSystemAccessFilteredEvent({
-      source: { org: "metafactory", agent: "cortex", instance: "local" },
+      source: { principal: "metafactory", agent: "cortex", instance: "local" },
       rendererId: "dashboard",
       envelopeSubject: "x.y.z",
       reason: "residency_blocked",
     });
     const b = createSystemAccessFilteredEvent({
-      source: { org: "metafactory", agent: "cortex", instance: "local" },
+      source: { principal: "metafactory", agent: "cortex", instance: "local" },
       rendererId: "dashboard",
       envelopeSubject: "x.y.z",
       reason: "residency_blocked",
@@ -527,7 +527,7 @@ describe("createAgentHeartbeatEvent", () => {
 
   test("required fields populated; envelope passes schema validation", () => {
     const env = createAgentHeartbeatEvent({
-      source: { org: "metafactory", agent: "cortex", instance: "local" },
+      source: { principal: "metafactory", agent: "cortex", instance: "local" },
       agentId: "echo",
       taskId: "task-abc",
       correlationId: CORRELATION_UUID,
@@ -559,7 +559,7 @@ describe("createAgentHeartbeatEvent", () => {
 
   test("each invocation returns a fresh UUID id", () => {
     const a = createAgentHeartbeatEvent({
-      source: { org: "metafactory", agent: "cortex", instance: "local" },
+      source: { principal: "metafactory", agent: "cortex", instance: "local" },
       agentId: "echo",
       taskId: "task-abc",
       correlationId: CORRELATION_UUID,
@@ -568,7 +568,7 @@ describe("createAgentHeartbeatEvent", () => {
       iteration: 1,
     });
     const b = createAgentHeartbeatEvent({
-      source: { org: "metafactory", agent: "cortex", instance: "local" },
+      source: { principal: "metafactory", agent: "cortex", instance: "local" },
       agentId: "echo",
       taskId: "task-abc",
       correlationId: CORRELATION_UUID,
@@ -581,7 +581,7 @@ describe("createAgentHeartbeatEvent", () => {
 
   test("federated classification opt-in for future cross-principal heartbeats", () => {
     const env = createAgentHeartbeatEvent({
-      source: { org: "metafactory", agent: "cortex", instance: "local" },
+      source: { principal: "metafactory", agent: "cortex", instance: "local" },
       agentId: "echo",
       taskId: "task-abc",
       correlationId: CORRELATION_UUID,
@@ -602,7 +602,7 @@ describe("createAgentHeartbeatEvent", () => {
     ] as const;
     for (const phase of phases) {
       const env = createAgentHeartbeatEvent({
-        source: { org: "metafactory", agent: "cortex", instance: "local" },
+        source: { principal: "metafactory", agent: "cortex", instance: "local" },
         agentId: "echo",
         taskId: "task-abc",
         correlationId: CORRELATION_UUID,

--- a/src/bus/bus-dispatch-listener.ts
+++ b/src/bus/bus-dispatch-listener.ts
@@ -187,7 +187,7 @@ export class BusDispatchListener {
    */
   private isPeerDispatch(envelope: Envelope): boolean {
     if (envelope.type !== "dispatch.task.dispatched") return false;
-    const ourSource = `${this.source.org}.${this.source.agent}.${this.source.instance}`;
+    const ourSource = `${this.source.principal}.${this.source.agent}.${this.source.instance}`;
     return envelope.source !== ourSource;
   }
 

--- a/src/bus/capability-registry.ts
+++ b/src/bus/capability-registry.ts
@@ -61,7 +61,7 @@
  * **Subject derivation (load-bearing for PR-7 wiring + pilot Phase B):**
  *
  * The runtime derives subjects from `(envelope.type, envelope.sovereignty.
- * classification, envelope.source's org segment)`:
+ * classification, envelope.source's principal segment)`:
  *
  *   - classification `"local"` → subject `local.{principal}.{type}`
  *   - With stack segment (IAW A.5) → `local.{principal}.{stack}.{type}`
@@ -104,7 +104,7 @@ export type PublishFn = (envelope: Envelope) => Promise<void>;
  */
 export interface CapabilityRegistrySource {
   /** Principal id — first dotted segment of `envelope.source`. */
-  org: string;
+  principal: string;
   /** Logical agent label for the *publisher* (typically `"cortex"`). */
   agent: string;
   /** Stable instance label — usually `"local"` for in-process emission. */
@@ -209,7 +209,7 @@ export const CAPABILITY_REGISTERED_EVENT_TYPE = "agents.capabilities.registered"
 // ---------------------------------------------------------------------------
 
 function buildSource(src: CapabilityRegistrySource): string {
-  return `${src.org}.${src.agent}.${src.instance}`;
+  return `${src.principal}.${src.agent}.${src.instance}`;
 }
 
 /**

--- a/src/bus/dispatch-events.ts
+++ b/src/bus/dispatch-events.ts
@@ -52,7 +52,7 @@ import type { SystemEventSource } from "./system-events";
 export type DispatchEventSource = SystemEventSource;
 
 function buildSource(src: SystemEventSource): string {
-  return `${src.org}.${src.agent}.${src.instance}`;
+  return `${src.principal}.${src.agent}.${src.instance}`;
 }
 
 /**
@@ -113,8 +113,8 @@ export interface DispatchTaskCommonOpts {
   /**
    * Agent identifier — the logical agent name that handled the task
    * (`cortex`, `pilot`, etc.). Distinct from `envelope.source` because
-   * `source` is `org.agent.instance` and we want a flat agent label
-   * for filters/projection.
+   * `source` is `{principal}.{assistant}.{instance}` and we want a flat
+   * agent label for filters/projection.
    */
   agentId: string;
   /**

--- a/src/bus/dispatch-source-publisher.ts
+++ b/src/bus/dispatch-source-publisher.ts
@@ -92,7 +92,7 @@ export async function publishInboundChatDispatchEnvelope(
   let subject: string;
   try {
     subject = buildDirectTaskPublishSubject(
-      opts.source.org,
+      opts.source.principal,
       targetDid,
       opts.stack,
       "chat",
@@ -143,7 +143,7 @@ export async function publishInboundChatDispatchEnvelope(
   try {
     const base = buildBaseEnvelope({
       type: "tasks.chat",
-      source: `${opts.source.org}.${opts.source.agent}.${opts.source.instance}`,
+      source: `${opts.source.principal}.${opts.source.agent}.${opts.source.instance}`,
       correlationId: opts.taskId,
       sovereignty: {
         classification: "local",

--- a/src/bus/envelope-builder.ts
+++ b/src/bus/envelope-builder.ts
@@ -41,7 +41,7 @@ import type { Envelope } from "./myelin/envelope-validator";
 export interface BaseEnvelopeOpts {
   /** Envelope `type` — `domain.entity.action` per G-1100.B. */
   type: string;
-  /** Pre-built source string — `org.agent.instance` (2-5 dotted segments). */
+  /** Pre-built source string — `{principal}.{assistant}.{instance}` (exactly 3 dotted segments, per myelin#185). */
   source: string;
   /** Payload — domain-specific contents. */
   payload: Record<string, unknown>;

--- a/src/bus/github-events.ts
+++ b/src/bus/github-events.ts
@@ -73,7 +73,7 @@ import { isUuid } from "../common/types/uuid";
 export type GithubEventSource = SystemEventSource;
 
 function buildSource(src: SystemEventSource): string {
-  return `${src.org}.${src.agent}.${src.instance}`;
+  return `${src.principal}.${src.agent}.${src.instance}`;
 }
 
 /**

--- a/src/bus/myelin/__tests__/envelope-validator.test.ts
+++ b/src/bus/myelin/__tests__/envelope-validator.test.ts
@@ -121,6 +121,10 @@ describe("envelope-validator", () => {
       ...(validEnvelope as object),
       signed_by: {
         method: "ed25519",
+        // myelin#182 (R2 breaking cut) — stamps carry `identity`, not the
+        // deprecated `principal` key. Pre-#182 the dual reader accepted
+        // either; this test was updated at cortex#453 to assert the
+        // canonical-only schema.
         identity: "did:mf:luna",
         signature: ED25519_SIG,
         at: "2026-05-08T09:00:00Z",

--- a/src/bus/myelin/__tests__/runtime-principal-symmetry.test.ts
+++ b/src/bus/myelin/__tests__/runtime-principal-symmetry.test.ts
@@ -3,49 +3,50 @@
  * `{principal}` symmetry invariant.
  *
  * Subscribe-side substitutes `{principal}` in NATS subject patterns from
- * `config.agent.operatorId` at startup via `orgFromConfig`. Publish-side
- * extracts `{principal}` from `envelope.source`'s first segment via
- * `orgFromEnvelope`. For any envelope this stack emits via the system-event
- * helpers (which build `source` as `${principal}.${agent}.${instance}`), the two
- * MUST return identical strings — otherwise publish/subscribe subjects
- * diverge and round-trips break.
+ * `config.agent.operatorId` at startup via `principalFromConfig`.
+ * Publish-side extracts `{principal}` from `envelope.source`'s first
+ * segment via `principalFromEnvelope`. For any envelope this stack emits
+ * via the system-event helpers (which build `source` as
+ * `${principal}.${assistant}.${instance}`), the two MUST return identical
+ * strings — otherwise publish/subscribe subjects diverge and round-trips
+ * break.
  */
 import { describe, test, expect } from "bun:test";
 
 import {
-  orgFromConfig,
-  orgFromEnvelope,
+  principalFromConfig,
+  principalFromEnvelope,
 } from "../envelope-validator";
 import { createSystemAdapterDegradedEvent } from "../../system-events";
 
 describe("MyelinRuntime — subscribe/publish {principal} symmetry (cortex#130 item 1)", () => {
-  test("orgFromConfig and orgFromEnvelope agree for stack-emitted envelopes", () => {
+  test("principalFromConfig and principalFromEnvelope agree for stack-emitted envelopes", () => {
     const operatorId = "metafactory";
     const envelope = createSystemAdapterDegradedEvent({
-      source: { org: operatorId, agent: "cortex", instance: "local" },
+      source: { principal: operatorId, agent: "cortex", instance: "local" },
       adapterId: "discord-1",
       platform: "discord",
       disconnectedSince: new Date("2026-05-16T10:00:00.000Z"),
       thresholdMs: 60_000,
     });
 
-    expect(orgFromConfig(operatorId)).toBe(orgFromEnvelope(envelope));
+    expect(principalFromConfig(operatorId)).toBe(principalFromEnvelope(envelope));
   });
 
-  test("orgFromConfig falls back to 'default' when operatorId is undefined", () => {
-    expect(orgFromConfig(undefined)).toBe("default");
+  test("principalFromConfig falls back to 'default' when operatorId is undefined", () => {
+    expect(principalFromConfig(undefined)).toBe("default");
   });
 
-  test("orgFromEnvelope extracts the first dotted segment", () => {
+  test("principalFromEnvelope extracts the first dotted segment", () => {
     const envelope = createSystemAdapterDegradedEvent({
-      source: { org: "andreas", agent: "luna", instance: "work" },
+      source: { principal: "andreas", agent: "luna", instance: "work" },
       adapterId: "slack-1",
       platform: "slack",
       disconnectedSince: new Date("2026-05-16T10:00:00.000Z"),
       thresholdMs: 60_000,
     });
 
-    expect(orgFromEnvelope(envelope)).toBe("andreas");
+    expect(principalFromEnvelope(envelope)).toBe("andreas");
     // Sanity: the envelope.source itself has the full multi-segment form.
     expect(envelope.source).toBe("andreas.luna.work");
   });
@@ -53,14 +54,14 @@ describe("MyelinRuntime — subscribe/publish {principal} symmetry (cortex#130 i
   test("symmetry holds when principal changes — second stack identity", () => {
     const operatorId = "the-metafactory";
     const envelope = createSystemAdapterDegradedEvent({
-      source: { org: operatorId, agent: "echo", instance: "local" },
+      source: { principal: operatorId, agent: "echo", instance: "local" },
       adapterId: "discord-1",
       platform: "discord",
       disconnectedSince: new Date("2026-05-16T10:00:00.000Z"),
       thresholdMs: 60_000,
     });
 
-    expect(orgFromConfig(operatorId)).toBe(orgFromEnvelope(envelope));
-    expect(orgFromEnvelope(envelope)).toBe("the-metafactory");
+    expect(principalFromConfig(operatorId)).toBe(principalFromEnvelope(envelope));
+    expect(principalFromEnvelope(envelope)).toBe("the-metafactory");
   });
 });

--- a/src/bus/myelin/__tests__/runtime.test.ts
+++ b/src/bus/myelin/__tests__/runtime.test.ts
@@ -244,26 +244,11 @@ describe("MyelinRuntime", () => {
     await runtime.stop();
   });
 
-  // R4 (vocabulary migration 2026-05) — back-compat regression test.
-  // Pre-migration cortex.yaml configs (and migrate-config output that
-  // round-trips legacy bot.yaml verbatim) carry the deprecated `{org}`
-  // placeholder. The runtime substituter MUST resolve both tokens to
-  // the same principal slug so operators don't have to re-author
-  // their nats.subjects list mid-migration.
-  test("subjects placeholder {org} is also substituted (R4 back-compat)", async () => {
-    const fake = makeFakeNatsConnection();
-    const config = makeConfig({
-      url: "nats://localhost:4222",
-      name: "cortex",
-      subjects: ["local.{org}.attention.>"],
-    });
-    const runtime = await startMyelinRuntime(config, {
-      connectImpl: async () => fake.nc,
-    });
-    expect(runtime.enabled).toBe(true);
-    expect(fake.subscribePatterns[0]).toBe("local.andreas.attention.>");
-    await runtime.stop();
-  });
+  // R4 (vocabulary migration 2026-05, myelin#185 + cortex#453) — the
+  // `{org}` back-compat substitution arm retired when myelin#185 landed.
+  // `migrate-config` rewrites pre-migration `{org}` tokens to `{principal}`
+  // before they reach runtime, so the substituter only needs to handle
+  // the canonical token.
 
   // cortex#269 — `{stack}.` token substitution. Principal-written narrow
   // subscribe patterns can now reference the principal's stack identity

--- a/src/bus/myelin/envelope-validator.ts
+++ b/src/bus/myelin/envelope-validator.ts
@@ -86,7 +86,7 @@ export const SCHEMA_SOURCE_COMMIT = "4c54b8e6e2157524099f4f01f13c044bcc3b9291";
 export interface Envelope {
   /** UUID v4 — unique per envelope. */
   id: string;
-  /** `org.agent.instance` — 2-5 dotted segments. */
+  /** `{principal}.{stack}.{assistant}` — exactly 3 dotted segments (myelin#185 breaking cut). */
   source: string;
   /** `domain.entity.action` — what kind of signal this is. */
   type: string;

--- a/src/bus/myelin/envelope-validator.ts
+++ b/src/bus/myelin/envelope-validator.ts
@@ -610,24 +610,25 @@ function firstSegment(s: string): string {
  * `agent.operatorId` at startup. These two values MUST agree for any
  * envelope this stack emits, or subjects diverge between publish/subscribe.
  *
- * Use {@link orgFromConfig} on the subscribe-side and {@link orgFromEnvelope}
- * on the publish-side. The unit test in
- * `src/bus/myelin/__tests__/runtime-org-symmetry.test.ts` pins the invariant
- * that for envelopes emitted by this stack's helpers, the two return
- * identical strings.
+ * Use {@link principalFromConfig} on the subscribe-side and
+ * {@link principalFromEnvelope} on the publish-side. The unit test in
+ * `src/bus/myelin/__tests__/runtime-principal-symmetry.test.ts` pins the
+ * invariant that for envelopes emitted by this stack's helpers, the two
+ * return identical strings.
  */
-export function orgFromEnvelope(envelope: Envelope): string {
+export function principalFromEnvelope(envelope: Envelope): string {
   return firstSegment(envelope.source);
 }
 
 /**
- * Subscribe-side `{principal}` resolver. See {@link orgFromEnvelope} for the
- * symmetric publish-side helper and the invariant they jointly preserve.
+ * Subscribe-side `{principal}` resolver. See {@link principalFromEnvelope}
+ * for the symmetric publish-side helper and the invariant they jointly
+ * preserve.
  *
  * Falls back to `"default"` when `operatorId` is unset — matches the
  * legacy inline expression at runtime.ts subscribe-site.
  */
-export function orgFromConfig(operatorId: string | undefined): string {
+export function principalFromConfig(operatorId: string | undefined): string {
   return operatorId ?? "default";
 }
 

--- a/src/bus/myelin/runtime.ts
+++ b/src/bus/myelin/runtime.ts
@@ -23,7 +23,7 @@ import {
 } from "./subscriber";
 import {
   deriveNatsSubject,
-  orgFromConfig,
+  principalFromConfig,
   type Envelope,
 } from "./envelope-validator";
 // IAW Phase B.3 — sign outbound envelopes via myelin's chain-aware
@@ -314,12 +314,12 @@ export interface BusEnvelopeSigner {
  * collapse `{stack}.` to empty; stack-aware deployments emit
  * `${stack}.`).
  *
- * Returns a closure so the resolved `(org, stack)` pair is captured
+ * Returns a closure so the resolved `(principal, stack)` pair is captured
  * once and applied to N pattern strings without reallocating the
  * substitution rules per call.
  */
 export function makeSubjectPlaceholderSubstituter(opts: {
-  org: string;
+  principal: string;
   stack?: string;
 }): (subjects: readonly string[]) => string[] {
   const stackToken = opts.stack !== undefined ? `${opts.stack}.` : "";
@@ -333,7 +333,7 @@ export function makeSubjectPlaceholderSubstituter(opts: {
       // {assistant}` (per `specs/namespace.md`) is the only form the schema
       // validator now accepts.
       s
-        .replaceAll("{principal}", opts.org)
+        .replaceAll("{principal}", opts.principal)
         .replaceAll("{stack}.", stackToken),
     );
 }
@@ -396,13 +396,13 @@ export async function startMyelinRuntime(
 
   const nats = config.nats;
   // IAW Phase A.3 follow-up (cortex#130 item 1): subscribe-side `{principal}` is
-  // resolved via the shared `orgFromConfig` helper. The publish-side
-  // (`deriveNatsSubject` → `orgFromEnvelope`) extracts the same segment
+  // resolved via the shared `principalFromConfig` helper. The publish-side
+  // (`deriveNatsSubject` → `principalFromEnvelope`) extracts the same segment
   // from `envelope.source` at emit time. Both helpers live in
   // `envelope-validator.ts` and the invariant they jointly preserve
   // (subscribe `{principal}` === publish `{principal}` for envelopes this stack emits)
   // has a regression test at
-  // `src/bus/myelin/__tests__/runtime-org-symmetry.test.ts`.
+  // `src/bus/myelin/__tests__/runtime-principal-symmetry.test.ts`.
   //
   // cortex#269 — `{stack}.` substituted alongside `{principal}` via the shared
   // `makeSubjectPlaceholderSubstituter` helper (defined above; also used
@@ -414,7 +414,7 @@ export async function startMyelinRuntime(
   // `local.{principal}.{stack}.system.>` (stack-aware) or `local.{principal}.system.>`
   // (legacy) depending on whether the boot path supplied a stack.
   const substituter = makeSubjectPlaceholderSubstituter({
-    org: orgFromConfig(config.agent.operatorId),
+    principal: principalFromConfig(config.agent.operatorId),
     stack: options?.stack,
   });
   const subjects = substituter(nats.subjects);

--- a/src/bus/myelin/runtime.ts
+++ b/src/bus/myelin/runtime.ts
@@ -325,17 +325,15 @@ export function makeSubjectPlaceholderSubstituter(opts: {
   const stackToken = opts.stack !== undefined ? `${opts.stack}.` : "";
   return (subjects: readonly string[]) =>
     subjects.map((s) =>
-      // R4 (vocabulary migration 2026-05) — accept BOTH `{principal}` (the
-      // canonical post-R7 token) and `{org}` (the deprecated alias) during
-      // the transition window. Operators migrating cortex.yaml will see
-      // both tokens in the wild — pre-migration configs carry `{org}`,
-      // post-migration configs carry `{principal}`, and `migrate-config`
-      // converts the legacy bot.yaml → cortex.yaml passing nats config through
-      // verbatim (so `{org}` flows through). Both must resolve to the
-      // same principal slug at runtime.
+      // R4 (vocabulary migration 2026-05, myelin#185 breaking cut +
+      // cortex#453) — `{principal}` is the canonical token. The transition
+      // window accepting `{org}` retired with myelin#185; `migrate-config`
+      // rewrites legacy bot.yaml `{org}` tokens to `{principal}` before
+      // they reach runtime, and the envelope grammar `{principal}.{stack}.
+      // {assistant}` (per `specs/namespace.md`) is the only form the schema
+      // validator now accepts.
       s
         .replaceAll("{principal}", opts.org)
-        .replaceAll("{org}", opts.org)
         .replaceAll("{stack}.", stackToken),
     );
 }

--- a/src/bus/review-events.ts
+++ b/src/bus/review-events.ts
@@ -85,7 +85,7 @@ import type { SystemEventSource } from "./system-events";
 export type ReviewEventSource = SystemEventSource;
 
 function buildSource(src: SystemEventSource): string {
-  return `${src.org}.${src.agent}.${src.instance}`;
+  return `${src.principal}.${src.agent}.${src.instance}`;
 }
 
 /**

--- a/src/bus/system-events.ts
+++ b/src/bus/system-events.ts
@@ -482,7 +482,7 @@ export interface SystemBusPeerDispatchReceivedOpts {
   /**
    * Source field from the peer's dispatch envelope (the `{principal}.
    * {agent}.{instance}` triple that identifies which peer just
-   * dispatched a task to us). Different from `opts.source.org` —
+   * dispatched a task to us). Different from `opts.source.principal` —
    * that's US, this is THEM.
    */
   peerSource: string;

--- a/src/bus/system-events.ts
+++ b/src/bus/system-events.ts
@@ -58,17 +58,19 @@ import { AGENT_HEARTBEAT_TYPE } from "../common/types/agent-heartbeat";
 
 /**
  * Source identifier used by every `system.*` event. Three dotted segments
- * matching the schema's `org.agent.instance` form. Kept as a struct in the
- * helper-options shape so callers don't string-concatenate by hand.
+ * matching the schema's `{principal}.{assistant}.{instance}` form (R4
+ * vocabulary migration; myelin#185 tightened this to exactly 3 segments).
+ * Kept as a struct in the helper-options shape so callers don't
+ * string-concatenate by hand.
  *
  * Examples (from spec §3.6):
  *   - `metafactory.pilot.local`
  *   - `metafactory.grove.dashboard`
- *   - For cortex-emitted system.* events: `{operatorId}.cortex.local`
+ *   - For cortex-emitted system.* events: `{principal}.cortex.local`
  */
 export interface SystemEventSource {
-  /** `agent.operatorId` — first segment. */
-  org: string;
+  /** `agent.operatorId` — first segment (principal slug). */
+  principal: string;
   /** Logical agent name — `cortex`, `grove`, `pilot`, etc. */
   agent: string;
   /** Stable instance name — usually `local` for in-process emission. */
@@ -85,7 +87,7 @@ export interface SystemEventSource {
 }
 
 function buildSource(src: SystemEventSource): string {
-  return `${src.org}.${src.agent}.${src.instance}`;
+  return `${src.principal}.${src.agent}.${src.instance}`;
 }
 
 /**

--- a/src/cli/cortex/commands/__tests__/migrate-config.test.ts
+++ b/src/cli/cortex/commands/__tests__/migrate-config.test.ts
@@ -435,16 +435,20 @@ describe("convertBotYaml — full fixture", () => {
     expect(result.warnings.some((w) => w.field === "grove")).toBe(true);
   });
 
-  test("passes nats config through unchanged", () => {
+  test("rewrites legacy {org} placeholder in nats.subjects to {principal} (R4)", () => {
     const legacy = loadFixture("full.bot.yaml");
     const result = convertBotYaml(legacy, { configDir: FIXTURE_DIR });
     expect(result.cortex.nats?.url).toBe("nats://localhost:4222");
-    // Fixture carries the legacy `local.{org}.>` token verbatim — this
-    // test asserts the migrate-config converter passes nats config
-    // through UNCHANGED. The legacy bot.yaml fixture is intentionally
-    // NOT touched by the vocabulary migration (it's the source format
-    // migrate-config reads from).
-    expect(result.cortex.nats?.subjects).toEqual(["local.{org}.>"]);
+    // Fixture carries the legacy `local.{org}.>` token verbatim. The
+    // migrate-config converter rewrites `{org}` → `{principal}` so the
+    // emitted cortex.yaml is consumable by post-#185 myelin runtimes
+    // (which dropped the `{org}` token from the subject grammar). The
+    // legacy bot.yaml fixture is intentionally NOT touched on disk —
+    // the rewrite happens in-memory at conversion time.
+    expect(result.cortex.nats?.subjects).toEqual(["local.{principal}.>"]);
+    expect(
+      result.warnings.some((w) => w.field === "nats.subjects"),
+    ).toBe(true);
   });
 
   test("bot.yaml-shape discord[].roles[] lifts into policy block (PR #310 r1 B-1 fix)", () => {

--- a/src/cli/cortex/commands/migrate-config-lib.ts
+++ b/src/cli/cortex/commands/migrate-config-lib.ts
@@ -1899,6 +1899,26 @@ function convertNats(legacyNats: unknown, warnings: ConversionWarning[]): unknow
       delete nats.identity;
     }
   }
+  // R4 (vocabulary migration 2026-05, myelin#185 + cortex#453) — the
+  // legacy bot.yaml `{org}` placeholder retired. Rewrite any `{org}`
+  // tokens in `nats.subjects` to the canonical `{principal}` so the
+  // emitted cortex.yaml is consumable by post-#185 myelin runtimes.
+  if (Array.isArray(nats.subjects)) {
+    let rewrote = false;
+    nats.subjects = nats.subjects.map((s) => {
+      if (typeof s !== "string" || !s.includes("{org}")) return s;
+      rewrote = true;
+      return s.replaceAll("{org}", "{principal}");
+    });
+    if (rewrote) {
+      warnings.push({
+        field: "nats.subjects",
+        message:
+          "rewrote legacy `{org}` placeholder to `{principal}` (R4 vocabulary " +
+          "migration; myelin#185 dropped the `{org}` token from the subject grammar).",
+      });
+    }
+  }
   return nats;
 }
 

--- a/src/cli/cortex/commands/migrate-config-lib.ts
+++ b/src/cli/cortex/commands/migrate-config-lib.ts
@@ -1903,14 +1903,16 @@ function convertNats(legacyNats: unknown, warnings: ConversionWarning[]): unknow
   // legacy bot.yaml `{org}` placeholder retired. Rewrite any `{org}`
   // tokens in `nats.subjects` to the canonical `{principal}` so the
   // emitted cortex.yaml is consumable by post-#185 myelin runtimes.
-  if (Array.isArray(nats.subjects)) {
-    let rewrote = false;
-    nats.subjects = nats.subjects.map((s) => {
+  const subjects = nats.subjects;
+  if (Array.isArray(subjects)) {
+    const rewroteIdxs: number[] = [];
+    const rewritten: unknown[] = subjects.map((s: unknown, idx: number): unknown => {
       if (typeof s !== "string" || !s.includes("{org}")) return s;
-      rewrote = true;
+      rewroteIdxs.push(idx);
       return s.replaceAll("{org}", "{principal}");
     });
-    if (rewrote) {
+    nats.subjects = rewritten;
+    if (rewroteIdxs.length > 0) {
       warnings.push({
         field: "nats.subjects",
         message:

--- a/src/cli/cortex/commands/migrate-config-lib.ts
+++ b/src/cli/cortex/commands/migrate-config-lib.ts
@@ -1905,14 +1905,15 @@ function convertNats(legacyNats: unknown, warnings: ConversionWarning[]): unknow
   // emitted cortex.yaml is consumable by post-#185 myelin runtimes.
   const subjects = nats.subjects;
   if (Array.isArray(subjects)) {
-    const rewroteIdxs: number[] = [];
-    const rewritten: unknown[] = subjects.map((s: unknown, idx: number): unknown => {
+    const didRewrite = subjects.some(
+      (s: unknown) => typeof s === "string" && s.includes("{org}"),
+    );
+    const rewritten: unknown[] = subjects.map((s: unknown): unknown => {
       if (typeof s !== "string" || !s.includes("{org}")) return s;
-      rewroteIdxs.push(idx);
       return s.replaceAll("{org}", "{principal}");
     });
     nats.subjects = rewritten;
-    if (rewroteIdxs.length > 0) {
+    if (didRewrite) {
       warnings.push({
         field: "nats.subjects",
         message:

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -645,11 +645,11 @@ export async function startCortex(
   // Without this, the audit-trail emit silently degrades to console.info
   // in production — only unit tests passed the explicit source.
   const systemEventSource: SystemEventSource = {
-    // cortex#427 — `org` is the `{principal}` subject segment; same
-    // resolution path as the dispatch-listener below so publisher and
-    // consumer can't disagree on which principal a `system.*` envelope
-    // belongs to.
-    org: principalId,
+    // cortex#427 — the `principal` segment is the `{principal}` subject
+    // segment; same resolution path as the dispatch-listener below so
+    // publisher and consumer can't disagree on which principal a
+    // `system.*` envelope belongs to.
+    principal: principalId,
     agent: "cortex",
     instance: "local",
     ...(config.agent.dataResidency !== undefined && {
@@ -1753,11 +1753,11 @@ export async function startCortex(
   // honest if the boot ever passes `undefined`.
   const subjectPlaceholderSubstituter = makeSubjectPlaceholderSubstituter({
     // cortex#427 — renderer subscribe-pattern substitution reads the
-    // shared `principalId` so renderer subjects and runtime-side
-    // emit subjects can't drift; the post-MIG-8 helper still names
-    // the field `org` (renderer schema parameter name not renamed in
-    // PR-A scope).
-    org: principalId,
+    // shared `principalId` so renderer subjects and runtime-side emit
+    // subjects can't drift. R4 (cortex#453) renamed the helper field
+    // from `org` to `principal` so the parameter name matches the
+    // subject grammar canonicalised in myelin#185.
+    principal: principalId,
     stack: options.stack !== undefined ? derivedStack.stack : undefined,
   });
 
@@ -2232,7 +2232,7 @@ function setupOutboundLog(
       // bus-driven path projects into the same threads as the JSONL path.
       router.register(
         worklog.surfaceConfig({
-          org: systemEventSource.org,
+          principal: systemEventSource.principal,
           adapterId: `worklog-${discordAdapter.instanceId}`,
         }),
       );

--- a/src/runner/__tests__/agent-team-harness.test.ts
+++ b/src/runner/__tests__/agent-team-harness.test.ts
@@ -8,7 +8,7 @@ import type { DispatchRequest } from "../../common/substrates/types";
 import type { DispatchEventSource } from "../../bus/dispatch-events";
 
 const SOURCE: DispatchEventSource = {
-  org: "metafactory",
+  principal: "metafactory",
   agent: "cortex",
   instance: "local",
 };

--- a/src/runner/__tests__/agent-team.test.ts
+++ b/src/runner/__tests__/agent-team.test.ts
@@ -34,7 +34,7 @@ function fakeBusPeerDeps(): NonNullable<AgentTeamOpts["busPeer"]> {
   // narrowly so the cast is the only weak point.
   const resolver = {} as TrustResolver;
   const source: DispatchEventSource = {
-    org: "metafactory",
+    principal: "metafactory",
     agent: "cortex",
     instance: "local",
   };

--- a/src/runner/__tests__/dispatch-listener.test.ts
+++ b/src/runner/__tests__/dispatch-listener.test.ts
@@ -43,7 +43,7 @@ import type { Agent } from "../../common/types/cortex-config";
 // ---------------------------------------------------------------------------
 
 const SOURCE: SystemEventSource = {
-  org: "metafactory",
+  principal: "metafactory",
   agent: "cortex",
   instance: "local",
 };

--- a/src/runner/__tests__/dispatch-listener.test.ts
+++ b/src/runner/__tests__/dispatch-listener.test.ts
@@ -3,7 +3,7 @@
  *
  * Coverage axes:
  *   1. Registration shape — surfaceConfig matches G-1111 §4 SurfaceAdapter
- *      contract; default subjects derive from source.org.
+ *      contract; default subjects derive from source.principal.
  *   2. Lifecycle — on success: started → completed; on non-zero exit:
  *      started → failed; on factory throw: started → failed; on exit 143:
  *      started → aborted.
@@ -216,7 +216,7 @@ const ABORTED_BY_FLAG_RESULT: CCSessionResult = {
 // ---------------------------------------------------------------------------
 
 describe("createDispatchListener — surfaceConfig", () => {
-  test("default subjects derive from source.org", () => {
+  test("default subjects derive from source.principal", () => {
     const { runtime } = recordingRuntime();
     const router = createSurfaceRouter(runtime);
     const listener = createDispatchListener({

--- a/src/runner/__tests__/heartbeat-ticker.test.ts
+++ b/src/runner/__tests__/heartbeat-ticker.test.ts
@@ -40,7 +40,7 @@ import {
 // ---------------------------------------------------------------------------
 
 const SOURCE: SystemEventSource = {
-  org: "metafactory",
+  principal: "metafactory",
   agent: "cortex",
   instance: "local",
 };

--- a/src/runner/__tests__/review-pipeline.test.ts
+++ b/src/runner/__tests__/review-pipeline.test.ts
@@ -55,7 +55,7 @@ import {
 // ---------------------------------------------------------------------------
 
 const SOURCE: ReviewEventSource = {
-  org: "metafactory",
+  principal: "metafactory",
   agent: "cortex",
   instance: "local",
 };

--- a/src/runner/__tests__/skill-verdict-block.contract.test.ts
+++ b/src/runner/__tests__/skill-verdict-block.contract.test.ts
@@ -67,7 +67,7 @@ import { runReviewPipeline } from "../review-pipeline";
 // ---------------------------------------------------------------------------
 
 const SOURCE: ReviewEventSource = {
-  org: "metafactory",
+  principal: "metafactory",
   agent: "cortex",
   instance: "local",
 };

--- a/src/runner/__tests__/worklog-manager-surface.test.ts
+++ b/src/runner/__tests__/worklog-manager-surface.test.ts
@@ -97,7 +97,7 @@ function makeFakeClient(channelId: string): { client: Client; calls: FakeCalls }
 // Helpers
 // ---------------------------------------------------------------------------
 
-const SOURCE = { org: "metafactory", agent: "cortex", instance: "local" };
+const SOURCE = { principal: "metafactory", agent: "cortex", instance: "local" };
 const TASK_ID = "11111111-1111-4111-8111-111111111111";
 const STARTED_AT = new Date("2026-05-09T12:00:00.000Z");
 const COMPLETED_AT = new Date("2026-05-09T12:00:30.000Z");
@@ -152,7 +152,7 @@ describe("WorklogManager.surfaceConfig — shape", () => {
   test("5-segment subject pattern when stack is omitted (legacy compat)", () => {
     const { client } = makeFakeClient("worklog-channel-id");
     const wlm = new WorklogManager(client, "worklog-channel-id");
-    const cfg = wlm.surfaceConfig({ org: "metafactory" });
+    const cfg = wlm.surfaceConfig({ principal: "metafactory" });
     expect(cfg.subjects).toEqual(["local.metafactory.dispatch.task.>"]);
     expect(cfg.id).toBe("worklog-manager");
   });
@@ -164,7 +164,7 @@ describe("WorklogManager.surfaceConfig — shape", () => {
   test("6-segment subject pattern when stack is supplied (cortex#268)", () => {
     const { client } = makeFakeClient("worklog-channel-id");
     const wlm = new WorklogManager(client, "worklog-channel-id");
-    const cfg = wlm.surfaceConfig({ org: "metafactory", stack: "default" });
+    const cfg = wlm.surfaceConfig({ principal: "metafactory", stack: "default" });
     expect(cfg.subjects).toEqual([
       "local.metafactory.default.dispatch.task.>",
     ]);
@@ -173,7 +173,7 @@ describe("WorklogManager.surfaceConfig — shape", () => {
   test("subscribe pattern honours multi-stack principal config", () => {
     const { client } = makeFakeClient("worklog-channel-id");
     const wlm = new WorklogManager(client, "worklog-channel-id");
-    const cfg = wlm.surfaceConfig({ org: "andreas", stack: "research" });
+    const cfg = wlm.surfaceConfig({ principal: "andreas", stack: "research" });
     expect(cfg.subjects).toEqual([
       "local.andreas.research.dispatch.task.>",
     ]);
@@ -182,14 +182,14 @@ describe("WorklogManager.surfaceConfig — shape", () => {
   test("custom adapter id honored", () => {
     const { client } = makeFakeClient("worklog-channel-id");
     const wlm = new WorklogManager(client, "worklog-channel-id");
-    const cfg = wlm.surfaceConfig({ org: "metafactory", adapterId: "worklog-test" });
+    const cfg = wlm.surfaceConfig({ principal: "metafactory", adapterId: "worklog-test" });
     expect(cfg.id).toBe("worklog-test");
   });
 
   test("render function exists and returns a Promise", () => {
     const { client } = makeFakeClient("worklog-channel-id");
     const wlm = new WorklogManager(client, "worklog-channel-id");
-    const cfg = wlm.surfaceConfig({ org: "metafactory" });
+    const cfg = wlm.surfaceConfig({ principal: "metafactory" });
     expect(typeof cfg.render).toBe("function");
     const result = cfg.render(makeStarted());
     expect(result).toBeInstanceOf(Promise);
@@ -205,7 +205,7 @@ describe("WorklogManager.surfaceConfig — started envelope", () => {
   test("creates a thread and posts opening line", async () => {
     const { client, calls } = makeFakeClient("worklog-channel-id");
     const wlm = new WorklogManager(client, "worklog-channel-id");
-    const cfg = wlm.surfaceConfig({ org: "metafactory" });
+    const cfg = wlm.surfaceConfig({ principal: "metafactory" });
 
     await cfg.render(makeStarted());
 
@@ -227,7 +227,7 @@ describe("WorklogManager.surfaceConfig — completed envelope", () => {
   test("after started, posts completion to thread + channel summary", async () => {
     const { client, calls } = makeFakeClient("worklog-channel-id");
     const wlm = new WorklogManager(client, "worklog-channel-id");
-    const cfg = wlm.surfaceConfig({ org: "metafactory" });
+    const cfg = wlm.surfaceConfig({ principal: "metafactory" });
 
     await cfg.render(makeStarted());
     const initialChannelLen = calls.channelSent.length;
@@ -253,7 +253,7 @@ describe("WorklogManager.surfaceConfig — failed envelope", () => {
   test("after started, posts failure with error_summary", async () => {
     const { client, calls } = makeFakeClient("worklog-channel-id");
     const wlm = new WorklogManager(client, "worklog-channel-id");
-    const cfg = wlm.surfaceConfig({ org: "metafactory" });
+    const cfg = wlm.surfaceConfig({ principal: "metafactory" });
 
     await cfg.render(makeStarted());
     await cfg.render(makeFailed());
@@ -269,7 +269,7 @@ describe("WorklogManager.surfaceConfig — aborted envelope", () => {
   test("after started, posts abort with reason", async () => {
     const { client, calls } = makeFakeClient("worklog-channel-id");
     const wlm = new WorklogManager(client, "worklog-channel-id");
-    const cfg = wlm.surfaceConfig({ org: "metafactory" });
+    const cfg = wlm.surfaceConfig({ principal: "metafactory" });
 
     await cfg.render(makeStarted());
     await cfg.render(makeAborted());
@@ -289,7 +289,7 @@ describe("WorklogManager.surfaceConfig — malformed envelope", () => {
   test("envelope with no payload.task_id → no Discord API calls", async () => {
     const { client, calls } = makeFakeClient("worklog-channel-id");
     const wlm = new WorklogManager(client, "worklog-channel-id");
-    const cfg = wlm.surfaceConfig({ org: "metafactory" });
+    const cfg = wlm.surfaceConfig({ principal: "metafactory" });
 
     const malformed: Envelope = {
       id: "00000000-0000-4000-8000-000000000000",
@@ -313,7 +313,7 @@ describe("WorklogManager.surfaceConfig — malformed envelope", () => {
   test("unknown dispatch sub-type → silent ignore (forward compatibility)", async () => {
     const { client, calls } = makeFakeClient("worklog-channel-id");
     const wlm = new WorklogManager(client, "worklog-channel-id");
-    const cfg = wlm.surfaceConfig({ org: "metafactory" });
+    const cfg = wlm.surfaceConfig({ principal: "metafactory" });
 
     const unknown: Envelope = {
       id: "00000000-0000-4000-8000-000000000000",
@@ -364,7 +364,7 @@ describe("WorklogManager — direct-call API still works after surfaceConfig", (
   test("direct-call path AND bus path coexist on one instance without thread collision", async () => {
     const { client, calls } = makeFakeClient("worklog-channel-id");
     const wlm = new WorklogManager(client, "worklog-channel-id");
-    const cfg = wlm.surfaceConfig({ org: "metafactory" });
+    const cfg = wlm.surfaceConfig({ principal: "metafactory" });
 
     // Drive the bus path: one task lifecycle (started → completed).
     await cfg.render(makeStarted());
@@ -412,7 +412,7 @@ describe("WorklogManager — direct-call API still works after surfaceConfig", (
     // pick up a direct-call thread keyed by some other UUID.
     const { client, calls } = makeFakeClient("worklog-channel-id");
     const wlm = new WorklogManager(client, "worklog-channel-id");
-    const cfg = wlm.surfaceConfig({ org: "metafactory" });
+    const cfg = wlm.surfaceConfig({ principal: "metafactory" });
 
     // Direct-call path opens a thread keyed by SESSION_ID
     const SESSION_ID = "33333333-3333-4333-8333-333333333333";
@@ -437,7 +437,7 @@ describe("WorklogManager — direct-call API still works after surfaceConfig", (
   test("cleanupStaleSessions still functional", () => {
     const { client } = makeFakeClient("worklog-channel-id");
     const wlm = new WorklogManager(client, "worklog-channel-id");
-    void wlm.surfaceConfig({ org: "metafactory" });
+    void wlm.surfaceConfig({ principal: "metafactory" });
     // No active sessions → returns 0
     expect(wlm.cleanupStaleSessions()).toBe(0);
   });

--- a/src/runner/dispatch-listener.ts
+++ b/src/runner/dispatch-listener.ts
@@ -203,7 +203,7 @@ export interface DispatchListenerOptions {
   stack?: string;
   /**
    * Subject pattern(s) to subscribe to. When omitted, the listener
-   * derives the default from `source.org` + optional `stack` per
+   * derives the default from `source.principal` + optional `stack` per
    * the IAW A.5 grammar. Tests can override with broader patterns
    * (`local.test.dispatch.task.received`).
    */
@@ -325,11 +325,11 @@ export interface DispatchListener {
  * when `stack` is supplied; falls through to the legacy 5-segment form
  * for backward compatibility with pre-A.5 deployments.
  */
-function dispatchReceivedSubject(org: string, stack?: string): string {
+function dispatchReceivedSubject(principal: string, stack?: string): string {
   if (stack === undefined) {
-    return `local.${org}.dispatch.task.received`;
+    return `local.${principal}.dispatch.task.received`;
   }
-  return `local.${org}.${stack}.dispatch.task.received`;
+  return `local.${principal}.${stack}.dispatch.task.received`;
 }
 
 /**
@@ -349,16 +349,16 @@ function dispatchReceivedSubject(org: string, stack?: string): string {
  * subjects can still be supplied explicitly through `subjects` for old
  * tests/config, but production defaults are canonical-only.
  */
-function canonicalTasksDirectSubject(org: string, stack?: string): string {
+function canonicalTasksDirectSubject(principal: string, stack?: string): string {
   if (stack === undefined) {
-    return `local.${org}.tasks.*.>`;
+    return `local.${principal}.tasks.*.>`;
   }
-  return `local.${org}.${stack}.tasks.*.>`;
+  return `local.${principal}.${stack}.tasks.*.>`;
 }
 
 /**
  * Default subject(s) for the runner's bus subscription. The `{principal}`
- * segment is substituted at registration time using `source.org` so a
+ * segment is substituted at registration time using `source.principal` so a
  * misconfigured runner with no principal id can still subscribe (it'll match
  * nothing unless someone publishes under `local.default.…`).
  *
@@ -367,8 +367,8 @@ function canonicalTasksDirectSubject(org: string, stack?: string): string {
  * pass `subjects` for legacy/federated fixtures, but production defaults
  * no longer subscribe to the pre-spec `dispatch.task.received` subject.
  */
-function defaultSubjects(org: string, stack?: string): string[] {
-  return [canonicalTasksDirectSubject(org, stack)];
+function defaultSubjects(principal: string, stack?: string): string[] {
+  return [canonicalTasksDirectSubject(principal, stack)];
 }
 
 export function createDispatchListener(
@@ -390,7 +390,7 @@ export function createDispatchListener(
   // Adapter-originated dispatches arrive with empty `signed_by[]` and
   // fall through `rejectEmpty: false`; signed bus traffic MUST verify.
   const cryptoVerify = opts.cryptoVerify ?? true;
-  const subjects = opts.subjects ?? defaultSubjects(source.org, opts.stack);
+  const subjects = opts.subjects ?? defaultSubjects(source.principal, opts.stack);
 
   let registration: { unregister: () => void } | null = null;
 
@@ -835,7 +835,7 @@ async function handleDispatchEnvelope(
     // single source of truth across the listener's subscribe-side
     // default AND this audit-envelope synthesis path (cortex#276
     // Maintainability finding cycle 2).
-    const auditEnvelopeSubject = subject ?? dispatchReceivedSubject(source.org, stack);
+    const auditEnvelopeSubject = subject ?? dispatchReceivedSubject(source.principal, stack);
     const auditCommon = {
       source,
       principalId: decision.principalId,
@@ -1255,7 +1255,7 @@ async function emitChainVerificationDeny(
     model_class: envelope.sovereignty.model_class,
   };
   const auditEnvelopeSubject =
-    subject ?? dispatchReceivedSubject(source.org, stack);
+    subject ?? dispatchReceivedSubject(source.principal, stack);
 
   const reasonPayload: SystemAccessDeniedReason = {
     kind: "chain_verification_failed",
@@ -1327,7 +1327,7 @@ async function emitReceivingAgentUnconfiguredDeny(
     model_class: envelope.sovereignty.model_class,
   };
   const auditEnvelopeSubject =
-    subject ?? dispatchReceivedSubject(source.org, stack);
+    subject ?? dispatchReceivedSubject(source.principal, stack);
 
   const denied = createSystemAccessDeniedEvent({
     source,

--- a/src/runner/heartbeat-ticker.ts
+++ b/src/runner/heartbeat-ticker.ts
@@ -50,7 +50,7 @@ export interface HeartbeatTickerStartOpts {
   intervalMs?: number;
   /** Myelin runtime — heartbeats publish via `runtime.publish`. */
   runtime: MyelinRuntime;
-  /** Source triple — same as the rest of `system.*` (org.agent.instance). */
+  /** Source triple — same as the rest of `system.*` (principal.agent.instance). */
   source: SystemEventSource;
   /** Logical agent name (`echo`, `luna`, ...). */
   agentId: string;

--- a/src/runner/substrate/__tests__/pi-dev-runner.test.ts
+++ b/src/runner/substrate/__tests__/pi-dev-runner.test.ts
@@ -40,7 +40,7 @@ import {
 // ---------------------------------------------------------------------------
 
 const SOURCE: ReviewEventSource = {
-  org: "metafactory",
+  principal: "metafactory",
   agent: "cortex",
   instance: "local",
 };

--- a/src/runner/worklog-manager.ts
+++ b/src/runner/worklog-manager.ts
@@ -262,10 +262,10 @@ export class WorklogManager {
    *
    * @param adapterId — defaults to `worklog-manager`. Configurable so a
    *   future multi-channel worklog (one channel per repo) can disambiguate.
-   * @param org — principal id segment. Worklog-manager doesn't store it (the
-   *   manager is constructed with a Discord client + channel ID, not a
-   *   bot config). Passing it explicitly keeps the dependency direction
-   *   clean (no config import here).
+   * @param principal — principal id segment. Worklog-manager doesn't store
+   *   it (the manager is constructed with a Discord client + channel ID,
+   *   not a bot config). Passing it explicitly keeps the dependency
+   *   direction clean (no config import here).
    * @param stack — optional principal stack segment (IAW Phase A.5,
    *   cortex#268). When supplied, the manager subscribes on the 6-segment
    *   grammar `local.{principal}.{stack}.dispatch.task.>` matching sage's
@@ -285,7 +285,7 @@ export class WorklogManager {
    * different window pass `maxAgeMs` explicitly.
    */
   surfaceConfig(opts: {
-    org: string;
+    principal: string;
     adapterId?: string;
     stack?: string;
   }): SurfaceAdapter {
@@ -296,8 +296,8 @@ export class WorklogManager {
     // haven't wired stack identity.
     const subject =
       opts.stack === undefined
-        ? `local.${opts.org}.dispatch.task.>`
-        : `local.${opts.org}.${opts.stack}.dispatch.task.>`;
+        ? `local.${opts.principal}.dispatch.task.>`
+        : `local.${opts.principal}.${opts.stack}.dispatch.task.>`;
     const subjects = [subject];
     return {
       id: opts.adapterId ?? "worklog-manager",

--- a/src/substrates/bus-peer/__tests__/harness.test.ts
+++ b/src/substrates/bus-peer/__tests__/harness.test.ts
@@ -155,7 +155,7 @@ function inboundEnvelope(opts: {
   };
 }
 
-const SOURCE = { org: "metafactory", agent: "cortex", instance: "local" };
+const SOURCE = { principal: "metafactory", agent: "cortex", instance: "local" };
 
 // =============================================================================
 // Cases

--- a/src/substrates/bus-peer/harness.ts
+++ b/src/substrates/bus-peer/harness.ts
@@ -187,7 +187,7 @@ export class BusPeerHarness implements SessionHarness {
     // ----------------------------------------------------------------
     const requestEnvelope: Envelope = {
       id: randomUUID(),
-      source: `${this.source.org}.${this.source.agent}.${this.source.instance}`,
+      source: `${this.source.principal}.${this.source.agent}.${this.source.instance}`,
       type: "dispatch.task.dispatched",
       timestamp: startedAt.toISOString(),
       correlation_id: correlationId,

--- a/src/substrates/claude-code/__tests__/harness.test.ts
+++ b/src/substrates/claude-code/__tests__/harness.test.ts
@@ -44,7 +44,7 @@ import type {
 // ---------------------------------------------------------------------------
 
 const SOURCE: DispatchEventSource = {
-  org: "metafactory",
+  principal: "metafactory",
   agent: "cortex",
   instance: "local",
 };

--- a/src/taps/cc-events/__tests__/cc-events.test.ts
+++ b/src/taps/cc-events/__tests__/cc-events.test.ts
@@ -95,7 +95,7 @@ describe("createCcEventEnvelope", () => {
   test("source segments override defaults", () => {
     const env = createCcEventEnvelope({
       event: makeEvent(),
-      source: { org: "metafactory", agent: "cortex", instance: "tap-relay" },
+      source: { principal: "metafactory", agent: "cortex", instance: "tap-relay" },
     });
     expect(env.source).toBe("metafactory.cortex.tap-relay");
   });
@@ -136,7 +136,7 @@ describe("createCcEventEnvelope", () => {
   test("source.dataResidency overrides the NZ default", () => {
     const env = createCcEventEnvelope({
       event: makeEvent(),
-      source: { org: "metafactory", agent: "cortex", instance: "relay", dataResidency: "EU" },
+      source: { principal: "metafactory", agent: "cortex", instance: "relay", dataResidency: "EU" },
     });
     expect(env.sovereignty.data_residency).toBe("EU");
   });
@@ -183,7 +183,7 @@ describe("createCcEventEnvelope", () => {
   test("envelope passes Ajv validation against vendored myelin schema", () => {
     const env = createCcEventEnvelope({
       event: makeEvent(),
-      source: { org: "metafactory" },
+      source: { principal: "metafactory" },
     });
     const result = validateEnvelope(env);
     if (!result.ok) {
@@ -206,7 +206,7 @@ describe("createCcEventEnvelope", () => {
     // first-party in-process originators on cortex#346.
     const env = createCcEventEnvelope({
       event: makeEvent(),
-      source: { org: "metafactory" },
+      source: { principal: "metafactory" },
       originatorPrincipal: "did:mf:cortex",
     });
     expect(env.originator).toEqual({
@@ -220,7 +220,7 @@ describe("createCcEventEnvelope", () => {
     // the originator block as constructed here.
     const env = createCcEventEnvelope({
       event: makeEvent(),
-      source: { org: "metafactory" },
+      source: { principal: "metafactory" },
       originatorPrincipal: "did:mf:cortex",
     });
     const result = validateEnvelope(env);
@@ -259,7 +259,7 @@ describe("createCcEventPublisher", () => {
 
   test("publishes legacy 5-segment local.{principal}.{type} when stack is omitted", () => {
     const link = makeLink();
-    const pub = createCcEventPublisher({ link: link.stub, org: "metafactory" });
+    const pub = createCcEventPublisher({ link: link.stub, principal: "metafactory" });
     pub(makeEvent({ event_type: "tool.bash.executed" }));
     expect(link.calls).toHaveLength(1);
     expect(link.calls[0]!.subject).toBe("local.metafactory.tool.bash.executed");
@@ -273,7 +273,7 @@ describe("createCcEventPublisher", () => {
     const link = makeLink();
     const pub = createCcEventPublisher({
       link: link.stub,
-      org: "metafactory",
+      principal: "metafactory",
       stack: "default",
     });
     pub(makeEvent({ event_type: "tool.bash.executed" }));
@@ -290,7 +290,7 @@ describe("createCcEventPublisher", () => {
     const link = makeLink();
     const pub = createCcEventPublisher({
       link: link.stub,
-      org: "andreas",
+      principal: "andreas",
       stack: "research",
     });
     pub(makeEvent({ event_type: "session.started" }));
@@ -308,7 +308,7 @@ describe("createCcEventPublisher", () => {
 
   test("payload is JSON-serialised envelope", () => {
     const link = makeLink();
-    const pub = createCcEventPublisher({ link: link.stub, org: "andreas" });
+    const pub = createCcEventPublisher({ link: link.stub, principal: "andreas" });
     pub(makeEvent({ event_type: "session.started" }));
     const env = JSON.parse(link.calls[0]!.payload);
     expect(env.type).toBe("session.started");
@@ -320,7 +320,7 @@ describe("createCcEventPublisher", () => {
     const link = makeLink();
     const pub = createCcEventPublisher({
       link: link.stub,
-      org: "metafactory",
+      principal: "metafactory",
       agent: "cortex",
       instance: "tap-prod",
     });
@@ -332,7 +332,7 @@ describe("createCcEventPublisher", () => {
   test("publish errors are swallowed (do not throw out)", () => {
     const link = makeLink();
     link.throwOnPublish(new Error("nats closed"));
-    const pub = createCcEventPublisher({ link: link.stub, org: "default" });
+    const pub = createCcEventPublisher({ link: link.stub, principal: "default" });
     // Must not throw — the relay's primary path is JSONL append, not bus
     expect(() => pub(makeEvent())).not.toThrow();
   });
@@ -342,7 +342,7 @@ describe("createCcEventPublisher", () => {
     const link = makeLink();
     const pub = createCcEventPublisher({
       link: link.stub,
-      org: "metafactory",
+      principal: "metafactory",
       stack: "default",
       originatorPrincipal: "did:mf:cortex",
     });
@@ -360,7 +360,7 @@ describe("createCcEventPublisher", () => {
 
   test("originator omitted when originatorPrincipal not configured (default off)", () => {
     const link = makeLink();
-    const pub = createCcEventPublisher({ link: link.stub, org: "metafactory" });
+    const pub = createCcEventPublisher({ link: link.stub, principal: "metafactory" });
     pub(makeEvent({ event_type: "tool.bash.executed" }));
     const env = JSON.parse(link.calls[0]!.payload);
     expect(env.originator).toBeUndefined();
@@ -371,7 +371,7 @@ describe("createCcEventPublisher", () => {
     let callCount = 0;
     const pub = createCcEventPublisher({
       link: link.stub,
-      org: "default",
+      principal: "default",
       buildEnvelope: (event, _source) => {
         callCount++;
         return {
@@ -423,7 +423,7 @@ describe("cc-events classification parameterisation (IAW A.3)", () => {
   test("createCcEventEnvelope: omitting classification defaults to local", () => {
     const env = createCcEventEnvelope({
       event: makeEvent(),
-      source: { org: "metafactory" },
+      source: { principal: "metafactory" },
     });
     expect(env.sovereignty.classification).toBe("local");
     expect(validateEnvelope(env).ok).toBe(true);
@@ -432,7 +432,7 @@ describe("cc-events classification parameterisation (IAW A.3)", () => {
   test("createCcEventEnvelope: classification: 'federated' flows into sovereignty", () => {
     const env = createCcEventEnvelope({
       event: makeEvent(),
-      source: { org: "metafactory" },
+      source: { principal: "metafactory" },
       classification: "federated",
     });
     expect(env.sovereignty.classification).toBe("federated");
@@ -442,7 +442,7 @@ describe("cc-events classification parameterisation (IAW A.3)", () => {
   test("createCcEventEnvelope: classification: 'public' flows into sovereignty", () => {
     const env = createCcEventEnvelope({
       event: makeEvent(),
-      source: { org: "metafactory" },
+      source: { principal: "metafactory" },
       classification: "public",
     });
     expect(env.sovereignty.classification).toBe("public");
@@ -457,7 +457,7 @@ describe("cc-events classification parameterisation (IAW A.3)", () => {
     const link = makeLink();
     const pub = createCcEventPublisher({
       link: link.stub,
-      org: "metafactory",
+      principal: "metafactory",
       classification: "federated",
     });
     pub(makeEvent({ event_type: "tool.bash.executed" }));
@@ -473,7 +473,7 @@ describe("cc-events classification parameterisation (IAW A.3)", () => {
     const link = makeLink();
     const pub = createCcEventPublisher({
       link: link.stub,
-      org: "metafactory",
+      principal: "metafactory",
       classification: "public",
     });
     pub(makeEvent({ event_type: "tool.bash.executed" }));
@@ -491,7 +491,7 @@ describe("cc-events classification parameterisation (IAW A.3)", () => {
     const link = makeLink();
     const pub = createCcEventPublisher({
       link: link.stub,
-      org: "metafactory",
+      principal: "metafactory",
     });
     pub(makeEvent({ event_type: "tool.bash.executed" }));
     expect(link.calls[0]!.subject).toBe(

--- a/src/taps/cc-events/cc-events.ts
+++ b/src/taps/cc-events/cc-events.ts
@@ -60,8 +60,9 @@ import type { PublishedEvent } from "./hooks/lib/event-types";
 /**
  * Source identifier struct for CC envelope construction. Mirrors the shape
  * in `bus/system-events.ts` — three dotted segments matching the schema's
- * `org.agent.instance` form. Kept structured so callers don't string-
- * concatenate by hand.
+ * `{principal}.{assistant}.{instance}` form (R4 vocabulary migration;
+ * myelin#185 tightened this to exactly 3 segments). Kept structured so
+ * callers don't string-concatenate by hand.
  *
  * Defaults applied at envelope-construction time:
  *   - `agent` defaults to `"cortex"` (the M7 application emitting these events)
@@ -69,8 +70,8 @@ import type { PublishedEvent } from "./hooks/lib/event-types";
  *     lifting hooks → bus)
  */
 export interface CcEventSource {
-  /** `agent.operatorId` — first segment. Defaults to `"default"` if absent. */
-  org?: string;
+  /** `agent.operatorId` — first segment (principal slug). Defaults to `"default"` if absent. */
+  principal?: string;
   /** Logical agent name. Defaults to `"cortex"`. */
   agent?: string;
   /** Stable instance name. Defaults to `"relay"`. */
@@ -86,7 +87,7 @@ export interface CcEventSource {
 }
 
 function buildSource(src: CcEventSource | undefined): string {
-  return `${src?.org ?? "default"}.${src?.agent ?? "cortex"}.${
+  return `${src?.principal ?? "default"}.${src?.agent ?? "cortex"}.${
     src?.instance ?? "relay"
   }`;
 }
@@ -135,7 +136,7 @@ export interface CreateCcEventEnvelopeOpts {
   event: PublishedEvent;
   /**
    * Envelope source — `{principal}.{agent}.{instance}` per schema. All fields
-   * have sensible defaults. Callers (the relay) typically override `org`
+   * have sensible defaults. Callers (the relay) typically override `principal`
    * to match the bot's `agent.operatorId`.
    */
   source?: CcEventSource;
@@ -235,12 +236,12 @@ export interface CreateCcEventPublisherOpts {
   /** Live NATS connection. Caller owns the lifecycle. */
   link: NatsLink;
   /**
-   * Operator/org segment used in the envelope `source` and (when
+   * Principal segment used in the envelope `source` and (when
    * classification is `local` or `federated`) the published NATS subject.
    * Defaults to `"default"` to mirror the MyelinRuntime convention when
    * `agent.operatorId` is absent.
    */
-  org?: string;
+  principal?: string;
   /**
    * Operator stack segment slotted between `{principal}` and `{type}` on the
    * derived NATS subject (myelin#113 — IAW Phase A.5; closes cortex#266).
@@ -256,7 +257,7 @@ export interface CreateCcEventPublisherOpts {
    * `MyelinRuntime.publish` receives, so the runtime path and the
    * cc-events relay agree on the wire grammar for one operator instance.
    * `public.` classification ignores `stack` (per myelin's
-   * `deriveNatsSubject` semantics — `public` subjects carry no org or
+   * `deriveNatsSubject` semantics — `public` subjects carry no principal or
    * stack segments).
    */
   stack?: string;
@@ -275,8 +276,8 @@ export interface CreateCcEventPublisherOpts {
   /**
    * IAW Phase A.3 — optional sovereignty classification. Defaults to
    * `"local"` for back-compat. Set `"federated"` or `"public"` to scope
-   * relay-lifted CC hooks beyond the org. Applied to every envelope this
-   * publisher produces.
+   * relay-lifted CC hooks beyond the principal. Applied to every envelope
+   * this publisher produces.
    */
   classification?: Classification;
   /**
@@ -341,10 +342,10 @@ export interface CreateCcEventPublisherOpts {
 export function createCcEventPublisher(
   opts: CreateCcEventPublisherOpts,
 ): (event: PublishedEvent) => void {
-  const org = opts.org ?? "default";
+  const principal = opts.principal ?? "default";
   const stack = opts.stack;
   const source: CcEventSource = {
-    org,
+    principal,
     agent: opts.agent ?? "cortex",
     instance: opts.instance ?? "relay",
     ...(opts.dataResidency !== undefined && { dataResidency: opts.dataResidency }),

--- a/src/taps/cc-events/relay.ts
+++ b/src/taps/cc-events/relay.ts
@@ -163,7 +163,7 @@ program
   )
   .option(
     "--org <org>",
-    "Operator/org segment for published subjects (local.{principal}.{type}). Falls back to env var CORTEX_PRINCIPAL (legacy: CORTEX_OPERATOR, GROVE_OPERATOR) or NATS_ORG.",
+    "Principal segment for published subjects (local.{principal}.{type}). Falls back to env var CORTEX_PRINCIPAL (legacy: CORTEX_OPERATOR, GROVE_OPERATOR) or NATS_ORG. (Flag name kept as `--org` for back-compat; the segment is the principal slug per R4 vocabulary migration.)",
   )
   .option(
     "--stack <stack>",
@@ -199,10 +199,12 @@ program
     const natsUrl: string | undefined = options.natsUrl ?? process.env.NATS_URL;
     const natsToken: string | undefined =
       options.natsToken ?? process.env.NATS_TOKEN;
-    // R9 (cortex#388 PR-3): the org/operator segment resolves through the
+    // R9 (cortex#388 PR-3): the principal segment resolves through the
     // principal env-var compat shim — CORTEX_PRINCIPAL with a fallback to
-    // the legacy CORTEX_OPERATOR / GROVE_OPERATOR names.
-    const org: string =
+    // the legacy CORTEX_OPERATOR / GROVE_OPERATOR names. The CLI flag
+    // `--org` is kept for back-compat (R4 cortex#453 — wire vocabulary
+    // renamed but CLI flag names are user-facing and stay one release).
+    const principal: string =
       options.org ?? resolvePrincipalEnv() ?? process.env.NATS_ORG ?? "default";
     // cortex#266 — IAW A.5 stack segment for 6-segment publishes.
     const stack: string | undefined =
@@ -244,7 +246,7 @@ program
         });
         onPublished = createCcEventPublisher({
           link: natsLink,
-          org,
+          principal,
           ...(stack !== undefined && { stack }),
           ...(originatorPrincipal !== undefined && { originatorPrincipal }),
         });
@@ -255,7 +257,7 @@ program
             ? ` originator="${originatorPrincipal}"`
             : "";
         console.log(
-          `cortex-relay: nats publishing enabled — ${safeUrl} (org="${org}"${stackSuffix}${originatorSuffix})`,
+          `cortex-relay: nats publishing enabled — ${safeUrl} (principal="${principal}"${stackSuffix}${originatorSuffix})`,
         );
       } catch (err) {
         // Per the design rule: failed NATS startup must NOT crash the

--- a/src/taps/gh-webhook-receiver/__tests__/integration.test.ts
+++ b/src/taps/gh-webhook-receiver/__tests__/integration.test.ts
@@ -53,7 +53,7 @@ interface Fetcher {
 
 const TEST_SECRET = "integration-test-secret";
 const TEST_SOURCE = {
-  org: "metafactory",
+  principal: "metafactory",
   agent: "cortex",
   instance: "local",
 };

--- a/src/taps/gh-webhook-receiver/__tests__/server.test.ts
+++ b/src/taps/gh-webhook-receiver/__tests__/server.test.ts
@@ -24,7 +24,7 @@ import { validateEnvelope, type Envelope } from "../../../bus/myelin/envelope-va
 
 const TEST_SECRET = "test-secret-for-receiver-tests";
 const TEST_SOURCE = {
-  org: "metafactory",
+  principal: "metafactory",
   agent: "cortex",
   instance: "local",
 };


### PR DESCRIPTION
## Summary

LOCKSTEP follow-up to myelin#185 (R7 breaking cut). Ties off the R4
vocabulary migration on the cortex side: drops the `{org}` subject
placeholder and renames cortex-local `org` → `principal`.

### Changes

1. **`chore(deps)` — bump `@the-metafactory/myelin` 9fc8476 → 4c54b8e**
   (post-#184 + #185). Picks up the R7 breaking cut: subject grammar
   `{org}` → `{principal}`, `source` tightened to exactly 3 segments
   (`{principal}.{stack}.{assistant}`), v3 envelope schema, and the
   R2 cut (myelin#182) dropping `signed_by[].principal` from the
   wire. Re-vendors `src/bus/myelin/vendor/envelope.schema.json`
   from the new schemas/ and bumps `SCHEMA_SOURCE_COMMIT` + the
   drift-guard test pin.

2. **R4a — drop `{org}` placeholder substitution arm.**
   - `makeSubjectPlaceholderSubstituter` (`src/bus/myelin/runtime.ts`)
     drops the `.replaceAll("{org}", …)` back-compat arm; only
     `{principal}` is now resolved.
   - `migrate-config` `convertNats` rewrites legacy bot.yaml `{org}`
     tokens in `nats.subjects` to `{principal}` at conversion time
     so emitted cortex.yaml is consumable by post-#185 myelin
     runtimes (warning surfaced on the converted field).

3. **R4b — rename `org` → `principal` in cortex-local code.**
   - Helper functions: `orgFromConfig` → `principalFromConfig`,
     `orgFromEnvelope` → `principalFromEnvelope`.
   - Test file: `runtime-org-symmetry.test.ts` →
     `runtime-principal-symmetry.test.ts`.
   - Struct field `source.org` → `source.principal` on
     `SystemEventSource`, `CcEventSource`, `CapabilityRegistrySource`,
     plus all cortex-internal callers (dispatch-listener, worklog-
     manager, system-events, dispatch-events, github-events,
     review-events, bus-dispatch-listener, dispatch-source-publisher,
     adapters, harness, runtime substituter).
   - Test fixtures across ~30 files updated from
     `source: { org: … }` → `source: { principal: … }`.

### Carve-outs preserved

- Relay CLI flag `--org <org>` kept for one back-compat release
  (user-facing CLI surface, not wire grammar). Help text updated.
- `signed_by[].principal` test fixtures in `envelope-validator.test.ts`:
  positive-accept tests updated to use `identity` (myelin#182 dropped
  the deprecated key from the wire); reject-tests left as-is since
  they assert rejection behaviour.

### Verification

- `bunx tsc --noEmit`: clean.
- `bun test`: 3544 pass, 2 skip, 0 fail (188 files, 8600 expects).
- `bun run lint:errors`: clean.

### Source-grammar emitter alignment

cortex emitters were already producing the strict 3-segment
`source` form (`${principal}.${agent}.${instance}` via `buildSource`
on `SystemEventSource` and friends). No extra collapse was required;
the dep bump validated this end-to-end.

### Parallel-merge note

cortex#452 (which also bumps the myelin dep) is being implemented
in parallel. Second to merge will hit a trivial conflict on
`package.json` + `bun.lock` (same dep bump). The orchestrator
manages the merge order.

Closes #453

Refs: cortex#436 (parent umbrella), myelin#185, myelin#182