### PR TITLE
feat(cli/discord): multi-server support — --guild flag + named server profiles

### DIFF
--- a/src/cli/discord/__tests__/server-context.test.ts
+++ b/src/cli/discord/__tests__/server-context.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Unit tests for the multi-server resolution helper.
+ *
+ * The `discord` CLI was single-guild: one top-level guildId + channels map.
+ * `resolveServerContext` layers two complementary overrides over that base —
+ * a `--guild <id>` flag and a `--server <name>` named profile — with the
+ * precedence `--guild`/`--channel` > `--server` profile > top-level config.
+ *
+ * These tests pin that precedence and, critically, the back-compat invariant:
+ * with no flags the resolved context is identical to the top-level config so
+ * the legacy single-guild path is untouched.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { DiscordCliConfig } from "../lib/config";
+import {
+  resolveServerContext,
+  registerServerProfile,
+  ServerContextError,
+} from "../lib/server-context";
+
+// Real guild IDs from the deployment: grove (top-level) + halden (profile).
+const GROVE_GUILD = "1487023327791808592";
+const HALDEN_GUILD = "1512054429023731884";
+
+function baseConfig(): DiscordCliConfig {
+  return {
+    botToken: "grove-token",
+    guildId: GROVE_GUILD,
+    defaultChannel: "cortex",
+    channels: { cortex: { id: "111" } },
+    servers: {
+      halden: {
+        guildId: HALDEN_GUILD,
+        defaultChannel: "general",
+        channels: { general: { id: "1512054429480648837" } },
+      },
+    },
+  };
+}
+
+describe("resolveServerContext — back-compat (no flags)", () => {
+  test("no flags resolves to the top-level config verbatim", () => {
+    const config = baseConfig();
+    const ctx = resolveServerContext(config, {});
+    expect(ctx.guildId).toBe(GROVE_GUILD);
+    expect(ctx.botToken).toBe("grove-token");
+    expect(ctx.defaultChannel).toBe("cortex");
+    expect(ctx.channels).toEqual({ cortex: { id: "111" } });
+    expect(ctx.serverName).toBeUndefined();
+  });
+
+  test("no flags on a minimal config (no servers block) is unchanged", () => {
+    const config: DiscordCliConfig = {
+      botToken: "t",
+      guildId: GROVE_GUILD,
+      defaultChannel: "cortex",
+    };
+    const ctx = resolveServerContext(config, {});
+    expect(ctx.guildId).toBe(GROVE_GUILD);
+    expect(ctx.botToken).toBe("t");
+    expect(ctx.defaultChannel).toBe("cortex");
+  });
+});
+
+describe("resolveServerContext — --guild flag (ISC-C2/C3)", () => {
+  test("--guild overrides guildId for name resolution", () => {
+    const ctx = resolveServerContext(baseConfig(), { guild: HALDEN_GUILD });
+    expect(ctx.guildId).toBe(HALDEN_GUILD);
+  });
+
+  test("--guild keeps the top-level token and channels (token guild-agnostic)", () => {
+    const ctx = resolveServerContext(baseConfig(), { guild: HALDEN_GUILD });
+    expect(ctx.botToken).toBe("grove-token");
+    expect(ctx.channels).toEqual({ cortex: { id: "111" } });
+    expect(ctx.serverName).toBeUndefined();
+  });
+});
+
+describe("resolveServerContext — --server profile (ISC-C7/C8)", () => {
+  test("--server overrides guildId with the profile's guildId", () => {
+    const ctx = resolveServerContext(baseConfig(), { server: "halden" });
+    expect(ctx.guildId).toBe(HALDEN_GUILD);
+    expect(ctx.serverName).toBe("halden");
+  });
+
+  test("--server uses the profile's defaultChannel and channels", () => {
+    const ctx = resolveServerContext(baseConfig(), { server: "halden" });
+    expect(ctx.defaultChannel).toBe("general");
+    expect(ctx.channels).toEqual({ general: { id: "1512054429480648837" } });
+  });
+
+  test("--server falls back to top-level token/channel when profile omits them", () => {
+    const config = baseConfig();
+    config.servers = { halden: { guildId: HALDEN_GUILD } };
+    const ctx = resolveServerContext(config, { server: "halden" });
+    expect(ctx.guildId).toBe(HALDEN_GUILD);
+    expect(ctx.botToken).toBe("grove-token"); // fell back to top-level
+    expect(ctx.defaultChannel).toBe("cortex"); // fell back to top-level
+    expect(ctx.channels).toEqual({ cortex: { id: "111" } });
+  });
+
+  test("--server uses the profile's own token when present", () => {
+    const config = baseConfig();
+    config.servers = { halden: { guildId: HALDEN_GUILD, botToken: "halden-token" } };
+    const ctx = resolveServerContext(config, { server: "halden" });
+    expect(ctx.botToken).toBe("halden-token");
+  });
+});
+
+describe("resolveServerContext — precedence (ISC-C9)", () => {
+  test("--guild beats the --server profile guildId when they agree-or-not", () => {
+    const config = baseConfig();
+    // profile resolves to HALDEN, but explicit --guild wins for guildId.
+    const ctx = resolveServerContext(config, { server: "halden", guild: HALDEN_GUILD });
+    expect(ctx.guildId).toBe(HALDEN_GUILD);
+    // profile's channels/defaultChannel still layered in.
+    expect(ctx.defaultChannel).toBe("general");
+  });
+});
+
+describe("resolveServerContext — error paths (ISC-C11/C12)", () => {
+  test("unknown --server profile throws loudly", () => {
+    expect(() => resolveServerContext(baseConfig(), { server: "nope" })).toThrow(
+      ServerContextError
+    );
+  });
+
+  test("profile missing guildId fails loudly", () => {
+    const config = baseConfig();
+    // Simulate a hand-edited profile with no guildId.
+    config.servers = { broken: { guildId: "" } };
+    expect(() => resolveServerContext(config, { server: "broken" })).toThrow(
+      /missing guildId/
+    );
+  });
+
+  test("conflicting --guild and --server (different guilds) errors clearly", () => {
+    expect(() =>
+      resolveServerContext(baseConfig(), { server: "halden", guild: GROVE_GUILD })
+    ).toThrow(/Conflicting guild/);
+  });
+
+  test("matching --guild and --server (same guild) does NOT error", () => {
+    const ctx = resolveServerContext(baseConfig(), {
+      server: "halden",
+      guild: HALDEN_GUILD,
+    });
+    expect(ctx.guildId).toBe(HALDEN_GUILD);
+  });
+
+  test("error messages never include the bot token", () => {
+    try {
+      resolveServerContext(baseConfig(), { server: "nope" });
+    } catch (err) {
+      expect((err as Error).message).not.toContain("grove-token");
+    }
+  });
+});
+
+describe("registerServerProfile (ISC-C13)", () => {
+  test("registers a new profile with guildId only", () => {
+    const config: DiscordCliConfig = { botToken: "t", guildId: GROVE_GUILD };
+    registerServerProfile(config, "halden", HALDEN_GUILD);
+    expect(config.servers?.halden?.guildId).toBe(HALDEN_GUILD);
+  });
+
+  test("registers a profile with a default channel", () => {
+    const config: DiscordCliConfig = {};
+    registerServerProfile(config, "halden", HALDEN_GUILD, "general");
+    expect(config.servers?.halden?.defaultChannel).toBe("general");
+  });
+
+  test("updating an existing profile preserves its cached channels", () => {
+    const config: DiscordCliConfig = {
+      servers: { halden: { guildId: "old", channels: { general: { id: "999" } } } },
+    };
+    registerServerProfile(config, "halden", HALDEN_GUILD);
+    expect(config.servers?.halden?.guildId).toBe(HALDEN_GUILD);
+    expect(config.servers?.halden?.channels).toEqual({ general: { id: "999" } });
+  });
+
+  test("never writes a token onto the profile", () => {
+    const config: DiscordCliConfig = {};
+    registerServerProfile(config, "halden", HALDEN_GUILD, "general");
+    expect(config.servers?.halden?.botToken).toBeUndefined();
+  });
+
+  test("empty guildId throws", () => {
+    const config: DiscordCliConfig = {};
+    expect(() => registerServerProfile(config, "halden", "")).toThrow(ServerContextError);
+  });
+});

