### PR TITLE
feat(mc): G-1113.C.3 — PullRequest + Review types + storage

### DIFF
--- a/src/surface/mc/__tests__/git-objects.test.ts
+++ b/src/surface/mc/__tests__/git-objects.test.ts
@@ -19,8 +19,14 @@ import {
   upsertTag,
   getTag,
   listTagsForRepository,
+  upsertPullRequest,
+  getPullRequest,
+  listPullRequestsForRepository,
+  upsertReview,
+  getReview,
+  listReviewsForPullRequest,
 } from "../db/git-objects";
-import type { GitRepository, GitBranch, GitCommit, GitTag } from "../types";
+import type { GitRepository, GitBranch, GitCommit, GitTag, PullRequest, Review } from "../types";
 
 describe("git-objects storage (C.1)", () => {
   const paths: string[] = [];
@@ -143,5 +149,65 @@ describe("git-objects storage (C.1)", () => {
     const db = freshDb();
     expect(getCommit(db, "nope")).toBeNull();
     expect(getTag(db, "nope")).toBeNull();
+  });
+
+  // --- C.3: pull requests + reviews ---
+
+  const pr: PullRequest = {
+    id: "pr-1",
+    workItemId: null,
+    repositoryId: "repo-1",
+    provider: "github",
+    providerNativeType: "pull_request",
+    externalId: "the-metafactory/cortex#556",
+    numberOrKey: "556",
+    title: "G-1113.C.3 — PR/Review",
+    sourceBranch: "feat/g-1113-c-3-pr-review",
+    targetBranch: "main",
+    url: "https://github.com/the-metafactory/cortex/pull/556",
+    state: "open",
+    reviewState: "needs_review",
+  };
+  const review: Review = {
+    id: "review-1",
+    pullRequestId: "pr-1",
+    reviewer: "sage",
+    state: "approved",
+    provider: "github",
+    url: "https://github.com/the-metafactory/cortex/pull/556#pullrequestreview-1",
+  };
+
+  it("round-trips a pull request (upsert → get → list) + idempotent state update", () => {
+    const db = freshDb();
+    upsertRepository(db, repo);
+    upsertPullRequest(db, pr);
+    expect(getPullRequest(db, "pr-1")).toEqual(pr);
+    expect(listPullRequestsForRepository(db, "repo-1")).toEqual([pr]);
+    upsertPullRequest(db, { ...pr, state: "merged", reviewState: "approved" });
+    expect(getPullRequest(db, "pr-1")).toEqual({ ...pr, state: "merged", reviewState: "approved" });
+    expect(listPullRequestsForRepository(db, "repo-1")).toHaveLength(1);
+  });
+
+  it("rejects an out-of-vocabulary PR state / review_state (CHECK enforced)", () => {
+    const db = freshDb();
+    upsertRepository(db, repo);
+    expect(() => upsertPullRequest(db, { ...pr, state: "bogus" as PullRequest["state"] })).toThrow();
+    expect(() => upsertPullRequest(db, { ...pr, reviewState: "bogus" as PullRequest["reviewState"] })).toThrow();
+  });
+
+  it("round-trips a review and lists by pull request", () => {
+    const db = freshDb();
+    upsertRepository(db, repo);
+    upsertPullRequest(db, pr);
+    upsertReview(db, review);
+    expect(getReview(db, "review-1")).toEqual(review);
+    expect(listReviewsForPullRequest(db, "pr-1")).toEqual([review]);
+  });
+
+  it("PR + review FKs enforced (ghost repo / ghost PR throw)", () => {
+    const db = freshDb();
+    upsertRepository(db, repo);
+    expect(() => upsertPullRequest(db, { ...pr, repositoryId: "ghost" })).toThrow();
+    expect(() => upsertReview(db, { ...review, pullRequestId: "ghost-pr" })).toThrow();
   });
 });

