### PR TITLE
fix(mc): dashboard dist path — resolve to repo root after src/surface/mc lift

### DIFF
--- a/src/surface/mc/__tests__/server.test.ts
+++ b/src/surface/mc/__tests__/server.test.ts
@@ -12,12 +12,14 @@ import type { WsClientRegistry } from "../ws/client-registry";
 import type { WsData } from "../ws/types";
 
 // Mirror `DASHBOARD_DIST` from ../server.ts. Server resolves it as
-// `<server.ts dir>/../../dist/dashboard-v2`; from this test file that's
-// three levels up (out of `__tests__/`, `mc/`, `surface/`) plus the same
-// `dist/dashboard-v2` tail. Kept in lockstep with server.ts by hand —
-// if the server path ever moves, this needs to move with it.
+// `<server.ts dir>/../../../dist/dashboard-v2` (repo root); from this
+// test file that's four levels up (out of `__tests__/`, `mc/`,
+// `surface/`, `src/`) plus the same `dist/dashboard-v2` tail. Kept in
+// lockstep with server.ts by hand — if the server path ever moves,
+// this needs to move with it.
 const DASHBOARD_DIST = join(
   dirname(fileURLToPath(import.meta.url)),
+  "..",
   "..",
   "..",
   "..",

--- a/src/surface/mc/server.ts
+++ b/src/surface/mc/server.ts
@@ -58,12 +58,15 @@ const startTime = Date.now();
 // booting the server — when the dist/ tree is missing the / route 404s
 // instead of falling back to the legacy HTML.
 //
-// Path resolution is two levels above the running server.ts at
-// src/mission-control/. When packaged, the resolver follows the same
-// relative offset, but a `dist/` folder is still expected to sit at the
-// project root.
+// Path resolution is three levels above the running server.ts at
+// src/surface/mc/ (the grove-v2 lift moved it down one level from
+// src/mission-control/ — two `..` left it pointing at `src/dist/`,
+// which never exists, so `/` 500'd on every install). When packaged,
+// the resolver follows the same relative offset, but a `dist/` folder
+// is still expected to sit at the project root.
 const DASHBOARD_DIST = join(
   dirname(fileURLToPath(import.meta.url)),
+  "..",
   "..",
   "..",
   "dist",


### PR DESCRIPTION
## Summary

The standalone Mission Control server (`src/surface/mc/index.ts`) 500'd on `/` on every install: `DASHBOARD_DIST` resolved two levels above `server.ts` — correct for grove-v2's `src/mission-control/`, wrong after the MIG lift to `src/surface/mc/` (lands on `src/dist/dashboard-v2`, which never exists).

- `server.ts`: third `..` → repo-root `dist/dashboard-v2`
- `server.test.ts`: matching fourth `..` in the hand-mirrored path — the SPA test was self-skipping for the same reason and now actually runs (4 pass, 0 skip)

## Verification

- `bunx tsc --noEmit` clean
- `bun test src/surface/mc/__tests__/server.test.ts` — 4 pass, 0 skip (SPA test enabled)
- Live: `/` → 200 (index.html), hashed JS asset → 200 (1.27 MB), `/health` → ok

## Out of scope

- The cortex-embedded dashboard API (`config.api.enabled` → dynamic import of `./surface/mc/api/index`) — that module was never migrated from grove-v2 (`src/bot/lib/dashboard-api.ts`); `api.enabled: true` fails non-fatal at startup. Filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)