### PR TITLE
feat(bus): F-3d — inbound sourceLink attribution (hook for cross-leaf verify) (closes #666)

### DIFF
--- a/docs/iteration-multi-network.md
+++ b/docs/iteration-multi-network.md
@@ -50,12 +50,16 @@ See `docs/design-multi-network.md` §9.
       no-op, stop()-cancels-pending-timer, post-stop reconnect no-op.
 
 ### F-3d — Inbound attribution + gate wiring
-- [ ] `EnvelopeHandler` gains additive `sourceLink?: string` (`runtime.ts:40`); existing handlers ignore.
-- [ ] Per-link subscriber tags delivered envelopes with the delivering `linkId`.
-- [ ] Anti-spoof: subject `{network_id}` must map to a network with `leaf_node === sourceLink`; mismatch
-      dropped + logged.
-- [ ] Surface-router fed gate (`surface-router.ts:350-366`) keyed by the delivering network.
-- [ ] Tests: attribution, anti-spoof drop, extend `runtime-principal-symmetry.test.ts` per-link.
+- [x] `EnvelopeHandler` gains additive `sourceLink?: string` (`runtime.ts:40`); existing handlers ignore.
+- [x] Per-link subscriber tags delivered envelopes with the delivering `linkId` (each leaf subscribes
+      `federated.{network_id}.>` and fans out with `sourceLink = leaf_node`; primary ⇒ `"primary"`).
+- [x] Anti-spoof: subject `{network_id}` must map to a network with `leaf_node === sourceLink`; mismatch
+      dropped + logged (runtime `passesSourceLinkCheck`) and denied at the surface-router gate
+      (`source_link_mismatch`).
+- [x] Surface-router fed gate keyed by the delivering network (additive `sourceLink` cross-check in
+      `evaluateFederationGate`; threaded through `dispatch` + the dispatch-listener Option-D gate).
+- [x] Tests: attribution (`runtime-source-link.test.ts`), anti-spoof drop (runtime + surface-router),
+      extend `runtime-principal-symmetry.test.ts` per-link `{network_id}` symmetry.
 
 ## Out of scope (deferred — design §3.5)
 - Per-network JetStream durables (`subscribePull` stays primary-only).

--- a/src/bus/__tests__/surface-router.test.ts
+++ b/src/bus/__tests__/surface-router.test.ts
@@ -2002,3 +2002,112 @@ describe("emitAccessFiltered — defensive .catch on publish failure (cortex#137
     }
   });
 });
+
+// =============================================================================
+// IAW Phase F-3d (cortex#666) — sourceLink anti-spoof cross-check
+// =============================================================================
+
+describe("evaluateFederationGate — F-3d sourceLink anti-spoof", () => {
+  test("no sourceLink supplied → cross-check skipped (pre-F-3d behaviour, allow)", () => {
+    const decision = evaluateFederationGate(
+      "federated.research-collab.tasks.code-review.ts",
+      makeFederatedEnvelope(),
+      networksMap([makeNetwork()]),
+      // sourceLink omitted entirely.
+    );
+    expect(decision).toBe("allow");
+  });
+
+  test("sourceLink matches the network's leaf_node → allow", () => {
+    const decision = evaluateFederationGate(
+      "federated.research-collab.tasks.code-review.ts",
+      makeFederatedEnvelope(),
+      networksMap([makeNetwork({ leaf_node: "leaf-research" })]),
+      "leaf-research",
+    );
+    expect(decision).toBe("allow");
+  });
+
+  test("sourceLink names a DIFFERENT leaf than the claimed network → source_link_mismatch", () => {
+    const decision = evaluateFederationGate(
+      "federated.research-collab.tasks.code-review.ts",
+      makeFederatedEnvelope(),
+      networksMap([makeNetwork({ leaf_node: "leaf-research" })]),
+      "leaf-jv", // arrived on the JV leaf, but subject claims research-collab.
+    );
+    expect(decision).toEqual({
+      kind: "source_link_mismatch",
+      networkId: "research-collab",
+      sourceLink: "leaf-jv",
+      expectedLeafNode: "leaf-research",
+    });
+  });
+
+  test('sourceLink === "primary" → cross-check skipped (network riding primary keeps accept/deny gating)', () => {
+    // A network without a `nats:` block rides the primary link; its declared
+    // leaf_node is NOT "primary", but a primary-delivered envelope must NOT be
+    // flagged as a spoof — the runtime's symmetric exclusion. The accept-list
+    // still governs admission.
+    const decision = evaluateFederationGate(
+      "federated.research-collab.tasks.code-review.ts",
+      makeFederatedEnvelope(),
+      networksMap([makeNetwork({ leaf_node: "leaf-research" })]),
+      "primary",
+    );
+    expect(decision).toBe("allow");
+  });
+
+  test("mismatch is decided BEFORE accept/deny (a subject the network WOULD accept is still spoof-denied)", () => {
+    const decision = evaluateFederationGate(
+      "federated.research-collab.tasks.code-review.ts", // in accept_subjects
+      makeFederatedEnvelope(),
+      networksMap([makeNetwork({ leaf_node: "leaf-research" })]),
+      "leaf-jv",
+    );
+    expect(decision).toMatchObject({ kind: "source_link_mismatch" });
+  });
+});
+
+describe("createSurfaceRouter — F-3d sourceLink threaded into the gate", () => {
+  test("dispatch(env, subject, sourceLink) with mismatched leaf → denied (no adapter render)", async () => {
+    const router = createSurfaceRouter(fakeRuntime(), {
+      federated: { networks: [makeNetwork({ leaf_node: "leaf-research" })] },
+    });
+    const a = recordingAdapter({
+      id: "a",
+      subjects: ["federated.research-collab.>"],
+    });
+    router.register(a.adapter);
+    await router.start();
+
+    // Subject claims research-collab but arrived on the JV leaf → spoof.
+    await router.dispatch(
+      makeFederatedEnvelope(),
+      "federated.research-collab.tasks.code-review.ts",
+      "leaf-jv",
+    );
+    await new Promise((r) => setTimeout(r, 0));
+    // Hard drop — the adapter never rendered.
+    expect(a.calls).toHaveLength(0);
+  });
+
+  test("dispatch(env, subject, sourceLink) with matching leaf → adapter renders", async () => {
+    const router = createSurfaceRouter(fakeRuntime(), {
+      federated: { networks: [makeNetwork({ leaf_node: "leaf-research" })] },
+    });
+    const a = recordingAdapter({
+      id: "a",
+      subjects: ["federated.research-collab.>"],
+    });
+    router.register(a.adapter);
+    await router.start();
+
+    await router.dispatch(
+      makeFederatedEnvelope(),
+      "federated.research-collab.tasks.code-review.ts",
+      "leaf-research",
+    );
+    await new Promise((r) => setTimeout(r, 0));
+    expect(a.calls).toHaveLength(1);
+  });
+});

--- a/src/bus/myelin/__tests__/runtime-principal-symmetry.test.ts
+++ b/src/bus/myelin/__tests__/runtime-principal-symmetry.test.ts
@@ -12,13 +12,22 @@
  * strings — otherwise publish/subscribe subjects diverge and round-trips
  * break.
  */
-import { describe, test, expect } from "bun:test";
+import { afterEach, beforeEach, describe, test, expect, mock } from "bun:test";
+import type {
+  ConnectionOptions,
+  NatsConnection,
+  Status,
+  Subscription,
+} from "nats";
 
 import {
   principalFromConfig,
   principalFromEnvelope,
 } from "../envelope-validator";
 import { createSystemAdapterDegradedEvent } from "../../system-events";
