### PR TITLE
feat(config): TC-4a — enforce chmod-600 on cortex.yaml (closes #636)

### DIFF
--- a/src/__tests__/cortex.test.ts
+++ b/src/__tests__/cortex.test.ts
@@ -24,7 +24,7 @@
  */
 
 import { describe, expect, test } from "bun:test";
-import { mkdtempSync, writeFileSync, rmSync } from "fs";
+import { mkdtempSync, writeFileSync, rmSync, chmodSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 import { AgentConfigSchema, type AgentConfig } from "../common/types/config";
@@ -731,6 +731,10 @@ describe("runDryRun — config validator (cortex#88 item 2)", () => {
       ].join("\n"),
       "utf-8",
     );
+    // TC-4a (cortex#636): the single-file config read enforces chmod 600
+    // (it carries platform bot tokens). Set 0600 so the gate passes and the
+    // dry-run exercises its real validation path, not the permission error.
+    chmodSync(cfgPath, 0o600);
     const result = runDryRun(cfgPath);
     expect(result.exitCode).toBe(0);
     expect(result.stdout).toMatch(/cortex config validation OK/);
@@ -767,6 +771,10 @@ describe("runDryRun — config validator (cortex#88 item 2)", () => {
       ].join("\n"),
       "utf-8",
     );
+    // TC-4a (cortex#636): the single-file config read enforces chmod 600
+    // (it carries platform bot tokens). Set 0600 so the gate passes and the
+    // dry-run exercises its real validation path, not the permission error.
+    chmodSync(cfgPath, 0o600);
     const result = runDryRun(cfgPath);
     expect(result.exitCode).toBe(0);
     expect(result.stdout).toMatch(/NATS=\(disabled\)/);
@@ -791,6 +799,10 @@ describe("runDryRun — config validator (cortex#88 item 2)", () => {
       ].join("\n"),
       "utf-8",
     );
+    // TC-4a (cortex#636): the single-file config read enforces chmod 600
+    // (it carries platform bot tokens). Set 0600 so the gate passes and the
+    // dry-run exercises its real validation path, not the permission error.
+    chmodSync(cfgPath, 0o600);
     const result = runDryRun(cfgPath);
     expect(result.exitCode).toBe(2);
     expect(result.stderr).toMatch(/cortex config validation FAILED/);
@@ -820,6 +832,10 @@ describe("runDryRun — config validator (cortex#88 item 2)", () => {
       ].join("\n"),
       "utf-8",
     );
+    // TC-4a (cortex#636): the single-file config read enforces chmod 600
+    // (it carries platform bot tokens). Set 0600 so the gate passes and the
+    // dry-run exercises its real validation path, not the permission error.
+    chmodSync(cfgPath, 0o600);
     const result = runDryRun(cfgPath);
     expect(result.exitCode).toBe(2);
     expect(result.stderr).toMatch(/has no agents — config invalid/);

--- a/src/common/config/__tests__/composer.test.ts
+++ b/src/common/config/__tests__/composer.test.ts
@@ -86,7 +86,9 @@ function fullCortexConfig(): Record<string, unknown> {
 /** Write a single-file `cortex.yaml` in `dir`, return its path. */
 function writeSingleFile(dir: string, config: Record<string, unknown>): string {
   const path = join(dir, "cortex.yaml");
-  writeFileSync(path, stringify(config));
+  // TC-4a (cortex#636): single-file config read enforces chmod 600 (it
+  // carries platform bot tokens). Write 0600 so the gate passes.
+  writeFileSync(path, stringify(config), { mode: 0o600 });
   return path;
 }
 

--- a/src/common/config/__tests__/loader.test.ts
+++ b/src/common/config/__tests__/loader.test.ts
@@ -4,7 +4,7 @@
  */
 
 import { test, expect, describe, beforeEach, afterEach } from "bun:test";
-import { mkdirSync, writeFileSync, rmSync, existsSync } from "fs";
+import { mkdirSync, writeFileSync, rmSync, existsSync, chmodSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 import { stringify } from "yaml";
@@ -26,7 +26,9 @@ function setupTestDir(): string {
 function writeCentralConfig(dir: string, config: Record<string, unknown>): string {
 
   const path = join(dir, "bot.yaml");
-  writeFileSync(path, stringify(config));
+  // TC-4a (cortex#636): the single-file config read enforces chmod 600
+  // (it carries platform bot tokens). Write fixtures 0600 so the gate passes.
+  writeFileSync(path, stringify(config), { mode: 0o600 });
   return path;
 }
 
@@ -359,7 +361,9 @@ import { loadConfigWithAgents } from "../loader";
 describe("MIG-7.2e — cortex-shape detection + transform", () => {
   function writeCortexConfig(dir: string, config: Record<string, unknown>): string {
     const path = join(dir, "cortex.yaml");
-    writeFileSync(path, stringify(config));
+    // TC-4a (cortex#636): the single-file config read enforces chmod 600
+  // (it carries platform bot tokens). Write fixtures 0600 so the gate passes.
+  writeFileSync(path, stringify(config), { mode: 0o600 });
     return path;
   }
 
@@ -854,5 +858,69 @@ describe("MIG-7.2e — cortex-shape detection + transform", () => {
     };
     const path = writeCortexConfig(testDir, cfg);
     expect(() => loadConfigWithAgents(path)).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TC-4a (cortex#636) — chmod-600 gate on the single-file cortex.yaml read.
+//
+// The single `cortex.yaml` carries platform BOT TOKENS (Discord/Slack/
+// Mattermost) inline, so the single-file load path enforces the same
+// chmod-600 gate the nkey-seed and `.creds` loaders already apply. The gate
+// is POSIX-only (the shared helper skips win32, where NTFS uses ACLs).
+// ---------------------------------------------------------------------------
+
+describe("TC-4a — chmod-600 gate on single-file cortex.yaml (cortex#636)", () => {
+  // Minimal valid cortex-shape config (mirrors the MIG-7.2e fixtures) — its
+  // own copy so this block is independent of the cortex-shape describe scope.
+  function minimalCortexConfig(): Record<string, unknown> {
+    return {
+      principal: { id: "jc", displayName: "JC", discordId: "1" },
+      agents: [
+        {
+          id: "ivy",
+          displayName: "Ivy",
+          persona: "./personas/ivy.md",
+          roles: [],
+          trust: [],
+          presence: {
+            discord: {
+              token: "fake-token-ivy",
+              guildId: "1",
+              agentChannelId: "2",
+              logChannelId: "3",
+            },
+          },
+        },
+      ],
+      claude: {},
+    };
+  }
+
+  // The gate is a no-op on win32 (NTFS ACLs are the principal's
+  // responsibility — see file-permissions.ts), so skip there.
+  const itPosix = process.platform === "win32" ? test.skip : test;
+
+  itPosix("rejects a cortex.yaml with looser-than-0600 perms", () => {
+    const path = join(testDir, "cortex.yaml");
+    writeFileSync(path, stringify(minimalCortexConfig()));
+    chmodSync(path, 0o644); // group/world-readable — must be rejected
+    expect(() => loadConfigWithAgents(path)).toThrow(/must be chmod 600/);
+  });
+
+  itPosix("rejects a group/world-writable cortex.yaml (0660)", () => {
+    const path = join(testDir, "cortex.yaml");
+    writeFileSync(path, stringify(minimalCortexConfig()));
+    chmodSync(path, 0o660);
+    expect(() => loadConfigWithAgents(path)).toThrow(/must be chmod 600/);
+  });
+
+  itPosix("loads a cortex.yaml that is exactly chmod 600", () => {
+    const path = join(testDir, "cortex.yaml");
+    writeFileSync(path, stringify(minimalCortexConfig()));
+    chmodSync(path, 0o600);
+    const loaded = loadConfigWithAgents(path);
+    expect(loaded.inlineAgents).toHaveLength(1);
+    expect(loaded.principal?.id).toBe("jc");
   });
 });

--- a/src/common/config/__tests__/surfaces-layer.test.ts
+++ b/src/common/config/__tests__/surfaces-layer.test.ts
@@ -159,7 +159,9 @@ function surfacesBlock(): Record<string, unknown> {
 function writeSingleFile(dir: string, config: Record<string, unknown>): string {
   mkdirSync(dir, { recursive: true });
   const path = join(dir, "cortex.yaml");
-  writeFileSync(path, stringify(config));
+  // TC-4a (cortex#636): single-file config read enforces chmod 600 (it
+  // carries platform bot tokens). Write 0600 so the gate passes.
+  writeFileSync(path, stringify(config), { mode: 0o600 });
   return path;
 }
 

--- a/src/common/config/__tests__/surfaces-on-loaded-config.test.ts
+++ b/src/common/config/__tests__/surfaces-on-loaded-config.test.ts
@@ -157,7 +157,9 @@ function surfacesBlock(): Record<string, unknown> {
 function writeSingleFile(dir: string, config: Record<string, unknown>): string {
   mkdirSync(dir, { recursive: true });
   const path = join(dir, "cortex.yaml");
-  writeFileSync(path, stringify(config));
+  // TC-4a (cortex#636): single-file config read enforces chmod 600 (it
+  // carries platform bot tokens). Write 0600 so the gate passes.
+  writeFileSync(path, stringify(config), { mode: 0o600 });
   return path;
 }
 
@@ -351,6 +353,7 @@ describe("GW.3b.2a.4 — legacy bot.yaml input: surfaces is always undefined", (
     const dir = join(testDir, "legacy");
     mkdirSync(dir, { recursive: true });
     const path = join(dir, "bot.yaml");
+    // TC-4a (cortex#636): single-file config read enforces chmod 600.
     writeFileSync(
       path,
       stringify({
@@ -358,6 +361,7 @@ describe("GW.3b.2a.4 — legacy bot.yaml input: surfaces is always undefined", (
         claude: { timeoutMs: 120000 },
         networksDir: "./networks",
       }),
+      { mode: 0o600 },
     );
     const loaded = loadConfigWithAgents(path);
     expect(loaded.surfaces).toBeUndefined();

--- a/src/common/config/__tests__/system-layer.test.ts
+++ b/src/common/config/__tests__/system-layer.test.ts
@@ -109,7 +109,9 @@ function stackBlocks(): Record<string, unknown> {
 
 function writeSingleFile(dir: string, config: Record<string, unknown>): string {
   const path = join(dir, "cortex.yaml");
-  writeFileSync(path, stringify(config));
+  // TC-4a (cortex#636): single-file config read enforces chmod 600 (it
+  // carries platform bot tokens). Write 0600 so the gate passes.
+  writeFileSync(path, stringify(config), { mode: 0o600 });
   return path;
 }
 

--- a/src/common/config/__tests__/watcher.test.ts
+++ b/src/common/config/__tests__/watcher.test.ts
@@ -3,11 +3,23 @@
  */
 
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-import { writeFileSync, unlinkSync, existsSync } from "fs";
+import { writeFileSync, unlinkSync, existsSync, chmodSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 import { ConfigWatcher } from "../watcher";
 import type { AgentConfig } from "../../types/config";
+
+/**
+ * Write a single-file config fixture at 0600. TC-4a (cortex#636): the
+ * single-file config read enforces chmod 600 (it carries platform bot
+ * tokens), so the watcher's reload path rejects looser modes. `chmodSync`
+ * (not the writeFileSync `mode` option) because reload tests rewrite an
+ * existing fixture in place, and the `mode` option only applies on creation.
+ */
+function writeConfigFixture(path: string, yaml: string): void {
+  writeFileSync(path, yaml, "utf-8");
+  chmodSync(path, 0o600);
+}
 
 const TEST_CONFIG: AgentConfig = {
   agent: {
@@ -131,7 +143,7 @@ paths:
   publishedEventsDir: "~/.claude/events/published"
   logDir: "~/.config/grove/logs"
 `;
-    writeFileSync(testConfigPath, yaml, "utf-8");
+    writeConfigFixture(testConfigPath, yaml);
   });
 
   afterEach(() => {
@@ -195,7 +207,7 @@ paths:
 `;
 
     watcher.start();
-    writeFileSync(testConfigPath, updatedYaml, "utf-8");
+    writeConfigFixture(testConfigPath, updatedYaml);
 
     // Wait for debounced reload
     await new Promise((resolve) => setTimeout(resolve, 300));
@@ -261,7 +273,7 @@ paths:
 `;
 
     watcher.start();
-    writeFileSync(testConfigPath, updatedYaml, "utf-8");
+    writeConfigFixture(testConfigPath, updatedYaml);
 
     // Wait for debounced reload
     await new Promise((resolve) => setTimeout(resolve, 300));
@@ -326,7 +338,7 @@ paths:
 `;
   beforeEach(() => {
     testConfigPath = join(tmpdir(), `cortex-c135-${Date.now()}-${Math.random().toString(36).slice(2)}.yaml`);
-    writeFileSync(testConfigPath, INITIAL_YAML, "utf-8");
+    writeConfigFixture(testConfigPath, INITIAL_YAML);
   });
   afterEach(() => {
     if (existsSync(testConfigPath)) unlinkSync(testConfigPath);
@@ -387,7 +399,7 @@ paths:
 `;
 
     watcher.start();
-    writeFileSync(testConfigPath, updatedYaml, "utf-8");
+    writeConfigFixture(testConfigPath, updatedYaml);
     await new Promise((resolve) => setTimeout(resolve, 300));
     watcher.stop();
 
@@ -462,7 +474,7 @@ paths:
 `;
 
     watcher.start();
-    writeFileSync(testConfigPath, updatedYaml, "utf-8");
+    writeConfigFixture(testConfigPath, updatedYaml);
     await new Promise((resolve) => setTimeout(resolve, 300));
     watcher.stop();
 

--- a/src/common/config/file-permissions.ts
+++ b/src/common/config/file-permissions.ts
@@ -11,6 +11,9 @@
  * Callers:
  *   - `account-signing-key.ts` (operator account signing key, SA-prefix)
  *   - `bus/nats/connection.ts` (NATS user `.creds`, JWT + NKey seed)
+ *   - `stack-signing-key.ts` (stack signing key, SU-prefix nkey seed)
+ *   - `loader.ts` (single-file `cortex.yaml` — carries platform bot tokens;
+ *     TC-4a / cortex#636)
  */
 
 import { statSync } from "fs";

--- a/src/common/config/loader.ts
+++ b/src/common/config/loader.ts
@@ -23,6 +23,7 @@ import {
   type StackConfig,
 } from "../types/cortex-config";
 import { foldSurfaceBindings, SurfacesSchema, type Surfaces } from "../types/surfaces";
+import { enforceChmod600 } from "./file-permissions";
 
 /**
  * Hardening cap on a single fragment file's size. Echo M3 on cortex#62 —
@@ -379,6 +380,17 @@ function composeRawConfigWithSurfaces(configPath: string): {
     // CFG.a.2 — single-file fallback. Capture any `surfaces:` block BEFORE
     // the fold so `LoadedConfig.surfaces` is populated symmetrically with the
     // directory-layout path (CFG.c design: both ingestion paths are symmetric).
+    //
+    // TC-4a (cortex#636) — the single `cortex.yaml` carries platform BOT
+    // TOKENS (Discord/Slack/Mattermost) inline, so it gets the same
+    // chmod-600 gate the nkey-seed (`stack-signing-key.ts`) and NATS
+    // `.creds` (`bus/nats/connection.ts`) loaders already enforce via the
+    // shared `enforceChmod600` helper. Sync `statSync` keeps the
+    // stat-then-read TOCTOU window as tight as the sibling loaders'; the
+    // daemon owns its config dir, so the practical risk is near zero — an
+    // attacker who can swap files there has already won. The helper skips
+    // the gate on win32 (NTFS ACLs are the principal's responsibility).
+    enforceChmod600(expandedPath);
     const content = readFileSync(expandedPath, "utf-8");
     const single = (parseYaml(content) ?? {}) as Record<string, unknown>;
     const surfaces = parseSurfaces(single.surfaces);


### PR DESCRIPTION
## What

`cortex.yaml` carries platform **BOT TOKENS** (Discord/Slack/Mattermost) inline, but the single-file load path read it with a plain `readFileSync` and **no permission gate** — unlike the nkey-seed (`stack-signing-key.ts`) and NATS `.creds` (`bus/nats/connection.ts`) loaders, which both enforce chmod 600 via the shared `enforceChmod600` helper.

This adds the same gate to the single-file fallback read in `composeRawConfigWithSurfaces` (`src/common/config/loader.ts`) — the path that ingests the monolithic cortex.yaml.

## How

- `enforceChmod600(expandedPath)` is called immediately before the single-file `readFileSync`, mirroring `stack-signing-key.ts:70` and `bus/nats/connection.ts:74` (same error style, same skip-on-win32 behaviour the helper already provides).
- Sync `statSync` keeps the stat-then-read **TOCTOU** window as tight as the sibling loaders'; documented consistently with the existing callers (the daemon owns its config dir, so the practical risk is near zero).
- **Scope:** only the **single `cortex.yaml`** read is gated. The directory-layout ingestion path (`system/` + `network/` + `surfaces/` + `stacks/` layer-merge) is untouched — TC-4a is scoped to the monolithic file with inline tokens, per #636.

## Keeping fixture-loading tests green

The single-file load path now rejects looser-than-0600 fixtures. Handled per ingestion branch:

- **Single-file fixtures** (read via the gated path) → write helpers now emit `{ mode: 0o600 }` (`loader.test.ts`, `composer.test.ts`, `surfaces-layer.test.ts`, `system-layer.test.ts`, `surfaces-on-loaded-config.test.ts`, and the `runDryRun` validator tests in `cortex.test.ts`).
- **Watcher reload tests** rewrite the fixture in place, where the `writeFileSync` `mode` option does NOT apply (it's creation-only) — so they use a `chmodSync`-after-write helper (`watcher.test.ts`).
- **Directory-layout fixtures** (system.yaml marker present → unguarded layer-merge branch) are left untouched.

## Test added

`loader.test.ts` → new describe `TC-4a — chmod-600 gate on single-file cortex.yaml (cortex#636)`:
- a 0644 cortex.yaml is rejected with `must be chmod 600`
- a 0660 (group/world-writable) cortex.yaml is rejected
- a 0600 cortex.yaml loads (asserts the agent + principal parse through)

POSIX-gated (`test.skip` on win32, matching the helper's own skip).

## Verification

- `bunx tsc --noEmit` (minus eslint.config.js) → no `error TS`
- `bun run lint:errors` → clean
- `bun test` (full suite) → **4050 pass / 0 fail** across 231 files
- config suites (`src/common/config/__tests__/*`) → 162 pass / 0 fail

Closes #636. Part of #627.