### PR TITLE
fix(network-registry): verify signature before recording nonce (#695)

### DIFF
--- a/src/services/network-registry/__tests__/principals.test.ts
+++ b/src/services/network-registry/__tests__/principals.test.ts
@@ -188,6 +188,50 @@ describe("POST /principals/:id/register — auth failures", () => {
     expect(res2.status).toBe(409);
   });
 
+  test("#695 — bad-signature POST does NOT burn the nonce", async () => {
+    // The nonce cache is durable (D1, #694). Before #695 the handler
+    // recorded the nonce BEFORE verifying the signature, so a bad-sig
+    // POST permanently consumed a nonce row — a later legitimate claim
+    // reusing that nonce would then wrongly 409. After the reorder the
+    // signature is verified first, so a bad-sig POST is rejected 401
+    // WITHOUT touching the nonce cache.
+    const nonce = randomNonce();
+
+    // Bad signature: sign with the wrong key while claiming pKey's pubkey.
+    const otherKey = await makePrincipalKey();
+    const badBody = await makeSignedRegistration("andreas", otherKey, {
+      pubkeyOverride: pKey.publicKeyB64,
+      nonce,
+    });
+    const badRes = await post("/principals/andreas/register", badBody);
+    expect(badRes.status).toBe(401);
+    expect(((await badRes.json()) as { error: string }).error).toBe("signature_invalid");
+
+    // A subsequent VALID POST reusing the SAME nonce must succeed —
+    // proving the bad-sig attempt never consumed the nonce.
+    const goodBody = await makeSignedRegistration("andreas", pKey, {
+      stacks: [{ stack_id: "andreas/laptop" }],
+      nonce,
+    });
+    const goodRes = await post("/principals/andreas/register", goodBody);
+    expect(goodRes.status).toBe(201);
+  });
+
+  test("#695 — valid-sig replay still rejects 409 (nonce consumed only on authentic path)", async () => {
+    // The reorder must NOT weaken replay protection: a validly-signed
+    // claim consumes its nonce, and a second validly-signed claim reusing
+    // that same nonce is still rejected 409.
+    const nonce = randomNonce();
+    const body1 = await makeSignedRegistration("andreas", pKey, { nonce });
+    const res1 = await post("/principals/andreas/register", body1);
+    expect(res1.status).toBe(201);
+
+    const body2 = await makeSignedRegistration("andreas", pKey, { nonce });
+    const res2 = await post("/principals/andreas/register", body2);
+    expect(res2.status).toBe(409);
+    expect(((await res2.json()) as { error: string }).error).toBe("nonce_replayed");
+  });
+
   test("rejects silent pubkey rotation", async () => {
     const body1 = await makeSignedRegistration("andreas", pKey);
     const res1 = await post("/principals/andreas/register", body1);

--- a/src/services/network-registry/src/routes/principals.ts
+++ b/src/services/network-registry/src/routes/principals.ts
@@ -113,22 +113,31 @@ export function principalRoutes(): Hono<{ Bindings: Env }> {
       );
     }
 
-    // Replay check.
-    const nonceCache = getNonceCache(c.env);
-    const fresh = await nonceCache.recordIfFresh(claim.nonce, now);
-    if (!fresh) {
-      return c.json({ error: "nonce_replayed" }, 409);
-    }
-
     // Signature verification. The principal signs canonical-JSON(claim)
     // with their declared pubkey. TOFU on first register (the claim
     // tells us which key to verify against); rotation requires the
     // previous key to sign a transition claim — out of scope for v1,
     // tracked as a follow-up.
+    //
+    // #695 — verify the signature BEFORE recording the nonce. The nonce
+    // cache is durable (D1, #694), so an unsigned/bad-signature POST that
+    // recorded its nonce first would permanently burn that nonce row
+    // without ever proving authenticity. A replay is only meaningful for
+    // an authentic (validly-signed) claim, so we shed bad-sig POSTs with
+    // 401 here and only consume a nonce on the authentic path below.
     const message = new TextEncoder().encode(canonicalJSON(claim));
     const valid = await verifyEd25519(claim.principal_pubkey, signed.signature, message);
     if (!valid) {
       return c.json({ error: "signature_invalid" }, 401);
+    }
+
+    // Replay check — only reached once the signature is proven valid, so
+    // a nonce row is consumed exclusively on the authentic path. A legit
+    // replay (valid signature, previously-seen nonce) still rejects 409.
+    const nonceCache = getNonceCache(c.env);
+    const fresh = await nonceCache.recordIfFresh(claim.nonce, now);
+    if (!fresh) {
+      return c.json({ error: "nonce_replayed" }, 409);
     }
 
     // Pubkey rotation policy for v1:


### PR DESCRIPTION
Closes #695.

## Problem

The `POST /principals/:id/register` handler recorded the replay nonce (`recordIfFresh`) **before** verifying the Ed25519 signature (`verifyEd25519`). Since #694 made the nonce cache **durable** (D1), an unsigned or bad-signature POST would permanently burn a nonce row without ever proving authenticity. A later *legitimate* claim reusing that nonce would then be wrongly rejected with 409 — an unauthenticated caller could grief a principal's nonce space.

## Change

Reorder so the signature verify runs first. Cheap gates that shed junk before crypto stay first; only the nonce-record step moves to after the verify:

**Before:** cheap gates → clock-skew → **recordIfFresh (nonce)** → **verifyEd25519 (signature)** → rotation guard → putPrincipal

**After:** cheap gates → clock-skew → **verifyEd25519 (signature)** → **recordIfFresh (nonce)** → rotation guard → putPrincipal

Rationale: a replay is only meaningful for an authentic (validly-signed) claim. An unsigned / bad-sig POST should be rejected 401 **without** consuming a (now durable) nonce row.

Rejection reasons/codes are **unchanged** — `signature_invalid` 401, `nonce_replayed` 409, etc. Only the ORDER changes. Replay protection is preserved: a valid-sig claim reusing a seen nonce still rejects 409 (nonce consumed only on the authentic path).

## Tests

- **`#695 — bad-signature POST does NOT burn the nonce`** — bad-sig POST → 401 `signature_invalid`; a subsequent VALID POST reusing the *same* nonce → 201, proving the nonce was never consumed on the bad-sig path.
- **`#695 — valid-sig replay still rejects 409`** — a validly-signed claim consumes its nonce; a second validly-signed claim reusing that nonce still → 409 `nonce_replayed`.

The existing happy-path, skew, replay, and rotation tests are unaffected.

## Verification

- `bun test` (registry suite): **87 pass, 0 fail**
- root `bunx tsc --noEmit`: **0 errors**
- `bun run lint:errors`: **clean** (exit 0)
- `bash scripts/check-carveouts.sh`: changed-files clean; whole-tree gate trips only on the registry's nested `node_modules` (wrangler SDK `...AndOperator` identifiers) — documented false positives, not in tracked source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)