### PR TITLE
feat(mc): G-1113.B.1 — Provider enum + SourceRef shape (types only)

### DIFF
--- a/src/surface/mc/__tests__/source-ref.test.ts
+++ b/src/surface/mc/__tests__/source-ref.test.ts
@@ -7,6 +7,14 @@
 import { test, expect } from "bun:test";
 import { PROVIDERS, isProvider, type Provider, type SourceRef, type TaskSourceSystem } from "../types";
 
+// Compile-time invariant: every legacy TaskSourceSystem member MUST be a
+// Provider. If someone adds a TaskSourceSystem member without adding it to
+// PROVIDERS, this line fails `tsc` — the superset relationship is enforced by
+// the type-checker, not by remembering to extend the runtime array below.
+type _AssertSourceSystemSubsetOfProvider = TaskSourceSystem extends Provider ? true : never;
+const _sourceSystemIsProviderSubset: _AssertSourceSystemSubsetOfProvider = true;
+void _sourceSystemIsProviderSubset;
+
 test("PROVIDERS lists the expected members", () => {
   expect([...PROVIDERS]).toEqual([
     "internal",

--- a/src/surface/mc/__tests__/source-ref.test.ts
+++ b/src/surface/mc/__tests__/source-ref.test.ts
@@ -1,0 +1,62 @@
+/**
+ * G-1113.B.1 — Provider enum + SourceRef shape (types only).
+ *
+ * Guards the single-source-of-truth invariant (PROVIDERS ⇄ Provider ⇄
+ * isProvider) and the legacy-superset relationship with TaskSourceSystem.
+ */
+import { test, expect } from "bun:test";
+import { PROVIDERS, isProvider, type Provider, type SourceRef, type TaskSourceSystem } from "../types";
+
+test("PROVIDERS lists the expected members", () => {
+  expect([...PROVIDERS]).toEqual([
+    "internal",
+    "github",
+    "gitlab",
+    "azure-devops",
+    "jira",
+    "linear",
+    "bitbucket",
+    "custom",
+  ]);
+});
+
+test("isProvider accepts every PROVIDERS member", () => {
+  for (const p of PROVIDERS) expect(isProvider(p)).toBe(true);
+});
+
+test("isProvider rejects non-members and non-strings", () => {
+  expect(isProvider("Github")).toBe(false); // case-sensitive
+  expect(isProvider("svn")).toBe(false);
+  expect(isProvider("")).toBe(false);
+  expect(isProvider(null)).toBe(false);
+  expect(isProvider(undefined)).toBe(false);
+  expect(isProvider(42)).toBe(false);
+});
+
+test("Provider is a superset of the legacy TaskSourceSystem", () => {
+  const legacy: TaskSourceSystem[] = ["github", "internal"];
+  for (const s of legacy) expect(isProvider(s)).toBe(true);
+});
+
+test("SourceRef shape: providerNativeType preserved on the normalized concept (design §11)", () => {
+  const mr: SourceRef = {
+    provider: "gitlab",
+    externalId: "42",
+    url: "https://gitlab.example/group/repo/-/merge_requests/42",
+    providerNativeType: "merge_request",
+  };
+  expect(mr.provider).toBe("gitlab");
+  expect(mr.providerNativeType).toBe("merge_request");
+
+  const internal: SourceRef = {
+    provider: "internal",
+    externalId: null,
+    url: null,
+    providerNativeType: null,
+  };
+  expect(internal.externalId).toBeNull();
+
+  // type-level: a valid Provider is assignable
+  const p: Provider = "azure-devops";
+  expect(isProvider(p)).toBe(true);
+});

--- a/src/surface/mc/types.ts
+++ b/src/surface/mc/types.ts
@@ -107,7 +107,13 @@ export interface SourceRef {
   externalId: string | null;
   /** Canonical URL to the backing object, when one exists. */
   url: string | null;
-  /** Provider-native object label preserved on the normalized concept. Null when not applicable. */
+  /**
+   * Provider-native object label preserved on the normalized concept
+   * (e.g. `"issue"`, `"pull_request"`, `"merge_request"`). Null when not
+   * applicable. Deliberately an opaque `string` at the source boundary — the
+   * typed literal union (`"pull_request" | "merge_request" | …`) lives on the
+   * Phase-C `PullRequest` Git concept, not here; don't narrow it in B.2/C.
+   */
   providerNativeType: string | null;
 }
 

--- a/src/surface/mc/types.ts
+++ b/src/surface/mc/types.ts
@@ -60,6 +60,57 @@ export type BlockReason =
 
 export type TaskSourceSystem = "github" | "internal";
 
+// --- Provider / source-ref model (G-1113.B.1) ---
+
+/**
+ * The set of work-item providers Mission Control can normalize a task from.
+ * `PROVIDERS` is the single source of truth — `Provider` is derived from it so
+ * the union and the runtime guard never drift. Superset of the legacy
+ * {@link TaskSourceSystem} (`github | internal`); the remaining members are
+ * declared now (B.1, types only) and wired in later phases.
+ */
+export const PROVIDERS = [
+  "internal",
+  "github",
+  "gitlab",
+  "azure-devops",
+  "jira",
+  "linear",
+  "bitbucket",
+  "custom",
+] as const;
+
+export type Provider = (typeof PROVIDERS)[number];
+
+/** Runtime guard for {@link Provider} — narrows untrusted input (config/API/wire). */
+export function isProvider(value: unknown): value is Provider {
+  return typeof value === "string" && (PROVIDERS as readonly string[]).includes(value);
+}
+
+/**
+ * Normalized reference to a task's origin in some provider, independent of the
+ * provider's own object model. Provider-specific adapters (B.3+) produce this
+ * shape so the rest of Mission Control never branches on `source=github`.
+ *
+ * `providerNativeType` preserves the provider's own object label
+ * (e.g. `"issue"`, `"pull_request"`, `"merge_request"`) on the normalized
+ * concept rather than forking the model per provider. This resolves the
+ * design §11 open question in favour of **native-type-as-field**: a GitLab
+ * merge request is a normalized PullRequest carrying
+ * `providerNativeType: "merge_request"` — not a separate `ChangeRequest`
+ * top-level concept. (The Git-object modelling that consumes this lands in
+ * Phase C; B.1 only fixes the source-ref shape.)
+ */
+export interface SourceRef {
+  provider: Provider;
+  /** Provider-native id of the backing object (issue number, MR iid, …). Null for internal/manual. */
+  externalId: string | null;
+  /** Canonical URL to the backing object, when one exists. */
+  url: string | null;
+  /** Provider-native object label preserved on the normalized concept. Null when not applicable. */
+  providerNativeType: string | null;
+}
+
 export interface Task {
   id: string;
   title: string;


### PR DESCRIPTION
First slice of **Phase B** (Provider-Neutral Source Refs, #538). Types only — no behavior change.

## Adds (`src/surface/mc/types.ts`)
- `PROVIDERS` single-source-of-truth array → derived `Provider` union (`internal | github | gitlab | azure-devops | jira | linear | bitbucket | custom`) + `isProvider` runtime guard. Superset of the legacy `TaskSourceSystem`.
- `SourceRef` shape `{ provider, externalId, url, providerNativeType }`.

## Resolves design §11 open question
**Native-type-as-field**: a GitLab merge request is a normalized `PullRequest` carrying `providerNativeType: "merge_request"` — *not* a separate top-level `ChangeRequest`. (The Git-object modelling that consumes this lands in Phase C; B.1 only fixes the source-ref shape.)

## Scope
- `Task` is untouched — its `SourceRef` migration + shim is **B.2** (#540).
- Unit test (`__tests__/source-ref.test.ts`) covers the `PROVIDERS⇄Provider⇄isProvider` invariant, the legacy-superset relationship, and the shape.

## Verify
`bunx tsc --noEmit` clean · `bun test source-ref.test.ts` 5/5 · carve-out gate passes.

Closes #539. Refs #538, #354.

> Note: the autonomous bus review loop is blocked by #535 (`empty_chain` signing) — this PR is self-reviewed via in-session sub-agents and needs a human approval to merge, same as #530.

🤖 Generated with [Claude Code](https://claude.com/claude-code)