### PR TITLE
feat(mc): ML.4 — Discord render branch for system.attention.*

### DIFF
--- a/src/adapters/__tests__/review-sink.test.ts
+++ b/src/adapters/__tests__/review-sink.test.ts
@@ -684,4 +684,41 @@ describe("review-sink — attention delivery (ML.4)", () => {
     await flushMicrotasks();
     expect(adapter.sentMessages).toHaveLength(0);
   });
+
+  test("attentionRouting must NOT rescue a non-attention envelope with no response_routing", async () => {
+    const { runtime, trigger } = fakeRuntime();
+    const adapter = discordMock();
+    const sink = createReviewSink({
+      runtime, adapters: [adapter], principal: "metafactory",
+      attentionRouting: logicalRouting("discord", "attention"),
+    });
+    await sink.start();
+    // A verdict with NO response_routing (pilot-only/Offer) must stay ignored —
+    // attentionRouting is for system.attention.* only, never verdict/lifecycle.
+    trigger(envelope("review.verdict.approved", verdictPayload({ verdict: "approved" })));
+    await flushMicrotasks();
+    expect(adapter.sentMessages).toHaveLength(0);
+  });
+
+  test("an attention envelope's own response_routing wins over attentionRouting", async () => {
+    const { runtime, trigger } = fakeRuntime();
+    const adapter = discordMock();
+    const sink = createReviewSink({
+      runtime, adapters: [adapter], principal: "metafactory",
+      attentionRouting: logicalRouting("discord", "attention"),
+    });
+    await sink.start();
+    trigger(
+      envelope("system.attention.opened", {
+        attention: { id: "att:stale:wi-1" },
+        deep_link_url: null,
+        presentation: "[low] stale needs attention",
+        response_routing: logicalRouting("discord", "ops", "ops/thread"),
+      })
+    );
+    await flushMicrotasks();
+    // Routed to the envelope's own response_routing, not the configured default.
+    expect(adapter.logicalTargetsResolved).toEqual([{ surface: "discord", channel: "ops", thread: "ops/thread" }]);
+    expect(adapter.sentMessages).toHaveLength(1);
+  });
 });

--- a/src/adapters/__tests__/review-sink.test.ts
+++ b/src/adapters/__tests__/review-sink.test.ts
@@ -119,10 +119,12 @@ describe("review-sink — subscription", () => {
     expect(sink.subjects).toEqual([
       "local.metafactory.dispatch.task.>",
       "local.metafactory.review.verdict.>",
+      "local.metafactory.system.attention.>",
     ]);
     expect(subscribedPatterns).toEqual([
       "local.metafactory.dispatch.task.>",
       "local.metafactory.review.verdict.>",
+      "local.metafactory.system.attention.>",
     ]);
   });
 
@@ -138,6 +140,7 @@ describe("review-sink — subscription", () => {
     expect(subscribedPatterns).toEqual([
       "local.andreas.meta-factory.dispatch.task.>",
       "local.andreas.meta-factory.review.verdict.>",
+      "local.andreas.meta-factory.system.attention.>",
     ]);
   });
 
