### PR TITLE
feat(cortex): deterministic review presentation + prose-fallback + runtime double-delivery fix

### DIFF
--- a/cortex.yaml.example
+++ b/cortex.yaml.example
@@ -208,12 +208,12 @@ agents:
         contextDepth: 10
         enableAgentLog: false
         trustedBotIds: []
-        # Bus-side subjects this agent subscribes to via the
-        # surface-router. The pattern below routes inbound code-review
-        # tasks at the stack level — the segment after `local.` is your
-        # principal id and the next segment is your stack id.
-        surfaceSubjects:
-          - local.principal-name.meta-factory.tasks.code-review.>  # <REPLACE_ME>: keep in sync with stack.id
+        # Inbound task envelopes must NOT be surfaced here — the adapter would
+        # render the raw envelope JSON to Discord (the cortex#477/#479 leak).
+        # Review OUTPUT is rendered by the review-sink (cortex#502/#503), which
+        # emits a deterministic `presentation` markdown, never raw JSON. Leave
+        # this empty unless an agent must surface a non-task subject.
+        surfaceSubjects: []
 
 # -----------------------------------------------------------------------------
 # renderers — non-agent-bound surfaces (dashboards, pagerduty, etc.)

--- a/src/adapters/__tests__/review-sink.test.ts
+++ b/src/adapters/__tests__/review-sink.test.ts
@@ -444,3 +444,140 @@ describe("review-sink — no-routing and resilience", () => {
     await Promise.resolve();
   });
 });
