### PR TITLE
fix(runner): fire-and-forget CC spawn in render callback (closes #484)

### DIFF
--- a/src/runner/__tests__/dispatch-listener.test.ts
+++ b/src/runner/__tests__/dispatch-listener.test.ts
@@ -2839,3 +2839,192 @@ describe("dispatch-listener — platform-id originator resolution (cortex#482)",
     expect(captured[0]!.principalId).toBe("alice");
   });
 });
+
+// ---------------------------------------------------------------------------
+// cortex#484 — fire-and-forget render contract
+// ---------------------------------------------------------------------------
+
+describe("dispatch-listener — fire-and-forget render (cortex#484)", () => {
+  /**
+   * The surface-router enforces `DEFAULT_RENDER_TIMEOUT_MS = 5000`
+   * per adapter render. CC sessions run for minutes; awaiting them
+   * inside the render callback aborted every dispatch via timeout
+   * (cortex#484). The fix: render returns once the handler is
+   * initiated; the CC session lifecycle continues from within a
+   * tracked background promise.
+   *
+   * This test asserts the render contract directly: trigger an
+   * envelope whose harness blocks until we release it, measure that
+   * the surface-router's onEnvelope handler returns promptly, and
+   * that the terminal `dispatch.task.completed` lifecycle envelope
+   * still fires once the harness unblocks.
+   */
+  test("render returns within 100ms regardless of CC session duration", async () => {
+    const r = recordingRuntime();
+    const router = createSurfaceRouter(r.runtime);
+    // Factory whose wait() blocks until we explicitly release it.
+    let releaseSession: (() => void) | undefined;
+    const sessionUnblocked = new Promise<void>((resolve) => {
+      releaseSession = resolve;
+    });
+    const factory: CCSessionFactory = () => {
+      const session = {
+        start() {
+          return session;
+        },
+        async wait(): Promise<CCSessionResult> {
+          await sessionUnblocked;
+          return SUCCESS_RESULT;
+        },
+      };
+      return session;
+    };
+
+    const listener = createDispatchListener({
+      runtime: r.runtime,
+      router,
+      source: SOURCE,
+      ccSessionFactory: factory,
+      policyEngine: engineGranting(["dispatch.cortex"]),
+    });
+    await listener.start();
+    await router.start();
+
+    const start = performance.now();
+    // Trigger envelope through runtime fan-out. The surface-router's
+    // onEnvelope handler kicks off the render race; render itself
+    // must resolve promptly so the race never times out.
+    r.trigger(makeReceivedEnvelope(), CANONICAL_CORTEX_CHAT_SUBJECT);
+    // Yield microtasks so the render callback's synchronous wiring
+    // settles. The render callback's returned promise should already
+    // be resolved by this point.
+    await Promise.resolve();
+    await Promise.resolve();
+    const elapsed = performance.now() - start;
+
+    // Budget: render must return promptly. 100ms is the issue's
+    // acceptance criterion; in practice the synchronous wiring
+    // settles in single-digit ms.
+    expect(elapsed).toBeLessThan(100);
+
+    // The CC session is still blocked — no terminal lifecycle yet.
+    // Audit + lifecycle envelopes all fire from within the background
+    // promise, so they MAY have started; only the terminal envelope
+    // is guaranteed not to be there.
+    expect(
+      r.published.some((e) => e.type === "dispatch.task.completed"),
+    ).toBe(false);
+
+    // Unblock the session and let the lifecycle envelopes drain.
+    releaseSession!();
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    // Terminal completion landed — full lifecycle even though render
+    // returned long before.
+    const types = r.published.map((e) => e.type);
+    expect(types).toContain("dispatch.task.completed");
+
+    // Drain so the test exits cleanly.
+    await listener.stop();
+  });
+
+  /**
+   * stop() must drain the inFlight Set so background CC sessions
+   * have a chance to publish terminal envelopes before teardown.
+   * Mirrors BusDispatchListener's `await Promise.allSettled(inFlight)`
+   * pattern.
+   */
+  test("stop() drains in-flight background dispatch handlers", async () => {
+    const r = recordingRuntime();
+    const router = createSurfaceRouter(r.runtime);
+    let releaseSession: (() => void) | undefined;
+    const sessionUnblocked = new Promise<void>((resolve) => {
+      releaseSession = resolve;
+    });
+    const factory: CCSessionFactory = () => {
+      const session = {
+        start() {
+          return session;
+        },
+        async wait(): Promise<CCSessionResult> {
+          await sessionUnblocked;
+          return SUCCESS_RESULT;
+        },
+      };
+      return session;
+    };
+
+    const listener = createDispatchListener({
+      runtime: r.runtime,
+      router,
+      source: SOURCE,
+      ccSessionFactory: factory,
+      policyEngine: engineGranting(["dispatch.cortex"]),
+    });
+    await listener.start();
+    await router.start();
+
+    r.trigger(makeReceivedEnvelope(), CANONICAL_CORTEX_CHAT_SUBJECT);
+    // Give the render kickoff a tick to register the inFlight promise.
+    await Promise.resolve();
+
+    // Kick off stop() — it must NOT return until inFlight drains.
+    // We race it against the session-release so we can prove it's
+    // actually waiting.
+    let stopResolved = false;
+    const stopPromise = listener.stop().then(() => {
+      stopResolved = true;
+    });
+    // A few microtask + macrotask flushes — stop() should still be
+    // waiting on the blocked session.
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(stopResolved).toBe(false);
+
+    // Release the session — stop() unblocks once the handler's
+    // terminal envelope publish settles.
+    releaseSession!();
+    await stopPromise;
+    expect(stopResolved).toBe(true);
+
+    // Terminal envelope did fire — confirms the inFlight drain
+    // captured the in-progress dispatch all the way to completion.
+    expect(
+      r.published.some((e) => e.type === "dispatch.task.completed"),
+    ).toBe(true);
+  });
+
+  /**
+   * Lifecycle envelopes (started/completed) must fire from within
+   * the background promise even though render has already returned.
+   */
+  test("dispatch.task lifecycle envelopes still fire after render returns", async () => {
+    const r = recordingRuntime();
+    const router = createSurfaceRouter(r.runtime);
+    const { factory } = fakeFactory(SUCCESS_RESULT);
+    const listener = createDispatchListener({
+      runtime: r.runtime,
+      router,
+      source: SOURCE,
+      ccSessionFactory: factory,
+      policyEngine: engineGranting(["dispatch.cortex"]),
+    });
+    await listener.start();
+    await router.start();
+
+    r.trigger(makeReceivedEnvelope(), CANONICAL_CORTEX_CHAT_SUBJECT);
+    // Drain — the fake factory resolves synchronously inside its
+    // wait(), so a short setTimeout yields enough for the background
+    // promise to walk the harness's lifecycle.
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    const types = r.published.map((e) => e.type);
+    expect(types).toEqual([
+      "system.access.allowed",
+      "dispatch.task.started",
+      "dispatch.task.completed",
+    ]);
+    for (const env of r.published) {
+      expect(env.correlation_id).toBe(TASK_ID);
+    }
+  });
+});

