### PR TITLE
feat(mc): G-1113.D.5b — provider-neutral WorkItem ingestion (GitHub first adapter)

### DIFF
--- a/src/surface/mc/__tests__/github-work-items.test.ts
+++ b/src/surface/mc/__tests__/github-work-items.test.ts
@@ -1,0 +1,88 @@
+/**
+ * G-1113.D.5b — GitHub WorkItemSource adapter: sub-issue → WorkItem
+ * normalization, phase mapping, and honest no-ops, with an injected `gh` fake.
+ */
+import { describe, it, expect } from "bun:test";
+import { GithubWorkItemSource } from "../adapters/github/work-items";
+import type { GhSpawnFn } from "../adapters/github/fetch";
+import type { Plan, PlanPhase } from "../types";
+import type { WorkItemSourceContext as Ctx } from "../adapters/work-item-source";
+
+function fakeSpawn(stdout: string, code = 0, stderr = ""): GhSpawnFn {
+  return () => ({
+    stdout: new Response(stdout).body as ReadableStream<Uint8Array>,
+    stderr: new Response(stderr).body as ReadableStream<Uint8Array>,
+    exited: Promise.resolve(code),
+    kill: () => {},
+  });
+}
+
+const plan = (over: Partial<Plan> = {}): Plan => ({
+  id: "plan-mission-control-cockpit",
+  title: "Cockpit",
+  kind: "design",
+  sourceDocumentUrl: null,
+  provider: "internal",
+  externalId: null,
+  umbrellaWorkItemId: "the-metafactory/cortex#354",
+  status: "active",
+  ...over,
+});
+
+const phases: PlanPhase[] = [
+  { id: "plan-mission-control-cockpit-phase-c", planId: "plan-mission-control-cockpit", title: "C", order: 2, status: "done" },
+  { id: "plan-mission-control-cockpit-phase-d", planId: "plan-mission-control-cockpit", title: "D", order: 3, status: "active" },
+];
+
+function ctx(p: Plan): Ctx {
+  return { plan: p, phases };
+}
+
+describe("GithubWorkItemSource (D.5b)", () => {
+  it("normalizes sub-issues → WorkItems with phase mapping + open/closed status", async () => {
+    const subIssuesJson = JSON.stringify([
+      { number: 581, title: "G-1113.D.4 — Phase detail view", state: "open", html_url: "https://github.com/the-metafactory/cortex/issues/581", labels: [{ name: "feature" }] },
+      { number: 556, title: "G-1113.C.3 — PRs + reviews", state: "closed", html_url: "https://github.com/the-metafactory/cortex/issues/556", labels: ["feature"] },
+      { number: 999, title: "Untagged work with no phase token", state: "open", html_url: "https://github.com/the-metafactory/cortex/issues/999", labels: [] },
+    ]);
+    const src = new GithubWorkItemSource({ spawn: fakeSpawn(subIssuesJson) });
+    const items = await src.fetchWorkItems(ctx(plan()));
+
+    expect(items.map((w) => [w.id, w.phaseId, w.status])).toEqual([
+      ["the-metafactory/cortex#581", "plan-mission-control-cockpit-phase-d", "open"],
+      ["the-metafactory/cortex#556", "plan-mission-control-cockpit-phase-c", "closed"],
+      ["the-metafactory/cortex#999", null, "open"], // no phase token → unphased (no guess)
+    ]);
+    // externalId == id (owner/repo#N bijection); provider github; url passthrough.
+    expect(items[0]?.externalId).toBe("the-metafactory/cortex#581");
+    expect(items[0]?.provider).toBe("github");
+    expect(items[0]?.url).toBe("https://github.com/the-metafactory/cortex/issues/581");
+    expect(items.every((w) => w.planId === "plan-mission-control-cockpit")).toBe(true);
+  });
+
+  it("no umbrella link → honest empty (never guesses)", async () => {
+    const src = new GithubWorkItemSource({ spawn: fakeSpawn("[]") });
+    expect(await src.fetchWorkItems(ctx(plan({ umbrellaWorkItemId: null })))).toEqual([]);
+  });
+
+  it("unparseable umbrella link → empty", async () => {
+    const src = new GithubWorkItemSource({ spawn: fakeSpawn("[]") });
+    expect(await src.fetchWorkItems(ctx(plan({ umbrellaWorkItemId: "not a ref" })))).toEqual([]);
+  });
+
+  it("gh fetch error → empty (best-effort, persists nothing)", async () => {
+    const src = new GithubWorkItemSource({ spawn: fakeSpawn("", 1, "HTTP 404: Not Found") });
+    expect(await src.fetchWorkItems(ctx(plan()))).toEqual([]);
+  });
+
+  it("skips malformed sub-issue rows rather than failing the batch", async () => {
+    const json = JSON.stringify([
+      { number: 1, title: "G-1113.D.1 — ok", state: "open", html_url: "https://x/1" },
+      { title: "missing number" },
+      { number: 2 }, // missing title/state/url
+    ]);
+    const src = new GithubWorkItemSource({ spawn: fakeSpawn(json) });
+    const items = await src.fetchWorkItems(ctx(plan()));
+    expect(items.map((w) => w.id)).toEqual(["the-metafactory/cortex#1"]);
+  });
+});

