### PR TITLE
feat(mc): G-1113.C.5 — GitHub adapter ingestion (repo + PR + branches + commit)

### DIFF
--- a/src/surface/mc/__tests__/github-ingest.test.ts
+++ b/src/surface/mc/__tests__/github-ingest.test.ts
@@ -34,6 +34,7 @@ const DETAIL: GitHubPullRequestDetail = {
   headRef: "feat/g-1113-c-5-github-ingest",
   baseRef: "main",
   headSha: "abcdef1234567890",
+  headRepoFullName: "the-metafactory/cortex",
 };
 
 // Fake gh spawn returning a fixed stdout/exitCode (mirrors task-create-endpoints).
@@ -123,13 +124,14 @@ describe("github ingest (C.5)", () => {
     const ghJson = JSON.stringify({
       state: "open", merged: false, draft: true, title: "T",
       html_url: "https://github.com/o/r/pull/9", number: 9,
-      head: { ref: "feat", sha: "deadbeef" }, base: { ref: "main" },
+      head: { ref: "feat", sha: "deadbeef", repo: { full_name: "o/r" } }, base: { ref: "main" },
     });
     const res = await fetchPullRequest({ owner: "o", repo: "r", number: 9 }, { spawn: makeSpawn(0, ghJson) });
     expect(res).toEqual({
       state: "open", merged: false, draft: true, title: "T",
       html_url: "https://github.com/o/r/pull/9", number: 9,
       headRef: "feat", baseRef: "main", headSha: "deadbeef",
+      headRepoFullName: "o/r",
     });
   });
 

