### PR TITLE
fix(discord): force @discordjs/ws onto `ws` on Bun — stop gateway flapping

### DIFF
--- a/src/bootstrap/__tests__/ws-transport.test.ts
+++ b/src/bootstrap/__tests__/ws-transport.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "bun:test";
+import { WebSocket as WsWebSocket } from "ws";
+import { installWsTransport } from "../ws-transport";
+
+describe("installWsTransport", () => {
+  const makeTarget = (existing?: unknown) =>
+    ({ WebSocket: existing }) as Record<string, unknown>;
+
+  it("forces the `ws` WebSocket on Bun and preserves the native impl", () => {
+    const native = function NativeWS() {};
+    const target = makeTarget(native);
+    const logs: string[] = [];
+
+    const r = installWsTransport(target, { isBun: true, nativeOptOut: false, log: (m) => logs.push(m) });
+
+    expect(r.applied).toBe(true);
+    expect(r.reason).toBe("applied:ws");
+    expect(target.WebSocket).toBe(WsWebSocket as unknown);
+    expect(target.__cortexNativeWebSocket).toBe(native);
+    expect(logs.join("")).toContain("forcing @discordjs/ws onto the `ws` package");
+  });
+
+  it("is a no-op on Node (native path already uses `ws`)", () => {
+    const native = function NativeWS() {};
+    const target = makeTarget(native);
+    const r = installWsTransport(target, { isBun: false, log: () => {} });
+    expect(r.applied).toBe(false);
+    expect(r.reason).toBe("not-bun");
+    expect(target.WebSocket).toBe(native); // untouched
+  });
+
+  it("respects the CORTEX_WS_NATIVE opt-out", () => {
+    const native = function NativeWS() {};
+    const target = makeTarget(native);
+    const r = installWsTransport(target, { isBun: true, nativeOptOut: true, log: () => {} });
+    expect(r.applied).toBe(false);
+    expect(r.reason).toBe("opt-out:CORTEX_WS_NATIVE");
+    expect(target.WebSocket).toBe(native); // untouched
+  });
+
+  it("is idempotent — a second apply no-ops", () => {
+    const target = makeTarget(function NativeWS() {});
+    installWsTransport(target, { isBun: true, log: () => {} });
+    const second = installWsTransport(target, { isBun: true, log: () => {} });
+    expect(second.applied).toBe(false);
+    expect(second.reason).toBe("already-applied");
+    expect(target.WebSocket).toBe(WsWebSocket as unknown);
+  });
+});