--- a/src/surface/mc/__tests__/github-work-items.test.ts
+++ b/src/surface/mc/__tests__/github-work-items.test.ts
@@ -60,6 +60,34 @@ describe("GithubWorkItemSource (D.5b)", () => {
     expect(items.every((w) => w.planId === "plan-mission-control-cockpit")).toBe(true);
   });
 
+  it("phase mapping is strict: incidental prose letters don't mis-file (false-positive guard)", async () => {
+    const json = JSON.stringify([
+      // Incidental ' c ' in prose must NOT pull this into phase C — the slice
+      // token .D.4 wins, and the bare 'c' is ignored.
+      { number: 1, title: "G-1113.D.4 — fix the c compiler warning", state: "open", html_url: "https://x/1" },
+      // Bare letter in prose, no slice token, no "Phase X" → unphased (not phase C).
+      { number: 2, title: "Refactor the c module", state: "open", html_url: "https://x/2" },
+      // Explicit prose form maps.
+      { number: 3, title: "Phase C cleanup", state: "open", html_url: "https://x/3" },
+    ]);
+    const src = new GithubWorkItemSource({ spawn: fakeSpawn(json) });
+    const items = await src.fetchWorkItems(ctx(plan()));
+    expect(items.map((w) => [w.id, w.phaseId])).toEqual([
+      ["the-metafactory/cortex#1", "plan-mission-control-cockpit-phase-d"], // .D.4 wins, not ' c '
+      ["the-metafactory/cortex#2", null], // incidental 'c' ignored
+      ["the-metafactory/cortex#3", "plan-mission-control-cockpit-phase-c"], // prose "Phase C"
+    ]);
+  });
+
+  it("ambiguous title citing two phases → unphased (null), never first-wins", async () => {
+    const json = JSON.stringify([
+      { number: 9, title: "G-1113.C.3 follow-up rolled into G-1113.D.4", state: "open", html_url: "https://x/9" },
+    ]);
+    const src = new GithubWorkItemSource({ spawn: fakeSpawn(json) });
+    const items = await src.fetchWorkItems(ctx(plan()));
+    expect(items[0]?.phaseId).toBeNull();
+  });
+
   it("no umbrella link → honest empty (never guesses)", async () => {
     const src = new GithubWorkItemSource({ spawn: fakeSpawn("[]") });
     expect(await src.fetchWorkItems(ctx(plan({ umbrellaWorkItemId: null })))).toEqual([]);

--- a/src/surface/mc/__tests__/work-item-source.test.ts
+++ b/src/surface/mc/__tests__/work-item-source.test.ts
@@ -101,4 +101,14 @@ describe("ingestWorkItems (D.5b orchestrator)", () => {
     expect(res.workItems).toEqual([]);
     expect(listWorkItemsForPlan(db, "plan-1")).toEqual([]);
   });
+
+  it("is all-or-nothing — a mid-batch upsert failure rolls back the whole transaction", async () => {
+    const db = freshDb();
+    upsertPlan(db, plan);
+    // Second row has a ghost phaseId → its upsert violates the phase FK and throws.
+    const src = mockSource([wi("a#1"), wi("a#2", { phaseId: "ghost-phase" })]);
+    await expect(ingestWorkItems(db, src, "plan-1")).rejects.toThrow();
+    // a#1 must NOT have persisted — the transaction rolled back, not a partial write.
+    expect(listWorkItemsForPlan(db, "plan-1")).toEqual([]);
+  });
 });

