### PR TITLE
feat(mc): G-1113.E.1 — AttentionItem type + storage + lifecycle (design §6/§7.4)

### DIFF
--- a/src/surface/mc/__tests__/attention.test.ts
+++ b/src/surface/mc/__tests__/attention.test.ts
@@ -51,16 +51,41 @@ describe("attention storage (E.1)", () => {
     upsertPlanPhase(db, phase);
     upsertWorkItem(db, wi);
   }
+  /** Seed the agents→tasks→assignment→sessions FK chain; returns the session id. */
+  function seedSession(db: ReturnType<typeof initDatabase>): string {
+    db.query(`INSERT INTO agents (id, name, type) VALUES ('ag-1', 'Echo', 'head')`).run();
+    db.query(
+      `INSERT INTO tasks (id, title, principal_id, source_system, status) VALUES ('tk-1', 'T', 'andreas', 'github', 'open')`
+    ).run();
+    db.query(
+      `INSERT INTO agent_task_assignment (id, agent_id, task_id, state) VALUES ('asg-1', 'ag-1', 'tk-1', 'running')`
+    ).run();
+    db.query(
+      `INSERT INTO sessions (id, assignment_id, endpoint_kind) VALUES ('sess-1', 'asg-1', 'local.observed')`
+    ).run();
+    return "sess-1";
+  }
 
-  it("round-trips an item + idempotent upsert", () => {
+  it("round-trips an item + idempotent upsert overwrites every mutable column", () => {
     const db = freshDb();
     seed(db);
     const item = att({});
     upsertAttentionItem(db, item);
     expect(getAttentionItem(db, "att-1")).toEqual(item);
-    upsertAttentionItem(db, { ...item, severity: "high" });
-    expect(getAttentionItem(db, "att-1")?.severity).toBe("high");
     expect(getAttentionItem(db, "nope")).toBeNull();
+    // Re-upsert the SAME id with a fully different record — proves the ON
+    // CONFLICT clause overwrites every mutable column (not just one).
+    const changed = att({
+      id: "att-1",
+      stackId: "clawbox",
+      workItemId: null,
+      sessionId: null,
+      kind: "review",
+      severity: "high",
+      status: "resolved",
+    });
+    upsertAttentionItem(db, changed);
+    expect(getAttentionItem(db, "att-1")).toEqual(changed);
   });
 
   it("CHECK rejects out-of-vocabulary kind / severity / status", () => {
@@ -105,5 +130,19 @@ describe("attention storage (E.1)", () => {
     const item = getAttentionItem(db, "a-1");
     expect(item).not.toBeNull();
     expect(item?.workItemId).toBeNull();
+  });
+
+  it("FK SET NULL: deleting the linked session clears session_id, keeps the item", () => {
+    const db = freshDb();
+    seed(db);
+    const sessionId = seedSession(db);
+    // The session is the PRIMARY link for this 'blocked' item (no work item).
+    upsertAttentionItem(db, att({ id: "a-1", workItemId: null, sessionId, kind: "blocked" }));
+    // Sessions cascade-delete with their assignment in production — deleting the
+    // session must clear the link (SET NULL), not block the delete or drop the item.
+    db.query(`DELETE FROM sessions WHERE id = ?`).run(sessionId);
+    const item = getAttentionItem(db, "a-1");
+    expect(item).not.toBeNull();
+    expect(item?.sessionId).toBeNull();
   });
 });

--- a/src/surface/mc/__tests__/attention.test.ts
+++ b/src/surface/mc/__tests__/attention.test.ts
@@ -1,0 +1,109 @@
+/**
+ * G-1113.E.1 — AttentionItem storage round-trip + lifecycle + FK behaviour.
+ */
+import { describe, it, expect, afterEach } from "bun:test";
+import { join } from "path";
+import { tmpdir } from "os";
+import { rmSync, existsSync } from "fs";
+import { initDatabase } from "../db/init";
+import { upsertPlan, upsertPlanPhase } from "../db/plans";
+import { upsertWorkItem } from "../db/work-items";
+import {
+  upsertAttentionItem,
+  getAttentionItem,
+  listOpenAttention,
+  resolveAttentionItem,
+  dismissAttentionItem,
+} from "../db/attention";
+import type { AttentionItem, Plan, PlanPhase, WorkItem } from "../types";
+
+const plan: Plan = {
+  id: "plan-1", title: "P", kind: "design", sourceDocumentUrl: null,
+  provider: "internal", externalId: null, umbrellaWorkItemId: null, status: "active",
+};
+const phase: PlanPhase = { id: "phase-a", planId: "plan-1", title: "A", order: 0, status: "active" };
+const wi: WorkItem = {
+  id: "wi-1", planId: "plan-1", phaseId: "phase-a", parentId: null, title: "WI",
+  description: null, status: "open", priority: "", provider: "github",
+  externalId: "o/r#1", url: null,
+};
+const att = (over: Partial<AttentionItem> = {}): AttentionItem => ({
+  id: "att-1",
+  stackId: "laptop",
+  workItemId: "wi-1",
+  sessionId: null,
+  kind: "blocked",
+  severity: "normal",
+  status: "open",
+  ...over,
+});
+
+describe("attention storage (E.1)", () => {
+  const paths: string[] = [];
+  afterEach(() => { for (const p of paths) if (existsSync(p)) rmSync(p); paths.length = 0; });
+  function freshDb() {
+    const p = join(tmpdir(), `att-${Date.now()}-${Math.random().toString(36).slice(2)}.db`);
+    paths.push(p);
+    return initDatabase(p);
+  }
+  function seed(db: ReturnType<typeof initDatabase>) {
+    upsertPlan(db, plan);
+    upsertPlanPhase(db, phase);
+    upsertWorkItem(db, wi);
+  }
+
+  it("round-trips an item + idempotent upsert", () => {
+    const db = freshDb();
+    seed(db);
+    const item = att({});
+    upsertAttentionItem(db, item);
+    expect(getAttentionItem(db, "att-1")).toEqual(item);
+    upsertAttentionItem(db, { ...item, severity: "high" });
+    expect(getAttentionItem(db, "att-1")?.severity).toBe("high");
+    expect(getAttentionItem(db, "nope")).toBeNull();
+  });
+
+  it("CHECK rejects out-of-vocabulary kind / severity / status", () => {
+    const db = freshDb();
+    seed(db);
+    expect(() => upsertAttentionItem(db, att({ kind: "bogus" as AttentionItem["kind"] }))).toThrow();
+    expect(() => upsertAttentionItem(db, att({ severity: "bogus" as AttentionItem["severity"] }))).toThrow();
+    expect(() => upsertAttentionItem(db, att({ status: "bogus" as AttentionItem["status"] }))).toThrow();
+  });
+
+  it("listOpenAttention returns open only, ordered by severity then age", () => {
+    const db = freshDb();
+    seed(db);
+    upsertAttentionItem(db, att({ id: "a-normal", severity: "normal" }));
+    upsertAttentionItem(db, att({ id: "a-critical", severity: "critical" }));
+    upsertAttentionItem(db, att({ id: "a-low", severity: "low" }));
+    upsertAttentionItem(db, att({ id: "a-resolved", severity: "critical", status: "resolved" }));
+    expect(listOpenAttention(db).map((i) => i.id)).toEqual(["a-critical", "a-normal", "a-low"]);
+  });
+
+  it("resolve / dismiss transition status and drop the item from the open queue", () => {
+    const db = freshDb();
+    seed(db);
+    upsertAttentionItem(db, att({ id: "a-1" }));
+    upsertAttentionItem(db, att({ id: "a-2" }));
+    expect(resolveAttentionItem(db, "a-1")).toBe(true);
+    expect(getAttentionItem(db, "a-1")?.status).toBe("resolved");
+    expect(dismissAttentionItem(db, "a-2")).toBe(true);
+    expect(getAttentionItem(db, "a-2")?.status).toBe("dismissed");
+    expect(listOpenAttention(db)).toEqual([]);
+    // transitioning an unknown id is a no-op (no row changed).
+    expect(resolveAttentionItem(db, "ghost")).toBe(false);
+  });
+
+  it("FK SET NULL: deleting the linked work item clears the link, keeps the item", () => {
+    const db = freshDb();
+    seed(db);
+    upsertAttentionItem(db, att({ id: "a-1", workItemId: "wi-1" }));
+    // Deleting the work item must NOT be blocked (SET NULL, not RESTRICT) and
+    // must leave the attention item intact with a null link.
+    db.query(`DELETE FROM work_items WHERE id = 'wi-1'`).run();
+    const item = getAttentionItem(db, "a-1");
+    expect(item).not.toBeNull();
+    expect(item?.workItemId).toBeNull();
+  });
+});

--- a/src/surface/mc/db/attention.ts
+++ b/src/surface/mc/db/attention.ts
@@ -66,6 +66,11 @@ export function getAttentionItem(db: Database, id: string): AttentionItem | null
 /**
  * Open items only, queue-ordered: critical → low, then oldest first (FIFO within
  * a severity). `critical|high|normal|low` isn't lexical, so order via a CASE rank.
+ *
+ * NB: idx_attention_status_severity serves the `status = 'open'` FILTER, not this
+ * CASE-rank sort (the index is on the raw severity string), so SQLite still sorts
+ * the open set — negligible at queue sizes; revisit with a numeric rank column if
+ * the open queue ever grows large.
  */
 export function listOpenAttention(db: Database): AttentionItem[] {
   const rows = db

--- a/src/surface/mc/db/attention.ts
+++ b/src/surface/mc/db/attention.ts
@@ -1,0 +1,99 @@
+/**
+ * G-1113.E.1 — AttentionItem storage (design §6 / §7.4). Idempotent upsert by
+ * id, get, list-open (queue order), and the resolve/dismiss lifecycle. Mirrors
+ * the plans / work-items pattern: snake_case rows → camelCase domain types;
+ * kind/severity/status are CHECK-backed in the schema so the casts are safe.
+ *
+ * Producers for each `kind` are wired in E.2; the queue UI is E.3; notification
+ * routing is E.4. This slice lands the model + storage + lifecycle only.
+ */
+import type { Database } from "bun:sqlite";
+import type { AttentionItem, AttentionKind, AttentionSeverity, AttentionStatus } from "../types";
+
+interface AttentionRow {
+  id: string;
+  stack_id: string;
+  work_item_id: string | null;
+  session_id: string | null;
+  kind: string;
+  severity: string;
+  status: string;
+}
+
+function rowToAttentionItem(r: AttentionRow): AttentionItem {
+  return {
+    id: r.id,
+    stackId: r.stack_id,
+    workItemId: r.work_item_id,
+    sessionId: r.session_id,
+    // kind / severity / status are CHECK-constrained in the schema.
+    kind: r.kind as AttentionKind,
+    severity: r.severity as AttentionSeverity,
+    status: r.status as AttentionStatus,
+  };
+}
+
+/** Insert or update an attention item by id (idempotent re-emission by a producer). */
+export function upsertAttentionItem(db: Database, item: AttentionItem): void {
+  db.query(
+    `INSERT INTO attention_items
+       (id, stack_id, work_item_id, session_id, kind, severity, status)
+     VALUES (?, ?, ?, ?, ?, ?, ?)
+     ON CONFLICT(id) DO UPDATE SET
+       stack_id = excluded.stack_id,
+       work_item_id = excluded.work_item_id,
+       session_id = excluded.session_id,
+       kind = excluded.kind,
+       severity = excluded.severity,
+       status = excluded.status,
+       updated_at = unixepoch()`
+  ).run(
+    item.id,
+    item.stackId,
+    item.workItemId,
+    item.sessionId,
+    item.kind,
+    item.severity,
+    item.status
+  );
+}
+
+export function getAttentionItem(db: Database, id: string): AttentionItem | null {
+  const row = db.query(`SELECT * FROM attention_items WHERE id = ?`).get(id) as AttentionRow | null;
+  return row ? rowToAttentionItem(row) : null;
+}
+
+/**
+ * Open items only, queue-ordered: critical → low, then oldest first (FIFO within
+ * a severity). `critical|high|normal|low` isn't lexical, so order via a CASE rank.
+ */
+export function listOpenAttention(db: Database): AttentionItem[] {
+  const rows = db
+    .query(
+      `SELECT * FROM attention_items
+       WHERE status = 'open'
+       ORDER BY CASE severity
+         WHEN 'critical' THEN 0 WHEN 'high' THEN 1 WHEN 'normal' THEN 2 ELSE 3 END,
+         created_at, id`
+    )
+    .all() as AttentionRow[];
+  return rows.map(rowToAttentionItem);
+}
+
+/** Lifecycle transition to a terminal state. Returns true if a row changed. */
+function setStatus(db: Database, id: string, status: AttentionStatus): boolean {
+  const res = db
+    .query(`UPDATE attention_items SET status = ?, updated_at = unixepoch() WHERE id = ?`)
+    .run(status, id);
+  return res.changes > 0;
+}
+
+/** Mark an item resolved (its underlying condition cleared). */
+export function resolveAttentionItem(db: Database, id: string): boolean {
+  return setStatus(db, id, "resolved");
+}
+
+/** Mark an item dismissed (the principal chose to clear it without action). */
+export function dismissAttentionItem(db: Database, id: string): boolean {
+  return setStatus(db, id, "dismissed");
+}

--- a/src/surface/mc/db/schema.ts
+++ b/src/surface/mc/db/schema.ts
@@ -25,6 +25,7 @@ export const TABLE_NAMES = [
   "plans",
   "plan_phases",
   "work_items",
+  "attention_items",
 ] as const;
 
 export const SCHEMA_SQL: string[] = [
@@ -439,6 +440,33 @@ export const SCHEMA_SQL: string[] = [
   // Work-item lookup by phase (phase detail, D.4) and by plan.
   `CREATE INDEX IF NOT EXISTS idx_work_items_phase ON work_items(phase_id)`,
   `CREATE INDEX IF NOT EXISTS idx_work_items_plan ON work_items(plan_id)`,
+
+  // --- attention_items (G-1113.E.1 — design §6 / §7.4) ---
+  // The cross-cutting attention queue. kind/severity/status are CHECK-bounded
+  // closed enums (cast in the mapper). work_item_id / session_id are the
+  // deep-link targets — FK ON DELETE SET NULL (NOT RESTRICT like the plan/work
+  // tables): attention is a transient/derived projection, so when its target
+  // entity churns the item survives with the link cleared rather than blocking
+  // the delete. (stack_id is a plain key — no stacks table in the MC DB yet.)
+  `CREATE TABLE IF NOT EXISTS attention_items (
+    id TEXT PRIMARY KEY,
+    stack_id TEXT NOT NULL,
+    work_item_id TEXT REFERENCES work_items(id) ON DELETE SET NULL,
+    session_id TEXT REFERENCES sessions(id) ON DELETE SET NULL,
+    kind TEXT NOT NULL
+      CHECK(kind IN ('input_needed','permission','review','failed_dispatch','stale','blocked')),
+    severity TEXT NOT NULL DEFAULT 'normal'
+      CHECK(severity IN ('low','normal','high','critical')),
+    status TEXT NOT NULL DEFAULT 'open'
+      CHECK(status IN ('open','resolved','dismissed')),
+    created_at INTEGER NOT NULL DEFAULT (unixepoch()),
+    updated_at INTEGER NOT NULL DEFAULT (unixepoch())
+  )`,
+
+  // Queue query: open items first, by severity. Plus work-item lookup.
+  `CREATE INDEX IF NOT EXISTS idx_attention_status_severity
+     ON attention_items(status, severity)`,
+  `CREATE INDEX IF NOT EXISTS idx_attention_work_item ON attention_items(work_item_id)`,
 ];
 
 /**

--- a/src/surface/mc/db/schema.ts
+++ b/src/surface/mc/db/schema.ts
@@ -448,6 +448,10 @@ export const SCHEMA_SQL: string[] = [
   // tables): attention is a transient/derived projection, so when its target
   // entity churns the item survives with the link cleared rather than blocking
   // the delete. (stack_id is a plain key — no stacks table in the MC DB yet.)
+  // E.2/E.3 FOLLOW-UP: if SET NULL clears the LAST link of an open item (both
+  // work_item_id + session_id null), the producer/reconciler must auto-resolve
+  // or dismiss it — an open item with no deep-link target violates §7.4. Storage
+  // alone can't decide that; it's a producer responsibility.
   `CREATE TABLE IF NOT EXISTS attention_items (
     id TEXT PRIMARY KEY,
     stack_id TEXT NOT NULL,

--- a/src/surface/mc/types.ts
+++ b/src/surface/mc/types.ts
@@ -379,6 +379,36 @@ export interface WorkItem {
   url: string | null;
 }
 
+// --- Attention (G-1113.E — design §6 / §7.4) ---
+
+export type AttentionKind =
+  | "input_needed"
+  | "permission"
+  | "review"
+  | "failed_dispatch"
+  | "stale"
+  | "blocked";
+export type AttentionSeverity = "low" | "normal" | "high" | "critical";
+export type AttentionStatus = "open" | "resolved" | "dismissed";
+
+/**
+ * One item in the cross-cutting attention queue (design §6 / §7.4) — something
+ * that needs principal action. `workItemId` / `sessionId` are the direct
+ * deep-link targets; plan / phase / PR deep-links derive through the work item
+ * (resolved in the E.3 UI). `kind` producers are wired in E.2; notification
+ * routing is E.4. Lifecycle: `open` → `resolved` (condition cleared) | `dismissed`.
+ */
+export interface AttentionItem {
+  id: string;
+  /** Stack/deployment the item belongs to (multi-stack federation). */
+  stackId: string;
+  workItemId: string | null;
+  sessionId: string | null;
+  kind: AttentionKind;
+  severity: AttentionSeverity;
+  status: AttentionStatus;
+}
+
 export interface Task {
   id: string;
   title: string;


### PR DESCRIPTION
## G-1113.E.1 — AttentionItem model + storage + lifecycle

First Phase E slice (umbrella #604): the cross-cutting attention-queue model. Faithful transcription of design §6 (the D.1/D.4 discipline).

### What's here
- **`types.ts`** — `AttentionItem` (§6: `id`, `stackId`, `workItemId`/`sessionId` deep-link targets, `kind`, `severity`, `status`) + `AttentionKind`/`Severity`/`Status` unions.
- **`db/schema.ts`** — `attention_items` table: `kind`/`severity`/`status` CHECK-bounded closed enums; `work_item_id`/`session_id` FK **`ON DELETE SET NULL`** — attention is a transient/derived projection, so a churning target **clears the link** rather than blocking the delete (deliberately *not* the `RESTRICT` the plan/work tables use); status+severity and work-item indexes.
- **`db/attention.ts`** — idempotent `upsert` / `get` / `listOpenAttention` (queue order: severity rank then FIFO) / `resolve` + `dismiss` lifecycle (`open → resolved | dismissed`).
- **`__tests__/attention.test.ts`** — round-trip + idempotent, CHECK rejections, open-only severity ordering, resolve/dismiss transitions + queue drop, and the **FK SET NULL** behaviour (deleting the work item clears the link, keeps the item).

### Scope
Model + storage + lifecycle only — matching the D.1 split. Producers per `kind` are **E.2** (#606), the queue UI is **E.3** (#607), notification routing is **E.4** (#608). §7.4's plan/phase/PR deep-links derive through the work item (resolved in E.3).

### Verification
- `bunx tsc --noEmit` clean · `bun run lint` 0 errors · carve-out gate PASS · `bun test src/surface/mc` 1247 pass / 0 fail · merge-guard clean

Closes #605. Part of #604 / #354.