### PR TITLE
feat(mc): ML.1 — plan→umbrella linkage (parse umbrellaWorkItemId from plan docs)

### DIFF
--- a/src/surface/mc/__tests__/plan-docs.test.ts
+++ b/src/surface/mc/__tests__/plan-docs.test.ts
@@ -12,6 +12,7 @@ import {
   ingestPlanDoc,
   ingestPlanDocsFromDir,
 } from "../ingest/plan-docs";
+import { parseGitHubRef, isParseError, canonicalRef } from "../adapters/github";
 
 // Cockpit-plan shape: H1 title, **Status:** line, numbered phase headings with id suffix.
 const COCKPIT = `# Plan — Mission Control Cortex Cockpit (G-1113)
@@ -258,6 +259,44 @@ describe("parsePlanDoc — umbrella linkage (ML.1)", () => {
       defaultRepo: { owner: "the-metafactory", repo: "cortex" },
     });
     expect(plan.umbrellaWorkItemId).toBeNull();
+  });
+
+  it("markdown-link form resolves via the URL (not the bracketed label) → correct repo", () => {
+    // Real iteration-doc form: `[#59](https://github.com/.../grove-v2/issues/59)`.
+    // The URL (grove-v2) must win over the bare `#59` label, even with a
+    // cortex defaultRepo present — else D.5b fetches the wrong repo's issue.
+    const { plan } = parsePlanDoc({
+      content: docWith("**Umbrella issue:** [#59](https://github.com/the-metafactory/grove-v2/issues/59)"),
+      path: "docs/iteration-x.md",
+      defaultRepo: { owner: "the-metafactory", repo: "cortex" },
+    });
+    expect(plan.umbrellaWorkItemId).toBe("the-metafactory/grove-v2#59");
+  });
+
+  it("repo-shorthand cortex#110: null without defaultRepo, qualified with it", () => {
+    const line = "**Umbrella issue:** cortex#110";
+    expect(parsePlanDoc({ content: docWith(line), path: "docs/plan-x.md" }).plan.umbrellaWorkItemId).toBeNull();
+    const qualified = parsePlanDoc({
+      content: docWith(line),
+      path: "docs/plan-x.md",
+      defaultRepo: { owner: "the-metafactory", repo: "cortex" },
+    }).plan.umbrellaWorkItemId;
+    expect(qualified).toBe("the-metafactory/cortex#110");
+  });
+
+  it("round-trips through D.5b's parser: umbrellaWorkItemId reparses identically (the integration contract)", () => {
+    for (const line of [
+      "**Umbrella issue:** the-metafactory/cortex#354",
+      "**Umbrella:** https://github.com/the-metafactory/cortex/issues/110",
+    ]) {
+      const id = parsePlanDoc({ content: docWith(line), path: "docs/plan-x.md" }).plan.umbrellaWorkItemId;
+      expect(id).not.toBeNull();
+      if (id === null) continue; // narrow for the round-trip below
+      // GithubWorkItemSource calls parseGitHubRef(plan.umbrellaWorkItemId) with NO defaults.
+      const ref = parseGitHubRef(id);
+      expect(isParseError(ref)).toBe(false);
+      if (!isParseError(ref)) expect(canonicalRef(ref)).toBe(id); // stable round-trip
+    }
   });
 
   it("no umbrella line → null; an explicit provider is not overridden by an umbrella", () => {

--- a/src/surface/mc/__tests__/plan-docs.test.ts
+++ b/src/surface/mc/__tests__/plan-docs.test.ts
@@ -211,3 +211,63 @@ describe("ingestPlanDoc / ingestPlanDocsFromDir (D.2, persistence)", () => {
     expect(getPlan(db, "architecture")).toBeNull();
   });
 });
