### PR TITLE
chore: bump to v4.1.0

### DIFF
--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -8,7 +8,7 @@ name: "Cortex"
 # now fail to load (strict canonical-only schemas). Run `cortex migrate-config`
 # to rewrite a pre-v4 config to the canonical `principal:` / `principalId` /
 # `principal_id` shape.
-version: "4.0.0"
+version: "4.1.0"
 type: component
 tier: community
 description: "Layer-7 collaboration surface for the metafactory ecosystem — the M7 application that consumes the Myelin stack"


### PR DESCRIPTION
Version bump 4.0.0 → **4.1.0** (minor) per the versioning SOP.

**What v4.1.0 ships** (on main since v4.0.0):
- **Unified surface gateway — one per operator, not per deployment.** Full inbound demux + outbound reply round-trip (#613, closes the loop on #524).
- **Config simplification** — surface bindings extracted to `surfaces.yaml` (`{instance → stack}`).
- Flag-gated (`CORTEX_GATEWAY`), SHADOW by default; LIVE publish behind `CORTEX_GATEWAY_PUBLISH`. Single-operator, multi-stack.

Source of truth: `arc-manifest.yaml`. Release + tag `v4.1.0` created after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)