### PR TITLE
feat(cortex): C-491 — dispatch-sink reply consumer (closes #491 outbound)

### DIFF
--- a/src/__tests__/cortex.test.ts
+++ b/src/__tests__/cortex.test.ts
@@ -198,8 +198,10 @@ describe("startCortex — wire-up", () => {
     // dispatch-listener no longer registers as a SurfaceAdapter; instead
     // it calls `runtime.onEnvelope(...)` directly so it can sit outside
     // the router's render-timeout (CC sessions take minutes, renderers
-    // are sub-second). That's two handlers in total post-#484.
-    expect(runtime.onEnvelopeHandlers.size).toBe(2);
+    // are sub-second). cortex#491 adds a THIRD handler: the dispatch sink
+    // (OUTBOUND) self-subscribes to the lifecycle stream via
+    // `runtime.onEnvelope` to deliver replies. Three handlers post-#491.
+    expect(runtime.onEnvelopeHandlers.size).toBe(3);
 
     await handle.stop();
     // Both `router.stop()` and `dispatchListener.stop()` unregister from
@@ -300,9 +302,10 @@ describe("startCortex — wire-up", () => {
       operator: { id: "v3-canonical-op" },
     });
     expect(handle).toBeDefined();
-    // 2 handlers: surface-router fan-out + dispatch-listener (cortex#484
-    // Option D — listener subscribes directly via runtime.onEnvelope).
-    expect(runtime.onEnvelopeHandlers.size).toBe(2);
+    // 3 handlers: surface-router fan-out + dispatch-listener (cortex#484
+    // Option D — listener subscribes directly via runtime.onEnvelope) +
+    // dispatch sink (cortex#491 — OUTBOUND lifecycle delivery).
+    expect(runtime.onEnvelopeHandlers.size).toBe(3);
     await handle.stop();
     expect(runtime.onEnvelopeHandlers.size).toBe(0);
   });
@@ -366,9 +369,12 @@ describe("startCortex — wire-up", () => {
       operator: { id: "test-op" },
     });
     expect(handle).toBeDefined();
-    // 2 handlers: surface-router fan-out + dispatch-listener (cortex#484
-    // Option D). Discord adapter would add a 3rd; disabled → still 2.
-    expect(runtime.onEnvelopeHandlers.size).toBe(2);
+    // 3 handlers: surface-router fan-out + dispatch-listener (cortex#484
+    // Option D) + dispatch sink (cortex#491). The disabled Discord
+    // instance registers NO adapter handler (adapters register with the
+    // surface-router via router.register, not runtime.onEnvelope) — the
+    // count stays at the three core subscribers.
+    expect(runtime.onEnvelopeHandlers.size).toBe(3);
     // No adapter started → no `system.adapter.*` envelope leaked.
     expect(runtime.published).toEqual([]);
     await handle.stop();
@@ -402,9 +408,12 @@ describe("startCortex — wire-up", () => {
       operator: { id: "test-op" },
     });
     expect(handle).toBeDefined();
-    // 2 handlers: surface-router fan-out + dispatch-listener (cortex#484
-    // Option D). Mattermost adapter would add a 3rd; skipped → still 2.
-    expect(runtime.onEnvelopeHandlers.size).toBe(2);
+    // 3 handlers: surface-router fan-out + dispatch-listener (cortex#484
+    // Option D) + dispatch sink (cortex#491). The skipped Mattermost
+    // instance registers NO adapter handler (adapters register with the
+    // surface-router via router.register, not runtime.onEnvelope) — the
+    // count stays at the three core subscribers.
+    expect(runtime.onEnvelopeHandlers.size).toBe(3);
     expect(runtime.published).toEqual([]);
     await handle.stop();
   });

--- a/src/__tests__/principal-identity-consistency.test.ts
+++ b/src/__tests__/principal-identity-consistency.test.ts
@@ -155,10 +155,12 @@ describe("principal-identity consistency (cortex#427 PR-A)", () => {
       // surface-router AND the dispatch-listener register handlers
       // on the runtime — the listener now subscribes directly
       // (executor-vs-renderer split, see
-      // `src/runner/dispatch-listener.ts` file-header docblock). Two
-      // handlers in total; both carry the resolved principal id in
-      // their derived subjects.
-      expect(runtime.onEnvelopeHandlers.size).toBe(2);
+      // `src/runner/dispatch-listener.ts` file-header docblock).
+      // cortex#491 adds a third: the dispatch sink (OUTBOUND) that
+      // self-subscribes to the lifecycle stream to deliver replies.
+      // Three handlers in total; all carry the resolved principal id
+      // in their derived subjects.
+      expect(runtime.onEnvelopeHandlers.size).toBe(3);
 
       // Stronger structural assertion: simulate an inbound envelope
       // on the V3-canonical subject. The router should accept it
@@ -253,9 +255,9 @@ describe("principal-identity consistency (cortex#427 PR-A)", () => {
     // candidate.) The positive "v3 wins" assertion is covered by
     // the unit test on `resolvePrincipalId` below.
     //
-    // Post cortex#484 Option D: 2 handlers (surface-router +
-    // dispatch-listener).
-    expect(runtime.onEnvelopeHandlers.size).toBe(2);
+    // Post cortex#484 Option D + cortex#491: 3 handlers (surface-router
+    // + dispatch-listener + dispatch sink).
+    expect(runtime.onEnvelopeHandlers.size).toBe(3);
     await handle.stop();
   });
 
@@ -279,9 +281,9 @@ describe("principal-identity consistency (cortex#427 PR-A)", () => {
       operator: { id: "v3-canonical-op" },
     });
 
-    // Post cortex#484 Option D: 2 handlers (surface-router +
-    // dispatch-listener).
-    expect(runtime.onEnvelopeHandlers.size).toBe(2);
+    // Post cortex#484 Option D + cortex#491: 3 handlers (surface-router
+    // + dispatch-listener + dispatch sink).
+    expect(runtime.onEnvelopeHandlers.size).toBe(3);
     await handle.stop();
   });
 

