### PR TITLE
fix(bus): verifier trusts own stack identity (closes #480)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -100,6 +100,15 @@ _Avoid_: consumer, egress, renderer (renderer is the cortex-internal interface n
 The payload field on an inbound dispatch envelope that tells the dispatch sink where to deliver lifecycle events. Carries the originating surface address — for a Discord-sourced dispatch: `{adapter_instance, channel_id, thread_id?}`. Echoed by the runner onto every `dispatch.task.{action}` lifecycle envelope so the originating dispatch sink can correlate completion → platform target without keeping state. Response routing is wire-level, not in-memory.
 _Avoid_: callback, return-address, reply-to
 
+### Identity & trust
+
+**Stack signing identity**:
+The **stack**'s own DID — `did:mf:{principal}-{stack-leaf}` — used to sign every envelope the stack publishes via `runtime.publish`. Distinct from agent DIDs (`did:mf:luna`, `did:mf:echo`): the stack is the cryptographic signer of the wire; the agent is the policy actor named in `originator`. A stack has exactly one signing identity, sourced from `stack.nkey_seed_path` in `cortex.yaml`.
+
+**Own-stack implicit trust**:
+Every cortex stack implicitly trusts its own signing identity — the chain verifier (`src/bus/verify-signed-by-chain.ts`) short-circuits when `chain[0].identity` matches the receiving stack's signing DID. The stack is the receiver; the receiver always has private-key authority for its own DID, so looking up the stack DID in the **agent** registry is structurally wrong. Without this short-circuit, adapter-originated dispatches (Discord/Mattermost/Slack chat → signed by the stack via `runtime.publish`) get rejected as `unknown_agent` and the runner silently drops every chat envelope. The crypto-verify pass still runs against the stack's NKey pubkey on these envelopes — short-circuit the *trust* check, not the *bytes* check (cortex#480).
+_Avoid_: self-trust (too generic), loopback-trust (overloads NATS loopback semantics)
+
 ## Relationships
 
 - A **principal** runs one or more **stacks**, and belongs to one or more **networks**.

--- a/src/bus/__tests__/bus-dispatch-listener.test.ts
+++ b/src/bus/__tests__/bus-dispatch-listener.test.ts
@@ -365,4 +365,48 @@ describe("BusDispatchListener — verification gate", () => {
     expect(stderrOutput).toContain("bus-dispatch-listener:luna");
     expect(stderrOutput).toContain("signer_not_trusted");
   });
+
+  test("[cortex#480] accepts an envelope self-signed by the receiving stack identity", async () => {
+    // Pre-fix repro: an adapter-originated dispatch reaching the
+    // dispatch-listener gets stamped by the stack identity
+    // (`did:mf:<principal>-<stack>`). The stack is NOT in the agent
+    // registry, so the pre-fix verifier rejected as `unknown_agent`.
+    // With cortex#480 wiring the stack-identity option, the listener
+    // short-circuits the registry lookup and emits the visibility
+    // event.
+    const stackIdentity = "did:mf:andreas-meta-factory";
+    const stackNKeyPub = "U" + "D".repeat(55);
+    const luna = agentFixture({ id: "luna", trust: [] });
+    const resolver = resolverWith(luna);
+    const { runtime, published, deliverInbound, drain } = fakeRuntime();
+
+    const listener = new BusDispatchListener({
+      runtime,
+      resolver,
+      receivingAgentId: "luna",
+      principalId: "andreas",
+      source: SOURCE,
+      // cryptoVerify default `false` here so we exercise structural-
+      // only own-stack short-circuit (the prod default for this
+      // listener until B.1c flag flip; the runner-side listener
+      // tested in cortex.ts wiring runs cryptoVerify: true).
+      stackIdentity,
+      stackNKeyPub,
+    });
+    listener.start();
+
+    deliverInbound(
+      peerDispatchEnvelope({
+        signerPrincipal: stackIdentity,
+        source: "andreas.meta-factory.local",
+        id: "00000000-0000-4000-8000-000000000def",
+      }),
+    );
+    await drain();
+
+    expect(published).toHaveLength(1);
+    expect(published[0]?.type).toBe("system.bus.peer_dispatch_received");
+
+    await listener.stop();
+  });
 });