+
+// ---------------------------------------------------------------------------
+// cortex#503 — presentation rendering + prose-fallback + never-JSON + idempotency
+// ---------------------------------------------------------------------------
+
+const flushMicrotasks = async () => {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+/** envelope() variant with an explicit id (for the idempotency test). */
+function envelopeWithId(
+  id: string,
+  type: string,
+  payload: Record<string, unknown>,
+): Envelope {
+  return { ...envelope(type, payload), id };
+}
+
+describe("review-sink — cortex#503 presentation rendering", () => {
+  test("renders ONLY payload.presentation verbatim when present (not the one-liner)", async () => {
+    const { runtime, trigger } = fakeRuntime();
+    const adapter = discordMock();
+    const sink = createReviewSink({ runtime, adapters: [adapter], principal: "metafactory" });
+    await sink.start();
+
+    const presentation =
+      "### 🔴 Changes requested\n\nBlocking: SQL injection.\n\n" +
+      "**Findings:** 1 blockers · 0 majors · 2 nits · 4 inline comments\n\n" +
+      "[Review on GitHub](https://github.com/the-metafactory/cortex/pull/57#r1) (`deadbee`)";
+
+    trigger(
+      envelope("review.verdict.changes-requested", {
+        ...verdictPayload({ presentation }),
+        response_routing: logicalRouting("discord", "cortex", "cortex/pr/57"),
+      }),
+    );
+    await flushMicrotasks();
+
+    expect(adapter.sentMessages).toHaveLength(1);
+    const text = adapter.sentMessages[0]!.text;
+    // The verbatim presentation markdown is present, with the reviewer ping.
+    expect(text).toContain("@luna");
+    expect(text).toContain(presentation);
+    // It did NOT fall back to the one-liner format (which uses "1B/2M/3N").
+    expect(text).not.toContain("1B/2M/3N");
+  });
+
+  test("falls back to the one-liner (never JSON) when presentation is absent", async () => {
+    const { runtime, trigger } = fakeRuntime();
+    const adapter = discordMock();
+    const sink = createReviewSink({ runtime, adapters: [adapter], principal: "metafactory" });
+    await sink.start();
+
+    // verdictPayload() has NO presentation field.
+    trigger(
+      envelope("review.verdict.changes-requested", {
+        ...verdictPayload(),
+        response_routing: logicalRouting("discord", "cortex", "cortex/pr/57"),
+      }),
+    );
+    await flushMicrotasks();
+
+    expect(adapter.sentMessages).toHaveLength(1);
+    const text = adapter.sentMessages[0]!.text;
+    expect(text).toContain("1B/2M/3N"); // the one-liner fallback
+    // Never a raw JSON dump.
+    expect(text).not.toContain('"verdict"');
+    expect(text).not.toContain('"findings"');
+    expect(text).not.toContain("```json");
+  });
+
+  test("prose-fallback dispatch.task.completed (chat_response) → posted as markdown reply", async () => {
+    const { runtime, trigger } = fakeRuntime();
+    const adapter = discordMock();
+    const sink = createReviewSink({ runtime, adapters: [adapter], principal: "metafactory" });
+    await sink.start();
+
+    const prose = "I reviewed the PR.\n\nLGTM, no blockers.";
+    trigger(
+      envelope("dispatch.task.completed", {
+        agent_id: "luna",
+        result_summary: "I reviewed the PR.",
+        chat_response: prose,
+        response_routing: logicalRouting("discord", "cortex", "cortex/pr/57"),
+      }),
+    );
+    await flushMicrotasks();
+
+    expect(adapter.sentMessages).toHaveLength(1);
+    expect(adapter.sentMessages[0]!.text).toBe(prose);
+  });
+
+  test("verdict-path completed (no chat_response) is still suppressed", async () => {
+    const { runtime, trigger } = fakeRuntime();
+    const adapter = discordMock();
+    const sink = createReviewSink({ runtime, adapters: [adapter], principal: "metafactory" });
+    await sink.start();
+
+    trigger(
+      envelope("dispatch.task.completed", {
+        agent_id: "luna",
+        result_summary: "verdict: blockers=0 — approved",
+        response_routing: logicalRouting("discord", "cortex", "cortex/pr/57"),
+      }),
+    );
+    await flushMicrotasks();
+
+    // No chat_response → this is the co-emitted completed; suppress it.
+    expect(adapter.sentMessages).toHaveLength(0);
+  });
+
+  test("idempotent render — second delivery of same envelope.id is a no-op", async () => {
+    const { runtime, trigger } = fakeRuntime();
+    const adapter = discordMock();
+    const sink = createReviewSink({ runtime, adapters: [adapter], principal: "metafactory" });
+    await sink.start();
+
+    const env = envelopeWithId(
+      "11111111-1111-4111-8111-111111111111",
+      "review.verdict.approved",
+      {
+        ...verdictPayload({ verdict: "approved" }),
+        response_routing: logicalRouting("discord", "cortex", "cortex/pr/57"),
+      },
+    );
+
+    trigger(env);
+    await flushMicrotasks();
+    trigger(env); // accidental double-delivery (same id)
+    await flushMicrotasks();
+
+    // Exactly ONE post despite two deliveries.
+    expect(adapter.sentMessages).toHaveLength(1);
+  });
+});

--- a/src/adapters/review-sink.ts
+++ b/src/adapters/review-sink.ts
@@ -158,25 +158,45 @@ function reviewSubjects(principal: string, stack?: string): string[] {
  */
 function renderText(envelope: Envelope): string | null {
   if (envelope.type.startsWith(VERDICT_TYPE_PREFIX)) {
-    const verdictLine = formatReviewVerdict(envelope);
-    if (verdictLine === null || verdictLine.length === 0) return null;
-    // Ping the deliverable agent back so the requester is notified. The
-    // verdict's `reviewer` is the agent that produced it (e.g. `luna`);
+    // cortex#503 — surfaces render ONLY the deterministic `presentation`
+    // markdown when cortex stamped it (verbatim, never a JSON dump). The
+    // `formatReviewVerdict` one-liner is the fallback for older verdicts
+    // (wire forward-compat) that predate `presentation`. Either way a ping
+    // mentions the reviewer so the requester is notified.
+    const presentation =
+      typeof envelope.payload.presentation === "string"
+        ? envelope.payload.presentation.trim()
+        : "";
+    const body = presentation.length > 0 ? presentation : formatReviewVerdict(envelope);
+    if (body === null || body.length === 0) return null;
+    // The verdict's `reviewer` is the agent that produced it (e.g. `luna`);
     // a leading `@{reviewer}` is the conventional Discord-style mention.
     const reviewer =
       typeof envelope.payload.reviewer === "string"
         ? envelope.payload.reviewer
         : "";
-    return reviewer ? `@${reviewer} ${verdictLine}` : verdictLine;
+    return reviewer ? `@${reviewer} ${body}` : body;
   }
-  // Double-reply guard (#502 review): on the review path a successful review
-  // co-emits BOTH `review.verdict.*` (the human-facing terminal reply, handled
-  // above) AND `dispatch.task.completed` (whose `result_summary` is just the
-  // verdict summary — redundant on a human surface, though load-bearing for the
-  // dashboard sink). Suppress `completed` here so the originating thread gets
-  // exactly ONE terminal message. `failed`/`aborted` have no co-emitted verdict,
-  // so they remain the terminal reply and still render.
-  if (envelope.type === "dispatch.task.completed") return null;
+  // cortex#503 — the PROSE-FALLBACK completion (agent answered in prose, no
+  // structured verdict) emits ONLY a `dispatch.task.completed` carrying the
+  // prose in `chat_response`, with NO co-emitted verdict. Render that prose
+  // as the terminal reply (markdown, never JSON). `formatDispatchLifecycle`
+  // already prefers `chat_response` over `result_summary`, so it returns the
+  // full prose here.
+  //
+  // Double-reply guard (#502 review): a STRUCTURED review co-emits BOTH a
+  // `review.verdict.*` (the human-facing terminal reply, handled above) AND a
+  // `dispatch.task.completed` whose `result_summary` is just the verdict
+  // summary — redundant on a human surface. That completed carries NO
+  // `chat_response`, so suppress it; the originating thread gets exactly ONE
+  // terminal message. `failed`/`aborted` have no co-emitted verdict, so they
+  // remain the terminal reply and still render.
+  if (envelope.type === "dispatch.task.completed") {
+    const hasProse =
+      typeof envelope.payload.chat_response === "string" &&
+      envelope.payload.chat_response.trim().length > 0;
+    if (!hasProse) return null;
+  }
   return formatDispatchLifecycle(envelope);
 }
 
@@ -189,6 +209,27 @@ export function createReviewSink(opts: ReviewSinkOptions): ReviewSink {
 
   let registration: { unregister: () => void } | null = null;
   let subscribers: MyelinSubscriber[] = [];
+
+  // cortex#491 belt-and-braces — render idempotency keyed by `envelope.id`.
+  // The runtime-level subscribe dedupe (cortex#491 in `runtime.ts`) is the
+  // primary defence against double-delivery; this second layer guarantees
+  // that even an accidental double-delivery from a misconfig (or a future
+  // overlapping-pattern path) cannot produce TWO GitHub/Discord renders for
+  // one envelope. Bounded so a long-lived sink can't leak: oldest ids evict
+  // once the window fills (envelopes arrive in roughly-temporal order, so a
+  // genuine duplicate lands well within the window).
+  const seenIds = new Set<string>();
+  const SEEN_WINDOW = 4096;
+  function alreadyRendered(id: string): boolean {
+    if (seenIds.has(id)) return true;
+    seenIds.add(id);
+    if (seenIds.size > SEEN_WINDOW) {
+      // Evict the oldest entry (insertion order — Set preserves it).
+      const oldest = seenIds.values().next().value;
+      if (oldest !== undefined) seenIds.delete(oldest);
+    }
+    return false;
+  }
 
   /**
    * Resolve the first adapter that drives `surface` to a native target for
@@ -228,6 +269,12 @@ export function createReviewSink(opts: ReviewSinkOptions): ReviewSink {
 
     const text = renderText(envelope);
     if (text === null || text.length === 0) return;
+
+    // cortex#491 belt-and-braces — at-most-once render per envelope.id. We
+    // mark seen only once we know this envelope WOULD post (routing present,
+    // text non-empty) so a non-actionable envelope doesn't consume a window
+    // slot. A second delivery of the same id is a silent no-op.
+    if (alreadyRendered(envelope.id)) return;
 
     let target: ResponseTarget | null;
     try {

--- a/src/bus/__tests__/review-consumer.test.ts
+++ b/src/bus/__tests__/review-consumer.test.ts
@@ -273,6 +273,50 @@ describe("ReviewConsumer.processEnvelope — cortex#237 PR-6", () => {
     ).toBe(`verdict: blockers=0 majors=2 nits=3 — approved`);
   });
 
+  test("cortex#503 — prose-fallback `completed` result → dispatch.task.completed (NO verdict) + ack", async () => {
+    const runtime = createRecordingRuntime();
+    const request = makeRequest("typescript");
+    const prose = "I reviewed the PR.\n\nLooks fine, no blockers found.";
+
+    const consumer = new ReviewConsumer(
+      baseOpts({
+        runtime,
+        pipelineRunner: fixedPipeline(() => ({
+          kind: "completed",
+          presentation: prose,
+        })),
+      }),
+    );
+
+    const decision = await consumer.processEnvelope(
+      request,
+      "local.metafactory.tasks.code-review.typescript",
+      null,
+    );
+
+    // Prose-fallback is a SUCCESS — ack the JetStream message.
+    expect(decision).toEqual({ kind: "ack" });
+
+    // Exactly TWO envelopes: started, then completed. NO review.verdict.*
+    // (we never fabricate a verdict from prose).
+    expect(runtime.published.length).toBe(2);
+    expect(runtime.published[0]!.type).toBe("dispatch.task.started");
+    expect(runtime.published[1]!.type).toBe("dispatch.task.completed");
+    expect(
+      runtime.published.some((e) => e.type.startsWith("review.verdict.")),
+    ).toBe(false);
+
+    // The completed envelope carries the prose verbatim as chat_response
+    // (the surface render) + a first-line result_summary label.
+    const completed = runtime.published[1]!.payload as {
+      chat_response?: string;
+      result_summary?: string;
+    };
+    expect(completed.chat_response).toBe(prose);
+    expect(completed.result_summary).toBe("I reviewed the PR.");
+    expect(runtime.published[1]!.correlation_id).toBe(request.id);
+  });
+
   test("2. unknown flavor → `cant_do` failed envelope + AckDecision is `term`", async () => {
     const runtime = createRecordingRuntime();
     // Agent claims only `typescript`; request asks for `python`.

--- a/src/bus/myelin/__tests__/runtime.test.ts
+++ b/src/bus/myelin/__tests__/runtime.test.ts
@@ -831,4 +831,101 @@ describe("MyelinRuntime", () => {
       expect(fake.publish).not.toHaveBeenCalled();
     });
   });
+
+  // -------------------------------------------------------------------------
+  // cortex#491 — idempotent push-subscribe per resolved pattern (double-bind fix)
+  // -------------------------------------------------------------------------
+  describe("cortex#491 idempotent push-subscribe", () => {
+    test("duplicate config nats.subjects pattern binds exactly ONE NATS subscription", async () => {
+      const fake = makeFakeNatsConnection();
+      const runtime = await startMyelinRuntime(
+        makeConfig({
+          url: "nats://localhost:4222",
+          name: "cortex",
+          // Same resolved pattern listed twice — pre-fix this double-bound
+          // the shared handlers Set and double-delivered every envelope.
+          subjects: ["local.test.>", "local.test.>"],
+        }),
+        { connectImpl: async () => fake.nc },
+      );
+      expect(runtime.enabled).toBe(true);
+      // Exactly ONE NATS subscription for the deduped pattern.
+      expect(fake.subscribePatterns).toEqual(["local.test.>"]);
+      // The skip is logged so operators can see the dedupe fired.
+      expect(
+        logs.some((l) => l.msg.includes("skipping duplicate subscribe")),
+      ).toBe(true);
+      await runtime.stop();
+    });
+
+    test("two DISTINCT patterns create two subscriptions (no over-dedup)", async () => {
+      const fake = makeFakeNatsConnection();
+      const runtime = await startMyelinRuntime(
+        makeConfig({
+          url: "nats://localhost:4222",
+          name: "cortex",
+          subjects: ["local.test.a.>", "local.test.b.>"],
+        }),
+        { connectImpl: async () => fake.nc },
+      );
+      expect(runtime.enabled).toBe(true);
+      expect(fake.subscribePatterns.sort()).toEqual([
+        "local.test.a.>",
+        "local.test.b.>",
+      ]);
+      await runtime.stop();
+    });
+
+    test("runtime.subscribe for a pattern already bound by config reuses it (no second bind)", async () => {
+      const fake = makeFakeNatsConnection();
+      const runtime = await startMyelinRuntime(
+        makeConfig({
+          url: "nats://localhost:4222",
+          name: "cortex",
+          subjects: ["local.test.>"],
+        }),
+        { connectImpl: async () => fake.nc },
+      );
+      expect(runtime.enabled).toBe(true);
+      expect(fake.subscribePatterns).toEqual(["local.test.>"]);
+
+      // A self-subscribe (e.g. review-sink / runner) for the SAME resolved
+      // pattern must NOT create a second NATS subscription — that is the
+      // double-bind the cortex#491 fix kills.
+      expect(runtime.subscribe).toBeDefined();
+      const sub = await runtime.subscribe!("local.test.>");
+      expect(sub).not.toBeNull();
+      // Still exactly one NATS subscription.
+      expect(fake.subscribePatterns).toEqual(["local.test.>"]);
+
+      await runtime.stop();
+    });
+
+    test("subscription cardinality is 1 for a doubly-listed pattern (fan-out runs once)", async () => {
+      // The double-delivery root cause is SUBSCRIBER cardinality, not handler
+      // cardinality: two push subscribers bound to a matching pattern each
+      // iterate the shared `handlers` Set, so every registered sink fires
+      // TWICE per publish. With the cortex#491 dedupe there is exactly ONE
+      // MyelinSubscriber → the shared handlers Set is iterated once per
+      // delivered envelope. The NATS subscription count is the observable
+      // proxy for "fan-out runs once".
+      const fake = makeFakeNatsConnection();
+      const runtime = await startMyelinRuntime(
+        makeConfig({
+          url: "nats://localhost:4222",
+          name: "cortex",
+          subjects: ["local.test.>", "local.test.>"],
+        }),
+        { connectImpl: async () => fake.nc },
+      );
+      expect(runtime.enabled).toBe(true);
+      expect(fake.subscribePatterns).toEqual(["local.test.>"]);
+      // The shared handlers Set dedupes by function reference, so a single
+      // onEnvelope registration is in the Set once; combined with one
+      // subscriber, a delivered envelope drives each handler exactly once.
+      const reg = runtime.onEnvelope(() => {});
+      reg.unregister();
+      await runtime.stop();
+    });
+  });
 });

--- a/src/bus/myelin/runtime.ts
+++ b/src/bus/myelin/runtime.ts
@@ -533,7 +533,44 @@ export async function startMyelinRuntime(
   }
 
   const subscribers: MyelinSubscriber[] = [];
-  for (const pattern of subjects) {
+  // cortex#491 — idempotent push-subscribe per RESOLVED pattern. Core-NATS
+  // push subscriptions are independent: if two subscribers bind to patterns
+  // that both match a subject, the broker delivers the envelope to BOTH, and
+  // each runs the full `for (const handler of handlers)` fan-out — so every
+  // registered sink (surface-router, worklog-manager, review-sink) fires
+  // TWICE for one publish. This is exactly the double-bind documented around
+  // `nats.subjects: []` in cortex.yaml: listing a pattern that a self-
+  // subscribe path (runtime.subscribe per cortex#477/#479) also binds
+  // re-creates the subscriber and double-delivers.
+  //
+  // The minimal, semantics-preserving fix is exact-pattern dedupe keyed by
+  // the resolved (post-substituter) pattern string: never create a second
+  // MyelinSubscriber for a pattern already bound. We deliberately do NOT do
+  // subsumption-merge (collapsing `a.b.>` into `a.>`) — that would CHANGE
+  // which subjects a subscriber receives and is harder to prove safe. Exact
+  // dedupe kills the double-bind without altering match semantics. The
+  // shared `handlers` Set, the surface-router's single registration, and
+  // `adapterMatches` are untouched (chat sink unaffected).
+  //
+  // The map spans BOTH the boot-time `nats.subjects` loop below AND the
+  // later `runtime.subscribe` self-subscribe path (`subscribePushEnabled`),
+  // so a config pattern that collides with a self-subscribe binds exactly
+  // once: whichever path runs first creates the subscriber; the second
+  // returns the SAME handle instead of double-binding.
+  const boundByPattern = new Map<string, MyelinSubscriber>();
+  /**
+   * Bind one resolved push pattern idempotently. Returns the already-bound
+   * subscriber on a duplicate, or `null` if `MyelinSubscriber.start` threw.
+   * Shared by the boot loop and `subscribePushEnabled`.
+   */
+  const bindPushPattern = (pattern: string): MyelinSubscriber | null => {
+    const existing = boundByPattern.get(pattern);
+    if (existing !== undefined) {
+      console.log(
+        `myelin-runtime: skipping duplicate subscribe to "${pattern}" (already bound)`,
+      );
+      return existing;
+    }
     try {
       const sub = MyelinSubscriber.start(link, {
         pattern,
@@ -556,13 +593,19 @@ export async function startMyelinRuntime(
         },
       });
       subscribers.push(sub);
+      boundByPattern.set(pattern, sub);
       console.log(`myelin-runtime: subscribed to "${pattern}"`);
+      return sub;
     } catch (err) {
       console.error(
         `myelin-runtime: failed to subscribe to "${pattern}":`,
         err instanceof Error ? err.message : String(err),
       );
+      return null;
     }
+  };
+  for (const pattern of subjects) {
+    bindPushPattern(pattern);
   }
 
   // cortex#337 — pre-#337 a non-empty `subjects[]` that ALL failed to
@@ -829,34 +872,19 @@ export async function startMyelinRuntime(
     if (stopped) {
       throw new Error("myelin-runtime: subscribe called after stop()");
     }
-    try {
-      const sub = MyelinSubscriber.start(link, {
-        pattern,
-        onEnvelope: (env, subject) => {
-          logEnvelope(env, subject);
-          for (const handler of handlers) {
-            try {
-              handler(env, subject);
-            } catch (err) {
-              console.error(
-                "myelin-runtime: onEnvelope handler threw:",
-                err instanceof Error ? err.message : String(err),
-              );
-            }
-          }
-        },
-      });
-      subscribers.push(sub);
-      await sub.ready;
-      console.log(`myelin-runtime: subscribed to "${pattern}"`);
-      return sub;
-    } catch (err) {
-      console.error(
-        `myelin-runtime: failed to subscribe to "${pattern}":`,
-        err instanceof Error ? err.message : String(err),
-      );
-      return null;
-    }
+    // cortex#491 — route through the shared idempotent binder so a self-
+    // subscribe that collides with a boot-time `nats.subjects` pattern (or
+    // an earlier self-subscribe of the same pattern) returns the EXISTING
+    // subscriber instead of double-binding the shared `handlers` Set. The
+    // binder owns its own try/catch + logging; `null` means start() threw.
+    const sub = bindPushPattern(pattern);
+    if (sub === null) return null;
+    // Await readiness on every call (including the deduped return): the
+    // already-bound subscriber's `ready` promise resolves immediately when
+    // it has already settled, so the caller's "subscription is live" contract
+    // holds whether this call created the subscriber or reused it.
+    await sub.ready;
+    return sub;
   };
 
   // cortex#338 — expose the live JetStreamManager so the boot path can

--- a/src/bus/review-consumer.ts
+++ b/src/bus/review-consumer.ts
@@ -752,6 +752,35 @@ export class ReviewConsumer {
       return { kind: "ack" };
     }
 
+    if (result.kind === "completed") {
+      // cortex#503 — PROSE-FALLBACK success. The agent answered in prose
+      // (no parseable structured verdict block), so there is NO
+      // `review.verdict.<kind>` co-emission — fabricating one would
+      // manufacture a verdict cortex cannot stand behind. We publish ONLY a
+      // `dispatch.task.completed` carrying the agent's prose so pilot's
+      // `--wait` observes a completion (and downgrades to commented/exit-0
+      // rather than gating on a phantom timeout), and the review sink renders
+      // the prose as markdown to the originating thread.
+      //
+      // `chatResponse` carries the FULL prose (the surface render); the first
+      // line (capped) is the dashboard `result_summary` label.
+      await this.safePublish(
+        createDispatchTaskCompletedEvent({
+          source: this.source,
+          taskId: crypto.randomUUID(),
+          agentId: this.agent.id,
+          correlationId: envelope.id,
+          startedAt,
+          completedAt: this.clock(),
+          resultSummary: firstLine(result.presentation),
+          chatResponse: result.presentation,
+          ...(responseRouting !== undefined && { responseRouting }),
+        }),
+        "dispatch.task.completed",
+      );
+      return { kind: "ack" };
+    }
+
     // result.kind === "failed" — publish the failed envelope and pick
     // the JetStream control per the four-way nak taxonomy (§7).
     await this.safePublish(result.envelope, "dispatch.task.failed");
@@ -1087,6 +1116,22 @@ export function readLogicalResponseRouting(
     channel: r.channel,
     ...(typeof r.thread === "string" && { thread: r.thread }),
   };
+}
+
+/**
+ * cortex#503 — first non-empty line of the prose-fallback presentation,
+ * capped at 1000 chars, for the `dispatch.task.completed` `result_summary`
+ * dashboard label. The FULL prose rides `chat_response`; this is only the
+ * scannable one-line label. Returns `undefined` for empty/whitespace prose
+ * so the completed builder omits `result_summary` rather than emitting an
+ * empty string.
+ */
+function firstLine(text: string): string | undefined {
+  for (const raw of text.split("\n")) {
+    const line = raw.trim();
+    if (line.length > 0) return line.slice(0, 1000);
+  }
+  return undefined;
 }
 
 /**

--- a/src/bus/review-events.ts
+++ b/src/bus/review-events.ts
@@ -307,6 +307,23 @@ export interface ReviewVerdictPayload {
   };
   /** Total inline comments posted with the review. */
   inline_comments: number;
+  /**
+   * cortex#503 — **Presentation markdown.** Deterministic markdown computed
+   * by cortex (NOT the reviewing agent) from the structured verdict fields
+   * above — verdict kind + `summary` + findings counts + the GitHub review
+   * link. Surfaces render this string VERBATIM as markdown; they never
+   * JSON-dump the payload. Authored by `buildPresentationMarkdown` in
+   * `runner/review-pipeline.ts` (idempotent: same payload in → identical
+   * string out), so the heading/emoji/counts/link are code-stamped while the
+   * agent's prose lives only in `summary`.
+   *
+   * OPTIONAL for wire forward-compat: older subscribers (pilot's verdict
+   * matcher keys on the envelope `type` suffix + `correlation_id` only, NOT
+   * on `presentation`) keep parsing unchanged, and a surface seeing no
+   * `presentation` falls back to a markdown prose/structured render — never
+   * a JSON dump.
+   */
+  presentation?: string;
 }
 
 /** Options for {@link createReviewVerdictEvent}. */
@@ -399,6 +416,14 @@ export function createReviewVerdictEvent(
         nits: opts.payload.findings.nits,
       },
       inline_comments: opts.payload.inline_comments,
+      // cortex#503 — code-stamped presentation markdown (deterministic; the
+      // reviewing agent never authored it). Surfaces render this verbatim.
+      // Optional on the wire: omitted when the producer didn't compute one
+      // (older callers / sage Phase-1), in which case surfaces fall back to
+      // the `formatReviewVerdict` one-liner — never a JSON dump.
+      ...(opts.payload.presentation !== undefined && {
+        presentation: opts.payload.presentation,
+      }),
       // cortex#502 — echo response routing when the inbound review request
       // carried it, so the review sink can render the verdict to the
       // originating thread. Omitted (no key on the wire) for pilot-only /

--- a/src/runner/__tests__/review-pipeline.test.ts
+++ b/src/runner/__tests__/review-pipeline.test.ts
@@ -12,7 +12,8 @@
  *        - wait() rejects → `not_now`
  *        - session aborted (timeout) → `not_now`
  *        - non-zero exit with no output → `not_now`
- *        - clean exit with no JSON block → `cant_do`
+ *        - clean exit with no JSON block → cortex#503 prose-fallback
+ *          `{ kind: "completed" }` (NOT `cant_do`; no fabricated verdict)
  *        - JSON block present but malformed → `cant_do`
  *        - JSON block parseable but missing/wrong-typed field → `cant_do`
  *        - JSON block has out-of-enum verdict → `cant_do`
@@ -46,6 +47,7 @@ import type {
 } from "../../substrates/claude-code/harness";
 import type { CCSessionResult } from "../cc-session";
 import {
+  buildPresentationMarkdown,
   runReviewPipeline,
   type ReviewPipelineOpts,
 } from "../review-pipeline";
@@ -350,17 +352,17 @@ describe("runReviewPipeline — failure taxonomy", () => {
     expect(reason.detail).toContain("137");
   });
 
-  test("clean exit with no JSON block → cant_do (skill broke contract)", async () => {
-    const { factory } = fakeFactory(
-      successResult("I reviewed the PR but forgot to emit a verdict block."),
-    );
+  test("cortex#503 — clean exit with no JSON block → completed prose-fallback (NOT cant_do)", async () => {
+    const prose = "I reviewed the PR but answered in prose.\n\nLGTM overall.";
+    const { factory } = fakeFactory(successResult(`  ${prose}  \n`));
     const result = await runReviewPipeline(baseOpts(factory));
-    expect(result.kind).toBe("failed");
-    if (result.kind !== "failed") return;
-    const payload = result.envelope.payload;
-    const reason = payload.reason as { kind: string; detail: string };
-    expect(reason.kind).toBe("cant_do");
-    expect(reason.detail).toContain("did not return parseable verdict block");
+    // The old hard-fail (cant_do) is gone — the agent completed, in prose.
+    expect(result.kind).toBe("completed");
+    if (result.kind !== "completed") return;
+    // presentation IS the trimmed prose (passthrough, still markdown).
+    expect(result.presentation).toBe(prose);
+    // No verdict envelope is fabricated; no failed envelope.
+    expect(result).not.toHaveProperty("envelope");
   });
 
   test("malformed JSON inside block → cant_do", async () => {
@@ -475,9 +477,10 @@ describe("runReviewPipeline — correlation_id contract", () => {
 
   test("failed envelope (cant_do path) carries correlation_id = requestEnvelope.id", async () => {
     const req = makeRequestEnvelope();
-    const { factory } = fakeFactory(
-      successResult("no block at all"),
-    );
+    // cortex#503 — the no-block path is now a `completed` prose-fallback, so
+    // exercise a genuine `cant_do` failure: a present-but-malformed JSON block.
+    const malformed = ["```json", "{ not: valid json }", "```"].join("\n");
+    const { factory } = fakeFactory(successResult(malformed));
     const result = await runReviewPipeline({
       ...baseOpts(factory),
       requestEnvelope: req,
@@ -694,5 +697,114 @@ describe("runReviewPipeline — responseRouting (cortex#502)", () => {
     await expect(
       runReviewPipeline({ ...baseOpts(factory), responseRouting: ROUTING }),
     ).resolves.toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cortex#503 — buildPresentationMarkdown (deterministic, idempotent, no JSON)
+// ---------------------------------------------------------------------------
+
+/** Internal VerdictBlock shape, mirrored for the unit tests. */
+const SAMPLE_BLOCK = {
+  verdict: "changes-requested" as ReviewVerdictKind,
+  summary: "Two majors in the auth path; three nits in tests.",
+  github_review_id: 2459183744,
+  github_review_url:
+    "https://github.com/the-metafactory/cortex/pull/229#pullrequestreview-2459183744",
+  submitted_at: "2026-05-16T09:51:30Z",
+  commit_id: "a1b2c3d4e5f6789012345678901234567890abcd",
+  findings: { blockers: 1, majors: 2, nits: 3 },
+  inline_comments: 5,
+};
+
+describe("buildPresentationMarkdown — deterministic markdown, zero LLM tokens", () => {
+  test("contains findings counts, 7-char commit, and the github_review_url", () => {
+    const md = buildPresentationMarkdown(SAMPLE_BLOCK);
+    expect(md).toContain("1 blockers");
+    expect(md).toContain("2 majors");
+    expect(md).toContain("3 nits");
+    expect(md).toContain("5 inline comments");
+    expect(md).toContain(SAMPLE_BLOCK.github_review_url);
+    // 7-char short commit, NOT the full 40-char SHA.
+    expect(md).toContain("a1b2c3d");
+    expect(md).not.toContain(SAMPLE_BLOCK.commit_id);
+    // The agent's own prose summary is preserved verbatim.
+    expect(md).toContain(SAMPLE_BLOCK.summary);
+  });
+
+  test("emoji + label by verdict kind", () => {
+    expect(buildPresentationMarkdown({ ...SAMPLE_BLOCK, verdict: "approved" })).toContain(
+      "✅ Approved",
+    );
+    expect(
+      buildPresentationMarkdown({ ...SAMPLE_BLOCK, verdict: "changes-requested" }),
+    ).toContain("🔴 Changes requested");
+    expect(
+      buildPresentationMarkdown({ ...SAMPLE_BLOCK, verdict: "commented" }),
+    ).toContain("💬 Commented");
+  });
+
+  test("idempotent — same block in → byte-identical string out", () => {
+    const a = buildPresentationMarkdown(SAMPLE_BLOCK);
+    const b = buildPresentationMarkdown({
+      ...SAMPLE_BLOCK,
+      findings: { ...SAMPLE_BLOCK.findings },
+    });
+    expect(a).toBe(b);
+  });
+
+  test("never leaks raw JSON — no payload braces / quoted-key pattern", () => {
+    const md = buildPresentationMarkdown(SAMPLE_BLOCK);
+    // No JSON object dump (the failure mode the field exists to prevent).
+    expect(md).not.toContain('"verdict"');
+    expect(md).not.toContain('"findings"');
+    expect(md).not.toContain('"github_review_url"');
+  });
+
+  test("empty github_review_url → no link line, no dangling commit", () => {
+    const md = buildPresentationMarkdown({
+      ...SAMPLE_BLOCK,
+      github_review_url: "",
+    });
+    expect(md).not.toContain("Review on GitHub");
+    expect(md).not.toContain("a1b2c3d");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cortex#503 — presentation stamped on the verdict payload
+// ---------------------------------------------------------------------------
+
+describe("runReviewPipeline — presentation on the verdict payload", () => {
+  test("verdict payload carries deterministic presentation matching the helper", async () => {
+    const block = buildVerdictBlock("changes-requested", {
+      summary: "Blocking: SQL injection in the search route.",
+      commit_id: "deadbeef0000111122223333444455556666aaaa",
+      github_review_url: "https://github.com/the-metafactory/cortex/pull/229#r1",
+      findings: { blockers: 1, majors: 0, nits: 2 },
+      inline_comments: 4,
+    });
+    const { factory } = fakeFactory(successResult(block));
+    const result = await runReviewPipeline(baseOpts(factory));
+    expect(result.kind).toBe("verdict");
+    if (result.kind !== "verdict") return;
+    const presentation = result.envelope.payload.presentation;
+    expect(typeof presentation).toBe("string");
+    expect(presentation as string).toContain("🔴 Changes requested");
+    expect(presentation as string).toContain("1 blockers");
+    expect(presentation as string).toContain("deadbee"); // 7-char commit
+    // verbatim deterministic — recompute and compare.
+    expect(presentation).toBe(
+      buildPresentationMarkdown({
+        verdict: "changes-requested",
+        summary: "Blocking: SQL injection in the search route.",
+        github_review_id: 2459183744,
+        github_review_url: "https://github.com/the-metafactory/cortex/pull/229#r1",
+        submitted_at: "2026-05-16T09:51:30Z",
+        commit_id: "deadbeef0000111122223333444455556666aaaa",
+        findings: { blockers: 1, majors: 0, nits: 2 },
+        inline_comments: 4,
+      }),
+    );
   });
 });

--- a/src/runner/review-pipeline.ts
+++ b/src/runner/review-pipeline.ts
@@ -54,7 +54,8 @@
  * | CC factory throws synchronously (binary missing)     | `not_now`   | Transient substrate failure (§7.3); principal-recoverable. |
  * | CC session `kill()` / inactivity timeout / abort     | `not_now`   | Substrate-side crash (§7.6) — pilot maps to exit 4.        |
  * | CC session exits non-zero with no parseable block    | `not_now`   | Substrate-side crash (§7.6).                                |
- * | CC session exits clean (0) but no verdict block      | `cant_do`   | Skill didn't fulfil its contract (§4.5).                    |
+ * | CC session exits clean (0) but no verdict block      | (none)      | cortex#503 — agent answered in prose; SUCCESS completion   |
+ * |                                                      |             | `{ kind: "completed", presentation }` (NOT a fail/verdict).|
  * | Verdict block present but JSON parse fails           | `cant_do`   | Skill emitted malformed output (§4.5).                      |
  * | Verdict block parses but required field missing/bad  | `cant_do`   | Schema mismatch (§4.5).                                     |
  * | Caller-injected policy refusal (e.g. scope-out)      | `wont_do`   | Reviewer policy refused (§7.2); explicit opt-in via opt.    |
@@ -111,9 +112,21 @@ import {
  * PR-6's consumer pattern-matches on `result.kind` to decide whether to
  * also publish a `dispatch.task.completed` (verdict path) or to skip
  * straight to acking the JetStream message (failed path).
+ *
+ * cortex#503 — a THIRD variant `kind: "completed"` carries the
+ * **prose-fallback** success: the CC session exited clean but emitted no
+ * parseable structured verdict block, so the agent answered in prose. The
+ * pipeline does NOT fabricate a structured verdict from that prose (that
+ * would violate "no agent/LLM tokens author the verdict" + the
+ * discriminator-alignment guard). Instead it returns the agent's own prose
+ * (markdown) as `presentation` and the consumer publishes a plain
+ * `dispatch.task.completed` (NOT a `review.verdict.<kind>`). JSON never
+ * reaches a surface: the verdict path computes deterministic presentation
+ * markdown, the prose path passes the prose through as markdown.
  */
 export type ReviewPipelineResult =
   | { kind: "verdict"; envelope: Envelope }
+  | { kind: "completed"; presentation: string }
   | { kind: "failed"; envelope: Envelope };
 
 /**
@@ -382,21 +395,27 @@ export async function runReviewPipeline(
   }
 
   // §4.5 — extract the structured-verdict JSON block from the CC stream's
-  // last assistant message. Absent block on a clean exit = skill didn't
-  // honour the contract (`cant_do`, permanent — principal must fix the
-  // skill, not retry the request).
+  // last assistant message.
+  //
+  // cortex#503 — absent block on a CLEAN exit is NO LONGER a hard-fail.
+  // Previously this returned `{ kind: "failed", reason: cant_do }`, which
+  // gated pilot's `--wait` (exit non-zero) on a review the agent actually
+  // completed — it just answered in prose rather than the structured block.
+  // We DO NOT fabricate a structured verdict from the prose (that would
+  // manufacture an approved/changes-requested/commented kind cortex cannot
+  // stand behind, violating "no agent/LLM tokens author the verdict"). The
+  // `inferVerdictFromProse` heuristic is deliberately NOT implemented.
+  //
+  // Instead this is a SUCCESS completion: `presentation` carries the raw
+  // prose (trimmed, still markdown), and the consumer publishes a plain
+  // `dispatch.task.completed` — NOT a `review.verdict.<kind>`. The remaining
+  // failure paths (malformed JSON when a block WAS present; substrate
+  // crash/timeout; field-validation) stay `cant_do`/`not_now` — those are
+  // genuine substrate/contract failures, distinct from "agent answered in
+  // prose".
   const block = extractVerdictBlock(result.response);
   if (block === null) {
-    return failed(
-      opts,
-      correlationId,
-      startedAt,
-      {
-        kind: "cant_do",
-        detail: "skill did not return parseable verdict block",
-      },
-      "skill did not return parseable verdict block",
-    );
+    return { kind: "completed", presentation: result.response.trim() };
   }
 
   const parsed = parseVerdictBlock(block);
@@ -435,6 +454,12 @@ export async function runReviewPipeline(
       nits: parsed.value.findings.nits,
     },
     inline_comments: parsed.value.inline_comments,
+    // cortex#503 — stamp the deterministic presentation markdown computed
+    // by cortex from the structured fields. Zero LLM tokens: the reviewing
+    // agent only authored `summary`; the heading/emoji/counts/link line are
+    // code-stamped here so it rides the `review.verdict.<kind>` payload onto
+    // the wire for surfaces to render verbatim.
+    presentation: buildPresentationMarkdown(parsed.value),
   };
 
   let envelope: Envelope;
@@ -640,4 +665,78 @@ function parseVerdictBlock(raw: string): ParseResult<VerdictBlock> {
       inline_comments: obj.inline_comments,
     },
   };
+}
+
+/**
+ * cortex#503 — build the deterministic **presentation markdown** for a
+ * parsed structured verdict.
+ *
+ * Pure, deterministic string-templating over the already-parsed structured
+ * fields (verdict kind, summary, findings counts, inline_comments, the
+ * GitHub review link + 7-char commit). ZERO agent/LLM tokens: the reviewing
+ * agent authored only `block.summary`; this code stamps the heading, emoji,
+ * findings line, and link. Idempotent — the same {@link VerdictBlock} in
+ * produces a byte-identical string out (no clocks, no randomness, no
+ * environment reads).
+ *
+ * Surfaces render this string VERBATIM as markdown (the review sink + any
+ * `review.verdict.*` adapter), so it must never embed raw JSON. Per the
+ * control-plane/data-plane rule, the FULL review body lives on GitHub (the
+ * `github_review_url`); this markdown is the cortex-side render the surfaces
+ * post — a Discord entity thread typically derives a one-liner from it.
+ *
+ * Shape:
+ *
+ *   ### {emoji} {Verdict-Label} — {repo}#{pr}
+ *
+ *   {summary}
+ *
+ *   **Findings:** {b} blockers · {m} majors · {n} nits · {i} inline comments
+ *
+ *   [Review on GitHub]({github_review_url}) ({commit7})
+ *
+ * Emoji + label by verdict:
+ *   - `approved`          → ✅ "Approved"
+ *   - `changes-requested` → 🔴 "Changes requested"
+ *   - `commented`         → 💬 "Commented"
+ */
+export function buildPresentationMarkdown(block: VerdictBlock): string {
+  let emoji: string;
+  let label: string;
+  if (block.verdict === "approved") {
+    emoji = "✅";
+    label = "Approved";
+  } else if (block.verdict === "changes-requested") {
+    emoji = "🔴";
+    label = "Changes requested";
+  } else {
+    emoji = "💬";
+    label = "Commented";
+  }
+
+  const { blockers, majors, nits } = block.findings;
+  const findingsLine =
+    `**Findings:** ${blockers} blockers · ${majors} majors · ${nits} nits ` +
+    `· ${block.inline_comments} inline comments`;
+
+  const lines: string[] = [`### ${emoji} ${label}`];
+
+  const summary = block.summary.trim();
+  if (summary.length > 0) {
+    lines.push("", summary);
+  }
+
+  lines.push("", findingsLine);
+
+  // GitHub link line — only when a URL is present (sage Phase-1 verdicts can
+  // carry an empty url). The commit suffix is the first 7 chars of the SHA
+  // (the conventional short form); omitted when commit_id is empty.
+  const url = block.github_review_url.trim();
+  if (url.length > 0) {
+    const commit7 = block.commit_id.trim().slice(0, 7);
+    const commitSuffix = commit7.length > 0 ? ` (\`${commit7}\`)` : "";
+    lines.push("", `[Review on GitHub](${url})${commitSuffix}`);
+  }
+
+  return lines.join("\n");
 }


### PR DESCRIPTION
Follow-up to #502/#503, driven by live testing. Three coordinated fixes so review replies read like a person, never fail on prose, and never double-post.

## 1. Deterministic `presentation` (zero LLM tokens)
- New pure helper `buildPresentationMarkdown(block)` in `review-pipeline.ts` — plain TS templating over the **already-parsed** structured verdict fields (verdict kind, findings counts, link, summary). The reviewing agent never authors it; cortex stamps it. Idempotent.
- Added optional `presentation?: string` to `ReviewVerdictPayload` + threaded through `createReviewVerdictEvent` (conditional spread → off the wire when absent → forward-compat with pilot's matcher).
- Surfaces render `presentation` (markdown), **never raw JSON**.

## 2. No hard-fail on a missing verdict block
- `review-pipeline.ts`: when there's no parseable block, instead of `cant_do`/`dispatch.task.failed`, emit a **successful** `{ kind: "completed", presentation }` carrying the harness's trimmed prose. No fabricated verdict (no `inferVerdictFromProse`) — a prose answer is a successful review, not a failure. Genuine substrate/malformed-JSON failures are unchanged.

## 3. Runtime double-delivery fix
- Root cause (the two Discord threads in live testing): the myelin runtime starts an independent push subscriber **per pattern** over one shared `handlers` Set, so two subscribers on overlapping patterns (worklog-manager + review-sink both on `dispatch.task.>`) fan out **twice**.
- Fix: **idempotent subscribe per resolved pattern** in `startMyelinRuntime` — never bind a second push subscriber for an already-bound pattern. Exact-pattern dedupe (semantics-preserving), not subsumption-merge. Surface-router (chat) registers a single `onEnvelope` handler and is unaffected.

## Plus
- `cortex.yaml.example`: drop `tasks.code-review.>` from `surfaceSubjects` (the raw-JSON-to-Discord leak, #477/#479 class) — matches the live config fix.

## Verification
- `bunx tsc --noEmit` clean; `eslint --quiet` clean; **1232 pass / 0 fail** (src/adapters src/bus src/runner). Adversarial review (2 agents): both **recommend-merge**, all claims source-verified.

⚠️ **Merge together with pilot's commented-fallback PR** (treats a prose `completed` as `commented` exit 0). Refs #502.

🤖 Generated with [Claude Code](https://claude.com/claude-code)