### PR TITLE
fix(adapters): C-721 — per-dispatch progress on bus sink paths (correlation_id)

### DIFF
--- a/src/adapters/__tests__/dispatch-sink.test.ts
+++ b/src/adapters/__tests__/dispatch-sink.test.ts
@@ -64,13 +64,14 @@ function fakeRuntime(): {
 function lifecycleEnvelope(
   type: string,
   payload: Record<string, unknown>,
+  correlationId = "task-1",
 ): Envelope {
   return {
     id: "00000000-0000-4000-8000-000000000099",
     source: "metafactory.runner.local",
     type,
     timestamp: "2026-05-09T12:00:00Z",
-    correlation_id: "task-1",
+    correlation_id: correlationId,
     sovereignty: {
       classification: "local",
       data_residency: "NZ",
@@ -221,6 +222,126 @@ describe("dispatch-sink — delivery to the originating target", () => {
     expect(adapter.sentMessages).toHaveLength(0);
     expect(adapter.progressSent).toHaveLength(1);
     expect(adapter.progressSent[0]!.text).toBe("Luna is working...");
+    // cortex#721 — progress carries the per-dispatch correlation key on
+    // `sessionId` so the adapter's `progressKey` scopes it per-dispatch.
+    expect(adapter.progressSent[0]!.target.sessionId).toBe("task-1");
+  });
+});
+
+// =============================================================================
+// cortex#721 — per-dispatch progress keying on the bus sink path
+//
+// The Discord adapter keys its "working…" placeholder on `target.sessionId`
+// (`progressKey` = `sessionId ? scope:sessionId : scope`). The bus sink built
+// the progress target with NO sessionId, so every dispatch's `started`
+// progress fell back to channel-scope and collapsed onto ONE edited message.
+// The fix threads `envelope.correlation_id` onto `sessionId`.
+// =============================================================================
+describe("dispatch-sink — per-dispatch progress keying (cortex#721)", () => {
+  test("two dispatches in the SAME channel get DISTINCT progress keys", async () => {
+    const { runtime, trigger } = fakeRuntime();
+    const adapter = new MockAdapter("discord-pai-collab");
+    const sink = createDispatchSink({ runtime, adapters: [adapter], principal: "metafactory" });
+    await sink.start();
+
+    // Two `started` envelopes, SAME channel/thread, DIFFERENT correlation_id.
+    trigger(
+      lifecycleEnvelope(
+        "dispatch.task.started",
+        {
+          agent_id: "luna",
+          response_routing: routing("discord-pai-collab", "C123", "T456"),
+        },
+        "corr-A",
+      ),
+    );
+    trigger(
+      lifecycleEnvelope(
+        "dispatch.task.started",
+        {
+          agent_id: "luna",
+          response_routing: routing("discord-pai-collab", "C123", "T456"),
+        },
+        "corr-B",
+      ),
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // Two SEPARATE progress messages, not one edited-in-place: the adapter
+    // would compute `progressKey` = `T456:corr-A` vs `T456:corr-B`.
+    expect(adapter.progressSent).toHaveLength(2);
+    const keys = adapter.progressSent.map((p) => p.target.sessionId);
+    expect(keys).toEqual(["corr-A", "corr-B"]);
+    expect(new Set(keys).size).toBe(2); // distinct
+    // Same channel/thread — only the session key distinguishes them.
+    expect(adapter.progressSent[0]!.target.channelId).toBe("C123");
+    expect(adapter.progressSent[1]!.target.channelId).toBe("C123");
+    expect(adapter.progressSent[0]!.target.threadId).toBe("T456");
+    expect(adapter.progressSent[1]!.target.threadId).toBe("T456");
+  });
+
+  test("falls back to payload.task_id when envelope.correlation_id is absent", async () => {
+    const { runtime, trigger } = fakeRuntime();
+    const adapter = new MockAdapter("discord-pai-collab");
+    const sink = createDispatchSink({ runtime, adapters: [adapter], principal: "metafactory" });
+    await sink.start();
+
+    // Build an envelope with NO top-level correlation_id; carry task_id instead.
+    const env = lifecycleEnvelope(
+      "dispatch.task.started",
+      {
+        agent_id: "luna",
+        task_id: "task-99",
+        response_routing: routing("discord-pai-collab", "C1"),
+      },
+      "task-1",
+    );
+    delete (env as { correlation_id?: string }).correlation_id;
+    trigger(env);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(adapter.progressSent).toHaveLength(1);
+    expect(adapter.progressSent[0]!.target.sessionId).toBe("task-99");
+  });
+
+  test("the terminal completed reply clears nothing extra and posts once per correlation", async () => {
+    const { runtime, trigger } = fakeRuntime();
+    const adapter = new MockAdapter("discord-pai-collab");
+    const sink = createDispatchSink({ runtime, adapters: [adapter], principal: "metafactory" });
+    await sink.start();
+
+    // started for corr-A, then completed for corr-A only.
+    trigger(
+      lifecycleEnvelope(
+        "dispatch.task.started",
+        {
+          agent_id: "luna",
+          response_routing: routing("discord-pai-collab", "C123"),
+        },
+        "corr-A",
+      ),
+    );
+    trigger(
+      lifecycleEnvelope(
+        "dispatch.task.completed",
+        {
+          agent_id: "luna",
+          chat_response: "done A",
+          response_routing: routing("discord-pai-collab", "C123"),
+        },
+        "corr-A",
+      ),
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // One progress (corr-A) + one durable reply (the terminal completed).
+    expect(adapter.progressSent).toHaveLength(1);
+    expect(adapter.progressSent[0]!.target.sessionId).toBe("corr-A");
+    expect(adapter.sentMessages).toHaveLength(1);
+    expect(adapter.sentMessages[0]!.text).toBe("done A");
   });
 });
 
@@ -471,6 +592,8 @@ describe("dispatch-sink — gateway multi-stack subscription (a.3d)", () => {
     expect(adapterA.progressSent[0]!.target).toEqual({
       instanceId: "discord:guild-A",
       channelId: "C-A",
+      // cortex#721 — progress carries the per-dispatch correlation key.
+      sessionId: "task-1",
     });
     expect(adapterB.progressSent).toHaveLength(0);
   });

--- a/src/adapters/__tests__/review-sink.test.ts
+++ b/src/adapters/__tests__/review-sink.test.ts
@@ -58,13 +58,18 @@ function fakeRuntime(): {
   };
 }
 
-function envelope(type: string, payload: Record<string, unknown>): Envelope {
+function envelope(
+  type: string,
+  payload: Record<string, unknown>,
+  correlationId = "req-1",
+  id = "00000000-0000-4000-8000-000000000099",
+): Envelope {
   return {
-    id: "00000000-0000-4000-8000-000000000099",
+    id,
     source: "metafactory.echo.local",
     type,
     timestamp: "2026-05-29T12:00:00Z",
-    correlation_id: "req-1",
+    correlation_id: correlationId,
     sovereignty: {
       classification: "local",
       data_residency: "NZ",
@@ -240,6 +245,10 @@ describe("review-sink — lifecycle delivery", () => {
     expect(adapter.sentMessages).toHaveLength(0);
     expect(adapter.progressSent).toHaveLength(1);
     expect(adapter.progressSent[0]!.text).toContain("Luna is working");
+    // cortex#721 — progress carries the per-review correlation key on
+    // `sessionId` (resolved targets carry none), so the adapter scopes the
+    // placeholder per-review rather than per-channel.
+    expect(adapter.progressSent[0]!.target.sessionId).toBe("req-1");
   });
 
   test("dispatch.task.failed → postResponse error reply", async () => {
@@ -282,6 +291,100 @@ describe("review-sink — lifecycle delivery", () => {
 
     expect(adapter.sentMessages).toHaveLength(1);
     expect(adapter.sentMessages[0]!.text).toContain("stopped");
+  });
+});
+
+// =============================================================================
+// cortex#721 — per-review progress keying on the bus sink path
+//
+// Same defect class as the dispatch sink: `resolveTarget` returns a target
+// with NO sessionId, so two concurrent reviews in the same channel/thread
+// collapsed onto one "reviewing…" placeholder. The fix threads
+// `envelope.correlation_id` onto the progress target's `sessionId`.
+// =============================================================================
+describe("review-sink — per-review progress keying (cortex#721)", () => {
+  test("two reviews in the SAME thread get DISTINCT progress keys", async () => {
+    const { runtime, trigger } = fakeRuntime();
+    const adapter = discordMock();
+    const sink = createReviewSink({ runtime, adapters: [adapter], principal: "metafactory" });
+    await sink.start();
+
+    // Distinct envelope ids so the at-most-once `alreadyRendered` guard
+    // (keyed on `envelope.id`) doesn't drop the second `started`.
+    trigger(
+      envelope(
+        "dispatch.task.started",
+        {
+          agent_id: "luna",
+          response_routing: logicalRouting("discord", "cortex", "cortex/pr/57"),
+        },
+        "rev-A",
+        "00000000-0000-4000-8000-0000000000a1",
+      ),
+    );
+    trigger(
+      envelope(
+        "dispatch.task.started",
+        {
+          agent_id: "luna",
+          response_routing: logicalRouting("discord", "cortex", "cortex/pr/57"),
+        },
+        "rev-B",
+        "00000000-0000-4000-8000-0000000000a2",
+      ),
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(adapter.progressSent).toHaveLength(2);
+    const keys = adapter.progressSent.map((p) => p.target.sessionId);
+    expect(keys).toEqual(["rev-A", "rev-B"]);
+    expect(new Set(keys).size).toBe(2); // distinct, not collapsed
+    // Same resolved channel/thread — only the session key distinguishes them.
+    expect(adapter.progressSent[0]!.target.channelId).toBe(
+      adapter.progressSent[1]!.target.channelId,
+    );
+  });
+
+  test("completed for one review's correlation clears only its own placeholder key", async () => {
+    const { runtime, trigger } = fakeRuntime();
+    const adapter = discordMock();
+    const sink = createReviewSink({ runtime, adapters: [adapter], principal: "metafactory" });
+    await sink.start();
+
+    // started for rev-A, then the terminal verdict for rev-A. Distinct
+    // envelope ids so the at-most-once guard doesn't drop the verdict.
+    trigger(
+      envelope(
+        "dispatch.task.started",
+        {
+          agent_id: "luna",
+          response_routing: logicalRouting("discord", "cortex", "cortex/pr/57"),
+        },
+        "rev-A",
+        "00000000-0000-4000-8000-0000000000b1",
+      ),
+    );
+    trigger(
+      envelope(
+        "review.verdict.changes-requested",
+        {
+          ...verdictPayload(),
+          response_routing: logicalRouting("discord", "cortex", "cortex/pr/57"),
+        },
+        "rev-A",
+        "00000000-0000-4000-8000-0000000000b2",
+      ),
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // One progress keyed on rev-A, plus the durable verdict reply.
+    expect(adapter.progressSent).toHaveLength(1);
+    expect(adapter.progressSent[0]!.target.sessionId).toBe("rev-A");
+    expect(adapter.sentMessages).toHaveLength(1);
   });
 });
 

--- a/src/adapters/dispatch-sink.ts
+++ b/src/adapters/dispatch-sink.ts
@@ -72,6 +72,32 @@ function readResponseRouting(envelope: Envelope): WireResponseRouting | null {
   };
 }
 
+/**
+ * cortex#721 — derive the per-dispatch correlation key for progress keying.
+ *
+ * The Discord adapter keys its "working…" progress placeholder on
+ * `target.sessionId` (`progressKey` = `sessionId ? scope:sessionId : scope`).
+ * The in-process dispatch-handler path (cortex#708/#713) threads the inbound
+ * correlation onto `sessionId`; the BUS sink path never did, so every
+ * dispatch's `started` progress fell back to channel-scope and collapsed
+ * onto ONE edited-in-place message.
+ *
+ * The lifecycle envelope already carries a per-dispatch correlation: the
+ * UUID-shaped `envelope.correlation_id` (set to the task UUID by
+ * `dispatch-events.buildBaseEnvelope`), with `payload.task_id` as the
+ * belt-and-braces fallback (the same `correlation_id ?? task_id` join the
+ * runner uses). Returns `undefined` only when neither is present — then
+ * channel-scoped keying is the correct (pre-#708) behaviour.
+ */
+export function dispatchCorrelationKey(envelope: Envelope): string | undefined {
+  if (typeof envelope.correlation_id === "string" && envelope.correlation_id.length > 0) {
+    return envelope.correlation_id;
+  }
+  const taskId = envelope.payload.task_id;
+  if (typeof taskId === "string" && taskId.length > 0) return taskId;
+  return undefined;
+}
+
 /** Lifecycle event types the sink delivers. */
 const LIFECYCLE_TYPE_PREFIX = "dispatch.task.";
 
@@ -267,7 +293,19 @@ export function createDispatchSink(opts: DispatchSinkOptions): DispatchSink {
         // A `started` event is a progress/typing indicator, not a final
         // reply — edit-in-place so the terminal `completed`/`failed`
         // reply is the durable message in the channel.
-        await adapter.sendProgress(target, text);
+        //
+        // cortex#721 — key per-dispatch progress on the lifecycle envelope's
+        // correlation id so two dispatches in the same channel/thread each
+        // get their OWN "working…" placeholder instead of editing one shared
+        // message. Set `sessionId` ONLY on the progress target: `postResponse`
+        // ignores it, and only `sendProgress` (edit-in-place) reads it via
+        // the adapter's `progressKey`.
+        const correlationKey = dispatchCorrelationKey(envelope);
+        const progressTarget: ResponseTarget =
+          correlationKey !== undefined
+            ? { ...target, sessionId: correlationKey }
+            : target;
+        await adapter.sendProgress(progressTarget, text);
         return;
       }
       // `completed` / `failed` / `aborted` — the terminal reply.

--- a/src/adapters/review-sink.ts
+++ b/src/adapters/review-sink.ts
@@ -56,6 +56,7 @@
 import type { Envelope } from "../bus/myelin/envelope-validator";
 import type { MyelinRuntime } from "../bus/myelin/runtime";
 import type { MyelinSubscriber } from "../bus/myelin/subscriber";
+import { dispatchCorrelationKey } from "./dispatch-sink";
 import {
   formatDispatchLifecycle,
   formatReviewVerdict,
@@ -355,7 +356,19 @@ export function createReviewSink(opts: ReviewSinkOptions): ReviewSink {
         // `started` is a progress/typing indicator (e.g. "Echo is
         // reviewing…"), not a final reply — edit-in-place so the terminal
         // verdict/failed reply is the durable message.
-        await adapter.sendProgress(target, text);
+        //
+        // cortex#721 — key the per-review progress placeholder on the
+        // lifecycle envelope's correlation id (resolved targets carry no
+        // `sessionId`), so two reviews in the same channel/thread each get
+        // their OWN "reviewing…" message instead of editing one shared
+        // placeholder. `postResponse` ignores `sessionId`; only
+        // `sendProgress` reads it via the adapter's `progressKey`.
+        const correlationKey = dispatchCorrelationKey(envelope);
+        const progressTarget: ResponseTarget =
+          correlationKey !== undefined
+            ? { ...target, sessionId: correlationKey }
+            : target;
+        await adapter.sendProgress(progressTarget, text);
         return;
       }
       // Verdict / completed / failed / aborted — the terminal reply.


### PR DESCRIPTION
Closes #721
Refs #708 #713

## Problem

The "Luna is working…" progress placeholder is still reused across bus dispatches in the same channel/thread — sequential interactions collapse onto one message. #708/#713 keyed progress on `target.sessionId` and threaded it on the **in-process dispatch-handler** path, but the **bus sink paths** never set it.

The Discord adapter's `progressKey` is `sessionId ? ${scope}:${sessionId} : scope` (`src/adapters/discord/index.ts:820`). Both `dispatch-sink` and `review-sink` built the progress `ResponseTarget` with **no `sessionId`**, so every dispatch's `started` progress fell back to channel-scope and edited the same message.

## Fix

The lifecycle envelope already carries `correlation_id` (unique per dispatch — it joins started→completed). Thread it onto the progress target's `sessionId` in both sinks:

- New exported helper `dispatchCorrelationKey(envelope)` in `dispatch-sink.ts` — returns `envelope.correlation_id`, falling back to `payload.task_id` (the same `correlation_id ?? task_id` join the runner uses), or `undefined` (→ channel-scoped, pre-#708 behaviour) when neither is present.
- `dispatch-sink`: set `sessionId` on the **progress** target only (the `dispatch.task.started` branch). `postResponse` ignores `sessionId`, so the terminal reply target is unchanged.
- `review-sink`: same, layered onto the resolved logical target (which carries no `sessionId`).

Each dispatch now keys its own placeholder (`${scope}:${correlation_id}`); concurrent/sequential dispatches no longer collapse. No change to channel-scoped result/buffering or the (already-correct) dispatch-handler path.

## Tests

Extended both sink suites:
- Two `dispatch.task.started` envelopes, **distinct `correlation_id`**, **same channel/thread** → adapter receives **two distinct progress keys** (asserted via the mock adapter's recorded `sessionId`), not one edited-in-place.
- `payload.task_id` fallback when `correlation_id` is absent.
- A terminal reply (completed / verdict) for one correlation posts once and keeps its own progress key.

## Verification

- `bunx tsc --noEmit` → 0
- `bun test src/adapters/` → 375 pass, 0 fail
- full `bun test` → 4389 pass, 0 fail (no new failures)
- `eslint` on changed files → clean (0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)