--- a/src/bus/__tests__/verifier-self-check.test.ts
+++ b/src/bus/__tests__/verifier-self-check.test.ts
@@ -1,0 +1,135 @@
+/**
+ * cortex#480 — tests for the boot-time verifier self-check.
+ *
+ * Coverage:
+ *   1. Happy path — self-signed envelope round-trips successfully.
+ *   2. Mismatched stackNKeyPub (signer key differs from declared pubkey)
+ *      → bytes-check fails, self-check logs error and returns ok=false.
+ *   3. Malformed `stackNKeyPub` → bytes-check can't decode, self-check
+ *      logs error and returns ok=false (defence-in-depth on the bridge).
+ */
+
+import { describe, test, expect } from "bun:test";
+import { createUser } from "@nats-io/nkeys";
+import { AgentRegistry } from "../../common/agents/registry";
+import { TrustResolver } from "../../common/agents/trust-resolver";
+import { runVerifierSelfCheck } from "../verifier-self-check";
+import type { Agent } from "../../common/types/cortex-config";
+
+function discordPresence() {
+  return {
+    enabled: true,
+    token: "discord-bot-token",
+    guildId: "1487000000000000000",
+    agentChannelId: "1487000000000000001",
+    logChannelId: "1487000000000000002",
+    contextDepth: 10,
+    enableAgentLog: false,
+    roles: [],
+    defaultRole: "allow-all",
+    dm: {
+      operatorRole: {
+        features: ["chat", "async", "team"] as const,
+        disallowedTools: [],
+        bashGuard: true,
+      },
+      defaultRole: "denied" as const,
+      userRoles: [],
+    },
+  };
+}
+
+function agentFixture(overrides: Partial<Agent> = {}): Agent {
+  return {
+    id: "luna",
+    displayName: "Luna",
+    persona: "./personas/luna.md",
+    roles: [],
+    trust: [],
+    presence: { discord: discordPresence() },
+    ...overrides,
+  } as Agent;
+}
+
+function generateStackKeypair() {
+  const kp = createUser();
+  const nkeyPub = kp.getPublicKey();
+  const rawSeed = (kp as unknown as { getRawSeed(): Uint8Array }).getRawSeed();
+  return { nkeyPub, rawSeed };
+}
+
+describe("runVerifierSelfCheck (cortex#480)", () => {
+  test("[1] self-signed round-trip succeeds", async () => {
+    const { nkeyPub, rawSeed } = generateStackKeypair();
+    const luna = agentFixture({ id: "luna", trust: [] });
+    const resolver = new TrustResolver(AgentRegistry.fromAgents([luna]));
+
+    const logs: string[] = [];
+    const errs: string[] = [];
+
+    const result = await runVerifierSelfCheck({
+      stackIdentity: "did:mf:andreas-meta-factory",
+      stackNKeyPub: nkeyPub,
+      stackSeedBytes: rawSeed,
+      resolver,
+      receivingAgentId: "luna",
+      principalId: "andreas",
+      log: (line) => logs.push(line),
+      err: (line) => errs.push(line),
+    });
+
+    expect(result.ok).toBe(true);
+    expect(errs).toHaveLength(0);
+    expect(logs.join("\n")).toContain("verifier-self-check OK");
+  });
+
+  test("[2] mismatched stackNKeyPub — signer key differs from declared pubkey → fail", async () => {
+    // Signer uses key A; we tell the verifier key B is the registered
+    // pubkey. The crypto-verify pass MUST fail to detect the
+    // split-brain hazard at boot rather than at first Discord chat.
+    const { rawSeed } = generateStackKeypair();
+    const { nkeyPub: differentKey } = generateStackKeypair();
+    const luna = agentFixture({ id: "luna", trust: [] });
+    const resolver = new TrustResolver(AgentRegistry.fromAgents([luna]));
+
+    const errs: string[] = [];
+    const result = await runVerifierSelfCheck({
+      stackIdentity: "did:mf:andreas-meta-factory",
+      stackNKeyPub: differentKey,
+      stackSeedBytes: rawSeed,
+      resolver,
+      receivingAgentId: "luna",
+      principalId: "andreas",
+      log: () => {},
+      err: (line) => errs.push(line),
+    });
+
+    expect(result.ok).toBe(false);
+    expect(errs.join("\n")).toContain("verifier-self-check: FAILED");
+  });
+
+  test("[3] malformed stackNKeyPub — verifier rejects, error logged", async () => {
+    const { rawSeed } = generateStackKeypair();
+    const luna = agentFixture({ id: "luna", trust: [] });
+    const resolver = new TrustResolver(AgentRegistry.fromAgents([luna]));
+
+    const errs: string[] = [];
+    const result = await runVerifierSelfCheck({
+      stackIdentity: "did:mf:andreas-meta-factory",
+      // Malformed — doesn't pass the U-prefix base32 decode in
+      // `nkeyToBase64Pubkey`. The bridge silently drops the entry,
+      // so the crypto-verify pass finds no Principal registered and
+      // rejects.
+      stackNKeyPub: "not-a-valid-nkey",
+      stackSeedBytes: rawSeed,
+      resolver,
+      receivingAgentId: "luna",
+      principalId: "andreas",
+      log: () => {},
+      err: (line) => errs.push(line),
+    });
+
+    expect(result.ok).toBe(false);
+    expect(errs.join("\n")).toContain("verifier-self-check: FAILED");
+  });
+});

--- a/src/bus/__tests__/verify-signed-by-chain.test.ts
+++ b/src/bus/__tests__/verify-signed-by-chain.test.ts
@@ -512,6 +512,123 @@ describe("verifySignedByChain — cryptoVerify (B.1c)", () => {
     }
   });
 
