### PR TITLE
feat(gateway): GW.a.2 — SurfaceGateway inbound orchestrator (shadow) (#524)

### DIFF
--- a/src/gateway/__tests__/surface-gateway.test.ts
+++ b/src/gateway/__tests__/surface-gateway.test.ts
@@ -179,10 +179,12 @@ class FakeSink implements GatewayInboundSink {
   readonly calls: { decision: GatewayInboundDecision; msg: InboundMessage }[] =
     [];
 
-  shouldThrow: Error | null = null;
+  /** Set to make publish() throw — `unknown` so non-Error throws are exercisable. */
+  shouldThrow: unknown = null;
 
   async publish(decision: GatewayInboundDecision, msg: InboundMessage): Promise<void> {
-    if (this.shouldThrow) throw this.shouldThrow;
+    // eslint-disable-next-line @typescript-eslint/only-throw-error -- a test deliberately throws a non-Error value to exercise handleInbound's String(err) defensive branch (production sinks may be JS that throws non-Errors)
+    if (this.shouldThrow !== null) throw this.shouldThrow;
     this.calls.push({ decision, msg });
   }
 }
@@ -490,8 +492,79 @@ describe("handleInbound — sink throws", () => {
 
       // Error should have been written to stderr
       const combined = stderrChunks.join("");
-      expect(combined).toContain("sink.publish error");
+      expect(combined).toContain("handleInbound error");
       expect(combined).toContain("bus not connected");
+    } finally {
+      process.stderr.write = savedWrite;
+    }
+  });
+
+  test("non-Error sink throw is stringified, no throw escapes", async () => {
+    const adapter = new MockAdapter("discord", "discord-luna-mf");
+    const index = buildBindingIndex(DISCORD_SURFACES);
+    const sink = new FakeSink();
+    sink.shouldThrow = "boom-string"; // non-Error throw value → String(err) branch
+
+    const stderrChunks: string[] = [];
+    const savedWrite: typeof process.stderr.write = process.stderr.write;
+    process.stderr.write = (chunk: string | Uint8Array): boolean => {
+      if (typeof chunk === "string") stderrChunks.push(chunk);
+      return savedWrite.call(process.stderr, chunk);
+    };
+
+    try {
+      const gw = new SurfaceGateway([adapter], index, sink);
+      await gw.start();
+      const inbound = msg({
+        platform: "discord",
+        instanceId: "discord-luna-mf",
+        guildId: "111222333444555666",
+        channelId: "ch-9000",
+      });
+      await expect(adapter.trigger(inbound)).resolves.toBeUndefined();
+      expect(stderrChunks.join("")).toContain("boom-string");
+    } finally {
+      process.stderr.write = savedWrite;
+    }
+  });
+});
+
+// ─── 12. onUnroutable hook throws → caught, loop survives ─────────────────────
+
+describe("handleInbound — onUnroutable hook throws", () => {
+  test("a throwing onUnroutable is caught, no throw escapes the adapter loop", async () => {
+    const adapter = new MockAdapter("discord", "discord-luna-mf");
+    const index = buildBindingIndex(DISCORD_SURFACES);
+    const sink = new FakeSink();
+
+    const stderrChunks: string[] = [];
+    const savedWrite: typeof process.stderr.write = process.stderr.write;
+    process.stderr.write = (chunk: string | Uint8Array): boolean => {
+      if (typeof chunk === "string") stderrChunks.push(chunk);
+      return savedWrite.call(process.stderr, chunk);
+    };
+
+    try {
+      const gw = new SurfaceGateway([adapter], index, sink, {
+        onUnroutable: () => {
+          throw new Error("hook blew up");
+        },
+      });
+      await gw.start();
+
+      // DM → unroutable → onUnroutable throws; handleInbound must still not throw.
+      const inbound = msg({
+        platform: "discord",
+        instanceId: "discord-luna-mf",
+        channelId: "dm-ch",
+        isDM: true,
+      });
+      await expect(adapter.trigger(inbound)).resolves.toBeUndefined();
+
+      const combined = stderrChunks.join("");
+      expect(combined).toContain("handleInbound error");
+      expect(combined).toContain("hook blew up");
+      expect(sink.calls).toHaveLength(0);
     } finally {
       process.stderr.write = savedWrite;
     }

--- a/src/gateway/__tests__/surface-gateway.test.ts
+++ b/src/gateway/__tests__/surface-gateway.test.ts
@@ -1,0 +1,590 @@
+/**
+ * cortex#524 GW.a.2 — SurfaceGateway inbound orchestrator tests (TDD Red→Green).
+ *
+ * Tests cover:
+ *
+ *   1. start() wires all adapters' onMessage to handleInbound
+ *   2. stop() stops all adapters
+ *   3. Routable inbound (Discord) → correct decision + responseRouting
+ *   4. Routable inbound (Slack) → correct decision + responseRouting
+ *   5. Routable inbound (Mattermost single-binding) → correct decision
+ *   6. Thread ID present → thread_id on responseRouting
+ *   7. No thread ID → thread_id absent on responseRouting
+ *   8. Unroutable inbound (DM / no guildId) → onUnroutable called, sink NOT called
+ *   9. Unroutable inbound (unknown guildId) → onUnroutable called, sink NOT called
+ *  10. Mattermost multi-binding → onUnroutable called, sink NOT called
+ *  11. Sink throws → error logged to stderr, loop survives (no throw escapes)
+ *  12. Default onUnroutable (console.warn) fires when no custom handler provided
+ *  13. LoggingInboundSink.publish writes to stdout (shadow stage)
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  SurfaceGateway,
+  LoggingInboundSink,
+  type GatewayInboundDecision,
+  type GatewayInboundSink,
+} from "../surface-gateway";
+import { buildBindingIndex } from "../binding-resolver";
+import type { PlatformAdapter, InboundMessage } from "../../adapters/types";
+import type { Surfaces } from "../../common/types/surfaces";
+
+// ─── Shared fixtures ─────────────────────────────────────────────────────────
+
+const DISCORD_SURFACES: Surfaces = {
+  discord: [
+    {
+      agent: "luna",
+      stack: "andreas/meta-factory",
+      binding: {
+        token: "tok-luna-discord",
+        guildId: "111222333444555666",
+        agentChannelId: "aaa000000000000001",
+        logChannelId: "bbb000000000000002",
+      },
+    },
+  ],
+};
+
+const SLACK_SURFACES: Surfaces = {
+  slack: [
+    {
+      agent: "luna",
+      stack: "andreas/meta-factory",
+      binding: {
+        botToken: "xoxb-111-222-abc",
+        appToken: "xapp-1-333-444-def",
+        workspaceId: "T0123456789",
+      },
+    },
+  ],
+};
+
+const MATTERMOST_SINGLE_SURFACES: Surfaces = {
+  mattermost: [
+    {
+      agent: "luna",
+      stack: "andreas/work",
+      binding: {
+        apiUrl: "https://mm.example.com",
+        apiToken: "mm-tok-abc",
+      },
+    },
+  ],
+};
+
+const MATTERMOST_MULTI_SURFACES: Surfaces = {
+  mattermost: [
+    {
+      agent: "luna",
+      stack: "andreas/work",
+      binding: { apiUrl: "https://mm.work.example.com", apiToken: "mm-tok-work" },
+    },
+    {
+      agent: "echo",
+      stack: "andreas/meta-factory",
+      binding: { apiUrl: "https://mm.mf.example.com", apiToken: "mm-tok-mf" },
+    },
+  ],
+};
+
+/** Minimal valid InboundMessage for tests that only care about routing fields */
+function msg(overrides: Partial<InboundMessage>): InboundMessage {
+  return {
+    platform: "discord",
+    instanceId: "discord-luna-mf",
+    authorId: "u1",
+    authorName: "Test User",
+    content: "hello gateway",
+    channelId: "ch-100",
+    attachments: [],
+    timestamp: new Date("2026-01-01T00:00:00Z"),
+    ...overrides,
+  };
+}
+
+// ─── MockAdapter ─────────────────────────────────────────────────────────────
+
+/**
+ * Minimal PlatformAdapter mock.
+ *
+ * Captures the `onMessage` callback so tests can drive inbound messages
+ * directly via `trigger(msg)`. `start()` / `stop()` are observable via
+ * `startCalled` / `stopCalled` counts.
+ */
+class MockAdapter implements PlatformAdapter {
+  readonly platform: string;
+  readonly instanceId: string;
+
+  startCalled = 0;
+  stopCalled = 0;
+
+  private _onMessage: ((msg: InboundMessage) => Promise<void>) | null = null;
+
+  constructor(platform: string, instanceId: string) {
+    this.platform = platform;
+    this.instanceId = instanceId;
+  }
+
+  async start(onMessage: (msg: InboundMessage) => Promise<void>): Promise<void> {
+    this.startCalled++;
+    this._onMessage = onMessage;
+  }
+
+  async stop(): Promise<void> {
+    this.stopCalled++;
+    this._onMessage = null;
+  }
+
+  /** Drive an inbound message through the registered onMessage callback. */
+  async trigger(inbound: InboundMessage): Promise<void> {
+    if (!this._onMessage) throw new Error("adapter not started");
+    await this._onMessage(inbound);
+  }
+
+  // ── stubs for the rest of PlatformAdapter ─────────────────────────────────
+
+  async getPlatformUserId(): Promise<string> {
+    return "bot-user-id";
+  }
+
+  async fetchContext() {
+    return [];
+  }
+
+  resolveAccess() {
+    return {
+      allowed: true,
+      features: { chat: true, async: false, team: false },
+    };
+  }
+
+  async postResponse() {}
+  async sendTyping() {}
+  async sendProgress() {}
+  async clearProgress() {}
+  async createThread() {
+    return { instanceId: this.instanceId, channelId: "new-thread" };
+  }
+  async resolveLogicalTarget() {
+    return null;
+  }
+  async notifyPrincipal() {}
+}
+
+// ─── FakeSink ─────────────────────────────────────────────────────────────────
+
+/** Capturing sink — records every publish call for assertion. */
+class FakeSink implements GatewayInboundSink {
+  readonly calls: { decision: GatewayInboundDecision; msg: InboundMessage }[] =
+    [];
+
+  shouldThrow: Error | null = null;
+
+  async publish(decision: GatewayInboundDecision, msg: InboundMessage): Promise<void> {
+    if (this.shouldThrow) throw this.shouldThrow;
+    this.calls.push({ decision, msg });
+  }
+}
+
+// ─── 1. start() wires all adapters ───────────────────────────────────────────
+
+describe("SurfaceGateway.start()", () => {
+  test("calls start() on every adapter", async () => {
+    const a1 = new MockAdapter("discord", "disc-1");
+    const a2 = new MockAdapter("slack", "slack-1");
+    const index = buildBindingIndex({});
+    const sink = new FakeSink();
+    const gw = new SurfaceGateway([a1, a2], index, sink);
+
+    await gw.start();
+
+    expect(a1.startCalled).toBe(1);
+    expect(a2.startCalled).toBe(1);
+  });
+});
+
+// ─── 2. stop() stops all adapters ────────────────────────────────────────────
+
+describe("SurfaceGateway.stop()", () => {
+  test("calls stop() on every adapter", async () => {
+    const a1 = new MockAdapter("discord", "disc-1");
+    const a2 = new MockAdapter("slack", "slack-1");
+    const index = buildBindingIndex({});
+    const sink = new FakeSink();
+    const gw = new SurfaceGateway([a1, a2], index, sink);
+
+    await gw.start();
+    await gw.stop();
+
+    expect(a1.stopCalled).toBe(1);
+    expect(a2.stopCalled).toBe(1);
+  });
+});
+
+// ─── 3. Routable inbound (Discord) ───────────────────────────────────────────
+
+describe("handleInbound — routable Discord message", () => {
+  test("publishes correct decision with match + responseRouting", async () => {
+    const adapter = new MockAdapter("discord", "discord-luna-mf");
+    const index = buildBindingIndex(DISCORD_SURFACES);
+    const sink = new FakeSink();
+    const gw = new SurfaceGateway([adapter], index, sink);
+    await gw.start();
+
+    const inbound = msg({
+      platform: "discord",
+      instanceId: "discord-luna-mf",
+      guildId: "111222333444555666",
+      channelId: "ch-9000",
+    });
+    await adapter.trigger(inbound);
+
+    expect(sink.calls).toHaveLength(1);
+    const call = sink.calls[0];
+    expect(call).toBeDefined();
+
+    const { decision } = call!;
+    expect(decision.match.platform).toBe("discord");
+    expect(decision.match.agent).toBe("luna");
+    expect(decision.match.principal).toBe("andreas");
+    expect(decision.match.stack).toBe("meta-factory");
+    expect(decision.match.instance).toBe("discord:111222333444555666");
+
+    expect(decision.responseRouting.adapter_instance).toBe("discord-luna-mf");
+    expect(decision.responseRouting.channel_id).toBe("ch-9000");
+    expect(decision.responseRouting.thread_id).toBeUndefined();
+  });
+});
+
+// ─── 4. Routable inbound (Slack) ─────────────────────────────────────────────
+
+describe("handleInbound — routable Slack message", () => {
+  test("publishes correct decision", async () => {
+    const adapter = new MockAdapter("slack", "slack-luna-mf");
+    const index = buildBindingIndex(SLACK_SURFACES);
+    const sink = new FakeSink();
+    const gw = new SurfaceGateway([adapter], index, sink);
+    await gw.start();
+
+    const inbound = msg({
+      platform: "slack",
+      instanceId: "slack-luna-mf",
+      guildId: "T0123456789", // Slack workspaceId maps to guildId on InboundMessage
+      channelId: "C111222333",
+    });
+    await adapter.trigger(inbound);
+
+    expect(sink.calls).toHaveLength(1);
+    const call = sink.calls[0];
+    expect(call).toBeDefined();
+
+    const { decision } = call!;
+    expect(decision.match.platform).toBe("slack");
+    expect(decision.match.agent).toBe("luna");
+    expect(decision.responseRouting.adapter_instance).toBe("slack-luna-mf");
+    expect(decision.responseRouting.channel_id).toBe("C111222333");
+  });
+});
+
+// ─── 5. Routable inbound (Mattermost single-binding) ─────────────────────────
+
+describe("handleInbound — routable Mattermost single-binding", () => {
+  test("publishes correct decision via single-binding fallback", async () => {
+    const adapter = new MockAdapter("mattermost", "mm-luna");
+    const index = buildBindingIndex(MATTERMOST_SINGLE_SURFACES);
+    const sink = new FakeSink();
+    const gw = new SurfaceGateway([adapter], index, sink);
+    await gw.start();
+
+    const inbound = msg({
+      platform: "mattermost",
+      instanceId: "mm-luna",
+      channelId: "ch-mm-1",
+    });
+    await adapter.trigger(inbound);
+
+    expect(sink.calls).toHaveLength(1);
+    const call = sink.calls[0];
+    expect(call).toBeDefined();
+
+    const { decision } = call!;
+    expect(decision.match.platform).toBe("mattermost");
+    expect(decision.match.agent).toBe("luna");
+    expect(decision.match.principal).toBe("andreas");
+    expect(decision.match.stack).toBe("work");
+    expect(decision.responseRouting.adapter_instance).toBe("mm-luna");
+  });
+});
+
+// ─── 6. Thread ID present → thread_id on responseRouting ─────────────────────
+
+describe("handleInbound — thread_id propagation", () => {
+  test("thread_id is set on responseRouting when msg.threadId is present", async () => {
+    const adapter = new MockAdapter("discord", "discord-luna-mf");
+    const index = buildBindingIndex(DISCORD_SURFACES);
+    const sink = new FakeSink();
+    const gw = new SurfaceGateway([adapter], index, sink);
+    await gw.start();
+
+    const inbound = msg({
+      platform: "discord",
+      instanceId: "discord-luna-mf",
+      guildId: "111222333444555666",
+      channelId: "ch-9000",
+      threadId: "thread-42",
+    });
+    await adapter.trigger(inbound);
+
+    expect(sink.calls).toHaveLength(1);
+    const call = sink.calls[0];
+    expect(call).toBeDefined();
+    expect(call!.decision.responseRouting.thread_id).toBe("thread-42");
+  });
+
+  test("thread_id is absent on responseRouting when msg.threadId is undefined", async () => {
+    const adapter = new MockAdapter("discord", "discord-luna-mf");
+    const index = buildBindingIndex(DISCORD_SURFACES);
+    const sink = new FakeSink();
+    const gw = new SurfaceGateway([adapter], index, sink);
+    await gw.start();
+
+    const inbound = msg({
+      platform: "discord",
+      instanceId: "discord-luna-mf",
+      guildId: "111222333444555666",
+      channelId: "ch-9000",
+      threadId: undefined,
+    });
+    await adapter.trigger(inbound);
+
+    expect(sink.calls).toHaveLength(1);
+    const call = sink.calls[0];
+    expect(call).toBeDefined();
+    expect("thread_id" in call!.decision.responseRouting).toBe(false);
+  });
+});
+
+// ─── 8. Unroutable inbound (DM / no guildId) ─────────────────────────────────
+
+describe("handleInbound — unroutable (DM)", () => {
+  test("onUnroutable is called, sink is NOT called", async () => {
+    const adapter = new MockAdapter("discord", "discord-luna-mf");
+    const index = buildBindingIndex(DISCORD_SURFACES);
+    const sink = new FakeSink();
+
+    const unroutableCalls: { msg: InboundMessage; reason: string }[] = [];
+    const gw = new SurfaceGateway([adapter], index, sink, {
+      onUnroutable: (m, r) => {
+        unroutableCalls.push({ msg: m, reason: r });
+      },
+    });
+    await gw.start();
+
+    // DM — no guildId
+    const inbound = msg({
+      platform: "discord",
+      instanceId: "discord-luna-mf",
+      channelId: "dm-ch",
+      isDM: true,
+    });
+    await adapter.trigger(inbound);
+
+    expect(unroutableCalls).toHaveLength(1);
+    expect(unroutableCalls[0]).toBeDefined();
+    expect(unroutableCalls[0]!.reason).toContain("DM");
+    expect(sink.calls).toHaveLength(0);
+  });
+});
+
+// ─── 9. Unroutable inbound (unknown guildId) ─────────────────────────────────
+
+describe("handleInbound — unroutable (unknown guildId)", () => {
+  test("onUnroutable is called with no-binding reason, sink is NOT called", async () => {
+    const adapter = new MockAdapter("discord", "discord-luna-mf");
+    const index = buildBindingIndex(DISCORD_SURFACES);
+    const sink = new FakeSink();
+
+    const unroutableCalls: string[] = [];
+    const gw = new SurfaceGateway([adapter], index, sink, {
+      onUnroutable: (_m, r) => {
+        unroutableCalls.push(r);
+      },
+    });
+    await gw.start();
+
+    const inbound = msg({
+      platform: "discord",
+      instanceId: "discord-luna-mf",
+      guildId: "999999999999999999", // not in the index
+      channelId: "ch-x",
+    });
+    await adapter.trigger(inbound);
+
+    expect(unroutableCalls).toHaveLength(1);
+    expect(unroutableCalls[0]).toBeDefined();
+    expect(unroutableCalls[0]!).toContain("no binding");
+    expect(sink.calls).toHaveLength(0);
+  });
+});
+
+// ─── 10. Mattermost multi-binding → unroutable ───────────────────────────────
+
+describe("handleInbound — mattermost multi-binding (unroutable)", () => {
+  test("onUnroutable is called with multi-binding reason, sink NOT called", async () => {
+    const adapter = new MockAdapter("mattermost", "mm-multi");
+    const index = buildBindingIndex(MATTERMOST_MULTI_SURFACES);
+    const sink = new FakeSink();
+
+    const unroutableCalls: string[] = [];
+    const gw = new SurfaceGateway([adapter], index, sink, {
+      onUnroutable: (_m, r) => {
+        unroutableCalls.push(r);
+      },
+    });
+    await gw.start();
+
+    const inbound = msg({
+      platform: "mattermost",
+      instanceId: "mm-multi",
+      channelId: "ch-mm",
+    });
+    await adapter.trigger(inbound);
+
+    expect(unroutableCalls).toHaveLength(1);
+    expect(unroutableCalls[0]).toBeDefined();
+    expect(unroutableCalls[0]!).toContain("multi-binding");
+    expect(sink.calls).toHaveLength(0);
+  });
+});
+
+// ─── 11. Sink throws → logged, loop survives ──────────────────────────────────
+
+describe("handleInbound — sink throws", () => {
+  test("sink error is logged to stderr, no throw escapes handleInbound", async () => {
+    const adapter = new MockAdapter("discord", "discord-luna-mf");
+    const index = buildBindingIndex(DISCORD_SURFACES);
+    const sink = new FakeSink();
+    sink.shouldThrow = new Error("bus not connected");
+
+    const stderrChunks: string[] = [];
+    const savedWrite: typeof process.stderr.write = process.stderr.write;
+    process.stderr.write = (chunk: string | Uint8Array): boolean => {
+      if (typeof chunk === "string") stderrChunks.push(chunk);
+      return savedWrite.call(process.stderr, chunk);
+    };
+
+    try {
+      const gw = new SurfaceGateway([adapter], index, sink);
+      await gw.start();
+
+      const inbound = msg({
+        platform: "discord",
+        instanceId: "discord-luna-mf",
+        guildId: "111222333444555666",
+        channelId: "ch-9000",
+      });
+
+      // Must not throw
+      await expect(adapter.trigger(inbound)).resolves.toBeUndefined();
+
+      // Error should have been written to stderr
+      const combined = stderrChunks.join("");
+      expect(combined).toContain("sink.publish error");
+      expect(combined).toContain("bus not connected");
+    } finally {
+      process.stderr.write = savedWrite;
+    }
+  });
+});
+
+// ─── 12. Default onUnroutable (console.warn) ─────────────────────────────────
+
+describe("SurfaceGateway — default onUnroutable", () => {
+  test("console.warn is called when no custom handler is provided", async () => {
+    const adapter = new MockAdapter("discord", "discord-luna-mf");
+    const index = buildBindingIndex(DISCORD_SURFACES);
+    const sink = new FakeSink();
+    // No onUnroutable option — default should call console.warn
+    const gw = new SurfaceGateway([adapter], index, sink);
+    await gw.start();
+
+    const warnMessages: unknown[] = [];
+    const originalWarn = console.warn;
+    console.warn = (...args: unknown[]) => {
+      warnMessages.push(...args);
+    };
+
+    try {
+      const inbound = msg({
+        platform: "discord",
+        instanceId: "discord-luna-mf",
+        channelId: "dm-ch",
+        // no guildId → DM → unroutable
+      });
+      await adapter.trigger(inbound);
+
+      expect(warnMessages.length).toBeGreaterThan(0);
+      const warnStr = String(warnMessages[0]);
+      expect(warnStr).toContain("unroutable");
+    } finally {
+      console.warn = originalWarn;
+    }
+  });
+});
+
+// ─── 13. LoggingInboundSink writes to stdout ─────────────────────────────────
+
+describe("LoggingInboundSink", () => {
+  test("publish writes a shadow-stage log line to stdout", async () => {
+    const sink = new LoggingInboundSink();
+    const index = buildBindingIndex(DISCORD_SURFACES);
+    const match = {
+      platform: "discord" as const,
+      agent: "luna",
+      principal: "andreas",
+      stack: "meta-factory",
+      instance: "discord:111222333444555666",
+    };
+    const decision: GatewayInboundDecision = {
+      match,
+      responseRouting: {
+        adapter_instance: "discord-luna-mf",
+        channel_id: "ch-9000",
+        thread_id: "t-42",
+      },
+    };
+    const inbound = msg({
+      platform: "discord",
+      instanceId: "discord-luna-mf",
+      guildId: "111222333444555666",
+      channelId: "ch-9000",
+      threadId: "t-42",
+    });
+
+    const stdoutChunks: string[] = [];
+    const savedWrite: typeof process.stdout.write = process.stdout.write;
+    process.stdout.write = (chunk: string | Uint8Array): boolean => {
+      if (typeof chunk === "string") stdoutChunks.push(chunk);
+      return savedWrite.call(process.stdout, chunk);
+    };
+
+    try {
+      await sink.publish(decision, inbound);
+
+      const combined = stdoutChunks.join("");
+      expect(combined).toContain("[surface-gateway:shadow]");
+      expect(combined).toContain("platform=discord");
+      expect(combined).toContain("agent=luna");
+      expect(combined).toContain("principal=andreas");
+      expect(combined).toContain("stack=meta-factory");
+      expect(combined).toContain("adapter_instance=discord-luna-mf");
+      expect(combined).toContain("channel_id=ch-9000");
+      expect(combined).toContain("thread_id=t-42");
+      // Unused variable suppressed intentionally
+      void index;
+    } finally {
+      process.stdout.write = savedWrite;
+    }
+  });
+});

--- a/src/gateway/surface-gateway.ts
+++ b/src/gateway/surface-gateway.ts
@@ -1,0 +1,309 @@
+/**
+ * GW.a.2 — SurfaceGateway inbound orchestrator (cortex#524, shadow stage).
+ *
+ * This module implements the INBOUND half of the shared surface gateway:
+ * for each platform adapter, it rebinds the `onMessage` callback to route
+ * inbound messages through the binding resolver and hand routing decisions
+ * to an injected {@link GatewayInboundSink}.
+ *
+ * ## Shadow stage (Stage 1, §7)
+ *
+ * In Stage 1 the sink is {@link LoggingInboundSink} — it logs the routing
+ * decision that WOULD be published to the bus, but does not actually publish.
+ * This lets the gateway run alongside per-stack adapters on a staging identity
+ * to prove demux correctness before any stack loses its own adapter.
+ *
+ * ## GW.a.3 follow-on
+ *
+ * The real bus-publishing sink, the `SurfaceGateway` wiring in `cortex.ts`,
+ * and the launchd plist that runs the gateway as a supervised process are all
+ * GW.a.3 work. This module is kept fully unit-testable behind injected
+ * interfaces so GW.a.3 only adds a sink implementation and wires things up,
+ * without touching the orchestrator.
+ *
+ * ## v1 decisions baked in
+ *
+ * - `responseRouting.adapter_instance` = `msg.instanceId` (the adapter's own
+ *   connection-instance key). This aligns with the outbound mux key the
+ *   gateway will use in GW.a.3: the `response_routing.instance` carried on
+ *   lifecycle envelopes back to the gateway is the adapter-instance id that
+ *   sourced the dispatch, so the mux can route the reply back to the right
+ *   platform connection.
+ *   NOTE: `GatewayBindingMatch.instance` (from GW.a.1) is derived from the
+ *   binding config (`platform:guildId`, etc.) and acts as a stable binding id;
+ *   `responseRouting.adapter_instance` = `msg.instanceId` is the live
+ *   connection-instance key (what the per-adapter `instanceId` carries at
+ *   runtime). In v1 these are the same value for non-gateway adapters; the
+ *   gateway itself owns a single adapter per binding and stamps the adapter's
+ *   `instanceId` on the wire so outbound mux keys reconcile.
+ *
+ * - Unroutable inbound is logged and dropped. The adapter loop must never throw
+ *   — a throw from `onMessage` can crash the adapter's internal event loop.
+ *
+ * - Sink errors are logged to stderr and swallowed. Same reason: the adapter
+ *   loop must stay alive even if a downstream publish transiently fails.
+ */
+
+import type { PlatformAdapter, InboundMessage } from "../adapters/types";
+import {
+  resolveBinding,
+  type GatewayBindingIndex,
+  type GatewayBindingMatch,
+} from "./binding-resolver";
+import type { ResponseRouting } from "../bus/dispatch-events";
+
+// =============================================================================
+// Public types
+// =============================================================================
+
+/**
+ * The routing decision the gateway derives from one inbound message.
+ *
+ * Carries the full binding match (target principal / stack / agent) and the
+ * response-routing address the runner must echo onto every lifecycle envelope
+ * so the outbound mux can deliver replies back to the correct platform
+ * connection.
+ */
+export interface GatewayInboundDecision {
+  /** Full binding match from the resolver — principal, stack, agent, instance. */
+  match: GatewayBindingMatch;
+
+  /**
+   * Wire-level response-routing address for this inbound message.
+   *
+   * `adapter_instance` = `msg.instanceId` — the connection-instance key of the
+   * adapter that received the message. The outbound mux in GW.a.3 reads this
+   * field off the lifecycle envelope to select which platform connection to
+   * render the reply on.
+   *
+   * `channel_id` / `thread_id` are the platform-native ids carried on the
+   * inbound message and echoed verbatim onto the lifecycle envelope chain.
+   */
+  responseRouting: ResponseRouting;
+}
+
+/**
+ * The injected seam that the gateway hands routing decisions to.
+ *
+ * In Stage 1 (shadow) this is {@link LoggingInboundSink} — it logs the
+ * decision for observability but does NOT publish to the bus.
+ *
+ * In GW.a.3 this is replaced by a real bus-publishing sink that publishes a
+ * canonical `tasks.@{did-encoded-assistant}.chat` envelope per
+ * `dispatch-source-publisher.ts`.
+ */
+export interface GatewayInboundSink {
+  publish(decision: GatewayInboundDecision, msg: InboundMessage): Promise<void>;
+}
+
+// =============================================================================
+// SurfaceGateway
+// =============================================================================
+
+/** Options for {@link SurfaceGateway}. */
+export interface SurfaceGatewayOptions {
+  /**
+   * Called when an inbound message cannot be routed (no binding match, DM on
+   * Discord/Slack with no single-binding fallback, or Mattermost multi-binding
+   * ambiguity). The default implementation emits a `console.warn`.
+   *
+   * Shadow stage: this is a logging hook. The adapter loop is never interrupted
+   * — `onUnroutable` must not throw.
+   */
+  onUnroutable?: (msg: InboundMessage, reason: string) => void;
+}
+
+/**
+ * The shared surface gateway's inbound orchestrator.
+ *
+ * Drives one or more {@link PlatformAdapter} instances, rebinding their
+ * `onMessage` callback to route inbound messages through the binding index
+ * and publish routing decisions to the injected {@link GatewayInboundSink}.
+ *
+ * In production (GW.a.3) the gateway is constructed once at startup, given the
+ * adapters for all `(platform, identity)` connections the gateway owns, and
+ * kept alive for the lifetime of the process. The launchd plist owns restart.
+ */
+export class SurfaceGateway {
+  private readonly adapters: PlatformAdapter[];
+  private readonly index: GatewayBindingIndex;
+  private readonly sink: GatewayInboundSink;
+  private readonly onUnroutable: (msg: InboundMessage, reason: string) => void;
+
+  constructor(
+    adapters: PlatformAdapter[],
+    index: GatewayBindingIndex,
+    sink: GatewayInboundSink,
+    opts?: SurfaceGatewayOptions,
+  ) {
+    this.adapters = adapters;
+    this.index = index;
+    this.sink = sink;
+    this.onUnroutable =
+      opts?.onUnroutable ??
+      ((msg, reason) => {
+        console.warn(
+          `[surface-gateway] unroutable inbound message — dropping. ` +
+            `platform=${msg.platform} instanceId=${msg.instanceId} ` +
+            `channelId=${msg.channelId} reason="${reason}"`,
+        );
+      });
+  }
+
+  /**
+   * Start all adapters, rebinding each `onMessage` callback to route through
+   * this gateway.
+   *
+   * Each adapter owns one `(platform, identity)` connection. The gateway is
+   * the sole `onMessage` handler — the per-stack `dispatchHandler.handleMessage`
+   * path is bypassed (design §5: "the `onMessage` callback is rebound").
+   */
+  async start(): Promise<void> {
+    await Promise.all(
+      this.adapters.map((adapter) =>
+        adapter.start((msg) => this.handleInbound(adapter, msg)),
+      ),
+    );
+  }
+
+  /**
+   * Stop all adapters, releasing their platform connections.
+   */
+  async stop(): Promise<void> {
+    await Promise.all(this.adapters.map((a) => a.stop()));
+  }
+
+  /**
+   * Route one inbound message to the sink.
+   *
+   * Called from inside the adapter's `onMessage` callback — MUST NOT throw.
+   * Any error (unroutable, sink failure) is logged and the method returns
+   * cleanly so the adapter loop stays alive.
+   */
+  async handleInbound(
+    _adapter: PlatformAdapter,
+    msg: InboundMessage,
+  ): Promise<void> {
+    const match = resolveBinding(this.index, msg);
+
+    if (match === null) {
+      const reason = unroutableReason(msg, this.index);
+      this.onUnroutable(msg, reason);
+      return;
+    }
+
+    const decision: GatewayInboundDecision = {
+      match,
+      responseRouting: {
+        // adapter_instance = msg.instanceId — the connection-instance key.
+        // See module doc "v1 decisions" for the reconciliation note.
+        adapter_instance: msg.instanceId,
+        channel_id: msg.channelId,
+        ...(msg.threadId !== undefined && { thread_id: msg.threadId }),
+      },
+    };
+
+    try {
+      await this.sink.publish(decision, msg);
+    } catch (err: unknown) {
+      // Sink errors are logged but never re-thrown — the adapter loop must
+      // survive a transient publish failure (e.g., bus not yet connected at
+      // Shadow stage). This is NOT an empty catch: the error is written to
+      // stderr with full context so it surfaces in logs.
+      process.stderr.write(
+        `[surface-gateway] sink.publish error — dropping message. ` +
+          `platform=${msg.platform} instanceId=${msg.instanceId} ` +
+          `channelId=${msg.channelId} ` +
+          `error=${err instanceof Error ? err.message : String(err)}\n`,
+      );
+    }
+  }
+}
+
+// =============================================================================
+// LoggingInboundSink (shadow-stage sink)
+// =============================================================================
+
+/**
+ * Shadow-stage sink — logs the routing decision and response-routing address
+ * that WOULD be published to the bus, without publishing.
+ *
+ * Used in Stage 1 to observe demux correctness on real traffic before any
+ * stack's adapter is retired. Replace with the real bus-publishing sink in
+ * GW.a.3.
+ *
+ * The logged subject mirrors the canonical `tasks.@{did-encoded-assistant}.chat`
+ * form the bus-publishing sink will use, so the shadow log is directly
+ * comparable to what the real sink will emit.
+ */
+export class LoggingInboundSink implements GatewayInboundSink {
+  publish(
+    decision: GatewayInboundDecision,
+    msg: InboundMessage,
+  ): Promise<void> {
+    const { match, responseRouting } = decision;
+
+    // Build the subject the GW.a.3 bus-publishing sink will publish on.
+    // principal / stack may be undefined when the binding carries no `stack`
+    // field (binding-resolver gap 4 / OQ4).
+    const subjectHint =
+      match.principal !== undefined && match.stack !== undefined
+        ? `local.${match.principal}.${match.stack}.tasks.@${match.agent}.chat`
+        : `<unresolved-stack>.tasks.@${match.agent}.chat`;
+
+    process.stdout.write(
+      `[surface-gateway:shadow] inbound routed ` +
+        `platform=${match.platform} ` +
+        `agent=${match.agent} ` +
+        `principal=${match.principal ?? "<unresolved>"} ` +
+        `stack=${match.stack ?? "<unresolved>"} ` +
+        `subject=${subjectHint} ` +
+        `response_routing={ adapter_instance=${responseRouting.adapter_instance} ` +
+        `channel_id=${responseRouting.channel_id}` +
+        (responseRouting.thread_id !== undefined
+          ? ` thread_id=${responseRouting.thread_id}`
+          : "") +
+        ` } ` +
+        `author=${msg.authorName} ` +
+        `content_length=${msg.content.length}\n`,
+    );
+
+    return Promise.resolve();
+  }
+}
+
+// =============================================================================
+// Internal helpers
+// =============================================================================
+
+/**
+ * Derive a human-readable reason string for an unroutable inbound message.
+ * Used by the default `onUnroutable` handler and can be passed to a custom one.
+ */
+function unroutableReason(
+  msg: InboundMessage,
+  index: GatewayBindingIndex,
+): string {
+  const { platform } = msg;
+
+  if (platform === "discord" || platform === "slack") {
+    if (!msg.guildId) {
+      return "DM (no guildId) — guild-granularity demux only in v1";
+    }
+    const map = platform === "discord" ? index.discord : index.slack;
+    if (!map.has(msg.guildId)) {
+      return `no binding for ${platform} guildId "${msg.guildId}"`;
+    }
+  }
+
+  if (platform === "mattermost") {
+    if (index.mattermostMulti) {
+      return "mattermost multi-binding ambiguity — no per-message server id to discriminate";
+    }
+    if (!index.mattermostSingle) {
+      return "no mattermost bindings configured";
+    }
+  }
+
+  return `no binding match for platform "${platform}"`;
+}

--- a/src/gateway/surface-gateway.ts
+++ b/src/gateway/surface-gateway.ts
@@ -177,41 +177,49 @@ export class SurfaceGateway {
    * Route one inbound message to the sink.
    *
    * Called from inside the adapter's `onMessage` callback — MUST NOT throw.
-   * Any error (unroutable, sink failure) is logged and the method returns
-   * cleanly so the adapter loop stays alive.
+   * The ENTIRE body runs under one try/catch so never-throw is a code
+   * invariant, not a caller obligation: a throwing `onUnroutable` hook, a
+   * throwing `sink.publish`, or anything else is logged with full context and
+   * swallowed so the adapter loop stays alive.
+   *
+   * @param _adapter the adapter that received the message. Unused in the shadow
+   *   stage; reserved for GW.a.3, where the outbound mux needs the per-connection
+   *   context to render replies. Kept on the signature (design §5 references
+   *   `gateway.handleInbound(adapter, msg)`) rather than re-threaded later.
    */
   async handleInbound(
     _adapter: PlatformAdapter,
     msg: InboundMessage,
   ): Promise<void> {
-    const match = resolveBinding(this.index, msg);
-
-    if (match === null) {
-      const reason = unroutableReason(msg, this.index);
-      this.onUnroutable(msg, reason);
-      return;
-    }
-
-    const decision: GatewayInboundDecision = {
-      match,
-      responseRouting: {
-        // adapter_instance = msg.instanceId — the connection-instance key.
-        // See module doc "v1 decisions" for the reconciliation note.
-        adapter_instance: msg.instanceId,
-        channel_id: msg.channelId,
-        ...(msg.threadId !== undefined && { thread_id: msg.threadId }),
-      },
-    };
-
     try {
+      const match = resolveBinding(this.index, msg);
+
+      if (match === null) {
+        const reason = unroutableReason(msg, this.index);
+        this.onUnroutable(msg, reason);
+        return;
+      }
+
+      const decision: GatewayInboundDecision = {
+        match,
+        responseRouting: {
+          // adapter_instance = msg.instanceId — the connection-instance key.
+          // See module doc "v1 decisions" for the reconciliation note.
+          adapter_instance: msg.instanceId,
+          channel_id: msg.channelId,
+          ...(msg.threadId !== undefined && { thread_id: msg.threadId }),
+        },
+      };
+
       await this.sink.publish(decision, msg);
     } catch (err: unknown) {
-      // Sink errors are logged but never re-thrown — the adapter loop must
-      // survive a transient publish failure (e.g., bus not yet connected at
-      // Shadow stage). This is NOT an empty catch: the error is written to
-      // stderr with full context so it surfaces in logs.
+      // handleInbound runs inside the adapter's onMessage loop and MUST NOT
+      // throw — a throw can crash the adapter's event loop. Any error (a
+      // throwing onUnroutable hook, a sink failure at Shadow stage before the
+      // bus is connected, etc.) is logged with full context and swallowed so
+      // the loop stays alive. This is NOT an empty catch.
       process.stderr.write(
-        `[surface-gateway] sink.publish error — dropping message. ` +
+        `[surface-gateway] handleInbound error — dropping message. ` +
           `platform=${msg.platform} instanceId=${msg.instanceId} ` +
           `channelId=${msg.channelId} ` +
           `error=${err instanceof Error ? err.message : String(err)}\n`,


### PR DESCRIPTION
Second slice of the shared surface gateway (#524, task #87). The **inbound orchestrator**, shadow stage — pure orchestration behind injected interfaces, **zero live I/O** (real bus sink + cortex.ts wiring + launchd are GW.a.3).

## What
`src/gateway/surface-gateway.ts` (+13 tests):
- **`SurfaceGateway`** — `start()` rebinds each adapter's `onMessage` → `handleInbound` (design §5); `handleInbound` resolves the binding (GW.a.1), drops unroutable via an `onUnroutable` hook (**never throws** — the adapter loop must survive), and on a match builds a `GatewayInboundDecision` + awaits `sink.publish` (sink errors logged to stderr, not re-thrown — no empty catch); `stop()` stops all adapters.
- **`GatewayInboundDecision { match, responseRouting }`** — `responseRouting.adapter_instance = msg.instanceId`, reconciling GW.a.1's config-derived binding `instance` with the wire's `adapter_instance` so GW.a.3's outbound mux keys on the same id (documented).
- **`GatewayInboundSink`** interface + **`LoggingInboundSink`** (shadow) — logs the routing decision + the subject it *would* publish; no bus publish. Proves demux on real traffic before any stack retires its adapter (design §7 Stage 1).

## Decisions baked in
- Shadow stage: observe/log; outbound mux + real publish = GW.a.3.
- Unroutable inbound logged + dropped, never thrown.
- `adapter_instance = msg.instanceId` (live connection key).

## Gates (verified on branch)
`tsc` 0 · `eslint --quiet` 0 · `bun test src/gateway/` **41/41** (28 resolver + 13 new) · whole-tree vocab gate PASS.

Refs #524 · part of #110.

🤖 Generated with [Claude Code](https://claude.com/claude-code)