### PR TITLE
feat(gateway): GW.a.3b.2c — suppress per-stack adapter for gateway-owned surfaces (#524)

### DIFF
--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -91,6 +91,8 @@ import type { PlatformAdapter } from "./adapters/types";
 import { createDispatchSink, type DispatchSink } from "./adapters/dispatch-sink";
 import { createReviewSink, type ReviewSink } from "./adapters/review-sink";
 import { startGatewayIfEnabled } from "./gateway/start-gateway";
+import { isGatewayEnabled } from "./gateway/gateway-bootstrap";
+import { gatewayOwnedSurfaceKeys } from "./gateway/gateway-adapters";
 import type { Surfaces } from "./common/types/surfaces";
 import type { SurfaceGateway } from "./gateway/surface-gateway";
 
@@ -1365,6 +1367,25 @@ export async function startCortex(
   const adapters: PlatformAdapter[] = [];
   const adapterCleanup: (() => void)[] = [];
 
+  // GW.a.3b.2c (cortex#524) — the per-stack adapter suppression set. When
+  // `CORTEX_GATEWAY` is set, the shared surface gateway (constructed below via
+  // `startGatewayIfEnabled`) builds ONE adapter per `surfaces:` binding on the
+  // SAME bot token the fold also wrote into `agents[].presence.{platform}`.
+  // Starting the per-stack adapter too would double-connect that bot identity
+  // and double-deliver every message (the §1.2 bug). Each loop below skips an
+  // instance whose `{platform}:{agent.id}` is in this set, yielding that
+  // surface to the gateway.
+  //
+  // SAFETY: `gatewayOwnedSurfaceKeys` returns an EMPTY set when the flag is off
+  // (or no surfaces are configured). An empty set makes every `.has(...)` below
+  // false → no `continue` → the per-stack loops are byte-identical to the
+  // pre-GW boot. `CORTEX_GATEWAY` is off on every live stack, so this is a
+  // true no-op on the live boot path.
+  const gatewayOwned = gatewayOwnedSurfaceKeys(
+    options.surfaces,
+    isGatewayEnabled(process.env),
+  );
+
   // MIG-7.2e: per-instance agent lookup. When cortex.yaml supplies
   // `inlineAgents` (reused from the registry-merge block above), each
   // Discord/Mattermost adapter binds to the declared Agent (real id,
@@ -1462,6 +1483,17 @@ export async function startCortex(
       trust: [],
       presence: { discord: presence },
     };
+    // GW.a.3b.2c — the gateway owns this surface; yield it so we don't
+    // double-connect the same bot token. `gatewayOwned` is empty when
+    // CORTEX_GATEWAY is off → this is never taken on the live boot path. The
+    // suppressed instance never enters `startedDiscord`, so the Pass-2 trust
+    // merge / outbound-poller bookkeeping simply never sees it.
+    if (gatewayOwned.has(`discord:${agent.id}`)) {
+      console.log(
+        `cortex: per-stack discord adapter for agent "${agent.id}" suppressed — the shared surface gateway owns this surface (CORTEX_GATEWAY).`,
+      );
+      continue; // skip — the gateway owns this connection
+    }
     try {
       // cortex#84: build the trusted-peer-bot allowlist once per adapter
       // start so the messageCreate hot path doesn't re-allocate per event.
@@ -1648,6 +1680,16 @@ export async function startCortex(
       trust: [],
       presence: { mattermost: presence },
     };
+    // GW.a.3b.2c — yield to the gateway when it owns this surface (see the
+    // Discord block above). `gatewayOwned` is empty when CORTEX_GATEWAY is off,
+    // so this never fires on the live boot path. The Mattermost loop pushes
+    // nothing to a later bookkeeping pass, so skipping is a clean `continue`.
+    if (gatewayOwned.has(`mattermost:${agent.id}`)) {
+      console.log(
+        `cortex: per-stack mattermost adapter for agent "${agent.id}" suppressed — the shared surface gateway owns this surface (CORTEX_GATEWAY).`,
+      );
+      continue; // skip — the gateway owns this connection
+    }
     try {
       const adapter = new MattermostAdapter(
         agent,
@@ -1729,6 +1771,16 @@ export async function startCortex(
       trust: [],
       presence: { slack: presence },
     };
+    // GW.a.3b.2c — yield to the gateway when it owns this surface (see the
+    // Discord block above). `gatewayOwned` is empty when CORTEX_GATEWAY is off,
+    // so this never fires on the live boot path. The suppressed instance never
+    // enters `startedSlack`, so the Pass-2 trust merge never sees it.
+    if (gatewayOwned.has(`slack:${agent.id}`)) {
+      console.log(
+        `cortex: per-stack slack adapter for agent "${agent.id}" suppressed — the shared surface gateway owns this surface (CORTEX_GATEWAY).`,
+      );
+      continue; // skip — the gateway owns this connection
+    }
     try {
       const adapter = new SlackAdapter(
         agent,

--- a/src/gateway/__tests__/gateway-owned-surface-keys.test.ts
+++ b/src/gateway/__tests__/gateway-owned-surface-keys.test.ts
@@ -1,0 +1,164 @@
+/**
+ * GW.a.3b.2c — `gatewayOwnedSurfaceKeys` tests (cortex#524, TDD).
+ *
+ * The helper builds the `{platform}:{agentId}` suppression set the per-stack
+ * adapter loops consult to yield gateway-owned surfaces. Its safety contract is
+ * the load-bearing part: it MUST return an empty set whenever the gateway is
+ * disabled OR no surfaces are configured, because the per-stack loops gate
+ * their skip on `set.has(...)` — an empty set guarantees a byte-identical
+ * flag-off boot. These tests pin both the safety contract and the key shape.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { gatewayOwnedSurfaceKeys } from "../gateway-adapters";
+import { isGatewayEnabled } from "../gateway-bootstrap";
+import type { Surfaces } from "../../common/types/surfaces";
+
+// A representative multi-platform binding map. Only the fields the helper reads
+// (`.agent`) matter for the key; the credential blocks are filled with the
+// minimum the `Surfaces` type expects.
+const DISCORD_LUNA = {
+  agent: "luna",
+  binding: {
+    token: "discord-bot-token",
+    guildId: "111111111111111111",
+    agentChannelId: "222222222222222222",
+    logChannelId: "333333333333333333",
+  },
+} as const;
+
+const SURFACES: Surfaces = {
+  discord: [DISCORD_LUNA],
+  slack: [
+    {
+      agent: "echo",
+      binding: {
+        botToken: "xoxb-aaa",
+        appToken: "xapp-bbb",
+        workspaceId: "T01234567",
+      },
+    },
+  ],
+  mattermost: [
+    {
+      agent: "sage",
+      binding: {
+        apiUrl: "https://mm.example.com",
+        apiToken: "mm-api-token",
+      },
+    },
+  ],
+};
+
+describe("gatewayOwnedSurfaceKeys — safety contract (empty set)", () => {
+  test("returns an empty set when disabled, even with surfaces present", () => {
+    const keys = gatewayOwnedSurfaceKeys(SURFACES, false);
+    expect(keys.size).toBe(0);
+  });
+
+  test("returns an empty set when surfaces is undefined (flag on)", () => {
+    const keys = gatewayOwnedSurfaceKeys(undefined, true);
+    expect(keys.size).toBe(0);
+  });
+
+  test("returns an empty set when surfaces is undefined AND disabled", () => {
+    const keys = gatewayOwnedSurfaceKeys(undefined, false);
+    expect(keys.size).toBe(0);
+  });
+
+  test("returns an empty set for an all-empty surfaces map when enabled", () => {
+    const keys = gatewayOwnedSurfaceKeys(
+      { discord: [], slack: [], mattermost: [] },
+      true,
+    );
+    expect(keys.size).toBe(0);
+  });
+});
+
+describe("gatewayOwnedSurfaceKeys — key shape (enabled)", () => {
+  test("builds {platform}:{agentId} keys for every binding", () => {
+    const keys = gatewayOwnedSurfaceKeys(SURFACES, true);
+    expect(keys.has("discord:luna")).toBe(true);
+    expect(keys.has("slack:echo")).toBe(true);
+    expect(keys.has("mattermost:sage")).toBe(true);
+    expect(keys.size).toBe(3);
+  });
+
+  test("does not invent keys for unbound platforms", () => {
+    const discordOnly: Surfaces = { discord: [DISCORD_LUNA] };
+    const keys = gatewayOwnedSurfaceKeys(discordOnly, true);
+    expect(keys.has("discord:luna")).toBe(true);
+    expect(keys.has("slack:echo")).toBe(false);
+    expect(keys.has("mattermost:sage")).toBe(false);
+    expect(keys.size).toBe(1);
+  });
+
+  test("handles multiple bindings on one platform", () => {
+    const multi: Surfaces = {
+      discord: [
+        DISCORD_LUNA,
+        {
+          agent: "nova",
+          binding: {
+            token: "discord-bot-token-2",
+            guildId: "444444444444444444",
+            agentChannelId: "555555555555555555",
+            logChannelId: "666666666666666666",
+          },
+        },
+      ],
+    };
+    const keys = gatewayOwnedSurfaceKeys(multi, true);
+    expect(keys.has("discord:luna")).toBe(true);
+    expect(keys.has("discord:nova")).toBe(true);
+    expect(keys.size).toBe(2);
+  });
+
+  test("reproduces the §1.2 double-connect decision the per-stack loop makes", () => {
+    // This mirrors EXACTLY how src/cortex.ts composes the suppression check:
+    //   const gatewayOwned = gatewayOwnedSurfaceKeys(options.surfaces, isGatewayEnabled(process.env));
+    //   if (gatewayOwned.has(`discord:${agent.id}`)) continue;  // yield to gateway
+    // Staging config: luna's discord binding is folded into presence (per-stack
+    // would start it) AND lives in surfaces (gateway starts it). With the flag
+    // ON the per-stack loop must yield; with the flag OFF it must not.
+    const flagOn = gatewayOwnedSurfaceKeys(
+      SURFACES,
+      isGatewayEnabled({ CORTEX_GATEWAY: "1" }),
+    );
+    expect(flagOn.has("discord:luna")).toBe(true); // per-stack loop yields
+
+    const flagOff = gatewayOwnedSurfaceKeys(
+      SURFACES,
+      isGatewayEnabled({ CORTEX_GATEWAY: undefined }),
+    );
+    expect(flagOff.has("discord:luna")).toBe(false); // per-stack loop starts (byte-identical)
+    expect(flagOff.size).toBe(0);
+
+    // Only "1" is truthy (matches isGatewayEnabled's contract) — "true" is off.
+    const flagTrue = gatewayOwnedSurfaceKeys(
+      SURFACES,
+      isGatewayEnabled({ CORTEX_GATEWAY: "true" }),
+    );
+    expect(flagTrue.size).toBe(0);
+  });
+
+  test("the same agent bound on two platforms yields two distinct keys", () => {
+    const crossPlatform: Surfaces = {
+      discord: [DISCORD_LUNA],
+      slack: [
+        {
+          agent: "luna",
+          binding: {
+            botToken: "xoxb-luna",
+            appToken: "xapp-luna",
+            workspaceId: "T76543210",
+          },
+        },
+      ],
+    };
+    const keys = gatewayOwnedSurfaceKeys(crossPlatform, true);
+    expect(keys.has("discord:luna")).toBe(true);
+    expect(keys.has("slack:luna")).toBe(true);
+    expect(keys.size).toBe(2);
+  });
+});

--- a/src/gateway/gateway-adapters.ts
+++ b/src/gateway/gateway-adapters.ts
@@ -264,3 +264,60 @@ export function buildGatewayAdapters(
 
   return adapters;
 }
+
+// =============================================================================
+// gatewayOwnedSurfaceKeys — the per-stack suppression set (GW.a.3b.2c)
+// =============================================================================
+
+/**
+ * Build the set of `{platform}:{agentId}` keys the gateway OWNS, so the
+ * per-stack adapter loops in `src/cortex.ts` can yield those surfaces to the
+ * gateway and avoid a second connection on the same bot identity (cortex#524,
+ * the §1.2 double-message bug).
+ *
+ * The problem this closes: `foldSurfaceBindings` folds a `surfaces:` binding
+ * INTO `agents[].presence.{platform}`, so the per-stack loop would start an
+ * adapter on that token — AND `buildGatewayAdapters` (above) ALSO builds an
+ * adapter on the same token from the same `Surfaces` map. Two connections on
+ * one bot identity in one runtime double-deliver every message. This set lets
+ * the per-stack loop skip exactly the (platform, agent) pairs the gateway owns.
+ *
+ * Keying convention: `{platform}:{agentId}` where `agentId` is the binding's
+ * `.agent` field (the fold-join key against `agents[].id`). The per-stack loop
+ * matches each instance to its `Agent` and checks `has(`{platform}:${agent.id}`)`.
+ * This is the SAME agent id both sides reference — the binding names it, the
+ * fold writes it into that agent's presence, and the loop resolves it back.
+ *
+ * ## Hard safety contract
+ *
+ * Returns an **empty set** when `enabled` is false OR `surfaces` is undefined.
+ * The per-stack loops gate their skip on `gatewayOwned.has(...)`; an empty set
+ * makes every `.has(...)` false → no skip → byte-identical flag-off boot. This
+ * is the single point that guarantees `CORTEX_GATEWAY` off changes nothing.
+ *
+ * Pure + side-effect-free — independently unit-testable.
+ */
+export function gatewayOwnedSurfaceKeys(
+  surfaces: Surfaces | undefined,
+  enabled: boolean,
+): Set<string> {
+  const keys = new Set<string>();
+
+  // Flag off OR no surfaces → empty set → zero suppression (byte-identical
+  // flag-off boot). This guard is the safety contract; do not weaken it.
+  if (!enabled || surfaces === undefined) {
+    return keys;
+  }
+
+  for (const entry of surfaces.discord ?? []) {
+    keys.add(`discord:${entry.agent}`);
+  }
+  for (const entry of surfaces.slack ?? []) {
+    keys.add(`slack:${entry.agent}`);
+  }
+  for (const entry of surfaces.mattermost ?? []) {
+    keys.add(`mattermost:${entry.agent}`);
+  }
+
+  return keys;
+}


### PR DESCRIPTION
Closes the **double-connect** the staging dry-run surfaced: `foldSurfaceBindings` folds a `surfaces:` binding into `agents[].presence.{platform}`, so the per-stack loop starts an adapter on the **same bot token** the gateway (a.3b.2b) also connects from `LoadedConfig.surfaces` → two connections on one identity = the §1.2 double-message bug. When `CORTEX_GATEWAY=1`, the per-stack loop now **yields** those surfaces to the gateway.

## What
- **`gatewayOwnedSurfaceKeys(surfaces, enabled)`** — pure helper; set of `{platform}:{agentId}` keys the gateway owns; **EMPTY when `enabled=false` or `surfaces` undefined**.
- **`cortex.ts`** (+52/-0): build the set once; each per-stack loop (discord/mattermost/slack), after resolving the instance's agent + before constructing the adapter, `continue`s (with a log) when `{platform}:{agent.id}` is gateway-owned. Suppressed instances never enter `startedDiscord`/`startedSlack` → Pass-2 trust-merge / outbound-poller bookkeeping undisturbed.

## ⚠️ Review focus (live-boot touch)
1. **Flag-off byte-identity** — the set is empty when `CORTEX_GATEWAY` is off → every `.has()` is false → no `continue` → per-stack loops unchanged. (Verified: boot smoke 27/27 green flag-unset; full src/ 3921 pass / 0 fail.) Scrutinize the 3 skip placements — are they after agent-resolution + before the `try`, and do suppressed instances cleanly avoid the later bookkeeping?
2. **Key join** — suppression joins on `{platform}:{agent.id}` (the binding `.agent`, the fold-join key); the gateway's own adapter `instanceId` uses `{platform}:{demuxKey}` — different keyspaces by design. Confirm the agent-id join is the right one for "same token, two connections".
3. Helper purity + tests (99 gateway, incl. the staging double-connect decision under flag on/off).

## Gates
`tsc` 0 · `eslint --quiet src/` 0 · `bun test src/gateway/` **99** · boot smoke **27/27** (flag unset) · `bun test src/` **3921 pass / 0 fail** · vocab gate PASS.

Refs #524 · part of #110.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
