### PR TITLE
docs(iaw): GW shared-gateway (#524) + Phase-E multi-network bridge (#117) designs

### DIFF
--- a/docs/design-multi-network-bridge.md
+++ b/docs/design-multi-network-bridge.md
@@ -1,0 +1,303 @@
+# Design — Multi-Network Bridges (IoAW Phase E)
+
+**Status:** Draft
+**Refs:** cortex#117 (IAW Phase E: Multi-network bridges + delegation) · cortex#110 (META — Internet of Agentic Work) · `docs/design-internet-of-agentic-work.md` §§3.4–3.6, §5 (Q4/Q7 lock-ins) · `docs/plan-internet-of-agentic-work.md` §6 (Phase E), §9.5 (multi-network runtime refactor)
+**Author:** Architect (Serena Blackwood)
+**Date:** 2026-06-01
+
+---
+
+## 0. The fundamental constraint
+
+The core Phase E concept, verbatim from the IoAW vision script (`design-internet-of-agentic-work.md` §3.4):
+
+> "Some stacks bridge between networks — your stack participates in two different collaborations, publishing certain capabilities to one network and different capabilities to the other."
+
+The fundamental constraint is **transport multiplicity under a single trust root**. A cortex stack is one signing identity (`stack.nkey_pub`, one principal) but must hold **N independent NATS leaf-node links simultaneously**, each one a separate broadcast/routing domain, each with its own peer roster, accept/deny policy, and announced capability subset — and the boundaries between those links must be airtight. A bridge stack that leaks network A's capabilities or data into network B is not a bug; it is a trust violation that defeats the entire isolation premise of the federation model.
+
+Everything below derives from that constraint. The good news, having read the code: **the config schema for this already exists** (`PolicyFederatedNetworkSchema`, `cortex-config.ts:1429`). Phase E is a *transport refactor of `MyelinRuntime`*, not a schema flip. cortex.yaml flipped exactly once already (Phase C); Phase E adds no flip (`plan-internet-of-agentic-work.md` §11.3 — "Phase E bump: minor — additive").
+
+---
+
+## 1. The model — one stack, N leaf-node links
+
+### 1.1 What a "network" is (and what it is NOT)
+
+Per `CONTEXT.md` (lines 19–23):
+
+> **Network**: A federation of **principals** whose **stacks** interconnect at the NATS leaf-node layer … A network is **not a subject segment**: it is deployment topology. Cross-principal reach is the `federated.` **scope** prefix … A principal may belong to more than one network.
+
+A network is topology, surfaced in policy as one entry in `policy.federated.networks[]`. The wire grammar for cross-principal traffic is `federated.{principal}.{stack}.{domain}.…` (`CONTEXT.md:73–80`). The network *id* DOES appear in cortex's federation subject grammar as `federated.{network_id}.…` — the `accept_subjects[]` cross-validation enforces the `federated.{network_id}.` prefix on every entry (`cortex-config.ts:1412–1417, 1465–1470`). The network is therefore a **policy + transport domain**, addressed on the wire by the `{network_id}` segment and carried by a dedicated leaf-node link.
+
+> **NAME-COLLISION WARNING (load-bearing).** `src/bus/network-resolver.ts` already owns a `config.networks[]` concept — but that is the **legacy grove** sense: Discord guilds and Mattermost channels mapped to *cloud-publish targets* (`buildNetworkLookups`, `network-resolver.ts:25–45`; `NetworkConfig` carries `endpoint`/`apiKey`/`cfAccess*`). **These are NOT IoAW federation networks.** Phase E must not reuse `network-resolver.ts`'s tables for federation. See Open Question 2 — recommend renaming the legacy concept during the CFG split.
+
+### 1.2 The bridge-stack picture (from §3.4)
+
+```
+                              ┌──────────────────┐
+                              │  Network A       │
+                              │  (research mesh) │
+                              └────────▲─────────┘
+                                       │ leaf-node A  (NatsLink A)
+          ┌──────────────────┐        │              network A peer registry + policy slice
+          │  bridge stack    │────────┘
+          │  principal: andreas
+          │  stack: andreas/research
+          │  agents: luna, echo, sage
+          │                  │────────┐
+          └──────────────────┘        │ leaf-node B  (NatsLink B)
+                                       │              network B peer registry + policy slice
+                              ┌────────▼─────────┐
+                              │  Network B       │
+                              │  (JV mesh)       │
+                              └──────────────────┘
+```
+
+One stack, one signing key, two **independent** memberships. The structural separation lives in the `leaf_node` reference (`design-internet-of-agentic-work.md:362`): "**A bridge stack has multiple `NatsLink`s simultaneously open**, one per leaf-node."
+
+### 1.3 Q4 lock-in — capability scoping at the network boundary
+
+Per Q4 (`design-internet-of-agentic-work.md:609–626`, locked 2026-05-13):
+
+> *Use separate networks rather than one stack bridging two networks with per-peer capability scoping. Each network is its own subject namespace + policy domain. A "bridge stack" simply participates in network A AND network B (two independent network memberships, two separate cortex.yaml peer-registry entries).*
+
+The granularity decision is **per-network, never per-peer**:
+
+- Scoping happens at the **network boundary** — one `cortex.yaml` (→ `network.yaml` post-CFG) entry per network membership.
+- Each network membership's `announce_capabilities[]` is *the subset of the stack's full `capabilities:` surface* published to that network (`design-internet-of-agentic-work.md:624` — "The Q2 stack-level capability schema declares the full capability surface; each network membership picks a subset to announce. No per-peer-within-network differentiation — networks ARE the granularity.").
+- This is what makes the multi-link runtime *simpler* than the rejected per-peer model: there is no per-peer subject filtering inside a network; a whole network is one link, one policy slice.
+
+---
+
+## 2. The MyelinRuntime refactor — single-link → link pool
+
+### 2.1 What exists today (read from `src/bus/myelin/runtime.ts`)
+
+The current runtime is **structurally single-link**:
+
+- `startMyelinRuntime(config, options)` opens exactly one `NatsLink` from `config.nats.url` (`runtime.ts:441–470`) and builds one `subscribers: MyelinSubscriber[]` array (`runtime.ts:472`).
+- Publish is link-bound at closure-init: `signAndPublishOnSubject(envelope, subject)` (`runtime.ts:559–642`) captures the single `link`, signs via myelin's chain-aware `signEnvelope` (`runtime.ts:602`, import `@the-metafactory/myelin/identity` at `runtime.ts:32`), and calls `link.publish(subject, …)` (`runtime.ts:641`).
+- `publishEnabled` (`runtime.ts:644`) derives the subject from `envelope.sovereignty.classification` via `deriveNatsSubject(envelope, stack)` — the A.3/A.5 work already supports `classification: "federated"` → `federated.{principal}.{stack}.{type}` (docblock `runtime.ts:62–84`). **So a single link already CAN emit `federated.*`** — what it cannot do is route different `federated.*` traffic out of *different physical links*.
+- `publishOnSubjectEnabled` (`runtime.ts:693`) is the explicit-subject escape hatch (Direction A, cortex#409) used for `tasks.@{assistant}.{capability}`.
+- `subscribePullEnabled` (`runtime.ts:707`) and `jetstreamManagerEnabled` (`runtime.ts:748`) are all bound to the single captured `link`.
+
+The single `link` variable is the whole problem. Federated emission already works *to one link*; Phase E makes the link selectable per network.
+
+### 2.2 The refactor — `Map<network_id, NatsLink>` link pool
+
+Per `plan-internet-of-agentic-work.md` §E.1 (lines 426–433) and Phase E acceptance (461–466):
+
+**Shape:**
+
+- Keep the existing **local link** (`config.nats.url`) as today — the `local.{principal}.{stack}.>` domain is unchanged.
+- For each *distinct* `leaf_node` in `policy.federated.networks[]`, open a dedicated `NatsLink` keyed by `network_id` (the `leaf_node` is the resolver key; the `network_id` is the routing key — see §3 on how a `leaf_node` name resolves to connection params).
+- Each link owns **its own** `subscribers[]` set, its own JetStream manager cache, and its own publish/sign core. The existing `signAndPublishOnSubject` factory is reparameterised to close over a *specific* link rather than the module-singleton `link`.
+
+**Link selection on publish:**
+
+- `publish(envelope)` / `publishOnSubject(envelope, subject)` select the target link by reading the **scope + network segment** of the resolved subject:
+  - `local.…` → the local link (the always-present base link).
+  - `federated.{network_id}.…` → the pool link for `{network_id}`. Per §E.1.3 (`plan:430`): "a publish to `federated.research-collab.>` routes via the research-collab link; a publish to `federated.jv.>` routes via the JV link."
+  - `public.…` → deferred (public mesh is out of scope, §3.5 / E.4.3).
+- Selection is a pure function of the subject — no global mutable routing state, no per-message Map rebuild (mirror the `network-resolver.ts:48–77` cached-lookup discipline).
+
+**Inbound source-network attribution (§E.1.4, `plan:431`):**
+
+- Each link's subscriber tags delivered envelopes with the *delivering network_id*. The `EnvelopeHandler` signature is `(envelope, subject)` today (`runtime.ts:40`); Phase E extends it (additively) to `(envelope, subject, sourceNetwork?)` so the surface-router gates against the correct network's `accept_subjects` / `deny_subjects` slice. Defence-in-depth: assert the subject's `{network_id}` segment equals the delivering link's `network_id` (anti-spoofing — see Open Question 5).
+
+**Lifecycle (§E.1.2, `plan:429`):**
+
+- Per-link connect / drain / reconnect. `NatsLink` already defers reconnect to nats.js (`connection.ts:118` `reconnect: true`). `stop()` drains every link's subscribers then closes every link (extend the existing `Promise.allSettled` drain at `runtime.ts:765`).
+- **Boot degradation:** the current runtime treats "all push subscribers failed" as a hard disabled-return (`runtime.ts:513–525`). With N links this becomes per-link: one network's leaf-node being down at boot must NOT take the whole daemon down — boot degraded, emit a `system.error` per dead link, retry in background. (Confirm — Open Question 4; this changes the boot contract.)
+
+### 2.3 Interface impact
+
+`MyelinRuntime` (`runtime.ts:43–172`) stays the single public handle. The pool is *internal*; callers still see `publish` / `publishOnSubject` / `subscribePull` / `jetstreamManager` / `onEnvelope` / `stop`. The additive, optional-property discipline already established for `publishOnSubject?` / `subscribePull?` / `jetstreamManager?` (so fake-runtime test stubs stay byte-identical, per the cortex#290 additivity constraint, `runtime.ts:121,147,169`) is preserved — Phase E adds no *required* surface, only widens internal routing and the optional `sourceNetwork` handler arg.
+
+---
+
+## 3. Config shape — `policy.federated.networks[].leaf_node`
+
+### 3.1 The schema already ships (read from `src/common/types/cortex-config.ts`)
+
+`PolicyFederatedNetworkSchema` (`cortex-config.ts:1429–1514`) already carries every field Phase E consumes:
+
+| Field | Type / constraint | Phase E role |
+|---|---|---|
+| `id` | letter-prefix id (`:1436`) | `{network_id}` subject segment + pool key |
+| `leaf_node` | letter-prefix id (`:1447`) — a **named reference**, NOT a URL | resolves to a `NatsLink` connection |
+| `peers[]` | `PolicyFederatedPeerSchema[]` (`:1457`) | per-network trust closure (`{operator_id, stack_id, operator_pubkey}`) |
+| `accept_subjects[]` | NATS subject patterns, `federated.{id}.` prefix enforced (`:1465`) | per-network inbound gate |
+| `deny_subjects[]` | NATS subject patterns (`:1477`) | per-network deny override |
+| `announce_capabilities[]` | `<domain>.<entity>` ids (`:1491`) | the per-network capability subset (Q4) |
+| `max_hop` | int ≥ 0, **required, no default** (`:1513`) | per-network hop budget |
+
+`PolicyFederatedSchema` (`cortex-config.ts:1582`) wraps `networks: PolicyFederatedNetworkSchema[]` + optional `registry`. The Phase D registry block (`PolicyFederatedRegistrySchema`, `:1543`) and per-peer schema (`PolicyFederatedPeerSchema`, `:1359`) are already in place. **Conclusion: Phase E adds no new config schema** — the schema docblocks even pre-announce this (`:1422–1427` — "Multi-link transport (one MyelinRuntime per network) lands in Phase E; Phase D operates one network's leaf-node at a time, named via `leaf_node`").
+
+### 3.2 The one missing piece — `leaf_node` → connection resolution
+
+`leaf_node` is a *named* reference (`cortex-config.ts:1441–1450`: "Reference to a named NATS leaf-node connection … In Phase D only one leaf-node is operable concurrently; the field exists for forward compat with Phase E's multi-link MyelinRuntime"). There is **no schema today** mapping that name to a URL / creds / token. Phase E must add a *connection table*:
+
+```yaml
+# network.yaml (CFG layered config — see §3.3)
+leaf_nodes:
+  nats-leaf-research:
+    url: nats://research-mesh.example:4222
+    creds_path: ~/.config/cortex/creds/research.creds   # chmod 600, NatsLink loader (connection.ts)
+  nats-leaf-jv:
+    url: nats://jv-mesh.example:4222
+    creds_path: ~/.config/cortex/creds/jv.creds
+
+policy:
+  federated:
+    networks:
+      - id: research-collab
+        leaf_node: nats-leaf-research          # → resolves to leaf_nodes[nats-leaf-research]
+        peers:
+          - principal_id: jcfischer
+            stack_id: jcfischer/sage-host
+            operator_pubkey: U_JC_…
+        accept_subjects: ["federated.research-collab.tasks.code-review.*"]
+        announce_capabilities: ["code-review", "security-scan"]
+        max_hop: 1
+      - id: jv-acme-bigcorp
+        leaf_node: nats-leaf-jv
+        peers:
+          - { operator_id: acme,    stack_id: acme/deploy-host,     operator_pubkey: U_ACME_… }
+          - { operator_id: bigcorp, stack_id: bigcorp/release-host, operator_pubkey: U_BIGCORP_… }
+        accept_subjects: ["federated.jv-acme-bigcorp.tasks.deploy.*"]
+        announce_capabilities: ["deploy", "release"]
+        max_hop: 0
+```
+
+This strawman matches §3.4's worked example (`design-internet-of-agentic-work.md:330–360`) verbatim except for the new `leaf_nodes:` resolution block, which is the genuinely new schema (Open Question 1 — exact block name + home layer needs principal sign-off). `NatsLink.connect` already accepts `{url, token?, credsPath?, name}` (`connection.ts:103`, `27–44`), so the resolution target maps 1:1 onto an existing API — no new connection primitive needed.
+
+### 3.3 How it lands in the CFG layered config (`network.yaml`)
+
+The CFG epic (cortex#83 — "config split: cortex.yaml → layered composer") splits the monolithic `cortex.yaml` into composed layers. **Federation topology is the cleanest candidate for its own layer** because it is: (a) the slice most likely to differ per deployment/environment, (b) the slice with the strongest "edit this together" cohesion (a `leaf_node` definition and the `networks[]` entry that references it must move as one), and (c) security-sensitive (creds paths). Recommendation: a `network.yaml` layer owning both `leaf_nodes:` and `policy.federated`, composed into the runtime config by the CFG composer. This keeps the federation membership editable as one unit and keeps creds-path references out of the general `cortex.yaml`. (Resolve the legacy-`networks[]` name collision at the same time — Open Question 2.)
+
+---
+
+## 4. Single-daemon vs per-stack-daemon (Q7)
+
+Q7 lock-in (`design-internet-of-agentic-work.md:655–673`) makes the stack a first-class protocol primitive and explicitly leaves the daemon-multiplicity choice to "Phase E design decision": "Multiple stacks per principal = multiple cortex daemons OR a single cortex daemon hosting multiple stacks."
+
+§9.5 of the plan (`plan-internet-of-agentic-work.md:564–567`) records the lean:
+
+> **Single daemon vs. per-stack daemon.** … Lean: **single-daemon for v1** (a principal typically has one or two stacks), per-stack daemon as a future option if isolation guarantees become load-bearing.
+> **Subject namespace within a multi-stack daemon.** … Lean: **shared link with subject-segment isolation** (saves NATS connections); rejected if test rig finds cross-stack subject leakage.
+
+**Decision for Phase E v1:**
+
+- **One daemon, lean.** The bridge stack is *one* cortex process. Lower process count, simpler ops, cross-network visibility for the orchestrator agent (§5).
+- **Two different "shared vs separate link" answers, by scope:**
+  - *Multi-stack within `local.`*: shared link with subject-segment isolation (the §9.5 lean — `local.{principal}.{stack₁}` and `local.{principal}.{stack₂}` ride one local link, isolated by the `{stack}` segment).
+  - *Multi-network across `federated.`*: **one dedicated `NatsLink` per network membership** (the §3.4 / E.1 requirement — physically separate links are the isolation mechanism *between networks*, not just a subject-segment convention).
+- The distinction matters: subject-segment isolation is sufficient inside a single trust domain (`local.`, one principal); it is **not** sufficient across federation networks, where the whole point is that network B's NATS server never even *sees* network A's subjects. Physical link separation is the structural guarantee.
+
+This is the architecturally defensible split: isolate by subject segment where the trust root is shared; isolate by physical link where the trust domains differ.
+
+---
+
+## 5. Subject isolation across networks (no cross-network leakage)
+
+Three independent layers enforce no-cross-network-leakage; the design relies on all three (defence-in-depth):
+
+1. **Physical (M1, leaf-node).** Each network's NATS server peers only with that network's members; leaf-node configs constrain bridged subjects to `federated.>` only (`design-internet-of-agentic-work.md:284`). A subject published on network A's link physically cannot reach network B's server. This is the load-bearing layer — it is enforced *below* cortex, in the leaf-node infra.
+
+2. **Routing (M2, runtime link selection).** The §2.2 link-pool routes a `federated.{network_id}.…` publish *only* to the `{network_id}` link. There is no code path that publishes one network's subject onto another network's link — link selection is a pure function of the subject's `{network_id}` segment. Inbound, each subscriber is bound to exactly one link and tags envelopes with the delivering network (§E.1.4), so a misrouted subject cannot be silently accepted under the wrong network's policy.
+
+3. **Policy (M6, surface-router accept/deny).** Phase D already landed the surface-router gate: `adapterMatches()` gates inbound `federated.*` against the originating network's `accept_subjects` / `deny_subjects`, emitting `system.access.denied` with `peer_deny_list` / `peer_not_in_accept_list` on miss, and `max_hop_exceeded` on over-budget chains (`plan-internet-of-agentic-work.md:370–372`, D.2.1–D.2.3). Phase E feeds the delivering network's id into this gate so the *correct* network's slice is applied.
+
+The `accept_subjects[]` schema's refusal of a bare `>` (`cortex-config.ts:1409–1417`) is a deliberate anti-leakage guard: the maximal valid accept pattern is `federated.{network_id}.>`, so a network can never accidentally accept-all across the `{network_id}` boundary.
+
+---
+
+## 6. Trust — a bridge stack must not leak A's capabilities/data to B
+
+The bridge stack is the single highest-value target in the whole topology: it sits in two trust domains at once. The trust model rests on four invariants, all grounded in existing primitives:
+
+1. **Capabilities are network-scoped (Q4).** `announce_capabilities[]` is per-network membership (`cortex-config.ts:1491`; §3.4 `:624`). Network A's announced subset is published only on network A's link (`system.capability.announced.{network_id}`, `:1485`) / registered with network scope at the registry (E.2.2). Network B never learns network A's announced capabilities because the announcement never crosses A's link. **Capability leakage is structurally prevented by the same link-isolation that prevents data leakage.**
+
+2. **Peers are network-scoped trust closures.** Each network's `peers[]` is "the trust closure for the network: a `signed_by[].principal` not in this list fails verification on the inbound side" (`cortex-config.ts:1453–1456`). Network A's peer pubkeys are not valid trust anchors for network B's link. A signature valid in A is meaningless in B.
+
+3. **Chain-of-stamps is the audit, principal-partitioned (Q6).** `signed_by[]` (the chain-aware `signEnvelope`, `runtime.ts:602`) records every stack an envelope crossed. There is no central audit service; each principal owns their slice (`design-internet-of-agentic-work.md:641–653`). A bridge stack's own stamp appears on both networks' traffic *it handled*, but A's audit and B's audit never merge on the wire — the bridge sees both because it *is* the bridge, by design, not by leakage.
+
+4. **No implicit cross-network forwarding.** A bridge stack relays A→B only when an agent *explicitly* re-emits (the delegation/orchestrator pattern, §7). There is no automatic subject bridging inside cortex; `max_hop` bounds even explicit relay (`cortex-config.ts:1497–1513`). A `max_hop: 0` network (the JV example, `design-internet-of-agentic-work.md:359`) accepts only directly-signed envelopes — no relay at all.
+
+The remaining trust question is encryption across the bridge (§7.2, Open Question 6): if a bridge re-emits, must it decrypt? That is a deliberate trust-model decision, not an accident — and it gates both E.3 and E.7.
+
+---
+
+## 7. Interaction with delegation (E.3) and encryption (E.7)
+
+### 7.1 Delegation / orchestrator pattern (§3.6, E.3)
+
+The orchestrator-agent pattern (`design-internet-of-agentic-work.md:387–430`) is *the* application that justifies multi-network: an assistant (e.g. Luna) whose role is to **delegate, not do** — it reads the cross-network capability registry, picks the target network/stack for an inbound task, emits a `federated.{network}.tasks.{capability}` envelope, and threads the chain-of-stamps reply back to the original requester.
+
+Multi-network is the *substrate* the orchestrator runs on:
+
+- The orchestrator needs the link pool (§2.2) to *reach* multiple networks. "Multi-network MyelinRuntime (one stack, N leaf-nodes) … Phase E" is listed as a building block of the orchestrator (`design-internet-of-agentic-work.md:425`).
+- Delegation is an **Offer** dispatch in most cases (capability-routed, claim-first-wins via NATS queue groups — Q5, `design:628–639`; `CONTEXT.md:68–73`). The orchestrator publishes to `federated.{network}.tasks.{capability}.{subcapability}`; one capable peer claims it per queue group. Per-network queue-group naming (`qg:{network_id}:{capability}`) keeps two networks from stealing each other's work (§9.8, Open Question 7).
+- Reply correlation binds via `correlation_id` + envelope id over the per-network queue group (E.3.2); failure (no claimant within timeout) falls back to a sibling network or emits `dispatch.task.failed` (E.3.3). This is event-driven, not blocking-wait — consistent with the dispatch lifecycle on `dispatch.task.{started|completed|failed|aborted}` (`CONTEXT.md:80`).
+- Q4's clean network boundaries are *what makes the orchestrator tractable*: "orchestration agents need clean network boundaries to reason about delegation" (`design:428`). Per-peer scoping (the rejected model) would have forced the orchestrator to reason about peer-level capability fragments inside a network.
+
+The orchestrator agent itself is *application logic* on the substrate harness (M6, `agent-team` / `bus-peer` harness per `CONTEXT.md:87–88`); Phase E *productionises* it (`design:428` — "Phase A enables; Phase E productionises"). This doc specifies the transport it needs, not the orchestrator's decision algorithm (capability-matching is its own follow-on, §9.6 of the plan / Open Question 8 territory).
+
+### 7.2 Encryption across the bridge (E.7)
+
+E.7 (envelope encryption / federation payload confidentiality — cortex#84, in flight) and Phase E intersect precisely at the bridge re-emit point:
+
+- If payloads are **network-scoped encrypted** (only network A's peers hold A's key), then a bridge/orchestrator that re-emits a task from network A *into* network B must **decrypt-then-re-encrypt** at the boundary — which means the bridge stack sees plaintext. That makes the bridge a *trusted decryption intermediary*.
+- The alternative — **end-to-end payload encryption that survives the bridge** — makes cross-network delegation of encrypted payloads *structurally impossible* (the originator in network A would have to hold network B's key, which violates network isolation).
+
+These are mutually exclusive. The decision is a trust-model choice (Open Question 6) that must be made *before* E.3 (delegation) and E.7 (encryption) can both ship. The recommendation embedded here: a bridge stack that performs delegation IS a trusted intermediary for the payloads it re-emits (it already sees them to route them); E.7 should therefore target **hop-by-hop confidentiality with per-network keys**, accepting that the bridge is a decryption point, rather than chasing end-to-end-across-bridges (which the topology forbids). The chain-of-stamps already records that the bridge handled the payload, so the trust is *attestable* (`signed_by[]`), which is the metafactory audit posture (Q6).
+
+The envelope metadata — `sovereignty`, `signed_by[]`, `correlation_id`, routing — stays cleartext in all cases (the bus routes on it; `CONTEXT.md:53–55`). Only the `payload` is a candidate for encryption. The link-pool refactor is encryption-agnostic: it routes on subject, never on payload, so §2.2 needs no change for E.7.
+
+---
+
+## 8. Implementation phasing (maps to plan §6 E.1–E.5)
+
+| Slice | Scope | Acceptance (plan §6) |
+|---|---|---|
+| **E.1** Multi-link MyelinRuntime | Link pool keyed by network_id; per-link lifecycle; subject-based link selection; inbound source-network tagging | `plan:426–433`, accept `:461–464` |
+| **E.1′** `leaf_node` resolution (new) | `leaf_nodes:` connection table + resolver; lands in CFG `network.yaml` | Open Question 1; `cortex-config.ts:1441` |
+| **E.2** Per-network capability announcement | `announce_capabilities[]` subset published per network; registry registration carries network scope | `plan:434–438` |
+| **E.3** Delegation primitives | Orchestrator reference impl on the link pool; reply correlation; failure fallback | `plan:440–445`; design §3.6 |
+| **E.4** Mesh variety scaffolding | Document private / isolated-private (JV) configs; public stub reserved (`policy.public.announce_capabilities[]`), no impl | `plan:447–451`; design §3.5 |
+| **E.5** Tests + production readiness | Bridge-stack 2-network integration test; delegation chain test; failure-mode tests | `plan:453–457`; META accept `plan:593` |
+
+**Versioning:** Phase E is a minor bump (additive — multi-network + delegation), per `plan:639`. No cortex.yaml schema flip.
+
+---
+
+## 9. Testing strategy
+
+The architecture is designed to be verifiable — designs that are hard to test can't hill-climb. Concrete, observable criteria:
+
+1. **Two-link single-process test (E.1.5 / E.5.1, `plan:432,455`).** One cortex process opens two leaf-nodes (fake `connectImpl` per `MyelinRuntimeOptions.connectImpl`, `runtime.ts:224`, so no real `nats-server`); publishes `federated.research-collab.*` through link A; receives `federated.jv.*` through link B; assert chain-of-stamps preserved across both, and assert **no** `federated.jv.*` ever appears on link A's wire (the leakage negative test — this is the test §9.5 says would *reject* the shared-link approach for networks).
+2. **Link-selection unit test.** Pure-function assertion: subject → link key. `local.*` → local; `federated.{n}.*` → pool[n]; unknown network → error (not silent drop).
+3. **Per-network capability test (E.2.3, `plan:438`).** Stack declares `[code-review, deploy]`; announces `code-review` to A and `deploy` to B; registry query per network returns the right subset; assert B's roster never shows `code-review`.
+4. **Boot-degradation test (Open Question 4).** Network B's leaf-node unreachable at boot → daemon boots, network A live, `system.error` emitted for B, B retried in background.
+5. **Delegation chain test (E.5.2, `plan:456`).** orchestrator → network → claimer → reply → originator; full chain-of-stamps verification at each hop; `max_hop` over-budget rejected.
+6. **Symmetry regression.** Extend the existing `runtime-org-symmetry` / `runtime-principal-symmetry` pattern (referenced `runtime.ts:400–407`) to assert per-link subscribe-`{network_id}` === publish-`{network_id}`.
+
+---
+
+## 10. Risk assessment
+
+| Risk | Likelihood | Mitigation |
+|---|---|---|
+| Cross-network subject leakage (the cardinal failure) | Med | Three-layer defence (§5); explicit negative test (§9.1); physical M1 leaf-node constraint is the backstop |
+| Name collision with legacy grove `networks[]` (`network-resolver.ts`) causes a wiring bug | High | Rename legacy concept during CFG split (Open Question 2); until then, never import `network-resolver.ts` tables into federation code |
+| One dead leaf-node crashes the whole daemon (current hard-fail boot contract, `runtime.ts:513`) | Med | Per-link degrade-not-crash (§2.2; Open Question 4) |
+| Bridge becomes a confused deputy (re-emits A's data into B) | Med | No implicit forwarding; `max_hop`; explicit-only re-emit via orchestrator; encryption decision (§7.2) |
+| E.7 encryption + E.3 delegation ship with incompatible trust assumptions | High | Resolve Open Question 6 *before* either ships; this doc flags the mutual exclusivity |
+| Per-network queue groups collide → networks steal each other's offered work | Med | `qg:{network_id}:{capability}` naming (§7.1; Open Question 7; plan §9.8) |
+
+---
+
+## 11. Recommendation (decision-quality summary)
+
+Refactor `MyelinRuntime` to own a **`Map<network_id, NatsLink>` link pool** — the always-present local link plus one dedicated `NatsLink` per distinct `policy.federated.networks[].leaf_node` — reparameterising the existing link-bound `signAndPublishOnSubject` sign+publish core (`runtime.ts:559`) to close over a *selected* link instead of the module singleton. Select the link by the subject's scope + `{network_id}` segment; never share a link across federation networks (physical separation is the inter-network isolation guarantee, where subject-segment isolation suffices only *within* the shared-trust `local.` scope). Run **one lean daemon for v1** (Q7 lock-in). The federation **config schema already exists** (`PolicyFederatedNetworkSchema`, `cortex-config.ts:1429`) — Phase E adds *no* schema flip; the only new config is a `leaf_node` → connection-params resolution table, which belongs in the CFG-layered `network.yaml`. Capability scoping, accept/deny gating, peer trust closure, and chain-of-stamps audit are all already per-network in the schema, so a bridge stack is **structurally** unable to leak network A's capabilities or data into network B — provided the three isolation layers (M1 leaf-node, M2 link selection, M6 surface-router gate) all hold and the negative-leakage test (§9.1) is green. Delegation (E.3) rides on top of this link pool; encryption (E.7) intersects it only at the bridge re-emit point, where a trust-model decision (Open Question 6) must precede shipping either.

--- a/docs/design-shared-surface-gateway.md
+++ b/docs/design-shared-surface-gateway.md
@@ -1,0 +1,228 @@
+**Status: Draft**
+
+**Refs:** cortex#524 (IAW GW: shared surface gateway — one assistant, many deployments) · `docs/design-internet-of-agentic-work.md` (IoAW architectural synthesis) · `docs/plan-internet-of-agentic-work.md` (phase ladder) · CFG epic (config split, task #83, CFG.a merged / CFG.b–CFG.c in flight) · child of cortex#110
+
+> **Provenance note (read first).** Issue #524 cites "plan §13.2" and depends on "CFG.c". As of this writing the implementation plan (`docs/plan-internet-of-agentic-work.md`) ends at §12 and contains no §13; `surfaces.yaml`, `CFG.c`, and `GW` appear in the issue tracker and the local task list (#83 EPIC CFG, #85 IAW GW) but **not yet** as ratified sections in either `docs/` artifact. This document therefore treats §13.2 and `surfaces.yaml` as **forward-references to be created by CFG.c**, and grounds the gateway design on what is real in the repo today: the `PlatformAdapter` contract, the per-presence-token adapter wiring in `src/cortex.ts`, the dispatch-source publisher, the `SurfaceRouter`, and the dispatch-source / dispatch-sink / response-routing vocabulary fixed in `CONTEXT.md`. Where this doc asserts a §13.2 or `surfaces.yaml` shape, that shape is a **proposal for CFG.c to ratify**, flagged inline.
+
+---
+
+## 1. The problem — N connections per bot identity
+
+### 1.1 What ships today
+
+cortex starts platform adapters by **iterating per-agent presence credentials**. In `src/cortex.ts` the daemon builds three token→agent maps:
+
+- `agentByDiscordToken` ← `a.presence.discord?.token` (`src/cortex.ts:1274-1275`)
+- `agentByMattermostApiToken` ← `a.presence.mattermost?.apiToken` (`src/cortex.ts:1276-1278`)
+- `agentBySlackBotToken` ← `a.presence.slack?.botToken` (`src/cortex.ts:1279-1281`)
+
+Then for **each** Discord instance it constructs a `DiscordAdapter`, registers its surface face with the router, and calls `adapter.start(...)`, which opens a live platform connection (`src/cortex.ts:1324-1457`; the Slack and Mattermost loops mirror this). The platform credential lives under `agents[].presence.{platform}.token` in the config schema (`src/common/types/cortex-config.ts:160` for Discord `token`, `:304` for Slack `botToken`, `:265` for Mattermost `apiToken`).
+
+The `PlatformAdapter` contract makes the connection ownership explicit: `start(onMessage)` "Connect to the platform and start listening", and `getPlatformUserId()` returns "the platform user id of the bot account **this adapter is connected as**" (`src/adapters/types.ts:108-124`).
+
+### 1.2 The fan-out
+
+The binding is therefore **one platform connection per adapter instance, keyed by the presence token**. This is fine for one stack. It breaks for the IoAW target state of "**one assistant, many deployments**" (issue title; `docs/design-internet-of-agentic-work.md` §3.2 multi-stack-per-principal, §3.3 multi-principal network):
+
+When the **same** assistant — say Luna — is deployed across N stacks (a principal running `andreas/meta-factory`, `andreas/work`, `andreas/halden`, per `CONTEXT.md` Stack), **each stack process runs its own adapter loop and opens its own connection using the same Luna bot token.** The platform sees N gateway connections (Discord), N Socket-Mode sockets (Slack), or N pollers (Mattermost) **for one bot identity**.
+
+Two concrete failure modes:
+
+1. **Rate-limit / connection-budget pressure.** Discord enforces per-bot session-start (`IDENTIFY`) limits and a global request budget per bot token; Slack Socket Mode and Mattermost polling similarly meter per bot identity. N stacks contending for one identity's budget is self-inflicted contention that scales with deployment count, not with traffic.
+2. **Double-message risk.** N connections under one identity each receive the same inbound platform event (a `messageCreate` in a shared guild). Without coordination, each bound stack's `dispatchHandler.handleMessage` (`src/cortex.ts:1416`) fires, so one human message can produce N dispatches and N replies. The current `trustedBotIds` anti-self-loop guards (`src/cortex.ts:1378`, `cortex-config.ts:204`) defend against bot-echo, not against N-way intra-identity duplication.
+
+### 1.3 Why this is the natural seam to cut
+
+The architecture already separates the **wire-facing roles** from the platform I/O. `CONTEXT.md` defines a **dispatch source** ("turns a platform message into a `tasks.@{assistant}.{capability}` envelope") and a **dispatch sink** ("consumes lifecycle envelopes … and renders them to a surface"), and states the load-bearing principle: **"Discord (and other platforms) are sources and/or sinks for chat envelopes — they are not the medium of communication. The bus is the medium."** (`CONTEXT.md`, `chat` capability entry.)
+
+If the bus is the medium, the platform connection is an **edge resource** that should be owned **once per identity**, not once per stack. That is the gateway.
+
+---
+
+## 2. The gateway — one platform connection per bot identity
+
+### 2.1 Definition
+
+**GW (shared surface gateway):** a process that owns **exactly one platform connection per `(platform, bot-identity)` pair**, acts as a pure **dispatch source** (inbound) and **dispatch sink** (outbound) on the bus, and uses a binding map (`surfaces.yaml`, §3) to **demux** inbound platform events to the right **stack** and **mux** outbound lifecycle envelopes back to the right platform connection.
+
+In `CONTEXT.md` vocabulary: the gateway is a dispatch source and dispatch sink that is **shared across stacks**. It is not an assistant, not an agent, not (necessarily) a stack — it is the surface edge, factored out.
+
+```
+                         ┌──────────────────────────────────────────┐
+   Discord guild   ◄────►│  GW — shared surface gateway               │
+   Slack workspace ◄────►│   • ONE connection per (platform,identity) │
+   Mattermost srv  ◄────►│   • reads surfaces.yaml binding map        │
+                         │   • demux inbound → bus  (dispatch source) │
+                         │   • mux  outbound ← bus  (dispatch sink)   │
+                         └───────────────┬────────────────────────────┘
+                                         │  bus (the medium)
+            ┌────────────────────────────┼────────────────────────────┐
+            ▼                            ▼                             ▼
+   stack: andreas/meta-factory   stack: andreas/work          stack: andreas/halden
+   (surface-bus-only)            (surface-bus-only)            (surface-bus-only)
+   subscribes tasks.@luna.chat   subscribes tasks.@luna.chat   subscribes tasks.@luna.chat
+   emits dispatch.task.*         emits dispatch.task.*         emits dispatch.task.*
+```
+
+### 2.2 Inbound path (demux — gateway as dispatch source)
+
+1. The single platform connection receives a native event and normalizes it to the existing `InboundMessage` (`src/adapters/types.ts:14-45`) — already platform-agnostic, already carrying `instanceId`, `guildId`, `channelId`, `threadId`, `channelName`, `threadName`, `authorId`.
+2. The gateway resolves the **target stack** from `surfaces.yaml` using the binding key — `(platform, instanceId)` and/or `(platform, guildId/workspaceId/teamId)` (§3.2).
+3. It publishes a canonical inbound dispatch envelope onto the bus for that stack, reusing the existing `publishInboundChatDispatchEnvelope` shape (`src/bus/dispatch-source-publisher.ts:81-185`): `distribution_mode: "direct"`, `target_assistant: did:mf:<assistant>`, subject `…{principal}.{stack}.tasks.@{did-encoded-assistant}.chat`, and `originator: { identity, attribution: "adapter-resolved" }` (`dispatch-source-publisher.ts:161-164`).
+4. **The bound stack consumes** the envelope on its existing dispatch listener (`local.{principal}.{stack}.tasks.*.>`, per `CONTEXT.md` Dispatch migration note) and runs it through its substrate harness — unchanged.
+
+Crucially, the **demux decision is `surfaces.yaml`-driven**, so exactly one stack is targeted. That, by construction, eliminates the §1.2 double-message problem: the platform event enters the bus once, addressed to one stack.
+
+### 2.3 Outbound path (mux — gateway as dispatch sink)
+
+1. The bound stack's runner emits `dispatch.task.{started|completed|failed|aborted}` lifecycle envelopes joined by `correlation_id` (`CONTEXT.md` Dispatch; `src/runner/dispatch-listener.ts:19-23`).
+2. Each lifecycle envelope carries **response routing** — "the originating surface address … `{adapter_instance, channel_id, thread_id?}`" that the runner "**echoes onto every `dispatch.task.{action}` lifecycle envelope so the originating dispatch sink can correlate completion → platform target without keeping state**" (`CONTEXT.md` Response routing).
+3. The gateway subscribes to lifecycle envelopes (across all bound stacks), reads `response_routing.instance` to pick **which of its platform connections** to render on, reconstructs the existing `ResponseTarget` (`{ instanceId, channelId, threadId }`, `src/adapters/types.ts:80-89`), and calls the existing `postResponse` / `sendProgress` / `clearProgress` methods on the right connection (`src/adapters/discord/index.ts:709,756,780`).
+
+The mux key is `response_routing.instance`. This is the **`response_routing.instance` bump** the issue calls for (§4).
+
+---
+
+## 3. Reading `surfaces.yaml` (the CFG.c precondition)
+
+### 3.1 Dependency on CFG.c
+
+GW is **additive and depends on CFG.c** (issue #524). CFG.a (the layered composer) is merged; CFG.b/CFG.c are in flight (task #83). CFG.c introduces `surfaces.yaml` as the place where the **{surface-instance → stack} binding** lives — pulled **out** of `agents[].presence.{platform}` (where the token lives today, `cortex-config.ts:160/265/304`) so that a surface binding is no longer implicitly owned by one stack's config.
+
+GW must not invent its own config format. It reads the CFG.c artifact. If CFG.c is not yet merged when GW.a starts, GW reads a **shim** that the composer can later supersede (§7 phasing).
+
+### 3.2 Proposed binding shape (for CFG.c to ratify)
+
+> **PROPOSAL — not yet in repo.** CFG.c owns the final schema. The fields below are what GW needs; their names should be reconciled with the CFG composer and the existing `PresenceSchema` field names (`token`, `guildId`, `workspaceId`, `channels`, `instanceId`).
+
+```yaml
+# surfaces.yaml  (CFG.c)  — one entry per platform connection the gateway owns
+surfaces:
+  - instance: luna-discord-mf          # the response_routing.instance value (§4)
+    platform: discord
+    identity:                          # ONE connection opened for this identity
+      token_ref: secrets://discord/luna
+      bot_user_id: "1487...."          # populated post-connect via getPlatformUserId()
+    bindings:                          # demux map: which inbound → which stack
+      - match: { guildId: "1487...", channelName: "cortex" }
+        principal: andreas
+        stack: meta-factory
+        assistant: luna
+      - match: { guildId: "1487...", channelName: "work" }
+        principal: andreas
+        stack: work
+        assistant: luna
+```
+
+GW resolves an `InboundMessage` against `bindings[].match` (most-specific wins: `threadName` > `channelName` > `guildId`), yielding `(principal, stack, assistant)` → the subject the dispatch-source publisher builds (`dispatch-source-publisher.ts:68-79,91-99`). `instance` is the stable id that flows out on `response_routing.instance`.
+
+### 3.3 The `response_routing.instance` bump
+
+Today the gateway-equivalent information is **in-memory only**: a `ResponseTarget.instanceId` (`src/adapters/types.ts:81-83`) that the same process that received the message already holds. Inbound envelopes carry ad-hoc payload keys (`grove_channel`, `grove_network`, `dispatch-source-publisher.ts:123-124`), **not** a structured `response_routing` block. For a *shared* gateway, the connection that renders the reply is in a **different** logical owner than the stack that did the work — so the instance id **must travel on the wire**.
+
+The bump: `response_routing` becomes a first-class field on the inbound envelope (`{ instance, channel_id, thread_id? }`), and the runner echoes it verbatim onto every `dispatch.task.{action}` lifecycle envelope — exactly the contract `CONTEXT.md` Response routing already specifies ("echoed by the runner onto every lifecycle envelope … Response routing is wire-level, not in-memory"). GW.a's job is to **populate `response_routing.instance` on publish** and **read it on the lifecycle subscription**. Whether the schema promotion is GW's PR or a CFG/myelin-schema prerequisite is an open question (§9, OQ4).
+
+---
+
+## 4. Per-stack adapter retirement — stacks go surface-bus-only
+
+Once GW owns the connection, a bound stack **no longer opens a platform connection**. It becomes **surface-bus-only**:
+
+- It does **not** instantiate `DiscordAdapter`/`SlackAdapter`/`MattermostAdapter` for a bound surface (the `src/cortex.ts:1324-1457` loop is skipped for surfaces present in `surfaces.yaml`).
+- It still **consumes** inbound dispatch envelopes on its dispatch listener and **emits** `dispatch.task.*` lifecycle envelopes — i.e., it participates purely as a bus peer. This is exactly the `bus-peer` posture the IoAW substrate-harness work already contemplates (`docs/design-internet-of-agentic-work.md` §2 "cortex#91 BusPeerHarness"; `CONTEXT.md` Substrate harness `bus-peer`).
+
+This is **GW.f** in the issue checklist ("retire per-stack adapters — stacks go surface-bus-only").
+
+A subtle, important consequence for the trust model: today the **stack** is the cryptographic signer (`CONTEXT.md`: "the **stack** signs the envelope via `runtime.publish` using the stack NKey"; the adapter only populates `originator`). When the gateway is a *separate* process publishing *on behalf of* a stack, **who signs?** This is the single most important unresolved decision and is broken out as OQ2 (§9). The retirement of per-stack adapters cannot land before it is resolved, because the inbound envelope GW publishes must be signed by *something* the bound stack and the network will accept.
+
+---
+
+## 5. Composition with existing adapters + the surface-router
+
+GW is **not a rewrite of the adapters** — it is a **new owner** of them. The composition is clean because the seams already exist:
+
+- **`PlatformAdapter` (I/O) is reused as-is.** `src/adapters/{discord,mattermost,slack}/index.ts` already encapsulate connect/listen/post/typing/progress/thread behind `start`/`stop`/`postResponse`/`sendProgress`/`getPlatformUserId` (`src/adapters/types.ts:102-144`). The gateway constructs **one** adapter instance per `(platform, identity)` and drives it directly. No adapter internals change.
+- **The `onMessage` callback is rebound.** Today: `adapter.start((msg) => dispatchHandler.handleMessage(adapter, msg))` (`src/cortex.ts:1416`) — handle locally, in-process. In the gateway: `adapter.start((msg) => gateway.demuxAndPublish(msg))` — resolve the binding, publish to the bound stack's subject. The `DispatchHandler` (in-process synchronous path, `src/bus/dispatch-handler.ts`) is **bypassed** at the gateway; dispatch happens on the bus, consumed by the bound stack.
+- **The `SurfaceRouter` stays inside each stack, not in the gateway.** The router (`src/bus/surface-router.ts`) is a **bus-envelope → adapter fan-out** within a process (`SurfaceAdapter.subjects` + `filter` + `render`, `src/bus/surface-router.ts:66-115`). The gateway's outbound side is the *inverse* concern (lifecycle-envelope → one platform connection, keyed by `response_routing.instance`), so the gateway runs its **own** thin sink subscriber rather than a `SurfaceRouter`. The router continues to serve **non-platform sinks that stay in-stack** (dashboard renderer, PagerDuty — `src/renderers/`), which are unaffected by GW because they are not platform connections.
+- **`TrustResolver` co-tenancy.** Today each adapter registers its `getPlatformUserId()` into the per-process `TrustResolver` for the in-process anti-self-loop / peer-trust merge (`src/cortex.ts:1431-1445`, `cortex#98` part B). In the gateway, the single connection registers once; cross-process peer trust falls back to the explicit `presence.{platform}.trustedBotIds` bridge (`cortex-config.ts:204`, `:369`) exactly as it does today for cross-process peers.
+
+Net: GW is roughly "the `src/cortex.ts:1274-1457` adapter loop, lifted into a dedicated owner, with the `onMessage` callback and the outbound sink re-pointed at the bus, and the per-stack copies removed."
+
+---
+
+## 6. Failure / reconnect — blast radius
+
+Collapsing N connections to 1 **concentrates** the failure domain. This is the central trade-off and must be designed for explicitly.
+
+### 6.1 The blast radius
+
+- **One connection drop affects ALL bound stacks.** Today, if `andreas/work`'s Discord connection drops, only `andreas/work` goes dark; the other stacks' own connections survive. Under GW, one Luna-Discord disconnect blacks out inbound and outbound for **every** stack bound to that connection.
+- **Outbound in-flight loss spans stacks.** A reconnect window during which `postResponse`/`sendProgress` calls fail (`src/adapters/discord/index.ts:730` already logs `postResponse failed while connected`) now drops replies for multiple stacks at once.
+
+### 6.2 Mitigations (design requirements for GW.a)
+
+1. **Inbound is naturally durable.** Inbound dispatch envelopes are published to the bus; if a bound stack is down, JetStream retention + the stack's consumer (queue-group claim, `CONTEXT.md` Offer/Subject) handle redelivery. The gateway's inbound responsibility ends at a successful publish. So **a stack outage does not require a gateway reconnect** — they are decoupled by the bus. This is a structural win: GW makes stacks *more* independently restartable, not less.
+2. **Connection is the single point.** The gateway needs first-class **reconnect with backoff** per connection (the adapters already carry retry primitives — `src/adapters/discord/retry.ts`). A connection-health signal should emit on the bus (`system.*`, reusing the `systemEventSource` pattern, `src/cortex.ts:647-658`) so the principal dashboard can see "Luna-Discord connection down — N stacks affected."
+3. **Outbound replay policy is an open question (OQ5).** On reconnect, should the gateway re-drain `dispatch.task.*` from a durable consumer (re-rendering latest state, at the cost of duplicate edits) or fire-and-forget (matching today's adapter behaviour, accepting dropped replies)? This is a deliberate availability-vs-duplication trade.
+4. **Run GW as its own supervised process.** A dedicated launchd plist (sibling to `ai.meta-factory.cortex.bot.plist` / `.relay.plist`, `src/services/`) so the gateway can restart independently of any stack, and so a stack deploy (`arc upgrade Cortex`) does not bounce the shared connection.
+
+The honest framing for the principal: **GW trades N small, independent failure domains for 1 larger, shared one, in exchange for removing the rate-limit and double-message defects and enabling "one assistant, many deployments."** The bus decoupling (mitigation 1) means the shared domain is *only* the platform edge, not the work itself.
+
+---
+
+## 7. Phased rollout
+
+GW is additive (issue #524). The rollout never has a flag-day where a stack has *no* path to its surface.
+
+### Stage 0 — `surfaces.yaml` lands (CFG.c, prerequisite)
+CFG.c ships the binding artifact and the composer wiring (task #83). No gateway behaviour yet. GW work is **blocked** on this (issue: "Depends on CFG.c").
+
+### Stage 1 — Gateway alongside per-stack adapters (GW.a, shadow)
+- Stand up the gateway process holding one connection per `(platform, identity)` for the chosen pilot identity (e.g. Luna-Discord).
+- Stacks **keep** their per-stack adapters (no `getPlatformUserId` collision risk because the gateway can run against a *staging* identity first, or in observe-only mode that publishes inbound envelopes but does not render outbound).
+- **Acceptance gate:** prove connection-count reduction and correct demux on the bus *before* any stack loses its adapter. Measure: platform-reported connection count for the identity, and zero double-dispatch in a shared channel.
+
+> Note: a real shared bot token cannot have *both* a per-stack adapter *and* the gateway connected simultaneously without re-introducing the §1.2 duplication. So Stage 1 is either (a) staging-identity shadow, or (b) per-binding cutover (Stage 2) done one binding at a time. The "alongside" phase is per-*binding*, not per-*identity*.
+
+### Stage 2 — Flip, binding by binding (GW.a → GW.f, incremental)
+- For each binding in `surfaces.yaml`: switch the bound stack to **surface-bus-only** (skip its adapter instantiation for that surface, §4) **in the same change** that the gateway begins owning that binding's connection. This keeps "exactly one connection per identity" invariant true throughout — never zero, never two.
+- The bound stack now relies on the wire `response_routing.instance` (§3.3) for outbound; verify replies land in the right channel/thread for the right stack.
+
+### Stage 3 — Retire per-stack platform connections (GW.f complete)
+- Once all bindings for an identity are gateway-owned, delete the per-stack adapter wiring for those platforms from the stack boot path; the `presence.{platform}.token` field migrates into `surfaces.yaml.identity` (CFG.c) and is removed from `agents[].presence` for bound surfaces.
+- The `DispatchHandler` in-process synchronous chat path (`src/bus/dispatch-handler.ts`) is retained only for any surfaces *not* gateway-bound (or retired with #412's `dispatch-handler.ts` deletion, `CONTEXT.md` Dispatch migration note — coordinate the two retirements).
+
+Each stage is independently revertible: revert a binding flip and the stack re-opens its own adapter.
+
+---
+
+## 8. Vocabulary compliance
+
+Per the live whole-tree vocabulary gate (`CONTEXT.md`), this design uses: **principal** (the human, root of trust), **stack** (one running cortex deployment), **assistant** (the named being, e.g. Luna), **agent** (the stack-local runtime hosting an assistant), **dispatch source / dispatch sink** (the gateway's two roles), **response routing** (the wire-level reply address), **Offer / Direct / Delegate** (dispatch modes; GW publishes **Direct** chat envelopes), and **scope** `local` / `federated` / `public` (GW v1 is `local` within one principal; cross-principal is `federated`, deferred — OQ3). No bare "operator" is used; where the NSC/NATS operator account is meant it is qualified ("NSC operator account" — not relevant to GW's data path).
+
+---
+
+## 9. Open questions for the principal
+
+1. **Connection dedup key** — `(platform, token)` (operational truth today, `cortex.ts:1274-1281`), `(platform, bot_user_id)`, or `(platform, assistant)`? They diverge when one assistant runs under two tokens.
+2. **Who signs the inbound envelope?** GW as a separate process is a dispatch source but `CONTEXT.md` makes the **stack** the cryptographic signer. Options: (a) gateway holds a delegated per-stack signing key; (b) gateway publishes originator-stamped, bound stack re-signs on ingest; (c) gateway IS a minimal stack. **Blocks GW.f.** (See §4.)
+3. **Cross-principal bindings** — is GW v1 single-principal (all bound stacks share one principal, all `local.`), with shared-channel cross-principal traffic (`federated.`, `CONTEXT.md` Network) deferred to a federation-aware gateway?
+4. **`response_routing` schema promotion** — is promoting `response_routing` to a first-class wire field GW's PR, or a CFG/myelin-schema prerequisite GW depends on? (See §3.3.)
+5. **Outbound replay on reconnect** — durable re-drain of `dispatch.task.*` (recover blast-radius, risk duplicate edits) vs fire-and-forget (match today, drop on disconnect)? (See §6.2.)
+6. **Shared outbound rate-limiting** — one connection now carries summed volume of all bound stacks against one identity's per-route quota; does GW need a shared route-keyed limiter + bus backpressure contract?
+7. **`surfaces.yaml` ownership + hot-reload** — gateway-owned file or CFG-composed into each `cortex.yaml`? Reload must not bounce connections for unaffected stacks (precedent: `src/common/config/watcher.ts`).
+
+---
+
+## 10. References (cited source)
+
+- `CONTEXT.md` — Principal / Stack / Assistant / Agent; Dispatch (Offer/Direct/Delegate, `distribution_mode`); Dispatch source; Dispatch sink; Response routing; `chat` capability ("the bus is the medium").
+- `src/adapters/types.ts:14-45` (`InboundMessage`), `:80-89` (`ResponseTarget`), `:102-144` (`PlatformAdapter`).
+- `src/cortex.ts:1274-1281` (token→agent dedup maps), `:1324-1457` (Discord adapter start loop + `getPlatformUserId` trust registration), `:1416` (`onMessage` → `dispatchHandler.handleMessage`), `:647-658` (`systemEventSource`).
+- `src/bus/dispatch-source-publisher.ts:57-66` (`adapterOriginatorIdentity`), `:81-185` (canonical inbound chat envelope: subject build, `distribution_mode:"direct"`, `originator`).
+- `src/bus/surface-router.ts:66-115` (`SurfaceAdapter`), `:160-176` (`SurfaceRouter`), `:200-236` (`subjectMatches`).
+- `src/adapters/discord/index.ts:709,756,780` (`postResponse`/`sendProgress`/`clearProgress`), `:730` (post-failure logging), `:1136` (surface render binding); `src/adapters/discord/retry.ts` (reconnect primitives).
+- `src/common/types/cortex-config.ts:157-244` (`DiscordPresenceSchema`, token + `surfaceSubjects` + `trustedBotIds`), `:258-276` (Mattermost), `:297-387` (Slack).
+- `src/runner/dispatch-listener.ts:8-55` (lifecycle envelope emission; render-vs-dispatch adapter shape).
+- `docs/design-internet-of-agentic-work.md` §3.1 (single stack), §3.2 (multi-stack per principal), §3.3 (multi-principal network), §2 (`bus-peer` / BusPeerHarness).
+- `docs/plan-internet-of-agentic-work.md` (phase ladder; note: ends at §12 — §13 is a forward-reference, see provenance note).


### PR DESCRIPTION
Two IoAW design docs from the design-sweep workflow, each **fresh-context reviewed** (grounded ✓, sound ✓, verdict=merge):

**GW — shared surface gateway (#524):** one platform connection per bot identity reading `surfaces.yaml` (CFG.c precondition), demux inbound platform events → bound stack over the bus, mux lifecycle envelopes out via a new `response_routing.instance`; reuse the existing `PlatformAdapter` I/O behind a new owner (not a rewrite); phased rollout. **Central open question (trust):** the stack is the cryptographic signer and the gateway is a dispatch source, NOT a stack — so who signs the gateway's inbound envelopes? Locked before GW.a.

**Bridge — Phase E multi-network (#117):** one stack, N concurrent `NatsLink`s (one per leaf-node), capability scoping at the network boundary (Q4 lock-in), single-daemon v1 with subject-segment isolation (Q7). Review flagged a real **name-collision**: `network-resolver.networks[]` is the *legacy grove* sense — must disambiguate from the federation `networks`.

Both Draft — open questions for the principal. Refs #524, #117 (children of #110).

🤖 Generated with [Claude Code](https://claude.com/claude-code)