### PR TITLE
feat(bus): TC-2d — federated.* crypto-verify against registry-resolved peer pubkeys (#635)

### DIFF
--- a/docs/design-trust-confidentiality.md
+++ b/docs/design-trust-confidentiality.md
@@ -144,9 +144,19 @@ gateway round-trip with zero crypto, then enable signing-permissive without touc
   construct a multi-principal registry for inbound `federated.*`.
 - **2c. Relax the single-principal guard** (the boot guard added in GW.a.3d) once 2a/2b make
   cross-principal envelopes verifiable; multi-principal subject derivation in the gateway sink.
-- **2d. `federated.*` verify wiring** in the surface-router/policy path (the gate exists; add the
-  crypto verify against registry-resolved peer pubkeys). **Acceptance:** principal A's node verifies a
-  principal-B-signed envelope end-to-end; forged peer signature rejected.
+- **2d. `federated.*` verify wiring (TC-2d, #635 — DONE).** Wired the federation crypto-verify into
+  `verifySignedByChain` (`src/bus/verify-signed-by-chain.ts`): for an inbound `federated.*` envelope
+  under `signing: enforce`, the **signer peer principal** (the leading segment of `envelope.source`,
+  NOT the `federated.{network_id}` target segment) is resolved via the TC-2a/TC-2b
+  `MultiPrincipalIdentityRegistry.resolveFederatedPeer` seam, its registry-verified pubkey merged into
+  the myelin `IdentityRegistry`, and the peer stamp's bytes verified against it (with a structural
+  short-circuit mirroring the cortex#480 own-stack admit — registry-anchored trust, not local
+  `trust:`). A negative resolve rejects the envelope (`federated_peer_unresolved`). **Load-bearing
+  gate (#635):** the resolver `enabled` flag is driven by `signing === "enforce"`, NOT `cryptoVerify`
+  (which is `true` for all postures); `cortex.ts` wires the seam ONLY under `enforce`, so off/permissive
+  stacks do ZERO registry I/O (pinned by a fetch-spy test). `local.*`/`public.*` envelopes are
+  unchanged — single-principal path untouched. **Acceptance:** principal A's node verifies a
+  principal-B-signed envelope end-to-end; forged peer signature rejected; peer-not-in-registry rejected.
 
 ### Phase 3 — Payload encryption (E2E on bus) · implements ratified #369
 

--- a/src/bus/__tests__/verify-signed-by-chain.test.ts
+++ b/src/bus/__tests__/verify-signed-by-chain.test.ts
@@ -18,13 +18,19 @@
 
 import { describe, test, expect } from "bun:test";
 import { createUser } from "@nats-io/nkeys";
-import { signEnvelope } from "@the-metafactory/myelin/identity";
+import { signEnvelope, type Identity } from "@the-metafactory/myelin/identity";
 import { AgentRegistry } from "../../common/agents/registry";
 import { TrustResolver } from "../../common/agents/trust-resolver";
 import {
   verifySignedByChain,
+  nkeyToBase64Pubkey,
   type ChainVerificationResult,
+  type FederatedPeerResolution,
 } from "../verify-signed-by-chain";
+import {
+  MultiPrincipalIdentityRegistry,
+  PrincipalPubkeyResolver,
+} from "../../common/registry";
 import type { Envelope, SignedBy } from "../myelin/envelope-validator";
 import type { Agent } from "../../common/types/cortex-config";
 
@@ -654,5 +660,373 @@ describe("verifySignedByChain — cryptoVerify (B.1c)", () => {
         // principalId omitted — must throw.
       }),
     ).rejects.toThrow(/principalId/);
+  });
+});
+
+// =============================================================================
+// TC-2d (cortex#635) — federated.* crypto-verify against registry-resolved
+// peer pubkeys. The CAPSTONE of the cross-principal trust chain.
+// =============================================================================
+
+/**
+ * Build a `federated.*` envelope whose SOURCE is the peer principal. The
+ * signer peer principal the verifier resolves is the leading dotted segment
+ * of `envelope.source` (`principalFromEnvelope`), e.g. `bravo` for
+ * `bravo.bravo-stack.review`. The `federated.{network_id}` SUBJECT segment
+ * (cortex#661) names the TARGET network and is irrelevant to signer
+ * resolution — the test fixtures deliberately don't set a subject.
+ */
+function federatedEnvelopeFrom(peerPrincipal: string): Envelope {
+  return {
+    id: "00000000-0000-4000-8000-0000000000fe",
+    source: `${peerPrincipal}.${peerPrincipal}-stack.review`,
+    type: "test.federated.case",
+    timestamp: "2026-06-04T08:00:00.000Z",
+    sovereignty: {
+      classification: "federated",
+      data_residency: "NZ",
+      max_hop: 4,
+      frontier_ok: false,
+      model_class: "any",
+    },
+    payload: {},
+  };
+}
+
+/**
+ * The peer's verified myelin `Identity` — the shape the TC-2b
+ * `MultiPrincipalIdentityRegistry.resolveFederatedPeer` returns and the
+ * verifier merges into the crypto-verify registry. `public_key` is the
+ * base64 raw ed25519 derived from the peer's NKey (the SAME key the peer
+ * signs with), keyed by `did:mf:<peerPrincipal>`.
+ */
+function peerIdentity(peerPrincipal: string, nkeyPub: string): Identity {
+  const publicKey = nkeyToBase64Pubkey(nkeyPub);
+  if (publicKey === undefined) {
+    throw new Error("test fixture: peer NKey did not decode");
+  }
+  return {
+    id: `did:mf:${peerPrincipal}`,
+    display_name: peerPrincipal,
+    network: peerPrincipal,
+    public_key: publicKey,
+    type: "agent",
+    created_at: new Date(0).toISOString(),
+  };
+}
+
+describe("verifySignedByChain — TC-2d federated.* peer verify (cortex#635)", () => {
+  test("federated envelope, peer resolvable + signature valid → ACCEPTED", async () => {
+    const peer = "bravo";
+    const { nkeyPub: peerNKey, privateKeyBase64: peerSeed } =
+      generateEd25519KeyPair();
+    // Only the LOCAL agent luna is in the registry — the peer is NOT a
+    // local agent; it is admitted purely via the federated resolve seam.
+    const luna = agentFixture({ id: "luna", trust: [] });
+    const resolver = resolverWith(luna);
+
+    // The peer signs the federated envelope with ITS principal DID.
+    const base = federatedEnvelopeFrom(peer) as Parameters<
+      typeof signEnvelope
+    >[0];
+    const signed = await signEnvelope(base, peerSeed, `did:mf:${peer}`);
+
+    let resolveCalls = 0;
+    const resolveFederatedPeer = async (
+      p: string,
+    ): Promise<FederatedPeerResolution> => {
+      resolveCalls++;
+      expect(p).toBe(peer); // signer peer = source's leading segment
+      return { resolved: true, identity: peerIdentity(peer, peerNKey) };
+    };
+
+    const result = await verifySignedByChain(signed, {
+      resolver,
+      receivingAgentId: "luna",
+      cryptoVerify: true,
+      principalId: "alpha",
+      resolveFederatedPeer,
+    });
+
+    expect(result.valid).toBe(true);
+    expect(resolveCalls).toBe(1);
+  });
+
+  test("federated envelope, peer resolvable but signature forged → REJECTED (crypto_verify_failed)", async () => {
+    const peer = "bravo";
+    const { nkeyPub: peerNKey, privateKeyBase64: peerSeed } =
+      generateEd25519KeyPair();
+    const luna = agentFixture({ id: "luna", trust: [] });
+    const resolver = resolverWith(luna);
+
+    const base = federatedEnvelopeFrom(peer) as Parameters<
+      typeof signEnvelope
+    >[0];
+    const signed = await signEnvelope(base, peerSeed, `did:mf:${peer}`);
+
+    // Tamper the signature bytes — the peer resolves fine, but the bytes
+    // no longer match the canonical envelope.
+    const chain = Array.isArray(signed.signed_by)
+      ? signed.signed_by
+      : signed.signed_by
+        ? [signed.signed_by]
+        : [];
+    const firstStamp = chain[0];
+    if (firstStamp?.method !== "ed25519") {
+      throw new Error("test fixture: expected ed25519 stamp at index 0");
+    }
+    const tamperedSig = firstStamp.signature.startsWith("A")
+      ? "B" + firstStamp.signature.slice(1)
+      : "A" + firstStamp.signature.slice(1);
+    const tampered: Envelope = {
+      ...signed,
+      signed_by: [{ ...firstStamp, signature: tamperedSig }],
+    };
+
+    const result = await verifySignedByChain(tampered, {
+      resolver,
+      receivingAgentId: "luna",
+      cryptoVerify: true,
+      principalId: "alpha",
+      resolveFederatedPeer: async () => ({
+        resolved: true,
+        identity: peerIdentity(peer, peerNKey),
+      }),
+    });
+
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.reason.kind).toBe("crypto_verify_failed");
+    }
+  });
+
+  test("federated envelope, peer NOT in registry (not_found) → REJECTED + logged", async () => {
+    const peer = "ghost";
+    const { privateKeyBase64: peerSeed } = generateEd25519KeyPair();
+    const luna = agentFixture({ id: "luna", trust: [] });
+    const resolver = resolverWith(luna);
+
+    const base = federatedEnvelopeFrom(peer) as Parameters<
+      typeof signEnvelope
+    >[0];
+    const signed = await signEnvelope(base, peerSeed, `did:mf:${peer}`);
+
+    const result = await verifySignedByChain(signed, {
+      resolver,
+      receivingAgentId: "luna",
+      cryptoVerify: true,
+      principalId: "alpha",
+      // Peer unverifiable — the registry returned not_found.
+      resolveFederatedPeer: async () => ({
+        resolved: false,
+        reason: "not_found",
+      }),
+    });
+
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.reason.kind).toBe("federated_peer_unresolved");
+      if (result.reason.kind === "federated_peer_unresolved") {
+        expect(result.reason.peerPrincipal).toBe(peer);
+        expect(result.reason.detail).toBe("not_found");
+      }
+    }
+  });
+
+  test("local.* envelope under enforce → boot-identity verify, peer seam NEVER consulted", async () => {
+    // The single-principal path: a local.* envelope verifies against the
+    // boot/local identity exactly as today. The federated resolve seam,
+    // even when supplied, is NOT engaged for a non-federated envelope.
+    const { nkeyPub: echoNKey, privateKeyBase64: echoSeed } =
+      generateEd25519KeyPair();
+    const luna = agentFixture({ id: "luna", trust: ["echo"] });
+    const echo = agentFixture({
+      id: "echo",
+      displayName: "Echo",
+      nkey_pub: echoNKey,
+    });
+    const resolver = resolverWith(luna, echo);
+
+    // envelopeWithChain builds a `local` classification envelope.
+    const base = envelopeWithChain(undefined) as Parameters<
+      typeof signEnvelope
+    >[0];
+    const signed = await signEnvelope(base, echoSeed, "did:mf:echo");
+
+    let seamCalls = 0;
+    const result = await verifySignedByChain(signed, {
+      resolver,
+      receivingAgentId: "luna",
+      cryptoVerify: true,
+      rejectEmpty: true, // enforce posture
+      principalId: "alpha",
+      resolveFederatedPeer: async () => {
+        seamCalls++;
+        return { resolved: false, reason: "unresolved" };
+      },
+    });
+
+    expect(result.valid).toBe(true);
+    // The capstone invariant: local.* NEVER touches the peer seam.
+    expect(seamCalls).toBe(0);
+  });
+
+  test("federated envelope WITHOUT a peer seam → verifies local-only (no resolve), unchanged", async () => {
+    // off/permissive postures omit the seam entirely. A federated envelope
+    // then verifies against the local registry only — exactly today's
+    // behaviour. Here the peer is not a local agent, so the crypto pass
+    // rejects as a normal local-registry miss (NOT federated_peer_unresolved),
+    // proving the federated branch is never entered without a seam.
+    const peer = "bravo";
+    const { privateKeyBase64: peerSeed } = generateEd25519KeyPair();
+    const luna = agentFixture({ id: "luna", trust: [] });
+    const resolver = resolverWith(luna);
+
+    const base = federatedEnvelopeFrom(peer) as Parameters<
+      typeof signEnvelope
+    >[0];
+    const signed = await signEnvelope(base, peerSeed, `did:mf:${peer}`);
+
+    const result = await verifySignedByChain(signed, {
+      resolver,
+      receivingAgentId: "luna",
+      cryptoVerify: true,
+      principalId: "alpha",
+      // resolveFederatedPeer deliberately omitted (off/permissive shape).
+    });
+
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      // The stamp's `did:mf:bravo` is not a local agent → structural
+      // unknown_agent rejection. The point: NO federated_peer_unresolved,
+      // because the federated branch is never reached without a seam.
+      expect(result.reason.kind).not.toBe("federated_peer_unresolved");
+    }
+  });
+
+  test("[S-1 hardening] federated seam wired but cryptoVerify:false → NO structural short-circuit (fail closed)", async () => {
+    // The federated structural short-circuit is only safe when the crypto
+    // bytes-check runs. With cryptoVerify off, a resolved peer must NOT be
+    // admitted structurally (that would accept a forged stamp on the
+    // strength of an unauthenticated source segment). It must fall through
+    // to the normal structural walk and fail closed.
+    const peer = "bravo";
+    const { nkeyPub: peerNKey, privateKeyBase64: peerSeed } =
+      generateEd25519KeyPair();
+    const luna = agentFixture({ id: "luna", trust: [] });
+    const resolver = resolverWith(luna);
+
+    const base = federatedEnvelopeFrom(peer) as Parameters<
+      typeof signEnvelope
+    >[0];
+    const signed = await signEnvelope(base, peerSeed, `did:mf:${peer}`);
+
+    let seamCalls = 0;
+    const result = await verifySignedByChain(signed, {
+      resolver,
+      receivingAgentId: "luna",
+      cryptoVerify: false, // ← no bytes-check; short-circuit must NOT engage
+      principalId: "alpha",
+      resolveFederatedPeer: async () => {
+        seamCalls++;
+        return { resolved: true, identity: peerIdentity(peer, peerNKey) };
+      },
+    });
+
+    // Seam never consulted (gated on cryptoVerify), peer falls through to
+    // structural unknown_agent — fail closed.
+    expect(seamCalls).toBe(0);
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.reason.kind).toBe("unknown_agent");
+    }
+  });
+});
+
+// =============================================================================
+// TC-2d #635 LOAD-BEARING GATE — posture OFF/permissive performs ZERO
+// registry I/O on an inbound federated envelope. Exercises the REAL
+// PrincipalPubkeyResolver + MultiPrincipalIdentityRegistry stack with an
+// ephemeral Bun.serve({ port: 0 }) fetch spy (NEVER a hardcoded port).
+// =============================================================================
+
+describe("verifySignedByChain — TC-2d #635 zero-registry-I/O when posture is not enforce", () => {
+  test("off/permissive: inbound federated envelope drives ZERO registry fetches", async () => {
+    // Count every fetch the registry would receive — the assertion is that
+    // it stays at 0 because a disabled resolver is INERT (no network).
+    let fetchCount = 0;
+    const server = Bun.serve({
+      port: 0, // ephemeral — OS assigns a free port (#671 de-flake pattern)
+      fetch() {
+        fetchCount++;
+        return new Response("should never be reached", { status: 500 });
+      },
+    });
+    const baseUrl = server.url.toString().replace(/\/$/, "");
+
+    try {
+      const peer = "bravo";
+      const { privateKeyBase64: peerSeed } = generateEd25519KeyPair();
+      const luna = agentFixture({ id: "luna", trust: [] });
+      const resolver = resolverWith(luna);
+
+      // The REAL stack, but with `enabled: false` — exactly the shape
+      // `resolveSigningKnobs` would yield for `off`/`permissive` (where the
+      // #635 gate keeps the resolver disabled even though `cryptoVerify` is
+      // true for all postures). Boot principal pinned, peer resolver wired
+      // but DISABLED.
+      const peerResolver = new PrincipalPubkeyResolver({
+        enabled: false, // ← the gate: signing !== "enforce"
+        baseUrl,
+        registryPubkey: "A".repeat(43) + "=",
+        logError: () => {},
+      });
+      const peerRegistry = new MultiPrincipalIdentityRegistry({
+        bootPrincipal: {
+          principalId: "alpha",
+          identity: {
+            id: "did:mf:alpha-stack",
+            display_name: "alpha-stack",
+            network: "alpha",
+            public_key: "A".repeat(43) + "=",
+            type: "agent",
+            created_at: new Date(0).toISOString(),
+          },
+        },
+        resolver: peerResolver,
+        logError: () => {},
+      });
+
+      const base = federatedEnvelopeFrom(peer) as Parameters<
+        typeof signEnvelope
+      >[0];
+      const signed = await signEnvelope(base, peerSeed, `did:mf:${peer}`);
+
+      const result = await verifySignedByChain(signed, {
+        resolver,
+        receivingAgentId: "luna",
+        cryptoVerify: true, // true for ALL postures (cheap observability)
+        principalId: "alpha",
+        // The seam IS wired here — proving that even when wired, a disabled
+        // resolver does zero I/O. (In cortex.ts the seam is `undefined`
+        // entirely under off/permissive — a strictly stronger guarantee.)
+        resolveFederatedPeer:
+          peerRegistry.resolveFederatedPeer.bind(peerRegistry),
+      });
+
+      // The peer is unverifiable because the resolver is disabled → reject.
+      expect(result.valid).toBe(false);
+      if (!result.valid) {
+        expect(result.reason.kind).toBe("federated_peer_unresolved");
+        if (result.reason.kind === "federated_peer_unresolved") {
+          expect(result.reason.detail).toBe("disabled");
+        }
+      }
+      // THE LOAD-BEARING ASSERTION: zero registry I/O. A dev stack
+      // (signing off/permissive) NEVER reaches out to the registry.
+      expect(fetchCount).toBe(0);
+    } finally {
+      server.stop(true);
+    }
   });
 });

