### PR TITLE
docs(ioaw): refresh design+plan to CONTEXT.md vocab + add config-split & shared-gateway epics

### DIFF
--- a/docs/design-internet-of-agentic-work.md
+++ b/docs/design-internet-of-agentic-work.md
@@ -4,13 +4,15 @@
 **Status:** Design draft. No implementation in this PR — only synthesis grounded in shipped code.
 **Scope:** Single design view across four sibling issues that, taken together, describe how cortex composes into networks of stacks.
 
-> **All 7 design questions resolved 2026-05-13 (Andreas).** Implementation plan: [`docs/plan-internet-of-agentic-work.md`](./plan-internet-of-agentic-work.md). Sub-issues track Phase A–E in cortex (filed as part of cortex#110 work). The §5 recommendations are now operator-locked; the plan doc is the working ground truth from here.
+> **Terminology aligned to CONTEXT.md** (the architectural source of truth, post operator→principal refactor). The HUMAN who owns and runs stacks is the **principal**; "operator" survives only as the NSC/NATS account-level concept (operator account NKey, operator JWT) and as the "Operator vision" reference label. Code identifiers / field names that still read `operator` (e.g. `home_operator`, `operatorId`) are tracked separately under cortex#448 and are left as-is here, flagged where they appear. Dispatch mode "broadcast" → **Offer**; "reach" → **scope**; "topic" → **subject**; overloaded "agent" disambiguated into **assistant** / **agent** / **sub-agent**; "persona" as a domain entity → **assistant** (persona file paths stay).
+
+> **All 7 design questions resolved 2026-05-13 (Andreas).** Implementation plan: [`docs/plan-internet-of-agentic-work.md`](./plan-internet-of-agentic-work.md). Sub-issues track Phase A–E in cortex (filed as part of cortex#110 work). The §5 recommendations are now principal-locked; the plan doc is the working ground truth from here.
 
 ---
 
 ## TL;DR
 
-Four sibling design issues converge on one architecture. cortex#91 (substrate harness) decouples agent execution from any single LLM vendor; cortex#102 (bot↔bot via bus envelopes) replaces platform-ID trust with cryptographic identity at L3/L4; cortex#107 (principal-based AAA) lifts authorization out of per-surface adapters and into a single PolicyEngine at M6; cortex#109 (envelope-visibility + subject-namespace routing) consumes myelin's `sovereignty.classification` taxonomy and the `local|federated|public` namespace so multi-operator federation becomes mechanically possible. The composition anchor is **stack → network → multi-network**: one operator can run multiple stacks; stacks join networks via NATS leaf-node federation; one stack can participate in multiple networks at once. Three scopes — local / federated / public — are not access control but expressed *intent*; sovereignty metadata carries the policy on every envelope. This doc maps each sibling to a layer in the M1–M7 stack, inventories what ships today vs. what is designed vs. what is open, sequences five implementation phases (A–E), and surfaces seven design questions that need Andreas's call before Phase A can start.
+Four sibling design issues converge on one architecture. cortex#91 (substrate harness) decouples agent execution from any single LLM vendor; cortex#102 (bot↔bot via bus envelopes) replaces platform-ID trust with cryptographic identity at L3/L4; cortex#107 (principal-based AAA) lifts authorization out of per-surface adapters and into a single PolicyEngine at M6; cortex#109 (envelope-visibility + subject-namespace routing) consumes myelin's `sovereignty.classification` taxonomy and the `local|federated|public` namespace so multi-principal federation becomes mechanically possible. The composition anchor is **stack → network → multi-network**: one principal can run multiple stacks; stacks join networks via NATS leaf-node federation; one stack can participate in multiple networks at once. Three scopes — local / federated / public — are not access control but expressed *intent*; sovereignty metadata carries the policy on every envelope. This doc maps each sibling to a layer in the M1–M7 stack, inventories what ships today vs. what is designed vs. what is open, sequences five implementation phases (A–E), and surfaces seven design questions that need Andreas's call before Phase A can start.
 
 The unit isn't the agent, isn't the stack — it's the network, and networks compose.
 
@@ -24,10 +26,10 @@ cortex's canonical layered architecture is the **M1–M7 Myelin stack** (`cortex
 
 Out of scope for myelin per `myelin/docs/architecture.md:81-88` — internet plumbing. Cortex's contract here is "assume authenticated, encrypted, ordered byte streams". Two artefacts at M1 matter for federation:
 
-- **NATS leaf-node topology.** `local.{org}.>` subjects are not replicated across operator boundaries (`myelin/specs/namespace.md:15-22`); enforcement is at the leaf-node configuration, not in application code. This is the load-bearing structural property — a misconfigured leaf-node breaks the sovereignty model irrespective of envelope content.
-- **Creds-auth.** cortex#86 (closed) — operator-mode NATS auth via `.creds` files. Per `cortex/src/common/types/cortex-config.ts:476` (`nats.credsPath`) and `src/bus/myelin/runtime.ts:148-154`, cortex authenticates connections via `credsAuthenticator(...)` before any envelope flows.
+- **NATS leaf-node topology.** `local.{principal}.>` subjects are not replicated across principal boundaries (`myelin/specs/namespace.md:15-22`); enforcement is at the leaf-node configuration, not in application code. This is the load-bearing structural property — a misconfigured leaf-node breaks the sovereignty model irrespective of envelope content.
+- **Creds-auth.** cortex#86 (closed) — NSC operator-account NATS auth via `.creds` files (the NATS "operator" here is the NSC account-tree root — `OP_ANDREAS`, the operator-account NKey / operator JWT — a distinct NATS concept, NOT the human principal). Per `cortex/src/common/types/cortex-config.ts:476` (`nats.credsPath`) and `src/bus/myelin/runtime.ts:148-154`, cortex authenticates connections via `credsAuthenticator(...)` before any envelope flows.
 
-**Module → layer map.** No cortex modules at M1; everything lives in operator-side NATS server configuration and platform-side leaf-node topology.
+**Module → layer map.** No cortex modules at M1; everything lives in principal-side NATS server configuration and platform-side leaf-node topology.
 
 ### M2 — Transport (NatsLink, MyelinRuntime publish/subscribe)
 
@@ -61,25 +63,25 @@ Cortex consumption today:
 
 ### M4 — Subject routing (local / federated / public namespace + tasks domain)
 
-myelin's namespace spec (`myelin/specs/namespace.md`) defines the three subject prefixes and their reach:
+myelin's namespace spec (`myelin/specs/namespace.md`) defines the three subject prefixes and their scope:
 
 | Prefix | Scope | Sovereignty Rule |
 |---|---|---|
-| `local.{org}.{domain}.{entity}.{action}` | Org only | Never leaves org boundary (M1 leaf-node enforced) |
-| `federated.{org}.{domain}.{entity}.{action}` | Cross-org | Subject to envelope sovereignty rules |
+| `local.{principal}.{domain}.{entity}.{action}` | Principal only | Never leaves principal boundary (M1 leaf-node enforced) |
+| `federated.{principal}.{domain}.{entity}.{action}` | Cross-principal | Subject to envelope sovereignty rules |
 | `public.{domain}.{entity}.{action}` | Unrestricted | No sovereignty constraints |
 
-The **tasks domain** (`myelin/specs/namespace.md:134-213`) extends the standard `{prefix}.{org}.{domain}.*` form with three distribution shapes:
+The **tasks domain** (`myelin/specs/namespace.md:134-213`) extends the standard `{prefix}.{principal}.{domain}.*` form with three distribution shapes:
 
-- **Broadcast** — `local.{org}.tasks.{capability}.{subcapability}` — competing consumers, queue-group exactly-once-per-group semantics.
-- **Direct/Delegate** — `local.{org}.tasks.@{principal}.{capability}` — single-recipient via DID-encoded `@`-segment.
-- **Dead-letter** — `local.{org}.tasks.dead-letter.{capability}` — unclaimable-task escalation.
+- **Offer** — `local.{principal}.tasks.{capability}.{subcapability}` — competing consumers, queue-group exactly-once-per-group semantics. (myelin's `DistributionMode` enum still ships the `'broadcast'` value; cortex maps `'broadcast'` → Offer at the boundary.)
+- **Direct/Delegate** — `local.{principal}.tasks.@{assistant}.{capability}` — single-recipient via DID-encoded `@`-segment naming an **assistant**.
+- **Dead-letter** — `local.{principal}.tasks.dead-letter.{capability}` — unclaimable-task escalation.
 
-The federated counterpart mirrors all three patterns (`myelin/specs/namespace.md:202-213`); subject routing for cross-operator work is wire-format-ready today.
+The federated counterpart mirrors all three patterns (`myelin/specs/namespace.md:202-213`); subject routing for cross-principal work is wire-format-ready today.
 
 Cortex consumption today:
-- `MyelinRuntime.publish()` (`src/bus/myelin/runtime.ts:236`) emits `local.${org}.${envelope.type}` — never `federated.*` or `public.*`. Subject prefix is hardcoded to match the hardcoded classification.
-- Subscribe-side `cortex.yaml.nats.subjects` may include any pattern via `{org}` substitution (`runtime.ts:126-128`) — but emit-side only produces `local.*`.
+- `MyelinRuntime.publish()` (`src/bus/myelin/runtime.ts:236`) emits `local.${principal}.${envelope.type}` — never `federated.*` or `public.*`. Subject prefix is hardcoded to match the hardcoded classification. (Code still reads the local var as `org`; that identifier rename is tracked under cortex#448.)
+- Subscribe-side `cortex.yaml.nats.subjects` may include any pattern via `{principal}` substitution (`runtime.ts:126-128`) — but emit-side only produces `local.*`.
 
 ### M5 — Stream / consumer (TASKS JetStream, retention, queue-group)
 
@@ -98,7 +100,7 @@ myelin's L6 is composition patterns — spec-pending (`myelin/docs/architecture.
 
 - **Surface-router** (`src/bus/surface-router.ts`) — G-1111.A. In-process fan-out point. Adapters declare interest via NATS-style subject patterns plus an optional payload filter; the router applies subject matching first, then payload filtering, then invokes `adapter.render(envelope)` with timeout + isolation (`surface-router.ts:259-270`, `surface-router.ts:291-319`).
 - **Dispatch-handler** (`src/bus/dispatch-handler.ts`) — orchestrates one inbound surface event through to one runner session. The natural integration point for cortex#107's PolicyEngine.
-- **Trust resolver** (`src/common/agents/trust-resolver.ts`) — cortex#76 + cortex#105. Process-wide bidirectional `(platform, platformUserId) ↔ agentId` map, plus operator-account-signing-key signature verification.
+- **Trust resolver** (`src/common/agents/trust-resolver.ts`) — cortex#76 + cortex#105. Process-wide bidirectional `(platform, platformUserId) ↔ agentId` map, plus NSC operator-account-signing-key signature verification (the operator-account NKey is the NSC trust root, not the human principal).
 - **PolicyEngine** (cortex#107) — does not yet exist. The design issue specifies a `src/common/policy/` module with `PolicyEngine.check(principal, intent) → { allow, capabilities } | { allow: false, reason }`.
 
 ### M7 — Surface adapters (Discord, Mattermost, dashboard, gh CLI, pilot)
@@ -107,14 +109,14 @@ Per `cortex/docs/architecture.md:288-303`, cortex is the L7 capability dashboard
 
 - **Discord adapter** (`src/adapters/discord/`) — owns the legacy role-resolver loop. cortex#107 thins it to translate-event-to-Principal (~30 LOC).
 - **Mattermost adapter** (`src/adapters/mattermost/`) — same shape.
-- **Dashboard renderer** (`src/renderers/dashboard.ts`) — subscribes to `local.{org}.>` and projects to D1; no sovereignty filter today (cortex#109 §3).
+- **Dashboard renderer** (`src/renderers/dashboard.ts`) — subscribes to `local.{principal}.>` and projects to D1; no sovereignty filter today (cortex#109 §3).
 - **Taps** — `src/taps/cc-events/` (CC hooks → bus, `cc-events.ts`), `src/taps/gh-webhook-receiver/` (GitHub HMAC → bus, `github-events.ts`).
 
 ### Module-to-layer map (cortex repo)
 
 | Layer | Cortex code | Myelin code |
 |---|---|---|
-| M1 | (operator NATS topology) | (out of scope) |
+| M1 | (principal-side NATS topology + NSC operator account) | (out of scope) |
 | M2 | `src/bus/nats/connection.ts`, `src/bus/myelin/runtime.ts`, `src/bus/myelin/subscriber.ts` | `src/transport/` (NATSTransport, InMemoryTransport) |
 | M3 | `src/bus/myelin/envelope-validator.ts` (pinned at `96b14ea`), `src/bus/envelope-builder.ts`, `src/bus/dispatch-events.ts`, `src/bus/system-events.ts`, `src/bus/github-events.ts`, `src/taps/cc-events/cc-events.ts` | `src/envelope.ts`, `src/types.ts`, `schemas/envelope.schema.json` |
 | M4 | (consumes myelin namespace spec — no cortex-side namespace code) | `src/identity/` (chain-of-stamps), `specs/namespace.md` |
@@ -126,47 +128,47 @@ Per `cortex/docs/architecture.md:288-303`, cortex is the L7 capability dashboard
 
 ## §2 — Current-state inventory by layer
 
-This section is rigorous about three states: **shipped** (running in production), **designed** (issue body or PR draft), **speculative** (idea in this synthesis or in operator-vision notes). Andreas wants the truth, not optimism.
+This section is rigorous about three states: **shipped** (running in production), **designed** (issue body or PR draft), **speculative** (idea in this synthesis or in Operator-vision notes). Andreas wants the truth, not optimism. ("Operator vision" is kept as the reference label for the originating video script; everywhere else the human is the **principal**.)
 
 ### What myelin ships today (shipped)
 
 - **L3 envelope schema** — `myelin/schemas/envelope.schema.json` with chain-of-stamps `signed_by[]` (post-#31 / PR #92), F-021 task fields (`requirements`, `distribution_mode`, `target_principal`, `deadline`, `sovereignty_required`), and economics block. `validateEnvelope()` is source of truth; schema mirrors.
 - **L3 sovereignty block** — five fields enforced as required + `additionalProperties: false` (`myelin/src/envelope.ts:88-113`). `parseSovereignty()` returns derived booleans (`canFederate`, `canReachFrontier`, `isLocalOnly`) without re-implementing rules.
-- **L3 namespace** — `myelin/specs/namespace.md` MY-101 closed. `deriveNatsSubject()`, `validateSubjectEnvelopeAlignment()`, tasks-domain Broadcast/Direct/Delegate/dead-letter grammar, DID-to-segment encoding with injectivity proof (`namespace.md:160-187`).
+- **L3 namespace** — `myelin/specs/namespace.md` MY-101 closed. `deriveNatsSubject()`, `validateSubjectEnvelopeAlignment()`, tasks-domain Broadcast/Direct/Delegate/dead-letter grammar (myelin's "Broadcast" mode is cortex's **Offer** — cortex maps `'broadcast'` → Offer at the boundary per CONTEXT.md), DID-to-segment encoding with injectivity proof (`namespace.md:160-187`).
 - **L4 identity** — `myelin/src/identity/`: `Principal`, `SignedBy` (Ed25519 + hub-stamp), `VerificationResult`. JCS (RFC 8785) canonicalization. `signEnvelope`, `verifyEnvelopeIdentity`, `requireVerifiedIdentity`. `PrincipalRegistry` (file-backed + in-memory). Chain-of-stamps is **shipped** (per `myelin/docs/envelope.md:177`).
 - **L2 transport** — `myelin/src/transport/`: `NATSTransport`, `InMemoryTransport`, factory + envelope wrapper.
-- **F-5 sovereignty engine** — `myelin/src/sovereignty/`: policy store, validators, audit log, transport. Specified for cross-layer enforcement; transport-level enforcement (sovereign refusal to route across operator boundary on classification mismatch) is **spec-pending** per myelin#11 (`myelin/docs/architecture.md:190-192`).
+- **F-5 sovereignty engine** — `myelin/src/sovereignty/`: policy store, validators, audit log, transport. Specified for cross-layer enforcement; transport-level enforcement (sovereign refusal to route across the principal boundary on classification mismatch) is **spec-pending** per myelin#11 (`myelin/docs/architecture.md:190-192`).
 
 ### What myelin is designing but not shipping (designed)
 
-- **L2 sovereignty enforcement** — myelin#11. The intended L2 enforcement (transport refusing to route an envelope across an operator boundary unless the sovereignty claim is satisfied) is spec-pending.
+- **L2 sovereignty enforcement** — myelin#11. The intended L2 enforcement (transport refusing to route an envelope across a principal boundary unless the sovereignty claim is satisfied) is spec-pending.
 - **L5 discovery** — myelin#9. No runtime capability registry.
 - **L6 composition** — myelin#10. Pipeline / fan-out / request-reply patterns exist in the wild (pilot review loop, signal flows) but are reinvented per use; no canonical specification.
 
 ### What cortex ships today (shipped)
 
-- **M2 — MyelinRuntime** with subscribe (subjects from `cortex.yaml.nats.subjects`) + publish (`local.${org}.${type}`) + `onEnvelope` fan-out + graceful drain on shutdown (`src/bus/myelin/runtime.ts`).
+- **M2 — MyelinRuntime** with subscribe (subjects from `cortex.yaml.nats.subjects`) + publish (`local.${principal}.${type}`; the in-code var is still `org`, pending cortex#448) + `onEnvelope` fan-out + graceful drain on shutdown (`src/bus/myelin/runtime.ts`).
 - **M3 — Four envelope constructors** (system, dispatch, github, cc). Each hardcodes `classification: "local"`. `data_residency` is parameterised via `dataResidency` on the source struct (defaulting to `"NZ"`); the four other sovereignty fields are hardcoded.
 - **M3 — Vendored envelope validator** at `src/bus/myelin/envelope-validator.ts`, pinned at myelin commit `96b14ea` (no chain-of-stamps array form, no F-021 task fields).
 - **M6 — Surface-router** with subject + payload filter matching, render isolation, AbortController-based timeout (`src/bus/surface-router.ts:291-319`).
-- **M6 — TrustResolver** with platform-ID-to-agent-ID map + operator-signature verifier (`src/common/agents/trust-resolver.ts:268-491`). NKey JWT verification chains to operator account signing pubkey.
+- **M6 — TrustResolver** with platform-ID-to-agent-ID map + operator-account-signature verifier (`src/common/agents/trust-resolver.ts:268-491`). NKey JWT verification chains to the NSC operator-account signing pubkey (NATS account root, not the human principal).
 - **M6 — Pass 1 / Pass 2 trust-mesh wiring** (cortex#105) — agent.trust list drives auto-populated allowlists at adapter startup.
 - **M7 — Discord + Mattermost adapters** with per-surface role-resolver. Same authorization policy duplicated per surface.
-- **M7 — Dashboard renderer** subscribes to `local.{org}.>` and projects to a ring buffer / D1; no sovereignty filter on the way in (`src/renderers/dashboard.ts:78-100`).
-- **CortexConfig schema** (`src/common/types/cortex-config.ts`) — `operator:`, `agents[]`, `renderers[]`, `nats:`. Operator has `dataResidency` (`OperatorSchema:99-111`). Agent has `runtime` block (claude-code / codex / pi-dev / custom + in-process / standalone) — the F-2 substrate seam.
+- **M7 — Dashboard renderer** subscribes to `local.{principal}.>` and projects to a ring buffer / D1; no sovereignty filter on the way in (`src/renderers/dashboard.ts:78-100`).
+- **CortexConfig schema** (`src/common/types/cortex-config.ts`) — `operator:` (the principal block; field name `operator` pending cortex#448 rename to `principal`), `agents[]`, `renderers[]`, `nats:`. The principal block has `dataResidency` (`OperatorSchema:99-111`, schema identifier pending cortex#448). Agent has `runtime` block (claude-code / codex / pi-dev / custom + in-process / standalone) — the F-2 substrate seam.
 
 ### What cortex is designing but not shipping (designed)
 
 - **cortex#91 SessionHarness** — `SessionHarness` interface with `dispatch(req): AsyncIterable<MyelinEnvelope>`. Two implementations: `ClaudeCodeHarness` (wraps existing cc-session.ts spawn logic), `BusPeerHarness` (publish-dispatch + subscribe-reply pattern sage already implements). Cortex#92 PR has Q5/Q6/Q7 awaiting Andreas confirmation.
 - **cortex#102 bot↔bot bus envelopes** — replaces Discord-platform-ID-based bot trust with NKey-signed envelopes verified via TrustResolver. Strategic; depends on cortex#91 substrate-harness landing.
-- **cortex#107 PolicyEngine** — `src/common/policy/`. `principals[]` + `roles[]` tables; per-event `PolicyEngine.check(principal, intent)`. Discord/Mattermost adapters thin to ~30 LOC. cortex.yaml flips ONCE at the end of this step (`policy:` block replaces per-adapter `roles[]`).
+- **cortex#107 PolicyEngine** — `src/common/policy/`. `principals[]` + `roles[]` tables; per-event `PolicyEngine.check(principal, intent)`. Discord/Mattermost adapters thin to ~30 LOC. cortex.yaml flips ONCE at the end of this step (`policy:` block replaces per-adapter `roles[]`). (Here `principal` is already the canonical term — a policy actor resolved from a `signed_by[]` stamp.)
 - **cortex#109 envelope-visibility consumption** — stops hardcoding `classification: "local"` at the four emit sites; surface-router honors `sovereignty.classification`; vendored envelope upgraded post-`96b14ea`; per-renderer visibility config; federation accept-rules + peer registry.
 
 ### What this synthesis adds (speculative)
 
 - **Multi-network bridge pattern.** One stack participates in two networks — what does it look like in cortex.yaml? (See §3.4.)
-- **Operator-private tiers within multi-stack** (Q7 below). Three stacks per operator, one of which is private to the other two stacks but federated to the network. Tiers within tiers.
-- **Cross-network audit trail ownership** (Q6 below). When a federated task crosses operator boundaries, the audit envelope chain has multiple operators in the `signed_by` chain — who's the source of truth?
+- **Principal-private tiers within multi-stack** (Q7 below). Three stacks per principal, one of which is private to the other two stacks but federated to the network. Tiers within tiers.
+- **Cross-network audit trail ownership** (Q6 below). When a federated task crosses principal boundaries, the audit envelope chain has multiple principals in the `signed_by` chain — who's the source of truth?
 
 ### Hardcoded today / placeholdered
 
@@ -176,25 +178,25 @@ This section is rigorous about three states: **shipped** (running in production)
 | `src/bus/system-events.ts:102` | `classification: "local"` literal | Same |
 | `src/bus/github-events.ts:89` | `classification: "local"` literal | Same |
 | `src/taps/cc-events/cc-events.ts:99` | `classification: "local"` literal | Same |
-| `src/bus/myelin/runtime.ts:236` | Subject hardcoded to `local.${org}.${envelope.type}` | publish-side cannot produce `federated.*` or `public.*` subjects |
+| `src/bus/myelin/runtime.ts:236` | Subject hardcoded to `local.${org}.${envelope.type}` (var `org` → `principal` pending cortex#448) | publish-side cannot produce `federated.*` or `public.*` subjects |
 | `src/bus/myelin/envelope-validator.ts:22` | `SCHEMA_SOURCE_COMMIT = "96b14ea..."` | Pre-chain-of-stamps, pre-F-021 task fields |
-| `src/renderers/dashboard.ts:78-100` | No sovereignty filter in projection pipeline | Federated/public envelopes would render on the operator dashboard regardless of `classification` |
-| `src/bus/surface-router.ts:259-270` | `adapterMatches` runs subject + payload filter, no sovereignty check | Same — no application-layer filter to enforce that a dashboard subscribing to `local.>` doesn't render an inbound `federated.peer-org.*` event delivered by a leaf-node misconfiguration |
-| `src/adapters/discord/role-resolver.ts` (and Mattermost equivalent) | Per-surface `roles[]` with `users[]` (platform IDs) | cortex#107 will move to top-level `policy.principals[]` with `home_operator` field; cortex.yaml stays in its current shape until that PR |
+| `src/renderers/dashboard.ts:78-100` | No sovereignty filter in projection pipeline | Federated/public envelopes would render on the principal's dashboard regardless of `classification` |
+| `src/bus/surface-router.ts:259-270` | `adapterMatches` runs subject + payload filter, no sovereignty check | Same — no application-layer filter to enforce that a dashboard subscribing to `local.>` doesn't render an inbound `federated.peer-principal.*` event delivered by a leaf-node misconfiguration |
+| `src/adapters/discord/role-resolver.ts` (and Mattermost equivalent) | Per-surface `roles[]` with `users[]` (platform IDs) | cortex#107 will move to top-level `policy.principals[]` with `home_operator` field (field name retained pending cortex#448); cortex.yaml stays in its current shape until that PR |
 
 ---
 
 ## §3 — The composition model
 
-### §3.1 Single stack — one operator, one cortex daemon, N agents
+### §3.1 Single stack — one principal, one cortex daemon, N agents
 
-The canonical single-operator stack as `cortex/docs/architecture.md:605-686` specifies it:
+The canonical single-principal stack as `cortex/docs/architecture.md:605-686` specifies it (the `operator:` config block is the principal block — field name pending cortex#448):
 
 ```
 ┌─────────────────────────────────────────────────────────────────┐
-│  operator: andreas                                              │
+│  principal: andreas                                             │
 │                                                                 │
-│  agents:                                                        │
+│  agents (each hosts one assistant):                            │
 │    - luna (Discord presence, persona, trust:[echo,holly,ivy])   │
 │    - echo (Discord presence, persona, trust:[luna,holly])       │
 │    - forge (Discord presence, persona)                          │
@@ -214,19 +216,19 @@ The canonical single-operator stack as `cortex/docs/architecture.md:605-686` spe
 ```
 
 What ships today:
-- Multiple agents in one cortex process — `cortex.yaml.agents[]` is canonical.
+- Multiple agents in one cortex process — `cortex.yaml.agents[]` is canonical. Each **agent** is a stack-local runtime that hosts exactly one **assistant** (luna, echo, forge, sage).
 - Each agent owns its `presence.<platform>` block (Discord, Mattermost). Trust is by logical agent id, never platform user id (`cortex-config.ts:268-291`, coupling rule §9.3).
 - TrustResolver provides the runtime platform-ID → agent-id map populated at adapter startup (`trust-resolver.ts:702-715`).
 - Renderers are non-agent-bound surfaces (dashboard, pagerduty, cli-tail, webhook-out) declared at top-level (`cortex-config.ts:321-403`).
 
 What sibling issues add at this scope:
 - cortex#91 — first-class `runtime.harness: bus-peer` for sage etc. (substrate-harness interface lets agents run out-of-process via NATS, not just in-process via Claude Code spawn).
-- cortex#102 — bot↔bot dispatch goes over the bus with NKey-signed envelopes; Discord becomes a presentation channel only.
-- cortex#107 — `roles[]` per-adapter collapses into top-level `policy:` block. Principal is what's resolved, not platform IDs.
+- cortex#102 — bot↔bot dispatch goes over the bus with NKey-signed envelopes; Discord becomes a presentation surface (dispatch source/sink) only.
+- cortex#107 — `roles[]` per-adapter collapses into top-level `policy:` block. The principal is what's resolved, not platform IDs.
 
-### §3.2 Multi-stack per operator — one operator, multiple cortex daemons
+### §3.2 Multi-stack per principal — one principal, multiple cortex daemons
 
-One operator can run multiple stacks side-by-side. The operator-facing distinction is concrete:
+One principal can run multiple stacks side-by-side. The principal-facing distinction is concrete:
 
 - **Research stack** — frontier-OK, frontier-only on some agents, no production data residency constraint
 - **Production stack** — local-only model class, EU residency, no frontier
@@ -237,31 +239,31 @@ How do they relate? Three plausible models:
 
 | Model | Subject namespacing | Pros | Cons |
 |---|---|---|---|
-| **A. Distinct operator IDs per stack** | `local.andreas-research.>` vs `local.andreas-production.>` | Mechanical separation; current cortex code supports it trivially | Loses the operator-level identity primitive; one human, three operator IDs |
-| **B. Same operator ID, distinct stack IDs as subdomain** | `local.andreas.research.>` vs `local.andreas.production.>` | Preserves single operator identity | Requires extending the namespace grammar — `{org}.{stack}.{domain}.{entity}.{action}` is one segment deeper than current spec |
-| **C. Same operator ID, same subject space, distinct agent ids** | `local.andreas.>` shared, agents like `luna-research`, `luna-production` | Minimal config change | No structural separation — anything published is visible to anything subscribed; sovereignty has to do all the work |
+| **A. Distinct principal IDs per stack** | `local.andreas-research.>` vs `local.andreas-production.>` | Mechanical separation; current cortex code supports it trivially | Loses the principal-level identity primitive; one human, three principal IDs |
+| **B. Same principal ID, distinct stack IDs as subdomain** | `local.andreas.research.>` vs `local.andreas.production.>` | Preserves single principal identity | Requires extending the namespace grammar — `{principal}.{stack}.{domain}.{entity}.{action}` is one segment deeper than the original spec |
+| **C. Same principal ID, same subject space, distinct agent ids** | `local.andreas.>` shared, agents like `luna-research`, `luna-production` | Minimal config change | No structural separation — anything published is visible to anything subscribed; sovereignty has to do all the work |
 
-Model A is the minimum-viable today. Model B is what the operator vision calls for (one operator, named-substack composition). Model C accepts that "stack" is a deployment unit but not a routing unit.
+Model A is the minimum-viable today. Model B is what the Operator vision calls for (one principal, named-substack composition). Model C accepts that "stack" is a deployment unit but not a routing unit.
 
-**Decision deferred to Q7** (see §5) — Andreas's call on whether `local.{org}.{stack}.>` deserves protocol status or stays a deployment convention.
+**Decision resolved by Q7** (see §5) — Andreas locked `local.{principal}.{stack}.>` as protocol status (Model B), making stack a first-class subject segment.
 
-### §3.3 Multi-operator network — peer-to-peer bus federation via NATS leaf-node
+### §3.3 Multi-principal network — peer-to-peer bus federation via NATS leaf-node
 
-Andreas's IP-routing analogy (`cortex#109` Background) maps onto NATS leaf-node federation as:
+Andreas's IP-routing analogy (`cortex#109` Background) maps onto NATS leaf-node federation as (federation is the default for any cross-principal traffic, per CONTEXT.md — `local.` never crosses the principal boundary):
 
 | OSI / IP concept | Cortex equivalent | Where it lives |
 |---|---|---|
-| AS / network prefix | `operator.id` + the `{org}` segment in subjects | `cortex.yaml.operator:` block |
+| AS / network prefix | the principal id + the `{principal}` segment in subjects | `cortex.yaml.operator:` block (principal block; field name pending cortex#448) |
 | Routing table | `policy.federated.peers[]` | NEW — proposed in cortex#109 |
-| BGP announce | `operator.<id>.identity` envelope signed by operator account NKey, broadcast on `public.operator.>` | NEW — proposed (out of scope for cortex#109) |
+| BGP announce | `<principal>.identity` envelope signed by the NSC operator-account NKey, published (Offer/announce) on `public.principal.>` | NEW — proposed (out of scope for cortex#109) |
 | IP packet header | NATS subject prefix + envelope `sovereignty.classification` | Existing — myelin namespace + envelope |
-| Router (forwarding) | Surface-router + NATS leaf-node federation | Half-wired (surface-router exists; leaf-node config is operator infra) |
-| Application gateway | Cortex daemon (one per operator stack) | Existing |
+| Router (forwarding) | Surface-router + NATS leaf-node federation | Half-wired (surface-router exists; leaf-node config is principal-side infra) |
+| Application gateway | Cortex daemon (one per principal's stack) | Existing |
 | Firewall (inbound boundary policy) | Surface-router accept-rules per peer | NEW — part of cortex#109 |
 
 ```
 ┌────────────────────────────┐                ┌─────────────────────────────┐
-│  operator: andreas         │                │  operator: jcfischer        │
+│  principal: andreas        │                │  principal: jcfischer       │
 │                            │                │                             │
 │  agents: luna, echo, sage  │                │  agents: ivy, holly         │
 │                            │                │                             │
@@ -281,18 +283,18 @@ Andreas's IP-routing analogy (`cortex#109` Background) maps onto NATS leaf-node 
 
 What this requires at each layer:
 
-- **M1 — leaf-node configuration.** Andreas's NATS server and JC's NATS server peer; their leaf-node configs whitelist each other and constrain bridged subjects to `federated.>` only. Operator-side infra; no cortex code.
+- **M1 — leaf-node configuration.** Andreas's NATS server and JC's NATS server peer; their leaf-node configs whitelist each other and constrain bridged subjects to `federated.>` only. Principal-side infra; no cortex code.
 - **M3 — sovereignty enforcement.** Outbound: cortex#109 unhardcodes `classification: "local"` so envelopes destined for `federated.jcfischer.*` carry `classification: "federated"`. Inbound: `validateSubjectEnvelopeAlignment()` rejects a `federated.*` subject with `local`-classified envelope at parse time.
-- **M4 — chain-of-stamps verification.** When Andreas's agent emits a federated task, the envelope `signed_by[0]` is Andreas's agent's NKey. When JC's agent picks it up and produces a result, JC's agent's NKey is appended as `signed_by[1]`. The chain proves the path; receivers verify against their own principal registries.
-- **M6 — peer registry + accept rules.** `policy.federated.peers[]` declares `{operator_id, operator_pubkey, accept_subjects, deny_subjects, max_hop}`. Surface-router consumes these to gate inbound federated envelopes by peer policy.
+- **M4 — chain-of-stamps verification.** When Andreas's agent emits a federated task, the envelope `signed_by[0]` is the andreas stack's signing NKey. When JC's agent picks it up and produces a result, JC's stack's NKey is appended as `signed_by[1]`. The chain proves the path; receivers verify against their own principal registries.
+- **M6 — peer registry + accept rules.** `policy.federated.peers[]` declares `{operator_id, operator_pubkey, accept_subjects, deny_subjects, max_hop}` (the `operator_id`/`operator_pubkey` field names are pending the cortex#448 rename to `principal_id`/`principal_pubkey`). Surface-router consumes these to gate inbound federated envelopes by peer policy.
 
-This is where cortex#107's PolicyEngine becomes load-bearing for multi-operator: each inbound federated envelope is a `Principal{ id: 'agent-X', home_operator: 'jcfischer' }`; the PolicyEngine resolves it via `policy.principals[]` (which now spans multiple home_operators) and applies the receiver's per-peer accept/deny rules.
+This is where cortex#107's PolicyEngine becomes load-bearing for multi-principal: each inbound federated envelope is a `Principal{ id: 'agent-X', home_operator: 'jcfischer' }` (the `home_operator` field name is retained pending cortex#448; semantically it is the home principal); the PolicyEngine resolves it via `policy.principals[]` (which now spans multiple home principals) and applies the receiver's per-peer accept/deny rules.
 
 ### §3.4 Multi-network — separate networks, not per-peer capability scoping (Q4 LOCKED-IN)
 
 **Q4 lock-in (2026-05-13 Andreas):** *Use separate networks rather than one stack bridging two networks with per-peer capability scoping. Each network is its own subject namespace + policy domain. A "bridge stack" simply participates in network A AND network B (two independent network memberships, two separate cortex.yaml peer-registry entries). Simpler than per-peer capability differentiation within one network.*
 
-A stack joins multiple networks simultaneously by maintaining multiple NATS leaf-node connections, each scoped to a different peer mesh. Each network is structurally independent — distinct subject namespace, distinct policy domain, distinct peer registry. Per the operator-vision script:
+A stack joins multiple networks simultaneously by maintaining multiple NATS leaf-node connections, each scoped to a different peer mesh. Each network is structurally independent — distinct subject namespace, distinct policy domain, distinct peer registry. Per the Operator-vision script:
 
 > "Some stacks bridge between networks — your stack participates in two different collaborations, publishing certain capabilities to one network and different capabilities to the other."
 
@@ -308,7 +310,7 @@ The locked-in answer collapses the previous "per-peer capability scoping" questi
                                                     │  (network A's peer registry)
                        ┌──────────────────┐         │
                        │  bridge stack    │─────────┘
-                       │  operator: andreas        │
+                       │  principal: andreas       │
                        │                  │
                        │  agents: luna, echo, sage │
                        │                  │─────────┐
@@ -323,14 +325,16 @@ The locked-in answer collapses the previous "per-peer capability scoping" questi
 
 What the lock-in changes from the prior framing:
 
-1. **Subjects per network.** Each network is its own namespace; `federated.{operator}.{stack}.>` belongs to one network membership. No per-peer subject filtering within a network is required.
+1. **Subjects per network.** Each network is its own namespace; `federated.{principal}.{stack}.>` belongs to one network membership. No per-peer subject filtering within a network is required.
 2. **Capability announcements per network.** Q2's stack-level capability schema (constrained `cortex.yaml`) is declared once per network membership, not per peer within a network. Bridge stacks declare two memberships, two capability sets.
 3. **Policy slice per network.** `policy.federated.networks[]` (preferred ergonomics, see Phase E plan) replaces `policy.federated.peers[]` as the top-level structure. Each network entry carries its own peer registry, accept rules, and `leaf_node` reference.
 
 A workable cortex.yaml strawman post-Q4 lock-in:
 
 ```yaml
-operator: { id: andreas }
+# `operator:`, `operator_id`, `operator_pubkey` keys below are the principal block /
+# principal id / principal pubkey — config-key renames tracked under cortex#448.
+operator: { id: andreas }     # the principal
 stack: { id: andreas/research, nkey_pub: SAA… }
 
 policy:
@@ -339,9 +343,9 @@ policy:
       - id: research-collab
         leaf_node: nats-leaf-research
         peers:
-          - operator_id: jcfischer
+          - operator_id: jcfischer        # peer principal id
             stack_id: jcfischer/sage-host
-            operator_pubkey: O_JC_…
+            operator_pubkey: O_JC_…        # peer principal pubkey
         accept_subjects: ["federated.research-collab.tasks.code-review.*"]
         announce_capabilities: ["code-review", "security-scan"]
         max_hop: 1
@@ -359,27 +363,27 @@ policy:
         max_hop: 0  # JV is fully gated — no further hops
 ```
 
-The `leaf_node` field references a named NATS connection (operator infra config) — this is where the structural separation between networks lives. **A bridge stack has multiple `NatsLink`s simultaneously open**, one per leaf-node. Cortex's current `MyelinRuntime` has a single link (`runtime.ts:142-169`); supporting multi-network requires either multiple runtimes per cortex process or extending the runtime to manage a link pool.
+The `leaf_node` field references a named NATS connection (principal-side infra config) — this is where the structural separation between networks lives. **A bridge stack has multiple `NatsLink`s simultaneously open**, one per leaf-node. Cortex's current `MyelinRuntime` has a single link (`runtime.ts:142-169`); supporting multi-network requires either multiple runtimes per cortex process or extending the runtime to manage a link pool.
 
 ### §3.5 Private / isolated / public mesh varieties
 
-From the operator-vision script: "Some stacks are private. No connections. ... Others join isolated private networks — four companies working on a joint venture ... And some stacks bridge between networks..."
+From the Operator-vision script: "Some stacks are private. No connections. ... Others join isolated private networks — four companies working on a joint venture ... And some stacks bridge between networks..."
 
 Mapping to concrete configurations:
 
-| Mesh variety | Operator example | NATS topology | cortex.yaml shape |
+| Mesh variety | Principal example | NATS topology | cortex.yaml shape |
 |---|---|---|---|
 | **Bank private** | Single bank, no federation at all | NATS server with no leaf-nodes; firewalled | `policy.federated.peers: []` — empty registry |
-| **JV isolated-private** | 4 companies, mesh between, no external | Each company's NATS server has leaf-nodes to the other 3; no public bridge | Each peer's `policy.federated.peers[]` lists the other 3 with bidirectional accept_subjects; the `{org}` segment becomes the JV's negotiated namespace |
+| **JV isolated-private** | 4 companies, mesh between, no external | Each company's NATS server has leaf-nodes to the other 3; no public bridge | Each peer's `policy.federated.peers[]` lists the other 3 with bidirectional accept_subjects; the `{principal}` segment becomes the JV's negotiated namespace |
 | **Bridge** | One stack participates in 2 distinct networks | 2 leaf-nodes per cortex process (see §3.4) | `policy.federated.peers[]` has 2 entries with distinct `leaf_node:` references |
-| **Public mesh** | "Come find me" capability marketplace | Each stack advertises capabilities on `public.operator.*.capability.>`; matching is by capability tag | `policy.public.announce_capabilities[]` (NEW — out of scope today) |
-| **Hybrid** | Operator has private agents + some federated agents | Some agents emit `local.>` only; others emit `federated.>` per task; the operator's policy decides per-agent | Per-agent `default_classification` could parameterise this (NEW) |
+| **Public mesh** | "Come find me" capability marketplace | Each stack advertises capabilities on `public.principal.*.capability.>`; matching is by capability tag | `policy.public.announce_capabilities[]` (NEW — out of scope today) |
+| **Hybrid** | Principal has private agents + some federated agents | Some agents emit `local.>` only; others emit `federated.>` per task; the principal's policy decides per-agent | Per-agent `default_classification` could parameterise this (NEW) |
 
 The **private mesh case (bank)** is the simplest: it's just §3.1 with explicit confirmation that no `federated.*` subjects ever cross leaf-nodes. The most important property is that this is mechanically enforced at M1 (leaf-node config), not at M6 (application policy) — so cortex.yaml never accidentally federates because no leaf-node exists.
 
 The **isolated-private mesh (JV)** is the interesting middle case. The 4 JV members need:
-- A negotiated `{org}` segment to name the JV (e.g. `acme-bigcorp-jv`).
-- Each member's operator key as a co-equal trust anchor in the JV's principal registry.
+- A negotiated `{principal}` segment to name the JV (e.g. `acme-bigcorp-jv`).
+- Each member's NSC operator-account key as a co-equal trust anchor in the JV's principal registry.
 - An off-bus negotiation channel for the leaf-node peering and capability declarations.
 
 The **public mesh** future case is out of scope today — it requires myelin#9 (L5 discovery) and a marketplace economics model neither of which are in flight.
@@ -390,13 +394,14 @@ Andreas surfaced an additional composition pattern in the 2026-05-13 Q1–Q7 loc
 
 > "One network could be a composition of capability, and it might be a delegation. Even so, I can see both networks where you're interacting with an orchestrator. It's like your router that will then delegate out to other networks and stacks to get work done. ... your main digital assistant that will then delegate around and coordinate on your behalf by leaning into these different networks and stacks depending on their capability."
 
-This is the **orchestrator-agent pattern** — a stack hosts an agent whose role is to delegate, not to do. The orchestrator is the operator's main digital assistant; it sees the network capability registry (Q2), routes inbound work to whichever network/stack has the matching capability, and threads results back via the chain-of-stamps audit trail (Q6).
+This is the **orchestrator-assistant pattern** — a stack hosts an agent whose role is to delegate, not to do; the assistant it hosts (e.g. luna) is the principal's main digital assistant. The orchestrator sees the network capability registry (Q2), dispatches inbound work (Delegate mode) to whichever network/stack has the matching capability, and threads results back via the chain-of-stamps audit trail (Q6).
 
 Mechanically:
 
 ```
                                    ┌────────────────────────────────┐
-                                   │  Orchestrator agent (luna)     │
+                                   │  Orchestrator agent (hosts     │
+                                   │  assistant luna)               │
                                    │  on stack: andreas/research    │
                                    │                                │
                                    │  - Reads capability registry   │
@@ -419,7 +424,7 @@ Building blocks (all of which exist or are scheduled in the IAW plan):
 | Building block | Source | Phase |
 |---|---|---|
 | Network capability registry | Q2 lock-in (cortex.yaml schema, aggregated cross-network) | Phase A (schema) + Phase D (network-side aggregation) |
-| Outbound federation envelope | cortex#109 §E + cortex#107 multi-operator dashboard | Phase D |
+| Outbound federation envelope | cortex#109 §E + cortex#107 multi-principal dashboard | Phase D |
 | Chain-of-stamps audit | Q6 lock-in (signed_by[] per envelope) | Phase B (consume) + Phase D (cross-network) |
 | Competing-consumer claim | Q5 lock-in (NATS queue groups, claim-first-wins) | Phase A foundation + Phase E multi-network |
 | Multi-network MyelinRuntime | §3.4 (one stack, N leaf-nodes) | Phase E |
@@ -427,7 +432,70 @@ Building blocks (all of which exist or are scheduled in the IAW plan):
 
 This is a **Phase E capability**, not Phase A. Phase A only needs to make the capability registry mechanically accessible; the orchestrator agent itself is application logic on top of the substrate (cortex#91) + chain-of-stamps (cortex#102) + per-network policy (Phase D peer registry). The pattern is what justifies the multi-network design over per-peer scoping (§3.4) — orchestration agents need clean network boundaries to reason about delegation.
 
-The orchestrator pattern is what gives operators the "main digital assistant that coordinates on your behalf" mental model — the same primitive that the Phase A substrate harness exposes per-agent now becomes a meta-capability across the operator's full federated graph.
+The orchestrator pattern is what gives principals the "main digital assistant that coordinates on your behalf" mental model — the same primitive that the Phase A substrate harness exposes per-agent now becomes a meta-capability across the principal's full federated graph.
+
+### §3.7 Config split — layering cortex.yaml by blast radius (foundation)
+
+Everything above assumes one config file per stack. Today that file — `~/.config/cortex/cortex.yaml` — is **~911 lines** and has quietly grown into the *whole-environment* config. It mixes, in one document:
+
+- **principal + stack identity** (`operator:` block / `stack:` block — names pending cortex#448),
+- the **capability catalog** (Q2's `capabilities:` schema),
+- a **~470-line policy block** (Q-locked `policy.principals[]` / `roles[]` / `policy.federated.networks[]`),
+- **agents + surface bindings** (each agent's `presence.<platform>` with its bot/app token + guild/team),
+- **system / substrate** knobs (`claude`, `execution`, `attachments`, `paths`, `nats`, `bus`),
+- and the **federation roster** (peer/network registry, Q3/Q4).
+
+These have wildly different **lifecycles and blast radii**. The `nats.subjects` patterns and the surface bindings are the most dangerous lines in the file — get a subject pattern wrong and you arm the **double-delivery landmine** (two subscriptions matching the same subject → every envelope rendered twice); get a surface binding wrong and a stack posts to the wrong guild. Yet they sit inches from routine edits like adding an aphorism capability or tweaking a role. A single fat file means a wrong edit anywhere risks a transport-level fault everywhere. This is exactly the coupling CONTEXT.md warns against — the transport knobs (M2) and the surface gateway bindings (M7) should not share an edit surface with M6 policy.
+
+**Proposal — split by blast radius into layered files composed at boot:**
+
+| File | Owns | Blast radius | Lifecycle |
+|---|---|---|---|
+| `system.yaml` | substrate: `claude` / `execution` / `attachments` / `paths` / `nats` / `bus` — **the dangerous transport knobs** | Whole stack: a wrong `nats.subjects` here is the double-delivery landmine | Rarely edited; changes are reviewed transport changes |
+| `network.yaml` | federation roster + hub leaf-remote (`policy.federated.networks[]`, peer registry, `leaf_node` references) | Cross-principal: a wrong peer pubkey breaks federation trust | Edited when joining/leaving a network |
+| `surfaces.yaml` | the shared **surface-gateway bindings** — bot/app token per platform + `{surface-instance → stack}` map (see §3.8) | Cross-stack: one wrong binding mis-routes a whole guild | Edited when a stack joins/leaves a surface instance |
+| `stacks/<name>.yaml` | per-deployment: stack identity, capabilities, `policy` (`principals` / `roles` / `access`), agents **without** surface token/guild | One stack only | Edited for routine per-stack work |
+
+The split is the structural expression of the layer model: `system.yaml` is M1/M2, `network.yaml` is M1/M4 federation, `surfaces.yaml` is M7 gateway, `stacks/<name>.yaml` is M6 policy + assistant/capability declaration. **Per-deployment differences stay per-stack** — which is correct: two stacks under one principal legitimately differ in capabilities, policy, and agents, and nothing forces them to share those.
+
+**Backwards-compatible multi-file composer.** A boot-time composer reads the layered files (with `stacks/<name>.yaml` selected by the running stack id) and merges them into the same in-memory `LoadedConfig` cortex builds today. A single monolithic `cortex.yaml` still works transitionally — the composer detects it and treats it as all-layers-in-one. **The composed result is byte-for-byte equivalent to today's `LoadedConfig`**, so no downstream code changes; this is a config-ingestion refactor, not a schema flip. It slots cleanly *before* the Phase C schema flip (it reorganises where keys live, it does not rename them) and gives the Phase C `policy:` flip a smaller, safer file to land in.
+
+### §3.8 Shared surface gateway — one assistant, many deployments
+
+CONTEXT.md states the principle directly: an assistant is *"the same assistant, different agent surfaces"*, and *"surfaces are sources/sinks, not the medium — the bus is the medium."* §3.8 is what that principle forces at the process level once a principal runs multiple stacks (§3.2) that all answer on the same Discord bot.
+
+**The hard platform constraint.** One Discord **bot** is one application, one token, one bot user. Discord allows exactly **one gateway connection per token** (`shardCount=1` for our scale), and that bot is a member of many guilds. So if each per-stack daemon opens its *own* gateway connection with the *same* bot token, the connections **collide** — Discord disconnects them in turn and the bot flaps (the same class of failure as the double-delivery landmine, but at the platform layer instead of the bus layer). Per-stack adapters with a shared token are structurally unsound. (Slack and Mattermost have the analogous one-socket-per-app-token constraint.)
+
+**Build — a shared surface-gateway process, one per platform per bot:**
+
+```
+            ┌──────────────────────────────────────────────┐
+            │  surface-gateway (discord)                    │
+            │  ONE gateway connection (one-per-token)       │
+            │  member of all bound guilds                   │
+            │  instance→stack resolver (guild → stack)      │
+            └───────────┬───────────────────────┬──────────┘
+              inbound    │                       │   outbound
+   guild msg → publish   │                       │   subscribe bound stacks'
+   tasks.@{assistant}.chat                       │   dispatch.task.* (lifecycle/verdict)
+                         ▼                       ▲
+        ┌────────────────────────────────────────────────────┐
+        │                      BUS (medium)                   │
+        └───────┬──────────────────┬──────────────────┬──────┘
+                ▼                  ▼                  ▼
+       stack: andreas/meta   stack: andreas/work  stack: andreas/halden
+       (surface-bus-only — no per-stack platform connection)
+```
+
+- **One connection.** The surface-gateway holds the single gateway connection for the bot, is a member of all bound instances, and routes `instance ↔ stack` over the bus.
+- **Inbound.** A guild message resolves to its target stack and is published as a canonical Direct/chat envelope on `local.{principal}.{stack}.tasks.@{assistant}.chat` (or `federated.…` when the message is peer-addressed — cross-principal traffic stays on `federated.` per CONTEXT.md). Exactly **one** inbound publish per platform message.
+- **Outbound.** The gateway subscribes to every bound stack's lifecycle/verdict envelopes (`dispatch.task.{started|completed|failed|aborted}`) and renders each to the right instance. **Response routing** extends from `{surface, channel, thread}` to add an `{instance}` field so the gateway knows *which* guild/workspace/team to deliver into.
+- **Surface-agnostic.** Only the **instance→stack resolver** is platform-specific (Discord guild / Slack workspace / Mattermost team); the bus stays platform-neutral. The same gateway shape drops onto any platform by swapping the resolver.
+- **Stacks become surface-bus-only.** Per-stack platform adapters retire — a stack no longer opens any Discord/Slack/Mattermost connection; it is a pure dispatch source/sink on the bus. This is what `surfaces.yaml` (§3.7) configures: the bot/app token lives once in the gateway, and the `{instance → stack}` map is the gateway's routing table.
+
+**This structurally eliminates double-posting.** With one connection and exactly one inbound publish per message, there is no second subscription to render a duplicate and no second socket to flap — the failure mode is designed out, not patched around.
+
+**Trade-off vs. separate-bot-per-stack.** The alternative is ready today with no build: give each stack its *own* Discord bot (its own token, its own application). That works immediately — distinct tokens never collide — at the cost of N bot users in the guild (one per stack), N sets of permissions to manage, and a fragmented presence ("which luna do I @ "). The shared surface gateway is the right long-term shape — one assistant, one bot identity, many backing stacks — but it is a real build (the gateway process + the resolver + the response-routing `{instance}` extension + retiring per-stack adapters). Separate-bot-per-stack is the pragmatic interim if a principal needs multi-stack on a shared platform *before* the gateway lands.
 
 ---
 
@@ -451,7 +519,7 @@ For each of cortex#91, #102, #107, #109: which layer it occupies, what it contri
 
 **Layer:** L3/L4 (envelope + identity). Bot identity moves from Discord-platform-ID gating (M7, surface-layer) to NKey-signed envelopes (L4, cryptographic).
 
-**Contribution to composition:** This is the issue that makes cross-operator trust work at all. Per the operator vision: "An agent on my stack and an agent on yours can both see the same task" — both agents need verifiable identity, and the trust anchor cannot be Discord (which is operator A's surface only; operator B doesn't see Discord IDs).
+**Contribution to composition:** This is the issue that makes cross-principal trust work at all. Per the Operator vision: "An agent on my stack and an agent on yours can both see the same task" — both agents need verifiable identity, and the trust anchor cannot be Discord (which is principal A's surface only; principal B doesn't see Discord IDs).
 
 The chain-of-stamps `signed_by[]` (shipped in myelin post-#31) is the carrier:
 - `signed_by[0]` = originating agent's NKey signature.
@@ -459,22 +527,22 @@ The chain-of-stamps `signed_by[]` (shipped in myelin post-#31) is the carrier:
 - Receivers verify each stamp against their principal registry (cortex#107's `policy.principals[]`).
 
 **Dependencies:**
-- *Depends on:* cortex#91 (BusPeerHarness is where `signed_by` verification happens on inbound dispatch) + myelin-shipped chain-of-stamps + cortex#76 TrustResolver (operator-signature verifier).
+- *Depends on:* cortex#91 (BusPeerHarness is where `signed_by` verification happens on inbound dispatch) + myelin-shipped chain-of-stamps + cortex#76 TrustResolver (operator-account-signature verifier).
 - *Depended on by:* cortex#109 phase E (federation accept-rules — peer agents identified by signed envelopes); cortex#107 PolicyEngine (principal resolution from `signed_by[].principal` field).
 
-**Open questions cortex#102 needs:** Q1 (how does a stack declare its OWN identity? — operator NKey vs operator.id vs both?). This is what makes the `home_operator` field in cortex#107's principal table meaningful.
+**Open questions cortex#102 needs:** Q1 (how does a stack declare its OWN identity? — NSC operator-account NKey vs principal id vs both?). This is what makes the `home_operator` field (the home-principal field; name pending cortex#448) in cortex#107's principal table meaningful.
 
 ### cortex#107 — Principal-based AAA at dispatch-handler
 
 **Layer:** M6 — application logic core. PolicyEngine is the single decision point for "what is this principal allowed to do?" — replacing per-surface duplication.
 
-**Contribution to composition:** This is the issue that flips cortex.yaml's auth model from per-adapter `roles[]` to top-level `policy:{ principals[], roles[] }`. The `home_operator` field on each principal is what makes multi-operator dashboards work (one cloud renderer can serve N operators because it slices events by `home_operator`).
+**Contribution to composition:** This is the issue that flips cortex.yaml's auth model from per-adapter `roles[]` to top-level `policy:{ principals[], roles[] }`. The `home_operator` field on each principal (field name pending cortex#448; it is the home-principal id) is what makes multi-principal dashboards work (one cloud renderer can serve N principals because it slices events by `home_operator`).
 
 cortex.yaml schema flips ONCE at the end of this step. Per cortex#107 §"Migration scope" steps A-G, the per-adapter `roles[]` go away in step D; `policy:` block is added in step C. This is the only schema flip in the whole roadmap — every other sibling issue is additive, not flipping.
 
 **Dependencies:**
 - *Depends on:* cortex#91 (`Principal` object passed to `SessionHarness.dispatch()`); cortex#109 §A+B (sovereignty consumption — PolicyEngine reads `envelope.sovereignty` as part of decision input).
-- *Depended on by:* cortex#107 §H (multi-operator cloud dashboard — the cloud renderer reuses the same PolicyEngine the local daemon uses); cortex#109 §E (federation accept-rules consume PolicyEngine for per-peer decisions).
+- *Depended on by:* cortex#107 §H (multi-principal cloud dashboard — the cloud renderer reuses the same PolicyEngine the local daemon uses); cortex#109 §E (federation accept-rules consume PolicyEngine for per-peer decisions).
 
 **Open questions cortex#107 needs:** Q5 (competing-consumer semantics — when a federated task arrives, who picks first? PolicyEngine decides on the basis of capability tags and queue-group semantics).
 
@@ -482,7 +550,7 @@ cortex.yaml schema flips ONCE at the end of this step. Per cortex#107 §"Migrati
 
 **Layer:** L3/L4 routing primitives. Three-tier `sovereignty.classification` consumption (M3) + NATS leaf-node federation (M1) + surface-router accept rules (M6).
 
-**Contribution to composition:** Without cortex#109, cortex literally cannot emit a `federated.*` or `public.*` envelope — the four emit sites hardcode `local`. This issue is the unblocker for multi-operator scenarios. It also wires the dashboard's visibility filter so an operator subscribing to `local.{org}.>` doesn't accidentally render an inbound federated envelope from a peer.
+**Contribution to composition:** Without cortex#109, cortex literally cannot emit a `federated.*` or `public.*` envelope — the four emit sites hardcode `local`. This issue is the unblocker for multi-principal scenarios. It also wires the dashboard's visibility filter so a principal subscribing to `local.{principal}.>` doesn't accidentally render an inbound federated envelope from a peer.
 
 cortex#109's own phasing:
 - A: Stop hardcoding `classification: "local"`.
@@ -540,7 +608,7 @@ Phases A+B can ship independently (before cortex#91 even lands) per cortex#109 �
                              ┌───────────────────────────────────┐
                              │ cortex#109 §E (federation accept- │
                              │ rules + peer registry) +          │
-                             │ cortex#107 §H (multi-operator     │
+                             │ cortex#107 §H (multi-principal    │
                              │ cloud dashboard)                  │
                              │ — Phase D federation              │
                              └────────────┬──────────────────────┘
@@ -557,21 +625,21 @@ Phases A+B can ship independently (before cortex#91 even lands) per cortex#109 �
 
 ## §5 — Seven design questions — all locked in 2026-05-13 (Andreas)
 
-All seven questions resolved by Andreas on 2026-05-13. The verbatim answers below are the operator-locked design; the prior architect recommendations have been replaced. Implementation now follows from these answers — see `docs/plan-internet-of-agentic-work.md`.
+All seven questions resolved by Andreas on 2026-05-13. The verbatim answers below are the principal-locked design (preserved verbatim — the quoted answer blocks retain Andreas's original wording, including "operator"); the prior architect recommendations have been replaced. Implementation now follows from these answers — see `docs/plan-internet-of-agentic-work.md`.
 
 ### Q1: How does a stack declare its OWN identity? [LOCKED-IN — 2026-05-13 Andreas]
 
 **Verbatim answer:** *Format `{operator_id}/{stack_id}` (slash-separated, like git refs). Examples: `andreas/research`, `andreas/production`, `jcfischer/sage-host`. NATS subject form: `local.{operator}.{stack}.>` and `federated.{operator}.{stack}.>`. Cryptographic chain: operator-account-NKey → stack-NKey → agent-NKeys. Uniqueness: operator-id is the authority root (one per operator, enforced by the network registry); sub-stacks unique within an operator's namespace. Default: `{operator_id}/default` if operator declares only one stack. Like email but without TLD baggage.*
 
-Implications captured into the synthesis:
+Implications captured into the synthesis (the verbatim answer's `{operator_id}` token is the **principal** id; the literal format string is kept as the locked decision, with the rename to `{principal_id}` tracked under cortex#448):
 
-- **Stack identity = `{operator_id}/{stack_id}`** — a single string with git-ref semantics. Replaces the prior "operator.id" / "operator NKey" pairing as the canonical surface identifier.
-- **NATS subject form grows a stack segment** — `local.{operator}.{stack}.{domain}.{entity}.{action}` and the `federated.{operator}.{stack}.>` counterpart. This is the Q7 lock-in materialised at the wire layer.
-- **Cryptographic chain is three-tier** — operator-account NKey signs stack NKey signs agent NKeys. The stack NKey becomes the per-envelope signing key on the outbound side; the operator-account NKey roots trust in the network registry (Q3).
-- **Uniqueness:** operator-id is unique network-wide (enforced by the cloud-side network registry, Q3); stack-id is unique within an operator namespace.
-- **Default convention:** an operator with one stack declares it as `{operator_id}/default`; no manual stack declaration needed.
+- **Stack identity = `{operator_id}/{stack_id}`** (i.e. `{principal}/{stack}`) — a single string with git-ref semantics. Replaces the prior "principal id" / NSC operator-account NKey pairing as the canonical surface identifier.
+- **NATS subject form grows a stack segment** — `local.{principal}.{stack}.{domain}.{entity}.{action}` and the `federated.{principal}.{stack}.>` counterpart. This is the Q7 lock-in materialised at the wire layer.
+- **Cryptographic chain is three-tier** — NSC operator-account NKey signs stack NKey signs agent NKeys. The stack NKey becomes the per-envelope signing key on the outbound side; the operator-account NKey roots trust in the network registry (Q3).
+- **Uniqueness:** the principal id is unique network-wide (enforced by the cloud-side network registry, Q3); stack-id is unique within a principal's namespace.
+- **Default convention:** a principal with one stack declares it as `{principal}/default`; no manual stack declaration needed.
 
-**Blocks:** cortex#102 (NKey identity carrier on the bus), cortex#107 §H (cloud dashboard `home_operator`/`home_stack` fields), the Phase A cortex.yaml `stack:` block addition.
+**Blocks:** cortex#102 (NKey identity carrier on the bus), cortex#107 §H (cloud dashboard `home_operator`/`home_stack` fields — names pending cortex#448), the Phase A cortex.yaml `stack:` block addition.
 
 ### Q2: How does a stack announce its CAPABILITIES to a network? [LOCKED-IN — 2026-05-13 Andreas]
 
@@ -581,7 +649,7 @@ Implications captured into the synthesis:
 
 - **Two-layer capability model:**
   - **Network capabilities** (top layer) = aggregated view across every agent in every stack in the network. Computed by the network's registry (Q3) from the union of member stacks' declared capabilities.
-  - **Stack capabilities** (operator layer) = declared in each operator's `cortex.yaml` under a `capabilities:` block. Per-agent annotations are first-class; the stack-level set is the union of its agents' annotations plus any stack-level extras.
+  - **Stack capabilities** (principal layer) = declared in each principal's `cortex.yaml` under a `capabilities:` block. Per-agent annotations are first-class; the stack-level set is the union of its agents' annotations plus any stack-level extras.
 - **Schema is constrained**, not free-text JSON. Required fields:
   - `id` — slug, network-stable (e.g. `code-review.typescript`, `literature-search.medline`).
   - `description` — short human-readable summary.
@@ -599,12 +667,12 @@ Implications captured into the synthesis:
 
 Implications captured into the synthesis:
 
-- **Centralised, declarative registry.** Operators edit their peer/network membership in `cortex.yaml` (or a sibling config file colocated with cortex.yaml). No NATS gossip path; the registry is config, not protocol traffic.
-- **Cloud-side network registry service** hosts the canonical pubkey directory across operators. Sits adjacent to the cloud dashboard (cortex#107 Step H) — same hosting boundary, same trust anchor. Operators read from it (to discover peers) and write to it (to publish their stack identity and capability surface). The "Internet" in *Internet of Agentic Work* is the registry plus the federated NATS mesh; the registry resolves operator-id ↔ pubkey across the network.
+- **Centralised, declarative registry.** Principals edit their peer/network membership in `cortex.yaml` (or a sibling config file colocated with cortex.yaml). No NATS gossip path; the registry is config, not protocol traffic.
+- **Cloud-side network registry service** hosts the canonical pubkey directory across principals. Sits adjacent to the cloud dashboard (cortex#107 Step H) — same hosting boundary, same trust anchor. Principals read from it (to discover peers) and write to it (to publish their stack identity and capability surface). The "Internet" in *Internet of Agentic Work* is the registry plus the federated NATS mesh; the registry resolves principal id ↔ pubkey across the network.
 - **No gossip via NATS.** The IP/BGP analogue was considered and rejected for v1 — the registry is a service, not a protocol. This keeps Phase D scoped to the federation primitive itself; gossip is a future evolution if scale demands it.
-- **Identity flow:** operator → cloud-side registry (publish operator NKey + stack identities + capability declaration) → other operators' cortex daemons read registry at startup + on schedule → local cortex.yaml peer entries reference the registry-discovered pubkeys by operator-id.
+- **Identity flow:** principal → cloud-side registry (publish NSC operator-account NKey + stack identities + capability declaration) → other principals' cortex daemons read registry at startup + on schedule → local cortex.yaml peer entries reference the registry-discovered pubkeys by principal id.
 
-**Blocks:** cortex#109 §E peer registry (now config-driven, not gossip-driven); cortex#107 §H (the cloud-side registry service is the natural home alongside the multi-operator dashboard). Phase D scope.
+**Blocks:** cortex#109 §E peer registry (now config-driven, not gossip-driven); cortex#107 §H (the cloud-side registry service is the natural home alongside the multi-principal dashboard). Phase D scope.
 
 ### Q4: Bridge-stack capability scoping — different capabilities per peer-network [LOCKED-IN — 2026-05-13 Andreas]
 
@@ -615,8 +683,8 @@ Implications captured into the synthesis (full schema in §3.4 above):
 - **Bridge stacks are stacks with multiple memberships**, not stacks with per-peer-scoped capabilities. Each network entry is independent; the stack participates in N networks by declaring N entries.
 - **`policy.federated.networks[]`** replaces the prior `policy.federated.peers[]` framing. Each network entry carries:
   - `id` — network slug.
-  - `leaf_node` — named NATS connection (operator infra config).
-  - `peers[]` — peer operator/stack list within this network.
+  - `leaf_node` — named NATS connection (principal-side infra config).
+  - `peers[]` — peer principal/stack list within this network.
   - `accept_subjects[]` / `deny_subjects[]` — per-network policy slice.
   - `announce_capabilities[]` — capability subset this network sees.
   - `max_hop` — per-network hop budget.
@@ -645,10 +713,10 @@ Implications captured into the synthesis:
 Implications captured into the synthesis:
 
 - **Chain-of-stamps IS the audit trail.** Each stack the envelope crosses adds its `signed_by[]` entry. Cryptographic provenance is the audit record — no separate audit subject, no centralised audit service.
-- **Stack identity** (Q1 — `{operator_id}/{stack_id}`) is what each stamp carries. Reading `signed_by[]` answers "this envelope passed through stacks A, B, C in that order."
-- **Unique envelope ID** combined with the chain provides full traceability across networks. Each operator can grep their local audit (their `signed_by[i]` entry) and reconstruct the cross-network path via stamp ordering.
-- **No central authority required** — each operator owns their slice of the audit (per Q3, the cloud-side registry holds identity, not transit traffic). Cross-operator forensics rebuild from the local audits combined.
-- **Operator sovereignty preserved.** No federated audit subject leaks across operator boundaries; no central service sees all traffic; each operator's view is bounded by what their stack actually handled.
+- **Stack identity** (Q1 — `{operator_id}/{stack_id}`, i.e. `{principal}/{stack}`) is what each stamp carries. Reading `signed_by[]` answers "this envelope passed through stacks A, B, C in that order."
+- **Unique envelope ID** combined with the chain provides full traceability across networks. Each principal can grep their local audit (their `signed_by[i]` entry) and reconstruct the cross-network path via stamp ordering.
+- **No central authority required** — each principal owns their slice of the audit (per Q3, the cloud-side registry holds identity, not transit traffic). Cross-principal forensics rebuild from the local audits combined.
+- **Principal sovereignty preserved.** No federated audit subject leaks across principal boundaries; no central service sees all traffic; each principal's view is bounded by what their stack actually handled.
 
 **Blocks:** Phase D (federation) — the audit story is what gets asked first in any compliance review. The Phase B chain-of-stamps consumption is the prerequisite that makes this audit pattern observable.
 
@@ -658,16 +726,16 @@ Implications captured into the synthesis:
 
 Implications captured into the synthesis:
 
-- **Stack is a first-class protocol primitive.** NATS subject grammar grows a stack segment: `local.{operator}.{stack}.{domain}.{entity}.{action}` for local, `federated.{operator}.{stack}.{domain}.{entity}.{action}` for federated. The 3-segment authority prefix replaces the 2-segment `{operator}.{domain}` form.
+- **Stack is a first-class protocol primitive.** NATS subject grammar grows a stack segment: `local.{principal}.{stack}.{domain}.{entity}.{action}` for local, `federated.{principal}.{stack}.{domain}.{entity}.{action}` for federated. The 3-segment authority prefix replaces the 2-segment `{principal}.{domain}` form.
 - **cortex.yaml `stack:` block.** New top-level config field:
   ```yaml
   stack:
     id: andreas/research          # matches Q1 format
-    nkey_pub: SAA…                # stack NKey, signed by operator account NKey
+    nkey_pub: SAA…                # stack NKey, signed by the NSC operator-account NKey
   ```
 - **Cortex daemon = stack host.** A running cortex process declares "I host stack X". The cortex.ts entrypoint registers the stack identity at boot and uses it for every outbound envelope's `signed_by[0]` entry.
-- **Multi-stack per operator** — Phase E design decision whether multiple stacks share a cortex daemon (lower process count, more complex isolation) or each stack runs its own daemon (cleaner isolation, more processes). Both wire-compatible.
-- **Backward compatibility:** if `cortex.yaml.stack` is not declared, default to `{operator_id}/default`. Existing deployments migrate without explicit operator action.
+- **Multi-stack per principal** — Phase E design decision whether multiple stacks share a cortex daemon (lower process count, more complex isolation) or each stack runs its own daemon (cleaner isolation, more processes). Both wire-compatible.
+- **Backward compatibility:** if `cortex.yaml.stack` is not declared, default to `{principal}/default`. Existing deployments migrate without explicit principal action.
 - **Myelin namespace coordination** — this changes the wire grammar; requires a myelin issue to update `specs/namespace.md`. File as Phase A blocker (or Phase A.5 if myelin needs lead time). Cortex's vendored envelope upgrade (cortex#109 §C, Phase A.2) is the natural ride-along moment.
 
 **Blocks:** Phase A (cortex.yaml `stack:` block); Phase A.5 (myelin namespace extension); Phase C (cortex.yaml schema flip is the last natural moment to absorb the stack-aware namespace without re-flipping).
@@ -681,8 +749,8 @@ Implications captured into the synthesis:
 | Q3 | Centralised cortex.yaml declaration + cloud-side network registry service alongside cortex#107 Step H dashboard; NOT NATS-gossiped | Phase D (peer registry + cloud registry service) |
 | Q4 | Separate networks, not per-peer-within-network scoping; bridge stack = multiple network memberships | Phase E (multi-link MyelinRuntime + `policy.federated.networks[]`) |
 | Q5 | NATS queue groups (claim-first-wins at bus layer); no reservation, no auction | Phase A (queue-group provisioning); Phase E (per-network queue groups) |
-| Q6 | Chain-of-stamps IS the audit; each stack stamps the envelope; operator-partitioned with cryptographic correlation | Phase B (chain-of-stamps consume); Phase D (cross-network audit observable) |
-| Q7 | Stack is first-class protocol primitive; namespace extends to `local.{operator}.{stack}.>` and `federated.{operator}.{stack}.>` | Phase A (cortex.yaml `stack:` block + myelin namespace extension) |
+| Q6 | Chain-of-stamps IS the audit; each stack stamps the envelope; principal-partitioned with cryptographic correlation | Phase B (chain-of-stamps consume); Phase D (cross-network audit observable) |
+| Q7 | Stack is first-class protocol primitive; namespace extends to `local.{principal}.{stack}.>` and `federated.{principal}.{stack}.>` | Phase A (cortex.yaml `stack:` block + myelin namespace extension) |
 
 ---
 
@@ -695,6 +763,8 @@ Five phases A–E. The cortex.yaml schema flips exactly ONCE — at the end of P
 **Scope:** cortex#91 substrate harness + cortex#109 §A+B (visibility consumption).
 
 These two are independent. cortex#91 lands the `SessionHarness` interface + `ClaudeCodeHarness` + `BusPeerHarness`; cortex#109 §A+B unhardcodes `classification: "local"` and adds surface-router visibility filtering.
+
+The **config split (§3.7)** is a third, independent foundation candidate for this phase — it is a backwards-compatible config-ingestion refactor (no schema flip) that shrinks the file the Phase C `policy:` flip has to land in and isolates the dangerous `nats`/surface bindings from routine edits. The **shared surface gateway (§3.8)** is a larger build that pairs with multi-stack-per-principal (§3.2); it can follow once §3.7's `surfaces.yaml` exists, with separate-bot-per-stack as the interim until then.
 
 **Estimated effort:** 2–3 weeks parallel. cortex#91 is ~1–2 weeks (per its own estimate). cortex#109 §A+B is ~1 week (4 emit-site changes + visibility filter + per-renderer config).
 
@@ -710,7 +780,7 @@ These two are independent. cortex#91 lands the `SessionHarness` interface + `Cla
 - Surface-router has a `sovereignty.classification` check in `adapterMatches()`.
 - Renderer config supports `visibility:` block (hide-residency / require-model-class / max-classification).
 
-**Does not require:** Phase B or any other phase. Phase A unblocks single-operator federation; multi-operator waits for Phase D.
+**Does not require:** Phase B or any other phase. Phase A unblocks single-principal federation; multi-principal waits for Phase D.
 
 ### Phase B — Identity (cortex#102 NKey-signed bot↔bot)
 
@@ -718,7 +788,7 @@ These two are independent. cortex#91 lands the `SessionHarness` interface + `Cla
 
 **Entry criteria:**
 - Phase A complete (BusPeerHarness exists as the integration point).
-- Q1 resolved (stack identity = operator NKey + operator.id pairing).
+- Q1 resolved (stack identity = NSC operator-account NKey + principal id pairing).
 
 **Exit criteria:**
 - BusPeerHarness verifies `signed_by[]` against TrustResolver.trustsByNKey() on every inbound dispatch.
@@ -748,22 +818,22 @@ These two are independent. cortex#91 lands the `SessionHarness` interface + `Cla
 
 **Estimated effort:** 2–3 weeks. The bulk of the change is the schema flip + migrate-config + adapter thinning. PolicyEngine implementation itself is ~1 week.
 
-**Critical insight:** This is the ONLY phase where the operator-facing config schema changes. Sequencing Phases A and B before Phase C means the flip happens once: the substrate harness work (Phase A) doesn't touch cortex.yaml's auth model; the NKey identity work (Phase B) extends `policy.principals[]` after the block exists. If Phase C were sequenced first, we'd flip the schema, then re-flip when Phase B adds NKey fields.
+**Critical insight:** This is the ONLY phase where the principal-facing config schema changes. Sequencing Phases A and B before Phase C means the flip happens once: the substrate harness work (Phase A) doesn't touch cortex.yaml's auth model; the NKey identity work (Phase B) extends `policy.principals[]` after the block exists. If Phase C were sequenced first, we'd flip the schema, then re-flip when Phase B adds NKey fields.
 
-### Phase D — Federation (multi-operator peer registry + accept rules)
+### Phase D — Federation (multi-principal peer registry + accept rules)
 
-**Scope:** cortex#109 §E (peer registry + accept-rules) + cortex#107 §H (multi-operator cloud dashboard).
+**Scope:** cortex#109 §E (peer registry + accept-rules) + cortex#107 §H (multi-principal cloud dashboard).
 
 **Entry criteria:**
-- Phase C complete (PolicyEngine exists; principals carry `home_operator`).
-- Q3 confirmed (operator-edited registry is the v1 posture).
+- Phase C complete (PolicyEngine exists; principals carry `home_operator` — field name pending cortex#448).
+- Q3 confirmed (principal-edited registry is the v1 posture).
 
 **Exit criteria:**
-- `policy.federated.peers[]` schema landed (`{ operator_id, operator_pubkey, accept_subjects, deny_subjects, max_hop }`).
+- `policy.federated.peers[]` schema landed (`{ operator_id, operator_pubkey, accept_subjects, deny_subjects, max_hop }` — `operator_id`/`operator_pubkey` are the peer principal id/pubkey, field names pending cortex#448).
 - Surface-router gates inbound `federated.*` envelopes by per-peer accept rules.
 - PolicyEngine extends to support per-peer policy slicing.
-- A second operator (jcfischer or test rig) successfully federates a task with the first operator's cortex; envelope chain is verifiable on both sides.
-- Cloud dashboard (the grove-api Worker today) extends to per-operator slicing using `home_operator` from `policy.principals[]`.
+- A second principal (jcfischer or test rig) successfully federates a task with the first principal's cortex; envelope chain is verifiable on both sides.
+- Cloud dashboard (the grove-api Worker today) extends to per-principal slicing using `home_operator` (field name pending cortex#448) from `policy.principals[]`.
 
 **Estimated effort:** 3–4 weeks. The peer registry schema is small; the cloud-dashboard multi-tenancy is the bulk.
 
@@ -780,10 +850,10 @@ These two are independent. cortex#91 lands the `SessionHarness` interface + `Cla
 - `MyelinRuntime` supports multiple NATS links concurrently (one per leaf-node).
 - `policy.federated.peers[].leaf_node` references a named NatsLink.
 - A test rig demonstrates a single cortex process participating in 2 distinct networks (separate leaf-nodes), publishing different capabilities to each.
-- Operator-vision script's "bridge stack" pattern is operable.
+- Operator-vision script's "bridge stack" pattern is operable (one stack, multiple principal-network memberships).
 - (Future, separate issue) Public mesh capability announcement scaffold — out of this phase's scope but possible after.
 
-**Estimated effort:** 4–6 weeks. This is the largest scope; multi-link support in MyelinRuntime + per-network policy slicing + operator infra coordination.
+**Estimated effort:** 4–6 weeks. This is the largest scope; multi-link support in MyelinRuntime + per-network policy slicing + principal-side infra coordination.
 
 ### Phase summary
 
@@ -803,9 +873,9 @@ Total roughly 12–18 weeks if sequenced; A+B+C is the foundation (~6 weeks) and
 
 ### What this doc does NOT address
 
-- **Operator UX for editing config.** cortex.yaml gets richer; operator-side dashboard support for editing `policy:` and `policy.federated.peers[]` is its own design (cortex#99 dashboard settings page).
-- **Runtime observability of cross-network traffic.** Distinct from sovereignty enforcement: how operators *see* the federation flow in real time. Signal-collector territory.
-- **Legal/compliance frameworks.** Data residency at the envelope level is necessary but not sufficient for GDPR / SOC2 / HIPAA. Each operator's compliance posture is theirs; this design enables the technical primitive.
+- **Principal UX for editing config.** cortex.yaml gets richer; principal-side dashboard support for editing `policy:` and `policy.federated.peers[]` is its own design (cortex#99 dashboard settings page).
+- **Runtime observability of cross-network traffic.** Distinct from sovereignty enforcement: how principals *see* the federation flow in real time. Signal-collector territory.
+- **Legal/compliance frameworks.** Data residency at the envelope level is necessary but not sufficient for GDPR / SOC2 / HIPAA. Each principal's compliance posture is theirs; this design enables the technical primitive.
 - **Pricing / economics for public mesh.** The myelin envelope has an `economics` block reserved for future marketplace integration; this design assumes it stays empty in v1.
 
 ### Risks of getting the layering wrong
@@ -813,7 +883,7 @@ Total roughly 12–18 weeks if sequenced; A+B+C is the foundation (~6 weeks) and
 - **Premature multi-network work without policy** = security surface. If Phase E lands before Phase C, every inbound federated envelope is accepted by anyone subscribing — no decision point. The PolicyEngine is the gate.
 - **Policy without substrate** = vendor lock at one harness. If Phase C lands before Phase A, the PolicyEngine bakes in Claude-Code-only assumptions (e.g. `roles[].disallowedTools` listing CC-specific tool names like `NotebookEdit`). The harness interface decouples this.
 - **Identity without substrate** = wire mismatch. If Phase B lands before Phase A, NKey verification has no inbound path (BusPeerHarness doesn't exist). cortex#102 is the strategic follow-up to cortex#91, not a replacement.
-- **Schema flip more than once.** The roadmap is designed so cortex.yaml flips ONCE (Phase C). If we re-flip later (e.g. to add a stack-aware namespace per Q7), every operator's `cortex.yaml` migration is two-step. Andreas wants one flip.
+- **Schema flip more than once.** The roadmap is designed so cortex.yaml flips ONCE (Phase C). If we re-flip later (e.g. to add a stack-aware namespace per Q7), every principal's `cortex.yaml` migration is two-step. Andreas wants one flip.
 
 ### Open coupling concerns
 
@@ -837,7 +907,7 @@ Total roughly 12–18 weeks if sequenced; A+B+C is the foundation (~6 weeks) and
 - `cortex/src/bus/surface-router.ts:124-160` — `subjectMatches` NATS-style pattern matcher
 - `cortex/src/bus/surface-router.ts:259-270` — `adapterMatches` (subject + payload filter; no sovereignty filter)
 - `cortex/src/bus/surface-router.ts:291-319` — `renderWithIsolation` (timeout + AbortController)
-- `cortex/src/common/agents/trust-resolver.ts:268-491` — operator-signature verification
+- `cortex/src/common/agents/trust-resolver.ts:268-491` — NSC operator-account-signature verification
 - `cortex/src/common/agents/trust-resolver.ts:702-715` — `trustsByPlatformId` (today's mechanism)
 - `cortex/src/common/types/cortex-config.ts:85-111` — `OperatorSchema` (id, dataResidency)
 - `cortex/src/common/types/cortex-config.ts:225-253` — `AgentRuntimeSchema` (substrate + capabilities)
@@ -888,8 +958,8 @@ Total roughly 12–18 weeks if sequenced; A+B+C is the foundation (~6 weeks) and
 
 ### Operator vision
 
-- "Internet of Agentic Work" video script (2026-05-13, in cortex#110 body) — the operator-facing mental model. Used as North Star; not replicated here. Three concepts mapped to issues in cortex#110's body table.
+- "Internet of Agentic Work" video script (2026-05-13, in cortex#110 body) — the principal-facing mental model (the script's own "Operator vision" framing is kept as a reference label). Used as North Star; not replicated here. Three concepts mapped to issues in cortex#110's body table.
 
 ---
 
-*Originating discussion: Andreas 2026-05-13 framing of multi-stack / multi-operator / multi-network routing as an OSI-perspective design problem; cortex#110 META issue + CodexResearcher report on cortex#109 confirming myelin already ships the routing primitives cortex needs. This synthesis closes the first acceptance step on cortex#110 — the deep current-state + OSI-layered analysis — and seeds the Phase A entry-criteria discussion.*
+*Originating discussion: Andreas 2026-05-13 framing of multi-stack / multi-principal / multi-network routing as an OSI-perspective design problem; cortex#110 META issue + CodexResearcher report on cortex#109 confirming myelin already ships the routing primitives cortex needs. This synthesis closes the first acceptance step on cortex#110 — the deep current-state + OSI-layered analysis — and seeds the Phase A entry-criteria discussion.*

--- a/docs/plan-internet-of-agentic-work.md
+++ b/docs/plan-internet-of-agentic-work.md
@@ -1,29 +1,31 @@
 # Plan — Internet of Agentic Work implementation
 
-**Status:** Working document. Single source of truth for the cortex#110 (META) work — the implementation of the Internet of Agentic Work composition model. Every PR cites a phase + checklist item from this doc. **For "what we're building and why" (architecture, OSI layering, composition model, operator vision), see the static design doc `docs/design-internet-of-agentic-work.md`.** This plan covers only the implementation sequencing: what ships in what phase, in what order, with what entry/exit criteria. When this doc and reality disagree, this doc wins (or is updated, never silently). When this doc and the design doc disagree on architecture, the design doc wins.
+> **Terminology aligned to CONTEXT.md** (the architectural source of truth, post operator→principal refactor). The human who owns and runs stacks is the **principal** (was "operator"); dispatch modes are **Offer / Direct / Delegate** (Offer was "broadcast"); a subject's travel limit is its **scope** (was "reach"); the dotted NATS routing string is a **subject** (was "topic"); the named being is an **assistant**, its stack-local runtime an **agent**, a spawned CC task a **sub-agent** (was overloaded "agent"). Preserved distinct concepts: the NSC/NATS **operator account** (operator NKey / operator JWT), the "Operator vision" reference label, and code identifiers / field names like `home_operator` / `operatorId` (tracked separately as cortex#448 — pending rename, left as-is here).
+
+**Status:** Working document. Single source of truth for the cortex#110 (META) work — the implementation of the Internet of Agentic Work composition model. Every PR cites a phase + checklist item from this doc. **For "what we're building and why" (architecture, OSI layering, composition model, Operator vision), see the static design doc `docs/design-internet-of-agentic-work.md`.** This plan covers only the implementation sequencing: what ships in what phase, in what order, with what entry/exit criteria. When this doc and reality disagree, this doc wins (or is updated, never silently). When this doc and the design doc disagree on architecture, the design doc wins.
 **Date opened:** 2026-05-13
 **Driver:** Andreas
-**Retires when:** Phase E closes (multi-network bridges + delegation patterns operable in production).
+**Retires when:** Phase E closes (multi-network bridges + delegation patterns operable in production), plus the two new epics under §13 (config split + shared surface gateway) land.
 
 **Related docs (load-bearing):**
 - **`docs/design-internet-of-agentic-work.md`** — the static architecture spec. What IAW IS. Reference this for any "how should this be structured" question; only reference *this* doc for implementation mechanics.
 - `docs/plan-cortex-migration.md` — the cortex spawn / migration plan from grove-v2. MIG-7 cutover is the moment cortex.yaml's schema flips for the first time; this plan's Phase C is the second (and last) schema flip.
-- `cortex#110` (META) — the operator-vision umbrella ("Internet of Agentic Work").
+- `cortex#110` (META) — the Operator-vision umbrella ("Internet of Agentic Work"). *("Operator vision" is the preserved North-Star reference label, not the human-actor sense.)*
 - `cortex#112` (this PR) — the synthesis design doc.
 - `cortex#91` — substrate harness (M6). Pre-existing sibling issue; consumed by Phase A.
 - `cortex#102` — bot↔bot via bus envelopes / NKey identity (L3/L4). Pre-existing sibling issue; Phase B.
-- `cortex#107` — principal-based AAA at dispatch-handler (M6). Pre-existing sibling issue; Phase C — includes Step H multi-operator cloud dashboard, consumed in Phase D.
+- `cortex#107` — principal-based AAA at dispatch-handler (M6). Pre-existing sibling issue; Phase C — includes Step H multi-principal cloud dashboard, consumed in Phase D.
 - `cortex#109` — envelope-visibility composition + subject-namespace routing (L3/L4). Pre-existing sibling issue; consumed in Phases A and D.
 - `~/Developer/myelin/specs/namespace.md` — myelin canonical namespace; Phase A extends to add a `{stack}` segment per Q7 lock-in.
 - `~/Developer/myelin/docs/envelope.md` — chain-of-stamps + sovereignty fields. Phase A consumes the post-`96b14ea` envelope; Phase B consumes `signed_by[]`.
-- `cortex/docs/architecture.md` §9 — agent + presence/renderer model (post-MIG-7 cortex.yaml shape; this plan extends it).
+- `cortex/docs/architecture.md` §9 — assistant + presence/renderer model (post-MIG-7 cortex.yaml shape; this plan extends it).
 - `~/Developer/compass/sops/dev-pipeline.md` + `worktree-discipline.md` + `pr-review.md` — standard dev SOPs.
 
 ---
 
 ## 1. Overview
 
-The Internet of Agentic Work is the composition model where stacks (`{operator_id}/{stack_id}`) join networks via NATS leaf-node federation; networks compose into the operator's federated graph; agents delegate across stacks and networks via the orchestrator pattern. Five phases sequenced A→E deliver this incrementally.
+The Internet of Agentic Work is the composition model where stacks (`{operator_id}/{stack_id}` — the slash-form id literal is tracked for rename under cortex#448; semantically the first segment is the **principal**) join networks via NATS leaf-node federation; networks compose into the principal's federated graph; assistants delegate across stacks and networks via the orchestrator pattern. Five phases sequenced A→E deliver this incrementally.
 
 ### 1.1 Phase ladder
 
@@ -33,14 +35,18 @@ The Internet of Agentic Work is the composition model where stacks (`{operator_i
 | **B** Identity | NKey-signed envelopes for bot↔bot (chain-of-stamps consumption) | 1–2 weeks | cortex#102 | No |
 | **C** Policy + schema flip | PolicyEngine at M6 + cortex.yaml flips ONCE (stack block, principal table, role table) | 2–3 weeks | cortex#107 | **Yes — the only one** |
 | **D** Federation | Peer registry + accept rules + network membership declaration + cloud-side network registry service | 3–4 weeks | cortex#107 (Step H) + cortex#109 (§E) | No (additive) |
+| **CFG** Config split (FOUNDATION) | Multi-file config composer + system.yaml extraction + surface bindings out of per-stack presence | 1–2 weeks | new sibling issue (§13) | No (additive; transitional single-file fallback) |
+| **GW** Shared surface gateway | One assistant, many deployments — gateway process + per-platform resolvers + per-stack adapter retirement | 3–4 weeks | new sibling issue (§13); depends on CFG | No (additive; `response_routing.instance` bump) |
 | **E** Multi-network bridges + delegation | A stack participating in N networks; cross-network delegation patterns | 4–6 weeks | new sibling issue (Phase E sub-issue, this plan) | No (additive) |
 
-Total: 12–18 weeks if strictly sequenced. Phases A and B are sequenceable; Phase C is the schema flip; Phase D depends on C; Phase E depends on D.
+Total: 12–18 weeks if strictly sequenced. Phases A and B are sequenceable; Phase C is the schema flip; Phase D depends on C; Phase E depends on D. The two new epics (§13) sit outside the A→E federation ladder: **CFG** (config split) is a low-risk foundation that should land before/with **GW** (shared surface gateway); GW builds on CFG's `surfaces.yaml`.
 
 ### 1.2 Locked-in design decisions (verbatim from §5 of the design doc, Andreas 2026-05-13)
 
+> These Q1–Q7 lock-ins are quoted verbatim and unchanged. Where they say "operator", note the vocabulary mapping: the human is the **principal** (subject segment `{principal}`); the cryptographic root named "operator-account-NKey" / "operator JWT" is the genuine **NSC/NATS operator account** and is preserved as-is. The `{operator_id}` id literal is tracked for rename under cortex#448.
+
 - **Q1 — Stack identity:** `{operator_id}/{stack_id}` slash-separated. NATS form `local.{operator}.{stack}.>` / `federated.{operator}.{stack}.>`. Cryptographic chain operator-account-NKey → stack-NKey → agent-NKeys. Operator-id is the network authority root.
-- **Q2 — Capabilities:** Two-part — network capabilities aggregated across all member stacks + operator-declared stack-level capabilities in cortex.yaml using a constrained schema (id, description, tags, provided_by, optional rate/cost).
+- **Q2 — Capabilities:** Two-part — network capabilities aggregated across all member stacks + principal-declared stack-level capabilities in cortex.yaml using a constrained schema (id, description, tags, provided_by, optional rate/cost).
 - **Q3 — Network registry:** Centralised; cortex.yaml + cloud-side network registry service alongside cortex#107 Step H dashboard. NOT NATS-gossiped.
 - **Q4 — Bridge-stack scoping:** Separate networks, not per-peer scoping. Bridge stack = multiple network memberships.
 - **Q5 — Competing-consumers:** NATS queue groups (claim-first-wins at bus layer); no reservation; no auction.
@@ -50,7 +56,7 @@ Total: 12–18 weeks if strictly sequenced. Phases A and B are sequenceable; Pha
 ### 1.3 Non-goals of this implementation plan
 
 - **Not a re-architecture.** Every Phase reuses existing M2–M6 cortex code (substrate harness, surface-router, trust resolver). New code is targeted.
-- **Not the operator-vision video script.** The video (cortex#110 body) is the "why"; this plan is the "how".
+- **Not the Operator-vision video script.** The video (cortex#110 body) is the "why"; this plan is the "how".
 - **Not myelin changes.** Phase A.5 (stack namespace extension) is filed AS a myelin issue but lands separately; cortex's vendored envelope rides along.
 - **Not the cloud dashboard refactor.** cortex#107 Step H is consumed in Phase D; this plan doesn't re-design it.
 - **Not the public mesh / capability marketplace.** Out of scope across all five phases; future evolution after Phase E if demand surfaces.
@@ -151,10 +157,10 @@ The `{operator_id}` and `{stack_id}` segments are embedded in NATS subjects afte
 - [x] cortex.yaml `capabilities:` block validates and is queryable from the substrate harness. — PR #146
 - [x] Vendored envelope past `96b14ea`; `signed_by[]` array surfaces structurally (no verification yet). — PR #128 (→ `4578ae1`), refreshed at PR #151 (→ `b69c877`)
 
-**Phase A does NOT require Phase B or later.** It unblocks single-stack federation; multi-operator waits for Phase D.
+**Phase A does NOT require Phase B or later.** It unblocks single-stack federation; multi-principal waits for Phase D.
 
 **Carry-over to Phase B (or future ops cycle):**
-- **cortex#138** — JetStream `TASKS` stream filter shape (`local.*.tasks.>` → `local.*.*.tasks.>`). Cortex publishes stack-aware subjects today (PR #151), but cortex has no in-tree TASKS-stream consumer to break; the filter cutover is an operator-side NATS-server action (cortex.yaml ships no stream config). Reframed as a forward gate that lands when cortex grows a TASKS-stream consumer in Phase B/C.
+- **cortex#138** — JetStream `TASKS` stream filter shape (`local.*.tasks.>` → `local.*.*.tasks.>`). Cortex publishes stack-aware subjects today (PR #151), but cortex has no in-tree TASKS-stream consumer to break; the filter cutover is a principal-side NATS-server action (cortex.yaml ships no stream config). Reframed as a forward gate that lands when cortex grows a TASKS-stream consumer in Phase B/C.
 - **cortex#139** — parallel-checkpoint proposal closed as moot. The myelin-lead-time risk it hedged against did not materialise: myelin#113 (the upstream namespace PR) merged 2026-05-13 at 16:01, three hours after cortex#139 was filed.
 
 ---
@@ -210,7 +216,7 @@ Carries over from A.1.3 — the class that should have shipped in Phase A.
 
 ### B.4 Tests
 
-- [ ] **B.4.1** Round-trip test: agent A (operator alpha) emits a dispatch; agent B (operator beta) verifies the signature; B's reply chain stamps both stacks.
+- [ ] **B.4.1** Round-trip test: agent A (principal alpha) emits a dispatch; agent B (principal beta) verifies the signature; B's reply chain stamps both stacks.
 - [ ] **B.4.2** Forged-signature test: a tampered envelope is rejected by BusPeerHarness.
 - [ ] **B.4.3** Cross-trust test: a stack not in the local trust registry is rejected.
 
@@ -254,13 +260,13 @@ Most of Phase C is paper until B.4 ships, but the paper can be drafted now:
 | Phase A tail follow-ups (#142, #143, #147, #148, #137, #136, #135, #150) | scattered small PRs | Yes |
 | cortex#97 observability envelopes | independent feature | Yes — feeds Phase C.4 |
 
-**Practical implication for a solo/small-team operator:** keep one Phase B PR in flight at a time (review cycle dominates), and use the wait windows to land Phase A tail PRs + draft Phase C design docs. Don't start Phase C implementation until B.4 is green — the principal model materially changes once `signed_by[].principal` is verifiable.
+**Practical implication for a solo/small-team principal:** keep one Phase B PR in flight at a time (review cycle dominates), and use the wait windows to land Phase A tail PRs + draft Phase C design docs. Don't start Phase C implementation until B.4 is green — the principal model materially changes once `signed_by[].principal` is verifiable.
 
 ---
 
 ## 4. Phase C — Policy + schema flip (PolicyEngine at M6)
 
-**Goal:** PolicyEngine is the single decision point for "what is this principal allowed to do?" — replacing per-surface duplication. cortex.yaml flips ONCE from per-adapter `roles[]` to top-level `policy:{ principals[], roles[] }`. The `stack:` block (Phase A) and the `capabilities:` block (Phase A) live alongside the new `policy:` block. **This is the only phase that flips the operator-facing config schema.**
+**Goal:** PolicyEngine is the single decision point for "what is this principal allowed to do?" — replacing per-surface duplication. cortex.yaml flips ONCE from per-adapter `roles[]` to top-level `policy:{ principals[], roles[] }`. The `stack:` block (Phase A) and the `capabilities:` block (Phase A) live alongside the new `policy:` block. **This is the only phase that flips the principal-facing config schema.**
 
 **Issue:** `cortex#? — IAW Phase C: Policy + schema flip`.
 
@@ -283,13 +289,13 @@ Most of Phase C is paper until B.4 ships, but the paper can be drafted now:
 
 ### C.2 cortex.yaml schema flip — C.2a DONE (cortex#219); C.2b/C.2c ratified, execution NEXT
 
-**Status as of 2026-05-16:** Design ratified in [PR #291](https://github.com/the-metafactory/cortex/pull/291). See [`docs/design-policy-cutover.md`](./design-policy-cutover.md) for the locked schema + 5-PR sequence and [`docs/iteration-policy-cutover.md`](./iteration-policy-cutover.md) for the operator-facing iteration checklist.
+**Status as of 2026-05-16:** Design ratified in [PR #291](https://github.com/the-metafactory/cortex/pull/291). See [`docs/design-policy-cutover.md`](./design-policy-cutover.md) for the locked schema + 5-PR sequence and [`docs/iteration-policy-cutover.md`](./iteration-policy-cutover.md) for the principal-facing iteration checklist.
 
 - [x] **C.2.1 (additive — C.2a)** Top-level `policy: { principals[], roles[] }` added; schema cross-refines uniqueness + role/trust referential integrity. Legacy per-adapter `roles[]` retained for backward compatibility. — cortex#219
 - [ ] **C.2.1.b (breaking — C.2b)** Per-adapter `roles[]` removed from `DiscordPresenceSchema` + `MattermostPresenceSchema` + `SlackPresenceSchema`; adapter role-resolver retired; v2.0.0 bump. — cortex#242 umbrella (split into 242a parallel-mode + 242b breaking removal per design §9).
 - [ ] **C.2.2** `policy.principals[]` schema extended — adds `platform_ids` (open record), `session_config: {default, dm?}`, multi-stack `(id, home_stack)` uniqueness scoping. Capability namespace adopted: `keyword.{chat,async,team}`, `tool.<name>`, `dispatch.<agent>`, `operator`, `<domain>.<entity>`. — cortex#243a (schema extension)
 - [ ] **C.2.3** Discord/Mattermost/Slack adapters call `PolicyEngine.check()` directly; role-resolver retired. Wired in parallel mode first (most-restrictive intersection), then exclusive at v2.0.0. — cortex#242a → cortex#242b
-- [ ] **C.2.4 (C.2c)** `migrate-config` CLI extension: lift legacy per-adapter `roles[]` into top-level `policy:`. Idempotent, with `--check` mode for the 242a operator pre-flight. Canonical tool inventory via cortex#243b. SOP + migration examples. — cortex#243c
+- [ ] **C.2.4 (C.2c)** `migrate-config` CLI extension: lift legacy per-adapter `roles[]` into top-level `policy:`. Idempotent, with `--check` mode for the 242a principal pre-flight. Canonical tool inventory via cortex#243b. SOP + migration examples. — cortex#243c
 
 ### C.3 Integration with substrate harness — DONE (cortex#220)
 
@@ -327,13 +333,13 @@ Phase C primary objective — *PolicyEngine as the single AAA decision point wit
 
 Pre-Phase-B caveat (Echo cortex#220 round 1): the dispatch-listener policy gate authorises on an unverified `signed_by[0].principal` claim until cortex#114 (Phase B verification) wires the verifier into the envelope-validator. The gate is `CORTEX_POLICY_REQUIRE_UNVERIFIED_ACK=1` opt-in until that closes.
 
-**Critical insight (from design doc §6):** This is the ONLY phase where the operator-facing config schema changes. Sequencing Phases A and B before Phase C means the flip happens once. Q7 lock-in is absorbed here — the stack-aware namespace already lands at Phase A as a structurally additive `stack:` block; Phase C's `policy.principals[]` carries `home_operator` + `home_stack` so the principal table is stack-aware from the moment the flip happens.
+**Critical insight (from design doc §6):** This is the ONLY phase where the principal-facing config schema changes. Sequencing Phases A and B before Phase C means the flip happens once. Q7 lock-in is absorbed here — the stack-aware namespace already lands at Phase A as a structurally additive `stack:` block; Phase C's `policy.principals[]` carries `home_operator` + `home_stack` (field names tracked for rename under cortex#448) so the principal table is stack-aware from the moment the flip happens.
 
 ---
 
-## 5. Phase D — Federation (multi-operator + cloud-side registry)
+## 5. Phase D — Federation (multi-principal + cloud-side registry)
 
-**Goal:** Multi-operator federation operable. `policy.federated.peers[]` (within `policy.federated.networks[]` per Q4 lock-in) declares peer operators + their pubkeys. Surface-router gates inbound `federated.*` envelopes by per-peer policy. Cloud-side network registry service hosts the canonical pubkey directory (per Q3 lock-in). cortex#107 Step H multi-operator dashboard consumes it.
+**Goal:** Multi-principal federation operable. `policy.federated.peers[]` (within `policy.federated.networks[]` per Q4 lock-in) declares peer principals + their pubkeys. Surface-router gates inbound `federated.*` envelopes by per-peer policy. Cloud-side network registry service hosts the canonical pubkey directory (per Q3 lock-in). cortex#107 Step H multi-principal dashboard consumes it.
 
 **Issue:** `cortex#? — IAW Phase D: Federation`.
 
@@ -341,7 +347,7 @@ Pre-Phase-B caveat (Echo cortex#220 round 1): the dispatch-listener policy gate 
 
 **Entry criteria:**
 
-- Phase C complete (PolicyEngine exists; principals carry `home_operator` + `home_stack`).
+- Phase C complete (PolicyEngine exists; principals carry `home_operator` + `home_stack` — field names tracked for rename under cortex#448).
 - Q3 lock-in confirmed (centralised registry, NOT gossip) — DONE 2026-05-13.
 
 ### D.1 `policy.federated.networks[]` schema
@@ -379,24 +385,24 @@ Pre-Phase-B caveat (Echo cortex#220 round 1): the dispatch-listener policy gate 
 ### D.4 Cloud-side network registry service
 
 - [x] **D.4.1** New service alongside `grove-api` (renamed to `cortex-api` post-MIG-7); hosted at `network.meta-factory.ai` or similar. Hono REST API. — `src/services/network-registry/` (this PR).
-- [x] **D.4.2** Endpoints:
-  - `POST /operators/{operator_id}/register` — operator publishes their operator NKey + stack identities + capability declaration (signed assertion).
-  - `GET /operators/{operator_id}` — peers query operator's current pubkey + stack list.
+- [x] **D.4.2** Endpoints (route literals `/operators/{operator_id}` carry the API path; tracked for rename under cortex#448):
+  - `POST /operators/{operator_id}/register` — the principal publishes their operator-account NKey + stack identities + capability declaration (signed assertion).
+  - `GET /operators/{operator_id}` — peers query the principal's current pubkey + stack list.
   - `GET /networks/{network_id}/roster` — query who's in this network.
   - `GET /capabilities?query=...` — capability search across networks.
-- [ ] **D.4.3** Cortex consults the registry at startup + on schedule to refresh peer pubkeys; in-memory cache invalidated on operator-publish events. — consumer side (cortex-side `RegistryClient`) is a separate follow-up; this PR ships the producer surface.
+- [ ] **D.4.3** Cortex consults the registry at startup + on schedule to refresh peer pubkeys; in-memory cache invalidated on principal-publish events. — consumer side (cortex-side `RegistryClient`) is a separate follow-up; this PR ships the producer surface.
 - [x] **D.4.4** Registry signs assertions; cortex verifies before trusting. — registry-side signing landed; cortex-side verification lands with D.4.3 consumer.
 
-### D.5 Cloud dashboard multi-operator slicing (cortex#107 Step H)
+### D.5 Cloud dashboard multi-principal slicing (cortex#107 Step H)
 
-- [ ] **D.5.1** The existing dashboard subscribes to `local.{operator}.{stack}.>`; the cloud variant subscribes to `federated.>` cross-operator (within accept-listed networks).
-- [ ] **D.5.2** Per-operator slicing keyed off `principal.home_operator` for filtering dashboard cards.
+- [ ] **D.5.1** The existing dashboard subscribes to `local.{operator}.{stack}.>` (subject literal); the cloud variant subscribes to `federated.>` cross-principal (within accept-listed networks).
+- [ ] **D.5.2** Per-principal slicing keyed off `principal.home_operator` (field name tracked for rename under cortex#448) for filtering dashboard cards.
 - [ ] **D.5.3** UI surfaces sovereignty + classification on every card (G-1110 work).
 
-### D.6 Tests + cross-operator integration
+### D.6 Tests + cross-principal integration
 
-- [ ] **D.6.1** Two-operator integration test: operator alpha emits `federated.research-collab.tasks.code-review.typescript`; operator beta picks it up via queue-group; beta's stack signs the reply; alpha verifies the chain. Both operators' audits show their respective stamps.
-- [ ] **D.6.2** Registry test: operator alpha registers; operator beta queries; beta's cortex refreshes its peer pubkey cache.
+- [ ] **D.6.1** Two-principal integration test: principal alpha emits `federated.research-collab.tasks.code-review.typescript`; principal beta picks it up via queue-group; beta's stack signs the reply; alpha verifies the chain. Both principals' audits show their respective stamps.
+- [ ] **D.6.2** Registry test: principal alpha registers; principal beta queries; beta's cortex refreshes its peer pubkey cache.
 - [ ] **D.6.3** Deny-list test: an attempted inbound envelope on a `deny_subjects` pattern is rejected with the correct reason.
 
 ### Phase D acceptance criteria
@@ -404,8 +410,8 @@ Pre-Phase-B caveat (Echo cortex#220 round 1): the dispatch-listener policy gate 
 - `policy.federated.networks[]` schema landed.
 - Surface-router gates inbound `federated.*` envelopes by per-peer accept rules.
 - PolicyEngine supports per-network slicing.
-- A second operator (jcfischer or test rig) successfully federates a task; envelope chain verifiable on both sides.
-- Cloud dashboard slices per operator using `home_operator`.
+- A second principal (jcfischer or test rig) successfully federates a task; envelope chain verifiable on both sides.
+- Cloud dashboard slices per principal using `home_operator` (field name tracked for rename under cortex#448).
 - Cloud-side network registry service deployed and integrated.
 
 ---
@@ -439,10 +445,10 @@ Pre-Phase-B caveat (Echo cortex#220 round 1): the dispatch-listener policy gate 
 
 ### E.3 Delegation pattern primitives (§3.6)
 
-- [ ] **E.3.1** Orchestrator agent reference implementation: a persona/runtime that reads the network capability registry, picks a target network/stack for an inbound task, emits a `federated.{network}.tasks.{capability}` envelope.
+- [ ] **E.3.1** Orchestrator agent reference implementation: an assistant + its hosting agent runtime that reads the network capability registry, picks a target network/stack for an inbound task, emits a `federated.{network}.tasks.{capability}` envelope.
 - [ ] **E.3.2** Reply correlation: the orchestrator waits for the chain-of-stamps reply via the per-link queue group; binds reply to the original inbound request via envelope ID.
 - [ ] **E.3.3** Failure handling: if no peer in the target network claims within timeout, fall back to a sibling network or emit `dispatch.task.failed`.
-- [ ] **E.3.4** Test rig: orchestrator agent on operator alpha delegates a TypeScript code-review task to operator beta's `code-review.typescript` capability; receives reply; threads through to original sender.
+- [ ] **E.3.4** Test rig: orchestrator agent on principal alpha delegates a TypeScript code-review task to principal beta's `code-review.typescript` capability; receives reply; threads through to original sender.
 
 ### E.4 Mesh variety scaffolding (private / isolated / public)
 
@@ -461,7 +467,7 @@ Pre-Phase-B caveat (Echo cortex#220 round 1): the dispatch-listener policy gate 
 - `MyelinRuntime` supports multiple NATS links concurrently (one per leaf-node).
 - `policy.federated.networks[].leaf_node` references a named NatsLink.
 - A test rig demonstrates a single cortex process participating in 2 distinct networks (separate leaf-nodes), publishing different capabilities to each.
-- Operator-vision script's "bridge stack" pattern operable.
+- Operator-vision script's "bridge stack" pattern operable. *(Operator vision = the reference label for the cortex#110 North-Star narrative; preserved, not the human-actor sense.)*
 - Orchestrator agent reference implementation delegates across networks via chain-of-stamps.
 - Mesh varieties documented; private + isolated-private operable; public deferred.
 
@@ -476,8 +482,10 @@ Each phase has one tracking issue in `the-metafactory/cortex`, child of cortex#1
 - `cortex#? — IAW Phase A: Foundation — substrate harness + visibility consumption`
 - `cortex#? — IAW Phase B: Identity — NKey-signed bot↔bot`
 - `cortex#? — IAW Phase C: Policy + schema flip — PolicyEngine at M6`
-- `cortex#? — IAW Phase D: Federation — multi-operator peer registry + cloud registry service`
+- `cortex#? — IAW Phase D: Federation — multi-principal peer registry + cloud registry service`
 - `cortex#? — IAW Phase E: Multi-network bridges + delegation`
+- `cortex#? — IAW Config split (CFG) — multi-file config composer + system.yaml + surfaces.yaml` *(new, §13; under cortex#110)*
+- `cortex#? — IAW Shared surface gateway (GW) — one assistant, many deployments` *(new, §13; under cortex#110)*
 
 Issue numbers filed and tracked in §8 cross-references below.
 
@@ -498,7 +506,7 @@ Each PR runs through the standard pilot-review-loop skill with Echo as primary r
 - Every new file has at least one test.
 - Type-check (`bunx tsc --noEmit`) is green before PR open.
 - New protocol semantics (envelope shape, subject grammar, signature flow) have integration tests at the bus boundary.
-- Cross-operator scenarios (Phase D+) have at minimum a two-stack integration test in a local test rig.
+- Cross-principal scenarios (Phase D+) have at minimum a two-stack integration test in a local test rig.
 
 ---
 
@@ -506,17 +514,19 @@ Each PR runs through the standard pilot-review-loop skill with Echo as primary r
 
 ### 8.1 Issues + PRs
 
-- **cortex#110** — META (operator-facing Internet of Agentic Work umbrella).
+- **cortex#110** — META (principal-facing Internet of Agentic Work umbrella).
 - **cortex#112** — design synthesis doc PR (this PR's sibling).
 - **cortex#91** — substrate harness (consumed in Phase A; SessionHarness interface).
 - **cortex#102** — bot↔bot via bus envelopes (consumed in Phase B; chain-of-stamps verification).
-- **cortex#107** — principal-based AAA (consumed in Phase C; PolicyEngine + cortex.yaml flip + Step H multi-operator dashboard in Phase D).
+- **cortex#107** — principal-based AAA (consumed in Phase C; PolicyEngine + cortex.yaml flip + Step H multi-principal dashboard in Phase D).
 - **cortex#109** — envelope-visibility composition (consumed in Phase A §A.2/§A.3/§A.4 + Phase D §D.1/§D.2).
 - **cortex#113** — IAW Phase A: Foundation (I-101).
 - **cortex#114** — IAW Phase B: Identity (I-102).
 - **cortex#115** — IAW Phase C: Policy + schema flip (I-103).
 - **cortex#116** — IAW Phase D: Federation (I-104).
 - **cortex#117** — IAW Phase E: Multi-network bridges + delegation (I-105).
+- **cortex#? — IAW CFG: Config split (I-106)** — new epic, §13.1; child of cortex#110. FOUNDATION; lands before/with GW.
+- **cortex#? — IAW GW: Shared surface gateway (I-107)** — new epic, §13.2; child of cortex#110. Depends on CFG.c (`surfaces.yaml`).
 
 ### 8.2 Blueprint
 
@@ -526,6 +536,8 @@ Each PR runs through the standard pilot-review-loop skill with Echo as primary r
 - **I-103** — IAW Phase C: Policy + schema flip.
 - **I-104** — IAW Phase D: Federation.
 - **I-105** — IAW Phase E: Multi-network bridges + delegation.
+- **I-106** — IAW CFG: Config split (FOUNDATION; §13.1).
+- **I-107** — IAW GW: Shared surface gateway (depends on I-106 CFG.c; §13.2).
 
 See `blueprint.yaml` for the dependency graph; `blueprint ready` indicates which phase is unblocked at any given time.
 
@@ -545,7 +557,7 @@ This section is the daily-driver scratchpad as Phase A implementation proceeds �
 ### 9.1 Phase A entry-criteria open items
 
 - **Myelin namespace extension lead time.** Phase A.5 needs a myelin issue + PR to land before cortex can fully consume the stack-aware namespace. If myelin is in flight on something else, cortex may need to ship A.1–A.4 first and circle back to A.5. Acceptable but flagged.
-- **Backward compatibility for existing deployments.** Default `{operator_id}/default` works in theory; need to verify the default-derivation produces identical subjects to today (currently `local.andreas.>` → should become `local.andreas.default.>` after Phase A.5 lands, with rewrite invisible to operators). Test rig.
+- **Backward compatibility for existing deployments.** Default `{operator_id}/default` works in theory; need to verify the default-derivation produces identical subjects to today (currently `local.andreas.>` → should become `local.andreas.default.>` after Phase A.5 lands, with rewrite invisible to principals). Test rig.
 
 ### 9.2 Phase B reconcile with cortex#92
 
@@ -553,22 +565,22 @@ This section is the daily-driver scratchpad as Phase A implementation proceeds �
 
 ### 9.3 Phase C schema-flip surface area
 
-- **`migrate-config` CLI changes.** cortex.yaml grew a `stack:` block in Phase A and a `capabilities:` block in Phase A; Phase C flips `roles[]` to `policy:`. The CLI needs to handle a multi-stage migration: an operator might be at Phase A schema (stack + capabilities, no policy) or Phase C schema (full flipped). Lean: idempotent re-runs — running migrate-config on already-flipped config is a no-op.
+- **`migrate-config` CLI changes.** cortex.yaml grew a `stack:` block in Phase A and a `capabilities:` block in Phase A; Phase C flips `roles[]` to `policy:`. The CLI needs to handle a multi-stage migration: a principal might be at Phase A schema (stack + capabilities, no policy) or Phase C schema (full flipped). Lean: idempotent re-runs — running migrate-config on already-flipped config is a no-op.
 - **Audit-envelope subject form.** Phase C emits `system.access.{allowed,denied}` on the stack-aware subject (`local.{operator}.{stack}.system.access.*`). Verify renderer subscriptions still match (renderer's `subjects:` pattern needs to include the new stack segment).
 
 ### 9.4 Phase D registry service ownership
 
-- **Cloud-side network registry — single service or per-network?** Recommendation: single global service (similar to DNS root + zone delegation) — operators register globally; networks are membership lists computed by the registry. Per-network instances could federate but adds complexity. Lean: single global registry alongside the cloud dashboard service; revisit if multi-region or compliance demands surface.
-- **Signed assertion format.** Registry assertions need to be verifiable independently of the registry's availability (operator A queries registry, registry returns operator B's pubkey signed by operator B's NKey + countersigned by registry). Use JCS canonicalisation for signature input; reuse the chain-of-stamps signing infrastructure from Phase B where possible.
+- **Cloud-side network registry — single service or per-network?** Recommendation: single global service (similar to DNS root + zone delegation) — principals register globally; networks are membership lists computed by the registry. Per-network instances could federate but adds complexity. Lean: single global registry alongside the cloud dashboard service; revisit if multi-region or compliance demands surface.
+- **Signed assertion format.** Registry assertions need to be verifiable independently of the registry's availability (principal A queries registry, registry returns principal B's pubkey signed by principal B's operator-account NKey + countersigned by registry). Use JCS canonicalisation for signature input; reuse the chain-of-stamps signing infrastructure from Phase B where possible.
 
 ### 9.5 Phase E multi-network MyelinRuntime refactor
 
-- **Single daemon vs. per-stack daemon.** Q7's "Phase E design decision" — does one cortex daemon host multiple stacks, or does each stack get its own daemon? Tradeoff: single daemon has lower process count + cross-stack visibility but more complex isolation; per-stack daemon has cleaner blast-radius but more process overhead + cross-stack IPC. Lean: single-daemon for v1 (operator typically has one or two stacks), per-stack daemon as a future option if isolation guarantees become load-bearing.
+- **Single daemon vs. per-stack daemon.** Q7's "Phase E design decision" — does one cortex daemon host multiple stacks, or does each stack get its own daemon? Tradeoff: single daemon has lower process count + cross-stack visibility but more complex isolation; per-stack daemon has cleaner blast-radius but more process overhead + cross-stack IPC. Lean: single-daemon for v1 (a principal typically has one or two stacks), per-stack daemon as a future option if isolation guarantees become load-bearing.
 - **Subject namespace within a multi-stack daemon.** If one daemon hosts `andreas/research` + `andreas/production`, do their subjects share a process-wide NatsLink (publish-side namespaced by stack segment) or separate links? Lean: shared link with subject-segment isolation (saves NATS connections); rejected if test rig finds cross-stack subject leakage.
 
 ### 9.6 Orchestrator agent pattern (§3.6) design follow-ons
 
-- **Capability matching algorithm.** Orchestrator reads network capability registry; how does it pick between two networks that both offer `code-review.typescript`? Options: (a) operator-declared preference list; (b) cost-aware (Q2 optional `cost` field); (c) load-aware (queue depth as proxy). Lean: (a) for v1 (deterministic), (b)/(c) future.
+- **Capability matching algorithm.** Orchestrator reads network capability registry; how does it pick between two networks that both offer `code-review.typescript`? Options: (a) principal-declared preference list; (b) cost-aware (Q2 optional `cost` field); (c) load-aware (queue depth as proxy). Lean: (a) for v1 (deterministic), (b)/(c) future.
 - **Reply correlation latency.** Chain-of-stamps reply over federation has more latency than in-process. Orchestrator needs configurable timeout per delegation; default ~30s? Open.
 
 ### 9.7 Inconsistencies surfaced during this plan write-up
@@ -592,14 +604,14 @@ The IAW implementation is complete when all of:
 - [ ] Phases A through E all closed (sub-issues + blueprint entries marked `done`).
 - [ ] At least one bridge stack operable in production — single cortex daemon participating in 2 networks concurrently, with cross-network traffic verified via chain-of-stamps audits on both sides.
 - [ ] Orchestrator agent reference implementation operable — delegates a task across networks, receives reply, threads results to original requester with full audit trail.
-- [ ] cortex.yaml schema has flipped exactly ONCE (at Phase C). Operator-edit history shows one schema migration, not multiple.
-- [ ] Cloud-side network registry service deployed at `network.meta-factory.ai` (or equivalent) — operators register their stacks, peers query the registry, signature chain verified.
-- [ ] Mesh varieties documented and at least one example of each operable: private (single stack, no federation), federated (≥2 operators), isolated-private (JV, multi-peer single-network), bridge (one stack in N networks).
+- [ ] cortex.yaml schema has flipped exactly ONCE (at Phase C). Principal-edit history shows one schema migration, not multiple.
+- [ ] Cloud-side network registry service deployed at `network.meta-factory.ai` (or equivalent) — principals register their stacks, peers query the registry, signature chain verified.
+- [ ] Mesh varieties documented and at least one example of each operable: private (single stack, no federation), federated (≥2 principals), isolated-private (JV, multi-peer single-network), bridge (one stack in N networks).
 - [ ] Substrate harness landed — at least 2 distinct harness implementations (`ClaudeCodeHarness` + `BusPeerHarness`) operate behind the same interface.
 - [ ] Chain-of-stamps `signed_by[]` verified on every inbound federated dispatch; forged/tampered envelopes provably rejected.
 - [ ] PolicyEngine at M6 is the single AAA decision point; Discord + Mattermost adapters at ~30 LOC each (translate event → Principal; no role-resolver in adapter).
-- [ ] All audit traffic remains operator-partitioned per Q6 lock-in; no central audit service exists; chain-of-stamps provides cross-operator correlation.
-- [ ] cortex#110 META closes; the operator-facing video story is operable in production.
+- [ ] All audit traffic remains principal-partitioned per Q6 lock-in; no central audit service exists; chain-of-stamps provides cross-principal correlation.
+- [ ] cortex#110 META closes; the Operator-vision video story is operable in production.
 
 ---
 
@@ -634,11 +646,11 @@ Per `compass/sops/versioning.md`:
 
 - Phase A bump: `v1.X.0` (minor — additive features: substrate harness, visibility, stack identity).
 - Phase B bump: `v1.X+1.0` (minor — additive: chain-of-stamps verification).
-- Phase C bump: `v2.0.0` (MAJOR — cortex.yaml schema flip is a breaking change for operators).
+- Phase C bump: `v2.0.0` (MAJOR — cortex.yaml schema flip is a breaking change for principals).
 - Phase D bump: `v2.X.0` (minor — additive: federation primitives).
 - Phase E bump: `v2.X+1.0` (minor — additive: multi-network + delegation).
 
-Phase C is the one major version bump in the IAW work. Operators get a one-shot `migrate-config` CLI to flip from `v1.X` to `v2.0`.
+Phase C is the one major version bump in the IAW work. Principals get a one-shot `migrate-config` CLI to flip from `v1.X` to `v2.0`.
 
 ### 11.4 Retrospective
 
@@ -682,8 +694,8 @@ Per `compass/sops/retrospective-and-process-mining.md`, after each phase merges:
 - `cortex/src/bus/github-events.ts:89` — `classification: "local"` hardcoded (Phase A.3).
 - `cortex/src/taps/cc-events/cc-events.ts:99` — `classification: "local"` hardcoded (Phase A.3).
 - `cortex/src/bus/surface-router.ts:259-270` — `adapterMatches` (Phase A.4 adds visibility filter; Phase D adds peer accept gating).
-- `cortex/src/common/agents/trust-resolver.ts:268-491` — operator-signature verification (Phase B extends with `trustsByNKey`).
-- `cortex/src/common/types/cortex-config.ts:85-111` — `OperatorSchema` (Phase A.5 adds `stack:` block).
+- `cortex/src/common/agents/trust-resolver.ts:268-491` — principal-signature verification (Phase B extends with `trustsByNKey`). *(Code symbol still named for "operator"; rename tracked under cortex#448.)*
+- `cortex/src/common/types/cortex-config.ts:85-111` — `OperatorSchema` (code type name; rename tracked under cortex#448; Phase A.5 adds `stack:` block).
 - `cortex/src/common/types/cortex-config.ts:447-491` — `NatsConfigSchema` (Phase A.5 ties stack NKey to existing credsAuthenticator).
 
 ### 12.5 Compass SOPs
@@ -696,8 +708,115 @@ Per `compass/sops/retrospective-and-process-mining.md`, after each phase merges:
 
 ### 12.6 Operator vision
 
-- "Internet of Agentic Work" video script (2026-05-13, in cortex#110 body) — the operator-facing mental model. Used as North Star; not replicated here.
+*("Operator vision" is the preserved North-Star reference label for the cortex#110 narrative — not the human-actor sense; the human is the **principal**.)*
+
+- "Internet of Agentic Work" video script (2026-05-13, in cortex#110 body) — the principal-facing mental model. Used as North Star; not replicated here.
 
 ---
 
-*Originating discussion: Andreas's 2026-05-13 verbatim lock-ins on Q1–Q7 + the "delegation pattern" framing (§3.6 new addition). This plan converts those decisions into a five-phase implementation roadmap with checkbox-driven task lists, mirroring the shape of `plan-cortex-migration.md`. Sequenced to flip the operator-facing schema exactly once (Phase C), with the stack-aware namespace landing structurally additively in Phase A and absorbed into the principal model at Phase C.*
+## 13. New epics — config split + shared surface gateway
+
+Two epics added under the cortex#110 META umbrella, alongside the A→E federation ladder. They are **not** federation phases; they are surface/config foundations the federation work and day-to-day multi-deployment operation both lean on. They follow the same §7 sub-issue + PR conventions (one sub-issue = one PR-sized slice; PR title `feat(cortex): I-NNN.X — {scope} (IAW {CFG|GW}.Y)`; pilot-loop with Echo as primary reviewer; test discipline per §7.4).
+
+**Sequencing:** **CFG (config split) is the foundation and lands first** — it is the lowest-risk slice and directly de-risks the double-message problem by isolating the `nats.subjects` landmine and pulling per-platform surface bindings out of per-stack config. **GW (shared surface gateway) builds on CFG** — specifically on the `surfaces.yaml` file CFG introduces. CFG should land before or alongside the gateway; GW.a depends on CFG.c.
+
+Neither epic flips the principal-facing schema in a breaking way: CFG ships a transitional single-file fallback so existing single-file `cortex.yaml` deployments keep loading unchanged, and `LoadedConfig` (the in-memory shape the rest of cortex consumes) is unchanged across CFG. GW is additive plus one envelope field bump (`response_routing.instance`).
+
+### 13.1 EPIC CFG — Config split (FOUNDATION)
+
+**Goal:** Decompose the monolithic single-file `cortex.yaml` into a composed multi-file layout (`system/`, `network/`, `surfaces/`, `stacks/*`) without changing `LoadedConfig` or any consumer. Isolating `system.yaml` (and the `nats.subjects` block in particular) removes the largest footgun behind the double-message problem, and moving surface bindings into `surfaces.yaml` is the precondition for the shared surface gateway.
+
+**Issue:** `cortex#? — IAW CFG: Config split (multi-file composer + system.yaml + surfaces.yaml)` (child of cortex#110).
+
+**Estimated effort:** 1–2 weeks.
+
+**Entry criteria:**
+- No federation-phase dependency: CFG can land in parallel with Phase A/B.
+- Current single-file `cortex.yaml` schema is the baseline; CFG preserves it as the transitional fallback.
+
+#### CFG.a Multi-file config composer + transitional single-file fallback
+
+- [ ] **CFG.a.1** Config loader composes a `LoadedConfig` from a directory layout (`system/`, `network/`, `surfaces/`, `stacks/*`) — deep-merge with documented precedence; `LoadedConfig` shape is **unchanged** (consumers untouched).
+- [ ] **CFG.a.2** Transitional single-file fallback: if the directory layout is absent, load the existing single-file `cortex.yaml` and produce the identical `LoadedConfig`. No principal-facing break.
+- [ ] **CFG.a.3** Composition is deterministic and idempotent; a documented file-not-found / both-present resolution order (directory layout wins; single-file fallback only when no layout present).
+- [ ] **CFG.a.4** Tests: directory layout composes to the same `LoadedConfig` as the equivalent single file (round-trip identity); single-file fallback path produces an identical `LoadedConfig`; precedence/merge-order tests.
+
+#### CFG.b Extract `system.yaml` (isolate the `nats.subjects` landmine)
+
+- [ ] **CFG.b.1** Move the cross-cutting machine config — `claude`, `execution`, `attachments`, `paths`, `nats`, `bus` — into `system/system.yaml`. The composer folds it into the same `LoadedConfig` slots.
+- [ ] **CFG.b.2** `nats.subjects` is isolated in `system.yaml` as its own clearly-commented block — the single place subject overrides live, removing the per-stack duplication that drives the double-message problem.
+- [ ] **CFG.b.3** Tests: a config with `system.yaml` present resolves `nats`/`bus`/`paths` identically to the pre-split single file; a malformed `nats.subjects` block fails loudly at load (not silently double-publishing).
+
+#### CFG.c Move surface bindings out of per-stack `agents.presence` into `surfaces.yaml`
+
+- [ ] **CFG.c.1** Surface bindings (Discord/Mattermost/Slack `token`, `guild`, channel/instance bindings) move from each stack's `agents.presence` block into a top-level `surfaces.yaml`.
+- [ ] **CFG.c.2** `LoadedConfig` still exposes the same effective presence/binding view to today's consumers (per-stack adapters keep working); the move is a source-layout change, not a runtime-shape change.
+- [ ] **CFG.c.3** `surfaces.yaml` is the file the shared surface gateway (GW) consumes — this slice is the GW precondition.
+- [ ] **CFG.c.4** Tests: per-stack adapter behaviour unchanged after the move (same tokens/guilds resolved); `surfaces.yaml` schema validates required binding fields.
+
+#### EPIC CFG acceptance criteria
+
+- [ ] Multi-file directory layout composes to a `LoadedConfig` identical to the equivalent single file.
+- [ ] Single-file `cortex.yaml` still loads via the transitional fallback (no principal-facing break).
+- [ ] `system.yaml` exists with `claude`/`execution`/`attachments`/`paths`/`nats`/`bus`; `nats.subjects` isolated in one place.
+- [ ] Surface bindings live in `surfaces.yaml`, out of per-stack `agents.presence`; per-stack adapters unchanged at runtime.
+- [ ] `LoadedConfig` shape unchanged across the whole epic; no consumer edits required.
+
+### 13.2 EPIC GW — Shared surface gateway (one assistant, many deployments)
+
+**Goal:** One platform connection per bot, shared across many stack deployments. A gateway process holds the single Discord/Slack/Mattermost connection, routes inbound platform messages to the right stack (`{instance → stack}`), and renders each stack's outbound lifecycle envelopes back to the right platform instance. Stacks stop owning per-platform adapters and become **surface-bus-only**: they publish/consume dispatch + lifecycle envelopes on the bus, and the gateway is the sole dispatch source/sink at the platform edge.
+
+**Issue:** `cortex#? — IAW GW: Shared surface gateway (one assistant, many deployments)` (child of cortex#110).
+
+**Estimated effort:** 3–4 weeks.
+
+**Entry criteria:**
+- **CFG.c complete** — `surfaces.yaml` is the binding source the gateway reads. GW.a depends on it.
+- Phase A complete (sovereignty-typed envelopes; surface-router visibility filter) — the gateway is a dispatch source/sink and signs/consumes per the same envelope contract.
+
+#### GW.a Gateway process: one connection per bot + `{instance → stack}` routing + inbound publish per stack
+
+- [ ] **GW.a.1** Gateway process holds exactly **one** platform connection per bot identity (reads bindings from `surfaces.yaml`), replacing N per-stack connections.
+- [ ] **GW.a.2** `{instance → stack}` routing table: an inbound platform message on a bound instance resolves to its target stack; the gateway publishes a canonical inbound dispatch envelope **on that stack's subject namespace** (per the stack's `{principal}.{stack}` segment), as a dispatch source.
+- [ ] **GW.a.3** Inbound attribution: gateway populates `originator.identity` (resolved DID) + `originator.attribution = "adapter-resolved"`; the target stack signs via `runtime.publish` (stack is the cryptographic signer — per CONTEXT.md own-stack trust model).
+- [ ] **GW.a.4** Tests: two stacks bound to one bot; a message on instance A publishes on stack A's subject only (no cross-stack leak); inbound envelope carries the right `originator` + scope.
+
+#### GW.b Outbound render to the right instance + `response_routing.instance` schema bump
+
+- [ ] **GW.b.1** Gateway is a dispatch sink: subscribes to `dispatch.task.{started|completed|failed|aborted}` across bound stacks and renders each to the correct platform instance.
+- [ ] **GW.b.2** `response_routing` payload field gains an `instance` member so a stack's outbound lifecycle envelope tells the gateway which platform instance to deliver to (echoed by the runner onto every lifecycle envelope per CONTEXT.md response-routing model). Additive schema bump; backward-compatible default for un-bumped envelopes.
+- [ ] **GW.b.3** Tests: a `completed` envelope with `response_routing.instance = A` renders to instance A only; missing `instance` falls back to the legacy single-instance behaviour.
+
+#### GW.c Discord resolver
+
+- [ ] **GW.c.1** Discord resolver: maps the gateway's single Discord connection ↔ `{instance → stack}` bindings from `surfaces.yaml`; resolves channel/thread/guild to a stack and back.
+- [ ] **GW.c.2** Tests: inbound Discord message resolves to the right stack; outbound renders to the right channel/thread.
+
+#### GW.d Slack resolver
+
+- [ ] **GW.d.1** Slack resolver: same contract as the Discord resolver against Slack's connection model (workspace/channel ↔ stack).
+- [ ] **GW.d.2** Tests: inbound/outbound round-trip for two stacks bound to one Slack app.
+
+#### GW.e Mattermost resolver
+
+- [ ] **GW.e.1** Mattermost resolver: same contract against Mattermost's connection model (team/channel ↔ stack).
+- [ ] **GW.e.2** Tests: inbound/outbound round-trip for two stacks bound to one Mattermost bot.
+
+#### GW.f Retire per-stack Discord adapters (stacks go surface-bus-only)
+
+- [ ] **GW.f.1** Remove the per-stack Discord adapter wiring; stacks no longer open platform connections — they publish/consume dispatch + lifecycle envelopes on the bus only.
+- [ ] **GW.f.2** The gateway is the sole platform-edge dispatch source/sink; surface-router visibility filtering (Phase A.4) still applies at the gateway.
+- [ ] **GW.f.3** Tests: a stack with no per-platform adapter still completes an end-to-end chat dispatch through the gateway; regression test that no stack opens a direct platform connection.
+
+#### EPIC GW acceptance criteria
+
+- [ ] One platform connection per bot, shared across ≥2 stacks (Discord proven; Slack + Mattermost resolvers landed).
+- [ ] Inbound platform messages route to the correct stack via `{instance → stack}`; no cross-stack leakage.
+- [ ] Outbound lifecycle envelopes render to the correct instance via `response_routing.instance`.
+- [ ] Per-stack Discord adapters retired; stacks are surface-bus-only.
+- [ ] Gateway honours Phase A.4 visibility filtering and the CONTEXT.md dispatch-source/sink + own-stack-trust model.
+- [ ] Built on CFG `surfaces.yaml`; no regression to single-file fallback deployments.
+
+---
+
+*Originating discussion: Andreas's 2026-05-13 verbatim lock-ins on Q1–Q7 + the "delegation pattern" framing (§3.6 new addition). This plan converts those decisions into a five-phase implementation roadmap with checkbox-driven task lists, mirroring the shape of `plan-cortex-migration.md`. Sequenced to flip the principal-facing schema exactly once (Phase C), with the stack-aware namespace landing structurally additively in Phase A and absorbed into the principal model at Phase C.*


### PR DESCRIPTION
Aligns the **Internet of Agentic Work** design + plan (cortex#110) to **CONTEXT.md** (the architectural source of truth, post operator→principal refactor), and adds the two pieces tonight surfaced that the locked 2026-05-13 design didn't cover.

## Vocabulary
operator→principal (~137), broadcast→Offer, reach→scope, topic→subject; agent → assistant/agent/sub-agent. **Preserved:** NSC/NATS account "operator", the "Operator vision" label, code field names (home_operator/operatorId — pending #448), and the **Q1–Q7 verbatim locked blocks** (only surrounding prose migrated).

## New (additive — Q1–Q7 + structure unchanged)
- **design §3.7 / plan EPIC CFG — Config split**: layer the ~911-line `cortex.yaml` by blast radius (system / network / surfaces / stacks), backwards-compatible composer; isolates the `nats.subjects` double-delivery landmine from routine edits.
- **design §3.8 / plan EPIC GW — Shared surface gateway**: one assistant across deployments via one bot per platform (one gateway connection), instance↔stack routing over the bus, surface-agnostic; structurally eliminates double-posting.

Verify pass: all 5 criteria (vocab surgical, carve-outs preserved, both epics present + consistent, Q1–Q7 intact, markdown clean). Approval gate before driving the epics into sub-issues + code.

Refs #110.

🤖 Generated with [Claude Code](https://claude.com/claude-code)