### PR TITLE
feat(mc): G-1113.D.4 — WorkItem model + phase-detail surface (design §6/§7.2)

### DIFF
--- a/src/surface/mc/__tests__/work-items.test.ts
+++ b/src/surface/mc/__tests__/work-items.test.ts
@@ -1,0 +1,168 @@
+/**
+ * G-1113.D.4 — WorkItem storage round-trip + phase-detail projection.
+ */
+import { describe, it, expect, afterEach } from "bun:test";
+import { join } from "path";
+import { tmpdir } from "os";
+import { rmSync, existsSync } from "fs";
+import { initDatabase } from "../db/init";
+import { upsertPlan, upsertPlanPhase } from "../db/plans";
+import {
+  upsertWorkItem,
+  getWorkItem,
+  listWorkItemsForPhase,
+  listWorkItemsForPlan,
+} from "../db/work-items";
+import { upsertRepository, upsertPullRequest } from "../db/git-objects";
+import { getPhaseDetail, handleGetPhaseDetail } from "../api/phase-detail";
+import type { Plan, PlanPhase, WorkItem, GitRepository, PullRequest } from "../types";
+
+const plan: Plan = {
+  id: "plan-1",
+  title: "Cockpit",
+  kind: "design",
+  sourceDocumentUrl: null,
+  provider: "internal",
+  externalId: null,
+  umbrellaWorkItemId: null,
+  status: "active",
+};
+const phaseA: PlanPhase = { id: "phase-a", planId: "plan-1", title: "A", order: 0, status: "active" };
+const phaseB: PlanPhase = { id: "phase-b", planId: "plan-1", title: "B", order: 1, status: "not_started" };
+
+const wi = (over: Partial<WorkItem>): WorkItem => ({
+  id: "wi-1",
+  planId: "plan-1",
+  phaseId: "phase-a",
+  parentId: null,
+  title: "Work item",
+  description: null,
+  status: "open",
+  priority: "1",
+  provider: "github",
+  externalId: "the-metafactory/cortex#42",
+  url: "https://github.com/the-metafactory/cortex/issues/42",
+  ...over,
+});
+
+describe("work-items storage (D.4)", () => {
+  const paths: string[] = [];
+  afterEach(() => {
+    for (const p of paths) if (existsSync(p)) rmSync(p);
+    paths.length = 0;
+  });
+  function freshDb() {
+    const p = join(tmpdir(), `wi-${Date.now()}-${Math.random().toString(36).slice(2)}.db`);
+    paths.push(p);
+    return initDatabase(p);
+  }
+
+  it("round-trips a work item + idempotent update; nullable plan/phase/parent", () => {
+    const db = freshDb();
+    upsertPlan(db, plan);
+    upsertPlanPhase(db, phaseA);
+    const item = wi({});
+    upsertWorkItem(db, item);
+    expect(getWorkItem(db, "wi-1")).toEqual(item);
+    upsertWorkItem(db, { ...item, status: "done" });
+    expect(getWorkItem(db, "wi-1")?.status).toBe("done");
+    // Fully-unlinked work item (no plan/phase/parent) is valid.
+    const orphan = wi({ id: "wi-x", planId: null, phaseId: null, parentId: null });
+    upsertWorkItem(db, orphan);
+    expect(getWorkItem(db, "wi-x")).toEqual(orphan);
+  });
+
+  it("lists by phase (priority,title ordered) and by plan; unknown id → null", () => {
+    const db = freshDb();
+    upsertPlan(db, plan);
+    upsertPlanPhase(db, phaseA);
+    upsertPlanPhase(db, phaseB);
+    upsertWorkItem(db, wi({ id: "wi-2", phaseId: "phase-a", priority: "2", title: "beta" }));
+    upsertWorkItem(db, wi({ id: "wi-1", phaseId: "phase-a", priority: "1", title: "alpha" }));
+    upsertWorkItem(db, wi({ id: "wi-3", phaseId: "phase-b", priority: "1", title: "gamma" }));
+    expect(listWorkItemsForPhase(db, "phase-a").map((w) => w.id)).toEqual(["wi-1", "wi-2"]);
+    expect(listWorkItemsForPhase(db, "phase-b").map((w) => w.id)).toEqual(["wi-3"]);
+    expect(listWorkItemsForPlan(db, "plan-1").map((w) => w.id)).toEqual(["wi-1", "wi-3", "wi-2"]);
+    expect(getWorkItem(db, "nope")).toBeNull();
+  });
+
+  it("FK enforced: ghost phase_id / plan_id / parent_id throw", () => {
+    const db = freshDb();
+    upsertPlan(db, plan);
+    upsertPlanPhase(db, phaseA);
+    expect(() => upsertWorkItem(db, wi({ phaseId: "ghost" }))).toThrow();
+    expect(() => upsertWorkItem(db, wi({ planId: "ghost" }))).toThrow();
+    expect(() => upsertWorkItem(db, wi({ parentId: "ghost" }))).toThrow();
+  });
+});
+
+describe("getPhaseDetail / handleGetPhaseDetail (D.4)", () => {
+  const paths: string[] = [];
+  afterEach(() => {
+    for (const p of paths) if (existsSync(p)) rmSync(p);
+    paths.length = 0;
+  });
+  function freshDb() {
+    const p = join(tmpdir(), `pd-${Date.now()}-${Math.random().toString(36).slice(2)}.db`);
+    paths.push(p);
+    return initDatabase(p);
+  }
+
+  it("projects phase + plan + work items, each with linked PRs", () => {
+    const db = freshDb();
+    upsertPlan(db, plan);
+    upsertPlanPhase(db, phaseA);
+    upsertWorkItem(db, wi({ id: "wi-1", phaseId: "phase-a" }));
+
+    const repo: GitRepository = {
+      id: "repo-1",
+      provider: "github",
+      owner: "the-metafactory",
+      name: "cortex",
+      url: null,
+      defaultBranch: "main",
+    };
+    upsertRepository(db, repo);
+    const pr: PullRequest = {
+      id: "pr-1",
+      workItemId: "wi-1",
+      repositoryId: "repo-1",
+      provider: "github",
+      providerNativeType: "pull_request",
+      externalId: "the-metafactory/cortex#42",
+      numberOrKey: "42",
+      title: "Implement wi-1",
+      sourceBranch: "feat/x",
+      targetBranch: "main",
+      url: "https://github.com/the-metafactory/cortex/pull/42",
+      state: "open",
+      reviewState: "needs_review",
+    };
+    upsertPullRequest(db, pr);
+
+    const detail = getPhaseDetail(db, "phase-a");
+    expect(detail?.phase.id).toBe("phase-a");
+    expect(detail?.plan?.id).toBe("plan-1");
+    expect(detail?.workItems).toHaveLength(1);
+    expect(detail?.workItems[0]?.workItem.id).toBe("wi-1");
+    expect(detail?.workItems[0]?.pullRequests.map((p) => p.id)).toEqual(["pr-1"]);
+  });
+
+  it("phase with no work items projects an empty list (honest empty state)", () => {
+    const db = freshDb();
+    upsertPlan(db, plan);
+    upsertPlanPhase(db, phaseA);
+    const detail = getPhaseDetail(db, "phase-a");
+    expect(detail?.workItems).toEqual([]);
+    expect(detail?.plan?.id).toBe("plan-1");
+  });
+
+  it("unknown phase → getPhaseDetail null, handler 404", async () => {
+    const db = freshDb();
+    expect(getPhaseDetail(db, "nope")).toBeNull();
+    const res = handleGetPhaseDetail(db, "nope");
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain("not found");
+  });
+});

