### PR TITLE
fix(cortex): dispatch review intent, not the /review method

### DIFF
--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -1049,9 +1049,16 @@ export async function startCortex(
         // PR-6 has no policy hook — that's a future PR (sovereignty /
         // compliance gate). Until then the pipeline goes straight to CC.
         promptBuilder: ({ payload }) =>
-          // Minimal prompt — the real skill-aware builder lands in PR-8.
-          // Echo's skill consumes `/review <owner/repo>#<pr>` style today.
-          `/review ${payload.repo}#${payload.pr}`,
+          // Dispatch INTENT, not method. cortex pings the reviewer with the
+          // PR to review; the reviewing agent (e.g. Echo) owns HOW — its
+          // persona routes to its canonical review entry (`/review-pr` →
+          // CodeReview skill → `gh pr review` + the cortex#237 verdict block).
+          // Do NOT send a `/review` slash command here: that hijacks the
+          // session into the generic built-in reviewer (which produces prose
+          // and *asks* before posting — never posting in a non-interactive
+          // dispatch). Capability routing already happened on the subject
+          // (`tasks.code-review.*`); the prompt only carries the intent.
+          `Review PR ${payload.repo}#${payload.pr}`,
         sessionOpts: reviewSessionOpts,
         ...(pipelineRunner !== undefined && { pipelineRunner }),
         ...(signatureVerifier !== undefined && { signatureVerifier }),


### PR DESCRIPTION
## Why reviews never landed on GitHub

cortex pinged the reviewer with **`/review {repo}#{pr}`** — a **slash command** that hijacks the dispatched session into the **generic built-in** reviewer, which produces prose and then *asks* "want me to post?". In a non-interactive `claude --print` dispatch nobody answers → **no `gh pr review`, no cortex#237 verdict block** (so the loop always resolved `commented`, never approve/changes-requested).

## Fix — dispatch intent, not method

The reviewing agent already owns the *how*: Echo's persona routes a review to `/review-pr` → CodeReview skill → `gh pr review` + the verdict block. Capability routing already happened on the subject (`tasks.code-review.*`). So the prompt now carries only the **intent**:
```
Review PR {repo}#{pr}
```
The center orchestrates; the edge specializes (`feedback_dispatch-not-dictate`). One change should fix the GitHub post **and** unlock the structured verdict / autonomous merge-gate.

## Verification
- tsc clean; eslint clean; review-consumer suite 51/51 (its `/review` fixtures are self-contained, unaffected).
- Post-deploy: re-run the pilot loop and confirm Echo posts to GitHub + returns a structured verdict.

Refs #502.

🤖 Generated with [Claude Code](https://claude.com/claude-code)