### PR TITLE
feat(mc): G-1113.D.2 — plan ingestion from repo-local plan docs

### DIFF
--- a/src/surface/mc/__tests__/plan-docs.test.ts
+++ b/src/surface/mc/__tests__/plan-docs.test.ts
@@ -1,0 +1,160 @@
+/**
+ * G-1113.D.2 — Plan-doc ingestion: parser purity + round-trip persistence.
+ */
+import { describe, it, expect, afterEach } from "bun:test";
+import { join } from "path";
+import { tmpdir } from "os";
+import { mkdtempSync, writeFileSync, rmSync, existsSync } from "fs";
+import { initDatabase } from "../db/init";
+import { getPlan, listPlans, listPhasesForPlan } from "../db/plans";
+import {
+  parsePlanDoc,
+  ingestPlanDoc,
+  ingestPlanDocsFromDir,
+} from "../ingest/plan-docs";
+
+// Cockpit-plan shape: H1 title, **Status:** line, numbered phase headings with id suffix.
+const COCKPIT = `# Plan — Mission Control Cortex Cockpit (G-1113)
+
+**Status:** draft for review
+
+## 5. Phases
+
+### 5.1 Phase A — Grounding (G-1113.A)
+- [ ] something
+### 5.2 Phase B — Provider-Neutral Source Refs (G-1113.B)
+### 5.3 Phase C — Software Mode Domain Model (G-1113.C)
+### 5.4 Phase D — Plan Lineage UI (G-1113.D)
+### 5.5 Phase E — Attention + Notifications (G-1113.E)
+`;
+
+// Iteration shape: bare `## Phase X — Title` headings, no numeric prefix, no Status line.
+const ITERATION = `# Mission Control v2 — Iteration plan
+
+## Phase A — Data foundation + local bot scaffold
+## Phase B — Dashboard attention core
+`;
+
+describe("parsePlanDoc (D.2, pure)", () => {
+  it("parses cockpit-shaped doc: title, kind, status, 5 ordered phases", () => {
+    const { plan, phases } = parsePlanDoc({
+      content: COCKPIT,
+      path: "docs/plan-mission-control-cockpit.md",
+      sourceDocumentUrl: "https://example/blob/docs/plan-mission-control-cockpit.md",
+    });
+    expect(plan.id).toBe("plan-mission-control-cockpit");
+    expect(plan.title).toBe("Plan — Mission Control Cortex Cockpit (G-1113)");
+    expect(plan.kind).toBe("design"); // generic plan default
+    expect(plan.status).toBe("draft"); // from "**Status:** draft for review"
+    expect(plan.provider).toBe("internal"); // repo-local doc default
+    expect(plan.externalId).toBeNull();
+    expect(plan.umbrellaWorkItemId).toBeNull();
+    expect(plan.sourceDocumentUrl).toBe(
+      "https://example/blob/docs/plan-mission-control-cockpit.md"
+    );
+    // 5 phases A–E, document order, trailing "(G-1113.x)" stripped, default not_started.
+    expect(phases.map((p) => [p.id, p.title, p.order, p.status])).toEqual([
+      ["plan-mission-control-cockpit-phase-a", "Grounding", 0, "not_started"],
+      ["plan-mission-control-cockpit-phase-b", "Provider-Neutral Source Refs", 1, "not_started"],
+      ["plan-mission-control-cockpit-phase-c", "Software Mode Domain Model", 2, "not_started"],
+      ["plan-mission-control-cockpit-phase-d", "Plan Lineage UI", 3, "not_started"],
+      ["plan-mission-control-cockpit-phase-e", "Attention + Notifications", 4, "not_started"],
+    ]);
+    expect(phases.every((p) => p.planId === plan.id)).toBe(true);
+  });
+
+  it("parses iteration-shaped doc: kind=iteration, bare phase headings, status defaults active", () => {
+    const { plan, phases } = parsePlanDoc({
+      content: ITERATION,
+      path: "docs/iteration-mission-control.md",
+    });
+    expect(plan.kind).toBe("iteration");
+    expect(plan.status).toBe("active"); // no **Status:** line → active default
+    expect(plan.sourceDocumentUrl).toBeNull();
+    expect(phases.map((p) => p.title)).toEqual([
+      "Data foundation + local bot scaffold",
+      "Dashboard attention core",
+    ]);
+  });
+
+  it("infers kind from filename / title keywords", () => {
+    const k = (path: string, content = "# T\n") => parsePlanDoc({ content, path }).plan.kind;
+    expect(k("docs/iteration-x.md")).toBe("iteration");
+    expect(k("docs/plan-cortex-migration.md")).toBe("migration");
+    expect(k("docs/plan-prod-rollout.md")).toBe("rollout");
+    expect(k("docs/plan-v3-release.md")).toBe("release");
+    expect(k("docs/plan-incident-2026.md")).toBe("incident");
+    expect(k("docs/plan-research-spike.md")).toBe("research");
+    expect(k("docs/plan-collaboration-surface.md")).toBe("design"); // default
+  });
+
+  it("does not false-match 'Phase sequencing' / 'Phase-by-phase' headings", () => {
+    const { phases } = parsePlanDoc({
+      content: "# T\n## 4. Phase sequencing\n## 4. Phase-by-phase plan\n",
+      path: "docs/plan-x.md",
+    });
+    expect(phases).toHaveLength(0);
+  });
+
+  it("doc with no phase headings → plan with zero phases (still valid)", () => {
+    const { plan, phases } = parsePlanDoc({
+      content: "# Just a plan\n\nProse only.\n",
+      path: "docs/plan-prose.md",
+    });
+    expect(plan.id).toBe("plan-prose");
+    expect(phases).toEqual([]);
+  });
+});
+
+describe("ingestPlanDoc / ingestPlanDocsFromDir (D.2, persistence)", () => {
+  const dbPaths: string[] = [];
+  const dirs: string[] = [];
+  afterEach(() => {
+    for (const p of dbPaths) if (existsSync(p)) rmSync(p);
+    for (const d of dirs) if (existsSync(d)) rmSync(d, { recursive: true, force: true });
+    dbPaths.length = 0;
+    dirs.length = 0;
+  });
+  function freshDb() {
+    const p = join(tmpdir(), `plandocs-${Date.now()}-${Math.random().toString(36).slice(2)}.db`);
+    dbPaths.push(p);
+    return initDatabase(p);
+  }
+
+  it("round-trips a doc into plan + phase rows; idempotent re-ingest", () => {
+    const db = freshDb();
+    const src = { content: COCKPIT, path: "docs/plan-mission-control-cockpit.md" };
+    ingestPlanDoc(db, src);
+    const plan = getPlan(db, "plan-mission-control-cockpit");
+    expect(plan?.kind).toBe("design");
+    expect(listPhasesForPlan(db, "plan-mission-control-cockpit")).toHaveLength(5);
+    // Re-ingesting the same doc updates in place — no duplicate plan or phase rows.
+    ingestPlanDoc(db, src);
+    expect(listPlans(db)).toHaveLength(1);
+    expect(listPhasesForPlan(db, "plan-mission-control-cockpit")).toHaveLength(5);
+  });
+
+  it("scans a dir for plan-*/iteration-* docs only, building source URLs", () => {
+    const db = freshDb();
+    const dir = mkdtempSync(join(tmpdir(), "plandocs-dir-"));
+    dirs.push(dir);
+    writeFileSync(join(dir, "plan-mission-control-cockpit.md"), COCKPIT);
+    writeFileSync(join(dir, "iteration-mission-control.md"), ITERATION);
+    writeFileSync(join(dir, "architecture.md"), "# Not a plan\n## Phase A — nope\n"); // ignored
+
+    const ingested = ingestPlanDocsFromDir(db, {
+      docsDir: dir,
+      urlForPath: (rel) => `https://example/blob/${rel}`,
+    });
+
+    expect(ingested.map((p) => p.plan.id).sort()).toEqual([
+      "iteration-mission-control",
+      "plan-mission-control-cockpit",
+    ]);
+    expect(listPlans(db)).toHaveLength(2); // architecture.md skipped
+    expect(getPlan(db, "plan-mission-control-cockpit")?.sourceDocumentUrl).toBe(
+      "https://example/blob/docs/plan-mission-control-cockpit.md"
+    );
+    expect(getPlan(db, "architecture")).toBeNull();
+  });
+});

