### PR TITLE
feat(network-registry): app-layer rate limiting + enumeration policy — dev=prod identical (closes #680, #681)

### DIFF
--- a/docs/sop-network-registry.md
+++ b/docs/sop-network-registry.md
@@ -126,6 +126,55 @@ For dev, substitute `--env dev`. Local-only iteration uses `bunx wrangler dev` (
 
 ---
 
+## Public-internet edge hardening (dev = prod) — #680 / #681
+
+**Parity principle (load-bearing).** `network-dev.meta-factory.ai` and `network.meta-factory.ai` are **both public internet endpoints**. Every protective control below is **identical** on dev and prod — **dev is not a laxer posture**. Anything applied to prod is applied to dev, byte-for-byte. The only legitimate per-environment difference is the CF rate-limit **namespace id** (Cloudflare requires a distinct namespace per environment); the **limit values, periods, and which endpoints are guarded are the same**. If you change a limit, change it in **both** `[env.dev]` and `[env.production]` blocks in `wrangler.toml` — there are parity-guard comments at both.
+
+This layer is **volumetric / abuse hardening only**. Correctness is already cryptographic and is unchanged: reads return registry-signed assertions of **public** keys (nothing secret), and writes require proof-of-possession (±5 min skew + nonce-replay 409 + Ed25519 verify 401 + rotation guard). No CF Access gate is added — federation peers are external and cannot authenticate; that is the correct posture for a public pubkey directory.
+
+### App-layer rate limiting (#680)
+
+Enforced with the Cloudflare Workers **native rate-limit binding** (`env.RL.limit({ key })` → `{ success }`), declared as `[[unsafe.bindings]]` of `type = "ratelimit"` in `wrangler.toml` — two bindings, present **identically** in `[env.dev]` and `[env.production]`:
+
+| Binding | Guards | Limit | Keyed by | Response when exceeded |
+|---|---|---|---|---|
+| `RL_REGISTER` | `POST /principals/:id/register` | **5 / 60 s** (strict) | `CF-Connecting-IP` **+** `principal_id` | `429 { "error": "rate_limited" }` |
+| `RL_READ` | `GET /principals/:id`, `GET /networks/:id/roster`, `GET /capabilities` | **120 / 60 s** (loose) | `CF-Connecting-IP` | `429 { "error": "rate_limited" }` |
+
+- **Strictest on register** because it is the mutation + Ed25519-verify compute path. Keying by `(IP, principal_id)` means one principal hammering register can't hide behind a shared/NAT egress IP, and one IP can't exhaust the budget across many principals.
+- **Looser on reads** because resolve (`GET /principals/:id`) is the **load-bearing federation primitive** — a peer fanning out to refresh many principals on a schedule must not be choked. 120 / 60 s (~2 req/s/IP sustained) is comfortable for a legitimate peer and hostile to a bulk enumerator.
+- **`GET /api/health` and `GET /registry/pubkey` are NOT rate-limited** — liveness and pin probes must stay cheap and always-answerable.
+- **The limit values are also code constants** (`src/rate-limit.ts` → `RATE_LIMITS`). The same constants drive an in-Worker token-bucket **fallback** used where the native binding is absent (`wrangler dev`, `bun test` — CF ships no local emulator for the binding). Because the limits live in code, dev and prod cannot drift even in the fallback path. ⚠️ The fallback bucket is **per-isolate / in-memory** — not colo-coordinated — exactly like the in-memory store and nonce cache; the durable backing ties to the D1 follow-up (`README.md` §Roadmap, #682). In production the **native binding** (durable, colo-coordinated) is the active path.
+
+**Ordering — rate-limit BEFORE signature verify (deliberate).** On `POST /principals/:id/register`, the `RL_REGISTER` check runs **after** the cheap path validation but **before** the JSON parse and the expensive Ed25519 verify. A flood of bad-signature registers is therefore **shed early at the 429 gate** rather than burning verify compute. The crypto gates still run for any request under the limit — the rate limiter is a guard in front of the wall, not the wall. (A native-binding error **fails open** so a limiter blip can't take the directory down; the crypto gates remain the hard correctness boundary.)
+
+**Provisioning the rate-limit namespaces.** The `[[unsafe.bindings]]` blocks reference `namespace_id` values per environment. These are CF account-scoped ratelimit namespace ids; set distinct ids for dev vs prod (the values in `wrangler.toml` are placeholders — replace with the ids your CF account assigns). The `limit`/`period` must stay identical across the two blocks.
+
+### Bot-fight-mode / WAF (zone-level — principal step, dev = prod)
+
+Bot-fight-mode and WAF managed rules are **zone/dashboard-level** Cloudflare controls — they are **not** Worker code and cannot live in `wrangler.toml`. They are configured by the principal in the Cloudflare dashboard (or via the CF API) for the `meta-factory.ai` zone, scoped to the registry routes. Because `network-dev` and `network` are routes in the **same** `meta-factory.ai` zone, a zone-level managed ruleset applies to both uniformly; if you scope a rule to a specific hostname, **apply the identical rule to both `network-dev.meta-factory.ai` and `network.meta-factory.ai`** — same parity principle as the in-code controls. Recommended baseline:
+
+- **Bot Fight Mode** (or Super Bot Fight Mode if on a paid plan) enabled for the zone — challenges obvious automated/abusive clients before they reach the Worker.
+- **WAF managed rules** (Cloudflare Managed Ruleset) deployed on the registry routes.
+
+These complement, not replace, the app-layer rate limiting above: the rate-limit binding caps request *volume per key*; bot-fight/WAF shed *malicious/automated* traffic shape. Note the registry's M2M clients are legitimate automation (cortex peers polling resolve on a schedule), so verify any bot rule doesn't challenge the federation's own peer traffic — prefer rules that target known-bad signatures over blanket "block all automation".
+
+### Public-exposure policy (dev = prod) — #681
+
+The registry deliberately exposes **federation-membership metadata** on its read surface. This is a **conscious, documented decision**, identical on dev and prod:
+
+| Endpoint | Exposure | Decision |
+|---|---|---|
+| `GET /principals/:id` (by-id resolve) | **PUBLIC, unauthenticated** | **Keep public.** This is the load-bearing federation primitive: a peer must resolve any principal's pubkey to verify its `signed_by[]` stamp. Gating it would break cross-principal verify. |
+| `GET /networks/:id/roster` (LIST members) | **PUBLIC, rate-limited** | **Keep functional** for federation discovery. Rate-limited via `RL_READ`. Returns only already-public fields: `principal_id`, `principal_pubkey`, matched `capabilities[]` (ids). |
+| `GET /capabilities?query=…` (LIST hits) | **PUBLIC, rate-limited** | **Keep functional** for capability discovery. Rate-limited via `RL_READ`. Returns only already-public fields: `capability_id`, `principal_id`, `networks[]`, `description`. |
+
+**Rationale.** Everything the list endpoints surface is **already published, public data**: a principal pubkey is public by definition (it's how peers verify), and capabilities are **open-announce** for discovery (any principal announces into any `network_id`; attribution is visible without a join handshake — see `README.md` §"Discovery vs. traffic gating"). The list endpoints expose **no internal-only detail**, so no response trimming is required. **No auth-gating is added** — federation peers are external and cannot authenticate; an auth gate would break discovery without protecting anything that isn't already public. Membership privacy is therefore **explicitly out of scope for v1**: the controls are (a) rate-limiting (so the surface can't be cheaply bulk-scraped) and (b) this documented decision. A sealed-network join handshake (membership privacy) remains a follow-up; *traffic* gating already lives in `accept_subjects` / `deny_subjects`, not in the directory.
+
+**Parity statement.** This exposure policy and its enforcement (the `RL_READ` limit on all three read paths) are **identical on `network-dev` and `network`**. No divergence.
+
+---
+
 ## Register a principal
 
 Registration is the principal flow that publishes a stack's **public** key into the registry so peers can resolve it. It is **proof-of-possession**: the registration claim is signed with the stack's own signing key, and the registry verifies that signature against the pubkey being claimed.

--- a/src/services/network-registry/__tests__/helpers.ts
+++ b/src/services/network-registry/__tests__/helpers.ts
@@ -11,6 +11,7 @@ import { canonicalJSON, generateKeypair, signEd25519 } from "../src/signing";
 import type { Capability, RegistrationClaim, StackIdentity } from "../src/types";
 import { _setNonceCacheForTest, _setStoreForTest } from "../src/store";
 import { _resetDerivedPublicKeyForTest } from "../src/index";
+import { _resetRateLimitBucketsForTest } from "../src/rate-limit";
 
 export interface PrincipalKey {
   privateKeyB64: string;
@@ -37,11 +38,17 @@ export async function makeRegistryKey(): Promise<{
   return { signingKey: kp.privateKeyB64, publicKey: kp.publicKeyB64 };
 }
 
-/** Reset all module-scoped state between tests (store, nonce cache, derived pubkey). */
+/**
+ * Reset all module-scoped state between tests (store, nonce cache, derived
+ * pubkey, rate-limit fallback buckets). The rate-limit buckets are module-scoped
+ * like the store, so without this reset they'd bleed across tests and a later
+ * test could spuriously 429.
+ */
 export function resetStores(): void {
   _setStoreForTest(undefined);
   _setNonceCacheForTest(undefined);
   _resetDerivedPublicKeyForTest();
+  _resetRateLimitBucketsForTest();
 }
 
 /**

--- a/src/services/network-registry/__tests__/rate-limit.test.ts
+++ b/src/services/network-registry/__tests__/rate-limit.test.ts
@@ -1,0 +1,337 @@
+/**
+ * #680 + #681 — Edge-hardening tests: app-layer rate limiting + enumeration
+ * policy. Drives the Worker via `app.fetch(request, env)` so the full Hono
+ * pipeline (read-limit middleware + register handler + signing) is exercised.
+ *
+ * Two layers are tested:
+ *   1. The in-Worker token-bucket FALLBACK (no native binding in `env`) — this
+ *      is what runs under `wrangler dev` and `bun test`.
+ *   2. The NATIVE binding path, via a mock `RateLimit` binding injected into
+ *      `env` — emulates the Cloudflare `env.RL.limit({ key })` contract.
+ *
+ * Parity note: the LIMIT VALUES are code constants (RATE_LIMITS) shared by both
+ * dev and prod, so testing them once tests both environments.
+ */
+
+import { describe, test, expect, beforeEach } from "bun:test";
+import app from "../src/index";
+import type { Env } from "../src/index";
+import {
+  makePrincipalKey,
+  makeRegistryKey,
+  makeSignedRegistration,
+  resetStores,
+  type PrincipalKey,
+} from "./helpers";
+import {
+  RATE_LIMITS,
+  type RateLimitBinding,
+} from "../src/rate-limit";
+import type { SignedAssertion, PrincipalRecord } from "../src/types";
+
+let env: Env;
+let pKey: PrincipalKey;
+
+beforeEach(async () => {
+  resetStores();
+  const reg = await makeRegistryKey();
+  env = {
+    REGISTRY_SIGNING_KEY: reg.signingKey,
+    REGISTRY_PUBLIC_KEY: reg.publicKey,
+    ENVIRONMENT: "test",
+  };
+  pKey = await makePrincipalKey();
+});
+
+/**
+ * Issue a request with an explicit client IP so each test keys its own bucket
+ * (the fallback keys on CF-Connecting-IP, falling back to "local").
+ */
+function reqWith(
+  path: string,
+  init: RequestInit & { ip?: string } = {},
+): Request {
+  const headers = new Headers(init.headers);
+  if (init.ip) headers.set("CF-Connecting-IP", init.ip);
+  return new Request(`http://localhost${path}`, { ...init, headers });
+}
+
+async function fetchApp(req: Request): Promise<Response> {
+  return app.fetch(req, env);
+}
+
+async function postRegister(
+  principalId: string,
+  body: unknown,
+  ip: string,
+): Promise<Response> {
+  return fetchApp(
+    reqWith(`/principals/${principalId}/register`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+      ip,
+    }),
+  );
+}
+
+// ===========================================================================
+// #680 — register limit (fallback bucket)
+// ===========================================================================
+
+describe("#680 register rate-limit (fallback bucket)", () => {
+  test("under the limit proceeds; over the limit returns 429", async () => {
+    const ip = "203.0.113.10";
+    const limit = RATE_LIMITS.register.limit; // 5
+
+    // First `limit` valid registers of the SAME principal+IP succeed (each is
+    // an idempotent re-register of the same pubkey; the rotation guard allows
+    // re-registering the same key).
+    for (let i = 0; i < limit; i++) {
+      const body = await makeSignedRegistration("andreas", pKey);
+      const res = await postRegister("andreas", body, ip);
+      expect(res.status).toBe(201);
+    }
+
+    // The (limit + 1)-th is shed with 429, carrying a Retry-After (the window
+    // period) so a well-behaved client backs off instead of hammering.
+    const overBody = await makeSignedRegistration("andreas", pKey);
+    const over = await postRegister("andreas", overBody, ip);
+    expect(over.status).toBe(429);
+    expect(over.headers.get("Retry-After")).toBe(String(RATE_LIMITS.register.periodSec));
+  });
+
+  test("the limit is keyed by (IP, principal) — a different principal is independent", async () => {
+    const ip = "203.0.113.20";
+    const limit = RATE_LIMITS.register.limit;
+
+    for (let i = 0; i < limit; i++) {
+      const body = await makeSignedRegistration("andreas", pKey);
+      const res = await postRegister("andreas", body, ip);
+      expect(res.status).toBe(201);
+    }
+    // andreas is now exhausted on this IP...
+    const exhausted = await postRegister(
+      "andreas",
+      await makeSignedRegistration("andreas", pKey),
+      ip,
+    );
+    expect(exhausted.status).toBe(429);
+
+    // ...but a DIFFERENT principal from the same IP has its own bucket.
+    const otherKey = await makePrincipalKey();
+    const otherRes = await postRegister(
+      "bravo",
+      await makeSignedRegistration("bravo", otherKey),
+      ip,
+    );
+    expect(otherRes.status).toBe(201);
+  });
+
+  test("429 body is opaque — no internals, no limit values leaked", async () => {
+    const ip = "203.0.113.30";
+    for (let i = 0; i < RATE_LIMITS.register.limit; i++) {
+      await postRegister("andreas", await makeSignedRegistration("andreas", pKey), ip);
+    }
+    const over = await postRegister(
+      "andreas",
+      await makeSignedRegistration("andreas", pKey),
+      ip,
+    );
+    expect(over.status).toBe(429);
+    const json = (await over.json()) as Record<string, unknown>;
+    // Only the opaque error code — nothing about limit/period/key/principal.
+    expect(json).toEqual({ error: "rate_limited" });
+    const serialized = JSON.stringify(json);
+    expect(serialized).not.toContain(String(RATE_LIMITS.register.limit));
+    expect(serialized).not.toContain("andreas");
+    expect(serialized).not.toContain(ip);
+  });
+});
+
+// ===========================================================================
+// #680 — ORDERING: rate-limit BEFORE signature verify
+// ===========================================================================
+
+describe("#680 rate-limit precedes signature verify (flood shedding)", () => {
+  test("a flood of BAD-signature registers is shed with 429, not 401", async () => {
+    const ip = "203.0.113.40";
+    const limit = RATE_LIMITS.register.limit;
+
+    // Build a registration whose signature will FAIL (tamper the pubkey so the
+    // claim signature no longer matches the declared key). Each of these would
+    // cost an Ed25519 verify if it reached the crypto gate.
+    async function badSigBody() {
+      const wrongKey = await makePrincipalKey();
+      // Sign with pKey but DECLARE wrongKey's pubkey → signature_invalid.
+      return makeSignedRegistration("andreas", pKey, {
+        pubkeyOverride: wrongKey.publicKeyB64,
+      });
+    }
+
+    // The first `limit` bad-sig attempts reach the verify gate → 401.
+    for (let i = 0; i < limit; i++) {
+      const res = await postRegister("andreas", await badSigBody(), ip);
+      expect(res.status).toBe(401);
+    }
+    // Once the IP+principal limit is hit, further bad-sig floods are shed at the
+    // rate-limit gate (429) BEFORE the expensive Ed25519 verify runs (which
+    // would otherwise return 401). This proves the gate runs first.
+    const flooded = await postRegister("andreas", await badSigBody(), ip);
+    expect(flooded.status).toBe(429);
+  });
+});
+
+// ===========================================================================
+// #680 — read limit on the GET surface (fallback bucket)
+// ===========================================================================
+
+describe("#680 read rate-limit on GET endpoints (fallback bucket)", () => {
+  test("GET /principals/:id over the read limit returns 429", async () => {
+    const ip = "203.0.113.50";
+    const limit = RATE_LIMITS.read.limit; // 120
+
+    // Register one principal so the resolve has something to return (this POST
+    // uses a different limit/key and doesn't consume the read budget).
+    await postRegister("andreas", await makeSignedRegistration("andreas", pKey), "198.51.100.1");
+
+    for (let i = 0; i < limit; i++) {
+      const res = await fetchApp(reqWith("/principals/andreas", { ip }));
+      expect(res.status).toBe(200);
+    }
+    const over = await fetchApp(reqWith("/principals/andreas", { ip }));
+    expect(over.status).toBe(429);
+    expect(await over.json()).toEqual({ error: "rate_limited" });
+    expect(over.headers.get("Retry-After")).toBe(String(RATE_LIMITS.read.periodSec));
+  });
+
+  test("GET /capabilities and /networks/:id/roster share the IP read budget", async () => {
+    const ip = "203.0.113.60";
+    const limit = RATE_LIMITS.read.limit;
+
+    // Spend the budget across BOTH list endpoints (the read limit is per-IP,
+    // not per-path), proving the enumeration surface as a whole is capped.
+    for (let i = 0; i < limit; i++) {
+      const path = i % 2 === 0 ? "/capabilities?query=x" : "/networks/n1/roster";
+      const res = await fetchApp(reqWith(path, { ip }));
+      expect(res.status).toBe(200);
+    }
+    const over = await fetchApp(reqWith("/capabilities?query=x", { ip }));
+    expect(over.status).toBe(429);
+  });
+
+  test("health + pubkey probes are NOT read-limited", async () => {
+    const ip = "203.0.113.70";
+    // Far exceed the read limit on the liveness/pin probes — they must keep
+    // answering 200, never 429 (throttling health checks is counterproductive).
+    for (let i = 0; i < RATE_LIMITS.read.limit + 5; i++) {
+      const h = await fetchApp(reqWith("/api/health", { ip }));
+      expect(h.status).toBe(200);
+    }
+    const pk = await fetchApp(reqWith("/registry/pubkey", { ip }));
+    expect(pk.status).toBe(200);
+  });
+});
+
+// ===========================================================================
+// #680 — NATIVE binding path (mocked)
+// ===========================================================================
+
+describe("#680 native rate-limit binding path", () => {
+  /** A mock binding that allows the first `allowFirst` calls, then denies. */
+  function mockBinding(allowFirst: number): RateLimitBinding & { calls: string[] } {
+    let n = 0;
+    const calls: string[] = [];
+    return {
+      calls,
+      async limit({ key }: { key: string }) {
+        calls.push(key);
+        return { success: n++ < allowFirst };
+      },
+    };
+  }
+
+  test("when RL_READ is bound, the native binding decides (deny → 429)", async () => {
+    const denyAll = mockBinding(0);
+    env.RL_READ = denyAll;
+    const res = await fetchApp(reqWith("/api/health", { ip: "1.1.1.1" })); // not limited
+    expect(res.status).toBe(200);
+    // health is not limited, so binding not consulted there; hit a limited path:
+    const limited = await fetchApp(reqWith("/capabilities?query=x", { ip: "1.1.1.1" }));
+    expect(limited.status).toBe(429);
+    expect(denyAll.calls.length).toBe(1);
+  });
+
+  test("when RL_REGISTER is bound, register consults it and is keyed by (IP, principal)", async () => {
+    const allowAll = mockBinding(1000);
+    env.RL_REGISTER = allowAll;
+    const res = await postRegister("andreas", await makeSignedRegistration("andreas", pKey), "9.9.9.9");
+    expect(res.status).toBe(201);
+    expect(allowAll.calls.length).toBe(1);
+    // Key folds IP and principal_id.
+    expect(allowAll.calls[0]).toContain("9.9.9.9");
+    expect(allowAll.calls[0]).toContain("andreas");
+  });
+
+  test("native-binding ERROR fails open (request allowed, registry stays up)", async () => {
+    env.RL_READ = {
+      async limit() {
+        throw new Error("binding transient fault");
+      },
+    };
+    await postRegister("andreas", await makeSignedRegistration("andreas", pKey), "198.51.100.9");
+    const res = await fetchApp(reqWith("/principals/andreas", { ip: "2.2.2.2" }));
+    // Fail-open: the resolve still succeeds despite the limiter throwing.
+    expect(res.status).toBe(200);
+  });
+});
+
+// ===========================================================================
+// #681 — enumeration / exposure policy
+// ===========================================================================
+
+describe("#681 enumeration policy (dev = prod)", () => {
+  test("by-id resolve stays PUBLIC (no auth gate) — load-bearing federation primitive", async () => {
+    await postRegister(
+      "andreas",
+      await makeSignedRegistration("andreas", pKey, {
+        capabilities: [{ id: "tasks.code-review", networks: ["research-collab"] }],
+      }),
+      "198.51.100.20",
+    );
+    // Unauthenticated GET resolves with no credentials at all.
+    const res = await fetchApp(reqWith("/principals/andreas", { ip: "5.5.5.5" }));
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as SignedAssertion<PrincipalRecord>;
+    expect(json.payload.principal_id).toBe("andreas");
+    expect(json.payload.principal_pubkey).toBe(pKey.publicKeyB64);
+  });
+
+  test("list endpoints stay functional and return the documented (unchanged) shape", async () => {
+    await postRegister(
+      "andreas",
+      await makeSignedRegistration("andreas", pKey, {
+        capabilities: [{ id: "tasks.code-review", networks: ["research-collab"] }],
+      }),
+      "198.51.100.21",
+    );
+
+    // roster: { network_id, members[] } with principal_id + pubkey + capabilities.
+    const roster = await fetchApp(reqWith("/networks/research-collab/roster", { ip: "6.6.6.1" }));
+    expect(roster.status).toBe(200);
+    const rosterJson = (await roster.json()) as SignedAssertion<{
+      network_id: string;
+      members: Array<{ principal_id: string; principal_pubkey: string; capabilities: string[] }>;
+    }>;
+    expect(rosterJson.payload.network_id).toBe("research-collab");
+    expect(rosterJson.payload.members[0]?.principal_id).toBe("andreas");
+
+    // capabilities: { query, hits[], truncated } — only published public fields.
+    const caps = await fetchApp(reqWith("/capabilities?query=code-review", { ip: "6.6.6.2" }));
+    expect(caps.status).toBe(200);
+    const capsJson = (await caps.json()) as SignedAssertion<{
+      hits: Array<{ capability_id: string; principal_id: string }>;
+    }>;
+    expect(capsJson.payload.hits[0]?.capability_id).toBe("tasks.code-review");
+  });
+});

--- a/src/services/network-registry/src/index.ts
+++ b/src/services/network-registry/src/index.ts
@@ -33,12 +33,20 @@
 
 import { Hono } from "hono";
 import { cors } from "hono/cors";
+import { createMiddleware } from "hono/factory";
 import { principalRoutes } from "./routes/principals";
 import { networkRoutes } from "./routes/networks";
 import { capabilityRoutes } from "./routes/capabilities";
 import { pubkeyFromPkcs8 } from "./signing";
+import type { RateLimitEnv } from "./rate-limit";
+import {
+  checkRateLimit,
+  clientKey,
+  retryAfterSeconds,
+  TOO_MANY_REQUESTS_BODY,
+} from "./rate-limit";
 
-export interface Env {
+export interface Env extends RateLimitEnv {
   /**
    * Base64-encoded PKCS#8 Ed25519 private key used to sign GET
    * responses. Provisioned via `wrangler secret put` per the
@@ -160,6 +168,34 @@ app.get("/registry/pubkey", (c) => {
   }
   return c.json({ algorithm: "Ed25519", public_key: pub });
 });
+
+// ---------------------------------------------------------------------------
+// Read rate-limit (#680) — looser IP-keyed limit on the load-bearing GET
+// surface. Applied to the resolve / roster / capabilities reads, NOT to
+// /api/health or /registry/pubkey (liveness + pin probes must stay cheap and
+// always-answerable; throttling a health check would be counterproductive).
+//
+// The register mutation has its OWN, stricter limit enforced inside the handler
+// (rate-limit BEFORE signature verify — see routes/principals.ts) so the gate
+// can fold principal_id into the key and shed bad-sig floods before the
+// expensive Ed25519 path.
+//
+// Limits are byte-identical on dev and prod (code constants in rate-limit.ts).
+// ---------------------------------------------------------------------------
+
+const readLimited = createMiddleware<{ Bindings: Env }>(async (c, next) => {
+  const allowed = await checkRateLimit(c.env, "read", clientKey(c.req.raw));
+  if (!allowed) {
+    return c.json(TOO_MANY_REQUESTS_BODY, 429, {
+      "Retry-After": String(retryAfterSeconds("read")),
+    });
+  }
+  await next();
+});
+
+app.use("/principals/:principal_id", readLimited);
+app.use("/networks/:network_id/roster", readLimited);
+app.use("/capabilities", readLimited);
 
 // ---------------------------------------------------------------------------
 // Mount route groups

--- a/src/services/network-registry/src/rate-limit.ts
+++ b/src/services/network-registry/src/rate-limit.ts
@@ -1,0 +1,226 @@
+/**
+ * #680 — App-layer rate limiting for the network-registry edge.
+ *
+ * The registry is a PUBLIC internet surface on BOTH `network-dev.meta-factory.ai`
+ * and `network.meta-factory.ai`. Per the principal's parity rule, dev is NOT a
+ * laxer posture: every control here is identical on dev and prod. The LIMIT
+ * VALUES live in this file as code constants (see `RATE_LIMITS` below), so they
+ * are inherently byte-identical across both environments — there is no per-env
+ * config knob that could drift. The only thing wrangler.toml declares per-env is
+ * the binding *namespace id* (CF requires a distinct id per env); the
+ * limit/period are NOT in wrangler.toml and cannot diverge.
+ *
+ * Mechanism (prefer native, documented fallback)
+ * ──────────────────────────────────────────────
+ * Cloudflare Workers ship a native rate-limit binding (`env.RL.limit({ key })`
+ * → `{ success }`), configured via `[[unsafe.bindings]]` with
+ * `type = "ratelimit"` in wrangler.toml. We use it when present.
+ *
+ * The native binding has **no local emulator**: it is `undefined` under
+ * `wrangler dev` and `bun test`. So this module degrades to a minimal
+ * in-Worker token-bucket keyed by the same key. The fallback is:
+ *   - correct for single-isolate / single-colo bursts, and
+ *   - per-isolate / in-memory — it does NOT coordinate across the colo,
+ *     exactly like the InMemoryRegistryStore + nonce cache already do
+ *     (see store.ts, README §Roadmap, and the durable-storage follow-up #682).
+ * In production the native binding (durable, colo-coordinated) is the active
+ * path; the bucket only runs where the binding is absent (tests/local).
+ *
+ * Ordering (security-relevant — see #680 acceptance):
+ * The IP rate-limit is CHEAP (one binding call / one map lookup). The signature
+ * verify on POST /register is EXPENSIVE (Ed25519 + canonical-JSON). So callers
+ * invoke the rate-limit gate BEFORE the signature check, so a flood of
+ * bad-signature registers is shed early rather than burning verify compute.
+ */
+
+/**
+ * The native Workers rate-limit binding shape (matches
+ * `@cloudflare/workers-types`' `RateLimit` interface). Declared locally so this
+ * module does not depend on the ambient global resolving in every build target.
+ */
+export interface RateLimitBinding {
+  limit(options: { key: string }): Promise<{ success: boolean }>;
+}
+
+/**
+ * A single named limit: at most `limit` requests per `periodSec` window.
+ *
+ * NOTE on the native binding: CF's `ratelimit` binding only supports
+ * `simple = { limit, period }` where `period` is **10 or 60 seconds**. We keep
+ * each declared period to one of those two values so the SAME numbers can be
+ * mirrored into wrangler.toml's `[[unsafe.bindings]]` blocks without
+ * translation. The token-bucket fallback honours arbitrary periods, but we
+ * stick to 10/60 so native and fallback agree.
+ */
+export interface RateLimitRule {
+  readonly limit: number;
+  readonly periodSec: 10 | 60;
+}
+
+/**
+ * Canonical limit table — IDENTICAL on dev and prod (code constant, not config).
+ *
+ * Tuned for a federation directory: hundreds of principals, M2M peers polling
+ * resolve on a schedule, NOT a high-QPS consumer API. Resolve (`GET
+ * /principals/:id`) is load-bearing for cross-principal verify, so its read
+ * limit is generous enough that a legitimately-busy peer fan-out won't choke,
+ * while still capping a scraper.
+ *
+ * If you change a value here, it changes for BOTH environments at once — that
+ * IS the parity guarantee. Do not introduce a per-env override.
+ */
+export const RATE_LIMITS = {
+  /**
+   * POST /principals/:id/register — strictest. Mutation + Ed25519 verify
+   * compute. A principal registers occasionally (boot, rotation), never in a
+   * tight loop. 5 / 60s per key absorbs a retry storm but sheds a flood.
+   */
+  register: { limit: 5, periodSec: 60 },
+  /**
+   * GET reads (resolve / roster / capabilities) — looser. Keyed by IP. 120 /
+   * 60s is ~2 req/s sustained per IP: comfortable for a federation peer
+   * refreshing many principals on a schedule, hostile to a bulk enumerator.
+   */
+  read: { limit: 120, periodSec: 60 },
+} as const satisfies Record<string, RateLimitRule>;
+
+export type RateLimitName = keyof typeof RATE_LIMITS;
+
+// ---------------------------------------------------------------------------
+// Native-binding env shape
+// ---------------------------------------------------------------------------
+
+/**
+ * The optional native bindings the Worker may carry. One binding per limit so
+ * CF can scope each independently. Absent under `wrangler dev` / `bun test`.
+ */
+export interface RateLimitEnv {
+  RL_REGISTER?: RateLimitBinding;
+  RL_READ?: RateLimitBinding;
+}
+
+const BINDING_FOR: Record<RateLimitName, keyof RateLimitEnv> = {
+  register: "RL_REGISTER",
+  read: "RL_READ",
+};
+
+// ---------------------------------------------------------------------------
+// In-Worker token-bucket fallback (per-isolate, in-memory)
+// ---------------------------------------------------------------------------
+
+interface BucketState {
+  /** Tokens remaining in the current window. */
+  tokens: number;
+  /** Epoch ms when the current window resets. */
+  resetAt: number;
+}
+
+/**
+ * Fixed-window counter keyed by `name:key`. Per-isolate, in-memory — NOT
+ * durable, NOT colo-coordinated (same caveat as the in-memory store). Used only
+ * when the native binding is absent (tests / `wrangler dev`).
+ *
+ * Module-scoped so it survives across requests within an isolate, with a
+ * threshold-gated sweep mirroring the nonce cache's pattern so the map can't
+ * grow unboundedly under key churn.
+ */
+const buckets = new Map<string, BucketState>();
+const SWEEP_THRESHOLD = 256;
+
+function fallbackLimit(name: RateLimitName, key: string, now: number): boolean {
+  const rule = RATE_LIMITS[name];
+  const windowMs = rule.periodSec * 1000;
+
+  if (buckets.size > SWEEP_THRESHOLD) {
+    for (const [k, st] of buckets) {
+      if (st.resetAt <= now) buckets.delete(k);
+    }
+  }
+
+  const mapKey = `${name}:${key}`;
+  const existing = buckets.get(mapKey);
+  if (!existing || existing.resetAt <= now) {
+    buckets.set(mapKey, { tokens: rule.limit - 1, resetAt: now + windowMs });
+    return true; // first request in a fresh window always succeeds
+  }
+  if (existing.tokens <= 0) return false;
+  existing.tokens -= 1;
+  return true;
+}
+
+/** Test-only — clear the fallback buckets between cases. */
+export function _resetRateLimitBucketsForTest(): void {
+  buckets.clear();
+}
+
+// ---------------------------------------------------------------------------
+// Public gate
+// ---------------------------------------------------------------------------
+
+/**
+ * Check one request against a named limit.
+ *
+ * @returns `true` if the request is ALLOWED, `false` if it exceeded the limit
+ *          (caller should return 429).
+ *
+ * Resolution order: native binding if bound, else the in-Worker fallback. The
+ * key is caller-supplied (IP and/or principal_id) — see `clientKey`.
+ *
+ * Fail-open on a native-binding error: if the binding call throws (CF transient
+ * fault), we allow the request rather than 503 the whole registry on a
+ * rate-limiter blip. This is the conventional posture — a rate limiter is a
+ * guard, not a correctness gate; the crypto gates remain the hard wall.
+ */
+export async function checkRateLimit(
+  env: RateLimitEnv,
+  name: RateLimitName,
+  key: string,
+  now: number = Date.now(),
+): Promise<boolean> {
+  const binding = env[BINDING_FOR[name]];
+  if (binding) {
+    try {
+      const { success } = await binding.limit({ key });
+      return success;
+    } catch (err) {
+      // Fail-open: a rate-limiter fault must not take down the directory.
+      console.error(
+        `[network-registry] rate-limit binding '${BINDING_FOR[name]}' errored, failing open: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+      return true;
+    }
+  }
+  return fallbackLimit(name, key, now);
+}
+
+/**
+ * Derive the rate-limit key from the request. Prefers `CF-Connecting-IP`
+ * (set by Cloudflare on every edge request; un-spoofable client IP). Falls back
+ * to a fixed sentinel when absent (local/test) so the limiter still functions
+ * deterministically rather than keying on `undefined`.
+ *
+ * For the register limit we additionally fold in the principal_id so one
+ * principal hammering register can't be masked behind a shared/NAT egress IP,
+ * and conversely one IP can't exhaust the limit for many principals — each
+ * (ip, principal) pair gets its own bucket.
+ */
+export function clientKey(req: Request, principalId?: string): string {
+  const ip = req.headers.get("CF-Connecting-IP") ?? "local";
+  return principalId ? `${ip}|${principalId}` : ip;
+}
+
+/** Standard 429 body — deliberately opaque (no internals, no limit values). */
+export const TOO_MANY_REQUESTS_BODY = { error: "rate_limited" } as const;
+
+/**
+ * `Retry-After` value (seconds) for a 429 on the given limit. We return the
+ * limit's window period — a safe upper bound on when a fresh window opens, so a
+ * well-behaved client backs off rather than hammering. This is the SAME public
+ * period already documented in the SOP; it leaks nothing the principal hasn't
+ * already published, and helps legitimate federation peers self-throttle.
+ */
+export function retryAfterSeconds(name: RateLimitName): number {
+  return RATE_LIMITS[name].periodSec;
+}

--- a/src/services/network-registry/src/routes/principals.ts
+++ b/src/services/network-registry/src/routes/principals.ts
@@ -17,6 +17,12 @@ import { Hono } from "hono";
 import { getRegistryPublicKey, type Env } from "../index";
 import { signEd25519, verifyEd25519, canonicalJSON } from "../signing";
 import { getNonceCache, getStore } from "../store";
+import {
+  checkRateLimit,
+  clientKey,
+  retryAfterSeconds,
+  TOO_MANY_REQUESTS_BODY,
+} from "../rate-limit";
 import type { PrincipalRecord, SignedAssertion } from "../types";
 import {
   isValidPrincipalId,
@@ -52,6 +58,25 @@ export function principalRoutes(): Hono<{ Bindings: Env }> {
     const principalId = c.req.param("principal_id");
     if (!isValidPrincipalId(principalId)) {
       return c.json({ error: "invalid principal_id in path" }, 400);
+    }
+
+    // #680 — rate-limit BEFORE the expensive signature verify. Register is the
+    // strictest limit (mutation + Ed25519 compute). We key by (IP, principal_id)
+    // so one principal hammering register can't hide behind a shared/NAT egress
+    // IP, and one IP can't exhaust the limit across many principals. Placing
+    // this here — after the cheap path validation, before JSON parse + verify —
+    // means a flood of bad-signature registers is shed early rather than burning
+    // verify compute. The limit value is a code constant identical on dev+prod
+    // (see rate-limit.ts RATE_LIMITS.register).
+    const allowed = await checkRateLimit(
+      c.env,
+      "register",
+      clientKey(c.req.raw, principalId),
+    );
+    if (!allowed) {
+      return c.json(TOO_MANY_REQUESTS_BODY, 429, {
+        "Retry-After": String(retryAfterSeconds("register")),
+      });
     }
 
     let body: unknown;

--- a/src/services/network-registry/wrangler.toml
+++ b/src/services/network-registry/wrangler.toml
@@ -49,6 +49,34 @@ routes = [
 ENVIRONMENT = "development"
 
 # ──────────────────────────────────────────────────────────────────
+# #680 — App-layer rate limiting (PARITY GUARD: dev == prod).
+#
+# These two bindings MUST stay byte-identical to the [env.production]
+# block below in `limit` and `period` and in which endpoints they
+# guard. `network-dev.meta-factory.ai` and `network.meta-factory.ai`
+# are BOTH public internet endpoints; dev is NOT a laxer posture.
+# If you change a limit, change it in BOTH blocks.
+#
+# The only legitimate per-env difference is `namespace_id` (CF requires
+# a distinct ratelimit namespace id per environment). The LIMIT VALUES
+# are also mirrored in code (src/rate-limit.ts RATE_LIMITS) which is the
+# active fallback where the native binding is absent (wrangler dev / test).
+#
+#   RL_REGISTER → POST /principals/:id/register   (strict: 5 / 60s)
+#   RL_READ     → GET resolve / roster / capabilities (loose: 120 / 60s)
+[[env.dev.unsafe.bindings]]
+name = "RL_REGISTER"
+type = "ratelimit"
+namespace_id = "1001"
+simple = { limit = 5, period = 60 }
+
+[[env.dev.unsafe.bindings]]
+name = "RL_READ"
+type = "ratelimit"
+namespace_id = "1002"
+simple = { limit = 120, period = 60 }
+
+# ──────────────────────────────────────────────────────────────────
 # Environment: Production (network.meta-factory.ai)
 # ──────────────────────────────────────────────────────────────────
 [env.production]
@@ -65,6 +93,30 @@ routes = [
 
 [env.production.vars]
 ENVIRONMENT = "production"
+
+# ──────────────────────────────────────────────────────────────────
+# #680 — App-layer rate limiting (PARITY GUARD: prod == dev).
+#
+# These two bindings MUST stay byte-identical to the [env.dev] block
+# above in `limit` and `period` and in which endpoints they guard.
+# Both hostnames are public; prod is NOT a stricter posture and dev is
+# NOT a laxer one — they are the SAME. The only per-env difference is
+# `namespace_id` (CF requires a distinct ratelimit namespace per env).
+# If you change a limit, change it in BOTH blocks.
+#
+#   RL_REGISTER → POST /principals/:id/register   (strict: 5 / 60s)
+#   RL_READ     → GET resolve / roster / capabilities (loose: 120 / 60s)
+[[env.production.unsafe.bindings]]
+name = "RL_REGISTER"
+type = "ratelimit"
+namespace_id = "2001"
+simple = { limit = 5, period = 60 }
+
+[[env.production.unsafe.bindings]]
+name = "RL_READ"
+type = "ratelimit"
+namespace_id = "2002"
+simple = { limit = 120, period = 60 }
 
 # Secrets (set via `wrangler secret put --env production`):
 #   REGISTRY_SIGNING_KEY  — base64-encoded PKCS#8 Ed25519 private key used


### PR DESCRIPTION
Public-internet edge hardening for the **network-registry** Worker, combining #680 (app-layer rate limiting) and #681 (enumeration/exposure policy) as one cohesive PR. Both `network-dev.meta-factory.ai` and `network.meta-factory.ai` are public; **every control here is IDENTICAL on dev and prod** — dev is not a laxer posture. This is **volumetric/abuse hardening only**; the cryptographic correctness gates (proof-of-possession, ±5 min skew, nonce-replay, rotation guard) are untouched.

## #680 — App-layer rate limiting

**Mechanism: native Cloudflare Workers rate-limit binding** (`env.RL.limit({ key })` → `{ success }`), declared as `[[unsafe.bindings]]` of `type = "ratelimit"`, present **byte-identically** in `[env.dev]` and `[env.production]` (confirmed via `wrangler 4.80 deploy --dry-run` on both envs). Verified the API shape against the installed `@cloudflare/workers-types` `RateLimit` interface and the wrangler 4.80 config mapping.

| Binding | Endpoint(s) | Limit | Key | Over → |
|---|---|---|---|---|
| `RL_REGISTER` | `POST /principals/:id/register` | **5 / 60 s** (strict) | `CF-Connecting-IP` + `principal_id` | `429 {"error":"rate_limited"}` + `Retry-After` |
| `RL_READ` | `GET /principals/:id`, `/networks/:id/roster`, `/capabilities` | **120 / 60 s** (loose) | `CF-Connecting-IP` | `429 {"error":"rate_limited"}` + `Retry-After` |

- `GET /api/health` and `/registry/pubkey` are **not** limited (liveness/pin probes stay always-answerable).
- **Register is strictest** (mutation + Ed25519 compute); keyed by (IP, principal) so neither a NAT egress IP nor a single principal can game it. **Reads are looser** because resolve is the load-bearing federation primitive — a peer fan-out must not choke.
- **Limit values are code constants** (`src/rate-limit.ts` `RATE_LIMITS`) that also drive an **in-Worker token-bucket fallback** used where the native binding is absent (`wrangler dev` / `bun test` — CF ships no local emulator). Because limits are code constants, dev/prod can't drift even in the fallback path. ⚠️ The fallback is **per-isolate / in-memory** (not colo-coordinated) — same caveat as the in-memory store + nonce cache; durable backing ties to the D1 follow-up **#682**. The **native binding (durable) is the active prod path.**

### Rate-limit-BEFORE-signature ordering (deliberate)
On register, the `RL_REGISTER` check runs **after** cheap path validation but **before** JSON parse + the expensive Ed25519 verify, so a flood of bad-signature registers is **shed at the 429 gate** rather than burning verify compute. Crypto gates still run for any request under the limit. A native-binding error **fails open** (the limiter is a guard in front of the crypto wall, not the wall). A dedicated test proves the ordering: a bad-sig flood returns 401 up to the limit, then 429.

## #681 — Enumeration / exposure policy (decided, documented, enforced — dev=prod)

| Endpoint | Decision |
|---|---|
| `GET /principals/:id` (by-id resolve) | **PUBLIC, unauthenticated** — load-bearing federation primitive; gating breaks cross-principal verify. |
| `GET /networks/:id/roster` (LIST) | **PUBLIC, rate-limited** — keep functional for discovery; exposes only already-public fields. |
| `GET /capabilities` (LIST) | **PUBLIC, rate-limited** — keep functional; exposes only already-public fields. |

**Rationale:** everything the list endpoints surface is already-published public data (pubkeys are public by definition; capabilities are open-announce for discovery). No internal-only detail → **no response trimming** and **no auth gate** (federation peers are external and can't authenticate). Membership privacy is an explicit v1 out-of-scope item (a sealed-network join handshake is a follow-up). Documented under **"Public-exposure policy (dev = prod)"** in `docs/sop-network-registry.md`.

## Parity guarantee
- `wrangler.toml` carries a **parity-guard comment at both `[env.dev]` and `[env.production]`** ratelimit blocks: limit/period/guarded-endpoints must stay byte-identical; only `namespace_id` differs (CF requires a distinct namespace per env). Verified identical: `RL_REGISTER 5/60`, `RL_READ 120/60` in both.
- The runbook states the parity principle explicitly.

## Tests (`bun test`, ephemeral, no hardcoded ports — 68 pass)
register over/under limit → 429/201; read-limit 429 across both list paths; health/pubkey unthrottled; rate-limit-before-signature (bad-sig flood → 429 not 401); native-binding mock path + (IP, principal) keying + fail-open; fallback bucket logic; 429 body opaque (no internals); `Retry-After` present; enumeration policy (by-id resolve public, list shape unchanged).

## Self-review (/code-review --fix high)
0 blockers, 0 majors. **1 nit applied:** Hardening lens H-03 — added `Retry-After` to 429 responses (value = the public window period; leaks nothing). **1 informational note (follow-up candidate, not blocking):** a separate in-memory-only rate limiter exists in `src/surface/mc/worker/src/rate-limiter.ts` (a different Worker/deploy, no native-binding path); consolidating the two into a shared module is a possible future cleanup — not done here to keep the network-registry service self-contained.

## Verification
- `bun test` (registry gate): **68 pass / 0 fail**
- root `bunx tsc --noEmit`: **0 errors**
- `bun run lint:errors`: **clean**
- `bash scripts/check-carveouts.sh`: **PASS on source** (principal vocab). ⚠️ The full-tree run flags hits inside the **gitignored** nested `src/services/network-registry/node_modules/` (vendored wrangler/workers-types bundle containing "Operator" substrings) — an environmental artifact of `bun install`, not committed and not present on a clean checkout. Confirmed PASS with that `node_modules` excluded.
- Pre-existing strict-tsc clash **#679** in the registry's local tsconfig (`TextEncoder().encode()` `ArrayBufferLike` + existing-test `string|undefined`) is unchanged — **no new patterns added**; the new `src/rate-limit.ts` is strict-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)