### PR TITLE
fix(scripts): C-717 — config-split-aware upgrade lifecycle (discover per-stack dirs, render sentinels)

### DIFF
--- a/scripts/__tests__/plist-render-stack-discovery.sh
+++ b/scripts/__tests__/plist-render-stack-discovery.sh
@@ -271,6 +271,136 @@ else
   printf '  ⊘ render_cortex_plists integration test skipped (non-Darwin host)\n'
 fi
 
+# ─── Section 8: config-split (directory layout) — cortex#717 ─────
+printf '\n=== config-split layout: discovery + render (cortex#717) ===\n'
+
+# Build a config dir that mirrors TONIGHT'S LIVE STATE after migration 0003:
+#   - per-stack dirs (meta-factory/, work/, halden/) each with
+#     system/system.yaml + a <slug>.yaml sentinel + stacks/<slug>.yaml
+#   - retained root monoliths (cortex.yaml, cortex.work.yaml,
+#     cortex.halden.yaml) left as rollback anchors.
+# Expected: discover {meta-factory, work, halden} from the DIRS (not doubled),
+# the root monoliths IGNORED, and each plist --config = the per-stack sentinel.
+SPLIT_DIR="${TMPBASE}/split-config"
+SPLIT_LAUNCH="${TMPBASE}/split-LaunchAgents"
+mkdir -p "${SPLIT_LAUNCH}"
+
+for s in meta-factory work halden; do
+  mkdir -p "${SPLIT_DIR}/${s}/system" "${SPLIT_DIR}/${s}/stacks"
+  # Directory-layout marker.
+  cat > "${SPLIT_DIR}/${s}/system/system.yaml" <<EOF
+nats:
+  url: nats://127.0.0.1:4222
+EOF
+  # Per-stack sentinel (pointer; loader resolves dir = dirname).
+  printf '' > "${SPLIT_DIR}/${s}/${s}.yaml"
+  # The composed stack file — carries stack.id + agents[].id.
+  cat > "${SPLIT_DIR}/${s}/stacks/${s}.yaml" <<EOF
+stack:
+  id: andreas/${s}
+agents:
+  - id: agent-${s}
+    token: "fake"
+EOF
+done
+
+# Retained root monoliths (rollback anchors) — MUST be ignored.
+printf 'agents:\n  - id: monolith-agent\n' > "${SPLIT_DIR}/cortex.yaml"
+printf 'agents:\n  - id: monolith-agent\n' > "${SPLIT_DIR}/cortex.work.yaml"
+printf 'agents:\n  - id: monolith-agent\n' > "${SPLIT_DIR}/cortex.halden.yaml"
+
+# --- discovery: exactly the three dir slugs, monoliths deduped away ---
+SPLIT_SLUGS="$(discover_stack_slugs "${SPLIT_DIR}")"
+assert_contains "split: discovers meta-factory (from dir)" "meta-factory" "${SPLIT_SLUGS}"
+assert_contains "split: discovers work (from dir)" "work" "${SPLIT_SLUGS}"
+assert_contains "split: discovers halden (from dir)" "halden" "${SPLIT_SLUGS}"
+SPLIT_COUNT="$(discover_stack_slugs "${SPLIT_DIR}" | wc -l | tr -d ' ')"
+assert_eq "split: 3 dirs + 3 monoliths → 3 slugs (not doubled)" "3" "${SPLIT_COUNT}"
+
+# --- resolve_stack_config_path: per-stack sentinel, NOT the monolith ---
+assert_eq "split: meta-factory --config = dir sentinel" \
+  "${SPLIT_DIR}/meta-factory/meta-factory.yaml" \
+  "$(resolve_stack_config_path "${SPLIT_DIR}" "meta-factory")"
+assert_eq "split: work --config = dir sentinel" \
+  "${SPLIT_DIR}/work/work.yaml" \
+  "$(resolve_stack_config_path "${SPLIT_DIR}" "work")"
+assert_eq "split: halden --config = dir sentinel" \
+  "${SPLIT_DIR}/halden/halden.yaml" \
+  "$(resolve_stack_config_path "${SPLIT_DIR}" "halden")"
+
+# --- resolve_stack_agent_config_path: stacks/<slug>.yaml under dir layout ---
+assert_eq "split: meta-factory agent-config = stacks/<slug>.yaml" \
+  "${SPLIT_DIR}/meta-factory/stacks/meta-factory.yaml" \
+  "$(resolve_stack_agent_config_path "${SPLIT_DIR}" "meta-factory")"
+
+# --- render meta-factory: --config points at sentinel; agent id from stacks/ ---
+render_stack_plist "${REPO_ROOT}" "${SPLIT_LAUNCH}" "${SPLIT_DIR}" "meta-factory" "${MOCK_BIN}/bun"
+MF_SPLIT="${SPLIT_LAUNCH}/ai.meta-factory.cortex.meta-factory.plist"
+assert_file_exists "split: meta-factory plist rendered" "${MF_SPLIT}"
+assert_contains "split: meta-factory --config = sentinel" \
+  "${SPLIT_DIR}/meta-factory/meta-factory.yaml" "$(cat "${MF_SPLIT}")"
+assert_not_contains "split: meta-factory --config is NOT the monolith" \
+  "<string>${SPLIT_DIR}/cortex.yaml</string>" "$(cat "${MF_SPLIT}")"
+assert_contains "split: meta-factory agent id read from stacks/<slug>.yaml" \
+  "agent-meta-factory" "$(cat "${MF_SPLIT}")"
+assert_not_contains "split: meta-factory did NOT read monolith agent id" \
+  "monolith-agent" "$(cat "${MF_SPLIT}")"
+assert_not_contains "split: meta-factory no leftover __CONFIG_PATH__" \
+  "__CONFIG_PATH__" "$(cat "${MF_SPLIT}")"
+
+# --- render work: --config = sentinel ---
+render_stack_plist "${REPO_ROOT}" "${SPLIT_LAUNCH}" "${SPLIT_DIR}" "work" "${MOCK_BIN}/bun"
+WORK_SPLIT="${SPLIT_LAUNCH}/ai.meta-factory.cortex.work.plist"
+assert_contains "split: work --config = sentinel" \
+  "${SPLIT_DIR}/work/work.yaml" "$(cat "${WORK_SPLIT}")"
+assert_not_contains "split: work no leftover __CONFIG_PATH__" \
+  "__CONFIG_PATH__" "$(cat "${WORK_SPLIT}")"
+
+# --- render halden (generic template): --config = sentinel; unique PID name ---
+render_stack_plist "${REPO_ROOT}" "${SPLIT_LAUNCH}" "${SPLIT_DIR}" "halden" "${MOCK_BIN}/bun"
+HALDEN_SPLIT="${SPLIT_LAUNCH}/ai.meta-factory.cortex.halden.plist"
+assert_contains "split: halden --config = sentinel" \
+  "${SPLIT_DIR}/halden/halden.yaml" "$(cat "${HALDEN_SPLIT}")"
+# PID-collision lesson (migration 0003): each stack's log/PID name carries the
+# unique slug, never cortex-cortex*. The generic template keys log paths off
+# __STACK_SLUG__, so assert the slug-unique name is present and no collision.
+assert_contains "split: halden log path uses unique cortex-halden name" \
+  "cortex-halden.log" "$(cat "${HALDEN_SPLIT}")"
+assert_not_contains "split: halden no cortex-cortex PID collision" \
+  "cortex-cortex" "$(cat "${HALDEN_SPLIT}")"
+assert_not_contains "split: halden no leftover __CONFIG_PATH__" \
+  "__CONFIG_PATH__" "$(cat "${HALDEN_SPLIT}")"
+
+# ─── Section 9: dir-wins dedup when only ONE stack is split ───────
+printf '\n=== config-split layout: mixed (one split, others monolith) ===\n'
+
+# work is split (dir), meta-factory + halden remain pure monoliths. Expect all
+# three discovered, work from the dir, the other two from monoliths.
+MIXED_DIR="${TMPBASE}/mixed-config"
+mkdir -p "${MIXED_DIR}/work/system" "${MIXED_DIR}/work/stacks"
+cat > "${MIXED_DIR}/work/system/system.yaml" <<EOF
+nats:
+  url: nats://127.0.0.1:4222
+EOF
+printf '' > "${MIXED_DIR}/work/work.yaml"
+printf 'stack:\n  id: andreas/work\nagents:\n  - id: agent-work\n' > "${MIXED_DIR}/work/stacks/work.yaml"
+# Monoliths for all three (work's monolith is the retained rollback anchor).
+printf 'agents:\n  - id: m\n' > "${MIXED_DIR}/cortex.yaml"
+printf 'agents:\n  - id: m\n' > "${MIXED_DIR}/cortex.work.yaml"
+printf 'agents:\n  - id: m\n' > "${MIXED_DIR}/cortex.halden.yaml"
+
+MIXED_COUNT="$(discover_stack_slugs "${MIXED_DIR}" | wc -l | tr -d ' ')"
+assert_eq "mixed: 3 slugs (work deduped to dir, mf+halden from monolith)" "3" "${MIXED_COUNT}"
+assert_eq "mixed: work resolves to dir sentinel" \
+  "${MIXED_DIR}/work/work.yaml" \
+  "$(resolve_stack_config_path "${MIXED_DIR}" "work")"
+assert_eq "mixed: meta-factory resolves to monolith (no dir)" \
+  "${MIXED_DIR}/cortex.yaml" \
+  "$(resolve_stack_config_path "${MIXED_DIR}" "meta-factory")"
+assert_eq "mixed: halden resolves to monolith (no dir)" \
+  "${MIXED_DIR}/cortex.halden.yaml" \
+  "$(resolve_stack_config_path "${MIXED_DIR}" "halden")"
+
 # ─── Summary ──────────────────────────────────────────────────────
 printf '\n'
 printf 'Results: %d passed, %d failed\n' "${PASS}" "${FAIL}"