--- a/src/surface/mc/__tests__/plan-docs.test.ts
+++ b/src/surface/mc/__tests__/plan-docs.test.ts
@@ -88,12 +88,65 @@ describe("parsePlanDoc (D.2, pure)", () => {
     expect(k("docs/plan-collaboration-surface.md")).toBe("design"); // default
   });
 
-  it("does not false-match 'Phase sequencing' / 'Phase-by-phase' headings", () => {
+  it("does not false-match separator-less headings (corpus near-misses)", () => {
     const { phases } = parsePlanDoc({
-      content: "# T\n## 4. Phase sequencing\n## 4. Phase-by-phase plan\n",
+      content: [
+        "# T",
+        "## 4. Phase sequencing", // no separator
+        "## 4. Phase-by-phase plan", // hyphen-joined, not 'Phase <label>'
+        "### Phase A acceptance criteria — ✅ all met (2026-05-15)", // IoAW:149 — words before dash
+        "### Cross-phase parallelism during Phase B", // 'Phase' not at heading start
+      ].join("\n"),
       path: "docs/plan-x.md",
     });
     expect(phases).toHaveLength(0);
+  });
+
+  it("preserves descriptive trailing parens; strips only id-shaped ones (IoAW corpus)", () => {
+    const { phases } = parsePlanDoc({
+      content: [
+        "# Internet of Agentic Work",
+        "## 2. Phase A — Foundation (substrate harness + visibility consumption + stack identity)",
+        "## 3. Phase B — Identity (NKey-signed bot↔bot)",
+        "## 4. Phase C — Policy + schema flip (PolicyEngine at M6)",
+        "### 5.4 Phase D — Plan Lineage UI (G-1113.D)", // id-shaped → stripped
+      ].join("\n"),
+      path: "docs/plan-internet-of-agentic-work.md",
+    });
+    expect(phases.map((p) => p.title)).toEqual([
+      "Foundation (substrate harness + visibility consumption + stack identity)",
+      "Identity (NKey-signed bot↔bot)",
+      "Policy + schema flip (PolicyEngine at M6)",
+      "Plan Lineage UI", // (G-1113.D) stripped
+    ]);
+  });
+
+  it("parses colon-delimited phase headings; preserves non-id '(Future)' (licensing corpus)", () => {
+    const { phases } = parsePlanDoc({
+      content: [
+        "# Licensing",
+        "## Phase 2A: License Foundation",
+        "## Phase 2B: Attribution and Documentation",
+        "## Phase 2D: Brand Protection (Future)",
+      ].join("\n"),
+      path: "docs/iteration-licensing.md",
+    });
+    expect(phases.map((p) => [p.id, p.title])).toEqual([
+      ["iteration-licensing-phase-2a", "License Foundation"],
+      ["iteration-licensing-phase-2b", "Attribution and Documentation"],
+      ["iteration-licensing-phase-2d", "Brand Protection (Future)"],
+    ]);
+  });
+
+  it("status: leading clause wins over narrative prose; word-boundaried (corpus)", () => {
+    const status = (line: string) =>
+      parsePlanDoc({ content: `# T\n\n**Status:** ${line}\n`, path: "docs/plan-x.md" }).plan.status;
+    // direction-a: "Active campaign … ~75% done already" → active, not done
+    expect(status("Active campaign. Re-grounded after audit revealed ~75% done already")).toBe("active");
+    expect(status("disclosed scope")).not.toBe("done"); // 'closed' ⊄ 'disclosed'
+    expect(status("Planned")).toBe("draft"); // licensing
+    expect(status("draft for review")).toBe("draft"); // cockpit
+    expect(status("Blocked on cortex#535")).toBe("blocked");
   });
 
   it("doc with no phase headings → plan with zero phases (still valid)", () => {

--- a/src/surface/mc/ingest/plan-docs.ts
+++ b/src/surface/mc/ingest/plan-docs.ts
@@ -1,0 +1,182 @@
+/**
+ * G-1113.D.2 — Plan ingestion from repo-local plan docs.
+ *
+ * Parses `docs/plan-*.md` / `docs/iteration-*.md` into {@link Plan} + ordered
+ * {@link PlanPhase} skeletons (design §6, plan §5.4). Deterministic + pure:
+ * `parsePlanDoc` takes markdown in and yields rows out; `ingestPlanDoc`
+ * persists them in a transaction via the D.1 storage layer.
+ *
+ * Scope boundary (honest, no-overclaim): we ingest the *skeleton* — title,
+ * kind, sourceDocumentUrl, ordered phases. We do NOT infer phase progress
+ * from the doc's checkboxes: those go stale (the cockpit plan still shows
+ * Phase A `- [ ]` after A merged), so trusting them would assert false
+ * progress. Phase status defaults to `not_started`; the real per-phase
+ * rollup is computed downstream (D.3+) from the Phase-C work-item model.
+ * The one non-stale signal we honour is the author-written `**Status:**`
+ * line, used for the plan's own status.
+ */
+import type { Database } from "bun:sqlite";
+import { readdirSync, readFileSync } from "fs";
+import { basename, join } from "path";
+import type { Plan, PlanKind, PlanPhase, PlanStatus, Provider } from "../types";
+import { upsertPlan, upsertPlanPhase } from "../db/plans";
+
+export interface PlanDocSource {
+  /** Markdown body of the doc. */
+  content: string;
+  /**
+   * Repo-relative path, e.g. `docs/plan-mission-control-cockpit.md`. Drives the
+   * deterministic plan id (basename without extension) and the kind heuristic.
+   */
+  path: string;
+  /** Canonical URL to the doc (e.g. a GitHub blob URL), when known. */
+  sourceDocumentUrl?: string | null;
+  /** Provider the plan is sourced from. Defaults to `internal` (a repo-local doc). */
+  provider?: Provider;
+}
+
+export interface ParsedPlanDoc {
+  plan: Plan;
+  phases: PlanPhase[];
+}
+
+/**
+ * Phase heading shapes handled (the two doc families in scope):
+ *   `### 5.4 Phase D — Plan Lineage UI (G-1113.D)`  (cockpit-plan: numbered, id suffix)
+ *   `## Phase A — Data foundation + local bot scaffold`  (iteration: bare)
+ * The optional `5.4 ` numeric prefix is skipped; the label (`D`, `A`, `1`) is
+ * captured non-greedily up to the first em/en-dash or hyphen separator.
+ */
+const PHASE_RE = /^#{2,4}\s+(?:[\d.]+\.?\s+)?Phase\s+(\S+?)\s*[—–-]\s*(.+?)\s*$/;
+/** First ATX H1 — the plan title. */
+const H1_RE = /^#\s+(.+?)\s*$/;
+/** Author-written status line, e.g. `**Status:** draft for review`. */
+const STATUS_RE = /^\*\*Status:\*\*\s*(.+)$/im;
+/** Trailing parenthetical to strip from a phase title, e.g. ` (G-1113.D)`. */
+const TRAILING_PAREN_RE = /\s*\([^)]*\)\s*$/;
+
+/** Slug used as the plan id — the doc basename without its `.md` extension. */
+function planIdFromPath(path: string): string {
+  return basename(path).replace(/\.md$/i, "");
+}
+
+/** Infer {@link PlanKind} from the filename + title. Generic plans default to `design`. */
+function inferKind(path: string, title: string): PlanKind {
+  const name = basename(path).toLowerCase();
+  if (name.startsWith("iteration-")) return "iteration";
+  const hay = `${name} ${title.toLowerCase()}`;
+  if (/\bmigration\b/.test(hay)) return "migration";
+  if (/\brollout\b/.test(hay)) return "rollout";
+  if (/\brelease\b/.test(hay)) return "release";
+  if (/\bincident\b|\bpost-?mortem\b/.test(hay)) return "incident";
+  if (/\bresearch\b/.test(hay)) return "research";
+  return "design";
+}
+
+/** Map the author-written `**Status:**` line to {@link PlanStatus}; absent → `active`. */
+function inferStatus(content: string): PlanStatus {
+  const raw = STATUS_RE.exec(content)?.[1];
+  if (raw !== undefined) {
+    const s = raw.toLowerCase();
+    if (s.includes("cancel")) return "cancelled";
+    if (/\bdone\b|complete|shipped|closed|merged/.test(s)) return "done";
+    if (s.includes("block")) return "blocked";
+    if (/draft|proposed|review/.test(s)) return "draft";
+    if (/active|progress|in[- ]flight|current/.test(s)) return "active";
+  }
+  // A plan doc that exists and isn't marked otherwise is treated as active work.
+  return "active";
+}
+
+function extractTitle(content: string, fallback: string): string {
+  for (const line of content.split("\n")) {
+    const title = H1_RE.exec(line)?.[1];
+    if (title !== undefined) return title.trim();
+  }
+  return fallback;
+}
+
+/** Parse a plan/iteration markdown doc into a {@link Plan} + ordered phases. Pure. */
+export function parsePlanDoc(src: PlanDocSource): ParsedPlanDoc {
+  const id = planIdFromPath(src.path);
+  const title = extractTitle(src.content, id);
+  const plan: Plan = {
+    id,
+    title,
+    kind: inferKind(src.path, title),
+    sourceDocumentUrl: src.sourceDocumentUrl ?? null,
+    provider: src.provider ?? "internal",
+    externalId: null,
+    umbrellaWorkItemId: null,
+    status: inferStatus(src.content),
+  };
+
+  const phases: PlanPhase[] = [];
+  const lines = src.content.split("\n");
+  let order = 0;
+  for (const line of lines) {
+    const m = PHASE_RE.exec(line);
+    const label = m?.[1];
+    const rawTitle = m?.[2];
+    if (label === undefined || rawTitle === undefined) continue;
+    const phaseTitle = rawTitle.replace(TRAILING_PAREN_RE, "").trim();
+    phases.push({
+      id: `${id}-phase-${label.toLowerCase()}`,
+      planId: id,
+      title: phaseTitle,
+      order: order++,
+      // Honest default — real per-phase progress is rolled up downstream (D.3+)
+      // from the work-item model, not inferred from (stale) doc checkboxes.
+      status: "not_started",
+    });
+  }
+
+  return { plan, phases };
+}
+
+/** Parse + persist a single plan doc (plan + phases) in one transaction. Idempotent by id. */
+export function ingestPlanDoc(db: Database, src: PlanDocSource): ParsedPlanDoc {
+  const parsed = parsePlanDoc(src);
+  const persist = db.transaction(() => {
+    upsertPlan(db, parsed.plan);
+    for (const phase of parsed.phases) upsertPlanPhase(db, phase);
+  });
+  persist();
+  return parsed;
+}
+
+/** Matches the in-scope doc families: `plan-*.md` and `iteration-*.md`. */
+const PLAN_DOC_FILE_RE = /^(plan|iteration)-.*\.md$/i;
+
+export interface IngestDirOptions {
+  /** Absolute path to the directory holding the plan/iteration docs (e.g. `<repo>/docs`). */
+  docsDir: string;
+  /** Repo-relative prefix recorded in each plan's `path`. Default `"docs"`. */
+  repoRelDir?: string;
+  /** Build a `sourceDocumentUrl` from a repo-relative path; return null when unknown. */
+  urlForPath?: (repoRelPath: string) => string | null;
+}
+
+/**
+ * Ingest every `plan-*.md` / `iteration-*.md` under {@link IngestDirOptions.docsDir}.
+ * Thin I/O wrapper around {@link ingestPlanDoc}; sorted for deterministic order.
+ */
+export function ingestPlanDocsFromDir(db: Database, opts: IngestDirOptions): ParsedPlanDoc[] {
+  const repoRelDir = opts.repoRelDir ?? "docs";
+  const files = readdirSync(opts.docsDir)
+    .filter((f) => PLAN_DOC_FILE_RE.test(f))
+    .sort();
+  const out: ParsedPlanDoc[] = [];
+  for (const f of files) {
+    const content = readFileSync(join(opts.docsDir, f), "utf8");
+    const repoRel = `${repoRelDir}/${f}`;
+    out.push(
+      ingestPlanDoc(db, {
+        content,
+        path: repoRel,
+        sourceDocumentUrl: opts.urlForPath?.(repoRel) ?? null,
+      })
+    );
+  }
+  return out;
+}

--- a/src/surface/mc/ingest/plan-docs.ts
+++ b/src/surface/mc/ingest/plan-docs.ts
@@ -41,19 +41,30 @@ export interface ParsedPlanDoc {
 }
 
 /**
- * Phase heading shapes handled (the two doc families in scope):
- *   `### 5.4 Phase D — Plan Lineage UI (G-1113.D)`  (cockpit-plan: numbered, id suffix)
- *   `## Phase A — Data foundation + local bot scaffold`  (iteration: bare)
- * The optional `5.4 ` numeric prefix is skipped; the label (`D`, `A`, `1`) is
- * captured non-greedily up to the first em/en-dash or hyphen separator.
+ * Phase heading shapes handled across the real `docs/plan-*` / `docs/iteration-*`
+ * corpus (H2–H6 ATX):
+ *   `### 5.4 Phase D — Plan Lineage UI (G-1113.D)`     (cockpit: numbered, id suffix)
+ *   `## 2. Phase A — Foundation (substrate harness …)`  (IoAW: numbered, descriptive paren)
+ *   `## Phase A — Data foundation + local bot scaffold` (iteration: bare, em-dash)
+ *   `## Phase 2A: License Foundation`                   (iteration: colon separator)
+ * The optional numeric prefix (`5.4 `, `2. `) is skipped; the label (`D`, `2A`)
+ * is captured non-greedily up to the first em/en-dash, hyphen, OR colon. A
+ * separator is required, so subsection headings with words between the label and
+ * a later dash (`### Phase A acceptance criteria — ✅ all met`) do NOT match.
  */
-const PHASE_RE = /^#{2,4}\s+(?:[\d.]+\.?\s+)?Phase\s+(\S+?)\s*[—–-]\s*(.+?)\s*$/;
+const PHASE_RE = /^#{2,6}\s+(?:[\d.]+\.?\s+)?Phase\s+(\S+?)\s*[—–:-]\s*(.+?)\s*$/;
 /** First ATX H1 — the plan title. */
 const H1_RE = /^#\s+(.+?)\s*$/;
 /** Author-written status line, e.g. `**Status:** draft for review`. */
 const STATUS_RE = /^\*\*Status:\*\*\s*(.+)$/im;
-/** Trailing parenthetical to strip from a phase title, e.g. ` (G-1113.D)`. */
-const TRAILING_PAREN_RE = /\s*\([^)]*\)\s*$/;
+/**
+ * Trailing parenthetical to strip from a phase title — ONLY when it's a compact
+ * id token (a feature/issue id like `(G-1113.D)` or `(#42)`): no spaces, and at
+ * least one digit. Descriptive parens that are part of the human title
+ * (`(substrate harness + visibility consumption)`, `(NKey-signed bot↔bot)`,
+ * `(Future)`) contain spaces and/or no digit, so they're preserved.
+ */
+const TRAILING_PAREN_RE = /\s*\((?=[\w.#-]*\d)[\w.#-]+\)\s*$/;
 
 /** Slug used as the plan id — the doc basename without its `.md` extension. */
 function planIdFromPath(path: string): string {
@@ -77,12 +88,16 @@ function inferKind(path: string, title: string): PlanKind {
 function inferStatus(content: string): PlanStatus {
   const raw = STATUS_RE.exec(content)?.[1];
   if (raw !== undefined) {
-    const s = raw.toLowerCase();
-    if (s.includes("cancel")) return "cancelled";
-    if (/\bdone\b|complete|shipped|closed|merged/.test(s)) return "done";
-    if (s.includes("block")) return "blocked";
-    if (/draft|proposed|review/.test(s)) return "draft";
-    if (/active|progress|in[- ]flight|current/.test(s)) return "active";
+    // Match keywords against the LEADING CLAUSE only. Status lines often run on
+    // into narrative prose (`Active campaign. … ~75% done already`) that would
+    // poison a whole-line scan — the "done" in the narrative must not beat the
+    // leading "Active". Word boundaries keep `closed` out of `disclosed` etc.
+    const head = (raw.split(/[.,;:—–]/)[0] ?? "").toLowerCase().trim();
+    if (/\bcancel(?:l?ed)?\b/.test(head)) return "cancelled";
+    if (/\b(?:done|complete|completed|shipped|closed|merged)\b/.test(head)) return "done";
+    if (/\bblock(?:ed)?\b/.test(head)) return "blocked";
+    if (/\b(?:draft|proposed|review|planned|backlog)\b/.test(head)) return "draft";
+    if (/\b(?:active|progress|in[- ]flight|current)\b/.test(head)) return "active";
   }
   // A plan doc that exists and isn't marked otherwise is treated as active work.
   return "active";
@@ -120,6 +135,10 @@ export function parsePlanDoc(src: PlanDocSource): ParsedPlanDoc {
     const rawTitle = m?.[2];
     if (label === undefined || rawTitle === undefined) continue;
     const phaseTitle = rawTitle.replace(TRAILING_PAREN_RE, "").trim();
+    // Phase id is derived from the label; real plan docs use unique labels
+    // (A/B/C…). If a doc ever repeated a label, parsePlanDoc still yields both
+    // rows (distinct order), but ingestPlanDoc's upsert would collapse them onto
+    // one row by id (last writer wins) — acceptable given the corpus, noted here.
     phases.push({
       id: `${id}-phase-${label.toLowerCase()}`,
       planId: id,


### PR DESCRIPTION
## G-1113.D.2 — Plan ingestion from repo-local plan docs

Parses `docs/plan-*.md` / `docs/iteration-*.md` into `Plan` + ordered `PlanPhase` skeletons (design §6, plan §5.4), persisted via the D.1 storage layer. This is the ingestion path that feeds the Plan overview surface (D.3).

### What's here
- **`src/surface/mc/ingest/plan-docs.ts`**
  - `parsePlanDoc` (pure): first H1 → title; filename/title keyword heuristic → `kind` (`iteration` / `migration` / `rollout` / `release` / `incident` / `research`, else `design`); author-written `**Status:**` line → `PlanStatus`; phase headings (`### N.M Phase X — Title (id)` **and** `## Phase X — Title`) → ordered `PlanPhase` rows with deterministic ids (`{planId}-phase-{label}`), trailing `(…)` stripped.
  - `ingestPlanDoc`: parse + upsert plan + phases in one transaction (idempotent by id).
  - `ingestPlanDocsFromDir`: thin `fs` scan over `plan-*`/`iteration-*` docs, builds `sourceDocumentUrl` via a caller hook.
- **`__tests__/plan-docs.test.ts`**: parser purity (title/kind/status/phase order + paren-strip + no false-match on `## 4. Phase sequencing` / `Phase-by-phase`), zero-phase docs, round-trip persistence, idempotent re-ingest, dir-scan filtering (ignores non-`plan/iteration` `.md`).

### Honest-skeleton scope (no-overclaim)
Phase status defaults to `not_started`. The cockpit plan's checkboxes go **stale** (Phase A still shows `- [ ]` after A merged), so trusting them would assert false progress. Real per-phase progress rollup is deferred to **D.3+**, computed from the Phase-C work-item model — not parsed from the doc. The one non-stale signal honoured is the author-written `**Status:**` line, used only for the plan's own status.

### Verification
- `bunx tsc --noEmit` clean
- `bun run lint` — 0 errors (pre-existing `bus-peer` warnings only)
- `bun test src/surface/mc` — 1201 pass / 0 fail
- carve-out gate: PASS

Closes #579. Part of #577, umbrella #354.