### PR TITLE
feat(mc): G-1113.C.1 — GitRepository + GitBranch types + storage

### DIFF
--- a/src/surface/mc/__tests__/git-objects.test.ts
+++ b/src/surface/mc/__tests__/git-objects.test.ts
@@ -1,0 +1,86 @@
+/**
+ * G-1113.C.1 — GitRepository + GitBranch storage round-trip.
+ */
+import { describe, it, expect, afterEach } from "bun:test";
+import { join } from "path";
+import { tmpdir } from "os";
+import { rmSync, existsSync } from "fs";
+import { initDatabase } from "../db/init";
+import {
+  upsertRepository,
+  getRepository,
+  listRepositories,
+  upsertBranch,
+  getBranch,
+  listBranchesForRepository,
+} from "../db/git-objects";
+import type { GitRepository, GitBranch } from "../types";
+
+describe("git-objects storage (C.1)", () => {
+  const paths: string[] = [];
+  afterEach(() => {
+    for (const p of paths) if (existsSync(p)) rmSync(p);
+    paths.length = 0;
+  });
+  function freshDb() {
+    const p = join(tmpdir(), `git-objects-${Date.now()}-${Math.random().toString(36).slice(2)}.db`);
+    paths.push(p);
+    return initDatabase(p);
+  }
+
+  const repo: GitRepository = {
+    id: "repo-1",
+    provider: "github",
+    owner: "the-metafactory",
+    name: "cortex",
+    url: "https://github.com/the-metafactory/cortex",
+    defaultBranch: "main",
+  };
+  const branch: GitBranch = {
+    id: "branch-1",
+    repositoryId: "repo-1",
+    name: "feat/g-1113-c-1",
+    baseRef: "main",
+    headSha: "abc1234",
+    provider: "github",
+    externalId: "the-metafactory/cortex@feat/g-1113-c-1",
+    url: "https://github.com/the-metafactory/cortex/tree/feat/g-1113-c-1",
+  };
+
+  it("round-trips a repository (upsert → get → list)", () => {
+    const db = freshDb();
+    upsertRepository(db, repo);
+    expect(getRepository(db, "repo-1")).toEqual(repo);
+    expect(listRepositories(db)).toEqual([repo]);
+  });
+
+  it("upsertRepository is idempotent and updates in place", () => {
+    const db = freshDb();
+    upsertRepository(db, repo);
+    upsertRepository(db, { ...repo, defaultBranch: "trunk", url: null });
+    expect(getRepository(db, "repo-1")).toEqual({ ...repo, defaultBranch: "trunk", url: null });
+    expect(listRepositories(db)).toHaveLength(1);
+  });
+
+  it("round-trips a branch and lists by repository", () => {
+    const db = freshDb();
+    upsertRepository(db, repo);
+    upsertBranch(db, branch);
+    expect(getBranch(db, "branch-1")).toEqual(branch);
+    expect(listBranchesForRepository(db, "repo-1")).toEqual([branch]);
+    expect(listBranchesForRepository(db, "other-repo")).toEqual([]);
+  });
+
+  it("getRepository / getBranch return null for unknown ids", () => {
+    const db = freshDb();
+    expect(getRepository(db, "nope")).toBeNull();
+    expect(getBranch(db, "nope")).toBeNull();
+  });
+
+  it("preserves null optional fields through the mapper", () => {
+    const db = freshDb();
+    const minimal: GitRepository = { id: "r2", provider: "gitlab", owner: null, name: "x", url: null, defaultBranch: null };
+    upsertRepository(db, minimal);
+    expect(getRepository(db, "r2")).toEqual(minimal);
+  });
+});

--- a/src/surface/mc/__tests__/git-objects.test.ts
+++ b/src/surface/mc/__tests__/git-objects.test.ts
@@ -83,4 +83,9 @@ describe("git-objects storage (C.1)", () => {
     upsertRepository(db, minimal);
     expect(getRepository(db, "r2")).toEqual(minimal);
   });
