### PR TITLE
chore(release): cortex v3.1.0 — bot-to-bot review reply loop + Discord stability

### DIFF
--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -2,7 +2,7 @@
 # See: https://github.com/the-metafactory/arc
 
 name: "Cortex"
-version: "3.0.3"
+version: "3.1.0"
 type: component
 tier: community
 description: "Layer-7 collaboration surface for the metafactory ecosystem — the M7 application that consumes the Myelin stack"


### PR DESCRIPTION
Version bump 3.0.3 → **3.1.0** (minor — new review-reply-loop feature + fixes). Covers tonight's merged work (#493, #495, #497, #498, #499, #500, #503, #504, #505, #506, #507). Tag + GitHub release follow on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)