### PR TITLE
test(bus): TC-1d — validate signing: enforce rejects unsigned end-to-end (closes #210)

### DIFF
--- a/docs/design-trust-confidentiality.md
+++ b/docs/design-trust-confidentiality.md
@@ -118,9 +118,21 @@ gateway round-trip with zero crypto, then enable signing-permissive without touc
   re-emit through the stack's **signer-bearing** runtime so `signAndPublishOnSubject` (`runtime.ts:559`)
   stamps it with the stack NKey before the harness runs. **Acceptance:** gateway-injected dispatches
   carry a stack `signed_by[]` stamp downstream.
-- **1d. Enforce.** Flip `signFailureMode` `fallback`→`drop` (#210) and tighten the `tasks.chat`
-  inbound path toward `rejectEmpty: true` once subscribe-side verification is enforcing. **Gate:** one
-  of the #552 revisit triggers (below) must hold.
+- **1d. Enforce (TC-1d, #210 — DONE: toggle-driven, no code change).** #210 originally tracked a
+  one-line source flip of `signFailureMode` `fallback`→`drop`. That flip is now a **per-deployment
+  config flip**, not a code change: TC-0 (#628) made `security.signing: enforce` resolve to
+  `{ rejectEmpty: true, signFailureMode: "drop", cryptoVerify: true }` via `resolveSigningKnobs`, and
+  TC-1c (#552) added the Shape-B re-sign-on-ingest so gateway-injected dispatches carry a stack
+  `signed_by[]` stamp BEFORE the reject gate runs. Under `enforce` an unsigned (empty-chain) inbound
+  is dropped (`empty_chain`); a re-signed gateway envelope is non-empty and passes. There is **no
+  global default flip** — the default posture stays `off` (backward-compatible), and an operator opts
+  a deployment into fail-closed by setting `signing: enforce` in that stack's `cortex.yaml`.
+  **Gate (per-deployment):** the stack must have signing provisioned (1b) and the Shape-B re-sign in
+  place (1c) before flipping `enforce`, else legitimate gateway/adapter traffic would be dropped at the
+  `rejectEmpty` gate. The enforce↔reject and `off`/`permissive`↔accept contract is pinned end-to-end in
+  `src/bus/__tests__/bus-dispatch-listener.test.ts` (TC-1d). **Acceptance:** with `signing: enforce`,
+  an unsigned peer dispatch is rejected and a stack-re-signed gateway dispatch is accepted; with
+  `off`/`permissive` the same unsigned dispatch is accepted (shadow).
 
 ### Phase 2 — Federation trust · removes the single-principal boundary
 

--- a/src/bus/__tests__/bus-dispatch-listener.test.ts
+++ b/src/bus/__tests__/bus-dispatch-listener.test.ts
@@ -23,6 +23,7 @@ import type {
 import type { Envelope, SignedBy } from "../myelin/envelope-validator";
 import type { Agent } from "../../common/types/cortex-config";
 import { BusDispatchListener } from "../bus-dispatch-listener";
+import { resolveSigningKnobs } from "../../common/security-posture";
 
 // =============================================================================
 // Fixtures (mirrors verify-signed-by-chain.test.ts patterns)
@@ -404,6 +405,204 @@ describe("BusDispatchListener — verification gate", () => {
     );
     await drain();
 
+    expect(published).toHaveLength(1);
+    expect(published[0]?.type).toBe("system.bus.peer_dispatch_received");
+
+    await listener.stop();
+  });
+});
+
+// =============================================================================
+// TC-1d (Trust & Confidentiality, #210) — `signing: enforce` rejects unsigned
+// traffic END-TO-END, posture-driven.
+//
+// This is the closing slice of the signing track. TC-0 (#628) wired the
+// `signing` → boot-knob mapping (`resolveSigningKnobs`); TC-1c (#552) added
+// the Shape-B re-sign-on-ingest. #210's original "flip `signFailureMode`
+// `fallback`→`drop`" is NO LONGER a code change — it is the per-deployment
+// `security.signing: enforce` flip. These cases pin that contract through the
+// REAL resolver and the REAL `verifySignedByChain` reject path:
+//
+//   - `enforce`            ⇒ rejectEmpty:true  ⇒ unsigned (empty-chain) dropped
+//   - `off` / `permissive` ⇒ rejectEmpty:false ⇒ same unsigned dispatch accepted
+//   - `enforce` + signFailureMode === "drop"  (publish-side fail-closed)
+//   - gateway composition: a stack-RE-SIGNED envelope (TC-1c) carries a
+//     non-empty chain and PASSES the reject gate under `enforce` — legitimate
+//     gateway-injected traffic is NOT collateral-dropped.
+//
+// `rejectEmpty` is sourced from `resolveSigningKnobs(posture).rejectEmpty`
+// rather than a hardcoded boolean — so a regression in TC-0's mapping breaks
+// these tests, which is the whole point of an end-to-end pin.
+// =============================================================================
+
+describe("BusDispatchListener — signing posture (TC-1d / #210)", () => {
+  // An UNSIGNED peer dispatch: no `signerPrincipal` ⇒ empty `signed_by[]`.
+  function unsignedPeerDispatch(id: string): Envelope {
+    return peerDispatchEnvelope({ id });
+  }
+
+  test("enforce → unsigned (empty-chain) peer dispatch is REJECTED end-to-end", async () => {
+    const luna = agentFixture({ id: "luna", trust: ["echo"] });
+    const echo = agentFixture({
+      id: "echo",
+      displayName: "Echo",
+      nkey_pub: NKEY_ECHO,
+    });
+    const resolver = resolverWith(luna, echo);
+    const { runtime, published, deliverInbound, drain } = fakeRuntime();
+
+    const enforce = resolveSigningKnobs("enforce");
+    // enforce is the ONLY posture that rejects + drops on sign failure.
+    expect(enforce.rejectEmpty).toBe(true);
+    expect(enforce.signFailureMode).toBe("drop");
+
+    const stderrLines: string[] = [];
+    const originalWrite = process.stderr.write.bind(process.stderr);
+    process.stderr.write = (chunk: string | Uint8Array): boolean => {
+      stderrLines.push(typeof chunk === "string" ? chunk : chunk.toString());
+      return true;
+    };
+
+    try {
+      const listener = new BusDispatchListener({
+        runtime,
+        resolver,
+        receivingAgentId: "luna",
+        principalId: "test-principal",
+        source: SOURCE,
+        // The posture drives the gate — NOT a hardcoded boolean.
+        rejectEmpty: enforce.rejectEmpty,
+      });
+      listener.start();
+
+      deliverInbound(
+        unsignedPeerDispatch("00000000-0000-4000-8000-0000000e0001"),
+      );
+      await drain();
+
+      // Rejected: no visibility event, stderr carries the empty_chain reason.
+      expect(published).toHaveLength(0);
+      await listener.stop();
+    } finally {
+      process.stderr.write = originalWrite;
+    }
+
+    const stderrOutput = stderrLines.join("");
+    expect(stderrOutput).toContain("bus-dispatch-listener:luna");
+    expect(stderrOutput).toContain("empty_chain");
+  });
+
+  test("off → the SAME unsigned dispatch is ACCEPTED (falls through, surfaced)", async () => {
+    const luna = agentFixture({ id: "luna", trust: ["echo"] });
+    const echo = agentFixture({
+      id: "echo",
+      displayName: "Echo",
+      nkey_pub: NKEY_ECHO,
+    });
+    const resolver = resolverWith(luna, echo);
+    const { runtime, published, deliverInbound, drain } = fakeRuntime();
+
+    const off = resolveSigningKnobs("off");
+    expect(off.rejectEmpty).toBe(false);
+
+    const listener = new BusDispatchListener({
+      runtime,
+      resolver,
+      receivingAgentId: "luna",
+      principalId: "test-principal",
+      source: SOURCE,
+      rejectEmpty: off.rejectEmpty,
+    });
+    listener.start();
+
+    deliverInbound(unsignedPeerDispatch("00000000-0000-4000-8000-0000000e0002"));
+    await drain();
+
+    // Accepted: the unsigned empty-chain envelope falls through, the listener
+    // surfaces exactly one visibility event.
+    expect(published).toHaveLength(1);
+    expect(published[0]?.type).toBe("system.bus.peer_dispatch_received");
+
+    await listener.stop();
+  });
+
+  test("permissive → the SAME unsigned dispatch is ACCEPTED (shadow mode)", async () => {
+    const luna = agentFixture({ id: "luna", trust: ["echo"] });
+    const echo = agentFixture({
+      id: "echo",
+      displayName: "Echo",
+      nkey_pub: NKEY_ECHO,
+    });
+    const resolver = resolverWith(luna, echo);
+    const { runtime, published, deliverInbound, drain } = fakeRuntime();
+
+    const permissive = resolveSigningKnobs("permissive");
+    expect(permissive.rejectEmpty).toBe(false);
+
+    const listener = new BusDispatchListener({
+      runtime,
+      resolver,
+      receivingAgentId: "luna",
+      principalId: "test-principal",
+      source: SOURCE,
+      rejectEmpty: permissive.rejectEmpty,
+    });
+    listener.start();
+
+    deliverInbound(unsignedPeerDispatch("00000000-0000-4000-8000-0000000e0003"));
+    await drain();
+
+    expect(published).toHaveLength(1);
+    expect(published[0]?.type).toBe("system.bus.peer_dispatch_received");
+
+    await listener.stop();
+  });
+
+  test("enforce + gateway composition → a stack-RE-SIGNED envelope PASSES the reject gate", async () => {
+    // TC-1c re-signs gateway-injected (originally unsigned) envelopes on
+    // ingest with the bound stack's identity BEFORE the reject gate runs.
+    // Under `enforce` (rejectEmpty:true) that re-signed envelope carries a
+    // NON-empty `signed_by[]` (the stack stamp), so it must pass the
+    // empty-chain gate — legitimate gateway traffic is not collateral-dropped.
+    // We model the post-re-sign envelope: a stamp by the stack identity, with
+    // the own-stack short-circuit wired (cortex#480) exactly as cortex.ts does.
+    const stackIdentity = "did:mf:andreas-meta-factory";
+    const stackNKeyPub = "U" + "D".repeat(55);
+    const luna = agentFixture({ id: "luna", trust: [] });
+    const resolver = resolverWith(luna);
+    const { runtime, published, deliverInbound, drain } = fakeRuntime();
+
+    const enforce = resolveSigningKnobs("enforce");
+    expect(enforce.rejectEmpty).toBe(true);
+
+    const listener = new BusDispatchListener({
+      runtime,
+      resolver,
+      receivingAgentId: "luna",
+      principalId: "andreas",
+      source: SOURCE,
+      // Enforce: the empty-chain gate is ARMED — but the re-signed envelope
+      // below carries a stack stamp, so it is non-empty and passes.
+      rejectEmpty: enforce.rejectEmpty,
+      // Structural own-stack short-circuit (cryptoVerify default false here),
+      // matching the dispatch-listener self-trust wiring for adapter/gateway
+      // originated dispatches.
+      stackIdentity,
+      stackNKeyPub,
+    });
+    listener.start();
+
+    deliverInbound(
+      peerDispatchEnvelope({
+        // The stack re-sign stamp (TC-1c) → non-empty chain under enforce.
+        signerPrincipal: stackIdentity,
+        source: "andreas.meta-factory.local",
+        id: "00000000-0000-4000-8000-0000000e0004",
+      }),
+    );
+    await drain();
+
+    // Passed the reject gate despite enforce: re-signed traffic surfaces.
     expect(published).toHaveLength(1);
     expect(published[0]?.type).toBe("system.bus.peer_dispatch_received");
 


### PR DESCRIPTION
## What

Closes #210. Completes the signing track (TC-0 wired the enforce knob-mapping; TC-1c added Shape-B re-sign). This slice **validates + documents** end-to-end that `signing: enforce` actually rejects unsigned traffic — it is **not** a global default flip.

#210 originally tracked a one-line source flip of `signFailureMode` `fallback`→`drop`. That is now a **per-deployment config flip**:

- **TC-0 (#628)** — `security.signing: enforce` resolves via `resolveSigningKnobs` to `{ rejectEmpty: true, signFailureMode: "drop", cryptoVerify: true }`.
- **TC-1c (#552)** — Shape-B re-sign-on-ingest stamps gateway-injected dispatches with a stack `signed_by[]` **before** the reject gate runs.

So the default posture stays `off` (backward-compatible); an operator opts a deployment into fail-closed via `signing: enforce` in that stack's `cortex.yaml`.

## Changes

- **`src/bus/__tests__/bus-dispatch-listener.test.ts`** — new `describe("BusDispatchListener — signing posture (TC-1d / #210)")` block. Drives the **real** `resolveSigningKnobs` resolver through the **real** `verifySignedByChain` reject path:
  - `enforce` → unsigned (empty-chain) inbound dispatch **REJECTED** (`empty_chain`, `rejectEmpty:true`); `signFailureMode === "drop"` asserted.
  - `off` / `permissive` → the **same** unsigned dispatch **ACCEPTED** (falls through, surfaced).
  - gateway composition: a stack-**re-signed** envelope (TC-1c) carries a non-empty chain and **passes** the reject gate under `enforce`.
  - `rejectEmpty` is sourced from `resolveSigningKnobs(posture).rejectEmpty`, not a hardcoded boolean — a TC-0 mapping regression breaks the test.
- **`docs/design-trust-confidentiality.md`** — Phase 1.1d reworded: enforce is a per-deployment `signing: enforce` flip gated on real signing (provisioned + Shape B), **no global default change**.

## Verification

- `bunx tsc --noEmit` — zero `error TS`.
- `bun run lint:errors` — clean.
- `bun test` on `bus-dispatch-listener` + `dispatch-listener` + `verify-signed-by-chain` + `security-posture` suites + the new TC-1d cases → **110 pass, 0 fail**.

Part of #627.

🤖 Generated with [Claude Code](https://claude.com/claude-code)