### PR TITLE
feat(mc): ML.2 — cockpit refresh orchestrator (ingestion + reconcile trigger)

### DIFF
--- a/src/cli/__tests__/cockpit-refresh.test.ts
+++ b/src/cli/__tests__/cockpit-refresh.test.ts
@@ -1,0 +1,69 @@
+/**
+ * ML.2 — cockpit-refresh CLI: arg parsing + run wiring (deps injected).
+ */
+import { describe, it, expect } from "bun:test";
+import {
+  parseCockpitRefreshArgs,
+  runCockpitRefresh,
+  type CockpitRefreshDeps,
+} from "../cockpit-refresh";
+import type { RefreshCockpitOptions, RefreshResult } from "../../surface/mc/refresh";
+
+describe("parseCockpitRefreshArgs (ML.2)", () => {
+  it("parses --docs / --stack / --repo / --db", () => {
+    const a = parseCockpitRefreshArgs(["--docs", "./docs", "--stack", "laptop", "--repo", "the-metafactory/cortex", "--db", "/tmp/mc.db"]);
+    expect(a).toEqual({ docsDir: "./docs", stackId: "laptop", repo: { owner: "the-metafactory", repo: "cortex" }, dbPath: "/tmp/mc.db" });
+  });
+
+  it("requires --docs and --stack", () => {
+    expect(parseCockpitRefreshArgs(["--stack", "x"])).toEqual({ error: "--docs <dir> is required" });
+    expect(parseCockpitRefreshArgs(["--docs", "d"])).toEqual({ error: "--stack <id> is required" });
+  });
+
+  it("rejects a malformed --repo", () => {
+    const r = parseCockpitRefreshArgs(["--docs", "d", "--stack", "s", "--repo", "justname"]);
+    expect("error" in r && r.error).toContain("owner/name");
+  });
+
+  it("repo is optional", () => {
+    expect(parseCockpitRefreshArgs(["--docs", "d", "--stack", "s"])).toEqual({
+      docsDir: "d", stackId: "s", repo: undefined, dbPath: undefined,
+    });
+  });
+});
+
+describe("runCockpitRefresh (ML.2)", () => {
+  const RESULT: RefreshResult = { plans: 2, workItems: 3, unsupportedProviders: 1, failedPlans: 0, attentionOpen: 1 };
+
+  it("opens the db at the given path and threads parsed opts into refresh", async () => {
+    const openedPaths: string[] = [];
+    const calls: RefreshCockpitOptions[] = [];
+    const deps: CockpitRefreshDeps = {
+      openDb: (p) => { openedPaths.push(p); return {} as never; },
+      refresh: async (_db, opts) => { calls.push(opts); return RESULT; },
+    };
+    const out = await runCockpitRefresh(["--docs", "/repo/docs", "--stack", "laptop", "--repo", "the-metafactory/cortex", "--db", "/tmp/x.db"], deps);
+    expect(out.code).toBe(0);
+    expect(out.result).toEqual(RESULT);
+    expect(openedPaths).toEqual(["/tmp/x.db"]);
+    const opts = calls[0];
+    expect(opts?.docsDir).toBe("/repo/docs");
+    expect(opts?.stackId).toBe("laptop");
+    expect(opts?.defaultRepo).toEqual({ owner: "the-metafactory", repo: "cortex" });
+    // urlForPath builds a github blob URL from the repo.
+    expect(opts?.urlForPath?.("docs/plan-x.md")).toBe(
+      "https://github.com/the-metafactory/cortex/blob/main/docs/plan-x.md"
+    );
+  });
+
+  it("returns code 2 + error on a usage problem (no db opened, no refresh run)", async () => {
+    let opened = false;
+    const out = await runCockpitRefresh(["--stack", "x"], {
+      openDb: () => { opened = true; return {} as never; },
+      refresh: async () => RESULT,
+    });
+    expect(out.code).toBe(2);
+    expect(out.error).toContain("--docs");
+    expect(opened).toBe(false);
+  });
+});

