### PR TITLE
feat(mc): ML.3 — publish attention notifications (system.attention.* onto the bus)

### DIFF
--- a/src/cli/__tests__/cockpit-refresh.test.ts
+++ b/src/cli/__tests__/cockpit-refresh.test.ts
@@ -33,7 +33,7 @@ describe("parseCockpitRefreshArgs (ML.2)", () => {
 });
 
 describe("runCockpitRefresh (ML.2)", () => {
-  const RESULT: RefreshResult = { plans: 2, workItems: 3, unsupportedProviders: 1, failedPlans: 0, attentionOpen: 1 };
+  const RESULT: RefreshResult = { plans: 2, workItems: 3, unsupportedProviders: 1, failedPlans: 0, attentionOpen: 1, notifiedOpened: 0, notifiedResolved: 0 };
 
   it("opens the db at the given path and threads parsed opts into refresh", async () => {
     const openedPaths: string[] = [];

--- a/src/surface/mc/__tests__/attention-publish.test.ts
+++ b/src/surface/mc/__tests__/attention-publish.test.ts
@@ -45,6 +45,34 @@ describe("reconcileAttention delta (ML.3)", () => {
     expect(r3.opened).toEqual([]);
     expect(r3.resolved.map((i) => i.id)).toEqual(["att:stale:wi"]);
   });
+
+  it("respects dismiss: a dismissed-but-still-stale item is NOT reopened or re-notified", () => {
+    const db = freshDb(paths);
+    db.query(`INSERT INTO work_items (id, title, status, priority, provider, updated_at) VALUES ('wi', 'x', 'open', '', 'github', ?)`).run(NOW - 30 * DAY);
+    const opts = { stackId: "laptop", nowEpochSec: NOW };
+    reconcileAttention(db, opts); // opens att:stale:wi
+    // Principal dismisses it (still stale).
+    db.query(`UPDATE attention_items SET status = 'dismissed' WHERE id = 'att:stale:wi'`).run();
+    const r = reconcileAttention(db, opts);
+    expect(r.opened).toEqual([]); // not re-notified
+    // And the row stays dismissed (not clobbered back to open).
+    const row = db.query(`SELECT status FROM attention_items WHERE id = 'att:stale:wi'`).get() as { status: string };
+    expect(row.status).toBe("dismissed");
+    expect(r.open.some((i) => i.id === "att:stale:wi")).toBe(false);
+  });
+
+  it("re-notifies after RESOLVE (not dismiss): a recurring condition opens again", () => {
+    const db = freshDb(paths);
+    db.query(`INSERT INTO work_items (id, title, status, priority, provider, updated_at) VALUES ('wi', 'x', 'open', '', 'github', ?)`).run(NOW - 30 * DAY);
+    const opts = { stackId: "laptop", nowEpochSec: NOW };
+    reconcileAttention(db, opts); // opened
+    db.query(`UPDATE work_items SET updated_at = ? WHERE id = 'wi'`).run(NOW); // touch → resolved next run
+    reconcileAttention(db, opts);
+    // Re-age it → recurs → should re-open + re-notify (resolved≠dismissed).
+    db.query(`UPDATE work_items SET updated_at = ? WHERE id = 'wi'`).run(NOW - 30 * DAY);
+    const r = reconcileAttention(db, opts);
+    expect(r.opened.map((i) => i.id)).toEqual(["att:stale:wi"]);
+  });
 });
 
 describe("publishReconcileDelta (ML.3)", () => {

--- a/src/surface/mc/__tests__/attention-publish.test.ts
+++ b/src/surface/mc/__tests__/attention-publish.test.ts
@@ -1,0 +1,110 @@
+/**
+ * ML.3 — reconcile delta (opened/resolved) + publishReconcileDelta + the
+ * refreshCockpit publish step.
+ */
+import { describe, it, expect, afterEach } from "bun:test";
+import { join } from "path";
+import { tmpdir } from "os";
+import { mkdtempSync, writeFileSync, rmSync, existsSync } from "fs";
+import { initDatabase } from "../db/init";
+import { reconcileAttention } from "../db/attention-sources";
+import { publishReconcileDelta } from "../attention-notify";
+import { refreshCockpit } from "../refresh";
+import type { Envelope } from "../../../bus/myelin/envelope-validator";
+import type { AttentionItem } from "../types";
+
+const NOW = 1_900_000_000;
+const DAY = 24 * 60 * 60;
+
+function freshDb(paths: string[]) {
+  const p = join(tmpdir(), `attpub-${Date.now()}-${Math.random().toString(36).slice(2)}.db`);
+  paths.push(p);
+  return initDatabase(p);
+}
+
+describe("reconcileAttention delta (ML.3)", () => {
+  const paths: string[] = [];
+  afterEach(() => { for (const p of paths) if (existsSync(p)) rmSync(p); paths.length = 0; });
+
+  it("reports newly-opened on first sight, then nothing on a no-change re-run, then resolved when cleared", () => {
+    const db = freshDb(paths);
+    db.query(`INSERT INTO work_items (id, title, status, priority, provider, updated_at) VALUES ('wi', 'x', 'open', '', 'github', ?)`).run(NOW - 30 * DAY);
+    const opts = { stackId: "laptop", nowEpochSec: NOW };
+
+    const r1 = reconcileAttention(db, opts);
+    expect(r1.opened.map((i) => i.id)).toEqual(["att:stale:wi"]); // first sight → opened
+    expect(r1.resolved).toEqual([]);
+
+    const r2 = reconcileAttention(db, opts);
+    expect(r2.opened).toEqual([]); // already open → not re-reported
+    expect(r2.resolved).toEqual([]);
+
+    // Touch the work item → no longer stale → resolved delta.
+    db.query(`UPDATE work_items SET updated_at = ? WHERE id = 'wi'`).run(NOW);
+    const r3 = reconcileAttention(db, opts);
+    expect(r3.opened).toEqual([]);
+    expect(r3.resolved.map((i) => i.id)).toEqual(["att:stale:wi"]);
+  });
+});
+
+describe("publishReconcileDelta (ML.3)", () => {
+  it("publishes opened → system.attention.opened and resolved → system.attention.resolved", async () => {
+    const published: Envelope[] = [];
+    const item = (id: string, over: Partial<AttentionItem> = {}): AttentionItem => ({
+      id, stackId: "laptop", workItemId: "wi-1", sessionId: null, kind: "stale", severity: "low", status: "open", ...over,
+    });
+    const n = await publishReconcileDelta(
+      { opened: [item("a-1")], resolved: [item("a-2", { status: "resolved" })] },
+      { source: { principal: "metafactory" }, deepLinkFor: (it) => `https://x/${it.id}` },
+      (env) => { published.push(env); }
+    );
+    expect(n).toEqual({ opened: 1, resolved: 1 });
+    expect(published.map((e) => e.type)).toEqual(["system.attention.opened", "system.attention.resolved"]);
+    expect((published[0]?.payload as { deep_link_url: string }).deep_link_url).toBe("https://x/a-1");
+  });
+});
+
+describe("refreshCockpit publish step (ML.3)", () => {
+  const paths: string[] = [];
+  const dirs: string[] = [];
+  afterEach(() => {
+    for (const p of paths) if (existsSync(p)) rmSync(p);
+    for (const d of dirs) if (existsSync(d)) rmSync(d, { recursive: true, force: true });
+    paths.length = 0; dirs.length = 0;
+  });
+
+  it("publishes the reconcile delta when a publisher + source are supplied", async () => {
+    const db = freshDb(paths);
+    const dir = mkdtempSync(join(tmpdir(), "attpub-docs-"));
+    dirs.push(dir);
+    writeFileSync(join(dir, "plan-x.md"), "# P\n\n**Status:** active\n\n## Phase A — X\n");
+    // A stale work item → reconcile opens one attention item to notify on.
+    db.query(`INSERT INTO work_items (id, title, status, priority, provider, updated_at) VALUES ('wi', 'x', 'open', '', 'github', ?)`).run(NOW - 30 * DAY);
+
+    const published: Envelope[] = [];
+    const res = await refreshCockpit(db, {
+      docsDir: dir,
+      stackId: "laptop",
+      nowEpochSec: NOW,
+      workItemSourceFor: () => null, // no work-item ingestion needed here
+      publish: (env) => { published.push(env); },
+      notifySource: { principal: "metafactory" },
+      deepLinkFor: (it) => `https://x/${it.id}`,
+    });
+    expect(res.notifiedOpened).toBe(1);
+    expect(res.notifiedResolved).toBe(0);
+    expect(published.map((e) => e.type)).toEqual(["system.attention.opened"]);
+  });
+
+  it("publishes nothing when no publisher is wired (the DB-only CLI path)", async () => {
+    const db = freshDb(paths);
+    const dir = mkdtempSync(join(tmpdir(), "attpub-docs-"));
+    dirs.push(dir);
+    writeFileSync(join(dir, "plan-x.md"), "# P\n\n**Status:** active\n\n## Phase A — X\n");
+    db.query(`INSERT INTO work_items (id, title, status, priority, provider, updated_at) VALUES ('wi', 'x', 'open', '', 'github', ?)`).run(NOW - 30 * DAY);
+    const res = await refreshCockpit(db, { docsDir: dir, stackId: "laptop", nowEpochSec: NOW, workItemSourceFor: () => null });
+    expect(res.notifiedOpened).toBe(0);
+    expect(res.notifiedResolved).toBe(0);
+    expect(res.attentionOpen).toBeGreaterThanOrEqual(1); // reconcile still ran
+  });
+});

--- a/src/surface/mc/attention-notify.ts
+++ b/src/surface/mc/attention-notify.ts
@@ -121,3 +121,18 @@ export async function publishAttentionNotifications(
   }
   return count;
 }
+
+/**
+ * ML.3 — publish a reconcile delta: newly-opened items as `system.attention.opened`
+ * and newly-resolved as `system.attention.resolved`, via the injected publisher.
+ * The thin glue between {@link reconcileAttention}'s delta and E.4's envelopes.
+ */
+export async function publishReconcileDelta(
+  delta: { opened: AttentionItem[]; resolved: AttentionItem[] },
+  opts: AttentionNotifyOptions & { deepLinkFor?: (item: AttentionItem) => string | null },
+  publish: EnvelopePublisher,
+): Promise<{ opened: number; resolved: number }> {
+  const opened = await publishAttentionNotifications(delta.opened, "opened", opts, publish);
+  const resolved = await publishAttentionNotifications(delta.resolved, "resolved", opts, publish);
+  return { opened, resolved };
+}

--- a/src/surface/mc/db/attention-sources.ts
+++ b/src/surface/mc/db/attention-sources.ts
@@ -75,10 +75,17 @@ export function reconcileAttention(db: Database, opts: ReconcileAttentionOptions
   const nowSec = opts.nowEpochSec ?? Math.floor(Date.now() / 1000);
   const staleBeforeSec = nowSec - Math.floor((opts.staleAfterMs ?? DEFAULT_STALE_AFTER_MS) / 1000);
 
-  // Snapshot the open set BEFORE mutating, to compute the open/resolve delta
-  // (ML.3 — what to notify on). An item absent-before-but-derived-now is newly
-  // opened (incl. a re-opened condition that was previously resolved).
-  const openBefore = new Set(listOpenAttention(db).map((i) => i.id));
+  // Snapshot the prior NON-resolved set (open + dismissed) BEFORE mutating, to
+  // compute the open/resolve delta (ML.3 — what to notify on) AND to respect
+  // dismiss. A dismissed item is "seen" — re-deriving it must NOT reopen it or
+  // re-notify (the principal said "stop showing me this"). Only an item absent
+  // from BOTH open and dismissed (i.e. genuinely new, or previously *resolved*
+  // and now recurring) counts as newly opened.
+  const priorRows = db
+    .query(`SELECT id, status FROM attention_items WHERE status IN ('open', 'dismissed')`)
+    .all() as { id: string; status: string }[];
+  const dismissedIds = new Set(priorRows.filter((r) => r.status === "dismissed").map((r) => r.id));
+  const seenBefore = new Set(priorRows.map((r) => r.id)); // open ∪ dismissed
 
   const derived = new Map<string, AttentionItem>();
 
@@ -125,11 +132,15 @@ export function reconcileAttention(db: Database, opts: ReconcileAttentionOptions
     });
   }
 
-  // Upsert everything derived as open (idempotent by id).
-  for (const item of derived.values()) upsertAttentionItem(db, item);
+  // Upsert derived items as open — but NEVER resurrect a dismissed one (skip it,
+  // leaving its 'dismissed' status intact so it neither reopens nor re-notifies).
+  for (const item of derived.values()) {
+    if (dismissedIds.has(item.id)) continue;
+    upsertAttentionItem(db, item);
+  }
 
-  // newly-opened = derived now but not open before this run.
-  const opened = [...derived.values()].filter((i) => !openBefore.has(i.id));
+  // newly-opened = derived now but not seen before (not open, not dismissed).
+  const opened = [...derived.values()].filter((i) => !seenBefore.has(i.id));
 
   // Resolve previously-open RECONCILED items whose condition no longer holds
   // (assignment unblocked / work item touched or terminal). Only our own
@@ -143,5 +154,7 @@ export function reconcileAttention(db: Database, opts: ReconcileAttentionOptions
     }
   }
 
-  return { open: [...derived.values()], opened, resolved };
+  // `open` reflects what's actually open: derived minus the dismissed (skipped) ones.
+  const open = [...derived.values()].filter((i) => !dismissedIds.has(i.id));
+  return { open, opened, resolved };
 }

