### PR TITLE
feat(mc): G-1113.D.6 — legacy iteration kanban behind a tab toggle

### DIFF
--- a/src/surface/mc/dashboard-v2/app.tsx
+++ b/src/surface/mc/dashboard-v2/app.tsx
@@ -28,6 +28,7 @@ import { useFocusArea } from "./hooks/use-focus-area";
 import { useTasks } from "./hooks/use-tasks";
 import { useGitLinks } from "./hooks/use-git-links";
 import { useSoftwareMode } from "./hooks/use-software-mode";
+import { useLegacyIterations } from "./hooks/use-legacy-iterations";
 import { useRepositories } from "./hooks/use-repositories";
 import { usePlans } from "./hooks/use-plans";
 import { usePhaseDetail } from "./hooks/use-phase-detail";
@@ -59,6 +60,9 @@ export function App() {
   const { theme, toggle: toggleTheme } = useTheme();
   // G-1113.C.7 — software mode gates the Repositories panel.
   const { softwareMode, toggle: toggleSoftwareMode } = useSoftwareMode();
+  // G-1113.D.6 — legacy-iterations toggle gates the legacy Iterations kanban
+  // (default ON until the Plans surface reaches parity).
+  const { legacyIterations, toggle: toggleLegacyIterations } = useLegacyIterations();
   const [paletteOpen, setPaletteOpen] = useState(false);
   const [toast, setToast] = useState<{ message: string; tone?: "ok" | "error" | "info" } | null>(null);
 
@@ -108,6 +112,13 @@ export function App() {
       setView("default");
     }
   }, [softwareMode, view]);
+  // G-1113.D.6 — if the legacy kanban is toggled OFF while on the Iterations
+  // tab or its detail surface, reset to default so the main area isn't blank.
+  useEffect(() => {
+    if (!legacyIterations && (view === "iterations" || view === "kanban-detail")) {
+      setView("default");
+    }
+  }, [legacyIterations, view]);
 
   // Drill-down state — only one open at a time per F-7 Decision 9.
   const [drillId, setDrillId] = useState<string | null>(null);
@@ -235,6 +246,15 @@ export function App() {
           </button>
           <button
             type="button"
+            className={`theme-btn${legacyIterations ? " active" : ""}`}
+            onClick={toggleLegacyIterations}
+            aria-pressed={legacyIterations}
+            title="Show the legacy iteration kanban (kept until the Plans surface reaches parity)"
+          >
+            {legacyIterations ? "◆ legacy" : "◇ legacy"}
+          </button>
+          <button
+            type="button"
             className="theme-btn"
             onClick={toggleTheme}
             aria-label={`Switch to ${theme === "dark" ? "light" : "dark"} theme`}
@@ -268,15 +288,17 @@ export function App() {
         >
           Metrics
         </button>
-        <button
-          type="button"
-          role="tab"
-          aria-selected={view === "iterations"}
-          className={`tab${view === "iterations" ? " active" : ""}`}
-          onClick={() => setView("iterations")}
-        >
-          Iterations
-        </button>
+        {legacyIterations && (
+          <button
+            type="button"
+            role="tab"
+            aria-selected={view === "iterations"}
+            className={`tab${view === "iterations" ? " active" : ""}`}
+            onClick={() => setView("iterations")}
+          >
+            Iterations
+          </button>
+        )}
         <button
           type="button"
           role="tab"

--- a/src/surface/mc/dashboard-v2/app.tsx
+++ b/src/surface/mc/dashboard-v2/app.tsx
@@ -405,6 +405,10 @@ export function App() {
               // drill-header). No drill-down close because the table
               // click is happening with no overlay open.
               onOpenIteration={(iterationId) => {
+                // G-1113.D.6 — the iteration cell routes into the legacy kanban;
+                // when legacy is toggled off that surface is hidden, so no-op
+                // rather than bounce through the reset effect.
+                if (!legacyIterations) return;
                 setSelectedIterationId(iterationId);
                 setView("kanban-detail");
               }}
@@ -688,6 +692,10 @@ export function App() {
         // clean iteration surface; the existing F-7 history pattern
         // is "Esc closes, no breadcrumb back" so this matches.
         onOpenIteration={(iterationId) => {
+          // G-1113.D.6 — guard BEFORE the drill-down teardown: when legacy is
+          // off the kanban surface is hidden, so don't tear down the open
+          // drill-down for a navigation that the reset effect would bounce.
+          if (!legacyIterations) return;
           setDrillId(null);
           setFocusMode(false);
           setSelectedIterationId(iterationId);

--- a/src/surface/mc/dashboard-v2/hooks/use-legacy-iterations.ts
+++ b/src/surface/mc/dashboard-v2/hooks/use-legacy-iterations.ts
@@ -1,0 +1,34 @@
+/**
+ * G-1113.D.6 — legacy-iterations toggle (localStorage-persisted).
+ *
+ * Keeps the legacy iteration kanban (the `Iterations` tab + its detail surface)
+ * available behind a toggle "until the plan surface reaches parity" (plan §5.4).
+ * Defaults to ON (legacy available) — the new Plans surface isn't fully live yet,
+ * so the toggle is purely additive: it adds the control to HIDE the legacy
+ * kanban once the principal is satisfied with parity, changing nothing by default.
+ * Mirrors use-software-mode's persistence shape.
+ */
+import { useCallback, useEffect, useState } from "react";
+
+const STORAGE_KEY = "mc.legacyIterations";
+
+function readLegacyIterations(): boolean {
+  if (typeof window === "undefined") return true;
+  // Default ON: only an explicit "off" hides the legacy kanban.
+  return window.localStorage?.getItem(STORAGE_KEY) !== "off";
+}
+
+export function useLegacyIterations(): { legacyIterations: boolean; toggle: () => void } {
+  const [legacyIterations, setLegacyIterations] = useState<boolean>(() => readLegacyIterations());
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    try {
+      window.localStorage?.setItem(STORAGE_KEY, legacyIterations ? "on" : "off");
+    } catch (_err) {
+      // localStorage unavailable (private mode / permissions) — the flag still
+      // applies in-session; persistence is best-effort (matches use-software-mode).
+    }
+  }, [legacyIterations]);
+  const toggle = useCallback(() => setLegacyIterations((v) => !v), []);
+  return { legacyIterations, toggle };
+}


### PR DESCRIPTION
## G-1113.D.6 — legacy iteration kanban behind a tab toggle

Keeps the legacy iteration kanban available behind a toggle "until the Plans surface reaches parity" (plan §5.4).

### What's here
- **`hooks/use-legacy-iterations.ts`** — localStorage flag `mc.legacyIterations`, **default ON**, best-effort persistence (mirrors `use-software-mode`).
- **`app.tsx`** — a header toggle (`◆/◇ legacy`), the **Iterations tab gated** on the flag, and a reset effect (toggling OFF while on `iterations`/`kanban-detail` → `default`, so the main area is never blank).

### Purely additive
Default ON means **nothing changes by default** — the slice just adds the *control* to hide the legacy kanban once the principal is satisfied the Plans surface has parity. No backend changes.

### Known minor edge
With legacy toggled OFF, a task-table iteration-cell click briefly sets `kanban-detail` before the reset effect bounces it to `default` (safe — no blank screen; never hit at the default-ON setting). Noted rather than spreading the flag into `task-table` props for this small slice.

### Verification
- `bunx tsc --noEmit` clean · `bun run lint` 0 errors · carve-out gate PASS · `bun test src/surface/mc` 1232 pass / 0 fail · `bun run build:dashboard` bundles · merge-guard clean (D.5)

Closes #583. Part of #577, umbrella #354.