### PR TITLE
feat(gateway): GW.a.3b.2d — attachInboundDispatch wiring + inbound observability (#524)

### DIFF
--- a/src/adapters/types.ts
+++ b/src/adapters/types.ts
@@ -168,4 +168,16 @@ export interface PlatformAdapter {
   notifyPrincipal(text: string): Promise<void>;
   /** F-092: Hot-reload adapter config (optional, for adapters that support it) */
   updateConfig?(config: unknown): void;
+  /**
+   * Two-phase inbound registration (optional). `start()` connects + stores the
+   * `onMessage` callback; this SECOND call registers the platform's message
+   * listener so inbound events actually dispatch. Discord + Slack split start
+   * from listen (the per-stack boot defers this until after Pass-2 trust merge);
+   * single-phase adapters (Mattermost) register inside `start()` and omit it.
+   *
+   * Callers that drive an adapter directly (the shared surface gateway,
+   * cortex#524) MUST call this after `start()` or no inbound is ever delivered.
+   * Idempotent — adapters latch on first attach so re-calls are no-ops.
+   */
+  attachInboundDispatch?(): void;
 }

--- a/src/gateway/__tests__/surface-gateway.test.ts
+++ b/src/gateway/__tests__/surface-gateway.test.ts
@@ -218,6 +218,7 @@ describe("SurfaceGateway.start()", () => {
     expect(a2.attachCalled).toBe(1);
     // attach MUST come after start (start stores onMessage; attach registers the listener).
     expect(a1.callOrder).toEqual(["start", "attach"]);
+    expect(a2.callOrder).toEqual(["start", "attach"]);
   });
 });
 

--- a/src/gateway/__tests__/surface-gateway.test.ts
+++ b/src/gateway/__tests__/surface-gateway.test.ts
@@ -118,6 +118,9 @@ class MockAdapter implements PlatformAdapter {
 
   startCalled = 0;
   stopCalled = 0;
+  attachCalled = 0;
+  /** Records start/attach order so tests can assert attach happens AFTER start. */
+  readonly callOrder: string[] = [];
 
   private _onMessage: ((msg: InboundMessage) => Promise<void>) | null = null;
 
@@ -128,7 +131,13 @@ class MockAdapter implements PlatformAdapter {
 
   async start(onMessage: (msg: InboundMessage) => Promise<void>): Promise<void> {
     this.startCalled++;
+    this.callOrder.push("start");
     this._onMessage = onMessage;
+  }
+
+  attachInboundDispatch(): void {
+    this.attachCalled++;
+    this.callOrder.push("attach");
   }
 
   async stop(): Promise<void> {
@@ -203,6 +212,12 @@ describe("SurfaceGateway.start()", () => {
 
     expect(a1.startCalled).toBe(1);
     expect(a2.startCalled).toBe(1);
+    // Two-phase inbound: start() must ALSO attach the message listener, or the
+    // adapter connects but never delivers inbound (the cortex#524 dry-run bug).
+    expect(a1.attachCalled).toBe(1);
+    expect(a2.attachCalled).toBe(1);
+    // attach MUST come after start (start stores onMessage; attach registers the listener).
+    expect(a1.callOrder).toEqual(["start", "attach"]);
   });
 });
 

--- a/src/gateway/surface-gateway.ts
+++ b/src/gateway/surface-gateway.ts
@@ -160,9 +160,22 @@ export class SurfaceGateway {
    */
   async start(): Promise<void> {
     await Promise.all(
-      this.adapters.map((adapter) =>
-        adapter.start((msg) => this.handleInbound(adapter, msg)),
-      ),
+      this.adapters.map(async (adapter) => {
+        await adapter.start((msg) => this.handleInbound(adapter, msg));
+        // Two-phase inbound: start() connects + stores onMessage; this registers
+        // the platform message listener (Discord/Slack split the two — see
+        // PlatformAdapter.attachInboundDispatch). Without it the adapter connects
+        // but never delivers inbound (the cortex#524 dry-run caught exactly this).
+        // The gateway has no Pass-2 trust merge to defer for, so attach right
+        // after start. Optional-chaining: single-phase adapters (Mattermost) omit
+        // it → no-op.
+        adapter.attachInboundDispatch?.();
+        process.stdout.write(
+          `[surface-gateway] adapter started + inbound listener attached — ` +
+            `platform=${adapter.platform} instanceId=${adapter.instanceId}` +
+            `${adapter.attachInboundDispatch === undefined ? " (single-phase; no attach)" : ""}\n`,
+        );
+      }),
     );
   }
 
@@ -192,6 +205,16 @@ export class SurfaceGateway {
     msg: InboundMessage,
   ): Promise<void> {
     try {
+      // Observability: every message that reaches the gateway is logged at
+      // entry, BEFORE routing — so "message arrived but didn't route" (a binding
+      // gap) is distinguishable from "no message arrived" (an adapter filter /
+      // listener gap) without guessing. (Interim stdout; the proper system.*
+      // bus/signal emission is the GW-observability follow-up.)
+      process.stdout.write(
+        `[surface-gateway] handleInbound received — platform=${msg.platform} ` +
+          `instanceId=${msg.instanceId} channel=${msg.channelId} ` +
+          `author=${msg.authorName} contentLen=${msg.content.length}\n`,
+      );
       const match = resolveBinding(this.index, msg);
 
       if (match === null) {


### PR DESCRIPTION
The shadow dry-run caught a real integration bug unit tests couldn't: the gateway **connected** the Discord adapter but **never delivered inbound**. Root cause: Discord/Slack adapters split **connect** (`start()`, stores `onMessage`) from **listen** (`attachInboundDispatch()`, registers `messageCreate`). `SurfaceGateway.start()` only called `start()` → bot connects, listener never wired → zero inbound.

## What
- **`PlatformAdapter`**: add optional `attachInboundDispatch?(): void` (two-phase inbound; Discord/Slack implement it, single-phase Mattermost omits it).
- **`SurfaceGateway.start()`**: after `adapter.start()`, call `adapter.attachInboundDispatch?.()` (no Pass-2 trust merge to defer for → attach right after start).
- **Observability** (interim stdout): `adapter started + inbound listener attached` at boot + `handleInbound received …` at gateway entry → distinguishes 'arrived but didn't route' from 'never arrived'. *(Proper `system.*`/signal emission is the queued follow-up.)*

## ✅ Validated LIVE (acceptance proof)
Shadow dry-run on a staging Discord bot:
```
[surface-gateway] handleInbound received — platform=discord channel=… author=Andreas …
[surface-gateway:shadow] inbound routed agent=luna stack=meta-factory subject=local.andreas.meta-factory.tasks.@luna.chat response_routing={ adapter_instance=… channel_id=… }
```
Demux proven end-to-end (connect → receive → demux → correct target stack + response_routing), on real messages.

## Gates
`tsc` 0 · `eslint --quiet` 0 · `bun test src/gateway/` **99** (incl. start()→attach order) · whole-tree vocab gate PASS.

Refs #524 · part of #110.

🤖 Generated with [Claude Code](https://claude.com/claude-code)