--- a/src/surface/mc/__tests__/work-item-source.test.ts
+++ b/src/surface/mc/__tests__/work-item-source.test.ts
@@ -1,0 +1,104 @@
+/**
+ * G-1113.D.5b — provider-neutral ingestion orchestrator (adapters/work-item-source.ts).
+ * Proven with a mock source — the orchestrator knows nothing about GitHub.
+ */
+import { describe, it, expect, afterEach } from "bun:test";
+import { join } from "path";
+import { tmpdir } from "os";
+import { rmSync, existsSync } from "fs";
+import { initDatabase } from "../db/init";
+import { upsertPlan, upsertPlanPhase } from "../db/plans";
+import { getWorkItem, listWorkItemsForPlan } from "../db/work-items";
+import { ingestWorkItems, type WorkItemSource } from "../adapters/work-item-source";
+import type { Plan, WorkItem } from "../types";
+
+const plan: Plan = {
+  id: "plan-1",
+  title: "Cockpit",
+  kind: "design",
+  sourceDocumentUrl: null,
+  provider: "internal",
+  externalId: null,
+  umbrellaWorkItemId: null,
+  status: "active",
+};
+
+/** A source that returns canned rows and records the context it was given. */
+function mockSource(items: WorkItem[]): WorkItemSource & { seen: { planId?: string; phaseCount?: number } } {
+  const seen: { planId?: string; phaseCount?: number } = {};
+  return {
+    provider: "custom",
+    seen,
+    async fetchWorkItems(ctx) {
+      seen.planId = ctx.plan.id;
+      seen.phaseCount = ctx.phases.length;
+      return items;
+    },
+  };
+}
+
+const wi = (id: string, over: Partial<WorkItem> = {}): WorkItem => ({
+  id,
+  planId: "plan-1",
+  phaseId: null,
+  parentId: null,
+  title: id,
+  description: null,
+  status: "open",
+  priority: "",
+  provider: "custom",
+  externalId: id,
+  url: null,
+  ...over,
+});
+
+describe("ingestWorkItems (D.5b orchestrator)", () => {
+  const paths: string[] = [];
+  afterEach(() => {
+    for (const p of paths) if (existsSync(p)) rmSync(p);
+    paths.length = 0;
+  });
+  function freshDb() {
+    const p = join(tmpdir(), `wis-${Date.now()}-${Math.random().toString(36).slice(2)}.db`);
+    paths.push(p);
+    return initDatabase(p);
+  }
+
+  it("persists the source's rows + passes plan & phases to the source", async () => {
+    const db = freshDb();
+    upsertPlan(db, plan);
+    upsertPlanPhase(db, { id: "plan-1-phase-a", planId: "plan-1", title: "A", order: 0, status: "active" });
+    const src = mockSource([wi("a#1"), wi("a#2")]);
+    const res = await ingestWorkItems(db, src, "plan-1");
+    expect(res.workItems).toHaveLength(2);
+    expect(getWorkItem(db, "a#1")?.title).toBe("a#1");
+    expect(listWorkItemsForPlan(db, "plan-1")).toHaveLength(2);
+    // The orchestrator handed the source the plan + its phases.
+    expect(src.seen.planId).toBe("plan-1");
+    expect(src.seen.phaseCount).toBe(1);
+  });
+
+  it("is idempotent — re-ingesting the same rows updates in place", async () => {
+    const db = freshDb();
+    upsertPlan(db, plan);
+    await ingestWorkItems(db, mockSource([wi("a#1", { status: "open" })]), "plan-1");
+    await ingestWorkItems(db, mockSource([wi("a#1", { status: "closed" })]), "plan-1");
+    expect(listWorkItemsForPlan(db, "plan-1")).toHaveLength(1);
+    expect(getWorkItem(db, "a#1")?.status).toBe("closed");
+  });
+
+  it("unknown plan → empty result, persists nothing", async () => {
+    const db = freshDb();
+    const res = await ingestWorkItems(db, mockSource([wi("a#1")]), "ghost");
+    expect(res.workItems).toEqual([]);
+    expect(getWorkItem(db, "a#1")).toBeNull();
+  });
+
+  it("empty source → no rows", async () => {
+    const db = freshDb();
+    upsertPlan(db, plan);
+    const res = await ingestWorkItems(db, mockSource([]), "plan-1");
+    expect(res.workItems).toEqual([]);
+    expect(listWorkItemsForPlan(db, "plan-1")).toEqual([]);
+  });
+});