@@ -146,7 +149,7 @@ describe("review-sink — subscription", () => {
     const sink = createReviewSink({ runtime, adapters: [], principal: "metafactory" });
     await sink.start();
     await sink.start();
-    expect(subscribedPatterns).toHaveLength(2);
+    expect(subscribedPatterns).toHaveLength(3);
     await sink.stop();
     await sink.stop();
     expect(subscribers.every((s) => s.stopped)).toBe(true);
@@ -627,5 +630,58 @@ describe("review-sink — cortex#503 presentation rendering", () => {
 
     // Exactly ONE post despite two deliveries.
     expect(adapter.sentMessages).toHaveLength(1);
+  });
+});
+
+describe("review-sink — attention delivery (ML.4)", () => {
+  const attnPayload = (presentation: string) => ({
+    attention: { id: "att:stale:wi-1", stack_id: "laptop", kind: "stale", severity: "low", work_item_id: "wi-1", session_id: null },
+    deep_link_url: "https://cortex.meta-factory.ai/work-items/wi-1",
+    presentation,
+  });
+
+  test("posts the deterministic presentation to the configured attention channel", async () => {
+    const { runtime, trigger } = fakeRuntime();
+    const adapter = discordMock();
+    const sink = createReviewSink({
+      runtime,
+      adapters: [adapter],
+      principal: "metafactory",
+      attentionRouting: logicalRouting("discord", "attention"),
+    });
+    await sink.start();
+
+    trigger(envelope("system.attention.opened", attnPayload("[low] stale needs attention — https://x/wi-1")));
+    await flushMicrotasks();
+
+    // Routed to the CONFIGURED attention channel (no response_routing on the envelope).
+    expect(adapter.logicalTargetsResolved).toEqual([{ surface: "discord", channel: "attention" }]);
+    expect(adapter.sentMessages).toHaveLength(1);
+    // Posts the presentation verbatim (no @reviewer ping — attention isn't a reply).
+    expect(adapter.sentMessages[0]!.text).toBe("[low] stale needs attention — https://x/wi-1");
+    expect(adapter.sentMessages[0]!.text).not.toContain("@");
+  });
+
+  test("ignored when no attentionRouting is configured (no destination)", async () => {
+    const { runtime, trigger } = fakeRuntime();
+    const adapter = discordMock();
+    const sink = createReviewSink({ runtime, adapters: [adapter], principal: "metafactory" });
+    await sink.start();
+    trigger(envelope("system.attention.resolved", attnPayload("[low] stale cleared")));
+    await flushMicrotasks();
+    expect(adapter.sentMessages).toHaveLength(0);
+  });
+
+  test("an envelope with no presentation is not posted", async () => {
+    const { runtime, trigger } = fakeRuntime();
+    const adapter = discordMock();
+    const sink = createReviewSink({
+      runtime, adapters: [adapter], principal: "metafactory",
+      attentionRouting: logicalRouting("discord", "attention"),
+    });
+    await sink.start();
+    trigger(envelope("system.attention.opened", { attention: {}, deep_link_url: null }));
+    await flushMicrotasks();
+    expect(adapter.sentMessages).toHaveLength(0);
   });
 });

