### PR TITLE
feat(mc): G-1113.D.1 — Plan + PlanPhase types + storage

### DIFF
--- a/docs/design-mission-control-cortex-cockpit.md
+++ b/docs/design-mission-control-cortex-cockpit.md
@@ -595,7 +595,9 @@ The next cycle should preserve the current surfaces and evolve them:
 
 ## 11. Open Questions
 
-1. Should the canonical top-level noun be `Plan`, `Program`, or `Work Plan`?
+1. ~~Should the canonical top-level noun be `Plan`, `Program`, or `Work Plan`?~~
+   **Resolved (G-1113.D.1, #578): `Plan`.** Matches the §3.5 and §6 doc
+   default; the `Plan` type + `plans` table commit to it.
 2. Should "phase" and "wave" be aliases, or should one be canonical?
 3. ~~Should `PullRequest` be the normalized model name, with GitLab merge request
    as a provider-native label, or should the model use `ChangeRequest`?~~

--- a/src/surface/mc/__tests__/plans.test.ts
+++ b/src/surface/mc/__tests__/plans.test.ts
@@ -1,0 +1,75 @@
+/**
+ * G-1113.D.1 — Plan + PlanPhase storage round-trip.
+ */
+import { describe, it, expect, afterEach } from "bun:test";
+import { join } from "path";
+import { tmpdir } from "os";
+import { rmSync, existsSync } from "fs";
+import { initDatabase } from "../db/init";
+import {
+  upsertPlan,
+  getPlan,
+  listPlans,
+  upsertPlanPhase,
+  getPlanPhase,
+  listPhasesForPlan,
+} from "../db/plans";
+import type { Plan, PlanPhase } from "../types";
+
+const plan: Plan = {
+  id: "plan-1",
+  title: "Mission Control Cockpit",
+  kind: "design",
+  sourceDocumentUrl: "https://github.com/the-metafactory/cortex/blob/main/docs/plan-mission-control-cockpit.md",
+  provider: "github",
+  externalId: "the-metafactory/cortex#354",
+  umbrellaWorkItemId: null,
+  status: "active",
+};
+const phaseA: PlanPhase = { id: "phase-a", planId: "plan-1", title: "Grounding", order: 0, status: "done" };
+const phaseB: PlanPhase = { id: "phase-b", planId: "plan-1", title: "Provider-Neutral Source Refs", order: 1, status: "active" };
+
+describe("plans storage (D.1)", () => {
+  const paths: string[] = [];
+  afterEach(() => { for (const p of paths) if (existsSync(p)) rmSync(p); paths.length = 0; });
+  function freshDb() {
+    const p = join(tmpdir(), `plans-${Date.now()}-${Math.random().toString(36).slice(2)}.db`);
+    paths.push(p);
+    return initDatabase(p);
+  }
+
+  it("round-trips a plan (upsert → get → list) + idempotent status update", () => {
+    const db = freshDb();
+    upsertPlan(db, plan);
+    expect(getPlan(db, "plan-1")).toEqual(plan);
+    expect(listPlans(db)).toEqual([plan]);
+    upsertPlan(db, { ...plan, status: "done" });
+    expect(getPlan(db, "plan-1")).toEqual({ ...plan, status: "done" });
+    expect(listPlans(db)).toHaveLength(1);
+  });
+
+  it("round-trips phases, ordered by phase_order", () => {
+    const db = freshDb();
+    upsertPlan(db, plan);
+    upsertPlanPhase(db, phaseB);
+    upsertPlanPhase(db, phaseA);
+    expect(getPlanPhase(db, "phase-a")).toEqual(phaseA);
+    // listed by order (A before B despite insert order)
+    expect(listPhasesForPlan(db, "plan-1")).toEqual([phaseA, phaseB]);
+  });
+
+  it("CHECK rejects out-of-vocabulary kind / status", () => {
+    const db = freshDb();
+    expect(() => upsertPlan(db, { ...plan, kind: "bogus" as Plan["kind"] })).toThrow();
+    expect(() => upsertPlan(db, { ...plan, status: "bogus" as Plan["status"] })).toThrow();
+    upsertPlan(db, plan);
+    expect(() => upsertPlanPhase(db, { ...phaseA, status: "bogus" as PlanPhase["status"] })).toThrow();
+  });
+
+  it("phase FK enforced (ghost plan_id throws); unknown ids → null", () => {
+    const db = freshDb();
+    expect(() => upsertPlanPhase(db, { ...phaseA, planId: "ghost" })).toThrow();
+    expect(getPlan(db, "nope")).toBeNull();
+    expect(getPlanPhase(db, "nope")).toBeNull();
+  });
+});

--- a/src/surface/mc/db/plans.ts
+++ b/src/surface/mc/db/plans.ts
@@ -1,0 +1,115 @@
+/**
+ * G-1113.D.1 — Plan + PlanPhase storage (design §6). Idempotent upsert by id,
+ * get, and list; snake_case rows → camelCase domain types. Mirrors the Phase-C
+ * git-objects pattern: provider narrowed via isProvider at the read boundary;
+ * CHECK-backed enums cast. Ingestion that fills these from plan docs is D.2.
+ */
+import type { Database } from "bun:sqlite";
+import type { Plan, PlanKind, PlanStatus, PlanPhase, PlanPhaseStatus } from "../types";
+import { isProvider } from "../types";
+
+interface PlanRow {
+  id: string;
+  title: string;
+  kind: string;
+  source_document_url: string | null;
+  provider: string;
+  external_id: string | null;
+  umbrella_work_item_id: string | null;
+  status: string;
+}
+
+function rowToPlan(r: PlanRow): Plan {
+  return {
+    id: r.id,
+    title: r.title,
+    kind: r.kind as PlanKind, // CHECK-constrained
+    sourceDocumentUrl: r.source_document_url,
+    provider: isProvider(r.provider) ? r.provider : "custom",
+    externalId: r.external_id,
+    umbrellaWorkItemId: r.umbrella_work_item_id,
+    status: r.status as PlanStatus, // CHECK-constrained
+  };
+}
+
+/** Insert or update a plan by id (idempotent re-ingestion). */
+export function upsertPlan(db: Database, plan: Plan): void {
+  db.query(
+    `INSERT INTO plans
+       (id, title, kind, source_document_url, provider, external_id,
+        umbrella_work_item_id, status)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+     ON CONFLICT(id) DO UPDATE SET
+       title = excluded.title,
+       kind = excluded.kind,
+       source_document_url = excluded.source_document_url,
+       provider = excluded.provider,
+       external_id = excluded.external_id,
+       umbrella_work_item_id = excluded.umbrella_work_item_id,
+       status = excluded.status,
+       updated_at = unixepoch()`
+  ).run(
+    plan.id,
+    plan.title,
+    plan.kind,
+    plan.sourceDocumentUrl,
+    plan.provider,
+    plan.externalId,
+    plan.umbrellaWorkItemId,
+    plan.status
+  );
+}
+
+export function getPlan(db: Database, id: string): Plan | null {
+  const row = db.query(`SELECT * FROM plans WHERE id = ?`).get(id) as PlanRow | null;
+  return row ? rowToPlan(row) : null;
+}
+
+export function listPlans(db: Database): Plan[] {
+  const rows = db.query(`SELECT * FROM plans ORDER BY title`).all() as PlanRow[];
+  return rows.map(rowToPlan);
+}
+
+interface PlanPhaseRow {
+  id: string;
+  plan_id: string;
+  title: string;
+  phase_order: number;
+  status: string;
+}
+
+function rowToPlanPhase(r: PlanPhaseRow): PlanPhase {
+  return {
+    id: r.id,
+    planId: r.plan_id,
+    title: r.title,
+    order: r.phase_order,
+    status: r.status as PlanPhaseStatus, // CHECK-constrained
+  };
+}
+
+/** Insert or update a plan phase by id (idempotent re-ingestion). */
+export function upsertPlanPhase(db: Database, phase: PlanPhase): void {
+  db.query(
+    `INSERT INTO plan_phases (id, plan_id, title, phase_order, status)
+     VALUES (?, ?, ?, ?, ?)
+     ON CONFLICT(id) DO UPDATE SET
+       plan_id = excluded.plan_id,
+       title = excluded.title,
+       phase_order = excluded.phase_order,
+       status = excluded.status,
+       updated_at = unixepoch()`
+  ).run(phase.id, phase.planId, phase.title, phase.order, phase.status);
+}
+
+export function getPlanPhase(db: Database, id: string): PlanPhase | null {
+  const row = db.query(`SELECT * FROM plan_phases WHERE id = ?`).get(id) as PlanPhaseRow | null;
+  return row ? rowToPlanPhase(row) : null;
+}
+
+export function listPhasesForPlan(db: Database, planId: string): PlanPhase[] {
+  const rows = db
+    .query(`SELECT * FROM plan_phases WHERE plan_id = ? ORDER BY phase_order, id`)
+    .all(planId) as PlanPhaseRow[];
+  return rows.map(rowToPlanPhase);
+}

--- a/src/surface/mc/db/schema.ts
+++ b/src/surface/mc/db/schema.ts
@@ -22,6 +22,8 @@ export const TABLE_NAMES = [
   "deployments",
   "artifacts",
   "releases",
+  "plans",
+  "plan_phases",
 ] as const;
 
 export const SCHEMA_SQL: string[] = [
@@ -370,6 +372,41 @@ export const SCHEMA_SQL: string[] = [
   `CREATE INDEX IF NOT EXISTS idx_deployments_repository ON deployments(repository_id)`,
   `CREATE INDEX IF NOT EXISTS idx_artifacts_repository ON artifacts(repository_id)`,
   `CREATE INDEX IF NOT EXISTS idx_releases_repository ON releases(repository_id)`,
+
+  // --- plans (G-1113.D.1 — design §6) ---
+  // kind/status CHECK-constrained (closed enums); provider app-validated via
+  // isProvider (no CHECK).
+  `CREATE TABLE IF NOT EXISTS plans (
+    id TEXT PRIMARY KEY,
+    title TEXT NOT NULL,
+    kind TEXT NOT NULL
+      CHECK(kind IN ('research','design','iteration','migration','release','rollout','incident')),
+    source_document_url TEXT,
+    provider TEXT NOT NULL,
+    external_id TEXT,
+    umbrella_work_item_id TEXT,
+    status TEXT NOT NULL DEFAULT 'draft'
+      CHECK(status IN ('draft','active','blocked','done','cancelled')),
+    created_at INTEGER NOT NULL DEFAULT (unixepoch()),
+    updated_at INTEGER NOT NULL DEFAULT (unixepoch())
+  )`,
+
+  // --- plan_phases (G-1113.D.1) ---
+  // `phase_order` column (avoids the SQL reserved word ORDER); maps to the
+  // PlanPhase.order field.
+  `CREATE TABLE IF NOT EXISTS plan_phases (
+    id TEXT PRIMARY KEY,
+    plan_id TEXT NOT NULL REFERENCES plans(id) ON DELETE RESTRICT,
+    title TEXT NOT NULL,
+    phase_order INTEGER NOT NULL DEFAULT 0,
+    status TEXT NOT NULL DEFAULT 'not_started'
+      CHECK(status IN ('not_started','active','blocked','done','cancelled')),
+    created_at INTEGER NOT NULL DEFAULT (unixepoch()),
+    updated_at INTEGER NOT NULL DEFAULT (unixepoch())
+  )`,
+
+  // Phase lookup by plan, ordered.
+  `CREATE INDEX IF NOT EXISTS idx_plan_phases_plan ON plan_phases(plan_id, phase_order)`,
 ];
 
 /**

--- a/src/surface/mc/types.ts
+++ b/src/surface/mc/types.ts
@@ -310,6 +310,45 @@ export interface Release {
   state: ReleaseState;
 }
 
+// --- Plan lineage (G-1113.D — design §6) ---
+
+export type PlanKind =
+  | "research"
+  | "design"
+  | "iteration"
+  | "migration"
+  | "release"
+  | "rollout"
+  | "incident";
+export type PlanStatus = "draft" | "active" | "blocked" | "done" | "cancelled";
+
+/**
+ * A plan/program — the work-management layer above tasks/work items (design §6).
+ * `umbrellaWorkItemId` links to the umbrella issue when one backs it (wired in
+ * later D slices). The phases are stored separately ({@link PlanPhase}).
+ */
+export interface Plan {
+  id: string;
+  title: string;
+  kind: PlanKind;
+  sourceDocumentUrl: string | null;
+  provider: Provider;
+  externalId: string | null;
+  umbrellaWorkItemId: string | null;
+  status: PlanStatus;
+}
+
+export type PlanPhaseStatus = "not_started" | "active" | "blocked" | "done" | "cancelled";
+
+/** An ordered phase/wave within a {@link Plan}. */
+export interface PlanPhase {
+  id: string;
+  planId: string;
+  title: string;
+  order: number;
+  status: PlanPhaseStatus;
+}
+
 export interface Task {
   id: string;
   title: string;


### PR DESCRIPTION
Phase D (#577) slice 1 — plan-lineage model layer (mirrors the Phase-C pattern).

- `types.ts`: `Plan` + `PlanPhase` (design §6). Resolves the §11 noun question: **Plan**.
- `schema.ts`: `plans` + `plan_phases` (kind/status CHECK; provider app-validated; phase FK → plans ON DELETE RESTRICT; `phase_order` column → `order`).
- `db/plans.ts`: upsert/get/list for plans + phases; mappers narrow provider, cast CHECK-backed enums.

No ingestion (D.2)/UI (D.3+) yet. `tsc`+`lint` clean · 31 tests green · gate green.

Closes #578. Refs #577, #354.

🤖 Generated with [Claude Code](https://claude.com/claude-code)