### PR TITLE
feat(bus): C-725 — federated review consumer handles Direct (@reviewer) requests

### DIFF
--- a/src/bus/__tests__/review-consumer.test.ts
+++ b/src/bus/__tests__/review-consumer.test.ts
@@ -59,6 +59,7 @@ import {
   type ReviewRequestPayload,
   type ReviewVerdictKind,
 } from "../review-events";
+import { encodeDidSegment } from "@the-metafactory/myelin/subjects";
 import type { JsMsg } from "nats";
 import type {
   ReviewPipelineOpts,
@@ -1771,5 +1772,151 @@ describe("ReviewConsumer — federated mode (cortex#686, ADR 0002)", () => {
       "review.verdict.approved",
       "dispatch.task.completed",
     ]);
+  });
+});
+
+describe("ReviewConsumer — federated DIRECT mode (cortex#725, ADR 0001/0002 §2)", () => {
+  // pilot#149 Direct dispatch (`--reviewer echo@jc/sage-host`) lands on this
+  // stack's OWN `federated.{me}.{my-stack}.tasks.@{did-encoded-reviewer}.code-review.{flavor}`
+  // subject — the named reviewer's DID is spliced in as an `@{did}` segment
+  // AFTER `tasks.`. cortex#725's NEW subscription `federated.{me}.{my-stack}.
+  // tasks.*.code-review.>` matches it (whole-token `*` over the `@{did}`
+  // segment). The inbound subject we pass here is exactly what that subscription
+  // delivers — TARGET = us (metafactory/meta-factory), reviewer = `did:mf:echo`.
+  //
+  // The KEY invariant cortex#725 proves: the federated consumer PATH is
+  // IDENTICAL for Direct and Offer. `envelope.type` is STILL
+  // `tasks.code-review.{flavor}` (the `@{did}` lives ONLY on the subject —
+  // myelin's `type` grammar forbids `@`), so `extractFlavor`, the requester
+  // decode from `originator.identity`, the peers[] gate, and the verdict-back
+  // routing are all the SAME code. Only the inbound subject differs.
+  const REVIEWER_SEGMENT = encodeDidSegment("did:mf:echo"); // → @did-mf-echo
+  const FED_DIRECT_SUBJECT =
+    `federated.metafactory.meta-factory.tasks.${REVIEWER_SEGMENT}.code-review.typescript`;
+
+  /** Shared federated opts: federated mode + the `jc`-peer network. */
+  function federatedOpts(
+    overrides: Partial<ReviewConsumerOpts> = {},
+  ): Partial<ReviewConsumerOpts> {
+    return {
+      federated: true,
+      federatedNetworks: [makeNetwork()],
+      ...overrides,
+    };
+  }
+
+  test("the Direct subject's @{did} segment is the reviewer/target-assistant, NOT the requester", () => {
+    // Sanity-pin the fixture: the `@{did}` on the subject decodes to the
+    // reviewer (echo), proving the requester must come from `originator`
+    // (jc.sage-host), never from the subject.
+    expect(FED_DIRECT_SUBJECT).toContain(".tasks.@did-mf-echo.code-review.");
+    expect(parseRequesterFromOriginator(makeFederatedRequest())).toEqual({
+      principal: "jc",
+      stack: "sage-host",
+    });
+  });
+
+  test("DIRECT verdict path → routed to REQUESTER (from originator), identical to Offer", async () => {
+    const runtime = createRecordingRuntime();
+    const request = makeFederatedRequest();
+    const verdict = buildVerdictEnvelope(request, "approved");
+
+    const consumer = new ReviewConsumer(
+      baseOpts(
+        federatedOpts({
+          runtime,
+          pipelineRunner: fixedPipeline((opts) => {
+            // Direct still stamps federated sovereignty.
+            expect(opts.classification).toBe("federated");
+            return { kind: "verdict", envelope: verdict };
+          }),
+        }),
+      ),
+    );
+
+    const decision = await consumer.processEnvelope(
+      request,
+      FED_DIRECT_SUBJECT,
+      null,
+    );
+    expect(decision).toEqual({ kind: "ack" });
+
+    // NOTHING on the local `publish` path; everything on `publishOnSubject`.
+    expect(runtime.published).toHaveLength(0);
+    const subjects = runtime.publishedOnSubject.map((p) => p.subject);
+    const types = runtime.publishedOnSubject.map((p) => p.envelope.type);
+    expect(types).toEqual([
+      "dispatch.task.started",
+      "review.verdict.approved",
+      "dispatch.task.completed",
+    ]);
+    // Verdict-back keyed on the REQUESTER (jc.sage-host, decoded from
+    // `originator.identity`), NOT on the subject's reviewer `@{did}` and NOT on
+    // the consumer's own principal — IDENTICAL to the Offer path.
+    for (const s of subjects) {
+      expect(s.startsWith("federated.jc.sage-host.")).toBe(true);
+    }
+    expect(subjects[1]).toBe("federated.jc.sage-host.review.verdict.approved");
+    expect(subjects[2]).toBe("federated.jc.sage-host.dispatch.task.completed");
+  });
+
+  test("DIRECT request from a NON-PEER requester → DENIED + DROPPED (no spawn, no publish)", async () => {
+    const runtime = createRecordingRuntime();
+    // Well-formed DID for `mallory` (decodes cleanly) — the ONLY reason to deny
+    // is non-membership in any configured network's peers[].
+    const request = makeFederatedRequest("did:mf:mallory-host");
+
+    let pipelineRan = false;
+    const consumer = new ReviewConsumer(
+      baseOpts(
+        federatedOpts({
+          runtime,
+          pipelineRunner: fixedPipeline(() => {
+            pipelineRan = true;
+            throw new Error("reviewer must NOT be spawned for a non-peer requester");
+          }),
+        }),
+      ),
+    );
+
+    const decision = await consumer.processEnvelope(
+      request,
+      FED_DIRECT_SUBJECT,
+      null,
+    );
+    expect(decision.kind).toBe("term");
+    expect(pipelineRan).toBe(false);
+    // The verdict (carrying reviewed-code findings) never reaches an untrusted
+    // principal — same fail-closed gate as the Offer path.
+    expect(runtime.published).toHaveLength(0);
+    expect(runtime.publishedOnSubject).toHaveLength(0);
+  });
+
+  test("DIRECT request with no resolvable requester (absent originator) → DENIED + DROPPED", async () => {
+    const runtime = createRecordingRuntime();
+    const request = makeFederatedRequest(NO_ORIGINATOR);
+
+    let pipelineRan = false;
+    const consumer = new ReviewConsumer(
+      baseOpts(
+        federatedOpts({
+          runtime,
+          pipelineRunner: fixedPipeline(() => {
+            pipelineRan = true;
+            throw new Error("reviewer must NOT be spawned for an un-attributable request");
+          }),
+        }),
+      ),
+    );
+
+    const decision = await consumer.processEnvelope(
+      request,
+      FED_DIRECT_SUBJECT,
+      null,
+    );
+    expect(decision.kind).toBe("term");
+    expect(pipelineRan).toBe(false);
+    expect(runtime.published).toHaveLength(0);
+    expect(runtime.publishedOnSubject).toHaveLength(0);
   });
 });

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -998,6 +998,23 @@ export async function startCortex(
   const federationConfigured =
     (options.policy?.federated?.networks ?? []).length > 0;
   const reviewFederatedSubjectPattern = `federated.${reviewPrincipalId}.${derivedStack.stack}.tasks.code-review.>`;
+  // cortex#725 (ADR 0001/0002 §2) — the FEDERATED **Direct** review pattern.
+  // pilot#149's `--reviewer {name}@{principal}/{stack}` Direct dispatch lands
+  // on `federated.{me}.{my-stack}.tasks.@{did-encoded-reviewer}.code-review.{flavor}`:
+  // the named reviewer's DID is spliced in as an `@{did}` segment AFTER `tasks.`
+  // (pilot's `deriveReviewRequestSubject`). The Offer filter above expects
+  // `code-review` in that position, so it never matches a Direct request —
+  // `pilot --reviewer name@p/s --wait` hangs (the cortex#725 gap).
+  //
+  // NATS whole-token `*` matches the entire `@{did-encoded-reviewer}` segment
+  // (same convention the LOCAL Direct dispatch uses: `local.{p}.{s}.tasks.*.>`
+  // in `dispatch-listener.ts`); the trailing literal `code-review` + `>`
+  // narrows to code-review flavors only (not every capability). The
+  // `envelope.type` of a Direct request is STILL `tasks.code-review.{flavor}`
+  // (the `@{did}` lives ONLY on the subject — myelin's `type` grammar forbids
+  // `@`), so `extractFlavor` + the whole federated consumer path work
+  // unchanged: only this extra subscription differs from the Offer path.
+  const reviewFederatedDirectSubjectPattern = `federated.${reviewPrincipalId}.${derivedStack.stack}.tasks.*.code-review.>`;
   const reviewConfig = options.bus?.review;
   const reviewStream = reviewConfig?.stream.name ?? "CODE_REVIEW";
   const reviewStreamMaxAgeNs =
@@ -1026,8 +1043,16 @@ export async function startCortex(
   // patterns, so an inbound `federated.{me}.{stack}.tasks.code-review.…`
   // request from a peer is captured by the same JetStream stream the local
   // consumer binds. A parallel federated DURABLE (per agent) binds below.
+  // cortex#725 — the Direct federated pattern joins the stream filter too, so
+  // an inbound `federated.{me}.{stack}.tasks.@{did}.code-review.…` Direct
+  // request is captured by the same CODE_REVIEW stream the Offer + local
+  // consumers bind. A parallel Direct DURABLE (per agent) binds below.
   const reviewStreamSubjects = federationConfigured
-    ? [reviewSubjectPattern, reviewFederatedSubjectPattern]
+    ? [
+        reviewSubjectPattern,
+        reviewFederatedSubjectPattern,
+        reviewFederatedDirectSubjectPattern,
+      ]
     : [reviewSubjectPattern];
 
   if (reviewJsm !== null) {
@@ -1298,47 +1323,75 @@ export async function startCortex(
       // flag). Only wired when a `federated:` policy block is declared — a
       // non-federating deployment skips this entirely (back-compat).
       if (federationConfigured) {
-        const federatedConsumer = makeConsumer(true);
-        reviewConsumers.push(federatedConsumer);
-        const federatedDurable = `cortex-review-consumer-federated-${reviewPrincipalId}-${agent.id}`;
-        if (reviewJsm !== null) {
-          try {
-            const outcome = await provisionReviewConsumer({
-              jsm: reviewJsm,
-              stream: reviewStream,
-              durable: federatedDurable,
-              maxDeliver: reviewConsumerMaxDeliver,
-            });
-            if (outcome === "created") {
-              console.log(
-                `cortex: provisioned JetStream durable "${federatedDurable}" on stream "${reviewStream}"`,
-              );
-            } else if (outcome === "updated") {
-              console.log(
-                `cortex: reconciled JetStream durable "${federatedDurable}" ack_wait (cortex#422) on stream "${reviewStream}"`,
+        // cortex#686 + cortex#725 — wire BOTH federated consumers (Offer +
+        // Direct) for this agent. They share the `makeConsumer(true)`
+        // construction (same reviewer, verifier, peers gate, verdict-back) and
+        // the SAME CODE_REVIEW stream; they differ ONLY in the subscription
+        // pattern + the durable (so Offer and Direct traffic ack independently).
+        // Factored into a closure so the two can't drift on provisioning /
+        // start / log wiring.
+        const startFederatedConsumer = async (
+          mode: "offer" | "direct",
+          pattern: string,
+          durable: string,
+        ): Promise<void> => {
+          const federatedConsumer = makeConsumer(true);
+          reviewConsumers.push(federatedConsumer);
+          if (reviewJsm !== null) {
+            try {
+              const outcome = await provisionReviewConsumer({
+                jsm: reviewJsm,
+                stream: reviewStream,
+                durable,
+                maxDeliver: reviewConsumerMaxDeliver,
+              });
+              if (outcome === "created") {
+                console.log(
+                  `cortex: provisioned JetStream durable "${durable}" on stream "${reviewStream}"`,
+                );
+              } else if (outcome === "updated") {
+                console.log(
+                  `cortex: reconciled JetStream durable "${durable}" ack_wait (cortex#422) on stream "${reviewStream}"`,
+                );
+              }
+            } catch (provisionErr) {
+              process.stderr.write(
+                `cortex: provisionReviewConsumer failed for "${durable}": ` +
+                  `${provisionErr instanceof Error ? provisionErr.message : String(provisionErr)}\n`,
               );
             }
-          } catch (provisionErr) {
-            process.stderr.write(
-              `cortex: provisionReviewConsumer failed for "${federatedDurable}": ` +
-                `${provisionErr instanceof Error ? provisionErr.message : String(provisionErr)}\n`,
+          }
+          const federatedStarted = await federatedConsumer.start({
+            pattern,
+            stream: reviewStream,
+            durable,
+          });
+          if (federatedStarted.subscribed) {
+            console.log(
+              `cortex: federated review consumer (${mode}) ready for agent=${agent.id} flavors=[${flavorSummary}] signed=${signedTag} substrate=${substrate} pattern=${pattern}`,
+            );
+          } else {
+            console.log(
+              `cortex: federated review consumer (${mode}) DORMANT for agent=${agent.id} flavors=[${flavorSummary}] signed=${signedTag} substrate=${substrate} — cortex MyelinRuntime subscriptions disabled (federated.* code-review envelopes will not be claimed by this consumer)`,
             );
           }
-        }
-        const federatedStarted = await federatedConsumer.start({
-          pattern: reviewFederatedSubjectPattern,
-          stream: reviewStream,
-          durable: federatedDurable,
-        });
-        if (federatedStarted.subscribed) {
-          console.log(
-            `cortex: federated review consumer ready for agent=${agent.id} flavors=[${flavorSummary}] signed=${signedTag} substrate=${substrate} pattern=${reviewFederatedSubjectPattern}`,
-          );
-        } else {
-          console.log(
-            `cortex: federated review consumer DORMANT for agent=${agent.id} flavors=[${flavorSummary}] signed=${signedTag} substrate=${substrate} — cortex MyelinRuntime subscriptions disabled (federated.* code-review envelopes will not be claimed by this consumer)`,
-          );
-        }
+        };
+
+        // cortex#686 (ADR 0001) — Offer: `federated.{me}.{stack}.tasks.code-review.>`.
+        await startFederatedConsumer(
+          "offer",
+          reviewFederatedSubjectPattern,
+          `cortex-review-consumer-federated-${reviewPrincipalId}-${agent.id}`,
+        );
+        // cortex#725 (ADR 0001/0002 §2) — Direct: this stack's OWN
+        // `federated.{me}.{stack}.tasks.@{did}.code-review.>` (the `@{did}` is
+        // the named reviewer/target-assistant). Routes the verdict back to the
+        // REQUESTER (from `originator.identity`) identically to the Offer path.
+        await startFederatedConsumer(
+          "direct",
+          reviewFederatedDirectSubjectPattern,
+          `cortex-review-consumer-federated-direct-${reviewPrincipalId}-${agent.id}`,
+        );
       }
     } catch (err) {
       // Per CLAUDE.md: log every error. A single agent's consumer crash


### PR DESCRIPTION
Closes #725
Refs #686 ADR-0002

## Gap
cortex#686 (merged) added a federated **Offer** consumer subscribing `federated.{me}.{stack}.tasks.code-review.>`. pilot#149 also emits a **Direct** shape (`--reviewer name@p/s`): `federated.{me}.{stack}.tasks.@{did-encoded-reviewer}.code-review.{flavor}` — the named reviewer's DID is spliced in as an `@{did}` segment **after** `tasks.`. The Offer filter expects `code-review` in that position, so Direct requests were never consumed and `pilot --reviewer name@p/s --wait` hung (no verdict-back).

## Fix (mirror the Offer path, reuse everything)
- **cortex.ts**: add the Direct federated pattern `federated.{me}.{stack}.tasks.*.code-review.>` (NATS whole-token `*` over the `@{did}` segment — the same convention local Direct dispatch already uses, `local.{p}.{s}.tasks.*.>`). Extend the `CODE_REVIEW` stream subject filter with it and bind a parallel per-agent durable `cortex-review-consumer-federated-direct-{principal}-{agent}` — **only when a `federated:` policy block is configured**. Factored the Offer + Direct provision/start into one `startFederatedConsumer` closure so they can't drift.
- **ReviewConsumer needs NO change**: a Direct request's `envelope.type` is STILL `tasks.code-review.{flavor}` (the `@{did}` lives ONLY on the subject — myelin's `type` grammar forbids `@`). So `extractFlavor`, the requester decode from `originator.identity`, the `peers[]` membership gate, and the verdict-back (`safePublish`→`publishOnSubject` on `federated.{requester}.{stack}.…`) are all the **same federated code** as Offer. `distribution_mode` is `direct` on the wire.

## Verdict-back shared with Offer
The Direct consumer is `makeConsumer(true)` — identical construction to the Offer federated consumer (same reviewer, verifier, `federatedNetworks` peers gate, prompt). Both route the verdict to the **requester** decoded from `originator.identity` (`did:mf:{principal}-{stack}`, first-hyphen split) via the unchanged `safePublish`. Never keyed on the subject's reviewer `@{did}`, never self. Same `peers[]` gate + fail-closed (deny + drop, no spawn, no publish) before the reviewer.

## FederationGrammar lens (wire-check)
5/5 PASS — no network on the wire (identity-only `{me}.{stack}` subject + topology-resolved peers); subscribes the consumer's OWN `federated.{me}.{my-stack}.…`; requester from `originator.identity` (NOT the subject — explicitly pinned by a test); reply keyed on requester + fail-closed peers gate; scope mirrored (`federated.*` in, `classification: federated` out). Local path byte-for-byte unchanged.

## Tests
Synthetic Direct inbound `federated.metafactory.meta-factory.tasks.@did-mf-echo.code-review.typescript` with `originator.identity = did:mf:jc-sage-host` from a configured peer → routes verdict to `federated.jc.sage-host.review.verdict.*` (+ `dispatch.task.*`); non-peer requester + absent originator → denied+dropped; a fixture-pin asserts the subject's `@{did}` is the reviewer while the requester comes from `originator`. Offer + local paths untouched.

## Verify
- `bunx tsc --noEmit` — 0 errors
- `bun test` (full) — 4413 pass / 0 fail (+4 new Direct tests)
- lint — 0 errors (29 pre-existing warnings, none on touched lines)
- vocab gate (`check-carveouts.sh`) — PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)