--- a/scripts/lib/plist-render.sh
+++ b/scripts/lib/plist-render.sh
@@ -103,21 +103,107 @@ slug_to_config_file() {
   fi
 }
 
-# Discover all stack slugs from config files under CONFIG_DIR.
-# Prints one slug per line. Never includes the relay daemon.
+# Resolve the `--config` path a stack's plist should point at, layout-aware
+# (cortex#717 / migration 0003).
+#
+# Two layouts coexist during the config-split transition:
+#   - Directory layout: <config_dir>/<slug>/system/system.yaml exists. The
+#     plist must point at the per-stack SENTINEL <config_dir>/<slug>/<slug>.yaml
+#     (the loader resolves configDir = dirname(<sentinel>) and composes the
+#     dir). This preserves the unique cortex-<slug>.pid naming — the
+#     PID-collision lesson from migration 0003.
+#   - Legacy monolith: no per-stack dir. The plist points at the root monolith
+#     <config_dir>/cortex[.<slug>].yaml.
+#
+# Prints the absolute config path. Directory layout takes precedence.
 #
 # Args:
-#   $1 CONFIG_DIR — directory containing cortex*.yaml files
+#   $1 CONFIG_DIR — cortex config dir
+#   $2 SLUG       — stack slug
+resolve_stack_config_path() {
+  local config_dir="$1"
+  local slug="$2"
+  if [ -f "${config_dir}/${slug}/system/system.yaml" ]; then
+    # Directory layout — point at the per-stack sentinel.
+    printf '%s' "${config_dir}/${slug}/${slug}.yaml"
+  else
+    # Legacy monolith.
+    printf '%s' "${config_dir}/$(slug_to_config_file "${slug}")"
+  fi
+}
+
+# Resolve the config file the agent id should be read FROM, layout-aware.
+#
+# Under the directory layout the sentinel <slug>/<slug>.yaml is a pointer and
+# carries no agents; `agents[].id` lives in <slug>/stacks/<slug>.yaml. Under
+# the legacy monolith the agents block is in the monolith itself.
+#
+# Prints the absolute path of the file to parse for the agent id. The caller
+# must tolerate a missing file (extract_agent_name falls back to "cortex").
+#
+# Args:
+#   $1 CONFIG_DIR — cortex config dir
+#   $2 SLUG       — stack slug
+resolve_stack_agent_config_path() {
+  local config_dir="$1"
+  local slug="$2"
+  if [ -f "${config_dir}/${slug}/system/system.yaml" ]; then
+    # Directory layout — agents[].id lives in stacks/<slug>.yaml.
+    printf '%s' "${config_dir}/${slug}/stacks/${slug}.yaml"
+  else
+    # Legacy monolith.
+    printf '%s' "${config_dir}/$(slug_to_config_file "${slug}")"
+  fi
+}
+
+# Discover all stack slugs under CONFIG_DIR. Prints one slug per line, sorted,
+# deduplicated. Never includes the relay daemon.
+#
+# cortex#717 / migration 0003 — two layouts coexist during the config-split
+# transition, and a stack may appear in BOTH (the split retains the root
+# monolith as a rollback anchor):
+#
+#   1. Directory layout: a subdir <config_dir>/<slug>/ containing
+#      system/system.yaml (the directory-layout marker). slug = dir basename.
+#   2. Legacy monolith: a root <config_dir>/cortex[.<slug>].yaml file.
+#
+# Precedence: the DIRECTORY LAYOUT WINS. If <config_dir>/<slug>/ exists for a
+# slug, the retained root monolith for that same slug is ignored (not double-
+# discovered) so `arc upgrade` doesn't re-point a split stack at its monolith.
+#
+# Args:
+#   $1 CONFIG_DIR — cortex config dir
 discover_stack_slugs() {
   local config_dir="$1"
-  # Use find + sort for deterministic ordering (glob expansion order is
-  # filesystem-dependent on some macOS versions).
+
+  # Pass 1: per-stack directories (the split layout). These take precedence.
+  # Marker: <config_dir>/<slug>/system/system.yaml. slug = the dir basename
+  # (parent of system/). find + sort gives deterministic ordering (glob order
+  # is filesystem-dependent on some macOS versions).
+  local dir_slugs=""
+  local marker slug
+  while IFS= read -r marker; do
+    [ -z "${marker}" ] && continue
+    slug="$(basename "$(dirname "$(dirname "${marker}")")")"
+    dir_slugs="${dir_slugs}${slug}"$'\n'
+    printf '%s\n' "${slug}"
+  done < <(find "${config_dir}" -mindepth 3 -maxdepth 3 -path '*/system/system.yaml' 2>/dev/null | sort)
+
+  # Pass 2: legacy root monoliths. Emit a monolith's slug ONLY when no per-stack
+  # dir already claimed it (dir wins → dedupe).
+  local cfg
   while IFS= read -r cfg; do
-    local slug
+    [ -z "${cfg}" ] && continue
     if slug="$(config_file_to_slug "${cfg}")"; then
+      # Skip if a per-stack dir already emitted this slug. -F: treat the slug
+      # as a fixed string (a slug is [a-zA-Z0-9_-] so this is belt-and-braces
+      # against any regex metachar leaking through).
+      if printf '%s' "${dir_slugs}" | grep -qxF "${slug}"; then
+        continue
+      fi
       printf '%s\n' "${slug}"
     fi
-  done < <(find "${config_dir}" -maxdepth 1 -name 'cortex*.yaml' | sort)
+  done < <(find "${config_dir}" -maxdepth 1 -name 'cortex*.yaml' 2>/dev/null | sort)
 }
 
 # Render the plist for a single stack slug into LAUNCH_DIR. Idempotent —