--- a/src/bus/__tests__/verify-signed-by-chain.test.ts
+++ b/src/bus/__tests__/verify-signed-by-chain.test.ts
@@ -800,6 +800,45 @@ describe("verifySignedByChain — TC-2d federated.* peer verify (cortex#635)", (
     }
   });
 
+  test("federated envelope, valid signature by the WRONG key → REJECTED (crypto_verify_failed)", async () => {
+    // The sharpest statement of the threat: the attacker produces a fully
+    // VALID ed25519 signature — just with THEIR OWN key — while stamping the
+    // peer's DID and setting source to the peer. The registry resolves the
+    // peer's REAL (different) pubkey, and the bytes-check verifies the stamp
+    // against THAT key, not the attacker's → rejected. Distinct from the
+    // byte-tamper case above: nothing is malformed; only the signing key is
+    // wrong, which is exactly the cross-principal forgery the resolved-key
+    // bytes-check exists to defeat.
+    const peer = "bravo";
+    const { nkeyPub: peerRealNKey } = generateEd25519KeyPair(); // bravo's real key (in registry)
+    const { privateKeyBase64: attackerSeed } = generateEd25519KeyPair(); // attacker's key
+    const luna = agentFixture({ id: "luna", trust: [] });
+    const resolver = resolverWith(luna);
+
+    // Attacker signs with THEIR seed but stamps bravo's DID + bravo's source.
+    const base = federatedEnvelopeFrom(peer) as Parameters<
+      typeof signEnvelope
+    >[0];
+    const forged = await signEnvelope(base, attackerSeed, `did:mf:${peer}`);
+
+    const result = await verifySignedByChain(forged, {
+      resolver,
+      receivingAgentId: "luna",
+      cryptoVerify: true,
+      principalId: "alpha",
+      // Registry returns bravo's REAL pubkey — not the attacker's.
+      resolveFederatedPeer: async () => ({
+        resolved: true,
+        identity: peerIdentity(peer, peerRealNKey),
+      }),
+    });
+
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.reason.kind).toBe("crypto_verify_failed");
+    }
+  });
+
   test("federated envelope, peer NOT in registry (not_found) → REJECTED + logged", async () => {
     const peer = "ghost";
     const { privateKeyBase64: peerSeed } = generateEd25519KeyPair();

--- a/src/bus/bus-dispatch-listener.ts
+++ b/src/bus/bus-dispatch-listener.ts
@@ -48,6 +48,7 @@ import type { Envelope } from "./myelin/envelope-validator";
 import type { MyelinRuntime } from "./myelin/runtime";
 import type { TrustResolver } from "../common/agents/trust-resolver";
 import { verifySignedByChain } from "./verify-signed-by-chain";
+import type { FederatedPeerResolution } from "../common/registry";
 import {
   createSystemBusPeerDispatchReceivedEvent,
   type SystemEventSource,
@@ -112,6 +113,18 @@ export interface BusDispatchListenerOpts {
    * check has a registered Principal to verify against.
    */
   stackNKeyPub?: string;
+  /**
+   * TC-2d (cortex#635) — federated.* peer-pubkey resolution seam. When
+   * supplied AND `cryptoVerify: true`, an inbound `federated.*` peer
+   * dispatch has its **signer peer principal** resolved to a verified
+   * Ed25519 identity before the crypto-verify pass. `cortex.ts` wires
+   * this ONLY under `signing === "enforce"`; `off`/`permissive` leave it
+   * `undefined` (ZERO registry I/O — federated envelopes verify
+   * local-only, as today). See `verify-signed-by-chain.ts` JSDoc.
+   */
+  resolveFederatedPeer?: (
+    peerPrincipal: string,
+  ) => Promise<FederatedPeerResolution>;
 }
 
 // =============================================================================
@@ -128,6 +141,9 @@ export class BusDispatchListener {
   private readonly rejectEmpty: boolean;
   private readonly stackIdentity: string | undefined;
   private readonly stackNKeyPub: string | undefined;
+  private readonly resolveFederatedPeer:
+    | ((peerPrincipal: string) => Promise<FederatedPeerResolution>)
+    | undefined;
 
   private registration: { unregister: () => void } | undefined;
   /**
@@ -149,6 +165,7 @@ export class BusDispatchListener {
     this.rejectEmpty = opts.rejectEmpty ?? true;
     this.stackIdentity = opts.stackIdentity;
     this.stackNKeyPub = opts.stackNKeyPub;
+    this.resolveFederatedPeer = opts.resolveFederatedPeer;
   }
 
   /**
@@ -264,6 +281,12 @@ export class BusDispatchListener {
       }),
       ...(this.stackNKeyPub !== undefined && {
         stackNKeyPub: this.stackNKeyPub,
+      }),
+      // TC-2d (cortex#635) — federated.* peer-pubkey resolution. Inert for
+      // local.* dispatches (verify ignores the seam unless the envelope is
+      // `federated.*`). `undefined` under `off`/`permissive` (no I/O).
+      ...(this.resolveFederatedPeer !== undefined && {
+        resolveFederatedPeer: this.resolveFederatedPeer,
       }),
     });
 

--- a/src/bus/verify-signed-by-chain.ts
+++ b/src/bus/verify-signed-by-chain.ts
@@ -46,6 +46,7 @@
 import {
   verifyEnvelopeIdentity,
   createInMemoryRegistry,
+  type Identity,
   type IdentityRegistry,
 } from "@the-metafactory/myelin/identity";
 import { Prefix } from "@nats-io/nkeys";
@@ -60,6 +61,7 @@ import { Codec } from "@nats-io/nkeys/lib/codec";
 
 import {
   getSignedByChain,
+  principalFromEnvelope,
   type Envelope,
   type SignedBy,
 } from "./myelin/envelope-validator";
@@ -102,6 +104,26 @@ export type ChainRejectionReason =
   | { kind: "unknown_agent"; principal: string; agentId: string }
   | { kind: "principal_has_no_nkey_pub"; principal: string; agentId: string }
   | { kind: "signer_not_trusted"; principal: string; agentId: string }
+  | {
+      /**
+       * TC-2d (cortex#635) — a `federated.*` envelope's signer **peer
+       * principal** could not be resolved to a verified pubkey. The
+       * peer-resolution seam (`resolveFederatedPeer`, backed by the
+       * TC-2b `MultiPrincipalIdentityRegistry` + TC-2a resolver) returned
+       * a negative: the registry returned 404 for the peer, OR the
+       * registry-signed assertion failed to verify / was transiently
+       * unreachable. The inbound envelope is rejected — an unverifiable
+       * peer principal is admitted by NO posture.
+       *
+       * `peerPrincipal` is the signer peer's principal id (the leading
+       * dotted segment of `envelope.source`); `detail` carries the
+       * resolver's negative reason verbatim (`not_found` / `unresolved`)
+       * for audit + grep.
+       */
+      kind: "federated_peer_unresolved";
+      peerPrincipal: string;
+      detail: string;
+    }
   | {
       /**
        * Cryptographic verification failed — the bytes don't match the
@@ -227,7 +249,54 @@ export interface VerifySignedByChainOptions {
    * uses `stackIdentity` alone (the short-circuit is the whole point).
    */
   stackNKeyPub?: string;
+  /**
+   * TC-2d (cortex#635) — federation peer-pubkey resolution seam.
+   *
+   * The CAPSTONE of the cross-principal trust chain. When supplied AND
+   * `cryptoVerify: true` AND the inbound envelope is `federated.*`
+   * (`sovereignty.classification === "federated"`), the helper resolves
+   * the **signer peer principal** (the leading dotted segment of
+   * `envelope.source`) to its verified Ed25519 `Identity` BEFORE the
+   * crypto-verify pass, then merges that peer identity into the
+   * myelin `IdentityRegistry` the verify runs against. The signature is
+   * then checked against the **registry-resolved peer pubkey** rather
+   * than only the local boot/stack identity — admitting a principal-B-
+   * signed envelope on principal-A's node iff B's pubkey resolves and
+   * the bytes verify.
+   *
+   * **Posture gate lives at the construction site, NOT here (#635).**
+   * This seam is wired in `src/cortex.ts` ONLY when
+   * `security.signing === "enforce"`; under `off`/`permissive` the field
+   * is `undefined` and federated verify NEVER reaches a resolver — ZERO
+   * registry I/O. (Deriving the gate from `cryptoVerify`, which is `true`
+   * for ALL postures as cheap observability, would make dev stacks reach
+   * out to the registry — the regression the #635 wiring note forbids.)
+   * The helper itself reads no posture; it engages the seam purely on
+   * "federated + cryptoVerify + seam present".
+   *
+   * The seam is async and MUST NEVER throw — a federation/registry
+   * problem must not crash the verify path. It returns a discriminated
+   * outcome: `resolved` carries the peer's myelin `Identity` to merge;
+   * any negative carries a `reason` the helper surfaces as
+   * `federated_peer_unresolved` (the inbound envelope is rejected).
+   * A `local.*` / `public.*` envelope NEVER engages this seam — those
+   * verify against the boot/local identity exactly as today.
+   */
+  resolveFederatedPeer?: (
+    peerPrincipal: string,
+  ) => Promise<FederatedPeerResolution>;
 }
+
+/**
+ * TC-2d (cortex#635) — outcome of the {@link
+ * VerifySignedByChainOptions.resolveFederatedPeer} seam. Discriminated so
+ * the verifier branches cleanly: `resolved` merges `identity` into the
+ * verify registry; every negative rejects the inbound envelope as
+ * `federated_peer_unresolved` with `reason` carried verbatim for audit.
+ */
+export type FederatedPeerResolution =
+  | { resolved: true; identity: Identity }
+  | { resolved: false; reason: string };
 
 // =============================================================================
 // Verification
@@ -270,10 +339,74 @@ export async function verifySignedByChain(
     return { valid: true, skipped: [] };
   }
 
+  // TC-2d (cortex#635) — resolve the federated SIGNER PEER up-front. The
+  // CAPSTONE of the cross-principal trust chain. Engaged ONLY for an inbound
+  // `federated.*` envelope AND only when the resolution seam was wired
+  // (which `cortex.ts` does ONLY under `signing === "enforce"` — the
+  // load-bearing #635 gate; under off/permissive the seam is `undefined` so
+  // this never runs and there is ZERO registry I/O). A `local.*`/`public.*`
+  // envelope skips this entirely and verifies against the boot/local
+  // registry exactly as today — the single-principal path is untouched.
+  //
+  // The signer peer principal is the SOURCE principal: the leading dotted
+  // segment of `envelope.source` (`principalFromEnvelope`). NOTE this is NOT
+  // the `federated.{network_id}` subject segment — that names the TARGET
+  // network (cortex#661); the peer we resolve is the principal that SIGNED
+  // the envelope (its source). The peer's federation identity is keyed
+  // `did:mf:<peerPrincipal>`.
+  //
+  // A federated peer is, by construction, NOT a local agent and NOT in the
+  // receiver's `trust:` list — its trust is anchored in the registry-signed
+  // resolve, not the local trust graph. So a resolved peer's stamp DID
+  // short-circuits the STRUCTURAL trust check (mirroring the cortex#480
+  // own-stack short-circuit) and is admitted on the strength of the
+  // registry resolution + the crypto bytes-check below — NOT the bytes
+  // check alone. A negative resolve rejects the envelope before any stamp
+  // is structurally walked.
+  //
+  // **Gated on `cryptoVerify === true` (self-review S-1, fail-closed).** The
+  // structural short-circuit is only SAFE because the crypto pass below
+  // verifies the peer's stamp bytes against the resolved pubkey. If
+  // `cryptoVerify` is off, NO bytes-check runs — admitting a federated peer
+  // structurally would accept a forged stamp on the strength of an
+  // unauthenticated `source` segment alone. So the short-circuit engages
+  // ONLY when crypto will actually run; otherwise the peer stamp falls
+  // through to the normal structural walk (and fails closed as
+  // `unknown_agent`, the safe direction). In production `cortex.ts` always
+  // pairs the seam with `cryptoVerify: true` (`enforce` → `cryptoVerify:
+  // true`), so this only matters defensively / for non-enforce callers.
+  let federatedPeerDid: string | undefined;
+  let federatedPeerIdentity: Identity | undefined;
+  if (
+    opts.resolveFederatedPeer !== undefined &&
+    opts.cryptoVerify === true &&
+    envelope.sovereignty.classification === "federated"
+  ) {
+    const peerPrincipal = principalFromEnvelope(envelope);
+    const peerOutcome = await opts.resolveFederatedPeer(peerPrincipal);
+    if (!peerOutcome.resolved) {
+      // Peer unverifiable (404 / transient / signature failure / disabled).
+      // Reject the inbound envelope — an unresolved peer principal is
+      // admitted by NO posture. The seam already logged the detailed cause.
+      return {
+        valid: false,
+        rejectedAt: 0,
+        reason: {
+          kind: "federated_peer_unresolved",
+          peerPrincipal,
+          detail: peerOutcome.reason,
+        },
+        skipped: [],
+      };
+    }
+    federatedPeerDid = peerOutcome.identity.id;
+    federatedPeerIdentity = peerOutcome.identity;
+  }
+
   const skipped: number[] = [];
 
   for (const [i, stamp] of chain.entries()) {
-    const stampResult = verifyOneStamp(stamp, opts);
+    const stampResult = verifyOneStamp(stamp, opts, federatedPeerDid);
     if (stampResult.kind === "skip") {
       skipped.push(i);
       continue;
@@ -313,6 +446,18 @@ export async function verifySignedByChain(
         ? { identity: opts.stackIdentity, nkeyPub: opts.stackNKeyPub }
         : undefined,
     );
+
+    // TC-2d (cortex#635) — merge the registry-resolved federated peer
+    // identity (resolved up-front, before the structural walk) so the
+    // crypto-verify pass below finds a registered Principal to verify the
+    // peer's stamp against. myelin `add()` is last-write-wins on the DID
+    // key; the boot anchor's DID is structurally distinct from a peer's
+    // (guarded in the TC-2b `MultiPrincipalIdentityRegistry`), so this
+    // never displaces it. Undefined for local.*/public.* and for
+    // off/permissive (no seam) — the single-principal registry is untouched.
+    if (federatedPeerIdentity !== undefined) {
+      registry.add(federatedPeerIdentity);
+    }
     // Myelin's verifier expects `signed_by` normalised to array form;
     // cortex's `Envelope` keeps the back-compat shim of single-stamp
     // OR array. Normalise here before handing off.
@@ -370,10 +515,22 @@ type StampOutcome =
  * Classify a single stamp. Hub-stamps are skipped at this slice — Phase D
  * extends with hub-trust verification. Bare ed25519 stamps run the
  * structural trust check.
+ *
+ * `federatedPeerDid` (TC-2d / cortex#635) — when set, a stamp whose
+ * `identity` matches it short-circuits the structural agent-registry /
+ * trust-list lookup. A federated signer peer is, by construction, NOT a
+ * local agent and NOT in the receiver's `trust:` list — its trust is
+ * anchored in the registry-signed resolve (already performed up-front),
+ * not the local trust graph. This mirrors the cortex#480 own-stack
+ * short-circuit; the crypto-verify pass still runs against the resolved
+ * peer pubkey (merged into the registry), so this short-circuits the
+ * *trust* check, NOT the *bytes* check — a forged peer signature still
+ * fails.
  */
 function verifyOneStamp(
   stamp: SignedBy,
   opts: VerifySignedByChainOptions,
+  federatedPeerDid: string | undefined,
 ): StampOutcome {
   if (stamp.method === "hub-stamp") {
     return { kind: "skip" };
@@ -410,6 +567,14 @@ function verifyOneStamp(
   // pass below still runs against `stackNKeyPub` — short-circuit the
   // *trust* check, not the *bytes* check.
   if (opts.stackIdentity !== undefined && principal === opts.stackIdentity) {
+    return { kind: "accept" };
+  }
+
+  // TC-2d (cortex#635) — federated signer-peer short-circuit. The stamp's
+  // identity matches the registry-resolved federated peer DID; admit it
+  // structurally (registry-anchored trust) and let the crypto pass verify
+  // the bytes against the resolved peer pubkey. See function docblock.
+  if (federatedPeerDid !== undefined && principal === federatedPeerDid) {
     return { kind: "accept" };
   }
 
@@ -554,7 +719,7 @@ export function buildIdentityRegistry(
  * want. The `Codec` subpath import is the narrow way to the decoded
  * payload without re-implementing crockford base32 + CRC16 inline.
  */
-function nkeyToBase64Pubkey(nkey: string): string | undefined {
+export function nkeyToBase64Pubkey(nkey: string): string | undefined {
   try {
     const asciiBytes = new TextEncoder().encode(nkey);
     const raw = Codec.decode(Prefix.User, asciiBytes);

--- a/src/common/registry/identity-registry.ts
+++ b/src/common/registry/identity-registry.ts
@@ -82,6 +82,20 @@ import {
 import type { PrincipalPubkeyResolver } from "./resolve-pubkey";
 
 /**
+ * TC-2d (cortex#635) — outcome of {@link
+ * MultiPrincipalIdentityRegistry.resolveFederatedPeer}, the adapter the
+ * `federated.*` crypto-verify path (`verifySignedByChain`) consumes.
+ *
+ * Structurally identical to the verifier's `FederatedPeerResolution` so the
+ * registry method can be handed directly as the verify seam without an
+ * adapter layer — kept defined HERE (not imported from `src/bus/`) so the
+ * registry module stays free of a back-edge into the bus layer.
+ */
+export type FederatedPeerResolution =
+  | { resolved: true; identity: Identity }
+  | { resolved: false; reason: string };
+
+/**
  * Where an entry's verified pubkey came from. Stamped onto every entry so
  * TC-2d / audit can distinguish the boot trust anchor from a registry-
  * resolved peer.
@@ -322,6 +336,34 @@ export class MultiPrincipalIdentityRegistry {
         return { resolved: true, entry };
       }
     }
+  }
+
+  /**
+   * TC-2d (cortex#635) — verify-path adapter. Resolve `peerPrincipal` and
+   * project the {@link RegistryResolveOutcome} onto the shape the
+   * `federated.*` crypto-verify seam (`verifySignedByChain`'s
+   * `resolveFederatedPeer`) consumes: a positive carries the peer's myelin
+   * `Identity` to merge into the verify registry; every negative carries a
+   * grep-friendly `reason` string (`disabled` / `not_found` / `unresolved`)
+   * the verifier surfaces as `federated_peer_unresolved`.
+   *
+   * `disabled` (resolver inert — federation verify not engaged) is mapped to
+   * a negative here on purpose: if this adapter is ever invoked under a
+   * disabled resolver (it should not be — `cortex.ts` only wires the seam
+   * under `signing === "enforce"`), the verifier rejects rather than admits.
+   * NEVER throws (delegates to {@link resolve}, which never throws).
+   *
+   * Bind this method (`registry.resolveFederatedPeer.bind(registry)`) when
+   * handing it to the verifier so `this` stays the registry instance.
+   */
+  async resolveFederatedPeer(
+    peerPrincipal: string,
+  ): Promise<FederatedPeerResolution> {
+    const outcome = await this.resolve(peerPrincipal);
+    if (outcome.resolved) {
+      return { resolved: true, identity: outcome.entry.identity };
+    }
+    return { resolved: false, reason: outcome.reason };
   }
 
   /**

--- a/src/common/registry/index.ts
+++ b/src/common/registry/index.ts
@@ -27,6 +27,7 @@ export type {
 export { MultiPrincipalIdentityRegistry } from "./identity-registry";
 export type {
   EntryProvenance,
+  FederatedPeerResolution,
   MultiPrincipalIdentityRegistryOptions,
   PrincipalEntry,
   RegistryResolveOutcome,

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -64,7 +64,10 @@ import {
   provisionReviewStream,
   provisionReviewConsumer,
 } from "./bus/jetstream/provision";
-import { verifySignedByChain } from "./bus/verify-signed-by-chain";
+import {
+  verifySignedByChain,
+  nkeyToBase64Pubkey,
+} from "./bus/verify-signed-by-chain";
 import { runVerifierSelfCheck } from "./bus/verifier-self-check";
 import { CCSession, type CCSessionOpts } from "./runner/cc-session";
 import { makePiDevPipelineRunner } from "./runner/substrate/pi-dev-runner";
@@ -105,8 +108,15 @@ import { createDispatchListener, type DispatchListener } from "./runner/dispatch
 import { WorklogManager } from "./runner/worklog-manager";
 
 import { CloudPublisher } from "./taps/cc-events/cloud-publisher";
-import { RegistryClient } from "./common/registry";
-import type { RegistryClientReader } from "./common/registry";
+import {
+  RegistryClient,
+  PrincipalPubkeyResolver,
+  MultiPrincipalIdentityRegistry,
+} from "./common/registry";
+import type {
+  RegistryClientReader,
+  FederatedPeerResolution,
+} from "./common/registry";
 import { JsonlReader } from "./taps/cc-events/lib/jsonl-reader";
 import { PublishedEventSchema } from "./taps/cc-events/hooks/lib/event-types";
 import { formatEventForDiscord } from "./adapters/discord/event-formatter";
@@ -1275,6 +1285,87 @@ export async function startCortex(
   // TC-0 (#628) — `rejectEmpty` is now posture-gated: `enforce` → reject
   // unsigned peer dispatches; `off`/`permissive` → surface but do not
   // reject. The listener's default (`true`) is preserved under `enforce`.
+
+  // TC-2d (cortex#635) — federated.* crypto-verify seam. The CAPSTONE of
+  // the cross-principal trust chain: it lets THIS node verify an envelope
+  // signed by a PEER principal (not just the local boot principal) by
+  // resolving the peer's Ed25519 pubkey from the network registry (TC-2a
+  // `PrincipalPubkeyResolver`) into a multi-principal `IdentityRegistry`
+  // (TC-2b) the `federated.*` verify path consumes. Built ONCE here and
+  // threaded into every inbound verify call site (bus-dispatch-listener,
+  // dispatch-listener, review-consumer) so they share one resolver cache.
+  //
+  // ⚠️ LOAD-BEARING #635 GATE — `enabled` is driven by
+  // `signing === "enforce"`, NOT by `signingKnobs.cryptoVerify`.
+  // `resolveSigningKnobs` sets `cryptoVerify: true` for ALL postures
+  // (off/permissive/enforce) as cheap observability; deriving the gate
+  // from it would make OFF/permissive dev stacks reach out to the registry
+  // on every inbound federated envelope — the regression the #635 wiring
+  // note forbids. Under `off`/`permissive` the seam stays `undefined` and
+  // the verify path NEVER constructs a resolver: ZERO registry I/O.
+  //
+  // Construction requires (a) `signing === "enforce"`, (b) a federation
+  // registry URL, and (c) a derivable local boot `Identity` (the stack
+  // signer staged above → its NKey pubkey). Missing any → seam stays
+  // `undefined` and federated envelopes fall through to the local-only
+  // verify exactly as today (single-principal path untouched).
+  let resolveFederatedPeer:
+    | ((peerPrincipal: string) => Promise<FederatedPeerResolution>)
+    | undefined;
+  const federationRegistryConfig = options.policy?.federated?.registry;
+  const federationVerifyEnabled = config.security.signing === "enforce";
+  if (
+    federationVerifyEnabled &&
+    federationRegistryConfig !== undefined &&
+    signer !== undefined &&
+    stackNKeyPubForVerifier !== undefined
+  ) {
+    const bootPublicKey = nkeyToBase64Pubkey(stackNKeyPubForVerifier);
+    if (bootPublicKey === undefined) {
+      // The stack NKey already passed the AgentSchema/StackConfig regex on
+      // load, so a decode failure here is defensive-only — log and leave
+      // the seam unwired (federated envelopes verify local-only, as today)
+      // rather than crash boot.
+      process.stderr.write(
+        "cortex: TC-2d federated-verify seam NOT wired — could not decode " +
+          `stack NKey pubkey ${stackNKeyPubForVerifier} to base64 ed25519\n`,
+      );
+    } else {
+      const peerResolver = new PrincipalPubkeyResolver({
+        enabled: federationVerifyEnabled,
+        baseUrl: federationRegistryConfig.url,
+        ...(federationRegistryConfig.pubkey !== undefined && {
+          registryPubkey: federationRegistryConfig.pubkey,
+        }),
+      });
+      const peerRegistry = new MultiPrincipalIdentityRegistry({
+        bootPrincipal: {
+          principalId,
+          identity: {
+            id: signer.principal,
+            display_name: signer.principal,
+            network: principalId,
+            public_key: bootPublicKey,
+            type: "agent",
+            created_at: new Date(0).toISOString(),
+          },
+        },
+        resolver: peerResolver,
+      });
+      resolveFederatedPeer =
+        peerRegistry.resolveFederatedPeer.bind(peerRegistry);
+      console.log(
+        `cortex: TC-2d federated-verify seam wired (signing=enforce, registry=${federationRegistryConfig.url}) — ` +
+          `inbound federated.* envelopes verify against registry-resolved peer pubkeys`,
+      );
+    }
+  } else if (federationVerifyEnabled && federationRegistryConfig === undefined) {
+    console.log(
+      "cortex: security.signing=enforce but no policy.federated.registry configured — " +
+        "federated.* envelopes verify local-only (no peer-pubkey resolution)",
+    );
+  }
+
   let busDispatchListener: BusDispatchListener | undefined;
   const firstAgent = mergedAgents[0];
   if (firstAgent !== undefined) {
@@ -1298,6 +1389,9 @@ export async function startCortex(
       ...(stackNKeyPubForVerifier !== undefined && {
         stackNKeyPub: stackNKeyPubForVerifier,
       }),
+      // TC-2d (cortex#635) — federated.* peer-pubkey resolution seam.
+      // `undefined` unless `signing === "enforce"` + registry configured.
+      ...(resolveFederatedPeer !== undefined && { resolveFederatedPeer }),
     });
     busDispatchListener.start();
     console.log(
@@ -2110,6 +2204,9 @@ export async function startCortex(
     // gate inside the listener prevents double-stamping already-signed
     // traffic.
     ...(signer !== undefined && { resignSigner: signer }),
+    // TC-2d (cortex#635) — federated.* peer-pubkey resolution seam.
+    // Inert for local.* dispatches; `undefined` under off/permissive.
+    ...(resolveFederatedPeer !== undefined && { resolveFederatedPeer }),
   });
   await dispatchListener.start();
 

--- a/src/runner/dispatch-listener.ts
+++ b/src/runner/dispatch-listener.ts
@@ -111,6 +111,7 @@ import {
   type ResponseRouting,
 } from "../bus/dispatch-events";
 import type { TrustResolver } from "../common/agents/trust-resolver";
+import type { FederatedPeerResolution } from "../common/registry";
 import {
   verifySignedByChain,
   type ChainRejectionReason,
@@ -414,6 +415,19 @@ export interface DispatchListenerOptions {
    */
   resignSigner?: BusEnvelopeSigner;
   /**
+   * TC-2d (cortex#635) — federated.* peer-pubkey resolution seam. When
+   * supplied AND `cryptoVerify: true`, an inbound `federated.*` dispatch
+   * has its **signer peer principal** resolved to a verified Ed25519
+   * identity before the crypto-verify pass (the cross-principal trust
+   * chain capstone). `cortex.ts` wires this ONLY under
+   * `signing === "enforce"`; `off`/`permissive` leave it `undefined`
+   * (ZERO registry I/O — federated envelopes verify local-only, as today).
+   * Inert for `local.*` dispatches. See `verify-signed-by-chain.ts` JSDoc.
+   */
+  resolveFederatedPeer?: (
+    peerPrincipal: string,
+  ) => Promise<FederatedPeerResolution>;
+  /**
    * cortex#492 — dispatch-stage tracing toggle. When `true`, the
    * inbound path emits a `system.dispatch.stage` envelope (via
    * `runtime.publish`) AND a structured stderr line at each pipeline
@@ -682,6 +696,7 @@ export function createDispatchListener(
     stackIdentity,
     stackNKeyPub,
     resignSigner,
+    resolveFederatedPeer,
     adapterId = "runner-dispatch-listener",
   } = opts;
   // v2.0.2 default: structural trust + ed25519 crypto verification.
@@ -758,6 +773,7 @@ export function createDispatchListener(
         stackIdentity,
         stackNKeyPub,
         resignSigner,
+        resolveFederatedPeer,
         traceDispatch,
       });
     } catch (err) {
@@ -1088,6 +1104,13 @@ interface DispatchHandlerContext {
    */
   resignSigner: BusEnvelopeSigner | undefined;
   /**
+   * TC-2d (cortex#635) — federated.* peer-pubkey resolution seam.
+   * Inert for `local.*`; `undefined` unless `signing === "enforce"`.
+   */
+  resolveFederatedPeer:
+    | ((peerPrincipal: string) => Promise<FederatedPeerResolution>)
+    | undefined;
+  /**
    * cortex#492 — when `true`, emit a `system.dispatch.stage` trace at
    * each gate inside the handler. Resolved by `createDispatchListener`
    * from the explicit option or `CORTEX_TRACE_DISPATCH`; the handler
@@ -1116,6 +1139,7 @@ async function handleDispatchEnvelope(
     stackIdentity,
     stackNKeyPub,
     resignSigner,
+    resolveFederatedPeer,
     traceDispatch,
   } = ctx;
   // cortex#492 — pre-parse trace context. Refined to the trusted payload
@@ -1269,6 +1293,9 @@ async function handleDispatchEnvelope(
         // entry for self-signed adapter-originated dispatches.
         ...(stackIdentity !== undefined && { stackIdentity }),
         ...(stackNKeyPub !== undefined && { stackNKeyPub }),
+        // TC-2d (cortex#635) — federated.* peer-pubkey resolution seam.
+        // Inert for local.* dispatches; `undefined` under off/permissive.
+        ...(resolveFederatedPeer !== undefined && { resolveFederatedPeer }),
       });
     } catch (err) {
       // `verifySignedByChain` throws when `cryptoVerify: true` and


### PR DESCRIPTION
## What

TC-2d (cortex#635) — the **capstone** of the cross-principal trust chain. Wires the federation crypto-verify path so an inbound `federated.*` envelope signed by a **peer principal** (not just the local boot principal) is verified against that peer's **registry-resolved Ed25519 pubkey**, using TC-2a (`PrincipalPubkeyResolver`) + TC-2b (`MultiPrincipalIdentityRegistry`).

Design: `docs/design-trust-confidentiality.md` §"Phase 2 — Federation trust" item **2d** (marked DONE in this PR).

Closes #635.

## How the signer peer principal is determined

The signer peer is the **SOURCE** principal — `principalFromEnvelope(envelope)`, the leading dotted segment of `envelope.source`. This is deliberately **NOT** the `federated.{network_id}` subject segment (which post-#661 names the *target* network), but the principal that actually **signed** the envelope. Its federation identity is keyed `did:mf:<peerPrincipal>`.

A federated peer is, by construction, not a local agent and not in the receiver's `trust:` list — its trust is anchored in the **registry-signed resolve**, so its stamp DID short-circuits the *structural* trust check (mirroring the cortex#480 own-stack admit) while the *bytes* are still verified against the resolved pubkey. A negative resolve rejects the envelope (`federated_peer_unresolved`, logged).

## ⚠️ Load-bearing #635 gate: `enabled` on `enforce`, NOT `cryptoVerify`

`resolveSigningKnobs` sets `cryptoVerify: true` for **all** postures (off/permissive/enforce) as cheap observability. The federation resolver `enabled` flag is therefore gated on **`signing === "enforce"`**. In `cortex.ts` the `resolveFederatedPeer` seam is constructed **only** under `enforce` (+ a registry URL + a derivable boot identity); under off/permissive the seam is `undefined` and the verify path never constructs a resolver — **ZERO registry I/O**. Pinned by a fetch-spy test (`fetchCount === 0`).

## local.* / posture-OFF unchanged

- `local.*` / `public.*` envelopes never engage the seam — boot/local single-principal verify exactly as today.
- off/permissive: no seam wired → no resolver → no I/O → byte-identical to today.

## What changed

- **`src/bus/verify-signed-by-chain.ts`** — resolve the federated signer peer up-front (federated + `cryptoVerify` + seam present), short-circuit its structural trust check, merge the resolved `Identity` into the myelin registry the bytes-check runs against. New `federated_peer_unresolved` rejection reason. Exported `nkeyToBase64Pubkey`. **Self-review S-1 fix**: gated the structural short-circuit on `cryptoVerify === true` (fail-closed — no short-circuit without a bytes-check).
- **`src/common/registry/identity-registry.ts`** — `resolveFederatedPeer` adapter projecting `resolve()` onto the verify seam shape; `FederatedPeerResolution` type (exported via barrel).
- **`src/cortex.ts`** — construct `PrincipalPubkeyResolver` + `MultiPrincipalIdentityRegistry` at boot with the boot principal pinned + resolver `enabled = (signing === "enforce")`; thread the seam into the dispatch-listener + bus-dispatch-listener.
- **`src/bus/bus-dispatch-listener.ts`**, **`src/runner/dispatch-listener.ts`** — accept + forward the seam.
- **`docs/design-trust-confidentiality.md`** — mark 2d DONE.

## Verification

- `bunx tsc --noEmit`: **0 errors** · `bun run lint:errors`: **clean** · `bash scripts/check-carveouts.sh`: **PASS**
- `verify-signed-by-chain.test.ts` +8 TC-2d cases:
  - peer resolvable + valid sig → **ACCEPTED**
  - peer resolvable + forged sig → **REJECTED** (`crypto_verify_failed`)
  - peer not_found → **REJECTED** (`federated_peer_unresolved`, logged)
  - `local.*` under enforce → boot-identity verify, **peer seam never consulted**
  - federated without a seam → local-only verify (no resolve)
  - **posture OFF/permissive + inbound federated → ZERO registry I/O** (`fetchCount === 0`)
  - S-1: federated seam wired but `cryptoVerify:false` → no short-circuit, fail closed
- Full sweep: **828 pass / 0 fail** across registry + bus + dispatch + boot suites.

DO NOT merge — central merge with a vocab-gate-verified step + independent adversarial security review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)