+  test("[cortex#480] cryptoVerify accepts a self-signed envelope from the receiving stack", async () => {
+    // The stack has private-key authority for its own DID. Adapter-
+    // originated dispatches arrive signed by the stack identity
+    // (`did:mf:<principal>-<stack>`), NOT by an agent in the registry.
+    // The verifier must short-circuit + bytes-check against the stack's
+    // own NKey.
+    const stackIdentity = "did:mf:andreas-meta-factory";
+    const { nkeyPub: stackNKeyPub, privateKeyBase64: stackSeed } =
+      generateEd25519KeyPair();
+    // Only luna is registered as an agent. The stack identity is NOT.
+    const luna = agentFixture({ id: "luna", trust: [] });
+    const resolver = resolverWith(luna);
+
+    const base = envelopeWithChain(undefined) as Parameters<
+      typeof signEnvelope
+    >[0];
+    const signed = await signEnvelope(base, stackSeed, stackIdentity);
+
+    const result = await verifySignedByChain(signed, {
+      resolver,
+      receivingAgentId: "luna",
+      cryptoVerify: true,
+      principalId: "andreas",
+      stackIdentity,
+      stackNKeyPub,
+    });
+
+    expect(result.valid).toBe(true);
+  });
+
+  test("[cortex#480] structural-only own-stack short-circuit (no agent registry hit needed)", async () => {
+    const stackIdentity = "did:mf:andreas-meta-factory";
+    const luna = agentFixture({ id: "luna", trust: [] });
+    const resolver = resolverWith(luna);
+
+    // Stamp claims the stack identity. The stack is NOT in the agent
+    // registry — pre-fix this would reject as `unknown_agent`.
+    const env = envelopeWithChain([ed25519Stamp(stackIdentity)]);
+    const result = await verifySignedByChain(env, {
+      resolver,
+      receivingAgentId: "luna",
+      stackIdentity,
+      // cryptoVerify deliberately omitted — structural-only path
+      // exercises the short-circuit in isolation.
+    });
+
+    expect(result.valid).toBe(true);
+  });
+
+  test("[cortex#480] rejects when stack DID does NOT match opts.stackIdentity", async () => {
+    // Defence in depth: a stamp claiming a *different* stack DID does
+    // NOT get the short-circuit; it falls back to the registry lookup
+    // and is rejected as `unknown_agent`.
+    const luna = agentFixture({ id: "luna", trust: [] });
+    const resolver = resolverWith(luna);
+
+    const env = envelopeWithChain([
+      ed25519Stamp("did:mf:other-stack"),
+    ]);
+    const result = await verifySignedByChain(env, {
+      resolver,
+      receivingAgentId: "luna",
+      stackIdentity: "did:mf:andreas-meta-factory",
+    });
+
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.reason.kind).toBe("unknown_agent");
+    }
+  });
+
+  test("[cortex#480] cryptoVerify rejects tampered self-signed stack envelope", async () => {
+    // Short-circuit handles TRUST; bytes-check still runs and catches
+    // forgery claiming the stack identity.
+    const stackIdentity = "did:mf:andreas-meta-factory";
+    const { nkeyPub: stackNKeyPub, privateKeyBase64: stackSeed } =
+      generateEd25519KeyPair();
+    const luna = agentFixture({ id: "luna", trust: [] });
+    const resolver = resolverWith(luna);
+
+    const base = envelopeWithChain(undefined) as Parameters<
+      typeof signEnvelope
+    >[0];
+    const signed = await signEnvelope(base, stackSeed, stackIdentity);
+
+    const chain = Array.isArray(signed.signed_by)
+      ? signed.signed_by
+      : signed.signed_by
+        ? [signed.signed_by]
+        : [];
+    const firstStamp = chain[0];
+    if (firstStamp?.method !== "ed25519") {
+      throw new Error("test fixture: expected ed25519 stamp at index 0");
+    }
+    const tamperedSig = firstStamp.signature.startsWith("A")
+      ? "B" + firstStamp.signature.slice(1)
+      : "A" + firstStamp.signature.slice(1);
+    const tamperedEnvelope: Envelope = {
+      ...signed,
+      signed_by: [{ ...firstStamp, signature: tamperedSig }],
+    };
+
+    const result = await verifySignedByChain(tamperedEnvelope, {
+      resolver,
+      receivingAgentId: "luna",
+      cryptoVerify: true,
+      principalId: "andreas",
+      stackIdentity,
+      stackNKeyPub,
+    });
+
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.reason.kind).toBe("crypto_verify_failed");
+    }
+  });
+
   test("cryptoVerify throws when principalId is missing", async () => {
     // Agent must have an nkey_pub + be self-trusted so the structural
     // check passes and the cryptoVerify-without-principalId branch is

--- a/src/bus/bus-dispatch-listener.ts
+++ b/src/bus/bus-dispatch-listener.ts
@@ -90,6 +90,20 @@ export interface BusDispatchListenerOpts {
    * the missing piece is config-side opt-in).
    */
   cryptoVerify?: boolean;
+  /**
+   * cortex#480 — the receiving stack's signing DID
+   * (e.g. `did:mf:andreas-meta-factory`). When supplied, stamps whose
+   * `identity` matches short-circuit the agent-registry / trust-list
+   * lookup — every cortex stack implicitly trusts its own signing
+   * identity. See `verify-signed-by-chain.ts` JSDoc for rationale.
+   */
+  stackIdentity?: string;
+  /**
+   * cortex#480 — the receiving stack's NKey public key. Required
+   * alongside `stackIdentity` when `cryptoVerify: true` so the bytes
+   * check has a registered Principal to verify against.
+   */
+  stackNKeyPub?: string;
 }
 
 // =============================================================================
@@ -103,6 +117,8 @@ export class BusDispatchListener {
   private readonly principalId: string;
   private readonly source: SystemEventSource;
   private readonly cryptoVerify: boolean;
+  private readonly stackIdentity: string | undefined;
+  private readonly stackNKeyPub: string | undefined;
 
   private registration: { unregister: () => void } | undefined;
   /**
@@ -121,6 +137,8 @@ export class BusDispatchListener {
     this.principalId = opts.principalId;
     this.source = opts.source;
     this.cryptoVerify = opts.cryptoVerify ?? false;
+    this.stackIdentity = opts.stackIdentity;
+    this.stackNKeyPub = opts.stackNKeyPub;
   }
 
   /**
@@ -228,6 +246,12 @@ export class BusDispatchListener {
       rejectEmpty: true,
       cryptoVerify: this.cryptoVerify,
       principalId: this.principalId,
+      ...(this.stackIdentity !== undefined && {
+        stackIdentity: this.stackIdentity,
+      }),
+      ...(this.stackNKeyPub !== undefined && {
+        stackNKeyPub: this.stackNKeyPub,
+      }),
     });
 
     if (!verification.valid) {

--- a/src/bus/verifier-self-check.ts
+++ b/src/bus/verifier-self-check.ts
@@ -1,0 +1,156 @@
+/**
+ * cortex#480 — boot-time self-signed envelope sanity check.
+ *
+ * At boot, after the chain verifier is wired into the dispatch listeners,
+ * publish a tiny envelope signed by the receiving stack's own NKey and
+ * run it through `verifySignedByChain` using the SAME options shape the
+ * production listeners use. If the round-trip fails, log a clear error
+ * — the runner is broken in a way that drops adapter-originated chat
+ * silently otherwise (cortex#480 root cause).
+ *
+ * **Why this exists** (per cortex#480 issue body):
+ * The bug it was designed to catch (verifier rejecting `did:mf:<stack>`
+ * as `unknown_agent`) shipped to production because no boot-time check
+ * exercised the verifier against the exact identity it would receive
+ * on the wire. Adding this sanity check closes the observability gap
+ * — a future regression in the stack-identity short-circuit, the
+ * `nkeyToBase64Pubkey` bridge, or the myelin Principal registry shape
+ * will fail at boot rather than at first Discord chat.
+ *
+ * **Failure mode**: stderr WARNING line — boot continues. A failing
+ * self-check is not fatal because tests + CI catch the structural cases
+ * upstream; this is the production-side last-line-of-defence. The
+ * stderr line is grep-friendly (`verifier-self-check`) so the
+ * pilot-loop / on-call can pattern-match in `cortex-meta-factory.error.log`.
+ *
+ * **What's NOT verified here:** the policy gate, the dispatch handler,
+ * the substrate dispatch — those are downstream of the verifier. The
+ * check exists to validate that a self-signed envelope IS admitted by
+ * the verifier, not that the rest of the pipeline accepts it.
+ */
+
+import { signEnvelope } from "@the-metafactory/myelin/identity";
+import type { TrustResolver } from "../common/agents/trust-resolver";
+import { verifySignedByChain } from "./verify-signed-by-chain";
+import type { Envelope } from "./myelin/envelope-validator";
+
+export interface VerifierSelfCheckOpts {
+  /** The stack's signing DID (e.g. `did:mf:andreas-meta-factory`). */
+  stackIdentity: string;
+  /** The stack's NKey public key (U-prefixed base32). */
+  stackNKeyPub: string;
+  /** The 32-byte raw ed25519 seed bytes (from `BusEnvelopeSigner.rawSeedBytes`). */
+  stackSeedBytes: Uint8Array;
+  /** Trust resolver wired into the production listeners. */
+  resolver: TrustResolver;
+  /** Receiving agent id — same as production listeners. */
+  receivingAgentId: string;
+  /** Principal id — same as production listeners. */
+  principalId: string;
+  /** Optional logger seam (tests; default: console / stderr). */
+  log?: (line: string) => void;
+  err?: (line: string) => void;
+}
+
+export interface VerifierSelfCheckResult {
+  /** True when the self-signed envelope round-tripped cleanly. */
+  ok: boolean;
+  /** Human-readable detail; populated on both success and failure. */
+  detail: string;
+}
+
+/**
+ * Run the self-check. Returns the result rather than throwing — callers
+ * decide whether to escalate (today: log + continue boot).
+ */
+export async function runVerifierSelfCheck(
+  opts: VerifierSelfCheckOpts,
+): Promise<VerifierSelfCheckResult> {
+  const log = opts.log ?? ((line: string) => {
+    console.log(line);
+  });
+  const err = opts.err ?? ((line: string) => {
+    process.stderr.write(line + "\n");
+  });
+
+  // Build a minimal envelope shape that satisfies the validator. We do
+  // NOT use the production envelope-builder helpers because we want the
+  // check to be self-contained and trivially auditable — the whole point
+  // is to flag wiring drift, so depending on the same wiring this is
+  // testing would defeat the purpose.
+  const base = {
+    id: crypto.randomUUID(),
+    source: `${opts.principalId}.cortex.self-check`,
+    type: "system.verifier.self_check" as const,
+    timestamp: new Date().toISOString(),
+    sovereignty: {
+      classification: "local" as const,
+      data_residency: "NZ" as const,
+      max_hop: 0,
+      frontier_ok: false,
+      model_class: "any" as const,
+    },
+    payload: { note: "cortex#480 boot-time self-check" },
+  };
+
+  let signed: Envelope;
+  try {
+    // `signEnvelope` expects base64-encoded raw seed; convert from raw
+    // bytes the same way `BusEnvelopeSigner` → MyelinRuntime conversion
+    // does internally.
+    const seedB64 = Buffer.from(opts.stackSeedBytes).toString("base64");
+    // signEnvelope returns a myelin envelope shape with the new
+    // signed_by stamp appended. Structurally compatible with cortex's
+    // Envelope (which carries a back-compat union shim on `signed_by`)
+    // so the return assignment requires no cast.
+    signed = await signEnvelope(base, seedB64, opts.stackIdentity);
+  } catch (signErr) {
+    const detail = signErr instanceof Error ? signErr.message : String(signErr);
+    err(
+      `verifier-self-check: FAILED to sign self-check envelope: ${detail} ` +
+        `— stack signing keypair may be malformed. Outbound publish will ` +
+        `produce broken stamps; adapter-originated chat will be dropped by ` +
+        `peer verifiers. See cortex#480 + cortex.yaml stack.nkey_seed_path.`,
+    );
+    return { ok: false, detail: `sign failed: ${detail}` };
+  }
+
+  try {
+    const result = await verifySignedByChain(signed, {
+      resolver: opts.resolver,
+      receivingAgentId: opts.receivingAgentId,
+      rejectEmpty: false,
+      cryptoVerify: true,
+      principalId: opts.principalId,
+      stackIdentity: opts.stackIdentity,
+      stackNKeyPub: opts.stackNKeyPub,
+    });
+    if (result.valid) {
+      log(
+        `cortex: verifier-self-check OK — self-signed envelope round-tripped ` +
+          `through verifySignedByChain (stack=${opts.stackIdentity})`,
+      );
+      return { ok: true, detail: "self-signed round-trip verified" };
+    }
+    const reason = result.reason.kind;
+    const fullReason =
+      result.reason.kind === "crypto_verify_failed"
+        ? `${reason} (${result.reason.myelinReason})`
+        : reason;
+    err(
+      `verifier-self-check: FAILED — self-signed envelope REJECTED at chain ` +
+        `index ${result.rejectedAt} with reason=${fullReason}. ` +
+        `Adapter-originated dispatches (Discord/Mattermost/Slack chat) will ` +
+        `be silently dropped by the runner. This is the cortex#480 class of ` +
+        `bug; check stackIdentity (${opts.stackIdentity}) + stackNKeyPub ` +
+        `wiring + signing-key consistency.`,
+    );
+    return { ok: false, detail: `rejected: ${fullReason}` };
+  } catch (verifyErr) {
+    const detail = verifyErr instanceof Error ? verifyErr.message : String(verifyErr);
+    err(
+      `verifier-self-check: FAILED — verifySignedByChain threw: ${detail}`,
+    );
+    return { ok: false, detail: `threw: ${detail}` };
+  }
+}

--- a/src/bus/verify-signed-by-chain.ts
+++ b/src/bus/verify-signed-by-chain.ts
@@ -194,6 +194,39 @@ export interface VerifySignedByChainOptions {
    * myelin: 5 minutes.
    */
   clockSkewMs?: number;
+  /**
+   * The receiving stack's own signing DID (e.g.
+   * `did:mf:andreas-meta-factory`). When supplied, any stamp whose
+   * `identity` matches this DID short-circuits the structural
+   * agent-registry + trust-list lookup and is treated as accepted
+   * — every cortex stack implicitly trusts its own signing identity.
+   *
+   * Rationale (cortex#480): adapter-originated dispatches are signed
+   * with the STACK identity (`did:mf:<principal>-<stack>`), not an
+   * agent identity. The agent registry holds agents (luna/echo/forge)
+   * — looking up the stack DID in it is structurally wrong and yields
+   * `unknown_agent`. The stack is the receiver; it always has
+   * private-key authority for its own DID.
+   *
+   * When `cryptoVerify: true` AND a stamp matches `stackIdentity`,
+   * the crypto-verify pass still runs against `stackNKeyPub` — being
+   * the stack short-circuits the *trust* check, not the *bytes*
+   * check. Forged bytes claiming the stack identity still fail.
+   */
+  stackIdentity?: string;
+  /**
+   * The receiving stack's signing NKey public key (`U` + 55 base32
+   * chars). Required when `stackIdentity` is set AND `cryptoVerify: true`
+   * so the bridge into myelin's `IdentityRegistry` can register the
+   * stack as a Principal whose `public_key` is the base64-encoded raw
+   * ed25519 pubkey. Without this the crypto layer would reject the
+   * self-signed stamp as `principal_not_registered` even though the
+   * structural check accepted it.
+   *
+   * Ignored when `cryptoVerify: false` — structural-only verification
+   * uses `stackIdentity` alone (the short-circuit is the whole point).
+   */
+  stackNKeyPub?: string;
 }
 
 // =============================================================================
@@ -269,6 +302,16 @@ export async function verifySignedByChain(
     const registry = buildIdentityRegistry(
       opts.resolver.getRegistry(),
       opts.principalId,
+      // cortex#480 — register the receiving stack as a Principal so the
+      // self-signed adapter-originated dispatches verify against the
+      // stack's own NKey pubkey. Only registered when both fields are
+      // set; missing either is a no-op (structural short-circuit above
+      // still handles the trust side, and crypto will reject as
+      // principal_not_registered which is the correct signal that the
+      // stack identity wasn't fully wired through).
+      opts.stackIdentity !== undefined && opts.stackNKeyPub !== undefined
+        ? { identity: opts.stackIdentity, nkeyPub: opts.stackNKeyPub }
+        : undefined,
     );
     // Myelin's verifier expects `signed_by` normalised to array form;
     // cortex's `Envelope` keeps the back-compat shim of single-stamp
@@ -354,6 +397,19 @@ function verifyOneStamp(
     };
   }
 
+  // cortex#480 — implicit own-stack trust. When the stamp's identity
+  // matches the receiving stack's signing DID (e.g. adapter-originated
+  // dispatches signed by `did:mf:<principal>-<stack>` via the
+  // MyelinRuntime publish path), short-circuit the agent-registry /
+  // trust-list lookup: the stack is NOT an agent, looking it up in the
+  // agent registry yields `unknown_agent`, but the receiving stack
+  // ALWAYS has private-key authority for its own DID. The crypto-verify
+  // pass below still runs against `stackNKeyPub` — short-circuit the
+  // *trust* check, not the *bytes* check.
+  if (opts.stackIdentity !== undefined && principal === opts.stackIdentity) {
+    return { kind: "accept" };
+  }
+
   const registry = opts.resolver.getRegistry();
   const agent = registry.tryGetById(agentId);
   if (!agent) {
@@ -419,6 +475,20 @@ function verifyOneStamp(
 export function buildIdentityRegistry(
   agentRegistry: AgentRegistry,
   principalId: string,
+  /**
+   * cortex#480 — optionally register the receiving stack's own signing
+   * identity as a Principal so self-signed envelopes (adapter-originated
+   * dispatches stamped by the stack DID via MyelinRuntime.publish)
+   * verify their bytes in the crypto-verify pass. The structural short-
+   * circuit in `verifyOneStamp` admits the stamp on trust; this entry
+   * makes the bytes-check find a registered Principal to verify against.
+   *
+   * `type: "stack"` (vs. "agent") differentiates the registry entry —
+   * myelin's verifier doesn't currently key off type, but tagging
+   * preserves the soma vocabulary distinction (principal/stack/agent
+   * are not the same thing).
+   */
+  stack?: { identity: string; nkeyPub: string },
 ): IdentityRegistry {
   const registry = createInMemoryRegistry();
   const createdAt = new Date(0).toISOString();
@@ -442,6 +512,22 @@ export function buildIdentityRegistry(
       type: "agent",
       created_at: createdAt,
     });
+  }
+  if (stack !== undefined) {
+    const stackPublicKey = nkeyToBase64Pubkey(stack.nkeyPub);
+    if (stackPublicKey !== undefined) {
+      registry.add({
+        id: stack.identity,
+        display_name: stack.identity,
+        network: principalId,
+        public_key: stackPublicKey,
+        // myelin's `Identity.type` union accepts "agent" — there isn't
+        // a distinct "stack" enum value at this slice. Tagging as agent
+        // for now; semantic distinction lives in cortex's own vocab.
+        type: "agent",
+        created_at: createdAt,
+      });
+    }
   }
   return registry;
 }

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -58,6 +58,7 @@ import {
   provisionReviewConsumer,
 } from "./bus/jetstream/provision";
 import { verifySignedByChain } from "./bus/verify-signed-by-chain";
+import { runVerifierSelfCheck } from "./bus/verifier-self-check";
 import { CCSession, type CCSessionOpts } from "./runner/cc-session";
 import { makePiDevPipelineRunner } from "./runner/substrate/pi-dev-runner";
 
@@ -1896,6 +1897,36 @@ export async function startCortex(
     }),
   });
   await dispatchListener.start();