--- a/src/cli/cockpit-refresh.ts
+++ b/src/cli/cockpit-refresh.ts
@@ -1,0 +1,95 @@
+/**
+ * ML.2 — runnable cockpit-refresh trigger.
+ *
+ * The runtime entry point that makes the cockpit live: opens the Mission
+ * Control DB and runs one `refreshCockpit` pass (plan-doc ingestion →
+ * provider-dispatched work-item ingestion → attention reconcile). Invoked by
+ * the principal on demand, or on a schedule (launchd/cron):
+ *
+ *   bun src/cli/cockpit-refresh.ts --docs ./docs --repo the-metafactory/cortex --stack laptop [--db <path>]
+ *
+ * The arg parser + run logic are exported (deps injected) so the wiring is
+ * unit-testable without touching the real FS / DB; `import.meta.main` runs it
+ * with the production deps.
+ */
+import type { Database } from "bun:sqlite";
+import { initDatabase } from "../surface/mc/db/init";
+import { DEFAULT_CONFIG } from "../surface/mc/config";
+import { refreshCockpit, defaultWorkItemSourceFor, type RefreshResult } from "../surface/mc/refresh";
+
+export interface CockpitRefreshArgs {
+  docsDir: string;
+  /** Default repo for qualifying short umbrella refs + building doc URLs. */
+  repo?: { owner: string; repo: string };
+  stackId: string;
+  /** Override the MC DB path (defaults to the configured location). */
+  dbPath?: string;
+}
+
+/** Read `--flag value` from argv. */
+function flag(argv: string[], name: string): string | undefined {
+  const i = argv.indexOf(`--${name}`);
+  return i >= 0 && i + 1 < argv.length ? argv[i + 1] : undefined;
+}
+
+/** Parse CLI args. Returns `{ error }` on a usage problem (exit code 2). */
+export function parseCockpitRefreshArgs(argv: string[]): CockpitRefreshArgs | { error: string } {
+  const docsDir = flag(argv, "docs");
+  if (!docsDir) return { error: "--docs <dir> is required" };
+  const stackId = flag(argv, "stack");
+  if (!stackId) return { error: "--stack <id> is required" };
+
+  let repo: { owner: string; repo: string } | undefined;
+  const repoArg = flag(argv, "repo");
+  if (repoArg !== undefined) {
+    const parts = repoArg.split("/");
+    if (parts.length !== 2 || !parts[0] || !parts[1]) {
+      return { error: `--repo must be owner/name (got "${repoArg}")` };
+    }
+    repo = { owner: parts[0], repo: parts[1] };
+  }
+
+  return { docsDir, stackId, repo, dbPath: flag(argv, "db") };
+}
+
+export interface CockpitRefreshDeps {
+  openDb: (path: string) => Database;
+  refresh: typeof refreshCockpit;
+}
+
+export interface CockpitRefreshOutcome {
+  code: number;
+  result?: RefreshResult;
+  error?: string;
+}
+
+/** Parse args, open the DB, run one refresh. Deps injected for testability. */
+export async function runCockpitRefresh(argv: string[], deps: CockpitRefreshDeps): Promise<CockpitRefreshOutcome> {
+  const parsed = parseCockpitRefreshArgs(argv);
+  if ("error" in parsed) return { code: 2, error: parsed.error };
+
+  const db = deps.openDb(parsed.dbPath ?? DEFAULT_CONFIG.db.path);
+  const result = await deps.refresh(db, {
+    docsDir: parsed.docsDir,
+    stackId: parsed.stackId,
+    defaultRepo: parsed.repo,
+    urlForPath: parsed.repo
+      ? (rel) => `https://github.com/${parsed.repo?.owner}/${parsed.repo?.repo}/blob/main/${rel}`
+      : undefined,
+    workItemSourceFor: defaultWorkItemSourceFor,
+  });
+  return { code: 0, result };
+}
+
+if (import.meta.main) {
+  void runCockpitRefresh(process.argv.slice(2), { openDb: initDatabase, refresh: refreshCockpit }).then(
+    ({ code, result, error }) => {
+      if (error !== undefined) {
+        process.stderr.write(`cockpit-refresh: ${error}\n`);
+      } else {
+        process.stdout.write(`cockpit-refresh: ${JSON.stringify(result)}\n`);
+      }
+      process.exit(code);
+    }
+  );
+}

