### PR TITLE
feat(bus)!: re-pin myelin f5ec865 — drop R10/R11 wire shims (LOCKSTEP w/ pilot)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
         "@octokit/webhooks-methods": "^6.0.0",
         "@slack/socket-mode": "^2.0.7",
         "@slack/web-api": "^7.16.0",
-        "@the-metafactory/myelin": "https://github.com/the-metafactory/myelin.git#4c54b8e6e2157524099f4f01f13c044bcc3b9291",
+        "@the-metafactory/myelin": "https://github.com/the-metafactory/myelin.git#f5ec8658030e2fc185f123b06d8bf94d9f74cd84",
         "@xyflow/react": "^12.10.2",
         "ajv": "^8.20.0",
         "ajv-formats": "^3.0.1",
@@ -124,7 +124,7 @@
 
     "@slack/web-api": ["@slack/web-api@7.16.0", "", { "dependencies": { "@slack/logger": "^4.0.1", "@slack/types": "^2.21.0", "@types/node": ">=18", "@types/retry": "0.12.0", "axios": "^1.16.0", "eventemitter3": "^5.0.1", "form-data": "^4.0.4", "is-electron": "2.2.2", "is-stream": "^2", "p-queue": "^6", "p-retry": "^4", "retry": "^0.13.1" } }, "sha512-68SAV77uuGKuhyyaRytX8UijVnqSLsTSKslGXw17cjQYXn+jtNl7gbaEjHgC5x2rhCuFdahBrEC2VCLppbzReg=="],
 
-    "@the-metafactory/myelin": ["@the-metafactory/myelin@github:the-metafactory/myelin#4c54b8e", { "dependencies": { "@msgpack/msgpack": "^3.1.3", "@nats-io/jetstream": "^3.4.0", "@nats-io/kv": "^3.4.0", "@nats-io/transport-node": "^3.4.0", "@noble/ed25519": "^3.1.0", "ajv": "8.20.0", "ajv-formats": "3.0.1" } }, "the-metafactory-myelin-4c54b8e"],
+    "@the-metafactory/myelin": ["@the-metafactory/myelin@github:the-metafactory/myelin#f5ec865", { "dependencies": { "@msgpack/msgpack": "^3.1.3", "@nats-io/jetstream": "^3.4.0", "@nats-io/kv": "^3.4.0", "@nats-io/transport-node": "^3.4.0", "@noble/ed25519": "^3.1.0", "ajv": "8.20.0", "ajv-formats": "3.0.1" } }, "the-metafactory-myelin-f5ec865"],
 
     "@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
 

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@octokit/webhooks-methods": "^6.0.0",
     "@slack/socket-mode": "^2.0.7",
     "@slack/web-api": "^7.16.0",
-    "@the-metafactory/myelin": "https://github.com/the-metafactory/myelin.git#4c54b8e6e2157524099f4f01f13c044bcc3b9291",
+    "@the-metafactory/myelin": "https://github.com/the-metafactory/myelin.git#f5ec8658030e2fc185f123b06d8bf94d9f74cd84",
     "@xyflow/react": "^12.10.2",
     "ajv": "^8.20.0",
     "ajv-formats": "^3.0.1",

--- a/scripts/check-carveouts.sh
+++ b/scripts/check-carveouts.sh
@@ -400,21 +400,26 @@ path_is_allowlisted() {
   return 1
 }
 