+
+  // cortex#480 — boot-time self-signed envelope sanity check. After the
+  // listeners are wired with `stackIdentity` + `stackNKeyPub`, build a
+  // tiny envelope signed by the stack's own NKey and round-trip it
+  // through `verifySignedByChain` to confirm the verifier admits it.
+  // The check exists because the cortex#480 root-cause (verifier
+  // rejecting `did:mf:<stack>` as unknown_agent) shipped to prod
+  // unnoticed — no boot-side observability exercised the identity the
+  // wire would actually carry. A future regression in the stack-trust
+  // short-circuit / NKey bridge / Principal-registry shape now fails
+  // loudly at boot with a grep-friendly stderr WARNING instead of at
+  // first Discord chat. Skipped when no signing identity is wired
+  // (deployments running unsigned by design).
+  if (
+    signer !== undefined
+    && stackNKeyPubForVerifier !== undefined
+    && firstAgent !== undefined
+  ) {
+    // Fire-and-forget by design — boot does not wait for the result.
+    // The check is informational; production deployment health is
+    // ultimately validated by the dashboard / first round-trip chat.
+    void runVerifierSelfCheck({
+      stackIdentity: signer.principal,
+      stackNKeyPub: stackNKeyPubForVerifier,
+      stackSeedBytes: signer.rawSeedBytes,
+      resolver: trustResolver,
+      receivingAgentId: firstAgent.id,
+      principalId,
+    });
+  }
 
   // Start router AFTER all surfaces register so the first envelope
   // (which may arrive synchronously after `runtime.onEnvelope`) fans

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -434,6 +434,13 @@ export async function startCortex(
   // runtime publishes unsigned. The error surfaces to principal logs
   // so they can fix the seed file and restart.
   let signer: BusEnvelopeSigner | undefined;
+  // cortex#480 — receiving stack's NKey public key for the chain
+  // verifier's own-stack short-circuit (structural) + crypto-registry
+  // entry (bytes-check). Captured from the loaded keypair below so the
+  // signer-side and verifier-side use the SAME key — eliminates a
+  // split-brain hazard where signer.publish stamps with key A but the
+  // verifier short-circuits on declared-but-stale key B.
+  let stackNKeyPubForVerifier: string | undefined;
   if (options.stack?.nkey_seed_path) {
     try {
       // `expandTilde` matches `NatsLink.connect`'s treatment of
@@ -485,6 +492,11 @@ export async function startCortex(
       }
 
       signer = { rawSeedBytes, principal };
+      // cortex#480 — capture the stack's NKey public key so the chain
+      // verifier can short-circuit + bytes-check self-signed envelopes.
+      // `kp.getPublicKey()` is the U-prefixed base32 NATS NKey, the
+      // same shape the verifier's `nkeyToBase64Pubkey` consumes.
+      stackNKeyPubForVerifier = kp.getPublicKey();
       // Soften wording: the runtime may still fail to start; the
       // signer is only "active" once `startMyelinRuntime` returns an
       // enabled runtime. Boot-log clarity matters more than terseness
@@ -1152,6 +1164,15 @@ export async function startCortex(
       // renamed the constructor parameter to `principalId`.
       principalId,
       source: systemEventSource,
+      // cortex#480 — implicit own-stack trust. When the stack has a
+      // signing key staged (signer !== undefined), pass the DID and
+      // NKey pubkey so peer-dispatch envelopes signed by THIS stack
+      // (e.g. loopback / future federated self-relays) verify cleanly
+      // instead of being rejected as unknown_agent.
+      ...(signer !== undefined && { stackIdentity: signer.principal }),
+      ...(stackNKeyPubForVerifier !== undefined && {
+        stackNKeyPub: stackNKeyPubForVerifier,
+      }),
     });
     busDispatchListener.start();
     console.log(
@@ -1864,6 +1885,15 @@ export async function startCortex(
     cryptoVerify: true,
     principalId,
     ...(firstAgent !== undefined && { receivingAgentId: firstAgent.id }),
+    // cortex#480 — implicit own-stack trust. Adapter-originated
+    // dispatches are signed by the stack identity (`did:mf:<principal>-
+    // <stack>`) via MyelinRuntime.publish; without this the verifier
+    // rejects them as `unknown_agent` because the stack is not in the
+    // agent registry. The stack is the RECEIVER; trust is implicit.
+    ...(signer !== undefined && { stackIdentity: signer.principal }),
+    ...(stackNKeyPubForVerifier !== undefined && {
+      stackNKeyPub: stackNKeyPubForVerifier,
+    }),
   });
   await dispatchListener.start();
 

--- a/src/runner/__tests__/dispatch-listener.test.ts
+++ b/src/runner/__tests__/dispatch-listener.test.ts
@@ -2042,6 +2042,66 @@ describe("dispatch-listener — chain verification (cortex#320)", () => {
     ]);
   });
 
