### PR TITLE
feat(config): CFG.b — system.yaml layer + loud nats.subjects validation (#523)

### DIFF
--- a/docs/config-layout/README.md
+++ b/docs/config-layout/README.md
@@ -1,0 +1,61 @@
+# Reference multi-file config layout (IAW CFG)
+
+This directory is a **documented, loadable reference** for the multi-file
+`cortex` config layout introduced by the IAW **CFG** epic
+(`docs/plan-internet-of-agentic-work.md` §13.1). It is an example/fixture, not a
+live deployment — copy it to your config dir and fill in real tokens/keys.
+
+## Why split the config
+
+A single fat `cortex.yaml` couples knobs with **wildly different blast radii**
+on one edit surface (design doc §3.7). The split isolates them by lifecycle:
+
+| File | Owns | Blast radius |
+|---|---|---|
+| `system/system.yaml` | substrate / transport: `claude`, `execution`, `attachments`, `paths`, `nats`, `bus` — **the dangerous transport knobs** | Whole stack |
+| `network/*.yaml` | federation roster (`policy.federated.networks[]`) | Cross-principal |
+| `surfaces/surfaces.yaml` | shared surface-gateway bindings (CFG.c / GW) | Cross-stack |
+| `stacks/*.yaml` | per-deployment policy / capabilities / agents | One stack only |
+
+## How composition works
+
+The boot composer (`composeRawConfig`, `src/common/config/loader.ts`) keys off
+the **marker file `system/system.yaml`**. When it is present, the composer reads
+the layers in this fixed precedence and deep-merges them into the SAME
+`LoadedConfig` the single file produced:
+
+```
+system/system.yaml      (base — most general)
+network/*.yaml          (sorted by filename)
+surfaces/surfaces.yaml
+stacks/*.yaml           (most specific — wins on leaf keys)
+```
+
+Later layers win on leaf keys; nested objects deep-merge; arrays and scalars
+replace wholesale. `LoadedConfig` is **unchanged** — no consumer edits. A single
+monolithic `cortex.yaml` still loads via the transitional single-file fallback
+(no marker file present), so existing deployments keep working unchanged.
+
+## The `nats.subjects` landmine (CFG.b.2)
+
+`nats.subjects` lives in **exactly one place** — `system/system.yaml` — and
+nowhere else. It is the most dangerous block in the config: a duplicate or
+overlapping subscribe pattern double-binds the boot subscriber and
+double-delivers every envelope (the double-message problem, cortex#491). Keeping
+it in one rarely-edited file removes the per-stack duplication that caused it.
+
+The loader validates the block **loudly at load** (CFG.b.3,
+`src/common/types/nats-subjects.ts`): a malformed pattern or a duplicate entry
+throws a clear error rather than parsing into a silent partial config that would
+double-publish.
+
+## This example
+
+- [`system/system.yaml`](./system/system.yaml) — the substrate layer, with the
+  prominently-commented `nats.subjects` block (kept at the safe `[]` default).
+- [`stacks/research.yaml`](./stacks/research.yaml) — one per-deployment stack
+  (principal + one agent), carrying no transport knobs.
+
+`surfaces/` and `network/` are omitted here — `surfaces.yaml` lands with CFG.c
+and the network roster with the federation phases; both are optional layers the
+composer skips when absent.

--- a/docs/config-layout/stacks/research.yaml
+++ b/docs/config-layout/stacks/research.yaml
@@ -1,0 +1,36 @@
+# =============================================================================
+# stacks/research.yaml — a per-deployment stack layer (reference example)
+# =============================================================================
+#
+# The MOST SPECIFIC layer. One stack only — routine per-stack edits land here
+# (capabilities, policy, agents, the assistant prose path). Blast radius is this
+# stack alone, so this is the file you touch for day-to-day work — deliberately
+# NOT the place the dangerous transport knobs (system.yaml) live.
+#
+# This reference carries the principal block + a single agent so the layout
+# composes to a complete, valid `LoadedConfig`. In a real multi-stack
+# deployment, the principal block can live in any layer (it is most natural in
+# system.yaml when one principal owns every stack on the host); it is kept here
+# to make this example self-contained.
+#
+# Note what is ABSENT: no `nats.subjects`, no `nats` transport block at all, no
+# surface tokens. Transport lives in system.yaml; surface bindings move to
+# surfaces.yaml (CFG.c / GW). A stack file never re-declares the subject list —
+# that is the structural fix for the double-message problem.
+
+principal:
+  id: andreas
+  displayName: Andreas
+
+agents:
+  - id: ivy
+    displayName: Ivy
+    persona: ./personas/ivy.md
+    roles: []
+    trust: []
+    presence:
+      discord:
+        token: REPLACE_WITH_DISCORD_BOT_TOKEN
+        guildId: "000000000000000000"
+        agentChannelId: "000000000000000000"
+        logChannelId: "000000000000000000"

--- a/docs/config-layout/system/system.yaml
+++ b/docs/config-layout/system/system.yaml
@@ -1,0 +1,118 @@
+# =============================================================================
+# system.yaml — the cross-cutting machine / substrate layer (IAW CFG.b)
+# =============================================================================
+#
+# This is the BASE layer of the multi-file config layout (IAW CFG). The boot
+# composer (`composeRawConfig` in src/common/config/loader.ts) reads the layered
+# files in a fixed precedence order and deep-merges them into the SAME in-memory
+# `LoadedConfig` cortex has always built from a single `cortex.yaml`:
+#
+#     system/system.yaml      ← THIS FILE (base — substrate / machine config)
+#     network/*.yaml          (federation roster, sorted by filename)
+#     surfaces/surfaces.yaml  (shared surface-gateway bindings — CFG.c / GW)
+#     stacks/*.yaml           (per-deployment policy / capabilities / agents)
+#
+# Later layers win on leaf keys. `system.yaml` is therefore the most GENERAL
+# layer — machine-wide substrate knobs that every stack on this host shares.
+#
+# Blast radius: WHOLE STACK. These are "the dangerous transport knobs"
+# (design-internet-of-agentic-work.md §3.7). A wrong value here is a
+# transport-level fault everywhere — which is exactly why they are isolated in
+# their own rarely-edited, reviewed-as-a-transport-change file, away from the
+# routine per-stack edits in `stacks/*.yaml`.
+#
+# What lives here (and ONLY here): claude / execution / attachments / paths /
+# nats / bus. `LoadedConfig` shape is unchanged — these fold into the identical
+# slots the single-file `cortex.yaml` populated. Single-file deployments keep
+# working via the transitional fallback; you do not have to split.
+
+# -----------------------------------------------------------------------------
+# claude — runtime config passed to spawned Claude Code sessions
+# -----------------------------------------------------------------------------
+claude:
+  timeoutMs: 300000          # sync chat dispatch budget
+  asyncTimeoutMs: 900000     # async: / team: dispatch budget
+  additionalArgs: []
+  allowedTools: []
+  disallowedTools:
+    - Write
+
+# -----------------------------------------------------------------------------
+# execution — dispatch backend selection
+# -----------------------------------------------------------------------------
+execution:
+  default: local
+  backends: []
+
+# -----------------------------------------------------------------------------
+# attachments — inbound file-handling limits
+# -----------------------------------------------------------------------------
+attachments:
+  enabled: true
+  maxFileSizeBytes: 10485760      # 10 MiB per file
+  maxTotalSizeBytes: 26214400     # 25 MiB per message
+  maxAttachmentsPerMessage: 10
+
+# -----------------------------------------------------------------------------
+# paths — on-disk locations cortex reads/writes (leading ~ expands to $HOME)
+# -----------------------------------------------------------------------------
+paths:
+  publishedEventsDir: ~/.claude/events/published
+  logDir: ~/.config/cortex/logs
+
+# =============================================================================
+# nats — M2 transport. THE SINGLE PLACE SUBJECT OVERRIDES LIVE (IAW CFG.b.2)
+# =============================================================================
+#
+# `nats.subjects` below is the most dangerous block in the whole config, and it
+# is isolated HERE — one place, one owner, reviewed as a transport change — so
+# it can never be duplicated across per-stack files. That per-stack duplication
+# is what drove the double-message problem: two layers each listing the same
+# subscribe pattern double-bound the boot subscriber, so every inbound envelope
+# was delivered AND dispatched twice (cortex#491; the `pre-natsdedup` era).
+nats:
+  url: nats://127.0.0.1:4222
+  name: cortex
+
+  # ---------------------------------------------------------------------------
+  # nats.subjects — push-mode broad-pattern subscriber list. (THE LANDMINE.)
+  # ---------------------------------------------------------------------------
+  #
+  # Default empty (`[]`) = pull-only mode (cortex#337). KEEP IT EMPTY unless you
+  # know exactly why you are adding a pattern. The runner's dispatch-listener
+  # self-subscribes its canonical `local.{principal}.{stack}.tasks.*.>` interest
+  # at start() (cortex#477/#479), so it is the SOLE binder for inbound tasks.
+  # Listing that same pattern here re-creates the boot-subscriber, double-binds
+  # the same handler set, and double-delivers + double-dispatches every
+  # chat/Direct/Delegate envelope — the double-message problem (cortex#491).
+  #
+  # The loader validates this block LOUDLY at load (IAW CFG.b.3,
+  # src/common/types/nats-subjects.ts):
+  #   - a malformed pattern (whitespace, empty segment, misplaced `>`) is rejected
+  #     with a clear error — never parsed into a silent partial config;
+  #   - a DUPLICATE pattern is rejected with the index of the first occurrence,
+  #     because a duplicate is precisely the double-bind footgun.
+  #
+  # Placeholder tokens `{principal}` / `{stack}` are substituted at runtime.
+  # Example (commented — do NOT enable without understanding the double-bind):
+  #   subjects:
+  #     - local.{principal}.{stack}.tasks.*.>
+  subjects: []
+
+  # NKey identity for envelope signing (paths point at on-disk key material;
+  # the loader enforces chmod 600 on the creds/account-signing files).
+  identity:
+    seedPath: ~/.config/nats/cortex.nk
+    publicKey: UD7OGEVBNJAUQ57H5NHSPJZOKKOXOZ4DEUJVAO5URHBIUAVSVTJGL4QV
+
+# -----------------------------------------------------------------------------
+# bus — application-level JetStream stream / consumer provisioning
+# -----------------------------------------------------------------------------
+bus:
+  review:
+    stream:
+      name: CODE_REVIEW
+      maxAgeSeconds: 86400      # 24h retention for unclaimed review tasks
+      maxBytes: 536870912       # 512 MiB finite cap
+    consumer:
+      maxDeliver: 5             # attempts before JetStream stops redelivery

--- a/docs/plan-internet-of-agentic-work.md
+++ b/docs/plan-internet-of-agentic-work.md
@@ -743,9 +743,9 @@ Neither epic flips the principal-facing schema in a breaking way: CFG ships a tr
 
 #### CFG.b Extract `system.yaml` (isolate the `nats.subjects` landmine)
 
-- [ ] **CFG.b.1** Move the cross-cutting machine config — `claude`, `execution`, `attachments`, `paths`, `nats`, `bus` — into `system/system.yaml`. The composer folds it into the same `LoadedConfig` slots.
-- [ ] **CFG.b.2** `nats.subjects` is isolated in `system.yaml` as its own clearly-commented block — the single place subject overrides live, removing the per-stack duplication that drives the double-message problem.
-- [ ] **CFG.b.3** Tests: a config with `system.yaml` present resolves `nats`/`bus`/`paths` identically to the pre-split single file; a malformed `nats.subjects` block fails loudly at load (not silently double-publishing).
+- [x] **CFG.b.1** Move the cross-cutting machine config — `claude`, `execution`, `attachments`, `paths`, `nats`, `bus` — into `system/system.yaml`. The composer folds it into the same `LoadedConfig` slots. — #523: composer base layer already merges these slots (CFG.a); CFG.b adds the documented reference layout `docs/config-layout/system/system.yaml` (+ `stacks/research.yaml` + README) proving the substrate blocks fold in unchanged. `LoadedConfig` shape untouched.
+- [x] **CFG.b.2** `nats.subjects` is isolated in `system.yaml` as its own clearly-commented block — the single place subject overrides live, removing the per-stack duplication that drives the double-message problem. — #523: prominently documented in the reference `system.yaml` + `docs/config-layout/README.md`.
+- [x] **CFG.b.3** Tests: a config with `system.yaml` present resolves `nats`/`bus`/`paths` identically to the pre-split single file; a malformed `nats.subjects` block fails loudly at load (not silently double-publishing). — #523: `src/common/types/nats-subjects.ts` (shared `NatsSubjectsSchema` — rejects malformed patterns AND duplicate entries loudly; mirrored onto both `NatsConfigSchema` and legacy `AgentConfigSchema`); tests in `src/common/config/__tests__/system-layer.test.ts` + `src/common/types/__tests__/nats-subjects.test.ts`.
 
 #### CFG.c Move surface bindings out of per-stack `agents.presence` into `surfaces.yaml`
 

--- a/src/common/config/__tests__/system-layer.test.ts
+++ b/src/common/config/__tests__/system-layer.test.ts
@@ -1,0 +1,240 @@
+/**
+ * IAW CFG.b — `system.yaml` substrate layer + the `nats.subjects` landmine.
+ *
+ * CFG.b makes the composer's base layer real: the cross-cutting machine config
+ * (`claude`, `execution`, `attachments`, `paths`, `nats`, `bus`) can live in
+ * `system/system.yaml`, and `nats.subjects` is isolated there as the single
+ * place subject overrides live. These tests prove:
+ *
+ *   (CFG.b.3a) a layout with `system.yaml` present resolves
+ *     `nats` / `bus` / `paths` / `claude` / `execution` IDENTICALLY to the
+ *     equivalent pre-split single file (round-trip fidelity of the substrate
+ *     slots — not just structural composition but the loaded `LoadedConfig`
+ *     view consumers read);
+ *
+ *   (CFG.b.3b) a malformed `nats.subjects` block fails LOUDLY at load — a clear
+ *     error, not a silent partial config that would double-publish. "Malformed"
+ *     covers both a syntactically-invalid pattern AND a duplicate pattern (the
+ *     double-bind footgun behind the double-message problem).
+ *
+ * Fixtures are small synthetic configs in a tmp dir; the repo's documented
+ * reference layout (docs/config-layout/) is loaded separately to prove it is a
+ * valid, composable example.
+ */
+
+import { test, expect, describe, beforeEach, afterEach } from "bun:test";
+import { mkdirSync, writeFileSync, rmSync, existsSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { stringify } from "yaml";
+import { loadConfigWithAgents } from "../loader";
+
+let testDir: string;
+
+beforeEach(() => {
+  testDir = join(tmpdir(), `cortex-systemlayer-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(testDir, { recursive: true });
+});
+
+afterEach(() => {
+  if (testDir && existsSync(testDir)) {
+    rmSync(testDir, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Fixture builders
+// ---------------------------------------------------------------------------
+
+/** The substrate blocks CFG.b.1 moves into system.yaml. */
+function systemBlocks(overrides?: { subjects?: unknown }): Record<string, unknown> {
+  return {
+    claude: {
+      timeoutMs: 300000,
+      asyncTimeoutMs: 900000,
+      disallowedTools: ["Write"],
+    },
+    execution: { default: "local", backends: [] },
+    attachments: {
+      enabled: true,
+      maxFileSizeBytes: 10485760,
+      maxTotalSizeBytes: 26214400,
+      maxAttachmentsPerMessage: 10,
+    },
+    paths: {
+      publishedEventsDir: "/tmp/events/published",
+      logDir: "/tmp/cortex/logs",
+    },
+    nats: {
+      url: "nats://127.0.0.1:4222",
+      name: "cortex",
+      subjects: overrides?.subjects ?? [],
+      identity: {
+        seedPath: "/tmp/cortex.nk",
+        publicKey: "UD7OGEVBNJAUQ57H5NHSPJZOKKOXOZ4DEUJVAO5URHBIUAVSVTJGL4QV",
+      },
+    },
+    bus: {
+      review: {
+        stream: { name: "CODE_REVIEW", maxAgeSeconds: 86400, maxBytes: 536870912 },
+        consumer: { maxDeliver: 5 },
+      },
+    },
+  };
+}
+
+/** The per-stack blocks (principal + agents) that live in stacks/*.yaml. */
+function stackBlocks(): Record<string, unknown> {
+  return {
+    principal: { id: "andreas", displayName: "Andreas" },
+    agents: [
+      {
+        id: "ivy",
+        displayName: "Ivy",
+        persona: "./personas/ivy.md",
+        roles: [],
+        trust: [],
+        presence: {
+          discord: {
+            token: "fake-token-ivy",
+            guildId: "1487023327791808592",
+            agentChannelId: "1487029848164536361",
+            logChannelId: "1487029942129524786",
+          },
+        },
+      },
+    ],
+  };
+}
+
+function writeSingleFile(dir: string, config: Record<string, unknown>): string {
+  const path = join(dir, "cortex.yaml");
+  writeFileSync(path, stringify(config));
+  return path;
+}
+
+/** Write a `system/` + `stacks/` layout and return the conventional path. */
+function writeSystemLayout(
+  dir: string,
+  system: Record<string, unknown>,
+  stack: Record<string, unknown>,
+): string {
+  mkdirSync(join(dir, "system"), { recursive: true });
+  writeFileSync(join(dir, "system", "system.yaml"), stringify(system));
+  mkdirSync(join(dir, "stacks"), { recursive: true });
+  writeFileSync(join(dir, "stacks", "research.yaml"), stringify(stack));
+  return join(dir, "cortex.yaml");
+}
+
+// ---------------------------------------------------------------------------
+// CFG.b.3 (a) — split with system.yaml resolves substrate slots identically
+// ---------------------------------------------------------------------------
+
+describe("CFG.b.3a — system.yaml split resolves substrate slots identically to single file", () => {
+  test("nats / bus / paths / claude / execution match the equivalent single file", () => {
+    const full = { ...systemBlocks(), ...stackBlocks() };
+
+    const singleDir = join(testDir, "single");
+    mkdirSync(singleDir, { recursive: true });
+    const singlePath = writeSingleFile(singleDir, full);
+
+    const splitDir = join(testDir, "split");
+    mkdirSync(splitDir, { recursive: true });
+    const splitPath = writeSystemLayout(splitDir, systemBlocks(), stackBlocks());
+
+    const single = loadConfigWithAgents(singlePath);
+    const split = loadConfigWithAgents(splitPath);
+
+    // Whole-LoadedConfig identity is the strongest assertion.
+    expect(split).toEqual(single);
+
+    // Spell out each substrate slot CFG.b.1 moved into system.yaml so a
+    // regression names the exact slot that drifted.
+    expect(split.config.nats).toEqual(single.config.nats);
+    expect(split.config.paths).toEqual(single.config.paths);
+    expect(split.config.claude).toEqual(single.config.claude);
+    expect(split.config.execution).toEqual(single.config.execution);
+    expect(split.config.attachments).toEqual(single.config.attachments);
+    expect(split.bus).toEqual(single.bus);
+
+    // And confirm the values actually came through (not both-undefined).
+    expect(split.config.nats?.url).toBe("nats://127.0.0.1:4222");
+    expect(split.config.paths?.publishedEventsDir).toBe("/tmp/events/published");
+    expect(split.bus?.review.consumer.maxDeliver).toBe(5);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CFG.b.3 (b) — malformed nats.subjects fails LOUDLY at load
+// ---------------------------------------------------------------------------
+
+describe("CFG.b.3b — malformed nats.subjects fails loudly at load", () => {
+  test("a duplicate subject pattern is rejected (double-bind footgun)", () => {
+    const system = systemBlocks({
+      subjects: ["local.{principal}.{stack}.tasks.*.>", "local.{principal}.{stack}.tasks.*.>"],
+    });
+    const path = writeSystemLayout(testDir, system, stackBlocks());
+    expect(() => loadConfigWithAgents(path)).toThrow(/duplicate subject pattern/i);
+  });
+
+  test("a syntactically-malformed pattern is rejected with a clear error", () => {
+    const system = systemBlocks({ subjects: ["local. bad .subject"] });
+    const path = writeSystemLayout(testDir, system, stackBlocks());
+    expect(() => loadConfigWithAgents(path)).toThrow(/not a valid NATS subscribe pattern/i);
+  });
+
+  test("a non-array nats.subjects is rejected", () => {
+    const system = systemBlocks({ subjects: "local.{principal}.>" });
+    const path = writeSystemLayout(testDir, system, stackBlocks());
+    expect(() => loadConfigWithAgents(path)).toThrow();
+  });
+
+  test("`>` not in final segment is rejected", () => {
+    const system = systemBlocks({ subjects: ["local.>.tasks"] });
+    const path = writeSystemLayout(testDir, system, stackBlocks());
+    expect(() => loadConfigWithAgents(path)).toThrow(/not a valid NATS subscribe pattern/i);
+  });
+
+  test("a valid placeholder + wildcard pattern parses (no false positive)", () => {
+    const system = systemBlocks({
+      subjects: ["local.{principal}.{stack}.tasks.*.>", "local.{principal}.system.>"],
+    });
+    const path = writeSystemLayout(testDir, system, stackBlocks());
+    const loaded = loadConfigWithAgents(path);
+    expect(loaded.config.nats?.subjects).toEqual([
+      "local.{principal}.{stack}.tasks.*.>",
+      "local.{principal}.system.>",
+    ]);
+  });
+
+  test("the failure-loud check is identical on the single-file fallback path", () => {
+    // The same malformed block in a single cortex.yaml must fail the same way —
+    // the validation lives on the schema, not the composer, so neither
+    // ingestion path can sneak a double-publishing config through.
+    const full = {
+      ...systemBlocks({ subjects: ["dup.pattern", "dup.pattern"] }),
+      ...stackBlocks(),
+    };
+    const path = writeSingleFile(testDir, full);
+    expect(() => loadConfigWithAgents(path)).toThrow(/duplicate subject pattern/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CFG.b.1/CFG.b.2 — the documented reference layout is a valid example
+// ---------------------------------------------------------------------------
+
+describe("CFG.b — docs/config-layout reference example composes", () => {
+  test("the reference system/system.yaml + stacks/research.yaml load cleanly", () => {
+    const refDir = join(import.meta.dir, "..", "..", "..", "..", "docs", "config-layout");
+    // The reference stack persona path won't exist, but loadConfigWithAgents
+    // does not resolve agent personas (that's the agents.d fragment loader);
+    // it only validates schema + composes. So this proves the reference layout
+    // is structurally valid and composes via the system.yaml marker.
+    const loaded = loadConfigWithAgents(join(refDir, "cortex.yaml"));
+    expect(loaded.principal?.id).toBe("andreas");
+    expect(loaded.config.nats?.subjects).toEqual([]); // landmine kept safe-default
+    expect(loaded.config.claude?.timeoutMs).toBe(300000);
+    expect(loaded.bus?.review.stream.name).toBe("CODE_REVIEW");
+  });
+});

--- a/src/common/config/loader.ts
+++ b/src/common/config/loader.ts
@@ -264,12 +264,50 @@ function deepMerge(
 }
 
 /**
+ * List `*.yaml` / `*.yml` files in `dir` in deterministic (sorted) order,
+ * skipping dotfiles. Returns `[]` when `dir` is absent. Single source of truth
+ * for the yaml-listing pattern the composer (`listLayerFiles`), the network
+ * loader (`loadNetworkFiles`), and the agents loader (`loadAgentsDirectory`)
+ * all need — extracted so they cannot drift (Echo nit #3 on cortex#525; the
+ * pre-extraction `listLayerFiles` block had already drifted from
+ * `loadNetworkFiles`, which did not skip dotfiles).
+ */
+function listYamlFiles(dir: string): string[] {
+  if (!existsSync(dir)) return [];
+  return readdirSync(dir)
+    .filter((f) => !f.startsWith("."))
+    .filter((f) => f.endsWith(".yaml") || f.endsWith(".yml"))
+    .sort();
+}
+
+/**
  * Read + parse a single YAML layer file into a raw record. Returns `{}` for a
  * file that parses to null/empty (an empty layer contributes nothing to the
  * merge). Throws a clear error on YAML parse failure so a malformed layer
  * fails loudly at load rather than silently dropping config.
+ *
+ * Echo nit #1 on cortex#525 — a per-layer byte cap (parity with the
+ * `FRAGMENT_MAX_BYTES` guard on `loadAgentFromFile`). An unbounded
+ * `readFileSync` against an accident- or attacker-controlled layer file in
+ * `system/` / `stacks/` is the same footgun the fragment loader already guards;
+ * the cap stops a runaway file from consuming memory or stalling the loader.
  */
 function readLayerFile(filePath: string): Record<string, unknown> {
+  let size: number;
+  try {
+    size = statSync(filePath).size;
+  } catch (err) {
+    throw new Error(
+      `config-composer: failed to stat layer ${filePath}: ${err instanceof Error ? err.message : String(err)}`,
+      { cause: err },
+    );
+  }
+  if (size > FRAGMENT_MAX_BYTES) {
+    throw new Error(
+      `config-composer: layer ${filePath} exceeds ${FRAGMENT_MAX_BYTES} bytes (got ${size}); refusing to read`,
+    );
+  }
+
   const content = readFileSync(filePath, "utf-8");
   let parsed: unknown;
   try {
@@ -290,17 +328,14 @@ function readLayerFile(filePath: string): Record<string, unknown> {
 }
 
 /**
- * List `*.yaml` / `*.yml` files in `dir` in deterministic (sorted) order.
- * Returns `[]` when `dir` is absent — an optional layer directory contributes
- * nothing. Dotfiles are skipped (matching `loadAgentsDirectory`).
+ * List `*.yaml` / `*.yml` layer files in `dir` as full paths, in deterministic
+ * (sorted) order. Returns `[]` when `dir` is absent — an optional layer
+ * directory contributes nothing. Thin wrapper over the shared `listYamlFiles`
+ * helper that joins each entry to `dir` (the composer wants paths; the agents +
+ * networks loaders want filenames to re-join against an expanded base dir).
  */
 function listLayerFiles(dir: string): string[] {
-  if (!existsSync(dir)) return [];
-  return readdirSync(dir)
-    .filter((f) => !f.startsWith("."))
-    .filter((f) => f.endsWith(".yaml") || f.endsWith(".yml"))
-    .sort()
-    .map((f) => join(dir, f));
+  return listYamlFiles(dir).map((f) => join(dir, f));
 }
 
 /**
@@ -316,7 +351,10 @@ function listLayerFiles(dir: string): string[] {
  * yields — so the existing `loadConfigWithAgents` parse/build is unchanged.
  */
 export function composeRawConfig(configPath: string): Record<string, unknown> {
-  const expandedPath = configPath.replace(/^~/, process.env.HOME ?? "~");
+  // Echo nit #2 on cortex#525 — use the fail-loud `expandTilde` helper instead
+  // of the silent `.replace(/^~/, … ?? "~")` form (which left a literal `~`
+  // when $HOME was unset, then failed obscurely deep in `readFileSync`).
+  const expandedPath = expandTilde(configPath);
   const configDir = dirname(expandedPath);
   const markerPath = join(configDir, LAYOUT_MARKER);
 
@@ -371,11 +409,15 @@ export function composeRawConfig(configPath: string): Record<string, unknown> {
  * unchanged across both paths.
  */
 export function loadConfigWithAgents(path: string): LoadedConfig {
-  const expandedPath = path.replace(/^~/, process.env.HOME ?? "~");
+  // Echo nit #2 on cortex#525 — expand the tilde ONCE here via the fail-loud
+  // helper, then hand the already-expanded path to `composeRawConfig`
+  // (`expandTilde` is idempotent on an absolute path), removing the redundant
+  // double expansion that previously happened in both functions.
+  const expandedPath = expandTilde(path);
   const configDir = dirname(expandedPath);
 
   // CFG.a.1/CFG.a.2 — compose from directory layout or fall back to single file.
-  const raw = composeRawConfig(path);
+  const raw = composeRawConfig(expandedPath);
 
   // Networks load against the on-disk path regardless of legacy/cortex shape —
   // both shapes share the same networks/ contract (G-500).
@@ -833,10 +875,7 @@ export function loadAgentsDirectory(dir: string): Agent[] {
     return [];
   }
 
-  const files = readdirSync(expandedDir)
-    .filter((f) => !f.startsWith("."))
-    .filter((f) => f.endsWith(".yaml") || f.endsWith(".yml"))
-    .sort();
+  const files = listYamlFiles(expandedDir);
 
   const agents: Agent[] = [];
   const seenIds = new Map<string, string>();
@@ -878,9 +917,7 @@ function loadNetworkFiles(networksDir: string, explicit: boolean): NetworkFile[]
     return [];
   }
 
-  const files = readdirSync(networksDir)
-    .filter(f => f.endsWith(".yaml") || f.endsWith(".yml"))
-    .sort();
+  const files = listYamlFiles(networksDir);
 
   const networks: NetworkFile[] = [];
   const seenIds = new Map<string, string>();

--- a/src/common/types/__tests__/nats-subjects.test.ts
+++ b/src/common/types/__tests__/nats-subjects.test.ts
@@ -1,0 +1,80 @@
+/**
+ * IAW CFG.b.3 — unit tests for the shared `nats.subjects` validator
+ * (src/common/types/nats-subjects.ts). The schema-level loud-failure behaviour
+ * is exercised end-to-end in src/common/config/__tests__/system-layer.test.ts;
+ * here we pin the primitives the schema is built from.
+ */
+
+import { test, expect, describe } from "bun:test";
+import {
+  NATS_SUBSCRIBE_SUBJECT_RE,
+  invalidSubscribeSubjectReason,
+  firstDuplicateSubject,
+  NatsSubjectsSchema,
+} from "../nats-subjects";
+
+describe("NATS_SUBSCRIBE_SUBJECT_RE — subscribe-pattern grammar", () => {
+  const valid = [
+    "local.andreas.research.tasks.chat",
+    "local.{principal}.{stack}.tasks.*.>",
+    "local.{principal}.system.>",
+    "federated.research-collab.tasks.code_review",
+    "*",
+    ">",
+    "a.*.b",
+    "tasks.*.>",
+  ];
+  for (const s of valid) {
+    test(`accepts "${s}"`, () => {
+      expect(NATS_SUBSCRIBE_SUBJECT_RE.test(s)).toBe(true);
+      expect(invalidSubscribeSubjectReason(s)).toBeNull();
+    });
+  }
+
+  const invalid = [
+    "",                       // empty
+    "local. bad .subject",    // whitespace in segments
+    "local.>.tasks",          // `>` not final
+    "local..tasks",           // empty segment
+    ".leading.dot",           // leading dot
+    "trailing.dot.",          // trailing dot
+    "UPPER.case",             // uppercase not allowed
+    "local.{unknown}.x",      // unknown placeholder token
+    "local.{principal}>.x",   // malformed placeholder/wildcard mash
+  ];
+  for (const s of invalid) {
+    test(`rejects "${s}"`, () => {
+      expect(invalidSubscribeSubjectReason(s)).not.toBeNull();
+    });
+  }
+});
+
+describe("firstDuplicateSubject", () => {
+  test("returns null for a distinct list", () => {
+    expect(firstDuplicateSubject(["a.b", "a.c", "d.>"])).toBeNull();
+  });
+  test("returns the first duplicated pattern", () => {
+    expect(firstDuplicateSubject(["a.b", "a.c", "a.b"])).toBe("a.b");
+  });
+});
+
+describe("NatsSubjectsSchema", () => {
+  test("defaults to []", () => {
+    expect(NatsSubjectsSchema.parse(undefined)).toEqual([]);
+  });
+  test("accepts a valid list", () => {
+    expect(
+      NatsSubjectsSchema.parse(["local.{principal}.{stack}.tasks.*.>"]),
+    ).toEqual(["local.{principal}.{stack}.tasks.*.>"]);
+  });
+  test("rejects a malformed entry", () => {
+    expect(() => NatsSubjectsSchema.parse(["bad subject"])).toThrow(
+      /not a valid NATS subscribe pattern/i,
+    );
+  });
+  test("rejects a duplicate entry with the first-seen index", () => {
+    expect(() => NatsSubjectsSchema.parse(["x.y", "x.y"])).toThrow(
+      /duplicate subject pattern.*x\.y.*first seen at index 0/i,
+    );
+  });
+});

--- a/src/common/types/config.ts
+++ b/src/common/types/config.ts
@@ -8,6 +8,7 @@
 
 import { z } from "zod/v4";
 import { NKEY_PUBKEY_REGEX } from "./nkey";
+import { NatsSubjectsSchema } from "./nats-subjects";
 
 // =============================================================================
 // Helper: typed empty default for nested Zod object schemas.
@@ -505,8 +506,12 @@ export const AgentConfigSchema = z.object({
      * provide at least one pattern when enabling NATS. The placeholder
      * `{principal}` is substituted with the boot-resolved `principal.id`
      * at runtime so a single template works across principals.
+     *
+     * MIRROR: `NatsConfigSchema.subjects` in `./cortex-config.ts`. Both use
+     * the shared `NatsSubjectsSchema` (IAW CFG.b.3) so a malformed or
+     * duplicate pattern fails loudly at load on either config shape.
      */
-    subjects: z.array(z.string().min(1)).default([]),
+    subjects: NatsSubjectsSchema,
     /**
      * Absolute path to operator account signing nkey file. Loaded into
      * daemon memory only. File MUST be chmod 600 (loader enforces).

--- a/src/common/types/cortex-config.ts
+++ b/src/common/types/cortex-config.ts
@@ -41,6 +41,7 @@ import {
   NetworkFileSchema,
 } from "./config";
 import { NKEY_PUBKEY_REGEX } from "./nkey";
+import { NatsSubjectsSchema } from "./nats-subjects";
 import { LETTER_PREFIX_ID_REGEX } from "./id";
 import { StackConfigSchema } from "./stack";
 
@@ -875,10 +876,16 @@ export const NatsConfigSchema = z.object({
   /** Connection name surfaced on the server's varz endpoint. */
   name: z.string().default("cortex"),
   /**
-   * Subject patterns to subscribe to. Default empty. `{principal}` is substituted
-   * with `principal.id` at runtime.
+   * Subject patterns to subscribe to. Default empty (pull-only, cortex#337).
+   * `{principal}` / `{stack}` are substituted at runtime.
+   *
+   * IAW CFG.b.2/CFG.b.3 — this is the single place subject overrides live, and
+   * the validator (`NatsSubjectsSchema`) fails LOUDLY on a malformed entry or a
+   * duplicate pattern. A duplicate here double-binds the boot subscriber and
+   * delivers every envelope twice (the double-message problem, cortex#491), so
+   * it is rejected at load rather than silently double-publishing.
    */
-  subjects: z.array(z.string().min(1)).default([]),
+  subjects: NatsSubjectsSchema,
   /** Optional NKey identity for envelope signing (MY-400). */
   identity: NatsIdentitySchema.optional(),
   /**

--- a/src/common/types/nats-subjects.ts
+++ b/src/common/types/nats-subjects.ts
@@ -1,0 +1,131 @@
+/**
+ * IAW CFG.b.3 — shared, fail-loud validator for the `nats.subjects` block.
+ *
+ * `nats.subjects` is the single place subject overrides live (CFG.b.2): the
+ * push-mode broad-pattern subscriber list the daemon binds at boot. It is the
+ * landmine behind the double-message problem — a duplicate or malformed pattern
+ * here re-creates a boot-subscriber that double-binds the same handler set, so
+ * every inbound chat/Direct/Delegate envelope is delivered AND dispatched twice
+ * (cortex#491, the `pre-natsdedup` backup era). The whole point of isolating the
+ * block in `system.yaml` is that this validation can be the one true gate.
+ *
+ * The contract is therefore: a malformed `nats.subjects` block fails LOUDLY at
+ * config load — a clear zod error — rather than parsing into a silently-partial
+ * config that would double-publish. "Malformed" means any of:
+ *
+ *   1. not an array of strings (caught by the element schema);
+ *   2. an entry that is not a syntactically-valid NATS subject pattern
+ *      (whitespace, empty segments, `>` not in final position, etc.);
+ *   3. a DUPLICATE entry — two identical patterns bind the same subscription
+ *      twice, which is exactly the double-publish footgun.
+ *
+ * Why centralised: the block lives in TWO schemas during the MIG-7.2 overlap
+ * window — `NatsConfigSchema` (cortex-config.ts) and the inline `nats` block in
+ * `AgentConfigSchema` (config.ts). Both flow to the same runtime subscribe path
+ * (`MyelinRuntime`'s boot-time `nats.subjects` loop), so both can double-publish.
+ * One validator, one source of truth — mirrors the `nkey.ts` precedent.
+ */
+
+import { z } from "zod/v4";
+
+/**
+ * NATS subject pattern grammar for `nats.subjects[]` entries.
+ *
+ * Unlike the federation `accept_subjects[]`/`deny_subjects[]` grammar (which is
+ * deliberately placeholder-free), `nats.subjects[]` patterns carry the
+ * `{principal}` / `{stack}` substitution tokens that `makeSubjectPlaceholderSubstituter`
+ * resolves at runtime (see `src/bus/myelin/runtime.ts`). The grammar therefore
+ * admits, per dotted segment:
+ *
+ *   - a lowercase-alphanumeric token: `[a-z][a-z0-9_-]*`
+ *   - a single-segment wildcard: `*`
+ *   - a placeholder token: `{principal}` or `{stack}`
+ *
+ * plus an optional trailing `>` multi-segment wildcard as the FINAL segment only.
+ *
+ * Segments are dot-separated with no empty segments (no leading/trailing dot, no
+ * `..`), and no whitespace anywhere. A bare `>` is permitted here (unlike the
+ * federation grammar) — `nats.subjects` is the local subscriber interest list,
+ * not a federation accept-list, so a catch-all local subscription is a legitimate
+ * (if rarely-wanted) choice the principal makes explicitly.
+ */
+export const NATS_SUBSCRIBE_SUBJECT_RE =
+  /^(([a-z][a-z0-9_-]*|\*|\{principal\}|\{stack\}))(\.([a-z][a-z0-9_-]*|\*|\{principal\}|\{stack\}))*(\.>)?$|^>$/;
+
+/**
+ * Validate a single `nats.subjects[]` entry. Returns an error string when the
+ * entry is malformed, or `null` when it is a valid subscribe pattern. Pulled
+ * out so the zod schema and any imperative caller share one rule.
+ */
+export function invalidSubscribeSubjectReason(subject: string): string | null {
+  if (subject.length === 0) {
+    return "empty subject pattern";
+  }
+  if (!NATS_SUBSCRIBE_SUBJECT_RE.test(subject)) {
+    return (
+      `"${subject}" is not a valid NATS subscribe pattern — expected ` +
+      `dot-separated lowercase segments (or the {principal}/{stack} placeholders ` +
+      `or a "*" single-segment wildcard), with an optional trailing ">" ` +
+      `multi-segment wildcard as the final segment`
+    );
+  }
+  return null;
+}
+
+/**
+ * Find the first duplicate entry in a subjects list, or `null` when all entries
+ * are distinct. Duplicate patterns are the double-bind footgun: listing the same
+ * pattern twice re-subscribes the same handler set, doubling delivery.
+ */
+export function firstDuplicateSubject(subjects: readonly string[]): string | null {
+  const seen = new Set<string>();
+  for (const s of subjects) {
+    if (seen.has(s)) return s;
+    seen.add(s);
+  }
+  return null;
+}
+
+/**
+ * The `nats.subjects` field schema — an array of validated subscribe patterns
+ * that is also rejected, at parse time, for duplicate entries. Defaults to `[]`
+ * (the documented pull-only default per cortex#337). Shared verbatim by
+ * `NatsConfigSchema` (cortex-config.ts) and the inline `nats` block in
+ * `AgentConfigSchema` (config.ts) so the two cannot drift.
+ *
+ * The element-level pattern check (`.refine` per entry) catches malformed
+ * patterns with a precise message; the array-level `.superRefine` catches a
+ * duplicate and attaches the error to the offending index so the principal sees
+ * exactly which line in their `system.yaml` to delete. Either failure throws a
+ * zod error at `loadConfigWithAgents` — a loud load-time failure, never a silent
+ * partial config.
+ */
+export const NatsSubjectsSchema = z
+  .array(
+    z.string().min(1).superRefine((s, ctx) => {
+      const reason = invalidSubscribeSubjectReason(s);
+      if (reason !== null) {
+        ctx.addIssue({ code: "custom", message: `nats.subjects: ${reason}` });
+      }
+    }),
+  )
+  .superRefine((subjects, ctx) => {
+    const seen = new Map<string, number>();
+    for (const [i, s] of subjects.entries()) {
+      const firstAt = seen.get(s);
+      if (firstAt !== undefined) {
+        ctx.addIssue({
+          code: "custom",
+          path: [i],
+          message:
+            `nats.subjects: duplicate subject pattern "${s}" ` +
+            `(first seen at index ${firstAt}). Duplicate patterns double-bind the ` +
+            `same subscription, which delivers and dispatches every matching ` +
+            `envelope twice (the double-message problem). Remove the duplicate.`,
+        });
+      } else {
+        seen.set(s, i);
+      }
+    }
+  })
+  .default([]);


### PR DESCRIPTION
EPIC CFG slice CFG.b (#523, builds on CFG.a #525). Makes the `system.yaml` substrate layer real (reference `docs/config-layout/{system,stacks}/` + README; folds `claude/execution/attachments/paths/nats/bus` into the unchanged `LoadedConfig` via CFG.a's composer) and **hardens the `nats.subjects` landmine**: a new shared `NatsSubjectsSchema` **fails loudly at load** on malformed patterns AND **duplicate entries** — the cortex#491 double-bind that drives the double-message problem — mirrored onto both `NatsConfigSchema` and the legacy `AgentConfig` nats block. Also the 3 CFG.a review nits (per-layer byte cap, `expandTilde` fail-loud, shared `listYamlFiles`).

**`LoadedConfig` shape unchanged; all 3 live single-file configs still load** (fallback unaffected). tsc clean · vocab gate **0** · lint clean · suite **3717 pass / 0 fail** (31 new tests). Next: CFG.c (surfaces.yaml → GW precondition). Part of #523.

🤖 Generated with [Claude Code](https://claude.com/claude-code)