### PR TITLE
fix(sinks): C-731 — clear the "working…" placeholder on terminal lifecycle events

### DIFF
--- a/src/adapters/__tests__/dispatch-sink.test.ts
+++ b/src/adapters/__tests__/dispatch-sink.test.ts
@@ -226,6 +226,56 @@ describe("dispatch-sink — delivery to the originating target", () => {
     // `sessionId` so the adapter's `progressKey` scopes it per-dispatch.
     expect(adapter.progressSent[0]!.target.sessionId).toBe("task-1");
   });
+
+  test("completed clears the progress placeholder (same correlation key) then posts the reply (cortex#731)", async () => {
+    const { runtime, trigger } = fakeRuntime();
+    const adapter = new MockAdapter("discord-pai-collab");
+    const sink = createDispatchSink({ runtime, adapters: [adapter], principal: "metafactory" });
+    await sink.start();
+
+    trigger(
+      lifecycleEnvelope("dispatch.task.completed", {
+        agent_id: "luna",
+        chat_response: "Yep, I can access both.",
+        response_routing: routing("discord-pai-collab", "C123", "T456"),
+      }),
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // The "working…" placeholder is cleared so it doesn't orphan above the reply,
+    // keyed on the SAME correlation id the `started` branch used.
+    expect(adapter.progressCleared).toHaveLength(1);
+    expect(adapter.progressCleared[0]!.sessionId).toBe("task-1");
+    expect(adapter.progressCleared[0]!.channelId).toBe("C123");
+    // The durable reply is still posted (channel-scoped, no sessionId).
+    expect(adapter.sentMessages).toHaveLength(1);
+    expect(adapter.sentMessages[0]!.text).toBe("Yep, I can access both.");
+    expect(adapter.sentMessages[0]!.target.sessionId).toBeUndefined();
+  });
+
+  test("failed clears the placeholder then surfaces the failure (cortex#731 bubble-back)", async () => {
+    const { runtime, trigger } = fakeRuntime();
+    const adapter = new MockAdapter("discord-pai-collab");
+    const sink = createDispatchSink({ runtime, adapters: [adapter], principal: "metafactory" });
+    await sink.start();
+
+    trigger(
+      lifecycleEnvelope("dispatch.task.failed", {
+        agent_id: "luna",
+        error_summary: "session timed out",
+        response_routing: routing("discord-pai-collab", "C123", "T456"),
+      }),
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(adapter.progressCleared).toHaveLength(1);
+    expect(adapter.progressCleared[0]!.sessionId).toBe("task-1");
+    // The failure bubbles to the surface instead of leaving "working…" forever.
+    expect(adapter.sentMessages).toHaveLength(1);
+    expect(adapter.sentMessages[0]!.text).toContain("failed");
+  });
 });
 
 // =============================================================================

--- a/src/adapters/__tests__/review-sink.test.ts
+++ b/src/adapters/__tests__/review-sink.test.ts
@@ -251,6 +251,31 @@ describe("review-sink — lifecycle delivery", () => {
     expect(adapter.progressSent[0]!.target.sessionId).toBe("req-1");
   });
 
