### PR TITLE
feat(cortex): ML.5 — bot-side cockpit refresh loop (closes #622)

### DIFF
--- a/src/common/config/__tests__/watcher.test.ts
+++ b/src/common/config/__tests__/watcher.test.ts
@@ -69,6 +69,13 @@ const TEST_CONFIG: AgentConfig = {
     publishedEventsDir: "~/.claude/events/published",
     logDir: "~/.config/grove/logs",
   },
+  cockpit: {
+    enabled: false,
+    docsDir: "docs",
+    repo: "",
+    refreshIntervalMs: 300_000,
+    attention: { surface: "discord", channel: "" },
+  },
   networksDir: "./networks",
   networks: [],
 };

--- a/src/common/types/config.ts
+++ b/src/common/types/config.ts
@@ -498,7 +498,24 @@ export const AgentConfigSchema = z.object({
       channel: z.string().default(""),
       thread: z.string().optional(),
     }).default(emptyDefault()),
-  }).default(emptyDefault()),
+  }).default(emptyDefault()).transform((val) => ({
+    // Same `emptyDefault()` quirk documented on the `github` block above:
+    // `.default(emptyDefault())` returns `{}` literally rather than re-parsing
+    // the inner defaults, so `config.cockpit.attention` would be undefined.
+    // Re-apply the inner defaults so callers get the populated shape. The `??`
+    // chains are load-bearing (not redundant) for the all-defaults parse path.
+    /* eslint-disable @typescript-eslint/no-unnecessary-condition */
+    enabled: val.enabled ?? false,
+    docsDir: val.docsDir ?? "docs",
+    repo: val.repo ?? "",
+    refreshIntervalMs: val.refreshIntervalMs ?? 300_000,
+    attention: {
+      surface: val.attention?.surface ?? "discord",
+      channel: val.attention?.channel ?? "",
+      ...(val.attention?.thread !== undefined && { thread: val.attention.thread }),
+    },
+    /* eslint-enable @typescript-eslint/no-unnecessary-condition */
+  })),
 
   /** G-500: Directory containing per-network YAML files */
   networksDir: z.string().default("./networks"),

--- a/src/common/types/config.ts
+++ b/src/common/types/config.ts
@@ -476,6 +476,30 @@ export const AgentConfigSchema = z.object({
     baseUrl: z.string().default(""),
   }).default(emptyDefault()),
 
+  /**
+   * G-1113 ML.5: Mission Control Cockpit live-refresh. OFF by default (opt-in)
+   * so existing deployments are unchanged. When `enabled`, the bot runs
+   * `refreshCockpit` on `refreshIntervalMs` (plan-doc ingestion → work-item
+   * ingestion → attention reconcile) and publishes `system.attention.*`
+   * notifications; `attention.channel` is the review-sink destination those
+   * render to (empty → notifications stay on the bus but aren't routed).
+   */
+  cockpit: z.object({
+    enabled: z.boolean().default(false),
+    /** Path to the plan/iteration docs dir (relative to cwd or absolute). */
+    docsDir: z.string().default("docs"),
+    /** Default repo ("owner/name") for short umbrella refs + doc URLs. */
+    repo: z.string().default(""),
+    /** Refresh interval in ms (default 5 min). */
+    refreshIntervalMs: z.number().int().positive().default(300_000),
+    /** Attention notification destination (the review-sink's attentionRouting). */
+    attention: z.object({
+      surface: z.string().default("discord"),
+      channel: z.string().default(""),
+      thread: z.string().optional(),
+    }).default(emptyDefault()),
+  }).default(emptyDefault()),
+
   /** G-500: Directory containing per-network YAML files */
   networksDir: z.string().default("./networks"),
 

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -91,6 +91,10 @@ import type { PlatformAdapter } from "./adapters/types";
 import { createDispatchSink, type DispatchSink } from "./adapters/dispatch-sink";
 import { createReviewSink, type ReviewSink } from "./adapters/review-sink";
 import { startGatewayIfEnabled } from "./gateway/start-gateway";
