### PR TITLE
feat(mc): G-1113.C.6 — PR + branch chips on task rows

### DIFF
--- a/src/surface/mc/__tests__/git-links.test.ts
+++ b/src/surface/mc/__tests__/git-links.test.ts
@@ -1,0 +1,61 @@
+/**
+ * G-1113.C.6 — task→Git-link projection + batch endpoint.
+ */
+import { describe, it, expect, afterEach } from "bun:test";
+import { join } from "path";
+import { tmpdir } from "os";
+import { rmSync, existsSync } from "fs";
+import { initDatabase } from "../db/init";
+import { upsertRepository, upsertBranch, upsertPullRequest } from "../db/git-objects";
+import { getGitLinks, handleListGitLinks } from "../api/git-links";
+import type { GitRepository, GitBranch, PullRequest } from "../types";
+
+const RID = "github:o/r";
+const repo: GitRepository = { id: RID, provider: "github", owner: "o", name: "r", url: "https://github.com/o/r", defaultBranch: null };
+const src: GitBranch = { id: `${RID}@feat/x`, repositoryId: RID, name: "feat/x", baseRef: null, headSha: "abc1234", provider: "github", externalId: null, url: "https://github.com/o/r/tree/feat/x" };
+const tgt: GitBranch = { id: `${RID}@main`, repositoryId: RID, name: "main", baseRef: null, headSha: null, provider: "github", externalId: null, url: "https://github.com/o/r/tree/main" };
+const pr: PullRequest = {
+  id: `${RID}#7`, workItemId: null, repositoryId: RID, provider: "github", providerNativeType: "pull_request",
+  externalId: "o/r#7", numberOrKey: "7", title: "T", sourceBranch: "feat/x", targetBranch: "main",
+  url: "https://github.com/o/r/pull/7", state: "open", reviewState: "none",
+};
+
+describe("git-links projection (C.6)", () => {
+  const paths: string[] = [];
+  afterEach(() => { for (const p of paths) if (existsSync(p)) rmSync(p); paths.length = 0; });
+  function freshDb() {
+    const p = join(tmpdir(), `git-links-${Date.now()}-${Math.random().toString(36).slice(2)}.db`);
+    paths.push(p);
+    const db = initDatabase(p);
+    upsertRepository(db, repo); upsertBranch(db, src); upsertBranch(db, tgt); upsertPullRequest(db, pr);
+    return db;
+  }
+
+  it("getGitLinks resolves a ref to its PR + source/target branches", () => {
+    const db = freshDb();
+    const links = getGitLinks(db, ["o/r#7"]);
+    expect(links["o/r#7"]).toEqual({ pullRequest: pr, sourceBranch: src, targetBranch: tgt });
+  });
+
+  it("omits refs with no linked PR; dedupes", () => {
+    const db = freshDb();
+    const links = getGitLinks(db, ["o/r#7", "o/r#999", "o/r#7"]);
+    expect(Object.keys(links)).toEqual(["o/r#7"]);
+  });
+
+  it("handleListGitLinks returns { links } keyed by ref from ?refs=", async () => {
+    const db = freshDb();
+    const res = handleListGitLinks(db, new URL("http://x/api/git/links?refs=o%2Fr%237,o%2Fr%23999"));
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { links: Record<string, unknown> };
+    expect(Object.keys(body.links)).toEqual(["o/r#7"]);
+  });
+
+  it("empty/missing refs → empty map", async () => {
+    const db = freshDb();
+    expect(getGitLinks(db, [])).toEqual({});
+    const res = handleListGitLinks(db, new URL("http://x/api/git/links"));
+    const body = (await res.json()) as { links: Record<string, unknown> };
+    expect(body.links).toEqual({});
+  });
+});

--- a/src/surface/mc/api/git-links.ts
+++ b/src/surface/mc/api/git-links.ts
@@ -17,8 +17,12 @@ export interface GitLink {
   targetBranch: GitBranch | null;
 }
 
