### PR TITLE
feat(config): F-3a — inline nats: per federated network + leaf_node consistency validator (closes #657)

### DIFF
--- a/cortex.yaml.example
+++ b/cortex.yaml.example
@@ -193,6 +193,41 @@ policy:
         - tool.read
         - tool.glob
         - tool.grep
+  # ---------------------------------------------------------------------------
+  # federated — optional cross-stack federation (Phase D + F-3)
+  # ---------------------------------------------------------------------------
+  # Each network is a trust closure with its own peers[], accept/deny subject
+  # lists, and hop budget. F-3a (cortex#657) adds an OPTIONAL inline `nats:`
+  # leaf-node connection per network (Option B). When `nats:` is present the
+  # network rides its own dedicated leaf; when ABSENT it rides the primary
+  # link (the top-level `nats:` block) — today's behaviour, byte-for-byte.
+  #
+  # `leaf_node` is the link-pool de-dup key: two networks sharing a leaf_node
+  # name share ONE physical link, so their `nats:` blocks MUST be consistent
+  # (byte-identical, or omitted on all but one). A conflicting `nats:` under a
+  # shared leaf_node fails config-load loudly.
+  #
+  # The per-network `nats:` block mirrors a subset of the top-level NATS
+  # schema: { url (nats://|tls://), credsPath?, name? }. token / subjects /
+  # identity are intentionally not accepted here.
+  #
+  # federated:
+  #   networks:
+  #     - id: research-collab
+  #       leaf_node: nats-leaf-research   # routing label / link-pool key
+  #       nats:                           # OPTIONAL — omit to ride primary link
+  #         url: nats://research:4222
+  #         credsPath: ~/.config/cortex/creds/research.creds
+  #       peers:
+  #         - principal_id: jcfischer
+  #           stack_id: jcfischer/sage-host
+  #           principal_pubkey: U...   # peer stack NKey public key (56 chars)
+  #       accept_subjects:
+  #         - federated.research-collab.>
+  #       deny_subjects: []
+  #       announce_capabilities:
+  #         - code-review.typescript
+  #       max_hop: 1
 
 # -----------------------------------------------------------------------------
 # agents — first-class agents on this stack

--- a/src/common/policy/__tests__/factory.test.ts
+++ b/src/common/policy/__tests__/factory.test.ts
@@ -977,6 +977,194 @@ describe("PolicyFederatedSchema cross-validation", () => {
     expect(policy.principals).toHaveLength(1);
     expect(policy.federated?.networks).toHaveLength(1);
   });
+
+  // ─── F-3a: inline per-network nats: block (cortex#657) ─────────────────
+  // Option B (docs/design-multi-network.md §2). Additive + back-compat:
+  // a network with an inline nats: leaf parses; a network with no nats:
+  // is unchanged (rides the primary link). leaf_node is the de-dup key:
+  // networks sharing a leaf_node MUST declare consistent connections.
+
+  test("F-3a: network with an inline nats: leaf block parses", () => {
+    const policy = PolicySchema.parse({
+      federated: {
+        networks: [{
+          id: "research-collab", leaf_node: "nats-leaf-research", peers: [],
+          accept_subjects: ["federated.research-collab.>"], deny_subjects: [],
+          announce_capabilities: [], max_hop: 1,
+          nats: {
+            url: "nats://research:4222",
+            credsPath: "~/.config/cortex/creds/research.creds",
+          },
+        }],
+      },
+    });
+    const net = policy.federated?.networks[0];
+    expect(net?.nats?.url).toBe("nats://research:4222");
+    expect(net?.nats?.credsPath).toBe("~/.config/cortex/creds/research.creds");
+    // name defaults to "cortex" (mirrors NatsConfigSchema.name).
+    expect(net?.nats?.name).toBe("cortex");
+  });
+
+  test("F-3a: network with NO nats: block parses unchanged (no leaf → primary link, today's behaviour)", () => {
+    const policy = PolicySchema.parse({
+      federated: {
+        networks: [{
+          id: "research-collab", leaf_node: "leaf", peers: [],
+          accept_subjects: [], deny_subjects: [],
+          announce_capabilities: [], max_hop: 0,
+        }],
+      },
+    });
+    expect(policy.federated?.networks[0]?.nats).toBeUndefined();
+  });
+
+  test("F-3a: nats.url must start with nats:// or tls:// (mirrors NatsConfigSchema)", () => {
+    expect(() =>
+      PolicySchema.parse({
+        federated: {
+          networks: [{
+            id: "n", leaf_node: "leaf", peers: [],
+            accept_subjects: [], deny_subjects: [],
+            announce_capabilities: [], max_hop: 0,
+            nats: { url: "http://research:4222" },
+          }],
+        },
+      }),
+    ).toThrow(/network\.nats\.url must start with nats:\/\/ or tls:\/\//);
+  });
+
+  test("F-3a: nats: block is strict — an unknown key (e.g. token) is rejected", () => {
+    // token/subjects/identity/accountSigningKeyPath are deliberately NOT
+    // part of the per-network leaf subset (design §4 rule 1). The strict
+    // object rejects them rather than silently dropping.
+    expect(() =>
+      PolicySchema.parse({
+        federated: {
+          networks: [{
+            id: "n", leaf_node: "leaf", peers: [],
+            accept_subjects: [], deny_subjects: [],
+            announce_capabilities: [], max_hop: 0,
+            nats: { url: "nats://research:4222", token: "secret" },
+          }],
+        },
+      }),
+    ).toThrow();
+  });
+
+  test("F-3a: two networks sharing a leaf_node with CONSISTENT nats: blocks parse", () => {
+    const policy = PolicySchema.parse({
+      federated: {
+        networks: [
+          {
+            id: "net-a", leaf_node: "shared-leaf", peers: [],
+            accept_subjects: [], deny_subjects: [],
+            announce_capabilities: [], max_hop: 0,
+            nats: { url: "nats://shared:4222", credsPath: "~/creds/shared.creds" },
+          },
+          {
+            id: "net-b", leaf_node: "shared-leaf", peers: [],
+            accept_subjects: [], deny_subjects: [],
+            announce_capabilities: [], max_hop: 0,
+            // Byte-identical block on the same leaf_node — share one link.
+            nats: { url: "nats://shared:4222", credsPath: "~/creds/shared.creds" },
+          },
+        ],
+      },
+    });
+    expect(policy.federated?.networks).toHaveLength(2);
+  });
+
+  test("F-3a: two networks sharing a leaf_node where one omits nats: parse (rides the defined link)", () => {
+    const policy = PolicySchema.parse({
+      federated: {
+        networks: [
+          {
+            id: "net-a", leaf_node: "shared-leaf", peers: [],
+            accept_subjects: [], deny_subjects: [],
+            announce_capabilities: [], max_hop: 0,
+            nats: { url: "nats://shared:4222" },
+          },
+          {
+            id: "net-b", leaf_node: "shared-leaf", peers: [],
+            accept_subjects: [], deny_subjects: [],
+            announce_capabilities: [], max_hop: 0,
+            // No nats: — rides the link net-a defined for this leaf_node.
+          },
+        ],
+      },
+    });
+    expect(policy.federated?.networks).toHaveLength(2);
+  });
+
+  test("F-3a: two networks sharing a leaf_node with MISMATCHED nats: fail loudly", () => {
+    expect(() =>
+      PolicySchema.parse({
+        federated: {
+          networks: [
+            {
+              id: "net-a", leaf_node: "shared-leaf", peers: [],
+              accept_subjects: [], deny_subjects: [],
+              announce_capabilities: [], max_hop: 0,
+              nats: { url: "nats://shared:4222" },
+            },
+            {
+              id: "net-b", leaf_node: "shared-leaf", peers: [],
+              accept_subjects: [], deny_subjects: [],
+              announce_capabilities: [], max_hop: 0,
+              // Different url on the SAME leaf_node — one leaf can't be
+              // two connections.
+              nats: { url: "nats://other:4222" },
+            },
+          ],
+        },
+      }),
+    ).toThrow(/conflicts with the one at federated\.networks\[0\].*consistent/s);
+  });
+
+  test("F-3a: mismatched credsPath on a shared leaf_node also fails", () => {
+    expect(() =>
+      PolicySchema.parse({
+        federated: {
+          networks: [
+            {
+              id: "net-a", leaf_node: "shared-leaf", peers: [],
+              accept_subjects: [], deny_subjects: [],
+              announce_capabilities: [], max_hop: 0,
+              nats: { url: "nats://shared:4222", credsPath: "~/creds/a.creds" },
+            },
+            {
+              id: "net-b", leaf_node: "shared-leaf", peers: [],
+              accept_subjects: [], deny_subjects: [],
+              announce_capabilities: [], max_hop: 0,
+              nats: { url: "nats://shared:4222", credsPath: "~/creds/b.creds" },
+            },
+          ],
+        },
+      }),
+    ).toThrow(/conflicts with the one at federated\.networks\[0\]/);
+  });
+
+  test("F-3a: DIFFERENT leaf_node names with different nats: blocks are independent (no conflict)", () => {
+    const policy = PolicySchema.parse({
+      federated: {
+        networks: [
+          {
+            id: "net-a", leaf_node: "leaf-a", peers: [],
+            accept_subjects: [], deny_subjects: [],
+            announce_capabilities: [], max_hop: 0,
+            nats: { url: "nats://a:4222" },
+          },
+          {
+            id: "net-b", leaf_node: "leaf-b", peers: [],
+            accept_subjects: [], deny_subjects: [],
+            announce_capabilities: [], max_hop: 0,
+            nats: { url: "nats://b:4222" },
+          },
+        ],
+      },
+    });
+    expect(policy.federated?.networks).toHaveLength(2);
+  });
 });
 
 describe("PolicyFederatedPeerSchema — R2.G operator→principal v4.0.0 BREAKING CUT (cortex#436)", () => {

--- a/src/common/types/cortex-config.ts
+++ b/src/common/types/cortex-config.ts
@@ -1432,6 +1432,61 @@ export type PolicyFederatedPeer = z.infer<typeof PolicyFederatedPeerSchema>;
 const NATS_SUBJECT_PATTERN_RE = /^([a-z][a-z0-9_-]*|\*)(\.([a-z][a-z0-9_-]*|\*))*(\.>)?$/;
 
 /**
+ * Per-network leaf-node connection — IAW Phase F-3a (cortex#657),
+ * Option B from `docs/design-multi-network.md` §2 (OD-F3-1, RATIFIED).
+ *
+ * A network may declare its own dedicated NATS leaf connection inline.
+ * This is a **subset** of the top-level `NatsConfigSchema` shape
+ * (`cortex-config.ts:870`) — only the connection-shaping fields, mirrored
+ * 1:1: `{ url, credsPath?, name? }`. Deliberately dropped vs the top-level
+ * schema:
+ *
+ *   - `subjects` — a per-network link's subscribe set derives from the
+ *     network's `accept_subjects`, not a standalone subjects list.
+ *   - `token` — bearer-token auth is discouraged for federated leaves
+ *     (creds-file auth is the path); add as a follow-up if a deployment
+ *     genuinely needs it.
+ *   - `identity` / `accountSigningKeyPath` — one stack identity signs
+ *     every link in F-3 (per-link signing keys are deferred — design §3.5).
+ *
+ * **Back-compat:** the field is OPTIONAL on the network. When absent, the
+ * network has no dedicated leaf and rides the primary link (`config.nats`)
+ * — exactly today's Phase D "one leaf at a time" behaviour. Zero
+ * per-network `nats:` blocks ⇒ today's single-link runtime, byte-for-byte.
+ *
+ * The LinkPool that consumes this lands in F-3b (cortex#658); F-3a is the
+ * schema + the `leaf_node`-consistency cross-validator only.
+ */
+export const PolicyFederatedNetworkNatsSchema = z.object({
+  /**
+   * Leaf-node connection URL. Same grammar as `NatsConfigSchema.url`:
+   * MUST start with `nats://` or `tls://`. Mirrored verbatim so the
+   * loader and `NatsLink.connect` treat a per-network URL identically
+   * to the primary one.
+   */
+  url: z.string().min(1).refine(
+    (s) => s.startsWith("nats://") || s.startsWith("tls://"),
+    { message: "network.nats.url must start with nats:// or tls://" },
+  ),
+  /**
+   * Connection name surfaced on the leaf server's varz endpoint.
+   * Defaults to `cortex` (same default as `NatsConfigSchema.name`) so a
+   * per-network leaf is identifiable when set, and harmless when omitted.
+   */
+  name: z.string().default("cortex"),
+  /**
+   * Path to a NATS user `.creds` file for this leaf's connect-time auth.
+   * Same semantics as `NatsConfigSchema.credsPath`: leading `~/` expands
+   * to `$HOME`; chmod-600 enforcement + file read happen in the
+   * `NatsLink` loader, not at schema time. Optional — a leaf may be
+   * anonymous in a test rig.
+   */
+  credsPath: z.string().optional(),
+}).strict();
+
+export type PolicyFederatedNetworkNats = z.infer<typeof PolicyFederatedNetworkNatsSchema>;
+
+/**
  * A single federation network — IAW Phase D.1 (cortex#116).
  *
  * Networks are the unit of federation policy in cortex per Q4
@@ -1440,6 +1495,14 @@ const NATS_SUBJECT_PATTERN_RE = /^([a-z][a-z0-9_-]*|\*)(\.([a-z][a-z0-9_-]*|\*))
  * budget. Multi-link transport (one MyelinRuntime per network)
  * lands in Phase E; Phase D operates one network's leaf-node at a
  * time, named via `leaf_node`.
+ *
+ * IAW Phase F-3a (cortex#657) the schema extends with an OPTIONAL
+ * per-network `nats:` block (Option B, `docs/design-multi-network.md`
+ * §2) — when present, the network has its own dedicated leaf
+ * connection; when absent, it rides the primary link (today's
+ * behaviour). The `leaf_node` name is the de-dup / pool key: two
+ * networks sharing a `leaf_node` share one physical link and so MUST
+ * declare consistent `nats:` blocks (cross-validated below).
  */
 export const PolicyFederatedNetworkSchema = z.object({
   /**
@@ -1526,6 +1589,20 @@ export const PolicyFederatedNetworkSchema = z.object({
    * Echo cortex#223 round 2.
    */
   max_hop: z.number().int().min(0),
+  /**
+   * IAW Phase F-3a (cortex#657) — OPTIONAL inline leaf-node connection
+   * (Option B, `docs/design-multi-network.md` §2). When present, this
+   * network rides its own dedicated NATS leaf; when absent, it rides the
+   * primary link (`config.nats`) — today's Phase D behaviour, byte-for-byte.
+   *
+   * The `leaf_node` field above is the pool key: two networks declaring
+   * the same `leaf_node` share one physical link, so their `nats:` blocks
+   * MUST be consistent — at most one declares the block and the rest omit
+   * it, or every declaration is byte-identical. Conflicting `nats:` under
+   * a shared `leaf_node` fails load loudly (cross-validated in
+   * `PolicySchema.superRefine`).
+   */
+  nats: PolicyFederatedNetworkNatsSchema.optional(),
 });
 
 export type PolicyFederatedNetwork = z.infer<typeof PolicyFederatedNetworkSchema>;
@@ -1718,6 +1795,18 @@ export const PolicySchema = z.object({
   if (policy.federated !== undefined) {
     // Uniqueness — networks[].id.
     const seenNetwork = new Map<string, number>();
+    // IAW Phase F-3a (cortex#657) — `leaf_node` is the link-pool de-dup
+    // key. Two networks sharing a `leaf_node` name share one physical
+    // NATS link, so their inline `nats:` blocks MUST agree on the
+    // connection. We remember the FIRST network that declared a `nats:`
+    // block for a given `leaf_node` (its index + the block), then assert
+    // every later network on the same `leaf_node` either omits `nats:`
+    // or declares a byte-identical block. A mismatch is a config error:
+    // one leaf cannot be two connections.
+    const leafNats = new Map<
+      string,
+      { networkIdx: number; nats: PolicyFederatedNetworkNats }
+    >();
     policy.federated.networks.forEach((n, networkIdx) => {
       const dupAt = seenNetwork.get(n.id);
       if (dupAt !== undefined) {
@@ -1754,6 +1843,30 @@ export const PolicySchema = z.object({
       };
       validateSubjectScope(n.accept_subjects, "accept_subjects");
       validateSubjectScope(n.deny_subjects, "deny_subjects");
+
+      // IAW Phase F-3a (cortex#657) — `leaf_node` connection consistency.
+      // Networks sharing a `leaf_node` share one physical link, so an
+      // inline `nats:` block here must not contradict an earlier network's
+      // block on the same `leaf_node`. The first declaration wins as the
+      // canonical connection; a later mismatched one is the offender. A
+      // later network that omits `nats:` (or re-declares an identical one)
+      // is fine — it just rides the already-defined link.
+      if (n.nats !== undefined) {
+        const prior = leafNats.get(n.leaf_node);
+        if (prior === undefined) {
+          leafNats.set(n.leaf_node, { networkIdx, nats: n.nats });
+        } else if (
+          prior.nats.url !== n.nats.url ||
+          prior.nats.name !== n.nats.name ||
+          prior.nats.credsPath !== n.nats.credsPath
+        ) {
+          ctx.addIssue({
+            code: "custom",
+            message: `network "${n.id}" declares a nats: block for leaf_node "${n.leaf_node}" that conflicts with the one at federated.networks[${prior.networkIdx}] — networks sharing a leaf_node share one physical link and MUST declare consistent (byte-identical) nats: connections, or omit nats: on all but one`,
+            path: ["federated", "networks", networkIdx, "nats"],
+          });
+        }
+      }
 
       // Per-network peer cross-validation.
       const seenPeerStack = new Map<string, number>();


### PR DESCRIPTION
## What

First slice of **F-3 multi-network** (design: `docs/design-multi-network.md`). Implements **OD-F3-1 (ratified): Option B** — a federated network configures its leaf node as an **inline `nats:` block per network**, not a separate `leaf_nodes:` table. `leaf_node` is the de-dup / link-pool key.

- Adds an **OPTIONAL `nats:` block** to `PolicyFederatedNetworkSchema`, mirroring a subset of `NatsConfigSchema` 1:1 — `{ url (nats://|tls://), credsPath?, name? }`. Dropped vs the top-level schema (per design §4 rule 1): `token` (creds-auth is the path for federated leaves), `subjects` (per-network subscribe derives from `accept_subjects`), `identity` / `accountSigningKeyPath` (one stack identity signs all links in F-3 — per-link keys deferred, §3.5). The block is `.strict()` so a stray dropped key fails loudly rather than being silently ignored.
- Adds a **`leaf_node`-consistency cross-validator** in the existing `PolicySchema.superRefine`: networks sharing a `leaf_node` name share one physical link, so their `nats:` blocks MUST be byte-identical (or omitted on all but one). A conflicting `nats:` under a shared `leaf_node` fails config-load loudly, in the existing per-offender `ctx.addIssue` style.
- Documents the field + a commented federation example in `cortex.yaml.example`.

## Back-compat

Additive. A network with **no `nats:` block** has no dedicated leaf — it rides the primary link (`config.nats`), exactly today's Phase D behaviour. **Zero per-network `nats:` blocks ⇒ today's single-link runtime, byte-for-byte.** The `LinkPool` that consumes the block lands in **F-3b (LinkPool slice, tracked separately)**; this slice is schema + validator + tests only.

## Verification

- `bunx tsc --noEmit` — clean (exit 0)
- `bun run lint:errors` — clean
- `bun test` on config/types + policy-factory + loader suites — **322 pass / 0 fail** (143 config+factory, 179 loader+policy)
- New tests cover: (a) inline `nats:` parses; (b) absent `nats:` → unchanged (no leaf); (c) two networks same `leaf_node` consistent → ok; (d) two networks same `leaf_node` mismatched → loud error; plus url-scheme enforcement, strict-key rejection (token), one-omits-on-shared-leaf, and distinct-leaf-name independence.

Part of #631 / #627.

Closes #657

🤖 Generated with [Claude Code](https://claude.com/claude-code)
