### PR TITLE
feat(bus): TC-1b — stack-identity provisioning + boot verifier-self-check (#632)

### DIFF
--- a/src/__tests__/cortex.security-posture-boot.test.ts
+++ b/src/__tests__/cortex.security-posture-boot.test.ts
@@ -30,6 +30,7 @@ import { join } from "path";
 import { tmpdir } from "os";
 import { createUser } from "nkeys.js";
 import { AgentConfigSchema, type AgentConfig } from "../common/types/config";
+import type { Agent } from "../common/types/cortex-config";
 import { startCortex } from "../cortex";
 import type { Envelope } from "../bus/myelin/envelope-validator";
 import type { EnvelopeHandler, MyelinRuntime } from "../bus/myelin/runtime";
@@ -47,6 +48,22 @@ function minimalConfig(security?: AgentConfig["security"]): AgentConfig {
     paths: { publishedEventsDir: "/tmp/grove-cortex-posture-test-published" },
   });
   return security === undefined ? base : { ...base, security };
+}
+
+/**
+ * Minimal inline `Agent` so the boot path has a `firstAgent` to run the TC-1b
+ * (#632) self-check against under `enforce`. Trust is empty (the self-check
+ * exercises the own-stack short-circuit, not peer trust).
+ */
+function enforceAgentFixture(): Agent {
+  return {
+    id: "luna",
+    displayName: "Luna",
+    persona: "./personas/luna.md",
+    roles: [],
+    trust: [],
+    presence: {},
+  } as Agent;
 }
 
 interface RecordingRuntime extends MyelinRuntime {
@@ -216,18 +233,32 @@ describe("startCortex — TC-0 security posture wiring (#628)", () => {
   });
 
   test("enforce → rejecting knobs (rejectEmpty=true, drop)", async () => {
+    // The posture-knob log line is emitted at boot independent of stack
+    // identity / agents. Under TC-1b (#632) an `enforce` stack with no
+    // self-verifiable identity FAILS FAST after that line, so we capture logs
+    // around the (expected) throw and assert the knob resolution still logged.
     const runtime = createRecordingRuntime();
     const cfg = minimalConfig({
       signing: "enforce",
       encryption: { payload: "off", at_rest: "off" },
       transport: { mtls: "off" },
     });
-    const { result: handle, logs } = await withCapturedConsoleLog(() =>
-      startCortex(cfg, {
-        ...COMMON_OPTS,
-        injectRuntime: runtime,
-      }),
-    );
+
+    const originalLog = console.log.bind(console);
+    const logs: string[] = [];
+    console.log = (...args: unknown[]): void => {
+      logs.push(args.map((a) => String(a)).join(" "));
+    };
+    let threw = false;
+    try {
+      await startCortex(cfg, { ...COMMON_OPTS, injectRuntime: runtime });
+    } catch (err) {
+      threw = true;
+      expect(err instanceof Error ? err.message : String(err)).toMatch(/REFUSING TO BOOT/i);
+    } finally {
+      console.log = originalLog;
+    }
+    expect(threw).toBe(true);
 
     const postureLines = logs.filter((l) =>
       l.includes("cortex: security posture — signing=enforce"),
@@ -235,7 +266,54 @@ describe("startCortex — TC-0 security posture wiring (#628)", () => {
     expect(postureLines.length).toBe(1);
     expect(postureLines[0]!).toContain("rejectEmpty=true");
     expect(postureLines[0]!).toContain("signFailureMode=drop");
+  });
 
-    await handle.stop();
+  test("TC-1b: enforce + valid stack identity + agent → boots clean", async () => {
+    // The positive path: a provisioned seed + an agent that can receive the
+    // self-check envelope. The boot self-check round-trips and boot proceeds.
+    const tmp = mkdtempSync(join(tmpdir(), "cortex-posture-enforce-ok-"));
+    const seedPath = join(tmp, "stack.nk");
+    writeFileSync(seedPath, new TextDecoder().decode(createUser().getSeed()));
+    chmodSync(seedPath, 0o600);
+    try {
+      const runtime = createRecordingRuntime();
+      const cfg = minimalConfig({
+        signing: "enforce",
+        encryption: { payload: "off", at_rest: "off" },
+        transport: { mtls: "off" },
+      });
+      const { result: handle, logs } = await withCapturedConsoleLog(() =>
+        startCortex(cfg, {
+          ...COMMON_OPTS,
+          stack: { id: "test-op/research", nkey_seed_path: seedPath },
+          inlineAgents: [enforceAgentFixture()],
+          injectRuntime: runtime,
+        }),
+      );
+      // Self-check round-tripped under enforce → boot proceeded.
+      expect(logs.join("\n")).toContain("verifier-self-check OK");
+      await handle.stop();
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test("TC-1b: enforce + no stack identity → REFUSES TO BOOT (fail fast)", async () => {
+    // The TC-1b boot gate: a stack serving SIGNED traffic under `enforce` must
+    // have a self-verifiable signing identity. With none wired, startCortex
+    // must throw rather than silently serve unverifiable traffic.
+    const runtime = createRecordingRuntime();
+    const cfg = minimalConfig({
+      signing: "enforce",
+      encryption: { payload: "off", at_rest: "off" },
+      transport: { mtls: "off" },
+    });
+    await expect(
+      startCortex(cfg, {
+        ...COMMON_OPTS,
+        inlineAgents: [enforceAgentFixture()],
+        injectRuntime: runtime,
+      }),
+    ).rejects.toThrow(/REFUSING TO BOOT/i);
   });
 });

--- a/src/__tests__/cortex.security-posture-boot.test.ts
+++ b/src/__tests__/cortex.security-posture-boot.test.ts
@@ -24,14 +24,21 @@
  * stderr/console capture pattern).
  */
 
-import { describe, expect, test } from "bun:test";
-import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "fs";
+import { describe, expect, test, spyOn } from "bun:test";
+import {
+  chmodSync,
+  existsSync,
+  mkdtempSync,
+  rmSync,
+  unlinkSync,
+  writeFileSync,
+} from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 import { createUser } from "nkeys.js";
 import { AgentConfigSchema, type AgentConfig } from "../common/types/config";
 import type { Agent } from "../common/types/cortex-config";
-import { startCortex } from "../cortex";
+import { startCortex, bootOrDie } from "../cortex";
 import type { Envelope } from "../bus/myelin/envelope-validator";
 import type { EnvelopeHandler, MyelinRuntime } from "../bus/myelin/runtime";
 
@@ -315,5 +322,73 @@ describe("startCortex — TC-0 security posture wiring (#628)", () => {
         injectRuntime: runtime,
       }),
     ).rejects.toThrow(/REFUSING TO BOOT/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// bootOrDie — the ENTRYPOINT-layer fatal-exit guarantee.
+//
+// The library `startCortex` rejecting (above) is NECESSARY but not SUFFICIENT:
+// the `start` action is an async commander action invoked by synchronous
+// `program.parse()`, which does not await it, so the rejection used to land in
+// the "non-fatal" unhandledRejection handler and the daemon lingered half-
+// booted. These tests pin that a boot-phase rejection now EXITS the process
+// non-zero and removes the PID file (so launchd can't see a "healthy" daemon).
+// ---------------------------------------------------------------------------
+describe("bootOrDie — boot-phase failure is fatal (cortex#632 review BLOCK)", () => {
+  function tmpPid(): string {
+    return join(
+      tmpdir(),
+      `cortex-bootordie-${process.pid}-${Math.random().toString(36).slice(2)}.pid`,
+    );
+  }
+
+  test("a boot throw (REFUSING TO BOOT) exits non-zero and removes the PID file", async () => {
+    const pidFile = tmpPid();
+    writeFileSync(pidFile, String(process.pid)); // simulate the singleton PID write
+
+    // Mock process.exit to HALT (throw) like the real thing, so we can assert
+    // the code without killing the test runner.
+    const exitSpy = spyOn(process, "exit").mockImplementation(
+      (code?: number) => {
+        throw new Error(`__exit__:${code}`);
+      },
+    );
+    const errSpy = spyOn(console, "error").mockImplementation(() => {});
+
+    try {
+      await expect(
+        bootOrDie(async () => {
+          throw new Error(
+            "verifier-self-check: REFUSING TO BOOT — stack identity unverifiable under signing: enforce",
+          );
+        }, pidFile),
+      ).rejects.toThrow("__exit__:1");
+
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      // The PID file MUST be gone — launchd must not see a healthy daemon.
+      expect(existsSync(pidFile)).toBe(false);
+      // The fatal reason is surfaced, not swallowed as "non-fatal".
+      expect(
+        errSpy.mock.calls.some((c) => String(c[0]).includes("FATAL")),
+      ).toBe(true);
+    } finally {
+      exitSpy.mockRestore();
+      errSpy.mockRestore();
+      if (existsSync(pidFile)) unlinkSync(pidFile);
+    }
+  });
+
+  test("a successful boot returns the handle and leaves the PID file intact", async () => {
+    const pidFile = tmpPid();
+    writeFileSync(pidFile, String(process.pid));
+    try {
+      const sentinel = { ok: true };
+      const handle = await bootOrDie(async () => sentinel, pidFile);
+      expect(handle).toBe(sentinel);
+      expect(existsSync(pidFile)).toBe(true); // healthy boot keeps its PID file
+    } finally {
+      if (existsSync(pidFile)) unlinkSync(pidFile);
+    }
   });
 });

--- a/src/bus/__tests__/stack-provisioning.test.ts
+++ b/src/bus/__tests__/stack-provisioning.test.ts
@@ -1,0 +1,211 @@
+/**
+ * TC-1b (#632) — stack-identity provisioning tests.
+ *
+ * Coverage:
+ *   1. generate writes a seed (mode 600) + derives the matching NKey pub +
+ *      base64 pubkey (pubkey == nkeyToBase64Pubkey(nkeyPub)).
+ *   2. generate REFUSES to clobber an existing seed without force; force
+ *      overwrites.
+ *   3. PROOF-OF-POSSESSION round-trip: a claim built by `buildRegistrationClaim`
+ *      is ACCEPTED by the REAL `POST /principals/{id}/register` route — the
+ *      signature verifies against the declared pubkey (same NKey key).
+ *   4. A claim TAMPERED after signing is REJECTED by the route (401).
+ *   5. materialFromSeedString re-derives identical material from a seed.
+ *   6. No secret material (seed) appears in the returned public surface.
+ */
+
+import { describe, test, expect, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, statSync, readFileSync, existsSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+import {
+  generateStackIdentity,
+  materialFromSeedString,
+  buildRegistrationClaim,
+  fingerprintOf,
+} from "../stack-provisioning";
+import { nkeyToBase64Pubkey } from "../verify-signed-by-chain";
+
+// Drive the REAL registry Worker route so proof-of-possession is exercised
+// end-to-end (not a re-implemented verifier).
+import registryApp from "../../services/network-registry/src/index";
+import type { Env } from "../../services/network-registry/src/index";
+import {
+  makeRegistryKey,
+  resetStores,
+} from "../../services/network-registry/__tests__/helpers";
+
+const tmpDirs: string[] = [];
+function freshDir(): string {
+  const d = mkdtempSync(join(tmpdir(), "tc1b-provision-"));
+  tmpDirs.push(d);
+  return d;
+}
+afterEach(() => {
+  while (tmpDirs.length > 0) {
+    const d = tmpDirs.pop()!;
+    rmSync(d, { recursive: true, force: true });
+  }
+  resetStores();
+});
+
+describe("generateStackIdentity (TC-1b #632)", () => {
+  test("[1] writes seed chmod 600 + derives matching pubkeys", () => {
+    const seedPath = join(freshDir(), "stack.nk");
+    const material = generateStackIdentity({ seedPath });
+
+    // Seed file exists, mode 600 (POSIX only).
+    expect(existsSync(seedPath)).toBe(true);
+    if (process.platform !== "win32") {
+      const mode = statSync(seedPath).mode & 0o777;
+      expect(mode).toBe(0o600);
+    }
+
+    // Seed on disk is the SU… user-class seed.
+    const onDisk = readFileSync(seedPath, "utf-8").trim();
+    expect(onDisk.startsWith("SU")).toBe(true);
+    expect(onDisk).toBe(material.seed.trim());
+
+    // NKey pub is U… and the base64 pubkey matches the bridge.
+    expect(material.nkeyPub.startsWith("U")).toBe(true);
+    expect(material.nkeyPub.length).toBe(56);
+    const bridged = nkeyToBase64Pubkey(material.nkeyPub);
+    expect(bridged).toBeDefined();
+    expect(material.pubkeyB64).toBe(bridged!);
+    expect(material.pubkeyB64.length).toBe(44); // 32 raw bytes base64
+    expect(material.fingerprint).toBe(material.pubkeyB64.slice(0, 12));
+  });
+
+  test("[2] refuses to clobber an existing seed without force; force overwrites", () => {
+    const seedPath = join(freshDir(), "stack.nk");
+    const first = generateStackIdentity({ seedPath });
+
+    // No force → throws, file untouched.
+    expect(() => generateStackIdentity({ seedPath })).toThrow(/refusing to overwrite/i);
+    expect(readFileSync(seedPath, "utf-8").trim()).toBe(first.seed.trim());
+
+    // force → new identity, file replaced.
+    const second = generateStackIdentity({ seedPath, force: true });
+    expect(second.nkeyPub).not.toBe(first.nkeyPub);
+    expect(readFileSync(seedPath, "utf-8").trim()).toBe(second.seed.trim());
+    if (process.platform !== "win32") {
+      expect(statSync(seedPath).mode & 0o777).toBe(0o600);
+    }
+  });
+
+  test("[5] materialFromSeedString re-derives identical material", () => {
+    const seedPath = join(freshDir(), "stack.nk");
+    const generated = generateStackIdentity({ seedPath });
+    const reloaded = materialFromSeedString(generated.seed);
+    expect(reloaded.nkeyPub).toBe(generated.nkeyPub);
+    expect(reloaded.pubkeyB64).toBe(generated.pubkeyB64);
+    expect(reloaded.fingerprint).toBe(generated.fingerprint);
+  });
+
+  test("[5b] materialFromSeedString rejects a non-user-class seed", () => {
+    expect(() => materialFromSeedString("SAABLAH")).toThrow(/user-class/i);
+  });
+});
+
+describe("proof-of-possession registration (TC-1b #632)", () => {
+  async function configuredEnv(): Promise<Env> {
+    resetStores();
+    const reg = await makeRegistryKey();
+    return {
+      REGISTRY_SIGNING_KEY: reg.signingKey,
+      REGISTRY_PUBLIC_KEY: reg.publicKey,
+      ENVIRONMENT: "test",
+    };
+  }
+
+  test("[3] claim signed with the stack NKey is ACCEPTED by the real route", async () => {
+    const env = await configuredEnv();
+    const seedPath = join(freshDir(), "stack.nk");
+    const material = generateStackIdentity({ seedPath });
+
+    const body = await buildRegistrationClaim({
+      principalId: "andreas",
+      material,
+      stacks: [{ stack_id: "andreas/research", display_name: "Research" }],
+      capabilities: [{ id: "tasks.code-review", description: "Reviews TS" }],
+    });
+
+    // The claim's declared pubkey is the stack's pubkey (proof binds to it).
+    expect(body.claim.principal_pubkey).toBe(material.pubkeyB64);
+
+    const res = await registryApp.fetch(
+      new Request("http://localhost/principals/andreas/register", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      }),
+      env,
+    );
+    expect(res.status).toBe(201);
+    const json = (await res.json()) as { payload: { principal_pubkey: string } };
+    // The registry stored the SAME pubkey — possession proven, no swap.
+    expect(json.payload.principal_pubkey).toBe(material.pubkeyB64);
+  });
+
+  test("[4] a claim TAMPERED after signing is REJECTED (401)", async () => {
+    const env = await configuredEnv();
+    const seedPath = join(freshDir(), "stack.nk");
+    const material = generateStackIdentity({ seedPath });
+
+    const body = await buildRegistrationClaim({
+      principalId: "andreas",
+      material,
+      stacks: [{ stack_id: "andreas/research" }],
+    });
+    // Tamper: smuggle in an extra stack the signature didn't cover.
+    body.claim.stacks.push({ stack_id: "andreas/sneaked-in" });
+
+    const res = await registryApp.fetch(
+      new Request("http://localhost/principals/andreas/register", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      }),
+      env,
+    );
+    expect(res.status).toBe(401);
+  });
+
+  test("[4b] a claim signed by a DIFFERENT key than declared is REJECTED (401)", async () => {
+    const env = await configuredEnv();
+    const sp1 = join(freshDir(), "a.nk");
+    const sp2 = join(freshDir(), "b.nk");
+    const keyA = generateStackIdentity({ seedPath: sp1 });
+    const keyB = generateStackIdentity({ seedPath: sp2 });
+
+    // Build a valid claim with key A, then swap the declared pubkey to B's —
+    // the signature (over the original claim) no longer matches B's pubkey.
+    const body = await buildRegistrationClaim({
+      principalId: "andreas",
+      material: keyA,
+      stacks: [{ stack_id: "andreas/research" }],
+    });
+    body.claim.principal_pubkey = keyB.pubkeyB64;
+
+    const res = await registryApp.fetch(
+      new Request("http://localhost/principals/andreas/register", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      }),
+      env,
+    );
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("secrets discipline (TC-1b #632)", () => {
+  test("[6] fingerprint is derived from the PUBLIC key only", () => {
+    const seedPath = join(freshDir(), "stack.nk");
+    const material = generateStackIdentity({ seedPath });
+    expect(fingerprintOf(material.pubkeyB64)).toBe(material.fingerprint);
+    // The fingerprint must not contain any portion of the seed.
+    expect(material.seed).not.toContain(material.fingerprint);
+  });
+});

--- a/src/bus/__tests__/stack-provisioning.test.ts
+++ b/src/bus/__tests__/stack-provisioning.test.ts
@@ -15,7 +15,14 @@
  */
 
 import { describe, test, expect, afterEach } from "bun:test";
-import { mkdtempSync, rmSync, statSync, readFileSync, existsSync } from "fs";
+import {
+  mkdtempSync,
+  rmSync,
+  statSync,
+  readFileSync,
+  existsSync,
+  symlinkSync,
+} from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 
@@ -92,6 +99,23 @@ describe("generateStackIdentity (TC-1b #632)", () => {
     if (process.platform !== "win32") {
       expect(statSync(seedPath).mode & 0o777).toBe(0o600);
     }
+  });
+
+  test("[2b] refuses to follow a dangling symlink at the seed path — no write-through (wx)", () => {
+    const dir = freshDir();
+    const seedPath = join(dir, "stack.nk");
+    const attackerTarget = join(dir, "attacker-capture.nk");
+    // Dangling symlink: its target does not exist, so existsSync(seedPath) is
+    // FALSE — the userspace no-clobber guard passes. Pre-fix (plain "w"),
+    // writeFileSync would FOLLOW the link and create attackerTarget, writing the
+    // seed THROUGH it to an attacker-controlled path. O_EXCL ("wx") refuses to
+    // create through a symlink.
+    symlinkSync(attackerTarget, seedPath);
+    expect(existsSync(seedPath)).toBe(false); // dangling → reported absent
+
+    expect(() => generateStackIdentity({ seedPath })).toThrow();
+    // The seed was NOT written through to the attacker-controlled target.
+    expect(existsSync(attackerTarget)).toBe(false);
   });
 
   test("[5] materialFromSeedString re-derives identical material", () => {

--- a/src/bus/__tests__/verifier-self-check-boot.test.ts
+++ b/src/bus/__tests__/verifier-self-check-boot.test.ts
@@ -1,0 +1,187 @@
+/**
+ * TC-1b (#632) — posture-aware boot gate (`bootVerifierSelfCheck`).
+ *
+ * Coverage:
+ *   1. enforce + missing identity → THROWS (refuse to boot).
+ *   2. enforce + valid identity → resolves (boot proceeds), no throw.
+ *   3. enforce + INVALID identity (mismatched pubkey) → THROWS.
+ *   4. off + missing identity → no-op, no throw (unsigned-dev default).
+ *   5. permissive + invalid identity → WARN, no throw (advisory shadow).
+ *   6. no secret material (seed bytes) appears in any log/err line.
+ */
+
+import { describe, test, expect } from "bun:test";
+import { createUser } from "@nats-io/nkeys";
+import { AgentRegistry } from "../../common/agents/registry";
+import { TrustResolver } from "../../common/agents/trust-resolver";
+import { bootVerifierSelfCheck } from "../verifier-self-check";
+import type { Agent } from "../../common/types/cortex-config";
+
+function discordPresence() {
+  return {
+    enabled: true,
+    token: "discord-bot-token",
+    guildId: "1487000000000000000",
+    agentChannelId: "1487000000000000001",
+    logChannelId: "1487000000000000002",
+    contextDepth: 10,
+    enableAgentLog: false,
+    roles: [],
+    defaultRole: "allow-all",
+    dm: {
+      operatorRole: {
+        features: ["chat", "async", "team"] as const,
+        disallowedTools: [],
+        bashGuard: true,
+      },
+      defaultRole: "denied" as const,
+      userRoles: [],
+    },
+  };
+}
+
+function agentFixture(overrides: Partial<Agent> = {}): Agent {
+  return {
+    id: "luna",
+    displayName: "Luna",
+    persona: "./personas/luna.md",
+    roles: [],
+    trust: [],
+    presence: { discord: discordPresence() },
+    ...overrides,
+  } as Agent;
+}
+
+function stackKeypair() {
+  const kp = createUser();
+  return {
+    nkeyPub: kp.getPublicKey(),
+    rawSeed: (kp as unknown as { getRawSeed(): Uint8Array }).getRawSeed(),
+  };
+}
+
+function resolverFor(): TrustResolver {
+  return new TrustResolver(AgentRegistry.fromAgents([agentFixture()]));
+}
+
+describe("bootVerifierSelfCheck (TC-1b #632)", () => {
+  test("[1] enforce + missing identity → refuses to boot (throws)", async () => {
+    const errs: string[] = [];
+    await expect(
+      bootVerifierSelfCheck({
+        posture: "enforce",
+        identity: undefined,
+        resolver: resolverFor(),
+        receivingAgentId: "luna",
+        principalId: "andreas",
+        log: () => {},
+        err: (l) => errs.push(l),
+      }),
+    ).rejects.toThrow(/REFUSING TO BOOT/i);
+  });
+
+  test("[2] enforce + valid identity → resolves, boot proceeds", async () => {
+    const { nkeyPub, rawSeed } = stackKeypair();
+    const logs: string[] = [];
+    const errs: string[] = [];
+    await bootVerifierSelfCheck({
+      posture: "enforce",
+      identity: {
+        stackIdentity: "did:mf:andreas-meta-factory",
+        stackNKeyPub: nkeyPub,
+        stackSeedBytes: rawSeed,
+      },
+      resolver: resolverFor(),
+      receivingAgentId: "luna",
+      principalId: "andreas",
+      log: (l) => logs.push(l),
+      err: (l) => errs.push(l),
+    });
+    expect(errs).toHaveLength(0);
+    expect(logs.join("\n")).toContain("verifier-self-check OK");
+  });
+
+  test("[3] enforce + INVALID identity (mismatched pubkey) → refuses to boot", async () => {
+    const { rawSeed } = stackKeypair();
+    const { nkeyPub: otherPub } = stackKeypair();
+    await expect(
+      bootVerifierSelfCheck({
+        posture: "enforce",
+        identity: {
+          stackIdentity: "did:mf:andreas-meta-factory",
+          // Declared pubkey belongs to a DIFFERENT key than the seed.
+          stackNKeyPub: otherPub,
+          stackSeedBytes: rawSeed,
+        },
+        resolver: resolverFor(),
+        receivingAgentId: "luna",
+        principalId: "andreas",
+        log: () => {},
+        err: () => {},
+      }),
+    ).rejects.toThrow(/REFUSING TO BOOT/i);
+  });
+
+  test("[4] off + missing identity → no-op, no throw", async () => {
+    const logs: string[] = [];
+    const errs: string[] = [];
+    await bootVerifierSelfCheck({
+      posture: "off",
+      identity: undefined,
+      resolver: resolverFor(),
+      receivingAgentId: "luna",
+      principalId: "andreas",
+      log: (l) => logs.push(l),
+      err: (l) => errs.push(l),
+    });
+    expect(errs).toHaveLength(0);
+    expect(logs).toHaveLength(0);
+  });
+
+  test("[5] permissive + invalid identity → advisory WARN, no throw", async () => {
+    const { rawSeed } = stackKeypair();
+    const { nkeyPub: otherPub } = stackKeypair();
+    const errs: string[] = [];
+    // Must NOT throw.
+    await bootVerifierSelfCheck({
+      posture: "permissive",
+      identity: {
+        stackIdentity: "did:mf:andreas-meta-factory",
+        stackNKeyPub: otherPub,
+        stackSeedBytes: rawSeed,
+      },
+      resolver: resolverFor(),
+      receivingAgentId: "luna",
+      principalId: "andreas",
+      log: () => {},
+      err: (l) => errs.push(l),
+    });
+    const joined = errs.join("\n");
+    expect(joined).toContain("verifier-self-check: FAILED");
+    expect(joined).toContain("continuing boot under signing=permissive");
+  });
+
+  test("[6] no secret seed bytes leak into any log/err line", async () => {
+    const { nkeyPub, rawSeed } = stackKeypair();
+    const seedB64 = Buffer.from(rawSeed).toString("base64");
+    const seedHex = Buffer.from(rawSeed).toString("hex");
+    const logs: string[] = [];
+    const errs: string[] = [];
+    await bootVerifierSelfCheck({
+      posture: "permissive",
+      identity: {
+        stackIdentity: "did:mf:andreas-meta-factory",
+        stackNKeyPub: nkeyPub,
+        stackSeedBytes: rawSeed,
+      },
+      resolver: resolverFor(),
+      receivingAgentId: "luna",
+      principalId: "andreas",
+      log: (l) => logs.push(l),
+      err: (l) => errs.push(l),
+    });
+    const all = [...logs, ...errs].join("\n");
+    expect(all).not.toContain(seedB64);
+    expect(all).not.toContain(seedHex);
+  });
+});

--- a/src/bus/stack-provisioning.ts
+++ b/src/bus/stack-provisioning.ts
@@ -260,7 +260,17 @@ export function generateStackIdentity(
   // file is never momentarily group/world-readable, then assert via chmod for
   // platforms where the umask widened the create mode. The trailing newline
   // matches `nsc generate nkey` output; `loadStackSigningKey` trims it.
-  writeFileSync(seedPath, material.seed + "\n", { mode: 0o600 });
+  //
+  // Non-force create uses flag "wx" (O_EXCL|O_CREAT): the no-clobber guarantee
+  // becomes KERNEL-enforced (closing the existsSync→write TOCTOU above) and a
+  // symlink planted at `seedPath` is REFUSED rather than followed-and-written-
+  // through. Force (deliberate rotation) overwrites in place ("w"); the chmod
+  // re-assert below covers that path, where writeFileSync ignores `mode` on an
+  // already-existing file.
+  writeFileSync(seedPath, material.seed + "\n", {
+    mode: 0o600,
+    ...(force ? {} : { flag: "wx" }),
+  });
   // Defensive: an inherited umask can clear bits from the create-mode on some
   // platforms, so re-assert 600 explicitly. No-op on POSIX where the create
   // mode already took; harmless on win32 (ACL-governed).

--- a/src/bus/stack-provisioning.ts
+++ b/src/bus/stack-provisioning.ts
@@ -1,0 +1,440 @@
+/**
+ * TC-1b (Trust & Confidentiality, #632) — stack-identity provisioning.
+ *
+ * Design: `docs/design-trust-confidentiality.md` §4 Phase 1.1b — "Ensure
+ * every deployed stack has `stack.nkey_seed_path` + registered `nkey_pub`".
+ * This is the CODE side of making SIGNED operation real: without a
+ * provisioned stack signing identity AND its pubkey registered in the
+ * network-registry, `signing: enforce` has nothing to verify against, and
+ * the boot `verifier-self-check` (cortex#480) cannot pass.
+ *
+ * ## What provisioning produces
+ *
+ *   1. A fresh NATS NKey **user-class** signing identity (ed25519 seed,
+ *      `SU…`). This is the SAME key the stack signs bus envelopes with —
+ *      design invariant §2.4 "no new long-term keys" — so there is exactly
+ *      ONE root of secret material per stack.
+ *   2. The seed written to the configured `stack.nkey_seed_path`, chmod
+ *      `600` (matching the TC-4a/4b file-mode hardening — `enforceChmod600`).
+ *   3. The matching NKey public key (`U…`, 56-char base32) for
+ *      `cortex.yaml stack.nkey_pub`.
+ *   4. A **signed registration claim** for `POST /principals/{id}/register`,
+ *      where the claim is signed with the SAME ed25519 key. This proves
+ *      possession (the registry verifies the signature against the declared
+ *      `principal_pubkey`; a silent key swap is rejected by the route's
+ *      rotation guard — `routes/principals.ts:118`).
+ *
+ * ## Key-shape bridge (load-bearing)
+ *
+ * The bus identity is a NATS NKey (`U…`/`SU…`, base32). The network-registry
+ * proof-of-possession contract is WebCrypto Ed25519 over **base64 raw 32-byte
+ * pubkey** + **base64 raw 64-byte signature** of `canonicalJSON(claim)`.
+ * These are the same ed25519 primitive under two encodings:
+ *
+ *   - `nkey.getPublicKey()` → `U…` → `nkeyToBase64Pubkey` → base64 raw pubkey
+ *     (the `claim.principal_pubkey` the registry stores + verifies against).
+ *   - `nkey` raw 32-byte seed → ed25519 sign of the canonical claim bytes →
+ *     base64 signature (the `signature` the registry verifies).
+ *
+ * Reproduced + pinned by a round-trip test against the registry route.
+ *
+ * ## Safety
+ *
+ *   - **Idempotent / refuse-to-clobber.** Rotating a stack identity is a
+ *     security event (peers cache the old pubkey; a silent swap is rejected
+ *     by the registry). `generateStackIdentity` REFUSES to overwrite an
+ *     existing seed file unless `force: true` is passed. The caller (CLI)
+ *     surfaces `--force` explicitly.
+ *   - **Secrets never logged.** This module returns the seed bytes/string to
+ *     its caller and writes them to disk; it NEVER writes the seed to a log
+ *     sink. Callers log the pubkey/fingerprint only (see `fingerprint`).
+ *   - **No live I/O here.** `buildRegistrationClaim` produces the signed body;
+ *     it does NOT POST it. Posting against a live registry is an ops step,
+ *     gated for the human — `registerStackIdentity` is the thin fetch wrapper
+ *     a caller opts into explicitly.
+ */
+
+import { writeFileSync, existsSync, chmodSync } from "fs";
+import { createUser, fromSeed, type KeyPair } from "nkeys.js";
+
+import { canonicalJSON } from "../common/registry/signing";
+import { nkeyToBase64Pubkey } from "./verify-signed-by-chain";
+
+// =============================================================================
+// Types
+// =============================================================================
+
+/**
+ * A freshly generated (or loaded) stack signing identity. The seed material
+ * is carried in-memory so the caller can write it AND derive the
+ * registration signature from the same key — NEVER log `seed`.
+ */
+export interface StackIdentityMaterial {
+  /** NATS NKey public key (`U…`, 56-char base32) for `stack.nkey_pub`. */
+  readonly nkeyPub: string;
+  /**
+   * Base64 raw 32-byte ed25519 pubkey — the `principal_pubkey` the registry
+   * stores and verifies the registration signature against. Equals
+   * `nkeyToBase64Pubkey(nkeyPub)`.
+   */
+  readonly pubkeyB64: string;
+  /**
+   * The NKey seed string (`SU…`). SECRET — written to the seed file, never
+   * logged. Present so the caller can sign the registration claim with the
+   * SAME key (proof-of-possession) without a second on-disk read.
+   */
+  readonly seed: string;
+  /**
+   * Short, log-safe fingerprint of the public key (first 12 base64 chars of
+   * `pubkeyB64`). Use this in log lines INSTEAD of any secret material.
+   */
+  readonly fingerprint: string;
+}
+
+/** A registration claim + detached signature, ready to POST to the registry. */
+export interface SignedRegistrationBody {
+  readonly claim: RegistrationClaimShape;
+  /** Base64 ed25519 signature over `canonicalJSON(claim)`. */
+  readonly signature: string;
+}
+
+/**
+ * Mirror of the network-registry `RegistrationClaim` wire shape
+ * (`src/services/network-registry/src/types.ts`). Reproduced rather than
+ * imported because the registry is a separately-bundled CF Worker excluded
+ * from the root tsconfig. MUST stay field-compatible — pinned by the
+ * round-trip test against the live route.
+ */
+export interface RegistrationClaimShape {
+  principal_id: string;
+  principal_pubkey: string;
+  stacks: { stack_id: string; display_name?: string; metadata?: Record<string, string> }[];
+  capabilities: { id: string; description?: string; networks?: string[] }[];
+  issued_at: string;
+  nonce: string;
+}
+
+// =============================================================================
+// PKCS#8 bridge — NKey raw seed → WebCrypto Ed25519 signer
+// =============================================================================
+
+/**
+ * RFC 8410 PKCS#8 prefix for an Ed25519 private key carrying a raw 32-byte
+ * seed. WebCrypto's `importKey("pkcs8", …)` is the portable path (Workers /
+ * Bun / Node) to sign with the same ed25519 key the NKey wraps. The 32 seed
+ * bytes are appended after this fixed 16-byte header.
+ */
+const PKCS8_ED25519_PREFIX = Uint8Array.from([
+  0x30, 0x2e, 0x02, 0x01, 0x00, 0x30, 0x05, 0x06, 0x03, 0x2b, 0x65, 0x70, 0x04,
+  0x22, 0x04, 0x20,
+]);
+
+/**
+ * Wrap a raw 32-byte ed25519 seed in PKCS#8 so WebCrypto can import it as an
+ * Ed25519 signing key. The resulting signature is byte-identical (and
+ * cross-verifiable) with the NKey's own `sign()` — confirmed by the bridge
+ * test — so registry proof-of-possession and bus signing share one key.
+ */
+function rawSeedToPkcs8(rawSeed: Uint8Array): Uint8Array {
+  if (rawSeed.length !== 32) {
+    throw new Error(
+      `stack-provisioning: expected 32-byte ed25519 seed, got ${rawSeed.length.toString()}`,
+    );
+  }
+  const out = new Uint8Array(PKCS8_ED25519_PREFIX.length + 32);
+  out.set(PKCS8_ED25519_PREFIX, 0);
+  out.set(rawSeed, PKCS8_ED25519_PREFIX.length);
+  return out;
+}
+
+/** Read the 32-byte raw ed25519 seed off an nkeys.js KeyPair. */
+function rawSeedOf(kp: KeyPair): Uint8Array {
+  return (kp as unknown as { getRawSeed(): Uint8Array }).getRawSeed();
+}
+
+/** Standard-base64 encode (NOT url-safe — matches the registry's alphabet). */
+function bytesToBase64(bytes: Uint8Array): string {
+  let bin = "";
+  for (const b of bytes) bin += String.fromCharCode(b);
+  return btoa(bin);
+}
+
+/**
+ * Sign `message` with the ed25519 key wrapped by `kp`, via WebCrypto. Returns
+ * a base64 raw 64-byte signature — the shape the registry's `verifyEd25519`
+ * consumes.
+ */
+async function signWithNKey(kp: KeyPair, message: Uint8Array): Promise<string> {
+  const pkcs8 = rawSeedToPkcs8(rawSeedOf(kp));
+  const key = await crypto.subtle.importKey(
+    "pkcs8",
+    pkcs8 as BufferSource,
+    { name: "Ed25519" },
+    false,
+    ["sign"],
+  );
+  const sig = await crypto.subtle.sign({ name: "Ed25519" }, key, message as BufferSource);
+  return bytesToBase64(new Uint8Array(sig));
+}
+
+// =============================================================================
+// Identity generation + seed-file write
+// =============================================================================
+
+/** Derive the log-safe fingerprint (never the seed) from a base64 pubkey. */
+export function fingerprintOf(pubkeyB64: string): string {
+  return pubkeyB64.slice(0, 12);
+}
+
+/**
+ * Build {@link StackIdentityMaterial} from an existing NKey KeyPair. Shared
+ * by `generateStackIdentity` (fresh keypair) and `loadStackIdentityMaterial`
+ * (re-derive from an on-disk seed for re-registration without rotation).
+ *
+ * @throws if the NKey pub cannot be decoded to a base64 ed25519 pubkey — a
+ *   malformed keypair must fail loudly here, not silently produce a claim the
+ *   registry would reject.
+ */
+function materialFromKeyPair(kp: KeyPair): StackIdentityMaterial {
+  const nkeyPub = kp.getPublicKey();
+  const pubkeyB64 = nkeyToBase64Pubkey(nkeyPub);
+  if (pubkeyB64 === undefined) {
+    throw new Error(
+      `stack-provisioning: could not decode NKey public key ${nkeyPub.slice(0, 8)}… ` +
+        `to a base64 ed25519 pubkey — keypair is malformed`,
+    );
+  }
+  const seed = new TextDecoder().decode(kp.getSeed());
+  return { nkeyPub, pubkeyB64, seed, fingerprint: fingerprintOf(pubkeyB64) };
+}
+
+export interface GenerateStackIdentityOptions {
+  /**
+   * Absolute (tilde already expanded) path the seed is written to. Should
+   * match `cortex.yaml stack.nkey_seed_path`.
+   */
+  readonly seedPath: string;
+  /**
+   * Overwrite an existing seed file. Default `false` — rotating a stack
+   * identity is a security event (peers cache the old key; the registry
+   * rejects a silent swap), so the default REFUSES to clobber.
+   */
+  readonly force?: boolean;
+  /**
+   * Seam for tests — inject a fixed KeyPair instead of `createUser()`.
+   * Production callers omit this.
+   * @internal
+   */
+  readonly keyPair?: KeyPair;
+}
+
+/**
+ * Generate a fresh stack signing identity and write its seed to `seedPath`
+ * with mode `600`. Returns the public material (incl. the in-memory seed so
+ * the caller can sign a registration claim with the same key).
+ *
+ * **Refuses to clobber** an existing seed unless `force: true` — see the
+ * rotation rationale above. On `force`, the existing file is overwritten and
+ * the OLD identity is silently superseded; the caller MUST treat this as a
+ * rotation (re-register the new pubkey, update `stack.nkey_pub`).
+ *
+ * @throws if `seedPath` exists and `force` is not set.
+ */
+export function generateStackIdentity(
+  opts: GenerateStackIdentityOptions,
+): StackIdentityMaterial {
+  const { seedPath, force = false } = opts;
+
+  if (existsSync(seedPath) && !force) {
+    throw new Error(
+      `stack-provisioning: refusing to overwrite existing seed at ${seedPath} — ` +
+        `rotating a stack identity is a security event (peers cache the old pubkey; ` +
+        `the registry rejects a silent key swap). Pass force to rotate deliberately.`,
+    );
+  }
+
+  const kp = opts.keyPair ?? createUser();
+  const material = materialFromKeyPair(kp);
+
+  // Write the seed, THEN chmod 600. We write with mode 0o600 up front so the
+  // file is never momentarily group/world-readable, then assert via chmod for
+  // platforms where the umask widened the create mode. The trailing newline
+  // matches `nsc generate nkey` output; `loadStackSigningKey` trims it.
+  writeFileSync(seedPath, material.seed + "\n", { mode: 0o600 });
+  // Defensive: an inherited umask can clear bits from the create-mode on some
+  // platforms, so re-assert 600 explicitly. No-op on POSIX where the create
+  // mode already took; harmless on win32 (ACL-governed).
+  if (process.platform !== "win32") {
+    chmodSync(seedPath, 0o600);
+  }
+
+  return material;
+}
+
+/**
+ * Re-derive {@link StackIdentityMaterial} from an existing on-disk seed,
+ * WITHOUT rotating. Use this to (re-)register an already-provisioned stack's
+ * pubkey — the common case after `arc upgrade` provisions a seed but the
+ * registry entry is missing. Goes through `loadStackSigningKey`'s chmod-600
+ * gate via `fromSeed` after the caller has validated the path.
+ *
+ * NOTE: this does NOT re-run `enforceChmod600` (the caller — typically the CLI
+ * — does, sharing the `loadStackSigningKey` discipline). It only parses the
+ * trimmed seed string into a KeyPair and derives the public material.
+ *
+ * @throws if the seed is not a valid `SU…` user-class NKey seed.
+ */
+export function materialFromSeedString(seed: string): StackIdentityMaterial {
+  const trimmed = seed.trim();
+  if (!trimmed.startsWith("SU")) {
+    throw new Error(
+      `stack-provisioning: expected a user-class NKey seed (SU…), got ${trimmed.slice(0, 2)}…`,
+    );
+  }
+  let kp: KeyPair;
+  try {
+    kp = fromSeed(new TextEncoder().encode(trimmed));
+  } catch (err) {
+    throw new Error(
+      `stack-provisioning: failed to parse seed: ${err instanceof Error ? err.message : String(err)}`,
+      { cause: err },
+    );
+  }
+  return materialFromKeyPair(kp);
+}
+
+// =============================================================================
+// Registration claim (proof-of-possession)
+// =============================================================================
+
+export interface BuildRegistrationClaimOptions {
+  /** The principal this stack belongs to (`{principal_id}`). */
+  readonly principalId: string;
+  /** The stack identity material (carries the seed to sign with). */
+  readonly material: StackIdentityMaterial;
+  /**
+   * The stack ids to register. Each MUST be `{principalId}/{slug}` — the
+   * registry rejects a prefix mismatch (forged-attribution guard).
+   */
+  readonly stacks: { stack_id: string; display_name?: string }[];
+  /** Capabilities to advertise (optional). */
+  readonly capabilities?: { id: string; description?: string; networks?: string[] }[];
+  /**
+   * Override the issued-at timestamp (tests / replay-window checks). Defaults
+   * to `now`. The registry enforces a ±5-minute clock-skew window.
+   * @internal
+   */
+  readonly issuedAt?: string;
+  /**
+   * Override the nonce (tests). Defaults to a fresh 16-byte random hex.
+   * @internal
+   */
+  readonly nonce?: string;
+}
+
+/**
+ * Build a signed registration body proving possession of the stack signing
+ * key. The claim is signed with the SAME ed25519 key whose pubkey it
+ * declares, so the registry's `verifyEd25519(claim.principal_pubkey, …)`
+ * succeeds and a tampered claim (or a claim signed by a different key) is
+ * rejected.
+ *
+ * Does NOT POST — returns the body for the caller to send (or print). Posting
+ * against a live registry is a gated ops step.
+ */
+export async function buildRegistrationClaim(
+  opts: BuildRegistrationClaimOptions,
+): Promise<SignedRegistrationBody> {
+  const claim: RegistrationClaimShape = {
+    principal_id: opts.principalId,
+    principal_pubkey: opts.material.pubkeyB64,
+    stacks: opts.stacks,
+    capabilities: opts.capabilities ?? [],
+    issued_at: opts.issuedAt ?? new Date().toISOString(),
+    nonce: opts.nonce ?? randomNonce(),
+  };
+
+  // Re-derive the KeyPair from the in-memory seed to sign. We sign over the
+  // SAME canonical-JSON the registry route reconstructs and verifies.
+  const kp = fromSeed(new TextEncoder().encode(opts.material.seed.trim()));
+  const message = new TextEncoder().encode(canonicalJSON(claim));
+  const signature = await signWithNKey(kp, message);
+
+  return { claim, signature };
+}
+
+/** Fresh 16-byte random nonce, lowercase hex — matches the registry's window. */
+export function randomNonce(): string {
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  let out = "";
+  for (const b of bytes) out += b.toString(16).padStart(2, "0");
+  return out;
+}
+
+// =============================================================================
+// Optional live registration (gated — caller opts in)
+// =============================================================================
+
+export interface RegisterStackIdentityOptions {
+  /** Registry base URL (no trailing slash needed). */
+  readonly registryUrl: string;
+  /** The principal id (becomes the `:principal_id` path segment). */
+  readonly principalId: string;
+  /** The signed body from {@link buildRegistrationClaim}. */
+  readonly body: SignedRegistrationBody;
+  /** Injected fetch (tests). Defaults to global fetch. @internal */
+  readonly fetchImpl?: typeof globalThis.fetch;
+  /** Request timeout (ms). Default 10s. */
+  readonly timeoutMs?: number;
+}
+
+export interface RegisterStackIdentityResult {
+  readonly ok: boolean;
+  readonly status: number;
+  /** Parsed JSON response body (registry assertion on success; error on fail). */
+  readonly response: unknown;
+}
+
+/**
+ * POST the signed registration to `POST /principals/{principalId}/register`.
+ *
+ * This is the ONLY function in this module that performs network I/O, and it
+ * is NEVER called at boot or from the generate path — a caller (CLI with an
+ * explicit `--register` flag, or an ops script) opts into it deliberately, so
+ * provisioning never silently mutates a live registry as a side effect of
+ * key generation.
+ */
+export async function registerStackIdentity(
+  opts: RegisterStackIdentityOptions,
+): Promise<RegisterStackIdentityResult> {
+  const fetchImpl = opts.fetchImpl ?? globalThis.fetch.bind(globalThis);
+  const url = `${opts.registryUrl.replace(/\/+$/, "")}/principals/${encodeURIComponent(opts.principalId)}/register`;
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => {
+    controller.abort();
+  }, opts.timeoutMs ?? 10_000);
+  try {
+    const res = await fetchImpl(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(opts.body),
+      signal: controller.signal,
+    });
+    let response: unknown;
+    try {
+      response = await res.json();
+    } catch (err) {
+      // Non-JSON body (e.g. a proxy error page). Surface the parse failure
+      // as the response rather than throwing — the caller decides.
+      response = {
+        error: "non_json_response",
+        detail: err instanceof Error ? err.message : String(err),
+      };
+    }
+    return { ok: res.ok, status: res.status, response };
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/src/bus/verifier-self-check.ts
+++ b/src/bus/verifier-self-check.ts
@@ -154,3 +154,135 @@ export async function runVerifierSelfCheck(
     return { ok: false, detail: `threw: ${detail}` };
   }
 }
+
+// =============================================================================
+// TC-1b (#632) — posture-aware boot gate
+// =============================================================================
+
+/**
+ * The three settable `security.signing` postures, re-exported here so the
+ * boot gate can be unit-tested without importing the full cortex-config
+ * schema graph.
+ */
+export type SigningPosture = "off" | "permissive" | "enforce";
+
+/**
+ * Inputs to the posture-aware boot self-check. A subset of the boot context
+ * in `src/cortex.ts`: the signing posture plus the (possibly-absent) stack
+ * identity captured at signer attach. When `identity` is `undefined` the
+ * stack has NO usable signing identity wired (no seed, or seed load failed).
+ */
+export interface BootVerifierSelfCheckOpts {
+  /** Resolved `config.security.signing`. */
+  posture: SigningPosture;
+  /**
+   * The stack identity captured at signer attach, or `undefined` when no
+   * signing identity is wired. Under `enforce` a `undefined` identity is a
+   * fatal misconfiguration (the boot gate throws); under `off`/`permissive`
+   * it is the expected unsigned-dev shape (the gate no-ops).
+   */
+  identity:
+    | {
+        /** Stack signing DID — `signer.principal`. */
+        stackIdentity: string;
+        /** Stack NKey public key. */
+        stackNKeyPub: string;
+        /** Raw 32-byte ed25519 seed bytes — `signer.rawSeedBytes`. */
+        stackSeedBytes: Uint8Array;
+      }
+    | undefined;
+  /** Trust resolver wired into the production listeners. */
+  resolver: TrustResolver;
+  /** Receiving agent id — same as production listeners. */
+  receivingAgentId: string;
+  /** Principal id — same as production listeners. */
+  principalId: string;
+  /** Optional logger seams (tests; default console / stderr). */
+  log?: (line: string) => void;
+  err?: (line: string) => void;
+}
+
+/**
+ * TC-1b boot gate around {@link runVerifierSelfCheck}, posture-aware per
+ * `docs/design-trust-confidentiality.md` §4 Phase 1.1b
+ * ("`verifier-self-check` passes on every stack at boot").
+ *
+ * Behaviour by posture:
+ *
+ *   - **`enforce`** — a stack serving SIGNED traffic MUST have a valid,
+ *     self-verifiable signing identity. If `identity` is missing (no seed /
+ *     load failed) OR the self-check round-trip fails, this **throws** so the
+ *     boot path aborts rather than silently serving traffic peers will reject.
+ *     A passing self-check returns normally.
+ *   - **`permissive`** — run the self-check when an identity is wired and WARN
+ *     (do not throw) on failure; no-op when no identity is wired. This is the
+ *     shadow rung: prove signing against live boot before gating.
+ *   - **`off`** — advisory. Run the self-check only when an identity happens
+ *     to be wired (observability), WARN on failure, never throw; no-op when
+ *     unsigned (today's dev default).
+ *
+ * Throwing (only under `enforce`) is the fail-fast contract: the caller does
+ * NOT wrap this in a swallow — a thrown error propagates to the CLI exit so
+ * launchd / the principal sees the refusal.
+ */
+export async function bootVerifierSelfCheck(
+  opts: BootVerifierSelfCheckOpts,
+): Promise<void> {
+  const err = opts.err ?? ((line: string) => {
+    process.stderr.write(line + "\n");
+  });
+
+  // No signing identity wired.
+  if (opts.identity === undefined) {
+    if (opts.posture === "enforce") {
+      // Fail fast: enforce with no signing identity means every outbound
+      // envelope would be unsigned and every inbound empty-chain rejected —
+      // the stack cannot serve. Refuse to boot with an actionable message.
+      throw new Error(
+        "verifier-self-check: REFUSING TO BOOT — security.signing=enforce but no " +
+          "stack signing identity is wired. Provision one with " +
+          "`cortex provision-stack` (writes stack.nkey_seed_path chmod 600 + " +
+          "registers the pubkey), set stack.nkey_seed_path in cortex.yaml, then " +
+          "restart. See docs/design-trust-confidentiality.md §Phase 1.1b.",
+      );
+    }
+    // off / permissive with no identity — the expected unsigned-dev shape.
+    // Nothing to check; stay silent (the unsigned-publish WARNING already
+    // fired upstream at signer-attach).
+    return;
+  }
+
+  const result = await runVerifierSelfCheck({
+    stackIdentity: opts.identity.stackIdentity,
+    stackNKeyPub: opts.identity.stackNKeyPub,
+    stackSeedBytes: opts.identity.stackSeedBytes,
+    resolver: opts.resolver,
+    receivingAgentId: opts.receivingAgentId,
+    principalId: opts.principalId,
+    ...(opts.log !== undefined && { log: opts.log }),
+    ...(opts.err !== undefined && { err: opts.err }),
+  });
+
+  if (result.ok) return;
+
+  if (opts.posture === "enforce") {
+    // Fail fast: the stack has an identity but it does not round-trip through
+    // the verifier — serving SIGNED traffic with it would silently drop every
+    // adapter-originated dispatch. Refuse to boot.
+    throw new Error(
+      `verifier-self-check: REFUSING TO BOOT — security.signing=enforce and the ` +
+        `stack signing identity (${opts.identity.stackIdentity}) failed the boot ` +
+        `self-check: ${result.detail}. The verifier would reject this stack's own ` +
+        `signatures; fix the stack.nkey_pub / registration / signing-key consistency ` +
+        `before serving signed traffic.`,
+    );
+  }
+
+  // off / permissive — advisory. runVerifierSelfCheck already logged the
+  // detailed FAILED line via `err`; add a posture note so the principal knows
+  // the boot deliberately continued under the non-enforcing posture.
+  err(
+    `verifier-self-check: continuing boot under signing=${opts.posture} despite ` +
+      `failed self-check (advisory; set signing=enforce to fail fast).`,
+  );
+}

--- a/src/cli/cortex/commands/__tests__/provision-stack.test.ts
+++ b/src/cli/cortex/commands/__tests__/provision-stack.test.ts
@@ -1,0 +1,227 @@
+/**
+ * TC-1b (#632) — `cortex provision-stack` CLI tests.
+ *
+ * Coverage:
+ *   1. generate writes a seed (mode 600) + prints pubkey, NOT the seed.
+ *   2. generate --json envelope carries pubkey + fingerprint, no seed.
+ *   3. generate refuses to clobber without --force (exit 1); --force succeeds.
+ *   4. generate rejects a bad principal-id (exit 2).
+ *   5. claim prints a signed body for an existing seed (no network).
+ *   6. register POSTs the proof-of-possession claim through an injected
+ *      registry route and reports success; a rejecting route → exit 1.
+ *   7. no seed material in stdout/stderr on any path.
+ */
+
+import { describe, test, expect, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, statSync, readFileSync, existsSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+import { dispatchProvisionStack } from "../provision-stack";
+
+// Real registry route for the register round-trip.
+import registryApp from "../../../../services/network-registry/src/index";
+import type { Env } from "../../../../services/network-registry/src/index";
+import {
+  makeRegistryKey,
+  resetStores,
+} from "../../../../services/network-registry/__tests__/helpers";
+
+const tmpDirs: string[] = [];
+function freshDir(): string {
+  const d = mkdtempSync(join(tmpdir(), "tc1b-cli-"));
+  tmpDirs.push(d);
+  return d;
+}
+afterEach(() => {
+  while (tmpDirs.length > 0) rmSync(tmpDirs.pop()!, { recursive: true, force: true });
+  resetStores();
+});
+
+/** Read the seed off disk so we can assert it never appears in CLI output. */
+function seedOnDisk(path: string): string {
+  return readFileSync(path, "utf-8").trim();
+}
+
+describe("cortex provision-stack generate (TC-1b #632)", () => {
+  test("[1] writes seed chmod 600, prints pubkey (not the seed)", async () => {
+    const seedPath = join(freshDir(), "stack.nk");
+    const res = await dispatchProvisionStack([
+      "generate",
+      "andreas",
+      "--seed-path",
+      seedPath,
+    ]);
+    expect(res.exitCode).toBe(0);
+    expect(existsSync(seedPath)).toBe(true);
+    if (process.platform !== "win32") {
+      expect(statSync(seedPath).mode & 0o777).toBe(0o600);
+    }
+    // stdout shows the NKey pub + the cortex.yaml block.
+    expect(res.stdout).toContain("nkey_pub:");
+    expect(res.stdout).toContain("andreas/default");
+    // SECRET: the seed must NOT be in any output.
+    const seed = seedOnDisk(seedPath);
+    expect(res.stdout).not.toContain(seed);
+    expect(res.stderr).not.toContain(seed);
+  });
+
+  test("[2] --json envelope carries pubkey + fingerprint, no seed", async () => {
+    const seedPath = join(freshDir(), "stack.nk");
+    const res = await dispatchProvisionStack([
+      "generate",
+      "andreas",
+      "--seed-path",
+      seedPath,
+      "--json",
+    ]);
+    expect(res.exitCode).toBe(0);
+    const env = JSON.parse(res.stdout) as {
+      status: string;
+      data: Record<string, string>;
+    };
+    expect(env.status).toBe("ok");
+    expect(env.data.nkey_pub).toMatch(/^U/);
+    const pub = env.data.pubkey_b64 ?? "";
+    expect(pub.length).toBe(44);
+    expect(env.data.fingerprint).toBe(pub.slice(0, 12));
+    expect(env.data.seed_mode).toBe("600");
+    // No seed field anywhere in the envelope.
+    expect(JSON.stringify(env)).not.toContain(seedOnDisk(seedPath));
+  });
+
+  test("[3] refuses to clobber without --force (exit 1); --force succeeds", async () => {
+    const seedPath = join(freshDir(), "stack.nk");
+    await dispatchProvisionStack(["generate", "andreas", "--seed-path", seedPath]);
+    const first = seedOnDisk(seedPath);
+
+    const refuse = await dispatchProvisionStack(["generate", "andreas", "--seed-path", seedPath]);
+    expect(refuse.exitCode).toBe(1);
+    expect(refuse.stderr).toMatch(/refusing to overwrite/i);
+    expect(seedOnDisk(seedPath)).toBe(first); // unchanged
+
+    const forced = await dispatchProvisionStack([
+      "generate",
+      "andreas",
+      "--seed-path",
+      seedPath,
+      "--force",
+    ]);
+    expect(forced.exitCode).toBe(0);
+    expect(seedOnDisk(seedPath)).not.toBe(first); // rotated
+  });
+
+  test("[4] rejects a bad principal-id (exit 2)", async () => {
+    const seedPath = join(freshDir(), "stack.nk");
+    const res = await dispatchProvisionStack([
+      "generate",
+      "BAD_CAPS",
+      "--seed-path",
+      seedPath,
+    ]);
+    expect(res.exitCode).toBe(2);
+    expect(existsSync(seedPath)).toBe(false);
+  });
+
+  test("[4b] rejects --stack-id whose prefix mismatches principal (exit 2)", async () => {
+    const seedPath = join(freshDir(), "stack.nk");
+    const res = await dispatchProvisionStack([
+      "generate",
+      "andreas",
+      "--seed-path",
+      seedPath,
+      "--stack-id",
+      "someoneelse/research",
+    ]);
+    expect(res.exitCode).toBe(2);
+  });
+});
+
+describe("cortex provision-stack claim (TC-1b #632)", () => {
+  test("[5] prints a signed body for an existing seed (no network)", async () => {
+    const seedPath = join(freshDir(), "stack.nk");
+    await dispatchProvisionStack(["generate", "andreas", "--seed-path", seedPath]);
+
+    const res = await dispatchProvisionStack(["claim", "andreas", "--seed-path", seedPath]);
+    expect(res.exitCode).toBe(0);
+    const body = JSON.parse(res.stdout) as {
+      claim: { principal_id: string; principal_pubkey: string; stacks: { stack_id: string }[] };
+      signature: string;
+    };
+    expect(body.claim.principal_id).toBe("andreas");
+    expect(body.claim.stacks[0]!.stack_id).toBe("andreas/default");
+    expect(body.signature.length).toBeGreaterThan(0);
+    // The printed body is public — but the raw seed must still not appear.
+    expect(res.stdout).not.toContain(seedOnDisk(seedPath));
+  });
+});
+
+describe("cortex provision-stack register (TC-1b #632)", () => {
+  async function configuredEnv(): Promise<Env> {
+    resetStores();
+    const reg = await makeRegistryKey();
+    return {
+      REGISTRY_SIGNING_KEY: reg.signingKey,
+      REGISTRY_PUBLIC_KEY: reg.publicKey,
+      ENVIRONMENT: "test",
+    };
+  }
+
+  test("[6] register POSTs proof-of-possession and reports success", async () => {
+    const env = await configuredEnv();
+    const seedPath = join(freshDir(), "stack.nk");
+    await dispatchProvisionStack(["generate", "andreas", "--seed-path", seedPath]);
+
+    // Patch global fetch to route to the in-memory registry app.
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = ((input: Request | string | URL, init?: RequestInit) => {
+      const req = input instanceof Request ? input : new Request(input, init);
+      return registryApp.fetch(req, env);
+    }) as typeof globalThis.fetch;
+    try {
+      const res = await dispatchProvisionStack([
+        "register",
+        "andreas",
+        "--seed-path",
+        seedPath,
+        "--registry-url",
+        "http://registry.test",
+        "--json",
+      ]);
+      expect(res.exitCode).toBe(0);
+      const out = JSON.parse(res.stdout) as { status: string; data: Record<string, string> };
+      expect(out.status).toBe("ok");
+      expect(out.data.registered).toContain("HTTP 201");
+      expect(res.stdout).not.toContain(seedOnDisk(seedPath));
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+  });
+
+  test("[6b] register surfaces a registry rejection as exit 1", async () => {
+    // Unconfigured registry → 503 registry_unconfigured.
+    const env: Env = { ENVIRONMENT: "test" };
+    const seedPath = join(freshDir(), "stack.nk");
+    await dispatchProvisionStack(["generate", "andreas", "--seed-path", seedPath]);
+
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = ((input: Request | string | URL, init?: RequestInit) => {
+      const req = input instanceof Request ? input : new Request(input, init);
+      return registryApp.fetch(req, env);
+    }) as typeof globalThis.fetch;
+    try {
+      const res = await dispatchProvisionStack([
+        "register",
+        "andreas",
+        "--seed-path",
+        seedPath,
+        "--registry-url",
+        "http://registry.test",
+      ]);
+      expect(res.exitCode).toBe(1);
+      expect(res.stderr).toMatch(/registry rejected/i);
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+  });
+});

--- a/src/cli/cortex/commands/provision-stack.ts
+++ b/src/cli/cortex/commands/provision-stack.ts
@@ -1,0 +1,453 @@
+#!/usr/bin/env bun
+/**
+ * `cortex provision-stack <subcommand>` — TC-1b (#632) stack-identity
+ * provisioning tooling.
+ *
+ * Makes SIGNED operation real: generate a stack signing identity (ed25519
+ * NKey seed), write it chmod 600 to `stack.nkey_seed_path`, and register its
+ * pubkey with the network-registry through the proof-of-possession
+ * `POST /principals/{id}/register` contract. Without this, `signing: enforce`
+ * has no identity to verify and the boot `verifier-self-check` cannot pass.
+ *
+ * Design: `docs/design-trust-confidentiality.md` §4 Phase 1.1b.
+ *
+ * Subcommands:
+ *   generate <principal-id> --seed-path <path> [--stack-id <id>] [--force]
+ *       Generate a fresh NKey signing identity, write the seed chmod 600
+ *       (REFUSES to clobber an existing seed without --force — rotation is a
+ *       security event), and print the NKey pubkey + base64 pubkey +
+ *       fingerprint. Add `--register --registry-url <url>` to ALSO build and
+ *       POST a signed registration claim (proof-of-possession with the same
+ *       key). Without --register it only generates locally.
+ *
+ *   claim <principal-id> --seed-path <path> [--stack-id <id>]
+ *       Build + print a signed registration body for an EXISTING seed, without
+ *       posting it. For air-gapped / review-before-post workflows.
+ *
+ *   register <principal-id> --seed-path <path> --registry-url <url> [--stack-id <id>]
+ *       Build the signed claim from an existing seed and POST it to the
+ *       registry. The ONLY subcommand that performs network I/O.
+ *
+ * Secrets discipline: the NKey SEED is written to disk + held in memory to
+ * sign the claim; it is NEVER printed or logged. Output carries the pubkey +
+ * a short fingerprint only.
+ *
+ * Exit codes:
+ *   0  success
+ *   1  operational failure (clobber refused, seed load error, registry reject)
+ *   2  usage error (bad flag, missing positional / required flag)
+ */
+
+import { existsSync } from "fs";
+import { readFile } from "fs/promises";
+
+import { expandTilde } from "../../../common/config/loader";
+import { enforceChmod600 } from "../../../common/config/file-permissions";
+import {
+  generateStackIdentity,
+  materialFromSeedString,
+  buildRegistrationClaim,
+  registerStackIdentity,
+  type StackIdentityMaterial,
+  type SignedRegistrationBody,
+} from "../../../bus/stack-provisioning";
+
+import { CliArgsError } from "./_shared/arg-error";
+import { envelopeError, envelopeOk, renderJson } from "./_shared/envelope";
+import { type ExitResult } from "./_shared/exit-result";
+import { parseSubcommandArgs, type SubcommandSpec } from "./_shared/parser";
+
+export { type ExitResult } from "./_shared/exit-result";
+
+// =============================================================================
+// Grammar
+// =============================================================================
+
+type ProvisionSubcommand = "generate" | "claim" | "register";
+
+const PRINCIPAL_ID_RE = /^[a-z][a-z0-9-]*$/;
+const STACK_ID_RE = /^[a-z][a-z0-9_-]*\/[a-z][a-z0-9_-]*$/;
+
+const SPEC: SubcommandSpec<ProvisionSubcommand> = {
+  cliName: "provision-stack",
+  subcommands: {
+    generate: {
+      positionals: ["principal-id"],
+      flags: {
+        "--seed-path": "value",
+        "--stack-id": "value",
+        "--force": "bool",
+        "--register": "bool",
+        "--registry-url": "value",
+      },
+    },
+    claim: {
+      positionals: ["principal-id"],
+      flags: { "--seed-path": "value", "--stack-id": "value" },
+    },
+    register: {
+      positionals: ["principal-id"],
+      flags: {
+        "--seed-path": "value",
+        "--stack-id": "value",
+        "--registry-url": "value",
+      },
+    },
+  },
+  universal: { "--json": "bool", "--help": "bool", "-h": "bool" },
+};
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+/** Resolve the stack id — explicit `--stack-id` or `{principal}/default`. */
+function resolveStackId(
+  principalId: string,
+  stackIdFlag: string | true | undefined,
+): { ok: true; stackId: string } | { ok: false; reason: string } {
+  if (stackIdFlag === undefined) {
+    return { ok: true, stackId: `${principalId}/default` };
+  }
+  if (stackIdFlag === true || typeof stackIdFlag !== "string") {
+    return { ok: false, reason: "--stack-id requires a value" };
+  }
+  if (!STACK_ID_RE.test(stackIdFlag)) {
+    return {
+      ok: false,
+      reason: `--stack-id "${stackIdFlag}" must be {principal_id}/{stack_id} (lowercase, letter-prefixed)`,
+    };
+  }
+  const prefix = stackIdFlag.split("/")[0];
+  if (prefix !== principalId) {
+    return {
+      ok: false,
+      reason: `--stack-id prefix "${prefix ?? ""}" must match principal-id "${principalId}"`,
+    };
+  }
+  return { ok: true, stackId: stackIdFlag };
+}
+
+/** Pull a required value-flag; returns the string or an error result. */
+function requireValueFlag(
+  flags: Record<string, string | true>,
+  name: string,
+): { ok: true; value: string } | { ok: false; reason: string } {
+  const v = flags[name];
+  if (v === undefined) return { ok: false, reason: `${name} is required` };
+  if (v === true) return { ok: false, reason: `${name} requires a value` };
+  return { ok: true, value: v };
+}
+
+/** Load + re-derive material from an existing seed file (chmod-600 gated). */
+async function materialFromSeedFile(
+  seedPath: string,
+): Promise<{ ok: true; material: StackIdentityMaterial } | { ok: false; reason: string }> {
+  const expanded = expandTilde(seedPath);
+  if (!existsSync(expanded)) {
+    return { ok: false, reason: `seed file not found at ${expanded}` };
+  }
+  try {
+    // Same chmod-600 discipline as loadStackSigningKey — refuse to read a
+    // group/world-readable secret.
+    enforceChmod600(expanded);
+  } catch (err) {
+    return { ok: false, reason: err instanceof Error ? err.message : String(err) };
+  }
+  let seed: string;
+  try {
+    seed = await readFile(expanded, "utf-8");
+  } catch (err) {
+    return { ok: false, reason: `failed to read seed: ${err instanceof Error ? err.message : String(err)}` };
+  }
+  try {
+    return { ok: true, material: materialFromSeedString(seed) };
+  } catch (err) {
+    return { ok: false, reason: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+// =============================================================================
+// Subcommand handlers
+// =============================================================================
+
+interface HandlerCtx {
+  principalId: string;
+  flags: Record<string, string | true>;
+  json: boolean;
+}
+
+async function runGenerate(ctx: HandlerCtx): Promise<ExitResult> {
+  const seedPathFlag = requireValueFlag(ctx.flags, "--seed-path");
+  if (!seedPathFlag.ok) return usageError("generate", seedPathFlag.reason, ctx.json);
+  const stackIdRes = resolveStackId(ctx.principalId, ctx.flags["--stack-id"]);
+  if (!stackIdRes.ok) return usageError("generate", stackIdRes.reason, ctx.json);
+
+  const seedPath = expandTilde(seedPathFlag.value);
+  const force = ctx.flags["--force"] === true;
+
+  let material: StackIdentityMaterial;
+  try {
+    material = generateStackIdentity({ seedPath, force });
+  } catch (err) {
+    return opError(err instanceof Error ? err.message : String(err), ctx.json, {
+      seed_path: seedPath,
+    });
+  }
+
+  // Optional registration (opt-in — never silent).
+  let registerNote: string | undefined;
+  if (ctx.flags["--register"] === true) {
+    const urlRes = requireValueFlag(ctx.flags, "--registry-url");
+    if (!urlRes.ok) {
+      return usageError("generate", `--register also needs ${urlRes.reason}`, ctx.json);
+    }
+    const reg = await doRegister(ctx.principalId, material, stackIdRes.stackId, urlRes.value);
+    if (!reg.ok) return opError(reg.reason, ctx.json, { fingerprint: material.fingerprint });
+    registerNote = reg.note;
+  }
+
+  // SECRETS: only the pubkey + fingerprint are surfaced; the seed is on disk.
+  const data: Record<string, string> = {
+    principal_id: ctx.principalId,
+    stack_id: stackIdRes.stackId,
+    nkey_pub: material.nkeyPub,
+    pubkey_b64: material.pubkeyB64,
+    fingerprint: material.fingerprint,
+    seed_path: seedPath,
+    seed_mode: "600",
+    ...(registerNote !== undefined && { registered: registerNote }),
+  };
+  if (ctx.json) {
+    return ok(renderJson(envelopeOk([], data)));
+  }
+  const lines = [
+    `cortex provision-stack: generated stack signing identity`,
+    `  principal:    ${ctx.principalId}`,
+    `  stack:        ${stackIdRes.stackId}`,
+    `  nkey_pub:     ${material.nkeyPub}`,
+    `  pubkey (b64): ${material.pubkeyB64}`,
+    `  fingerprint:  ${material.fingerprint}`,
+    `  seed written: ${seedPath} (chmod 600)`,
+    ...(registerNote !== undefined ? [`  registered:   ${registerNote}`] : []),
+    ``,
+    `Next: set in cortex.yaml under stack: —`,
+    `  stack:`,
+    `    id: ${stackIdRes.stackId}`,
+    `    nkey_seed_path: ${seedPath}`,
+    `    nkey_pub: ${material.nkeyPub}`,
+    ...(registerNote === undefined
+      ? [
+          ``,
+          `The pubkey is NOT yet registered. To register (required before`,
+          `signing: enforce), re-run with --register --registry-url <url>,`,
+          `or use \`cortex provision-stack register\`.`,
+        ]
+      : []),
+    ``,
+  ];
+  return ok(lines.join("\n"));
+}
+
+async function runClaim(ctx: HandlerCtx): Promise<ExitResult> {
+  const seedPathFlag = requireValueFlag(ctx.flags, "--seed-path");
+  if (!seedPathFlag.ok) return usageError("claim", seedPathFlag.reason, ctx.json);
+  const stackIdRes = resolveStackId(ctx.principalId, ctx.flags["--stack-id"]);
+  if (!stackIdRes.ok) return usageError("claim", stackIdRes.reason, ctx.json);
+
+  const matRes = await materialFromSeedFile(seedPathFlag.value);
+  if (!matRes.ok) return opError(matRes.reason, ctx.json);
+
+  const body = await buildRegistrationClaim({
+    principalId: ctx.principalId,
+    material: matRes.material,
+    stacks: [{ stack_id: stackIdRes.stackId }],
+  });
+
+  // The body is safe to print — it carries the PUBLIC key + a detached
+  // signature, never the seed.
+  if (ctx.json) {
+    return ok(renderJson(envelopeOk([body as unknown as Record<string, unknown>], {
+      fingerprint: matRes.material.fingerprint,
+    })));
+  }
+  return ok(JSON.stringify(body, null, 2) + "\n");
+}
+
+async function runRegister(ctx: HandlerCtx): Promise<ExitResult> {
+  const seedPathFlag = requireValueFlag(ctx.flags, "--seed-path");
+  if (!seedPathFlag.ok) return usageError("register", seedPathFlag.reason, ctx.json);
+  const urlRes = requireValueFlag(ctx.flags, "--registry-url");
+  if (!urlRes.ok) return usageError("register", urlRes.reason, ctx.json);
+  const stackIdRes = resolveStackId(ctx.principalId, ctx.flags["--stack-id"]);
+  if (!stackIdRes.ok) return usageError("register", stackIdRes.reason, ctx.json);
+
+  const matRes = await materialFromSeedFile(seedPathFlag.value);
+  if (!matRes.ok) return opError(matRes.reason, ctx.json);
+
+  const reg = await doRegister(ctx.principalId, matRes.material, stackIdRes.stackId, urlRes.value);
+  if (!reg.ok) return opError(reg.reason, ctx.json, { fingerprint: matRes.material.fingerprint });
+
+  const data: Record<string, string> = {
+    principal_id: ctx.principalId,
+    stack_id: stackIdRes.stackId,
+    fingerprint: matRes.material.fingerprint,
+    registered: reg.note,
+  };
+  if (ctx.json) return ok(renderJson(envelopeOk([], data)));
+  return ok(
+    `cortex provision-stack: ${reg.note}\n  principal: ${ctx.principalId}\n  stack: ${stackIdRes.stackId}\n  fingerprint: ${matRes.material.fingerprint}\n`,
+  );
+}
+
+/** Shared register flow — build claim + POST. Returns a log-safe note. */
+async function doRegister(
+  principalId: string,
+  material: StackIdentityMaterial,
+  stackId: string,
+  registryUrl: string,
+): Promise<{ ok: true; note: string } | { ok: false; reason: string }> {
+  let body: SignedRegistrationBody;
+  try {
+    body = await buildRegistrationClaim({
+      principalId,
+      material,
+      stacks: [{ stack_id: stackId }],
+    });
+  } catch (err) {
+    return { ok: false, reason: `failed to build registration claim: ${err instanceof Error ? err.message : String(err)}` };
+  }
+
+  let result: Awaited<ReturnType<typeof registerStackIdentity>>;
+  try {
+    result = await registerStackIdentity({ registryUrl, principalId, body });
+  } catch (err) {
+    return { ok: false, reason: `registry POST failed: ${err instanceof Error ? err.message : String(err)}` };
+  }
+  if (!result.ok) {
+    const detail =
+      typeof result.response === "object" && result.response !== null
+        ? JSON.stringify(result.response)
+        : String(result.response);
+    return {
+      ok: false,
+      reason: `registry rejected registration (HTTP ${result.status.toString()}): ${detail}`,
+    };
+  }
+  return { ok: true, note: `registered pubkey ${material.fingerprint}… at ${registryUrl} (HTTP ${result.status.toString()})` };
+}
+
+// =============================================================================
+// Result builders
+// =============================================================================
+
+function ok(stdout: string): ExitResult {
+  return { exitCode: 0, stdout, stderr: "" };
+}
+
+function usageError(sub: string, reason: string, json: boolean): ExitResult {
+  const stderr = json
+    ? renderJson(envelopeError(reason, { subcommand: sub }))
+    : `cortex provision-stack ${sub}: ${reason}\n${topLevelHelp()}`;
+  return { exitCode: 2, stdout: "", stderr };
+}
+
+function opError(reason: string, json: boolean, context?: Record<string, string>): ExitResult {
+  const stderr = json
+    ? renderJson(envelopeError(reason, context))
+    : `cortex provision-stack: ${reason}\n`;
+  return { exitCode: 1, stdout: "", stderr };
+}
+
+// =============================================================================
+// Dispatcher
+// =============================================================================
+
+export async function dispatchProvisionStack(argv: string[]): Promise<ExitResult> {
+  let parsed;
+  try {
+    parsed = parseSubcommandArgs(SPEC, argv);
+  } catch (err) {
+    if (err instanceof CliArgsError) {
+      return { exitCode: 2, stdout: "", stderr: `cortex provision-stack: ${err.message}\n${topLevelHelp()}` };
+    }
+    throw err;
+  }
+
+  const json = parsed.flags["--json"] === true;
+
+  if (parsed.subcommand === "help" || parsed.help) {
+    return { exitCode: 0, stdout: topLevelHelp(), stderr: "" };
+  }
+  if (parsed.subcommand === "unknown") {
+    const msg =
+      parsed.rawSubcommand === ""
+        ? "usage error — no subcommand specified."
+        : `unknown subcommand "${parsed.rawSubcommand}".`;
+    return { exitCode: 2, stdout: "", stderr: `cortex provision-stack: ${msg}\n${topLevelHelp()}` };
+  }
+
+  const principalId = parsed.positionals["principal-id"] ?? "";
+  if (!PRINCIPAL_ID_RE.test(principalId)) {
+    return usageError(
+      parsed.subcommand,
+      `principal-id "${principalId}" must be lowercase alphanumeric + hyphen, letter-prefixed`,
+      json,
+    );
+  }
+
+  const ctx: HandlerCtx = { principalId, flags: parsed.flags, json };
+  switch (parsed.subcommand) {
+    case "generate":
+      return runGenerate(ctx);
+    case "claim":
+      return runClaim(ctx);
+    case "register":
+      return runRegister(ctx);
+  }
+}
+
+// =============================================================================
+// Help
+// =============================================================================
+
+function topLevelHelp(): string {
+  return `cortex provision-stack — stack-identity provisioning (TC-1b, #632)
+
+Usage:
+  cortex provision-stack generate <principal-id> --seed-path <path> [--stack-id <id>] [--force] [--register --registry-url <url>] [--json]
+  cortex provision-stack claim    <principal-id> --seed-path <path> [--stack-id <id>] [--json]
+  cortex provision-stack register <principal-id> --seed-path <path> --registry-url <url> [--stack-id <id>] [--json]
+
+Subcommands:
+  generate   Generate a fresh NKey signing identity; write seed chmod 600
+             (refuses to clobber without --force — rotation is a security
+             event); print the pubkey. Add --register --registry-url to also
+             register the pubkey via proof-of-possession.
+  claim      Print a signed registration body for an existing seed WITHOUT
+             posting (air-gapped / review-before-post).
+  register   Build the claim from an existing seed and POST it to the registry.
+
+Flags:
+  --seed-path <path>     Path to the stack signing seed (matches stack.nkey_seed_path).
+  --stack-id <id>        {principal}/{slug}; defaults to <principal-id>/default.
+  --force                Allow overwriting an existing seed (DELIBERATE rotation).
+  --register             (generate only) also register the pubkey after generating.
+  --registry-url <url>   Network-registry base URL for registration.
+  --json                 Emit a { status, items, data, error } envelope.
+
+Secrets: the NKey SEED is written to disk + held in memory to sign the claim;
+it is NEVER printed or logged. Output carries the pubkey + fingerprint only.
+`;
+}
+
+// =============================================================================
+// Main
+// =============================================================================
+
+if (import.meta.main) {
+  const result = await dispatchProvisionStack(process.argv.slice(2));
+  if (result.stdout) process.stdout.write(result.stdout);
+  if (result.stderr) process.stderr.write(result.stderr);
+  process.exit(result.exitCode);
+}

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -68,7 +68,7 @@ import {
   verifySignedByChain,
   nkeyToBase64Pubkey,
 } from "./bus/verify-signed-by-chain";
-import { runVerifierSelfCheck } from "./bus/verifier-self-check";
+import { bootVerifierSelfCheck } from "./bus/verifier-self-check";
 import { CCSession, type CCSessionOpts } from "./runner/cc-session";
 import { makePiDevPipelineRunner } from "./runner/substrate/pi-dev-runner";
 
@@ -2272,34 +2272,54 @@ export async function startCortex(
       `adapters=${adapters.length}`,
   );
 
-  // cortex#480 — boot-time self-signed envelope sanity check. After the
-  // listeners are wired with `stackIdentity` + `stackNKeyPub`, build a
-  // tiny envelope signed by the stack's own NKey and round-trip it
-  // through `verifySignedByChain` to confirm the verifier admits it.
-  // The check exists because the cortex#480 root-cause (verifier
-  // rejecting `did:mf:<stack>` as unknown_agent) shipped to prod
-  // unnoticed — no boot-side observability exercised the identity the
-  // wire would actually carry. A future regression in the stack-trust
-  // short-circuit / NKey bridge / Principal-registry shape now fails
-  // loudly at boot with a grep-friendly stderr WARNING instead of at
-  // first Discord chat. Skipped when no signing identity is wired
-  // (deployments running unsigned by design).
-  if (
-    signer !== undefined
-    && stackNKeyPubForVerifier !== undefined
-    && firstAgent !== undefined
-  ) {
-    // Fire-and-forget by design — boot does not wait for the result.
-    // The check is informational; production deployment health is
-    // ultimately validated by the dashboard / first round-trip chat.
-    void runVerifierSelfCheck({
-      stackIdentity: signer.principal,
-      stackNKeyPub: stackNKeyPubForVerifier,
-      stackSeedBytes: signer.rawSeedBytes,
+  // cortex#480 + TC-1b (#632) — boot-time self-signed envelope sanity check,
+  // posture-aware. After the listeners are wired with `stackIdentity` +
+  // `stackNKeyPub`, build a tiny envelope signed by the stack's own NKey and
+  // round-trip it through `verifySignedByChain` to confirm the verifier
+  // admits it. The check exists because the cortex#480 root-cause (verifier
+  // rejecting `did:mf:<stack>` as unknown_agent) shipped to prod unnoticed —
+  // no boot-side observability exercised the identity the wire would actually
+  // carry.
+  //
+  // TC-1b makes the gate **posture-aware** (per design §Phase 1.1b
+  // "`verifier-self-check` passes on every stack at boot"):
+  //   - `enforce` → a missing OR unverifiable stack identity FAILS FAST: the
+  //     gate throws, the catch below maps it to a fatal boot error and the
+  //     CLI exits non-zero. A stack serving SIGNED traffic must not run with
+  //     an identity its own verifier rejects.
+  //   - `permissive`/`off` → advisory: WARN on failure (or when no identity
+  //     is wired, no-op), boot continues — the pre-TC-1b behaviour.
+  //
+  // We `await` (not fire-and-forget) so the `enforce` throw can abort boot
+  // deterministically before the router starts admitting envelopes. The
+  // grep-friendly `verifier-self-check` stderr line is preserved for
+  // pilot-loop / on-call pattern matching.
+  if (firstAgent !== undefined) {
+    const selfCheckIdentity =
+      signer !== undefined && stackNKeyPubForVerifier !== undefined
+        ? {
+            stackIdentity: signer.principal,
+            stackNKeyPub: stackNKeyPubForVerifier,
+            stackSeedBytes: signer.rawSeedBytes,
+          }
+        : undefined;
+    await bootVerifierSelfCheck({
+      posture: config.security.signing,
+      identity: selfCheckIdentity,
       resolver: trustResolver,
       receivingAgentId: firstAgent.id,
       principalId,
     });
+  } else if (config.security.signing === "enforce") {
+    // No agents at all under `enforce` — there is no `receivingAgentId` to run
+    // the self-check against, but a stack with no agents cannot serve signed
+    // traffic meaningfully either. Refuse to boot with the same fail-fast
+    // posture so a misconfigured enforce stack does not start silently.
+    throw new Error(
+      "verifier-self-check: REFUSING TO BOOT — security.signing=enforce but no " +
+        "agents are configured; cannot run the boot self-check. Configure at " +
+        "least one agent, or drop signing to permissive/off.",
+    );
   }
 
   // Start router AFTER all surfaces register so the first envelope

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -3050,6 +3050,43 @@ export function runDryRun(configPath: string): DryRunResult {
 // Skipping the CLI wiring at module load is what lets tests
 // `import { startCortex }` here without parsing argv or registering signal
 // handlers.
+/**
+ * Run the boot sequence and treat ANY boot-phase failure as FATAL. The daemon
+ * must NEVER linger half-booted — inbound dispatch listeners already live, the
+ * PID file written so launchd sees a "healthy" process — while the failure that
+ * should have stopped it is logged and ignored. This is the load-bearing
+ * guarantee behind `signing: enforce`: a stack whose `bootVerifierSelfCheck`
+ * throws "REFUSING TO BOOT" MUST exit non-zero, not survive serving traffic.
+ *
+ * Why a helper and not just a try/catch inline: the `start` action is an async
+ * commander action invoked by the synchronous `program.parse()`, which does NOT
+ * await it. A rejected boot promise would otherwise fall through to the
+ * `unhandledRejection` handler and be logged "non-fatal". Because this helper
+ * calls `process.exit(1)` itself, the fatal exit happens regardless of whether
+ * the dispatcher awaits the action.
+ */
+export async function bootOrDie<T>(
+  boot: () => Promise<T>,
+  pidFile: string,
+): Promise<T> {
+  try {
+    return await boot();
+  } catch (err) {
+    console.error(
+      `cortex: FATAL — boot aborted: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    // Remove the PID file so launchd / `cortex status` don't mistake a process
+    // that failed to boot for a healthy daemon. Best-effort — the exit is what
+    // actually matters.
+    try {
+      if (existsSync(pidFile)) unlinkSync(pidFile);
+    } catch (_err) {
+      // PID cleanup failed; nothing safe to do but proceed to the fatal exit.
+    }
+    process.exit(1);
+  }
+}
+
 if (import.meta.main) {
   const program = new Command()
     .name("cortex")
@@ -3092,22 +3129,29 @@ if (import.meta.main) {
       // block when the principal declared one — `startCortex` calls
       // `deriveStackId` and logs the resolved stack id. Today this is
       // observational only; emit subjects are unchanged.
-      const { config, inlineAgents, stack, policy, principal, bus, surfaces } = loadConfigWithAgents(options.config);
-      const handle = await startCortex(config, {
-        configPath: options.config,
-        ...(inlineAgents.length > 0 && { inlineAgents }),
-        ...(stack !== undefined && { stack }),
-        ...(policy !== undefined && { policy }),
-        // PR-R13.B.i: both LoadedConfig and StartCortexOptions now use
-        // the canonical `.principal` field.
-        ...(principal !== undefined && { principal }),
-        ...(bus !== undefined && { bus }),
-        // IAW GW (cortex#524) — thread the validated surface binding map
-        // through so the flag-gated gateway block in startCortex can read it.
-        // Dormant unless CORTEX_GATEWAY is set; undefined when no surfaces:
-        // block was declared.
-        ...(surfaces !== undefined && { surfaces }),
-      });
+      // Boot through bootOrDie: a config-load error OR a boot-phase throw
+      // (notably the signing:enforce verifier-self-check "REFUSING TO BOOT")
+      // exits the process non-zero instead of being swallowed as a "non-fatal"
+      // unhandled rejection. The daemon must not survive a failed security gate.
+      const handle = await bootOrDie(async () => {
+        const { config, inlineAgents, stack, policy, principal, bus, surfaces } =
+          loadConfigWithAgents(options.config);
+        return startCortex(config, {
+          configPath: options.config,
+          ...(inlineAgents.length > 0 && { inlineAgents }),
+          ...(stack !== undefined && { stack }),
+          ...(policy !== undefined && { policy }),
+          // PR-R13.B.i: both LoadedConfig and StartCortexOptions now use
+          // the canonical `.principal` field.
+          ...(principal !== undefined && { principal }),
+          ...(bus !== undefined && { bus }),
+          // IAW GW (cortex#524) — thread the validated surface binding map
+          // through so the flag-gated gateway block in startCortex can read it.
+          // Dormant unless CORTEX_GATEWAY is set; undefined when no surfaces:
+          // block was declared.
+          ...(surfaces !== undefined && { surfaces }),
+        });
+      }, pidFile);
 
       const shutdown = async () => {
         await handle.stop();


### PR DESCRIPTION
## TC-1b — stack-identity provisioning + boot verifier-self-check (closes #632)

Design: [`docs/design-trust-confidentiality.md`](docs/design-trust-confidentiality.md) §4 **Phase 1.1b** — "Ensure every deployed stack has `stack.nkey_seed_path` + registered `nkey_pub` … Acceptance: `verifier-self-check` passes on every stack at boot." This is the **CODE** that makes SIGNED operation real: without a provisioned stack signing identity AND its pubkey registered, `signing: enforce` has nothing to verify against and the boot self-check cannot pass. Critical-path before a signed pilot→Echo round-trip.

> ⚠️ CODE ONLY. No production keys are generated and nothing is deployed here. Running provisioning against a live registry stays a gated human/ops step.

### What ALREADY existed (reused, not rewritten)
- **`src/bus/verifier-self-check.ts`** (cortex#480) — the self-signed-envelope round-trip through `verifySignedByChain`. TC-1b **wires it into the boot path posture-aware**; the round-trip logic is untouched.
- **`POST /principals/{id}/register`** proof-of-possession route + the rotation guard (silent key swap → 409) + `RegistryClient`.
- **`enforceChmod600`**, **`loadStackSigningKey`** (chmod-600 discipline), **`nkeyToBase64Pubkey`** (NKey→base64 ed25519 bridge), the verify-only `src/common/registry/signing.ts` mirror.

### What this PR ADDS
1. **`src/bus/stack-provisioning.ts`** — generate an ed25519 **NKey** signing identity (the **same** key the stack signs bus envelopes with — design invariant §2.4 "no new long-term keys"; one root of secret material per stack), write the seed **chmod 600**, derive the NKey pub + base64 pubkey, and build a **registration claim signed with that same key**.
   - **Proof-of-possession:** the claim is signed over `canonicalJSON(claim)` with the stack key; the registry verifies the signature against the declared `principal_pubkey`. A **tampered** claim or a claim signed by a **different** key is rejected (401). Pinned by a round-trip test against the **real** registry route.
   - **Key bridge:** NKey raw 32-byte seed → PKCS#8 → WebCrypto Ed25519. The derived base64 pubkey equals `nkeyToBase64Pubkey(nkeyPub)` exactly, and the NKey-native and WebCrypto signatures cross-verify — so registry registration and bus signing share **one** key.
   - **Idempotent / refuse-to-clobber:** `generateStackIdentity` REFUSES to overwrite an existing seed without `force` (rotation is a security event). No live registry I/O on the generate path; `registerStackIdentity` is an opt-in fetch wrapper.
2. **`src/cli/cortex/commands/provision-stack.ts`** — `cortex provision-stack generate|claim|register` (follows the existing `_shared` subcommand/envelope CLI convention).
   - `generate` writes the seed mode 600, prints the pubkey + a cortex.yaml `stack:` block; `--register --registry-url` opts into registration. `claim` prints a signed body without posting (air-gapped). `register` POSTs an existing seed's claim.
   - **Secrets discipline:** the seed is written to disk + held in memory to sign the claim; it is **NEVER printed or logged**. Output carries the pubkey + a short fingerprint only.
3. **Boot self-check wiring (`bootVerifierSelfCheck` + `src/cortex.ts`)** — posture-aware gate:
   - **`enforce`** → a missing / unregistered / unverifiable stack identity **FAILS FAST** (refuse to boot with an actionable message) rather than silently serving traffic peers will reject. `await`-ed so the throw aborts boot **before** `router.start()` admits any envelope.
   - **`off` / `permissive`** → advisory: warn and continue (the pre-TC-1b behaviour); no-op when no identity is wired (today's unsigned-dev default).

### Failure handling & secrets
- No empty catches (CLAUDE.md); every failure path logs or returns a typed result.
- Secrets never logged: log lines carry the **pubkey / fingerprint**, never the seed. Pinned by "no seed bytes leak into logs" tests in both the boot-gate and CLI suites.

### Verification
- `bunx tsc --noEmit` → **0 errors**
- `bun run lint:errors` → clean (changed files)
- `bash scripts/check-carveouts.sh` (full diff) → **PASS** (`principal` not `operator` in all new prose; existing `*_pubkey` / `operatorRole` are carve-outs)
- Tests: new `stack-provisioning` (8) + `verifier-self-check-boot` (6) + `provision-stack` CLI (8); updated `cortex.security-posture-boot` (now covers enforce-fails-fast + enforce-boots-clean); registry/bus/boot suites green. **Full suite: 4214 pass / 0 fail.**

### Self-review (`/code-review --fix high`)
SHIP — no blockers, no majors. Two advisory nits, no code change warranted:
- The `enforce` fail-fast throws after the dispatch/review sinks start but before `router.start()` (no traffic served) — matches the existing cortex.ts throw-site pattern; launchd restarts.
- `register` permits `http://` registry URLs — the claim is signed (no secret transmitted; the seed never leaves the host) and the registry response is verified downstream by `RegistryClient`'s pinned-pubkey check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)