### PR TITLE
feat(mc): G-1113.C.4 — Check/Build + Deployment + Artifact + Release + storage

### DIFF
--- a/src/surface/mc/__tests__/git-objects.test.ts
+++ b/src/surface/mc/__tests__/git-objects.test.ts
@@ -25,8 +25,31 @@ import {
   upsertReview,
   getReview,
   listReviewsForPullRequest,
+  upsertCheck,
+  getCheck,
+  listChecksForRepository,
+  upsertDeployment,
+  getDeployment,
+  listDeploymentsForRepository,
+  upsertArtifact,
+  getArtifact,
+  listArtifactsForRepository,
+  upsertRelease,
+  getRelease,
+  listReleasesForRepository,
 } from "../db/git-objects";
-import type { GitRepository, GitBranch, GitCommit, GitTag, PullRequest, Review } from "../types";
+import type {
+  GitRepository,
+  GitBranch,
+  GitCommit,
+  GitTag,
+  PullRequest,
+  Review,
+  Check,
+  Deployment,
+  Artifact,
+  Release,
+} from "../types";
 
 describe("git-objects storage (C.1)", () => {
   const paths: string[] = [];
@@ -213,5 +236,83 @@ describe("git-objects storage (C.1)", () => {
     upsertRepository(db, repo);
     expect(() => upsertPullRequest(db, { ...pr, repositoryId: "ghost" })).toThrow();
     expect(() => upsertReview(db, { ...review, pullRequestId: "ghost-pr" })).toThrow();
+  });
+
+  // --- C.4: checks / deployments / artifacts / releases ---
+
+  const check: Check = {
+    id: "check-1",
+    repositoryId: "repo-1",
+    commitSha: "abc1234def",
+    name: "Typecheck",
+    kind: "check",
+    state: "success",
+    provider: "github",
+    url: "https://github.com/the-metafactory/cortex/runs/1",
+  };
+  const deployment: Deployment = {
+    id: "deploy-1",
+    repositoryId: "repo-1",
+    environment: "production",
+    state: "success",
+    provider: "github",
+    url: "https://github.com/the-metafactory/cortex/deployments/1",
+  };
+  const artifact: Artifact = {
+    id: "artifact-1",
+    repositoryId: "repo-1",
+    name: "dashboard-bundle.js",
+    provider: "github",
+    url: null,
+  };
+  const release: Release = {
+    id: "release-1",
+    repositoryId: "repo-1",
+    provider: "github",
+    externalId: "rel-99",
+    name: "Cortex v3.1.0",
+    tagName: "v3.1.0",
+    url: "https://github.com/the-metafactory/cortex/releases/tag/v3.1.0",
+    state: "published",
+  };
+
+  it("round-trips check / deployment / artifact / release + idempotent update", () => {
+    const db = freshDb();
+    upsertRepository(db, repo);
+    upsertCheck(db, check);
+    upsertDeployment(db, deployment);
+    upsertArtifact(db, artifact);
+    upsertRelease(db, release);
+    expect(getCheck(db, "check-1")).toEqual(check);
+    expect(getDeployment(db, "deploy-1")).toEqual(deployment);
+    expect(getArtifact(db, "artifact-1")).toEqual(artifact);
+    expect(getRelease(db, "release-1")).toEqual(release);
+    expect(listChecksForRepository(db, "repo-1")).toEqual([check]);
+    expect(listDeploymentsForRepository(db, "repo-1")).toEqual([deployment]);
+    expect(listArtifactsForRepository(db, "repo-1")).toEqual([artifact]);
+    expect(listReleasesForRepository(db, "repo-1")).toEqual([release]);
+    upsertCheck(db, { ...check, state: "failure", kind: "build" });
+    expect(getCheck(db, "check-1")).toEqual({ ...check, state: "failure", kind: "build" });
+    expect(listChecksForRepository(db, "repo-1")).toHaveLength(1);
+  });
+
+  it("CHECK constraints reject out-of-vocabulary enums", () => {
+    const db = freshDb();
+    upsertRepository(db, repo);
+    expect(() => upsertCheck(db, { ...check, kind: "bogus" as Check["kind"] })).toThrow();
+    expect(() => upsertCheck(db, { ...check, state: "bogus" as Check["state"] })).toThrow();
+    expect(() => upsertDeployment(db, { ...deployment, state: "bogus" as Deployment["state"] })).toThrow();
+    expect(() => upsertRelease(db, { ...release, state: "bogus" as Release["state"] })).toThrow();
+  });
+
+  it("check/deployment/artifact FKs enforced; release accepts null repositoryId", () => {
+    const db = freshDb();
+    upsertRepository(db, repo);
+    expect(() => upsertCheck(db, { ...check, repositoryId: "ghost" })).toThrow();
+    expect(() => upsertDeployment(db, { ...deployment, repositoryId: "ghost" })).toThrow();
+    expect(() => upsertArtifact(db, { ...artifact, repositoryId: "ghost" })).toThrow();
+    // Release.repositoryId is nullable per §6 — null skips the FK check.
+    upsertRelease(db, { ...release, id: "release-2", repositoryId: null });
+    expect(getRelease(db, "release-2")).toEqual({ ...release, id: "release-2", repositoryId: null });
   });
 });