--- a/src/surface/mc/__tests__/refresh.test.ts
+++ b/src/surface/mc/__tests__/refresh.test.ts
@@ -1,0 +1,114 @@
+/**
+ * ML.2 — cockpit refresh orchestrator: the full live chain end-to-end
+ * (plan docs → plans/phases → provider-dispatched work items → attention).
+ */
+import { describe, it, expect, afterEach } from "bun:test";
+import { join } from "path";
+import { tmpdir } from "os";
+import { mkdtempSync, writeFileSync, rmSync, existsSync } from "fs";
+import { initDatabase } from "../db/init";
+import { getPlan, listPlans } from "../db/plans";
+import { getWorkItem, listWorkItemsForPlan } from "../db/work-items";
+import { listOpenAttention } from "../db/attention";
+import { refreshCockpit, defaultWorkItemSourceFor, type WorkItemSourceFactory } from "../refresh";
+import { GithubWorkItemSource } from "../adapters/github/work-items";
+import type { WorkItemSource } from "../adapters/work-item-source";
+import type { WorkItem } from "../types";
+
+const NOW = 1_900_000_000;
+const DAY = 24 * 60 * 60;
+
+// A plan doc whose umbrella ref makes it a github plan (ML.1 → provider github).
+const GH_PLAN = `# Cockpit\n\n**Status:** active\n**Umbrella issue:** the-metafactory/cortex#354\n\n## Phase A — Grounding\n`;
+// A plan doc with no umbrella → internal provider (no work-item source).
+const INTERNAL_PLAN = `# Internal plan\n\n**Status:** active\n\n## Phase A — X\n`;
+
+/** A mock github source returning N canned work items for the plan's first phase. */
+function mockFactory(itemsByPlan: Record<string, WorkItem[]>): WorkItemSourceFactory {
+  return (provider) =>
+    provider === "github"
+      ? ({
+          provider: "github",
+          fetchWorkItems: async (ctx) => itemsByPlan[ctx.plan.id] ?? [],
+        } satisfies WorkItemSource)
+      : null;
+}
+
+describe("refreshCockpit (ML.2)", () => {
+  const dbPaths: string[] = [];
+  const dirs: string[] = [];
+  afterEach(() => {
+    for (const p of dbPaths) if (existsSync(p)) rmSync(p);
+    for (const d of dirs) if (existsSync(d)) rmSync(d, { recursive: true, force: true });
+    dbPaths.length = 0;
+    dirs.length = 0;
+  });
+  function freshDb() {
+    const p = join(tmpdir(), `refresh-${Date.now()}-${Math.random().toString(36).slice(2)}.db`);
+    dbPaths.push(p);
+    return initDatabase(p);
+  }
+  function docsDir(files: Record<string, string>) {
+    const dir = mkdtempSync(join(tmpdir(), "refresh-docs-"));
+    dirs.push(dir);
+    for (const [name, content] of Object.entries(files)) writeFileSync(join(dir, name), content);
+    return dir;
+  }
+
+  it("runs the full chain: docs → plans → provider-dispatched work items → attention", async () => {
+    const db = freshDb();
+    const dir = docsDir({ "plan-cockpit.md": GH_PLAN, "iteration-internal.md": INTERNAL_PLAN });
+
+    // Pre-seed a stale work item so the reconcile step (3) has something to flag.
+    db.query(
+      `INSERT INTO work_items (id, title, status, priority, provider, updated_at) VALUES ('wi-stale', 'old', 'open', '', 'github', ?)`
+    ).run(NOW - 30 * DAY);
+
+    const wi: WorkItem = {
+      id: "the-metafactory/cortex#581", planId: "plan-cockpit", phaseId: "plan-cockpit-phase-a",
+      parentId: null, title: "G-1113.D.4", description: null, status: "open", priority: "",
+      provider: "github", externalId: "the-metafactory/cortex#581", url: "https://x/581",
+    };
+    const res = await refreshCockpit(db, {
+      docsDir: dir,
+      stackId: "laptop",
+      nowEpochSec: NOW,
+      workItemSourceFor: mockFactory({ "plan-cockpit": [wi] }),
+    });
+
+    // Plans: both docs ingested; the github one provider=github, internal one internal.
+    expect(res.plans).toBe(2);
+    expect(getPlan(db, "plan-cockpit")?.provider).toBe("github");
+    expect(getPlan(db, "iteration-internal")?.provider).toBe("internal");
+    // Work items: ingested for the github plan; the internal plan has no source.
+    expect(res.workItems).toBe(1);
+    expect(res.unsupportedProviders).toBe(1); // the internal plan
+    expect(getWorkItem(db, "the-metafactory/cortex#581")?.phaseId).toBe("plan-cockpit-phase-a");
+    expect(listWorkItemsForPlan(db, "plan-cockpit")).toHaveLength(1);
+    // Attention reconcile ran: the pre-seeded stale work item is now flagged.
+    expect(res.attentionOpen).toBeGreaterThanOrEqual(1);
+    expect(listOpenAttention(db).some((a) => a.id === "att:stale:wi-stale")).toBe(true);
+  });
+
+  it("is idempotent — a second refresh yields the same populated state", async () => {
+    const db = freshDb();
+    const dir = docsDir({ "plan-cockpit.md": GH_PLAN });
+    const wi: WorkItem = {
+      id: "o/r#1", planId: "plan-cockpit", phaseId: null, parentId: null, title: "WI",
+      description: null, status: "open", priority: "", provider: "github", externalId: "o/r#1", url: null,
+    };
+    const opts = { docsDir: dir, stackId: "laptop", nowEpochSec: NOW, workItemSourceFor: mockFactory({ "plan-cockpit": [wi] }) };
+    await refreshCockpit(db, opts);
+    const second = await refreshCockpit(db, opts);
+    expect(second.plans).toBe(1);
+    expect(second.workItems).toBe(1);
+    expect(listPlans(db)).toHaveLength(1);
+    expect(listWorkItemsForPlan(db, "plan-cockpit")).toHaveLength(1);
+  });
+
+  it("defaultWorkItemSourceFor dispatches github → GithubWorkItemSource, others → null", () => {
+    expect(defaultWorkItemSourceFor("github")).toBeInstanceOf(GithubWorkItemSource);
+    expect(defaultWorkItemSourceFor("gitlab")).toBeNull();
+    expect(defaultWorkItemSourceFor("internal")).toBeNull();
+  });
+});

