### PR TITLE
feat(runner,bus): C-710 — per-skill grants via PreToolUse hook

### DIFF
--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -65,6 +65,15 @@ provides:
       target: ~/.claude/hooks/CortexEventLogger.hook.ts
     - source: src/runner/hooks/bash-guard.hook.ts
       target: ~/.claude/hooks/CortexBashGuard.hook.ts
+    # cortex#710 (C-701 Part B) — per-skill grant PreToolUse hook. Installed
+    # as a symlink ONLY (no `hooks:` entry below) so it is NEVER registered in
+    # the principal's GLOBAL settings.json — it would otherwise gate the
+    # principal's own Skill invocations. It is registered PER-SESSION in the
+    # curated `--settings` file (session-settings.ts) for bot sessions that
+    # carry skill grants. The symlink must exist so that curated file can
+    # reference the installed absolute path.
+    - source: src/runner/hooks/skill-guard.hook.ts
+      target: ~/.claude/hooks/CortexSkillGuard.hook.ts
     - source: src/taps/cc-events/hooks/lib
       target: ~/.claude/hooks/lib/cortex-events
 

--- a/src/bus/__tests__/dispatch-source-publisher.test.ts
+++ b/src/bus/__tests__/dispatch-source-publisher.test.ts
@@ -131,6 +131,7 @@ function baseOpts(
     resumeSessionId: undefined,
     allowedDirs: [],
     disallowedTools: [],
+    allowedSkills: undefined,
     timeoutMs: undefined,
     cwd: undefined,
     additionalArgs: undefined,
@@ -248,5 +249,36 @@ describe("dispatch-source-publisher — F-1b subject principal derivation (corte
 
     expect(result.published).toBe(true);
     expect(result.subject).toBe("local.holly.tasks.@did-mf-luna.chat");
+  });
+
+  // ── cortex#710 — per-skill grant list rides the payload `allowed_skills` ────
+
+  test("grants present → payload carries allowed_skills", async () => {
+    const runtime = makeRecordingRuntime();
+    await publishInboundChatDispatchEnvelope(
+      baseOpts(runtime, { allowedSkills: ["code-review"] }),
+    );
+    const payload = runtime.subjectPublishes[0]!.envelope.payload;
+    expect(payload.allowed_skills).toEqual(["code-review"]);
+  });
+
+  test("grants explicitly [] → payload carries the empty array (decided: no skills)", async () => {
+    const runtime = makeRecordingRuntime();
+    await publishInboundChatDispatchEnvelope(
+      baseOpts(runtime, { allowedSkills: [] }),
+    );
+    const payload = runtime.subjectPublishes[0]!.envelope.payload;
+    // Emitted even for [] so the runner distinguishes "no decision" (absent)
+    // from "decided: no skills".
+    expect(payload.allowed_skills).toEqual([]);
+  });
+
+  test("grants undefined → payload OMITS allowed_skills (no decision)", async () => {
+    const runtime = makeRecordingRuntime();
+    await publishInboundChatDispatchEnvelope(
+      baseOpts(runtime, { allowedSkills: undefined }),
+    );
+    const payload = runtime.subjectPublishes[0]!.envelope.payload;
+    expect("allowed_skills" in payload).toBe(false);
   });
 });