--- a/src/surface/mc/db/git-objects.ts
+++ b/src/surface/mc/db/git-objects.ts
@@ -18,6 +18,14 @@ import type {
   PullRequestReviewState,
   Review,
   ReviewState,
+  Check,
+  CheckKind,
+  CheckState,
+  Deployment,
+  DeploymentState,
+  Artifact,
+  Release,
+  ReleaseState,
 } from "../types";
 import { isProvider } from "../types";
 
@@ -363,4 +371,218 @@ export function listReviewsForPullRequest(db: Database, pullRequestId: string): 
     .query(`SELECT * FROM reviews WHERE pull_request_id = ? ORDER BY id`)
     .all(pullRequestId) as ReviewRow[];
   return rows.map(rowToReview);
+}
+
+// --- checks/builds (G-1113.C.4) ---
+
+interface CheckRow {
+  id: string;
+  repository_id: string;
+  commit_sha: string | null;
+  name: string;
+  kind: string;
+  state: string;
+  provider: string;
+  url: string | null;
+}
+
+function rowToCheck(r: CheckRow): Check {
+  return {
+    id: r.id,
+    repositoryId: r.repository_id,
+    commitSha: r.commit_sha,
+    name: r.name,
+    kind: r.kind as CheckKind, // CHECK-constrained
+    state: r.state as CheckState, // CHECK-constrained
+    provider: isProvider(r.provider) ? r.provider : "custom",
+    url: r.url,
+  };
+}
+
+/** Insert or update a check/build by id (idempotent re-ingestion). */
+export function upsertCheck(db: Database, check: Check): void {
+  db.query(
+    `INSERT INTO checks (id, repository_id, commit_sha, name, kind, state, provider, url)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+     ON CONFLICT(id) DO UPDATE SET
+       repository_id = excluded.repository_id,
+       commit_sha = excluded.commit_sha,
+       name = excluded.name,
+       kind = excluded.kind,
+       state = excluded.state,
+       provider = excluded.provider,
+       url = excluded.url,
+       updated_at = unixepoch()`
+  ).run(check.id, check.repositoryId, check.commitSha, check.name, check.kind, check.state, check.provider, check.url);
+}
+
+export function getCheck(db: Database, id: string): Check | null {
+  const row = db.query(`SELECT * FROM checks WHERE id = ?`).get(id) as CheckRow | null;
+  return row ? rowToCheck(row) : null;
+}
+
+export function listChecksForRepository(db: Database, repositoryId: string): Check[] {
+  const rows = db
+    .query(`SELECT * FROM checks WHERE repository_id = ? ORDER BY name`)
+    .all(repositoryId) as CheckRow[];
+  return rows.map(rowToCheck);
+}
+
+// --- deployments (G-1113.C.4) ---
+
+interface DeploymentRow {
+  id: string;
+  repository_id: string;
+  environment: string;
+  state: string;
+  provider: string;
+  url: string | null;
+}
+
+function rowToDeployment(r: DeploymentRow): Deployment {
+  return {
+    id: r.id,
+    repositoryId: r.repository_id,
+    environment: r.environment,
+    state: r.state as DeploymentState, // CHECK-constrained
+    provider: isProvider(r.provider) ? r.provider : "custom",
+    url: r.url,
+  };
+}
+
+/** Insert or update a deployment by id (idempotent re-ingestion). */
+export function upsertDeployment(db: Database, dep: Deployment): void {
+  db.query(
+    `INSERT INTO deployments (id, repository_id, environment, state, provider, url)
+     VALUES (?, ?, ?, ?, ?, ?)
+     ON CONFLICT(id) DO UPDATE SET
+       repository_id = excluded.repository_id,
+       environment = excluded.environment,
+       state = excluded.state,
+       provider = excluded.provider,
+       url = excluded.url,
+       updated_at = unixepoch()`
+  ).run(dep.id, dep.repositoryId, dep.environment, dep.state, dep.provider, dep.url);
+}
+
+export function getDeployment(db: Database, id: string): Deployment | null {
+  const row = db.query(`SELECT * FROM deployments WHERE id = ?`).get(id) as DeploymentRow | null;
+  return row ? rowToDeployment(row) : null;
+}
+
+export function listDeploymentsForRepository(db: Database, repositoryId: string): Deployment[] {
+  const rows = db
+    .query(`SELECT * FROM deployments WHERE repository_id = ? ORDER BY environment`)
+    .all(repositoryId) as DeploymentRow[];
+  return rows.map(rowToDeployment);
+}
+
+// --- artifacts (G-1113.C.4) ---
+
+interface ArtifactRow {
+  id: string;
+  repository_id: string;
+  name: string;
+  provider: string;
+  url: string | null;
+}
+
+function rowToArtifact(r: ArtifactRow): Artifact {
+  return {
+    id: r.id,
+    repositoryId: r.repository_id,
+    name: r.name,
+    provider: isProvider(r.provider) ? r.provider : "custom",
+    url: r.url,
+  };
+}
+
+/** Insert or update an artifact by id (idempotent re-ingestion). */
+export function upsertArtifact(db: Database, artifact: Artifact): void {
+  db.query(
+    `INSERT INTO artifacts (id, repository_id, name, provider, url)
+     VALUES (?, ?, ?, ?, ?)
+     ON CONFLICT(id) DO UPDATE SET
+       repository_id = excluded.repository_id,
+       name = excluded.name,
+       provider = excluded.provider,
+       url = excluded.url,
+       updated_at = unixepoch()`
+  ).run(artifact.id, artifact.repositoryId, artifact.name, artifact.provider, artifact.url);
+}
+
+export function getArtifact(db: Database, id: string): Artifact | null {
+  const row = db.query(`SELECT * FROM artifacts WHERE id = ?`).get(id) as ArtifactRow | null;
+  return row ? rowToArtifact(row) : null;
+}
+
+export function listArtifactsForRepository(db: Database, repositoryId: string): Artifact[] {
+  const rows = db
+    .query(`SELECT * FROM artifacts WHERE repository_id = ? ORDER BY name`)
+    .all(repositoryId) as ArtifactRow[];
+  return rows.map(rowToArtifact);
+}
+
+// --- releases (G-1113.C.4 — design §6) ---
+
+interface ReleaseRow {
+  id: string;
+  repository_id: string | null;
+  provider: string;
+  external_id: string | null;
+  name: string;
+  tag_name: string | null;
+  url: string | null;
+  state: string;
+}
+
+function rowToRelease(r: ReleaseRow): Release {
+  return {
+    id: r.id,
+    repositoryId: r.repository_id,
+    provider: isProvider(r.provider) ? r.provider : "custom",
+    externalId: r.external_id,
+    name: r.name,
+    tagName: r.tag_name,
+    url: r.url,
+    state: r.state as ReleaseState, // CHECK-constrained
+  };
+}
+
+/** Insert or update a release by id (idempotent re-ingestion). */
+export function upsertRelease(db: Database, release: Release): void {
+  db.query(
+    `INSERT INTO releases (id, repository_id, provider, external_id, name, tag_name, url, state)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+     ON CONFLICT(id) DO UPDATE SET
+       repository_id = excluded.repository_id,
+       provider = excluded.provider,
+       external_id = excluded.external_id,
+       name = excluded.name,
+       tag_name = excluded.tag_name,
+       url = excluded.url,
+       state = excluded.state,
+       updated_at = unixepoch()`
+  ).run(
+    release.id,
+    release.repositoryId,
+    release.provider,
+    release.externalId,
+    release.name,
+    release.tagName,
+    release.url,
+    release.state
+  );
+}
+
+export function getRelease(db: Database, id: string): Release | null {
+  const row = db.query(`SELECT * FROM releases WHERE id = ?`).get(id) as ReleaseRow | null;
+  return row ? rowToRelease(row) : null;
+}
+
+export function listReleasesForRepository(db: Database, repositoryId: string): Release[] {
+  const rows = db
+    .query(`SELECT * FROM releases WHERE repository_id = ? ORDER BY name`)
+    .all(repositoryId) as ReleaseRow[];
+  return rows.map(rowToRelease);
 }