+// G-1113 ML.5 — cockpit live-refresh loop (opt-in via config.cockpit).
+import { refreshCockpit, defaultWorkItemSourceFor } from "./surface/mc/refresh";
+import { startCockpitRefreshLoop, type CockpitRefreshLoop } from "./surface/mc/refresh-loop";
+import type { Database as BunDatabase } from "bun:sqlite";
 import { isGatewayEnabled } from "./gateway/gateway-bootstrap";
 import { gatewayOwnedSurfaceKeys } from "./gateway/gateway-adapters";
 import type { Surfaces } from "./common/types/surfaces";
@@ -2059,11 +2063,20 @@ export async function startCortex(
   // `formatDispatchLifecycle`, and posts back. NOT wired via
   // `surfaceSubjects` (that would double-reply). Dormant when the runtime
   // is disabled (no NATS) or no adapters started.
+  // ML.5 — attention notifications (system.attention.*) render to the configured
+  // cockpit channel. Only wired when a channel is set; otherwise the sink ignores
+  // attention envelopes (unchanged behaviour).
+  const attn = config.cockpit.attention;
+  const attentionRouting =
+    attn.channel !== ""
+      ? { surface: attn.surface, channel: attn.channel, ...(attn.thread !== undefined && { thread: attn.thread }) }
+      : undefined;
   const reviewSink: ReviewSink = createReviewSink({
     runtime,
     adapters,
     principal: principalId,
     stack: derivedStack.stack,
+    ...(attentionRouting !== undefined && { attentionRouting }),
   });
   await reviewSink.start();
   console.log(
@@ -2136,12 +2149,39 @@ export async function startCortex(
   // Dashboard API + usage monitor (G-201 / G-206) — opt-in.
   let dashboardApi: { stop?: () => void } | null = null;
   let usageMonitor: UsageMonitor | null = null;
+  let mcDb: BunDatabase | null = null;
   if (config.api.enabled && !options.disableDashboard) {
     try {
-      ({ api: dashboardApi, usageMonitor } = await setupDashboard(config, principalId, options.principal?.displayName, dispatchHandler, cloudPublisher));
+      ({ api: dashboardApi, usageMonitor, mcDb } = await setupDashboard(config, principalId, options.principal?.displayName, dispatchHandler, cloudPublisher));
     } catch (err) {
       console.error("cortex: dashboard API startup error (non-fatal):", err instanceof Error ? err.message : err);
     }
+  }
+
+  // G-1113 ML.5 — cockpit live-refresh loop. Opt-in via `config.cockpit.enabled`;
+  // runs refreshCockpit (ingest → reconcile) on an interval and publishes
+  // `system.attention.*` notifications via the bus (the review-sink renders them
+  // to `cockpit.attention.channel`). Closes the make-it-live loop end-to-end.
+  let cockpitLoop: CockpitRefreshLoop | null = null;
+  if (config.cockpit.enabled && mcDb !== null) {
+    const cockpitDb = mcDb;
+    const [repoOwner, repoName] = config.cockpit.repo.split("/");
+    const defaultRepo = repoOwner && repoName ? { owner: repoOwner, repo: repoName } : undefined;
+    const baseUrl = config.grove.baseUrl !== "" ? config.grove.baseUrl : `http://localhost:${config.api.port}`;
+    cockpitLoop = startCockpitRefreshLoop({
+      intervalMs: config.cockpit.refreshIntervalMs,
+      run: () =>
+        refreshCockpit(cockpitDb, {
+          docsDir: config.cockpit.docsDir,
+          ...(defaultRepo !== undefined && { defaultRepo }),
+          stackId: derivedStack.stack,
+          publish: (env) => runtime.publish(env),
+          notifySource: { principal: principalId, agent: "cortex", instance: "local" },
+          deepLinkFor: (item) => (item.workItemId !== null ? `${baseUrl}/work-items/${item.workItemId}` : null),
+          workItemSourceFor: defaultWorkItemSourceFor,
+        }),
+    });
+    console.log(`cortex: cockpit refresh loop started — every ${config.cockpit.refreshIntervalMs}ms, docs=${config.cockpit.docsDir}`);
   }
 
   // MIG-5.6 (C-106): GitHub webhook receiver — opt-in via `github.receiver.enabled`
@@ -2268,6 +2308,7 @@ export async function startCortex(
     const drain = async (): Promise<void> => {
       completeSync("config-watcher stop", () => configWatcher?.stop());
       completeSync("usage-monitor stop", () => usageMonitor?.stop());
+      completeSync("cockpit refresh loop stop", () => cockpitLoop?.stop());
       completeSync("dashboard stop", () => dashboardApi?.stop?.());
       completeSync("github webhook receiver stop", () => githubReceiver?.stop());
       for (let i = 0; i < adapterCleanup.length; i++) {
@@ -2426,7 +2467,7 @@ async function setupDashboard(
   principalDisplayName: string | undefined,
   dispatchHandler: DispatchHandler,
   cloudPublisher: CloudPublisher | null,
-): Promise<{ api: { stop?: () => void }; usageMonitor: UsageMonitor }> {
+): Promise<{ api: { stop?: () => void }; usageMonitor: UsageMonitor; mcDb: BunDatabase | null }> {
   const { DashboardApi } = await import("./surface/mc/api/index" as string);
   const dbPath = join(STATE_DIR, "dashboard.db");
   const cortexRoot = join(dirname(import.meta.dir), ".");
@@ -2483,7 +2524,10 @@ async function setupDashboard(
     const changed = api.getState().updateSessionUsage(sessionId, usage);
     if (changed) api.notifyStateChanged();
   });
-  return { api, usageMonitor };
+  // ML.5 — expose the MC DB handle so the bot can run the cockpit refresh loop
+  // (it has `runtime.publish` in scope; the dashboard owns the DB).
+  const mcDb = (api.getDb() ?? null) as BunDatabase | null;
+  return { api, usageMonitor, mcDb };
 }
 /* eslint-enable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unnecessary-type-assertion */
 

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -2168,11 +2168,21 @@ export async function startCortex(
     const [repoOwner, repoName] = config.cockpit.repo.split("/");
     const defaultRepo = repoOwner && repoName ? { owner: repoOwner, repo: repoName } : undefined;
     const baseUrl = config.grove.baseUrl !== "" ? config.grove.baseUrl : `http://localhost:${config.api.port}`;
+    // Resolve docsDir to an absolute path so the ingest doesn't depend on the
+    // launchd plist's CWD (which isn't guaranteed to be the repo root). Warn
+    // once at startup if it's missing rather than only failing every tick.
+    const docsDir = isAbsolute(config.cockpit.docsDir) ? config.cockpit.docsDir : join(process.cwd(), config.cockpit.docsDir);
+    if (!existsSync(docsDir)) {
+      console.warn(`cortex: cockpit.enabled but docsDir not found at ${docsDir} — plan ingest will be empty until it exists`);
+    }
+    if (config.cockpit.attention.channel === "") {
+      console.warn("cortex: cockpit.enabled but cockpit.attention.channel is empty — attention notifications publish to the bus only (no surface rendering); set it to route them");
+    }
     cockpitLoop = startCockpitRefreshLoop({
       intervalMs: config.cockpit.refreshIntervalMs,
       run: () =>
         refreshCockpit(cockpitDb, {
-          docsDir: config.cockpit.docsDir,
+          docsDir,
           ...(defaultRepo !== undefined && { defaultRepo }),
           stackId: derivedStack.stack,
           publish: (env) => runtime.publish(env),
@@ -2181,7 +2191,9 @@ export async function startCortex(
           workItemSourceFor: defaultWorkItemSourceFor,
         }),
     });
-    console.log(`cortex: cockpit refresh loop started — every ${config.cockpit.refreshIntervalMs}ms, docs=${config.cockpit.docsDir}`);
+    console.log(`cortex: cockpit refresh loop started — every ${config.cockpit.refreshIntervalMs}ms, docs=${docsDir}`);
+  } else if (config.cockpit.enabled && mcDb === null) {
+    console.warn(`cortex: cockpit.enabled but dashboard DB unavailable (api.enabled=${config.api.enabled}, disableDashboard=${!!options.disableDashboard}) — refresh loop not started`);
   }
 
   // MIG-5.6 (C-106): GitHub webhook receiver — opt-in via `github.receiver.enabled`

--- a/src/surface/mc/__tests__/refresh-loop.test.ts
+++ b/src/surface/mc/__tests__/refresh-loop.test.ts
@@ -1,0 +1,67 @@
+/**
+ * ML.5 — cockpit refresh loop: scheduling + isolation + stop (injected scheduler).
+ */
+import { describe, it, expect } from "bun:test";
+import { startCockpitRefreshLoop } from "../refresh-loop";
+
+/** A fake scheduler that captures the tick fn so the test drives it manually. */
+function fakeScheduler() {
+  let captured: (() => void) | null = null;
+  let cancelled = false;
+  const schedule = (fn: () => void, _ms: number) => {
+    captured = fn;
+    return () => { cancelled = true; };
+  };
+  return { schedule, tick: () => captured?.(), get cancelled() { return cancelled; } };
+}
+
+const flush = async () => { await Promise.resolve(); await Promise.resolve(); await Promise.resolve(); };
+
+describe("startCockpitRefreshLoop (ML.5)", () => {
+  it("runs once on start, then on each scheduled tick", async () => {
+    const s = fakeScheduler();
+    let runs = 0;
+    startCockpitRefreshLoop({ run: async () => { runs += 1; }, intervalMs: 1000, schedule: s.schedule });
+    await flush();
+    expect(runs).toBe(1); // runOnStart
+    s.tick(); await flush();
+    s.tick(); await flush();
+    expect(runs).toBe(3);
+  });
+
+  it("runOnStart:false defers the first run to the first tick", async () => {
+    const s = fakeScheduler();
+    let runs = 0;
+    startCockpitRefreshLoop({ run: async () => { runs += 1; }, intervalMs: 1000, runOnStart: false, schedule: s.schedule });
+    await flush();
+    expect(runs).toBe(0);
+    s.tick(); await flush();
+    expect(runs).toBe(1);
+  });
+
+  it("isolates a failing run: routes to onError, keeps ticking", async () => {
+    const s = fakeScheduler();
+    const errors: unknown[] = [];
+    let runs = 0;
+    startCockpitRefreshLoop({
+      run: async () => { runs += 1; throw new Error(`boom ${runs}`); },
+      intervalMs: 1000,
+      onError: (e) => errors.push(e),
+      schedule: s.schedule,
+    });
+    await flush();
+    s.tick(); await flush();
+    expect(runs).toBe(2); // kept ticking despite the first throw
+    expect(errors).toHaveLength(2);
+    expect((errors[0] as Error).message).toBe("boom 1");
+  });
+
+  it("stop() cancels the schedule and is idempotent", () => {
+    const s = fakeScheduler();
+    const loop = startCockpitRefreshLoop({ run: async () => {}, intervalMs: 1000, runOnStart: false, schedule: s.schedule });
+    expect(s.cancelled).toBe(false);
+    loop.stop();
+    expect(s.cancelled).toBe(true);
+    loop.stop(); // idempotent — no throw
+  });
+});

--- a/src/surface/mc/refresh-loop.ts
+++ b/src/surface/mc/refresh-loop.ts
@@ -1,0 +1,67 @@
+/**
+ * ML.5 — schedulable cockpit-refresh loop.
+ *
+ * The bot (cortex.ts) runs `refreshCockpit` on an interval so the cockpit stays
+ * live: real data ingested + reconciled + attention notifications published.
+ * This is the testable schedule wrapper — the scheduler is injectable so the
+ * timing logic is unit-tested without real timers, and production passes
+ * setInterval/clearInterval. Best-effort: a failed run never throws out of the
+ * tick (it routes to `onError`), so one bad refresh can't kill the loop.
+ */
+export interface CockpitRefreshLoopOptions {
+  /** One refresh pass (e.g. () => refreshCockpit(db, opts)). */
+  run: () => Promise<unknown>;
+  /** Interval between refreshes (ms). */
+  intervalMs: number;
+  /** Called with any error a run throws/rejects. Defaults to a stderr line. */
+  onError?: (err: unknown) => void;
+  /** Run once immediately on start (default true) so the first refresh isn't a full interval away. */
+  runOnStart?: boolean;
+  /**
+   * Injectable scheduler — returns a canceller. Defaults to
+   * setInterval/clearInterval. Tests pass a fake to drive ticks deterministically.
+   */
+  schedule?: (fn: () => void, ms: number) => () => void;
+}
+
+export interface CockpitRefreshLoop {
+  /** Stop the loop (idempotent). */
+  stop: () => void;
+}
+
+const defaultSchedule = (fn: () => void, ms: number): (() => void) => {
+  const id = setInterval(fn, ms);
+  return () => {
+    clearInterval(id);
+  };
+};
+
+export function startCockpitRefreshLoop(opts: CockpitRefreshLoopOptions): CockpitRefreshLoop {
+  const schedule = opts.schedule ?? defaultSchedule;
+  const onError =
+    opts.onError ??
+    ((err: unknown) =>
+      process.stderr.write(
+        `[cockpit-refresh-loop] refresh failed: ${err instanceof Error ? err.message : String(err)}\n`
+      ));
+
+  // Each tick is fire-and-forget + self-isolating: a rejected run routes to
+  // onError, never escaping the timer callback.
+  const tick = (): void => {
+    void Promise.resolve()
+      .then(() => opts.run())
+      .catch(onError);
+  };
+
+  if (opts.runOnStart !== false) tick();
+  const cancel = schedule(tick, opts.intervalMs);
+
+  let stopped = false;
+  return {
+    stop: () => {
+      if (stopped) return;
+      stopped = true;
+      cancel();
+    },
+  };
+}


### PR DESCRIPTION
## ML.5 — bot-side `refreshCockpit` trigger

Closes the **make-it-live** loop (#614). The cockpit had all the machinery (ingest → reconcile → publish) but nothing on the bot side drove it on a schedule. ML.5 wires `refreshCockpit` into `cortex.ts` so the running bot keeps the cockpit live.

### What changed
- **`src/surface/mc/refresh-loop.ts` (NEW)** — `startCockpitRefreshLoop({run, intervalMs, onError?, runOnStart?, schedule?})`. Injectable scheduler (default `setInterval`/`clearInterval`) so the timing logic is unit-tested without real timers. Each tick is best-effort: a rejected run routes to `onError` and never escapes the timer, so one bad refresh can't kill the loop. `runOnStart` default true; `stop()` idempotent.
- **`config.ts`** — opt-in `cockpit` section: `enabled` (default **false**), `docsDir`, `repo`, `refreshIntervalMs` (default 5min), `attention { surface, channel, thread? }`.
- **`cortex.ts`** — `setupDashboard` now returns the MC db; when `cockpit.enabled && mcDb`, the loop starts and calls `refreshCockpit` with the bot's `runtime.publish` + deep-link builder. `createReviewSink` gains `attentionRouting` from `config.cockpit.attention` so `system.attention.*` notifications route to the configured channel. Loop `stop()` wired into cleanup.

### Why opt-in
`cockpit.enabled` defaults to **false** → existing deployments see zero behavior change. Operators turn it on per-stack when ready.

### Verification
- `bunx tsc --noEmit` clean
- `bun run lint` — 0 errors (26 pre-existing bus-peer warnings)
- `bash scripts/check-carveouts.sh` — PASS
- `bun test src/surface/mc src/common/config src/adapters` — 1795 pass / 0 fail
- `bun run build:dashboard` — builds
- refresh-loop unit tests 4/4 (runs-on-start + ticks; runOnStart:false; error-isolation keeps ticking; stop idempotent)

Closes #622. Final slice of the make-it-live epic #614.

🤖 Generated with [Claude Code](https://claude.com/claude-code)