### PR TITLE
docs(config): add agent nkey_pub to cortex.yaml.example for bot↔bot dispatch

### DIFF
--- a/cortex.yaml.example
+++ b/cortex.yaml.example
@@ -179,6 +179,12 @@ policy:
 agents:
   - id: echo
     displayName: Echo
+    # OPTIONAL but REQUIRED for NKey-verified bot↔bot dispatch: the agent's
+    # Ed25519 public key (U-prefixed) from its NATS creds. Without it a peer
+    # signing a request as did:mf:echo is rejected `principal_has_no_nkey_pub`
+    # (the agent then falls back to platform-id trust only). Paste the
+    # U-prefixed pubkey from ~/.config/nats/echo.creds.
+    nkey_pub: UAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA  # <REPLACE_ME>
     persona: ./personas/echo.md
     trust: []
     runtime:


### PR DESCRIPTION
Adds an optional, documented `nkey_pub` placeholder to the example agent so fresh installs can do NKey-verified bot↔bot dispatch (without it, a peer signing as `did:mf:echo` is rejected `principal_has_no_nkey_pub` — the gap that blocked the review loop until the live config got per-agent keys). Doc/config only; YAML validates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)