### PR TITLE
Pass forge hint to Sage review runner

### DIFF
--- a/src/bus/review-events.ts
+++ b/src/bus/review-events.ts
@@ -184,6 +184,11 @@ export interface ReviewRequestPayload {
    * runner passes `--post` to the sage subprocess.
    */
   post?: boolean;
+  /**
+   * Forge backend the task target belongs to. Omitted means GitHub for
+   * backwards compatibility with pre-sage#43 publishers.
+   */
+  forge?: "github" | "gitlab";
 }
 
 /** Options for {@link createReviewRequestEvent}. */

--- a/src/runner/substrate/__tests__/pi-dev-runner.test.ts
+++ b/src/runner/substrate/__tests__/pi-dev-runner.test.ts
@@ -429,6 +429,45 @@ describe("cortex#331 Phase 1 — makePiDevPipelineRunner", () => {
     }
   });
 
+  test("passes payload.forge through to sage review", async () => {
+    const prior = process.env.SAGE_SUBSTRATE;
+    process.env.SAGE_SUBSTRATE = "codex";
+    try {
+      const spawn = makeRecordingSpawn(makeSpawnResult("## review\n", "", 0));
+      const runner = makePiDevPipelineRunner({
+        spawn: spawn.fn,
+        which: whichSuccess,
+      });
+      const base = makePipelineOpts();
+      const opts: ReviewPipelineOpts = {
+        ...base,
+        payload: {
+          ...base.payload,
+          repo: "saca/secacademy",
+          pr: 62,
+          post: true,
+          forge: "gitlab",
+        },
+      };
+
+      await runner(opts);
+
+      expect(spawn.calls[0]).toEqual([
+        FAKE_SAGE_BIN,
+        "review",
+        "saca/secacademy#62",
+        "--substrate",
+        "codex",
+        "--post",
+        "--forge",
+        "gitlab",
+      ]);
+    } finally {
+      if (prior === undefined) delete process.env.SAGE_SUBSTRATE;
+      else process.env.SAGE_SUBSTRATE = prior;
+    }
+  });
+
   test("cortex#409 — absent post → argv omits --post", async () => {
     const prior = process.env.SAGE_SUBSTRATE;
     delete process.env.SAGE_SUBSTRATE;

--- a/src/runner/substrate/pi-dev-runner.ts
+++ b/src/runner/substrate/pi-dev-runner.ts
@@ -239,6 +239,10 @@ export function makePiDevPipelineRunner(
     if (pipeline.payload.post === true) {
       argv.push("--post");
     }
+    const forge = pipeline.payload.forge;
+    if (forge === "github" || forge === "gitlab") {
+      argv.push("--forge", forge);
+    }
 
     let proc: PiDevSpawnResult;
     try {


### PR DESCRIPTION
## Summary
- preserve review task payload.forge when Cortex shells out to sage review
- pass --forge github|gitlab alongside --substrate and --post
- add a regression test for the saca/secacademy#62 GitLab dispatch shape

## Diagnosis
Sage dispatch was publishing a GitLab-shaped task, but Cortex reconstructed the ref as owner/repo#N and invoked sage review without --forge. That converted GitLab MRs back into GitHub PR shorthand inside the runner.

## Verification
- bun test src/runner/substrate/__tests__/pi-dev-runner.test.ts
- bunx tsc --noEmit
- bun test