### PR TITLE
feat(mc): G-1113.D.7c — relax tasks.source_system CHECK to provider-neutral storage

### DIFF
--- a/src/surface/mc/__tests__/d7c-source-system-migration.test.ts
+++ b/src/surface/mc/__tests__/d7c-source-system-migration.test.ts
@@ -141,6 +141,34 @@ describe("D.7c — tasks.source_system CHECK rebuild migration", () => {
     db2.close();
   });
 
+  it("rolls back (and leaves the original table intact) if the rebuild would break FK integrity", () => {
+    const path = freshPath();
+    const old = buildOldDb(path);
+    old.run(
+      `INSERT INTO tasks (id, title, principal_id, source_system, status) VALUES ('t-1', 'A', 'andreas', 'github', 'open')`
+    );
+    old.run(`INSERT INTO agents (id, name, type) VALUES ('a-1', 'Echo', 'head')`);
+    // Pre-seed an ORPHAN assignment (task_id points at no task) with FK enforcement
+    // off — so the post-rebuild foreign_key_check finds a violation and the rebuild
+    // must roll back rather than commit.
+    old.run("PRAGMA foreign_keys = OFF");
+    old.run(
+      `INSERT INTO agent_task_assignment (id, agent_id, task_id, state) VALUES ('x-orphan', 'a-1', 'ghost-task', 'queued')`
+    );
+    old.close();
+
+    // initDatabase must THROW (the rebuild detected the FK violation pre-COMMIT).
+    expect(() => initDatabase(path)).toThrow(/foreign-key violation/i);
+
+    // Rollback proven: the ORIGINAL CHECK'd tasks table is intact, data preserved.
+    const raw = new Database(path);
+    const tasksSql = (raw.query(`SELECT sql FROM sqlite_master WHERE name='tasks'`).get() as { sql: string }).sql;
+    expect(tasksSql).toMatch(/CHECK\s*\(\s*source_system\s+IN/i); // still the old shape
+    expect((raw.query(`SELECT COUNT(*) c FROM tasks`).get() as { c: number }).c).toBe(1);
+    expect((raw.query(`SELECT title FROM tasks WHERE id='t-1'`).get() as { title: string }).title).toBe("A");
+    raw.close();
+  });
+
   it("a fresh DB is born neutral — no CHECK, no rebuild needed", () => {
     const path = freshPath();
     const db = initDatabase(path);

--- a/src/surface/mc/__tests__/d7c-source-system-migration.test.ts
+++ b/src/surface/mc/__tests__/d7c-source-system-migration.test.ts
@@ -1,0 +1,156 @@
+/**
+ * G-1113.D.7c — existing-DB rebuild migration for tasks.source_system.
+ *
+ * Proves the table-rebuild (drop the github|internal CHECK) is DATA-SAFE on an
+ * existing DB: it preserves every column (incl. the migrated iteration_id), all
+ * rows, and the agent_task_assignment → tasks FK — the PR #120 data-loss class
+ * of failure. Builds a faithful pre-D.7c DB (full schema, but the OLD tasks
+ * shape with the CHECK), then reopens via initDatabase to trigger the rebuild.
+ */
+import { describe, it, expect, afterEach } from "bun:test";
+import { Database } from "bun:sqlite";
+import { join } from "path";
+import { tmpdir } from "os";
+import { rmSync, existsSync } from "fs";
+import { SCHEMA_SQL, COLUMN_ADD_MIGRATIONS } from "../db/schema";
+import { initDatabase } from "../db/init";
+
+// The pre-D.7c tasks shape — base columns WITH the source_system CHECK.
+const OLD_TASKS = `CREATE TABLE IF NOT EXISTS tasks (
+  id TEXT PRIMARY KEY,
+  title TEXT NOT NULL,
+  description TEXT,
+  priority INTEGER NOT NULL DEFAULT 2,
+  principal_id TEXT NOT NULL,
+  source_system TEXT NOT NULL CHECK(source_system IN ('github','internal')),
+  source_url TEXT,
+  source_external_id TEXT,
+  related_refs_json TEXT,
+  status TEXT NOT NULL DEFAULT 'open'
+    CHECK(status IN ('open','in_progress','done','cancelled')),
+  created_at INTEGER NOT NULL DEFAULT (unixepoch()),
+  updated_at INTEGER NOT NULL DEFAULT (unixepoch())
+)`;
+
+/** Build a faithful pre-D.7c DB: full schema, but the OLD (CHECK'd) tasks table. */
+function buildOldDb(path: string): Database {
+  const db = new Database(path, { create: true });
+  db.run("PRAGMA foreign_keys = ON");
+  for (const sql of SCHEMA_SQL) {
+    db.run(sql.includes("CREATE TABLE IF NOT EXISTS tasks (") ? OLD_TASKS : sql);
+  }
+  // Apply the iteration_id column-add exactly as the old code would have.
+  for (const m of COLUMN_ADD_MIGRATIONS) {
+    const present = db.query(`SELECT 1 FROM pragma_table_info(?) WHERE name = ?`).get(m.table, m.column);
+    if (!present) db.run(m.ddl);
+    if (m.post) for (const s of m.post) db.run(s);
+  }
+  return db;
+}
+
+describe("D.7c — tasks.source_system CHECK rebuild migration", () => {
+  const paths: string[] = [];
+  afterEach(() => {
+    for (const p of paths) {
+      for (const suffix of ["", "-wal", "-shm"]) if (existsSync(p + suffix)) rmSync(p + suffix);
+    }
+    paths.length = 0;
+  });
+  function freshPath() {
+    const p = join(tmpdir(), `d7c-${Date.now()}-${Math.random().toString(36).slice(2)}.db`);
+    paths.push(p);
+    return p;
+  }
+
+  it("preserves rows, iteration_id, and the assignment FK while dropping the CHECK", () => {
+    const path = freshPath();
+
+    // --- seed a pre-D.7c DB: an iteration, a github task filed under it, an agent + assignment.
+    const old = buildOldDb(path);
+    old.run(`INSERT INTO iterations (id, title, state) VALUES ('it-1', 'Iter', 'inbox')`);
+    old.run(
+      `INSERT INTO tasks (id, title, principal_id, source_system, source_url, source_external_id, status, iteration_id)
+       VALUES ('t-1', 'A task', 'andreas', 'github', 'https://github.com/o/r/issues/1', 'o/r#1', 'open', 'it-1')`
+    );
+    old.run(`INSERT INTO agents (id, name, type) VALUES ('a-1', 'Echo', 'head')`);
+    old.run(
+      `INSERT INTO agent_task_assignment (id, agent_id, task_id, state) VALUES ('x-1', 'a-1', 't-1', 'queued')`
+    );
+    // The old CHECK rejects a non-github/internal provider.
+    expect(() =>
+      old.run(
+        `INSERT INTO tasks (id, title, principal_id, source_system, status) VALUES ('t-bad', 'x', 'andreas', 'gitlab', 'open')`
+      )
+    ).toThrow();
+    old.close();
+
+    // --- reopen via initDatabase → triggers the D.7c rebuild.
+    const db = initDatabase(path);
+
+    // CHECK is gone — `tasks` schema no longer carries the source_system CHECK.
+    const tasksSql = (db.query(`SELECT sql FROM sqlite_master WHERE name='tasks'`).get() as { sql: string }).sql;
+    expect(tasksSql).not.toMatch(/CHECK\s*\(\s*source_system/i);
+
+    // Data preserved exactly — including the migrated iteration_id column.
+    const t = db.query(`SELECT * FROM tasks WHERE id='t-1'`).get() as Record<string, unknown>;
+    expect(t.source_system).toBe("github");
+    expect(t.source_external_id).toBe("o/r#1");
+    expect(t.iteration_id).toBe("it-1");
+
+    // The assignment FK survived the drop/rename, and integrity is intact.
+    const x = db.query(`SELECT task_id FROM agent_task_assignment WHERE id='x-1'`).get() as { task_id: string };
+    expect(x.task_id).toBe("t-1");
+    expect(db.query(`PRAGMA foreign_key_check`).all()).toEqual([]);
+
+    // A provider-neutral source_system now inserts (CHECK relaxed).
+    expect(() =>
+      db.run(
+        `INSERT INTO tasks (id, title, principal_id, source_system, status) VALUES ('t-gl', 'gl', 'andreas', 'gitlab', 'open')`
+      )
+    ).not.toThrow();
+
+    // The status CHECK is still enforced (we only dropped the source_system one).
+    expect(() =>
+      db.run(
+        `INSERT INTO tasks (id, title, principal_id, source_system, status) VALUES ('t-bs', 'x', 'andreas', 'github', 'bogus')`
+      )
+    ).toThrow();
+
+    // Indexes recreated.
+    const idx = db.query(`SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='tasks'`).all() as { name: string }[];
+    const names = idx.map((r) => r.name);
+    expect(names).toContain("idx_tasks_status_priority_updated");
+    expect(names).toContain("idx_tasks_iteration");
+    db.close();
+  });
+
+  it("is idempotent — a second init does not re-rebuild or error, data intact", () => {
+    const path = freshPath();
+    const old = buildOldDb(path);
+    old.run(
+      `INSERT INTO tasks (id, title, principal_id, source_system, status) VALUES ('t-1', 'A', 'andreas', 'github', 'open')`
+    );
+    old.close();
+
+    const db1 = initDatabase(path);
+    db1.close();
+    // Second open: detect() sees no CHECK → skips the rebuild cleanly.
+    const db2 = initDatabase(path);
+    expect((db2.query(`SELECT COUNT(*) c FROM tasks`).get() as { c: number }).c).toBe(1);
+    expect(db2.query(`PRAGMA foreign_key_check`).all()).toEqual([]);
+    db2.close();
+  });
+
+  it("a fresh DB is born neutral — no CHECK, no rebuild needed", () => {
+    const path = freshPath();
+    const db = initDatabase(path);
+    const tasksSql = (db.query(`SELECT sql FROM sqlite_master WHERE name='tasks'`).get() as { sql: string }).sql;
+    expect(tasksSql).not.toMatch(/CHECK\s*\(\s*source_system/i);
+    expect(() =>
+      db.run(
+        `INSERT INTO tasks (id, title, principal_id, source_system, status) VALUES ('t-1', 'x', 'andreas', 'gitlab', 'open')`
+      )
+    ).not.toThrow();
+    db.close();
+  });
+});

--- a/src/surface/mc/api/iteration-import.ts
+++ b/src/surface/mc/api/iteration-import.ts
@@ -408,11 +408,11 @@ export function importSubIssueFromMetadata(
     };
   }
 
-  // Fresh task row. Mirrors F-12b's INSERT shape (the schema's
-  // `source_system` CHECK rejects anything other than 'github' /
-  // 'internal', so we lean on the parent's source_system being
-  // 'github' — sub-issues only flow through this path for GitHub
-  // parents per Decision 7).
+  // Fresh task row. Mirrors F-12b's INSERT shape. Sub-issues only flow
+  // through this path for GitHub parents (Decision 7), so source_system is
+  // hardcoded 'github' below. (The DB's source_system CHECK was dropped in
+  // G-1113.D.7c — the column is now provider-neutral — but this path remains
+  // GitHub-specific by design until other providers grow an import path.)
   const taskId = generateId();
   const status = child.state === "closed" ? "done" : "open";
   // Principal id mirrors F-12b's DEFAULT_PRINCIPAL_ID — the sub-issue

--- a/src/surface/mc/dashboard-v2/__tests__/task-table-filter.test.ts
+++ b/src/surface/mc/dashboard-v2/__tests__/task-table-filter.test.ts
@@ -20,6 +20,7 @@ import {
 } from "../lib/task-table-filter";
 import type { TaskListItem, TaskAssignmentRow } from "../../db/tasks";
 import type { AssignmentState } from "../../types";
+import { isProvider } from "../../types";
 
 const NOW = Date.parse("2026-04-24T12:00:00.000Z");
 
@@ -35,7 +36,9 @@ function task(over: Partial<TaskListItem> = {}): TaskListItem {
     source_ref: over.source_ref ?? null,
     source_url: over.source_url ?? null,
     source: over.source ?? {
-      provider: over.source_system ?? "internal",
+      // source_system is open `string` post-D.7c — narrow to a Provider here
+      // (mirrors taskRowToSourceRef); unknown/undefined → "internal" default.
+      provider: isProvider(over.source_system) ? over.source_system : "internal",
       externalId: null,
       url: over.source_url ?? null,
       providerNativeType: null,

--- a/src/surface/mc/db/init.ts
+++ b/src/surface/mc/db/init.ts
@@ -58,16 +58,18 @@ export function initDatabase(dbPath: string): Database {
       db.run("BEGIN");
       try {
         for (const sql of rb.steps) db.run(sql);
+        // Verify integrity BEFORE committing — a violating rebuild is rolled
+        // back, never made durable (prevention, not just detection).
+        const violations = db.query("PRAGMA foreign_key_check").all();
+        if (violations.length > 0) {
+          throw new Error(
+            `D.7c rebuild of '${rb.table}' left ${violations.length} foreign-key violation(s): ${JSON.stringify(violations)}`
+          );
+        }
         db.run("COMMIT");
       } catch (err) {
         db.run("ROLLBACK");
         throw err;
-      }
-      const violations = db.query("PRAGMA foreign_key_check").all();
-      if (violations.length > 0) {
-        throw new Error(
-          `D.7c rebuild of '${rb.table}' left ${violations.length} foreign-key violation(s): ${JSON.stringify(violations)}`
-        );
       }
     } finally {
       // Always restore the connection-level FK enforcement the rest of the app expects.

--- a/src/surface/mc/db/init.ts
+++ b/src/surface/mc/db/init.ts
@@ -5,7 +5,7 @@
 import { Database } from "bun:sqlite";
 import { mkdirSync } from "fs";
 import { dirname } from "path";
-import { COLUMN_ADD_MIGRATIONS, SCHEMA_SQL } from "./schema";
+import { COLUMN_ADD_MIGRATIONS, REBUILD_MIGRATIONS, SCHEMA_SQL } from "./schema";
 
 /**
  * Open (or create) a SQLite database at the given path,
@@ -38,6 +38,40 @@ export function initDatabase(dbPath: string): Database {
     }
     if (m.post) {
       for (const sql of m.post) db.run(sql);
+    }
+  }
+
+  // G-1113.D.7c — guarded table-rebuild migrations (drop a CHECK that SQLite
+  // can't ALTER away). Runs AFTER the column-adds so the rebuild can copy
+  // every current column. Each is idempotent via `detect` (skips once the old
+  // shape is gone). FK enforcement is toggled OFF only around the rebuild —
+  // the drop/rename would otherwise trip the agent_task_assignment → tasks FK
+  // mid-rebuild — and a foreign_key_check verifies integrity before re-enabling.
+  for (const rb of REBUILD_MIGRATIONS) {
+    const row = db
+      .query(`SELECT sql FROM sqlite_master WHERE type = 'table' AND name = ?`)
+      .get(rb.table) as { sql: string } | null;
+    if (!row || !rb.detect(row.sql)) continue;
+
+    db.run("PRAGMA foreign_keys = OFF");
+    try {
+      db.run("BEGIN");
+      try {
+        for (const sql of rb.steps) db.run(sql);
+        db.run("COMMIT");
+      } catch (err) {
+        db.run("ROLLBACK");
+        throw err;
+      }
+      const violations = db.query("PRAGMA foreign_key_check").all();
+      if (violations.length > 0) {
+        throw new Error(
+          `D.7c rebuild of '${rb.table}' left ${violations.length} foreign-key violation(s): ${JSON.stringify(violations)}`
+        );
+      }
+    } finally {
+      // Always restore the connection-level FK enforcement the rest of the app expects.
+      db.run("PRAGMA foreign_keys = ON");
     }
   }
 

--- a/src/surface/mc/db/iterations.ts
+++ b/src/surface/mc/db/iterations.ts
@@ -19,7 +19,7 @@
  */
 
 import type { Database } from "bun:sqlite";
-import type { SourceRef } from "../types";
+import type { Provider, SourceRef } from "../types";
 import { epochSecondsToIso, taskRowToSourceRef } from "./tasks";
 import {
   ITERATION_STATES,
@@ -41,8 +41,12 @@ import {
  */
 export { ITERATION_STATES, type IterationState };
 
-/** Recognised source systems (Decision 7 — GitHub in v1, others later). */
-export type IterationSourceSystem = "github" | "jira" | "linear" | null;
+/**
+ * Source system of an imported iteration. G-1113.D.7c — provider-neutral: any
+ * {@link Provider} (or null for internal/manually-typed). The DB column is open
+ * TEXT (no CHECK); consumers read the normalized `source.provider` (D.7a).
+ */
+export type IterationSourceSystem = Provider | null;
 
 /**
  * Default cap on inbox results (Decision 10 Q3 — "lean: 100, server-side").

--- a/src/surface/mc/db/schema.ts
+++ b/src/surface/mc/db/schema.ts
@@ -38,7 +38,10 @@ export const SCHEMA_SQL: string[] = [
     description TEXT,
     priority INTEGER NOT NULL DEFAULT 2,
     principal_id TEXT NOT NULL,
-    source_system TEXT NOT NULL CHECK(source_system IN ('github','internal')),
+    -- G-1113.D.7c — provider-neutral: no CHECK (app-validated via isProvider at
+    -- the read boundary, matching the git/work-item tables). Existing DBs are
+    -- migrated off the old CHECK by REBUILD_MIGRATIONS below.
+    source_system TEXT NOT NULL,
     source_url TEXT,
     source_external_id TEXT,
     related_refs_json TEXT,
@@ -468,6 +471,78 @@ export const COLUMN_ADD_MIGRATIONS: ColumnAddMigration[] = [
     column: "iteration_id",
     ddl: `ALTER TABLE tasks ADD COLUMN iteration_id TEXT REFERENCES iterations(id)`,
     post: [
+      `CREATE INDEX IF NOT EXISTS idx_tasks_iteration ON tasks(iteration_id)`,
+    ],
+  },
+];
+
+/**
+ * G-1113.D.7c — table-rebuild migrations for EXISTING DBs.
+ *
+ * SQLite can't `ALTER TABLE ... DROP CONSTRAINT`, so relaxing a CHECK on an
+ * existing table requires the standard rebuild recipe (new table → copy → drop
+ * → rename). Fresh DBs already get the relaxed schema from SCHEMA_SQL, so each
+ * rebuild is GUARDED by `detect(currentSql)` and only fires when the OLD shape
+ * is still present — making it idempotent (post-migration it never re-runs).
+ *
+ * init.ts runs these AFTER COLUMN_ADD_MIGRATIONS (so added columns like
+ * tasks.iteration_id already exist) with foreign_keys OFF, inside a transaction,
+ * and a foreign_key_check afterwards.
+ *
+ * ⚠️ TRANSITIONAL + DATA-CRITICAL: `steps` must reproduce the table's FULL
+ * current shape = base SCHEMA_SQL columns + every COLUMN_ADD_MIGRATIONS column
+ * (today: tasks.iteration_id). If a future column-add lands, it MUST be added to
+ * the rebuild DDL below until this migration is retired (once all deployments
+ * have migrated past the source_system CHECK). The INSERT uses an explicit
+ * column list — never SELECT * — so a shape mismatch fails loudly, not silently.
+ */
+export interface RebuildMigration {
+  table: string;
+  /** Fire the rebuild only when the live table's stored SQL still matches the OLD shape. */
+  detect: (currentTableSql: string) => boolean;
+  /** Ordered DDL/DML, run with foreign_keys OFF inside a transaction. */
+  steps: string[];
+}
+
+export const REBUILD_MIGRATIONS: RebuildMigration[] = [
+  {
+    table: "tasks",
+    // Old shape carried `CHECK(source_system IN ('github','internal'))`.
+    detect: (sql) => /source_system\s+TEXT\s+NOT\s+NULL\s+CHECK\s*\(\s*source_system\s+IN/i.test(sql),
+    steps: [
+      // New tasks shape: base columns (source_system CHECK dropped; status CHECK
+      // kept) + the iteration_id column added by COLUMN_ADD_MIGRATIONS.
+      `CREATE TABLE tasks_new (
+        id TEXT PRIMARY KEY,
+        title TEXT NOT NULL,
+        description TEXT,
+        priority INTEGER NOT NULL DEFAULT 2,
+        principal_id TEXT NOT NULL,
+        source_system TEXT NOT NULL,
+        source_url TEXT,
+        source_external_id TEXT,
+        related_refs_json TEXT,
+        status TEXT NOT NULL DEFAULT 'open'
+          CHECK(status IN ('open','in_progress','done','cancelled')),
+        created_at INTEGER NOT NULL DEFAULT (unixepoch()),
+        updated_at INTEGER NOT NULL DEFAULT (unixepoch()),
+        iteration_id TEXT REFERENCES iterations(id)
+      )`,
+      // Explicit column list (never SELECT *) so a shape mismatch errors loudly.
+      `INSERT INTO tasks_new
+         (id, title, description, priority, principal_id, source_system,
+          source_url, source_external_id, related_refs_json, status,
+          created_at, updated_at, iteration_id)
+       SELECT
+          id, title, description, priority, principal_id, source_system,
+          source_url, source_external_id, related_refs_json, status,
+          created_at, updated_at, iteration_id
+       FROM tasks`,
+      `DROP TABLE tasks`,
+      `ALTER TABLE tasks_new RENAME TO tasks`,
+      // Recreate the indexes (SCHEMA_SQL's + the iteration_id partner index).
+      `CREATE INDEX IF NOT EXISTS idx_tasks_status_priority_updated
+         ON tasks(status, priority, updated_at DESC)`,
       `CREATE INDEX IF NOT EXISTS idx_tasks_iteration ON tasks(iteration_id)`,
     ],
   },

--- a/src/surface/mc/db/tasks.ts
+++ b/src/surface/mc/db/tasks.ts
@@ -87,7 +87,9 @@ export interface TaskListItem {
   created_at: string;
   /** ISO-8601 UTC (hydrated from INTEGER epoch). */
   updated_at: string;
-  source_system: "github" | "internal";
+  /** Raw stored provider key. Open `string` since D.7c dropped the CHECK;
+   *  the normalized {@link SourceRef} (`source`) is what consumers should read. */
+  source_system: string;
   source_ref: string | null;
   source_url: string | null;
   /**
@@ -123,18 +125,17 @@ export interface TaskListItem {
 }
 
 /**
- * G-1113.B.2 — map a task's legacy `source_*` columns onto a normalized
- * {@link SourceRef}. The DB still stores `source_system` (`github` | `internal`)
- * + `source_url` + `source_external_id` (B.2 is additive — columns and the
- * `source_system` CHECK are unchanged; widening to new providers is B.3+). This
- * shim is the single boundary that produces the normalized shape, so the rest
- * of Mission Control can stop branching on `source_system === "github"`
- * (the remaining call sites migrate in B.3/B.4).
+ * G-1113.B.2 — map a task's `source_*` columns onto a normalized
+ * {@link SourceRef}. The DB stores `source_system` + `source_url` +
+ * `source_external_id`. This shim is the single boundary that produces the
+ * normalized shape, so the rest of Mission Control branches on
+ * `source.provider`, never the raw `source_system`.
  *
- * `provider` falls back to `"custom"` only if the stored value isn't a known
- * {@link Provider} — today the CHECK guarantees `github`/`internal`, both valid
- * providers, so the fallback is defensive. `providerNativeType` is null until a
- * provider-specific adapter (B.3+) populates it.
+ * As of G-1113.D.7c the `source_system` CHECK has been DROPPED — the column is
+ * open provider-neutral `TEXT`. So `provider` is narrowed via {@link isProvider}
+ * here and the `"custom"` fallback is now a LIVE path for any stored value
+ * that isn't a known {@link Provider}, not merely defensive. `providerNativeType`
+ * is null until a provider-specific adapter populates it.
  */
 export function taskRowToSourceRef(row: {
   source_system: string;
@@ -203,7 +204,8 @@ interface TaskRow {
   status: TaskStatus;
   created_at: number;
   updated_at: number;
-  source_system: "github" | "internal";
+  // Raw DB column — open `string` since D.7c dropped the source_system CHECK.
+  source_system: string;
   source_url: string | null;
   source_external_id: string | null;
   aggregate_state_rank: number | null;

--- a/src/surface/mc/types.ts
+++ b/src/surface/mc/types.ts
@@ -58,6 +58,13 @@ export type BlockReason =
 
 // --- Entity types ---
 
+/**
+ * Legacy closed source-system set. As of G-1113.D.7c the `tasks.source_system`
+ * column is open provider-neutral `TEXT` (the CHECK was dropped), so this is no
+ * longer the type of {@link Task.source_system} (now `string`). Retained as the
+ * historical set + for the `TaskSourceSystem extends Provider` subset assertion
+ * (source-ref.test.ts) that proves the migrated values stay valid Providers.
+ */
 export type TaskSourceSystem = "github" | "internal";
 
 // --- Provider / source-ref model (G-1113.B.1) ---
@@ -378,7 +385,8 @@ export interface Task {
   description: string | null;
   priority: number;
   principal_id: string;
-  source_system: TaskSourceSystem;
+  /** Raw stored provider key — open `string` since D.7c (CHECK dropped). */
+  source_system: string;
   source_url: string | null;
   source_external_id: string | null;
   related_refs_json: string | null;


### PR DESCRIPTION
## G-1113.D.7c — provider-neutral `source_system` storage (the migration)

Final D.7 increment, completing the legacy→provider-neutral decoupling. `tasks.source_system` was the **last DB-level CHECK** pinning the legacy layer to `github|internal`; this relaxes it to match the git/work-item tables (open `TEXT`, app-validated via `isProvider`). `iterations.source_system` already had no DB CHECK — only its TS type was narrow (now `Provider | null`).

### ⚠️ This is the high-risk slice (live-data table rebuild) — here's why it's safe
SQLite can't `ALTER TABLE ... DROP CONSTRAINT`, so existing DBs need a table rebuild. The trap (PR #120 class): `tasks` has a migrated `iteration_id` column + an `agent_task_assignment → tasks` FK; a naive rebuild drops them.

- **`schema.ts`** — canonical `tasks` DDL drops the CHECK (fresh DBs born neutral); new `REBUILD_MIGRATIONS` is a **guarded** rebuild (`detect()` only fires on the old CHECK'd shape → idempotent). The rebuild DDL reproduces the **full** current shape (base + `iteration_id`) and the INSERT uses an **explicit column list** (never `SELECT *`) so a shape mismatch fails loudly, never silently drops data.
- **`init.ts`** — rebuilds run **after** the column-adds (so `iteration_id` exists to copy), with `foreign_keys OFF` + a transaction + a `foreign_key_check` that throws on any violation, and `PRAGMA foreign_keys = ON` restored in `finally`.
- **`__tests__/d7c-source-system-migration.test.ts`** — the safety proof: builds a faithful pre-D.7c DB (full schema, old CHECK'd tasks) with an iteration + a github task (with `iteration_id`) + an agent + assignment, reopens via `initDatabase`, and asserts: rows preserved, **`iteration_id` preserved**, **assignment FK intact** (`foreign_key_check` clean), CHECK gone (a `gitlab` task now inserts), **status CHECK still enforced**, indexes recreated, **idempotent** on re-run, and fresh DBs born neutral.

### Verification
- `bunx tsc --noEmit` clean · `bun run lint` 0 errors · carve-out gate PASS · `bun test src/surface/mc` 1240 pass / 0 fail · merge-guard clean

Closes #600. **Completes #590** (D.7) → with D.7a/D.7b this finishes the legacy→provider-neutral migration. Part of #577 / #354.