### PR TITLE
fix(cortex): C-486 — move platform-id resolution to dispatch-source (closes #486)

### DIFF
--- a/src/bus/__tests__/dispatch-handler.test.ts
+++ b/src/bus/__tests__/dispatch-handler.test.ts
@@ -7,11 +7,45 @@ import type { Envelope } from "../myelin/envelope-validator";
 import type { MyelinRuntime } from "../myelin/runtime";
 import type { DispatchSourcePublishResult } from "../dispatch-source-publisher";
 import { validateEnvelope } from "../myelin/envelope-validator";
+import { PolicyEngine } from "../../common/policy/engine";
 import type {
   CCSessionFactory,
   CCSessionLike,
 } from "../../substrates/claude-code/harness";
 import type { CCSessionResult, CCSessionOpts } from "../../runner/cc-session";
+
+/**
+ * cortex#486 — adapter-side platform-id → principal resolution at
+ * envelope-publish time requires a wired PolicyEngine. This helper
+ * builds an engine that resolves the two `(platform, authorId)` tuples
+ * the publish-path tests use:
+ *
+ *   - `(discord, 1487204875912609844)` → `andreas`
+ *   - `(mattermost, 8wkrnxq3abcdef)` → `andreas`
+ *
+ * Tests that exercise unresolvable inputs (the cortex#420 nit-5
+ * DID-grammar collision case) pass `policyEngine: undefined` so the
+ * publish refuses with `invalid-originator` — same surface, different
+ * root cause from the pre-#486 fallback.
+ */
+function makePublishPolicyEngine(): PolicyEngine {
+  return new PolicyEngine({
+    principals: [
+      {
+        id: "andreas",
+        home_operator: "andreas",
+        home_stack: "andreas/research",
+        role: ["operator"],
+        trust: [],
+        platform_ids: {
+          discord: ["1487204875912609844"],
+          mattermost: ["8wkrnxq3abcdef"],
+        },
+      },
+    ],
+    roles: [{ id: "operator", capabilities: ["dispatch.test-agent"] }],
+  });
+}
 
 // Minimal config that satisfies AgentConfig shape for testing
 function makeConfig(overrides: Partial<AgentConfig> = {}): AgentConfig {
@@ -1006,6 +1040,7 @@ describe("DispatchHandler — Direction A Stage 4-B inbound envelope publish (co
         instance: "local",
       },
       stack: "meta-factory",
+      policyEngine: makePublishPolicyEngine(),
     });
 
     const published = await callPublishInboundDispatchEnvelope(
@@ -1027,9 +1062,11 @@ describe("DispatchHandler — Direction A Stage 4-B inbound envelope publish (co
     expect(envelope.type).toBe("tasks.chat");
     expect(envelope.distribution_mode).toBe("direct");
     expect(envelope.target_assistant).toBe("did:mf:test-agent");
-    expect(envelope.originator?.identity).toBe(
-      "did:mf:discord-1487204875912609844",
-    );
+    // cortex#486 — `originator.identity` is the RESOLVED principal DID
+    // (`did:mf:andreas`), not a platform-prefixed snowflake. The
+    // dispatch source did the `(discord, 1487...) → andreas` lookup at
+    // publish time via the wired PolicyEngine.
+    expect(envelope.originator?.identity).toBe("did:mf:andreas");
     expect(envelope.originator?.attribution).toBe("adapter-resolved");
     expect(envelope.sovereignty.classification).toBe("local");
     expect(envelope.sovereignty.data_residency).toBe("NZ");
@@ -1074,6 +1111,7 @@ describe("DispatchHandler — Direction A Stage 4-B inbound envelope publish (co
         instance: "local",
       },
       // no stack
+      policyEngine: makePublishPolicyEngine(),
     });
 
     const published = await callPublishInboundDispatchEnvelope(
@@ -1102,6 +1140,7 @@ describe("DispatchHandler — Direction A Stage 4-B inbound envelope publish (co
         dataResidency: "AU",
       },
       stack: "meta-factory",
+      policyEngine: makePublishPolicyEngine(),
     });
 
     await callPublishInboundDispatchEnvelope(handler, dispatchOpts());
@@ -1177,7 +1216,11 @@ describe("DispatchHandler — Direction A Stage 4-B inbound envelope publish (co
     await handler.shutdown();
   });
 
