### PR TITLE
feat(mc): G-1113.B.4 — provider badge on task rows + Sources view

### DIFF
--- a/src/surface/mc/dashboard-v2/__tests__/iteration-display.test.ts
+++ b/src/surface/mc/dashboard-v2/__tests__/iteration-display.test.ts
@@ -312,6 +312,7 @@ describe("validateTaskUpdatedPayload", () => {
         id: "t-1",
         title: "T",
         iteration: { id: "it-1", title: 42, state: "designing" },
+        source: SRC,
       })
     ).toBeNull();
   });
@@ -322,6 +323,7 @@ describe("validateTaskUpdatedPayload", () => {
         id: "t-1",
         title: "T",
         iteration: { id: "it-1", title: "Alpha", state: "bogus" },
+        source: SRC,
       })
     ).toBeNull();
   });

--- a/src/surface/mc/dashboard-v2/__tests__/iteration-display.test.ts
+++ b/src/surface/mc/dashboard-v2/__tests__/iteration-display.test.ts
@@ -260,8 +260,10 @@ describe("validateTaskUpdatedPayload", () => {
     return validateTaskUpdatedPayload(raw) !== null;
   }
 
+  const SRC = { provider: "github", externalId: null, url: null, providerNativeType: null };
+
   it("accepts a well-formed payload (no iteration)", () => {
-    expect(isAccepted({ id: "t-1", title: "T", iteration: null })).toBe(true);
+    expect(isAccepted({ id: "t-1", title: "T", iteration: null, source: SRC })).toBe(true);
   });
 
   it("accepts a well-formed payload (with iteration)", () => {
@@ -270,8 +272,19 @@ describe("validateTaskUpdatedPayload", () => {
         id: "t-1",
         title: "T",
         iteration: { id: "it-1", title: "Alpha", state: "designing" },
+        source: SRC,
       })
     ).toBe(true);
+  });
+
+  it("returns null when source is missing or malformed (G-1113.B.4 guard)", () => {
+    expect(validateTaskUpdatedPayload({ id: "t-1", title: "T", iteration: null })).toBeNull();
+    expect(
+      validateTaskUpdatedPayload({ id: "t-1", title: "T", iteration: null, source: { provider: "svn-bogus", externalId: null, url: null, providerNativeType: null } })
+    ).toBeNull();
+    expect(
+      validateTaskUpdatedPayload({ id: "t-1", title: "T", iteration: null, source: { provider: "github", externalId: 42, url: null, providerNativeType: null } })
+    ).toBeNull();
   });
 
   it("returns null for non-object input", () => {

--- a/src/surface/mc/dashboard-v2/__tests__/provider-badge.test.ts
+++ b/src/surface/mc/dashboard-v2/__tests__/provider-badge.test.ts
@@ -1,0 +1,28 @@
+/**
+ * G-1113.B.4 — provider badge metadata + Sources view state (pure helpers).
+ */
+import { test, expect } from "bun:test";
+import { providerMeta } from "../components/provider-badge";
+import { sourceState, ACTIVE_PROVIDERS } from "../components/sources-view";
+import { PROVIDERS } from "../../types";
+
+test("providerMeta is total over the Provider union with non-empty labels", () => {
+  for (const p of PROVIDERS) {
+    const meta = providerMeta(p);
+    expect(typeof meta.label).toBe("string");
+    expect(meta.label.length).toBeGreaterThan(0);
+  }
+});
+
+test("github + internal render as active; the rest as available", () => {
+  expect(sourceState("github")).toBe("active");
+  expect(sourceState("internal")).toBe("active");
+  for (const p of PROVIDERS) {
+    const expected = p === "github" || p === "internal" ? "active" : "available";
+    expect(sourceState(p)).toBe(expected);
+  }
+});
+
+test("ACTIVE_PROVIDERS matches the tasks.source_system CHECK (github, internal)", () => {
+  expect([...ACTIVE_PROVIDERS].sort()).toEqual(["github", "internal"]);
+});

--- a/src/surface/mc/dashboard-v2/app.tsx
+++ b/src/surface/mc/dashboard-v2/app.tsx
@@ -19,6 +19,7 @@ import { useIterations } from "./hooks/use-iterations";
 import { useMetrics } from "./hooks/use-metrics";
 import { useWorkingAgents } from "./hooks/use-working-agents";
 import { MetricsPanel } from "./components/metrics-panel";
+import { SourcesView } from "./components/sources-view";
 import { Toast } from "./components/toast";
 import { useFocusArea } from "./hooks/use-focus-area";
 import { useTasks } from "./hooks/use-tasks";
@@ -44,7 +45,7 @@ import type { Command } from "./components/command-palette";
  * may upgrade to a hash route if deep-linking turns out to be
  * principal-requested; for now the in-memory view is sufficient.
  */
-type DashboardView = "default" | "metrics" | "iterations" | "kanban-detail";
+type DashboardView = "default" | "metrics" | "iterations" | "sources" | "kanban-detail";
 
 export function App() {
   const { theme, toggle: toggleTheme } = useTheme();
@@ -229,6 +230,15 @@ export function App() {
         >
           Iterations
         </button>
+        <button
+          type="button"
+          role="tab"
+          aria-selected={view === "sources"}
+          className={`tab${view === "sources" ? " active" : ""}`}
+          onClick={() => setView("sources")}
+        >
+          Sources
+        </button>
       </nav>
 
       <main className="scaffold-main">
@@ -368,6 +378,11 @@ export function App() {
             state.transition keeps the panel current as work happens.
           */
           <MetricsPanel state={metrics} />
+        )}
+
+        {view === "sources" && (
+          /* G-1113.B.4 — provider-neutral Sources config view. */
+          <SourcesView />
         )}
 
         {view === "iterations" && (

--- a/src/surface/mc/dashboard-v2/components/provider-badge.tsx
+++ b/src/surface/mc/dashboard-v2/components/provider-badge.tsx
@@ -1,0 +1,48 @@
+/**
+ * G-1113.B.4 — provider-aware source badge.
+ *
+ * Renders a small colour-dot + provider label, fed by a task's normalized
+ * `SourceRef.provider` (G-1113.B.1/B.2). Today every task reads "GitHub" or
+ * "Internal"; the badge is provider-aware so future GitLab / Azure DevOps /
+ * Jira / Linear tasks render distinctly without touching call sites.
+ */
+import type { Provider } from "../../types";
+
+export interface ProviderMeta {
+  /** Human label shown in the badge + Sources view. */
+  label: string;
+}
+
+const PROVIDER_META: Record<Provider, ProviderMeta> = {
+  internal: { label: "Internal" },
+  github: { label: "GitHub" },
+  gitlab: { label: "GitLab" },
+  "azure-devops": { label: "Azure DevOps" },
+  jira: { label: "Jira" },
+  linear: { label: "Linear" },
+  bitbucket: { label: "Bitbucket" },
+  custom: { label: "Custom" },
+};
+
+/** Pure lookup — display metadata for a provider. Total over the Provider union. */
+export function providerMeta(provider: Provider): ProviderMeta {
+  return PROVIDER_META[provider];
+}
+
+export interface ProviderBadgeProps {
+  provider: Provider;
+}
+
+/**
+ * Small provider badge: a per-provider colour dot (the "icon") + the label.
+ * Colour comes from `.provider-badge .dot.provider-{name}` in global.css.
+ */
+export function ProviderBadge({ provider }: ProviderBadgeProps) {
+  const meta = providerMeta(provider);
+  return (
+    <span className="provider-badge" title={`Source: ${meta.label}`}>
+      <span className={`dot provider-${provider}`} aria-hidden="true" />
+      <span className="provider-label">{meta.label}</span>
+    </span>
+  );
+}

--- a/src/surface/mc/dashboard-v2/components/provider-badge.tsx
+++ b/src/surface/mc/dashboard-v2/components/provider-badge.tsx
@@ -40,7 +40,7 @@ export interface ProviderBadgeProps {
 export function ProviderBadge({ provider }: ProviderBadgeProps) {
   const meta = providerMeta(provider);
   return (
-    <span className="provider-badge" title={`Source: ${meta.label}`}>
+    <span className="provider-badge" title="Source">
       <span className={`dot provider-${provider}`} aria-hidden="true" />
       <span className="provider-label">{meta.label}</span>
     </span>

--- a/src/surface/mc/dashboard-v2/components/sources-view.tsx
+++ b/src/surface/mc/dashboard-v2/components/sources-view.tsx
@@ -1,0 +1,42 @@
+/**
+ * G-1113.B.4 — Sources config view.
+ *
+ * Lists the work-item providers Mission Control knows about and their state.
+ * Today only GitHub + Internal are wired (the `tasks.source_system` CHECK
+ * allows `github`/`internal`); the rest are declared in the {@link Provider}
+ * union and render as "available" so the path to adding one is visible. When a
+ * provider gets a real adapter (B.3+ pattern) it moves to "active".
+ */
+import { PROVIDERS, type Provider } from "../../types";
+import { ProviderBadge } from "./provider-badge";
+
+/** Providers with a wired adapter / accepted by the task source CHECK today. */
+export const ACTIVE_PROVIDERS: ReadonlySet<Provider> = new Set<Provider>(["github", "internal"]);
+
+export function sourceState(provider: Provider): "active" | "available" {
+  return ACTIVE_PROVIDERS.has(provider) ? "active" : "available";
+}
+
+export function SourcesView() {
+  return (
+    <section className="scaffold-section sources-view" aria-label="Configured sources">
+      <h2>Sources</h2>
+      <p className="dim">
+        Providers Mission Control can normalize tasks from. Only <strong>active</strong>{" "}
+        providers are wired today; <strong>available</strong> ones are declared and
+        gain an adapter as work lands.
+      </p>
+      <ul className="sources-list">
+        {PROVIDERS.map((provider) => {
+          const state = sourceState(provider);
+          return (
+            <li key={provider} className={`source-row source-${state}`}>
+              <ProviderBadge provider={provider} />
+              <span className={`source-state state-${state}`}>{state}</span>
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+}

--- a/src/surface/mc/dashboard-v2/components/task-table.tsx
+++ b/src/surface/mc/dashboard-v2/components/task-table.tsx
@@ -19,6 +19,7 @@ import { TaskFilters } from "./task-filters";
 import { AddTaskModal } from "./add-task-modal";
 import { DispatchButton } from "./dispatch-button";
 import { Pill } from "./pill";
+import { ProviderBadge } from "./provider-badge";
 import { DEFAULT_AGENT_DISPLAY_NAME } from "../lib/agent-defaults";
 import {
   chipPillKind,
@@ -363,7 +364,10 @@ function TaskRow({
       >
         P{task.priority}
       </td>
-      <td className="title">{task.title}</td>
+      <td className="title">
+        <ProviderBadge provider={task.source.provider} />
+        <span className="title-text">{task.title}</span>
+      </td>
       <td className="iteration">
         {task.iteration ? (
           <button

--- a/src/surface/mc/dashboard-v2/lib/iteration-display.ts
+++ b/src/surface/mc/dashboard-v2/lib/iteration-display.ts
@@ -22,6 +22,7 @@
 
 import type { TaskIterationTag, TaskListItem } from "../../db/tasks";
 import { ITERATION_STATES, type IterationState } from "../../db/iterations";
+import { isProvider } from "../../types";
 
 /** Visual truncation cap. Mirrors the F-8 column width budget. */
 export const ITERATION_TITLE_MAX_CHARS = 20;
@@ -201,6 +202,16 @@ export function validateTaskUpdatedPayload(raw: unknown): TaskListItem | null {
     if (!itPatch) return null;
     if (typeof itPatch.title !== "string") return null;
     if (typeof itPatch.state !== "string") return null;
+  }
+  // G-1113.B.4 — `source` (SourceRef) is now a required field a renderer reads
+  // (the provider badge). Guard its shape so a malformed source-less broadcast
+  // can't land in the cache with `source === undefined` despite the TS cast.
+  const src = t.source;
+  if (!src || typeof src !== "object") return null;
+  const s = src as Record<string, unknown>;
+  if (!isProvider(s.provider)) return null;
+  for (const f of ["externalId", "url", "providerNativeType"] as const) {
+    if (s[f] !== null && typeof s[f] !== "string") return null;
   }
   return raw as TaskListItem;
 }

--- a/src/surface/mc/dashboard-v2/styles/global.css
+++ b/src/surface/mc/dashboard-v2/styles/global.css
@@ -295,6 +295,39 @@ html, body {
 }
 .scaffold-footer a { color: var(--fg-dim); text-decoration: none; }
 .scaffold-footer a:hover { color: var(--fg); text-decoration: underline; }
+
+/* G-1113.B.4 — provider source badge (task rows + Sources view) */
+.provider-badge {
+  display: inline-flex; align-items: center; gap: 5px;
+  margin-right: 8px; vertical-align: baseline;
+  font-size: 10.5px; color: var(--fg-faint); white-space: nowrap;
+}
+.provider-badge .dot {
+  width: 7px; height: 7px; border-radius: 50%;
+  background: var(--fg-faint); flex: 0 0 auto;
+}
+.provider-badge .dot.provider-github { background: #8957e5; }
+.provider-badge .dot.provider-gitlab { background: #e24329; }
+.provider-badge .dot.provider-azure-devops { background: #0078d4; }
+.provider-badge .dot.provider-jira { background: #2684ff; }
+.provider-badge .dot.provider-linear { background: #5e6ad2; }
+.provider-badge .dot.provider-bitbucket { background: #2580f4; }
+.provider-badge .dot.provider-internal { background: var(--fg-dim); }
+.provider-badge .dot.provider-custom { background: var(--fg-faint); }
+.title-text { vertical-align: baseline; }
+
+/* Sources view */
+.sources-view .sources-list { list-style: none; margin: 8px 0 0; padding: 0; }
+.sources-view .source-row {
+  display: flex; align-items: center; gap: 10px;
+  padding: 6px 0; border-bottom: 1px solid var(--line-soft);
+}
+.sources-view .source-state {
+  font-size: 10.5px; text-transform: uppercase; letter-spacing: 0.04em;
+}
+.sources-view .source-state.state-active { color: var(--d, var(--fg)); }
+.sources-view .source-state.state-available { color: var(--fg-faint); }
+.sources-view .source-available .provider-label { color: var(--fg-faint); }
 .scaffold-section h2 {
   margin: 0 0 6px 0;
   font-size: 11px; font-weight: 600; letter-spacing: 0.06em;


### PR DESCRIPTION
Phase B (#538) slice 4 — provider provenance visible, fed by the normalized `SourceRef` (B.1/B.2).

## Changes
- **ProviderBadge** (`provider-badge.tsx`): colour-dot + label from `task.source.provider`; total `providerMeta()` over the Provider union. Rendered in every task-table title cell.
- **SourcesView** + "Sources" nav tab: lists all `PROVIDERS` with state — `github`/`internal` **active** (wired / accepted by the `source_system` CHECK), the rest **available**. `sourceState()` pure helper.
- **B.3 follow-up (#541):** `validateTaskUpdatedPayload` now guards the `source` shape (provider ∈ Provider; externalId/url/providerNativeType string|null) — a renderer now reads `task.source`.
- CSS: per-provider dot colours + Sources list.

## Verify
`tsc` clean · `build:dashboard` ok (artifacts in bundle) · provider-badge + iteration-display (incl. new source-guard cases) + task-table-filter **77** tests green · carve-out gate green.

Closes #542. Refs #538, #354.

> Bus review loop blocked by #535; self-reviewed via in-session sub-agents, merged under standing authorization once review-clear + CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)