### PR TITLE
feat(gateway): F-1b — inbound cross-principal publish on binding principal (closes #651)

### DIFF
--- a/src/bus/__tests__/dispatch-source-publisher.test.ts
+++ b/src/bus/__tests__/dispatch-source-publisher.test.ts
@@ -1,0 +1,252 @@
+/**
+ * cortex#651 (F-1b) — dispatch-source publisher subject-derivation tests.
+ *
+ * F-1 (#629) wired the OUTBOUND (reply) leg per-principal; F-1b completes the
+ * INBOUND (request) leg. The surface gateway serves MULTIPLE principals on one
+ * shared bus, so a cross-principal binding's inbound request must be published
+ * onto the BOUND stack's runner subscription
+ * (`local.{bindingPrincipal}.{stack}.tasks.@{agent}.{cap}`), NOT the gateway
+ * principal's subject.
+ *
+ * The publish SUBJECT principal is now derived from the OPT-IN
+ * `subjectPrincipal` field, falling back to `source.principal` when absent.
+ * These tests pin the four cases:
+ *
+ *   1. Gateway cross-principal — `subjectPrincipal` set, differs from source →
+ *      subject uses the BINDING principal.
+ *   2. Per-stack / same-principal — `subjectPrincipal` absent →
+ *      subject uses `source.principal` (back-compat, byte-identical).
+ *   3. Gap-4 — `subjectPrincipal` undefined → falls back to the gateway
+ *      (source) principal.
+ *   4. Same-principal gateway binding — `subjectPrincipal === source.principal`
+ *      → subject unchanged.
+ *
+ * SECURITY-SENSITIVE: cross-principal routing. The publisher is SHARED with the
+ * per-stack `dispatch-handler` path — the per-stack path NEVER sets
+ * `subjectPrincipal`, so its subject derivation is unchanged. Anti-criterion:
+ * the per-stack author metadata (`opts.principal = msg.authorName`) must NEVER
+ * leak into the subject.
+ */
+
+import { test, expect, describe, beforeEach, afterEach } from "bun:test";
+import {
+  publishInboundChatDispatchEnvelope,
+  type InboundChatDispatchPublishOpts,
+} from "../dispatch-source-publisher";
+import type { InboundMessage } from "../../adapters/types";
+import type { Envelope } from "../myelin/envelope-validator";
+import type { MyelinRuntime } from "../myelin/runtime";
+import type { SystemEventSource } from "../system-events";
+import { PolicyEngine } from "../../common/policy/engine";
+
+// =============================================================================
+// Fixtures
+// =============================================================================
+
+/**
+ * Policy engine that resolves the `(discord, <authorId>)` tuple used by these
+ * tests to a registered principal DID, so the publish is not refused with
+ * `invalid-originator`. Two principals are registered so the originator
+ * resolution succeeds regardless of which one drives the subject.
+ */
+function makePolicyEngine(): PolicyEngine {
+  return new PolicyEngine({
+    principals: [
+      {
+        id: "andreas",
+        home_principal: "andreas",
+        home_stack: "andreas/research",
+        role: ["operator"],
+        trust: [],
+        platform_ids: { discord: ["1487204875912609844"] },
+      },
+      {
+        id: "holly",
+        home_principal: "holly",
+        home_stack: "holly/research",
+        role: ["operator"],
+        trust: [],
+        platform_ids: { discord: ["9999999999999999999"] },
+      },
+    ],
+    roles: [{ id: "operator", capabilities: ["dispatch.luna"] }],
+  });
+}
+
+interface RecordingRuntime extends MyelinRuntime {
+  subjectPublishes: { envelope: Envelope; subject: string }[];
+}
+
+function makeRecordingRuntime(): RecordingRuntime {
+  const subjectPublishes: { envelope: Envelope; subject: string }[] = [];
+  return {
+    enabled: true,
+    onEnvelope: () => ({ unregister: () => {} }),
+    publish: async () => {},
+    publishOnSubject: async (envelope: Envelope, subject: string) => {
+      subjectPublishes.push({ envelope, subject });
+    },
+    stop: async () => {},
+    subjectPublishes,
+  };
+}
+
+/** Gateway dispatch-source identity — principal is the GATEWAY principal. */
+const GATEWAY_SOURCE: SystemEventSource = {
+  principal: "andreas",
+  agent: "gateway",
+  instance: "gateway-0",
+  dataResidency: "NZ",
+};
+
+function makeMsg(overrides: Partial<InboundMessage> = {}): InboundMessage {
+  return {
+    platform: "discord",
+    instanceId: "discord:111222333",
+    authorId: "1487204875912609844",
+    authorName: "TestUser",
+    channelId: "channel-aaa",
+    content: "Hello!",
+    guildId: "111222333",
+    attachments: [],
+    timestamp: new Date("2026-06-03T00:00:00.000Z"),
+    ...overrides,
+  };
+}
+
+function baseOpts(
+  runtime: MyelinRuntime,
+  overrides: Partial<InboundChatDispatchPublishOpts> = {},
+): InboundChatDispatchPublishOpts {
+  return {
+    runtime,
+    source: GATEWAY_SOURCE,
+    policyEngine: makePolicyEngine(),
+    stack: "meta-factory",
+    agentName: "luna",
+    agentDisplayName: "luna",
+    taskId: "11111111-1111-4111-8111-111111111111",
+    msg: makeMsg(),
+    prompt: "user prompt",
+    resumeSessionId: undefined,
+    allowedDirs: [],
+    disallowedTools: [],
+    timeoutMs: undefined,
+    cwd: undefined,
+    additionalArgs: undefined,
+    groveChannel: undefined,
+    groveNetwork: undefined,
+    project: undefined,
+    entity: undefined,
+    principal: undefined,
+    ...overrides,
+  };
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe("dispatch-source-publisher — F-1b subject principal derivation (cortex#651)", () => {
+  let originalError: typeof console.error;
+
+  beforeEach(() => {
+    originalError = console.error;
+    console.error = () => {};
+  });
+
+  afterEach(() => {
+    console.error = originalError;
+  });
+
+  // ── ISC-C1: gateway cross-principal → subject under BINDING principal ───────
+
+  test("cross-principal: subjectPrincipal differing from source → subject uses BINDING principal", async () => {
+    const runtime = makeRecordingRuntime();
+    const result = await publishInboundChatDispatchEnvelope(
+      baseOpts(runtime, {
+        // gateway principal = andreas (source); binding principal = holly
+        subjectPrincipal: "holly",
+      }),
+    );
+
+    expect(result.published).toBe(true);
+    expect(result.subject).toBe(
+      "local.holly.meta-factory.tasks.@did-mf-luna.chat",
+    );
+    expect(runtime.subjectPublishes).toHaveLength(1);
+    expect(runtime.subjectPublishes[0]?.subject).toBe(
+      "local.holly.meta-factory.tasks.@did-mf-luna.chat",
+    );
+    // The subject must NOT be the gateway (source) principal.
+    expect(result.subject).not.toContain("local.andreas.");
+  });
+
+  // ── ISC-C2 / ISC-A1: per-stack path (no subjectPrincipal) → source.principal
+
+  test("per-stack: subjectPrincipal absent → subject uses source.principal (back-compat)", async () => {
+    const runtime = makeRecordingRuntime();
+    // Per-stack path passes `principal: msg.authorName` (payload metadata) and
+    // NEVER sets subjectPrincipal. The author name must NOT leak into the subject.
+    const result = await publishInboundChatDispatchEnvelope(
+      baseOpts(runtime, {
+        principal: "TestUser", // author metadata — payload only
+        // subjectPrincipal intentionally omitted
+      }),
+    );
+
+    expect(result.published).toBe(true);
+    expect(result.subject).toBe(
+      "local.andreas.meta-factory.tasks.@did-mf-luna.chat",
+    );
+    // ANTI: author metadata must not become the subject principal.
+    expect(result.subject).not.toContain("local.TestUser.");
+  });
+
+  // ── ISC-C3: gap-4 → subjectPrincipal undefined → gateway-principal fallback ─
+
+  test("gap-4: subjectPrincipal undefined → falls back to gateway (source) principal", async () => {
+    const runtime = makeRecordingRuntime();
+    const result = await publishInboundChatDispatchEnvelope(
+      baseOpts(runtime, {
+        subjectPrincipal: undefined, // gap-4 binding: no parsed principal
+      }),
+    );
+
+    expect(result.published).toBe(true);
+    expect(result.subject).toBe(
+      "local.andreas.meta-factory.tasks.@did-mf-luna.chat",
+    );
+  });
+
+  // ── ISC-C4: same-principal gateway binding → subject unchanged ──────────────
+
+  test("same-principal: subjectPrincipal === source.principal → subject unchanged", async () => {
+    const runtime = makeRecordingRuntime();
+    const result = await publishInboundChatDispatchEnvelope(
+      baseOpts(runtime, {
+        subjectPrincipal: "andreas", // equals gateway principal
+      }),
+    );
+
+    expect(result.published).toBe(true);
+    expect(result.subject).toBe(
+      "local.andreas.meta-factory.tasks.@did-mf-luna.chat",
+    );
+  });
+
+  // ── Stackless cross-principal subject shape ────────────────────────────────
+
+  test("cross-principal stackless: subject omits stack segment but uses binding principal", async () => {
+    const runtime = makeRecordingRuntime();
+    const result = await publishInboundChatDispatchEnvelope(
+      baseOpts(runtime, {
+        stack: undefined,
+        subjectPrincipal: "holly",
+      }),
+    );
+
+    expect(result.published).toBe(true);
+    expect(result.subject).toBe("local.holly.tasks.@did-mf-luna.chat");
+  });
+});

--- a/src/bus/dispatch-source-publisher.ts
+++ b/src/bus/dispatch-source-publisher.ts
@@ -39,6 +39,28 @@ export interface InboundChatDispatchPublishOpts {
   entity: string | undefined;
   principal: string | undefined;
   /**
+   * cortex#651 (F-1b) — **routing** principal for the publish SUBJECT, distinct
+   * from {@link principal} (which is author/identity metadata stamped into the
+   * payload body, e.g. the per-stack path passes `msg.authorName`).
+   *
+   * The surface gateway serves MULTIPLE principals on one shared bus. A
+   * cross-principal binding's inbound request must land on the BOUND stack's
+   * runner subscription at `local.{bindingPrincipal}.{stack}.tasks.*`
+   * (dispatch-listener.ts), NOT on the gateway principal's subject. The
+   * gateway sink sets this to the binding's parsed principal
+   * (`match.principal`).
+   *
+   * When `undefined`, the subject falls back to `source.principal` — the
+   * EXACT pre-F-1b behaviour. The per-stack `dispatch-handler` path never sets
+   * this field, so its subject derivation is byte-for-byte unchanged. Gap-4
+   * gateway bindings (no parsed principal) leave this `undefined` and thus
+   * fall back to the gateway principal, which is the intended gap-4 default.
+   *
+   * F-1 (#629) wired the OUTBOUND (reply) leg per-principal; this field
+   * completes the INBOUND (request) leg, closing #629's cross-principal goal.
+   */
+  subjectPrincipal?: string;
+  /**
    * cortex#486 — PolicyEngine consulted at publish time to resolve the
    * inbound `(platform, authorId)` tuple to a registered principal id.
    * The adapter is the right layer for this lookup per
@@ -145,10 +167,17 @@ export async function publishInboundChatDispatchEnvelope(
   }
 
   const targetDid = `did:mf:${opts.agentName}`;
+  // cortex#651 (F-1b) — derive the SUBJECT principal. Cross-principal gateway
+  // bindings set `subjectPrincipal` to the binding's parsed principal so the
+  // request lands on the BOUND stack's subscription. Absent (per-stack path,
+  // gap-4 gateway bindings, same-principal) → fall back to `source.principal`,
+  // the exact pre-F-1b behaviour. Note: this is distinct from the payload
+  // `principal` field, which carries author/identity metadata.
+  const subjectPrincipal = opts.subjectPrincipal ?? opts.source.principal;
   let subject: string;
   try {
     subject = buildDirectTaskPublishSubject(
-      opts.source.principal,
+      subjectPrincipal,
       targetDid,
       opts.stack,
       "chat",

--- a/src/gateway/__tests__/bus-inbound-sink.test.ts
+++ b/src/gateway/__tests__/bus-inbound-sink.test.ts
@@ -357,4 +357,61 @@ describe("BusInboundSink", () => {
 
     expect(calls[0]?.msg.threadId).toBe("thread-xyz-789");
   });
+
+  // ── Test 13 (F-1b, cortex#651): subjectPrincipal = match.principal ───────────
+  //
+  // The gateway serves MULTIPLE principals on one shared bus. The inbound
+  // request SUBJECT must be derived from the BINDING's parsed principal so a
+  // cross-principal binding lands on the BOUND stack's runner subscription
+  // (`local.{bindingPrincipal}.{stack}.tasks.*`), not the gateway principal.
+  // The sink threads `match.principal` into the OPT-IN `subjectPrincipal` field;
+  // the publisher derives the subject from it (fallback: source.principal).
+
+  test("cross-principal binding → subjectPrincipal = match.principal (differs from gateway principal)", async () => {
+    const { sink, calls } = makeSink();
+    // STUB_SOURCE.principal is "andreas" (the gateway principal). The binding's
+    // parsed principal is "holly" → a CROSS-principal binding.
+    const decision = makeDecision({
+      match: {
+        platform: "discord",
+        agent: "luna",
+        principal: "holly",
+        stack: "research",
+        instance: "discord:111222333",
+      },
+    });
+
+    await sink.publish(decision, makeMsg());
+
+    const opts = calls[0];
+    if (opts === undefined) throw new Error("expected publishFn to have been called");
+    // The routing principal for the subject is the BINDING principal, not the gateway.
+    expect(opts.subjectPrincipal).toBe("holly");
+    // The payload `principal` field carries the same binding principal (F-1 behaviour).
+    expect(opts.principal).toBe("holly");
+  });
+
+  test("same-principal binding → subjectPrincipal = match.principal (equals gateway principal)", async () => {
+    const { sink, calls } = makeSink();
+    // Default decision: match.principal === "andreas" === gateway principal.
+    await sink.publish(makeDecision(), makeMsg());
+
+    expect(calls[0]?.subjectPrincipal).toBe("andreas");
+  });
+
+  test("gap-4 binding (no principal) → subjectPrincipal undefined → publisher falls back to gateway principal", async () => {
+    const { sink, calls } = makeSink();
+    const decision = makeDecision();
+    decision.match = {
+      ...decision.match,
+      stack: undefined,
+      principal: undefined,
+    };
+
+    await sink.publish(decision, makeMsg());
+
+    // undefined threads through; the publisher's `?? source.principal` yields
+    // the gateway principal — the intended gap-4 default.
+    expect(calls[0]?.subjectPrincipal).toBeUndefined();
+  });
 });

--- a/src/gateway/bus-inbound-sink.ts
+++ b/src/gateway/bus-inbound-sink.ts
@@ -151,6 +151,15 @@ export class BusInboundSink implements GatewayInboundSink {
       // harness's responsibility (design §2.2/§4).
       prompt: msg.content,
       principal: match.principal,
+      // cortex#651 (F-1b) — route the inbound request SUBJECT under the
+      // binding's parsed principal so a cross-principal binding lands on the
+      // BOUND stack's runner subscription (local.{bindingPrincipal}.{stack}.tasks.*),
+      // not the gateway principal. Gap-4 bindings have match.principal === undefined
+      // → the publisher falls back to source.principal (the gateway principal),
+      // which is the intended gap-4 default. Same-principal bindings set this to
+      // the gateway principal → identical subject, no behaviour change.
+      // F-1 (#629) did the outbound (reply) leg; this completes the inbound leg.
+      subjectPrincipal: match.principal,
       // The publisher derives response_routing from msg.instanceId directly via
       // responseRoutingFromMessage() — consistent with decision.responseRouting.
       // We do NOT double-stamp it here.


### PR DESCRIPTION
Closes #651. Part of #627. Completes the cross-principal goal of #629.

## Problem

F-1 (#629) wired the gateway **outbound** (reply) leg per-principal, but the **inbound** (request) leg still published on the **gateway** principal's subject. `dispatch-source-publisher.ts` built the inbound subject from `opts.source.principal` (the gateway principal), while the binding's parsed principal (`match.principal`) was used ONLY in the payload body.

Result: a cross-principal binding's inbound request landed on `local.{gatewayPrincipal}.{stack}.tasks.*` and never reached the bound stack's runner subscription at `local.{bindingPrincipal}.{stack}.tasks.*` (`dispatch-listener.ts`) — and risked colliding with a same-named agent under the gateway principal. Cross-principal collaboration was half-wired: replies routed per-principal, requests mis-routed.

## Fix (minimal + surgical, back-compat preserved)

- **`dispatch-source-publisher.ts`** — new OPT-IN `subjectPrincipal?` on `InboundChatDispatchPublishOpts`. The publish SUBJECT principal is derived as `subjectPrincipal ?? source.principal`. When absent → exact pre-F-1b behaviour.
- **`bus-inbound-sink.ts`** — the gateway sink sets `subjectPrincipal: match.principal`, routing the request under the binding principal. Gap-4 bindings have `match.principal === undefined` → the publisher falls back to `source.principal` (the gateway principal), the intended gap-4 default.

### Shared-publisher safety (the load-bearing detail)

The publisher is **SHARED** with the per-stack `dispatch-handler` path. That path passes `principal: msg.authorName` — a human **display name**, payload-only metadata that differs from `source.principal` on nearly every message. Branching the subject on "principal differs from source.principal" would therefore have **broken** the per-stack path (routing under the author's name). Instead the gateway sets a *separate* `subjectPrincipal`; the per-stack path never sets it, so `subjectPrincipal ?? source.principal` keeps the per-stack subject **byte-for-byte unchanged**. Pinned by the existing dispatch-handler subject test (`local.andreas.meta-factory.tasks.@did-mf-test-agent.chat`).

## Security

SECURITY-SENSITIVE (cross-principal routing). No auth/signing code touched — only an opt-in routing field + subject derivation. Cross-principal remains UNSIGNED/dev-only and double-opt-in gated (`CORTEX_GATEWAY` + `CORTEX_GATEWAY_PUBLISH`); signing layered later (#552/#635).

## Verification

- `bunx tsc --noEmit` — no `error TS`
- `bun run lint:errors` — clean
- `bun test` dispatch-source-publisher + bus-inbound-sink → **20 pass**
- `bun test` dispatch-handler + dispatch-listener (back-compat) → **110 pass**

### Test coverage
- Gateway cross-principal: inbound subject uses the **binding's** principal (`local.holly.meta-factory.tasks.@did-mf-luna.chat`), not the gateway.
- Per-stack / same-principal: subject unchanged (`source.principal`) — back-compat pinned; author metadata (`TestUser`) never leaks into the subject.
- Gap-4: gateway-principal fallback.
- Stackless cross-principal subject shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)