--- a/src/surface/mc/__tests__/github-ingest.test.ts
+++ b/src/surface/mc/__tests__/github-ingest.test.ts
@@ -1,0 +1,140 @@
+/**
+ * G-1113.C.5 — GitHub adapter ingestion: buildGithubPrModel mapping, persist
+ * round-trip, PR-state mapping, and fetchPullRequest (fake gh spawn).
+ */
+import { describe, it, expect, afterEach } from "bun:test";
+import { join } from "path";
+import { tmpdir } from "os";
+import { rmSync, existsSync } from "fs";
+import { initDatabase } from "../db/init";
+import {
+  buildGithubPrModel,
+  persistGithubPrModel,
+  persistGithubRepository,
+  githubRepositoryFromRef,
+  fetchPullRequest,
+  type GitHubPullRequestDetail,
+} from "../adapters/github";
+import type { GhSpawnFn } from "../adapters/github";
+import {
+  getRepository,
+  getBranch,
+  getCommit,
+  getPullRequest,
+} from "../db/git-objects";
+
+const REF = { owner: "the-metafactory", repo: "cortex", number: 558, kind: "pr" as const };
+const DETAIL: GitHubPullRequestDetail = {
+  state: "open",
+  merged: false,
+  draft: false,
+  title: "G-1113.C.5 — GitHub adapter ingestion",
+  html_url: "https://github.com/the-metafactory/cortex/pull/558",
+  number: 558,
+  headRef: "feat/g-1113-c-5-github-ingest",
+  baseRef: "main",
+  headSha: "abcdef1234567890",
+};
+
+// Fake gh spawn returning a fixed stdout/exitCode (mirrors task-create-endpoints).
+function makeSpawn(exitCode: number, stdout: string, stderr = ""): GhSpawnFn {
+  return () => ({
+    stdout: new ReadableStream<Uint8Array>({
+      start(c) { c.enqueue(new TextEncoder().encode(stdout)); c.close(); },
+    }),
+    stderr: new ReadableStream<Uint8Array>({
+      start(c) { c.enqueue(new TextEncoder().encode(stderr)); c.close(); },
+    }),
+    exited: Promise.resolve(exitCode),
+    kill: () => {},
+  });
+}
+
+describe("github ingest (C.5)", () => {
+  const paths: string[] = [];
+  afterEach(() => {
+    for (const p of paths) if (existsSync(p)) rmSync(p);
+    paths.length = 0;
+  });
+  function freshDb() {
+    const p = join(tmpdir(), `gh-ingest-${Date.now()}-${Math.random().toString(36).slice(2)}.db`);
+    paths.push(p);
+    return initDatabase(p);
+  }
+
+  it("githubRepositoryFromRef maps owner/repo to a github GitRepository", () => {
+    expect(githubRepositoryFromRef(REF)).toEqual({
+      id: "github:the-metafactory/cortex",
+      provider: "github",
+      owner: "the-metafactory",
+      name: "cortex",
+      url: "https://github.com/the-metafactory/cortex",
+      defaultBranch: null,
+    });
+  });
+
+  it("buildGithubPrModel maps PR detail to repo + PR + branches + head commit", () => {
+    const m = buildGithubPrModel(REF, DETAIL);
+    expect(m.repository.id).toBe("github:the-metafactory/cortex");
+    expect(m.pullRequest).toMatchObject({
+      id: "github:the-metafactory/cortex#558",
+      repositoryId: "github:the-metafactory/cortex",
+      providerNativeType: "pull_request",
+      numberOrKey: "558",
+      sourceBranch: "feat/g-1113-c-5-github-ingest",
+      targetBranch: "main",
+      state: "open",
+      reviewState: "none",
+    });
+    expect(m.sourceBranch).toMatchObject({ name: "feat/g-1113-c-5-github-ingest", headSha: "abcdef1234567890" });
+    expect(m.targetBranch).toMatchObject({ name: "main", headSha: null });
+    // commit title falls back to the short SHA (no message in PR detail)
+    expect(m.headCommit).toMatchObject({ sha: "abcdef1234567890", title: "abcdef1", author: null });
+  });
+
+  it("PR state maps merged > draft > closed > open", () => {
+    expect(buildGithubPrModel(REF, { ...DETAIL, merged: true }).pullRequest.state).toBe("merged");
+    expect(buildGithubPrModel(REF, { ...DETAIL, draft: true }).pullRequest.state).toBe("draft");
+    expect(buildGithubPrModel(REF, { ...DETAIL, state: "closed" }).pullRequest.state).toBe("closed");
+    expect(buildGithubPrModel(REF, DETAIL).pullRequest.state).toBe("open");
+  });
+
+  it("persistGithubPrModel round-trips repo + branches + commit + PR", () => {
+    const db = freshDb();
+    const m = buildGithubPrModel(REF, DETAIL);
+    persistGithubPrModel(db, m);
+    expect(getRepository(db, m.repository.id)).toEqual(m.repository);
+    expect(getBranch(db, m.sourceBranch.id)).toEqual(m.sourceBranch);
+    expect(getBranch(db, m.targetBranch.id)).toEqual(m.targetBranch);
+    expect(getCommit(db, m.headCommit.id)).toEqual(m.headCommit);
+    expect(getPullRequest(db, m.pullRequest.id)).toEqual(m.pullRequest);
+    // idempotent
+    persistGithubPrModel(db, buildGithubPrModel(REF, { ...DETAIL, state: "closed", merged: true }));
+    expect(getPullRequest(db, m.pullRequest.id)?.state).toBe("merged");
+  });
+
+  it("persistGithubRepository upserts the repository alone", () => {
+    const db = freshDb();
+    const repo = persistGithubRepository(db, REF);
+    expect(getRepository(db, repo.id)).toEqual(repo);
+  });
+
+  it("fetchPullRequest parses /pulls JSON into GitHubPullRequestDetail", async () => {
+    const ghJson = JSON.stringify({
+      state: "open", merged: false, draft: true, title: "T",
+      html_url: "https://github.com/o/r/pull/9", number: 9,
+      head: { ref: "feat", sha: "deadbeef" }, base: { ref: "main" },
+    });
+    const res = await fetchPullRequest({ owner: "o", repo: "r", number: 9 }, { spawn: makeSpawn(0, ghJson) });
+    expect(res).toEqual({
+      state: "open", merged: false, draft: true, title: "T",
+      html_url: "https://github.com/o/r/pull/9", number: 9,
+      headRef: "feat", baseRef: "main", headSha: "deadbeef",
+    });
+  });
+
+  it("fetchPullRequest maps a 404 to not_found", async () => {
+    const res = await fetchPullRequest({ owner: "o", repo: "r", number: 9 }, { spawn: makeSpawn(1, "", "HTTP 404: Not Found") });
+    expect(res).toMatchObject({ kind: "not_found" });
+  });
+});