--- a/src/adapters/review-sink.ts
+++ b/src/adapters/review-sink.ts
@@ -96,11 +96,15 @@ function readLogicalRouting(envelope: Envelope): WireLogicalRouting | null {
 
 const LIFECYCLE_TYPE_PREFIX = "dispatch.task.";
 const VERDICT_TYPE_PREFIX = "review.verdict.";
+// G-1113.ML.4 — the attention notification stream (system.attention.{opened,resolved}).
+const ATTENTION_TYPE_PREFIX = "system.attention.";
 
 /** True for the envelope types the review sink acts on. */
 function isReviewSinkType(type: string): boolean {
   return (
-    type.startsWith(LIFECYCLE_TYPE_PREFIX) || type.startsWith(VERDICT_TYPE_PREFIX)
+    type.startsWith(LIFECYCLE_TYPE_PREFIX) ||
+    type.startsWith(VERDICT_TYPE_PREFIX) ||
+    type.startsWith(ATTENTION_TYPE_PREFIX)
   );
 }
 
@@ -126,6 +130,14 @@ export interface ReviewSinkOptions {
   principal: string;
   /** Optional `{stack}` segment (the 6-segment grammar). */
   stack?: string;
+  /**
+   * G-1113.ML.4 — destination for attention notifications. Unlike verdicts
+   * (which reply to the request's `response_routing`), attention items are
+   * unsolicited, so the sink needs a configured channel. When omitted,
+   * `system.attention.*` envelopes are ignored (no destination — matching the
+   * missing-`response_routing` behaviour for verdicts).
+   */
+  attentionRouting?: WireLogicalRouting;
 }
 
 export interface ReviewSink {
@@ -147,7 +159,8 @@ export interface ReviewSink {
  */
 function reviewSubjects(principal: string, stack?: string): string[] {
   const base = stack === undefined ? `local.${principal}` : `local.${principal}.${stack}`;
-  return [`${base}.dispatch.task.>`, `${base}.review.verdict.>`];
+  // G-1113.ML.4 — also the attention stream (same `local` classification).
+  return [`${base}.dispatch.task.>`, `${base}.review.verdict.>`, `${base}.system.attention.>`];
 }
 
 /**
@@ -157,6 +170,16 @@ function reviewSubjects(principal: string, stack?: string): string[] {
  * be posted.
  */
 function renderText(envelope: Envelope): string | null {
+  // G-1113.ML.4 — attention notifications render their deterministic
+  // `presentation` verbatim (built in code by E.4 / ML.3, never an LLM token).
+  // No reviewer mention — an attention item is an unsolicited signal, not a reply.
+  if (envelope.type.startsWith(ATTENTION_TYPE_PREFIX)) {
+    const presentation =
+      typeof envelope.payload.presentation === "string"
+        ? envelope.payload.presentation.trim()
+        : "";
+    return presentation.length > 0 ? presentation : null;
+  }
   if (envelope.type.startsWith(VERDICT_TYPE_PREFIX)) {
     // cortex#503 — surfaces render ONLY the deterministic `presentation`
     // markdown when cortex stamped it (verbatim, never a JSON dump). The
@@ -218,7 +241,7 @@ function reviewingAgentId(envelope: Envelope): string | null {
  * Create a review sink. Wires nothing until `start()` is called.
  */
 export function createReviewSink(opts: ReviewSinkOptions): ReviewSink {
-  const { runtime, adapters, principal, stack } = opts;
+  const { runtime, adapters, principal, stack, attentionRouting } = opts;
   const subjects = reviewSubjects(principal, stack);
 
   let registration: { unregister: () => void } | null = null;
@@ -289,8 +312,14 @@ export function createReviewSink(opts: ReviewSinkOptions): ReviewSink {
   async function deliver(envelope: Envelope): Promise<void> {
     if (!isReviewSinkType(envelope.type)) return;
 
-    const routing = readLogicalRouting(envelope);
-    if (routing === null) return; // pilot-only / bus-peer / Offer / malformed.
+    // Attention notifications carry no `response_routing` (they're unsolicited);
+    // they route to the configured `attentionRouting`. Verdict/lifecycle keep
+    // their reply-to routing. An attention envelope MAY still carry its own
+    // response_routing (forward-compat) — prefer it when present.
+    const routing =
+      readLogicalRouting(envelope) ??
+      (envelope.type.startsWith(ATTENTION_TYPE_PREFIX) ? attentionRouting ?? null : null);
+    if (routing === null) return; // pilot-only / bus-peer / Offer / malformed / unconfigured attention.
 
     const text = renderText(envelope);
     if (text === null || text.length === 0) return;


### PR DESCRIPTION
## ML.4 — Discord render branch for `system.attention.*`

Extends the `review-sink` surface adapter to render attention notifications, mirroring the `review.verdict.*` branch (per #618).

### What's here
- **`adapters/review-sink.ts`**
  - subscribes to `local.{principal}[.{stack}].system.attention.>` (alongside `dispatch.task.>` + `review.verdict.>`).
  - `renderText` renders `system.attention.*` via `payload.presentation` **verbatim** (deterministic, built by E.4/ML.3 — never an LLM token); **no `@reviewer` mention** (attention is unsolicited, not a reply).
  - **routing**: attention items carry no `response_routing` (no reply-to), so they route to a configured **`attentionRouting`** (`{surface, channel, thread?}`) on `ReviewSinkOptions`; omitted → ignored (matches the missing-`response_routing` behaviour for verdicts). An envelope's own `response_routing` still wins if present.
- **`review-sink.test`** — subscription now includes the attention subject; +3 attention-delivery tests (posts the presentation to the configured channel; ignored when unconfigured; no-post when `presentation` is absent).

### Verification
- `bunx tsc --noEmit` clean · `bun run lint` 0 errors · carve-out gate PASS · `bun test src/adapters src/surface/mc src/cli` 1945 pass / 0 fail · merge-guard clean

Closes #618. Part of #614. **ML.5 (#622)** — the bot-side `refreshCockpit` + `MyelinRuntime.publish` trigger (+ passing `attentionRouting` to the sink) — closes the make-it-live loop end-to-end.