-  test("mattermost authorId encodes onto did:mf:mattermost- prefix", async () => {
+  test("mattermost authorId resolves to principal DID — `did:mf:andreas` (cortex#486)", async () => {
+    // cortex#486: the publish-time resolution is platform-agnostic. The
+    // engine maps `(mattermost, 8wkrnxq3abcdef) → andreas`; the envelope
+    // carries the resolved principal DID — no platform-prefixed shape
+    // ever lands on the wire.
     const runtime = makeRecordingRuntimeWithSubject();
     const handler = new DispatchHandler({
       config: makeConfig(),
@@ -1189,6 +1232,7 @@ describe("DispatchHandler — Direction A Stage 4-B inbound envelope publish (co
         instance: "local",
       },
       stack: "meta-factory",
+      policyEngine: makePublishPolicyEngine(),
     });
     await callPublishInboundDispatchEnvelope(
       handler,
@@ -1201,20 +1245,20 @@ describe("DispatchHandler — Direction A Stage 4-B inbound envelope publish (co
     );
     expect(
       runtime.subjectPublishes[0]?.envelope.originator?.identity,
-    ).toBe("did:mf:mattermost-8wkrnxq3abcdef");
+    ).toBe("did:mf:andreas");
     await handler.shutdown();
   });
 
-  test("exotic authorId with no DID-valid encoding → returns false, no publish (cortex#420 nit-5)", async () => {
-    // After the cortex#420 nit-5 fix, `adapterOriginatorIdentity`
-    // returns `null` (rather than a collision-prone `{prefix}-unknown`
-    // fallback) when the resulting candidate fails myelin's `DID_RE`.
-    // An authorId composed entirely of characters outside `[a-z0-9._-]`
-    // collapses to all-hyphens after the safe-id replace step, which
-    // produces a candidate containing `--` — rejected by DID_RE's
-    // `-(?!-)` clause. `publishInboundDispatchEnvelope` MUST return
-    // `false` so callers can distinguish a failed canonical publish, and
-    // no envelope is published on the bus.
+  test("unresolvable platform identity → returns false, no publish (cortex#486)", async () => {
+    // cortex#486 — the dispatch source resolves `(platform, authorId)`
+    // through the wired PolicyEngine; an unmapped tuple yields a null
+    // originator identity and `publishInboundDispatchEnvelope` returns
+    // `false`. Pre-#486 this test exercised the DID_RE rejection of
+    // platform-prefixed shapes (cortex#420 nit-5); post-#486 that
+    // grammar concern is moot because the publish never emits a
+    // platform-prefixed DID in the first place. The publish-time
+    // refusal IS the security boundary — the engine doesn't authorise
+    // an unknown Discord user just because they typed in chat.
     const runtime = makeRecordingRuntimeWithSubject();
     const handler = new DispatchHandler({
       config: makeConfig(),
@@ -1226,17 +1270,46 @@ describe("DispatchHandler — Direction A Stage 4-B inbound envelope publish (co
         instance: "local",
       },
       stack: "meta-factory",
+      policyEngine: makePublishPolicyEngine(),
     });
     const published = await callPublishInboundDispatchEnvelope(
       handler,
       dispatchOpts({
         msg: makeMsg({
           platform: "discord",
-          // `!!!` → safe-id `---` → candidate `did:mf:discord----`
-          // contains `--`, fails DID_RE.
-          authorId: "!!!",
+          // Discord snowflake that no principal claims — engine returns
+          // undefined; publish refuses with `invalid-originator`.
+          authorId: "999999999999999999",
         }),
       }),
+    );
+    expect(published).toBe(false);
+    expect(runtime.subjectPublishes.length).toBe(0);
+    await handler.shutdown();
+  });
+
+  test("missing policyEngine → returns false, no publish (cortex#486 fail-closed)", async () => {
+    // cortex#486 — without a wired PolicyEngine the dispatch source
+    // cannot resolve `(platform, authorId)` to a principal. The publish
+    // fails closed with `invalid-originator` rather than emitting a
+    // platform-prefixed DID. Production boots without an engine only
+    // when no `policy:` block is declared (deliberately rare).
+    const runtime = makeRecordingRuntimeWithSubject();
+    const handler = new DispatchHandler({
+      config: makeConfig(),
+      securityPreamble: "",
+      runtime,
+      systemEventSource: {
+        principal: "andreas",
+        agent: "cortex",
+        instance: "local",
+      },
+      stack: "meta-factory",
+      // no policyEngine
+    });
+    const published = await callPublishInboundDispatchEnvelope(
+      handler,
+      dispatchOpts(),
     );
     expect(published).toBe(false);
     expect(runtime.subjectPublishes.length).toBe(0);
@@ -1282,6 +1355,7 @@ describe("DispatchHandler — Direction A Stage 4-B inbound envelope publish (co
       },
       stack: "meta-factory",
       ccSessionFactory: ccFactory,
+      policyEngine: makePublishPolicyEngine(),
     });
     await handler.handleMessage(
       adapter,
@@ -1333,6 +1407,7 @@ describe("DispatchHandler — Direction A Stage 4-B inbound envelope publish (co
       },
       stack: "meta-factory",
       ccSessionFactory: ccFactory,
+      policyEngine: makePublishPolicyEngine(),
     });
     try {
       await handler.handleMessage(
@@ -1387,6 +1462,7 @@ describe("DispatchHandler — Direction A Stage 4-B inbound envelope publish (co
       },
       stack: "meta-factory",
       ccSessionFactory: ccFactory,
+      policyEngine: makePublishPolicyEngine(),
     });
 
     await handler.handleMessage(
@@ -1394,7 +1470,11 @@ describe("DispatchHandler — Direction A Stage 4-B inbound envelope publish (co
       makeMsg({
         content: "hello",
         platform: "discord",
-        authorId: "!!!",
+        // cortex#486 — unresolvable Discord snowflake (no principal
+        // claims it). Engine returns undefined → publish refuses with
+        // `invalid-originator`; the apology surface fires the same
+        // user-facing message it did pre-#486 for grammar-invalid ids.
+        authorId: "999999999999999999",
       }),
     );
 

--- a/src/bus/dispatch-handler.ts
+++ b/src/bus/dispatch-handler.ts
@@ -59,6 +59,7 @@ import {
   publishInboundChatDispatchEnvelope,
   type DispatchSourcePublishResult,
 } from "./dispatch-source-publisher";
+import type { PolicyEngine } from "../common/policy/engine";
 import { join } from "path";
 
 /** Read version from arc-manifest.yaml (cached after first read). */
@@ -139,6 +140,17 @@ export interface DispatchHandlerOpts {
    * matching the listener's stack-less subscription path.
    */
   stack?: string;
+  /**
+   * cortex#486 — PolicyEngine consulted at envelope-publish time to
+   * resolve the inbound `(platform, authorId)` tuple to a registered
+   * principal id. Required for the dispatch-source publish path: per
+   * CONTEXT.md §Dispatch-source the adapter populates
+   * `originator.identity` with the **resolved** principal DID. Boot
+   * paths without a `policy:` block leave this undefined; the
+   * dispatch-source publish then refuses with `invalid-originator`
+   * (deliberate fail-closed posture).
+   */
+  policyEngine?: PolicyEngine;
 }
 
 /**
@@ -216,6 +228,11 @@ export class DispatchHandler extends EventEmitter {
    * See `DispatchHandlerOpts.stack`.
    */
   private readonly stack: string | undefined;
+  /**
+   * cortex#486 — PolicyEngine for adapter-side platform-id resolution
+   * at envelope-publish time. See `DispatchHandlerOpts.policyEngine`.
+   */
+  private readonly policyEngine: PolicyEngine | undefined;
 
   constructor(opts: DispatchHandlerOpts) {
     super();
@@ -233,6 +250,7 @@ export class DispatchHandler extends EventEmitter {
     this.retryMaxAttempts = opts.retry?.maxAttempts ?? DEFAULT_RETRY_MAX_ATTEMPTS;
     this.retryMaxTotalMs = opts.retry?.maxTotalMs ?? DEFAULT_RETRY_MAX_TOTAL_MS;
     this.stack = opts.stack;
+    this.policyEngine = opts.policyEngine;
     this.sessions = new SessionManager({ idleTimeoutMs: 10 * 60 * 1000 });
     this.taskTracker = new TaskTracker();
 
@@ -404,6 +422,7 @@ export class DispatchHandler extends EventEmitter {
       stack: this.stack,
       agentName: this.config.agent.name,
       agentDisplayName: this.config.agent.displayName,
+      policyEngine: this.policyEngine,
       ...opts,
     });
     if (result.published) {

--- a/src/bus/dispatch-source-publisher.ts
+++ b/src/bus/dispatch-source-publisher.ts
@@ -1,6 +1,7 @@
 import { directTaskSubject } from "@the-metafactory/myelin/subjects";
 import { DID_RE } from "@the-metafactory/myelin/identity";
 import type { InboundMessage } from "../adapters/types";
+import type { PolicyEngine } from "../common/policy/engine";
 import { buildBaseEnvelope } from "./envelope-builder";
 import type { Envelope } from "./myelin/envelope-validator";
 import type { MyelinRuntime } from "./myelin/runtime";
@@ -36,6 +37,17 @@ export interface InboundChatDispatchPublishOpts {
   project: string | undefined;
   entity: string | undefined;
   operator: string | undefined;
+  /**
+   * cortex#486 — PolicyEngine consulted at publish time to resolve the
+   * inbound `(platform, authorId)` tuple to a registered principal id.
+   * The adapter is the right layer for this lookup per
+   * CONTEXT.md §Dispatch-source — `originator.identity` MUST carry the
+   * **resolved** principal DID (`did:mf:<principal-id>`), never a
+   * platform-prefixed snowflake. When the engine is absent OR cannot
+   * resolve the tuple, the publish is refused with reason
+   * `invalid-originator`; the caller surfaces a degraded dispatch.
+   */
+  policyEngine: PolicyEngine | undefined;
 }
 
 export interface DispatchSourcePublishResult {
@@ -51,16 +63,39 @@ export interface DispatchSourcePublishResult {
 }
 
 /**
- * Map a platform-side author identifier onto a DID-grammar-compliant
- * `did:mf:<name>` string suitable for `originator.identity`.
+ * Resolve a platform-side author identifier to a registered principal DID
+ * (`did:mf:<principal-id>`), suitable for `originator.identity` on an
+ * inbound dispatch envelope.
+ *
+ * cortex#486 — resolution belongs at the dispatch source (this layer),
+ * not at the consume-side resolver. Per CONTEXT.md §Dispatch-source the
+ * adapter populates `originator.identity` with the **resolved** human/
+ * agent DID. Pre-#486 this function emitted a platform-prefixed DID
+ * (`did:mf:<platform>-<authorId>`) which forced the runner's
+ * `resolvePrincipalId` to do a reverse-lookup. That snowflake DID shape
+ * is no longer produced anywhere in the codebase.
+ *
+ * Returns:
+ *   - `did:mf:<principal-id>` when the engine maps `(platform, authorId)`
+ *     to a registered principal AND the result passes myelin's `DID_RE`.
+ *   - `null` when the engine is absent (boot-without-policy), the tuple
+ *     isn't registered (unknown platform identity), OR the resolved id
+ *     can't be encoded as a DID-grammar-compliant tail. The caller
+ *     refuses the publish with a clear `invalid-originator` reason — no
+ *     anonymous-principal fallback, no platform-prefixed leakage.
  */
 export function adapterOriginatorIdentity(
+  engine: PolicyEngine | undefined,
   platform: string,
   authorId: string,
 ): string | null {
-  const prefix = platform.toLowerCase();
-  const safeId = authorId.toLowerCase().replace(/[^a-z0-9._-]/g, "-");
-  const candidate = `did:mf:${prefix}-${safeId}`;
+  if (engine === undefined) return null;
+  const principalId = engine.lookupPrincipalIdByPlatformId(
+    platform.toLowerCase(),
+    authorId,
+  );
+  if (principalId === undefined) return null;
+  const candidate = `did:mf:${principalId}`;
   if (DID_RE.test(candidate)) return candidate;
   return null;
 }
@@ -106,12 +141,16 @@ export async function publishInboundChatDispatchEnvelope(
   }
 
   const originatorIdentity = adapterOriginatorIdentity(
+    opts.policyEngine,
     opts.msg.platform,
     opts.msg.authorId,
   );
   if (originatorIdentity === null) {
     console.error(
-      `dispatch-source: cannot derive DID-valid originator identity for platform=${opts.msg.platform} authorId=${opts.msg.authorId}`,
+      `dispatch-source: cannot resolve platform identity to a registered principal — platform=${opts.msg.platform} authorId=${opts.msg.authorId}` +
+        (opts.policyEngine === undefined
+          ? " (no policy engine wired — boot without policy:)"
+          : " (engine: unknown platform tuple)"),
     );
     return { published: false, subject, reason: "invalid-originator" };
   }

--- a/src/common/policy/__tests__/engine.test.ts
+++ b/src/common/policy/__tests__/engine.test.ts
@@ -226,12 +226,20 @@ describe("PolicyEngine — sovereignty (C.1 smoke)", () => {
   });
 });
 
-describe("PolicyEngine — platform-id reverse lookup (cortex#482)", () => {
-  // cortex#482 — adapter-originated envelopes set
-  // `originator.identity = did:mf:<platform>-<authorId>` (e.g.
-  // `did:mf:discord-1134325176796987522`). The dispatch resolver
-  // back-resolves this to a registered `Principal.id` by consulting
-  // `Principal.platform_ids[platform][]` via the engine's reverse index.
+describe("PolicyEngine — platform-id reverse lookup (cortex#482 / cortex#486)", () => {
+  // cortex#482 introduced the engine-side reverse index from
+  // `Principal.platform_ids[platform][]` to a principal id. The
+  // resolver-side use of it shipped in PR #483 and was reverted in
+  // cortex#486, which moved the lookup to the dispatch-source publisher
+  // (`adapterOriginatorIdentity` in `src/bus/dispatch-source-publisher.ts`).
+  //
+  // The engine surface (`lookupPrincipalIdByPlatformId` + `knownPlatforms`)
+  // remains — it is now consumed at envelope-publish time by the adapter
+  // layer so `originator.identity` carries the RESOLVED principal DID
+  // (`did:mf:<principal-id>`), per CONTEXT.md §Dispatch-source. The
+  // post-#486 dispatch-listener no longer calls this surface; an
+  // illustrative example like `did:mf:discord-1134325176796987522` is
+  // therefore no longer produced anywhere in cortex.
 
   test("registered (platform, author_id) tuple → principal id", () => {
     const engine = new PolicyEngine({

--- a/src/common/policy/engine.ts
+++ b/src/common/policy/engine.ts
@@ -132,24 +132,26 @@ export class PolicyEngine {
    * later principal in the constructor list wins (last-write semantics,
    * consistent with `principalsById`'s `new Map(...)` collision rule).
    *
-   * **Duplication note (PR #483 — keep in sync with
-   * `PlatformPrincipalIndex` in `src/common/policy/policy-gate.ts`).**
-   * `PlatformPrincipalIndex` builds the same `(platform, platform_id)
-   * → principal_id` lookup from the same `policy.principals[]` shape,
-   * for adapter-side `resolvePolicyAccess`. Both indexes are kept
-   * because they serve different boundaries:
+   * **Duplication note (keep in sync with `PlatformPrincipalIndex` in
+   * `src/common/policy/policy-gate.ts`).** `PlatformPrincipalIndex`
+   * builds the same `(platform, platform_id) → principal_id` lookup
+   * from the same `policy.principals[]` shape, for adapter-side
+   * `resolvePolicyAccess`.
    *
-   *   - `PlatformPrincipalIndex` runs adapter-side, BEFORE the
-   *     envelope hits the bus. The adapter has the platform + raw
-   *     platform-id in hand (e.g. Discord snowflake) and just needs
-   *     `resolve(platform, id)` to construct the originator DID.
-   *   - This engine-side index runs bus-side, AFTER the envelope is
-   *     verified. The runner has only a flat `did:mf:<platform>-<id>`
-   *     string and needs both (a) the platform set, for
-   *     longest-prefix disambiguation (see {@link knownPlatforms}),
-   *     and (b) the reverse lookup. Holding the registry here lets
-   *     `dispatch-listener.ts` consume policy decisions without
-   *     pulling in `policy-gate.ts` (adapter-layer module).
+   * Pre-#486: both indexes were kept because they served different
+   * boundaries — `PlatformPrincipalIndex` adapter-side BEFORE publish,
+   * this index runner-side AFTER verify (PR #483 used it to back-
+   * resolve platform-prefixed originator DIDs to a principal id).
+   *
+   * Post-#486: the runner no longer consumes this index — the dispatch
+   * source resolves `(platform, authorId)` to a principal at publish
+   * time so `originator.identity` lands on the wire as the resolved
+   * principal DID. This index remains because (a) it's the engine's
+   * native surface (`lookupPrincipalIdByPlatformId`) and the
+   * dispatch-source now consumes it from there rather than depending
+   * on `policy-gate.ts`, and (b) keeping a single registry inside the
+   * engine avoids drift between dispatch-source and federation
+   * surfaces that may also want the reverse lookup in future.
    *
    * Schema-side changes (case-folding, platform-name canonicalisation,
    * deprecation) must land in BOTH places or the boundaries drift.
@@ -193,18 +195,24 @@ export class PolicyEngine {
    * claims that platform identity.
    *
    * Consumes the reverse index built from
-   * `Principal.platform_ids[platform][]` at construction. The
-   * dispatch-listener's `resolvePrincipalId` calls this when an
-   * adapter-originated envelope's `originator.identity` decodes to a
-   * platform-prefixed shape (`did:mf:<platform>-<authorId>` per
-   * `adapterOriginatorIdentity` in
-   * `src/bus/dispatch-source-publisher.ts`).
+   * `Principal.platform_ids[platform][]` at construction. Post-#486
+   * the canonical caller is the dispatch-source publisher
+   * (`adapterOriginatorIdentity` in
+   * `src/bus/dispatch-source-publisher.ts`), which performs the
+   * `(platform, authorId) → principal-id` resolution at envelope
+   * publish time so `originator.identity` carries the RESOLVED
+   * principal DID (`did:mf:<principal-id>`). PR #483 briefly used
+   * this surface from the dispatch-listener's `resolvePrincipalId`
+   * for a back-resolve when the publisher emitted a platform-
+   * prefixed DID; cortex#486 reverted that and moved the lookup
+   * adapter-side, restoring the CONTEXT.md §Dispatch-source
+   * "adapter populates `originator.identity` with the **resolved**
+   * human/agent DID" contract.
    *
    * Returning `undefined` for unknown tuples is the security
-   * default: the caller forwards the raw platform-prefixed id to
-   * `check()`, which then denies with `unknown_principal`. No
-   * platform identity gets implicitly authorised by failure to
-   * resolve.
+   * default: the adapter refuses the publish with
+   * `invalid-originator`. No platform identity gets implicitly
+   * authorised by failure to resolve.
    */
   lookupPrincipalIdByPlatformId(
     platform: string,
@@ -217,25 +225,18 @@ export class PolicyEngine {
    * IAW cortex#483 — registered platform names (the keys of the
    * `platform → author_id → principal_id` reverse index).
    *
-   * Exposed so callers can disambiguate platform-prefixed agent ids
-   * by longest-prefix match against the registered set. Required
-   * because `adapterOriginatorIdentity` joins `<platform>-<authorId>`
-   * with a single hyphen separator AND the schema's
-   * `LETTER_PREFIX_ID_REGEX = /^[a-z][a-z0-9-]*$/` permits hyphenated
-   * platform names (e.g. `mcp-cli`, `discord-bot`, `email-imap`).
-   * A naive first-hyphen split of `did:mf:mcp-cli-myUser123` yields
-   * `(platform=mcp, authorId=cli-myUser123)` which misses the real
-   * key `(mcp-cli, myUser123)` — silent denial-of-service for
-   * hyphenated-platform principals.
+   * Originally introduced (PR #483) so the dispatch-listener could
+   * disambiguate platform-prefixed agent ids by longest-prefix match
+   * against the registered set. cortex#486 retired that consumer:
+   * platform-id resolution now happens at the dispatch source, which
+   * has the `(platform, authorId)` tuple directly and doesn't need to
+   * disambiguate after-the-fact from a flattened DID tail.
    *
-   * The dispatch-listener's `parsePlatformPrefixedAgentId` iterates
-   * this set and picks the longest registered platform that prefixes
-   * the agent id, breaking the ambiguity symmetrically with the
-   * publisher.
-   *
-   * Returns an `Iterable` (not an array snapshot) to avoid
-   * materialising a copy on every dispatch; callers that need
-   * stable iteration should spread it.
+   * The surface stays — it's still useful for ad-hoc diagnostics
+   * (e.g. enumerating which platforms are policy-registered in boot
+   * logs, or unit tests that exercise the reverse index). Returns an
+   * `Iterable` (not an array snapshot) to avoid materialising a copy
+   * on every call; callers that need stable iteration should spread.
    */
   get knownPlatforms(): Iterable<string> {
     return this.principalIdByPlatformId.keys();

--- a/src/common/policy/types.ts
+++ b/src/common/policy/types.ts
@@ -67,15 +67,21 @@ export interface Principal {
    */
   readonly trust: readonly string[];
   /**
-   * IAW cortex#482 — platform-author-id → principal mapping.
+   * IAW cortex#482 + cortex#486 — platform-author-id → principal
+   * mapping.
    *
    * Open record of `<platform_name> → <author_id>[]`, mirroring
-   * `PolicyPrincipalSchema.platform_ids` on cortex.yaml. The engine
-   * consumes this to back-resolve adapter-originated DIDs of the
-   * shape `did:mf:<platform>-<authorId>` (emitted by
-   * `adapterOriginatorIdentity` in `src/bus/dispatch-source-publisher.ts`)
-   * to a principal id via
-   * `PolicyEngine.lookupPrincipalIdByPlatformId(platform, authorId)`.
+   * `PolicyPrincipalSchema.platform_ids` on cortex.yaml. Consumed
+   * at envelope-publish time by the dispatch-source publisher
+   * (`adapterOriginatorIdentity` in
+   * `src/bus/dispatch-source-publisher.ts`) via
+   * `PolicyEngine.lookupPrincipalIdByPlatformId(platform, authorId)`
+   * to resolve the inbound `(platform, authorId)` tuple to a
+   * registered principal. The envelope then carries
+   * `originator.identity = did:mf:<principal-id>` — the RESOLVED
+   * principal DID, per CONTEXT.md §Dispatch-source. Platform-prefixed
+   * DID shapes (`did:mf:<platform>-<authorId>`) no longer appear on
+   * the wire (the pre-#486 cortex#482 / PR #483 behaviour).
    *
    * Optional + defaults to `{}` so existing callers (engine tests,
    * federation peer principals — which by convention SHOULD NOT

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -1255,6 +1255,28 @@ export async function startCortex(
     }
   }
 
+  // v2.0.0 (cortex#297) — build engine + lookup index + principal registry
+  // ONCE so the dispatch handler and the three adapter loops below share
+  // the same instances. The policy block is parsed at config-load time;
+  // the factory + index builders are idempotent over the same input.
+  //
+  // v2.0.1 (cortex#311): retired the `CORTEX_POLICY_REQUIRE_UNVERIFIED_ACK`
+  // env-var gate. PolicyEngine activates whenever a `policy:` block is
+  // declared (which v2.0.0's schema already enforces for boot). The
+  // pre-Phase-B unverified-principal-claim trade-off is now an
+  // informational boot-log notice from the dispatch-listener builder
+  // below — gating it behind an env var created an M-3 split-brain where
+  // adapters denied every inbound while bus dispatches bypassed auth
+  // entirely (Echo PR #310 r1 finding, cortex#311).
+  //
+  // cortex#486 — moved earlier (was constructed just before the discord
+  // adapter loop) so the DispatchHandler can consume the engine for
+  // adapter-side platform-id → principal resolution at envelope-publish
+  // time. See `dispatch-source-publisher` / CONTEXT.md §Dispatch-source.
+  const adapterPolicyEngine = policyEngineFromConfig(options.policy);
+  const adapterPolicyLookup = buildPlatformPrincipalIndex(options.policy);
+  const adapterPolicyRegistry = buildPrincipalRegistry(options.policy);
+
   // Dispatch-handler — synchronous platform-message → CC pipeline.
   //
   // MIG-3.8 / C-104: hand the runtime + systemEventSource down so the handler
@@ -1263,6 +1285,13 @@ export async function startCortex(
   // fields are passed unconditionally — when the runtime is the no-op stub
   // (NATS absent), `MyelinRuntime.publish` is a no-op and emission falls
   // through silently. See `DispatchHandler.canPublishSystemEvent`.
+  //
+  // cortex#486 — `policyEngine` is required for the canonical
+  // dispatch-source envelope publish path. When no `policy:` block is
+  // declared `adapterPolicyEngine` is undefined and the publish fails
+  // closed with `invalid-originator` (deliberate — pre-Phase-B silently
+  // accepted unmapped originators; the v2.0.x policy-gated stack does
+  // not).
   const dispatchHandler = new DispatchHandler({
     config,
     securityPreamble,
@@ -1270,6 +1299,7 @@ export async function startCortex(
     runtime,
     systemEventSource,
     stack: derivedStack.stack,
+    ...(adapterPolicyEngine !== undefined && { policyEngine: adapterPolicyEngine }),
   });
 
   // Cloud publisher (G-401 + G-500) — opt-in via cloud-capable network.
@@ -1334,22 +1364,11 @@ export async function startCortex(
   }
   const startedDiscord: StartedDiscord[] = [];
 
-  // v2.0.0 (cortex#297) — build engine + lookup index + principal registry
-  // ONCE so the three adapter loops below share the same instances. The
-  // policy block is parsed at config-load time; the factory + index
-  // builders are idempotent over the same input.
-  //
-  // v2.0.1 (cortex#311): retired the `CORTEX_POLICY_REQUIRE_UNVERIFIED_ACK`
-  // env-var gate. PolicyEngine activates whenever a `policy:` block is
-  // declared (which v2.0.0's schema already enforces for boot). The
-  // pre-Phase-B unverified-principal-claim trade-off is now an
-  // informational boot-log notice from the dispatch-listener builder
-  // below — gating it behind an env var created an M-3 split-brain where
-  // adapters denied every inbound while bus dispatches bypassed auth
-  // entirely (Echo PR #310 r1 finding, cortex#311).
-  const adapterPolicyEngine = policyEngineFromConfig(options.policy);
-  const adapterPolicyLookup = buildPlatformPrincipalIndex(options.policy);
-  const adapterPolicyRegistry = buildPrincipalRegistry(options.policy);
+  // cortex#486 — `adapterPolicyEngine` / `adapterPolicyLookup` /
+  // `adapterPolicyRegistry` are constructed above (before the
+  // DispatchHandler) so the dispatch-source publish path can consume the
+  // engine for `(platform, authorId) → principal_id` resolution. The
+  // three values are shared with the adapter loops below verbatim.
 
   for (const instance of config.discord) {
     if (!instance.enabled) {

--- a/src/runner/__tests__/dispatch-listener.test.ts
+++ b/src/runner/__tests__/dispatch-listener.test.ts
@@ -2469,20 +2469,29 @@ describe("dispatch-listener — originator (cortex#346 / myelin#161)", () => {
 });
 
 // ---------------------------------------------------------------------------
-// cortex#482 — platform-prefixed originator DIDs back-resolve to a principal
-// id via `Principal.platform_ids[platform][]`. Adapter-originated dispatches
-// set `originator.identity = did:mf:<platform>-<authorId>` (see
-// `adapterOriginatorIdentity` in `src/bus/dispatch-source-publisher.ts`).
-// Before this fix the runner stripped `did:mf:` and looked up the literal
-// `<platform>-<authorId>` as `Principal.id` → `unknown_principal`.
+// cortex#486 — originator-DID resolution at the dispatch listener.
+//
+// Pre-#486 history: cortex#482 + PR #483 (Echo R1 major) wired a resolver-
+// side reverse-lookup that mapped platform-prefixed originator DIDs
+// (`did:mf:<platform>-<authorId>`) back to a registered principal id via
+// `engine.lookupPrincipalIdByPlatformId`. That cleared the chat round-
+// trip but at the wrong layer: per CONTEXT.md §Dispatch-source the
+// adapter is required to populate `originator.identity` with the
+// RESOLVED principal DID at publish time. cortex#486 moved the lookup to
+// `adapterOriginatorIdentity` in `src/bus/dispatch-source-publisher.ts`,
+// so by the time an envelope reaches the listener the originator is
+// already `did:mf:<principal-id>` — a simple `did:mf:` strip suffices.
+//
+// These tests pin the post-#486 listener contract: round-trip principal
+// DIDs through unchanged, and fail closed on platform-prefixed shapes
+// that should never appear on the wire anymore.
 // ---------------------------------------------------------------------------
 
-describe("dispatch-listener — platform-id originator resolution (cortex#482)", () => {
-  test("platform-prefixed originator DID with a mapped principal → resolves to principal id", async () => {
-    // Andreas declared as principal `andreas` with `platform_ids.discord =
-    // ["1134325176796987522"]`. Discord adapter publishes an envelope with
-    // `originator.identity = did:mf:discord-1134325176796987522`. The
-    // resolver should hand the engine `andreas`, not `discord-1134...`.
+describe("dispatch-listener — originator DID resolution (cortex#486)", () => {
+  test("originator.identity = did:mf:<principal-id> → strips prefix, no reverse lookup", async () => {
+    // Post-#486 contract: the adapter has already resolved
+    // `(platform, authorId)` to `andreas` at publish time. The
+    // listener strips `did:mf:` and forwards `andreas` to the engine.
     const captured: { principalId: string; intent: Intent }[] = [];
     const engine = new PolicyEngine({
       principals: [
@@ -2492,6 +2501,9 @@ describe("dispatch-listener — platform-id originator resolution (cortex#482)",
           home_stack: "andreas/research",
           role: ["operator"],
           trust: [],
+          // platform_ids stays on the principal — still used by the
+          // engine's `lookupPrincipalIdByPlatformId` surface (consumed
+          // at publish time by the dispatch-source).
           platform_ids: { discord: ["1134325176796987522"] },
         },
       ],
@@ -2518,7 +2530,7 @@ describe("dispatch-listener — platform-id originator resolution (cortex#482)",
 
     const env = makeReceivedEnvelope();
     env.originator = {
-      identity: "did:mf:discord-1134325176796987522",
+      identity: "did:mf:andreas",
       attribution: "adapter-resolved",
     };
 
@@ -2527,7 +2539,7 @@ describe("dispatch-listener — platform-id originator resolution (cortex#482)",
 
     expect(captured).toHaveLength(1);
     expect(captured[0]!.principalId).toBe("andreas");
-    // Allow path: engine grants dispatch.cortex → success lifecycle fires.
+    // Allow path: engine grants dispatch.cortex → success lifecycle.
     expect(r.published.map((e) => e.type)).toEqual([
       "system.access.allowed",
       "dispatch.task.started",
@@ -2535,11 +2547,13 @@ describe("dispatch-listener — platform-id originator resolution (cortex#482)",
     ]);
   });
 
-  test("platform-prefixed originator DID without a mapped principal → falls through to raw tail (engine denies unknown_principal)", async () => {
-    // Defence-in-depth: a Discord snowflake that no principal claims
-    // MUST NOT be implicitly authorised. The resolver falls through to
-    // the raw `<platform>-<authorId>` tail; engine denies; the existing
-    // security boundary is preserved.
+  test("platform-prefixed originator DID (`did:mf:discord-<id>`) → forwarded raw, engine denies unknown_principal", async () => {
+    // Defence-in-depth — pre-#486 the listener would back-resolve this
+    // shape. Post-#486 it MUST NOT: a platform-prefixed DID landing on
+    // the wire indicates either (a) a stale pre-#486 publisher (bug),
+    // (b) a forged envelope, or (c) a non-cortex publisher with broken
+    // semantics. The listener forwards the raw `discord-<id>` tail; the
+    // engine denies `unknown_principal`. No security regression.
     const captured: { principalId: string; intent: Intent }[] = [];
     const engine = new PolicyEngine({
       principals: [
@@ -2575,8 +2589,10 @@ describe("dispatch-listener — platform-id originator resolution (cortex#482)",
 
     const env = makeReceivedEnvelope();
     env.originator = {
-      // Unmapped snowflake.
-      identity: "did:mf:discord-999999999999999999",
+      // This shape is no longer produced by `adapterOriginatorIdentity`
+      // post-#486. If it lands here, treat it as opaque and let the
+      // engine deny — no implicit back-resolution.
+      identity: "did:mf:discord-1134325176796987522",
       attribution: "adapter-resolved",
     };
 
@@ -2584,258 +2600,10 @@ describe("dispatch-listener — platform-id originator resolution (cortex#482)",
     await new Promise((resolve) => setTimeout(resolve, 10));
 
     expect(captured).toHaveLength(1);
-    // Falls through to the raw tail — the engine resolves it as the
-    // (literal) principal id and denies with `unknown_principal`.
-    expect(captured[0]!.principalId).toBe("discord-999999999999999999");
+    // Listener strips `did:mf:` and forwards the raw tail verbatim.
+    expect(captured[0]!.principalId).toBe("discord-1134325176796987522");
     const types = r.published.map((e) => e.type);
     expect(types).toContain("system.access.denied");
     expect(types).toContain("dispatch.task.failed");
-  });
-
-  test("direct did:mf:<principal-id> (no platform prefix) → existing behaviour preserved", async () => {
-    // Non-platform originators (e.g. `did:mf:alice` from cortex-as-relay
-    // flows) must continue to round-trip through the existing path: the
-    // bare segment is the principal id, no reverse lookup is attempted.
-    const captured: { principalId: string; intent: Intent }[] = [];
-    const engine = new PolicyEngine({
-      principals: [
-        {
-          id: "alice",
-          home_operator: "andreas",
-          home_stack: "andreas/research",
-          role: ["operator"],
-          trust: [],
-          // Note: alice ALSO has a discord platform_id, to prove the
-          // resolver doesn't accidentally reverse-lookup non-platform
-          // DIDs against the index.
-          platform_ids: { discord: ["alice-discord-id"] },
-        },
-      ],
-      roles: [{ id: "operator", capabilities: ["dispatch.cortex"] }],
-    });
-    const origCheck = engine.check.bind(engine);
-    engine.check = (principalId, intent) => {
-      captured.push({ principalId, intent });
-      return origCheck(principalId, intent);
-    };
-
-    const r = recordingRuntime();
-    const router = createSurfaceRouter(r.runtime);
-    const { factory } = fakeFactory(SUCCESS_RESULT);
-    const listener = createDispatchListener({
-      runtime: r.runtime,
-      router,
-      source: SOURCE,
-      ccSessionFactory: factory,
-      policyEngine: engine,
-    });
-    await listener.start();
-    await router.start();
-
-    const env = makeReceivedEnvelope();
-    env.originator = {
-      identity: "did:mf:alice",
-      attribution: "adapter-resolved",
-    };
-
-    r.trigger(env, CANONICAL_CORTEX_CHAT_SUBJECT);
-    await new Promise((resolve) => setTimeout(resolve, 10));
-
-    expect(captured).toHaveLength(1);
-    expect(captured[0]!.principalId).toBe("alice");
-    expect(r.published.map((e) => e.type)).toEqual([
-      "system.access.allowed",
-      "dispatch.task.started",
-      "dispatch.task.completed",
-    ]);
-  });
-
-  // -------------------------------------------------------------------------
-  // PR #483 — Echo R1 major. Hyphenated platform names (`mcp-cli`,
-  // `discord-bot`, `email-imap`) round-trip through the publisher's single-
-  // hyphen separator. The parser must consult the engine's known-platform
-  // set and pick the longest registered prefix, otherwise
-  // `did:mf:mcp-cli-myUser123` mis-splits to `(mcp, cli-myUser123)` and
-  // silently denies the principal.
-  // -------------------------------------------------------------------------
-
-  test("hyphenated platform name (mcp-cli) → longest-prefix match resolves correctly", async () => {
-    // Register `mcp-cli` as a platform on principal `alice`. The
-    // publisher would emit `did:mf:mcp-cli-myUser123`. The parser must
-    // recognise `mcp-cli` (not `mcp`) as the platform.
-    const captured: { principalId: string; intent: Intent }[] = [];
-    const engine = new PolicyEngine({
-      principals: [
-        {
-          id: "alice",
-          home_operator: "andreas",
-          home_stack: "andreas/research",
-          role: ["operator"],
-          trust: [],
-          // Author id is lowercase to match `adapterOriginatorIdentity`
-          // (publisher) which lowercases the author id before joining.
-          platform_ids: { "mcp-cli": ["myuser123"] },
-        },
-      ],
-      roles: [{ id: "operator", capabilities: ["dispatch.cortex"] }],
-    });
-    const origCheck = engine.check.bind(engine);
-    engine.check = (principalId, intent) => {
-      captured.push({ principalId, intent });
-      return origCheck(principalId, intent);
-    };
-
-    const r = recordingRuntime();
-    const router = createSurfaceRouter(r.runtime);
-    const { factory } = fakeFactory(SUCCESS_RESULT);
-    const listener = createDispatchListener({
-      runtime: r.runtime,
-      router,
-      source: SOURCE,
-      ccSessionFactory: factory,
-      policyEngine: engine,
-    });
-    await listener.start();
-    await router.start();
-
-    const env = makeReceivedEnvelope();
-    env.originator = {
-      identity: "did:mf:mcp-cli-myuser123",
-      attribution: "adapter-resolved",
-    };
-
-    r.trigger(env, CANONICAL_CORTEX_CHAT_SUBJECT);
-    await new Promise((resolve) => setTimeout(resolve, 10));
-
-    expect(captured).toHaveLength(1);
-    // Critical: must resolve to `alice`, not `discord-999...`-style raw
-    // tail. With a naive first-hyphen split, this would have
-    // mis-resolved to (mcp, cli-myuser123) and denied.
-    expect(captured[0]!.principalId).toBe("alice");
-    expect(r.published.map((e) => e.type)).toEqual([
-      "system.access.allowed",
-      "dispatch.task.started",
-      "dispatch.task.completed",
-    ]);
-  });
-
-  test("hyphenated-platform-shape DID with NO matching registered platform → falls through to raw tail (engine denies)", async () => {
-    // Same shape (`did:mf:mcp-cli-...`) but no principal registers a
-    // platform named `mcp-cli` (only `discord`). The parser must NOT
-    // greedy-match against `mcp` (it isn't registered either) and must
-    // NOT fall back to the legacy first-hyphen split. It returns
-    // `undefined`; caller forwards the raw tail; engine denies.
-    const captured: { principalId: string; intent: Intent }[] = [];
-    const engine = new PolicyEngine({
-      principals: [
-        {
-          id: "andreas",
-          home_operator: "andreas",
-          home_stack: "andreas/research",
-          role: ["operator"],
-          trust: [],
-          platform_ids: { discord: ["1134325176796987522"] },
-        },
-      ],
-      roles: [{ id: "operator", capabilities: ["dispatch.cortex"] }],
-    });
-    const origCheck = engine.check.bind(engine);
-    engine.check = (principalId, intent) => {
-      captured.push({ principalId, intent });
-      return origCheck(principalId, intent);
-    };
-
-    const r = recordingRuntime();
-    const router = createSurfaceRouter(r.runtime);
-    const { factory } = fakeFactory(SUCCESS_RESULT);
-    const listener = createDispatchListener({
-      runtime: r.runtime,
-      router,
-      source: SOURCE,
-      ccSessionFactory: factory,
-      policyEngine: engine,
-    });
-    await listener.start();
-    await router.start();
-
-    const env = makeReceivedEnvelope();
-    env.originator = {
-      identity: "did:mf:mcp-cli-myuser123",
-      attribution: "adapter-resolved",
-    };
-
-    r.trigger(env, CANONICAL_CORTEX_CHAT_SUBJECT);
-    await new Promise((resolve) => setTimeout(resolve, 10));
-
-    expect(captured).toHaveLength(1);
-    // No registered platform matches `mcp-cli-...`, so the parser
-    // returns undefined and the caller forwards the raw tail.
-    expect(captured[0]!.principalId).toBe("mcp-cli-myuser123");
-    const types = r.published.map((e) => e.type);
-    expect(types).toContain("system.access.denied");
-    expect(types).toContain("dispatch.task.failed");
-  });
-
-  test("both `mcp` and `mcp-cli` registered → longest prefix wins", async () => {
-    // Adversarial case: two platforms registered where one is a
-    // prefix of the other. `did:mf:mcp-cli-myuser123` MUST resolve as
-    // (`mcp-cli`, `myuser123`) — the longest registered prefix — not
-    // (`mcp`, `cli-myuser123`).
-    const captured: { principalId: string; intent: Intent }[] = [];
-    const engine = new PolicyEngine({
-      principals: [
-        {
-          id: "alice",
-          home_operator: "andreas",
-          home_stack: "andreas/research",
-          role: ["operator"],
-          trust: [],
-          platform_ids: { "mcp-cli": ["myuser123"] },
-        },
-        {
-          id: "bob",
-          home_operator: "andreas",
-          home_stack: "andreas/research",
-          role: ["operator"],
-          trust: [],
-          // bob owns the (`mcp`, `cli-myuser123`) tuple — proving the
-          // parser does NOT pick `mcp` even though it would also match
-          // and resolve to a valid principal.
-          platform_ids: { mcp: ["cli-myuser123"] },
-        },
-      ],
-      roles: [{ id: "operator", capabilities: ["dispatch.cortex"] }],
-    });
-    const origCheck = engine.check.bind(engine);
-    engine.check = (principalId, intent) => {
-      captured.push({ principalId, intent });
-      return origCheck(principalId, intent);
-    };
-
-    const r = recordingRuntime();
-    const router = createSurfaceRouter(r.runtime);
-    const { factory } = fakeFactory(SUCCESS_RESULT);
-    const listener = createDispatchListener({
-      runtime: r.runtime,
-      router,
-      source: SOURCE,
-      ccSessionFactory: factory,
-      policyEngine: engine,
-    });
-    await listener.start();
-    await router.start();
-
-    const env = makeReceivedEnvelope();
-    env.originator = {
-      identity: "did:mf:mcp-cli-myuser123",
-      attribution: "adapter-resolved",
-    };
-
-    r.trigger(env, CANONICAL_CORTEX_CHAT_SUBJECT);
-    await new Promise((resolve) => setTimeout(resolve, 10));
-
-    expect(captured).toHaveLength(1);
-    // Longest-prefix wins: `mcp-cli` (7 chars) beats `mcp` (3 chars).
-    expect(captured[0]!.principalId).toBe("alice");
   });
 });

--- a/src/runner/dispatch-listener.ts
+++ b/src/runner/dispatch-listener.ts
@@ -1052,7 +1052,7 @@ function checkDispatchPolicy(
   payload: DispatchTaskReceivedPayload,
   sourceNetwork: string | undefined,
 ): DispatchPolicyResult {
-  const principalId = resolvePrincipalId(envelope, payload, engine);
+  const principalId = resolvePrincipalId(envelope, payload);
 
   // IAW Phase D.3 — surface `source_network` onto the intent when the
   // inbound wire subject was `federated.{network_id}.>`. The engine
@@ -1122,141 +1122,28 @@ function checkDispatchPolicy(
  * the engine receives a deterministic `unknown_principal` rather than
  * silent coercion (Echo cortex#220 round 2 S-1).
  *
- * **cortex#482 — adapter-originated platform-prefixed DIDs.** When the
- * adapter publishes an envelope it sets
- * `originator.identity = adapterOriginatorIdentity(platform, authorId) =
- * did:mf:<platform>-<authorId>` (see
- * `src/bus/dispatch-source-publisher.ts`). Stripping `did:mf:` yields
- * a tail like `discord-1134325176796987522` — which is NOT a registered
- * `Principal.id` (Andreas is declared as `andreas` with
- * `platform_ids.discord = ["1134325176796987522"]`). To close the gap,
- * once the bare segment matches `<platform>-<authorId>` and the engine
- * is in hand, we consult `engine.lookupPrincipalIdByPlatformId(...)`
- * for a reverse-lookup. A hit returns the registered principal id; a
- * miss falls through to the raw platform-prefixed tail, which the
- * engine then denies with `unknown_principal` — the existing security
- * boundary is preserved.
- *
- * **PR #483 (Echo R1 major) — hyphenated-platform disambiguation.**
- * The schema's `LETTER_PREFIX_ID_REGEX` permits hyphenated platform
- * names (`mcp-cli`, `discord-bot`), and `adapterOriginatorIdentity`
- * joins `<platform>-<authorId>` with a single hyphen — so a naive
- * first-hyphen split would mis-resolve. `parsePlatformPrefixedAgentId`
- * now consults `engine.knownPlatforms` and picks the longest
- * registered platform that prefixes the bare segment, making the
- * parser symmetric with the publisher.
- *
- * The engine arg is optional so legacy callers (and the no-engine
- * fail-closed boot path) keep working without churn.
+ * **cortex#486 — resolver-side platform-id lookup removed.** PR #483
+ * (cortex#482) briefly performed a reverse-lookup here when the bare
+ * agent id matched a `<platform>-<authorId>` shape. That cleared the
+ * chat round-trip, but at the wrong layer: per CONTEXT.md §Dispatch-
+ * source the adapter is required to populate `originator.identity`
+ * with the **resolved** human/agent DID. cortex#486 moved the
+ * `(platform, authorId) → principal_id` resolution into
+ * `adapterOriginatorIdentity` (`src/bus/dispatch-source-publisher.ts`),
+ * so by the time the envelope lands here `originator.identity` is
+ * already `did:mf:<principal-id>` and a simple `did:mf:` strip is
+ * enough. Unresolvable platform identities now fail closed at publish
+ * time (`invalid-originator`) — they never reach this function.
  */
 function resolvePrincipalId(
   envelope: Envelope,
   payload: DispatchTaskReceivedPayload,
-  engine?: PolicyEngine,
 ): string {
   const actorDid = getActorPrincipal(envelope);
   if (actorDid === undefined) return payload.agent_id;
   const agentId = extractAgentIdFromDid(actorDid);
   if (agentId === undefined) return actorDid;
-  // IAW cortex#482 — adapter-originated DIDs of the shape
-  // `did:mf:<platform>-<authorId>` decode here to a `<platform>-<authorId>`
-  // tail. When the engine is supplied AND the tail matches that shape,
-  // attempt a `platform_ids[]` reverse-lookup. A direct `did:mf:<id>` (no
-  // platform-style hyphen prefix) skips the lookup and falls through to
-  // the existing behaviour; an unmapped platform identity also falls
-  // through to the raw tail (engine denies `unknown_principal`).
-  if (engine !== undefined) {
-    const platformMatch = parsePlatformPrefixedAgentId(
-      agentId,
-      engine.knownPlatforms,
-    );
-    if (platformMatch !== undefined) {
-      const resolved = engine.lookupPrincipalIdByPlatformId(
-        platformMatch.platform,
-        platformMatch.authorId,
-      );
-      if (resolved !== undefined) return resolved;
-    }
-  }
   return agentId;
-}
-
-/**
- * IAW cortex#482 + PR #483 (Echo R1 major) — split a
- * `<platform>-<authorId>` bare agent-id segment (the tail of
- * `did:mf:<platform>-<authorId>` after the `did:mf:` strip) into its
- * `platform` + `authorId` parts, disambiguating against the set of
- * platforms registered with the engine.
- *
- * The grammar mirrors `adapterOriginatorIdentity` (publisher side):
- *   - `platform` is the lowercase platform tag — letters/digits AND
- *     HYPHENS. The schema's `LETTER_PREFIX_ID_REGEX =
- *     /^[a-z][a-z0-9-]*$/` permits hyphenated names (`mcp-cli`,
- *     `discord-bot`, `email-imap`).
- *   - `authorId` is the remainder. Also may contain hyphens (the
- *     publisher's `[^a-z0-9._-]` → `-` mapping for unsafe chars).
- *
- * A naive first-hyphen split is therefore asymmetric with the
- * publisher: `did:mf:mcp-cli-myUser123` (real tuple
- * `(mcp-cli, myUser123)`) would split to `(mcp, cli-myUser123)` and
- * miss the reverse lookup → silent denial-of-service for any
- * principal whose platform name contains a hyphen. PR #483 closes
- * that gap by consulting the engine's `knownPlatforms` set and
- * picking the **longest** registered platform that prefixes the
- * agent id (with the required `-` separator immediately after).
- *
- * Disambiguation strategy:
- *
- *   1. **Longest-prefix match against `knownPlatforms`.** For each
- *      registered platform `P`, the agent id matches when it starts
- *      with `P + "-"` AND has a non-empty tail. Among all matches,
- *      the longest `P` wins (so `mcp-cli` beats `mcp` when both are
- *      registered). This is symmetric with the publisher: the
- *      adapter that emitted the DID is the one that registered the
- *      platform name with the engine, so the longest-matching
- *      registered platform IS the publisher's platform.
- *   2. **No match → return `undefined`.** Falling back to the
- *      first-hyphen split would re-introduce the asymmetry (and
- *      could mask config-drift bugs by silently parsing a tail
- *      from an unregistered platform). Returning `undefined` makes
- *      the caller fall through to the raw tail, the engine denies
- *      `unknown_principal`, and the deny audit surfaces the issue.
- *
- * Returns `undefined` for shapes that don't carry a registered
- * platform prefix (e.g. `andreas`, `luna`, or any platform-shape id
- * whose platform isn't in `knownPlatforms`). Those flow through the
- * legacy path untouched.
- *
- * **Note on principal-id ambiguity with hyphens.** A principal id
- * like `my-agent` parsed against `knownPlatforms = ["my"]` would
- * match as `(my, agent)`. This is by design: if an operator
- * registered `my` as a platform AND named a principal `my-agent`,
- * the reverse index is the authority — an `(my, agent)` miss
- * returns `undefined` from `lookupPrincipalIdByPlatformId` and the
- * caller falls through to the raw tail. The schema's tuple-
- * uniqueness check prevents the genuine ambiguity (same id
- * registered as both a principal and a platform identity).
- */
-function parsePlatformPrefixedAgentId(
-  agentId: string,
-  knownPlatforms: Iterable<string>,
-): { platform: string; authorId: string } | undefined {
-  let bestPlatform: string | undefined;
-  for (const platform of knownPlatforms) {
-    // Must be `<platform>-<non-empty-tail>`. `startsWith(platform +
-    // "-")` plus a bounds check that there's at least one char after
-    // the separator.
-    if (agentId.length <= platform.length + 1) continue;
-    if (!agentId.startsWith(`${platform}-`)) continue;
-    if (bestPlatform === undefined || platform.length > bestPlatform.length) {
-      bestPlatform = platform;
-    }
-  }
-  if (bestPlatform === undefined) return undefined;
-  return {
-    platform: bestPlatform,
-    authorId: agentId.slice(bestPlatform.length + 1),
-  };
 }
 
 /**


### PR DESCRIPTION
## Summary

Move platform-id → principal resolution from the runner's
`resolvePrincipalId` to the dispatch-source publisher
(`adapterOriginatorIdentity`). Reverts the resolver-side reverse-lookup
added in cortex#483 (PR-483, merged earlier today) so the architecture
aligns with CONTEXT.md §Dispatch-source: *"adapter populates
`originator.identity` with the **resolved** human/agent DID"*.

Closes #486.

## Why

Per `CONTEXT.md` the adapter must publish envelopes carrying the
*resolved* principal DID (`did:mf:andreas`). Pre-#486 the publisher
emitted `did:mf:<platform>-<authorId>` and the listener back-resolved
via `engine.lookupPrincipalIdByPlatformId`. That cleared the chat
round-trip last night but at the wrong layer — resolution at the wrong
layer requires re-resolution at the consume layer, and the
platform-prefixed DID shape leaked layering concerns onto the wire.

This PR moves the lookup into `adapterOriginatorIdentity`:

- `adapterOriginatorIdentity(engine, platform, authorId)` consults the
  wired PolicyEngine. Hit → `did:mf:<principal-id>`; miss → null
  (publish refuses with `invalid-originator`).
- `DispatchHandler` accepts a `policyEngine` and threads it to
  `publishInboundChatDispatchEnvelope`.
- `cortex.ts` constructs `adapterPolicyEngine` earlier so the dispatch
  handler can consume it; adapter loops share the same instance.
- `dispatch-listener.ts` reverts `resolvePrincipalId` to the simple
  `did:mf:` strip (the pre-#482 shape). `parsePlatformPrefixedAgentId`
  helper deleted as dead code.
- Tests updated to assert `originator.identity = did:mf:<principal-id>`
  on the wire and the fail-closed behaviour when no engine is wired or
  the tuple is unmapped. New defence-in-depth test pins that a
  platform-prefixed DID landing at the listener (forged / pre-#486
  publisher) is forwarded raw and denied with `unknown_principal`.

## Wire-level effect

- `originator.identity` on inbound dispatch envelopes is now
  `did:mf:<principal-id>` (e.g. `did:mf:andreas`) — never
  platform-prefixed.
- Unresolvable platform identities (random Discord user not in
  `policy.principals[]`) fail closed at publish time with a clear
  `invalid-originator` reason — not silently passed through to fail
  later at the listener.
- Runner's `resolvePrincipalId` is engine-independent again.
- Security boundary preserved: forged envelopes still fail at chain
  verify; platform-prefixed shapes landing at the listener (which the
  publisher no longer produces) are forwarded raw and denied.

## Why this preserves C-388 separation of concerns

The dispatch source has the `(platform, authorId)` tuple directly and
the policy registry in hand — it's the single layer that should own
the platform-identity → principal mapping. The listener becomes layer-
neutral: it consumes principal DIDs and lets the engine answer
yes/no on capability claims. No re-resolution, no after-the-fact
disambiguation against `knownPlatforms`.

## Verification

- `grep -rEn 'did:mf:discord-|did:mf:mattermost-|did:mf:slack-' src/`
  returns zero hits in non-test code.
- `bunx tsc --noEmit` clean.
- `bun test` 3568 pass / 2 skip / 0 fail.
- `bun run lint:errors` clean.

## Test plan

- [x] Unit: `adapterOriginatorIdentity` returns resolved principal DID
      on hit, null on miss / no engine.
- [x] Unit: `DispatchHandler` with wired engine publishes envelopes
      carrying `did:mf:<principal-id>` for Discord and Mattermost.
- [x] Unit: `DispatchHandler` without engine refuses publish with
      `invalid-originator` (cortex#486 fail-closed).
- [x] Unit: listener's `resolvePrincipalId` strips `did:mf:` and
      forwards the principal id directly.
- [x] Defence-in-depth: platform-prefixed DID landing at the listener
      is forwarded raw and denied with `unknown_principal`.
- [ ] Manual: chat round-trip on the metafactory dev stack continues
      to work end-to-end (orchestrator to validate after merge order
      is decided vs. cortex#484).

## Coordination note

cortex#484 (Option D — runner uses `runtime.subscribe` directly,
drops surface-router registration) is being implemented in parallel
and touches `src/runner/dispatch-listener.ts` heavily. Likely conflict
with this PR's revert of `resolvePrincipalId`. Once both PRs open, the
orchestrator handles merge order + rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)