### PR TITLE
feat(mc): G-1113.E.3 — attention queue UI surface (design §7.4)

### DIFF
--- a/src/surface/mc/__tests__/attention-queue.test.ts
+++ b/src/surface/mc/__tests__/attention-queue.test.ts
@@ -65,9 +65,9 @@ describe("getAttentionQueue (E.3)", () => {
     upsertPlanPhase(db, phase);
     upsertWorkItem(db, wi); // wi-1
     upsertWorkItem(db, { ...wi, id: "wi-2", title: "Other" });
-    // The work_item_id FK (enforced on insert) means a link is always either a
-    // real work item or NULL — a dangling ref can't exist, so resolveLink's
-    // id-fallback is defensive/unreachable; we test with real work items.
+    // work_item_id is an FK with ON DELETE SET NULL, so a link is always either
+    // a real work item or NULL — a dangling ref can't exist, so resolveLink's
+    // id-fallback is defensively unreachable; we test with real work items.
     upsertAttentionItem(db, att({ id: "att-low", workItemId: "wi-2", kind: "stale", severity: "low" }));
     upsertAttentionItem(db, att({ id: "att-crit", workItemId: "wi-1", kind: "blocked", severity: "critical" }));
     upsertAttentionItem(db, att({ id: "att-done", workItemId: "wi-1", severity: "critical", status: "resolved" }));

--- a/src/surface/mc/__tests__/attention-queue.test.ts
+++ b/src/surface/mc/__tests__/attention-queue.test.ts
@@ -1,0 +1,89 @@
+/**
+ * G-1113.E.3 — attention queue projection (api/attention.ts): deep-link resolution.
+ */
+import { describe, it, expect, afterEach } from "bun:test";
+import { join } from "path";
+import { tmpdir } from "os";
+import { rmSync, existsSync } from "fs";
+import { initDatabase } from "../db/init";
+import { upsertPlan, upsertPlanPhase } from "../db/plans";
+import { upsertWorkItem } from "../db/work-items";
+import { upsertAttentionItem } from "../db/attention";
+import { getAttentionQueue, handleListAttention } from "../api/attention";
+import type { AttentionItem, Plan, PlanPhase, WorkItem } from "../types";
+
+const plan: Plan = {
+  id: "plan-1", title: "P", kind: "design", sourceDocumentUrl: null,
+  provider: "internal", externalId: null, umbrellaWorkItemId: null, status: "active",
+};
+const phase: PlanPhase = { id: "phase-a", planId: "plan-1", title: "A", order: 0, status: "active" };
+const wi: WorkItem = {
+  id: "wi-1", planId: "plan-1", phaseId: "phase-a", parentId: null, title: "Fix the thing",
+  description: null, status: "open", priority: "", provider: "github", externalId: "o/r#1", url: null,
+};
+const att = (over: Partial<AttentionItem>): AttentionItem => ({
+  id: "att-x", stackId: "laptop", workItemId: null, sessionId: null,
+  kind: "blocked", severity: "normal", status: "open", ...over,
+});
+
+describe("getAttentionQueue (E.3)", () => {
+  const paths: string[] = [];
+  afterEach(() => { for (const p of paths) if (existsSync(p)) rmSync(p); paths.length = 0; });
+  function freshDb() {
+    const p = join(tmpdir(), `attq-${Date.now()}-${Math.random().toString(36).slice(2)}.db`);
+    paths.push(p);
+    return initDatabase(p);
+  }
+  function seedSession(db: ReturnType<typeof initDatabase>): string {
+    db.query(`INSERT INTO agents (id, name, type) VALUES ('ag-1', 'Echo', 'head')`).run();
+    db.query(`INSERT INTO tasks (id, title, principal_id, source_system, status) VALUES ('tk-1', 'T', 'andreas', 'github', 'open')`).run();
+    db.query(`INSERT INTO agent_task_assignment (id, agent_id, task_id, state) VALUES ('asg-1', 'ag-1', 'tk-1', 'running')`).run();
+    db.query(`INSERT INTO sessions (id, assignment_id, endpoint_kind) VALUES ('sess-1', 'asg-1', 'local.observed')`).run();
+    return "sess-1";
+  }
+
+  it("resolves a work-item link to its title (→ work-item-detail route)", () => {
+    const db = freshDb();
+    upsertPlan(db, plan); upsertPlanPhase(db, phase); upsertWorkItem(db, wi);
+    upsertAttentionItem(db, att({ id: "att-wi", workItemId: "wi-1", kind: "stale", severity: "low" }));
+    const [entry] = getAttentionQueue(db);
+    expect(entry?.item.id).toBe("att-wi");
+    expect(entry?.link).toEqual({ kind: "work-item", workItemId: "wi-1", label: "Fix the thing" });
+  });
+
+  it("resolves a session link to its assignment id (→ drill-down route)", () => {
+    const db = freshDb();
+    const sessionId = seedSession(db);
+    upsertAttentionItem(db, att({ id: "att-sess", sessionId, kind: "permission", severity: "high" }));
+    const [entry] = getAttentionQueue(db);
+    expect(entry?.link).toEqual({ kind: "session", sessionId: "sess-1", assignmentId: "asg-1" });
+  });
+
+  it("lists only open items, severity-ordered (resolved excluded)", () => {
+    const db = freshDb();
+    upsertPlan(db, plan);
+    upsertPlanPhase(db, phase);
+    upsertWorkItem(db, wi); // wi-1
+    upsertWorkItem(db, { ...wi, id: "wi-2", title: "Other" });
+    // The work_item_id FK (enforced on insert) means a link is always either a
+    // real work item or NULL — a dangling ref can't exist, so resolveLink's
+    // id-fallback is defensive/unreachable; we test with real work items.
+    upsertAttentionItem(db, att({ id: "att-low", workItemId: "wi-2", kind: "stale", severity: "low" }));
+    upsertAttentionItem(db, att({ id: "att-crit", workItemId: "wi-1", kind: "blocked", severity: "critical" }));
+    upsertAttentionItem(db, att({ id: "att-done", workItemId: "wi-1", severity: "critical", status: "resolved" }));
+    const q = getAttentionQueue(db);
+    expect(q.map((e) => e.item.id)).toEqual(["att-crit", "att-low"]); // severity order, resolved excluded
+    expect(q[0]?.link).toEqual({ kind: "work-item", workItemId: "wi-1", label: "Fix the thing" });
+  });
+
+  it("handleListAttention returns a { attention } envelope (200 + JSON)", async () => {
+    const db = freshDb();
+    upsertPlan(db, plan); upsertPlanPhase(db, phase); upsertWorkItem(db, wi);
+    upsertAttentionItem(db, att({ id: "att-wi", workItemId: "wi-1" }));
+    const res = handleListAttention(db);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("application/json");
+    const body = (await res.json()) as { attention: { item: { id: string } }[] };
+    expect(body.attention[0]?.item.id).toBe("att-wi");
+  });
+});

--- a/src/surface/mc/api/attention.ts
+++ b/src/surface/mc/api/attention.ts
@@ -1,0 +1,53 @@
+/**
+ * G-1113.E.3 — attention queue projection + endpoint (design §7.4).
+ *
+ * Lists the open attention items (severity-ordered by db/attention) and
+ * resolves each one's deep-link target so the UI can route to it:
+ *   - workItemId → the work item (title) → the work-item-detail surface (D.5).
+ *   - sessionId  → its assignment id (sessions.assignment_id) → the drill-down.
+ * §7.4 requires every item to deep-link; E.2 already guarantees an open item
+ * carries at least one of these targets, so `link.kind` is never "none" for a
+ * reconciled item — but the projection tolerates an unresolved link defensively.
+ */
+import type { Database } from "bun:sqlite";
+import type { AttentionItem } from "../types";
+import { listOpenAttention } from "../db/attention";
+import { getWorkItem } from "../db/work-items";
+
+export type AttentionLink =
+  | { kind: "work-item"; workItemId: string; label: string }
+  | { kind: "session"; sessionId: string; assignmentId: string | null }
+  | { kind: "none" };
+
+export interface AttentionEntry {
+  item: AttentionItem;
+  /** Resolved deep-link target the UI routes on. */
+  link: AttentionLink;
+}
+
+function resolveLink(db: Database, item: AttentionItem): AttentionLink {
+  if (item.workItemId !== null) {
+    const wi = getWorkItem(db, item.workItemId);
+    return { kind: "work-item", workItemId: item.workItemId, label: wi?.title ?? item.workItemId };
+  }
+  if (item.sessionId !== null) {
+    const row = db
+      .query(`SELECT assignment_id FROM sessions WHERE id = ?`)
+      .get(item.sessionId) as { assignment_id: string } | null;
+    return { kind: "session", sessionId: item.sessionId, assignmentId: row?.assignment_id ?? null };
+  }
+  return { kind: "none" };
+}
+
+/** The open attention queue, each item with its resolved deep-link target. */
+export function getAttentionQueue(db: Database): AttentionEntry[] {
+  return listOpenAttention(db).map((item) => ({ item, link: resolveLink(db, item) }));
+}
+
+/** GET /api/attention — open attention items with resolved deep-links. */
+export function handleListAttention(db: Database): Response {
+  return new Response(JSON.stringify({ attention: getAttentionQueue(db) }), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}

--- a/src/surface/mc/api/attention.ts
+++ b/src/surface/mc/api/attention.ts
@@ -7,7 +7,9 @@
  *   - sessionId  → its assignment id (sessions.assignment_id) → the drill-down.
  * §7.4 requires every item to deep-link; E.2 already guarantees an open item
  * carries at least one of these targets, so `link.kind` is never "none" for a
- * reconciled item — but the projection tolerates an unresolved link defensively.
+ * reconciled item. `work_item_id`/`session_id` are FK columns with ON DELETE
+ * SET NULL, so each is either a live row or NULL — never a dangling ref — which
+ * is why the label / assignmentId fallbacks below are defensively unreachable.
  */
 import type { Database } from "bun:sqlite";
 import type { AttentionItem } from "../types";

--- a/src/surface/mc/dashboard-v2/app.tsx
+++ b/src/surface/mc/dashboard-v2/app.tsx
@@ -24,6 +24,7 @@ import { RepositoriesView } from "./components/repositories-view";
 import { PlansView } from "./components/plans-view";
 import { PhaseDetailView } from "./components/phase-detail-view";
 import { WorkItemDetailView } from "./components/work-item-detail-view";
+import { AttentionView } from "./components/attention-view";
 import { Toast } from "./components/toast";
 import { useFocusArea } from "./hooks/use-focus-area";
 import { useTasks } from "./hooks/use-tasks";
@@ -33,6 +34,7 @@ import { useLegacyIterations } from "./hooks/use-legacy-iterations";
 import { useRepositories } from "./hooks/use-repositories";
 import { usePlans } from "./hooks/use-plans";
 import { usePhaseDetail } from "./hooks/use-phase-detail";
+import { useAttention } from "./hooks/use-attention";
 import { useWorkItemDetail } from "./hooks/use-work-item-detail";
 import { useTheme } from "./hooks/use-theme";
 import { useWebSocket } from "./hooks/use-websocket";
@@ -56,7 +58,7 @@ import type { Command } from "./components/command-palette";
  * may upgrade to a hash route if deep-linking turns out to be
  * principal-requested; for now the in-memory view is sufficient.
  */
-type DashboardView = "default" | "metrics" | "iterations" | "sources" | "repositories" | "plans" | "phase-detail" | "work-item-detail" | "kanban-detail";
+type DashboardView = "default" | "metrics" | "iterations" | "sources" | "repositories" | "plans" | "phase-detail" | "work-item-detail" | "attention" | "kanban-detail";
 
 export function App() {
   const { theme, toggle: toggleTheme } = useTheme();
@@ -100,9 +102,12 @@ export function App() {
   // G-1113.D.4 — selected phase for the phase-detail surface (reached from the
   // Plans overview by clicking a phase; exited back to `plans`).
   const [selectedPhaseId, setSelectedPhaseId] = useState<string | null>(null);
-  // G-1113.D.5 — selected work item for the work-item-detail surface (reached
-  // from phase-detail by clicking a work item; exited back to `phase-detail`).
+  // G-1113.D.5 — selected work item for the work-item-detail surface.
   const [selectedWorkItemId, setSelectedWorkItemId] = useState<string | null>(null);
+  // G-1113.E.3 — work-item-detail is reachable from TWO surfaces (phase-detail
+  // and the Attention queue); remember which to return to on close so "back"
+  // never lands on a blank phase-detail (no phase selected).
+  const [workItemBackView, setWorkItemBackView] = useState<DashboardView>("phase-detail");
   // G-1113.C.7 — Repositories panel data (fetched only when on its tab).
   const repos = useRepositories(softwareMode && view === "repositories");
   // G-1113.D.3 — Plans overview data (fetched only when on its tab).
@@ -111,16 +116,19 @@ export function App() {
   const phaseDetail = usePhaseDetail(view === "phase-detail" ? selectedPhaseId : null);
   // G-1113.D.5 — work-item-detail data (fetched whenever a work item is selected).
   const workItemDetail = useWorkItemDetail(view === "work-item-detail" ? selectedWorkItemId : null);
+  // G-1113.E.3 — attention queue data (fetched only when on the Attention tab).
+  const attention = useAttention(softwareMode && view === "attention");
   // If software mode is toggled OFF while on a software-mode view (Repositories
-  // / Plans / phase-detail / work-item-detail), the tab + render both gate off —
-  // reset to default so the main area isn't left blank.
+  // / Plans / phase-detail / work-item-detail / attention), the tab + render
+  // both gate off — reset to default so the main area isn't left blank.
   useEffect(() => {
     if (
       !softwareMode &&
       (view === "repositories" ||
         view === "plans" ||
         view === "phase-detail" ||
-        view === "work-item-detail")
+        view === "work-item-detail" ||
+        view === "attention")
     ) {
       setView("default");
     }
@@ -341,6 +349,17 @@ export function App() {
             onClick={() => setView("plans")}
           >
             Plans
+          </button>
+        )}
+        {softwareMode && (
+          <button
+            type="button"
+            role="tab"
+            aria-selected={view === "attention"}
+            className={`tab${view === "attention" ? " active" : ""}`}
+            onClick={() => setView("attention")}
+          >
+            Attention
           </button>
         )}
       </nav>
@@ -650,21 +669,36 @@ export function App() {
             }}
             onOpenWorkItem={(workItemId) => {
               setSelectedWorkItemId(workItemId);
+              setWorkItemBackView("phase-detail");
               setView("work-item-detail");
             }}
           />
         )}
 
         {view === "work-item-detail" && softwareMode && selectedWorkItemId && (
-          /* G-1113.D.5 — work-item detail (reached from a phase-detail work item).
-             Back returns to the phase-detail surface (selectedPhaseId is retained). */
+          /* G-1113.D.5 — work-item detail. Back returns to whichever surface
+             opened it (phase-detail or the Attention queue) — see workItemBackView. */
           <WorkItemDetailView
             detail={workItemDetail.detail}
             loaded={workItemDetail.loaded}
             onClose={() => {
-              setView("phase-detail");
+              setView(workItemBackView);
               setSelectedWorkItemId(null);
             }}
+          />
+        )}
+
+        {view === "attention" && softwareMode && (
+          /* G-1113.E.3 — attention queue surface (deep-links to WI / session). */
+          <AttentionView
+            entries={attention.entries}
+            loaded={attention.loaded}
+            onOpenWorkItem={(workItemId) => {
+              setSelectedWorkItemId(workItemId);
+              setWorkItemBackView("attention");
+              setView("work-item-detail");
+            }}
+            onOpenAssignment={(assignmentId) => setDrillId(assignmentId)}
           />
         )}
       </main>

--- a/src/surface/mc/dashboard-v2/components/attention-view.tsx
+++ b/src/surface/mc/dashboard-v2/components/attention-view.tsx
@@ -1,0 +1,64 @@
+/**
+ * G-1113.E.3 — attention queue surface (design §7.4). Lists open attention
+ * items (severity-ordered by the projection), each deep-linking to the exact
+ * work item (→ work-item-detail) or session (→ drill-down) that needs action.
+ */
+import type { AttentionEntry } from "../../api/attention";
+import type { AttentionKind } from "../../types";
+
+const KIND_LABEL: Record<AttentionKind, string> = {
+  input_needed: "input needed",
+  permission: "permission",
+  review: "review",
+  failed_dispatch: "failed dispatch",
+  stale: "stale",
+  blocked: "blocked",
+};
+
+export interface AttentionViewProps {
+  entries: AttentionEntry[];
+  loaded: boolean;
+  /** Open the work-item-detail surface (E.3 deep-link). */
+  onOpenWorkItem?: (workItemId: string) => void;
+  /** Open the drill-down for an assignment (E.3 deep-link for session items). */
+  onOpenAssignment?: (assignmentId: string) => void;
+}
+
+export function AttentionView({ entries, loaded, onOpenWorkItem, onOpenAssignment }: AttentionViewProps) {
+  return (
+    <section className="scaffold-section attention-view" aria-label="Attention">
+      <h2>
+        Attention {loaded && entries.length > 0 ? <span className="dim">({entries.length})</span> : null}
+      </h2>
+      {!loaded ? (
+        <p className="dim">Loading…</p>
+      ) : entries.length === 0 ? (
+        <p className="dim">Nothing needs your attention.</p>
+      ) : (
+        <ul className="attention-list">
+          {entries.map(({ item, link }) => {
+            const deepLink =
+              link.kind === "work-item" && onOpenWorkItem
+                ? { label: link.label, onClick: () => onOpenWorkItem(link.workItemId) }
+                : link.kind === "session" && link.assignmentId && onOpenAssignment
+                  ? { label: "open session", onClick: () => onOpenAssignment(link.assignmentId as string) }
+                  : null;
+            return (
+              <li key={item.id} className={`attention-item sev-${item.severity}`}>
+                <span className={`badge kind-${item.kind}`}>{KIND_LABEL[item.kind]}</span>
+                <span className={`badge sev-${item.severity}`}>{item.severity}</span>
+                {deepLink ? (
+                  <button type="button" className="attention-link" onClick={deepLink.onClick}>
+                    {deepLink.label}
+                  </button>
+                ) : (
+                  <span className="dim faint">{link.kind === "work-item" ? link.label : "—"}</span>
+                )}
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/src/surface/mc/dashboard-v2/hooks/use-attention.ts
+++ b/src/surface/mc/dashboard-v2/hooks/use-attention.ts
@@ -1,0 +1,42 @@
+/**
+ * G-1113.E.3 — fetch the open attention queue for the Attention surface.
+ * Only fetches when `enabled` (software mode on + Attention tab visible).
+ * Best-effort: a failure yields an empty queue, not an error surface.
+ */
+import { useEffect, useState } from "react";
+import { getJson } from "../lib/api";
+import type { AttentionEntry } from "../../api/attention";
+
+interface AttentionResponse {
+  attention: AttentionEntry[];
+}
+
+export function useAttention(enabled: boolean): { entries: AttentionEntry[]; loaded: boolean } {
+  const [entries, setEntries] = useState<AttentionEntry[]>([]);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    if (!enabled) return;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const res = await getJson<AttentionResponse>("/api/attention");
+        if (!cancelled) {
+          setEntries(res.attention ?? []);
+          setLoaded(true);
+        }
+      } catch (_err) {
+        // Best-effort: the surface shows an empty state rather than an error.
+        if (!cancelled) {
+          setEntries([]);
+          setLoaded(true);
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [enabled]);
+
+  return { entries, loaded };
+}

--- a/src/surface/mc/dashboard-v2/styles/global.css
+++ b/src/surface/mc/dashboard-v2/styles/global.css
@@ -475,6 +475,31 @@ html, body {
 .work-item-detail .review-state.state-commented,
 .work-item-detail .review-state.state-pending,
 .work-item-detail .review-state.state-dismissed { color: var(--fg-dim); }
+
+/* G-1113.E.3 — attention queue surface */
+.attention-view .attention-list { list-style: none; margin: 0; padding: 0; }
+.attention-view .attention-item {
+  display: flex; align-items: center; gap: 8px;
+  padding: 6px 10px; margin-top: 6px; font-size: 12px;
+  border: 1px solid var(--line); border-left-width: 3px; border-radius: 6px;
+  background: var(--panel);
+}
+.attention-view .attention-item.sev-critical { border-left-color: var(--bad); }
+.attention-view .attention-item.sev-high { border-left-color: var(--warn); }
+.attention-view .attention-item.sev-normal { border-left-color: var(--accent); }
+.attention-view .attention-item.sev-low { border-left-color: var(--line); }
+.attention-view .badge {
+  font-size: 10px; font-weight: 600; letter-spacing: 0.04em; text-transform: uppercase;
+  padding: 1px 6px; border-radius: 4px; border: 1px solid var(--line); color: var(--fg-dim);
+}
+.attention-view .badge.sev-critical { color: var(--bad); border-color: color-mix(in oklch, var(--bad) 40%, transparent); }
+.attention-view .badge.sev-high { color: var(--warn); border-color: color-mix(in oklch, var(--warn) 40%, transparent); }
+.attention-view .attention-link {
+  margin-left: auto; padding: 0; border: 0; background: none; font: inherit;
+  color: var(--accent); cursor: pointer; text-align: right;
+}
+.attention-view .attention-link:hover { text-decoration: underline; }
+.attention-view .attention-link:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
 .scaffold-section h2 {
   margin: 0 0 6px 0;
   font-size: 11px; font-weight: 600; letter-spacing: 0.06em;

--- a/src/surface/mc/server.ts
+++ b/src/surface/mc/server.ts
@@ -43,6 +43,7 @@ import { handleListRepositories } from "./api/git-repos";
 import { handleListPlans } from "./api/plans";
 import { handleGetPhaseDetail } from "./api/phase-detail";
 import { handleGetWorkItemDetail } from "./api/work-item-detail";
+import { handleListAttention } from "./api/attention";
 import type { ProcessManager } from "./session/process-manager";
 import type { SpawnFn } from "./session/endpoint-resolver";
 import { join, dirname } from "path";
@@ -451,6 +452,14 @@ async function handleApi(
       });
     }
     return handleGetWorkItemDetail(db, id);
+  }
+
+  // G-1113.E.3 — GET /api/attention — open attention items with deep-links.
+  if (pathname === "/api/attention") {
+    if (req.method !== "GET") {
+      return methodNotAllowed(["GET"]);
+    }
+    return handleListAttention(db);
   }
 
   if (pathname === "/api/tasks") {


### PR DESCRIPTION
## G-1113.E.3 — attention queue UI surface

A software-mode **Attention** tab listing the open attention queue (E.2 producers), each item deep-linking to the exact target that needs action — the §7.4 deliverable.

### What's here
- **`api/attention.ts`** — `getAttentionQueue` + `GET /api/attention`: open items (severity-ordered by `db/attention`) each with a **resolved deep-link**: `workItemId` → work-item title (→ the work-item-detail surface, D.5); `sessionId` → its `assignment_id` (→ the drill-down). The `work_item_id` FK guarantees a link is a real work item or NULL — a dangling ref can't exist — so the id-fallback is defensive/unreachable (noted in the test).
- **dashboard-v2** — `use-attention` hook, `attention-view` (kind + severity badges, severity-tinted rows, deep-link buttons), `app.tsx` Attention tab + render + reset effect.
- **nav fix**: `work-item-detail` is now reachable from **two** surfaces (phase-detail and Attention), so it tracks a **return view** (`workItemBackView`) — "back" returns to whichever opened it, never a blank phase-detail.
- **`__tests__/attention-queue.test.ts`** — work-item + session link resolution, open-only severity ordering, `{ attention }` envelope.

### Verification
- `bunx tsc --noEmit` clean · `bun run lint` 0 errors · carve-out gate PASS · `bun test src/surface/mc` 1259 pass / 0 fail · `bun run build:dashboard` bundles · merge-guard clean

Closes #607. Part of #604 / #354. (E.4 — notification routing — is the last slice.)