### PR TITLE
feat(mc): G-1113.C.7 — per-repository panel (software mode)

### DIFF
--- a/src/surface/mc/__tests__/git-repos.test.ts
+++ b/src/surface/mc/__tests__/git-repos.test.ts
@@ -1,0 +1,55 @@
+/**
+ * G-1113.C.7 — per-repository projection + endpoint.
+ */
+import { describe, it, expect, afterEach } from "bun:test";
+import { join } from "path";
+import { tmpdir } from "os";
+import { rmSync, existsSync } from "fs";
+import { initDatabase } from "../db/init";
+import {
+  upsertRepository,
+  upsertBranch,
+  upsertPullRequest,
+  upsertRelease,
+} from "../db/git-objects";
+import { getRepositoriesWithGit, handleListRepositories } from "../api/git-repos";
+import type { GitRepository, GitBranch, PullRequest, Release } from "../types";
+
+const RID = "github:o/r";
+const repo: GitRepository = { id: RID, provider: "github", owner: "o", name: "r", url: "https://github.com/o/r", defaultBranch: "main" };
+const branch: GitBranch = { id: `${RID}@main`, repositoryId: RID, name: "main", baseRef: null, headSha: null, provider: "github", externalId: null, url: null };
+const pr: PullRequest = { id: `${RID}#1`, workItemId: null, repositoryId: RID, provider: "github", providerNativeType: "pull_request", externalId: "o/r#1", numberOrKey: "1", title: "T", sourceBranch: "feat", targetBranch: "main", url: "https://github.com/o/r/pull/1", state: "open", reviewState: "none" };
+const release: Release = { id: `${RID}@v1`, repositoryId: RID, provider: "github", externalId: null, name: "v1.0.0", tagName: "v1.0.0", url: null, state: "published" };
+
+describe("git-repos projection (C.7)", () => {
+  const paths: string[] = [];
+  afterEach(() => { for (const p of paths) if (existsSync(p)) rmSync(p); paths.length = 0; });
+  function freshDb() {
+    const p = join(tmpdir(), `git-repos-${Date.now()}-${Math.random().toString(36).slice(2)}.db`);
+    paths.push(p);
+    return initDatabase(p);
+  }
+
+  it("groups a repository with its branches, PRs, and releases", () => {
+    const db = freshDb();
+    upsertRepository(db, repo); upsertBranch(db, branch); upsertPullRequest(db, pr); upsertRelease(db, release);
+    const views = getRepositoriesWithGit(db);
+    expect(views).toHaveLength(1);
+    expect(views[0]).toEqual({ repository: repo, branches: [branch], pullRequests: [pr], releases: [release] });
+  });
+
+  it("returns an empty list when no repositories are ingested", () => {
+    const db = freshDb();
+    expect(getRepositoriesWithGit(db)).toEqual([]);
+  });
+
+  it("handleListRepositories returns { repositories } JSON", async () => {
+    const db = freshDb();
+    upsertRepository(db, repo);
+    const res = handleListRepositories(db);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { repositories: { repository: GitRepository }[] };
+    expect(body.repositories).toHaveLength(1);
+    expect(body.repositories[0]!.repository.id).toBe(RID);
+  });
+});

