### PR TITLE
fix(runner): de-flake bash-guard ingest test — ephemeral port (closes #670)

### DIFF
--- a/src/runner/hooks/__tests__/bash-guard.hook.test.ts
+++ b/src/runner/hooks/__tests__/bash-guard.hook.test.ts
@@ -229,9 +229,11 @@ describe("bash-guard.hook — block telemetry", () => {
   });
 
   test("a block POSTs the event to the HTTP ingest endpoint", async () => {
-    // The hook POSTs to a hardcoded http://localhost:8766/api/events/ingest
-    // before falling back to JSONL. Stand up a real listener on that port so
-    // the POST "succeeds", and capture the request body to assert its shape.
+    // The hook POSTs to its ingest endpoint before falling back to JSONL. Stand
+    // up a real listener on an EPHEMERAL port (port: 0) and point the hook at it
+    // via CORTEX_INGEST_URL, so the POST "succeeds" and we can capture the body
+    // to assert its shape. Using port 0 (not the hardcoded 8766) avoids the
+    // EADDRINUSE flake when sibling Bun.serve suites hold 8766 under the full run.
     //
     // NOTE: the hook must be spawned *asynchronously* here. spawnSync would
     // block the test's event loop, starving the in-process Bun.serve so the
@@ -245,7 +247,7 @@ describe("bash-guard.hook — block telemetry", () => {
     } = { body: null, path: null, contentType: null };
 
     const server = Bun.serve({
-      port: 8766,
+      port: 0,
       async fetch(req) {
         seen.path = new URL(req.url).pathname;
         seen.contentType = req.headers.get("content-type");
@@ -253,6 +255,7 @@ describe("bash-guard.hook — block telemetry", () => {
         return new Response("ok", { status: 200 });
       },
     });
+    const ingestUrl = `http://localhost:${server.port}/api/events/ingest`;
 
     try {
       const groveOverrides = new Set(GROVE_ENV_KEYS);
@@ -263,6 +266,7 @@ describe("bash-guard.hook — block telemetry", () => {
       Object.assign(merged, {
         GROVE_CHANNEL: "test-channel",
         HOME: homeDir,
+        CORTEX_INGEST_URL: ingestUrl,
       });
 
       const proc = Bun.spawn(["bun", HOOK_PATH], {

--- a/src/runner/hooks/bash-guard.hook.ts
+++ b/src/runner/hooks/bash-guard.hook.ts
@@ -143,7 +143,12 @@ function deny(reason: string): void {
 // here must never affect the deny decision.
 // =============================================================================
 
-const INGEST_URL = "http://localhost:8766/api/events/ingest";
+// Default targets the local dashboard ingest endpoint. Overridable via
+// CORTEX_INGEST_URL so tests can point the POST at an ephemeral port instead of
+// the hardcoded 8766 (which collides with sibling Bun.serve suites under the
+// full test run). Production leaves the env unset → unchanged behaviour.
+const INGEST_URL =
+  process.env.CORTEX_INGEST_URL ?? "http://localhost:8766/api/events/ingest";
 const EVENTS_DIR = join(process.env.HOME ?? "~", ".claude", "events");
 const RAW_DIR = join(EVENTS_DIR, "raw");
 


### PR DESCRIPTION
## Problem
`bash-guard.hook.test.ts` ("a block POSTs the event to the HTTP ingest endpoint") bound `Bun.serve({ port: 8766 })` because the hook POSTed to a **hardcoded** `http://localhost:8766/api/events/ingest`. Sibling suites (`mc/api`, `mc/index`, `common/timeout`) also bind 8766 → under the full `bun test` run, `EADDRINUSE` → intermittent failure. Echo flagged it during the #668 review (passed 12/12 in isolation, won the CI race that run).

## Fix (root cause, surgical)
- `bash-guard.hook.ts`: `INGEST_URL` now `process.env.CORTEX_INGEST_URL ?? "http://localhost:8766/..."` — default unchanged, production untouched.
- test: binds `port: 0` (ephemeral), points the spawned hook at it via `CORTEX_INGEST_URL`. No hardcoded-port coupling.

## Verification
- **De-flake proven**: 12/12 pass with 8766 *deliberately squatted* by a background server (the exact contention that crashed it).
- tsc 0 · lint clean · vocab gate PASS.

Closes #670.