--- a/src/adapters/__tests__/dispatch-sink.test.ts
+++ b/src/adapters/__tests__/dispatch-sink.test.ts
@@ -1,0 +1,326 @@
+/**
+ * cortex#491 — dispatch sink (OUTBOUND) tests.
+ *
+ * Pins the consumer's contract (CONTEXT.md §Dispatch-sink / §Response-routing):
+ *   - subscribes to `local.{principal}[.{stack}].dispatch.task.>`
+ *   - reads `payload.response_routing` echoed by the runner
+ *   - filters to envelopes whose `adapter_instance` is THIS instance
+ *   - renders via `formatDispatchLifecycle` (reused from cortex#497)
+ *   - posts to the EXACT originating channel/thread (`postResponse`)
+ *   - `started` → `sendProgress` (typing/progress indicator)
+ *   - single delivery path: exactly one post per terminal envelope
+ */
+
+import { describe, expect, test } from "bun:test";
+import { createDispatchSink } from "../dispatch-sink";
+import { MockAdapter } from "../mock";
+import type { Envelope } from "../../bus/myelin/envelope-validator";
+import type { MyelinRuntime } from "../../bus/myelin/runtime";
+import type { MyelinSubscriber } from "../../bus/myelin/subscriber";
+
+/**
+ * Minimal runtime stub. Records subscribe patterns and lets a test fire an
+ * envelope through every registered `onEnvelope` handler. Mirrors the
+ * recordingRuntime in the dispatch-listener tests.
+ */
+function fakeRuntime(): {
+  runtime: MyelinRuntime;
+  trigger: (env: Envelope) => void;
+  subscribedPatterns: string[];
+  subscribers: { pattern: string; stopped: boolean }[];
+} {
+  const handlers = new Set<Parameters<MyelinRuntime["onEnvelope"]>[0]>();
+  const subscribedPatterns: string[] = [];
+  const subscribers: { pattern: string; stopped: boolean }[] = [];
+  const runtime: MyelinRuntime = {
+    enabled: true,
+    onEnvelope: (handler: Parameters<MyelinRuntime["onEnvelope"]>[0]) => {
+      handlers.add(handler);
+      return { unregister: () => { handlers.delete(handler); } };
+    },
+    publish: async () => {},
+    subscribe: async (pattern: string) => {
+      subscribedPatterns.push(pattern);
+      const entry = { pattern, stopped: false };
+      subscribers.push(entry);
+      return {
+        stop: async () => { entry.stopped = true; },
+      } as unknown as MyelinSubscriber;
+    },
+    stop: async () => {},
+  };
+  return {
+    runtime,
+    trigger: (env) => {
+      // onEnvelope fan-out hands (envelope, subject); the sink filters by
+      // envelope.type, so subject is informational here.
+      for (const h of handlers) h(env, "local.metafactory.dispatch.task.completed");
+    },
+    subscribedPatterns,
+    subscribers,
+  };
+}
+
+function lifecycleEnvelope(
+  type: string,
+  payload: Record<string, unknown>,
+): Envelope {
+  return {
+    id: "00000000-0000-4000-8000-000000000099",
+    source: "metafactory.runner.local",
+    type,
+    timestamp: "2026-05-09T12:00:00Z",
+    correlation_id: "task-1",
+    sovereignty: {
+      classification: "local",
+      data_residency: "NZ",
+      max_hop: 0,
+      frontier_ok: false,
+      model_class: "local-only",
+    },
+    payload,
+  };
+}
+
+const routing = (instance: string, channel: string, thread?: string) => ({
+  adapter_instance: instance,
+  channel_id: channel,
+  ...(thread !== undefined && { thread_id: thread }),
+});
+
+describe("dispatch-sink — subscription", () => {
+  test("subscribes to the stack-less lifecycle pattern when no stack", async () => {
+    const { runtime, subscribedPatterns } = fakeRuntime();
+    const sink = createDispatchSink({ runtime, adapters: [], principal: "metafactory" });
+    await sink.start();
+    expect(sink.subjects).toEqual(["local.metafactory.dispatch.task.>"]);
+    expect(subscribedPatterns).toEqual(["local.metafactory.dispatch.task.>"]);
+  });
+
+  test("subscribes to the stack-aware pattern when a stack is given", async () => {
+    const { runtime, subscribedPatterns } = fakeRuntime();
+    const sink = createDispatchSink({
+      runtime,
+      adapters: [],
+      principal: "andreas",
+      stack: "meta-factory",
+    });
+    await sink.start();
+    expect(subscribedPatterns).toEqual([
+      "local.andreas.meta-factory.dispatch.task.>",
+    ]);
+  });
+
+  test("start() is idempotent — no duplicate subscriptions", async () => {
+    const { runtime, subscribedPatterns } = fakeRuntime();
+    const sink = createDispatchSink({ runtime, adapters: [], principal: "metafactory" });
+    await sink.start();
+    await sink.start();
+    expect(subscribedPatterns).toHaveLength(1);
+  });
+
+  test("stop() drains subscribers and is idempotent", async () => {
+    const { runtime, subscribers } = fakeRuntime();
+    const sink = createDispatchSink({ runtime, adapters: [], principal: "metafactory" });
+    await sink.start();
+    await sink.stop();
+    await sink.stop();
+    expect(subscribers.every((s) => s.stopped)).toBe(true);
+  });
+});
+
+describe("dispatch-sink — delivery to the originating target", () => {
+  test("posts a completed reply to the exact channel + thread via formatDispatchLifecycle", async () => {
+    const { runtime, trigger } = fakeRuntime();
+    const adapter = new MockAdapter("discord-pai-collab");
+    const sink = createDispatchSink({ runtime, adapters: [adapter], principal: "metafactory" });
+    await sink.start();
+
+    trigger(
+      lifecycleEnvelope("dispatch.task.completed", {
+        agent_id: "luna",
+        result_summary: "first-line label",
+        chat_response: "Here is the full answer.",
+        response_routing: routing("discord-pai-collab", "C123", "T456"),
+      }),
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(adapter.sentMessages).toHaveLength(1);
+    const sent = adapter.sentMessages[0]!;
+    // Prefers the full chat_response over result_summary (cortex#491).
+    expect(sent.text).toBe("Here is the full answer.");
+    // EXACT originating target.
+    expect(sent.target).toEqual({
+      instanceId: "discord-pai-collab",
+      channelId: "C123",
+      threadId: "T456",
+    });
+  });
+
+  test("falls back to result_summary when no chat_response is carried", async () => {
+    const { runtime, trigger } = fakeRuntime();
+    const adapter = new MockAdapter("discord-pai-collab");
+    const sink = createDispatchSink({ runtime, adapters: [adapter], principal: "metafactory" });
+    await sink.start();
+
+    trigger(
+      lifecycleEnvelope("dispatch.task.completed", {
+        agent_id: "luna",
+        result_summary: "🗣️ Luna: Done.",
+        response_routing: routing("discord-pai-collab", "C123"),
+      }),
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(adapter.sentMessages[0]!.text).toBe("🗣️ Luna: Done.");
+    // No thread_id → channel-scope target (no threadId field).
+    expect(adapter.sentMessages[0]!.target).toEqual({
+      instanceId: "discord-pai-collab",
+      channelId: "C123",
+    });
+  });
+
+  test("posts a failed reply via postResponse", async () => {
+    const { runtime, trigger } = fakeRuntime();
+    const adapter = new MockAdapter("discord-pai-collab");
+    const sink = createDispatchSink({ runtime, adapters: [adapter], principal: "metafactory" });
+    await sink.start();
+
+    trigger(
+      lifecycleEnvelope("dispatch.task.failed", {
+        agent_id: "echo",
+        error_summary: "claude exited 1",
+        response_routing: routing("discord-pai-collab", "C9"),
+      }),
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(adapter.sentMessages).toHaveLength(1);
+    expect(adapter.sentMessages[0]!.text).toBe("Echo failed: claude exited 1");
+  });
+
+  test("started uses sendProgress, not postResponse", async () => {
+    const { runtime, trigger } = fakeRuntime();
+    const adapter = new MockAdapter("discord-pai-collab");
+    const sink = createDispatchSink({ runtime, adapters: [adapter], principal: "metafactory" });
+    await sink.start();
+
+    trigger(
+      lifecycleEnvelope("dispatch.task.started", {
+        agent_id: "luna",
+        response_routing: routing("discord-pai-collab", "C123", "T456"),
+      }),
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(adapter.sentMessages).toHaveLength(0);
+    expect(adapter.progressSent).toHaveLength(1);
+    expect(adapter.progressSent[0]!.text).toBe("Luna is working...");
+  });
+});
+
+describe("dispatch-sink — instance filter (no cross-instance posting)", () => {
+  test("ignores a lifecycle envelope routed to ANOTHER adapter instance", async () => {
+    const { runtime, trigger } = fakeRuntime();
+    const mine = new MockAdapter("discord-pai-collab");
+    const sink = createDispatchSink({ runtime, adapters: [mine], principal: "metafactory" });
+    await sink.start();
+
+    trigger(
+      lifecycleEnvelope("dispatch.task.completed", {
+        agent_id: "luna",
+        result_summary: "for someone else",
+        response_routing: routing("discord-other-instance", "C999"),
+      }),
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(mine.sentMessages).toHaveLength(0);
+  });
+
+  test("routes each envelope to its own instance among many adapters", async () => {
+    const { runtime, trigger } = fakeRuntime();
+    const a = new MockAdapter("inst-a");
+    const b = new MockAdapter("inst-b");
+    const sink = createDispatchSink({ runtime, adapters: [a, b], principal: "metafactory" });
+    await sink.start();
+
+    trigger(
+      lifecycleEnvelope("dispatch.task.completed", {
+        agent_id: "luna",
+        result_summary: "to B",
+        response_routing: routing("inst-b", "Cb"),
+      }),
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(a.sentMessages).toHaveLength(0);
+    expect(b.sentMessages).toHaveLength(1);
+    expect(b.sentMessages[0]!.target.channelId).toBe("Cb");
+  });
+});
+
+describe("dispatch-sink — no-routing and non-lifecycle envelopes", () => {
+  test("ignores a lifecycle envelope with NO response_routing (bus-peer / Offer)", async () => {
+    const { runtime, trigger } = fakeRuntime();
+    const adapter = new MockAdapter("discord-pai-collab");
+    const sink = createDispatchSink({ runtime, adapters: [adapter], principal: "metafactory" });
+    await sink.start();
+
+    trigger(
+      lifecycleEnvelope("dispatch.task.completed", {
+        agent_id: "luna",
+        result_summary: "no routing here",
+      }),
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(adapter.sentMessages).toHaveLength(0);
+  });
+
+  test("ignores non-lifecycle envelope types entirely", async () => {
+    const { runtime, trigger } = fakeRuntime();
+    const adapter = new MockAdapter("discord-pai-collab");
+    const sink = createDispatchSink({ runtime, adapters: [adapter], principal: "metafactory" });
+    await sink.start();
+
+    trigger(
+      lifecycleEnvelope("review.cycle.completed", {
+        agent_id: "luna",
+        response_routing: routing("discord-pai-collab", "C123"),
+      }),
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(adapter.sentMessages).toHaveLength(0);
+    expect(adapter.progressSent).toHaveLength(0);
+  });
+
+  test("single delivery path — exactly one post per terminal envelope", async () => {
+    const { runtime, trigger } = fakeRuntime();
+    const adapter = new MockAdapter("discord-pai-collab");
+    const sink = createDispatchSink({ runtime, adapters: [adapter], principal: "metafactory" });
+    await sink.start();
+
+    const env = lifecycleEnvelope("dispatch.task.completed", {
+      agent_id: "luna",
+      chat_response: "answer",
+      response_routing: routing("discord-pai-collab", "C123"),
+    });
+    trigger(env);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // The sink is the ONLY thing posting — never doubles a single envelope.
+    expect(adapter.sentMessages).toHaveLength(1);
+  });
+});

--- a/src/adapters/dispatch-sink.ts
+++ b/src/adapters/dispatch-sink.ts
@@ -1,0 +1,226 @@
+/**
+ * cortex#491 — **Dispatch sink** (OUTBOUND, Option B).
+ *
+ * The outbound half of a platform adapter (CONTEXT.md §Dispatch-sink): it
+ * subscribes to the dispatch lifecycle stream
+ * (`dispatch.task.{started|completed|failed|aborted}`), filters to the
+ * envelopes whose **response routing** (CONTEXT.md §Response-routing)
+ * names THIS adapter instance, renders the lifecycle event to text, and
+ * delivers it back to the EXACT originating channel/thread via
+ * `adapter.postResponse` / `adapter.sendProgress`.
+ *
+ * The sink keeps NO inbound state — the routing is wire-level. The runner
+ * echoes `payload.response_routing` (`{ adapter_instance, channel_id,
+ * thread_id? }`) onto every lifecycle envelope (see
+ * `src/runner/dispatch-listener.ts` → `echoResponseRouting`); the sink
+ * reads it straight off the envelope and posts.
+ *
+ * ## Single delivery path
+ *
+ * This consumer is the SOLE deliverer of lifecycle replies. It subscribes
+ * via the runtime directly (`runtime.subscribe` + `runtime.onEnvelope`,
+ * symmetric with how the runner self-subscribes in cortex#484 Option D),
+ * NOT via `surfaceSubjects` on the surface-router. Adding
+ * `dispatch.task.*` to a surface adapter's `surfaceSubjects` would be a
+ * SECOND, cruder delivery path (it renders the JSON code-block fallback
+ * to whatever channel the adapter is bound to) and would double-reply.
+ * The render-leak guard `surfaceSubjects: []` stays untouched.
+ *
+ * ## Text rendering
+ *
+ * Reuses `formatDispatchLifecycle` from `envelope-renderer.ts` (the
+ * cortex#497 renderer) verbatim — one formatter, no reinvented copy. The
+ * sink owns delivery + instance targeting; the renderer owns the text.
+ */
+
+import type { Envelope } from "../bus/myelin/envelope-validator";
+import type { MyelinRuntime } from "../bus/myelin/runtime";
+import type { MyelinSubscriber } from "../bus/myelin/subscriber";
+import { formatDispatchLifecycle } from "./envelope-renderer";
+import type { PlatformAdapter, ResponseTarget } from "./types";
+
+/**
+ * Response-routing shape as it appears on a lifecycle envelope's payload
+ * (snake_case wire idiom). Structurally the same triple a `ResponseTarget`
+ * carries. Mirrors `ResponseRouting` in `src/bus/dispatch-events.ts`; kept
+ * local to the sink's parse so the consumer doesn't depend on the runner's
+ * publish-side type for a read-only decode.
+ */
+interface WireResponseRouting {
+  adapter_instance: string;
+  channel_id: string;
+  thread_id?: string;
+}
+
+/**
+ * Parse `payload.response_routing` into a typed routing record, or `null`
+ * when the envelope carried none / it was malformed. Bus-peer and Offer
+ * dispatches have no originating surface address, so a missing field is a
+ * normal, non-error case — the sink simply ignores those envelopes.
+ */
+function readResponseRouting(envelope: Envelope): WireResponseRouting | null {
+  const raw = envelope.payload.response_routing;
+  if (raw === null || typeof raw !== "object") return null;
+  const r = raw as Record<string, unknown>;
+  if (typeof r.adapter_instance !== "string" || typeof r.channel_id !== "string") {
+    return null;
+  }
+  return {
+    adapter_instance: r.adapter_instance,
+    channel_id: r.channel_id,
+    ...(typeof r.thread_id === "string" && { thread_id: r.thread_id }),
+  };
+}
+
+/** Lifecycle event types the sink delivers. */
+const LIFECYCLE_TYPE_PREFIX = "dispatch.task.";
+
+export interface DispatchSinkOptions {
+  /**
+   * Runtime to subscribe on. The sink uses the SAME `onEnvelope` +
+   * `subscribe` primitives the runner uses, so it sees every lifecycle
+   * envelope the runner publishes via `runtime.publish`.
+   */
+  runtime: MyelinRuntime;
+  /**
+   * Platform adapters whose outbound side this sink drives. The sink
+   * matches `response_routing.adapter_instance` against each adapter's
+   * `instanceId`; envelopes for an instance NOT in this list are ignored
+   * (no cross-instance posting).
+   */
+  adapters: readonly PlatformAdapter[];
+  /**
+   * `{principal}` segment of the lifecycle subject. The sink subscribes to
+   * `local.{principal}[.{stack}].dispatch.task.>`.
+   */
+  principal: string;
+  /**
+   * Optional `{stack}` segment. When the runtime publishes with a stack
+   * (the 6-segment grammar), the subscribe pattern must carry it too.
+   */
+  stack?: string;
+}
+
+export interface DispatchSink {
+  /** Subject pattern(s) the sink subscribes to (exposed for testing). */
+  readonly subjects: readonly string[];
+  /** Wire up `onEnvelope` + `subscribe`. Idempotent. */
+  start(): Promise<void>;
+  /** Unregister + drain subscribers. Idempotent. */
+  stop(): Promise<void>;
+}
+
+/**
+ * Build the lifecycle subscribe pattern. `dispatch.task.*` envelopes are
+ * `classification: "local"`, so the subject is
+ * `local.{principal}[.{stack}].dispatch.task.>` — the `>` wildcard covers
+ * every action (`started`/`completed`/`failed`/`aborted`). Mirrors the
+ * runner's `canonicalTasksDirectSubject` stack-aware/legacy split so the
+ * subscribe side never drifts from the publish side's `deriveNatsSubject`.
+ */
+function lifecycleSubject(principal: string, stack?: string): string {
+  if (stack === undefined) {
+    return `local.${principal}.dispatch.task.>`;
+  }
+  return `local.${principal}.${stack}.dispatch.task.>`;
+}
+
+/**
+ * Create a dispatch sink. Wires nothing until `start()` is called.
+ */
+export function createDispatchSink(opts: DispatchSinkOptions): DispatchSink {
+  const { runtime, adapters, principal, stack } = opts;
+  // Index adapters by instanceId for the response-routing filter.
+  const adapterByInstance = new Map<string, PlatformAdapter>(
+    adapters.map((a) => [a.instanceId, a]),
+  );
+  const subjects = [lifecycleSubject(principal, stack)];
+
+  let registration: { unregister: () => void } | null = null;
+  let subscribers: MyelinSubscriber[] = [];
+
+  /**
+   * Deliver one lifecycle envelope. Pure routing + render + post; never
+   * throws (the runtime `onEnvelope` fan-out must not see a throw, and a
+   * failed delivery for one envelope must not stop the next).
+   */
+  async function deliver(envelope: Envelope): Promise<void> {
+    // Only lifecycle envelopes carry response routing the sink acts on.
+    if (!envelope.type.startsWith(LIFECYCLE_TYPE_PREFIX)) return;
+
+    const routing = readResponseRouting(envelope);
+    if (routing === null) return; // bus-peer / Offer / malformed — not ours.
+
+    // Instance filter — ignore envelopes routed to OTHER adapter
+    // instances. This is what makes multiple sinks (one per adapter
+    // instance) safe to run side by side without cross-posting.
+    const adapter = adapterByInstance.get(routing.adapter_instance);
+    if (adapter === undefined) return;
+
+    const text = formatDispatchLifecycle(envelope);
+    if (text === null || text.length === 0) return;
+
+    const target: ResponseTarget = {
+      instanceId: routing.adapter_instance,
+      channelId: routing.channel_id,
+      ...(routing.thread_id !== undefined && { threadId: routing.thread_id }),
+    };
+
+    try {
+      if (envelope.type === "dispatch.task.started") {
+        // A `started` event is a progress/typing indicator, not a final
+        // reply — edit-in-place so the terminal `completed`/`failed`
+        // reply is the durable message in the channel.
+        await adapter.sendProgress(target, text);
+        return;
+      }
+      // `completed` / `failed` / `aborted` — the terminal reply.
+      await adapter.postResponse(target, text);
+    } catch (err) {
+      // A platform post failure must not crash the fan-out. Log to
+      // stderr (per CLAUDE.md no-empty-catch rule) and move on; the
+      // dispatch already completed on the bus, only the surface delivery
+      // failed (rate limit, deleted channel, etc.).
+      process.stderr.write(
+        `cortex: dispatch-sink postResponse failed (instance=${routing.adapter_instance}, ` +
+          `channel=${routing.channel_id}, type=${envelope.type}): ` +
+          `${err instanceof Error ? err.message : String(err)}\n`,
+      );
+    }
+  }
+
+  return {
+    subjects,
+    async start() {
+      if (registration) return;
+      // Register the fan-out handler FIRST so any envelope that arrives
+      // synchronously after `subscribe()` is seen. The handler filters by
+      // event-type prefix (stack-agnostic) — robust even if a future
+      // emit site lands the lifecycle envelope on a slightly different
+      // subject shape than the subscribe pattern anticipated.
+      registration = runtime.onEnvelope((envelope) => {
+        if (!envelope.type.startsWith(LIFECYCLE_TYPE_PREFIX)) return;
+        // Fire-and-forget; `deliver` owns its own error boundary.
+        void deliver(envelope);
+      });
+      // Self-subscribe so the sink's declared interest doesn't depend on
+      // `nats.subjects[]` in cortex.yaml. `subscribe` is OPTIONAL on the
+      // runtime (undefined → stub runtime, stay dormant); `null` return →
+      // runtime disabled (no NATS). Both are legitimate dormant states.
+      if (runtime.subscribe) {
+        for (const pattern of subjects) {
+          const sub = await runtime.subscribe(pattern);
+          if (sub) subscribers.push(sub);
+        }
+      }
+    },
+    async stop() {
+      if (!registration) return;
+      registration.unregister();
+      registration = null;
+      const drained = subscribers;
+      subscribers = [];
+      await Promise.allSettled(drained.map((s) => s.stop()));
+    },
+  };
+}

--- a/src/adapters/envelope-renderer.ts
+++ b/src/adapters/envelope-renderer.ts
@@ -42,7 +42,22 @@ export function formatEnvelopeAsMarkdown(envelope: Envelope): string {
   ].join("\n");
 }
 
-function formatDispatchLifecycle(envelope: Envelope): string | null {
+/**
+ * Render a `dispatch.task.{started|completed|failed|aborted}` lifecycle
+ * envelope to concise reply text, or `null` for any other envelope type.
+ *
+ * Exported (cortex#491) so the **dispatch sink** (`src/adapters/dispatch-sink.ts`)
+ * reuses the SAME text it already produces for the surface-router render
+ * path — one formatter, no drift, no reinvented copy. The sink is the
+ * delivery half (`postResponse`/`sendProgress`); this stays the pure
+ * text half.
+ *
+ * For `dispatch.task.completed` it prefers the FULL untruncated
+ * `chat_response` (cortex#491 — the complete chat round-trip) and falls
+ * back to `result_summary` (the first-line/1000-char dashboard label)
+ * when no full reply was carried — so non-chat dispatches still render.
+ */
+export function formatDispatchLifecycle(envelope: Envelope): string | null {
   const payload = envelope.payload;
   const agent = typeof payload.agent_id === "string" ? payload.agent_id : "agent";
   const label = agent.charAt(0).toUpperCase() + agent.slice(1);
@@ -52,6 +67,10 @@ function formatDispatchLifecycle(envelope: Envelope): string | null {
   }
 
   if (envelope.type === "dispatch.task.completed") {
+    // cortex#491 — full reply when present (chat round-trip), else the
+    // dashboard summary label, else a terse default.
+    const full = typeof payload.chat_response === "string" ? payload.chat_response.trim() : "";
+    if (full) return full;
     const summary = typeof payload.result_summary === "string" ? payload.result_summary.trim() : "Done.";
     return summary || "Done.";
   }

--- a/src/bus/__tests__/dispatch-handler.test.ts
+++ b/src/bus/__tests__/dispatch-handler.test.ts
@@ -1094,10 +1094,59 @@ describe("DispatchHandler — Direction A Stage 4-B inbound envelope publish (co
     expect(payload.entity).toBe("issue/409");
     expect(payload.operator).toBe("andreas");
 
+    // cortex#491 — response routing stamped from the inbound message so
+    // the runner can echo it onto lifecycle envelopes and the dispatch
+    // sink can deliver the reply (CONTEXT.md §Response-routing). The
+    // default `makeMsg` has no threadId, so `thread_id` is omitted.
+    expect(payload.response_routing).toEqual({
+      adapter_instance: "mock-instance",
+      channel_id: "ch1",
+    });
+
     // Envelope must validate against the vendored myelin schema —
     // catches any regression where the new envelope shape drifts
     // from the wire contract the dispatch-listener consumes.
     expect(validateEnvelope(envelope).ok).toBe(true);
+
+    await handler.shutdown();
+  });
+
+  test("cortex#491 — response_routing carries thread_id for a threaded message", async () => {
+    const runtime = makeRecordingRuntimeWithSubject();
+    const handler = new DispatchHandler({
+      config: makeConfig(),
+      securityPreamble: "",
+      runtime,
+      systemEventSource: {
+        principal: "andreas",
+        agent: "cortex",
+        instance: "local",
+      },
+      stack: "meta-factory",
+      policyEngine: makePublishPolicyEngine(),
+    });
+
+    const published = await callPublishInboundDispatchEnvelope(
+      handler,
+      dispatchOpts({
+        msg: makeMsg({
+          platform: "discord",
+          authorId: "1487204875912609844",
+          instanceId: "discord-pai-collab",
+          channelId: "C100",
+          threadId: "T200",
+          content: "hello in a thread",
+        }),
+      }),
+    );
+
+    expect(published).toBe(true);
+    const { envelope } = runtime.subjectPublishes[0]!;
+    expect(envelope.payload.response_routing).toEqual({
+      adapter_instance: "discord-pai-collab",
+      channel_id: "C100",
+      thread_id: "T200",
+    });
 
     await handler.shutdown();
   });

--- a/src/bus/dispatch-events.ts
+++ b/src/bus/dispatch-events.ts
@@ -51,6 +51,34 @@ import type { SystemEventSource } from "./system-events";
 // the underlying shape is identical.
 export type DispatchEventSource = SystemEventSource;
 
+/**
+ * cortex#491 — **Response routing** (CONTEXT.md §Response-routing).
+ *
+ * The originating-surface address carried on an inbound dispatch envelope's
+ * payload (`response_routing`) and ECHOED by the runner onto every
+ * `dispatch.task.{action}` lifecycle envelope. A **dispatch sink** (the
+ * platform adapter's outbound side) reads it off the lifecycle envelope to
+ * deliver the reply to the right channel/thread WITHOUT keeping any inbound
+ * state — the routing is wire-level, not in-memory.
+ *
+ * For a Discord/Mattermost/Slack-sourced dispatch the address is
+ * `{ adapter_instance, channel_id, thread_id? }` — structurally the same
+ * triple a `ResponseTarget` carries (`{ instanceId, channelId, threadId? }`),
+ * but in the snake_case wire idiom the rest of the envelope payload uses.
+ *
+ * Future dispatch sources (MC dashboard "send task", taps) populate the
+ * same shape; sinks that don't recognise the `adapter_instance` ignore the
+ * envelope (see the dispatch-sink consumer in `src/adapters/dispatch-sink.ts`).
+ */
+export interface ResponseRouting {
+  /** Adapter instance id that sourced the dispatch (e.g. `discord-pai-collab`). */
+  adapter_instance: string;
+  /** Platform-native channel id to deliver the reply to. */
+  channel_id: string;
+  /** Thread id when the dispatch arrived in a thread/DM; omitted at channel scope. */
+  thread_id?: string;
+}
+
 function buildSource(src: SystemEventSource): string {
   return `${src.principal}.${src.agent}.${src.instance}`;
 }
@@ -134,6 +162,16 @@ export interface DispatchTaskCommonOpts {
    * {@link validateSubjectEnvelopeAlignment}).
    */
   classification?: Classification;
+  /**
+   * cortex#491 — **Response routing** echoed from the inbound dispatch
+   * envelope onto this lifecycle envelope. When supplied, surfaces as
+   * `payload.response_routing` so the originating **dispatch sink** can
+   * target the reply without keeping inbound state. Omitted (no field on
+   * the wire) for lifecycle events that have no originating surface
+   * address — e.g. a bus-peer or Offer dispatch whose source did not
+   * carry response routing.
+   */
+  responseRouting?: ResponseRouting;
 }
 
 /**
@@ -161,6 +199,11 @@ function buildBaseEnvelope(
     payload: {
       task_id: common.taskId,
       agent_id: common.agentId,
+      // cortex#491 — echo response routing when the inbound dispatch
+      // carried it, so the originating dispatch sink can find its target.
+      ...(common.responseRouting !== undefined && {
+        response_routing: common.responseRouting,
+      }),
       ...payloadExtras,
     },
   });
@@ -208,6 +251,17 @@ export interface DispatchTaskCompletedOpts extends DispatchTaskCommonOpts {
    * reasonable length — surfaces typically render the first line).
    */
   resultSummary?: string;
+  /**
+   * cortex#491 — the FULL, untruncated assistant reply for chat-style
+   * dispatches. `result_summary` is the first line capped at 1000 chars
+   * (a dashboard label); `chat_response` is the complete text a
+   * **dispatch sink** posts back to the originating channel via
+   * `adapter.postResponse`. Omitted for non-chat dispatches (the sink
+   * falls back to `result_summary`). Carries the same sovereignty as the
+   * envelope — `local` for local chat — so the full reply on the wire
+   * respects the dispatch's classification.
+   */
+  chatResponse?: string;
 }
 
 /**
@@ -226,6 +280,10 @@ export function createDispatchTaskCompletedEvent(
     completed_at: opts.completedAt.toISOString(),
     ...(opts.resultSummary !== undefined && {
       result_summary: opts.resultSummary,
+    }),
+    // cortex#491 — full reply for the chat round-trip (dispatch sink → postResponse).
+    ...(opts.chatResponse !== undefined && {
+      chat_response: opts.chatResponse,
     }),
   });
 }

--- a/src/bus/dispatch-source-publisher.ts
+++ b/src/bus/dispatch-source-publisher.ts
@@ -2,6 +2,7 @@ import { directTaskSubject } from "@the-metafactory/myelin/subjects";
 import { DID_RE } from "@the-metafactory/myelin/identity";
 import type { InboundMessage } from "../adapters/types";
 import type { PolicyEngine } from "../common/policy/engine";
+import type { ResponseRouting } from "./dispatch-events";
 import { buildBaseEnvelope } from "./envelope-builder";
 import type { Envelope } from "./myelin/envelope-validator";
 import type { MyelinRuntime } from "./myelin/runtime";
@@ -100,6 +101,26 @@ export function adapterOriginatorIdentity(
   return null;
 }
 
+/**
+ * cortex#491 — derive **response routing** from the inbound platform
+ * message (CONTEXT.md §Response-routing). The originating surface address
+ * `{ adapter_instance, channel_id, thread_id? }` is stamped onto the
+ * inbound payload so the runner can echo it onto the lifecycle envelopes
+ * and the originating **dispatch sink** can deliver the reply to the right
+ * channel/thread without keeping inbound state.
+ *
+ * `thread_id` is omitted (not present on the wire) when the message did
+ * not arrive in a thread/DM — the sink falls back to channel-scope
+ * delivery, matching `ResponseTarget`'s `threadId ?? channelId` convention.
+ */
+function responseRoutingFromMessage(msg: InboundMessage): ResponseRouting {
+  return {
+    adapter_instance: msg.instanceId,
+    channel_id: msg.channelId,
+    ...(msg.threadId !== undefined && { thread_id: msg.threadId }),
+  };
+}
+
 function buildDirectTaskPublishSubject(
   principal: string,
   targetDid: string,
@@ -159,6 +180,9 @@ export async function publishInboundChatDispatchEnvelope(
     task_id: opts.taskId,
     agent_id: opts.agentName,
     prompt: opts.prompt,
+    // cortex#491 — originating surface address; the runner echoes this onto
+    // every lifecycle envelope so the dispatch sink can post the reply back.
+    response_routing: responseRoutingFromMessage(opts.msg),
     ...(opts.groveChannel !== undefined && { grove_channel: opts.groveChannel }),
     ...(opts.groveNetwork !== undefined && { grove_network: opts.groveNetwork }),
     agent_name: opts.agentDisplayName,

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -82,6 +82,7 @@ import {
 import { MattermostAdapter } from "./adapters/mattermost";
 import { SlackAdapter } from "./adapters/slack";
 import type { PlatformAdapter } from "./adapters/types";
+import { createDispatchSink, type DispatchSink } from "./adapters/dispatch-sink";
 
 import { createDispatchListener, type DispatchListener } from "./runner/dispatch-listener";
 import { WorklogManager } from "./runner/worklog-manager";
@@ -1937,6 +1938,34 @@ export async function startCortex(
   });
   await dispatchListener.start();
 
+  // cortex#491 — dispatch sink (OUTBOUND). The single delivery path for
+  // dispatch lifecycle replies (CONTEXT.md §Dispatch-sink). Subscribes to
+  // `local.{principal}[.{stack}].dispatch.task.>` via the runtime
+  // (symmetric with the runner's self-subscribe — NOT via
+  // `surfaceSubjects`, which would be a second, double-replying path),
+  // filters each lifecycle envelope to the adapter instance named by its
+  // echoed `response_routing` (cortex#491 plumbing), renders the text via
+  // `formatDispatchLifecycle` (cortex#497), and posts back to the exact
+  // originating channel/thread via `adapter.postResponse` /
+  // `adapter.sendProgress`. Dormant when the runtime is disabled (no
+  // NATS) or no adapters started.
+  const dispatchSink: DispatchSink = createDispatchSink({
+    runtime,
+    adapters,
+    principal: principalId,
+    // `derivedStack.stack` is always defined in production (boot derives a
+    // stack id); pass it so the sink's subscribe pattern lands on the same
+    // 6-segment grammar the runtime publishes lifecycle envelopes on. The
+    // dispatch-listener wiring above passes `derivedStack.stack` the same
+    // way.
+    stack: derivedStack.stack,
+  });
+  await dispatchSink.start();
+  console.log(
+    `cortex: dispatch-sink started — subjects=[${dispatchSink.subjects.join(", ")}], ` +
+      `adapters=${adapters.length}`,
+  );
+
   // cortex#480 — boot-time self-signed envelope sanity check. After the
   // listeners are wired with `stackIdentity` + `stackNKeyPub`, build a
   // tiny envelope signed by the stack's own NKey and round-trip it
@@ -2074,6 +2103,7 @@ export async function startCortex(
       ...adapterCleanup.map((_, i) => `outbound poller stop[${i}]`),
       ...reviewConsumers.map((c, i) => `review-consumer stop[${i}] (agent=${c.agent.id})`),
       "dispatch-listener stop",
+      "dispatch-sink stop",
       "surface-router stop",
       "dispatch-handler shutdown",
       ...adapterStopNames,
@@ -2123,6 +2153,11 @@ export async function startCortex(
         }
       }
       await completeAsync("dispatch-listener stop", dispatchListener.stop());
+      // cortex#491 — drain the dispatch sink after the runner stops
+      // publishing lifecycle envelopes but before the surface-router /
+      // adapters stop, so no late `postResponse` lands after the
+      // platform connections close. `stop()` is idempotent.
+      await completeAsync("dispatch-sink stop", dispatchSink.stop());
       // IAW B.2a — bus-dispatch-listener drain runs after the dispatch
       // listener (which feeds dispatch-handler) but before the
       // surface-router stop. The listener's `stop()` awaits its

--- a/src/runner/__tests__/dispatch-listener.test.ts
+++ b/src/runner/__tests__/dispatch-listener.test.ts
@@ -539,6 +539,71 @@ describe("dispatch-listener — success path", () => {
     const completed = r.published.find((e) => e.type === "dispatch.task.completed");
     expect(completed).toBeDefined();
     expect(completed?.payload.result_summary).toBe("Hello!");
+    // cortex#491 — the completed envelope ALSO carries the full,
+    // untruncated reply (`chat_response`) for the dispatch sink to post
+    // back as the chat round-trip; `result_summary` stays the first-line
+    // dashboard label.
+    expect(completed?.payload.chat_response).toBe("Hello!\nMore details follow.");
+  });
+
+  test("cortex#491 — echoes response_routing onto every lifecycle envelope", async () => {
+    const r = recordingRuntime();
+    const router = createSurfaceRouter(r.runtime);
+    const { factory } = fakeFactory(SUCCESS_RESULT);
+    const listener = createDispatchListener({
+      runtime: r.runtime,
+      source: SOURCE,
+      ccSessionFactory: factory,
+      policyEngine: engineGranting(["dispatch.cortex"]),
+    });
+    await listener.start();
+    await router.start();
+
+    const routing = {
+      adapter_instance: "discord-pai-collab",
+      channel_id: "C123",
+      thread_id: "T456",
+    };
+    r.trigger(
+      makeReceivedEnvelope({
+        response_routing: routing,
+      }),
+      CANONICAL_CORTEX_CHAT_SUBJECT,
+    );
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    // Every LIFECYCLE envelope (started/completed) carries the echoed
+    // routing so the dispatch sink can target the reply. The audit
+    // envelope (system.access.allowed) is not a lifecycle envelope.
+    const lifecycle = r.published.filter((e) => e.type.startsWith("dispatch.task."));
+    expect(lifecycle.length).toBeGreaterThan(0);
+    for (const env of lifecycle) {
+      expect(env.payload.response_routing).toEqual(routing);
+    }
+  });
+
+  test("cortex#491 — no response_routing on lifecycle when the inbound carried none", async () => {
+    const r = recordingRuntime();
+    const router = createSurfaceRouter(r.runtime);
+    const { factory } = fakeFactory(SUCCESS_RESULT);
+    const listener = createDispatchListener({
+      runtime: r.runtime,
+      source: SOURCE,
+      ccSessionFactory: factory,
+      policyEngine: engineGranting(["dispatch.cortex"]),
+    });
+    await listener.start();
+    await router.start();
+
+    // bus-peer / Offer style inbound — no response_routing on the payload.
+    r.trigger(makeReceivedEnvelope(), CANONICAL_CORTEX_CHAT_SUBJECT);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    const lifecycle = r.published.filter((e) => e.type.startsWith("dispatch.task."));
+    expect(lifecycle.length).toBeGreaterThan(0);
+    for (const env of lifecycle) {
+      expect(env.payload.response_routing).toBeUndefined();
+    }
   });
 
   test("CC opts plumbed from payload to factory (snake_case → camelCase)", async () => {

--- a/src/runner/dispatch-listener.ts
+++ b/src/runner/dispatch-listener.ts
@@ -105,7 +105,10 @@ import type {
   PolicyDenyReason,
   Principal,
 } from "../common/policy/types";
-import { createDispatchTaskFailedEvent } from "../bus/dispatch-events";
+import {
+  createDispatchTaskFailedEvent,
+  type ResponseRouting,
+} from "../bus/dispatch-events";
 import type { TrustResolver } from "../common/agents/trust-resolver";
 import {
   verifySignedByChain,
@@ -192,6 +195,16 @@ export interface DispatchTaskReceivedPayload {
   project?: string;
   entity?: string;
   operator?: string;
+  /**
+   * cortex#491 — **Response routing** (CONTEXT.md §Response-routing): the
+   * originating surface address `{ adapter_instance, channel_id,
+   * thread_id? }`. Populated by a platform-adapter dispatch source so the
+   * runner can ECHO it onto every `dispatch.task.{action}` lifecycle
+   * envelope; the originating **dispatch sink** then delivers the reply to
+   * the right channel/thread without keeping inbound state. Omitted for
+   * dispatch sources with no platform reply surface (bus-peer, Offer).
+   */
+  response_routing?: ResponseRouting;
 }
 
 export interface DispatchListenerOptions {
@@ -1485,6 +1498,14 @@ async function handleDispatchEnvelope(
   // strict happens-before ordering the original implementation relied
   // on (`started` is observable before any terminal envelope, even when
   // the runtime is the bus's actual NATS transport).
+  //
+  // cortex#491 — ECHO response routing onto every lifecycle envelope so
+  // the originating dispatch sink can target the reply without state. The
+  // harness is substrate-agnostic and never sees the inbound payload; the
+  // runner — which parsed it — does the echo here. `undefined` when the
+  // dispatch source carried no `response_routing` (bus-peer / Offer): the
+  // envelope passes through verbatim, exactly as before this change.
+  const responseRouting = payload.response_routing;
   let firstYield = true;
   for await (const env of harness.dispatch(req)) {
     if (firstYield) {
@@ -1494,8 +1515,29 @@ async function handleDispatchEnvelope(
       // `started` got all the way through to a live CC session.
       trace(traceDispatch, runtime, source, "started", "info", traceCtx);
     }
-    await runtime.publish(env);
+    await runtime.publish(echoResponseRouting(env, responseRouting));
   }
+}
+
+/**
+ * cortex#491 — return a lifecycle envelope with `payload.response_routing`
+ * echoed from the inbound dispatch. Returns the envelope unchanged when
+ * there is no routing to echo, or when the harness already stamped one
+ * (defensive — the runner is the single echo authority, but we never
+ * clobber an existing value). Builds a fresh payload object so the
+ * harness's own envelope reference is not mutated in place.
+ */
+function echoResponseRouting(
+  env: Envelope,
+  responseRouting: ResponseRouting | undefined,
+): Envelope {
+  if (responseRouting === undefined) return env;
+  const payload = (env.payload ?? {}) as Record<string, unknown>;
+  if (payload.response_routing !== undefined) return env;
+  return {
+    ...env,
+    payload: { ...payload, response_routing: responseRouting },
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/src/runner/dispatch-listener.ts
+++ b/src/runner/dispatch-listener.ts
@@ -1532,7 +1532,7 @@ function echoResponseRouting(
   responseRouting: ResponseRouting | undefined,
 ): Envelope {
   if (responseRouting === undefined) return env;
-  const payload = (env.payload ?? {}) as Record<string, unknown>;
+  const payload = env.payload;
   if (payload.response_routing !== undefined) return env;
   return {
     ...env,

--- a/src/substrates/claude-code/harness.ts
+++ b/src/substrates/claude-code/harness.ts
@@ -442,6 +442,7 @@ export class ClaudeCodeHarness implements SessionHarness {
     correlationId: string,
     completedAt: Date,
     resultSummary?: string,
+    chatResponse?: string,
   ): Envelope {
     return createDispatchTaskCompletedEvent({
       source: this.source,
@@ -451,6 +452,10 @@ export class ClaudeCodeHarness implements SessionHarness {
       startedAt,
       completedAt,
       ...(resultSummary !== undefined && { resultSummary }),
+      // cortex#491 — carry the FULL CC reply (untruncated) so the dispatch
+      // sink can post the complete chat round-trip back to the channel.
+      // `resultSummary` stays the first-line/1000-char dashboard label.
+      ...(chatResponse !== undefined && { chatResponse }),
     });
   }
 
@@ -524,6 +529,8 @@ export class ClaudeCodeHarness implements SessionHarness {
         correlationId,
         new Date(),
         result.response ? truncateDispatchResultSummary(result.response) : undefined,
+        // cortex#491 — full reply, untruncated, for the chat round-trip.
+        result.response ? result.response : undefined,
       );
     }
 


### PR DESCRIPTION
## What

Completes cortex#491 **OUTBOUND** (Option B): the **dispatch sink** reply consumer. Composes on top of #497 (just merged), which added `formatDispatchLifecycle` as a render-only formatter. #497 renders text; this PR adds the **delivery + targeting** half — so there is a single, non-double-replying delivery path.

## Model (CONTEXT.md)

- **§Dispatch-sink** — "a platform adapter's OUTBOUND side subscribes to `dispatch.task.{started|completed|failed|aborted}` filtered by the dispatch's response routing and turns lifecycle events into `postResponse`/`sendProgress`."
- **§Response-routing** — `{adapter_instance, channel_id, thread_id?}` echoed onto every lifecycle envelope so the originating sink can correlate completion → platform target **without keeping state** (wire-level, not in-memory).

## Two halves

**Plumbing (first commit — finishes the existing WIP):**
- `src/bus/dispatch-source-publisher.ts` — `responseRoutingFromMessage(msg)` stamps `{adapter_instance, channel_id, thread_id?}` onto the inbound `tasks.chat` payload as `response_routing`.
- `src/runner/dispatch-listener.ts` — `ResponseRouting` type + `echoResponseRouting(env, routing)` echoes `payload.response_routing` onto every lifecycle envelope the runner publishes. `undefined` (bus-peer / Offer) → envelope passes through verbatim.
- `src/bus/dispatch-events.ts` + `src/substrates/claude-code/harness.ts` — carry the full untruncated `chat_response` (the complete chat round-trip) alongside the `result_summary` dashboard label.

**Sink consumer (this PR's new piece):**
- `src/adapters/dispatch-sink.ts` — `createDispatchSink({ runtime, adapters, principal, stack })`:
  - Subscribes to `local.{principal}[.{stack}].dispatch.task.>` via `runtime.onEnvelope` + `runtime.subscribe` — **symmetric with how the runner self-subscribes** (cortex#484 Option D), NOT via `surfaceSubjects`.
  - Reads `payload.response_routing`; **filters to envelopes whose `adapter_instance` matches an adapter instance this sink drives** (ignores others — no cross-instance posting).
  - Renders reply text by **reusing `formatDispatchLifecycle`** from `envelope-renderer.ts` (#497) — exported, not reinvented. Prefers the full `chat_response`, falls back to `result_summary`.
  - `dispatch.task.started` → `adapter.sendProgress` (typing/progress); `completed`/`failed`/`aborted` → `adapter.postResponse` to `{channel_id, thread_id?}` — the EXACT originating channel/thread.
- Wired in `src/cortex.ts` right after `dispatchListener.start()`; drained in the shutdown sequence.

## Single delivery path (no double-reply)

The sink is the **only** thing that posts lifecycle replies. It does **not** add `dispatch.task.*` to `surfaceSubjects` — that would be a second, cruder path (JSON code-block fallback to whatever channel the adapter is bound to) and would double-reply. The `surfaceSubjects: []` render-leak guard is left untouched.

## Sovereignty / PII

The sink posts whatever the lifecycle envelope carries; `chat_response` carries the same sovereignty classification as the dispatch (`local` for local chat). No new exfil path.

## Tests

- `src/adapters/__tests__/dispatch-sink.test.ts` (new): subscribe pattern (stack-aware + stack-less), idempotent start/stop + drain, post to exact channel+thread via `formatDispatchLifecycle`, `chat_response`-preferred / `result_summary`-fallback, `started`→`sendProgress`, `failed`→`postResponse`, **instance filter ignores other instances**, routes among many adapters, ignores no-routing (bus-peer/Offer) + non-lifecycle envelopes, **single-post per terminal envelope**.
- `src/bus/__tests__/dispatch-handler.test.ts`: `response_routing` on the published inbound payload (+ `thread_id` for a threaded message).
- `src/runner/__tests__/dispatch-listener.test.ts`: echo onto every lifecycle envelope; absent when inbound carried none; `chat_response` full-reply path on completed.
- `src/__tests__/cortex.test.ts` + `principal-identity-consistency.test.ts`: handler-count wire-up assertions updated 2→3 (the sink is the third `onEnvelope` subscriber).

## Verification

- `bunx tsc --noEmit` — clean.
- `bun test` — 3607 pass / 2 skip / 0 fail (190 files). Pre-existing flakes cortex#460/#461 did not trigger this run.
- `bun run lint:errors` — clean.

Composes on #497; reuses its `formatDispatchLifecycle`. Does NOT merge.

Closes #491 (outbound).