--- a/src/surface/mc/__tests__/refresh.test.ts
+++ b/src/surface/mc/__tests__/refresh.test.ts
@@ -106,6 +106,43 @@ describe("refreshCockpit (ML.2)", () => {
     expect(listWorkItemsForPlan(db, "plan-cockpit")).toHaveLength(1);
   });
 
+  it("a github plan with a null umbrella dispatches the source but ingests nothing (honest no-op)", async () => {
+    const db = freshDb();
+    // No **Umbrella** line → provider stays internal → no github source. To exercise
+    // a github plan whose source returns [] (null-umbrella no-op), inject a source
+    // that returns [] and a doc whose umbrella makes it github.
+    const dir = docsDir({ "plan-cockpit.md": GH_PLAN });
+    const res = await refreshCockpit(db, {
+      docsDir: dir, stackId: "laptop", nowEpochSec: NOW,
+      workItemSourceFor: mockFactory({}), // github source returns [] for this plan
+    });
+    expect(res.plans).toBe(1);
+    expect(res.workItems).toBe(0);
+    expect(res.unsupportedProviders).toBe(0); // a source WAS dispatched, it just had nothing
+    expect(res.failedPlans).toBe(0);
+    expect(listWorkItemsForPlan(db, "plan-cockpit")).toEqual([]);
+  });
+
+  it("isolates a throwing source: the batch continues + reconcile still runs", async () => {
+    const db = freshDb();
+    const dir = docsDir({ "plan-cockpit.md": GH_PLAN });
+    db.query(
+      `INSERT INTO work_items (id, title, status, priority, provider, updated_at) VALUES ('wi-stale', 'old', 'open', '', 'github', ?)`
+    ).run(NOW - 30 * DAY);
+    const throwingFactory: WorkItemSourceFactory = (provider) =>
+      provider === "github"
+        ? ({ provider: "github", fetchWorkItems: async () => { throw new Error("gh boom"); } } satisfies WorkItemSource)
+        : null;
+    const res = await refreshCockpit(db, {
+      docsDir: dir, stackId: "laptop", nowEpochSec: NOW, workItemSourceFor: throwingFactory,
+    });
+    expect(res.failedPlans).toBe(1); // the throw was isolated, not propagated
+    expect(res.workItems).toBe(0);
+    // reconcile still ran despite the failed plan — the stale item is flagged.
+    expect(res.attentionOpen).toBeGreaterThanOrEqual(1);
+    expect(listOpenAttention(db).some((a) => a.id === "att:stale:wi-stale")).toBe(true);
+  });
+
   it("defaultWorkItemSourceFor dispatches github → GithubWorkItemSource, others → null", () => {
     expect(defaultWorkItemSourceFor("github")).toBeInstanceOf(GithubWorkItemSource);
     expect(defaultWorkItemSourceFor("gitlab")).toBeNull();

--- a/src/surface/mc/refresh.ts
+++ b/src/surface/mc/refresh.ts
@@ -1,0 +1,106 @@
+/**
+ * ML.2 — cockpit refresh orchestrator (make-it-live runtime trigger).
+ *
+ * Chains the three deferred-until-now mechanisms into one principal-triggered
+ * pass that pulls real data through the cockpit:
+ *   1. plan-doc ingestion (D.2)      — docs/plan-*.md + iteration-*.md → Plan + phases
+ *   2. work-item ingestion (D.5b)    — per plan, dispatched by provider → WorkItems
+ *   3. attention reconcile (E.2)     — derive the open attention set from the new state
+ *
+ * Provider dispatch is INJECTED (`workItemSourceFor`) so the orchestrator stays
+ * provider-neutral + testable; `defaultWorkItemSourceFor` is the production
+ * factory (GitHub today, more providers as their sources land). Notification
+ * publish (ML.3) consumes the reconcile result separately.
+ */
+import type { Database } from "bun:sqlite";
+import type { Provider } from "./types";
+import { ingestPlanDocsFromDir } from "./ingest/plan-docs";
+import { ingestWorkItems, type WorkItemSource } from "./adapters/work-item-source";
+import { GithubWorkItemSource } from "./adapters/github/work-items";
+import { reconcileAttention } from "./db/attention-sources";
+
+/** Map a plan's provider → the WorkItemSource that ingests its work items (null = unsupported). */
+export type WorkItemSourceFactory = (provider: Provider) => WorkItemSource | null;
+
+/**
+ * Production dispatch: GitHub is the first (and today only) adapter. Other
+ * providers return null until their WorkItemSource lands — the orchestrator
+ * skips them (their plans still ingest as skeletons).
+ */
+export function defaultWorkItemSourceFor(provider: Provider): WorkItemSource | null {
+  if (provider === "github") return new GithubWorkItemSource();
+  return null;
+}
+
+export interface RefreshCockpitOptions {
+  /** Absolute path to the docs dir holding the plan/iteration docs. */
+  docsDir: string;
+  /** Repo-relative prefix recorded on each plan's path (default "docs"). */
+  repoRelDir?: string;
+  /** Build a sourceDocumentUrl from a repo-relative path. */
+  urlForPath?: (repoRelPath: string) => string | null;
+  /** Default {owner, repo} for qualifying short umbrella refs (ML.1). */
+  defaultRepo?: { owner: string; repo: string };
+  /** Stack id stamped on produced attention items (E.2). */
+  stackId: string;
+  /** Provider → WorkItemSource dispatch. Defaults to {@link defaultWorkItemSourceFor}. */
+  workItemSourceFor?: WorkItemSourceFactory;
+  /** Stale threshold for attention (E.2). */
+  staleAfterMs?: number;
+  /** Injected current epoch seconds (deterministic tests). */
+  nowEpochSec?: number;
+}
+
+export interface RefreshResult {
+  /** Plans ingested from docs. */
+  plans: number;
+  /** Work items ingested across all plans. */
+  workItems: number;
+  /** Plans whose provider had no WorkItemSource (skipped ingestion). */
+  unsupportedProviders: number;
+  /** Open attention items after reconcile. */
+  attentionOpen: number;
+}
+
+/**
+ * Run one full cockpit refresh. Principal-triggered; safe to re-run (every step
+ * is idempotent — upsert by deterministic id + reconcile diff).
+ */
+export async function refreshCockpit(db: Database, opts: RefreshCockpitOptions): Promise<RefreshResult> {
+  const sourceFor = opts.workItemSourceFor ?? defaultWorkItemSourceFor;
+
+  // 1. Plan docs → plans + phases (+ umbrella linkage from ML.1).
+  const parsed = ingestPlanDocsFromDir(db, {
+    docsDir: opts.docsDir,
+    repoRelDir: opts.repoRelDir,
+    urlForPath: opts.urlForPath,
+    defaultRepo: opts.defaultRepo,
+  });
+
+  // 2. Per plan, dispatch a source by provider and ingest its work items.
+  let workItems = 0;
+  let unsupportedProviders = 0;
+  for (const { plan } of parsed) {
+    const source = sourceFor(plan.provider);
+    if (source === null) {
+      unsupportedProviders += 1;
+      continue;
+    }
+    const res = await ingestWorkItems(db, source, plan.id);
+    workItems += res.workItems.length;
+  }
+
+  // 3. Reconcile attention from the freshly-ingested state.
+  const attention = reconcileAttention(db, {
+    stackId: opts.stackId,
+    staleAfterMs: opts.staleAfterMs,
+    nowEpochSec: opts.nowEpochSec,
+  });
+
+  return {
+    plans: parsed.length,
+    workItems,
+    unsupportedProviders,
+    attentionOpen: attention.open.length,
+  };
+}

--- a/src/surface/mc/refresh.ts
+++ b/src/surface/mc/refresh.ts
@@ -58,6 +58,8 @@ export interface RefreshResult {
   workItems: number;
   /** Plans whose provider had no WorkItemSource (skipped ingestion). */
   unsupportedProviders: number;
+  /** Plans whose work-item ingestion threw (isolated; reconcile still ran). */
+  failedPlans: number;
   /** Open attention items after reconcile. */
   attentionOpen: number;
 }
@@ -78,16 +80,27 @@ export async function refreshCockpit(db: Database, opts: RefreshCockpitOptions):
   });
 
   // 2. Per plan, dispatch a source by provider and ingest its work items.
