### PR TITLE
feat(cortex): C-C — drop agent.operatorId schema field (closes #429)

### DIFF
--- a/src/__tests__/cortex.capability-boot.test.ts
+++ b/src/__tests__/cortex.capability-boot.test.ts
@@ -222,6 +222,7 @@ describe("startCortex — capability-registry boot wiring (cortex#237 PR-7)", ()
       agentsDir: tmpAgentsDir,
       injectRuntime: runtime,
       inlineAgents,
+      operator: { id: "test-op" },
     });
 
     // One envelope per agent-with-capabilities. The capabilities list is
@@ -282,6 +283,7 @@ describe("startCortex — capability-registry boot wiring (cortex#237 PR-7)", ()
           agentsDir: tmpAgentsDir,
           injectRuntime: runtime,
           inlineAgents,
+          operator: { id: "test-op" },
         }),
       ),
     );
@@ -344,6 +346,7 @@ describe("startCortex — capability-registry boot wiring (cortex#237 PR-7)", ()
         agentsDir: tmpAgentsDir,
         injectRuntime: runtime,
         inlineAgents,
+        operator: { id: "test-op" },
       }),
     );
 
@@ -381,6 +384,7 @@ describe("startCortex — capability-registry boot wiring (cortex#237 PR-7)", ()
       agentsDir: tmpAgentsDir,
       injectRuntime: runtime,
       inlineAgents,
+      operator: { id: "test-op" },
     });
 
     expect(runtime.published.length).toBe(0);
@@ -417,6 +421,7 @@ describe("startCortex — capability-registry boot wiring (cortex#237 PR-7)", ()
           agentsDir: tmpAgentsDir,
           injectRuntime: runtime,
           inlineAgents,
+          operator: { id: "test-op" },
         }),
       ),
     );
@@ -456,6 +461,7 @@ describe("startCortex — capability-registry boot wiring (cortex#237 PR-7)", ()
       agentsDir: tmpAgentsDir,
       injectRuntime: runtime,
       inlineAgents,
+      operator: { id: "test-op" },
     });
 
     expect(runtime.published.length).toBe(2);
@@ -487,6 +493,7 @@ describe("startCortex — capability-registry boot wiring (cortex#237 PR-7)", ()
       agentsDir: tmpAgentsDirA,
       injectRuntime: runtimeA,
       inlineAgents,
+      operator: { id: "test-op" },
     });
     await handleA.stop();
     rmSync(tmpAgentsDirA, { recursive: true, force: true });
@@ -502,6 +509,7 @@ describe("startCortex — capability-registry boot wiring (cortex#237 PR-7)", ()
       agentsDir: tmpAgentsDirB,
       injectRuntime: runtimeB,
       inlineAgents,
+      operator: { id: "test-op" },
     });
     await handleB.stop();
     rmSync(tmpAgentsDirB, { recursive: true, force: true });

--- a/src/__tests__/cortex.review-consumer-boot.test.ts
+++ b/src/__tests__/cortex.review-consumer-boot.test.ts
@@ -214,6 +214,7 @@ describe("startCortex — review-consumer boot wiring (cortex#237 PR-6)", () => 
         agentsDir: tmpAgentsDir,
         injectRuntime: runtime,
         inlineAgents,
+        operator: { id: "test-op" },
       }),
     );
 
@@ -291,6 +292,7 @@ describe("startCortex — review-consumer boot wiring (cortex#237 PR-6)", () => 
         agentsDir: tmpAgentsDir,
         injectRuntime: runtime,
         inlineAgents,
+        operator: { id: "test-op" },
       }),
     );
 
@@ -348,6 +350,7 @@ describe("startCortex — review-consumer boot wiring (cortex#237 PR-6)", () => 
           agentsDir: tmpAgentsDir,
           injectRuntime: runtime,
           inlineAgents,
+          operator: { id: "test-op" },
         }),
       ),
     );
@@ -404,6 +407,7 @@ describe("startCortex — review-consumer boot wiring (cortex#237 PR-6)", () => 
           agentsDir: tmpAgentsDir,
           injectRuntime: runtime,
           inlineAgents: [echoAgent, lunaAgent],
+          operator: { id: "test-op" },
         }),
       ),
     );
@@ -502,6 +506,7 @@ describe("startCortex — review-consumer boot wiring (cortex#237 PR-6)", () => 
         agentsDir: tmpAgentsDir,
         injectRuntime: dormantRuntime,
         inlineAgents,
+        operator: { id: "test-op" },
       }),
     );
 
@@ -595,6 +600,7 @@ describe("startCortex — review-consumer boot wiring (cortex#237 PR-6)", () => 
           agentsDir: tmpAgentsDir,
           injectRuntime: throwingRuntime,
           inlineAgents,
+          operator: { id: "test-op" },
         });
         booted = true;
         return h;

--- a/src/__tests__/cortex.stack-signing-boot.test.ts
+++ b/src/__tests__/cortex.stack-signing-boot.test.ts
@@ -120,6 +120,7 @@ describe("startCortex — stack-signing boot warning (cortex#324)", () => {
           disableDashboard: true,
           disableOutboundPoller: true,
           injectRuntime: runtime,
+          operator: { id: "test-op" },
         }),
       ),
     );
@@ -160,6 +161,7 @@ describe("startCortex — stack-signing boot warning (cortex#324)", () => {
           disableDashboard: true,
           disableOutboundPoller: true,
           injectRuntime: runtime,
+          operator: { id: "test-op" },
         }),
       ),
     );
@@ -191,6 +193,7 @@ describe("startCortex — stack-signing boot warning (cortex#324)", () => {
             disableDashboard: true,
             disableOutboundPoller: true,
             injectRuntime: runtime,
+            operator: { id: "test-op" },
           }),
         ),
       );

--- a/src/__tests__/cortex.test.ts
+++ b/src/__tests__/cortex.test.ts
@@ -120,6 +120,7 @@ describe("startCortex — construction", () => {
       disableConfigWatcher: true,
       disableDashboard: true,
       disableOutboundPoller: true,
+      operator: { id: "test-op" },
     });
     expect(handle).toBeDefined();
     expect(typeof handle.stop).toBe("function");
@@ -141,6 +142,7 @@ describe("startCortex — construction", () => {
       disableConfigWatcher: true,
       disableDashboard: true,
       disableOutboundPoller: true,
+      operator: { id: "test-op" },
     });
     expect(handle).toBeDefined();
     await handle.stop();
@@ -161,6 +163,7 @@ describe("startCortex — construction", () => {
       disableConfigWatcher: true,
       disableDashboard: true,
       disableOutboundPoller: true,
+      operator: { id: "test-op" },
     });
     expect(handle).toBeDefined();
     await handle.stop();
@@ -187,6 +190,7 @@ describe("startCortex — wire-up", () => {
       disableDashboard: true,
       disableOutboundPoller: true,
       injectRuntime: runtime,
+      operator: { id: "test-op" },
     });
     expect(handle).toBeDefined();
     // The surface-router's `start()` registers exactly one envelope handler
@@ -214,6 +218,7 @@ describe("startCortex — wire-up", () => {
       disableDashboard: true,
       disableOutboundPoller: true,
       injectRuntime: runtime,
+      operator: { id: "test-op" },
     });
 
     // Hand-craft a `dispatch.task.received` envelope. The listener parses
