### PR TITLE
feat(mc): G-1113.A.1 — grounding: build-path fix + cockpit docs + glossary + banners

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -84,6 +84,10 @@ _Avoid_: routing, assignment, hand-off. Never call the Offer mode "broadcast" �
 
 ### Surfaces, substrates, dispatch routing
 
+**Mission Control** (the cockpit surface):
+The principal-facing M7 dashboard surface — one pane over plans, work items, sessions, and the attention queue. A **modular React application** (`src/surface/mc/dashboard-v2/`: an `App` shell over per-concern components — `FocusArea`, `WorkingGrid`, `TaskTable`, drill-down — backed by data hooks and pure, independently-testable display helpers), served by the MC server (`src/surface/mc/server.ts`) locally or the CF Worker in cloud. It **replaced the retired monolithic HTML dashboard** (`src/dashboard/`, deleted at the MIG-6 cutover): the surface is composed of small, testable components, not one rendered page. Mission Control plays the **dispatch sink** role for lifecycle envelopes; the cockpit redesign is tracked under G-1113.
+_Avoid_: monolithic dashboard, the HTML dashboard, grove dashboard, `src/dashboard` (retired)
+
 **Substrate harness** (or just **harness**):
 The M6 runtime layer that executes a single **dispatch** on one execution substrate and yields lifecycle **envelopes**. Closed enum of `HarnessId` values: `claude-code`, `bus-peer`, `openai-codex`, `cursor`, `gemini`, `mistral`, `pi-dev`, `agent-team`. The harness boundary is what makes the runner substrate-agnostic — the same `DispatchRequest` flows into any harness; the same `dispatch.task.{action}` envelopes flow out. The `agent-team` harness composes other harnesses to fulfil **Delegate**-mode dispatches.
 _Avoid_: backend, executor, engine, runtime (overloaded with `MyelinRuntime`)

--- a/docs/design-api-security.md
+++ b/docs/design-api-security.md
@@ -1,5 +1,13 @@
 # Grove API Security Hardening — Design Spec
 
