### PR TITLE
fix(lint): clear 3 eslint errors in surfaces.ts (unblock the Lint gate on main)

### DIFF
--- a/src/common/types/surfaces.ts
+++ b/src/common/types/surfaces.ts
@@ -219,7 +219,6 @@ export type MattermostSurfaceBinding = z.infer<typeof MattermostSurfaceBindingSc
 // =============================================================================
 
 const PLATFORMS = ["discord", "slack", "mattermost"] as const;
-type Platform = (typeof PLATFORMS)[number];
 
 function isPlainObject(v: unknown): v is Record<string, unknown> {
   return typeof v === "object" && v !== null && !Array.isArray(v);
@@ -304,11 +303,9 @@ export function foldSurfaceBindings(
             `Fix the binding's \`agent:\` field or add the agent to a stack.`,
         );
       }
-      const presence = isPlainObject(agent.presence)
-        ? (agent.presence as Record<string, unknown>)
-        : {};
+      const presence = isPlainObject(agent.presence) ? agent.presence : {};
       const existing = isPlainObject(presence[platform])
-        ? (presence[platform] as Record<string, unknown>)
+        ? presence[platform]
         : {};
       // Binding wins on leaf keys (surfaces.yaml is the credential surface of
       // truth, layered over any inline non-binding presence knobs).


### PR DESCRIPTION
Main's **Lint** check (`eslint --quiet`, errors-only blocking gate) is red — 3 errors in `foldSurfaceBindings` (`src/common/types/surfaces.ts`), pre-existing (landed before the gate was wired, surfaced on #533's CI):

| Line | Rule | Fix |
|------|------|-----|
| 222 | `no-unused-vars` — `Platform` declared, never used | remove the dead type alias (the fold loop infers from `PLATFORMS` directly) |
| 308 | `no-unnecessary-type-assertion` | drop `as Record<string, unknown>` — `isPlainObject` is a type guard, branch already narrowed |
| 311 | `no-unnecessary-type-assertion` | same |

**Behavior-preserving.** The casts were no-ops (eslint flagged them precisely because they don't change the inferred type), and `Platform` had zero references. `LoadedConfig` shape unchanged.

**Verified:** `bunx eslint --quiet src/common/types/surfaces.ts` → clean; `bunx tsc --noEmit` → exit 0, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)