--- a/src/surface/mc/__tests__/work-items.test.ts
+++ b/src/surface/mc/__tests__/work-items.test.ts
@@ -94,6 +94,27 @@ describe("work-items storage (D.4)", () => {
     expect(() => upsertWorkItem(db, wi({ planId: "ghost" }))).toThrow();
     expect(() => upsertWorkItem(db, wi({ parentId: "ghost" }))).toThrow();
   });
+
+  it("self-ref parent FK satisfied: child links to a parent work item", () => {
+    const db = freshDb();
+    upsertPlan(db, plan);
+    upsertPlanPhase(db, phaseA);
+    // Insert order is load-bearing under FK enforcement: parent before child.
+    upsertWorkItem(db, wi({ id: "wi-parent", parentId: null, title: "parent" }));
+    upsertWorkItem(db, wi({ id: "wi-child", parentId: "wi-parent", title: "child" }));
+    expect(getWorkItem(db, "wi-child")?.parentId).toBe("wi-parent");
+    expect(listWorkItemsForPhase(db, "phase-a").map((w) => w.id)).toEqual(["wi-child", "wi-parent"]);
+  });
+
+  it("phase ordering is lexicographic by priority (spec: priority is a string)", () => {
+    const db = freshDb();
+    upsertPlan(db, plan);
+    upsertPlanPhase(db, phaseA);
+    upsertWorkItem(db, wi({ id: "wi-10", priority: "10", title: "ten" }));
+    upsertWorkItem(db, wi({ id: "wi-2", priority: "2", title: "two" }));
+    // '10' < '2' lexicographically — locks the documented (§6 string-priority) behaviour.
+    expect(listWorkItemsForPhase(db, "phase-a").map((w) => w.id)).toEqual(["wi-10", "wi-2"]);
+  });
 });
 
 describe("getPhaseDetail / handleGetPhaseDetail (D.4)", () => {

--- a/src/surface/mc/api/phase-detail.ts
+++ b/src/surface/mc/api/phase-detail.ts
@@ -1,0 +1,59 @@
+/**
+ * G-1113.D.4 — phase-detail projection + endpoint (design §7.2).
+ *
+ * A single phase with its parent plan and the work items filed under it, each
+ * work item carrying its linked pull requests (via PullRequest.workItemId).
+ *
+ * Honest-data scope: §7.2 also lists sessions, branches, checks/reviews, and
+ * attention items. Of those, only PR linkage is queryable today —
+ * `pull_requests.work_item_id` exists + is indexed. Sessions have no work-item
+ * column (they link via assignment→task), and attention items are Phase E. So
+ * those sections are intentionally NOT projected here; they deepen in later
+ * slices as the linkage lands. Work items themselves are empty until WorkItem
+ * ingestion (a filed D.4 follow-up) — the surface shows an honest empty state.
+ */
+import type { Database } from "bun:sqlite";
+import type { Plan, PlanPhase, WorkItem, PullRequest } from "../types";
+import { getPlan } from "../db/plans";
+import { getPlanPhase } from "../db/plans";
+import { listWorkItemsForPhase } from "../db/work-items";
+import { listPullRequestsForWorkItem } from "../db/git-objects";
+
+export interface WorkItemWithLinks {
+  workItem: WorkItem;
+  pullRequests: PullRequest[];
+}
+
+export interface PhaseDetail {
+  phase: PlanPhase;
+  /** Parent plan, when the phase's plan row resolves (it always should via FK). */
+  plan: Plan | null;
+  workItems: WorkItemWithLinks[];
+}
+
+/** Project a single phase with its plan + work items (each with linked PRs). Null if the phase is unknown. */
+export function getPhaseDetail(db: Database, phaseId: string): PhaseDetail | null {
+  const phase = getPlanPhase(db, phaseId);
+  if (!phase) return null;
+  const plan = getPlan(db, phase.planId);
+  const workItems = listWorkItemsForPhase(db, phaseId).map((workItem) => ({
+    workItem,
+    pullRequests: listPullRequestsForWorkItem(db, workItem.id),
+  }));
+  return { phase, plan, workItems };
+}
+
+/** GET /api/phases/:id — phase detail (plan + work items + linked PRs); 404 if unknown. */
+export function handleGetPhaseDetail(db: Database, phaseId: string): Response {
+  const detail = getPhaseDetail(db, phaseId);
+  if (!detail) {
+    return new Response(JSON.stringify({ error: "phase not found" }), {
+      status: 404,
+      headers: { "content-type": "application/json" },
+    });
+  }
+  return new Response(JSON.stringify(detail), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}

--- a/src/surface/mc/api/phase-detail.ts
+++ b/src/surface/mc/api/phase-detail.ts
@@ -14,8 +14,7 @@
  */
 import type { Database } from "bun:sqlite";
 import type { Plan, PlanPhase, WorkItem, PullRequest } from "../types";
-import { getPlan } from "../db/plans";
-import { getPlanPhase } from "../db/plans";
+import { getPlan, getPlanPhase } from "../db/plans";
 import { listWorkItemsForPhase } from "../db/work-items";
 import { listPullRequestsForWorkItem } from "../db/git-objects";
 

--- a/src/surface/mc/dashboard-v2/app.tsx
+++ b/src/surface/mc/dashboard-v2/app.tsx
@@ -22,6 +22,7 @@ import { MetricsPanel } from "./components/metrics-panel";
 import { SourcesView } from "./components/sources-view";
 import { RepositoriesView } from "./components/repositories-view";
 import { PlansView } from "./components/plans-view";
+import { PhaseDetailView } from "./components/phase-detail-view";
 import { Toast } from "./components/toast";
 import { useFocusArea } from "./hooks/use-focus-area";
 import { useTasks } from "./hooks/use-tasks";
@@ -29,6 +30,7 @@ import { useGitLinks } from "./hooks/use-git-links";
 import { useSoftwareMode } from "./hooks/use-software-mode";
 import { useRepositories } from "./hooks/use-repositories";
 import { usePlans } from "./hooks/use-plans";
+import { usePhaseDetail } from "./hooks/use-phase-detail";
 import { useTheme } from "./hooks/use-theme";
 import { useWebSocket } from "./hooks/use-websocket";
 import { ApiFailure, postJson } from "./lib/api";
@@ -51,7 +53,7 @@ import type { Command } from "./components/command-palette";
  * may upgrade to a hash route if deep-linking turns out to be
  * principal-requested; for now the in-memory view is sufficient.
  */
-type DashboardView = "default" | "metrics" | "iterations" | "sources" | "repositories" | "plans" | "kanban-detail";
+type DashboardView = "default" | "metrics" | "iterations" | "sources" | "repositories" | "plans" | "phase-detail" | "kanban-detail";
 
 export function App() {
   const { theme, toggle: toggleTheme } = useTheme();
@@ -89,15 +91,22 @@ export function App() {
   // returns to `iterations`).
   const [view, setView] = useState<DashboardView>("default");
   const [selectedIterationId, setSelectedIterationId] = useState<string | null>(null);
+  // G-1113.D.4 — selected phase for the phase-detail surface (reached from the
+  // Plans overview by clicking a phase; exited back to `plans`).
+  const [selectedPhaseId, setSelectedPhaseId] = useState<string | null>(null);
   // G-1113.C.7 — Repositories panel data (fetched only when on its tab).
   const repos = useRepositories(softwareMode && view === "repositories");
   // G-1113.D.3 — Plans overview data (fetched only when on its tab).
   const plans = usePlans(softwareMode && view === "plans");
+  // G-1113.D.4 — phase-detail data (fetched whenever a phase is selected).
+  const phaseDetail = usePhaseDetail(view === "phase-detail" ? selectedPhaseId : null);
   // If software mode is toggled OFF while on a software-mode view (Repositories
-  // / Plans), the tab + render both gate off — reset to default so the main
-  // area isn't left blank.
+  // / Plans / phase-detail), the tab + render both gate off — reset to default
+  // so the main area isn't left blank.
   useEffect(() => {
-    if (!softwareMode && (view === "repositories" || view === "plans")) setView("default");
+    if (!softwareMode && (view === "repositories" || view === "plans" || view === "phase-detail")) {
+      setView("default");
+    }
   }, [softwareMode, view]);
 
   // Drill-down state — only one open at a time per F-7 Decision 9.
@@ -452,8 +461,16 @@ export function App() {
         )}
 
         {view === "plans" && softwareMode && (
-          /* G-1113.D.3 — plan overview surface. */
-          <PlansView plans={plans.plans} loaded={plans.loaded} />
+          /* G-1113.D.3 — plan overview surface. D.4 — clicking a phase opens
+             the phase-detail surface. */
+          <PlansView
+            plans={plans.plans}
+            loaded={plans.loaded}
+            onOpenPhase={(phaseId) => {
+              setSelectedPhaseId(phaseId);
+              setView("phase-detail");
+            }}
+          />
         )}
 
         {view === "iterations" && (
@@ -577,6 +594,18 @@ export function App() {
               // applied optimistic updates, but a refetch is cheap and
               // resyncs any inbox drift).
               iterations.refetch();
+            }}
+          />
+        )}
+
+        {view === "phase-detail" && softwareMode && (
+          /* G-1113.D.4 — phase-detail surface (reached from a Plans phase row). */
+          <PhaseDetailView
+            detail={phaseDetail.detail}
+            loaded={phaseDetail.loaded}
+            onClose={() => {
+              setView("plans");
+              setSelectedPhaseId(null);
             }}
           />
         )}

--- a/src/surface/mc/dashboard-v2/app.tsx
+++ b/src/surface/mc/dashboard-v2/app.tsx
@@ -598,8 +598,10 @@ export function App() {
           />
         )}
 
-        {view === "phase-detail" && softwareMode && (
-          /* G-1113.D.4 — phase-detail surface (reached from a Plans phase row). */
+        {view === "phase-detail" && softwareMode && selectedPhaseId && (
+          /* G-1113.D.4 — phase-detail surface (reached from a Plans phase row).
+             Guard on selectedPhaseId too (mirrors kanban-detail) so the surface
+             never renders a perpetual "Loading…" if view is ever set without one. */
           <PhaseDetailView
             detail={phaseDetail.detail}
             loaded={phaseDetail.loaded}

--- a/src/surface/mc/dashboard-v2/components/phase-detail-view.tsx
+++ b/src/surface/mc/dashboard-v2/components/phase-detail-view.tsx
@@ -1,0 +1,85 @@
+/**
+ * G-1113.D.4 — phase-detail surface (design §7.2). Shows a phase's parent plan,
+ * its work items, and each work item's linked pull requests.
+ *
+ * Honest-data scope: §7.2 also lists sessions / branches / checks / reviews /
+ * attention items; only PR linkage is queryable today (see api/phase-detail.ts),
+ * so those sections aren't shown — they deepen as the linkage lands. Work items
+ * are empty until WorkItem ingestion (a filed follow-up); the surface shows an
+ * honest empty state meanwhile.
+ */
+import type { PhaseDetail } from "../../api/phase-detail";
+
+export interface PhaseDetailViewProps {
+  detail: PhaseDetail | null;
+  loaded: boolean;
+  onClose: () => void;
+}
+
+export function PhaseDetailView({ detail, loaded, onClose }: PhaseDetailViewProps) {
+  return (
+    <section className="scaffold-section phase-detail" aria-label="Phase detail">
+      <div className="phase-detail-head">
+        <button type="button" className="tab" onClick={onClose}>
+          ← Plans
+        </button>
+      </div>
+
+      {!loaded ? (
+        <p className="dim">Loading…</p>
+      ) : !detail ? (
+        <p className="dim">Phase not found.</p>
+      ) : (
+        <>
+          <h2>{detail.phase.title}</h2>
+          <p className="plan-meta">
+            {detail.plan ? <span className="dim">{detail.plan.title}</span> : null}
+            <span className={`badge status-${detail.phase.status}`}>{detail.phase.status}</span>
+          </p>
+
+          <h3 className="phase-section-label">
+            Work items <span className="dim">({detail.workItems.length})</span>
+          </h3>
+          {detail.workItems.length === 0 ? (
+            <p className="dim faint">
+              No work items linked to this phase yet — work-item ingestion lands in a later slice.
+            </p>
+          ) : (
+            <ul className="work-items">
+              {detail.workItems.map(({ workItem: w, pullRequests }) => (
+                <li key={w.id} className="work-item">
+                  <div className="work-item-head">
+                    {w.url ? (
+                      <a href={w.url} target="_blank" rel="noopener noreferrer">
+                        {w.title}
+                      </a>
+                    ) : (
+                      <span>{w.title}</span>
+                    )}
+                    {w.status ? <span className="badge">{w.status}</span> : null}
+                  </div>
+                  {pullRequests.length > 0 ? (
+                    <ul className="work-item-prs">
+                      {pullRequests.map((pr) => (
+                        <li key={pr.id}>
+                          {pr.url ? (
+                            <a href={pr.url} target="_blank" rel="noopener noreferrer">
+                              #{pr.numberOrKey}
+                            </a>
+                          ) : (
+                            <span>#{pr.numberOrKey}</span>
+                          )}{" "}
+                          <span className={`phase-status status-${pr.state}`}>{pr.state}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  ) : null}
+                </li>
+              ))}
+            </ul>
+          )}
+        </>
+      )}
+    </section>
+  );
+}

--- a/src/surface/mc/dashboard-v2/components/plans-view.tsx
+++ b/src/surface/mc/dashboard-v2/components/plans-view.tsx
@@ -30,9 +30,11 @@ function progressLine(ov: PlanOverview): string {
 export interface PlansViewProps {
   plans: PlanOverview[];
   loaded: boolean;
+  /** Open the phase-detail surface for a phase (D.4). */
+  onOpenPhase?: (phaseId: string) => void;
 }
 
-export function PlansView({ plans, loaded }: PlansViewProps) {
+export function PlansView({ plans, loaded, onOpenPhase }: PlansViewProps) {
   return (
     <section className="scaffold-section plans-view" aria-label="Plans">
       <h2>Plans</h2>
@@ -69,17 +71,33 @@ export function PlansView({ plans, loaded }: PlansViewProps) {
               <p className="dim faint">No phases parsed from the source doc.</p>
             ) : (
               <ol className="plan-phases">
-                {ov.phases.map((ph) => (
-                  <li
-                    key={ph.id}
-                    className={`plan-phase${ph.id === ov.currentPhaseId ? " current" : ""}`}
-                  >
-                    <span className="phase-title">{ph.title}</span>
-                    <span className={`phase-status status-${ph.status}`}>
-                      {PHASE_STATUS_LABEL[ph.status]}
-                    </span>
-                  </li>
-                ))}
+                {ov.phases.map((ph) => {
+                  const cls = `plan-phase${ph.id === ov.currentPhaseId ? " current" : ""}`;
+                  const inner = (
+                    <>
+                      <span className="phase-title">{ph.title}</span>
+                      <span className={`phase-status status-${ph.status}`}>
+                        {PHASE_STATUS_LABEL[ph.status]}
+                      </span>
+                    </>
+                  );
+                  return (
+                    <li key={ph.id} className={cls}>
+                      {onOpenPhase ? (
+                        <button
+                          type="button"
+                          className="plan-phase-btn"
+                          onClick={() => onOpenPhase(ph.id)}
+                          aria-label={`Open phase ${ph.title}`}
+                        >
+                          {inner}
+                        </button>
+                      ) : (
+                        inner
+                      )}
+                    </li>
+                  );
+                })}
               </ol>
             )}
           </div>

--- a/src/surface/mc/dashboard-v2/hooks/use-phase-detail.ts
+++ b/src/surface/mc/dashboard-v2/hooks/use-phase-detail.ts
@@ -1,0 +1,42 @@
+/**
+ * G-1113.D.4 — fetch the phase-detail projection for the selected phase.
+ * Fetches whenever `phaseId` is non-null; best-effort (failure → null detail).
+ */
+import { useEffect, useState } from "react";
+import { getJson } from "../lib/api";
+import type { PhaseDetail } from "../../api/phase-detail";
+
+export function usePhaseDetail(phaseId: string | null): { detail: PhaseDetail | null; loaded: boolean } {
+  const [detail, setDetail] = useState<PhaseDetail | null>(null);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    if (!phaseId) {
+      setDetail(null);
+      setLoaded(false);
+      return;
+    }
+    let cancelled = false;
+    setLoaded(false);
+    void (async () => {
+      try {
+        const res = await getJson<PhaseDetail>(`/api/phases/${encodeURIComponent(phaseId)}`);
+        if (!cancelled) {
+          setDetail(res);
+          setLoaded(true);
+        }
+      } catch (_err) {
+        // Best-effort: the surface shows an empty/not-found state rather than erroring.
+        if (!cancelled) {
+          setDetail(null);
+          setLoaded(true);
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [phaseId]);
+
+  return { detail, loaded };
+}

--- a/src/surface/mc/dashboard-v2/styles/global.css
+++ b/src/surface/mc/dashboard-v2/styles/global.css
@@ -399,6 +399,41 @@ html, body {
 .plans-view .phase-status.status-active { color: var(--accent); }
 .plans-view .phase-status.status-done { color: var(--ok); }
 .plans-view .phase-status.status-blocked { color: var(--bad); }
+/* D.4 — phase rows are buttons that open phase detail */
+.plans-view .plan-phase-btn {
+  display: flex; align-items: baseline; justify-content: space-between;
+  gap: 10px; width: 100%; padding: 0; border: 0; background: none;
+  font: inherit; color: inherit; text-align: left; cursor: pointer;
+}
+.plans-view .plan-phase-btn:hover .phase-title { text-decoration: underline; }
+.plans-view .plan-phase-btn:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+
+/* G-1113.D.4 — phase-detail surface */
+.phase-detail .phase-detail-head { margin-bottom: 8px; }
+.phase-detail .phase-section-label {
+  margin: 14px 0 6px 0; font-size: 11px; font-weight: 600; letter-spacing: 0.06em;
+  text-transform: uppercase; color: var(--fg-faint);
+}
+.phase-detail .work-items { list-style: none; margin: 0; padding: 0; }
+.phase-detail .work-item {
+  border: 1px solid var(--line); border-radius: 8px;
+  background: var(--panel); padding: 10px 12px; margin-top: 8px;
+}
+.phase-detail .work-item-head { display: flex; align-items: center; gap: 8px; font-size: 13px; }
+.phase-detail .work-item-head a { color: var(--fg); text-decoration: none; }
+.phase-detail .work-item-head a:hover { text-decoration: underline; }
+.phase-detail .work-item .badge {
+  font-size: 10px; font-weight: 600; letter-spacing: 0.04em; text-transform: uppercase;
+  padding: 1px 6px; border-radius: 4px; border: 1px solid var(--line); color: var(--fg-dim);
+}
+.phase-detail .work-item-prs { list-style: none; margin: 6px 0 0 0; padding: 0; font-size: 11px; }
+.phase-detail .work-item-prs li { padding: 2px 0; }
+.phase-detail .work-item-prs a { color: var(--fg-dim); text-decoration: none; }
+.phase-detail .work-item-prs a:hover { color: var(--fg); text-decoration: underline; }
+.phase-detail .phase-status.status-open,
+.phase-detail .phase-status.status-draft { color: var(--fg-dim); }
+.phase-detail .phase-status.status-merged { color: var(--ok); }
+.phase-detail .phase-status.status-closed { color: var(--bad); }
 .scaffold-section h2 {
   margin: 0 0 6px 0;
   font-size: 11px; font-weight: 600; letter-spacing: 0.06em;

--- a/src/surface/mc/db/git-objects.ts
+++ b/src/surface/mc/db/git-objects.ts
@@ -345,6 +345,18 @@ export function listPullRequestsForRepository(db: Database, repositoryId: string
   return rows.map(rowToPullRequest);
 }
 
+/**
+ * G-1113.D.4 — PRs linked to a work item (via `work_item_id`, index-backed by
+ * `idx_pull_requests_work_item`). Drives the phase-detail projection: a phase's
+ * work items each carry their linked PRs.
+ */
+export function listPullRequestsForWorkItem(db: Database, workItemId: string): PullRequest[] {
+  const rows = db
+    .query(`SELECT * FROM pull_requests WHERE work_item_id = ? ORDER BY number_or_key`)
+    .all(workItemId) as PullRequestRow[];
+  return rows.map(rowToPullRequest);
+}
+
 interface ReviewRow {
   id: string;
   pull_request_id: string;

--- a/src/surface/mc/db/schema.ts
+++ b/src/surface/mc/db/schema.ts
@@ -24,6 +24,7 @@ export const TABLE_NAMES = [
   "releases",
   "plans",
   "plan_phases",
+  "work_items",
 ] as const;
 
 export const SCHEMA_SQL: string[] = [
@@ -407,6 +408,34 @@ export const SCHEMA_SQL: string[] = [
 
   // Phase lookup by plan, ordered.
   `CREATE INDEX IF NOT EXISTS idx_plan_phases_plan ON plan_phases(plan_id, phase_order)`,
+
+  // --- work_items (G-1113.D.4 — design §6) ---
+  // The cockpit's work-management noun (distinct from `tasks`). Links up to a
+  // plan + phase, and self-references via parent_id for sub-items. Per §6,
+  // `status` and `priority` are open provider-native strings — NOT CHECK-
+  // constrained (unlike plan/phase status), so any provider's vocabulary maps
+  // through. `provider` is app-validated via isProvider (no CHECK), matching
+  // the Git-object tables. All FKs ON DELETE RESTRICT: ingestion only upserts,
+  // never deletes, so these are orphan safety-nets rather than live policy.
+  `CREATE TABLE IF NOT EXISTS work_items (
+    id TEXT PRIMARY KEY,
+    plan_id TEXT REFERENCES plans(id) ON DELETE RESTRICT,
+    phase_id TEXT REFERENCES plan_phases(id) ON DELETE RESTRICT,
+    parent_id TEXT REFERENCES work_items(id) ON DELETE RESTRICT,
+    title TEXT NOT NULL,
+    description TEXT,
+    status TEXT NOT NULL DEFAULT '',
+    priority TEXT NOT NULL DEFAULT '',
+    provider TEXT NOT NULL,
+    external_id TEXT,
+    url TEXT,
+    created_at INTEGER NOT NULL DEFAULT (unixepoch()),
+    updated_at INTEGER NOT NULL DEFAULT (unixepoch())
+  )`,
+
+  // Work-item lookup by phase (phase detail, D.4) and by plan.
+  `CREATE INDEX IF NOT EXISTS idx_work_items_phase ON work_items(phase_id)`,
+  `CREATE INDEX IF NOT EXISTS idx_work_items_plan ON work_items(plan_id)`,
 ];
 
 /**

--- a/src/surface/mc/db/work-items.ts
+++ b/src/surface/mc/db/work-items.ts
@@ -79,7 +79,13 @@ export function getWorkItem(db: Database, id: string): WorkItem | null {
   return row ? rowToWorkItem(row) : null;
 }
 
-/** Work items filed under a phase, ordered by priority then title (stable). */
+/**
+ * Work items filed under a phase, ordered by priority then title (stable on id).
+ * NOTE: `priority` is an open string (§6), so this ORDER BY is lexicographic —
+ * `'10'` sorts before `'2'`. Faithful to the spec today; when ingestion (#587)
+ * lands and a provider emits numeric priorities, revisit whether a numeric-aware
+ * sort key is wanted. The behaviour is locked by a test.
+ */
 export function listWorkItemsForPhase(db: Database, phaseId: string): WorkItem[] {
   const rows = db
     .query(`SELECT * FROM work_items WHERE phase_id = ? ORDER BY priority, title, id`)

--- a/src/surface/mc/db/work-items.ts
+++ b/src/surface/mc/db/work-items.ts
@@ -1,0 +1,96 @@
+/**
+ * G-1113.D.4 — WorkItem storage (design §6). Idempotent upsert by id, get, and
+ * list (by phase / by plan); snake_case rows → camelCase domain types. Mirrors
+ * the plans / git-objects pattern: provider narrowed via isProvider at the read
+ * boundary; `status`/`priority` are open strings (no CHECK), passed through
+ * verbatim. Ingestion that fills these (from the umbrella's sub-issues) is a
+ * follow-up; D.4 lands the model + storage + phase-detail projection.
+ */
+import type { Database } from "bun:sqlite";
+import type { WorkItem } from "../types";
+import { isProvider } from "../types";
+
+interface WorkItemRow {
+  id: string;
+  plan_id: string | null;
+  phase_id: string | null;
+  parent_id: string | null;
+  title: string;
+  description: string | null;
+  status: string;
+  priority: string;
+  provider: string;
+  external_id: string | null;
+  url: string | null;
+}
+
+function rowToWorkItem(r: WorkItemRow): WorkItem {
+  return {
+    id: r.id,
+    planId: r.plan_id,
+    phaseId: r.phase_id,
+    parentId: r.parent_id,
+    title: r.title,
+    description: r.description,
+    status: r.status,
+    priority: r.priority,
+    provider: isProvider(r.provider) ? r.provider : "custom",
+    externalId: r.external_id,
+    url: r.url,
+  };
+}
+
+/** Insert or update a work item by id (idempotent re-ingestion). */
+export function upsertWorkItem(db: Database, wi: WorkItem): void {
+  db.query(
+    `INSERT INTO work_items
+       (id, plan_id, phase_id, parent_id, title, description, status, priority,
+        provider, external_id, url)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+     ON CONFLICT(id) DO UPDATE SET
+       plan_id = excluded.plan_id,
+       phase_id = excluded.phase_id,
+       parent_id = excluded.parent_id,
+       title = excluded.title,
+       description = excluded.description,
+       status = excluded.status,
+       priority = excluded.priority,
+       provider = excluded.provider,
+       external_id = excluded.external_id,
+       url = excluded.url,
+       updated_at = unixepoch()`
+  ).run(
+    wi.id,
+    wi.planId,
+    wi.phaseId,
+    wi.parentId,
+    wi.title,
+    wi.description,
+    wi.status,
+    wi.priority,
+    wi.provider,
+    wi.externalId,
+    wi.url
+  );
+}
+
+export function getWorkItem(db: Database, id: string): WorkItem | null {
+  const row = db.query(`SELECT * FROM work_items WHERE id = ?`).get(id) as WorkItemRow | null;
+  return row ? rowToWorkItem(row) : null;
+}
+
+/** Work items filed under a phase, ordered by priority then title (stable). */
+export function listWorkItemsForPhase(db: Database, phaseId: string): WorkItem[] {
+  const rows = db
+    .query(`SELECT * FROM work_items WHERE phase_id = ? ORDER BY priority, title, id`)
+    .all(phaseId) as WorkItemRow[];
+  return rows.map(rowToWorkItem);
+}
+
+/** Work items belonging to a plan (any phase, including unphased). */
+export function listWorkItemsForPlan(db: Database, planId: string): WorkItem[] {
+  const rows = db
+    .query(`SELECT * FROM work_items WHERE plan_id = ? ORDER BY priority, title, id`)
+    .all(planId) as WorkItemRow[];
+  return rows.map(rowToWorkItem);
+}

--- a/src/surface/mc/server.ts
+++ b/src/surface/mc/server.ts
@@ -41,6 +41,7 @@ import {
 import { handleListGitLinks } from "./api/git-links";
 import { handleListRepositories } from "./api/git-repos";
 import { handleListPlans } from "./api/plans";
+import { handleGetPhaseDetail } from "./api/phase-detail";
 import type { ProcessManager } from "./session/process-manager";
 import type { SpawnFn } from "./session/endpoint-resolver";
 import { join, dirname } from "path";
@@ -416,6 +417,22 @@ async function handleApi(
       return methodNotAllowed(["GET"]);
     }
     return handleListPlans(db);
+  }
+
+  // G-1113.D.4 — GET /api/phases/:id — phase detail (plan + work items + linked
+  // PRs) for the phase-detail surface.
+  if (pathname.startsWith("/api/phases/")) {
+    if (req.method !== "GET") {
+      return methodNotAllowed(["GET"]);
+    }
+    const phaseId = decodeURIComponent(pathname.slice("/api/phases/".length));
+    if (!phaseId || phaseId.includes("/")) {
+      return new Response(JSON.stringify({ error: "invalid phase id" }), {
+        status: 400,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    return handleGetPhaseDetail(db, phaseId);
   }
 
   if (pathname === "/api/tasks") {

--- a/src/surface/mc/types.ts
+++ b/src/surface/mc/types.ts
@@ -349,6 +349,29 @@ export interface PlanPhase {
   status: PlanPhaseStatus;
 }
 
+/**
+ * A unit of work within a plan/phase (design §6) — the cockpit's work-management
+ * noun, distinct from the legacy {@link Task}. Links up to a {@link Plan} and
+ * {@link PlanPhase}, and self-references via `parentId` for sub-items. Git
+ * objects link back via {@link PullRequest.workItemId}. Per §6, `status` and
+ * `priority` are open provider-native strings (no closed enum), so they are
+ * deliberately not narrowed here. `phaseId`/`planId` are nullable — a work item
+ * can exist before it's filed under a phase.
+ */
+export interface WorkItem {
+  id: string;
+  planId: string | null;
+  phaseId: string | null;
+  parentId: string | null;
+  title: string;
+  description: string | null;
+  status: string;
+  priority: string;
+  provider: Provider;
+  externalId: string | null;
+  url: string | null;
+}
+
 export interface Task {
   id: string;
   title: string;


### PR DESCRIPTION
## G-1113.D.4 — WorkItem model + phase-detail surface (design §6 / §7.2)

Introduces the cockpit's work-management noun (`WorkItem`) and the phase drill-down reached from the D.3 Plans overview.

### What's here
- **`types.ts`** — `WorkItem` (faithful §6: `planId`/`phaseId`/`parentId`, open-string `status`/`priority`, provider-neutral).
- **`db/schema.ts`** — `work_items` table (plan/phase/parent FKs `ON DELETE RESTRICT`; `provider` no-CHECK; `status`/`priority` open strings per §6) + phase/plan indexes.
- **`db/work-items.ts`** — `upsert`/`get`/`listWorkItemsForPhase`/`listWorkItemsForPlan`.
- **`db/git-objects.ts`** — `listPullRequestsForWorkItem` (via `work_item_id`, index-backed by the existing `idx_pull_requests_work_item`).
- **`api/phase-detail.ts`** — `getPhaseDetail` + `GET /api/phases/:id` → phase + parent plan + work items, each with linked PRs.
- **dashboard-v2** — `use-phase-detail` hook, `phase-detail-view` component, PlansView phase rows become buttons that open phase detail, `app.tsx` nav (`phase-detail` view + back, reset-effect extended to cover it), `global.css`.
- **`__tests__/work-items.test.ts`** — storage round-trip + idempotent update, FK rejections (ghost plan/phase/parent), list ordering, projection (phase+plan+WI+PRs), empty-state, 404.

### ⚠️ Scope decision — please sanity-check
Design §6 specifies `WorkItem` exactly (this PR transcribes it, as D.1 did for Plan/PlanPhase). But **WorkItem ingestion is not a listed slice**, so I deferred it to **#587** (mirroring the D.1-storage → D.2-ingestion split). Consequence: `work_items` is empty until #587 lands, so the phase-detail surface shows an honest empty state (`"No work items linked to this phase yet"`) — same pattern as D.3 shipping before its counts. If you'd rather ingestion land *before* the phase-detail UI, say so and I'll resequence.

§7.2 also lists sessions / branches / checks / reviews / attention. Only **PR linkage** is queryable today (`pull_requests.work_item_id` exists; sessions link via assignment→task with no work-item column; attention is Phase E), so those sections are intentionally not shown — they deepen as the linkage lands.

### Surface placement
Gated behind the **software-mode** flag (consistent with D.3/C.7); reached by clicking a phase row in the Plans overview.

### Verification
- `bunx tsc --noEmit` clean · `bun run lint` 0 errors · `bun test src/surface/mc` 1217 pass / 0 fail · `bun run build:dashboard` bundles · carve-out gate PASS
- Merge-guard: merged `origin/main` (D.2+D.3) into the branch — clean

Closes #581. Follow-up: #587. Part of #577, umbrella #354.