### PR TITLE
feat(bus): F-3b — LinkPool core: per-network leaf links + subject-routed publish (closes #659)

### DIFF
--- a/src/bus/myelin/__tests__/runtime-linkpool.test.ts
+++ b/src/bus/myelin/__tests__/runtime-linkpool.test.ts
@@ -459,6 +459,62 @@ describe("MyelinRuntime LinkPool (F-3b, cortex#659)", () => {
     await runtime.stop();
   });
 
+  // (f) KNOWN EMIT-SITE ASYMMETRY PIN (cortex#661). `deriveNatsSubject`
+  //     emits `federated.{principal}.{stack}.{type}` — segment[1] is the
+  //     PRINCIPAL, whereas selectLink (per design §3.2) keys segment[1] as
+  //     the network_id. This test PINS the current behaviour of the derive
+  //     path (`runtime.publish`, NOT publishOnSubject) for a federated
+  //     envelope WHILE a leaf link exists: segment[1] = the source principal
+  //     ("metafactory"), which matches no network id ("research-collab"), so
+  //     the publish hits the unknown-network skip and is DROPPED. This is the
+  //     documented seam deferred to F-3c/E.2 — the fix lands at the EMIT
+  //     site (cortex#661), not in selectLink. When that fix lands this test
+  //     is expected to CHANGE (the federated envelope should land on the
+  //     leaf); until then it guards against silent drift in the routing path.
+  test("(f) KNOWN SEAM (cortex#661): runtime.publish() of a federated envelope WITH a leaf present hits the unknown-network skip (emit-site asymmetry, deferred to F-3c)", async () => {
+    const reg = makeFakeRegistry();
+    const routingErrors: RoutingError[] = [];
+    const networks = [
+      makeNetwork({
+        id: "research-collab",
+        leaf_node: "nats-leaf-research",
+        nats: { url: RESEARCH_URL, name: "cortex" },
+      }),
+    ];
+    const runtime = await startMyelinRuntime(
+      makeConfig({ url: PRIMARY_URL, name: "cortex", subjects: [] }),
+      {
+        connectImpl: reg.connectImpl,
+        federatedNetworks: networks,
+        stack: "default",
+        onRoutingError: (info) => routingErrors.push(info),
+      },
+    );
+    const primary = reg.forUrl(PRIMARY_URL)!;
+    const research = reg.forUrl(RESEARCH_URL)!;
+
+    // DERIVE path: source principal = "metafactory" → derived subject is
+    // `federated.metafactory.default.<type>` (segment[1] = principal).
+    await runtime.publish(
+      makeEnvelope({ classification: "federated", id: "seam-661-id" }),
+    );
+
+    // selectLink reads segment[1]="metafactory", finds no network with
+    // id==="metafactory" → unknown-network skip. Nothing published anywhere.
+    expect(routingErrors).toEqual([
+      {
+        reason: "unknown_network_in_publish_subject",
+        subject: "federated.metafactory.default.system.adapter.degraded",
+        networkId: "metafactory",
+        envelopeId: "seam-661-id",
+      },
+    ]);
+    expect(primary.publishes).toEqual([]);
+    expect(research.publishes).toEqual([]);
+
+    await runtime.stop();
+  });
+
   // (+) stop() drains + closes ALL pool links.
   test("(+) stop() drains and closes every pool link", async () => {
     const reg = makeFakeRegistry();

--- a/src/bus/myelin/__tests__/runtime-linkpool.test.ts
+++ b/src/bus/myelin/__tests__/runtime-linkpool.test.ts
@@ -1,0 +1,548 @@
+/**
+ * F-3b (cortex#659): MyelinRuntime LinkPool tests.
+ *
+ * The runtime backs EVERY publish/subscribe, so the back-compat invariant
+ * is load-bearing: with ZERO per-network `nats:` configured, the pool has
+ * ONLY the primary link and behaviour is byte-identical to the pre-F-3b
+ * single-link runtime. These tests cover the design (`docs/design-multi-
+ * network.md` §7) matrix:
+ *
+ *   (a) zero networks → single primary link, publishes route to primary
+ *       (back-compat proof).
+ *   (b) a `federated.{net}.*` publish routes to that net's leaf link
+ *       (per-link publish capture).
+ *   (c) `local.*` / `public.*` always → primary even with leaves present.
+ *   (d) `federated.{unknown}.*` → routing error + NO publish.
+ *   (e) per-link dedupe (the cortex#491 `boundByPattern` is per-link).
+ *   (+) negative leakage (§5 cardinal): `federated.{B}.*` never on link A.
+ *   (+) `stop()` drains + closes ALL pool links.
+ *
+ * Uses the `MyelinRuntimeOptions.connectImpl` fake-link seam — no real
+ * `nats-server`. A PER-URL fake registry lets each test assert WHICH link
+ * saw WHICH publish: `connectImpl` receives `ConnectionOptions.servers[0]`
+ * (the url), so the fake routes by url to a distinct recording connection.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import type {
+  ConnectionOptions,
+  NatsConnection,
+  Status,
+  Subscription,
+} from "nats";
+import type { AgentConfig } from "../../../common/types/config";
+import type { PolicyFederatedNetwork } from "../../../common/types/cortex-config";
+import { startMyelinRuntime, type RoutingError } from "../runtime";
+
+function makeConfig(natsBlock: AgentConfig["nats"]): AgentConfig {
+  return {
+    agent: { name: "luna", displayName: "Luna" },
+    nats: natsBlock,
+  } as unknown as AgentConfig;
+}
+
+/** One fake NATS connection that records its own publishes + subscribes. */
+function makeFakeConn() {
+  const statusListeners = new Set<(s: Status | null) => void>();
+  const subscribePatterns: string[] = [];
+  const publishes: { subject: string; payload: string | Uint8Array }[] = [];
+
+  const status = () =>
+    (async function* () {
+      const queue: (Status | null)[] = [];
+      let waiter: ((s: Status | null) => void) | null = null;
+      const listener = (s: Status | null) => {
+        if (waiter) {
+          const w = waiter;
+          waiter = null;
+          w(s);
+        } else {
+          queue.push(s);
+        }
+      };
+      statusListeners.add(listener);
+      try {
+        while (true) {
+          if (queue.length > 0) {
+            const next = queue.shift()!;
+            if (next === null) return;
+            yield next;
+            continue;
+          }
+          const next = await new Promise<Status | null>((r) => (waiter = r));
+          if (next === null) return;
+          yield next;
+        }
+      } finally {
+        statusListeners.delete(listener);
+      }
+    })();
+
+  const subscribe = mock((pattern: string) => {
+    subscribePatterns.push(pattern);
+    let iteratorResolve: (() => void) | null = null;
+    const iteratorDone = new Promise<void>((r) => {
+      iteratorResolve = r;
+    });
+    // eslint-disable-next-line require-yield
+    const iterator = (async function* () {
+      await iteratorDone;
+    })();
+    return {
+      [Symbol.asyncIterator]: () => iterator,
+      drain: mock(async () => {
+        iteratorResolve?.();
+      }),
+      closed: Promise.resolve(),
+    } as unknown as Subscription;
+  });
+
+  const drain = mock(async () => {
+    for (const l of statusListeners) l(null);
+  });
+
+  const publish = mock((subject: string, payload: string | Uint8Array) => {
+    publishes.push({ subject, payload });
+  });
+
+  const nc = { status, subscribe, drain, publish } as unknown as NatsConnection;
+  return { nc, subscribe, subscribePatterns, publishes, publish, drain };
+}
+
+/**
+ * A per-URL fake registry. `connectImpl` branches on the connect url so
+ * each physical link gets its own recording connection — the test then
+ * asserts which url (i.e. which link) saw which publish.
+ */
+function makeFakeRegistry() {
+  const byUrl = new Map<string, ReturnType<typeof makeFakeConn>>();
+  const connectImpl = async (opts: ConnectionOptions): Promise<NatsConnection> => {
+    const url = (opts.servers as string[])[0] ?? "<no-url>";
+    let conn = byUrl.get(url);
+    if (!conn) {
+      conn = makeFakeConn();
+      byUrl.set(url, conn);
+    }
+    return conn.nc;
+  };
+  return {
+    connectImpl,
+    /** Fetch the recording connection for a url (created on connect). */
+    forUrl: (url: string) => byUrl.get(url),
+    byUrl,
+  };
+}
+
+const PRIMARY_URL = "nats://localhost:4222";
+const RESEARCH_URL = "nats://research:4222";
+const JV_URL = "nats://jv:4222";
+
+/** Minimal valid `PolicyFederatedNetwork` fixture. */
+function makeNetwork(
+  overrides: Partial<PolicyFederatedNetwork>,
+): PolicyFederatedNetwork {
+  return {
+    id: "research-collab",
+    leaf_node: "nats-leaf-research",
+    peers: [],
+    accept_subjects: [],
+    deny_subjects: [],
+    announce_capabilities: [],
+    max_hop: 0,
+    ...overrides,
+  };
+}
+
+/** Federated envelope whose derived subject we control via an explicit publishOnSubject. */
+function makeEnvelope(
+  overrides: Partial<{ id: string; type: string; classification: string }> = {},
+) {
+  return {
+    id: overrides.id ?? "11111111-1111-4111-8111-111111111111",
+    source: "metafactory.grove.local",
+    type: overrides.type ?? "system.adapter.degraded",
+    timestamp: "2026-06-04T12:00:00.000Z",
+    sovereignty: {
+      classification: (overrides.classification ?? "local") as
+        | "local"
+        | "federated"
+        | "public",
+      data_residency: "NZ",
+      max_hop: 0,
+      frontier_ok: true,
+      model_class: "any" as const,
+    },
+    payload: { adapter_id: "discord-luna" },
+  };
+}
+
+describe("MyelinRuntime LinkPool (F-3b, cortex#659)", () => {
+  let logs: { kind: "log" | "info" | "warn" | "error"; msg: string }[];
+  let restore: () => void;
+
+  beforeEach(() => {
+    logs = [];
+    const o = {
+      log: console.log,
+      info: console.info,
+      warn: console.warn,
+      error: console.error,
+    };
+    console.log = (...a: unknown[]) => logs.push({ kind: "log", msg: a.map(String).join(" ") });
+    console.info = (...a: unknown[]) => logs.push({ kind: "info", msg: a.map(String).join(" ") });
+    console.warn = (...a: unknown[]) => logs.push({ kind: "warn", msg: a.map(String).join(" ") });
+    console.error = (...a: unknown[]) => logs.push({ kind: "error", msg: a.map(String).join(" ") });
+    restore = () => {
+      console.log = o.log;
+      console.info = o.info;
+      console.warn = o.warn;
+      console.error = o.error;
+    };
+  });
+  afterEach(() => restore());
+
+  // (a) BACK-COMPAT PROOF — zero per-network nats: ⇒ single primary link,
+  //     all publishes route to it, byte-identical to today.
+  test("(a) back-compat: zero federated networks ⇒ single primary link; all publishes route to primary", async () => {
+    const reg = makeFakeRegistry();
+    const runtime = await startMyelinRuntime(
+      makeConfig({ url: PRIMARY_URL, name: "cortex", subjects: ["local.{principal}.>"] }),
+      { connectImpl: reg.connectImpl, stack: "default" },
+      // NB: federatedNetworks omitted entirely.
+    );
+    expect(runtime.enabled).toBe(true);
+    // Exactly ONE physical link was opened.
+    expect(reg.byUrl.size).toBe(1);
+    const primary = reg.forUrl(PRIMARY_URL)!;
+    expect(primary).toBeDefined();
+
+    // local.* publish → primary, with the SAME subject the pre-F-3b runtime
+    // produced (`local.{principal-from-source}.{stack}.{type}`).
+    await runtime.publish(makeEnvelope({ type: "system.adapter.degraded" }));
+    expect(primary.publishes.map((p) => p.subject)).toEqual([
+      "local.metafactory.default.system.adapter.degraded",
+    ]);
+
+    // A federated envelope with NO leaf in the pool still rides primary —
+    // byte-identical to the single-link runtime (no routing error, no skip)
+    // because the primary-only pool has no separate federated routing.
+    await runtime.publish(
+      makeEnvelope({ classification: "federated", type: "system.adapter.degraded" }),
+    );
+    expect(primary.publishes.map((p) => p.subject)).toEqual([
+      "local.metafactory.default.system.adapter.degraded",
+      "federated.metafactory.default.system.adapter.degraded",
+    ]);
+    // No routing error was logged in the back-compat case.
+    expect(logs.some((l) => l.msg.includes("unknown_network_in_publish_subject"))).toBe(false);
+
+    await runtime.stop();
+  });
+
+  // (b) federated.{net}.* routes to that net's leaf link.
+  test("(b) federated.{net}.* publish routes to that network's leaf link", async () => {
+    const reg = makeFakeRegistry();
+    const networks = [
+      makeNetwork({
+        id: "research-collab",
+        leaf_node: "nats-leaf-research",
+        nats: { url: RESEARCH_URL, name: "cortex" },
+      }),
+    ];
+    const runtime = await startMyelinRuntime(
+      makeConfig({ url: PRIMARY_URL, name: "cortex", subjects: [] }),
+      { connectImpl: reg.connectImpl, federatedNetworks: networks },
+    );
+    expect(runtime.enabled).toBe(true);
+    // Two physical links: primary + the research leaf.
+    expect(reg.byUrl.size).toBe(2);
+    const primary = reg.forUrl(PRIMARY_URL)!;
+    const research = reg.forUrl(RESEARCH_URL)!;
+
+    await runtime.publishOnSubject!(
+      makeEnvelope({ classification: "federated" }),
+      "federated.research-collab.system.adapter.degraded",
+    );
+    // Landed on the research leaf ONLY.
+    expect(research.publishes.map((p) => p.subject)).toEqual([
+      "federated.research-collab.system.adapter.degraded",
+    ]);
+    expect(primary.publishes).toEqual([]);
+
+    await runtime.stop();
+  });
+
+  // (c) local.* / public.* always → primary even with leaves present.
+  test("(c) local.* and public.* always route to primary even with leaf links present", async () => {
+    const reg = makeFakeRegistry();
+    const networks = [
+      makeNetwork({
+        id: "research-collab",
+        leaf_node: "nats-leaf-research",
+        nats: { url: RESEARCH_URL, name: "cortex" },
+      }),
+    ];
+    const runtime = await startMyelinRuntime(
+      makeConfig({ url: PRIMARY_URL, name: "cortex", subjects: [] }),
+      { connectImpl: reg.connectImpl, federatedNetworks: networks },
+    );
+    const primary = reg.forUrl(PRIMARY_URL)!;
+    const research = reg.forUrl(RESEARCH_URL)!;
+
+    await runtime.publishOnSubject!(makeEnvelope(), "local.metafactory.system.x");
+    await runtime.publishOnSubject!(
+      makeEnvelope({ classification: "public" }),
+      "public.system.x",
+    );
+    expect(primary.publishes.map((p) => p.subject)).toEqual([
+      "local.metafactory.system.x",
+      "public.system.x",
+    ]);
+    // The leaf saw NONE of it.
+    expect(research.publishes).toEqual([]);
+
+    await runtime.stop();
+  });
+
+  // (d) federated.{unknown}.* → routing error + NO publish.
+  test("(d) federated.{unknown}.* emits routing error and does NOT publish (skip)", async () => {
+    const reg = makeFakeRegistry();
+    const routingErrors: RoutingError[] = [];
+    const networks = [
+      makeNetwork({
+        id: "research-collab",
+        leaf_node: "nats-leaf-research",
+        nats: { url: RESEARCH_URL, name: "cortex" },
+      }),
+    ];
+    const runtime = await startMyelinRuntime(
+      makeConfig({ url: PRIMARY_URL, name: "cortex", subjects: [] }),
+      {
+        connectImpl: reg.connectImpl,
+        federatedNetworks: networks,
+        onRoutingError: (info) => routingErrors.push(info),
+      },
+    );
+    const primary = reg.forUrl(PRIMARY_URL)!;
+    const research = reg.forUrl(RESEARCH_URL)!;
+
+    await runtime.publishOnSubject!(
+      makeEnvelope({ classification: "federated", id: "deadbeef-id" }),
+      "federated.no-such-net.system.x",
+    );
+
+    // Routing error fired with the canonical reason; NOTHING published.
+    expect(routingErrors).toEqual([
+      {
+        reason: "unknown_network_in_publish_subject",
+        subject: "federated.no-such-net.system.x",
+        networkId: "no-such-net",
+        envelopeId: "deadbeef-id",
+      },
+    ]);
+    expect(primary.publishes).toEqual([]);
+    expect(research.publishes).toEqual([]);
+
+    await runtime.stop();
+  });
+
+  // (+) NEGATIVE LEAKAGE (§5 cardinal): federated.{B}.* never on link A.
+  test("(+) negative leakage: a federated.{jv}.* publish never appears on the research leaf", async () => {
+    const reg = makeFakeRegistry();
+    const networks = [
+      makeNetwork({
+        id: "research-collab",
+        leaf_node: "nats-leaf-research",
+        nats: { url: RESEARCH_URL, name: "cortex" },
+      }),
+      makeNetwork({
+        id: "jv",
+        leaf_node: "nats-leaf-jv",
+        nats: { url: JV_URL, name: "cortex" },
+      }),
+    ];
+    const runtime = await startMyelinRuntime(
+      makeConfig({ url: PRIMARY_URL, name: "cortex", subjects: [] }),
+      { connectImpl: reg.connectImpl, federatedNetworks: networks },
+    );
+    expect(reg.byUrl.size).toBe(3); // primary + research + jv
+    const research = reg.forUrl(RESEARCH_URL)!;
+    const jv = reg.forUrl(JV_URL)!;
+
+    await runtime.publishOnSubject!(
+      makeEnvelope({ classification: "federated" }),
+      "federated.jv.system.x",
+    );
+    await runtime.publishOnSubject!(
+      makeEnvelope({ classification: "federated" }),
+      "federated.research-collab.system.y",
+    );
+
+    // jv traffic hit jv only; research traffic hit research only.
+    expect(jv.publishes.map((p) => p.subject)).toEqual(["federated.jv.system.x"]);
+    expect(research.publishes.map((p) => p.subject)).toEqual([
+      "federated.research-collab.system.y",
+    ]);
+    // CARDINAL: jv's subject never leaked onto the research leaf's wire.
+    expect(research.publishes.some((p) => p.subject.startsWith("federated.jv."))).toBe(false);
+
+    await runtime.stop();
+  });
+
+  // (+) two networks SHARING a leaf_node ⇒ ONE physical link (de-dup key).
+  test("(+) two networks sharing a leaf_node share one physical leaf link", async () => {
+    const reg = makeFakeRegistry();
+    const networks = [
+      makeNetwork({
+        id: "research-collab",
+        leaf_node: "shared-leaf",
+        nats: { url: RESEARCH_URL, name: "cortex" },
+      }),
+      makeNetwork({
+        id: "research-collab-2",
+        leaf_node: "shared-leaf",
+        // Second declaration omits nats: (rides the first's link) — the
+        // F-3a cross-validator guarantees consistency.
+      }),
+    ];
+    const runtime = await startMyelinRuntime(
+      makeConfig({ url: PRIMARY_URL, name: "cortex", subjects: [] }),
+      { connectImpl: reg.connectImpl, federatedNetworks: networks },
+    );
+    // primary + ONE shared leaf = 2 links (not 3).
+    expect(reg.byUrl.size).toBe(2);
+    const shared = reg.forUrl(RESEARCH_URL)!;
+
+    // Both network ids route to the SAME leaf.
+    await runtime.publishOnSubject!(
+      makeEnvelope({ classification: "federated" }),
+      "federated.research-collab.system.a",
+    );
+    await runtime.publishOnSubject!(
+      makeEnvelope({ classification: "federated" }),
+      "federated.research-collab-2.system.b",
+    );
+    expect(shared.publishes.map((p) => p.subject)).toEqual([
+      "federated.research-collab.system.a",
+      "federated.research-collab-2.system.b",
+    ]);
+
+    await runtime.stop();
+  });
+
+  // (e) per-link dedupe — the cortex#491 boundByPattern is per-link
+  //     (primary-bound in F-3b). A duplicate self-subscribe to a pattern a
+  //     boot subscriber already bound returns the SAME subscriber.
+  test("(e) per-link dedupe: duplicate primary subscribe returns the existing subscriber (no double-bind)", async () => {
+    const reg = makeFakeRegistry();
+    const runtime = await startMyelinRuntime(
+      makeConfig({
+        url: PRIMARY_URL,
+        name: "cortex",
+        subjects: ["local.metafactory.system.>"],
+      }),
+      { connectImpl: reg.connectImpl },
+    );
+    const primary = reg.forUrl(PRIMARY_URL)!;
+    // Boot subscribed once.
+    expect(primary.subscribePatterns).toEqual(["local.metafactory.system.>"]);
+
+    // Self-subscribe the SAME resolved pattern — must NOT create a second
+    // NATS subscription (dedupe via the primary link's boundByPattern).
+    const sub = await runtime.subscribe!("local.metafactory.system.>");
+    expect(sub).not.toBeNull();
+    expect(primary.subscribePatterns).toEqual(["local.metafactory.system.>"]);
+    expect(
+      logs.some((l) => l.msg.includes("skipping duplicate subscribe")),
+    ).toBe(true);
+
+    await runtime.stop();
+  });
+
+  // (+) stop() drains + closes ALL pool links.
+  test("(+) stop() drains and closes every pool link", async () => {
+    const reg = makeFakeRegistry();
+    const networks = [
+      makeNetwork({
+        id: "research-collab",
+        leaf_node: "nats-leaf-research",
+        nats: { url: RESEARCH_URL, name: "cortex" },
+      }),
+      makeNetwork({
+        id: "jv",
+        leaf_node: "nats-leaf-jv",
+        nats: { url: JV_URL, name: "cortex" },
+      }),
+    ];
+    const runtime = await startMyelinRuntime(
+      makeConfig({ url: PRIMARY_URL, name: "cortex", subjects: [] }),
+      { connectImpl: reg.connectImpl, federatedNetworks: networks },
+    );
+    const primary = reg.forUrl(PRIMARY_URL)!;
+    const research = reg.forUrl(RESEARCH_URL)!;
+    const jv = reg.forUrl(JV_URL)!;
+
+    await runtime.stop();
+
+    // Each link's underlying connection was drained on close().
+    expect(primary.drain).toHaveBeenCalled();
+    expect(research.drain).toHaveBeenCalled();
+    expect(jv.drain).toHaveBeenCalled();
+  });
+
+  // (+) a leaf that fails to connect at boot does NOT take the runtime down
+  //     (degrade-don't-crash seam — full lifecycle is F-3c). Its network's
+  //     publishes then resolve to the unknown-network skip.
+  test("(+) leaf connect failure degrades (runtime stays enabled on primary); that network's publishes skip", async () => {
+    const routingErrors: RoutingError[] = [];
+    // A registry whose JV url throws on connect, but primary + research succeed.
+    const byUrl = new Map<string, ReturnType<typeof makeFakeConn>>();
+    const connectImpl = async (opts: ConnectionOptions): Promise<NatsConnection> => {
+      const url = (opts.servers as string[])[0] ?? "";
+      if (url === JV_URL) throw new Error("leaf down");
+      let conn = byUrl.get(url);
+      if (!conn) {
+        conn = makeFakeConn();
+        byUrl.set(url, conn);
+      }
+      return conn.nc;
+    };
+    const networks = [
+      makeNetwork({
+        id: "research-collab",
+        leaf_node: "nats-leaf-research",
+        nats: { url: RESEARCH_URL, name: "cortex" },
+      }),
+      makeNetwork({
+        id: "jv",
+        leaf_node: "nats-leaf-jv",
+        nats: { url: JV_URL, name: "cortex" },
+      }),
+    ];
+    const runtime = await startMyelinRuntime(
+      makeConfig({ url: PRIMARY_URL, name: "cortex", subjects: [] }),
+      { connectImpl, federatedNetworks: networks, onRoutingError: (i) => routingErrors.push(i) },
+    );
+    // Primary up ⇒ runtime enabled despite the dead jv leaf.
+    expect(runtime.enabled).toBe(true);
+    expect(logs.some((l) => l.kind === "error" && l.msg.includes("nats-leaf-jv"))).toBe(true);
+
+    const research = byUrl.get(RESEARCH_URL)!;
+    // research traffic still routes fine.
+    await runtime.publishOnSubject!(
+      makeEnvelope({ classification: "federated" }),
+      "federated.research-collab.system.a",
+    );
+    expect(research.publishes.map((p) => p.subject)).toEqual([
+      "federated.research-collab.system.a",
+    ]);
+    // jv traffic skips (its leaf never made it into the pool).
+    await runtime.publishOnSubject!(
+      makeEnvelope({ classification: "federated" }),
+      "federated.jv.system.b",
+    );
+    expect(routingErrors.map((e) => e.networkId)).toEqual(["jv"]);
+
+    await runtime.stop();
+  });
+});

--- a/src/bus/myelin/runtime.ts
+++ b/src/bus/myelin/runtime.ts
@@ -890,20 +890,40 @@ export async function startMyelinRuntime(
    * publish" (the only `null` case today is an unknown federated network,
    * which also fires `onRoutingError`). `{network_id}` is the subject's
    * SECOND segment — the same grammar the inbound surface-router federation
-   * gate already keys off (`evaluateFederationGate`, `surface-router.ts`),
-   * so publish/subscribe routing agree on what a federated subject's
-   * network segment is.
+   * gate already keys off (`evaluateFederationGate`, `surface-router.ts`)
+   * and the design (`docs/design-multi-network.md` §3.2) mandates, so
+   * publish/subscribe routing agree on what a federated subject's network
+   * segment is.
    *
-   * BACK-COMPAT: with zero leaf links (no per-network `nats:`),
-   * `networkIdToLinkId` is empty or maps every network to `'primary'`, so
-   * even a `federated.*` subject whose segment[1] matches a configured
-   * network resolves to `primary` — and a `federated.*` subject for an
-   * UN-configured segment was already not separately routable pre-F-3b
-   * (it just published on the single link). To preserve that exact
-   * behaviour, the unknown-network skip ONLY engages when there is at
-   * least one leaf link in the pool; with a primary-only pool every
-   * subject (including stray `federated.*`) routes to primary, byte-for-
-   * byte as today.
+   * KNOWN EMIT-SITE ASYMMETRY (cortex#661, deferred to F-3c/E.2 — NOT a
+   * back-compat hazard). `deriveNatsSubject` currently emits federated
+   * subjects as `federated.{principal}.{stack}.{type}` — segment[1] is the
+   * PRINCIPAL, not the network_id this function (correctly, per §3.2) keys
+   * off. Consequence: a REAL federated publish routed through the derive
+   * path (`runtime.publish` with `classification: "federated"`) WHILE a leaf
+   * link exists resolves segment[1]=`{principal}` and — unless a network is
+   * coincidentally named after the principal — hits the unknown-network skip
+   * and is DROPPED (or mis-routes on that coincidence). This is harmless
+   * today only because (1) the zero-leaf back-compat case short-circuits to
+   * primary below before any segment is read, and (2) F-3b scopes the
+   * federated emit/relay enablement (E.2/E.3/E.7) OUT — no production site
+   * emits a `classification: "federated"` envelope through the derive path
+   * with a leaf present yet. The fix lands at the EMIT site under cortex#661,
+   * not here: `selectLink` already implements the design grammar. The
+   * regression test `(f)` in `runtime-linkpool.test.ts` PINS this current
+   * derive-path-with-leaf behaviour so the seam is explicit, not silent.
+   *
+   * BACK-COMPAT (the load-bearing zero-leaf invariant): with zero leaf
+   * links (no per-network `nats:`) the pool is primary-only, so the
+   * `pool.size === 1` short-circuit below returns `primary` for EVERY
+   * subject — including any stray `federated.*` — WITHOUT reading
+   * segment[1] at all. The unknown-network skip is therefore a
+   * multi-link-ONLY concept and never engages in the zero-leaf case; a
+   * `federated.*` subject for an un-configured segment was already not
+   * separately routable pre-F-3b (it just published on the single link),
+   * and that is preserved byte-for-byte. NOTE this short-circuit is also
+   * what makes the cortex#661 emit-site asymmetry above invisible today —
+   * it only surfaces once a leaf link exists.
    */
   const selectLink = (subject: string, envelopeId: string): PoolLink | null => {
     // Non-federated subjects (`local.*`, `public.*`, and anything that

--- a/src/bus/myelin/runtime.ts
+++ b/src/bus/myelin/runtime.ts
@@ -15,6 +15,7 @@
 
 import type { ConnectionOptions, NatsConnection } from "nats";
 import type { AgentConfig } from "../../common/types/config";
+import type { PolicyFederatedNetwork } from "../../common/types/cortex-config";
 import { NatsLink } from "../nats/connection";
 import {
   MyelinSubscriber,
@@ -332,6 +333,57 @@ export interface MyelinRuntimeOptions {
    * runtime no-op semantics.
    */
   principal?: string;
+  /**
+   * IAW Phase F-3b (cortex#659) — the federation networks the runtime
+   * builds its `LinkPool` from. Sourced from `policy.federated.networks[]`
+   * (which already flows through `cortex.ts` boot, separate from the
+   * `AgentConfig` this function takes). Each network that declares an
+   * inline `nats:` block (F-3a, Option B — `docs/design-multi-network.md`
+   * §2) contributes one leaf `NatsLink`, keyed by `leaf_node` (the pool /
+   * de-dup key: two networks sharing a `leaf_node` share one physical
+   * link). Networks WITHOUT a `nats:` block ride the `primary` link.
+   *
+   * **Back-compat:** when undefined or empty — or when no network declares
+   * a `nats:` block — the pool contains ONLY the `primary` link and every
+   * publish routes to it, byte-identical to the pre-F-3b single-link
+   * runtime. This is the load-bearing zero-network no-op invariant
+   * (design §3, §7.4).
+   */
+  federatedNetworks?: readonly PolicyFederatedNetwork[];
+  /**
+   * IAW Phase F-3b (cortex#659) — sink for publish-routing errors. The
+   * design (§3.2) calls for a `system.error`
+   * (`unknown_network_in_publish_subject`) + skip when a publish resolves
+   * to a `federated.{unknown}.*` subject (a network with no leaf in the
+   * pool). The runtime has no `SystemEventSource` wired and publishing a
+   * system envelope from inside the publish-routing path would itself need
+   * to route (back to `primary`) with a recursion hazard — so F-3b
+   * surfaces the signal through this structured callback (defaulting to a
+   * `console.error` with the canonical reason) rather than a typed bus
+   * envelope. A later slice (F-3c / inbound attribution, design §3.3/§8)
+   * can promote it to a real `system.error` audit envelope by wiring a
+   * source here. Tests use this seam to capture the routing error
+   * deterministically.
+   */
+  onRoutingError?: (info: RoutingError) => void;
+}
+
+/**
+ * IAW Phase F-3b (cortex#659) — structured publish-routing error surfaced
+ * via {@link MyelinRuntimeOptions.onRoutingError}. Today the only `reason`
+ * is `unknown_network_in_publish_subject` (a `federated.{network_id}.*`
+ * publish whose `{network_id}` has no link in the pool); the discriminated
+ * shape leaves room for additional routing failure modes without breaking
+ * the callback contract.
+ */
+export interface RoutingError {
+  reason: "unknown_network_in_publish_subject";
+  /** The resolved subject the publish targeted. */
+  subject: string;
+  /** The `{network_id}` segment that failed to resolve to a pool link. */
+  networkId: string;
+  /** The envelope id, for joinability with the audit/event stream. */
+  envelopeId: string;
 }
 
 /**
@@ -500,10 +552,30 @@ export async function startMyelinRuntime(
     );
   }
 
-  let link: NatsLink;
-  const safeUrl = nats.url.replace(/\/\/[^@/]+@/, "//***@");
+  // IAW Phase F-3b (cortex#659) — the LinkPool. A `PoolLink` bundles one
+  // `NatsLink` with its OWN subscriber set, `boundByPattern` dedupe map,
+  // and lazily-built `jsmCache`. Pre-F-3b these were module-singletons
+  // closed over the single `link`; the dedupe and JetStream-manager caching
+  // are per-physical-link (a double-bind is per-link; a JSM round-trip is
+  // per-connection), so they belong on the link, not the runtime.
+  interface PoolLink {
+    /** Pool key — `'primary'` for `config.nats`; `leaf_node` for a leaf. */
+    readonly linkId: string;
+    readonly link: NatsLink;
+    /** This link's own bound push subscriptions (cortex#491 dedupe is per-link). */
+    readonly subscribers: MyelinSubscriber[];
+    readonly boundByPattern: Map<string, MyelinSubscriber>;
+    /** Lazily-resolved JetStreamManager for this link (cortex#338). */
+    jsmCache: Promise<import("nats").JetStreamManager> | null;
+  }
+
+  const safeUrlOf = (url: string): string => url.replace(/\/\/[^@/]+@/, "//***@");
+
+  // The primary link backs `local.*` / `public.*` and every back-compat
+  // case (zero per-network `nats:` ⇒ this is the ONLY link in the pool).
+  let primary: PoolLink;
   try {
-    link = await NatsLink.connect({
+    const primaryLink = await NatsLink.connect({
       url: nats.url,
       token: nats.token,
       // cortex#86: operator-mode auth path. NatsLink loader expands ~/
@@ -513,10 +585,21 @@ export async function startMyelinRuntime(
       name: nats.name,
       ...(options?.connectImpl ? { connectImpl: options.connectImpl } : {}),
     });
+    primary = {
+      linkId: "primary",
+      link: primaryLink,
+      subscribers: [],
+      boundByPattern: new Map(),
+      jsmCache: null,
+    };
     console.log(
-      `myelin-runtime: connected to ${safeUrl} as "${nats.name}"`,
+      `myelin-runtime: connected to ${safeUrlOf(nats.url)} as "${nats.name}" (link=primary)`,
     );
   } catch (err) {
+    // Primary down ⇒ runtime disabled, exactly as the pre-F-3b single-link
+    // path. The primary link governs `enabled` (design §3.4, OD-F3-2):
+    // per-network leaf degradation is F-3c — F-3b keeps the primary-down
+    // contract identical so the back-compat case is byte-for-byte.
     console.error(
       "myelin-runtime: failed to connect — continuing without NATS:",
       err instanceof Error ? err.message : String(err),
@@ -532,7 +615,115 @@ export async function startMyelinRuntime(
     };
   }
 
-  const subscribers: MyelinSubscriber[] = [];
+  // The pool, keyed by `linkId`. `primary` is always present; leaf links
+  // are added below. `pool.get('primary')` is the back-compat default for
+  // every selection path.
+  const pool = new Map<string, PoolLink>();
+  pool.set(primary.linkId, primary);
+
+  // IAW Phase F-3b — build one leaf link per DISTINCT federated network
+  // `leaf_node` that declared an inline `nats:` block (F-3a, Option B). The
+  // `leaf_node` is the de-dup key: two networks sharing a `leaf_node` share
+  // ONE physical link (the F-3a cross-validator guarantees their `nats:`
+  // blocks are consistent, so the first declaration wins and the second is
+  // a no-op). Networks WITHOUT a `nats:` block contribute nothing here —
+  // they ride the primary link.
+  //
+  // `network_id → linkId` is the publish-routing resolution map, built once
+  // here (no per-message Map rebuild — design §3.2, mirrors
+  // `network-resolver.ts` cached-lookup discipline). A network whose
+  // `leaf_node` has no leaf link resolves to `'primary'` (rides primary),
+  // preserving the back-compat default.
+  //
+  // NAME-COLLISION (design §3.2): this keys off
+  // `options.federatedNetworks` (← `policy.federated.networks[]`), NEVER
+  // `config.networks[]` (the legacy grove Discord-guild → cloud-publish
+  // table owned by `network-resolver.ts`). The two must never cross.
+  const federatedNetworks = options?.federatedNetworks ?? [];
+
+  // PASS 1 — build one leaf link per DISTINCT `leaf_node` that some network
+  // declared a `nats:` block for. The first network with a given
+  // `leaf_node` defines the connection; later networks sharing it reuse the
+  // link (the F-3a cross-validator guarantees their `nats:` blocks agree,
+  // so we don't re-read them). A `leaf_node` whose construction throws is
+  // simply absent from the pool (the degrade-don't-crash seam below).
+  for (const network of federatedNetworks) {
+    if (network.nats === undefined) continue; // rides primary — resolved in PASS 2.
+    const leafId = network.leaf_node;
+    if (pool.has(leafId)) continue; // already built by an earlier sharing network.
+    try {
+      const leafLink = await NatsLink.connect({
+        url: network.nats.url,
+        ...(network.nats.credsPath ? { credsPath: network.nats.credsPath } : {}),
+        name: network.nats.name,
+        ...(options?.connectImpl ? { connectImpl: options.connectImpl } : {}),
+      });
+      pool.set(leafId, {
+        linkId: leafId,
+        link: leafLink,
+        subscribers: [],
+        boundByPattern: new Map(),
+        jsmCache: null,
+      });
+      console.log(
+        `myelin-runtime: connected to ${safeUrlOf(network.nats.url)} as "${network.nats.name}" (link=${leafId}, network=${network.id})`,
+      );
+    } catch (err) {
+      // F-3b SEAM → F-3c (design §3.4, OD-F3-2 "degrade, don't crash"):
+      // a per-network leaf being down at boot must NOT take the daemon
+      // down. F-3b constructs the leaf links and logs a leaf-construction
+      // failure here; the FULL degraded-boot lifecycle (mark-disabled +
+      // background nats.js retry + the OD-F3-2 boot-contract semantics) is
+      // F-3c. For F-3b the `leaf_node` whose construction failed simply has
+      // no pool entry, so PASS 2 leaves networks pointing at it UNMAPPED,
+      // and their publishes resolve to a `federated.{unknown}` routing
+      // error + skip (fail-closed: a dark network routes nothing). The
+      // primary link governs `enabled` and is unaffected.
+      console.error(
+        `myelin-runtime: failed to connect leaf "${leafId}" (network=${network.id}) at ${safeUrlOf(network.nats.url)} — that network is dark; primary unaffected (F-3c hardens this):`,
+        err instanceof Error ? err.message : String(err),
+      );
+    }
+  }
+
+  // PASS 2 — map each network id to its target `linkId`:
+  //   - its `leaf_node`, IF a leaf link for that `leaf_node` exists in the
+  //     pool (it declared `nats:`, OR a sibling sharing the `leaf_node`
+  //     did, and the connect succeeded);
+  //   - else `'primary'` (no `nats:` anywhere for this `leaf_node` ⇒ rides
+  //     primary, today's behaviour).
+  // A network whose `leaf_node` had a leaf that FAILED to connect is left
+  // UNMAPPED on purpose — `selectLink` then skips its publishes (dead
+  // network fails closed) rather than silently leaking onto primary.
+  const networkIdToLinkId = new Map<string, string>();
+  const leafNodeDeclaredNats = new Set<string>();
+  for (const network of federatedNetworks) {
+    if (network.nats !== undefined) leafNodeDeclaredNats.add(network.leaf_node);
+  }
+  for (const network of federatedNetworks) {
+    if (pool.has(network.leaf_node)) {
+      // Leaf link is live — route this network to it.
+      networkIdToLinkId.set(network.id, network.leaf_node);
+    } else if (leafNodeDeclaredNats.has(network.leaf_node)) {
+      // A `nats:` block WAS declared for this `leaf_node` but the leaf
+      // failed to connect — leave UNMAPPED so the network fails closed.
+      // (skip the set: `networkIdToLinkId.get(id)` returns undefined.)
+    } else {
+      // No `nats:` anywhere for this `leaf_node` — ride the primary link.
+      networkIdToLinkId.set(network.id, primary.linkId);
+    }
+  }
+
+  // Back-compat alias: every existing reference to the single `link` now
+  // targets the primary link's `NatsLink`. The subscribe/pull/jsm helpers
+  // below stay bound to `primary` (design §3.5 — `subscribePull` and the
+  // boot-time push subscribers are primary-only in F-3b; per-network
+  // subscribe is F-3d inbound attribution).
+  const link = primary.link;
+  // `subscribers` / `boundByPattern` for the boot-time push loop + the
+  // self-subscribe path are the PRIMARY link's (design §3.5). Leaf links
+  // carry their own empty sets (publish-only in F-3b).
+  const subscribers = primary.subscribers;
   // cortex#491 — idempotent push-subscribe per RESOLVED pattern. Core-NATS
   // push subscriptions are independent: if two subscribers bind to patterns
   // that both match a subject, the broker delivers the envelope to BOTH, and
@@ -557,7 +748,14 @@ export async function startMyelinRuntime(
   // so a config pattern that collides with a self-subscribe binds exactly
   // once: whichever path runs first creates the subscriber; the second
   // returns the SAME handle instead of double-binding.
-  const boundByPattern = new Map<string, MyelinSubscriber>();
+  //
+  // F-3b (cortex#659): the dedupe map is now PER-LINK — it lives on the
+  // primary `PoolLink` (`primary.boundByPattern`). Boot-time push
+  // subscribers + the `runtime.subscribe` self-subscribe path are
+  // primary-only in F-3b (design §3.5), so they share the primary link's
+  // map. Leaf links carry their own (empty) `boundByPattern` for when
+  // per-network subscribe lands (F-3d).
+  const boundByPattern = primary.boundByPattern;
   /**
    * Bind one resolved push pattern idempotently. Returns the already-bound
    * subscriber on a duplicate, or `null` if `MyelinSubscriber.start` threw.
@@ -617,9 +815,17 @@ export async function startMyelinRuntime(
   // is the new path; failed push subscribers are still treated as a
   // boot failure for that configuration shape.
   if (pushSubscribersConfigured && subscribers.length === 0) {
-    await link.close().catch(() => {
-      // best-effort close on no-subscribers path; ignore errors
-    });
+    // F-3b: close EVERY pool link on this disabled-fallback path, not just
+    // primary — leaf links opened above must not leak when the runtime
+    // collapses back to disabled. `allSettled` so one link's close error
+    // doesn't block another's.
+    await Promise.allSettled(
+      [...pool.values()].map((p) =>
+        p.link.close().catch(() => {
+          // best-effort close on no-subscribers path; ignore errors
+        }),
+      ),
+    );
     return {
       enabled: false,
       onEnvelope,
@@ -655,6 +861,93 @@ export async function startMyelinRuntime(
     ? Buffer.from(signer.rawSeedBytes).toString("base64")
     : undefined;
 
+  // IAW Phase F-3b (cortex#659) — the routing-error sink (design §3.2).
+  // Defaults to a structured `console.error` carrying the canonical
+  // `unknown_network_in_publish_subject` reason; a later slice can wire a
+  // real `system.error` audit envelope via `options.onRoutingError`.
+  const onRoutingError =
+    options?.onRoutingError ??
+    ((info: RoutingError) => {
+      console.error(
+        `myelin-runtime: ${info.reason} subject=${info.subject} network=${info.networkId} id=${info.envelopeId} — SKIPPING publish (no link in pool for this federated network)`,
+      );
+    });
+
+  /**
+   * IAW Phase F-3b (cortex#659) — PURE link selection from the RESOLVED
+   * subject (design §3.2). No global mutable routing state, no per-message
+   * Map rebuild: reads `network_id → linkId` (built once at boot) and the
+   * `pool`.
+   *
+   *   | resolved subject            | target link                         |
+   *   |-----------------------------|-------------------------------------|
+   *   | `local.…`                   | `primary`                           |
+   *   | `public.…`                  | `primary` (public mesh deferred §3.5)|
+   *   | `federated.{network_id}.…`  | the pool link owning `{network_id}` |
+   *   | `federated.{unknown}.…`     | none → routing error + skip         |
+   *
+   * Returns the selected `PoolLink`, or `null` to signal "skip the
+   * publish" (the only `null` case today is an unknown federated network,
+   * which also fires `onRoutingError`). `{network_id}` is the subject's
+   * SECOND segment — the same grammar the inbound surface-router federation
+   * gate already keys off (`evaluateFederationGate`, `surface-router.ts`),
+   * so publish/subscribe routing agree on what a federated subject's
+   * network segment is.
+   *
+   * BACK-COMPAT: with zero leaf links (no per-network `nats:`),
+   * `networkIdToLinkId` is empty or maps every network to `'primary'`, so
+   * even a `federated.*` subject whose segment[1] matches a configured
+   * network resolves to `primary` — and a `federated.*` subject for an
+   * UN-configured segment was already not separately routable pre-F-3b
+   * (it just published on the single link). To preserve that exact
+   * behaviour, the unknown-network skip ONLY engages when there is at
+   * least one leaf link in the pool; with a primary-only pool every
+   * subject (including stray `federated.*`) routes to primary, byte-for-
+   * byte as today.
+   */
+  const selectLink = (subject: string, envelopeId: string): PoolLink | null => {
+    // Non-federated subjects (`local.*`, `public.*`, and anything that
+    // isn't a federated subject) always go to primary.
+    if (!subject.startsWith("federated.")) {
+      return primary;
+    }
+    // Primary-only pool ⇒ federated traffic rides primary, exactly as the
+    // single-link runtime did pre-F-3b. No routing error in this case: the
+    // unknown-network skip is a multi-link-only concept.
+    if (pool.size === 1) {
+      return primary;
+    }
+    // `federated.{network_id}.…` — segment[1] is the network id.
+    const networkId = subject.split(".")[1];
+    if (networkId === undefined || networkId.length === 0) {
+      // Malformed `federated.` / `federated..…` — treat as unknown network.
+      onRoutingError({
+        reason: "unknown_network_in_publish_subject",
+        subject,
+        networkId: "<malformed>",
+        envelopeId,
+      });
+      return null;
+    }
+    const linkId = networkIdToLinkId.get(networkId);
+    const target = linkId === undefined ? undefined : pool.get(linkId);
+    if (target === undefined) {
+      // Unknown network (no such network id) OR a network whose declared
+      // leaf failed to connect at boot (left UNMAPPED in PASS 2) — both
+      // fail closed: signal + skip, NEVER leak onto primary. A network
+      // configured WITHOUT any `nats:` maps to `'primary'` and resolves
+      // here normally.
+      onRoutingError({
+        reason: "unknown_network_in_publish_subject",
+        subject,
+        networkId,
+        envelopeId,
+      });
+      return null;
+    }
+    return target;
+  };
+
   /**
    * Shared sign + wire-publish core. `publishEnabled` derives the
    * subject from `envelope.type` via `deriveNatsSubject`; the
@@ -662,6 +955,11 @@ export async function startMyelinRuntime(
    * subject built from `directTaskSubject`-style helpers. Both then
    * share the post-stop guard, signer wiring, and stderr-logged
    * link.publish below.
+   *
+   * F-3b (cortex#659): selects the target `PoolLink` from the resolved
+   * subject FIRST (pure `selectLink`), then signs + publishes on THAT
+   * link. An unknown federated network skips the publish (returns after
+   * `onRoutingError` already fired inside `selectLink`).
    */
   const signAndPublishOnSubject = async (
     envelope: Envelope,
@@ -677,6 +975,16 @@ export async function startMyelinRuntime(
       // drain-safe, but short-circuiting at this layer keeps the contract
       // explicit ("publish-after-stop is a no-op") and saves a JSON.stringify
       // of the envelope on the shutdown path.
+      return;
+    }
+
+    // F-3b (cortex#659): select the target link from the resolved subject
+    // BEFORE signing. An unknown federated network returns null —
+    // `selectLink` already fired `onRoutingError`; skip the publish (do
+    // NOT fall back to primary, per design §3.2: a misrouted federated
+    // subject must never leak onto the wrong link).
+    const target = selectLink(subject, envelope.id);
+    if (target === null) {
       return;
     }
 
@@ -745,7 +1053,11 @@ export async function startMyelinRuntime(
     // can fall through to the legacy in-process path (silent drops
     // here would mean inbound chat dispatches are lost when the bus
     // is unreachable).
-    link.publish(subject, JSON.stringify(envelopeToPublish));
+    //
+    // F-3b (cortex#659): publish on the SELECTED link, not the module
+    // singleton — `federated.{network_id}.…` lands on that network's leaf,
+    // `local.*` / `public.*` on primary.
+    target.link.publish(subject, JSON.stringify(envelopeToPublish));
   };
 
   const publishEnabled = async (envelope: Envelope): Promise<void> => {
@@ -891,10 +1203,13 @@ export async function startMyelinRuntime(
   // provision streams + per-agent durables before `ReviewConsumer.start`
   // binds to them. Cached on first call so the boot path doesn't pay a
   // server round-trip per per-agent provisioning call.
-  let jsmCache: Promise<import("nats").JetStreamManager> | null = null;
+  //
+  // F-3b (cortex#659): `jetstreamManager` stays bound to the PRIMARY link
+  // (design §3.5 — no per-network JetStream durables in F-3). The cache
+  // lives on the primary `PoolLink` (`primary.jsmCache`).
   const jetstreamManagerEnabled = (): Promise<import("nats").JetStreamManager> => {
-    jsmCache ??= link.raw.jetstreamManager();
-    return jsmCache;
+    primary.jsmCache ??= primary.link.raw.jetstreamManager();
+    return primary.jsmCache;
   };
 
   return {
@@ -908,15 +1223,25 @@ export async function startMyelinRuntime(
     stop: async () => {
       if (stopped) return;
       stopped = true;
-      // Drain subscribers first so they exit cleanly; then close the
-      // underlying link.
-      await Promise.allSettled(subscribers.map((s) => s.stop()));
-      await link.close().catch((err: unknown) => {
-        console.error(
-          "myelin-runtime: close error:",
-          err instanceof Error ? err.message : String(err),
-        );
-      });
+      // F-3b (cortex#659): drain EVERY pool link's subscribers, then close
+      // EVERY link. `allSettled` throughout so one link's drain/close
+      // failure does not block another's (design §3.4). Leaf links carry
+      // empty subscriber sets in F-3b (publish-only) but are drained +
+      // closed uniformly so F-3c/F-3d can add per-link subscribers without
+      // touching this teardown.
+      await Promise.allSettled(
+        [...pool.values()].flatMap((p) => p.subscribers.map((s) => s.stop())),
+      );
+      await Promise.allSettled(
+        [...pool.values()].map((p) =>
+          p.link.close().catch((err: unknown) => {
+            console.error(
+              `myelin-runtime: close error (link=${p.linkId}):`,
+              err instanceof Error ? err.message : String(err),
+            );
+          }),
+        ),
+      );
       console.log("myelin-runtime: stopped");
     },
   };

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -657,6 +657,17 @@ export async function startCortex(
         // (publish unsigned on transient sign failure). Ignored by the
         // runtime when no signer is attached.
         signFailureMode: signingKnobs.signFailureMode,
+        // IAW Phase F-3b (cortex#659) — the federation networks the runtime
+        // builds its LinkPool from. Each network declaring an inline `nats:`
+        // block (F-3a) contributes one leaf NatsLink; networks without it
+        // ride the primary link. Zero per-network `nats:` ⇒ primary-only
+        // pool ⇒ today's single-link behaviour byte-for-byte. Sourced from
+        // the SAME `policy.federated.networks[]` the surface-router gate
+        // keys off — NEVER `config.networks[]` (the legacy grove
+        // cloud-publish table; design §3.2 NAME-COLLISION).
+        ...(options.policy?.federated?.networks !== undefined && {
+          federatedNetworks: options.policy.federated.networks,
+        }),
       });
     } catch (err) {
       console.error("cortex: myelin runtime startup error (non-fatal):", err instanceof Error ? err.message : err);


### PR DESCRIPTION
Closes #659. Part of #631 / #627 (Trust & Confidentiality / multi-network).

Implements **F-3b** per `docs/design-multi-network.md` §3: refactor the single-link `MyelinRuntime` into an internal **LinkPool**, with publish routing as a pure function of the resolved subject. E.2/E.3/E.7 stay out of scope; this is the transport substrate they ride on.

## What changed

- **Internal `LinkPool`** inside `startMyelinRuntime` — an always-present `primary` link (from `config.nats`, exactly as today) plus one `NatsLink` per **distinct** federated network `leaf_node` that declared an inline `nats:` block (F-3a, Option B). `leaf_node` is the de-dup / pool key: two networks sharing a `leaf_node` share one physical link.
- **Public `MyelinRuntime` interface UNCHANGED** — the pool is private (additive-optional discipline for `publishOnSubject?`/`subscribePull?`/`subscribe?`/`jetstreamManager?` preserved; fake-runtime stubs stay byte-identical).
- **Publish routing = pure `selectLink(subject)`** (design §3.2), reads the resolved subject's **segment[1]** as the network id — the same grammar the inbound surface-router federation gate (`evaluateFederationGate`) already keys off:

  | resolved subject | target link |
  |---|---|
  | `local.…` | primary |
  | `public.…` | primary (public mesh deferred §3.5) |
  | `federated.{network_id}.…` | that network's leaf link |
  | `federated.{unknown}.…` | **routing error + skip** (`unknown_network_in_publish_subject`); never leaks onto primary |

  `signAndPublishOnSubject` selects the link **first**, then signs + publishes on it.
- **Per-link `boundByPattern` dedupe** + **per-link `jsmCache`** (moved onto the `PoolLink`). `stop()` drains + closes **every** link via `Promise.allSettled`.
- **Wiring:** `MyelinRuntimeOptions.federatedNetworks`, set in `cortex.ts` from `policy.federated.networks[]` — **never** `config.networks[]` (the legacy grove cloud-publish table; design §3.2 NAME-COLLISION).

## Back-compat proof (load-bearing)

With **zero** per-network `nats:` configured (today's case), the pool contains **only** the `primary` link, **all** publishes route to it, and behaviour is **byte-identical** to the pre-F-3b single-link runtime. `selectLink` short-circuits to primary when `pool.size === 1`, so even stray `federated.*` traffic rides primary exactly as before (no routing error in the single-link case). The primary link still governs `enabled` and the primary-down path is unchanged.

Proven by test **(a)** (zero networks → one physical link → `local.*` and `federated.*` both land on primary with the same subjects, no routing error) and by all **125** pre-existing myelin tests passing unchanged.

## Verification

- `bunx tsc --noEmit` — clean (no `error TS`)
- `bun run lint:errors` — clean
- `bun test src/bus/myelin/` — **125 pass** (incl. 9 new linkpool tests)
- `bun test src/bus/ src/runner/` — **913 pass / 1 skip / 0 fail**
- `bun test src/gateway/ src/common/` — **848 pass / 0 fail** (covers the `cortex.ts` boot wiring)

### Test matrix (`src/bus/myelin/__tests__/runtime-linkpool.test.ts`)

(a) back-compat: zero networks → single primary link, all publishes route to primary · (b) `federated.{net}.*` → that net's leaf · (c) `local.*`/`public.*` → primary even with leaves present · (d) `federated.{unknown}.*` → routing error + no publish · (e) per-link dedupe (no double-bind) · (+) shared-`leaf_node` → one physical link · (+) **negative leakage** (§5 cardinal): `federated.{jv}.*` never on the research leaf · (+) `stop()` drains/closes all links · (+) leaf connect failure degrades (runtime stays enabled on primary; that network's publishes skip).

## Design decisions / seams left for F-3c

- **Degraded-boot lifecycle (§3.4, OD-F3-2).** F-3b **constructs** the leaf links and logs a construction failure; the **full** degraded-boot lifecycle (mark-disabled state + nats.js background retry semantics) is **F-3c**. A leaf that fails to connect at boot is simply absent from the pool, so its network's publishes resolve to the unknown-network **skip** — already fail-closed (a dark network routes nothing); primary is unaffected and `enabled` stays true. Covered by the leaf-down test.
- **Unknown-network signal.** Design §3.2 calls for a `system.error`. The runtime has no `SystemEventSource` wired, and publishing a system envelope from inside the publish-routing path would itself need to route (back to primary) with a recursion hazard — so F-3b surfaces it through a structured `onRoutingError` sink (default: `console.error` with the canonical reason). **F-3c / inbound-attribution (F-3d)** can promote it to a typed `system.error` audit envelope by wiring a source.
- **One confirmed (not guessed) asymmetry.** `deriveNatsSubject` currently emits `federated.{principal}.{stack}.{type}` (segment[1] = principal), whereas the inbound surface-router and §3.2 routing key segment[1] as the **network_id**. F-3b routes on the resolved subject's segment[1] per the design, which only diverges from primary when a leaf link exists for that segment value — so the zero-leaf back-compat case is unaffected. Emit-site production of network-id-keyed federated subjects is a consumer concern, documented as a seam in the code.
- **§3.5 holds:** `subscribePull` and the boot-time push subscribers stay bound to `primary`; one stack signer threads into every link's publish core unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)