### PR TITLE
feat(mc-worker): DO-backed dashboard WebSocket (/ws) for cloud-mode live push

### DIFF
--- a/src/surface/mc/worker/src/__tests__/dashboard-socket-protocol.test.ts
+++ b/src/surface/mc/worker/src/__tests__/dashboard-socket-protocol.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Unit tests for the pure DashboardSocket protocol helpers (no workerd runtime).
+ * The DO class glue (upgrade, hibernation, alarm) is verified end-to-end via a
+ * real wss client at deploy.
+ */
+import { describe, it, expect } from "bun:test";
+import {
+  WS_PROTOCOL_VERSION,
+  connectedMessage,
+  clientReply,
+  eventMessage,
+  fanout,
+  type SocketSink,
+} from "../dashboard-socket-protocol";
+
+/** A mock socket recording sends, optionally throwing on send (dead client). */
+function mockSocket(opts: { throwOnSend?: boolean } = {}) {
+  const sent: string[] = [];
+  let closed: { code: number; reason: string } | null = null;
+  const sink: SocketSink = {
+    send(data: string) {
+      if (opts.throwOnSend) throw new Error("socket closed");
+      sent.push(data);
+    },
+    close(code: number, reason: string) {
+      closed = { code, reason };
+    },
+  };
+  return { sink, sent, get closed() { return closed; } };
+}
+
+describe("connectedMessage", () => {
+  it("emits the connected handshake with the protocol version (matches server.ts)", () => {
+    const msg = JSON.parse(connectedMessage("abc"));
+    expect(msg.type).toBe("connected");
+    expect(msg.clientId).toBe("abc");
+    expect(msg.protocolVersion).toBe(WS_PROTOCOL_VERSION);
+    expect(WS_PROTOCOL_VERSION).toBe(2); // pinned to ws/types.ts
+  });
+});
+
+describe("clientReply", () => {
+  it("replies pong to a client ping", () => {
+    expect(clientReply(JSON.stringify({ type: "ping" }))).toBe(JSON.stringify({ type: "pong" }));
+  });
+  it("does not reply to pong (liveness only)", () => {
+    expect(clientReply(JSON.stringify({ type: "pong" }))).toBeNull();
+  });
+  it("ignores other typed messages", () => {
+    expect(clientReply(JSON.stringify({ type: "subscribe", channel: "x" }))).toBeNull();
+  });
+  it("ignores non-JSON frames", () => {
+    expect(clientReply("not json")).toBeNull();
+  });
+});
+
+describe("eventMessage", () => {
+  it("mirrors notifications.ts broadcastEvent shape", () => {
+    const ev = { event_id: "e1", event_type: "tool.bash", session_id: "s1" };
+    expect(eventMessage("s1", ev)).toEqual({ type: "event", sessionId: "s1", event: ev });
+  });
+});
+
+describe("fanout", () => {
+  it("sends one message to every live socket and counts them", () => {
+    const a = mockSocket();
+    const b = mockSocket();
+    const sent = fanout([a.sink, b.sink], { type: "ping" });
+    expect(sent).toBe(2);
+    expect(a.sent).toEqual([JSON.stringify({ type: "ping" })]);
+    expect(b.sent).toEqual([JSON.stringify({ type: "ping" })]);
+  });
+
+  it("prunes a dead socket (send throws) and excludes it from the count", () => {
+    const ok = mockSocket();
+    const dead = mockSocket({ throwOnSend: true });
+    const sent = fanout([ok.sink, dead.sink], { type: "event", sessionId: "s", event: {} });
+    expect(sent).toBe(1);
+    expect(ok.sent).toHaveLength(1);
+    expect(dead.closed).toEqual({ code: 1011, reason: "send failed" });
+  });
+
+  it("serializes the message once as JSON", () => {
+    const a = mockSocket();
+    fanout([a.sink], { type: "event", sessionId: "s1", event: { n: 1 } });
+    expect(JSON.parse(a.sent[0]!)).toEqual({ type: "event", sessionId: "s1", event: { n: 1 } });
+  });
+});