--- a/src/surface/mc/api/git-repos.ts
+++ b/src/surface/mc/api/git-repos.ts
@@ -1,0 +1,39 @@
+/**
+ * G-1113.C.7 — per-repository projection + endpoint for the Repositories panel.
+ *
+ * Groups the software-mode Git model (C.1–C.4) by repository: each repo with
+ * its branches, pull requests, and releases. Read-only; reuses the git-objects
+ * list queries.
+ */
+import type { Database } from "bun:sqlite";
+import type { GitRepository, GitBranch, PullRequest, Release } from "../types";
+import {
+  listRepositories,
+  listBranchesForRepository,
+  listPullRequestsForRepository,
+  listReleasesForRepository,
+} from "../db/git-objects";
+
+export interface RepositoryView {
+  repository: GitRepository;
+  branches: GitBranch[];
+  pullRequests: PullRequest[];
+  releases: Release[];
+}
+
+export function getRepositoriesWithGit(db: Database): RepositoryView[] {
+  return listRepositories(db).map((repository) => ({
+    repository,
+    branches: listBranchesForRepository(db, repository.id),
+    pullRequests: listPullRequestsForRepository(db, repository.id),
+    releases: listReleasesForRepository(db, repository.id),
+  }));
+}
+
+/** GET /api/git/repositories — repos grouped with their branches/PRs/releases. */
+export function handleListRepositories(db: Database): Response {
+  return new Response(JSON.stringify({ repositories: getRepositoriesWithGit(db) }), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}

--- a/src/surface/mc/api/git-repos.ts
+++ b/src/surface/mc/api/git-repos.ts
@@ -11,7 +11,7 @@ import {
   listRepositories,
   listBranchesForRepository,
   listPullRequestsForRepository,
-  listReleasesForRepository,
+  listRecentReleasesForRepository,
 } from "../db/git-objects";
 
 export interface RepositoryView {
@@ -21,12 +21,19 @@ export interface RepositoryView {
   releases: Release[];
 }
 
+/**
+ * 3 index-backed child queries per repo (branches/PRs/releases) on top of
+ * listRepositories — an N+1 across repos, acceptable for a panel (few repos).
+ * `releases` is the recent, capped set (the panel shows "recent releases", not
+ * the full history). Releases with a NULL repository_id are intentionally
+ * excluded — this is a strictly per-repository panel.
+ */
 export function getRepositoriesWithGit(db: Database): RepositoryView[] {
   return listRepositories(db).map((repository) => ({
     repository,
     branches: listBranchesForRepository(db, repository.id),
     pullRequests: listPullRequestsForRepository(db, repository.id),
-    releases: listReleasesForRepository(db, repository.id),
+    releases: listRecentReleasesForRepository(db, repository.id),
   }));
 }
 

--- a/src/surface/mc/dashboard-v2/app.tsx
+++ b/src/surface/mc/dashboard-v2/app.tsx
@@ -89,6 +89,11 @@ export function App() {
   const [selectedIterationId, setSelectedIterationId] = useState<string | null>(null);
   // G-1113.C.7 — Repositories panel data (fetched only when on its tab).
   const repos = useRepositories(softwareMode && view === "repositories");
+  // If software mode is toggled OFF while on the Repositories view, the tab +
+  // render both gate off — reset to default so the main area isn't left blank.
+  useEffect(() => {
+    if (!softwareMode && view === "repositories") setView("default");
+  }, [softwareMode, view]);
 
   // Drill-down state — only one open at a time per F-7 Decision 9.
   const [drillId, setDrillId] = useState<string | null>(null);

--- a/src/surface/mc/dashboard-v2/app.tsx
+++ b/src/surface/mc/dashboard-v2/app.tsx
@@ -20,10 +20,13 @@ import { useMetrics } from "./hooks/use-metrics";
 import { useWorkingAgents } from "./hooks/use-working-agents";
 import { MetricsPanel } from "./components/metrics-panel";
 import { SourcesView } from "./components/sources-view";
+import { RepositoriesView } from "./components/repositories-view";
 import { Toast } from "./components/toast";
 import { useFocusArea } from "./hooks/use-focus-area";
 import { useTasks } from "./hooks/use-tasks";
 import { useGitLinks } from "./hooks/use-git-links";
+import { useSoftwareMode } from "./hooks/use-software-mode";
+import { useRepositories } from "./hooks/use-repositories";
 import { useTheme } from "./hooks/use-theme";
 import { useWebSocket } from "./hooks/use-websocket";
 import { ApiFailure, postJson } from "./lib/api";
@@ -46,10 +49,12 @@ import type { Command } from "./components/command-palette";
  * may upgrade to a hash route if deep-linking turns out to be
  * principal-requested; for now the in-memory view is sufficient.
  */
-type DashboardView = "default" | "metrics" | "iterations" | "sources" | "kanban-detail";
+type DashboardView = "default" | "metrics" | "iterations" | "sources" | "repositories" | "kanban-detail";
 
 export function App() {
   const { theme, toggle: toggleTheme } = useTheme();
+  // G-1113.C.7 — software mode gates the Repositories panel.
+  const { softwareMode, toggle: toggleSoftwareMode } = useSoftwareMode();
   const [paletteOpen, setPaletteOpen] = useState(false);
   const [toast, setToast] = useState<{ message: string; tone?: "ok" | "error" | "info" } | null>(null);
 
@@ -82,6 +87,8 @@ export function App() {
   // returns to `iterations`).
   const [view, setView] = useState<DashboardView>("default");
   const [selectedIterationId, setSelectedIterationId] = useState<string | null>(null);
+  // G-1113.C.7 — Repositories panel data (fetched only when on its tab).
+  const repos = useRepositories(softwareMode && view === "repositories");
 
   // Drill-down state — only one open at a time per F-7 Decision 9.
   const [drillId, setDrillId] = useState<string | null>(null);
@@ -200,6 +207,15 @@ export function App() {
           </span>
           <button
             type="button"
+            className={`theme-btn${softwareMode ? " active" : ""}`}
+            onClick={toggleSoftwareMode}
+            aria-pressed={softwareMode}
+            title="Toggle software mode (Repositories panel + Git objects)"
+          >
+            {softwareMode ? "◆ software" : "◇ software"}
+          </button>
+          <button
+            type="button"
             className="theme-btn"
             onClick={toggleTheme}
             aria-label={`Switch to ${theme === "dark" ? "light" : "dark"} theme`}
@@ -251,6 +267,17 @@ export function App() {
         >
           Sources
         </button>
+        {softwareMode && (
+          <button
+            type="button"
+            role="tab"
+            aria-selected={view === "repositories"}
+            className={`tab${view === "repositories" ? " active" : ""}`}
+            onClick={() => setView("repositories")}
+          >
+            Repositories
+          </button>
+        )}
       </nav>
 
       <main className="scaffold-main">
@@ -396,6 +423,11 @@ export function App() {
         {view === "sources" && (
           /* G-1113.B.4 — provider-neutral Sources config view. */
           <SourcesView />
+        )}
+
+        {view === "repositories" && softwareMode && (
+          /* G-1113.C.7 — per-repository software-mode panel. */
+          <RepositoriesView repositories={repos.repositories} loaded={repos.loaded} />
         )}
 
         {view === "iterations" && (

--- a/src/surface/mc/dashboard-v2/components/repositories-view.tsx
+++ b/src/surface/mc/dashboard-v2/components/repositories-view.tsx
@@ -1,0 +1,94 @@
+/**
+ * G-1113.C.7 — per-repository panel (software mode). Each repository card
+ * groups its pull requests, branches, and releases from the Git model.
+ */
+import type { RepositoryView } from "../../api/git-repos";
+
+interface ColItem {
+  key: string;
+  label: string;
+  url: string | null;
+}
+
+function RepoColumn({ title, items }: { title: string; items: ColItem[] }) {
+  return (
+    <div className="repo-col">
+      <h4>
+        {title} <span className="dim">({items.length})</span>
+      </h4>
+      {items.length === 0 ? (
+        <p className="dim faint">—</p>
+      ) : (
+        <ul>
+          {items.map((i) => (
+            <li key={i.key}>
+              {i.url ? (
+                <a href={i.url} target="_blank" rel="noopener noreferrer">
+                  {i.label}
+                </a>
+              ) : (
+                i.label
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+export interface RepositoriesViewProps {
+  repositories: RepositoryView[];
+  loaded: boolean;
+}
+
+export function RepositoriesView({ repositories, loaded }: RepositoriesViewProps) {
+  return (
+    <section className="scaffold-section repos-view" aria-label="Repositories">
+      <h2>Repositories</h2>
+      {!loaded ? (
+        <p className="dim">Loading…</p>
+      ) : repositories.length === 0 ? (
+        <p className="dim">
+          No repositories ingested yet — create a task from a GitHub PR to populate the
+          software-mode model.
+        </p>
+      ) : (
+        repositories.map(({ repository: r, branches, pullRequests, releases }) => (
+          <div key={r.id} className="repo-card">
+            <h3>
+              {r.owner ? `${r.owner}/${r.name}` : r.name}
+              {r.url ? (
+                <a className="dim mono repo-link" href={r.url} target="_blank" rel="noopener noreferrer">
+                  ↗
+                </a>
+              ) : null}
+            </h3>
+            <div className="repo-cols">
+              <RepoColumn
+                title="Pull requests"
+                items={pullRequests.map((p) => ({
+                  key: p.id,
+                  label: `#${p.numberOrKey} · ${p.state}`,
+                  url: p.url,
+                }))}
+              />
+              <RepoColumn
+                title="Branches"
+                items={branches.map((b) => ({ key: b.id, label: b.name, url: b.url }))}
+              />
+              <RepoColumn
+                title="Releases"
+                items={releases.map((rel) => ({
+                  key: rel.id,
+                  label: `${rel.name} · ${rel.state}`,
+                  url: rel.url,
+                }))}
+              />
+            </div>
+          </div>
+        ))
+      )}
+    </section>
+  );
+}

--- a/src/surface/mc/dashboard-v2/hooks/use-repositories.ts
+++ b/src/surface/mc/dashboard-v2/hooks/use-repositories.ts
@@ -1,0 +1,45 @@
+/**
+ * G-1113.C.7 — fetch the per-repository Git projection for the Repositories
+ * panel. Only fetches when `enabled` (software mode on + panel visible).
+ * Best-effort: a failure yields an empty list, not an error surface.
+ */
+import { useEffect, useState } from "react";
+import { getJson } from "../lib/api";
+import type { RepositoryView } from "../../api/git-repos";
+
+interface RepositoriesResponse {
+  repositories: RepositoryView[];
+}
+
+export function useRepositories(enabled: boolean): {
+  repositories: RepositoryView[];
+  loaded: boolean;
+} {
+  const [repositories, setRepositories] = useState<RepositoryView[]>([]);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    if (!enabled) return;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const res = await getJson<RepositoriesResponse>("/api/git/repositories");
+        if (!cancelled) {
+          setRepositories(res.repositories ?? []);
+          setLoaded(true);
+        }
+      } catch (_err) {
+        // Best-effort: the panel shows an empty state rather than an error.
+        if (!cancelled) {
+          setRepositories([]);
+          setLoaded(true);
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [enabled]);
+
+  return { repositories, loaded };
+}

--- a/src/surface/mc/dashboard-v2/hooks/use-software-mode.ts
+++ b/src/surface/mc/dashboard-v2/hooks/use-software-mode.ts
@@ -18,7 +18,12 @@ export function useSoftwareMode(): { softwareMode: boolean; toggle: () => void }
   const [softwareMode, setSoftwareMode] = useState<boolean>(() => readSoftwareMode());
   useEffect(() => {
     if (typeof window === "undefined") return;
-    window.localStorage?.setItem(STORAGE_KEY, softwareMode ? "on" : "off");
+    try {
+      window.localStorage?.setItem(STORAGE_KEY, softwareMode ? "on" : "off");
+    } catch (_err) {
+      // localStorage unavailable (private mode / permissions) — the flag still
+      // applies in-session; persistence is best-effort (matches use-theme).
+    }
   }, [softwareMode]);
   const toggle = useCallback(() => setSoftwareMode((v) => !v), []);
   return { softwareMode, toggle };

--- a/src/surface/mc/dashboard-v2/hooks/use-software-mode.ts
+++ b/src/surface/mc/dashboard-v2/hooks/use-software-mode.ts
@@ -1,0 +1,25 @@
+/**
+ * G-1113.C.7 — software-mode flag (localStorage-persisted, off by default).
+ *
+ * Gates software-development surfaces (the Repositories panel) so the cockpit
+ * stays generic-mode by default and promotes Git objects only when the
+ * principal opts in. Mirrors use-theme's persistence shape.
+ */
+import { useCallback, useEffect, useState } from "react";
+
+const STORAGE_KEY = "mc.softwareMode";
+
+function readSoftwareMode(): boolean {
+  if (typeof window === "undefined") return false;
+  return window.localStorage?.getItem(STORAGE_KEY) === "on";
+}
+
+export function useSoftwareMode(): { softwareMode: boolean; toggle: () => void } {
+  const [softwareMode, setSoftwareMode] = useState<boolean>(() => readSoftwareMode());
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    window.localStorage?.setItem(STORAGE_KEY, softwareMode ? "on" : "off");
+  }, [softwareMode]);
+  const toggle = useCallback(() => setSoftwareMode((v) => !v), []);
+  return { softwareMode, toggle };
+}

--- a/src/surface/mc/dashboard-v2/styles/global.css
+++ b/src/surface/mc/dashboard-v2/styles/global.css
@@ -347,6 +347,24 @@ html, body {
 .sources-view .source-state.state-active { color: var(--d, var(--fg)); }
 .sources-view .source-state.state-available { color: var(--fg-faint); }
 .sources-view .source-available .provider-label { color: var(--fg-faint); }
+
+/* G-1113.C.7 — per-repository panel */
+.repos-view .repo-card {
+  border: 1px solid var(--line); border-radius: 8px;
+  background: var(--panel); padding: 12px 14px; margin-top: 10px;
+}
+.repos-view .repo-card h3 { margin: 0 0 8px 0; font-size: 13px; font-weight: 600; }
+.repos-view .repo-link { margin-left: 6px; text-decoration: none; }
+.repos-view .repo-cols { display: flex; gap: 18px; flex-wrap: wrap; }
+.repos-view .repo-col { flex: 1 1 180px; min-width: 160px; }
+.repos-view .repo-col h4 {
+  margin: 0 0 4px 0; font-size: 10.5px; font-weight: 600;
+  letter-spacing: 0.06em; text-transform: uppercase; color: var(--fg-faint);
+}
+.repos-view .repo-col ul { list-style: none; margin: 0; padding: 0; font-size: 11px; }
+.repos-view .repo-col li { padding: 2px 0; }
+.repos-view .repo-col a { color: var(--fg-dim); text-decoration: none; }
+.repos-view .repo-col a:hover { color: var(--fg); text-decoration: underline; }
 .scaffold-section h2 {
   margin: 0 0 6px 0;
   font-size: 11px; font-weight: 600; letter-spacing: 0.06em;

--- a/src/surface/mc/db/git-objects.ts
+++ b/src/surface/mc/db/git-objects.ts
@@ -605,3 +605,19 @@ export function listReleasesForRepository(db: Database, repositoryId: string): R
     .all(repositoryId) as ReleaseRow[];
   return rows.map(rowToRelease);
 }
+
+/**
+ * G-1113.C.7 — most-recent releases for a repository, newest first, capped.
+ * Backs the Repositories panel's "recent releases" (vs the unbounded
+ * name-ordered list above).
+ */
+export function listRecentReleasesForRepository(
+  db: Database,
+  repositoryId: string,
+  limit = 10
+): Release[] {
+  const rows = db
+    .query(`SELECT * FROM releases WHERE repository_id = ? ORDER BY created_at DESC, id DESC LIMIT ?`)
+    .all(repositoryId, limit) as ReleaseRow[];
+  return rows.map(rowToRelease);
+}

--- a/src/surface/mc/server.ts
+++ b/src/surface/mc/server.ts
@@ -39,6 +39,7 @@ import {
   IMAGE_BODY_MAX_BYTES,
 } from "./api/handlers";
 import { handleListGitLinks } from "./api/git-links";
+import { handleListRepositories } from "./api/git-repos";
 import type { ProcessManager } from "./session/process-manager";
 import type { SpawnFn } from "./session/endpoint-resolver";
 import { join, dirname } from "path";
@@ -396,6 +397,15 @@ async function handleApi(
       return methodNotAllowed(["GET"]);
     }
     return handleListGitLinks(db, url);
+  }
+
+  // G-1113.C.7 — GET /api/git/repositories — repos grouped with branches/PRs/
+  // releases for the software-mode Repositories panel.
+  if (pathname === "/api/git/repositories") {
+    if (req.method !== "GET") {
+      return methodNotAllowed(["GET"]);
+    }
+    return handleListRepositories(db);
   }
 
   if (pathname === "/api/tasks") {


### PR DESCRIPTION
Phase C (#553) **final slice** — the Repositories panel, gated behind a software-mode flag. **Completes Phase C.**

- `api/git-repos.ts` **(new)**: `getRepositoriesWithGit` projection (repos grouped with branches/PRs/releases) + `GET /api/git/repositories`; route registered.
- `dashboard-v2`: `use-software-mode` (localStorage flag, off by default), `use-repositories` (fetch only when on the panel; best-effort), `RepositoriesView` (per-repo card: PRs / branches / releases).
- `app.tsx`: "◇ software" header toggle; Repositories nav tab + view render **only when software mode is on** (generic-mode default, Git objects on opt-in). CSS.

## Verify
`tsc` + `lint` clean · `build:dashboard` ok (artifacts in bundle) · projection/handler + **api.test router regression (123)** green · gate green.

Closes #560. Refs #553, #354.

🤖 Generated with [Claude Code](https://claude.com/claude-code)