--- a/src/surface/mc/db/schema.ts
+++ b/src/surface/mc/db/schema.ts
@@ -18,6 +18,10 @@ export const TABLE_NAMES = [
   "git_tags",
   "pull_requests",
   "reviews",
+  "checks",
+  "deployments",
+  "artifacts",
+  "releases",
 ] as const;
 
 export const SCHEMA_SQL: string[] = [
@@ -299,6 +303,70 @@ export const SCHEMA_SQL: string[] = [
      ON pull_requests(work_item_id)`,
   `CREATE INDEX IF NOT EXISTS idx_reviews_pull_request
      ON reviews(pull_request_id)`,
+
+  // --- checks / builds (G-1113.C.4 — §3.8 "check / status check" + "build") ---
+  // One entity, `kind` distinguishes; state CHECK-constrained; provider
+  // app-validated via isProvider (no CHECK); FK → repo ON DELETE RESTRICT.
+  `CREATE TABLE IF NOT EXISTS checks (
+    id TEXT PRIMARY KEY,
+    repository_id TEXT NOT NULL REFERENCES git_repositories(id) ON DELETE RESTRICT,
+    commit_sha TEXT,
+    name TEXT NOT NULL,
+    kind TEXT NOT NULL DEFAULT 'check' CHECK(kind IN ('check','build')),
+    state TEXT NOT NULL DEFAULT 'pending'
+      CHECK(state IN ('pending','success','failure','error','neutral','cancelled')),
+    provider TEXT NOT NULL,
+    url TEXT,
+    created_at INTEGER NOT NULL DEFAULT (unixepoch()),
+    updated_at INTEGER NOT NULL DEFAULT (unixepoch())
+  )`,
+
+  // --- deployments (G-1113.C.4) ---
+  `CREATE TABLE IF NOT EXISTS deployments (
+    id TEXT PRIMARY KEY,
+    repository_id TEXT NOT NULL REFERENCES git_repositories(id) ON DELETE RESTRICT,
+    environment TEXT NOT NULL,
+    state TEXT NOT NULL DEFAULT 'pending'
+      CHECK(state IN ('pending','in_progress','success','failure','inactive')),
+    provider TEXT NOT NULL,
+    url TEXT,
+    created_at INTEGER NOT NULL DEFAULT (unixepoch()),
+    updated_at INTEGER NOT NULL DEFAULT (unixepoch())
+  )`,
+
+  // --- artifacts (G-1113.C.4) ---
+  `CREATE TABLE IF NOT EXISTS artifacts (
+    id TEXT PRIMARY KEY,
+    repository_id TEXT NOT NULL REFERENCES git_repositories(id) ON DELETE RESTRICT,
+    name TEXT NOT NULL,
+    provider TEXT NOT NULL,
+    url TEXT,
+    created_at INTEGER NOT NULL DEFAULT (unixepoch()),
+    updated_at INTEGER NOT NULL DEFAULT (unixepoch())
+  )`,
+
+  // --- releases (G-1113.C.4 — design §6) ---
+  // repository_id is NULLABLE per §6 (FK still holds when present; NULL skips
+  // the check). state CHECK-constrained.
+  `CREATE TABLE IF NOT EXISTS releases (
+    id TEXT PRIMARY KEY,
+    repository_id TEXT REFERENCES git_repositories(id) ON DELETE RESTRICT,
+    provider TEXT NOT NULL,
+    external_id TEXT,
+    name TEXT NOT NULL,
+    tag_name TEXT,
+    url TEXT,
+    state TEXT NOT NULL DEFAULT 'draft'
+      CHECK(state IN ('draft','published','failed','archived')),
+    created_at INTEGER NOT NULL DEFAULT (unixepoch()),
+    updated_at INTEGER NOT NULL DEFAULT (unixepoch())
+  )`,
+
+  // lookups by repository
+  `CREATE INDEX IF NOT EXISTS idx_checks_repository ON checks(repository_id, commit_sha)`,
+  `CREATE INDEX IF NOT EXISTS idx_deployments_repository ON deployments(repository_id)`,
+  `CREATE INDEX IF NOT EXISTS idx_artifacts_repository ON artifacts(repository_id)`,
+  `CREATE INDEX IF NOT EXISTS idx_releases_repository ON releases(repository_id)`,
 ];
 
 /**

--- a/src/surface/mc/types.ts
+++ b/src/surface/mc/types.ts
@@ -240,6 +240,76 @@ export interface Review {
   url: string | null;
 }
 
+export type CheckKind = "check" | "build";
+export type CheckState =
+  | "pending"
+  | "success"
+  | "failure"
+  | "error"
+  | "neutral"
+  | "cancelled";
+
+/**
+ * A status check or build (design §3.8 lists "check / status check" and "build"
+ * — modelled as one entity with a `kind`, since they share a lifecycle). §6 has
+ * no dedicated interface; this is the minimal provider-neutral shape.
+ */
+export interface Check {
+  id: string;
+  repositoryId: string;
+  /** Commit SHA the check ran against, when known. */
+  commitSha: string | null;
+  name: string;
+  kind: CheckKind;
+  state: CheckState;
+  provider: Provider;
+  url: string | null;
+}
+
+export type DeploymentState =
+  | "pending"
+  | "in_progress"
+  | "success"
+  | "failure"
+  | "inactive";
+
+/** A deployment of a build/release to an environment (design §3.8 noun). */
+export interface Deployment {
+  id: string;
+  repositoryId: string;
+  environment: string;
+  state: DeploymentState;
+  provider: Provider;
+  url: string | null;
+}
+
+/** A build output / release asset (design §3.8 noun). */
+export interface Artifact {
+  id: string;
+  repositoryId: string;
+  name: string;
+  provider: Provider;
+  url: string | null;
+}
+
+export type ReleaseState = "draft" | "published" | "failed" | "archived";
+
+/**
+ * A published cut of a repository (design §6). `repositoryId` is nullable per
+ * §6 (a release can predate repo linkage); `tagName` links to the {@link GitTag}
+ * by name when present.
+ */
+export interface Release {
+  id: string;
+  repositoryId: string | null;
+  provider: Provider;
+  externalId: string | null;
+  name: string;
+  tagName: string | null;
+  url: string | null;
+  state: ReleaseState;
+}
+
 export interface Task {
   id: string;
   title: string;


### PR DESCRIPTION
Phase C (#553) slice 4 — **completes the design §3.8 Git nouns** at the model layer.

- `types.ts`: `Check` (one entity, `kind` check|build) + `Deployment` + `Artifact` + `Release` (design §6; nullable repositoryId). Check/Deployment/Artifact aren't in §6 — minimal provider-neutral shapes.
- `schema.ts`: `checks` + `deployments` + `artifacts` + `releases`. state/kind CHECK-constrained; provider app-validated via isProvider; FK → repo ON DELETE RESTRICT (releases FK nullable per §6).
- `db/git-objects.ts`: upsert/get/listForRepository for all four; mappers narrow provider, cast CHECK-backed enums.

## Verify
`tsc` + `lint` clean · 44 tests green (round-trip, idempotent, CHECK + FK rejections, nullable-release-FK) · gate green.

Closes #557. Refs #553, #354.

🤖 Generated with [Claude Code](https://claude.com/claude-code)