### PR TITLE
docs: design + iteration plan — Trust & Confidentiality (signed/encrypted/federated)

### DIFF
--- a/docs/design-trust-confidentiality.md
+++ b/docs/design-trust-confidentiality.md
@@ -1,0 +1,234 @@
+# Design: Trust & Confidentiality — Signed · Encrypted · Federated
+
+**Status:** Draft (consolidation design) · **Owner:** Andreas · **Stakeholder:** JC (E2E NATS / identity)
+**Provenance:** Consolidates and sequences ratified work — does **not** re-decide it.
+Child of #110 (META: Internet of Agentic Work); cross-links #117 (Phase E) and #524 (Gateway).
+
+> This design ties three already-specified strands together and adds two new defense-in-depth
+> layers. It is grounded in a source map of the live code (signing, identity/registry, transport,
+> at-rest stores) — file:line references throughout trace to `main` as of v4.1.0.
+
+---
+
+## 1. Goal
+
+Remove the **unsigned-intra-operator trust crutch** and the **single-operator boundary**, and add
+confidentiality at every layer. Concretely, move from today's posture —
+
+- gateway→stack envelopes published **unsigned** (D1 "Shape A"), trusted only because they share one
+  host/NATS account (single operator);
+- **single-principal** `IdentityRegistry` (cross-operator verification not wired);
+- **no payload confidentiality** on the bus, **no at-rest encryption**, **no mTLS** —
+
+to a posture where every bus envelope is **attributable (signed)** and optionally **confidential
+(encrypted)**, cross-operator flows are **cryptographically verifiable**, and data at rest and in
+transit is **encrypted**.
+
+## 2. Non-goals & invariants (inherited — must not be contradicted)
+
+1. **Never extend the frozen envelope schema.** Confidentiality rides on `extensions.enc`; all
+   routing/trust metadata (`signed_by[]`, `sovereignty`, `target_*`, `originator`, `economics`)
+   stays cleartext. (architecture §4.3; `design-envelope-encryption.md` §1.3)
+2. **Encrypt-then-sign.** Seal `payload` first, then the `signed_by[]` chain signs over the sealed
+   form. Decrypt only after `verifySignedByChain` accepts. (`runtime.ts:602` signs JCS-canonical bytes
+   incl. `payload`; verify never reads `payload` → structurally clean.)
+3. **The stack is the sole cryptographic signer.** Gateways/dispatch-sources never touch identity.
+   (CONTEXT.md §Dispatch-source, D1 / cortex#524 OQ2, 2026-06-02)
+4. **Reuse the identity mesh — no new long-term keys, no certs for envelope crypto.** X25519
+   encryption keys are derived deterministically from the existing per-stack Ed25519 seed
+   (`stack.nkey_seed_path`, chmod-600). One root of secret material. (key-model decision, this design)
+5. **Signing-only is the out-of-box default; encryption is opt-in per network**, with a
+   both-accepted transition window. Cortex stays deployable with zero crypto ceremony. (#369 ratified)
+6. **TLS is an operational mandate, not in-scope for M1** — but the gap that no mTLS *client* path
+   exists (`connection.ts` has no TLS surface) is addressed here as a transport-hardening layer.
+7. **Every layer is independently toggleable; the dev default is OFF/permissive.** Signing, payload
+   encryption, at-rest encryption, and mTLS each read a mode from a unified `security:` config block
+   (Phase 0). You can run the whole stack unencrypted/unsigned, then ramp each layer
+   `off → permissive → enforce` independently and reversibly. No layer is wired in a way that can't be
+   turned off for local development/testing. (Posture decision, this design — see Phase 0.)
+
+## 3. Current state (source-mapped)
+
+| Area | Today | Evidence |
+|------|-------|----------|
+| Envelope | `payload` is a discrete opaque field; signatures live in `signed_by[]` (Ed25519 chain) | `envelope-validator.ts:119,137,254` |
+| Signing | `MyelinRuntime` signs via `signAndPublishOnSubject` when a `signer` is set; gateway runtime has none → unsigned | `runtime.ts:559,602`; `bus-inbound-sink.ts:26-32` |
+| Verify | `verifySignedByChain` = structural trust + opt-in `cryptoVerify`; stack short-circuit via `stackIdentity` (#480) | `verify-signed-by-chain.ts:221,328,412` |
+| **#535 blocker** | review-consumer verifier built **without** `stackIdentity`/`stackNKeyPub` → stack-signed requests hit `principal_has_no_nkey_pub` | `cortex.ts:1008-1019` (cf. listener `1223-1225`) |
+| Identity | 3-tier principal→stack→agent; `did:mf:<principal>-<stack>`; Ed25519 NKeys only | `cortex.ts:474-476`; `stack.ts:86-133` |
+| Registry | `network-registry` Worker stores `operator_pubkey` + stacks; signed assertions; **not wired into cortex runtime yet** | `services/network-registry/src/routes/principals.ts:33,141` |
+| Federation | `policy.federated.networks[]` + accept/deny + hop-budget gating exist; **cross-operator pubkey verify NOT wired**; peer pubkeys static in yaml | `cortex-config.ts:1359,1429`; `engine.ts:176-184,253-285` |
+| Single-principal | one boot `principalId` stamps every agent's `Identity.network`; no cross-principal verify path | `cortex.ts:395,853`; `verify-signed-by-chain.ts:438-443` |
+| Encryption keys | **none** — only Ed25519 signing. No x25519/NaCl in `src/`. myelin has unused AES-256-GCM at-rest primitive | `package.json`; `myelin/src/agent-identity/encryption.ts` |
+| At-rest | local SQLite (`dashboard.db`, `mission-control.db`, learning), event JSONL — **no encryption**; D1 CF-managed only | `mc/db/init.ts:20`; `cc-events` JSONL |
+| **cortex.yaml** | **bot tokens** loaded with **no chmod-600 gate** (unlike nkey/creds loaders) | `loader.ts:255` |
+| Transport | NATS client: NKey/JWT or token auth; **no TLS/client-cert surface** at all | `connection.ts:27-47,103-138` |
+
+## 4. Design
+
+### Phase 0 — Security posture & toggles (lands FIRST) · "get it working off, ramp later"
+
+A unified `security:` block in `cortex.yaml`, read by every other phase. Every layer defaults **OFF**
+so the stack runs unencrypted/unsigned out of the box for development; each layer ramps independently
+through three modes and is reversible at any time.
+
+```yaml
+security:
+  signing:   off | permissive | enforce   # off: no signer. permissive: sign + cryptoVerify but
+                                           #   rejectEmpty:false + signFailureMode:fallback (LOG, don't
+                                           #   reject — observe). enforce: signFailureMode:drop +
+                                           #   rejectEmpty:true (reject unsigned/invalid).
+  encryption:
+    payload: off | opt-in | require        # off: cleartext payload. opt-in: seal when the recipient
+                                           #   advertises an enc_pub (both-cleartext-and-sealed accepted
+                                           #   in the transition window). require: reject cleartext.
+    at_rest: off | on                      # off: plaintext columns. on: field-encrypt the
+                                           #   high-sensitivity columns.
+  transport:
+    mtls:    off | on | require            # off: today's NKey/JWT auth only. on: offer client cert.
+                                           #   require: refuse non-mTLS connections.
+```
+
+**Why three modes, not a boolean:** the middle `permissive`/`on` rung is the dev affordance — sign and
+verify (or offer mTLS / encrypt-when-possible) but **never reject**, so a layer can be proven in shadow
+against live traffic before it gates anything. This mirrors the gateway's SHADOW→LIVE double-opt-in and
+reuses the existing `cryptoVerify`/`rejectEmpty`/`signFailureMode` knobs rather than inventing new ones.
+
+**Mapping to existing knobs** (Phase 0 is mostly *wiring*, not new mechanism):
+- `signing: permissive` ⇒ `cryptoVerify:true` + `rejectEmpty:false` + `signFailureMode:"fallback"`.
+- `signing: enforce` ⇒ `rejectEmpty:true` + `signFailureMode:"drop"` (this is the #210 / TC-1d cutover).
+- `encryption.payload` ⇒ the #369 opt-in/both-accepted negotiation, surfaced as one mode.
+- `transport.mtls` ⇒ the TC-4d `tls` block presence + a `require` refuse-plaintext guard.
+
+**Acceptance:** with `security:` absent or all-`off`, the stack behaves exactly as today (unsigned,
+cleartext, NKey-auth). Flipping any single layer's mode changes only that layer. A dev can run the full
+gateway round-trip with zero crypto, then enable signing-permissive without touching any other config.
+
+### Phase 1 — Make signing real (single-operator) · removes the unsigned-trust crutch
+
+- **1a. Fix #535 (quick, unblocks the review loop).** Thread `stackIdentity: signer.principal` +
+  `stackNKeyPub` into the review-consumer's `signatureVerifier` closure (`cortex.ts:1008-1019`),
+  matching the dispatch-listener (`1223-1225`). ~3 lines + a regression test. **Acceptance:** pilot
+  review-requests verify; no `principal_has_no_nkey_pub`.
+- **1b. Stack-identity provisioning everywhere.** Ensure every deployed stack has
+  `stack.nkey_seed_path` + registered `nkey_pub`; resolve the v4 provisioning gaps (stack.id in
+  signed blocks). **Acceptance:** `verifier-self-check` passes on every stack at boot.
+- **1c. Shape B — re-sign on ingest (#552).** At the bound stack's ingest point (just after
+  `verifySignedByChain` accepts the unsigned gateway envelope, `dispatch-listener.ts:~1190`),
+  re-emit through the stack's **signer-bearing** runtime so `signAndPublishOnSubject` (`runtime.ts:559`)
+  stamps it with the stack NKey before the harness runs. **Acceptance:** gateway-injected dispatches
+  carry a stack `signed_by[]` stamp downstream.
+- **1d. Enforce.** Flip `signFailureMode` `fallback`→`drop` (#210) and tighten the `tasks.chat`
+  inbound path toward `rejectEmpty: true` once subscribe-side verification is enforcing. **Gate:** one
+  of the #552 revisit triggers (below) must hold.
+
+### Phase 2 — Federation trust · removes the single-operator boundary
+
+- **2a. Registry client (Phase D.4).** Wire a cortex-side `RegistryClient` that resolves peer
+  `operator_pubkey` from `GET /principals/{id}` (registry-signed assertion, pinned registry pubkey)
+  instead of static yaml. (`network-registry` already serves this.)
+- **2b. Multi-principal `IdentityRegistry`.** Change `buildIdentityRegistry` (`verify-signed-by-chain.ts:438-443`)
+  to stamp peer agents with the **peer's** principal/network rather than the single boot `principalId`;
+  construct a multi-principal registry for inbound `federated.*`.
+- **2c. Relax the single-principal guard** (the boot guard added in GW.a.3d) once 2a/2b make
+  cross-principal envelopes verifiable; multi-principal subject derivation in the gateway sink.
+- **2d. `federated.*` verify wiring** in the surface-router/policy path (the gate exists; add the
+  crypto verify against registry-resolved peer pubkeys). **Acceptance:** principal A's node verifies a
+  principal-B-signed envelope end-to-end; forged peer signature rejected.
+
+### Phase 3 — Payload encryption (E2E on bus) · implements ratified #369
+
+Implement `docs/design-envelope-encryption.md` (E.7) as-specified:
+- **Sealed `extensions.enc`** — replace cleartext `payload` with `{ ciphertext, alg, recipients[] }`;
+  metadata stays cleartext. No schema change.
+- **X25519 derived from the Ed25519 stack identity** (ed25519→x25519 conversion); recipient pubs
+  distributed via the same mesh (config / agent-registry / registry assertion — one `enc_pub` field).
+- **Encrypt-then-sign** at `signAndPublishOnSubject`; **decrypt-after-verify** at the post-verify
+  seam in the dispatch path. Opt-in per network; both-accepted transition window.
+- **Depends on Phase 2** (peer X25519 pubs need the registry/multi-principal path).
+  **Acceptance:** a federated peer without the recipient key cannot read `payload`; the intended
+  stack decrypts; sovereignty/routing unaffected.
+
+### Phase 4 — At-rest + mTLS (NEW) · defense-in-depth, **parallel from the start**
+
+- **4a. `cortex.yaml` chmod-600 gate (immediate quick win).** Add `enforceChmod600` to the config
+  load path (`loader.ts:255`) — bot tokens are currently unprotected, unlike nkey/creds. Standalone fix.
+- **4b. File-mode hardening.** Tighten the event `published/` dir `0755`→`0700`
+  (`EventLogger.hook.ts:107`); audit dir/file modes across stores.
+- **4c. At-rest field encryption.** App-level field encryption of high-sensitivity columns —
+  local SQLite `events.payload`, `tasks.description`, `iterations.body`; D1 `github_events.payload`,
+  `audit_log.detail/ip`, `users.email`. Indexed/ID/principal columns stay cleartext for dashboard
+  slicing. Reuse myelin's AES-256-GCM primitive; key derived from the stack identity. OS-FDE as the
+  baseline. (D1 cannot run SQLCipher — field-level is the only app-controlled option.)
+- **4d. NATS mTLS.** Extend `NatsLinkOptions` (`connection.ts:27`) with a `tls?: { ca, cert, key,
+  keyPath }` block; load cert/key with the chmod-600 pattern; set `ConnectionOptions.tls`. Plumb
+  `nats.tls.*` into cortex.yaml + the relay CLI (relay's `NatsLink` is token-only today).
+- **4e. Cloud-publisher mTLS + non-TLS warning.** Optional mTLS on the cloud-publisher→Worker leg;
+  a loud non-fatal `system.error` warning when a `federated` leaf-node runs without TLS (enc-design §2).
+
+## 5. Dependency graph
+
+```
+Phase 0 (security: toggles, all default OFF) ── lands FIRST, gates every layer's mode
+        │
+        ├─► Phase 1 (signing) ──► Phase 2 (federation verify) ──► Phase 3 (payload encryption)
+        │      1a #535 (now)         2a registry client            (needs peer X25519 from 2a/2b)
+        │      1b provisioning       2b multi-principal registry
+        │      1c #552 re-sign       2c relax single-principal
+        │      1d #210 enforce       2d federated verify
+        │
+        └─► Phase 4 (at-rest + mTLS) ── independent ── parallel from the start
+               4a chmod-600 (immediate)  4c field encryption  4d NATS mTLS  4e cloud-publisher mTLS
+```
+
+Phase 0 is foundational but small (mostly wiring existing knobs to one config block). Each capability
+phase implements its layer **behind its toggle**, so partial progress never forces crypto on a dev stack.
+
+### Drive priority (revised): federation-FIRST, unsigned
+
+The principal goal is **cross-principal, multi-deployment collaboration ASAP** — not waiting on the full
+crypto stack. The toggles make this safe to sequence out of strict dependency order: with
+`security.signing: off`, the federation **routing/topology** can be built and proven UNSIGNED, then
+signing + encryption layered on via their toggles. Splitting Phase 2 by what actually needs crypto:
+
+- **Phase F — Federation routing (no crypto required; PRIORITISED):**
+  - **F-1** Relax the single-principal guard + multi-principal subject derivation (was TC-2c) — today one
+    boot `principalId` stamps everything (`cortex.ts:395,853`); this is the real near-term blocker.
+  - **F-2** Cross-principal routing on a shared bus — two principals, one NATS, `federated.{principal}.{stack}`
+    subjects (grammar + accept/deny + hop-budget gating already exist, `surface-router.ts:651-730`).
+    Acceptance: two principals exchange envelopes cross-principal with `signing:off`.
+  - **F-3** Multi-link / multi-network runtime — one NATS leaf per network/deployment (E.1 / #348) for
+    true multi-deployment bridging.
+- **Phase 2-verify — Federation crypto (deferred behind the signing toggle):** registry-resolved peer
+  pubkeys (TC-2a) + multi-principal `IdentityRegistry` (TC-2b) + `federated.*` crypto-verify (TC-2d).
+  Only engaged when `signing: enforce`.
+
+> ⚠️ **Security caveat (load-bearing):** unsigned cross-principal federation is **unauthenticated** — a
+> peer can claim any principal identity. Acceptable for dev / trusted-party testing only. `signing:enforce`
+> + `encryption.payload` MUST be on before federation faces an untrusted or cross-org peer. The toggle
+> ramp makes this a deliberate, reviewable flip.
+
+**Revised drive order:** Phase 0 (toggles off) → **Phase F (F-1→F-2→F-3, unsigned)** → harden:
+signing (1) → federation-verify (2-verify) → encryption (3). Phase 4 (at-rest/mTLS) parallel throughout.
+
+Encryption (3) **cannot precede** federation verify (2); both build on signing (1). Phase 4 is
+orthogonal — no dependency on 1–3.
+
+## 6. Threat model (what each layer defends)
+
+| Layer | Defends against | Residual |
+|-------|-----------------|----------|
+| Signing (1) | Forged/replayed envelopes; unattributable gateway injection | Confidentiality (bus is readable) |
+| Federation verify (2) | A malicious peer impersonating principal B | Trust in the registry's pinned pubkey |
+| Payload encryption (3) | A curious/compromised bus or peer reading `payload` | Metadata is cleartext (by design) |
+| At-rest (4a–c) | Disk/DB theft, leaked config tokens | OS-level / key-custody |
+| mTLS (4d–e) | On-wire sniffing, server impersonation | App-layer identity still required |
+
+## 7. Open decisions (to resolve during the drive)
+
+- **OD-1:** X25519 derivation — RFC-8032 ed25519→x25519, or independent X25519 keypair co-stored?
+  (#369 leans derive; confirm with JC.)
+- **OD-2:** At-rest key custody — derive a DB-encryption key from the stack seed, or a separate
+  operator-held key? (Disk theft + seed theft are correlated if same root.)
+- **OD-3:** mTLS vs NKey/JWT — complement or replace? (NATS supports both; pick posture.)
+- **OD-4:** Enforcement cutover timing for 1d/#210 — which #552 trigger fires first.

--- a/docs/iteration-trust-confidentiality.md
+++ b/docs/iteration-trust-confidentiality.md
@@ -1,28 +1,28 @@
 # Iteration Plan: Trust & Confidentiality
 
-Tracks `docs/design-trust-confidentiality.md`. Umbrella: **#TBD** (child of #110; cross-links #117, #524).
+Tracks `docs/design-trust-confidentiality.md`. Umbrella: **#627** (child of #110; cross-links #117, #524).
 Each slice is a sub-issue. `folds #N` = an existing issue this slice subsumes/reuses (don't recreate).
 Status: ☐ planned · ◐ in-progress · ☑ done.
 
 | Slice | Title | Phase | Folds / New | Status | Issue |
 |-------|-------|-------|-------------|--------|-------|
-| **TC-0** | Security posture config — unified `security:` toggles (signing/encryption/at-rest/mTLS), all default OFF; ramp `off→permissive→enforce` | 0 Posture | new | ☐ | — |
-| **TC-1a** | Fix #535 — thread `stackIdentity`/`stackNKeyPub` into review-consumer verifier | 1 Signing | folds #535 | ☐ | — |
-| **TC-1b** | Stack-identity provisioning + boot `verifier-self-check` on every stack | 1 Signing | new | ☐ | — |
-| **TC-1c** | Shape B — bound stack re-signs gateway-injected envelopes on ingest | 1 Signing | folds #552 | ☐ | — |
-| **TC-1d** | Enforce — `signFailureMode` → `drop`; tighten `rejectEmpty` on `tasks.chat` | 1 Signing | folds #210 | ☐ | — |
-| **TC-2c** | **F-1:** Relax single-principal guard + multi-principal subject derivation | **F Routing** (priority) | new | ☐ | — |
-| **TC-F2** | **F-2:** Cross-principal routing on a shared bus (two principals, one NATS, `federated.*`, unsigned) | **F Routing** (priority) | new | ☐ | — |
-| **TC-F3** | **F-3:** Multi-link / multi-network runtime — one NATS leaf per network/deployment | **F Routing** | new (E.1 / #348) | ☐ | — |
-| **TC-2a** | Registry client — resolve peer pubkeys via `GET /principals/{id}` (Phase D.4) | 2-verify (harden) | new | ☐ | — |
-| **TC-2b** | Multi-principal `IdentityRegistry` (peer-stamped, not single boot principal) | 2-verify (harden) | new | ☐ | — |
-| **TC-2d** | `federated.*` crypto-verify wiring against registry-resolved peer pubkeys | 2-verify (harden) | new | ☐ | — |
-| **TC-3** | Payload encryption — sealed `extensions.enc`, X25519-from-ed25519, encrypt-then-sign | 3 Encryption | folds #369 | ☐ | — |
-| **TC-4a** | `cortex.yaml` chmod-600 gate (bot tokens) — **immediate quick win** | 4 At-rest/mTLS | new | ☐ | — |
-| **TC-4b** | File-mode hardening (event `published/` 0755→0700; mode audit) | 4 At-rest/mTLS | new | ☐ | — |
-| **TC-4c** | At-rest field encryption (high-sensitivity columns; local SQLite + D1) | 4 At-rest/mTLS | new | ☐ | — |
-| **TC-4d** | NATS mTLS — `tls` surface on `NatsLink` + cortex.yaml/relay plumbing | 4 At-rest/mTLS | new | ☐ | — |
-| **TC-4e** | Cloud-publisher mTLS + non-TLS `federated` leaf-node warning | 4 At-rest/mTLS | new | ☐ | — |
+| **TC-0** | Security posture config — unified `security:` toggles (signing/encryption/at-rest/mTLS), all default OFF; ramp `off→permissive→enforce` | 0 Posture | new | ☐ | #628 |
+| **TC-1a** | Fix #535 — thread `stackIdentity`/`stackNKeyPub` into review-consumer verifier | 1 Signing | folds #535 | ☐ | #535 |
+| **TC-1b** | Stack-identity provisioning + boot `verifier-self-check` on every stack | 1 Signing | new | ☐ | #632 |
+| **TC-1c** | Shape B — bound stack re-signs gateway-injected envelopes on ingest | 1 Signing | folds #552 | ☐ | #552 |
+| **TC-1d** | Enforce — `signFailureMode` → `drop`; tighten `rejectEmpty` on `tasks.chat` | 1 Signing | folds #210 | ☐ | #210 |
+| **TC-2c** | **F-1:** Relax single-principal guard + multi-principal subject derivation | **F Routing** (priority) | new | ☐ | #629 |
+| **TC-F2** | **F-2:** Cross-principal routing on a shared bus (two principals, one NATS, `federated.*`, unsigned) | **F Routing** (priority) | new | ☐ | #630 |
+| **TC-F3** | **F-3:** Multi-link / multi-network runtime — one NATS leaf per network/deployment | **F Routing** | new (E.1 / #348) | ☐ | #631 |
+| **TC-2a** | Registry client — resolve peer pubkeys via `GET /principals/{id}` (Phase D.4) | 2-verify (harden) | new | ☐ | #633 |
+| **TC-2b** | Multi-principal `IdentityRegistry` (peer-stamped, not single boot principal) | 2-verify (harden) | new | ☐ | #634 |
+| **TC-2d** | `federated.*` crypto-verify wiring against registry-resolved peer pubkeys | 2-verify (harden) | new | ☐ | #635 |
+| **TC-3** | Payload encryption — sealed `extensions.enc`, X25519-from-ed25519, encrypt-then-sign | 3 Encryption | folds #369 | ☐ | #369 |
+| **TC-4a** | `cortex.yaml` chmod-600 gate (bot tokens) — **immediate quick win** | 4 At-rest/mTLS | new | ☐ | #636 |
+| **TC-4b** | File-mode hardening (event `published/` 0755→0700; mode audit) | 4 At-rest/mTLS | new | ☐ | #637 |
+| **TC-4c** | At-rest field encryption (high-sensitivity columns; local SQLite + D1) | 4 At-rest/mTLS | new | ☐ | #638 |
+| **TC-4d** | NATS mTLS — `tls` surface on `NatsLink` + cortex.yaml/relay plumbing | 4 At-rest/mTLS | new | ☐ | #639 |
+| **TC-4e** | Cloud-publisher mTLS + non-TLS `federated` leaf-node warning | 4 At-rest/mTLS | new | ☐ | #640 |
 
 ## Drive order — federation-FIRST (unsigned), crypto layered on after
 

--- a/docs/iteration-trust-confidentiality.md
+++ b/docs/iteration-trust-confidentiality.md
@@ -1,0 +1,48 @@
+# Iteration Plan: Trust & Confidentiality
+
+Tracks `docs/design-trust-confidentiality.md`. Umbrella: **#TBD** (child of #110; cross-links #117, #524).
+Each slice is a sub-issue. `folds #N` = an existing issue this slice subsumes/reuses (don't recreate).
+Status: ☐ planned · ◐ in-progress · ☑ done.
+
+| Slice | Title | Phase | Folds / New | Status | Issue |
+|-------|-------|-------|-------------|--------|-------|
+| **TC-0** | Security posture config — unified `security:` toggles (signing/encryption/at-rest/mTLS), all default OFF; ramp `off→permissive→enforce` | 0 Posture | new | ☐ | — |
+| **TC-1a** | Fix #535 — thread `stackIdentity`/`stackNKeyPub` into review-consumer verifier | 1 Signing | folds #535 | ☐ | — |
+| **TC-1b** | Stack-identity provisioning + boot `verifier-self-check` on every stack | 1 Signing | new | ☐ | — |
+| **TC-1c** | Shape B — bound stack re-signs gateway-injected envelopes on ingest | 1 Signing | folds #552 | ☐ | — |
+| **TC-1d** | Enforce — `signFailureMode` → `drop`; tighten `rejectEmpty` on `tasks.chat` | 1 Signing | folds #210 | ☐ | — |
+| **TC-2c** | **F-1:** Relax single-principal guard + multi-principal subject derivation | **F Routing** (priority) | new | ☐ | — |
+| **TC-F2** | **F-2:** Cross-principal routing on a shared bus (two principals, one NATS, `federated.*`, unsigned) | **F Routing** (priority) | new | ☐ | — |
+| **TC-F3** | **F-3:** Multi-link / multi-network runtime — one NATS leaf per network/deployment | **F Routing** | new (E.1 / #348) | ☐ | — |
+| **TC-2a** | Registry client — resolve peer pubkeys via `GET /principals/{id}` (Phase D.4) | 2-verify (harden) | new | ☐ | — |
+| **TC-2b** | Multi-principal `IdentityRegistry` (peer-stamped, not single boot principal) | 2-verify (harden) | new | ☐ | — |
+| **TC-2d** | `federated.*` crypto-verify wiring against registry-resolved peer pubkeys | 2-verify (harden) | new | ☐ | — |
+| **TC-3** | Payload encryption — sealed `extensions.enc`, X25519-from-ed25519, encrypt-then-sign | 3 Encryption | folds #369 | ☐ | — |
+| **TC-4a** | `cortex.yaml` chmod-600 gate (bot tokens) — **immediate quick win** | 4 At-rest/mTLS | new | ☐ | — |
+| **TC-4b** | File-mode hardening (event `published/` 0755→0700; mode audit) | 4 At-rest/mTLS | new | ☐ | — |
+| **TC-4c** | At-rest field encryption (high-sensitivity columns; local SQLite + D1) | 4 At-rest/mTLS | new | ☐ | — |
+| **TC-4d** | NATS mTLS — `tls` surface on `NatsLink` + cortex.yaml/relay plumbing | 4 At-rest/mTLS | new | ☐ | — |
+| **TC-4e** | Cloud-publisher mTLS + non-TLS `federated` leaf-node warning | 4 At-rest/mTLS | new | ☐ | — |
+
+## Drive order — federation-FIRST (unsigned), crypto layered on after
+
+Principal goal: **cross-principal, multi-deployment collaboration ASAP**. The Phase-0 toggles let us run
+federation routing UNSIGNED, then ramp crypto. (⚠️ see caveat below.)
+
+1. **Now, in parallel (small, independent, high-value):** **TC-0** (posture toggles, all default OFF) · **TC-1a** (#535, ~3 lines, unblocks review loop) · **TC-4a** (chmod-600 quick win).
+2. **PRIORITY — federation routing, unsigned (`security.signing: off`):** TC-2c/**F-1** (relax single-principal guard + multi-principal subjects) → **TC-F2** (cross-principal on a shared bus — two principals collaborating, unsigned) → **TC-F3** (multi-link / multi-network bridging). *This is the goal; reachable without any crypto.*
+3. **Harden — signing:** TC-1b → TC-1c (#552) → TC-1d (#210, flip `signing: enforce`).
+4. **Harden — federation crypto-verify:** TC-2a → TC-2b → TC-2d (engaged when `signing: enforce`).
+5. **Harden — encryption:** TC-3 (#369) — payload encryption (needs TC-2a/2b).
+6. **Parallel throughout:** TC-4b–4e (at-rest + mTLS) — no dependency on the above.
+
+> ⚠️ **Caveat:** unsigned cross-principal federation is **unauthenticated** (a peer can claim any
+> principal). Fine for dev / trusted-party testing. `signing: enforce` + `encryption.payload` MUST be on
+> before federation faces an untrusted or cross-org peer — a deliberate, reviewable toggle flip.
+
+## Exit criteria
+
+- Every bus envelope on a configured stack carries a verifiable stack `signed_by[]` stamp; unsigned dispatches dropped (not fallback).
+- A principal-B-signed `federated.*` envelope verifies on principal A's node; forged peer signature rejected.
+- On an encryption-enabled network, a peer without the recipient key cannot read `payload`; intended stack decrypts; routing/sovereignty unaffected.
+- No plaintext bot tokens or high-sensitivity columns at rest without app-level encryption or enforced 0600; NATS connections support mTLS.


### PR DESCRIPTION
Consolidation design + iteration plan for the trust/confidentiality track. Umbrella **#627** (child of #110; cross-links #117, #524).

- References ratified work (#369 encryption, #552 Shape B, #535, Phase D) rather than re-deciding it; specs the two new layers (at-rest, mTLS).
- **Phase 0:** unified `security:` toggles, all default OFF — run the stack unsigned/cleartext, ramp `off→permissive→enforce`.
- **Drive priority: federation-FIRST (unsigned)** — F-1 relax single-principal guard → F-2 cross-principal shared bus → F-3 multi-link; signing/encryption layered on after.
- ⚠️ Unsigned cross-principal = unauthenticated (dev/trusted-party only).

Docs only. Closes nothing; tracked by #627.

🤖 Generated with [Claude Code](https://claude.com/claude-code)