### PR TITLE
feat(dashboard): rebrand UI Grove → Cortex

### DIFF
--- a/src/surface/mc/__tests__/server.test.ts
+++ b/src/surface/mc/__tests__/server.test.ts
@@ -93,7 +93,7 @@ describe("mission-control server", () => {
     // mount point + page title rather than route strings (which now
     // live inside the bundled JS, not the HTML).
     expect(body).toContain('<div id="root">');
-    expect(body).toContain("Grove · Mission Control");
+    expect(body).toContain("Cortex · Mission Control");
   });
 
   // Spec NFR: "On port already in use: exit with clear error message naming the port".

--- a/src/surface/mc/dashboard-v2/app.tsx
+++ b/src/surface/mc/dashboard-v2/app.tsx
@@ -237,7 +237,7 @@ export function App() {
   return (
     <div className="scaffold-shell">
       <header className="scaffold-header">
-        <h1>Grove · Mission Control</h1>
+        <h1>Cortex · Mission Control</h1>
         <div className="right">
           {/*
             G-1113 — Mission Control Cockpit redesign signpost. Links to the

--- a/src/surface/mc/dashboard-v2/components/drill-input.tsx
+++ b/src/surface/mc/dashboard-v2/components/drill-input.tsx
@@ -528,7 +528,7 @@ export function DrillInput({ assignmentId, assignment, ws, onSend }: DrillInputP
 
 function readonlyPlaceholder(mode: ReturnType<typeof resolveDrillInputMode>): string {
   if (mode === "observed") {
-    return "This session is observed. Input ships when you open it in a controlled Grove session.";
+    return "This session is observed. Input ships when you open it in a controlled Cortex session.";
   }
   if (mode === "shadow") {
     return "This task has no active session yet. Click Dispatch to start one.";

--- a/src/surface/mc/dashboard-v2/index.html
+++ b/src/surface/mc/dashboard-v2/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Grove · Mission Control</title>
+  <title>Cortex · Mission Control</title>
   <!--
     Pre-paint theme application — avoids FOUC on light-mode reload.
     Reads the same `mc.theme` key as `useTheme`; React hydration is a


### PR DESCRIPTION
## Rebrand the operator-facing UI: Grove → Cortex

The dashboard header still read **Grove · Mission Control**, but the operator-facing brand is **Cortex** (per CLAUDE.md). This renames the user-visible strings only.

### Changed (user-visible)
- `dashboard-v2/index.html` — `<title>` → `Cortex · Mission Control`
- `dashboard-v2/app.tsx:240` — `<h1>` → `Cortex · Mission Control`
- `dashboard-v2/components/drill-input.tsx:531` — observed-session placeholder → "controlled **Cortex** session"
- `__tests__/server.test.ts` — brand assertion updated to match

### Intentionally NOT changed (out of scope for v1)
Infra names stay `grove-*`: the `grove-dashboard` Pages project, `grove-api` worker, `grove-dev.meta-factory.ai` / `grove.meta-factory.ai` hosts, `grove-events` D1. The DNS/project rename is a separate post-MIG-8 phase per `docs/plan-cortex-migration.md` open-question 12 (operator brand and legacy DNS host can legitimately differ during v1). Also left the internal `iteration-status.test.ts` "Grove-only" describe string (test jargon, not user-facing).

### Verification
- `bunx tsc --noEmit` clean
- `bun run build:dashboard` builds
- `bash scripts/check-carveouts.sh` PASS
- `bun test src/surface/mc/dashboard-v2` 429 pass / 0 fail; `server.test.ts` 3/3
- Visible-Grove sweep of the dashboard → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)