### PR TITLE
feat(network-registry): registry-keypair generation command + PKCS#8 format fix (closes #677)

### DIFF
--- a/docs/sop-network-registry.md
+++ b/docs/sop-network-registry.md
@@ -52,13 +52,27 @@ The registry signs that bound triple with `REGISTRY_SIGNING_KEY` (`signAssertion
 
 **Where the pubkey comes from:** the Worker derives the public key from `REGISTRY_SIGNING_KEY` at boot (`ensurePublicKey` → `pubkeyFromPkcs8` in `src/index.ts`), unless `REGISTRY_PUBLIC_KEY` is set explicitly. Principals obtain it by querying `GET /registry/pubkey`, which returns `{ "algorithm": "Ed25519", "public_key": "<base64>" }`.
 
-> **⚠️ Not yet implemented — registry-keypair provisioning command.** There is **no** CLI or script in the repo that *generates* the registry's keypair. `wrangler.toml` and `README.md` instruct the principal to `wrangler secret put REGISTRY_SIGNING_KEY` and paste a base64-encoded Ed25519 private key, but neither supplies the generation command. **You must generate it by hand, out-of-band, and there is a format discrepancy to resolve first** (see the next callout). This is the single biggest manual gap in the registry-provisioning story.
+### Generate the registry keypair
 
-> **⚠️ Format discrepancy in the source — confirm before generating.** The key format is described inconsistently:
-> - `src/index.ts` (`Env.REGISTRY_SIGNING_KEY` JSDoc) and `README.md` say **"base64-encoded PKCS#8 Ed25519 private key"**, and the Worker derives the pubkey via `pubkeyFromPkcs8(...)`.
-> - `wrangler.toml`'s secrets comment says **"64 raw bytes (seed + pubkey), base64-encoded"**.
->
-> These are two *different* encodings. The code path that actually runs (`pubkeyFromPkcs8` in `src/index.ts`) consumes **PKCS#8**, so the PKCS#8 description is the authoritative one and the `wrangler.toml` comment appears stale. Verify against `src/services/network-registry/src/signing.ts` before generating a key, and do not assume the `wrangler.toml` "raw 64 bytes" wording.
+Generate the registry's signing keypair with the registry's own tool:
+
+```bash
+cd src/services/network-registry
+bun install
+bun run gen-key            # → scripts/generate-registry-keypair.ts
+```
+
+`gen-key` mints a fresh Ed25519 keypair via WebCrypto and prints:
+
+- **`REGISTRY_SIGNING_KEY`** — the base64 **PKCS#8** Ed25519 private key (the single SECRET line; paste it into `wrangler secret put`).
+- the base64 **raw** public key (pin it as `policy.federated.registry.pubkey` — see [§5](#5-wire-a-cortex-to-use-the-registry)).
+- a short fingerprint for log-safe reference.
+
+Before it emits anything, the tool asserts the generated PKCS#8 key round-trips through the registry's **own** `pubkeyFromPkcs8()` to exactly the raw pubkey it prints — so the key is guaranteed consumable by the Worker (if it didn't, the tool refuses and exits non-zero). Flags: `--json` (machine-readable envelope), `--out <path>` (also write the private key chmod 600, O_EXCL refuse-clobber), `--force` (deliberate rotation overwrite), `--help`.
+
+> **Secrets discipline:** the private key is printed once, clearly labelled `REGISTRY_SIGNING_KEY (SECRET …)`, because you need it for `wrangler secret put`. It is never logged, and is only written to disk with `--out` (chmod 600).
+
+**Key format (resolved — #677).** The secret is unambiguously a **base64-encoded PKCS#8 Ed25519 private key**. The Worker derives its pubkey from it via `pubkeyFromPkcs8(...)` (`src/signing.ts`), and `index.ts`, `README.md`, `wrangler.toml`, and `gen-key` now all agree on PKCS#8. (The old `wrangler.toml` "64 raw bytes (seed + pubkey)" wording was stale and has been corrected.)
 
 ### Trust-anchor warning — pin, don't TOFU
 
@@ -92,9 +106,11 @@ bun install
 **Provision the signing secret, then deploy** (from `README.md` §Deploy):
 
 ```bash
-# One-time per environment: provision the signing key.
+# One-time per environment: generate the keypair (see "Generate the
+# registry keypair" above), then provision the signing key.
+bun run gen-key                                          # prints the secret + pubkey
 bunx wrangler secret put REGISTRY_SIGNING_KEY --env production
-# Paste the base64-encoded Ed25519 private key (PKCS#8 — see the format callout above).
+# Paste the base64 PKCS#8 Ed25519 private key printed by gen-key.
 
 # Deploy
 bunx wrangler deploy --env production
@@ -102,7 +118,7 @@ bunx wrangler deploy --env production
 
 For dev, substitute `--env dev`. Local-only iteration uses `bunx wrangler dev` (the `dev` script in `package.json`), which runs without a signing key — the Worker then degrades to the "unconfigured" path (see [§4](#the-unconfigured-sentinel)).
 
-> **⚠️ Not yet implemented — DNS / routes.** Both `[env.dev]` and `[env.production]` have their `routes = [...]` blocks **commented out** in `wrangler.toml` ("Routes for dev are TBD…", "finalised at deploy time"). The plan names `network.meta-factory.ai` (prod) and `network-dev.meta-factory.ai` (dev), but DNS is not provisioned in-repo. You must uncomment + tune the route and provision DNS at first deploy. Until then a deploy produces a Worker with no public hostname.
+> **⚠️ Principal step — provision DNS, then deploy.** The `routes = [...]` blocks in `wrangler.toml` are now **set**: `[env.production]` → `network.meta-factory.ai/*` and `[env.dev]` → `network-dev.meta-factory.ai/*`, both in the `meta-factory.ai` zone (same `{ pattern, zone_name }` shape as the gh-webhook + mc-worker Workers). The remaining steps the principal takes are: **(a)** create the matching **proxied DNS record** in the `meta-factory.ai` zone (`network` / `network-dev`), and **(b)** `bunx wrangler deploy --env production|dev`. DNS provisioning is not done in-repo — until the record exists the route has nothing to resolve to. Additional TLDs (`.dev`/`.io`) can be added analogously if multi-TLD reach is wanted.
 
 > **⚠️ Not yet implemented — durable persistence.** Per `README.md` §Storage, the store is **in-memory per-isolate** (`InMemoryRegistryStore`). Registrations do **not** survive isolate recycling, and different isolates may hold different state. D1 / KV persistence is an explicit follow-up (`README.md` §Roadmap items 1–2), as is durable nonce-replay storage. **Do not treat a v1 registry as a durable directory** — a principal may need to re-register after an isolate cycles.
 

--- a/src/services/network-registry/README.md
+++ b/src/services/network-registry/README.md
@@ -78,17 +78,24 @@ real-world signature paths are exercised.
 ## Deploy
 
 ```bash
-# One-time per environment: provision the signing key.
+# One-time per environment: generate the registry's signing keypair.
+# Prints the base64 PKCS#8 private key (REGISTRY_SIGNING_KEY) + the raw
+# base64 public key to pin client-side. Verified to round-trip through
+# the Worker's own pubkeyFromPkcs8() before it emits.
+bun run gen-key
+
+# Provision the signing key (paste the printed REGISTRY_SIGNING_KEY value).
 bunx wrangler secret put REGISTRY_SIGNING_KEY --env production
-# Paste a base64-encoded PKCS#8 Ed25519 private key.
+# The secret is a base64-encoded PKCS#8 Ed25519 private key (#677).
 
 # Deploy
 bunx wrangler deploy --env production
 ```
 
-DNS for `network.meta-factory.ai` is provisioned at first deploy time;
-the placeholder route in `wrangler.toml` is commented out and finalised
-then.
+The `wrangler.toml` route points `network.meta-factory.ai` (prod) /
+`network-dev.meta-factory.ai` (dev) at this Worker. The principal creates
+the matching proxied DNS record in the `meta-factory.ai` zone, then runs
+`wrangler deploy --env <env>`.
 
 ## Roadmap (follow-ups)
 

--- a/src/services/network-registry/__tests__/generate-registry-keypair.test.ts
+++ b/src/services/network-registry/__tests__/generate-registry-keypair.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Tests for the registry-keypair generation script (#677 follow-up).
+ *
+ * The load-bearing assertions:
+ *   1. The generated PKCS#8 private round-trips through the registry's OWN
+ *      `pubkeyFromPkcs8` to EXACTLY the emitted raw pubkey (the correctness
+ *      contract — if this breaks, the key is useless to the Worker).
+ *   2. The generated key can actually sign, and the registry's `verifyEd25519`
+ *      verifies that signature against the emitted pubkey (end-to-end).
+ *   3. `--out` writes the private key chmod 600 and refuses to clobber
+ *      (O_EXCL), with --force overriding. A planted symlink is refused.
+ *   4. No private-key bytes leak into output beyond the single intended
+ *      emission (the SECRET line / `registry_signing_key` JSON field).
+ *
+ * All filesystem state is ephemeral (mkdtemp). No hardcoded paths/ports.
+ */
+
+import { describe, test, expect, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, statSync, readFileSync, existsSync, symlinkSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+import {
+  generateRegistryKeypair,
+  dispatch,
+  parseArgs,
+  type KeygenResult,
+  type KeygenOptions,
+} from "../scripts/generate-registry-keypair";
+import {
+  pubkeyFromPkcs8,
+  signEd25519,
+  verifyEd25519,
+  canonicalJSON,
+  base64ToBytes,
+} from "../src/signing";
+
+const tmpDirs: string[] = [];
+function freshDir(): string {
+  const d = mkdtempSync(join(tmpdir(), "regkey-"));
+  tmpDirs.push(d);
+  return d;
+}
+afterEach(() => {
+  while (tmpDirs.length > 0) rmSync(tmpDirs.pop()!, { recursive: true, force: true });
+});
+
+/** Pull the structured data block out of a successful --json run. */
+function jsonData(res: KeygenResult): Record<string, string> {
+  const env = JSON.parse(res.stdout) as { status: string; data: Record<string, string> };
+  expect(env.status).toBe("ok");
+  return env.data;
+}
+
+describe("generate-registry-keypair — correctness contract", () => {
+  test("[1] emitted PKCS#8 round-trips through pubkeyFromPkcs8 to the emitted pubkey", async () => {
+    const res = await generateRegistryKeypair({ json: true });
+    expect(res.exitCode).toBe(0);
+    const data = jsonData(res);
+
+    const priv = data.registry_signing_key!;
+    const pub = data.registry_public_key!;
+
+    // THE contract: the registry's own derive path must reproduce the pubkey.
+    const derived = await pubkeyFromPkcs8(priv);
+    expect(derived).toBe(pub);
+
+    // Shape sanity: raw pubkey is 32 bytes; fingerprint is the 12-char prefix.
+    expect(base64ToBytes(pub).length).toBe(32);
+    expect(data.fingerprint).toBe(pub.slice(0, 12));
+    expect(data.algorithm).toBe("Ed25519");
+  });
+
+  test("[2] the generated key signs and the registry's verifyEd25519 verifies it", async () => {
+    const res = await generateRegistryKeypair({ json: true });
+    const data = jsonData(res);
+    const priv = data.registry_signing_key!;
+    const pub = data.registry_public_key!;
+
+    // End-to-end: sign a sample assertion-shaped payload with the generated
+    // private key, verify against the emitted raw pubkey — exactly the path
+    // the Worker's signAssertion / consumer verify uses.
+    const payload = { payload: { principal_id: "andreas" }, issued_at: "2026-06-04T00:00:00.000Z", registry: pub };
+    const message = new TextEncoder().encode(canonicalJSON(payload));
+    const signature = await signEd25519(priv, message);
+    expect(await verifyEd25519(pub, signature, message)).toBe(true);
+
+    // Tamper → must NOT verify.
+    const tampered = new TextEncoder().encode(canonicalJSON({ ...payload, registry: "x" + pub.slice(1) }));
+    expect(await verifyEd25519(pub, signature, tampered)).toBe(false);
+  });
+
+  test("[3] two invocations produce DIFFERENT keys (fresh keypair each time)", async () => {
+    const a = jsonData(await generateRegistryKeypair({ json: true }));
+    const b = jsonData(await generateRegistryKeypair({ json: true }));
+    expect(a.registry_signing_key).not.toBe(b.registry_signing_key);
+    expect(a.registry_public_key).not.toBe(b.registry_public_key);
+  });
+});
+
+describe("generate-registry-keypair — file write (chmod 600, refuse-clobber)", () => {
+  test("[4] --out writes the private key chmod 600", async () => {
+    const out = join(freshDir(), "registry.pkcs8");
+    const res = await generateRegistryKeypair({ json: true, out });
+    expect(res.exitCode).toBe(0);
+    expect(existsSync(out)).toBe(true);
+    if (process.platform !== "win32") {
+      expect(statSync(out).mode & 0o777).toBe(0o600);
+    }
+    // The file holds the SAME private key that was emitted.
+    const onDisk = readFileSync(out, "utf-8").trim();
+    expect(onDisk).toBe(jsonData(res).registry_signing_key);
+    // And that private key derives to the emitted pubkey.
+    expect(await pubkeyFromPkcs8(onDisk)).toBe(jsonData(res).registry_public_key);
+  });
+
+  test("[5] --out refuses to clobber without --force (exit 1); --force overwrites", async () => {
+    const out = join(freshDir(), "registry.pkcs8");
+    const first = await generateRegistryKeypair({ json: true, out });
+    expect(first.exitCode).toBe(0);
+    const firstKey = readFileSync(out, "utf-8").trim();
+
+    const refused = await generateRegistryKeypair({ json: true, out });
+    expect(refused.exitCode).toBe(1);
+    expect(refused.stderr).toMatch(/refusing to overwrite/i);
+    expect(readFileSync(out, "utf-8").trim()).toBe(firstKey); // unchanged
+
+    const forced = await generateRegistryKeypair({ json: true, out, force: true });
+    expect(forced.exitCode).toBe(0);
+    expect(readFileSync(out, "utf-8").trim()).not.toBe(firstKey); // rotated
+  });
+
+  test("[6] --out refuses to follow a planted symlink (O_EXCL)", async () => {
+    const dir = freshDir();
+    const target = join(dir, "victim");
+    writeFileSync(target, "PRE-EXISTING\n");
+    const link = join(dir, "link.pkcs8");
+    symlinkSync(target, link);
+
+    const res = await generateRegistryKeypair({ json: true, out: link });
+    expect(res.exitCode).toBe(1);
+    expect(res.stderr).toMatch(/refusing to overwrite/i);
+    // The symlink target must be UNTOUCHED — no write-through.
+    expect(readFileSync(target, "utf-8")).toBe("PRE-EXISTING\n");
+  });
+});
+
+describe("generate-registry-keypair — secrets discipline", () => {
+  test("[7] human output emits the private key exactly once, labelled SECRET", async () => {
+    const res = await generateRegistryKeypair({});
+    expect(res.exitCode).toBe(0);
+    // Recover the private key from a JSON run to know what to grep for.
+    const data = jsonData(await generateRegistryKeypair({ json: true }));
+    // (Different key — but both are valid PKCS#8 base64; assert the human
+    // render carries its OWN single secret line under the SECRET banner.)
+    expect(res.stdout).toContain("REGISTRY_SIGNING_KEY (SECRET");
+    expect(res.stdout).toContain("Worker secret");
+    expect(res.stderr).toBe("");
+    // Sanity: the JSON `data` field carries the secret under the expected key.
+    expect(data.registry_signing_key).toBeDefined();
+  });
+
+  test("[8] the private key appears exactly once in human stdout (no accidental echo)", async () => {
+    // Generate via JSON to capture the exact secret, then assert the human
+    // formatter — fed the SAME material — emits it once and only once.
+    const data = jsonData(await generateRegistryKeypair({ json: true }));
+    const priv = data.registry_signing_key!;
+    // Build a human render by parsing: we cannot inject the key, so instead
+    // assert the structural guarantee on a fresh human run — its single secret
+    // line is the only base64 PKCS#8 blob (starts with the Ed25519 PKCS#8
+    // marker "MC4CAQAw").
+    const human = await generateRegistryKeypair({});
+    const pkcs8Lines = human.stdout.split("\n").filter((l) => l.startsWith("MC4CAQAw"));
+    expect(pkcs8Lines.length).toBe(1);
+    // The public key (raw, 44 chars) is NOT a PKCS#8 blob, so it never matches.
+    expect(priv.startsWith("MC4CAQAw")).toBe(true);
+  });
+
+  test("[9] --json error path on a write failure does not include any key", async () => {
+    // Force a clobber refusal in JSON mode and confirm the error envelope
+    // carries no key material.
+    const out = join(freshDir(), "k.pkcs8");
+    await generateRegistryKeypair({ json: true, out });
+    const refused = await generateRegistryKeypair({ json: true, out });
+    expect(refused.exitCode).toBe(1);
+    const env = JSON.parse(refused.stderr) as { status: string; error: { reason: string } };
+    expect(env.status).toBe("error");
+    expect(env.error.reason).toMatch(/refusing to overwrite/i);
+    // No PKCS#8 blob anywhere in the error output.
+    expect(refused.stderr).not.toMatch(/MC4CAQAw/);
+  });
+});
+
+describe("generate-registry-keypair — arg parsing", () => {
+  test("[10] --help returns exit 0 with usage", async () => {
+    const res = await dispatch(["--help"]);
+    expect(res.exitCode).toBe(0);
+    expect(res.stdout).toContain("generate-registry-keypair");
+    expect(res.stdout).toContain("REGISTRY_SIGNING_KEY");
+  });
+
+  test("[11] unknown flag → exit 2", async () => {
+    const res = await dispatch(["--bogus"]);
+    expect(res.exitCode).toBe(2);
+    expect(res.stderr).toMatch(/unknown argument/i);
+  });
+
+  test("[12] --out with no value → exit 2", () => {
+    const parsed = parseArgs(["--out"]);
+    expect("exitCode" in parsed).toBe(true);
+    expect((parsed as KeygenResult).exitCode).toBe(2);
+  });
+
+  test("[13] parseArgs returns options for valid flags", () => {
+    const parsed = parseArgs(["--json", "--out", "/tmp/x", "--force"]);
+    expect("exitCode" in parsed).toBe(false);
+    const opts = parsed as KeygenOptions;
+    expect(opts.json).toBe(true);
+    expect(opts.out).toBe("/tmp/x");
+    expect(opts.force).toBe(true);
+  });
+});

--- a/src/services/network-registry/package.json
+++ b/src/services/network-registry/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "wrangler dev",
     "deploy": "wrangler deploy",
+    "gen-key": "bun run scripts/generate-registry-keypair.ts",
     "test": "bun test"
   },
   "dependencies": {

--- a/src/services/network-registry/scripts/generate-registry-keypair.ts
+++ b/src/services/network-registry/scripts/generate-registry-keypair.ts
@@ -1,0 +1,354 @@
+#!/usr/bin/env bun
+/**
+ * `generate-registry-keypair` — provision the network-registry's OWN signing
+ * keypair (the `REGISTRY_SIGNING_KEY` Cloudflare Worker secret).
+ *
+ * Closes the headline provisioning gap flagged in `docs/sop-network-registry.md`:
+ * principals were told to `wrangler secret put REGISTRY_SIGNING_KEY` and paste a
+ * base64 key, but nothing in the repo MADE one. This is that tool.
+ *
+ * ## Why it lives HERE (in the registry service, not the cortex CLI)
+ *
+ * The registry signing key is the registry's OWN concern. By living inside
+ * `src/services/network-registry/` this script imports `../src/signing.ts`
+ * directly and reuses the EXACT functions the Worker runs — `generateKeypair`
+ * (WebCrypto Ed25519) and, crucially, `pubkeyFromPkcs8` (the registry's own
+ * pubkey-derivation path used by `ensurePublicKey` at boot). That makes the
+ * correctness contract below a check against the registry's real code, not a
+ * re-implementation. The alternative — a `cortex` CLI subcommand — would have
+ * to reach across the root↔Worker bundle boundary (the registry is excluded
+ * from the root tsconfig) and re-derive PKCS#8 handling, exactly the coupling
+ * `stack-provisioning.ts` had to carry for the per-stack NKey case. The
+ * registry key has no NKey bridge to justify that, so it belongs with the
+ * Worker that consumes it.
+ *
+ * ## What it produces
+ *
+ *   1. A fresh Ed25519 keypair via WebCrypto.
+ *   2. PRIVATE key exported as PKCS#8 → base64 — the `REGISTRY_SIGNING_KEY`
+ *      secret value (`wrangler secret put`). This is the ONLY sensitive line
+ *      of output; everything else is public.
+ *   3. PUBLIC key exported as raw 32 bytes → base64 — what principals pin as
+ *      `policy.federated.registry.pubkey` and (optionally) `REGISTRY_PUBLIC_KEY`.
+ *   4. A short fingerprint (first 12 base64 chars of the raw pubkey) for
+ *      log-safe reference.
+ *
+ * ## Correctness contract (load-bearing)
+ *
+ * Before emitting anything, the script asserts that
+ * `pubkeyFromPkcs8(<emitted PKCS#8 base64>)` returns EXACTLY the raw-public
+ * base64 it is about to print. If the generated key does not round-trip
+ * through the registry's OWN derive path, the key is useless to the Worker —
+ * so we refuse to emit it and exit non-zero. A test pins the same invariant
+ * (`__tests__/generate-registry-keypair.test.ts`).
+ *
+ * ## Secrets discipline
+ *
+ * The PKCS#8 private key is printed to stdout exactly once, clearly labelled as
+ * the secret, because the principal NEEDS it to paste into `wrangler secret put`.
+ * It is NEVER written to a log sink, and (by default) NEVER written to a file.
+ * With `--out <path>` the private key is written chmod 600 with an O_EXCL
+ * create (refuses to clobber, refuses to follow a planted symlink) — mirroring
+ * the seed-file discipline in `src/bus/stack-provisioning.ts` (TC-1b).
+ *
+ * ## Usage
+ *
+ *   bun run gen-key                       # print keypair + next steps to stdout
+ *   bun run gen-key --json                # machine-readable envelope
+ *   bun run gen-key --out registry.pkcs8  # also write the private key chmod 600
+ *   bun run gen-key --out k --force       # allow overwriting an existing file
+ *
+ * Exit codes:
+ *   0  success
+ *   1  operational failure (round-trip mismatch, clobber refused, write error)
+ *   2  usage error (unknown flag, --out without a value)
+ */
+
+import { writeFileSync, chmodSync } from "fs";
+
+import { generateKeypair, pubkeyFromPkcs8, base64ToBytes } from "../src/signing";
+
+// =============================================================================
+// Result shape (mirrors the cortex CLI ExitResult convention)
+// =============================================================================
+
+export interface KeygenResult {
+  exitCode: 0 | 1 | 2;
+  stdout: string;
+  stderr: string;
+}
+
+export interface KeygenOptions {
+  /** Emit a JSON envelope instead of human-readable text. */
+  json?: boolean;
+  /**
+   * If set, also write the PKCS#8 private key to this path, chmod 600,
+   * refusing to clobber an existing file unless `force`.
+   */
+  out?: string;
+  /** Allow overwriting an existing `--out` file (deliberate rotation). */
+  force?: boolean;
+}
+
+// =============================================================================
+// Core
+// =============================================================================
+
+/**
+ * Generate a registry keypair, verify it round-trips through the registry's
+ * own `pubkeyFromPkcs8`, and render the principal-facing output. Pure with
+ * respect to stdout/stderr (returns strings); the only side effect is the
+ * optional chmod-600 file write under `--out`.
+ */
+export async function generateRegistryKeypair(
+  opts: KeygenOptions = {},
+): Promise<KeygenResult> {
+  // 1. Mint the keypair using the SAME WebCrypto path the Worker tests use.
+  const { privateKeyB64, publicKeyB64 } = await generateKeypair();
+
+  // 2. CORRECTNESS CONTRACT — the emitted PKCS#8 MUST derive, through the
+  //    registry's OWN function, to the emitted raw pubkey. If not, the key is
+  //    unusable by the Worker; refuse to emit it.
+  let derived: string;
+  try {
+    derived = await pubkeyFromPkcs8(privateKeyB64);
+  } catch (err) {
+    return opError(
+      `round-trip check failed: pubkeyFromPkcs8 threw: ${err instanceof Error ? err.message : String(err)}`,
+      opts.json ?? false,
+    );
+  }
+  if (derived !== publicKeyB64) {
+    return opError(
+      `round-trip mismatch: pubkeyFromPkcs8(private) !== exported raw pubkey — ` +
+        `generated key is not consumable by the registry; refusing to emit`,
+      opts.json ?? false,
+    );
+  }
+
+  // Sanity-check the shapes so a malformed export can't slip into output.
+  const rawPubLen = base64ToBytes(publicKeyB64).length;
+  if (rawPubLen !== 32) {
+    return opError(
+      `unexpected raw public key length ${rawPubLen.toString()} (want 32)`,
+      opts.json ?? false,
+    );
+  }
+
+  const fingerprint = publicKeyB64.slice(0, 12);
+
+  // 3. Optional chmod-600 file write of the PRIVATE key.
+  let outNote: string | undefined;
+  if (opts.out !== undefined) {
+    const writeRes = writePrivateKeyFile(opts.out, privateKeyB64, opts.force ?? false);
+    if (!writeRes.ok) return opError(writeRes.reason, opts.json ?? false);
+    outNote = `${opts.out} (chmod 600)`;
+  }
+
+  // 4. Render.
+  if (opts.json) {
+    // The JSON envelope mirrors the cortex CLI `{ status, items, data }` shape.
+    // The private key IS present here (the principal needs it) — clearly keyed
+    // as `registry_signing_key`, the single sensitive field.
+    const data: Record<string, string> = {
+      algorithm: "Ed25519",
+      registry_signing_key: privateKeyB64, // SECRET — PKCS#8 base64
+      registry_public_key: publicKeyB64, // raw base64 (pin this)
+      fingerprint,
+      ...(outNote !== undefined && { private_key_file: outNote }),
+    };
+    const envelope = { status: "ok", items: [], data };
+    return ok(JSON.stringify(envelope, null, 2) + "\n");
+  }
+
+  return ok(renderHuman({ privateKeyB64, publicKeyB64, fingerprint, outNote }));
+}
+
+// =============================================================================
+// File write (chmod 600, refuse-clobber, O_EXCL) — mirrors TC-1b discipline
+// =============================================================================
+
+function writePrivateKeyFile(
+  path: string,
+  privateKeyB64: string,
+  force: boolean,
+): { ok: true } | { ok: false; reason: string } {
+  try {
+    // Non-force create uses "wx" (O_EXCL|O_CREAT): the no-clobber guarantee is
+    // KERNEL-enforced (no existsSync→write TOCTOU) and a symlink planted at
+    // `path` is REFUSED rather than followed-and-written-through. Force
+    // (deliberate rotation) overwrites in place ("w"); the chmod re-assert
+    // below covers that path, where writeFileSync ignores `mode` on an
+    // already-existing file.
+    writeFileSync(path, privateKeyB64 + "\n", {
+      mode: 0o600,
+      ...(force ? {} : { flag: "wx" }),
+    });
+  } catch (err) {
+    const e = err as NodeJS.ErrnoException;
+    if (e.code === "EEXIST") {
+      return {
+        ok: false,
+        reason:
+          `refusing to overwrite existing file at ${path} — rotating the registry ` +
+          `signing key is a federation-wide event (every consumer must re-pin). ` +
+          `Pass --force to rotate deliberately.`,
+      };
+    }
+    return { ok: false, reason: `failed to write ${path}: ${e.message}` };
+  }
+  // Defensive: an inherited umask can clear bits from the create-mode on some
+  // platforms, so re-assert 600 explicitly. No-op on POSIX where the create
+  // mode already took; harmless on win32 (ACL-governed).
+  if (process.platform !== "win32") {
+    try {
+      chmodSync(path, 0o600);
+    } catch (err) {
+      return {
+        ok: false,
+        reason: `wrote ${path} but failed to chmod 600: ${err instanceof Error ? err.message : String(err)}`,
+      };
+    }
+  }
+  return { ok: true };
+}
+
+// =============================================================================
+// Rendering
+// =============================================================================
+
+function renderHuman(args: {
+  privateKeyB64: string;
+  publicKeyB64: string;
+  fingerprint: string;
+  outNote: string | undefined;
+}): string {
+  const { privateKeyB64, publicKeyB64, fingerprint, outNote } = args;
+  return [
+    `network-registry: generated a fresh Ed25519 signing keypair`,
+    ``,
+    `  fingerprint:  ${fingerprint}`,
+    `  public key:   ${publicKeyB64}`,
+    ...(outNote !== undefined ? [`  private file: ${outNote}`] : []),
+    ``,
+    `─── REGISTRY_SIGNING_KEY (SECRET — base64 PKCS#8 Ed25519 private key) ───`,
+    privateKeyB64,
+    `────────────────────────────────────────────────────────────────────────`,
+    ``,
+    `Next steps:`,
+    ``,
+    `  1. Set the secret on the Worker (paste the SECRET line above when prompted):`,
+    `       bunx wrangler secret put REGISTRY_SIGNING_KEY --env production`,
+    ``,
+    `  2. Pin the PUBLIC key on every consuming cortex (cortex.yaml):`,
+    `       policy:`,
+    `         federated:`,
+    `           registry:`,
+    `             url: https://network.meta-factory.ai`,
+    `             pubkey: ${publicKeyB64}`,
+    ``,
+    `  3. (Optional) The Worker derives its pubkey from the secret at boot via`,
+    `     pubkeyFromPkcs8(). Set REGISTRY_PUBLIC_KEY only if you want to skip`,
+    `     that derivation — it must equal the public key above.`,
+    ``,
+    `The private key is the registry's federation-wide trust anchor. Anyone`,
+    `holding it can forge a signed assertion for ANY principal. Keep it ONLY as`,
+    `a Worker secret — never in cortex.yaml, never in a log, never committed.`,
+    ``,
+  ].join("\n");
+}
+
+// =============================================================================
+// Result builders
+// =============================================================================
+
+function ok(stdout: string): KeygenResult {
+  return { exitCode: 0, stdout, stderr: "" };
+}
+
+function opError(reason: string, json: boolean): KeygenResult {
+  const stderr = json
+    ? JSON.stringify({ status: "error", items: [], error: { reason } }, null, 2) + "\n"
+    : `generate-registry-keypair: ${reason}\n`;
+  return { exitCode: 1, stdout: "", stderr };
+}
+
+function usageError(reason: string): KeygenResult {
+  return { exitCode: 2, stdout: "", stderr: `generate-registry-keypair: ${reason}\n${helpText()}` };
+}
+
+// =============================================================================
+// Arg parsing + dispatch
+// =============================================================================
+
+export function parseArgs(argv: string[]): KeygenOptions | KeygenResult {
+  const opts: KeygenOptions = {};
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]!;
+    switch (arg) {
+      case "--json":
+        opts.json = true;
+        break;
+      case "--force":
+        opts.force = true;
+        break;
+      case "--out": {
+        const value = argv[i + 1];
+        if (value === undefined || value.startsWith("-")) {
+          return usageError(`--out requires a value`);
+        }
+        opts.out = value;
+        i++;
+        break;
+      }
+      case "--help":
+      case "-h":
+        return { exitCode: 0, stdout: helpText(), stderr: "" };
+      default:
+        return usageError(`unknown argument "${arg}"`);
+    }
+  }
+  return opts;
+}
+
+export async function dispatch(argv: string[]): Promise<KeygenResult> {
+  const parsed = parseArgs(argv);
+  if ("exitCode" in parsed) return parsed; // help or usage error
+  return generateRegistryKeypair(parsed);
+}
+
+function helpText(): string {
+  return `generate-registry-keypair — provision the network-registry signing keypair
+
+Usage:
+  bun run gen-key [--out <path>] [--force] [--json]
+
+Produces a fresh Ed25519 keypair:
+  • REGISTRY_SIGNING_KEY  base64 PKCS#8 private key — paste into wrangler secret put
+  • public key            base64 raw 32-byte pubkey — pin as policy.federated.registry.pubkey
+
+The generated key is verified to round-trip through the registry's OWN
+pubkeyFromPkcs8() before anything is emitted.
+
+Flags:
+  --out <path>   Also write the PKCS#8 private key to <path>, chmod 600
+                 (refuses to clobber an existing file without --force).
+  --force        Allow overwriting an existing --out file (deliberate rotation).
+  --json         Emit a { status, items, data } envelope instead of text.
+  --help, -h     Show this help.
+
+Secrets: the private key is printed once (clearly labelled) because you need it
+for wrangler. It is NEVER logged, and only written to disk with --out (chmod 600).
+`;
+}
+
+// =============================================================================
+// Main
+// =============================================================================
+
+if (import.meta.main) {
+  const result = await dispatch(process.argv.slice(2));
+  if (result.stdout) process.stdout.write(result.stdout);
+  if (result.stderr) process.stderr.write(result.stderr);
+  process.exit(result.exitCode);
+}

--- a/src/services/network-registry/tsconfig.json
+++ b/src/services/network-registry/tsconfig.json
@@ -14,6 +14,6 @@
     "isolatedModules": true,
     "noUncheckedIndexedAccess": true
   },
-  "include": ["src/**/*.ts", "__tests__/**/*.ts"],
+  "include": ["src/**/*.ts", "__tests__/**/*.ts", "scripts/**/*.ts"],
   "exclude": ["node_modules"]
 }

--- a/src/services/network-registry/wrangler.toml
+++ b/src/services/network-registry/wrangler.toml
@@ -37,12 +37,13 @@ ENVIRONMENT = "local"
 name = "cortex-network-registry-dev"
 workers_dev = false
 
-# Routes for dev are TBD — typically network-dev.meta-factory.ai once
-# DNS is provisioned. Listed here as placeholder; uncomment + tune at
-# deploy time. Same-zone TLS + CF Access still apply.
-# routes = [
-#   { pattern = "network-dev.meta-factory.ai/*", zone_name = "meta-factory.ai" }
-# ]
+# Dev route. The principal must create the proxied DNS record for
+# network-dev.meta-factory.ai in the meta-factory.ai zone, then
+# `wrangler deploy --env dev`. Same-zone TLS + CF Access still apply.
+# Additional TLDs (.dev/.io) can be added analogously if multi-TLD is wanted.
+routes = [
+  { pattern = "network-dev.meta-factory.ai/*", zone_name = "meta-factory.ai" }
+]
 
 [env.dev.vars]
 ENVIRONMENT = "development"
@@ -54,19 +55,28 @@ ENVIRONMENT = "development"
 name = "cortex-network-registry"
 workers_dev = false
 
-# routes = [
-#   { pattern = "network.meta-factory.ai/*", zone_name = "meta-factory.ai" }
-# ]
+# Production route. The principal must create the proxied DNS record for
+# network.meta-factory.ai in the meta-factory.ai zone, then
+# `wrangler deploy --env production`. Same-zone TLS + CF Access still apply.
+# Additional TLDs (.dev/.io) can be added analogously if multi-TLD is wanted.
+routes = [
+  { pattern = "network.meta-factory.ai/*", zone_name = "meta-factory.ai" }
+]
 
 [env.production.vars]
 ENVIRONMENT = "production"
 
 # Secrets (set via `wrangler secret put --env production`):
-#   REGISTRY_SIGNING_KEY  — base64-encoded Ed25519 private key used to
-#                           sign GET responses (registry assertions).
-#                           Generate with:
+#   REGISTRY_SIGNING_KEY  — base64-encoded PKCS#8 Ed25519 private key used
+#                           to sign GET responses (registry assertions).
+#                           Format: base64 PKCS#8 Ed25519 private key — the
+#                           exact shape the Worker derives its pubkey from via
+#                           pubkeyFromPkcs8() (src/signing.ts) at boot. (NOT a
+#                           raw seed+pubkey concatenation — #677.)
+#                           Generate one with:
+#                             bun run gen-key            # in this directory
+#                           then paste the printed REGISTRY_SIGNING_KEY value:
 #                             bunx wrangler secret put REGISTRY_SIGNING_KEY
-#                           Format: 64 raw bytes (seed + pubkey),
-#                           base64-encoded. The corresponding public key
-#                           is exposed at GET /registry/pubkey so peers
-#                           can pin it at config time.
+#                           The corresponding public key is exposed at
+#                           GET /registry/pubkey so peers can pin it at
+#                           config time (and is printed by `gen-key`).


### PR DESCRIPTION
Closes the headline network-registry provisioning gap flagged in `docs/sop-network-registry.md` and fixes the format discrepancy in #677.

## The gap

`docs/sop-network-registry.md` (just merged) flagged that there is **no** command to generate the network-registry's own signing keypair — principals were told to `wrangler secret put REGISTRY_SIGNING_KEY` and paste a base64 key, but nothing MADE one. And #677: `wrangler.toml` said the format is "64 raw bytes (seed + pubkey)" while the running code (`pubkeyFromPkcs8` in `src/signing.ts`) consumes **base64 PKCS#8**. The code is authoritative.

## The command — `bun run gen-key`

`src/services/network-registry/scripts/generate-registry-keypair.ts`:
- Generates an **Ed25519** keypair via WebCrypto (`crypto.subtle.generateKey("Ed25519", …)`).
- Exports the PRIVATE key as **PKCS#8 → base64** (the `REGISTRY_SIGNING_KEY` secret value).
- Exports the PUBLIC key as **raw → base64** (pin as `policy.federated.registry.pubkey`, optional `REGISTRY_PUBLIC_KEY`).
- Prints a fingerprint + copy-pasteable next steps (`wrangler secret put`, the cortex.yaml pin block).

**Where it lives + why:** in the registry service itself, not the cortex CLI. The registry signing key is the registry's own concern, and living here lets the script import `../src/signing.ts` directly — reusing the **exact** `generateKeypair` + `pubkeyFromPkcs8` the Worker runs. The alternative (a `cortex` CLI subcommand) would have to reach across the root↔Worker bundle boundary (the registry is excluded from the root tsconfig) and re-derive PKCS#8 handling — the same coupling `stack-provisioning.ts` carries for the per-stack NKey case, with no NKey bridge here to justify it.

## Correctness contract (load-bearing)

Before emitting anything, the command asserts — and a test pins — that:

```
pubkeyFromPkcs8(<emitted PKCS#8 base64>) === <emitted raw-public base64>
```

i.e. the generated key round-trips through the registry's **own** derive path. If it doesn't, the key is useless to the Worker, so the command refuses to emit and exits non-zero. A second test signs a sample assertion with the generated key and verifies it through the registry's own `verifyEd25519` against the emitted pubkey (end-to-end).

## Secrets discipline (mirrors TC-1b `provision-stack`)

- The private key is the **single labelled SECRET** stdout line (the principal needs it for `wrangler secret put`); never logged.
- `--out <path>` writes the private key **chmod 600** with an `O_EXCL` refuse-clobber (symlink-safe, write-through refused); `--force` for deliberate rotation.
- Tests assert the secret appears exactly once and never leaks on the error path.

## #677 fix — PKCS#8 authoritative

`wrangler.toml`'s secret-format comment corrected from "64 raw bytes (seed + pubkey)" to **base64 PKCS#8 Ed25519 private key**. `index.ts` JSDoc, `README.md`, `wrangler.toml`, and `gen-key` now all agree on PKCS#8.

## Also folded in (same files)

- **DNS routes** set in `wrangler.toml`: `network.meta-factory.ai/*` (prod) / `network-dev.meta-factory.ai/*` (dev), matching the gh-webhook + mc-worker `{ pattern, zone_name }` shape. Config only — the principal provisions the proxied DNS record + deploys.
- **Runbook** (`sop-network-registry.md`): replaced the "⚠️ not yet implemented — keypair command" callout with the real command, resolved the format-discrepancy callout, and updated the DNS callout to "config done, principal provisions DNS + deploys". The in-memory-persistence callout is kept as-is (separate slice).

## Tests / verify

- New test suite (13 tests) — all keys are throwaway, all FS state in `mkdtemp` temp dirs. **No real key generated or committed.**
- Registry suite green (56 pass), root `bunx tsc --noEmit` clean, `bun run lint:errors` clean, `scripts/check-carveouts.sh` PASS (principal vocabulary).

Closes #677.

🤖 Generated with [Claude Code](https://claude.com/claude-code)