### PR TITLE
feat(config): CFG.a — multi-file config composer + single-file fallback (#523)

### DIFF
--- a/src/common/config/__tests__/composer.test.ts
+++ b/src/common/config/__tests__/composer.test.ts
@@ -1,0 +1,297 @@
+/**
+ * IAW CFG.a — multi-file config composer tests.
+ *
+ * CFG.a is a config-INGESTION refactor: a directory layout
+ * (`system/system.yaml` + optional `network/*.yaml`, `surfaces/surfaces.yaml`,
+ * `stacks/*.yaml`) must compose to the SAME `LoadedConfig` the equivalent
+ * single `cortex.yaml` produces. These tests prove:
+ *
+ *   (a) round-trip identity — a split layout and the equivalent single file
+ *       yield deep-equal `LoadedConfig` (CFG.a.4 primary);
+ *   (b) the single-file fallback path is byte-identical to pre-CFG.a
+ *       (CFG.a.2);
+ *   (c) precedence/merge-order — later layers win on leaf keys, deep-merge of
+ *       nested objects, array-replace semantics (CFG.a.3);
+ *   (d) determinism + idempotency — composing twice yields the same object.
+ *
+ * Fixtures are small synthetic configs built in a tmp dir, NOT the real
+ * cortex.yaml — CFG.a only proves the composer *capability*; moving the real
+ * config into the layers is CFG.b/CFG.c.
+ */
+
+import { test, expect, describe, beforeEach, afterEach } from "bun:test";
+import { mkdirSync, writeFileSync, rmSync, existsSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { stringify } from "yaml";
+import { composeRawConfig, loadConfigWithAgents } from "../loader";
+
+let testDir: string;
+
+beforeEach(() => {
+  testDir = join(tmpdir(), `cortex-composer-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(testDir, { recursive: true });
+});
+
+afterEach(() => {
+  if (testDir && existsSync(testDir)) {
+    rmSync(testDir, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Fixture builders
+// ---------------------------------------------------------------------------
+
+/**
+ * A complete, valid cortex-shape config object. This is the single-file
+ * baseline; the split-layout fixtures below carve THIS object across the
+ * directory layers so the composed result must equal it exactly.
+ */
+function fullCortexConfig(): Record<string, unknown> {
+  return {
+    principal: {
+      id: "jc",
+      displayName: "Jens-Christian",
+      discordId: "285727653603049472",
+    },
+    claude: { timeoutMs: 300000 },
+    nats: {
+      url: "nats://127.0.0.1:4222",
+      identity: {
+        seedPath: "/tmp/cortex.nk",
+        publicKey: "UAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+      },
+    },
+    agents: [
+      {
+        id: "ivy",
+        displayName: "Ivy",
+        persona: "./personas/ivy.md",
+        roles: [],
+        trust: ["luna"],
+        presence: {
+          discord: {
+            token: "fake-token-ivy",
+            guildId: "1487023327791808592",
+            agentChannelId: "1487029848164536361",
+            logChannelId: "1487029942129524786",
+          },
+        },
+      },
+    ],
+  };
+}
+
+/** Write a single-file `cortex.yaml` in `dir`, return its path. */
+function writeSingleFile(dir: string, config: Record<string, unknown>): string {
+  const path = join(dir, "cortex.yaml");
+  writeFileSync(path, stringify(config));
+  return path;
+}
+
+/**
+ * Write a directory layout under `dir` carving `config` across layers, then
+ * return the conventional `cortex.yaml` path the caller passes (the marker
+ * file `system/system.yaml` is what actually selects the layout — the
+ * `cortex.yaml` path need not even exist).
+ */
+function writeLayout(dir: string, layers: {
+  system: Record<string, unknown>;
+  network?: Record<string, Record<string, unknown>>;
+  surfaces?: Record<string, unknown>;
+  stacks?: Record<string, Record<string, unknown>>;
+}): string {
+  mkdirSync(join(dir, "system"), { recursive: true });
+  writeFileSync(join(dir, "system", "system.yaml"), stringify(layers.system));
+
+  if (layers.network) {
+    mkdirSync(join(dir, "network"), { recursive: true });
+    for (const [name, body] of Object.entries(layers.network)) {
+      writeFileSync(join(dir, "network", name), stringify(body));
+    }
+  }
+  if (layers.surfaces) {
+    mkdirSync(join(dir, "surfaces"), { recursive: true });
+    writeFileSync(join(dir, "surfaces", "surfaces.yaml"), stringify(layers.surfaces));
+  }
+  if (layers.stacks) {
+    mkdirSync(join(dir, "stacks"), { recursive: true });
+    for (const [name, body] of Object.entries(layers.stacks)) {
+      writeFileSync(join(dir, "stacks", name), stringify(body));
+    }
+  }
+  return join(dir, "cortex.yaml");
+}
+
+// ---------------------------------------------------------------------------
+// CFG.a.4 (a) — round-trip identity: split layout == single file
+// ---------------------------------------------------------------------------
+
+describe("CFG.a.4 — round-trip identity (split layout composes to single-file LoadedConfig)", () => {
+  test("split layout and equivalent single file yield deep-equal LoadedConfig", () => {
+    const full = fullCortexConfig();
+
+    // Single-file baseline.
+    const singleDir = join(testDir, "single");
+    mkdirSync(singleDir, { recursive: true });
+    const singlePath = writeSingleFile(singleDir, full);
+
+    // Equivalent split layout: carve `full` across system + stacks. The
+    // principal + machine config live in system.yaml; the agents[] live in a
+    // stack file. Composed deep-merge must reconstruct `full` exactly.
+    const splitDir = join(testDir, "split");
+    mkdirSync(splitDir, { recursive: true });
+    const splitPath = writeLayout(splitDir, {
+      system: {
+        principal: full.principal,
+        claude: full.claude,
+        nats: full.nats,
+      },
+      stacks: {
+        "research.yaml": { agents: full.agents },
+      },
+    });
+
+    const single = loadConfigWithAgents(singlePath);
+    const split = loadConfigWithAgents(splitPath);
+
+    expect(split).toEqual(single);
+  });
+
+  test("composed raw object equals parsed single-file raw object", () => {
+    const full = fullCortexConfig();
+    const singleDir = join(testDir, "single");
+    mkdirSync(singleDir, { recursive: true });
+    const singlePath = writeSingleFile(singleDir, full);
+
+    const splitDir = join(testDir, "split");
+    mkdirSync(splitDir, { recursive: true });
+    const splitPath = writeLayout(splitDir, {
+      system: { principal: full.principal, claude: full.claude, nats: full.nats },
+      stacks: { "research.yaml": { agents: full.agents } },
+    });
+
+    expect(composeRawConfig(splitPath)).toEqual(composeRawConfig(singlePath));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CFG.a.2 — single-file fallback identity
+// ---------------------------------------------------------------------------
+
+describe("CFG.a.2 — single-file fallback", () => {
+  test("no directory layout → composeRawConfig reads the single file verbatim", () => {
+    const full = fullCortexConfig();
+    const path = writeSingleFile(testDir, full);
+    // No `system/system.yaml` marker → fallback. Raw equals the parsed file.
+    expect(composeRawConfig(path)).toEqual(full);
+  });
+
+  test("single-file fallback produces a fully-valid LoadedConfig", () => {
+    const full = fullCortexConfig();
+    const path = writeSingleFile(testDir, full);
+    const loaded = loadConfigWithAgents(path);
+    expect(loaded.inlineAgents).toHaveLength(1);
+    expect(loaded.inlineAgents[0]!.id).toBe("ivy");
+    expect(loaded.principal?.id).toBe("jc");
+    expect(loaded.config.nats?.url).toBe("nats://127.0.0.1:4222");
+  });
+
+  test("layout marker present → single cortex.yaml is NOT read (layout wins)", () => {
+    // Put a DIFFERENT, would-be-invalid single file alongside a valid layout.
+    // If the composer wrongly read cortex.yaml, the result would carry the
+    // decoy's marker key; the layout path must ignore it entirely.
+    writeSingleFile(testDir, { decoy: true });
+    const layoutPath = writeLayout(testDir, {
+      system: fullCortexConfig(),
+    });
+    const raw = composeRawConfig(layoutPath);
+    expect(raw.decoy).toBeUndefined();
+    expect((raw.principal as Record<string, unknown>).id).toBe("jc");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CFG.a.3 — precedence / merge-order + determinism + idempotency
+// ---------------------------------------------------------------------------
+
+describe("CFG.a.3 — precedence + deep-merge semantics", () => {
+  test("later layer wins on a scalar leaf key (stacks override system)", () => {
+    const path = writeLayout(testDir, {
+      system: { claude: { timeoutMs: 100 }, principal: { id: "jc" } },
+      stacks: { "z.yaml": { claude: { timeoutMs: 999 } } },
+    });
+    const raw = composeRawConfig(path);
+    // stacks layer is last → its leaf wins.
+    expect((raw.claude as Record<string, unknown>).timeoutMs).toBe(999);
+    // unmentioned leaf from the base survives the deep-merge.
+    expect((raw.principal as Record<string, unknown>).id).toBe("jc");
+  });
+
+  test("nested objects deep-merge rather than replace wholesale", () => {
+    const path = writeLayout(testDir, {
+      system: { nats: { url: "nats://base:4222", identity: { seedPath: "/a" } } },
+      stacks: { "s.yaml": { nats: { identity: { publicKey: "PUB" } } } },
+    });
+    const raw = composeRawConfig(path);
+    const nats = raw.nats as Record<string, unknown>;
+    const identity = nats.identity as Record<string, unknown>;
+    // url survives (only present in base); seedPath survives; publicKey added.
+    expect(nats.url).toBe("nats://base:4222");
+    expect(identity.seedPath).toBe("/a");
+    expect(identity.publicKey).toBe("PUB");
+  });
+
+  test("arrays replace wholesale (no element-wise merge)", () => {
+    const path = writeLayout(testDir, {
+      system: { agents: [{ id: "a" }, { id: "b" }] },
+      stacks: { "s.yaml": { agents: [{ id: "c" }] } },
+    });
+    const raw = composeRawConfig(path);
+    // stacks layer's array replaces the base array entirely.
+    expect(raw.agents).toEqual([{ id: "c" }]);
+  });
+
+  test("network layer sits between system and stacks (filename-sorted, deterministic)", () => {
+    const path = writeLayout(testDir, {
+      system: { k: "system", principal: { id: "jc" } },
+      network: { "01-a.yaml": { k: "net-a" }, "02-b.yaml": { k: "net-b" } },
+      stacks: { "s.yaml": {} },
+    });
+    const raw = composeRawConfig(path);
+    // Within the network layer, 02-b sorts after 01-a → net-b wins; no stack
+    // override of `k`, so the last network value persists.
+    expect(raw.k).toBe("net-b");
+  });
+
+  test("surfaces layer sits after network, before stacks", () => {
+    const path = writeLayout(testDir, {
+      system: { k: "system" },
+      network: { "n.yaml": { k: "net" } },
+      surfaces: { k: "surfaces" },
+      stacks: { "s.yaml": { other: 1 } },
+    });
+    // network → surfaces (later wins) → stacks doesn't touch `k`.
+    expect(composeRawConfig(path).k).toBe("surfaces");
+  });
+
+  test("composition is idempotent — composing twice yields an equal object", () => {
+    const path = writeLayout(testDir, {
+      system: fullCortexConfig(),
+      stacks: { "s.yaml": { claude: { timeoutMs: 1 } } },
+    });
+    const first = composeRawConfig(path);
+    const second = composeRawConfig(path);
+    expect(second).toEqual(first);
+  });
+
+  test("empty layer file contributes nothing to the merge", () => {
+    mkdirSync(join(testDir, "system"), { recursive: true });
+    writeFileSync(join(testDir, "system", "system.yaml"), stringify(fullCortexConfig()));
+    mkdirSync(join(testDir, "stacks"), { recursive: true });
+    writeFileSync(join(testDir, "stacks", "empty.yaml"), ""); // empty → {}
+    const raw = composeRawConfig(join(testDir, "cortex.yaml"));
+    expect((raw.principal as Record<string, unknown>).id).toBe("jc");
+  });
+});

--- a/src/common/config/loader.ts
+++ b/src/common/config/loader.ts
@@ -191,6 +191,160 @@ export function loadConfig(path: string): AgentConfig {
   return loadConfigWithAgents(path).config;
 }
 
+// =============================================================================
+// IAW CFG.a — multi-file config composer + transitional single-file fallback
+// =============================================================================
+//
+// CFG.a is a config-INGESTION refactor only: it builds the SAME `raw` object
+// `parseYaml(cortex.yaml)` produces, then feeds it through the existing
+// parse/build so `LoadedConfig` stays byte-identical. No consumer edits.
+//
+// Two ingestion paths, resolved deterministically by `composeRawConfig`:
+//
+//   1. Directory layout (CFG.a.1) — the config dir contains a marker file
+//      `system/system.yaml`. The composer reads the layer files in a fixed
+//      precedence order and deep-merges them into one raw object:
+//
+//          system/system.yaml   (base — cross-cutting machine config)
+//          network/*.yaml        (sorted by filename)
+//          surfaces/surfaces.yaml
+//          stacks/*.yaml         (sorted by filename)
+//
+//      Later layers win on leaf keys (deep-merge of objects; arrays + scalars
+//      replace wholesale — see `deepMerge`). The order is system → network →
+//      surfaces → stacks because system is the most general (machine-wide)
+//      and stacks are the most specific (per-deployment) — specific overrides
+//      general, the conventional config-cascade direction (Apache/nginx-style,
+//      matching the G-500 networks/ precedent).
+//
+//   2. Single-file fallback (CFG.a.2) — no `system/system.yaml` marker present.
+//      Read the single `cortex.yaml` (or bot.yaml) at `configPath` exactly as
+//      before. Identical `LoadedConfig`, no principal-facing break.
+//
+// Resolution rule (CFG.a.3): directory layout present (marker file exists) →
+// use it; else single-file fallback. The composer is deterministic (fixed
+// layer order, filename-sorted globs) and idempotent (composing twice yields
+// the same object — `deepMerge` is a pure fold, no in-place mutation of inputs).
+
+/** The marker file whose presence selects the directory-layout path. */
+const LAYOUT_MARKER = join("system", "system.yaml");
+
+/**
+ * Deep-merge `source` onto `base`, returning a new object. Plain objects are
+ * merged recursively; arrays and scalars from `source` replace the `base`
+ * value wholesale (no element-wise array merge — config arrays like
+ * `agents[]` / `nats.subjects[]` are replace-or-keep units, not append lists;
+ * element-wise merge would silently splice fragments together in surprising
+ * orders). Neither input is mutated — both are treated as read-only, so
+ * composing the same layers twice yields an identical result (idempotent).
+ */
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+function deepMerge(
+  base: Record<string, unknown>,
+  source: Record<string, unknown>,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = { ...base };
+  for (const key of Object.keys(source)) {
+    const sv = source[key];
+    const bv = out[key];
+    if (isPlainObject(bv) && isPlainObject(sv)) {
+      out[key] = deepMerge(bv, sv);
+    } else {
+      // Arrays + scalars (and object-over-non-object / non-object-over-object)
+      // replace wholesale. structuredClone keeps the merged object detached
+      // from the source layer so later idempotent re-composition can't alias
+      // and mutate a shared nested array/object.
+      out[key] = structuredClone(sv);
+    }
+  }
+  return out;
+}
+
+/**
+ * Read + parse a single YAML layer file into a raw record. Returns `{}` for a
+ * file that parses to null/empty (an empty layer contributes nothing to the
+ * merge). Throws a clear error on YAML parse failure so a malformed layer
+ * fails loudly at load rather than silently dropping config.
+ */
+function readLayerFile(filePath: string): Record<string, unknown> {
+  const content = readFileSync(filePath, "utf-8");
+  let parsed: unknown;
+  try {
+    parsed = parseYaml(content);
+  } catch (err) {
+    throw new Error(
+      `config-composer: failed to parse layer ${filePath}: ${err instanceof Error ? err.message : String(err)}`,
+      { cause: err },
+    );
+  }
+  if (parsed === null || parsed === undefined) return {};
+  if (!isPlainObject(parsed)) {
+    throw new Error(
+      `config-composer: layer ${filePath} must be a YAML mapping at the top level, got ${Array.isArray(parsed) ? "array" : typeof parsed}`,
+    );
+  }
+  return parsed;
+}
+
+/**
+ * List `*.yaml` / `*.yml` files in `dir` in deterministic (sorted) order.
+ * Returns `[]` when `dir` is absent — an optional layer directory contributes
+ * nothing. Dotfiles are skipped (matching `loadAgentsDirectory`).
+ */
+function listLayerFiles(dir: string): string[] {
+  if (!existsSync(dir)) return [];
+  return readdirSync(dir)
+    .filter((f) => !f.startsWith("."))
+    .filter((f) => f.endsWith(".yaml") || f.endsWith(".yml"))
+    .sort()
+    .map((f) => join(dir, f));
+}
+
+/**
+ * CFG.a.1 — compose the raw config object from a directory layout, or fall
+ * back to the single file (CFG.a.2).
+ *
+ * `configPath` is the path the caller already passes (e.g. a `cortex.yaml`
+ * file). Layout detection keys off the file's directory: if
+ * `${dir}/system/system.yaml` exists, the directory layout is used; otherwise
+ * the single file at `configPath` is read verbatim.
+ *
+ * Returns the merged `raw` object — the exact shape `parseYaml(cortex.yaml)`
+ * yields — so the existing `loadConfigWithAgents` parse/build is unchanged.
+ */
+export function composeRawConfig(configPath: string): Record<string, unknown> {
+  const expandedPath = configPath.replace(/^~/, process.env.HOME ?? "~");
+  const configDir = dirname(expandedPath);
+  const markerPath = join(configDir, LAYOUT_MARKER);
+
+  // CFG.a.3 resolution rule: directory layout present → use it; else fallback.
+  if (!existsSync(markerPath)) {
+    // CFG.a.2 — transitional single-file fallback. Identical to pre-CFG.a.
+    const content = readFileSync(expandedPath, "utf-8");
+    return (parseYaml(content) ?? {}) as Record<string, unknown>;
+  }
+
+  // CFG.a.1 — directory layout. Fixed precedence: system → network → surfaces
+  // → stacks (later wins on leaf keys).
+  const layerFiles: string[] = [
+    markerPath,
+    ...listLayerFiles(join(configDir, "network")),
+    ...(existsSync(join(configDir, "surfaces", "surfaces.yaml"))
+      ? [join(configDir, "surfaces", "surfaces.yaml")]
+      : []),
+    ...listLayerFiles(join(configDir, "stacks")),
+  ];
+
+  let raw: Record<string, unknown> = {};
+  for (const file of layerFiles) {
+    raw = deepMerge(raw, readLayerFile(file));
+  }
+  return raw;
+}
+
 /**
  * MIG-7.2e — config-schema flip.
  *
@@ -210,13 +364,18 @@ export function loadConfig(path: string): AgentConfig {
  * rejections in `CortexConfigSchema` (legacy `agent:` / `discord:` /
  * `mattermost:` / `trustedAgentBots:` at the top level) surface as zod
  * errors only when the detection trips the cortex branch.
+ *
+ * IAW CFG.a — the raw config object is now built by `composeRawConfig`, which
+ * either deep-merges a directory layout (`system/`, `network/`, `surfaces/`,
+ * `stacks/`) or reads the single `cortex.yaml` verbatim. `LoadedConfig` is
+ * unchanged across both paths.
  */
 export function loadConfigWithAgents(path: string): LoadedConfig {
   const expandedPath = path.replace(/^~/, process.env.HOME ?? "~");
   const configDir = dirname(expandedPath);
 
-  const content = readFileSync(expandedPath, "utf-8");
-  const raw = (parseYaml(content) ?? {}) as Record<string, unknown>;
+  // CFG.a.1/CFG.a.2 — compose from directory layout or fall back to single file.
+  const raw = composeRawConfig(path);
 
   // Networks load against the on-disk path regardless of legacy/cortex shape —
   // both shapes share the same networks/ contract (G-500).


### PR DESCRIPTION
EPIC CFG foundation slice (#523). Adds `composeRawConfig()`: if `system/system.yaml` marker is present, deep-merges a directory layout (system → network/* → surfaces → stacks/*, leaf-wins, arrays replace) into the same raw object the single-file path produces; else reads `cortex.yaml` verbatim (transitional fallback). **`LoadedConfig` byte-identical** — interface untouched, consumers unchanged (config-ingestion refactor only).

12-test composer suite: round-trip identity (split layout == equivalent single file), fallback, precedence, idempotency, layout-wins-over-stray-cortex.yaml.

tsc clean · full suite **3686 pass / 0 fail** · vocab gate **0**. Next: CFG.b (system.yaml/nats.subjects), CFG.c (surfaces.yaml). Part of #523.

🤖 Generated with [Claude Code](https://claude.com/claude-code)