### PR TITLE
test(gateway): F-2 — cross-principal collaboration end-to-end validation + example (closes #630)

### DIFF
--- a/docs/design-shared-surface-gateway.md
+++ b/docs/design-shared-surface-gateway.md
@@ -196,6 +196,46 @@ Each stage is independently revertible: revert a binding flip and the stack re-o
 
 ---
 
+## 7a. Multi-principal bindings (F-1 / F-2 — cross-principal, unsigned)
+
+> **Status:** shipped. F-1 (`cortex#629`) + F-1b (`cortex#651`) wired the routing; F-2 (`cortex#630`) proved it end-to-end. Resolves OQ3 below for the **unsigned, dev/trusted** case.
+
+The gateway is no longer single-principal. One gateway can hold bindings for **more than one principal** on the same bus, so two principals collaborate through a single surface edge. Each binding's `stack: {principal}/{stack}` field carries its OWN principal:
+
+- **Inbound (request leg, F-1b):** an inbound message on a binding publishes its canonical `tasks.@{assistant}.chat` envelope on **that binding's** principal subject — `local.{bindingPrincipal}.{stack}.tasks.@{assistant}.chat` — so it lands on the BOUND stack's runner subscription, not the gateway principal's. The gateway sink threads the binding's parsed principal through `subjectPrincipal` (`bus-inbound-sink.ts`); a gap-4 binding (no `stack` field) falls back to the gateway principal.
+- **Outbound (reply leg, F-1):** the gateway's dispatch sink subscribes to one lifecycle subject per distinct `(principal, stack)` pair (`startGatewayIfEnabled` → `principalStacks` → `createDispatchSink`), so each bound stack's `dispatch.task.*` reply is seen on its OWN principal namespace and routed back to the originating adapter instance. The `adapter_instance` filter remains the sole delivery gate — replies never cross-post between principals.
+- **Guard relaxation (F-1):** a cross-principal binding (principal ≠ gateway principal) previously threw at boot (a.3d single-principal guard). It now emits a non-fatal **WARN** and starts. The binding is **UNSIGNED / UNAUTHENTICATED** — fine for a dev/trusted shared bus, but signing (`cortex#552` / `cortex#635`) MUST be on before untrusted peers.
+
+### Example — two principals, one gateway
+
+```yaml
+# surfaces.yaml — two principals bound to ONE gateway on ONE bus.
+# The gateway principal is "andreas"; "joel/production" is a CROSS-principal
+# binding (starts with a WARN — UNSIGNED, dev/trusted only).
+surfaces:
+  discord:
+    - agent: luna
+      stack: andreas/research          # intra-principal (the gateway principal)
+      binding:
+        token: REPLACE_WITH_DISCORD_BOT_TOKEN_A
+        guildId: "111111111111111111"
+        agentChannelId: "000000000000000001"
+        logChannelId: "000000000000000002"
+    - agent: sage
+      stack: joel/production           # CROSS-principal — second principal, unsigned
+      binding:
+        token: REPLACE_WITH_DISCORD_BOT_TOKEN_B
+        guildId: "222222222222222222"
+        agentChannelId: "000000000000000003"
+        logChannelId: "000000000000000004"
+```
+
+With this map, an inbound on guild `111…` publishes on `local.andreas.research.tasks.@…luna.chat` and an inbound on guild `222…` on `local.joel.production.tasks.@…sage.chat`; each principal's reply routes back to its own adapter instance, with no cross-posting. End-to-end coverage: `src/gateway/__tests__/cross-principal-routing.integration.test.ts`.
+
+> ⚠️ **Unsigned caveat.** Cross-principal routing here runs with `security.signing: off` (the gateway publishes originator-stamped + unsigned on the cross-principal hop; `CONTEXT.md` §Dispatch-source). A peer can claim any principal. Use only on a dev / trusted-party bus. Flip `signing: enforce` (and, for cross-org peers, encryption) before any untrusted peer — see `docs/iteration-trust-confidentiality.md`.
+
+---
+
 ## 8. Vocabulary compliance
 
 Per the live whole-tree vocabulary gate (`CONTEXT.md`), this design uses: **principal** (the human, root of trust), **stack** (one running cortex deployment), **assistant** (the named being, e.g. Luna), **agent** (the stack-local runtime hosting an assistant), **dispatch source / dispatch sink** (the gateway's two roles), **response routing** (the wire-level reply address), **Offer / Direct / Delegate** (dispatch modes; GW publishes **Direct** chat envelopes), and **scope** `local` / `federated` / `public` (GW v1 is `local` within one principal; cross-principal is `federated`, deferred — OQ3). No bare "operator" is used; where the NSC/NATS operator account is meant it is qualified ("NSC operator account" — not relevant to GW's data path).
@@ -206,7 +246,7 @@ Per the live whole-tree vocabulary gate (`CONTEXT.md`), this design uses: **prin
 
 1. **Connection dedup key** — `(platform, token)` (operational truth today, `cortex.ts:1274-1281`), `(platform, bot_user_id)`, or `(platform, assistant)`? They diverge when one assistant runs under two tokens.
 2. **Who signs the inbound envelope?** GW as a separate process is a dispatch source but `CONTEXT.md` makes the **stack** the cryptographic signer. Options: (a) gateway holds a delegated per-stack signing key; (b) gateway publishes originator-stamped, bound stack re-signs on ingest; (c) gateway IS a minimal stack. **Blocks GW.f.** (See §4.)
-3. **Cross-principal bindings** — is GW v1 single-principal (all bound stacks share one principal, all `local.`), with shared-channel cross-principal traffic (`federated.`, `CONTEXT.md` Network) deferred to a federation-aware gateway?
+3. ~~**Cross-principal bindings** — is GW v1 single-principal (all bound stacks share one principal, all `local.`), with shared-channel cross-principal traffic (`federated.`, `CONTEXT.md` Network) deferred to a federation-aware gateway?~~ **RESOLVED (F-1/F-2, see §7a):** the gateway is now multi-principal on a shared bus, UNSIGNED (dev/trusted only). Each binding routes on its OWN principal's `local.{principal}.{stack}` subjects (inbound + outbound). The cross-org/`federated.` + signing case is still deferred to the trust-confidentiality harden phases (`cortex#552` / `cortex#635`).
 4. **`response_routing` schema promotion** — is promoting `response_routing` to a first-class wire field GW's PR, or a CFG/myelin-schema prerequisite GW depends on? (See §3.3.)
 5. **Outbound replay on reconnect** — durable re-drain of `dispatch.task.*` (recover blast-radius, risk duplicate edits) vs fire-and-forget (match today, drop on disconnect)? (See §6.2.)
 6. **Shared outbound rate-limiting** — one connection now carries summed volume of all bound stacks against one identity's per-route quota; does GW need a shared route-keyed limiter + bus backpressure contract?

--- a/docs/iteration-trust-confidentiality.md
+++ b/docs/iteration-trust-confidentiality.md
@@ -12,7 +12,7 @@ Status: ☐ planned · ◐ in-progress · ☑ done.
 | **TC-1c** | Shape B — bound stack re-signs gateway-injected envelopes on ingest | 1 Signing | folds #552 | ☐ | #552 |
 | **TC-1d** | Enforce — `signFailureMode` → `drop`; tighten `rejectEmpty` on `tasks.chat` | 1 Signing | folds #210 | ☐ | #210 |
 | **TC-2c** | **F-1:** Relax single-principal guard + multi-principal subject derivation | **F Routing** (priority) | new | ☐ | #629 |
-| **TC-F2** | **F-2:** Cross-principal routing on a shared bus (two principals, one NATS, `federated.*`, unsigned) | **F Routing** (priority) | new | ☐ | #630 |
+| **TC-F2** | **F-2:** Cross-principal routing on a shared bus (two principals, one NATS, `federated.*`, unsigned) | **F Routing** (priority) | new | ☑ | #630 |
 | **TC-F3** | **F-3:** Multi-link / multi-network runtime — one NATS leaf per network/deployment | **F Routing** | new (E.1 / #348) | ☐ | #631 |
 | **TC-2a** | Registry client — resolve peer pubkeys via `GET /principals/{id}` (Phase D.4) | 2-verify (harden) | new | ☐ | #633 |
 | **TC-2b** | Multi-principal `IdentityRegistry` (peer-stamped, not single boot principal) | 2-verify (harden) | new | ☐ | #634 |

--- a/src/gateway/__tests__/cross-principal-routing.integration.test.ts
+++ b/src/gateway/__tests__/cross-principal-routing.integration.test.ts
@@ -1,0 +1,460 @@
+/**
+ * F-2 (TC-F2, cortex#630) — cross-principal collaboration, end-to-end.
+ *
+ * The HEADLINE PROOF for the federation-routing track: two principals
+ * collaborating through ONE shared surface gateway on ONE bus, UNSIGNED.
+ *
+ * F-1 (#629) relaxed the single-principal guard and added multi-principal
+ * subject derivation (outbound reply leg). F-1b (#651) completed the inbound
+ * request leg (`subjectPrincipal`). F-2 adds NO new routing code — it stands up
+ * the real wiring (`startGatewayIfEnabled` → `BusInboundSink` inbound +
+ * `createDispatchSink` outbound) against a capturing mock runtime and proves
+ * the cross-principal flow behaves end-to-end:
+ *
+ *   1. An inbound message on principal-A's binding (`andreas/research`)
+ *      publishes on principal-A's OWN subject
+ *      (`local.andreas.research.tasks.@…luna.chat`) — NOT the gateway principal.
+ *   2. An inbound message on principal-B's binding (`joel/production`)
+ *      publishes on principal-B's OWN subject
+ *      (`local.joel.production.tasks.@…sage.chat`).
+ *   3. The OUTBOUND dispatch sink subscribes to BOTH principals' lifecycle
+ *      subjects (derived from F-1's `principalStacks`), and routes a
+ *      `dispatch.task.completed` reply for EACH back to the correct adapter
+ *      instance — no cross-posting between principals.
+ *   4. Cross-principal bindings start with a WARN (not a throw) — the F-1
+ *      relaxation of the a.3d single-principal hard guard.
+ *
+ * The gateway principal is `andreas`; `joel/production` is the cross-principal
+ * binding. Everything runs with signing OFF (the gateway publishes
+ * originator-stamped + unsigned on the intra-/cross-principal hop — dev/trusted
+ * only; see CONTEXT.md §Dispatch-source + the UNSIGNED warning in
+ * start-gateway.ts).
+ *
+ * No reinvention: real `BusInboundSink` + `createDispatchSink`, the real
+ * `SurfaceGateway`, real `MockAdapter`s (capturing onMessage + postResponse),
+ * and the real `publishInboundChatDispatchEnvelope` publisher — only the NATS
+ * runtime and the policy engine are faked (one capturing object each).
+ */
+
+import { describe, expect, test } from "bun:test";
+import { startGatewayIfEnabled } from "../start-gateway";
+import { BusInboundSink } from "../bus-inbound-sink";
+import { createDispatchSink } from "../../adapters/dispatch-sink";
+import { MockAdapter } from "../../adapters/mock";
+import type { GatewayAdapterFactory } from "../gateway-adapters";
+import type { PlatformAdapter, InboundMessage } from "../../adapters/types";
+import type { Surfaces } from "../../common/types/surfaces";
+import type { Envelope } from "../../bus/myelin/envelope-validator";
+import type { MyelinRuntime, EnvelopeHandler } from "../../bus/myelin/runtime";
+import type { MyelinSubscriber } from "../../bus/myelin/subscriber";
+import type { SystemEventSource } from "../../bus/system-events";
+import type { PolicyEngine } from "../../common/policy/engine";
+
+// =============================================================================
+// Fakes — one capturing runtime + one resolving policy engine. Everything else
+// (gateway, sinks, adapters, publisher) is the real production code.
+// =============================================================================
+
+/**
+ * Capturing mock runtime. Records inbound publishes (`publishOnSubject` →
+ * `{ subject, envelope }`) AND outbound subscribes (`subscribe` → pattern), and
+ * lets a test fan an envelope through every registered `onEnvelope` handler
+ * (the outbound dispatch-sink delivery path). Mirrors the recordingRuntime in
+ * dispatch-sink.test.ts, extended with `publishOnSubject` for the inbound leg.
+ */
+function makeCapturingRuntime(): {
+  runtime: MyelinRuntime;
+  published: { subject: string; envelope: Envelope }[];
+  subscribedPatterns: string[];
+  fan: (env: Envelope) => void;
+} {
+  const handlers = new Set<EnvelopeHandler>();
+  const published: { subject: string; envelope: Envelope }[] = [];
+  const subscribedPatterns: string[] = [];
+
+  const runtime: MyelinRuntime = {
+    enabled: true,
+    onEnvelope: (handler: EnvelopeHandler) => {
+      handlers.add(handler);
+      return { unregister: () => { handlers.delete(handler); } };
+    },
+    publish: async () => {},
+    publishOnSubject: async (envelope: Envelope, subject: string) => {
+      published.push({ subject, envelope });
+    },
+    subscribe: async (pattern: string) => {
+      subscribedPatterns.push(pattern);
+      return { stop: async () => {} } as unknown as MyelinSubscriber;
+    },
+    stop: async () => {},
+  };
+
+  return {
+    runtime,
+    published,
+    subscribedPatterns,
+    fan: (env) => {
+      // onEnvelope fan-out hands (envelope, subject); the dispatch sink filters
+      // by envelope.type, so the subject string here is informational.
+      for (const h of handlers) h(env, "local.x.dispatch.task.completed");
+    },
+  };
+}
+
+/**
+ * Fake policy engine resolving the two test authors to registered principal ids
+ * so the inbound publisher does NOT refuse with `invalid-originator`. Only the
+ * one method the publisher calls (`lookupPrincipalIdByPlatformId`) is
+ * implemented; the rest of `PolicyEngine` is unused here.
+ */
+function makeResolvingPolicyEngine(
+  map: Record<string, string>,
+): PolicyEngine {
+  return {
+    lookupPrincipalIdByPlatformId: (_platform: string, authorId: string) =>
+      map[authorId],
+  } as unknown as PolicyEngine;
+}
+
+/** The gateway's own dispatch-source identity (gateway principal = "andreas"). */
+const GATEWAY_SOURCE: SystemEventSource = {
+  principal: "andreas",
+  agent: "gateway",
+  instance: "gateway-0",
+  dataResidency: "NZ",
+};
+
+/**
+ * Adapter factory that returns a real {@link MockAdapter} per binding, keyed to
+ * the gateway's interim instance id (`discord:{guildId}`), and records each
+ * adapter so the test can drive inbound (`simulateMessage`) and assert outbound
+ * (`sentMessages`). The gateway demuxes on the inbound message's own
+ * `platform`/`guildId`, NOT on the adapter's `platform`, so a MockAdapter is a
+ * faithful stand-in for the real Discord adapter on the routing path.
+ */
+function makeMockAdapterFactory(): {
+  factory: GatewayAdapterFactory;
+  byInstance: Map<string, MockAdapter>;
+} {
+  const byInstance = new Map<string, MockAdapter>();
+  const build = (instanceId: string): PlatformAdapter => {
+    const a = new MockAdapter(instanceId);
+    byInstance.set(instanceId, a);
+    return a;
+  };
+  const factory: GatewayAdapterFactory = {
+    discord: (args) => build(args.instanceId),
+    slack: (args) => build(args.instanceId),
+    mattermost: (args) => build(args.instanceId),
+  };
+  return { factory, byInstance };
+}
+
+/**
+ * Two principals on ONE gateway/bus:
+ *   - andreas/research  (the gateway principal — intra-principal)
+ *   - joel/production   (a SECOND principal — cross-principal, UNSIGNED)
+ * Each is a Discord binding with a distinct guildId → distinct adapter instance.
+ */
+const TWO_PRINCIPAL_SURFACES: Surfaces = {
+  discord: [
+    {
+      agent: "luna",
+      stack: "andreas/research",
+      binding: {
+        token: "tok-andreas-research",
+        guildId: "111111111111111111",
+        agentChannelId: "aaa000000000000001",
+        logChannelId: "bbb000000000000002",
+      },
+    },
+    {
+      agent: "sage",
+      stack: "joel/production",
+      binding: {
+        token: "tok-joel-production",
+        guildId: "222222222222222222",
+        agentChannelId: "ccc000000000000003",
+        logChannelId: "ddd000000000000004",
+      },
+    },
+  ],
+};
+
+const INSTANCE_A = "discord:111111111111111111"; // andreas/research
+const INSTANCE_B = "discord:222222222222222222"; // joel/production
+
+/** Inbound message fixture for a given guild/instance/author. */
+function inbound(overrides: Partial<InboundMessage>): InboundMessage {
+  return {
+    platform: "discord",
+    instanceId: INSTANCE_A,
+    authorId: "author-default",
+    authorName: "Tester",
+    channelId: "chan-1",
+    content: "hello",
+    guildId: "111111111111111111",
+    attachments: [],
+    timestamp: new Date("2026-06-03T00:00:00.000Z"),
+    ...overrides,
+  };
+}
+
+/** A `dispatch.task.completed` lifecycle envelope echoing a response routing. */
+function completedEnvelope(routing: {
+  adapter_instance: string;
+  channel_id: string;
+  thread_id?: string;
+}, chatResponse: string): Envelope {
+  return {
+    id: "00000000-0000-4000-8000-0000000000aa",
+    source: "any.runner.local",
+    type: "dispatch.task.completed",
+    timestamp: "2026-06-03T00:01:00Z",
+    correlation_id: "task-xyz",
+    sovereignty: {
+      classification: "local",
+      data_residency: "NZ",
+      max_hop: 0,
+      frontier_ok: false,
+      model_class: "local-only",
+    },
+    payload: {
+      agent_id: "agent",
+      chat_response: chatResponse,
+      response_routing: routing,
+    },
+  };
+}
+
+/** Let queued microtasks (the sink's fire-and-forget `deliver`) settle. */
+async function flush(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+// =============================================================================
+// The end-to-end proof
+// =============================================================================
+
+describe("F-2 — cross-principal collaboration through one gateway (unsigned)", () => {
+  test("inbound on each principal's binding publishes on THAT principal's subject; outbound replies route back per-principal without cross-posting", async () => {
+    const { runtime, published, subscribedPatterns, fan } = makeCapturingRuntime();
+    const { factory, byInstance } = makeMockAdapterFactory();
+    const policyEngine = makeResolvingPolicyEngine({
+      "author-andreas": "andreas",
+      "author-joel": "joel",
+    });
+
+    // ── Stand up the gateway LIVE (both opt-in flags) over two principals. ────
+    // Capture stderr to assert the F-1 cross-principal WARN fired (not a throw).
+    const origWrite = process.stderr.write.bind(process.stderr);
+    const stderr: string[] = [];
+    process.stderr.write = (chunk: string | Uint8Array): boolean => {
+      stderr.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString());
+      return true;
+    };
+
+    let started;
+    try {
+      started = await startGatewayIfEnabled({
+        env: { CORTEX_GATEWAY: "1", CORTEX_GATEWAY_PUBLISH: "1" },
+        surfaces: TWO_PRINCIPAL_SURFACES,
+        principal: "andreas", // gateway principal; joel is cross-principal
+        runtime,
+        source: GATEWAY_SOURCE,
+        policyEngine,
+        factory,
+      });
+    } finally {
+      process.stderr.write = origWrite;
+    }
+
+    if (started === undefined) throw new Error("expected the gateway to start");
+
+    // ── (4) Cross-principal binding WARNED (not threw) — the F-1 relaxation. ──
+    const warning = stderr.join("");
+    expect(warning).toMatch(/cross-principal/i);
+    expect(warning).toMatch(/UNSIGNED/);
+    expect(warning).toMatch(/joel\/production/);
+
+    // LIVE: the double-opt-in selected the bus-publishing inbound sink.
+    expect(started.gateway.inboundSink).toBeInstanceOf(BusInboundSink);
+
+    // F-1: the started gateway exposes BOTH principals' (principal, stack) pairs,
+    // each carrying its OWN parsed principal (joel NOT absorbed into andreas).
+    expect(started.principalStacks).toEqual([
+      { principal: "andreas", stack: "research" },
+      { principal: "joel", stack: "production" },
+    ]);
+
+    // ── Wire the OUTBOUND dispatch sink over BOTH principals (F-1 subjects). ──
+    const dispatchSink = createDispatchSink({
+      runtime,
+      adapters: started.adapters,
+      principal: "andreas",
+      principalStacks: started.principalStacks,
+    });
+    await dispatchSink.start();
+
+    // (3a) The sink subscribes to BOTH principals' lifecycle subjects — each on
+    // its OWN principal namespace, no collapse onto the gateway principal.
+    expect(subscribedPatterns).toContain("local.andreas.research.dispatch.task.>");
+    expect(subscribedPatterns).toContain("local.joel.production.dispatch.task.>");
+    expect(subscribedPatterns).toHaveLength(2);
+
+    // ── INBOUND leg: drive a message on EACH principal's binding. ─────────────
+    const adapterA = byInstance.get(INSTANCE_A);
+    const adapterB = byInstance.get(INSTANCE_B);
+    if (adapterA === undefined || adapterB === undefined) {
+      throw new Error("expected both gateway adapters to be constructed");
+    }
+
+    // Principal A (andreas/research) — guild 111…, author resolves to "andreas".
+    await adapterA.simulateMessage(
+      inbound({
+        instanceId: INSTANCE_A,
+        guildId: "111111111111111111",
+        authorId: "author-andreas",
+        channelId: "chan-A",
+        content: "research please",
+      }),
+    );
+
+    // Principal B (joel/production) — guild 222…, author resolves to "joel".
+    await adapterB.simulateMessage(
+      inbound({
+        instanceId: INSTANCE_B,
+        guildId: "222222222222222222",
+        authorId: "author-joel",
+        channelId: "chan-B",
+        content: "ship it",
+      }),
+    );
+
+    // (1)+(2) Two publishes, each on ITS OWN principal's subject. The agent DID
+    // is encoded into the subject token (`@did-mf-{agent}`) by myelin's
+    // directTaskSubject; assert the principal/stack prefix + chat suffix.
+    expect(published).toHaveLength(2);
+
+    const subjectA = published.find((p) =>
+      p.subject.startsWith("local.andreas.research.tasks."),
+    );
+    const subjectB = published.find((p) =>
+      p.subject.startsWith("local.joel.production.tasks."),
+    );
+
+    // (1) Principal A landed on andreas/research — NOT the gateway principal
+    // alone, NOT joel.
+    expect(subjectA).toBeDefined();
+    expect(subjectA!.subject).toBe(
+      "local.andreas.research.tasks.@did-mf-luna.chat",
+    );
+    // (2) Principal B landed on joel/production — the CROSS-principal subject,
+    // on joel's namespace, not andreas's.
+    expect(subjectB).toBeDefined();
+    expect(subjectB!.subject).toBe(
+      "local.joel.production.tasks.@did-mf-sage.chat",
+    );
+
+    // Sanity: no inbound publish leaked onto the OTHER principal's namespace.
+    expect(
+      published.some((p) => p.subject.startsWith("local.andreas.production.")),
+    ).toBe(false);
+    expect(
+      published.some((p) => p.subject.startsWith("local.joel.research.")),
+    ).toBe(false);
+
+    // ── OUTBOUND leg: fan a completed reply for EACH principal's instance. ────
+    // Principal A's runner replies, routed to instance A.
+    fan(
+      completedEnvelope(
+        { adapter_instance: INSTANCE_A, channel_id: "chan-A" },
+        "Research answer for andreas.",
+      ),
+    );
+    // Principal B's runner replies, routed to instance B.
+    fan(
+      completedEnvelope(
+        { adapter_instance: INSTANCE_B, channel_id: "chan-B" },
+        "Production answer for joel.",
+      ),
+    );
+    await flush();
+
+    // (3b) Each reply posted to the CORRECT adapter instance — no cross-posting.
+    expect(adapterA.sentMessages).toHaveLength(1);
+    expect(adapterA.sentMessages[0]!.text).toBe("Research answer for andreas.");
+    expect(adapterA.sentMessages[0]!.target).toEqual({
+      instanceId: INSTANCE_A,
+      channelId: "chan-A",
+    });
+
+    expect(adapterB.sentMessages).toHaveLength(1);
+    expect(adapterB.sentMessages[0]!.text).toBe("Production answer for joel.");
+    expect(adapterB.sentMessages[0]!.target).toEqual({
+      instanceId: INSTANCE_B,
+      channelId: "chan-B",
+    });
+
+    // The adapter_instance filter is the sole delivery gate: principal A's
+    // adapter never saw principal B's reply and vice-versa.
+    expect(
+      adapterA.sentMessages.some((m) => m.text.includes("joel")),
+    ).toBe(false);
+    expect(
+      adapterB.sentMessages.some((m) => m.text.includes("andreas")),
+    ).toBe(false);
+
+    await dispatchSink.stop();
+    await started.gateway.stop();
+  });
+
+  test("a reply routed to an unknown instance is dropped (no cross-principal leak to either adapter)", async () => {
+    const { runtime, fan } = makeCapturingRuntime();
+    const { factory, byInstance } = makeMockAdapterFactory();
+    const policyEngine = makeResolvingPolicyEngine({ "author-x": "andreas" });
+
+    const origWrite = process.stderr.write.bind(process.stderr);
+    process.stderr.write = (): boolean => true; // mute the F-1 cross-principal WARN
+    let started;
+    try {
+      started = await startGatewayIfEnabled({
+        env: { CORTEX_GATEWAY: "1", CORTEX_GATEWAY_PUBLISH: "1" },
+        surfaces: TWO_PRINCIPAL_SURFACES,
+        principal: "andreas",
+        runtime,
+        source: GATEWAY_SOURCE,
+        policyEngine,
+        factory,
+      });
+    } finally {
+      process.stderr.write = origWrite;
+    }
+    if (started === undefined) throw new Error("expected the gateway to start");
+
+    const dispatchSink = createDispatchSink({
+      runtime,
+      adapters: started.adapters,
+      principal: "andreas",
+      principalStacks: started.principalStacks,
+    });
+    await dispatchSink.start();
+
+    // A reply addressed to an instance NEITHER principal owns.
+    fan(
+      completedEnvelope(
+        { adapter_instance: "discord:999999999999999999", channel_id: "ghost" },
+        "should reach nobody",
+      ),
+    );
+    await flush();
+
+    for (const a of byInstance.values()) {
+      expect(a.sentMessages).toHaveLength(0);
+    }
+
+    await dispatchSink.stop();
+    await started.gateway.stop();
+  });
+});


### PR DESCRIPTION
## F-2 (TC-F2, cortex#630) — cross-principal collaboration, end-to-end

Closes #630. Part of #627. **Validates #629 (F-1) + #651 (F-1b).**

F-1 (#629) relaxed the single-principal guard and added multi-principal subject derivation (outbound reply leg). F-1b (#651) completed the inbound request leg (`subjectPrincipal`). **F-2 adds NO new routing code** — it stands up the real wiring against a capturing mock runtime and proves the cross-principal flow works end-to-end, plus ships a documented example.

### What's here

**1. Integration test** — `src/gateway/__tests__/cross-principal-routing.integration.test.ts`

Stands up a LIVE gateway over **two principals on one bus** (`andreas/research` + `joel/production`, gateway principal = `andreas`) via the real `startGatewayIfEnabled` → `BusInboundSink` (inbound) + `createDispatchSink` (outbound), against a capturing mock runtime, a resolving fake `PolicyEngine`, and real `MockAdapter`s. Asserts end-to-end:

- **Inbound, principal A:** a message on `andreas/research`'s binding publishes on `local.andreas.research.tasks.@did-mf-luna.chat` — its OWN principal subject, NOT the gateway principal alone.
- **Inbound, principal B:** a message on `joel/production`'s binding publishes on `local.joel.production.tasks.@did-mf-sage.chat` — the cross-principal subject, on joel's namespace.
- **Outbound:** the dispatch sink subscribes to **both** principals' lifecycle subjects (`local.andreas.research.dispatch.task.>` + `local.joel.production.dispatch.task.>`, from F-1's `principalStacks`) and routes a `dispatch.task.completed` reply for each back to the **correct adapter instance** — no cross-posting between principals.
- **Guard:** cross-principal bindings start with a **WARN** (not a throw) — the F-1 relaxation of the a.3d single-principal guard.
- **Negative:** a reply addressed to an unknown instance is dropped (no leak to either adapter).

**2. Documented example** — `docs/design-shared-surface-gateway.md`

New §7a documents the multi-principal capability with a two-principal `surfaces.yaml` example and the unsigned/dev-only caveat. OQ3 (cross-principal deferred) marked **resolved** by F-1/F-2 for the unsigned case. TC-F2 ticked in `docs/iteration-trust-confidentiality.md`.

> ⚠️ Cross-principal routing runs `security.signing: off` (gateway publishes originator-stamped + unsigned on the cross-principal hop). Dev/trusted bus only; signing (#552/#635) before untrusted peers.

### Verification

- `bunx tsc --noEmit` — no `error TS`
- `bun run lint:errors` — clean
- `bun test src/gateway/` — **139 pass, 0 fail** (incl. the new integration test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)