+import { startMyelinRuntime } from "../runtime";
+import type { AgentConfig } from "../../../common/types/config";
+import type { PolicyFederatedNetwork } from "../../../common/types/cortex-config";
 
 describe("MyelinRuntime — subscribe/publish {principal} symmetry (cortex#130 item 1)", () => {
   test("principalFromConfig and principalFromEnvelope agree for stack-emitted envelopes", () => {
@@ -64,5 +73,188 @@ describe("MyelinRuntime — subscribe/publish {principal} symmetry (cortex#130 i
 
     expect(principalFromConfig(principalId)).toBe(principalFromEnvelope(envelope));
     expect(principalFromEnvelope(envelope)).toBe("the-metafactory");
+  });
+});
+
+// =============================================================================
+// IAW Phase F-3d (cortex#666) — per-link {network_id} symmetry (design §7.8).
+// =============================================================================
+//
+// For each federated leaf link the SUBSCRIBE pattern is `federated.{network_id}.>`
+// (the inbound-attribution per-leaf subscription) and the PUBLISH routing keys
+// off the same `{network_id}` segment (subject[1]) in `selectLink`. The
+// invariant: subscribe-`{network_id}` === publish-`{network_id}` per leaf, so a
+// federated round-trip lands on (and is attributed to) the SAME link both ways.
+
+function makeConfig(natsBlock: AgentConfig["nats"]): AgentConfig {
+  return {
+    agent: { name: "luna", displayName: "Luna" },
+    nats: natsBlock,
+  } as unknown as AgentConfig;
+}
+
+function makeFakeConn() {
+  const statusListeners = new Set<(s: Status | null) => void>();
+  const subscribePatterns: string[] = [];
+  const publishes: { subject: string; payload: string | Uint8Array }[] = [];
+  const status = () =>
+    (async function* () {
+      const queue: (Status | null)[] = [];
+      let waiter: ((s: Status | null) => void) | null = null;
+      const listener = (s: Status | null) => {
+        if (waiter) {
+          const w = waiter;
+          waiter = null;
+          w(s);
+        } else queue.push(s);
+      };
+      statusListeners.add(listener);
+      try {
+        while (true) {
+          if (queue.length > 0) {
+            const next = queue.shift()!;
+            if (next === null) return;
+            yield next;
+            continue;
+          }
+          const next = await new Promise<Status | null>((r) => (waiter = r));
+          if (next === null) return;
+          yield next;
+        }
+      } finally {
+        statusListeners.delete(listener);
+      }
+    })();
+  const subscribe = mock((pattern: string) => {
+    subscribePatterns.push(pattern);
+    let resolve: (() => void) | null = null;
+    const done = new Promise<void>((r) => (resolve = r));
+    // eslint-disable-next-line require-yield
+    const iterator = (async function* () {
+      await done;
+    })();
+    return {
+      [Symbol.asyncIterator]: () => iterator,
+      drain: mock(async () => resolve?.()),
+      closed: Promise.resolve(),
+    } as unknown as Subscription;
+  });
+  const drain = mock(async () => {
+    for (const l of statusListeners) l(null);
+  });
+  const publish = mock((subject: string, payload: string | Uint8Array) => {
+    publishes.push({ subject, payload });
+  });
+  const nc = { status, subscribe, drain, publish } as unknown as NatsConnection;
+  return { nc, subscribePatterns, publishes };
+}
+
+function makeFakeRegistry() {
+  const byUrl = new Map<string, ReturnType<typeof makeFakeConn>>();
+  const connectImpl = async (opts: ConnectionOptions): Promise<NatsConnection> => {
+    const url = (opts.servers as string[])[0] ?? "<no-url>";
+    let conn = byUrl.get(url);
+    if (!conn) {
+      conn = makeFakeConn();
+      byUrl.set(url, conn);
+    }
+    return conn.nc;
+  };
+  return { connectImpl, forUrl: (url: string) => byUrl.get(url) };
+}
+
+function makeNetwork(overrides: Partial<PolicyFederatedNetwork>): PolicyFederatedNetwork {
+  return {
+    id: "research-collab",
+    leaf_node: "nats-leaf-research",
+    peers: [],
+    accept_subjects: [],
+    deny_subjects: [],
+    announce_capabilities: [],
+    max_hop: 0,
+    ...overrides,
+  };
+}
+
+function makeEnvelope() {
+  return {
+    id: "11111111-1111-4111-8111-111111111111",
+    source: "metafactory.grove.local",
+    type: "system.adapter.degraded",
+    timestamp: "2026-06-04T12:00:00.000Z",
+    sovereignty: {
+      classification: "federated" as const,
+      data_residency: "NZ",
+      max_hop: 0,
+      frontier_ok: true,
+      model_class: "any" as const,
+    },
+    payload: { adapter_id: "discord-luna" },
+  };
+}
+
+describe("MyelinRuntime — per-link {network_id} symmetry (F-3d, cortex#666 §7.8)", () => {
+  let restore: () => void;
+  beforeEach(() => {
+    const o = { log: console.log, info: console.info, error: console.error };
+    console.log = () => {};
+    console.info = () => {};
+    console.error = () => {};
+    restore = () => {
+      console.log = o.log;
+      console.info = o.info;
+      console.error = o.error;
+    };
+  });
+  afterEach(() => restore());
+
+  test("subscribe-{network_id} === publish-{network_id} per leaf link", async () => {
+    const reg = makeFakeRegistry();
+    const RESEARCH_URL = "nats://research:4222";
+    const JV_URL = "nats://jv:4222";
+    const networks = [
+      makeNetwork({
+        id: "research-collab",
+        leaf_node: "nats-leaf-research",
+        nats: { url: RESEARCH_URL, name: "cortex" },
+      }),
+      makeNetwork({
+        id: "jv-collab",
+        leaf_node: "nats-leaf-jv",
+        nats: { url: JV_URL, name: "cortex" },
+      }),
+    ];
+    const runtime = await startMyelinRuntime(
+      makeConfig({ url: "nats://localhost:4222", name: "cortex", subjects: [] }),
+      { connectImpl: reg.connectImpl, federatedNetworks: networks },
+    );
+    expect(runtime.enabled).toBe(true);
+
+    const research = reg.forUrl(RESEARCH_URL)!;
+    const jv = reg.forUrl(JV_URL)!;
+
+    // SUBSCRIBE side: each leaf subscribes to its OWN network's segment.
+    expect(research.subscribePatterns).toEqual(["federated.research-collab.>"]);
+    expect(jv.subscribePatterns).toEqual(["federated.jv-collab.>"]);
+
+    // PUBLISH side: a `federated.{network_id}.…` publish routes to the SAME
+    // leaf whose subscribe pattern carries that `{network_id}` — and ONLY that
+    // leaf (no cross-network leakage).
+    await runtime.publishOnSubject!(
+      makeEnvelope(),
+      "federated.research-collab.system.adapter.degraded",
+    );
+    await runtime.publishOnSubject!(
+      makeEnvelope(),
+      "federated.jv-collab.system.adapter.degraded",
+    );
+    expect(research.publishes.map((p) => p.subject)).toEqual([
+      "federated.research-collab.system.adapter.degraded",
+    ]);
+    expect(jv.publishes.map((p) => p.subject)).toEqual([
+      "federated.jv-collab.system.adapter.degraded",
+    ]);
+
+    await runtime.stop();
   });
 });

--- a/src/bus/myelin/__tests__/runtime-source-link.test.ts
+++ b/src/bus/myelin/__tests__/runtime-source-link.test.ts
@@ -1,0 +1,420 @@
+/**
+ * F-3d (cortex#666): MyelinRuntime inbound `sourceLink` attribution tests.
+ *
+ * F-3d threads WHICH pool link (and therefore which federation network)
+ * delivered an inbound envelope through to the runtime's `onEnvelope`
+ * handlers as an additive trailing `sourceLink` arg. The design
+ * (`docs/design-multi-network.md` §3.3 / §7 row 7) requires:
+ *
+ *   (a) inbound on a LEAF link  → handler receives sourceLink = that leaf_node;
+ *   (b) inbound on the PRIMARY  → handler receives sourceLink = "primary";
+ *   (c) single-link deployment  → unchanged: a 2-arg `(env, subject)` handler
+ *       still works (the third arg is optional + trailing);
+ *   (d) anti-spoof: a `federated.{A}.*` subject delivered on leaf B is DROPPED
+ *       + logged before fan-out (§3.3 / §5 isolation layer 2).
+ *
+ * Unlike `runtime-linkpool.test.ts` (publish routing — its fake subscribe
+ * blocks forever), this file uses a DELIVERABLE fake connection whose
+ * subscription async-iterator can be fed a message, so we can drive inbound
+ * delivery on a specific link and assert the attribution the handler sees.
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import type {
+  ConnectionOptions,
+  NatsConnection,
+  Status,
+  Subscription,
+} from "nats";
+import type { AgentConfig } from "../../../common/types/config";
+import type { PolicyFederatedNetwork } from "../../../common/types/cortex-config";
+import { startMyelinRuntime } from "../runtime";
+
+function makeConfig(natsBlock: AgentConfig["nats"]): AgentConfig {
+  return {
+    agent: { name: "luna", displayName: "Luna" },
+    nats: natsBlock,
+  } as unknown as AgentConfig;
+}
+
+/**
+ * A fake NATS connection whose subscriptions can be FED inbound messages.
+ * `deliver(pattern, subject, payload)` pushes a `{ subject, data }` message
+ * into the matching subscription's async-iterator queue, which the
+ * NatsSubscription consume loop picks up exactly as a real broker delivery.
+ */
+function makeDeliverableConn() {
+  const subscribePatterns: string[] = [];
+  const publishes: { subject: string; payload: string | Uint8Array }[] = [];
+
+  // Per-pattern message queues + waiters so we can deliver after the consume
+  // loop has started awaiting.
+  interface SubChannel {
+    queue: { subject: string; data: Uint8Array }[];
+    waiter: ((m: { subject: string; data: Uint8Array } | null) => void) | null;
+    closed: boolean;
+  }
+  const channels = new Map<string, SubChannel>();
+
+  // Status stream that ENDS on drain() (mirrors runtime-linkpool's fake) so
+  // NatsLink.close()'s status-loop join resolves promptly instead of waiting
+  // out the 2s watchdog.
+  const statusListeners = new Set<(s: Status | null) => void>();
+  const status = () =>
+    (async function* () {
+      const queue: (Status | null)[] = [];
+      let waiter: ((s: Status | null) => void) | null = null;
+      const listener = (s: Status | null) => {
+        if (waiter) {
+          const w = waiter;
+          waiter = null;
+          w(s);
+        } else {
+          queue.push(s);
+        }
+      };
+      statusListeners.add(listener);
+      try {
+        while (true) {
+          if (queue.length > 0) {
+            const next = queue.shift()!;
+            if (next === null) return;
+            yield next;
+            continue;
+          }
+          const next = await new Promise<Status | null>((r) => (waiter = r));
+          if (next === null) return;
+          yield next;
+        }
+      } finally {
+        statusListeners.delete(listener);
+      }
+    })();
+
+  const subscribe = mock((pattern: string) => {
+    subscribePatterns.push(pattern);
+    const chan: SubChannel = { queue: [], waiter: null, closed: false };
+    channels.set(pattern, chan);
+    const iterator = (async function* () {
+      while (true) {
+        if (chan.queue.length > 0) {
+          const next = chan.queue.shift()!;
+          yield next;
+          continue;
+        }
+        if (chan.closed) return;
+        const next = await new Promise<{ subject: string; data: Uint8Array } | null>(
+          (r) => (chan.waiter = r),
+        );
+        if (next === null) return;
+        yield next;
+      }
+    })();
+    return {
+      [Symbol.asyncIterator]: () => iterator,
+      drain: mock(async () => {
+        chan.closed = true;
+        chan.waiter?.(null);
+      }),
+      closed: Promise.resolve(),
+    } as unknown as Subscription;
+  });
+
+  const drain = mock(async () => {
+    for (const chan of channels.values()) {
+      chan.closed = true;
+      chan.waiter?.(null);
+    }
+    // End the status stream so the link's status-loop join resolves.
+    for (const l of statusListeners) l(null);
+  });
+
+  const publish = mock((subject: string, payload: string | Uint8Array) => {
+    publishes.push({ subject, payload });
+  });
+
+  const nc = { status, subscribe, drain, publish } as unknown as NatsConnection;
+
+  /** Push one inbound message into the subscription bound to `pattern`. */
+  const deliver = (pattern: string, subject: string, payloadObj: unknown) => {
+    const chan = channels.get(pattern);
+    if (!chan) throw new Error(`no subscription bound to pattern "${pattern}"`);
+    const data = new TextEncoder().encode(JSON.stringify(payloadObj));
+    const msg = { subject, data };
+    if (chan.waiter) {
+      const w = chan.waiter;
+      chan.waiter = null;
+      w(msg);
+    } else {
+      chan.queue.push(msg);
+    }
+  };
+
+  return { nc, subscribe, subscribePatterns, publishes, deliver };
+}
+
+/** Per-URL deliverable fake registry — mirrors runtime-linkpool's shape. */
+function makeFakeRegistry() {
+  const byUrl = new Map<string, ReturnType<typeof makeDeliverableConn>>();
+  const connectImpl = async (opts: ConnectionOptions): Promise<NatsConnection> => {
+    const url = (opts.servers as string[])[0] ?? "<no-url>";
+    let conn = byUrl.get(url);
+    if (!conn) {
+      conn = makeDeliverableConn();
+      byUrl.set(url, conn);
+    }
+    return conn.nc;
+  };
+  return { connectImpl, forUrl: (url: string) => byUrl.get(url), byUrl };
+}
+
+const PRIMARY_URL = "nats://localhost:4222";
+const RESEARCH_URL = "nats://research:4222";
+const JV_URL = "nats://jv:4222";
+
+function makeNetwork(
+  overrides: Partial<PolicyFederatedNetwork>,
+): PolicyFederatedNetwork {
+  return {
+    id: "research-collab",
+    leaf_node: "nats-leaf-research",
+    peers: [],
+    accept_subjects: [],
+    deny_subjects: [],
+    announce_capabilities: [],
+    max_hop: 0,
+    ...overrides,
+  };
+}
+
+/** A schema-valid envelope object (what the wire carries; validated on delivery). */
+function makeEnvelope(
+  overrides: Partial<{ id: string; type: string; classification: string }> = {},
+) {
+  return {
+    id: overrides.id ?? "11111111-1111-4111-8111-111111111111",
+    source: "metafactory.grove.local",
+    type: overrides.type ?? "system.adapter.degraded",
+    timestamp: "2026-06-04T12:00:00.000Z",
+    sovereignty: {
+      classification: (overrides.classification ?? "federated") as
+        | "local"
+        | "federated"
+        | "public",
+      data_residency: "NZ",
+      max_hop: 0,
+      frontier_ok: true,
+      model_class: "any" as const,
+    },
+    payload: { adapter_id: "discord-luna" },
+  };
+}
+
+describe("MyelinRuntime inbound sourceLink attribution (F-3d, cortex#666)", () => {
+  let logs: { kind: "log" | "info" | "warn" | "error"; msg: string }[];
+  let restore: () => void;
+
+  beforeEach(() => {
+    logs = [];
+    const o = { log: console.log, info: console.info, warn: console.warn, error: console.error };
+    console.log = (...a: unknown[]) => logs.push({ kind: "log", msg: a.map(String).join(" ") });
+    console.info = (...a: unknown[]) => logs.push({ kind: "info", msg: a.map(String).join(" ") });
+    console.warn = (...a: unknown[]) => logs.push({ kind: "warn", msg: a.map(String).join(" ") });
+    console.error = (...a: unknown[]) => logs.push({ kind: "error", msg: a.map(String).join(" ") });
+    restore = () => {
+      console.log = o.log;
+      console.info = o.info;
+      console.warn = o.warn;
+      console.error = o.error;
+    };
+  });
+  afterEach(() => restore());
+
+  // (a) Inbound on a LEAF link → sourceLink = that leaf's leaf_node.
+  test("(a) inbound on a leaf link tags sourceLink = the leaf's leaf_node", async () => {
+    const reg = makeFakeRegistry();
+    const networks = [
+      makeNetwork({
+        id: "research-collab",
+        leaf_node: "nats-leaf-research",
+        nats: { url: RESEARCH_URL, name: "cortex" },
+      }),
+    ];
+    const runtime = await startMyelinRuntime(
+      makeConfig({ url: PRIMARY_URL, name: "cortex", subjects: [] }),
+      { connectImpl: reg.connectImpl, federatedNetworks: networks },
+    );
+    expect(runtime.enabled).toBe(true);
+
+    const seen: { subject: string; sourceLink?: string }[] = [];
+    runtime.onEnvelope((_env, subject, sourceLink) => {
+      seen.push({ subject, sourceLink });
+    });
+
+    const research = reg.forUrl(RESEARCH_URL)!;
+    // The leaf subscribes to `federated.{network_id}.>` for its network.
+    expect(research.subscribePatterns).toContain("federated.research-collab.>");
+
+    research.deliver(
+      "federated.research-collab.>",
+      "federated.research-collab.system.adapter.degraded",
+      makeEnvelope(),
+    );
+    // Let the async consume loop + validate + fan-out settle.
+    await new Promise((r) => setTimeout(r, 5));
+
+    expect(seen).toEqual([
+      {
+        subject: "federated.research-collab.system.adapter.degraded",
+        sourceLink: "nats-leaf-research",
+      },
+    ]);
+
+    await runtime.stop();
+  });
+
+  // (b) Inbound on the PRIMARY link → sourceLink = "primary".
+  test("(b) inbound on the primary link tags sourceLink = \"primary\"", async () => {
+    const reg = makeFakeRegistry();
+    const runtime = await startMyelinRuntime(
+      makeConfig({
+        url: PRIMARY_URL,
+        name: "cortex",
+        subjects: ["local.{principal}.>"],
+      }),
+      { connectImpl: reg.connectImpl, principal: "metafactory" },
+    );
+    expect(runtime.enabled).toBe(true);
+
+    const seen: { subject: string; sourceLink?: string }[] = [];
+    runtime.onEnvelope((_env, subject, sourceLink) => {
+      seen.push({ subject, sourceLink });
+    });
+
+    const primary = reg.forUrl(PRIMARY_URL)!;
+    // Primary subscribed to the resolved `local.metafactory.>` pattern.
+    expect(primary.subscribePatterns).toContain("local.metafactory.>");
+
+    primary.deliver(
+      "local.metafactory.>",
+      "local.metafactory.system.adapter.degraded",
+      makeEnvelope({ classification: "local" }),
+    );
+    await new Promise((r) => setTimeout(r, 5));
+
+    expect(seen).toEqual([
+      {
+        subject: "local.metafactory.system.adapter.degraded",
+        sourceLink: "primary",
+      },
+    ]);
+
+    await runtime.stop();
+  });
+
+  // (c) Single-link deployment → an existing 2-arg handler still works.
+  test("(c) single-link: a legacy (env, subject) 2-arg handler keeps working", async () => {
+    const reg = makeFakeRegistry();
+    const runtime = await startMyelinRuntime(
+      makeConfig({
+        url: PRIMARY_URL,
+        name: "cortex",
+        subjects: ["local.{principal}.>"],
+      }),
+      { connectImpl: reg.connectImpl, principal: "metafactory" },
+      // NB: federatedNetworks omitted — pure single-link deployment.
+    );
+    expect(runtime.enabled).toBe(true);
+    // Exactly one physical link — the primary.
+    expect(reg.byUrl.size).toBe(1);
+
+    // A handler with the OLD 2-arg shape. The optional trailing `sourceLink`
+    // is invisible to it — it never reads a third arg. TypeScript accepts the
+    // narrower 2-arg function where the 3-arg `EnvelopeHandler` is expected
+    // (parameter bivariance on the extra trailing param) — that IS the
+    // back-compat guarantee under test, so no cast is needed.
+    const seen: { subject: string }[] = [];
+    runtime.onEnvelope((_env, subject) => {
+      seen.push({ subject });
+    });
+
+    const primary = reg.forUrl(PRIMARY_URL)!;
+    primary.deliver(
+      "local.metafactory.>",
+      "local.metafactory.system.adapter.degraded",
+      makeEnvelope({ classification: "local" }),
+    );
+    await new Promise((r) => setTimeout(r, 5));
+
+    expect(seen).toEqual([{ subject: "local.metafactory.system.adapter.degraded" }]);
+
+    await runtime.stop();
+  });
+
+  // (d) Anti-spoof: a federated.{A}.* subject delivered on leaf B is dropped.
+  test("(d) anti-spoof: a subject naming network A delivered on leaf B is dropped + logged", async () => {
+    const reg = makeFakeRegistry();
+    const networks = [
+      makeNetwork({
+        id: "research-collab",
+        leaf_node: "nats-leaf-research",
+        nats: { url: RESEARCH_URL, name: "cortex" },
+      }),
+      makeNetwork({
+        id: "jv-collab",
+        leaf_node: "nats-leaf-jv",
+        nats: { url: JV_URL, name: "cortex" },
+      }),
+    ];
+    const runtime = await startMyelinRuntime(
+      makeConfig({ url: PRIMARY_URL, name: "cortex", subjects: [] }),
+      { connectImpl: reg.connectImpl, federatedNetworks: networks },
+    );
+    expect(runtime.enabled).toBe(true);
+
+    const seen: { subject: string; sourceLink?: string }[] = [];
+    runtime.onEnvelope((_env, subject, sourceLink) => {
+      seen.push({ subject, sourceLink });
+    });
+
+    const jv = reg.forUrl(JV_URL)!;
+    // Spoof: deliver a `federated.research-collab.*` subject on the JV leaf's
+    // OWN subscription. (We push it into the jv leaf's `federated.jv-collab.>`
+    // channel, simulating a leaf that delivered a subject for a different
+    // network — the cardinal cross-network leak the assertion guards.)
+    jv.deliver(
+      "federated.jv-collab.>",
+      "federated.research-collab.system.adapter.degraded",
+      makeEnvelope(),
+    );
+    await new Promise((r) => setTimeout(r, 5));
+
+    // Dropped — no handler saw it.
+    expect(seen).toEqual([]);
+    // And it was logged as a spoof drop.
+    expect(
+      logs.some(
+        (l) =>
+          l.kind === "error" &&
+          l.msg.includes("DROPPING spoofed envelope") &&
+          l.msg.includes("research-collab"),
+      ),
+    ).toBe(true);
+
+    // Sanity: a CORRECTLY-attributed subject on the JV leaf DOES fan out.
+    jv.deliver(
+      "federated.jv-collab.>",
+      "federated.jv-collab.system.adapter.degraded",
+      makeEnvelope(),
+    );
+    await new Promise((r) => setTimeout(r, 5));
+    expect(seen).toEqual([
+      {
+        subject: "federated.jv-collab.system.adapter.degraded",
+        sourceLink: "nats-leaf-jv",
+      },
+    ]);
+
+    await runtime.stop();
+  });
+});

--- a/src/bus/myelin/runtime.ts
+++ b/src/bus/myelin/runtime.ts
@@ -1151,6 +1151,25 @@ export async function startMyelinRuntime(
   // surface-router gate + `selectLink` already use, so inbound attribution and
   // outbound routing agree on a federated subject's network segment.
   //
+  // KNOWN EMIT-SITE ASYMMETRY (cortex#661 — the SAME seam `selectLink`
+  // documents on the OUTBOUND side, here on the INBOUND side; NOT a
+  // back-compat hazard). `deriveNatsSubject` currently emits federated
+  // subjects as `federated.{principal}.{stack}.{type}` — segment[1] is the
+  // PRINCIPAL, not the `network_id` this subscription pattern (correctly, per
+  // §3.2) keys off. Consequence: until #661 fixes the emit site, a REAL
+  // federated envelope produced through the derive path won't match a leaf's
+  // `federated.{network_id}.>` interest (unless a principal is coincidentally
+  // named after a network). Harmless today for the same reason as the outbound
+  // seam: no production site emits a `classification: "federated"` envelope
+  // through the derive path with a leaf present yet (E.2/E.3/E.7 federated
+  // emit/relay enablement is OUT of scope here). Publish (`selectLink`) and
+  // subscribe (this loop) are INTERNALLY CONSISTENT — both use the
+  // `{network_id}` grammar — so when #661 corrects emit, both ends start
+  // matching together. The anti-spoof check (`passesSourceLinkCheck`) only
+  // ever runs on subjects that actually arrived here, which are
+  // `federated.{network_id}.…` by construction of this very pattern, so
+  // segment[1] is genuinely the network_id at the check site — no false-drop.
+  //
   // **Back-compat:** with zero leaf links this loop binds nothing — the pool
   // is primary-only and delivery is byte-identical to pre-F-3d. A DOWN leaf
   // (link === null) is skipped by `bindPushPattern`; the F-3c background

--- a/src/bus/myelin/runtime.ts
+++ b/src/bus/myelin/runtime.ts
@@ -37,8 +37,39 @@ import { signEnvelope } from "@the-metafactory/myelin/identity";
  * subscription, with the actual NATS subject (so wildcard-pattern
  * subscribers can route on the concrete subject — see
  * `src/bus/surface-router.ts`, G-1111.A).
+ *
+ * IAW Phase F-3d (cortex#666) — `sourceLink` ADDITIVELY tags WHICH pool
+ * link (and therefore which federation network) delivered an inbound
+ * envelope. It is the delivering link's `linkId`:
+ *
+ *   - `"primary"` — the `config.nats` link (local/public + every back-compat
+ *     case: zero per-network `nats:` ⇒ the only link ⇒ always `"primary"`).
+ *   - a `leaf_node` name — a per-network federated leaf (F-3a Option B).
+ *
+ * The value is the pool's de-dup key for the delivering link, which is the
+ * `leaf_node` the F-3d anti-spoof + surface-router federated gate cross-check
+ * the subject's `{network_id}` segment against (a subject claiming
+ * `federated.{X}.…` that arrived on a link NOT owning network X is a spoof,
+ * per design §3.3 / §5). `undefined` when the delivery site has no link
+ * context (test-only direct `dispatch` calls, and disabled-runtime handlers
+ * that never fire).
+ *
+ * **Back-compat:** the third arg is optional + trailing, so every existing
+ * `(envelope, subject)` handler keeps its byte-identical shape — TypeScript
+ * permits a 2-arg function where a 3-arg type is expected (parameter
+ * bivariance on the extra trailing param). Single-link deployments always see
+ * `sourceLink === "primary"`, which is exactly the pre-F-3d behaviour with one
+ * extra, ignorable fact attached.
+ *
+ * This slice provides the HOOK; per-network signed-federation verify
+ * (TC-2d, cortex#635) is the consumer that turns the attribution into a
+ * cryptographic peer-pubkey lookup keyed off the delivering network.
  */
-export type EnvelopeHandler = (envelope: Envelope, subject: string) => void;
+export type EnvelopeHandler = (
+  envelope: Envelope,
+  subject: string,
+  sourceLink?: string,
+) => void;
 
 /** Lifecycle handle so cortex can clean up on shutdown. */
 export interface MyelinRuntime {
@@ -971,61 +1002,166 @@ export async function startMyelinRuntime(
   // once: whichever path runs first creates the subscriber; the second
   // returns the SAME handle instead of double-binding.
   //
-  // F-3b (cortex#659): the dedupe map is now PER-LINK — it lives on the
-  // primary `PoolLink` (`primary.boundByPattern`). Boot-time push
-  // subscribers + the `runtime.subscribe` self-subscribe path are
-  // primary-only in F-3b (design §3.5), so they share the primary link's
-  // map. Leaf links carry their own (empty) `boundByPattern` for when
-  // per-network subscribe lands (F-3d).
-  const boundByPattern = primary.boundByPattern;
+  // F-3b (cortex#659): the dedupe map is now PER-LINK — it lives on each
+  // `PoolLink` (`poolLink.boundByPattern`). Boot-time `nats.subjects` push
+  // subscribers + the `runtime.subscribe` self-subscribe path bind on the
+  // PRIMARY link's map (design §3.5); F-3d (cortex#666) per-leaf inbound
+  // subscriptions bind on each leaf's own map. `bindPushPattern` now takes the
+  // target `PoolLink` explicitly rather than closing over a single map.
+
   /**
-   * Bind one resolved push pattern idempotently. Returns the already-bound
-   * subscriber on a duplicate, or `null` if `MyelinSubscriber.start` threw.
-   * Shared by the boot loop and `subscribePushEnabled`.
+   * IAW Phase F-3d (cortex#666) — fan an inbound envelope out to every
+   * registered handler, tagging the delivering link's `linkId` as
+   * `sourceLink`. Each handler runs in its own try/catch so one slow/failing
+   * consumer can't poison the others (router-level isolation lives in the
+   * surface-router; this is the defensive last line).
+   *
+   * `sourceLink` is the `PoolLink.linkId` of whichever link's subscriber
+   * delivered the envelope — `"primary"` for the `config.nats` link, the
+   * `leaf_node` for a federated leaf. The anti-spoof assertion (§3.3 / §5)
+   * runs at the per-link subscriber site (`bindPushPattern`) BEFORE this
+   * fan-out, so a `federated.{X}.…` subject that arrived on a link not owning
+   * network X never reaches handlers at all. The `sourceLink` carried here is
+   * the surplus attribution TC-2d (cortex#635) keys its per-network verify
+   * off — F-3d is the structural prerequisite, not the verify itself.
    */
-  const bindPushPattern = (pattern: string): MyelinSubscriber | null => {
-    const existing = boundByPattern.get(pattern);
+  const fanOut = (env: Envelope, subject: string, sourceLink: string): void => {
+    for (const handler of handlers) {
+      try {
+        handler(env, subject, sourceLink);
+      } catch (err) {
+        console.error(
+          "myelin-runtime: onEnvelope handler threw:",
+          err instanceof Error ? err.message : String(err),
+        );
+      }
+    }
+  };
+
+  /**
+   * IAW Phase F-3d (cortex#666) — anti-spoof source-link assertion (design
+   * §3.3 / §5, isolation layer 2). For a `federated.{network_id}.…` subject
+   * delivered on a leaf link, the subject's `{network_id}` segment MUST map to
+   * a network whose `leaf_node` equals the delivering `linkId`; an envelope
+   * claiming network X that arrived on a link NOT owning X is a cross-network
+   * spoof and is DROPPED + logged. The PRIMARY link carries `local.*` /
+   * `public.*` plus every network WITHOUT a `nats:` block (those ride
+   * primary), so primary-delivered traffic is never spoof-checked here — its
+   * legitimacy is governed by the surface-router federation gate, not by link
+   * attribution. Non-`federated.*` subjects are never checked.
+   *
+   * Returns `true` when the envelope is allowed to fan out, `false` when it
+   * was dropped as a spoof.
+   *
+   * **Back-compat:** with zero leaf links the primary subscriber is the only
+   * one bound and `linkId === "primary"`, so this returns `true` for every
+   * subject — byte-identical to the pre-F-3d single-link delivery path.
+   */
+  const passesSourceLinkCheck = (subject: string, linkId: string): boolean => {
+    // Only leaf-delivered federated subjects are spoof-checked. Primary
+    // delivery + non-federated subjects pass through (see docblock).
+    if (linkId === primary.linkId) return true;
+    if (!subject.startsWith("federated.")) return true;
+    const claimedNetworkId = subject.split(".")[1];
+    // The link that delivered this owns these network ids (built once at boot
+    // — the inverse of `networkIdToLinkId`, scoped to THIS leaf). A subject
+    // whose `{network_id}` doesn't resolve to a network on this exact leaf is
+    // a spoof.
+    const owningLinkId =
+      claimedNetworkId === undefined || claimedNetworkId.length === 0
+        ? undefined
+        : networkIdToLinkId.get(claimedNetworkId);
+    if (owningLinkId === linkId) return true;
+    console.error(
+      `myelin-runtime: DROPPING spoofed envelope subject=${subject} — claimed network "${claimedNetworkId ?? "<malformed>"}" did not arrive on its own leaf (delivered on link="${linkId}", network maps to link="${owningLinkId ?? "<unknown>"}")`,
+    );
+    return false;
+  };
+
+  /**
+   * Bind one resolved push pattern idempotently ON A SPECIFIC POOL LINK.
+   * Returns the already-bound subscriber on a duplicate, or `null` if
+   * `MyelinSubscriber.start` threw. Shared by the boot loop (primary +
+   * per-leaf F-3d subscriptions) and `subscribePushEnabled`.
+   *
+   * IAW Phase F-3d (cortex#666): the dedupe map + `subscribers[]` are the
+   * TARGET link's own (per-link, per design §3.5 / the cortex#491 per-link
+   * dedupe), and the fan-out tags `poolLink.linkId` as `sourceLink`. A leaf
+   * subscriber additionally runs `passesSourceLinkCheck` before fanning out
+   * (anti-spoof). Primary keeps its pre-F-3d behaviour exactly (the check is
+   * a no-op for `linkId === "primary"`).
+   */
+  const bindPushPattern = (
+    poolLink: PoolLink,
+    pattern: string,
+  ): MyelinSubscriber | null => {
+    const existing = poolLink.boundByPattern.get(pattern);
     if (existing !== undefined) {
       console.log(
-        `myelin-runtime: skipping duplicate subscribe to "${pattern}" (already bound)`,
+        `myelin-runtime: skipping duplicate subscribe to "${pattern}" on link="${poolLink.linkId}" (already bound)`,
       );
       return existing;
     }
+    // A down leaf (link === null) cannot bind a subscription; the background
+    // reconnect re-binds the leaf's interest when it attaches (F-3c/F-3d).
+    const targetLink = poolLink.link;
+    if (targetLink === null) {
+      console.error(
+        `myelin-runtime: cannot subscribe to "${pattern}" on down link="${poolLink.linkId}" — skipping (background reconnect will re-bind)`,
+      );
+      return null;
+    }
     try {
-      const sub = MyelinSubscriber.start(link, {
+      const sub = MyelinSubscriber.start(targetLink, {
         pattern,
         onEnvelope: (env, subject) => {
           logEnvelope(env, subject);
-          // Fan out to registered handlers. Each handler runs in its
-          // own try/catch so one slow/failing consumer can't poison
-          // the others (router-level isolation lives in the
-          // surface-router; this is a defensive last line).
-          for (const handler of handlers) {
-            try {
-              handler(env, subject);
-            } catch (err) {
-              console.error(
-                "myelin-runtime: onEnvelope handler threw:",
-                err instanceof Error ? err.message : String(err),
-              );
-            }
-          }
+          // Anti-spoof BEFORE fan-out (leaf links only; no-op for primary).
+          if (!passesSourceLinkCheck(subject, poolLink.linkId)) return;
+          fanOut(env, subject, poolLink.linkId);
         },
       });
-      subscribers.push(sub);
-      boundByPattern.set(pattern, sub);
-      console.log(`myelin-runtime: subscribed to "${pattern}"`);
+      poolLink.subscribers.push(sub);
+      poolLink.boundByPattern.set(pattern, sub);
+      console.log(
+        `myelin-runtime: subscribed to "${pattern}" on link="${poolLink.linkId}"`,
+      );
       return sub;
     } catch (err) {
       console.error(
-        `myelin-runtime: failed to subscribe to "${pattern}":`,
+        `myelin-runtime: failed to subscribe to "${pattern}" on link="${poolLink.linkId}":`,
         err instanceof Error ? err.message : String(err),
       );
       return null;
     }
   };
+  // Boot-time push subscribers from `nats.subjects[]` bind on the PRIMARY link
+  // (design §3.5 — broad-pattern push is primary-only; leaf links carry
+  // network-scoped subscriptions wired just below).
   for (const pattern of subjects) {
-    bindPushPattern(pattern);
+    bindPushPattern(primary, pattern);
+  }
+
+  // IAW Phase F-3d (cortex#666) — per-leaf inbound subscriptions. Each leaf
+  // link subscribes to the federated subjects of EVERY network mapped to it,
+  // so an inbound envelope on that leaf fans out tagged with the leaf's
+  // `linkId` as `sourceLink` (design §3.3 — "each subscriber binds to exactly
+  // one link and tags `sourceLink`"). The pattern is `federated.{network_id}.>`
+  // per network on the leaf — the same `{network_id}`-keyed grammar the
+  // surface-router gate + `selectLink` already use, so inbound attribution and
+  // outbound routing agree on a federated subject's network segment.
+  //
+  // **Back-compat:** with zero leaf links this loop binds nothing — the pool
+  // is primary-only and delivery is byte-identical to pre-F-3d. A DOWN leaf
+  // (link === null) is skipped by `bindPushPattern`; the F-3c background
+  // reconnect attaches the link but re-binding its interest on reconnect is
+  // deferred (the leaf comes back publish-capable; inbound re-bind is a TC-2d-
+  // adjacent follow-up, noted in the PR).
+  for (const [networkId, linkId] of networkIdToLinkId) {
+    if (linkId === primary.linkId) continue; // rides primary — no leaf sub.
+    const leaf = pool.get(linkId);
+    if (leaf === undefined) continue; // defensive — mapping invariant holds.
+    bindPushPattern(leaf, `federated.${networkId}.>`);
   }
 
   // cortex#337 — pre-#337 a non-empty `subjects[]` that ALL failed to
@@ -1474,7 +1610,11 @@ export async function startMyelinRuntime(
     // an earlier self-subscribe of the same pattern) returns the EXISTING
     // subscriber instead of double-binding the shared `handlers` Set. The
     // binder owns its own try/catch + logging; `null` means start() threw.
-    const sub = bindPushPattern(pattern);
+    // F-3d (cortex#666): the self-subscribe path stays bound to the PRIMARY
+    // link (design §3.5 — broad-pattern push is primary-only; per-network
+    // inbound is the boot-time per-leaf loop above). Primary delivery is never
+    // spoof-checked, so a self-subscribed handler sees `sourceLink: "primary"`.
+    const sub = bindPushPattern(primary, pattern);
     if (sub === null) return null;
     // Await readiness on every call (including the deduped return): the
     // already-bound subscriber's `ready` promise resolves immediately when

--- a/src/bus/surface-router.ts
+++ b/src/bus/surface-router.ts
@@ -171,8 +171,21 @@ export interface SurfaceRouter {
   /** Dispatch one envelope to all matching adapters. Subject is optional;
    *  when omitted, it is derived from `envelope.type` for local testing.
    *  Production callers (the future runtime hook) MUST pass the actual
-   *  NATS subject so wildcard patterns match correctly. */
-  dispatch(envelope: Envelope, subject?: string): Promise<void>;
+   *  NATS subject so wildcard patterns match correctly.
+   *
+   *  IAW Phase F-3d (cortex#666) — optional trailing `sourceLink` carrying
+   *  the delivering pool link's `linkId` (`"primary"` or a federated
+   *  `leaf_node`), threaded from the runtime's `onEnvelope` fan-out. The
+   *  federation gate consumes it as an ADDITIVE anti-spoof cross-check: a
+   *  `federated.{X}.…` subject delivered on a link NOT owning network X is
+   *  rejected. Omitted (or `undefined`) preserves pre-F-3d behaviour
+   *  exactly — the cross-check only runs when an attribution is supplied,
+   *  so existing 2-arg callers and single-link deployments are unchanged. */
+  dispatch(
+    envelope: Envelope,
+    subject?: string,
+    sourceLink?: string,
+  ): Promise<void>;
 }
 
 // =============================================================================
@@ -300,12 +313,18 @@ export function createSurfaceRouter(
       // Wire runtime → router. Each envelope from any active subscription
       // arrives at the router with its actual NATS subject (so wildcard
       // patterns route correctly).
-      envelopeReg = runtime.onEnvelope((env, subject) => {
+      envelopeReg = runtime.onEnvelope((env, subject, sourceLink) => {
         // dispatch() returns a Promise; we don't await — the runtime's
         // subscriber loop must not block on adapter rendering. The router
         // already isolates adapter errors via renderWithIsolation so this
         // floating Promise resolves cleanly.
-        void router.dispatch(env, subject);
+        //
+        // IAW Phase F-3d (cortex#666): forward the delivering link's
+        // attribution so the federation gate can cross-check the subject's
+        // claimed network against the link it actually arrived on. Additive —
+        // a runtime that doesn't tag (older fake stubs) passes `undefined` and
+        // the gate's cross-check is skipped.
+        void router.dispatch(env, subject, sourceLink);
       });
     },
 
@@ -319,7 +338,7 @@ export function createSurfaceRouter(
       }
     },
 
-    async dispatch(envelope, subject) {
+    async dispatch(envelope, subject, sourceLink) {
       if (stopped) return;
 
       const effectiveSubject = subject ?? envelope.type;
@@ -354,6 +373,12 @@ export function createSurfaceRouter(
           effectiveSubject,
           envelope,
           federatedNetworksById,
+          // IAW Phase F-3d (cortex#666) — additive anti-spoof input. When the
+          // runtime tags the delivering `linkId`, the gate cross-checks the
+          // subject's claimed `{network_id}` against the network the
+          // attribution belongs to; `undefined` (no attribution) skips the
+          // cross-check, preserving pre-F-3d behaviour.
+          sourceLink,
         );
         if (decision !== "allow") {
           emitFederationDenied(
@@ -646,6 +671,21 @@ export type FederationGateDecision =
       networkId: string;
       observed_hops: number;
       max_hop: number;
+    }
+  | {
+      /**
+       * IAW Phase F-3d (cortex#666) — anti-spoof: the envelope's subject
+       * claimed network `networkId`, but it was DELIVERED on a link whose
+       * `leaf_node` does not own that network (`sourceLink`). A subject
+       * claiming `federated.{X}.…` that arrived on a link not owning X is a
+       * cross-network spoof (design §3.3 / §5 isolation layer 2). Only
+       * possible when a `sourceLink` attribution is supplied — the
+       * cross-check is skipped otherwise (back-compat).
+       */
+      kind: "source_link_mismatch";
+      networkId: string;
+      sourceLink: string;
+      expectedLeafNode: string;
     };
 
 /**
@@ -675,6 +715,7 @@ export function evaluateFederationGate(
   subject: string,
   envelope: Envelope,
   networksById: Map<string, PolicyFederatedNetwork>,
+  sourceLink?: string,
 ): FederationGateDecision {
   // Subject MUST start with `federated.` — caller guards this, but
   // the function is exported for tests and we'd rather fail-closed
@@ -715,6 +756,40 @@ export function evaluateFederationGate(
       kind: "peer_not_in_accept_list",
       networkId,
       unknown_network: true,
+    };
+  }
+
+  // IAW Phase F-3d (cortex#666) — anti-spoof cross-check (design §3.3 / §5
+  // isolation layer 2). When the runtime supplied a LEAF delivering-link
+  // attribution, the subject's claimed network MUST be served by that exact
+  // leaf: the network's `leaf_node` has to equal `sourceLink`. A subject
+  // claiming `federated.{X}.…` that arrived on a different leaf is a
+  // cross-network spoof and is denied BEFORE deny/accept/hop checks — the
+  // delivering link is more authoritative than any subject-pattern rule.
+  //
+  // SKIPPED in two cases (both back-compat-preserving):
+  //   1. `sourceLink === undefined` — no attribution (pre-F-3d callers,
+  //      primary-only deployments routed without tagging). Behaviour
+  //      unchanged unless the runtime opts in.
+  //   2. `sourceLink === "primary"` — the envelope arrived on the primary
+  //      link, which carries `local.*`/`public.*` PLUS every federated
+  //      network WITHOUT a `nats:` block (those ride primary by design).
+  //      A network riding primary keeps its declared `leaf_node` name, so a
+  //      `leaf_node !== "primary"` equality would wrongly flag legitimate
+  //      primary-routed federated traffic. The runtime's `passesSourceLinkCheck`
+  //      makes the symmetric exclusion (primary delivery is never spoof-checked);
+  //      this gate mirrors it. Primary-routed federated subjects remain
+  //      governed by the accept/deny/hop checks below, exactly as pre-F-3d.
+  if (
+    sourceLink !== undefined &&
+    sourceLink !== "primary" &&
+    network.leaf_node !== sourceLink
+  ) {
+    return {
+      kind: "source_link_mismatch",
+      networkId,
+      sourceLink,
+      expectedLeafNode: network.leaf_node,
     };
   }
 
@@ -834,6 +909,14 @@ export function emitFederationDenied(
         kind: "max_hop_exceeded",
         observed_hops: decision.observed_hops,
         max_hop: decision.max_hop,
+      };
+      break;
+    case "source_link_mismatch":
+      // IAW Phase F-3d (cortex#666) — anti-spoof denial.
+      reason = {
+        kind: "source_link_mismatch",
+        source_link: decision.sourceLink,
+        expected_leaf_node: decision.expectedLeafNode,
       };
       break;
   }

--- a/src/bus/system-events.ts
+++ b/src/bus/system-events.ts
@@ -771,6 +771,12 @@ export function createSystemAccessDeniedEvent(
  *     (D.2.3). Variant fields carry the observed hop count + the
  *     network's budget so subscribers can render "3 stamps > 1
  *     allowed" without re-parsing the envelope.
+ *   - `"source_link_mismatch"` — IAW Phase F-3d (cortex#666) anti-spoof:
+ *     the subject claimed network `network_id`, but it was DELIVERED on a
+ *     federated leaf link whose `leaf_node` does not own that network. A
+ *     cross-network spoof (design §3.3 / §5). Variant fields carry the
+ *     delivering link and the network's expected `leaf_node` so audit
+ *     consumers can render "arrived on leaf X, expected leaf Y".
  *
  * Subjects (the actual `deny_subjects` / `accept_subjects` patterns
  * are principal data, not enum values — they ride on `reason.subject`
@@ -779,7 +785,8 @@ export function createSystemAccessDeniedEvent(
 export type SystemAccessFederationDeniedReasonKind =
   | "peer_not_in_accept_list"
   | "peer_deny_list"
-  | "max_hop_exceeded";
+  | "max_hop_exceeded"
+  | "source_link_mismatch";
 
 /**
  * Options for `createSystemAccessFederationDeniedEvent` — the D.2
@@ -860,6 +867,14 @@ export interface SystemAccessFederationDeniedOpts {
         observed_hops: number;
         /** Configured `network.max_hop`. */
         max_hop: number;
+      }
+    | {
+        /** IAW Phase F-3d (cortex#666) — anti-spoof leaf/subject mismatch. */
+        kind: "source_link_mismatch";
+        /** The link the envelope actually arrived on (delivering `linkId`). */
+        source_link: string;
+        /** The `leaf_node` the claimed network is configured to use. */
+        expected_leaf_node: string;
       };
   /** Classification override; defaults to local per system.* convention. */
   classification?: Classification;

--- a/src/runner/dispatch-listener.ts
+++ b/src/runner/dispatch-listener.ts
@@ -812,7 +812,7 @@ export function createDispatchListener(
       // directly on the runtime, symmetric with `BusDispatchListener`.
       // The handler filters by subject + dispatches in a tracked
       // microtask; no render-timeout wraps the CC session.
-      envelopeRegistration = runtime.onEnvelope((envelope, subject) => {
+      envelopeRegistration = runtime.onEnvelope((envelope, subject, sourceLink) => {
         // cortex#492 — best-effort trace context from the raw envelope
         // before the payload is parsed. `task_id` falls back to the
         // correlation_id / envelope id; `agent_id` is a peek at the
@@ -857,6 +857,11 @@ export function createDispatchListener(
             subject,
             envelope,
             federatedNetworksById,
+            // IAW Phase F-3d (cortex#666) — additive anti-spoof input. The
+            // runtime tags the delivering `linkId`; the gate cross-checks the
+            // subject's claimed network against the link it arrived on.
+            // `undefined` (no attribution) skips the cross-check (back-compat).
+            sourceLink,
           );
           if (decision !== "allow") {
             trace(


### PR DESCRIPTION
Closes #666. Part of #631 / #627. Final F-3-core slice.

## What
Thread WHICH pool link (and therefore which federation network) delivered an inbound envelope through to the runtime's `onEnvelope` handlers, as an **additive trailing** `sourceLink?` arg. F-3b/F-3c built the LinkPool (per-network leaf links, subject-routed publish, degrade-don't-crash); F-3d adds the symmetric **inbound** attribution that the surface-router federated gate and TC-2d (#635) consume.

This slice provides the **hook** — it does NOT implement crypto verify.

## Changes
- **`EnvelopeHandler`** (`runtime.ts`) gains optional trailing `sourceLink?: string`: `"primary"` for the `config.nats` link, a `leaf_node` for a federated leaf.
- **Per-leaf inbound subscriptions**: each leaf link subscribes to `federated.{network_id}.>` for every network mapped to it, and fans out tagging `sourceLink = leaf_node`. Boot-time `nats.subjects[]` + the self-subscribe path stay primary-only (design §3.5) and tag `"primary"`.
- **Runtime anti-spoof** (`passesSourceLinkCheck`): a `federated.{X}.…` subject delivered on a leaf NOT owning X is DROPPED + logged BEFORE fan-out (design §3.3 / §5 isolation layer 2). Primary delivery + non-federated subjects are never spoof-checked.
- **Surface-router federated gate** fed the attribution as an ADDITIVE anti-spoof cross-check: new `source_link_mismatch` `FederationGateDecision` + matching `system.access.denied` reason kind. Threaded through `dispatch(env, subject, sourceLink?)`, the runtime `onEnvelope` wiring, and the dispatch-listener Option-D gate.

## Back-compat (single-link ⇒ unchanged)
- Third arg is optional + trailing ⇒ existing `(envelope, subject)` handlers keep their byte-identical shape (verified by a test).
- Zero per-network `nats:` ⇒ pool is primary-only ⇒ `sourceLink` is always `"primary"` ⇒ delivery byte-identical to pre-F-3d.
- The gate cross-check is SKIPPED when `sourceLink` is `undefined` (no attribution) or `"primary"` (a network riding primary keeps its declared `leaf_node`; primary-routed federated traffic stays governed by accept/deny/hop, not link attribution). The runtime makes the symmetric exclusion.

## Verification
- `bunx tsc --noEmit` — clean (no error TS).
- `bun run lint:errors` — clean.
- `bun test src/bus/ src/runner/` — **936 pass / 0 fail** (1 skip pre-existing).
- New tests:
  - `runtime-source-link.test.ts` — (a) leaf inbound → `sourceLink = leaf_node`; (b) primary inbound → `"primary"`; (c) legacy 2-arg handler still works; (d) anti-spoof drop (cross-network subject on the wrong leaf) + correct delivery sanity.
  - `surface-router.test.ts` — gate cross-check: no-sourceLink skip, match→allow, mismatch→`source_link_mismatch`, `"primary"`→skip, mismatch-decided-before-accept; + `dispatch(env, subject, sourceLink)` wiring (mismatch drops, match renders).
  - `runtime-principal-symmetry.test.ts` — per-link `{network_id}` symmetry (subscribe `federated.{net}.>` === publish-routing key per leaf; no cross-leak).

## What's left
- **TC-2d (#635)** — per-network signed-federation verify. F-3d is the structural prerequisite: the `sourceLink` attribution is the exact hook TC-2d keys its per-network peer-pubkey lookup off (a signature valid in network A is meaningless in B). This slice ships the attribution + anti-spoof seam; cryptographic verify is out of scope (federation ships unsigned per the federation-FIRST drive).
- **Emit-grammar fix (#661)** — `deriveNatsSubject` still emits `federated.{principal}.{stack}.{type}` (segment[1] = principal, not network_id). Harmless today (no production site emits `classification: "federated"` through the derive path with a leaf present; the zero-leaf back-compat short-circuit hides it), but the emit-site fix lands under #661 so a real federated `runtime.publish` routes by network_id. F-3d's inbound subscribe + `selectLink` already use the correct `{network_id}`-keyed grammar.
- Re-binding a leaf's inbound interest on F-3c background-reconnect is deferred (the leaf returns publish-capable; inbound re-bind is a TC-2d-adjacent follow-up — noted in the per-leaf subscribe loop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)