### PR TITLE
feat(bus): TC-4d/4e — transport mTLS (NATS + cloud-publisher) + non-TLS federated-leaf warning

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -132,6 +132,10 @@ export default tseslint.config(
       "src/taps/gh-webhook/",
       "src/surface/mc/dashboard-v2/",
       "**/*.bak.ts",
+      // TC-4e — Node-subprocess mTLS test server (runs under Node, not Bun;
+      // raw node:https + process.stdout protocol). Not part of the typed
+      // project, same as the scripts/ carve-out below.
+      "src/taps/cc-events/__tests__/mtls-wire-server.mjs",
       "eslint.config.js",
       "scripts/",
       ".github/scripts/",

--- a/src/bus/myelin/__tests__/runtime-transport-mtls.test.ts
+++ b/src/bus/myelin/__tests__/runtime-transport-mtls.test.ts
@@ -1,0 +1,259 @@
+/**
+ * TC-4d / TC-4e (#627 Phase 4) — MyelinRuntime LinkPool transport-mTLS wiring.
+ *
+ * Asserts that the `transportMtls` posture threads the built `tls` block into
+ * the nats.js connect options for BOTH the primary link AND each federated
+ * leaf link, and that the federated-leaf-without-TLS advisory fires:
+ *
+ *   - mtls off (default) → NO `tls` on any connect opts (back-compat: the
+ *     connect options are byte-identical to the pre-TC-4d path).
+ *   - mtls on → `tls` (cert/key/ca contents) present on primary + leaf opts.
+ *   - federated leaf without TLS (mtls off, nats:// leaf) → the structured
+ *     cleartext sink fires for that leaf.
+ *
+ * Uses the `connectImpl` fake-link seam to capture each link's `ConnectionOptions`
+ * — no real `nats-server`, no real TLS handshake. Cert material is throwaway PEM
+ * text in a temp dir (the builder reads bytes, it does not parse X.509).
+ */
+
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { chmodSync, mkdirSync, rmSync, writeFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import type {
+  ConnectionOptions,
+  NatsConnection,
+  Status,
+  Subscription,
+} from "nats";
+import type { AgentConfig } from "../../../common/types/config";
+import type { PolicyFederatedNetwork } from "../../../common/types/cortex-config";
+import type { FederatedCleartextWarning } from "../../../common/config/transport-mtls";
+import { startMyelinRuntime } from "../runtime";
+
+let testDir: string;
+let certPath: string;
+let keyPath: string;
+let caPath: string;
+
+beforeEach(() => {
+  testDir = join(
+    tmpdir(),
+    `cortex-runtime-mtls-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(testDir, { recursive: true });
+  certPath = join(testDir, "client.crt");
+  keyPath = join(testDir, "client.key");
+  caPath = join(testDir, "ca.crt");
+  writeFileSync(certPath, "-----BEGIN CERTIFICATE-----\nCRT\n-----END CERTIFICATE-----\n");
+  writeFileSync(keyPath, "-----BEGIN PRIVATE KEY-----\nKEY\n-----END PRIVATE KEY-----\n");
+  writeFileSync(caPath, "-----BEGIN CERTIFICATE-----\nCA\n-----END CERTIFICATE-----\n");
+  chmodSync(keyPath, 0o600);
+});
+
+afterEach(() => {
+  rmSync(testDir, { recursive: true, force: true });
+});
+
+/**
+ * Fake NATS connection — only the surface `startMyelinRuntime` touches. The
+ * status loop AND every subscriber iterator terminate on `drain()` so
+ * `runtime.stop()` resolves promptly (no 5s status-loop close timeout).
+ */
+function makeFakeConn(): NatsConnection {
+  const statusListeners = new Set<(s: Status | null) => void>();
+  const status = () =>
+    (async function* () {
+      const queue: (Status | null)[] = [];
+      let waiter: ((s: Status | null) => void) | null = null;
+      const listener = (s: Status | null) => {
+        if (waiter) {
+          const w = waiter;
+          waiter = null;
+          w(s);
+        } else {
+          queue.push(s);
+        }
+      };
+      statusListeners.add(listener);
+      try {
+        while (true) {
+          if (queue.length > 0) {
+            const next = queue.shift()!;
+            if (next === null) return;
+            yield next;
+            continue;
+          }
+          const next = await new Promise<Status | null>((r) => (waiter = r));
+          if (next === null) return;
+          yield next;
+        }
+      } finally {
+        statusListeners.delete(listener);
+      }
+    })();
+  const subscribe = mock(() => {
+    let iteratorResolve: (() => void) | null = null;
+    const iteratorDone = new Promise<void>((r) => {
+      iteratorResolve = r;
+    });
+    // eslint-disable-next-line require-yield
+    const iterator = (async function* () {
+      await iteratorDone;
+    })();
+    return {
+      [Symbol.asyncIterator]: () => iterator,
+      drain: mock(async () => {
+        iteratorResolve?.();
+      }),
+      closed: Promise.resolve(),
+    } as unknown as Subscription;
+  });
+  const drain = mock(async () => {
+    for (const l of statusListeners) l(null);
+  });
+  const publish = mock(() => {});
+  return { status, subscribe, drain, publish } as unknown as NatsConnection;
+}
+
+/** A connectImpl that records the ConnectionOptions of every link it opens. */
+function makeRecordingConnect(): {
+  connectImpl: (opts: ConnectionOptions) => Promise<NatsConnection>;
+  opts: ConnectionOptions[];
+} {
+  const opts: ConnectionOptions[] = [];
+  const connectImpl = async (o: ConnectionOptions): Promise<NatsConnection> => {
+    opts.push(o);
+    return makeFakeConn();
+  };
+  return { connectImpl, opts };
+}
+
+function makeConfig(url: string): AgentConfig {
+  return {
+    agent: { name: "luna", displayName: "Luna" },
+    nats: { url, name: "cortex", subjects: [] },
+  } as unknown as AgentConfig;
+}
+
+function makeNetwork(overrides: Partial<PolicyFederatedNetwork>): PolicyFederatedNetwork {
+  return {
+    id: "research-collab",
+    leaf_node: "nats-leaf-research",
+    peers: [],
+    accept_subjects: [],
+    deny_subjects: [],
+    announce_capabilities: [],
+    max_hop: 0,
+    ...overrides,
+  };
+}
+
+describe("MyelinRuntime transport mTLS (TC-4d/4e)", () => {
+  test("mtls off → NO tls on the primary connect opts (back-compat)", async () => {
+    const { connectImpl, opts } = makeRecordingConnect();
+    const runtime = await startMyelinRuntime(makeConfig("nats://localhost:4222"), {
+      connectImpl,
+      transportMtls: { mode: "off", paths: { cert_path: certPath, key_path: keyPath } },
+    });
+    expect(runtime.enabled).toBe(true);
+    expect(opts).toHaveLength(1);
+    expect(opts[0]).not.toHaveProperty("tls");
+    await runtime.stop();
+  });
+
+  test("transportMtls omitted entirely → NO tls (zero-config default)", async () => {
+    const { connectImpl, opts } = makeRecordingConnect();
+    const runtime = await startMyelinRuntime(makeConfig("nats://localhost:4222"), {
+      connectImpl,
+    });
+    expect(opts[0]).not.toHaveProperty("tls");
+    await runtime.stop();
+  });
+
+  test("mtls on → tls (cert/key/ca) present on the PRIMARY connect opts", async () => {
+    const { connectImpl, opts } = makeRecordingConnect();
+    const runtime = await startMyelinRuntime(makeConfig("nats://localhost:4222"), {
+      connectImpl,
+      transportMtls: {
+        mode: "on",
+        paths: { cert_path: certPath, key_path: keyPath, ca_path: caPath },
+      },
+    });
+    expect(opts).toHaveLength(1);
+    const tls = (opts[0] as { tls?: { cert?: string; key?: string; ca?: string } }).tls;
+    expect(tls).toBeDefined();
+    expect(tls?.cert).toContain("BEGIN CERTIFICATE");
+    expect(tls?.key).toContain("BEGIN PRIVATE KEY");
+    expect(tls?.ca).toContain("BEGIN CERTIFICATE");
+    // Hard line — no skip-verify on the wire opts.
+    expect(tls).not.toHaveProperty("rejectUnauthorized");
+    await runtime.stop();
+  });
+
+  test("mtls on → tls present on BOTH primary AND each federated leaf opts", async () => {
+    const { connectImpl, opts } = makeRecordingConnect();
+    const network = makeNetwork({
+      id: "research-collab",
+      leaf_node: "nats-leaf-research",
+      nats: { url: "nats://research:4222", name: "cortex-research" },
+    });
+    const runtime = await startMyelinRuntime(makeConfig("nats://localhost:4222"), {
+      connectImpl,
+      federatedNetworks: [network],
+      transportMtls: {
+        mode: "on",
+        paths: { cert_path: certPath, key_path: keyPath, ca_path: caPath },
+      },
+    });
+    // Two links: primary + the one federated leaf — both carry tls.
+    expect(opts).toHaveLength(2);
+    for (const o of opts) {
+      const tls = (o as { tls?: { cert?: string } }).tls;
+      expect(tls).toBeDefined();
+      expect(tls?.cert).toContain("BEGIN CERTIFICATE");
+    }
+    await runtime.stop();
+  });
+
+  test("federated leaf without TLS → cleartext warning sink fires (TC-4e)", async () => {
+    const { connectImpl } = makeRecordingConnect();
+    const warnings: FederatedCleartextWarning[] = [];
+    const network = makeNetwork({
+      id: "research-collab",
+      leaf_node: "nats-leaf-research",
+      // nats:// (not tls://) leaf + mtls off ⇒ cleartext federated leg.
+      nats: { url: "nats://research:4222", name: "cortex-research" },
+    });
+    const runtime = await startMyelinRuntime(makeConfig("nats://localhost:4222"), {
+      connectImpl,
+      federatedNetworks: [network],
+      transportMtls: {
+        mode: "off",
+        onFederatedCleartext: (info) => warnings.push(info),
+      },
+    });
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]?.leafId).toBe("nats-leaf-research");
+    expect(warnings[0]?.networkId).toBe("research-collab");
+    expect(warnings[0]?.safeUrl).toContain("research");
+    await runtime.stop();
+  });
+
+  test("federated leaf on a tls:// URL → NO cleartext warning", async () => {
+    const { connectImpl } = makeRecordingConnect();
+    const warnings: FederatedCleartextWarning[] = [];
+    const network = makeNetwork({
+      id: "research-collab",
+      leaf_node: "nats-leaf-research",
+      nats: { url: "tls://research:4222", name: "cortex-research" },
+    });
+    const runtime = await startMyelinRuntime(makeConfig("nats://localhost:4222"), {
+      connectImpl,
+      federatedNetworks: [network],
+      transportMtls: { mode: "off", onFederatedCleartext: (info) => warnings.push(info) },
+    });
+    expect(warnings).toHaveLength(0);
+    await runtime.stop();
+  });
+});

--- a/src/bus/myelin/runtime.ts
+++ b/src/bus/myelin/runtime.ts
@@ -18,6 +18,13 @@ import type { AgentConfig } from "../../common/types/config";
 import type { PolicyFederatedNetwork } from "../../common/types/cortex-config";
 import { NatsLink } from "../nats/connection";
 import {
+  buildNatsTlsOptions,
+  warnFederatedCleartext,
+  type MtlsMode,
+  type MtlsPaths,
+  type FederatedCleartextWarning,
+} from "../../common/config/transport-mtls";
+import {
   MyelinSubscriber,
   type EnvelopeErrorHandler,
   type EnvelopeHandler as SubscriberEnvelopeHandler,
@@ -444,6 +451,36 @@ export interface MyelinRuntimeOptions {
     setTimer: (cb: () => void, ms: number) => ReconnectTimerHandle;
     clearTimer: (handle: ReconnectTimerHandle) => void;
   };
+  /**
+   * TC-4d/4e (#627 Phase 4) — transport-mTLS posture for the LinkPool. The
+   * runtime builds a `tls` block (via `buildNatsTlsOptions`) for the PRIMARY
+   * link AND each federated leaf link, gated by `mode`:
+   *
+   *   - `off` (default / omitted) — no `tls` on any link; plaintext,
+   *     byte-identical to the pre-TC-4d single-link AND F-3 multi-link paths.
+   *   - `on` — offer a client cert when the cert/key/ca paths load; degrade
+   *     to plaintext (loud warning) when they don't.
+   *   - `require` — every link MUST present a client cert; a missing/invalid
+   *     cert FAILS CLOSED (the connect throws — primary failure disables the
+   *     runtime, a leaf failure leaves that network dark per the F-3c contract).
+   *
+   * Cross-principal federated leaves especially want mTLS, so the same posture
+   * applies to leaf links — and a federated leaf that connects WITHOUT TLS
+   * triggers the {@link warnFederatedCleartext} advisory regardless of mode.
+   *
+   * **Back-compat:** when omitted (or `mode: "off"`), no tls machinery
+   * engages — the pool is byte-identical to today.
+   */
+  transportMtls?: {
+    mode: MtlsMode;
+    paths?: MtlsPaths;
+    /**
+     * Optional structured sink for the federated-leaf-cleartext warning. The
+     * runtime has no `SystemEventSource`; a caller that does can pass a sink
+     * here to promote the stderr advisory to a `system.error` audit envelope.
+     */
+    onFederatedCleartext?: (info: FederatedCleartextWarning) => void;
+  };
 }
 
 /**
@@ -706,6 +743,15 @@ export async function startMyelinRuntime(
   // reference avoid a forbidden non-null assertion on the now-nullable
   // `PoolLink.link`. Primary is the ONE link guaranteed live past this block.
   let primaryLink: NatsLink;
+  // TC-4d (#627 Phase 4) — transport-mTLS posture for the whole pool. `off`
+  // (default / omitted) builds no tls block on any link ⇒ plaintext,
+  // byte-identical to today. `require` fails closed at connect (a missing/
+  // invalid cert throws below, which for the primary disables the runtime).
+  const mtlsMode: MtlsMode = options?.transportMtls?.mode ?? "off";
+  const mtlsPaths: MtlsPaths | undefined = options?.transportMtls?.paths;
+  const primaryTls = buildNatsTlsOptions(mtlsMode, mtlsPaths, {
+    site: "primary link",
+  });
   try {
     primaryLink = await NatsLink.connect({
       url: nats.url,
@@ -715,6 +761,8 @@ export async function startMyelinRuntime(
       // credsPath wins with a warn log.
       ...(nats.credsPath ? { credsPath: nats.credsPath } : {}),
       name: nats.name,
+      // TC-4d: transport mTLS (undefined ⇒ plaintext, unchanged).
+      ...(primaryTls !== undefined ? { tls: primaryTls } : {}),
       ...(options?.connectImpl ? { connectImpl: options.connectImpl } : {}),
     });
     primary = {
@@ -883,12 +931,36 @@ export async function startMyelinRuntime(
     if (network.nats === undefined) continue; // rides primary — resolved in PASS 2.
     const leafId = network.leaf_node;
     if (pool.has(leafId)) continue; // already built by an earlier sharing network.
+    // TC-4d (#627 Phase 4) — same transport-mTLS posture as the primary,
+    // applied per-leaf. Cross-principal federated leaves especially want
+    // mTLS; under `require` a leaf with a missing/invalid cert throws below
+    // and that network goes dark (F-3c degrade-don't-crash), while primary is
+    // unaffected. `off` ⇒ no tls block ⇒ plaintext, byte-identical to today.
+    const leafTls = buildNatsTlsOptions(mtlsMode, mtlsPaths, {
+      site: `leaf "${leafId}"`,
+    });
+    // TC-4e — a FEDERATED leaf that ends up WITHOUT TLS is a cross-principal
+    // cleartext-confidentiality risk. Warn loudly (advisory, regardless of
+    // posture) when neither a tls block was built NOR the URL is `tls://`.
+    const leafProtected = leafTls !== undefined || network.nats.url.startsWith("tls://");
+    if (!leafProtected) {
+      warnFederatedCleartext(
+        {
+          leafId,
+          networkId: network.id,
+          safeUrl: safeUrlOf(network.nats.url),
+        },
+        options?.transportMtls?.onFederatedCleartext,
+      );
+    }
     // The connect options retained on the PoolLink so the F-3c background-
     // reconnect scheduler can re-attempt with the SAME parameters.
     const leafConnectOpts: Parameters<typeof NatsLink.connect>[0] = {
       url: network.nats.url,
       ...(network.nats.credsPath ? { credsPath: network.nats.credsPath } : {}),
       name: network.nats.name,
+      // TC-4d: transport mTLS for this leaf (undefined ⇒ plaintext).
+      ...(leafTls !== undefined ? { tls: leafTls } : {}),
       ...(options?.connectImpl ? { connectImpl: options.connectImpl } : {}),
     };
     try {

--- a/src/bus/nats/connection.ts
+++ b/src/bus/nats/connection.ts
@@ -20,6 +20,7 @@ import {
   Events,
   type ConnectionOptions,
   type NatsConnection,
+  type TlsOptions,
 } from "nats";
 import { enforceChmod600 } from "../../common/config/file-permissions";
 import { expandTilde } from "../../common/config/loader";
@@ -42,6 +43,22 @@ export interface NatsLinkOptions {
   credsPath?: string;
   /** Connection name surfaced on the server's `varz` endpoint. */
   name?: string;
+  /**
+   * TC-4d (#627 Phase 4) — transport-mTLS options for this connection. When
+   * present, it is passed straight through to nats.js's `connect({ tls })` so
+   * the client presents its certificate and verifies the server's. When
+   * `undefined` (the default), no `tls` block is sent and the connection is
+   * plaintext NKey/JWT auth — byte-identical to pre-TC-4d.
+   *
+   * Built by `buildNatsTlsOptions` (`src/common/config/transport-mtls.ts`)
+   * from the `security.transport.mtls` posture + cert/key/ca paths. This
+   * wrapper is deliberately dumb: it does NOT read posture or load files — the
+   * caller builds the (already chmod-600-gated, contents-loaded) options and
+   * passes them in. It NEVER injects `rejectUnauthorized:false` or any
+   * skip-verify hatch (CLAUDE.md hard line); the contents-or-undefined shape
+   * is the whole contract.
+   */
+  tls?: TlsOptions;
   /** Override the underlying nats `connect` function (test seam). */
   connectImpl?: (opts: ConnectionOptions) => Promise<NatsConnection>;
 }
@@ -117,6 +134,13 @@ export class NatsLink {
       name,
       // Defer reconnect to the underlying client; we just log status.
       reconnect: true,
+      // TC-4d (#627 Phase 4) — transport mTLS. When the caller built a `tls`
+      // block (posture `on`/`require` with a loaded client cert), pass it
+      // through verbatim so the node transport negotiates mutual TLS. Omitted
+      // entirely when undefined ⇒ plaintext, byte-identical to pre-TC-4d. We
+      // never set `rejectUnauthorized` — nats.js defaults it to `true` (both
+      // sides verify) and we never weaken that (CLAUDE.md hard line).
+      ...(opts.tls !== undefined ? { tls: opts.tls } : {}),
     };
 
     if (opts.credsPath) {

--- a/src/common/config/__tests__/transport-mtls.test.ts
+++ b/src/common/config/__tests__/transport-mtls.test.ts
@@ -1,0 +1,248 @@
+/**
+ * TC-4d / TC-4e (#627 Phase 4) — tests for the transport-mTLS options builder.
+ *
+ * Covers the DECIDED mode mapping + the secret/safety contract:
+ *   - off → undefined (no tls block; plaintext, byte-identical to today).
+ *   - on  → builds tls when cert/key load; degrades (warn, no throw) when not.
+ *   - require → builds tls; FAILS CLOSED (throws) on missing/invalid material.
+ *   - key file not chmod-600 → rejected (mirrors the nkey-seed loader gate).
+ *   - cert/key/ca CONTENTS never appear in any stderr line (paths + fingerprint
+ *     only).
+ *   - the federated-leaf-without-TLS advisory fires (stderr + structured sink).
+ *
+ * Throwaway cert/key/ca material is written to a per-test temp dir. The builder
+ * reads bytes and threads them into the tls object — it does NOT parse PEM — so
+ * deterministic dummy material exercises every branch without standing up a
+ * real TLS server or generating real X.509 chains.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { chmodSync, mkdirSync, rmSync, writeFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import {
+  buildNatsTlsOptions,
+  buildHttpsMtlsMaterial,
+  warnFederatedCleartext,
+  type MtlsPaths,
+} from "../transport-mtls";
+
+let testDir: string;
+
+beforeEach(() => {
+  testDir = join(
+    tmpdir(),
+    `cortex-transport-mtls-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(testDir, { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(testDir, { recursive: true, force: true });
+});
+
+/** Distinctive throwaway contents so a leak into a log line is detectable. */
+const CERT_PEM = "-----BEGIN CERTIFICATE-----\nTESTCERTBYTES-DEADBEEF\n-----END CERTIFICATE-----\n";
+const KEY_PEM = "-----BEGIN PRIVATE KEY-----\nTESTKEYBYTES-S3CR3T-DO-NOT-LOG\n-----END PRIVATE KEY-----\n";
+const CA_PEM = "-----BEGIN CERTIFICATE-----\nTESTCABYTES-CAFEBABE\n-----END CERTIFICATE-----\n";
+
+/** Write cert+key (+optional CA) at the given key mode; return the paths. */
+function writeCertMaterial(keyMode: number, withCa = true): MtlsPaths {
+  const certPath = join(testDir, "client.crt");
+  const keyPath = join(testDir, "client.key");
+  writeFileSync(certPath, CERT_PEM);
+  writeFileSync(keyPath, KEY_PEM);
+  chmodSync(keyPath, keyMode);
+  if (withCa) {
+    const caPath = join(testDir, "ca.crt");
+    writeFileSync(caPath, CA_PEM);
+    chmodSync(caPath, 0o644); // CA is public material — any mode is fine.
+    return { cert_path: certPath, key_path: keyPath, ca_path: caPath };
+  }
+  return { cert_path: certPath, key_path: keyPath };
+}
+
+/** Capture every `process.stderr.write` during `fn` and return the joined text. */
+function captureStderr(fn: () => void): string {
+  const original = process.stderr.write.bind(process.stderr);
+  let captured = "";
+  process.stderr.write = ((chunk: string | Uint8Array): boolean => {
+    captured += typeof chunk === "string" ? chunk : new TextDecoder().decode(chunk);
+    return true;
+  });
+  try {
+    fn();
+  } finally {
+    process.stderr.write = original;
+  }
+  return captured;
+}
+
+describe("buildNatsTlsOptions", () => {
+  test("off → undefined (no tls block; plaintext back-compat)", () => {
+    const paths = writeCertMaterial(0o600);
+    const out = captureStderr(() => {
+      const tls = buildNatsTlsOptions("off", paths, { site: "primary link" });
+      expect(tls).toBeUndefined();
+    });
+    // off must be silent + emit nothing — byte-identical to today.
+    expect(out).toBe("");
+  });
+
+  test("off with NO paths → undefined (the zero-config default)", () => {
+    const tls = buildNatsTlsOptions("off", undefined, { site: "primary link" });
+    expect(tls).toBeUndefined();
+  });
+
+  test("on → builds tls (cert/key/ca contents) when material loads", () => {
+    const paths = writeCertMaterial(0o600);
+    const tls = buildNatsTlsOptions("on", paths, { site: "primary link" });
+    expect(tls).toBeDefined();
+    expect(tls?.cert).toBe(CERT_PEM);
+    expect(tls?.key).toBe(KEY_PEM);
+    expect(tls?.ca).toBe(CA_PEM);
+  });
+
+  test("on without a CA → builds tls, omits ca (system trust store)", () => {
+    const paths = writeCertMaterial(0o600, /* withCa */ false);
+    const tls = buildNatsTlsOptions("on", paths, { site: "primary link" });
+    expect(tls).toBeDefined();
+    expect(tls?.cert).toBe(CERT_PEM);
+    expect(tls).not.toHaveProperty("ca");
+  });
+
+  test("NEVER emits rejectUnauthorized / skip-verify (no-weaken hard line)", () => {
+    const paths = writeCertMaterial(0o600);
+    const tls = buildNatsTlsOptions("require", paths, { site: "primary link" });
+    expect(tls).toBeDefined();
+    // The tls object must carry ONLY cert/key/ca — no insecure escape hatch.
+    expect(tls).not.toHaveProperty("rejectUnauthorized");
+    expect(JSON.stringify(tls)).not.toContain("rejectUnauthorized");
+    expect(JSON.stringify(tls)).not.toContain("insecure");
+  });
+
+  test("on with NO cert paths → undefined (degrade to plaintext) + warns", () => {
+    const out = captureStderr(() => {
+      const tls = buildNatsTlsOptions("on", undefined, { site: "primary link" });
+      expect(tls).toBeUndefined();
+    });
+    expect(out).toMatch(/WARNING/);
+    expect(out).toMatch(/cert_path, key_path/);
+  });
+
+  test("require with NO cert paths → FAILS CLOSED (throws, no plaintext)", () => {
+    expect(() =>
+      buildNatsTlsOptions("require", undefined, { site: "primary link" }),
+    ).toThrow(/require.*missing.*refusing to connect/s);
+  });
+
+  test("require with a missing cert FILE → FAILS CLOSED (throws)", () => {
+    const paths: MtlsPaths = {
+      cert_path: join(testDir, "nope.crt"),
+      key_path: join(testDir, "nope.key"),
+    };
+    expect(() =>
+      buildNatsTlsOptions("require", paths, { site: "primary link" }),
+    ).toThrow(/require.*failed to load|ENOENT|no such file/s);
+  });
+
+  test("require + key NOT chmod-600 → rejected (mirrors nkey-seed gate)", () => {
+    const paths = writeCertMaterial(0o644);
+    expect(() =>
+      buildNatsTlsOptions("require", paths, { site: "primary link" }),
+    ).toThrow(/chmod 600/);
+  });
+
+  test("on + key NOT chmod-600 → degrades to plaintext (warns, no throw)", () => {
+    const paths = writeCertMaterial(0o644);
+    const out = captureStderr(() => {
+      const tls = buildNatsTlsOptions("on", paths, { site: "primary link" });
+      expect(tls).toBeUndefined();
+    });
+    expect(out).toMatch(/WARNING/);
+    expect(out).toMatch(/chmod 600/);
+  });
+
+  test("NEVER logs cert/key/ca CONTENTS — only paths + a fingerprint", () => {
+    const paths = writeCertMaterial(0o600);
+    const out = captureStderr(() => {
+      buildNatsTlsOptions("require", paths, { site: "primary link" });
+    });
+    // The private-key bytes and the distinctive cert/CA bytes must not leak.
+    expect(out).not.toContain("TESTKEYBYTES-S3CR3T-DO-NOT-LOG");
+    expect(out).not.toContain("TESTCERTBYTES-DEADBEEF");
+    expect(out).not.toContain("TESTCABYTES-CAFEBABE");
+    expect(out).not.toContain("BEGIN PRIVATE KEY");
+    // But it DOES carry a fingerprint for audit/join.
+    expect(out).toMatch(/fingerprint sha256:[0-9a-f]{16}/);
+  });
+});
+
+describe("buildHttpsMtlsMaterial (cloud-publisher leg)", () => {
+  test("off → undefined (ordinary server-auth HTTPS, back-compat)", () => {
+    const paths = writeCertMaterial(0o600);
+    const mat = buildHttpsMtlsMaterial("off", paths, { site: "cloud-publisher" });
+    expect(mat).toBeUndefined();
+  });
+
+  test("on → cert/key/ca material when it loads", () => {
+    const paths = writeCertMaterial(0o600);
+    const mat = buildHttpsMtlsMaterial("on", paths, { site: "cloud-publisher" });
+    expect(mat).toEqual({ cert: CERT_PEM, key: KEY_PEM, ca: CA_PEM });
+  });
+
+  test("require with missing material → FAILS CLOSED (throws)", () => {
+    expect(() =>
+      buildHttpsMtlsMaterial("require", undefined, { site: "cloud-publisher" }),
+    ).toThrow(/require.*missing.*refusing to send/s);
+  });
+
+  test("require + key not chmod-600 → rejected", () => {
+    const paths = writeCertMaterial(0o644);
+    expect(() =>
+      buildHttpsMtlsMaterial("require", paths, { site: "cloud-publisher" }),
+    ).toThrow(/chmod 600/);
+  });
+
+  test("never carries a skip-verify field", () => {
+    const paths = writeCertMaterial(0o600);
+    const mat = buildHttpsMtlsMaterial("require", paths, { site: "cloud-publisher" });
+    expect(JSON.stringify(mat)).not.toContain("rejectUnauthorized");
+    expect(JSON.stringify(mat)).not.toContain("insecure");
+  });
+});
+
+describe("warnFederatedCleartext", () => {
+  test("emits a loud stderr advisory AND invokes the structured sink", () => {
+    const seen: { leafId: string; networkId: string; safeUrl: string }[] = [];
+    const out = captureStderr(() => {
+      warnFederatedCleartext(
+        { leafId: "peer-leaf", networkId: "mf-prod", safeUrl: "nats://peer.example:4222" },
+        (info) => seen.push(info),
+      );
+    });
+    expect(out).toMatch(/WARNING/);
+    expect(out).toMatch(/federated leaf "peer-leaf"/);
+    expect(out).toMatch(/network=mf-prod/);
+    expect(out).toMatch(/WITHOUT TLS/);
+    expect(out).toMatch(/CLEARTEXT/);
+    // Structured sink received the same payload (audit-envelope promotion seam).
+    expect(seen).toHaveLength(1);
+    expect(seen[0]).toEqual({
+      leafId: "peer-leaf",
+      networkId: "mf-prod",
+      safeUrl: "nats://peer.example:4222",
+    });
+  });
+
+  test("stderr-only path works with no sink (default)", () => {
+    const out = captureStderr(() => {
+      warnFederatedCleartext({
+        leafId: "leaf-x",
+        networkId: "net-y",
+        safeUrl: "nats://x:4222",
+      });
+    });
+    expect(out).toMatch(/WARNING.*federated leaf "leaf-x"/s);
+  });
+});

--- a/src/common/config/transport-mtls.ts
+++ b/src/common/config/transport-mtls.ts
@@ -259,8 +259,16 @@ export function buildHttpsMtlsMaterial(
     const cert = readFileSync(expandedCert, "utf-8");
     const key = readFileSync(expandedKey, "utf-8");
     const ca = caPath !== undefined ? readFileSync(expandTilde(caPath), "utf-8") : undefined;
+    // TC-4e (review FIX-FIRST): do NOT claim "presenting client cert" here —
+    // loading the cert and ATTACHING it to a request init is not, by itself,
+    // proof the runtime puts it on the wire. That a Bun `fetch` with
+    // `tls: { cert, key, ca }` actually PRESENTS the client cert to a real
+    // mTLS-enforcing server is verified by the wire-level test
+    // (`taps/cc-events/__tests__/cloud-publisher.mtls-wire.test.ts`, a Node
+    // `requestCert` server observing the client CN). This line states only
+    // what we KNOW at THIS point: the material loaded and will be attached.
     process.stderr.write(
-      `transport.mtls=${mode}: ${ctx.site} presenting client cert ` +
+      `transport.mtls=${mode}: ${ctx.site} loaded client cert, will attach to the HTTPS leg ` +
         `(fingerprint sha256:${fingerprint(cert)}${ca !== undefined ? ", custom CA" : ", system CA"})\n`,
     );
     return { cert, key, ...(ca !== undefined ? { ca } : {}) };

--- a/src/common/config/transport-mtls.ts
+++ b/src/common/config/transport-mtls.ts
@@ -1,0 +1,333 @@
+/**
+ * TC-4d / TC-4e (Trust & Confidentiality, #627 Phase 4) — transport-mTLS
+ * options builder.
+ *
+ * Transport-layer defense-in-depth: mutual-TLS on the wire, gated by the
+ * `security.transport.mtls` posture toggle (TC-0, default OFF). This module is
+ * the single, DRY mapping from the posture's mTLS mode + a cert/key/ca path
+ * block to the concrete `tls` block nats.js's `connect({ tls })` consumes —
+ * applied at every connection site (primary link + per-network leaf links in
+ * the LinkPool, the cortex-relay, and the cloud-publisher→Worker leg).
+ *
+ * INDEPENDENT of the envelope-signing path (`security.signing` →
+ * `resolveSigningKnobs`): signing is an M3/M4 envelope-layer concern; mTLS is
+ * an M1/M2 transport-layer concern. They engage on orthogonal toggles.
+ *
+ * ## DECIDED mode mapping (a security decision — do not improvise)
+ *
+ * | `transport.mtls` | build tls? | missing/invalid cert/key/ca          |
+ * | ---------------- | ---------- | ------------------------------------ |
+ * | `off`            | never      | n/a — plaintext, byte-identical today |
+ * | `on`             | best-effort| warn, connect plaintext (offer mode) |
+ * | `require`        | always     | **FAIL CLOSED** — throw, never plaintext |
+ *
+ * - **off** — return `undefined`. No `tls` block is passed to `connect()`;
+ *   the connection is plaintext NKey/JWT auth, byte-identical to pre-TC-4d.
+ *   This is the load-bearing back-compat invariant.
+ * - **on** — OFFER a client cert when the cert/key/ca paths are configured
+ *   and load cleanly. If they are absent or unreadable, log a warning and
+ *   return `undefined` (connect plaintext) — `on` is advisory, not enforcing.
+ * - **require** — REFUSE a non-mTLS connection. A missing, unreadable, or
+ *   bad-permission cert/key/ca is a hard error: this throws so the connect
+ *   site fails closed rather than silently downgrading to plaintext.
+ *
+ * ## Hard line (CLAUDE.md "NEVER disable authentication")
+ *
+ * This builder NEVER emits `rejectUnauthorized: false` or any skip-verify /
+ * insecure escape hatch. mTLS means BOTH sides verify: the server verifies our
+ * client cert, and our client verifies the server cert against the configured
+ * (or system) CA. nats.js's node transport defaults `rejectUnauthorized` to
+ * `true`; we leave it at that default and never override it.
+ *
+ * ## Secret discipline (CLAUDE.md "NEVER use empty catch blocks")
+ *
+ * - The private KEY file is chmod-600 gated via the shared `enforceChmod600`
+ *   (same gate as the nkey-seed / `.creds` loaders).
+ * - Cert/key/ca CONTENTS are NEVER logged — only paths and a short SHA-256
+ *   fingerprint of the client cert (for join/audit) ever reach a log line.
+ */
+
+import { readFileSync } from "fs";
+import { createHash } from "crypto";
+import type { TlsOptions } from "nats";
+import { enforceChmod600 } from "./file-permissions";
+import { expandTilde } from "./loader";
+
+/** The `transport.mtls` toggle's three settable values (mirrors the schema). */
+export type MtlsMode = "off" | "on" | "require";
+
+/**
+ * The cert/key/ca path block read from the posture config
+ * (`security.transport.tls`). All three are optional so a partial config
+ * surfaces a clear per-mode error rather than a schema rejection: a principal
+ * who sets `mtls: require` but forgets `key_path` should get a fail-closed
+ * connect error naming the missing field, not a silent plaintext fallback.
+ */
+export interface MtlsPaths {
+  /** Path to the PEM client certificate this stack presents. */
+  cert_path?: string;
+  /** Path to the PEM private key for `cert_path`. chmod-600 enforced. */
+  key_path?: string;
+  /** Path to the PEM CA bundle used to verify the server's cert. */
+  ca_path?: string;
+}
+
+/** Where this builder is being invoked — threaded into log lines for triage. */
+export interface MtlsContext {
+  /** e.g. "primary link", `leaf "<id>"`, "cortex-relay", "cloud-publisher". */
+  readonly site: string;
+}
+
+/**
+ * Short, non-sensitive fingerprint of a PEM blob — SHA-256, first 16 hex
+ * chars. Safe to log: it identifies WHICH cert is in play without revealing
+ * any key/cert bytes. Never call this on a private key.
+ */
+function fingerprint(pem: string): string {
+  return createHash("sha256").update(pem).digest("hex").slice(0, 16);
+}
+
+/**
+ * Build the nats.js `tls` options for a connection, gated by the mTLS posture
+ * mode. Returns `undefined` when no `tls` block should be passed (plaintext).
+ *
+ * Loads cert/key/ca CONTENTS (not paths) so the chmod-600 gate on the private
+ * key runs in OUR loader rather than being delegated to nats.js — same
+ * discipline as `loadCredsBytes` / `loadStackSigningKey`. Passing contents via
+ * `cert`/`key`/`ca` keeps the path off the nats.js side and lets us enforce the
+ * permission policy uniformly.
+ *
+ * @param mode  `security.transport.mtls`.
+ * @param paths `security.transport.tls` cert/key/ca path block (may be empty).
+ * @param ctx   Connection site label for log lines.
+ * @throws under `require` when cert/key/ca is absent, unreadable, or the key
+ *         file is not chmod-600 — the connect site MUST fail closed.
+ */
+export function buildNatsTlsOptions(
+  mode: MtlsMode,
+  paths: MtlsPaths | undefined,
+  ctx: MtlsContext,
+): TlsOptions | undefined {
+  // off — plaintext, byte-identical to pre-TC-4d. No tls block at all.
+  if (mode === "off") return undefined;
+
+  const certPath = paths?.cert_path;
+  const keyPath = paths?.key_path;
+  const caPath = paths?.ca_path;
+
+  // A complete client-cert triple is cert + key (+ optional CA for server
+  // verification; when ca_path is omitted the system trust store is used).
+  const haveClientCert = certPath !== undefined && keyPath !== undefined;
+
+  if (!haveClientCert) {
+    const missing = [
+      certPath === undefined ? "cert_path" : null,
+      keyPath === undefined ? "key_path" : null,
+    ]
+      .filter((m): m is string => m !== null)
+      .join(", ");
+    if (mode === "require") {
+      // Fail closed — never silently downgrade to plaintext under `require`.
+      throw new Error(
+        `transport.mtls=require but ${missing} missing for ${ctx.site}: ` +
+          `refusing to connect without a client certificate (no plaintext fallback)`,
+      );
+    }
+    // mode === "on" — advisory offer mode. No client cert configured ⇒
+    // connect plaintext, but say so loudly so the principal notices the gap.
+    process.stderr.write(
+      `WARNING: transport.mtls=on but ${missing} missing for ${ctx.site} — ` +
+        `connecting WITHOUT a client certificate (set security.transport.tls.{cert_path,key_path} to offer mTLS)\n`,
+    );
+    return undefined;
+  }
+
+  // Load the materials. Under `require` any failure (missing file, bad perms,
+  // unreadable CA) is fatal — propagate so the connect site fails closed.
+  // Under `on` a load failure degrades to plaintext with a loud warning.
+  try {
+    // certPath/keyPath are non-undefined here (haveClientCert gate above).
+    const expandedCert = expandTilde(certPath);
+    const expandedKey = expandTilde(keyPath);
+
+    // chmod-600 gate on the PRIVATE KEY only — same policy as the nkey-seed
+    // / `.creds` loaders. The cert + CA are public material; no perm gate.
+    enforceChmod600(expandedKey);
+
+    const cert = readFileSync(expandedCert, "utf-8");
+    const key = readFileSync(expandedKey, "utf-8");
+    const ca = caPath !== undefined ? readFileSync(expandTilde(caPath), "utf-8") : undefined;
+
+    // Pass CONTENTS, not paths. NEVER set rejectUnauthorized:false — both
+    // sides verify (CLAUDE.md hard line). When `ca` is omitted, nats.js's
+    // node transport verifies the server against the system trust store.
+    const tls: TlsOptions = {
+      cert,
+      key,
+      ...(ca !== undefined ? { ca } : {}),
+    };
+
+    process.stderr.write(
+      `transport.mtls=${mode}: ${ctx.site} presenting client cert ` +
+        `(fingerprint sha256:${fingerprint(cert)}${ca !== undefined ? ", custom CA" : ", system CA"})\n`,
+    );
+    return tls;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (mode === "require") {
+      // Fail closed — re-throw with the site so the principal can fix the path
+      // / permissions. The connect site must NOT fall back to plaintext.
+      throw new Error(
+        `transport.mtls=require: failed to load client cert/key/ca for ${ctx.site}: ${message} ` +
+          `(refusing to connect — fix the cert paths/permissions or set mtls=on to allow plaintext fallback)`,
+        { cause: err },
+      );
+    }
+    // mode === "on" — degrade to plaintext, loudly.
+    process.stderr.write(
+      `WARNING: transport.mtls=on: failed to load client cert/key/ca for ${ctx.site}: ${message} — ` +
+        `connecting WITHOUT mTLS (plaintext)\n`,
+    );
+    return undefined;
+  }
+}
+
+/**
+ * TC-4e — client-cert material for an HTTPS mTLS leg (the cloud-publisher →
+ * Worker POST). Mirrors {@link buildNatsTlsOptions} but returns PEM strings in
+ * the shape Bun's `fetch({ tls })` (and node's `https.Agent`) consume, rather
+ * than nats.js's `TlsOptions`. Same posture gating + same hard line: NEVER a
+ * skip-verify hatch.
+ */
+export interface HttpsMtlsMaterial {
+  /** PEM client certificate. */
+  cert: string;
+  /** PEM private key (loaded from a chmod-600 file). */
+  key: string;
+  /** PEM CA bundle, when a custom CA is configured (else system trust store). */
+  ca?: string;
+}
+
+/**
+ * Build HTTPS client-cert material for the cloud-publisher leg, gated by the
+ * mTLS posture mode. Returns `undefined` when no client cert should be
+ * presented (plaintext-over-TLS, i.e. server-auth-only HTTPS — the default).
+ *
+ * - `off` — `undefined` (today's behaviour: ordinary HTTPS, server auth only).
+ * - `on`  — present a client cert when cert/key load; degrade (warn) if not.
+ * - `require` — a missing/invalid cert FAILS CLOSED (throws).
+ *
+ * @throws under `require` when cert/key/ca is absent, unreadable, or the key
+ *         file is not chmod-600.
+ */
+export function buildHttpsMtlsMaterial(
+  mode: MtlsMode,
+  paths: MtlsPaths | undefined,
+  ctx: MtlsContext,
+): HttpsMtlsMaterial | undefined {
+  if (mode === "off") return undefined;
+
+  const certPath = paths?.cert_path;
+  const keyPath = paths?.key_path;
+  const caPath = paths?.ca_path;
+  const haveClientCert = certPath !== undefined && keyPath !== undefined;
+
+  if (!haveClientCert) {
+    const missing = [
+      certPath === undefined ? "cert_path" : null,
+      keyPath === undefined ? "key_path" : null,
+    ]
+      .filter((m): m is string => m !== null)
+      .join(", ");
+    if (mode === "require") {
+      throw new Error(
+        `transport.mtls=require but ${missing} missing for ${ctx.site}: ` +
+          `refusing to send without a client certificate (no plaintext fallback)`,
+      );
+    }
+    process.stderr.write(
+      `WARNING: transport.mtls=on but ${missing} missing for ${ctx.site} — ` +
+        `sending WITHOUT a client certificate (server-auth HTTPS only)\n`,
+    );
+    return undefined;
+  }
+
+  try {
+    const expandedCert = expandTilde(certPath);
+    const expandedKey = expandTilde(keyPath);
+    enforceChmod600(expandedKey);
+    const cert = readFileSync(expandedCert, "utf-8");
+    const key = readFileSync(expandedKey, "utf-8");
+    const ca = caPath !== undefined ? readFileSync(expandTilde(caPath), "utf-8") : undefined;
+    process.stderr.write(
+      `transport.mtls=${mode}: ${ctx.site} presenting client cert ` +
+        `(fingerprint sha256:${fingerprint(cert)}${ca !== undefined ? ", custom CA" : ", system CA"})\n`,
+    );
+    return { cert, key, ...(ca !== undefined ? { ca } : {}) };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (mode === "require") {
+      throw new Error(
+        `transport.mtls=require: failed to load client cert/key/ca for ${ctx.site}: ${message} ` +
+          `(refusing to send — fix the cert paths/permissions or set mtls=on to allow fallback)`,
+        { cause: err },
+      );
+    }
+    process.stderr.write(
+      `WARNING: transport.mtls=on: failed to load client cert/key/ca for ${ctx.site}: ${message} — ` +
+        `sending WITHOUT mTLS (server-auth HTTPS only)\n`,
+    );
+    return undefined;
+  }
+}
+
+/**
+ * TC-4e — advisory warning when a FEDERATED leaf link connects WITHOUT TLS.
+ * Cross-principal cleartext on a federated leaf is a confidentiality risk
+ * (another principal's deployment is on the far end); even when `mtls` is off
+ * the principal should KNOW the federated traffic is in the clear.
+ *
+ * Fires regardless of posture (it's advisory, not gated) — but is most
+ * relevant when `mtls` is off and federated leaves exist. A leaf whose URL is
+ * `tls://…` OR which built a `tls` block is considered protected and is NOT
+ * warned about. A `nats://…` federated leaf with no `tls` block triggers the
+ * warning.
+ *
+ * The runtime has no `SystemEventSource` threaded into the LinkPool (see
+ * `runtime.ts` F-3b/F-3c seams), so this writes to stderr by default and
+ * additionally invokes an optional structured sink so a caller that DOES have
+ * an event source can promote it to a `system.error` audit envelope.
+ *
+ * @param info  the leaf identity + url + whether a tls block was built.
+ * @param sink  optional structured sink (defaults to stderr only).
+ */
+export interface FederatedCleartextWarning {
+  /** The leaf's pool key (`leaf_node`). */
+  readonly leafId: string;
+  /** The federation network id riding this leaf. */
+  readonly networkId: string;
+  /** The leaf's connect URL (credentials already redacted by the caller). */
+  readonly safeUrl: string;
+}
+
+/**
+ * Emit the federated-leaf-without-TLS warning. Called by the LinkPool when a
+ * leaf for a federated network connects over a non-TLS transport.
+ *
+ * @param info structured warning payload.
+ * @param sink optional structured sink; when provided it runs IN ADDITION to
+ *   the stderr line (so an event-source-backed caller can audit it).
+ */
+export function warnFederatedCleartext(
+  info: FederatedCleartextWarning,
+  sink?: (info: FederatedCleartextWarning) => void,
+): void {
+  process.stderr.write(
+    `WARNING: federated leaf "${info.leafId}" (network=${info.networkId}) connected to ${info.safeUrl} ` +
+      `WITHOUT TLS — cross-principal traffic on this leaf is in CLEARTEXT. ` +
+      `Set security.transport.mtls and a tls:// leaf URL to protect it.\n`,
+  );
+  if (sink !== undefined) {
+    sink(info);
+  }
+}

--- a/src/common/types/config.ts
+++ b/src/common/types/config.ts
@@ -60,6 +60,8 @@ function emptyDefault<T>(): T {
 //   advertises an enc_pub (both accepted) · require = reject cleartext.
 // - `encryption.at_rest`: off | on (field-encrypt high-sensitivity columns).
 // - `transport.mtls`: off | on (offer client cert) | require (refuse non-mTLS).
+//   `transport.tls.{cert_path,key_path,ca_path}` (TC-4d/4e) carry the client
+//   cert material consumed when `mtls` is on/require. Key file chmod-600 gated.
 //
 // The `emptyDefault()` + transform idiom mirrors the `cockpit` block below:
 // `.default(emptyDefault())` returns `{}` without re-parsing inner defaults,
@@ -73,6 +75,19 @@ export const SecurityPostureSchema = z.object({
   }).default(emptyDefault()),
   transport: z.object({
     mtls: z.enum(["off", "on", "require"]).default("off"),
+    // TC-4d/4e (#627 Phase 4) — client cert/key/ca paths for transport mTLS.
+    // CONSUMED only when `mtls` is `on`/`require` (the `buildNatsTlsOptions`
+    // builder in `src/common/config/transport-mtls.ts` reads them). The
+    // private `key_path` is chmod-600 gated at load (same policy as the
+    // nkey-seed / `.creds` loaders); cert + ca are public material. All three
+    // are optional so a partial config fails per-mode at connect time (a clear
+    // fail-closed error under `require`) rather than being rejected at schema
+    // parse — and so the back-compat `off` path never requires these fields.
+    tls: z.object({
+      cert_path: z.string().optional(),
+      key_path: z.string().optional(),
+      ca_path: z.string().optional(),
+    }).optional(),
   }).default(emptyDefault()),
 }).default(emptyDefault()).transform((val) => ({
   /* eslint-disable @typescript-eslint/no-unnecessary-condition */
@@ -83,6 +98,7 @@ export const SecurityPostureSchema = z.object({
   },
   transport: {
     mtls: val.transport?.mtls ?? "off",
+    ...(val.transport?.tls !== undefined ? { tls: val.transport.tls } : {}),
   },
   /* eslint-enable @typescript-eslint/no-unnecessary-condition */
 }));

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -27,6 +27,7 @@ import { loadConfigWithAgents, loadAgentsDirectory, expandTilde, FragmentLoadErr
 import { ConfigWatcher } from "./common/config/watcher";
 import { type AgentConfig, getAllRepos } from "./common/types/config";
 import { resolveSigningKnobs } from "./common/security-posture";
+import { buildHttpsMtlsMaterial } from "./common/config/transport-mtls";
 import { fetchWithTimeout } from "./common/timeout";
 import { UsageMonitor } from "./common/usage/monitor";
 import { AgentRegistry } from "./common/agents/registry";
@@ -678,6 +679,18 @@ export async function startCortex(
         ...(options.policy?.federated?.networks !== undefined && {
           federatedNetworks: options.policy.federated.networks,
         }),
+        // TC-4d/4e (#627 Phase 4) — transport-mTLS posture for the LinkPool
+        // (primary + every federated leaf). Default `off` ⇒ no tls block on
+        // any link, byte-identical to today; `require` fails closed at connect.
+        // The federated-leaf-cleartext warning fires from the runtime
+        // regardless of mode. `config.security` is always populated (TC-0
+        // schema default), so this is safe for legacy bot.yaml input too.
+        transportMtls: {
+          mode: config.security.transport.mtls,
+          ...(config.security.transport.tls !== undefined && {
+            paths: config.security.transport.tls,
+          }),
+        },
       });
     } catch (err) {
       console.error("cortex: myelin runtime startup error (non-fatal):", err instanceof Error ? err.message : err);
@@ -1525,10 +1538,23 @@ export async function startCortex(
   const hasCloudNetworks = config.networks.some((n) => !!n.cloud);
   if (hasCloudNetworks) {
     const networkResolver = createNetworkResolver(config);
-    cloudPublisher = new CloudPublisher({ networkResolver });
+    // TC-4e (#627 Phase 4) — optional client-cert material for the
+    // publisher→Worker HTTPS leg, gated by the same `security.transport.mtls`
+    // posture as the bus links. `off` (default) ⇒ undefined ⇒ ordinary
+    // server-auth HTTPS, byte-identical to today; `require` fails closed at
+    // boot if the cert/key/ca are missing/invalid.
+    const cloudMtls = buildHttpsMtlsMaterial(
+      config.security.transport.mtls,
+      config.security.transport.tls,
+      { site: "cloud-publisher" },
+    );
+    cloudPublisher = new CloudPublisher({
+      networkResolver,
+      ...(cloudMtls !== undefined && { mtls: cloudMtls }),
+    });
     const networkIds = config.networks.filter((n) => n.cloud).map((n) => n.id);
     console.log(`cortex: cloud publisher active (networks: ${networkIds.join(", ")})`);
-    CloudPublisher.checkEndpoints(networkResolver, networkIds).catch((err: unknown) => {
+    CloudPublisher.checkEndpoints(networkResolver, networkIds, cloudMtls).catch((err: unknown) => {
       console.error("cortex: endpoint health check error:", err instanceof Error ? err.message : String(err));
     });
   } else if (config.api.mode === "cloud") {

--- a/src/taps/cc-events/__tests__/cloud-publisher.mtls-wire.test.ts
+++ b/src/taps/cc-events/__tests__/cloud-publisher.mtls-wire.test.ts
@@ -1,0 +1,245 @@
+/**
+ * TC-4e (review FIX-FIRST) — WIRE-LEVEL mTLS test for the cloud-publisher.
+ *
+ * THE GAP THAT HID THE DEFECT. The mocked-fetch tests in
+ * `cloud-publisher.test.ts` only prove `init.tls` is ATTACHED to the request —
+ * they cannot see whether the runtime actually puts the client certificate on
+ * the wire. The security review's premise was that Bun's `fetch` SILENTLY
+ * DROPS the client cert/key, so the cloud→Worker leg runs server-auth-only
+ * HTTPS while the principal believes `require` is enforcing mutual TLS. This
+ * test settles it empirically against a REAL mTLS-enforcing server.
+ *
+ * WHY A NODE SUBPROCESS SERVER. Bun 1.3.2's own `node:https` server does NOT
+ * implement client-cert verification: it neither enforces `requestCert` /
+ * `rejectUnauthorized` nor exposes `socket.getPeerCertificate()`. An in-process
+ * (Bun-hosted) server therefore cannot observe presentation — it would falsely
+ * pass. Node's `https` server does both, and it faithfully mirrors production
+ * (the Cloudflare Worker is a real mTLS-enforcing endpoint). So we run the
+ * server under Node (`mtls-wire-server.mjs`) and drive it with the
+ * cloud-publisher's Bun `fetch` client.
+ *
+ * ASSERTIONS:
+ *   (a) WITH mtls material → the Node server sees the client CN and reports
+ *       `authorized: true` ⇒ the cert IS presented on the wire (real mutual
+ *       auth). Health probe too.
+ *   (b) WITHOUT mtls material → the `requestCert: true` server REJECTS the
+ *       handshake (tlsClientError; the request never reaches the handler) ⇒
+ *       proving the server genuinely enforces, so (a) is not a false pass. The
+ *       cloud-publisher swallows the error (events stay in local JSONL).
+ *
+ * If a Node binary cannot be located the suite is skipped (CI always has one;
+ * `bun test` under fnm/asdf resolves it). It does NOT silently pass.
+ */
+
+import { test, expect, describe, beforeAll, afterAll } from "bun:test";
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { execSync } from "node:child_process";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { CloudPublisher } from "../cloud-publisher";
+import type { PublishedEvent } from "../hooks/lib/event-types";
+import type { NetworkResolver, NetworkConfig } from "../../../common/types/config";
+import {
+  TEST_CA,
+  TEST_SERVER_CERT,
+  TEST_SERVER_KEY,
+  TEST_CLIENT_CERT,
+  TEST_CLIENT_KEY,
+  TEST_CLIENT_CN,
+} from "./mtls-fixtures";
+
+// ---------------------------------------------------------------------------
+
+function makeEvent(): PublishedEvent {
+  return {
+    event_id: crypto.randomUUID(),
+    event_type: "agent.task.started",
+    timestamp: new Date().toISOString(),
+    session_id: "wire-session",
+    agent_id: "luna",
+    agent_name: "Luna",
+    payload: { task: "wire" },
+  };
+}
+
+function resolverFor(endpoint: string): NetworkResolver {
+  return (networkId: string | undefined): NetworkConfig | null => ({
+    id: networkId ?? "default",
+    endpoint,
+    apiKey: "grove_sk_wire",
+    principalId: "andreas",
+  });
+}
+
+/**
+ * Resolve a Node binary path, or null when none is available. (Under `bun
+ * test`, `process.execPath` is the bun binary, so we must locate node on PATH;
+ * the test server needs Node's real client-cert-verifying https server.)
+ */
+function findNode(): string | null {
+  try {
+    const p = execSync("command -v node", { encoding: "utf-8" }).trim();
+    return p.length > 0 ? p : null;
+  } catch {
+    // No node on PATH — the wire suite skips (it never silently passes).
+    return null;
+  }
+}
+
+interface ServerHandle {
+  port: number;
+  lines: () => Record<string, unknown>[];
+  stop: () => void;
+}
+
+const SERVER_SCRIPT = join(import.meta.dir, "mtls-wire-server.mjs");
+
+function startNodeServer(
+  nodeBin: string,
+  certDir: string,
+): Promise<ServerHandle> {
+  return new Promise((resolve, reject) => {
+    const child: ChildProcessWithoutNullStreams = spawn(nodeBin, [SERVER_SCRIPT], {
+      env: {
+        ...process.env,
+        CA_PATH: join(certDir, "ca.crt"),
+        SERVER_CERT_PATH: join(certDir, "server.crt"),
+        SERVER_KEY_PATH: join(certDir, "server.key"),
+      },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    const lines: Record<string, unknown>[] = [];
+    let buf = "";
+    let settled = false;
+
+    child.stdout.on("data", (chunk: Buffer) => {
+      buf += chunk.toString("utf-8");
+      let idx: number;
+      while ((idx = buf.indexOf("\n")) >= 0) {
+        const line = buf.slice(0, idx).trim();
+        buf = buf.slice(idx + 1);
+        if (line.length === 0) continue;
+        const portMatch = /^PORT=(\d+)$/.exec(line);
+        if (portMatch && !settled) {
+          settled = true;
+          resolve({
+            port: Number(portMatch[1]),
+            lines: () => lines.slice(),
+            stop: () => {
+              child.stdin.end();
+              child.kill("SIGTERM");
+            },
+          });
+          continue;
+        }
+        try {
+          lines.push(JSON.parse(line) as Record<string, unknown>);
+        } catch {
+          // non-JSON diagnostic line — ignore.
+        }
+      }
+    });
+
+    child.on("error", (err) => {
+      if (!settled) {
+        settled = true;
+        reject(err);
+      }
+    });
+    child.stderr.on("data", () => {
+      // Node may print TLS warnings; the JSON lines on stdout are the contract.
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+
+const nodeBin = findNode();
+const describeWire = nodeBin ? describe : describe.skip;
+
+describeWire("CloudPublisher — wire-level mTLS (Node https server, requestCert)", () => {
+  let certDir: string;
+
+  beforeAll(() => {
+    certDir = mkdtempSync(join(tmpdir(), "cp-mtls-wire-"));
+    writeFileSync(join(certDir, "ca.crt"), TEST_CA);
+    writeFileSync(join(certDir, "server.crt"), TEST_SERVER_CERT);
+    writeFileSync(join(certDir, "server.key"), TEST_SERVER_KEY);
+  });
+
+  afterAll(() => {
+    rmSync(certDir, { recursive: true, force: true });
+  });
+
+  const mtlsMaterial = { cert: TEST_CLIENT_CERT, key: TEST_CLIENT_KEY, ca: TEST_CA };
+
+  test("POST presents the client cert on the wire (server observes the CN, authorized)", async () => {
+    const srv = await startNodeServer(nodeBin!, certDir);
+    try {
+      const pub = new CloudPublisher({
+        networkResolver: resolverFor(`https://localhost:${srv.port}`),
+        batchIntervalMs: 60_000,
+        mtls: mtlsMaterial,
+      });
+      pub.publish(makeEvent());
+      await pub.flush();
+      await pub.close();
+      // Give the server a tick to flush its stdout line.
+      await new Promise((r) => setTimeout(r, 100));
+
+      const ingest = srv.lines().find((l) => l.path === "/api/ingest");
+      expect(ingest).toBeDefined();
+      expect(ingest!.clientCN).toBe(TEST_CLIENT_CN);
+      expect(ingest!.authorized).toBe(true);
+    } finally {
+      srv.stop();
+    }
+  });
+
+  test("health probe presents the client cert on the wire", async () => {
+    const srv = await startNodeServer(nodeBin!, certDir);
+    try {
+      await CloudPublisher.checkEndpoints(
+        resolverFor(`https://localhost:${srv.port}`),
+        ["default"],
+        mtlsMaterial,
+      );
+      await new Promise((r) => setTimeout(r, 100));
+
+      const health = srv.lines().find((l) => l.path === "/api/health");
+      expect(health).toBeDefined();
+      expect(health!.clientCN).toBe(TEST_CLIENT_CN);
+      expect(health!.authorized).toBe(true);
+    } finally {
+      srv.stop();
+    }
+  });
+
+  test("WITHOUT mtls material the requestCert server REJECTS the handshake (no cert on wire)", async () => {
+    const srv = await startNodeServer(nodeBin!, certDir);
+    try {
+      const pub = new CloudPublisher({
+        networkResolver: resolverFor(`https://localhost:${srv.port}`),
+        batchIntervalMs: 60_000,
+        maxRetries: 1,
+        // mtls omitted ⇒ server-auth-only HTTPS.
+      });
+      pub.publish(makeEvent());
+      await pub.flush(); // must NOT throw — error is swallowed, events kept locally
+      await pub.close();
+      await new Promise((r) => setTimeout(r, 100));
+
+      const allLines = srv.lines();
+      // No request reached the handler presenting our client CN.
+      const presented = allLines.some((l) => l.clientCN === TEST_CLIENT_CN);
+      expect(presented).toBe(false);
+      // The enforcing server rejected the cert-less handshake.
+      const rejected = allLines.some((l) => typeof l.tlsClientError === "string");
+      expect(rejected).toBe(true);
+    } finally {
+      srv.stop();
+    }
+  });
+});

--- a/src/taps/cc-events/__tests__/cloud-publisher.test.ts
+++ b/src/taps/cc-events/__tests__/cloud-publisher.test.ts
@@ -352,4 +352,61 @@ describe("CloudPublisher", () => {
     // Should NOT throw — errors are logged, not propagated
     await CloudPublisher.checkEndpoints(resolver, ["default"]);
   });
+
+  // ---------------------------------------------------------------------------
+  // TC-4e (#627 Phase 4): cloud-publisher mTLS on the →Worker HTTPS leg
+  // ---------------------------------------------------------------------------
+
+  const MTLS_MATERIAL = {
+    cert: "-----BEGIN CERTIFICATE-----\nCRT\n-----END CERTIFICATE-----\n",
+    key: "-----BEGIN PRIVATE KEY-----\nKEY\n-----END PRIVATE KEY-----\n",
+    ca: "-----BEGIN CERTIFICATE-----\nCA\n-----END CERTIFICATE-----\n",
+  };
+
+  test("attaches the client-cert tls block to the ingest POST when mtls set", async () => {
+    pushOk();
+    const pub = new CloudPublisher({
+      networkResolver: createTestNetworkResolver("https://grove-api.example.com", "grove_sk_test123", "andreas"),
+      batchIntervalMs: 60_000,
+      mtls: MTLS_MATERIAL,
+    });
+    pub.publish(makeEvent());
+    await pub.flush();
+
+    expect(fetchCalls.length).toBe(1);
+    const init = fetchCalls[0]!.init as RequestInit & { tls?: typeof MTLS_MATERIAL };
+    expect(init.tls).toBeDefined();
+    expect(init.tls?.cert).toBe(MTLS_MATERIAL.cert);
+    expect(init.tls?.key).toBe(MTLS_MATERIAL.key);
+    expect(init.tls?.ca).toBe(MTLS_MATERIAL.ca);
+    // Hard line — no skip-verify field ever rides along.
+    expect(JSON.stringify(init)).not.toContain("rejectUnauthorized");
+    pub.close();
+  });
+
+  test("omits tls (ordinary server-auth HTTPS) when mtls is NOT configured — back-compat", async () => {
+    pushOk();
+    const pub = new CloudPublisher({
+      networkResolver: createTestNetworkResolver("https://grove-api.example.com", "grove_sk_test123", "andreas"),
+      batchIntervalMs: 60_000,
+    });
+    pub.publish(makeEvent());
+    await pub.flush();
+
+    expect(fetchCalls.length).toBe(1);
+    const init = fetchCalls[0]!.init as RequestInit & { tls?: unknown };
+    expect(init.tls).toBeUndefined();
+    pub.close();
+  });
+
+  test("checkEndpoints attaches the client-cert tls block to the health probe", async () => {
+    pushOk();
+    const resolver = createTestNetworkResolver("https://grove-api.example.com", "grove_sk_test123", "andreas");
+    await CloudPublisher.checkEndpoints(resolver, ["default"], MTLS_MATERIAL);
+
+    expect(fetchCalls.length).toBe(1);
+    expect(fetchCalls[0]!.url).toBe("https://grove-api.example.com/api/health");
+    const init = fetchCalls[0]!.init as RequestInit & { tls?: typeof MTLS_MATERIAL };
+    expect(init.tls?.cert).toBe(MTLS_MATERIAL.cert);
+  });
 });

--- a/src/taps/cc-events/__tests__/mtls-fixtures.ts
+++ b/src/taps/cc-events/__tests__/mtls-fixtures.ts
@@ -1,0 +1,144 @@
+/**
+ * TC-4e — NON-SECRET test cert fixtures for the cloud-publisher wire-level
+ * mTLS tests. A throwaway PKI (self-signed CA → server cert for localhost →
+ * client cert CN=cortex-cloud-publisher) used ONLY by an in-process loopback
+ * `node:https` server in the cloud-publisher test suite. These authenticate
+ * nothing real; they exist so a test can stand up a `requestCert: true,
+ * rejectUnauthorized: true` server and assert that the cloud-publisher's POST
+ * actually PRESENTS the client cert on the wire (not merely that `init.tls`
+ * was attached). Regenerate freely — no trust is vested in them.
+ *
+ * Why baked PEMs and not runtime generation: `node:crypto` has no X.509
+ * signing API, and adding a cert-gen dependency (`selfsigned` / `node-forge`)
+ * for a test fixture violates the "no heavy deps" rule. Baked fixtures are
+ * deterministic and CI-safe (no openssl shell-out).
+ */
+
+/** Self-signed test CA. Verifies both the server and client certs below. */
+export const TEST_CA = `-----BEGIN CERTIFICATE-----
+MIIDCTCCAfGgAwIBAgIUcb3x86ld52C+Zw3WJgIJdXOzlNQwDQYJKoZIhvcNAQEL
+BQAwEzERMA8GA1UEAwwIQ1BUZXN0Q0EwIBcNMjYwNjA0MTEzNDEyWhgPMjEyNjA1
+MTExMTM0MTJaMBMxETAPBgNVBAMMCENQVGVzdENBMIIBIjANBgkqhkiG9w0BAQEF
+AAOCAQ8AMIIBCgKCAQEAuHRcCoD1QOPpjChd8iVjUx0SjOHoVYDW0dDofi3alCTr
+ZtlvEiJY0XHm6jsQYDNUf9SEY+3d+fS840FmX2l6x+Yhy9fwl4uvmlNcUeDUARAx
+w2cns9D7AwK5oZ3cFT5aRpf2TE1MNPaS2mCHZihir0xAeuQdtpgk5O7tSe7/OyZU
+2lii8z0C9jYrDSxgLgSYyvVIZ543v2d9reAvAC22JpHmOaRI6afly5chDSAtGAKs
+vaUCb5mvBbIHpBvtGxwru3etEho6Lrs6EkcS4JhfyMlNFqGal7jKeiBz2dgHnUOR
+PJiPkT8WQZ92qQ5uOrU9FouMUMt+KKCle9Yiwztq3QIDAQABo1MwUTAdBgNVHQ4E
+FgQUlK08kX57sCxwUROZvtwvzj1PAREwHwYDVR0jBBgwFoAUlK08kX57sCxwUROZ
+vtwvzj1PAREwDwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAQEAnHS4
+FLZjm8PVzNAGPx1F/TGYGGhGH/2MXnnqW941/qlaHn1pX81XLN3tKG1moPU8z9/b
+SqLwVGmyI5Zkta1XJk1+phIfLJn8DMIRa9LW1Gev3DcMT5oV3b+yhRbSleMUiVQG
+T2BX+83ztwqlc37kZpKrpaFIELyu4AlP7V9L7ML1OZptDVlLiEslfHcE7wH31iJm
+Cs3oEehGRZyZfK9vteQuJy44G0u6PuhBzsV5aEHYDM7Nx4FqN6+iyyP24Kk1xSo6
+6HmhlV8VjnUYXZ65mDXgOHseZ8ejX3d5s7bPUWc06L/o+fh1wnOhpFBzGuvI7vaG
+tvx/Ozan0/+Deg86ww==
+-----END CERTIFICATE-----
+`;
+
+/** Loopback server cert (CN=localhost, SAN localhost/127.0.0.1). */
+export const TEST_SERVER_CERT = `-----BEGIN CERTIFICATE-----
+MIIDFTCCAf2gAwIBAgIUPjG0PqLe8LO/QXtIYlaA1xbFtZMwDQYJKoZIhvcNAQEL
+BQAwEzERMA8GA1UEAwwIQ1BUZXN0Q0EwIBcNMjYwNjA0MTEzNDEyWhgPMjEyNjA1
+MTExMTM0MTJaMBQxEjAQBgNVBAMMCWxvY2FsaG9zdDCCASIwDQYJKoZIhvcNAQEB
+BQADggEPADCCAQoCggEBALEStUPwLVEYES8oMVaQossKVM4OO6TP0u/Swc11uj5k
+hlG7TuBO1nJuq5Do+Q+3kvXzhhMULqZrHimMbuKmccYzFWIR5/H67XvqM+gIqEtU
+0zGonv5Kg5WRNicDi6UDaKsj6HidtyCI1njnGy69YN7xjOSJzqfmPhBdJlnx1BeZ
+93yFfIfb91PtPJ7tGZZ3bDo2rqtVxuIeIDYMi0rhWgqinvbH9EnRzS9ROKeloqbF
+enXjZ0M2FSiwJU+SnAsOOlsFueRDPt0tFOb89fAHLoGGWxZ/sFS383+0SbwPH2Ad
+fURLdv+aFksXlo9SrU3HvU0XKbX9EzsH7nvSNMTmpy0CAwEAAaNeMFwwGgYDVR0R
+BBMwEYIJbG9jYWxob3N0hwR/AAABMB0GA1UdDgQWBBSWoYiXlkJRmCBlVDcus4vz
+t0zthDAfBgNVHSMEGDAWgBSUrTyRfnuwLHBRE5m+3C/OPU8BETANBgkqhkiG9w0B
+AQsFAAOCAQEAOzsF50IIe3Id1qAJfj5jWp9pVfXLl3vHvq5jEyyloFOE0ZCtuDiD
+A0JWMwvv8XwPaRZXdxJpO08INmJcHQHnNQByC3wv287n7Tw/NnuIRQobgzs7R2dC
+sL4WH/CgbshInkbdZa5rFa40d8Sr39mIAclztdV0bYVWIuefvBjPHDrzL/wL32US
+xDBx1rrcGUkE3rhbAxFlBY4F1plhN60XZKWOChD+66Y50ETBO0DH0JEOk3zrylBJ
+X0e/x0wuSMp8hevaN2c8lVh2xW9T4keHsZV7wlQqRD6GN5MZcBH+nVEW88igSBD8
+9dMHv0wravqPyySxQg0W/va9XKGw24HJ/A==
+-----END CERTIFICATE-----
+`;
+
+/** Private key for {@link TEST_SERVER_CERT}. NON-SECRET fixture. */
+export const TEST_SERVER_KEY = `-----BEGIN PRIVATE KEY-----
+MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQCxErVD8C1RGBEv
+KDFWkKLLClTODjukz9Lv0sHNdbo+ZIZRu07gTtZybquQ6PkPt5L184YTFC6max4p
+jG7ipnHGMxViEefx+u176jPoCKhLVNMxqJ7+SoOVkTYnA4ulA2irI+h4nbcgiNZ4
+5xsuvWDe8Yzkic6n5j4QXSZZ8dQXmfd8hXyH2/dT7Tye7RmWd2w6Nq6rVcbiHiA2
+DItK4VoKop72x/RJ0c0vUTinpaKmxXp142dDNhUosCVPkpwLDjpbBbnkQz7dLRTm
+/PXwBy6BhlsWf7BUt/N/tEm8Dx9gHX1ES3b/mhZLF5aPUq1Nx71NFym1/RM7B+57
+0jTE5qctAgMBAAECggEAPucHb3/1iTZEfH0JsdeljP05jQ1vUKfnJfy3jfZBWAK7
+2HLynSpEcdgwqESqnVO4KBj/Su3DeKjaySWzCl7YUfE5qmH0BHkAPiG/mLDioAgd
+Ein1eR4dSleQZiGTTOY+G3WhEp/sOumBTufCN0NdEzW5uEHgILLg301H33HRxyP4
+k5NUktpjMUOcaZzNrhH9VNqyUpX7bjrm5sZE4+Rnjlv/Kv21fc6k8X7/2GIc/31y
+R5QjsTN/ZmYBbH7n9kba6J6go2CcqNe0GEZVrb/SxDEZUcNWlBFt/wSmp29Yo7VC
+XYAlkeRj1WfEGJEuaLFJXshL7Bvqx8gOg6yF+NZQPQKBgQD6H9YS2xKxmPdqvrfq
+2LmweDi54OlZmBlusaSgZ3pf2sJfC+y7HnyIjJkml+98u5Ed++gFC9+bxcp3c2ou
+G+gmhPSNM0qoGJrwbZs86dWy27ZijbAyoDXxVBPt2hEM4+0LfpPJJnyJ5IXFe4yv
+9r9FXq3ftyEUNEiMtQ8HUy6wRwKBgQC1O5DlocHv/2QdOsToxkF5Ilm3dmCHadv+
+1ZPDPA98ykm6uM2xXKNX1VALNOPHF8RNd2/wcmVNINE01N0n+ZuoGi6WFrnjiZ3o
+sxtCo6x9mAZXRGsosJqpN9YAX1NvHZdKQUkzWem/te7LTPYFUxPs++KZ5lFepAP2
+GDtm1C966wKBgQCn4riY/WzFwivH/W2Ld57jwT4qHbnjRkFD2H7sn6g3MKmojGOA
+kYz7RowBqJe5/FgCbTQmNvsHHrKwjMpnWpnvSOyw3g2tWJ6e5KL/NuEWZX09F2d+
+A6VRb6LU0rsBEPfp8DMYH/oVwEq97BjZf2CRGmTQtaXBXvqXX2xP+VhsPwKBgCbz
+5JLWj56L3/LAXO5DHnNwxKPAF8NDJ3vAYAAIerOxruMpMVy7sogAWzHtbj+uhgy4
+bSDbFZbcRNr8HYSoC6K37edofw++1mfbhzJth3d/I23CUN3wB23ziFWQJ5isXYYi
+Ph+BZdJEwkyEACTo1FGNWgkGDdsvmYJddvcFCCd9AoGATcDGhbw0zo3zP2wD3/b7
+e2HD6IOQ27IBE/ng/NlPnFhwpTWIEz66Mir3j+8+tTEMMwpalZP5qCO/1ltxtggm
+7RpJP5pA0FYfEihTJ330tOzKH0c3iqi+LI9s4CZvlTVOqXWiRNi/RJ8eKNHrCoqS
+yP86qI4I4NiLJNkc8kvL41c=
+-----END PRIVATE KEY-----
+`;
+
+/** Client cert (CN=cortex-cloud-publisher). The CN the server should observe. */
+export const TEST_CLIENT_CERT = `-----BEGIN CERTIFICATE-----
+MIICvTCCAaUCFD4xtD6i3vCzv0F7SGJWgNcWxbWUMA0GCSqGSIb3DQEBCwUAMBMx
+ETAPBgNVBAMMCENQVGVzdENBMCAXDTI2MDYwNDExMzQxMloYDzIxMjYwNTExMTEz
+NDEyWjAhMR8wHQYDVQQDDBZjb3J0ZXgtY2xvdWQtcHVibGlzaGVyMIIBIjANBgkq
+hkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAmvyjpbdN7+anmGuFNHh25A5a1LoMiNfq
+MczMtRkCSDB+7s3b5CsyrV89VVfgWA4N8ox66DVqwrY3cTvNK8212KfNmuhWdfTF
+/p4R/R+ESAbvNtS542cd286X+hQ8M+YXFBwybufMLwba5BlkJgW/JUdgbydOr1B7
+JBa1cHm0/WuJ2EbZiYhPdlrKqrY4Ff2/cTN126iM/ule7+msHkEaKvSlGyzagPW8
+Y/zsXoko3HIvtZ2/rfjEmkqkMQuCI9NHyKVx3B1bXi7V/9YrSQeEL0k3EP4wW/Zm
+k+7+YYHv1+4ToiePL3QC1Crqj7Xs2OhRoe+/yBbUynIsh/bQFTms6QIDAQABMA0G
+CSqGSIb3DQEBCwUAA4IBAQCzNovzVBlVAopCAb5NVtnZNNyK8D+koraL8b3BMcub
+G2QGbilW5yrmHZyWfSHax/xTwkriAJ6ef2+KopSyS1DPebG40k/GZXqChpZREEkI
+kXr0U6ShKMueLu4CQbmp+ZXEmDwBFe/sLK9KpPJuaJtlry5XA5ZjA0sKXJGVpE7l
+o/NDTKguFNusuWztocuoAX+aEhtgZ90X5WCbtusyUABTdjq4bZCyRIh3NDKeUb4q
+RO4w6gO6oAFx40w5upUBL7QPc+S49+BLMqboy+uNNzRoI4kEPXzAgDrjEh5f/YYk
+OqKYlu7r9D74cM2TTy1ufufrtNFAoYrC0BFFucfAWent
+-----END CERTIFICATE-----
+`;
+
+/** Private key for {@link TEST_CLIENT_CERT}. NON-SECRET fixture. */
+export const TEST_CLIENT_KEY = `-----BEGIN PRIVATE KEY-----
+MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQCa/KOlt03v5qeY
+a4U0eHbkDlrUugyI1+oxzMy1GQJIMH7uzdvkKzKtXz1VV+BYDg3yjHroNWrCtjdx
+O80rzbXYp82a6FZ19MX+nhH9H4RIBu821LnjZx3bzpf6FDwz5hcUHDJu58wvBtrk
+GWQmBb8lR2BvJ06vUHskFrVwebT9a4nYRtmJiE92WsqqtjgV/b9xM3XbqIz+6V7v
+6aweQRoq9KUbLNqA9bxj/OxeiSjcci+1nb+t+MSaSqQxC4Ij00fIpXHcHVteLtX/
+1itJB4QvSTcQ/jBb9maT7v5hge/X7hOiJ48vdALUKuqPtezY6FGh77/IFtTKciyH
+9tAVOazpAgMBAAECggEAAtNWMpju3wUTWzONnNfmjKXoLm6QYy/IMB18ghTemOfn
+w9farrRCEvf/J3bH9c8Bc9baDZueB/FNaDSdBakKdp9TinkPzMwi48S9uExvwNDo
+jEqQnivUzGYIg67aAfULnhUdWcPYfKcpNy/xJpd4+peMfhDx7dS0/q16eWkXSBNG
+LpwbLMIAUM2br5geXtD7h1nwTuYC00ZzuO/n04OT3dfFDVixXVxhgu8tHR9BoNrx
+jbtvvu30vP+T94f9U3COe7GvUy9aYK2Qvd7DQaWNpB/G8Tsz7yvE5kY146rvPKCW
+15DTp/0P7gcMnpneTgvFERT5gQXK3dASI5SE4aa4sQKBgQDNXaMnUkYKM6BGTXJK
+st+DznLDJwrSALD9yRGMEdw36re5dk7YoyrQRA1mpi7dfPU3SGj2dPRLDPiJ5ew7
+IECNpT9336R0ECrIzN3XvMiLEiEaeRyoPmLpr6FLwXka3m71RXK8a3hvc+j4Vbkt
+5dfAC53eAO74dB11XW+SpL/aEQKBgQDBMype/qogvCbfxpKvgXxYeM8JkhQAHvO3
+sXaIyW49H+G8/XUNqof3NTSoFxErBaklYlx5Xe9FfKXFYtWZ94TsdEzgeN4YBCbe
+Yy/vr1GdZeGBsm1tkuwLOYnzd0OWWhGAsZJuXoSYwgvnCOWUuy34VNg5dz5PiObM
+waqFdTQNWQKBgQCDSnvF5blVSFAM4fJRgy2WLGP+E3W9cCe299a5/6kULoCqltIt
+eZMjdn5Cw7dubjau0yIXfgm3+WDjeBSgcCwU4jJDRrzyXmub2C1zgQOMtVhofkkt
+3kSKNXge4F+2J8I0F+QURXjHeAjWyqcKish1xHd2uI4OVN2IbOWpkJ3+oQKBgFpX
+B4gWAw19jZvz6aFhpfhkvUMXaHzJ/GK3+9pofkDcyJyr0/FI/X0OBwpWhvOcGQTf
+Iqip0PmoGIfc+E6fnCtJEq2gNxH51wcEUGT+kOZNvo38Fgk3u2JgTG5pJVSH10lb
+P0KWteAMVK56zYenow5M9jKg3KUqOeoi4Q64yFc5AoGBAIYAjMDcx3BWDh7Sorf+
+NTTi4lazmuIO2qI916lvFFzg00RmJ2VQ+J8+dmoJ5Wj2DV4CpeOSwxqvzCK2KSKE
+Tdl21sJYZXK090DRv0ghncGfQlS/woTYStzqUG+P1XOPe5kg+923TZ44+SaHY8ht
+vukjXVw2rRT4wa5rJ2muzYO1
+-----END PRIVATE KEY-----
+`;
+
+/** The CN baked into {@link TEST_CLIENT_CERT}; what a wire test asserts. */
+export const TEST_CLIENT_CN = "cortex-cloud-publisher";

--- a/src/taps/cc-events/__tests__/mtls-wire-server.mjs
+++ b/src/taps/cc-events/__tests__/mtls-wire-server.mjs
@@ -1,0 +1,65 @@
+/**
+ * TC-4e (review FIX-FIRST) — a REAL mTLS-enforcing HTTPS server, run as a Node
+ * subprocess by the cloud-publisher wire test.
+ *
+ * Why a Node subprocess and not an in-process server: Bun 1.3.2's `node:https`
+ * server does NOT implement client-cert verification — it neither enforces
+ * `requestCert`/`rejectUnauthorized` nor exposes `socket.getPeerCertificate()`.
+ * So an in-process (Bun-hosted) server cannot observe whether the client
+ * presented a certificate. Node's `https` server DOES both. Running the server
+ * under Node faithfully reproduces production: the Cloudflare Worker is a real
+ * mTLS-enforcing endpoint, and this proves Bun's `fetch` (the client) presents
+ * the client cert TO such a server.
+ *
+ * Protocol: reads cert paths + behaviour from argv/env, prints `PORT=<n>` on
+ * stdout once listening, and for every request prints one JSON line on stdout:
+ *   {"path": "...", "clientCN": "<CN|null>", "authorized": <bool>}
+ * The test parses these lines to assert the client cert reached the wire.
+ *
+ * NON-SECRET: only ever loaded with throwaway test fixtures.
+ */
+import { createServer } from "node:https";
+import { readFileSync } from "node:fs";
+
+const caPath = process.env.CA_PATH;
+const certPath = process.env.SERVER_CERT_PATH;
+const keyPath = process.env.SERVER_KEY_PATH;
+
+const server = createServer(
+  {
+    cert: readFileSync(certPath, "utf-8"),
+    key: readFileSync(keyPath, "utf-8"),
+    ca: readFileSync(caPath, "utf-8"),
+    requestCert: true,
+    // Enforce: a client that presents no cert (or an untrusted one) is
+    // rejected at the handshake. NO skip-verify anywhere.
+    rejectUnauthorized: true,
+  },
+  (req, res) => {
+    const sock = req.socket;
+    const peer = typeof sock.getPeerCertificate === "function" ? sock.getPeerCertificate() : {};
+    const cn = peer && peer.subject && typeof peer.subject.CN === "string" ? peer.subject.CN : null;
+    process.stdout.write(
+      JSON.stringify({ path: req.url, clientCN: cn, authorized: sock.authorized }) + "\n",
+    );
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ ok: true }));
+  },
+);
+
+// A no-client-cert handshake against requestCert+rejectUnauthorized surfaces
+// here — the request never reaches the handler. Record it so the test can see
+// that a cert-less client is genuinely rejected.
+server.on("tlsClientError", (err) => {
+  process.stdout.write(JSON.stringify({ tlsClientError: err.message }) + "\n");
+});
+
+server.listen(0, "127.0.0.1", () => {
+  const addr = server.address();
+  const port = typeof addr === "object" && addr ? addr.port : 0;
+  process.stdout.write(`PORT=${port}\n`);
+});
+
+// Exit cleanly when the parent closes stdin.
+process.stdin.on("end", () => server.close(() => process.exit(0)));
+process.stdin.resume();

--- a/src/taps/cc-events/cloud-publisher.ts
+++ b/src/taps/cc-events/cloud-publisher.ts
@@ -33,8 +33,19 @@ import type { HttpsMtlsMaterial } from "../../common/config/transport-mtls";
  * declare it. This narrow extension types the `tls` we attach WITHOUT widening
  * to `any` and without a Bun-types dependency. We only ever set `cert`/`key`/
  * `ca` (contents) — NEVER `rejectUnauthorized` or any skip-verify field
- * (CLAUDE.md hard line). On a runtime that ignores `tls` on fetch the leg
- * stays server-auth HTTPS (no downgrade of verification, just no client cert).
+ * (CLAUDE.md hard line).
+ *
+ * WIRE BEHAVIOUR (review FIX-FIRST, empirically verified — see
+ * `__tests__/cloud-publisher.mtls-wire.test.ts`): on Bun 1.3.2, attaching
+ * `tls: { cert, key, ca }` to `fetch` DOES present the client certificate to a
+ * real mTLS-enforcing server (Cloudflare Worker / a Node `https` server with
+ * `requestCert: true`). The cloud→Worker leg therefore runs REAL mutual auth
+ * under `require`, not server-auth-only. (The security review's "Bun silently
+ * drops the cert" reading reproduced only under socket-pool / session-ticket
+ * contamination — a probe that reuses an already-mTLS-authenticated keep-alive
+ * socket. Against a fresh connection the cert is presented; the wire test
+ * proves this against a real enforcing server and is the regression guard for
+ * any future runtime that might drop it.)
  */
 type MtlsRequestInit = RequestInit & {
   tls?: { cert: string; key: string; ca?: string };

--- a/src/taps/cc-events/cloud-publisher.ts
+++ b/src/taps/cc-events/cloud-publisher.ts
@@ -25,6 +25,20 @@
 import type { PublishedEvent } from "./hooks/lib/event-types";
 import type { NetworkResolver } from "../../common/types/config";
 import { fetchWithTimeout } from "../../common/timeout";
+import type { HttpsMtlsMaterial } from "../../common/config/transport-mtls";
+
+/**
+ * TC-4e (#627 Phase 4) — Bun's `fetch` accepts a `tls` field on the request
+ * init for client-cert (mutual) TLS; the WHATWG `RequestInit` type does not
+ * declare it. This narrow extension types the `tls` we attach WITHOUT widening
+ * to `any` and without a Bun-types dependency. We only ever set `cert`/`key`/
+ * `ca` (contents) — NEVER `rejectUnauthorized` or any skip-verify field
+ * (CLAUDE.md hard line). On a runtime that ignores `tls` on fetch the leg
+ * stays server-auth HTTPS (no downgrade of verification, just no client cert).
+ */
+type MtlsRequestInit = RequestInit & {
+  tls?: { cert: string; key: string; ca?: string };
+};
 
 export interface CloudPublisherConfig {
   /** Function to resolve network config by network_id. Returns null for unknown networks. */
@@ -33,6 +47,16 @@ export interface CloudPublisherConfig {
   batchSizeLimit?: number;   // default 50
   maxRetries?: number;       // default 3
   retryBaseMs?: number;      // default 1000 (backoff = 2^attempt * retryBaseMs)
+  /**
+   * TC-4e (#627 Phase 4) — optional client-cert material for the
+   * publisher→Worker HTTPS leg (built by `buildHttpsMtlsMaterial` from the
+   * `security.transport.mtls` posture). When present, every `/api/ingest` POST
+   * (and the startup health probe) presents this client certificate. When
+   * `undefined` (default / posture `off`), the leg is ordinary server-auth
+   * HTTPS — byte-identical to pre-TC-4e. Loaded once at boot; contents are
+   * never logged.
+   */
+  mtls?: HttpsMtlsMaterial;
 }
 
 export class CloudPublisher {
@@ -41,6 +65,8 @@ export class CloudPublisher {
   private readonly batchSizeLimit: number;
   private readonly maxRetries: number;
   private readonly retryBaseMs: number;
+  /** TC-4e — client-cert material for the →Worker HTTPS leg, or undefined. */
+  private readonly mtls?: HttpsMtlsMaterial;
 
   private static readonly MAX_BUFFER_SIZE = 500;
   private buffer: PublishedEvent[] = [];
@@ -53,6 +79,7 @@ export class CloudPublisher {
     this.batchSizeLimit = config.batchSizeLimit ?? 50;
     this.maxRetries = config.maxRetries ?? 3;
     this.retryBaseMs = config.retryBaseMs ?? 1000;
+    this.mtls = config.mtls;
 
     this.interval = setInterval(() => {
       void this.flushInternal();
@@ -102,7 +129,11 @@ export class CloudPublisher {
    * Detects stale endpoints (redirects from zombie CF Access apps), timeouts, and DNS failures.
    * Non-blocking — logs warnings but does not prevent startup.
    */
-  static async checkEndpoints(resolver: NetworkResolver, networkIds: string[]): Promise<void> {
+  static async checkEndpoints(
+    resolver: NetworkResolver,
+    networkIds: string[],
+    mtls?: HttpsMtlsMaterial,
+  ): Promise<void> {
     for (const networkId of networkIds) {
       const config = resolver(networkId);
       if (!config) continue;
@@ -114,11 +145,15 @@ export class CloudPublisher {
           headers["CF-Access-Client-Id"] = config.cfAccessClientId;
           headers["CF-Access-Client-Secret"] = config.cfAccessClientSecret;
         }
-        const res = await fetchWithTimeout("cloud_publisher", 5_000, url, {
+        // TC-4e — present the client cert on the health probe too, so a
+        // require-mode misconfig surfaces at startup, not first publish.
+        const init: MtlsRequestInit = {
           method: "GET",
           headers,
           redirect: "manual",
-        });
+          ...(mtls !== undefined ? { tls: mtls } : {}),
+        };
+        const res = await fetchWithTimeout("cloud_publisher", 5_000, url, init);
 
         if (res.status >= 300 && res.status < 400) {
           const location = res.headers.get("location") ?? "(unknown)";
@@ -215,7 +250,16 @@ export class CloudPublisher {
           headers["CF-Access-Client-Id"] = networkConfig.cfAccessClientId;
           headers["CF-Access-Client-Secret"] = networkConfig.cfAccessClientSecret;
         }
-        const res = await fetch(url, { method: "POST", headers, body, redirect: "manual" });
+        // TC-4e — attach the client cert when mTLS material is configured;
+        // omitted ⇒ ordinary server-auth HTTPS, byte-identical to pre-TC-4e.
+        const init: MtlsRequestInit = {
+          method: "POST",
+          headers,
+          body,
+          redirect: "manual",
+          ...(this.mtls !== undefined ? { tls: this.mtls } : {}),
+        };
+        const res = await fetch(url, init);
 
         if (res.ok) {
           return; // Success

--- a/src/taps/cc-events/relay.ts
+++ b/src/taps/cc-events/relay.ts
@@ -16,6 +16,11 @@ import { RawEventSchema } from "./hooks/lib/event-types";
 import { resolvePrincipalEnv } from "./hooks/lib/principal-env";
 import { NatsLink } from "../../bus/nats/connection";
 import { createCcEventPublisher } from "./cc-events";
+import {
+  buildNatsTlsOptions,
+  type MtlsMode,
+  type MtlsPaths,
+} from "../../common/config/transport-mtls";
 
 // Per-command Commander option shapes. Pin the permissive `opts: any`
 // default to the actual flag set so `opts.policy` etc. narrow.
@@ -27,6 +32,11 @@ interface StartOptions {
   org?: string;
   stack?: string;
   originatorPrincipal?: string;
+  // TC-4d (#627 Phase 4) — transport mTLS for the relay's own NatsLink.
+  mtls?: string;
+  tlsCert?: string;
+  tlsKey?: string;
+  tlsCa?: string;
 }
 interface TestOptions {
   policy: string;
@@ -173,6 +183,22 @@ program
     "--originator-principal <did>",
     "cortex#346 / myelin#161 — DID (did:mf:<name>) stamped onto envelope.originator for every relay-lifted CC event. Attribution mode is fixed at 'adapter-resolved' (the relay maps the running CC session to the stack's myelin principal). Falls back to env var CORTEX_ORIGINATOR_PRINCIPAL. Omit to publish without an originator block (pre-#346 behaviour; receivers fall back to signed_by[0].principal).",
   )
+  .option(
+    "--mtls <mode>",
+    "TC-4d (#627 Phase 4) — transport mTLS mode for the relay's NATS connection: off (default, plaintext) | on (offer client cert, degrade to plaintext if absent) | require (refuse non-mTLS, fail closed). Falls back to env var CORTEX_TRANSPORT_MTLS.",
+  )
+  .option(
+    "--tls-cert <path>",
+    "TC-4d — path to the PEM client certificate the relay presents. Falls back to env var CORTEX_TLS_CERT_PATH.",
+  )
+  .option(
+    "--tls-key <path>",
+    "TC-4d — path to the PEM private key for --tls-cert (chmod 600 enforced). Falls back to env var CORTEX_TLS_KEY_PATH.",
+  )
+  .option(
+    "--tls-ca <path>",
+    "TC-4d — path to the PEM CA bundle used to verify the NATS server cert (omit to use the system trust store). Falls back to env var CORTEX_TLS_CA_PATH.",
+  )
   .action(async (options: StartOptions) => {
     if (!existsSync(options.policy)) {
       console.error(`Policy file not found: ${options.policy}`);
@@ -237,12 +263,40 @@ program
     let natsLink: NatsLink | undefined;
     let onPublished: ((e: import("./hooks/lib/event-types").PublishedEvent) => void) | undefined;
 
+    // TC-4d (#627 Phase 4) — transport-mTLS for the relay's own NatsLink
+    // (token-only pre-TC-4d). Mode + cert/key/ca resolve from flags then env;
+    // `off` (default) builds no tls block ⇒ plaintext, byte-identical to today.
+    // Under `require`, a missing/invalid cert throws from `buildNatsTlsOptions`
+    // and is caught by the existing connect try/catch — the relay then
+    // continues JSONL-only (it must never crash its archival job), but it does
+    // NOT publish over a plaintext bus, so the fail-closed guarantee holds.
+    const mtlsModeRaw = options.mtls ?? process.env.CORTEX_TRANSPORT_MTLS ?? "off";
+    if (mtlsModeRaw !== "off" && mtlsModeRaw !== "on" && mtlsModeRaw !== "require") {
+      console.error(
+        `cortex-relay: invalid --mtls / CORTEX_TRANSPORT_MTLS value ${JSON.stringify(mtlsModeRaw)} — must be off | on | require`,
+      );
+      process.exit(1);
+    }
+    const mtlsMode: MtlsMode = mtlsModeRaw;
+    // `MtlsPaths` fields are all optional; `buildNatsTlsOptions` reads them via
+    // `paths?.cert_path`, so an absent flag/env resolving to `undefined` is
+    // equivalent to omitting the key. No conditional spread needed.
+    const tlsPaths: MtlsPaths = {
+      cert_path: options.tlsCert ?? process.env.CORTEX_TLS_CERT_PATH,
+      key_path: options.tlsKey ?? process.env.CORTEX_TLS_KEY_PATH,
+      ca_path: options.tlsCa ?? process.env.CORTEX_TLS_CA_PATH,
+    };
+
     if (natsUrl) {
       try {
+        const relayTls = buildNatsTlsOptions(mtlsMode, tlsPaths, {
+          site: "cortex-relay",
+        });
         natsLink = await NatsLink.connect({
           url: natsUrl,
           token: natsToken,
           name: "cortex-relay",
+          ...(relayTls !== undefined ? { tls: relayTls } : {}),
         });
         onPublished = createCcEventPublisher({
           link: natsLink,


### PR DESCRIPTION
## What

Transport-layer defense-in-depth: **mutual-TLS on the wire**, gated by the existing `security.transport.mtls` posture toggle (TC-0, **default OFF**). Implements `docs/design-trust-confidentiality.md` **§Phase 4 (4d + 4e)** — the at-rest/mTLS branch that runs "parallel from the start", **independent of the envelope-signing path** (different layer: signing is M3/M4 envelope, mTLS is M1/M2 transport).

## TC-4d — NATS mTLS

- New `src/common/config/transport-mtls.ts`: `buildNatsTlsOptions(mode, paths, ctx)` is the single DRY mapping from the `security.transport.mtls` mode + a new `transport.tls.{cert_path,key_path,ca_path}` block to nats.js's `tls` ConnectionOptions. Loads cert/key/ca **contents** (so the chmod-600 gate runs in our loader, not nats.js).
- `NatsLinkOptions.tls` threads the built block into `connect({ tls })`.
- Wired at **every** connection site:
  - **primary link** + **each federated leaf link** in the MyelinRuntime LinkPool (`runtime.ts`),
  - the **cortex-relay**'s own NatsLink (new `--mtls` / `--tls-cert|key|ca` flags + `CORTEX_TRANSPORT_MTLS` / `CORTEX_TLS_*_PATH` env).

### The `transport.mtls` gate (default-off, enforce-fails-closed)

| mode | build tls? | missing/invalid cert/key/ca |
|------|-----------|------------------------------|
| `off` (default) | never | n/a — plaintext, byte-identical to today |
| `on` | best-effort offer | warn + connect plaintext |
| `require` | always | **FAIL CLOSED** — throw, never plaintext |

Under `require` the relay's throw is caught by the existing connect guard → relay continues **JSONL-only**, it does **not** publish over a plaintext bus, so the fail-closed guarantee holds end-to-end.

## TC-4e — cloud-publisher mTLS + federated-cleartext warning

- `buildHttpsMtlsMaterial(...)` loads client-cert material for the **cloud-publisher → Worker HTTPS leg**; `CloudPublisherConfig.mtls` attaches it to the ingest POST + startup health probe via Bun fetch's `tls`. `off` → ordinary server-auth HTTPS (back-compat).
- A **federated leaf that connects WITHOUT TLS** (`nats://` + mtls off) fires a LOUD `warnFederatedCleartext` advisory (stderr + optional structured sink for `system.error` promotion) — cross-principal cleartext is a confidentiality risk. Fires **regardless of posture** (advisory), most relevant when mtls is off and federated leaves exist.

## The no-skip-verify hard line (CLAUDE.md)

This change **never** emits `rejectUnauthorized:false` or any insecure/skip-verify escape hatch — every such token in the diff is in a docstring **asserting** the prohibition. mTLS means **both** sides verify; nats.js's secure default (`rejectUnauthorized: true`) is left intact. Private **key** files are chmod-600 gated (shared `enforceChmod600`, same policy as the nkey-seed / `.creds` loaders); cert/key/ca **contents are never logged** — only paths + a SHA-256 fingerprint.

## OFF = back-compat

With `mtls: off` (the schema default) **no** tls block is built on any link and the connect options are **byte-identical** to today. Pinned by tests (`off → undefined`, runtime `not.toHaveProperty("tls")`, cloud-publisher `init.tls` undefined).

## Verification

- `bunx tsc --noEmit` — 0 errors
- `bun run lint:errors` — clean
- `bash scripts/check-carveouts.sh` — PASS (uses `principal`, "cross-principal")
- New tests (throwaway certs in temp dirs; connect-options builder asserted — no real TLS server): mode mapping, **enforce-fail-closed** (missing paths / missing file / non-chmod-600 key), **OFF byte-identical**, **no key/cert bytes in any log line**, **federated-cleartext warning fires** (+ tls:// suppresses it), leaf+primary tls threading, cloud-publisher tls-init attach.
- Full suite: **4244 pass / 0 fail**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)