### PR TITLE
fix(runner): platform-id originator → principal resolution (closes #482)

### DIFF
--- a/src/common/policy/__tests__/engine.test.ts
+++ b/src/common/policy/__tests__/engine.test.ts
@@ -226,6 +226,90 @@ describe("PolicyEngine — sovereignty (C.1 smoke)", () => {
   });
 });
 
+describe("PolicyEngine — platform-id reverse lookup (cortex#482)", () => {
+  // cortex#482 — adapter-originated envelopes set
+  // `originator.identity = did:mf:<platform>-<authorId>` (e.g.
+  // `did:mf:discord-1134325176796987522`). The dispatch resolver
+  // back-resolves this to a registered `Principal.id` by consulting
+  // `Principal.platform_ids[platform][]` via the engine's reverse index.
+
+  test("registered (platform, author_id) tuple → principal id", () => {
+    const engine = new PolicyEngine({
+      principals: [
+        principal({
+          id: "andreas",
+          platform_ids: { discord: ["1134325176796987522"] },
+        }),
+      ],
+      roles: [role("operator", ["dispatch.cortex"])],
+    });
+
+    expect(
+      engine.lookupPrincipalIdByPlatformId("discord", "1134325176796987522"),
+    ).toBe("andreas");
+  });
+
+  test("unmapped (platform, author_id) tuple → undefined (engine then denies upstream)", () => {
+    const engine = new PolicyEngine({
+      principals: [
+        principal({
+          id: "andreas",
+          platform_ids: { discord: ["1134325176796987522"] },
+        }),
+      ],
+      roles: [role("operator", [])],
+    });
+
+    // Different snowflake.
+    expect(
+      engine.lookupPrincipalIdByPlatformId("discord", "999999999999999999"),
+    ).toBeUndefined();
+    // Known author_id but on a platform this principal doesn't claim.
+    expect(
+      engine.lookupPrincipalIdByPlatformId("slack", "1134325176796987522"),
+    ).toBeUndefined();
+    // Platform with no declared principals at all.
+    expect(
+      engine.lookupPrincipalIdByPlatformId("mattermost", "anything"),
+    ).toBeUndefined();
+  });
+
+  test("principal without platform_ids → no entries in reverse index", () => {
+    // Federation peer principals (and the default `principal()` fixture)
+    // omit `platform_ids` — the reverse index just stays empty for them.
+    const engine = new PolicyEngine({
+      principals: [principal({ id: "luna" })],
+      roles: [role("operator", [])],
+    });
+
+    expect(
+      engine.lookupPrincipalIdByPlatformId("discord", "anything"),
+    ).toBeUndefined();
+  });
+
+  test("multi-platform principal → resolves on each declared platform", () => {
+    const engine = new PolicyEngine({
+      principals: [
+        principal({
+          id: "andreas",
+          platform_ids: {
+            discord: ["1134325176796987522"],
+            mattermost: ["mm-andreas-id"],
+          },
+        }),
+      ],
+      roles: [role("operator", [])],
+    });
+
+    expect(
+      engine.lookupPrincipalIdByPlatformId("discord", "1134325176796987522"),
+    ).toBe("andreas");
+    expect(
+      engine.lookupPrincipalIdByPlatformId("mattermost", "mm-andreas-id"),
+    ).toBe("andreas");
+  });
+});
+
 describe("PolicyEngine — boot accessors", () => {
   test("principalCount + roleCount reflect constructor opts", () => {
     const engine = new PolicyEngine({

--- a/src/common/policy/__tests__/engine.test.ts
+++ b/src/common/policy/__tests__/engine.test.ts
@@ -308,6 +308,40 @@ describe("PolicyEngine — platform-id reverse lookup (cortex#482)", () => {
       engine.lookupPrincipalIdByPlatformId("mattermost", "mm-andreas-id"),
     ).toBe("andreas");
   });
+
+  // PR #483 — `knownPlatforms` exposes the reverse-index keys so callers
+  // (dispatch-listener.parsePlatformPrefixedAgentId) can disambiguate
+  // hyphenated platform names by longest-prefix match.
+  test("knownPlatforms exposes the set of registered platform names", () => {
+    const engine = new PolicyEngine({
+      principals: [
+        principal({
+          id: "andreas",
+          platform_ids: {
+            discord: ["1"],
+            "mcp-cli": ["2"],
+          },
+        }),
+        principal({
+          id: "alice",
+          platform_ids: { mattermost: ["mm-1"] },
+        }),
+      ],
+      roles: [role("operator", [])],
+    });
+
+    const platforms = [...engine.knownPlatforms].sort();
+    expect(platforms).toEqual(["discord", "mattermost", "mcp-cli"]);
+  });
+
+  test("knownPlatforms is empty when no principals declare platform_ids", () => {
+    const engine = new PolicyEngine({
+      principals: [principal({ id: "luna" })],
+      roles: [role("operator", [])],
+    });
+
+    expect([...engine.knownPlatforms]).toEqual([]);
+  });
 });
 
 describe("PolicyEngine — boot accessors", () => {

--- a/src/common/policy/engine.ts
+++ b/src/common/policy/engine.ts
@@ -191,6 +191,34 @@ export class PolicyEngine {
   }
 
   /**
+   * IAW cortex#483 — registered platform names (the keys of the
+   * `platform → author_id → principal_id` reverse index).
+   *
+   * Exposed so callers can disambiguate platform-prefixed agent ids
+   * by longest-prefix match against the registered set. Required
+   * because `adapterOriginatorIdentity` joins `<platform>-<authorId>`
+   * with a single hyphen separator AND the schema's
+   * `LETTER_PREFIX_ID_REGEX = /^[a-z][a-z0-9-]*$/` permits hyphenated
+   * platform names (e.g. `mcp-cli`, `discord-bot`, `email-imap`).
+   * A naive first-hyphen split of `did:mf:mcp-cli-myUser123` yields
+   * `(platform=mcp, authorId=cli-myUser123)` which misses the real
+   * key `(mcp-cli, myUser123)` — silent denial-of-service for
+   * hyphenated-platform principals.
+   *
+   * The dispatch-listener's `parsePlatformPrefixedAgentId` iterates
+   * this set and picks the longest registered platform that prefixes
+   * the agent id, breaking the ambiguity symmetrically with the
+   * publisher.
+   *
+   * Returns an `Iterable` (not an array snapshot) to avoid
+   * materialising a copy on every dispatch; callers that need
+   * stable iteration should spread it.
+   */
+  get knownPlatforms(): Iterable<string> {
+    return this.principalIdByPlatformId.keys();
+  }
+
+  /**
    * Authorise a principal id to exercise an intent. Returns a
    * `PolicyDecision` discriminated on `allow`.
    *

--- a/src/common/policy/engine.ts
+++ b/src/common/policy/engine.ts
@@ -131,6 +131,29 @@ export class PolicyEngine {
    * `PolicySchema.superRefine`; if a duplicate slips through here the
    * later principal in the constructor list wins (last-write semantics,
    * consistent with `principalsById`'s `new Map(...)` collision rule).
+   *
+   * **Duplication note (PR #483 — keep in sync with
+   * `PlatformPrincipalIndex` in `src/common/policy/policy-gate.ts`).**
+   * `PlatformPrincipalIndex` builds the same `(platform, platform_id)
+   * → principal_id` lookup from the same `policy.principals[]` shape,
+   * for adapter-side `resolvePolicyAccess`. Both indexes are kept
+   * because they serve different boundaries:
+   *
+   *   - `PlatformPrincipalIndex` runs adapter-side, BEFORE the
+   *     envelope hits the bus. The adapter has the platform + raw
+   *     platform-id in hand (e.g. Discord snowflake) and just needs
+   *     `resolve(platform, id)` to construct the originator DID.
+   *   - This engine-side index runs bus-side, AFTER the envelope is
+   *     verified. The runner has only a flat `did:mf:<platform>-<id>`
+   *     string and needs both (a) the platform set, for
+   *     longest-prefix disambiguation (see {@link knownPlatforms}),
+   *     and (b) the reverse lookup. Holding the registry here lets
+   *     `dispatch-listener.ts` consume policy decisions without
+   *     pulling in `policy-gate.ts` (adapter-layer module).
+   *
+   * Schema-side changes (case-folding, platform-name canonicalisation,
+   * deprecation) must land in BOTH places or the boundaries drift.
+   * Cross-referenced from `PlatformPrincipalIndex` JSDoc.
    */
   private readonly principalIdByPlatformId: ReadonlyMap<string, ReadonlyMap<string, string>>;
 

--- a/src/common/policy/engine.ts
+++ b/src/common/policy/engine.ts
@@ -122,6 +122,17 @@ export class PolicyEngine {
    * any federated `check()` in that case.
    */
   private readonly networksById: ReadonlyMap<string, FederatedNetwork> | undefined;
+  /**
+   * IAW cortex#482 — reverse index `platform → author_id → principal_id`.
+   *
+   * Built once at construction from each principal's `platform_ids`
+   * map so `lookupPrincipalIdByPlatformId` is O(1) per call. Uniqueness
+   * of `(platform, author_id)` tuples is enforced upstream by
+   * `PolicySchema.superRefine`; if a duplicate slips through here the
+   * later principal in the constructor list wins (last-write semantics,
+   * consistent with `principalsById`'s `new Map(...)` collision rule).
+   */
+  private readonly principalIdByPlatformId: ReadonlyMap<string, ReadonlyMap<string, string>>;
 
   constructor(opts: PolicyEngineOptions) {
     this.principalsById = new Map(opts.principals.map((p) => [p.id, p]));
@@ -129,6 +140,54 @@ export class PolicyEngine {
     this.networksById = opts.federated
       ? new Map(opts.federated.networks.map((n) => [n.id, n]))
       : undefined;
+
+    // IAW cortex#482 — flatten principals[].platform_ids[platform][]
+    // into a `platform → author_id → principal_id` reverse index.
+    // Built at construction and never mutated; the registry is a
+    // cortex.yaml snapshot (see `Principal.role`'s `readonly`
+    // discipline JSDoc).
+    const reverse = new Map<string, Map<string, string>>();
+    for (const p of opts.principals) {
+      const platformIds = p.platform_ids;
+      if (platformIds === undefined) continue;
+      for (const [platform, ids] of Object.entries(platformIds)) {
+        let bucket = reverse.get(platform);
+        if (bucket === undefined) {
+          bucket = new Map<string, string>();
+          reverse.set(platform, bucket);
+        }
+        for (const authorId of ids) {
+          bucket.set(authorId, p.id);
+        }
+      }
+    }
+    this.principalIdByPlatformId = reverse;
+  }
+
+  /**
+   * IAW cortex#482 — reverse-lookup a `(platform, author_id)` tuple
+   * to a registered principal id, or `undefined` when no principal
+   * claims that platform identity.
+   *
+   * Consumes the reverse index built from
+   * `Principal.platform_ids[platform][]` at construction. The
+   * dispatch-listener's `resolvePrincipalId` calls this when an
+   * adapter-originated envelope's `originator.identity` decodes to a
+   * platform-prefixed shape (`did:mf:<platform>-<authorId>` per
+   * `adapterOriginatorIdentity` in
+   * `src/bus/dispatch-source-publisher.ts`).
+   *
+   * Returning `undefined` for unknown tuples is the security
+   * default: the caller forwards the raw platform-prefixed id to
+   * `check()`, which then denies with `unknown_principal`. No
+   * platform identity gets implicitly authorised by failure to
+   * resolve.
+   */
+  lookupPrincipalIdByPlatformId(
+    platform: string,
+    authorId: string,
+  ): string | undefined {
+    return this.principalIdByPlatformId.get(platform)?.get(authorId);
   }
 
   /**

--- a/src/common/policy/factory.ts
+++ b/src/common/policy/factory.ts
@@ -71,6 +71,11 @@ export function policyEngineFromConfig(
       home_stack: p.home_stack,
       role: p.role,
       trust: p.trust,
+      // IAW cortex#482 — thread platform_ids onto the engine so it
+      // can back-resolve adapter-originated `did:mf:<platform>-<authorId>`
+      // DIDs to a principal id. The Zod schema defaults the map to `{}`
+      // (per `PolicyPrincipalSchema.platform_ids`); forward as-is.
+      platform_ids: p.platform_ids,
     })),
     roles: policy.roles.map((r) => ({
       id: r.id,

--- a/src/common/policy/policy-gate.ts
+++ b/src/common/policy/policy-gate.ts
@@ -36,6 +36,16 @@ import type { Policy, PolicyPrincipal } from "../types/cortex-config";
  *
  * Built once at adapter construction time. Read-only at runtime; backed
  * by an internal `Map`.
+ *
+ * **Duplication note (PR #483 — keep in sync with the engine-side
+ * reverse index `principalIdByPlatformId` in
+ * `src/common/policy/engine.ts`).** Both indexes are built from
+ * the same `policy.principals[].platform_ids` shape but serve
+ * different boundaries (adapter-side pre-publish vs runner-side
+ * post-verify). Schema changes (case-folding, platform-name
+ * canonicalisation, deprecation) must land in BOTH places or the
+ * boundaries drift. See `PolicyEngine.principalIdByPlatformId`
+ * JSDoc for the full justification.
  */
 export class PlatformPrincipalIndex {
   private readonly map: ReadonlyMap<string, string>;

--- a/src/common/policy/types.ts
+++ b/src/common/policy/types.ts
@@ -66,6 +66,25 @@ export interface Principal {
    * snapshot discipline as `role`.
    */
   readonly trust: readonly string[];
+  /**
+   * IAW cortex#482 — platform-author-id → principal mapping.
+   *
+   * Open record of `<platform_name> → <author_id>[]`, mirroring
+   * `PolicyPrincipalSchema.platform_ids` on cortex.yaml. The engine
+   * consumes this to back-resolve adapter-originated DIDs of the
+   * shape `did:mf:<platform>-<authorId>` (emitted by
+   * `adapterOriginatorIdentity` in `src/bus/dispatch-source-publisher.ts`)
+   * to a principal id via
+   * `PolicyEngine.lookupPrincipalIdByPlatformId(platform, authorId)`.
+   *
+   * Optional + defaults to `{}` so existing callers (engine tests,
+   * federation peer principals — which by convention SHOULD NOT
+   * carry platform_ids per `PolicyPrincipalSchema` JSDoc) keep
+   * working unchanged. The engine treats the map as read-only after
+   * construction — mutating it post-construction does not refresh
+   * the reverse index.
+   */
+  readonly platform_ids?: Readonly<Record<string, readonly string[]>>;
 }
 
 /**

--- a/src/runner/__tests__/dispatch-listener.test.ts
+++ b/src/runner/__tests__/dispatch-listener.test.ts
@@ -2649,4 +2649,193 @@ describe("dispatch-listener — platform-id originator resolution (cortex#482)",
       "dispatch.task.completed",
     ]);
   });
+
+  // -------------------------------------------------------------------------
+  // PR #483 — Echo R1 major. Hyphenated platform names (`mcp-cli`,
+  // `discord-bot`, `email-imap`) round-trip through the publisher's single-
+  // hyphen separator. The parser must consult the engine's known-platform
+  // set and pick the longest registered prefix, otherwise
+  // `did:mf:mcp-cli-myUser123` mis-splits to `(mcp, cli-myUser123)` and
+  // silently denies the principal.
+  // -------------------------------------------------------------------------
+
+  test("hyphenated platform name (mcp-cli) → longest-prefix match resolves correctly", async () => {
+    // Register `mcp-cli` as a platform on principal `alice`. The
+    // publisher would emit `did:mf:mcp-cli-myUser123`. The parser must
+    // recognise `mcp-cli` (not `mcp`) as the platform.
+    const captured: { principalId: string; intent: Intent }[] = [];
+    const engine = new PolicyEngine({
+      principals: [
+        {
+          id: "alice",
+          home_operator: "andreas",
+          home_stack: "andreas/research",
+          role: ["operator"],
+          trust: [],
+          // Author id is lowercase to match `adapterOriginatorIdentity`
+          // (publisher) which lowercases the author id before joining.
+          platform_ids: { "mcp-cli": ["myuser123"] },
+        },
+      ],
+      roles: [{ id: "operator", capabilities: ["dispatch.cortex"] }],
+    });
+    const origCheck = engine.check.bind(engine);
+    engine.check = (principalId, intent) => {
+      captured.push({ principalId, intent });
+      return origCheck(principalId, intent);
+    };
+
+    const r = recordingRuntime();
+    const router = createSurfaceRouter(r.runtime);
+    const { factory } = fakeFactory(SUCCESS_RESULT);
+    const listener = createDispatchListener({
+      runtime: r.runtime,
+      router,
+      source: SOURCE,
+      ccSessionFactory: factory,
+      policyEngine: engine,
+    });
+    await listener.start();
+    await router.start();
+
+    const env = makeReceivedEnvelope();
+    env.originator = {
+      identity: "did:mf:mcp-cli-myuser123",
+      attribution: "adapter-resolved",
+    };
+
+    r.trigger(env, CANONICAL_CORTEX_CHAT_SUBJECT);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(captured).toHaveLength(1);
+    // Critical: must resolve to `alice`, not `discord-999...`-style raw
+    // tail. With a naive first-hyphen split, this would have
+    // mis-resolved to (mcp, cli-myuser123) and denied.
+    expect(captured[0]!.principalId).toBe("alice");
+    expect(r.published.map((e) => e.type)).toEqual([
+      "system.access.allowed",
+      "dispatch.task.started",
+      "dispatch.task.completed",
+    ]);
+  });
+
+  test("hyphenated-platform-shape DID with NO matching registered platform → falls through to raw tail (engine denies)", async () => {
+    // Same shape (`did:mf:mcp-cli-...`) but no principal registers a
+    // platform named `mcp-cli` (only `discord`). The parser must NOT
+    // greedy-match against `mcp` (it isn't registered either) and must
+    // NOT fall back to the legacy first-hyphen split. It returns
+    // `undefined`; caller forwards the raw tail; engine denies.
+    const captured: { principalId: string; intent: Intent }[] = [];
+    const engine = new PolicyEngine({
+      principals: [
+        {
+          id: "andreas",
+          home_operator: "andreas",
+          home_stack: "andreas/research",
+          role: ["operator"],
+          trust: [],
+          platform_ids: { discord: ["1134325176796987522"] },
+        },
+      ],
+      roles: [{ id: "operator", capabilities: ["dispatch.cortex"] }],
+    });
+    const origCheck = engine.check.bind(engine);
+    engine.check = (principalId, intent) => {
+      captured.push({ principalId, intent });
+      return origCheck(principalId, intent);
+    };
+
+    const r = recordingRuntime();
+    const router = createSurfaceRouter(r.runtime);
+    const { factory } = fakeFactory(SUCCESS_RESULT);
+    const listener = createDispatchListener({
+      runtime: r.runtime,
+      router,
+      source: SOURCE,
+      ccSessionFactory: factory,
+      policyEngine: engine,
+    });
+    await listener.start();
+    await router.start();
+
+    const env = makeReceivedEnvelope();
+    env.originator = {
+      identity: "did:mf:mcp-cli-myuser123",
+      attribution: "adapter-resolved",
+    };
+
+    r.trigger(env, CANONICAL_CORTEX_CHAT_SUBJECT);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(captured).toHaveLength(1);
+    // No registered platform matches `mcp-cli-...`, so the parser
+    // returns undefined and the caller forwards the raw tail.
+    expect(captured[0]!.principalId).toBe("mcp-cli-myuser123");
+    const types = r.published.map((e) => e.type);
+    expect(types).toContain("system.access.denied");
+    expect(types).toContain("dispatch.task.failed");
+  });
+
+  test("both `mcp` and `mcp-cli` registered → longest prefix wins", async () => {
+    // Adversarial case: two platforms registered where one is a
+    // prefix of the other. `did:mf:mcp-cli-myuser123` MUST resolve as
+    // (`mcp-cli`, `myuser123`) — the longest registered prefix — not
+    // (`mcp`, `cli-myuser123`).
+    const captured: { principalId: string; intent: Intent }[] = [];
+    const engine = new PolicyEngine({
+      principals: [
+        {
+          id: "alice",
+          home_operator: "andreas",
+          home_stack: "andreas/research",
+          role: ["operator"],
+          trust: [],
+          platform_ids: { "mcp-cli": ["myuser123"] },
+        },
+        {
+          id: "bob",
+          home_operator: "andreas",
+          home_stack: "andreas/research",
+          role: ["operator"],
+          trust: [],
+          // bob owns the (`mcp`, `cli-myuser123`) tuple — proving the
+          // parser does NOT pick `mcp` even though it would also match
+          // and resolve to a valid principal.
+          platform_ids: { mcp: ["cli-myuser123"] },
+        },
+      ],
+      roles: [{ id: "operator", capabilities: ["dispatch.cortex"] }],
+    });
+    const origCheck = engine.check.bind(engine);
+    engine.check = (principalId, intent) => {
+      captured.push({ principalId, intent });
+      return origCheck(principalId, intent);
+    };
+
+    const r = recordingRuntime();
+    const router = createSurfaceRouter(r.runtime);
+    const { factory } = fakeFactory(SUCCESS_RESULT);
+    const listener = createDispatchListener({
+      runtime: r.runtime,
+      router,
+      source: SOURCE,
+      ccSessionFactory: factory,
+      policyEngine: engine,
+    });
+    await listener.start();
+    await router.start();
+
+    const env = makeReceivedEnvelope();
+    env.originator = {
+      identity: "did:mf:mcp-cli-myuser123",
+      attribution: "adapter-resolved",
+    };
+
+    r.trigger(env, CANONICAL_CORTEX_CHAT_SUBJECT);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(captured).toHaveLength(1);
+    // Longest-prefix wins: `mcp-cli` (7 chars) beats `mcp` (3 chars).
+    expect(captured[0]!.principalId).toBe("alice");
+  });
 });

--- a/src/runner/__tests__/dispatch-listener.test.ts
+++ b/src/runner/__tests__/dispatch-listener.test.ts
@@ -2467,3 +2467,186 @@ describe("dispatch-listener — originator (cortex#346 / myelin#161)", () => {
     expect(optsCaptured).toHaveLength(0);
   });
 });
+
+// ---------------------------------------------------------------------------
+// cortex#482 — platform-prefixed originator DIDs back-resolve to a principal
+// id via `Principal.platform_ids[platform][]`. Adapter-originated dispatches
+// set `originator.identity = did:mf:<platform>-<authorId>` (see
+// `adapterOriginatorIdentity` in `src/bus/dispatch-source-publisher.ts`).
+// Before this fix the runner stripped `did:mf:` and looked up the literal
+// `<platform>-<authorId>` as `Principal.id` → `unknown_principal`.
+// ---------------------------------------------------------------------------
+
+describe("dispatch-listener — platform-id originator resolution (cortex#482)", () => {
+  test("platform-prefixed originator DID with a mapped principal → resolves to principal id", async () => {
+    // Andreas declared as principal `andreas` with `platform_ids.discord =
+    // ["1134325176796987522"]`. Discord adapter publishes an envelope with
+    // `originator.identity = did:mf:discord-1134325176796987522`. The
+    // resolver should hand the engine `andreas`, not `discord-1134...`.
+    const captured: { principalId: string; intent: Intent }[] = [];
+    const engine = new PolicyEngine({
+      principals: [
+        {
+          id: "andreas",
+          home_operator: "andreas",
+          home_stack: "andreas/research",
+          role: ["operator"],
+          trust: [],
+          platform_ids: { discord: ["1134325176796987522"] },
+        },
+      ],
+      roles: [{ id: "operator", capabilities: ["dispatch.cortex"] }],
+    });
+    const origCheck = engine.check.bind(engine);
+    engine.check = (principalId, intent) => {
+      captured.push({ principalId, intent });
+      return origCheck(principalId, intent);
+    };
+
+    const r = recordingRuntime();
+    const router = createSurfaceRouter(r.runtime);
+    const { factory } = fakeFactory(SUCCESS_RESULT);
+    const listener = createDispatchListener({
+      runtime: r.runtime,
+      router,
+      source: SOURCE,
+      ccSessionFactory: factory,
+      policyEngine: engine,
+    });
+    await listener.start();
+    await router.start();
+
+    const env = makeReceivedEnvelope();
+    env.originator = {
+      identity: "did:mf:discord-1134325176796987522",
+      attribution: "adapter-resolved",
+    };
+
+    r.trigger(env, CANONICAL_CORTEX_CHAT_SUBJECT);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0]!.principalId).toBe("andreas");
+    // Allow path: engine grants dispatch.cortex → success lifecycle fires.
+    expect(r.published.map((e) => e.type)).toEqual([
+      "system.access.allowed",
+      "dispatch.task.started",
+      "dispatch.task.completed",
+    ]);
+  });
+
+  test("platform-prefixed originator DID without a mapped principal → falls through to raw tail (engine denies unknown_principal)", async () => {
+    // Defence-in-depth: a Discord snowflake that no principal claims
+    // MUST NOT be implicitly authorised. The resolver falls through to
+    // the raw `<platform>-<authorId>` tail; engine denies; the existing
+    // security boundary is preserved.
+    const captured: { principalId: string; intent: Intent }[] = [];
+    const engine = new PolicyEngine({
+      principals: [
+        {
+          id: "andreas",
+          home_operator: "andreas",
+          home_stack: "andreas/research",
+          role: ["operator"],
+          trust: [],
+          platform_ids: { discord: ["1134325176796987522"] },
+        },
+      ],
+      roles: [{ id: "operator", capabilities: ["dispatch.cortex"] }],
+    });
+    const origCheck = engine.check.bind(engine);
+    engine.check = (principalId, intent) => {
+      captured.push({ principalId, intent });
+      return origCheck(principalId, intent);
+    };
+
+    const r = recordingRuntime();
+    const router = createSurfaceRouter(r.runtime);
+    const { factory } = fakeFactory(SUCCESS_RESULT);
+    const listener = createDispatchListener({
+      runtime: r.runtime,
+      router,
+      source: SOURCE,
+      ccSessionFactory: factory,
+      policyEngine: engine,
+    });
+    await listener.start();
+    await router.start();
+
+    const env = makeReceivedEnvelope();
+    env.originator = {
+      // Unmapped snowflake.
+      identity: "did:mf:discord-999999999999999999",
+      attribution: "adapter-resolved",
+    };
+
+    r.trigger(env, CANONICAL_CORTEX_CHAT_SUBJECT);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(captured).toHaveLength(1);
+    // Falls through to the raw tail — the engine resolves it as the
+    // (literal) principal id and denies with `unknown_principal`.
+    expect(captured[0]!.principalId).toBe("discord-999999999999999999");
+    const types = r.published.map((e) => e.type);
+    expect(types).toContain("system.access.denied");
+    expect(types).toContain("dispatch.task.failed");
+  });
+
+  test("direct did:mf:<principal-id> (no platform prefix) → existing behaviour preserved", async () => {
+    // Non-platform originators (e.g. `did:mf:alice` from cortex-as-relay
+    // flows) must continue to round-trip through the existing path: the
+    // bare segment is the principal id, no reverse lookup is attempted.
+    const captured: { principalId: string; intent: Intent }[] = [];
+    const engine = new PolicyEngine({
+      principals: [
+        {
+          id: "alice",
+          home_operator: "andreas",
+          home_stack: "andreas/research",
+          role: ["operator"],
+          trust: [],
+          // Note: alice ALSO has a discord platform_id, to prove the
+          // resolver doesn't accidentally reverse-lookup non-platform
+          // DIDs against the index.
+          platform_ids: { discord: ["alice-discord-id"] },
+        },
+      ],
+      roles: [{ id: "operator", capabilities: ["dispatch.cortex"] }],
+    });
+    const origCheck = engine.check.bind(engine);
+    engine.check = (principalId, intent) => {
+      captured.push({ principalId, intent });
+      return origCheck(principalId, intent);
+    };
+
+    const r = recordingRuntime();
+    const router = createSurfaceRouter(r.runtime);
+    const { factory } = fakeFactory(SUCCESS_RESULT);
+    const listener = createDispatchListener({
+      runtime: r.runtime,
+      router,
+      source: SOURCE,
+      ccSessionFactory: factory,
+      policyEngine: engine,
+    });
+    await listener.start();
+    await router.start();
+
+    const env = makeReceivedEnvelope();
+    env.originator = {
+      identity: "did:mf:alice",
+      attribution: "adapter-resolved",
+    };
+
+    r.trigger(env, CANONICAL_CORTEX_CHAT_SUBJECT);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0]!.principalId).toBe("alice");
+    expect(r.published.map((e) => e.type)).toEqual([
+      "system.access.allowed",
+      "dispatch.task.started",
+      "dispatch.task.completed",
+    ]);
+  });
+});

--- a/src/runner/dispatch-listener.ts
+++ b/src/runner/dispatch-listener.ts
@@ -1137,6 +1137,15 @@ function checkDispatchPolicy(
  * engine then denies with `unknown_principal` — the existing security
  * boundary is preserved.
  *
+ * **PR #483 (Echo R1 major) — hyphenated-platform disambiguation.**
+ * The schema's `LETTER_PREFIX_ID_REGEX` permits hyphenated platform
+ * names (`mcp-cli`, `discord-bot`), and `adapterOriginatorIdentity`
+ * joins `<platform>-<authorId>` with a single hyphen — so a naive
+ * first-hyphen split would mis-resolve. `parsePlatformPrefixedAgentId`
+ * now consults `engine.knownPlatforms` and picks the longest
+ * registered platform that prefixes the bare segment, making the
+ * parser symmetric with the publisher.
+ *
  * The engine arg is optional so legacy callers (and the no-engine
  * fail-closed boot path) keep working without churn.
  */
@@ -1157,7 +1166,10 @@ function resolvePrincipalId(
   // the existing behaviour; an unmapped platform identity also falls
   // through to the raw tail (engine denies `unknown_principal`).
   if (engine !== undefined) {
-    const platformMatch = parsePlatformPrefixedAgentId(agentId);
+    const platformMatch = parsePlatformPrefixedAgentId(
+      agentId,
+      engine.knownPlatforms,
+    );
     if (platformMatch !== undefined) {
       const resolved = engine.lookupPrincipalIdByPlatformId(
         platformMatch.platform,
@@ -1170,37 +1182,80 @@ function resolvePrincipalId(
 }
 
 /**
- * IAW cortex#482 — split a `<platform>-<authorId>` bare agent-id segment
- * (the tail of `did:mf:<platform>-<authorId>` after the `did:mf:` strip)
- * into its `platform` + `authorId` parts.
+ * IAW cortex#482 + PR #483 (Echo R1 major) — split a
+ * `<platform>-<authorId>` bare agent-id segment (the tail of
+ * `did:mf:<platform>-<authorId>` after the `did:mf:` strip) into its
+ * `platform` + `authorId` parts, disambiguating against the set of
+ * platforms registered with the engine.
  *
  * The grammar mirrors `adapterOriginatorIdentity` (publisher side):
- *   - `platform` is the lowercase platform tag (`discord`, `mattermost`,
- *     `slack`, …) — letters/digits, the same alphabet the publisher's
- *     `prefix = platform.toLowerCase()` produces.
- *   - `authorId` is everything after the first hyphen. May itself contain
- *     hyphens (the publisher uses `[^a-z0-9._-]` → `-` for unsafe chars
- *     in the platform-side id), so we split on the FIRST hyphen only.
+ *   - `platform` is the lowercase platform tag — letters/digits AND
+ *     HYPHENS. The schema's `LETTER_PREFIX_ID_REGEX =
+ *     /^[a-z][a-z0-9-]*$/` permits hyphenated names (`mcp-cli`,
+ *     `discord-bot`, `email-imap`).
+ *   - `authorId` is the remainder. Also may contain hyphens (the
+ *     publisher's `[^a-z0-9._-]` → `-` mapping for unsafe chars).
  *
- * Returns `undefined` for shapes that don't carry an embedded platform
- * (e.g. `andreas`, `luna`) — those flow through the legacy path
- * untouched.
+ * A naive first-hyphen split is therefore asymmetric with the
+ * publisher: `did:mf:mcp-cli-myUser123` (real tuple
+ * `(mcp-cli, myUser123)`) would split to `(mcp, cli-myUser123)` and
+ * miss the reverse lookup → silent denial-of-service for any
+ * principal whose platform name contains a hyphen. PR #483 closes
+ * that gap by consulting the engine's `knownPlatforms` set and
+ * picking the **longest** registered platform that prefixes the
+ * agent id (with the required `-` separator immediately after).
  *
- * Note: a hyphen by itself is ambiguous (a principal id like `my-agent`
- * would parse as platform=`my`, authorId=`agent`). The engine's reverse
- * index disambiguates: an unknown `(platform, authorId)` tuple simply
- * misses and the original agent-id is returned. So this helper is
- * permissive about parsing — the index is the authority on whether the
- * mapping is real.
+ * Disambiguation strategy:
+ *
+ *   1. **Longest-prefix match against `knownPlatforms`.** For each
+ *      registered platform `P`, the agent id matches when it starts
+ *      with `P + "-"` AND has a non-empty tail. Among all matches,
+ *      the longest `P` wins (so `mcp-cli` beats `mcp` when both are
+ *      registered). This is symmetric with the publisher: the
+ *      adapter that emitted the DID is the one that registered the
+ *      platform name with the engine, so the longest-matching
+ *      registered platform IS the publisher's platform.
+ *   2. **No match → return `undefined`.** Falling back to the
+ *      first-hyphen split would re-introduce the asymmetry (and
+ *      could mask config-drift bugs by silently parsing a tail
+ *      from an unregistered platform). Returning `undefined` makes
+ *      the caller fall through to the raw tail, the engine denies
+ *      `unknown_principal`, and the deny audit surfaces the issue.
+ *
+ * Returns `undefined` for shapes that don't carry a registered
+ * platform prefix (e.g. `andreas`, `luna`, or any platform-shape id
+ * whose platform isn't in `knownPlatforms`). Those flow through the
+ * legacy path untouched.
+ *
+ * **Note on principal-id ambiguity with hyphens.** A principal id
+ * like `my-agent` parsed against `knownPlatforms = ["my"]` would
+ * match as `(my, agent)`. This is by design: if an operator
+ * registered `my` as a platform AND named a principal `my-agent`,
+ * the reverse index is the authority — an `(my, agent)` miss
+ * returns `undefined` from `lookupPrincipalIdByPlatformId` and the
+ * caller falls through to the raw tail. The schema's tuple-
+ * uniqueness check prevents the genuine ambiguity (same id
+ * registered as both a principal and a platform identity).
  */
 function parsePlatformPrefixedAgentId(
   agentId: string,
+  knownPlatforms: Iterable<string>,
 ): { platform: string; authorId: string } | undefined {
-  const hyphen = agentId.indexOf("-");
-  if (hyphen <= 0 || hyphen === agentId.length - 1) return undefined;
+  let bestPlatform: string | undefined;
+  for (const platform of knownPlatforms) {
+    // Must be `<platform>-<non-empty-tail>`. `startsWith(platform +
+    // "-")` plus a bounds check that there's at least one char after
+    // the separator.
+    if (agentId.length <= platform.length + 1) continue;
+    if (!agentId.startsWith(`${platform}-`)) continue;
+    if (bestPlatform === undefined || platform.length > bestPlatform.length) {
+      bestPlatform = platform;
+    }
+  }
+  if (bestPlatform === undefined) return undefined;
   return {
-    platform: agentId.slice(0, hyphen),
-    authorId: agentId.slice(hyphen + 1),
+    platform: bestPlatform,
+    authorId: agentId.slice(bestPlatform.length + 1),
   };
 }
 

--- a/src/runner/dispatch-listener.ts
+++ b/src/runner/dispatch-listener.ts
@@ -1052,7 +1052,7 @@ function checkDispatchPolicy(
   payload: DispatchTaskReceivedPayload,
   sourceNetwork: string | undefined,
 ): DispatchPolicyResult {
-  const principalId = resolvePrincipalId(envelope, payload);
+  const principalId = resolvePrincipalId(envelope, payload, engine);
 
   // IAW Phase D.3 — surface `source_network` onto the intent when the
   // inbound wire subject was `federated.{network_id}.>`. The engine
@@ -1121,14 +1121,87 @@ function checkDispatchPolicy(
  * method, empty tail, multi-segment colon) we surface the raw string so
  * the engine receives a deterministic `unknown_principal` rather than
  * silent coercion (Echo cortex#220 round 2 S-1).
+ *
+ * **cortex#482 — adapter-originated platform-prefixed DIDs.** When the
+ * adapter publishes an envelope it sets
+ * `originator.identity = adapterOriginatorIdentity(platform, authorId) =
+ * did:mf:<platform>-<authorId>` (see
+ * `src/bus/dispatch-source-publisher.ts`). Stripping `did:mf:` yields
+ * a tail like `discord-1134325176796987522` — which is NOT a registered
+ * `Principal.id` (Andreas is declared as `andreas` with
+ * `platform_ids.discord = ["1134325176796987522"]`). To close the gap,
+ * once the bare segment matches `<platform>-<authorId>` and the engine
+ * is in hand, we consult `engine.lookupPrincipalIdByPlatformId(...)`
+ * for a reverse-lookup. A hit returns the registered principal id; a
+ * miss falls through to the raw platform-prefixed tail, which the
+ * engine then denies with `unknown_principal` — the existing security
+ * boundary is preserved.
+ *
+ * The engine arg is optional so legacy callers (and the no-engine
+ * fail-closed boot path) keep working without churn.
  */
 function resolvePrincipalId(
   envelope: Envelope,
   payload: DispatchTaskReceivedPayload,
+  engine?: PolicyEngine,
 ): string {
   const actorDid = getActorPrincipal(envelope);
   if (actorDid === undefined) return payload.agent_id;
-  return extractAgentIdFromDid(actorDid) ?? actorDid;
+  const agentId = extractAgentIdFromDid(actorDid);
+  if (agentId === undefined) return actorDid;
+  // IAW cortex#482 — adapter-originated DIDs of the shape
+  // `did:mf:<platform>-<authorId>` decode here to a `<platform>-<authorId>`
+  // tail. When the engine is supplied AND the tail matches that shape,
+  // attempt a `platform_ids[]` reverse-lookup. A direct `did:mf:<id>` (no
+  // platform-style hyphen prefix) skips the lookup and falls through to
+  // the existing behaviour; an unmapped platform identity also falls
+  // through to the raw tail (engine denies `unknown_principal`).
+  if (engine !== undefined) {
+    const platformMatch = parsePlatformPrefixedAgentId(agentId);
+    if (platformMatch !== undefined) {
+      const resolved = engine.lookupPrincipalIdByPlatformId(
+        platformMatch.platform,
+        platformMatch.authorId,
+      );
+      if (resolved !== undefined) return resolved;
+    }
+  }
+  return agentId;
+}
+
+/**
+ * IAW cortex#482 — split a `<platform>-<authorId>` bare agent-id segment
+ * (the tail of `did:mf:<platform>-<authorId>` after the `did:mf:` strip)
+ * into its `platform` + `authorId` parts.
+ *
+ * The grammar mirrors `adapterOriginatorIdentity` (publisher side):
+ *   - `platform` is the lowercase platform tag (`discord`, `mattermost`,
+ *     `slack`, …) — letters/digits, the same alphabet the publisher's
+ *     `prefix = platform.toLowerCase()` produces.
+ *   - `authorId` is everything after the first hyphen. May itself contain
+ *     hyphens (the publisher uses `[^a-z0-9._-]` → `-` for unsafe chars
+ *     in the platform-side id), so we split on the FIRST hyphen only.
+ *
+ * Returns `undefined` for shapes that don't carry an embedded platform
+ * (e.g. `andreas`, `luna`) — those flow through the legacy path
+ * untouched.
+ *
+ * Note: a hyphen by itself is ambiguous (a principal id like `my-agent`
+ * would parse as platform=`my`, authorId=`agent`). The engine's reverse
+ * index disambiguates: an unknown `(platform, authorId)` tuple simply
+ * misses and the original agent-id is returned. So this helper is
+ * permissive about parsing — the index is the authority on whether the
+ * mapping is real.
+ */
+function parsePlatformPrefixedAgentId(
+  agentId: string,
+): { platform: string; authorId: string } | undefined {
+  const hyphen = agentId.indexOf("-");
+  if (hyphen <= 0 || hyphen === agentId.length - 1) return undefined;
+  return {
+    platform: agentId.slice(0, hyphen),
+    authorId: agentId.slice(hyphen + 1),
+  };
 }
 
 /**


### PR DESCRIPTION
## Summary

Closes cortex#482 — the third (and last) gate blocking chat round-trip on Andreas's running stack.

Adapter-originated dispatches set `originator.identity = did:mf:<platform>-<authorId>` (e.g. `did:mf:discord-1134325176796987522` from `adapterOriginatorIdentity` in `src/bus/dispatch-source-publisher.ts`). The dispatch policy resolver previously stripped `did:mf:` and treated the literal tail `discord-1134325176796987522` as a `Principal.id`. That fails: Andreas is declared as principal `andreas` with `platform_ids.discord = ["1134325176796987522"]` — the platform_ids[] index was never consulted. Result: every Discord chat dispatch denied with `unknown_principal`.

Per the issue's recommended Option A (resolver-side mapping):

- Add optional `platform_ids` to the policy `Principal` interface.
- Build a `(platform, author_id) → principal_id` reverse index in the `PolicyEngine` constructor; expose `lookupPrincipalIdByPlatformId(platform, authorId)`.
- Thread `platform_ids` through `policyEngineFromConfig`.
- In `resolvePrincipalId` (dispatch-listener), once the originator DID decodes to a `<platform>-<authorId>` bare segment AND the engine is in hand, attempt the reverse lookup. A hit returns the registered principal id; a miss falls through to the raw tail so the engine still denies with `unknown_principal` — no security regression.

Non-platform DIDs (`did:mf:<principal-id>`) skip the lookup and preserve existing behaviour. Engines without the cortex#482 field behave identically to pre-fix.

## Files changed (6 / +425/-2)

| File | Change |
|---|---|
| `src/common/policy/types.ts` | `Principal.platform_ids?: Readonly<Record<string, readonly string[]>>` |
| `src/common/policy/engine.ts` | Reverse index + `lookupPrincipalIdByPlatformId` method |
| `src/common/policy/factory.ts` | Forward `p.platform_ids` from `Policy` into engine |
| `src/runner/dispatch-listener.ts` | `resolvePrincipalId(envelope, payload, engine?)` — platform-prefixed reverse-lookup before fall-through |
| `src/common/policy/__tests__/engine.test.ts` | 4 cases on the new lookup method |
| `src/runner/__tests__/dispatch-listener.test.ts` | 3 cases on the end-to-end resolver path |

## Test plan

- [x] `bunx tsc --noEmit` — clean
- [x] `bun test src/common/policy/__tests__/engine.test.ts src/runner/__tests__/dispatch-listener.test.ts` — 81 pass / 0 fail
- [x] `bun test` — 3566 pass / 2 skip / 0 fail
- [x] `bun run lint:errors` — clean
- [ ] Manual: mention Luna in #cortex on Andreas's stack; daemon log should no longer show `dispatch-listener: denied envelope ... reason=unknown_principal`; allow lifecycle envelopes fire and the response posts back.

## Refs

- cortex#479 (runner self-subscribe — first gate)
- cortex#481 (own-stack trust — second gate)
- CONTEXT.md §Identity & trust + §Dispatch-source

🤖 Generated with [Claude Code](https://claude.com/claude-code)