+  test("terminal event clears the 'reviewing…' placeholder (same correlation key) then posts (cortex#731)", async () => {
+    const { runtime, trigger } = fakeRuntime();
+    const adapter = discordMock();
+    const sink = createReviewSink({ runtime, adapters: [adapter], principal: "metafactory" });
+    await sink.start();
+
+    trigger(
+      envelope("dispatch.task.completed", {
+        agent_id: "echo",
+        chat_response: "Verdict: approved.",
+        response_routing: logicalRouting("discord", "cortex", "cortex/pr/57"),
+      }),
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // Placeholder cleared with the SAME correlation-keyed target the `started`
+    // branch used, so it doesn't orphan above the durable verdict (cortex#731).
+    expect(adapter.progressCleared).toHaveLength(1);
+    expect(adapter.progressCleared[0]!.sessionId).toBe("req-1");
+    expect(adapter.sentMessages).toHaveLength(1);
+    expect(adapter.sentMessages[0]!.target.sessionId).toBeUndefined();
+  });
+
   test("dispatch.task.failed → postResponse error reply", async () => {
     const { runtime, trigger } = fakeRuntime();
     const adapter = discordMock();

--- a/src/adapters/dispatch-sink.ts
+++ b/src/adapters/dispatch-sink.ts
@@ -288,27 +288,32 @@ export function createDispatchSink(opts: DispatchSinkOptions): DispatchSink {
       ...(routing.thread_id !== undefined && { threadId: routing.thread_id }),
     };
 
+    // cortex#721 — key per-dispatch progress on the lifecycle envelope's
+    // correlation id so two dispatches in the same channel/thread each get
+    // their OWN "working…" placeholder instead of editing one shared message.
+    // `sessionId` rides ONLY the progress target: `postResponse` ignores it,
+    // and only `sendProgress`/`clearProgress` read it via the adapter's
+    // `progressKey`. The terminal branch MUST reuse this exact key to delete
+    // the placeholder the `started` branch created (cortex#731).
+    const correlationKey = dispatchCorrelationKey(envelope);
+    const progressTarget: ResponseTarget =
+      correlationKey !== undefined
+        ? { ...target, sessionId: correlationKey }
+        : target;
+
     try {
       if (envelope.type === "dispatch.task.started") {
         // A `started` event is a progress/typing indicator, not a final
         // reply — edit-in-place so the terminal `completed`/`failed`
         // reply is the durable message in the channel.
-        //
-        // cortex#721 — key per-dispatch progress on the lifecycle envelope's
-        // correlation id so two dispatches in the same channel/thread each
-        // get their OWN "working…" placeholder instead of editing one shared
-        // message. Set `sessionId` ONLY on the progress target: `postResponse`
-        // ignores it, and only `sendProgress` (edit-in-place) reads it via
-        // the adapter's `progressKey`.
-        const correlationKey = dispatchCorrelationKey(envelope);
-        const progressTarget: ResponseTarget =
-          correlationKey !== undefined
-            ? { ...target, sessionId: correlationKey }
-            : target;
         await adapter.sendProgress(progressTarget, text);
         return;
       }
-      // `completed` / `failed` / `aborted` — the terminal reply.
+      // `completed` / `failed` / `aborted` — the terminal reply. Clear the
+      // `started` "working…" placeholder first (same correlation-keyed
+      // target), else it orphans above the durable reply (cortex#731), then
+      // post the reply.
+      await adapter.clearProgress(progressTarget);
       await adapter.postResponse(target, text);
     } catch (err) {
       // A platform post failure must not crash the fan-out. Log to

--- a/src/adapters/mock.ts
+++ b/src/adapters/mock.ts
@@ -31,6 +31,8 @@ export class MockAdapter implements PlatformAdapter {
   typingSent: ResponseTarget[] = [];
   /** Recorded sendProgress calls */
   progressSent: { target: ResponseTarget; text: string }[] = [];
+  /** Recorded clearProgress calls (cortex#731) */
+  progressCleared: ResponseTarget[] = [];
   /** Recorded createThread calls */
   threadsCreated: { msg: InboundMessage; name: string }[] = [];
   /** cortex#502 — recorded resolveLogicalTarget calls */
@@ -127,8 +129,8 @@ export class MockAdapter implements PlatformAdapter {
     this.progressSent.push({ target, text });
   }
 
-  async clearProgress(_target: ResponseTarget): Promise<void> {
-    // No-op for mock
+  async clearProgress(target: ResponseTarget): Promise<void> {
+    this.progressCleared.push(target);
   }
 
   async createThread(msg: InboundMessage, name: string): Promise<ResponseTarget> {

--- a/src/adapters/review-sink.ts
+++ b/src/adapters/review-sink.ts
@@ -351,27 +351,32 @@ export function createReviewSink(opts: ReviewSinkOptions): ReviewSink {
     const adapter = adapters.find((a) => a.instanceId === target.instanceId);
     if (adapter === undefined) return;
 
+    // cortex#721 — key the per-review progress placeholder on the lifecycle
+    // envelope's correlation id (resolved targets carry no `sessionId`), so
+    // two reviews in the same channel/thread each get their OWN "reviewing…"
+    // message instead of editing one shared placeholder. `postResponse`
+    // ignores `sessionId`; only `sendProgress`/`clearProgress` read it via the
+    // adapter's `progressKey`. The terminal branch MUST reuse this exact key
+    // to delete the placeholder the `started` branch created (cortex#731).
+    const correlationKey = dispatchCorrelationKey(envelope);
+    const progressTarget: ResponseTarget =
+      correlationKey !== undefined
+        ? { ...target, sessionId: correlationKey }
+        : target;
+
     try {
       if (envelope.type === "dispatch.task.started") {
         // `started` is a progress/typing indicator (e.g. "Echo is
         // reviewing…"), not a final reply — edit-in-place so the terminal
         // verdict/failed reply is the durable message.
-        //
-        // cortex#721 — key the per-review progress placeholder on the
-        // lifecycle envelope's correlation id (resolved targets carry no
-        // `sessionId`), so two reviews in the same channel/thread each get
-        // their OWN "reviewing…" message instead of editing one shared
-        // placeholder. `postResponse` ignores `sessionId`; only
-        // `sendProgress` reads it via the adapter's `progressKey`.
-        const correlationKey = dispatchCorrelationKey(envelope);
-        const progressTarget: ResponseTarget =
-          correlationKey !== undefined
-            ? { ...target, sessionId: correlationKey }
-            : target;
         await adapter.sendProgress(progressTarget, text);
         return;
       }
-      // Verdict / completed / failed / aborted — the terminal reply.
+      // Verdict / completed / failed / aborted — the terminal reply. Clear the
+      // `started` "reviewing…" placeholder first (same correlation-keyed
+      // target), else it orphans above the durable verdict (cortex#731), then
+      // post the reply.
+      await adapter.clearProgress(progressTarget);
       await adapter.postResponse(target, text);
     } catch (err) {
       // A platform post failure must not crash the fan-out (per CLAUDE.md


### PR DESCRIPTION
## Problem
The `{agent} is working…` placeholder sticks in the channel after the reply (see #731) — and when a dispatch fails, the failure reply is posted but the stale placeholder masks it, so it looks like nothing came back.

## Root cause
The bus delivery sinks (`dispatch-sink`, `review-sink`) post the placeholder on `dispatch.task.started` via `sendProgress`, but on the terminal event (`completed`/`failed`/`aborted`) they call `postResponse` **without** `clearProgress`. The in-process `dispatch-handler` already clears in its `finally`; only the bus-sink path (now the active path post gateway/bus routing) was missing it.

## Fix
On the terminal branch, `clearProgress` with the **same correlation-keyed target** the `started` branch used (the #721 `sessionId: correlationKey` keying, so `progressKey` matches), then `postResponse`. Applied to both sinks. Hoisted the correlation-key/progress-target computation so both branches share it.

## Bubble-back
Failures already emit `dispatch.task.failed` (CC inactivity timeout → classified failure → emitted; `timeoutMs: 300000`), which the sink renders as "{agent} failed: …". This fix ensures that terminal event **clears the placeholder and surfaces** instead of being masked by a stuck "working…".

## Tests
- Mock adapter records `clearProgress` (`progressCleared`).
- `dispatch-sink`: `completed` clears the correlation-keyed placeholder then posts the reply; `failed` clears then surfaces the failure.
- `review-sink`: terminal event clears the "reviewing…" placeholder then posts the verdict.
- `bunx tsc --noEmit` clean; `bun test src/adapters/` 381 pass / 0 fail.

Closes #731