-# ── myelin-GATED transition-test files (R5/R10/R11 back-compat regression
-#    suites). The bare fixture line `distribution_mode: "broadcast"` (R5) and
-#    `target_principal` / `signed_by[].principal` (R10/R11) fixture values in
-#    these files exercise the read-tolerance shim and carry no per-line marker,
-#    so they're suppressed here rather than by the line-pattern filter. These
-#    suites delete when the corresponding myelin breaking cut lands.
-#    Ref 0002 §R5 (envelope-validator.test.ts:333,339,396), §R10, §R11. ──
+# ── myelin-GATED transition-test files (R5 back-compat regression suite).
+#    The bare fixture line `distribution_mode: "broadcast"` (R5) in
+#    envelope-validator.test.ts exercises the read-tolerance shim and carries
+#    no per-line marker, so it's suppressed here rather than by the line-pattern
+#    filter. This entry deletes when the myelin R5/R11 `broadcast`→`offer`
+#    breaking cut lands (f5ec865 still ACCEPTS `broadcast` on read).
+#    Ref 0002 §R5 (envelope-validator.test.ts).
+#
+#    Removed at the #81 / cortex#436 myelin re-pin (4c54b8e → f5ec865, R10/R13
+#    breaking cut on `target_principal`):
+#      - runtime.test.ts — its R4 `{org}` substitution test retired with
+#        myelin#185 and it carries no broadcast-emit / target_principal /
+#        signed_by-principal fixture; the only deprecated-term hit is the
+#        historical `agent.operatorId/operatorName` comment, which the
+#        standalone `agent.operator(Id|Name)` line carve-out already covers.
+#      - runtime-principal-symmetry.test.ts — carries zero deprecated-term
+#        hits (all `principal:` refs are the canonical `source.principal`
+#        field), so it no longer needs file-level suppression. ──
 GATED_TEST_PATHS=(
   'src/bus/myelin/__tests__/envelope-validator.test.ts'
-  'src/bus/myelin/__tests__/runtime.test.ts'
-  # R4/R10/R11 transition-shim symmetry suite — asserts principalFromConfig and
-  # principalFromEnvelope agree across the shim era. Uses `operatorId` as the
-  # subscribe-side config-id local var (the held legacy name the shim resolves).
-  # RETIRE: with the #81 myelin re-pin (R4/R10/R11 breaking cut).
-  'src/bus/myelin/__tests__/runtime-principal-symmetry.test.ts'
 )
 path_is_gated_test() {
   local path="$1" entry

--- a/src/__tests__/iaw-phase-d-integration.test.ts
+++ b/src/__tests__/iaw-phase-d-integration.test.ts
@@ -470,15 +470,15 @@ describe("IAW Phase D.6.1 — cross-operator federated dispatch + reply (refs co
 
       // β's audit also preserves α's signed_by[] chain verbatim
       // (C.4.3 invariant). One stamp originally from α; α's DID on it.
-      // R2 (vocabulary migration 2026-05) — dual-read stamp DID:
-      // canonical `identity` wins; fall back to deprecated `principal`
-      // for pre-migration / JetStream-replayed stamps.
+      // R11 (vocabulary migration 2026-05, breaking cut myelin#182) — the
+      // stamp DID is `identity` only; the deprecated `principal` key was
+      // dropped from the wire and is rejected by the envelope schema.
       const auditSignedBy = (
-        betaAllowed!.payload as { signed_by?: { identity?: string; principal?: string }[] }
+        betaAllowed!.payload as { signed_by?: { identity?: string }[] }
       ).signed_by;
       expect(auditSignedBy).toBeDefined();
       expect(auditSignedBy!.length).toBeGreaterThanOrEqual(1);
-      expect(auditSignedBy![0]?.identity ?? auditSignedBy![0]?.principal).toBe(alpha.signerPrincipalDid);
+      expect(auditSignedBy![0]?.identity).toBe(alpha.signerPrincipalDid);
 
       // ─── β's reply is re-signed with β's stack key + replayed ────
       // The dispatch-listener publishes the harness's terminal envelope

--- a/src/bus/myelin/__tests__/envelope-validator.test.ts
+++ b/src/bus/myelin/__tests__/envelope-validator.test.ts
@@ -311,7 +311,7 @@ describe("envelope-validator — F-021 task envelope fields (IAW Phase A.2)", ()
       sovereignty_required: "strict",
       deadline: "2026-06-01T00:00:00Z",
       distribution_mode: "direct",
-      target_principal: "did:mf:echo",
+      target_assistant: "did:mf:echo",
     };
     const result = validateEnvelope(env);
     expect(result.ok).toBe(true);
@@ -319,7 +319,7 @@ describe("envelope-validator — F-021 task envelope fields (IAW Phase A.2)", ()
       expect(result.envelope.requirements).toEqual(["code-review", "typescript"]);
       expect(result.envelope.sovereignty_required).toBe("strict");
       expect(result.envelope.distribution_mode).toBe("direct");
-      expect(result.envelope.target_principal).toBe("did:mf:echo");
+      expect(result.envelope.target_assistant).toBe("did:mf:echo");
       expect(result.envelope.deadline).toBe("2026-06-01T00:00:00Z");
     }
   });
@@ -347,20 +347,35 @@ describe("envelope-validator — F-021 task envelope fields (IAW Phase A.2)", ()
     expect(result.ok).toBe(true);
   });
 
