### PR TITLE
feat(bus): TC-1c — Shape B re-sign gateway-injected envelopes on ingest (closes #552)

### DIFF
--- a/src/bus/system-events.ts
+++ b/src/bus/system-events.ts
@@ -1059,6 +1059,12 @@ export type SystemDispatchStage =
   | "chain-verify-start"
   | "chain-verified"
   | "chain-rejected"
+  // TC-1c (#552) — Shape B re-sign on ingest. Emitted when a signer-bearing
+  // stack re-stamps an empty-chain gateway-injected / adapter-originated
+  // envelope with its own NKey, after the chain verifier accepts it and
+  // before the policy gate. `pass` = re-stamped; `fail` = sign failed and the
+  // dispatch fell through with the original unsigned envelope.
+  | "resigned-on-ingest"
   | "policy-decision"
   | "session-spawning"
   | "started";

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -2087,6 +2087,18 @@ export async function startCortex(
     ...(stackNKeyPubForVerifier !== undefined && {
       stackNKeyPub: stackNKeyPubForVerifier,
     }),
+    // TC-1c (#552) — Shape B re-sign on ingest. Hand the dispatch-listener
+    // the SAME stack signer the runtime uses, so an empty-chain inbound
+    // envelope (a gateway Shape-A injection or adapter-originated dispatch)
+    // is re-stamped with the stack NKey on ingest and becomes
+    // cryptographically attributable to this stack. `signer` is non-undefined
+    // ONLY when `security.signing` resolved `attachSigner: true`
+    // (`permissive`/`enforce`) AND a stack seed loaded — so under
+    // `signing: off` (the default) `resignSigner` is omitted entirely and
+    // ingest stays pure Shape A (byte-identical to today). The empty-chain
+    // gate inside the listener prevents double-stamping already-signed
+    // traffic.
+    ...(signer !== undefined && { resignSigner: signer }),
   });
   await dispatchListener.start();
 

--- a/src/runner/__tests__/dispatch-listener.test.ts
+++ b/src/runner/__tests__/dispatch-listener.test.ts
@@ -2220,6 +2220,244 @@ describe("dispatch-listener — chain verification (cortex#320)", () => {
 });
 
 // ---------------------------------------------------------------------------