-/** Bound the batch — task lists are paged; this caps a pathological query string. */
-const MAX_REFS = 200;
+/**
+ * Bound the batch. Matches the task feed's page size (TASKS_QUERY_LIMIT=500 in
+ * db/tasks.ts) so every visible row can resolve its chips — while still capping
+ * a pathological query string. (If the page limit grows, raise this with it.)
+ */
+const MAX_REFS = 500;
 
 /**
  * Resolve each external ref (`owner/repo#N`) to its {@link GitLink}, or omit it

--- a/src/surface/mc/api/git-links.ts
+++ b/src/surface/mc/api/git-links.ts
@@ -1,0 +1,58 @@
+/**
+ * G-1113.C.6 — task → Git-model link projection + batch endpoint.
+ *
+ * The dashboard renders first-class PR + branch chips on task rows. A
+ * github-sourced task links to its PR by ref (the task's `source_external_id`
+ * equals the PR's `externalId`; `PullRequest.workItemId` is wired in Phase D).
+ * This serves a batch lookup so the task table fetches all visible rows' links
+ * in one call (no N+1).
+ */
+import type { Database } from "bun:sqlite";
+import type { PullRequest, GitBranch } from "../types";
+import { getPullRequestByExternalId, getBranch } from "../db/git-objects";
+
+export interface GitLink {
+  pullRequest: PullRequest;
+  sourceBranch: GitBranch | null;
+  targetBranch: GitBranch | null;
+}
+
+/** Bound the batch — task lists are paged; this caps a pathological query string. */
+const MAX_REFS = 200;
+
+/**
+ * Resolve each external ref (`owner/repo#N`) to its {@link GitLink}, or omit it
+ * when no PR is linked. Branch ids follow the C.5 ingest convention
+ * `${repositoryId}@${branchName}`.
+ */
+export function getGitLinks(db: Database, externalIds: string[]): Record<string, GitLink> {
+  const out: Record<string, GitLink> = {};
+  const seen = new Set<string>();
+  for (const ref of externalIds) {
+    if (seen.has(ref) || ref.length === 0) continue;
+    seen.add(ref);
+    const pr = getPullRequestByExternalId(db, ref);
+    if (!pr) continue;
+    out[ref] = {
+      pullRequest: pr,
+      sourceBranch: getBranch(db, `${pr.repositoryId}@${pr.sourceBranch}`),
+      targetBranch: getBranch(db, `${pr.repositoryId}@${pr.targetBranch}`),
+    };
+  }
+  return out;
+}
+
+/** GET /api/git/links?refs=owner/repo%23N,owner/repo%23M — batch link lookup. */
+export function handleListGitLinks(db: Database, url: URL): Response {
+  const raw = url.searchParams.get("refs") ?? "";
+  const refs = raw
+    .split(",")
+    .map((r) => r.trim())
+    .filter((r) => r.length > 0)
+    .slice(0, MAX_REFS);
+  const links = getGitLinks(db, refs);
+  return new Response(JSON.stringify({ links }), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}

--- a/src/surface/mc/dashboard-v2/app.tsx
+++ b/src/surface/mc/dashboard-v2/app.tsx
@@ -23,6 +23,7 @@ import { SourcesView } from "./components/sources-view";
 import { Toast } from "./components/toast";
 import { useFocusArea } from "./hooks/use-focus-area";
 import { useTasks } from "./hooks/use-tasks";
+import { useGitLinks } from "./hooks/use-git-links";
 import { useTheme } from "./hooks/use-theme";
 import { useWebSocket } from "./hooks/use-websocket";
 import { ApiFailure, postJson } from "./lib/api";
@@ -60,6 +61,17 @@ export function App() {
   const tasks = useTasks(ws);
   const working = useWorkingAgents(ws);
   const iterations = useIterations(ws);
+
+  // G-1113.C.6 — batch-fetch PR/branch links for the visible github-sourced
+  // tasks so each row can render first-class chips.
+  const gitRefs = useMemo(
+    () =>
+      tasks.visible
+        .filter((t) => t.source.provider === "github" && t.source.externalId)
+        .map((t) => t.source.externalId as string),
+    [tasks.visible]
+  );
+  const gitLinks = useGitLinks(gitRefs);
   const metrics = useMetrics(ws);
   const [focusSelectedIdx, setFocusSelectedIdx] = useState<number>(-1);
 
@@ -280,6 +292,7 @@ export function App() {
               visible={tasks.visible}
               loaded={tasks.loaded}
               error={tasks.error}
+              gitLinks={gitLinks}
               filters={tasks.filters}
               sort={tasks.sort}
               onTogglePriority={tasks.togglePriority}

--- a/src/surface/mc/dashboard-v2/components/git-chips.tsx
+++ b/src/surface/mc/dashboard-v2/components/git-chips.tsx
@@ -1,0 +1,47 @@
+/**
+ * G-1113.C.6 — first-class PR + branch chips for a task row.
+ *
+ * Fed by a {@link GitLink} (the task's linked PR + its source/target branches,
+ * matched by ref — see api/git-links). The PR chip is state-coloured and links
+ * out; review state shows on hover (checks are deferred to C.5b, so the hover
+ * surfaces review state only for now). Branch chips show source → target.
+ */
+import type { GitLink } from "../../api/git-links";
+
+const PR_STATE_KIND: Record<string, string> = {
+  open: "pr-open",
+  draft: "pr-draft",
+  merged: "pr-merged",
+  closed: "pr-closed",
+};
+
+export interface GitChipsProps {
+  link: GitLink;
+}
+
+export function GitChips({ link }: GitChipsProps) {
+  const { pullRequest: pr, sourceBranch } = link;
+  const reviewLabel = pr.reviewState === "none" ? "no review yet" : pr.reviewState.replace(/_/g, " ");
+  return (
+    <span className="git-chips">
+      <a
+        className={`git-chip pr ${PR_STATE_KIND[pr.state] ?? ""}`}
+        href={pr.url}
+        target="_blank"
+        rel="noopener noreferrer"
+        title={`Pull request #${pr.numberOrKey} · ${pr.state} · review: ${reviewLabel}`}
+      >
+        #{pr.numberOrKey} {pr.state}
+      </a>
+      <span
+        className="git-chip branch"
+        title={
+          `${pr.sourceBranch} → ${pr.targetBranch}` +
+          (sourceBranch?.headSha ? ` · ${sourceBranch.headSha.slice(0, 7)}` : "")
+        }
+      >
+        {pr.sourceBranch} → {pr.targetBranch}
+      </span>
+    </span>
+  );
+}

--- a/src/surface/mc/dashboard-v2/components/git-chips.tsx
+++ b/src/surface/mc/dashboard-v2/components/git-chips.tsx
@@ -25,7 +25,7 @@ export function GitChips({ link }: GitChipsProps) {
   return (
     <span className="git-chips">
       <a
-        className={`git-chip pr ${PR_STATE_KIND[pr.state] ?? ""}`}
+        className={`git-chip pr ${PR_STATE_KIND[pr.state] ?? "pr-unknown"}`}
         href={pr.url}
         target="_blank"
         rel="noopener noreferrer"

--- a/src/surface/mc/dashboard-v2/components/task-table.tsx
+++ b/src/surface/mc/dashboard-v2/components/task-table.tsx
@@ -20,6 +20,8 @@ import { AddTaskModal } from "./add-task-modal";
 import { DispatchButton } from "./dispatch-button";
 import { Pill } from "./pill";
 import { ProviderBadge } from "./provider-badge";
+import { GitChips } from "./git-chips";
+import type { GitLink } from "../../api/git-links";
 import { DEFAULT_AGENT_DISPLAY_NAME } from "../lib/agent-defaults";
 import {
   chipPillKind,
@@ -123,6 +125,13 @@ export interface TaskTableProps {
   dispatchingTaskIds?: ReadonlySet<string>;
   /** Display name for the agent that will receive the dispatch. Default "Default Agent". */
   dispatchAgentLabel?: string;
+
+  /**
+   * G-1113.C.6 — task → PR/branch links keyed by the task's source ref
+   * (`task.source.externalId`). Rows with a match render PR + branch chips.
+   * Optional; absent map = no chips (table works unchanged).
+   */
+  gitLinks?: Record<string, GitLink>;
 }
 
 export function TaskTable(props: TaskTableProps) {
@@ -136,6 +145,7 @@ export function TaskTable(props: TaskTableProps) {
     onDispatch,
     dispatchingTaskIds,
     dispatchAgentLabel,
+    gitLinks,
   } = props;
 
   const [focusedRowIdx, setFocusedRowIdx] = useState(-1);
@@ -279,6 +289,7 @@ export function TaskTable(props: TaskTableProps) {
                 {...(onDispatch ? { onDispatch } : {})}
                 dispatching={dispatchingTaskIds?.has(t.id) ?? false}
                 dispatchAgentLabel={dispatchAgentLabel ?? DEFAULT_AGENT_DISPLAY_NAME}
+                gitLink={t.source.externalId ? gitLinks?.[t.source.externalId] : undefined}
               />
             ))}
           </tbody>
@@ -320,6 +331,7 @@ function TaskRow({
   onDispatch,
   dispatching,
   dispatchAgentLabel,
+  gitLink,
 }: {
   task: TaskListItem;
   focused: boolean;
@@ -328,6 +340,7 @@ function TaskRow({
   onDispatch?: (task: TaskListItem) => void;
   dispatching: boolean;
   dispatchAgentLabel: string;
+  gitLink?: GitLink;
 }) {
   const closed = task.status === "done" || task.status === "cancelled";
   const cls = [
@@ -366,6 +379,7 @@ function TaskRow({
       </td>
       <td className="title">
         <ProviderBadge provider={task.source.provider} />
+        {gitLink ? <GitChips link={gitLink} /> : null}
         <span className="title-text">{task.title}</span>
       </td>
       <td className="iteration">

--- a/src/surface/mc/dashboard-v2/hooks/use-git-links.ts
+++ b/src/surface/mc/dashboard-v2/hooks/use-git-links.ts
@@ -1,0 +1,46 @@
+/**
+ * G-1113.C.6 — batch-fetch task → PR/branch links for the visible task rows.
+ *
+ * Given the github-sourced refs (`owner/repo#N`) of the visible tasks, fetches
+ * `GET /api/git/links?refs=…` once and returns a map keyed by ref. Best-effort:
+ * on any failure the map is empty and chips simply don't render (the task table
+ * stays fully functional). Re-fetches when the ref set changes.
+ */
+import { useEffect, useState } from "react";
+import { getJson } from "../lib/api";
+import type { GitLink } from "../../api/git-links";
+
+interface GitLinksResponse {
+  links: Record<string, GitLink>;
+}
+
+export function useGitLinks(refs: readonly string[]): Record<string, GitLink> {
+  const [links, setLinks] = useState<Record<string, GitLink>>({});
+  // Stable dependency: the sorted, de-duped ref set as one string.
+  const key = Array.from(new Set(refs)).sort().join(",");
+
+  useEffect(() => {
+    if (key.length === 0) {
+      setLinks({});
+      return;
+    }
+    let cancelled = false;
+    void (async () => {
+      try {
+        const res = await getJson<GitLinksResponse>(
+          `/api/git/links?refs=${encodeURIComponent(key)}`
+        );
+        if (!cancelled) setLinks(res.links ?? {});
+      } catch (_err) {
+        // Best-effort surface: a links fetch failure must not break the task
+        // table. Clear the map so stale chips don't linger; no user-facing error.
+        if (!cancelled) setLinks({});
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [key]);
+
+  return links;
+}

--- a/src/surface/mc/dashboard-v2/styles/global.css
+++ b/src/surface/mc/dashboard-v2/styles/global.css
@@ -316,6 +316,21 @@ html, body {
 .provider-badge .dot.provider-custom { background: var(--fg-faint); }
 .title-text { vertical-align: baseline; }
 
+/* G-1113.C.6 — first-class PR + branch chips on task rows */
+.git-chips { display: inline-flex; align-items: center; gap: 6px; margin-right: 8px; }
+.git-chip {
+  font-size: 10px; line-height: 1; white-space: nowrap;
+  padding: 2px 6px; border-radius: 6px;
+  border: 1px solid var(--line-soft); color: var(--fg-dim);
+  background: var(--panel-2); text-decoration: none;
+}
+.git-chip.pr:hover { border-color: var(--line); color: var(--fg); }
+.git-chip.pr.pr-open { color: var(--a); border-color: color-mix(in oklch, var(--a) 30%, transparent); background: color-mix(in oklch, var(--a) 10%, transparent); }
+.git-chip.pr.pr-merged { color: var(--d); border-color: color-mix(in oklch, var(--d) 30%, transparent); background: color-mix(in oklch, var(--d) 10%, transparent); }
+.git-chip.pr.pr-closed { color: var(--h); border-color: color-mix(in oklch, var(--h) 30%, transparent); background: color-mix(in oklch, var(--h) 10%, transparent); }
+.git-chip.pr.pr-draft { color: var(--fg-faint); }
+.git-chip.branch { font-family: var(--mono); color: var(--fg-faint); }
+
 /* Sources view */
 .sources-view .sources-list { list-style: none; margin: 8px 0 0; padding: 0; }
 .sources-view .source-row {

--- a/src/surface/mc/dashboard-v2/styles/global.css
+++ b/src/surface/mc/dashboard-v2/styles/global.css
@@ -329,7 +329,11 @@ html, body {
 .git-chip.pr.pr-merged { color: var(--d); border-color: color-mix(in oklch, var(--d) 30%, transparent); background: color-mix(in oklch, var(--d) 10%, transparent); }
 .git-chip.pr.pr-closed { color: var(--h); border-color: color-mix(in oklch, var(--h) 30%, transparent); background: color-mix(in oklch, var(--h) 10%, transparent); }
 .git-chip.pr.pr-draft { color: var(--fg-faint); }
-.git-chip.branch { font-family: var(--mono); color: var(--fg-faint); }
+.git-chip.branch {
+  font-family: var(--mono); color: var(--fg-faint);
+  display: inline-block; max-width: 240px; overflow: hidden;
+  text-overflow: ellipsis; vertical-align: bottom;
+}
 
 /* Sources view */
 .sources-view .sources-list { list-style: none; margin: 8px 0 0; padding: 0; }

--- a/src/surface/mc/db/git-objects.ts
+++ b/src/surface/mc/db/git-objects.ts
@@ -324,6 +324,12 @@ export function getPullRequest(db: Database, id: string): PullRequest | null {
  * `owner/repo#N`). This is how a github-sourced task links to its PR until
  * Phase D wires `PullRequest.workItemId`: the task's `source_external_id` (the
  * canonical ref) equals the PR's `externalId`.
+ *
+ * Assumes externalId is unique per PR — true today because the only writer
+ * (adapters/github ingest) derives both `id` and `externalId` from the same
+ * `owner/repo#N`, a bijection. There's no UNIQUE constraint, so if a second
+ * provider ever reuses the `owner/repo#N` shape, add an `AND provider = ?`
+ * filter before relying on this. `LIMIT 1` is the safe-today fallback.
  */
 export function getPullRequestByExternalId(db: Database, externalId: string): PullRequest | null {
   const row = db

--- a/src/surface/mc/db/git-objects.ts
+++ b/src/surface/mc/db/git-objects.ts
@@ -319,6 +319,19 @@ export function getPullRequest(db: Database, id: string): PullRequest | null {
   return row ? rowToPullRequest(row) : null;
 }
 
+/**
+ * G-1113.C.6 — look up a PR by its provider-native `externalId` (e.g.
+ * `owner/repo#N`). This is how a github-sourced task links to its PR until
+ * Phase D wires `PullRequest.workItemId`: the task's `source_external_id` (the
+ * canonical ref) equals the PR's `externalId`.
+ */
+export function getPullRequestByExternalId(db: Database, externalId: string): PullRequest | null {
+  const row = db
+    .query(`SELECT * FROM pull_requests WHERE external_id = ? ORDER BY id LIMIT 1`)
+    .get(externalId) as PullRequestRow | null;
+  return row ? rowToPullRequest(row) : null;
+}
+
 export function listPullRequestsForRepository(db: Database, repositoryId: string): PullRequest[] {
   const rows = db
     .query(`SELECT * FROM pull_requests WHERE repository_id = ? ORDER BY number_or_key`)

--- a/src/surface/mc/db/schema.ts
+++ b/src/surface/mc/db/schema.ts
@@ -301,6 +301,9 @@ export const SCHEMA_SQL: string[] = [
      ON pull_requests(repository_id)`,
   `CREATE INDEX IF NOT EXISTS idx_pull_requests_work_item
      ON pull_requests(work_item_id)`,
+  // C.6 — task→PR link lookup is keyed by external_id (the canonical ref).
+  `CREATE INDEX IF NOT EXISTS idx_pull_requests_external_id
+     ON pull_requests(external_id)`,
   `CREATE INDEX IF NOT EXISTS idx_reviews_pull_request
      ON reviews(pull_request_id)`,
 

--- a/src/surface/mc/server.ts
+++ b/src/surface/mc/server.ts
@@ -38,6 +38,7 @@ import {
   handleSendInput,
   IMAGE_BODY_MAX_BYTES,
 } from "./api/handlers";
+import { handleListGitLinks } from "./api/git-links";
 import type { ProcessManager } from "./session/process-manager";
 import type { SpawnFn } from "./session/endpoint-resolver";
 import { join, dirname } from "path";
@@ -386,6 +387,15 @@ async function handleApi(
       return methodNotAllowed(["GET"]);
     }
     return handleListFocusArea(db);
+  }
+
+  // G-1113.C.6 — GET /api/git/links?refs=… — batch task→PR/branch link lookup
+  // for the dashboard's PR/branch chips.
+  if (pathname === "/api/git/links") {
+    if (req.method !== "GET") {
+      return methodNotAllowed(["GET"]);
+    }
+    return handleListGitLinks(db, url);
   }
 
   if (pathname === "/api/tasks") {


### PR DESCRIPTION
Phase C (#553) slice 6 — first-class PR + branch chips on task rows; review state on hover (checks deferred to C.5b — no data yet).

- `db/git-objects.ts`: `getPullRequestByExternalId` (task↔PR match by source ref until Phase D's workItemId).
- `api/git-links.ts` **(new)**: `getGitLinks` projection + `GET /api/git/links?refs=…` batch endpoint (capped/deduped — no N+1). Handler kept out of `handlers.ts` given parallel dev.
- `server.ts`: register the route (import + one block).
- `dashboard-v2`: `GitChips` (state-coloured PR chip + source→target branch chip) + `use-git-links` hook (best-effort — failure = no chips) + wired into the task-row title cell + app.tsx. CSS.

## Verify
`tsc` + `lint` clean · `build:dashboard` ok · projection/handler tests + **api.test router regression (124)** green · gate green.

Closes #559. Refs #553, #354.

🤖 Generated with [Claude Code](https://claude.com/claude-code)