--- a/src/surface/mc/db/attention-sources.ts
+++ b/src/surface/mc/db/attention-sources.ts
@@ -45,6 +45,15 @@ export interface ReconcileAttentionOptions {
   nowEpochSec?: number;
 }
 
+export interface ReconcileResult {
+  /** The full set of items currently open after this reconcile. */
+  open: AttentionItem[];
+  /** Items that transitioned absent → open this run (notify "opened"). */
+  opened: AttentionItem[];
+  /** Items that transitioned open → resolved this run (notify "resolved"). */
+  resolved: AttentionItem[];
+}
+
 /** Map a block reason to its attention kind + severity. Exhaustive over BlockReason. */
 function blockReasonToAttention(reason: BlockReason): { kind: AttentionKind; severity: AttentionSeverity } {
   switch (reason.kind) {
@@ -62,9 +71,14 @@ function blockReasonToAttention(reason: BlockReason): { kind: AttentionKind; sev
  * any previously-open reconciled item whose condition has cleared. Idempotent.
  * Returns the items currently derived as open.
  */
-export function reconcileAttention(db: Database, opts: ReconcileAttentionOptions): { open: AttentionItem[] } {
+export function reconcileAttention(db: Database, opts: ReconcileAttentionOptions): ReconcileResult {
   const nowSec = opts.nowEpochSec ?? Math.floor(Date.now() / 1000);
   const staleBeforeSec = nowSec - Math.floor((opts.staleAfterMs ?? DEFAULT_STALE_AFTER_MS) / 1000);
+
+  // Snapshot the open set BEFORE mutating, to compute the open/resolve delta
+  // (ML.3 — what to notify on). An item absent-before-but-derived-now is newly
+  // opened (incl. a re-opened condition that was previously resolved).
+  const openBefore = new Set(listOpenAttention(db).map((i) => i.id));
 
   const derived = new Map<string, AttentionItem>();
 
@@ -114,13 +128,20 @@ export function reconcileAttention(db: Database, opts: ReconcileAttentionOptions
   // Upsert everything derived as open (idempotent by id).
   for (const item of derived.values()) upsertAttentionItem(db, item);
 
+  // newly-opened = derived now but not open before this run.
+  const opened = [...derived.values()].filter((i) => !openBefore.has(i.id));
+
   // Resolve previously-open RECONCILED items whose condition no longer holds
   // (assignment unblocked / work item touched or terminal). Only our own
   // prefixes — never touch items produced by other sources.
+  const resolved: AttentionItem[] = [];
   for (const open of listOpenAttention(db)) {
     const reconciled = open.id.startsWith(BLOCK_PREFIX) || open.id.startsWith(STALE_PREFIX);
-    if (reconciled && !derived.has(open.id)) resolveAttentionItem(db, open.id);
+    if (reconciled && !derived.has(open.id)) {
+      resolveAttentionItem(db, open.id);
+      resolved.push(open);
+    }
   }
 
-  return { open: [...derived.values()] };
+  return { open: [...derived.values()], opened, resolved };
 }

--- a/src/surface/mc/refresh.ts
+++ b/src/surface/mc/refresh.ts
@@ -18,6 +18,12 @@ import { ingestPlanDocsFromDir } from "./ingest/plan-docs";
 import { ingestWorkItems, type WorkItemSource } from "./adapters/work-item-source";
 import { GithubWorkItemSource } from "./adapters/github/work-items";
 import { reconcileAttention } from "./db/attention-sources";
+import {
+  publishReconcileDelta,
+  type AttentionNotifySource,
+  type EnvelopePublisher,
+} from "./attention-notify";
+import type { AttentionItem } from "./types";
 
 /** Map a plan's provider → the WorkItemSource that ingests its work items (null = unsupported). */
 export type WorkItemSourceFactory = (provider: Provider) => WorkItemSource | null;
@@ -49,6 +55,15 @@ export interface RefreshCockpitOptions {
   staleAfterMs?: number;
   /** Injected current epoch seconds (deterministic tests). */
   nowEpochSec?: number;
+  /**
+   * ML.3 — optional bus publisher. When provided (with `notifySource`), the
+   * reconcile delta is published as `system.attention.*` envelopes. Omitted by
+   * the DB-only CLI trigger; supplied by the bot where the MyelinRuntime lives.
+   */
+  publish?: EnvelopePublisher;
+  notifySource?: AttentionNotifySource;
+  /** Builds a deep-link URL for an attention item (for the notification). */
+  deepLinkFor?: (item: AttentionItem) => string | null;
 }
 
 export interface RefreshResult {
@@ -62,6 +77,9 @@ export interface RefreshResult {
   failedPlans: number;
   /** Open attention items after reconcile. */
   attentionOpen: number;
+  /** Attention notifications published this run (0 when no publisher is wired). */
+  notifiedOpened: number;
+  notifiedResolved: number;
 }
 
 /**
@@ -110,11 +128,34 @@ export async function refreshCockpit(db: Database, opts: RefreshCockpitOptions):
     nowEpochSec: opts.nowEpochSec,
   });
 
+  // 4. ML.3 — publish the open/resolve delta onto the bus when a publisher is
+  //    wired (the bot; the DB-only CLI omits it). Best-effort: never let a
+  //    publish failure abort the refresh.
+  let notifiedOpened = 0;
+  let notifiedResolved = 0;
+  if (opts.publish && opts.notifySource) {
+    try {
+      const n = await publishReconcileDelta(
+        { opened: attention.opened, resolved: attention.resolved },
+        { source: opts.notifySource, deepLinkFor: opts.deepLinkFor },
+        opts.publish
+      );
+      notifiedOpened = n.opened;
+      notifiedResolved = n.resolved;
+    } catch (err) {
+      process.stderr.write(
+        `[cockpit-refresh] attention notification publish failed: ${err instanceof Error ? err.message : String(err)}\n`
+      );
+    }
+  }
+
   return {
     plans: parsed.length,
     workItems,
     unsupportedProviders,
     failedPlans,
     attentionOpen: attention.open.length,
+    notifiedOpened,
+    notifiedResolved,
   };
 }

--- a/src/surface/mc/refresh.ts
+++ b/src/surface/mc/refresh.ts
@@ -133,6 +133,11 @@ export async function refreshCockpit(db: Database, opts: RefreshCockpitOptions):
   //    publish failure abort the refresh.
   let notifiedOpened = 0;
   let notifiedResolved = 0;
+  if (opts.publish && !opts.notifySource) {
+    process.stderr.write(
+      "[cockpit-refresh] publisher supplied without notifySource — attention notifications skipped\n"
+    );
+  }
   if (opts.publish && opts.notifySource) {
     try {
       const n = await publishReconcileDelta(


### PR DESCRIPTION
## ML.3 — publish attention notifications

Wires the reconcile delta onto the bus so attention surfaces get notified.

### What's here
- **`db/attention-sources.ts`** — `reconcileAttention` now returns a **delta**: `{ open, opened, resolved }` (snapshots the open set before mutating). `opened` = absent-before-but-derived-now (incl. a re-opened condition); `resolved` = open→resolved this run. Existing `.open` consumers are unaffected.
- **`attention-notify.ts`** — `publishReconcileDelta(delta, opts, publish)` maps `opened` → `system.attention.opened` + `resolved` → `system.attention.resolved` via E.4's `publishAttentionNotifications`.
- **`refresh.ts`** — `refreshCockpit` gains optional `publish` + `notifySource` + `deepLinkFor`; after reconcile it publishes the delta (**best-effort** — a publish failure logs to stderr, never aborts the refresh). `RefreshResult` gains `notifiedOpened`/`notifiedResolved`. The DB-only CLI omits the publisher; the **bot** supplies `MyelinRuntime.publish` (the bus-runtime context).
- **tests** — reconcile delta (opened on first sight / silent on no-change / resolved when cleared); `publishReconcileDelta` envelope types + deep-links; `refreshCockpit` publish step with + without a publisher.

### Verification
- `bunx tsc --noEmit` clean · `bun run lint` 0 errors · carve-out gate PASS · `bun test src/surface/mc src/cli` 1600 pass / 0 fail · merge-guard clean

Closes #617. Part of #614. (ML.4 — the Discord render branch for `system.attention.*` — is the last slice.)