### PR TITLE
feat(vocab): R2.G — registry client + federated-peer config operator→principal

### DIFF
--- a/src/__tests__/iaw-phase-d-integration.test.ts
+++ b/src/__tests__/iaw-phase-d-integration.test.ts
@@ -248,9 +248,9 @@ function alphaFederated(beta: StackHandle): PolicyFederated {
     leaf_node: "leaf-research",
     peers: [
       {
-        operator_id: "beta",
+        principal_id: "beta",
         stack_id: beta.homeStack,
-        operator_pubkey: "U" + "A".repeat(55), // structural-only here; α doesn't crypto-verify β's reply via this field
+        principal_pubkey: "U" + "A".repeat(55), // structural-only here; α doesn't crypto-verify β's reply via this field
       },
     ],
     accept_subjects: [
@@ -275,9 +275,9 @@ function betaFederated(alpha: StackHandle): PolicyFederated {
     leaf_node: "leaf-research",
     peers: [
       {
-        operator_id: "alpha",
+        principal_id: "alpha",
         stack_id: alpha.homeStack,
-        operator_pubkey: "U" + "A".repeat(55),
+        principal_pubkey: "U" + "A".repeat(55),
       },
     ],
     accept_subjects: [

--- a/src/common/policy/__tests__/factory.test.ts
+++ b/src/common/policy/__tests__/factory.test.ts
@@ -16,7 +16,11 @@
 import { describe, expect, test } from "bun:test";
 import { policyEngineFromConfig } from "../factory";
 import { PolicyEngine } from "../engine";
-import { PolicySchema, type Policy } from "../../types/cortex-config";
+import {
+  PolicySchema,
+  FederatedPeerPrincipalConflictError,
+  type Policy,
+} from "../../types/cortex-config";
 
 function parsePolicy(input: unknown): Policy {
   return PolicySchema.parse(input);
@@ -75,9 +79,9 @@ describe("policyEngineFromConfig", () => {
             leaf_node: "leaf",
             peers: [
               {
-                operator_id: "andreas",
+                principal_id: "andreas",
                 stack_id: "andreas/research",
-                operator_pubkey: pubkey,
+                principal_pubkey: pubkey,
               },
             ],
             accept_subjects: ["federated.research-collab.>"],
@@ -679,9 +683,9 @@ describe("PolicyFederatedSchema", () => {
             leaf_node: "nats-leaf-research",
             peers: [
               {
-                operator_id: "jcfischer",
+                principal_id: "jcfischer",
                 stack_id: "jcfischer/sage-host",
-                operator_pubkey: PEER_PUBKEY_A,
+                principal_pubkey: PEER_PUBKEY_A,
               },
             ],
             accept_subjects: ["federated.research-collab.tasks.code-review.*"],
@@ -764,22 +768,22 @@ describe("PolicyFederatedSchema", () => {
     ).toThrow(/<domain>\.<entity>/);
   });
 
-  test("rejects peer.operator_pubkey that isn't a U-prefixed NKey", () => {
+  test("rejects peer.principal_pubkey that isn't a U-prefixed NKey", () => {
     expect(() =>
       PolicySchema.parse({
         federated: {
           networks: [{
             id: "n", leaf_node: "leaf",
             peers: [{
-              operator_id: "alpha", stack_id: "alpha/main",
-              operator_pubkey: "not-an-nkey",
+              principal_id: "alpha", stack_id: "alpha/main",
+              principal_pubkey: "not-an-nkey",
             }],
             accept_subjects: [], deny_subjects: [],
             announce_capabilities: [], max_hop: 0,
           }],
         },
       }),
-    ).toThrow(/operator_pubkey must be a base32 NKey/);
+    ).toThrow(/principal_pubkey must be a base32 NKey/);
   });
 });
 
@@ -797,24 +801,24 @@ describe("PolicyFederatedSchema cross-validation", () => {
     ).toThrow(/network id.*n.*already declared/);
   });
 
-  test("rejects peer.stack_id whose prefix doesn't match peer.operator_id", () => {
+  test("rejects peer.stack_id whose prefix doesn't match peer.principal_id", () => {
     expect(() =>
       PolicySchema.parse({
         federated: {
           networks: [{
             id: "n", leaf_node: "leaf",
             peers: [{
-              operator_id: "jcfischer",
+              principal_id: "jcfischer",
               // Drifted prefix — would let an operator forge attribution.
               stack_id: "evil-actor/sage-host",
-              operator_pubkey: PEER_PUBKEY_A,
+              principal_pubkey: PEER_PUBKEY_A,
             }],
             accept_subjects: [], deny_subjects: [],
             announce_capabilities: [], max_hop: 0,
           }],
         },
       }),
-    ).toThrow(/must start with peer\.operator_id/);
+    ).toThrow(/must start with peer\.principal_id/);
   });
 
   test("rejects duplicate peer.stack_id within a network", () => {
@@ -824,8 +828,8 @@ describe("PolicyFederatedSchema cross-validation", () => {
           networks: [{
             id: "n", leaf_node: "leaf",
             peers: [
-              { operator_id: "alpha", stack_id: "alpha/main", operator_pubkey: PEER_PUBKEY_A },
-              { operator_id: "alpha", stack_id: "alpha/main", operator_pubkey: PEER_PUBKEY_B },
+              { principal_id: "alpha", stack_id: "alpha/main", principal_pubkey: PEER_PUBKEY_A },
+              { principal_id: "alpha", stack_id: "alpha/main", principal_pubkey: PEER_PUBKEY_B },
             ],
             accept_subjects: [], deny_subjects: [],
             announce_capabilities: [], max_hop: 0,
@@ -835,25 +839,25 @@ describe("PolicyFederatedSchema cross-validation", () => {
     ).toThrow(/peer\.stack_id.*already declared/);
   });
 
-  test("rejects duplicate peer.operator_pubkey within a network (paste error)", () => {
+  test("rejects duplicate peer.principal_pubkey within a network (paste error)", () => {
     expect(() =>
       PolicySchema.parse({
         federated: {
           networks: [{
             id: "n", leaf_node: "leaf",
             peers: [
-              { operator_id: "alpha", stack_id: "alpha/main", operator_pubkey: PEER_PUBKEY_A },
-              { operator_id: "beta", stack_id: "beta/main", operator_pubkey: PEER_PUBKEY_A },
+              { principal_id: "alpha", stack_id: "alpha/main", principal_pubkey: PEER_PUBKEY_A },
+              { principal_id: "beta", stack_id: "beta/main", principal_pubkey: PEER_PUBKEY_A },
             ],
             accept_subjects: [], deny_subjects: [],
             announce_capabilities: [], max_hop: 0,
           }],
         },
       }),
-    ).toThrow(/operator_pubkey already declared.*pubkey collision/);
+    ).toThrow(/principal_pubkey already declared.*pubkey collision/);
   });
 
-  test("same operator_pubkey is allowed across DIFFERENT networks (cross-network dedup not enforced)", () => {
+  test("same principal_pubkey is allowed across DIFFERENT networks (cross-network dedup not enforced)", () => {
     // Per-network uniqueness only — a single operator's stack may
     // legitimately participate in multiple networks with the same
     // pubkey. The schema doesn't reject this.
@@ -862,13 +866,13 @@ describe("PolicyFederatedSchema cross-validation", () => {
         networks: [
           {
             id: "net-a", leaf_node: "leaf",
-            peers: [{ operator_id: "alpha", stack_id: "alpha/main", operator_pubkey: PEER_PUBKEY_A }],
+            peers: [{ principal_id: "alpha", stack_id: "alpha/main", principal_pubkey: PEER_PUBKEY_A }],
             accept_subjects: [], deny_subjects: [],
             announce_capabilities: [], max_hop: 0,
           },
           {
             id: "net-b", leaf_node: "leaf",
-            peers: [{ operator_id: "alpha", stack_id: "alpha/main", operator_pubkey: PEER_PUBKEY_A }],
+            peers: [{ principal_id: "alpha", stack_id: "alpha/main", principal_pubkey: PEER_PUBKEY_A }],
             accept_subjects: [], deny_subjects: [],
             announce_capabilities: [], max_hop: 0,
           },
@@ -888,7 +892,7 @@ describe("PolicyFederatedSchema cross-validation", () => {
             {
               id: "other", leaf_node: "leaf",
               peers: [
-                { operator_id: "alpha", stack_id: "wrong-prefix/main", operator_pubkey: PEER_PUBKEY_A },
+                { principal_id: "alpha", stack_id: "wrong-prefix/main", principal_pubkey: PEER_PUBKEY_A },
               ],
               accept_subjects: [], deny_subjects: [],
               announce_capabilities: [], max_hop: 0,
@@ -900,7 +904,7 @@ describe("PolicyFederatedSchema cross-validation", () => {
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       expect(message).toContain("dup");
-      expect(message).toContain("must start with peer.operator_id");
+      expect(message).toContain("must start with peer.principal_id");
     }
   });
 
@@ -963,7 +967,7 @@ describe("PolicyFederatedSchema cross-validation", () => {
       federated: {
         networks: [{
           id: "research-collab", leaf_node: "leaf",
-          peers: [{ operator_id: "jcfischer", stack_id: "jcfischer/sage-host", operator_pubkey: PEER_PUBKEY_C }],
+          peers: [{ principal_id: "jcfischer", stack_id: "jcfischer/sage-host", principal_pubkey: PEER_PUBKEY_C }],
           accept_subjects: ["federated.research-collab.>"],
           deny_subjects: [],
           announce_capabilities: ["code-review.typescript"],
@@ -973,5 +977,97 @@ describe("PolicyFederatedSchema cross-validation", () => {
     });
     expect(policy.principals).toHaveLength(1);
     expect(policy.federated?.networks).toHaveLength(1);
+  });
+});
+
+describe("PolicyFederatedPeerSchema — R2.G operator→principal accept-both transition (cortex#436)", () => {
+  // Legacy peer keys (`operator_id` / `operator_pubkey`) are still
+  // accepted on load and rewritten to the canonical
+  // `principal_id` / `principal_pubkey` by
+  // `acceptLegacyFederatedPeerPrincipal`. Federation is pre-launch, so
+  // this transition is cheap insurance + parity with the R2.I cloud
+  // block. Removed in the breaking release.
+  function parsePeer(peer: Record<string, unknown>) {
+    return PolicySchema.parse({
+      federated: {
+        networks: [{
+          id: "n", leaf_node: "leaf",
+          peers: [peer],
+          accept_subjects: [], deny_subjects: [],
+          announce_capabilities: [], max_hop: 0,
+        }],
+      },
+    });
+  }
+
+  test("canonical principal_id / principal_pubkey parse verbatim", () => {
+    const policy = parsePeer({
+      principal_id: "alpha",
+      stack_id: "alpha/main",
+      principal_pubkey: PEER_PUBKEY_A,
+    });
+    const peer = policy.federated?.networks[0]?.peers[0];
+    expect(peer?.principal_id).toBe("alpha");
+    expect(peer?.principal_pubkey).toBe(PEER_PUBKEY_A);
+  });
+
+  test("legacy operator_id / operator_pubkey are rewritten to canonical", () => {
+    const policy = parsePeer({
+      operator_id: "alpha",
+      stack_id: "alpha/main",
+      operator_pubkey: PEER_PUBKEY_A,
+    });
+    const peer = policy.federated?.networks[0]?.peers[0];
+    // The parsed (canonical) shape carries no `operator_*` keys.
+    expect(peer?.principal_id).toBe("alpha");
+    expect(peer?.principal_pubkey).toBe(PEER_PUBKEY_A);
+    expect((peer as Record<string, unknown>).operator_id).toBeUndefined();
+    expect((peer as Record<string, unknown>).operator_pubkey).toBeUndefined();
+  });
+
+  test("mixed legacy id + canonical pubkey both rewrite/pass cleanly", () => {
+    const policy = parsePeer({
+      operator_id: "alpha",
+      stack_id: "alpha/main",
+      principal_pubkey: PEER_PUBKEY_A,
+    });
+    const peer = policy.federated?.networks[0]?.peers[0];
+    expect(peer?.principal_id).toBe("alpha");
+    expect(peer?.principal_pubkey).toBe(PEER_PUBKEY_A);
+  });
+
+  test("BOTH principal_id and operator_id present → dual-key conflict throws", () => {
+    expect(() =>
+      parsePeer({
+        principal_id: "alpha",
+        operator_id: "alpha",
+        stack_id: "alpha/main",
+        principal_pubkey: PEER_PUBKEY_A,
+      }),
+    ).toThrow(FederatedPeerPrincipalConflictError);
+  });
+
+  test("BOTH principal_pubkey and operator_pubkey present → dual-key conflict throws", () => {
+    expect(() =>
+      parsePeer({
+        principal_id: "alpha",
+        stack_id: "alpha/main",
+        principal_pubkey: PEER_PUBKEY_A,
+        operator_pubkey: PEER_PUBKEY_A,
+      }),
+    ).toThrow(FederatedPeerPrincipalConflictError);
+  });
+
+  test("legacy keys still cross-validate (stack_id prefix vs rewritten principal_id)", () => {
+    // The rewrite happens before cross-validation, so a drifted
+    // legacy `operator_id` is caught by the same prefix check that
+    // guards the canonical field.
+    expect(() =>
+      parsePeer({
+        operator_id: "jcfischer",
+        stack_id: "evil-actor/sage-host",
+        operator_pubkey: PEER_PUBKEY_A,
+      }),
+    ).toThrow(/must start with peer\.principal_id/);
   });
 });

--- a/src/common/policy/engine.ts
+++ b/src/common/policy/engine.ts
@@ -76,7 +76,7 @@ export interface FederatedNetwork {
    * `stack_id` to validate that an incoming principal's
    * `home_stack` belongs to the network's peer roster.
    *
-   * Other peer fields (`operator_id`, `operator_pubkey`) are
+   * Other peer fields (`principal_id`, `principal_pubkey`) are
    * consumed elsewhere (verifier, registry); the engine doesn't
    * read them.
    */

--- a/src/common/policy/factory.ts
+++ b/src/common/policy/factory.ts
@@ -54,7 +54,7 @@ export function policyEngineFromConfig(
   // slim `FederatedPolicy` shape. The engine only reads `id` +
   // `peers[].stack_id`; other fields (`accept_subjects`,
   // `deny_subjects`, `max_hop`, `announce_capabilities`,
-  // `operator_pubkey`, `operator_id`, `leaf_node`) are consumed
+  // `principal_pubkey`, `principal_id`, `leaf_node`) are consumed
   // elsewhere (surface-router D.2, verifier, registry D.4).
   const federated: FederatedPolicy | undefined = policy.federated
     ? {

--- a/src/common/registry/__tests__/client.test.ts
+++ b/src/common/registry/__tests__/client.test.ts
@@ -20,7 +20,7 @@ import { describe, expect, mock, test } from "bun:test";
 
 import { RegistryClient } from "../client";
 import { canonicalJSON } from "../signing";
-import type { OperatorRecord, SignedAssertion } from "../types";
+import type { PrincipalRecord, SignedAssertion } from "../types";
 
 // =============================================================================
 // Test helpers — Ed25519 sign-side (the client only verifies; tests
@@ -78,12 +78,12 @@ const FAKE_PEER_PUBKEY_V2 = "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB=";
 /**
  * Build a wire-shape payload — the JSON the registry emits and the
  * client deserializes. Wire fields are `principal_id` / `principal_pubkey`
- * per PR-R7c-network-registry; cortex's internal `OperatorRecord`
- * cache type uses different field names and the client maps between
- * them. Tests assert against the in-memory `OperatorRecord` view, so
- * the fixture is left as `unknown`-typed wire bytes.
+ * (PR-R7c-network-registry); cortex's internal `PrincipalRecord` cache
+ * type now mirrors the same field names (PR-R2.G), and the client
+ * passes them through verbatim after verification. Tests assert
+ * against the in-memory `PrincipalRecord` view.
  */
-function makeOperator(
+function makePrincipalWire(
   principal_id: string,
   pubkeyB64 = FAKE_PEER_PUBKEY_V1,
 ): {
@@ -131,7 +131,7 @@ function jsonResponse(body: unknown, status = 200): Response {
 describe("RegistryClient — TOFU + pinned pubkey", () => {
   test("TOFU: fetches /registry/pubkey at start() and pins the response", async () => {
     const kp = await generateKeypair();
-    const op = makeOperator("andreas");
+    const op = makePrincipalWire("andreas");
     const assertion = await signAssertion(kp.privateKey, kp.publicKeyB64, op);
 
     let pubkeyFetched = false;
@@ -155,7 +155,7 @@ describe("RegistryClient — TOFU + pinned pubkey", () => {
       expect(pubkeyFetched).toBe(true);
       const fetched = client.getPrincipal("andreas");
       expect(fetched).toBeDefined();
-      expect(fetched?.operator_id).toBe("andreas");
+      expect(fetched?.principal_id).toBe("andreas");
     } finally {
       client.stop();
     }
@@ -163,7 +163,7 @@ describe("RegistryClient — TOFU + pinned pubkey", () => {
 
   test("pinned pubkey from config skips the /registry/pubkey TOFU call", async () => {
     const kp = await generateKeypair();
-    const op = makeOperator("jcfischer");
+    const op = makePrincipalWire("jcfischer");
     const assertion = await signAssertion(kp.privateKey, kp.publicKeyB64, op);
 
     let pubkeyFetched = false;
@@ -196,7 +196,7 @@ describe("RegistryClient — TOFU + pinned pubkey", () => {
 describe("RegistryClient — getPrincipal()", () => {
   test("returns the verified record after a successful refresh", async () => {
     const kp = await generateKeypair();
-    const op = makeOperator("andreas", FAKE_PEER_PUBKEY_V1);
+    const op = makePrincipalWire("andreas", FAKE_PEER_PUBKEY_V1);
     const assertion = await signAssertion(kp.privateKey, kp.publicKeyB64, op);
 
     const fakeFetch = makeRouteFetch({
@@ -214,12 +214,12 @@ describe("RegistryClient — getPrincipal()", () => {
     await client.start();
     try {
       const got = client.getPrincipal("andreas");
-      // The cache is keyed on the cortex-internal `OperatorRecord`
-      // shape (`operator_id`/`operator_pubkey`), built from the wire
-      // payload (`principal_id`/`principal_pubkey`) per PR-R7c.
-      const expected: OperatorRecord = {
-        operator_id: op.principal_id,
-        operator_pubkey: op.principal_pubkey,
+      // The cache holds a cortex-internal `PrincipalRecord` whose
+      // field names (`principal_id`/`principal_pubkey`) now mirror the
+      // wire payload verbatim (PR-R7c wire + PR-R2.G symbol).
+      const expected: PrincipalRecord = {
+        principal_id: op.principal_id,
+        principal_pubkey: op.principal_pubkey,
         stacks: op.stacks,
         capabilities: op.capabilities,
         updated_at: op.updated_at,
@@ -239,7 +239,7 @@ describe("RegistryClient — getPrincipal()", () => {
     // structural shape correct" attack the verify step must catch.
     const signerKp = await generateKeypair();
     const pinnedKp = await generateKeypair();
-    const op = makeOperator("attacker");
+    const op = makePrincipalWire("attacker");
     const issued_at = new Date().toISOString();
     const bound = canonicalJSON({ payload: op, issued_at, registry: pinnedKp.publicKeyB64 });
     const sigBuf = await crypto.subtle.sign(
@@ -247,7 +247,7 @@ describe("RegistryClient — getPrincipal()", () => {
       signerKp.privateKey,
       new TextEncoder().encode(bound),
     );
-    const forged: SignedAssertion<ReturnType<typeof makeOperator>> = {
+    const forged: SignedAssertion<ReturnType<typeof makePrincipalWire>> = {
       payload: op,
       issued_at,
       registry: pinnedKp.publicKeyB64,
@@ -301,8 +301,8 @@ describe("RegistryClient — getPrincipal()", () => {
 
   test("returns undefined when the registry returned an `unconfigured` sentinel", async () => {
     const kp = await generateKeypair();
-    const op = makeOperator("andreas");
-    const unsignedAssertion: SignedAssertion<ReturnType<typeof makeOperator>> = {
+    const op = makePrincipalWire("andreas");
+    const unsignedAssertion: SignedAssertion<ReturnType<typeof makePrincipalWire>> = {
       payload: op,
       issued_at: new Date().toISOString(),
       registry: "unconfigured",
@@ -332,7 +332,7 @@ describe("RegistryClient — getPrincipal()", () => {
   test("returns undefined when the registry pubkey on the assertion does not match the pinned pubkey", async () => {
     const realKp = await generateKeypair();
     const otherKp = await generateKeypair();
-    const op = makeOperator("victim");
+    const op = makePrincipalWire("victim");
     // Assertion is well-signed by realKp, but the client pinned otherKp.
     const assertion = await signAssertion(realKp.privateKey, realKp.publicKeyB64, op);
     const fakeFetch = makeRouteFetch({
@@ -362,7 +362,7 @@ describe("RegistryClient — getPrincipal()", () => {
     // `alice`. The signature verifies, the registry pubkey matches —
     // only the per-principal id check catches it.
     const kp = await generateKeypair();
-    const eve = makeOperator("eve");
+    const eve = makePrincipalWire("eve");
     const assertion = await signAssertion(kp.privateKey, kp.publicKeyB64, eve);
     const fakeFetch = makeRouteFetch({
       "/principals/alice": () => jsonResponse(assertion),
@@ -394,7 +394,7 @@ describe("RegistryClient — getPrincipal()", () => {
     // assertion would have verified.
     const kp = await generateKeypair();
     const op = {
-      ...makeOperator("andreas"),
+      ...makePrincipalWire("andreas"),
       principal_pubkey: "definitely-not-base64-ed25519", // wrong length + alphabet
     };
     const assertion = await signAssertion(kp.privateKey, kp.publicKeyB64, op);
@@ -429,7 +429,7 @@ describe("RegistryClient — start()/stop() idempotency", () => {
     // doubled fetch count. The `started` flag fixes that. Echo
     // cortex#230 round 1.
     const kp = await generateKeypair();
-    const op = makeOperator("andreas");
+    const op = makePrincipalWire("andreas");
     const assertion = await signAssertion(kp.privateKey, kp.publicKeyB64, op);
     const fetchCalls: string[] = [];
     const fakeFetch: FakeFetchHandler = async (url: string) => {
@@ -473,7 +473,7 @@ describe("RegistryClient — start()/stop() idempotency", () => {
     // semantics persist beyond start() — not just "TOFU plus one
     // eager-refresh retry then give up".
     const kp = await generateKeypair();
-    const op = makeOperator("andreas");
+    const op = makePrincipalWire("andreas");
     const assertion = await signAssertion(kp.privateKey, kp.publicKeyB64, op);
 
     let pubkeyAttempts = 0;
@@ -519,7 +519,7 @@ describe("RegistryClient — periodic refresh + shutdown", () => {
     let currentPubkey = FAKE_PEER_PUBKEY_V1;
     const fakeFetch: FakeFetchHandler = async (url: string) => {
       if (url.endsWith("/principals/andreas")) {
-        const op = makeOperator("andreas", currentPubkey);
+        const op = makePrincipalWire("andreas", currentPubkey);
         const assertion = await signAssertion(kp.privateKey, kp.publicKeyB64, op);
         return jsonResponse(assertion);
       }
@@ -538,11 +538,11 @@ describe("RegistryClient — periodic refresh + shutdown", () => {
     });
     await client.start();
     try {
-      expect(client.getPrincipal("andreas")?.operator_pubkey).toBe(FAKE_PEER_PUBKEY_V1);
+      expect(client.getPrincipal("andreas")?.principal_pubkey).toBe(FAKE_PEER_PUBKEY_V1);
       // Principal rotates their pubkey upstream.
       currentPubkey = FAKE_PEER_PUBKEY_V2;
       await client.refreshAll();
-      expect(client.getPrincipal("andreas")?.operator_pubkey).toBe(FAKE_PEER_PUBKEY_V2);
+      expect(client.getPrincipal("andreas")?.principal_pubkey).toBe(FAKE_PEER_PUBKEY_V2);
     } finally {
       client.stop();
     }
@@ -550,7 +550,7 @@ describe("RegistryClient — periodic refresh + shutdown", () => {
 
   test("stop() cancels the refresh timer", async () => {
     const kp = await generateKeypair();
-    const op = makeOperator("andreas");
+    const op = makePrincipalWire("andreas");
     const assertion = await signAssertion(kp.privateKey, kp.publicKeyB64, op);
 
     const fetchCalls: string[] = [];
@@ -586,7 +586,7 @@ describe("RegistryClient — periodic refresh + shutdown", () => {
     // first completes. The fake `fetch` records every call; with the
     // guard the second invocation must NOT issue any GET.
     const kp = await generateKeypair();
-    const op = makeOperator("andreas");
+    const op = makePrincipalWire("andreas");
     const assertion = await signAssertion(kp.privateKey, kp.publicKeyB64, op);
 
     const fetchCalls: string[] = [];
@@ -635,7 +635,7 @@ describe("RegistryClient — periodic refresh + shutdown", () => {
 
   test("invalidate() drops a cache entry; the next refresh repopulates it", async () => {
     const kp = await generateKeypair();
-    const op = makeOperator("andreas");
+    const op = makePrincipalWire("andreas");
     const assertion = await signAssertion(kp.privateKey, kp.publicKeyB64, op);
     const fakeFetch = makeRouteFetch({
       "/principals/andreas": () => jsonResponse(assertion),

--- a/src/common/registry/client.ts
+++ b/src/common/registry/client.ts
@@ -58,7 +58,7 @@
 
 import { canonicalJSON, verifyEd25519 } from "./signing";
 import type {
-  OperatorRecord,
+  PrincipalRecord,
   RegistryClientOptions,
   RegistryClientReader,
 } from "./types";
@@ -90,8 +90,8 @@ export class RegistryClient implements RegistryClientReader {
    * fresh chance. Echo cortex#230 round 1.
    */
   private readonly tofuMode: boolean;
-  /** In-memory cache: `operator_id → verified OperatorRecord`. */
-  private readonly cache = new Map<string, OperatorRecord>();
+  /** In-memory cache: `principal_id → verified PrincipalRecord`. */
+  private readonly cache = new Map<string, PrincipalRecord>();
 
   private refreshTimer: ReturnType<typeof setInterval> | undefined;
   /** Abort controller scoped to the current cycle's in-flight requests. */
@@ -214,7 +214,7 @@ export class RegistryClient implements RegistryClientReader {
   }
 
   /** RegistryClientReader.getPrincipal — see interface JSDoc. */
-  getPrincipal(principalId: string): OperatorRecord | undefined {
+  getPrincipal(principalId: string): PrincipalRecord | undefined {
     return this.cache.get(principalId);
   }
 
@@ -324,9 +324,9 @@ export class RegistryClient implements RegistryClientReader {
     principalId: string,
     signal: AbortSignal,
   ): Promise<void> {
-    // Wire path is `/principals/:principal_id` per PR-R7c-network-registry.
-    // The cortex-internal cache type (`OperatorRecord`) keeps its symbol
-    // pending PR-R2.G; only the wire path + field reads flip here.
+    // Wire path is `/principals/:principal_id`; the cortex-internal
+    // cache type is `PrincipalRecord` (PR-R2.G aligned the symbol with
+    // the wire shape the service flipped to in PR-R7c).
     const url = `${this.url}/principals/${encodeURIComponent(principalId)}`;
     const raw = await this.fetchJson(url, signal);
     if (raw === undefined) return; // already logged inside fetchJson
@@ -348,7 +348,7 @@ export class RegistryClient implements RegistryClientReader {
   private async verifyAssertion(
     principalId: string,
     raw: unknown,
-  ): Promise<OperatorRecord | undefined> {
+  ): Promise<PrincipalRecord | undefined> {
     const pinned = this.pinnedPubkey;
     if (pinned === undefined) {
       this.logError(
@@ -452,13 +452,13 @@ export class RegistryClient implements RegistryClientReader {
     // Defensive: the producer types include arrays we trust the
     // service to populate, but a corrupted payload could send the
     // wrong shape past the structural checks above. Normalise. The
-    // cortex-internal cache type (`OperatorRecord`) keeps its symbol
-    // pending PR-R2.G; wire fields read as `principal_*` per R7c.
+    // cortex-internal cache type `PrincipalRecord` mirrors the wire
+    // `principal_*` fields the service emits (PR-R7c + PR-R2.G).
     return {
-      operator_id: principalId,
-      operator_pubkey: payload.principal_pubkey,
-      stacks: Array.isArray(payload.stacks) ? (payload.stacks as OperatorRecord["stacks"]) : [],
-      capabilities: Array.isArray(payload.capabilities) ? (payload.capabilities as OperatorRecord["capabilities"]) : [],
+      principal_id: principalId,
+      principal_pubkey: payload.principal_pubkey,
+      stacks: Array.isArray(payload.stacks) ? (payload.stacks as PrincipalRecord["stacks"]) : [],
+      capabilities: Array.isArray(payload.capabilities) ? (payload.capabilities as PrincipalRecord["capabilities"]) : [],
       updated_at: typeof payload.updated_at === "string" ? payload.updated_at : "",
     };
   }

--- a/src/common/registry/index.ts
+++ b/src/common/registry/index.ts
@@ -8,7 +8,7 @@
 export { RegistryClient } from "./client";
 export type {
   Capability,
-  OperatorRecord,
+  PrincipalRecord,
   RegistryClientOptions,
   RegistryClientReader,
   RegistryPubkeyResponse,

--- a/src/common/registry/types.ts
+++ b/src/common/registry/types.ts
@@ -13,8 +13,8 @@
  * The shapes below are structurally compatible with the producer
  * types in `src/services/network-registry/src/types.ts` — that file
  * remains the source of truth for the schema, and any drift between
- * the two is a bug. When the registry's payload shape changes, this
- * file moves first, then the service.
+ * the two is a bug. When the registry's payload shape changes, the
+ * service moves first, then this file follows.
  *
  * TODO: a single shared `@cortex/registry-types` package would
  * eliminate the redeclaration but is over-scoped for D.4.3.
@@ -25,7 +25,7 @@
  * `StackIdentity` on the producer side.
  */
 export interface StackIdentity {
-  /** `{operator_id}/{stack_slug}` — slash-delimited. */
+  /** `{principal_id}/{stack_slug}` — slash-delimited. */
   stack_id: string;
   display_name?: string;
   metadata?: Record<string, string>;
@@ -42,22 +42,22 @@ export interface Capability {
 }
 
 /**
- * The view of a principal returned by `GET /operators/{operator_id}`.
- * Mirrors `OperatorRecord` on the producer side.
+ * The view of a principal returned by `GET /principals/{principal_id}`.
+ * Mirrors `PrincipalRecord` on the producer side.
  *
- * `operator_pubkey` is base64-encoded Ed25519 (32 raw bytes → 44 chars
+ * `principal_pubkey` is base64-encoded Ed25519 (32 raw bytes → 44 chars
  * including padding). This is distinct from the NATS NKey format used
- * by the static `policy.federated.networks[].peers[].operator_pubkey`
+ * by the static `policy.federated.networks[].peers[].principal_pubkey`
  * field in cortex.yaml — D.4.3 introduces this second format as the
  * registry-resolved alternative. Phase-B caveat: the surface-router's
  * NKey-based verification path is unchanged; D.4.3 only populates a
  * cache; consumers wanting registry-resolved verification must opt in
  * by reading from this client instead of the static peer list.
  */
-export interface OperatorRecord {
-  operator_id: string;
+export interface PrincipalRecord {
+  principal_id: string;
   /** Base64 Ed25519 pubkey (32 raw bytes, 44 chars w/ padding). */
-  operator_pubkey: string;
+  principal_pubkey: string;
   stacks: StackIdentity[];
   capabilities: Capability[];
   updated_at: string;
@@ -112,9 +112,7 @@ export interface RegistryClientOptions {
   pubkey?: string;
   /**
    * Principal ids the client should track. Populated at boot from
-   * `policy.federated.networks[].peers[].operator_id` (de-duplicated;
-   * wire field stays `operator_id` until PR-R7c-network-registry
-   * renames the registry service).
+   * `policy.federated.networks[].peers[].principal_id` (de-duplicated).
    * Empty list means the client starts dormant — no refresh cycles,
    * `getPrincipal()` always returns undefined.
    */
@@ -154,16 +152,13 @@ export interface RegistryClientOptions {
  */
 export interface RegistryClientReader {
   /**
-   * Return the cached `OperatorRecord` for `principalId`, or
+   * Return the cached `PrincipalRecord` for `principalId`, or
    * `undefined` if the principal is unknown, the cache is empty, the
    * last fetch failed, or the signature did not verify.
-   *
-   * The return type stays `OperatorRecord` until PR-R7c-network-registry
-   * renames the registry service's wire-shape symbol.
    *
    * Never throws — federation failures must not crash the rest of
    * cortex. All error paths log via `logError` and return
    * `undefined`.
    */
-  getPrincipal(principalId: string): OperatorRecord | undefined;
+  getPrincipal(principalId: string): PrincipalRecord | undefined;
 }

--- a/src/common/types/cortex-config.ts
+++ b/src/common/types/cortex-config.ts
@@ -1348,35 +1348,45 @@ export type PolicyRole = z.infer<typeof PolicyRoleSchema>;
  *
  * Every peer is a remote principal's stack-NKey identity that this
  * principal's cortex will accept federated traffic from. The triple
- * `{operator_id, stack_id, operator_pubkey}` is the verifiable
+ * `{principal_id, stack_id, principal_pubkey}` is the verifiable
  * attribution slot: incoming federated envelopes carry
  * `signed_by[].principal = did:mf:<stack_id>` + a signature that
- * verifies against `operator_pubkey`. Phase D verification wiring
+ * verifies against `principal_pubkey`. Phase D verification wiring
  * lands in D.2/D.3; the schema lands first so principals can declare
  * their federation topology before the verification path is live.
+ *
+ * R2.G vocabulary migration (cortex#436) — the canonical peer-identity
+ * keys are `principal_id` / `principal_pubkey`. The legacy
+ * `operator_id` / `operator_pubkey` keys are still accepted on load
+ * (rewritten by `acceptLegacyFederatedPeerPrincipal` with a one-time
+ * deprecation warning) so any hand-written federation block keeps
+ * working through the transition. Federation is pre-launch so the risk
+ * is low; accept-both is cheap insurance and keeps the peer block
+ * consistent with the R2.I cloud-block transition
+ * (`acceptLegacyCloudPrincipalId` in `config.ts`).
  */
-export const PolicyFederatedPeerSchema = z.object({
+const PolicyFederatedPeerObjectSchema = z.object({
   /**
    * Peer principal id — same letter-prefix grammar as `PrincipalConfigSchema.id`.
    * Distinct from the principal's local id; the local principal's id
    * doesn't appear in `federated.networks[].peers[]` (the local
    * principal IS the consumer of the peer list).
    */
-  operator_id: z.string().regex(
+  principal_id: z.string().regex(
     LETTER_PREFIX_ID_REGEX,
-    "peer.operator_id must match the principal id grammar (lowercase alphanumeric + hyphen, starting with a letter)",
+    "peer.principal_id must match the principal id grammar (lowercase alphanumeric + hyphen, starting with a letter)",
   ),
   /**
-   * Peer stack id in `{operator_id}/{stack_id}` form — same shape as
-   * `PolicyPrincipalSchema.home_stack`. The `operator_id` prefix MUST
-   * match the sibling `operator_id` field (cross-validated below);
+   * Peer stack id in `{principal_id}/{stack_id}` form — same shape as
+   * `PolicyPrincipalSchema.home_stack`. The `principal_id` prefix MUST
+   * match the sibling `principal_id` field (cross-validated below);
    * the redundancy is deliberate so principals can read the file and
    * see "yes, this is jcfischer's sage-host stack" without splitting
    * the identity across fields.
    */
   stack_id: z.string().regex(
     /^[a-z][a-z0-9_-]*\/[a-z][a-z0-9_-]*$/,
-    "peer.stack_id must match {operator_id}/{stack_id} format",
+    "peer.stack_id must match {principal_id}/{stack_id} format",
   ),
   /**
    * Peer principal's NKey public key — same 56-char U-prefixed base32
@@ -1385,11 +1395,93 @@ export const PolicyFederatedPeerSchema = z.object({
    * for a registry-resolved lookup; until then, principals paste the
    * peer's pubkey directly into cortex.yaml.
    */
-  operator_pubkey: z.string().regex(
+  principal_pubkey: z.string().regex(
     NKEY_PUBKEY_REGEX,
-    "peer.operator_pubkey must be a base32 NKey public key (U-prefixed, 56 chars total)",
+    "peer.principal_pubkey must be a base32 NKey public key (U-prefixed, 56 chars total)",
   ),
 });
+
+/**
+ * Thrown when a federated peer block declares BOTH a canonical key
+ * (`principal_id` / `principal_pubkey`) and its legacy alias
+ * (`operator_id` / `operator_pubkey`). Carries a stable `code`
+ * discriminator (parity with `CloudPrincipalIdConflictError` from the
+ * R2.I cloud-block transition).
+ */
+export class FederatedPeerPrincipalConflictError extends Error {
+  readonly code = "dual_field_conflict";
+  constructor(message: string) {
+    super(message);
+    this.name = "FederatedPeerPrincipalConflictError";
+  }
+}
+
+let warnedLegacyFederatedPeerPrincipal = false;
+/**
+ * Pre-parse rewriter: accept the legacy peer keys `operator_id` /
+ * `operator_pubkey` as aliases of the canonical `principal_id` /
+ * `principal_pubkey`. Runs as a `z.preprocess` BEFORE
+ * `PolicyFederatedPeerObjectSchema` validates, so the legacy keys
+ * never reach the (deliberately `operator_*`-free) object schema.
+ * Mirrors `acceptLegacyCloudPrincipalId` (R2.I) but covers two fields.
+ *
+ * Per field:
+ *   - canonical only            → pass through verbatim
+ *   - legacy only               → rewrite to the canonical key, warn once
+ *   - BOTH present              → throw (dual-key conflict, R3/R2.I parity)
+ *   - neither                   → pass through; the object schema's
+ *                                 `.regex(...)` surfaces the missing-key
+ *                                 error under the canonical name
+ */
+export function acceptLegacyFederatedPeerPrincipal(raw: unknown): unknown {
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) return raw;
+  const obj = raw as Record<string, unknown>;
+
+  // `!= null` (not `!== undefined`) so a valueless YAML key line
+  // (parses to null) is NOT treated as a live key — avoids a spurious
+  // dual-key rejection or rewrite for an empty alias line.
+  const hasCanonicalId = obj.principal_id != null;
+  const hasLegacyId = obj.operator_id != null;
+  const hasCanonicalPubkey = obj.principal_pubkey != null;
+  const hasLegacyPubkey = obj.operator_pubkey != null;
+
+  if ((hasCanonicalId && hasLegacyId) || (hasCanonicalPubkey && hasLegacyPubkey)) {
+    const which = hasCanonicalId && hasLegacyId ? "principal_id`/`operator_id" : "principal_pubkey`/`operator_pubkey";
+    throw new FederatedPeerPrincipalConflictError(
+      "federated peer declares BOTH the canonical and legacy form of " +
+        "`" + which + "`. R2.G (cortex#436) — the `operator_*` peer keys " +
+        "are deprecated but still accepted as aliases; a peer declaring " +
+        "both forms of a field is ambiguous and is rejected before any " +
+        "federation-attribution decision. Delete the legacy `operator_*` " +
+        "line(s) and keep the `principal_*` form.",
+    );
+  }
+
+  if (hasLegacyId || hasLegacyPubkey) {
+    if (!warnedLegacyFederatedPeerPrincipal) {
+      warnedLegacyFederatedPeerPrincipal = true;
+      console.warn(
+        "config: federated peer `operator_id:` / `operator_pubkey:` are " +
+          "deprecated (R2.G, cortex#436) — rename them to `principal_id:` / " +
+          "`principal_pubkey:`. The legacy keys are still accepted for now " +
+          "and rewritten on load. This warning prints once per process.",
+      );
+    }
+    const { operator_id, operator_pubkey, ...rest } = obj;
+    return {
+      ...rest,
+      ...(hasLegacyId && { principal_id: operator_id }),
+      ...(hasLegacyPubkey && { principal_pubkey: operator_pubkey }),
+    };
+  }
+
+  return raw;
+}
+
+export const PolicyFederatedPeerSchema = z.preprocess(
+  acceptLegacyFederatedPeerPrincipal,
+  PolicyFederatedPeerObjectSchema,
+);
 
 export type PolicyFederatedPeer = z.infer<typeof PolicyFederatedPeerSchema>;
 
@@ -1520,7 +1612,7 @@ export type PolicyFederatedNetwork = z.infer<typeof PolicyFederatedNetworkSchema
  * Declares the cortex-network-registry endpoint the principal wants
  * cortex to consult for peer-pubkey resolution. When present, the
  * `RegistryClient` (in `src/common/registry/`) is instantiated at
- * boot and consults `{url}/operators/{id}` on a refresh schedule
+ * boot and consults `{url}/principals/{id}` on a refresh schedule
  * to populate an in-memory cache of verified peer pubkeys.
  *
  * The trust anchor is the registry's own Ed25519 pubkey:
@@ -1555,7 +1647,7 @@ export const PolicyFederatedRegistrySchema = z.object({
    * pinned for the lifetime of the process. Principals wanting a
    * persistent pin across restarts must paste it here.
    *
-   * Grammar matches the registry service's `OperatorRecord.operator_pubkey`
+   * Grammar matches the registry service's `PrincipalRecord.principal_pubkey`
    * shape (base64 of 32 raw bytes → 44 chars including `=` padding).
    * Validated softly (length + base64 alphabet) — strict 32-byte
    * decoding happens at the client during initial fetch.
@@ -1743,17 +1835,17 @@ export const PolicySchema = z.object({
       const seenPeerStack = new Map<string, number>();
       const seenPeerPubkey = new Map<string, number>();
       n.peers.forEach((peer, peerIdx) => {
-        // stack_id prefix must match operator_id — the two fields
+        // stack_id prefix must match principal_id — the two fields
         // are deliberately redundant so the file reads naturally,
         // but they MUST agree. A drift between them would let an
         // principal declare "peer X has stack Y" where Y belongs to
         // a different principal — the surface-router would then
         // accept federated traffic claiming a forged identity.
-        const expectedPrefix = `${peer.operator_id}/`;
+        const expectedPrefix = `${peer.principal_id}/`;
         if (!peer.stack_id.startsWith(expectedPrefix)) {
           ctx.addIssue({
             code: "custom",
-            message: `peer.stack_id "${peer.stack_id}" must start with peer.operator_id "${peer.operator_id}" — got prefix "${peer.stack_id.split("/")[0]}/" instead`,
+            message: `peer.stack_id "${peer.stack_id}" must start with peer.principal_id "${peer.principal_id}" — got prefix "${peer.stack_id.split("/")[0]}/" instead`,
             path: ["federated", "networks", networkIdx, "peers", peerIdx, "stack_id"],
           });
         }
@@ -1772,19 +1864,19 @@ export const PolicySchema = z.object({
           seenPeerStack.set(peer.stack_id, peerIdx);
         }
 
-        // Uniqueness — peer.operator_pubkey within a network. A
+        // Uniqueness — peer.principal_pubkey within a network. A
         // single pubkey appearing twice signals a copy-paste error
         // (principal pasted the same key into two peer entries with
         // different stack_ids); the schema catches it.
-        const dupKeyAt = seenPeerPubkey.get(peer.operator_pubkey);
+        const dupKeyAt = seenPeerPubkey.get(peer.principal_pubkey);
         if (dupKeyAt !== undefined) {
           ctx.addIssue({
             code: "custom",
-            message: `peer.operator_pubkey already declared at federated.networks[${networkIdx}].peers[${dupKeyAt}] (pubkey collision — paste error?)`,
-            path: ["federated", "networks", networkIdx, "peers", peerIdx, "operator_pubkey"],
+            message: `peer.principal_pubkey already declared at federated.networks[${networkIdx}].peers[${dupKeyAt}] (pubkey collision — paste error?)`,
+            path: ["federated", "networks", networkIdx, "peers", peerIdx, "principal_pubkey"],
           });
         } else {
-          seenPeerPubkey.set(peer.operator_pubkey, peerIdx);
+          seenPeerPubkey.set(peer.principal_pubkey, peerIdx);
         }
       });
     });

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -1258,14 +1258,14 @@ export async function startCortex(
   let registryClient: RegistryClient | null = null;
   const registryConfig = options.policy?.federated?.registry;
   if (registryConfig !== undefined) {
-    const peerOperatorIds = Array.from(
+    const peerPrincipalIds = Array.from(
       new Set(
         (options.policy?.federated?.networks ?? []).flatMap((n) =>
-          n.peers.map((p) => p.operator_id),
+          n.peers.map((p) => p.principal_id),
         ),
       ),
     );
-    if (peerOperatorIds.length === 0) {
+    if (peerPrincipalIds.length === 0) {
       console.log(
         `cortex: policy.federated.registry configured (${registryConfig.url}) but no peers declared — registry client dormant`,
       );
@@ -1273,14 +1273,14 @@ export async function startCortex(
       registryClient = new RegistryClient({
         url: registryConfig.url,
         ...(registryConfig.pubkey !== undefined && { pubkey: registryConfig.pubkey }),
-        principalIds: peerOperatorIds,
+        principalIds: peerPrincipalIds,
       });
       // Boot the client asynchronously — TOFU + initial refresh must
       // not block the rest of cortex boot. Errors inside `start()`
       // are already logged via the client's own `logError` seam.
       void registryClient.start();
       console.log(
-        `cortex: registry client started (${registryConfig.url}, tracking ${peerOperatorIds.length} peer(s))`,
+        `cortex: registry client started (${registryConfig.url}, tracking ${peerPrincipalIds.length} peer(s))`,
       );
     }
   }


### PR DESCRIPTION
## What (R2.G of cortex#436)

Completes the network-registry operator→principal rename on the **cortex client + config** side. The **service side (R7c) already landed** in #469 (`routes/principals.ts`, `operators.ts` deleted) — so the client's prior `operator_*` carve-outs (which only existed *because* the service lagged) now flip to match:
- `registry/{types,client,signing,index}.ts` — `OperatorRecord`→`PrincipalRecord`, calls `/principals/:principal_id`, reads `principal_id`/`principal_pubkey`
- `cortex.ts` / `id.ts` — federated-peer reads `p.operator_id`→`p.principal_id`
- `cortex-config.ts` `PolicyFederatedPeerSchema` — `principal_id`/`principal_pubkey` with an **R3-style accept-both transition** (legacy `operator_id`/`operator_pubkey` rewritten, both-keys rejected via `FederatedPeerPrincipalConflictError`, warn-once) + 6-case test

## Verification
`bunx tsc --noEmit` clean · `bun test` **3675 pass / 0 fail** · 0 dangling `/operators`/`OperatorRecord` in registry+client paths.

## Note
The federated-peer config is a pre-launch federation feature; the accept-both transition is cheap insurance + consistent with R2.I. This **closes the registry cluster** — the only remaining R2 surface is the `{operator_id}/{stack_id}` stack-grammar prose idiom + the gate-recall fix.

Part of #436.

🤖 Generated with [Claude Code](https://claude.com/claude-code)