### PR TITLE
feat!: v4.0.0 — vocab migration breaking cut + fully-ratcheted gate (closes R2 #436)

### DIFF
--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -2,7 +2,13 @@
 # See: https://github.com/the-metafactory/arc
 
 name: "Cortex"
-version: "3.1.0"
+# v4.0.0 BREAKING (cortex#436 R2.I/R2.G/R3) — the legacy principal-identity
+# config keys are no longer accepted: the top-level `operator:` block, the cloud
+# `operatorId` key, and the federated-peer `operator_id` / `operator_pubkey` keys
+# now fail to load (strict canonical-only schemas). Run `cortex migrate-config`
+# to rewrite a pre-v4 config to the canonical `principal:` / `principalId` /
+# `principal_id` shape.
+version: "4.0.0"
 type: component
 tier: community
 description: "Layer-7 collaboration surface for the metafactory ecosystem — the M7 application that consumes the Myelin stack"

--- a/docs/agents-md/architecture.md
+++ b/docs/agents-md/architecture.md
@@ -26,7 +26,7 @@ Internal componentisation (per `docs/architecture.md` §8):
 - `src/adapters/` — Platform adapters (Discord, Mattermost) that register with the surface-router rather than subscribing to NATS directly. `mock.ts` for tests.
 - `src/runner/` — CC orchestration: cc-session (streaming `claude --print --output-format stream-json`), session-manager (per-thread CC session for `--resume`), stream-parser, agent-team (multi-agent moderator + participants), dispatch-listener, security-preamble, prompt-builder, worklog-manager, task-tracker, bash-guard hook.
 - `src/taps/` — Publishers onto the bus: `cc-events/` (CC hooks + EventLogger + relay + cloud-publisher), `gh-webhook/` (CF Worker at `hooks.meta-factory.ai` validating GitHub HMAC and forwarding).
-- `src/cli/` — Operator CLIs: `discord/` (post messages, read channels, list threads from terminal), `cldyo-live` (instrumented Opus session wrapper), `cortex/` (top-level CLI).
+- `src/cli/` — Principal CLIs: `discord/` (post messages, read channels, list threads from terminal), `cldyo-live` (instrumented Opus session wrapper), `cortex/` (top-level CLI).
 - `src/renderers/` — Renderer interface + dashboard renderer + pagerduty renderer (the G-1111 §4.6 fail-safe pair).
 - `src/common/` — Shared types + utilities: agent-detection, event-processor, event-utils, github-events, agents/, config/, timeout, types/, usage.
 - `src/services/` — launchd plists: `ai.meta-factory.cortex.meta-factory.plist` (metafactory dev stack), `ai.meta-factory.cortex.work.plist` (parallel work stack — cortex#244), `ai.meta-factory.cortex.relay.plist` (shared relay).

--- a/scripts/check-carveouts.sh
+++ b/scripts/check-carveouts.sh
@@ -77,7 +77,14 @@ CHECK_PERSONA=0
 # the reader-side union/shim is myelin-gated and excluded by construction
 # (we only match `distribution_mode ... = / : "broadcast"`, i.e. a write).
 # ──────────────────────────────────────────────────────────────────────────
-PAT_OPERATOR='\b[Oo]perator\b'
+# Widened from `\b[Oo]perator\b` to bare `[Oo]perator` so the recall catches
+# camelCase/snake_case compounds the word-boundary form was BLIND to — operatorId,
+# operator_id, home_operator, OperatorConfig, operatorRole, isOperator (the R2
+# identifier cluster, ~190 live sites). The carve-out filter below removes the
+# legitimate non-principal senses (NSC operatorAccount, policy authz-role literal,
+# R7-gated operatorDiscordId, EventBridge comparison operator). Verified no
+# `cooperat*` false-friends in the tree.
+PAT_OPERATOR='[Oo]perator'
 PAT_BOTCONFIG='\bBotConfig(Schema)?\b'
 PAT_BROADCAST_EMIT='distribution_mode[[:space:]]*[:=][[:space:]]*["'"'"']broadcast'
 PAT_PERSONA='\bpersona\b'
@@ -116,6 +123,72 @@ ALLOWLIST_PATHS=(
   # so these never appear there; this matters for the `-` per-PR-diff path.)
   'scripts/check-carveouts.sh'
   '.github/workflows/'
+  # Policy authorization-role cluster — `operator` here is the reserved
+  # authz ROLE / capability literal (CONTEXT.md → Mission Control authorization
+  # role; #513), NOT the principal. The policy engine + its fixtures + the
+  # cutover design doc carry it as a kept role-id string.
+  'src/common/policy/'
+  'docs/design-policy-cutover.md'
+  # User-auth RBAC tier `viewer|operator|admin` — the MC authorization role
+  # (CONTEXT.md, #513). A persisted privilege level, never the principal.
+  'src/surface/mc/worker/src/user-auth/'
+  # EventBridge comparison OPERATOR (equals / anything-but) — a programming
+  # term, not the vocab. Single-purpose filter-grammar file.
+  'src/bus/payload-filter.ts'
+  'src/bus/__tests__/payload-filter.test.ts'
+  # R3 dual-block-guard: this test NAMES the legacy `operator:` config key on
+  # purpose to verify the transition guard (retires with the breaking cut).
+  # Sibling to the migrate-config legacy-reader tests already allowlisted.
+  'src/common/config/__tests__/loader.test.ts'
+  # NSC trust/signing infrastructure — `operator` = the NATS account operator
+  # (cortex#76 trust anchor): OperatorVerifier, verifyOperator, operator pubkey,
+  # SA/SO/SU seed hierarchy. Platform term throughout these files.
+  'src/common/agents/trust-resolver.ts'
+  'src/common/agents/__tests__/trust-resolver-operator-verify.test.ts'
+  'src/common/config/account-signing-key.ts'
+  'src/common/config/stack-signing-key.ts'
+  # NATS connection wrapper — `operator` throughout = NSC operator-mode `.creds`
+  # auth + the operator-account signing-key loader it mirrors (cortex#86/#87).
+  # A NATS-infrastructure file, never the principal. Class: NSC.
+  # RETIRE: never (NSC operator is the permanent qualified survivor).
+  'src/bus/nats/connection.ts'
+  # NSC operator-account signing TEST fixtures — siblings of the two source files
+  # above (already allowlisted). They import nkeys.js `createOperator`, mint
+  # SO-prefixed operator seeds, and assert the loader REJECTS them. `operator`
+  # throughout = the NATS account-tree root, never the principal. Class: NSC.
+  # RETIRE: never (NSC operator is the permanent qualified survivor, CONTEXT.md).
+  'src/common/config/__tests__/account-signing-key.test.ts'
+  'src/common/config/__tests__/stack-signing-key.test.ts'
+  # HISTORICAL removed-field regression test — describes and guards the
+  # v3-REMOVED `config.agent.operatorId` legacy field (cortex#429 PR-C). Its
+  # whole purpose is to assert a stray reader of the removed field never creeps
+  # back; renaming the token would misdescribe WHAT was removed. Class: HISTORICAL.
+  # RETIRE: when the legacy-field-reader guard is no longer worth keeping (post
+  # v3.0.0 stabilisation).
+  'src/__tests__/principal-identity-consistency.test.ts'
+  # Legacy-migration cortex.yaml example configs — `before-*.yaml` is the
+  # pre-cutover shape (legacy `operator:` block + `operator` synthetic-principal
+  # role), `after-*.yaml` shows the migrated output; README documents the path.
+  # They EXIST to demonstrate the migrate-config legacy reader; same class as the
+  # migrate-config fixtures. RETIRE: when migrate-config is removed (v3.0.0 cut).
+  'docs/migration-examples/'
+  # Legacy v2 `.bot.yaml` migrate-config TEST fixtures — carry the deprecated
+  # `operatorId:` / `operatorName:` v2 keys (cortex#429 PR-C drop) as INPUT to
+  # the migrate-config path. Same class as migrate-config*.test.ts (allowlisted).
+  # RETIRE: with the migrate-config CLI removal (v3.0.0 cut).
+  'src/cli/cortex/commands/__tests__/fixtures/'
+  # Archived v1→v2 cutover note — frozen historical doc describing the legacy
+  # `sessions.operator_id` schema drift that the v2 cutover resolved. Class:
+  # HISTORICAL (archive). RETIRE: never (archive is immutable).
+  'docs/archive/'
+  # Policy converter — emits + reads the legacy `operator:` block and the
+  # reserved `operator` role/capability literal. Sibling to migrate-config-lib.
+  'src/cli/cortex/commands/migrate-config-policy.ts'
+  # IAW design/plan docs — #510-owned (refreshed); residual hits are
+  # code-identifier mentions discussed as prose, tracked on the IAW epic.
+  'docs/design-internet-of-agentic-work.md'
+  'docs/plan-internet-of-agentic-work.md'
+  'src/__tests__/iaw-phase-d-integration.test.ts'
 )
 
 # ──────────────────────────────────────────────────────────────────────────
@@ -134,6 +207,106 @@ CARVEOUT_LINE_PATTERNS=(
   'operator-account'
   'operator[[:space:]]+(NKey|JWT|account)'
   '(NKey|JWT|account)[[:space:]]+operator'
+  # NSC camelCase/snake forms newly visible under the widened recall.
+  '[Oo]peratorAccount'
+  '[Oo]peratorVerifier'
+  'verify[Oo]perator'
+  '[Oo]peratorSign'
+  'operator_pubkey'
+  'operator-mode'
+  '[Oo]peratorRecord'
+  # NSC operator-account signing seed/nkey file paths (`operator.nk`, `operator.nkey`,
+  # `operator.creds`). The NATS account-tree root seed (CONTEXT.md → NSC operator);
+  # a filesystem path to the operator-account key, never the principal. Class: NSC.
+  'operator\.(nk|nkey|creds|seed)'
+  # R7-gated network.operator block (operatorDiscordId/Mattermost/Slack) — the
+  # held R7 wire fields; rename waits for the myelin {org}→{principal} cut.
+  'operator(DiscordId|MattermostId|SlackId|PlatformIds|Role|RoleId)'
+  # ── LEGACY config-key tokens (R2.D/R2.I/R2.G + cortex#429 PR-C) ────────────
+  # The R2 identifier rename (operatorId/operator_id/operator_pubkey/operatorName
+  # → principalId/principal_id/principal_pubkey) is COMPLETE on main: there is no
+  # live canonical declaration of these tokens anywhere (verified — every surviving
+  # site is either a back-compat reader that still ACCEPTS the legacy key, a
+  # removed-field reference, or a legacy-migration test fixture). These tokens are
+  # therefore, by construction, the deprecated-alias class — same family as the
+  # already-allowlisted migrate-config-lib reader. Matching the token here carves
+  # the transitional readers (config.ts `acceptLegacyCloudPrincipalId`, loader.ts
+  # `buildLegacyNetwork`, cortex-config.ts legacy-peer reader, watcher.ts
+  # removed-field list, cortex.ts/runtime.ts PR-C comments) + the `.bot.yaml` /
+  # boot-test fixtures that feed them.
+  # RETIRE: when the breaking v3.0.0 cut deletes the legacy readers (manifest
+  # PR-11) — at which point these tokens vanish from the tree and the pattern is
+  # dead. A NEW genuine `operatorId` cannot appear because the canonical key is
+  # `principalId`; if one ever does it is a regression caught at code review, not
+  # by this gate (the gate's job here is the transitional window only).
+  'operator(Id|Name)\b'
+  '\boperator_id\b'
+  # Frozen D1 index identifier — `idx_sessions_operator` is KEPT as the index
+  # name in migration 0004 even though its column was renamed to `principal_id`
+  # (renaming a live index name is churn with no benefit). A frozen DDL
+  # identifier, same class as the allowlisted SQL migrations. RETIRE: never.
+  'idx_sessions_operator'
+  # GROVE_* event-payload wire key (separate GROVE migration, retires MIG-8):
+  # `payload.operator_id` / `p.operator_id` reads in event-processor.ts.
+  'payload\.operator_id'
+  '\bp\.operator_id'
+  # Policy authz-role predicate `isOperatorPrincipal` — exported from
+  # src/common/policy/resolve-access.ts (already path-allowlisted); the adapter
+  # call sites (discord/mattermost/slack) import it. "is this principal the
+  # operator (MC authorization role)?" per CONTEXT.md MC-role. Class: AUTHZ-ROLE.
+  'isOperatorPrincipal'
+  '\bisOperator\b'
+  # R4 rename-map PROSE — design/code lines that DOCUMENT the myelin-gated
+  # `operator.id` → `principal.id` / `Identity.operator` → `.network` rename by
+  # NAMING the pre-rename field. Renaming the token here would destroy the
+  # description of WHAT is being renamed (same logic as the HISTORICAL class).
+  # RETIRE with the myelin R4 breaking cut (#168/#171). Scoped to lines that
+  # carry an explicit rename arrow so it cannot mask a bare live `operator`.
+  'operator(\.id|`)?[[:space:]]*(→|->|renamed|is being renamed)'
+  '(renamed|rename)[[:space:]]*`?operator'
+  # Legacy `operator:` CONFIG-BLOCK reader (R3 transition + buildLegacyNetwork).
+  # The top-level `operator:` cortex.yaml block is the v2 key the loader still
+  # ACCEPTS (and migrate-config rewrites to `principal:`); same class as the
+  # already-allowlisted loader.test.ts R3 dual-block-guard. Matches the backtick-
+  # quoted prose key, the `raw.operator` / `hasOperator` reader symbols, and the
+  # `network.operator` held-block assignment. RETIRE: v3.0.0 breaking cut deletes
+  # the legacy reader (manifest PR-11).
+  '`operator:`'
+  # `operator.id` legacy-block field accessor — the dotted field on the legacy
+  # `operator:` cortex.yaml block. The only live code reads are in the
+  # already-allowlisted migrate-config-lib reader; every other occurrence is R4
+  # rename-map prose in design docs documenting `operator.id` → `principal.id`
+  # (myelin-gated R4 cut, design-bus-addressing.md §201). Class: LEGACY-BLOCK / R4.
+  # RETIRE: v3.0.0 legacy-reader deletion + myelin R4 cut.
+  '\boperator\.id\b'
+  '\braw\.operator\b'
+  '\bhasOperator\b'
+  '\bnetwork\.operator\b'
+  'operator:[[:space:]]*z\.object'              # R7 held network.operator block schema
+  'operator:.*→.*principal:|`operator:`→`principal:`'  # R3 transition prose
+  # `operator` POLICY CAPABILITY / authz-role literal in prose — "is this
+  # principal an operator?" decisions consult the PolicyEngine `operator`
+  # capability (CONTEXT.md MC authorization role). Class: AUTHZ-ROLE (kept).
+  'an operator\?|`operator`[[:space:]]*(capability|role)'
+  "'operator',?[[:space:]]*'code-reviewer'"     # role-id example string (cortex-config.ts)
+  # Legacy federated-peer `operator_*` keys (R2.G reader) — the cortex-config.ts
+  # acceptLegacyPeer reader prose/code naming the deprecated `operator_*` peer
+  # keys it rewrites to `principal_*`. Same class as the cloud `operatorId`
+  # reader. RETIRE: v3.0.0 cut. (`operator_pubkey`/`operator_id` tokens already
+  # covered; this catches the `operator_*` glob prose.)
+  'operator_\*'
+  'operator\*Id'                                # removed-field glob prose (loader.ts:452)
+  # Config-shape detection prose naming the legacy `operator:` block alongside
+  # the canonical `principal:` key (loader.ts detectConfigShape). LEGACY-BLOCK.
+  'principal/operator'
+  # Policy authz-role literal appearing in NON-policy test fixtures (bus/runner
+  # dispatch tests): `role: ["operator"]`, `id: "operator"`, `role("operator"`.
+  '(role|roles|id|capability|allow)[^A-Za-z]{1,4}["(]operator'
+  # Authz-role literal in YAML config EXAMPLES (cortex-config.ts header doc,
+  # design-soma-integration.md policy block): `role: [operator]` / `roles: [operator]`
+  # — the MC/policy authorization role (CONTEXT.md #513), kept. Bracket-list form
+  # the quoted pattern above misses. Class: AUTHZ-ROLE.
+  '\broles?:[[:space:]]*\[operator'
   # (2/4) GROVE_* env tier (separate migration).
   'GROVE_OPERATOR'
   'GROVE_[A-Z]'
@@ -191,6 +364,11 @@ path_is_allowlisted() {
 GATED_TEST_PATHS=(
   'src/bus/myelin/__tests__/envelope-validator.test.ts'
   'src/bus/myelin/__tests__/runtime.test.ts'
+  # R4/R10/R11 transition-shim symmetry suite — asserts principalFromConfig and
+  # principalFromEnvelope agree across the shim era. Uses `operatorId` as the
+  # subscribe-side config-id local var (the held legacy name the shim resolves).
+  # RETIRE: with the #81 myelin re-pin (R4/R10/R11 breaking cut).
+  'src/bus/myelin/__tests__/runtime-principal-symmetry.test.ts'
 )
 path_is_gated_test() {
   local path="$1" entry

--- a/scripts/check-carveouts.sh
+++ b/scripts/check-carveouts.sh
@@ -136,10 +136,13 @@ ALLOWLIST_PATHS=(
   # term, not the vocab. Single-purpose filter-grammar file.
   'src/bus/payload-filter.ts'
   'src/bus/__tests__/payload-filter.test.ts'
-  # R3 dual-block-guard: this test NAMES the legacy `operator:` config key on
-  # purpose to verify the transition guard (retires with the breaking cut).
-  # Sibling to the migrate-config legacy-reader tests already allowlisted.
+  # R2.I/R3 transition tests: loader.test.ts NAMES the legacy cloud `operatorId`
+  # and the flat `api.operatorId` reader on purpose (now flipped to rejection
+  # assertions); watcher.test.ts fixtures carry the flat `api.operatorId` slot
+  # (carve-out #3 legacy `api` block). Siblings to the migrate-config legacy-reader
+  # tests already allowlisted. Class: LEGACY-READER fixtures.
   'src/common/config/__tests__/loader.test.ts'
+  'src/common/config/__tests__/watcher.test.ts'
   # NSC trust/signing infrastructure — `operator` = the NATS account operator
   # (cortex#76 trust anchor): OperatorVerifier, verifyOperator, operator pubkey,
   # SA/SO/SU seed hierarchy. Platform term throughout these files.
@@ -223,24 +226,61 @@ CARVEOUT_LINE_PATTERNS=(
   # held R7 wire fields; rename waits for the myelin {org}→{principal} cut.
   'operator(DiscordId|MattermostId|SlackId|PlatformIds|Role|RoleId)'
   # ── LEGACY config-key tokens (R2.D/R2.I/R2.G + cortex#429 PR-C) ────────────
-  # The R2 identifier rename (operatorId/operator_id/operator_pubkey/operatorName
-  # → principalId/principal_id/principal_pubkey) is COMPLETE on main: there is no
-  # live canonical declaration of these tokens anywhere (verified — every surviving
-  # site is either a back-compat reader that still ACCEPTS the legacy key, a
-  # removed-field reference, or a legacy-migration test fixture). These tokens are
-  # therefore, by construction, the deprecated-alias class — same family as the
-  # already-allowlisted migrate-config-lib reader. Matching the token here carves
-  # the transitional readers (config.ts `acceptLegacyCloudPrincipalId`, loader.ts
-  # `buildLegacyNetwork`, cortex-config.ts legacy-peer reader, watcher.ts
-  # removed-field list, cortex.ts/runtime.ts PR-C comments) + the `.bot.yaml` /
-  # boot-test fixtures that feed them.
-  # RETIRE: when the breaking v3.0.0 cut deletes the legacy readers (manifest
-  # PR-11) — at which point these tokens vanish from the tree and the pattern is
-  # dead. A NEW genuine `operatorId` cannot appear because the canonical key is
-  # `principalId`; if one ever does it is a regression caught at code review, not
-  # by this gate (the gate's job here is the transitional window only).
-  'operator(Id|Name)\b'
-  '\boperator_id\b'
+  # v4.0.0 BREAKING CUT (#536) — the transition-era legacy config-key READERS are
+  # GONE: cloud `operatorId` (config.ts `acceptLegacyCloudPrincipalId`), federated
+  # `operator_id`/`operator_pubkey` (cortex-config.ts `acceptLegacyFederatedPeerPrincipal`),
+  # and the top-level `operator:` block (loader.ts `DualBlockConflictError`) are all
+  # deleted, and the cloud/peer schemas are `.strict()` canonical-only. `operatorId`
+  # is therefore FULLY RATCHETED: the bare token-global carve (`operator(Id|Name)\b`,
+  # `\boperator_id\b`) has been REMOVED so a fresh `operatorId` in a NEW src/ file
+  # FAILS the gate. The narrow patterns below carve only the genuine SURVIVORS, each
+  # anchored to its distinctive non-principal context:
+  #
+  #   (a) the flat `api.operatorId` bot.yaml LEGACY READER (carve-out #3) — the
+  #       in-loader sibling of migrate-config-lib: reads an old bot.yaml's flat
+  #       `api.operatorId` and rewrites it to the canonical cloud `principalId`.
+  #       Its source file (loader.ts) + the watcher fixtures that feed the `api`
+  #       block are path-allowlisted below; the single schema-slot declaration in
+  #       config.ts is line-carved here.
+  #   (b) HISTORICAL prose describing the v3-REMOVED PR-C fields — always the
+  #       dotted `agent.operatorId` / `config.agent.operatorId` / `agent.operatorName`
+  #       (and slash-compounds) accessor form. A new genuine field declaration is
+  #       never written as a dotted `agent.`-prefixed accessor in a comment.
+  #   (c) the `operatorId → principalId` / `operator_id → principal_id` RENAME-MAP
+  #       prose (cloud.ts emitter doc, cloud-publisher comment, migration DDL prose)
+  #       — documents WHAT was renamed; carries an explicit rename arrow.
+  #
+  # GROVE `payload.operator_id` (event-processor) keeps its own pattern below; NSC
+  # `operator_pubkey` / `operator-mode` keep theirs; the frozen `idx_sessions_operator`
+  # DDL keeps its own.
+  # (a) flat `api.operatorId` legacy-reader schema slot (config.ts:447 declaration +
+  #     reader/fixture lines). The bare `api.operatorId` accessor + the lone
+  #     `operatorId: z.string().default("")` slot.
+  '\bapi\.operatorId\b'
+  'operatorId:[[:space:]]*z\.string\(\)\.default\(""\)'
+  'agent\.operatorId'                                       # (b) bot.yaml legacy accessor + PR-C prose
+  # (b) HISTORICAL prose describing the removed PR-C `agent.operator*` fields —
+  # the dotted accessor form (incl. `config.agent.operatorId`, `agent.operatorName`,
+  # `agent.operatorId/operatorName`, `agent.operatorId/Discord`).
+  'agent\.operator(Id|Name)'
+  'operatorId/(operatorName|Discord)'
+  # (c) RENAME-MAP prose carrying an explicit arrow: `operatorId → principalId`,
+  # `operator_id → principal_id`, `operator_id` → `principal_id` (DDL prose).
+  'operator(Id|_id)[^A-Za-z]{0,4}(→|->)[^A-Za-z]{0,4}principal'
+  # (c) misc kept rename-map / emitter doc prose that names the legacy cloud
+  # `operatorId:` key it no longer writes, + the dashboard `operatorId` wiring note,
+  # + the `expect(...).not.toContain("operatorId:")` assertion guarding the emitter.
+  'legacy `operatorId:`'
+  'operatorId:"'
+  'dashboard.{0,3}`?operatorId'
+  # Backtick-QUOTED config-key reference in prose/JSDoc — `operatorId` /
+  # `operatorId:` naming the v4-REMOVED cloud key (config.ts cut docstring,
+  # NetworkConfig doc, api-reader comment). A fresh genuine field declaration is
+  # never backtick-quoted; this only carves prose that NAMES the removed key.
+  '`operatorId:?`'
+  # frozen-DDL prose: `sessions.operator_id` / `tasks.operator_id` (migration 0004
+  # rename note in types.ts + the DDL file itself, already path-allowlisted).
+  '(sessions|tasks|github_events|usage_snapshots)\.operator_id'
   # Frozen D1 index identifier — `idx_sessions_operator` is KEPT as the index
   # name in migration 0004 even though its column was renamed to `principal_id`
   # (renaming a live index name is churn with no benefit). A frozen DDL
@@ -254,8 +294,14 @@ CARVEOUT_LINE_PATTERNS=(
   # src/common/policy/resolve-access.ts (already path-allowlisted); the adapter
   # call sites (discord/mattermost/slack) import it. "is this principal the
   # operator (MC authorization role)?" per CONTEXT.md MC-role. Class: AUTHZ-ROLE.
+  # Stays a GLOBAL carve — it's the policy authz predicate, not a principal id.
   'isOperatorPrincipal'
-  '\bisOperator\b'
+  # Adapter-local `isOperator(authorId)` method (mattermost/slack adapters) — the
+  # per-adapter "is this author the MC-authorization-role operator?" check. Class:
+  # AUTHZ-ROLE, path-scoped to the method-call form so a bare `isOperator`
+  # IDENTIFIER outside the adapter method can't free-ride. The bare token-global
+  # `\bisOperator\b` carve was REMOVED with the v4.0.0 cut.
+  'isOperator\('
   # R4 rename-map PROSE — design/code lines that DOCUMENT the myelin-gated
   # `operator.id` → `principal.id` / `Identity.operator` → `.network` rename by
   # NAMING the pre-rename field. Renaming the token here would destroy the

--- a/src/__tests__/cortex.capability-boot.test.ts
+++ b/src/__tests__/cortex.capability-boot.test.ts
@@ -53,7 +53,6 @@ function minimalConfig(overrides: Partial<Record<string, unknown>> = {}): AgentC
     agent: {
       name: "test-cortex",
       displayName: "TestCortex",
-      operatorId: "test-op",
     },
     discord: [],
     mattermost: [],

--- a/src/__tests__/cortex.review-consumer-boot.test.ts
+++ b/src/__tests__/cortex.review-consumer-boot.test.ts
@@ -57,7 +57,6 @@ function minimalConfig(overrides: Partial<Record<string, unknown>> = {}): AgentC
     agent: {
       name: "test-cortex",
       displayName: "TestCortex",
-      operatorId: "test-op",
     },
     discord: [],
     mattermost: [],

--- a/src/__tests__/cortex.review-session-opts.test.ts
+++ b/src/__tests__/cortex.review-session-opts.test.ts
@@ -25,7 +25,6 @@ function configWith(claudeOverrides: Partial<AgentConfig["claude"]>): AgentConfi
     agent: {
       name: "test-cortex",
       displayName: "TestCortex",
-      operatorId: "test-op",
     },
     discord: [],
     mattermost: [],

--- a/src/__tests__/cortex.stack-signing-boot.test.ts
+++ b/src/__tests__/cortex.stack-signing-boot.test.ts
@@ -38,7 +38,6 @@ function minimalConfig(): AgentConfig {
     agent: {
       name: "test-cortex",
       displayName: "TestCortex",
-      operatorId: "test-op",
     },
     discord: [],
     mattermost: [],

--- a/src/__tests__/cortex.test.ts
+++ b/src/__tests__/cortex.test.ts
@@ -49,7 +49,6 @@ function minimalConfig(overrides: Partial<Record<string, unknown>> = {}): AgentC
     agent: {
       name: "test-cortex",
       displayName: "TestCortex",
-      operatorId: "test-op",
     },
     discord: [],
     mattermost: [],

--- a/src/__tests__/review-roundtrip.integration.test.ts
+++ b/src/__tests__/review-roundtrip.integration.test.ts
@@ -75,8 +75,6 @@ function makeConfig(url: string): AgentConfig {
     agent: {
       name: "cortex",
       displayName: "Cortex",
-      operatorId: "test-op",
-      operatorName: "Test Operator",
       dataResidency: "NZ",
     },
     nats: {

--- a/src/bus/__tests__/dispatch-handler.test.ts
+++ b/src/bus/__tests__/dispatch-handler.test.ts
@@ -200,7 +200,7 @@ describe("DispatchHandler", () => {
 
   describe("principal notification", () => {
     test("non-principal triggers notification", async () => {
-      // user1 is not operator1, so notification should fire
+      // user1 is not principal1, so notification should fire
       await router.handleMessage(adapter, makeMsg({
         platform: "discord",
         authorId: "user999",
@@ -220,7 +220,7 @@ describe("DispatchHandler", () => {
       // on `msg.dmType === "principal"`.
       await router.handleMessage(adapter, makeMsg({
         platform: "discord",
-        authorId: "operator1",
+        authorId: "principal1",
         content: "/help",
         isDM: true,
         dmType: "principal",

--- a/src/bus/myelin/__tests__/runtime-principal-symmetry.test.ts
+++ b/src/bus/myelin/__tests__/runtime-principal-symmetry.test.ts
@@ -22,19 +22,19 @@ import { createSystemAdapterDegradedEvent } from "../../system-events";
 
 describe("MyelinRuntime — subscribe/publish {principal} symmetry (cortex#130 item 1)", () => {
   test("principalFromConfig and principalFromEnvelope agree for stack-emitted envelopes", () => {
-    const operatorId = "metafactory";
+    const principalId = "metafactory";
     const envelope = createSystemAdapterDegradedEvent({
-      source: { principal: operatorId, agent: "cortex", instance: "local" },
+      source: { principal: principalId, agent: "cortex", instance: "local" },
       adapterId: "discord-1",
       platform: "discord",
       disconnectedSince: new Date("2026-05-16T10:00:00.000Z"),
       thresholdMs: 60_000,
     });
 
-    expect(principalFromConfig(operatorId)).toBe(principalFromEnvelope(envelope));
+    expect(principalFromConfig(principalId)).toBe(principalFromEnvelope(envelope));
   });
 
-  test("principalFromConfig falls back to 'default' when operatorId is undefined", () => {
+  test("principalFromConfig falls back to 'default' when principalId is undefined", () => {
     expect(principalFromConfig(undefined)).toBe("default");
   });
 
@@ -53,16 +53,16 @@ describe("MyelinRuntime — subscribe/publish {principal} symmetry (cortex#130 i
   });
 
   test("symmetry holds when principal changes — second stack identity", () => {
-    const operatorId = "the-metafactory";
+    const principalId = "the-metafactory";
     const envelope = createSystemAdapterDegradedEvent({
-      source: { principal: operatorId, agent: "echo", instance: "local" },
+      source: { principal: principalId, agent: "echo", instance: "local" },
       adapterId: "discord-1",
       platform: "discord",
       disconnectedSince: new Date("2026-05-16T10:00:00.000Z"),
       thresholdMs: 60_000,
     });
 
-    expect(principalFromConfig(operatorId)).toBe(principalFromEnvelope(envelope));
+    expect(principalFromConfig(principalId)).toBe(principalFromEnvelope(envelope));
     expect(principalFromEnvelope(envelope)).toBe("the-metafactory");
   });
 });

--- a/src/bus/myelin/envelope-validator.ts
+++ b/src/bus/myelin/envelope-validator.ts
@@ -626,11 +626,11 @@ export function principalFromEnvelope(envelope: Envelope): string {
  * for the symmetric publish-side helper and the invariant they jointly
  * preserve.
  *
- * Falls back to `"default"` when `operatorId` is unset — matches the
+ * Falls back to `"default"` when `principalId` is unset — matches the
  * legacy inline expression at runtime.ts subscribe-site.
  */
-export function principalFromConfig(operatorId: string | undefined): string {
-  return operatorId ?? "default";
+export function principalFromConfig(principalId: string | undefined): string {
+  return principalId ?? "default";
 }
 
 export function deriveNatsSubject(envelope: Envelope, stack?: string): string {

--- a/src/cli/cortex/commands/cloud.ts
+++ b/src/cli/cortex/commands/cloud.ts
@@ -544,7 +544,7 @@ async function cloudSetup(flags: Record<string, string>): Promise<void> {
 // cloud add-principal
 // =============================================================================
 
-async function cloudAddOperator(flags: Record<string, string>): Promise<void> {
+async function cloudAddPrincipal(flags: Record<string, string>): Promise<void> {
   const name = flags.name;
   const agentName = flags["agent-name"];
   const endpoint = flags.endpoint;
@@ -1035,7 +1035,7 @@ export async function runCloudCommand(argv: string[]): Promise<void> {
       await cloudSetup(flags);
       break;
     case "add-principal":
-      await cloudAddOperator(flags);
+      await cloudAddPrincipal(flags);
       break;
     case "status":
       await cloudStatus(flags);

--- a/src/common/config/__tests__/loader.test.ts
+++ b/src/common/config/__tests__/loader.test.ts
@@ -185,14 +185,14 @@ describe("legacy fallback", () => {
 });
 
 // ---------------------------------------------------------------------------
-// R2.I (cortex#436) — cloud `operatorId` → `principalId` BREAKING-CONFIG
-// transition. The canonical key is `principalId`; the legacy `operatorId`
-// cloud key is still accepted on load (rewritten + deprecation-warned),
-// so existing user network files / cortex.yaml don't break. Mirrors the R3
-// top-level operator:→principal: accept-both pattern.
+// R2.I (cortex#436) — cloud `operatorId` → `principalId` v4.0.0 BREAKING CUT.
+// The canonical (and only) key is `principalId`. The legacy `operatorId` cloud
+// alias accepted during the transition release is GONE: a cloud block carrying
+// `operatorId` is now rejected as an unknown key (strict object). Principals
+// run `cortex migrate-config` to rewrite a legacy `operatorId:`-shaped config.
 // ---------------------------------------------------------------------------
 
-describe("R2.I cloud principalId transition", () => {
+describe("R2.I cloud principalId — v4.0.0 breaking cut", () => {
   test("canonical cloud `principalId` loads", () => {
     const configPath = writeCentralConfig(testDir, minimalCentral());
     writeNetworkFile(testDir, "alpha.yaml", {
@@ -209,9 +209,9 @@ describe("R2.I cloud principalId transition", () => {
     expect(alpha?.cloud?.principalId).toBe("andreas");
   });
 
-  test("LEGACY cloud `operatorId` still loads and is rewritten to `principalId`", () => {
-    // A pre-R2.I network file written by an existing user — the deprecated
-    // `operatorId:` cloud key MUST keep loading.
+  test("LEGACY cloud `operatorId` is now REJECTED (unknown key)", () => {
+    // A pre-v4 network file carrying the deprecated `operatorId:` cloud key
+    // no longer loads — the strict schema rejects the unknown key.
     const configPath = writeCentralConfig(testDir, minimalCentral());
     writeNetworkFile(testDir, "legacy.yaml", {
       id: "legacy",
@@ -222,15 +222,12 @@ describe("R2.I cloud principalId transition", () => {
       },
     });
 
-    const config = loadConfig(configPath);
-    const legacy = config.networks.find((n) => n.id === "legacy");
-    // Legacy key is accepted and surfaced under the canonical field.
-    expect(legacy?.cloud?.principalId).toBe("andreas-legacy");
-    // The deprecated key is NOT carried through on the validated type.
-    expect((legacy?.cloud as Record<string, unknown> | undefined)?.operatorId).toBeUndefined();
+    expect(() => loadConfig(configPath)).toThrow();
   });
 
-  test("declaring BOTH `principalId` and legacy `operatorId` in a cloud block is rejected", () => {
+  test("a cloud block carrying BOTH `principalId` and legacy `operatorId` is rejected (unknown key)", () => {
+    // Previously a dual-key conflict; under the strict canonical-only schema
+    // the legacy alias is simply an unknown key.
     const configPath = writeCentralConfig(testDir, minimalCentral());
     writeNetworkFile(testDir, "conflict.yaml", {
       id: "conflict",
@@ -242,7 +239,7 @@ describe("R2.I cloud principalId transition", () => {
       },
     });
 
-    expect(() => loadConfig(configPath)).toThrow(/BOTH `principalId`.*`operatorId`/s);
+    expect(() => loadConfig(configPath)).toThrow();
   });
 });
 
@@ -357,7 +354,7 @@ describe("error reporting", () => {
 // returns the rich agents[] alongside via `inlineAgents` so `startCortex`
 // can route per-instance identity correctly.
 
-import { loadConfigWithAgents, DualBlockConflictError } from "../loader";
+import { loadConfigWithAgents } from "../loader";
 
 describe("MIG-7.2e — cortex-shape detection + transform", () => {
   function writeCortexConfig(dir: string, config: Record<string, unknown>): string {
@@ -821,49 +818,41 @@ describe("MIG-7.2e — cortex-shape detection + transform", () => {
     expect(loaded.principal?.discordId).toBe("285727653603049472");
   });
 
-  // v3.0.0 BREAKING (manifest PR-11) — cortex.yaml requires the
-  // canonical `principal:` key. The dual-block trust-boundary guard
-  // (`DualBlockConflictError`) is RETAINED: a config carrying BOTH
-  // `principal:` and `operator:` is still rejected with
-  // `dual_field_conflict` before any membership / capability decision.
-  // Legacy `operator:`-only configs no longer load via this path;
-  // operators rewrite via `cortex migrate-config <config.yaml>`.
+  // v4.0.0 BREAKING CUT — cortex.yaml requires the canonical `principal:`
+  // key. The legacy top-level `operator:` block reader is GONE, and with it
+  // the transition-era dual-block guard (`DualBlockConflictError`): there is
+  // no longer an `operator:` reader for a `principal:` block to be ambiguous
+  // against. A stray `operator:` key is now just an unrecognised top-level
+  // key — ignored when the config is otherwise cortex-shape, and a steer
+  // toward `cortex migrate-config` when an `operator:`-only config falls
+  // through to the legacy bot.yaml path.
 
-  test("v3 BREAKING — rejects a cortex.yaml carrying BOTH `principal:` and `operator:` with dual_field_conflict", () => {
-    // Trust-boundary regression: a hand-edited config mid-migration that
-    // kept the old block while adding the new one MUST be rejected, not
-    // silently resolved to one block.
+  test("v4 BREAKING — a `principal:`-shaped config with a stray `operator:` key still loads (operator block ignored)", () => {
+    // No dual-block conflict at v4: the `operator:` reader was removed, so
+    // the leftover key is inert. The principal id is sole-sourced from the
+    // canonical `principal:` block.
     const cfg = minimalCortexPrincipalShape();
     cfg.operator = { id: "someone-else", discordId: "999" };
     const path = writeCortexConfig(testDir, cfg);
 
-    expect(() => loadConfigWithAgents(path)).toThrow(DualBlockConflictError);
-    expect(() => loadConfigWithAgents(path)).toThrow(/dual|BOTH/i);
+    const loaded = loadConfigWithAgents(path);
+    expect(loaded.inlineAgents).toHaveLength(1);
+    // The canonical principal wins; the legacy `operator:` block does not
+    // override or shadow it.
+    expect(loaded.principal?.id).toBe("jc");
   });
 
-  test("v3 BREAKING — the dual-block error carries the `dual_field_conflict` code", () => {
-    const cfg = minimalCortexPrincipalShape();
-    cfg.operator = { id: "someone-else" };
-    const path = writeCortexConfig(testDir, cfg);
-    try {
-      loadConfigWithAgents(path);
-      throw new Error("expected loadConfigWithAgents to throw");
-    } catch (e) {
-      expect(e).toBeInstanceOf(DualBlockConflictError);
-      expect((e as DualBlockConflictError).code).toBe("dual_field_conflict");
-    }
-  });
-
-  test("v3 BREAKING — dual-block conflict fires even when `agents:` is absent (trust boundary, not shape-gated)", () => {
-    // The conflict is a deployment-config trust boundary — it must surface
-    // regardless of whether the rest of the config is structurally
-    // cortex-shape. A config with both blocks and no agents must not
-    // fall through to the legacy bot.yaml path.
+  test("v4 BREAKING — a legacy `operator:`-only cortex.yaml no longer loads as cortex-shape", () => {
+    // Pre-v4 this might have resolved via the `operator:` reader. With the
+    // reader gone, an `operator:`-block-only config is NOT cortex-shape
+    // (no canonical `principal:` block), so it falls through to the legacy
+    // bot.yaml path — where, lacking any valid bot.yaml fields, it is
+    // rejected. The principal must run `cortex migrate-config`.
     const cfg: Record<string, unknown> = {
-      principal: { id: "jc" },
       operator: { id: "jc" },
+      agents: minimalCortex().agents,
     };
     const path = writeCortexConfig(testDir, cfg);
-    expect(() => loadConfigWithAgents(path)).toThrow(DualBlockConflictError);
+    expect(() => loadConfigWithAgents(path)).toThrow();
   });
 });

--- a/src/common/config/loader.ts
+++ b/src/common/config/loader.ts
@@ -150,75 +150,30 @@ function isZodLikeError(err: unknown): err is ZodLikeError {
 }
 
 /**
- * R3 vocabulary migration (cortex#388) v3.0.0 BREAKING — typed error
- * raised when a single `cortex.yaml` carries BOTH a legacy `operator:`
- * block AND the canonical `principal:` block.
+ * R3 vocabulary migration (cortex#388) — v4.0.0 BREAKING CUT. Resolve the
+ * principal block from a cortex-shape config. cortex.yaml requires the
+ * canonical `principal:` key; the legacy top-level `operator:` block reader
+ * is GONE. A config still carrying an `operator:` block is no longer
+ * recognised as cortex-shape — it falls through to the bot.yaml-shape
+ * detection path and the principal is steered toward `cortex migrate-config`,
+ * which continues to read legacy `operator:`-shaped input.
  *
- * The trust-boundary contract from v2.x is preserved at v3: a config
- * declaring two principal blocks is ambiguous and MUST be rejected
- * before any membership / capability decision. v3 drops the
- * legacy-only acceptance path (principals upgrading from v2.x run
- * `cortex migrate-config <config.yaml>` to delete the old block), but
- * the dual-block rejection stays — a hand-edited config that kept the
- * old block while adding the new one must surface the conflict
- * loudly rather than be silently resolved.
- */
-export class DualBlockConflictError extends Error {
-  /** Stable discriminator for programmatic handling by callers / tests. */
-  public readonly code = "dual_field_conflict" as const;
-
-  constructor(message: string) {
-    super(message);
-    this.name = "DualBlockConflictError";
-  }
-}
-
-/**
- * R3 vocabulary migration (cortex#388) v3.0.0 BREAKING — resolve the
- * principal block from a cortex-shape config. cortex.yaml now requires
- * the canonical `principal:` key; the legacy `operator:`-only path was
- * removed at v3.0.0 (manifest PR-11). Principals upgrading from v2.x run
- * `cortex migrate-config <config.yaml>` to rewrite their config — the
- * migrate-config CLI continues to read legacy `operator:`-shaped input
- * (historical record per cortex#388 completion-signal allow-list).
- *
- * Trust-boundary rule: if BOTH `principal:` and `operator:` keys are
- * present (a hand-edited config mid-migration that kept the old block
- * while adding the new one), raise `DualBlockConflictError` — the
- * ambiguous config must surface rather than silently resolve to one
- * block before any membership / capability decision.
+ * The transition-era dual-block guard (`DualBlockConflictError`, raised when
+ * a config carried BOTH `principal:` and a legacy `operator:` block) retired
+ * with this cut: there is no longer an `operator:` reader to be ambiguous
+ * against.
  */
 function resolvePrincipalBlock(
   raw: Record<string, unknown>,
 ): Record<string, unknown> | undefined {
-  const hasPrincipal =
-    raw.principal !== null && typeof raw.principal === "object";
-  const hasOperator =
-    raw.operator !== null && typeof raw.operator === "object";
-
-  if (hasPrincipal && hasOperator) {
-    throw new DualBlockConflictError(
-      "cortex.yaml declares BOTH a `principal:` block and a legacy " +
-        "`operator:` block. v3.0.0 BREAKING (manifest PR-11) — the " +
-        "`operator:` block is no longer a valid cortex.yaml key, but a " +
-        "config declaring both is a deployment-config trust boundary and " +
-        "is rejected before any membership / capability decision is made. " +
-        "Delete the legacy `operator:` block (run `cortex migrate-config " +
-        "<your-config.yaml>` to regenerate a clean `principal:`-shaped " +
-        "config).",
-    );
+  if (raw.principal !== null && typeof raw.principal === "object") {
+    return raw.principal as Record<string, unknown>;
   }
-
-  if (hasPrincipal) return raw.principal as Record<string, unknown>;
   return undefined;
 }
 
 function isCortexShape(raw: Record<string, unknown>): boolean {
-  // v3.0.0 BREAKING — cortex.yaml requires the canonical `principal:`
-  // key. A config still carrying the legacy `operator:` block falls
-  // through to the bot.yaml-shape detection path, where it is loaded
-  // by the migrate-config-compatible legacy reader and the principal
-  // is steered toward `cortex migrate-config`.
+  // v4.0.0 BREAKING — cortex.yaml requires the canonical `principal:` key.
   return (
     resolvePrincipalBlock(raw) !== undefined &&
     Array.isArray(raw.agents) &&
@@ -437,8 +392,8 @@ function loadCortexShape(
   // id; per-instance routing flows via `inlineAgents` so the multi-agent
   // case stays correct.
   //
-  // cortex#429 PR-C — `operatorId` and `operatorName` synthesis retired
-  // alongside the schema fields. Downstream consumers (cortex.ts,
+  // cortex#429 PR-C — `agent.operatorId` and `agent.operatorName` synthesis
+  // retired alongside the schema fields. Downstream consumers (cortex.ts,
   // myelin runtime) now read the principal identity directly from
   // `LoadedConfig.principal.id` (returned below) and the helpers that
   // accept it as a parameter.

--- a/src/common/config/watcher.ts
+++ b/src/common/config/watcher.ts
@@ -65,7 +65,6 @@ const SAFE_FIELDS = new Set([
 
   // Agent identity
   "agent.displayName",
-  "agent.operatorName",
 ]);
 
 /**

--- a/src/common/policy/__tests__/factory.test.ts
+++ b/src/common/policy/__tests__/factory.test.ts
@@ -18,7 +18,6 @@ import { policyEngineFromConfig } from "../factory";
 import { PolicyEngine } from "../engine";
 import {
   PolicySchema,
-  FederatedPeerPrincipalConflictError,
   type Policy,
 } from "../../types/cortex-config";
 
@@ -980,13 +979,11 @@ describe("PolicyFederatedSchema cross-validation", () => {
   });
 });
 
-describe("PolicyFederatedPeerSchema — R2.G operator→principal accept-both transition (cortex#436)", () => {
-  // Legacy peer keys (`operator_id` / `operator_pubkey`) are still
-  // accepted on load and rewritten to the canonical
-  // `principal_id` / `principal_pubkey` by
-  // `acceptLegacyFederatedPeerPrincipal`. Federation is pre-launch, so
-  // this transition is cheap insurance + parity with the R2.I cloud
-  // block. Removed in the breaking release.
+describe("PolicyFederatedPeerSchema — R2.G operator→principal v4.0.0 BREAKING CUT (cortex#436)", () => {
+  // The legacy peer keys (`operator_id` / `operator_pubkey`) accepted
+  // during the transition release are GONE. The schema is now a strict
+  // canonical-only object: a peer declaring an `operator_*` key is
+  // rejected as an unknown key. Parity with the R2.I cloud-block cut.
   function parsePeer(peer: Record<string, unknown>) {
     return PolicySchema.parse({
       federated: {
@@ -1011,32 +1008,23 @@ describe("PolicyFederatedPeerSchema — R2.G operator→principal accept-both tr
     expect(peer?.principal_pubkey).toBe(PEER_PUBKEY_A);
   });
 
-  test("legacy operator_id / operator_pubkey are rewritten to canonical", () => {
-    const policy = parsePeer({
-      operator_id: "alpha",
-      stack_id: "alpha/main",
-      operator_pubkey: PEER_PUBKEY_A,
-    });
-    const peer = policy.federated?.networks[0]?.peers[0];
-    // The parsed (canonical) shape carries no `operator_*` keys.
-    expect(peer?.principal_id).toBe("alpha");
-    expect(peer?.principal_pubkey).toBe(PEER_PUBKEY_A);
-    expect((peer as Record<string, unknown>).operator_id).toBeUndefined();
-    expect((peer as Record<string, unknown>).operator_pubkey).toBeUndefined();
+  test("legacy operator_id key is now REJECTED (unknown key, breaking cut)", () => {
+    // A pre-v4 peer block carrying the deprecated `operator_id` /
+    // `operator_pubkey` keys no longer loads — the strict schema rejects
+    // the unknown keys. (No `principal_id` is supplied, so the canonical
+    // field is also absent; either way the parse fails.)
+    expect(() =>
+      parsePeer({
+        operator_id: "alpha",
+        stack_id: "alpha/main",
+        operator_pubkey: PEER_PUBKEY_A,
+      }),
+    ).toThrow();
   });
 
-  test("mixed legacy id + canonical pubkey both rewrite/pass cleanly", () => {
-    const policy = parsePeer({
-      operator_id: "alpha",
-      stack_id: "alpha/main",
-      principal_pubkey: PEER_PUBKEY_A,
-    });
-    const peer = policy.federated?.networks[0]?.peers[0];
-    expect(peer?.principal_id).toBe("alpha");
-    expect(peer?.principal_pubkey).toBe(PEER_PUBKEY_A);
-  });
-
-  test("BOTH principal_id and operator_id present → dual-key conflict throws", () => {
+  test("a stray operator_id ALONGSIDE the canonical keys is REJECTED (unknown key)", () => {
+    // Previously this was a dual-key conflict; under the strict
+    // canonical-only schema the legacy alias is simply an unknown key.
     expect(() =>
       parsePeer({
         principal_id: "alpha",
@@ -1044,10 +1032,10 @@ describe("PolicyFederatedPeerSchema — R2.G operator→principal accept-both tr
         stack_id: "alpha/main",
         principal_pubkey: PEER_PUBKEY_A,
       }),
-    ).toThrow(FederatedPeerPrincipalConflictError);
+    ).toThrow();
   });
 
-  test("BOTH principal_pubkey and operator_pubkey present → dual-key conflict throws", () => {
+  test("a stray operator_pubkey ALONGSIDE the canonical keys is REJECTED (unknown key)", () => {
     expect(() =>
       parsePeer({
         principal_id: "alpha",
@@ -1055,18 +1043,17 @@ describe("PolicyFederatedPeerSchema — R2.G operator→principal accept-both tr
         principal_pubkey: PEER_PUBKEY_A,
         operator_pubkey: PEER_PUBKEY_A,
       }),
-    ).toThrow(FederatedPeerPrincipalConflictError);
+    ).toThrow();
   });
 
-  test("legacy keys still cross-validate (stack_id prefix vs rewritten principal_id)", () => {
-    // The rewrite happens before cross-validation, so a drifted
-    // legacy `operator_id` is caught by the same prefix check that
-    // guards the canonical field.
+  test("canonical keys still cross-validate (stack_id prefix vs principal_id)", () => {
+    // A drifted `principal_id` (whose prefix doesn't match `stack_id`)
+    // is caught by the document-level prefix check.
     expect(() =>
       parsePeer({
-        operator_id: "jcfischer",
+        principal_id: "jcfischer",
         stack_id: "evil-actor/sage-host",
-        operator_pubkey: PEER_PUBKEY_A,
+        principal_pubkey: PEER_PUBKEY_A,
       }),
     ).toThrow(/must start with peer\.principal_id/);
   });

--- a/src/common/substrates/types.ts
+++ b/src/common/substrates/types.ts
@@ -35,7 +35,7 @@
  *     Codex harness would see `["exec"]`. Cortex stays out of the
  *     translation business. See `ToolCapability` doc.
  *   - **Q1 (stack identity).** `agent.id` accepts a string today; the
- *     `{operator_id}/{stack_id}` shape is enforced by cortex.yaml's
+ *     `{principal_id}/{stack_id}` shape is enforced by cortex.yaml's
  *     `stack:` block in Phase A.5 — not at this protocol layer. A.1 only
  *     needs the type to *carry* the identity.
  *   - **Q5 (streaming subject convention).** `DispatchRequest.requestId`

--- a/src/common/types/__tests__/capability.test.ts
+++ b/src/common/types/__tests__/capability.test.ts
@@ -35,7 +35,7 @@ import { CortexConfigSchema } from "../cortex-config";
 // Fixture helpers (mirror the patterns in stack.test.ts + cortex-config.test.ts)
 // =============================================================================
 
-function minOperator() {
+function minPrincipal() {
   return { id: "andreas" };
 }
 
@@ -60,7 +60,7 @@ function minAgent(overrides: Record<string, unknown> = {}) {
 
 function minConfig(overrides: Record<string, unknown> = {}) {
   return {
-    principal: minOperator(),
+    principal: minPrincipal(),
     agents: [minAgent()],
     claude: {},
     ...overrides,

--- a/src/common/types/__tests__/cortex-config.test.ts
+++ b/src/common/types/__tests__/cortex-config.test.ts
@@ -518,7 +518,7 @@ describe("AgentConfigSchema.nats.accountSigningKeyPath (MIRROR)", () => {
   /** Minimal AgentConfig shell to exercise the optional `nats` block. */
   function minAgentConfig(natsExtras: Record<string, unknown> = {}) {
     return {
-      agent: { name: "test", displayName: "Test", operatorId: "op" },
+      agent: { name: "test", displayName: "Test" },
       discord: [],
       mattermost: [],
       claude: { timeoutMs: 1000 },

--- a/src/common/types/__tests__/cortex-config.test.ts
+++ b/src/common/types/__tests__/cortex-config.test.ts
@@ -45,7 +45,7 @@ import {
  */
 const VALID_NKEY = "U" + "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUVZ"; // 1 + 55 = 56
 
-function minOperator() {
+function minPrincipal() {
   return { id: "andreas" };
 }
 
@@ -70,7 +70,7 @@ function minAgent(overrides: Record<string, unknown> = {}) {
 
 function minConfig() {
   return {
-    principal: minOperator(),
+    principal: minPrincipal(),
     agents: [minAgent()],
     claude: {},
   };

--- a/src/common/types/__tests__/stack.test.ts
+++ b/src/common/types/__tests__/stack.test.ts
@@ -33,7 +33,7 @@ import {
 
 const VALID_NKEY = "U" + "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMNOPQRSTUVZ"; // U + 55
 
-function minOperator() {
+function minPrincipal() {
   return { id: "andreas" };
 }
 
@@ -58,7 +58,7 @@ function minAgent(overrides: Record<string, unknown> = {}) {
 
 function minConfig(overrides: Record<string, unknown> = {}) {
   return {
-    principal: minOperator(),
+    principal: minPrincipal(),
     agents: [minAgent()],
     claude: {},
     ...overrides,

--- a/src/common/types/config.ts
+++ b/src/common/types/config.ts
@@ -179,98 +179,20 @@ function normalizeToArray(val: unknown): unknown {
 /**
  * Cloud endpoint configuration for a network.
  *
- * R2.I vocabulary migration (cortex#436) — BREAKING-CONFIG with a
- * backward-compatible transition. The canonical principal-identity key is
- * `principalId`. The legacy `operatorId` key is still accepted on load so
- * existing `cortex.yaml` / `networks/*.yaml` files keep working; it is
- * rewritten to `principalId` by `acceptLegacyCloudPrincipalId` and emits a
- * one-time deprecation warning. This mirrors the R3 top-level
- * `operator:`→`principal:` transition (accept-both + deprecate; see
- * `src/common/config/loader.ts` `resolvePrincipalBlock`).
- *
- * Trust-boundary rule (R3 parity): a single cloud block declaring BOTH
- * `principalId` and `operatorId` is ambiguous and is rejected, rather than
- * silently resolving to one — a hand-edited config mid-migration must
- * surface the conflict loudly.
+ * R2.I vocabulary migration (cortex#436) — v4.0.0 BREAKING CUT. The canonical
+ * (and only) principal-identity key is `principalId`. The legacy `operatorId`
+ * cloud alias that was accepted during the transition release is gone: a block
+ * declaring `operatorId` is now rejected as an unknown key (strict object), the
+ * same as any other typo. Run `cortex migrate-config <your-config.yaml>` to
+ * rewrite a legacy `operatorId:`-shaped config to `principalId:`.
  */
-const NetworkCloudObjectSchema = z.object({
+export const NetworkCloudSchema = z.object({
   endpoint: z.string().min(1),
   apiKey: z.string().min(1),
   principalId: z.string().min(1),
   cfAccessClientId: z.string().optional(),
   cfAccessClientSecret: z.string().optional(),
-});
-
-/**
- * Pre-parse rewriter: accept the legacy cloud `operatorId` key as an alias of
- * the canonical `principalId`. Runs as a `z.preprocess` BEFORE
- * `NetworkCloudObjectSchema` validates, so the legacy key never reaches the
- * (deliberately `operatorId`-free) object schema.
- *
- * - canonical only (`principalId`)              → pass through verbatim
- * - legacy only (`operatorId`)                  → rewrite to `principalId`, warn once
- * - BOTH present                                → throw (dual-key conflict, R3 parity)
- * - neither                                     → pass through; object schema's
- *                                                 `principalId.min(1)` surfaces the
- *                                                 missing-key error with the canonical name
- */
-/**
- * Thrown when a network cloud block declares BOTH `principalId` and the legacy
- * `operatorId` alias. Carries a stable `code` discriminator (parity with the
- * top-level R3 `DualBlockConflictError` — kept as a separate class here because
- * `loader.ts` imports this module, so importing its error back would be circular).
- */
-export class CloudPrincipalIdConflictError extends Error {
-  readonly code = "dual_field_conflict";
-  constructor(message: string) {
-    super(message);
-    this.name = "CloudPrincipalIdConflictError";
-  }
-}
-
-let warnedLegacyCloudPrincipalId = false;
-export function acceptLegacyCloudPrincipalId(raw: unknown): unknown {
-  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) return raw;
-  const obj = raw as Record<string, unknown>;
-  // `!= null` (not `!== undefined`) so a valueless YAML `operatorId:` / `principalId:`
-  // line (which parses to null) is NOT treated as a live key — avoids a spurious
-  // dual-key rejection or rewrite for an empty alias line.
-  const hasCanonical = obj.principalId != null;
-  const hasLegacy = obj.operatorId != null;
-
-  if (hasCanonical && hasLegacy) {
-    throw new CloudPrincipalIdConflictError(
-      "network cloud block declares BOTH `principalId` (canonical) and the " +
-        "legacy `operatorId` key. R2.I (cortex#436) BREAKING-CONFIG — the " +
-        "`operatorId` cloud key is deprecated but still accepted as an alias; " +
-        "a block declaring both is ambiguous and is rejected before any " +
-        "event-attribution decision. Delete the legacy `operatorId` line " +
-        "(run `cortex migrate-config <your-config.yaml>` to regenerate a " +
-        "clean `principalId:`-shaped config).",
-    );
-  }
-
-  if (hasLegacy) {
-    if (!warnedLegacyCloudPrincipalId) {
-      warnedLegacyCloudPrincipalId = true;
-      console.warn(
-        "config: network cloud `operatorId:` is deprecated (R2.I, cortex#436) — " +
-          "rename it to `principalId:`. The legacy key is still accepted for now " +
-          "and rewritten on load; run `cortex migrate-config <your-config.yaml>` " +
-          "to update your config. This warning prints once per process.",
-      );
-    }
-    const { operatorId, ...rest } = obj;
-    return { ...rest, principalId: operatorId };
-  }
-
-  return raw;
-}
-
-export const NetworkCloudSchema = z.preprocess(
-  acceptLegacyCloudPrincipalId,
-  NetworkCloudObjectSchema,
-);
+}).strict();
 
 /** Per-network Claude security overrides */
 export const NetworkClaudeSchema = z.object({

--- a/src/common/types/cortex-config.ts
+++ b/src/common/types/cortex-config.ts
@@ -1213,12 +1213,12 @@ export const PolicyPrincipalSchema = z.object({
     "principal.home_principal must match the principal id grammar (lowercase alphanumeric + hyphen, starting with a letter)",
   ),
   /**
-   * Stack identity in `{operator_id}/{stack_id}` form — same shape
+   * Stack identity in `{principal_id}/{stack_id}` form — same shape
    * as `StackConfigSchema.id` (Phase A.5).
    */
   home_stack: z.string().regex(
     /^[a-z][a-z0-9_-]*\/[a-z][a-z0-9_-]*$/,
-    "principal.home_stack must match {operator_id}/{stack_id} format",
+    "principal.home_stack must match {principal_id}/{stack_id} format",
   ),
   /**
    * Stack signing NKey public key. **Declared at C.2a for forward

--- a/src/common/types/cortex-config.ts
+++ b/src/common/types/cortex-config.ts
@@ -1355,17 +1355,15 @@ export type PolicyRole = z.infer<typeof PolicyRoleSchema>;
  * lands in D.2/D.3; the schema lands first so principals can declare
  * their federation topology before the verification path is live.
  *
- * R2.G vocabulary migration (cortex#436) — the canonical peer-identity
- * keys are `principal_id` / `principal_pubkey`. The legacy
- * `operator_id` / `operator_pubkey` keys are still accepted on load
- * (rewritten by `acceptLegacyFederatedPeerPrincipal` with a one-time
- * deprecation warning) so any hand-written federation block keeps
- * working through the transition. Federation is pre-launch so the risk
- * is low; accept-both is cheap insurance and keeps the peer block
- * consistent with the R2.I cloud-block transition
- * (`acceptLegacyCloudPrincipalId` in `config.ts`).
+ * R2.G vocabulary migration (cortex#436) — v4.0.0 BREAKING CUT. The
+ * canonical (and only) peer-identity keys are `principal_id` /
+ * `principal_pubkey`. The legacy `operator_id` / `operator_pubkey`
+ * aliases that were accepted during the transition release are gone: a
+ * peer block declaring either is now rejected as an unknown key (strict
+ * object), the same as any other typo. Consistent with the R2.I
+ * cloud-block breaking cut in `config.ts`.
  */
-const PolicyFederatedPeerObjectSchema = z.object({
+export const PolicyFederatedPeerSchema = z.object({
   /**
    * Peer principal id — same letter-prefix grammar as `PrincipalConfigSchema.id`.
    * Distinct from the principal's local id; the local principal's id
@@ -1399,89 +1397,7 @@ const PolicyFederatedPeerObjectSchema = z.object({
     NKEY_PUBKEY_REGEX,
     "peer.principal_pubkey must be a base32 NKey public key (U-prefixed, 56 chars total)",
   ),
-});
-
-/**
- * Thrown when a federated peer block declares BOTH a canonical key
- * (`principal_id` / `principal_pubkey`) and its legacy alias
- * (`operator_id` / `operator_pubkey`). Carries a stable `code`
- * discriminator (parity with `CloudPrincipalIdConflictError` from the
- * R2.I cloud-block transition).
- */
-export class FederatedPeerPrincipalConflictError extends Error {
-  readonly code = "dual_field_conflict";
-  constructor(message: string) {
-    super(message);
-    this.name = "FederatedPeerPrincipalConflictError";
-  }
-}
-
-let warnedLegacyFederatedPeerPrincipal = false;
-/**
- * Pre-parse rewriter: accept the legacy peer keys `operator_id` /
- * `operator_pubkey` as aliases of the canonical `principal_id` /
- * `principal_pubkey`. Runs as a `z.preprocess` BEFORE
- * `PolicyFederatedPeerObjectSchema` validates, so the legacy keys
- * never reach the (deliberately `operator_*`-free) object schema.
- * Mirrors `acceptLegacyCloudPrincipalId` (R2.I) but covers two fields.
- *
- * Per field:
- *   - canonical only            → pass through verbatim
- *   - legacy only               → rewrite to the canonical key, warn once
- *   - BOTH present              → throw (dual-key conflict, R3/R2.I parity)
- *   - neither                   → pass through; the object schema's
- *                                 `.regex(...)` surfaces the missing-key
- *                                 error under the canonical name
- */
-export function acceptLegacyFederatedPeerPrincipal(raw: unknown): unknown {
-  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) return raw;
-  const obj = raw as Record<string, unknown>;
-
-  // `!= null` (not `!== undefined`) so a valueless YAML key line
-  // (parses to null) is NOT treated as a live key — avoids a spurious
-  // dual-key rejection or rewrite for an empty alias line.
-  const hasCanonicalId = obj.principal_id != null;
-  const hasLegacyId = obj.operator_id != null;
-  const hasCanonicalPubkey = obj.principal_pubkey != null;
-  const hasLegacyPubkey = obj.operator_pubkey != null;
-
-  if ((hasCanonicalId && hasLegacyId) || (hasCanonicalPubkey && hasLegacyPubkey)) {
-    const which = hasCanonicalId && hasLegacyId ? "principal_id`/`operator_id" : "principal_pubkey`/`operator_pubkey";
-    throw new FederatedPeerPrincipalConflictError(
-      "federated peer declares BOTH the canonical and legacy form of " +
-        "`" + which + "`. R2.G (cortex#436) — the `operator_*` peer keys " +
-        "are deprecated but still accepted as aliases; a peer declaring " +
-        "both forms of a field is ambiguous and is rejected before any " +
-        "federation-attribution decision. Delete the legacy `operator_*` " +
-        "line(s) and keep the `principal_*` form.",
-    );
-  }
-
-  if (hasLegacyId || hasLegacyPubkey) {
-    if (!warnedLegacyFederatedPeerPrincipal) {
-      warnedLegacyFederatedPeerPrincipal = true;
-      console.warn(
-        "config: federated peer `operator_id:` / `operator_pubkey:` are " +
-          "deprecated (R2.G, cortex#436) — rename them to `principal_id:` / " +
-          "`principal_pubkey:`. The legacy keys are still accepted for now " +
-          "and rewritten on load. This warning prints once per process.",
-      );
-    }
-    const { operator_id, operator_pubkey, ...rest } = obj;
-    return {
-      ...rest,
-      ...(hasLegacyId && { principal_id: operator_id }),
-      ...(hasLegacyPubkey && { principal_pubkey: operator_pubkey }),
-    };
-  }
-
-  return raw;
-}
-
-export const PolicyFederatedPeerSchema = z.preprocess(
-  acceptLegacyFederatedPeerPrincipal,
-  PolicyFederatedPeerObjectSchema,
-);
+}).strict();
 
 export type PolicyFederatedPeer = z.infer<typeof PolicyFederatedPeerSchema>;
 

--- a/src/common/types/stack.ts
+++ b/src/common/types/stack.ts
@@ -61,7 +61,7 @@ import { NKEY_PUBKEY_REGEX } from "./nkey";
  *     id: andreas/research
  *     nkey_pub: UA…
  *
- * The `id` regex enforces `{operator_id}/{stack_id}` where each segment is
+ * The `id` regex enforces `{principal_id}/{stack_id}` where each segment is
  * lowercase alphanumeric + hyphens/underscores, starting with a letter. Both
  * `PrincipalConfigSchema.id` and `StackConfigSchema.id` segments share the letter-
  * prefix rule (unified by cortex#141 before the IAW A.5.5 namespace cutover);
@@ -85,14 +85,14 @@ import { NKEY_PUBKEY_REGEX } from "./nkey";
  */
 export const StackConfigSchema = z.object({
   /**
-   * `{operator_id}/{stack_id}` — both segments lowercase, starting with a
+   * `{principal_id}/{stack_id}` — both segments lowercase, starting with a
    * letter, alphanumeric + hyphen/underscore. Embedded verbatim in NATS
    * subject segments once the myelin namespace extension (myelin#113)
    * lands, so the regex matches what a NATS subject can carry.
    */
   id: z.string().regex(
     /^[a-z][a-z0-9_-]*\/[a-z][a-z0-9_-]*$/,
-    "stack.id must match {operator_id}/{stack_id} format (lowercase alphanumeric + hyphens/underscores, each segment starts with letter)",
+    "stack.id must match {principal_id}/{stack_id} format (lowercase alphanumeric + hyphens/underscores, each segment starts with letter)",
   ),
   /**
    * Stack-level NKey public key (`U` + 55 base32 chars). Optional in

--- a/src/services/network-registry/src/signing.ts
+++ b/src/services/network-registry/src/signing.ts
@@ -48,7 +48,7 @@ export function canonicalJSON(value: unknown): string {
 }
 
 // =============================================================================
-// Base64 (URL-safe NOT used — operators paste standard base64)
+// Base64 (URL-safe NOT used — principals paste standard base64)
 // =============================================================================
 
 export function base64ToBytes(b64: string): Uint8Array<ArrayBuffer> {

--- a/src/settings/cortex-hooks.json
+++ b/src/settings/cortex-hooks.json
@@ -1,5 +1,5 @@
 {
-  "_comment": "Reference / operator-facing fallback for ~/.claude/settings.json. arc auto-registers these hooks from arc-manifest.yaml's provides.hooks during `arc install/upgrade Cortex` — do NOT manually merge this file into settings.json or hooks will double-fire. Paths here point at the INSTALLED symlinks (created by arc under ~/.claude/hooks/), matching what arc itself writes. Holly cortex#52 round 1 architecture findings #4 + #5.",
+  "_comment": "Reference / principal-facing fallback for ~/.claude/settings.json. arc auto-registers these hooks from arc-manifest.yaml's provides.hooks during `arc install/upgrade Cortex` — do NOT manually merge this file into settings.json or hooks will double-fire. Paths here point at the INSTALLED symlinks (created by arc under ~/.claude/hooks/), matching what arc itself writes. Holly cortex#52 round 1 architecture findings #4 + #5.",
   "hooks": {
     "SessionStart": [
       {

--- a/src/substrates/bus-peer/harness.ts
+++ b/src/substrates/bus-peer/harness.ts
@@ -110,7 +110,7 @@ export interface BusPeerHarnessOpts {
    * peers. The capability registry (Phase A.6) aggregates across all
    * harnesses; this list is what cortex sees from this harness.
    * Empty array is legal during scaffold work — the harness is
-   * structurally valid but operators won't actually dispatch tasks
+   * structurally valid but principals won't actually dispatch tasks
    * to it.
    */
   capabilities?: Capability[];
@@ -166,7 +166,7 @@ export class BusPeerHarness implements SessionHarness {
    *     sees the outbound request"; no synthetic terminal is emitted
    *     locally before the started yield. A future B.1c+ refinement
    *     could opt into the `await + synthetic failed-terminal`
-   *     pattern (Echo's option B on cortex#195) if operators want
+   *     pattern (Echo's option B on cortex#195) if principals want
    *     a louder failure surface, but at this slice we mirror the
    *     existing runtime contract.
    */

--- a/src/substrates/claude-code/harness.ts
+++ b/src/substrates/claude-code/harness.ts
@@ -106,7 +106,7 @@ import {
  * the warning every dispatch and the "once per harness instance" guarantee
  * was effectively never honoured under the production wiring. Module scope
  * keeps the latch durable across every harness construction in the
- * process, which matches what operators expect from a noise-suppression
+ * process, which matches what principals expect from a noise-suppression
  * warning. Reset is exposed for tests via `__resetWarnedNonUuidRequestId`.
  */
 let warnedNonUuidRequestId = false;


### PR DESCRIPTION
## What — the migration-closing PR

Lands the **camelCase-recall fix** (the root cause: `\b[Oo]perator\b` was blind to `operatorId`, so the R2 cluster was invisible — "gate=0" never meant done) and drives the gate to **0 whole-tree**, so the ratchet can finally protect the principal vocabulary.

- **Recall widened** `\b[Oo]perator\b` → `[Oo]perator` (catches camelCase/snake compounds)
- **Swept** the 6 genuine `{operator_id}/{stack_id}` stack-grammar prose + safe renames (`cloudAddOperator`→`cloudAddPrincipal`, `minOperator`→`minPrincipal`, principal-sense prose)
- **Carve-outs** (each with class label + retire-condition) for the legitimate residual: NSC operator-mode/signing tests, GROVE `payload.operator_id` (MIG-8), the HISTORICAL removed-field test (`options.operator.id`), legacy back-compat readers, R7 `operatorRole`, migration-examples, the myelin-gated R4/R10/R11 shim test (#81)

## Verification
gate **= 0** whole-tree · ratchet still **flags** a novel `operatorThingy` + bare `operator` prose (not neutered) · `tsc` clean · `bun test` **3675 pass / 0 fail**.

## ⚠️ Reviewer: please scrutinize the carve-out tightness
The `operator(Id|Name)\b` + `\boperator_id\b` patterns are **token-global** — they correctly carve today's residual (all legacy/GROVE/PR-C readers, since R2.D/I/G are merged) but would also mask a **future** `operatorId` regression. Defensible as temporary (retires when the legacy readers do), but flag if you think they should be **path-scoped** to the specific legacy files instead. I'll tighten per your call.

Closes the R2 cluster of #436. Remaining: cortex+pilot myelin re-pin (#81, lockstep deploy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)