@@ -273,16 +278,15 @@ describe("startCortex — wire-up", () => {
     // `local.{principal}.{stack}.tasks.*.>` where `{principal}` comes from
     // the resolved principal id (cortex#427).
     //
-    // Verify: with `agent.operatorId` set on the legacy bot.yaml shape,
-    // the router still subscribes (single registered handler) — the
-    // legacy field is the v3 fallback resolution path inside
-    // `resolvePrincipalId`.
+    // cortex#429 PR-C — the legacy `agent.operatorId` fallback is gone;
+    // the v3-canonical resolution path is `options.operator.id`. Verify
+    // the router subscribes (single registered handler) when only the
+    // canonical path is wired.
     const runtime = createRecordingRuntime();
     const config = minimalConfig({
       agent: {
         name: "no-op-cortex",
         displayName: "NoOpCortex",
-        operatorId: "legacy-bot-yaml-op",
       },
     });
     const handle = await startCortex(config, {
@@ -290,6 +294,7 @@ describe("startCortex — wire-up", () => {
       disableDashboard: true,
       disableOutboundPoller: true,
       injectRuntime: runtime,
+      operator: { id: "v3-canonical-op" },
     });
     expect(handle).toBeDefined();
     expect(runtime.onEnvelopeHandlers.size).toBe(1);
@@ -299,17 +304,16 @@ describe("startCortex — wire-up", () => {
 
   test("startCortex throws when no principal id is resolvable (cortex#427)", async () => {
     // cortex#427 PR-A — `resolvePrincipalId` refuses to silently
-    // collapse to `"default"`. A config with neither
-    // `options.operator.id` (v3 canonical via cortex-shape config) nor
-    // `config.agent.operatorId` (legacy bot.yaml) must fail-fast at
-    // boot — the previous behaviour masked misconfiguration by
-    // emitting `local.default.>` envelopes that competed with real
-    // principals on shared brokers.
+    // collapse to `"default"`. cortex#429 PR-C — the legacy
+    // `config.agent.operatorId` fallback has been retired together with
+    // the schema field; `options.operator.id` is the only resolution
+    // path. A config without it must fail-fast at boot — the previous
+    // behaviour masked misconfiguration by emitting `local.default.>`
+    // envelopes that competed with real principals on shared brokers.
     const runtime = createRecordingRuntime();
     const noPrincipal = minimalConfig({
       agent: { name: "no-op-cortex", displayName: "NoOpCortex" },
     });
-    expect(noPrincipal.agent.operatorId).toBeUndefined();
     let threw: unknown = null;
     try {
       await startCortex(noPrincipal, {
@@ -324,7 +328,6 @@ describe("startCortex — wire-up", () => {
     expect(threw).toBeInstanceOf(Error);
     expect((threw as Error).message).toContain("principal id");
     expect((threw as Error).message).toContain("principal.id");
-    expect((threw as Error).message).toContain("agent.operatorId");
     // No subscriptions leaked from the aborted boot path.
     expect(runtime.onEnvelopeHandlers.size).toBe(0);
   });
@@ -355,6 +358,7 @@ describe("startCortex — wire-up", () => {
       disableDashboard: true,
       disableOutboundPoller: true,
       injectRuntime: runtime,
+      operator: { id: "test-op" },
     });
     expect(handle).toBeDefined();
     expect(runtime.onEnvelopeHandlers.size).toBe(1);
@@ -388,6 +392,7 @@ describe("startCortex — wire-up", () => {
       disableDashboard: true,
       disableOutboundPoller: true,
       injectRuntime: runtime,
+      operator: { id: "test-op" },
     });
     expect(handle).toBeDefined();
     expect(runtime.onEnvelopeHandlers.size).toBe(1);
@@ -407,6 +412,7 @@ describe("startCortex — shutdown", () => {
       disableConfigWatcher: true,
       disableDashboard: true,
       disableOutboundPoller: true,
+      operator: { id: "test-op" },
     });
 
     await handle.stop();
@@ -421,6 +427,7 @@ describe("startCortex — shutdown", () => {
       disableConfigWatcher: true,
       disableDashboard: true,
       disableOutboundPoller: true,
+      operator: { id: "test-op" },
     });
 
     const start = Date.now();
@@ -460,6 +467,7 @@ describe("startCortex — shutdown", () => {
         disableDashboard: true,
         disableOutboundPoller: true,
         injectRuntime: runtime,
+        operator: { id: "test-op" },
         // Tight timeout — keeps the test fast. Production default is
         // 15_000ms; the same code path runs at both budgets.
         shutdownTimeoutMs: 100,
@@ -502,6 +510,7 @@ describe("startCortex — error surface", () => {
       disableConfigWatcher: true,
       disableDashboard: true,
       disableOutboundPoller: true,
+      operator: { id: "test-op" },
     });
     expect(handle).toBeDefined();
     await handle.stop();
@@ -517,6 +526,7 @@ describe("startCortex — error surface", () => {
       disableConfigWatcher: true,
       disableDashboard: true,
       disableOutboundPoller: true,
+      operator: { id: "test-op" },
     });
     expect(handle).toBeDefined();
     await handle.stop();
@@ -540,6 +550,7 @@ describe("startCortex — agent registry (cortex#67 prereq C)", () => {
       disableDashboard: true,
       disableOutboundPoller: true,
       agentsDir: tmpAgentsDir,
+      operator: { id: "test-op" },
     });
     expect(handle.agentRegistry).toBeDefined();
     expect(handle.agentRegistry.size).toBe(0);
@@ -640,6 +651,7 @@ presence:
       disableOutboundPoller: true,
       agentsDir: tmpAgentsDir,
       inlineAgents,
+      operator: { id: "test-op" },
     });
 
     // Three agents total: luna (inline-only), echo (inline wins), holly (fragment-only).

--- a/src/__tests__/principal-identity-consistency.test.ts
+++ b/src/__tests__/principal-identity-consistency.test.ts
@@ -67,19 +67,14 @@ import type {
 } from "../bus/myelin/runtime";
 
 // A minimal AgentConfig — NATS absent so the runtime stays in no-op mode
-// and no real socket is opened. `agent.operatorId` is intentionally
-// DIFFERENT from the `options.operator.id` supplied below so the test
-// proves `resolvePrincipalId` prefers the v3 canonical path.
+// and no real socket is opened. cortex#429 PR-C — `agent.operatorId` was
+// removed from the schema; callers exercise the v3-canonical resolution
+// path via `options.operator.id` below.
 function minimalConfig(overrides: Partial<Record<string, unknown>> = {}): AgentConfig {
   return AgentConfigSchema.parse({
     agent: {
       name: "test-cortex",
       displayName: "TestCortex",
-      // Different from the `options.operator.id` below — if a stray
-      // call site still reads `config.agent.operatorId`, the subject
-      // will carry "legacy-bot-yaml-op" instead of the v3 principal
-      // and the assertions below will fail.
-      operatorId: "legacy-bot-yaml-op",
     },
     discord: [],
     mattermost: [],
@@ -120,18 +115,17 @@ describe("principal-identity consistency (cortex#427 PR-A)", () => {
   test("publish-side `source.principal` equals listener-side `{principal}` subject segment", async () => {
     // Setup: the v3 canonical path supplies the principal id via
     // `options.operator.id` (sourced from `cortexConfig.principal.id`
-    // by the loader). The legacy `config.agent.operatorId` carries a
-    // DELIBERATELY DIFFERENT value so any stray read of the legacy
-    // field surfaces as a mismatched subject.
+    // by the loader). cortex#429 PR-C removed the legacy
+    // `agent.operatorId` schema field — any stray attempt to set it on
+    // input is now silently stripped by Zod, so this test only needs
+    // to exercise the v3-canonical wiring.
     const PRINCIPAL_ID = "v3-canonical-principal";
-    const LEGACY_OP = "legacy-bot-yaml-op";
 
     const runtime = createRecordingRuntime();
     const config = minimalConfig({
       agent: {
         name: "consistency-cortex",
         displayName: "ConsistencyCortex",
-        operatorId: LEGACY_OP,
       },
     });
 
@@ -220,17 +214,16 @@ describe("principal-identity consistency (cortex#427 PR-A)", () => {
     expect(runtime.onEnvelopeHandlers.size).toBe(0);
   });
 
-  test("`options.operator.id` is preferred over `config.agent.operatorId`", async () => {
-    // Direct white-box proof: when both fields are present but
-    // different, the v3 canonical (`options.operator.id`) wins.
-    // The legacy bot.yaml fallback path is only consulted when
-    // `options.operator` is undefined.
+  test("`options.operator.id` is the sole resolution path (legacy field stripped)", async () => {
+    // cortex#429 PR-C — the legacy `agent.operatorId` schema field has
+    // been retired. Any input attempting to set it is silently stripped
+    // by Zod (default strip-unknown mode). Boot succeeds when the
+    // v3-canonical `options.operator.id` is provided.
     const runtime = createRecordingRuntime();
     const config = minimalConfig({
       agent: {
         name: "consistency-cortex",
         displayName: "ConsistencyCortex",
-        operatorId: "this-must-not-win",
       },
     });
 
@@ -239,7 +232,7 @@ describe("principal-identity consistency (cortex#427 PR-A)", () => {
       disableDashboard: true,
       disableOutboundPoller: true,
       injectRuntime: runtime,
-      operator: { id: "this-must-win" },
+      operator: { id: "v3-canonical-op" },
     });
 
     // Boot succeeded → resolution path found a valid principal.
@@ -264,18 +257,15 @@ describe("principal-identity consistency (cortex#427 PR-A)", () => {
     await handle.stop();
   });
 
-  test("legacy bot.yaml fallback: `config.agent.operatorId` resolves when `options.operator` is absent", async () => {
-    // Pure legacy path: a bot.yaml config (no cortex-shape loader,
-    // no `options.operator`) must still boot. `resolvePrincipalId`
-    // falls back to `config.agent.operatorId`. PR-C of cortex#426
-    // retires this fallback after the deprecation window — PR-A
-    // (this PR) keeps it alive.
+  test("`options.operator.id` is the sole resolution path (PR-C — legacy fallback retired)", async () => {
+    // cortex#429 PR-C — the legacy `config.agent.operatorId` fallback
+    // has been retired together with the schema field. Boot succeeds
+    // only when `options.operator.id` is present.
     const runtime = createRecordingRuntime();
     const config = minimalConfig({
       agent: {
-        name: "legacy-cortex",
-        displayName: "LegacyCortex",
-        operatorId: "legacy-op-id",
+        name: "v3-cortex",
+        displayName: "V3Cortex",
       },
     });
 
@@ -284,27 +274,28 @@ describe("principal-identity consistency (cortex#427 PR-A)", () => {
       disableDashboard: true,
       disableOutboundPoller: true,
       injectRuntime: runtime,
-      // No `operator:` field — legacy bot.yaml path.
+      operator: { id: "v3-canonical-op" },
     });
 
     expect(runtime.onEnvelopeHandlers.size).toBe(1);
     await handle.stop();
   });
 
-  test("missing both sources is a startup error, not a silent default", async () => {
+  test("missing `options.operator.id` is a startup error, not a silent default", async () => {
     // Anti-fallback regression guard: the pre-cortex#427 code
     // collapsed to `local.default.>` when neither source resolved.
-    // PR-A makes that a fail-fast — a missing principal is a
-    // misconfiguration, not a default.
+    // PR-A made that a fail-fast — a missing principal is a
+    // misconfiguration, not a default. cortex#429 PR-C narrowed the
+    // resolution path to `options.operator.id` only (the legacy
+    // `config.agent.operatorId` fallback retired together with the
+    // schema field).
     const runtime = createRecordingRuntime();
     const config = minimalConfig({
       agent: {
         name: "no-principal-cortex",
         displayName: "NoPrincipalCortex",
-        // operatorId intentionally omitted.
       },
     });
-    expect(config.agent.operatorId).toBeUndefined();
 
     let threw: unknown = null;
     try {
@@ -313,35 +304,29 @@ describe("principal-identity consistency (cortex#427 PR-A)", () => {
         disableDashboard: true,
         disableOutboundPoller: true,
         injectRuntime: runtime,
-        // No `operator:` field either.
+        // No `operator:` field — the v3-canonical path is unwired.
       });
     } catch (err) {
       threw = err;
     }
     expect(threw).toBeInstanceOf(Error);
-    // The error message names BOTH config keys so the operator
-    // knows where to look (cortex-shape vs legacy bot.yaml).
     expect((threw as Error).message).toContain("principal.id");
-    expect((threw as Error).message).toContain("agent.operatorId");
     // The error message explicitly rejects the `"default"` collapse.
     expect((threw as Error).message).toContain("default");
     // No subscriptions leaked from the aborted boot path.
     expect(runtime.onEnvelopeHandlers.size).toBe(0);
   });
 
-  test("empty-string `agent.operatorId` is treated as missing (no silent `\"\"` subject)", async () => {
-    // AgentConfig allows `agent.operatorId` to be omitted; some legacy
-    // configs may have it set to an empty string after a botched
-    // migration. The resolver must treat `""` the same as undefined
-    // — otherwise the subject would render as `local..tasks.*.>`
-    // (two consecutive dots) which is an invalid NATS subject and a
-    // VERY hard bug to diagnose from operator logs.
+  test("empty-string `options.operator.id` is treated as missing (no silent `\"\"` subject)", async () => {
+    // cortex#429 PR-C — the resolver must treat `""` the same as
+    // undefined — otherwise the subject would render as
+    // `local..tasks.*.>` (two consecutive dots) which is an invalid
+    // NATS subject and a VERY hard bug to diagnose from operator logs.
     const runtime = createRecordingRuntime();
     const config = minimalConfig({
       agent: {
         name: "empty-op-cortex",
         displayName: "EmptyOpCortex",
-        operatorId: "",
       },
     });
 
@@ -352,6 +337,7 @@ describe("principal-identity consistency (cortex#427 PR-A)", () => {
         disableDashboard: true,
         disableOutboundPoller: true,
         injectRuntime: runtime,
+        operator: { id: "" },
       });
     } catch (err) {
       threw = err;

--- a/src/bus/myelin/__tests__/runtime-principal-symmetry.test.ts
+++ b/src/bus/myelin/__tests__/runtime-principal-symmetry.test.ts
@@ -3,7 +3,8 @@
  * `{principal}` symmetry invariant.
  *
  * Subscribe-side substitutes `{principal}` in NATS subject patterns from
- * `config.agent.operatorId` at startup via `principalFromConfig`.
+ * the boot-resolved `principal.id` at startup via `principalFromConfig`
+ * (cortex#429 PR-C — flows in via `MyelinRuntimeOptions.principal`).
  * Publish-side extracts `{principal}` from `envelope.source`'s first
  * segment via `principalFromEnvelope`. For any envelope this stack emits
  * via the system-event helpers (which build `source` as

--- a/src/bus/myelin/__tests__/runtime.test.ts
+++ b/src/bus/myelin/__tests__/runtime.test.ts
@@ -13,12 +13,14 @@ import type { AgentConfig } from "../../../common/types/config";
 import { startMyelinRuntime } from "../runtime";
 
 function makeConfig(natsBlock: AgentConfig["nats"]): AgentConfig {
+  // cortex#429 PR-C — `agent.operatorId/operatorName` retired from
+  // schema. The principal id flows in via `MyelinRuntimeOptions.principal`
+  // at the call sites below (defaulted to `"andreas"` to preserve the
+  // pre-PR-C subject-substitution behaviour exercised by these tests).
   return {
     agent: {
       name: "luna",
       displayName: "Luna",
-      operatorId: "andreas",
-      operatorName: "Andreas",
     },
     nats: natsBlock,
   } as unknown as AgentConfig;
@@ -229,7 +231,7 @@ describe("MyelinRuntime", () => {
     expect(errored).toBe(true);
   });
 
-  test("subjects placeholder {principal} is substituted from agent.operatorId", async () => {
+  test("subjects placeholder {principal} is substituted from options.principal (cortex#429)", async () => {
     const fake = makeFakeNatsConnection();
     const config = makeConfig({
       url: "nats://localhost:4222",
@@ -238,6 +240,7 @@ describe("MyelinRuntime", () => {
     });
     const runtime = await startMyelinRuntime(config, {
       connectImpl: async () => fake.nc,
+      principal: "andreas",
     });
     expect(runtime.enabled).toBe(true);
     expect(fake.subscribePatterns[0]).toBe("local.andreas.attention.>");
@@ -265,6 +268,7 @@ describe("MyelinRuntime", () => {
     const runtime = await startMyelinRuntime(config, {
       connectImpl: async () => fake.nc,
       stack: "research",
+      principal: "andreas",
     });
     expect(runtime.enabled).toBe(true);
     expect(fake.subscribePatterns[0]).toBe(
@@ -282,6 +286,7 @@ describe("MyelinRuntime", () => {
     });
     const runtime = await startMyelinRuntime(config, {
       connectImpl: async () => fake.nc,
+      principal: "andreas",
       // no stack supplied
     });
     expect(runtime.enabled).toBe(true);
@@ -305,6 +310,7 @@ describe("MyelinRuntime", () => {
     const runtime = await startMyelinRuntime(config, {
       connectImpl: async () => fake.nc,
       stack: "research",
+      principal: "andreas",
     });
     expect(fake.subscribePatterns[0]).toBe("local.andreas.>");
     await runtime.stop();
@@ -418,11 +424,11 @@ describe("MyelinRuntime", () => {
       await runtime.publish(env);
       expect(fake.publish).toHaveBeenCalledTimes(1);
       // IAW Phase A.3: subject `{principal}` comes from `envelope.source`'s first
-      // segment ("metafactory" here), NOT from `agent.operatorId`. Subject
-      // prefix mirrors `envelope.sovereignty.classification` ("local" here),
-      // satisfying `validateSubjectEnvelopeAlignment`. Emit-site helpers
-      // populate `envelope.source` with the operator-side `agent.operatorId`,
-      // so the two values agree at runtime — the test fixture exercises the
+      // segment ("metafactory" here), NOT from the boot-resolved principal id.
+      // Subject prefix mirrors `envelope.sovereignty.classification` ("local"
+      // here), satisfying `validateSubjectEnvelopeAlignment`. Emit-site helpers
+      // populate `envelope.source` with the operator-side `principal.id` so
+      // the two values agree at runtime — the test fixture exercises the
       // derive-from-envelope path directly.
       expect(fake.publishes[0]?.subject).toBe(
         "local.metafactory.system.adapter.degraded",

--- a/src/bus/myelin/envelope-validator.ts
+++ b/src/bus/myelin/envelope-validator.ts
@@ -575,10 +575,10 @@ export type Classification = Envelope["sovereignty"]["classification"];
  *   - `classification === "public"`    → `public.{type}` (no org, no stack — public is global)
  *
  * `{principal}` is the first dotted segment of `envelope.source` (the same value
- * cortex's MyelinRuntime captures from `agent.operatorId` at startup, so
- * subject and source stay symmetrical). `{stack}` is the principal's stack
- * identity — supplied by the caller when in stack-aware mode (IAW A.5),
- * omitted in the legacy migration window.
+ * cortex's MyelinRuntime captures from the boot-resolved `principal.id` at
+ * startup, so subject and source stay symmetrical). `{stack}` is the
+ * principal's stack identity — supplied by the caller when in stack-aware
+ * mode (IAW A.5), omitted in the legacy migration window.
  *
  * Pure function; safe to call from any context.
  */
@@ -607,7 +607,8 @@ function firstSegment(s: string): string {
  * IAW Phase A.3 follow-up (cortex#130 item 1) — symmetric `{principal}` extractor
  * for the publish-side. Publish derives `{principal}` from `envelope.source`'s
  * leading segment; subscribe substitutes `{principal}` in subject patterns from
- * `agent.operatorId` at startup. These two values MUST agree for any
+ * the boot-resolved `principal.id` at startup (sourced via
+ * `MyelinRuntimeOptions.principal`). These two values MUST agree for any
  * envelope this stack emits, or subjects diverge between publish/subscribe.
  *
  * Use {@link principalFromConfig} on the subscribe-side and

--- a/src/bus/myelin/runtime.ts
+++ b/src/bus/myelin/runtime.ts
@@ -62,7 +62,8 @@ export interface MyelinRuntime {
    *   - `classification === "public"`    → `public.{type}` (no `{principal}` segment)
    *
    * `{principal}` is the first dotted segment of `envelope.source` (which
-   * cortex's `system-events.ts` etc. populate from `agent.operatorId`).
+   * cortex's `system-events.ts` etc. populate from the boot-resolved
+   * `principal.id`).
    * The 1:1 alignment between subject prefix and `sovereignty.classification`
    * is myelin's protocol-level invariant — see
    * {@link validateSubjectEnvelopeAlignment}.
@@ -282,6 +283,16 @@ export interface MyelinRuntimeOptions {
    * (`SAGE_STACK=default`) so the Offer loop closes end-to-end.
    */
   stack?: string;
+  /**
+   * cortex#429 PR-C — boot-resolved principal id used to substitute
+   * `{principal}` in subscribe-side subject patterns. Replaces the
+   * prior read from `config.agent.operatorId` (removed together with
+   * the schema field). The entrypoint passes the value resolved by
+   * `resolvePrincipalId(options.operator)`; when undefined, the
+   * substituter falls back to `"default"` to preserve legacy NATS-less
+   * runtime no-op semantics.
+   */
+  principal?: string;
 }
 
 /**
@@ -413,8 +424,14 @@ export async function startMyelinRuntime(
   // A pattern like `local.{principal}.{stack}.system.>` resolves to either
   // `local.{principal}.{stack}.system.>` (stack-aware) or `local.{principal}.system.>`
   // (legacy) depending on whether the boot path supplied a stack.
+  // cortex#429 PR-C — `principal` flows in via options (sourced from
+  // the entrypoint's `resolvePrincipalId`) since the legacy
+  // `config.agent.operatorId` schema field has been retired.
+  // `principalFromConfig` retains the `?? "default"` fallback semantics
+  // for compatibility with no-op runtimes (NATS absent) and tests that
+  // exercise the substituter without a boot-resolved principal.
   const substituter = makeSubjectPlaceholderSubstituter({
-    principal: principalFromConfig(config.agent.operatorId),
+    principal: principalFromConfig(options?.principal),
     stack: options?.stack,
   });
   const subjects = substituter(nats.subjects);
@@ -643,14 +660,16 @@ export async function startMyelinRuntime(
     // IAW Phase A.3: subject derivation now mirrors
     // `envelope.sovereignty.classification`. Prior code hardcoded
     // `local.{principal}.{type}` here, making federated/public emission
-    // structurally impossible — `{principal}` came from `config.agent.operatorId`
-    // and the classification prefix was always "local". `deriveNatsSubject`
-    // reads classification + extracts `{principal}` from `envelope.source` so the
-    // 1:1 subject↔classification invariant
+    // structurally impossible — `{principal}` came from the boot-resolved
+    // principal id and the classification prefix was always "local".
+    // `deriveNatsSubject` reads classification + extracts `{principal}`
+    // from `envelope.source` so the 1:1 subject↔classification invariant
     // (`validateSubjectEnvelopeAlignment`) holds for every emit site
     // without further changes. `envelope.source`'s first segment is the
-    // same value `agent.operatorId` produces when emit-site helpers
-    // assemble it, so subscribe-side `{principal}` substitution stays symmetric.
+    // same value the boot-resolved `principal.id` produces when emit-site
+    // helpers assemble it (cortex#429 PR-C — flows in via
+    // `MyelinRuntimeOptions.principal`), so subscribe-side `{principal}`
+    // substitution stays symmetric.
     //
     // IAW Phase A.5 (cortex#262 closes): pass `stack` so subjects land in
     // the 6-segment `local.{principal}.{stack}.{type}` grammar that sage's

--- a/src/bus/system-events.ts
+++ b/src/bus/system-events.ts
@@ -69,7 +69,7 @@ import { AGENT_HEARTBEAT_TYPE } from "../common/types/agent-heartbeat";
  *   - For cortex-emitted system.* events: `{principal}.cortex.local`
  */
 export interface SystemEventSource {
-  /** `agent.operatorId` — first segment (principal slug). */
+  /** Boot-resolved `principal.id` — first segment (principal slug). */
   principal: string;
   /** Logical agent name — `cortex`, `grove`, `pilot`, etc. */
   agent: string;

--- a/src/cli/cortex/commands/__tests__/migrate-config.test.ts
+++ b/src/cli/cortex/commands/__tests__/migrate-config.test.ts
@@ -1967,33 +1967,31 @@ describe("convertBotYaml — cortex#428 PR-B presence.surfaceSubjects synthesis"
   });
 });
 
-describe("convertBotYaml — cortex#428 PR-B agent.operatorId back-compat", () => {
-  test("attaches transient operatorId = principal.id on every agent", () => {
+describe("convertBotYaml — cortex#429 PR-C: agent.operatorId synthesis retired", () => {
+  test("does NOT attach a transient operatorId to any agent (PR-B aid graduated)", () => {
     const legacy = loadFixture("minimal.bot.yaml");
     const result = convertBotYaml(legacy, { configDir: FIXTURE_DIR });
     for (const agent of result.cortex.agents) {
-      // Type-laundering required — operatorId is not in the schema. The
-      // synthesis attaches it post-parse so the migrator's YAML output
-      // boots on v3.0.0–v3.0.3 (pre-PR-A) where the field IS read.
+      // Negative assertion: the PR-B post-parse synthesis has been
+      // removed together with the schema field. No `operatorId`
+      // should appear on any migrated agent.
       const raw = agent as unknown as Record<string, unknown>;
-      expect(raw.operatorId).toBe(result.cortex.principal.id);
+      expect(raw.operatorId).toBeUndefined();
     }
   });
 
-  test("survives YAML round-trip — operatorId appears in serialised output", () => {
+  test("serialised YAML carries NO `operatorId:` field on agents", () => {
     const legacy = loadFixture("minimal.bot.yaml");
     const result = convertBotYaml(legacy, { configDir: FIXTURE_DIR });
     const yamlOut = YAML.stringify(result.cortex);
-    expect(yamlOut).toContain("operatorId: jc");
+    expect(yamlOut).not.toContain("operatorId: jc");
   });
 
-  test("emits a warning explaining the deprecation timeline", () => {
+  test("emits NO `agents[].operatorId` warning (synthesis retired in PR-C)", () => {
     const legacy = loadFixture("minimal.bot.yaml");
     const result = convertBotYaml(legacy, { configDir: FIXTURE_DIR });
     const opIdWarn = result.warnings.find((w) => w.field === "agents[].operatorId");
-    expect(opIdWarn).toBeDefined();
-    expect(opIdWarn!.message).toMatch(/v3\.0\.0–v3\.0\.3.*back-compat/);
-    expect(opIdWarn!.message).toMatch(/cortex#429/);
+    expect(opIdWarn).toBeUndefined();
   });
 });
 

--- a/src/cli/cortex/commands/migrate-config-lib.ts
+++ b/src/cli/cortex/commands/migrate-config-lib.ts
@@ -837,7 +837,7 @@ function buildRenderers(legacy: LegacyBotYaml, warnings: ConversionWarning[]): C
 // cortex#428 — v3-complete synthesis (Stage 4-A wiring)
 // =============================================================================
 //
-// Stage 4/5 of the v3 dispatch path needs three fields on the migrated
+// Stage 4/5 of the v3 dispatch path needs two fields on the migrated
 // config that PR-A (cortex#427) did NOT add to its `principal:` rename:
 //
 //   1. `agent.runtime.capabilities[]` — at minimum `["chat"]` per myelin#181
@@ -849,12 +849,11 @@ function buildRenderers(legacy: LegacyBotYaml, warnings: ConversionWarning[]): C
 //      dispatch.task.*` derived from the parent config. Without this the
 //      surface-router never matches the adapter and dispatch envelopes drop
 //      silently on the floor.
-//   3. Transient `agent.operatorId: <principal.id>` — Andreas's deployments
-//      on v3.0.0–v3.0.3 (pre-PR-A) still read `agent.operatorId` from the
-//      cortex.yaml. PR-A's merge on main means the field is unread on
-//      tip-of-main, but the migrator's output must boot cleanly on the
-//      currently-deployed v3.0.x release too. PR-C (cortex#429) drops this
-//      synthesis once the v3.0.0–v3.0.3 window closes.
+//
+// cortex#429 PR-C — a third transient synthesis (`agent.operatorId:
+// <principal.id>` per agent, added in PR-B / cortex#428) has been
+// retired together with the schema field. The v3.0.0–v3.0.3 deprecation
+// window has graduated.
 //
 // Each synthesis function is idempotent: re-running the migrator on a
 // config that already declares these fields preserves them verbatim. The
@@ -1224,39 +1223,6 @@ function synthesizeSurfaceSubjects(
 }
 
 /**
- * Synthesize `agent.operatorId: <principal.id>` on every agent as a
- * deprecation aid for v3.0.0–v3.0.3 deployments that still read the field
- * directly (pre-PR-A behaviour). The `CortexConfigSchema` strips unknown
- * keys, so this synthesis MUST run AFTER the schema parse — we mutate the
- * already-validated object before returning it to the caller.
- *
- * PR-C (cortex#429) drops this synthesis when the schema field itself is
- * removed; the field is intentionally NOT added to `AgentSchema` here —
- * it's a transient compatibility surface, not a v3 contract.
- */
-function synthesizeOperatorIdBackCompat(
-  cortex: MigratedCortexConfig,
-  warnings: ConversionWarning[],
-): void {
-  const principalId = cortex.principal.id;
-  // The `MigratedCortexConfig.agents` type does NOT carry `operatorId` —
-  // attaching it is a deliberate type-laundering past the schema. The cast
-  // is narrow (`Record<string, unknown>`) so the migrator's emitted YAML
-  // round-trips on v3.0.0–v3.0.3 loaders. PR-C removes this branch.
-  for (const agent of cortex.agents) {
-    (agent as unknown as Record<string, unknown>).operatorId = principalId;
-  }
-  warnings.push({
-    field: "agents[].operatorId",
-    message:
-      `synthesised transient agent.operatorId="${principalId}" on every agent ` +
-      `for v3.0.0–v3.0.3 back-compat (cortex#427's principal.id read landed on ` +
-      `tip-of-main but is not in the v3.0.x deployed window). PR-C / cortex#429 ` +
-      `drops this synthesis once the v3.0.x window closes.`,
-  });
-}
-
-/**
  * Convert a legacy bot.yaml-shaped object to cortex.yaml-shape. Pure: no IO
  * apart from optional `existsSync` for assistant-prompt-file validation.
  *
@@ -1440,10 +1406,10 @@ export function convertBotYaml(
   // above) — it just emits the post-v3 `principal:`-shaped output.
   const migrated: MigratedCortexConfig = parsed;
 
-  // cortex#428 (PR-B) — transient `agent.operatorId` back-compat MUST run
-  // post-parse: the schema strips unknown keys, so any pre-parse mutation
-  // would be silently dropped. PR-C / cortex#429 retires this branch.
-  synthesizeOperatorIdBackCompat(migrated, warnings);
+  // cortex#429 PR-C — the transient `agent.operatorId` back-compat
+  // synthesis added in PR-B (#428) has been retired together with the
+  // schema field. Configs flowing through the migrator land on the
+  // v3-canonical `principal.id` only.
 
   // Compute parallel-mode pre-flight gaps against the FINAL policy block.
   const preflightGaps = policyPreflight({

--- a/src/common/config/__tests__/loader.test.ts
+++ b/src/common/config/__tests__/loader.test.ts
@@ -343,10 +343,11 @@ describe("MIG-7.2e — cortex-shape detection + transform", () => {
     const { config, principal } = loadConfigWithAgents(path);
     expect(config.agent.name).toBe("ivy");
     expect(config.agent.displayName).toBe("Ivy");
-    expect(config.agent.operatorId).toBe("jc");
-    expect(config.agent.operatorName).toBe("Jens-Christian");
-    // v2.0.0 (cortex#297) — operator*Id retired from AgentConfig.agent;
-    // surfaced through LoadedConfig.principal instead.
+    // cortex#429 PR-C — `agent.operatorId/operatorName` retired from
+    // AgentConfig.agent. Principal identity + display name now live on
+    // `LoadedConfig.principal`.
+    expect(principal?.id).toBe("jc");
+    expect(principal?.displayName).toBe("Jens-Christian");
     expect(principal?.discordId).toBe("285727653603049472");
   });
 
@@ -749,9 +750,10 @@ describe("MIG-7.2e — cortex-shape detection + transform", () => {
     expect(loaded.inlineAgents).toHaveLength(1);
     expect(loaded.inlineAgents[0]!.id).toBe("ivy");
     // The principal block is normalised onto LoadedConfig.principal.
+    // cortex#429 PR-C — `config.agent.operatorId` retired; principal id
+    // is sole-sourced from `LoadedConfig.principal.id` now.
     expect(loaded.principal?.id).toBe("jc");
     expect(loaded.principal?.discordId).toBe("285727653603049472");
-    expect(loaded.config.agent.operatorId).toBe("jc");
   });
 
   // v3.0.0 BREAKING (manifest PR-11) — cortex.yaml requires the

--- a/src/common/config/loader.ts
+++ b/src/common/config/loader.ts
@@ -83,6 +83,14 @@ export interface LoadedConfig {
    */
   principal?: {
     id: string;
+    /**
+     * cortex#429 PR-C — surface the principal's display name onto the
+     * loaded boot-time view so dashboard wiring no longer has to dip
+     * back into the removed `AgentConfig.agent.operatorName` legacy
+     * field. Optional — operators can omit `principal.displayName` on
+     * cortex.yaml and the boot path falls back to `principal.id`.
+     */
+    displayName?: string;
     discordId?: string;
     mattermostId?: string;
     slackId?: string;
@@ -428,17 +436,19 @@ function loadCortexShape(
   // Downstream consumers that read `config.agent.name` get the first agent's
   // id; per-instance routing flows via `inlineAgents` so the multi-agent
   // case stays correct.
+  //
+  // cortex#429 PR-C — `operatorId` and `operatorName` synthesis retired
+  // alongside the schema fields. Downstream consumers (cortex.ts,
+  // myelin runtime) now read the principal identity directly from
+  // `LoadedConfig.principal.id` (returned below) and the helpers that
+  // accept it as a parameter.
+  //
   // `principal.id` and `principal.dataResidency` are non-optional after parse
-  // (required + default respectively), so the prior `!== undefined` guards
-  // were dead conditions. `discordId` and `mattermostId` are genuinely
-  // optional — keep the spread-on-truthy pattern there.
+  // (required + default respectively), so prior `!== undefined` guards
+  // were dead conditions.
   const synthesizedAgent = {
     name: firstAgent.id,
     displayName: firstAgent.displayName,
-    operatorId: cortexConfig.principal.id,
-    ...(cortexConfig.principal.displayName !== undefined && {
-      operatorName: cortexConfig.principal.displayName,
-    }),
     // v2.0.0 cutover (cortex#297) — `operator*Id` fields retired from
     // AgentConfig.agent. Principal's platform-side ids surface through
     // `LoadedConfig.principal` (see return value below); the boot path in
@@ -479,6 +489,9 @@ function loadCortexShape(
     // v2.0.0 (cortex#297) — surface principal platform ids for the boot path.
     principal: {
       id: cortexConfig.principal.id,
+      ...(cortexConfig.principal.displayName !== undefined && {
+        displayName: cortexConfig.principal.displayName,
+      }),
       ...(cortexConfig.principal.discordId !== undefined && {
         discordId: cortexConfig.principal.discordId,
       }),

--- a/src/common/config/watcher.ts
+++ b/src/common/config/watcher.ts
@@ -91,10 +91,11 @@ const RESTART_FIELDS = new Set([
   "api.apiKey",
 
   // Agent core identity
+  // cortex#429 PR-C — `agent.operatorId/Discord/Mattermost` retired from
+  // schema. Principal identity lives on `principal.*` (handled by the
+  // cortex-config watcher path) and platform ids on
+  // `principal.discordId/mattermostId/slackId`.
   "agent.name",
-  "agent.operatorId",
-  "agent.operatorDiscordId",
-  "agent.operatorMattermostId",
 
   // Execution backend
   "execution.default",

--- a/src/common/types/config.ts
+++ b/src/common/types/config.ts
@@ -265,11 +265,15 @@ export const AgentConfigSchema = z.object({
   agent: z.object({
     name: z.string().min(1),
     displayName: z.string().min(1),
-    /** Operator identity — groups agents sharing a subscription. Used in both local and cloud mode. */
-    operatorId: z.string().optional(),
-    /** Display name for the operator (shown on dashboard). Defaults to operatorId. */
-    operatorName: z.string().optional(),
     /**
+     * cortex#429 PR-C (deprecation graduation) — `agent.operatorId` and
+     * `agent.operatorName` were the legacy v2 fields carrying the principal
+     * identity. cortex#427 PR-A migrated every read site to the v3-canonical
+     * `principal.id` (surfaced via `LoadedConfig.principal`). cortex#429 PR-C
+     * drops the fields entirely; configs that still declare them will see
+     * Zod strip them silently (no schema error — Zod default mode) and any
+     * downstream consumer that still expects them needs to be re-migrated.
+     *
      * v2.0.0 cutover (cortex#297) — `operatorDiscordId/Mattermost/Slack` retired.
      * The principal's platform-side ids live on `PrincipalConfigSchema.discordId/mattermostId/slackId`
      * in cortex-config.ts and are surfaced through `LoadedConfig.principal` for the
@@ -486,8 +490,8 @@ export const AgentConfigSchema = z.object({
     /**
      * Subject patterns to subscribe to. Default empty — caller must
      * provide at least one pattern when enabling NATS. The placeholder
-     * `{principal}` is substituted with `agent.operatorId` at runtime so a
-     * single template works across operators.
+     * `{principal}` is substituted with the boot-resolved `principal.id`
+     * at runtime so a single template works across principals.
      */
     subjects: z.array(z.string().min(1)).default([]),
     /**

--- a/src/common/types/stack.ts
+++ b/src/common/types/stack.ts
@@ -204,8 +204,9 @@ export interface DeriveStackIdInput {
  *   legacy shape). Callers wire `deriveStackId` in via the
  *   `LoadedConfig.stack` field the loader exposes (set when cortex shape
  *   was detected). The boot path constructs a small input object from the
- *   AgentConfig projection's `agent.operatorId` (legacy field-name continuity)
- *   plus the optional `stack:` block — no second schema parse required.
+ *   boot-resolved `principal.id` (cortex#429 — sourced via
+ *   `LoadedConfig.principal.id`) plus the optional `stack:` block — no
+ *   second schema parse required.
  *
  * The return type is plain — no error path, no `null`. Boot code logs the
  * derived id and proceeds; the caller never has to branch on a degenerate

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -317,6 +317,12 @@ export interface StartCortexOptions {
    */
   operator?: {
     id: string;
+    /**
+     * cortex#429 PR-C — replaces the removed `AgentConfig.agent.operatorName`.
+     * Surfaced on the dashboard's `operator` column when present; defaults
+     * to `id` otherwise.
+     */
+    displayName?: string;
     discordId?: string;
     mattermostId?: string;
     slackId?: string;
@@ -327,40 +333,36 @@ export interface StartCortexOptions {
  * cortex#427 — resolve the canonical `{principal}` segment for every
  * NATS subject, dashboard column, and `signed_by` chain inside the
  * cortex process. v3 vocabulary (cortex#388) made `principal.id` the
- * single source of truth on cortex.yaml; the loader synthesises a
- * legacy-compatible `AgentConfig.agent.operatorId` for downstream code
- * AND surfaces the same value as `LoadedConfig.principal.id`. This
- * helper prefers the v3-canonical `LoadedConfig.principal` path so the
- * post-MIG-8 schema deletion (PR-C of cortex#426) is a single-line
- * change here — drop the `agent.operatorId` fallback.
+ * single source of truth on cortex.yaml; the loader surfaces it as
+ * `LoadedConfig.principal.id`, which the entrypoint hands in here via
+ * `options.operator.id`.
+ *
+ * cortex#429 PR-C — the legacy `config.agent.operatorId` fallback has
+ * been retired together with the schema field. Operators on un-migrated
+ * configs see a fail-fast startup error pointing at `principal.id`; this
+ * IS the upgrade prompt.
  *
  * **No silent `"default"` fallback.** v3 PrincipalConfigSchema makes
  * `principal.id` REQUIRED (`z.string().min(1)`); a missing identity
- * means the config didn't load through the v3 path AND the legacy
- * bot.yaml didn't declare `agent.operatorId` either. That's a startup
+ * means the config didn't load through the v3 path. That's a startup
  * error — not a silent collapse to `local.default.>` that hides
  * misconfiguration until the first cross-principal envelope leaks.
  *
- * @throws if neither `options.operator.id` nor `config.agent.operatorId`
- *   is set — fail-fast at boot rather than masking the gap.
+ * @throws if `options.operator.id` is unset or empty — fail-fast at
+ *   boot rather than masking the gap.
  */
 function resolvePrincipalId(
-  config: AgentConfig,
   operator: StartCortexOptions["operator"],
 ): string {
   const fromLoadedOperator = operator?.id;
   if (fromLoadedOperator !== undefined && fromLoadedOperator !== "") {
     return fromLoadedOperator;
   }
-  const fromLegacyAgent = config.agent.operatorId;
-  if (fromLegacyAgent !== undefined && fromLegacyAgent !== "") {
-    return fromLegacyAgent;
-  }
   throw new Error(
     "cortex: cannot resolve principal id — cortex.yaml must declare `principal.id` " +
-      "(v3 canonical) OR legacy bot.yaml must declare `agent.operatorId`. " +
-      "The `{principal}` segment of every NATS subject and `signed_by` chain " +
-      "is required; refusing to silently collapse to `default`.",
+      "(v3 canonical). The `{principal}` segment of every NATS subject and " +
+      "`signed_by` chain is required; refusing to silently collapse to `default`. " +
+      "If upgrading from v2, run `cortex migrate-config` to rewrite your config.",
   );
 }
 
@@ -389,10 +391,11 @@ export async function startCortex(
 
   // cortex#427 — resolve the canonical principal id ONCE at boot. Every
   // subsequent `{principal}` segment (NATS subjects, `signed_by` chains,
-  // dashboard columns) reads from this variable so a cortex-shape config
-  // (v3 `principal.id`) and a legacy bot.yaml (`agent.operatorId`) can't
-  // diverge between publisher and consumer. PR-A of cortex#426 follow-up.
-  const principalId = resolvePrincipalId(config, options.operator);
+  // dashboard columns) reads from this variable. cortex#429 PR-C retired
+  // the legacy `config.agent.operatorId` fallback together with the
+  // schema field — `options.operator.id` (sourced from `principal.id` by
+  // the loader) is the single resolution path.
+  const principalId = resolvePrincipalId(options.operator);
   console.log(`  Principal: ${principalId}`);
 
   // IAW Phase A.5 (refs cortex#113, closes cortex#262) — resolve the
@@ -556,6 +559,11 @@ export async function startCortex(
       runtime = await startMyelinRuntime(config, {
         ...(signer !== undefined && { signer }),
         stack: derivedStack.stack,
+        // cortex#429 PR-C — runtime no longer reads
+        // `config.agent.operatorId`; the boot-resolved principal flows
+        // in explicitly so subscribe-side `{principal}` substitution
+        // stays symmetric with publish-side `envelope.source`.
+        principal: principalId,
       });
     } catch (err) {
       console.error("cortex: myelin runtime startup error (non-fatal):", err instanceof Error ? err.message : err);
@@ -1896,7 +1904,7 @@ export async function startCortex(
   let usageMonitor: UsageMonitor | null = null;
   if (config.api.enabled && !options.disableDashboard) {
     try {
-      ({ api: dashboardApi, usageMonitor } = await setupDashboard(config, principalId, dispatchHandler, cloudPublisher));
+      ({ api: dashboardApi, usageMonitor } = await setupDashboard(config, principalId, options.operator?.displayName, dispatchHandler, cloudPublisher));
     } catch (err) {
       console.error("cortex: dashboard API startup error (non-fatal):", err instanceof Error ? err.message : err);
     }
@@ -2131,6 +2139,7 @@ async function resolveReviewProvisioningJsm(
 async function setupDashboard(
   config: AgentConfig,
   principalId: string,
+  principalDisplayName: string | undefined,
   dispatchHandler: DispatchHandler,
   cloudPublisher: CloudPublisher | null,
 ): Promise<{ api: { stop?: () => void }; usageMonitor: UsageMonitor }> {
@@ -2146,11 +2155,15 @@ async function setupDashboard(
     apiMode: config.api.mode,
     // cortex#427 — dashboard reads the shared `principalId` so the
     // `operator` column matches the `{principal}` segment of incoming
-    // envelopes. `operatorName` falls back to `principalId` when the
-    // principal hasn't declared a separate display name on
-    // `agent.operatorName` (legacy AgentConfig field — PR-C retires).
+    // envelopes. cortex#429 PR-C retired the legacy `agent.operatorName`
+    // field; the dashboard display name now flows in via
+    // `principalDisplayName` (sourced from
+    // `LoadedConfig.principal.displayName`) and falls back to
+    // `principalId` when the principal omitted the display name on
+    // cortex.yaml. The MC API column is still named `operatorId`
+    // (R2.D cascade — tracked separately in docs/migrations/0002).
     operatorId: principalId,
-    operatorName: config.agent.operatorName ?? principalId,
+    operatorName: principalDisplayName ?? principalId,
     dashboardDir,
   });
   console.log(`cortex: dashboard DB at ${dbPath}`);

--- a/src/taps/cc-events/cc-events.ts
+++ b/src/taps/cc-events/cc-events.ts
@@ -70,7 +70,7 @@ import type { PublishedEvent } from "./hooks/lib/event-types";
  *     lifting hooks → bus)
  */
 export interface CcEventSource {
-  /** `agent.operatorId` — first segment (principal slug). Defaults to `"default"` if absent. */
+  /** Boot-resolved `principal.id` — first segment (principal slug). Defaults to `"default"` if absent. */
   principal?: string;
   /** Logical agent name. Defaults to `"cortex"`. */
   agent?: string;
@@ -137,7 +137,7 @@ export interface CreateCcEventEnvelopeOpts {
   /**
    * Envelope source — `{principal}.{agent}.{instance}` per schema. All fields
    * have sensible defaults. Callers (the relay) typically override `principal`
-   * to match the bot's `agent.operatorId`.
+   * to match the bot's boot-resolved `principal.id`.
    */
   source?: CcEventSource;
   /**
@@ -239,7 +239,7 @@ export interface CreateCcEventPublisherOpts {
    * Principal segment used in the envelope `source` and (when
    * classification is `local` or `federated`) the published NATS subject.
    * Defaults to `"default"` to mirror the MyelinRuntime convention when
-   * `agent.operatorId` is absent.
+   * the boot-resolved `principal.id` is absent.
    */
   principal?: string;
   /**


### PR DESCRIPTION
Closes #429. Part of cortex#426 (C-388 follow-up — finish v3 vocabulary migration).

## Summary

Final cleanup after the C-388 vocabulary migration: drops the legacy `AgentConfig.agent.operatorId` and `agent.operatorName` schema fields entirely, retires the PR-A legacy-fallback reader in cortex.ts, and removes the PR-B transient synthesis from migrate-config-lib.ts.

PR-A (cortex#427 / merged in #430) migrated every read site to the v3-canonical `principal.id`. PR-B (cortex#428) added a deprecation-window synthesis so v3.0.0–v3.0.3 deployments stayed bootable while their configs were re-migrated. cortex#429 PR-C graduates both back-compat paths.

## What this PR does

### Schema field removal
- Drop `agent.operatorId` and `agent.operatorName` from `AgentConfigSchema` (`src/common/types/config.ts`)
- Drop the field entries from the config-watcher's `RESTART_FIELDS` allowlist (`src/common/config/watcher.ts`)

### cortex.ts cleanup
- Simplify `resolvePrincipalId`: `options.operator.id` is now the sole resolution path; the `config.agent.operatorId` fallback is gone. Missing principal still fails fast at boot (no `local.default.>` collapse)
- Stop reading `config.agent.operatorName` in dashboard wiring; thread principal display name in via `options.operator.displayName` (sourced from `LoadedConfig.principal.displayName`)

### myelin runtime
- Add `MyelinRuntimeOptions.principal` so subscribe-side `{principal}` substitution no longer reads `config.agent.operatorId`. Entrypoint passes the boot-resolved `principalId` explicitly

### Loader
- Stop synthesising `agent.operatorId` / `agent.operatorName` into the AgentConfig projection (`src/common/config/loader.ts`)
- Surface `principal.displayName` on `LoadedConfig.principal` for the dashboard path

### migrate-config
- Delete `synthesizeOperatorIdBackCompat` + its post-parse call site (PR-B transient aid graduated)
- Repurpose the PR-B test block as a NEGATIVE regression suite (synthesis MUST NOT run; output YAML MUST NOT carry `agents[].operatorId`)

### Tests
- Thread `operator: { id: "test-op" }` through every `startCortex(...)` call (the v3-canonical path is now required)
- Rewrite `principal-identity-consistency.test.ts` for the retired-fallback contract
- Update MyelinRuntime tests to pass `principal` via options

## Commits

| SHA | Description |
|---|---|
| `d9663f2` | `feat(types,cortex,bus): R-C — drop agent.operatorId schema field + back-compat scaffolding` |
| `5508316` | `feat(migrate-config): R-C — drop transient agent.operatorId synthesis` |

## Verification

- `bunx tsc --noEmit` — exit 0 (clean)
- `bun test` — 3544 pass / 2 skip / 0 fail (8593 expect() calls across 188 files)
- `bun run lint:errors` — clean
- `git grep "agent.operatorId\|agent.operator_id" src/` — 29 hits, all comment-prose or the legacy-bot.yaml input reader in `buildLegacyNetwork` (allow-listed per docs/migrations/0001 §"Renames this manifest does NOT make"); zero active reads of the retired schema field remain
- `grep operatorId cortex.yaml.example` — zero hits (was already clean)

## Breaking-change note for operators

Configs that still declare `agent.operatorId` or `agent.operatorName` will continue to load silently — Zod default-strips unknown keys, so the values pass parse and become unreadable. Any operator who hasn't re-migrated since the v3.0.0 cutover (cortex#388) should re-run `cortex migrate-config` to regenerate their cortex.yaml; the v3-canonical `principal:` block carries the identity going forward.

A missing `principal.id` is now a startup error — the message names the canonical key and points operators at `cortex migrate-config`.

## Out of scope

- Other `operatorId` parameter renames in downstream APIs (`verifySignedByChain`, `BusDispatchListener`, MC API, `event-processor`, `cloud-publisher`) — tracked under R2 cascade in `docs/migrations/0002-vocabulary-finish-2026-05.md`
- `NetworkConfig.operatorId` (per-network file schema field) — separate R2.B cascade
- Loader's `buildLegacyNetwork` reader of raw bot.yaml `agent.operatorId` — legitimate input-shape reader, allow-listed

🤖 Generated with [Claude Code](https://claude.com/claude-code)