### PR TITLE
feat(gateway): GW BusInboundSink flip — live publish behind a 2nd opt-in flag (#524)

### DIFF
--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -2180,16 +2180,24 @@ export async function startCortex(
   // and constructs NOTHING — this block is a true no-op and the per-stack
   // adapter boot above is entirely unaffected. When the flag IS set AND
   // `surfaces:` bindings exist, it builds one adapter per binding, constructs
-  // a shadow-stage SurfaceGateway (LoggingInboundSink — no bus publish yet),
-  // starts it, and returns the instance so `gw?.stop()` joins the shutdown
-  // drain below. The flag-on path is shadow/log-only this slice; the
-  // BusInboundSink flip is a later slice. This is purely additive — it does
-  // not touch, reorder, or risk the existing adapter-construction flow.
+  // a SurfaceGateway, starts it, and returns the instance so `gw?.stop()` joins
+  // the shutdown drain below. Sink selection is a SECOND opt-in flag: with
+  // `CORTEX_GATEWAY_PUBLISH` unset the gateway runs SHADOW (LoggingInboundSink —
+  // no bus publish, unchanged from today); only when CORTEX_GATEWAY_PUBLISH=1 is
+  // ALSO set does it run LIVE (BusInboundSink — publishing to the bus). This is
+  // purely additive — it does not touch, reorder, or risk the existing
+  // adapter-construction flow.
   const gw: SurfaceGateway | undefined = await startGatewayIfEnabled({
     env: process.env,
     surfaces: options.surfaces,
     principal: principalId,
     runtime,
+    // Threaded for the live-path BusInboundSink (selected only when the second
+    // opt-in flag CORTEX_GATEWAY_PUBLISH is set). When the gateway is off
+    // (default) startGatewayIfEnabled returns before reading either — purely
+    // additive args, no behaviour change on a dormant stack.
+    source: systemEventSource,
+    policyEngine: adapterPolicyEngine,
   });
 
   // Shutdown — reverse-order; capped at SHUTDOWN_TIMEOUT_MS.

--- a/src/gateway/__tests__/gateway-bootstrap.test.ts
+++ b/src/gateway/__tests__/gateway-bootstrap.test.ts
@@ -21,10 +21,16 @@
 import { describe, expect, test, spyOn } from "bun:test";
 import {
   isGatewayEnabled,
+  isGatewayPublishEnabled,
   maybeCreateSurfaceGateway,
   type GatewayBootstrapOpts,
 } from "../gateway-bootstrap";
-import { SurfaceGateway } from "../surface-gateway";
+import {
+  SurfaceGateway,
+  LoggingInboundSink,
+  type GatewayInboundSink,
+  type GatewayInboundDecision,
+} from "../surface-gateway";
 import type { PlatformAdapter, InboundMessage } from "../../adapters/types";
 import type { Surfaces } from "../../common/types/surfaces";
 
@@ -129,6 +135,42 @@ describe("isGatewayEnabled", () => {
 
   test("returns false when CORTEX_GATEWAY is undefined in the env record", () => {
     expect(isGatewayEnabled({ CORTEX_GATEWAY: undefined })).toBe(false);
+  });
+});
+
+// =============================================================================
+// isGatewayPublishEnabled — the second, independent opt-in gate
+// =============================================================================
+
+describe("isGatewayPublishEnabled", () => {
+  test("returns false when CORTEX_GATEWAY_PUBLISH is unset", () => {
+    expect(isGatewayPublishEnabled({})).toBe(false);
+  });
+
+  test("returns true when CORTEX_GATEWAY_PUBLISH is '1'", () => {
+    expect(isGatewayPublishEnabled({ CORTEX_GATEWAY_PUBLISH: "1" })).toBe(true);
+  });
+
+  test("returns false when CORTEX_GATEWAY_PUBLISH is '0'", () => {
+    expect(isGatewayPublishEnabled({ CORTEX_GATEWAY_PUBLISH: "0" })).toBe(false);
+  });
+
+  test("returns false when CORTEX_GATEWAY_PUBLISH is 'true' (only '1' is truthy)", () => {
+    expect(isGatewayPublishEnabled({ CORTEX_GATEWAY_PUBLISH: "true" })).toBe(false);
+  });
+
+  test("returns false when CORTEX_GATEWAY_PUBLISH is undefined in the env record", () => {
+    expect(isGatewayPublishEnabled({ CORTEX_GATEWAY_PUBLISH: undefined })).toBe(false);
+  });
+
+  test("is independent of CORTEX_GATEWAY (reads only its own key)", () => {
+    // The two flags are orthogonal at the read layer; the AND is composed by
+    // the caller (startGatewayIfEnabled). isGatewayPublishEnabled ignores
+    // CORTEX_GATEWAY entirely.
+    expect(isGatewayPublishEnabled({ CORTEX_GATEWAY: "1" })).toBe(false);
+    expect(
+      isGatewayPublishEnabled({ CORTEX_GATEWAY: "0", CORTEX_GATEWAY_PUBLISH: "1" }),
+    ).toBe(true);
   });
 });
 
@@ -353,6 +395,68 @@ describe("maybeCreateSurfaceGateway — happy path", () => {
       expect(combined).toMatch(/1\s+binding/);
       // 2 adapters
       expect(combined).toMatch(/2\s+adapter/);
+    } finally {
+      stdoutSpy.mockRestore();
+    }
+  });
+});
+
+// =============================================================================
+// maybeCreateSurfaceGateway — sink injection (shadow default, live override)
+// =============================================================================
+
+describe("maybeCreateSurfaceGateway — sink injection", () => {
+  test("defaults to LoggingInboundSink when no sink is injected", () => {
+    const gw = maybeCreateSurfaceGateway({
+      enabled: true,
+      surfaces: DISCORD_SURFACES,
+      adapters: [makeFakeAdapter()],
+    });
+    expect(gw).toBeInstanceOf(SurfaceGateway);
+    expect(gw!.inboundSink).toBeInstanceOf(LoggingInboundSink);
+  });
+
+  test("uses the injected sink when one is provided", () => {
+    // A minimal custom sink (not a LoggingInboundSink) — proves the factory
+    // honours the injection rather than always constructing its own default.
+    const calls: GatewayInboundDecision[] = [];
+    const customSink: GatewayInboundSink = {
+      publish: async (decision: GatewayInboundDecision) => {
+        calls.push(decision);
+      },
+    };
+
+    const gw = maybeCreateSurfaceGateway({
+      enabled: true,
+      surfaces: DISCORD_SURFACES,
+      adapters: [makeFakeAdapter()],
+      sink: customSink,
+    });
+    expect(gw).toBeInstanceOf(SurfaceGateway);
+    // identity check — exactly the injected instance, not a default
+    expect(gw!.inboundSink).toBe(customSink);
+    expect(gw!.inboundSink).not.toBeInstanceOf(LoggingInboundSink);
+  });
+
+  test("logs LIVE + BusInboundSink wording when a non-logging sink is injected", () => {
+    const messages: string[] = [];
+    const stdoutSpy = spyOn(process.stdout, "write").mockImplementation((msg) => {
+      messages.push(String(msg));
+      return true;
+    });
+    try {
+      const customSink: GatewayInboundSink = {
+        publish: async () => {},
+      };
+      maybeCreateSurfaceGateway({
+        enabled: true,
+        surfaces: DISCORD_SURFACES,
+        adapters: [makeFakeAdapter()],
+        sink: customSink,
+      });
+      const combined = messages.join("");
+      expect(combined).toContain("LIVE");
+      expect(combined).toContain("BusInboundSink");
     } finally {
       stdoutSpy.mockRestore();
     }

--- a/src/gateway/__tests__/start-gateway.test.ts
+++ b/src/gateway/__tests__/start-gateway.test.ts
@@ -14,11 +14,14 @@
 
 import { describe, expect, test } from "bun:test";
 import { startGatewayIfEnabled } from "../start-gateway";
-import { SurfaceGateway } from "../surface-gateway";
+import { SurfaceGateway, LoggingInboundSink } from "../surface-gateway";
+import { BusInboundSink } from "../bus-inbound-sink";
 import type { GatewayAdapterFactory } from "../gateway-adapters";
 import type { PlatformAdapter } from "../../adapters/types";
 import type { Surfaces } from "../../common/types/surfaces";
 import type { MyelinRuntime } from "../../bus/myelin/runtime";
+import type { SystemEventSource } from "../../bus/system-events";
+import type { PolicyEngine } from "../../common/policy/engine";
 
 // =============================================================================
 // Fakes
@@ -29,6 +32,20 @@ const RUNTIME_STUB = {
   onEnvelope: () => () => {},
   stop: async () => {},
 } as unknown as MyelinRuntime;
+
+// Live-sink deps. They only need to be present (non-undefined) for the
+// BusInboundSink to be constructed; these tests assert the SELECTED SINK TYPE,
+// not a real publish (BusInboundSink publish behaviour is covered in
+// bus-inbound-sink.test.ts).
+const SOURCE_STUB = {
+  scope: "local",
+  principal: "andreas",
+  instance: "gateway-1",
+} as unknown as SystemEventSource;
+
+const POLICY_ENGINE_STUB = {
+  resolve: () => undefined,
+} as unknown as PolicyEngine;
 
 function makeFakeAdapter(
   platform: "discord" | "slack" | "mattermost",
@@ -115,6 +132,8 @@ describe("startGatewayIfEnabled — flag off", () => {
       surfaces: DISCORD_SURFACES,
       principal: "andreas",
       runtime: RUNTIME_STUB,
+      source: SOURCE_STUB,
+      policyEngine: POLICY_ENGINE_STUB,
       factory,
     });
     expect(gw).toBeUndefined();
@@ -131,6 +150,8 @@ describe("startGatewayIfEnabled — flag off", () => {
       surfaces: DISCORD_SURFACES,
       principal: "andreas",
       runtime: RUNTIME_STUB,
+      source: SOURCE_STUB,
+      policyEngine: POLICY_ENGINE_STUB,
       factory,
     });
     expect(gw).toBeUndefined();
@@ -146,6 +167,8 @@ describe("startGatewayIfEnabled — flag off", () => {
       surfaces: DISCORD_SURFACES,
       principal: "andreas",
       runtime: RUNTIME_STUB,
+      source: SOURCE_STUB,
+      policyEngine: POLICY_ENGINE_STUB,
       factory,
     });
     expect(gw).toBeUndefined();
@@ -162,6 +185,8 @@ describe("startGatewayIfEnabled — flag on", () => {
       surfaces: DISCORD_SURFACES,
       principal: "andreas",
       runtime: RUNTIME_STUB,
+      source: SOURCE_STUB,
+      policyEngine: POLICY_ENGINE_STUB,
       factory,
     });
     expect(gw).toBeInstanceOf(SurfaceGateway);
@@ -179,6 +204,8 @@ describe("startGatewayIfEnabled — flag on", () => {
       surfaces: undefined,
       principal: "andreas",
       runtime: RUNTIME_STUB,
+      source: SOURCE_STUB,
+      policyEngine: POLICY_ENGINE_STUB,
       factory,
     });
     expect(gw).toBeUndefined();
@@ -195,6 +222,8 @@ describe("startGatewayIfEnabled — flag on", () => {
       surfaces: {},
       principal: "andreas",
       runtime: RUNTIME_STUB,
+      source: SOURCE_STUB,
+      policyEngine: POLICY_ENGINE_STUB,
       factory,
     });
     expect(gw).toBeUndefined();
@@ -209,10 +238,119 @@ describe("startGatewayIfEnabled — flag on", () => {
       surfaces: DISCORD_SURFACES,
       principal: "andreas",
       runtime: RUNTIME_STUB,
+      source: SOURCE_STUB,
+      policyEngine: POLICY_ENGINE_STUB,
       factory,
     });
     expect(gw).toBeInstanceOf(SurfaceGateway);
     // stop() resolves without throwing
     await gw?.stop();
+  });
+});
+
+// =============================================================================
+// Sink selection — the CORTEX_GATEWAY_PUBLISH double-opt-in gate
+// =============================================================================
+
+describe("startGatewayIfEnabled — sink selection (CORTEX_GATEWAY_PUBLISH)", () => {
+  test("publish flag OFF (gateway on) → gateway uses LoggingInboundSink (SHADOW)", async () => {
+    const started: string[] = [];
+    const { factory } = makeCountingFactory(started);
+    const gw = await startGatewayIfEnabled({
+      env: { CORTEX_GATEWAY: "1" }, // publish flag absent
+      surfaces: DISCORD_SURFACES,
+      principal: "andreas",
+      runtime: RUNTIME_STUB,
+      source: SOURCE_STUB,
+      policyEngine: POLICY_ENGINE_STUB,
+      factory,
+    });
+    expect(gw).toBeInstanceOf(SurfaceGateway);
+    // SHADOW: no bus publish. The gateway's sink is a LoggingInboundSink,
+    // exactly as it is today.
+    expect(gw?.inboundSink).toBeInstanceOf(LoggingInboundSink);
+    expect(gw?.inboundSink).not.toBeInstanceOf(BusInboundSink);
+  });
+
+  test("publish flag '0' (gateway on) → still SHADOW (only '1' is truthy)", async () => {
+    const started: string[] = [];
+    const { factory } = makeCountingFactory(started);
+    const gw = await startGatewayIfEnabled({
+      env: { CORTEX_GATEWAY: "1", CORTEX_GATEWAY_PUBLISH: "0" },
+      surfaces: DISCORD_SURFACES,
+      principal: "andreas",
+      runtime: RUNTIME_STUB,
+      source: SOURCE_STUB,
+      policyEngine: POLICY_ENGINE_STUB,
+      factory,
+    });
+    expect(gw?.inboundSink).toBeInstanceOf(LoggingInboundSink);
+  });
+
+  test("publish flag 'true' (gateway on) → still SHADOW (only '1' is truthy)", async () => {
+    const started: string[] = [];
+    const { factory } = makeCountingFactory(started);
+    const gw = await startGatewayIfEnabled({
+      env: { CORTEX_GATEWAY: "1", CORTEX_GATEWAY_PUBLISH: "true" },
+      surfaces: DISCORD_SURFACES,
+      principal: "andreas",
+      runtime: RUNTIME_STUB,
+      source: SOURCE_STUB,
+      policyEngine: POLICY_ENGINE_STUB,
+      factory,
+    });
+    expect(gw?.inboundSink).toBeInstanceOf(LoggingInboundSink);
+  });
+
+  test("BOTH flags '1' → gateway uses BusInboundSink (LIVE — publishing)", async () => {
+    const started: string[] = [];
+    const { factory } = makeCountingFactory(started);
+    const gw = await startGatewayIfEnabled({
+      env: { CORTEX_GATEWAY: "1", CORTEX_GATEWAY_PUBLISH: "1" },
+      surfaces: DISCORD_SURFACES,
+      principal: "andreas",
+      runtime: RUNTIME_STUB,
+      source: SOURCE_STUB,
+      policyEngine: POLICY_ENGINE_STUB,
+      factory,
+    });
+    expect(gw).toBeInstanceOf(SurfaceGateway);
+    // LIVE: the double-opt-in flipped the gateway to the bus-publishing sink.
+    expect(gw?.inboundSink).toBeInstanceOf(BusInboundSink);
+  });
+
+  test("publish flag '1' but gateway flag OFF → undefined (gateway gate still wins)", async () => {
+    const started: string[] = [];
+    const { factory, constructed } = makeCountingFactory(started);
+    const gw = await startGatewayIfEnabled({
+      env: { CORTEX_GATEWAY_PUBLISH: "1" }, // gateway flag absent
+      surfaces: DISCORD_SURFACES,
+      principal: "andreas",
+      runtime: RUNTIME_STUB,
+      source: SOURCE_STUB,
+      policyEngine: POLICY_ENGINE_STUB,
+      factory,
+    });
+    // The publish flag alone does NOT enable the gateway — CORTEX_GATEWAY is the
+    // primary gate. Nothing is constructed.
+    expect(gw).toBeUndefined();
+    expect(constructed).toEqual([]);
+    expect(started).toEqual([]);
+  });
+
+  test("both flags '1' but no bindings → undefined, never reaches BusInboundSink", async () => {
+    const started: string[] = [];
+    const { factory, constructed } = makeCountingFactory(started);
+    const gw = await startGatewayIfEnabled({
+      env: { CORTEX_GATEWAY: "1", CORTEX_GATEWAY_PUBLISH: "1" },
+      surfaces: {}, // no bindings → Path-2 degrade, no publish
+      principal: "andreas",
+      runtime: RUNTIME_STUB,
+      source: SOURCE_STUB,
+      policyEngine: POLICY_ENGINE_STUB,
+      factory,
+    });
+    expect(gw).toBeUndefined();
+    expect(constructed).toEqual([]);
   });
 });

--- a/src/gateway/gateway-bootstrap.ts
+++ b/src/gateway/gateway-bootstrap.ts
@@ -5,13 +5,16 @@
  * at least one surface binding exists, builds the binding index, and returns a
  * fully constructed (but not yet started) {@link SurfaceGateway}.
  *
- * ## Shadow stage (this slice)
+ * ## Sink selection (shadow default, live opt-in)
  *
- * `maybeCreateSurfaceGateway` ALWAYS wires {@link LoggingInboundSink} as the
- * inbound sink — it logs the routing decision that WOULD be published to the
- * bus, but does NOT publish. This lets the gateway run alongside per-stack
- * adapters on a staging identity to prove demux correctness before any stack
- * loses its own adapter. The live bus-publishing sink flip is GW.a.3b.2.
+ * `maybeCreateSurfaceGateway` defaults to {@link LoggingInboundSink} (SHADOW)
+ * when no `sink` is injected — it logs the routing decision that WOULD be
+ * published to the bus, but does NOT publish. This lets the gateway run
+ * alongside per-stack adapters on a staging identity to prove demux
+ * correctness before any stack loses its own adapter. A live `BusInboundSink`
+ * is injected by `startGatewayIfEnabled` ONLY when the second opt-in flag
+ * `CORTEX_GATEWAY_PUBLISH` is set — making live publish a deliberate
+ * double-opt-in (`CORTEX_GATEWAY` AND `CORTEX_GATEWAY_PUBLISH`).
  *
  * ## GW.a.3b.2 prerequisites (NOT done in this slice)
  *
@@ -59,6 +62,7 @@ import { buildBindingIndex } from "./binding-resolver";
 import {
   SurfaceGateway,
   LoggingInboundSink,
+  type GatewayInboundSink,
 } from "./surface-gateway";
 
 // =============================================================================
@@ -87,6 +91,17 @@ export interface GatewayBootstrapOpts {
   /** Platform adapters the gateway will own — injected by GW.a.3b.2 caller. */
   adapters: PlatformAdapter[];
   /**
+   * The inbound sink the gateway publishes routing decisions to.
+   *
+   * Defaults to {@link LoggingInboundSink} (SHADOW — logs the decision that
+   * WOULD be published, but does NOT touch the bus) when omitted, so every
+   * existing caller and the default shadow stage are unchanged. The live-path
+   * `BusInboundSink` is injected here by `startGatewayIfEnabled` ONLY when the
+   * second opt-in flag `CORTEX_GATEWAY_PUBLISH` is set — making live publish a
+   * deliberate double-opt-in.
+   */
+  sink?: GatewayInboundSink;
+  /**
    * Optional unroutable-message hook forwarded to {@link SurfaceGateway}.
    * When absent the gateway's default `console.warn` fires.
    */
@@ -111,6 +126,33 @@ export function isGatewayEnabled(
   env: Record<string, string | undefined> = process.env,
 ): boolean {
   return env.CORTEX_GATEWAY === "1";
+}
+
+// =============================================================================
+// isGatewayPublishEnabled
+// =============================================================================
+
+/**
+ * Read the `CORTEX_GATEWAY_PUBLISH` flag from `env` (defaults to `process.env`).
+ *
+ * Returns `true` iff `env.CORTEX_GATEWAY_PUBLISH === "1"`. All other values —
+ * including `"true"`, `"yes"`, `"on"`, and `undefined` — return `false`,
+ * mirroring {@link isGatewayEnabled}'s strict `"1"`-only contract.
+ *
+ * This is the SECOND, independent opt-in gate. The gateway only publishes to
+ * the bus (live `BusInboundSink`) when BOTH `CORTEX_GATEWAY` AND
+ * `CORTEX_GATEWAY_PUBLISH` are `"1"`. With the gateway flag on but THIS flag
+ * off, the gateway runs in SHADOW (`LoggingInboundSink` — no publish), exactly
+ * as it does today. Live publish is a deliberate double-opt-in because it runs
+ * on live stacks.
+ *
+ * Kept separate from {@link isGatewayEnabled} so each flag is independently
+ * testable without constructing anything.
+ */
+export function isGatewayPublishEnabled(
+  env: Record<string, string | undefined> = process.env,
+): boolean {
+  return env.CORTEX_GATEWAY_PUBLISH === "1";
 }
 
 // =============================================================================
@@ -184,19 +226,22 @@ export function maybeCreateSurfaceGateway(
   // (loud startup failure on bad config). The throw propagates to the caller.
   const index = buildBindingIndex(surfaces);
 
-  // Shadow stage: ALWAYS use LoggingInboundSink here.
-  // The real BusInboundSink flip (publishing to the bus) is GW.a.3b.2 work —
-  // that slice wires the live runtime and swaps LoggingInboundSink for
-  // BusInboundSink in the cortex.ts boot path.
-  const sink = new LoggingInboundSink();
+  // Sink selection: defaults to LoggingInboundSink (SHADOW — no bus publish)
+  // when the caller omits `sink`, so every existing caller and the default
+  // shadow stage are byte-unchanged. A live BusInboundSink is injected by
+  // `startGatewayIfEnabled` only when the second opt-in flag
+  // `CORTEX_GATEWAY_PUBLISH` is set. This factory does not read either flag —
+  // it trusts the caller's choice of sink, keeping it pure and testable.
+  const sink = opts.sink ?? new LoggingInboundSink();
+  const live = !(sink instanceof LoggingInboundSink);
 
   const gw = new SurfaceGateway(adapters, index, sink, { onUnroutable });
 
   process.stdout.write(
-    `[surface-gateway] surface gateway constructed (SHADOW)` +
+    `[surface-gateway] surface gateway constructed (${live ? "LIVE" : "SHADOW"})` +
       ` — ${bindingCount} ${bindingCount === 1 ? "binding" : "bindings"},` +
       ` ${adapters.length} ${adapters.length === 1 ? "adapter" : "adapters"};` +
-      ` LoggingInboundSink (no bus publish)\n`,
+      ` ${live ? "BusInboundSink (publishing to the bus)" : "LoggingInboundSink (no bus publish)"}\n`,
   );
 
   return gw;

--- a/src/gateway/start-gateway.ts
+++ b/src/gateway/start-gateway.ts
@@ -24,11 +24,16 @@
  *   3. flag on + bindings → build adapters, construct the gateway, `gw.start()`,
  *      return the started instance.
  *
- * ## Shadow stage (this slice)
+ * ## Sink selection — shadow default, live double-opt-in
  *
- * `maybeCreateSurfaceGateway` always wires `LoggingInboundSink` — even the
- * flag-on path is shadow/log-only and publishes NOTHING to the bus. The
- * `BusInboundSink` flip is a later slice.
+ * `CORTEX_GATEWAY=1` alone runs the gateway in SHADOW: `maybeCreateSurfaceGateway`
+ * defaults to `LoggingInboundSink` (logs the routing decision, publishes
+ * NOTHING) — unchanged from today. Only when `CORTEX_GATEWAY_PUBLISH=1` is ALSO
+ * set does this function construct a `BusInboundSink` and inject it, flipping
+ * the gateway LIVE (publishing canonical dispatch envelopes to the bus). Live
+ * publish is a deliberate double-opt-in because the gateway runs on live stacks.
+ * The empty-bindings Path-2 always stays on `LoggingInboundSink` (there is
+ * nothing to publish without bindings anyway).
  *
  * ## Why bindings are checked before building adapters
  *
@@ -41,6 +46,7 @@
 
 import {
   isGatewayEnabled,
+  isGatewayPublishEnabled,
   maybeCreateSurfaceGateway,
 } from "./gateway-bootstrap";
 import {
@@ -48,9 +54,12 @@ import {
   defaultGatewayAdapterFactory,
   type GatewayAdapterFactory,
 } from "./gateway-adapters";
+import { BusInboundSink } from "./bus-inbound-sink";
 import type { SurfaceGateway } from "./surface-gateway";
 import type { Surfaces } from "../common/types/surfaces";
 import type { MyelinRuntime } from "../bus/myelin/runtime";
+import type { SystemEventSource } from "../bus/system-events";
+import type { PolicyEngine } from "../common/policy/engine";
 import type { InboundMessage } from "../adapters/types";
 
 // =============================================================================
@@ -67,6 +76,21 @@ export interface StartGatewayOpts {
   principal: string;
   /** Myelin runtime (may be dormant — adapters track state locally either way). */
   runtime: MyelinRuntime | undefined;
+  /**
+   * The gateway's dispatch-source identity, threaded into a live
+   * {@link BusInboundSink}. Supplies principal / agent / instance for the
+   * envelope `source`. `undefined` before the bus connects → the publisher
+   * refuses with `reason: "missing-runtime"`. Only consumed when
+   * `CORTEX_GATEWAY_PUBLISH` selects the live sink.
+   */
+  source: SystemEventSource | undefined;
+  /**
+   * Policy engine that resolves `(platform, authorId)` → principal DID for the
+   * envelope `originator.identity`, threaded into a live {@link BusInboundSink}.
+   * `undefined` → the publisher refuses with `reason: "invalid-originator"`.
+   * Only consumed when `CORTEX_GATEWAY_PUBLISH` selects the live sink.
+   */
+  policyEngine: PolicyEngine | undefined;
   /**
    * Adapter-construction seam. Production omits this and gets
    * {@link defaultGatewayAdapterFactory}; tests inject a recording fake that
@@ -131,10 +155,45 @@ export async function startGatewayIfEnabled(
     factory: opts.factory ?? defaultGatewayAdapterFactory,
   });
 
+  // Sink selection — the SECOND opt-in gate.
+  //
+  // SHADOW (default): `CORTEX_GATEWAY_PUBLISH` unset → omit `sink`, so
+  // `maybeCreateSurfaceGateway` defaults to `LoggingInboundSink` (logs only, no
+  // bus publish). This is the unchanged-from-today behaviour for a gateway-on,
+  // publish-off stack.
+  //
+  // LIVE (double-opt-in): `CORTEX_GATEWAY` AND `CORTEX_GATEWAY_PUBLISH` both
+  // "1" → construct a `BusInboundSink` and inject it, so each routable inbound
+  // message is published to the bus as a canonical dispatch envelope.
+  //
+  // D1 (CONTEXT.md §Dispatch-source, 2026-06-02): the gateway is a separate
+  // process with NO stack NKey, so `BusInboundSink` publishes via this runtime
+  // UNSIGNED + originator-stamped on the intra-principal hop (Shape A v1). The
+  // bound stack's consumer tolerates unsigned (`rejectEmpty:false`). The
+  // explicit re-sign-on-ingest (Shape B) is deferred to cortex#552 — signing is
+  // a property of the injected runtime, not of this sink.
+  const publish = isGatewayPublishEnabled(opts.env);
+  const sink = publish
+    ? new BusInboundSink({
+        runtime: opts.runtime,
+        source: opts.source,
+        policyEngine: opts.policyEngine,
+      })
+    : undefined;
+
+  process.stdout.write(
+    publish
+      ? "[surface-gateway] CORTEX_GATEWAY_PUBLISH set — gateway LIVE" +
+          " (BusInboundSink — publishing to the bus)\n"
+      : "[surface-gateway] CORTEX_GATEWAY_PUBLISH unset — gateway SHADOW" +
+          " (LoggingInboundSink — no bus publish)\n",
+  );
+
   const gw = maybeCreateSurfaceGateway({
     enabled: true,
     surfaces,
     adapters,
+    ...(sink !== undefined && { sink }),
     ...(opts.onUnroutable !== undefined && { onUnroutable: opts.onUnroutable }),
   });
 

--- a/src/gateway/surface-gateway.ts
+++ b/src/gateway/surface-gateway.ts
@@ -151,6 +151,20 @@ export class SurfaceGateway {
   }
 
   /**
+   * The inbound sink this gateway publishes routing decisions to.
+   *
+   * Read-only observability accessor: lets callers (and tests) inspect which
+   * sink mode the gateway was constructed with — {@link LoggingInboundSink}
+   * (shadow, no bus publish) vs a live `BusInboundSink` (publishing). The
+   * shadow-vs-live selection is made by `startGatewayIfEnabled` behind the
+   * `CORTEX_GATEWAY_PUBLISH` flag; exposing the sink here is how the boot path
+   * and tests confirm which mode is in effect without reaching into privates.
+   */
+  get inboundSink(): GatewayInboundSink {
+    return this.sink;
+  }
+
+  /**
    * Start all adapters, rebinding each `onMessage` callback to route through
    * this gateway.
    *


### PR DESCRIPTION
The gateway can now **publish** inbound dispatches to the bus (live) — gated so **shadow stays the default**. Live publish is a deliberate **double-opt-in**:

| Flags | Mode |
|-------|------|
| `CORTEX_GATEWAY` unset | off — **byte-identical boot** |
| `CORTEX_GATEWAY=1` | ON, **shadow** (LoggingInboundSink, no publish — unchanged from today) |
| `CORTEX_GATEWAY=1` + `CORTEX_GATEWAY_PUBLISH=1` | **live** (BusInboundSink — publishes) |

## What
- **`gateway-bootstrap`**: `maybeCreateSurfaceGateway` gains optional `sink?` (default `LoggingInboundSink` → shadow + existing callers unchanged); `+ isGatewayPublishEnabled`.
- **`start-gateway`**: `StartGatewayOpts` + `source`/`policyEngine`; Path-3 constructs `BusInboundSink({runtime, source, policyEngine})` when publish-enabled, else shadow.
- **`cortex.ts`**: **additive-only** — threads `source=systemEventSource` + `policyEngine=adapterPolicyEngine` into the already-flag-gated call (no reorder, no new control flow).
- **`surface-gateway`**: read-only `get inboundSink()` accessor (test/observability seam).

## D1 (documented)
The gateway has no stack NKey → publishes **unsigned** (Shape A); the bound stack tolerates unsigned (`rejectEmpty:false`); explicit re-sign (Shape B) deferred to #552.

## Review focus
1. **Flag-off + publish-off byte-identity** — cortex.ts is additive args only; both flags default-off → shadow/no-op (boot smoke 27/27 green, flags unset; full src/ 3968 pass).
2. The new `get inboundSink()` public accessor (read-only) + the `instanceof LoggingInboundSink` log-wording check — acceptable?
3. Sink selection: publish-off → Logging; both-on → Bus; gateway-off → undefined; no-bindings → never Bus.

## Gates
`tsc` 0 · `eslint --quiet src/` 0 · `bun test src/gateway/` **114** · boot smoke **27/27** · `bun test src/` **3968 pass / 0 fail** · vocab gate PASS.

Refs #524 · part of #110.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