@@ -125,13 +211,19 @@ discover_stack_slugs() {
 #
 # Slug-to-template mapping:
 #   meta-factory → src/services/ai.meta-factory.cortex.meta-factory.plist
-#                  (has __AGENT_NAME__ extracted from cortex.yaml)
+#                  (has __AGENT_NAME__ + __CONFIG_PATH__)
 #   work         → src/services/ai.meta-factory.cortex.work.plist
+#                  (has __CONFIG_PATH__)
 #   <other>      → src/services/ai.meta-factory.cortex.stack.plist
-#                  (generic template; uses __STACK_SLUG__ + __CONFIG_FILE__)
+#                  (generic template; uses __STACK_SLUG__ + __CONFIG_PATH__)
 #
-# For any slug: if the config yaml is absent the plist is removed (same
-# stale-plist guard as the original cortex#244 work-stack logic, now
+# All templates carry __CONFIG_PATH__ — the layout-aware absolute --config
+# path (cortex#717): the per-stack sentinel under the directory layout, or the
+# legacy root monolith. This is what stops `arc upgrade` reverting the
+# config-split.
+#
+# For any slug: if the resolved config yaml is absent the plist is removed
+# (same stale-plist guard as the original cortex#244 work-stack logic, now
 # generalised to all stacks).
 #
 # Args:
@@ -149,10 +241,12 @@ render_stack_plist() {
 
   local dst="${launch_dir}/ai.meta-factory.cortex.${slug}.plist"
 
-  # Derive config filename from slug via the shared inverse function.
-  local config_file
-  config_file="$(slug_to_config_file "${slug}")"
-  local config_yaml="${config_dir}/${config_file}"
+  # Resolve the layout-aware --config path (cortex#717): per-stack sentinel
+  # when the directory layout exists, else the legacy root monolith. This is
+  # the path stamped into the plist's --config arg and the path whose
+  # existence gates the stale-plist guard below.
+  local config_yaml
+  config_yaml="$(resolve_stack_config_path "${config_dir}" "${slug}")"
 
   # If the config no longer exists, remove any stale rendered plist so
   # launchd doesn't crash-loop trying to start a daemon whose --config
@@ -161,9 +255,9 @@ render_stack_plist() {
     if [ -f "${dst}" ]; then
       launchctl unload "${dst}" 2>/dev/null || true
       rm -f "${dst}"
-      echo "  ⊘ ${slug} plist removed — ${config_file} not present (stack un-scaffolded)"
+      echo "  ⊘ ${slug} plist removed — ${config_yaml} not present (stack un-scaffolded)"
     else
-      echo "  ⊘ ${slug} plist skipped — ${config_file} not present"
+      echo "  ⊘ ${slug} plist skipped — ${config_yaml} not present"
     fi
     return 0
   fi
@@ -176,14 +270,19 @@ render_stack_plist() {
         echo "  ⚠ Template missing: ${src}" >&2
         return 1
       fi
+      # Agent id lives in stacks/<slug>.yaml under the dir layout, or the
+      # monolith under the legacy layout (cortex#717).
+      local agent_config
+      agent_config="$(resolve_stack_agent_config_path "${config_dir}" "${slug}")"
       local agent_name
-      agent_name="$(extract_agent_name "${config_yaml}")" || return 1
+      agent_name="$(extract_agent_name "${agent_config}")" || return 1
       sed -e "s|__CORTEX_DIR__|${cortex_dir}|g" \
           -e "s|__BUN_PATH__|${bun_path}|g" \
           -e "s|__HOME__|${HOME}|g" \
+          -e "s|__CONFIG_PATH__|${config_yaml}|g" \
           -e "s|__AGENT_NAME__|${agent_name}|g" \
           "${src}" > "${dst}"
-      echo "  ✓ meta-factory plist rendered → ${dst} (agent=${agent_name})"
+      echo "  ✓ meta-factory plist rendered → ${dst} (agent=${agent_name}, config=${config_yaml})"
       ;;
     work)
       local src="${cortex_dir}/src/services/ai.meta-factory.cortex.work.plist"
@@ -194,8 +293,9 @@ render_stack_plist() {
       sed -e "s|__CORTEX_DIR__|${cortex_dir}|g" \
           -e "s|__BUN_PATH__|${bun_path}|g" \
           -e "s|__HOME__|${HOME}|g" \
+          -e "s|__CONFIG_PATH__|${config_yaml}|g" \
           "${src}" > "${dst}"
-      echo "  ✓ work plist rendered → ${dst}"
+      echo "  ✓ work plist rendered → ${dst} (config=${config_yaml})"
       ;;
     *)
       # Generic stack — use the parameterised stack template.
@@ -208,9 +308,9 @@ render_stack_plist() {
           -e "s|__BUN_PATH__|${bun_path}|g" \
           -e "s|__HOME__|${HOME}|g" \
           -e "s|__STACK_SLUG__|${slug}|g" \
-          -e "s|__CONFIG_FILE__|${config_file}|g" \
+          -e "s|__CONFIG_PATH__|${config_yaml}|g" \
           "${src}" > "${dst}"
-      echo "  ✓ ${slug} plist rendered → ${dst}"
+      echo "  ✓ ${slug} plist rendered → ${dst} (config=${config_yaml})"
       ;;
   esac
 }
@@ -218,14 +318,16 @@ render_stack_plist() {
 # Render plists for relay + all discovered stacks into ${LAUNCH_DIR}.
 # Idempotent — overwrites any previous render of the same filename.
 #
-# cortex#700: stacks are now discovered from cortex*.yaml globs, not a
-# hardcoded list. Adding a new stack = adding its config; no script edit
-# needed.
+# cortex#700: stacks are discovered, not a hardcoded list. cortex#717:
+# discovery is config-split-aware — per-stack dirs (<slug>/system/system.yaml)
+# take precedence over retained root monoliths, and each plist's --config
+# points at the per-stack sentinel under the dir layout. Adding a new stack =
+# adding its config (dir or monolith); no script edit needed.
 #
 # Args:
 #   $1 CORTEX_DIR  — repo root (provides plist templates under src/services/)
 #   $2 LAUNCH_DIR  — target dir (typically ${HOME}/Library/LaunchAgents)
-#   $3 CONFIG_DIR  — cortex config dir (provides cortex*.yaml for discovery)
+#   $3 CONFIG_DIR  — cortex config dir (per-stack dirs and/or cortex*.yaml)
 render_cortex_plists() {
   local cortex_dir="$1"
   local launch_dir="$2"
@@ -250,8 +352,8 @@ render_cortex_plists() {
     echo "  ✓ Relay plist rendered → ${relay_dst}"
   fi
 
-  # Stack plists — one per discovered cortex*.yaml config (cortex#700).
-  # cortex.yaml → meta-factory, cortex.{slug}.yaml → {slug}
+  # Stack plists — one per discovered stack (cortex#700 + cortex#717).
+  # Per-stack dirs (<slug>/system/system.yaml) win over root monoliths.
   local rendered_count=0
   while IFS= read -r slug; do
     render_stack_plist "${cortex_dir}" "${launch_dir}" "${config_dir}" "${slug}" "${bun_path}" || true
@@ -259,6 +361,6 @@ render_cortex_plists() {
   done < <(discover_stack_slugs "${config_dir}")
 
   if [ "${rendered_count}" -eq 0 ]; then
-    echo "  ⚠ No cortex*.yaml configs found in ${config_dir} — no stack plists rendered" >&2
+    echo "  ⚠ No stacks discovered in ${config_dir} (no per-stack dirs or cortex*.yaml) — no stack plists rendered" >&2
   fi
 }

--- a/scripts/postupgrade.sh
+++ b/scripts/postupgrade.sh
@@ -39,22 +39,29 @@ echo "  ✓ Nested symlinks refreshed"
 # in. Idempotent — skipped when the field is already set.
 #
 # cortex#700: loop over all discovered stacks rather than hardcoding
-# cortex.yaml + cortex.work.yaml. Derive the nkey basename from the config
-# filename: cortex.yaml → "cortex", cortex.{slug}.yaml → "cortex-{slug}".
+# cortex.yaml + cortex.work.yaml. Derive the nkey basename from the slug:
+# meta-factory → "cortex", {slug} → "cortex-{slug}".
+#
+# cortex#717: target the file that actually carries the `stack:` block,
+# layout-aware. Under the directory layout that is stacks/<slug>.yaml (the
+# sentinel <slug>.yaml is a pointer with no stack block); under the legacy
+# monolith it is the monolith itself. resolve_stack_agent_config_path() gives
+# us that path — the same file extract_agent_name reads agents[].id from, and
+# the file where stack.id lives.
 echo "  Provisioning stack signing identity..."
 source "${SCRIPT_DIR}/lib/stack-identity-provision.sh"
 source "${SCRIPT_DIR}/lib/plist-render.sh"
 
 while IFS= read -r slug; do
-  local_config_file="$(slug_to_config_file "${slug}")"
-  # nkey basename: cortex.yaml → "cortex", cortex.{slug}.yaml → "cortex-{slug}".
+  stack_config="$(resolve_stack_agent_config_path "${CONFIG_DIR}" "${slug}")"
+  # nkey basename: meta-factory → "cortex", {slug} → "cortex-{slug}".
   if [ "${slug}" = "meta-factory" ]; then
     nkey_basename="cortex"
   else
     nkey_basename="cortex-${slug}"
   fi
-  if [ -f "${CONFIG_DIR}/${local_config_file}" ]; then
-    provision_stack_identity "${CONFIG_DIR}/${local_config_file}" "${nkey_basename}" || true
+  if [ -f "${stack_config}" ]; then
+    provision_stack_identity "${stack_config}" "${nkey_basename}" || true
   fi
 done < <(discover_stack_slugs "${CONFIG_DIR}")
 

--- a/scripts/preupgrade.sh
+++ b/scripts/preupgrade.sh
@@ -114,8 +114,10 @@ if [ "$(uname)" = "Darwin" ]; then
   # cortex#700: enumerate discovered stacks and stop each that is currently
   # registered with launchd. Replace the three hardcoded unload calls (meta-
   # factory / work and the now-removed halden gap) with a single loop driven
-  # by discover_stack_slugs. discover_stack_slugs globs cortex*.yaml so any
-  # new stack config is automatically included — no script edit required.
+  # by discover_stack_slugs. cortex#717: discover_stack_slugs is now config-
+  # split-aware (per-stack dirs win over retained root monoliths), so the
+  # recorded running-set matches what postupgrade renders + restarts. Any new
+  # stack (dir or monolith) is automatically included — no script edit needed.
   while IFS= read -r slug; do
     label="ai.meta-factory.cortex.${slug}"
     plist="${LAUNCH_DIR}/${label}.plist"

--- a/src/services/ai.meta-factory.cortex.meta-factory.plist
+++ b/src/services/ai.meta-factory.cortex.meta-factory.plist
@@ -9,7 +9,7 @@
         <string>__HOME__/bin/cortex</string>
         <string>start</string>
         <string>--config</string>
-        <string>__HOME__/.config/cortex/cortex.yaml</string>
+        <string>__CONFIG_PATH__</string>
     </array>
     <key>WorkingDirectory</key>
     <string>__CORTEX_DIR__</string>

--- a/src/services/ai.meta-factory.cortex.stack.plist
+++ b/src/services/ai.meta-factory.cortex.stack.plist
@@ -9,7 +9,7 @@
         <string>__HOME__/bin/cortex</string>
         <string>start</string>
         <string>--config</string>
-        <string>__HOME__/.config/cortex/__CONFIG_FILE__</string>
+        <string>__CONFIG_PATH__</string>
     </array>
     <key>WorkingDirectory</key>
     <string>__CORTEX_DIR__</string>

--- a/src/services/ai.meta-factory.cortex.work.plist
+++ b/src/services/ai.meta-factory.cortex.work.plist
@@ -9,7 +9,7 @@
         <string>__HOME__/bin/cortex</string>
         <string>start</string>
         <string>--config</string>
-        <string>__HOME__/.config/cortex/cortex.work.yaml</string>
+        <string>__CONFIG_PATH__</string>
     </array>
     <key>WorkingDirectory</key>
     <string>__CORTEX_DIR__</string>


### PR DESCRIPTION
## Problem

`arc upgrade Cortex` reverts the migration-0003 config-split. The #700 stack-aware lifecycle in `scripts/lib/plist-render.sh`:

- `discover_stack_slugs` globbed `find ... -name 'cortex*.yaml'` → found the **retained root monoliths** (rollback anchors).
- `render_stack_plist` set each plist's `--config` to `$config_dir/$(slug_to_config_file "$slug")` = the **monolith path**.

So postupgrade re-pointed every stack's plist back at the monolith → reverted the split (per-stack dir layout bypassed; `cortex-<slug>.pid` names collapse to `cortex-cortex*.pid`). DEPLOY-BLOCKER for v4.5.0.

## Fix (config-split-aware discovery + render)

**`discover_stack_slugs`** — discover per-stack dirs via the `<slug>/system/system.yaml` marker (slug = dir basename), AND legacy root monoliths, with **directory layout taking precedence**: a retained monolith is deduped away when its per-stack dir exists. On today's live state {meta-factory, work, halden} are discovered from the **dirs**; the monoliths are ignored.

**`render_stack_plist`** — `--config` resolves (new `resolve_stack_config_path`) to the per-stack **sentinel** `<slug>/<slug>.yaml` under the dir layout, else the legacy monolith. This preserves the unique `cortex-<slug>.pid` naming (migration 0003 PID-collision lesson). The three templates (`ai.meta-factory.cortex.{meta-factory,work,stack}.plist`) now carry a **`__CONFIG_PATH__`** placeholder instead of hardcoding the monolith path (the generic template's old `__CONFIG_FILE__` is replaced).

**`extract_agent_name`** — reads `agents[].id` from the file that carries it: `stacks/<slug>.yaml` under the dir layout (the sentinel is a pointer), else the monolith — via new `resolve_stack_agent_config_path`. The postupgrade **signing-identity provisioning** loop now targets the same file (where `stack.id` lives), so signing fields land in the live composed config, not the stale monolith.

**`preupgrade.sh`** — shares `discover_stack_slugs`, so its recorded running-set matches postupgrade's render/restart set (verified). Relay still handled separately. Stale-plist removal guard preserved.

## How monoliths are ignored + PID names preserved

- Dir discovery runs first and records each dir slug; the monolith pass skips any slug already claimed by a dir (`grep -qxF` dedupe). With both present (live state), only the dir slugs are emitted.
- Log/PID paths in the templates key off the **slug** (`cortex-<slug>.log`), not the config filename — so the unique `cortex-<slug>.pid` naming survives both layouts. New test asserts `cortex-halden.log` present and no `cortex-cortex` collision.

## Tests

Extended `scripts/__tests__/plist-render-stack-discovery.sh`:
- **config-split fixture**: per-stack dirs (meta-factory/, work/, halden/ each with `system/system.yaml` + `<slug>.yaml` sentinel + `stacks/<slug>.yaml`) AND retained root monoliths → asserts discovers exactly {meta-factory, work, halden} from the **dirs** (count = 3, not doubled), `--config` = per-stack sentinels, agent id read from `stacks/<slug>.yaml` (not the monolith), unique PID name.
- **mixed fixture**: one split stack + two pure monoliths → dir wins for the split one, monoliths for the rest.
- **legacy-only** (pre-existing sections) still pass — back-compat.

61/61 pass. `launchctl` mocked; no live `~/.config/cortex` touched.

## Verification

- Shell tests: **61 passed, 0 failed**
- `bunx tsc --noEmit`: clean (no TS touched)
- eslint `--quiet`: clean
- `bash scripts/check-carveouts.sh` (whole-tree, CI-authoritative): **PASS**
- shellcheck: no findings on new code (pre-existing info-level only on untouched `kill ${PIDS}` lines)

Constraints honored: shell + template placeholder edits only; no live `arc upgrade`/`launchctl`/`~/.config/cortex` mutation (the live smoke-test — held #700 AC — is the operator's).

Closes #717
Refs #700 #714

🤖 Generated with [Claude Code](https://claude.com/claude-code)