--- a/src/surface/mc/__tests__/git-objects.test.ts
+++ b/src/surface/mc/__tests__/git-objects.test.ts
@@ -202,6 +202,10 @@ describe("git-objects storage (C.1)", () => {
     upsertReview(db, review);
     expect(getReview(db, "review-1")).toEqual(review);
     expect(listReviewsForPullRequest(db, "pr-1")).toEqual([review]);
+    // idempotent update: re-upsert with a different state + null reviewer
+    upsertReview(db, { ...review, state: "changes_requested", reviewer: null });
+    expect(getReview(db, "review-1")).toEqual({ ...review, state: "changes_requested", reviewer: null });
+    expect(listReviewsForPullRequest(db, "pr-1")).toHaveLength(1);
   });
 
   it("PR + review FKs enforced (ghost repo / ghost PR throw)", () => {

--- a/src/surface/mc/db/git-objects.ts
+++ b/src/surface/mc/db/git-objects.ts
@@ -8,7 +8,17 @@
  * that fills these from the GitHub adapter is C.5; commits/tags/PRs are C.2/C.3.
  */
 import type { Database } from "bun:sqlite";
-import type { GitRepository, GitBranch, GitCommit, GitTag } from "../types";
+import type {
+  GitRepository,
+  GitBranch,
+  GitCommit,
+  GitTag,
+  PullRequest,
+  PullRequestState,
+  PullRequestReviewState,
+  Review,
+  ReviewState,
+} from "../types";
 import { isProvider } from "../types";
 
 interface RepoRow {
@@ -217,4 +227,140 @@ export function listTagsForRepository(db: Database, repositoryId: string): GitTa
     .query(`SELECT * FROM git_tags WHERE repository_id = ? ORDER BY name`)
     .all(repositoryId) as TagRow[];
   return rows.map(rowToTag);
+}
+
+// --- pull requests + reviews (G-1113.C.3) ---
+
+interface PullRequestRow {
+  id: string;
+  work_item_id: string | null;
+  repository_id: string;
+  provider: string;
+  provider_native_type: string;
+  external_id: string;
+  number_or_key: string;
+  title: string;
+  source_branch: string;
+  target_branch: string;
+  url: string;
+  state: string;
+  review_state: string;
+}
+
+function rowToPullRequest(r: PullRequestRow): PullRequest {
+  return {
+    id: r.id,
+    workItemId: r.work_item_id,
+    repositoryId: r.repository_id,
+    provider: isProvider(r.provider) ? r.provider : "custom",
+    providerNativeType: r.provider_native_type,
+    externalId: r.external_id,
+    numberOrKey: r.number_or_key,
+    title: r.title,
+    sourceBranch: r.source_branch,
+    targetBranch: r.target_branch,
+    url: r.url,
+    // state / review_state are CHECK-constrained in the schema, so the cast is
+    // backed by the DB (unlike provider, which has no CHECK).
+    state: r.state as PullRequestState,
+    reviewState: r.review_state as PullRequestReviewState,
+  };
+}
+
+/** Insert or update a pull request by id (idempotent re-ingestion). */
+export function upsertPullRequest(db: Database, pr: PullRequest): void {
+  db.query(
+    `INSERT INTO pull_requests
+       (id, work_item_id, repository_id, provider, provider_native_type,
+        external_id, number_or_key, title, source_branch, target_branch, url,
+        state, review_state)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+     ON CONFLICT(id) DO UPDATE SET
+       work_item_id = excluded.work_item_id,
+       repository_id = excluded.repository_id,
+       provider = excluded.provider,
+       provider_native_type = excluded.provider_native_type,
+       external_id = excluded.external_id,
+       number_or_key = excluded.number_or_key,
+       title = excluded.title,
+       source_branch = excluded.source_branch,
+       target_branch = excluded.target_branch,
+       url = excluded.url,
+       state = excluded.state,
+       review_state = excluded.review_state,
+       updated_at = unixepoch()`
+  ).run(
+    pr.id,
+    pr.workItemId,
+    pr.repositoryId,
+    pr.provider,
+    pr.providerNativeType,
+    pr.externalId,
+    pr.numberOrKey,
+    pr.title,
+    pr.sourceBranch,
+    pr.targetBranch,
+    pr.url,
+    pr.state,
+    pr.reviewState
+  );
+}
+
+export function getPullRequest(db: Database, id: string): PullRequest | null {
+  const row = db.query(`SELECT * FROM pull_requests WHERE id = ?`).get(id) as PullRequestRow | null;
+  return row ? rowToPullRequest(row) : null;
+}
+
+export function listPullRequestsForRepository(db: Database, repositoryId: string): PullRequest[] {
+  const rows = db
+    .query(`SELECT * FROM pull_requests WHERE repository_id = ? ORDER BY number_or_key`)
+    .all(repositoryId) as PullRequestRow[];
+  return rows.map(rowToPullRequest);
+}
+
+interface ReviewRow {
+  id: string;
+  pull_request_id: string;
+  reviewer: string | null;
+  state: string;
+  provider: string;
+  url: string | null;
+}
+
+function rowToReview(r: ReviewRow): Review {
+  return {
+    id: r.id,
+    pullRequestId: r.pull_request_id,
+    reviewer: r.reviewer,
+    state: r.state as ReviewState, // CHECK-constrained in the schema
+    provider: isProvider(r.provider) ? r.provider : "custom",
+    url: r.url,
+  };
+}
+
+/** Insert or update a review by id (idempotent re-ingestion). */
+export function upsertReview(db: Database, review: Review): void {
+  db.query(
+    `INSERT INTO reviews (id, pull_request_id, reviewer, state, provider, url)
+     VALUES (?, ?, ?, ?, ?, ?)
+     ON CONFLICT(id) DO UPDATE SET
+       pull_request_id = excluded.pull_request_id,
+       reviewer = excluded.reviewer,
+       state = excluded.state,
+       provider = excluded.provider,
+       url = excluded.url,
+       updated_at = unixepoch()`
+  ).run(review.id, review.pullRequestId, review.reviewer, review.state, review.provider, review.url);
+}
+
+export function getReview(db: Database, id: string): Review | null {
+  const row = db.query(`SELECT * FROM reviews WHERE id = ?`).get(id) as ReviewRow | null;
+  return row ? rowToReview(row) : null;
+}
+
+export function listReviewsForPullRequest(db: Database, pullRequestId: string): Review[] {
+  const rows = db
+    .query(`SELECT * FROM reviews WHERE pull_request_id = ? ORDER BY id`)
+    .all(pullRequestId) as ReviewRow[];
+  return rows.map(rowToReview);
 }

--- a/src/surface/mc/db/schema.ts
+++ b/src/surface/mc/db/schema.ts
@@ -16,6 +16,8 @@ export const TABLE_NAMES = [
   "git_branches",
   "git_commits",
   "git_tags",
+  "pull_requests",
+  "reviews",
 ] as const;
 
 export const SCHEMA_SQL: string[] = [
@@ -252,6 +254,51 @@ export const SCHEMA_SQL: string[] = [
      ON git_commits(repository_id, sha)`,
   `CREATE INDEX IF NOT EXISTS idx_git_tags_repository
      ON git_tags(repository_id, name)`,
+
+  // --- pull_requests (G-1113.C.3 — design §6) ---
+  // work_item_id is intentionally NOT a FK (the task/work-item linkage is wired
+  // in Phase D); state/review_state CHECK-constrained (closed enums, like
+  // tasks.status); provider app-validated via isProvider (no CHECK).
+  `CREATE TABLE IF NOT EXISTS pull_requests (
+    id TEXT PRIMARY KEY,
+    work_item_id TEXT,
+    repository_id TEXT NOT NULL REFERENCES git_repositories(id) ON DELETE RESTRICT,
+    provider TEXT NOT NULL,
+    provider_native_type TEXT NOT NULL,
+    external_id TEXT NOT NULL,
+    number_or_key TEXT NOT NULL,
+    title TEXT NOT NULL,
+    source_branch TEXT NOT NULL,
+    target_branch TEXT NOT NULL,
+    url TEXT NOT NULL,
+    state TEXT NOT NULL DEFAULT 'open'
+      CHECK(state IN ('draft','open','merged','closed')),
+    review_state TEXT NOT NULL DEFAULT 'none'
+      CHECK(review_state IN ('none','needs_review','changes_requested','approved')),
+    created_at INTEGER NOT NULL DEFAULT (unixepoch()),
+    updated_at INTEGER NOT NULL DEFAULT (unixepoch())
+  )`,
+
+  // --- reviews (G-1113.C.3) ---
+  `CREATE TABLE IF NOT EXISTS reviews (
+    id TEXT PRIMARY KEY,
+    pull_request_id TEXT NOT NULL REFERENCES pull_requests(id) ON DELETE RESTRICT,
+    reviewer TEXT,
+    state TEXT NOT NULL
+      CHECK(state IN ('approved','changes_requested','commented','pending','dismissed')),
+    provider TEXT NOT NULL,
+    url TEXT,
+    created_at INTEGER NOT NULL DEFAULT (unixepoch()),
+    updated_at INTEGER NOT NULL DEFAULT (unixepoch())
+  )`,
+
+  // PR lookup by repository + work item; reviews by PR.
+  `CREATE INDEX IF NOT EXISTS idx_pull_requests_repository
+     ON pull_requests(repository_id)`,
+  `CREATE INDEX IF NOT EXISTS idx_pull_requests_work_item
+     ON pull_requests(work_item_id)`,
+  `CREATE INDEX IF NOT EXISTS idx_reviews_pull_request
+     ON reviews(pull_request_id)`,
 ];
 
 /**

--- a/src/surface/mc/types.ts
+++ b/src/surface/mc/types.ts
@@ -206,7 +206,8 @@ export interface PullRequest {
   workItemId: string | null;
   repositoryId: string;
   provider: Provider;
-  providerNativeType: "pull_request" | "merge_request" | string;
+  /** Provider-native label, e.g. `"pull_request"` (GitHub) or `"merge_request"` (GitLab). */
+  providerNativeType: string;
   externalId: string;
   numberOrKey: string;
   title: string;

--- a/src/surface/mc/types.ts
+++ b/src/surface/mc/types.ts
@@ -187,6 +187,58 @@ export interface GitTag {
   url: string | null;
 }
 
+export type PullRequestState = "draft" | "open" | "merged" | "closed";
+export type PullRequestReviewState =
+  | "none"
+  | "needs_review"
+  | "changes_requested"
+  | "approved";
+
+/**
+ * A pull request (design §6). The normalized concept; provider-native types
+ * (GitHub pull request, GitLab merge request) ride as `providerNativeType`.
+ * `workItemId` links to the owning work item/task (populated by Phase D — null
+ * for now). `reviewState` is the aggregate; individual {@link Review}s are
+ * stored separately.
+ */
+export interface PullRequest {
+  id: string;
+  workItemId: string | null;
+  repositoryId: string;
+  provider: Provider;
+  providerNativeType: "pull_request" | "merge_request" | string;
+  externalId: string;
+  numberOrKey: string;
+  title: string;
+  sourceBranch: string;
+  targetBranch: string;
+  url: string;
+  state: PullRequestState;
+  reviewState: PullRequestReviewState;
+}
+
+export type ReviewState =
+  | "approved"
+  | "changes_requested"
+  | "commented"
+  | "pending"
+  | "dismissed";
+
+/**
+ * An individual review on a {@link PullRequest}. §6 has no dedicated interface
+ * (it carries an aggregate `reviewState` on the PR); this is the minimal shape
+ * for the per-review rows the GitHub adapter (C.5) will populate.
+ */
+export interface Review {
+  id: string;
+  pullRequestId: string;
+  /** Reviewer login / display name, when known. */
+  reviewer: string | null;
+  state: ReviewState;
+  provider: Provider;
+  url: string | null;
+}
+
 export interface Task {
   id: string;
   title: string;


### PR DESCRIPTION
Phase C (#553) slice 3.

- `types.ts`: `PullRequest` (design §6 — 13 fields; `state` draft/open/merged/closed + aggregate `reviewState`; `providerNativeType` preserves pull_request/merge_request) + `Review` (§6 has none — minimal per-review shape + `ReviewState`).
- `schema.ts`: `pull_requests` + `reviews`. `state`/`review_state` CHECK-constrained; provider app-validated (no CHECK); `work_item_id` NOT a FK (task linkage is Phase D); FKs ON DELETE RESTRICT.
- `db/git-objects.ts`: upsert/get/list for PRs + reviews; mappers narrow provider via isProvider, cast CHECK-backed state enums.

## Verify
`tsc` clean · 41 tests green (incl. CHECK + FK rejections) · gate green.

Closes #556. Refs #553, #354.

🤖 Generated with [Claude Code](https://claude.com/claude-code)