+> **⚠️ Historical — lifted from grove-v2.** This document predates the Cortex Mission Control Cockpit
+> redesign and describes grove-v2 architecture, module paths, or naming that no longer match current
+> Cortex. It is retained for design lineage and rationale, **not** as current reference. For the
+> canonical cockpit design and vocabulary see
+> [`design-mission-control-cortex-cockpit.md`](./design-mission-control-cortex-cockpit.md) and
+> [`glossary-mission-control.md`](./glossary-mission-control.md) (tracked under
+> [G-1113](https://github.com/the-metafactory/cortex/issues/354)).
+
 <!-- lifted-from-grove-v2-at-MIG-7.11 -->
 <!-- Original location: github.com/the-metafactory/grove-v2 docs/design-api-security.md -->
 <!-- Lifted: 2026-05-11 — historical references to grove/grove-v2 retained for provenance. -->

--- a/docs/design-cloud-api.md
+++ b/docs/design-cloud-api.md
@@ -1,5 +1,13 @@
 # Cloud API — Design Spec
 
+> **⚠️ Historical — lifted from grove-v2.** This document predates the Cortex Mission Control Cockpit
+> redesign and describes grove-v2 architecture, module paths, or naming that no longer match current
+> Cortex. It is retained for design lineage and rationale, **not** as current reference. For the
+> canonical cockpit design and vocabulary see
+> [`design-mission-control-cortex-cockpit.md`](./design-mission-control-cortex-cockpit.md) and
+> [`glossary-mission-control.md`](./glossary-mission-control.md) (tracked under
+> [G-1113](https://github.com/the-metafactory/cortex/issues/354)).
+
 <!-- lifted-from-grove-v2-at-MIG-7.11 -->
 <!-- Original location: github.com/the-metafactory/grove-v2 docs/design-cloud-api.md -->
 <!-- Lifted: 2026-05-11 — historical references to grove/grove-v2 retained for provenance. -->

--- a/docs/design-dashboard-efficiency.md
+++ b/docs/design-dashboard-efficiency.md
@@ -1,5 +1,13 @@
 # Dashboard Efficiency — Design Spec
 
+> **⚠️ Historical — lifted from grove-v2.** This document predates the Cortex Mission Control Cockpit
+> redesign and describes grove-v2 architecture, module paths, or naming that no longer match current
+> Cortex. It is retained for design lineage and rationale, **not** as current reference. For the
+> canonical cockpit design and vocabulary see
+> [`design-mission-control-cortex-cockpit.md`](./design-mission-control-cortex-cockpit.md) and
+> [`glossary-mission-control.md`](./glossary-mission-control.md) (tracked under
+> [G-1113](https://github.com/the-metafactory/cortex/issues/354)).
+
 <!-- lifted-from-grove-v2-at-MIG-7.11 -->
 <!-- Original location: github.com/the-metafactory/grove-v2 docs/design-dashboard-efficiency.md -->
 <!-- Lifted: 2026-05-11 — historical references to grove/grove-v2 retained for provenance. -->

--- a/docs/design-dm-operator-channel.md
+++ b/docs/design-dm-operator-channel.md
@@ -1,5 +1,13 @@
 # DM Principal Channel — Design Spec
 
+> **⚠️ Historical — lifted from grove-v2.** This document predates the Cortex Mission Control Cockpit
+> redesign and describes grove-v2 architecture, module paths, or naming that no longer match current
+> Cortex. It is retained for design lineage and rationale, **not** as current reference. For the
+> canonical cockpit design and vocabulary see
+> [`design-mission-control-cortex-cockpit.md`](./design-mission-control-cortex-cockpit.md) and
+> [`glossary-mission-control.md`](./glossary-mission-control.md) (tracked under
+> [G-1113](https://github.com/the-metafactory/cortex/issues/354)).
+
 <!-- lifted-from-grove-v2-at-MIG-7.11 -->
 <!-- Original location: github.com/the-metafactory/grove-v2 docs/design-dm-operator-channel.md -->
 <!-- Lifted: 2026-05-11 — historical references to grove/grove-v2 retained for provenance. -->

--- a/docs/design-mc-f12-task-curation.md
+++ b/docs/design-mc-f12-task-curation.md
@@ -1,5 +1,13 @@
 # F-12 — Task curation UX (pre-implementation addendum)
 
+> **⚠️ Historical — lifted from grove-v2.** This document predates the Cortex Mission Control Cockpit
+> redesign and describes grove-v2 architecture, module paths, or naming that no longer match current
+> Cortex. It is retained for design lineage and rationale, **not** as current reference. For the
+> canonical cockpit design and vocabulary see
+> [`design-mission-control-cortex-cockpit.md`](./design-mission-control-cortex-cockpit.md) and
+> [`glossary-mission-control.md`](./glossary-mission-control.md) (tracked under
+> [G-1113](https://github.com/the-metafactory/cortex/issues/354)).
+
 <!-- lifted-from-grove-v2-at-MIG-7.11 -->
 <!-- Original location: github.com/the-metafactory/grove-v2 docs/design-mc-f12-task-curation.md -->
 <!-- Lifted: 2026-05-11 — historical references to grove/grove-v2 retained for provenance. -->

--- a/docs/design-mc-f12b-add-to-queue.md
+++ b/docs/design-mc-f12b-add-to-queue.md
@@ -1,5 +1,13 @@
 # F-12b — "Add to queue" from GitHub issue (pre-implementation addendum)
 
+> **⚠️ Historical — lifted from grove-v2.** This document predates the Cortex Mission Control Cockpit
+> redesign and describes grove-v2 architecture, module paths, or naming that no longer match current
+> Cortex. It is retained for design lineage and rationale, **not** as current reference. For the
+> canonical cockpit design and vocabulary see
+> [`design-mission-control-cortex-cockpit.md`](./design-mission-control-cortex-cockpit.md) and
+> [`glossary-mission-control.md`](./glossary-mission-control.md) (tracked under
+> [G-1113](https://github.com/the-metafactory/cortex/issues/354)).
+
 <!-- lifted-from-grove-v2-at-MIG-7.11 -->
 <!-- Original location: github.com/the-metafactory/grove-v2 docs/design-mc-f12b-add-to-queue.md -->
 <!-- Lifted: 2026-05-11 — historical references to grove/grove-v2 retained for provenance. -->

--- a/docs/design-mc-f18-metrics.md
+++ b/docs/design-mc-f18-metrics.md
@@ -1,5 +1,13 @@
 # F-18 — Mission Control metrics (pre-implementation addendum)
 
+> **⚠️ Historical — lifted from grove-v2.** This document predates the Cortex Mission Control Cockpit
+> redesign and describes grove-v2 architecture, module paths, or naming that no longer match current
+> Cortex. It is retained for design lineage and rationale, **not** as current reference. For the
+> canonical cockpit design and vocabulary see
+> [`design-mission-control-cortex-cockpit.md`](./design-mission-control-cortex-cockpit.md) and
+> [`glossary-mission-control.md`](./glossary-mission-control.md) (tracked under
+> [G-1113](https://github.com/the-metafactory/cortex/issues/354)).
+
 <!-- lifted-from-grove-v2-at-MIG-7.11 -->
 <!-- Original location: github.com/the-metafactory/grove-v2 docs/design-mc-f18-metrics.md -->
 <!-- Lifted: 2026-05-11 — historical references to grove/grove-v2 retained for provenance. -->

--- a/docs/design-mc-f7-attention-view.md
+++ b/docs/design-mc-f7-attention-view.md
@@ -1,5 +1,13 @@
 # F-7 — Attention drill-down view (pre-implementation addendum)
 
+> **⚠️ Historical — lifted from grove-v2.** This document predates the Cortex Mission Control Cockpit
+> redesign and describes grove-v2 architecture, module paths, or naming that no longer match current
+> Cortex. It is retained for design lineage and rationale, **not** as current reference. For the
+> canonical cockpit design and vocabulary see
+> [`design-mission-control-cortex-cockpit.md`](./design-mission-control-cortex-cockpit.md) and
+> [`glossary-mission-control.md`](./glossary-mission-control.md) (tracked under
+> [G-1113](https://github.com/the-metafactory/cortex/issues/354)).
+
 <!-- lifted-from-grove-v2-at-MIG-7.11 -->
 <!-- Original location: github.com/the-metafactory/grove-v2 docs/design-mc-f7-attention-view.md -->
 <!-- Lifted: 2026-05-11 — historical references to grove/grove-v2 retained for provenance. -->

--- a/docs/design-mc-f9-working-grid.md
+++ b/docs/design-mc-f9-working-grid.md
@@ -1,5 +1,13 @@
 # F-9 — Working-agent grid (pre-implementation addendum)
 
+> **⚠️ Historical — lifted from grove-v2.** This document predates the Cortex Mission Control Cockpit
+> redesign and describes grove-v2 architecture, module paths, or naming that no longer match current
+> Cortex. It is retained for design lineage and rationale, **not** as current reference. For the
+> canonical cockpit design and vocabulary see
+> [`design-mission-control-cortex-cockpit.md`](./design-mission-control-cortex-cockpit.md) and
+> [`glossary-mission-control.md`](./glossary-mission-control.md) (tracked under
+> [G-1113](https://github.com/the-metafactory/cortex/issues/354)).
+
 <!-- lifted-from-grove-v2-at-MIG-7.11 -->
 <!-- Original location: github.com/the-metafactory/grove-v2 docs/design-mc-f9-working-grid.md -->
 <!-- Lifted: 2026-05-11 — historical references to grove/grove-v2 retained for provenance. -->

--- a/docs/design-mission-control-cortex-cockpit.md
+++ b/docs/design-mission-control-cortex-cockpit.md
@@ -1,0 +1,609 @@
+# Mission Control Cortex Cockpit
+
+**Status:** draft for review  
+**Tracking:** G-1113 — the-metafactory/cortex#354  
+**Owners:** Andreas + Soma  
+**Scope:** Re-ground Mission Control after the grove-v2 to Cortex/Myelin/NATS migration.
+
+## 1. Purpose
+
+Mission Control should become the operator cockpit for a Cortex stack. The
+operator should be able to see what assistants and Cortex agents are doing,
+inspect their current context, notice when work needs attention, provide input
+or review feedback, and watch higher-level plans move through issues, pull
+requests, checks, releases, and deployments.
+
+The original Grove v2 Mission Control vision is still the source material:
+attention, drill-down, input return, notifications, task curation, and live
+agent observability. The substrate underneath has changed. Cortex now has stack
+identity, Myelin/NATS, signed envelopes, capability dispatch, local substrate
+sessions, and multiple collaboration surfaces.
+
+This document translates the Grove v2 vision into Cortex terminology and adds
+a plan-level view above individual tasks.
+
+## 2. Design Lineage
+
+Compass defines the document and execution chain:
+
+```text
+Research
+  -> Design decisions
+      -> Roadmap
+          -> Design specs
+              -> Iteration / migration / release plans
+                  -> Umbrella issues
+                      -> Feature issues / work items
+                          -> Pull requests
+                              -> Code
+```
+
+Mission Control should be the runtime view of that chain. It should not only
+show individual sessions. It should show how sessions, issues, pull requests,
+reviews, commits, checks, and releases roll up into a larger plan.
+
+## 3. Core Concepts
+
+### 3.1 Stack
+
+A stack is the Cortex runtime boundary. It owns:
+
+- stack identity
+- signing key
+- policy principals
+- agents and presences
+- Myelin/NATS subjects
+- local execution permissions
+
+Examples:
+
+- `andreas/meta-factory`
+- `andreas/work`
+
+Mission Control is scoped to one stack at a time, with future support for a
+multi-stack overview.
+
+### 3.2 Assistant And Cortex Agent
+
+Use Soma's layer split:
+
+- **assistant**: persistent named being, such as Luna, PAI, or Sage.
+- **Cortex agent**: the stack-local daemon/process identity that hosts or
+  represents assistant work on Myelin/NATS.
+
+Mission Control may show both. The operator cares about the assistant name,
+while the runtime needs the stack-local Cortex agent identity and signing
+provenance.
+
+### 3.3 Substrate And Session
+
+A substrate is the runtime where work is performed:
+
+- Codex
+- Claude Code
+- Pi.dev
+- Cortex/Myelin daemon
+- future local or remote execution hosts
+
+A session is one running substrate interaction. It has:
+
+- assistant / Cortex agent
+- stack
+- task or work item
+- substrate
+- prompt/input context
+- event stream
+- tool calls
+- status
+- attention state
+
+### 3.4 Task
+
+A task is Mission Control's local unit of work. It can originate from many
+places, but it is not identical to its provider object.
+
+Examples of task sources:
+
+- manual/internal task
+- GitHub issue
+- GitLab issue
+- Azure Boards work item
+- Jira issue
+- Linear issue
+- routine-generated task
+- dispatch-generated task
+
+Provider identity is metadata on the task, not the task itself.
+
+### 3.5 Plan
+
+A plan is the work-management layer above tasks.
+
+Plan kinds:
+
+- research plan
+- design plan
+- migration plan
+- iteration plan
+- release plan
+- rollout plan
+- incident response plan
+
+A plan has a source document and a set of phases or waves. It may be backed by
+an umbrella issue, a Jira version, an Azure Boards epic, a Linear project, or a
+repo-local markdown file.
+
+### 3.6 Phase Or Wave
+
+A phase or wave is an ordered slice of a plan. It groups work items under a
+high-level concept.
+
+Examples:
+
+- `Phase A — Data foundation`
+- `Wave 2 — Slack work stack`
+- `MIG-7 — top-level Cortex wiring`
+- `v2.0.6 release hardening`
+
+The UI may use either "phase" or "wave" depending on the plan's own language,
+but the model should treat them as the same structural concept.
+
+### 3.7 Work Item
+
+A work item is the provider-backed executable tracking object under a phase.
+
+Examples:
+
+- GitHub issue
+- GitLab issue
+- Azure Boards work item
+- Jira issue
+- Linear issue
+- internal Mission Control task
+
+Work items can have child work items, and a plan can have an umbrella work
+item that rolls up progress from child work items.
+
+### 3.8 Git Objects
+
+Software mode must preserve Git-native nouns. These are first-class concepts,
+not vague "work products":
+
+- repository
+- branch
+- commit
+- tag
+- release
+- pull request
+- review
+- check / status check
+- build
+- deployment
+- artifact
+
+The provider is abstracted; the Git concept is not. For example, a GitLab
+merge request maps to Mission Control's pull request concept while retaining
+`providerNativeType: "merge_request"` for display and provider API calls.
+
+## 4. Modes
+
+Mission Control should support modes or lenses. The model stays shared; the UI
+changes what it promotes.
+
+### 4.1 Generic Mode
+
+Generic mode centers:
+
+- tasks
+- source refs
+- assignees
+- status
+- priority
+- comments
+- sessions
+- attention items
+
+This mode works for non-software workflows and for provider backends such as
+Jira, Linear, or Azure Boards when no Git objects are attached.
+
+### 4.2 Software Mode
+
+Software mode promotes software-development objects:
+
+- repositories
+- branches
+- commits
+- tags
+- releases
+- pull requests / merge requests
+- reviews
+- checks and builds
+- deployments
+- artifacts
+
+This mirrors Jira Software: a generic task/work-item system becomes a software
+cockpit when connected to source control, CI, and release providers.
+
+Software mode should be the first real Cortex Mission Control mode because the
+immediate operator workflows are software-agent workflows.
+
+## 5. Provider Neutrality
+
+Mission Control should be provider-neutral at the source/ref boundary.
+
+Provider-specific adapters or taps normalize provider-native objects into
+Mission Control concepts:
+
+| Provider object | Mission Control concept |
+| --- | --- |
+| GitHub issue | Work item |
+| GitLab issue | Work item |
+| Azure Boards work item | Work item |
+| Jira issue | Work item |
+| Linear issue | Work item |
+| GitHub pull request | Pull request |
+| GitLab merge request | Pull request with native label "Merge request" |
+| Azure DevOps pull request | Pull request |
+| Git tag | Tag |
+| GitHub release | Release |
+| GitLab release | Release |
+| Azure DevOps build | Check / build |
+
+The UI should use provider-native labels when they help the operator, but the
+core model should not fork by provider.
+
+### 5.1 GitHub Abstraction Is In Scope
+
+Cortex currently has real GitHub-specific implementation: webhook ingestion,
+issue/PR import, GitHub URL parsing, `github.repos` config, GitHub event
+envelopes, and dashboard inbox paths that assume `source=github`.
+
+This design treats that as implementation history, not as the target Mission
+Control model. Abstracting GitHub into provider-neutral Mission Control concepts
+is in scope for this cockpit line of work.
+
+The rule:
+
+- keep Git-native concepts concrete: repository, branch, commit, tag, release,
+  pull request, review, check, build, deployment, artifact
+- abstract the provider layer: GitHub, GitLab, Azure DevOps, Bitbucket, custom
+- preserve provider-native display labels where useful
+- keep existing GitHub behavior working while moving it behind normalized
+  source/work-item/Git-object boundaries
+
+In other words, GitHub becomes the first provider adapter for the new model, not
+the model itself.
+
+## 6. Proposed Domain Model
+
+Illustrative TypeScript shape:
+
+```ts
+type Provider =
+  | "internal"
+  | "github"
+  | "gitlab"
+  | "azure-devops"
+  | "jira"
+  | "linear"
+  | "bitbucket"
+  | "custom";
+
+interface Plan {
+  id: string;
+  title: string;
+  kind: "research" | "design" | "iteration" | "migration" | "release" | "rollout" | "incident";
+  sourceDocumentUrl: string | null;
+  provider: Provider;
+  externalId: string | null;
+  umbrellaWorkItemId: string | null;
+  status: "draft" | "active" | "blocked" | "done" | "cancelled";
+}
+
+interface PlanPhase {
+  id: string;
+  planId: string;
+  title: string;
+  order: number;
+  status: "not_started" | "active" | "blocked" | "done" | "cancelled";
+}
+
+interface WorkItem {
+  id: string;
+  planId: string | null;
+  phaseId: string | null;
+  parentId: string | null;
+  title: string;
+  description: string | null;
+  status: string;
+  priority: string;
+  provider: Provider;
+  externalId: string | null;
+  url: string | null;
+}
+
+interface GitRepository {
+  id: string;
+  provider: Provider;
+  owner: string | null;
+  name: string;
+  url: string | null;
+  defaultBranch: string | null;
+}
+
+interface GitBranch {
+  id: string;
+  repositoryId: string;
+  name: string;
+  baseRef: string | null;
+  headSha: string | null;
+  provider: Provider;
+  externalId: string | null;
+  url: string | null;
+}
+
+interface GitCommit {
+  id: string;
+  repositoryId: string;
+  sha: string;
+  title: string;
+  author: string | null;
+  url: string | null;
+}
+
+interface PullRequest {
+  id: string;
+  workItemId: string | null;
+  repositoryId: string;
+  provider: Provider;
+  providerNativeType: "pull_request" | "merge_request" | string;
+  externalId: string;
+  numberOrKey: string;
+  title: string;
+  sourceBranch: string;
+  targetBranch: string;
+  url: string;
+  state: "draft" | "open" | "merged" | "closed";
+  reviewState: "none" | "needs_review" | "changes_requested" | "approved";
+}
+
+interface Release {
+  id: string;
+  repositoryId: string | null;
+  provider: Provider;
+  externalId: string | null;
+  name: string;
+  tagName: string | null;
+  url: string | null;
+  state: "draft" | "published" | "failed" | "archived";
+}
+
+interface Session {
+  id: string;
+  stackId: string;
+  assistantId: string;
+  cortexAgentId: string | null;
+  substrate: string;
+  workItemId: string | null;
+  status: "queued" | "running" | "blocked" | "completed" | "failed" | "cancelled";
+}
+
+interface AttentionItem {
+  id: string;
+  stackId: string;
+  workItemId: string | null;
+  sessionId: string | null;
+  kind: "input_needed" | "permission" | "review" | "failed_dispatch" | "stale" | "blocked";
+  severity: "low" | "normal" | "high" | "critical";
+  status: "open" | "resolved" | "dismissed";
+}
+```
+
+This is not a final schema. It is the vocabulary boundary the implementation
+should converge toward.
+
+## 7. UI Shape
+
+### 7.1 Plan Overview
+
+Top-level plan view:
+
+- plan title and source document
+- current phase/wave
+- progress by phase
+- open/blocked/done work item counts
+- pull request counts by review state
+- release/deployment status when present
+- attention summary
+
+Example:
+
+```text
+Cortex v2.0.6 Release Plan
+Phase A  Docs and grounding      3/4 done
+Phase B  Software mode model     1/5 active
+Phase C  Live session rollup     blocked
+Phase D  Release and rollout     not started
+```
+
+### 7.2 Phase Detail
+
+Phase detail shows:
+
+- work items in the phase
+- assigned assistant / Cortex agent
+- current session status
+- linked branches
+- linked pull requests
+- checks and reviews
+- attention items
+
+### 7.3 Work Item Detail
+
+Work item detail is the operational drill-down:
+
+- source provider and external link
+- current assistant/session
+- event log
+- branch and pull request links
+- review comments
+- checks/builds
+- operator input box
+- curation actions: dispatch, requeue, abandon, hand off
+
+### 7.4 Attention Queue
+
+Attention queue cuts across plans and phases:
+
+- blocked sessions
+- permission requests
+- review checkpoints
+- failed dispatches
+- stale work
+- PR review requests
+- failing checks requiring triage
+
+Every attention item should deep-link to the exact plan, phase, work item,
+pull request, or session that needs action.
+
+## 8. Pipeline Rollup
+
+Mission Control should be able to answer:
+
+- Which plan is this work part of?
+- Which phase/wave is currently active?
+- Which work items are blocked?
+- Which pull requests are waiting for review?
+- Which branches are active but have no pull request?
+- Which checks are failing?
+- Which sessions are running, stale, or waiting for input?
+- Which releases are ready, blocked, or shipped?
+
+This is the pane-of-glass goal: the operator sees the whole execution pipeline
+from design document to release.
+
+## 9. Relation To Existing Cortex Mission Control
+
+Current Cortex Mission Control already has:
+
+- React dashboard under `src/surface/mc/dashboard-v2/`
+- tasks
+- assignments
+- sessions
+- event log
+- focus area
+- working-agent grid
+- iteration board
+- metrics
+- GitHub-specific issue/PR ingestion pieces
+
+Known drift to resolve:
+
+- docs still refer to `src/mission-control` even though Cortex uses
+  `src/surface/mc`
+- package scripts still point at the old dashboard path
+- task source schema is still constrained around GitHub/internal
+- GitHub parser/fetch code is provider-specific
+- inbox views assume `source=github`
+
+### 9.1 Current UI Findings
+
+The existing React UI has useful structure:
+
+- `App` owns the top-level tabs: default execution view, metrics, iterations,
+  and iteration detail.
+- The default view already gives the operator execution visibility through
+  `FocusArea`, `WorkingGrid`, and `TaskTable`.
+- The drill-down overlay already gives a session/assignment attention surface:
+  `DrillHeader`, `DrillLog`, `CurationToolbar`, and `DrillInput`.
+- The iterations view already has a kanban board plus a full-page detail view.
+- The task table already supports dispatch and links tasks to iteration detail.
+- The hook/test layout is relatively modular: data hooks, pure display helpers,
+  and component tests already exist under `dashboard-v2/`.
+
+The existing UI gaps are equally clear:
+
+- "Iteration" is currently a kanban/task wrapper, not the plan-lineage object
+  described in this document.
+- There is no top-level plan/program view that rolls up phases/waves, work
+  items, pull requests, branches, checks, releases, sessions, and attention.
+- GitHub-specific source assumptions leak into the task/inbox flow.
+- Git objects are not first-class UI/model concepts yet. Branches, pull
+  requests, checks, releases, and deployments appear only indirectly or through
+  provider-specific paths.
+- The dashboard still carries Grove-era language in comments and docs.
+
+### 9.2 Response To Findings
+
+The next cycle should preserve the current surfaces and evolve them:
+
+- Keep `FocusArea`, `WorkingGrid`, `TaskTable`, and `DrillDown` as the
+  execution cockpit foundation.
+- Recast the existing `Iterations` tab into a broader `Plans` or `Work Plans`
+  surface rather than adding plan lineage to the task table.
+- Treat the current iteration board/detail as a candidate implementation
+  substrate for plan phases/waves, not as the final information architecture.
+- Add provider-neutral source refs and first-class Git objects behind the UI
+  before adding new visual affordances that depend on them.
+- Keep GitHub working as the first provider while moving GitHub parsing/fetching
+  behind provider adapter boundaries.
+- Rename or annotate Grove-era comments/docs only when they mislead current
+  Cortex work; avoid noisy historical churn.
+
+## 10. First Implementation Slices
+
+### Slice 1 — Grounding PR
+
+- Add this design document.
+- Fix dashboard build/watch script paths.
+- Mark lifted Grove v2 docs as historical/source material where needed.
+- Add a short glossary in the docs index or Mission Control design area.
+- Record the current UI findings from §9.1 as the baseline for follow-up work.
+
+### Slice 2 — Provider-Neutral Source Refs
+
+- Relax source provider vocabulary in types and schema.
+- Add normalized source ref helpers.
+- Keep GitHub behavior working.
+- Add tests with GitHub, GitLab, Azure DevOps, Jira, and internal examples.
+- Move GitHub-specific parsing/fetching behind adapter-shaped boundaries where
+  the Mission Control model consumes normalized source refs.
+
+### Slice 3 — Software Mode Model
+
+- Add first-class Git object types for repository, branch, commit, tag,
+  release, pull request, review, check/build, deployment, and artifact.
+- Map existing GitHub data into the new model.
+- Preserve provider-native display labels.
+- Ensure branch is represented explicitly as a Git object, because feature
+  branches are central to Compass worktree and pull-request workflow.
+
+### Slice 4 — Plan Lineage UI
+
+- Add a plan overview surface.
+- Roll up phase/work-item/pull-request/session state.
+- Link existing iteration board concepts into the new plan model.
+- Decide whether the existing `Iterations` tab becomes `Plans` directly or
+  remains a compatibility view while the new plan surface lands beside it.
+
+### Slice 5 — Attention And Notifications
+
+- Connect blocked sessions, review checkpoints, failed checks, and PR review
+  requests into one attention queue.
+- Route notifications through stack surfaces such as Slack, Discord, or
+  Mattermost.
+
+## 11. Open Questions
+
+1. Should the canonical top-level noun be `Plan`, `Program`, or `Work Plan`?
+2. Should "phase" and "wave" be aliases, or should one be canonical?
+3. Should `PullRequest` be the normalized model name, with GitLab merge request
+   as a provider-native label, or should the model use `ChangeRequest`?
+4. How much of the existing iteration board should be preserved versus folded
+   into the new plan overview?
+5. Which provider should be added first after GitHub: Azure DevOps, GitLab,
+   Jira, or Linear?
+6. Should plan state mirror provider state passively, or should Mission Control
+   write back status changes to provider work items?
+7. Which events should be sourced from Myelin envelopes versus direct provider
+   API/tap ingestion?

--- a/docs/design-mission-control-cortex-cockpit.md
+++ b/docs/design-mission-control-cortex-cockpit.md
@@ -7,8 +7,8 @@
 
 ## 1. Purpose
 
-Mission Control should become the operator cockpit for a Cortex stack. The
-operator should be able to see what assistants and Cortex agents are doing,
+Mission Control should become the principal cockpit for a Cortex stack. The
+principal should be able to see what assistants and Cortex agents are doing,
 inspect their current context, notice when work needs attention, provide input
 or review feedback, and watch higher-level plans move through issues, pull
 requests, checks, releases, and deployments.
@@ -71,7 +71,7 @@ Use Soma's layer split:
 - **Cortex agent**: the stack-local daemon/process identity that hosts or
   represents assistant work on Myelin/NATS.
 
-Mission Control may show both. The operator cares about the assistant name,
+Mission Control may show both. The principal cares about the assistant name,
 while the runtime needs the stack-local Cortex agent identity and signing
 provenance.
 
@@ -225,7 +225,7 @@ This mirrors Jira Software: a generic task/work-item system becomes a software
 cockpit when connected to source control, CI, and release providers.
 
 Software mode should be the first real Cortex Mission Control mode because the
-immediate operator workflows are software-agent workflows.
+immediate principal workflows are software-agent workflows.
 
 ## 5. Provider Neutrality
 
@@ -249,7 +249,7 @@ Mission Control concepts:
 | GitLab release | Release |
 | Azure DevOps build | Check / build |
 
-The UI should use provider-native labels when they help the operator, but the
+The UI should use provider-native labels when they help the principal, but the
 core model should not fork by provider.
 
 ### 5.1 GitHub Abstraction Is In Scope
@@ -448,7 +448,7 @@ Work item detail is the operational drill-down:
 - branch and pull request links
 - review comments
 - checks/builds
-- operator input box
+- principal input box
 - curation actions: dispatch, requeue, abandon, hand off
 
 ### 7.4 Attention Queue
@@ -479,7 +479,7 @@ Mission Control should be able to answer:
 - Which sessions are running, stale, or waiting for input?
 - Which releases are ready, blocked, or shipped?
 
-This is the pane-of-glass goal: the operator sees the whole execution pipeline
+This is the pane-of-glass goal: the principal sees the whole execution pipeline
 from design document to release.
 
 ## 9. Relation To Existing Cortex Mission Control
@@ -512,7 +512,7 @@ The existing React UI has useful structure:
 
 - `App` owns the top-level tabs: default execution view, metrics, iterations,
   and iteration detail.
-- The default view already gives the operator execution visibility through
+- The default view already gives the principal execution visibility through
   `FocusArea`, `WorkingGrid`, and `TaskTable`.
 - The drill-down overlay already gives a session/assignment attention surface:
   `DrillHeader`, `DrillLog`, `CurationToolbar`, and `DrillInput`.

--- a/docs/design-session-activity.md
+++ b/docs/design-session-activity.md
@@ -1,5 +1,13 @@
 # Live Session Activity — Design Spec
 
+> **⚠️ Historical — lifted from grove-v2.** This document predates the Cortex Mission Control Cockpit
+> redesign and describes grove-v2 architecture, module paths, or naming that no longer match current
+> Cortex. It is retained for design lineage and rationale, **not** as current reference. For the
+> canonical cockpit design and vocabulary see
+> [`design-mission-control-cortex-cockpit.md`](./design-mission-control-cortex-cockpit.md) and
+> [`glossary-mission-control.md`](./glossary-mission-control.md) (tracked under
+> [G-1113](https://github.com/the-metafactory/cortex/issues/354)).
+
 <!-- lifted-from-grove-v2-at-MIG-7.11 -->
 <!-- Original location: github.com/the-metafactory/grove-v2 docs/design-session-activity.md -->
 <!-- Lifted: 2026-05-11 — historical references to grove/grove-v2 retained for provenance. -->

--- a/docs/design-spawn-integration.md
+++ b/docs/design-spawn-integration.md
@@ -1,5 +1,13 @@
 # Grove × Spawn — Execution & Capacity Integration
 
+> **⚠️ Historical — lifted from grove-v2.** This document predates the Cortex Mission Control Cockpit
+> redesign and describes grove-v2 architecture, module paths, or naming that no longer match current
+> Cortex. It is retained for design lineage and rationale, **not** as current reference. For the
+> canonical cockpit design and vocabulary see
+> [`design-mission-control-cortex-cockpit.md`](./design-mission-control-cortex-cockpit.md) and
+> [`glossary-mission-control.md`](./glossary-mission-control.md) (tracked under
+> [G-1113](https://github.com/the-metafactory/cortex/issues/354)).
+
 <!-- lifted-from-grove-v2-at-MIG-7.11 -->
 <!-- Original location: github.com/the-metafactory/grove-v2 docs/design-spawn-integration.md -->
 <!-- Lifted: 2026-05-11 — historical references to grove/grove-v2 retained for provenance. -->

--- a/docs/design-test-rig.md
+++ b/docs/design-test-rig.md
@@ -1,5 +1,13 @@
 # metafactory Test Rig -- Design Spec
 
+> **⚠️ Historical — lifted from grove-v2.** This document predates the Cortex Mission Control Cockpit
+> redesign and describes grove-v2 architecture, module paths, or naming that no longer match current
+> Cortex. It is retained for design lineage and rationale, **not** as current reference. For the
+> canonical cockpit design and vocabulary see
+> [`design-mission-control-cortex-cockpit.md`](./design-mission-control-cortex-cockpit.md) and
+> [`glossary-mission-control.md`](./glossary-mission-control.md) (tracked under
+> [G-1113](https://github.com/the-metafactory/cortex/issues/354)).
+
 <!-- lifted-from-grove-v2-at-MIG-7.11 -->
 <!-- Original location: github.com/the-metafactory/grove-v2 docs/design-test-rig.md -->
 <!-- Lifted: 2026-05-11 — historical references to grove/grove-v2 retained for provenance. -->

--- a/docs/glossary-mission-control.md
+++ b/docs/glossary-mission-control.md
@@ -157,7 +157,7 @@ The lens that promotes software-development objects — [repositories](#reposito
 [branches](#branch), [commits](#commit), [pull requests](#pull-request),
 [reviews](#review), [checks](#check), [releases](#release),
 [deployments](#deployment), [artifacts](#artifact). The first real Cortex Mission
-Control mode, because the immediate operator workflows are software-agent
+Control mode, because the immediate principal workflows are software-agent
 workflows. (Mirrors how Jira Software turns a generic work-item system into a
 software cockpit when connected to source control, CI, and release providers.)
 
@@ -168,7 +168,7 @@ software cockpit when connected to source control, CI, and release providers.)
 A few surface-level terms that recur in the cockpit UI and design docs:
 
 - **Attention queue** — the single "who needs me right now" feed. One entry per
-  blocked/waiting [session](#session) or work item needing the operator.
+  blocked/waiting [session](#session) or work item needing the principal.
 - **Drill-down** — the detail view opened from any card: event log, input
   affordance, and (in software mode) linked Git objects.
 - **Working grid** — the live tiles of [Cortex agents](#cortex-agent) with active

--- a/docs/glossary-mission-control.md
+++ b/docs/glossary-mission-control.md
@@ -1,0 +1,177 @@
+# Glossary — Mission Control Cockpit
+
+> Canonical vocabulary for the Cortex Mission Control cockpit (G-1113). Definitions
+> here are the principal-facing source of truth; they track the core concepts in
+> [`design-mission-control-cortex-cockpit.md`](./design-mission-control-cortex-cockpit.md)
+> §3–§4. When a term in the dashboard, a design doc, or a plan is ambiguous, this
+> file decides it.
+>
+> Tracked under [G-1113 · Mission Control Cockpit](https://github.com/the-metafactory/cortex/issues/354).
+
+---
+
+## Runtime & identity
+
+### Stack
+
+The Cortex runtime boundary. A stack owns its identity, signing key, policy
+principals (AAA authorization subjects — distinct from the human
+**principal** who owns the stack), agents and presences, its Myelin/NATS
+subjects, and its local execution permissions. Written `{principal}/{stack}` — e.g. `andreas/meta-factory`,
+`andreas/work`. Mission Control is scoped to **one stack at a time**, with
+multi-stack overview a future capability.
+
+### Assistant
+
+A persistent, named being — Luna, PAI, Sage. The assistant is what the principal
+thinks of as "who" is doing the work; it persists across sessions, substrates,
+and stacks. (Soma's upper identity layer.)
+
+### Cortex Agent
+
+The stack-local daemon/process identity that hosts or represents an
+[assistant](#assistant)'s work on Myelin/NATS. Where the assistant is the
+durable being, the Cortex agent is the runtime identity with signing provenance
+inside one [stack](#stack). One assistant may be represented by different Cortex
+agents on different stacks. In `CONTEXT.md`'s house vocabulary this is the bare
+term **Agent**.
+
+### Substrate
+
+The runtime where work is actually performed: Codex, Claude Code, Pi.dev, the
+Cortex/Myelin daemon, or a future local/remote execution host. The substrate is
+the "engine"; the [session](#session) is one run of it.
+
+### Session
+
+One running [substrate](#substrate) interaction. A session carries its
+assistant / Cortex agent, [stack](#stack), [task](#task) or [work item](#work-item),
+substrate, prompt/input context, event stream, tool calls, status, and attention
+state. A task may accrue many sessions over its life.
+
+---
+
+## Work management
+
+### Task
+
+Mission Control's **local** unit of work. A task may originate from many places
+— a manual/internal note, a GitHub/GitLab/Jira/Linear issue, an Azure Boards
+work item, or a routine- or dispatch-generated request — but it is **not**
+identical to its provider object. Provider identity is metadata on the task, not
+the task itself — it rides as `provider` / `externalId` / `url` fields on the
+work item, not a named type (see the domain model,
+[§6](./design-mission-control-cortex-cockpit.md)).
+
+### Plan
+
+The work-management layer **above** tasks. A plan has a source document and a set
+of [phases or waves](#phase--wave). Kinds include research, design, migration,
+iteration, release, rollout, and incident-response plans. A plan may be backed by
+an umbrella issue, a Jira version, an Azure Boards epic, a Linear project, or a
+repo-local markdown file.
+
+### Phase / Wave
+
+An ordered slice of a [plan](#plan) that groups [work items](#work-item) under a
+high-level concept — e.g. `Phase A — Data foundation`, `Wave 2 — Slack work
+stack`, `MIG-7 — top-level Cortex wiring`. "Phase" and "wave" are the **same
+structural concept**; the UI uses whichever word the plan itself uses.
+
+### Work Item
+
+The **provider-backed, executable tracking object** under a [phase](#phase--wave)
+— a GitHub/GitLab/Jira/Linear issue, an Azure Boards work item, or an internal
+Mission Control task. Work items may have child work items; a plan may have an
+umbrella work item that rolls up progress from its children.
+
+---
+
+## Software-mode (Git) nouns
+
+> First-class in [Software Mode](#software-mode). The provider is abstracted; the
+> Git concept is not. A GitLab merge request maps to the **Pull Request** concept
+> while retaining `providerNativeType: "merge_request"` for display and API calls.
+
+### Repository
+
+A source-control repository — the container for branches, commits, and history
+under which software-mode work happens.
+
+### Branch
+
+A named line of development within a [repository](#repository). Work items in
+software mode typically resolve to a branch.
+
+### Commit
+
+A single recorded change to a [repository](#repository), identified by its SHA.
+
+### Pull Request
+
+A request to merge one [branch](#branch) into another, carrying
+[reviews](#review) and [checks](#check). The canonical concept; provider-native
+types (GitHub pull request, GitLab merge request) map onto it.
+
+### Review
+
+A human or agent assessment attached to a [pull request](#pull-request) —
+approve, request-changes, or comment. In Cortex, agent reviews ride the bus and
+surface in the [attention queue](#mission-control-terms).
+
+### Check
+
+A status check or CI signal attached to a [commit](#commit) or
+[pull request](#pull-request) — a build, test run, lint, or gate that reports
+pass/fail/pending.
+
+### Release
+
+A versioned, published cut of a [repository](#repository) (e.g. a tag promoted to
+a published release). The unit deployment targets.
+
+### Deployment
+
+The act (and record) of shipping a [release](#release) or build to an
+environment — dev, staging, or production.
+
+### Artifact
+
+A build output produced by a [check](#check)/build or attached to a
+[release](#release) — a bundle, image, binary, or report.
+
+---
+
+## Modes
+
+### Generic Mode
+
+The lens that centers tasks, source refs, assignees, status, priority, comments,
+[sessions](#session), and attention items. Works for non-software workflows and
+for provider backends (Jira, Linear, Azure Boards) when no [Git
+objects](#software-mode-git-nouns) are attached.
+
+### Software Mode
+
+The lens that promotes software-development objects — [repositories](#repository),
+[branches](#branch), [commits](#commit), [pull requests](#pull-request),
+[reviews](#review), [checks](#check), [releases](#release),
+[deployments](#deployment), [artifacts](#artifact). The first real Cortex Mission
+Control mode, because the immediate operator workflows are software-agent
+workflows. (Mirrors how Jira Software turns a generic work-item system into a
+software cockpit when connected to source control, CI, and release providers.)
+
+---
+
+## Mission Control terms
+
+A few surface-level terms that recur in the cockpit UI and design docs:
+
+- **Attention queue** — the single "who needs me right now" feed. One entry per
+  blocked/waiting [session](#session) or work item needing the operator.
+- **Drill-down** — the detail view opened from any card: event log, input
+  affordance, and (in software mode) linked Git objects.
+- **Working grid** — the live tiles of [Cortex agents](#cortex-agent) with active
+  [sessions](#session).
+- **Dispatch** — handing a [task](#task)/work item to an agent to start a
+  [session](#session).

--- a/docs/plan-mission-control-cockpit.md
+++ b/docs/plan-mission-control-cockpit.md
@@ -1,0 +1,426 @@
+# Plan — Mission Control Cortex Cockpit (G-1113)
+
+**Status:** draft for review
+**Branch:** `feat/g-1113-mission-control-cockpit`
+**Driver:** Andreas
+**Design:** [`docs/design-mission-control-cortex-cockpit.md`](design-mission-control-cortex-cockpit.md)
+**Umbrella issue:** _(to be filed once this plan is agreed)_
+**Process:** umbrella → phase sub-issues → sub-feature PRs; one PR per sub-feature; pilot review loop with Echo primary
+
+---
+
+## 1. What we're building (recap from design spec)
+
+Turn the current Mission Control dashboard into an **operator cockpit**: one
+pane of glass over plans, their phases, work items, branches, PRs, checks,
+releases, agent sessions, and what needs attention. The same surface should
+work for software workflows (Git-native) and generic workflows (Jira / Linear
+/ internal tasks).
+
+Four shifts make this different from today's dashboard:
+
+1. **Provider-neutral.** Today the code assumes `source=github`. Tomorrow
+   GitHub is the first of several adapters (GitLab, Azure DevOps, Jira,
+   Linear, internal). Provider becomes metadata, not a type fork.
+2. **Git objects are first-class.** Repository, branch, commit, tag,
+   release, pull request, review, check, build, deployment, artifact — each
+   has a typed shape, storage, and ingestion path. No vague "work product"
+   union.
+3. **Plans above tasks.** The Compass execution chain
+   (research → design → roadmap → spec → iteration plan → umbrella → work
+   item → PR → code) becomes Mission Control's runtime view. Plans / Phases
+   live above tasks and roll up state.
+4. **One attention queue.** Blocked sessions, PR review requests, failed
+   checks, stale work, failed dispatches — one queue, one set of deep-links,
+   one notification path.
+
+**Shape of the work:** five phases (A–E), `A → B → (C ∥ D) → E`,
+17–27 PRs total.
+
+The methodology we use here — markdown plan doc + GitHub umbrella + sub-issues
++ blueprint dependency graph + task list — is intentionally the same chain
+Mission Control will eventually visualize. This plan is dogfood for the
+cockpit it produces.
+
+### 1.1 Iterative delivery — each phase ships visible value
+
+This is not a big-bang redesign. **Every phase ships an operator-visible
+improvement to Mission Control.** If we stop after any phase, the operator is
+left with a surface that is better than before, not a half-finished
+construction site.
+
+| Phase | What the operator sees after this phase |
+|---|---|
+| A — Grounding | Dashboard builds again; glossary linked from footer; "G-1113 cockpit redesign" badge in header linking to the plan |
+| B — Provider-neutral refs | Each task row shows a provider badge; a "Sources" view lists configured providers |
+| C — Software mode model | Branches + PRs as first-class chips on task rows; a per-repo Git-object grouping |
+| D — Plan lineage UI | A "Plans" surface with this plan as the first card; phase progress, drill-down to phase detail |
+| E — Attention + notifs | Unified attention queue with deep-links; routed notifications across Discord/Slack/Mattermost |
+
+Within a phase, sub-features are sequenced so each PR moves something
+operator-visible forward, not just internal plumbing. Model-layer PRs that
+don't have an immediate UI manifestation are scheduled so they ship in the
+same phase as the UI affordance that exposes them.
+
+## 2. What this plan covers
+
+This is the execution plan for the design spec
+`design-mission-control-cortex-cockpit.md`. It defines:
+
+- How the design's five slices (§10) become GitHub issues
+- How those issues break into pools of pull requests
+- The phase/wave structure and dependency order
+- Per-phase acceptance criteria and visible deliverables
+- The conventions agents use when working autonomously against this plan
+
+When this plan and reality disagree, this plan wins (or is updated, never
+silently). When this plan and the design spec disagree on what Mission Control
+*is*, the design spec wins.
+
+## 3. Issue + PR structure
+
+```
+G-1113  Mission Control Cortex Cockpit (umbrella issue)
+  ├── G-1113.A  Phase A — Grounding              (sub-issue → 1 PR)
+  ├── G-1113.B  Phase B — Provider-Neutral Refs  (sub-issue → N PRs)
+  ├── G-1113.C  Phase C — Software Mode Model    (sub-issue → N PRs)
+  ├── G-1113.D  Phase D — Plan Lineage UI        (sub-issue → N PRs)
+  └── G-1113.E  Phase E — Attention + Notifications (sub-issue → N PRs)
+```
+
+**Sub-issue scope.** Each phase sub-issue (`G-1113.A` .. `G-1113.E`) is itself
+a mini-umbrella. When a phase starts, its sub-features (`G-1113.B.1`,
+`G-1113.B.2`, ...) are filed as further sub-issues, each closed by exactly one
+PR. We do not pre-file phase sub-feature issues — they are filed at phase
+start, after the prior phase's findings inform sub-feature shape.
+
+**PR convention.** One sub-feature == one PR. Branch name
+`feat/g-1113-{phase-letter}-{slot}-{slug}`, e.g.
+`feat/g-1113-b-1-source-ref-types`. Title `feat(mc): G-1113.B.1 — {scope}`.
+Body links `Closes the-metafactory/cortex#{sub-feature issue}` and references
+the phase sub-issue.
+
+**Plan doc tick-through.** Every merged PR ticks its box in §5 below AND in
+the phase sub-issue's checklist.
+
+## 4. Phase sequencing
+
+```
+                                      ┌─→ C  Software Mode Model ─┐
+A  Grounding ──→ B  Provider Refs ────┤                           ├──→ E  Attention
+                                      └─→ D  Plan Lineage UI ─────┘
+```
+
+Mirrors `blueprint.yaml`:
+
+- `G-1113.A` ← no deps
+- `G-1113.B` ← `[G-1113.A]`
+- `G-1113.C` ← `[G-1113.B]`
+- `G-1113.D` ← `[G-1113.B]`
+- `G-1113.E` ← `[G-1113.C, G-1113.D]`
+
+- **Phase A** is gating: it lands the plan doc itself + fixes the build-script
+  drift that blocks any dashboard work.
+- **Phase B** is the foundation. C, D, and E all consume provider-neutral
+  source refs and Mission Control's normalized work-item model.
+- **Phase C** and **Phase D** can be developed in parallel once B lands. C
+  fleshes out the Git-object domain model; D fleshes out the Plan/Phase model.
+- **Phase E** depends on C + D being far enough along that attention items
+  can reference real Git objects + plan lineage. It can begin in parallel
+  with C/D once both have landed their model types.
+
+A given phase ships when its acceptance criteria (§5) are met, not when an
+arbitrary PR count is hit.
+
+## 5. The phases
+
+### 5.1 Phase A — Grounding (G-1113.A)
+
+**Goal:** make the work plan executable and put a first cockpit-shaped
+visible signal in the existing dashboard.
+
+**Visible deliverable (what the operator sees after Phase A):**
+
+- The dashboard builds and runs again (today the build script points at the
+  wrong path).
+- A small "G-1113 · Mission Control Cockpit redesign" badge in the dashboard
+  header, linking to the umbrella issue + plan doc on GitHub.
+- A "Glossary" link in the dashboard footer pointing at
+  `docs/glossary-mission-control.md`.
+
+**Sub-features:**
+
+- [ ] **G-1113.A.1** — Grounding PR · single PR · branch `feat/g-1113-a-1-grounding`
+  - Add `docs/plan-mission-control-cockpit.md` (this file).
+  - Fix `package.json` `build:dashboard` + `watch:dashboard` to point at
+    `src/surface/mc/dashboard-v2/` (currently still `src/mission-control/...`).
+  - Add `docs/glossary-mission-control.md` covering: Stack, Assistant,
+    Cortex Agent, Substrate, Session, Task, Plan, Phase/Wave, Work Item,
+    Repository, Branch, Commit, Pull Request, Review, Check, Release,
+    Deployment, Artifact, Generic Mode, Software Mode.
+  - Add the header "G-1113" badge + footer "Glossary" link to
+    `src/surface/mc/dashboard-v2/`. Hardcoded URLs are fine; no ingestion.
+  - Annotate genuinely-misleading lifted Grove v2 docs with a one-paragraph
+    "Historical — lifted from grove-v2" banner. Scope: only docs whose
+    architecture/paths actively mislead current Cortex work. Skip pure-language
+    drift; skip iteration retros; skip `architecture.md` (Cortex-canonical).
+    Target list (subject to verification during PR):
+    `design-mc-f7-attention-view.md`, `design-mc-f9-working-grid.md`,
+    `design-mc-f12-task-curation.md`, `design-mc-f12b-add-to-queue.md`,
+    `design-mc-f18-metrics.md`, `design-session-activity.md`,
+    `design-dashboard-efficiency.md`, `design-dm-operator-channel.md`,
+    `design-cloud-api.md`, `design-api-security.md`, `design-test-rig.md`,
+    `design-spawn-integration.md`.
+
+**Acceptance criteria:**
+
+- `bun run build:dashboard` succeeds.
+- Header badge + footer link render in the dashboard and resolve correctly.
+- New glossary doc renders in repo without broken internal links.
+- Each annotated historical doc carries the standard banner (consistent
+  wording, link back to the new design spec).
+- This plan doc and the design spec are both on `main` via this PR's merge.
+
+**Dependencies:** none (gating).
+
+---
+
+### 5.2 Phase B — Provider-Neutral Source Refs (G-1113.B)
+
+**Goal:** introduce a normalized source-ref model + make provider
+provenance visible on every task. Keep existing GitHub behavior working.
+
+**Visible deliverable (what the operator sees after Phase B):**
+
+- Every task row shows a small provider badge (icon + provider name).
+  Today they all read "GitHub"; the badge is provider-aware so future
+  GitLab / Azure DevOps / Jira tasks render distinctly.
+- A "Sources" config view (under Settings or as a sidebar item) lists the
+  configured providers and their basic state (today: GitHub only).
+
+**Sub-features (sketched — refined at phase start):**
+
+- [ ] **G-1113.B.1** — Source-ref type + Provider enum
+  - Add `Provider` union (`internal | github | gitlab | azure-devops | jira | linear | bitbucket | custom`).
+  - Add normalized `SourceRef` shape (`{ provider, externalId, url, providerNativeType }`).
+  - No behavior change; types only.
+- [ ] **G-1113.B.2** — Task schema: replace `source=github` assumptions with `SourceRef`
+  - Update task storage + API contracts to accept the new shape.
+  - Migration shim: existing GitHub tasks read as `{ provider: 'github', ... }`.
+- [ ] **G-1113.B.3** — GitHub adapter boundary
+  - Move GitHub URL parsing / webhook ingestion / API fetch behind an
+    `adapters/github/` boundary that emits normalized source refs.
+  - No new providers wired; just moving the existing code behind the
+    boundary.
+- [ ] **G-1113.B.4** — Provider badge on task rows + Sources view
+  - Small provider-aware badge component, fed by `SourceRef`.
+  - "Sources" config view listing configured providers.
+- [ ] **G-1113.B.5** — Fixture-based adapter parity tests
+  - Provider examples for GitHub (real), GitLab (fixture), Azure DevOps
+    (fixture), Jira (fixture), internal (synthetic).
+  - Tests assert each adapter produces a valid `SourceRef`.
+
+**Acceptance criteria:**
+
+- All existing GitHub-sourced tasks still flow end-to-end (no regression).
+- Provider badge visible on every task row and reflects `SourceRef.provider`.
+- Sources view renders configured providers from config.
+- New `SourceRef` is the only way new code in this phase touches a provider.
+- Fixture suite covers all five listed providers at the source-ref level.
+
+**Dependencies:** Phase A.
+
+**Open question carried from design §11:** Provider naming — `merge_request`
+preserved as `providerNativeType` on a normalized `PullRequest`, or distinct
+top-level `ChangeRequest` concept? Resolution should happen during B.1.
+
+---
+
+### 5.3 Phase C — Software Mode Domain Model (G-1113.C)
+
+**Goal:** first-class Git objects in the model layer **and** surface them
+in the UI as first-class chips/rows.
+
+**Visible deliverable (what the operator sees after Phase C):**
+
+- Each task row shows linked branches + PRs as compact first-class chips
+  (not just a link). Chip hover reveals check status + review state.
+- A new "Repositories" sidebar / panel groups branches + PRs + recent
+  releases per repository.
+- Provider-native labels preserved on chips ("Merge request" when
+  applicable).
+
+**Sub-features (sketched — refined at phase start):**
+
+- [ ] **G-1113.C.1** — `GitRepository` + `GitBranch` types + storage
+- [ ] **G-1113.C.2** — `GitCommit` + `GitTag` types + storage
+- [ ] **G-1113.C.3** — `PullRequest` (+ `Review`) types + storage
+- [ ] **G-1113.C.4** — `Check` / `Build` + `Deployment` + `Artifact` types
+- [ ] **G-1113.C.5** — GitHub adapter populates the new model from existing
+  webhook + REST data
+- [ ] **G-1113.C.6** — UI: first-class branch + PR chips on task rows;
+  check/review state on hover
+- [ ] **G-1113.C.7** — UI: per-repository panel grouping branches + PRs +
+  recent releases (gated behind a software-mode flag)
+
+**Acceptance criteria:**
+
+- Every Git noun listed in design §3.8 has a typed shape, storage, and an
+  ingestion path from the GitHub adapter.
+- Branch + PR chips visible on every task row that has linked refs.
+- Per-repo panel renders and stays consistent with task-row chips.
+- No visual regression on existing surfaces.
+- New types are not yet referenced by the Plan model (that's Phase D).
+
+**Dependencies:** Phase B.
+
+---
+
+### 5.4 Phase D — Plan Lineage UI (G-1113.D)
+
+**Goal:** the plan/program surface that rolls up phase, work item, PR,
+session, and attention state. Recasts the existing `Iterations` tab.
+
+**Visible deliverable (what the operator sees after Phase D):**
+
+- A new "Plans" tab (or recast Iterations tab) shows plans as cards: title,
+  current phase, per-phase progress bar, work-item / PR / release /
+  attention counts.
+- This plan doc itself appears as the first Plan card with phases A–E
+  enumerated.
+- Drilling into a phase opens phase detail: work items, sessions, linked
+  branches/PRs/checks/reviews.
+- Work-item detail shows plan/phase context + linked Git objects.
+
+**Sub-features (sketched — refined at phase start):**
+
+- [ ] **G-1113.D.1** — `Plan` + `PlanPhase` types + storage
+- [ ] **G-1113.D.2** — Plan ingestion: parse repo-local plan docs
+  (`docs/plan-*.md`, `docs/iteration-*.md`) into `Plan` rows with
+  `sourceDocumentUrl`
+- [ ] **G-1113.D.3** — Plan overview surface (a new tab or recast `Iterations`)
+  showing the design §7.1 layout: title, current phase, per-phase progress,
+  WI/PR/release/attention counts
+- [ ] **G-1113.D.4** — Phase detail view (design §7.2)
+- [ ] **G-1113.D.5** — Work-item detail evolves to show plan/phase context
+  + linked branches/PRs/checks (design §7.3)
+- [ ] **G-1113.D.6** — Compatibility: keep the legacy iteration kanban
+  available behind a tab toggle until plan surface reaches parity
+
+**Acceptance criteria:**
+
+- A plan defined in markdown (e.g. this file) appears as a Plan row in the
+  UI with each Phase A–E enumerated and progress accurate.
+- Drilling into a phase shows its sub-feature work items + linked PRs +
+  current session, sourced from the Phase C model.
+- No regression in operator-visible task flow.
+
+**Dependencies:** Phase B; benefits from Phase C but does not block on C
+beyond the WI ⇄ PR linkage (D.5).
+
+**Open question carried from design §11:** canonical noun — `Plan` vs
+`Program` vs `Work Plan`. Defaulted to **`Plan`** in this doc; revisit during
+D.1.
+
+---
+
+### 5.5 Phase E — Attention + Notifications (G-1113.E)
+
+**Goal:** one attention queue across plans, phases, work items, PRs, and
+sessions. Notifications routed through stack surfaces (Discord, Slack,
+Mattermost).
+
+**Visible deliverable (what the operator sees after Phase E):**
+
+- An "Attention" panel (or header icon with counter) listing everything
+  that needs operator action: blocked sessions, PR review requests,
+  permission requests, failed checks, failed dispatches, stale work.
+- Each item carries a deep-link to the exact plan / phase / work item /
+  PR / session that needs action.
+- The same deep-links arrive as routed notifications in Discord / Slack /
+  Mattermost channels.
+
+**Sub-features (sketched — refined at phase start):**
+
+- [ ] **G-1113.E.1** — `AttentionItem` type + storage + lifecycle (open →
+  resolved/dismissed)
+- [ ] **G-1113.E.2** — Attention sources wired:
+  - blocked sessions (from runner)
+  - permission requests
+  - review checkpoints (PR review_requested)
+  - failed dispatches (Myelin envelope nak)
+  - failing checks
+  - stale work items
+- [ ] **G-1113.E.3** — Attention queue UI surface (design §7.4) with
+  deep-links into plan / phase / WI / PR / session
+- [ ] **G-1113.E.4** — Notification routing: emit `system.attention.*`
+  envelopes; Discord adapter renders them in the appropriate channel/thread
+
+**Acceptance criteria:**
+
+- Every attention kind listed in design §7.4 has a producer + a deep-link.
+- Notifications land in the operator's expected Discord/Slack/Mattermost
+  channel for each kind.
+- Attention items resolve correctly when their underlying condition clears
+  (PR approved, check passes, session unblocks).
+
+**Dependencies:** Phase C (Git-object attention sources) + Phase D (deep-link
+targets). Can begin once C and D have landed their model layers; UI work
+may parallelize with later D sub-features.
+
+---
+
+## 6. Sequencing summary
+
+| Phase | Depends on | Blocks | Indicative PR count |
+|---|---|---|---|
+| A — Grounding | — | B | 1 |
+| B — Provider-neutral refs | A | C, D, E | 4–6 |
+| C — Software mode model | B | E (partial) | 6–9 |
+| D — Plan lineage UI | B (+ C for D.5) | E (partial) | 5–8 |
+| E — Attention + notifications | C + D | — | 3–5 |
+
+Total indicative: **19–29 PRs** across the umbrella. (Slightly larger than
+the original 17–27 because each phase now ships a UI affordance, not just
+plumbing.)
+
+## 7. Open decisions
+
+Carried from design §11. Resolve at the start of the phase that depends on
+each, not now:
+
+1. Canonical top-level noun — `Plan` (provisional default) vs `Program` vs
+   `Work Plan`. → resolved by D.1.
+2. `phase` vs `wave` alias-or-canonical. → resolved by D.1.
+3. `PullRequest` vs `ChangeRequest`. → resolved by B.1.
+4. Iteration board: replace vs compatibility-tab. → resolved by D.3 / D.6.
+5. Next provider after GitHub. → resolved when Phase B+ findings inform.
+6. Plan state: passive mirror vs write-back. → resolved during D.5.
+7. Myelin events vs direct provider API for which signals. → resolved
+   during E.2.
+
+## 8. Process notes
+
+- **Worktree discipline.** Each sub-feature gets its own worktree under
+  `../cortex-g-1113-{slot}-{slug}` cut from `origin/main`. The umbrella
+  branch (`feat/g-1113-mission-control-cockpit`) only carries this plan +
+  the design spec; sub-feature work happens on fresh branches.
+- **Review loop.** Echo primary on PR review via the pilot loop; in-session
+  sub-agent (Engineer subagent_type) fallback when Echo dispatch flakes.
+- **Tick discipline.** Merging a sub-feature PR ticks the box in this plan
+  AND comments-and-closes the sub-feature sub-issue. The phase sub-issue
+  closes when all its sub-features tick. The umbrella closes when all
+  phases close.
+- **Plan vs blueprint.** The dependency graph lives in `blueprint.yaml`
+  under `G-1113` + `G-1113.A` .. `G-1113.E` (+ `G-1113.A.1` pre-filed). This
+  doc is the human-readable narrative; the blueprint is the queryable
+  source of truth. `blueprint ready` shows what's unblocked; `blueprint
+  update cortex:G-1113.X --status in-progress` claims a phase. Sub-feature
+  blueprint nodes for B/C/D/E are filed at phase start, matching the
+  sub-issue filing convention in §3.
+- **No GitHub Projects board.** The umbrella + sub-issues are the board.
+  Sub-issue rollup is GitHub's native sub-issue feature.
+- **Autonomous work mode.** Once this plan is agreed, the TaskList is
+  populated from §5: one TaskCreate per open `G-1113.X.Y` checkbox. Agents
+  pick the next ready task (dependencies satisfied) and work it through
+  to merged PR.

--- a/docs/plan-mission-control-cockpit.md
+++ b/docs/plan-mission-control-cockpit.md
@@ -11,7 +11,7 @@
 
 ## 1. What we're building (recap from design spec)
 
-Turn the current Mission Control dashboard into an **operator cockpit**: one
+Turn the current Mission Control dashboard into an **principal cockpit**: one
 pane of glass over plans, their phases, work items, branches, PRs, checks,
 releases, agent sessions, and what needs attention. The same surface should
 work for software workflows (Git-native) and generic workflows (Jira / Linear
@@ -44,12 +44,12 @@ cockpit it produces.
 
 ### 1.1 Iterative delivery — each phase ships visible value
 
-This is not a big-bang redesign. **Every phase ships an operator-visible
-improvement to Mission Control.** If we stop after any phase, the operator is
+This is not a big-bang redesign. **Every phase ships an principal-visible
+improvement to Mission Control.** If we stop after any phase, the principal is
 left with a surface that is better than before, not a half-finished
 construction site.
 
-| Phase | What the operator sees after this phase |
+| Phase | What the principal sees after this phase |
 |---|---|
 | A — Grounding | Dashboard builds again; glossary linked from footer; "G-1113 cockpit redesign" badge in header linking to the plan |
 | B — Provider-neutral refs | Each task row shows a provider badge; a "Sources" view lists configured providers |
@@ -58,7 +58,7 @@ construction site.
 | E — Attention + notifs | Unified attention queue with deep-links; routed notifications across Discord/Slack/Mattermost |
 
 Within a phase, sub-features are sequenced so each PR moves something
-operator-visible forward, not just internal plumbing. Model-layer PRs that
+principal-visible forward, not just internal plumbing. Model-layer PRs that
 don't have an immediate UI manifestation are scheduled so they ship in the
 same phase as the UI affordance that exposes them.
 
@@ -139,7 +139,7 @@ arbitrary PR count is hit.
 **Goal:** make the work plan executable and put a first cockpit-shaped
 visible signal in the existing dashboard.
 
-**Visible deliverable (what the operator sees after Phase A):**
+**Visible deliverable (what the principal sees after Phase A):**
 
 - The dashboard builds and runs again (today the build script points at the
   wrong path).
@@ -190,7 +190,7 @@ visible signal in the existing dashboard.
 **Goal:** introduce a normalized source-ref model + make provider
 provenance visible on every task. Keep existing GitHub behavior working.
 
-**Visible deliverable (what the operator sees after Phase B):**
+**Visible deliverable (what the principal sees after Phase B):**
 
 - Every task row shows a small provider badge (icon + provider name).
   Today they all read "GitHub"; the badge is provider-aware so future
@@ -241,7 +241,7 @@ top-level `ChangeRequest` concept? Resolution should happen during B.1.
 **Goal:** first-class Git objects in the model layer **and** surface them
 in the UI as first-class chips/rows.
 
-**Visible deliverable (what the operator sees after Phase C):**
+**Visible deliverable (what the principal sees after Phase C):**
 
 - Each task row shows linked branches + PRs as compact first-class chips
   (not just a link). Chip hover reveals check status + review state.
@@ -281,7 +281,7 @@ in the UI as first-class chips/rows.
 **Goal:** the plan/program surface that rolls up phase, work item, PR,
 session, and attention state. Recasts the existing `Iterations` tab.
 
-**Visible deliverable (what the operator sees after Phase D):**
+**Visible deliverable (what the principal sees after Phase D):**
 
 - A new "Plans" tab (or recast Iterations tab) shows plans as cards: title,
   current phase, per-phase progress bar, work-item / PR / release /
@@ -313,7 +313,7 @@ session, and attention state. Recasts the existing `Iterations` tab.
   UI with each Phase A–E enumerated and progress accurate.
 - Drilling into a phase shows its sub-feature work items + linked PRs +
   current session, sourced from the Phase C model.
-- No regression in operator-visible task flow.
+- No regression in principal-visible task flow.
 
 **Dependencies:** Phase B; benefits from Phase C but does not block on C
 beyond the WI ⇄ PR linkage (D.5).
@@ -330,10 +330,10 @@ D.1.
 sessions. Notifications routed through stack surfaces (Discord, Slack,
 Mattermost).
 
-**Visible deliverable (what the operator sees after Phase E):**
+**Visible deliverable (what the principal sees after Phase E):**
 
 - An "Attention" panel (or header icon with counter) listing everything
-  that needs operator action: blocked sessions, PR review requests,
+  that needs principal action: blocked sessions, PR review requests,
   permission requests, failed checks, failed dispatches, stale work.
 - Each item carries a deep-link to the exact plan / phase / work item /
   PR / session that needs action.
@@ -359,7 +359,7 @@ Mattermost).
 **Acceptance criteria:**
 
 - Every attention kind listed in design §7.4 has a producer + a deep-link.
-- Notifications land in the operator's expected Discord/Slack/Mattermost
+- Notifications land in the principal's expected Discord/Slack/Mattermost
   channel for each kind.
 - Attention items resolve correctly when their underlying condition clears
   (PR approved, check passes, session unblocks).

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     }
   },
   "scripts": {
-    "build:dashboard": "bun build src/mission-control/dashboard-v2/index.html --outdir dist/dashboard-v2 --target browser",
-    "watch:dashboard": "bun build src/mission-control/dashboard-v2/index.html --outdir dist/dashboard-v2 --target browser --watch",
+    "build:dashboard": "bun build src/surface/mc/dashboard-v2/index.html --outdir dist/dashboard-v2 --target browser",
+    "watch:dashboard": "bun build src/surface/mc/dashboard-v2/index.html --outdir dist/dashboard-v2 --target browser --watch",
     "lint": "eslint .",
     "lint:errors": "eslint --quiet .",
     "lint:fix": "eslint --fix ."

--- a/scripts/check-carveouts.sh
+++ b/scripts/check-carveouts.sh
@@ -360,6 +360,10 @@ CARVEOUT_LINE_PATTERNS=(
   'grove-v2'
   'grove-dashboard'
   'grove-bot'
+  # Historical grove-v2 doc filename whose NAME carries the legacy term; the
+  # file itself is bannered/path-allowlisted. Bare references to it (e.g. the
+  # G-1113 plan's banner-target list) are filename citations, not vocab usage.
+  'design-dm-operator-channel'
   # (6) platform-bot contexts.
   'trustedBotIds'
   'botUserId'

--- a/src/surface/mc/dashboard-v2/app.tsx
+++ b/src/surface/mc/dashboard-v2/app.tsx
@@ -168,6 +168,20 @@ export function App() {
       <header className="scaffold-header">
         <h1>Grove · Mission Control</h1>
         <div className="right">
+          {/*
+            G-1113 — Mission Control Cockpit redesign signpost. Links to the
+            umbrella issue tracking the cockpit rework. Hardcoded URL per
+            plan §5.1 (Phase A grounding) — no ingestion.
+          */}
+          <a
+            className="cockpit-badge mono"
+            href="https://github.com/the-metafactory/cortex/issues/354"
+            target="_blank"
+            rel="noopener noreferrer"
+            title="G-1113 · Mission Control Cockpit redesign — umbrella issue"
+          >
+            G-1113 · Cockpit redesign
+          </a>
           <span className="dim mono" style={{ fontSize: 11 }}>
             <Keycap>⌘</Keycap> <Keycap>K</Keycap> palette
           </span>
@@ -519,6 +533,21 @@ export function App() {
           onDismiss={() => setToast(null)}
         />
       )}
+
+      {/*
+        G-1113 Phase A — footer signpost. Links to the cockpit glossary so the
+        vocabulary (Stack, Assistant, Cortex Agent, Work Item, …) is one click
+        away from the surface. Hardcoded URL per plan §5.1; no ingestion.
+      */}
+      <footer className="scaffold-footer dim mono">
+        <a
+          href="https://github.com/the-metafactory/cortex/blob/main/docs/glossary-mission-control.md"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Glossary
+        </a>
+      </footer>
     </div>
   );
 }

--- a/src/surface/mc/dashboard-v2/styles/global.css
+++ b/src/surface/mc/dashboard-v2/styles/global.css
@@ -260,7 +260,7 @@ html, body {
 /* --- Scaffold-stage placeholder layout (MIG-1 only; MIG-2 onward replaces this) --- */
 .scaffold-shell {
   height: 100%;
-  display: grid; grid-template-rows: auto auto 1fr;
+  display: grid; grid-template-rows: auto auto 1fr auto;
 }
 .scaffold-header {
   display: flex; align-items: center; justify-content: space-between;
@@ -271,12 +271,30 @@ html, body {
   margin: 0; font-size: 14px; font-weight: 600; letter-spacing: 0.01em;
 }
 .scaffold-header .right { display: flex; align-items: center; gap: 10px; }
+/* G-1113 — cockpit-redesign signpost badge in the header */
+.cockpit-badge {
+  font-size: 10.5px; line-height: 1;
+  color: var(--fg-dim); text-decoration: none;
+  background: var(--panel-2);
+  border: 1px solid var(--line-soft); border-radius: 6px;
+  padding: 3px 7px; white-space: nowrap;
+}
+.cockpit-badge:hover { color: var(--fg); border-color: var(--line); }
 .scaffold-main {
   padding: 24px;
   display: flex; flex-direction: column; gap: 14px;
   color: var(--fg-dim);
   overflow: auto;
 }
+/* G-1113 — footer signpost (glossary link) */
+.scaffold-footer {
+  display: flex; align-items: center; justify-content: flex-end;
+  gap: 12px; padding: 6px 16px;
+  border-top: 1px solid var(--line); background: var(--panel);
+  font-size: 11px;
+}
+.scaffold-footer a { color: var(--fg-dim); text-decoration: none; }
+.scaffold-footer a:hover { color: var(--fg); text-decoration: underline; }
 .scaffold-section h2 {
   margin: 0 0 6px 0;
   font-size: 11px; font-weight: 600; letter-spacing: 0.06em;


### PR DESCRIPTION
## G-1113.A.1 — Grounding (Phase A)

First slice of the **Mission Control Cockpit** redesign (umbrella #354). Makes the dashboard buildable again, lands the cockpit design+plan on `main`, and clears grove-v2 drift from the docs that actively mislead current Cortex work.

Closes #356. Refs #354. Plan: `docs/plan-mission-control-cockpit.md` §5.1.

### What changed

- **OOTB build fix** — `package.json` `build:dashboard` + `watch:dashboard` pointed at the pre-migration `src/mission-control/dashboard-v2/` (gone since the MIG-2/MIG-6 move), so a fresh `bun run build:dashboard` failed and the dashboard `/` 404'd. Repointed to `src/surface/mc/dashboard-v2/`.
- **Cockpit docs promoted to main** — `docs/design-mission-control-cortex-cockpit.md` + `docs/plan-mission-control-cockpit.md`.
- **Glossary** — `docs/glossary-mission-control.md`: 20 cockpit terms (Stack, Assistant, Cortex Agent, Substrate, Session, Task, Plan, Phase/Wave, Work Item, Repository, Branch, Commit, Pull Request, Review, Check, Release, Deployment, Artifact, Generic Mode, Software Mode), sourced from the design spec §3–§4 and reconciled with `CONTEXT.md` house vocabulary.
- **Dashboard signposts** — header "G-1113 · Cockpit redesign" badge + footer "Glossary" link in the `dashboard-v2` shell (hardcoded URLs per plan §5.1; no ingestion).
- **Historical banners** — 12 lifted grove-v2 design docs carry a consistent "Historical — lifted from grove-v2" banner linking to the new design spec + glossary. Each was verified to genuinely mislead (stale `src/mission-control/` / `src/bot/` paths), not just language drift.
- **CONTEXT.md alignment** — added the **Mission Control** glossary term recording the surface as a **modular React app** (`dashboard-v2`: `App` shell + per-concern components + data hooks + pure display helpers), **not** the retired monolithic `src/dashboard/` HTML (deleted at MIG-6).

### Acceptance criteria (plan §5.1)

- [x] `bun run build:dashboard` succeeds (84 modules, 1.23 MB bundle)
- [x] Header badge + footer link render (verified present in built bundle) and resolve (glossary URL resolves once this merges to `main` — hardcoded URL allowed per plan)
- [x] Glossary renders with no broken internal links
- [x] Each annotated historical doc carries the consistent banner linking to the new design spec
- [x] Design spec + plan are on the branch

### Review

Self-reviewed via a 4-lens sub-agent pass (UI/build, glossary+CONTEXT.md accuracy, banner/link integrity, grounding-scope fidelity). UI lens clean; fixed the findings before pushing: corrected a glossary citation to a non-existent `SourceRef` type (→ §6 domain model `provider`/`externalId`/`url`), disambiguated "policy principals" vs the human **principal**, reconciled "Cortex Agent" with CONTEXT.md's **Agent**, dropped a stale per-phase `Branch:` header on the design spec, and aligned "operator-facing" → "principal-facing".

### Test plan

- `bun run build:dashboard` → green
- Behaviour-preserving: no MC runtime/logic changes; docs + build-script + small dashboard shell signposts only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
