### PR TITLE
feat(gateway): GW.a.3b.1 — flag-gated bootstrap factory (#524)

### DIFF
--- a/src/gateway/__tests__/gateway-bootstrap.test.ts
+++ b/src/gateway/__tests__/gateway-bootstrap.test.ts
@@ -1,0 +1,401 @@
+/**
+ * GW.a.3b.1 — gateway-bootstrap tests (cortex#524, TDD Red→Green).
+ *
+ * Tests cover:
+ *
+ *   1.  isGatewayEnabled — CORTEX_GATEWAY unset → false
+ *   2.  isGatewayEnabled — CORTEX_GATEWAY="1" → true
+ *   3.  isGatewayEnabled — CORTEX_GATEWAY="0" → false
+ *   4.  isGatewayEnabled — CORTEX_GATEWAY="true" → false (only "1" is truthy)
+ *   5.  maybeCreateSurfaceGateway — enabled=false → undefined (flag off)
+ *   6.  maybeCreateSurfaceGateway — enabled=true, surfaces=undefined → undefined + logged
+ *   7.  maybeCreateSurfaceGateway — enabled=true, surfaces={} (no bindings) → undefined + logged
+ *   8.  maybeCreateSurfaceGateway — enabled=true, valid discord surfaces → SurfaceGateway instance
+ *   9.  maybeCreateSurfaceGateway — valid discord surfaces, injected adapters forwarded to instance
+ *  10.  maybeCreateSurfaceGateway — onUnroutable forwarded to SurfaceGateway options
+ *  11.  maybeCreateSurfaceGateway — enabled=true, surfaces with slack binding → SurfaceGateway instance
+ *  12.  maybeCreateSurfaceGateway — enabled=true, surfaces with mattermost binding → SurfaceGateway instance
+ *  13.  maybeCreateSurfaceGateway — buildBindingIndex throws (duplicate key) → propagates error
+ */
+
+import { describe, expect, test, spyOn, beforeEach, afterEach } from "bun:test";
+import {
+  isGatewayEnabled,
+  maybeCreateSurfaceGateway,
+  type GatewayBootstrapOpts,
+} from "../gateway-bootstrap";
+import { SurfaceGateway } from "../surface-gateway";
+import type { PlatformAdapter, InboundMessage } from "../../adapters/types";
+import type { Surfaces } from "../../common/types/surfaces";
+
+// =============================================================================
+// Minimal fake PlatformAdapter (no real platform connection needed)
+// =============================================================================
+
+function makeFakeAdapter(instanceId = "fake-adapter-1"): PlatformAdapter {
+  return {
+    platform: "discord",
+    instanceId,
+    start: async () => {},
+    stop: async () => {},
+    getPlatformUserId: async () => "bot-user-id",
+    fetchContext: async () => [],
+    resolveAccess: () => ({
+      allowed: true,
+      features: { chat: true, async: false, team: false },
+    }),
+    postResponse: async () => {},
+    sendTyping: async () => {},
+    sendProgress: async () => {},
+    clearProgress: async () => {},
+    createThread: async () => ({
+      instanceId,
+      channelId: "ch-new-thread",
+    }),
+    resolveLogicalTarget: async () => null,
+    notifyPrincipal: async () => {},
+  };
+}
+
+// =============================================================================
+// Surfaces fixtures
+// =============================================================================
+
+const DISCORD_SURFACES: Surfaces = {
+  discord: [
+    {
+      agent: "luna",
+      stack: "andreas/meta-factory",
+      binding: {
+        token: "tok-luna-discord",
+        guildId: "111222333444555666",
+        agentChannelId: "aaa000000000000001",
+        logChannelId: "bbb000000000000002",
+      },
+    },
+  ],
+};
+
+const SLACK_SURFACES: Surfaces = {
+  slack: [
+    {
+      agent: "luna",
+      stack: "andreas/meta-factory",
+      binding: {
+        botToken: "xoxb-111-222-abc",
+        appToken: "xapp-1-333-444-def",
+        workspaceId: "T0123456789",
+      },
+    },
+  ],
+};
+
+const MATTERMOST_SURFACES: Surfaces = {
+  mattermost: [
+    {
+      agent: "luna",
+      stack: "andreas/meta-factory",
+      binding: {
+        apiUrl: "https://mm.example.com",
+        apiToken: "mm-api-token-xyz",
+      },
+    },
+  ],
+};
+
+/** Empty Surfaces object — all arrays absent; zero bindings across all platforms. */
+const EMPTY_SURFACES: Surfaces = {};
+
+// =============================================================================
+// isGatewayEnabled
+// =============================================================================
+
+describe("isGatewayEnabled", () => {
+  test("returns false when CORTEX_GATEWAY is unset", () => {
+    expect(isGatewayEnabled({})).toBe(false);
+  });
+
+  test("returns true when CORTEX_GATEWAY is '1'", () => {
+    expect(isGatewayEnabled({ CORTEX_GATEWAY: "1" })).toBe(true);
+  });
+
+  test("returns false when CORTEX_GATEWAY is '0'", () => {
+    expect(isGatewayEnabled({ CORTEX_GATEWAY: "0" })).toBe(false);
+  });
+
+  test("returns false when CORTEX_GATEWAY is 'true' (only '1' is truthy)", () => {
+    expect(isGatewayEnabled({ CORTEX_GATEWAY: "true" })).toBe(false);
+  });
+
+  test("returns false when CORTEX_GATEWAY is undefined in the env record", () => {
+    expect(isGatewayEnabled({ CORTEX_GATEWAY: undefined })).toBe(false);
+  });
+});
+
+// =============================================================================
+// maybeCreateSurfaceGateway — flag-off path
+// =============================================================================
+
+describe("maybeCreateSurfaceGateway — enabled=false", () => {
+  test("returns undefined immediately when enabled is false", () => {
+    const opts: GatewayBootstrapOpts = {
+      enabled: false,
+      surfaces: DISCORD_SURFACES,
+      adapters: [makeFakeAdapter()],
+    };
+    const result = maybeCreateSurfaceGateway(opts);
+    expect(result).toBeUndefined();
+  });
+
+  test("returns undefined without logging when enabled is false (no stderr output)", () => {
+    const stderrSpy = spyOn(process.stderr, "write").mockImplementation(() => true);
+    try {
+      const opts: GatewayBootstrapOpts = {
+        enabled: false,
+        surfaces: DISCORD_SURFACES,
+        adapters: [makeFakeAdapter()],
+      };
+      maybeCreateSurfaceGateway(opts);
+      // No stderr call expected for the flag-off path
+      const gatewayCalls = stderrSpy.mock.calls.filter((args) =>
+        String(args[0]).includes("gateway"),
+      );
+      expect(gatewayCalls.length).toBe(0);
+    } finally {
+      stderrSpy.mockRestore();
+    }
+  });
+});
+
+// =============================================================================
+// maybeCreateSurfaceGateway — surfaces absent / empty
+// =============================================================================
+
+describe("maybeCreateSurfaceGateway — no bindings", () => {
+  test("returns undefined when surfaces is undefined, logs to stderr", () => {
+    const stderrSpy = spyOn(process.stderr, "write").mockImplementation(() => true);
+    try {
+      const opts: GatewayBootstrapOpts = {
+        enabled: true,
+        surfaces: undefined,
+        adapters: [makeFakeAdapter()],
+      };
+      const result = maybeCreateSurfaceGateway(opts);
+      expect(result).toBeUndefined();
+      const logged = stderrSpy.mock.calls.some((args) =>
+        String(args[0]).includes("CORTEX_GATEWAY"),
+      );
+      expect(logged).toBe(true);
+    } finally {
+      stderrSpy.mockRestore();
+    }
+  });
+
+  test("returns undefined when surfaces is empty object, logs to stderr", () => {
+    const stderrSpy = spyOn(process.stderr, "write").mockImplementation(() => true);
+    try {
+      const opts: GatewayBootstrapOpts = {
+        enabled: true,
+        surfaces: EMPTY_SURFACES,
+        adapters: [makeFakeAdapter()],
+      };
+      const result = maybeCreateSurfaceGateway(opts);
+      expect(result).toBeUndefined();
+      const logged = stderrSpy.mock.calls.some((args) =>
+        String(args[0]).includes("CORTEX_GATEWAY"),
+      );
+      expect(logged).toBe(true);
+    } finally {
+      stderrSpy.mockRestore();
+    }
+  });
+
+  test("stderr message mentions 'no surfaces bindings found' when surfaces empty", () => {
+    const messages: string[] = [];
+    const stderrSpy = spyOn(process.stderr, "write").mockImplementation((msg) => {
+      messages.push(String(msg));
+      return true;
+    });
+    try {
+      maybeCreateSurfaceGateway({
+        enabled: true,
+        surfaces: EMPTY_SURFACES,
+        adapters: [makeFakeAdapter()],
+      });
+      const combined = messages.join("");
+      expect(combined).toContain("no surfaces bindings found");
+    } finally {
+      stderrSpy.mockRestore();
+    }
+  });
+});
+
+// =============================================================================
+// maybeCreateSurfaceGateway — happy path (returns SurfaceGateway)
+// =============================================================================
+
+describe("maybeCreateSurfaceGateway — happy path", () => {
+  test("returns a SurfaceGateway instance when discord surfaces provided", () => {
+    const result = maybeCreateSurfaceGateway({
+      enabled: true,
+      surfaces: DISCORD_SURFACES,
+      adapters: [makeFakeAdapter()],
+    });
+    expect(result).toBeInstanceOf(SurfaceGateway);
+  });
+
+  test("returns a SurfaceGateway instance when slack surfaces provided", () => {
+    const result = maybeCreateSurfaceGateway({
+      enabled: true,
+      surfaces: SLACK_SURFACES,
+      adapters: [makeFakeAdapter("fake-slack-1")],
+    });
+    expect(result).toBeInstanceOf(SurfaceGateway);
+  });
+
+  test("returns a SurfaceGateway instance when mattermost surfaces provided", () => {
+    const result = maybeCreateSurfaceGateway({
+      enabled: true,
+      surfaces: MATTERMOST_SURFACES,
+      adapters: [makeFakeAdapter("fake-mm-1")],
+    });
+    expect(result).toBeInstanceOf(SurfaceGateway);
+  });
+
+  test("the returned gateway can start and stop the injected adapters", async () => {
+    const started: string[] = [];
+    const stopped: string[] = [];
+    const fakeAdapter = makeFakeAdapter("injected-adapter");
+    fakeAdapter.start = async (onMsg) => {
+      started.push(fakeAdapter.instanceId);
+    };
+    fakeAdapter.stop = async () => {
+      stopped.push(fakeAdapter.instanceId);
+    };
+
+    const gw = maybeCreateSurfaceGateway({
+      enabled: true,
+      surfaces: DISCORD_SURFACES,
+      adapters: [fakeAdapter],
+    });
+    expect(gw).toBeInstanceOf(SurfaceGateway);
+    await gw!.start();
+    expect(started).toEqual(["injected-adapter"]);
+    await gw!.stop();
+    expect(stopped).toEqual(["injected-adapter"]);
+  });
+
+  test("onUnroutable callback is forwarded to the SurfaceGateway", async () => {
+    const unroutableCalls: { msg: InboundMessage; reason: string }[] = [];
+
+    const gw = maybeCreateSurfaceGateway({
+      enabled: true,
+      surfaces: DISCORD_SURFACES,
+      adapters: [makeFakeAdapter()],
+      onUnroutable: (msg, reason) => {
+        unroutableCalls.push({ msg, reason });
+      },
+    });
+
+    expect(gw).toBeInstanceOf(SurfaceGateway);
+
+    // Trigger handleInbound with a message that won't route (wrong guildId)
+    const fakeAdapter = makeFakeAdapter();
+    const dmMsg: InboundMessage = {
+      platform: "discord",
+      instanceId: "discord-luna-mf",
+      authorId: "user-1",
+      authorName: "Test User",
+      content: "hello",
+      channelId: "ch-dm",
+      attachments: [],
+      timestamp: new Date(),
+      // No guildId → DM → unroutable
+    };
+    await gw!.handleInbound(fakeAdapter, dmMsg);
+    expect(unroutableCalls.length).toBe(1);
+  });
+
+  test("logs a one-line SHADOW summary to stdout on construction", () => {
+    const messages: string[] = [];
+    const stdoutSpy = spyOn(process.stdout, "write").mockImplementation((msg) => {
+      messages.push(String(msg));
+      return true;
+    });
+    try {
+      maybeCreateSurfaceGateway({
+        enabled: true,
+        surfaces: DISCORD_SURFACES,
+        adapters: [makeFakeAdapter()],
+      });
+      const combined = messages.join("");
+      expect(combined).toContain("SHADOW");
+      expect(combined).toContain("LoggingInboundSink");
+    } finally {
+      stdoutSpy.mockRestore();
+    }
+  });
+
+  test("summary log includes binding count and adapter count", () => {
+    const messages: string[] = [];
+    const stdoutSpy = spyOn(process.stdout, "write").mockImplementation((msg) => {
+      messages.push(String(msg));
+      return true;
+    });
+    try {
+      maybeCreateSurfaceGateway({
+        enabled: true,
+        surfaces: DISCORD_SURFACES,
+        adapters: [makeFakeAdapter("a1"), makeFakeAdapter("a2")],
+      });
+      const combined = messages.join("");
+      // 1 discord binding → "1 binding"
+      expect(combined).toMatch(/1\s+binding/);
+      // 2 adapters
+      expect(combined).toMatch(/2\s+adapter/);
+    } finally {
+      stdoutSpy.mockRestore();
+    }
+  });
+});
+
+// =============================================================================
+// maybeCreateSurfaceGateway — error propagation
+// =============================================================================
+
+describe("maybeCreateSurfaceGateway — error propagation", () => {
+  test("propagates Error from buildBindingIndex (duplicate demux key)", () => {
+    const duplicateDiscord: Surfaces = {
+      discord: [
+        {
+          agent: "luna",
+          stack: "andreas/meta-factory",
+          binding: {
+            token: "tok-1",
+            guildId: "SAME_GUILD",
+            agentChannelId: "aaa000000000000001",
+            logChannelId: "bbb000000000000002",
+          },
+        },
+        {
+          agent: "sage",
+          stack: "andreas/work",
+          binding: {
+            token: "tok-2",
+            guildId: "SAME_GUILD", // duplicate — buildBindingIndex throws
+            agentChannelId: "ccc000000000000003",
+            logChannelId: "ddd000000000000004",
+          },
+        },
+      ],
+    };
+
+    expect(() =>
+      maybeCreateSurfaceGateway({
+        enabled: true,
+        surfaces: duplicateDiscord,
+        adapters: [makeFakeAdapter()],
+      }),
+    ).toThrow(/ambiguous discord config/);
+  });
+});

--- a/src/gateway/__tests__/gateway-bootstrap.test.ts
+++ b/src/gateway/__tests__/gateway-bootstrap.test.ts
@@ -18,7 +18,7 @@
  *  13.  maybeCreateSurfaceGateway — buildBindingIndex throws (duplicate key) → propagates error
  */
 
-import { describe, expect, test, spyOn, beforeEach, afterEach } from "bun:test";
+import { describe, expect, test, spyOn } from "bun:test";
 import {
   isGatewayEnabled,
   maybeCreateSurfaceGateway,

--- a/src/gateway/gateway-bootstrap.ts
+++ b/src/gateway/gateway-bootstrap.ts
@@ -1,0 +1,200 @@
+/**
+ * GW.a.3b.1 — flag-gated gateway bootstrap factory (cortex#524).
+ *
+ * Pure construction logic: reads the `CORTEX_GATEWAY` env flag, validates that
+ * at least one surface binding exists, builds the binding index, and returns a
+ * fully constructed (but not yet started) {@link SurfaceGateway}.
+ *
+ * ## Shadow stage (this slice)
+ *
+ * `maybeCreateSurfaceGateway` ALWAYS wires {@link LoggingInboundSink} as the
+ * inbound sink — it logs the routing decision that WOULD be published to the
+ * bus, but does NOT publish. This lets the gateway run alongside per-stack
+ * adapters on a staging identity to prove demux correctness before any stack
+ * loses its own adapter. The live bus-publishing sink flip is GW.a.3b.2.
+ *
+ * ## GW.a.3b.2 prerequisites (NOT done in this slice)
+ *
+ * 1. **cortex.ts boot wiring** — call `maybeCreateSurfaceGateway` after
+ *    adapters are built, attach the returned gateway to the shutdown sequence
+ *    (`await gw.start()` on startup; `await gw.stop()` on SIGTERM/SIGINT), and
+ *    guard the whole block behind the same `enabled` flag.
+ *
+ * 2. **`LoadedConfig` must expose `Surfaces`** — today `foldSurfaceBindings`
+ *    (`src/common/config/loader.ts:389`) folds surface bindings into the
+ *    per-agent presence blocks and then DROPS the `surfaces:` key, so
+ *    `LoadedConfig` does not retain the binding map. GW.a.3b.2 must either:
+ *      (a) surface the validated `Surfaces` object on `LoadedConfig` (preferred
+ *          — the gateway reads it from there), or
+ *      (b) have the gateway read `surfaces.yaml` directly via a side-load.
+ *    Option (a) is preferred; the fold already runs the schema validation, so
+ *    the validated object is available at that point and can be returned
+ *    alongside the existing `LoadedConfig` shape.
+ *
+ * 3. **Live staging adapters** — a throwaway gateway bot identity (cortex#562)
+ *    with its own Discord/Slack application and bot token is needed to connect
+ *    real platform adapters to the gateway during the shadow dry-run. These are
+ *    injected via the `adapters` parameter; constructing them from a live config
+ *    is GW.a.3b.2 work.
+ *
+ * ## Decision log (principal-locked 2026-06-02)
+ *
+ * - Env var name: `CORTEX_GATEWAY` (not `GATEWAY_ENABLED` — stays in the
+ *   cortex namespace, consistent with `CORTEX_CHANNEL`, `CORTEX_AGENT_*`).
+ * - Only `"1"` is truthy; `"true"`, `"yes"`, `"on"` are all false. Keeps the
+ *   contract minimal and grep-stable.
+ * - `isGatewayEnabled` is kept separate from the factory so flag-reading is
+ *   independently testable without constructing anything.
+ * - Empty-surfaces early-exit is a stderr warning (not a throw) because a
+ *   misconfigured-but-flagged deployment should degrade gracefully — the rest
+ *   of cortex starts normally, the gateway simply does not run.
+ */
+
+import type { PlatformAdapter, InboundMessage } from "../adapters/types";
+import type { Surfaces } from "../common/types/surfaces";
+import { buildBindingIndex } from "./binding-resolver";
+import {
+  SurfaceGateway,
+  LoggingInboundSink,
+} from "./surface-gateway";
+
+// =============================================================================
+// Public API
+// =============================================================================
+
+/**
+ * Constructor-time options for {@link maybeCreateSurfaceGateway}.
+ *
+ * The caller is responsible for:
+ *   - evaluating the flag (`enabled = isGatewayEnabled(process.env)`)
+ *   - sourcing the surface binding map (GW.a.3b.2 loads it from `LoadedConfig`)
+ *   - constructing the live adapters (GW.a.3b.2 builds them from the config)
+ *
+ * This keeps the factory pure and independently testable.
+ */
+export interface GatewayBootstrapOpts {
+  /** Pass `isGatewayEnabled(process.env)` — the factory does not read env directly. */
+  enabled: boolean;
+  /**
+   * The validated surface binding map from the config layer.
+   * `undefined` when the config has no `surfaces:` block (GW.a.3b.2 precondition
+   * 2 above — `LoadedConfig` must expose this).
+   */
+  surfaces: Surfaces | undefined;
+  /** Platform adapters the gateway will own — injected by GW.a.3b.2 caller. */
+  adapters: PlatformAdapter[];
+  /**
+   * Optional unroutable-message hook forwarded to {@link SurfaceGateway}.
+   * When absent the gateway's default `console.warn` fires.
+   */
+  onUnroutable?: (msg: InboundMessage, reason: string) => void;
+}
+
+// =============================================================================
+// isGatewayEnabled
+// =============================================================================
+
+/**
+ * Read the `CORTEX_GATEWAY` flag from `env` (defaults to `process.env`).
+ *
+ * Returns `true` iff `env.CORTEX_GATEWAY === "1"`. All other values —
+ * including `"true"`, `"yes"`, `"on"`, and `undefined` — return `false`.
+ * Kept separate from the factory so flag-reading is independently testable.
+ *
+ * Decision (2026-06-02): only `"1"` is truthy; the contract is minimal and
+ * grep-stable across launchd plists, `.env` files, and shell exports.
+ */
+export function isGatewayEnabled(
+  env: Record<string, string | undefined> = process.env,
+): boolean {
+  return env.CORTEX_GATEWAY === "1";
+}
+
+// =============================================================================
+// Binding count helper
+// =============================================================================
+
+/**
+ * Count the total number of surface bindings across all platforms in a
+ * `Surfaces` map.
+ *
+ * Used for the empty-check (zero → early-exit) and the construction log line.
+ */
+function countBindings(surfaces: Surfaces): number {
+  return (
+    (surfaces.discord?.length ?? 0) +
+    (surfaces.slack?.length ?? 0) +
+    (surfaces.mattermost?.length ?? 0)
+  );
+}
+
+// =============================================================================
+// maybeCreateSurfaceGateway
+// =============================================================================
+
+/**
+ * Flag-gated factory for {@link SurfaceGateway}.
+ *
+ * Three exit paths:
+ *
+ *   1. `enabled === false` → return `undefined` silently. Today's per-stack
+ *      dispatch path is entirely untouched; the gateway is opt-in.
+ *
+ *   2. `enabled === true` but zero bindings (`surfaces` absent or all arrays
+ *      empty) → return `undefined` + a clear `stderr` warning. The flag is set
+ *      but there is nothing to demux — degrade gracefully rather than starting
+ *      an idle gateway process.
+ *
+ *   3. Otherwise → build the binding index, construct a {@link SurfaceGateway}
+ *      with a {@link LoggingInboundSink} (shadow stage — no bus publish), log a
+ *      one-line summary to stdout, and return the instance. The caller calls
+ *      `gw.start()` / `gw.stop()` at the appropriate lifecycle points.
+ *
+ * @throws re-throws any `Error` from `buildBindingIndex` (e.g. duplicate demux
+ *   keys) — config invariant violations should fail loudly at startup.
+ */
+export function maybeCreateSurfaceGateway(
+  opts: GatewayBootstrapOpts,
+): SurfaceGateway | undefined {
+  const { enabled, surfaces, adapters, onUnroutable } = opts;
+
+  // ── Path 1: flag off ─────────────────────────────────────────────────────
+  if (!enabled) {
+    return undefined;
+  }
+
+  // ── Path 2: flag on but no bindings ──────────────────────────────────────
+  const bindingCount = surfaces !== undefined ? countBindings(surfaces) : 0;
+  if (surfaces === undefined || bindingCount === 0) {
+    process.stderr.write(
+      "[surface-gateway] CORTEX_GATEWAY set but no surfaces bindings found" +
+        " — gateway not started. " +
+        "Ensure surfaces.yaml is present and LoadedConfig exposes the Surfaces map" +
+        " (GW.a.3b.2 prerequisite).\n",
+    );
+    return undefined;
+  }
+
+  // ── Path 3: construct ────────────────────────────────────────────────────
+  //
+  // buildBindingIndex throws on duplicate demux keys — that is intentional
+  // (loud startup failure on bad config). The throw propagates to the caller.
+  const index = buildBindingIndex(surfaces);
+
+  // Shadow stage: ALWAYS use LoggingInboundSink here.
+  // The real BusInboundSink flip (publishing to the bus) is GW.a.3b.2 work —
+  // that slice wires the live runtime and swaps LoggingInboundSink for
+  // BusInboundSink in the cortex.ts boot path.
+  const sink = new LoggingInboundSink();
+
+  const gw = new SurfaceGateway(adapters, index, sink, { onUnroutable });
+
+  process.stdout.write(
+    `[surface-gateway] surface gateway constructed (SHADOW)` +
+      ` — ${bindingCount} ${bindingCount === 1 ? "binding" : "bindings"},` +
+      ` ${adapters.length} ${adapters.length === 1 ? "adapter" : "adapters"};` +
+      ` LoggingInboundSink (no bus publish)\n`,
+  );
+
+  return gw;
+}

--- a/src/gateway/gateway-bootstrap.ts
+++ b/src/gateway/gateway-bootstrap.ts
@@ -35,7 +35,10 @@
  *    with its own Discord/Slack application and bot token is needed to connect
  *    real platform adapters to the gateway during the shadow dry-run. These are
  *    injected via the `adapters` parameter; constructing them from a live config
- *    is GW.a.3b.2 work.
+ *    is GW.a.3b.2 work. **Precondition a.3b.2 must honour:** pass ≥1 adapter when
+ *    bindings are present — this factory does not guard `adapters: []` (a gateway
+ *    with bindings but no connections has nothing to receive on); a.3b.2 builds
+ *    one adapter per `(platform, identity)` the gateway owns.
  *
  * ## Decision log (principal-locked 2026-06-02)
  *


### PR DESCRIPTION
First live-path GW slice — but still **pure + unit-tested**: no cortex.ts change, no live adapters, no bus publish. The construction logic a.3b.2 will call from the boot path.

## What
`src/gateway/gateway-bootstrap.ts` (+18 tests):
- **`isGatewayEnabled(env)`** — reads `CORTEX_GATEWAY` (true iff `=== "1"`; principal-locked, grep-stable). Separate from the factory for testability.
- **`maybeCreateSurfaceGateway({enabled, surfaces, adapters, onUnroutable})`** — 3 exit paths:
  1. flag off → `undefined` (today's per-stack path untouched — the **revert switch**);
  2. flag on + zero bindings → `undefined` + stderr warning (degrade gracefully);
  3. else → `buildBindingIndex` + `new SurfaceGateway(adapters, index, LoggingInboundSink)` (**SHADOW** — logs, no bus publish) + summary.

## Documented a.3b.2 prerequisites (NOT in this slice)
1. cortex.ts boot wiring (`gw?.start()`/`stop()` behind the flag).
2. **Expose `Surfaces` on `LoadedConfig`** — `foldSurfaceBindings` (`loader.ts:389`) drops the `surfaces:` key today.
3. Live staging adapters (#562 bot).

## Gates (verified on branch)
`tsc` 0 · `eslint --quiet` 0 · `bun test src/gateway/` **73/73** (55 prior + 18 new) · whole-tree vocab gate PASS.

Refs #524 · part of #110.

🤖 Generated with [Claude Code](https://claude.com/claude-code)