### PR TITLE
feat(gateway): GW.a.3b.2b — dormant flag-gated cortex.ts boot wiring (#524)

### DIFF
--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -90,6 +90,9 @@ import { SlackAdapter } from "./adapters/slack";
 import type { PlatformAdapter } from "./adapters/types";
 import { createDispatchSink, type DispatchSink } from "./adapters/dispatch-sink";
 import { createReviewSink, type ReviewSink } from "./adapters/review-sink";
+import { startGatewayIfEnabled } from "./gateway/start-gateway";
+import type { Surfaces } from "./common/types/surfaces";
+import type { SurfaceGateway } from "./gateway/surface-gateway";
 
 import { createDispatchListener, type DispatchListener } from "./runner/dispatch-listener";
 import { WorklogManager } from "./runner/worklog-manager";
@@ -315,6 +318,17 @@ export interface StartCortexOptions {
    * @internal — not part of the public API; semver does not apply.
    */
   bus?: BusConfig;
+  /**
+   * IAW GW (cortex#524) — validated surface binding map from
+   * `LoadedConfig.surfaces`. Consumed ONLY by the flag-gated
+   * `startGatewayIfEnabled` block below; when `CORTEX_GATEWAY` is unset (the
+   * default on every live stack) this field is read but the gateway is never
+   * constructed. Undefined for legacy `bot.yaml` input and for cortex-shape
+   * input with no `surfaces:` block.
+   *
+   * @internal — not part of the public API; semver does not apply.
+   */
+  surfaces?: Surfaces;
   /**
    * v2.0.0 cutover (cortex#297) — principal's platform-side ids surfaced
    * from `PrincipalConfigSchema` via `LoadedConfig.principal`. Replaces the
@@ -2108,6 +2122,24 @@ export async function startCortex(
     );
   }
 
+  // IAW GW (cortex#524) — shared surface gateway, flag-gated + DORMANT by
+  // default. `startGatewayIfEnabled` reads `CORTEX_GATEWAY` from the env;
+  // when the flag is unset (every live stack today) it returns `undefined`
+  // and constructs NOTHING — this block is a true no-op and the per-stack
+  // adapter boot above is entirely unaffected. When the flag IS set AND
+  // `surfaces:` bindings exist, it builds one adapter per binding, constructs
+  // a shadow-stage SurfaceGateway (LoggingInboundSink — no bus publish yet),
+  // starts it, and returns the instance so `gw?.stop()` joins the shutdown
+  // drain below. The flag-on path is shadow/log-only this slice; the
+  // BusInboundSink flip is a later slice. This is purely additive — it does
+  // not touch, reorder, or risk the existing adapter-construction flow.
+  const gw: SurfaceGateway | undefined = await startGatewayIfEnabled({
+    env: process.env,
+    surfaces: options.surfaces,
+    principal: principalId,
+    runtime,
+  });
+
   // Shutdown — reverse-order; capped at SHUTDOWN_TIMEOUT_MS.
   //
   // Echo round-1 N2 — abandoned-set tracking: each drain step is named
@@ -2144,6 +2176,10 @@ export async function startCortex(
       "dispatch-listener stop",
       "dispatch-sink stop",
       "review-sink stop",
+      // IAW GW (cortex#524) — only present when the flag-gated gateway started;
+      // `gw` is `undefined` on every dormant (default) stack, in which case the
+      // drain step below is a no-op and this slot self-completes immediately.
+      "surface-gateway stop",
       "surface-router stop",
       "dispatch-handler shutdown",
       ...adapterStopNames,
@@ -2204,6 +2240,13 @@ export async function startCortex(
       // surface-router / adapters close, so no late `postResponse` lands
       // after the platform connections close. `stop()` is idempotent.
       await completeAsync("review-sink stop", reviewSink.stop());
+      // IAW GW (cortex#524) — stop the shared surface gateway (its own
+      // adapter connections, separate from the per-stack `adapters[]`) on the
+      // same boundary as the sinks: after the runner stops publishing but
+      // before the surface-router / per-stack adapters close. `gw` is
+      // `undefined` on every dormant (default) stack — `gw?.stop()` is then a
+      // no-op and the slot self-completes.
+      await completeAsync("surface-gateway stop", gw?.stop());
       // IAW B.2a — bus-dispatch-listener drain runs after the dispatch
       // listener (which feeds dispatch-handler) but before the
       // surface-router stop. The listener's `stop()` awaits its
@@ -2653,7 +2696,7 @@ if (import.meta.main) {
       // block when the principal declared one — `startCortex` calls
       // `deriveStackId` and logs the resolved stack id. Today this is
       // observational only; emit subjects are unchanged.
-      const { config, inlineAgents, stack, policy, principal, bus } = loadConfigWithAgents(options.config);
+      const { config, inlineAgents, stack, policy, principal, bus, surfaces } = loadConfigWithAgents(options.config);
       const handle = await startCortex(config, {
         configPath: options.config,
         ...(inlineAgents.length > 0 && { inlineAgents }),
@@ -2663,6 +2706,11 @@ if (import.meta.main) {
         // the canonical `.principal` field.
         ...(principal !== undefined && { principal }),
         ...(bus !== undefined && { bus }),
+        // IAW GW (cortex#524) — thread the validated surface binding map
+        // through so the flag-gated gateway block in startCortex can read it.
+        // Dormant unless CORTEX_GATEWAY is set; undefined when no surfaces:
+        // block was declared.
+        ...(surfaces !== undefined && { surfaces }),
       });
 
       const shutdown = async () => {

--- a/src/gateway/__tests__/gateway-adapters.test.ts
+++ b/src/gateway/__tests__/gateway-adapters.test.ts
@@ -1,0 +1,282 @@
+/**
+ * GW.a.3b.2b — gateway-adapters tests (cortex#524, TDD Red→Green).
+ *
+ * `buildGatewayAdapters` constructs ONE {@link PlatformAdapter} per surface
+ * binding from the binding's credentials + injected deps. These tests use an
+ * INJECTED factory so adapters are CONSTRUCTED, never started/connected — no
+ * live tokens, no network. They assert:
+ *
+ *   1. one adapter per binding, across discord/slack/mattermost
+ *   2. the right platform + the binding credentials reach the factory
+ *   3. the gateway source identity `{principal}.gateway.{instance}` is built
+ *      and the interim instance id (`{platform}:{demuxKey}`) is threaded
+ *   4. zero bindings → zero adapters
+ *   5. deps.runtime / deps.systemEventSource are forwarded verbatim
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  buildGatewayAdapters,
+  type GatewayAdapterDeps,
+  type GatewayAdapterFactory,
+} from "../gateway-adapters";
+import type { PlatformAdapter, InboundMessage } from "../../adapters/types";
+import type { Surfaces } from "../../common/types/surfaces";
+import type { SystemEventSource } from "../../bus/system-events";
+import type { MyelinRuntime } from "../../bus/myelin/runtime";
+
+// =============================================================================
+// Recording fake factory — construct-only, captures every call's args
+// =============================================================================
+
+interface FactoryCall {
+  platform: "discord" | "slack" | "mattermost";
+  instanceId: string;
+  source: SystemEventSource;
+  /** The credential block handed to the factory (presence-shaped). */
+  binding: Record<string, unknown>;
+  runtime: MyelinRuntime | undefined;
+}
+
+function makeFakeAdapter(
+  platform: "discord" | "slack" | "mattermost",
+  instanceId: string,
+): PlatformAdapter {
+  return {
+    platform,
+    instanceId,
+    start: async () => {},
+    stop: async () => {},
+    getPlatformUserId: async () => "bot-user-id",
+    fetchContext: async () => [],
+    resolveAccess: () => ({
+      allowed: true,
+      features: { chat: true, async: false, team: false },
+    }),
+    postResponse: async () => {},
+    sendTyping: async () => {},
+    sendProgress: async () => {},
+    clearProgress: async () => {},
+    createThread: async () => ({ instanceId, channelId: "ch" }),
+    resolveLogicalTarget: async () => null,
+    notifyPrincipal: async () => {},
+  };
+}
+
+function makeRecordingFactory(): {
+  factory: GatewayAdapterFactory;
+  calls: FactoryCall[];
+} {
+  const calls: FactoryCall[] = [];
+  const factory: GatewayAdapterFactory = {
+    discord: (args) => {
+      calls.push({
+        platform: "discord",
+        instanceId: args.instanceId,
+        source: args.source,
+        binding: args.binding,
+        runtime: args.runtime,
+      });
+      return makeFakeAdapter("discord", args.instanceId);
+    },
+    slack: (args) => {
+      calls.push({
+        platform: "slack",
+        instanceId: args.instanceId,
+        source: args.source,
+        binding: args.binding,
+        runtime: args.runtime,
+      });
+      return makeFakeAdapter("slack", args.instanceId);
+    },
+    mattermost: (args) => {
+      calls.push({
+        platform: "mattermost",
+        instanceId: args.instanceId,
+        source: args.source,
+        binding: args.binding,
+        runtime: args.runtime,
+      });
+      return makeFakeAdapter("mattermost", args.instanceId);
+    },
+  };
+  return { factory, calls };
+}
+
+// =============================================================================
+// Fixtures
+// =============================================================================
+
+const RUNTIME_STUB = {
+  publish: async () => {},
+  onEnvelope: () => () => {},
+  stop: async () => {},
+} as unknown as MyelinRuntime;
+
+function makeDeps(factory: GatewayAdapterFactory): GatewayAdapterDeps {
+  return {
+    principal: "andreas",
+    runtime: RUNTIME_STUB,
+    factory,
+  };
+}
+
+const DISCORD_SURFACES: Surfaces = {
+  discord: [
+    {
+      agent: "luna",
+      stack: "andreas/meta-factory",
+      binding: {
+        token: "tok-luna-discord",
+        guildId: "111222333444555666",
+        agentChannelId: "aaa000000000000001",
+        logChannelId: "bbb000000000000002",
+      },
+    },
+  ],
+};
+
+const MULTI_SURFACES: Surfaces = {
+  discord: [
+    {
+      agent: "luna",
+      stack: "andreas/meta-factory",
+      binding: {
+        token: "tok-luna",
+        guildId: "G-LUNA",
+        agentChannelId: "aaa000000000000001",
+        logChannelId: "bbb000000000000002",
+      },
+    },
+  ],
+  slack: [
+    {
+      agent: "sage",
+      stack: "andreas/work",
+      binding: {
+        botToken: "xoxb-1-2-3",
+        appToken: "xapp-1-2-3",
+        workspaceId: "T0123456789",
+      },
+    },
+  ],
+  mattermost: [
+    {
+      agent: "echo",
+      stack: "andreas/ops",
+      binding: {
+        apiUrl: "https://mm.example.com",
+        apiToken: "mm-tok",
+      },
+    },
+  ],
+};
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe("buildGatewayAdapters", () => {
+  test("zero bindings → zero adapters, factory never called", () => {
+    const { factory, calls } = makeRecordingFactory();
+    const adapters = buildGatewayAdapters({}, makeDeps(factory));
+    expect(adapters).toEqual([]);
+    expect(calls.length).toBe(0);
+  });
+
+  test("one discord binding → one discord adapter", () => {
+    const { factory, calls } = makeRecordingFactory();
+    const adapters = buildGatewayAdapters(DISCORD_SURFACES, makeDeps(factory));
+    expect(adapters.length).toBe(1);
+    expect(adapters[0]?.platform).toBe("discord");
+    expect(calls.length).toBe(1);
+    expect(calls[0]?.platform).toBe("discord");
+  });
+
+  test("discord binding forwards the credential block verbatim", () => {
+    const { factory, calls } = makeRecordingFactory();
+    buildGatewayAdapters(DISCORD_SURFACES, makeDeps(factory));
+    const call = calls[0];
+    expect(call?.binding.token).toBe("tok-luna-discord");
+    expect(call?.binding.guildId).toBe("111222333444555666");
+    expect(call?.binding.agentChannelId).toBe("aaa000000000000001");
+    expect(call?.binding.logChannelId).toBe("bbb000000000000002");
+  });
+
+  test("source identity is {principal}.gateway.{instance} with the interim instance id", () => {
+    const { factory, calls } = makeRecordingFactory();
+    buildGatewayAdapters(DISCORD_SURFACES, makeDeps(factory));
+    const src = calls[0]?.source;
+    expect(src?.principal).toBe("andreas");
+    expect(src?.agent).toBe("gateway");
+    // interim instance id = `{platform}:{demuxKey}` (= guildId for discord)
+    expect(src?.instance).toBe("discord:111222333444555666");
+  });
+
+  test("instanceId threaded to the factory matches the interim instance id", () => {
+    const { factory, calls } = makeRecordingFactory();
+    buildGatewayAdapters(DISCORD_SURFACES, makeDeps(factory));
+    expect(calls[0]?.instanceId).toBe("discord:111222333444555666");
+  });
+
+  test("runtime is forwarded verbatim to the factory", () => {
+    const { factory, calls } = makeRecordingFactory();
+    buildGatewayAdapters(DISCORD_SURFACES, makeDeps(factory));
+    expect(calls[0]?.runtime).toBe(RUNTIME_STUB);
+  });
+
+  test("mixed surfaces → one adapter per binding, correct platforms", () => {
+    const { factory, calls } = makeRecordingFactory();
+    const adapters = buildGatewayAdapters(MULTI_SURFACES, makeDeps(factory));
+    expect(adapters.length).toBe(3);
+    const platforms = adapters.map((a) => a.platform).sort();
+    expect(platforms).toEqual(["discord", "mattermost", "slack"]);
+    const callPlatforms = calls.map((c) => c.platform).sort();
+    expect(callPlatforms).toEqual(["discord", "mattermost", "slack"]);
+  });
+
+  test("slack source instance is slack:{workspaceId}", () => {
+    const { factory, calls } = makeRecordingFactory();
+    buildGatewayAdapters(MULTI_SURFACES, makeDeps(factory));
+    const slackCall = calls.find((c) => c.platform === "slack");
+    expect(slackCall?.source.instance).toBe("slack:T0123456789");
+    expect(slackCall?.binding.botToken).toBe("xoxb-1-2-3");
+    expect(slackCall?.binding.appToken).toBe("xapp-1-2-3");
+  });
+
+  test("mattermost source instance is mattermost:{apiUrl}", () => {
+    const { factory, calls } = makeRecordingFactory();
+    buildGatewayAdapters(MULTI_SURFACES, makeDeps(factory));
+    const mmCall = calls.find((c) => c.platform === "mattermost");
+    expect(mmCall?.source.instance).toBe("mattermost:https://mm.example.com");
+    expect(mmCall?.binding.apiUrl).toBe("https://mm.example.com");
+    expect(mmCall?.binding.apiToken).toBe("mm-tok");
+  });
+
+  test("constructed adapters are never started by the builder", async () => {
+    // Build with a factory whose adapters record start() calls; the builder
+    // must NOT call start() — start is the gateway's job at gw.start().
+    const started: string[] = [];
+    const factory: GatewayAdapterFactory = {
+      discord: (args) => {
+        const a = makeFakeAdapter("discord", args.instanceId);
+        a.start = async () => {
+          started.push(args.instanceId);
+        };
+        return a;
+      },
+      slack: (args) => makeFakeAdapter("slack", args.instanceId),
+      mattermost: (args) => makeFakeAdapter("mattermost", args.instanceId),
+    };
+    buildGatewayAdapters(DISCORD_SURFACES, {
+      principal: "andreas",
+      runtime: RUNTIME_STUB,
+      factory,
+    });
+    // builder is synchronous + construct-only
+    expect(started).toEqual([]);
+    // sanity: the message type import is exercised (no-op assertion)
+    const _msgType: InboundMessage | undefined = undefined;
+    expect(_msgType).toBeUndefined();
+  });
+});

--- a/src/gateway/__tests__/start-gateway.test.ts
+++ b/src/gateway/__tests__/start-gateway.test.ts
@@ -1,0 +1,218 @@
+/**
+ * GW.a.3b.2b — start-gateway tests (cortex#524, TDD Red→Green).
+ *
+ * `startGatewayIfEnabled` is the flag-on orchestration that keeps cortex.ts
+ * thin. These tests assert the HARD SAFETY CONTRACT:
+ *
+ *   - flag OFF → returns undefined, constructs NOTHING (the injected adapter
+ *     factory is NEVER called — proves the flag-off path is a true no-op).
+ *   - flag ON + surfaces → builds N adapters, constructs a SurfaceGateway,
+ *     calls gw.start(), returns the started gateway (injected fakes only —
+ *     no live connection is faked).
+ *   - flag ON + no surfaces → returns undefined (degrade gracefully).
+ */
+
+import { describe, expect, test } from "bun:test";
+import { startGatewayIfEnabled } from "../start-gateway";
+import { SurfaceGateway } from "../surface-gateway";
+import type { GatewayAdapterFactory } from "../gateway-adapters";
+import type { PlatformAdapter } from "../../adapters/types";
+import type { Surfaces } from "../../common/types/surfaces";
+import type { MyelinRuntime } from "../../bus/myelin/runtime";
+
+// =============================================================================
+// Fakes
+// =============================================================================
+
+const RUNTIME_STUB = {
+  publish: async () => {},
+  onEnvelope: () => () => {},
+  stop: async () => {},
+} as unknown as MyelinRuntime;
+
+function makeFakeAdapter(
+  platform: "discord" | "slack" | "mattermost",
+  instanceId: string,
+  onStart?: () => void,
+): PlatformAdapter {
+  return {
+    platform,
+    instanceId,
+    start: async () => {
+      onStart?.();
+    },
+    stop: async () => {},
+    getPlatformUserId: async () => "bot-user-id",
+    fetchContext: async () => [],
+    resolveAccess: () => ({
+      allowed: true,
+      features: { chat: true, async: false, team: false },
+    }),
+    postResponse: async () => {},
+    sendTyping: async () => {},
+    sendProgress: async () => {},
+    clearProgress: async () => {},
+    createThread: async () => ({ instanceId, channelId: "ch" }),
+    resolveLogicalTarget: async () => null,
+    notifyPrincipal: async () => {},
+  };
+}
+
+/** A factory + a record of how many times it was invoked. */
+function makeCountingFactory(started: string[]): {
+  factory: GatewayAdapterFactory;
+  constructed: string[];
+} {
+  const constructed: string[] = [];
+  const factory: GatewayAdapterFactory = {
+    discord: (args) => {
+      constructed.push(args.instanceId);
+      return makeFakeAdapter("discord", args.instanceId, () =>
+        started.push(args.instanceId),
+      );
+    },
+    slack: (args) => {
+      constructed.push(args.instanceId);
+      return makeFakeAdapter("slack", args.instanceId, () =>
+        started.push(args.instanceId),
+      );
+    },
+    mattermost: (args) => {
+      constructed.push(args.instanceId);
+      return makeFakeAdapter("mattermost", args.instanceId, () =>
+        started.push(args.instanceId),
+      );
+    },
+  };
+  return { factory, constructed };
+}
+
+const DISCORD_SURFACES: Surfaces = {
+  discord: [
+    {
+      agent: "luna",
+      stack: "andreas/meta-factory",
+      binding: {
+        token: "tok-luna-discord",
+        guildId: "111222333444555666",
+        agentChannelId: "aaa000000000000001",
+        logChannelId: "bbb000000000000002",
+      },
+    },
+  ],
+};
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe("startGatewayIfEnabled — flag off", () => {
+  test("CORTEX_GATEWAY unset → returns undefined, constructs NOTHING", async () => {
+    const started: string[] = [];
+    const { factory, constructed } = makeCountingFactory(started);
+    const gw = await startGatewayIfEnabled({
+      env: {}, // flag unset
+      surfaces: DISCORD_SURFACES,
+      principal: "andreas",
+      runtime: RUNTIME_STUB,
+      factory,
+    });
+    expect(gw).toBeUndefined();
+    // HARD CONTRACT: nothing constructed, nothing started.
+    expect(constructed).toEqual([]);
+    expect(started).toEqual([]);
+  });
+
+  test("CORTEX_GATEWAY='0' → returns undefined, constructs NOTHING", async () => {
+    const started: string[] = [];
+    const { factory, constructed } = makeCountingFactory(started);
+    const gw = await startGatewayIfEnabled({
+      env: { CORTEX_GATEWAY: "0" },
+      surfaces: DISCORD_SURFACES,
+      principal: "andreas",
+      runtime: RUNTIME_STUB,
+      factory,
+    });
+    expect(gw).toBeUndefined();
+    expect(constructed).toEqual([]);
+    expect(started).toEqual([]);
+  });
+
+  test("CORTEX_GATEWAY='true' → returns undefined (only '1' is truthy)", async () => {
+    const started: string[] = [];
+    const { factory, constructed } = makeCountingFactory(started);
+    const gw = await startGatewayIfEnabled({
+      env: { CORTEX_GATEWAY: "true" },
+      surfaces: DISCORD_SURFACES,
+      principal: "andreas",
+      runtime: RUNTIME_STUB,
+      factory,
+    });
+    expect(gw).toBeUndefined();
+    expect(constructed).toEqual([]);
+  });
+});
+
+describe("startGatewayIfEnabled — flag on", () => {
+  test("flag on + surfaces → builds adapters, returns a started SurfaceGateway", async () => {
+    const started: string[] = [];
+    const { factory, constructed } = makeCountingFactory(started);
+    const gw = await startGatewayIfEnabled({
+      env: { CORTEX_GATEWAY: "1" },
+      surfaces: DISCORD_SURFACES,
+      principal: "andreas",
+      runtime: RUNTIME_STUB,
+      factory,
+    });
+    expect(gw).toBeInstanceOf(SurfaceGateway);
+    // one adapter constructed for the one discord binding
+    expect(constructed).toEqual(["discord:111222333444555666"]);
+    // gw.start() was awaited → the adapter's start() ran
+    expect(started).toEqual(["discord:111222333444555666"]);
+  });
+
+  test("flag on but surfaces undefined → returns undefined (graceful degrade)", async () => {
+    const started: string[] = [];
+    const { factory, constructed } = makeCountingFactory(started);
+    const gw = await startGatewayIfEnabled({
+      env: { CORTEX_GATEWAY: "1" },
+      surfaces: undefined,
+      principal: "andreas",
+      runtime: RUNTIME_STUB,
+      factory,
+    });
+    expect(gw).toBeUndefined();
+    // no bindings → no adapters → no gateway
+    expect(constructed).toEqual([]);
+    expect(started).toEqual([]);
+  });
+
+  test("flag on but surfaces empty → returns undefined", async () => {
+    const started: string[] = [];
+    const { factory, constructed } = makeCountingFactory(started);
+    const gw = await startGatewayIfEnabled({
+      env: { CORTEX_GATEWAY: "1" },
+      surfaces: {},
+      principal: "andreas",
+      runtime: RUNTIME_STUB,
+      factory,
+    });
+    expect(gw).toBeUndefined();
+    expect(constructed).toEqual([]);
+  });
+
+  test("the returned gateway can be stopped", async () => {
+    const started: string[] = [];
+    const { factory } = makeCountingFactory(started);
+    const gw = await startGatewayIfEnabled({
+      env: { CORTEX_GATEWAY: "1" },
+      surfaces: DISCORD_SURFACES,
+      principal: "andreas",
+      runtime: RUNTIME_STUB,
+      factory,
+    });
+    expect(gw).toBeInstanceOf(SurfaceGateway);
+    // stop() resolves without throwing
+    await gw?.stop();
+  });
+});

--- a/src/gateway/gateway-adapters.ts
+++ b/src/gateway/gateway-adapters.ts
@@ -1,0 +1,266 @@
+/**
+ * GW.a.3b.2b — gateway adapter construction (cortex#524).
+ *
+ * `buildGatewayAdapters` turns the validated `Surfaces` binding map into ONE
+ * {@link PlatformAdapter} per binding, ready for the {@link SurfaceGateway} to
+ * own. It is the construction half of the live wiring; `start-gateway.ts`
+ * orchestrates the flag check + `gw.start()`.
+ *
+ * ## How a binding maps to a presence + adapter
+ *
+ * Each `surfaces.{platform}[]` entry is `{ agent, stack?, binding }` where
+ * `binding` carries the platform credentials (CFG.c — it is a permissive
+ * superset of the matching `{Discord,Slack,Mattermost}PresenceSchema`; see
+ * `src/common/types/surfaces.ts`). To turn a binding into a live adapter:
+ *
+ *   1. Re-parse `binding` through the canonical presence schema. The binding
+ *      schema validated only the required credential fields; the presence
+ *      schema fills defaults (`enabled`, `contextDepth`, `channels`, …) and
+ *      produces the exact typed shape each adapter constructor expects. This
+ *      is correct-by-construction — no casts, no hand-built presence objects
+ *      that could drift from the schema.
+ *   2. Derive the gateway's interim instance id `{platform}:{demuxKey}` — the
+ *      SAME id `binding-resolver.ts` stamps as `GatewayBindingMatch.instance`,
+ *      so the inbound demux and the outbound adapter agree on the connection
+ *      key (design §3.3 / OQ4: replace with an explicit `instance` field when
+ *      the schema grows one).
+ *   3. Build the gateway source identity `{principal}.gateway.{instance}` — a
+ *      {@link SystemEventSource} with `agent: "gateway"` (principal-locked
+ *      decision 2026-06-02). This is the source stamped onto any
+ *      `system.adapter.*` envelope the gateway's adapters emit.
+ *   4. Hand `{ instanceId, source, binding, presence, runtime }` to the
+ *      injected {@link GatewayAdapterFactory}, which constructs the concrete
+ *      adapter. The factory is injected so tests CONSTRUCT (never start /
+ *      connect) — no live tokens required. Production uses
+ *      {@link defaultGatewayAdapterFactory}.
+ *
+ * ## Shadow stage (this slice)
+ *
+ * The constructed adapters are NOT started here — `start()` is the
+ * {@link SurfaceGateway}'s job (`gw.start()`), which rebinds each adapter's
+ * `onMessage` to route through the binding index into the (shadow-stage)
+ * `LoggingInboundSink`. So even when the gateway runs, nothing is published to
+ * the bus yet (the `BusInboundSink` flip is a later slice).
+ *
+ * ## Gateway principal-DM target
+ *
+ * The adapter infra requires a `principal: { discordId? }` (etc.) block — the
+ * principal's platform id used for `notifyPrincipal`. The gateway is
+ * shadow/log-only and does not DM the principal, so it passes an empty block.
+ * When the live bus-publishing slice lands, the gateway's principal-DM target
+ * can be threaded through `deps` if needed.
+ */
+
+import { DiscordAdapter } from "../adapters/discord";
+import { SlackAdapter } from "../adapters/slack";
+import { MattermostAdapter } from "../adapters/mattermost";
+import type { PlatformAdapter } from "../adapters/types";
+import type { Surfaces } from "../common/types/surfaces";
+import {
+  DiscordPresenceSchema,
+  SlackPresenceSchema,
+  MattermostPresenceSchema,
+  type DiscordPresence,
+  type SlackPresence,
+  type MattermostPresence,
+  type Agent,
+} from "../common/types/cortex-config";
+import type { SystemEventSource } from "../bus/system-events";
+import type { MyelinRuntime } from "../bus/myelin/runtime";
+
+// =============================================================================
+// Factory seam — injected so tests construct without live connections
+// =============================================================================
+
+/** Args common to every per-platform factory call. */
+interface FactoryArgsBase {
+  /** Interim instance id `{platform}:{demuxKey}` (= binding-resolver match.instance). */
+  instanceId: string;
+  /** Gateway source identity `{principal}.gateway.{instance}`. */
+  source: SystemEventSource;
+  /**
+   * The raw credential block from `surfaces.{platform}[].binding`. Forwarded
+   * for observability / test assertions; the typed `presence` below is what
+   * the adapter constructor consumes.
+   */
+  binding: Record<string, unknown>;
+  /** Myelin runtime for `system.adapter.*` emission (may be dormant). */
+  runtime: MyelinRuntime | undefined;
+}
+
+interface DiscordFactoryArgs extends FactoryArgsBase {
+  presence: DiscordPresence;
+}
+interface SlackFactoryArgs extends FactoryArgsBase {
+  presence: SlackPresence;
+}
+interface MattermostFactoryArgs extends FactoryArgsBase {
+  presence: MattermostPresence;
+}
+
+/**
+ * The injected adapter-construction seam. One builder per platform. Production
+ * uses {@link defaultGatewayAdapterFactory}; tests inject a recording fake that
+ * returns construct-only stubs (no platform connection).
+ */
+export interface GatewayAdapterFactory {
+  discord(args: DiscordFactoryArgs): PlatformAdapter;
+  slack(args: SlackFactoryArgs): PlatformAdapter;
+  mattermost(args: MattermostFactoryArgs): PlatformAdapter;
+}
+
+/** Injected dependencies for {@link buildGatewayAdapters}. */
+export interface GatewayAdapterDeps {
+  /** Principal slug — first segment of the gateway source identity. */
+  principal: string;
+  /** Myelin runtime (may be dormant — adapters track state locally either way). */
+  runtime: MyelinRuntime | undefined;
+  /** Adapter-construction seam. Defaults to {@link defaultGatewayAdapterFactory}. */
+  factory: GatewayAdapterFactory;
+}
+
+// =============================================================================
+// Synthetic agent for gateway-owned adapters
+// =============================================================================
+
+/**
+ * The gateway owns one connection per binding but is NOT a stack — it has no
+ * persona file and dispatches nothing locally (inbound is rebound to the
+ * gateway's sink, bypassing `dispatchHandler.handleMessage`). The adapter
+ * constructor still requires an `Agent`; build a minimal synthetic one keyed
+ * to the binding's `agent` id so log lines and the trust set are coherent.
+ *
+ * `persona` is a sentinel — the gateway never spawns a CC session through this
+ * adapter, so the persona file is never read.
+ */
+function syntheticGatewayAgent(
+  agentId: string,
+  presence: Agent["presence"],
+): Agent {
+  return {
+    id: agentId,
+    displayName: agentId,
+    persona: "(gateway-owned — no local dispatch)",
+    trust: [],
+    presence,
+  };
+}
+
+// =============================================================================
+// Default (production) factory — constructs the real adapters
+// =============================================================================
+
+/**
+ * Production factory. Constructs the concrete platform adapters with an empty
+ * principal-DM block (the gateway is shadow/log-only; see module doc). The
+ * adapters are CONSTRUCTED only — `buildGatewayAdapters` does not start them.
+ */
+export const defaultGatewayAdapterFactory: GatewayAdapterFactory = {
+  discord: ({ instanceId, source, presence, runtime }) =>
+    new DiscordAdapter(syntheticGatewayAgent(source.agent, { discord: presence }), presence, {
+      instanceId,
+      principal: {},
+      ...(runtime !== undefined && { runtime }),
+      systemEventSource: source,
+    }),
+
+  slack: ({ instanceId, source, presence, runtime }) =>
+    new SlackAdapter(syntheticGatewayAgent(source.agent, { slack: presence }), presence, {
+      instanceId,
+      principal: {},
+      ...(runtime !== undefined && { runtime }),
+      systemEventSource: source,
+    }),
+
+  mattermost: ({ instanceId, source, presence, runtime }) =>
+    new MattermostAdapter(
+      syntheticGatewayAgent(source.agent, { mattermost: presence }),
+      presence,
+      {
+        instanceId,
+        principal: {},
+        ...(runtime !== undefined && { runtime }),
+        systemEventSource: source,
+      },
+    ),
+};
+
+// =============================================================================
+// buildGatewayAdapters
+// =============================================================================
+
+/** Build the gateway source identity `{principal}.gateway.{instance}`. */
+function gatewaySource(principal: string, instance: string): SystemEventSource {
+  return { principal, agent: "gateway", instance };
+}
+
+/**
+ * Construct ONE {@link PlatformAdapter} per surface binding.
+ *
+ * Synchronous + construct-only: it never calls `adapter.start()` (that is the
+ * {@link SurfaceGateway}'s responsibility). Returns the adapters in
+ * discord→slack→mattermost order. An empty/absent `Surfaces` map yields `[]`
+ * and never touches the factory.
+ *
+ * @throws re-throws any error from the canonical presence parse (a binding
+ *   that the binding-schema admitted but the presence-schema rejects) or from
+ *   an adapter constructor (e.g. Mattermost requires apiUrl + apiToken) so a
+ *   misconfigured binding fails loudly at boot rather than silently dropping a
+ *   connection.
+ */
+export function buildGatewayAdapters(
+  surfaces: Surfaces,
+  deps: GatewayAdapterDeps,
+): PlatformAdapter[] {
+  const { principal, runtime, factory } = deps;
+  const adapters: PlatformAdapter[] = [];
+
+  // ── Discord — demux key = guildId ─────────────────────────────────────────
+  for (const entry of surfaces.discord ?? []) {
+    const presence = DiscordPresenceSchema.parse(entry.binding);
+    const instanceId = `discord:${presence.guildId}`;
+    adapters.push(
+      factory.discord({
+        instanceId,
+        source: gatewaySource(principal, instanceId),
+        binding: entry.binding,
+        runtime,
+        presence,
+      }),
+    );
+  }
+
+  // ── Slack — demux key = workspaceId ───────────────────────────────────────
+  for (const entry of surfaces.slack ?? []) {
+    const presence = SlackPresenceSchema.parse(entry.binding);
+    const instanceId = `slack:${presence.workspaceId}`;
+    adapters.push(
+      factory.slack({
+        instanceId,
+        source: gatewaySource(principal, instanceId),
+        binding: entry.binding,
+        runtime,
+        presence,
+      }),
+    );
+  }
+
+  // ── Mattermost — demux key = apiUrl (single-binding fallback) ─────────────
+  for (const entry of surfaces.mattermost ?? []) {
+    const presence = MattermostPresenceSchema.parse(entry.binding);
+    // apiUrl is optional on the presence schema but required on the binding
+    // schema; the binding-resolver keys the interim instance on it too.
+    const instanceId = `mattermost:${presence.apiUrl ?? "<unset>"}`;
+    adapters.push(
+      factory.mattermost({
+        instanceId,
+        source: gatewaySource(principal, instanceId),
+        binding: entry.binding,
+        runtime,
+        presence,
+      }),
+    );
+  }
+
+  return adapters;
+}

--- a/src/gateway/start-gateway.ts
+++ b/src/gateway/start-gateway.ts
@@ -1,0 +1,147 @@
+/**
+ * GW.a.3b.2b — flag-gated gateway start orchestration (cortex#524).
+ *
+ * `startGatewayIfEnabled` is the ONE call cortex.ts makes to (maybe) stand up
+ * the shared surface gateway. It keeps the boot path thin: cortex.ts adds a
+ * single guarded `const gw = await startGatewayIfEnabled(...)` after its
+ * per-stack adapters are built, and registers `gw?.stop()` in the existing
+ * shutdown sequence. All flag-on orchestration lives HERE.
+ *
+ * ## HARD SAFETY CONTRACT
+ *
+ * `CORTEX_GATEWAY` is OFF by default. When off this function returns
+ * `undefined` and constructs NOTHING — it does not call the adapter factory,
+ * does not touch the runtime, does not start anything. The flag-off path is a
+ * true no-op; cortex's existing per-stack adapter boot is entirely unaffected.
+ *
+ * ## Three exit paths (mirrors `maybeCreateSurfaceGateway`)
+ *
+ *   1. flag off → `undefined`, nothing constructed.
+ *   2. flag on but no surface bindings → `undefined` (the factory is never
+ *      called because `maybeCreateSurfaceGateway` early-exits before any
+ *      adapter is needed — we mirror that by checking bindings first and
+ *      skipping `buildGatewayAdapters` entirely).
+ *   3. flag on + bindings → build adapters, construct the gateway, `gw.start()`,
+ *      return the started instance.
+ *
+ * ## Shadow stage (this slice)
+ *
+ * `maybeCreateSurfaceGateway` always wires `LoggingInboundSink` — even the
+ * flag-on path is shadow/log-only and publishes NOTHING to the bus. The
+ * `BusInboundSink` flip is a later slice.
+ *
+ * ## Why bindings are checked before building adapters
+ *
+ * `buildGatewayAdapters` is construct-only and cheap, but constructing real
+ * platform adapters opens no connection (start is deferred) — still, building
+ * zero-value adapters for a no-binding config is pointless work, and the
+ * factory-never-called invariant in the no-binding case keeps the contract
+ * crisp + testable. We compute `hasBindings` up front and short-circuit.
+ */
+
+import {
+  isGatewayEnabled,
+  maybeCreateSurfaceGateway,
+} from "./gateway-bootstrap";
+import {
+  buildGatewayAdapters,
+  defaultGatewayAdapterFactory,
+  type GatewayAdapterFactory,
+} from "./gateway-adapters";
+import type { SurfaceGateway } from "./surface-gateway";
+import type { Surfaces } from "../common/types/surfaces";
+import type { MyelinRuntime } from "../bus/myelin/runtime";
+import type { InboundMessage } from "../adapters/types";
+
+// =============================================================================
+// Public API
+// =============================================================================
+
+/** Options for {@link startGatewayIfEnabled}. */
+export interface StartGatewayOpts {
+  /** The env record to read `CORTEX_GATEWAY` from (cortex.ts passes `process.env`). */
+  env: Record<string, string | undefined>;
+  /** Validated surface binding map from `LoadedConfig.surfaces` (may be undefined). */
+  surfaces: Surfaces | undefined;
+  /** Principal slug — first segment of the gateway source identity. */
+  principal: string;
+  /** Myelin runtime (may be dormant — adapters track state locally either way). */
+  runtime: MyelinRuntime | undefined;
+  /**
+   * Adapter-construction seam. Production omits this and gets
+   * {@link defaultGatewayAdapterFactory}; tests inject a recording fake that
+   * returns construct-only stubs (no platform connection).
+   */
+  factory?: GatewayAdapterFactory;
+  /** Optional unroutable-message hook forwarded to the gateway. */
+  onUnroutable?: (msg: InboundMessage, reason: string) => void;
+}
+
+/** Count the total bindings across all platforms in a `Surfaces` map. */
+function countBindings(surfaces: Surfaces): number {
+  return (
+    (surfaces.discord?.length ?? 0) +
+    (surfaces.slack?.length ?? 0) +
+    (surfaces.mattermost?.length ?? 0)
+  );
+}
+
+/**
+ * Flag-gated: maybe construct + start the shared surface gateway.
+ *
+ * Returns the started {@link SurfaceGateway} when the flag is on AND surface
+ * bindings exist; otherwise `undefined`. See the module doc for the HARD
+ * SAFETY CONTRACT — flag off constructs NOTHING.
+ *
+ * @throws re-throws from `buildGatewayAdapters` (bad presence / adapter
+ *   construction) and `maybeCreateSurfaceGateway` (duplicate demux key) so a
+ *   misconfigured-but-flagged deployment fails loudly at boot. The flag-off
+ *   path never reaches either and so never throws.
+ */
+export async function startGatewayIfEnabled(
+  opts: StartGatewayOpts,
+): Promise<SurfaceGateway | undefined> {
+  const enabled = isGatewayEnabled(opts.env);
+
+  // ── Path 1: flag off → true no-op. Construct NOTHING. ─────────────────────
+  if (!enabled) {
+    return undefined;
+  }
+
+  // ── Path 2: flag on but no bindings → degrade gracefully. ─────────────────
+  // Short-circuit BEFORE buildGatewayAdapters so the factory is never called
+  // when there is nothing to demux (keeps the no-binding invariant crisp).
+  const { surfaces } = opts;
+  if (surfaces === undefined || countBindings(surfaces) === 0) {
+    // maybeCreateSurfaceGateway emits the principal-facing stderr warning for
+    // the no-binding case; delegate to it (with empty adapters) so the log
+    // line lives in exactly one place.
+    return maybeCreateSurfaceGateway({
+      enabled: true,
+      surfaces,
+      adapters: [],
+      ...(opts.onUnroutable !== undefined && { onUnroutable: opts.onUnroutable }),
+    });
+  }
+
+  // ── Path 3: flag on + bindings → build, construct, start. ─────────────────
+  const adapters = buildGatewayAdapters(surfaces, {
+    principal: opts.principal,
+    runtime: opts.runtime,
+    factory: opts.factory ?? defaultGatewayAdapterFactory,
+  });
+
+  const gw = maybeCreateSurfaceGateway({
+    enabled: true,
+    surfaces,
+    adapters,
+    ...(opts.onUnroutable !== undefined && { onUnroutable: opts.onUnroutable }),
+  });
+
+  // `gw` is defined here (bindings > 0 + adapters built), but the factory
+  // contract returns `SurfaceGateway | undefined` — guard rather than assert.
+  if (gw !== undefined) {
+    await gw.start();
+  }
+  return gw;
+}


### PR DESCRIPTION
Wires the shared surface gateway into the **live cortex.ts boot path** — **DORMANT by default**. `CORTEX_GATEWAY` off (every live stack) → constructs NOTHING; boot is byte-identical.

## What
- **`gateway-adapters.ts`** — `buildGatewayAdapters(surfaces, deps)`: one adapter per binding, re-parses each `binding` through the canonical presence schema (correct-by-construction), injectable factory (tests construct, never connect). Source = `{principal}.gateway.{instance}`.
- **`start-gateway.ts`** — `startGatewayIfEnabled(opts)`: the ONE call cortex.ts makes. Flag off → `undefined` (no-op, factory never called); on+no-bindings → undefined+warn; on+bindings → build + `maybeCreateSurfaceGateway` + `start`. Shadow (`LoggingInboundSink`, no bus publish).
- **`cortex.ts`** — **+49/-1, purely additive**: one guarded `startGatewayIfEnabled(...)` after the (untouched) adapter loop + a `gw?.stop()` drain slot; `surfaces` threaded from `LoadedConfig.surfaces`.

## ⚠️ Review focus (live-boot touch)
1. **Flag-off byte-identity** — scrutinize the cortex.ts diff: is the gateway block purely additive + flag-guarded, the existing adapter loop untouched? (Verified: cortex boot smoke 27/27 green with flag unset; full src/ 3891 pass / 0 fail.)
2. **buildGatewayAdapters** — binding→presence re-parse correct? The synthetic gateway `Agent` (id `gateway`) sound? Construct-only (no connect)?
3. **Shutdown ordering** — `gw?.stop()` drained on the right boundary (after sinks, before per-stack adapters/router)?

## Caveat (accepted)
The **flag-ON path is NOT dry-run-validated** — needs the #562 staging bot. Correct-by-construction + unit-tested with injected fakes; no faked live connection. BusInboundSink flip + launchd are later slices.

## Gates
`tsc` 0 · `eslint --quiet src/` 0 · `bun test src/gateway/` **90** · `bun test src/` **3891 pass / 0 fail** · vocab gate PASS.

Refs #524 · part of #110.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