--- a/src/bootstrap/ws-transport.ts
+++ b/src/bootstrap/ws-transport.ts
@@ -1,0 +1,76 @@
+/**
+ * WebSocket transport bootstrap — force `@discordjs/ws` onto the robust `ws`
+ * package on Bun.
+ *
+ * Root cause (cortex#546/#581/#590/#591/#593 — the recurring
+ * `ClientConnectionResetError … Attempting a reconnect` flapping, same class
+ * as the 2026-05-09 8.4h outage): `@discordjs/util`'s
+ * `shouldUseGlobalFetchAndWebSocket()` keys on `"bun" in process.versions`,
+ * so on Bun it returns true and `@discordjs/ws` binds
+ *
+ *   WebSocketConstructor = shouldUseGlobalFetchAndWebSocket()
+ *     ? globalThis.WebSocket        // ← Bun's native WebSocket (drops: "Connection ended")
+ *     : import_ws.WebSocket;        // ← the battle-tested `ws` package (a hard dep, installed, unused)
+ *
+ * (`@discordjs/ws/dist/index.js:602`). discord.js on Node always uses `ws`;
+ * only Bun/Deno opt into native. We restore the Node-tested transport by
+ * overriding `globalThis.WebSocket` with the `ws` implementation BEFORE
+ * `@discordjs/ws` evaluates that module-level constructor.
+ *
+ * Placement contract: this module MUST be imported before any transitive
+ * `discord.js` import. cortex runs UNBUNDLED from source under Bun
+ * (`~/bin/cortex` → `src/cortex.ts`), so there is no tree-shake/bundle step
+ * to defeat the override — being the first import of the entry module is
+ * sufficient. ESM evaluates imported modules depth-first in source order, so
+ * `import "./bootstrap/ws-transport"` on line 1 runs its side effect before
+ * the discord.js subtree is evaluated.
+ *
+ * Scope: Bun only. On Node `shouldUseGlobalFetchAndWebSocket()` is already
+ * false (so @discordjs/ws uses `ws` regardless) and we leave the global
+ * untouched. Opt-out via `CORTEX_WS_NATIVE=1` to A/B against Bun's native
+ * transport while validating this fix.
+ */
+import { WebSocket as WsWebSocket } from "ws";
+
+/** True when running under Bun (where the native-WebSocket opt-in bites). */
+function runningUnderBun(): boolean {
+  if (typeof (globalThis as { Bun?: unknown }).Bun !== "undefined") return true;
+  const versions = (typeof process !== "undefined" ? process.versions : undefined) as
+    | (NodeJS.ProcessVersions & { bun?: string })
+    | undefined;
+  return typeof versions?.bun === "string";
+}
+
+/**
+ * Apply the override. Exported (rather than run purely as an import side
+ * effect) so the unit test can assert behaviour deterministically against an
+ * injected target object without mutating the real global. The module-load
+ * side effect below calls it against `globalThis`.
+ */
+export function installWsTransport(
+  target: Record<string, unknown> = globalThis as unknown as Record<string, unknown>,
+  opts: { isBun?: boolean; nativeOptOut?: boolean; log?: (msg: string) => void } = {},
+): { applied: boolean; reason: string } {
+  const isBun = opts.isBun ?? runningUnderBun();
+  const nativeOptOut = opts.nativeOptOut ?? process.env.CORTEX_WS_NATIVE === "1";
+
+  if (!isBun) return { applied: false, reason: "not-bun" };
+  if (nativeOptOut) return { applied: false, reason: "opt-out:CORTEX_WS_NATIVE" };
+
+  // Preserve the native impl for diagnostics / explicit fallback, then swap
+  // in `ws`. Idempotent: a second call sees `ws` already installed and no-ops.
+  if (target.WebSocket === (WsWebSocket as unknown)) {
+    return { applied: false, reason: "already-applied" };
+  }
+  target.__cortexNativeWebSocket = target.WebSocket;
+  target.WebSocket = WsWebSocket as unknown;
+  const log = opts.log ?? ((m: string) => process.stderr.write(m));
+  log(
+    "cortex/ws-transport: Bun detected — forcing @discordjs/ws onto the `ws` package " +
+      "(set CORTEX_WS_NATIVE=1 to keep Bun's native WebSocket)\n",
+  );
+  return { applied: true, reason: "applied:ws" };
+}
+
+// Module-load side effect: apply against the real global immediately.
+installWsTransport();

--- a/src/bootstrap/ws-transport.ts
+++ b/src/bootstrap/ws-transport.ts
@@ -35,9 +35,7 @@ import { WebSocket as WsWebSocket } from "ws";
 /** True when running under Bun (where the native-WebSocket opt-in bites). */
 function runningUnderBun(): boolean {
   if (typeof (globalThis as { Bun?: unknown }).Bun !== "undefined") return true;
-  const versions = (typeof process !== "undefined" ? process.versions : undefined) as
-    | (NodeJS.ProcessVersions & { bun?: string })
-    | undefined;
+  const versions = (typeof process !== "undefined" ? process.versions : undefined);
   return typeof versions?.bun === "string";
 }
 