+  test("[cortex#480] cryptoVerify:true + envelope self-signed by stack identity → allow (own-stack short-circuit)", async () => {
+    // Pre-fix repro: adapter-originated dispatches (Discord chat) reach
+    // the runner stamped by the stack identity `did:mf:<principal>-
+    // <stack>`. The stack is NOT in the agent registry, so the verifier
+    // rejected as `unknown_agent` and the CC session never spawned.
+    // cortex#480 wires `stackIdentity` + `stackNKeyPub` through so the
+    // verifier short-circuits the registry lookup AND the crypto pass
+    // has the stack pubkey registered as a Principal for bytes-check.
+    const { nkeyPub: stackNKey, privateKeyBase64: stackSeed } =
+      generateEd25519KeyPairForRunner();
+    const stackIdentity = "did:mf:andreas-meta-factory";
+    // Agent registry holds ONLY cortex/luna. The stack DID is not in
+    // it. Pre-fix would reject this as `unknown_agent` agentId=
+    // `andreas-meta-factory`.
+    const cortex = agentFixtureForRunner({ id: "cortex", trust: [] });
+    const resolver = runnerResolverWith(cortex);
+
+    const r = recordingRuntime();
+    const router = createSurfaceRouter(r.runtime);
+    const { factory } = fakeFactory(SUCCESS_RESULT);
+    const listener = createDispatchListener({
+      runtime: r.runtime,
+      router,
+      source: SOURCE,
+      ccSessionFactory: factory,
+      policyEngine: engineGranting(["dispatch.cortex"]),
+      trustResolver: resolver,
+      receivingAgentId: "cortex",
+      principalId: "andreas",
+      cryptoVerify: true,
+      stackIdentity,
+      stackNKeyPub: stackNKey,
+    });
+    await listener.start();
+    await router.start();
+
+    const base = makeReceivedEnvelope() as Parameters<typeof signEnvelope>[0];
+    const signed = await signEnvelope(base, stackSeed, stackIdentity);
+
+    r.trigger(signed, CANONICAL_CORTEX_CHAT_SUBJECT);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    // Verifier short-circuits on stackIdentity match (no registry hit
+    // needed); crypto pass finds the stack registered in the bridged
+    // IdentityRegistry and verifies bytes. The policy engine in this
+    // test's fixture doesn't list the stack DID as a principal, so
+    // the dispatch is denied DOWNSTREAM of the verifier with
+    // `unknown_principal` — NOT with `chain_verification_failed`.
+    // That distinction is the entire point of this test: pre-fix the
+    // verifier rejected as `unknown_agent` and no policy gate ran.
+    const denied = r.published.find((e) => e.type === "system.access.denied");
+    expect(denied).toBeDefined();
+    const reason = denied!.payload.reason as { kind: string };
+    expect(reason.kind).not.toBe("chain_verification_failed");
+    // unknown_principal is the expected post-verifier policy decision
+    // for a stack DID that isn't enumerated in the test's
+    // PolicyEngine principals[].
+    expect(reason.kind).toBe("unknown_principal");
+  });
+
   test("[6] cryptoVerify:true + tampered signature → chain_verification_failed deny", async () => {
     const { nkeyPub, privateKeyBase64 } = generateEd25519KeyPairForRunner();
     const cortex = agentFixtureForRunner({

--- a/src/runner/dispatch-listener.ts
+++ b/src/runner/dispatch-listener.ts
@@ -291,6 +291,21 @@ export interface DispatchListenerOptions {
    * that supply only one configure deliberately incomplete state).
    */
   receivingAgentId?: string;
+  /**
+   * cortex#480 — the receiving stack's signing DID (e.g.
+   * `did:mf:andreas-meta-factory`). Threaded through to
+   * `verifySignedByChain` so adapter-originated dispatches signed by
+   * the stack identity short-circuit the agent-registry membership
+   * check (the stack is the receiver, not an agent in the registry).
+   */
+  stackIdentity?: string;
+  /**
+   * cortex#480 — the receiving stack's NKey public key. Required
+   * alongside `stackIdentity` when `cryptoVerify: true` (the
+   * production default) so the bytes-check has a registered
+   * Principal to verify against.
+   */
+  stackNKeyPub?: string;
 }
 
 export interface DispatchListener {
@@ -384,6 +399,8 @@ export function createDispatchListener(
     trustResolver,
     receivingAgentId,
     principalId,
+    stackIdentity,
+    stackNKeyPub,
     adapterId = "runner-dispatch-listener",
   } = opts;
   // v2.0.2 default: structural trust + ed25519 crypto verification.
@@ -431,6 +448,8 @@ export function createDispatchListener(
         cryptoVerify,
         principalId,
         receivingAgentId,
+        stackIdentity,
+        stackNKeyPub,
       }),
   };
 
@@ -619,6 +638,10 @@ interface DispatchHandlerContext {
   cryptoVerify: boolean;
   principalId: string | undefined;
   receivingAgentId: string | undefined;
+  /** cortex#480 — receiving stack's signing DID for own-stack trust. */
+  stackIdentity: string | undefined;
+  /** cortex#480 — receiving stack's NKey pubkey for crypto-verify pass. */
+  stackNKeyPub: string | undefined;
 }
 
 async function handleDispatchEnvelope(
@@ -637,6 +660,8 @@ async function handleDispatchEnvelope(
     cryptoVerify,
     principalId,
     receivingAgentId,
+    stackIdentity,
+    stackNKeyPub,
   } = ctx;
   const payload = parsePayload(envelope);
   if (!payload) {
@@ -724,6 +749,10 @@ async function handleDispatchEnvelope(
         rejectEmpty: false,
         cryptoVerify,
         ...(cryptoVerify && principalId !== undefined && { principalId }),
+        // cortex#480 — own-stack trust short-circuit + crypto registry
+        // entry for self-signed adapter-originated dispatches.
+        ...(stackIdentity !== undefined && { stackIdentity }),
+        ...(stackNKeyPub !== undefined && { stackNKeyPub }),
       });
     } catch (err) {
       // `verifySignedByChain` throws when `cryptoVerify: true` and


### PR DESCRIPTION
## Summary

cortex#480 — every cortex stack now implicitly trusts its own signing identity in the chain verifier. Adapter-originated dispatches (Discord/Mattermost/Slack chat) are signed by the **stack** DID (`did:mf:<principal>-<stack>`) via `MyelinRuntime.publish`, but pre-fix the verifier looked the stack up in the **agent** registry, found nothing, and rejected as `unknown_agent at chain index 0` — silently dropping every chat envelope before the CC session could spawn.

## What changed

- **`src/bus/verify-signed-by-chain.ts`** — `VerifySignedByChainOptions` gains `stackIdentity?` + `stackNKeyPub?`. When a stamp's `identity` matches `stackIdentity`, short-circuit the agent-registry / trust-list lookup. The crypto-verify pass still runs against the stack's NKey pubkey registered as a Principal in the bridged `IdentityRegistry` — short-circuit the *trust* check, not the *bytes* check. Forged bytes claiming the stack identity still fail.
- **`src/bus/bus-dispatch-listener.ts`** + **`src/runner/dispatch-listener.ts`** — pass the two new options through.
- **`src/cortex.ts`** — derive `stackIdentity = signer.principal` and `stackNKeyPub = kp.getPublicKey()` from the loaded signing keypair so signer-side and verifier-side use the SAME key (eliminates a split-brain hazard from a stale declared `stack.nkey_pub`).
- **`src/bus/verifier-self-check.ts`** — new boot-time sanity check. Builds a tiny envelope, signs it with the stack's NKey, round-trips through `verifySignedByChain` with the same options shape the production listeners use. Logs a grep-friendly `verifier-self-check OK` or `verifier-self-check: FAILED` line. Wired in `cortex.ts` after `dispatchListener.start()`, fire-and-forget; closes the observability gap that let cortex#480 ship to prod unnoticed.
- **`CONTEXT.md`** — new `§Identity & trust` subsection: Stack signing identity + Own-stack implicit trust entries.

## Tests

- Unit (verify-signed-by-chain): own-stack accept, mismatched stack DID rejects, crypto self-signed accepts, tampered self-signed rejects.
- Bus integration (bus-dispatch-listener): self-signed envelope round-trips to a `system.bus.peer_dispatch_received` event.
- Runner integration (dispatch-listener): adapter-shaped self-signed envelope passes chain verification — policy denies downstream with `unknown_principal` (NOT `chain_verification_failed`), which is the entire point.
- Boot self-check: happy path, mismatched pubkey (split-brain detection), malformed pubkey (bridge defence-in-depth).

Full suite: 3559 pass, 0 fail.

## Breaking changes

None — purely additive trust path. Call sites without `stackIdentity` retain pre-fix behaviour.

## Test plan

- [x] `bunx tsc --noEmit`
- [x] `bun test` — 3559 pass, 0 fail
- [x] `bun run lint:errors`
- [ ] Deploy + verify Discord chat round-trips successfully (cortex#480 reproduction unblocked on Andreas's running stack)
- [ ] Confirm `verifier-self-check OK` appears in `cortex-meta-factory.log` at boot

🤖 Generated with [Claude Code](https://claude.com/claude-code)