--- a/src/surface/mc/worker/src/__tests__/dashboard-socket-protocol.test.ts
+++ b/src/surface/mc/worker/src/__tests__/dashboard-socket-protocol.test.ts
@@ -9,6 +9,7 @@ import {
   connectedMessage,
   clientReply,
   eventMessage,
+  toDashboardEvent,
   fanout,
   type SocketSink,
 } from "../dashboard-socket-protocol";
@@ -54,10 +55,33 @@ describe("clientReply", () => {
   });
 });
 
+describe("toDashboardEvent", () => {
+  it("maps the ingest wire shape to the McEvent shape the renderer expects", () => {
+    const ingest = {
+      event_id: "e1",
+      event_type: "tool.bash",
+      session_id: "s1",
+      payload: { cmd: "ls" },
+      timestamp: "2026-06-04T00:00:00Z",
+    };
+    expect(toDashboardEvent(ingest)).toEqual({
+      id: "e1", // event_id → id (renderer keys on .id)
+      session_id: "s1",
+      type: "tool.bash", // event_type → type (renderer switches on .type)
+      payload: { cmd: "ls" },
+      timestamp: "2026-06-04T00:00:00Z",
+    });
+  });
+});
+
 describe("eventMessage", () => {
-  it("mirrors notifications.ts broadcastEvent shape", () => {
-    const ev = { event_id: "e1", event_type: "tool.bash", session_id: "s1" };
-    expect(eventMessage("s1", ev)).toEqual({ type: "event", sessionId: "s1", event: ev });
+  it("wraps a DashboardEvent (McEvent shape) in the {type:event,sessionId,event} envelope", () => {
+    const ev = { id: "e1", session_id: "s1", type: "tool.bash", payload: {}, timestamp: "t" };
+    const msg = eventMessage("s1", ev);
+    expect(msg).toEqual({ type: "event", sessionId: "s1", event: ev });
+    // The body the frontend casts as McEvent must carry id + type, not event_id/event_type.
+    expect(msg.event.id).toBe("e1");
+    expect(msg.event.type).toBe("tool.bash");
   });
 });
 

--- a/src/surface/mc/worker/src/dashboard-socket-protocol.ts
+++ b/src/surface/mc/worker/src/dashboard-socket-protocol.ts
@@ -1,0 +1,80 @@
+/**
+ * Pure WebSocket-protocol helpers for the DashboardSocket Durable Object.
+ *
+ * These functions carry ZERO Cloudflare-runtime dependency (no `cloudflare:workers`,
+ * no WebSocketPair, no DO state) so they are unit-testable under `bun test`. The
+ * DO class (`dashboard-socket.ts`) is thin glue over these; its runtime wiring
+ * (upgrade, hibernation, alarm) is verified at deploy via a real wss client.
+ *
+ * The message vocabulary mirrors the local bot's `src/surface/mc/notifications.ts`
+ * and the `connected`/`ping`/`pong` handshake in `src/surface/mc/server.ts`, so the
+ * existing frontend client (`dashboard-v2/hooks/use-websocket.ts`) needs no changes.
+ */
+
+/** Protocol version — must match `src/surface/mc/ws/types.ts` WS_PROTOCOL_VERSION. */
+export const WS_PROTOCOL_VERSION = 2;
+
+/** The `connected` handshake the client reads on open (mirrors server.ts open()). */
+export function connectedMessage(clientId: string): string {
+  return JSON.stringify({
+    type: "connected",
+    clientId,
+    serverVersion: "cloud",
+    protocolVersion: WS_PROTOCOL_VERSION,
+  });
+}
+
+/**
+ * Compute the server's reply to an inbound client frame.
+ * - client `{type:"ping"}`  → `{type:"pong"}` (string)
+ * - `pong` / any other type → null (liveness only, no reply)
+ * - non-JSON / no type field → null (ignored)
+ */
+export function clientReply(raw: string): string | null {
+  let parsed: { type?: unknown } | null = null;
+  try {
+    parsed = JSON.parse(raw) as { type?: unknown };
+  } catch (_err) {
+    // Non-JSON frame — ignore. Inbound traffic still counts as liveness upstream.
+    return null;
+  }
+  if (parsed && parsed.type === "ping") {
+    return JSON.stringify({ type: "pong" });
+  }
+  return null;
+}
+
+/** The live `event` push shape — mirrors notifications.ts broadcastEvent. */
+export function eventMessage(sessionId: string, event: unknown): { type: "event"; sessionId: string; event: unknown } {
+  return { type: "event", sessionId, event };
+}
+
+/** A socket sink — the subset of WebSocket the fanout needs. */
+export interface SocketSink {
+  send(data: string): void;
+  close(code: number, reason: string): void;
+}
+
+/**
+ * Fan a message to every socket. Returns the count delivered. A socket whose
+ * `send` throws (already closing) is closed and excluded from the count, so a
+ * dead client never blocks delivery to the rest.
+ */
+export function fanout(sockets: Iterable<SocketSink>, message: unknown): number {
+  const json = JSON.stringify(message);
+  let sent = 0;
+  for (const ws of sockets) {
+    try {
+      ws.send(json);
+      sent += 1;
+    } catch (_err) {
+      // Socket is already closing/closed — prune it so it stops receiving.
+      try {
+        ws.close(1011, "send failed");
+      } catch (_closeErr) {
+        // Already closed; nothing to do.
+      }
+    }
+  }
+  return sent;
+}

--- a/src/surface/mc/worker/src/dashboard-socket-protocol.ts
+++ b/src/surface/mc/worker/src/dashboard-socket-protocol.ts
@@ -44,8 +44,46 @@ export function clientReply(raw: string): string | null {
   return null;
 }
 
-/** The live `event` push shape — mirrors notifications.ts broadcastEvent. */
-export function eventMessage(sessionId: string, event: unknown): { type: "event"; sessionId: string; event: unknown } {
+/**
+ * The dashboard-facing event shape — mirrors `McEvent` in src/surface/mc/types.ts
+ * (`id`/`type`, NOT the ingest wire's `event_id`/`event_type`). The renderer
+ * (`dashboard-v2/lib/event-rows.ts`) switches on `.type` and keys on `.id`, so
+ * the live push MUST carry this shape, not a raw IngestEvent.
+ */
+export interface DashboardEvent {
+  id: string;
+  session_id: string;
+  type: string;
+  payload: Record<string, unknown>;
+  timestamp: string;
+}
+
+/** The subset of the ingest wire event this mapper needs. */
+interface IngestEventLike {
+  event_id: string;
+  event_type: string;
+  session_id: string;
+  payload: Record<string, unknown>;
+  timestamp: string;
+}
+
+/**
+ * Map an ingest-wire event (`event_id`/`event_type`) to the dashboard `McEvent`
+ * shape (`id`/`type`). Without this the frontend renders every live row as
+ * "unknown" (switch on undefined `.type`) with colliding React keys (undefined `.id`).
+ */
+export function toDashboardEvent(e: IngestEventLike): DashboardEvent {
+  return {
+    id: e.event_id,
+    session_id: e.session_id,
+    type: e.event_type,
+    payload: e.payload,
+    timestamp: e.timestamp,
+  };
+}
+
+/** The live `event` push envelope — mirrors notifications.ts broadcastEvent ({type:"event",sessionId,event}). */
+export function eventMessage(sessionId: string, event: DashboardEvent): { type: "event"; sessionId: string; event: DashboardEvent } {
   return { type: "event", sessionId, event };
 }
 

--- a/src/surface/mc/worker/src/dashboard-socket.ts
+++ b/src/surface/mc/worker/src/dashboard-socket.ts
@@ -47,18 +47,31 @@ export class DashboardSocket extends DurableObject<Env> {
     return new Response(null, { status: 101, webSocket: client });
   }
 
-  /** Internal: the worker POSTs `{message}` here after a write so all clients get it. */
+  /**
+   * Internal: the worker POSTs `{messages:[...]}` (batch, preferred — one DO
+   * round-trip per ingest) or `{message}` (single) here so all clients get it.
+   */
   private async handleBroadcast(request: Request): Promise<Response> {
-    let payload: { message?: unknown };
+    let payload: { message?: unknown; messages?: unknown[] };
     try {
-      payload = (await request.json()) as { message?: unknown };
+      payload = (await request.json()) as { message?: unknown; messages?: unknown[] };
     } catch (_err) {
       return Response.json({ ok: false, error: "invalid JSON" }, { status: 400 });
     }
-    if (typeof payload.message === "undefined") {
-      return Response.json({ ok: false, error: "message required" }, { status: 400 });
+    const batch: unknown[] = Array.isArray(payload.messages)
+      ? payload.messages
+      : typeof payload.message !== "undefined"
+        ? [payload.message]
+        : [];
+    if (batch.length === 0) {
+      return Response.json({ ok: false, error: "message or messages required" }, { status: 400 });
     }
-    const sent = fanout(this.ctx.getWebSockets() as unknown as SocketSink[], payload.message);
+    // Fetch the socket set once and reuse across the batch (fanout prunes dead ones).
+    const sockets = this.ctx.getWebSockets() as unknown as SocketSink[];
+    let sent = 0;
+    for (const message of batch) {
+      sent += fanout(sockets, message);
+    }
     return Response.json({ ok: true, sent });
   }
 
@@ -101,6 +114,9 @@ export class DashboardSocket extends DurableObject<Env> {
   }
 
   private async ensurePingAlarm(): Promise<void> {
+    // Idempotent by design: a DO holds at most one pending alarm, so two
+    // concurrent upgrades both observing null and both calling setAlarm just
+    // overwrite to the same ~30s target — no duplicate alarms, no leak.
     const existing = await this.ctx.storage.getAlarm();
     if (existing === null) {
       await this.ctx.storage.setAlarm(Date.now() + PING_INTERVAL_MS);

--- a/src/surface/mc/worker/src/dashboard-socket.ts
+++ b/src/surface/mc/worker/src/dashboard-socket.ts
@@ -1,0 +1,109 @@
+/**
+ * DashboardSocket — Durable Object backing the cloud-mode dashboard WebSocket (`/ws`).
+ *
+ * CF Workers are stateless, so server-push across connections needs a DO to hold
+ * the sockets and fan out. A single global instance (idFromName("global")) holds
+ * every connected dashboard for the stack; the worker forwards `GET /ws` upgrades
+ * here and POSTs `/broadcast` after ingest. Uses the WebSocket Hibernation API so
+ * idle connections don't pin the DO in memory.
+ *
+ * Protocol/message helpers live in `dashboard-socket-protocol.ts` (unit-tested);
+ * this class is the runtime glue, verified end-to-end via a real wss client at deploy.
+ */
+import { DurableObject } from "cloudflare:workers";
+import type { Env } from "./index";
+import { connectedMessage, clientReply, fanout, type SocketSink } from "./dashboard-socket-protocol";
+
+/** Server-initiated ping cadence — keeps connections warm + drives idle detection. */
+const PING_INTERVAL_MS = 30_000;
+
+export class DashboardSocket extends DurableObject<Env> {
+  /** Routes the two inbound shapes: `/broadcast` (internal POST) and the `/ws` upgrade. */
+  override async fetch(request: Request): Promise<Response> {
+    const url = new URL(request.url);
+
+    if (url.pathname === "/broadcast" && request.method === "POST") {
+      return this.handleBroadcast(request);
+    }
+
+    if ((request.headers.get("Upgrade") ?? "").toLowerCase() !== "websocket") {
+      return new Response("expected websocket upgrade", { status: 426 });
+    }
+
+    const pair = new WebSocketPair();
+    const client = pair[0];
+    const server = pair[1];
+    this.ctx.acceptWebSocket(server);
+
+    const clientId = crypto.randomUUID();
+    try {
+      server.send(connectedMessage(clientId));
+    } catch (_err) {
+      // Socket closed before the handshake landed; acceptWebSocket already
+      // registered it, so the close handler will clean up. Nothing to do here.
+    }
+    await this.ensurePingAlarm();
+
+    return new Response(null, { status: 101, webSocket: client });
+  }
+
+  /** Internal: the worker POSTs `{message}` here after a write so all clients get it. */
+  private async handleBroadcast(request: Request): Promise<Response> {
+    let payload: { message?: unknown };
+    try {
+      payload = (await request.json()) as { message?: unknown };
+    } catch (_err) {
+      return Response.json({ ok: false, error: "invalid JSON" }, { status: 400 });
+    }
+    if (typeof payload.message === "undefined") {
+      return Response.json({ ok: false, error: "message required" }, { status: 400 });
+    }
+    const sent = fanout(this.ctx.getWebSockets() as unknown as SocketSink[], payload.message);
+    return Response.json({ ok: true, sent });
+  }
+
+  /** Hibernation handler — client frames. Reply to ping with pong; else liveness only. */
+  override webSocketMessage(ws: WebSocket, message: string | ArrayBuffer): void {
+    const text = typeof message === "string" ? message : new TextDecoder().decode(message);
+    const reply = clientReply(text);
+    if (reply !== null) {
+      try {
+        ws.send(reply);
+      } catch (_err) {
+        // Client vanished mid-reply; the close handler will prune it.
+      }
+    }
+  }
+
+  /** Complete the closing handshake when the client goes away. */
+  override webSocketClose(ws: WebSocket, code: number, _reason: string, _wasClean: boolean): void {
+    try {
+      ws.close(code, "client closed");
+    } catch (_err) {
+      // Already closed — nothing to do.
+    }
+  }
+
+  override webSocketError(ws: WebSocket, _error: unknown): void {
+    try {
+      ws.close(1011, "socket error");
+    } catch (_err) {
+      // Already closed — nothing to do.
+    }
+  }
+
+  /** Server-initiated ping loop. Stops scheduling once no clients remain. */
+  override async alarm(): Promise<void> {
+    const sockets = this.ctx.getWebSockets();
+    if (sockets.length === 0) return; // no clients → let the ping loop go idle
+    fanout(sockets as unknown as SocketSink[], { type: "ping" });
+    await this.ctx.storage.setAlarm(Date.now() + PING_INTERVAL_MS);
+  }
+
+  private async ensurePingAlarm(): Promise<void> {
+    const existing = await this.ctx.storage.getAlarm();
+    if (existing === null) {
+      await this.ctx.storage.setAlarm(Date.now() + PING_INTERVAL_MS);
+    }
+  }
+}

--- a/src/surface/mc/worker/src/index.ts
+++ b/src/surface/mc/worker/src/index.ts
@@ -16,6 +16,7 @@ import { githubRoutes } from "./routes/github";
 import { adminRoutes } from "./routes/admin";
 import { syncRoutes } from "./routes/sync";
 import { dashboardRoutes } from "./routes/dashboard";
+import { DashboardSocket } from "./dashboard-socket";
 
 export interface Env extends AuthBindings {
   GROVE_KEYS: KVNamespace;
@@ -24,6 +25,8 @@ export interface Env extends AuthBindings {
   GITHUB_TOKEN: string;
   GITHUB_REPOS: string;
   CORS_ORIGIN: string;
+  /** DO backing the dashboard WebSocket (/ws) — single global instance per stack. */
+  DASHBOARD_SOCKET: DurableObjectNamespace;
 }
 
 const app = new Hono<{ Bindings: Env }>();
@@ -133,4 +136,24 @@ app.notFound((c) => {
   return c.json({ error: "not found" }, 404);
 });
 
-export default app;
+// ---------------------------------------------------------------------------
+// WebSocket (/ws) — handled at the module level, BEFORE Hono.
+// Routing the 101 upgrade through Hono's `*` CORS middleware would clone the
+// Response and drop the `webSocket` handle. So we intercept /ws here and forward
+// the raw request straight to the single global DashboardSocket DO instance.
+// Auth: /ws inherits the host-level CF Access app (the browser sends the
+// CF_Authorization cookie on the same-origin handshake) — no code-level bypass.
+// ---------------------------------------------------------------------------
+const worker = {
+  fetch(request: Request, env: Env, ctx: ExecutionContext): Response | Promise<Response> {
+    const url = new URL(request.url);
+    if (url.pathname === "/ws") {
+      const id = env.DASHBOARD_SOCKET.idFromName("global");
+      return env.DASHBOARD_SOCKET.get(id).fetch(request);
+    }
+    return app.fetch(request, env, ctx);
+  },
+};
+
+export default worker;
+export { DashboardSocket };

--- a/src/surface/mc/worker/src/routes/ingest.ts
+++ b/src/surface/mc/worker/src/routes/ingest.ts
@@ -22,7 +22,7 @@ import type {
   UsageSnapshotData,
 } from "../../../../../common/types";
 import { invalidateCache } from "./state";
-import { eventMessage } from "../dashboard-socket-protocol";
+import { eventMessage, toDashboardEvent } from "../dashboard-socket-protocol";
 
 type Variables = { principalId: string; principalKey: PrincipalKey };
 
@@ -114,17 +114,19 @@ ingestRoutes.post("/api/ingest", requireApiKey, async (c) => {
  */
 async function broadcastIngestedEvents(env: Env, events: IngestEvent[]): Promise<void> {
   if (!env.DASHBOARD_SOCKET) return; // binding absent (e.g. bare local dev) — skip
+  // Map each ingest-wire event to the dashboard McEvent shape (event_id→id,
+  // event_type→type) the renderer expects, and send the whole batch in ONE DO
+  // round-trip (not one subrequest per event).
+  const messages = events.map((event) => eventMessage(event.session_id, toDashboardEvent(event)));
   const stub = env.DASHBOARD_SOCKET.get(env.DASHBOARD_SOCKET.idFromName("global"));
-  for (const event of events) {
-    try {
-      await stub.fetch("https://do/broadcast", {
-        method: "POST",
-        body: JSON.stringify({ message: eventMessage(event.session_id, event) }),
-      });
-    } catch (err) {
-      // Best-effort live push; log and continue. Ingest already succeeded.
-      console.error("[ingest] WS broadcast failed:", err instanceof Error ? err.message : String(err));
-    }
+  try {
+    await stub.fetch("https://do/broadcast", {
+      method: "POST",
+      body: JSON.stringify({ messages }),
+    });
+  } catch (err) {
+    // Best-effort live push; log and continue. Ingest already succeeded.
+    console.error("[ingest] WS broadcast failed:", err instanceof Error ? err.message : String(err));
   }
 }
 

--- a/src/surface/mc/worker/src/routes/ingest.ts
+++ b/src/surface/mc/worker/src/routes/ingest.ts
@@ -22,6 +22,7 @@ import type {
   UsageSnapshotData,
 } from "../../../../../common/types";
 import { invalidateCache } from "./state";
+import { eventMessage } from "../dashboard-socket-protocol";
 
 type Variables = { principalId: string; principalKey: PrincipalKey };
 
@@ -58,6 +59,8 @@ ingestRoutes.post("/api/ingest", requireApiKey, async (c) => {
 
   const db = c.env.GROVE_DB;
   const activitySessionIds = new Set<string>();
+  // Events that committed this request — fanned to live dashboards after the response.
+  const broadcastable: IngestEvent[] = [];
 
   for (const event of body.events) {
     if (!event.event_id || !event.event_type || !event.session_id) {
@@ -77,6 +80,7 @@ ingestRoutes.post("/api/ingest", requireApiKey, async (c) => {
       }
 
       ingested++;
+      broadcastable.push(event);
     } catch {
       // INSERT OR IGNORE handles duplicates; other errors are skipped
       skipped++;
@@ -93,8 +97,36 @@ ingestRoutes.post("/api/ingest", requireApiKey, async (c) => {
     invalidateCache();
   }
 
+  // Live push: fan each committed event to connected dashboards via the
+  // DashboardSocket DO. Best-effort and off the response path (waitUntil) — a
+  // broadcast failure must never affect the ingest result.
+  if (broadcastable.length > 0) {
+    c.executionCtx.waitUntil(broadcastIngestedEvents(c.env, broadcastable));
+  }
+
   return c.json({ ok: true, ingested, skipped });
 });
+
+/**
+ * Fan committed events to live dashboard clients via the DashboardSocket DO.
+ * Mirrors the local bot's `broadcastEvent` ({type:"event", sessionId, event}).
+ * Never throws — a dead/absent DO must not surface to the ingesting bot.
+ */
+async function broadcastIngestedEvents(env: Env, events: IngestEvent[]): Promise<void> {
+  if (!env.DASHBOARD_SOCKET) return; // binding absent (e.g. bare local dev) — skip
+  const stub = env.DASHBOARD_SOCKET.get(env.DASHBOARD_SOCKET.idFromName("global"));
+  for (const event of events) {
+    try {
+      await stub.fetch("https://do/broadcast", {
+        method: "POST",
+        body: JSON.stringify({ message: eventMessage(event.session_id, event) }),
+      });
+    } catch (err) {
+      // Best-effort live push; log and continue. Ingest already succeeded.
+      console.error("[ingest] WS broadcast failed:", err instanceof Error ? err.message : String(err));
+    }
+  }
+}
 
 // ---------------------------------------------------------------------------
 // D1 persistence — maps ProcessedSessionEvent variants to D1 SQL

--- a/src/surface/mc/worker/wrangler.toml
+++ b/src/surface/mc/worker/wrangler.toml
@@ -20,6 +20,18 @@ database_id = "placeholder-local-id"
 binding = "GROVE_KEYS"
 id = "placeholder-local-kv-id"
 
+# DashboardSocket DO — backs the dashboard WebSocket (/ws). Named environments
+# do NOT inherit top-level DO bindings, so it is re-declared in each env below;
+# this base binding covers bare `wrangler dev`. The migration is top-level and
+# shared across environments.
+[[durable_objects.bindings]]
+name = "DASHBOARD_SOCKET"
+class_name = "DashboardSocket"
+
+[[migrations]]
+tag = "v1"
+new_sqlite_classes = ["DashboardSocket"]
+
 # ──────────────────────────────────────────────────────────────────
 # Environment: Development (grove-dev.meta-factory.{ai,dev,io})
 # ──────────────────────────────────────────────────────────────────
@@ -29,11 +41,19 @@ workers_dev = false
 routes = [
   { pattern = "grove-dev.meta-factory.ai/api/*", zone_name = "meta-factory.ai" },
   { pattern = "grove-dev.meta-factory.ai/admin/*", zone_name = "meta-factory.ai" },
+  { pattern = "grove-dev.meta-factory.ai/ws", zone_name = "meta-factory.ai" },
   { pattern = "grove-dev.meta-factory.dev/api/*", zone_name = "meta-factory.dev" },
   { pattern = "grove-dev.meta-factory.dev/admin/*", zone_name = "meta-factory.dev" },
+  { pattern = "grove-dev.meta-factory.dev/ws", zone_name = "meta-factory.dev" },
   { pattern = "grove-dev.meta-factory.io/api/*", zone_name = "meta-factory.io" },
-  { pattern = "grove-dev.meta-factory.io/admin/*", zone_name = "meta-factory.io" }
+  { pattern = "grove-dev.meta-factory.io/admin/*", zone_name = "meta-factory.io" },
+  { pattern = "grove-dev.meta-factory.io/ws", zone_name = "meta-factory.io" }
 ]
+
+# DashboardSocket DO binding (dev) — env configs don't inherit the base binding.
+[[env.dev.durable_objects.bindings]]
+name = "DASHBOARD_SOCKET"
+class_name = "DashboardSocket"
 
 [env.dev.vars]
 CORS_ORIGIN = "https://grove-dev.meta-factory.ai,https://grove-dev.meta-factory.dev,https://grove-dev.meta-factory.io,http://localhost:8766,http://localhost:8765"
@@ -73,11 +93,20 @@ workers_dev = false
 routes = [
   { pattern = "grove.meta-factory.ai/api/*", zone_name = "meta-factory.ai" },
   { pattern = "grove.meta-factory.ai/admin/*", zone_name = "meta-factory.ai" },
+  { pattern = "grove.meta-factory.ai/ws", zone_name = "meta-factory.ai" },
   { pattern = "grove.meta-factory.dev/api/*", zone_name = "meta-factory.dev" },
   { pattern = "grove.meta-factory.dev/admin/*", zone_name = "meta-factory.dev" },
+  { pattern = "grove.meta-factory.dev/ws", zone_name = "meta-factory.dev" },
   { pattern = "grove.meta-factory.io/api/*", zone_name = "meta-factory.io" },
-  { pattern = "grove.meta-factory.io/admin/*", zone_name = "meta-factory.io" }
+  { pattern = "grove.meta-factory.io/admin/*", zone_name = "meta-factory.io" },
+  { pattern = "grove.meta-factory.io/ws", zone_name = "meta-factory.io" }
 ]
+
+# DashboardSocket DO binding (production) — config ready; deploy is a separate
+# promote (this work deploys --env dev only).
+[[env.production.durable_objects.bindings]]
+name = "DASHBOARD_SOCKET"
+class_name = "DashboardSocket"
 
 [env.production.vars]
 # S-002: CORS for production — restricted to dashboard origins (all three TLDs).


### PR DESCRIPTION
## DO-backed `/ws` for cloud-mode live push

The cloud worker served only `/api/*` + `/admin/*` — no `/ws` — so the dashboard's live WebSocket (`dashboard-v2/hooks/use-websocket.ts`) never connected in cloud mode (infinite reconnect spam). CF Workers are stateless, so server-push across connections needs a **Durable Object** to hold sockets + fan out.

### What changed
- **`dashboard-socket-protocol.ts` (NEW)** — pure, unit-tested helpers: `connected` handshake (protocol v2, matches `ws/types.ts`), `clientReply` (ping→pong), `eventMessage` (`{type:"event",sessionId,event}` — same vocab as `notifications.ts`), `fanout` (broadcast + prune dead sockets). No `cloudflare:workers` dep → runs under `bun test` (9/9).
- **`dashboard-socket.ts` (NEW)** — `DashboardSocket` Durable Object: WebSocket **Hibernation API** (`acceptWebSocket`/`getWebSockets`), `/ws` upgrade → `101`, internal `POST /broadcast` fanout, client ping→pong, **alarm-driven server ping (30s)**, close/error cleanup. Thin glue over the pure helpers.
- **`index.ts`** — `Env.DASHBOARD_SOCKET`; `/ws` handled at the **module `fetch` level, before Hono** (routing the `101` through Hono's `*` CORS middleware would clone the response and drop the `webSocket` handle); `export { DashboardSocket }`.
- **`routes/ingest.ts`** — after a committed ingest, fans each event to live dashboards via the DO (`waitUntil`, best-effort — **never** affects the ingest result).
- **`wrangler.toml`** — DO binding (base + dev + prod) + top-level migration (`new_sqlite_classes`) + `/ws` routes for dev **and** prod hosts.

### Auth / scope
- `/ws` inherits the **host-level CF Access** app (browser `CF_Authorization` cookie on the same-origin handshake) — **no code-level auth bypass**. Verified: unauthenticated `/ws` → CF Access challenge.
- Frontend WS client **unchanged** (the DO conforms to it).
- Config written for prod; **only `--env dev` deployed** here (prod promote is a separate decision).
- Honest scope: the cloud worker only sees session/event **ingest**, so cloud live-push covers the `event` stream (drives the dashboard's refetch subscribers). Task/iteration live edits stay bot-local.

### Verification
- `bun test dashboard-socket-protocol.test.ts` — **9/9** (handshake, ping→pong, eventMessage shape, fanout + dead-socket prune).
- Root `bunx tsc --noEmit` clean (CI gate; worker excluded per repo tsconfig). My worker code type-checks clean vs `@cloudflare/workers-types`.
- `bun run lint` — 0 errors. `check-carveouts` PASS.
- **Dev deploy** (`wrangler deploy --env dev`): DO bound (`DASHBOARD_SOCKET`), `/ws` routes on all 3 TLDs, migration applied. `/ws` → CF Access challenge (routed + gated).
- ⚠️ End-to-end authenticated wss frame exchange is **operator-in-browser** (behind CF Access; no service-token secret available to script it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)