### PR TITLE
fix(dispatch): C-729 — trust-scope the prompt filter for the operator's channel @mentions, not just DMs

### DIFF
--- a/src/adapters/discord/__tests__/author-is-principal.test.ts
+++ b/src/adapters/discord/__tests__/author-is-principal.test.ts
@@ -1,0 +1,225 @@
+/**
+ * cortex#729 — the home-principal trust signal (`authorIsPrincipal`) is
+ * computed for EVERY inbound Discord message, not just DMs.
+ *
+ * Background:
+ *   #724 trust-scoped the dispatch-handler's prompt filter so the home
+ *   principal's own messages aren't hard-blocked by the prompt-injection
+ *   scanner (live FP: PI-002 "act as a jumphost"). But it read `msg.dmType`,
+ *   which the adapter sets only inside its `if (isDM)` branch. For a CHANNEL
+ *   @mention, `dmType` is undefined → the home principal's channel message
+ *   stayed hard-blocked (live: #halden-observe, where Luna has dmOwner:false so
+ *   a channel @mention is the only path).
+ *
+ * Fix:
+ *   The adapter now calls `isOperatorPrincipal(...)` UNCONDITIONALLY and stamps
+ *   `authorIsPrincipal` on the inbound message — DM and channel alike — via the
+ *   same non-spoofable PolicyEngine principal-role check. `dmType` stays
+ *   DM-only.
+ *
+ * This suite pins:
+ *   1. The home principal's CHANNEL @mention → authorIsPrincipal === true (and
+ *      dmType stays undefined — it's a channel, not a DM).
+ *   2. A non-principal's CHANNEL @mention → authorIsPrincipal === false.
+ *   3. The home principal's DM → authorIsPrincipal === true AND dmType === "principal".
+ *
+ * Harness mirrors guild-filter.test.ts / dm-ownership.test.ts: a FakeClient
+ * EventEmitter drives the real handler; a duck-typed policyEngine + policyLookup
+ * resolve exactly one author id as the home principal.
+ */
+
+import { describe, expect, test, beforeEach, afterEach } from "bun:test";
+import { EventEmitter } from "events";
+import { ChannelType } from "discord.js";
+import { DiscordAdapter, type DiscordAdapterInfra } from "../index";
+import type { Agent, DiscordPresence } from "../../../common/types/cortex-config";
+import type { InboundMessage } from "../../types";
+
+// ---------------------------------------------------------------------------
+// Console suppression
+// ---------------------------------------------------------------------------
+
+let originalWarn: typeof console.warn;
+let originalError: typeof console.error;
+let originalLog: typeof console.log;
+
+beforeEach(() => {
+  originalWarn = console.warn;
+  originalError = console.error;
+  originalLog = console.log;
+  console.warn = () => {};
+  console.error = () => {};
+  console.log = () => {};
+});
+
+afterEach(() => {
+  console.warn = originalWarn;
+  console.error = originalError;
+  console.log = originalLog;
+});
+
+// ---------------------------------------------------------------------------
+// Fakes
+// ---------------------------------------------------------------------------
+
+const SELF_BOT_ID = "self-bot-id";
+const PRINCIPAL_AUTHOR_ID = "principal-author";
+const STRANGER_AUTHOR_ID = "stranger-author";
+const GUILD_ID = "1487023327791808592";
+
+class FakeClient extends EventEmitter {
+  public user = { id: SELF_BOT_ID };
+  isReady() {
+    return true;
+  }
+  channels = { fetch: async () => null };
+}
+
+/**
+ * Duck-typed policy stack consumed by `isOperatorPrincipal`:
+ *   index.resolve(platform, platformId) → principalId | undefined
+ *   engine.check(principalId, intent) → { allow }
+ * Exactly the PRINCIPAL_AUTHOR_ID resolves and is granted the capability the
+ * PolicyEngine keys the home-principal role on; everyone else is a
+ * non-principal.
+ */
+function makePrincipalPolicy(): Pick<DiscordAdapterInfra, "policyEngine" | "policyLookup"> {
+  const policyLookup = {
+    resolve: (_platform: string, platformId: string): string | undefined =>
+      platformId === PRINCIPAL_AUTHOR_ID ? "home-principal" : undefined,
+  };
+  const policyEngine = {
+    check: (principalId: string): { allow: boolean } => ({
+      allow: principalId === "home-principal",
+    }),
+  };
+  return {
+    policyEngine: policyEngine as unknown as DiscordAdapterInfra["policyEngine"],
+    policyLookup: policyLookup as unknown as DiscordAdapterInfra["policyLookup"],
+  };
+}
+
+/** A DM (guildId null) or guild @mention, authored by `authorId`, mentioning self. */
+function makeMessage(opts: {
+  id: string;
+  guildId: string | null;
+  authorId: string;
+}): unknown {
+  const isDM = opts.guildId === null;
+  return {
+    id: opts.id,
+    guildId: opts.guildId,
+    content: `<@${SELF_BOT_ID}> ping`,
+    createdAt: new Date(),
+    author: { id: opts.authorId, displayName: "Author", bot: false },
+    mentions: { has: (u: { id: string }) => u.id === SELF_BOT_ID },
+    attachments: new Map(),
+    channel: {
+      id: isDM ? "dm-channel" : "guild-channel",
+      type: isDM ? ChannelType.DM : ChannelType.GuildText,
+      name: isDM ? undefined : "halden-observe",
+    },
+  };
+}
+
+function makeAdapter(): {
+  fakeClient: FakeClient;
+  dispatched: InboundMessage[];
+} {
+  const presence: DiscordPresence = {
+    enabled: true,
+    token: "shared-bot-token",
+    guildId: GUILD_ID,
+    agentChannelId: "c1",
+    logChannelId: "c2",
+    contextDepth: 0,
+    enableAgentLog: false,
+    trustedBotIds: [],
+    dmOwner: true,
+    surfaceSubjects: [],
+  };
+  const agent: Agent = {
+    id: "test-agent",
+    displayName: "TestAgent",
+    persona: "(test)",
+    trust: [],
+    presence: { discord: presence },
+  };
+  const infra: DiscordAdapterInfra = {
+    instanceId: "discord-A",
+    principal: {},
+    ...makePrincipalPolicy(),
+  };
+  const adapter = new DiscordAdapter(agent, presence, infra);
+
+  const fakeClient = new FakeClient();
+  (adapter as unknown as { client: FakeClient }).client = fakeClient;
+
+  const dispatched: InboundMessage[] = [];
+  (adapter as unknown as {
+    onMessage: (msg: InboundMessage) => Promise<void>;
+  }).onMessage = async (msg) => {
+    dispatched.push(msg);
+  };
+
+  adapter.attachInboundDispatch();
+
+  return { fakeClient, dispatched };
+}
+
+async function fireMessageCreate(
+  fakeClient: FakeClient,
+  message: unknown,
+): Promise<void> {
+  fakeClient.emit("messageCreate", message);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("DiscordAdapter: authorIsPrincipal trust signal (cortex#729)", () => {
+  test("home-principal CHANNEL @mention → authorIsPrincipal=true (dmType stays undefined)", async () => {
+    const { fakeClient, dispatched } = makeAdapter();
+
+    await fireMessageCreate(
+      fakeClient,
+      makeMessage({ id: "ch-1", guildId: GUILD_ID, authorId: PRINCIPAL_AUTHOR_ID }),
+    );
+
+    expect(dispatched.length).toBe(1);
+    expect(dispatched[0]?.isDM).toBe(false);
+    expect(dispatched[0]?.authorIsPrincipal).toBe(true);
+    // dmType is DM-only — a channel message must not set it.
+    expect(dispatched[0]?.dmType).toBeUndefined();
+  });
+
+  test("non-principal CHANNEL @mention → authorIsPrincipal=false", async () => {
+    const { fakeClient, dispatched } = makeAdapter();
+
+    await fireMessageCreate(
+      fakeClient,
+      makeMessage({ id: "ch-2", guildId: GUILD_ID, authorId: STRANGER_AUTHOR_ID }),
+    );
+
+    expect(dispatched.length).toBe(1);
+    expect(dispatched[0]?.isDM).toBe(false);
+    expect(dispatched[0]?.authorIsPrincipal).toBe(false);
+    expect(dispatched[0]?.dmType).toBeUndefined();
+  });
+
+  test("home-principal DM → authorIsPrincipal=true AND dmType=principal (DM path unchanged)", async () => {
+    const { fakeClient, dispatched } = makeAdapter();
+
+    await fireMessageCreate(
+      fakeClient,
+      makeMessage({ id: "dm-1", guildId: null, authorId: PRINCIPAL_AUTHOR_ID }),
+    );
+
+    expect(dispatched.length).toBe(1);
+    expect(dispatched[0]?.isDM).toBe(true);
+    expect(dispatched[0]?.authorIsPrincipal).toBe(true);
+    expect(dispatched[0]?.dmType).toBe("principal");
+  });
+});

--- a/src/adapters/discord/index.ts
+++ b/src/adapters/discord/index.ts
@@ -472,16 +472,24 @@ export class DiscordAdapter implements PlatformAdapter {
       // `infra.principal.discordId` field is preserved for the
       // `notifyPrincipal` / `bufferPrincipalDM` paths which still need a
       // Discord-side mailbox.
+      // cortex#729 — the home-principal trust signal must be computed for
+      // EVERY inbound message (DM and channel @mention), not just DMs. The
+      // PolicyEngine principal-role check on the authenticated Discord author
+      // id is non-spoofable. `dmType` stays DM-only (it carries DM-specific
+      // routing semantics); `authorIsPrincipal` is the sibling signal the
+      // dispatch-handler's filter trust-scope reads so the home principal's
+      // CHANNEL @mentions aren't hard-blocked (live FP: PI-002 "act as a
+      // jumphost" in #halden-observe, where Luna has `dmOwner: false` so a
+      // channel @mention is the only path).
+      const authorIsPrincipal = isOperatorPrincipal(
+        "discord",
+        message.author.id,
+        this.infra.policyEngine,
+        this.infra.policyLookup,
+      );
       let dmType: "principal" | "user" | undefined;
       if (isDM) {
-        dmType = isOperatorPrincipal(
-          "discord",
-          message.author.id,
-          this.infra.policyEngine,
-          this.infra.policyLookup,
-        )
-          ? "principal"
-          : "user";
+        dmType = authorIsPrincipal ? "principal" : "user";
       }
 
       // G-204c: Resolve channel/thread names for context routing
@@ -522,6 +530,7 @@ export class DiscordAdapter implements PlatformAdapter {
         guildId: message.guildId ?? undefined,
         isDM,
         dmType,
+        authorIsPrincipal,
         attachments: allAttachments
           .filter((a) => !(a.name === "message.txt" && messageTxt))
           .map((a) => ({

--- a/src/adapters/mattermost/index.ts
+++ b/src/adapters/mattermost/index.ts
@@ -157,6 +157,13 @@ export class MattermostAdapter implements PlatformAdapter {
           content: mmMsg.content,
           channelId: mmMsg.channelId,
           threadId: mmMsg.rootId, // Thread to original message for proper reply threading
+          // cortex#729 — stamp the home-principal trust signal for parity with
+          // the Discord adapter, so the dispatch-handler's prompt-filter
+          // trust-scope bypasses the hard-block for the home principal's
+          // messages here too (Mattermost has no DM-classification, so this is
+          // the ONLY trust signal it carries). Non-spoofable: the same
+          // PolicyEngine principal-role check on the authenticated user id.
+          authorIsPrincipal: this.isOperator(mmMsg.userId),
           attachments: mmMsg.fileIds
             ? await this.fetchFileAttachments(mmMsg.fileIds)
             : [],

--- a/src/adapters/types.ts
+++ b/src/adapters/types.ts
@@ -36,6 +36,16 @@ export interface InboundMessage {
   isDM?: boolean;
   /** DM classification: principal (full access) or user (standard guards) */
   dmType?: "principal" | "user";
+  /**
+   * cortex#729: True when the authenticated sender is the home principal,
+   * computed for EVERY inbound message (DM and channel @mention) via the
+   * PolicyEngine principal-role check. Unlike `dmType` (DM-only), this signal
+   * is set in channels too, so the dispatch-handler's prompt-filter
+   * trust-scope can bypass the hard-block for the home principal's channel
+   * @mentions — not just their DMs. Non-spoofable (keyed on the
+   * authenticated platform author id). Defaults to false/undefined.
+   */
+  authorIsPrincipal?: boolean;
   /** Inbound file attachments */
   attachments: InboundAttachment[];
   /** Message timestamp */

--- a/src/bus/__tests__/dispatch-handler.test.ts
+++ b/src/bus/__tests__/dispatch-handler.test.ts
@@ -1056,6 +1056,133 @@ describe("DispatchHandler — prompt-filter trust scope (cortex#723)", () => {
 });
 
 // ---------------------------------------------------------------------------
+// cortex#729 — #724 trust-scoped the prompt filter for the home principal's
+// DMs, but gated the bypass on `isPrincipalDM` (msg.isDM && msg.dmType ===
+// "principal"). `dmType` is set only inside the adapter's `if (isDM)` branch, so
+// the home principal's CHANNEL @mention (isDM=false → dmType undefined) fell
+// through and stayed hard-blocked (live FP: PI-002 "act as a jumphost" in
+// #halden-observe, where Luna has dmOwner:false so a channel @mention is the
+// only path). The fix adds `msg.authorIsPrincipal`, computed by the adapter for
+// EVERY inbound message via the same non-spoofable PolicyEngine principal-role
+// check, and the handler now bypasses on `(isPrincipalDM || msg.authorIsPrincipal)`.
+//
+// Contract:
+//   - home-principal CHANNEL @mention (isDM=false, authorIsPrincipal=true) whose
+//     content matches a block pattern → PROCESSED (reaches CC, NO can't-process
+//     reply), match LOGGED for visibility.
+//   - non-principal CHANNEL sender, same content → still BLOCKED.
+//   - the home-principal DM path (#724) is unchanged (covered above).
+// ---------------------------------------------------------------------------
+
+describe("DispatchHandler — prompt-filter trust scope, channel @mentions (cortex#729)", () => {
+  // Same PI-002-tripping content the #723 tests use — the exact live FP class.
+  const ACT_AS_CONTENT =
+    "Dig deeper — the probe is not the jump host. A different machine would act as a jumphost.";
+
+  let originalWarn: typeof console.warn;
+  let originalError: typeof console.error;
+  let originalLog: typeof console.log;
+  let logLines: string[];
+
+  beforeEach(() => {
+    originalWarn = console.warn;
+    originalError = console.error;
+    originalLog = console.log;
+    logLines = [];
+    console.warn = () => {};
+    console.error = () => {};
+    console.log = (...args: unknown[]) => {
+      logLines.push(args.map((a) => String(a)).join(" "));
+    };
+  });
+
+  afterEach(() => {
+    console.warn = originalWarn;
+    console.error = originalError;
+    console.log = originalLog;
+  });
+
+  test("home-principal CHANNEL @mention matching a block pattern is PROCESSED (not blocked) and the match is logged", async () => {
+    const { factory, spawnCount } = makeStubFactory([
+      successResult({ response: "On it — here's the jumphost answer." }),
+    ]);
+
+    const adapter = new MockAdapter();
+    const handler = new DispatchHandler({
+      config: makeConfig(),
+      securityPreamble: "",
+      ccSessionFactory: factory,
+    });
+
+    // A guild CHANNEL @mention (NOT a DM) from the home principal. `isDM` is
+    // false so `dmType` is undefined — the home-principal signal arrives solely
+    // via `authorIsPrincipal`, which is exactly the #729 path.
+    await handler.handleMessage(
+      adapter,
+      makeMsg({
+        platform: "discord",
+        authorId: "principal1",
+        content: ACT_AS_CONTENT,
+        isDM: false,
+        authorIsPrincipal: true,
+      }),
+    );
+
+    // The message reached the CC path — the filter did NOT short-circuit it.
+    expect(spawnCount()).toBe(1);
+
+    const texts = adapter.sentMessages.map((m) => m.text);
+    expect(texts.some((t) => t.includes("I can't process that message"))).toBe(false);
+    expect(texts.some((t) => t.includes("Content filter blocked"))).toBe(false);
+    expect(texts).toContain("On it — here's the jumphost answer.");
+
+    // The match is logged for principal visibility (cortex#723/#729).
+    expect(
+      logLines.some(
+        (l) => l.includes("[PROMPT-FILTER]") && l.includes("home-principal"),
+      ),
+    ).toBe(true);
+
+    await handler.shutdown();
+  });
+
+  test("non-principal CHANNEL sender with the same role-play content is still BLOCKED (no CC spawn)", async () => {
+    const { factory, spawnCount } = makeStubFactory([
+      successResult({ response: "should never run" }),
+    ]);
+
+    const adapter = new MockAdapter();
+    const handler = new DispatchHandler({
+      config: makeConfig(),
+      securityPreamble: "",
+      ccSessionFactory: factory,
+    });
+
+    // Same content, same channel shape — but the sender is NOT the home
+    // principal (authorIsPrincipal omitted → undefined/false). Must stay blocked.
+    await handler.handleMessage(
+      adapter,
+      makeMsg({
+        platform: "discord",
+        authorId: "user999",
+        authorName: "Stranger",
+        content: ACT_AS_CONTENT,
+        isDM: false,
+      }),
+    );
+
+    expect(spawnCount()).toBe(0);
+
+    const texts = adapter.sentMessages.map((m) => m.text);
+    expect(texts.length).toBe(1);
+    expect(texts[0]).toContain("I can't process that message");
+    expect(texts[0]).toContain("Content filter blocked");
+
+    await handler.shutdown();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Direction A Stage 4-B (cortex#409) — publishInboundDispatchEnvelope
 //
 // Dispatch-source path. The handler publishes chat/direct dispatches as

--- a/src/bus/dispatch-handler.ts
+++ b/src/bus/dispatch-handler.ts
@@ -714,15 +714,25 @@ export class DispatchHandler extends EventEmitter {
         // cortex#723 — trust-scope the hard-block. A prompt-injection filter
         // gates UNTRUSTED content (cross-principal, relayed, webhook); the home
         // principal commands their OWN assistant and cannot "inject" it.
-        // Hard-blocking the principal's direct messages is a category error
-        // that breaks principal control (live FP: PI-002 "act as a jumphost" —
-        // legit infra language). `isPrincipalDM` (set above) is true only when
-        // an adapter classified the sender as the home principal via the
-        // PolicyEngine principal-role capability — the authoritative trust
-        // signal. For that sender, log the match for visibility and ALLOW.
-        // Untrusted senders (unknown / cross-principal without trust) stay
-        // hard-blocked exactly as before — the filter is NOT weakened for them.
-        if (isPrincipalDM) {
+        // Hard-blocking the principal's messages is a category error that
+        // breaks principal control (live FP: PI-002 "act as a jumphost" —
+        // legit infra language).
+        //
+        // cortex#729 — extend the bypass from DM-only to channel @mentions.
+        // #724 gated this on `isPrincipalDM`, but `dmType` is set only for DMs,
+        // so the home principal's CHANNEL @mention fell through and stayed
+        // blocked (live: PI-002 in #halden-observe, where Luna has
+        // `dmOwner: false` so a channel @mention is the ONLY path).
+        // `msg.authorIsPrincipal` is the sibling signal the adapter now computes
+        // for every inbound message via the SAME PolicyEngine principal-role
+        // check — non-spoofable, keyed on the authenticated author id. The home
+        // principal, DM OR channel, is commanding their own assistant; log the
+        // match for visibility and ALLOW. Non-principal senders (unknown /
+        // cross-principal without trust, in DMs OR channels) stay hard-blocked
+        // exactly as before — the filter is NOT weakened for them. Note the
+        // relaxed preamble (above) stays DM-only: channels are less private, so
+        // only the FILTER BYPASS goes channel-inclusive, not the preamble.
+        if (isPrincipalDM || msg.authorIsPrincipal) {
           console.log(
             `dispatch-handler: [PROMPT-FILTER] allowing home-principal message despite match (${filterResult.reason ?? "unspecified"}) — the principal commands their own assistant (cortex#723): "${parsed.content.slice(0, 100)}"`,
           );


### PR DESCRIPTION
Closes #729
Refs #723 #724

## Problem

#724 trust-scoped the dispatch-handler's prompt-injection filter so the home principal's own messages aren't hard-blocked — but gated the bypass on `isPrincipalDM` (`msg.isDM && msg.dmType === "principal"`). The adapter sets `dmType` **only inside its `if (isDM)` branch**, so a home-principal **CHANNEL @mention** (`isDM=false` → `dmType` undefined) fell through and stayed hard-blocked.

Live: Andreas @mentions Luna in **#halden-observe** with "…would **act as** a jumphost" → "I can't process that message. Content filter blocked (matched: PI-002)". halden's Luna has `dmOwner: false`, so a channel @mention is the **only** path.

## Fix

Compute the home-principal trust signal for **every** inbound message via the same non-spoofable PolicyEngine principal-role check.

- `src/adapters/types.ts` — add `authorIsPrincipal?: boolean` sibling to `dmType`.
- `src/adapters/discord/index.ts` — lift `isOperatorPrincipal(...)` out of the `if (isDM)` guard; set `authorIsPrincipal` on every inbound msg (DM **and** channel). `dmType` unchanged (still DM-only).
- `src/adapters/mattermost/index.ts` — stamp `authorIsPrincipal` via the existing `isOperator()` helper for parity (Mattermost carries no DM classification, so this is its only trust signal).
- `src/bus/dispatch-handler.ts` — change the filter bypass from `if (isPrincipalDM)` to `if (isPrincipalDM || msg.authorIsPrincipal)`. The **relaxed preamble stays DM-only** — only the FILTER BYPASS goes channel-inclusive (channels are less private).

## Security

The bypass applies **only** when `isOperatorPrincipal` confirms the home principal — the PolicyEngine principal-role check on the **authenticated** Discord/Mattermost author id (non-spoofable). A non-principal channel sender → `authorIsPrincipal` false → **stays blocked**. The untrusted path is unchanged. `handleMessage` is reachable only from `adapter.start(...)` callbacks, so `authorIsPrincipal` is always adapter-computed — no bus-envelope path can inject it.

## Tests

- `src/bus/__tests__/dispatch-handler.test.ts`: home-principal **channel** @mention (isDM=false, authorIsPrincipal=true) tripping PI-002 → **PROCESSED** (reaches CC, match logged, no can't-process reply); **non-principal** channel sender, same content → still **BLOCKED**; existing operator-DM (#724) case still green.
- `src/adapters/discord/__tests__/author-is-principal.test.ts` (new): adapter sets `authorIsPrincipal=true` for the home principal's channel message, `false` for a non-principal, and `true`+`dmType=principal` for the home principal's DM.

## Verification

- `bunx tsc --noEmit` — 0 errors
- `bun test src/bus/ src/adapters/ src/runner/` — 1426 pass / 1 skip / 0 fail
- `bun run lint:errors` — clean
- vocab gate (`check-carveouts.sh`) — PASS
- Full `bun test` — no new failures (2 pre-existing flakes under full-suite concurrency: `dispatch-listener` re-sign-on-ingest + `ConfigWatcher` file-watch timing; both pass in isolation, neither touched by this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)