### PR TITLE
feat(mc-worker): grove→cortex DEV cutover (Phase 1)

### DIFF
--- a/src/surface/mc/worker/package.json
+++ b/src/surface/mc/worker/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "wrangler dev",
     "deploy": "wrangler deploy",
-    "db:migrate": "wrangler d1 execute GROVE_DB --file=./schema.sql"
+    "db:migrate": "wrangler d1 execute CORTEX_DB --file=./schema.sql"
   },
   "dependencies": {
     "hono": "^4.7.0",

--- a/src/surface/mc/worker/src/auth.ts
+++ b/src/surface/mc/worker/src/auth.ts
@@ -69,19 +69,19 @@ export async function requireApiKey(c: Context<{ Bindings: Env; Variables: { pri
   const auth = c.req.header("Authorization");
 
   if (!auth || !auth.startsWith("Bearer ")) {
-    logAuditEvent(c.env.GROVE_DB, { eventType: "api_key_auth", result: "failure", ip, endpoint, method, detail: "missing bearer header" });
+    logAuditEvent(c.env.CORTEX_DB, { eventType: "api_key_auth", result: "failure", ip, endpoint, method, detail: "missing bearer header" });
     return c.json({ error: "missing Authorization: Bearer header" }, 401);
   }
 
   const token = auth.slice(7);
   if (!token) {
-    logAuditEvent(c.env.GROVE_DB, { eventType: "api_key_auth", result: "failure", ip, endpoint, method, detail: "empty token" });
+    logAuditEvent(c.env.CORTEX_DB, { eventType: "api_key_auth", result: "failure", ip, endpoint, method, detail: "empty token" });
     return c.json({ error: "empty bearer token" }, 401);
   }
 
-  const keyData = await c.env.GROVE_KEYS.get(token, "json") as PrincipalKey | null;
+  const keyData = await c.env.CORTEX_KEYS.get(token, "json") as PrincipalKey | null;
   if (!keyData) {
-    logAuditEvent(c.env.GROVE_DB, { eventType: "api_key_auth", result: "failure", ip, endpoint, method, detail: "invalid or revoked key" });
+    logAuditEvent(c.env.CORTEX_DB, { eventType: "api_key_auth", result: "failure", ip, endpoint, method, detail: "invalid or revoked key" });
     return c.json({ error: "invalid or revoked API key" }, 401);
   }
 
@@ -90,10 +90,10 @@ export async function requireApiKey(c: Context<{ Bindings: Env; Variables: { pri
   // empty principal that ingest would then trust as the attribution identity.
   const principalId = keyData.principal_id;
   if (!principalId) {
-    logAuditEvent(c.env.GROVE_DB, { eventType: "api_key_auth", result: "failure", ip, endpoint, method, detail: "key missing principal_id" });
+    logAuditEvent(c.env.CORTEX_DB, { eventType: "api_key_auth", result: "failure", ip, endpoint, method, detail: "key missing principal_id" });
     return c.json({ error: "API key missing principal identity" }, 401);
   }
-  logAuditEvent(c.env.GROVE_DB, { eventType: "api_key_auth", result: "success", ip, endpoint, method, identity: principalId });
+  logAuditEvent(c.env.CORTEX_DB, { eventType: "api_key_auth", result: "success", ip, endpoint, method, identity: principalId });
   c.set("principalId", principalId);
   c.set("principalKey", keyData);
   await next();
@@ -109,18 +109,18 @@ export async function requireAdmin(c: Context<{ Bindings: Env }>, next: Next) {
   const auth = c.req.header("Authorization");
 
   if (!auth || !auth.startsWith("Bearer ")) {
-    logAuditEvent(c.env.GROVE_DB, { eventType: "admin_auth", result: "failure", ip, endpoint, method, detail: "missing bearer header" });
+    logAuditEvent(c.env.CORTEX_DB, { eventType: "admin_auth", result: "failure", ip, endpoint, method, detail: "missing bearer header" });
     return c.json({ error: "missing Authorization: Bearer header" }, 401);
   }
 
   const token = auth.slice(7);
   const adminSecret = c.env.ADMIN_SECRET;
   if (!adminSecret || token !== adminSecret) {
-    logAuditEvent(c.env.GROVE_DB, { eventType: "admin_auth", result: "failure", ip, endpoint, method, detail: "invalid admin secret" });
+    logAuditEvent(c.env.CORTEX_DB, { eventType: "admin_auth", result: "failure", ip, endpoint, method, detail: "invalid admin secret" });
     return c.json({ error: "unauthorized" }, 403);
   }
 
-  logAuditEvent(c.env.GROVE_DB, { eventType: "admin_auth", result: "success", ip, endpoint, method, identity: "admin" });
+  logAuditEvent(c.env.CORTEX_DB, { eventType: "admin_auth", result: "success", ip, endpoint, method, identity: "admin" });
   await next();
 }
 
@@ -252,19 +252,19 @@ export async function requireCfAccess(c: Context<{ Bindings: Env; Variables: { c
   const token = match?.[1];
 
   if (!token) {
-    logAuditEvent(c.env.GROVE_DB, { eventType: "cf_access_auth", result: "failure", ip, endpoint, method, detail: "no CF_Authorization cookie" });
+    logAuditEvent(c.env.CORTEX_DB, { eventType: "cf_access_auth", result: "failure", ip, endpoint, method, detail: "no CF_Authorization cookie" });
     return c.json({ error: "authentication required" }, 403);
   }
 
   const payload = await validateCfAccessJwt(token, audience);
   if (!payload) {
-    logAuditEvent(c.env.GROVE_DB, { eventType: "cf_access_auth", result: "failure", ip, endpoint, method, detail: "invalid or expired JWT" });
+    logAuditEvent(c.env.CORTEX_DB, { eventType: "cf_access_auth", result: "failure", ip, endpoint, method, detail: "invalid or expired JWT" });
     return c.json({ error: "invalid or expired access token" }, 403);
   }
 
   // Attach identity to context for downstream use
   const email = (payload.email as string) ?? "unknown";
-  logAuditEvent(c.env.GROVE_DB, { eventType: "cf_access_auth", result: "success", ip, endpoint, method, identity: email });
+  logAuditEvent(c.env.CORTEX_DB, { eventType: "cf_access_auth", result: "success", ip, endpoint, method, identity: email });
   c.set("cfAccessEmail", email);
   await next();
 }

--- a/src/surface/mc/worker/src/index.ts
+++ b/src/surface/mc/worker/src/index.ts
@@ -19,7 +19,7 @@ import { dashboardRoutes } from "./routes/dashboard";
 import { DashboardSocket } from "./dashboard-socket";
 
 export interface Env extends AuthBindings {
-  GROVE_KEYS: KVNamespace;
+  CORTEX_KEYS: KVNamespace;
   ADMIN_SECRET: string;
   GITHUB_WEBHOOK_SECRET: string;
   GITHUB_TOKEN: string;
@@ -73,7 +73,7 @@ app.get("/api/health", (c) => {
 
 // H-002: Pipeline health — cloud version (no relay, just last-event stats from D1)
 app.get("/api/pipeline/health", async (c) => {
-  const db = c.env.GROVE_DB;
+  const db = c.env.CORTEX_DB;
   const row = await db.prepare(`
     SELECT MAX(last_event_at) as last_event_at, COUNT(*) as active_sessions
     FROM sessions WHERE status = 'active'

--- a/src/surface/mc/worker/src/routes/admin.ts
+++ b/src/surface/mc/worker/src/routes/admin.ts
@@ -50,7 +50,7 @@ adminRoutes.post("/admin/keys", requireAdmin, async (c) => {
   };
 
   // Store in KV (key as key, metadata as value)
-  await c.env.GROVE_KEYS.put(key, JSON.stringify(keyData));
+  await c.env.CORTEX_KEYS.put(key, JSON.stringify(keyData));
 
   return c.json({
     key,
@@ -65,7 +65,7 @@ adminRoutes.post("/admin/keys", requireAdmin, async (c) => {
 // ---------------------------------------------------------------------------
 
 adminRoutes.get("/admin/audit", requireRole("admin"), async (c) => {
-  const db = c.env.GROVE_DB;
+  const db = c.env.CORTEX_DB;
   const limit = Math.min(parseInt(c.req.query("limit") ?? "100"), 500);
   const eventType = c.req.query("type"); // Optional filter: api_key_auth, admin_auth, cf_access_auth
   const resultFilter = c.req.query("result"); // Optional filter: success, failure
@@ -105,12 +105,12 @@ adminRoutes.delete("/admin/keys/:key", requireAdmin, async (c) => {
   }
 
   // Check if key exists
-  const existing = await c.env.GROVE_KEYS.get(key);
+  const existing = await c.env.CORTEX_KEYS.get(key);
   if (!existing) {
     return c.json({ error: "key not found" }, 404);
   }
 
-  await c.env.GROVE_KEYS.delete(key);
+  await c.env.CORTEX_KEYS.delete(key);
 
   return c.json({ ok: true, revoked: key });
 });
@@ -127,7 +127,7 @@ adminRoutes.delete("/admin/repos/:owner/:name", requireAdmin, async (c) => {
   }
 
   const fullName = `${owner}/${name}`;
-  const db = c.env.GROVE_DB;
+  const db = c.env.CORTEX_DB;
 
   // Delete from all tables that reference this repo
   const results = await db.batch([

--- a/src/surface/mc/worker/src/routes/dashboard.ts
+++ b/src/surface/mc/worker/src/routes/dashboard.ts
@@ -11,7 +11,7 @@ import { getCachedSnapshot } from "./state";
 export const dashboardRoutes = new Hono<{ Bindings: Env }>();
 
 dashboardRoutes.get("/api/dashboard", async (c) => {
-  const db = c.env.GROVE_DB;
+  const db = c.env.CORTEX_DB;
   const { json } = await getCachedSnapshot(db);
 
   return new Response(json, {

--- a/src/surface/mc/worker/src/routes/github.ts
+++ b/src/surface/mc/worker/src/routes/github.ts
@@ -46,7 +46,7 @@ githubRoutes.post("/api/github/webhook", async (c) => {
   }
 
   const payload = JSON.parse(body);
-  const db = c.env.GROVE_DB;
+  const db = c.env.CORTEX_DB;
 
   // Get allowed repos from env (comma-separated)
   const allowedRepos = (c.env.GITHUB_REPOS ?? "").split(",").map((s) => s.trim()).filter(Boolean);

--- a/src/surface/mc/worker/src/routes/ingest.ts
+++ b/src/surface/mc/worker/src/routes/ingest.ts
@@ -57,7 +57,7 @@ ingestRoutes.post("/api/ingest", requireApiKey, async (c) => {
   let ingested = 0;
   let skipped = 0;
 
-  const db = c.env.GROVE_DB;
+  const db = c.env.CORTEX_DB;
   const activitySessionIds = new Set<string>();
   // Events that committed this request — fanned to live dashboards after the response.
   const broadcastable: IngestEvent[] = [];

--- a/src/surface/mc/worker/src/routes/repos.ts
+++ b/src/surface/mc/worker/src/routes/repos.ts
@@ -18,7 +18,7 @@ export const repoRoutes = new Hono<{ Bindings: Env }>();
 // ---------------------------------------------------------------------------
 
 repoRoutes.get("/api/repos", async (c) => {
-  const db = c.env.GROVE_DB;
+  const db = c.env.CORTEX_DB;
 
   const { results } = await db.prepare(`
     SELECT r.full_name, r.short_name, r.description, r.default_branch, r.synced_at,
@@ -50,7 +50,7 @@ repoRoutes.get("/api/repos", async (c) => {
 // ---------------------------------------------------------------------------
 
 repoRoutes.get("/api/repos/:name/issues", async (c) => {
-  const db = c.env.GROVE_DB;
+  const db = c.env.CORTEX_DB;
   const repoName = c.req.param("name");
   const state = c.req.query("state") as "open" | "closed" | undefined;
 
@@ -93,7 +93,7 @@ repoRoutes.get("/api/repos/:name/issues", async (c) => {
 // ---------------------------------------------------------------------------
 
 repoRoutes.get("/api/repos/:name/pulls", async (c) => {
-  const db = c.env.GROVE_DB;
+  const db = c.env.CORTEX_DB;
   const repoName = c.req.param("name");
   const state = c.req.query("state") as "open" | "closed" | "merged" | undefined;
 
@@ -138,7 +138,7 @@ repoRoutes.get("/api/repos/:name/pulls", async (c) => {
 // ---------------------------------------------------------------------------
 
 repoRoutes.get("/api/repos/:name/pulls/:n/comments", async (c) => {
-  const db = c.env.GROVE_DB;
+  const db = c.env.CORTEX_DB;
   const repoName = c.req.param("name");
   const prNumber = parseInt(c.req.param("n"));
 

--- a/src/surface/mc/worker/src/routes/state.ts
+++ b/src/surface/mc/worker/src/routes/state.ts
@@ -206,7 +206,7 @@ export async function getCachedSnapshot(db: D1Database): Promise<{ json: string;
 export const stateRoutes = new Hono<{ Bindings: Env }>();
 
 stateRoutes.get("/api/state", async (c) => {
-  const db = c.env.GROVE_DB;
+  const db = c.env.CORTEX_DB;
   const project = c.req.query("project");
   // IAW D.5.2 — `?home_principal=<id>` slices the snapshot to a single
   // originating principal. Sentinel `"local"` means "null home_principal

--- a/src/surface/mc/worker/src/routes/stats.ts
+++ b/src/surface/mc/worker/src/routes/stats.ts
@@ -10,7 +10,7 @@ import type { Env } from "../index";
 export const statsRoutes = new Hono<{ Bindings: Env }>();
 
 statsRoutes.get("/api/stats/activity", async (c) => {
-  const db = c.env.GROVE_DB;
+  const db = c.env.CORTEX_DB;
   const days = Math.min(parseInt(c.req.query("days") ?? "7"), 90);
 
   const now = new Date();

--- a/src/surface/mc/worker/src/routes/sync.ts
+++ b/src/surface/mc/worker/src/routes/sync.ts
@@ -24,7 +24,7 @@ syncRoutes.post("/api/sync", requireApiKey, async (c) => {
     return c.json({ error: "GITHUB_REPOS not configured" }, 503);
   }
 
-  const db = c.env.GROVE_DB;
+  const db = c.env.CORTEX_DB;
   const totals = { repos: 0, issues: 0, prs: 0, releases: 0, commits: 0 };
 
   for (const repoFullName of reposConfig) {

--- a/src/surface/mc/worker/src/user-auth/middleware/require-agent-access.ts
+++ b/src/surface/mc/worker/src/user-auth/middleware/require-agent-access.ts
@@ -34,7 +34,7 @@ export function requireAgentAccess(requiredScope: GrantScope) {
     }
 
     // Single query: fetch agent + best matching grant in one round-trip
-    const row = await c.env.GROVE_DB.prepare(`
+    const row = await c.env.CORTEX_DB.prepare(`
       SELECT
         a.id AS agent_id,
         a.owner_id,
@@ -58,7 +58,7 @@ export function requireAgentAccess(requiredScope: GrantScope) {
     }>();
 
     if (!row) {
-      logAuditEvent(c.env.GROVE_DB, {
+      logAuditEvent(c.env.CORTEX_DB, {
         eventType: "agent_access", result: "failure", ip, endpoint, method,
         identity: user.email, detail: `agent ${agentId} not found`,
       });
@@ -75,7 +75,7 @@ export function requireAgentAccess(requiredScope: GrantScope) {
     });
 
     if (!result.allowed) {
-      logAuditEvent(c.env.GROVE_DB, {
+      logAuditEvent(c.env.CORTEX_DB, {
         eventType: "agent_access", result: "failure", ip, endpoint, method,
         identity: user.email,
         detail: `no_agent_access: agent=${agentId}, required=${requiredScope}, available=${result.availableScope ?? "none"}`,
@@ -88,7 +88,7 @@ export function requireAgentAccess(requiredScope: GrantScope) {
       }, 403);
     }
 
-    logAuditEvent(c.env.GROVE_DB, {
+    logAuditEvent(c.env.CORTEX_DB, {
       eventType: "agent_access", result: "success", ip, endpoint, method,
       identity: user.email,
       detail: `agent=${agentId}, scope=${requiredScope}, resolution=${result.resolution}, available=${result.availableScope}`,

--- a/src/surface/mc/worker/src/user-auth/middleware/require-auth.ts
+++ b/src/surface/mc/worker/src/user-auth/middleware/require-auth.ts
@@ -30,7 +30,7 @@ export async function authenticateUser(
   if (!email) {
     return { ok: false, error: "no CF Access identity" };
   }
-  const user = await getUserByEmail(env.GROVE_DB, email);
+  const user = await getUserByEmail(env.CORTEX_DB, email);
   if (!user) {
     return { ok: false, error: "user not provisioned", email };
   }
@@ -52,14 +52,14 @@ export function requireAuth() {
 
     const auth = await authenticateUser(c.env, c.req);
     if (!auth.ok) {
-      logAuditEvent(c.env.GROVE_DB, {
+      logAuditEvent(c.env.CORTEX_DB, {
         eventType: "auth", result: "failure", ip, endpoint, method,
         identity: auth.email, detail: auth.error,
       });
       return c.json({ error: "authentication required" }, 401);
     }
 
-    logAuditEvent(c.env.GROVE_DB, {
+    logAuditEvent(c.env.CORTEX_DB, {
       eventType: "auth", result: "success", ip, endpoint, method,
       identity: auth.email,
     });

--- a/src/surface/mc/worker/src/user-auth/middleware/require-role.ts
+++ b/src/surface/mc/worker/src/user-auth/middleware/require-role.ts
@@ -26,7 +26,7 @@ export function requireRole(minRole: Role) {
 
     const auth = await authenticateUser(c.env, c.req);
     if (!auth.ok) {
-      logAuditEvent(c.env.GROVE_DB, {
+      logAuditEvent(c.env.CORTEX_DB, {
         eventType: "role_check", result: "failure", ip, endpoint, method,
         identity: auth.email, detail: auth.error,
       });
@@ -35,14 +35,14 @@ export function requireRole(minRole: Role) {
 
     const result = checkRole(auth.user.role, minRole);
     if (!result.allowed) {
-      logAuditEvent(c.env.GROVE_DB, {
+      logAuditEvent(c.env.CORTEX_DB, {
         eventType: "role_check", result: "failure", ip, endpoint, method,
         identity: auth.email, detail: `insufficient_role: has ${auth.user.role}, needs ${minRole}`,
       });
       return c.json({ error: result.error, required: result.required, current: result.current }, 403);
     }
 
-    logAuditEvent(c.env.GROVE_DB, {
+    logAuditEvent(c.env.CORTEX_DB, {
       eventType: "role_check", result: "success", ip, endpoint, method,
       identity: auth.email, detail: `role=${auth.user.role} meets ${minRole}`,
     });

--- a/src/surface/mc/worker/src/user-auth/routes/auth.ts
+++ b/src/surface/mc/worker/src/user-auth/routes/auth.ts
@@ -52,7 +52,7 @@ async function resolveAgentAccess(
 ): Promise<{ agent: AgentRecord } | Response> {
   const user = c.get("user");
   const agentId = c.req.param("agentId");
-  const db = c.env.GROVE_DB;
+  const db = c.env.CORTEX_DB;
 
   const agent = await db.prepare("SELECT * FROM agents WHERE id = ?").bind(agentId).first<AgentRecord>();
   if (!agent) {
@@ -77,7 +77,7 @@ async function resolveAgentAccess(
   });
 
   if (!access.allowed) {
-    logAuditEvent(c.env.GROVE_DB, {
+    logAuditEvent(c.env.CORTEX_DB, {
       eventType: "agent_access", result: "failure",
       ip: getClientIp(c), endpoint: new URL(c.req.url).pathname, method: c.req.method,
       identity: user.email,
@@ -103,7 +103,7 @@ authRoutes.use("/api/auth/*", requireAuth());
 
 authRoutes.get("/api/auth/me", async (c) => {
   const user = c.get("user");
-  const db = c.env.GROVE_DB;
+  const db = c.env.CORTEX_DB;
 
   const [ownedAgents, receivedGrants, givenGrants] = await Promise.all([
     db.prepare("SELECT * FROM agents WHERE owner_id = ?").bind(user.id).all(),
@@ -138,7 +138,7 @@ authRoutes.get("/api/auth/users", async (c) => {
   const user = c.get("user");
   const result = checkRole(user.role, "admin");
   if (!result.allowed) {
-    logAuditEvent(c.env.GROVE_DB, {
+    logAuditEvent(c.env.CORTEX_DB, {
       eventType: "role_check", result: "failure",
       ip: getClientIp(c), endpoint: new URL(c.req.url).pathname, method: "GET",
       identity: user.email,
@@ -148,7 +148,7 @@ authRoutes.get("/api/auth/users", async (c) => {
   }
 
   const { limit, offset } = parsePagination(c);
-  const users = await c.env.GROVE_DB.prepare(
+  const users = await c.env.CORTEX_DB.prepare(
     "SELECT * FROM users ORDER BY created_at LIMIT ? OFFSET ?",
   ).bind(limit, offset).all();
   return c.json({ users: users.results, limit, offset });
@@ -162,7 +162,7 @@ authRoutes.put("/api/auth/users/:id/role", async (c) => {
   const caller = c.get("user");
   const result = checkRole(caller.role, "admin");
   if (!result.allowed) {
-    logAuditEvent(c.env.GROVE_DB, {
+    logAuditEvent(c.env.CORTEX_DB, {
       eventType: "role_check", result: "failure",
       ip: getClientIp(c), endpoint: new URL(c.req.url).pathname, method: "PUT",
       identity: caller.email,
@@ -177,7 +177,7 @@ authRoutes.put("/api/auth/users/:id/role", async (c) => {
     return c.json({ error: "invalid role", valid: ["viewer", "operator", "admin"] }, 400);
   }
 
-  const db = c.env.GROVE_DB;
+  const db = c.env.CORTEX_DB;
   const target = await db.prepare("SELECT * FROM users WHERE id = ?").bind(targetId).first<UserRecord>();
   if (!target) {
     return c.json({ error: "user_not_found", id: targetId }, 404);
@@ -213,7 +213,7 @@ authRoutes.put("/api/auth/users/:id/role", async (c) => {
 
 authRoutes.get("/api/auth/agents", async (c) => {
   const user = c.get("user");
-  const db = c.env.GROVE_DB;
+  const db = c.env.CORTEX_DB;
 
   if (user.role === "admin") {
     const { limit, offset } = parsePagination(c);
@@ -252,7 +252,7 @@ authRoutes.get("/api/auth/agents/:agentId", async (c) => {
   const { agent } = result;
 
   const agentId = c.req.param("agentId");
-  const db = c.env.GROVE_DB;
+  const db = c.env.CORTEX_DB;
 
   const [grants, owner] = await Promise.all([
     db.prepare(`
@@ -275,7 +275,7 @@ authRoutes.get("/api/auth/agents/:agentId", async (c) => {
 authRoutes.post("/api/auth/agents/:agentId/grants", async (c) => {
   const caller = c.get("user");
   const agentId = c.req.param("agentId");
-  const db = c.env.GROVE_DB;
+  const db = c.env.CORTEX_DB;
 
   const agent = await db.prepare("SELECT * FROM agents WHERE id = ?").bind(agentId).first<AgentRecord>();
   if (!agent) {
@@ -355,7 +355,7 @@ authRoutes.get("/api/auth/agents/:agentId/grants", async (c) => {
   if (result instanceof Response) return result;
 
   const agentId = c.req.param("agentId");
-  const db = c.env.GROVE_DB;
+  const db = c.env.CORTEX_DB;
   const { limit, offset } = parsePagination(c);
 
   const grants = await db.prepare(`
@@ -376,7 +376,7 @@ authRoutes.get("/api/auth/agents/:agentId/grants", async (c) => {
 authRoutes.delete("/api/auth/grants/:grantId", async (c) => {
   const caller = c.get("user");
   const grantId = c.req.param("grantId");
-  const db = c.env.GROVE_DB;
+  const db = c.env.CORTEX_DB;
 
   const grant = await db.prepare(
     "SELECT * FROM agent_grants WHERE id = ?",

--- a/src/surface/mc/worker/src/user-auth/types.ts
+++ b/src/surface/mc/worker/src/user-auth/types.ts
@@ -46,6 +46,6 @@ export interface GrantRecord {
  * The consuming Worker's Env must extend this.
  */
 export interface AuthBindings {
-  GROVE_DB: D1Database;
+  CORTEX_DB: D1Database;
   CF_ACCESS_AUD: string;
 }

--- a/src/surface/mc/worker/wrangler.toml
+++ b/src/surface/mc/worker/wrangler.toml
@@ -12,12 +12,12 @@ CORS_ORIGIN = "http://localhost:8766,http://localhost:8765"
 
 # Base bindings for local dev (wrangler dev uses these defaults)
 [[d1_databases]]
-binding = "GROVE_DB"
+binding = "CORTEX_DB"
 database_name = "grove-events-local"
 database_id = "placeholder-local-id"
 
 [[kv_namespaces]]
-binding = "GROVE_KEYS"
+binding = "CORTEX_KEYS"
 id = "placeholder-local-kv-id"
 
 # DashboardSocket DO — backs the dashboard WebSocket (/ws). Named environments
@@ -33,21 +33,21 @@ tag = "v1"
 new_sqlite_classes = ["DashboardSocket"]
 
 # ──────────────────────────────────────────────────────────────────
-# Environment: Development (grove-dev.meta-factory.{ai,dev,io})
+# Environment: Development (cortex-dev.meta-factory.{ai,dev,io})
 # ──────────────────────────────────────────────────────────────────
 [env.dev]
-name = "grove-api-dev"
+name = "cortex-api-dev"
 workers_dev = false
 routes = [
-  { pattern = "grove-dev.meta-factory.ai/api/*", zone_name = "meta-factory.ai" },
-  { pattern = "grove-dev.meta-factory.ai/admin/*", zone_name = "meta-factory.ai" },
-  { pattern = "grove-dev.meta-factory.ai/ws", zone_name = "meta-factory.ai" },
-  { pattern = "grove-dev.meta-factory.dev/api/*", zone_name = "meta-factory.dev" },
-  { pattern = "grove-dev.meta-factory.dev/admin/*", zone_name = "meta-factory.dev" },
-  { pattern = "grove-dev.meta-factory.dev/ws", zone_name = "meta-factory.dev" },
-  { pattern = "grove-dev.meta-factory.io/api/*", zone_name = "meta-factory.io" },
-  { pattern = "grove-dev.meta-factory.io/admin/*", zone_name = "meta-factory.io" },
-  { pattern = "grove-dev.meta-factory.io/ws", zone_name = "meta-factory.io" }
+  { pattern = "cortex-dev.meta-factory.ai/api/*", zone_name = "meta-factory.ai" },
+  { pattern = "cortex-dev.meta-factory.ai/admin/*", zone_name = "meta-factory.ai" },
+  { pattern = "cortex-dev.meta-factory.ai/ws", zone_name = "meta-factory.ai" },
+  { pattern = "cortex-dev.meta-factory.dev/api/*", zone_name = "meta-factory.dev" },
+  { pattern = "cortex-dev.meta-factory.dev/admin/*", zone_name = "meta-factory.dev" },
+  { pattern = "cortex-dev.meta-factory.dev/ws", zone_name = "meta-factory.dev" },
+  { pattern = "cortex-dev.meta-factory.io/api/*", zone_name = "meta-factory.io" },
+  { pattern = "cortex-dev.meta-factory.io/admin/*", zone_name = "meta-factory.io" },
+  { pattern = "cortex-dev.meta-factory.io/ws", zone_name = "meta-factory.io" }
 ]
 
 # DashboardSocket DO binding (dev) — env configs don't inherit the base binding.
@@ -56,19 +56,19 @@ name = "DASHBOARD_SOCKET"
 class_name = "DashboardSocket"
 
 [env.dev.vars]
-CORS_ORIGIN = "https://grove-dev.meta-factory.ai,https://grove-dev.meta-factory.dev,https://grove-dev.meta-factory.io,http://localhost:8766,http://localhost:8765"
+CORS_ORIGIN = "https://cortex-dev.meta-factory.ai,https://cortex-dev.meta-factory.dev,https://cortex-dev.meta-factory.io,http://localhost:8766,http://localhost:8765"
 ENVIRONMENT = "development"
 
-# Dev D1 (provisioned 2026-04-12, region OC)
+# Dev D1 (cortex-events-dev, provisioned 2026-06-04, region OC)
 [[env.dev.d1_databases]]
-binding = "GROVE_DB"
-database_name = "grove-events-dev"
-database_id = "761252d9-d553-4461-aae8-bbe32c16abce"
+binding = "CORTEX_DB"
+database_name = "cortex-events-dev"
+database_id = "44d8f835-cb8e-4c1e-b6ca-21572f44ba03"
 
-# Dev KV (provisioned 2026-04-12)
+# Dev KV (cortex-keys-dev, provisioned 2026-06-04)
 [[env.dev.kv_namespaces]]
-binding = "GROVE_KEYS"
-id = "f8de83818fc54d978609a0aab79ebbb7"
+binding = "CORTEX_KEYS"
+id = "078d4e580a8c4d39a431a19dde191102"
 
 # ──────────────────────────────────────────────────────────────────
 # Environment: Production (grove.meta-factory.{ai,dev,io})
@@ -117,13 +117,13 @@ ENVIRONMENT = "production"
 
 # Production D1 (existing)
 [[env.production.d1_databases]]
-binding = "GROVE_DB"
+binding = "CORTEX_DB"
 database_name = "grove-events"
 database_id = "bf59021b-5a65-46ef-a33a-37882294fcc0"
 
 # Production KV (existing)
 [[env.production.kv_namespaces]]
-binding = "GROVE_KEYS"
+binding = "CORTEX_KEYS"
 id = "b8b33e5ff1bd43c19efa8ceb91cb5337"
 
 # Secrets (set via wrangler secret put --env production):


### PR DESCRIPTION
## grove→cortex cutover — Phase 1 (DEV)

First phase of the full infra rename (`Plans/grove-to-cortex-cutover.md`). **Dev only**; prod stays `grove-*` until Phase 2.

### Code
- Worker bindings **`GROVE_DB`→`CORTEX_DB`, `GROVE_KEYS`→`CORTEX_KEYS`** (59 refs / 17 files) — unambiguous identifiers, mechanical rename.
- `wrangler.toml [env.dev]`: worker `cortex-api-dev`; D1 `cortex-events-dev`; KV `cortex-keys-dev`; routes + CORS → `cortex-dev.meta-factory.{ai,dev,io}`. **Prod block unchanged** (renamed Phase 2) apart from the shared binding identifiers (only take effect on next prod deploy).

### Infra stood up (live, behind zero-trust)
`cortex-events-dev` D1 (schema.sql + migrations, #645 workaround) · `cortex-keys-dev` KV · `cortex-api-dev` worker (deployed) · `cortex-dashboard-dev` Pages (deployed) · `cortex-dev.meta-factory.ai` DNS · **"Cortex Dashboard (dev)" CF Access** (Team + M2M, mirrors grove-dev). Verified: domain active, root/`/api`/`/ws` all `302→CF Access`.

### Scope guards
- Legacy `the-metafactory/grove` + `grove-v2` references **untouched** (historical provenance).
- Frontend WS client unchanged. Prod (`grove-*`) untouched and still live.
- grove-dev redirect + the full prod cutover (Phases 2–4) are tracked follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)