### PR TITLE
feat(bus,runner): C-686 — federated review consumer (ADR-0002) + inbound gate rework

### DIFF
--- a/docs/adr/0002-federated-dispatch-addressing-and-verdict-back.md
+++ b/docs/adr/0002-federated-dispatch-addressing-and-verdict-back.md
@@ -20,7 +20,7 @@ Getting this wrong has happened three times: cortex#661 (network on wire), pilot
 For a cross-principal dispatch:
 
 - **`envelope.source`** first segments are the **TARGET** `{principal}.{stack}` — because `deriveNatsSubject` derives the subject from `source`, and the receiver subscribes to its own identity. This is the *addressing* role.
-- **`envelope.originator.identity`** is the **REQUESTER** `{principal}/{stack}` — "who the signer is acting on behalf of" (CONTEXT.md §capability: *"only the `originator` field and the scope vary by source"*; `originator` is a signed/signable field). This is the *attribution + reply-to* role.
+- **`envelope.originator.identity`** is the **REQUESTER**, carried as the DID `did:mf:{requester-principal}-{requester-stack}` — "who the signer is acting on behalf of" (CONTEXT.md §capability: *"only the `originator` field and the scope vary by source"*; `originator` is a signed/signable field). This is the *attribution + reply-to* role. **It is NOT a bare `{principal}/{stack}` slash form:** myelin validates `originator.identity` against the `did:mf:<name>` DID grammar, which rejects `/`. The canonical encoding is `stack.id` with `/`→`-` (cortex `src/cortex.ts:483`: `did:mf:${stack.id.replace("/","-")}`; pilot's `encodeRequesterDid`: `did:mf:${principal}-${stack}`). **Decode** = strip the `did:mf:` prefix, then split the remainder on the **FIRST hyphen** into `{principal, stack}`. This rests on the **principal-carries-no-hyphen assumption**: a principal is a single hyphen-free token while a stack MAY contain hyphens, so the first hyphen is the unambiguous boundary — e.g. `did:mf:andreas-meta-factory` → principal `andreas`, stack `meta-factory`.
 - The **network is never on the wire.** No `extensions.network_id` is required for routing; `selectLink` resolves the target leaf from the target principal (subject segment[1]) via `peers[]`.
 
 ### 2. REQUEST subjects (requester → target)
@@ -31,12 +31,12 @@ For a cross-principal dispatch:
 | **Direct** | `federated.{target-principal}.{target-stack}.tasks.@{did-encoded-reviewer}.code-review.{flavor}` | `direct` |
 
 - `source = {target-principal}.{target-stack}.pilot`
-- `originator.identity = {requester-principal}/{requester-stack}`, `originator.method = federated`
+- `originator.identity = did:mf:{requester-principal}-{requester-stack}` (= `stack.id` with `/`→`-`; e.g. `did:mf:andreas-meta-factory`), `originator.method = federated`
 - `sovereignty.classification = federated`, `max_hop = 1`
 
 ### 3. VERDICT-BACK (target → requester)
 
-The target's review consumer (cortex#686) derives the requester from **`originator.identity`** (NOT the inbound subject, NOT `source`), then publishes with `source` addressing the **requester's** scope:
+The target's review consumer (cortex#686) decodes the requester from **`originator.identity`** (NOT the inbound subject, NOT `source`) — strip `did:mf:`, split on the FIRST hyphen → `{requester-principal, requester-stack}` (e.g. `did:mf:andreas-meta-factory` → `andreas` / `meta-factory`) — then publishes with `source` addressing the **requester's** scope:
 
 - verdict: `federated.{requester-principal}.{requester-stack}.review.verdict.{approved|changes-requested|commented}`
 - lifecycle: `federated.{requester-principal}.{requester-stack}.dispatch.task.{started|completed|failed|aborted}`

--- a/src/bus/__tests__/review-consumer.test.ts
+++ b/src/bus/__tests__/review-consumer.test.ts
@@ -42,11 +42,12 @@ import {
   OFFER_DISPATCH_REVIEWER,
   failedReasonToAckDecision,
   parseReviewRequestPayload,
-  parseFederatedRequester,
+  parseRequesterFromOriginator,
   readLogicalResponseRouting,
   type ReviewConsumerAgent,
   type ReviewConsumerOpts,
 } from "../review-consumer";
+import type { PolicyFederatedNetwork } from "../../common/types/cortex-config";
 import type { DispatchTaskFailedReason } from "../dispatch-events";
 import type { AckDecision } from "../myelin/subscriber";
 import {
@@ -149,6 +150,77 @@ function makeRequest(flavor: ReviewFlavor = "typescript"): Envelope {
     flavor,
     payload: PAYLOAD,
   });
+}
+
+// ---------------------------------------------------------------------------
+// cortex#686 (ADR 0002) — federated fixtures
+// ---------------------------------------------------------------------------
+
+/** 56-char U-prefixed base32 NKey — matches the surface-router test fixture. */
+const FED_PEER_PUBKEY = "U" + "A".repeat(55);
+
+/** The REQUESTER identity carried in `originator.identity` (ADR 0002 §1). */
+const REQUESTER_PRINCIPAL = "jc";
+const REQUESTER_STACK = "sage-host";
+const REQUESTER_IDENTITY = `${REQUESTER_PRINCIPAL}/${REQUESTER_STACK}`;
+
+/**
+ * A configured federation network whose `peers[]` lists the requester `jc` as a
+ * member. The consumer-path `peers[]` gate (ADR 0002 §5) admits a requester
+ * only when it resolves here.
+ */
+function makeNetwork(
+  overrides: Partial<PolicyFederatedNetwork> = {},
+): PolicyFederatedNetwork {
+  return {
+    id: "research-collab",
+    leaf_node: "leaf-research",
+    peers: [
+      {
+        principal_id: REQUESTER_PRINCIPAL,
+        stack_id: `${REQUESTER_PRINCIPAL}/${REQUESTER_STACK}`,
+        principal_pubkey: FED_PEER_PUBKEY,
+      },
+    ],
+    accept_subjects: ["federated.jc.sage-host.tasks.code-review.>"],
+    deny_subjects: [],
+    announce_capabilities: [],
+    max_hop: 1,
+    ...overrides,
+  };
+}
+
+/**
+ * Build an inbound FEDERATED review-request envelope per ADR 0002:
+ *   - the subject (built by `cortex.ts`) addresses the TARGET = us
+ *     (`federated.{our-principal}.{our-stack}.…`); tests pass it as the
+ *     `subject` arg to `processEnvelope` (see `FED_SUBJECT`).
+ *   - `originator.identity = {requester-principal}/{requester-stack}` carries
+ *     the REQUESTER (who the verdict routes back to), `attribution: "federated"`.
+ *
+ * `createReviewRequestEvent` doesn't stamp an originator, so we set it here —
+ * mirrors how the requester stack (pilot#149) populates it on the wire.
+ */
+/** Sentinel for "stamp no originator block at all" (distinct from the default). */
+const NO_ORIGINATOR = Symbol("no-originator");
+
+function makeFederatedRequest(
+  identity: string | typeof NO_ORIGINATOR = REQUESTER_IDENTITY,
+  flavor: ReviewFlavor = "typescript",
+): Envelope {
+  const env = createReviewRequestEvent({
+    source: SOURCE,
+    flavor,
+    classification: "federated",
+    payload: PAYLOAD,
+  });
+  if (identity !== NO_ORIGINATOR) {
+    (env as { originator?: unknown }).originator = {
+      identity,
+      attribution: "federated",
+    };
+  }
+  return env;
 }
 
 /**
@@ -1377,65 +1449,88 @@ describe("ReviewConsumer — response_routing echo (cortex#502)", () => {
 // cortex#686 (ADR 0001) — FEDERATED review consumer
 // ---------------------------------------------------------------------------
 
-describe("parseFederatedRequester — ADR 0001 grammar (cortex#686)", () => {
-  test("stack-aware subject → {principal, stack} from segment[1]/[2]", () => {
+describe("parseRequesterFromOriginator — ADR 0002 §1 (cortex#686)", () => {
+  test("slash form `{principal}/{stack}` → {principal, stack}", () => {
     expect(
-      parseFederatedRequester(
-        "federated.jc.sage-host.tasks.code-review.typescript",
-      ),
+      parseRequesterFromOriginator(makeFederatedRequest("jc/sage-host")),
     ).toEqual({ principal: "jc", stack: "sage-host" });
   });
 
-  test("stack-less 5-segment subject → {principal} only", () => {
+  test("strips a `did:mf:` prefix before the slash split", () => {
     expect(
-      parseFederatedRequester("federated.jc.tasks.code-review.typescript"),
-    ).toEqual({ principal: "jc" });
+      parseRequesterFromOriginator(makeFederatedRequest("did:mf:jc/sage-host")),
+    ).toEqual({ principal: "jc", stack: "sage-host" });
   });
 
-  test("non-federated subject → undefined (falls through to local publish)", () => {
-    expect(
-      parseFederatedRequester("local.andreas.meta-factory.tasks.code-review.ts"),
-    ).toBeUndefined();
+  test("no originator block → undefined (fails closed)", () => {
+    // NO_ORIGINATOR leaves the originator unset.
+    expect(parseRequesterFromOriginator(makeFederatedRequest(NO_ORIGINATOR))).toBeUndefined();
   });
 
-  test("bare `federated.` → undefined", () => {
-    expect(parseFederatedRequester("federated.")).toBeUndefined();
+  test("originator identity with no slash → undefined (ambiguous principal/stack)", () => {
+    // A bare `did:mf:jc-sage-host`-style id can't split unambiguously — the very
+    // failure mode that forced the slash form. Fail closed.
+    expect(parseRequesterFromOriginator(makeFederatedRequest("jc-sage-host"))).toBeUndefined();
   });
 
-  test("federated subject with no tasks segment → undefined (not dispatch traffic)", () => {
-    expect(parseFederatedRequester("federated.jc.sage-host")).toBeUndefined();
+  test("leading slash → undefined", () => {
+    expect(parseRequesterFromOriginator(makeFederatedRequest("/sage-host"))).toBeUndefined();
   });
 
-  test("does NOT treat a network id as a segment — principal is segment[1]", () => {
-    // The network is NEVER on the wire (ADR 0001). segment[1] is the requester
-    // principal, not a network id.
-    const r = parseFederatedRequester(
-      "federated.jc.sage-host.tasks.code-review.bun",
-    );
-    expect(r?.principal).toBe("jc");
-    expect(r?.stack).toBe("sage-host");
+  test("trailing slash → undefined", () => {
+    expect(parseRequesterFromOriginator(makeFederatedRequest("jc/"))).toBeUndefined();
+  });
+
+  test("multi-slash body → undefined (stack is a single segment)", () => {
+    expect(parseRequesterFromOriginator(makeFederatedRequest("jc/sage/host"))).toBeUndefined();
+  });
+
+  test("does NOT read the requester off the subject or source — both address the TARGET", () => {
+    // The subject is irrelevant to this function; the requester is the originator.
+    const env = makeFederatedRequest("jc/sage-host");
+    // `source` addresses the target (us = metafactory), per ADR 0001/0002.
+    expect(env.source.startsWith("metafactory")).toBe(true);
+    expect(parseRequesterFromOriginator(env)).toEqual({
+      principal: "jc",
+      stack: "sage-host",
+    });
   });
 });
 
-describe("ReviewConsumer — federated mode (cortex#686)", () => {
-  /** Inbound federated review-request subject keyed to the REQUESTER `jc/sage-host`. */
-  const FED_SUBJECT = "federated.jc.sage-host.tasks.code-review.typescript";
+describe("ReviewConsumer — federated mode (cortex#686, ADR 0002)", () => {
+  // Inbound subject addresses the TARGET (us = metafactory/meta-factory), the
+  // way cortex.ts builds the federated subscription. The REQUESTER lives in
+  // `originator.identity`, NOT here.
+  const FED_SUBJECT =
+    "federated.metafactory.meta-factory.tasks.code-review.typescript";
 
-  test("verdict path → ALL envelopes routed via publishOnSubject on federated.{requester}.{stack}.{type}", async () => {
+  /** Shared federated opts: federated mode + the `jc`-peer network. */
+  function federatedOpts(
+    overrides: Partial<ReviewConsumerOpts> = {},
+  ): Partial<ReviewConsumerOpts> {
+    return {
+      federated: true,
+      federatedNetworks: [makeNetwork()],
+      ...overrides,
+    };
+  }
+
+  test("verdict path → ALL envelopes routed via publishOnSubject on federated.{requester}.{stack}.{type} (requester from originator)", async () => {
     const runtime = createRecordingRuntime();
-    const request = makeRequest("typescript");
+    const request = makeFederatedRequest();
     const verdict = buildVerdictEnvelope(request, "approved");
 
     const consumer = new ReviewConsumer(
-      baseOpts({
-        runtime,
-        federated: true,
-        pipelineRunner: fixedPipeline((opts) => {
-          // cortex#686 — the pipeline is told to stamp federated sovereignty.
-          expect(opts.classification).toBe("federated");
-          return { kind: "verdict", envelope: verdict };
+      baseOpts(
+        federatedOpts({
+          runtime,
+          pipelineRunner: fixedPipeline((opts) => {
+            // cortex#686 — the pipeline is told to stamp federated sovereignty.
+            expect(opts.classification).toBe("federated");
+            return { kind: "verdict", envelope: verdict };
+          }),
         }),
-      }),
+      ),
     );
 
     const decision = await consumer.processEnvelope(request, FED_SUBJECT, null);
@@ -1450,8 +1545,9 @@ describe("ReviewConsumer — federated mode (cortex#686)", () => {
       "review.verdict.approved",
       "dispatch.task.completed",
     ]);
-    // Every emitted subject targets the REQUESTER's identity (jc/sage-host),
-    // NOT the consumer's own principal/stack and NOT a network id.
+    // Every emitted subject targets the REQUESTER's identity (jc/sage-host
+    // from `originator.identity`), NOT the consumer's own principal/stack
+    // (metafactory/meta-factory) and NOT a network id.
     for (const s of subjects) {
       expect(s.startsWith("federated.jc.sage-host.")).toBe(true);
     }
@@ -1461,14 +1557,15 @@ describe("ReviewConsumer — federated mode (cortex#686)", () => {
 
   test("correlation_id preserved across the federated verdict + lifecycle envelopes", async () => {
     const runtime = createRecordingRuntime();
-    const request = makeRequest("typescript");
+    const request = makeFederatedRequest();
     const verdict = buildVerdictEnvelope(request, "approved");
     const consumer = new ReviewConsumer(
-      baseOpts({
-        runtime,
-        federated: true,
-        pipelineRunner: fixedPipeline(() => ({ kind: "verdict", envelope: verdict })),
-      }),
+      baseOpts(
+        federatedOpts({
+          runtime,
+          pipelineRunner: fixedPipeline(() => ({ kind: "verdict", envelope: verdict })),
+        }),
+      ),
     );
     await consumer.processEnvelope(request, FED_SUBJECT, null);
     for (const { envelope } of runtime.publishedOnSubject) {
@@ -1476,24 +1573,21 @@ describe("ReviewConsumer — federated mode (cortex#686)", () => {
     }
   });
 
-  test("pre-pipeline failure (bad payload) → failed envelope routed on federated subject", async () => {
+  test("pre-pipeline failure (bad payload) → failed envelope routed on requester subject", async () => {
     const runtime = createRecordingRuntime();
-    // A review-typed envelope with an unparseable payload.
-    const bad = createReviewRequestEvent({
-      source: SOURCE,
-      flavor: "typescript",
-      payload: PAYLOAD,
-    });
+    // A review-typed federated envelope (good originator) with bad payload.
+    const bad = makeFederatedRequest();
     (bad as { payload: Record<string, unknown> }).payload = { nonsense: true };
 
     const consumer = new ReviewConsumer(
-      baseOpts({
-        runtime,
-        federated: true,
-        pipelineRunner: fixedPipeline(() => {
-          throw new Error("pipeline must not run on a bad payload");
+      baseOpts(
+        federatedOpts({
+          runtime,
+          pipelineRunner: fixedPipeline(() => {
+            throw new Error("pipeline must not run on a bad payload");
+          }),
         }),
-      }),
+      ),
     );
 
     const decision = await consumer.processEnvelope(bad, FED_SUBJECT, null);
@@ -1507,32 +1601,124 @@ describe("ReviewConsumer — federated mode (cortex#686)", () => {
 
   test("federated emitted envelopes declare federated sovereignty", async () => {
     const runtime = createRecordingRuntime();
-    const request = makeRequest("typescript");
+    const request = makeFederatedRequest();
     const verdict = buildVerdictEnvelope(request, "commented");
     const consumer = new ReviewConsumer(
-      baseOpts({
-        runtime,
-        federated: true,
-        pipelineRunner: fixedPipeline((opts) => ({
-          kind: "verdict",
-          // Echo the pipeline's classification onto the verdict so the test
-          // sees federated sovereignty end-to-end.
-          envelope: createReviewVerdictEvent({
-            source: SOURCE,
-            kind: "commented",
-            correlationId: request.id,
-            ...(opts.classification !== undefined && {
-              classification: opts.classification,
+      baseOpts(
+        federatedOpts({
+          runtime,
+          pipelineRunner: fixedPipeline((opts) => ({
+            kind: "verdict",
+            // Echo the pipeline's classification onto the verdict so the test
+            // sees federated sovereignty end-to-end.
+            envelope: createReviewVerdictEvent({
+              source: SOURCE,
+              kind: "commented",
+              correlationId: request.id,
+              ...(opts.classification !== undefined && {
+                classification: opts.classification,
+              }),
+              payload: (verdict.payload as never),
             }),
-            payload: (verdict.payload as never),
-          }),
-        })),
-      }),
+          })),
+        }),
+      ),
     );
     await consumer.processEnvelope(request, FED_SUBJECT, null);
     for (const { envelope } of runtime.publishedOnSubject) {
       expect(envelope.sovereignty.classification).toBe("federated");
     }
+  });
+
+  // ---- ADR 0002 §5 — peers[] membership gate (defense-in-depth) ----------
+
+  test("requester NOT in any configured network's peers[] → DENIED + DROPPED (no spawn, no publish)", async () => {
+    const runtime = createRecordingRuntime();
+    // Originator names a principal `mallory` that is in no network's peers[].
+    const request = makeFederatedRequest("mallory/host");
+
+    let pipelineRan = false;
+    const consumer = new ReviewConsumer(
+      baseOpts(
+        federatedOpts({
+          runtime,
+          pipelineRunner: fixedPipeline(() => {
+            pipelineRan = true;
+            throw new Error("reviewer must NOT be spawned for a non-peer requester");
+          }),
+        }),
+      ),
+    );
+
+    const decision = await consumer.processEnvelope(request, FED_SUBJECT, null);
+    expect(decision.kind).toBe("term");
+    expect(pipelineRan).toBe(false);
+    // NOTHING published on either path — the verdict (which carries reviewed-code
+    // findings) never reaches an untrusted principal.
+    expect(runtime.published).toHaveLength(0);
+    expect(runtime.publishedOnSubject).toHaveLength(0);
+  });
+
+  test("federated request with NO resolvable requester (absent originator) → DENIED + DROPPED", async () => {
+    const runtime = createRecordingRuntime();
+    const request = makeFederatedRequest(NO_ORIGINATOR); // no originator block
+
+    let pipelineRan = false;
+    const consumer = new ReviewConsumer(
+      baseOpts(
+        federatedOpts({
+          runtime,
+          pipelineRunner: fixedPipeline(() => {
+            pipelineRan = true;
+            throw new Error("reviewer must NOT be spawned for an un-attributable request");
+          }),
+        }),
+      ),
+    );
+
+    const decision = await consumer.processEnvelope(request, FED_SUBJECT, null);
+    expect(decision.kind).toBe("term");
+    expect(pipelineRan).toBe(false);
+    expect(runtime.published).toHaveLength(0);
+    expect(runtime.publishedOnSubject).toHaveLength(0);
+  });
+
+  test("self-loop (requester principal == receiving principal) → DENIED + DROPPED", async () => {
+    const runtime = createRecordingRuntime();
+    // SOURCE.principal is `metafactory`; an originator naming us as the
+    // requester is a self-loop — drop it.
+    const request = makeFederatedRequest("metafactory/meta-factory");
+
+    let pipelineRan = false;
+    const consumer = new ReviewConsumer(
+      baseOpts(
+        federatedOpts({
+          runtime,
+          // Add metafactory to peers so the only reason to deny is the self-loop.
+          federatedNetworks: [
+            makeNetwork({
+              peers: [
+                {
+                  principal_id: "metafactory",
+                  stack_id: "metafactory/meta-factory",
+                  principal_pubkey: FED_PEER_PUBKEY,
+                },
+              ],
+            }),
+          ],
+          pipelineRunner: fixedPipeline(() => {
+            pipelineRan = true;
+            throw new Error("reviewer must NOT be spawned for a self-loop");
+          }),
+        }),
+      ),
+    );
+
+    const decision = await consumer.processEnvelope(request, FED_SUBJECT, null);
+    expect(decision.kind).toBe("term");
+    expect(pipelineRan).toBe(false);
+    expect(runtime.published).toHaveLength(0);
+    expect(runtime.publishedOnSubject).toHaveLength(0);
   });
 
   test("local mode (federated: false) is byte-for-byte unchanged — uses runtime.publish", async () => {

--- a/src/bus/__tests__/review-consumer.test.ts
+++ b/src/bus/__tests__/review-consumer.test.ts
@@ -159,10 +159,15 @@ function makeRequest(flavor: ReviewFlavor = "typescript"): Envelope {
 /** 56-char U-prefixed base32 NKey — matches the surface-router test fixture. */
 const FED_PEER_PUBKEY = "U" + "A".repeat(55);
 
-/** The REQUESTER identity carried in `originator.identity` (ADR 0002 §1). */
+/**
+ * The REQUESTER identity carried in `originator.identity` (ADR 0002 §1) — the
+ * `did:mf:{principal}-{stack}` DID form (= `stack.id` with `/`→`-`), the exact
+ * shape pilot's `encodeRequesterDid` emits. NOT a bare `{principal}/{stack}`
+ * slash form (myelin's DID grammar rejects `/`).
+ */
 const REQUESTER_PRINCIPAL = "jc";
 const REQUESTER_STACK = "sage-host";
-const REQUESTER_IDENTITY = `${REQUESTER_PRINCIPAL}/${REQUESTER_STACK}`;
+const REQUESTER_IDENTITY = `did:mf:${REQUESTER_PRINCIPAL}-${REQUESTER_STACK}`;
 
 /**
  * A configured federation network whose `peers[]` lists the requester `jc` as a
@@ -195,8 +200,9 @@ function makeNetwork(
  *   - the subject (built by `cortex.ts`) addresses the TARGET = us
  *     (`federated.{our-principal}.{our-stack}.…`); tests pass it as the
  *     `subject` arg to `processEnvelope` (see `FED_SUBJECT`).
- *   - `originator.identity = {requester-principal}/{requester-stack}` carries
- *     the REQUESTER (who the verdict routes back to), `attribution: "federated"`.
+ *   - `originator.identity = did:mf:{requester-principal}-{requester-stack}`
+ *     (the DID form = `stack.id` with `/`→`-`) carries the REQUESTER (who the
+ *     verdict routes back to), `attribution: "federated"`.
  *
  * `createReviewRequestEvent` doesn't stamp an originator, so we set it here —
  * mirrors how the requester stack (pilot#149) populates it on the wire.
@@ -1450,16 +1456,32 @@ describe("ReviewConsumer — response_routing echo (cortex#502)", () => {
 // ---------------------------------------------------------------------------
 
 describe("parseRequesterFromOriginator — ADR 0002 §1 (cortex#686)", () => {
-  test("slash form `{principal}/{stack}` → {principal, stack}", () => {
+  test("DID form `did:mf:{principal}-{stack}` → {principal, stack} (first-hyphen split)", () => {
     expect(
-      parseRequesterFromOriginator(makeFederatedRequest("jc/sage-host")),
+      parseRequesterFromOriginator(makeFederatedRequest("did:mf:jc-sage-host")),
     ).toEqual({ principal: "jc", stack: "sage-host" });
   });
 
-  test("strips a `did:mf:` prefix before the slash split", () => {
+  test("first-hyphen split keeps a multi-hyphen stack intact (did:mf:andreas-meta-factory)", () => {
+    // The worked example from ADR 0002 §1: the principal is hyphen-free, so the
+    // FIRST hyphen is the boundary and every later hyphen belongs to the stack.
     expect(
-      parseRequesterFromOriginator(makeFederatedRequest("did:mf:jc/sage-host")),
-    ).toEqual({ principal: "jc", stack: "sage-host" });
+      parseRequesterFromOriginator(
+        makeFederatedRequest("did:mf:andreas-meta-factory"),
+      ),
+    ).toEqual({ principal: "andreas", stack: "meta-factory" });
+  });
+
+  test("exact inverse of pilot's encodeRequesterDid (= stack.id with /→-)", () => {
+    // pilot#149 `encodeRequesterDid(principal, stack)` = `did:mf:${principal}-${stack}`.
+    // Round-trip: encode then decode MUST recover the original pair.
+    const encode = (principal: string, stack: string) =>
+      `did:mf:${principal}-${stack}`;
+    expect(
+      parseRequesterFromOriginator(
+        makeFederatedRequest(encode("andreas", "meta-factory")),
+      ),
+    ).toEqual({ principal: "andreas", stack: "meta-factory" });
   });
 
   test("no originator block → undefined (fails closed)", () => {
@@ -1467,27 +1489,27 @@ describe("parseRequesterFromOriginator — ADR 0002 §1 (cortex#686)", () => {
     expect(parseRequesterFromOriginator(makeFederatedRequest(NO_ORIGINATOR))).toBeUndefined();
   });
 
-  test("originator identity with no slash → undefined (ambiguous principal/stack)", () => {
-    // A bare `did:mf:jc-sage-host`-style id can't split unambiguously — the very
-    // failure mode that forced the slash form. Fail closed.
-    expect(parseRequesterFromOriginator(makeFederatedRequest("jc-sage-host"))).toBeUndefined();
+  test("no `did:mf:` prefix → undefined (only the DID form is on the wire)", () => {
+    // A bare slash form `jc/sage-host` lacks the DID prefix — fail closed.
+    expect(parseRequesterFromOriginator(makeFederatedRequest("jc/sage-host"))).toBeUndefined();
   });
 
-  test("leading slash → undefined", () => {
-    expect(parseRequesterFromOriginator(makeFederatedRequest("/sage-host"))).toBeUndefined();
+  test("DID body with no hyphen → undefined (ambiguous principal/stack)", () => {
+    // `did:mf:sagehost` can't split principal from stack — fail closed.
+    expect(parseRequesterFromOriginator(makeFederatedRequest("did:mf:sagehost"))).toBeUndefined();
   });
 
-  test("trailing slash → undefined", () => {
-    expect(parseRequesterFromOriginator(makeFederatedRequest("jc/"))).toBeUndefined();
+  test("leading hyphen → undefined", () => {
+    expect(parseRequesterFromOriginator(makeFederatedRequest("did:mf:-sage-host"))).toBeUndefined();
   });
 
-  test("multi-slash body → undefined (stack is a single segment)", () => {
-    expect(parseRequesterFromOriginator(makeFederatedRequest("jc/sage/host"))).toBeUndefined();
+  test("trailing hyphen → undefined", () => {
+    expect(parseRequesterFromOriginator(makeFederatedRequest("did:mf:jc-"))).toBeUndefined();
   });
 
   test("does NOT read the requester off the subject or source — both address the TARGET", () => {
     // The subject is irrelevant to this function; the requester is the originator.
-    const env = makeFederatedRequest("jc/sage-host");
+    const env = makeFederatedRequest("did:mf:jc-sage-host");
     // `source` addresses the target (us = metafactory), per ADR 0001/0002.
     expect(env.source.startsWith("metafactory")).toBe(true);
     expect(parseRequesterFromOriginator(env)).toEqual({
@@ -1545,9 +1567,9 @@ describe("ReviewConsumer — federated mode (cortex#686, ADR 0002)", () => {
       "review.verdict.approved",
       "dispatch.task.completed",
     ]);
-    // Every emitted subject targets the REQUESTER's identity (jc/sage-host
-    // from `originator.identity`), NOT the consumer's own principal/stack
-    // (metafactory/meta-factory) and NOT a network id.
+    // Every emitted subject targets the REQUESTER's identity (jc.sage-host,
+    // decoded from the `did:mf:jc-sage-host` `originator.identity` DID), NOT the
+    // consumer's own principal/stack (metafactory/meta-factory) and NOT a network id.
     for (const s of subjects) {
       expect(s.startsWith("federated.jc.sage-host.")).toBe(true);
     }
@@ -1635,7 +1657,8 @@ describe("ReviewConsumer — federated mode (cortex#686, ADR 0002)", () => {
   test("requester NOT in any configured network's peers[] → DENIED + DROPPED (no spawn, no publish)", async () => {
     const runtime = createRecordingRuntime();
     // Originator names a principal `mallory` that is in no network's peers[].
-    const request = makeFederatedRequest("mallory/host");
+    // Well-formed DID (decodes cleanly) so the ONLY reason to deny is non-membership.
+    const request = makeFederatedRequest("did:mf:mallory-host");
 
     let pipelineRan = false;
     const consumer = new ReviewConsumer(
@@ -1686,8 +1709,9 @@ describe("ReviewConsumer — federated mode (cortex#686, ADR 0002)", () => {
   test("self-loop (requester principal == receiving principal) → DENIED + DROPPED", async () => {
     const runtime = createRecordingRuntime();
     // SOURCE.principal is `metafactory`; an originator naming us as the
-    // requester is a self-loop — drop it.
-    const request = makeFederatedRequest("metafactory/meta-factory");
+    // requester is a self-loop — drop it. Well-formed DID so the ONLY reason
+    // to deny is the self-loop, not a decode failure.
+    const request = makeFederatedRequest("did:mf:metafactory-meta-factory");
 
     let pipelineRan = false;
     const consumer = new ReviewConsumer(

--- a/src/bus/__tests__/review-consumer.test.ts
+++ b/src/bus/__tests__/review-consumer.test.ts
@@ -42,6 +42,7 @@ import {
   OFFER_DISPATCH_REVIEWER,
   failedReasonToAckDecision,
   parseReviewRequestPayload,
+  parseFederatedRequester,
   readLogicalResponseRouting,
   type ReviewConsumerAgent,
   type ReviewConsumerOpts,
@@ -93,17 +94,21 @@ const PAYLOAD: ReviewRequestPayload = {
 interface RecordingRuntime extends MyelinRuntime {
   published: Envelope[];
   publishOutcomes: { ok: boolean; error?: Error }[];
+  /** cortex#686 — every `publishOnSubject(envelope, subject)` call, in order. */
+  publishedOnSubject: { envelope: Envelope; subject: string }[];
 }
 
 function createRecordingRuntime(): RecordingRuntime {
   const published: Envelope[] = [];
   const publishOutcomes: { ok: boolean; error?: Error }[] = [];
+  const publishedOnSubject: { envelope: Envelope; subject: string }[] = [];
   let publishCallIndex = 0;
   const onEnvelopeHandlers = new Set<EnvelopeHandler>();
   return {
     enabled: false,
     published,
     publishOutcomes,
+    publishedOnSubject,
     onEnvelope(handler) {
       onEnvelopeHandlers.add(handler);
       return {
@@ -119,6 +124,10 @@ function createRecordingRuntime(): RecordingRuntime {
         throw outcome.error ?? new Error("publish failed");
       }
       published.push(envelope);
+    },
+    // cortex#686 — federated review consumer routes verdicts via this path.
+    publishOnSubject: async (envelope: Envelope, subject: string) => {
+      publishedOnSubject.push({ envelope, subject });
     },
     stop: async () => {},
   };
@@ -1361,5 +1370,196 @@ describe("ReviewConsumer — response_routing echo (cortex#502)", () => {
       // ...but no response_routing key anywhere.
       expect("response_routing" in (env.payload as object)).toBe(false);
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cortex#686 (ADR 0001) — FEDERATED review consumer
+// ---------------------------------------------------------------------------
+
+describe("parseFederatedRequester — ADR 0001 grammar (cortex#686)", () => {
+  test("stack-aware subject → {principal, stack} from segment[1]/[2]", () => {
+    expect(
+      parseFederatedRequester(
+        "federated.jc.sage-host.tasks.code-review.typescript",
+      ),
+    ).toEqual({ principal: "jc", stack: "sage-host" });
+  });
+
+  test("stack-less 5-segment subject → {principal} only", () => {
+    expect(
+      parseFederatedRequester("federated.jc.tasks.code-review.typescript"),
+    ).toEqual({ principal: "jc" });
+  });
+
+  test("non-federated subject → undefined (falls through to local publish)", () => {
+    expect(
+      parseFederatedRequester("local.andreas.meta-factory.tasks.code-review.ts"),
+    ).toBeUndefined();
+  });
+
+  test("bare `federated.` → undefined", () => {
+    expect(parseFederatedRequester("federated.")).toBeUndefined();
+  });
+
+  test("federated subject with no tasks segment → undefined (not dispatch traffic)", () => {
+    expect(parseFederatedRequester("federated.jc.sage-host")).toBeUndefined();
+  });
+
+  test("does NOT treat a network id as a segment — principal is segment[1]", () => {
+    // The network is NEVER on the wire (ADR 0001). segment[1] is the requester
+    // principal, not a network id.
+    const r = parseFederatedRequester(
+      "federated.jc.sage-host.tasks.code-review.bun",
+    );
+    expect(r?.principal).toBe("jc");
+    expect(r?.stack).toBe("sage-host");
+  });
+});
+
+describe("ReviewConsumer — federated mode (cortex#686)", () => {
+  /** Inbound federated review-request subject keyed to the REQUESTER `jc/sage-host`. */
+  const FED_SUBJECT = "federated.jc.sage-host.tasks.code-review.typescript";
+
+  test("verdict path → ALL envelopes routed via publishOnSubject on federated.{requester}.{stack}.{type}", async () => {
+    const runtime = createRecordingRuntime();
+    const request = makeRequest("typescript");
+    const verdict = buildVerdictEnvelope(request, "approved");
+
+    const consumer = new ReviewConsumer(
+      baseOpts({
+        runtime,
+        federated: true,
+        pipelineRunner: fixedPipeline((opts) => {
+          // cortex#686 — the pipeline is told to stamp federated sovereignty.
+          expect(opts.classification).toBe("federated");
+          return { kind: "verdict", envelope: verdict };
+        }),
+      }),
+    );
+
+    const decision = await consumer.processEnvelope(request, FED_SUBJECT, null);
+    expect(decision).toEqual({ kind: "ack" });
+
+    // NOTHING on the local `publish` path; everything on `publishOnSubject`.
+    expect(runtime.published).toHaveLength(0);
+    const subjects = runtime.publishedOnSubject.map((p) => p.subject);
+    const types = runtime.publishedOnSubject.map((p) => p.envelope.type);
+    expect(types).toEqual([
+      "dispatch.task.started",
+      "review.verdict.approved",
+      "dispatch.task.completed",
+    ]);
+    // Every emitted subject targets the REQUESTER's identity (jc/sage-host),
+    // NOT the consumer's own principal/stack and NOT a network id.
+    for (const s of subjects) {
+      expect(s.startsWith("federated.jc.sage-host.")).toBe(true);
+    }
+    expect(subjects[1]).toBe("federated.jc.sage-host.review.verdict.approved");
+    expect(subjects[2]).toBe("federated.jc.sage-host.dispatch.task.completed");
+  });
+
+  test("correlation_id preserved across the federated verdict + lifecycle envelopes", async () => {
+    const runtime = createRecordingRuntime();
+    const request = makeRequest("typescript");
+    const verdict = buildVerdictEnvelope(request, "approved");
+    const consumer = new ReviewConsumer(
+      baseOpts({
+        runtime,
+        federated: true,
+        pipelineRunner: fixedPipeline(() => ({ kind: "verdict", envelope: verdict })),
+      }),
+    );
+    await consumer.processEnvelope(request, FED_SUBJECT, null);
+    for (const { envelope } of runtime.publishedOnSubject) {
+      expect(envelope.correlation_id).toBe(request.id);
+    }
+  });
+
+  test("pre-pipeline failure (bad payload) → failed envelope routed on federated subject", async () => {
+    const runtime = createRecordingRuntime();
+    // A review-typed envelope with an unparseable payload.
+    const bad = createReviewRequestEvent({
+      source: SOURCE,
+      flavor: "typescript",
+      payload: PAYLOAD,
+    });
+    (bad as { payload: Record<string, unknown> }).payload = { nonsense: true };
+
+    const consumer = new ReviewConsumer(
+      baseOpts({
+        runtime,
+        federated: true,
+        pipelineRunner: fixedPipeline(() => {
+          throw new Error("pipeline must not run on a bad payload");
+        }),
+      }),
+    );
+
+    const decision = await consumer.processEnvelope(bad, FED_SUBJECT, null);
+    expect(decision.kind).toBe("term");
+    expect(runtime.published).toHaveLength(0);
+    expect(runtime.publishedOnSubject).toHaveLength(1);
+    const failed = runtime.publishedOnSubject[0]!;
+    expect(failed.envelope.type).toBe("dispatch.task.failed");
+    expect(failed.subject).toBe("federated.jc.sage-host.dispatch.task.failed");
+  });
+
+  test("federated emitted envelopes declare federated sovereignty", async () => {
+    const runtime = createRecordingRuntime();
+    const request = makeRequest("typescript");
+    const verdict = buildVerdictEnvelope(request, "commented");
+    const consumer = new ReviewConsumer(
+      baseOpts({
+        runtime,
+        federated: true,
+        pipelineRunner: fixedPipeline((opts) => ({
+          kind: "verdict",
+          // Echo the pipeline's classification onto the verdict so the test
+          // sees federated sovereignty end-to-end.
+          envelope: createReviewVerdictEvent({
+            source: SOURCE,
+            kind: "commented",
+            correlationId: request.id,
+            ...(opts.classification !== undefined && {
+              classification: opts.classification,
+            }),
+            payload: (verdict.payload as never),
+          }),
+        })),
+      }),
+    );
+    await consumer.processEnvelope(request, FED_SUBJECT, null);
+    for (const { envelope } of runtime.publishedOnSubject) {
+      expect(envelope.sovereignty.classification).toBe("federated");
+    }
+  });
+
+  test("local mode (federated: false) is byte-for-byte unchanged — uses runtime.publish", async () => {
+    const runtime = createRecordingRuntime();
+    const request = makeRequest("typescript");
+    const verdict = buildVerdictEnvelope(request, "approved");
+    const consumer = new ReviewConsumer(
+      baseOpts({
+        runtime,
+        // federated NOT set → local path.
+        pipelineRunner: fixedPipeline((opts) => {
+          expect(opts.classification).toBeUndefined();
+          return { kind: "verdict", envelope: verdict };
+        }),
+      }),
+    );
+    await consumer.processEnvelope(
+      request,
+      "local.metafactory.meta-factory.tasks.code-review.typescript",
+      null,
+    );
+    // Local path: everything on `publish`, nothing on `publishOnSubject`.
+    expect(runtime.publishedOnSubject).toHaveLength(0);
+    expect(runtime.published.map((e) => e.type)).toEqual([
+      "dispatch.task.started",
+      "review.verdict.approved",
+      "dispatch.task.completed",
+    ]);
   });
 });

--- a/src/bus/__tests__/surface-router.test.ts
+++ b/src/bus/__tests__/surface-router.test.ts
@@ -1432,11 +1432,24 @@ function makeSignedByChain(principals: string[]): SignedBy[] {
   }));
 }
 
+// cortex#686 (ADR 0001) — the source network is now resolved from the SOURCE
+// PRINCIPAL's `peers[]` membership, not a subject segment. `makeFederatedEnvelope`
+// signs from source `metafactory.pilot.local` (principal `metafactory`), so the
+// default network lists `metafactory` as a configured peer — the resolution that
+// the gate now keys on.
+const FED_PEER_PUBKEY = "U" + "A".repeat(55); // 56-char U-prefixed base32 NKey.
+
 function makeNetwork(overrides: Partial<PolicyFederatedNetwork> = {}): PolicyFederatedNetwork {
   return {
     id: "research-collab",
     leaf_node: "leaf-research",
-    peers: [],
+    peers: [
+      {
+        principal_id: "metafactory",
+        stack_id: "metafactory/meta-factory",
+        principal_pubkey: FED_PEER_PUBKEY,
+      },
+    ],
     accept_subjects: ["federated.research-collab.tasks.code-review.>"],
     deny_subjects: [],
     announce_capabilities: [],
@@ -1521,34 +1534,49 @@ describe("evaluateFederationGate — deny-list precedence", () => {
   });
 });
 
-describe("evaluateFederationGate — unknown network", () => {
-  test("no network entry → peer_not_in_accept_list with unknown_network: true", () => {
+describe("evaluateFederationGate — ADR 0001 source-principal resolution (cortex#686)", () => {
+  test("source principal in a configured network's peers[] → resolves + allows on accept-list match", () => {
+    // Source `metafactory` is a peer of `research-collab`; the subject targets
+    // this stack (`andreas/meta-factory`) and matches the accept-list pattern.
     const decision = evaluateFederationGate(
-      "federated.unknown-net.tasks.x",
+      "federated.andreas.meta-factory.tasks.code-review.typescript",
       makeFederatedEnvelope(),
+      networksMap([
+        makeNetwork({
+          accept_subjects: ["federated.andreas.meta-factory.tasks.code-review.>"],
+        }),
+      ]),
+    );
+    expect(decision).toBe("allow");
+  });
+
+  test("source principal in NO configured network's peers[] → peer_not_in_accept_list (unknown_network, sentinel=source principal)", () => {
+    const decision = evaluateFederationGate(
+      "federated.andreas.meta-factory.tasks.code-review.ts",
+      makeFederatedEnvelope({ source: "stranger.pilot.local" }),
       networksMap([makeNetwork()]),
     );
     expect(decision).toEqual({
       kind: "peer_not_in_accept_list",
-      networkId: "unknown-net",
+      networkId: "stranger", // the unresolved SOURCE PRINCIPAL, not a subject segment.
       unknown_network: true,
     });
   });
 
-  test("empty networks map → unknown_network for every federated subject", () => {
+  test("empty networks map → unknown_network for every federated subject (source resolves to nothing)", () => {
     const decision = evaluateFederationGate(
-      "federated.research-collab.tasks.code-review.ts",
+      "federated.andreas.meta-factory.tasks.code-review.ts",
       makeFederatedEnvelope(),
       new Map(),
     );
     expect(decision).toEqual({
       kind: "peer_not_in_accept_list",
-      networkId: "research-collab",
+      networkId: "metafactory", // the unresolved source principal.
       unknown_network: true,
     });
   });
 
-  test("malformed subject (no network id segment) → unknown_network with <malformed> sentinel", () => {
+  test("malformed subject (no target/stack segment) → unknown_network with <malformed> sentinel", () => {
     const decision = evaluateFederationGate(
       "federated.",
       makeFederatedEnvelope(),
@@ -1815,7 +1843,7 @@ describe("createSurfaceRouter — D.2 federation gating end-to-end", () => {
     expect(published).toHaveLength(0);
   });
 
-  test("unknown network id in subject → denied with unknown_network: true", async () => {
+  test("source principal not a configured peer → denied with unknown_network: true (ADR 0001)", async () => {
     const { runtime, published } = fakeRuntimeWithPublishLog();
     const router = createSurfaceRouter(runtime, {
       systemEventSource: TEST_SYSTEM_EVENT_SOURCE,
@@ -1827,9 +1855,12 @@ describe("createSurfaceRouter — D.2 federation gating end-to-end", () => {
     });
     router.register(a.adapter);
 
+    // Source `stranger` is in no configured network's peers[] → the gate
+    // can't resolve a source network and denies as unknown_network, carrying
+    // the unresolved SOURCE PRINCIPAL (not a subject segment) as the sentinel.
     await router.dispatch(
-      makeFederatedEnvelope({ type: "tasks.x" }),
-      "federated.some-other-net.tasks.x",
+      makeFederatedEnvelope({ type: "tasks.x", source: "stranger.pilot.local" }),
+      "federated.andreas.meta-factory.tasks.x",
     );
 
     expect(a.calls).toHaveLength(0);
@@ -1837,7 +1868,7 @@ describe("createSurfaceRouter — D.2 federation gating end-to-end", () => {
     expect(published).toHaveLength(1);
     expect(published[0]?.payload).toMatchObject({
       reason: { kind: "peer_not_in_accept_list", unknown_network: true },
-      network_id: "some-other-net",
+      network_id: "stranger",
     });
   });
 

--- a/src/bus/review-consumer.ts
+++ b/src/bus/review-consumer.ts
@@ -238,8 +238,8 @@ export interface ReviewConsumerOpts {
    * {requester-stack}.…` grammar, instead of the consumer's own
    * `local.{my-principal}.{my-stack}.…`.
    *
-   * **The requester is derived from `envelope.originator.identity`** (the
-   * `{requester-principal}/{requester-stack}` slash form per ADR 0002 §1) —
+   * **The requester is decoded from `envelope.originator.identity`** (the
+   * `did:mf:{requester-principal}-{requester-stack}` DID form per ADR 0002 §1) —
    * NOT from the inbound subject (whose `{principal}.{stack}` segments address
    * the TARGET = this receiving stack, per ADR 0001), and NOT from
    * `envelope.source` (which also addresses the target). Reading the requester
@@ -286,20 +286,21 @@ export interface ReviewConsumerOpts {
 
 /**
  * cortex#686 (ADR 0002) — the requester's `{principal}.{stack}` identity,
- * derived from the inbound envelope's `originator.identity` (the
- * `{requester-principal}/{requester-stack}` slash form). The federated
- * consumer keys every verdict + lifecycle envelope it routes back to this
- * identity so the peer's `pilot --wait` (subscribed on
+ * decoded from the inbound envelope's `originator.identity` DID (the
+ * `did:mf:{requester-principal}-{requester-stack}` form = `stack.id` with
+ * `/`→`-`). The federated consumer keys every verdict + lifecycle envelope it
+ * routes back to this identity so the peer's `pilot --wait` (subscribed on
  * `federated.{its-principal}.{its-stack}.review.verdict.>`) resolves.
  *
  * The requester is the policy actor in `originator`, NOT the subject (which
  * addresses the TARGET) — see {@link parseRequesterFromOriginator}.
  */
 export interface FederatedRequester {
-  /** Requester principal — the segment BEFORE the `/` in `originator.identity`. */
+  /** Requester principal — the DID body segment BEFORE the FIRST `-`
+   *  (principals carry no hyphen). */
   principal: string;
-  /** Requester stack — the segment AFTER the `/`; omitted when the originator
-   *  carries only a bare principal (no stack). */
+  /** Requester stack — the DID body segment AFTER the first `-` (may itself
+   *  contain hyphens, e.g. `meta-factory`). */
   stack?: string;
 }
 
@@ -1048,7 +1049,8 @@ export class ReviewConsumer {
    * cortex#686 — when `requester` is supplied (federated mode), the envelope
    * is published on the REQUESTER-keyed `federated.{requester-principal}.
    * {requester-stack}.{type}` subject via {@link MyelinRuntime.publishOnSubject}
-   * (deriving the subject from `envelope.type` + the requester identity). The
+   * (deriving the subject from `envelope.type` + the requester identity decoded
+   * from the `did:mf:{principal}-{stack}` originator DID). The
    * runtime's `selectLink` resolves the requester principal → leaf from the
    * `peers[]` topology so the verdict reaches the peer stack's
    * `pilot --wait`. Absent `requester` → the unchanged local
@@ -1168,9 +1170,9 @@ export function extractFlavor(envelope: Envelope, _subject: string): string | nu
 }
 
 /**
- * cortex#686 (ADR 0002 §1+§3) — derive the REQUESTER's `{principal}.{stack}`
+ * cortex#686 (ADR 0002 §1+§3) — decode the REQUESTER's `{principal}.{stack}`
  * identity from an inbound FEDERATED review-request envelope's
- * `originator.identity`.
+ * `originator.identity` DID.
  *
  * **Why `originator`, not the subject or `source`.** Under ADR 0001 a federated
  * subject is `federated.{TARGET-principal}.{TARGET-stack}.tasks.code-review.…`
@@ -1181,19 +1183,30 @@ export function extractFlavor(envelope: Envelope, _subject: string): string | nu
  * BLOCKER). ADR 0002 §1 carries the requester in `originator.identity` —
  * "who the signer is acting on behalf of" — a signed/signable field.
  *
- * **Format (ADR 0002 §1, §3):** `originator.identity = {requester-principal}/
- * {requester-stack}` — slash-delimited so the principal and stack split
- * unambiguously (a `did:mf:{principal}-{stack}` DID can't: hyphens appear in
- * both). A `did:mf:` prefix, if present, is stripped before the split. The
- * dual-read of the deprecated `originator.principal` key is handled by
- * {@link getActorPrincipal}.
+ * **Format (ADR 0002 §1, §3): `originator.identity = did:mf:{requester-principal}-{requester-stack}`.**
+ * This is the requester stack's canonical signing-DID — exactly `stack.id` with
+ * `/`→`-` (cortex `src/cortex.ts:483`: `did:mf:${stack.id.replace("/","-")}`).
+ * It is NOT a bare `{principal}/{stack}` slash form: myelin validates
+ * `originator.identity` against the `did:mf:<name>` DID grammar, which rejects
+ * `/`. The encoder is pilot's `encodeRequesterDid` (pilot#149,
+ * `src/bus/publish-review-request.ts`): `did:mf:${principal}-${stack}`; this
+ * decoder is its EXACT inverse (lockstep — pilot#149 ↔ cortex#686).
  *
- * Returns `undefined` when there is no `originator` block, the identity is
- * empty, or it carries no `/` to split principal from stack — the federated
- * consumer then DENIES + DROPS the request (an un-attributable cross-principal
- * source is never reviewed; see {@link ReviewConsumer.federatedRequesterDenyReason}),
- * and `safePublish` would in any case fail closed to the local path rather than
- * guess a requester.
+ * **Decode:** require a `did:mf:` prefix, strip it, then split the remainder on
+ * the FIRST `-` into `{principal, stack}`. The first-hyphen split rests on the
+ * **principal-carries-no-hyphen assumption**: a principal segment is a single
+ * `^[a-z][a-z0-9]*$`-style token, while a STACK may itself contain hyphens
+ * (e.g. `meta-factory`). So `did:mf:andreas-meta-factory` decodes to principal
+ * `andreas` / stack `meta-factory` — the first hyphen separates the two; every
+ * later hyphen belongs to the stack. (A principal with a hyphen would be
+ * indistinguishable from a stack boundary; the wire grammar forbids it.)
+ *
+ * Returns `undefined` (→ deny + drop) when there is no `originator` block, the
+ * identity is empty, it lacks the `did:mf:` prefix, or the post-prefix body
+ * carries no `-` to split principal from stack. The federated consumer then
+ * DENIES + DROPS the request (an un-attributable / non-conformant cross-principal
+ * source is never reviewed; see {@link ReviewConsumer.federatedRequesterDenyReason}).
+ * The bare slash form is NOT accepted — only the DID form is on the wire.
  *
  * Exported for the review-consumer tests.
  */
@@ -1210,19 +1223,24 @@ export function parseRequesterFromOriginator(
   const raw = getActorPrincipal(envelope);
   if (raw === undefined || raw.length === 0) return undefined;
 
-  // Strip an optional `did:mf:` method prefix; the {principal}/{stack} body
-  // follows either way (ADR 0002 §1 writes the bare slash form).
-  const body = raw.startsWith("did:mf:") ? raw.slice("did:mf:".length) : raw;
-  const slash = body.indexOf("/");
-  if (slash <= 0 || slash === body.length - 1) {
-    // No slash, leading slash, or trailing slash → can't split an unambiguous
-    // {principal}/{stack}. Fail closed.
+  // Require the `did:mf:` method prefix — the wire carries the DID form, never
+  // a bare slash form (myelin's DID grammar rejects `/`). Fail closed otherwise.
+  const PREFIX = "did:mf:";
+  if (!raw.startsWith(PREFIX)) return undefined;
+  const body = raw.slice(PREFIX.length);
+
+  // Split on the FIRST hyphen: principal (no hyphen) | stack (may contain
+  // hyphens). `did:mf:andreas-meta-factory` → principal `andreas`, stack
+  // `meta-factory`. The exact inverse of pilot's
+  // `encodeRequesterDid` = `did:mf:${principal}-${stack}` (= stack.id `/`→`-`).
+  const hyphen = body.indexOf("-");
+  if (hyphen <= 0 || hyphen === body.length - 1) {
+    // No hyphen, leading hyphen, or trailing hyphen → can't split an
+    // unambiguous {principal}-{stack}. Fail closed.
     return undefined;
   }
-  const principal = body.slice(0, slash);
-  const stack = body.slice(slash + 1);
-  // A multi-slash body (`a/b/c`) is malformed — a stack is a single segment.
-  if (stack.includes("/")) return undefined;
+  const principal = body.slice(0, hyphen);
+  const stack = body.slice(hyphen + 1);
   return { principal, stack };
 }
 

--- a/src/bus/review-consumer.ts
+++ b/src/bus/review-consumer.ts
@@ -65,6 +65,7 @@
  */
 
 import type { ConsumerMessages, JsMsg } from "nats";
+import { deriveSubject } from "@the-metafactory/myelin/subjects";
 import type { MyelinRuntime } from "./myelin/runtime";
 import type { Envelope } from "./myelin/envelope-validator";
 import type { MyelinSubscriber } from "./myelin/subscriber";
@@ -227,10 +228,46 @@ export interface ReviewConsumerOpts {
    */
   signatureVerifier?: SignatureVerifier;
   /**
+   * cortex#686 (ADR 0001) — FEDERATED routing mode. When `true`, the consumer
+   * treats every inbound envelope as a cross-principal (federated) review
+   * request and routes ALL emitted lifecycle + verdict envelopes back to the
+   * REQUESTER's identity on the conformant `federated.{requester-principal}.
+   * {requester-stack}.…` grammar, instead of the consumer's own
+   * `local.{my-principal}.{my-stack}.…`.
+   *
+   * The requester `{principal}.{stack}` is parsed from the inbound subject
+   * (`federated.{requester-principal}.{requester-stack}.tasks.code-review.…`),
+   * NOT from a network id (which is never on the wire — ADR 0001). The
+   * emitted envelopes are stamped `classification: "federated"` and published
+   * via {@link MyelinRuntime.publishOnSubject} on the requester-keyed subject;
+   * the runtime's `selectLink` resolves the requester principal → leaf from
+   * the `peers[]` topology. This is the cortex receiver that closes the
+   * cross-principal review loop so the peer's `pilot --wait` resolves.
+   *
+   * Default `false` → the existing local-consumer behaviour (publish via
+   * `runtime.publish`, deriving `local.{my-principal}.{my-stack}.…`),
+   * byte-for-byte unchanged.
+   */
+  federated?: boolean;
+  /**
    * Test seam — clock. Defaults to `() => new Date()`. Tests inject a
    * fixed clock so emitted `startedAt`/`completedAt` are deterministic.
    */
   clock?: () => Date;
+}
+
+/**
+ * cortex#686 — the requester's `{principal}.{stack}` identity, parsed from an
+ * inbound federated review-request subject. The federated consumer keys every
+ * verdict + lifecycle envelope it routes back to this identity so the peer's
+ * `pilot --wait` (subscribed on `federated.{its-principal}.{its-stack}.…`)
+ * resolves.
+ */
+export interface FederatedRequester {
+  /** Requester principal — subject segment[1] under the ADR-0001 grammar. */
+  principal: string;
+  /** Requester stack — subject segment[2]; omitted for the 5-segment form. */
+  stack?: string;
 }
 
 /**
@@ -314,6 +351,8 @@ export class ReviewConsumer {
   ) => Promise<ReviewPipelineResult>;
   /** Optional inbound signature verifier (cortex#327). Undefined disables the gate. */
   private readonly signatureVerifier: SignatureVerifier | undefined;
+  /** cortex#686 — federated routing mode (verdict back to the requester). */
+  private readonly federated: boolean;
   private readonly clock: () => Date;
 
   /** Promises for in-flight pipelines so `stop()` can drain. */
@@ -339,6 +378,7 @@ export class ReviewConsumer {
     }
     this.pipelineRunner = opts.pipelineRunner ?? runReviewPipeline;
     this.signatureVerifier = opts.signatureVerifier;
+    this.federated = opts.federated ?? false;
     this.clock = opts.clock ?? (() => new Date());
 
     this.flavors = deriveFlavors(opts.agent.capabilities);
@@ -441,6 +481,19 @@ export class ReviewConsumer {
     // envelopes (the verdict still reaches pilot via correlation_id).
     const responseRouting = readLogicalResponseRouting(envelope) ?? undefined;
 
+    // cortex#686 — in federated mode, parse the REQUESTER `{principal}.{stack}`
+    // off the inbound subject ONCE so every emitted envelope routes back to the
+    // requester on the conformant `federated.{requester}.{stack}.…` grammar.
+    // `undefined` in local mode (or when the subject isn't a parseable
+    // federated subject) — `safePublish` then falls through to the local
+    // `runtime.publish` path, byte-for-byte unchanged.
+    const requester = this.federated
+      ? parseFederatedRequester(subject)
+      : undefined;
+    // Stamp federated sovereignty on every emitted envelope so the wire is
+    // self-consistent with the `federated.*` subject it lands on.
+    const classification = requester !== undefined ? "federated" : undefined;
+
     const deliveryCount = redeliveryCountFrom(msg);
     if (deliveryCount > 1) {
       await this.safePublish(
@@ -453,8 +506,10 @@ export class ReviewConsumer {
           abortedAt: this.clock(),
           reason: `redelivery (attempt ${deliveryCount})`,
           ...(responseRouting !== undefined && { responseRouting }),
+          ...(classification !== undefined && { classification }),
         }),
         "dispatch.task.aborted",
+        requester,
       );
       // Note: we continue with pipeline processing. The aborted envelope
       // is advisory; the pipeline's terminal envelope (verdict/failed)
@@ -472,6 +527,7 @@ export class ReviewConsumer {
         },
         `unrecognised review subject: ${subject}`,
         responseRouting,
+        requester,
       );
       return { kind: "term", reason: "non-review subject" };
     }
@@ -487,6 +543,7 @@ export class ReviewConsumer {
         },
         `bad payload for ${subject}`,
         responseRouting,
+        requester,
       );
       return { kind: "term", reason: "payload validation failed" };
     }
@@ -525,6 +582,7 @@ export class ReviewConsumer {
           { kind: "cant_do", detail: failureDetail },
           `chain verification failed for ${subject}`,
           responseRouting,
+          requester,
         );
         return { kind: "term", reason: failureDetail };
       }
@@ -542,6 +600,7 @@ export class ReviewConsumer {
         },
         `no capability match for code-review.${flavor}`,
         responseRouting,
+        requester,
       );
       return { kind: "term", reason: "no capability match" };
     }
@@ -564,6 +623,7 @@ export class ReviewConsumer {
         },
         "review consumer at maxConcurrent",
         responseRouting,
+        requester,
       );
       return { kind: "nak", delayMs: retryAfterMs };
     }
@@ -579,8 +639,10 @@ export class ReviewConsumer {
         correlationId: envelope.id,
         startedAt,
         ...(responseRouting !== undefined && { responseRouting }),
+        ...(classification !== undefined && { classification }),
       }),
       "dispatch.task.started",
+      requester,
     );
 
     // 6. Run the pipeline. Track the promise for `stop()` drain.
@@ -589,6 +651,7 @@ export class ReviewConsumer {
       payload,
       startedAt,
       responseRouting,
+      requester,
     );
     const tracked: Promise<{ decision: AckDecision }> = pipelinePromise.then(
       (decision) => ({ decision }),
@@ -667,7 +730,12 @@ export class ReviewConsumer {
     payload: ReviewRequestPayload,
     startedAt: Date,
     responseRouting?: LogicalResponseRouting,
+    requester?: FederatedRequester,
   ): Promise<AckDecision> {
+    // cortex#686 — federated mode stamps every emitted envelope with federated
+    // sovereignty so the wire is self-consistent with the requester-keyed
+    // `federated.*` subject `safePublish` routes it on.
+    const classification = requester !== undefined ? "federated" : undefined;
     if (this.stopped) {
       // Mid-shutdown: don't start new pipeline runs. Nak with a 0 hint
       // so the survivor (or the next boot) picks it up. We still publish
@@ -681,6 +749,7 @@ export class ReviewConsumer {
         },
         "consumer shutting down before pipeline start",
         responseRouting,
+        requester,
       );
       return { kind: "nak", delayMs: 0 };
     }
@@ -702,6 +771,9 @@ export class ReviewConsumer {
         // cortex#502 — pass the logical routing into the pipeline so the
         // verdict + failed terminal envelopes it builds carry it.
         ...(responseRouting !== undefined && { responseRouting }),
+        // cortex#686 — federated reviews stamp the pipeline's terminal
+        // (verdict/failed) envelopes with federated sovereignty.
+        ...(classification !== undefined && { classification }),
         // cortex#361 — attach a bus-side heartbeat ticker to the CC
         // session so `system.agent.heartbeat` envelopes flow while the
         // review is in flight. The hook keeps `runtime.publish` calls
@@ -727,6 +799,8 @@ export class ReviewConsumer {
           retry_after_ms: 0,
         },
         `pipeline runner threw: ${detail}`,
+        responseRouting,
+        requester,
       );
       return { kind: "nak", delayMs: 0 };
     }
@@ -735,7 +809,7 @@ export class ReviewConsumer {
       // §8.2 — verdict FIRST, then dispatch.task.completed. Pilot's
       // "first matching event wins" treats the verdict as the primary
       // signal and `completed` as the crash-resilience close.
-      await this.safePublish(result.envelope, "review.verdict.*");
+      await this.safePublish(result.envelope, "review.verdict.*", requester);
       await this.safePublish(
         createDispatchTaskCompletedEvent({
           source: this.source,
@@ -746,8 +820,10 @@ export class ReviewConsumer {
           completedAt: this.clock(),
           resultSummary: extractSummary(result.envelope),
           ...(responseRouting !== undefined && { responseRouting }),
+          ...(classification !== undefined && { classification }),
         }),
         "dispatch.task.completed",
+        requester,
       );
       return { kind: "ack" };
     }
@@ -775,15 +851,17 @@ export class ReviewConsumer {
           resultSummary: firstLine(result.presentation),
           chatResponse: result.presentation,
           ...(responseRouting !== undefined && { responseRouting }),
+          ...(classification !== undefined && { classification }),
         }),
         "dispatch.task.completed",
+        requester,
       );
       return { kind: "ack" };
     }
 
     // result.kind === "failed" — publish the failed envelope and pick
     // the JetStream control per the four-way nak taxonomy (§7).
-    await this.safePublish(result.envelope, "dispatch.task.failed");
+    await this.safePublish(result.envelope, "dispatch.task.failed", requester);
     return failedReasonToAckDecision(reasonOf(result.envelope));
   }
 
@@ -801,8 +879,12 @@ export class ReviewConsumer {
     reason: DispatchTaskFailedReason,
     errorSummary: string,
     responseRouting?: LogicalResponseRouting,
+    requester?: FederatedRequester,
   ): Promise<void> {
     const now = this.clock();
+    // cortex#686 — federated failures declare federated sovereignty so they
+    // route back to the requester self-consistently with the subject.
+    const classification = requester !== undefined ? "federated" : undefined;
     const failed = createReviewTaskFailedEvent({
       source: this.source,
       taskId: crypto.randomUUID(),
@@ -816,8 +898,9 @@ export class ReviewConsumer {
       // failures (bad subject/payload, no capability, backpressure) still
       // render to the originating thread.
       ...(responseRouting !== undefined && { responseRouting }),
+      ...(classification !== undefined && { classification }),
     });
-    await this.safePublish(failed, "dispatch.task.failed");
+    await this.safePublish(failed, "dispatch.task.failed", requester);
   }
 
   /**
@@ -834,20 +917,53 @@ export class ReviewConsumer {
    *
    * **SINGLE PUBLISH PATH (cortex#340).** Every lifecycle + verdict
    * envelope ReviewConsumer emits routes through this method —
-   * `runtime.publish` is the only legitimate exit. Adding a direct
+   * `runtime.publish` (local) or `runtime.publishOnSubject` (federated, since
+   * cortex#686) are the only legitimate exits. Adding a direct
    * `link.publish` or `nc.publish` call would bypass the error trap
    * AND the recording-runtime test fixture, both of which we rely on
    * for the publish-routing audit covered by parametric tests in
    * `__tests__/review-consumer.test.ts`. If a future feature needs a
    * publish from inside this class, extend `safePublish` rather than
    * introducing a sibling path.
+   *
+   * cortex#686 — when `requester` is supplied (federated mode), the envelope
+   * is published on the REQUESTER-keyed `federated.{requester-principal}.
+   * {requester-stack}.{type}` subject via {@link MyelinRuntime.publishOnSubject}
+   * (deriving the subject from `envelope.type` + the requester identity). The
+   * runtime's `selectLink` resolves the requester principal → leaf from the
+   * `peers[]` topology so the verdict reaches the peer stack's
+   * `pilot --wait`. Absent `requester` → the unchanged local
+   * `runtime.publish` path (derives `local.{my-principal}.{my-stack}.…`).
    */
   private async safePublish(
     envelope: Envelope,
     label: string,
+    requester?: FederatedRequester,
   ): Promise<void> {
     try {
-      await this.runtime.publish(envelope);
+      if (requester !== undefined && this.runtime.publishOnSubject !== undefined) {
+        // ADR 0001 — federated subject carries the REQUESTER's identity
+        // (`{principal}.{stack}`), NEVER a network id. `deriveSubject` builds
+        // the same `{principal}.{stack}` grammar as `local.*`, only the scope
+        // prefix differs; routing (which leaf) is resolved from topology by
+        // `selectLink`, not from the wire.
+        const subject = deriveSubject(
+          "federated",
+          requester.principal,
+          envelope.type,
+          requester.stack,
+        );
+        await this.runtime.publishOnSubject(envelope, subject);
+      } else {
+        // Local mode, OR federated mode against a runtime that doesn't ship
+        // `publishOnSubject`. The latter only happens on a DISABLED runtime
+        // (its `publish` is itself a no-op) or a legacy test stub — in both
+        // cases falling through here cannot misroute a live federated verdict
+        // onto a local subject, because no live publish occurs. Every
+        // production (enabled) runtime ships `publishOnSubject`, so federated
+        // mode always takes the branch above on the wire.
+        await this.runtime.publish(envelope);
+      }
     } catch (err) {
       process.stderr.write(
         `review-consumer: publish failed for ${label} (agent=${this.agent.id}): ` +
@@ -930,6 +1046,56 @@ export function extractFlavor(envelope: Envelope, _subject: string): string | nu
   const flavor = t.slice("tasks.code-review.".length);
   if (flavor.length === 0 || flavor.includes(".")) return null;
   return flavor;
+}
+
+/**
+ * cortex#686 (ADR 0001) — parse the REQUESTER's `{principal}.{stack}` identity
+ * from an inbound FEDERATED review-request subject.
+ *
+ * Conformant grammar: `federated.{requester-principal}.{requester-stack}.tasks.
+ * code-review.<flavor>` — segment[1] is the requester principal, segment[2] the
+ * requester stack. The network is NEVER on the wire (resolved from topology),
+ * so it is not a segment here. The 5-segment form
+ * (`federated.{principal}.tasks.code-review.<flavor>`, no stack) is tolerated:
+ * `stack` is left undefined and `deriveSubject` emits the matching stack-less
+ * verdict subject.
+ *
+ * Returns `undefined` when the subject is not a parseable federated subject —
+ * the consumer then falls through to the local `runtime.publish` path (so a
+ * mis-scoped envelope can't silently route a verdict to the wrong place; it
+ * lands on the consumer's own local subject and is observable as a routing
+ * anomaly rather than a cross-principal leak).
+ *
+ * The `tasks` segment must be present (this is dispatch traffic, not a bare
+ * `federated.{principal}.{stack}` announcement) so a malformed subject doesn't
+ * mistake a non-tasks segment for the stack.
+ *
+ * Exported for the review-consumer tests.
+ */
+export function parseFederatedRequester(
+  subject: string,
+): FederatedRequester | undefined {
+  const parts = subject.split(".");
+  if (parts[0] !== "federated") return undefined;
+  const principal = parts[1];
+  if (principal === undefined || principal.length === 0) return undefined;
+
+  // Locate the `tasks` domain segment to disambiguate the stack-aware
+  // (segment[2] = stack) from the stack-less (segment[2] = "tasks") form.
+  const tasksIdx = parts.indexOf("tasks");
+  if (tasksIdx < 2) {
+    // No `tasks` segment, or it sits before a stack could — not dispatch
+    // traffic on the conformant grammar.
+    return undefined;
+  }
+  if (tasksIdx === 2) {
+    // `federated.{principal}.tasks.…` — 5-segment stack-less form.
+    return { principal };
+  }
+  // `federated.{principal}.{stack}.tasks.…` — stack-aware form.
+  const stack = parts[2];
+  if (stack === undefined || stack.length === 0) return undefined;
+  return { principal, stack };
 }
 
 /**

--- a/src/bus/review-consumer.ts
+++ b/src/bus/review-consumer.ts
@@ -68,6 +68,9 @@ import type { ConsumerMessages, JsMsg } from "nats";
 import { deriveSubject } from "@the-metafactory/myelin/subjects";
 import type { MyelinRuntime } from "./myelin/runtime";
 import type { Envelope } from "./myelin/envelope-validator";
+import { getActorPrincipal } from "./myelin/envelope-validator";
+import { resolveSourceNetwork } from "./surface-router";
+import type { PolicyFederatedNetwork } from "../common/types/cortex-config";
 import type { MyelinSubscriber } from "./myelin/subscriber";
 import type { AckDecision } from "./myelin/subscriber";
 import {
@@ -228,20 +231,25 @@ export interface ReviewConsumerOpts {
    */
   signatureVerifier?: SignatureVerifier;
   /**
-   * cortex#686 (ADR 0001) — FEDERATED routing mode. When `true`, the consumer
+   * cortex#686 (ADR 0002) — FEDERATED routing mode. When `true`, the consumer
    * treats every inbound envelope as a cross-principal (federated) review
    * request and routes ALL emitted lifecycle + verdict envelopes back to the
    * REQUESTER's identity on the conformant `federated.{requester-principal}.
    * {requester-stack}.…` grammar, instead of the consumer's own
    * `local.{my-principal}.{my-stack}.…`.
    *
-   * The requester `{principal}.{stack}` is parsed from the inbound subject
-   * (`federated.{requester-principal}.{requester-stack}.tasks.code-review.…`),
-   * NOT from a network id (which is never on the wire — ADR 0001). The
-   * emitted envelopes are stamped `classification: "federated"` and published
-   * via {@link MyelinRuntime.publishOnSubject} on the requester-keyed subject;
-   * the runtime's `selectLink` resolves the requester principal → leaf from
-   * the `peers[]` topology. This is the cortex receiver that closes the
+   * **The requester is derived from `envelope.originator.identity`** (the
+   * `{requester-principal}/{requester-stack}` slash form per ADR 0002 §1) —
+   * NOT from the inbound subject (whose `{principal}.{stack}` segments address
+   * the TARGET = this receiving stack, per ADR 0001), and NOT from
+   * `envelope.source` (which also addresses the target). Reading the requester
+   * off the subject — as cortex#715 originally did — routes every verdict to
+   * SELF and the loop never closes (the cortex#686 BLOCKER this rework fixes).
+   *
+   * The emitted envelopes are stamped `classification: "federated"` and
+   * published via {@link MyelinRuntime.publishOnSubject} on the requester-keyed
+   * subject; the runtime's `selectLink` resolves the requester principal → leaf
+   * from the `peers[]` topology. This is the cortex receiver that closes the
    * cross-principal review loop so the peer's `pilot --wait` resolves.
    *
    * Default `false` → the existing local-consumer behaviour (publish via
@@ -250,6 +258,26 @@ export interface ReviewConsumerOpts {
    */
   federated?: boolean;
   /**
+   * cortex#686 (ADR 0002 §5) — the federation peer topology, used by the
+   * defense-in-depth `peers[]` membership gate the federated consumer runs
+   * BEFORE spawning the reviewer. Resolved from
+   * `policy.federated.networks[]` at boot. The gate resolves the REQUESTER
+   * principal (from `originator.identity`) against these networks' `peers[]`
+   * and fails closed (deny + drop, no CC spawn, no publish) when the requester
+   * is not a configured peer.
+   *
+   * Under `signing: off` this membership check is the application-layer trust
+   * boundary; under `enforce` the `signed_by` chain + the (signed) originator
+   * field add the crypto check on top. Empty / undefined → no live federated
+   * traffic is admitted (a federated consumer with no declared peers denies
+   * every requester — fail closed), but in practice the consumer is only wired
+   * with `federated: true` when at least one network is configured (see
+   * `src/cortex.ts` `federationConfigured`).
+   *
+   * Only consulted in federated mode; ignored on the local path.
+   */
+  federatedNetworks?: readonly PolicyFederatedNetwork[];
+  /**
    * Test seam — clock. Defaults to `() => new Date()`. Tests inject a
    * fixed clock so emitted `startedAt`/`completedAt` are deterministic.
    */
@@ -257,16 +285,21 @@ export interface ReviewConsumerOpts {
 }
 
 /**
- * cortex#686 — the requester's `{principal}.{stack}` identity, parsed from an
- * inbound federated review-request subject. The federated consumer keys every
- * verdict + lifecycle envelope it routes back to this identity so the peer's
- * `pilot --wait` (subscribed on `federated.{its-principal}.{its-stack}.…`)
- * resolves.
+ * cortex#686 (ADR 0002) — the requester's `{principal}.{stack}` identity,
+ * derived from the inbound envelope's `originator.identity` (the
+ * `{requester-principal}/{requester-stack}` slash form). The federated
+ * consumer keys every verdict + lifecycle envelope it routes back to this
+ * identity so the peer's `pilot --wait` (subscribed on
+ * `federated.{its-principal}.{its-stack}.review.verdict.>`) resolves.
+ *
+ * The requester is the policy actor in `originator`, NOT the subject (which
+ * addresses the TARGET) — see {@link parseRequesterFromOriginator}.
  */
 export interface FederatedRequester {
-  /** Requester principal — subject segment[1] under the ADR-0001 grammar. */
+  /** Requester principal — the segment BEFORE the `/` in `originator.identity`. */
   principal: string;
-  /** Requester stack — subject segment[2]; omitted for the 5-segment form. */
+  /** Requester stack — the segment AFTER the `/`; omitted when the originator
+   *  carries only a bare principal (no stack). */
   stack?: string;
 }
 
@@ -353,6 +386,12 @@ export class ReviewConsumer {
   private readonly signatureVerifier: SignatureVerifier | undefined;
   /** cortex#686 — federated routing mode (verdict back to the requester). */
   private readonly federated: boolean;
+  /**
+   * cortex#686 (ADR 0002 §5) — federation peer topology indexed by network id,
+   * for the `peers[]` membership gate. Empty in local mode / when no networks
+   * are configured.
+   */
+  private readonly federatedNetworksById: Map<string, PolicyFederatedNetwork>;
   private readonly clock: () => Date;
 
   /** Promises for in-flight pipelines so `stop()` can drain. */
@@ -379,6 +418,13 @@ export class ReviewConsumer {
     this.pipelineRunner = opts.pipelineRunner ?? runReviewPipeline;
     this.signatureVerifier = opts.signatureVerifier;
     this.federated = opts.federated ?? false;
+    // cortex#686 (ADR 0002 §5) — index the peer topology by network id once at
+    // construction so the consumer-path gate is O(networks) per envelope. Built
+    // even in local mode (cheap, empty); only consulted when `federated`.
+    this.federatedNetworksById = new Map<string, PolicyFederatedNetwork>();
+    for (const network of opts.federatedNetworks ?? []) {
+      this.federatedNetworksById.set(network.id, network);
+    }
     this.clock = opts.clock ?? (() => new Date());
 
     this.flavors = deriveFlavors(opts.agent.capabilities);
@@ -481,15 +527,50 @@ export class ReviewConsumer {
     // envelopes (the verdict still reaches pilot via correlation_id).
     const responseRouting = readLogicalResponseRouting(envelope) ?? undefined;
 
-    // cortex#686 — in federated mode, parse the REQUESTER `{principal}.{stack}`
-    // off the inbound subject ONCE so every emitted envelope routes back to the
-    // requester on the conformant `federated.{requester}.{stack}.…` grammar.
-    // `undefined` in local mode (or when the subject isn't a parseable
-    // federated subject) — `safePublish` then falls through to the local
-    // `runtime.publish` path, byte-for-byte unchanged.
+    // cortex#686 (ADR 0002) — in federated mode, derive the REQUESTER
+    // `{principal}.{stack}` from the inbound envelope's `originator.identity`
+    // ONCE so every emitted envelope routes back to the requester on the
+    // conformant `federated.{requester}.{stack}.…` grammar.
+    //
+    // The requester is the POLICY ACTOR in `originator`, NOT the subject: under
+    // ADR 0001 the subject's `{principal}.{stack}` segments address the TARGET
+    // (this receiving stack), and `envelope.source` likewise addresses the
+    // target. Reading the requester off the subject (the cortex#715 BLOCKER)
+    // routes every verdict to SELF and the loop never closes.
+    //
+    // `undefined` in local mode, OR (in federated mode) when
+    // `originator.identity` is absent / malformed. An un-attributable federated
+    // request is DENIED + DROPPED by the gate below (we never even reach
+    // `safePublish`); the `safePublish` local fall-through remains the
+    // belt-and-braces backstop for the non-denied path against a runtime that
+    // lacks `publishOnSubject` (a disabled runtime / legacy stub — never a live
+    // wire), so a verdict is never guessed onto a cross-principal target.
     const requester = this.federated
-      ? parseFederatedRequester(subject)
+      ? parseRequesterFromOriginator(envelope)
       : undefined;
+
+    // cortex#686 (ADR 0002 §5) — defense-in-depth `peers[]` gate ON THE CONSUMER
+    // PATH. Run the membership check BEFORE spawning the reviewer or emitting
+    // anything: the requester principal MUST be a configured peer in some
+    // `policy.federated.networks[].peers[]`. A non-peer requester (or a
+    // federated request with no resolvable requester) is DENIED and DROPPED —
+    // no CC subprocess, no verdict, no lifecycle envelope. Under `signing: off`
+    // this membership check is the application-layer trust boundary; under
+    // `enforce` the signed_by chain + signed originator add the crypto check.
+    if (this.federated) {
+      const denyReason = this.federatedRequesterDenyReason(requester);
+      if (denyReason !== null) {
+        process.stderr.write(
+          `cortex/review-consumer: federated request DENIED (dropped) for ` +
+            `agent="${this.agent.id}" subject=${subject} envelope=${envelope.id} — ${denyReason}\n`,
+        );
+        // Term so JetStream removes the message (permanent — a non-peer
+        // requester won't become a peer on redelivery) WITHOUT emitting any
+        // verdict/lifecycle envelope to a principal we don't trust.
+        return { kind: "term", reason: `federated requester denied: ${denyReason}` };
+      }
+    }
+
     // Stamp federated sovereignty on every emitted envelope so the wire is
     // self-consistent with the `federated.*` subject it lands on.
     const classification = requester !== undefined ? "federated" : undefined;
@@ -704,6 +785,44 @@ export class ReviewConsumer {
   // -------------------------------------------------------------------------
   // Internals
   // -------------------------------------------------------------------------
+
+  /**
+   * cortex#686 (ADR 0002 §5) — the federated `peers[]` membership gate.
+   * Returns a human-readable deny reason when the inbound federated request
+   * must be DROPPED, or `null` when it may proceed to the reviewer.
+   *
+   * Deny when:
+   *   1. No requester could be derived from `originator.identity` (absent /
+   *      malformed) — we can't name (or trust) the cross-principal source, so
+   *      fail closed. (`safePublish` would already fall back to the local path,
+   *      but a federated consumer must not even spawn the reviewer for an
+   *      un-attributable request.)
+   *   2. The requester is THIS receiving stack's own principal — a self-loop
+   *      (an envelope that named us as the requester). Drop rather than review
+   *      our own request and route the verdict to ourselves.
+   *   3. The requester principal resolves to NO configured network's `peers[]`
+   *      — an unknown / untrusted peer.
+   *
+   * Pure-ish (reads only `this.*` config + the argument); no side effects.
+   */
+  private federatedRequesterDenyReason(
+    requester: FederatedRequester | undefined,
+  ): string | null {
+    if (requester === undefined) {
+      return "no requester in originator.identity (absent or malformed)";
+    }
+    if (requester.principal === this.source.principal) {
+      return `self-loop: requester principal "${requester.principal}" is this receiving stack`;
+    }
+    const resolved = resolveSourceNetwork(
+      requester.principal,
+      this.federatedNetworksById,
+    );
+    if (resolved === undefined) {
+      return `requester principal "${requester.principal}" is in no configured network's peers[]`;
+    }
+    return null;
+  }
 
   /** Capability claim: exact `code-review.<flavor>` or generic `code-review`. */
   private claims(flavor: string): boolean {
@@ -1049,52 +1168,61 @@ export function extractFlavor(envelope: Envelope, _subject: string): string | nu
 }
 
 /**
- * cortex#686 (ADR 0001) — parse the REQUESTER's `{principal}.{stack}` identity
- * from an inbound FEDERATED review-request subject.
+ * cortex#686 (ADR 0002 §1+§3) — derive the REQUESTER's `{principal}.{stack}`
+ * identity from an inbound FEDERATED review-request envelope's
+ * `originator.identity`.
  *
- * Conformant grammar: `federated.{requester-principal}.{requester-stack}.tasks.
- * code-review.<flavor>` — segment[1] is the requester principal, segment[2] the
- * requester stack. The network is NEVER on the wire (resolved from topology),
- * so it is not a segment here. The 5-segment form
- * (`federated.{principal}.tasks.code-review.<flavor>`, no stack) is tolerated:
- * `stack` is left undefined and `deriveSubject` emits the matching stack-less
- * verdict subject.
+ * **Why `originator`, not the subject or `source`.** Under ADR 0001 a federated
+ * subject is `federated.{TARGET-principal}.{TARGET-stack}.tasks.code-review.…`
+ * and `deriveNatsSubject` derives that from `envelope.source` — so BOTH the
+ * subject's `{principal}.{stack}` segments AND `envelope.source` address the
+ * TARGET (this receiving stack), not the requester. Reading the requester off
+ * either routes the verdict to SELF and the loop never closes (the cortex#715
+ * BLOCKER). ADR 0002 §1 carries the requester in `originator.identity` —
+ * "who the signer is acting on behalf of" — a signed/signable field.
  *
- * Returns `undefined` when the subject is not a parseable federated subject —
- * the consumer then falls through to the local `runtime.publish` path (so a
- * mis-scoped envelope can't silently route a verdict to the wrong place; it
- * lands on the consumer's own local subject and is observable as a routing
- * anomaly rather than a cross-principal leak).
+ * **Format (ADR 0002 §1, §3):** `originator.identity = {requester-principal}/
+ * {requester-stack}` — slash-delimited so the principal and stack split
+ * unambiguously (a `did:mf:{principal}-{stack}` DID can't: hyphens appear in
+ * both). A `did:mf:` prefix, if present, is stripped before the split. The
+ * dual-read of the deprecated `originator.principal` key is handled by
+ * {@link getActorPrincipal}.
  *
- * The `tasks` segment must be present (this is dispatch traffic, not a bare
- * `federated.{principal}.{stack}` announcement) so a malformed subject doesn't
- * mistake a non-tasks segment for the stack.
+ * Returns `undefined` when there is no `originator` block, the identity is
+ * empty, or it carries no `/` to split principal from stack — the federated
+ * consumer then DENIES + DROPS the request (an un-attributable cross-principal
+ * source is never reviewed; see {@link ReviewConsumer.federatedRequesterDenyReason}),
+ * and `safePublish` would in any case fail closed to the local path rather than
+ * guess a requester.
  *
  * Exported for the review-consumer tests.
  */
-export function parseFederatedRequester(
-  subject: string,
+export function parseRequesterFromOriginator(
+  envelope: Envelope,
 ): FederatedRequester | undefined {
-  const parts = subject.split(".");
-  if (parts[0] !== "federated") return undefined;
-  const principal = parts[1];
-  if (principal === undefined || principal.length === 0) return undefined;
+  // getActorPrincipal precedence: originator.identity → originator.principal
+  // (deprecated dual-read) → signed_by[0].identity. For a federated dispatch
+  // the requester is the originator; the signed_by[0] fallback is the relaying
+  // stack, which for a self-signed cross-principal hop is also the requester
+  // stack — but we require the originator block to be present so an un-stamped
+  // envelope fails closed rather than borrowing the signer as the requester.
+  if (envelope.originator === undefined) return undefined;
+  const raw = getActorPrincipal(envelope);
+  if (raw === undefined || raw.length === 0) return undefined;
 
-  // Locate the `tasks` domain segment to disambiguate the stack-aware
-  // (segment[2] = stack) from the stack-less (segment[2] = "tasks") form.
-  const tasksIdx = parts.indexOf("tasks");
-  if (tasksIdx < 2) {
-    // No `tasks` segment, or it sits before a stack could — not dispatch
-    // traffic on the conformant grammar.
+  // Strip an optional `did:mf:` method prefix; the {principal}/{stack} body
+  // follows either way (ADR 0002 §1 writes the bare slash form).
+  const body = raw.startsWith("did:mf:") ? raw.slice("did:mf:".length) : raw;
+  const slash = body.indexOf("/");
+  if (slash <= 0 || slash === body.length - 1) {
+    // No slash, leading slash, or trailing slash → can't split an unambiguous
+    // {principal}/{stack}. Fail closed.
     return undefined;
   }
-  if (tasksIdx === 2) {
-    // `federated.{principal}.tasks.…` — 5-segment stack-less form.
-    return { principal };
-  }
-  // `federated.{principal}.{stack}.tasks.…` — stack-aware form.
-  const stack = parts[2];
-  if (stack === undefined || stack.length === 0) return undefined;
+  const principal = body.slice(0, slash);
+  const stack = body.slice(slash + 1);
+  // A multi-slash body (`a/b/c`) is malformed — a stack is a single segment.
+  if (stack.includes("/")) return undefined;
   return { principal, stack };
 }
 

--- a/src/bus/surface-router.ts
+++ b/src/bus/surface-router.ts
@@ -48,6 +48,7 @@ import {
 } from "./system-events";
 import {
   getSignedByChain,
+  principalFromEnvelope,
   type Envelope,
 } from "./myelin/envelope-validator";
 import type { MyelinRuntime } from "./myelin/runtime";
@@ -649,10 +650,15 @@ function emitAccessFiltered(
  * `"allow"` short-circuits all later work — the envelope flows through
  * to adapter matching exactly as it did pre-D.2.
  *
- * Every deny branch carries the network id we resolved (or attempted
- * to resolve, in the `unknown_network` case) so the audit envelope can
- * surface "peer claimed network 'x'" without `dispatch()` re-parsing
- * the subject.
+ * Every deny branch carries the network id we resolved (or, in the
+ * `unknown_network` case, the SOURCE PRINCIPAL we failed to resolve to any
+ * configured peer) so the audit envelope can surface why the envelope was
+ * rejected without `dispatch()` re-parsing the subject.
+ *
+ * cortex#686 (ADR 0001) — the `networkId` field now carries the SOURCE
+ * network id resolved from the source principal's membership in a configured
+ * network's `peers[]`, NOT a subject segment. On the `unknown_network` branch
+ * it carries the unresolved source principal as a searchable sentinel.
  */
 export type FederationGateDecision =
   | "allow"
@@ -689,49 +695,71 @@ export type FederationGateDecision =
     };
 
 /**
- * ⚠️ ADR 0001 (supersedes cortex#661) GRAMMAR MISMATCH — REWORK IN cortex#686.
+ * cortex#686 (ADR 0001) — resolve the SOURCE network from the SOURCE PRINCIPAL.
  *
- * This gate still parses subject segment[1] as a `{network_id}` (the cortex#661
- * wire grammar). ADR 0001 removed the network from the wire: an inbound
- * federated subject is now `federated.{principal}.{stack}.…` where segment[1] is
- * the RECEIVING principal, not a network id. Against the new grammar this gate
- * looks up `networksById.get(<principal>)`, finds nothing (network ids and
- * principal ids share a namespace but differ in value), and DENIES every
- * conformant inbound federated envelope as `peer_not_in_accept_list`
- * (`unknown_network: true`).
+ * Find the configured network whose `peers[]` lists `sourcePrincipal` as a
+ * `principal_id`. Returns the network + its id, or `undefined` when the source
+ * principal is in no configured network's peer list (an unknown/untrusted peer).
  *
- * This FAILS CLOSED (no cross-network leak — the safe direction) but it is a
- * functional break for the inbound federated path. It is dormant only because
- * no federated dispatch consumer exists yet (ADR 0001 §Consequences); the
- * conformant rework lands in lockstep with the federated review consumer
- * (cortex#686) + pilot#149. Until then, do NOT rely on this gate's accept path
- * for ADR-0001 traffic. The cross-principal TRUST decision the gate is meant to
- * own moves to: the per-leaf inbound subscription scope (`runtime.ts`), the
- * `verify-signed-by-chain` peer-pubkey lookup keyed off `sourceLink`, and the
- * `peers[]` topology — re-derive the gate's accept/deny check on the
- * `{principal}.{stack}` grammar there.
+ * ADR 0001 mandates that the network is resolved from deployment topology
+ * (`policy.federated.networks[].peers[]`), NOT read off the wire. A peer
+ * principal is, by config invariant, declared in at most the networks the local
+ * stack joins; first match wins (a principal appearing in multiple networks'
+ * `peers[]` is an unusual topology — the first declared network governs its
+ * accept/deny rules, matching the publish-side `principalIdToLinkId` first-wins
+ * resolution in `runtime.ts`).
  *
- * Parse `federated.{network_id}.<...>` and check the subject against
- * the resolved network's policy. Pure function — exported so tests can
- * probe each branch in isolation without spinning up a runtime + router.
+ * Pure helper — exported for tests.
+ */
+export function resolveSourceNetwork(
+  sourcePrincipal: string,
+  networksById: Map<string, PolicyFederatedNetwork>,
+): { networkId: string; network: PolicyFederatedNetwork } | undefined {
+  for (const [networkId, network] of networksById) {
+    for (const peer of network.peers) {
+      if (peer.principal_id === sourcePrincipal) {
+        return { networkId, network };
+      }
+    }
+  }
+  return undefined;
+}
+
+/**
+ * cortex#686 (ADR 0001, supersedes cortex#661) — federation accept/deny gate on
+ * the conformant `{principal}.{stack}` grammar.
  *
- * Decision order (matches D.2 spec semantics):
+ * The network is NO LONGER read off the wire. An inbound federated subject is
+ * `federated.{target-principal}.{stack}.…` where segment[1] is the RECEIVING
+ * principal (this stack), not a network id. The SOURCE network is resolved from
+ * the SOURCE PRINCIPAL (`principalFromEnvelope` — the leading segment of
+ * `envelope.source`) via its membership in a configured network's `peers[]`
+ * (`resolveSourceNetwork`). This is the L1/L7 separation ADR 0001 mandates:
+ * identity is on the wire (the source signs as its principal), topology
+ * (which network that principal reaches us on) is in config.
  *
- *   1. Subject must declare a network id (`federated.<id>.<...>`).
- *      Bare `federated` or `federated.` is rejected as
- *      `peer_not_in_accept_list` with `unknown_network: true`.
- *   2. The network id must be in `policy.federated.networks[]`.
- *      Missing → same deny kind with `unknown_network: true`.
- *   3. `deny_subjects[]` is checked BEFORE `accept_subjects[]` —
- *      principal intent on the deny list overrides any accept hit.
- *      D.2 spec: "A match here overrides accept_subjects[]".
- *   4. `accept_subjects[]` must contain a matching pattern. Empty
- *      accept list means "accept nothing" (D.1 schema doc); the
- *      envelope is rejected even when no deny pattern matched.
- *   5. Hop budget last — by spec it's the cheapest check but
- *      conceptually it's "you're allowed but you've travelled too
- *      far", so running it after the accept-list keeps the deny
- *      reason precedence intuitive (accept-misses report first).
+ * Pure function — exported so tests can probe each branch in isolation without
+ * spinning up a runtime + router.
+ *
+ * Decision order (matches D.2 spec semantics, re-derived on the ADR-0001 grammar):
+ *
+ *   1. The source principal must resolve to a configured network via its
+ *      `peers[]` membership. An unresolved source principal (in no configured
+ *      network's peer list) is rejected as `peer_not_in_accept_list` with
+ *      `unknown_network: true`, carrying the unresolved source principal as the
+ *      searchable `networkId` sentinel.
+ *   2. `deny_subjects[]` is checked BEFORE `accept_subjects[]` — principal
+ *      intent on the deny list overrides any accept hit (D.2: "A match here
+ *      overrides accept_subjects[]").
+ *   3. `accept_subjects[]` must contain a matching pattern. Empty accept list
+ *      means "accept nothing" (D.1 schema doc); the envelope is rejected even
+ *      when no deny pattern matched.
+ *   4. Hop budget last — "you're allowed but you've travelled too far", run
+ *      after the accept-list so the deny-reason precedence stays intuitive.
+ *
+ * The F-3d anti-spoof `sourceLink` cross-check now asserts the RESOLVED source
+ * network's `leaf_node` equals the delivering link — a subject that arrived on a
+ * leaf not owning the resolved network is a cross-network spoof.
  */
 export function evaluateFederationGate(
   subject: string,
@@ -751,18 +779,10 @@ export function evaluateFederationGate(
   }
 
   const parts = subject.split(".");
-  // `federated.{id}.<...>` requires at least 3 segments — `federated`,
-  // `{id}`, and one or more rest segments. A 2-segment `federated.x`
-  // is technically a network announcement subject but D.2 only gates
-  // dispatch traffic, which always has trailing segments. We deny
-  // the malformed shape to fail closed.
-  //
-  // Echo cortex#226 round 1: report a sentinel `"<malformed>"` rather
-  // than the literal empty string for the network id — principals
-  // filtering the access stream by `payload.network_id` get a
-  // searchable token instead of an empty cell. `unknown_network: true`
-  // still flags this branch separately from "id present but not
-  // declared" so the dashboard can render the more specific message.
+  // `federated.{target-principal}.{stack}.<...>` requires at least 3 segments.
+  // A bare `federated` / `federated.` is malformed dispatch traffic — fail
+  // closed with the `<malformed>` sentinel so principals filtering the access
+  // stream by `payload.network_id` get a searchable token, not an empty cell.
   if (parts.length < 3 || parts[1] === undefined || parts[1].length === 0) {
     return {
       kind: "peer_not_in_accept_list",
@@ -771,23 +791,32 @@ export function evaluateFederationGate(
     };
   }
 
-  const networkId = parts[1];
-  const network = networksById.get(networkId);
-  if (!network) {
+  // ADR 0001 — resolve the SOURCE network from the SOURCE PRINCIPAL (the leading
+  // segment of `envelope.source`), NOT from subject segment[1] (which is the
+  // RECEIVING principal under the conformant grammar). A source principal that
+  // matches no configured network's `peers[]` is an unknown/untrusted peer.
+  const sourcePrincipal = principalFromEnvelope(envelope);
+  const resolved = resolveSourceNetwork(sourcePrincipal, networksById);
+  if (resolved === undefined) {
     return {
       kind: "peer_not_in_accept_list",
-      networkId,
+      // Carry the unresolved source principal as the searchable sentinel —
+      // the audit stream's `network_id` now reads "peer principal X is in no
+      // configured network's peers[]" rather than a stale subject segment.
+      networkId: sourcePrincipal,
       unknown_network: true,
     };
   }
+  const { networkId, network } = resolved;
 
-  // IAW Phase F-3d (cortex#666) — anti-spoof cross-check (design §3.3 / §5
-  // isolation layer 2). When the runtime supplied a LEAF delivering-link
-  // attribution, the subject's claimed network MUST be served by that exact
-  // leaf: the network's `leaf_node` has to equal `sourceLink`. A subject
-  // claiming `federated.{X}.…` that arrived on a different leaf is a
-  // cross-network spoof and is denied BEFORE deny/accept/hop checks — the
-  // delivering link is more authoritative than any subject-pattern rule.
+  // IAW Phase F-3d (cortex#666), reworked for ADR 0001 (cortex#686) — anti-spoof
+  // cross-check (design §3.3 / §5 isolation layer 2). When the runtime supplied a
+  // LEAF delivering-link attribution, the RESOLVED source network (from the source
+  // principal's `peers[]` membership) MUST be served by that exact leaf: the
+  // network's `leaf_node` has to equal `sourceLink`. A source principal whose
+  // resolved network rides a different leaf than the one it arrived on is a
+  // cross-network spoof, denied BEFORE deny/accept/hop checks — the delivering
+  // link is more authoritative than any subject-pattern or topology rule.
   //
   // SKIPPED in two cases (both back-compat-preserving):
   //   1. `sourceLink === undefined` — no attribution (pre-F-3d callers,

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -986,6 +986,18 @@ export async function startCortex(
   // Reuses `derivedStack.stack` resolved at boot (line 308) — same source
   // sage's bridge subscription already uses for `local.{principal}.{stack}.>`.
   const reviewSubjectPattern = `local.${reviewPrincipalId}.${derivedStack.stack}.tasks.code-review.>`;
+  // cortex#686 (ADR 0001) — the FEDERATED review pattern: this RECEIVING stack's
+  // OWN identity (`federated.{my-principal}.{my-stack}.tasks.code-review.>`),
+  // the same `{principal}.{stack}` segments as the local pattern, only the
+  // scope prefix differs (the network is NEVER on the wire — resolved from
+  // topology). Cross-principal review-requests from a configured peer land
+  // here; the federated consumer routes the verdict back to the REQUESTER's
+  // identity (see ReviewConsumer `federated` mode). Gated on a `federated:`
+  // policy block: a deployment with no federation declared adds no federated
+  // filter/consumer (back-compat — local path byte-for-byte unchanged).
+  const federationConfigured =
+    (options.policy?.federated?.networks ?? []).length > 0;
+  const reviewFederatedSubjectPattern = `federated.${reviewPrincipalId}.${derivedStack.stack}.tasks.code-review.>`;
   const reviewConfig = options.bus?.review;
   const reviewStream = reviewConfig?.stream.name ?? "CODE_REVIEW";
   const reviewStreamMaxAgeNs =
@@ -1009,18 +1021,27 @@ export async function startCortex(
   // try/catch and aborted boot (sage review on #338, round 2).
   const reviewJsm = await resolveReviewProvisioningJsm(runtime, reviewCapableAgents);
 
+  // cortex#686 — the CODE_REVIEW stream's subject filter carries BOTH the
+  // local and (when federation is configured) the federated code-review
+  // patterns, so an inbound `federated.{me}.{stack}.tasks.code-review.…`
+  // request from a peer is captured by the same JetStream stream the local
+  // consumer binds. A parallel federated DURABLE (per agent) binds below.
+  const reviewStreamSubjects = federationConfigured
+    ? [reviewSubjectPattern, reviewFederatedSubjectPattern]
+    : [reviewSubjectPattern];
+
   if (reviewJsm !== null) {
     try {
       const outcome = await provisionReviewStream({
         jsm: reviewJsm,
         name: reviewStream,
-        subjects: [reviewSubjectPattern],
+        subjects: reviewStreamSubjects,
         maxAgeNs: reviewStreamMaxAgeNs,
         maxBytes: reviewStreamMaxBytes,
       });
       if (outcome === "created") {
         console.log(
-          `cortex: provisioned JetStream stream "${reviewStream}" (subjects=[${reviewSubjectPattern}])`,
+          `cortex: provisioned JetStream stream "${reviewStream}" (subjects=[${reviewStreamSubjects.join(", ")}])`,
         );
       } else if (outcome === "exists") {
         console.log(
@@ -1142,38 +1163,51 @@ export async function startCortex(
 
       const reviewSessionOpts = buildReviewSessionOpts(config, agent);
 
-      const consumer = new ReviewConsumer({
-        agent: consumerAgent,
-        source: systemEventSource,
-        runtime,
-        // CC session factory — spawns a real `claude` process. Mirrors the
-        // default factory inside `ClaudeCodeHarness` (the harness keeps its
-        // own copy private; we don't re-export to avoid the symbol leaking
-        // into the public bus surface). Tests don't reach the factory
-        // unless `processEnvelope` is invoked; the boot test in
-        // `src/__tests__/cortex.review-consumer-boot.test.ts` only
-        // exercises instantiation + subscribe. Stays wired even when a
-        // non-CC pipelineRunner is selected — the consumer's type still
-        // requires the factory, and the CC path remains the default
-        // fallthrough for non-pi-dev substrates.
-        ccSessionFactory: (opts) => new CCSession(opts),
-        // PR-6 has no policy hook — that's a future PR (sovereignty /
-        // compliance gate). Until then the pipeline goes straight to CC.
-        promptBuilder: ({ payload }) =>
-          // Dispatch INTENT, not method. cortex pings the reviewer with the
-          // PR to review; the reviewing agent (e.g. Echo) owns HOW — its
-          // persona routes to its canonical review entry (`/review-pr` →
-          // CodeReview skill → `gh pr review` + the cortex#237 verdict block).
-          // Do NOT send a `/review` slash command here: that hijacks the
-          // session into the generic built-in reviewer (which produces prose
-          // and *asks* before posting — never posting in a non-interactive
-          // dispatch). Capability routing already happened on the subject
-          // (`tasks.code-review.*`); the prompt only carries the intent.
-          `Review PR ${payload.repo}#${payload.pr}`,
-        sessionOpts: reviewSessionOpts,
-        ...(pipelineRunner !== undefined && { pipelineRunner }),
-        ...(signatureVerifier !== undefined && { signatureVerifier }),
-      });
+      // cortex#686 — shared construction options for the local + federated
+      // consumers. Both serve the SAME reviewer agent (same capabilities,
+      // verifier, substrate, prompt); they differ only in the `federated` flag
+      // (which flips verdict routing to the requester) and the subscription
+      // pattern/durable. Factored into a closure so the two consumers can't
+      // drift on the heavy CC-session / verifier / prompt wiring.
+      const makeConsumer = (federated: boolean): ReviewConsumer =>
+        new ReviewConsumer({
+          agent: consumerAgent,
+          source: systemEventSource,
+          runtime,
+          // CC session factory — spawns a real `claude` process. Mirrors the
+          // default factory inside `ClaudeCodeHarness` (the harness keeps its
+          // own copy private; we don't re-export to avoid the symbol leaking
+          // into the public bus surface). Tests don't reach the factory
+          // unless `processEnvelope` is invoked; the boot test in
+          // `src/__tests__/cortex.review-consumer-boot.test.ts` only
+          // exercises instantiation + subscribe. Stays wired even when a
+          // non-CC pipelineRunner is selected — the consumer's type still
+          // requires the factory, and the CC path remains the default
+          // fallthrough for non-pi-dev substrates.
+          ccSessionFactory: (opts) => new CCSession(opts),
+          // PR-6 has no policy hook — that's a future PR (sovereignty /
+          // compliance gate). Until then the pipeline goes straight to CC.
+          promptBuilder: ({ payload }) =>
+            // Dispatch INTENT, not method. cortex pings the reviewer with the
+            // PR to review; the reviewing agent (e.g. Echo) owns HOW — its
+            // persona routes to its canonical review entry (`/review-pr` →
+            // CodeReview skill → `gh pr review` + the cortex#237 verdict block).
+            // Do NOT send a `/review` slash command here: that hijacks the
+            // session into the generic built-in reviewer (which produces prose
+            // and *asks* before posting — never posting in a non-interactive
+            // dispatch). Capability routing already happened on the subject
+            // (`tasks.code-review.*`); the prompt only carries the intent.
+            `Review PR ${payload.repo}#${payload.pr}`,
+          sessionOpts: reviewSessionOpts,
+          ...(pipelineRunner !== undefined && { pipelineRunner }),
+          ...(signatureVerifier !== undefined && { signatureVerifier }),
+          // cortex#686 — federated consumers route the verdict back to the
+          // requester's identity on the conformant `federated.{requester}.…`
+          // grammar (the cortex receiver that closes the cross-principal loop).
+          ...(federated && { federated: true }),
+        });
+
+      const consumer = makeConsumer(false);
       reviewConsumers.push(consumer);
       // Subscribe via the runtime's subscribePull helper. When the
       // runtime is disabled the helper returns null inside start() and
@@ -1246,6 +1280,58 @@ export async function startCortex(
         console.log(
           `cortex: review consumer DORMANT for agent=${agent.id} flavors=[${flavorSummary}] signed=${signedTag} substrate=${substrate} — cortex MyelinRuntime subscriptions disabled (G-1111 pending; tasks.code-review.* envelopes will not be claimed by this consumer)`,
         );
+      }
+
+      // cortex#686 (ADR 0001) — the FEDERATED review consumer. Subscribes this
+      // stack's OWN federated identity (`federated.{my-principal}.{my-stack}.
+      // tasks.code-review.>`) on the SAME CODE_REVIEW stream (its subject
+      // filter was extended above when federation is configured), via a
+      // SEPARATE durable so local + federated traffic ack independently. Routes
+      // the verdict back to the REQUESTER's identity (the `federated: true`
+      // flag). Only wired when a `federated:` policy block is declared — a
+      // non-federating deployment skips this entirely (back-compat).
+      if (federationConfigured) {
+        const federatedConsumer = makeConsumer(true);
+        reviewConsumers.push(federatedConsumer);
+        const federatedDurable = `cortex-review-consumer-federated-${reviewPrincipalId}-${agent.id}`;
+        if (reviewJsm !== null) {
+          try {
+            const outcome = await provisionReviewConsumer({
+              jsm: reviewJsm,
+              stream: reviewStream,
+              durable: federatedDurable,
+              maxDeliver: reviewConsumerMaxDeliver,
+            });
+            if (outcome === "created") {
+              console.log(
+                `cortex: provisioned JetStream durable "${federatedDurable}" on stream "${reviewStream}"`,
+              );
+            } else if (outcome === "updated") {
+              console.log(
+                `cortex: reconciled JetStream durable "${federatedDurable}" ack_wait (cortex#422) on stream "${reviewStream}"`,
+              );
+            }
+          } catch (provisionErr) {
+            process.stderr.write(
+              `cortex: provisionReviewConsumer failed for "${federatedDurable}": ` +
+                `${provisionErr instanceof Error ? provisionErr.message : String(provisionErr)}\n`,
+            );
+          }
+        }
+        const federatedStarted = await federatedConsumer.start({
+          pattern: reviewFederatedSubjectPattern,
+          stream: reviewStream,
+          durable: federatedDurable,
+        });
+        if (federatedStarted.subscribed) {
+          console.log(
+            `cortex: federated review consumer ready for agent=${agent.id} flavors=[${flavorSummary}] signed=${signedTag} substrate=${substrate} pattern=${reviewFederatedSubjectPattern}`,
+          );
+        } else {
+          console.log(
+            `cortex: federated review consumer DORMANT for agent=${agent.id} flavors=[${flavorSummary}] signed=${signedTag} substrate=${substrate} — cortex MyelinRuntime subscriptions disabled (federated.* code-review envelopes will not be claimed by this consumer)`,
+          );
+        }
       }
     } catch (err) {
       // Per CLAUDE.md: log every error. A single agent's consumer crash

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -1204,7 +1204,14 @@ export async function startCortex(
           // cortex#686 — federated consumers route the verdict back to the
           // requester's identity on the conformant `federated.{requester}.…`
           // grammar (the cortex receiver that closes the cross-principal loop).
-          ...(federated && { federated: true }),
+          // The peer topology is passed so the consumer-path `peers[]` gate
+          // (ADR 0002 §5) can deny a non-peer requester BEFORE spawning the
+          // reviewer — defense-in-depth that, under `signing: off`, is the
+          // application-layer trust boundary on the consumer path.
+          ...(federated && {
+            federated: true,
+            federatedNetworks: options.policy?.federated?.networks ?? [],
+          }),
         });
 
       const consumer = makeConsumer(false);

--- a/src/runner/__tests__/dispatch-listener.test.ts
+++ b/src/runner/__tests__/dispatch-listener.test.ts
@@ -1495,6 +1495,40 @@ describe("dispatch-listener — policy gating (C.3.1)", () => {
    * Capability set is parameterised so individual tests can flip
    * allow/deny on the role grant.
    */
+  // cortex#686 (ADR 0001) — the listener resolves the audit `source_network`
+  // from the SOURCE PRINCIPAL's `peers[]` membership in its OWN federated
+  // config (mirroring the engine's, since both come from the same cortex.yaml
+  // `policy.federated`). `makeReceivedEnvelope` signs from source principal
+  // `metafactory`, so the listener's network lists `metafactory` as a peer.
+  const FED_PEER_PUBKEY = "U" + "A".repeat(55); // 56-char U-prefixed base32 NKey.
+  function listenerFederation(networkId = "research-collab"): {
+    networks: import("../../common/types/cortex-config").PolicyFederatedNetwork[];
+  } {
+    return {
+      networks: [
+        {
+          id: networkId,
+          leaf_node: "leaf-research",
+          peers: [
+            {
+              principal_id: "metafactory",
+              stack_id: "metafactory/meta-factory",
+              principal_pubkey: FED_PEER_PUBKEY,
+            },
+          ],
+          // ADR 0001 — accept-list matches the RECEIVING subject (the target
+          // principal/stack on the wire), not the network id. Wide-open here
+          // so the gate's accept check passes and the policy engine's
+          // federation branch is what these tests exercise.
+          accept_subjects: ["federated.>"],
+          deny_subjects: [],
+          announce_capabilities: [],
+          max_hop: 5,
+        },
+      ],
+    };
+  }
+
   function engineWithFederation(opts: {
     capabilities: readonly string[];
     networkId?: string;
@@ -1570,6 +1604,9 @@ describe("dispatch-listener — policy gating (C.3.1)", () => {
       source: SOURCE,
       subjects: ["federated.partner-only.dispatch.task.received"],
       ccSessionFactory: factory,
+      // cortex#686 — listener resolves source_network from the source
+      // principal's peer membership; `metafactory` is a peer of `partner-only`.
+      federated: listenerFederation("partner-only"),
       policyEngine: engineWithFederation({
         capabilities: ["dispatch.cortex"],
         networkId: "partner-only",
@@ -1617,6 +1654,11 @@ describe("dispatch-listener — policy gating (C.3.1)", () => {
       // listener receives envelopes from networks it doesn't know.
       subjects: ["federated.>"],
       ccSessionFactory: factory,
+      // cortex#686 — the listener resolves the source principal (`metafactory`)
+      // to `phantom-network` via its peer roster, but the ENGINE only declares
+      // `research-collab`, so the engine's federation branch denies the
+      // resolved source_network as `unknown_network`.
+      federated: listenerFederation("phantom-network"),
       policyEngine: engineWithFederation({
         capabilities: ["dispatch.cortex"],
         networkId: "research-collab",
@@ -1625,11 +1667,12 @@ describe("dispatch-listener — policy gating (C.3.1)", () => {
     await listener.start();
     await router.start();
 
-    // Envelope arrives on a federated subject whose network id isn't
-    // declared in policy.federated.networks[].
+    // Envelope arrives on a conformant federated subject; the source network
+    // is resolved from the source principal's peer membership (ADR 0001), not
+    // a subject segment.
     r.trigger(
       makeReceivedEnvelope(),
-      "federated.phantom-network.dispatch.task.received",
+      "federated.andreas.meta-factory.dispatch.task.received",
     );
     await new Promise((resolve) => setTimeout(resolve, 10));
 
@@ -1662,6 +1705,9 @@ describe("dispatch-listener — policy gating (C.3.1)", () => {
       source: SOURCE,
       subjects: ["federated.research-collab.dispatch.task.received"],
       ccSessionFactory: factory,
+      // cortex#686 — source principal resolves to research-collab for the
+      // audit `source_network` annotation.
+      federated: listenerFederation("research-collab"),
       policyEngine: engineWithFederation({
         // No dispatch.cortex grant — capability check misses.
         capabilities: ["other.cap"],
@@ -1748,6 +1794,9 @@ describe("dispatch-listener — policy gating (C.3.1)", () => {
       source: SOURCE,
       subjects: ["federated.research-collab.dispatch.task.received"],
       ccSessionFactory: factory,
+      // cortex#686 — source_network resolves from the source principal's peer
+      // membership in the listener's federated config.
+      federated: listenerFederation("research-collab"),
       policyEngine: engine,
     });
     await listener.start();

--- a/src/runner/dispatch-listener.ts
+++ b/src/runner/dispatch-listener.ts
@@ -70,6 +70,7 @@ import {
   getSignedByChain,
   getFirstStampPrincipal,
   getTargetAssistant,
+  principalFromEnvelope,
 } from "../bus/myelin/envelope-validator";
 import { encodeDidSegment } from "@the-metafactory/myelin/subjects";
 import type { MyelinRuntime, BusEnvelopeSigner } from "../bus/myelin/runtime";
@@ -77,6 +78,7 @@ import { signEnvelope } from "@the-metafactory/myelin/identity";
 import {
   emitFederationDenied,
   evaluateFederationGate,
+  resolveSourceNetwork,
   subjectMatches,
 } from "../bus/surface-router";
 import type { PolicyFederated, PolicyFederatedNetwork } from "../common/types/cortex-config";
@@ -100,7 +102,6 @@ import type {
 import type { PolicyEngine } from "../common/policy/engine";
 import { extractAgentIdFromDid } from "../common/policy/did";
 import { isUuid } from "../common/types/uuid";
-import { LETTER_PREFIX_ID_REGEX } from "../common/types/id";
 import type {
   Intent,
   PolicyDenyReason,
@@ -780,6 +781,7 @@ export function createDispatchListener(
         stackNKeyPub,
         resignSigner,
         resolveFederatedPeer,
+        federatedNetworksById,
         traceDispatch,
       });
     } catch (err) {
@@ -1122,6 +1124,13 @@ interface DispatchHandlerContext {
     | ((peerPrincipal: string) => Promise<FederatedPeerResolution>)
     | undefined;
   /**
+   * cortex#686 (ADR 0001) — federated networks indexed by id, used to resolve
+   * the SOURCE network from the SOURCE PRINCIPAL's `peers[]` membership for the
+   * `source_network` audit annotation (ADR 0001 — the network is never on the
+   * wire). Built once by `createDispatchListener`; empty map = no federation.
+   */
+  federatedNetworksById: Map<string, PolicyFederatedNetwork>;
+  /**
    * cortex#492 — when `true`, emit a `system.dispatch.stage` trace at
    * each gate inside the handler. Resolved by `createDispatchListener`
    * from the explicit option or `CORTEX_TRACE_DISPATCH`; the handler
@@ -1151,6 +1160,7 @@ async function handleDispatchEnvelope(
     stackNKeyPub,
     resignSigner,
     resolveFederatedPeer,
+    federatedNetworksById,
     traceDispatch,
   } = ctx;
   // cortex#492 — pre-parse trace context. Refined to the trusted payload
@@ -1477,7 +1487,7 @@ async function handleDispatchEnvelope(
   // subject when the envelope arrived via `federated.{id}.>`. Local
   // dispatches (subjects like `local.{principal}.dispatch.task.received`)
   // leave it `undefined` so the engine skips the federation branch.
-  const sourceNetwork = extractSourceNetwork(subject);
+  const sourceNetwork = extractSourceNetwork(envelope, subject, federatedNetworksById);
   let gatedPrincipal: Principal | undefined;
   if (policyEngine === undefined) {
     // v2.0.1 (cortex#311): fail-closed when policy engine is unavailable.
@@ -1920,46 +1930,41 @@ function enrichDenyReason(
 }
 
 /**
- * ⚠️ ADR 0001 (supersedes cortex#661) GRAMMAR MISMATCH — REWORK IN cortex#686.
+ * cortex#686 (ADR 0001, supersedes cortex#661) — resolve the SOURCE network id
+ * from the SOURCE PRINCIPAL via deployment topology, NOT from a subject segment.
  *
- * This reads subject segment[1] as a `{network_id}` (the cortex#661 grammar).
- * Under ADR 0001 segment[1] is the RECEIVING principal, not a network id — so on
- * a conformant inbound `federated.{principal}.{stack}.…` subject this returns the
- * PRINCIPAL where it claims to return a network id. Its sole consumer is the
- * `source_network` audit-annotation on `system.access.denied` (an observability
- * field, not an isolation decision), and the federation gate it feeds
- * (`evaluateFederationGate`) is itself ADR-mismatched + fails closed — so the
- * mislabelled value cannot WIDEN access; it only mis-tags the audit stream until
- * the cortex#686 lockstep reworks both onto the `{principal}.{stack}` grammar.
+ * Under ADR 0001 the network is NEVER on the wire: an inbound federated subject
+ * is `federated.{target-principal}.{stack}.…` where segment[1] is the RECEIVING
+ * principal. The source network is resolved from the source principal (the
+ * leading segment of `envelope.source`, via `principalFromEnvelope`) by finding
+ * the configured network whose `peers[]` lists that principal — the same
+ * `resolveSourceNetwork` topology lookup the federation gate uses. This keeps
+ * the `source_network` audit-annotation on `system.access.denied` correct under
+ * the conformant grammar instead of mis-tagging it with the receiving principal.
  *
- * IAW Phase D.3 (cortex#116) — derive the federation network id from
- * a NATS subject of the form `federated.{network_id}.<...>`. Returns
- * `undefined` for any other subject shape (including local dispatches
- * and undefined inputs).
+ * Returns the resolved network id, or `undefined` when:
+ *   - the envelope is not federated (`local.*` / `public.*` subjects, where the
+ *     engine skips the federation branch), or
+ *   - the source principal is in no configured network's `peers[]` (the
+ *     federation gate has already denied such an envelope before this is read).
  *
- * The `{network_id}` grammar matches `PolicyFederatedNetworkSchema.id`
- * — lowercase alphanumeric + hyphen, starting with a letter. A
- * subject whose second segment doesn't match this grammar yields
- * `undefined` (defensive — the schema rejects malformed network ids
- * at config-load, but the wire path could still surface unexpected
- * subjects).
- *
- * Examples:
- *   `federated.research-collab.tasks.code-review` → `"research-collab"`
- *   `federated.research-collab` → `undefined` (no trailing segments,
- *     not a dispatch subject)
- *   `local.metafactory.dispatch.task.received` → `undefined`
- *   `undefined` → `undefined`
+ * IAW Phase D.3 (cortex#116) — the consumer of this value is the engine's
+ * federation branch + the `system.access.denied` audit annotation.
  */
-function extractSourceNetwork(subject: string | undefined): string | undefined {
-  if (subject === undefined) return undefined;
-  const parts = subject.split(".");
-  if (parts.length < 3) return undefined;
-  if (parts[0] !== "federated") return undefined;
-  const networkId = parts[1];
-  if (networkId === undefined || networkId.length === 0) return undefined;
-  if (!LETTER_PREFIX_ID_REGEX.test(networkId)) return undefined;
-  return networkId;
+function extractSourceNetwork(
+  envelope: Envelope,
+  subject: string | undefined,
+  networksById: Map<string, PolicyFederatedNetwork>,
+): string | undefined {
+  // Only federated traffic carries a source network. Local/public dispatches
+  // leave it undefined so the engine skips the federation branch — same
+  // contract as the pre-ADR subject-prefix guard.
+  if (!subject?.startsWith("federated.")) {
+    return undefined;
+  }
+  const sourcePrincipal = principalFromEnvelope(envelope);
+  const resolved = resolveSourceNetwork(sourcePrincipal, networksById);
+  return resolved?.networkId;
 }
 
 /**

--- a/src/runner/review-pipeline.ts
+++ b/src/runner/review-pipeline.ts
@@ -75,7 +75,7 @@
  * consumer.
  */
 
-import type { Envelope } from "../bus/myelin/envelope-validator";
+import type { Classification, Envelope } from "../bus/myelin/envelope-validator";
 import {
   createReviewTaskFailedEvent,
   createReviewVerdictEvent,
@@ -228,6 +228,16 @@ export interface ReviewPipelineOpts {
    * (pilot-only / bus-peer / Offer path unchanged).
    */
   responseRouting?: AnyResponseRouting;
+  /**
+   * cortex#686 — sovereignty classification for the terminal envelopes the
+   * pipeline builds (`review.verdict.<kind>` + `dispatch.task.failed`).
+   * Defaults to `"local"` (the local review-consumer path, unchanged). The
+   * FEDERATED review consumer sets `"federated"` so the verdict + failed
+   * envelopes it routes back to a cross-principal requester declare federated
+   * sovereignty self-consistently with the `federated.*` subject they publish
+   * on. Threaded into both builders verbatim; the pipeline never inspects it.
+   */
+  classification?: Classification;
   /**
    * cortex#361 — optional lifecycle hook fired after the CC session is
    * constructed + `start()` is called, before `wait()` resolves. The
@@ -472,6 +482,10 @@ export async function runReviewPipeline(
       ...(opts.responseRouting !== undefined && {
         responseRouting: opts.responseRouting,
       }),
+      // cortex#686 — federated verdict declares federated sovereignty.
+      ...(opts.classification !== undefined && {
+        classification: opts.classification,
+      }),
       payload,
     });
   } catch (err) {
@@ -526,6 +540,10 @@ function failed(
     // review sink can render the error to the originating thread.
     ...(opts.responseRouting !== undefined && {
       responseRouting: opts.responseRouting,
+    }),
+    // cortex#686 — federated failed terminal declares federated sovereignty.
+    ...(opts.classification !== undefined && {
+      classification: opts.classification,
     }),
   });
   return { kind: "failed", envelope };


### PR DESCRIPTION
Closes #686
Refs #691 #669

## What

The cortex receiver that closes the cross-principal review loop. An inbound conformant `federated.{my-principal}.{my-stack}.tasks.code-review.>` review-request from a configured peer is **accepted → peers[]-gated → verified → routed to the local reviewer (Echo) → verdict published back keyed to the REQUESTER's identity** on `federated.{requester-principal}.{requester-stack}.{review.verdict.*|dispatch.task.*}`, so the peer's `pilot --wait` resolves instead of timing out (exit 124).

Built on **ADR-0002** (`docs/adr/0002-federated-dispatch-addressing-and-verdict-back.md`) on top of the **ADR-0001 grammar** (#691). The network is **never on the wire** — subjects carry `{principal}.{stack}`; the network is resolved from topology (`policy.federated.networks[].peers[]`). The **requester is carried in `originator`, not the subject** (the subject and `source` both address the TARGET).

## ⛔→✅ The two blockers the adversarial review found on #715 — now FIXED

### BLOCKER 1 — verdict misroute (requester read from the wrong source)
The old `parseFederatedRequester(subject)` derived the requester from the inbound subject's segment[1] — but per ADR-0001 that segment is the **RECEIVER's own identity**, so every verdict routed to **self** → `selectLink` found no peer leaf for our own principal → **never published** → the loop never closed.

**Fix (ADR-0002 §1+§3):** new `parseRequesterFromOriginator(envelope)` decodes the requester `{principal}.{stack}` from **`envelope.originator.identity`** — NOT the subject and NOT `source`. Fails closed when the originator is absent/malformed — never guesses a requester. The verdict + lifecycle publish via `runtime.publishOnSubject` on the requester-keyed `federated.{requester}.{stack}.{type}` subject; `selectLink` resolves the leaf from `peers[]`.

### BLOCKER 1b (loop-closer) — DID-encoding mismatch with pilot#149, now FIXED
ADR-0002 §1 + the original `parseRequesterFromOriginator` expected a **bare `{principal}/{stack}` slash form** in `originator.identity`. That's off-contract: **myelin validates `originator.identity` against the `did:mf:<name>` DID grammar, which rejects `/`** — so the slash-form decoder would fail closed on every real federated request and the loop would never close. Meanwhile **pilot#149 already encodes the requester correctly** (`encodeRequesterDid` → `did:mf:{principal}-{stack}`, e.g. `did:mf:andreas-main`).

**Fix:** the decode is now the **exact inverse of pilot's encode** (`did:mf:${principal}-${stack}` = `stack.id` with `/`→`-`, per cortex `src/cortex.ts:483`): require a `did:mf:` prefix, strip it, **split the remainder on the FIRST hyphen** into `{principal, stack}`. Principals carry no hyphen; **stacks may** (e.g. `did:mf:andreas-meta-factory` → principal `andreas` / stack `meta-factory`) — the first hyphen is the unambiguous boundary, the principal-no-hyphen assumption is stated explicitly in ADR-0002 §1. The bare slash form is **no longer accepted**; no `did:mf:` prefix or no hyphen → deny + drop. ADR-0002 §1 + worked example + §3 verdict-back line updated to match. This closes the cortex#686 ↔ pilot#149 lockstep mismatch.

### GAP 2 — peers[] gate not on the consumer path
The reworked gate (`resolveSourceNetwork`/`evaluateFederationGate`) ran only in surface-router/dispatch-listener, NOT in the federated `ReviewConsumer` that spawns the reviewer — so the headline AC ("a non-peer source is denied") wasn't enforced where the CC subprocess actually starts.

**Fix (ADR-0002 §5):** the federated `ReviewConsumer` now runs `federatedRequesterDenyReason(requester)` **BEFORE** spawning the reviewer. It resolves the **REQUESTER** principal (from `originator.identity`) via `resolveSourceNetwork` against `policy.federated.networks[].peers[]` and **denies + drops** (term, no CC spawn, no verdict, no lifecycle envelope) when the requester is (a) un-attributable, (b) a self-loop (requester principal == receiving principal), or (c) not a configured peer. Under `signing: off` this membership check is the application-layer trust boundary; under `enforce` the `signed_by` chain + signed `originator` add the crypto check. `cortex.ts` wires `federatedNetworks` from `policy.federated.networks`.

## Subjects (ADR-0002)

| | subject |
|---|---|
| **Subscribe (federated consumer)** | `federated.{my-principal}.{my-stack}.tasks.code-review.>` — this RECEIVING stack's own identity = the TARGET (ADR-0002 §2). The requester is NOT in the subject; it's in `originator`. |
| **Stream filter (CODE_REVIEW)** | extended to `[local.{me}.{stack}.tasks.code-review.>, federated.{me}.{stack}.tasks.code-review.>]` when federation is configured |
| **Verdict published** | `federated.{requester-principal}.{requester-stack}.review.verdict.{approved\|changes-requested\|commented}` |
| **Lifecycle published** | `federated.{requester-principal}.{requester-stack}.dispatch.task.{started\|completed\|failed\|aborted}` |

Verdict routing uses `runtime.publishOnSubject`; `selectLink` resolves the requester principal → leaf from `peers[]`.

## Gate rework (deferred from #691)

The inbound surface-router/dispatch-listener gate resolves the **source network from the source principal** (`resolveSourceNetwork` finds the network whose `peers[].principal_id` matches `principalFromEnvelope(envelope)`), `unknown_network` fires when the source principal is in no configured peer list, source-link anti-spoof checks the resolved network's `leaf_node`. (Inbound gate stays in the #691-breadcrumbed dormant-fail-closed state on main; the **consumer-path** peers[] gate above is the live boundary for federated review traffic.)

## Federated verify (TC-2d)

Reuses the existing `verifySignedByChain` seam (peer principal = `principalFromEnvelope(source)`, pubkey via registry) — grammar-agnostic, unchanged. The federated consumer is wired with the same per-agent `signatureVerifier` closure as the local consumer. Under `security.signing: off` (default) the seam is `undefined` → no-op; the consumer works in both off and enforce modes.

## Consumer / pipeline

- `ReviewConsumer` gains `federated` + `federatedNetworks`. In federated mode every emitted envelope is stamped `classification: "federated"` and routed via `publishOnSubject` on the **requester** subject. `safePublish` stays the single publish path (local `publish` / federated `publishOnSubject`) and the fail-closed-to-local backstop is retained for a runtime lacking `publishOnSubject` (disabled/stub — never a live wire). Local mode is byte-for-byte unchanged.
- `review-pipeline` threads `classification` onto the verdict + failed terminal envelopes.
- `cortex.ts` provisions a parallel per-agent federated durable and starts a second consumer with `federated: true` + the peer topology — only when a `federated:` policy block is declared.

## Tests (rewritten for ADR-0002)

The old fixtures modelled `federated.jc.sage-host.…` as the inbound subject (requester-in-subject) — **unreachable** per ADR-0002 (that subject would never match the receiver's JetStream filter). Rewritten so the inbound is `federated.{us}.{our-stack}.tasks.code-review.…` with `originator.identity = did:mf:{requester}-{stack}` (the DID form pilot#149 emits), asserting:

- the verdict + lifecycle publish to `federated.{requester}.{stack}.{review.verdict.*|dispatch.task.*}` (requester from originator);
- `parseRequesterFromOriginator` — DID form `did:mf:jc-sage-host` decodes via first-hyphen split; `did:mf:andreas-meta-factory` → `andreas`/`meta-factory` (multi-hyphen stack intact); a round-trip case asserts the decode is the **exact inverse** of pilot's `encodeRequesterDid`; no-originator / no-`did:mf:`-prefix (bare slash form) / no-hyphen / leading-/trailing-hyphen all fail closed; and it ignores subject + source;
- the **peers[] gate** denies + drops a non-peer requester, an un-attributable request, and a self-loop (no spawn, no publish);
- local mode byte-for-byte unchanged.

## Verification

- `bunx tsc --noEmit` — 0 errors
- `bun test src/bus/ src/runner/` — green (1040 pass, 0 fail); `review-consumer.test.ts` 68 pass
- full `bun test` — 0 fail (4407 pass, 2 skip)
- `eslint` on touched files — clean; `check-carveouts.sh` (vocab gate) — PASS
- CodeReview FederationGrammar lens — 5/5 PASS (FG-3 requester-in-originator-DID is the fix)

## ⚠️ LOCKSTEP — pilot#149 (cross-repo, NOT in this PR)

End-to-end requires **pilot#149** to EMIT per ADR-0002: `source` addressing the TARGET, `originator.identity = did:mf:{requester}-{stack}` (pilot's `encodeRequesterDid`), `--principal`/`--reviewer@p/s` replacing `--network`. **Cross-checked (read-only):** pilot#149's `encodeRequesterDid` (on `feat/pilot-148-peer-targeting`, `src/bus/publish-review-request.ts`) produces exactly `did:mf:${principal}-${stack}` = `stack.id` with `/`→`-` — this cortex decoder is its exact inverse (first-hyphen split). No pilot change needed. This cortex consumer is **unit-verified with synthetic inbound envelopes** only; merge in lockstep with pilot#149. The orchestrator adversarially reviews both before the lockstep merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