+  //    Isolate each plan: one provider source misbehaving must NOT abort the
+  //    batch or skip the reconcile step (best-effort, matching the posture the
+  //    GithubWorkItemSource already takes internally).
   let workItems = 0;
   let unsupportedProviders = 0;
+  let failedPlans = 0;
   for (const { plan } of parsed) {
     const source = sourceFor(plan.provider);
     if (source === null) {
       unsupportedProviders += 1;
       continue;
     }
-    const res = await ingestWorkItems(db, source, plan.id);
-    workItems += res.workItems.length;
+    try {
+      const res = await ingestWorkItems(db, source, plan.id);
+      workItems += res.workItems.length;
+    } catch (err) {
+      failedPlans += 1;
+      process.stderr.write(
+        `[cockpit-refresh] work-item ingestion failed for plan ${plan.id}: ${err instanceof Error ? err.message : String(err)}\n`
+      );
+    }
   }
 
   // 3. Reconcile attention from the freshly-ingested state.
@@ -101,6 +114,7 @@ export async function refreshCockpit(db: Database, opts: RefreshCockpitOptions):
     plans: parsed.length,
     workItems,
     unsupportedProviders,
+    failedPlans,
     attentionOpen: attention.open.length,
   };
 }


### PR DESCRIPTION
## ML.2 — cockpit refresh orchestrator