+
+describe("parsePlanDoc — umbrella linkage (ML.1)", () => {
+  const docWith = (umbrellaLine: string) =>
+    `# A plan\n\n**Status:** active\n${umbrellaLine}\n\n## Phase A — X\n`;
+
+  it("parses a full owner/repo#N umbrella ref → owner/repo#N + github provider", () => {
+    const { plan } = parsePlanDoc({
+      content: docWith("**Umbrella issue:** the-metafactory/cortex#354"),
+      path: "docs/plan-x.md",
+    });
+    expect(plan.umbrellaWorkItemId).toBe("the-metafactory/cortex#354");
+    expect(plan.provider).toBe("github"); // a github umbrella implies github provider
+  });
+
+  it("parses a GitHub issues URL", () => {
+    const { plan } = parsePlanDoc({
+      content: docWith("**Umbrella:** https://github.com/the-metafactory/cortex/issues/110"),
+      path: "docs/plan-x.md",
+    });
+    expect(plan.umbrellaWorkItemId).toBe("the-metafactory/cortex#110");
+  });
+
+  it("qualifies a short ref (#N) via defaultRepo", () => {
+    const { plan } = parsePlanDoc({
+      content: docWith("**Umbrella issue:** #354"),
+      path: "docs/plan-x.md",
+      defaultRepo: { owner: "the-metafactory", repo: "cortex" },
+    });
+    expect(plan.umbrellaWorkItemId).toBe("the-metafactory/cortex#354");
+  });
+
+  it("a short ref with NO defaultRepo → null (can't qualify, honest)", () => {
+    const { plan } = parsePlanDoc({
+      content: docWith("**Umbrella issue:** #354"),
+      path: "docs/plan-x.md",
+    });
+    expect(plan.umbrellaWorkItemId).toBeNull();
+    expect(plan.provider).toBe("internal"); // no github umbrella → stays internal
+  });
+
+  it("a placeholder umbrella line → null (the cockpit doc's '_(to be filed)_' case)", () => {
+    const { plan } = parsePlanDoc({
+      content: docWith("**Umbrella issue:** _(to be filed once this plan is agreed)_"),
+      path: "docs/plan-x.md",
+      defaultRepo: { owner: "the-metafactory", repo: "cortex" },
+    });
+    expect(plan.umbrellaWorkItemId).toBeNull();
+  });
+
+  it("no umbrella line → null; an explicit provider is not overridden by an umbrella", () => {
+    expect(parsePlanDoc({ content: docWith(""), path: "docs/plan-x.md" }).plan.umbrellaWorkItemId).toBeNull();
+    const { plan } = parsePlanDoc({
+      content: docWith("**Umbrella issue:** the-metafactory/cortex#354"),
+      path: "docs/plan-x.md",
+      provider: "internal", // explicit wins over the github-umbrella inference
+    });
+    expect(plan.umbrellaWorkItemId).toBe("the-metafactory/cortex#354");
+    expect(plan.provider).toBe("internal");
+  });
+});

--- a/src/surface/mc/ingest/plan-docs.ts
+++ b/src/surface/mc/ingest/plan-docs.ts
@@ -20,6 +20,8 @@ import { readdirSync, readFileSync } from "fs";
 import { basename, join } from "path";
 import type { Plan, PlanKind, PlanPhase, PlanStatus, Provider } from "../types";
 import { upsertPlan, upsertPlanPhase } from "../db/plans";