--- a/src/bus/dispatch-handler.ts
+++ b/src/bus/dispatch-handler.ts
@@ -450,6 +450,8 @@ export class DispatchHandler extends EventEmitter {
     resumeSessionId: string | undefined;
     allowedDirs: string[];
     disallowedTools: string[];
+    /** cortex#710 — per-skill grant list (see InboundChatDispatchPublishOpts). */
+    allowedSkills: string[] | undefined;
     timeoutMs: number | undefined;
     cwd: string | undefined;
     additionalArgs: string[] | undefined;
@@ -721,8 +723,23 @@ export class DispatchHandler extends EventEmitter {
       const effectiveDisallowed = access.toolRestrictions?.length
         ? access.toolRestrictions
         : [...new Set([...globalDisallowed, ...networkDisallowed])];
-      // G-121: If allowedSkills is explicitly empty, hard-block the Skill tool
-      if (access.allowedSkills?.length === 0 && !effectiveDisallowed.includes("Skill")) {
+
+      // cortex#710 (C-701 Part B) — default-deny + per-skill grants, FLIPPED
+      // ATOMICALLY from the legacy binary G-121 gate. The grant decision is
+      // `access.allowedSkills`:
+      //   - undefined / []  → NO skills. Hard-block the bare `Skill` tool
+      //     (the legacy-direct path consumes `effectiveDisallowed` straight
+      //     into CCSession; the bus path's harness also re-asserts this deny
+      //     as a backstop).
+      //   - [...]           → grant exactly those skills. Do NOT deny `Skill`:
+      //     the grant flows as `allowedSkills` to the session, which (a)
+      //     broadly ALLOWS the bare `Skill` tool and (b) registers the Skill
+      //     Guard PreToolUse hook that denies any skill ∉ the list. This is
+      //     the {broad Skill allow + gate hook} pair — never the broken
+      //     {`Skill(name)` allow + bare `Skill` deny} of the reverted #706.
+      const skillGrants = access.allowedSkills;
+      const hasSkillGrants = skillGrants !== undefined && skillGrants.length > 0;
+      if (!hasSkillGrants && !effectiveDisallowed.includes("Skill")) {
         effectiveDisallowed.push("Skill");
       }
       // G-500: Per-network claude overrides take precedence over global
@@ -764,6 +781,10 @@ export class DispatchHandler extends EventEmitter {
           resumeSessionId: existingSession?.sessionId,
           allowedDirs: invokeDirs,
           disallowedTools: effectiveDisallowed,
+          // cortex#710 — carry the grant decision so the runner harness
+          // applies {broad Skill allow + gate hook} for grants, default-deny
+          // otherwise. `access.allowedSkills` is undefined → field omitted.
+          allowedSkills: skillGrants,
           timeoutMs: this.config.claude.timeoutMs,
           cwd: effectiveCwd,
           additionalArgs: this.config.claude.additionalArgs,
@@ -789,13 +810,13 @@ export class DispatchHandler extends EventEmitter {
       // 12. Route by mode
       switch (parsed.mode) {
         case "async":
-          await this.handleAsync(adapter, msg, prompt, existingSession?.sessionId, invokeDirs, effectiveDisallowed, attachmentSessionId, sessionKey, bashGuardDisabled, effectiveBashAllowlist, effectiveGroveChannel, effectiveGroveNetwork, groveProject, groveEntity, principal, effectiveCwd);
+          await this.handleAsync(adapter, msg, prompt, existingSession?.sessionId, invokeDirs, effectiveDisallowed, attachmentSessionId, sessionKey, bashGuardDisabled, effectiveBashAllowlist, effectiveGroveChannel, effectiveGroveNetwork, groveProject, groveEntity, principal, effectiveCwd, skillGrants);
           break;
         case "team":
-          await this.handleTeam(adapter, msg, parsed.content, invokeDirs, effectiveDisallowed, bashGuardDisabled, effectiveBashAllowlist, effectiveGroveChannel, effectiveGroveNetwork, groveProject, groveEntity, principal, effectiveCwd);
+          await this.handleTeam(adapter, msg, parsed.content, invokeDirs, effectiveDisallowed, bashGuardDisabled, effectiveBashAllowlist, effectiveGroveChannel, effectiveGroveNetwork, groveProject, groveEntity, principal, effectiveCwd, skillGrants);
           break;
         default:
-          await this.handleSync(adapter, msg, prompt, existingSession?.sessionId, invokeDirs, effectiveDisallowed, attachmentSessionId, sessionKey, useSession, bashGuardDisabled, effectiveBashAllowlist, effectiveGroveChannel, effectiveGroveNetwork, groveProject, groveEntity, principal, effectiveCwd);
+          await this.handleSync(adapter, msg, prompt, existingSession?.sessionId, invokeDirs, effectiveDisallowed, attachmentSessionId, sessionKey, useSession, bashGuardDisabled, effectiveBashAllowlist, effectiveGroveChannel, effectiveGroveNetwork, groveProject, groveEntity, principal, effectiveCwd, skillGrants);
           break;
       }
     } catch (error) {
@@ -831,6 +852,8 @@ export class DispatchHandler extends EventEmitter {
     groveEntity?: string,
     principal?: string,
     cwd?: string,
+    /** cortex#710 — per-skill grant list ([...] → grants; undefined/[] → none). */
+    allowedSkills?: string[],
   ): Promise<void> {
     const target = this.targetFromMsg(adapter, msg);
 
@@ -871,6 +894,7 @@ export class DispatchHandler extends EventEmitter {
       resumeSessionId,
       allowedTools: this.config.claude.allowedTools,
       disallowedTools,
+      ...(allowedSkills !== undefined && { allowedSkills }),
       allowedDirs: invokeDirs.length > 0 ? invokeDirs : undefined,
       cwd,
       bashAllowlist,
@@ -1165,6 +1189,8 @@ export class DispatchHandler extends EventEmitter {
     groveEntity?: string,
     principal?: string,
     cwd?: string,
+    /** cortex#710 — per-skill grant list ([...] → grants; undefined/[] → none). */
+    allowedSkills?: string[],
   ): Promise<void> {
     const taskId = `task-${randomUUID()}`;
 
@@ -1186,6 +1212,7 @@ export class DispatchHandler extends EventEmitter {
       resumeSessionId,
       allowedTools: this.config.claude.allowedTools,
       disallowedTools,
+      ...(allowedSkills !== undefined && { allowedSkills }),
       allowedDirs: invokeDirs.length > 0 ? invokeDirs : undefined,
       cwd,
       project: groveProject,
@@ -1294,6 +1321,8 @@ export class DispatchHandler extends EventEmitter {
     groveEntity?: string,
     principal?: string,
     _cwd?: string,
+    /** cortex#710 — per-skill grant list ([...] → grants; undefined/[] → none). */
+    allowedSkills?: string[],
   ): Promise<void> {
     const taskId = `team-${randomUUID()}`;
 
@@ -1316,6 +1345,7 @@ export class DispatchHandler extends EventEmitter {
       additionalArgs: this.config.claude.additionalArgs,
       allowedTools: this.config.claude.allowedTools,
       disallowedTools,
+      ...(allowedSkills !== undefined && { allowedSkills }),
       allowedDirs: invokeDirs.length > 0 ? invokeDirs : undefined,
       timeoutMs: this.config.claude.asyncTimeoutMs,
       bashGuardDisabled,

--- a/src/bus/dispatch-source-publisher.ts
+++ b/src/bus/dispatch-source-publisher.ts
@@ -30,6 +30,15 @@ export interface InboundChatDispatchPublishOpts {
   resumeSessionId: string | undefined;
   allowedDirs: string[];
   disallowedTools: string[];
+  /**
+   * cortex#710 — per-skill grant list. `undefined` → omit `allowed_skills`
+   * from the payload (the runner harness applies default-deny: no Skill
+   * tool). `[]` → explicit no-skills. `[...]` → grant exactly those skills
+   * via the runner's Skill Guard PreToolUse hook. The dispatch-handler maps
+   * `AccessDecision.allowedSkills` here; the gateway leaves it `undefined`
+   * (it grants nothing — see bus-inbound-sink.ts).
+   */
+  allowedSkills: string[] | undefined;
   timeoutMs: number | undefined;
   cwd: string | undefined;
   additionalArgs: string[] | undefined;
@@ -220,6 +229,12 @@ export async function publishInboundChatDispatchEnvelope(
     }),
     ...(opts.disallowedTools.length > 0 && {
       disallowed_tools: opts.disallowedTools,
+    }),
+    // cortex#710 — carry the per-skill grant list when the source decided
+    // one. Emitted even for `[]` (explicit no-skills) so the runner can
+    // distinguish "no decision" (field absent) from "decided: no skills".
+    ...(opts.allowedSkills !== undefined && {
+      allowed_skills: opts.allowedSkills,
     }),
     ...(opts.allowedDirs.length > 0 && { allowed_dirs: opts.allowedDirs }),
     ...(opts.timeoutMs !== undefined && { timeout_ms: opts.timeoutMs }),

--- a/src/common/substrates/types.ts
+++ b/src/common/substrates/types.ts
@@ -359,6 +359,24 @@ export interface DispatchRequest {
    */
   tools: ToolCapability;
   /**
+   * cortex#710 — per-skill grant list. Distinct from `tools`: skills are a
+   * Claude-Code-specific capability gated by a PreToolUse hook, not by the
+   * `allowedTools`/`disallowedTools` permission lists (Claude Code's `Skill`
+   * tool has no `Skill(<name>)` specifier syntax, so the grant can't be
+   * expressed as a tool rule — see cortex#706/#710).
+   *
+   * Semantics, mirroring `AccessDecision.allowedSkills`:
+   *   - `undefined` → no decision carried; the harness applies its default
+   *     (which, for the CC harness, is the default-deny `disallowedTools:
+   *     ["Skill"]` posture — no skills).
+   *   - `[]` → explicit default-deny: no skills (no Skill tool).
+   *   - `[...]` → grant exactly those skills via the Skill Guard PreToolUse
+   *     hook + a broad `Skill` allow.
+   *
+   * Non-CC harnesses (bus-peer, future) ignore this field.
+   */
+  allowedSkills?: string[];
+  /**
    * Pluggable context bundle. The runner attaches whatever the agent's
    * trigger source produced (Discord message history, GitHub PR diffs,
    * attachments, environment hints). The harness handles whichever

--- a/src/gateway/bus-inbound-sink.ts
+++ b/src/gateway/bus-inbound-sink.ts
@@ -171,10 +171,17 @@ export class BusInboundSink implements GatewayInboundSink {
       // Without this, an envelope carrying empty allow/deny lists spawns a
       // session where the `Skill` tool is AVAILABLE BY DEFAULT (verified,
       // CLI 2.1.158) — a fail-open hole on the gateway path. Fail-closed.
-      // Per-skill grants on this path are the cortex#701 Part B follow-up
-      // (PreToolUse-hook design); until it lands the gateway path has no
-      // skills, by design.
       disallowedTools: ["Skill"],
+      // cortex#710 — the per-skill grant mechanism now exists (PreToolUse
+      // hook + broad `Skill` allow, applied when `allowedSkills` is a
+      // non-empty list). The gateway is a thin demux that grants NOTHING, so
+      // it leaves `allowedSkills` undefined → the runner harness keeps the
+      // default-deny posture and the bare `Skill` deny above stays in force.
+      // If/when a gateway binding is given an explicit skill grant set (a
+      // future config-split #5 concern), THIS is the field to populate; the
+      // bound stack's harness would then apply the hook-based grant exactly
+      // as the per-stack dispatch path does. Until then: no skills, by design.
+      allowedSkills: undefined,
       // Optional opts — the gateway does not own these; the bound stack applies
       // its own policy and session context.
       resumeSessionId: undefined,

--- a/src/runner/__tests__/cc-session-isolation.test.ts
+++ b/src/runner/__tests__/cc-session-isolation.test.ts
@@ -13,6 +13,7 @@
  */
 
 import { describe, test, expect, spyOn, afterEach } from "bun:test";
+import { readFileSync } from "fs";
 import { CCSession } from "../cc-session";
 
 interface Captured {
@@ -105,6 +106,126 @@ describe("CCSession — settings isolation (default ON)", () => {
       process.env.CLAUDE_HOOKS_PATH = prev.CLAUDE_HOOKS_PATH;
       if (prev.CLAUDE_CODE_EXTRA_SETTINGS === undefined) delete process.env.CLAUDE_CODE_EXTRA_SETTINGS;
       if (prev.CLAUDE_HOOKS_PATH === undefined) delete process.env.CLAUDE_HOOKS_PATH;
+    }
+  });
+});
+
+describe("CCSession — per-skill grants (cortex#710)", () => {
+  /**
+   * Capturing spy that ALSO reads the curated `--settings` file content at
+   * spawn time — before it throws (which triggers CCSession's catch path,
+   * which cleans up the temp dir). So we snapshot the file while it exists.
+   */
+  function captureSpawnWithSettings(): {
+    calls: (Captured & { settings: unknown })[];
+    restore: () => void;
+  } {
+    const calls: (Captured & { settings: unknown })[] = [];
+    const spy = spyOn(Bun, "spawn").mockImplementation(((
+      cmd: string[],
+      opts: { env: Record<string, string> },
+    ) => {
+      const idx = cmd.indexOf("--settings");
+      const settings =
+        idx > -1 ? JSON.parse(readFileSync(cmd[idx + 1]!, "utf8")) : undefined;
+      calls.push({ cmd, env: opts.env, settings });
+      throw new Error("spawn intercepted by test");
+    }) as unknown as typeof Bun.spawn);
+    return { calls, restore: () => spy.mockRestore() };
+  }
+
+  const skillEntry = (settings: {
+    hooks: { PreToolUse: { matcher?: string }[] };
+  }) => settings.hooks.PreToolUse.find((e) => e.matcher === "Skill");
+
+  test("WITH grants → curated file registers the Skill hook + CORTEX_SKILL_GRANTS env set", () => {
+    const { calls, restore } = captureSpawnWithSettings();
+    try {
+      const session = new CCSession({
+        prompt: "hi",
+        groveChannel: "test",
+        claudeDir: "/fake/.claude",
+        allowedSkills: ["code-review"],
+      });
+      session.on("error", () => {/* expected */});
+      session.start();
+
+      expect(calls.length).toBe(1);
+      const skill = skillEntry(calls[0]!.settings as never) as
+        | { hooks: { command: string }[] }
+        | undefined;
+      expect(skill).toBeDefined();
+      expect(skill!.hooks[0]!.command).toContain("CortexSkillGuard.hook.ts");
+      // The grant list reaches the hook via env, as a JSON array.
+      expect(calls[0]!.env.CORTEX_SKILL_GRANTS).toBe(JSON.stringify(["code-review"]));
+    } finally {
+      restore();
+    }
+  });
+
+  test("NO grants → no Skill hook + no CORTEX_SKILL_GRANTS env (default-deny path)", () => {
+    const { calls, restore } = captureSpawnWithSettings();
+    try {
+      const session = new CCSession({
+        prompt: "hi",
+        groveChannel: "test",
+        claudeDir: "/fake/.claude",
+        // no allowedSkills
+      });
+      session.on("error", () => {/* expected */});
+      session.start();
+
+      expect(skillEntry(calls[0]!.settings as never)).toBeUndefined();
+      expect(calls[0]!.env.CORTEX_SKILL_GRANTS).toBeUndefined();
+    } finally {
+      restore();
+    }
+  });
+
+  test("grants normalise tool lists: Skill added to a non-empty allowlist, stripped from deny", () => {
+    const { calls, restore } = captureSpawnWithSettings();
+    try {
+      const session = new CCSession({
+        prompt: "hi",
+        groveChannel: "test",
+        claudeDir: "/fake/.claude",
+        allowedSkills: ["code-review"],
+        allowedTools: ["Bash", "Read"],
+        disallowedTools: ["Skill", "WebFetch"],
+      });
+      session.on("error", () => {/* expected */});
+      session.start();
+
+      const argv = calls[0]!.cmd;
+      const allowedIdx = argv.indexOf("--allowedTools");
+      const disallowedIdx = argv.indexOf("--disallowedTools");
+      // Skill is broadly allowed (the hook is the real gate)…
+      expect(argv[allowedIdx + 1]).toContain("Skill");
+      // …and NOT in the deny list (the broken intermediate state).
+      expect(argv[disallowedIdx + 1]).not.toContain("Skill");
+      // unrelated deny survives
+      expect(argv[disallowedIdx + 1]).toContain("WebFetch");
+    } finally {
+      restore();
+    }
+  });
+
+  test("empty grants array → treated as no grants (no hook, no env)", () => {
+    const { calls, restore } = captureSpawnWithSettings();
+    try {
+      const session = new CCSession({
+        prompt: "hi",
+        groveChannel: "test",
+        claudeDir: "/fake/.claude",
+        allowedSkills: [],
+      });
+      session.on("error", () => {/* expected */});
+      session.start();
+
+      expect(skillEntry(calls[0]!.settings as never)).toBeUndefined();
+      expect(calls[0]!.env.CORTEX_SKILL_GRANTS).toBeUndefined();
+    } finally {
+      restore();
     }
   });
 });

--- a/src/runner/__tests__/dispatch-listener.test.ts
+++ b/src/runner/__tests__/dispatch-listener.test.ts
@@ -648,7 +648,10 @@ describe("dispatch-listener — success path", () => {
     expect(opts.agentName).toBe("Cortex");
     expect(opts.agentId).toBe("cortex"); // sourced from payload.agent_id
     expect(opts.allowedTools).toEqual(["Read", "Edit"]);
-    expect(opts.disallowedTools).toEqual(["Bash"]);
+    // cortex#710 — no allowed_skills on the payload → harness appends the
+    // default-deny `Skill` alongside the payload's `Bash` deny.
+    expect(opts.disallowedTools).toEqual(["Bash", "Skill"]);
+    expect(opts.allowedSkills).toBeUndefined();
     expect(opts.allowedDirs).toEqual(["/tmp"]);
     expect(opts.timeoutMs).toBe(60_000);
     expect(opts.cwd).toBe("/tmp");
@@ -657,6 +660,38 @@ describe("dispatch-listener — success path", () => {
     expect(opts.entity).toBe("issue/12");
     expect(opts.principal).toBe("andreas");
     expect(opts.resumeSessionId).toBe("prior-session");
+  });
+
+  test("allowed_skills round-trips payload → harness → CCSessionOpts (cortex#710)", async () => {
+    // The grant decision rides the payload's `allowed_skills`; the harness
+    // turns it into {broad Skill allow + allowedSkills (→ gate hook)} —
+    // never the broken {Skill(name) allow + bare Skill deny}.
+    const r = recordingRuntime();
+    const router = createSurfaceRouter(r.runtime);
+    const { factory, optsCaptured } = fakeFactory(SUCCESS_RESULT);
+    const listener = createDispatchListener({
+      runtime: r.runtime,
+      source: SOURCE,
+      ccSessionFactory: factory,
+      policyEngine: engineGranting(["dispatch.cortex"]),
+    });
+    await listener.start();
+    await router.start();
+
+    r.trigger(
+      makeReceivedEnvelope({
+        prompt: "review the PR",
+        allowed_skills: ["code-review"],
+      }),
+      CANONICAL_CORTEX_CHAT_SUBJECT,
+    );
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(optsCaptured).toHaveLength(1);
+    const opts = optsCaptured[0]!;
+    expect(opts.allowedSkills).toEqual(["code-review"]);
+    expect(opts.allowedTools ?? []).toContain("Skill");
+    expect(opts.disallowedTools ?? []).not.toContain("Skill");
   });
 
   test("agent_name falls back to agent_id when omitted (A.1b flip)", async () => {
@@ -723,7 +758,11 @@ describe("dispatch-listener — success path", () => {
     expect(opts.entity).toBeUndefined();
     expect(opts.project).toBeUndefined();
     expect(opts.allowedTools).toBeUndefined();
-    expect(opts.disallowedTools).toBeUndefined();
+    // cortex#710 — even a bare payload (no allowed_skills) gets the
+    // harness's default-deny `Skill` so the session has no Skill tool. This
+    // is the only knob the flip adds to an otherwise-minimal opts.
+    expect(opts.disallowedTools).toEqual(["Skill"]);
+    expect(opts.allowedSkills).toBeUndefined();
   });
 
   test("delegate distribution mode routes to AgentTeamHarness", async () => {

--- a/src/runner/__tests__/session-settings.test.ts
+++ b/src/runner/__tests__/session-settings.test.ts
@@ -69,6 +69,60 @@ describe("buildCuratedSettings — cortex's own hooks only", () => {
   });
 });
 
+describe("buildCuratedSettings — per-skill grant hook (cortex#710)", () => {
+  interface Curated {
+    hooks: Record<string, { matcher?: string; hooks: { command: string }[] }[]>;
+  }
+
+  const skillHook = (s: Curated) =>
+    s.hooks.PreToolUse!.find((e) => e.matcher === "Skill");
+
+  test("NO grants → no Skill hook registered (default-deny lives in disallowedTools)", () => {
+    expect(skillHook(buildCuratedSettings("/fake/.claude") as unknown as Curated)).toBeUndefined();
+    expect(
+      skillHook(buildCuratedSettings("/fake/.claude", []) as unknown as Curated),
+    ).toBeUndefined();
+  });
+
+  test("WITH grants → Skill Guard hook registered under the Skill matcher", () => {
+    const s = buildCuratedSettings("/fake/.claude", ["code-review"]) as unknown as Curated;
+    const entry = skillHook(s);
+    expect(entry).toBeDefined();
+    expect(entry!.hooks[0]!.command).toMatch(/\/hooks\/CortexSkillGuard\.hook\.ts$/);
+  });
+
+  test("the Bash guard is ALWAYS present, with or without grants", () => {
+    for (const grants of [undefined, [], ["code-review"]]) {
+      const s = buildCuratedSettings("/fake/.claude", grants) as unknown as Curated;
+      const bash = s.hooks.PreToolUse!.find((e) => e.matcher === "Bash");
+      expect(bash).toBeDefined();
+      expect(bash!.hooks[0]!.command).toContain("CortexBashGuard.hook.ts");
+    }
+  });
+
+  test("grant list is NOT baked into the settings file (it rides the env var)", () => {
+    // The grant names travel via CORTEX_SKILL_GRANTS, not the curated file —
+    // the file only registers the gate hook. Asserting the skill NAME is
+    // absent keeps the two channels separate (the hook reads the env).
+    const s = buildCuratedSettings("/fake/.claude", ["code-review"]);
+    expect(JSON.stringify(s)).not.toContain("code-review");
+  });
+
+  test("createIsolatedSettings threads grants into the written file", () => {
+    const iso = createIsolatedSettings("/fake/.claude", ["code-review"]);
+    try {
+      const written = JSON.parse(readFileSync(iso.settingsPath, "utf8"));
+      const skill = written.hooks.PreToolUse.find(
+        (e: { matcher?: string }) => e.matcher === "Skill",
+      );
+      expect(skill).toBeDefined();
+      expect(skill.hooks[0].command).toContain("CortexSkillGuard.hook.ts");
+    } finally {
+      iso.cleanup();
+    }
+  });
+});
+
 describe("createIsolatedSettings — materialised file + args", () => {
   test("writes a settings file and emits the isolation args", () => {
     const iso = createIsolatedSettings("/fake/.claude");

--- a/src/runner/agent-team.ts
+++ b/src/runner/agent-team.ts
@@ -115,6 +115,14 @@ export interface AgentTeamOpts {
   additionalArgs?: string[];
   allowedTools?: string[];
   disallowedTools?: string[];
+  /**
+   * cortex#710 — per-skill grant list, propagated to ALL team sessions
+   * (moderator + participants + synthesis) so a granted team inherits the
+   * Skill Guard PreToolUse hook + broad `Skill` allow like any other
+   * session. Undefined/empty → no skills (default-deny). Per-participant
+   * skill overrides are out of scope; the whole team shares the grant set.
+   */
+  allowedSkills?: string[];
   allowedDirs?: string[];
   timeoutMs?: number;
   /** Bash guard config — propagated to all team sessions (moderator + participants) */
@@ -565,6 +573,7 @@ export class AgentTeam extends EventEmitter {
       additionalArgs: this.opts.additionalArgs,
       allowedTools: this.opts.allowedTools,
       disallowedTools: this.opts.disallowedTools,
+      ...(this.opts.allowedSkills !== undefined && { allowedSkills: this.opts.allowedSkills }),
       allowedDirs: this.opts.allowedDirs,
       timeoutMs: this.opts.timeoutMs ?? 900_000,
       bashGuardDisabled: this.opts.bashGuardDisabled,
@@ -674,6 +683,7 @@ export class AgentTeam extends EventEmitter {
       additionalArgs: this.opts.additionalArgs,
       allowedTools: config.allowedTools ?? this.opts.allowedTools,
       disallowedTools: config.disallowedTools ?? this.opts.disallowedTools,
+      ...(this.opts.allowedSkills !== undefined && { allowedSkills: this.opts.allowedSkills }),
       allowedDirs: config.dirs ?? this.opts.allowedDirs,
       timeoutMs: this.opts.timeoutMs ?? 900_000,
       bashGuardDisabled: this.opts.bashGuardDisabled,
@@ -846,6 +856,7 @@ export class AgentTeam extends EventEmitter {
       additionalArgs: this.opts.additionalArgs,
       allowedTools: this.opts.allowedTools,
       disallowedTools: this.opts.disallowedTools,
+      ...(this.opts.allowedSkills !== undefined && { allowedSkills: this.opts.allowedSkills }),
       allowedDirs: this.opts.allowedDirs,
       timeoutMs: this.opts.timeoutMs ?? 900_000,
       bashGuardDisabled: this.opts.bashGuardDisabled,

--- a/src/runner/cc-session.ts
+++ b/src/runner/cc-session.ts
@@ -9,7 +9,12 @@ import { EventEmitter } from "events";
 import { homedir } from "os";
 import { parseStreamLine, StreamLineBuffer, type UsageStats, type StreamEvent } from "./stream-parser";
 import { buildClaudeArgs, type ClaudeInvocationOpts } from "./claude-invoker";
-import { createIsolatedSettings, scopeSessionEnv, type IsolatedSettings } from "./session-settings";
+import {
+  createIsolatedSettings,
+  scopeSessionEnv,
+  CORTEX_SKILL_GRANTS_ENV,
+  type IsolatedSettings,
+} from "./session-settings";
 
 // Re-export for convenience
 export type { UsageStats, StreamEvent };
@@ -60,6 +65,23 @@ export interface CCSessionOpts {
    * tests can point at a fixture dir; production leaves it unset.
    */
   claudeDir?: string;
+  /**
+   * cortex#710 (Part B) — per-skill grant list for this session. When
+   * NON-EMPTY, the curated settings file registers the Skill Guard
+   * PreToolUse hook (matcher `Skill`), the bare `Skill` tool is broadly
+   * allowed, and this list is passed to the hook via the
+   * `CORTEX_SKILL_GRANTS` env var so it denies any skill ∉ the list.
+   *
+   * When `undefined`/empty, no Skill hook is registered and the caller is
+   * expected to keep `disallowedTools: ["Skill"]` (default-deny, no Skill
+   * tool). Set together as an atomic pair by the dispatch path — never
+   * {`Skill(name)` allow + bare `Skill` deny}, which is broken (cortex#706).
+   *
+   * Only honoured when `settingsIsolation` is on (the default). A
+   * principal-as-self session (`settingsIsolation:false`) inherits the
+   * principal's full skill set and does not register the gate.
+   */
+  allowedSkills?: string[];
 }
 
 export interface CCSessionResult {
@@ -123,12 +145,42 @@ export class CCSession extends EventEmitter {
     // are appended to additionalArgs so they sit before `-p <prompt>`
     // (buildClaudeArgs puts the prompt last).
     const isolate = this.opts.settingsIsolation !== false;
+    // cortex#710 — per-skill grants. Non-empty → curated settings registers
+    // the Skill Guard hook AND the grant list is exported to it via env. The
+    // two MUST move together (the #706 atomicity lesson).
+    const skillGrants = this.opts.allowedSkills;
+    const hasSkillGrants =
+      isolate && skillGrants !== undefined && skillGrants.length > 0;
     const isolationArgs: string[] = [];
     if (isolate) {
       this.isolatedSettings = createIsolatedSettings(
         this.opts.claudeDir ?? `${homedir()}/.claude`,
+        skillGrants,
       );
       isolationArgs.push(...this.isolatedSettings.args);
+    }
+
+    // cortex#710 — when grants are present, the bare `Skill` tool must be
+    // PERMITTED at the permission layer so the Skill Guard hook (registered
+    // in the curated settings) is the real gate. Normalise the tool lists
+    // here so CCSession is self-consistent regardless of which caller built
+    // them (harness pre-pairs them; the dispatch-handler direct paths rely on
+    // this). Strip any `Skill` deny, and add `Skill` to a NON-EMPTY allowlist
+    // that lacks it (an empty allowlist means "no --allowedTools flag →
+    // allow-by-default", which already permits the bare Skill tool).
+    let effectiveAllowedTools = this.opts.allowedTools;
+    let effectiveDisallowedTools = this.opts.disallowedTools;
+    if (hasSkillGrants) {
+      if (effectiveDisallowedTools?.includes("Skill")) {
+        effectiveDisallowedTools = effectiveDisallowedTools.filter((t) => t !== "Skill");
+      }
+      if (
+        effectiveAllowedTools !== undefined &&
+        effectiveAllowedTools.length > 0 &&
+        !effectiveAllowedTools.includes("Skill")
+      ) {
+        effectiveAllowedTools = [...effectiveAllowedTools, "Skill"];
+      }
     }
 
     // Build args from existing buildClaudeArgs, then inject stream-json
@@ -137,8 +189,8 @@ export class CCSession extends EventEmitter {
       groveChannel: this.opts.groveChannel,
       groveNetwork: this.opts.groveNetwork,
       resumeSessionId: this.opts.resumeSessionId,
-      allowedTools: this.opts.allowedTools,
-      disallowedTools: this.opts.disallowedTools,
+      allowedTools: effectiveAllowedTools,
+      disallowedTools: effectiveDisallowedTools,
       allowedDirs: this.opts.allowedDirs,
       additionalArgs: [
         "--verbose",
@@ -169,6 +221,14 @@ export class CCSession extends EventEmitter {
       ...(this.opts.project && { GROVE_PROJECT: this.opts.project }),
       ...(this.opts.entity && { GROVE_ENTITY: this.opts.entity }),
       ...(this.opts.principal && { GROVE_OPERATOR: this.opts.principal }),
+      // cortex#710 — pass the per-skill grant list to the Skill Guard hook.
+      // Only set when the curated settings actually registered the hook
+      // (hasSkillGrants), so the env var and the hook move atomically. Layered
+      // here (after scopeSessionEnv) alongside cortex's other pipeline vars; it
+      // is not a CLAUDE_* var so scoping passes it through regardless.
+      ...(hasSkillGrants && {
+        [CORTEX_SKILL_GRANTS_ENV]: JSON.stringify(skillGrants),
+      }),
     };
 
     // Pass bash allowlist config to bash-guard.hook.ts

--- a/src/runner/dispatch-listener.ts
+++ b/src/runner/dispatch-listener.ts
@@ -190,6 +190,12 @@ export interface DispatchTaskReceivedPayload {
   resume_session_id?: string;
   allowed_tools?: string[];
   disallowed_tools?: string[];
+  /**
+   * cortex#710 — per-skill grant list. `undefined` → harness default
+   * (default-deny, no Skill tool); `[]` → explicit no-skills; `[...]` →
+   * grant exactly those skills via the Skill Guard PreToolUse hook.
+   */
+  allowed_skills?: string[];
   allowed_dirs?: string[];
   timeout_ms?: number;
   cwd?: string;
@@ -1035,6 +1041,11 @@ function buildDispatchRequest(
   const req: DispatchRequest = {
     prompt: payload.prompt,
     tools,
+    // cortex#710 — per-skill grants ride the payload's `allowed_skills`.
+    // Omitted when the payload didn't carry it (→ harness default-deny).
+    ...(payload.allowed_skills !== undefined && {
+      allowedSkills: payload.allowed_skills,
+    }),
     context: hasEnvContext ? [{ kind: "env", data: envContext }] : [],
     agent: {
       id: payload.agent_id,

--- a/src/runner/hooks/__tests__/skill-guard.hook.test.ts
+++ b/src/runner/hooks/__tests__/skill-guard.hook.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Tests for the Cortex Skill Guard PreToolUse hook (cortex#710, C-701 Part B).
+ *
+ * Two layers:
+ *   - PURE logic (parseGrantList / extractSkillName / decideSkill) — the
+ *     name-extraction + allow/deny decision, exercised directly.
+ *   - PROCESS behaviour — spawn the hook with a Skill tool-call payload on
+ *     stdin and assert the exit code + stdout decision:
+ *       * granted skill → exit 0, {"continue":true}
+ *       * un-granted skill → exit 2, structured PreToolUse deny
+ *       * no/empty grant list → deny (fail-closed)
+ *       * malformed payload → deny (fail-closed)
+ */
+
+import { describe, test, expect } from "bun:test";
+import { spawnSync } from "child_process";
+import { join } from "path";
+import {
+  parseGrantList,
+  extractSkillName,
+  decideSkill,
+} from "../skill-guard.hook";
+
+const HOOK_PATH = join(import.meta.dir, "..", "skill-guard.hook.ts");
+
+interface RunResult {
+  status: number | null;
+  stdout: string;
+}
+
+/** Run the hook with a tool-call payload on stdin + a grant-list env. */
+function runHook(
+  payload: Record<string, unknown> | string,
+  grants: string | undefined,
+): RunResult {
+  // Build a clean env: start from process.env, drop any inherited grant var,
+  // then apply this test's value (undefined → unset).
+  const merged: Record<string, string> = {};
+  for (const [k, v] of Object.entries(process.env)) {
+    if (v !== undefined && k !== "CORTEX_SKILL_GRANTS") merged[k] = v;
+  }
+  if (grants !== undefined) merged.CORTEX_SKILL_GRANTS = grants;
+
+  const input = typeof payload === "string" ? payload : JSON.stringify(payload);
+  const result = spawnSync("bun", [HOOK_PATH], {
+    encoding: "utf-8",
+    input,
+    env: merged,
+  });
+  return { status: result.status, stdout: result.stdout };
+}
+
+// ---------------------------------------------------------------------------
+// Pure logic
+// ---------------------------------------------------------------------------
+
+describe("parseGrantList — fail-closed parsing", () => {
+  test("parses a JSON array of skill names", () => {
+    expect(parseGrantList('["code-review","art"]')).toEqual(["code-review", "art"]);
+  });
+
+  test("undefined env → empty (deny-all)", () => {
+    expect(parseGrantList(undefined)).toEqual([]);
+  });
+
+  test("empty string → empty (deny-all)", () => {
+    expect(parseGrantList("")).toEqual([]);
+  });
+
+  test("malformed JSON → empty (deny-all, never widens access)", () => {
+    expect(parseGrantList("not json")).toEqual([]);
+  });
+
+  test("non-array JSON → empty (deny-all)", () => {
+    expect(parseGrantList('{"skill":"code-review"}')).toEqual([]);
+    expect(parseGrantList('"code-review"')).toEqual([]);
+  });
+
+  test("filters non-string members", () => {
+    expect(parseGrantList('["code-review",42,null,"art"]')).toEqual([
+      "code-review",
+      "art",
+    ]);
+  });
+});
+
+describe("extractSkillName — name extraction from the Skill tool input", () => {
+  test("reads tool_input.skill for tool_name 'Skill'", () => {
+    expect(
+      extractSkillName({ tool_name: "Skill", tool_input: { skill: "code-review" } }),
+    ).toBe("code-review");
+  });
+
+  test("accepts the lowercase 'skill' tool name", () => {
+    expect(
+      extractSkillName({ tool_name: "skill", tool_input: { skill: "art" } }),
+    ).toBe("art");
+  });
+
+  test("tolerates a raw-string tool_input", () => {
+    expect(extractSkillName({ tool_name: "Skill", tool_input: "code-review" })).toBe(
+      "code-review",
+    );
+  });
+
+  test("non-Skill tool → null (this hook governs only Skill)", () => {
+    expect(
+      extractSkillName({ tool_name: "Bash", tool_input: { skill: "code-review" } }),
+    ).toBeNull();
+  });
+
+  test("missing tool_name → null", () => {
+    expect(extractSkillName({ tool_input: { skill: "code-review" } })).toBeNull();
+  });
+
+  test("empty / whitespace skill name → null", () => {
+    expect(extractSkillName({ tool_name: "Skill", tool_input: { skill: "  " } })).toBeNull();
+    expect(extractSkillName({ tool_name: "Skill", tool_input: {} })).toBeNull();
+  });
+});
+
+describe("decideSkill — allow/deny decision", () => {
+  test("granted name → allow", () => {
+    expect(decideSkill("code-review", ["code-review"]).allow).toBe(true);
+  });
+
+  test("un-granted name → deny with a reason naming the skill + grant list", () => {
+    const d = decideSkill("art", ["code-review"]);
+    expect(d.allow).toBe(false);
+    expect(d.reason).toContain("art");
+    expect(d.reason).toContain("code-review");
+  });
+
+  test("empty grant list → deny everything", () => {
+    expect(decideSkill("code-review", []).allow).toBe(false);
+  });
+
+  test("null skill name (not a Skill invocation) → allow pass-through", () => {
+    expect(decideSkill(null, ["code-review"]).allow).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Process behaviour (the actual hook contract Claude Code sees)
+// ---------------------------------------------------------------------------
+
+describe("skill-guard.hook — process behaviour", () => {
+  test("granted skill → exit 0, {continue:true}", () => {
+    const r = runHook(
+      { tool_name: "Skill", tool_input: { skill: "code-review" } },
+      '["code-review"]',
+    );
+    expect(r.status).toBe(0);
+    expect(JSON.parse(r.stdout.trim())).toEqual({ continue: true });
+  });
+
+  test("un-granted skill → exit 2, structured PreToolUse deny", () => {
+    const r = runHook(
+      { tool_name: "Skill", tool_input: { skill: "art" } },
+      '["code-review"]',
+    );
+    expect(r.status).toBe(2);
+    const out = JSON.parse(r.stdout.trim());
+    expect(out.hookSpecificOutput.hookEventName).toBe("PreToolUse");
+    expect(out.hookSpecificOutput.permissionDecision).toBe("deny");
+    expect(out.hookSpecificOutput.permissionDecisionReason).toContain("art");
+  });
+
+  test("no grant-list env → deny (fail-closed)", () => {
+    const r = runHook(
+      { tool_name: "Skill", tool_input: { skill: "code-review" } },
+      undefined,
+    );
+    expect(r.status).toBe(2);
+    expect(JSON.parse(r.stdout.trim()).hookSpecificOutput.permissionDecision).toBe(
+      "deny",
+    );
+  });
+
+  test("empty grant list → deny (fail-closed)", () => {
+    const r = runHook(
+      { tool_name: "Skill", tool_input: { skill: "code-review" } },
+      "[]",
+    );
+    expect(r.status).toBe(2);
+  });
+
+  test("malformed payload → deny (fail-closed)", () => {
+    const r = runHook("not json at all", '["code-review"]');
+    expect(r.status).toBe(2);
+    expect(JSON.parse(r.stdout.trim()).hookSpecificOutput.permissionDecision).toBe(
+      "deny",
+    );
+  });
+
+  test("exactly one grant → only that skill passes, everything else denied", () => {
+    const granted = runHook(
+      { tool_name: "Skill", tool_input: { skill: "code-review" } },
+      '["code-review"]',
+    );
+    const other = runHook(
+      { tool_name: "Skill", tool_input: { skill: "telos" } },
+      '["code-review"]',
+    );
+    expect(granted.status).toBe(0);
+    expect(other.status).toBe(2);
+  });
+});

--- a/src/runner/hooks/__tests__/skill-guard.hook.test.ts
+++ b/src/runner/hooks/__tests__/skill-guard.hook.test.ts
@@ -14,6 +14,7 @@
 
 import { describe, test, expect } from "bun:test";
 import { spawnSync } from "child_process";
+import { statSync } from "fs";
 import { join } from "path";
 import {
   parseGrantList,
@@ -144,6 +145,20 @@ describe("decideSkill — allow/deny decision", () => {
 // Process behaviour (the actual hook contract Claude Code sees)
 // ---------------------------------------------------------------------------
 
+describe("skill-guard.hook — install posture", () => {
+  test("hook file is executable (owner +x) — bare-path hook command must run", () => {
+    // cortex#710 fail-open root cause: the hook was committed 100644 (no +x).
+    // arc installs the symlink preserving source mode, and the curated
+    // settings invoke it by BARE PATH (`${claudeDir}/hooks/CortexSkillGuard.hook.ts`),
+    // not `bun <path>`. A non-executable bare-path hook fails to run → the
+    // broad `Skill` allow stands → every un-granted skill executes. Every
+    // other cortex hook is committed 100755; this asserts skill-guard stays so.
+    const mode = statSync(HOOK_PATH).mode;
+    // owner execute bit
+    expect(mode & 0o100).toBe(0o100);
+  });
+});
+
 describe("skill-guard.hook — process behaviour", () => {
   test("granted skill → exit 0, {continue:true}", () => {
     const r = runHook(
@@ -204,5 +219,83 @@ describe("skill-guard.hook — process behaviour", () => {
     );
     expect(granted.status).toBe(0);
     expect(other.status).toBe(2);
+  });
+
+  test("Skill call with no resolvable name → deny (fail-closed)", () => {
+    // tool_name IS Skill but tool_input carries no `skill` — we cannot
+    // identify the skill and the bare Skill tool is broadly allowed, so this
+    // MUST fail closed (it used to fall through to allow via decideSkill(null)).
+    const r = runHook({ tool_name: "Skill", tool_input: {} }, '["code-review"]');
+    expect(r.status).toBe(2);
+    expect(JSON.parse(r.stdout.trim()).hookSpecificOutput.permissionDecision).toBe(
+      "deny",
+    );
+  });
+
+  test("empty stdin → deny (fail-closed, NOT allow)", () => {
+    // cortex#710 fail-open regression: an empty read means we failed to
+    // capture the payload, not "this isn't a Skill call". Must deny.
+    const r = runHook("", '["code-review"]');
+    expect(r.status).toBe(2);
+    expect(JSON.parse(r.stdout.trim()).hookSpecificOutput.permissionDecision).toBe(
+      "deny",
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Live fail-open regression (cortex#710): stdin arriving AFTER the hook spawns
+//
+// The hook used to race the stdin read against a 200ms timeout and then treat
+// an empty buffer as "not a Skill call" → allow. Under live Claude Code the
+// payload routinely arrives >200ms after spawn, so a granted-but-restricted
+// session launched EVERY un-granted skill (proven live). The fix reads stdin
+// to EOF (5s hang-stop cap) and fails CLOSED on empty/timeout. These tests
+// pipe a DELAYED payload through a shell so the hook process is already
+// running before the JSON shows up — the exact race that failed live.
+// ---------------------------------------------------------------------------
+
+describe("skill-guard.hook — delayed-stdin fail-open regression", () => {
+  /** Run the hook with the payload written to stdin after `delayMs`. */
+  function runHookDelayed(
+    payload: Record<string, unknown>,
+    grants: string,
+    delayMs: number,
+  ): RunResult {
+    const merged: Record<string, string> = {};
+    for (const [k, v] of Object.entries(process.env)) {
+      if (v !== undefined && k !== "CORTEX_SKILL_GRANTS") merged[k] = v;
+    }
+    merged.CORTEX_SKILL_GRANTS = grants;
+    const json = JSON.stringify(payload);
+    // `sleep` then `printf` the payload — the hook is spawned and reading
+    // before the JSON arrives, reproducing the live pipe-delay race.
+    const result = spawnSync(
+      "bash",
+      [
+        "-c",
+        `sleep ${(delayMs / 1000).toFixed(3)}; printf %s ${JSON.stringify(json)} | bun ${JSON.stringify(HOOK_PATH)}`,
+      ],
+      { encoding: "utf-8", env: merged },
+    );
+    return { status: result.status, stdout: result.stdout };
+  }
+
+  test("delayed un-granted skill → still DENY (no fail-open)", () => {
+    const r = runHookDelayed(
+      { tool_name: "Skill", tool_input: { skill: "simplify" } },
+      '["code-review"]',
+      300,
+    );
+    expect(r.status).toBe(2);
+  });
+
+  test("delayed granted skill → still ALLOW", () => {
+    const r = runHookDelayed(
+      { tool_name: "Skill", tool_input: { skill: "code-review" } },
+      '["code-review"]',
+      300,
+    );
+    expect(r.status).toBe(0);
   });
 });

--- a/src/runner/hooks/skill-guard.hook.ts
+++ b/src/runner/hooks/skill-guard.hook.ts
@@ -1,0 +1,213 @@
+#!/usr/bin/env bun
+/**
+ * Cortex Skill Guard — PreToolUse hook for the `Skill` tool (cortex#710,
+ * C-701 Part B — TRUST-PATH/security).
+ *
+ * ## Why a hook (and not a permission rule)
+ *
+ * The original #706 Part B tried to express per-skill grants with
+ * `allowedTools: ["Skill(code-review)"]` + `disallowedTools: ["Skill"]`.
+ * That is broken by design (proven in the #706 review):
+ *
+ *   - Claude Code's `Skill` tool has **no specifier syntax** — there is no
+ *     `Skill(<name>)` rule form, so `Skill(code-review)` matches nothing.
+ *   - Permission precedence is **deny → ask → allow; deny ALWAYS wins**,
+ *     regardless of specificity. So a bare `Skill` deny suppresses the
+ *     granted skill too → a granted reviewer gets NO skills at all.
+ *
+ * The correct mechanism is a **PreToolUse hook** (matcher `Skill`):
+ *
+ *   - Hooks run **before** permission rules; a blocking hook beats `allow`.
+ *   - So the session can broadly **allow** the bare `Skill` tool (the
+ *     permission rule is permissive) while THIS hook is the real gate: it
+ *     inspects the invoked skill name and DENIES any name ∉ the grant list.
+ *
+ * Wiring (see `src/runner/session-settings.ts`):
+ *   - A session WITH grants registers this hook under `PreToolUse` matcher
+ *     `Skill` in the curated `--settings` file, AND broadly allows `Skill`.
+ *   - The grant list reaches this hook via the `CORTEX_SKILL_GRANTS` env
+ *     var (a JSON array of allowed skill names), set on the child env by
+ *     `cc-session.ts` — the same layering as `GROVE_BASH_GUARD`.
+ *   - A session with NO grants does NOT register this hook; it keeps the
+ *     bare-`Skill` `disallowedTools` deny (default-deny, no Skill tool).
+ *
+ * ## Deny behaviour
+ *
+ * On an un-granted skill the hook is **doubly fail-closed**:
+ *   1. Emits Claude Code's structured PreToolUse *deny* decision on stdout
+ *      ({"hookSpecificOutput":{...,"permissionDecision":"deny",
+ *       "permissionDecisionReason":"…"}}) so the reason surfaces to the
+ *      agent and the Cortex→Discord relay (mirrors bash-guard.hook.ts).
+ *   2. Exits with code **2** — Claude Code treats a PreToolUse hook exit 2
+ *      as a hard block. Belt-and-braces: even a CLI that ignored the
+ *      structured output would still be blocked by the non-zero exit.
+ *
+ * ## Fail-closed posture on malformed input / missing grant list
+ *
+ * If `CORTEX_SKILL_GRANTS` is absent or not a JSON array, the grant list is
+ * empty → every skill is denied. A session that wants skills MUST register
+ * this hook with a populated grant list; the absence of a grant list never
+ * silently allows skills. (A session with no grants doesn't register the
+ * hook at all and relies on the `disallowedTools: ["Skill"]` rule instead,
+ * so this path is the defence-in-depth backstop.)
+ */
+
+interface HookInput {
+  session_id?: string;
+  tool_name?: string;
+  // The `Skill` tool input carries the invoked skill name on `skill`
+  // (verified against the codebase's own event-utils.ts, which reads
+  // `input.skill` for the "Using skill: …" detail). May arrive as a raw
+  // string in degenerate cases; we tolerate both shapes.
+  tool_input?: { skill?: unknown } | string;
+}
+
+/** The Skill tool's name as Claude Code emits it (seen as both casings). */
+const SKILL_TOOL_NAMES = new Set(["Skill", "skill"]);
+
+/**
+ * Parse the per-session grant list from `CORTEX_SKILL_GRANTS` (JSON array of
+ * skill-name strings). Returns `[]` (deny-all) on absence or malformed input
+ * — fail-closed. Exported for unit tests.
+ */
+export function parseGrantList(raw: string | undefined): string[] {
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((s): s is string => typeof s === "string");
+  } catch {
+    // Malformed grant list — fail closed (deny all). A bad env value must
+    // never widen access.
+    return [];
+  }
+}
+
+/**
+ * Extract the invoked skill name from a PreToolUse hook input for the
+ * `Skill` tool. Returns `null` when the input is not a Skill invocation or
+ * carries no usable name. Exported for unit tests.
+ */
+export function extractSkillName(input: HookInput): string | null {
+  if (input.tool_name === undefined || !SKILL_TOOL_NAMES.has(input.tool_name)) {
+    return null;
+  }
+  const ti = input.tool_input;
+  if (typeof ti === "string") {
+    const trimmed = ti.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  }
+  if (ti && typeof ti === "object" && typeof ti.skill === "string") {
+    const trimmed = ti.skill.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  }
+  return null;
+}
+
+/**
+ * Decide allow/deny for a Skill invocation given the grant list. Pure —
+ * exported for unit tests. `null` skill name (not a Skill invocation, or no
+ * name) is treated as a pass-through allow: this hook only gates Skill, and
+ * Claude Code only fires it on the `Skill` matcher, so a `null` here means
+ * "not something this hook governs".
+ */
+export function decideSkill(
+  skillName: string | null,
+  grants: string[],
+): { allow: boolean; reason?: string } {
+  if (skillName === null) return { allow: true };
+  if (grants.includes(skillName)) return { allow: true };
+  return {
+    allow: false,
+    reason:
+      `[Cortex Skill Guard] Blocked skill "${skillName}": not in this ` +
+      `session's grant list [${grants.map((g) => `"${g}"`).join(", ")}]. ` +
+      `This is a hard security boundary (least-privilege per-skill grants, ` +
+      `cortex#701). Ask the principal to grant this skill to the agent's ` +
+      `role if it is genuinely needed.`,
+  };
+}
+
+/** Emit the pass-through decision (mirrors bash-guard.hook.ts). */
+function allow(): void {
+  console.log(JSON.stringify({ continue: true }));
+}
+
+/**
+ * Emit Claude Code's structured PreToolUse *deny* decision. The
+ * `permissionDecisionReason` surfaces back to the agent + the Cortex→Discord
+ * relay (mirrors bash-guard.hook.ts).
+ */
+function deny(reason: string): void {
+  console.log(
+    JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "deny",
+        permissionDecisionReason: reason,
+      },
+    }),
+  );
+}
+
+async function readStdin(): Promise<string> {
+  const reader = Bun.stdin.stream().getReader();
+  let raw = "";
+  const readLoop = (async () => {
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      raw += new TextDecoder().decode(value, { stream: true });
+    }
+  })();
+  await Promise.race([readLoop, new Promise<void>((r) => setTimeout(r, 200))]);
+  return raw;
+}
+
+async function main(): Promise<void> {
+  let input: HookInput;
+  try {
+    const raw = await readStdin();
+    if (!raw.trim()) {
+      // No payload — nothing to gate. Allow (the hook is only registered for
+      // the Skill matcher; an empty payload is not a Skill invocation).
+      allow();
+      return;
+    }
+    input = JSON.parse(raw) as HookInput;
+  } catch {
+    // Can't parse the payload. We CANNOT confirm which skill is being
+    // invoked, so the only safe posture is to deny — a malformed payload
+    // must not slip an un-named skill past the gate. Fail closed.
+    const reason =
+      "[Cortex Skill Guard] Blocked: could not parse the Skill tool input — " +
+      "denying to stay fail-closed.";
+    deny(reason);
+    process.exit(2);
+  }
+
+  const skillName = extractSkillName(input);
+  const grants = parseGrantList(process.env.CORTEX_SKILL_GRANTS);
+  const decision = decideSkill(skillName, grants);
+
+  if (decision.allow) {
+    allow();
+    return;
+  }
+
+  // Write the deny decision FIRST (surfaces the reason), then exit 2 so the
+  // block is enforced even by a CLI that ignores structured hook output.
+  deny(decision.reason ?? "[Cortex Skill Guard] Blocked.");
+  process.exit(2);
+}
+
+main().catch(() => {
+  // An unexpected failure in the gate must fail CLOSED, not open: if we
+  // can't run the check, deny. Mirrors the malformed-input path above.
+  deny(
+    "[Cortex Skill Guard] Blocked: internal hook error — denying to stay " +
+      "fail-closed.",
+  );
+  process.exit(2);
+});

--- a/src/runner/hooks/skill-guard.hook.ts
+++ b/src/runner/hooks/skill-guard.hook.ts
@@ -150,19 +150,57 @@ function deny(reason: string): void {
   );
 }
 
+/**
+ * Read the PreToolUse payload from stdin to EOF.
+ *
+ * ## Why this MUST read to EOF (cortex#710 fail-open fix)
+ *
+ * An earlier version raced the read against a 200ms timeout (copied from
+ * bash-guard). That is sound for bash-guard — the Bash tool is allow-by-
+ * default, so a timed-out guard that falls through to `allow()` merely
+ * declines to block one Bash command. It is **catastrophic here**: the whole
+ * skill model is "the bare `Skill` tool is broadly ALLOWED and THIS hook is
+ * the only gate". If the read abandons before Claude Code has finished piping
+ * the JSON payload (observed live, CLI 2.1.158: the payload routinely arrives
+ * >200ms after the hook process spawns), `raw` is empty → the caller's
+ * empty-input branch ran `allow()` → **every un-granted skill executed**
+ * (proven live: a session granted only `code-review` launched `simplify`).
+ *
+ * So we read to EOF with a generous hard cap purely as a hang-stop (a wedged
+ * pipe must not hang the session forever). On the cap firing we throw, and the
+ * caller treats a throw as fail-CLOSED (deny) — never allow.
+ */
+const STDIN_READ_CAP_MS = 5_000;
+
 async function readStdin(): Promise<string> {
-  const reader = Bun.stdin.stream().getReader();
-  let raw = "";
-  const readLoop = (async () => {
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) break;
-      raw += new TextDecoder().decode(value, { stream: true });
-    }
-  })();
-  await Promise.race([readLoop, new Promise<void>((r) => setTimeout(r, 200))]);
-  return raw;
+  // `Bun.stdin.text()` consumes the stream to EOF and resolves with the FULL
+  // payload — the correct primitive for a hook that MUST see the whole JSON
+  // before deciding (it was verified live to deliver the complete Claude Code
+  // PreToolUse payload, where the old 200ms-race reader returned empty). We
+  // still bound it with a hang-stop cap: a wedged/never-closing pipe must not
+  // hang the session forever. On the cap firing we reject → the caller treats
+  // a throw as fail-CLOSED (deny), never allow. This is the opposite posture
+  // from the old race, which returned partial/empty input and let the
+  // empty-input branch fail OPEN.
+  const timedOut = Symbol("timedOut");
+  // Hold the timer id so we can clear it the instant the read wins. A pending
+  // setTimeout keeps the event loop alive, so on the ALLOW path (which falls
+  // off the end of `main()` rather than `process.exit`ing) an uncleared timer
+  // would block process exit for the full cap — the hook would appear to hang.
+  let capTimer: ReturnType<typeof setTimeout> | undefined;
+  const outcome = await Promise.race([
+    Bun.stdin.text(),
+    new Promise<typeof timedOut>((r) => {
+      capTimer = setTimeout(() => {
+        r(timedOut);
+      }, STDIN_READ_CAP_MS);
+    }),
+  ]);
+  if (capTimer !== undefined) clearTimeout(capTimer);
+  if (outcome === timedOut) {
+    throw new Error("skill-guard: stdin read exceeded cap before EOF");
+  }
+  return outcome;
 }
 
 async function main(): Promise<void> {
@@ -170,16 +208,25 @@ async function main(): Promise<void> {
   try {
     const raw = await readStdin();
     if (!raw.trim()) {
-      // No payload — nothing to gate. Allow (the hook is only registered for
-      // the Skill matcher; an empty payload is not a Skill invocation).
-      allow();
-      return;
+      // Empty payload. Claude Code ONLY fires this hook on the `Skill`
+      // matcher, so an empty read means we failed to capture the payload
+      // (e.g. the read ended before the JSON was piped) — NOT "this isn't a
+      // Skill call". We cannot identify the skill, and the bare `Skill` tool
+      // is broadly allowed, so allowing here would let an un-granted skill
+      // run. Fail CLOSED. (cortex#710 — this branch used to `allow()`, which
+      // was a live-proven fail-open under the old 200ms stdin race.)
+      const reason =
+        "[Cortex Skill Guard] Blocked: empty Skill tool input — could not " +
+        "identify the skill; denying to stay fail-closed.";
+      deny(reason);
+      process.exit(2);
     }
     input = JSON.parse(raw) as HookInput;
   } catch {
-    // Can't parse the payload. We CANNOT confirm which skill is being
-    // invoked, so the only safe posture is to deny — a malformed payload
-    // must not slip an un-named skill past the gate. Fail closed.
+    // Can't read or parse the payload. We CANNOT confirm which skill is being
+    // invoked, so the only safe posture is to deny — a malformed (or
+    // never-fully-read) payload must not slip an un-named skill past the
+    // gate. Fail closed.
     const reason =
       "[Cortex Skill Guard] Blocked: could not parse the Skill tool input — " +
       "denying to stay fail-closed.";
@@ -189,6 +236,25 @@ async function main(): Promise<void> {
 
   const skillName = extractSkillName(input);
   const grants = parseGrantList(process.env.CORTEX_SKILL_GRANTS);
+
+  // cortex#710 fail-closed disambiguation. `extractSkillName` returns `null`
+  // for TWO different cases; only ONE of them is safe to allow:
+  //   (a) the tool_name is NOT a Skill call → genuinely not ours to gate
+  //       (Claude Code shouldn't fire us here, but if it does, pass through).
+  //   (b) the tool_name IS `Skill`/`skill` but the name is missing/empty/
+  //       unparseable → we CANNOT identify the skill. The bare `Skill` tool is
+  //       broadly allowed, so passing through would run an un-identified skill.
+  //       That must fail CLOSED.
+  const isSkillCall =
+    input.tool_name !== undefined && SKILL_TOOL_NAMES.has(input.tool_name);
+  if (skillName === null && isSkillCall) {
+    const reason =
+      "[Cortex Skill Guard] Blocked: Skill invocation with no resolvable " +
+      "skill name — denying to stay fail-closed.";
+    deny(reason);
+    process.exit(2);
+  }
+
   const decision = decideSkill(skillName, grants);
 
   if (decision.allow) {
@@ -202,12 +268,22 @@ async function main(): Promise<void> {
   process.exit(2);
 }
 
-main().catch(() => {
-  // An unexpected failure in the gate must fail CLOSED, not open: if we
-  // can't run the check, deny. Mirrors the malformed-input path above.
-  deny(
-    "[Cortex Skill Guard] Blocked: internal hook error — denying to stay " +
-      "fail-closed.",
-  );
-  process.exit(2);
-});
+// Only execute the gate when run AS a script (the production hook path).
+// Guard with `import.meta.main` so unit tests can `import` the pure helpers
+// (parseGrantList / extractSkillName / decideSkill) WITHOUT triggering
+// `main()` — which now reads stdin to EOF and `process.exit(2)`s on an empty
+// read (the fail-closed fix). Without this guard, importing the module from
+// the test runner would hang on stdin or kill the runner with exit 2 before
+// the suite summary prints. The installed hook is always invoked as a script,
+// so `import.meta.main` is true there and the gate runs exactly as before.
+if (import.meta.main) {
+  main().catch(() => {
+    // An unexpected failure in the gate must fail CLOSED, not open: if we
+    // can't run the check, deny. Mirrors the malformed-input path above.
+    deny(
+      "[Cortex Skill Guard] Blocked: internal hook error — denying to stay " +
+        "fail-closed.",
+    );
+    process.exit(2);
+  });
+}

--- a/src/runner/session-settings.ts
+++ b/src/runner/session-settings.ts
@@ -22,12 +22,17 @@
  *   --settings <file-or-json>     Path to a settings JSON file (additive).
  *
  * The principal's global `~/.claude/settings.json` is the **user** source.
- * By spawning bot sessions with `--setting-sources project,local` we
- * EXCLUDE the `user` source entirely — nothing from the principal's global
- * settings (hooks, skills, plugins, permissions) is loaded. We then layer
- * cortex's OWN curated settings on top via `--settings <path>`, containing
- * only cortex's hooks (EventLogger, bash-guard, context) plus the
- * explicitly-granted skills/tools for this session.
+ * By spawning bot sessions with an EMPTY `--setting-sources ""` we load NO
+ * ambient source at all — not `user` (the principal's global settings), and
+ * not `project`/`local` (the cwd repo's `.claude/`). Nothing from the
+ * principal's global settings (hooks, skills, plugins, permissions) — and
+ * nothing from the working-repo cwd — is loaded. We then layer cortex's OWN
+ * curated settings on top via `--settings <path>`, containing only cortex's
+ * hooks (EventLogger, bash-guard, context) plus, when the session is granted
+ * skills, the Skill Guard PreToolUse hook (cortex#710). See the "Why drop
+ * `project` and `local`, not just `user`?" self-check below for why the
+ * tighter empty-source default (rather than `project,local`) is the only
+ * sound posture.
  *
  * ### Why `--setting-sources ` (empty) and not `--bare`?
  *
@@ -41,9 +46,9 @@
  *
  * ### Why drop `project` and `local`, not just `user`? (cortex#701 self-check)
  *
- * `--setting-sources project,local` excludes the principal's GLOBAL
- * `~/.claude/settings.json` (`user`) — but `--settings` is ADDITIVE, not a
- * replacement, so `project` (`<cwd>/.claude/settings.json`) and `local`
+ * A narrower `--setting-sources project,local` would exclude the principal's
+ * GLOBAL `~/.claude/settings.json` (`user`) — but `--settings` is ADDITIVE,
+ * not a replacement, so `project` (`<cwd>/.claude/settings.json`) and `local`
  * (`<cwd>/.claude/settings.local.json`) STILL load alongside the curated
  * file. Empirically verified (CLI 2.1.158): a project/local hook in the
  * session cwd fires INSIDE the bot session even with `--settings` present.
@@ -144,23 +149,67 @@ export const CORTEX_PRESERVED_CLAUDE_ENV = new Set<string>([
 ]);
 
 /**
+ * Env var carrying the per-session **skill grant list** to the Skill Guard
+ * PreToolUse hook (cortex#710). Value is a JSON array of allowed skill-name
+ * strings (e.g. `["code-review"]`). The hook (`skill-guard.hook.ts`) reads
+ * this and DENIES any `Skill` invocation whose name is not in the list.
+ *
+ * Set on the child env by `cc-session.ts`, layered AFTER `scopeSessionEnv`
+ * (it is not a `CLAUDE_*` var, so scoping passes it through regardless; the
+ * explicit layering keeps it alongside cortex's other pipeline vars). Mirrors
+ * how `GROVE_BASH_GUARD` carries the bash-guard config to that hook.
+ */
+export const CORTEX_SKILL_GRANTS_ENV = "CORTEX_SKILL_GRANTS";
+
+/**
  * Build the curated settings object cortex spawns bot sessions under.
  *
  * Contains ONLY cortex's own hooks (resolved to the installed symlink
- * paths under `${claudeDir}/hooks/`) plus an optional permissions block
- * carrying the explicitly-granted tools. Skills are gated separately via
- * the `Skill` tool allow/deny on the CLI (see dispatch-handler Part B);
- * this object never re-adds the principal's skills because it is the ONLY
- * settings file loaded besides the repo-scoped project/local sources.
+ * paths under `${claudeDir}/hooks/`). It never re-adds the principal's
+ * skills/hooks because it is the ONLY settings file loaded — the spawn
+ * passes an EMPTY `--setting-sources` so no ambient source (`user`,
+ * `project`, `local`) loads alongside it.
+ *
+ * ## Skill gating (cortex#710, Part B)
+ *
+ * When `skillGrants` is a NON-EMPTY array, the session is meant to have
+ * those skills. We register the **Skill Guard** PreToolUse hook (matcher
+ * `Skill`) here; the caller broadly ALLOWS the bare `Skill` tool (so the
+ * permission rule is permissive) and the hook is the real gate — it denies
+ * any skill name ∉ the grant list (see `skill-guard.hook.ts`). The grant
+ * list itself reaches the hook via the {@link CORTEX_SKILL_GRANTS_ENV} env
+ * var on the child, NOT via this file.
+ *
+ * When `skillGrants` is `undefined`/empty, NO Skill hook is registered:
+ * the caller keeps the default-deny `disallowedTools: ["Skill"]` rule
+ * instead (no Skill tool at all). This is the #706 lesson made atomic — a
+ * session is either {broad `Skill` allow + this gate hook} or {no `Skill`
+ * tool}, never the broken {`Skill(name)` allow + bare `Skill` deny}.
  *
  * @param claudeDir Absolute path to the cortex-owned `.claude` dir holding
  *   the installed hook symlinks. Defaults to `${HOME}/.claude`.
+ * @param skillGrants Per-session skill grant list. Non-empty → register the
+ *   Skill Guard hook. Undefined/empty → no Skill hook (default-deny lives
+ *   in the caller's `disallowedTools`).
  */
-export function buildCuratedSettings(claudeDir: string): Record<string, unknown> {
+export function buildCuratedSettings(
+  claudeDir: string,
+  skillGrants?: readonly string[],
+): Record<string, unknown> {
   const hook = (name: string) => ({
     type: "command",
     command: `${claudeDir}/hooks/${name}`,
   });
+
+  // PreToolUse always carries the Bash guard. When the session is granted
+  // skills, ALSO register the Skill guard (matcher `Skill`) — the per-skill
+  // gate that backs the broad `Skill` allow the caller layers in.
+  const preToolUse: { matcher: string; hooks: ReturnType<typeof hook>[] }[] = [
+    { matcher: "Bash", hooks: [hook("CortexBashGuard.hook.ts")] },
+  ];
+  if (skillGrants !== undefined && skillGrants.length > 0) {
+    preToolUse.push({ matcher: "Skill", hooks: [hook("CortexSkillGuard.hook.ts")] });
+  }
 
   // Mirrors src/settings/cortex-hooks.json (the reference fallback) but
   // pinned to ABSOLUTE installed paths so it stands alone without relying
@@ -172,9 +221,7 @@ export function buildCuratedSettings(claudeDir: string): Record<string, unknown>
       PostToolUse: [{ hooks: [hook("CortexEventLogger.hook.ts")] }],
       Stop: [{ hooks: [hook("CortexEventLogger.hook.ts")] }],
       UserPromptSubmit: [{ hooks: [hook("CortexEventLogger.hook.ts")] }],
-      PreToolUse: [
-        { matcher: "Bash", hooks: [hook("CortexBashGuard.hook.ts")] },
-      ],
+      PreToolUse: preToolUse,
     },
   };
 }
@@ -203,13 +250,27 @@ export interface IsolatedSettings {
  * return the args + cleanup. The caller spawns `claude` with
  * `[...buildClaudeArgs(opts), ...isolated.args]` (or threads `args` into
  * additionalArgs) and invokes `cleanup()` on session exit.
+ *
+ * @param claudeDir Absolute path to the cortex-owned `.claude` dir holding
+ *   the installed hook symlinks.
+ * @param skillGrants Per-session skill grant list (cortex#710). Non-empty →
+ *   the curated file registers the Skill Guard PreToolUse hook; the caller
+ *   must ALSO broadly allow the `Skill` tool and set the
+ *   {@link CORTEX_SKILL_GRANTS_ENV} env var. Undefined/empty → no Skill hook.
  */
-export function createIsolatedSettings(claudeDir: string): IsolatedSettings {
+export function createIsolatedSettings(
+  claudeDir: string,
+  skillGrants?: readonly string[],
+): IsolatedSettings {
   const dir = mkdtempSync(join(tmpdir(), "cortex-session-"));
   const settingsPath = join(dir, "settings.json");
-  writeFileSync(settingsPath, JSON.stringify(buildCuratedSettings(claudeDir), null, 2), {
-    mode: 0o600,
-  });
+  writeFileSync(
+    settingsPath,
+    JSON.stringify(buildCuratedSettings(claudeDir, skillGrants), null, 2),
+    {
+      mode: 0o600,
+    },
+  );
 
   return {
     settingsPath,

--- a/src/substrates/claude-code/__tests__/harness.test.ts
+++ b/src/substrates/claude-code/__tests__/harness.test.ts
@@ -235,7 +235,83 @@ describe("ClaudeCodeHarness — DispatchRequest → CCSessionOpts mapping", () =
     await drain(h.dispatch(req));
 
     expect(cap.opts[0]?.allowedTools).toEqual(["Bash", "Edit"]);
-    expect(cap.opts[0]?.disallowedTools).toEqual(["WebFetch"]);
+    // cortex#710 — with no skill grants, the harness ALSO appends the
+    // default-deny `Skill` (no Skill tool). `WebFetch` from `tools.deny`
+    // is preserved; `Skill` is added as the fail-closed backstop.
+    expect(cap.opts[0]?.disallowedTools).toEqual(["WebFetch", "Skill"]);
+  });
+
+  // cortex#710 (C-701 Part B) — per-skill grants applied ATOMICALLY with the
+  // Skill tool permission. The whole point: a granted agent gets {broad Skill
+  // allow + the gate hook via allowedSkills}, NEVER {Skill(name) allow + bare
+  // Skill deny} (the broken #706 form).
+  describe("per-skill grants (cortex#710 default-deny flip)", () => {
+    test("NO grants (undefined) → default-deny: Skill appended to disallowedTools, no allowedSkills", async () => {
+      const cap = captureFactory(makeResult());
+      const h = new ClaudeCodeHarness({ source: SOURCE, ccSessionFactory: cap.factory });
+
+      await drain(h.dispatch(makeRequest({ tools: { allow: ["Bash"] } })));
+
+      expect(cap.opts[0]?.disallowedTools).toContain("Skill");
+      expect(cap.opts[0]?.allowedSkills).toBeUndefined();
+      // The bare Skill is NOT in allowedTools — there is no Skill tool.
+      expect(cap.opts[0]?.allowedTools ?? []).not.toContain("Skill");
+    });
+
+    test("empty grants ([]) → default-deny: Skill denied, no allowedSkills", async () => {
+      const cap = captureFactory(makeResult());
+      const h = new ClaudeCodeHarness({ source: SOURCE, ccSessionFactory: cap.factory });
+
+      await drain(
+        h.dispatch(makeRequest({ tools: { allow: ["Bash"] }, allowedSkills: [] })),
+      );
+
+      expect(cap.opts[0]?.disallowedTools).toContain("Skill");
+      expect(cap.opts[0]?.allowedSkills).toBeUndefined();
+    });
+
+    test("WITH grants → broad Skill ALLOW + allowedSkills set + Skill NOT denied (the atomic pair)", async () => {
+      const cap = captureFactory(makeResult());
+      const h = new ClaudeCodeHarness({ source: SOURCE, ccSessionFactory: cap.factory });
+
+      await drain(
+        h.dispatch(
+          makeRequest({
+            tools: { allow: ["Bash"], deny: ["WebFetch"] },
+            allowedSkills: ["code-review"],
+          }),
+        ),
+      );
+
+      // (a) the gate hook is fed the grant list
+      expect(cap.opts[0]?.allowedSkills).toEqual(["code-review"]);
+      // (b) the bare Skill tool is broadly ALLOWED (permission rule permissive)
+      expect(cap.opts[0]?.allowedTools).toContain("Skill");
+      // (c) Skill is NOT in the deny list — the broken form would have it here
+      expect(cap.opts[0]?.disallowedTools ?? []).not.toContain("Skill");
+      // unrelated denies survive
+      expect(cap.opts[0]?.disallowedTools).toContain("WebFetch");
+    });
+
+    test("grants + an upstream Skill deny → deny is REMOVED (never the broken intermediate state)", async () => {
+      const cap = captureFactory(makeResult());
+      const h = new ClaudeCodeHarness({ source: SOURCE, ccSessionFactory: cap.factory });
+
+      // Simulate a stale upstream that put Skill in deny AND carries a grant:
+      // the atomic flip must resolve to {allow + hook}, not {allow + deny}.
+      await drain(
+        h.dispatch(
+          makeRequest({
+            tools: { allow: [], deny: ["Skill"] },
+            allowedSkills: ["code-review"],
+          }),
+        ),
+      );
+
+      expect(cap.opts[0]?.disallowedTools ?? []).not.toContain("Skill");
+      expect(cap.opts[0]?.allowedTools).toContain("Skill");
+      expect(cap.opts[0]?.allowedSkills).toEqual(["code-review"]);
+    });
   });
 
   test("empty tools.allow drops the field rather than passing an empty array", async () => {

--- a/src/substrates/claude-code/harness.ts
+++ b/src/substrates/claude-code/harness.ts
@@ -334,11 +334,40 @@ export class ClaudeCodeHarness implements SessionHarness {
     };
 
     // Q1-α: harness-native tool strings pass through untouched.
-    if (req.tools.allow.length > 0) {
-      opts.allowedTools = [...req.tools.allow];
+    const allowedTools = req.tools.allow.length > 0 ? [...req.tools.allow] : [];
+    const disallowedTools =
+      req.tools.deny && req.tools.deny.length > 0 ? [...req.tools.deny] : [];
+
+    // cortex#710 — per-skill grants, applied ATOMICALLY with the `Skill`
+    // tool permission so a granted agent never lands in the broken
+    // intermediate state {`Skill(name)` allow + bare `Skill` deny} (#706).
+    //
+    //   - Grants present (allowedSkills non-empty): broadly ALLOW the bare
+    //     `Skill` tool and REMOVE any `Skill` deny, so the permission layer
+    //     is permissive — the Skill Guard PreToolUse hook (registered in the
+    //     curated settings when CCSessionOpts.allowedSkills is non-empty) is
+    //     the real per-skill gate. The grant list reaches the hook via the
+    //     CORTEX_SKILL_GRANTS env var (cc-session.ts).
+    //   - No grants (undefined or []): keep the default-deny posture — ensure
+    //     `Skill` is in disallowedTools (no Skill tool at all). The upstream
+    //     dispatch path already emits a bare `Skill` deny; this is the
+    //     harness-side backstop so the CC session is fail-closed even if the
+    //     envelope omitted it.
+    const grants = req.allowedSkills;
+    if (grants !== undefined && grants.length > 0) {
+      opts.allowedSkills = [...grants];
+      if (!allowedTools.includes("Skill")) allowedTools.push("Skill");
+      const skillDenyIdx = disallowedTools.indexOf("Skill");
+      if (skillDenyIdx !== -1) disallowedTools.splice(skillDenyIdx, 1);
+    } else {
+      if (!disallowedTools.includes("Skill")) disallowedTools.push("Skill");
     }
-    if (req.tools.deny && req.tools.deny.length > 0) {
-      opts.disallowedTools = [...req.tools.deny];
+
+    if (allowedTools.length > 0) {
+      opts.allowedTools = allowedTools;
+    }
+    if (disallowedTools.length > 0) {
+      opts.disallowedTools = disallowedTools;
     }
 
     // Q6: wall-clock cap maps to cc-session's existing inactivity timer


### PR DESCRIPTION
Closes #710
Refs #701 #706

## Why a hook (not a permission rule)

#706 Part B's `Skill(<name>)` tool-rule approach was proven **broken by design** in review: Claude Code's `Skill` tool has **no specifier syntax** (no `Skill(<name>)` rule form) and permission precedence is **deny → ask → allow; deny always wins**. So `disallowedTools:["Skill"]` + `allowedTools:["Skill(code-review)"]` denies the granted skill too. The correct mechanism is a **PreToolUse hook** (matcher `Skill`): hooks run **before** permission rules, and a blocking hook (exit 2) beats a broad allow. So the session broadly **allows** the bare `Skill` tool and the hook is the real per-skill gate.

## Hook design

`src/runner/hooks/skill-guard.hook.ts` (new):

- **Grant list → hook:** the per-session grant list reaches the hook via the `CORTEX_SKILL_GRANTS` env var (a JSON array of allowed skill names), set on the child env by `cc-session.ts` — the same layering as `GROVE_BASH_GUARD`. The hook itself is path-fixed; the curated `--settings` file only references it.
- **Name extraction:** reads `tool_input.skill` (the field the codebase already uses for "Using skill: …"); tolerates tool name `"Skill"`/`"skill"` and a raw-string `tool_input`.
- **Deny:** doubly fail-closed — emits Claude Code's structured PreToolUse `permissionDecision:"deny"` (surfaces the reason to the agent + relay, mirroring bash-guard) **and** `process.exit(2)` (hard block even if a CLI ignored the structured output). Fail-closed on malformed input, missing/empty grant list, and internal error.
- **Install:** arc-manifest **symlink only** (`CortexSkillGuard.hook.ts`) — deliberately **not** in the global `hooks:` block, so it is never registered in the principal's global `settings.json` (it would otherwise gate the principal's own Skill use). It is registered **per-session** in the curated `--settings` file for bot sessions that carry grants.

## Atomic dispatch-handler flip

`dispatch-handler.ts` flips from the legacy binary G-121 gate (`allowed_skills:[]` = no Skill; non-empty = ALL skills) to **default-deny + per-skill grants**, computed atomically:

- **No grants (undefined/[])** → push the bare `Skill` deny (`disallowedTools`), default-deny, no Skill tool.
- **Grants ([...])** → do **not** deny `Skill`; carry `allowedSkills` to the session, which produces **{broad `Skill` allow + the gate hook}** — never the broken `{Skill(name) allow + bare Skill deny}`.

`allowedSkills` is threaded through the canonical bus path **and** all three direct handlers (sync/async/team). Carried end-to-end: `DispatchRequest.allowedSkills` → payload `allowed_skills` (publisher + listener) → CC harness (broad Skill allow + `allowedSkills`, else default-deny) → `CCSession` (registers the hook + sets the env + normalises tool lists). AgentTeam propagates grants to moderator/participant/synthesis. `cc-session.ts` is self-consistent: with grants it strips any `Skill` deny and adds `Skill` to a non-empty allowlist, regardless of caller.

**Gateway** (`bus-inbound-sink.ts`): keeps the fail-closed bare-`Skill` deny; leaves `allowedSkills` undefined (the thin demux grants nothing) — wired for future per-binding grant carry.

**Cosmetic:** fixed stale `--setting-sources project,local` prose in `session-settings.ts` (code emits `""`).

## Verification

- `bunx tsc --noEmit` — clean
- `bun test src/runner/ src/bus/ src/gateway/ src/common/` — 1918 pass / 0 fail
- full `bun test` — 4379 pass / 0 fail (no new fails)
- `bun run lint` — 0 errors (29 pre-existing warnings, none in changed files)
- vocab gate `scripts/check-carveouts.sh` — PASS

**Unit-verified:** hook gating (granted→exit0, un-granted→exit2, name extraction, fail-closed paths); session-settings hook registration (grants→hook, no grants→none); cc-session env + settings wiring + tool-list normalisation; harness atomic flip (broad Skill allow + allowedSkills vs default-deny); publisher/listener `allowed_skills` round-trip; default-deny on a minimal payload.

## ⚠️ LIVE VERIFY HELD (operator action)

The AC *"an agent granted exactly one skill gets exactly that skill — verified live"* requires a **real installed skill in a running `claude` session** (granted skill invokable, un-granted denied). This **cannot be done autonomously** — it is the same reason #706 Part B wasn't redone live. The mechanism is built and unit-tested; the live grant verification is **held for the operator**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)