### PR TITLE
feat(mc): G-1113.E.2 — attention producers (reconciler over DB state)

### DIFF
--- a/src/surface/mc/__tests__/attention-sources.test.ts
+++ b/src/surface/mc/__tests__/attention-sources.test.ts
@@ -1,0 +1,103 @@
+/**
+ * G-1113.E.2 — attention reconciler: derive open items from DB state, upsert,
+ * and auto-resolve cleared conditions.
+ */
+import { describe, it, expect, afterEach } from "bun:test";
+import { join } from "path";
+import { tmpdir } from "os";
+import { rmSync, existsSync } from "fs";
+import { initDatabase } from "../db/init";
+import { getAttentionItem, listOpenAttention } from "../db/attention";
+import { reconcileAttention } from "../db/attention-sources";
+import type { AttentionKind, AttentionSeverity, BlockReason } from "../types";
+
+const NOW = 1_900_000_000; // fixed epoch seconds for deterministic staleness
+const DAY = 24 * 60 * 60;
+
+describe("reconcileAttention (E.2)", () => {
+  const paths: string[] = [];
+  afterEach(() => { for (const p of paths) if (existsSync(p)) rmSync(p); paths.length = 0; });
+  function freshDb() {
+    const p = join(tmpdir(), `attsrc-${Date.now()}-${Math.random().toString(36).slice(2)}.db`);
+    paths.push(p);
+    return initDatabase(p);
+  }
+
+  /** Insert a blocked assignment (+ session) carrying the given block reason. */
+  function seedBlocked(db: ReturnType<typeof initDatabase>, reason: BlockReason) {
+    db.query(`INSERT INTO agents (id, name, type) VALUES ('ag-1', 'Echo', 'head')`).run();
+    db.query(
+      `INSERT INTO tasks (id, title, principal_id, source_system, status) VALUES ('tk-1', 'T', 'andreas', 'github', 'in_progress')`
+    ).run();
+    db.query(
+      `INSERT INTO agent_task_assignment (id, agent_id, task_id, state, block_reason) VALUES ('asg-1', 'ag-1', 'tk-1', 'blocked', ?)`
+    ).run(JSON.stringify(reason));
+    db.query(
+      `INSERT INTO sessions (id, assignment_id, endpoint_kind) VALUES ('sess-1', 'asg-1', 'local.observed')`
+    ).run();
+  }
+
+  function seedWorkItem(db: ReturnType<typeof initDatabase>, id: string, status: string, updatedAtSec: number) {
+    db.query(
+      `INSERT INTO work_items (id, title, status, priority, provider, updated_at) VALUES (?, ?, ?, '', 'github', ?)`
+    ).run(id, id, status, updatedAtSec);
+  }
+
+  const opts = { stackId: "laptop", nowEpochSec: NOW };
+
+  it("maps block reasons to attention kind/severity, deep-linked via session", () => {
+    const cases: [BlockReason, AttentionKind, AttentionSeverity][] = [
+      [{ kind: "permission.request", payload: { requested_action: "write" } }, "permission", "high"],
+      [{ kind: "review.checkpoint", payload: { description: "approve?" } }, "review", "normal"],
+      [{ kind: "tool.error", payload: { tool_name: "bash", error_message: "boom" } }, "blocked", "high"],
+    ];
+    for (const [reason, kind, severity] of cases) {
+      const db = freshDb();
+      seedBlocked(db, reason);
+      reconcileAttention(db, opts);
+      const item = getAttentionItem(db, "att:block:asg-1");
+      expect(item?.kind).toBe(kind);
+      expect(item?.severity).toBe(severity);
+      expect(item?.sessionId).toBe("sess-1");
+      expect(item?.workItemId).toBeNull();
+      expect(item?.stackId).toBe("laptop");
+    }
+  });
+
+  it("flags stale open work items; ignores terminal + recently-touched ones", () => {
+    const db = freshDb();
+    seedWorkItem(db, "wi-stale", "open", NOW - 30 * DAY); // open + old → stale
+    seedWorkItem(db, "wi-fresh", "open", NOW - 1 * DAY); // open + recent → not stale
+    seedWorkItem(db, "wi-closed", "closed", NOW - 30 * DAY); // terminal → never stale
+    reconcileAttention(db, opts);
+    expect(getAttentionItem(db, "att:stale:wi-stale")?.kind).toBe("stale");
+    expect(getAttentionItem(db, "att:stale:wi-stale")?.severity).toBe("low");
+    expect(getAttentionItem(db, "att:stale:wi-fresh")).toBeNull();
+    expect(getAttentionItem(db, "att:stale:wi-closed")).toBeNull();
+  });
+
+  it("resolves a previously-open item once its condition clears", () => {
+    const db = freshDb();
+    seedBlocked(db, { kind: "permission.request", payload: { requested_action: "write" } });
+    reconcileAttention(db, opts);
+    expect(getAttentionItem(db, "att:block:asg-1")?.status).toBe("open");
+
+    // Assignment unblocks (state → completed, block_reason cleared).
+    db.query(`UPDATE agent_task_assignment SET state = 'completed', block_reason = NULL WHERE id = 'asg-1'`).run();
+    reconcileAttention(db, opts);
+    expect(getAttentionItem(db, "att:block:asg-1")?.status).toBe("resolved");
+    expect(listOpenAttention(db)).toEqual([]);
+  });
+
+  it("is idempotent — re-running yields the same single open item per id", () => {
+    const db = freshDb();
+    seedBlocked(db, { kind: "tool.error", payload: { tool_name: "bash", error_message: "x" } });
+    seedWorkItem(db, "wi-stale", "open", NOW - 30 * DAY);
+    reconcileAttention(db, opts);
+    const first = listOpenAttention(db).map((i) => i.id).sort();
+    reconcileAttention(db, opts);
+    const second = listOpenAttention(db).map((i) => i.id).sort();
+    expect(second).toEqual(first);
+    expect(second).toEqual(["att:block:asg-1", "att:stale:wi-stale"]);
+  });
+});

