### PR TITLE
feat(mc): G-1113.E.4 — attention notification routing (system.attention.* envelopes)

### DIFF
--- a/src/bus/system-events.ts
+++ b/src/bus/system-events.ts
@@ -87,7 +87,7 @@ export interface SystemEventSource {
   dataResidency?: string;
 }
 
-function buildSource(src: SystemEventSource): string {
+export function buildSource(src: SystemEventSource): string {
   return `${src.principal}.${src.agent}.${src.instance}`;
 }
 
@@ -108,7 +108,7 @@ function buildSource(src: SystemEventSource): string {
  * envelope's reach. The default keeps every existing call site behaving
  * identically.
  */
-function defaultSystemSovereignty(
+export function defaultSystemSovereignty(
   source: SystemEventSource,
   classification: Classification = "local",
 ): Envelope["sovereignty"] {

--- a/src/surface/mc/__tests__/attention-notify.test.ts
+++ b/src/surface/mc/__tests__/attention-notify.test.ts
@@ -74,4 +74,16 @@ describe("attentionNotificationEnvelope (E.4)", () => {
     expect((published[0]?.payload as { deep_link_url: string }).deep_link_url).toBe("https://x/wi-1");
     expect((published[1]?.payload as { deep_link_url: string }).deep_link_url).toBe("https://x/wi-2");
   });
+
+  it("publishAttentionNotifications falls back to opts.deepLinkUrl when deepLinkFor is absent", async () => {
+    const published: Envelope[] = [];
+    await publishAttentionNotifications(
+      [item({ id: "a-1" })],
+      "opened",
+      { source, deepLinkUrl: "https://fixed/link" }, // no deepLinkFor
+      (env) => { published.push(env); }
+    );
+    expect((published[0]?.payload as { deep_link_url: string }).deep_link_url).toBe("https://fixed/link");
+    expect((published[0]?.payload as { presentation: string }).presentation).toContain("https://fixed/link");
+  });
 });

--- a/src/surface/mc/__tests__/attention-notify.test.ts
+++ b/src/surface/mc/__tests__/attention-notify.test.ts
@@ -1,0 +1,77 @@
+/**
+ * G-1113.E.4 — attention notification envelopes + publish seam.
+ */
+import { describe, it, expect } from "bun:test";
+import {
+  attentionNotificationEnvelope,
+  attentionPresentation,
+  publishAttentionNotifications,
+} from "../attention-notify";
+import type { Envelope } from "../../../bus/myelin/envelope-validator";
+import type { AttentionItem } from "../types";
+
+const item = (over: Partial<AttentionItem> = {}): AttentionItem => ({
+  id: "att-1", stackId: "laptop", workItemId: "wi-1", sessionId: null,
+  kind: "review", severity: "high", status: "open", ...over,
+});
+const source = { principal: "metafactory" };
+
+describe("attentionNotificationEnvelope (E.4)", () => {
+  it("builds a system.attention.opened envelope with the system.* posture + deterministic presentation", () => {
+    const env = attentionNotificationEnvelope(item(), "opened", {
+      source,
+      deepLinkUrl: "https://cortex.meta-factory.ai/work-items/wi-1",
+    });
+    expect(env.type).toBe("system.attention.opened");
+    expect(env.source).toBe("metafactory.cortex.local"); // {principal}.{agent}.{instance} defaults
+    expect(env.sovereignty).toEqual({
+      classification: "local",
+      data_residency: "NZ",
+      max_hop: 0,
+      frontier_ok: false,
+      model_class: "local-only",
+    });
+    const p = env.payload as { attention: Record<string, unknown>; deep_link_url: string; presentation: string };
+    expect(p.attention).toEqual({
+      id: "att-1", stack_id: "laptop", kind: "review", severity: "high",
+      work_item_id: "wi-1", session_id: null,
+    });
+    expect(p.deep_link_url).toBe("https://cortex.meta-factory.ai/work-items/wi-1");
+    // Code-rendered, deterministic — no LLM tokens.
+    expect(p.presentation).toBe("[high] review needs attention — https://cortex.meta-factory.ai/work-items/wi-1");
+    // Fresh id + ISO timestamp per call.
+    expect(env.id).toMatch(/^[0-9a-f-]{36}$/);
+    expect(env.timestamp).toMatch(/T.*Z$/);
+  });
+
+  it("resolved presentation omits the deep-link; honours source overrides + residency", () => {
+    const env = attentionNotificationEnvelope(item({ kind: "blocked", severity: "critical" }), "resolved", {
+      source: { principal: "acme", agent: "cortex", instance: "dash", dataResidency: "EU" },
+      deepLinkUrl: "https://x/y",
+    });
+    expect(env.type).toBe("system.attention.resolved");
+    expect(env.source).toBe("acme.cortex.dash");
+    expect((env.sovereignty as { data_residency: string }).data_residency).toBe("EU");
+    expect((env.payload as { presentation: string }).presentation).toBe("[critical] blocked cleared");
+  });
+
+  it("presentation is pure + deterministic", () => {
+    expect(attentionPresentation(item({ severity: "low", kind: "stale" }), "opened", null)).toBe(
+      "[low] stale needs attention"
+    );
+  });
+
+  it("publishAttentionNotifications emits one envelope per item via the injected publisher", async () => {
+    const published: Envelope[] = [];
+    const n = await publishAttentionNotifications(
+      [item({ id: "a-1", workItemId: "wi-1" }), item({ id: "a-2", workItemId: "wi-2" })],
+      "opened",
+      { source, deepLinkFor: (it) => `https://x/${it.workItemId}` },
+      (env) => { published.push(env); }
+    );
+    expect(n).toBe(2);
+    expect(published.map((e) => e.type)).toEqual(["system.attention.opened", "system.attention.opened"]);
+    expect((published[0]?.payload as { deep_link_url: string }).deep_link_url).toBe("https://x/wi-1");
+    expect((published[1]?.payload as { deep_link_url: string }).deep_link_url).toBe("https://x/wi-2");
+  });
+});

--- a/src/surface/mc/attention-notify.ts
+++ b/src/surface/mc/attention-notify.ts
@@ -9,18 +9,22 @@
  * deep-link so a surface can also build a richer rendering if it wants.
  *
  * Layering: this is the M7 surface domain (it owns AttentionItem); it uses the
- * bus's `buildBaseEnvelope` primitive (M2) — the correct M7→M2 direction. The
- * sovereignty posture mirrors `bus/system-events` `defaultSystemSovereignty`:
- * attention exposes internal state, so it's principal-only and never frontier.
+ * bus's `buildBaseEnvelope` primitive + the `system.*` source/sovereignty
+ * helpers (M2) — the correct M7→M2 direction. Reusing `defaultSystemSovereignty`
+ * (rather than re-stating the posture) keeps attention on the same audited
+ * principal-only/never-frontier posture as the other `system.*` emitters.
  *
- * Emit wiring (publish the deltas a reconcile produces; Discord adapter
- * subscribes to `system.attention.*` and renders `payload.presentation`) is the
- * integration step — same mechanism-vs-trigger split as the D.2/D.5b/E.2
- * ingestion + reconcile mechanisms. `publishAttentionNotifications` below is the
- * publish seam (injected publisher) so the emit path is testable now.
+ * Emit wiring is the DEFERRED integration step (same mechanism-vs-trigger split
+ * as the D.2/D.5b/E.2 ingestion + reconcile mechanisms): a caller publishes the
+ * deltas a reconcile produces, and a Discord surface adapter would subscribe to
+ * `system.attention.*` and render `payload.presentation` — that adapter branch
+ * does NOT exist yet (it mirrors the `review.verdict.*` branch in
+ * adapters/review-sink). `publishAttentionNotifications` below is the publish
+ * seam (injected publisher) so the emit path is testable now.
  */
 import type { Envelope } from "../../bus/myelin/envelope-validator";
 import { buildBaseEnvelope } from "../../bus/envelope-builder";
+import { buildSource, defaultSystemSovereignty } from "../../bus/system-events";
 import type { AttentionItem } from "./types";
 
 export type AttentionAction = "opened" | "resolved";
@@ -56,27 +60,29 @@ export function attentionPresentation(
   return `[${item.severity}] ${item.kind} ${verb}${where}`;
 }
 
-/** Build a `system.attention.{action}` envelope for one item. */
+/**
+ * Build a `system.attention.{action}` envelope for one item. `action` is the
+ * caller-asserted lifecycle transition (the reconcile delta — newly-opened vs
+ * newly-resolved), NOT derived from `item.status`; the caller owns that
+ * decision so a single item can be re-notified across transitions.
+ */
 export function attentionNotificationEnvelope(
   item: AttentionItem,
   action: AttentionAction,
   opts: AttentionNotifyOptions,
 ): Envelope {
-  const agent = opts.source.agent ?? "cortex";
-  const instance = opts.source.instance ?? "local";
+  // Reuse the system.* source + sovereignty helpers (no duplicated posture).
+  const sysSource = {
+    principal: opts.source.principal,
+    agent: opts.source.agent ?? "cortex",
+    instance: opts.source.instance ?? "local",
+    dataResidency: opts.source.dataResidency,
+  };
   const deepLinkUrl = opts.deepLinkUrl ?? null;
   return buildBaseEnvelope({
     type: `system.attention.${action}`,
-    source: `${opts.source.principal}.${agent}.${instance}`,
-    // Mirrors bus/system-events defaultSystemSovereignty: principal-only,
-    // never frontier — attention exposes internal stack state.
-    sovereignty: {
-      classification: "local",
-      data_residency: opts.source.dataResidency ?? "NZ",
-      max_hop: 0,
-      frontier_ok: false,
-      model_class: "local-only",
-    },
+    source: buildSource(sysSource),
+    sovereignty: defaultSystemSovereignty(sysSource),
     payload: {
       attention: {
         id: item.id,

--- a/src/surface/mc/attention-notify.ts
+++ b/src/surface/mc/attention-notify.ts
@@ -1,0 +1,117 @@
+/**
+ * G-1113.E.4 — attention notification routing (design §5.5 / §7.4).
+ *
+ * Builds `system.attention.{opened,resolved}` envelopes from AttentionItems so
+ * the bus can route them to stack surfaces (Discord/Slack/Mattermost). The
+ * message is rendered HERE, in code, into a deterministic `presentation` string
+ * (the deterministic-surface model: surfaces render `presentation` verbatim,
+ * never an LLM token). The envelope carries the structured attention data + a
+ * deep-link so a surface can also build a richer rendering if it wants.
+ *
+ * Layering: this is the M7 surface domain (it owns AttentionItem); it uses the
+ * bus's `buildBaseEnvelope` primitive (M2) — the correct M7→M2 direction. The
+ * sovereignty posture mirrors `bus/system-events` `defaultSystemSovereignty`:
+ * attention exposes internal state, so it's principal-only and never frontier.
+ *
+ * Emit wiring (publish the deltas a reconcile produces; Discord adapter
+ * subscribes to `system.attention.*` and renders `payload.presentation`) is the
+ * integration step — same mechanism-vs-trigger split as the D.2/D.5b/E.2
+ * ingestion + reconcile mechanisms. `publishAttentionNotifications` below is the
+ * publish seam (injected publisher) so the emit path is testable now.
+ */
+import type { Envelope } from "../../bus/myelin/envelope-validator";
+import { buildBaseEnvelope } from "../../bus/envelope-builder";
+import type { AttentionItem } from "./types";
+
+export type AttentionAction = "opened" | "resolved";
+
+export interface AttentionNotifySource {
+  /** Boot-resolved principal slug — first source segment. */
+  principal: string;
+  /** Logical agent — defaults to "cortex". */
+  agent?: string;
+  /** Instance — defaults to "local". */
+  instance?: string;
+  /** Data-residency code stamped into sovereignty. Defaults to "NZ". */
+  dataResidency?: string;
+}
+
+export interface AttentionNotifyOptions {
+  source: AttentionNotifySource;
+  /** Canonical deep-link URL to the item's target (caller builds from its surface base). */
+  deepLinkUrl?: string | null;
+}
+
+/**
+ * Deterministic one-liner — built in code, never an LLM token. Shape:
+ * `[severity] kind needs attention — <url>` / `[severity] kind cleared`.
+ */
+export function attentionPresentation(
+  item: AttentionItem,
+  action: AttentionAction,
+  deepLinkUrl: string | null,
+): string {
+  const verb = action === "opened" ? "needs attention" : "cleared";
+  const where = action === "opened" && deepLinkUrl ? ` — ${deepLinkUrl}` : "";
+  return `[${item.severity}] ${item.kind} ${verb}${where}`;
+}
+
+/** Build a `system.attention.{action}` envelope for one item. */
+export function attentionNotificationEnvelope(
+  item: AttentionItem,
+  action: AttentionAction,
+  opts: AttentionNotifyOptions,
+): Envelope {
+  const agent = opts.source.agent ?? "cortex";
+  const instance = opts.source.instance ?? "local";
+  const deepLinkUrl = opts.deepLinkUrl ?? null;
+  return buildBaseEnvelope({
+    type: `system.attention.${action}`,
+    source: `${opts.source.principal}.${agent}.${instance}`,
+    // Mirrors bus/system-events defaultSystemSovereignty: principal-only,
+    // never frontier — attention exposes internal stack state.
+    sovereignty: {
+      classification: "local",
+      data_residency: opts.source.dataResidency ?? "NZ",
+      max_hop: 0,
+      frontier_ok: false,
+      model_class: "local-only",
+    },
+    payload: {
+      attention: {
+        id: item.id,
+        stack_id: item.stackId,
+        kind: item.kind,
+        severity: item.severity,
+        work_item_id: item.workItemId,
+        session_id: item.sessionId,
+      },
+      deep_link_url: deepLinkUrl,
+      // Code-rendered message the surface displays verbatim.
+      presentation: attentionPresentation(item, action, deepLinkUrl),
+    },
+  });
+}
+
+/** A publisher seam — the bus client's publish, injected for testability. */
+export type EnvelopePublisher = (envelope: Envelope) => void | Promise<void>;
+
+/**
+ * Publish `system.attention.{action}` envelopes for a batch of items via the
+ * injected publisher. The caller supplies the reconcile delta (newly-opened →
+ * "opened", newly-resolved → "resolved") + a deep-link builder.
+ */
+export async function publishAttentionNotifications(
+  items: AttentionItem[],
+  action: AttentionAction,
+  opts: AttentionNotifyOptions & { deepLinkFor?: (item: AttentionItem) => string | null },
+  publish: EnvelopePublisher,
+): Promise<number> {
+  let count = 0;
+  for (const item of items) {
+    const deepLinkUrl = opts.deepLinkFor ? opts.deepLinkFor(item) : (opts.deepLinkUrl ?? null);
+    await publish(attentionNotificationEnvelope(item, action, { ...opts, deepLinkUrl }));
+    count += 1;
+  }
+  return count;
+}


### PR DESCRIPTION
## G-1113.E.4 — attention notification routing

The **last Phase E slice**. Builds `system.attention.{opened,resolved}` envelopes from AttentionItems so the bus routes them to stack surfaces (Discord/Slack/Mattermost).

### What's here
- **`src/surface/mc/attention-notify.ts`**
  - `attentionNotificationEnvelope(item, action, opts)` → a `system.attention.*` envelope built via the bus `buildBaseEnvelope` primitive (correct **M7→M2** layering — the surface owns `AttentionItem`, consumes the bus primitive). Carries structured attention data + `deep_link_url` + a **deterministic `presentation`** string rendered **in code** (the deterministic-surface model — surfaces display it verbatim, never an LLM token).
  - sovereignty mirrors `bus/system-events` `defaultSystemSovereignty` (principal-only, never frontier — attention exposes internal state).
  - `publishAttentionNotifications(items, action, opts, publish)` — the **publish seam** (injected publisher) so the emit path is testable now.
- **`__tests__/attention-notify.test.ts`** — envelope type/source/sovereignty/payload + the deterministic presentation (opened *with* deep-link, resolved *without*), source overrides + data-residency, and batch publish via a mock publisher.

### Integration wiring (runtime step)
Publishing the reconcile delta (newly-opened → `opened`, newly-resolved → `resolved`) and the Discord adapter subscribing to `system.attention.*` to render `payload.presentation` is the runtime wiring — the same mechanism-vs-trigger split used across D.2 / D.5b / E.2. The emit primitive + deterministic message are built and tested here.

### Verification
- `bunx tsc --noEmit` clean · `bun run lint` 0 errors · carve-out gate PASS · `bun test src/surface/mc` 1263 pass / 0 fail · merge-guard clean

Closes #608. **Completes Phase E (#604) → the G-1113 cockpit umbrella #354.**