+// ML.1 — reuse the GitHub adapter boundary to parse/normalize an umbrella ref.
+import { parseGitHubRef, isParseError, canonicalRef } from "../adapters/github";
 
 export interface PlanDocSource {
   /** Markdown body of the doc. */
@@ -31,8 +33,18 @@ export interface PlanDocSource {
   path: string;
   /** Canonical URL to the doc (e.g. a GitHub blob URL), when known. */
   sourceDocumentUrl?: string | null;
-  /** Provider the plan is sourced from. Defaults to `internal` (a repo-local doc). */
+  /**
+   * Provider the plan is sourced from. Defaults to `internal` for a repo-local
+   * doc — UNLESS a GitHub umbrella ref is parsed (ML.1), which implies `github`
+   * (so D.5b dispatches the GitHub WorkItemSource). An explicit value here
+   * always wins.
+   */
   provider?: Provider;
+  /**
+   * ML.1 — default `{owner, repo}` used to qualify a short umbrella ref
+   * (`#N` / `repo#N`) declared in the doc. Typically the repo the docs live in.
+   */
+  defaultRepo?: { owner: string; repo: string };
 }
 
 export interface ParsedPlanDoc {
@@ -69,6 +81,29 @@ const TRAILING_PAREN_RE = /\s*\((?=[\w.#-]*\d)[\w.#-]+\)\s*$/;
 /** Slug used as the plan id — the doc basename without its `.md` extension. */
 function planIdFromPath(path: string): string {
   return basename(path).replace(/\.md$/i, "");
+}
+
+/** The author-written umbrella declaration line, e.g. `**Umbrella issue:** cortex#354`. */
+const UMBRELLA_LINE_RE = /^\*\*Umbrella(?:\s+issue)?:\*\*\s*(.+)$/im;
+/** A candidate ref token within that line: a github issues/pull URL, owner/repo#N, repo#N, or #N. */
+const UMBRELLA_TOKEN_RE =
+  /https?:\/\/github\.com\/\S+|[\w.-]+\/[\w.-]+#\d+|[\w.-]+#\d+|#\d+/;
+
+/**
+ * ML.1 — parse a plan doc's declared umbrella issue into the canonical
+ * `owner/repo#N` form the GitHub WorkItemSource (D.5b) consumes. Returns null
+ * when no umbrella line exists, the line is a placeholder (e.g.
+ * `_(to be filed)_`), or the ref can't be resolved (short ref with no
+ * `defaultRepo`). Reuses the GitHub adapter's parser/normalizer.
+ */
+function extractUmbrellaRef(content: string, defaultRepo?: { owner: string; repo: string }): string | null {
+  const line = UMBRELLA_LINE_RE.exec(content)?.[1];
+  if (line === undefined) return null;
+  const token = UMBRELLA_TOKEN_RE.exec(line)?.[0];
+  if (token === undefined) return null; // placeholder / no ref
+  const ref = parseGitHubRef(token, defaultRepo ?? {});
+  if (isParseError(ref)) return null;
+  return canonicalRef(ref); // owner/repo#N
 }
 
 /** Infer {@link PlanKind} from the filename + title. Generic plans default to `design`. */
@@ -115,14 +150,17 @@ function extractTitle(content: string, fallback: string): string {
 export function parsePlanDoc(src: PlanDocSource): ParsedPlanDoc {
   const id = planIdFromPath(src.path);
   const title = extractTitle(src.content, id);
+  // ML.1 — a declared GitHub umbrella links the plan to its sub-issues (D.5b)
+  // and implies a github provider (unless the caller set one explicitly).
+  const umbrellaWorkItemId = extractUmbrellaRef(src.content, src.defaultRepo);
   const plan: Plan = {
     id,
     title,
     kind: inferKind(src.path, title),
     sourceDocumentUrl: src.sourceDocumentUrl ?? null,
-    provider: src.provider ?? "internal",
+    provider: src.provider ?? (umbrellaWorkItemId !== null ? "github" : "internal"),
     externalId: null,
-    umbrellaWorkItemId: null,
+    umbrellaWorkItemId,
     status: inferStatus(src.content),
   };
 
@@ -174,6 +212,8 @@ export interface IngestDirOptions {
   repoRelDir?: string;
   /** Build a `sourceDocumentUrl` from a repo-relative path; return null when unknown. */
   urlForPath?: (repoRelPath: string) => string | null;
+  /** ML.1 — default `{owner, repo}` for qualifying short umbrella refs (the docs' repo). */
+  defaultRepo?: { owner: string; repo: string };
 }
 
 /**
@@ -194,6 +234,7 @@ export function ingestPlanDocsFromDir(db: Database, opts: IngestDirOptions): Par
         content,
         path: repoRel,
         sourceDocumentUrl: opts.urlForPath?.(repoRel) ?? null,
+        defaultRepo: opts.defaultRepo,
       })
     );
   }

--- a/src/surface/mc/ingest/plan-docs.ts
+++ b/src/surface/mc/ingest/plan-docs.ts
@@ -85,9 +85,14 @@ function planIdFromPath(path: string): string {
 
 /** The author-written umbrella declaration line, e.g. `**Umbrella issue:** cortex#354`. */
 const UMBRELLA_LINE_RE = /^\*\*Umbrella(?:\s+issue)?:\*\*\s*(.+)$/im;
-/** A candidate ref token within that line: a github issues/pull URL, owner/repo#N, repo#N, or #N. */
-const UMBRELLA_TOKEN_RE =
-  /https?:\/\/github\.com\/\S+|[\w.-]+\/[\w.-]+#\d+|[\w.-]+#\d+|#\d+/;
+// Candidate ref forms, tried MOST-QUALIFIED FIRST regardless of position —
+// crucial for the markdown-link form `[#59](https://github.com/o/r/issues/59)`,
+// where the bracketed `#59` label sits left of the canonical URL. Trying the
+// URL first picks the real repo (grove-v2#59), not the bare label. The URL is
+// bounded by `[^\s)\]]+` so it doesn't swallow the markdown link's closing `)`.
+const UMBRELLA_URL_RE = /https?:\/\/github\.com\/[^\s)\]]+/;
+const UMBRELLA_OWNER_REPO_RE = /[\w.-]+\/[\w.-]+#\d+/;
+const UMBRELLA_SHORT_RE = /[\w.-]+#\d+|#\d+/;
 
 /**
  * ML.1 — parse a plan doc's declared umbrella issue into the canonical
@@ -95,11 +100,18 @@ const UMBRELLA_TOKEN_RE =
  * when no umbrella line exists, the line is a placeholder (e.g.
  * `_(to be filed)_`), or the ref can't be resolved (short ref with no
  * `defaultRepo`). Reuses the GitHub adapter's parser/normalizer.
+ *
+ * Only the FIRST `**Umbrella…**` line is consulted (by design): a placeholder
+ * first line intentionally yields null ("not yet filed"). The line must START
+ * with `**Umbrella`, so body prose like "the umbrella cortex#110" can't match.
  */
 function extractUmbrellaRef(content: string, defaultRepo?: { owner: string; repo: string }): string | null {
   const line = UMBRELLA_LINE_RE.exec(content)?.[1];
   if (line === undefined) return null;
-  const token = UMBRELLA_TOKEN_RE.exec(line)?.[0];
+  const token =
+    UMBRELLA_URL_RE.exec(line)?.[0] ??
+    UMBRELLA_OWNER_REPO_RE.exec(line)?.[0] ??
+    UMBRELLA_SHORT_RE.exec(line)?.[0];
   if (token === undefined) return null; // placeholder / no ref
   const ref = parseGitHubRef(token, defaultRepo ?? {});
   if (isParseError(ref)) return null;


### PR DESCRIPTION
## ML.1 — plan→umbrella linkage

First **make-it-live** slice (#614). The G-1113 cockpit is built but renders empty because doc-ingested plans had `umbrellaWorkItemId = null` — so the D.5b GitHub `WorkItemSource` had no umbrella to fetch sub-issues from. This wires that link from the plan doc.

### What's here
- **`ingest/plan-docs.ts`**
  - `extractUmbrellaRef`: parses a `**Umbrella issue:**` / `**Umbrella:**` line → a ref token (GitHub issues/pull URL, `owner/repo#N`, `repo#N`, or `#N`) → normalized to `owner/repo#N` via the GitHub adapter (`parseGitHubRef` + `canonicalRef`). Placeholder (`_(to be filed)_`) / no-ref / unqualifiable-short-ref → **null** (honest).
  - `PlanDocSource` + `IngestDirOptions` gain `defaultRepo` to qualify short refs (the docs' repo).
  - A parsed GitHub umbrella implies `provider = "github"` (so D.5b dispatches the GitHub source); an explicit `src.provider` still wins.
- **`__tests__/plan-docs.test.ts`** — full `owner/repo#N`, issues URL, short-ref + `defaultRepo`, short-ref without (null), the cockpit doc's placeholder, no-line, and explicit-provider-not-overridden.

### Verification
- `bunx tsc --noEmit` clean · `bun run lint` 0 errors · carve-out gate PASS · `bun test src/surface/mc` 1270 pass / 0 fail · merge-guard clean

Closes #615. Part of #614. (ML.2 — the runtime trigger that calls ingestion + reconcile — is next.)