### PR TITLE
feat(gateway): F-1 — relax single-principal guard + multi-principal subjects (closes #629)

### DIFF
--- a/src/adapters/__tests__/dispatch-sink.test.ts
+++ b/src/adapters/__tests__/dispatch-sink.test.ts
@@ -475,3 +475,150 @@ describe("dispatch-sink — gateway multi-stack subscription (a.3d)", () => {
     expect(adapterB.progressSent).toHaveLength(0);
   });
 });
+
+// ─── F-1 multi-principal subscription (cortex#629) ───────────────────────────
+
+describe("dispatch-sink — gateway multi-principal subscription (F-1, cortex#629)", () => {
+  test("`principalStacks` builds one subject per (principal, stack) pair, own principal in each", async () => {
+    const { runtime, subscribedPatterns } = fakeRuntime();
+    const sink = createDispatchSink({
+      runtime,
+      adapters: [],
+      // the gateway's own principal is irrelevant when principalStacks is set;
+      // each subject carries its OWN principal segment.
+      principal: "gateway-principal",
+      principalStacks: [
+        { principal: "andreas", stack: "meta-factory" },
+        { principal: "robin", stack: "research" },
+      ],
+    });
+    await sink.start();
+    expect(sink.subjects).toEqual([
+      "local.andreas.meta-factory.dispatch.task.>",
+      "local.robin.research.dispatch.task.>",
+    ]);
+    expect(subscribedPatterns).toEqual([...sink.subjects]);
+  });
+
+  test("`undefined` stack → the 5-segment subject under THAT pair's principal", async () => {
+    const { runtime } = fakeRuntime();
+    const sink = createDispatchSink({
+      runtime,
+      adapters: [],
+      principal: "gateway-principal",
+      principalStacks: [
+        { principal: "andreas", stack: "meta-factory" },
+        { principal: "andreas" }, // gap-4: no stack
+      ],
+    });
+    await sink.start();
+    expect(sink.subjects).toEqual([
+      "local.andreas.meta-factory.dispatch.task.>",
+      "local.andreas.dispatch.task.>",
+    ]);
+  });
+
+  test("duplicate (principal, stack) pairs collapse; same leaf under different principals does NOT", async () => {
+    const { runtime } = fakeRuntime();
+    const sink = createDispatchSink({
+      runtime,
+      adapters: [],
+      principal: "gateway-principal",
+      principalStacks: [
+        { principal: "andreas", stack: "research" },
+        { principal: "andreas", stack: "research" }, // exact dup → collapses
+        { principal: "robin", stack: "research" }, // same leaf, diff principal → kept
+        { principal: "andreas" }, // gap-4 undefined → its own bucket
+        { principal: "andreas" }, // dup undefined → collapses
+      ],
+    });
+    await sink.start();
+    expect(sink.subjects).toEqual([
+      "local.andreas.research.dispatch.task.>",
+      "local.robin.research.dispatch.task.>",
+      "local.andreas.dispatch.task.>",
+    ]);
+  });
+
+  test("`principalStacks` (non-empty) takes precedence over both `stacks` and `stack`", async () => {
+    const { runtime } = fakeRuntime();
+    const sink = createDispatchSink({
+      runtime,
+      adapters: [],
+      principal: "gateway-principal",
+      stack: "ignored-single",
+      stacks: ["ignored-multi"],
+      principalStacks: [{ principal: "robin", stack: "research" }],
+    });
+    await sink.start();
+    expect(sink.subjects).toEqual(["local.robin.research.dispatch.task.>"]);
+  });
+
+  test("EMPTY `principalStacks: []` falls back to `stacks` (no silent zero-subscribe)", async () => {
+    const { runtime, subscribedPatterns } = fakeRuntime();
+    const sink = createDispatchSink({
+      runtime,
+      adapters: [],
+      principal: "andreas",
+      stacks: ["meta-factory"],
+      principalStacks: [],
+    });
+    await sink.start();
+    expect(sink.subjects).toEqual(["local.andreas.meta-factory.dispatch.task.>"]);
+    expect(subscribedPatterns).toEqual([...sink.subjects]);
+  });
+
+  test("EMPTY `principalStacks` and no `stacks` falls back to the single `stack`", async () => {
+    const { runtime } = fakeRuntime();
+    const sink = createDispatchSink({
+      runtime,
+      adapters: [],
+      principal: "andreas",
+      stack: "meta-factory",
+      principalStacks: [],
+    });
+    await sink.start();
+    expect(sink.subjects).toEqual(["local.andreas.meta-factory.dispatch.task.>"]);
+  });
+
+  test("delivers across principals keyed by adapter_instance — ONE handler, no double-deliver", async () => {
+    const { runtime, trigger } = fakeRuntime();
+    const adapterA = new MockAdapter("discord:guild-A"); // andreas/meta-factory
+    const adapterB = new MockAdapter("discord:guild-B"); // robin/research
+    const sink = createDispatchSink({
+      runtime,
+      adapters: [adapterA, adapterB],
+      principal: "andreas",
+      principalStacks: [
+        { principal: "andreas", stack: "meta-factory" },
+        { principal: "robin", stack: "research" },
+      ],
+    });
+    await sink.start();
+
+    trigger(
+      lifecycleEnvelope("dispatch.task.completed", {
+        agent_id: "luna",
+        chat_response: "andreas reply",
+        response_routing: routing("discord:guild-A", "C-A"),
+      }),
+    );
+    trigger(
+      lifecycleEnvelope("dispatch.task.completed", {
+        agent_id: "robin",
+        chat_response: "robin reply",
+        response_routing: routing("discord:guild-B", "C-B"),
+      }),
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // Each reply delivered exactly once to its own instance — the single
+    // onEnvelope handler + adapter_instance filter prevents any double-deliver
+    // across the two principal subjects.
+    expect(adapterA.sentMessages).toHaveLength(1);
+    expect(adapterA.sentMessages[0]!.text).toBe("andreas reply");
+    expect(adapterB.sentMessages).toHaveLength(1);
+    expect(adapterB.sentMessages[0]!.text).toBe("robin reply");
+  });
+});

--- a/src/adapters/dispatch-sink.ts
+++ b/src/adapters/dispatch-sink.ts
@@ -114,6 +114,22 @@ export interface DispatchSinkOptions {
    * envelope; the `adapter_instance` filter remains the sole delivery gate.
    */
   stacks?: readonly (string | undefined)[];
+  /**
+   * F-1 (cortex#629) — MULTIPLE `(principal, stack)` pairs. When the shared
+   * surface gateway serves MORE THAN ONE principal on a shared bus (signing
+   * OFF — dev/trusted only), each bound stack's reply lands on ITS OWN
+   * principal's namespace, not the gateway principal's. `stacks` (above) is
+   * single-principal — it pairs every leaf with the one `principal`. This
+   * generalises it: one subscribe subject per DISTINCT `(principal, stack)`
+   * pair (`local.{principal}.{stack}.dispatch.task.>`, or the 5-segment
+   * `local.{principal}.dispatch.task.>` when `stack` is `undefined`).
+   *
+   * When provided and non-empty, `principalStacks` takes precedence over BOTH
+   * `stacks` and `stack`. The single delivery invariant is unchanged: still
+   * exactly ONE `onEnvelope` handler, so multiple subjects never double-deliver
+   * — the `adapter_instance` filter remains the sole delivery gate.
+   */
+  principalStacks?: readonly { principal: string; stack?: string }[];
 }
 
 export interface DispatchSink {
@@ -167,6 +183,28 @@ function distinctStacks(
 }
 
 /**
+ * De-duplicate a `(principal, stack)` pair list, preserving order. The
+ * `undefined` stack (gap-4 / 5-segment case) is its own bucket PER principal —
+ * keyed on a ` `-separated `principal stack` string so it never collides with a
+ * real stack name or with another principal's undefined bucket. Used to fold
+ * the gateway's per-binding `(principal, stack)` pairs into one subscribe-subject
+ * set (F-1 multi-principal — cortex#629).
+ */
+function distinctPrincipalStacks(
+  pairs: readonly { principal: string; stack?: string }[],
+): { principal: string; stack?: string }[] {
+  const seen = new Set<string>();
+  const out: { principal: string; stack?: string }[] = [];
+  for (const p of pairs) {
+    const key = `${p.principal} ${p.stack ?? "undefined"}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(p);
+  }
+  return out;
+}
+
+/**
  * Create a dispatch sink. Wires nothing until `start()` is called.
  */
 export function createDispatchSink(opts: DispatchSinkOptions): DispatchSink {
@@ -175,13 +213,24 @@ export function createDispatchSink(opts: DispatchSinkOptions): DispatchSink {
   const adapterByInstance = new Map<string, PlatformAdapter>(
     adapters.map((a) => [a.instanceId, a]),
   );
-  // a.3d — `stacks` (gateway multi-stack) takes precedence over the single
-  // `stack` when present: one subscribe subject per distinct bound stack.
-  // Otherwise the single-stack (per-stack caller) path is unchanged.
+  // Subject precedence (most → least specific):
+  //   1. `principalStacks` (F-1 multi-principal — cortex#629): one subject per
+  //      distinct `(principal, stack)` pair. Each pair carries its OWN principal
+  //      segment, so the gateway can subscribe across principals on a shared bus.
+  //   2. `stacks` (a.3d gateway multi-stack): many stacks under the ONE
+  //      `principal`.
+  //   3. `stack` (per-stack `cortex.ts` wiring): the single-subject default.
+  // Whichever path is taken, there is exactly ONE `onEnvelope` handler, so the
+  // subject COUNT never affects delivery — the `adapter_instance` filter is the
+  // sole delivery gate (no double-deliver).
   const subjects =
-    opts.stacks !== undefined && opts.stacks.length > 0
-      ? distinctStacks(opts.stacks).map((s) => lifecycleSubject(principal, s))
-      : [lifecycleSubject(principal, stack)];
+    opts.principalStacks !== undefined && opts.principalStacks.length > 0
+      ? distinctPrincipalStacks(opts.principalStacks).map((p) =>
+          lifecycleSubject(p.principal, p.stack),
+        )
+      : opts.stacks !== undefined && opts.stacks.length > 0
+        ? distinctStacks(opts.stacks).map((s) => lifecycleSubject(principal, s))
+        : [lifecycleSubject(principal, stack)];
 
   let registration: { unregister: () => void } | null = null;
   let subscribers: MyelinSubscriber[] = [];

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -2362,7 +2362,13 @@ export async function startCortex(
         runtime,
         adapters: startedGateway.adapters,
         principal: principalId,
+        // F-1 (cortex#629) — subscribe per distinct `(principal, stack)` pair so
+        // a multi-principal gateway sees every bound stack's replies on the
+        // right principal namespace. `principalStacks` takes precedence over
+        // `stacks` in the sink; `stacks` is still passed for the
+        // single-principal back-compat path / readability.
         stacks: startedGateway.stacks,
+        principalStacks: startedGateway.principalStacks,
       })
     : undefined;
   if (gatewayDispatchSink !== undefined) {

--- a/src/gateway/__tests__/binding-resolver.test.ts
+++ b/src/gateway/__tests__/binding-resolver.test.ts
@@ -20,6 +20,7 @@ import {
   buildBindingIndex,
   resolveBinding,
   distinctBoundStacks,
+  distinctBoundPrincipalStacks,
   crossPrincipalBindings,
   type GatewayBindingIndex,
   type GatewayBindingMatch,
@@ -571,6 +572,142 @@ describe("distinctBoundStacks — gateway outbound subject derivation", () => {
 
   test("no bindings → empty list", () => {
     expect(distinctBoundStacks({})).toEqual([]);
+  });
+});
+
+// ─── 13b. distinctBoundPrincipalStacks (F-1 multi-principal — cortex#629) ──────
+
+describe("distinctBoundPrincipalStacks — multi-principal subject derivation", () => {
+  test("single binding → one (principal, stack) pair from its parsed stack", () => {
+    expect(distinctBoundPrincipalStacks(DISCORD_SURFACES, "andreas")).toEqual([
+      { principal: "andreas", stack: "meta-factory" },
+    ]);
+  });
+
+  test("bindings under DIFFERENT principals → one pair each, own principal preserved", () => {
+    const surfaces: Surfaces = {
+      discord: [
+        {
+          agent: "luna",
+          stack: "andreas/meta-factory",
+          binding: { token: "t1", guildId: "G1", agentChannelId: "a", logChannelId: "b" },
+        },
+        {
+          agent: "robin",
+          // a second principal on the shared bus
+          stack: "robin/research",
+          binding: { token: "t2", guildId: "G2", agentChannelId: "c", logChannelId: "d" },
+        },
+      ],
+    };
+    // gateway principal "andreas"; the "robin" binding keeps its OWN principal
+    // (NOT collapsed onto the gateway principal).
+    expect(distinctBoundPrincipalStacks(surfaces, "andreas")).toEqual([
+      { principal: "andreas", stack: "meta-factory" },
+      { principal: "robin", stack: "research" },
+    ]);
+  });
+
+  test("same (principal, stack) across platforms → deduped to one pair", () => {
+    const surfaces: Surfaces = {
+      discord: [
+        {
+          agent: "luna",
+          stack: "andreas/meta-factory",
+          binding: { token: "t1", guildId: "G1", agentChannelId: "a", logChannelId: "b" },
+        },
+      ],
+      slack: [
+        {
+          agent: "luna",
+          // identical (principal, stack) → collapses
+          stack: "andreas/meta-factory",
+          binding: { botToken: "xoxb", appToken: "xapp", workspaceId: "W1" },
+        },
+      ],
+    };
+    expect(distinctBoundPrincipalStacks(surfaces, "andreas")).toEqual([
+      { principal: "andreas", stack: "meta-factory" },
+    ]);
+  });
+
+  test("same stack LEAF under different principals → two distinct pairs (not collapsed)", () => {
+    const surfaces: Surfaces = {
+      discord: [
+        {
+          agent: "luna",
+          stack: "andreas/research",
+          binding: { token: "t1", guildId: "G1", agentChannelId: "a", logChannelId: "b" },
+        },
+        {
+          agent: "robin",
+          // SAME leaf "research", DIFFERENT principal → must NOT dedup
+          stack: "robin/research",
+          binding: { token: "t2", guildId: "G2", agentChannelId: "c", logChannelId: "d" },
+        },
+      ],
+    };
+    expect(distinctBoundPrincipalStacks(surfaces, "andreas")).toEqual([
+      { principal: "andreas", stack: "research" },
+      { principal: "robin", stack: "research" },
+    ]);
+  });
+
+  test("gap-4 binding (no stack field) → gateway principal + undefined stack", () => {
+    const noStack: Surfaces = {
+      discord: [
+        {
+          agent: "luna",
+          binding: { token: "t", guildId: "G", agentChannelId: "a", logChannelId: "b" },
+        },
+      ],
+    };
+    expect(distinctBoundPrincipalStacks(noStack, "andreas")).toEqual([
+      { principal: "andreas", stack: undefined },
+    ]);
+  });
+
+  test("mixed: stacked cross-principal + gap-4 → pair plus the gateway-principal undefined bucket", () => {
+    const mixed: Surfaces = {
+      discord: [
+        {
+          agent: "robin",
+          stack: "robin/meta-factory",
+          binding: { token: "t1", guildId: "G1", agentChannelId: "a", logChannelId: "b" },
+        },
+        {
+          agent: "luna",
+          // gap-4 → gateway principal "andreas", undefined stack
+          binding: { token: "t2", guildId: "G2", agentChannelId: "c", logChannelId: "d" },
+        },
+      ],
+    };
+    expect(distinctBoundPrincipalStacks(mixed, "andreas")).toEqual([
+      { principal: "robin", stack: "meta-factory" },
+      { principal: "andreas", stack: undefined },
+    ]);
+  });
+
+  test("two gap-4 bindings → a single gateway-principal undefined bucket (dedup)", () => {
+    const twoGap4: Surfaces = {
+      discord: [
+        {
+          agent: "luna",
+          binding: { token: "t1", guildId: "G1", agentChannelId: "a", logChannelId: "b" },
+        },
+        {
+          agent: "ivy",
+          binding: { token: "t2", guildId: "G2", agentChannelId: "c", logChannelId: "d" },
+        },
+      ],
+    };
+    expect(distinctBoundPrincipalStacks(twoGap4, "andreas")).toEqual([
+      { principal: "andreas", stack: undefined },
+    ]);
+  });
+
+  test("no bindings → empty list", () => {
+    expect(distinctBoundPrincipalStacks({}, "andreas")).toEqual([]);
   });
 });
 

--- a/src/gateway/__tests__/start-gateway.test.ts
+++ b/src/gateway/__tests__/start-gateway.test.ts
@@ -201,6 +201,11 @@ describe("startGatewayIfEnabled — flag on", () => {
     ]);
     // the one binding's stack leaf (parsed from "andreas/meta-factory")
     expect(gw?.stacks).toEqual(["meta-factory"]);
+    // F-1 (cortex#629) — the distinct (principal, stack) pair for the multi-
+    // principal sink subjects. Single-principal stays under the gateway principal.
+    expect(gw?.principalStacks).toEqual([
+      { principal: "andreas", stack: "meta-factory" },
+    ]);
   });
 
   test("multi-stack bindings → distinct bound stacks (a.3d outbound subjects)", async () => {
@@ -250,7 +255,71 @@ describe("startGatewayIfEnabled — flag on", () => {
     ]);
   });
 
-  test("cross-principal binding → throws loudly at boot (single-principal v1)", async () => {
+  test("multi-principal bindings → WARNS, starts, exposes per-principal pairs (F-1, cortex#629)", async () => {
+    const started: string[] = [];
+    const { factory } = makeCountingFactory(started);
+    const multiPrincipal: Surfaces = {
+      discord: [
+        {
+          agent: "luna",
+          stack: "andreas/meta-factory",
+          binding: {
+            token: "tok-1",
+            guildId: "111",
+            agentChannelId: "aaa000000000000001",
+            logChannelId: "bbb000000000000002",
+          },
+        },
+        {
+          agent: "robin",
+          // a SECOND principal on the shared bus
+          stack: "robin/research",
+          binding: {
+            token: "tok-2",
+            guildId: "222",
+            agentChannelId: "ccc000000000000003",
+            logChannelId: "ddd000000000000004",
+          },
+        },
+      ],
+    };
+
+    const origWrite = process.stderr.write.bind(process.stderr);
+    const stderr: string[] = [];
+    process.stderr.write = (chunk: string | Uint8Array): boolean => {
+      stderr.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString());
+      return true;
+    };
+
+    let gw;
+    try {
+      gw = await startGatewayIfEnabled({
+        env: { CORTEX_GATEWAY: "1" },
+        surfaces: multiPrincipal,
+        // gateway principal "andreas" — "robin" is cross-principal
+        principal: "andreas",
+        runtime: RUNTIME_STUB,
+        source: SOURCE_STUB,
+        policyEngine: POLICY_ENGINE_STUB,
+        factory,
+      });
+    } finally {
+      process.stderr.write = origWrite;
+    }
+
+    // ALLOWED + WARNED.
+    expect(gw?.gateway).toBeInstanceOf(SurfaceGateway);
+    expect(stderr.join("")).toMatch(/UNSIGNED/);
+
+    // F-1 — one (principal, stack) pair per principal, each carrying its OWN
+    // parsed principal (NOT collapsed onto the gateway principal).
+    expect(gw?.principalStacks).toEqual([
+      { principal: "andreas", stack: "meta-factory" },
+      { principal: "robin", stack: "research" },
+    ]);
+  });
+
+  test("cross-principal binding → WARNS (stderr) and ALLOWS the gateway to start (F-1, cortex#629)", async () => {
     const started: string[] = [];
     const { factory, constructed } = makeCountingFactory(started);
     const crossPrincipal: Surfaces = {
@@ -268,8 +337,20 @@ describe("startGatewayIfEnabled — flag on", () => {
         },
       ],
     };
-    await expect(
-      startGatewayIfEnabled({
+
+    // Capture stderr to assert the UNSIGNED/dev-only warning fired.
+    const origWrite = process.stderr.write.bind(process.stderr);
+    const stderr: string[] = [];
+    process.stderr.write = (chunk: string | Uint8Array): boolean => {
+      stderr.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString());
+      return true;
+    };
+
+    let gw;
+    try {
+      // F-1 (cortex#629): a cross-principal binding is no longer a hard throw —
+      // the gateway starts and the binding is allowed (UNSIGNED/dev-only).
+      gw = await startGatewayIfEnabled({
         env: { CORTEX_GATEWAY: "1" },
         surfaces: crossPrincipal,
         principal: "andreas",
@@ -277,11 +358,28 @@ describe("startGatewayIfEnabled — flag on", () => {
         source: SOURCE_STUB,
         policyEngine: POLICY_ENGINE_STUB,
         factory,
-      }),
-    ).rejects.toThrow(/cross-principal/i);
-    // Fails BEFORE building or starting any adapter.
-    expect(constructed).toEqual([]);
-    expect(started).toEqual([]);
+      });
+    } finally {
+      process.stderr.write = origWrite;
+    }
+
+    // ALLOWED: the gateway started over the cross-principal binding.
+    expect(gw?.gateway).toBeInstanceOf(SurfaceGateway);
+    expect(constructed).toEqual(["discord:111222333444555666"]);
+    expect(started).toEqual(["discord:111222333444555666"]);
+
+    // WARNED: a clear UNSIGNED/dev-only stderr warning fired, naming the
+    // offending binding.
+    const warning = stderr.join("");
+    expect(warning).toMatch(/cross-principal/i);
+    expect(warning).toMatch(/UNSIGNED/);
+    expect(warning).toMatch(/someone-else\/meta-factory/);
+
+    // F-1 — the cross-principal binding's OWN principal flows through to the
+    // outbound sink subjects (not absorbed into the gateway principal).
+    expect(gw?.principalStacks).toEqual([
+      { principal: "someone-else", stack: "meta-factory" },
+    ]);
   });
 
   test("flag on but surfaces undefined → returns undefined (graceful degrade)", async () => {

--- a/src/gateway/binding-resolver.ts
+++ b/src/gateway/binding-resolver.ts
@@ -234,6 +234,86 @@ export function distinctBoundStacks(
 }
 
 // =============================================================================
+// distinctBoundPrincipalStacks  (F-1 multi-principal subjects — cortex#629)
+// =============================================================================
+
+/**
+ * One distinct `(principal, stack)` pair the gateway's outbound dispatch sink
+ * must subscribe to. The bound stack's OWN runner republishes
+ * `dispatch.task.*` on `local.{principal}.{stack}.dispatch.task.>`, stamping
+ * its own runtime principal + stack leaf — so the sink needs one subscribe
+ * subject per distinct `(principal, stack)` pair across every binding.
+ */
+export interface BoundPrincipalStack {
+  /**
+   * Principal segment of the lifecycle subject. Parsed from the binding's
+   * `{principal}/{stack}` field; falls back to the gateway's own principal for
+   * a gap-4 binding (no `stack` field — §4 above), which publishes on the
+   * gateway principal's namespace.
+   */
+  principal: string;
+  /**
+   * Stack leaf, or `undefined` for a gap-4 binding (the 5-segment legacy
+   * subject `local.{principal}.dispatch.task.>`).
+   */
+  stack: string | undefined;
+}
+
+/**
+ * The distinct set of `(principal, stack)` pairs across every surface binding.
+ *
+ * **F-1 (cortex#629) — multi-principal subjects.** {@link distinctBoundStacks}
+ * collapses every binding onto the gateway's single principal (single-principal
+ * v1). When the gateway serves MULTIPLE principals on a shared bus (F-1, with
+ * signing OFF), each binding's reply lands on ITS OWN principal's namespace —
+ * `local.{thatPrincipal}.{stack}.dispatch.task.>` — not the gateway principal's.
+ * The outbound sink therefore needs one subscribe subject per distinct
+ * `(principal, stack)` pair, derived HERE from each binding's PARSED principal.
+ *
+ * Derivation (re-uses `parseStack`, the single `{principal}/{stack}` source —
+ * no drift):
+ *   - A binding with a `stack` field yields `{ principal: <parsed>, stack:
+ *     <parsed leaf> }`.
+ *   - A gap-4 binding (no `stack` field, §4 above) carries no principal, so it
+ *     falls back to the gateway's own `principal` with `stack: undefined` — the
+ *     5-segment legacy subject it publishes on.
+ *
+ * Pairs are deduped on `(principal, stack)` (with `undefined` stack as its own
+ * bucket per principal), preserving binding iteration order across discord →
+ * slack → mattermost.
+ *
+ * Cross-principal bindings are UNSIGNED/UNAUTHENTICATED in F-1 (dev/trusted
+ * only); the boot path WARNS rather than throwing ({@link
+ * crossPrincipalBindings} stays the detector — only the consumer changed from
+ * throw→warn). Signing is layered on later (cortex#552 / cortex#635).
+ */
+export function distinctBoundPrincipalStacks(
+  surfaces: Surfaces,
+  gatewayPrincipal: string,
+): BoundPrincipalStack[] {
+  const seen = new Set<string>();
+  const out: BoundPrincipalStack[] = [];
+  const add = (raw: string | undefined): void => {
+    const parsed = parseStack(raw);
+    // Gap-4 (no stack field) → the binding has no principal of its own and
+    // publishes on the gateway principal's 5-segment legacy subject.
+    const principal = parsed.principal ?? gatewayPrincipal;
+    const stack = parsed.stack;
+    // Dedup key: a ` ` separator keeps the principal/stack boundary
+    // unambiguous, and a distinct sentinel for the undefined-stack bucket so it
+    // never collides with a real stack name.
+    const key = `${principal} ${stack ?? "undefined"}`;
+    if (seen.has(key)) return;
+    seen.add(key);
+    out.push({ principal, stack });
+  };
+  for (const e of surfaces.discord ?? []) add(e.stack);
+  for (const e of surfaces.slack ?? []) add(e.stack);
+  for (const e of surfaces.mattermost ?? []) add(e.stack);
+  return out;
+}
+
+// =============================================================================
 // crossPrincipalBindings  (single-principal v1 enforcement — a.3d review)
 // =============================================================================
 

--- a/src/gateway/start-gateway.ts
+++ b/src/gateway/start-gateway.ts
@@ -55,7 +55,12 @@ import {
   type GatewayAdapterFactory,
 } from "./gateway-adapters";
 import { BusInboundSink } from "./bus-inbound-sink";
-import { distinctBoundStacks, crossPrincipalBindings } from "./binding-resolver";
+import {
+  distinctBoundStacks,
+  distinctBoundPrincipalStacks,
+  crossPrincipalBindings,
+  type BoundPrincipalStack,
+} from "./binding-resolver";
 import type { SurfaceGateway } from "./surface-gateway";
 import type { Surfaces } from "../common/types/surfaces";
 import type { MyelinRuntime } from "../bus/myelin/runtime";
@@ -124,8 +129,22 @@ export interface StartedGateway {
   /**
    * Distinct bound-stack leaves (`undefined` = a gap-4 no-stack binding) for
    * the outbound sink's subscribe subjects. See {@link distinctBoundStacks}.
+   *
+   * Single-principal: these pair with the gateway's own principal. Prefer
+   * {@link StartedGateway.principalStacks} for the multi-principal sink subjects
+   * (F-1 — cortex#629); `stacks` is retained for back-compat / single-principal
+   * callers.
    */
   stacks: readonly (string | undefined)[];
+  /**
+   * F-1 (cortex#629) — distinct `(principal, stack)` pairs across every
+   * binding, each carrying its OWN parsed principal (gap-4 bindings fall back
+   * to the gateway principal). The outbound dispatch sink builds one subscribe
+   * subject per pair so a multi-principal gateway sees every bound stack's
+   * replies on the right principal namespace. See
+   * {@link distinctBoundPrincipalStacks}.
+   */
+  principalStacks: readonly BoundPrincipalStack[];
 }
 
 /** Count the total bindings across all platforms in a `Surfaces` map. */
@@ -179,19 +198,28 @@ export async function startGatewayIfEnabled(
 
   // ── Path 3: flag on + bindings → build, construct, start. ─────────────────
   //
-  // a.3d review (single-principal v1 enforcement): the inbound publisher and
-  // the outbound dispatch sink both key off the gateway's OWN principal and
-  // discard each binding's parsed principal. Reject any cross-principal binding
-  // LOUDLY at boot rather than silently absorbing it into the gateway
-  // principal's namespace (the latent cross-principal leak single-principal v1
-  // excludes). Same loud-validation stance as `buildBindingIndex`.
+  // F-1 (cortex#629) — multi-principal, UNSIGNED. The gateway now serves
+  // bindings spanning MORE THAN ONE principal on a shared bus so cross-principal
+  // collaboration works. The outbound dispatch sink subscribes per distinct
+  // `(principal, stack)` pair (see `principalStacks` below) — each binding's
+  // reply lands on ITS OWN principal namespace, no longer absorbed into the
+  // gateway principal's.
+  //
+  // a.3d shipped a HARD THROW here (single-principal v1). F-1 RELAXES that to a
+  // non-fatal WARNING: cross-principal bindings are allowed but are
+  // UNSIGNED/UNAUTHENTICATED, so the inbound publish hop carries no per-stack
+  // signature. That is fine for a dev/trusted shared bus but MUST NOT face
+  // untrusted peers until signing is layered on (cortex#552 / cortex#635).
+  // `crossPrincipalBindings` stays the detector — only this consumer changed
+  // from throw→warn.
   const crossPrincipal = crossPrincipalBindings(surfaces, opts.principal);
   if (crossPrincipal.length > 0) {
-    throw new Error(
-      `gateway: cross-principal surface bindings are not supported in single-principal v1 — ` +
-        `${crossPrincipal.map((s) => `"${s}"`).join(", ")} ` +
-        `declare a principal other than "${opts.principal}". ` +
-        `Either move them under "${opts.principal}/…" or run a separate gateway for that principal.`,
+    process.stderr.write(
+      `[surface-gateway] WARNING: cross-principal surface bindings are UNSIGNED/UNAUTHENTICATED ` +
+        `— dev/trusted only; enable signing before untrusted peers. ` +
+        `Bindings ${crossPrincipal.map((s) => `"${s}"`).join(", ")} ` +
+        `declare a principal other than the gateway principal "${opts.principal}". ` +
+        `Allowing (F-1, cortex#629); signing is layered on later (cortex#552 / cortex#635).\n`,
     );
   }
 
@@ -252,13 +280,17 @@ export async function startGatewayIfEnabled(
 
   // a.3d (cortex#524) — hand the boot path the adapters + bound stacks the
   // OUTBOUND dispatch sink needs. The sink itself is constructed in cortex.ts
-  // (it owns the `runtime`), but the bound-stack subject set is derived HERE,
-  // where `surfaces` is parsed, so subject-shape logic stays in the gateway
-  // layer. Single-principal v1: the sink's principal segment is the gateway
-  // principal (supplied at the boot site).
+  // (it owns the `runtime`), but the subject set is derived HERE, where
+  // `surfaces` is parsed, so subject-shape logic stays in the gateway layer.
+  //
+  // F-1 (cortex#629) — also derive `principalStacks`: distinct `(principal,
+  // stack)` pairs carrying each binding's OWN parsed principal, so a
+  // multi-principal gateway sink subscribes per principal namespace. `stacks`
+  // is retained for back-compat (single-principal callers / the legacy shape).
   return {
     gateway: gw,
     adapters,
     stacks: distinctBoundStacks(surfaces),
+    principalStacks: distinctBoundPrincipalStacks(surfaces, opts.principal),
   };
 }


### PR DESCRIPTION
Closes #629. Part of #627.

## ⚠️ Cross-principal is UNSIGNED / dev-only

This slice lets the shared surface gateway serve **MULTIPLE principals** on a shared bus so cross-principal collaboration works **with signing OFF**. Cross-principal surface bindings are **UNSIGNED / UNAUTHENTICATED** — **dev/trusted bus only**. The boot path now emits a loud stderr warning rather than allowing this silently. **Do NOT expose to untrusted peers until signing is layered on (#552 / #635).**

## What changed

### Part 1 — relax the single-principal guard
`src/gateway/start-gateway.ts`: a.3d shipped a **hard THROW** when bindings spanned >1 principal (single-principal v1). F-1 changes that consumer to a **non-fatal stderr WARNING** and **allows** the gateway to start:

> `[surface-gateway] WARNING: cross-principal surface bindings are UNSIGNED/UNAUTHENTICATED — dev/trusted only; enable signing before untrusted peers. …`

`crossPrincipalBindings()` (`src/gateway/binding-resolver.ts`) stays the **detector** — only the consumer changed throw→warn.

### Part 2 — multi-principal subjects
- `src/gateway/binding-resolver.ts`: new `distinctBoundPrincipalStacks(surfaces, gatewayPrincipal)` derives distinct `(principal, stack)` pairs from **each binding's OWN parsed principal** (gap-4 bindings with no `stack` field fall back to the gateway principal). Reuses `parseStack` (no drift); deduped on `(principal, stack)` so the same stack leaf under two principals stays two pairs.
- `src/adapters/dispatch-sink.ts`: new `principalStacks` option builds **one subscribe subject per `(principal, stack)` pair** (`local.{principal}.{stack}.dispatch.task.>`). Precedence: `principalStacks` → `stacks` → `stack`; an empty `principalStacks: []` falls back (no silent zero-subscribe). Still exactly **ONE `onEnvelope` handler** — the `adapter_instance` filter is the sole delivery gate, so multiple subjects never double-deliver.
- `StartedGateway` exposes `principalStacks`; `src/cortex.ts` threads it into the gateway dispatch sink. The single-principal `stacks`/`stack` paths are **preserved (back-compat)**.

## Verification

- `bunx tsc --noEmit` — clean (no error TS; eslint.config.js ignored)
- `bun run lint:errors` — clean (exit 0)
- `bun test src/gateway/ src/adapters/__tests__/dispatch-sink.test.ts` — **134 + 30 pass, 0 fail**

### Tests added
- **start-gateway**: cross-principal binding now asserts **warn (stderr) + allow (gateway starts)** instead of throw; new multi-principal test asserts each binding's own principal flows to `principalStacks`.
- **binding-resolver**: `distinctBoundPrincipalStacks` — single, cross-principal, cross-platform dedup, **same leaf under different principals not collapsed**, gap-4 → gateway principal + undefined stack, two gap-4 dedup, empty.
- **dispatch-sink**: `principalStacks` subject-per-pair, undefined-stack 5-segment subject, dedup incl. same-leaf-different-principal, precedence over `stacks`/`stack`, empty fallback, single-handler cross-principal delivery (no double-deliver).

🤖 Generated with [Claude Code](https://claude.com/claude-code)