### PR TITLE
feat(cortex): C-502 — review dispatch-sink + response_routing echo (platform-neutral review reply loop)

### DIFF
--- a/src/__tests__/cortex.test.ts
+++ b/src/__tests__/cortex.test.ts
@@ -200,8 +200,10 @@ describe("startCortex — wire-up", () => {
     // the router's render-timeout (CC sessions take minutes, renderers
     // are sub-second). cortex#491 adds a THIRD handler: the dispatch sink
     // (OUTBOUND) self-subscribes to the lifecycle stream via
-    // `runtime.onEnvelope` to deliver replies. Three handlers post-#491.
-    expect(runtime.onEnvelopeHandlers.size).toBe(3);
+    // `runtime.onEnvelope` to deliver replies. cortex#502 adds a FOURTH:
+    // the review sink (OUTBOUND) self-subscribes to the review lifecycle
+    // + verdict streams. Four handlers post-#502.
+    expect(runtime.onEnvelopeHandlers.size).toBe(4);
 
     await handle.stop();
     // Both `router.stop()` and `dispatchListener.stop()` unregister from
@@ -302,10 +304,11 @@ describe("startCortex — wire-up", () => {
       operator: { id: "v3-canonical-op" },
     });
     expect(handle).toBeDefined();
-    // 3 handlers: surface-router fan-out + dispatch-listener (cortex#484
+    // 4 handlers: surface-router fan-out + dispatch-listener (cortex#484
     // Option D — listener subscribes directly via runtime.onEnvelope) +
-    // dispatch sink (cortex#491 — OUTBOUND lifecycle delivery).
-    expect(runtime.onEnvelopeHandlers.size).toBe(3);
+    // dispatch sink (cortex#491 — OUTBOUND lifecycle delivery) + review
+    // sink (cortex#502 — OUTBOUND review lifecycle + verdict delivery).
+    expect(runtime.onEnvelopeHandlers.size).toBe(4);
     await handle.stop();
     expect(runtime.onEnvelopeHandlers.size).toBe(0);
   });
@@ -369,12 +372,12 @@ describe("startCortex — wire-up", () => {
       operator: { id: "test-op" },
     });
     expect(handle).toBeDefined();
-    // 3 handlers: surface-router fan-out + dispatch-listener (cortex#484
-    // Option D) + dispatch sink (cortex#491). The disabled Discord
-    // instance registers NO adapter handler (adapters register with the
-    // surface-router via router.register, not runtime.onEnvelope) — the
-    // count stays at the three core subscribers.
-    expect(runtime.onEnvelopeHandlers.size).toBe(3);
+    // 4 handlers: surface-router fan-out + dispatch-listener (cortex#484
+    // Option D) + dispatch sink (cortex#491) + review sink (cortex#502).
+    // The disabled Discord instance registers NO adapter handler (adapters
+    // register with the surface-router via router.register, not
+    // runtime.onEnvelope) — the count stays at the four core subscribers.
+    expect(runtime.onEnvelopeHandlers.size).toBe(4);
     // No adapter started → no `system.adapter.*` envelope leaked.
     expect(runtime.published).toEqual([]);
     await handle.stop();
@@ -408,12 +411,12 @@ describe("startCortex — wire-up", () => {
       operator: { id: "test-op" },
     });
     expect(handle).toBeDefined();
-    // 3 handlers: surface-router fan-out + dispatch-listener (cortex#484
-    // Option D) + dispatch sink (cortex#491). The skipped Mattermost
-    // instance registers NO adapter handler (adapters register with the
-    // surface-router via router.register, not runtime.onEnvelope) — the
-    // count stays at the three core subscribers.
-    expect(runtime.onEnvelopeHandlers.size).toBe(3);
+    // 4 handlers: surface-router fan-out + dispatch-listener (cortex#484
+    // Option D) + dispatch sink (cortex#491) + review sink (cortex#502).
+    // The skipped Mattermost instance registers NO adapter handler
+    // (adapters register with the surface-router via router.register, not
+    // runtime.onEnvelope) — the count stays at the four core subscribers.
+    expect(runtime.onEnvelopeHandlers.size).toBe(4);
     expect(runtime.published).toEqual([]);
     await handle.stop();
   });

--- a/src/__tests__/principal-identity-consistency.test.ts
+++ b/src/__tests__/principal-identity-consistency.test.ts
@@ -158,9 +158,11 @@ describe("principal-identity consistency (cortex#427 PR-A)", () => {
       // `src/runner/dispatch-listener.ts` file-header docblock).
       // cortex#491 adds a third: the dispatch sink (OUTBOUND) that
       // self-subscribes to the lifecycle stream to deliver replies.
-      // Three handlers in total; all carry the resolved principal id
+      // cortex#502 adds a fourth: the review sink (OUTBOUND) that
+      // self-subscribes to the review lifecycle + verdict streams.
+      // Four handlers in total; all carry the resolved principal id
       // in their derived subjects.
-      expect(runtime.onEnvelopeHandlers.size).toBe(3);
+      expect(runtime.onEnvelopeHandlers.size).toBe(4);
 
       // Stronger structural assertion: simulate an inbound envelope
       // on the V3-canonical subject. The router should accept it
@@ -255,9 +257,9 @@ describe("principal-identity consistency (cortex#427 PR-A)", () => {
     // candidate.) The positive "v3 wins" assertion is covered by
     // the unit test on `resolvePrincipalId` below.
     //
-    // Post cortex#484 Option D + cortex#491: 3 handlers (surface-router
-    // + dispatch-listener + dispatch sink).
-    expect(runtime.onEnvelopeHandlers.size).toBe(3);
+    // Post cortex#484 Option D + cortex#491 + cortex#502: 4 handlers
+    // (surface-router + dispatch-listener + dispatch sink + review sink).
+    expect(runtime.onEnvelopeHandlers.size).toBe(4);
     await handle.stop();
   });
 
@@ -281,9 +283,9 @@ describe("principal-identity consistency (cortex#427 PR-A)", () => {
       operator: { id: "v3-canonical-op" },
     });
 
-    // Post cortex#484 Option D + cortex#491: 3 handlers (surface-router
-    // + dispatch-listener + dispatch sink).
-    expect(runtime.onEnvelopeHandlers.size).toBe(3);
+    // Post cortex#484 Option D + cortex#491 + cortex#502: 4 handlers
+    // (surface-router + dispatch-listener + dispatch sink + review sink).
+    expect(runtime.onEnvelopeHandlers.size).toBe(4);
     await handle.stop();
   });
 

--- a/src/adapters/__tests__/review-sink.test.ts
+++ b/src/adapters/__tests__/review-sink.test.ts
@@ -388,6 +388,40 @@ describe("review-sink — no-routing and resilience", () => {
     expect(adapter.sentMessages).toHaveLength(1);
   });
 
