### PR TITLE
feat(mc): G-1113.D.5 — work-item detail surface (design §7.3)

### DIFF
--- a/src/surface/mc/__tests__/work-item-detail.test.ts
+++ b/src/surface/mc/__tests__/work-item-detail.test.ts
@@ -63,6 +63,33 @@ describe("getWorkItemDetail (D.5)", () => {
     expect(detail?.pullRequests[0]?.reviews.map((r) => r.state)).toEqual(["approved"]);
   });
 
+  it("projects multiple PRs; a PR with no reviews → reviews:[] (the D.5 delta)", () => {
+    const db = freshDb();
+    upsertPlan(db, plan);
+    upsertPlanPhase(db, phase);
+    upsertWorkItem(db, wi);
+    upsertRepository(db, repo);
+    upsertPullRequest(db, pr); // pr-588, has one review
+    upsertReview(db, review);
+    upsertPullRequest(db, { ...pr, id: "pr-589", numberOrKey: "589", reviewState: "needs_review" }); // no reviews
+
+    const detail = getWorkItemDetail(db, "the-metafactory/cortex#581");
+    expect(detail?.pullRequests).toHaveLength(2);
+    expect(detail?.pullRequests.find((p) => p.pullRequest.id === "pr-589")?.reviews).toEqual([]);
+    expect(detail?.pullRequests.find((p) => p.pullRequest.id === "pr-588")?.reviews).toHaveLength(1);
+  });
+
+  it("handler 200 returns the detail envelope", async () => {
+    const db = freshDb();
+    upsertPlan(db, plan);
+    upsertPlanPhase(db, phase);
+    upsertWorkItem(db, wi);
+    const res = handleGetWorkItemDetail(db, "the-metafactory/cortex#581");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { workItem: { id: string } };
+    expect(body.workItem.id).toBe("the-metafactory/cortex#581");
+  });
+
   it("unphased / unplanned work item → null plan & phase, still projects", () => {
     const db = freshDb();
     upsertWorkItem(db, { ...wi, id: "wi-orphan", planId: null, phaseId: null });

--- a/src/surface/mc/__tests__/work-item-detail.test.ts
+++ b/src/surface/mc/__tests__/work-item-detail.test.ts
@@ -1,0 +1,83 @@
+/**
+ * G-1113.D.5 — work-item detail projection (api/work-item-detail.ts).
+ */
+import { describe, it, expect, afterEach } from "bun:test";
+import { join } from "path";
+import { tmpdir } from "os";
+import { rmSync, existsSync } from "fs";
+import { initDatabase } from "../db/init";
+import { upsertPlan, upsertPlanPhase } from "../db/plans";
+import { upsertWorkItem } from "../db/work-items";
+import { upsertRepository, upsertPullRequest, upsertReview } from "../db/git-objects";
+import { getWorkItemDetail, handleGetWorkItemDetail } from "../api/work-item-detail";
+import type { Plan, PlanPhase, WorkItem, GitRepository, PullRequest, Review } from "../types";
+
+const plan: Plan = {
+  id: "plan-1", title: "Cockpit", kind: "design", sourceDocumentUrl: null,
+  provider: "internal", externalId: null, umbrellaWorkItemId: null, status: "active",
+};
+const phase: PlanPhase = { id: "phase-d", planId: "plan-1", title: "Plan Lineage", order: 3, status: "active" };
+const repo: GitRepository = {
+  id: "repo-1", provider: "github", owner: "the-metafactory", name: "cortex", url: null, defaultBranch: "main",
+};
+const wi: WorkItem = {
+  id: "the-metafactory/cortex#581", planId: "plan-1", phaseId: "phase-d", parentId: null,
+  title: "G-1113.D.4 — Phase detail", description: null, status: "closed", priority: "",
+  provider: "github", externalId: "the-metafactory/cortex#581",
+  url: "https://github.com/the-metafactory/cortex/issues/581",
+};
+const pr: PullRequest = {
+  id: "pr-588", workItemId: "the-metafactory/cortex#581", repositoryId: "repo-1", provider: "github",
+  providerNativeType: "pull_request", externalId: "the-metafactory/cortex#588", numberOrKey: "588",
+  title: "D.4 impl", sourceBranch: "feat/d4", targetBranch: "main",
+  url: "https://github.com/the-metafactory/cortex/pull/588", state: "merged", reviewState: "approved",
+};
+const review: Review = {
+  id: "rev-1", pullRequestId: "pr-588", reviewer: "sage", state: "approved", provider: "github", url: null,
+};
+
+describe("getWorkItemDetail (D.5)", () => {
+  const paths: string[] = [];
+  afterEach(() => { for (const p of paths) if (existsSync(p)) rmSync(p); paths.length = 0; });
+  function freshDb() {
+    const p = join(tmpdir(), `wid-${Date.now()}-${Math.random().toString(36).slice(2)}.db`);
+    paths.push(p);
+    return initDatabase(p);
+  }
+
+  it("projects work item + plan/phase context + linked PRs with reviews", () => {
+    const db = freshDb();
+    upsertPlan(db, plan);
+    upsertPlanPhase(db, phase);
+    upsertWorkItem(db, wi);
+    upsertRepository(db, repo);
+    upsertPullRequest(db, pr);
+    upsertReview(db, review);
+
+    const detail = getWorkItemDetail(db, "the-metafactory/cortex#581");
+    expect(detail?.workItem.title).toBe("G-1113.D.4 — Phase detail");
+    expect(detail?.plan?.id).toBe("plan-1");
+    expect(detail?.phase?.id).toBe("phase-d");
+    expect(detail?.pullRequests).toHaveLength(1);
+    expect(detail?.pullRequests[0]?.pullRequest.id).toBe("pr-588");
+    expect(detail?.pullRequests[0]?.reviews.map((r) => r.state)).toEqual(["approved"]);
+  });
+
+  it("unphased / unplanned work item → null plan & phase, still projects", () => {
+    const db = freshDb();
+    upsertWorkItem(db, { ...wi, id: "wi-orphan", planId: null, phaseId: null });
+    const detail = getWorkItemDetail(db, "wi-orphan");
+    expect(detail?.plan).toBeNull();
+    expect(detail?.phase).toBeNull();
+    expect(detail?.pullRequests).toEqual([]);
+  });
+
+  it("unknown work item → getWorkItemDetail null, handler 404", async () => {
+    const db = freshDb();
+    expect(getWorkItemDetail(db, "nope")).toBeNull();
+    const res = handleGetWorkItemDetail(db, "nope");
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain("not found");
+  });
+});

--- a/src/surface/mc/api/work-item-detail.ts
+++ b/src/surface/mc/api/work-item-detail.ts
@@ -1,0 +1,65 @@
+/**
+ * G-1113.D.5 — work-item detail projection + endpoint (design §7.3).
+ *
+ * The operational drill-down for a single work item: its plan/phase context
+ * and its linked pull requests (each with their reviews).
+ *
+ * Honest-data scope: §7.3 also lists current session, event log, checks/builds,
+ * a principal input box, and curation actions (dispatch/requeue/abandon/hand
+ * off). Of those:
+ *   - sessions/event-log link via assignment→task, NOT to a work item (no
+ *     work_item column), so they aren't projected here;
+ *   - checks link by commit SHA, which a PullRequest row doesn't carry, so the
+ *     PR→check path isn't queryable yet (deepens when head-sha plumbing lands);
+ *   - curation actions operate on the legacy assignment lifecycle, which work
+ *     items aren't wired to.
+ * So D.5 surfaces what's genuinely linked today — plan/phase + PRs + reviews —
+ * and leaves the rest for later slices rather than rendering fabricated panels.
+ */
+import type { Database } from "bun:sqlite";
+import type { Plan, PlanPhase, WorkItem, PullRequest, Review } from "../types";
+import { getPlan, getPlanPhase } from "../db/plans";
+import { getWorkItem } from "../db/work-items";
+import { listPullRequestsForWorkItem, listReviewsForPullRequest } from "../db/git-objects";
+
+export interface PullRequestWithReviews {
+  pullRequest: PullRequest;
+  reviews: Review[];
+}
+
+export interface WorkItemDetail {
+  workItem: WorkItem;
+  /** Owning plan, when the work item is filed under one. */
+  plan: Plan | null;
+  /** Owning phase, when the work item is filed under one. */
+  phase: PlanPhase | null;
+  pullRequests: PullRequestWithReviews[];
+}
+
+/** Project a single work item with its plan/phase context + linked PRs (each with reviews). Null if unknown. */
+export function getWorkItemDetail(db: Database, workItemId: string): WorkItemDetail | null {
+  const workItem = getWorkItem(db, workItemId);
+  if (!workItem) return null;
+  const plan = workItem.planId !== null ? getPlan(db, workItem.planId) : null;
+  const phase = workItem.phaseId !== null ? getPlanPhase(db, workItem.phaseId) : null;
+  const pullRequests = listPullRequestsForWorkItem(db, workItemId).map((pullRequest) => ({
+    pullRequest,
+    reviews: listReviewsForPullRequest(db, pullRequest.id),
+  }));
+  return { workItem, plan, phase, pullRequests };
+}
+
+/** GET /api/work-items/:id — work-item detail; 404 if unknown. */
+export function handleGetWorkItemDetail(db: Database, workItemId: string): Response {
+  const detail = getWorkItemDetail(db, workItemId);
+  if (!detail) {
+    return new Response(JSON.stringify({ error: "work item not found" }), {
+      status: 404,
+      headers: { "content-type": "application/json" },
+    });
+  }
+  return new Response(JSON.stringify(detail), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}

--- a/src/surface/mc/dashboard-v2/app.tsx
+++ b/src/surface/mc/dashboard-v2/app.tsx
@@ -23,6 +23,7 @@ import { SourcesView } from "./components/sources-view";
 import { RepositoriesView } from "./components/repositories-view";
 import { PlansView } from "./components/plans-view";
 import { PhaseDetailView } from "./components/phase-detail-view";
+import { WorkItemDetailView } from "./components/work-item-detail-view";
 import { Toast } from "./components/toast";
 import { useFocusArea } from "./hooks/use-focus-area";
 import { useTasks } from "./hooks/use-tasks";
@@ -31,6 +32,7 @@ import { useSoftwareMode } from "./hooks/use-software-mode";
 import { useRepositories } from "./hooks/use-repositories";
 import { usePlans } from "./hooks/use-plans";
 import { usePhaseDetail } from "./hooks/use-phase-detail";
+import { useWorkItemDetail } from "./hooks/use-work-item-detail";
 import { useTheme } from "./hooks/use-theme";
 import { useWebSocket } from "./hooks/use-websocket";
 import { ApiFailure, postJson } from "./lib/api";
@@ -53,7 +55,7 @@ import type { Command } from "./components/command-palette";
  * may upgrade to a hash route if deep-linking turns out to be
  * principal-requested; for now the in-memory view is sufficient.
  */
-type DashboardView = "default" | "metrics" | "iterations" | "sources" | "repositories" | "plans" | "phase-detail" | "kanban-detail";
+type DashboardView = "default" | "metrics" | "iterations" | "sources" | "repositories" | "plans" | "phase-detail" | "work-item-detail" | "kanban-detail";
 
 export function App() {
   const { theme, toggle: toggleTheme } = useTheme();
@@ -94,17 +96,28 @@ export function App() {
   // G-1113.D.4 — selected phase for the phase-detail surface (reached from the
   // Plans overview by clicking a phase; exited back to `plans`).
   const [selectedPhaseId, setSelectedPhaseId] = useState<string | null>(null);
+  // G-1113.D.5 — selected work item for the work-item-detail surface (reached
+  // from phase-detail by clicking a work item; exited back to `phase-detail`).
+  const [selectedWorkItemId, setSelectedWorkItemId] = useState<string | null>(null);
   // G-1113.C.7 — Repositories panel data (fetched only when on its tab).
   const repos = useRepositories(softwareMode && view === "repositories");
   // G-1113.D.3 — Plans overview data (fetched only when on its tab).
   const plans = usePlans(softwareMode && view === "plans");
   // G-1113.D.4 — phase-detail data (fetched whenever a phase is selected).
   const phaseDetail = usePhaseDetail(view === "phase-detail" ? selectedPhaseId : null);
+  // G-1113.D.5 — work-item-detail data (fetched whenever a work item is selected).
+  const workItemDetail = useWorkItemDetail(view === "work-item-detail" ? selectedWorkItemId : null);
   // If software mode is toggled OFF while on a software-mode view (Repositories
-  // / Plans / phase-detail), the tab + render both gate off — reset to default
-  // so the main area isn't left blank.
+  // / Plans / phase-detail / work-item-detail), the tab + render both gate off —
+  // reset to default so the main area isn't left blank.
   useEffect(() => {
-    if (!softwareMode && (view === "repositories" || view === "plans" || view === "phase-detail")) {
+    if (
+      !softwareMode &&
+      (view === "repositories" ||
+        view === "plans" ||
+        view === "phase-detail" ||
+        view === "work-item-detail")
+    ) {
       setView("default");
     }
   }, [softwareMode, view]);
@@ -608,6 +621,23 @@ export function App() {
             onClose={() => {
               setView("plans");
               setSelectedPhaseId(null);
+            }}
+            onOpenWorkItem={(workItemId) => {
+              setSelectedWorkItemId(workItemId);
+              setView("work-item-detail");
+            }}
+          />
+        )}
+
+        {view === "work-item-detail" && softwareMode && selectedWorkItemId && (
+          /* G-1113.D.5 — work-item detail (reached from a phase-detail work item).
+             Back returns to the phase-detail surface (selectedPhaseId is retained). */
+          <WorkItemDetailView
+            detail={workItemDetail.detail}
+            loaded={workItemDetail.loaded}
+            onClose={() => {
+              setView("phase-detail");
+              setSelectedWorkItemId(null);
             }}
           />
         )}

--- a/src/surface/mc/dashboard-v2/components/phase-detail-view.tsx
+++ b/src/surface/mc/dashboard-v2/components/phase-detail-view.tsx
@@ -14,9 +14,11 @@ export interface PhaseDetailViewProps {
   detail: PhaseDetail | null;
   loaded: boolean;
   onClose: () => void;
+  /** Open the work-item detail surface (D.5). */
+  onOpenWorkItem?: (workItemId: string) => void;
 }
 
-export function PhaseDetailView({ detail, loaded, onClose }: PhaseDetailViewProps) {
+export function PhaseDetailView({ detail, loaded, onClose, onOpenWorkItem }: PhaseDetailViewProps) {
   return (
     <section className="scaffold-section phase-detail" aria-label="Phase detail">
       <div className="phase-detail-head">
@@ -49,13 +51,29 @@ export function PhaseDetailView({ detail, loaded, onClose }: PhaseDetailViewProp
               {detail.workItems.map(({ workItem: w, pullRequests }) => (
                 <li key={w.id} className="work-item">
                   <div className="work-item-head">
-                    {w.url ? (
-                      <a href={w.url} target="_blank" rel="noopener noreferrer">
+                    {onOpenWorkItem ? (
+                      <button
+                        type="button"
+                        className="work-item-open"
+                        onClick={() => onOpenWorkItem(w.id)}
+                        aria-label={`Open work item ${w.title}`}
+                      >
                         {w.title}
-                      </a>
+                      </button>
                     ) : (
                       <span>{w.title}</span>
                     )}
+                    {w.url ? (
+                      <a
+                        className="dim mono wid-ext"
+                        href={w.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        aria-label="Open on provider"
+                      >
+                        ↗
+                      </a>
+                    ) : null}
                     {w.status ? <span className="badge">{w.status}</span> : null}
                   </div>
                   {pullRequests.length > 0 ? (

--- a/src/surface/mc/dashboard-v2/components/work-item-detail-view.tsx
+++ b/src/surface/mc/dashboard-v2/components/work-item-detail-view.tsx
@@ -8,6 +8,7 @@
  * renders only the genuinely-linked context: plan/phase + PRs + reviews.
  */
 import type { WorkItemDetail } from "../../api/work-item-detail";
+import { ProviderBadge } from "./provider-badge";
 
 export interface WorkItemDetailViewProps {
   detail: WorkItemDetail | null;
@@ -43,9 +44,7 @@ export function WorkItemDetailView({ detail, loaded, onClose }: WorkItemDetailVi
             {/* plan / phase breadcrumb */}
             {detail.plan ? <span className="dim">{detail.plan.title}</span> : null}
             {detail.phase ? <span className="dim">› {detail.phase.title}</span> : null}
-            <span className={`badge provider-${detail.workItem.provider}`}>
-              {detail.workItem.provider}
-            </span>
+            <ProviderBadge provider={detail.workItem.provider} />
             {detail.workItem.status ? (
               <span className="badge">{detail.workItem.status}</span>
             ) : null}

--- a/src/surface/mc/dashboard-v2/components/work-item-detail-view.tsx
+++ b/src/surface/mc/dashboard-v2/components/work-item-detail-view.tsx
@@ -1,0 +1,95 @@
+/**
+ * G-1113.D.5 — work-item detail surface (design §7.3). Shows a work item's
+ * plan/phase context and its linked pull requests (each with reviews).
+ *
+ * Honest-data scope: §7.3 also lists current session, event log, checks/builds,
+ * a principal input box, and curation actions — none are linked to a work item
+ * today (see api/work-item-detail.ts), so they aren't shown. This surface
+ * renders only the genuinely-linked context: plan/phase + PRs + reviews.
+ */
+import type { WorkItemDetail } from "../../api/work-item-detail";
+
+export interface WorkItemDetailViewProps {
+  detail: WorkItemDetail | null;
+  loaded: boolean;
+  onClose: () => void;
+}
+
+export function WorkItemDetailView({ detail, loaded, onClose }: WorkItemDetailViewProps) {
+  return (
+    <section className="scaffold-section work-item-detail" aria-label="Work item detail">
+      <div className="wid-head">
+        <button type="button" className="tab" onClick={onClose}>
+          ← Phase
+        </button>
+      </div>
+
+      {!loaded ? (
+        <p className="dim">Loading…</p>
+      ) : !detail ? (
+        <p className="dim">Work item not found.</p>
+      ) : (
+        <>
+          <h2>
+            {detail.workItem.url ? (
+              <a href={detail.workItem.url} target="_blank" rel="noopener noreferrer">
+                {detail.workItem.title}
+              </a>
+            ) : (
+              detail.workItem.title
+            )}
+          </h2>
+          <p className="plan-meta">
+            {/* plan / phase breadcrumb */}
+            {detail.plan ? <span className="dim">{detail.plan.title}</span> : null}
+            {detail.phase ? <span className="dim">› {detail.phase.title}</span> : null}
+            <span className={`badge provider-${detail.workItem.provider}`}>
+              {detail.workItem.provider}
+            </span>
+            {detail.workItem.status ? (
+              <span className="badge">{detail.workItem.status}</span>
+            ) : null}
+          </p>
+
+          <h3 className="wid-section-label">
+            Pull requests <span className="dim">({detail.pullRequests.length})</span>
+          </h3>
+          {detail.pullRequests.length === 0 ? (
+            <p className="dim faint">No linked pull requests.</p>
+          ) : (
+            <ul className="wid-prs">
+              {detail.pullRequests.map(({ pullRequest: pr, reviews }) => (
+                <li key={pr.id} className="wid-pr">
+                  <div className="wid-pr-head">
+                    {pr.url ? (
+                      <a href={pr.url} target="_blank" rel="noopener noreferrer">
+                        #{pr.numberOrKey}
+                      </a>
+                    ) : (
+                      <span>#{pr.numberOrKey}</span>
+                    )}
+                    <span className="dim mono">
+                      {pr.sourceBranch} → {pr.targetBranch}
+                    </span>
+                    <span className={`phase-status status-${pr.state}`}>{pr.state}</span>
+                    <span className="dim">{pr.reviewState}</span>
+                  </div>
+                  {reviews.length > 0 ? (
+                    <ul className="wid-reviews">
+                      {reviews.map((r) => (
+                        <li key={r.id}>
+                          <span className="dim">{r.reviewer ?? "—"}</span>{" "}
+                          <span className={`review-state state-${r.state}`}>{r.state}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  ) : null}
+                </li>
+              ))}
+            </ul>
+          )}
+        </>
+      )}
+    </section>
+  );
+}

--- a/src/surface/mc/dashboard-v2/hooks/use-work-item-detail.ts
+++ b/src/surface/mc/dashboard-v2/hooks/use-work-item-detail.ts
@@ -1,0 +1,46 @@
+/**
+ * G-1113.D.5 — fetch the work-item detail projection for the selected work item.
+ * Fetches whenever `workItemId` is non-null; best-effort (failure → null detail).
+ */
+import { useEffect, useState } from "react";
+import { getJson } from "../lib/api";
+import type { WorkItemDetail } from "../../api/work-item-detail";
+
+export function useWorkItemDetail(workItemId: string | null): {
+  detail: WorkItemDetail | null;
+  loaded: boolean;
+} {
+  const [detail, setDetail] = useState<WorkItemDetail | null>(null);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    if (!workItemId) {
+      setDetail(null);
+      setLoaded(false);
+      return;
+    }
+    let cancelled = false;
+    setLoaded(false);
+    void (async () => {
+      try {
+        // id carries `/` and `#` — encode it as a query param.
+        const res = await getJson<WorkItemDetail>(`/api/work-items?id=${encodeURIComponent(workItemId)}`);
+        if (!cancelled) {
+          setDetail(res);
+          setLoaded(true);
+        }
+      } catch (_err) {
+        // Best-effort: the surface shows a not-found state rather than erroring.
+        if (!cancelled) {
+          setDetail(null);
+          setLoaded(true);
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [workItemId]);
+
+  return { detail, loaded };
+}

--- a/src/surface/mc/dashboard-v2/styles/global.css
+++ b/src/surface/mc/dashboard-v2/styles/global.css
@@ -434,6 +434,47 @@ html, body {
 .phase-detail .phase-status.status-draft { color: var(--fg-dim); }
 .phase-detail .phase-status.status-merged { color: var(--ok); }
 .phase-detail .phase-status.status-closed { color: var(--bad); }
+/* D.5 — a work item's title is a button that opens its detail surface */
+.phase-detail .work-item-open {
+  padding: 0; border: 0; background: none; font: inherit; color: var(--fg);
+  text-align: left; cursor: pointer;
+}
+.phase-detail .work-item-open:hover { text-decoration: underline; }
+.phase-detail .work-item-open:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+.phase-detail .wid-ext { text-decoration: none; }
+
+/* G-1113.D.5 — work-item detail surface */
+.work-item-detail .wid-head { margin-bottom: 8px; }
+.work-item-detail h2 { font-size: 14px; }
+.work-item-detail h2 a { color: var(--fg); text-decoration: none; }
+.work-item-detail h2 a:hover { text-decoration: underline; }
+.work-item-detail .wid-section-label {
+  margin: 14px 0 6px 0; font-size: 11px; font-weight: 600; letter-spacing: 0.06em;
+  text-transform: uppercase; color: var(--fg-faint);
+}
+.work-item-detail .badge {
+  font-size: 10px; font-weight: 600; letter-spacing: 0.04em; text-transform: uppercase;
+  padding: 1px 6px; border-radius: 4px; border: 1px solid var(--line); color: var(--fg-dim);
+}
+.work-item-detail .wid-prs { list-style: none; margin: 0; padding: 0; }
+.work-item-detail .wid-pr {
+  border: 1px solid var(--line); border-radius: 8px;
+  background: var(--panel); padding: 10px 12px; margin-top: 8px;
+}
+.work-item-detail .wid-pr-head { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; font-size: 12px; }
+.work-item-detail .wid-pr-head a { color: var(--fg); text-decoration: none; }
+.work-item-detail .wid-pr-head a:hover { text-decoration: underline; }
+.work-item-detail .phase-status.status-merged { color: var(--ok); }
+.work-item-detail .phase-status.status-open { color: var(--fg-dim); }
+.work-item-detail .phase-status.status-draft { color: var(--fg-dim); }
+.work-item-detail .phase-status.status-closed { color: var(--bad); }
+.work-item-detail .wid-reviews { list-style: none; margin: 6px 0 0 0; padding: 0; font-size: 11px; }
+.work-item-detail .wid-reviews li { padding: 2px 0; }
+.work-item-detail .review-state.state-approved { color: var(--ok); }
+.work-item-detail .review-state.state-changes_requested { color: var(--bad); }
+.work-item-detail .review-state.state-commented,
+.work-item-detail .review-state.state-pending,
+.work-item-detail .review-state.state-dismissed { color: var(--fg-dim); }
 .scaffold-section h2 {
   margin: 0 0 6px 0;
   font-size: 11px; font-weight: 600; letter-spacing: 0.06em;

--- a/src/surface/mc/server.ts
+++ b/src/surface/mc/server.ts
@@ -42,6 +42,7 @@ import { handleListGitLinks } from "./api/git-links";
 import { handleListRepositories } from "./api/git-repos";
 import { handleListPlans } from "./api/plans";
 import { handleGetPhaseDetail } from "./api/phase-detail";
+import { handleGetWorkItemDetail } from "./api/work-item-detail";
 import type { ProcessManager } from "./session/process-manager";
 import type { SpawnFn } from "./session/endpoint-resolver";
 import { join, dirname } from "path";
@@ -433,6 +434,23 @@ async function handleApi(
       });
     }
     return handleGetPhaseDetail(db, phaseId);
+  }
+
+  // G-1113.D.5 — GET /api/work-items?id=… — work-item detail (plan/phase context
+  // + linked PRs with reviews). The id is a query param (not a path segment)
+  // because work-item ids are `owner/repo#N` and carry `/` and `#`.
+  if (pathname === "/api/work-items") {
+    if (req.method !== "GET") {
+      return methodNotAllowed(["GET"]);
+    }
+    const id = url.searchParams.get("id");
+    if (!id) {
+      return new Response(JSON.stringify({ error: "missing id query param" }), {
+        status: 400,
+        headers: { "content-type": "application/json" },
+      });
+    }
+    return handleGetWorkItemDetail(db, id);
   }
 
   if (pathname === "/api/tasks") {


### PR DESCRIPTION
## G-1113.D.5 — work-item detail surface (design §7.3)

The operational drill-down for a single work item, reached by clicking a work item in the phase-detail surface (D.4). Completes the Plans → phase → work-item navigation chain.

### What's here
- **`api/work-item-detail.ts`** — `getWorkItemDetail` + `GET /api/work-items?id=…` → work item + plan/phase context + linked PRs, each with their reviews. (Query param, not a path segment — work-item ids are `owner/repo#N` and carry `/` and `#`.)
- **dashboard-v2** — `use-work-item-detail` hook, `work-item-detail-view` component, PhaseDetailView work-item rows become buttons that open the detail (small `↗` external link retained), `app.tsx` nav (`work-item-detail` view + back to phase-detail, reset-effect extended), `global.css`.
- **`__tests__/work-item-detail.test.ts`** — projection (WI + plan/phase + PRs + reviews), unphased/unplanned WI → null plan/phase, unknown → 404.

### Honest-data scope
§7.3 also lists current session, event log, checks/builds, a principal input box, and curation actions (dispatch/requeue/abandon/hand off). **None are linked to a work item today** — sessions link via assignment→task (no work-item column); checks link by commit SHA, which a PR row doesn't carry; curation operates on the legacy assignment lifecycle. So they aren't rendered (no fabricated panels); this surfaces only the genuinely-linked context: plan/phase + PRs + reviews.

### ⚠️ Where the dashboard stands — "scaffolding vs live"
With D.1–D.5b + this, the **whole Plans → phase → work-item → PR/review chain is built and tested**, but it renders **honest empty states end-to-end** because nothing populates it live yet. Two gaps stand between this and a live dashboard, both known:
1. **Plans have no umbrella link** — doc-ingested plans (D.2) set `umbrellaWorkItemId = null`, so the D.5b GitHub ingester no-ops. Needs the plan doc (or an action) to declare its umbrella issue.
2. **No ingestion trigger** — `ingestWorkItems` has no runtime caller (endpoint/CLI) yet.

Happy to prioritise a thin "make-it-live" slice (umbrella linkage + trigger + provider dispatch) next if you'd rather see real data than more surfaces — flagging since it's the gap between the built chain and a usable cockpit.

### Verification
- `bunx tsc --noEmit` clean · `bun run lint` 0 errors · carve-out gate PASS · `bun test src/surface/mc` 1223 pass / 0 fail · `bun run build:dashboard` bundles · merge-guard clean (D.5b)

Closes #582. Part of #577, umbrella #354.