### PR TITLE
feat(vocab): R2.I — cloud-network operatorId→principalId (accept-both transition)

### DIFF
--- a/docs/migrations/0002-vocabulary-finish-2026-05.md
+++ b/docs/migrations/0002-vocabulary-finish-2026-05.md
@@ -339,8 +339,14 @@ These are local variables holding the **principal's** Discord/Slack/Mattermost i
 
 ### R2.I — Config loader + watcher + types
 
+**Status (cortex#436):** DONE for the **cloud-network cluster** — `NetworkCloudSchema.operatorId` → `principalId` (BREAKING-CONFIG with a backward-compatible transition) + `NetworkConfig.principalId` type + `network-resolver` + `cloud-publisher` symbol reads + `buildBotYamlSnippet` emits `principalId:`. The transition mirrors R3's top-level `operator:`→`principal:` accept-both pattern:
+- `NetworkCloudSchema` is now `z.preprocess(acceptLegacyCloudPrincipalId, NetworkCloudObjectSchema)`. The object schema carries only the canonical `principalId`; the preprocess step rewrites a legacy `operatorId` key → `principalId` (one-time deprecation warning), rejects a block declaring BOTH keys (R3-parity dual-key conflict), and lets the canonical-only path through verbatim. Existing `cortex.yaml` / `networks/*.yaml` with cloud `operatorId` keep loading.
+- `loader.ts buildLegacyNetwork` rewrites the legacy flat `api.operatorId` (and grove-v2 `agent.operatorId`) into the canonical cloud `principalId` when synthesising the default network. The legacy flat `api.operatorId` schema slot (`config.ts` `api` block) is intentionally NOT renamed — it is the backward-compat reader.
+
+The remaining `operatorId` hits enumerated below are CARVE-OUTS (R7 `agent.operatorId` synthesis — already retired via cortex#429 PR-C — and the legacy `api.*` reader). They are NOT part of the cloud-network rename.
+
 `src/common/types/config.ts`:
-- `:183` `operatorId: z.string().min(1),` (in `NetworkConfig` cloud block — required)
+- `:183` `operatorId: z.string().min(1),` (in `NetworkConfig` cloud block — required) — **DONE → `principalId`**
 - `:269` `operatorId: z.string().optional(),` (in `BotConfig.agent`)
 - `:270` "Defaults to operatorId" — doc
 - `:274` `OperatorSchema.discordId/…` — R1 cascade

--- a/src/bus/__tests__/network-resolver.test.ts
+++ b/src/bus/__tests__/network-resolver.test.ts
@@ -23,7 +23,7 @@ function makeNetwork(id: string, overrides: Partial<NetworkFile> = {}): NetworkF
     cloud: {
       endpoint: `https://${id}.workers.dev`,
       apiKey: `grove_sk_${id}`,
-      operatorId: `op-${id}`,
+      principalId: `op-${id}`,
     },
     discord: [],
     mattermost: [],
@@ -142,7 +142,7 @@ describe("createNetworkResolver", () => {
     expect(alphaConfig!.id).toBe("alpha");
     expect(alphaConfig!.endpoint).toBe("https://alpha.workers.dev");
     expect(alphaConfig!.apiKey).toBe("grove_sk_alpha");
-    expect(alphaConfig!.operatorId).toBe("op-alpha");
+    expect(alphaConfig!.principalId).toBe("op-alpha");
 
     const betaConfig = resolver("beta");
     expect(betaConfig).not.toBeNull();

--- a/src/bus/network-resolver.ts
+++ b/src/bus/network-resolver.ts
@@ -95,15 +95,15 @@ export function createNetworkResolver(config: AgentConfig): NetworkResolver {
     if (networkId) {
       const network = tables.networksById.get(networkId);
       if (!network?.cloud) return null;
-      const { endpoint, apiKey, operatorId, cfAccessClientId, cfAccessClientSecret } = network.cloud;
-      return { id: network.id, endpoint, apiKey, operatorId, cfAccessClientId, cfAccessClientSecret };
+      const { endpoint, apiKey, principalId, cfAccessClientId, cfAccessClientSecret } = network.cloud;
+      return { id: network.id, endpoint, apiKey, principalId, cfAccessClientId, cfAccessClientSecret };
     }
 
     // No network ID — return first network with cloud config
     for (const network of config.networks) {
       if (network.cloud) {
-        const { endpoint, apiKey, operatorId, cfAccessClientId, cfAccessClientSecret } = network.cloud;
-        return { id: network.id, endpoint, apiKey, operatorId, cfAccessClientId, cfAccessClientSecret };
+        const { endpoint, apiKey, principalId, cfAccessClientId, cfAccessClientSecret } = network.cloud;
+        return { id: network.id, endpoint, apiKey, principalId, cfAccessClientId, cfAccessClientSecret };
       }
     }
 

--- a/src/cli/cortex/commands/__tests__/cloud.test.ts
+++ b/src/cli/cortex/commands/__tests__/cloud.test.ts
@@ -178,10 +178,10 @@ describe("buildBotYamlSnippet", () => {
     expect(snippet).toContain("mode: cloud");
     expect(snippet).toContain("endpoint: https://grove-api.meta-factory.ai");
     expect(snippet).toContain("apiKey: grove_sk_abc123");
-    // bot.yaml's `operatorId:` YAML key is the NetworkCloudSchema field
-    // (R2.I — config-schema rename, separate PR). PR-R2d only renames
-    // the JSON wire field + CLI flag.
-    expect(snippet).toContain("operatorId: andreas");
+    // R2.I (cortex#436) renamed the NetworkCloudSchema field
+    // operatorId → principalId; the emitted snippet uses the canonical key.
+    expect(snippet).toContain("principalId: andreas");
+    expect(snippet).not.toContain("operatorId:");
   });
 });
 

--- a/src/cli/cortex/commands/cloud.ts
+++ b/src/cli/cortex/commands/cloud.ts
@@ -75,10 +75,12 @@ export function updateWranglerToml(
 /**
  * Build a bot.yaml snippet for a cloud-mode principal.
  *
- * The `operatorId:` YAML key matches `NetworkCloudSchema.operatorId`
- * in src/common/types/config.ts (rename owned by R2.I — the config
- * schema field). PR-R2d renames the CLI flag + JSON wire field; the
- * config-schema rename is the next breaking cut.
+ * The `principalId:` YAML key matches `NetworkCloudSchema.principalId`
+ * in src/common/types/config.ts. R2.I (cortex#436) renamed the cloud
+ * config field operatorId → principalId; this emitter now writes the
+ * canonical key. Existing configs with the legacy `operatorId:` key still
+ * load (the schema accepts both and rewrites on load), but freshly
+ * generated snippets use the canonical name.
  */
 export function buildBotYamlSnippet(opts: {
   endpoint: string;
@@ -89,7 +91,7 @@ export function buildBotYamlSnippet(opts: {
   mode: cloud
   endpoint: ${opts.endpoint}
   apiKey: ${opts.apiKey}
-  operatorId: ${opts.principalId}`;
+  principalId: ${opts.principalId}`;
 }
 
 /**

--- a/src/common/config/__tests__/loader.test.ts
+++ b/src/common/config/__tests__/loader.test.ts
@@ -52,7 +52,7 @@ function minimalNetwork(id: string, overrides: Record<string, unknown> = {}): Re
     cloud: {
       endpoint: `https://${id}.workers.dev`,
       apiKey: `grove_sk_${id}`,
-      operatorId: `op-${id}`,
+      principalId: `op-${id}`,
     },
     ...overrides,
   };
@@ -164,6 +164,9 @@ describe("legacy fallback", () => {
     expect(config.networks).toHaveLength(1);
     expect(config.networks[0]!.id).toBe("default");
     expect(config.discord).toHaveLength(1);
+    // R2.I (cortex#436) — the legacy flat `api.operatorId` is rewritten into
+    // the canonical cloud `principalId` by buildLegacyNetwork.
+    expect(config.networks[0]!.cloud?.principalId).toBe("op1");
   });
 
   test("empty networksDir creates no networks (beyond legacy fallback)", () => {
@@ -178,6 +181,68 @@ describe("legacy fallback", () => {
     expect(config.networks).toHaveLength(0);
     expect(config.discord).toHaveLength(0);
     expect(config.mattermost).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// R2.I (cortex#436) — cloud `operatorId` → `principalId` BREAKING-CONFIG
+// transition. The canonical key is `principalId`; the legacy `operatorId`
+// cloud key is still accepted on load (rewritten + deprecation-warned),
+// so existing user network files / cortex.yaml don't break. Mirrors the R3
+// top-level operator:→principal: accept-both pattern.
+// ---------------------------------------------------------------------------
+
+describe("R2.I cloud principalId transition", () => {
+  test("canonical cloud `principalId` loads", () => {
+    const configPath = writeCentralConfig(testDir, minimalCentral());
+    writeNetworkFile(testDir, "alpha.yaml", {
+      id: "alpha",
+      cloud: {
+        endpoint: "https://alpha.workers.dev",
+        apiKey: "grove_sk_alpha",
+        principalId: "andreas",
+      },
+    });
+
+    const config = loadConfig(configPath);
+    const alpha = config.networks.find((n) => n.id === "alpha");
+    expect(alpha?.cloud?.principalId).toBe("andreas");
+  });
+
+  test("LEGACY cloud `operatorId` still loads and is rewritten to `principalId`", () => {
+    // A pre-R2.I network file written by an existing user — the deprecated
+    // `operatorId:` cloud key MUST keep loading.
+    const configPath = writeCentralConfig(testDir, minimalCentral());
+    writeNetworkFile(testDir, "legacy.yaml", {
+      id: "legacy",
+      cloud: {
+        endpoint: "https://legacy.workers.dev",
+        apiKey: "grove_sk_legacy",
+        operatorId: "andreas-legacy",
+      },
+    });
+
+    const config = loadConfig(configPath);
+    const legacy = config.networks.find((n) => n.id === "legacy");
+    // Legacy key is accepted and surfaced under the canonical field.
+    expect(legacy?.cloud?.principalId).toBe("andreas-legacy");
+    // The deprecated key is NOT carried through on the validated type.
+    expect((legacy?.cloud as Record<string, unknown> | undefined)?.operatorId).toBeUndefined();
+  });
+
+  test("declaring BOTH `principalId` and legacy `operatorId` in a cloud block is rejected", () => {
+    const configPath = writeCentralConfig(testDir, minimalCentral());
+    writeNetworkFile(testDir, "conflict.yaml", {
+      id: "conflict",
+      cloud: {
+        endpoint: "https://conflict.workers.dev",
+        apiKey: "grove_sk_conflict",
+        principalId: "andreas",
+        operatorId: "andreas-legacy",
+      },
+    });
+
+    expect(() => loadConfig(configPath)).toThrow(/BOTH `principalId`.*`operatorId`/s);
   });
 });
 

--- a/src/common/config/loader.ts
+++ b/src/common/config/loader.ts
@@ -821,18 +821,23 @@ function buildLegacyNetwork(raw: Record<string, unknown>): NetworkFile {
   const api = raw.api as Record<string, unknown>;
   const agent = raw.agent as Record<string, unknown> | undefined;
 
-  const operatorId = (api.operatorId ?? (agent ? agent.operatorId : undefined)) as string | undefined;
-  if (!operatorId) {
+  // R2.I (cortex#436) — the cloud-network principal-identity field is now
+  // `principalId`. This legacy reader still accepts the legacy flat keys
+  // (`api.operatorId` / grove-v2 `agent.operatorId`) and rewrites them into
+  // the canonical cloud `principalId` when synthesising the default network,
+  // mirroring the R3 legacy-reader pattern.
+  const principalId = (api.operatorId ?? (agent ? agent.operatorId : undefined)) as string | undefined;
+  if (!principalId) {
     console.warn(
-      "config-loader: no operatorId configured (api.operatorId or agent.operatorId). " +
+      "config-loader: no principal id configured (api.operatorId or agent.operatorId). " +
       "Skipping cloud config for legacy default network to avoid phantom dashboard entries.",
     );
   }
 
-  const cloud: Record<string, unknown> | undefined = operatorId ? {
+  const cloud: Record<string, unknown> | undefined = principalId ? {
     endpoint: api.endpoint as string,
     apiKey: api.apiKey as string,
-    operatorId,
+    principalId,
     ...(api.cfAccessClientId ? { cfAccessClientId: api.cfAccessClientId } : {}),
     ...(api.cfAccessClientSecret ? { cfAccessClientSecret: api.cfAccessClientSecret } : {}),
   } : undefined;

--- a/src/common/types/config.ts
+++ b/src/common/types/config.ts
@@ -176,14 +176,84 @@ function normalizeToArray(val: unknown): unknown {
 // G-500: Per-network file schemas
 // =============================================================================
 
-/** Cloud endpoint configuration for a network */
-export const NetworkCloudSchema = z.object({
+/**
+ * Cloud endpoint configuration for a network.
+ *
+ * R2.I vocabulary migration (cortex#436) — BREAKING-CONFIG with a
+ * backward-compatible transition. The canonical principal-identity key is
+ * `principalId`. The legacy `operatorId` key is still accepted on load so
+ * existing `cortex.yaml` / `networks/*.yaml` files keep working; it is
+ * rewritten to `principalId` by `acceptLegacyCloudPrincipalId` and emits a
+ * one-time deprecation warning. This mirrors the R3 top-level
+ * `operator:`→`principal:` transition (accept-both + deprecate; see
+ * `src/common/config/loader.ts` `resolvePrincipalBlock`).
+ *
+ * Trust-boundary rule (R3 parity): a single cloud block declaring BOTH
+ * `principalId` and `operatorId` is ambiguous and is rejected, rather than
+ * silently resolving to one — a hand-edited config mid-migration must
+ * surface the conflict loudly.
+ */
+const NetworkCloudObjectSchema = z.object({
   endpoint: z.string().min(1),
   apiKey: z.string().min(1),
-  operatorId: z.string().min(1),
+  principalId: z.string().min(1),
   cfAccessClientId: z.string().optional(),
   cfAccessClientSecret: z.string().optional(),
 });
+
+/**
+ * Pre-parse rewriter: accept the legacy cloud `operatorId` key as an alias of
+ * the canonical `principalId`. Runs as a `z.preprocess` BEFORE
+ * `NetworkCloudObjectSchema` validates, so the legacy key never reaches the
+ * (deliberately `operatorId`-free) object schema.
+ *
+ * - canonical only (`principalId`)              → pass through verbatim
+ * - legacy only (`operatorId`)                  → rewrite to `principalId`, warn once
+ * - BOTH present                                → throw (dual-key conflict, R3 parity)
+ * - neither                                     → pass through; object schema's
+ *                                                 `principalId.min(1)` surfaces the
+ *                                                 missing-key error with the canonical name
+ */
+let warnedLegacyCloudPrincipalId = false;
+export function acceptLegacyCloudPrincipalId(raw: unknown): unknown {
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) return raw;
+  const obj = raw as Record<string, unknown>;
+  const hasCanonical = obj.principalId !== undefined;
+  const hasLegacy = obj.operatorId !== undefined;
+
+  if (hasCanonical && hasLegacy) {
+    throw new Error(
+      "network cloud block declares BOTH `principalId` (canonical) and the " +
+        "legacy `operatorId` key. R2.I (cortex#436) BREAKING-CONFIG — the " +
+        "`operatorId` cloud key is deprecated but still accepted as an alias; " +
+        "a block declaring both is ambiguous and is rejected before any " +
+        "event-attribution decision. Delete the legacy `operatorId` line " +
+        "(run `cortex migrate-config <your-config.yaml>` to regenerate a " +
+        "clean `principalId:`-shaped config).",
+    );
+  }
+
+  if (hasLegacy) {
+    if (!warnedLegacyCloudPrincipalId) {
+      warnedLegacyCloudPrincipalId = true;
+      console.warn(
+        "config: network cloud `operatorId:` is deprecated (R2.I, cortex#436) — " +
+          "rename it to `principalId:`. The legacy key is still accepted for now " +
+          "and rewritten on load; run `cortex migrate-config <your-config.yaml>` " +
+          "to update your config. This warning prints once per process.",
+      );
+    }
+    const { operatorId, ...rest } = obj;
+    return { ...rest, principalId: operatorId };
+  }
+
+  return raw;
+}
+
+export const NetworkCloudSchema = z.preprocess(
+  acceptLegacyCloudPrincipalId,
+  NetworkCloudObjectSchema,
+);
 
 /** Per-network Claude security overrides */
 export const NetworkClaudeSchema = z.object({
@@ -428,7 +498,11 @@ export const AgentConfigSchema = z.object({
     port: z.number().int().positive().default(8766),
     corsOrigin: z.string().default("*"),
     mode: z.enum(["local", "cloud"]).default("local"),
-    // Legacy cloud fields — kept for backward compat, migrated to network files by config-loader
+    // Legacy cloud fields — kept for backward compat, migrated to network files by config-loader.
+    // R2.I (cortex#436): `operatorId` here is the LEGACY flat `api.*` key. It is
+    // intentionally NOT renamed — this block is the backward-compat reader, and
+    // `buildLegacyNetwork` rewrites it to the canonical cloud `principalId` when
+    // synthesising the default network. New configs use per-network `cloud.principalId`.
     endpoint: z.string().default(""),
     apiKey: z.string().default(""),
     operatorId: z.string().default(""),
@@ -558,8 +632,8 @@ export interface NetworkConfig {
   endpoint: string;
   /** API key for this network */
   apiKey: string;
-  /** Principal ID for event attribution */
-  operatorId: string;
+  /** Principal ID for event attribution (R2.I rename of legacy `operatorId`) */
+  principalId: string;
   /** S-001: CF Access service token for machine-to-machine auth (optional) */
   cfAccessClientId?: string;
   cfAccessClientSecret?: string;
@@ -567,7 +641,7 @@ export interface NetworkConfig {
 
 /**
  * Function type for resolving network config by network_id.
- * Used by CloudPublisher to look up endpoint/apiKey/operatorId.
+ * Used by CloudPublisher to look up endpoint/apiKey/principalId.
  * Returns null if network_id is unknown.
  */
 export type NetworkResolver = (networkId: string | undefined) => NetworkConfig | null;

--- a/src/common/types/config.ts
+++ b/src/common/types/config.ts
@@ -214,15 +214,32 @@ const NetworkCloudObjectSchema = z.object({
  *                                                 `principalId.min(1)` surfaces the
  *                                                 missing-key error with the canonical name
  */
+/**
+ * Thrown when a network cloud block declares BOTH `principalId` and the legacy
+ * `operatorId` alias. Carries a stable `code` discriminator (parity with the
+ * top-level R3 `DualBlockConflictError` — kept as a separate class here because
+ * `loader.ts` imports this module, so importing its error back would be circular).
+ */
+export class CloudPrincipalIdConflictError extends Error {
+  readonly code = "dual_field_conflict";
+  constructor(message: string) {
+    super(message);
+    this.name = "CloudPrincipalIdConflictError";
+  }
+}
+
 let warnedLegacyCloudPrincipalId = false;
 export function acceptLegacyCloudPrincipalId(raw: unknown): unknown {
   if (raw === null || typeof raw !== "object" || Array.isArray(raw)) return raw;
   const obj = raw as Record<string, unknown>;
-  const hasCanonical = obj.principalId !== undefined;
-  const hasLegacy = obj.operatorId !== undefined;
+  // `!= null` (not `!== undefined`) so a valueless YAML `operatorId:` / `principalId:`
+  // line (which parses to null) is NOT treated as a live key — avoids a spurious
+  // dual-key rejection or rewrite for an empty alias line.
+  const hasCanonical = obj.principalId != null;
+  const hasLegacy = obj.operatorId != null;
 
   if (hasCanonical && hasLegacy) {
-    throw new Error(
+    throw new CloudPrincipalIdConflictError(
       "network cloud block declares BOTH `principalId` (canonical) and the " +
         "legacy `operatorId` key. R2.I (cortex#436) BREAKING-CONFIG — the " +
         "`operatorId` cloud key is deprecated but still accepted as an alias; " +

--- a/src/taps/cc-events/__tests__/cloud-publisher.test.ts
+++ b/src/taps/cc-events/__tests__/cloud-publisher.test.ts
@@ -32,9 +32,9 @@ function createTestNetworkResolver(endpoint: string, apiKey: string, principalId
       id: networkId ?? "default",
       endpoint,
       apiKey,
-      // `NetworkConfig.operatorId` is the TS field name pending R2.I;
-      // PR-R2d only renames the JSON wire field on the bus.
-      operatorId: principalId,
+      // R2.I (cortex#436) renamed the cloud-network TS field to `principalId`;
+      // it serialises to the `principal_id` wire field on the bus.
+      principalId,
     };
   };
 }

--- a/src/taps/cc-events/cloud-publisher.ts
+++ b/src/taps/cc-events/cloud-publisher.ts
@@ -197,10 +197,10 @@ export class CloudPublisher {
 
     const url = `${networkConfig.endpoint.replace(/\/+$/, "")}/api/ingest`;
     const body = JSON.stringify({
-      // Wire field is `principal_id` per PR-R2d. The TypeScript field
-      // `NetworkConfig.operatorId` still reads as `operatorId` pending
-      // PR-R2.I (config-schema rename).
-      principal_id: networkConfig.operatorId,
+      // Wire field is `principal_id` per PR-R2d. The TypeScript field is
+      // `NetworkConfig.principalId` after R2.I (cortex#436) renamed the
+      // cloud-network config field operatorId → principalId.
+      principal_id: networkConfig.principalId,
       events,
     });
 


### PR DESCRIPTION
## What (R2.I of cortex#436)

Renames the **cloud-network config field** `operatorId` → `principalId` — a breaking cortex.yaml input field, shipped with an **R3-style backward-compatible transition** so existing configs don't break:
- `NetworkCloudSchema` → canonical `principalId` via `z.preprocess` that **rewrites a legacy `operatorId` key** (once-per-process deprecation warning) and **rejects a block declaring both** (DualBlockConflictError parity with R3).
- `loader.buildLegacyNetwork` rewrites legacy flat `api.operatorId`/grove-v2 `agent.operatorId` → canonical cloud `principalId`.
- `NetworkConfig.principalId`, `network-resolver`, `cloud-publisher` (`principal_id` wire), `cloud.ts` emitter all aligned to canonical.

## Back-compat proven
New test: a legacy `cortex.yaml` with cloud `operatorId` still loads and is rewritten to `principalId`; both-keys is rejected. `bunx tsc --noEmit` clean · `bun test` **3669 pass / 0 fail**.

## Left (other clusters)
`agent.operatorId` (cortex#429 PR-C, already-retired AgentConfig field), the legacy flat `api.operatorId` back-compat reader slot, registry `operator_*` (R2.G / in-flight R7c), policy (R2.J). Gate flags ~34 on changed files — all these documented carve-outs/back-compat slots (main's gate is camelCase-blind; the recall fix + their carve-outs land last).

Part of #436.

🤖 Generated with [Claude Code](https://claude.com/claude-code)