+  test("verdict + co-emitted dispatch.task.completed → exactly ONE terminal post", async () => {
+    // A successful review co-emits BOTH review.verdict.* (the human-facing
+    // reply) AND dispatch.task.completed (whose result_summary duplicates the
+    // verdict) on the same correlation_id + routing. The sink must post only
+    // the verdict — completed is suppressed — so the thread isn't double-replied.
+    const { runtime, trigger } = fakeRuntime();
+    const adapter = discordMock();
+    const sink = createReviewSink({ runtime, adapters: [adapter], principal: "metafactory" });
+    await sink.start();
+
+    const routing = logicalRouting("discord", "cortex", "cortex/pr/57");
+    trigger(
+      envelope("review.verdict.approved", {
+        ...verdictPayload({ verdict: "approved" }),
+        response_routing: routing,
+      }),
+    );
+    trigger(
+      envelope("dispatch.task.completed", {
+        result_summary: "verdict: blockers=0 majors=0 nits=0 — recommend: merge",
+        response_routing: routing,
+      }),
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // Exactly one terminal message, and it's the VERDICT (carries the `@luna`
+    // requester ping, which only the verdict path adds) — not the completed
+    // envelope's result_summary.
+    expect(adapter.sentMessages).toHaveLength(1);
+    expect(adapter.sentMessages[0]?.text).toContain("@luna");
+  });
+
   test("never throws when postResponse rejects", async () => {
     const { runtime, trigger } = fakeRuntime();
     const adapter = discordMock();

--- a/src/adapters/__tests__/review-sink.test.ts
+++ b/src/adapters/__tests__/review-sink.test.ts
@@ -1,0 +1,412 @@
+/**
+ * cortex#502 — review sink (OUTBOUND) tests. Mirrors dispatch-sink.test.ts.
+ *
+ * Pins the consumer's contract:
+ *   - subscribes to BOTH `local.{principal}[.{stack}].dispatch.task.>` AND
+ *     `…review.verdict.>`
+ *   - reads `payload.response_routing` (LOGICAL shape — `{ surface, channel,
+ *     thread? }`)
+ *   - filters by `surface` matching an adapter it drives (no cross-surface)
+ *   - resolves logical→native via `adapter.resolveLogicalTarget`
+ *   - `dispatch.task.started` → `sendProgress`
+ *   - `review.verdict.*` / `completed`/`failed`/`aborted` → `postResponse`
+ *   - verdict renders the one-liner + GitHub link + requester ping
+ *   - ignores envelopes with no response_routing (pilot-only / Offer)
+ *   - single post per terminal envelope; never throws when postResponse rejects
+ */
+
+import { describe, expect, test } from "bun:test";
+import { createReviewSink } from "../review-sink";
+import { MockAdapter } from "../mock";
+import type { Envelope } from "../../bus/myelin/envelope-validator";
+import type { MyelinRuntime } from "../../bus/myelin/runtime";
+import type { MyelinSubscriber } from "../../bus/myelin/subscriber";
+
+function fakeRuntime(): {
+  runtime: MyelinRuntime;
+  trigger: (env: Envelope) => void;
+  subscribedPatterns: string[];
+  subscribers: { pattern: string; stopped: boolean }[];
+} {
+  const handlers = new Set<Parameters<MyelinRuntime["onEnvelope"]>[0]>();
+  const subscribedPatterns: string[] = [];
+  const subscribers: { pattern: string; stopped: boolean }[] = [];
+  const runtime: MyelinRuntime = {
+    enabled: true,
+    onEnvelope: (handler: Parameters<MyelinRuntime["onEnvelope"]>[0]) => {
+      handlers.add(handler);
+      return { unregister: () => { handlers.delete(handler); } };
+    },
+    publish: async () => {},
+    subscribe: async (pattern: string) => {
+      subscribedPatterns.push(pattern);
+      const entry = { pattern, stopped: false };
+      subscribers.push(entry);
+      return {
+        stop: async () => { entry.stopped = true; },
+      } as unknown as MyelinSubscriber;
+    },
+    stop: async () => {},
+  };
+  return {
+    runtime,
+    trigger: (env) => {
+      for (const h of handlers) h(env, "local.metafactory.review.verdict.approved");
+    },
+    subscribedPatterns,
+    subscribers,
+  };
+}
+
+function envelope(type: string, payload: Record<string, unknown>): Envelope {
+  return {
+    id: "00000000-0000-4000-8000-000000000099",
+    source: "metafactory.echo.local",
+    type,
+    timestamp: "2026-05-29T12:00:00Z",
+    correlation_id: "req-1",
+    sovereignty: {
+      classification: "local",
+      data_residency: "NZ",
+      max_hop: 0,
+      frontier_ok: false,
+      model_class: "local-only",
+    },
+    payload,
+  };
+}
+
+const logicalRouting = (surface: string, channel: string, thread?: string) => ({
+  surface,
+  channel,
+  ...(thread !== undefined && { thread }),
+});
+
+function verdictPayload(overrides: Record<string, unknown> = {}) {
+  return {
+    repo: "the-metafactory/cortex",
+    pr: 57,
+    reviewer: "luna",
+    verdict: "changes-requested",
+    summary: "verdict: blockers=1 majors=2 nits=3 — request-changes",
+    github_review_id: 123,
+    github_review_url:
+      "https://github.com/the-metafactory/cortex/pull/57#pullrequestreview-123",
+    submitted_at: "2026-05-29T12:01:00Z",
+    commit_id: "abc123",
+    findings: { blockers: 1, majors: 2, nits: 3 },
+    inline_comments: 5,
+    ...overrides,
+  };
+}
+
+// A mock adapter whose `platform`/`logicalSurface` is "discord" so it
+// matches a `surface: "discord"` envelope.
+function discordMock(instanceId = "discord-cortex"): MockAdapter {
+  const a = new MockAdapter(instanceId);
+  // Override the readonly `platform` for the surface filter. The sink
+  // pre-filters on `adapter.platform === routing.surface`.
+  Object.defineProperty(a, "platform", { value: "discord", writable: false });
+  a.logicalSurface = "discord";
+  return a;
+}
+
+describe("review-sink — subscription", () => {
+  test("subscribes to BOTH dispatch.task.> and review.verdict.> (stack-less)", async () => {
+    const { runtime, subscribedPatterns } = fakeRuntime();
+    const sink = createReviewSink({ runtime, adapters: [], principal: "metafactory" });
+    await sink.start();
+    expect(sink.subjects).toEqual([
+      "local.metafactory.dispatch.task.>",
+      "local.metafactory.review.verdict.>",
+    ]);
+    expect(subscribedPatterns).toEqual([
+      "local.metafactory.dispatch.task.>",
+      "local.metafactory.review.verdict.>",
+    ]);
+  });
+
+  test("subscribes to the stack-aware patterns when a stack is given", async () => {
+    const { runtime, subscribedPatterns } = fakeRuntime();
+    const sink = createReviewSink({
+      runtime,
+      adapters: [],
+      principal: "andreas",
+      stack: "meta-factory",
+    });
+    await sink.start();
+    expect(subscribedPatterns).toEqual([
+      "local.andreas.meta-factory.dispatch.task.>",
+      "local.andreas.meta-factory.review.verdict.>",
+    ]);
+  });
+
+  test("start() is idempotent; stop() drains and is idempotent", async () => {
+    const { runtime, subscribedPatterns, subscribers } = fakeRuntime();
+    const sink = createReviewSink({ runtime, adapters: [], principal: "metafactory" });
+    await sink.start();
+    await sink.start();
+    expect(subscribedPatterns).toHaveLength(2);
+    await sink.stop();
+    await sink.stop();
+    expect(subscribers.every((s) => s.stopped)).toBe(true);
+  });
+});
+
+describe("review-sink — verdict delivery", () => {
+  test("posts the verdict one-liner + GitHub link + requester ping to the resolved thread", async () => {
+    const { runtime, trigger } = fakeRuntime();
+    const adapter = discordMock();
+    const sink = createReviewSink({ runtime, adapters: [adapter], principal: "metafactory" });
+    await sink.start();
+
+    trigger(
+      envelope("review.verdict.changes-requested", {
+        ...verdictPayload(),
+        response_routing: logicalRouting("discord", "cortex", "cortex/pr/57"),
+      }),
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // resolveLogicalTarget was called with the logical triple.
+    expect(adapter.logicalTargetsResolved).toEqual([
+      { surface: "discord", channel: "cortex", thread: "cortex/pr/57" },
+    ]);
+    // Exactly one post, to the resolved native target.
+    expect(adapter.sentMessages).toHaveLength(1);
+    const sent = adapter.sentMessages[0]!;
+    expect(sent.target).toEqual({
+      instanceId: "discord-cortex",
+      channelId: "chan:cortex",
+      threadId: "thread:cortex/pr/57",
+    });
+    // Text carries the ping + emoji + verdict label + findings + url.
+    expect(sent.text).toContain("@luna");
+    expect(sent.text).toContain("🔴");
+    expect(sent.text).toContain("requested changes");
+    expect(sent.text).toContain("the-metafactory/cortex#57");
+    expect(sent.text).toContain("1B/2M/3N");
+    expect(sent.text).toContain(
+      "https://github.com/the-metafactory/cortex/pull/57#pullrequestreview-123",
+    );
+  });
+
+  test("approved verdict renders the ✅ label", async () => {
+    const { runtime, trigger } = fakeRuntime();
+    const adapter = discordMock();
+    const sink = createReviewSink({ runtime, adapters: [adapter], principal: "metafactory" });
+    await sink.start();
+
+    trigger(
+      envelope("review.verdict.approved", {
+        ...verdictPayload({
+          verdict: "approved",
+          findings: { blockers: 0, majors: 0, nits: 0 },
+        }),
+        response_routing: logicalRouting("discord", "cortex", "cortex/pr/57"),
+      }),
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(adapter.sentMessages[0]!.text).toContain("✅");
+    expect(adapter.sentMessages[0]!.text).toContain("approved");
+  });
+});
+
+describe("review-sink — lifecycle delivery", () => {
+  test("dispatch.task.started → sendProgress (not postResponse)", async () => {
+    const { runtime, trigger } = fakeRuntime();
+    const adapter = discordMock();
+    const sink = createReviewSink({ runtime, adapters: [adapter], principal: "metafactory" });
+    await sink.start();
+
+    trigger(
+      envelope("dispatch.task.started", {
+        agent_id: "luna",
+        response_routing: logicalRouting("discord", "cortex", "cortex/pr/57"),
+      }),
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(adapter.sentMessages).toHaveLength(0);
+    expect(adapter.progressSent).toHaveLength(1);
+    expect(adapter.progressSent[0]!.text).toContain("Luna is working");
+  });
+
+  test("dispatch.task.failed → postResponse error reply", async () => {
+    const { runtime, trigger } = fakeRuntime();
+    const adapter = discordMock();
+    const sink = createReviewSink({ runtime, adapters: [adapter], principal: "metafactory" });
+    await sink.start();
+
+    trigger(
+      envelope("dispatch.task.failed", {
+        agent_id: "echo",
+        error_summary: "claude exited 1",
+        response_routing: logicalRouting("discord", "cortex", "cortex/pr/57"),
+      }),
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(adapter.sentMessages).toHaveLength(1);
+    expect(adapter.sentMessages[0]!.text).toBe("Echo failed: claude exited 1");
+  });
+
+  test("dispatch.task.aborted → postResponse", async () => {
+    const { runtime, trigger } = fakeRuntime();
+    const adapter = discordMock();
+    const sink = createReviewSink({ runtime, adapters: [adapter], principal: "metafactory" });
+    await sink.start();
+
+    trigger(
+      envelope("dispatch.task.aborted", {
+        agent_id: "echo",
+        reason: "timeout",
+        response_routing: logicalRouting("discord", "cortex"),
+      }),
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(adapter.sentMessages).toHaveLength(1);
+    expect(adapter.sentMessages[0]!.text).toContain("stopped");
+  });
+});
+
+describe("review-sink — surface filter", () => {
+  test("ignores an envelope for a surface this sink doesn't drive", async () => {
+    const { runtime, trigger } = fakeRuntime();
+    const adapter = discordMock(); // drives "discord"
+    const sink = createReviewSink({ runtime, adapters: [adapter], principal: "metafactory" });
+    await sink.start();
+
+    trigger(
+      envelope("review.verdict.approved", {
+        ...verdictPayload({ verdict: "approved" }),
+        response_routing: logicalRouting("slack", "cortex", "cortex/pr/57"),
+      }),
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // The pre-filter (`adapter.platform !== surface`) skips the adapter
+    // entirely — resolveLogicalTarget is not even called.
+    expect(adapter.logicalTargetsResolved).toHaveLength(0);
+    expect(adapter.sentMessages).toHaveLength(0);
+  });
+
+  test("routes to the matching surface among many adapters", async () => {
+    const { runtime, trigger } = fakeRuntime();
+    const disc = discordMock("discord-cortex");
+    const other = new MockAdapter("mock-other"); // platform "mock"
+    const sink = createReviewSink({
+      runtime,
+      adapters: [other, disc],
+      principal: "metafactory",
+    });
+    await sink.start();
+
+    trigger(
+      envelope("review.verdict.approved", {
+        ...verdictPayload({ verdict: "approved" }),
+        response_routing: logicalRouting("discord", "cortex", "cortex/pr/57"),
+      }),
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(other.sentMessages).toHaveLength(0);
+    expect(disc.sentMessages).toHaveLength(1);
+  });
+});
+
+describe("review-sink — no-routing and resilience", () => {
+  test("ignores an envelope with NO response_routing (pilot-only / Offer)", async () => {
+    const { runtime, trigger } = fakeRuntime();
+    const adapter = discordMock();
+    const sink = createReviewSink({ runtime, adapters: [adapter], principal: "metafactory" });
+    await sink.start();
+
+    trigger(
+      envelope("review.verdict.approved", verdictPayload({ verdict: "approved" })),
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(adapter.logicalTargetsResolved).toHaveLength(0);
+    expect(adapter.sentMessages).toHaveLength(0);
+  });
+
+  test("ignores non-review/non-lifecycle envelope types entirely", async () => {
+    const { runtime, trigger } = fakeRuntime();
+    const adapter = discordMock();
+    const sink = createReviewSink({ runtime, adapters: [adapter], principal: "metafactory" });
+    await sink.start();
+
+    trigger(
+      envelope("review.cycle.completed", {
+        agent_id: "luna",
+        response_routing: logicalRouting("discord", "cortex"),
+      }),
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(adapter.sentMessages).toHaveLength(0);
+    expect(adapter.progressSent).toHaveLength(0);
+  });
+
+  test("single post per terminal envelope (no double-reply)", async () => {
+    const { runtime, trigger } = fakeRuntime();
+    const adapter = discordMock();
+    const sink = createReviewSink({ runtime, adapters: [adapter], principal: "metafactory" });
+    await sink.start();
+
+    trigger(
+      envelope("review.verdict.approved", {
+        ...verdictPayload({ verdict: "approved" }),
+        response_routing: logicalRouting("discord", "cortex", "cortex/pr/57"),
+      }),
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(adapter.sentMessages).toHaveLength(1);
+  });
+
+  test("never throws when postResponse rejects", async () => {
+    const { runtime, trigger } = fakeRuntime();
+    const adapter = discordMock();
+    adapter.postResponse = async () => {
+      throw new Error("rate limited");
+    };
+    const sink = createReviewSink({ runtime, adapters: [adapter], principal: "metafactory" });
+    await sink.start();
+
+    expect(() =>
+      trigger(
+        envelope("review.verdict.approved", {
+          ...verdictPayload({ verdict: "approved" }),
+          response_routing: logicalRouting("discord", "cortex", "cortex/pr/57"),
+        }),
+      ),
+    ).not.toThrow();
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+});

--- a/src/adapters/discord/__tests__/resolve-logical-target.test.ts
+++ b/src/adapters/discord/__tests__/resolve-logical-target.test.ts
@@ -1,0 +1,201 @@
+/**
+ * cortex#502 — `DiscordAdapter.resolveLogicalTarget` tests.
+ *
+ * Pins the logical→native seam the review sink relies on:
+ *   - `surface !== "discord"` → null (no cross-surface posting)
+ *   - resolves `channel` (repo short name) → guild channel snowflake by name
+ *   - when `thread` present → reuses `findOrCreateThreadByName` to get the
+ *     thread snowflake, returns a thread-scope ResponseTarget
+ *   - when `thread` absent → channel-scope ResponseTarget
+ *   - unknown channel name → null
+ */
+
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import { ChannelType } from "discord.js";
+import { DiscordAdapter, type DiscordAdapterInfra } from "../index";
+import type { Agent, DiscordPresence } from "../../../common/types/cortex-config";
+
+let originalWarn: typeof console.warn;
+let originalLog: typeof console.log;
+beforeEach(() => {
+  originalWarn = console.warn;
+  originalLog = console.log;
+  console.warn = () => {};
+  console.log = () => {};
+});
+afterEach(() => {
+  console.warn = originalWarn;
+  console.log = originalLog;
+});
+
+const GUILD_ID = "g1";
+
+/** Fake thread channel — only the fields the adapter reads. */
+interface FakeThread {
+  id: string;
+  name: string;
+}
+
+/** Fake text channel exposing the `threads` manager surface. */
+class FakeTextChannel {
+  type = ChannelType.GuildText;
+  id: string;
+  name: string;
+  existingThreads: FakeThread[] = [];
+  private nextThreadId = 7000;
+
+  constructor(id: string, name: string) {
+    this.id = id;
+    this.name = name;
+  }
+
+  threads = {
+    fetchActive: async () => {
+      const map = new Map<string, FakeThread>();
+      for (const t of this.existingThreads) map.set(t.id, t);
+      return { threads: map, members: new Map() };
+    },
+    create: async (opts: { name: string; autoArchiveDuration?: number; type?: number }) => {
+      const thread: FakeThread = { id: `thread-${this.nextThreadId++}`, name: opts.name };
+      this.existingThreads.push(thread);
+      return thread;
+    },
+  };
+}
+
+/**
+ * Fake client exposing BOTH `guilds.cache.get(id).channels.cache.find(...)`
+ * (the channel-by-name resolution `resolveLogicalTarget` uses) AND
+ * `channels.fetch(id)` (the parent fetch `findOrCreateThreadByName` uses).
+ */
+class FakeClient {
+  private channelsByName = new Map<string, FakeTextChannel>();
+  private channelsById = new Map<string, FakeTextChannel>();
+
+  addChannel(channel: FakeTextChannel): void {
+    this.channelsByName.set(channel.name, channel);
+    this.channelsById.set(channel.id, channel);
+  }
+
+  channels = {
+    fetch: async (id: string) => this.channelsById.get(id) ?? null,
+  };
+
+  guilds = {
+    cache: {
+      get: (id: string) => {
+        if (id !== GUILD_ID) return undefined;
+        const channels = this.channelsByName;
+        return {
+          channels: {
+            cache: {
+              find: (
+                pred: (c: { type: number; name: string; id: string }) => boolean,
+              ) => {
+                for (const c of channels.values()) {
+                  if (pred(c)) return c;
+                }
+                return undefined;
+              },
+            },
+          },
+        };
+      },
+    },
+  };
+}
+
+function makeAdapter(): { adapter: DiscordAdapter; client: FakeClient } {
+  const presence: DiscordPresence = {
+    enabled: true,
+    token: "fake-token",
+    guildId: GUILD_ID,
+    agentChannelId: "c1",
+    logChannelId: "c2",
+    contextDepth: 0,
+    enableAgentLog: false,
+    trustedBotIds: [],
+    surfaceSubjects: [],
+  };
+  const agent: Agent = {
+    id: "test-agent",
+    displayName: "TestAgent",
+    persona: "(test)",
+    trust: [],
+    presence: { discord: presence },
+  };
+  const infra: DiscordAdapterInfra = {
+    instanceId: "discord-cortex502",
+    principal: {},
+  };
+  const adapter = new DiscordAdapter(agent, presence, infra);
+  const client = new FakeClient();
+  (adapter as unknown as { client: FakeClient }).client = client;
+  return { adapter, client };
+}
+
+describe("DiscordAdapter.resolveLogicalTarget", () => {
+  test("returns null for a non-discord surface", async () => {
+    const { adapter } = makeAdapter();
+    const target = await adapter.resolveLogicalTarget({
+      surface: "slack",
+      channel: "cortex",
+      thread: "cortex/pr/57",
+    });
+    expect(target).toBeNull();
+  });
+
+  test("resolves channel→snowflake + findOrCreateThreadByName for the thread", async () => {
+    const { adapter, client } = makeAdapter();
+    client.addChannel(new FakeTextChannel("chan-cortex", "cortex"));
+
+    const target = await adapter.resolveLogicalTarget({
+      surface: "discord",
+      channel: "cortex",
+      thread: "cortex/pr/57",
+    });
+    expect(target).not.toBeNull();
+    expect(target!.instanceId).toBe("discord-cortex502");
+    expect(target!.channelId).toBe("chan-cortex");
+    // Thread was created and its snowflake returned.
+    expect(target!.threadId).toMatch(/^thread-/);
+  });
+
+  test("reuses an existing thread of the same name (idempotent)", async () => {
+    const { adapter, client } = makeAdapter();
+    const channel = new FakeTextChannel("chan-cortex", "cortex");
+    channel.existingThreads.push({ id: "thread-existing", name: "cortex/pr/57" });
+    client.addChannel(channel);
+
+    const target = await adapter.resolveLogicalTarget({
+      surface: "discord",
+      channel: "cortex",
+      thread: "cortex/pr/57",
+    });
+    expect(target!.threadId).toBe("thread-existing");
+  });
+
+  test("channel-scope target when no thread is given", async () => {
+    const { adapter, client } = makeAdapter();
+    client.addChannel(new FakeTextChannel("chan-cortex", "cortex"));
+
+    const target = await adapter.resolveLogicalTarget({
+      surface: "discord",
+      channel: "cortex",
+    });
+    expect(target).toEqual({
+      instanceId: "discord-cortex502",
+      channelId: "chan-cortex",
+    });
+  });
+
+  test("returns null when the channel name is unknown", async () => {
+    const { adapter } = makeAdapter();
+    const target = await adapter.resolveLogicalTarget({
+      surface: "discord",
+      channel: "does-not-exist",
+      thread: "x/pr/1",
+    });
+    expect(target).toBeNull();
+  });
+});

--- a/src/adapters/discord/index.ts
+++ b/src/adapters/discord/index.ts
@@ -910,6 +910,89 @@ export class DiscordAdapter implements PlatformAdapter {
     }
   }
 
+  /**
+   * cortex#502 — resolve a LOGICAL surface address (the review-path
+   * `response_routing` shape) to a native Discord {@link ResponseTarget}.
+   *
+   * The review wire stays platform-neutral: `channel` is a repo short name
+   * (the channel-routing SOP's "repos get channels") and `thread`, when
+   * present, is the `{repo}/{entity-type}/{number}` logical key ("GitHub
+   * entities get threads"). This method maps logical→native:
+   *
+   *   1. If `addr.surface !== "discord"`, return `null` — this is not our
+   *      surface, the review sink skips us (no cross-surface posting).
+   *   2. Resolve `addr.channel` (the repo short name) to a guild text
+   *      channel by NAME. The SOP guarantees one logical channel per repo,
+   *      so a name match is unambiguous.
+   *   3. If `addr.thread` is present, reuse the existing
+   *      {@link findOrCreateThreadByName} (the same primitive the inbound
+   *      channel-routing path uses) to get/create the `{repo}/...` thread
+   *      snowflake.
+   *   4. Return `null` on any unresolved channel/thread so the sink ignores
+   *      the envelope rather than mis-posting.
+   */
+  async resolveLogicalTarget(addr: {
+    surface: string;
+    channel: string;
+    thread?: string;
+  }): Promise<ResponseTarget | null> {
+    // Surface guard — only resolve addresses targeting Discord.
+    if (addr.surface !== this.platform) return null;
+    if (!this.client) return null;
+
+    // Resolve the repo-short-name channel to a guild text-channel snowflake
+    // by name. Scope the lookup to this adapter's guild so a name that
+    // exists in multiple guilds the bot is in can't cross-resolve.
+    const channelSnowflake = this.resolveChannelByName(addr.channel);
+    if (channelSnowflake === null) {
+      console.warn(
+        `discord-${this.instanceId}: resolveLogicalTarget: no channel named "${addr.channel}" in guild ${this.presence.guildId}`,
+      );
+      return null;
+    }
+
+    // Channel-scope target when no thread is requested.
+    if (addr.thread === undefined) {
+      return { instanceId: this.instanceId, channelId: channelSnowflake };
+    }
+
+    // Entity→thread: reuse the SOP machinery. `findOrCreateThreadByName`
+    // is idempotent — repeated review pings for the same PR collapse to a
+    // single `{repo}/pr/N` thread.
+    const thread = await this.findOrCreateThreadByName(
+      channelSnowflake,
+      addr.thread,
+    );
+    if (thread === null) {
+      // Thread couldn't be created/found (non-text parent, perms, etc.).
+      // Fall back to channel-scope rather than dropping the reply.
+      return { instanceId: this.instanceId, channelId: channelSnowflake };
+    }
+    return {
+      instanceId: this.instanceId,
+      channelId: channelSnowflake,
+      threadId: thread.threadId,
+      _native: thread.channel,
+    };
+  }
+
+  /**
+   * cortex#502 — resolve a channel NAME (repo short name) to its Discord
+   * snowflake within this adapter's guild. Returns `null` when no guild
+   * text channel of that name is found. Uses the discord.js channel cache
+   * (populated on connect via the `Guilds` intent); a cache miss for a
+   * channel that exists is rare for a long-lived connection.
+   */
+  private resolveChannelByName(name: string): string | null {
+    if (!this.client) return null;
+    const guild = this.client.guilds.cache.get(this.presence.guildId);
+    if (!guild) return null;
+    const match = guild.channels.cache.find(
+      (c) => c.type === ChannelType.GuildText && c.name === name,
+    );
+    return match ? match.id : null;
+  }
+
   async notifyOperator(text: string): Promise<void> {
     const principalDiscordId = this.infra.principal.discordId;
     if (!principalDiscordId || !this.client) return;

--- a/src/adapters/envelope-renderer.ts
+++ b/src/adapters/envelope-renderer.ts
@@ -87,3 +87,59 @@ export function formatDispatchLifecycle(envelope: Envelope): string | null {
 
   return null;
 }
+
+/**
+ * cortex#502 — render a `review.verdict.{approved|changes-requested|commented}`
+ * envelope to a concise one-liner reply, or `null` for any other envelope
+ * type. The verdict is the PRIMARY review reply; the **review sink**
+ * (`src/adapters/review-sink.ts`) reuses this formatter (one formatter, no
+ * reinvented copy — same discipline as the dispatch sink reusing
+ * `formatDispatchLifecycle`). The sink owns delivery + the requester ping;
+ * this stays the pure text half.
+ *
+ * Shape:
+ *   `{emoji} {reviewer} {verdict-label} {repo}#{pr} — {b}B/{m}M/{n}N · {url}`
+ *
+ * e.g. `🔴 echo requested changes the-metafactory/cortex#57 — 1B/2M/3N · https://github.com/...`
+ *
+ * Emoji + verdict-label by `payload.verdict`:
+ *   - `approved`          → ✅ "approved"
+ *   - `changes-requested` → 🔴 "requested changes"
+ *   - `commented`         → 💬 "commented on"
+ *
+ * Returns `null` (rather than a JSON fallback) for non-verdict envelopes so
+ * the sink can decide whether to fall through to `formatDispatchLifecycle`.
+ */
+export function formatReviewVerdict(envelope: Envelope): string | null {
+  if (!envelope.type.startsWith("review.verdict.")) return null;
+  const payload = envelope.payload;
+
+  const reviewer = typeof payload.reviewer === "string" ? payload.reviewer : "reviewer";
+  const repo = typeof payload.repo === "string" ? payload.repo : "?";
+  const pr = typeof payload.pr === "number" ? payload.pr : "?";
+  const url =
+    typeof payload.github_review_url === "string" ? payload.github_review_url : "";
+
+  const verdict = typeof payload.verdict === "string" ? payload.verdict : "";
+  let emoji: string;
+  let verdictLabel: string;
+  if (verdict === "approved") {
+    emoji = "✅";
+    verdictLabel = "approved";
+  } else if (verdict === "changes-requested") {
+    emoji = "🔴";
+    verdictLabel = "requested changes";
+  } else {
+    // "commented" or any unknown verdict — render neutrally.
+    emoji = "💬";
+    verdictLabel = "commented on";
+  }
+
+  const findings = (payload.findings ?? {}) as Record<string, unknown>;
+  const b = typeof findings.blockers === "number" ? findings.blockers : 0;
+  const m = typeof findings.majors === "number" ? findings.majors : 0;
+  const n = typeof findings.nits === "number" ? findings.nits : 0;
+
+  const head = `${emoji} ${reviewer} ${verdictLabel} ${repo}#${pr} — ${b}B/${m}M/${n}N`;
+  return url ? `${head} · ${url}` : head;
+}

--- a/src/adapters/mattermost/index.ts
+++ b/src/adapters/mattermost/index.ts
@@ -339,6 +339,24 @@ export class MattermostAdapter implements PlatformAdapter {
     };
   }
 
+  /**
+   * cortex#502 — logical→native resolution seam. Not yet implemented for
+   * Mattermost: returns `null` so the review sink skips this adapter (no
+   * cross-surface posting). When Mattermost gains review-sink delivery it
+   * maps `addr.channel` (repo short name) → channel id and `addr.thread`
+   * → root post id with its own name→primitive lookup; the wire is
+   * unchanged. The surface guard also returns `null` for non-`mattermost`
+   * surfaces.
+   */
+  // eslint-disable-next-line @typescript-eslint/require-await
+  async resolveLogicalTarget(_addr: {
+    surface: string;
+    channel: string;
+    thread?: string;
+  }): Promise<ResponseTarget | null> {
+    return null;
+  }
+
   async notifyOperator(text: string): Promise<void> {
     const principalMattermostId = this.infra.principal.mattermostId;
     if (!principalMattermostId) return;

--- a/src/adapters/mock.ts
+++ b/src/adapters/mock.ts
@@ -33,6 +33,15 @@ export class MockAdapter implements PlatformAdapter {
   progressSent: { target: ResponseTarget; text: string }[] = [];
   /** Recorded createThread calls */
   threadsCreated: { msg: InboundMessage; name: string }[] = [];
+  /** cortex#502 — recorded resolveLogicalTarget calls */
+  logicalTargetsResolved: { surface: string; channel: string; thread?: string }[] = [];
+  /**
+   * cortex#502 — the `surface` this mock claims to drive for
+   * `resolveLogicalTarget`. Defaults to `"mock"` (matching `platform`).
+   * A `resolveLogicalTarget({ surface })` whose surface !== this value
+   * returns `null` (the review sink then skips this adapter).
+   */
+  logicalSurface = "mock";
   /** Recorded notifyOperator calls */
   operatorNotifications: string[] = [];
   /** MIG-3b: Recorded envelopes received via surfaceConfig.render() */
@@ -135,6 +144,31 @@ export class MockAdapter implements PlatformAdapter {
   async notifyOperator(text: string): Promise<void> {
     this.operatorNotifications.push(text);
   }
+
+  /**
+   * cortex#502 — resolve a logical surface address to a native target.
+   * Records the call. Returns `null` when `addr.surface` !== `logicalSurface`
+   * (mirrors the Discord adapter's surface guard); otherwise maps the
+   * logical channel/thread to deterministic mock snowflakes so the review
+   * sink's posting path is exercised end-to-end.
+   */
+  async resolveLogicalTarget(addr: {
+    surface: string;
+    channel: string;
+    thread?: string;
+  }): Promise<ResponseTarget | null> {
+    this.logicalTargetsResolved.push({
+      surface: addr.surface,
+      channel: addr.channel,
+      ...(addr.thread !== undefined && { thread: addr.thread }),
+    });
+    if (addr.surface !== this.logicalSurface) return null;
+    return {
+      instanceId: this.instanceId,
+      channelId: `chan:${addr.channel}`,
+      ...(addr.thread !== undefined && { threadId: `thread:${addr.thread}` }),
+    };
+  }
   /* eslint-enable @typescript-eslint/require-await */
 
   /** Simulate an inbound message (for testing) */
@@ -154,6 +188,7 @@ export class MockAdapter implements PlatformAdapter {
     this.typingSent = [];
     this.progressSent = [];
     this.threadsCreated = [];
+    this.logicalTargetsResolved = [];
     this.operatorNotifications = [];
     this.envelopesRendered = [];
     this.threadCounter = 0;

--- a/src/adapters/review-sink.ts
+++ b/src/adapters/review-sink.ts
@@ -169,6 +169,14 @@ function renderText(envelope: Envelope): string | null {
         : "";
     return reviewer ? `@${reviewer} ${verdictLine}` : verdictLine;
   }
+  // Double-reply guard (#502 review): on the review path a successful review
+  // co-emits BOTH `review.verdict.*` (the human-facing terminal reply, handled
+  // above) AND `dispatch.task.completed` (whose `result_summary` is just the
+  // verdict summary — redundant on a human surface, though load-bearing for the
+  // dashboard sink). Suppress `completed` here so the originating thread gets
+  // exactly ONE terminal message. `failed`/`aborted` have no co-emitted verdict,
+  // so they remain the terminal reply and still render.
+  if (envelope.type === "dispatch.task.completed") return null;
   return formatDispatchLifecycle(envelope);
 }
 

--- a/src/adapters/review-sink.ts
+++ b/src/adapters/review-sink.ts
@@ -1,0 +1,301 @@
+/**
+ * cortex#502 — **Review sink** (OUTBOUND).
+ *
+ * The review-path analogue of the cortex#491/#498 dispatch sink. It is the
+ * outbound half of a platform adapter for the capability-dispatch review
+ * pipeline: it subscribes to BOTH the review lifecycle stream
+ * (`dispatch.task.{started|completed|failed|aborted}`) AND the load-bearing
+ * verdict stream (`review.verdict.{approved|changes-requested|commented}`),
+ * filters to the envelopes whose echoed **logical response routing**
+ * (`payload.response_routing` = `{ surface, channel, thread? }`) names a
+ * surface THIS sink drives, resolves the logical address to a native target
+ * via `adapter.resolveLogicalTarget`, renders the event to text, and posts
+ * it back to the originating channel/thread.
+ *
+ * ## Logical vs snowflake routing (the #502 divergence)
+ *
+ * The chat dispatch sink (#498) reads a Discord-snowflake triple
+ * (`{ adapter_instance, channel_id, thread_id }`) and posts directly. The
+ * review sink reads a platform-NEUTRAL logical triple
+ * (`{ surface, channel, thread? }` — repo short name + `{repo}/{type}/{n}`
+ * entity key per the channel-routing SOP) and asks each adapter to map it
+ * to native via `resolveLogicalTarget`. The wire never carries a snowflake,
+ * so the same envelope routes on Discord/Mattermost/Slack unchanged — each
+ * adapter owns its own name→primitive mapping at the sink.
+ *
+ * ## Surface filter (no cross-surface posting)
+ *
+ * There is no `adapter_instance` on the review wire. The sink filters by
+ * `response_routing.surface` matching an adapter's `platform`; a surface no
+ * driven adapter matches is ignored (mirrors the chat sink's instance
+ * filter). The SOP guarantees one logical channel per repo, so a
+ * surface + channel-name match is unambiguous.
+ *
+ * ## Single delivery path
+ *
+ * This consumer is the SOLE deliverer of review replies. It subscribes via
+ * the runtime directly (`runtime.subscribe` + `runtime.onEnvelope`,
+ * symmetric with the runner and the chat sink), NOT via `surfaceSubjects`.
+ * Adding `review.verdict.*` / `dispatch.task.*` to a surface adapter's
+ * `surfaceSubjects` would be a SECOND, double-replying path.
+ *
+ * ## Best-effort delivery
+ *
+ * Surface replies are best-effort / at-most-once by design (a dropped
+ * Discord post must never block the bus). Durability of the AUTHORITATIVE
+ * verdict is owned by pilot's `correlation_id` subscription, not the sink.
+ * Same never-throw error boundary as the dispatch sink.
+ *
+ * ## Text rendering
+ *
+ * Reuses `formatReviewVerdict` (verdict one-liner) and
+ * `formatDispatchLifecycle` (started/failed/aborted) from
+ * `envelope-renderer.ts` — one formatter family, no reinvented copy.
+ */
+
+import type { Envelope } from "../bus/myelin/envelope-validator";
+import type { MyelinRuntime } from "../bus/myelin/runtime";
+import type { MyelinSubscriber } from "../bus/myelin/subscriber";
+import {
+  formatDispatchLifecycle,
+  formatReviewVerdict,
+} from "./envelope-renderer";
+import type { PlatformAdapter, ResponseTarget } from "./types";
+
+/**
+ * The logical response-routing shape as it appears on a review envelope's
+ * payload. Mirrors `LogicalResponseRouting` in `src/bus/dispatch-events.ts`;
+ * kept local to the sink's parse so the consumer doesn't depend on the
+ * publish-side type for a read-only decode.
+ */
+interface WireLogicalRouting {
+  surface: string;
+  channel: string;
+  thread?: string;
+}
+
+/**
+ * Parse `payload.response_routing` into a typed logical routing record, or
+ * `null` when the envelope carried none / it was malformed. Bus-peer /
+ * pilot-only / Offer dispatches have no originating surface address, so a
+ * missing field is a normal, non-error case — the sink ignores those.
+ */
+function readLogicalRouting(envelope: Envelope): WireLogicalRouting | null {
+  const raw = envelope.payload.response_routing;
+  if (raw === null || typeof raw !== "object") return null;
+  const r = raw as Record<string, unknown>;
+  if (typeof r.surface !== "string" || typeof r.channel !== "string") {
+    return null;
+  }
+  return {
+    surface: r.surface,
+    channel: r.channel,
+    ...(typeof r.thread === "string" && { thread: r.thread }),
+  };
+}
+
+const LIFECYCLE_TYPE_PREFIX = "dispatch.task.";
+const VERDICT_TYPE_PREFIX = "review.verdict.";
+
+/** True for the envelope types the review sink acts on. */
+function isReviewSinkType(type: string): boolean {
+  return (
+    type.startsWith(LIFECYCLE_TYPE_PREFIX) || type.startsWith(VERDICT_TYPE_PREFIX)
+  );
+}
+
+export interface ReviewSinkOptions {
+  /**
+   * Runtime to subscribe on. The sink uses the SAME `onEnvelope` +
+   * `subscribe` primitives the runner uses, so it sees every lifecycle +
+   * verdict envelope the review consumer publishes via `runtime.publish`.
+   */
+  runtime: MyelinRuntime;
+  /**
+   * Platform adapters whose outbound side this sink drives. The sink
+   * filters `response_routing.surface` against each adapter's `platform`
+   * and asks the matching adapter to `resolveLogicalTarget`; envelopes for
+   * a surface no adapter drives are ignored (no cross-surface posting).
+   */
+  adapters: readonly PlatformAdapter[];
+  /**
+   * `{principal}` segment of the subjects. The sink subscribes to
+   * `local.{principal}[.{stack}].dispatch.task.>` AND
+   * `local.{principal}[.{stack}].review.verdict.>`.
+   */
+  principal: string;
+  /** Optional `{stack}` segment (the 6-segment grammar). */
+  stack?: string;
+}
+
+export interface ReviewSink {
+  /** Subject pattern(s) the sink subscribes to (exposed for testing). */
+  readonly subjects: readonly string[];
+  /** Wire up `onEnvelope` + `subscribe`. Idempotent. */
+  start(): Promise<void>;
+  /** Unregister + drain subscribers. Idempotent. */
+  stop(): Promise<void>;
+}
+
+/**
+ * Build the two subscribe patterns (lifecycle + verdict). Both envelope
+ * families are `classification: "local"`, so the subjects are
+ * `local.{principal}[.{stack}].dispatch.task.>` and
+ * `local.{principal}[.{stack}].review.verdict.>`. Mirrors the runner /
+ * dispatch-sink stack-aware/legacy split so the subscribe side never drifts
+ * from the publish side's subject derivation.
+ */
+function reviewSubjects(principal: string, stack?: string): string[] {
+  const base = stack === undefined ? `local.${principal}` : `local.${principal}.${stack}`;
+  return [`${base}.dispatch.task.>`, `${base}.review.verdict.>`];
+}
+
+/**
+ * Render the text for one review-sink envelope. Verdict envelopes render
+ * via `formatReviewVerdict` plus a requester ping; lifecycle envelopes
+ * render via `formatDispatchLifecycle`. Returns `null` when nothing should
+ * be posted.
+ */
+function renderText(envelope: Envelope): string | null {
+  if (envelope.type.startsWith(VERDICT_TYPE_PREFIX)) {
+    const verdictLine = formatReviewVerdict(envelope);
+    if (verdictLine === null || verdictLine.length === 0) return null;
+    // Ping the deliverable agent back so the requester is notified. The
+    // verdict's `reviewer` is the agent that produced it (e.g. `luna`);
+    // a leading `@{reviewer}` is the conventional Discord-style mention.
+    const reviewer =
+      typeof envelope.payload.reviewer === "string"
+        ? envelope.payload.reviewer
+        : "";
+    return reviewer ? `@${reviewer} ${verdictLine}` : verdictLine;
+  }
+  return formatDispatchLifecycle(envelope);
+}
+
+/**
+ * Create a review sink. Wires nothing until `start()` is called.
+ */
+export function createReviewSink(opts: ReviewSinkOptions): ReviewSink {
+  const { runtime, adapters, principal, stack } = opts;
+  const subjects = reviewSubjects(principal, stack);
+
+  let registration: { unregister: () => void } | null = null;
+  let subscribers: MyelinSubscriber[] = [];
+
+  /**
+   * Resolve the first adapter that drives `surface` to a native target for
+   * the logical address, or `null` when no adapter drives the surface / the
+   * address can't be resolved. The first adapter whose `resolveLogicalTarget`
+   * returns non-null wins; an adapter returns `null` for a surface it
+   * doesn't drive, so iterating is the surface filter.
+   */
+  async function resolveTarget(
+    routing: WireLogicalRouting,
+  ): Promise<ResponseTarget | null> {
+    for (const adapter of adapters) {
+      // Cheap pre-filter: only ask adapters whose platform matches the
+      // surface. (resolveLogicalTarget also guards internally, but this
+      // avoids a wasted async call per non-matching adapter.)
+      if (adapter.platform !== routing.surface) continue;
+      const target = await adapter.resolveLogicalTarget({
+        surface: routing.surface,
+        channel: routing.channel,
+        ...(routing.thread !== undefined && { thread: routing.thread }),
+      });
+      if (target !== null) return target;
+    }
+    return null;
+  }
+
+  /**
+   * Deliver one review envelope. Pure routing + resolve + render + post;
+   * never throws (the runtime `onEnvelope` fan-out must not see a throw,
+   * and a failed delivery for one envelope must not stop the next).
+   */
+  async function deliver(envelope: Envelope): Promise<void> {
+    if (!isReviewSinkType(envelope.type)) return;
+
+    const routing = readLogicalRouting(envelope);
+    if (routing === null) return; // pilot-only / bus-peer / Offer / malformed.
+
+    const text = renderText(envelope);
+    if (text === null || text.length === 0) return;
+
+    let target: ResponseTarget | null;
+    try {
+      target = await resolveTarget(routing);
+    } catch (err) {
+      // A resolve failure (e.g. a thread-create API error) must not crash
+      // the fan-out. Log and drop this delivery.
+      process.stderr.write(
+        `cortex: review-sink resolveLogicalTarget failed (surface=${routing.surface}, ` +
+          `channel=${routing.channel}, type=${envelope.type}): ` +
+          `${err instanceof Error ? err.message : String(err)}\n`,
+      );
+      return;
+    }
+    // No adapter drives this surface, or the channel/thread didn't resolve.
+    if (target === null) return;
+
+    // Pick the right adapter (by instanceId) to post through.
+    const adapter = adapters.find((a) => a.instanceId === target.instanceId);
+    if (adapter === undefined) return;
+
+    try {
+      if (envelope.type === "dispatch.task.started") {
+        // `started` is a progress/typing indicator (e.g. "Echo is
+        // reviewing…"), not a final reply — edit-in-place so the terminal
+        // verdict/failed reply is the durable message.
+        await adapter.sendProgress(target, text);
+        return;
+      }
+      // Verdict / completed / failed / aborted — the terminal reply.
+      await adapter.postResponse(target, text);
+    } catch (err) {
+      // A platform post failure must not crash the fan-out (per CLAUDE.md
+      // no-empty-catch rule). The review already completed on the bus;
+      // only the surface delivery failed (rate limit, deleted channel,
+      // etc.). The authoritative verdict still reached pilot via
+      // correlation_id.
+      process.stderr.write(
+        `cortex: review-sink postResponse failed (surface=${routing.surface}, ` +
+          `channel=${routing.channel}, type=${envelope.type}): ` +
+          `${err instanceof Error ? err.message : String(err)}\n`,
+      );
+    }
+  }
+
+  return {
+    subjects,
+    async start() {
+      if (registration) return;
+      // Register the fan-out handler FIRST so any envelope arriving
+      // synchronously after `subscribe()` is seen. The handler filters by
+      // event-type prefix (stack-agnostic) for robustness against subject-
+      // shape drift.
+      registration = runtime.onEnvelope((envelope) => {
+        if (!isReviewSinkType(envelope.type)) return;
+        // Fire-and-forget; `deliver` owns its own error boundary.
+        void deliver(envelope);
+      });
+      // Self-subscribe so the sink's declared interest doesn't depend on
+      // `nats.subjects[]` in cortex.yaml. `subscribe` is OPTIONAL on the
+      // runtime (undefined → stub runtime, stay dormant); `null` return →
+      // runtime disabled (no NATS). Both are legitimate dormant states.
+      if (runtime.subscribe) {
+        for (const pattern of subjects) {
+          const sub = await runtime.subscribe(pattern);
+          if (sub) subscribers.push(sub);
+        }
+      }
+    },
+    async stop() {
+      if (!registration) return;
+      registration.unregister();
+      registration = null;
+      const drained = subscribers;
+      subscribers = [];
+      await Promise.allSettled(drained.map((s) => s.stop()));
+    },
+  };
+}

--- a/src/adapters/slack/index.ts
+++ b/src/adapters/slack/index.ts
@@ -599,6 +599,24 @@ export class SlackAdapter implements PlatformAdapter {
     };
   }
 
+  /**
+   * cortex#502 — logical→native resolution seam. Not yet implemented for
+   * Slack: returns `null` so the review sink skips this adapter (no
+   * cross-surface posting). A future Slack implementation maps
+   * `addr.channel` (repo short name) → channel id via `conversations.list`
+   * and `addr.thread` → a `thread_ts` of a per-entity root message; the
+   * wire stays platform-neutral. The surface guard also returns `null` for
+   * non-`slack` surfaces.
+   */
+  // eslint-disable-next-line @typescript-eslint/require-await
+  async resolveLogicalTarget(_addr: {
+    surface: string;
+    channel: string;
+    thread?: string;
+  }): Promise<ResponseTarget | null> {
+    return null;
+  }
+
   async notifyOperator(text: string): Promise<void> {
     const principalSlackId = this.infra.principal.slackId;
     if (!principalSlackId) return;

--- a/src/adapters/types.ts
+++ b/src/adapters/types.ts
@@ -137,6 +137,33 @@ export interface PlatformAdapter {
   clearProgress(target: ResponseTarget): Promise<void>;
   /** Create a thread from a message */
   createThread(msg: InboundMessage, name: string): Promise<ResponseTarget>;
+
+  /**
+   * cortex#502 — resolve a LOGICAL surface address (the review-path
+   * `response_routing` shape) to a native {@link ResponseTarget}.
+   *
+   * The review wire stays platform-NEUTRAL (`{ surface, channel, thread? }`
+   * — repo short name + `{repo}/{entity-type}/{number}` logical key per the
+   * channel-routing SOP) so the same `review.verdict.*` / `dispatch.task.*`
+   * envelope routes on Discord/Mattermost/Slack unchanged. Each adapter
+   * implements this seam to map logical→native:
+   *
+   *   - Returns `null` when `addr.surface` is NOT this adapter's platform
+   *     (the review sink then skips this adapter — no cross-surface posting).
+   *   - Otherwise resolves `addr.channel` (repo short name) to the platform
+   *     channel and, when `addr.thread` is present, the platform thread
+   *     primitive (Discord reuses `findOrCreateThreadByName`).
+   *   - Returns `null` when the channel/thread can't be resolved (caller
+   *     falls back to ignoring the envelope rather than mis-posting).
+   *
+   * Mattermost/Slack implement the same method later with their own
+   * name→primitive mapping; the wire never changes.
+   */
+  resolveLogicalTarget(addr: {
+    surface: string;
+    channel: string;
+    thread?: string;
+  }): Promise<ResponseTarget | null>;
   /** Send a notification to the operator */
   notifyOperator(text: string): Promise<void>;
   /** F-092: Hot-reload adapter config (optional, for adapters that support it) */

--- a/src/bus/__tests__/review-consumer.test.ts
+++ b/src/bus/__tests__/review-consumer.test.ts
@@ -42,6 +42,7 @@ import {
   OFFER_DISPATCH_REVIEWER,
   failedReasonToAckDecision,
   parseReviewRequestPayload,
+  readLogicalResponseRouting,
   type ReviewConsumerAgent,
   type ReviewConsumerOpts,
 } from "../review-consumer";
@@ -1052,5 +1053,269 @@ describe("parseReviewRequestPayload — cortex#384 dual-shape acceptance", () =>
       pr_url: "https://github.com/the-metafactory/cortex/issues/5",
     });
     expect(parseReviewRequestPayload(env)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cortex#502 — response_routing echo
+// ---------------------------------------------------------------------------
+
+const LOGICAL_ROUTING = {
+  surface: "discord",
+  channel: "cortex",
+  thread: "cortex/pr/57",
+};
+
+/** A request envelope carrying the logical `response_routing` field. */
+function makeRequestWithRouting(
+  routing: unknown = LOGICAL_ROUTING,
+): Envelope {
+  const base = createReviewRequestEvent({
+    source: SOURCE,
+    flavor: "typescript",
+    payload: PAYLOAD,
+  });
+  return {
+    ...base,
+    payload: { ...base.payload, response_routing: routing },
+  };
+}
+
+/** Read `payload.response_routing` off an emitted envelope. */
+function routingOf(env: Envelope): unknown {
+  return (env.payload as { response_routing?: unknown }).response_routing;
+}
+
+describe("readLogicalResponseRouting (helper)", () => {
+  test("reads the logical triple with thread", () => {
+    expect(readLogicalResponseRouting(makeRequestWithRouting())).toEqual(LOGICAL_ROUTING);
+  });
+
+  test("reads channel-scope (no thread)", () => {
+    const env = makeRequestWithRouting({ surface: "discord", channel: "cortex" });
+    expect(readLogicalResponseRouting(env)).toEqual({
+      surface: "discord",
+      channel: "cortex",
+    });
+  });
+
+  test("returns null on missing field", () => {
+    expect(readLogicalResponseRouting(makeRequest("typescript"))).toBeNull();
+  });
+
+  test("returns null on malformed field (missing surface/channel)", () => {
+    expect(readLogicalResponseRouting(makeRequestWithRouting({ surface: "discord" }))).toBeNull();
+    expect(readLogicalResponseRouting(makeRequestWithRouting({ channel: "cortex" }))).toBeNull();
+    expect(readLogicalResponseRouting(makeRequestWithRouting("not-an-object"))).toBeNull();
+  });
+});
+
+describe("ReviewConsumer — response_routing echo (cortex#502)", () => {
+  test("verdict path: started + verdict + completed all carry identical response_routing + correlation_id", async () => {
+    const runtime = createRecordingRuntime();
+    const request = makeRequestWithRouting();
+    const consumer = new ReviewConsumer(
+      baseOpts({
+        runtime,
+        // The real pipeline threads opts.responseRouting onto the verdict;
+        // emulate that here so the verdict carries it like production.
+        pipelineRunner: fixedPipeline((opts) => ({
+          kind: "verdict",
+          envelope: createReviewVerdictEvent({
+            source: SOURCE,
+            kind: "approved",
+            correlationId: opts.requestEnvelope.id,
+            ...(opts.responseRouting !== undefined && {
+              responseRouting: opts.responseRouting,
+            }),
+            payload: {
+              repo: PAYLOAD.repo,
+              pr: PAYLOAD.pr,
+              reviewer: "echo",
+              verdict: "approved",
+              summary: "verdict: blockers=0 majors=0 nits=0 — approved",
+              github_review_id: 1,
+              github_review_url: "https://github.com/x/y/pull/1#r1",
+              submitted_at: "2026-05-29T12:00:00Z",
+              commit_id: "abc",
+              findings: { blockers: 0, majors: 0, nits: 0 },
+              inline_comments: 0,
+            },
+          }),
+        })),
+      }),
+    );
+
+    await consumer.processEnvelope(
+      request,
+      "local.metafactory.tasks.code-review.typescript",
+      null,
+    );
+
+    expect(runtime.published.map((e) => e.type)).toEqual([
+      "dispatch.task.started",
+      "review.verdict.approved",
+      "dispatch.task.completed",
+    ]);
+    for (const env of runtime.published) {
+      expect(routingOf(env)).toEqual(LOGICAL_ROUTING);
+      expect(env.correlation_id).toBe(request.id);
+    }
+  });
+
+  test("failed path: started + failed carry response_routing", async () => {
+    const runtime = createRecordingRuntime();
+    const request = makeRequestWithRouting();
+    const consumer = new ReviewConsumer(
+      baseOpts({
+        runtime,
+        pipelineRunner: fixedPipeline((opts) => ({
+          kind: "failed",
+          envelope: createReviewTaskFailedEvent({
+            source: SOURCE,
+            taskId: crypto.randomUUID(),
+            agentId: "echo",
+            correlationId: opts.requestEnvelope.id,
+            startedAt: new Date(),
+            failedAt: new Date(),
+            errorSummary: "boom",
+            reason: { kind: "cant_do", detail: "boom" },
+            ...(opts.responseRouting !== undefined && {
+              responseRouting: opts.responseRouting,
+            }),
+          }),
+        })),
+      }),
+    );
+
+    await consumer.processEnvelope(
+      request,
+      "local.metafactory.tasks.code-review.typescript",
+      null,
+    );
+
+    expect(runtime.published.map((e) => e.type)).toEqual([
+      "dispatch.task.started",
+      "dispatch.task.failed",
+    ]);
+    for (const env of runtime.published) {
+      expect(routingOf(env)).toEqual(LOGICAL_ROUTING);
+    }
+  });
+
+  test("pre-pipeline failure (no capability) echoes response_routing onto the failed envelope", async () => {
+    const runtime = createRecordingRuntime();
+    // Request a flavor this agent (typescript-only) does NOT claim.
+    const request = {
+      ...makeRequestWithRouting(),
+    };
+    // Override the type to a non-claimed flavor.
+    const pythonRequest: Envelope = {
+      ...request,
+      type: "tasks.code-review.python",
+    };
+    const consumer = new ReviewConsumer(baseOpts({ runtime }));
+
+    const decision = await consumer.processEnvelope(
+      pythonRequest,
+      "local.metafactory.tasks.code-review.python",
+      null,
+    );
+
+    expect(decision.kind).toBe("term");
+    expect(runtime.published.length).toBe(1);
+    expect(runtime.published[0]!.type).toBe("dispatch.task.failed");
+    expect(routingOf(runtime.published[0]!)).toEqual(LOGICAL_ROUTING);
+  });
+
+  test("aborted path (redelivery>1) echoes response_routing", async () => {
+    const runtime = createRecordingRuntime();
+    const request = makeRequestWithRouting();
+    const consumer = new ReviewConsumer(
+      baseOpts({
+        runtime,
+        pipelineRunner: fixedPipeline((opts) => ({
+          kind: "verdict",
+          envelope: createReviewVerdictEvent({
+            source: SOURCE,
+            kind: "approved",
+            correlationId: opts.requestEnvelope.id,
+            ...(opts.responseRouting !== undefined && {
+              responseRouting: opts.responseRouting,
+            }),
+            payload: {
+              repo: PAYLOAD.repo,
+              pr: PAYLOAD.pr,
+              reviewer: "echo",
+              verdict: "approved",
+              summary: "ok",
+              github_review_id: 1,
+              github_review_url: "https://github.com/x/y/pull/1#r1",
+              submitted_at: "2026-05-29T12:00:00Z",
+              commit_id: "abc",
+              findings: { blockers: 0, majors: 0, nits: 0 },
+              inline_comments: 0,
+            },
+          }),
+        })),
+      }),
+    );
+
+    await consumer.processEnvelope(
+      request,
+      "local.metafactory.tasks.code-review.typescript",
+      { info: { redeliveryCount: 2 }, redelivered: true } as unknown as JsMsg,
+    );
+
+    const aborted = runtime.published.find((e) => e.type === "dispatch.task.aborted");
+    expect(aborted).toBeDefined();
+    expect(routingOf(aborted!)).toEqual(LOGICAL_ROUTING);
+  });
+
+  test("request WITHOUT response_routing → no key on ANY emitted envelope (pilot-only path)", async () => {
+    const runtime = createRecordingRuntime();
+    const request = makeRequest("typescript"); // no response_routing
+    const consumer = new ReviewConsumer(
+      baseOpts({
+        runtime,
+        pipelineRunner: fixedPipeline((opts) => ({
+          kind: "verdict",
+          envelope: createReviewVerdictEvent({
+            source: SOURCE,
+            kind: "approved",
+            correlationId: opts.requestEnvelope.id,
+            ...(opts.responseRouting !== undefined && {
+              responseRouting: opts.responseRouting,
+            }),
+            payload: {
+              repo: PAYLOAD.repo,
+              pr: PAYLOAD.pr,
+              reviewer: "echo",
+              verdict: "approved",
+              summary: "ok",
+              github_review_id: 1,
+              github_review_url: "https://github.com/x/y/pull/1#r1",
+              submitted_at: "2026-05-29T12:00:00Z",
+              commit_id: "abc",
+              findings: { blockers: 0, majors: 0, nits: 0 },
+              inline_comments: 0,
+            },
+          }),
+        })),
+      }),
+    );
+
+    await consumer.processEnvelope(
+      request,
+      "local.metafactory.tasks.code-review.typescript",
+      null,
+    );
+
+    // correlation_id still intact on every envelope...
+    for (const env of runtime.published) {
+      expect(env.correlation_id).toBe(request.id);
+      // ...but no response_routing key anywhere.
+      expect("response_routing" in (env.payload as object)).toBe(false);
+    }
   });
 });

--- a/src/bus/__tests__/review-events.test.ts
+++ b/src/bus/__tests__/review-events.test.ts
@@ -331,6 +331,63 @@ describe("createReviewVerdictEvent", () => {
     findings.blockers = 99;
     expect((env.payload as { findings: { blockers: number } }).findings.blockers).toBe(1);
   });
+
+  // cortex#502 — response_routing (logical shape) on the verdict.
+  test("stamps payload.response_routing (logical shape) when supplied", () => {
+    const env = createReviewVerdictEvent({
+      source: SOURCE,
+      kind: "approved",
+      correlationId: REQUEST_ENVELOPE_ID,
+      responseRouting: {
+        surface: "discord",
+        channel: "cortex",
+        thread: "cortex/pr/57",
+      },
+      payload: makeVerdictPayload({ verdict: "approved" }),
+    });
+    expect((env.payload as { response_routing?: unknown }).response_routing).toEqual({
+      surface: "discord",
+      channel: "cortex",
+      thread: "cortex/pr/57",
+    });
+    expect(validateEnvelope(env).ok).toBe(true);
+  });
+
+  test("stamps response_routing without thread (channel-scope)", () => {
+    const env = createReviewVerdictEvent({
+      source: SOURCE,
+      kind: "commented",
+      correlationId: REQUEST_ENVELOPE_ID,
+      responseRouting: { surface: "discord", channel: "cortex" },
+      payload: makeVerdictPayload({ verdict: "commented" }),
+    });
+    expect((env.payload as { response_routing?: unknown }).response_routing).toEqual({
+      surface: "discord",
+      channel: "cortex",
+    });
+  });
+
+  test("omits the response_routing key entirely when not supplied", () => {
+    const env = createReviewVerdictEvent({
+      source: SOURCE,
+      kind: "approved",
+      correlationId: REQUEST_ENVELOPE_ID,
+      payload: makeVerdictPayload({ verdict: "approved" }),
+    });
+    expect("response_routing" in (env.payload as object)).toBe(false);
+  });
+
+  test("response_routing coexists with the discriminator guard (still throws on mismatch)", () => {
+    expect(() =>
+      createReviewVerdictEvent({
+        source: SOURCE,
+        kind: "approved",
+        correlationId: REQUEST_ENVELOPE_ID,
+        responseRouting: { surface: "discord", channel: "cortex" },
+        payload: makeVerdictPayload({ verdict: "commented" }),
+      }),
+    ).toThrow(/verdict-kind\/payload mismatch/);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/bus/dispatch-events.ts
+++ b/src/bus/dispatch-events.ts
@@ -69,6 +69,18 @@ export type DispatchEventSource = SystemEventSource;
  * Future dispatch sources (MC dashboard "send task", taps) populate the
  * same shape; sinks that don't recognise the `adapter_instance` ignore the
  * envelope (see the dispatch-sink consumer in `src/adapters/dispatch-sink.ts`).
+ *
+ * This is the **chat-path / snowflake** shape (cortex#498). The review path
+ * (cortex#502) uses the sibling {@link LogicalResponseRouting} shape — a
+ * platform-NEUTRAL logical address (`{ surface, channel, thread? }`) where
+ * `channel` is a repo short name and `thread` is the
+ * `{repo-short}/{entity-type}/{number}` logical entity key per the
+ * channel-routing SOP. Both shapes ride `payload.response_routing`; both are
+ * passed verbatim by the dispatch builders (no builder-body change — the
+ * field just widens to the union {@link AnyResponseRouting}). The review sink
+ * resolves the logical address to a native target via
+ * `PlatformAdapter.resolveLogicalTarget`; the chat dispatch sink reads the
+ * snowflake triple directly.
  */
 export interface ResponseRouting {
   /** Adapter instance id that sourced the dispatch (e.g. `discord-pai-collab`). */
@@ -78,6 +90,45 @@ export interface ResponseRouting {
   /** Thread id when the dispatch arrived in a thread/DM; omitted at channel scope. */
   thread_id?: string;
 }
+
+/**
+ * cortex#502 — **Logical response routing** (the review-path shape).
+ *
+ * A platform-NEUTRAL surface address echoed onto the review lifecycle
+ * (`dispatch.task.*`) AND verdict (`review.verdict.*`) envelopes. Unlike the
+ * chat-path {@link ResponseRouting} (Discord snowflakes), this carries
+ * LOGICAL names so the same envelope routes on Discord/Mattermost/Slack
+ * unchanged — each adapter maps logical→native at the sink via
+ * `PlatformAdapter.resolveLogicalTarget`.
+ *
+ * - `surface` — platform identity (`"discord"` | `"mattermost"` | `"slack"`).
+ *   The review sink filters to envelopes whose surface matches an adapter it
+ *   drives; a surface it doesn't drive is ignored (no cross-surface posting),
+ *   mirroring the chat sink's `adapter_instance` filter. There is deliberately
+ *   NO `adapter_instance` on the review wire — the sink resolves by surface +
+ *   channel name (the SOP guarantees one logical channel per repo).
+ * - `channel` — LOGICAL channel slug = repo short name (e.g. `"cortex"`).
+ *   Repo→channel per the channel-routing SOP.
+ * - `thread` — LOGICAL entity address `{repo-short}/{entity-type}/{number}`
+ *   (e.g. `"cortex/pr/57"`). Entity→thread per the SOP. Omitted = channel-scope.
+ */
+export interface LogicalResponseRouting {
+  /** Platform identity, e.g. `"discord"` | `"mattermost"` | `"slack"`. */
+  surface: string;
+  /** Logical channel slug — repo short name (e.g. `"cortex"`). */
+  channel: string;
+  /** Logical entity address `{repo-short}/{entity-type}/{number}`; omitted = channel-scope. */
+  thread?: string;
+}
+
+/**
+ * The union the dispatch builders accept for `responseRouting` and stamp
+ * verbatim onto `payload.response_routing`. Chat (cortex#498) uses the
+ * snowflake {@link ResponseRouting}; review (cortex#502) uses the logical
+ * {@link LogicalResponseRouting}. The builders never inspect or transform the
+ * value — the type widening alone admits both producers.
+ */
+export type AnyResponseRouting = ResponseRouting | LogicalResponseRouting;
 
 function buildSource(src: SystemEventSource): string {
   return `${src.principal}.${src.agent}.${src.instance}`;
@@ -170,8 +221,13 @@ export interface DispatchTaskCommonOpts {
    * the wire) for lifecycle events that have no originating surface
    * address — e.g. a bus-peer or Offer dispatch whose source did not
    * carry response routing.
+   *
+   * cortex#502 — the type is the union {@link AnyResponseRouting}: the
+   * chat path stamps the snowflake {@link ResponseRouting} shape, the
+   * review path stamps the logical {@link LogicalResponseRouting} shape.
+   * The builder passes whatever it receives through verbatim.
    */
-  responseRouting?: ResponseRouting;
+  responseRouting?: AnyResponseRouting;
 }
 
 /**

--- a/src/bus/review-consumer.ts
+++ b/src/bus/review-consumer.ts
@@ -79,6 +79,7 @@ import {
   createDispatchTaskStartedEvent,
   createDispatchTaskCompletedEvent,
   createDispatchTaskAbortedEvent,
+  type LogicalResponseRouting,
 } from "./dispatch-events";
 import {
   runReviewPipeline,
@@ -433,6 +434,13 @@ export class ReviewConsumer {
     // than letting the worst-case dead-letter window run out. The abort
     // is a courtesy emission — the per-attempt pipeline still runs and
     // emits its own terminal envelope.
+    // cortex#502 — read the LOGICAL response routing off the inbound
+    // request once and echo it onto every emitted lifecycle + the verdict.
+    // Absent (bus-peer / direct-pilot-only / Offer) → undefined → no
+    // `response_routing` key on the wire → the review sink ignores the
+    // envelopes (the verdict still reaches pilot via correlation_id).
+    const responseRouting = readLogicalResponseRouting(envelope) ?? undefined;
+
     const deliveryCount = redeliveryCountFrom(msg);
     if (deliveryCount > 1) {
       await this.safePublish(
@@ -444,6 +452,7 @@ export class ReviewConsumer {
           startedAt: this.clock(),
           abortedAt: this.clock(),
           reason: `redelivery (attempt ${deliveryCount})`,
+          ...(responseRouting !== undefined && { responseRouting }),
         }),
         "dispatch.task.aborted",
       );
@@ -462,6 +471,7 @@ export class ReviewConsumer {
           detail: `envelope type "${envelope.type}" is not a tasks.code-review.<flavor> request`,
         },
         `unrecognised review subject: ${subject}`,
+        responseRouting,
       );
       return { kind: "term", reason: "non-review subject" };
     }
@@ -476,6 +486,7 @@ export class ReviewConsumer {
           detail: "payload validation failed (missing/invalid repo or pr)",
         },
         `bad payload for ${subject}`,
+        responseRouting,
       );
       return { kind: "term", reason: "payload validation failed" };
     }
@@ -513,6 +524,7 @@ export class ReviewConsumer {
           envelope,
           { kind: "cant_do", detail: failureDetail },
           `chain verification failed for ${subject}`,
+          responseRouting,
         );
         return { kind: "term", reason: failureDetail };
       }
@@ -529,6 +541,7 @@ export class ReviewConsumer {
           detail: `agent "${this.agent.id}" does not claim code-review.${flavor}`,
         },
         `no capability match for code-review.${flavor}`,
+        responseRouting,
       );
       return { kind: "term", reason: "no capability match" };
     }
@@ -550,6 +563,7 @@ export class ReviewConsumer {
           retry_after_ms: retryAfterMs,
         },
         "review consumer at maxConcurrent",
+        responseRouting,
       );
       return { kind: "nak", delayMs: retryAfterMs };
     }
@@ -564,12 +578,18 @@ export class ReviewConsumer {
         agentId: this.agent.id,
         correlationId: envelope.id,
         startedAt,
+        ...(responseRouting !== undefined && { responseRouting }),
       }),
       "dispatch.task.started",
     );
 
     // 6. Run the pipeline. Track the promise for `stop()` drain.
-    const pipelinePromise = this.runPipeline(envelope, payload, startedAt);
+    const pipelinePromise = this.runPipeline(
+      envelope,
+      payload,
+      startedAt,
+      responseRouting,
+    );
     const tracked: Promise<{ decision: AckDecision }> = pipelinePromise.then(
       (decision) => ({ decision }),
     );
@@ -646,6 +666,7 @@ export class ReviewConsumer {
     envelope: Envelope,
     payload: ReviewRequestPayload,
     startedAt: Date,
+    responseRouting?: LogicalResponseRouting,
   ): Promise<AckDecision> {
     if (this.stopped) {
       // Mid-shutdown: don't start new pipeline runs. Nak with a 0 hint
@@ -659,6 +680,7 @@ export class ReviewConsumer {
           retry_after_ms: 0,
         },
         "consumer shutting down before pipeline start",
+        responseRouting,
       );
       return { kind: "nak", delayMs: 0 };
     }
@@ -677,6 +699,9 @@ export class ReviewConsumer {
         }),
         ...(this.sessionOpts !== undefined && { sessionOpts: this.sessionOpts }),
         ...(this.policyCheck !== undefined && { policyCheck: this.policyCheck }),
+        // cortex#502 — pass the logical routing into the pipeline so the
+        // verdict + failed terminal envelopes it builds carry it.
+        ...(responseRouting !== undefined && { responseRouting }),
         // cortex#361 — attach a bus-side heartbeat ticker to the CC
         // session so `system.agent.heartbeat` envelopes flow while the
         // review is in flight. The hook keeps `runtime.publish` calls
@@ -720,6 +745,7 @@ export class ReviewConsumer {
           startedAt,
           completedAt: this.clock(),
           resultSummary: extractSummary(result.envelope),
+          ...(responseRouting !== undefined && { responseRouting }),
         }),
         "dispatch.task.completed",
       );
@@ -745,6 +771,7 @@ export class ReviewConsumer {
     request: Envelope,
     reason: DispatchTaskFailedReason,
     errorSummary: string,
+    responseRouting?: LogicalResponseRouting,
   ): Promise<void> {
     const now = this.clock();
     const failed = createReviewTaskFailedEvent({
@@ -756,6 +783,10 @@ export class ReviewConsumer {
       failedAt: now,
       errorSummary,
       reason,
+      // cortex#502 — echo routing so the consumer's own pre-pipeline
+      // failures (bad subject/payload, no capability, backpressure) still
+      // render to the originating thread.
+      ...(responseRouting !== undefined && { responseRouting }),
     });
     await this.safePublish(failed, "dispatch.task.failed");
   }
@@ -1025,6 +1056,37 @@ export function parseReviewRequestPayload(
   if (p.post === true) out.post = true;
   if (forge !== undefined) out.forge = forge;
   return out;
+}
+
+/**
+ * cortex#502 — read the LOGICAL response routing off an inbound review
+ * request envelope's `payload.response_routing`, or `null` when absent /
+ * malformed. The review path uses the platform-neutral logical shape
+ * (`{ surface, channel, thread? }`) — distinct from the chat path's
+ * snowflake triple. A missing/invalid field is a normal, non-error case
+ * (pilot-only / bus-peer / Offer dispatch): the consumer simply omits
+ * `response_routing` from every emitted envelope, and the review sink
+ * ignores them. The authoritative verdict still reaches pilot via
+ * `correlation_id`.
+ *
+ * `surface` + `channel` are required; `thread` is optional (channel-scope
+ * when omitted). Exported for the review-consumer tests.
+ */
+export function readLogicalResponseRouting(
+  envelope: Envelope,
+): LogicalResponseRouting | null {
+  const raw = (envelope.payload as Record<string, unknown> | undefined)
+    ?.response_routing;
+  if (raw === null || typeof raw !== "object") return null;
+  const r = raw as Record<string, unknown>;
+  if (typeof r.surface !== "string" || typeof r.channel !== "string") {
+    return null;
+  }
+  return {
+    surface: r.surface,
+    channel: r.channel,
+    ...(typeof r.thread === "string" && { thread: r.thread }),
+  };
 }
 
 /**

--- a/src/bus/review-events.ts
+++ b/src/bus/review-events.ts
@@ -74,6 +74,7 @@ import type { Classification, Envelope } from "./myelin/envelope-validator";
 import { buildBaseEnvelope as buildSharedEnvelope } from "./envelope-builder";
 import {
   createDispatchTaskFailedEvent,
+  type AnyResponseRouting,
   type DispatchTaskFailedOpts,
   type DispatchTaskFailedReason,
 } from "./dispatch-events";
@@ -330,6 +331,20 @@ export interface CreateReviewVerdictEventOpts {
    * `tasks.code-review.*` parameterisation.
    */
   classification?: Classification;
+  /**
+   * cortex#502 — **Response routing** echoed from the inbound review
+   * request envelope onto the verdict. The verdict is the PRIMARY reply
+   * the review sink renders, so it MUST carry routing (the shared
+   * `dispatch.task.*` builders carry it on the lifecycle envelopes; this
+   * is the only NEW emit surface). When supplied, surfaces as
+   * `payload.response_routing` (the logical
+   * {@link import("./dispatch-events").LogicalResponseRouting} shape for
+   * review). Omitted (no field on the wire) for bus-peer / direct-pilot-
+   * only / Offer dispatches whose request carried no routing — the review
+   * sink then ignores the verdict envelope (the authoritative verdict
+   * still reaches pilot via `correlation_id`, unchanged).
+   */
+  responseRouting?: AnyResponseRouting;
   /** Payload per §4.2. */
   payload: ReviewVerdictPayload;
 }
@@ -384,6 +399,13 @@ export function createReviewVerdictEvent(
         nits: opts.payload.findings.nits,
       },
       inline_comments: opts.payload.inline_comments,
+      // cortex#502 — echo response routing when the inbound review request
+      // carried it, so the review sink can render the verdict to the
+      // originating thread. Omitted (no key on the wire) for pilot-only /
+      // bus-peer / Offer dispatches.
+      ...(opts.responseRouting !== undefined && {
+        response_routing: opts.responseRouting,
+      }),
     },
   });
 }

--- a/src/common/agents/__tests__/presence-binding.test.ts
+++ b/src/common/agents/__tests__/presence-binding.test.ts
@@ -94,6 +94,13 @@ class FakeAdapter implements PlatformAdapter {
   async createThread(msg: InboundMessage, _name: string): Promise<ResponseTarget> {
     return { instanceId: this.instanceId, channelId: msg.channelId };
   }
+  async resolveLogicalTarget(_addr: {
+    surface: string;
+    channel: string;
+    thread?: string;
+  }): Promise<ResponseTarget | null> {
+    return null;
+  }
   async notifyOperator(_text: string) {}
 }
 

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -89,6 +89,7 @@ import { MattermostAdapter } from "./adapters/mattermost";
 import { SlackAdapter } from "./adapters/slack";
 import type { PlatformAdapter } from "./adapters/types";
 import { createDispatchSink, type DispatchSink } from "./adapters/dispatch-sink";
+import { createReviewSink, type ReviewSink } from "./adapters/review-sink";
 
 import { createDispatchListener, type DispatchListener } from "./runner/dispatch-listener";
 import { WorklogManager } from "./runner/worklog-manager";
@@ -1972,6 +1973,31 @@ export async function startCortex(
       `adapters=${adapters.length}`,
   );
 
+  // cortex#502 — review sink (OUTBOUND). The SOLE deliverer of review
+  // replies (verdict + lifecycle) back to the originating surface. An
+  // ADDITIONAL `onEnvelope` subscriber alongside the chat dispatch sink:
+  // subscribes to `local.{principal}[.{stack}].dispatch.task.>` AND
+  // `…review.verdict.>`, reads each envelope's echoed LOGICAL routing
+  // (`response_routing` = `{ surface, channel, thread? }` — repo→channel,
+  // entity→thread per the channel-routing SOP), filters to the surface a
+  // driven adapter matches, resolves logical→native via
+  // `adapter.resolveLogicalTarget`, renders the verdict one-liner via
+  // `formatReviewVerdict` (+ a requester ping) / the lifecycle via
+  // `formatDispatchLifecycle`, and posts back. NOT wired via
+  // `surfaceSubjects` (that would double-reply). Dormant when the runtime
+  // is disabled (no NATS) or no adapters started.
+  const reviewSink: ReviewSink = createReviewSink({
+    runtime,
+    adapters,
+    principal: principalId,
+    stack: derivedStack.stack,
+  });
+  await reviewSink.start();
+  console.log(
+    `cortex: review-sink started — subjects=[${reviewSink.subjects.join(", ")}], ` +
+      `adapters=${adapters.length}`,
+  );
+
   // cortex#480 — boot-time self-signed envelope sanity check. After the
   // listeners are wired with `stackIdentity` + `stackNKeyPub`, build a
   // tiny envelope signed by the stack's own NKey and round-trip it
@@ -2110,6 +2136,7 @@ export async function startCortex(
       ...reviewConsumers.map((c, i) => `review-consumer stop[${i}] (agent=${c.agent.id})`),
       "dispatch-listener stop",
       "dispatch-sink stop",
+      "review-sink stop",
       "surface-router stop",
       "dispatch-handler shutdown",
       ...adapterStopNames,
@@ -2164,6 +2191,12 @@ export async function startCortex(
       // adapters stop, so no late `postResponse` lands after the
       // platform connections close. `stop()` is idempotent.
       await completeAsync("dispatch-sink stop", dispatchSink.stop());
+      // cortex#502 — drain the review sink on the same boundary as the
+      // chat dispatch sink: after the runner/consumers stop publishing
+      // review lifecycle + verdict envelopes but before the
+      // surface-router / adapters close, so no late `postResponse` lands
+      // after the platform connections close. `stop()` is idempotent.
+      await completeAsync("review-sink stop", reviewSink.stop());
       // IAW B.2a — bus-dispatch-listener drain runs after the dispatch
       // listener (which feeds dispatch-handler) but before the
       // surface-router stop. The listener's `stop()` awaits its

--- a/src/runner/__tests__/review-pipeline.test.ts
+++ b/src/runner/__tests__/review-pipeline.test.ts
@@ -637,3 +637,62 @@ describe("runReviewPipeline — onSessionSpawned hook", () => {
     expect(stopCalled).toBeGreaterThanOrEqual(1);
   });
 });
+
+// ---------------------------------------------------------------------------
+// cortex#502 — responseRouting threaded onto both terminal envelopes
+// ---------------------------------------------------------------------------
+
+describe("runReviewPipeline — responseRouting (cortex#502)", () => {
+  const ROUTING = { surface: "discord", channel: "cortex", thread: "cortex/pr/57" };
+
+  test("verdict terminal carries payload.response_routing", async () => {
+    const { factory } = fakeFactory(successResult(buildVerdictBlock("approved")));
+    const result = await runReviewPipeline({
+      ...baseOpts(factory),
+      responseRouting: ROUTING,
+    });
+    expect(result.kind).toBe("verdict");
+    if (result.kind !== "verdict") return;
+    expect(
+      (result.envelope.payload as { response_routing?: unknown }).response_routing,
+    ).toEqual(ROUTING);
+    expect(validateEnvelope(result.envelope).ok).toBe(true);
+  });
+
+  test("failed terminal carries payload.response_routing", async () => {
+    const result = await runReviewPipeline({
+      ...baseOpts(throwingFactory("claude binary not found")),
+      responseRouting: ROUTING,
+    });
+    expect(result.kind).toBe("failed");
+    if (result.kind !== "failed") return;
+    expect(
+      (result.envelope.payload as { response_routing?: unknown }).response_routing,
+    ).toEqual(ROUTING);
+  });
+
+  test("omitted → no response_routing key on either terminal", async () => {
+    const { factory } = fakeFactory(successResult(buildVerdictBlock("approved")));
+    const verdict = await runReviewPipeline(baseOpts(factory));
+    expect(verdict.kind).toBe("verdict");
+    if (verdict.kind === "verdict") {
+      expect("response_routing" in (verdict.envelope.payload as object)).toBe(false);
+    }
+    const failed = await runReviewPipeline(
+      baseOpts(throwingFactory("nope")),
+    );
+    expect(failed.kind).toBe("failed");
+    if (failed.kind === "failed") {
+      expect("response_routing" in (failed.envelope.payload as object)).toBe(false);
+    }
+  });
+
+  test("pipeline stays non-throwing and never references a runtime", async () => {
+    // The opts type has no runtime field — this is a structural guarantee.
+    // Assert the happy + failure paths both return (never throw) with routing.
+    const { factory } = fakeFactory(successResult(buildVerdictBlock("approved")));
+    await expect(
+      runReviewPipeline({ ...baseOpts(factory), responseRouting: ROUTING }),
+    ).resolves.toBeDefined();
+  });
+});

--- a/src/runner/review-pipeline.ts
+++ b/src/runner/review-pipeline.ts
@@ -84,6 +84,7 @@ import {
   type ReviewVerdictKind,
   type ReviewVerdictPayload,
 } from "../bus/review-events";
+import type { AnyResponseRouting } from "../bus/dispatch-events";
 import type {
   CCSessionFactory,
   CCSessionLike,
@@ -204,6 +205,16 @@ export interface ReviewPipelineOpts {
    * omitted, no policy gate runs and the pipeline goes straight to CC.
    */
   policyCheck?: ReviewPolicyCheck;
+  /**
+   * cortex#502 — the logical response routing echoed from the inbound
+   * review request envelope. Threaded onto BOTH terminal envelopes the
+   * pipeline builds — the `review.verdict.<kind>` (primary reply) and the
+   * `dispatch.task.failed` — so the review sink can render either outcome
+   * to the originating thread. Passed through verbatim; the pipeline never
+   * inspects or transforms it. Omitted → no `response_routing` on the wire
+   * (pilot-only / bus-peer / Offer path unchanged).
+   */
+  responseRouting?: AnyResponseRouting;
   /**
    * cortex#361 — optional lifecycle hook fired after the CC session is
    * constructed + `start()` is called, before `wait()` resolves. The
@@ -432,6 +443,10 @@ export async function runReviewPipeline(
       source: opts.source,
       kind: parsed.value.verdict,
       correlationId,
+      // cortex#502 — echo logical routing onto the verdict (primary reply).
+      ...(opts.responseRouting !== undefined && {
+        responseRouting: opts.responseRouting,
+      }),
       payload,
     });
   } catch (err) {
@@ -482,6 +497,11 @@ function failed(
     failedAt: new Date(),
     errorSummary,
     reason,
+    // cortex#502 — echo logical routing onto the failed terminal too so the
+    // review sink can render the error to the originating thread.
+    ...(opts.responseRouting !== undefined && {
+      responseRouting: opts.responseRouting,
+    }),
   });
   return { kind: "failed", envelope };
 }


### PR DESCRIPTION
## C-502 — consumer/sink half of the platform-neutral review reply loop

Completes the grove-v2 review loop the bus-native way: a CC dev session (orchestrator) signs as Luna → pings Echo over the bus → Echo reviews → **the verdict comes back to the originating thread + pings the requester**. Mirrors the chat dispatch-sink (#498) pattern for the review path.

### Changes
- **`src/adapters/review-sink.ts` (NEW)** — self-subscribes to `…dispatch.task.>` + `…review.verdict.>` (core-NATS fan-out, symmetric with the runner/#498), filters by `response_routing.surface`, renders the verdict + lifecycle to the originating thread via a new `PlatformAdapter.resolveLogicalTarget` (logical `{surface, channel, thread}` → native), pings the requester (`@luna`) back.
- **review-consumer / review-pipeline / review-events / dispatch-events** — read `response_routing` off the inbound request and echo it onto the lifecycle + `review.verdict.*` envelopes (correlation_id-joined). `ResponseRouting | LogicalResponseRouting` union (review = logical, chat = snowflake; both ride `payload.response_routing`).
- Wired in `src/cortex.ts` like the chat sink.

### Review fix applied
The workflow's adversarial review caught a **double terminal reply** (consumer co-emits `review.verdict.*` AND `dispatch.task.completed`, both routed → two posts). Fixed: the sink suppresses `dispatch.task.completed` (the verdict is the human reply; `failed`/`aborted` still render) + regression test firing both, asserting exactly one post.

### Verification
- `bunx tsc --noEmit` clean; `eslint --quiet` clean on all changed files; **1234 + the new double-reply test pass** (review-sink suite 15/15).
- Architecture per CONTEXT.md §The bus / §Surfaces / §Response routing — logical addressing generalizes to Slack/Telegram/Mattermost.

⚠️ **Merge together with pilot#140** (the producer that stamps `response_routing`). Until pilot stamps it, this sink no-ops on real requests.

Closes #502.

🤖 Generated with [Claude Code](https://claude.com/claude-code)