+
+  it("rejects a branch whose repository_id has no repository (FK enforced)", () => {
+    const db = freshDb();
+    expect(() => upsertBranch(db, { ...branch, repositoryId: "ghost-repo" })).toThrow();
+  });
 });

--- a/src/surface/mc/__tests__/schema.test.ts
+++ b/src/surface/mc/__tests__/schema.test.ts
@@ -18,7 +18,7 @@ describe("mission-control schema", () => {
     db.close();
   });
 
-  it("creates all 5 required tables", () => {
+  it("creates all required tables", () => {
     const tables = db
       .query("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
       .all() as { name: string }[];

--- a/src/surface/mc/db/git-objects.ts
+++ b/src/surface/mc/db/git-objects.ts
@@ -8,7 +8,8 @@
  * that fills these from the GitHub adapter is C.5; commits/tags/PRs are C.2/C.3.
  */
 import type { Database } from "bun:sqlite";
-import type { GitRepository, GitBranch, Provider } from "../types";
+import type { GitRepository, GitBranch } from "../types";
+import { isProvider } from "../types";
 
 interface RepoRow {
   id: string;
@@ -33,7 +34,9 @@ interface BranchRow {
 function rowToRepository(r: RepoRow): GitRepository {
   return {
     id: r.id,
-    provider: r.provider as Provider,
+    // Read-boundary narrowing: provider has no DB CHECK, so enforce the
+    // Provider invariant here (matches db/tasks.ts) rather than blind-casting.
+    provider: isProvider(r.provider) ? r.provider : "custom",
     owner: r.owner,
     name: r.name,
     url: r.url,
@@ -48,7 +51,7 @@ function rowToBranch(r: BranchRow): GitBranch {
     name: r.name,
     baseRef: r.base_ref,
     headSha: r.head_sha,
-    provider: r.provider as Provider,
+    provider: isProvider(r.provider) ? r.provider : "custom",
     externalId: r.external_id,
     url: r.url,
   };

--- a/src/surface/mc/db/git-objects.ts
+++ b/src/surface/mc/db/git-objects.ts
@@ -1,0 +1,119 @@
+/**
+ * G-1113.C.1 — storage for the first-class Git objects (design §3.8/§6).
+ *
+ * GitRepository + GitBranch persistence: upsert (id is the stable key, so
+ * re-ingesting the same object updates in place), get-by-id, and list. Rows are
+ * snake_case columns; the mappers project to the camelCase domain types. No
+ * provider branching here — the model is provider-neutral (G-1113.B). Ingestion
+ * that fills these from the GitHub adapter is C.5; commits/tags/PRs are C.2/C.3.
+ */
+import type { Database } from "bun:sqlite";
+import type { GitRepository, GitBranch, Provider } from "../types";
+
+interface RepoRow {
+  id: string;
+  provider: string;
+  owner: string | null;
+  name: string;
+  url: string | null;
+  default_branch: string | null;
+}
+
+interface BranchRow {
+  id: string;
+  repository_id: string;
+  name: string;
+  base_ref: string | null;
+  head_sha: string | null;
+  provider: string;
+  external_id: string | null;
+  url: string | null;
+}
+
+function rowToRepository(r: RepoRow): GitRepository {
+  return {
+    id: r.id,
+    provider: r.provider as Provider,
+    owner: r.owner,
+    name: r.name,
+    url: r.url,
+    defaultBranch: r.default_branch,
+  };
+}
+
+function rowToBranch(r: BranchRow): GitBranch {
+  return {
+    id: r.id,
+    repositoryId: r.repository_id,
+    name: r.name,
+    baseRef: r.base_ref,
+    headSha: r.head_sha,
+    provider: r.provider as Provider,
+    externalId: r.external_id,
+    url: r.url,
+  };
+}
+
+/** Insert or update a repository by id (idempotent re-ingestion). */
+export function upsertRepository(db: Database, repo: GitRepository): void {
+  db.query(
+    `INSERT INTO git_repositories (id, provider, owner, name, url, default_branch)
+     VALUES (?, ?, ?, ?, ?, ?)
+     ON CONFLICT(id) DO UPDATE SET
+       provider = excluded.provider,
+       owner = excluded.owner,
+       name = excluded.name,
+       url = excluded.url,
+       default_branch = excluded.default_branch,
+       updated_at = unixepoch()`
+  ).run(repo.id, repo.provider, repo.owner, repo.name, repo.url, repo.defaultBranch);
+}
+
+export function getRepository(db: Database, id: string): GitRepository | null {
+  const row = db.query(`SELECT * FROM git_repositories WHERE id = ?`).get(id) as RepoRow | null;
+  return row ? rowToRepository(row) : null;
+}
+
+export function listRepositories(db: Database): GitRepository[] {
+  const rows = db.query(`SELECT * FROM git_repositories ORDER BY owner, name`).all() as RepoRow[];
+  return rows.map(rowToRepository);
+}
+
+/** Insert or update a branch by id (idempotent re-ingestion). */
+export function upsertBranch(db: Database, branch: GitBranch): void {
+  db.query(
+    `INSERT INTO git_branches
+       (id, repository_id, name, base_ref, head_sha, provider, external_id, url)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+     ON CONFLICT(id) DO UPDATE SET
+       repository_id = excluded.repository_id,
+       name = excluded.name,
+       base_ref = excluded.base_ref,
+       head_sha = excluded.head_sha,
+       provider = excluded.provider,
+       external_id = excluded.external_id,
+       url = excluded.url,
+       updated_at = unixepoch()`
+  ).run(
+    branch.id,
+    branch.repositoryId,
+    branch.name,
+    branch.baseRef,
+    branch.headSha,
+    branch.provider,
+    branch.externalId,
+    branch.url
+  );
+}
+
+export function getBranch(db: Database, id: string): GitBranch | null {
+  const row = db.query(`SELECT * FROM git_branches WHERE id = ?`).get(id) as BranchRow | null;
+  return row ? rowToBranch(row) : null;
+}
+
+export function listBranchesForRepository(db: Database, repositoryId: string): GitBranch[] {
+  const rows = db
+    .query(`SELECT * FROM git_branches WHERE repository_id = ? ORDER BY name`)
+    .all(repositoryId) as BranchRow[];
+  return rows.map(rowToBranch);
+}

--- a/src/surface/mc/db/schema.ts
+++ b/src/surface/mc/db/schema.ts
@@ -199,7 +199,10 @@ export const SCHEMA_SQL: string[] = [
   // --- git_branches (G-1113.C.1) ---
   `CREATE TABLE IF NOT EXISTS git_branches (
     id TEXT PRIMARY KEY,
-    repository_id TEXT NOT NULL REFERENCES git_repositories(id),
+    -- ON DELETE RESTRICT: a repository can't be dropped while branches reference
+    -- it. Ingestion (C.5) only ever upserts Git objects, never deletes them, so
+    -- this is a safety net against orphaned branches rather than a live policy.
+    repository_id TEXT NOT NULL REFERENCES git_repositories(id) ON DELETE RESTRICT,
     name TEXT NOT NULL,
     base_ref TEXT,
     head_sha TEXT,

--- a/src/surface/mc/db/schema.ts
+++ b/src/surface/mc/db/schema.ts
@@ -12,6 +12,8 @@ export const TABLE_NAMES = [
   "sessions",
   "events",
   "iterations",
+  "git_repositories",
+  "git_branches",
 ] as const;
 
 export const SCHEMA_SQL: string[] = [
@@ -178,6 +180,39 @@ export const SCHEMA_SQL: string[] = [
   // (mirrors F-8's idx_tasks_status_priority_updated).
   `CREATE INDEX IF NOT EXISTS idx_iterations_state_priority
      ON iterations(state, priority, updated_at DESC)`,
+
+  // --- git_repositories (G-1113.C.1 — design §3.8/§6) ---
+  // First-class Git objects. `provider` is intentionally NOT CHECK-constrained
+  // (unlike tasks.source_system): the full Provider union is app-validated via
+  // isProvider at the boundary, keeping the model provider-neutral/extensible.
+  `CREATE TABLE IF NOT EXISTS git_repositories (
+    id TEXT PRIMARY KEY,
+    provider TEXT NOT NULL,
+    owner TEXT,
+    name TEXT NOT NULL,
+    url TEXT,
+    default_branch TEXT,
+    created_at INTEGER NOT NULL DEFAULT (unixepoch()),
+    updated_at INTEGER NOT NULL DEFAULT (unixepoch())
+  )`,
+
+  // --- git_branches (G-1113.C.1) ---
+  `CREATE TABLE IF NOT EXISTS git_branches (
+    id TEXT PRIMARY KEY,
+    repository_id TEXT NOT NULL REFERENCES git_repositories(id),
+    name TEXT NOT NULL,
+    base_ref TEXT,
+    head_sha TEXT,
+    provider TEXT NOT NULL,
+    external_id TEXT,
+    url TEXT,
+    created_at INTEGER NOT NULL DEFAULT (unixepoch()),
+    updated_at INTEGER NOT NULL DEFAULT (unixepoch())
+  )`,
+
+  // Branch lookup by repository (per-repo panel, C.7).
+  `CREATE INDEX IF NOT EXISTS idx_git_branches_repository
+     ON git_branches(repository_id, name)`,
 ];
 
 /**

--- a/src/surface/mc/types.ts
+++ b/src/surface/mc/types.ts
@@ -133,6 +133,36 @@ export function isSourceRef(value: unknown): value is SourceRef {
   return true;
 }
 
+// --- Software-mode Git objects (G-1113.C — design §3.8 / §6) ---
+//
+// First-class Git nouns, provider-abstracted (the Git concept is concrete; the
+// provider rides as a field). C.1 lands GitRepository + GitBranch (types +
+// storage); commits/tags (C.2), PRs/reviews (C.3), checks/deployments/artifacts
+// (C.4) follow. Ingestion from the GitHub adapter is C.5; UI is C.6/C.7.
+
+export interface GitRepository {
+  id: string;
+  provider: Provider;
+  /** Owner / org / group segment, when the provider has one. */
+  owner: string | null;
+  name: string;
+  url: string | null;
+  defaultBranch: string | null;
+}
+
+export interface GitBranch {
+  id: string;
+  repositoryId: string;
+  name: string;
+  /** The ref this branch is based on (e.g. the PR's base), when known. */
+  baseRef: string | null;
+  /** Head commit SHA, when known. */
+  headSha: string | null;
+  provider: Provider;
+  externalId: string | null;
+  url: string | null;
+}
+
 export interface Task {
   id: string;
   title: string;


### PR DESCRIPTION
First slice of **Phase C** (Software Mode Domain Model, #553). First-class Git objects at the model + storage layer.

## Changes
- `types.ts`: `GitRepository` + `GitBranch` (design §6 shapes).
- `schema.ts`: `git_repositories` + `git_branches` tables. `provider` left app-validated via `isProvider` (no CHECK) to stay provider-neutral; branch→repo FK + per-repo index.
- `db/git-objects.ts`: idempotent `upsert`/`get`/`list` for repos + branches; snake_case row → camelCase domain mappers.

## Scope
No adapter ingestion (C.5), no UI (C.6/C.7); not referenced by the Plan model (Phase D).

## Verify
`tsc` clean · git-objects round-trip + db-init **10** tests green · carve-out gate green.

Closes #554. Refs #553, #354.

> In-session pilot dev loop: self-reviewed via sub-agents, merged under standing authorization once review-clear + CI green (#535 still gates the bus reviewer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)