### PR TITLE
feat(mc): G-1113.B.5 — isSourceRef validator + adapter parity fixtures

### DIFF
--- a/src/surface/mc/__tests__/source-ref-parity.test.ts
+++ b/src/surface/mc/__tests__/source-ref-parity.test.ts
@@ -1,0 +1,59 @@
+/**
+ * G-1113.B.5 — adapter parity at the SourceRef boundary.
+ *
+ * Every provider — whether it has a real adapter today (github via
+ * githubRefToSourceRef, internal via taskRowToSourceRef) or only a declared
+ * future one (gitlab / azure-devops / jira / linear / bitbucket / custom) —
+ * must produce a value that satisfies {@link isSourceRef}. This pins the
+ * contract a future adapter (B.3 pattern) has to meet before it can be wired,
+ * and guarantees every member of the Provider union has a representative
+ * example.
+ */
+import { test, expect } from "bun:test";
+import { isSourceRef, PROVIDERS, type Provider, type SourceRef } from "../types";
+import { githubRefToSourceRef } from "../adapters/github";
+import { taskRowToSourceRef } from "../db/tasks";
+
+/** One representative SourceRef per provider — real adapter output where one exists. */
+const EXAMPLES: Record<Provider, SourceRef> = {
+  // real adapter (B.3)
+  github: githubRefToSourceRef({ owner: "the-metafactory", repo: "cortex", number: 543, kind: "issue" }),
+  // real shim (B.2) on an internal task row
+  internal: taskRowToSourceRef({ source_system: "internal", source_url: null, source_external_id: null }),
+  // declared-but-unwired providers — fixtures matching what their adapter would emit
+  gitlab: { provider: "gitlab", externalId: "group/proj!42", url: "https://gitlab.example/group/proj/-/merge_requests/42", providerNativeType: "merge_request" },
+  "azure-devops": { provider: "azure-devops", externalId: "org/proj/123", url: "https://dev.azure.com/org/proj/_workitems/edit/123", providerNativeType: "work_item" },
+  jira: { provider: "jira", externalId: "PROJ-7", url: "https://jira.example/browse/PROJ-7", providerNativeType: "issue" },
+  linear: { provider: "linear", externalId: "ENG-99", url: "https://linear.app/team/issue/ENG-99", providerNativeType: "issue" },
+  bitbucket: { provider: "bitbucket", externalId: "ws/repo/5", url: "https://bitbucket.org/ws/repo/pull-requests/5", providerNativeType: "pullrequest" },
+  custom: { provider: "custom", externalId: "ref-1", url: null, providerNativeType: null },
+};
+
+test("every Provider has a parity example", () => {
+  for (const p of PROVIDERS) expect(EXAMPLES[p]).toBeDefined();
+  expect(Object.keys(EXAMPLES).sort()).toEqual([...PROVIDERS].sort());
+});
+
+test("every provider example is a valid SourceRef", () => {
+  for (const p of PROVIDERS) {
+    const ref = EXAMPLES[p];
+    expect(isSourceRef(ref)).toBe(true);
+    expect(ref.provider).toBe(p);
+  }
+});
+
+test("isSourceRef rejects malformed shapes", () => {
+  expect(isSourceRef(null)).toBe(false);
+  expect(isSourceRef({})).toBe(false);
+  expect(isSourceRef({ provider: "svn", externalId: null, url: null, providerNativeType: null })).toBe(false);
+  expect(isSourceRef({ provider: "github", externalId: 42, url: null, providerNativeType: null })).toBe(false);
+  // providerNativeType is required (string | null) — a missing field is rejected.
+  expect(isSourceRef({ provider: "github", externalId: null, url: null })).toBe(false);
+});
+
+test("real adapters (github, internal) agree with the boundary contract", () => {
+  expect(isSourceRef(EXAMPLES.github)).toBe(true);
+  expect(EXAMPLES.github.externalId).toBe("the-metafactory/cortex#543");
+  expect(EXAMPLES.internal.provider).toBe("internal");
+  expect(EXAMPLES.internal.externalId).toBeNull();
+});

--- a/src/surface/mc/dashboard-v2/lib/iteration-display.ts
+++ b/src/surface/mc/dashboard-v2/lib/iteration-display.ts
@@ -22,7 +22,7 @@
 
 import type { TaskIterationTag, TaskListItem } from "../../db/tasks";
 import { ITERATION_STATES, type IterationState } from "../../db/iterations";
-import { isProvider } from "../../types";
+import { isSourceRef } from "../../types";
 
 /** Visual truncation cap. Mirrors the F-8 column width budget. */
 export const ITERATION_TITLE_MAX_CHARS = 20;
@@ -206,12 +206,7 @@ export function validateTaskUpdatedPayload(raw: unknown): TaskListItem | null {
   // G-1113.B.4 — `source` (SourceRef) is now a required field a renderer reads
   // (the provider badge). Guard its shape so a malformed source-less broadcast
   // can't land in the cache with `source === undefined` despite the TS cast.
-  const src = t.source;
-  if (!src || typeof src !== "object") return null;
-  const s = src as Record<string, unknown>;
-  if (!isProvider(s.provider)) return null;
-  for (const f of ["externalId", "url", "providerNativeType"] as const) {
-    if (s[f] !== null && typeof s[f] !== "string") return null;
-  }
+  // B.5 — reuse the canonical SourceRef guard (single source of truth).
+  if (!isSourceRef(t.source)) return null;
   return raw as TaskListItem;
 }

--- a/src/surface/mc/types.ts
+++ b/src/surface/mc/types.ts
@@ -117,6 +117,22 @@ export interface SourceRef {
   providerNativeType: string | null;
 }
 
+/**
+ * Runtime guard for {@link SourceRef} — the parity contract every provider
+ * adapter (G-1113.B.3+) must satisfy: `provider` is a known {@link Provider}
+ * and `externalId` / `url` / `providerNativeType` are each `string | null`.
+ * Narrows untrusted input (wire frames, fixtures, future adapter output).
+ */
+export function isSourceRef(value: unknown): value is SourceRef {
+  if (!value || typeof value !== "object") return false;
+  const v = value as Record<string, unknown>;
+  if (!isProvider(v.provider)) return false;
+  for (const field of ["externalId", "url", "providerNativeType"] as const) {
+    if (v[field] !== null && typeof v[field] !== "string") return false;
+  }
+  return true;
+}
+
 export interface Task {
   id: string;
   title: string;


### PR DESCRIPTION
Final **Phase B** (#538) slice. Pins the `SourceRef` contract every provider adapter must satisfy.

## Changes
- `types.ts`: `isSourceRef(x)` runtime guard (provider ∈ Provider; externalId/url/providerNativeType each string|null) — the parity contract, reusable by wire validators + future adapters.
- `source-ref-parity.test.ts`: one example per Provider — **github** (real, `githubRefToSourceRef`), **internal** (real, `taskRowToSourceRef`), and gitlab/azure-devops/jira/linear/bitbucket/custom (fixtures). Asserts every Provider member has an example, each satisfies `isSourceRef`, + malformed-shape rejections.

Test-only + one additive validator; no behavior change. **Closes out Phase B.**

## Verify
`tsc` clean · parity + all source-ref tests **17** green · carve-out gate green.

Closes #543. Refs #538, #354.

> Bus review loop blocked by #535; self-reviewed via in-session sub-agents, merged under standing authorization once review-clear + CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)