### PR TITLE
feat(mc): G-1113.D.7a — iterations read-boundary onto provider-neutral SourceRef

### DIFF
--- a/src/surface/mc/__tests__/iterations.test.ts
+++ b/src/surface/mc/__tests__/iterations.test.ts
@@ -512,6 +512,23 @@ describe("listInboxItems", () => {
     expect(items[0]?.updated_at).toMatch(/T.*Z$/);
   });
 
+  it("D.7a — exposes a provider-neutral source narrowed from source_system", () => {
+    insertTask(h.db, "t-1", {
+      source_system: "github",
+      source_url: "https://github.com/foo/bar/issues/1",
+      source_external_id: "foo/bar#1",
+    });
+    const item = listInboxItems(h.db)[0];
+    expect(item?.source).toEqual({
+      provider: "github",
+      externalId: "foo/bar#1",
+      url: "https://github.com/foo/bar/issues/1",
+      providerNativeType: null,
+    });
+    // raw column still present (storage detail) until D.7c relaxes the CHECK.
+    expect(item?.source_system).toBe("github");
+  });
+
   it("?source=github filters to a single source system", () => {
     // Insert via the schema-bypass path so we can exercise the source
     // filter even with non-CHECK-allowed values. (`tasks.source_system`

--- a/src/surface/mc/dashboard-v2/__tests__/iteration-board-layout.test.ts
+++ b/src/surface/mc/dashboard-v2/__tests__/iteration-board-layout.test.ts
@@ -19,6 +19,7 @@ import {
   ITERATION_BOARD_COLUMNS,
   type IterationBoardColumn,
 } from "../lib/iteration-board-layout";
+import { isProvider } from "../../types";
 import type {
   InboxItem,
   IterationListItem,
@@ -42,14 +43,24 @@ function iter(over: Partial<IterationListItem> = {}): IterationListItem {
 }
 
 function inbox(over: Partial<InboxItem> = {}): InboxItem {
+  const source_system = over.source_system ?? "github";
+  const source_url = over.source_url ?? "https://github.com/foo/bar/issues/1";
+  const source_external_id = over.source_external_id ?? "github:foo/bar#1";
   return {
     id: over.id ?? "t-1",
     title: over.title ?? "Inbox task",
     priority: over.priority ?? 2,
     status: over.status ?? "open",
-    source_system: over.source_system ?? "github",
-    source_url: over.source_url ?? "https://github.com/foo/bar/issues/1",
-    source_external_id: over.source_external_id ?? "github:foo/bar#1",
+    // D.7a — provider-neutral origin, kept consistent with the raw columns.
+    source: over.source ?? {
+      provider: isProvider(source_system) ? source_system : "custom",
+      externalId: source_external_id,
+      url: source_url,
+      providerNativeType: null,
+    },
+    source_system,
+    source_url,
+    source_external_id,
     created_at: over.created_at ?? "2026-04-26T00:00:00.000Z",
     updated_at: over.updated_at ?? "2026-04-26T00:00:00.000Z",
   };

--- a/src/surface/mc/dashboard-v2/components/iteration-board.tsx
+++ b/src/surface/mc/dashboard-v2/components/iteration-board.tsx
@@ -392,7 +392,7 @@ function IterationCard({ entry, dragging, onOpen, onDragStart, onDragEnd }: Iter
         {/*
           F-17 — inbox column visual hint. Tasks that arrived via the
           GitHub auto-import (webhook or principal-driven path) carry
-          `source_system === 'github'` on the InboxItem. The denorm is
+          `source.provider === 'github'` on the InboxItem. The denorm is
           identical to the iteration-side badge above; rendering here
           gives the principal a one-glance signal that a row landed via
           the upstream pipeline rather than being typed directly.
@@ -401,8 +401,11 @@ function IterationCard({ entry, dragging, onOpen, onDragStart, onDragEnd }: Iter
           URL on the iteration card") the badge is informational only —
           it never drives state or behaviour. Click-through stays via
           the `source-link` rendered above.
+
+          G-1113.D.7a — branch on the provider-neutral `source.provider`,
+          not the raw `source_system` column.
         */}
-        {isInbox && (entry.item as InboxItem).source_system === "github" && (
+        {isInbox && (entry.item as InboxItem).source.provider === "github" && (
           <span
             className="source-badge gh"
             title="Auto-imported from GitHub"

--- a/src/surface/mc/db/iterations.ts
+++ b/src/surface/mc/db/iterations.ts
@@ -19,6 +19,8 @@
  */
 
 import type { Database } from "bun:sqlite";
+import type { SourceRef } from "../types";
+import { isProvider } from "../types";
 import { epochSecondsToIso } from "./tasks";
 import {
   ITERATION_STATES,
@@ -163,6 +165,14 @@ export interface InboxItem {
   title: string;
   priority: number;
   status: string;
+  /**
+   * Provider-neutral origin (G-1113.D.7a) — the shape new code should read,
+   * mirroring the task DTO's `source` (B.2). `source_system` / `source_url` /
+   * `source_external_id` remain as the raw storage columns (relaxing their
+   * CHECK to provider-neutral is D.7c); consumers should branch on
+   * `source.provider`, not the raw `source_system`.
+   */
+  source: SourceRef;
   source_system: string;
   source_url: string | null;
   source_external_id: string | null;
@@ -321,6 +331,14 @@ export function listInboxItems(
     title: r.title,
     priority: r.priority,
     status: r.status,
+    // Provider-neutral origin (D.7a): narrow source_system → Provider at the
+    // read boundary, exactly as the task DTO does (B.2). Unknown → "custom".
+    source: {
+      provider: isProvider(r.source_system) ? r.source_system : "custom",
+      externalId: r.source_external_id,
+      url: r.source_url,
+      providerNativeType: null,
+    } satisfies SourceRef,
     source_system: r.source_system,
     source_url: r.source_url,
     source_external_id: r.source_external_id,

--- a/src/surface/mc/db/iterations.ts
+++ b/src/surface/mc/db/iterations.ts
@@ -20,8 +20,7 @@
 
 import type { Database } from "bun:sqlite";
 import type { SourceRef } from "../types";
-import { isProvider } from "../types";
-import { epochSecondsToIso } from "./tasks";
+import { epochSecondsToIso, taskRowToSourceRef } from "./tasks";
 import {
   ITERATION_STATES,
   TRANSITIONS,
@@ -331,14 +330,9 @@ export function listInboxItems(
     title: r.title,
     priority: r.priority,
     status: r.status,
-    // Provider-neutral origin (D.7a): narrow source_system → Provider at the
-    // read boundary, exactly as the task DTO does (B.2). Unknown → "custom".
-    source: {
-      provider: isProvider(r.source_system) ? r.source_system : "custom",
-      externalId: r.source_external_id,
-      url: r.source_url,
-      providerNativeType: null,
-    } satisfies SourceRef,
+    // Provider-neutral origin (D.7a): reuse the task DTO's single normalization
+    // boundary (B.2) so the inbox + task mappers can't drift. Unknown → "custom".
+    source: taskRowToSourceRef(r),
     source_system: r.source_system,
     source_url: r.source_url,
     source_external_id: r.source_external_id,


### PR DESCRIPTION
## G-1113.D.7a — iterations read-boundary onto provider-neutral SourceRef

First **D.7** increment (#590 decomposed into D.7a #598 / D.7b #599 / D.7c #600). No schema change — mirrors what B.2 did for the task DTO.

### What's here
- **`db/iterations.ts`** — `InboxItem` gains `source: SourceRef`, narrowed from `source_system` via `isProvider` at the read boundary (unknown → `"custom"`). Raw `source_system`/`source_url`/`source_external_id` columns are retained as a storage detail (relaxing their CHECK is **D.7c**).
- **`iteration-board.tsx`** — the inbox GitHub badge now branches on `source.provider === "github"`, not the raw `source_system === "github"`.
- **tests** — pin the `listInboxItems` source-narrowing; board-layout fixture builds a consistent `source`.

### Why this shape
This is the iterations-side equivalent of B.2's task work: get the **read path** off raw `source_system` and onto the normalized `SourceRef` first, with **no schema/migration risk**. D.7b routes `iteration-import.ts` (the auth-sensitive webhook path) behind the `adapters/github` boundary; D.7c does the storage CHECK relaxation (table-rebuild migration) last, once nothing reads the closed union.

### Verification
- `bunx tsc --noEmit` clean · `bun run lint` 0 errors · carve-out gate PASS · `bun test src/surface/mc` 1238 pass / 0 fail · `bun run build:dashboard` bundles · merge-guard clean (D.6)

Closes #598. Part of #590 / #577 / #354.