### PR TITLE
feat(bus): TC-2b — multi-principal peer-stamped IdentityRegistry (#634)

### DIFF
--- a/src/common/registry/__tests__/identity-registry.test.ts
+++ b/src/common/registry/__tests__/identity-registry.test.ts
@@ -1,0 +1,438 @@
+/**
+ * TC-2b (cortex#634) — MultiPrincipalIdentityRegistry tests.
+ *
+ * Covers the spec matrix:
+ *
+ *   1. Back-compat — single boot principal still resolves as before
+ *      (no resolver wired; only the pinned boot entry is available).
+ *   2. Multi-principal — register/resolve principals A and B, both
+ *      retrievable, no cross-contamination.
+ *   3. On-demand resolve populates the map via the resolver; second
+ *      lookup is a cache hit (no re-resolve).
+ *   4. Posture OFF — peer lookup performs ZERO registry I/O; only the
+ *      boot entry is available.
+ *   5. Unresolved peer → negative outcome, NOT a throw; the local boot
+ *      entry is never overwritten.
+ *
+ * The on-demand end-to-end test drives a real TC-2a `PrincipalPubkeyResolver`
+ * against an EPHEMERAL `Bun.serve({ port: 0 })` registry stub — never a
+ * hardcoded port (the #671 de-flake). The remaining tests inject a tiny
+ * resolver stub so the cache / posture / negative paths are deterministic
+ * and I/O-free.
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+
+import {
+  MultiPrincipalIdentityRegistry,
+  type RegistryResolveOutcome,
+} from "../identity-registry";
+import { PrincipalPubkeyResolver, type ResolveResult } from "../resolve-pubkey";
+import { canonicalJSON } from "../signing";
+import type { Identity } from "@the-metafactory/myelin/identity";
+
+// =============================================================================
+// Fixtures
+// =============================================================================
+
+// A structurally-valid base64 Ed25519 pubkey (44 chars w/ padding).
+const PEER_PUBKEY_A = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+const PEER_PUBKEY_B = "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB=";
+const BOOT_PUBKEY = "Q0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0NDQ0M=";
+
+function bootIdentity(principalId: string): Identity {
+  return {
+    id: `did:mf:${principalId}`,
+    display_name: principalId,
+    network: principalId,
+    public_key: BOOT_PUBKEY,
+    type: "agent",
+    created_at: new Date(0).toISOString(),
+  };
+}
+
+/**
+ * Minimal resolver stub implementing `Pick<PrincipalPubkeyResolver,
+ * "resolve">`. Drives the registry's resolve matrix without any I/O.
+ * Counts calls so cache-hit tests can assert no re-resolve.
+ */
+function makeResolverStub(
+  responses: Record<string, ResolveResult>,
+  fallback: ResolveResult = { status: "unresolved" },
+): { resolve: (id: string) => Promise<ResolveResult>; calls: string[] } {
+  const calls: string[] = [];
+  return {
+    calls,
+    resolve(id: string): Promise<ResolveResult> {
+      calls.push(id);
+      return Promise.resolve(responses[id] ?? fallback);
+    },
+  };
+}
+
+// =============================================================================
+// 1. Back-compat — single boot principal, no resolver
+// =============================================================================
+
+describe("back-compat (single-principal)", () => {
+  test("boot principal resolves synchronously and via resolve()", async () => {
+    const reg = new MultiPrincipalIdentityRegistry({
+      bootPrincipal: { principalId: "boot", identity: bootIdentity("boot") },
+    });
+
+    const got = reg.get("boot");
+    expect(got).toBeDefined();
+    expect(got?.provenance).toBe("local-boot");
+    expect(got?.identity.public_key).toBe(BOOT_PUBKEY);
+
+    const resolved = await reg.resolve("boot");
+    expect(resolved.resolved).toBe(true);
+    if (resolved.resolved) {
+      expect(resolved.entry.principalId).toBe("boot");
+      expect(resolved.entry.provenance).toBe("local-boot");
+    }
+  });
+
+  test("materialised myelin registry contains exactly the boot identity", () => {
+    const reg = new MultiPrincipalIdentityRegistry({
+      bootPrincipal: { principalId: "boot", identity: bootIdentity("boot") },
+    });
+    const myelin = reg.toIdentityRegistry();
+    expect(myelin.list()).toHaveLength(1);
+    expect(myelin.resolve("did:mf:boot")?.public_key).toBe(BOOT_PUBKEY);
+  });
+
+  test("unknown peer with no resolver is inert (disabled), no boot mutation", async () => {
+    const reg = new MultiPrincipalIdentityRegistry({
+      bootPrincipal: { principalId: "boot", identity: bootIdentity("boot") },
+    });
+    const outcome = await reg.resolve("stranger");
+    expect(outcome).toEqual({ resolved: false, reason: "disabled" });
+    expect(reg.get("stranger")).toBeUndefined();
+    expect(reg.list()).toHaveLength(1);
+  });
+});
+
+// =============================================================================
+// 2. Multi-principal — A and B, no cross-contamination
+// =============================================================================
+
+describe("multi-principal", () => {
+  test("resolves A and B; both retrievable; no cross-contamination", async () => {
+    const stub = makeResolverStub({
+      alice: { status: "resolved", principalPubkey: PEER_PUBKEY_A },
+      bob: { status: "resolved", principalPubkey: PEER_PUBKEY_B },
+    });
+    const reg = new MultiPrincipalIdentityRegistry({
+      bootPrincipal: { principalId: "boot", identity: bootIdentity("boot") },
+      resolver: stub,
+    });
+
+    const a = await reg.resolve("alice");
+    const b = await reg.resolve("bob");
+
+    expect(a.resolved).toBe(true);
+    expect(b.resolved).toBe(true);
+    if (a.resolved) expect(a.entry.identity.public_key).toBe(PEER_PUBKEY_A);
+    if (b.resolved) expect(b.entry.identity.public_key).toBe(PEER_PUBKEY_B);
+
+    // No cross-contamination: A's pubkey stays A's, B's stays B's.
+    expect(reg.get("alice")?.identity.public_key).toBe(PEER_PUBKEY_A);
+    expect(reg.get("bob")?.identity.public_key).toBe(PEER_PUBKEY_B);
+    expect(reg.get("alice")?.identity.id).toBe("did:mf:alice");
+    expect(reg.get("bob")?.identity.id).toBe("did:mf:bob");
+    expect(reg.get("alice")?.provenance).toBe("resolved-registry");
+
+    // Boot + 2 peers materialise into the myelin registry.
+    const myelin = reg.toIdentityRegistry();
+    expect(myelin.list()).toHaveLength(3);
+    expect(myelin.resolve("did:mf:alice")?.public_key).toBe(PEER_PUBKEY_A);
+    expect(myelin.resolve("did:mf:bob")?.public_key).toBe(PEER_PUBKEY_B);
+    expect(myelin.resolve("did:mf:boot")?.public_key).toBe(BOOT_PUBKEY);
+  });
+
+  test("peerNetwork override stamps the resolved Identity.network", async () => {
+    const stub = makeResolverStub({
+      alice: { status: "resolved", principalPubkey: PEER_PUBKEY_A },
+    });
+    const reg = new MultiPrincipalIdentityRegistry({
+      bootPrincipal: { principalId: "boot", identity: bootIdentity("boot") },
+      resolver: stub,
+      peerNetwork: () => "shared-net",
+    });
+    const a = await reg.resolve("alice");
+    if (a.resolved) expect(a.entry.identity.network).toBe("shared-net");
+    // Default would have been the peer's own id.
+    expect(reg.get("alice")?.identity.network).toBe("shared-net");
+  });
+});
+
+// =============================================================================
+// 3. On-demand resolve populates the map; cache hit on second lookup
+// =============================================================================
+
+describe("on-demand resolve + cache", () => {
+  test("second resolve is a cache hit — resolver not consulted twice", async () => {
+    const stub = makeResolverStub({
+      alice: { status: "resolved", principalPubkey: PEER_PUBKEY_A },
+    });
+    const reg = new MultiPrincipalIdentityRegistry({
+      bootPrincipal: { principalId: "boot", identity: bootIdentity("boot") },
+      resolver: stub,
+    });
+
+    const first = await reg.resolve("alice");
+    expect(first.resolved).toBe(true);
+    expect(stub.calls).toEqual(["alice"]);
+
+    // Synchronous get now hits the populated map.
+    expect(reg.get("alice")?.identity.public_key).toBe(PEER_PUBKEY_A);
+
+    const second = await reg.resolve("alice");
+    expect(second.resolved).toBe(true);
+    // Resolver consulted exactly once across both resolves.
+    expect(stub.calls).toEqual(["alice"]);
+  });
+
+  test("end-to-end through a real resolver + ephemeral registry stub", async () => {
+    const kp = await generateKeypair();
+    const counter = { principals: 0, pubkey: 0 };
+    const stub = startRegistryStub({
+      registryPubkey: kp.publicKeyB64,
+      sign: (payload) => signAssertion(kp.privateKey, kp.publicKeyB64, payload),
+      counter,
+    });
+    serversToStop.push(stub.stop);
+
+    const resolver = new PrincipalPubkeyResolver({
+      enabled: true,
+      baseUrl: stub.baseUrl,
+      registryPubkey: kp.publicKeyB64,
+    });
+    const reg = new MultiPrincipalIdentityRegistry({
+      bootPrincipal: { principalId: "boot", identity: bootIdentity("boot") },
+      resolver,
+    });
+
+    // Miss → on-demand resolve populates the map.
+    expect(reg.get("alice")).toBeUndefined();
+    const outcome = await reg.resolve("alice");
+    expect(outcome.resolved).toBe(true);
+    if (outcome.resolved) {
+      expect(outcome.entry.provenance).toBe("resolved-registry");
+      expect(outcome.entry.identity.id).toBe("did:mf:alice");
+    }
+    expect(counter.principals).toBe(1);
+
+    // Cache hit: second resolve does not re-fetch the registry.
+    await reg.resolve("alice");
+    expect(counter.principals).toBe(1);
+
+    // The materialised myelin registry now carries the resolved peer.
+    expect(reg.toIdentityRegistry().resolve("did:mf:alice")).not.toBeNull();
+  });
+});
+
+// =============================================================================
+// 4. Posture OFF — zero I/O, only boot entry available
+// =============================================================================
+
+describe("posture OFF", () => {
+  test("disabled resolver performs ZERO registry I/O", async () => {
+    let fetchCalls = 0;
+    const resolver = new PrincipalPubkeyResolver({
+      enabled: false, // signing !== "enforce"
+      baseUrl: "http://127.0.0.1:1", // never reached
+      registryPubkey: BOOT_PUBKEY,
+      fetch: ((..._args: Parameters<typeof fetch>) => {
+        fetchCalls++;
+        return Promise.reject(new Error("network must not be touched when OFF"));
+      }) as typeof fetch,
+    });
+    const reg = new MultiPrincipalIdentityRegistry({
+      bootPrincipal: { principalId: "boot", identity: bootIdentity("boot") },
+      resolver,
+    });
+
+    const outcome = await reg.resolve("alice");
+    expect(outcome).toEqual({ resolved: false, reason: "disabled" });
+    expect(fetchCalls).toBe(0);
+
+    // Only the boot entry is available.
+    expect(reg.get("alice")).toBeUndefined();
+    expect(reg.list()).toHaveLength(1);
+    expect(reg.get("boot")?.provenance).toBe("local-boot");
+  });
+});
+
+// =============================================================================
+// 5. Unresolved / not_found peer → negative, never a throw; boot untouched
+// =============================================================================
+
+describe("negative paths (no throw, boot anchor preserved)", () => {
+  test("unresolved peer → reason 'unresolved', not cached, boot intact", async () => {
+    const stub = makeResolverStub(
+      {},
+      { status: "unresolved" }, // every miss is unresolved
+    );
+    const reg = new MultiPrincipalIdentityRegistry({
+      bootPrincipal: { principalId: "boot", identity: bootIdentity("boot") },
+      resolver: stub,
+      logError: () => {}, // negative-path logging is asserted by behaviour, not stderr
+    });
+
+    const outcome = await reg.resolve("ghost");
+    expect(outcome).toEqual({ resolved: false, reason: "unresolved" });
+    // Negative not cached — re-resolve consults the resolver again.
+    expect(reg.get("ghost")).toBeUndefined();
+    await reg.resolve("ghost");
+    expect(stub.calls).toEqual(["ghost", "ghost"]);
+
+    // Boot anchor untouched.
+    expect(reg.get("boot")?.identity.public_key).toBe(BOOT_PUBKEY);
+    expect(reg.list()).toHaveLength(1);
+  });
+
+  test("not_found peer → reason 'not_found', not cached", async () => {
+    const stub = makeResolverStub({ ghost: { status: "not_found" } });
+    const reg = new MultiPrincipalIdentityRegistry({
+      bootPrincipal: { principalId: "boot", identity: bootIdentity("boot") },
+      resolver: stub,
+      logError: () => {}, // negative-path logging is asserted by behaviour
+    });
+    const outcome: RegistryResolveOutcome = await reg.resolve("ghost");
+    expect(outcome).toEqual({ resolved: false, reason: "not_found" });
+    expect(reg.get("ghost")).toBeUndefined();
+  });
+
+  test("resolver returning the boot id does NOT overwrite the boot anchor", async () => {
+    // A misbehaving / hostile resolver tries to re-stamp the boot principal
+    // with a different pubkey. The pinned boot entry must win.
+    const stub = makeResolverStub({
+      boot: { status: "resolved", principalPubkey: PEER_PUBKEY_A },
+    });
+    const reg = new MultiPrincipalIdentityRegistry({
+      bootPrincipal: { principalId: "boot", identity: bootIdentity("boot") },
+      resolver: stub,
+    });
+
+    // get() always returns the pinned boot entry without consulting resolver.
+    expect(reg.get("boot")?.identity.public_key).toBe(BOOT_PUBKEY);
+    // resolve() returns the pinned entry (cache hit) — resolver never called.
+    const outcome = await reg.resolve("boot");
+    expect(outcome.resolved).toBe(true);
+    if (outcome.resolved) {
+      expect(outcome.entry.provenance).toBe("local-boot");
+      expect(outcome.entry.identity.public_key).toBe(BOOT_PUBKEY);
+    }
+    expect(stub.calls).toEqual([]); // boot is a cache hit, no resolver I/O
+    expect(reg.list()).toHaveLength(1);
+  });
+});
+
+// =============================================================================
+// Ed25519 sign-side helpers + ephemeral registry stub (mirrors
+// resolve-pubkey.test.ts — Bun.serve({ port: 0 }), never a hardcoded port).
+// =============================================================================
+
+const serversToStop: (() => void)[] = [];
+afterEach(() => {
+  while (serversToStop.length > 0) {
+    const stop = serversToStop.pop();
+    if (stop) stop();
+  }
+});
+
+function bytesToBase64(bytes: Uint8Array): string {
+  let bin = "";
+  for (const b of bytes) bin += String.fromCharCode(b);
+  return btoa(bin);
+}
+
+async function generateKeypair(): Promise<{
+  privateKey: CryptoKey;
+  publicKeyB64: string;
+}> {
+  const kp = await crypto.subtle.generateKey({ name: "Ed25519" }, true, [
+    "sign",
+    "verify",
+  ]);
+  const raw = await crypto.subtle.exportKey("raw", kp.publicKey);
+  return {
+    privateKey: kp.privateKey,
+    publicKeyB64: bytesToBase64(new Uint8Array(raw)),
+  };
+}
+
+interface PrincipalPayload {
+  principal_id: string;
+  principal_pubkey: string;
+  stacks: unknown[];
+  capabilities: unknown[];
+  updated_at: string;
+}
+
+async function signAssertion(
+  registryPrivateKey: CryptoKey,
+  registryPubkey: string,
+  payload: PrincipalPayload,
+): Promise<unknown> {
+  const issued_at = new Date().toISOString();
+  const bound = canonicalJSON({ payload, issued_at, registry: registryPubkey });
+  const sig = await crypto.subtle.sign(
+    { name: "Ed25519" },
+    registryPrivateKey,
+    new TextEncoder().encode(bound),
+  );
+  return {
+    payload,
+    issued_at,
+    registry: registryPubkey,
+    signature: bytesToBase64(new Uint8Array(sig)),
+  };
+}
+
+interface RegistryStubOptions {
+  registryPubkey: string;
+  sign: (payload: PrincipalPayload) => Promise<unknown>;
+  counter: { principals: number; pubkey: number };
+}
+
+function startRegistryStub(opts: RegistryStubOptions): {
+  baseUrl: string;
+  stop: () => void;
+} {
+  const server = Bun.serve({
+    port: 0, // ephemeral — OS assigns a free port (#671 de-flake pattern)
+    async fetch(req) {
+      const url = new URL(req.url);
+      if (url.pathname === "/registry/pubkey") {
+        opts.counter.pubkey++;
+        return Response.json({
+          algorithm: "Ed25519",
+          public_key: opts.registryPubkey,
+        });
+      }
+      const match = /^\/principals\/(.+)$/.exec(url.pathname);
+      if (match) {
+        opts.counter.principals++;
+        const principalId = decodeURIComponent(match[1] ?? "");
+        const payload: PrincipalPayload = {
+          principal_id: principalId,
+          principal_pubkey: PEER_PUBKEY_A,
+          stacks: [{ stack_id: `${principalId}/laptop` }],
+          capabilities: [],
+          updated_at: new Date().toISOString(),
+        };
+        return Response.json(await opts.sign(payload));
+      }
+      return new Response("not found", { status: 404 });
+    },
+  });
+  return {
+    baseUrl: server.url.toString(),
+    stop: () => {
+      server.stop(true);
+    },
+  };
+}

--- a/src/common/registry/__tests__/identity-registry.test.ts
+++ b/src/common/registry/__tests__/identity-registry.test.ts
@@ -331,6 +331,87 @@ describe("negative paths (no throw, boot anchor preserved)", () => {
 });
 
 // =============================================================================
+// DID-collision attack — boot anchor displacement at materialisation
+// =============================================================================
+
+describe("DID-collision attack (boot anchor displacement)", () => {
+  // The internal map is keyed by principalId, but the materialised myelin
+  // registry the verifier consumes is keyed by DID and is last-write-wins.
+  // `peerDid(p) = did:mf:<p>` is injective over principalId, so two peers can
+  // never collide — the ONLY reachable collision is peer-vs-boot, because the
+  // boot DID is a caller-supplied STACK DID (`did:mf:<principal>-<stack>`),
+  // independent of the boot principalId. A peer registering the hyphenated id
+  // `andreas-meta-factory` yields `did:mf:andreas-meta-factory`, colliding with
+  // a boot stack DID of the same form. That peer must be REFUSED, or a registry
+  // compromise could shadow the out-of-band boot anchor in the verify registry.
+
+  // Boot whose principalId ("boot") differs from its DID (a stack-DID form),
+  // so a peer with a distinct principalId can collide on the DID.
+  function bootWithStackDid(): Identity {
+    return {
+      id: "did:mf:andreas-meta-factory",
+      display_name: "boot",
+      network: "andreas",
+      public_key: BOOT_PUBKEY,
+      type: "agent",
+      created_at: new Date(0).toISOString(),
+    };
+  }
+
+  test("peer whose DID collides with the boot DID is refused; boot pubkey preserved in BOTH key spaces", async () => {
+    const stub = makeResolverStub({
+      "andreas-meta-factory": {
+        status: "resolved",
+        principalPubkey: PEER_PUBKEY_A,
+      },
+    });
+    const reg = new MultiPrincipalIdentityRegistry({
+      bootPrincipal: { principalId: "boot", identity: bootWithStackDid() },
+      resolver: stub,
+    });
+
+    // Distinct principalId → NOT a boot cache-hit → reaches the resolver →
+    // the DID-collision guard fires (proves it's the guard, not the map cache).
+    const outcome = await reg.resolve("andreas-meta-factory");
+    expect(outcome.resolved).toBe(false);
+    if (!outcome.resolved) expect(outcome.reason).toBe("unresolved");
+    expect(stub.calls).toEqual(["andreas-meta-factory"]); // resolver WAS consulted
+
+    // principalId map: the collision entry was never stored.
+    expect(reg.get("andreas-meta-factory")).toBeUndefined();
+    expect(reg.list()).toHaveLength(1);
+
+    // DID-keyed materialised registry: the boot pubkey survives, NOT the peer's.
+    const myelin = reg.toIdentityRegistry();
+    expect(myelin.list()).toHaveLength(1);
+    expect(myelin.resolve("did:mf:andreas-meta-factory")?.public_key).toBe(
+      BOOT_PUBKEY,
+    );
+  });
+
+  test("a non-colliding peer alongside a stack-DID boot still resolves normally", async () => {
+    // Guard is a precise equality check on the boot DID — it must not reject
+    // legitimate peers that merely share a principal prefix.
+    const stub = makeResolverStub({
+      andreas: { status: "resolved", principalPubkey: PEER_PUBKEY_B },
+    });
+    const reg = new MultiPrincipalIdentityRegistry({
+      bootPrincipal: { principalId: "boot", identity: bootWithStackDid() },
+      resolver: stub,
+    });
+
+    const outcome = await reg.resolve("andreas"); // did:mf:andreas ≠ boot DID
+    expect(outcome.resolved).toBe(true);
+    expect(reg.get("andreas")?.identity.public_key).toBe(PEER_PUBKEY_B);
+    const myelin = reg.toIdentityRegistry();
+    expect(myelin.resolve("did:mf:andreas")?.public_key).toBe(PEER_PUBKEY_B);
+    expect(myelin.resolve("did:mf:andreas-meta-factory")?.public_key).toBe(
+      BOOT_PUBKEY,
+    );
+  });
+});
+
+// =============================================================================
 // Ed25519 sign-side helpers + ephemeral registry stub (mirrors
 // resolve-pubkey.test.ts — Bun.serve({ port: 0 }), never a hardcoded port).
 // =============================================================================

--- a/src/common/registry/identity-registry.ts
+++ b/src/common/registry/identity-registry.ts
@@ -44,10 +44,15 @@
  *
  * TC-2d / audit can distinguish "we trust this because the principal pinned
  * it at boot" from "we trust this because the network registry asserted it".
- * A resolved peer entry NEVER overwrites the pinned local boot identity
- * (`pin(principalId, …)` is rejected for the boot id) — the boot anchor is
- * the strongest link in the chain and a registry compromise must not be able
- * to displace it.
+ * A resolved peer entry NEVER overwrites the pinned local boot identity, in
+ * EITHER key space: a resolve for the boot `principalId` short-circuits on the
+ * cache before the resolver is consulted, AND a resolved peer whose
+ * `did:mf:<principalId>` collides with the boot DID is refused (the
+ * materialised myelin registry is DID-keyed and last-write-wins, so without
+ * this guard a hyphenated registry id like `andreas-meta-factory` could shadow
+ * the boot stack DID `did:mf:andreas-meta-factory`). The boot anchor is the
+ * strongest link in the chain and a registry compromise must not be able to
+ * displace it.
  *
  * ## Failure handling (CLAUDE.md: NEVER empty catch)
  *
@@ -177,12 +182,20 @@ export class MultiPrincipalIdentityRegistry {
   private readonly entries = new Map<string, PrincipalEntry>();
   /** The boot principal id — immutable, never overwritten by a peer. */
   private readonly bootPrincipalId: string;
+  /**
+   * The boot principal's DID. The boot anchor is keyed two ways: by
+   * `principalId` in {@link entries} AND by this DID in the materialised
+   * myelin registry. A resolved peer must never collide with EITHER, so we
+   * refuse to store a peer whose `peerDid(principalId)` equals this value.
+   */
+  private readonly bootDid: string;
   private readonly resolver: Pick<PrincipalPubkeyResolver, "resolve"> | undefined;
   private readonly peerNetwork: (principalId: string) => string;
   private readonly logError: (msg: string) => void;
 
   constructor(options: MultiPrincipalIdentityRegistryOptions) {
     this.bootPrincipalId = options.bootPrincipal.principalId;
+    this.bootDid = options.bootPrincipal.identity.id;
     this.resolver = options.resolver;
     this.peerNetwork = options.peerNetwork ?? ((id) => id);
     this.logError =
@@ -272,7 +285,24 @@ export class MultiPrincipalIdentityRegistry {
       case "resolved": {
         // Reached only on a CACHE MISS, so `principalId` cannot be the boot
         // id (boot is always cached above) — the boot anchor is structurally
-        // safe from a resolver-supplied pubkey.
+        // safe from a resolver-supplied pubkey IN THE principalId MAP.
+        //
+        // But the materialised myelin registry is keyed by DID, and
+        // `peerDid(principalId)` is NOT injective with the boot DID: registry
+        // ids permit hyphens and the boot stack DID is `did:mf:<principal>-
+        // <stack>`, so a peer id like `andreas-meta-factory` yields the same
+        // DID as boot `did:mf:andreas-meta-factory`. myelin `add()` is
+        // last-write-wins, so storing such a peer would let a registry
+        // assertion DISPLACE the out-of-band boot anchor in the exact
+        // registry the verifier consumes. Refuse it — a peer whose DID
+        // collides with the boot anchor is a trust-displacement attempt.
+        const did = peerDid(principalId);
+        if (did === this.bootDid) {
+          this.logError(
+            `resolve(${principalId}): SECURITY — resolved peer DID ${did} collides with the boot anchor DID; refusing (possible trust-displacement via a hyphenated registry id)`,
+          );
+          return { resolved: false, reason: "unresolved" };
+        }
         const entry: PrincipalEntry = {
           principalId,
           identity: {
@@ -304,7 +334,24 @@ export class MultiPrincipalIdentityRegistry {
    */
   toIdentityRegistry(): IdentityRegistry {
     const registry = createInMemoryRegistry();
+    // myelin `add()` is last-write-wins on the DID key. Track DIDs and skip
+    // any later entry that collides with one already added. The boot principal
+    // is inserted first in `entries` (ctor) so it is iterated first here and
+    // therefore always WINS a collision — the boot anchor can never be
+    // displaced in the materialised registry the verifier consumes. (The
+    // resolve-success guard already refuses peers whose DID collides with the
+    // boot DID; this is the defense-in-depth backstop, and it also prevents
+    // two distinct peers with a colliding DID from silently clobbering.)
+    const seenDids = new Set<string>();
     for (const entry of this.entries.values()) {
+      const did = entry.identity.id;
+      if (seenDids.has(did)) {
+        this.logError(
+          `toIdentityRegistry: skipping ${entry.principalId} (provenance=${entry.provenance}) — DID ${did} already materialised; refusing to overwrite`,
+        );
+        continue;
+      }
+      seenDids.add(did);
       registry.add(entry.identity);
     }
     return registry;

--- a/src/common/registry/identity-registry.ts
+++ b/src/common/registry/identity-registry.ts
@@ -1,0 +1,312 @@
+/**
+ * TC-2b (Trust & Confidentiality, cortex#634) — multi-principal,
+ * peer-stamped `IdentityRegistry`.
+ *
+ * ## What this is
+ *
+ * The federation crypto-verify chain (`docs/design-trust-confidentiality.md`
+ * §"Phase 2-verify") needs to look up the **verified Ed25519 pubkey of ANY
+ * peer principal** that signed an inbound `federated.{principal}.{stack}`
+ * envelope — not just the local boot principal. Until TC-2b the verifier's
+ * `buildIdentityRegistry` (`src/bus/verify-signed-by-chain.ts`) stamped
+ * EVERY agent with the single boot `principalId`; cross-principal envelopes
+ * were therefore unverifiable (the design's "single-principal boundary").
+ *
+ * `MultiPrincipalIdentityRegistry` lifts that boundary. It holds a MAP of
+ * `principal_id → verified peer entry`, with the **local boot principal**
+ * pinned as an always-present, never-overwritten entry. Unknown peers are
+ * resolved **on demand** via the TC-2a `PrincipalPubkeyResolver` (registry-
+ * signed `GET /principals/{id}`, pinned-registry-pubkey verified), cached,
+ * and then served synchronously. TC-2d consumes the materialised myelin
+ * `IdentityRegistry` (`toIdentityRegistry()`) in the `federated.*` verify
+ * path.
+ *
+ * ## Posture gate (default-OFF — load-bearing)
+ *
+ * Per the #635 wiring note, the federation verify path engages ONLY under
+ * `security.signing: enforce` — NOT merely when `cryptoVerify` is on (which
+ * is `true` even for `off`/`permissive` as cheap observability). The
+ * resolver is constructed with its own `enabled` flag driven by
+ * `signing === "enforce"`; when federation verify is OFF the resolver is
+ * inert and `resolve()` returns `{ status: "disabled" }` with ZERO network
+ * I/O. In that state ONLY the pinned local boot entry is available — exactly
+ * today's single-principal behaviour. This registry does no posture reading
+ * itself: it delegates the gate to the resolver it is handed (an `enabled:
+ * false` / absent resolver ⇒ peer lookups never reach out).
+ *
+ * ## Peer-stamping (provenance)
+ *
+ * Every entry records its `provenance`:
+ *   - `"local-boot"`   — the pinned local boot principal (config-supplied,
+ *     out-of-band trust anchor). Exactly one such entry; immutable.
+ *   - `"resolved-registry"` — a peer whose pubkey was resolved + verified
+ *     via the TC-2a resolver against the pinned registry pubkey.
+ *
+ * TC-2d / audit can distinguish "we trust this because the principal pinned
+ * it at boot" from "we trust this because the network registry asserted it".
+ * A resolved peer entry NEVER overwrites the pinned local boot identity
+ * (`pin(principalId, …)` is rejected for the boot id) — the boot anchor is
+ * the strongest link in the chain and a registry compromise must not be able
+ * to displace it.
+ *
+ * ## Failure handling (CLAUDE.md: NEVER empty catch)
+ *
+ * `resolve()` NEVER throws — a federation/registry problem must not crash
+ * the verify path. An unresolved peer yields a clear negative
+ * (`{ resolved: false, reason }`) that the verifier rejects on, logged via
+ * the injected `logError` seam (defaults to `process.stderr`). A negative
+ * is NOT cached (the underlying resolver already declines to cache
+ * negatives), so a peer that registers after its first probe becomes
+ * resolvable without waiting out a TTL.
+ *
+ * ## Back-compat (single-principal case)
+ *
+ * Constructed with only a boot principal and no resolver, this class behaves
+ * as a single-entry registry: `get(bootId)` returns the boot identity,
+ * `toIdentityRegistry()` materialises exactly the boot identity, and
+ * `resolve(anyPeer)` returns `{ resolved: false, reason: "disabled" }`
+ * without I/O. Existing single-principal consumers see no change.
+ */
+
+import {
+  createInMemoryRegistry,
+  type Identity,
+  type IdentityRegistry,
+} from "@the-metafactory/myelin/identity";
+
+import type { PrincipalPubkeyResolver } from "./resolve-pubkey";
+
+/**
+ * Where an entry's verified pubkey came from. Stamped onto every entry so
+ * TC-2d / audit can distinguish the boot trust anchor from a registry-
+ * resolved peer.
+ */
+export type EntryProvenance = "local-boot" | "resolved-registry";
+
+/**
+ * A single verified principal entry held by the registry.
+ */
+export interface PrincipalEntry {
+  /** The principal id (e.g. `andreas`) — the map key. */
+  readonly principalId: string;
+  /**
+   * The materialised myelin `Identity` for this principal. Fed verbatim
+   * into the myelin `IdentityRegistry` that the crypto-verify path consumes.
+   */
+  readonly identity: Identity;
+  /** How this entry's pubkey was established. See {@link EntryProvenance}. */
+  readonly provenance: EntryProvenance;
+}
+
+/**
+ * Outcome of an async {@link MultiPrincipalIdentityRegistry.resolve}.
+ * Discriminated so TC-2d can branch: a positive feeds the entry into the
+ * verify path; every negative rejects the inbound envelope.
+ */
+export type RegistryResolveOutcome =
+  | { resolved: true; entry: PrincipalEntry }
+  | {
+      resolved: false;
+      /**
+       * Why the peer could not be resolved:
+       *   - `"disabled"`    — federation verify is OFF (resolver inert / absent);
+       *                       no I/O was performed.
+       *   - `"not_found"`   — the registry returned 404 for this principal id.
+       *   - `"unresolved"`  — transient/structural failure (network, parse,
+       *                       signature, mismatch). Retry-able; not cached.
+       */
+      reason: "disabled" | "not_found" | "unresolved";
+    };
+
+/** Construction options for {@link MultiPrincipalIdentityRegistry}. */
+export interface MultiPrincipalIdentityRegistryOptions {
+  /**
+   * The local boot principal — the pinned, always-present, never-overwritten
+   * trust anchor. `principalId` is its map key; `identity` is the myelin
+   * `Identity` to materialise into the verify registry (the same shape
+   * `buildIdentityRegistry` constructs for the local stack).
+   */
+  bootPrincipal: { principalId: string; identity: Identity };
+  /**
+   * On-demand peer-pubkey resolver (TC-2a). When omitted, peer lookups are
+   * inert (`resolve()` returns `{ resolved: false, reason: "disabled" }`)
+   * — the single-principal back-compat path. When present, its OWN
+   * `enabled` flag (driven by `signing === "enforce"`) decides whether it
+   * reaches out: a disabled resolver short-circuits to `{ status:
+   * "disabled" }` with zero I/O, surfaced here as `reason: "disabled"`.
+   */
+  resolver?: Pick<PrincipalPubkeyResolver, "resolve">;
+  /**
+   * The owning-network slug stamped onto resolved peer `Identity` objects'
+   * `network` field. For a federated peer the network IS the peer's own
+   * principal id (the bus-addressing model — see `verify-signed-by-chain.ts`
+   * R4 note). Defaults to the resolved peer's own `principalId`.
+   */
+  peerNetwork?: (principalId: string) => string;
+  /**
+   * Logger seam — defaults to writing to `process.stderr` (CLAUDE.md
+   * "no empty catches"). Tests inject a spy / no-op.
+   */
+  logError?: (msg: string) => void;
+}
+
+/**
+ * Build the DID for a peer principal's federation identity. Peers are
+ * stamped with `did:mf:<principalId>` — the principal-level identity that
+ * signs `federated.{principal}.{stack}` envelopes. Mirrors the
+ * `did:mf:<id>` convention `buildIdentityRegistry` uses for local agents.
+ */
+function peerDid(principalId: string): string {
+  return `did:mf:${principalId}`;
+}
+
+/**
+ * Multi-principal, peer-stamped identity registry. Construct once at boot
+ * with the local boot principal pinned + (optionally) the TC-2a resolver,
+ * then:
+ *   - `get(principalId)` — synchronous lookup against what's already stored.
+ *   - `resolve(principalId)` — async resolve-and-cache for unknown peers
+ *     (posture-gated via the resolver).
+ *   - `toIdentityRegistry()` — materialise the myelin `IdentityRegistry`
+ *     the crypto-verify path consumes.
+ *
+ * Single-process, in-memory.
+ */
+export class MultiPrincipalIdentityRegistry {
+  /** `principal_id → verified entry`. The boot principal is pinned here. */
+  private readonly entries = new Map<string, PrincipalEntry>();
+  /** The boot principal id — immutable, never overwritten by a peer. */
+  private readonly bootPrincipalId: string;
+  private readonly resolver: Pick<PrincipalPubkeyResolver, "resolve"> | undefined;
+  private readonly peerNetwork: (principalId: string) => string;
+  private readonly logError: (msg: string) => void;
+
+  constructor(options: MultiPrincipalIdentityRegistryOptions) {
+    this.bootPrincipalId = options.bootPrincipal.principalId;
+    this.resolver = options.resolver;
+    this.peerNetwork = options.peerNetwork ?? ((id) => id);
+    this.logError =
+      options.logError ??
+      ((msg: string) => {
+        process.stderr.write(`identity-registry: ${msg}\n`);
+      });
+
+    // Pin the local boot principal — always present, provenance "local-boot".
+    this.entries.set(this.bootPrincipalId, {
+      principalId: this.bootPrincipalId,
+      identity: options.bootPrincipal.identity,
+      provenance: "local-boot",
+    });
+  }
+
+  /**
+   * Synchronous lookup against what's ALREADY stored (the pinned boot
+   * principal + any peer resolved by a prior `resolve()`). Returns
+   * `undefined` for a principal that has not been resolved — the caller
+   * should `resolve()` (async) to attempt populating it. NEVER does I/O.
+   */
+  get(principalId: string): PrincipalEntry | undefined {
+    return this.entries.get(principalId);
+  }
+
+  /** Whether a principal is already stored (boot or previously-resolved). */
+  has(principalId: string): boolean {
+    return this.entries.has(principalId);
+  }
+
+  /** All stored entries (boot + resolved peers). For audit / introspection. */
+  list(): PrincipalEntry[] {
+    return Array.from(this.entries.values());
+  }
+
+  /**
+   * Resolve `principalId` to its verified entry.
+   *
+   * Cache-first: a stored entry (boot or previously-resolved) is returned
+   * synchronously-fast without I/O. On a miss, consults the TC-2a resolver
+   * (when present + enabled); a successful, verified resolve is stamped
+   * `provenance: "resolved-registry"`, cached, and returned. Posture-gated:
+   * when the resolver is absent or disabled, no I/O is performed and
+   * `{ resolved: false, reason: "disabled" }` is returned — only the boot
+   * entry (and any earlier-resolved peer) is available.
+   *
+   * The pinned local boot entry is NEVER overwritten: a resolve for the
+   * boot id returns the pinned entry without consulting the resolver, so a
+   * registry assertion cannot displace the out-of-band boot anchor.
+   *
+   * NEVER throws.
+   */
+  async resolve(principalId: string): Promise<RegistryResolveOutcome> {
+    // Cache-first. The pinned boot principal is ALWAYS in `entries` (set in
+    // the ctor, never deleted — there is no eviction API), so a resolve for
+    // the boot id short-circuits here and the resolver is NEVER consulted
+    // for it. This is the mechanism by which a registry assertion can never
+    // displace the out-of-band boot anchor: the resolved-peer write below is
+    // unreachable for the boot id.
+    const cached = this.entries.get(principalId);
+    if (cached !== undefined) {
+      return { resolved: true, entry: cached };
+    }
+
+    // No resolver wired (single-principal back-compat) → inert.
+    if (this.resolver === undefined) {
+      return { resolved: false, reason: "disabled" };
+    }
+
+    const result = await this.resolver.resolve(principalId);
+    switch (result.status) {
+      case "disabled":
+        // Posture OFF — the resolver did no I/O. Federation verify not engaged.
+        return { resolved: false, reason: "disabled" };
+      case "not_found":
+        this.logError(
+          `resolve(${principalId}): registry returned not_found; peer is unverifiable`,
+        );
+        return { resolved: false, reason: "not_found" };
+      case "unresolved":
+        // Already logged in detail by the resolver; record a clear negative.
+        this.logError(
+          `resolve(${principalId}): unresolved (transient/structural); peer is unverifiable this attempt`,
+        );
+        return { resolved: false, reason: "unresolved" };
+      case "resolved": {
+        // Reached only on a CACHE MISS, so `principalId` cannot be the boot
+        // id (boot is always cached above) — the boot anchor is structurally
+        // safe from a resolver-supplied pubkey.
+        const entry: PrincipalEntry = {
+          principalId,
+          identity: {
+            id: peerDid(principalId),
+            display_name: principalId,
+            network: this.peerNetwork(principalId),
+            public_key: result.principalPubkey,
+            type: "agent",
+            // Resolved at runtime; the registry record carries no creation
+            // timestamp for the peer, so anchor to the epoch (a stable,
+            // non-misleading value — myelin only requires a valid ISO-8601).
+            created_at: new Date(0).toISOString(),
+          },
+          provenance: "resolved-registry",
+        };
+        this.entries.set(principalId, entry);
+        return { resolved: true, entry };
+      }
+    }
+  }
+
+  /**
+   * Materialise a myelin `IdentityRegistry` containing the pinned boot
+   * identity plus every peer resolved so far. This is the shape the
+   * crypto-verify path (`verifyEnvelopeIdentity`, TC-2d) consumes. A fresh
+   * registry is built per call from the current entry set — cheap (single-
+   * digit-to-dozens of entries) and avoids handing the verifier a mutable
+   * reference into our internal store.
+   */
+  toIdentityRegistry(): IdentityRegistry {
+    const registry = createInMemoryRegistry();
+    for (const entry of this.entries.values()) {
+      registry.add(entry.identity);
+    }
+    return registry;
+  }
+}

--- a/src/common/registry/index.ts
+++ b/src/common/registry/index.ts
@@ -9,6 +9,10 @@
  *   - `PrincipalPubkeyResolver` (TC-2a, cortex#633) — on-demand,
  *     posture-gated peer-pubkey resolver for the federation crypto-verify
  *     chain (TC-2b/TC-2d). Default-OFF; inert unless `signing: enforce`.
+ *   - `MultiPrincipalIdentityRegistry` (TC-2b, cortex#634) — multi-principal,
+ *     peer-stamped registry: a pinned local boot principal plus peers
+ *     resolved on demand via the TC-2a resolver. Materialises the myelin
+ *     `IdentityRegistry` the `federated.*` crypto-verify path (TC-2d) reads.
  */
 
 export { RegistryClient } from "./client";
@@ -20,6 +24,13 @@ export type {
   PrincipalPubkeyResolverOptions,
   ResolveResult,
 } from "./resolve-pubkey";
+export { MultiPrincipalIdentityRegistry } from "./identity-registry";
+export type {
+  EntryProvenance,
+  MultiPrincipalIdentityRegistryOptions,
+  PrincipalEntry,
+  RegistryResolveOutcome,
+} from "./identity-registry";
 export type {
   Capability,
   PrincipalRecord,


### PR DESCRIPTION
## TC-2b — multi-principal, peer-stamped `IdentityRegistry` (#634)

Extends the cortex-side registry layer from a single boot-principal store to a **multi-principal, peer-stamped** `MultiPrincipalIdentityRegistry`, so the `federated.*` crypto-verify path (TC-2d, next slice) can look up ANY peer principal's verified Ed25519 pubkey — not just the local boot principal's.

Design: [`docs/design-trust-confidentiality.md`](../blob/main/docs/design-trust-confidentiality.md) §"Phase 2 — Federation trust" / **§2b "Multi-principal `IdentityRegistry`"** and §"Phase 2-verify" (engaged only under `signing: enforce`).

### What it does

- Holds a **MAP** of `principal_id → verified entry`. The local boot principal is **pinned** (always present, provenance `"local-boot"`) and is **never overwritten** by a resolved peer — a registry assertion cannot displace the out-of-band boot anchor (cache-first short-circuit guarantees this structurally; the resolved-peer write is unreachable for the boot id).
- `get(principalId)` — **synchronous** lookup against what's already stored (no I/O).
- `resolve(principalId)` — **async** resolve-and-cache for unknown peers via the TC-2a `PrincipalPubkeyResolver`, stamping resolved entries `"resolved-registry"`. Cache hit on the second lookup.
- `toIdentityRegistry()` — materialises the myelin `IdentityRegistry` (boot + resolved peers) that the TC-2d verify path consumes.

### Posture-gated, default-OFF

The registry delegates the gate to the resolver it is handed. Federation verify engages **only under `security.signing: enforce`** — per the #635 wiring note, gated on `signing`, **NOT** `cryptoVerify` (which is `true` even for `off`/`permissive`). A disabled or absent resolver performs **ZERO network I/O**; only the boot entry is available — exactly today's single-principal behaviour.

### Back-compat (single-principal)

Constructed with only a boot principal and no resolver, the class is a single-entry registry — **existing single-principal consumers see no change**. `resolve(anyPeer)` returns `{ resolved: false, reason: "disabled" }` without I/O; `toIdentityRegistry()` materialises exactly the boot identity. (Pinned + asserted in `back-compat (single-principal)` tests.) The verifier's existing `buildIdentityRegistry` path is untouched in this slice — TC-2d wires the multi-principal registry into the `federated.*` verify.

### Failure handling (CLAUDE.md: no empty catch)

An unresolved / `not_found` peer yields a clear negative (verify rejects), logged via the injected `logError` seam; `resolve()` **never throws**; negatives are not cached.

### Tests — ephemeral `Bun.serve({ port: 0 })` only (never a hardcoded port, per #671)

- back-compat single-principal still resolves as before;
- multi-principal A/B both retrievable, no cross-contamination;
- on-demand resolve populates the map + cache hit (resolver consulted once);
- posture OFF → zero registry I/O, only boot entry available;
- unresolved / not_found → negative outcome (not a throw), boot anchor never overwritten;
- end-to-end through a real `PrincipalPubkeyResolver` + ephemeral registry stub.

### Verification

- `bunx tsc --noEmit` — **0 errors**
- `bun run lint:errors` — **clean**
- `bash scripts/check-carveouts.sh` — **PASS** (`principal`/`network` vocab; existing `*_pubkey` identifiers are carve-outs)
- `bun test` registry + network-registry + bus/myelin + verify-signed-by-chain — **245 pass / 0 fail**

Self-reviewed with `/code-review --fix high`: one finding (unreachable defensive boot-id guard inside `resolve`) removed and replaced with a clearer cache-first invariant comment. Verdict: **SHIP**.

Closes #634.

🤖 Generated with [Claude Code](https://claude.com/claude-code)