--- a/src/surface/mc/__tests__/attention-sources.test.ts
+++ b/src/surface/mc/__tests__/attention-sources.test.ts
@@ -16,25 +16,40 @@ const DAY = 24 * 60 * 60;
 
 describe("reconcileAttention (E.2)", () => {
   const paths: string[] = [];
-  afterEach(() => { for (const p of paths) if (existsSync(p)) rmSync(p); paths.length = 0; });
+  afterEach(() => {
+    for (const p of paths) if (existsSync(p)) rmSync(p);
+    paths.length = 0;
+  });
   function freshDb() {
     const p = join(tmpdir(), `attsrc-${Date.now()}-${Math.random().toString(36).slice(2)}.db`);
     paths.push(p);
     return initDatabase(p);
   }
 
-  /** Insert a blocked assignment (+ session) carrying the given block reason. */
-  function seedBlocked(db: ReturnType<typeof initDatabase>, reason: BlockReason) {
-    db.query(`INSERT INTO agents (id, name, type) VALUES ('ag-1', 'Echo', 'head')`).run();
+  /**
+   * Insert a blocked assignment carrying `reason`; a session is created unless
+   * `withSession` is false (to exercise the no-deep-link skip). The shared
+   * agent/task are seeded idempotently (INSERT OR IGNORE) so this is safe to
+   * call repeatedly on a DB; each assignment + session is suffixed by `suffix`.
+   */
+  function seedBlocked(
+    db: ReturnType<typeof initDatabase>,
+    reason: BlockReason,
+    suffix = "1",
+    withSession = true
+  ) {
+    db.query(`INSERT OR IGNORE INTO agents (id, name, type) VALUES ('ag-1', 'Echo', 'head')`).run();
     db.query(
-      `INSERT INTO tasks (id, title, principal_id, source_system, status) VALUES ('tk-1', 'T', 'andreas', 'github', 'in_progress')`
+      `INSERT OR IGNORE INTO tasks (id, title, principal_id, source_system, status) VALUES ('tk-1', 'T', 'andreas', 'github', 'in_progress')`
     ).run();
     db.query(
-      `INSERT INTO agent_task_assignment (id, agent_id, task_id, state, block_reason) VALUES ('asg-1', 'ag-1', 'tk-1', 'blocked', ?)`
-    ).run(JSON.stringify(reason));
-    db.query(
-      `INSERT INTO sessions (id, assignment_id, endpoint_kind) VALUES ('sess-1', 'asg-1', 'local.observed')`
-    ).run();
+      `INSERT INTO agent_task_assignment (id, agent_id, task_id, state, block_reason) VALUES (?, 'ag-1', 'tk-1', 'blocked', ?)`
+    ).run(`asg-${suffix}`, JSON.stringify(reason));
+    if (withSession) {
+      db.query(
+        `INSERT INTO sessions (id, assignment_id, endpoint_kind) VALUES (?, ?, 'local.observed')`
+      ).run(`sess-${suffix}`, `asg-${suffix}`);
+    }
   }
 
   function seedWorkItem(db: ReturnType<typeof initDatabase>, id: string, status: string, updatedAtSec: number) {
@@ -87,6 +102,41 @@ describe("reconcileAttention (E.2)", () => {
     reconcileAttention(db, opts);
     expect(getAttentionItem(db, "att:block:asg-1")?.status).toBe("resolved");
     expect(listOpenAttention(db)).toEqual([]);
+  });
+
+  it("does NOT produce an item for a blocked assignment with no session (no deep-link)", () => {
+    const db = freshDb();
+    seedBlocked(db, { kind: "tool.error", payload: { tool_name: "bash", error_message: "x" } }, "1", false);
+    reconcileAttention(db, opts);
+    expect(getAttentionItem(db, "att:block:asg-1")).toBeNull();
+    expect(listOpenAttention(db)).toEqual([]);
+  });
+
+  it("resolves only the cleared item when one of several conditions clears", () => {
+    const db = freshDb();
+    seedBlocked(db, { kind: "permission.request", payload: { requested_action: "w" } }, "1");
+    seedBlocked(db, { kind: "tool.error", payload: { tool_name: "bash", error_message: "x" } }, "2");
+    reconcileAttention(db, opts);
+    expect(listOpenAttention(db).map((i) => i.id).sort()).toEqual(["att:block:asg-1", "att:block:asg-2"]);
+    // asg-1 unblocks; asg-2 stays blocked.
+    db.query(`UPDATE agent_task_assignment SET state = 'completed', block_reason = NULL WHERE id = 'asg-1'`).run();
+    reconcileAttention(db, opts);
+    expect(getAttentionItem(db, "att:block:asg-1")?.status).toBe("resolved");
+    expect(getAttentionItem(db, "att:block:asg-2")?.status).toBe("open");
+  });
+
+  it("staleness honours the threshold boundary and resolves once a row is touched", () => {
+    const db = freshDb();
+    seedWorkItem(db, "wi-1", "open", NOW - 1 * DAY); // fresh → not stale yet
+    reconcileAttention(db, opts);
+    expect(getAttentionItem(db, "att:stale:wi-1")).toBeNull();
+    // Time advances past the 7d threshold → now flagged.
+    reconcileAttention(db, { ...opts, nowEpochSec: NOW + 10 * DAY });
+    expect(getAttentionItem(db, "att:stale:wi-1")?.status).toBe("open");
+    // The work item is touched (updated_at bumped) → resolves on next run.
+    db.query(`UPDATE work_items SET updated_at = ? WHERE id = 'wi-1'`).run(NOW + 10 * DAY);
+    reconcileAttention(db, { ...opts, nowEpochSec: NOW + 10 * DAY });
+    expect(getAttentionItem(db, "att:stale:wi-1")?.status).toBe("resolved");
   });
 
   it("is idempotent — re-running yields the same single open item per id", () => {

--- a/src/surface/mc/db/attention-sources.ts
+++ b/src/surface/mc/db/attention-sources.ts
@@ -71,13 +71,22 @@ export function reconcileAttention(db: Database, opts: ReconcileAttentionOptions
   // 1. Blocked assignments (listFocusArea is the state='blocked' projection).
   for (const a of listFocusArea(db)) {
     if (!a.block_reason) continue; // schema guarantees non-null when blocked, but be defensive
+    const sessionId = a.session?.id ?? null;
+    // §7.4 requires every attention item to deep-link; the session is the only
+    // link target for a block-source item (no work-item linkage from an
+    // assignment). A blocked assignment with no session therefore has no
+    // deep-link target — skip rather than surface an un-actionable item. This
+    // honours the invariant the E.1 schema note delegates to the producer.
+    // (In practice the three block reasons all originate from a running CC
+    // session, so this is an edge; revisit if a session-less block proves real.)
+    if (!sessionId) continue;
     const { kind, severity } = blockReasonToAttention(a.block_reason);
     const id = `${BLOCK_PREFIX}${a.id}`;
     derived.set(id, {
       id,
       stackId: opts.stackId,
       workItemId: null,
-      sessionId: a.session?.id ?? null,
+      sessionId,
       kind,
       severity,
       status: "open",

--- a/src/surface/mc/db/attention-sources.ts
+++ b/src/surface/mc/db/attention-sources.ts
@@ -1,0 +1,117 @@
+/**
+ * G-1113.E.2 — attention producers (design §5.5 / §7.4).
+ *
+ * `reconcileAttention` derives the open attention set from current DB state and
+ * upserts it, then auto-resolves any previously-open item whose condition has
+ * cleared (acceptance criterion: "items resolve when their condition clears" +
+ * the E.1 orphaned-link follow-up). A derive+diff reconciler — rather than
+ * hooking every runner/bus emit point — keeps producers idempotent (stable ids)
+ * and the whole thing pure + testable. A periodic/event trigger that CALLS it
+ * is the integration step (kept minimal, like the D.2/D.5b ingestion split).
+ *
+ * Sources wired here (the DB-derivable kinds with a clean deep-link):
+ *   - blocked assignments → kind from block_reason (permission / review /
+ *     blocked), deep-linked via the assignment's session.
+ *   - stale work items → kind "stale", deep-linked via the work item.
+ *
+ * Deferred (documented, NOT silently dropped):
+ *   - "failed_dispatch": a Myelin envelope nak — bus-level, not in the MC DB;
+ *     wired when the dispatch-failure event lands a DB record.
+ *   - failing checks: a Check links by commit SHA, with no direct work-item /
+ *     session deep-link target (§7.4 requires one) until the check→PR→workItem
+ *     chain exists; revisit with that linkage.
+ *   - "input_needed": no current block_reason maps to it; a future producer.
+ */
+import type { Database } from "bun:sqlite";
+import type { AttentionItem, AttentionKind, AttentionSeverity, BlockReason } from "../types";
+import { listFocusArea } from "./assignments";
+import { upsertAttentionItem, listOpenAttention, resolveAttentionItem } from "./attention";
+
+/** Deterministic id prefixes — let re-runs upsert in place + diff for resolution. */
+const BLOCK_PREFIX = "att:block:";
+const STALE_PREFIX = "att:stale:";
+
+/** Work-item statuses treated as terminal (never "stale"). GitHub ingest writes open/closed. */
+const TERMINAL_WORK_ITEM_STATUSES = new Set(["done", "closed", "cancelled", "completed"]);
+
+const DEFAULT_STALE_AFTER_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+
+export interface ReconcileAttentionOptions {
+  /** Stack/deployment id stamped on produced items. */
+  stackId: string;
+  /** An open work item untouched longer than this is "stale". Default 7 days. */
+  staleAfterMs?: number;
+  /** Current time in epoch SECONDS (injectable for deterministic tests). */
+  nowEpochSec?: number;
+}
+
+/** Map a block reason to its attention kind + severity. Exhaustive over BlockReason. */
+function blockReasonToAttention(reason: BlockReason): { kind: AttentionKind; severity: AttentionSeverity } {
+  switch (reason.kind) {
+    case "permission.request":
+      return { kind: "permission", severity: "high" };
+    case "review.checkpoint":
+      return { kind: "review", severity: "normal" };
+    case "tool.error":
+      return { kind: "blocked", severity: "high" };
+  }
+}
+
+/**
+ * Derive the current open-attention set from DB state, upsert it, and resolve
+ * any previously-open reconciled item whose condition has cleared. Idempotent.
+ * Returns the items currently derived as open.
+ */
+export function reconcileAttention(db: Database, opts: ReconcileAttentionOptions): { open: AttentionItem[] } {
+  const nowSec = opts.nowEpochSec ?? Math.floor(Date.now() / 1000);
+  const staleBeforeSec = nowSec - Math.floor((opts.staleAfterMs ?? DEFAULT_STALE_AFTER_MS) / 1000);
+
+  const derived = new Map<string, AttentionItem>();
+
+  // 1. Blocked assignments (listFocusArea is the state='blocked' projection).
+  for (const a of listFocusArea(db)) {
+    if (!a.block_reason) continue; // schema guarantees non-null when blocked, but be defensive
+    const { kind, severity } = blockReasonToAttention(a.block_reason);
+    const id = `${BLOCK_PREFIX}${a.id}`;
+    derived.set(id, {
+      id,
+      stackId: opts.stackId,
+      workItemId: null,
+      sessionId: a.session?.id ?? null,
+      kind,
+      severity,
+      status: "open",
+    });
+  }
+
+  // 2. Stale work items (open + untouched past the threshold).
+  const staleRows = db
+    .query(`SELECT id, status FROM work_items WHERE updated_at < ?`)
+    .all(staleBeforeSec) as { id: string; status: string }[];
+  for (const w of staleRows) {
+    if (TERMINAL_WORK_ITEM_STATUSES.has(w.status.toLowerCase())) continue;
+    const id = `${STALE_PREFIX}${w.id}`;
+    derived.set(id, {
+      id,
+      stackId: opts.stackId,
+      workItemId: w.id,
+      sessionId: null,
+      kind: "stale",
+      severity: "low",
+      status: "open",
+    });
+  }
+
+  // Upsert everything derived as open (idempotent by id).
+  for (const item of derived.values()) upsertAttentionItem(db, item);
+
+  // Resolve previously-open RECONCILED items whose condition no longer holds
+  // (assignment unblocked / work item touched or terminal). Only our own
+  // prefixes — never touch items produced by other sources.
+  for (const open of listOpenAttention(db)) {
+    const reconciled = open.id.startsWith(BLOCK_PREFIX) || open.id.startsWith(STALE_PREFIX);
+    if (reconciled && !derived.has(open.id)) resolveAttentionItem(db, open.id);
+  }
+
+  return { open: [...derived.values()] };
+}


### PR DESCRIPTION
## G-1113.E.2 — attention producers

`reconcileAttention` derives the open attention set from current DB state, upserts it (idempotent by deterministic id), and **auto-resolves** any previously-open reconciled item whose condition has cleared — the acceptance criterion ("items resolve when their condition clears") + the E.1-flagged orphaned-link follow-up, handled in one place.

### Sources wired (DB-derivable, with a clean deep-link)
- **blocked assignments** → kind from `block_reason`: `permission.request` → `permission`/high, `review.checkpoint` → `review`/normal, `tool.error` → `blocked`/high. Deep-linked via the assignment's **session** (`listFocusArea` is the `state='blocked'` projection).
- **stale work items** (open + untouched past the threshold, default 7d) → `stale`/low, deep-linked via the **work item**. Terminal statuses (`done`/`closed`/`cancelled`/`completed`) never go stale.

### Deferred (documented in-code, not silently dropped)
- **`failed_dispatch`** — a Myelin envelope nak is bus-level with no MC-DB record yet; wired when that lands a row.
- **failing checks** — a `Check` links by commit SHA with no direct work-item/session deep-link target (§7.4 requires one) until the check→PR→workItem chain exists.
- **`input_needed`** — no current `block_reason` maps to it; a future producer.

### Design note
A **derive+diff reconciler** (rather than hooking every runner/bus emit point) keeps producers idempotent + pure + testable. The periodic/event trigger that *calls* `reconcileAttention` is the integration step — kept minimal here, mirroring the D.2/D.5b ingestion-mechanism split.

### Verification
- `bunx tsc --noEmit` clean · `bun run lint` 0 errors · carve-out gate PASS · `bun test src/surface/mc` 1252 pass / 0 fail · merge-guard clean

Closes #606. Part of #604 / #354.