### PR TITLE
feat(config): CFG.c — surfaces.yaml binding layer (closes #523, EPIC CFG complete)

### DIFF
--- a/docs/config-layout/README.md
+++ b/docs/config-layout/README.md
@@ -49,13 +49,57 @@ The loader validates the block **loudly at load** (CFG.b.3,
 throws a clear error rather than parsing into a silent partial config that would
 double-publish.
 
+## The surface binding map (CFG.c)
+
+`surfaces/surfaces.yaml` holds the per-platform **surface bindings**
+(Discord/Slack/Mattermost `token`, `guild`, channel/instance bindings), moved
+out of each stack's `agents[*].presence.{platform}` block. It is the
+`{surface-instance → stack}` map the **shared surface gateway (GW, §13.2)**
+consumes to hold one platform connection per bot and route inbound messages to
+the right stack.
+
+The composer **folds** each binding back into the matching agent's
+`presence.{platform}` block at load (joining on the binding's `agent:` id
+against `stacks/*.yaml` `agents[].id`) and drops the top-level `surfaces:` key —
+so the composed raw config is identical to the inline (pre-CFG.c) form and
+`LoadedConfig` is **byte-identical**. It is a source-layout change, not a
+runtime-shape change; the per-stack adapters and the per-presence-token wiring
+in `src/cortex.ts` are untouched.
+
+Binding-map shape (validated loudly at load — CFG.c.4,
+`src/common/types/surfaces.ts`):
+
+```yaml
+surfaces:
+  <platform>:                  # discord | slack | mattermost
+    - agent: <agent-id>        # join key against stacks/*.yaml agents[].id
+      stack: <principal>/<stack>   # OPTIONAL — the {instance → stack} GW routes on
+      binding:                 # the required per-platform credential/instance fields
+        ...
+```
+
+Required binding fields: discord → `token`, `guildId`, `agentChannelId`,
+`logChannelId`; slack → `botToken` (`xoxb-…`), `appToken` (`xapp-…`),
+`workspaceId` (`T…`); mattermost → `apiUrl`, `apiToken`.
+
+**Precedence / fallback.** `surfaces.yaml` is OPTIONAL — per-stack
+`presence.{platform}` is always the fallback (the three live single-file
+deployments carry bindings inline and have no `surfaces.yaml`). When BOTH are
+present for the same platform, the surfaces.yaml binding **wins on leaf keys**
+(it is the credential surface-of-truth) while inline non-binding knobs
+(`contextDepth`, `surfaceSubjects`, …) survive the merge. A binding naming an
+agent absent from every stack fails **loudly** rather than silently dropping a
+credential.
+
 ## This example
 
 - [`system/system.yaml`](./system/system.yaml) — the substrate layer, with the
   prominently-commented `nats.subjects` block (kept at the safe `[]` default).
+- [`surfaces/surfaces.yaml`](./surfaces/surfaces.yaml) — the surface binding map;
+  binds the `ivy` agent's Discord presence (Slack + Mattermost commented out).
 - [`stacks/research.yaml`](./stacks/research.yaml) — one per-deployment stack
-  (principal + one agent), carrying no transport knobs.
+  (principal + one agent), carrying no transport knobs and an EMPTY
+  `presence: {}` — its Discord binding folds in from `surfaces.yaml`.
 
-`surfaces/` and `network/` are omitted here — `surfaces.yaml` lands with CFG.c
-and the network roster with the federation phases; both are optional layers the
-composer skips when absent.
+`network/` is omitted here — the network roster lands with the federation
+phases; it is an optional layer the composer skips when absent.

--- a/docs/config-layout/stacks/research.yaml
+++ b/docs/config-layout/stacks/research.yaml
@@ -14,9 +14,16 @@
 # to make this example self-contained.
 #
 # Note what is ABSENT: no `nats.subjects`, no `nats` transport block at all, no
-# surface tokens. Transport lives in system.yaml; surface bindings move to
-# surfaces.yaml (CFG.c / GW). A stack file never re-declares the subject list —
-# that is the structural fix for the double-message problem.
+# surface tokens. Transport lives in system.yaml; surface bindings live in
+# surfaces.yaml (CFG.c / GW) and the composer FOLDS them back into this agent's
+# `presence.discord` block at load. A stack file never re-declares the subject
+# list — that is the structural fix for the double-message problem.
+#
+# The agent below declares an EMPTY `presence: {}` — its surface binding (the
+# Discord token + guild + channels) lives in `surfaces/surfaces.yaml`, keyed by
+# this agent's id (`ivy`). Non-binding presence knobs (e.g. `contextDepth`,
+# `surfaceSubjects`) could still be declared here inline; the surfaces.yaml
+# binding merges on top, winning on the credential leaf keys.
 
 principal:
   id: andreas
@@ -28,9 +35,4 @@ agents:
     persona: ./personas/ivy.md
     roles: []
     trust: []
-    presence:
-      discord:
-        token: REPLACE_WITH_DISCORD_BOT_TOKEN
-        guildId: "000000000000000000"
-        agentChannelId: "000000000000000000"
-        logChannelId: "000000000000000000"
+    presence: {}

--- a/docs/config-layout/surfaces/surfaces.yaml
+++ b/docs/config-layout/surfaces/surfaces.yaml
@@ -1,0 +1,91 @@
+# =============================================================================
+# surfaces/surfaces.yaml — the shared surface-gateway binding map (IAW CFG.c)
+# =============================================================================
+#
+# This is the SURFACES layer of the multi-file config layout (IAW CFG). It moves
+# the per-platform surface bindings (Discord/Slack/Mattermost `token`, `guild`,
+# channel/instance bindings) OUT of each stack's `agents[*].presence.{platform}`
+# block and INTO one top-level file. The boot composer
+# (`composeRawConfig` in src/common/config/loader.ts) reads it in this fixed
+# precedence and FOLDS each binding back into the matching agent's
+# `presence.{platform}` block:
+#
+#     system/system.yaml      (base — substrate / machine config)
+#     network/*.yaml          (federation roster, sorted by filename)
+#     surfaces/surfaces.yaml  ← THIS FILE (cross-stack surface bindings)
+#     stacks/*.yaml           (per-deployment policy / capabilities / agents)
+#
+# It is a SOURCE-LAYOUT change, not a runtime-shape change: after the fold the
+# composed raw config is identical to the inline (pre-CFG.c) form, so
+# `LoadedConfig` is byte-identical and every consumer (the per-stack adapters,
+# the per-presence-token wiring in src/cortex.ts) keeps working unchanged.
+#
+# OPTIONAL layer. A deployment with no surfaces.yaml keeps its bindings inline
+# in per-stack presence — that is the transitional fallback the three live
+# single-file configs (cortex.yaml / cortex.work.yaml / cortex.halden.yaml)
+# take. Per-stack presence is ALWAYS the fallback; surfaces.yaml layers on top.
+#
+# -----------------------------------------------------------------------------
+# Why this file exists: the shared surface gateway (GW, plan §13.2) precondition
+# -----------------------------------------------------------------------------
+#
+# This is the `{surface-instance → stack}` binding map the shared surface
+# gateway (GW) consumes. The gateway holds ONE platform connection per bot and
+# routes inbound platform messages to the right stack — it reads
+# `surfaces.{platform}[]` to build its `{instance → stack}` routing table
+# (GW.a.1 / GW.c.1 / GW.d.1 / GW.e.1). Pulling the bindings into this single
+# file is what lets the gateway own the platform edge without each stack opening
+# its own connection.
+#
+# -----------------------------------------------------------------------------
+# Shape (the binding map — what GW reads)
+# -----------------------------------------------------------------------------
+#
+#   surfaces:
+#     <platform>:                 # discord | slack | mattermost
+#       - agent: <agent-id>       # which agent's presence.<platform> this fills
+#                                 #   (join key against stacks/*.yaml agents[].id)
+#         stack: <principal>/<stack>   # OPTIONAL — the {instance → stack} binding
+#                                      #   GW routes on. Carried verbatim for the
+#                                      #   gateway; the composer does not consume
+#                                      #   it (agent id is the fold key).
+#         binding:                # the per-platform credential / instance fields
+#           ...                   #   (the binding subset of *PresenceSchema)
+#
+# Required binding fields, per platform (validated LOUDLY at load — CFG.c.4):
+#   - discord:    token, guildId, agentChannelId, logChannelId
+#   - slack:      botToken (xoxb-…), appToken (xapp-…), workspaceId (T…)
+#   - mattermost: apiUrl, apiToken
+#
+# Non-binding presence knobs (e.g. discord `contextDepth`, `surfaceSubjects`,
+# `trustedBotIds`) MAY stay inline in the stack's presence block; surfaces.yaml
+# owns only the binding. When both carry the same platform, the surfaces.yaml
+# binding WINS on leaf keys (it is the credential surface-of-truth), while inline
+# non-binding knobs survive the merge.
+#
+# Copy this file to your config dir and fill in real tokens/keys.
+
+surfaces:
+  discord:
+    - agent: ivy
+      stack: andreas/research
+      binding:
+        token: REPLACE_WITH_DISCORD_BOT_TOKEN
+        guildId: "000000000000000000"
+        agentChannelId: "000000000000000000"
+        logChannelId: "000000000000000000"
+
+  # slack:
+  #   - agent: ivy
+  #     stack: andreas/research
+  #     binding:
+  #       botToken: xoxb-REPLACE
+  #       appToken: xapp-REPLACE
+  #       workspaceId: T01234567
+
+  # mattermost:
+  #   - agent: ivy
+  #     stack: andreas/research
+  #     binding:
+  #       apiUrl: https://mattermost.example.com
+  #       apiToken: REPLACE_WITH_MATTERMOST_TOKEN

--- a/docs/plan-internet-of-agentic-work.md
+++ b/docs/plan-internet-of-agentic-work.md
@@ -749,18 +749,18 @@ Neither epic flips the principal-facing schema in a breaking way: CFG ships a tr
 
 #### CFG.c Move surface bindings out of per-stack `agents.presence` into `surfaces.yaml`
 
-- [ ] **CFG.c.1** Surface bindings (Discord/Mattermost/Slack `token`, `guild`, channel/instance bindings) move from each stack's `agents.presence` block into a top-level `surfaces.yaml`.
-- [ ] **CFG.c.2** `LoadedConfig` still exposes the same effective presence/binding view to today's consumers (per-stack adapters keep working); the move is a source-layout change, not a runtime-shape change.
-- [ ] **CFG.c.3** `surfaces.yaml` is the file the shared surface gateway (GW) consumes — this slice is the GW precondition.
-- [ ] **CFG.c.4** Tests: per-stack adapter behaviour unchanged after the move (same tokens/guilds resolved); `surfaces.yaml` schema validates required binding fields.
+- [x] **CFG.c.1** Surface bindings (Discord/Mattermost/Slack `token`, `guild`, channel/instance bindings) move from each stack's `agents.presence` block into a top-level `surfaces.yaml`. — #523: `surfaces.yaml` layer + `SurfacesSchema` (`src/common/types/surfaces.ts`) — the `{surface-instance → stack}` binding map keyed by platform; the composer (`composeRawConfig`) reads `surfaces/surfaces.yaml` and `foldSurfaceBindings` folds each binding back into `agents[*].presence.{platform}`.
+- [x] **CFG.c.2** `LoadedConfig` still exposes the same effective presence/binding view to today's consumers (per-stack adapters keep working); the move is a source-layout change, not a runtime-shape change. — #523: the fold drops the top-level `surfaces:` key so the composed raw config is identical to the inline form; `LoadedConfig` byte-identical (round-trip test asserts `toEqual`). The per-presence-token wiring in `src/cortex.ts` + the flattened `config.{discord,slack,mattermost}` arrays are untouched.
+- [x] **CFG.c.3** `surfaces.yaml` is the file the shared surface gateway (GW) consumes — this slice is the GW precondition. — #523: binding-map shape documented in `docs/config-layout/surfaces/surfaces.yaml` + `docs/config-layout/README.md` (the `{agent, stack?, binding}` map + required fields per platform).
+- [x] **CFG.c.4** Tests: per-stack adapter behaviour unchanged after the move (same tokens/guilds resolved); `surfaces.yaml` schema validates required binding fields. — #523: `src/common/config/__tests__/surfaces-layer.test.ts` — round-trip (bindings-in-surfaces.yaml resolves to the same effective view as bindings-in-per-stack-presence, all 3 platforms), required-binding-field validation (missing `token`/`botToken`/`apiToken` + typo'd platform key fail loudly), no-surfaces.yaml fallback, surfaces-wins-over-inline precedence, unknown-agent loud failure, fold idempotence.
 
 #### EPIC CFG acceptance criteria
 
-- [ ] Multi-file directory layout composes to a `LoadedConfig` identical to the equivalent single file.
-- [ ] Single-file `cortex.yaml` still loads via the transitional fallback (no principal-facing break).
-- [ ] `system.yaml` exists with `claude`/`execution`/`attachments`/`paths`/`nats`/`bus`; `nats.subjects` isolated in one place.
-- [ ] Surface bindings live in `surfaces.yaml`, out of per-stack `agents.presence`; per-stack adapters unchanged at runtime.
-- [ ] `LoadedConfig` shape unchanged across the whole epic; no consumer edits required.
+- [x] Multi-file directory layout composes to a `LoadedConfig` identical to the equivalent single file. — CFG.a #525 + CFG.b #529 + CFG.c #523.
+- [x] Single-file `cortex.yaml` still loads via the transitional fallback (no principal-facing break). — CFG.a #525; CFG.c confirmed the 3 live single-file configs still load through the modified composer (fold is a no-op when no `surfaces:` key present).
+- [x] `system.yaml` exists with `claude`/`execution`/`attachments`/`paths`/`nats`/`bus`; `nats.subjects` isolated in one place. — CFG.b #529.
+- [x] Surface bindings live in `surfaces.yaml`, out of per-stack `agents.presence`; per-stack adapters unchanged at runtime. — CFG.c #523.
+- [x] `LoadedConfig` shape unchanged across the whole epic; no consumer edits required. — CFG.a/b/c: round-trip `toEqual` identity tests at each slice; no consumer edits in CFG.c (the fold runs entirely inside `composeRawConfig`).
 
 ### 13.2 EPIC GW — Shared surface gateway (one assistant, many deployments)
 

--- a/src/common/config/__tests__/surfaces-layer.test.ts
+++ b/src/common/config/__tests__/surfaces-layer.test.ts
@@ -1,0 +1,388 @@
+/**
+ * IAW CFG.c — `surfaces.yaml` layer + the binding fold.
+ *
+ * CFG.c moves the per-platform surface bindings (Discord/Slack/Mattermost
+ * `token`, `guild`, channel/instance bindings) out of each stack's
+ * `agents[*].presence.{platform}` block into a top-level `surfaces.yaml` layer
+ * — the file the shared surface gateway (GW) consumes. It is a source-layout
+ * change, not a runtime-shape change: `LoadedConfig` is byte-identical and the
+ * per-stack adapters keep working unchanged.
+ *
+ * These tests prove:
+ *
+ *   (CFG.c.4 round-trip) bindings-in-surfaces.yaml resolve to the SAME
+ *     effective `LoadedConfig` (presence/binding view) as bindings-in-per-stack
+ *     presence — same tokens/guilds/channels resolved, for all three platforms;
+ *
+ *   (CFG.c.4 schema) `surfaces.yaml` validates required binding fields — a
+ *     binding missing `token` (Discord) / `botToken` (Slack) / `apiToken`
+ *     (Mattermost) fails loudly at load;
+ *
+ *   (CFG.c.2 fallback) a config with NO surfaces.yaml (per-stack presence only
+ *     — the three live-deployment shape) loads unchanged, fold is a no-op;
+ *
+ *   (design fork) when BOTH surfaces.yaml AND inline per-stack presence carry
+ *     the same platform, the surfaces.yaml binding wins on leaf keys (it is the
+ *     credential surface-of-truth) while inline non-binding knobs survive;
+ *
+ *   (loud failure) a binding naming an unknown agent fails loudly rather than
+ *     silently dropping a credential.
+ */
+
+import { test, expect, describe, beforeEach, afterEach } from "bun:test";
+import { mkdirSync, writeFileSync, rmSync, existsSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { stringify } from "yaml";
+import { loadConfigWithAgents } from "../loader";
+import { foldSurfaceBindings, SurfacesSchema } from "../../types/surfaces";
+
+let testDir: string;
+
+beforeEach(() => {
+  testDir = join(
+    tmpdir(),
+    `cortex-surfaces-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(testDir, { recursive: true });
+});
+
+afterEach(() => {
+  if (testDir && existsSync(testDir)) {
+    rmSync(testDir, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Fixture builders
+// ---------------------------------------------------------------------------
+
+/** The substrate blocks (system.yaml layer — needed for the directory layout). */
+function systemBlocks(): Record<string, unknown> {
+  return {
+    claude: { timeoutMs: 300000, asyncTimeoutMs: 900000, disallowedTools: ["Write"] },
+    execution: { default: "local", backends: [] },
+    attachments: {
+      enabled: true,
+      maxFileSizeBytes: 10485760,
+      maxTotalSizeBytes: 26214400,
+      maxAttachmentsPerMessage: 10,
+    },
+    paths: { publishedEventsDir: "/tmp/events/published", logDir: "/tmp/cortex/logs" },
+    nats: {
+      url: "nats://127.0.0.1:4222",
+      name: "cortex",
+      subjects: [],
+      identity: {
+        seedPath: "/tmp/cortex.nk",
+        publicKey: "UD7OGEVBNJAUQ57H5NHSPJZOKKOXOZ4DEUJVAO5URHBIUAVSVTJGL4QV",
+      },
+    },
+    bus: {
+      review: {
+        stream: { name: "CODE_REVIEW", maxAgeSeconds: 86400, maxBytes: 536870912 },
+        consumer: { maxDeliver: 5 },
+      },
+    },
+  };
+}
+
+const DISCORD_BINDING = {
+  token: "fake-token-ivy",
+  guildId: "1487023327791808592",
+  agentChannelId: "1487029848164536361",
+  logChannelId: "1487029942129524786",
+};
+
+const SLACK_BINDING = {
+  botToken: "xoxb-fake-bot-token",
+  appToken: "xapp-fake-app-token",
+  workspaceId: "T0123456789",
+};
+
+const MATTERMOST_BINDING = {
+  apiUrl: "https://mm.example.com",
+  apiToken: "fake-mm-token",
+};
+
+/** Stack with bindings INLINE in per-stack presence (the pre-CFG.c shape). */
+function stackInline(): Record<string, unknown> {
+  return {
+    principal: { id: "andreas", displayName: "Andreas" },
+    agents: [
+      {
+        id: "ivy",
+        displayName: "Ivy",
+        persona: "./personas/ivy.md",
+        roles: [],
+        trust: [],
+        presence: {
+          discord: { ...DISCORD_BINDING },
+          slack: { ...SLACK_BINDING },
+          mattermost: { ...MATTERMOST_BINDING },
+        },
+      },
+    ],
+  };
+}
+
+/** Stack with NO bindings in presence — they live in surfaces.yaml instead. */
+function stackNoBindings(): Record<string, unknown> {
+  return {
+    principal: { id: "andreas", displayName: "Andreas" },
+    agents: [
+      {
+        id: "ivy",
+        displayName: "Ivy",
+        persona: "./personas/ivy.md",
+        roles: [],
+        trust: [],
+        presence: {},
+      },
+    ],
+  };
+}
+
+/** surfaces.yaml carrying the same bindings the inline stack carried. */
+function surfacesBlock(): Record<string, unknown> {
+  return {
+    surfaces: {
+      discord: [{ agent: "ivy", stack: "andreas/research", binding: { ...DISCORD_BINDING } }],
+      slack: [{ agent: "ivy", stack: "andreas/research", binding: { ...SLACK_BINDING } }],
+      mattermost: [
+        { agent: "ivy", stack: "andreas/research", binding: { ...MATTERMOST_BINDING } },
+      ],
+    },
+  };
+}
+
+function writeSingleFile(dir: string, config: Record<string, unknown>): string {
+  mkdirSync(dir, { recursive: true });
+  const path = join(dir, "cortex.yaml");
+  writeFileSync(path, stringify(config));
+  return path;
+}
+
+/** Write system/ + surfaces/ + stacks/ layout; return the conventional path. */
+function writeSurfacesLayout(
+  dir: string,
+  system: Record<string, unknown>,
+  surfaces: Record<string, unknown>,
+  stack: Record<string, unknown>,
+): string {
+  mkdirSync(join(dir, "system"), { recursive: true });
+  writeFileSync(join(dir, "system", "system.yaml"), stringify(system));
+  mkdirSync(join(dir, "surfaces"), { recursive: true });
+  // surfaces.yaml's top-level key is `surfaces:` — write the block verbatim.
+  writeFileSync(join(dir, "surfaces", "surfaces.yaml"), stringify(surfaces));
+  mkdirSync(join(dir, "stacks"), { recursive: true });
+  writeFileSync(join(dir, "stacks", "research.yaml"), stringify(stack));
+  return join(dir, "cortex.yaml");
+}
+
+// ---------------------------------------------------------------------------
+// CFG.c.4 — round-trip: surfaces.yaml resolves to the SAME effective view as
+// inline per-stack presence (same tokens/guilds/channels for all 3 platforms)
+// ---------------------------------------------------------------------------
+
+describe("CFG.c.4 — surfaces.yaml round-trips to the same effective presence/binding view", () => {
+  test("split layout (system + surfaces + stack) == inline single-file LoadedConfig", () => {
+    // Inline baseline: single file with bindings in per-stack presence.
+    const inlineFull = { ...systemBlocks(), ...stackInline() };
+    const inlinePath = writeSingleFile(join(testDir, "inline"), inlineFull);
+
+    // surfaces.yaml form: bindings live in surfaces.yaml, presence is empty.
+    const splitPath = writeSurfacesLayout(
+      join(testDir, "split"),
+      systemBlocks(),
+      surfacesBlock(),
+      stackNoBindings(),
+    );
+
+    const inline = loadConfigWithAgents(inlinePath);
+    const split = loadConfigWithAgents(splitPath);
+
+    // Whole-LoadedConfig identity — the strongest assertion: the move is a
+    // source-layout change, not a runtime-shape change.
+    expect(split).toEqual(inline);
+
+    // Spell out the resolved binding view per platform so a regression names
+    // the exact platform that drifted. The effective view consumers read is
+    // (a) inlineAgents[*].presence (cortex.ts per-presence-token wiring) and
+    // (b) the flattened config.{discord,slack,mattermost} arrays (adapters).
+    const ivy = split.inlineAgents[0]!;
+    expect(ivy.presence.discord?.token).toBe(DISCORD_BINDING.token);
+    expect(ivy.presence.discord?.guildId).toBe(DISCORD_BINDING.guildId);
+    expect(ivy.presence.slack?.botToken).toBe(SLACK_BINDING.botToken);
+    expect(ivy.presence.slack?.workspaceId).toBe(SLACK_BINDING.workspaceId);
+    expect(ivy.presence.mattermost?.apiToken).toBe(MATTERMOST_BINDING.apiToken);
+
+    // Flattened adapter arrays — same tokens/guilds resolved.
+    expect(split.config.discord[0]?.token).toBe(DISCORD_BINDING.token);
+    expect(split.config.discord[0]?.guildId).toBe(DISCORD_BINDING.guildId);
+    expect(split.config.slack[0]?.botToken).toBe(SLACK_BINDING.botToken);
+    expect(split.config.mattermost[0]?.apiToken).toBe(MATTERMOST_BINDING.apiToken);
+  });
+
+  test("inline-single-file baseline and split agree on the flattened instanceIds", () => {
+    const inlinePath = writeSingleFile(join(testDir, "inline"), {
+      ...systemBlocks(),
+      ...stackInline(),
+    });
+    const splitPath = writeSurfacesLayout(
+      join(testDir, "split"),
+      systemBlocks(),
+      surfacesBlock(),
+      stackNoBindings(),
+    );
+    const inline = loadConfigWithAgents(inlinePath);
+    const split = loadConfigWithAgents(splitPath);
+    expect(split.config.discord.map((d) => d.instanceId)).toEqual(
+      inline.config.discord.map((d) => d.instanceId),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CFG.c.2 — fallback: a config with NO surfaces.yaml loads unchanged
+// (the three live-deployment shape; per-stack presence is the fallback)
+// ---------------------------------------------------------------------------
+
+describe("CFG.c.2 — no surfaces.yaml → per-stack presence is the fallback (fold is a no-op)", () => {
+  test("single-file inline config with no surfaces key loads unchanged", () => {
+    const path = writeSingleFile(join(testDir, "live"), {
+      ...systemBlocks(),
+      ...stackInline(),
+    });
+    const loaded = loadConfigWithAgents(path);
+    expect(loaded.inlineAgents[0]!.presence.discord?.token).toBe(DISCORD_BINDING.token);
+    expect(loaded.config.discord[0]?.token).toBe(DISCORD_BINDING.token);
+  });
+
+  test("foldSurfaceBindings returns input untouched when no surfaces key present", () => {
+    const raw = { ...stackInline() };
+    const folded = foldSurfaceBindings(raw);
+    // Same effective agents shape (no surfaces key was present to fold).
+    expect(folded.agents).toEqual(raw.agents);
+    expect("surfaces" in folded).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CFG.c.4 — schema validates required binding fields (loud failure)
+// ---------------------------------------------------------------------------
+
+describe("CFG.c.4 — surfaces.yaml schema validates required binding fields", () => {
+  test("Discord binding missing token fails loudly", () => {
+    expect(() =>
+      SurfacesSchema.parse({
+        discord: [{ agent: "ivy", binding: { guildId: "1", agentChannelId: "2", logChannelId: "3" } }],
+      }),
+    ).toThrow();
+  });
+
+  test("Slack binding with a non-xoxb botToken fails loudly", () => {
+    expect(() =>
+      SurfacesSchema.parse({
+        slack: [{ agent: "ivy", binding: { botToken: "nope", appToken: "xapp-x", workspaceId: "T01234567" } }],
+      }),
+    ).toThrow();
+  });
+
+  test("Mattermost binding missing apiToken fails loudly", () => {
+    expect(() =>
+      SurfacesSchema.parse({
+        mattermost: [{ agent: "ivy", binding: { apiUrl: "https://mm.example.com" } }],
+      }),
+    ).toThrow();
+  });
+
+  test("unknown top-level platform key fails loudly (typo guard)", () => {
+    expect(() =>
+      SurfacesSchema.parse({
+        discrod: [{ agent: "ivy", binding: { ...DISCORD_BINDING } }],
+      }),
+    ).toThrow();
+  });
+
+  test("malformed surfaces.yaml fails at load via the composer", () => {
+    const path = writeSurfacesLayout(
+      join(testDir, "bad"),
+      systemBlocks(),
+      { surfaces: { discord: [{ agent: "ivy", binding: { guildId: "1" } }] } },
+      stackNoBindings(),
+    );
+    expect(() => loadConfigWithAgents(path)).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Design fork — surfaces.yaml binding wins over inline presence on leaf keys;
+// inline non-binding knobs survive
+// ---------------------------------------------------------------------------
+
+describe("CFG.c design fork — surfaces.yaml binding precedence over inline presence", () => {
+  test("surfaces.yaml binding wins on leaf keys; inline non-binding knobs survive", () => {
+    // Stack carries an inline discord presence with an OLD token + a
+    // non-binding knob (contextDepth). surfaces.yaml supplies the NEW token.
+    const stack = {
+      principal: { id: "andreas", displayName: "Andreas" },
+      agents: [
+        {
+          id: "ivy",
+          displayName: "Ivy",
+          persona: "./personas/ivy.md",
+          roles: [],
+          trust: [],
+          presence: {
+            discord: {
+              token: "OLD-inline-token",
+              guildId: DISCORD_BINDING.guildId,
+              agentChannelId: DISCORD_BINDING.agentChannelId,
+              logChannelId: DISCORD_BINDING.logChannelId,
+              contextDepth: 42,
+            },
+          },
+        },
+      ],
+    };
+    const surfaces = {
+      surfaces: {
+        discord: [{ agent: "ivy", binding: { ...DISCORD_BINDING, token: "NEW-surfaces-token" } }],
+      },
+    };
+    const path = writeSurfacesLayout(join(testDir, "fork"), systemBlocks(), surfaces, stack);
+    const loaded = loadConfigWithAgents(path);
+    // surfaces.yaml token wins.
+    expect(loaded.inlineAgents[0]!.presence.discord?.token).toBe("NEW-surfaces-token");
+    // inline non-binding knob survives the merge.
+    expect(loaded.inlineAgents[0]!.presence.discord?.contextDepth).toBe(42);
+  });
+
+  test("binding naming an unknown agent fails loudly", () => {
+    const path = writeSurfacesLayout(
+      join(testDir, "unknown"),
+      systemBlocks(),
+      { surfaces: { discord: [{ agent: "ghost", binding: { ...DISCORD_BINDING } }] } },
+      stackNoBindings(),
+    );
+    expect(() => loadConfigWithAgents(path)).toThrow(/names agent "ghost"/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Idempotence — folding twice yields the same object
+// ---------------------------------------------------------------------------
+
+describe("CFG.c — foldSurfaceBindings is pure + idempotent", () => {
+  test("folding the same raw twice yields equal results and does not mutate input", () => {
+    const raw = { ...stackNoBindings(), ...surfacesBlock() };
+    const snapshot = structuredClone(raw);
+    const once = foldSurfaceBindings(raw);
+    const twiceInput = { ...stackNoBindings(), ...surfacesBlock() };
+    const twice = foldSurfaceBindings(twiceInput);
+    expect(once).toEqual(twice);
+    // Input not mutated (surfaces key still present on the original).
+    expect(raw).toEqual(snapshot);
+  });
+});

--- a/src/common/config/loader.ts
+++ b/src/common/config/loader.ts
@@ -22,6 +22,7 @@ import {
   type SlackPresence,
   type StackConfig,
 } from "../types/cortex-config";
+import { foldSurfaceBindings } from "../types/surfaces";
 
 /**
  * Hardening cap on a single fragment file's size. Echo M3 on cortex#62 —
@@ -360,9 +361,14 @@ export function composeRawConfig(configPath: string): Record<string, unknown> {
 
   // CFG.a.3 resolution rule: directory layout present → use it; else fallback.
   if (!existsSync(markerPath)) {
-    // CFG.a.2 — transitional single-file fallback. Identical to pre-CFG.a.
+    // CFG.a.2 — transitional single-file fallback. Identical to pre-CFG.a,
+    // except a single file MAY also carry an inline `surfaces:` block — fold
+    // it the same way so the two ingestion paths stay symmetric (CFG.c). A
+    // file with no `surfaces:` key (the three live deployments) is returned
+    // untouched by the fold.
     const content = readFileSync(expandedPath, "utf-8");
-    return (parseYaml(content) ?? {}) as Record<string, unknown>;
+    const single = (parseYaml(content) ?? {}) as Record<string, unknown>;
+    return foldSurfaceBindings(single);
   }
 
   // CFG.a.1 — directory layout. Fixed precedence: system → network → surfaces
@@ -380,7 +386,12 @@ export function composeRawConfig(configPath: string): Record<string, unknown> {
   for (const file of layerFiles) {
     raw = deepMerge(raw, readLayerFile(file));
   }
-  return raw;
+  // CFG.c — fold any `surfaces:` block into `agents[*].presence.{platform}`
+  // and drop the top-level `surfaces:` key, so the result is the exact shape
+  // the inline (pre-CFG.c) config produced. `LoadedConfig` is unchanged. A
+  // layout with no surfaces.yaml leaves `raw` without a `surfaces:` key, so the
+  // fold is a no-op and per-stack presence is the fallback.
+  return foldSurfaceBindings(raw);
 }
 
 /**

--- a/src/common/types/surfaces.ts
+++ b/src/common/types/surfaces.ts
@@ -1,0 +1,321 @@
+/**
+ * IAW CFG.c — the `surfaces.yaml` layer schema + the binding-fold helper.
+ *
+ * CFG.c moves the per-platform **surface bindings** (Discord/Slack/Mattermost
+ * `token`, `guild`, channel/instance bindings) out of each stack's
+ * `agents[*].presence.{platform}` block and into a top-level `surfaces.yaml`
+ * layer. This is the file the shared surface gateway (GW, §13.2) consumes: it
+ * is the `{surface-instance → stack}` binding map — the single place that says
+ * "this platform credential/instance belongs to this stack's agent".
+ *
+ * It is a **source-layout change, not a runtime-shape change**. The composer
+ * (`composeRawConfig`) reads `surfaces/surfaces.yaml`, folds each binding back
+ * into the matching `agents[*].presence.{platform}` block of the raw config,
+ * and drops the `surfaces:` key — so by the time the existing
+ * `loadCortexShape` parse/flatten runs, the raw object is **identical** to the
+ * inline (pre-CFG.c) form. `LoadedConfig` is byte-identical; every consumer
+ * (`src/cortex.ts` per-presence-token wiring, the per-stack adapters) keeps
+ * working unchanged.
+ *
+ * The fold is **additive and optional**: a config with NO `surfaces.yaml` (the
+ * three live deployments — `cortex.yaml` / `cortex.work.yaml` /
+ * `cortex.halden.yaml` carry bindings inline in per-stack presence) loads
+ * unchanged via the fallback. Per-stack presence is always the fallback;
+ * `surfaces.yaml` is layered on top.
+ *
+ * =============================================================================
+ * The binding map shape (GW precondition — CFG.c.3)
+ * =============================================================================
+ *
+ * ```yaml
+ * surfaces:
+ *   discord:
+ *     - agent: ivy            # which agent's presence.discord this binding fills
+ *       stack: andreas/research   # OPTIONAL — the target stack id (GW {instance → stack})
+ *       binding:              # the per-platform binding/credential fields
+ *         token: REPLACE_WITH_DISCORD_BOT_TOKEN
+ *         guildId: "000000000000000000"
+ *         agentChannelId: "000000000000000000"
+ *         logChannelId: "000000000000000000"
+ *   slack:
+ *     - agent: ivy
+ *       binding:
+ *         botToken: xoxb-...
+ *         appToken: xapp-...
+ *         workspaceId: T01234567
+ *   mattermost:
+ *     - agent: ivy
+ *       binding:
+ *         apiUrl: https://mm.example.com
+ *         apiToken: ...
+ * ```
+ *
+ * - **Key**: platform (`discord` | `slack` | `mattermost`).
+ * - **`agent`**: the agent id whose `presence.{platform}` block this binding
+ *   fills. This is the join key against `stacks/*.yaml` `agents[].id`.
+ * - **`stack`**: OPTIONAL `{principal}/{stack}` id — the surface-instance ↔
+ *   stack binding the GW routes on (`{instance → stack}`). Carried verbatim so
+ *   the gateway can build its routing table; the composer does not consume it
+ *   when folding (the agent id is the fold key within the composed raw config).
+ * - **`binding`**: the per-platform credential/instance fields — exactly the
+ *   subset of `{Discord,Slack,Mattermost}PresenceSchema` that constitutes the
+ *   surface binding (the dangerous tokens + the guild/workspace/channel ids).
+ *   These are merged onto the agent's existing `presence.{platform}` block
+ *   (binding wins on leaf keys), so a stack file may still carry the
+ *   non-binding presence knobs (`contextDepth`, `surfaceSubjects`, …) inline.
+ *
+ * Why `binding` is a nested sub-object rather than flat: it draws a crisp line
+ * between the **binding** the GW owns (and resolves per instance) and the rest
+ * of the presence block the stack owns. The GW reads `surfaces.{platform}[].binding`
+ * for the connection; the stack keeps the render knobs.
+ */
+
+import { z } from "zod/v4";
+
+import { LETTER_PREFIX_ID_REGEX } from "./id";
+
+// =============================================================================
+// Per-platform binding schemas — the credential/instance subset that moves
+// =============================================================================
+//
+// These intentionally mirror the binding-bearing fields of the matching
+// `*PresenceSchema` in `cortex-config.ts`. They are deliberately PERMISSIVE
+// supersets (`.passthrough()` is avoided — see below) of the required binding
+// fields: the schema's job here is to validate the REQUIRED binding fields
+// (CFG.c.4) are present and well-typed. The full presence validation still
+// happens downstream when the folded raw config is parsed by
+// `CortexConfigSchema` — so any binding field also re-validates against the
+// canonical presence schema after the fold. Keeping the binding schemas as
+// supersets (required fields + open `.catchall`) means a stack can put any
+// presence-shaped knob under `binding` and have it folded; the canonical
+// presence schema is the final arbiter.
+
+/**
+ * Discord surface binding — the connection-defining subset of
+ * `DiscordPresenceSchema`. `token` + `guildId` are the irreducible binding;
+ * the channel ids are the instance's render targets. `catchall(z.unknown())`
+ * lets any other presence field (e.g. `contextDepth`, `trustedBotIds`,
+ * `surfaceSubjects`) ride along under `binding` and fold through — the
+ * canonical `DiscordPresenceSchema` validates them post-fold.
+ */
+export const DiscordBindingSchema = z
+  .object({
+    token: z.string().min(1, "surfaces.discord[].binding.token is required"),
+    guildId: z.coerce.string().min(1, "surfaces.discord[].binding.guildId is required"),
+    agentChannelId: z.coerce
+      .string()
+      .min(1, "surfaces.discord[].binding.agentChannelId is required"),
+    logChannelId: z.coerce
+      .string()
+      .min(1, "surfaces.discord[].binding.logChannelId is required"),
+  })
+  .catchall(z.unknown());
+
+/**
+ * Slack surface binding — `botToken` + `appToken` + `workspaceId` are the
+ * irreducible Socket-Mode binding (mirror of `SlackPresenceSchema`). Regexes
+ * match the canonical presence schema so a malformed token fails at the
+ * surfaces layer, not only post-fold.
+ */
+export const SlackBindingSchema = z
+  .object({
+    botToken: z
+      .string()
+      .regex(/^xoxb-/, "surfaces.slack[].binding.botToken must be a bot user OAuth token (xoxb-...)"),
+    appToken: z
+      .string()
+      .regex(/^xapp-/, "surfaces.slack[].binding.appToken must be an app-level token (xapp-...)"),
+    workspaceId: z.coerce
+      .string()
+      .regex(
+        /^T[A-Z0-9]{8,16}$/,
+        "surfaces.slack[].binding.workspaceId must be a Slack team id (T... with 8-16 trailing chars)",
+      ),
+  })
+  .catchall(z.unknown());
+
+/**
+ * Mattermost surface binding — the API connection subset of
+ * `MattermostPresenceSchema`. `apiUrl` + `apiToken` are the irreducible
+ * binding (the bot needs both to reach the server); webhook/trigger knobs ride
+ * along via the catchall.
+ */
+export const MattermostBindingSchema = z
+  .object({
+    apiUrl: z.string().min(1, "surfaces.mattermost[].binding.apiUrl is required"),
+    apiToken: z.string().min(1, "surfaces.mattermost[].binding.apiToken is required"),
+  })
+  .catchall(z.unknown());
+
+// =============================================================================
+// Binding entry — one surface-instance bound to one stack's agent
+// =============================================================================
+
+/** Common fields on every per-platform binding entry. */
+const bindingEntryBase = {
+  /**
+   * The agent id whose `presence.{platform}` block this binding fills — the
+   * join key against `stacks/*.yaml` `agents[].id`. Same id grammar as
+   * `AgentSchema.id` (letter-prefixed lowercase alphanumeric + hyphen).
+   */
+  agent: z.string().regex(
+    LETTER_PREFIX_ID_REGEX,
+    "surfaces[].agent must be a valid agent id (lowercase alphanumeric + hyphen, starting with a letter) matching an agents[].id in the stack",
+  ),
+  /**
+   * OPTIONAL `{principal}/{stack}` id — the surface-instance ↔ stack binding
+   * the GW routes on. Carried verbatim for the gateway's `{instance → stack}`
+   * routing table; the composer does not consume it when folding (the agent
+   * id is the fold key). Validated loosely as a non-empty string here — the
+   * canonical stack-id grammar lives in `StackConfigSchema.id` and is GW's to
+   * resolve.
+   */
+  stack: z.string().min(1).optional(),
+};
+
+export const DiscordSurfaceBindingSchema = z.object({
+  ...bindingEntryBase,
+  binding: DiscordBindingSchema,
+});
+
+export const SlackSurfaceBindingSchema = z.object({
+  ...bindingEntryBase,
+  binding: SlackBindingSchema,
+});
+
+export const MattermostSurfaceBindingSchema = z.object({
+  ...bindingEntryBase,
+  binding: MattermostBindingSchema,
+});
+
+// =============================================================================
+// Top-level `surfaces:` block
+// =============================================================================
+
+/**
+ * The `surfaces:` block — the binding map. Keyed by platform; each platform
+ * holds a list of `{agent, stack?, binding}` entries. All three platforms are
+ * optional (a deployment may bind only Discord). `.strict()` rejects an
+ * unknown platform key loudly so a typo (`discrod:`) surfaces at load rather
+ * than silently contributing nothing to the fold.
+ */
+export const SurfacesSchema = z
+  .object({
+    discord: z.array(DiscordSurfaceBindingSchema).optional(),
+    slack: z.array(SlackSurfaceBindingSchema).optional(),
+    mattermost: z.array(MattermostSurfaceBindingSchema).optional(),
+  })
+  // `.strict()` rejects an unknown platform key loudly so a typo (`discrod:`)
+  // surfaces at load rather than silently contributing nothing to the fold.
+  .strict();
+
+export type Surfaces = z.infer<typeof SurfacesSchema>;
+export type DiscordSurfaceBinding = z.infer<typeof DiscordSurfaceBindingSchema>;
+export type SlackSurfaceBinding = z.infer<typeof SlackSurfaceBindingSchema>;
+export type MattermostSurfaceBinding = z.infer<typeof MattermostSurfaceBindingSchema>;
+
+// =============================================================================
+// The fold — surfaces.yaml bindings → agents[*].presence.{platform}
+// =============================================================================
+
+const PLATFORMS = ["discord", "slack", "mattermost"] as const;
+type Platform = (typeof PLATFORMS)[number];
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+/**
+ * CFG.c.1/CFG.c.2 — fold a `surfaces:` block into the composed raw config's
+ * `agents[*].presence.{platform}` blocks, returning a NEW raw object with the
+ * top-level `surfaces:` key removed.
+ *
+ * Called by `composeRawConfig` AFTER the directory layers are deep-merged and
+ * BEFORE the result is handed to the parse/flatten path. The result is the
+ * exact shape the inline (pre-CFG.c) config produced — so `LoadedConfig` is
+ * unchanged and no consumer is touched.
+ *
+ * Resolution / precedence (the design fork called out in CFG.c):
+ *
+ *   - The binding's `agent` field is matched against `agents[].id` in the
+ *     composed raw config. The binding is merged onto that agent's
+ *     `presence.{platform}` block, **binding fields winning on leaf keys**
+ *     (the surfaces.yaml layer is the more-specific surface-of-truth for the
+ *     credential/instance fields, layered on top of any inline presence the
+ *     stack file declared). A stack may therefore keep non-binding presence
+ *     knobs (`contextDepth`, `surfaceSubjects`) inline and let surfaces.yaml
+ *     own only the binding — the two merge.
+ *   - If the agent has no `presence.{platform}` block yet, one is created from
+ *     the binding alone.
+ *   - **No matching agent → loud error.** A binding that names an agent absent
+ *     from every stack is almost certainly a typo or a stale binding; failing
+ *     loudly beats silently dropping a credential (which would leave the agent
+ *     dark with no diagnostic).
+ *
+ * `surfaces` absent or empty → `raw` returned unchanged (minus a no-op clone),
+ * which is the fallback path the three live single-presence configs take.
+ *
+ * The function does NOT mutate its input (pure fold — idempotent re-composition
+ * yields the same object, matching `deepMerge`'s contract).
+ */
+export function foldSurfaceBindings(
+  raw: Record<string, unknown>,
+): Record<string, unknown> {
+  const surfacesRaw = raw.surfaces;
+  if (surfacesRaw === undefined || surfacesRaw === null) {
+    // No surfaces layer — per-stack presence is the fallback. Nothing to fold.
+    return raw;
+  }
+
+  // Validate the binding map loudly (CFG.c.4 — required binding fields). A
+  // malformed surfaces.yaml fails at load, not silently.
+  const surfaces = SurfacesSchema.parse(surfacesRaw);
+
+  // Detach so we never mutate the caller's object (idempotent fold).
+  const out = structuredClone(raw);
+  delete out.surfaces;
+
+  const agents = out.agents;
+  if (!Array.isArray(agents)) {
+    throw new Error(
+      "config-composer: surfaces.yaml is present but the composed config declares no `agents:` array to fold bindings into — " +
+        "surface bindings name an agent id, so at least one stack with `agents:` must compose alongside surfaces.yaml.",
+    );
+  }
+
+  // Index agents by id for the fold join.
+  const agentById = new Map<string, Record<string, unknown>>();
+  for (const a of agents) {
+    if (isPlainObject(a) && typeof a.id === "string") {
+      agentById.set(a.id, a);
+    }
+  }
+
+  for (const platform of PLATFORMS) {
+    const entries = surfaces[platform];
+    if (!entries) continue;
+    for (const entry of entries) {
+      const agent = agentById.get(entry.agent);
+      if (!agent) {
+        throw new Error(
+          `config-composer: surfaces.yaml ${platform} binding names agent "${entry.agent}", ` +
+            `but no agents[].id in the composed config matches it. ` +
+            `Known agent ids: [${[...agentById.keys()].join(", ") || "(none)"}]. ` +
+            `Fix the binding's \`agent:\` field or add the agent to a stack.`,
+        );
+      }
+      const presence = isPlainObject(agent.presence)
+        ? (agent.presence as Record<string, unknown>)
+        : {};
+      const existing = isPlainObject(presence[platform])
+        ? (presence[platform] as Record<string, unknown>)
+        : {};
+      // Binding wins on leaf keys (surfaces.yaml is the credential surface of
+      // truth, layered over any inline non-binding presence knobs).
+      presence[platform] = { ...existing, ...entry.binding };
+      agent.presence = presence;
+    }
+  }
+
+  return out;
+}


### PR DESCRIPTION
Final EPIC CFG slice (#523). Surface bindings move out of per-stack `agents.presence` into an optional top-level **`surfaces.yaml`**; `foldSurfaceBindings` matches each binding's `agent`→`agents[].id`, merges onto `presence.{platform}`, deletes the `surfaces:` key — so the post-fold raw is the inline pre-CFG.c form and **`LoadedConfig` is byte-identical**. Per-stack `presence` is the fallback (surfaces.yaml is optional). Loud validation of required binding fields. **This is the GW (#524) precondition** — GW reads `surfaces.{platform}[]` for its `{instance→stack}` routing table.

**`LoadedConfig` shape unchanged; all 3 live configs load unchanged** (fold is a no-op — they have no surfaces.yaml). tsc clean · suite **3729 pass / 0 fail** (12 new tests) · vocab gate **0**. Closes #523 — **EPIC CFG (a/b/c) complete**; unblocks GW #524.

🤖 Generated with [Claude Code](https://claude.com/claude-code)