The make-it-live trigger: chains the three deferred mechanisms into one re-runnable pass that pulls real data through the cockpit.

### What's here
- **`src/surface/mc/refresh.ts`**
  - `refreshCockpit(db, opts)` — runs **plan-doc ingestion (D.2) → provider-dispatched work-item ingestion (D.5b) → attention reconcile (E.2)**, idempotent (every step upserts by deterministic id / diffs).
  - `workItemSourceFor` dispatch is **injected** (provider-neutral + testable); `defaultWorkItemSourceFor` is the production factory (`github` → `GithubWorkItemSource`; other providers skipped until their source lands — their plans still ingest as skeletons).
  - returns counts: `plans` / `workItems` / `unsupportedProviders` / `attentionOpen`.
- **`__tests__/refresh.test.ts`** — the **full chain end-to-end**: a github-umbrella plan doc → `plan(provider=github)` → mock-source work items persisted; an internal plan → unsupported/skipped; a pre-seeded stale work item flagged by the reconcile step. Plus idempotent re-run + the default dispatch factory.

### Trigger wiring
The HTTP/CLI entry point that calls `refreshCockpit` with config-resolved opts (`docsDir` / `defaultRepo` / `stackId`) is the thin final step — kept out of this slice since it needs a small config addition; the orchestrator + its end-to-end test are the substantive, proven mechanism.

### Verification
- `bunx tsc --noEmit` clean · `bun run lint` 0 errors · carve-out gate PASS · `bun test src/surface/mc` 1276 pass / 0 fail · merge-guard clean

Closes #616. Part of #614. (ML.3 — publish the reconcile delta as `system.attention.*` — is next.)