### PR TITLE
fix(dispatch): C-723 — trust-scope the prompt-injection filter (don't hard-block the operator)

### DIFF
--- a/src/bus/__tests__/dispatch-handler.test.ts
+++ b/src/bus/__tests__/dispatch-handler.test.ts
@@ -928,6 +928,134 @@ describe("DispatchHandler — chat-path CC failure retry (cortex#360)", () => {
 });
 
 // ---------------------------------------------------------------------------
+// cortex#723 — prompt-injection filter is trust-scoped at the dispatch-handler
+// caller. The filter (@metafactory/content-filter, scanPrompt) gates UNTRUSTED
+// inbound content; the home principal commands their OWN assistant and must not
+// be hard-blocked by it. The live FP that motivated this: PI-002 role_play_trigger
+// matched "…would act as a jumphost" (legit infra language) in Andreas's own DM.
+//
+// Contract:
+//   - home-principal DM whose content matches a block pattern → PROCESSED
+//     (reaches the CC path, NO "I can't process that message" reply), and the
+//     match is LOGGED for principal visibility.
+//   - untrusted sender's role-play injection → still BLOCKED (posts the
+//     "I can't process that message" reply, never reaches CC).
+//
+// The scanner itself is unchanged — the trust decision belongs at the caller,
+// which holds the policy context (sender principal/role via `msg.dmType`).
+// ---------------------------------------------------------------------------
+
+describe("DispatchHandler — prompt-filter trust scope (cortex#723)", () => {
+  // Content that reliably trips PI-002 (role_play_trigger, "act as") in the
+  // real @metafactory/content-filter — the exact FP class from the issue.
+  const ACT_AS_CONTENT =
+    "Dig deeper — the probe is not the jump host. A different machine would act as a jumphost.";
+
+  let originalWarn: typeof console.warn;
+  let originalError: typeof console.error;
+  let originalLog: typeof console.log;
+  let logLines: string[];
+
+  beforeEach(() => {
+    originalWarn = console.warn;
+    originalError = console.error;
+    originalLog = console.log;
+    logLines = [];
+    console.warn = () => {};
+    console.error = () => {};
+    // Capture log output so we can assert the home-principal match is logged
+    // for principal visibility (the issue's "log/flag for visibility" clause).
+    console.log = (...args: unknown[]) => {
+      logLines.push(args.map((a) => String(a)).join(" "));
+    };
+  });
+
+  afterEach(() => {
+    console.warn = originalWarn;
+    console.error = originalError;
+    console.log = originalLog;
+  });
+
+  test("home-principal DM matching a block pattern is PROCESSED (not blocked) and the match is logged for visibility", async () => {
+    const { factory, spawnCount } = makeStubFactory([
+      successResult({ response: "On it — here's the jumphost answer." }),
+    ]);
+
+    const adapter = new MockAdapter();
+    const handler = new DispatchHandler({
+      config: makeConfig(),
+      securityPreamble: "",
+      ccSessionFactory: factory,
+    });
+
+    await handler.handleMessage(
+      adapter,
+      makeMsg({
+        platform: "discord",
+        authorId: "principal1",
+        content: ACT_AS_CONTENT,
+        isDM: true,
+        dmType: "principal",
+      }),
+    );
+
+    // The message reached the CC path — the filter did NOT short-circuit it.
+    expect(spawnCount()).toBe(1);
+
+    const texts = adapter.sentMessages.map((m) => m.text);
+    // No filter-block reply was posted to the principal.
+    expect(texts.some((t) => t.includes("I can't process that message"))).toBe(false);
+    expect(texts.some((t) => t.includes("Content filter blocked"))).toBe(false);
+    // The CC response (success path) was posted instead.
+    expect(texts).toContain("On it — here's the jumphost answer.");
+
+    // The match is still logged for principal visibility (cortex#723).
+    expect(
+      logLines.some(
+        (l) => l.includes("[PROMPT-FILTER]") && l.includes("home-principal"),
+      ),
+    ).toBe(true);
+
+    await handler.shutdown();
+  });
+
+  test("untrusted sender's role-play injection is still BLOCKED (posts the can't-process reply, no CC spawn)", async () => {
+    const { factory, spawnCount } = makeStubFactory([
+      successResult({ response: "should never run" }),
+    ]);
+
+    const adapter = new MockAdapter();
+    const handler = new DispatchHandler({
+      config: makeConfig(),
+      securityPreamble: "",
+      ccSessionFactory: factory,
+    });
+
+    // Same block-triggering content, but from an untrusted (non-principal)
+    // sender — a plain guild message, not a principal DM. Must stay blocked.
+    await handler.handleMessage(
+      adapter,
+      makeMsg({
+        platform: "discord",
+        authorId: "user999",
+        authorName: "Stranger",
+        content: ACT_AS_CONTENT,
+      }),
+    );
+
+    // The filter short-circuited before any CC spawn.
+    expect(spawnCount()).toBe(0);
+
+    const texts = adapter.sentMessages.map((m) => m.text);
+    expect(texts.length).toBe(1);
+    expect(texts[0]).toContain("I can't process that message");
+    expect(texts[0]).toContain("Content filter blocked");
+
+    await handler.shutdown();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Direction A Stage 4-B (cortex#409) — publishInboundDispatchEnvelope
 //
 // Dispatch-source path. The handler publishes chat/direct dispatches as

--- a/src/bus/dispatch-handler.ts
+++ b/src/bus/dispatch-handler.ts
@@ -711,9 +711,26 @@ export class DispatchHandler extends EventEmitter {
       // includes /Users/... paths (PII-008). See grove#179.
       const filterResult = scanPrompt(parsed.content, msg.platform);
       if (!filterResult.allowed) {
-        const target = this.targetFromMsg(adapter, msg);
-        await adapter.postResponse(target, `I can't process that message. ${filterResult.reason ?? ""}`);
-        return;
+        // cortex#723 — trust-scope the hard-block. A prompt-injection filter
+        // gates UNTRUSTED content (cross-principal, relayed, webhook); the home
+        // principal commands their OWN assistant and cannot "inject" it.
+        // Hard-blocking the principal's direct messages is a category error
+        // that breaks principal control (live FP: PI-002 "act as a jumphost" —
+        // legit infra language). `isPrincipalDM` (set above) is true only when
+        // an adapter classified the sender as the home principal via the
+        // PolicyEngine principal-role capability — the authoritative trust
+        // signal. For that sender, log the match for visibility and ALLOW.
+        // Untrusted senders (unknown / cross-principal without trust) stay
+        // hard-blocked exactly as before — the filter is NOT weakened for them.
+        if (isPrincipalDM) {
+          console.log(
+            `dispatch-handler: [PROMPT-FILTER] allowing home-principal message despite match (${filterResult.reason ?? "unspecified"}) — the principal commands their own assistant (cortex#723): "${parsed.content.slice(0, 100)}"`,
+          );
+        } else {
+          const target = this.targetFromMsg(adapter, msg);
+          await adapter.postResponse(target, `I can't process that message. ${filterResult.reason ?? ""}`);
+          return;
+        }
       }
 
       // 11. Build CC invocation options


### PR DESCRIPTION
Closes #723

## Problem

`src/bus/dispatch-handler.ts` calls `scanPrompt(parsed.content, msg.platform)` and **hard-blocks** on a BLOCKED decision regardless of WHO sent the message. A prompt-injection filter exists to gate **untrusted** content (cross-principal, relayed, webhook). The **home principal commands their own assistant** and cannot "inject" it — hard-blocking their direct messages is a category error that breaks principal control.

**Live bug:** the home principal DM'd the assistant *"…a different machine to the halden stack that would **act as** a jumphost"* → `@metafactory/content-filter` PI-002 (`role_play_trigger`) matched `act\s+as\b` (legit infrastructure language) → *"I can't process that message. Content filter blocked this message (matched: PI-002)"*.

## Fix

Trust-scope the hard-block at the **caller** (which holds the policy context):

- Gate on `isPrincipalDM` — already resolved a few lines above from `msg.dmType === "principal"`, which adapters set **only** via the authoritative PolicyEngine principal-role capability (`isOperatorPrincipal`). Not spoofable by message content.
- For the home principal: **log the match for visibility** (`dispatch-handler: [PROMPT-FILTER] …`) and **ALLOW** the message through to the CC path.
- For everyone else (unknown / cross-principal / guild): **byte-identical** to the prior behavior — posts the can't-process reply and returns. The filter is **NOT weakened** for untrusted inbound.

`scanPrompt` itself is unchanged — it's the scanner; the trust decision belongs at the dispatch-handler.

## Tests (`src/bus/__tests__/dispatch-handler.test.ts`)

New describe block `DispatchHandler — prompt-filter trust scope (cortex#723)`:

1. **home-principal DM** whose content trips PI-002 (`"…would act as a jumphost"`) is **PROCESSED** — reaches the CC path (fake `ccSessionFactory`, `spawnCount === 1`), posts the CC response, posts **no** can't-process reply, and the match **is logged** (asserted via captured `console.log`).
2. **untrusted sender** sending the same block-triggering content is still **BLOCKED** — `spawnCount === 0`, posts *"I can't process that message … Content filter blocked"*.

## Verification

- `bunx tsc --noEmit` → 0
- `bun test src/bus/ src/runner/` → green (1024 pass / 0 fail)
- full `bun test` → 4391 pass / 0 fail / 2 skip — no new failures
- `eslint` on changed files → clean
- vocab carve-out gate → PASS (used canonical `principal` vocabulary, not deprecated `operator`)

## Follow-up (separate, NOT in this PR)

PI-002's bare `act\s+as\b` over-matches descriptive "X acts as Y". That pattern tuning lives in `@metafactory/content-filter` and is filed separately (narrow to clause-initial/imperative or assistant-directed role-play). This cortex PR only fixes the trust-scope category error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)