### PR TITLE
feat(gateway): GW.a.3d — outbound reply round-trip (reuse createDispatchSink over gateway adapters)

### DIFF
--- a/src/adapters/__tests__/dispatch-sink.test.ts
+++ b/src/adapters/__tests__/dispatch-sink.test.ts
@@ -324,3 +324,154 @@ describe("dispatch-sink — no-routing and non-lifecycle envelopes", () => {
     expect(adapter.sentMessages).toHaveLength(1);
   });
 });
+
+// =============================================================================
+// a.3d (cortex#524) — multi-stack `stacks` option (shared surface gateway)
+// =============================================================================
+
+describe("dispatch-sink — gateway multi-stack subscription (a.3d)", () => {
+  test("`stacks` builds one distinct lifecycle subject per bound stack", async () => {
+    const { runtime, subscribedPatterns } = fakeRuntime();
+    const sink = createDispatchSink({
+      runtime,
+      adapters: [],
+      principal: "andreas",
+      stacks: ["meta-factory", "research"],
+    });
+    await sink.start();
+    expect(sink.subjects).toEqual([
+      "local.andreas.meta-factory.dispatch.task.>",
+      "local.andreas.research.dispatch.task.>",
+    ]);
+    expect(subscribedPatterns).toEqual([...sink.subjects]);
+  });
+
+  test("`undefined` stack entry → the 5-segment legacy subject (gap-4 binding)", async () => {
+    const { runtime } = fakeRuntime();
+    const sink = createDispatchSink({
+      runtime,
+      adapters: [],
+      principal: "andreas",
+      stacks: ["meta-factory", undefined],
+    });
+    await sink.start();
+    expect(sink.subjects).toEqual([
+      "local.andreas.meta-factory.dispatch.task.>",
+      "local.andreas.dispatch.task.>",
+    ]);
+  });
+
+  test("duplicate stacks collapse to one subject each (incl. duplicate undefined)", async () => {
+    const { runtime } = fakeRuntime();
+    const sink = createDispatchSink({
+      runtime,
+      adapters: [],
+      principal: "andreas",
+      stacks: ["a", "a", undefined, undefined, "b"],
+    });
+    await sink.start();
+    expect(sink.subjects).toEqual([
+      "local.andreas.a.dispatch.task.>",
+      "local.andreas.dispatch.task.>",
+      "local.andreas.b.dispatch.task.>",
+    ]);
+  });
+
+  test("`stacks` (non-empty) takes precedence over a single `stack`", async () => {
+    const { runtime } = fakeRuntime();
+    const sink = createDispatchSink({
+      runtime,
+      adapters: [],
+      principal: "andreas",
+      stack: "ignored-single",
+      stacks: ["meta-factory"],
+    });
+    await sink.start();
+    expect(sink.subjects).toEqual([
+      "local.andreas.meta-factory.dispatch.task.>",
+    ]);
+  });
+
+  test("EMPTY `stacks: []` falls back to the single `stack` (no silent zero-subscribe)", async () => {
+    const { runtime, subscribedPatterns } = fakeRuntime();
+    const sink = createDispatchSink({
+      runtime,
+      adapters: [],
+      principal: "andreas",
+      stack: "fallback-stack",
+      stacks: [],
+    });
+    await sink.start();
+    // The guard is `stacks.length > 0`; an empty array must NOT yield zero
+    // subjects (which would silently drop every reply) — it falls back to
+    // the single-stack subject.
+    expect(sink.subjects).toEqual([
+      "local.andreas.fallback-stack.dispatch.task.>",
+    ]);
+    expect(subscribedPatterns).toEqual([...sink.subjects]);
+  });
+
+  test("delivers across bound stacks, keyed by adapter_instance, with no cross-posting", async () => {
+    const { runtime, trigger } = fakeRuntime();
+    // Two gateway adapters (one per bound stack), plus a THIRD instance that
+    // the gateway does NOT own — proves the adapter_instance filter is the
+    // sole delivery gate even with a broad multi-stack subscription.
+    const adapterA = new MockAdapter("discord:guild-A");
+    const adapterB = new MockAdapter("discord:guild-B");
+    const sink = createDispatchSink({
+      runtime,
+      adapters: [adapterA, adapterB],
+      principal: "andreas",
+      stacks: ["meta-factory", "research"],
+    });
+    await sink.start();
+
+    // A `started` event for stack `meta-factory`, routed to gateway adapter A
+    // → progress/typing indicator (sendProgress), NOT a durable postResponse.
+    trigger(
+      lifecycleEnvelope("dispatch.task.started", {
+        agent_id: "luna",
+        started_at: "2026-05-09T12:00:00Z",
+        response_routing: routing("discord:guild-A", "C-A"),
+      }),
+    );
+    // Reply for stack `research`, routed to gateway adapter B.
+    trigger(
+      lifecycleEnvelope("dispatch.task.completed", {
+        agent_id: "ivy",
+        chat_response: "research reply",
+        response_routing: routing("discord:guild-B", "C-B", "T-B"),
+      }),
+    );
+    // Reply routed to an instance the gateway does NOT own → ignored.
+    trigger(
+      lifecycleEnvelope("dispatch.task.completed", {
+        agent_id: "luna",
+        chat_response: "not ours",
+        response_routing: routing("discord:guild-OTHER", "C-X"),
+      }),
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // Only adapter B posted the terminal reply; A never cross-posts another
+    // instance's reply.
+    expect(adapterB.sentMessages).toHaveLength(1);
+    expect(adapterB.sentMessages[0]!.text).toBe("research reply");
+    expect(adapterB.sentMessages[0]!.target).toEqual({
+      instanceId: "discord:guild-B",
+      channelId: "C-B",
+      threadId: "T-B",
+    });
+    expect(adapterA.sentMessages).toHaveLength(0);
+    // The `started` event went to adapter A as a progress indicator, keyed by
+    // its own instance — proving the started→sendProgress path works over the
+    // multi-stack subscription and stays instance-scoped.
+    expect(adapterA.progressSent).toHaveLength(1);
+    expect(adapterA.progressSent[0]!.target).toEqual({
+      instanceId: "discord:guild-A",
+      channelId: "C-A",
+    });
+    expect(adapterB.progressSent).toHaveLength(0);
+  });
+});

--- a/src/adapters/dispatch-sink.ts
+++ b/src/adapters/dispatch-sink.ts
@@ -99,6 +99,21 @@ export interface DispatchSinkOptions {
    * (the 6-segment grammar), the subscribe pattern must carry it too.
    */
   stack?: string;
+  /**
+   * a.3d (cortex#524) — MULTIPLE `{stack}` segments. The shared surface
+   * gateway serves many bound stacks under ONE principal, so its outbound
+   * sink must subscribe to every bound stack's lifecycle subject, not just
+   * one. When provided and non-empty, `stacks` takes precedence over `stack`:
+   * one subscribe subject is built per DISTINCT entry. An `undefined` entry
+   * maps to the 5-segment legacy subject (`local.{principal}.dispatch.task.>`)
+   * — the shape a gap-4 binding with no `stack` field publishes on.
+   *
+   * Single-stack callers (the per-stack `cortex.ts` wiring) keep passing
+   * `stack`. Regardless of subject count there is still exactly ONE
+   * `onEnvelope` handler, so multiple subjects never double-deliver an
+   * envelope; the `adapter_instance` filter remains the sole delivery gate.
+   */
+  stacks?: readonly (string | undefined)[];
 }
 
 export interface DispatchSink {
@@ -126,6 +141,32 @@ function lifecycleSubject(principal: string, stack?: string): string {
 }
 
 /**
+ * De-duplicate a `(string | undefined)[]` of stack tokens, preserving order.
+ * `undefined` (the gap-4 / 5-segment case) is its own single bucket, tracked
+ * with a boolean so it never collides with any real stack name. Used to fold
+ * the gateway's per-binding stacks into one subscribe-subject set.
+ */
+function distinctStacks(
+  stacks: readonly (string | undefined)[],
+): (string | undefined)[] {
+  const seen = new Set<string>();
+  let sawUndefined = false;
+  const out: (string | undefined)[] = [];
+  for (const s of stacks) {
+    if (s === undefined) {
+      if (sawUndefined) continue;
+      sawUndefined = true;
+      out.push(undefined);
+      continue;
+    }
+    if (seen.has(s)) continue;
+    seen.add(s);
+    out.push(s);
+  }
+  return out;
+}
+
+/**
  * Create a dispatch sink. Wires nothing until `start()` is called.
  */
 export function createDispatchSink(opts: DispatchSinkOptions): DispatchSink {
@@ -134,7 +175,13 @@ export function createDispatchSink(opts: DispatchSinkOptions): DispatchSink {
   const adapterByInstance = new Map<string, PlatformAdapter>(
     adapters.map((a) => [a.instanceId, a]),
   );
-  const subjects = [lifecycleSubject(principal, stack)];
+  // a.3d — `stacks` (gateway multi-stack) takes precedence over the single
+  // `stack` when present: one subscribe subject per distinct bound stack.
+  // Otherwise the single-stack (per-stack caller) path is unchanged.
+  const subjects =
+    opts.stacks !== undefined && opts.stacks.length > 0
+      ? distinctStacks(opts.stacks).map((s) => lifecycleSubject(principal, s))
+      : [lifecycleSubject(principal, stack)];
 
   let registration: { unregister: () => void } | null = null;
   let subscribers: MyelinSubscriber[] = [];

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -2239,7 +2239,7 @@ export async function startCortex(
   // ALSO set does it run LIVE (BusInboundSink — publishing to the bus). This is
   // purely additive — it does not touch, reorder, or risk the existing
   // adapter-construction flow.
-  const gw: SurfaceGateway | undefined = await startGatewayIfEnabled({
+  const startedGateway = await startGatewayIfEnabled({
     env: process.env,
     surfaces: options.surfaces,
     principal: principalId,
@@ -2251,6 +2251,59 @@ export async function startCortex(
     source: systemEventSource,
     policyEngine: adapterPolicyEngine,
   });
+  const gw: SurfaceGateway | undefined = startedGateway?.gateway;
+
+  // a.3d (cortex#524) — gateway OUTBOUND reply round-trip. Reuse the per-stack
+  // `createDispatchSink` (cortex#491) over the GATEWAY's own adapters instead
+  // of building a second mux. The sink subscribes to every bound stack's
+  // lifecycle subject (`stacks` derived from the surface bindings) and posts
+  // each reply back to the exact originating channel/thread via the gateway
+  // adapter named by the envelope's echoed `response_routing.adapter_instance`.
+  //
+  // Coexists safely with the per-stack dispatch sink wired above: both register
+  // an `onEnvelope` handler on the SAME runtime, but the `adapter_instance`
+  // filter keys off disjoint adapter-instance sets (gateway adapters vs the
+  // per-stack `adapters[]`), so any one lifecycle envelope is delivered by at
+  // most one sink — never double-replied. Idle in SHADOW (no inbound published
+  // → nothing routes to the gateway adapters); active once the gateway is LIVE.
+  //
+  // a.3d review: that no-double-reply / no-wrong-channel safety RESTS on the
+  // instance-id sets being disjoint. The gateway-owned-surface suppression
+  // (GW.a.3b.2c) already keeps gateway-owned surfaces out of `adapters[]`, but
+  // a per-stack adapter whose `instanceId` is hand-set to the gateway's
+  // `{platform}:{demuxKey}` form would collide and let one envelope post to two
+  // channels. Assert disjointness LOUDLY at boot rather than trust convention.
+  if (startedGateway !== undefined) {
+    const perStackInstances = new Set(adapters.map((a) => a.instanceId));
+    const collisions = startedGateway.adapters
+      .map((a) => a.instanceId)
+      .filter((id) => perStackInstances.has(id));
+    if (collisions.length > 0) {
+      throw new Error(
+        `cortex: gateway adapter instanceId(s) ${collisions.map((c) => `"${c}"`).join(", ")} ` +
+          `collide with per-stack adapter instanceId(s). The gateway and per-stack ` +
+          `dispatch sinks share one runtime and route by instanceId, so a collision ` +
+          `would deliver one reply through both — posting to two channels. Ensure no ` +
+          `per-stack adapter sets its instanceId to the gateway's "{platform}:{demuxKey}" form.`,
+      );
+    }
+  }
+
+  const gatewayDispatchSink: DispatchSink | undefined = startedGateway
+    ? createDispatchSink({
+        runtime,
+        adapters: startedGateway.adapters,
+        principal: principalId,
+        stacks: startedGateway.stacks,
+      })
+    : undefined;
+  if (gatewayDispatchSink !== undefined) {
+    await gatewayDispatchSink.start();
+    console.log(
+      `cortex: gateway dispatch-sink started — subjects=[${gatewayDispatchSink.subjects.join(", ")}], ` +
+        `adapters=${startedGateway?.adapters.length ?? 0}`,
+    );
+  }
 
   // Shutdown — reverse-order; capped at SHUTDOWN_TIMEOUT_MS.
   //
@@ -2288,6 +2341,10 @@ export async function startCortex(
       "dispatch-listener stop",
       "dispatch-sink stop",
       "review-sink stop",
+      // a.3d (cortex#524) — gateway outbound dispatch sink; `undefined` on a
+      // dormant (default) stack, in which case the drain step is a no-op and
+      // this slot self-completes immediately.
+      "gateway-dispatch-sink stop",
       // IAW GW (cortex#524) — only present when the flag-gated gateway started;
       // `gw` is `undefined` on every dormant (default) stack, in which case the
       // drain step below is a no-op and this slot self-completes immediately.
@@ -2353,6 +2410,15 @@ export async function startCortex(
       // surface-router / adapters close, so no late `postResponse` lands
       // after the platform connections close. `stop()` is idempotent.
       await completeAsync("review-sink stop", reviewSink.stop());
+      // a.3d (cortex#524) — drain the gateway outbound dispatch sink BEFORE the
+      // gateway's own adapters close (surface-gateway stop, below), mirroring
+      // the per-stack dispatch-sink boundary so no late `postResponse` lands
+      // after the gateway's platform connections close. `stop()` is idempotent;
+      // `undefined` on a dormant stack → no-op.
+      await completeAsync(
+        "gateway-dispatch-sink stop",
+        gatewayDispatchSink?.stop(),
+      );
       // IAW GW (cortex#524) — stop the shared surface gateway (its own
       // adapter connections, separate from the per-stack `adapters[]`) on the
       // same boundary as the sinks: after the runner stops publishing but

--- a/src/gateway/__tests__/binding-resolver.test.ts
+++ b/src/gateway/__tests__/binding-resolver.test.ts
@@ -19,6 +19,8 @@ import { describe, expect, test } from "bun:test";
 import {
   buildBindingIndex,
   resolveBinding,
+  distinctBoundStacks,
+  crossPrincipalBindings,
   type GatewayBindingIndex,
   type GatewayBindingMatch,
 } from "../binding-resolver";
@@ -489,5 +491,160 @@ describe("stack-parsing — degenerate inputs collapse to undefined", () => {
     expect(match).not.toBeNull();
     expect(match!.principal).toBeUndefined();
     expect(match!.stack).toBeUndefined();
+  });
+});
+
+// ─── 13. distinctBoundStacks (a.3d outbound subjects) ─────────────────────────
+
+describe("distinctBoundStacks — gateway outbound subject derivation", () => {
+  test("single binding → its parsed stack leaf", () => {
+    expect(distinctBoundStacks(DISCORD_SURFACES)).toEqual(["meta-factory"]);
+  });
+
+  test("distinct stacks across platforms, deduped, in iteration order", () => {
+    const surfaces: Surfaces = {
+      discord: [
+        {
+          agent: "luna",
+          stack: "andreas/meta-factory",
+          binding: { token: "t1", guildId: "G1", agentChannelId: "a", logChannelId: "b" },
+        },
+        {
+          agent: "ivy",
+          stack: "andreas/research",
+          binding: { token: "t2", guildId: "G2", agentChannelId: "c", logChannelId: "d" },
+        },
+      ],
+      slack: [
+        {
+          agent: "luna",
+          // same leaf as the first discord binding → collapses to one entry
+          stack: "andreas/meta-factory",
+          binding: { botToken: "xoxb", appToken: "xapp", workspaceId: "W1" },
+        },
+      ],
+      mattermost: [
+        {
+          agent: "forge",
+          // a third, mattermost-only leaf → exercises the mattermost loop
+          stack: "andreas/ops",
+          binding: { apiUrl: "https://mm.example.com", apiToken: "mm-tok" },
+        },
+      ],
+    };
+    expect(distinctBoundStacks(surfaces)).toEqual([
+      "meta-factory",
+      "research",
+      "ops",
+    ]);
+  });
+
+  test("gap-4 binding (no stack field) → a single `undefined` entry", () => {
+    const noStack: Surfaces = {
+      discord: [
+        {
+          agent: "luna",
+          // no `stack:` — gap 4
+          binding: { token: "t", guildId: "G", agentChannelId: "a", logChannelId: "b" },
+        },
+      ],
+    };
+    expect(distinctBoundStacks(noStack)).toEqual([undefined]);
+  });
+
+  test("mixed stacked + gap-4 bindings → leaf plus one undefined", () => {
+    const mixed: Surfaces = {
+      discord: [
+        {
+          agent: "luna",
+          stack: "andreas/meta-factory",
+          binding: { token: "t1", guildId: "G1", agentChannelId: "a", logChannelId: "b" },
+        },
+        {
+          agent: "ivy",
+          binding: { token: "t2", guildId: "G2", agentChannelId: "c", logChannelId: "d" },
+        },
+      ],
+    };
+    expect(distinctBoundStacks(mixed)).toEqual(["meta-factory", undefined]);
+  });
+
+  test("no bindings → empty list", () => {
+    expect(distinctBoundStacks({})).toEqual([]);
+  });
+});
+
+// ─── 14. crossPrincipalBindings (single-principal v1 enforcement) ──────────────
+
+describe("crossPrincipalBindings — single-principal v1 guard", () => {
+  test("all bindings under the gateway principal → no offenders", () => {
+    const surfaces: Surfaces = {
+      discord: [
+        {
+          agent: "luna",
+          stack: "andreas/meta-factory",
+          binding: { token: "t1", guildId: "G1", agentChannelId: "a", logChannelId: "b" },
+        },
+      ],
+      slack: [
+        {
+          agent: "ivy",
+          stack: "andreas/research",
+          binding: { botToken: "xoxb", appToken: "xapp", workspaceId: "W1" },
+        },
+      ],
+    };
+    expect(crossPrincipalBindings(surfaces, "andreas")).toEqual([]);
+  });
+
+  test("a binding under another principal → flagged (across all platforms)", () => {
+    const surfaces: Surfaces = {
+      discord: [
+        {
+          agent: "luna",
+          stack: "andreas/meta-factory",
+          binding: { token: "t1", guildId: "G1", agentChannelId: "a", logChannelId: "b" },
+        },
+      ],
+      mattermost: [
+        {
+          agent: "forge",
+          stack: "someone-else/ops",
+          binding: { apiUrl: "https://mm.example.com", apiToken: "mm-tok" },
+        },
+      ],
+    };
+    expect(crossPrincipalBindings(surfaces, "andreas")).toEqual(["someone-else/ops"]);
+  });
+
+  test("gap-4 binding (no stack / no principal) is never flagged", () => {
+    const surfaces: Surfaces = {
+      discord: [
+        {
+          agent: "luna",
+          // no stack → no principal → cannot be cross-principal
+          binding: { token: "t", guildId: "G", agentChannelId: "a", logChannelId: "b" },
+        },
+      ],
+    };
+    expect(crossPrincipalBindings(surfaces, "andreas")).toEqual([]);
+  });
+
+  test("duplicate offending stack ids collapse to one", () => {
+    const surfaces: Surfaces = {
+      discord: [
+        {
+          agent: "a",
+          stack: "other/x",
+          binding: { token: "t1", guildId: "G1", agentChannelId: "a", logChannelId: "b" },
+        },
+        {
+          agent: "b",
+          stack: "other/x",
+          binding: { token: "t2", guildId: "G2", agentChannelId: "c", logChannelId: "d" },
+        },
+      ],
+    };
+    expect(crossPrincipalBindings(surfaces, "andreas")).toEqual(["other/x"]);
   });
 });

--- a/src/gateway/__tests__/start-gateway.test.ts
+++ b/src/gateway/__tests__/start-gateway.test.ts
@@ -189,11 +189,99 @@ describe("startGatewayIfEnabled — flag on", () => {
       policyEngine: POLICY_ENGINE_STUB,
       factory,
     });
-    expect(gw).toBeInstanceOf(SurfaceGateway);
+    expect(gw?.gateway).toBeInstanceOf(SurfaceGateway);
     // one adapter constructed for the one discord binding
     expect(constructed).toEqual(["discord:111222333444555666"]);
     // gw.start() was awaited → the adapter's start() ran
     expect(started).toEqual(["discord:111222333444555666"]);
+    // a.3d — the started gateway exposes its adapters + bound stacks so the
+    // boot path can wire the OUTBOUND dispatch sink over them.
+    expect(gw?.adapters.map((a) => a.instanceId)).toEqual([
+      "discord:111222333444555666",
+    ]);
+    // the one binding's stack leaf (parsed from "andreas/meta-factory")
+    expect(gw?.stacks).toEqual(["meta-factory"]);
+  });
+
+  test("multi-stack bindings → distinct bound stacks (a.3d outbound subjects)", async () => {
+    const started: string[] = [];
+    const { factory } = makeCountingFactory(started);
+    const multiStack: Surfaces = {
+      discord: [
+        {
+          agent: "luna",
+          stack: "andreas/meta-factory",
+          binding: {
+            token: "tok-1",
+            guildId: "111",
+            agentChannelId: "aaa000000000000001",
+            logChannelId: "bbb000000000000002",
+          },
+        },
+        {
+          agent: "ivy",
+          stack: "andreas/research",
+          binding: {
+            token: "tok-2",
+            guildId: "222",
+            agentChannelId: "ccc000000000000003",
+            logChannelId: "ddd000000000000004",
+          },
+        },
+      ],
+    };
+    const gw = await startGatewayIfEnabled({
+      env: { CORTEX_GATEWAY: "1" },
+      surfaces: multiStack,
+      principal: "andreas",
+      runtime: RUNTIME_STUB,
+      source: SOURCE_STUB,
+      policyEngine: POLICY_ENGINE_STUB,
+      factory,
+    });
+    expect(gw?.gateway).toBeInstanceOf(SurfaceGateway);
+    // both bound stacks surface, in binding order — the outbound sink builds
+    // one lifecycle subscribe subject per entry so neither stack's replies are
+    // dropped.
+    expect(gw?.stacks).toEqual(["meta-factory", "research"]);
+    expect(gw?.adapters.map((a) => a.instanceId)).toEqual([
+      "discord:111",
+      "discord:222",
+    ]);
+  });
+
+  test("cross-principal binding → throws loudly at boot (single-principal v1)", async () => {
+    const started: string[] = [];
+    const { factory, constructed } = makeCountingFactory(started);
+    const crossPrincipal: Surfaces = {
+      discord: [
+        {
+          agent: "luna",
+          // principal "someone-else" ≠ gateway principal "andreas"
+          stack: "someone-else/meta-factory",
+          binding: {
+            token: "tok",
+            guildId: "111222333444555666",
+            agentChannelId: "aaa000000000000001",
+            logChannelId: "bbb000000000000002",
+          },
+        },
+      ],
+    };
+    await expect(
+      startGatewayIfEnabled({
+        env: { CORTEX_GATEWAY: "1" },
+        surfaces: crossPrincipal,
+        principal: "andreas",
+        runtime: RUNTIME_STUB,
+        source: SOURCE_STUB,
+        policyEngine: POLICY_ENGINE_STUB,
+        factory,
+      }),
+    ).rejects.toThrow(/cross-principal/i);
+    // Fails BEFORE building or starting any adapter.
+    expect(constructed).toEqual([]);
+    expect(started).toEqual([]);
   });
 
   test("flag on but surfaces undefined → returns undefined (graceful degrade)", async () => {
@@ -242,9 +330,9 @@ describe("startGatewayIfEnabled — flag on", () => {
       policyEngine: POLICY_ENGINE_STUB,
       factory,
     });
-    expect(gw).toBeInstanceOf(SurfaceGateway);
+    expect(gw?.gateway).toBeInstanceOf(SurfaceGateway);
     // stop() resolves without throwing
-    await gw?.stop();
+    await gw?.gateway.stop();
   });
 });
 
@@ -265,11 +353,11 @@ describe("startGatewayIfEnabled — sink selection (CORTEX_GATEWAY_PUBLISH)", ()
       policyEngine: POLICY_ENGINE_STUB,
       factory,
     });
-    expect(gw).toBeInstanceOf(SurfaceGateway);
+    expect(gw?.gateway).toBeInstanceOf(SurfaceGateway);
     // SHADOW: no bus publish. The gateway's sink is a LoggingInboundSink,
     // exactly as it is today.
-    expect(gw?.inboundSink).toBeInstanceOf(LoggingInboundSink);
-    expect(gw?.inboundSink).not.toBeInstanceOf(BusInboundSink);
+    expect(gw?.gateway.inboundSink).toBeInstanceOf(LoggingInboundSink);
+    expect(gw?.gateway.inboundSink).not.toBeInstanceOf(BusInboundSink);
   });
 
   test("publish flag '0' (gateway on) → still SHADOW (only '1' is truthy)", async () => {
@@ -284,7 +372,7 @@ describe("startGatewayIfEnabled — sink selection (CORTEX_GATEWAY_PUBLISH)", ()
       policyEngine: POLICY_ENGINE_STUB,
       factory,
     });
-    expect(gw?.inboundSink).toBeInstanceOf(LoggingInboundSink);
+    expect(gw?.gateway.inboundSink).toBeInstanceOf(LoggingInboundSink);
   });
 
   test("publish flag 'true' (gateway on) → still SHADOW (only '1' is truthy)", async () => {
@@ -299,7 +387,7 @@ describe("startGatewayIfEnabled — sink selection (CORTEX_GATEWAY_PUBLISH)", ()
       policyEngine: POLICY_ENGINE_STUB,
       factory,
     });
-    expect(gw?.inboundSink).toBeInstanceOf(LoggingInboundSink);
+    expect(gw?.gateway.inboundSink).toBeInstanceOf(LoggingInboundSink);
   });
 
   test("BOTH flags '1' → gateway uses BusInboundSink (LIVE — publishing)", async () => {
@@ -314,9 +402,9 @@ describe("startGatewayIfEnabled — sink selection (CORTEX_GATEWAY_PUBLISH)", ()
       policyEngine: POLICY_ENGINE_STUB,
       factory,
     });
-    expect(gw).toBeInstanceOf(SurfaceGateway);
+    expect(gw?.gateway).toBeInstanceOf(SurfaceGateway);
     // LIVE: the double-opt-in flipped the gateway to the bus-publishing sink.
-    expect(gw?.inboundSink).toBeInstanceOf(BusInboundSink);
+    expect(gw?.gateway.inboundSink).toBeInstanceOf(BusInboundSink);
   });
 
   test("publish flag '1' but gateway flag OFF → undefined (gateway gate still wins)", async () => {

--- a/src/gateway/binding-resolver.ts
+++ b/src/gateway/binding-resolver.ts
@@ -180,6 +180,109 @@ function parseStack(raw: string | undefined): {
 }
 
 // =============================================================================
+// distinctBoundStacks  (a.3d outbound — cortex#524)
+// =============================================================================
+
+/**
+ * The distinct set of bound stack leaves across every surface binding.
+ *
+ * The shared surface gateway serves many bound stacks under ONE principal.
+ * Its OUTBOUND dispatch sink (cortex#491 `createDispatchSink`, reused here per
+ * a.3d) must subscribe to the lifecycle subject of EVERY bound stack — the
+ * bound stack's OWN runner republishes `dispatch.task.*` on
+ * `local.{principal}.{stack}.dispatch.task.>`, stamping its own runtime
+ * principal (which EQUALS the gateway principal under single-principal v1 — the
+ * gateway is a separate process and does not stamp the reply) and its stack
+ * leaf. A stack whose subject the sink never subscribes to would have its
+ * replies silently dropped.
+ *
+ * Returns one entry per DISTINCT parsed `stack` leaf (re-using `parseStack`,
+ * the single source of `{principal}/{stack}` parsing — no drift). A gap-4
+ * binding (no `stack` field, §4 above) yields a single `undefined` entry,
+ * which the sink turns into the 5-segment legacy subject
+ * `local.{principal}.dispatch.task.>` — the shape such a binding publishes on.
+ *
+ * Single-principal v1 (§ "v1 decisions" above): the principal segment is the
+ * gateway's own principal, supplied by the caller; cross-principal bindings are
+ * rejected loudly at boot ({@link crossPrincipalBindings}), so this safely
+ * returns stack leaves only.
+ */
+export function distinctBoundStacks(
+  surfaces: Surfaces,
+): (string | undefined)[] {
+  const seen = new Set<string>();
+  let sawUndefined = false;
+  const out: (string | undefined)[] = [];
+  const add = (raw: string | undefined): void => {
+    const { stack } = parseStack(raw);
+    if (stack === undefined) {
+      // gap-4 binding (no stack field) → a single `undefined` bucket, tracked
+      // with a boolean so it never collides with any real stack name.
+      if (sawUndefined) return;
+      sawUndefined = true;
+      out.push(undefined);
+      return;
+    }
+    if (seen.has(stack)) return;
+    seen.add(stack);
+    out.push(stack);
+  };
+  for (const e of surfaces.discord ?? []) add(e.stack);
+  for (const e of surfaces.slack ?? []) add(e.stack);
+  for (const e of surfaces.mattermost ?? []) add(e.stack);
+  return out;
+}
+
+// =============================================================================
+// crossPrincipalBindings  (single-principal v1 enforcement — a.3d review)
+// =============================================================================
+
+/**
+ * The `stack` ids of any bindings whose parsed principal differs from the
+ * gateway's own principal — i.e. cross-principal bindings.
+ *
+ * **Why this exists (a.3d review finding).** The gateway is single-principal
+ * in v1 (§ "v1 decisions" above): both the inbound publisher and the outbound
+ * dispatch sink key off the gateway's OWN principal and discard each binding's
+ * parsed principal. That makes the single-principal rule an *assumption*. A
+ * binding that declared `{otherPrincipal}/{stack}` would then be silently
+ * absorbed into the gateway principal's namespace on both legs — the exact
+ * latent cross-principal leak single-principal v1 is meant to exclude.
+ *
+ * This helper turns the assumption into an enforceable gate: the caller throws
+ * a loud boot error when the result is non-empty (same loud-validation style as
+ * {@link buildBindingIndex}'s duplicate-key throw), so a cross-principal
+ * misconfig fails at startup rather than mis-routing at runtime. Bindings with
+ * no `stack` field (gap-4) carry no principal and are never flagged.
+ *
+ * Returns the offending raw `stack` values (deduped, in iteration order) so the
+ * error message can name them.
+ */
+export function crossPrincipalBindings(
+  surfaces: Surfaces,
+  principal: string,
+): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  const check = (raw: string | undefined): void => {
+    // Narrow `raw` to a string up front: a gap-4 binding (no `stack`) carries
+    // no principal and can never be cross-principal, so skip it. This also
+    // lets us push `raw` without a non-null assertion.
+    if (raw === undefined) return;
+    const parsed = parseStack(raw);
+    if (parsed.principal !== undefined && parsed.principal !== principal) {
+      if (seen.has(raw)) return;
+      seen.add(raw);
+      out.push(raw);
+    }
+  };
+  for (const e of surfaces.discord ?? []) check(e.stack);
+  for (const e of surfaces.slack ?? []) check(e.stack);
+  for (const e of surfaces.mattermost ?? []) check(e.stack);
+  return out;
+}
+
+// =============================================================================
 // buildBindingIndex
 // =============================================================================
 

--- a/src/gateway/start-gateway.ts
+++ b/src/gateway/start-gateway.ts
@@ -55,12 +55,13 @@ import {
   type GatewayAdapterFactory,
 } from "./gateway-adapters";
 import { BusInboundSink } from "./bus-inbound-sink";
+import { distinctBoundStacks, crossPrincipalBindings } from "./binding-resolver";
 import type { SurfaceGateway } from "./surface-gateway";
 import type { Surfaces } from "../common/types/surfaces";
 import type { MyelinRuntime } from "../bus/myelin/runtime";
 import type { SystemEventSource } from "../bus/system-events";
 import type { PolicyEngine } from "../common/policy/engine";
-import type { InboundMessage } from "../adapters/types";
+import type { InboundMessage, PlatformAdapter } from "../adapters/types";
 
 // =============================================================================
 // Public API
@@ -101,6 +102,32 @@ export interface StartGatewayOpts {
   onUnroutable?: (msg: InboundMessage, reason: string) => void;
 }
 
+/**
+ * What a successfully-started gateway hands back to the cortex.ts boot path.
+ *
+ * a.3d (cortex#524) — the gateway owns its platform adapters AND the set of
+ * bound stacks; the OUTBOUND dispatch sink (constructed in `cortex.ts`,
+ * mirroring the per-stack sink) needs both. Rather than reaching into the
+ * gateway's internals, `startGatewayIfEnabled` exposes them here so the
+ * subject derivation stays in the gateway layer (where `surfaces` is parsed)
+ * while the sink construction stays at the boot site (where `runtime` lives).
+ */
+export interface StartedGateway {
+  /** The started inbound demux gateway. Joins the shutdown drain via `stop()`. */
+  gateway: SurfaceGateway;
+  /**
+   * The gateway's own platform adapters — one per surface binding. The
+   * outbound dispatch sink drives THESE (its `adapter_instance` filter keys
+   * off their `instanceId`), disjoint from the per-stack `adapters[]`.
+   */
+  adapters: readonly PlatformAdapter[];
+  /**
+   * Distinct bound-stack leaves (`undefined` = a gap-4 no-stack binding) for
+   * the outbound sink's subscribe subjects. See {@link distinctBoundStacks}.
+   */
+  stacks: readonly (string | undefined)[];
+}
+
 /** Count the total bindings across all platforms in a `Surfaces` map. */
 function countBindings(surfaces: Surfaces): number {
   return (
@@ -124,7 +151,7 @@ function countBindings(surfaces: Surfaces): number {
  */
 export async function startGatewayIfEnabled(
   opts: StartGatewayOpts,
-): Promise<SurfaceGateway | undefined> {
+): Promise<StartedGateway | undefined> {
   const enabled = isGatewayEnabled(opts.env);
 
   // ── Path 1: flag off → true no-op. Construct NOTHING. ─────────────────────
@@ -138,17 +165,36 @@ export async function startGatewayIfEnabled(
   const { surfaces } = opts;
   if (surfaces === undefined || countBindings(surfaces) === 0) {
     // maybeCreateSurfaceGateway emits the principal-facing stderr warning for
-    // the no-binding case; delegate to it (with empty adapters) so the log
-    // line lives in exactly one place.
-    return maybeCreateSurfaceGateway({
+    // the no-binding case AND returns `undefined` (zero bindings). Call it for
+    // that one-place log side-effect, then return `undefined` — there is no
+    // gateway, no adapters, and no outbound sink to wire.
+    maybeCreateSurfaceGateway({
       enabled: true,
       surfaces,
       adapters: [],
       ...(opts.onUnroutable !== undefined && { onUnroutable: opts.onUnroutable }),
     });
+    return undefined;
   }
 
   // ── Path 3: flag on + bindings → build, construct, start. ─────────────────
+  //
+  // a.3d review (single-principal v1 enforcement): the inbound publisher and
+  // the outbound dispatch sink both key off the gateway's OWN principal and
+  // discard each binding's parsed principal. Reject any cross-principal binding
+  // LOUDLY at boot rather than silently absorbing it into the gateway
+  // principal's namespace (the latent cross-principal leak single-principal v1
+  // excludes). Same loud-validation stance as `buildBindingIndex`.
+  const crossPrincipal = crossPrincipalBindings(surfaces, opts.principal);
+  if (crossPrincipal.length > 0) {
+    throw new Error(
+      `gateway: cross-principal surface bindings are not supported in single-principal v1 — ` +
+        `${crossPrincipal.map((s) => `"${s}"`).join(", ")} ` +
+        `declare a principal other than "${opts.principal}". ` +
+        `Either move them under "${opts.principal}/…" or run a separate gateway for that principal.`,
+    );
+  }
+
   const adapters = buildGatewayAdapters(surfaces, {
     principal: opts.principal,
     runtime: opts.runtime,
@@ -199,8 +245,20 @@ export async function startGatewayIfEnabled(
 
   // `gw` is defined here (bindings > 0 + adapters built), but the factory
   // contract returns `SurfaceGateway | undefined` — guard rather than assert.
-  if (gw !== undefined) {
-    await gw.start();
+  if (gw === undefined) {
+    return undefined;
   }
-  return gw;
+  await gw.start();
+
+  // a.3d (cortex#524) — hand the boot path the adapters + bound stacks the
+  // OUTBOUND dispatch sink needs. The sink itself is constructed in cortex.ts
+  // (it owns the `runtime`), but the bound-stack subject set is derived HERE,
+  // where `surfaces` is parsed, so subject-shape logic stays in the gateway
+  // layer. Single-principal v1: the sink's principal segment is the gateway
+  // principal (supplied at the boot site).
+  return {
+    gateway: gw,
+    adapters,
+    stacks: distinctBoundStacks(surfaces),
+  };
 }


### PR DESCRIPTION
## Summary

The shared surface gateway's **return leg** (cortex#524, design captured on #524): catch each bound stack's `dispatch.task.*` lifecycle reply off the bus and post it back to the **exact** originating channel/thread through the gateway's **own** adapters — by **reusing the per-stack `createDispatchSink`** (cortex#491) over the gateway adapters, **not** building a second mux.

Inbound (GW.a.3a/b) is already on main; this closes the loop.

## How the round-trip closes

- Inbound publishes `tasks.@{agent}.chat` with `response_routing.adapter_instance = msg.instanceId` (the gateway adapter).
- The bound stack's runner echoes that routing onto every lifecycle envelope (`dispatch-listener.echoResponseRouting`).
- The gateway runs **one** `createDispatchSink` over its adapters; the `adapter_instance` filter posts only replies routed to a gateway adapter — **disjoint** from the per-stack sink's instances, so both coexist on one runtime with **no double-reply**.

## Scope decisions (principal-locked)

- **Explicit per-stack subjects, not a wildcard.** The sink subscribes to exactly the bound stacks' lifecycle subjects. This is least-privilege *and* a **correctness** requirement: a cross-process stack whose subject the gateway never subscribes to would have its replies silently dropped (the subscribe set is what makes NATS deliver them, not just a filter).
- **Wired in `cortex.ts`** (mirrors the per-stack sink); the bound-stack subject set is derived in the gateway layer where `surfaces` is parsed.

## Changes

- `src/adapters/dispatch-sink.ts` — add `stacks?: readonly (string | undefined)[]`: one subscribe subject per **distinct** bound stack (an `undefined` entry → the 5-segment legacy subject for a gap-4 binding with no `stack`). Still **one** `onEnvelope` handler, so multi-subject never double-delivers.
- `src/gateway/binding-resolver.ts` — `distinctBoundStacks(surfaces)`: the distinct bound-stack leaves for the outbound subjects (reuses `parseStack` — single source of `{principal}/{stack}` parsing).
- `src/gateway/start-gateway.ts` — `startGatewayIfEnabled` returns `StartedGateway { gateway, adapters, stacks }` so the boot path can wire the sink without reaching into gateway internals.
- `src/cortex.ts` — construct + start the gateway outbound dispatch sink over the gateway's adapters; drain it **before** the gateway adapters close (mirrors the per-stack sink boundary).
- Tests — gateway multi-stack subjects + delivery/no-cross-post; `distinctBoundStacks` (incl. gap-4 + dedup + cross-platform); start-gateway `adapters`/`stacks` exposure.

## Behaviour

- **SHADOW** (`CORTEX_GATEWAY=1`, publish off): idle — no inbound published → nothing routes to the gateway adapters.
- **LIVE** (`CORTEX_GATEWAY_PUBLISH=1`): active — replies post back through the gateway adapters.
- Dormant default stacks (no `CORTEX_GATEWAY`): the sink is `undefined`; the drain slot self-completes. Zero behaviour change.

## Verification

- `bunx tsc --noEmit` — clean
- `bun run lint:errors` — clean
- `bun test` (whole repo) — **3979 pass, 2 skip, 0 fail**

Part of cortex#524.

🤖 Generated with [Claude Code](https://claude.com/claude-code)