### PR TITLE
feat(config): expose validated Surfaces on LoadedConfig (#524, GW.a.3b.2a)

### DIFF
--- a/src/common/config/__tests__/surfaces-layer.test.ts
+++ b/src/common/config/__tests__/surfaces-layer.test.ts
@@ -202,9 +202,18 @@ describe("CFG.c.4 — surfaces.yaml round-trips to the same effective presence/b
     const inline = loadConfigWithAgents(inlinePath);
     const split = loadConfigWithAgents(splitPath);
 
-    // Whole-LoadedConfig identity — the strongest assertion: the move is a
-    // source-layout change, not a runtime-shape change.
-    expect(split).toEqual(inline);
+    // Fold-output identity — the move is a source-layout change, not a
+    // runtime-shape change. The split config additionally carries `surfaces`
+    // (the validated binding map captured before foldSurfaceBindings drops the
+    // top-level key — GW.a.3b.2a, cortex#524); the inline config does not have
+    // a `surfaces:` key in its input, so `inline.surfaces` is undefined. The
+    // fold output (agents presence + flattened adapter arrays) is unchanged.
+    expect(split.config).toEqual(inline.config);
+    expect(split.inlineAgents).toEqual(inline.inlineAgents);
+    expect(split.principal).toEqual(inline.principal);
+    expect(split.stack).toEqual(inline.stack);
+    expect(split.policy).toEqual(inline.policy);
+    expect(split.bus).toEqual(inline.bus);
 
     // Spell out the resolved binding view per platform so a regression names
     // the exact platform that drifted. The effective view consumers read is

--- a/src/common/config/__tests__/surfaces-on-loaded-config.test.ts
+++ b/src/common/config/__tests__/surfaces-on-loaded-config.test.ts
@@ -1,0 +1,365 @@
+/**
+ * GW.a.3b.2a — `LoadedConfig.surfaces` exposure (cortex#524).
+ *
+ * `loadConfigWithAgents` must now populate `LoadedConfig.surfaces` with the
+ * validated `Surfaces` binding map when the input declared a `surfaces:` block
+ * (via `surfaces/surfaces.yaml` in a directory layout, or inline in a single
+ * file). Configs with NO surfaces yield `surfaces: undefined`.
+ *
+ * These tests prove:
+ *
+ *   (GW.3b.2a.1) a directory layout WITH surfaces.yaml → `LoadedConfig.surfaces`
+ *     carries the validated `Surfaces` object (binding contents correct); AND the
+ *     folded `agents[*].presence` shape is still correct (byte-identical fold —
+ *     the same tokens/guilds/channels are present as when the bindings lived
+ *     inline in per-stack presence).
+ *
+ *   (GW.3b.2a.2) a config WITHOUT surfaces (neither surfaces.yaml nor an inline
+ *     `surfaces:` key) → `LoadedConfig.surfaces === undefined` AND the
+ *     existing agents presence shape is unchanged.
+ *
+ *   (GW.3b.2a.3) a single-file cortex.yaml WITH an inline `surfaces:` block →
+ *     `LoadedConfig.surfaces` is populated (single-file path is symmetric with
+ *     the directory-layout path per CFG.a / CFG.c design).
+ *
+ *   (GW.3b.2a.4) the fold output is byte-identical regardless of whether
+ *     surfaces arrive via directory layout or inline. The presence/binding view
+ *     every existing consumer sees must not change.
+ */
+
+import { test, expect, describe, beforeEach, afterEach } from "bun:test";
+import { mkdirSync, writeFileSync, rmSync, existsSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { stringify } from "yaml";
+import { loadConfigWithAgents } from "../loader";
+
+let testDir: string;
+
+beforeEach(() => {
+  testDir = join(
+    tmpdir(),
+    `cortex-surfaces-loadedconfig-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(testDir, { recursive: true });
+});
+
+afterEach(() => {
+  if (testDir && existsSync(testDir)) {
+    rmSync(testDir, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Fixture constants
+// ---------------------------------------------------------------------------
+
+const DISCORD_BINDING = {
+  token: "fake-token-ivy",
+  guildId: "1487023327791808592",
+  agentChannelId: "1487029848164536361",
+  logChannelId: "1487029942129524786",
+};
+
+const SLACK_BINDING = {
+  botToken: "xoxb-fake-bot-token",
+  appToken: "xapp-fake-app-token",
+  workspaceId: "T0123456789",
+};
+
+const MATTERMOST_BINDING = {
+  apiUrl: "https://mm.example.com",
+  apiToken: "fake-mm-token",
+};
+
+/** The substrate blocks needed by cortex-shape loader (system.yaml layer). */
+function systemBlocks(): Record<string, unknown> {
+  return {
+    claude: { timeoutMs: 300000, asyncTimeoutMs: 900000, disallowedTools: ["Write"] },
+    execution: { default: "local", backends: [] },
+    attachments: {
+      enabled: true,
+      maxFileSizeBytes: 10485760,
+      maxTotalSizeBytes: 26214400,
+      maxAttachmentsPerMessage: 10,
+    },
+    paths: { publishedEventsDir: "/tmp/events/published", logDir: "/tmp/cortex/logs" },
+    nats: {
+      url: "nats://127.0.0.1:4222",
+      name: "cortex",
+      subjects: [],
+      identity: {
+        seedPath: "/tmp/cortex.nk",
+        publicKey: "UD7OGEVBNJAUQ57H5NHSPJZOKKOXOZ4DEUJVAO5URHBIUAVSVTJGL4QV",
+      },
+    },
+    bus: {
+      review: {
+        stream: { name: "CODE_REVIEW", maxAgeSeconds: 86400, maxBytes: 536870912 },
+        consumer: { maxDeliver: 5 },
+      },
+    },
+  };
+}
+
+/** Stack with NO surface bindings in per-stack presence (bindings live in surfaces.yaml). */
+function stackNoBindings(): Record<string, unknown> {
+  return {
+    principal: { id: "andreas", displayName: "Andreas" },
+    agents: [
+      {
+        id: "ivy",
+        displayName: "Ivy",
+        persona: "./personas/ivy.md",
+        roles: [],
+        trust: [],
+        presence: {},
+      },
+    ],
+  };
+}
+
+/** Stack with bindings INLINE in per-stack presence (the pre-CFG.c shape). */
+function stackInline(): Record<string, unknown> {
+  return {
+    principal: { id: "andreas", displayName: "Andreas" },
+    agents: [
+      {
+        id: "ivy",
+        displayName: "Ivy",
+        persona: "./personas/ivy.md",
+        roles: [],
+        trust: [],
+        presence: {
+          discord: { ...DISCORD_BINDING },
+          slack: { ...SLACK_BINDING },
+          mattermost: { ...MATTERMOST_BINDING },
+        },
+      },
+    ],
+  };
+}
+
+/** The `surfaces:` block carrying all three platform bindings. */
+function surfacesBlock(): Record<string, unknown> {
+  return {
+    surfaces: {
+      discord: [{ agent: "ivy", stack: "andreas/research", binding: { ...DISCORD_BINDING } }],
+      slack: [{ agent: "ivy", stack: "andreas/research", binding: { ...SLACK_BINDING } }],
+      mattermost: [
+        { agent: "ivy", stack: "andreas/research", binding: { ...MATTERMOST_BINDING } },
+      ],
+    },
+  };
+}
+
+/** Write a single-file cortex.yaml in `dir`, return its path. */
+function writeSingleFile(dir: string, config: Record<string, unknown>): string {
+  mkdirSync(dir, { recursive: true });
+  const path = join(dir, "cortex.yaml");
+  writeFileSync(path, stringify(config));
+  return path;
+}
+
+/**
+ * Write a directory layout: system/ + surfaces/ + stacks/. Returns the
+ * conventional `cortex.yaml` path (the directory marker is what selects the
+ * layout — cortex.yaml itself need not exist).
+ */
+function writeSurfacesLayout(
+  dir: string,
+  system: Record<string, unknown>,
+  surfaces: Record<string, unknown>,
+  stack: Record<string, unknown>,
+): string {
+  mkdirSync(join(dir, "system"), { recursive: true });
+  writeFileSync(join(dir, "system", "system.yaml"), stringify(system));
+  mkdirSync(join(dir, "surfaces"), { recursive: true });
+  writeFileSync(join(dir, "surfaces", "surfaces.yaml"), stringify(surfaces));
+  mkdirSync(join(dir, "stacks"), { recursive: true });
+  writeFileSync(join(dir, "stacks", "research.yaml"), stringify(stack));
+  return join(dir, "cortex.yaml");
+}
+
+// ---------------------------------------------------------------------------
+// GW.3b.2a.1 — directory layout WITH surfaces.yaml: LoadedConfig.surfaces
+// is populated AND the fold output is byte-identical
+// ---------------------------------------------------------------------------
+
+describe("GW.3b.2a.1 — directory layout with surfaces.yaml populates LoadedConfig.surfaces", () => {
+  test("LoadedConfig.surfaces carries the validated binding map (all three platforms)", () => {
+    const path = writeSurfacesLayout(
+      join(testDir, "layout"),
+      systemBlocks(),
+      surfacesBlock(),
+      stackNoBindings(),
+    );
+    const loaded = loadConfigWithAgents(path);
+
+    // surfaces must be defined and carry the validated binding map.
+    expect(loaded.surfaces).toBeDefined();
+    const surfaces = loaded.surfaces!;
+
+    // Discord binding contents correct.
+    expect(surfaces.discord).toHaveLength(1);
+    expect(surfaces.discord![0]!.agent).toBe("ivy");
+    expect(surfaces.discord![0]!.stack).toBe("andreas/research");
+    expect(surfaces.discord![0]!.binding.token).toBe(DISCORD_BINDING.token);
+    expect(surfaces.discord![0]!.binding.guildId).toBe(DISCORD_BINDING.guildId);
+    expect(surfaces.discord![0]!.binding.agentChannelId).toBe(DISCORD_BINDING.agentChannelId);
+    expect(surfaces.discord![0]!.binding.logChannelId).toBe(DISCORD_BINDING.logChannelId);
+
+    // Slack binding contents correct.
+    expect(surfaces.slack).toHaveLength(1);
+    expect(surfaces.slack![0]!.agent).toBe("ivy");
+    expect(surfaces.slack![0]!.binding.botToken).toBe(SLACK_BINDING.botToken);
+    expect(surfaces.slack![0]!.binding.appToken).toBe(SLACK_BINDING.appToken);
+    expect(surfaces.slack![0]!.binding.workspaceId).toBe(SLACK_BINDING.workspaceId);
+
+    // Mattermost binding contents correct.
+    expect(surfaces.mattermost).toHaveLength(1);
+    expect(surfaces.mattermost![0]!.agent).toBe("ivy");
+    expect(surfaces.mattermost![0]!.binding.apiUrl).toBe(MATTERMOST_BINDING.apiUrl);
+    expect(surfaces.mattermost![0]!.binding.apiToken).toBe(MATTERMOST_BINDING.apiToken);
+  });
+
+  test("fold output is byte-identical: agents[*].presence has the correct bindings", () => {
+    // Verify the fold is still correct: inlineAgents[0].presence must carry
+    // the bindings that surfaces.yaml declared, after the fold.
+    const path = writeSurfacesLayout(
+      join(testDir, "fold-check"),
+      systemBlocks(),
+      surfacesBlock(),
+      stackNoBindings(),
+    );
+    const loaded = loadConfigWithAgents(path);
+
+    // inlineAgents presence shape (the consumer cortex.ts reads).
+    const ivy = loaded.inlineAgents[0]!;
+    expect(ivy.presence.discord?.token).toBe(DISCORD_BINDING.token);
+    expect(ivy.presence.discord?.guildId).toBe(DISCORD_BINDING.guildId);
+    expect(ivy.presence.slack?.botToken).toBe(SLACK_BINDING.botToken);
+    expect(ivy.presence.mattermost?.apiToken).toBe(MATTERMOST_BINDING.apiToken);
+
+    // Flattened adapter arrays (the shape adapters read).
+    expect(loaded.config.discord[0]?.token).toBe(DISCORD_BINDING.token);
+    expect(loaded.config.discord[0]?.guildId).toBe(DISCORD_BINDING.guildId);
+    expect(loaded.config.slack[0]?.botToken).toBe(SLACK_BINDING.botToken);
+    expect(loaded.config.mattermost[0]?.apiToken).toBe(MATTERMOST_BINDING.apiToken);
+  });
+
+  test("fold byte-identity: presence/binding view equals the inline (pre-CFG.c) shape", () => {
+    // The fold-then-expose path must produce the SAME presence/binding view as
+    // a config that carries bindings directly in per-stack presence (inline).
+    // This proves byte-identity of the fold output across both ingestion paths.
+    const inlinePath = writeSingleFile(join(testDir, "inline"), {
+      ...systemBlocks(),
+      ...stackInline(),
+    });
+    const splitPath = writeSurfacesLayout(
+      join(testDir, "split"),
+      systemBlocks(),
+      surfacesBlock(),
+      stackNoBindings(),
+    );
+
+    const inline = loadConfigWithAgents(inlinePath);
+    const split = loadConfigWithAgents(splitPath);
+
+    // The fold-output fields (the only ones downstream consumers read) must
+    // be equal. The split config additionally carries `surfaces` (the inline
+    // config does not, since it has no `surfaces:` key) — that is the ONLY
+    // difference, and it is intentional (GW.a.3b.2a exposes the binding map).
+    expect(split.config).toEqual(inline.config);
+    expect(split.inlineAgents).toEqual(inline.inlineAgents);
+    expect(split.principal).toEqual(inline.principal);
+    expect(split.stack).toEqual(inline.stack);
+    expect(split.policy).toEqual(inline.policy);
+    expect(split.bus).toEqual(inline.bus);
+
+    // The split config has surfaces; the inline config does not.
+    expect(split.surfaces).toBeDefined();
+    expect(inline.surfaces).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GW.3b.2a.2 — config WITHOUT surfaces: surfaces === undefined, fold unchanged
+// ---------------------------------------------------------------------------
+
+describe("GW.3b.2a.2 — config without surfaces: LoadedConfig.surfaces is undefined", () => {
+  test("single-file inline config (no surfaces key): surfaces is undefined", () => {
+    const path = writeSingleFile(join(testDir, "no-surfaces"), {
+      ...systemBlocks(),
+      ...stackInline(),
+    });
+    const loaded = loadConfigWithAgents(path);
+    expect(loaded.surfaces).toBeUndefined();
+  });
+
+  test("directory layout with no surfaces.yaml: surfaces is undefined", () => {
+    // Write a layout without surfaces/ directory.
+    const dir = join(testDir, "no-surfaces-layout");
+    mkdirSync(join(dir, "system"), { recursive: true });
+    writeFileSync(
+      join(dir, "system", "system.yaml"),
+      stringify({ ...systemBlocks(), ...stackInline() }),
+    );
+    const loaded = loadConfigWithAgents(join(dir, "cortex.yaml"));
+    expect(loaded.surfaces).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GW.3b.2a.3 — single-file cortex.yaml WITH inline surfaces: block:
+// LoadedConfig.surfaces is populated (single-file path is symmetric)
+// ---------------------------------------------------------------------------
+
+describe("GW.3b.2a.3 — single-file cortex.yaml with inline surfaces: block", () => {
+  test("inline surfaces block in single file populates LoadedConfig.surfaces", () => {
+    // A single cortex.yaml may carry an inline `surfaces:` block. The
+    // single-file fallback path must be symmetric with the directory-layout path.
+    const path = writeSingleFile(join(testDir, "inline-surfaces"), {
+      ...systemBlocks(),
+      ...stackNoBindings(),
+      ...surfacesBlock(),
+    });
+    const loaded = loadConfigWithAgents(path);
+
+    expect(loaded.surfaces).toBeDefined();
+    expect(loaded.surfaces!.discord).toHaveLength(1);
+    expect(loaded.surfaces!.discord![0]!.binding.token).toBe(DISCORD_BINDING.token);
+    expect(loaded.surfaces!.slack).toHaveLength(1);
+    expect(loaded.surfaces!.slack![0]!.binding.botToken).toBe(SLACK_BINDING.botToken);
+    expect(loaded.surfaces!.mattermost).toHaveLength(1);
+    expect(loaded.surfaces!.mattermost![0]!.binding.apiToken).toBe(MATTERMOST_BINDING.apiToken);
+
+    // Fold is still correct: bindings folded into presence.
+    expect(loaded.inlineAgents[0]!.presence.discord?.token).toBe(DISCORD_BINDING.token);
+    expect(loaded.config.discord[0]?.token).toBe(DISCORD_BINDING.token);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GW.3b.2a.4 — legacy bot.yaml input: surfaces is undefined (not applicable)
+// ---------------------------------------------------------------------------
+
+describe("GW.3b.2a.4 — legacy bot.yaml input: surfaces is always undefined", () => {
+  test("legacy bot.yaml (no principal/agents, no surfaces): surfaces is undefined", () => {
+    // Legacy input has no principal: / agents: blocks — takes the legacy path.
+    // surfaces: would be meaningless on legacy input; must yield undefined.
+    const dir = join(testDir, "legacy");
+    mkdirSync(dir, { recursive: true });
+    const path = join(dir, "bot.yaml");
+    writeFileSync(
+      path,
+      stringify({
+        agent: { name: "test-bot", displayName: "TestBot" },
+        claude: { timeoutMs: 120000 },
+        networksDir: "./networks",
+      }),
+    );
+    const loaded = loadConfigWithAgents(path);
+    expect(loaded.surfaces).toBeUndefined();
+  });
+});

--- a/src/common/config/loader.ts
+++ b/src/common/config/loader.ts
@@ -22,7 +22,7 @@ import {
   type SlackPresence,
   type StackConfig,
 } from "../types/cortex-config";
-import { foldSurfaceBindings } from "../types/surfaces";
+import { foldSurfaceBindings, SurfacesSchema, type Surfaces } from "../types/surfaces";
 
 /**
  * Hardening cap on a single fragment file's size. Echo M3 on cortex#62 —
@@ -119,6 +119,13 @@ export interface LoadedConfig {
    * undefined and the boot path uses hardcoded defaults.
    */
   bus?: BusConfig;
+  /**
+   * Optional surface binding map (IAW GW, cortex#524). Populated only when
+   * the input declared a `surfaces:` block / surfaces.yaml layer. Consumed
+   * by the runtime gateway bootstrap (`maybeCreateSurfaceGateway`). Legacy
+   * bot.yaml input yields undefined.
+   */
+  surfaces?: Surfaces;
 }
 
 /**
@@ -340,35 +347,39 @@ function listLayerFiles(dir: string): string[] {
 }
 
 /**
- * CFG.a.1 — compose the raw config object from a directory layout, or fall
- * back to the single file (CFG.a.2).
+ * GW.a.3b.2a surfaces-aware variant of the composer (cortex#524).
  *
- * `configPath` is the path the caller already passes (e.g. a `cortex.yaml`
- * file). Layout detection keys off the file's directory: if
- * `${dir}/system/system.yaml` exists, the directory layout is used; otherwise
- * the single file at `configPath` is read verbatim.
+ * Seam choice: option (b) — this new `composeRawConfigWithSurfaces` function
+ * captures the validated `Surfaces` object BEFORE `foldSurfaceBindings` drops
+ * the top-level `surfaces:` key, and returns it alongside the folded `raw`.
+ * `composeRawConfig` delegates here and returns only `.raw`, so its existing
+ * signature and every caller (composer tests, external consumers) are
+ * untouched. `loadConfigWithAgents` calls this variant directly and threads
+ * `.surfaces` through to `LoadedConfig.surfaces`.
  *
- * Returns the merged `raw` object — the exact shape `parseYaml(cortex.yaml)`
- * yields — so the existing `loadConfigWithAgents` parse/build is unchanged.
+ * Caller blast-radius: zero — `composeRawConfig`'s signature is unchanged.
+ *
+ * HARD INVARIANT: the `.raw` returned is byte-identical to what
+ * `composeRawConfig` returned pre-GW.a.3b.2a. The fold is unchanged; the only
+ * addition is the separately captured `surfaces` value.
  */
-export function composeRawConfig(configPath: string): Record<string, unknown> {
-  // Echo nit #2 on cortex#525 — use the fail-loud `expandTilde` helper instead
-  // of the silent `.replace(/^~/, … ?? "~")` form (which left a literal `~`
-  // when $HOME was unset, then failed obscurely deep in `readFileSync`).
+export function composeRawConfigWithSurfaces(configPath: string): {
+  raw: Record<string, unknown>;
+  surfaces: Surfaces | undefined;
+} {
   const expandedPath = expandTilde(configPath);
   const configDir = dirname(expandedPath);
   const markerPath = join(configDir, LAYOUT_MARKER);
 
   // CFG.a.3 resolution rule: directory layout present → use it; else fallback.
   if (!existsSync(markerPath)) {
-    // CFG.a.2 — transitional single-file fallback. Identical to pre-CFG.a,
-    // except a single file MAY also carry an inline `surfaces:` block — fold
-    // it the same way so the two ingestion paths stay symmetric (CFG.c). A
-    // file with no `surfaces:` key (the three live deployments) is returned
-    // untouched by the fold.
+    // CFG.a.2 — single-file fallback. Capture any `surfaces:` block BEFORE
+    // the fold so `LoadedConfig.surfaces` is populated symmetrically with the
+    // directory-layout path (CFG.c design: both ingestion paths are symmetric).
     const content = readFileSync(expandedPath, "utf-8");
     const single = (parseYaml(content) ?? {}) as Record<string, unknown>;
-    return foldSurfaceBindings(single);
+    const surfaces = parseSurfaces(single.surfaces);
+    return { raw: foldSurfaceBindings(single), surfaces };
   }
 
   // CFG.a.1 — directory layout. Fixed precedence: system → network → surfaces
@@ -382,16 +393,47 @@ export function composeRawConfig(configPath: string): Record<string, unknown> {
     ...listLayerFiles(join(configDir, "stacks")),
   ];
 
-  let raw: Record<string, unknown> = {};
+  let merged: Record<string, unknown> = {};
   for (const file of layerFiles) {
-    raw = deepMerge(raw, readLayerFile(file));
+    merged = deepMerge(merged, readLayerFile(file));
   }
-  // CFG.c — fold any `surfaces:` block into `agents[*].presence.{platform}`
-  // and drop the top-level `surfaces:` key, so the result is the exact shape
-  // the inline (pre-CFG.c) config produced. `LoadedConfig` is unchanged. A
-  // layout with no surfaces.yaml leaves `raw` without a `surfaces:` key, so the
-  // fold is a no-op and per-stack presence is the fallback.
-  return foldSurfaceBindings(raw);
+  // Capture surfaces BEFORE the fold drops the `surfaces:` key. The fold
+  // itself (`foldSurfaceBindings`) already calls `SurfacesSchema.parse`
+  // internally — `parseSurfaces` re-uses the same schema so the parse is
+  // redundant but cheap (no I/O). Both share the same validated result shape.
+  const surfaces = parseSurfaces(merged.surfaces);
+  return { raw: foldSurfaceBindings(merged), surfaces };
+}
+
+/**
+ * Parse the raw `surfaces:` value against `SurfacesSchema`. Returns `undefined`
+ * when the value is absent or null (no surfaces declared). Throws on malformed
+ * input — the caller (`composeRawConfigWithSurfaces`) lets this propagate so
+ * a bad surfaces.yaml fails loudly at load, matching `foldSurfaceBindings`'s
+ * own validation contract.
+ */
+function parseSurfaces(value: unknown): Surfaces | undefined {
+  if (value === undefined || value === null) return undefined;
+  return SurfacesSchema.parse(value);
+}
+
+/**
+ * CFG.a.1 — compose the raw config object from a directory layout, or fall
+ * back to the single file (CFG.a.2).
+ *
+ * `configPath` is the path the caller already passes (e.g. a `cortex.yaml`
+ * file). Layout detection keys off the file's directory: if
+ * `${dir}/system/system.yaml` exists, the directory layout is used; otherwise
+ * the single file at `configPath` is read verbatim.
+ *
+ * Returns the merged `raw` object — the exact shape `parseYaml(cortex.yaml)`
+ * yields — so the existing `loadConfigWithAgents` parse/build is unchanged.
+ *
+ * Delegates to `composeRawConfigWithSurfaces` and returns only `.raw`.
+ * Callers that need `LoadedConfig.surfaces` should use `loadConfigWithAgents`.
+ */
+export function composeRawConfig(configPath: string): Record<string, unknown> {
+  return composeRawConfigWithSurfaces(configPath).raw;
 }
 
 /**
@@ -421,14 +463,16 @@ export function composeRawConfig(configPath: string): Record<string, unknown> {
  */
 export function loadConfigWithAgents(path: string): LoadedConfig {
   // Echo nit #2 on cortex#525 — expand the tilde ONCE here via the fail-loud
-  // helper, then hand the already-expanded path to `composeRawConfig`
+  // helper, then hand the already-expanded path to `composeRawConfigWithSurfaces`
   // (`expandTilde` is idempotent on an absolute path), removing the redundant
   // double expansion that previously happened in both functions.
   const expandedPath = expandTilde(path);
   const configDir = dirname(expandedPath);
 
-  // CFG.a.1/CFG.a.2 — compose from directory layout or fall back to single file.
-  const raw = composeRawConfig(expandedPath);
+  // CFG.a.1/CFG.a.2 — compose from directory layout or fall back to single
+  // file. Capture the validated `Surfaces` binding map before the fold drops
+  // the top-level `surfaces:` key (GW.a.3b.2a, cortex#524).
+  const { raw, surfaces } = composeRawConfigWithSurfaces(expandedPath);
 
   // Networks load against the on-disk path regardless of legacy/cortex shape —
   // both shapes share the same networks/ contract (G-500).
@@ -448,7 +492,7 @@ export function loadConfigWithAgents(path: string): LoadedConfig {
   const networks = loadNetworkFiles(networksDir, explicitNetworksDir);
 
   if (isCortexShape(raw)) {
-    return loadCortexShape(raw, networks);
+    return loadCortexShape(raw, networks, surfaces);
   }
 
   // ---------------------------------------------------------------------
@@ -566,6 +610,7 @@ function detectLegacyAuthorisationFields(raw: Record<string, unknown>): string[]
 function loadCortexShape(
   raw: Record<string, unknown>,
   networks: NetworkFile[],
+  surfaces: Surfaces | undefined,
 ): LoadedConfig {
   // v3.0.0 BREAKING (manifest PR-11) — cortex.yaml requires the canonical
   // `principal:` key. Pass the raw config straight to the schema; the
@@ -680,6 +725,11 @@ function loadCortexShape(
     // cross-references + uniqueness, so this is a pure carry-through.
     ...(cortexConfig.policy !== undefined && { policy: cortexConfig.policy }),
     bus: cortexConfig.bus,
+    // IAW GW, cortex#524 — surface the validated `surfaces:` binding map to
+    // the boot path. Captured before foldSurfaceBindings drops the top-level
+    // key; undefined when the input declared no surfaces block. The gateway
+    // bootstrap (`maybeCreateSurfaceGateway`) reads this at boot.
+    ...(surfaces !== undefined && { surfaces }),
   };
 }
 

--- a/src/common/config/loader.ts
+++ b/src/common/config/loader.ts
@@ -363,7 +363,10 @@ function listLayerFiles(dir: string): string[] {
  * `composeRawConfig` returned pre-GW.a.3b.2a. The fold is unchanged; the only
  * addition is the separately captured `surfaces` value.
  */
-export function composeRawConfigWithSurfaces(configPath: string): {
+// Not exported — `loadConfigWithAgents` is the public entry for the `surfaces`
+// field; `composeRawConfig` (the delegating wrapper below) stays the public
+// raw-compose API for its existing callers.
+function composeRawConfigWithSurfaces(configPath: string): {
   raw: Record<string, unknown>;
   surfaces: Surfaces | undefined;
 } {


### PR DESCRIPTION
Unblocks the runtime gateway: `maybeCreateSurfaceGateway` (a.3b.1) needs the `Surfaces` binding map at boot, but `composeRawConfig` folds surfaces into presence then **drops** the `surfaces:` key — so `LoadedConfig` didn't retain it.

## What
- **`LoadedConfig.surfaces?: Surfaces`** — mirrors the `stack?`/`policy?`/`bus?` optional-cortex-field pattern; populated only for cortex-shape input with surfaces; legacy → undefined.
- **Seam (option b, zero blast-radius):** new `composeRawConfigWithSurfaces` captures the validated `Surfaces` **before** the fold drops the key, returns `{ raw, surfaces }`. `composeRawConfig` delegates (`return …​.raw`) so its signature + all 12+ callers are **untouched**. `loadConfigWithAgents` threads it through.

## Byte-identity invariant — HELD
The folded `raw` is byte-identical to before — proven by the **full existing CFG/fold suite (405 tests) still green**. `parseSurfaces` fails loud on malformed surfaces (matches `foldSurfaceBindings`).

## ⚠️ One existing-test change (please scrutinize)
`surfaces-layer.test.ts`: the old `expect(split).toEqual(inline)` (whole-LoadedConfig) **can't hold now** — `split` (surfaces.yaml layout) carries `.surfaces`; `inline` (presence bindings) has `.surfaces === undefined` — *intentional, by input shape*. Narrowed to compare all 6 fold-output fields (config/inlineAgents/principal/stack/policy/bus = everything consumers read); the new `surfaces-on-loaded-config.test.ts` covers `.surfaces` directly. Covers everything that should match; hides nothing.

## Gates
`tsc` 0 · `eslint --quiet src/common/` 0 · `bun test src/common/config src/common/types/__tests__` **412/412** · whole-tree vocab gate PASS.

Refs #524 · part of #110.

🤖 Generated with [Claude Code](https://claude.com/claude-code)