--- a/src/cli/discord/discord.ts
+++ b/src/cli/discord/discord.ts
@@ -9,19 +9,43 @@
 import { Command } from "commander";
 import YAML from "yaml";
 import { loadConfig, saveConfig, getConfigPath } from "./lib/config";
+import { resolveServerContext, registerServerProfile, ServerContextError } from "./lib/server-context";
+import type { ResolvedServerContext, ServerContextOptions } from "./lib/server-context";
+import type { DiscordCliConfig } from "./lib/config";
 import { postMessage, resolveChannelByName, resolveThreadByName, readMessages, listChannels, listThreads } from "./lib/discord";
 
 // Per-command option shapes. Commander's typing is permissive; pinning each
 // `.action((opts) => …)` to the concrete shape lets the typed-checked preset
 // narrow .channel/.thread/.limit instead of falling through as `any`.
-interface PostOptions {
+// `guild`/`server` carry the multi-server overrides (see lib/server-context).
+interface PostOptions extends ServerContextOptions {
   channel?: string;
   thread?: string;
 }
-interface ReadOptions {
+interface ReadOptions extends ServerContextOptions {
   channel?: string;
   thread?: string;
   limit: string;
+}
+
+/**
+ * Resolve the effective server context for a command, translating a
+ * `ServerContextError` into a CLI error + exit. Returns a context whose
+ * `guildId`/`botToken` are then validated by the caller exactly as before.
+ */
+function resolveContextOrExit(
+  config: ReturnType<typeof loadConfig>,
+  opts: ServerContextOptions
+): ResolvedServerContext {
+  try {
+    return resolveServerContext(config, opts);
+  } catch (err) {
+    if (err instanceof ServerContextError) {
+      console.error(err.message);
+      process.exit(1);
+    }
+    throw err;
+  }
 }
 
 // `setNestedValue`/`getNestedValue` walk an arbitrarily-nested config tree.
@@ -47,15 +71,18 @@ program
   .argument("<message...>", "Message text (multiple words joined)")
   .option("-c, --channel <name>", "Channel name (default: defaultChannel from config)")
   .option("-t, --thread <name-or-id>", "Thread name or ID to post into")
+  .option("-g, --guild <id>", "Guild ID to resolve channel/thread names against (overrides config)")
+  .option("-s, --server <name>", "Named server profile from config (layers guildId + overrides)")
   .action(async (messageParts: string[], opts: PostOptions) => {
     const config = loadConfig();
+    const ctx = resolveContextOrExit(config, opts);
     const message = messageParts.join(" ");
 
-    if (!config.botToken) {
+    if (!ctx.botToken) {
       console.error("Bot token required. Run: discord config set botToken <token>");
       process.exit(1);
     }
-    if (!config.guildId) {
+    if (!ctx.guildId) {
       console.error("Guild ID required. Run: discord config set guildId <id>");
       process.exit(1);
     }
@@ -63,7 +90,7 @@ program
     // Resolve thread by name if provided and not a numeric ID
     let threadId = opts.thread;
     if (threadId && !/^\d+$/.test(threadId)) {
-      const resolved = await resolveThreadByName(config.botToken, config.guildId, threadId);
+      const resolved = await resolveThreadByName(ctx.botToken, ctx.guildId, threadId);
       if (!resolved) {
         console.error(`Thread "${threadId}" not found. Run: discord threads`);
         process.exit(1);
@@ -71,27 +98,26 @@ program
       threadId = resolved.id;
     }
 
-    const channelName = opts.channel ?? config.defaultChannel;
+    const channelName = opts.channel ?? ctx.defaultChannel;
     if (!threadId && !channelName) {
       console.error("No channel or thread specified and no defaultChannel configured.");
       console.error("Run: discord config set defaultChannel <name>");
       process.exit(1);
     }
 
-    // Resolve channel name → ID (cached in config, or looked up via API)
+    // Resolve channel name → ID (cached in context, or looked up via API).
+    // A cached id posts directly and is guild-agnostic — no resolution needed.
     let channelId: string | undefined;
     if (channelName) {
-      channelId = config.channels?.[channelName]?.id;
+      channelId = ctx.channels?.[channelName]?.id;
       if (!channelId) {
-        channelId = await resolveChannelByName(config.botToken, config.guildId, channelName) ?? undefined;
+        channelId = await resolveChannelByName(ctx.botToken, ctx.guildId, channelName) ?? undefined;
         if (!channelId && !threadId) {
           console.error(`Channel "#${channelName}" not found. Run: discord channels`);
           process.exit(1);
         }
         if (channelId) {
-          // Cache the resolved ID
-          config.channels ??= {};
-          config.channels[channelName] = { id: channelId };
+          cacheChannelId(config, ctx, channelName, channelId);
           saveConfig(config);
         }
       }
@@ -103,7 +129,7 @@ program
       process.exit(1);
     }
 
-    const result = await postMessage(config.botToken, targetId, message);
+    const result = await postMessage(ctx.botToken, targetId, message);
     if (result.success) {
       console.log(`Posted to #${channelName}${opts.thread ? ` (thread)` : ""}`);
     } else {
@@ -120,14 +146,17 @@ program
   .option("-c, --channel <name>", "Channel name (default: defaultChannel from config)")
   .option("-t, --thread <name-or-id>", "Thread name or ID to read from")
   .option("-n, --limit <n>", "Number of messages", "10")
+  .option("-g, --guild <id>", "Guild ID to resolve channel/thread names against (overrides config)")
+  .option("-s, --server <name>", "Named server profile from config (layers guildId + overrides)")
   .action(async (opts: ReadOptions) => {
     const config = loadConfig();
+    const ctx = resolveContextOrExit(config, opts);
 
-    if (!config.botToken) {
+    if (!ctx.botToken) {
       console.error("Bot token required. Run: discord config set botToken <token>");
       process.exit(1);
     }
-    if (!config.guildId) {
+    if (!ctx.guildId) {
       console.error("Guild ID required. Run: discord config set guildId <id>");
       process.exit(1);
     }
@@ -135,7 +164,7 @@ program
     // Resolve thread by name if provided
     let threadId = opts.thread;
     if (threadId && !/^\d+$/.test(threadId)) {
-      const resolved = await resolveThreadByName(config.botToken, config.guildId, threadId);
+      const resolved = await resolveThreadByName(ctx.botToken, ctx.guildId, threadId);
       if (!resolved) {
         console.error(`Thread "${threadId}" not found. Run: discord threads`);
         process.exit(1);
@@ -148,27 +177,26 @@ program
     if (threadId) {
       readTargetId = threadId;
     } else {
-      const channelName = opts.channel ?? config.defaultChannel;
+      const channelName = opts.channel ?? ctx.defaultChannel;
       if (!channelName) {
         console.error("No channel or thread specified and no defaultChannel configured.");
         process.exit(1);
       }
 
-      let channelId = config.channels?.[channelName]?.id;
+      let channelId = ctx.channels?.[channelName]?.id;
       if (!channelId) {
-        channelId = await resolveChannelByName(config.botToken, config.guildId, channelName) ?? undefined;
+        channelId = await resolveChannelByName(ctx.botToken, ctx.guildId, channelName) ?? undefined;
         if (!channelId) {
           console.error(`Channel "#${channelName}" not found.`);
           process.exit(1);
         }
-        config.channels ??= {};
-        config.channels[channelName] = { id: channelId };
+        cacheChannelId(config, ctx, channelName, channelId);
         saveConfig(config);
       }
       readTargetId = channelId;
     }
 
-    const messages = await readMessages(config.botToken, readTargetId, parseInt(opts.limit));
+    const messages = await readMessages(ctx.botToken, readTargetId, parseInt(opts.limit));
     for (const msg of messages) {
       const time = new Date(msg.timestamp).toLocaleTimeString("en-US", { hour: "2-digit", minute: "2-digit" });
       console.log(`[${time}] ${msg.author}: ${msg.content}`);
@@ -180,14 +208,17 @@ program
 program
   .command("channels")
   .description("List channels in the Discord server")
-  .action(async () => {
+  .option("-g, --guild <id>", "Guild ID to list channels from (overrides config)")
+  .option("-s, --server <name>", "Named server profile from config (layers guildId + overrides)")
+  .action(async (opts: ServerContextOptions) => {
     const config = loadConfig();
-    if (!config.botToken || !config.guildId) {
+    const ctx = resolveContextOrExit(config, opts);
+    if (!ctx.botToken || !ctx.guildId) {
       console.error("botToken and guildId required. Run: discord config set botToken <token>");
       process.exit(1);
     }
 
-    const channels = await listChannels(config.botToken, config.guildId);
+    const channels = await listChannels(ctx.botToken, ctx.guildId);
     for (const ch of channels) {
       console.log(`  #${ch.name.padEnd(25)} ${ch.id}`);
     }
@@ -198,14 +229,17 @@ program
 program
   .command("threads")
   .description("List active threads in the Discord server")
-  .action(async () => {
+  .option("-g, --guild <id>", "Guild ID to list threads from (overrides config)")
+  .option("-s, --server <name>", "Named server profile from config (layers guildId + overrides)")
+  .action(async (opts: ServerContextOptions) => {
     const config = loadConfig();
-    if (!config.botToken || !config.guildId) {
+    const ctx = resolveContextOrExit(config, opts);
+    if (!ctx.botToken || !ctx.guildId) {
       console.error("botToken and guildId required.");
       process.exit(1);
     }
 
-    const threads = await listThreads(config.botToken, config.guildId);
+    const threads = await listThreads(ctx.botToken, ctx.guildId);
     if (threads.length === 0) {
       console.log("No active threads.");
       return;
@@ -231,6 +265,30 @@ configCmd
     setNestedValue(config as unknown as ConfigObject, key, value);
     saveConfig(config);
     console.log(`Set ${key} = ${value.length > 50 ? value.slice(0, 50) + "..." : value}`);
+  });
+
+configCmd
+  .command("set-server")
+  .description("Register a named server profile (a second guild the bot is in)")
+  .argument("<name>", "Profile name (e.g. halden)")
+  .argument("<guildId>", "Discord guild/server ID for the profile")
+  .argument("[defaultChannel]", "Optional default channel name for the profile")
+  .action((name: string, guildId: string, defaultChannel?: string) => {
+    const config = loadConfig();
+    try {
+      registerServerProfile(config, name, guildId, defaultChannel);
+    } catch (err) {
+      if (err instanceof ServerContextError) {
+        console.error(err.message);
+        process.exit(1);
+      }
+      throw err;
+    }
+    saveConfig(config);
+    console.log(
+      `Registered server "${name}" → guild ${guildId}` +
+        (defaultChannel ? ` (default channel #${defaultChannel})` : "")
+    );
   });
 
 configCmd
@@ -264,6 +322,28 @@ configCmd
   });
 
 // ─── helpers ───────────────────────────────────────────────────────────────
+
+/**
+ * Cache a freshly-resolved channel id back into config, writing to the active
+ * server profile's `channels` map when a `--server` profile is in effect, else
+ * to the top-level `channels`. Keeps each guild's name→id cache isolated so a
+ * name that exists in two guilds never cross-contaminates.
+ */
+function cacheChannelId(
+  config: DiscordCliConfig,
+  ctx: ResolvedServerContext,
+  channelName: string,
+  channelId: string
+): void {
+  const profile = ctx.serverName ? config.servers?.[ctx.serverName] : undefined;
+  if (profile) {
+    profile.channels ??= {};
+    profile.channels[channelName] = { id: channelId };
+  } else {
+    config.channels ??= {};
+    config.channels[channelName] = { id: channelId };
+  }
+}
 
 function setNestedValue(obj: ConfigObject, key: string, value: string): void {
   const parts = key.split(".");

--- a/src/cli/discord/lib/config.ts
+++ b/src/cli/discord/lib/config.ts
@@ -17,6 +17,26 @@ export interface ChannelConfig {
   id: string;
 }
 
+/**
+ * A named server profile — a second (or third, …) guild the same bot is in.
+ *
+ * Only `guildId` is required: it is the value used for channel/thread NAME
+ * resolution within that guild. `botToken`, `defaultChannel`, and `channels`
+ * are optional overrides; when absent the top-level (grove) values are used.
+ * This lets one token serve every guild the bot has joined while keeping each
+ * guild's name→id resolution scoped to the right server.
+ */
+export interface ServerProfile {
+  /** Discord guild/server ID for this profile (required) */
+  guildId: string;
+  /** Per-profile bot token; falls back to top-level botToken when absent */
+  botToken?: string;
+  /** Per-profile default channel; falls back to top-level defaultChannel */
+  defaultChannel?: string;
+  /** Per-profile cached channel name→id map */
+  channels?: Record<string, ChannelConfig>;
+}
+
 export interface DiscordCliConfig {
   /** Discord bot token */
   botToken?: string;
@@ -26,6 +46,8 @@ export interface DiscordCliConfig {
   defaultChannel?: string;
   /** Named channel configs */
   channels?: Record<string, ChannelConfig>;
+  /** Named server profiles for guilds other than the top-level (grove) one */
+  servers?: Record<string, ServerProfile>;
 }
 
 const CONFIG_PATH = join(process.env.HOME ?? "~", ".config", "grove", "cli.yaml");

--- a/src/cli/discord/lib/server-context.ts
+++ b/src/cli/discord/lib/server-context.ts
@@ -1,0 +1,144 @@
+/**
+ * Server-context resolution — the single place that decides WHICH guild a
+ * `discord` command resolves channel/thread names against, and which
+ * token / default-channel / cached-channels apply.
+ *
+ * Two complementary mechanisms layer over the single-guild base config:
+ *
+ *   1. `-g, --guild <id>`   — overrides the guildId used for NAME resolution.
+ *   2. `-s, --server <name>` — selects a named profile from `config.servers`,
+ *      layering its guildId (required) plus optional botToken / defaultChannel
+ *      / channels over the top-level values.
+ *
+ * Precedence (highest wins): explicit `--guild` flag  >  `--server` profile
+ * >  top-level config. The `--channel` flag (handled by the caller) likewise
+ * beats a profile's `defaultChannel`.
+ *
+ * Back-compat invariant: with neither `--guild` nor `--server`, the resolved
+ * context is byte-identical to the top-level config — the legacy single-guild
+ * path is untouched.
+ *
+ * This module is intentionally PURE (no I/O, no process.exit, no network) so
+ * the precedence logic is unit-testable in isolation. Callers translate a
+ * thrown `ServerContextError` into a CLI error + exit code.
+ */
+
+import type { ChannelConfig, DiscordCliConfig, ServerProfile } from "./config";
+
+/** Flags that influence server-context resolution, parsed from argv. */
+export interface ServerContextOptions {
+  /** Raw `--guild <id>` value, if provided. */
+  guild?: string;
+  /** Raw `--server <name>` value, if provided. */
+  server?: string;
+}
+
+/**
+ * The effective context a command operates in after layering flags + profile
+ * over the base config. `guildId` may still be undefined when nothing supplies
+ * one (same as today's "Guild ID required" path) — the caller validates it.
+ */
+export interface ResolvedServerContext {
+  /** Guild ID used for channel/thread NAME resolution (may be undefined). */
+  guildId?: string;
+  /** Bot token to authenticate API calls (may be undefined). */
+  botToken?: string;
+  /** Default channel name when none passed on the command line. */
+  defaultChannel?: string;
+  /** Cached channel name→id map for guild-agnostic id posting. */
+  channels?: Record<string, ChannelConfig>;
+  /** Name of the profile applied, when `--server` was used. */
+  serverName?: string;
+}
+
+/** Raised for caller-facing, user-fixable resolution failures. */
+export class ServerContextError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ServerContextError";
+  }
+}
+
+/**
+ * Resolve the effective server context from base config + flags.
+ *
+ * @throws ServerContextError when the named profile is unknown, the profile
+ *   is missing its required guildId, or `--guild` and `--server` disagree on
+ *   the guild.
+ */
+export function resolveServerContext(
+  config: DiscordCliConfig,
+  opts: ServerContextOptions
+): ResolvedServerContext {
+  // Start from the top-level (grove) values — the no-flag path returns these
+  // unchanged, preserving byte-identical legacy behaviour.
+  let guildId = config.guildId;
+  let botToken = config.botToken;
+  let defaultChannel = config.defaultChannel;
+  let channels = config.channels;
+  let serverName: string | undefined;
+
+  // ── Layer 1: named server profile ────────────────────────────────────────
+  if (opts.server) {
+    const profile = config.servers?.[opts.server];
+    if (!profile) {
+      throw new ServerContextError(
+        `Server profile "${opts.server}" not found. ` +
+          `Register it with: discord config set-server ${opts.server} <guildId>`
+      );
+    }
+    if (!profile.guildId) {
+      throw new ServerContextError(
+        `Server profile "${opts.server}" is missing guildId. ` +
+          `Set it with: discord config set-server ${opts.server} <guildId>`
+      );
+    }
+    guildId = profile.guildId;
+    serverName = opts.server;
+    // Optional overrides fall back to the top-level values when absent.
+    if (profile.botToken) botToken = profile.botToken;
+    if (profile.defaultChannel) defaultChannel = profile.defaultChannel;
+    if (profile.channels) channels = profile.channels;
+  }
+
+  // ── Layer 2: explicit --guild flag (highest precedence for guildId) ───────
+  if (opts.guild) {
+    // A profile + an explicit guild that disagree is almost certainly a
+    // principal mistake — fail loudly rather than silently picking one.
+    if (serverName && guildId && opts.guild !== guildId) {
+      throw new ServerContextError(
+        `Conflicting guild: --guild ${opts.guild} but --server "${serverName}" ` +
+          `resolves to guild ${guildId}. Pass only one, or make them agree.`
+      );
+    }
+    guildId = opts.guild;
+  }
+
+  return { guildId, botToken, defaultChannel, channels, serverName };
+}
+
+/**
+ * Register (or update) a named server profile in the config object, mutating
+ * and returning it. Pure aside from the in-place mutation — does NOT persist;
+ * the caller saves. `guildId` is required; `defaultChannel` is optional. A
+ * per-profile token is intentionally NOT settable here so this command never
+ * writes a token (token sharing across guilds is the whole point).
+ *
+ * @throws ServerContextError on an empty name or guildId.
+ */
+export function registerServerProfile(
+  config: DiscordCliConfig,
+  name: string,
+  guildId: string,
+  defaultChannel?: string
+): DiscordCliConfig {
+  if (!name) throw new ServerContextError("Server profile name is required.");
+  if (!guildId) throw new ServerContextError("guildId is required.");
+
+  config.servers ??= {};
+  const existing: ServerProfile | undefined = config.servers[name];
+  const next: ServerProfile = { ...existing, guildId };
+  if (defaultChannel) next.defaultChannel = defaultChannel;
+  config.servers[name] = next;
+  return config;
+}

--- a/src/cli/discord/skill/SKILL.md
+++ b/src/cli/discord/skill/SKILL.md
@@ -26,6 +26,27 @@ discord threads                            # List active threads
 
 Run `discord --help` for full command list.
 
+### Multi-server (posting to a guild other than grove)
+
+The bot can be in several guilds with the same token. Target another guild
+either by a one-off `--guild <id>` (overrides the guild used for channel/thread
+name resolution) or by a saved `--server <name>` profile:
+
+```bash
+# One-off: resolve the channel name in the halden guild
+discord post --guild 1512054429023731884 --channel general "Deployed halden"
+
+# Saved profile (register once, then reference by name):
+discord config set-server halden 1512054429023731884 general
+discord post --server halden "Deployed halden"
+discord read  --server halden
+```
+
+Precedence: explicit `--guild`/`--channel` flags  >  `--server` profile  >
+top-level config. With neither flag, behaviour is identical to single-guild.
+A cached `channels.<name>.id` posts by id directly and is guild-agnostic; the
+`--guild`/`--server` override only changes how a channel *name* is resolved.
+
 ---
 
 ## Workflow Routing
@@ -48,5 +69,19 @@ If `discord config show` returns empty, guide the user:
 1. `discord config set botToken <token>`
 2. `discord config set guildId <id>`
 3. `discord config set defaultChannel <name>`
+
+For a second guild the bot has joined (e.g. halden), register a profile:
+
+4. `discord config set-server halden <guildId> [defaultChannel]`
+
+Or hand-edit the `servers:` block in the config file:
+
+```yaml
+servers:
+  halden:
+    guildId: "1512054429023731884"
+    defaultChannel: general   # optional; falls back to top-level
+    # botToken / channels optional — omitted fields fall back to top-level
+```
 
 Config stored at `~/.config/grove/cli.yaml`.

--- a/src/cli/discord/skill/Workflows/Post.md
+++ b/src/cli/discord/skill/Workflows/Post.md
@@ -19,8 +19,25 @@ Post a message to a Discord channel.
 
 4. **Confirm** — report success or failure to the user.
 
+## Posting to another guild (multi-server)
+
+The same bot can post to any guild it has joined (e.g. grove + halden). Pick the
+guild for channel/thread name resolution with one of:
+
+```bash
+# Saved profile (preferred — register once with `discord config set-server`):
+discord post --server halden "Deployed v0.6.0 to halden"
+
+# One-off by guild ID:
+discord post --guild 1512054429023731884 --channel general "Deployed halden"
+```
+
+Precedence: `--guild`/`--channel` beat a `--server` profile, which beats the
+top-level config. With no `--server`/`--guild`, posting is exactly as before.
+
 ## Notes
 
 - For multi-line messages, use quotes and `\n` or write to a temp file first.
 - If posting fails with "Bot token required", run `discord config show` and guide setup.
-- Channel names are resolved automatically on first use and cached.
+- Channel names are resolved automatically on first use and cached (per guild).
+- `--guild` and `--server` must not disagree on the guild — the CLI errors if they do.


### PR DESCRIPTION
## What

The `discord` CLI was single-guild: `~/.config/grove/cli.yaml` carried one top-level `guildId` (grove) plus a `channels` map. Now that Luna's bot is in a **second guild (halden, `1512054429023731884`)** on the **same token**, this adds two complementary ways to post/read across guilds.

## Two mechanisms

**1. `-g, --guild <id>` flag** (on `post`, `read`, `threads`, `channels`)
Overrides `config.guildId` for channel/thread **name resolution only**. Same token (works for any guild the bot has joined). A cached `channels[name].id` still posts by id directly and is **guild-agnostic** — the override only changes how a *name* resolves.

**2. Named server profiles** (`-s, --server <name>`)
New optional config block:
```yaml
servers:
  halden:
    guildId: "1512054429023731884"
    defaultChannel: general   # optional → falls back to top-level
    # botToken / channels optional → fall back to top-level
```
`--server <name>` layers the profile over the base config: its `guildId` (required) overrides; its `botToken`/`defaultChannel`/`channels` override when present, else fall back to the top-level (grove) values. Register one from the CLI:
```bash
discord config set-server halden 1512054429023731884 general
```
(`set-server` never writes a token — token sharing across guilds is the whole point.)

## Precedence

`explicit --guild / --channel`  >  `--server profile`  >  `top-level config`

## Back-compat proof

With **neither** `--guild` nor `--server`, `resolveServerContext` returns the top-level config values **verbatim** — the legacy single-guild path is byte-identical. Pinned by tests:
- `no flags resolves to the top-level config verbatim`
- `no flags on a minimal config (no servers block) is unchanged`

## Guardrails

- Conflicting `--guild` + `--server` (different guilds) → clear `Conflicting guild:` error (matching guilds are allowed).
- A profile missing `guildId` → fails loudly (`missing guildId`).
- The bot token is **never logged** — error messages reference guildId/profile-name only (pinned by `error messages never include the bot token`).

## halden usage example

```bash
# Saved profile:
discord post --server halden "Deployed v0.6.0 to halden"
discord read  --server halden

# One-off by guild ID:
discord post --guild 1512054429023731884 --channel general "Deployed halden"
```

## Design

Resolution logic lives in a **pure, I/O-free** `src/cli/discord/lib/server-context.ts` (`resolveServerContext` + `registerServerProfile` + `ServerContextError`). The commands consume it; the action closures stay thin. This keeps precedence/fallback unit-testable in isolation.

## Verify

- `bunx tsc --noEmit` — 0 errors
- `bun run lint:errors` — clean
- `bash scripts/check-carveouts.sh` — PASS (principal vocab)
- `bun test src/cli/discord/` — 19 pass / 0 fail

## Files

- `lib/config.ts` — `ServerProfile` interface + `servers?` field
- `lib/server-context.ts` (new) — pure resolution + registration helpers
- `discord.ts` — `--guild`/`--server` on post/read/threads/channels, `config set-server`, per-guild cache write-back
- `__tests__/server-context.test.ts` (new) — 19 tests
- `skill/SKILL.md` + `skill/Workflows/Post.md` — halden examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)