+// TC-1c (#552) — Shape B re-sign gateway-injected envelopes on ingest
+// ---------------------------------------------------------------------------
+
+/**
+ * Generate a real ed25519 keypair shaped for the dispatch-listener's
+ * `resignSigner` option (`{ rawSeedBytes, principal }`) AND the chain
+ * verifier (`nkey_pub`). Mirrors `generateEd25519KeyPairForRunner` but also
+ * returns the raw seed bytes the signer carries.
+ */
+function generateStackSignerForRunner(principal: string): {
+  signer: { rawSeedBytes: Uint8Array; principal: string };
+  nkeyPub: string;
+} {
+  const kp = createUser();
+  const nkeyPub = kp.getPublicKey();
+  const rawSeedBytes = (
+    kp as unknown as { getRawSeed(): Uint8Array }
+  ).getRawSeed();
+  return { signer: { rawSeedBytes, principal }, nkeyPub };
+}
+
+/** Read an envelope's normalised `signed_by[]` chain (single | array | none). */
+function chainOf(env: Envelope): { method?: string; identity?: string }[] {
+  const sb = env.signed_by;
+  if (sb === undefined) return [];
+  return Array.isArray(sb) ? sb : [sb];
+}
+
+describe("dispatch-listener — Shape B re-sign on ingest (TC-1c #552)", () => {
+  // Stack identity the gateway-bound stack signs with. Matches the
+  // `did:mf:<principal>-<stack>` shape `cortex.ts` derives + the own-stack
+  // short-circuit (cortex#480) so the re-stamped envelope verifies on any
+  // re-entry.
+  const STACK_IDENTITY = "did:mf:andreas-meta-factory";
+
+  /** Single-principal engine that resolves `andreas` from `originator`. */
+  function engineForGatewayPrincipal(): PolicyEngine {
+    return new PolicyEngine({
+      principals: [
+        {
+          id: "andreas",
+          home_principal: "andreas",
+          home_stack: "andreas/meta-factory",
+          role: ["operator"],
+          trust: [],
+          platform_ids: { discord: ["1134325176796987522"] },
+        },
+      ],
+      roles: [{ id: "operator", capabilities: ["dispatch.cortex"] }],
+    });
+  }
+
+  /**
+   * A gateway Shape-A injection: empty `signed_by[]` + `originator` stamped
+   * (the gateway resolved the platform author to `did:mf:andreas` and
+   * published UNSIGNED — `dispatch-source-publisher.ts`).
+   */
+  function gatewayInjectedEnvelope(): Envelope {
+    const env = makeReceivedEnvelope();
+    env.originator = {
+      identity: "did:mf:andreas",
+      attribution: "adapter-resolved",
+    };
+    return env;
+  }
+
+  test("(a) signing off (no resignSigner) → gateway-injected envelope stays UNSIGNED (pure Shape A, unchanged)", async () => {
+    // Default posture (`signing: off`) → `cortex.ts` omits `resignSigner`.
+    // The empty-chain gateway envelope flows through verify (rejectEmpty:false)
+    // and the policy gate WITHOUT acquiring any signed_by stamp — byte-
+    // identical to today's behaviour. The audit envelope carries an empty
+    // signed_by chain.
+    const { nkeyPub } = generateStackSignerForRunner(STACK_IDENTITY);
+    const cortex = agentFixtureForRunner({ id: "cortex", trust: [] });
+    const resolver = runnerResolverWith(cortex);
+
+    const r = recordingRuntime();
+    const router = createSurfaceRouter(r.runtime);
+    const { factory } = fakeFactory(SUCCESS_RESULT);
+    const listener = createDispatchListener({
+      runtime: r.runtime,
+      source: SOURCE,
+      ccSessionFactory: factory,
+      policyEngine: engineForGatewayPrincipal(),
+      trustResolver: resolver,
+      receivingAgentId: "cortex",
+      principalId: "andreas",
+      cryptoVerify: true,
+      stackIdentity: STACK_IDENTITY,
+      stackNKeyPub: nkeyPub,
+      // resignSigner deliberately OMITTED — models `signing: off`.
+    });
+    await listener.start();
+    await router.start();
+
+    r.trigger(gatewayInjectedEnvelope(), CANONICAL_CORTEX_CHAT_SUBJECT);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    // Allow path: audit + lifecycle envelopes flow (dispatch is not dropped).
+    expect(r.published.map((e) => e.type)).toEqual([
+      "system.access.allowed",
+      "dispatch.task.started",
+      "dispatch.task.completed",
+    ]);
+    // The audit envelope carries the originating chain VERBATIM — empty,
+    // because no re-sign happened. This is the load-bearing back-compat pin.
+    const allowed = r.published.find((e) => e.type === "system.access.allowed")!;
+    const auditChain = (allowed.payload.signed_by ?? []) as unknown[];
+    expect(auditChain).toHaveLength(0);
+  });
+
+  test("(b) signing permissive + seed (resignSigner) → gateway-injected envelope carries a STACK signed_by[] stamp after ingest", async () => {
+    // Posture `permissive`/`enforce` + a loaded seed → `cortex.ts` passes
+    // `resignSigner`. The empty-chain gateway envelope is re-stamped on
+    // ingest with the stack NKey BEFORE the policy gate, so the downstream
+    // `system.access.allowed` audit envelope carries a stack signed_by[]
+    // stamp — the acceptance criterion.
+    const { signer, nkeyPub } = generateStackSignerForRunner(STACK_IDENTITY);
+    const cortex = agentFixtureForRunner({ id: "cortex", trust: [] });
+    const resolver = runnerResolverWith(cortex);
+
+    const captured: { principalId: string; intent: Intent }[] = [];
+    const engine = engineForGatewayPrincipal();
+    const origCheck = engine.check.bind(engine);
+    engine.check = (principalId, intent) => {
+      captured.push({ principalId, intent });
+      return origCheck(principalId, intent);
+    };
+
+    const r = recordingRuntime();
+    const router = createSurfaceRouter(r.runtime);
+    const { factory } = fakeFactory(SUCCESS_RESULT);
+    const listener = createDispatchListener({
+      runtime: r.runtime,
+      source: SOURCE,
+      ccSessionFactory: factory,
+      policyEngine: engine,
+      trustResolver: resolver,
+      receivingAgentId: "cortex",
+      principalId: "andreas",
+      cryptoVerify: true,
+      stackIdentity: STACK_IDENTITY,
+      stackNKeyPub: nkeyPub,
+      resignSigner: signer,
+    });
+    await listener.start();
+    await router.start();
+
+    r.trigger(gatewayInjectedEnvelope(), CANONICAL_CORTEX_CHAT_SUBJECT);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    // Dispatch is NOT dropped — allow + lifecycle flow.
+    expect(r.published.map((e) => e.type)).toEqual([
+      "system.access.allowed",
+      "dispatch.task.started",
+      "dispatch.task.completed",
+    ]);
+
+    // The audit envelope now carries a stack signed_by[] stamp — the
+    // gateway-injected request is cryptographically attributable to the
+    // stack. (`system.access.*` carries the originating chain verbatim via
+    // getSignedByChain, line 1375.)
+    const allowed = r.published.find((e) => e.type === "system.access.allowed")!;
+    const auditChain = (allowed.payload.signed_by ?? []) as {
+      method?: string;
+      identity?: string;
+    }[];
+    expect(auditChain).toHaveLength(1);
+    expect(auditChain[0]!.method).toBe("ed25519");
+    expect(auditChain[0]!.identity).toBe(STACK_IDENTITY);
+
+    // Policy attribution is UNCHANGED: the engine still resolved `andreas`
+    // from `originator.identity`, NOT the stack stamp at signed_by[0].
+    // Appending a stack stamp to a previously-empty chain must not change
+    // who the dispatch is attributed to.
+    expect(captured).toHaveLength(1);
+    expect(captured[0]!.principalId).toBe("andreas");
+  });
+
+  test("(c) per-stack already-signed dispatch is NOT re-stamped (empty-chain gate; no double-stamp, loop-safe)", async () => {
+    // A real per-stack dispatch already carries the stack stamp (the stack
+    // signed it via runtime.publish), OR our own re-stamped envelope
+    // re-entered the listener. Either way the chain is non-empty, so the
+    // re-sign hook MUST skip it — no double-stamp, and the re-consume loop is
+    // closed.
+    const { signer, nkeyPub } = generateStackSignerForRunner(STACK_IDENTITY);
+    const cortex = agentFixtureForRunner({ id: "cortex", trust: [] });
+    const resolver = runnerResolverWith(cortex);
+
+    const r = recordingRuntime();
+    const router = createSurfaceRouter(r.runtime);
+    const { factory } = fakeFactory(SUCCESS_RESULT);
+    const listener = createDispatchListener({
+      runtime: r.runtime,
+      source: SOURCE,
+      ccSessionFactory: factory,
+      policyEngine: engineForGatewayPrincipal(),
+      trustResolver: resolver,
+      receivingAgentId: "cortex",
+      principalId: "andreas",
+      cryptoVerify: true,
+      stackIdentity: STACK_IDENTITY,
+      stackNKeyPub: nkeyPub,
+      resignSigner: signer,
+    });
+    await listener.start();
+    await router.start();
+
+    // Pre-sign the envelope with the SAME stack key (models the per-stack
+    // path: the stack already signed via runtime.publish). Keep the
+    // originator so policy resolves `andreas`.
+    const base = gatewayInjectedEnvelope() as Parameters<typeof signEnvelope>[0];
+    const preSigned = (await signEnvelope(
+      base,
+      Buffer.from(signer.rawSeedBytes).toString("base64"),
+      STACK_IDENTITY,
+    )) as Envelope;
+    expect(chainOf(preSigned)).toHaveLength(1);
+
+    r.trigger(preSigned, CANONICAL_CORTEX_CHAT_SUBJECT);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    // Allow + lifecycle (own-stack short-circuit accepts the single stamp).
+    expect(r.published.map((e) => e.type)).toEqual([
+      "system.access.allowed",
+      "dispatch.task.started",
+      "dispatch.task.completed",
+    ]);
+
+    // The audit chain is STILL length 1 — the hook did NOT append a second
+    // stamp to the already-signed envelope. No double-stamp.
+    const allowed = r.published.find((e) => e.type === "system.access.allowed")!;
+    const auditChain = (allowed.payload.signed_by ?? []) as unknown[];
+    expect(auditChain).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // cortex#346 — myelin#161 originator field consumed via getActorPrincipal
 // ---------------------------------------------------------------------------
 

--- a/src/runner/__tests__/dispatch-listener.test.ts
+++ b/src/runner/__tests__/dispatch-listener.test.ts
@@ -2455,6 +2455,73 @@ describe("dispatch-listener — Shape B re-sign on ingest (TC-1c #552)", () => {
     const auditChain = (allowed.payload.signed_by ?? []) as unknown[];
     expect(auditChain).toHaveLength(1);
   });
+
+  test("(e) re-sign failure is non-fatal → dispatch proceeds UNSIGNED (Shape A fallback), not dropped", async () => {
+    // A transient crypto failure inside `signEnvelope` (modelled here with a
+    // malformed seed that trips its 32-byte length guard) MUST NOT drop the
+    // dispatch. The hook logs + falls through with the original (unsigned)
+    // envelope, mirroring the runtime's `signFailureMode: "fallback"` posture.
+    // The downstream audit envelope therefore carries an EMPTY signed_by chain,
+    // and policy attribution is unaffected (resolved from `originator`).
+    const { nkeyPub } = generateStackSignerForRunner(STACK_IDENTITY);
+    // Malformed signer: a 1-byte seed → `signEnvelope` throws at its
+    // `expected 32-byte Ed25519 seed` guard. principal stays a valid DID so the
+    // throw comes from the seed, not the DID check.
+    const brokenSigner = {
+      rawSeedBytes: new Uint8Array([1]),
+      principal: STACK_IDENTITY,
+    };
+    const cortex = agentFixtureForRunner({ id: "cortex", trust: [] });
+    const resolver = runnerResolverWith(cortex);
+
+    const captured: { principalId: string }[] = [];
+    const engine = engineForGatewayPrincipal();
+    const origCheck = engine.check.bind(engine);
+    engine.check = (principalId, intent) => {
+      captured.push({ principalId });
+      return origCheck(principalId, intent);
+    };
+
+    const r = recordingRuntime();
+    const router = createSurfaceRouter(r.runtime);
+    const { factory } = fakeFactory(SUCCESS_RESULT);
+    const listener = createDispatchListener({
+      runtime: r.runtime,
+      source: SOURCE,
+      ccSessionFactory: factory,
+      policyEngine: engine,
+      trustResolver: resolver,
+      receivingAgentId: "cortex",
+      principalId: "andreas",
+      cryptoVerify: true,
+      stackIdentity: STACK_IDENTITY,
+      stackNKeyPub: nkeyPub,
+      resignSigner: brokenSigner,
+    });
+    await listener.start();
+    await router.start();
+
+    r.trigger(gatewayInjectedEnvelope(), CANONICAL_CORTEX_CHAT_SUBJECT);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    // Dispatch is NOT dropped — the sign failure fell through to the policy
+    // gate and the harness ran (allow + lifecycle).
+    expect(r.published.map((e) => e.type)).toEqual([
+      "system.access.allowed",
+      "dispatch.task.started",
+      "dispatch.task.completed",
+    ]);
+
+    // The audit envelope carries an EMPTY signed_by chain — the re-stamp did
+    // not land, so ingest fell back to pure Shape A. No partial / corrupt stamp.
+    const allowed = r.published.find((e) => e.type === "system.access.allowed")!;
+    const auditChain = (allowed.payload.signed_by ?? []) as unknown[];
+    expect(auditChain).toHaveLength(0);
+
+    // Attribution unchanged: still resolved `andreas` from `originator`.
+    expect(captured).toHaveLength(1);
+    expect(captured[0]!.principalId).toBe("andreas");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/runner/dispatch-listener.ts
+++ b/src/runner/dispatch-listener.ts
@@ -72,7 +72,8 @@ import {
   getTargetAssistant,
 } from "../bus/myelin/envelope-validator";
 import { encodeDidSegment } from "@the-metafactory/myelin/subjects";
-import type { MyelinRuntime } from "../bus/myelin/runtime";
+import type { MyelinRuntime, BusEnvelopeSigner } from "../bus/myelin/runtime";
+import { signEnvelope } from "@the-metafactory/myelin/identity";
 import {
   emitFederationDenied,
   evaluateFederationGate,
@@ -376,6 +377,43 @@ export interface DispatchListenerOptions {
    */
   stackNKeyPub?: string;
   /**
+   * TC-1c (#552) — **Shape B re-sign on ingest.** The receiving stack's
+   * envelope signer (`{ rawSeedBytes, principal }`, the SAME
+   * {@link BusEnvelopeSigner} `cortex.ts` hands to `startMyelinRuntime`).
+   * When supplied, an inbound dispatch that arrived with an **empty
+   * `signed_by[]`** (a gateway Shape-A injection or an adapter-originated
+   * dispatch) is re-stamped IN PLACE with the stack NKey — right after
+   * `verifySignedByChain` accepts it and BEFORE the policy gate — so the
+   * downstream `system.access.*` audit envelopes (and any further
+   * processing) are cryptographically attributable to the stack. The
+   * stack vouches for the gateway-injected request; the gateway stays a
+   * pure transport that never touches identity (CONTEXT.md §Dispatch-
+   * source, decision 2026-06-02).
+   *
+   * **Posture-gated.** `cortex.ts` supplies this ONLY when
+   * `security.signing` resolves `attachSigner: true` (`permissive` /
+   * `enforce`) AND a stack seed loaded. Under `signing: off` (the default)
+   * the field is `undefined` → no re-sign → byte-identical to today's pure
+   * Shape A. This is the load-bearing back-compat invariant.
+   *
+   * **In-place, not re-publish.** Re-publishing on the same
+   * `tasks.@{agent}.chat` subject the listener subscribes to would loop;
+   * the same dispatch must carry the stamp before the harness runs, so we
+   * append via myelin `signEnvelope` and continue the handler with the
+   * re-stamped envelope.
+   *
+   * **Empty-chain-only.** Only an envelope with NO existing chain is
+   * re-stamped — never double-stamp an already-signed envelope (a real
+   * signed dispatch, or our own re-stamped traffic), which also keeps the
+   * own-stack short-circuit and the loop-safety invariant intact. Policy
+   * attribution is unaffected: `resolvePrincipalId` reads
+   * `originator.identity` first (the gateway stamps it), only falling back
+   * to `signed_by[0]` when no originator exists — appending a stack stamp
+   * to a previously-empty chain does NOT change the policy-resolved
+   * principal.
+   */
+  resignSigner?: BusEnvelopeSigner;
+  /**
    * cortex#492 — dispatch-stage tracing toggle. When `true`, the
    * inbound path emits a `system.dispatch.stage` envelope (via
    * `runtime.publish`) AND a structured stderr line at each pipeline
@@ -643,6 +681,7 @@ export function createDispatchListener(
     principalId,
     stackIdentity,
     stackNKeyPub,
+    resignSigner,
     adapterId = "runner-dispatch-listener",
   } = opts;
   // v2.0.2 default: structural trust + ed25519 crypto verification.
@@ -718,6 +757,7 @@ export function createDispatchListener(
         receivingAgentId,
         stackIdentity,
         stackNKeyPub,
+        resignSigner,
         traceDispatch,
       });
     } catch (err) {
@@ -1036,6 +1076,13 @@ interface DispatchHandlerContext {
   /** cortex#480 — receiving stack's NKey pubkey for crypto-verify pass. */
   stackNKeyPub: string | undefined;
   /**
+   * TC-1c (#552) — Shape B re-sign signer. When supplied (posture
+   * `permissive`/`enforce` + a loaded stack seed), an empty-chain inbound
+   * envelope is re-stamped with the stack NKey on ingest. See
+   * {@link DispatchListenerOptions.resignSigner}.
+   */
+  resignSigner: BusEnvelopeSigner | undefined;
+  /**
    * cortex#492 — when `true`, emit a `system.dispatch.stage` trace at
    * each gate inside the handler. Resolved by `createDispatchListener`
    * from the explicit option or `CORTEX_TRACE_DISPATCH`; the handler
@@ -1063,6 +1110,7 @@ async function handleDispatchEnvelope(
     receivingAgentId,
     stackIdentity,
     stackNKeyPub,
+    resignSigner,
     traceDispatch,
   } = ctx;
   // cortex#492 — pre-parse trace context. Refined to the trusted payload
@@ -1284,6 +1332,82 @@ async function handleDispatchEnvelope(
       "pass",
       traceCtx,
     );
+  }
+
+  // TC-1c (#552) — Shape B re-sign on ingest. The shared surface gateway
+  // (cortex#524) injects inbound dispatches UNSIGNED + `originator`-stamped
+  // (Shape A): it runs in a separate process with a signer-less runtime and
+  // cannot call `runtime.publish` to sign. When this stack has its own
+  // signer (posture `permissive`/`enforce` + a loaded stack seed; `cortex.ts`
+  // only passes `resignSigner` then), we re-stamp the envelope HERE — just
+  // after the chain verifier accepted it, before the policy gate and the
+  // harness — so the stack becomes the cryptographic origin for
+  // gateway-injected traffic and the downstream `system.access.*` audit
+  // envelopes carry a stack `signed_by[]` stamp (CONTEXT.md §Dispatch-source,
+  // decision 2026-06-02). The stack vouches for the request; the gateway
+  // stays a pure transport that never touches identity.
+  //
+  // Gated on an EMPTY chain only. An envelope that already carries a stamp
+  // (a real signed dispatch, or our own re-stamped traffic that re-entered
+  // the listener) is left untouched — we never double-stamp, which also
+  // closes any re-consume loop and preserves the own-stack short-circuit.
+  // Policy attribution is unaffected: `resolvePrincipalId`/`getActorPrincipal`
+  // read `originator.identity` FIRST (the gateway stamps it) and only fall
+  // back to `signed_by[0]` when no originator exists, so appending a stack
+  // stamp to a previously-empty chain does not change the resolved principal.
+  //
+  // In-place (not a bus re-publish): re-publishing on the same
+  // `tasks.@{agent}.chat` subject the listener subscribes to would loop, and
+  // the SAME dispatch must carry the stamp before the harness runs. We reuse
+  // myelin's append-mode `signEnvelope` (the same primitive
+  // `MyelinRuntime.signAndPublishOnSubject` uses) and continue with the
+  // re-stamped envelope. A sign failure is non-fatal: log + fall through with
+  // the original (unsigned) envelope, mirroring the runtime's `fallback`
+  // posture — a transient crypto failure must not drop the dispatch.
+  if (
+    resignSigner !== undefined &&
+    getSignedByChain(envelope).length === 0
+  ) {
+    try {
+      const reSignerSeedBase64 = Buffer.from(
+        resignSigner.rawSeedBytes,
+      ).toString("base64");
+      envelope = await signEnvelope(
+        envelope as Parameters<typeof signEnvelope>[0],
+        reSignerSeedBase64,
+        resignSigner.principal,
+      );
+      trace(
+        traceDispatch,
+        runtime,
+        source,
+        "resigned-on-ingest",
+        "pass",
+        traceCtx,
+        resignSigner.principal,
+      );
+    } catch (err) {
+      // Non-fatal — see the `signFailureMode: "fallback"` rationale in
+      // `MyelinRuntime.signAndPublishOnSubject`. We deliberately omit
+      // `err.message` interpolation: myelin's `signEnvelope` builds error
+      // strings from seed inputs, and we don't want partial seed-shape facts
+      // landing in logs. The error class + envelope id is enough to triage.
+      const reason = err instanceof Error ? err.name : "unknown";
+      trace(
+        traceDispatch,
+        runtime,
+        source,
+        "resigned-on-ingest",
+        "fail",
+        traceCtx,
+        reason,
+      );
+      process.stderr.write(
+        `[runner/dispatch-listener] re-sign on ingest failed for envelope ` +
+          `${envelope.id} (correlation_id=${envelope.correlation_id ?? "<none>"}) ` +
+          `reason=${reason} — continuing with unsigned envelope (Shape A fallback)\n`,
+      );
+    }
   }
 
   // IAW Phase C.3.1 — policy gate. The engine resolves the originating


### PR DESCRIPTION
## What

D1 **Shape B** (Trust & Confidentiality Phase 1c, design `docs/design-trust-confidentiality.md` §1c): when the bound stack ingests a **gateway-injected** envelope that arrived **unsigned** (Shape A), it now re-signs it with its **own stack NKey on ingest** — so the envelope becomes cryptographically attributable to the stack. The gateway stays a pure transport that never touches identity (CONTEXT.md §Dispatch-source, decision 2026-06-02).

Closes #552. Part of #627.

## How

- **Insertion point** (`src/runner/dispatch-listener.ts`): just after `verifySignedByChain` accepts the envelope and **before** the policy gate. The re-sign hook runs only when the chain arrived **empty** (a gateway Shape-A injection or adapter-originated dispatch).
- **Mechanism — in-place re-stamp, NOT a bus re-publish.** Append a stack stamp via myelin's append-mode `signEnvelope` (the same primitive `MyelinRuntime.signAndPublishOnSubject` uses) and continue the handler with the re-stamped envelope. The downstream `system.access.*` audit envelopes (`getSignedByChain`, line ~1375) then carry the stack `signed_by[]` stamp — the acceptance criterion.
  - A bus re-publish on the same `tasks.@{agent}.chat` subject the listener subscribes to would **loop**, and the spec requires the SAME dispatch to carry the stamp "before the harness runs" — so in-place is the correct mechanism.
- **New option** `DispatchListenerOptions.resignSigner` (a `BusEnvelopeSigner` — the SAME signer `cortex.ts` hands `startMyelinRuntime`), threaded into the handler context.
- **New dispatch-stage trace value** `resigned-on-ingest` (`src/bus/system-events.ts`).

## Posture gating + back-compat (load-bearing)

Gated on `config.security.signing` via the **TC-0 `attachSigner` knob**. `cortex.ts` passes `resignSigner` **only when `signer !== undefined`** — which is true ONLY when `signing` resolved `attachSigner: true` (`permissive`/`enforce`) AND a stack seed loaded.

| `signing` | re-sign on ingest? |
|-----------|--------------------|
| `off` (default) | **no** — `resignSigner` omitted → pure Shape A, byte-identical to today |
| `permissive` / `enforce` (+ seed) | yes — empty-chain envelopes re-stamped with the stack NKey |

Default `off` → behaviour unchanged. Pinned by test (a).

## Design decision (no design change needed)

The phrase "re-emit through `signAndPublishOnSubject`" in the design doc is loose; the precise, correct mechanism is **in-place append**, not a NATS re-publish (loop-safety + the stamp must ride the same dispatch). Two correctness invariants resolved during investigation:

1. **Loop-safety / no double-stamp** — gated on an **empty chain only**. An already-signed envelope (a real per-stack dispatch, or our own re-stamped traffic re-entering the listener) is left untouched.
2. **Policy attribution unchanged** — `resolvePrincipalId` → `getActorPrincipal` reads `originator.identity` **first** (the gateway stamps it), only falling back to `signed_by[0]` when no originator exists. Appending a stack stamp to a previously-empty chain does **not** change the policy-resolved principal. Pinned by test (b).

A sign failure is **non-fatal**: log + fall through with the original unsigned envelope (mirrors the runtime's `signFailureMode: "fallback"` posture — a transient crypto failure must not drop the dispatch).

## Verification

- `bunx tsc --noEmit` — **0** `error TS`
- `bun run lint:errors` — clean
- `bun test` on `dispatch-listener` + `bus-inbound-sink` + `verify-signed-by-chain` + `security-posture` — **112 pass / 0 fail**
- New tests (`src/runner/__tests__/dispatch-listener.test.ts`, describe "Shape B re-sign on ingest (TC-1c #552)"):
  - **(a)** signing off (no `resignSigner`) → gateway-injected envelope stays unsigned; audit `signed_by` empty (back-compat pin).
  - **(b)** permissive + seed → gateway-injected envelope carries a stack `signed_by[]` stamp after ingest; policy still attributes to `andreas` via `originator`.
  - **(c)** already-signed per-stack dispatch is NOT re-stamped (empty-chain gate; no double-stamp, loop-safe).
- Confirmed via `CORTEX_TRACE_DISPATCH=1` that the `resigned-on-ingest` stage fires in (b) only, not (a)/(c).

🤖 Generated with [Claude Code](https://claude.com/claude-code)