### PR TITLE
fix(cortex): C-491 — sync chat reply fall-through (closes #491 outbound)

### DIFF
--- a/src/bus/__tests__/dispatch-handler.test.ts
+++ b/src/bus/__tests__/dispatch-handler.test.ts
@@ -1322,7 +1322,17 @@ describe("DispatchHandler — Direction A Stage 4-B inbound envelope publish (co
   // path by default.
   // ---------------------------------------------------------------------------
 
-  test("chat mode publishes canonical envelope by default — legacy CC does not spawn", async () => {
+  test("chat mode publishes canonical envelope AND falls through to reply (cortex#491)", async () => {
+    // cortex#491 (Bug 2): a successful canonical bus publish must NOT
+    // short-circuit the sync chat path. PR #421 added a bare early-return
+    // on `publishResult.published`, which skipped `handleSync` — the only
+    // code that posts the CC reply via `adapter.postResponse`. No consumer
+    // of `dispatch.task.completed` posts back to the channel, so every sync
+    // chat response was silently dropped. The fix keeps the bus publish
+    // (observability) and falls through to `handleSync`, which spawns CC
+    // and posts the reply. This test now asserts BOTH: the envelope is
+    // published (==1) AND the CC session spawns (==1) AND the reply lands
+    // on the channel.
     const runtime = makeRecordingRuntimeWithSubject();
     let spawnCount = 0;
     const ccFactory: CCSessionFactory = (_opts: CCSessionOpts) => {
@@ -1334,7 +1344,7 @@ describe("DispatchHandler — Direction A Stage 4-B inbound envelope publish (co
         wait() {
           return Promise.resolve<CCSessionResult>({
             success: true,
-            response: "legacy",
+            response: "hello back from CC",
             exitCode: 0,
             durationMs: 0,
             sessionId: "fake-session",
@@ -1365,11 +1375,15 @@ describe("DispatchHandler — Direction A Stage 4-B inbound envelope publish (co
         authorId: "1487204875912609844",
       }),
     );
+    // Bus publish preserved (observability).
     expect(runtime.subjectPublishes.length).toBe(1);
-    expect(spawnCount).toBe(0);
     expect(runtime.subjectPublishes[0]?.subject).toBe(
       "local.andreas.meta-factory.tasks.@did-mf-test-agent.chat",
     );
+    // Fall-through to handleSync: CC spawns and the reply is posted back.
+    expect(spawnCount).toBe(1);
+    expect(adapter.sentMessages).toHaveLength(1);
+    expect(adapter.sentMessages[0]?.text).toBe("hello back from CC");
     await handler.shutdown();
   });
 
@@ -1386,7 +1400,7 @@ describe("DispatchHandler — Direction A Stage 4-B inbound envelope publish (co
         wait() {
           return Promise.resolve<CCSessionResult>({
             success: true,
-            response: "legacy",
+            response: "hello back from CC",
             exitCode: 0,
             durationMs: 0,
             sessionId: "fake-session",
@@ -1419,10 +1433,14 @@ describe("DispatchHandler — Direction A Stage 4-B inbound envelope publish (co
         }),
       );
       expect(runtime.subjectPublishes.length).toBe(1);
-      expect(spawnCount).toBe(0);
       expect(runtime.subjectPublishes[0]?.subject).toBe(
         "local.andreas.meta-factory.tasks.@did-mf-test-agent.chat",
       );
+      // cortex#491 — env flag is gone AND the canonical publish no longer
+      // short-circuits the reply: CC spawns and posts back.
+      expect(spawnCount).toBe(1);
+      expect(adapter.sentMessages).toHaveLength(1);
+      expect(adapter.sentMessages[0]?.text).toBe("hello back from CC");
     } finally {
       delete process.env.CORTEX_ADAPTER_ENVELOPE_MODE;
     }

--- a/src/bus/dispatch-handler.ts
+++ b/src/bus/dispatch-handler.ts
@@ -729,7 +729,17 @@ export class DispatchHandler extends EventEmitter {
           entity: groveEntity,
           operator: groveOperator,
         });
-        if (publishResult.published) return;
+        // cortex#491 (Bug 2): do NOT early-return on a successful canonical
+        // publish. PR #421 made the canonical-task-envelope publish the default
+        // for sync chat and added a bare `if (publishResult.published) return;`
+        // here — but no consumer of `dispatch.task.completed` posts the CC
+        // reply back to the channel, so the early-return silently dropped every
+        // sync chat response. We keep the bus publish (observability/telemetry
+        // preserved) and fall through to `switch (parsed.mode) → handleSync`,
+        // which runs the CC session and posts the full reply via
+        // `adapter.postResponse`. Async/team modes are unaffected — they never
+        // entered this `parsed.mode === "sync"` block. The `invalid-originator`
+        // and other publish-failure branches below are preserved exactly.
         if (publishResult.reason === "invalid-originator") {
           await adapter.postResponse(
             { instanceId: msg.instanceId, channelId: msg.channelId, threadId: msg.threadId },
@@ -737,9 +747,11 @@ export class DispatchHandler extends EventEmitter {
           );
           return;
         }
-        console.warn(
-          `dispatch-handler: canonical chat dispatch publish unavailable (${publishResult.reason ?? "unknown"}) — using direct sync path for this message`,
-        );
+        if (!publishResult.published) {
+          console.warn(
+            `dispatch-handler: canonical chat dispatch publish unavailable (${publishResult.reason ?? "unknown"}) — using direct sync path for this message`,
+          );
+        }
       }
 
       // 12. Route by mode


### PR DESCRIPTION
## C-491 (Bug 2): sync chat never posts the CC reply back to the channel

References cortex#491. Closes the **outbound-reply** half of #491. The Bug-1 `nats.subjects` dedup is a separate PR and independent of this change.

### Root cause (proven)

`src/bus/dispatch-handler.ts`, in the `parsed.mode === "sync"` block of `handleMessage`:

```ts
const publishResult = await this.publishInboundDispatchEnvelope({ ... });
if (publishResult.published) return;   // <-- the bug
```

PR #421 (canonical-task-envelope default) made the canonical bus publish the default path for sync chat and added a bare `if (publishResult.published) return;`. On a **successful** publish that early-return exits `handleMessage` before reaching the `switch (parsed.mode)` → `handleSync` — and `handleSync` is the **only** code that runs the CC session and posts the reply back to the channel via `adapter.postResponse(target, finalResult.response)`.

No consumer of `dispatch.task.completed` posts back to the channel, so the canonical envelope was published (observability worked) but the human never saw a reply. Every sync chat response was silently dropped.

### The fix (surgical — 16 insertions / 4 deletions in `dispatch-handler.ts`)

1. **Remove the bare `return;`** on a successful publish, so control falls through to `switch (parsed.mode)` → `handleSync`, which runs CC and posts the full reply. The bus publish is **kept** — observability/telemetry preserved.
2. **Guard the `console.warn`** with `if (!publishResult.published)` so the "publish unavailable, using direct sync path" warning no longer misfires on a *successful* publish (it now only fires on a genuine publish failure).
3. The `invalid-originator` branch (posts the denial + returns) and every other publish-failure branch are **preserved exactly**.

### What is NOT touched

- `surfaceSubjects: []` is **correct and untouched** — that path dumps raw JSON and is unrelated to this bug.
- `nats.subjects` (Bug 1 dedup) is **untouched** — that fix is a separate PR.
- **async / team modes are unaffected** — they never enter the `parsed.mode === "sync"` block; the `switch` still routes them to `handleAsync` / `handleTeam`.

### Tests

`src/bus/__tests__/dispatch-handler.test.ts`:

- Updated the two tests that encoded the buggy early-return (they asserted `spawnCount === 0`, i.e. CC never spawned). They now assert the **fixed** behavior:
  - the canonical envelope is still published (`subjectPublishes.length === 1`, correct subject), **and**
  - CC spawns (`spawnCount === 1`), **and**
  - the reply lands on the channel (`adapter.sentMessages[0].text === "hello back from CC"`).
- The `invalid-originator` test is unchanged and still passes (`spawnCount === 0`, apology posted) — that path correctly returns early.

### Verification

- `bunx tsc --noEmit` — clean (exit 0)
- `bun test src/bus/__tests__/dispatch-handler.test.ts` — **37 pass / 0 fail**
- `bun run lint:errors` — clean (exit 0)
- Full `bun test` — 3569 pass / 2 skip. The intermittent failures (runner `dispatch-listener` chain-verify timing, `bash-guard` HTTP-ingest timing, `SlackAdapter` mid-drain ordering, `AgentsDirectoryWatcher` debounce) are **pre-existing flaky/environmental** (tracked under cortex#460/#461); each passes deterministically when run in isolation, and all live in modules this PR does not touch (this PR changes only `dispatch-handler.ts` + its test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)