--- a/src/runner/dispatch-listener.ts
+++ b/src/runner/dispatch-listener.ts
@@ -423,6 +423,26 @@ export function createDispatchListener(
   interface RuntimeSubscriber { stop(): Promise<void>; }
   let runtimeSubscribers: RuntimeSubscriber[] = [];
 
+  // cortex#484 — in-flight dispatch handlers tracked for fire-and-forget
+  // background execution. The surface-router enforces a per-render
+  // `DEFAULT_RENDER_TIMEOUT_MS = 5000` (`surface-router.ts:242`) to
+  // protect against hung adapters; CC sessions legitimately run for
+  // minutes, so awaiting them inside the `render` callback aborts
+  // every dispatch via timeout. We instead kick off the handler as a
+  // tracked background promise and return immediately from `render`;
+  // the CC session lifecycle continues to fire `dispatch.task.{started,
+  // completed,failed}` envelopes from within the background promise.
+  //
+  // Mirrors the `BusDispatchListener` `inFlight` + `trackInFlight` +
+  // `stop()`-drain pattern (`src/bus/bus-dispatch-listener.ts`) so the
+  // listener can be cleanly torn down in tests / shutdown without
+  // late publish side effects landing on a closed channel.
+  const inFlight = new Set<Promise<void>>();
+  function trackInFlight(p: Promise<void>): void {
+    inFlight.add(p);
+    void p.finally(() => inFlight.delete(p));
+  }
+
   const surfaceConfig: SurfaceAdapter = {
     id: adapterId,
     subjects,
@@ -436,21 +456,50 @@ export function createDispatchListener(
     // iteration can wire `signal.aborted` to `harness.shutdown({ graceful:
     // false })` so surface-router timeouts end the CC process eagerly
     // rather than waiting for cc-session's internal timer to fire.
-    render: (envelope, _signal, subject) =>
-      handleDispatchEnvelope(envelope, subject, {
-        runtime,
-        source,
-        ccSessionFactory,
-        agentTeamFactory,
-        policyEngine,
-        stack: opts.stack,
-        trustResolver,
-        cryptoVerify,
-        principalId,
-        receivingAgentId,
-        stackIdentity,
-        stackNKeyPub,
-      }),
+    //
+    // cortex#484 — `render` returns once the handler is INITIATED, not
+    // once it completes. The handler runs as a fire-and-forget tracked
+    // promise so the surface-router's 5s render-timeout doesn't abort
+    // long-running CC sessions. Errors from the background handler are
+    // caught locally so the unhandled-rejection contract is preserved.
+    render: (envelope, _signal, subject) => {
+      const work = (async () => {
+        try {
+          await handleDispatchEnvelope(envelope, subject, {
+            runtime,
+            source,
+            ccSessionFactory,
+            agentTeamFactory,
+            policyEngine,
+            stack: opts.stack,
+            trustResolver,
+            cryptoVerify,
+            principalId,
+            receivingAgentId,
+            stackIdentity,
+            stackNKeyPub,
+          });
+        } catch (err) {
+          // The handler already publishes structured failure envelopes
+          // for every modeled error path (parse, verify, policy deny,
+          // harness throw). Anything that escapes is a programming
+          // error or runtime-stub assertion — log it so it doesn't
+          // disappear into an unhandled-rejection void, but don't
+          // re-throw: render has already returned and there's nothing
+          // upstream to receive the throw.
+          process.stderr.write(
+            `[runner/dispatch-listener] background handler threw on ` +
+              `envelope ${envelope.id} (correlation_id=` +
+              `${envelope.correlation_id ?? "<none>"}): ` +
+              `${err instanceof Error ? err.message : String(err)}\n`,
+          );
+        }
+      })();
+      trackInFlight(work);
+      // Resolve immediately — the surface-router's render-timeout race
+      // sees a fast-settling promise and never trips.
+      return Promise.resolve();
+    },
   };
 
   return {
@@ -491,6 +540,16 @@ export function createDispatchListener(
       const drained = runtimeSubscribers;
       runtimeSubscribers = [];
       await Promise.allSettled(drained.map((s) => s.stop()));
+      // cortex#484 — drain in-flight background dispatch handlers
+      // before returning. Mirrors BusDispatchListener.stop()'s drain
+      // (`Promise.allSettled(this.inFlight)`) so test teardown and
+      // graceful shutdown can `await listener.stop()` and trust that
+      // no late publish side effects land on a closed channel. The
+      // unregister() above already prevents NEW renders from arriving;
+      // this drain ensures already-initiated CC sessions get a chance
+      // to publish their terminal lifecycle envelopes before the
+      // runtime tears down.
+      await Promise.allSettled(Array.from(inFlight));
     },
   };
 }


### PR DESCRIPTION
## Summary

Per cortex#484: the surface-router enforces a 5s render-timeout per adapter to protect against hung renderers. CC sessions take minutes; awaiting them in the render callback aborted every dispatch via timeout (`render timeout after 5000ms`).

## Fix

- Extract `handleDispatchEnvelope` into a fire-and-forget background promise, tracked in an `inFlight: Set<Promise<void>>` collection
- Mirrors `BusDispatchListener`'s `inFlight + trackInFlight + stop-drain` pattern (`src/bus/bus-dispatch-listener.ts`)
- `render` returns `Promise.resolve()` immediately once the handler is initiated
- Lifecycle envelopes (`system.access.allowed/denied`, `dispatch.task.{started,completed,failed,aborted}`) continue to fire from within the background promise
- `stop()` drains `inFlight` with `Promise.allSettled` so background CC sessions get a chance to publish terminal envelopes before teardown
- Background handler errors caught locally and written to stderr (the handler already publishes structured failure envelopes for every modeled error path; anything that escapes is a programming error)

## Architectural note (out of scope for this fix)

The runner-dispatch-listener is wired through the surface-router as a `SurfaceAdapter`, but per `docs/architecture.md` §3.4 and `CONTEXT.md` §Dispatch sink, the surface-router's render path is intended for **outbound** lifecycle envelopes going to dispatch sinks (Discord post, dashboard update). The runner is a **consumer/executor** upstream of the surface-router. The `SurfaceAdapter` shape reuse is deliberate per the file-level doc-comment (lines 47-56) — "the runner is logically *also* a surface ... re-using the same shape keeps the router code path uniform" — but the render-timeout was always inappropriate for CC spawn.

A follow-up could mirror `BusDispatchListener` and consume inbound envelopes via `runtime.onEnvelope()` directly, bypassing the surface-router for the runner path entirely (Option D from the issue discussion). That is a deeper architectural refactor — federation gate, visibility filter, subject pattern matching all need re-implementing on the listener side. Out of scope for this P0 timeout fix; the fire-and-forget pattern here closes the immediate bug and is itself architecturally sound (matches `BusDispatchListener`'s `inFlight` pattern).

## Test plan

- [x] `bunx tsc --noEmit` clean
- [x] `bun test src/runner/__tests__/dispatch-listener.test.ts` — 67/67 pass (3 new cortex#484 tests)
- [x] `bun test` — 3574/3574 pass
- [x] `bun run lint:errors` — clean
- [ ] Acceptance test on Andreas's running stack: mention Luna in #cortex; verify no `render timeout after 5000ms` in daemon log; verify channel response posts

## New tests (cortex#484)

- `render returns within 100ms regardless of CC session duration` — blocks the CC harness, measures render-return time
- `stop() drains in-flight background dispatch handlers` — proves stop() waits on blocked CC sessions
- `dispatch.task lifecycle envelopes still fire after render returns` — full lifecycle drain even with fast-returning render

Closes cortex#484.