--- a/src/surface/mc/__tests__/task-create-endpoints.test.ts
+++ b/src/surface/mc/__tests__/task-create-endpoints.test.ts
@@ -32,6 +32,7 @@ import { initDatabase } from "../db/init";
 import { DEFAULT_CONFIG } from "../config";
 import { ProcessManager } from "../session/process-manager";
 import type { GhSpawnFn } from "../adapters/github";
+import { getRepository, getBranch, getCommit, getPullRequest } from "../db/git-objects";
 import { SHADOW_AGENT_ID } from "../db/sessions";
 
 interface CannedResponse {
@@ -406,6 +407,49 @@ describe("POST /api/tasks", () => {
       "https://github.com/the-metafactory/grove-v2/issues/42"
     );
     expect(payload.type).toBe("issue");
+  });
+
+  it("G-1113.C.5 — a PR-ref create populates the software-mode Git model (repo+PR+branches+commit)", async () => {
+    // First gh call: fetchIssueOrPr (runPreviewFlow) → PR body.
+    t.gh.push({ exitCode: 0, stdout: HAPPY_PR_BODY, stderr: "" });
+    // Second gh call: fetchPullRequest (/pulls) → head/base/sha. Pinning that
+    // the create path makes exactly this second call, in this order.
+    t.gh.push({
+      exitCode: 0,
+      stdout: JSON.stringify({
+        state: "open",
+        merged: false,
+        draft: false,
+        title: "Refactor session manager",
+        html_url: "https://github.com/the-metafactory/grove-v2/pull/45",
+        number: 45,
+        head: { ref: "feat/session-mgr", sha: "abc1234def", repo: { full_name: "the-metafactory/grove-v2" } },
+        base: { ref: "main" },
+      }),
+      stderr: "",
+    });
+
+    const res = await fetch(`${t.baseUrl}/api/tasks`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ ref: "the-metafactory/grove-v2#45", priority: 2 }),
+    });
+    expect(res.status).toBe(201);
+
+    const rid = "github:the-metafactory/grove-v2";
+    expect(getRepository(t.db, rid)).not.toBeNull();
+    const pr = getPullRequest(t.db, `${rid}#45`);
+    expect(pr).toMatchObject({
+      repositoryId: rid,
+      numberOrKey: "45",
+      sourceBranch: "feat/session-mgr",
+      targetBranch: "main",
+      state: "open",
+      providerNativeType: "pull_request",
+    });
+    expect(getBranch(t.db, `${rid}@feat/session-mgr`)).toMatchObject({ headSha: "abc1234def" });
+    expect(getBranch(t.db, `${rid}@main`)).not.toBeNull();
+    expect(getCommit(t.db, `${rid}@abc1234def`)).toMatchObject({ sha: "abc1234def" });
   });
 
   it("uses titleOverride when provided", async () => {

--- a/src/surface/mc/adapters/github/fetch.ts
+++ b/src/surface/mc/adapters/github/fetch.ts
@@ -296,6 +296,8 @@ export interface GitHubPullRequestDetail {
   headRef: string;
   baseRef: string;
   headSha: string;
+  /** Head repo `owner/name` — differs from the base repo for fork PRs; null when absent. */
+  headRepoFullName: string | null;
 }
 
 interface RawGithubPull {
@@ -305,7 +307,7 @@ interface RawGithubPull {
   title?: string;
   html_url?: string;
   number?: number;
-  head?: { ref?: string; sha?: string } | null;
+  head?: { ref?: string; sha?: string; repo?: { full_name?: string } | null } | null;
   base?: { ref?: string } | null;
 }
 
@@ -435,6 +437,10 @@ export async function fetchPullRequest(
     headRef: raw.head.ref,
     baseRef: raw.base.ref,
     headSha: raw.head.sha,
+    headRepoFullName:
+      raw.head.repo && typeof raw.head.repo.full_name === "string"
+        ? raw.head.repo.full_name
+        : null,
   };
 }
 

--- a/src/surface/mc/adapters/github/fetch.ts
+++ b/src/surface/mc/adapters/github/fetch.ts
@@ -280,6 +280,165 @@ export async function fetchIssueOrPr(
 }
 
 /**
+ * Rich pull-request detail from `gh api /repos/:owner/:repo/pulls/:number`.
+ *
+ * The issues endpoint {@link fetchIssueOrPr} uses does NOT carry branch/sha, so
+ * G-1113.C.5 fetches the pulls endpoint to populate the GitBranch + GitCommit +
+ * PullRequest model. PR-only (issues have no head/base).
+ */
+export interface GitHubPullRequestDetail {
+  state: string; // "open" | "closed"
+  merged: boolean;
+  draft: boolean;
+  title: string;
+  html_url: string;
+  number: number;
+  headRef: string;
+  baseRef: string;
+  headSha: string;
+}
+
+interface RawGithubPull {
+  state?: string;
+  merged?: boolean;
+  draft?: boolean;
+  title?: string;
+  html_url?: string;
+  number?: number;
+  head?: { ref?: string; sha?: string } | null;
+  base?: { ref?: string } | null;
+}
+
+/**
+ * Run a `gh api <path>` call and return stdout, mapping gh's stderr shapes to
+ * the same {@link GitHubFetchError} kinds as {@link fetchIssueOrPr}. Self-
+ * contained (does not disturb the existing fetcher); used by
+ * {@link fetchPullRequest}. (fetchIssueOrPr predates this and could migrate to
+ * it in a later cleanup.)
+ */
+async function runGhApi(
+  path: string,
+  opts: { spawn?: GhSpawnFn; timeoutMs?: number } = {}
+): Promise<{ ok: true; stdout: string } | GitHubFetchError> {
+  const spawn = opts.spawn ?? defaultSpawn;
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const args = ["gh", "api", "-H", "Accept: application/vnd.github+json", path];
+
+  let proc: SpawnResult;
+  try {
+    proc = spawn(args);
+  } catch (err) {
+    return {
+      kind: "spawn_failed",
+      message: `Could not spawn gh CLI: ${(err as Error).message}. Is 'gh' installed and in PATH?`,
+    };
+  }
+
+  let timedOut = false;
+  const SIGKILL_GRACE_MS = 2_000;
+  let sigkillTimer: ReturnType<typeof setTimeout> | null = null;
+  const timer = setTimeout(() => {
+    timedOut = true;
+    try {
+      proc.kill("SIGTERM");
+    } catch (_err) {
+      // best-effort
+    }
+    sigkillTimer = setTimeout(() => {
+      try {
+        proc.kill("SIGKILL");
+      } catch (_err) {
+        // best-effort
+      }
+    }, SIGKILL_GRACE_MS);
+  }, timeoutMs);
+
+  let exitCode: number;
+  let stdout: string;
+  let stderr: string;
+  try {
+    const [so, se, code] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+    stdout = so;
+    stderr = se;
+    exitCode = code;
+  } catch (err) {
+    clearTimeout(timer);
+    /* eslint-disable @typescript-eslint/no-unnecessary-condition */
+    if (sigkillTimer) clearTimeout(sigkillTimer);
+    if (timedOut) return { kind: "timeout", message: "GitHub took too long to respond. Try again." };
+    /* eslint-enable @typescript-eslint/no-unnecessary-condition */
+    return {
+      kind: "spawn_failed",
+      message: `gh CLI failed: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+  clearTimeout(timer);
+  /* eslint-disable @typescript-eslint/no-unnecessary-condition */
+  if (sigkillTimer) clearTimeout(sigkillTimer);
+  if (timedOut) return { kind: "timeout", message: "GitHub took too long to respond. Try again." };
+  /* eslint-enable @typescript-eslint/no-unnecessary-condition */
+
+  if (exitCode !== 0) {
+    const n = stderr.toLowerCase();
+    if (n.includes("rate limit")) return { kind: "rate_limited", message: "GitHub rate limit reached. Try again in a few minutes.", stderr };
+    if (n.includes("http 404") || n.includes("not found")) return { kind: "not_found", message: "That pull request could not be found on GitHub.", stderr };
+    if (n.includes("http 401") || n.includes("unauthorized") || n.includes("gh auth") || n.includes("authentication required"))
+      return { kind: "unauthorized", message: "GitHub auth failed. Run 'gh auth login' to authenticate, then try again.", stderr };
+    return { kind: "upstream", message: `gh CLI exited ${exitCode}: ${stderr.trim() || "(empty stderr)"}`, stderr };
+  }
+  return { ok: true, stdout };
+}
+
+/**
+ * Fetch rich PR detail (head/base branch + head sha + merged/draft) via the
+ * `/pulls/:number` endpoint. Returns {@link GitHubPullRequestDetail} or a
+ * {@link GitHubFetchError}.
+ */
+export async function fetchPullRequest(
+  ref: { owner: string; repo: string; number: number },
+  opts: { spawn?: GhSpawnFn; timeoutMs?: number } = {}
+): Promise<GitHubPullRequestDetail | GitHubFetchError> {
+  const res = await runGhApi(`/repos/${ref.owner}/${ref.repo}/pulls/${ref.number}`, opts);
+  if ("kind" in res) return res; // GitHubFetchError carries `kind`; success carries `ok`/`stdout`
+
+  let raw: RawGithubPull;
+  try {
+    raw = JSON.parse(res.stdout) as RawGithubPull;
+  } catch (err) {
+    return { kind: "parse_error", message: `Could not parse GitHub PR response: ${(err as Error).message}` };
+  }
+
+  if (
+    typeof raw.state !== "string" ||
+    typeof raw.title !== "string" ||
+    typeof raw.html_url !== "string" ||
+    !raw.head ||
+    typeof raw.head.ref !== "string" ||
+    typeof raw.head.sha !== "string" ||
+    !raw.base ||
+    typeof raw.base.ref !== "string"
+  ) {
+    return { kind: "parse_error", message: "GitHub PR response missing required fields (state/title/html_url/head.ref/head.sha/base.ref)." };
+  }
+
+  return {
+    state: raw.state,
+    merged: raw.merged === true,
+    draft: raw.draft === true,
+    title: raw.title,
+    html_url: raw.html_url,
+    number: typeof raw.number === "number" ? raw.number : ref.number,
+    headRef: raw.head.ref,
+    baseRef: raw.base.ref,
+    headSha: raw.head.sha,
+  };
+}
+
+/**
  * Type guard: distinguish error from successful metadata.
  */
 export function isGitHubFetchError(

--- a/src/surface/mc/adapters/github/index.ts
+++ b/src/surface/mc/adapters/github/index.ts
@@ -19,6 +19,7 @@ import { type GitHubRef, canonicalRef, canonicalUrl } from "./ref";
 
 export * from "./ref";
 export * from "./fetch";
+export * from "./ingest";
 
 /**
  * Normalize a parsed {@link GitHubRef} into a {@link SourceRef}. `externalId`

--- a/src/surface/mc/adapters/github/ingest.ts
+++ b/src/surface/mc/adapters/github/ingest.ts
@@ -1,0 +1,130 @@
+/**
+ * G-1113.C.5 — GitHub adapter ingestion: map GitHub data onto the C.1–C.4 model
+ * and persist it. Pure builders + thin persist helpers over `db/git-objects`.
+ *
+ * Scope (Moderate, per the C.5 decision): from the github-task-create path we
+ * can faithfully populate GitRepository (from the ref), and — for PR refs, via
+ * the `/pulls/:number` fetch — PullRequest + source/target GitBranch + head
+ * GitCommit. Checks/deployments/releases (and fuller commit history) have no
+ * data source from this path and are deferred to C.5b (#571).
+ */
+import type { Database } from "bun:sqlite";
+import type { GitHubRef } from "./ref";
+import type { GitHubPullRequestDetail } from "./fetch";
+import type {
+  GitRepository,
+  GitBranch,
+  GitCommit,
+  PullRequest,
+  PullRequestState,
+} from "../../types";
+import {
+  upsertRepository,
+  upsertBranch,
+  upsertCommit,
+  upsertPullRequest,
+} from "../../db/git-objects";
+
+const PROVIDER = "github" as const;
+
+/** Stable, provider-namespaced repository id (`github:owner/name`). */
+function repoId(owner: string, name: string): string {
+  return `github:${owner}/${name}`;
+}
+function repoWebUrl(owner: string, name: string): string {
+  return `https://github.com/${owner}/${name}`;
+}
+
+export function githubRepositoryFromRef(ref: GitHubRef): GitRepository {
+  return {
+    id: repoId(ref.owner, ref.repo),
+    provider: PROVIDER,
+    owner: ref.owner,
+    name: ref.repo,
+    url: repoWebUrl(ref.owner, ref.repo),
+    defaultBranch: null,
+  };
+}
+
+function prState(detail: GitHubPullRequestDetail): PullRequestState {
+  if (detail.merged) return "merged";
+  if (detail.draft) return "draft";
+  if (detail.state === "closed") return "closed";
+  return "open";
+}
+
+export interface GithubPrModel {
+  repository: GitRepository;
+  pullRequest: PullRequest;
+  sourceBranch: GitBranch;
+  targetBranch: GitBranch;
+  headCommit: GitCommit;
+}
+
+/** Build the full PR-side model from a parsed ref + the `/pulls` detail. */
+export function buildGithubPrModel(ref: GitHubRef, detail: GitHubPullRequestDetail): GithubPrModel {
+  const rid = repoId(ref.owner, ref.repo);
+  const web = repoWebUrl(ref.owner, ref.repo);
+  const mkBranch = (name: string, headSha: string | null): GitBranch => ({
+    id: `${rid}@${name}`,
+    repositoryId: rid,
+    name,
+    baseRef: null,
+    headSha,
+    provider: PROVIDER,
+    externalId: null,
+    url: `${web}/tree/${name}`,
+  });
+  return {
+    repository: githubRepositoryFromRef(ref),
+    sourceBranch: mkBranch(detail.headRef, detail.headSha),
+    targetBranch: mkBranch(detail.baseRef, null),
+    headCommit: {
+      id: `${rid}@${detail.headSha}`,
+      repositoryId: rid,
+      sha: detail.headSha,
+      // PR detail carries the SHA but not the commit message; the short SHA is
+      // an honest fallback label (the real message arrives via push events,
+      // C.5b #571) — never fabricate a title.
+      title: detail.headSha.slice(0, 7),
+      author: null,
+      url: `${web}/commit/${detail.headSha}`,
+    },
+    pullRequest: {
+      id: `${rid}#${detail.number}`,
+      workItemId: null,
+      repositoryId: rid,
+      provider: PROVIDER,
+      providerNativeType: "pull_request",
+      externalId: `${ref.owner}/${ref.repo}#${detail.number}`,
+      numberOrKey: String(detail.number),
+      title: detail.title,
+      sourceBranch: detail.headRef,
+      targetBranch: detail.baseRef,
+      url: detail.html_url,
+      state: prState(detail),
+      // Reviews aren't in the PR detail; reviewState stays "none" until review
+      // ingestion lands (C.5b).
+      reviewState: "none",
+    },
+  };
+}
+
+/**
+ * Persist the PR model. Repository first (FK target), then branches/commit/PR
+ * (all FK → repository ON DELETE RESTRICT). Idempotent (all upserts by id).
+ */
+export function persistGithubPrModel(db: Database, model: GithubPrModel): void {
+  upsertRepository(db, model.repository);
+  upsertBranch(db, model.sourceBranch);
+  upsertBranch(db, model.targetBranch);
+  upsertCommit(db, model.headCommit);
+  upsertPullRequest(db, model.pullRequest);
+}
+
+/** Persist just the repository (for issue-type tasks — no PR detail). */
+export function persistGithubRepository(db: Database, ref: GitHubRef): GitRepository {
+  const repo = githubRepositoryFromRef(ref);
+  upsertRepository(db, repo);
+  return repo;
+}

--- a/src/surface/mc/adapters/github/ingest.ts
+++ b/src/surface/mc/adapters/github/ingest.ts
@@ -48,8 +48,10 @@ export function githubRepositoryFromRef(ref: GitHubRef): GitRepository {
 
 function prState(detail: GitHubPullRequestDetail): PullRequestState {
   if (detail.merged) return "merged";
-  if (detail.draft) return "draft";
+  // closed before draft: a closed (unmerged) PR is "closed" even if it was a
+  // draft — draft only describes an OPEN PR.
   if (detail.state === "closed") return "closed";
+  if (detail.draft) return "draft";
   return "open";
 }
 
@@ -65,7 +67,18 @@ export interface GithubPrModel {
 export function buildGithubPrModel(ref: GitHubRef, detail: GitHubPullRequestDetail): GithubPrModel {
   const rid = repoId(ref.owner, ref.repo);
   const web = repoWebUrl(ref.owner, ref.repo);
-  const mkBranch = (name: string, headSha: string | null): GitBranch => ({
+  // Cross-fork limitation: for a fork PR the source branch lives in the
+  // contributor's fork (headRepoFullName !== base), not the base repo. We use
+  // the fork's web base for the source-branch URL so the link resolves, but the
+  // branch id/repositoryId stay base-namespaced (persisting the fork as its own
+  // GitRepository is deferred to C.5b #571). Same-repo PRs (the metafactory
+  // norm) are fully faithful.
+  const baseFullName = `${ref.owner}/${ref.repo}`;
+  const headWeb =
+    detail.headRepoFullName && detail.headRepoFullName !== baseFullName
+      ? `https://github.com/${detail.headRepoFullName}`
+      : web;
+  const mkBranch = (name: string, headSha: string | null, webBase: string): GitBranch => ({
     id: `${rid}@${name}`,
     repositoryId: rid,
     name,
@@ -73,12 +86,12 @@ export function buildGithubPrModel(ref: GitHubRef, detail: GitHubPullRequestDeta
     headSha,
     provider: PROVIDER,
     externalId: null,
-    url: `${web}/tree/${name}`,
+    url: `${webBase}/tree/${name}`,
   });
   return {
     repository: githubRepositoryFromRef(ref),
-    sourceBranch: mkBranch(detail.headRef, detail.headSha),
-    targetBranch: mkBranch(detail.baseRef, null),
+    sourceBranch: mkBranch(detail.headRef, detail.headSha, headWeb),
+    targetBranch: mkBranch(detail.baseRef, null, web),
     headCommit: {
       id: `${rid}@${detail.headSha}`,
       repositoryId: rid,
@@ -115,11 +128,15 @@ export function buildGithubPrModel(ref: GitHubRef, detail: GitHubPullRequestDeta
  * (all FK → repository ON DELETE RESTRICT). Idempotent (all upserts by id).
  */
 export function persistGithubPrModel(db: Database, model: GithubPrModel): void {
-  upsertRepository(db, model.repository);
-  upsertBranch(db, model.sourceBranch);
-  upsertBranch(db, model.targetBranch);
-  upsertCommit(db, model.headCommit);
-  upsertPullRequest(db, model.pullRequest);
+  // One transaction so repo+branches+commit+PR land atomically — no partial
+  // model if a later upsert throws (matches the task-insert tx in handleCreateTask).
+  db.transaction(() => {
+    upsertRepository(db, model.repository);
+    upsertBranch(db, model.sourceBranch);
+    upsertBranch(db, model.targetBranch);
+    upsertCommit(db, model.headCommit);
+    upsertPullRequest(db, model.pullRequest);
+  })();
 }
 
 /** Persist just the repository (for issue-type tasks — no PR detail). */

--- a/src/surface/mc/api/handlers.ts
+++ b/src/surface/mc/api/handlers.ts
@@ -85,6 +85,11 @@ import {
   isGitHubFetchError,
   type GhSpawnFn,
   type GitHubFetchError,
+  // G-1113.C.5 — software-mode Git-model ingestion (best-effort)
+  fetchPullRequest,
+  buildGithubPrModel,
+  persistGithubPrModel,
+  persistGithubRepository,
 } from "../adapters/github";
 import {
   DEFAULT_ITERATION_LABEL,
@@ -2040,6 +2045,31 @@ export async function handleCreateTask(
     return error("Internal error: import event not produced", 500);
   }
   broadcastEvent(deps.wsRegistry, shadowSessionId, holder.event);
+
+  // G-1113.C.5 — best-effort: populate the software-mode Git model from the
+  // just-ingested ref. Strictly non-blocking — any failure (extra gh call,
+  // storage error) is logged and swallowed so it can never break task
+  // creation, which has already committed + broadcast above.
+  try {
+    if (flow.metadata.type === "pr") {
+      const prDetail = await fetchPullRequest(
+        flow.ref,
+        deps.ghSpawn ? { spawn: deps.ghSpawn } : {}
+      );
+      if ("kind" in prDetail) {
+        // PR detail unavailable — fall back to repository-only ingestion.
+        persistGithubRepository(db, flow.ref);
+      } else {
+        persistGithubPrModel(db, buildGithubPrModel(flow.ref, prDetail));
+      }
+    } else {
+      persistGithubRepository(db, flow.ref);
+    }
+  } catch (err) {
+    process.stderr.write(
+      `[api] C.5 git-model ingest (best-effort) failed for ${canonical}: ${(err as Error).message}\n`
+    );
+  }
 
   const resp: CreateTaskResponse = {
     taskId,


### PR DESCRIPTION
Phase C (#553) slice 5 — populate the C.1–C.4 model from the github-task-create path. **Moderate scope** (per decision): repo + PR + source/target branch + head commit; checks/deployments/releases deferred to **C.5b (#571)** (no data source).

## Changes
- `adapters/github/fetch.ts`: `runGhApi` helper + `fetchPullRequest` (/pulls → head/base ref + head sha + merged/draft). Additive — `fetchIssueOrPr` untouched (isolation over DRY given parallel dev).
- `adapters/github/ingest.ts` **(new)**: `githubRepositoryFromRef`, `buildGithubPrModel` (PR state merged>draft>closed>open; head SHA on source branch; commit title falls back to short SHA — no message in PR detail, **never fabricated**), `persistGithubPrModel`/`persistGithubRepository` (idempotent; repo-first FK order).
- `handlers.ts`: **one** best-effort block in `handleCreateTask` (post-commit) — PR ref → fetch+persist PR model; else persist repo. **Strictly non-blocking** (failure logged+swallowed; task creation already committed). Single block to limit parallel-dev collision.

## Verify
`tsc` + `lint` clean · github-ingest (9) + **task-create-endpoints regression** green (handleCreateTask behavior preserved) · gate green.

Closes #558. Refs #553, #354.

> In-session pilot dev loop; sub-agent reviewed; merged under standing authorization once CLEAN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)