### PR TITLE
fix(runner): runner self-subscribes via MyelinRuntime (closes #477)

### DIFF
--- a/src/bus/myelin/runtime.ts
+++ b/src/bus/myelin/runtime.ts
@@ -147,6 +147,45 @@ export interface MyelinRuntime {
    */
   subscribePull?(opts: MyelinSubscribePullOpts): MyelinSubscriber | null;
   /**
+   * cortex#477 — bind an ADDITIONAL push-mode subscription to the
+   * underlying NATS link, beyond whatever `nats.subjects[]` already
+   * configured at boot. The returned subscriber's `onEnvelope` fans
+   * out through the same per-runtime handler set as the static
+   * `nats.subjects` subscribers, so any `runtime.onEnvelope` handler
+   * (incl. the `SurfaceRouter`'s) receives matching envelopes
+   * automatically — callers do NOT pass their own handler.
+   *
+   * **Why this exists.** Listeners (today: `createDispatchListener`)
+   * derive their canonical subject pattern programmatically from the
+   * running principal + stack (e.g.
+   * `local.{principal}.{stack}.tasks.*.>`). Pre-#477 they relied on
+   * `nats.subjects[]` in `cortex.yaml` being a superset of that
+   * pattern — an unenforced cross-config invariant that silently
+   * broke on deployments whose config wasn't kept in lockstep with
+   * the listener's declared interest. `subscribe()` lets the listener
+   * self-subscribe at `start()` time, symmetric with
+   * `ReviewConsumer`'s `subscribePull` model, and drops the
+   * cross-config invariant entirely.
+   *
+   * **Returns `null` when the runtime is disabled** (no NATS configured,
+   * connect failed). Callers MUST tolerate the null return — same
+   * defensive contract as `subscribePull` — so push-mode listeners
+   * stay dormant when the bus is absent without aborting boot.
+   *
+   * The runtime tracks the returned subscriber on its internal
+   * `subscribers[]` list, so `runtime.stop()` drains it alongside the
+   * boot-time push subscribers — callers don't have to call
+   * `subscriber.stop()` themselves on runtime shutdown (though they
+   * MAY do so on listener-scoped teardown, which is the dispatch-
+   * listener's pattern).
+   *
+   * **Optional on the interface** so existing fake-runtime test stubs
+   * keep their byte-identical shapes — additivity constraint same as
+   * `subscribePull`. Callers MUST treat an undefined property as
+   * equivalent to a `null` return.
+   */
+  subscribe?(pattern: string): Promise<MyelinSubscriber | null>;
+  /**
    * Resolve a narrow provisioning capability against the underlying
    * link, or `null` when the runtime is disabled (no NATS configured
    * or connect failed).
@@ -384,6 +423,13 @@ export async function startMyelinRuntime(
   // `MyelinRuntime.subscribePull` docblock.
   const subscribePullDisabled = (_opts: MyelinSubscribePullOpts): null => null;
 
+  // cortex#477 — push-mode subscribe no-op for disabled paths. Mirrors
+  // `subscribePullDisabled` (returns null on the same "bus dormant"
+  // contract). Listeners (e.g. dispatch-listener) tolerate the null and
+  // stay dormant rather than aborting boot.
+  // eslint-disable-next-line @typescript-eslint/require-await
+  const subscribePushDisabled = async (_pattern: string): Promise<null> => null;
+
   // eslint-disable-next-line @typescript-eslint/no-empty-function, @typescript-eslint/require-await
   const stopDisabled = async () => {};
 
@@ -400,6 +446,7 @@ export async function startMyelinRuntime(
       onEnvelope,
       publish: publishDisabled,
       subscribePull: subscribePullDisabled,
+      subscribe: subscribePushDisabled,
       jetstreamManager: jetstreamManagerDisabled,
       stop: stopDisabled,
     };
@@ -479,6 +526,7 @@ export async function startMyelinRuntime(
       onEnvelope,
       publish: publishDisabled,
       subscribePull: subscribePullDisabled,
+      subscribe: subscribePushDisabled,
       jetstreamManager: jetstreamManagerDisabled,
       stop: stopDisabled,
     };
@@ -534,6 +582,7 @@ export async function startMyelinRuntime(
       onEnvelope,
       publish: publishDisabled,
       subscribePull: subscribePullDisabled,
+      subscribe: subscribePushDisabled,
       jetstreamManager: jetstreamManagerDisabled,
       stop: stopDisabled,
     };
@@ -757,6 +806,59 @@ export async function startMyelinRuntime(
     return sub;
   };
 
+  // cortex#477 — push-mode subscribe helper for the enabled path. Lets
+  // listeners (today: `createDispatchListener`) self-subscribe to their
+  // declared interest at `start()` time rather than relying on
+  // `nats.subjects[]` in `cortex.yaml` being a superset (an unenforced
+  // cross-config invariant that silently broke deployments whose config
+  // wasn't kept in lockstep with the listener's canonical pattern). The
+  // returned subscriber fans out through the same `handlers` set used by
+  // the boot-time push subscribers — any `runtime.onEnvelope` handler
+  // (e.g. the `SurfaceRouter`'s) receives matching envelopes without
+  // any extra wiring on the caller's side. Tracked on the same
+  // `subscribers[]` array so `runtime.stop()` drains it alongside the
+  // boot-time subs.
+  //
+  // Returns `null` if `MyelinSubscriber.start` throws — same
+  // log-and-continue contract as the boot-time loop above. Throwing on
+  // post-stop is symmetric with `subscribePullEnabled` (deliberate
+  // contract violation; caller should surface via its own try/catch).
+  const subscribePushEnabled = async (
+    pattern: string,
+  ): Promise<MyelinSubscriber | null> => {
+    if (stopped) {
+      throw new Error("myelin-runtime: subscribe called after stop()");
+    }
+    try {
+      const sub = MyelinSubscriber.start(link, {
+        pattern,
+        onEnvelope: (env, subject) => {
+          logEnvelope(env, subject);
+          for (const handler of handlers) {
+            try {
+              handler(env, subject);
+            } catch (err) {
+              console.error(
+                "myelin-runtime: onEnvelope handler threw:",
+                err instanceof Error ? err.message : String(err),
+              );
+            }
+          }
+        },
+      });
+      subscribers.push(sub);
+      await sub.ready;
+      console.log(`myelin-runtime: subscribed to "${pattern}"`);
+      return sub;
+    } catch (err) {
+      console.error(
+        `myelin-runtime: failed to subscribe to "${pattern}":`,
+        err instanceof Error ? err.message : String(err),
+      );
+      return null;
+    }
+  };
+
   // cortex#338 — expose the live JetStreamManager so the boot path can
   // provision streams + per-agent durables before `ReviewConsumer.start`
   // binds to them. Cached on first call so the boot path doesn't pay a
@@ -773,6 +875,7 @@ export async function startMyelinRuntime(
     publish: publishEnabled,
     publishOnSubject: publishOnSubjectEnabled,
     subscribePull: subscribePullEnabled,
+    subscribe: subscribePushEnabled,
     jetstreamManager: jetstreamManagerEnabled,
     stop: async () => {
       if (stopped) return;

--- a/src/runner/__tests__/dispatch-listener.test.ts
+++ b/src/runner/__tests__/dispatch-listener.test.ts
@@ -69,9 +69,20 @@ function recordingRuntime(): {
   published: Envelope[];
   /** Trigger a manual onEnvelope call for the surface-router to process. */
   trigger: (env: Envelope, subject: string) => void;
+  /**
+   * cortex#477 — patterns the listener has self-subscribed to via
+   * `runtime.subscribe(...)`. Asserts the dispatch-listener's
+   * `start()` no longer relies on `nats.subjects[]` covering its
+   * canonical pattern.
+   */
+  subscribedPatterns: string[];
+  /** Subscribers handed out by `subscribe()` — for stop()-side assertions. */
+  subscribers: { pattern: string; stopped: boolean }[];
 } {
   const handlers = new Set<Parameters<MyelinRuntime["onEnvelope"]>[0]>();
   const published: Envelope[] = [];
+  const subscribedPatterns: string[] = [];
+  const subscribers: { pattern: string; stopped: boolean }[] = [];
   return {
     runtime: {
       enabled: true,
@@ -82,12 +93,33 @@ function recordingRuntime(): {
       publish: async (env) => {
         published.push(env);
       },
+      // cortex#477 — surface the push-mode subscribe path so the
+      // listener's `start()` can self-subscribe via the runtime
+      // rather than relying on `nats.subjects[]`. The stub records
+      // every pattern + returns a minimal subscriber so the
+      // listener's `stop()` drain path is exercised end-to-end.
+      subscribe: async (pattern) => {
+        subscribedPatterns.push(pattern);
+        const entry = { pattern, stopped: false };
+        subscribers.push(entry);
+        return {
+          pattern,
+          ready: Promise.resolve(),
+          stop: async () => {
+            entry.stopped = true;
+          },
+        } as unknown as Awaited<
+          ReturnType<NonNullable<MyelinRuntime["subscribe"]>>
+        >;
+      },
       stop: async () => {},
     },
     published,
     trigger: (env, subject) => {
       for (const h of handlers) h(env, subject);
     },
+    subscribedPatterns,
+    subscribers,
   };
 }
 
@@ -325,6 +357,135 @@ describe("createDispatchListener — surfaceConfig", () => {
       ccSessionFactory: fakeFactory(SUCCESS_RESULT).factory,
     });
     expect(listener.surfaceConfig.id).toBe("runner-dispatch-listener-test");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cortex#477 — self-subscribe via runtime.subscribe()
+// ---------------------------------------------------------------------------
+
+describe("createDispatchListener — runtime self-subscribe (cortex#477)", () => {
+  test("start() self-subscribes to canonical pattern via runtime.subscribe()", async () => {
+    // Pre-#477 the listener relied on `nats.subjects[]` in cortex.yaml
+    // being a superset of its canonical pattern — an unenforced
+    // cross-config invariant that silently broke deployments whose
+    // config wasn't kept in lockstep. Now the listener self-subscribes
+    // at start() time via the runtime, symmetric with ReviewConsumer's
+    // subscribePull model.
+    const r = recordingRuntime();
+    const router = createSurfaceRouter(r.runtime);
+    const listener = createDispatchListener({
+      runtime: r.runtime,
+      router,
+      source: SOURCE,
+      stack: "meta-factory",
+      ccSessionFactory: fakeFactory(SUCCESS_RESULT).factory,
+    });
+
+    expect(r.subscribedPatterns).toEqual([]);
+    await listener.start();
+    expect(r.subscribedPatterns).toEqual([
+      "local.metafactory.meta-factory.tasks.*.>",
+    ]);
+  });
+
+  test("start() with stack omitted falls back to 5-segment canonical", async () => {
+    const r = recordingRuntime();
+    const router = createSurfaceRouter(r.runtime);
+    const listener = createDispatchListener({
+      runtime: r.runtime,
+      router,
+      source: SOURCE,
+      ccSessionFactory: fakeFactory(SUCCESS_RESULT).factory,
+    });
+    await listener.start();
+    expect(r.subscribedPatterns).toEqual(["local.metafactory.tasks.*.>"]);
+  });
+
+  test("start() with explicit subjects passes them all to runtime.subscribe()", async () => {
+    const r = recordingRuntime();
+    const router = createSurfaceRouter(r.runtime);
+    const listener = createDispatchListener({
+      runtime: r.runtime,
+      router,
+      source: SOURCE,
+      subjects: ["local.test.a.>", "local.test.b.>"],
+      ccSessionFactory: fakeFactory(SUCCESS_RESULT).factory,
+    });
+    await listener.start();
+    expect(r.subscribedPatterns).toEqual(["local.test.a.>", "local.test.b.>"]);
+  });
+
+  test("stop() drains the runtime subscribers the listener owns", async () => {
+    const r = recordingRuntime();
+    const router = createSurfaceRouter(r.runtime);
+    const listener = createDispatchListener({
+      runtime: r.runtime,
+      router,
+      source: SOURCE,
+      stack: "meta-factory",
+      ccSessionFactory: fakeFactory(SUCCESS_RESULT).factory,
+    });
+    await listener.start();
+    expect(r.subscribers.every((s) => !s.stopped)).toBe(true);
+    await listener.stop();
+    expect(r.subscribers.every((s) => s.stopped)).toBe(true);
+  });
+
+  test("start() tolerates a runtime stub that lacks subscribe() (additivity contract)", async () => {
+    // Mirrors the ReviewConsumer subscribePull contract — older fake
+    // runtime stubs may not expose `subscribe`. The listener treats an
+    // undefined property as "no push-mode subscriptions wired" and
+    // stays dormant on that path (router registration still happens).
+    const handlers = new Set<Parameters<MyelinRuntime["onEnvelope"]>[0]>();
+    const minimalRuntime: MyelinRuntime = {
+      enabled: true,
+      onEnvelope: (handler) => {
+        handlers.add(handler);
+        return { unregister: () => { handlers.delete(handler); } };
+      },
+      publish: async () => {},
+      stop: async () => {},
+    };
+    const router = createSurfaceRouter(minimalRuntime);
+    const listener = createDispatchListener({
+      runtime: minimalRuntime,
+      router,
+      source: SOURCE,
+      ccSessionFactory: fakeFactory(SUCCESS_RESULT).factory,
+    });
+    await listener.start();
+    await listener.stop();
+    // No assertion beyond "doesn't throw" — the listener registered
+    // with the router and skipped self-subscribe without error.
+    expect(true).toBe(true);
+  });
+
+  test("start() tolerates runtime.subscribe() returning null (bus dormant)", async () => {
+    // When the runtime is disabled (no NATS configured / connect
+    // failed), `subscribe()` returns null. The listener treats that
+    // as a legitimate dormant state, not an error.
+    const handlers = new Set<Parameters<MyelinRuntime["onEnvelope"]>[0]>();
+    const dormantRuntime: MyelinRuntime = {
+      enabled: false,
+      onEnvelope: (handler) => {
+        handlers.add(handler);
+        return { unregister: () => { handlers.delete(handler); } };
+      },
+      publish: async () => {},
+      subscribe: async () => null,
+      stop: async () => {},
+    };
+    const router = createSurfaceRouter(dormantRuntime);
+    const listener = createDispatchListener({
+      runtime: dormantRuntime,
+      router,
+      source: SOURCE,
+      ccSessionFactory: fakeFactory(SUCCESS_RESULT).factory,
+    });
+    await listener.start();
+    await listener.stop();
+    expect(true).toBe(true);
   });
 });
 

--- a/src/runner/dispatch-listener.ts
+++ b/src/runner/dispatch-listener.ts
@@ -393,6 +393,18 @@ export function createDispatchListener(
   const subjects = opts.subjects ?? defaultSubjects(source.principal, opts.stack);
 
   let registration: { unregister: () => void } | null = null;
+  // cortex#477 — push-mode NATS subscriptions owned by this listener.
+  // Pre-#477 the runner relied on `nats.subjects[]` in `cortex.yaml`
+  // being a superset of its declared `subjects` — an unenforced
+  // cross-config invariant that silently broke deployments whose
+  // config wasn't kept in lockstep with the listener's canonical
+  // pattern (see cortex#477 root cause analysis). The listener now
+  // self-subscribes via `runtime.subscribe(pattern)` at `start()`
+  // time, symmetric with `ReviewConsumer`'s `subscribePull` model.
+  // Stored so `stop()` can drain the subscribers cleanly on teardown
+  // even when the runtime stays running.
+  interface RuntimeSubscriber { stop(): Promise<void>; }
+  let runtimeSubscribers: RuntimeSubscriber[] = [];
 
   const surfaceConfig: SurfaceAdapter = {
     id: adapterId,
@@ -427,16 +439,39 @@ export function createDispatchListener(
     // start/stop are part of the surface-listener contract — return
     // Promise<void> even when the body is sync, so callers can await
     // alongside other lifecycle hooks (cc-session, bus, taps).
-    // eslint-disable-next-line @typescript-eslint/require-await
     async start() {
       if (registration) return;
       registration = router.register(surfaceConfig);
+      // cortex#477 — self-subscribe via `runtime.subscribe()` so the
+      // runner's declared interest no longer depends on
+      // `nats.subjects[]` in `cortex.yaml`. `subscribe` is OPTIONAL
+      // on the `MyelinRuntime` interface (additivity constraint per
+      // Architect cortex#290) — undefined means the runtime stub
+      // doesn't model push subscriptions, and we stay dormant (same
+      // contract as `subscribePull`). The returned subscriber may
+      // also be `null` if the runtime is disabled (no NATS configured
+      // / connect failed); that's a legitimate dormant state, not an
+      // error.
+      if (runtime.subscribe) {
+        for (const pattern of subjects) {
+          const sub = await runtime.subscribe(pattern);
+          if (sub) {
+            runtimeSubscribers.push(sub);
+          }
+        }
+      }
     },
-    // eslint-disable-next-line @typescript-eslint/require-await
     async stop() {
       if (!registration) return;
       registration.unregister();
       registration = null;
+      // Drain listener-owned runtime subscribers. The runtime tracks
+      // them on its internal subscribers[] too, so `runtime.stop()`
+      // would also drain them — but listener-scoped teardown should
+      // not require runtime shutdown to release NATS resources.
+      const drained = runtimeSubscribers;
+      runtimeSubscribers = [];
+      await Promise.allSettled(drained.map((s) => s.stop()));
     },
   };
 }


### PR DESCRIPTION
## Summary

- **Root cause** (per [cortex#477](https://github.com/the-metafactory/cortex/issues/477) investigation): `createDispatchListener` relied on `nats.subjects[]` in `cortex.yaml` being a superset of its declared canonical pattern (`local.{principal}.{stack}.tasks.*.>`). That cross-config invariant was unenforced and broke on Andreas's stack — chat envelopes published to `local.andreas.meta-factory.tasks.@did-mf-luna.chat` had no NATS subscriber because `nats.subjects` was a pre-#409 leftover (`local.metafactory.tasks.code-review.>`).
- **Fix**: add `MyelinRuntime.subscribe(pattern)` and have the listener self-subscribe at `start()` time, symmetric with `ReviewConsumer`'s `subscribePull` model. Drops the cross-config invariant entirely.
- **Surgical**: 3 files, +301 LOC (most of it is docblock + tests). No opportunistic refactors.

## Design

**`MyelinRuntime.subscribe(pattern: string): Promise<MyelinSubscriber | null>`** — OPTIONAL on the interface (additivity constraint per Architect's cortex#290 review, mirrors `subscribePull`). Binds an additional push-mode subscription to the underlying NATS link and fans out through the runtime's `handlers` set, so any `runtime.onEnvelope` handler (incl. the `SurfaceRouter`'s) receives matching envelopes automatically — callers do NOT pass their own handler.

- **Enabled path** (`subscribePushEnabled`): wraps `MyelinSubscriber.start(link, …)`, tracks on the existing `subscribers[]` so `runtime.stop()` drains alongside boot-time subs, logs `myelin-runtime: subscribed to "${pattern}"` (same log shape as the boot loop), returns `null` on subscribe error.
- **Disabled path** (`subscribePushDisabled`): returns `null` — same dormant-bus contract as `subscribePullDisabled`.
- **Throws on post-stop** — symmetric with `subscribePullEnabled`.

**`createDispatchListener.start()` / `.stop()`** — calls `runtime.subscribe?.(pattern)` for each declared subject; stores the returned subscribers on a listener-scoped array so `.stop()` drains them on teardown (independent of runtime shutdown). Tolerates:
- A runtime stub that lacks `subscribe()` (undefined property → stay dormant)
- `subscribe()` returning `null` (bus dormant → stay dormant)

Neither aborts boot.

## Files changed

- `src/bus/myelin/runtime.ts` — interface method + enabled/disabled implementations
- `src/runner/dispatch-listener.ts` — `start()` self-subscribe, `stop()` drain
- `src/runner/__tests__/dispatch-listener.test.ts` — extended `recordingRuntime` + 6 new tests

## Test plan

- [x] `bunx tsc --noEmit` clean
- [x] `bun test src/runner/__tests__/dispatch-listener.test.ts` — 57 pass (was 51, +6 new tests)
- [x] `bun test src/bus/myelin/__tests__/` — 111 pass
- [x] `bun test` (full suite) — 3550 pass, 2 skip, 0 fail
- [x] `bun run lint:errors` clean
- [ ] Manual: verify on Andreas's `meta-factory` stack that a Discord chat envelope on `local.andreas.meta-factory.tasks.@did-mf-luna.chat` is now delivered to the runner (the live repro from #477)

## Breaking change

None — `subscribe` is OPTIONAL on the `MyelinRuntime` interface (same additivity contract as `subscribePull`). Existing fake runtime stubs across the test tree stay byte-identical; production callers that don't use the new method see no change.

## Note on Fix A (config-side)

The issue documented two fixes — Fix A (config-side: update `nats.subjects[]` to cover the canonical pattern) and Fix B (code-side: this PR). Fix A is still recommended for Andreas's stack today to unblock him, separately from this code change. The two stack cleanly: even after this PR lands, an operator's `nats.subjects[]` is still honoured for non-listener-owned subscriptions (renderers, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)