@@ -48,7 +46,7 @@ function runningUnderBun(): boolean {
  * side effect below calls it against `globalThis`.
  */
 export function installWsTransport(
-  target: Record<string, unknown> = globalThis as unknown as Record<string, unknown>,
+  target: Record<string, unknown> = globalThis,
   opts: { isBun?: boolean; nativeOptOut?: boolean; log?: (msg: string) => void } = {},
 ): { applied: boolean; reason: string } {
   const isBun = opts.isBun ?? runningUnderBun();
@@ -63,7 +61,7 @@ export function installWsTransport(
     return { applied: false, reason: "already-applied" };
   }
   target.__cortexNativeWebSocket = target.WebSocket;
-  target.WebSocket = WsWebSocket as unknown;
+  target.WebSocket = WsWebSocket;
   const log = opts.log ?? ((m: string) => process.stderr.write(m));
   log(
     "cortex/ws-transport: Bun detected — forcing @discordjs/ws onto the `ws` package " +

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -11,6 +11,12 @@
  * tests construct pieces directly; the CLI bottom wires SIGINT/SIGTERM.
  */
 
+// MUST be first: forces @discordjs/ws onto the `ws` package on Bun (overrides
+// globalThis.WebSocket) BEFORE any transitive discord.js import evaluates its
+// module-level WebSocket constructor. Fixes the recurring gateway flapping
+// (cortex#546/#581/#590/#591/#593). See src/bootstrap/ws-transport.ts.
+import "./bootstrap/ws-transport";
+
 import { Command } from "commander";
 import { existsSync, writeFileSync, readFileSync, unlinkSync, mkdirSync, readdirSync } from "fs";
 import { basename, join, dirname, isAbsolute } from "path";


### PR DESCRIPTION
## Problem

The cortex daemon's Discord adapters flap constantly:
```
luna-discord: shard 0 WebSocket error: WebSocket connection to 'wss://gateway.discord.gg/…' failed: Connection ended
```
This is the root of the recurring auto-filed `[ClientConnectionResetError] … Attempting a reconnect` bugs (#546, #581, #590, #591, #593) and the same class as the 2026-05-09 8.4h outage.

## Root cause

`@discordjs/util`'s `shouldUseGlobalFetchAndWebSocket()` keys on `"bun" in process.versions`, so **on Bun it returns true** and `@discordjs/ws` binds:
```js
// @discordjs/ws/dist/index.js:602
WebSocketConstructor = shouldUseGlobalFetchAndWebSocket()
  ? globalThis.WebSocket   // ← Bun's native WebSocket (drops: "Connection ended")
  : import_ws.WebSocket;   // ← the battle-tested `ws` package (a hard dep, installed, UNUSED on Bun)
```
discord.js on Node always uses `ws`; only Bun/Deno opt into native. Bun 1.3.2's native gateway WebSocket is the unstable one.

## Fix

Restore the Node-tested transport by overriding `globalThis.WebSocket` with the `ws` implementation **before** `@discordjs/ws` evaluates that module-level constructor.

- **`src/bootstrap/ws-transport.ts`** — Bun-only override; preserves the native impl on `__cortexNativeWebSocket`; idempotent; opt-out via `CORTEX_WS_NATIVE=1` (to A/B the transports).
- Imported as the **first import** of `src/cortex.ts`. cortex runs **unbundled** from source under Bun (`~/bin/cortex` → `src/cortex.ts`), so first-import placement is sufficient — there's no bundler/tree-shake step to defeat it (verified: only the dashboard is `bun build`-bundled).
- Node deployments unaffected: there `shouldUseGlobalFetchAndWebSocket()` is already false, so this sets `globalThis.WebSocket` to the same `ws` impl Node already uses.

## Verification

- `bun test src/bootstrap/__tests__/ws-transport.test.ts` → 4 pass (Bun-apply, Node no-op, opt-out, idempotency)
- `bun test src/adapters/discord/__tests__/client-degraded.test.ts` → 9 pass (no regression)
- `bunx tsc --noEmit` → no errors in the new files
- Post-deploy validation: watch `reconnects so far` / `shard … reconnecting` counts drop toward ~0 in `cortex-meta-factory.error.log`.

Addresses #546 #581 #590 #591 #593.

🤖 Generated with [Claude Code](https://claude.com/claude-code)