--- a/src/surface/mc/adapters/github/fetch.ts
+++ b/src/surface/mc/adapters/github/fetch.ts
@@ -445,6 +445,70 @@ export async function fetchPullRequest(
 }
 
 /**
+ * G-1113.D.5b — a sub-issue of an umbrella issue, as the WorkItem ingester
+ * needs it. Subset of GitHub's `/issues/:n/sub_issues` array element.
+ */
+export interface GitHubSubIssue {
+  number: number;
+  title: string;
+  /** "open" | "closed" — verbatim from GitHub. */
+  state: string;
+  html_url: string;
+  /** Label names only. */
+  labels: string[];
+}
+
+interface RawGithubSubIssue {
+  number?: number;
+  title?: string;
+  state?: string;
+  html_url?: string;
+  labels?: ({ name?: string } | string)[];
+}
+
+/**
+ * G-1113.D.5b — fetch the sub-issues of an umbrella issue via
+ * `/repos/:owner/:repo/issues/:number/sub_issues`. Returns the normalized
+ * array or a {@link GitHubFetchError}. Used by the GitHub WorkItemSource to
+ * enumerate a plan's work items. Same `gh` CLI trust root + error mapping as
+ * {@link fetchPullRequest}.
+ */
+export async function fetchSubIssues(
+  ref: { owner: string; repo: string; number: number },
+  opts: { spawn?: GhSpawnFn; timeoutMs?: number } = {}
+): Promise<GitHubSubIssue[] | GitHubFetchError> {
+  const res = await runGhApi(`/repos/${ref.owner}/${ref.repo}/issues/${ref.number}/sub_issues`, opts);
+  if ("kind" in res) return res;
+
+  let raw: RawGithubSubIssue[];
+  try {
+    const parsed = JSON.parse(res.stdout) as unknown;
+    if (!Array.isArray(parsed)) {
+      return { kind: "parse_error", message: "GitHub sub_issues response was not an array." };
+    }
+    raw = parsed as RawGithubSubIssue[];
+  } catch (err) {
+    return { kind: "parse_error", message: `Could not parse GitHub sub_issues response: ${(err as Error).message}` };
+  }
+
+  const out: GitHubSubIssue[] = [];
+  for (const r of raw) {
+    if (typeof r.number !== "number" || typeof r.title !== "string" || typeof r.state !== "string" || typeof r.html_url !== "string") {
+      // Skip malformed rows rather than failing the whole ingest — a single
+      // odd sub-issue shouldn't sink the batch. (Logged by the caller's count.)
+      continue;
+    }
+    const labels = Array.isArray(r.labels)
+      ? r.labels
+          .map((l) => (typeof l === "string" ? l : l.name))
+          .filter((n): n is string => typeof n === "string")
+      : [];
+    out.push({ number: r.number, title: r.title, state: r.state, html_url: r.html_url, labels });
+  }
+  return out;
+}
+
+/**
  * Type guard: distinguish error from successful metadata.
  */
 export function isGitHubFetchError(

--- a/src/surface/mc/adapters/github/fetch.ts
+++ b/src/surface/mc/adapters/github/fetch.ts
@@ -387,7 +387,7 @@ async function runGhApi(
   if (exitCode !== 0) {
     const n = stderr.toLowerCase();
     if (n.includes("rate limit")) return { kind: "rate_limited", message: "GitHub rate limit reached. Try again in a few minutes.", stderr };
-    if (n.includes("http 404") || n.includes("not found")) return { kind: "not_found", message: "That pull request could not be found on GitHub.", stderr };
+    if (n.includes("http 404") || n.includes("not found")) return { kind: "not_found", message: "That GitHub resource could not be found.", stderr };
     if (n.includes("http 401") || n.includes("unauthorized") || n.includes("gh auth") || n.includes("authentication required"))
       return { kind: "unauthorized", message: "GitHub auth failed. Run 'gh auth login' to authenticate, then try again.", stderr };
     return { kind: "upstream", message: `gh CLI exited ${exitCode}: ${stderr.trim() || "(empty stderr)"}`, stderr };

--- a/src/surface/mc/adapters/github/work-items.ts
+++ b/src/surface/mc/adapters/github/work-items.ts
@@ -1,0 +1,105 @@
+/**
+ * G-1113.D.5b — GitHub WorkItemSource: the FIRST adapter against the
+ * provider-neutral {@link WorkItemSource} contract (adapters/work-item-source.ts).
+ *
+ * A plan's work items are the sub-issues of its umbrella issue. This adapter
+ * reads the umbrella ref off `plan.umbrellaWorkItemId` (canonical `owner/repo#N`),
+ * fetches the sub-issues via the GitHub adapter's `fetchSubIssues`, and
+ * normalizes each into a provider-neutral {@link WorkItem}. All GitHub specifics
+ * — the `gh` CLI, the `owner/repo#N` shape, the `G-1113.<PHASE>.<n>` slice-id
+ * convention used to map a sub-issue to a phase — stay behind this boundary.
+ *
+ * Honest no-op: if the plan carries no umbrella link (doc-ingested plans from
+ * D.2 have `umbrellaWorkItemId === null`), or the link doesn't parse, the source
+ * returns `[]` — it never guesses. Wiring the umbrella link onto a plan is a
+ * separate concern (a D.2 enhancement or operator action).
+ */
+import type { Plan, PlanPhase, Provider, WorkItem } from "../../types";
+import type { WorkItemSource, WorkItemSourceContext } from "../work-item-source";
+import { parseGitHubRef, isParseError } from "./ref";
+import { fetchSubIssues, type GhSpawnFn, type GitHubSubIssue } from "./fetch";
+
+export interface GithubWorkItemSourceOptions {
+  /** Injected `gh` spawn for tests; defaults to the real CLI inside fetchSubIssues. */
+  spawn?: GhSpawnFn;
+  timeoutMs?: number;
+}
+
+/**
+ * Map a sub-issue to one of the plan's phases via the phase label embedded in
+ * the slice id convention (`G-1113.<PHASE>.<n>` → phase label `<PHASE>`). The
+ * labels come from the plan's OWN phases (`{planId}-phase-{label}`, set by D.2),
+ * so this isn't hardcoded to one plan — it matches whatever labels the plan has.
+ * Returns null when no phase label is found in the title (work item stays filed
+ * under the plan, unphased — honest rather than guessing a phase).
+ */
+function mapPhaseId(title: string, phases: PlanPhase[], planId: string): string | null {
+  const prefix = `${planId}-phase-`;
+  for (const ph of phases) {
+    if (!ph.id.startsWith(prefix)) continue;
+    const label = ph.id.slice(prefix.length);
+    if (!label) continue;
+    // Match the label as a dot/space-delimited token (e.g. ".D." in
+    // "G-1113.D.4 — …", or " D " in "Phase D — …"), case-insensitive.
+    const escaped = label.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    if (new RegExp(`[.\\s](${escaped})[.\\s]`, "i").test(title)) return ph.id;
+  }
+  return null;
+}
+
+function subIssueToWorkItem(
+  sub: GitHubSubIssue,
+  plan: Plan,
+  phases: PlanPhase[],
+  owner: string,
+  repo: string
+): WorkItem {
+  const externalId = `${owner}/${repo}#${sub.number}`;
+  return {
+    // id == externalId: a stable owner/repo#N bijection (matches the PR adapter
+    // convention) so re-ingestion is idempotent.
+    id: externalId,
+    planId: plan.id,
+    phaseId: mapPhaseId(sub.title, phases, plan.id),
+    parentId: null,
+    title: sub.title,
+    description: null,
+    // WorkItem.status is an open string (§6) — GitHub's open/closed verbatim.
+    status: sub.state,
+    priority: "",
+    provider: "github",
+    externalId,
+    url: sub.html_url,
+  };
+}
+
+/** GitHub implementation of the provider-neutral {@link WorkItemSource}. */
+export class GithubWorkItemSource implements WorkItemSource {
+  readonly provider: Provider = "github";
+
+  constructor(private readonly opts: GithubWorkItemSourceOptions = {}) {}
+
+  async fetchWorkItems(ctx: WorkItemSourceContext): Promise<WorkItem[]> {
+    const { plan, phases } = ctx;
+    if (plan.umbrellaWorkItemId === null) return []; // no umbrella link → nothing to ingest
+    const ref = parseGitHubRef(plan.umbrellaWorkItemId);
+    if (isParseError(ref)) return []; // unparseable link → honest no-op (never guess)
+
+    const subs = await fetchSubIssues(
+      { owner: ref.owner, repo: ref.repo, number: ref.number },
+      { spawn: this.opts.spawn, timeoutMs: this.opts.timeoutMs }
+    );
+    if (!Array.isArray(subs)) {
+      // fetchSubIssues returns an array on success, a GitHubFetchError otherwise.
+      // Surface the failure to stderr rather than silently swallowing (CLAUDE.md:
+      // no empty catches). Ingestion is best-effort — an empty result lets the
+      // orchestrator persist nothing this run.
+      process.stderr.write(
+        `[github-work-items] fetchSubIssues failed for ${plan.umbrellaWorkItemId}: ${subs.kind} — ${subs.message}\n`
+      );
+      return [];
+    }
+
+    return subs.map((sub) => subIssueToWorkItem(sub, plan, phases, ref.owner, ref.repo));
+  }
+}

--- a/src/surface/mc/adapters/github/work-items.ts
+++ b/src/surface/mc/adapters/github/work-items.ts
@@ -12,7 +12,7 @@
  * Honest no-op: if the plan carries no umbrella link (doc-ingested plans from
  * D.2 have `umbrellaWorkItemId === null`), or the link doesn't parse, the source
  * returns `[]` — it never guesses. Wiring the umbrella link onto a plan is a
- * separate concern (a D.2 enhancement or operator action).
+ * separate concern (a D.2 enhancement or principal action).
  */
 import type { Plan, PlanPhase, Provider, WorkItem } from "../../types";
 import type { WorkItemSource, WorkItemSourceContext } from "../work-item-source";

--- a/src/surface/mc/adapters/github/work-items.ts
+++ b/src/surface/mc/adapters/github/work-items.ts
@@ -27,24 +27,39 @@ export interface GithubWorkItemSourceOptions {
 
 /**
  * Map a sub-issue to one of the plan's phases via the phase label embedded in
- * the slice id convention (`G-1113.<PHASE>.<n>` → phase label `<PHASE>`). The
+ * the slice-id convention (`G-1113.<PHASE>.<n>` → phase label `<PHASE>`). The
  * labels come from the plan's OWN phases (`{planId}-phase-{label}`, set by D.2),
  * so this isn't hardcoded to one plan — it matches whatever labels the plan has.
- * Returns null when no phase label is found in the title (work item stays filed
- * under the plan, unphased — honest rather than guessing a phase).
+ *
+ * Matching is deliberately STRICT to avoid mis-filing: phase labels are often
+ * single letters (a–e), so a loose token match would mis-attribute incidental
+ * letters in prose (label `c` ⊂ "fix the c compiler"). We accept only:
+ *   - the dotted slice-id form `<…>.<LABEL>.<n>` (or `<LABEL>.<n>` at the start), and
+ *   - the explicit prose form `Phase <LABEL>` (the word "phase" must precede).
+ * If MORE THAN ONE phase label matches, the title is ambiguous → returns null
+ * (work item stays unphased — honest rather than guessing). Returns null when no
+ * label matches.
  */
 function mapPhaseId(title: string, phases: PlanPhase[], planId: string): string | null {
   const prefix = `${planId}-phase-`;
+  let found: string | null = null;
+  let count = 0;
   for (const ph of phases) {
     if (!ph.id.startsWith(prefix)) continue;
     const label = ph.id.slice(prefix.length);
     if (!label) continue;
-    // Match the label as a dot/space-delimited token (e.g. ".D." in
-    // "G-1113.D.4 — …", or " D " in "Phase D — …"), case-insensitive.
-    const escaped = label.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-    if (new RegExp(`[.\\s](${escaped})[.\\s]`, "i").test(title)) return ph.id;
+    const esc = label.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    // Slice-id form: label dot-bounded (or at string start) + a numeric slice
+    // index — `.D.4` / leading `D.4`. Prose form: the word "phase" then the label.
+    const sliceForm = new RegExp(`(?:^|\\.)${esc}\\.\\d`, "i");
+    const proseForm = new RegExp(`\\bphase\\s+${esc}\\b`, "i");
+    if (sliceForm.test(title) || proseForm.test(title)) {
+      found = ph.id;
+      count += 1;
+    }
   }
-  return null;
+  // Exactly one phase label matched → file under it; zero or ambiguous → null.
+  return count === 1 ? found : null;
 }
 
 function subIssueToWorkItem(

--- a/src/surface/mc/adapters/work-item-source.ts
+++ b/src/surface/mc/adapters/work-item-source.ts
@@ -1,0 +1,63 @@
+/**
+ * G-1113.D.5b — provider-neutral WorkItem ingestion.
+ *
+ * `WorkItemSource` is the contract ANY provider's work-item ingester satisfies:
+ * given a plan + its phases, it returns provider-neutral {@link WorkItem} rows.
+ * `ingestWorkItems` is the provider-agnostic orchestrator — it resolves the
+ * plan, asks the source for rows, and persists them transactionally. GitHub is
+ * the first adapter implemented against this (see adapters/github/work-items.ts),
+ * but nothing here knows about GitHub — adding GitLab/Jira/Linear is "write
+ * another `WorkItemSource`", exactly as Phase B established for `SourceRef`.
+ */
+import type { Database } from "bun:sqlite";
+import type { Plan, PlanPhase, Provider, WorkItem } from "../types";
+import { getPlan, listPhasesForPlan } from "../db/plans";
+import { upsertWorkItem } from "../db/work-items";
+
+/** What a source is given to normalize work items for a single plan. */
+export interface WorkItemSourceContext {
+  plan: Plan;
+  /** The plan's phases (ordered), so a source can map work items → phaseId. */
+  phases: PlanPhase[];
+}
+
+/** Provider-neutral work-item ingester. One implementation per provider. */
+export interface WorkItemSource {
+  /** The provider this source emits work items for. */
+  readonly provider: Provider;
+  /**
+   * Fetch + normalize the plan's work items into provider-neutral rows.
+   * Persistence-free — the orchestrator persists. Returns `[]` when the source
+   * has nothing to ingest (e.g. the plan carries no link to this provider).
+   */
+  fetchWorkItems(ctx: WorkItemSourceContext): Promise<WorkItem[]>;
+}
+
+export interface IngestResult {
+  /** The work items the source produced (and that were persisted). */
+  workItems: WorkItem[];
+}
+
+/**
+ * Orchestrate ingestion for one plan through a given source. Resolves the plan
+ * + phases, delegates normalization to the source, and upserts the rows in a
+ * single transaction (idempotent by id). Returns an empty result when the plan
+ * is unknown or the source produces nothing.
+ */
+export async function ingestWorkItems(
+  db: Database,
+  source: WorkItemSource,
+  planId: string
+): Promise<IngestResult> {
+  const plan = getPlan(db, planId);
+  if (!plan) return { workItems: [] };
+  const phases = listPhasesForPlan(db, planId);
+  const workItems = await source.fetchWorkItems({ plan, phases });
+  if (workItems.length > 0) {
+    const persist = db.transaction(() => {
+      for (const wi of workItems) upsertWorkItem(db, wi);
+    });
+    persist();
+  }
+  return { workItems };
+}


### PR DESCRIPTION
## G-1113.D.5b — provider-neutral WorkItem ingestion

Per your 2026-06-03 decision: **define the neutral interface first, GitHub as the first adapter against it** — so neutrality is exercised by design, not just asserted (the same discipline Phase B established for `SourceRef`).

### What's here
- **`adapters/work-item-source.ts`** (the neutral core) — `WorkItemSource` contract (`provider` + `fetchWorkItems(ctx)`) and `ingestWorkItems(db, source, planId)`: resolves the plan + phases, delegates normalization to the source, and upserts transactionally (idempotent). **Knows nothing about GitHub** — adding GitLab/Jira is "write another `WorkItemSource`".
- **`adapters/github/work-items.ts`** — `GithubWorkItemSource`, the first adapter. Reads the umbrella ref off `plan.umbrellaWorkItemId` (`owner/repo#N`), fetches its sub-issues, maps each → provider-neutral `WorkItem`. Phase mapping uses the plan's **own** phase labels (`{planId}-phase-{label}`) against the slice-id convention (`G-1113.<PHASE>.<n>`) — not hardcoded to one plan.
- **`adapters/github/fetch.ts`** — `fetchSubIssues` via `/issues/:n/sub_issues`, reusing `runGhApi` (same `gh`-CLI trust root + error mapping); skips malformed rows rather than failing the batch.
- **tests** — orchestrator proven with a **mock source** (proves the core is provider-blind); GitHub adapter proven with an **injected `gh` spawn fake** (normalization, phase mapping, open/closed status, and the no-umbrella / unparseable / fetch-error / malformed-row no-op paths).

### Honest scope / no-op behaviour
- Doc-ingested plans (D.2) have `umbrellaWorkItemId === null`, so the GitHub source **returns `[]`** for them — it never guesses an umbrella. Wiring the umbrella link onto a plan is a separate concern (a D.2 enhancement or operator action).
- gh fetch errors are **surfaced to stderr**, not swallowed (no empty catches), and yield an empty result (best-effort).

### Next wiring step (not in this slice)
A runtime trigger (endpoint/CLI) that picks the adapter by `plan.provider` and calls `ingestWorkItems` — fold into D.5 or a thin follow-up. D.5b lands the **mechanism + neutral contract**, matching the D.2 ingestion-mechanism precedent. Until wired, phase-detail (D.4) keeps its honest empty state.

### Verification
- `bunx tsc --noEmit` clean · `bun run lint` 0 errors · `bun test src/surface/mc` 1228 pass / 0 fail · merge-guard clean

Closes #587. Part of #577, umbrella #354.