### PR TITLE
fix(discord): avoid bogus resume session for chat dispatch

### DIFF
--- a/src/adapters/__tests__/envelope-renderer.test.ts
+++ b/src/adapters/__tests__/envelope-renderer.test.ts
@@ -119,6 +119,25 @@ describe("formatEnvelopeAsMarkdown — payload code block", () => {
   });
 });
 
+describe("formatEnvelopeAsMarkdown — dispatch lifecycle", () => {
+  test("renders dispatch lifecycle as concise status text", () => {
+    expect(formatEnvelopeAsMarkdown(makeEnvelope({
+      type: "dispatch.task.started",
+      payload: { agent_id: "ivy" },
+    }))).toBe("Ivy is working...");
+
+    expect(formatEnvelopeAsMarkdown(makeEnvelope({
+      type: "dispatch.task.completed",
+      payload: { agent_id: "ivy", result_summary: "🗣️ Ivy: Here." },
+    }))).toBe("🗣️ Ivy: Here.");
+
+    expect(formatEnvelopeAsMarkdown(makeEnvelope({
+      type: "dispatch.task.failed",
+      payload: { agent_id: "ivy", error_summary: "claude exited 1" },
+    }))).toBe("Ivy failed: claude exited 1");
+  });
+});
+
 describe("formatEnvelopeAsMarkdown — overall shape", () => {
   test("output has exactly the documented N-line structure with correlation_id", () => {
     const out = formatEnvelopeAsMarkdown(

--- a/src/adapters/discord/__tests__/render-envelope.test.ts
+++ b/src/adapters/discord/__tests__/render-envelope.test.ts
@@ -218,6 +218,28 @@ describe("DiscordAdapter.renderEnvelope — happy path", () => {
     expect(sends[0]?.channelId).toBe("channel-A");
   });
 
+  test("renders agent-scoped envelope for this adapter's agent", async () => {
+    const { adapter, sends } = makeAdapter({
+      surfaceFallbackChannelId: "channel-A",
+    });
+    await adapter.surfaceConfig.render(
+      makeEnvelope({ payload: { agent_id: "test" } }),
+    );
+    expect(sends).toHaveLength(1);
+    expect(sends[0]?.channelId).toBe("channel-A");
+  });
+
+  test("drops agent-scoped envelope for a different agent", async () => {
+    const { adapter, sends } = makeAdapter({
+      surfaceFallbackChannelId: "channel-A",
+    });
+    await adapter.surfaceConfig.render(
+      makeEnvelope({ payload: { agent_id: "juniper" } }),
+    );
+    expect(sends).toHaveLength(0);
+    expect(warnings).toHaveLength(0);
+  });
+
   test("formatted message contains envelope.type as bold header", async () => {
     const { adapter, sends } = makeAdapter({
       surfaceFallbackChannelId: "channel-A",

--- a/src/adapters/discord/index.ts
+++ b/src/adapters/discord/index.ts
@@ -1162,7 +1162,16 @@ export class DiscordAdapter implements PlatformAdapter {
    * delivery errors and buffers when disconnected. The router's
    * `renderWithIsolation` wraps us in a timeout regardless.
    */
+  private shouldRenderEnvelope(envelope: Envelope): boolean {
+    const envelopeAgentId = envelope.payload.agent_id;
+    return typeof envelopeAgentId !== "string" || envelopeAgentId === this.agent.id;
+  }
+
   private async renderEnvelope(envelope: Envelope, _signal?: AbortSignal): Promise<void> {
+    if (!this.shouldRenderEnvelope(envelope)) {
+      return;
+    }
+
     // Buffering at the adapter level would duplicate `postResponse`'s
     // existing pending-result mechanism; instead we drop here and rely
     // on JetStream replay (per design-cortex.md §3.3 "lost event ≠ lost

--- a/src/adapters/envelope-renderer.ts
+++ b/src/adapters/envelope-renderer.ts
@@ -30,6 +30,9 @@ import type { Envelope } from "../bus/myelin/envelope-validator";
  * the envelope details.
  */
 export function formatEnvelopeAsMarkdown(envelope: Envelope): string {
+  const renderedDispatch = formatDispatchLifecycle(envelope);
+  if (renderedDispatch) return renderedDispatch;
+
   const corr = envelope.correlation_id ? ` [${envelope.correlation_id}]` : "";
   return [
     `**${envelope.type}**${corr}`,
@@ -37,4 +40,31 @@ export function formatEnvelopeAsMarkdown(envelope: Envelope): string {
     JSON.stringify(envelope.payload, null, 2),
     "```",
   ].join("\n");
+}
+
+function formatDispatchLifecycle(envelope: Envelope): string | null {
+  const payload = envelope.payload;
+  const agent = typeof payload.agent_id === "string" ? payload.agent_id : "agent";
+  const label = agent.charAt(0).toUpperCase() + agent.slice(1);
+
+  if (envelope.type === "dispatch.task.started") {
+    return `${label} is working...`;
+  }
+
+  if (envelope.type === "dispatch.task.completed") {
+    const summary = typeof payload.result_summary === "string" ? payload.result_summary.trim() : "Done.";
+    return summary || "Done.";
+  }
+
+  if (envelope.type === "dispatch.task.failed") {
+    const summary = typeof payload.error_summary === "string" ? payload.error_summary.trim() : "unknown error";
+    return `${label} failed: ${summary}`;
+  }
+
+  if (envelope.type === "dispatch.task.aborted") {
+    const reason = typeof payload.reason === "string" ? payload.reason.trim() : "aborted";
+    return `${label} stopped: ${reason}`;
+  }
+
+  return null;
 }

--- a/src/bus/__tests__/dispatch-handler.test.ts
+++ b/src/bus/__tests__/dispatch-handler.test.ts
@@ -1,4 +1,7 @@
 import { test, expect, describe, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
 import { MockAdapter } from "../../adapters/mock";
 import { DispatchHandler } from "../dispatch-handler";
 import type { InboundMessage } from "../../adapters/types";
@@ -1099,6 +1102,41 @@ describe("DispatchHandler — Direction A Stage 4-B inbound envelope publish (co
     await handler.shutdown();
   });
 
+  test("per-adapter target agent overrides host config agent", async () => {
+    const runtime = makeRecordingRuntimeWithSubject();
+    const handler = new DispatchHandler({
+      config: makeConfig(),
+      securityPreamble: "",
+      runtime,
+      systemEventSource: {
+        principal: "andreas",
+        agent: "cortex",
+        instance: "local",
+      },
+      stack: "meta-factory",
+      policyEngine: makePublishPolicyEngine(),
+    });
+
+    const published = await callPublishInboundDispatchEnvelope(
+      handler,
+      dispatchOpts({
+        targetAgent: { id: "holly", displayName: "Holly" },
+      }),
+    );
+
+    expect(published).toBe(true);
+    expect(runtime.subjectPublishes[0]?.subject).toBe(
+      "local.andreas.meta-factory.tasks.@did-mf-holly.chat",
+    );
+    expect(runtime.subjectPublishes[0]?.envelope.target_assistant).toBe(
+      "did:mf:holly",
+    );
+    expect(runtime.subjectPublishes[0]?.envelope.payload.agent_id).toBe("holly");
+    expect(runtime.subjectPublishes[0]?.envelope.payload.agent_name).toBe("Holly");
+
+    await handler.shutdown();
+  });
+
   test("stackless subject when stack is omitted", async () => {
     const runtime = makeRecordingRuntimeWithSubject();
     const handler = new DispatchHandler({
@@ -1370,7 +1408,51 @@ describe("DispatchHandler — Direction A Stage 4-B inbound envelope publish (co
     expect(runtime.subjectPublishes[0]?.subject).toBe(
       "local.andreas.meta-factory.tasks.@did-mf-test-agent.chat",
     );
+    expect(runtime.subjectPublishes[0]?.envelope.payload).not.toHaveProperty("resume_session_id");
     await handler.shutdown();
+  });
+
+  test("chat mode injects the target agent persona into canonical dispatch prompt", async () => {
+    const runtime = makeRecordingRuntimeWithSubject();
+    const adapter = new MockAdapter();
+    const dir = mkdtempSync(join(tmpdir(), "cortex-persona-"));
+    const personaPath = join(dir, "juniper.md");
+    writeFileSync(personaPath, "# Juniper\\nYou are Juniper, not Ivy.\\n");
+
+    const handler = new DispatchHandler({
+      config: makeConfig(),
+      securityPreamble: "",
+      runtime,
+      systemEventSource: {
+        principal: "andreas",
+        agent: "cortex",
+        instance: "local",
+      },
+      stack: "meta-factory",
+      policyEngine: makePublishPolicyEngine(),
+    });
+
+    try {
+      await handler.handleMessage(
+        adapter,
+        makeMsg({
+          content: "hello",
+          platform: "discord",
+          authorId: "1487204875912609844",
+        }),
+        { id: "juniper", displayName: "Juniper", persona: personaPath },
+      );
+
+      const prompt = runtime.subjectPublishes[0]?.envelope.payload.prompt;
+      expect(typeof prompt).toBe("string");
+      expect(prompt).toContain("You are Juniper (agent id: juniper).");
+      expect(prompt).toContain("# Juniper");
+      expect(prompt).toContain("hello");
+      expect(runtime.subjectPublishes[0]?.envelope.payload.agent_id).toBe("juniper");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+      await handler.shutdown();
+    }
   });
 
   test("chat mode no longer consults CORTEX_ADAPTER_ENVELOPE_MODE", async () => {

--- a/src/bus/dispatch-handler.ts
+++ b/src/bus/dispatch-handler.ts
@@ -82,6 +82,12 @@ function getGroveVersion(): string {
   return _cachedVersion;
 }
 
+interface DispatchTargetAgent {
+  id: string;
+  displayName: string;
+  persona?: string;
+}
+
 export interface DispatchHandlerOpts {
   config: AgentConfig;
   securityPreamble: string;
@@ -233,6 +239,7 @@ export class DispatchHandler extends EventEmitter {
    * at envelope-publish time. See `DispatchHandlerOpts.policyEngine`.
    */
   private readonly policyEngine: PolicyEngine | undefined;
+  private readonly personaPromptCache = new Map<string, string | null>();
 
   constructor(opts: DispatchHandlerOpts) {
     super();
@@ -292,6 +299,42 @@ export class DispatchHandler extends EventEmitter {
       return null;
     }
     return { runtime, source };
+  }
+
+
+  /**
+   * Multi-agent Discord runs share one Cortex process, so Claude Code's
+   * ambient user context is not enough to select the addressed agent. The
+   * matched adapter agent must be injected into the prompt before the
+   * bus-mediated runner sees it.
+   */
+  private targetAgentPersonaPreamble(targetAgent: DispatchTargetAgent | undefined): string {
+    if (targetAgent === undefined) return "";
+
+    const identity =
+      `You are ${targetAgent.displayName} (agent id: ${targetAgent.id}). ` +
+      `Respond as ${targetAgent.displayName}; do not identify as any other agent.\n\n`;
+
+    const personaPath = targetAgent.persona;
+    if (personaPath === undefined || personaPath.length === 0) return identity;
+
+    let persona = this.personaPromptCache.get(personaPath);
+    if (persona === undefined) {
+      try {
+        persona = readFileSync(personaPath, "utf-8").trim();
+      } catch (err) {
+        const detail = err instanceof Error ? err.message : String(err);
+        console.warn(
+          `dispatch-handler: could not read persona for ${targetAgent.id} at ${personaPath}: ${detail}`,
+        );
+        persona = null;
+      }
+      this.personaPromptCache.set(personaPath, persona);
+    }
+
+    return persona === null || persona.length === 0
+      ? identity
+      : `${identity}${persona}\n\n`;
   }
 
   /**
@@ -403,6 +446,7 @@ export class DispatchHandler extends EventEmitter {
     taskId: string;
     msg: InboundMessage;
     prompt: string;
+    targetAgent?: DispatchTargetAgent;
     resumeSessionId: string | undefined;
     allowedDirs: string[];
     disallowedTools: string[];
@@ -420,8 +464,8 @@ export class DispatchHandler extends EventEmitter {
       runtime: wiring?.runtime,
       source: wiring?.source,
       stack: this.stack,
-      agentName: this.config.agent.name,
-      agentDisplayName: this.config.agent.displayName,
+      agentName: opts.targetAgent?.id ?? this.config.agent.name,
+      agentDisplayName: opts.targetAgent?.displayName ?? this.config.agent.displayName,
       policyEngine: this.policyEngine,
       ...opts,
     });
@@ -498,7 +542,11 @@ export class DispatchHandler extends EventEmitter {
   }
 
   /** Main entry point — called by adapters when a message arrives */
-  async handleMessage(adapter: PlatformAdapter, msg: InboundMessage): Promise<void> {
+  async handleMessage(
+    adapter: PlatformAdapter,
+    msg: InboundMessage,
+    targetAgent?: DispatchTargetAgent,
+  ): Promise<void> {
     try {
       // 1. Access control
       const access = adapter.resolveAccess(msg);
@@ -657,7 +705,7 @@ export class DispatchHandler extends EventEmitter {
         context,
         isResume: !!existingSession,
         attachmentPrompt: attachPrompt,
-        securityPreamble: channelContextNote + skillRestrictionNote + effectivePreamble,
+        securityPreamble: this.targetAgentPersonaPreamble(targetAgent) + channelContextNote + skillRestrictionNote + effectivePreamble,
       });
 
       // 10. Scan user message (not the full assembled prompt) for injection.
@@ -717,7 +765,8 @@ export class DispatchHandler extends EventEmitter {
           taskId: dispatchTaskId,
           msg,
           prompt,
-          resumeSessionId: existingSession?.sessionId ?? attachmentSessionId,
+          targetAgent,
+          resumeSessionId: existingSession?.sessionId,
           allowedDirs: invokeDirs,
           disallowedTools: effectiveDisallowed,
           timeoutMs: this.config.claude.timeoutMs,

--- a/src/bus/dispatch-lifecycle-summary.ts
+++ b/src/bus/dispatch-lifecycle-summary.ts
@@ -15,10 +15,18 @@ export function truncateDispatchErrorSummary(msg: string): string {
 }
 
 /**
- * Trim result summaries to the first line. Surfaces typically render this
- * inline next to a task label, so cap at 1000 chars to leave room for chrome.
+ * Trim result summaries to the first useful line. PAI-formatted chat replies
+ * start with status chrome, so prefer the first content-bearing line.
  */
 export function truncateDispatchResultSummary(text: string): string {
-  const first = text.split("\n", 1)[0] ?? text;
+  const lines = text.split("\n").map((line) => line.trim()).filter(Boolean);
+  const first = lines.find((line) =>
+    !line.startsWith("══")
+    && !/^[-= ]*PAI\b/i.test(line)
+    && !line.startsWith("TASK:")
+    && !line.startsWith("VERIFY:")
+    && !line.startsWith("🗒️")
+    && !line.startsWith("✅")
+  ) ?? lines[0] ?? text;
   return first.length > 1000 ? first.slice(0, 997) + "..." : first;
 }

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -13,7 +13,7 @@
 
 import { Command } from "commander";
 import { existsSync, writeFileSync, readFileSync, unlinkSync, mkdirSync, readdirSync } from "fs";
-import { basename, join, dirname } from "path";
+import { basename, join, dirname, isAbsolute } from "path";
 import { parse as parseYaml } from "yaml";
 import type { TextChannel } from "discord.js";
 
@@ -367,6 +367,20 @@ function resolvePrincipalId(
   );
 }
 
+function targetAgentForDispatch(
+  agent: Pick<Agent, "id" | "displayName" | "persona">,
+  configDir: string,
+): { id: string; displayName: string; persona: string } {
+  const expandedPersona = expandTilde(agent.persona);
+  return {
+    id: agent.id,
+    displayName: agent.displayName,
+    persona: isAbsolute(expandedPersona)
+      ? expandedPersona
+      : join(configDir, expandedPersona),
+  };
+}
+
 /**
  * Construct the full cortex stack and start it. Returns a stop handle.
  *
@@ -384,6 +398,7 @@ export async function startCortex(
     ? options.configPath.replace(/^~/, process.env.HOME ?? "~")
     : DEFAULT_CONFIG;
 
+  const configDir = dirname(expandedConfigPath);
   const securityPreamble = buildSecurityPreamble(config, expandedConfigPath);
   console.log("cortex: starting...");
   console.log(`  Agent: ${config.agent.displayName}`);
@@ -1462,7 +1477,7 @@ export async function startCortex(
       // Register the adapter's surface-router face. Empty `surfaceSubjects`
       // makes this a no-op match; harmless to register either way.
       router.register(adapter.surfaceConfig);
-      await adapter.start((msg) => dispatchHandler.handleMessage(adapter, msg));
+      await adapter.start((msg) => dispatchHandler.handleMessage(adapter, msg, targetAgentForDispatch(agent, configDir)));
       adapters.push(adapter);
 
       // cortex#98 (part B) — Pass 1 step c: register this adapter's bot
@@ -1619,7 +1634,7 @@ export async function startCortex(
         },
       );
       router.register(adapter.surfaceConfig);
-      await adapter.start((msg) => dispatchHandler.handleMessage(adapter, msg));
+      await adapter.start((msg) => dispatchHandler.handleMessage(adapter, msg, targetAgentForDispatch(agent, configDir)));
       adapters.push(adapter);
       console.log(`cortex: mattermost adapter started (instance: ${instanceId}, ${instance.channels.length} channel(s))`);
     } catch (err) {
@@ -1717,7 +1732,7 @@ export async function startCortex(
       // `attachInboundDispatch()`. This is the Slack equivalent of
       // discord.js's buffered-events-before-listener pattern.
       const explicitTrustedBotIds: ReadonlySet<string> = new Set(instance.trustedBotIds);
-      await adapter.start((msg) => dispatchHandler.handleMessage(adapter, msg));
+      await adapter.start((msg) => dispatchHandler.handleMessage(adapter, msg, targetAgentForDispatch(agent, configDir)));
       adapters.push(adapter);
       // Best-effort trust-resolver registration matches the Discord pattern.
       if (agentRegistry.tryGetById(agent.id)) {

--- a/src/substrates/claude-code/__tests__/harness.test.ts
+++ b/src/substrates/claude-code/__tests__/harness.test.ts
@@ -180,6 +180,19 @@ describe("ClaudeCodeHarness — happy path", () => {
     expect(completed?.payload.result_summary).toBe("Hello, world!");
   });
 
+  test("completed envelope summary skips PAI status chrome", async () => {
+    const result = makeResult({
+      response: "═══ PAI ═══════════════════════════\n🗒️ TASK: Acknowledge greeting\n✅ VERIFY: Ready\n🗣️ Ivy: Here and ready.",
+    });
+    const cap = captureFactory(result);
+    const h = new ClaudeCodeHarness({ source: SOURCE, ccSessionFactory: cap.factory });
+
+    const envelopes = await drain(h.dispatch(makeRequest()));
+    const completed = envelopes[1];
+
+    expect(completed?.payload.result_summary).toBe("🗣️ Ivy: Here and ready.");
+  });
+
   test("envelope source matches the harness source triple", async () => {
     const cap = captureFactory(makeResult());
     const h = new ClaudeCodeHarness({ source: SOURCE, ccSessionFactory: cap.factory });


### PR DESCRIPTION
## Summary
- stop publishing synthetic attachment session IDs as Claude resume IDs for normal Discord chat dispatches
- render dispatch lifecycle envelopes as concise user-facing status text instead of raw JSON
- skip PAI status chrome when deriving completed task summaries

Refs #409. Related to the live clawbox Ivy incident where Claude exited with `No conversation found with session ID`.

## Verification
- `bun test src/bus/__tests__/dispatch-handler.test.ts src/substrates/claude-code/__tests__/harness.test.ts src/adapters/__tests__/envelope-renderer.test.ts`
- `bunx tsc --noEmit --pretty false`
- live clawbox diagnosis: Discord path was passing a generated attachment UUID as `resume_session_id`; synthetic bus dispatches without resume completed successfully