-  test("rejects a direct envelope missing target_principal", () => {
+  test("rejects a direct envelope missing target_assistant", () => {
     const env = {
       ...(validEnvelope as object),
       distribution_mode: "direct",
-      // target_principal: missing — schema cross-field rule rejects
+      // target_assistant: missing — schema cross-field rule rejects
     };
     const result = validateEnvelope(env);
     expect(result.ok).toBe(false);
   });
 
-  test("rejects a delegate envelope missing target_principal", () => {
+  test("rejects a delegate envelope missing target_assistant", () => {
     const env = {
       ...(validEnvelope as object),
       distribution_mode: "delegate",
+    };
+    const result = validateEnvelope(env);
+    expect(result.ok).toBe(false);
+  });
+
+  test("rejects a direct envelope that carries the dropped target_principal key (R13 breaking cut)", () => {
+    // Vocabulary migration 2026-05 R13 / myelin#184 — `target_principal`
+    // was removed from the wire. The schema's `additionalProperties: false`
+    // now rejects any envelope that still carries it, even when a valid
+    // `target_assistant` is also present.
+    const env = {
+      ...(validEnvelope as object),
+      distribution_mode: "direct",
+      target_assistant: "did:mf:echo",
+      target_principal: "did:mf:echo",
     };
     const result = validateEnvelope(env);
     expect(result.ok).toBe(false);
@@ -379,17 +394,17 @@ describe("envelope-validator — F-021 task envelope fields (IAW Phase A.2)", ()
     const env = {
       ...(validEnvelope as object),
       distribution_mode: "multicast",
-      target_principal: "did:mf:echo",
+      target_assistant: "did:mf:echo",
     };
     const result = validateEnvelope(env);
     expect(result.ok).toBe(false);
   });
 
-  test("rejects a target_principal that is not a DID", () => {
+  test("rejects a target_assistant that is not a DID", () => {
     const env = {
       ...(validEnvelope as object),
       distribution_mode: "direct",
-      target_principal: "echo@example.com",
+      target_assistant: "echo@example.com",
     };
     const result = validateEnvelope(env);
     expect(result.ok).toBe(false);
@@ -417,7 +432,7 @@ describe("envelope-validator — F-021 task envelope fields (IAW Phase A.2)", ()
     if (result.ok) {
       expect(result.envelope.requirements).toBeUndefined();
       expect(result.envelope.distribution_mode).toBeUndefined();
-      expect(result.envelope.target_principal).toBeUndefined();
+      expect(result.envelope.target_assistant).toBeUndefined();
     }
   });
 
@@ -586,16 +601,18 @@ describe("envelope-validator — chain helpers (IAW Phase A.2)", () => {
     // The transition schema accepts BOTH the deprecated and the renamed
     // form so pre-migration / JetStream-replayed envelopes still validate.
     //
-    // cortex#452 / PR-R11 — bumped 9fc8476 → 4c54b8e (myelin main post-#184)
-    // to land the breaking cut on stamp DIDs: `signed_by[].principal` is no
-    // longer accepted on the wire (the deprecated key is now rejected as
-    // `additionalProperties`). The vendored schema picks up the v3 `$id`
-    // (`/schemas/envelope/v3`) and the source-grammar tightening to the
-    // fixed-3 form `{principal}.{stack}.{assistant}` (myelin#183). The
-    // matching cortex-side reader shim drop ships here per
-    // docs/migrations/0002-vocabulary-finish-2026-05.md §PR-R11.
+    // cortex#436 / cortex#81 / PR-R10 — bumped 4c54b8e → f5ec865 (myelin
+    // main post-#184) to land the breaking cut on the routing target field:
+    // `target_principal` is no longer accepted on the wire (the deprecated
+    // key is now rejected as `additionalProperties`); direct/delegate
+    // envelopes must carry `target_assistant`. This is a lockstep companion
+    // to the earlier signed_by[].principal cut (R11). The vendored schema
+    // tracks f5ec865 structurally (verified identical to the npm dep's
+    // schema). The matching cortex-side reader shim drop (getTargetAssistant
+    // no longer dual-reads) ships here per
+    // docs/migrations/0002-vocabulary-finish-2026-05.md §R10.
     expect(SCHEMA_SOURCE_COMMIT).toBe(
-      "4c54b8e6e2157524099f4f01f13c044bcc3b9291",
+      "f5ec8658030e2fc185f123b06d8bf94d9f74cd84",
     );
   });
 

--- a/src/bus/myelin/envelope-validator.ts
+++ b/src/bus/myelin/envelope-validator.ts
@@ -47,7 +47,8 @@
  *   - `signed_by` accepts a single stamp OR a chain (`SignedBy[]`) per
  *     myelin#31. `getSignedByChain()` normalises both shapes into an array.
  *   - `requirements`, `sovereignty_required`, `deadline`,
- *     `distribution_mode`, `target_principal` per F-021.
+ *     `distribution_mode`, `target_assistant` per F-021 (the field was
+ *     `target_principal` at the A.2 baseline; renamed R13 / myelin#184).
  *   - `economics` upgraded to F-15 typed shape (`budget` / `actual` /
  *     `wallet` / `billing_ref` / `currency`), still optional and not
  *     security-bearing per myelin architecture.md §5.2.
@@ -75,7 +76,7 @@ import schema from "./vendor/envelope.schema.json" with { type: "json" };
  * comments + tests use `myelin#161` to point at the merge that landed the
  * feature — they're the same change, different ticket facets.
  */
-export const SCHEMA_SOURCE_COMMIT = "4c54b8e6e2157524099f4f01f13c044bcc3b9291";
+export const SCHEMA_SOURCE_COMMIT = "f5ec8658030e2fc185f123b06d8bf94d9f74cd84";
 
 /**
  * Hand-typed Envelope shape matching the JSON Schema. We hand-write rather
@@ -170,17 +171,11 @@ export interface Envelope {
   /**
    * F-021 — required when `distribution_mode` is `direct` or `delegate`.
    * DID of the receiving assistant (`did:mf:<name>`). Vocabulary migration
-   * 2026-05 R13 renamed from `target_principal`; the transition schema
-   * accepts both names — readers should prefer `target_assistant` and
-   * fall back to `target_principal` via {@link getTargetAssistant}.
+   * 2026-05 R13 (breaking cut myelin#184) renamed from `target_principal`;
+   * the deprecated key was dropped from the wire — envelopes carrying it
+   * are rejected by the schema. Resolve via {@link getTargetAssistant}.
    */
   target_assistant?: string;
-  /**
-   * @deprecated Renamed to `target_assistant` (vocabulary migration
-   * 2026-05, R13). Pre-migration envelopes carry this key; accepted on
-   * read through the transition window. Removed in the breaking major.
-   */
-  target_principal?: string;
   /**
    * myelin#161 — policy-level actor identity, separate from the
    * cryptographic `signed_by[]` chain. The chain proves WHO signed; the
@@ -255,18 +250,11 @@ export interface SignedByEd25519 {
   method: "ed25519";
   /**
    * Stamp DID — `did:mf:<name>` per myelin convention. Vocabulary
-   * migration 2026-05 R2 — canonical key is `identity`; the transition
-   * schema accepts `principal` too. Readers should use
-   * {@link getLastStampPrincipal} or {@link stampIdentityDid} which
-   * dual-read.
+   * migration 2026-05 R2 (breaking cut myelin#182): canonical key is
+   * `identity`; the deprecated `principal` key was dropped from the wire
+   * — stamps carrying it are rejected by the schema.
    */
   identity?: string;
-  /**
-   * @deprecated Renamed to `identity` (vocabulary migration 2026-05, R2).
-   * Pre-migration / JetStream-replayed stamps carry this key; accepted
-   * on read through the transition window. Removed in the breaking major.
-   */
-  principal?: string;
   /** Base64-encoded ed25519 signature (88+ chars). */
   signature: string;
   /** ISO-8601 timestamp the signature was produced. */
@@ -284,15 +272,11 @@ export interface SignedByHubStamp {
   method: "hub-stamp";
   /**
    * Originating identity — `did:mf:<name>`. Vocabulary migration 2026-05
-   * R2 — canonical key is `identity`; transition schema accepts both.
+   * R2 (breaking cut myelin#182): canonical key is `identity`; the
+   * deprecated `principal` key was dropped from the wire — stamps
+   * carrying it are rejected by the schema.
    */
   identity?: string;
-  /**
-   * @deprecated Renamed to `identity` (vocabulary migration 2026-05, R2).
-   * Pre-migration / JetStream-replayed stamps carry this key; accepted
-   * on read through the transition window. Removed in the breaking major.
-   */
-  principal?: string;
   /** Hub identity that re-signed — `did:mf:<hub-name>`. */
   stamped_by: string;
   /** Base64-encoded ed25519 signature from the hub. */
@@ -515,17 +499,19 @@ export function getActorPrincipal(envelope: Envelope): string | undefined {
 }
 
 /**
- * Resolve the `target_assistant` of a Direct/Delegate envelope across the
- * R13 transition window (vocabulary migration 2026-05). Canonical key is
- * `target_assistant`; falls back to the deprecated `target_principal`
- * for pre-migration / JetStream-replayed envelopes.
+ * Resolve the `target_assistant` of a Direct/Delegate envelope.
  *
- * Returns `undefined` for envelopes that carry neither key (e.g. an
+ * Vocabulary migration 2026-05 R13 (breaking cut myelin#184): the
+ * deprecated `target_principal` key was dropped from the wire — the
+ * dual-read fallback has been retired per docs/migrations/
+ * 0002-vocabulary-finish-2026-05.md §R10. The schema now rejects any
+ * envelope that still carries `target_principal`.
+ *
+ * Returns `undefined` for envelopes that carry no target (e.g. an
  * Offer dispatch).
  */
 export function getTargetAssistant(envelope: Envelope): string | undefined {
-  // eslint-disable-next-line @typescript-eslint/no-deprecated
-  return envelope.target_assistant ?? envelope.target_principal;
+  return envelope.target_assistant;
 }
 
 /**

--- a/src/bus/myelin/vendor/envelope.schema.json
+++ b/src/bus/myelin/vendor/envelope.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://myelin.metafactory.ai/schemas/envelope/v3",
   "title": "Myelin Envelope",
-  "description": "Universal message envelope for the agentic nervous system. One schema for all signals — sovereignty travels with the message. v3 (vocabulary migration 2026-05, breaking cuts myelin#182 + myelin#183): `signed_by[].principal` → `identity` (myelin#182 — old key dropped from the wire) and `{org}` → `{principal}` with the `source` grammar tightened to the fixed-3 form `{principal}.{stack}.{assistant}` (myelin#183 — legacy 3–5 segment `org.agent.instance` shape no longer accepted; that was the shape the pilot review-loop bug exploited, see CONTEXT.md line 99). The schema still accepts the deprecated form for the remaining transition fields (originator, target_principal, distribution_mode broadcast) so pre-migration / JetStream-replayed envelopes validate; subsequent breaking cuts drop those. v2 stays published for consumers pinned to the transition grammar; v1 stays published for consumers pinned to the pre-migration grammar.",
+  "description": "Universal message envelope for the agentic nervous system. One schema for all signals — sovereignty travels with the message. v3 (vocabulary migration 2026-05, breaking cuts myelin#182 + myelin#183): `signed_by[].principal` → `identity` (myelin#182 — old key dropped from the wire) and `{org}` → `{principal}` with the `source` grammar tightened to the fixed-3 form `{principal}.{stack}.{assistant}` (myelin#183 — legacy 3–5 segment `org.agent.instance` shape no longer accepted; that was the shape the pilot review-loop bug exploited, see CONTEXT.md line 99). v3.0 (vocabulary migration 2026-05, breaking cut myelin#184): `target_principal` → `target_assistant` (R13 — old key dropped from the wire; direct/delegate envelopes carrying it are rejected by `additionalProperties: false`). The schema still accepts the deprecated form for the remaining transition fields (originator `principal`, distribution_mode `broadcast`) so pre-migration / JetStream-replayed envelopes validate; subsequent breaking cuts drop those. v2 stays published for consumers pinned to the transition grammar; v1 stays published for consumers pinned to the pre-migration grammar.",
   "type": "object",
   "required": ["id", "source", "type", "timestamp", "sovereignty", "payload"],
   "properties": {
@@ -171,12 +171,7 @@
     "target_assistant": {
       "type": "string",
       "pattern": "^did:mf:[a-z](?:[a-z0-9._]|-(?!-))+$",
-      "description": "F-021: required when distribution_mode is direct or delegate. DID of the receiving assistant. R13 (vocabulary migration 2026-05): renamed from 'target_principal'."
-    },
-    "target_principal": {
-      "type": "string",
-      "pattern": "^did:mf:[a-z](?:[a-z0-9._]|-(?!-))+$",
-      "description": "DEPRECATED (vocabulary migration 2026-05, R13) — renamed to 'target_assistant'. Accepted on read through the transition window for pre-migration / JetStream-replayed envelopes; an envelope carrying BOTH keys is rejected (dual_field_conflict). Removed in the breaking major."
+      "description": "F-021: required when distribution_mode is direct or delegate. DID of the receiving assistant — the @-target named assistant (the `@`-segment of a Tasks-Domain subject names an assistant, not a principal; see CONTEXT.md). R13 (vocabulary migration 2026-05, breaking cut): the deprecated 'target_principal' key was removed from the wire — envelopes carrying it are rejected by `additionalProperties: false`."
     },
     "originator": {
       "type": "object",
@@ -211,16 +206,7 @@
         "properties": { "distribution_mode": { "enum": ["direct", "delegate"] } },
         "required": ["distribution_mode"]
       },
-      "then": {
-        "anyOf": [
-          { "required": ["target_assistant"] },
-          { "required": ["target_principal"] }
-        ]
-      }
-    },
-    {
-      "comment": "R13 dual_field_conflict — direct/delegate routing target must not carry BOTH the deprecated and renamed key.",
-      "not": { "required": ["target_principal", "target_assistant"] }
+      "then": { "required": ["target_assistant"] }
     }
   ],
   "additionalProperties": false,

--- a/src/bus/verify-signed-by-chain.ts
+++ b/src/bus/verify-signed-by-chain.ts
@@ -317,12 +317,15 @@ export async function verifySignedByChain(
     // cortex's `Envelope` keeps the back-compat shim of single-stamp
     // OR array. Normalise here before handing off.
     //
-    // R2 (vocabulary migration 2026-05) — the cortex vendored SignedBy
-    // declares `identity?` AND `principal?` as optional so the transition
-    // window can carry either; upstream myelin's discriminated union
-    // requires exactly one. The runtime guarantee is identical (the
-    // envelope validator's `dual_field_conflict` check fires before this
-    // helper runs), so cast through `unknown` at the type boundary.
+    // R11 (vocabulary migration 2026-05, breaking cut myelin#182) — the
+    // cortex vendored SignedBy now declares `identity?` only (the
+    // deprecated `principal` stamp key was dropped from the wire). The
+    // residual cast through `unknown` bridges the remaining structural
+    // gap: cortex's `Envelope` keeps the single-stamp-OR-array shim on
+    // `signed_by` while upstream myelin's `signed_by` is array-only, and
+    // cortex's `SignedBy` marks `identity` optional (it is required at the
+    // schema layer, validated before this helper runs) where upstream's
+    // discriminated union requires it structurally.
     const myelinEnvelope = {
       ...envelope,
       signed_by: chain,


### PR DESCRIPTION
## What (#81 — cortex side)

Re-pins myelin `9fc8476`→`f5ec865` and removes the cortex dual-tolerance shims for the wire fields f5ec865 **cut**:
- **R10/R13** `target_principal` → dropped from `Envelope` type + vendored schema (+ `getTargetAssistant()` simplified; envelopes carrying it now rejected by `additionalProperties:false`)
- **R11** signed_by stamp `.principal` → dropped from `SignedByEd25519`/`SignedByHubStamp`

**Deliberately KEPT** (f5ec865 still accepts both on the wire — removing would break interop): **R2** `originator.principal` (dual-read via `getActorPrincipal`), **R5** `broadcast` distribution_mode. They retire in a later lockstep cut.

Vendored `src/bus/myelin/` (cortex's runtime source — 71 importers) synced; schema now byte-identical to f5ec865. De-gated the runtime/symmetry test suites.

## ⚠️ LOCKSTEP DEPLOY — do NOT merge+deploy alone
cortex now **rejects** `target_principal` + signed_by `.principal`. **Pilot must re-pin to f5ec865 and deploy together** (pilot PR incoming) or the live review-loop wire breaks. Both merge + `arc upgrade` as a pair.

## Verification
`tsc` clean · `bun test` **3674 pass / 0 fail** · vocab gate **0** · the `?? .principal` stamp reads removed; R2/R5 shims confirmed retained.

Closes the cortex half of #81.

🤖 Generated with [Claude Code](https://claude.com/claude-code)