### PR TITLE
feat(taps): TC-4b — tighten event published/ dir to 0700 + mode audit (closes #637)

### DIFF
--- a/src/runner/db-utils.ts
+++ b/src/runner/db-utils.ts
@@ -16,7 +16,9 @@ import { dirname } from "path";
 export function initDatabase(dbPath: string): Database {
   const dir = dirname(dbPath);
   if (!existsSync(dir)) {
-    mkdirSync(dir, { recursive: true });
+    // TC-4b (cortex#637): runner SQLite dir holds session + worklog rows
+    // (prompts, commands) — owner-only (0o700), never world-readable.
+    mkdirSync(dir, { recursive: true, mode: 0o700 });
   }
 
   const db = new Database(dbPath);

--- a/src/surface/mc/db/init.ts
+++ b/src/surface/mc/db/init.ts
@@ -14,7 +14,9 @@ import { COLUMN_ADD_MIGRATIONS, REBUILD_MIGRATIONS, SCHEMA_SQL } from "./schema"
  * Creates parent directories if they don't exist.
  */
 export function initDatabase(dbPath: string): Database {
-  mkdirSync(dirname(dbPath), { recursive: true });
+  // TC-4b (cortex#637): the Mission Control SQLite dir holds event rows with
+  // prompt/command/tool previews — owner-only (0o700), never world-readable.
+  mkdirSync(dirname(dbPath), { recursive: true, mode: 0o700 });
 
   const db = new Database(dbPath, { create: true });
   db.run("PRAGMA journal_mode = WAL");

--- a/src/taps/cc-events/hooks/EventLogger.hook.ts
+++ b/src/taps/cc-events/hooks/EventLogger.hook.ts
@@ -104,7 +104,9 @@ function ensureDir(dir: string, mode: number): void {
 }
 
 ensureDir(RAW_DIR, 0o700);
-ensureDir(join(EVENTS_DIR, "published"), 0o755);
+// TC-4b (cortex#637): published/ JSONL holds prompt/command/tool previews —
+// owner-only (0o700) to match raw/, not world-readable.
+ensureDir(join(EVENTS_DIR, "published"), 0o700);
 
 // =============================================================================
 // H-004: HTTP POST ingestion (primary), JSONL fallback (secondary)

--- a/src/taps/cc-events/lib/__tests__/event-processor.test.ts
+++ b/src/taps/cc-events/lib/__tests__/event-processor.test.ts
@@ -111,6 +111,10 @@ describe("EventProcessor", () => {
     expect(existsSync(newPubDir)).toBe(true);
     // Mask to the low 9 permission bits; assert rwx------ (0o700).
     expect(statSync(newPubDir).mode & 0o777).toBe(0o700);
+    // The published JSONL file itself must be owner-only (0o600), matching the
+    // EventLogger raw/ files — defense-in-depth if the file is copied out of
+    // the 0o700 dir. (rw-------)
+    expect(statSync(pubFile).mode & 0o777).toBe(0o600);
   });
 
   test("returns 0 for empty raw file", () => {

--- a/src/taps/cc-events/lib/__tests__/event-processor.test.ts
+++ b/src/taps/cc-events/lib/__tests__/event-processor.test.ts
@@ -1,7 +1,7 @@
 import { test, expect, describe, beforeEach, afterEach } from "bun:test";
 import { EventProcessor } from "../event-processor";
 import { JsonlReader } from "../jsonl-reader";
-import { mkdirSync, writeFileSync, readFileSync, rmSync, existsSync, appendFileSync } from "fs";
+import { mkdirSync, writeFileSync, readFileSync, rmSync, existsSync, appendFileSync, statSync } from "fs";
 import { join } from "path";
 import type { RelayPolicy } from "../policy-schema";
 
@@ -93,6 +93,24 @@ describe("EventProcessor", () => {
 
     expect(existsSync(newPubDir)).toBe(true);
     expect(existsSync(pubFile)).toBe(true);
+  });
+
+  test("TC-4b (cortex#637): creates published directory at 0o700 (owner-only)", () => {
+    // published/ JSONL holds prompt/command/tool previews — the dir must be
+    // owner-only, never world-readable. POSIX-gated: NTFS uses ACLs, not modes.
+    if (process.platform === "win32") return;
+
+    const rawFile = join(RAW_DIR, "s-mode.jsonl");
+    const newPubDir = join(TEST_DIR, "mode-published");
+    const pubFile = join(newPubDir, "s-mode.jsonl");
+    const processor = new EventProcessor(testPolicy);
+
+    writeEvent(rawFile, sampleRawEvent(1));
+    processor.processFile(rawFile, pubFile);
+
+    expect(existsSync(newPubDir)).toBe(true);
+    // Mask to the low 9 permission bits; assert rwx------ (0o700).
+    expect(statSync(newPubDir).mode & 0o777).toBe(0o700);
   });
 
   test("returns 0 for empty raw file", () => {

--- a/src/taps/cc-events/lib/event-processor.ts
+++ b/src/taps/cc-events/lib/event-processor.ts
@@ -68,7 +68,9 @@ export class EventProcessor {
     // Ensure published directory exists
     const pubDir = dirname(publishedPath);
     if (!existsSync(pubDir)) {
-      mkdirSync(pubDir, { recursive: true, mode: 0o755 });
+      // TC-4b (cortex#637): published/ JSONL holds prompt/command/tool
+      // previews — owner-only (0o700) to match the EventLogger raw/ dir.
+      mkdirSync(pubDir, { recursive: true, mode: 0o700 });
     }
 
     let published = 0;

--- a/src/taps/cc-events/lib/event-processor.ts
+++ b/src/taps/cc-events/lib/event-processor.ts
@@ -78,7 +78,11 @@ export class EventProcessor {
       const result = processEvent(raw, this.policy);
       if (result) {
         appendFileSync(publishedPath, JSON.stringify(result) + "\n");
-        chmodSync(publishedPath, 0o644);
+        // TC-4b (cortex#637): the published JSONL holds prompt/command/tool
+        // previews — owner-only (0o600) to match the EventLogger raw/ files,
+        // not world-readable. The 0o700 dir guards traversal; the 0o600 file
+        // mode is defense-in-depth if the file is ever copied out of the dir.
+        chmodSync(publishedPath, 0o600);
         published++;
 
         // MIG-5b: Best-effort bus tap. JSONL append above is the primary


### PR DESCRIPTION
## TC-4b — at-rest permission hardening for the event pipeline

Closes #637. Part of #627.

The `published/` event JSONL holds prompt/command/tool previews but was created **world-readable (0o755)**, while sibling `raw/` was already owner-only (0o700). This tightens `published/` to `0o700` and audits the other at-rest dir-creates that hold sensitive data.

### Changes

| Site | Holds | Before | After |
|------|-------|--------|-------|
| `taps/cc-events/hooks/EventLogger.hook.ts:107` | published/ JSONL (prompt/command/tool previews) | `0o755` | `0o700` |
| `taps/cc-events/lib/event-processor.ts:71` | same published/ dir, relay-side re-create | `0o755` | `0o700` |
| `surface/mc/db/init.ts:17` | Mission Control SQLite dir (event rows w/ previews) | default (world-readable) | `0o700` |
| `runner/db-utils.ts:19` | runner SQLite dir (session + worklog rows) | default (world-readable) | `0o700` |

Each site gets a one-line comment citing the rationale. No behavior changes beyond perms. The cortex-relay reads `published/` as the same user, so tightening is read-transparent.

### Verification

- `bunx tsc --noEmit` — no `error TS`
- `bun run lint:errors` — clean (`eslint --quiet .`)
- `bun test src/taps/cc-events/` — 149 pass / 0 fail
- `bun test src/runner/ src/surface/mc/db/` — 333 pass / 0 fail (touched-site suites)
- New test: `event-processor.test.ts` — POSIX-gated (`win32` skip) assertion that `processFile` creates the published dir at `0o700`

🤖 Generated with [Claude Code](https://claude.com/claude-code)