### PR TITLE
feat(mc): G-1113.C.2 — GitCommit + GitTag types + storage

### DIFF
--- a/src/surface/mc/__tests__/git-objects.test.ts
+++ b/src/surface/mc/__tests__/git-objects.test.ts
@@ -13,8 +13,14 @@ import {
   upsertBranch,
   getBranch,
   listBranchesForRepository,
+  upsertCommit,
+  getCommit,
+  listCommitsForRepository,
+  upsertTag,
+  getTag,
+  listTagsForRepository,
 } from "../db/git-objects";
-import type { GitRepository, GitBranch } from "../types";
+import type { GitRepository, GitBranch, GitCommit, GitTag } from "../types";
 
 describe("git-objects storage (C.1)", () => {
   const paths: string[] = [];
@@ -87,5 +93,55 @@ describe("git-objects storage (C.1)", () => {
   it("rejects a branch whose repository_id has no repository (FK enforced)", () => {
     const db = freshDb();
     expect(() => upsertBranch(db, { ...branch, repositoryId: "ghost-repo" })).toThrow();
+  });
+
+  // --- C.2: commits + tags ---
+
+  const commit: GitCommit = {
+    id: "commit-1",
+    repositoryId: "repo-1",
+    sha: "abc1234def",
+    title: "feat: add the thing",
+    author: "Andreas",
+    url: "https://github.com/the-metafactory/cortex/commit/abc1234def",
+  };
+  const tag: GitTag = {
+    id: "tag-1",
+    repositoryId: "repo-1",
+    name: "v3.1.0",
+    targetSha: "abc1234def",
+    provider: "github",
+    url: "https://github.com/the-metafactory/cortex/releases/tag/v3.1.0",
+  };
+
+  it("round-trips a commit (upsert → get → list) + idempotent update", () => {
+    const db = freshDb();
+    upsertRepository(db, repo);
+    upsertCommit(db, commit);
+    expect(getCommit(db, "commit-1")).toEqual(commit);
+    expect(listCommitsForRepository(db, "repo-1")).toEqual([commit]);
+    upsertCommit(db, { ...commit, title: "feat: renamed", author: null });
+    expect(getCommit(db, "commit-1")).toEqual({ ...commit, title: "feat: renamed", author: null });
+    expect(listCommitsForRepository(db, "repo-1")).toHaveLength(1);
+  });
+
+  it("round-trips a tag and narrows an unknown provider to custom", () => {
+    const db = freshDb();
+    upsertRepository(db, repo);
+    upsertTag(db, tag);
+    expect(getTag(db, "tag-1")).toEqual(tag);
+    expect(listTagsForRepository(db, "repo-1")).toEqual([tag]);
+  });
+
+  it("commit + tag FKs are enforced (ghost repository_id throws)", () => {
+    const db = freshDb();
+    expect(() => upsertCommit(db, { ...commit, repositoryId: "ghost" })).toThrow();
+    expect(() => upsertTag(db, { ...tag, repositoryId: "ghost" })).toThrow();
+  });
+
+  it("getCommit / getTag return null for unknown ids", () => {
+    const db = freshDb();
+    expect(getCommit(db, "nope")).toBeNull();
+    expect(getTag(db, "nope")).toBeNull();
   });
 });

--- a/src/surface/mc/db/git-objects.ts
+++ b/src/surface/mc/db/git-objects.ts
@@ -8,7 +8,7 @@
  * that fills these from the GitHub adapter is C.5; commits/tags/PRs are C.2/C.3.
  */
 import type { Database } from "bun:sqlite";
-import type { GitRepository, GitBranch } from "../types";
+import type { GitRepository, GitBranch, GitCommit, GitTag } from "../types";
 import { isProvider } from "../types";
 
 interface RepoRow {
@@ -119,4 +119,102 @@ export function listBranchesForRepository(db: Database, repositoryId: string): G
     .query(`SELECT * FROM git_branches WHERE repository_id = ? ORDER BY name`)
     .all(repositoryId) as BranchRow[];
   return rows.map(rowToBranch);
+}
+
+// --- commits (G-1113.C.2) ---
+
+interface CommitRow {
+  id: string;
+  repository_id: string;
+  sha: string;
+  title: string;
+  author: string | null;
+  url: string | null;
+}
+
+function rowToCommit(r: CommitRow): GitCommit {
+  return {
+    id: r.id,
+    repositoryId: r.repository_id,
+    sha: r.sha,
+    title: r.title,
+    author: r.author,
+    url: r.url,
+  };
+}
+
+/** Insert or update a commit by id (idempotent re-ingestion). */
+export function upsertCommit(db: Database, commit: GitCommit): void {
+  db.query(
+    `INSERT INTO git_commits (id, repository_id, sha, title, author, url)
+     VALUES (?, ?, ?, ?, ?, ?)
+     ON CONFLICT(id) DO UPDATE SET
+       repository_id = excluded.repository_id,
+       sha = excluded.sha,
+       title = excluded.title,
+       author = excluded.author,
+       url = excluded.url,
+       updated_at = unixepoch()`
+  ).run(commit.id, commit.repositoryId, commit.sha, commit.title, commit.author, commit.url);
+}
+
+export function getCommit(db: Database, id: string): GitCommit | null {
+  const row = db.query(`SELECT * FROM git_commits WHERE id = ?`).get(id) as CommitRow | null;
+  return row ? rowToCommit(row) : null;
+}
+
+export function listCommitsForRepository(db: Database, repositoryId: string): GitCommit[] {
+  const rows = db
+    .query(`SELECT * FROM git_commits WHERE repository_id = ? ORDER BY sha`)
+    .all(repositoryId) as CommitRow[];
+  return rows.map(rowToCommit);
+}
+
+// --- tags (G-1113.C.2) ---
+
+interface TagRow {
+  id: string;
+  repository_id: string;
+  name: string;
+  target_sha: string | null;
+  provider: string;
+  url: string | null;
+}
+
+function rowToTag(r: TagRow): GitTag {
+  return {
+    id: r.id,
+    repositoryId: r.repository_id,
+    name: r.name,
+    targetSha: r.target_sha,
+    provider: isProvider(r.provider) ? r.provider : "custom",
+    url: r.url,
+  };
+}
+
+/** Insert or update a tag by id (idempotent re-ingestion). */
+export function upsertTag(db: Database, tag: GitTag): void {
+  db.query(
+    `INSERT INTO git_tags (id, repository_id, name, target_sha, provider, url)
+     VALUES (?, ?, ?, ?, ?, ?)
+     ON CONFLICT(id) DO UPDATE SET
+       repository_id = excluded.repository_id,
+       name = excluded.name,
+       target_sha = excluded.target_sha,
+       provider = excluded.provider,
+       url = excluded.url,
+       updated_at = unixepoch()`
+  ).run(tag.id, tag.repositoryId, tag.name, tag.targetSha, tag.provider, tag.url);
+}
+
+export function getTag(db: Database, id: string): GitTag | null {
+  const row = db.query(`SELECT * FROM git_tags WHERE id = ?`).get(id) as TagRow | null;
+  return row ? rowToTag(row) : null;
+}
+
+export function listTagsForRepository(db: Database, repositoryId: string): GitTag[] {
+  const rows = db
+    .query(`SELECT * FROM git_tags WHERE repository_id = ? ORDER BY name`)
+    .all(repositoryId) as TagRow[];
+  return rows.map(rowToTag);
 }

--- a/src/surface/mc/db/schema.ts
+++ b/src/surface/mc/db/schema.ts
@@ -14,6 +14,8 @@ export const TABLE_NAMES = [
   "iterations",
   "git_repositories",
   "git_branches",
+  "git_commits",
+  "git_tags",
 ] as const;
 
 export const SCHEMA_SQL: string[] = [
@@ -216,6 +218,40 @@ export const SCHEMA_SQL: string[] = [
   // Branch lookup by repository (per-repo panel, C.7).
   `CREATE INDEX IF NOT EXISTS idx_git_branches_repository
      ON git_branches(repository_id, name)`,
+
+  // --- git_commits (G-1113.C.2 — design §6) ---
+  // Per §6 a commit has no provider field (it's repository-scoped); the
+  // ON DELETE RESTRICT policy matches git_branches (ingestion upserts only).
+  `CREATE TABLE IF NOT EXISTS git_commits (
+    id TEXT PRIMARY KEY,
+    repository_id TEXT NOT NULL REFERENCES git_repositories(id) ON DELETE RESTRICT,
+    sha TEXT NOT NULL,
+    title TEXT NOT NULL,
+    author TEXT,
+    url TEXT,
+    created_at INTEGER NOT NULL DEFAULT (unixepoch()),
+    updated_at INTEGER NOT NULL DEFAULT (unixepoch())
+  )`,
+
+  // --- git_tags (G-1113.C.2) ---
+  // provider left app-validated via isProvider (no CHECK), matching the other
+  // Git objects.
+  `CREATE TABLE IF NOT EXISTS git_tags (
+    id TEXT PRIMARY KEY,
+    repository_id TEXT NOT NULL REFERENCES git_repositories(id) ON DELETE RESTRICT,
+    name TEXT NOT NULL,
+    target_sha TEXT,
+    provider TEXT NOT NULL,
+    url TEXT,
+    created_at INTEGER NOT NULL DEFAULT (unixepoch()),
+    updated_at INTEGER NOT NULL DEFAULT (unixepoch())
+  )`,
+
+  // Commit lookup by repository + sha; tag lookup by repository.
+  `CREATE INDEX IF NOT EXISTS idx_git_commits_repository
+     ON git_commits(repository_id, sha)`,
+  `CREATE INDEX IF NOT EXISTS idx_git_tags_repository
+     ON git_tags(repository_id, name)`,
 ];
 
 /**

--- a/src/surface/mc/types.ts
+++ b/src/surface/mc/types.ts
@@ -163,6 +163,30 @@ export interface GitBranch {
   url: string | null;
 }
 
+export interface GitCommit {
+  id: string;
+  repositoryId: string;
+  sha: string;
+  title: string;
+  author: string | null;
+  url: string | null;
+}
+
+/**
+ * A Git tag. Design §3.8 lists `tag` as a first-class noun but §6 has no
+ * dedicated interface (Release carries a `tagName`); this is the minimal
+ * provider-neutral shape, consistent with the other Git objects.
+ */
+export interface GitTag {
+  id: string;
+  repositoryId: string;
+  name: string;
+  /** SHA of the commit/object the tag points to, when known. */
+  targetSha: string | null;
+  provider: Provider;
+  url: string | null;
+}
+
 export interface Task {
   id: string;
   title: string;


### PR DESCRIPTION
Phase C (#553) slice 2, mirroring C.1.

- `types.ts`: `GitCommit` (design §6 — no provider, repo-scoped) + `GitTag` (§3.8 noun; §6 has no dedicated interface, so the minimal provider-neutral shape).
- `schema.ts`: `git_commits` + `git_tags` (FK → git_repositories ON DELETE RESTRICT; tag provider app-validated via isProvider).
- `db/git-objects.ts`: upsert/get/listForRepository for commits + tags; tag mapper narrows provider via isProvider at the read boundary.

> Note: `Release` (§6, carries tagName) is the remaining §3.8 noun without a slice title — folding it into **C.4** alongside deployment/artifact.

## Verify
`tsc` clean · 37 tests green (incl. FK rejection) · gate green.

Closes #555. Refs #553, #354.

🤖 Generated with [Claude Code](https://claude.com/claude-code)