### PR TITLE
feat(registry): S1 — network descriptor + roster client (pin+verify, cache)

### DIFF
--- a/src/common/registry/__tests__/encoding.test.ts
+++ b/src/common/registry/__tests__/encoding.test.ts
@@ -1,0 +1,60 @@
+/**
+ * S1 (#735) — DD-8 pubkey-encoding bridge tests.
+ *
+ * Round-trips a KNOWN ed25519 key between the two surfaces: config/peers
+ * nkey-U (`U…`) ↔ registry base64 raw. A real NKey from `@nats-io/nkeys`
+ * grounds the test in the actual codec the rest of cortex uses, not a
+ * hand-built fixture.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { createUser } from "@nats-io/nkeys";
+
+import { base64PubkeyToNkey, nkeyToBase64Pubkey } from "../encoding";
+
+describe("DD-8 pubkey encoding bridge", () => {
+  test("round-trips a known key: nkey-U → base64 → nkey-U", () => {
+    // A real user NKey gives us a known-good `U…` pubkey.
+    const kp = createUser();
+    const nkeyU = kp.getPublicKey();
+    expect(nkeyU).toMatch(/^U[A-Z2-7]{55}$/);
+
+    const base64 = nkeyToBase64Pubkey(nkeyU);
+    expect(base64).toBeDefined();
+    expect(base64).toMatch(/^[A-Za-z0-9+/]{43}=$/);
+
+    const backToNkey = base64PubkeyToNkey(base64!);
+    expect(backToNkey).toBe(nkeyU);
+  });
+
+  test("round-trips the other direction: base64 → nkey-U → base64", () => {
+    const kp = createUser();
+    const base64 = nkeyToBase64Pubkey(kp.getPublicKey());
+    expect(base64).toBeDefined();
+
+    const nkeyU = base64PubkeyToNkey(base64!);
+    expect(nkeyU).toBeDefined();
+    expect(nkeyU).toMatch(/^U[A-Z2-7]{55}$/);
+
+    const back = nkeyToBase64Pubkey(nkeyU!);
+    expect(back).toBe(base64);
+  });
+
+  test("base64PubkeyToNkey rejects a non-base64-Ed25519 string", () => {
+    expect(base64PubkeyToNkey("not-base64!!!")).toBeUndefined();
+    // Right alphabet, wrong length (not 44 chars / not 32 raw bytes).
+    expect(base64PubkeyToNkey("AAAA")).toBeUndefined();
+  });
+
+  test("base64PubkeyToNkey rejects a 44-char base64 that decodes to != 32 bytes", () => {
+    // 44 base64 chars but the regex requires the 43+`=` 32-byte shape; a
+    // value that is structurally base64 but not a 32-byte key is rejected.
+    // (All-`A` 43 chars + `=` decodes to 32 zero bytes — that IS 32 bytes and
+    // is a structurally-valid key, so use a clearly-wrong padding shape.)
+    expect(base64PubkeyToNkey("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")).toBeUndefined();
+  });
+
+  test("nkeyToBase64Pubkey rejects a malformed nkey", () => {
+    expect(nkeyToBase64Pubkey("not-an-nkey")).toBeUndefined();
+  });
+});

--- a/src/common/registry/__tests__/network-cache.test.ts
+++ b/src/common/registry/__tests__/network-cache.test.ts
@@ -1,0 +1,90 @@
+/**
+ * S1 (#735) — NetworkCache unit tests (DD-10 disk fallback).
+ *
+ * Direct tests of the cache primitive: store/load round-trip, corrupt-file
+ * resilience, wrong-network rejection, and the no-file case. These complement
+ * the client-level cache tests in `network-client.test.ts`.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+import { NetworkCache } from "../network-cache";
+import type { NetworkDescriptor, NetworkRosterResult } from "../types";
+
+const noopLog = (): void => {
+  /* swallow */
+};
+
+let tmp: string;
+let cache: NetworkCache;
+
+const descriptor: NetworkDescriptor = {
+  network_id: "iaw",
+  hub_url: "tls://hub.meta-factory.ai:7422",
+  leaf_port: 7422,
+  members: ["andreas", "jc"],
+};
+const roster: NetworkRosterResult = {
+  network_id: "iaw",
+  members: [{ principal_id: "andreas", principal_pubkey: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=" }],
+};
+
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), "cortex-cache-unit-"));
+  cache = new NetworkCache({ cacheDir: tmp, logError: noopLog });
+});
+
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+describe("NetworkCache", () => {
+  test("store then load round-trips a verified pair", () => {
+    expect(cache.store("iaw", descriptor, roster)).toBe(true);
+    const loaded = cache.load("iaw");
+    expect(loaded?.descriptor).toEqual(descriptor);
+    expect(loaded?.roster).toEqual(roster);
+    expect(typeof loaded?.cached_at).toBe("string");
+  });
+
+  test("load returns undefined when no cache file exists", () => {
+    expect(cache.load("absent")).toBeUndefined();
+  });
+
+  test("load returns undefined on a corrupt (non-JSON) cache file", () => {
+    writeFileSync(join(tmp, "iaw.json"), "{ not valid json", { encoding: "utf8" });
+    expect(cache.load("iaw")).toBeUndefined();
+  });
+
+  test("load rejects a file whose cached network_id does not match", () => {
+    // A descriptor for a DIFFERENT network written under the iaw filename.
+    cache.store("other", { ...descriptor, network_id: "other" }, { ...roster, network_id: "other" });
+    // Hand-place the 'other' content under the 'iaw' filename to simulate a
+    // swapped/corrupt file.
+    const otherContent = cache.load("other");
+    expect(otherContent).toBeDefined();
+    writeFileSync(
+      join(tmp, "iaw.json"),
+      JSON.stringify({
+        schema_version: 1,
+        cached_at: new Date().toISOString(),
+        descriptor: { ...descriptor, network_id: "other" },
+        roster: { ...roster, network_id: "other" },
+      }),
+      { encoding: "utf8" },
+    );
+    expect(cache.load("iaw")).toBeUndefined();
+  });
+
+  test("load rejects an unknown schema_version", () => {
+    writeFileSync(
+      join(tmp, "iaw.json"),
+      JSON.stringify({ schema_version: 999, cached_at: "x", descriptor, roster }),
+      { encoding: "utf8" },
+    );
+    expect(cache.load("iaw")).toBeUndefined();
+  });
+});

--- a/src/common/registry/__tests__/network-client.test.ts
+++ b/src/common/registry/__tests__/network-client.test.ts
@@ -1,0 +1,409 @@
+/**
+ * S1 (#735 · spec §6 F1) — NetworkRegistryClient tests.
+ *
+ * Covers the AC + the S1 brief's required cases, all against a STUB registry
+ * (an injected `fetch` closure + a real Ed25519 sign-side) — NO network I/O:
+ *
+ *   1. valid signed descriptor parse (DD-12)
+ *   2. valid signed roster parse
+ *   3. bad-signature → rejected (the load-bearing DD-9 test)
+ *   4. registry-pubkey mismatch → rejected (DD-9)
+ *   5. unknown-network 404 handling
+ *   6. cache write-after-verify + loadCached read (DD-10)
+ *   7. cache is NOT written when verification fails (DD-10 trust boundary)
+ *   8. unreachable transport → distinguished from not_found / unverified
+ *
+ * The sign-side mirrors `client.test.ts`: a fresh WebCrypto Ed25519 keypair
+ * signs `canonicalJSON({ payload, issued_at, registry })`, the exact triple
+ * the registry's `signAssertion` binds.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+import { NetworkRegistryClient } from "../network-client";
+import { canonicalJSON } from "../signing";
+import type {
+  NetworkDescriptor,
+  NetworkRosterResult,
+  SignedAssertion,
+} from "../types";
+
+// =============================================================================
+// Sign-side test helpers (the client only verifies).
+// =============================================================================
+
+function bytesToBase64(bytes: Uint8Array): string {
+  let bin = "";
+  for (const b of bytes) bin += String.fromCharCode(b);
+  return btoa(bin);
+}
+
+async function generateKeypair(): Promise<{
+  privateKey: CryptoKey;
+  publicKeyB64: string;
+}> {
+  const kp = await crypto.subtle.generateKey({ name: "Ed25519" }, true, [
+    "sign",
+    "verify",
+  ]);
+  const raw = await crypto.subtle.exportKey("raw", kp.publicKey);
+  return {
+    privateKey: kp.privateKey,
+    publicKeyB64: bytesToBase64(new Uint8Array(raw)),
+  };
+}
+
+async function signAssertion<T>(
+  privateKey: CryptoKey,
+  registryPubkey: string,
+  payload: T,
+): Promise<SignedAssertion<T>> {
+  const issued_at = new Date().toISOString();
+  const bound = canonicalJSON({ payload, issued_at, registry: registryPubkey });
+  const sig = await crypto.subtle.sign(
+    { name: "Ed25519" },
+    privateKey,
+    new TextEncoder().encode(bound),
+  );
+  return {
+    payload,
+    issued_at,
+    registry: registryPubkey,
+    signature: bytesToBase64(new Uint8Array(sig)),
+  };
+}
+
+/** A structurally-valid base64 Ed25519 peer pubkey (44 chars). */
+const PEER_PUBKEY = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+
+function makeDescriptor(networkId: string): NetworkDescriptor {
+  return {
+    network_id: networkId,
+    hub_url: "tls://hub.meta-factory.ai:7422",
+    leaf_port: 7422,
+    members: ["andreas", "jc"],
+  };
+}
+
+function makeRoster(networkId: string): NetworkRosterResult {
+  return {
+    network_id: networkId,
+    members: [
+      { principal_id: "andreas", stack_id: "andreas/meta-factory", principal_pubkey: PEER_PUBKEY },
+      { principal_id: "jc", principal_pubkey: PEER_PUBKEY },
+    ],
+  };
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+type RouteMap = Record<string, () => Promise<Response> | Response>;
+
+/** Match by URL suffix so route keys can be short ("/networks/iaw"). */
+function routeFetch(routes: RouteMap): typeof globalThis.fetch {
+  return (async (input: RequestInfo | URL): Promise<Response> => {
+    const url =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.href
+          : input.url;
+    for (const [suffix, handler] of Object.entries(routes)) {
+      if (url.endsWith(suffix)) return handler();
+    }
+    return new Response("not found", { status: 404 });
+  }) as typeof globalThis.fetch;
+}
+
+const noopLog = (): void => {
+  /* swallow in tests; assertions cover behaviour, not log text */
+};
+
+// =============================================================================
+// Fixtures
+// =============================================================================
+
+const NET = "iaw";
+let registryPubkey: string;
+let registryPrivate: CryptoKey;
+let tmp: string;
+
+beforeEach(async () => {
+  const kp = await generateKeypair();
+  registryPubkey = kp.publicKeyB64;
+  registryPrivate = kp.privateKey;
+  tmp = mkdtempSync(join(tmpdir(), "cortex-net-cache-"));
+});
+
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+function makeClient(routes: RouteMap): NetworkRegistryClient {
+  return new NetworkRegistryClient({
+    url: "https://registry.example",
+    pubkey: registryPubkey, // config-pinned (DD-9) — no TOFU
+    fetch: routeFetch(routes),
+    logError: noopLog,
+    cacheOptions: { cacheDir: tmp, logError: noopLog },
+  });
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe("NetworkRegistryClient — descriptor (DD-12)", () => {
+  test("parses a valid signed descriptor", async () => {
+    const assertion = await signAssertion(registryPrivate, registryPubkey, makeDescriptor(NET));
+    const client = makeClient({ [`/networks/${NET}`]: () => jsonResponse(assertion) });
+
+    const result = await client.getNetworkDescriptor(NET);
+    expect(result.status).toBe("ok");
+    if (result.status === "ok") {
+      expect(result.value.hub_url).toBe("tls://hub.meta-factory.ai:7422");
+      expect(result.value.leaf_port).toBe(7422);
+      expect(result.value.members).toEqual(["andreas", "jc"]);
+    }
+  });
+
+  test("rejects a descriptor with a BAD signature (DD-9)", async () => {
+    const assertion = await signAssertion(registryPrivate, registryPubkey, makeDescriptor(NET));
+    // Tamper the payload AFTER signing — the signature no longer covers it.
+    const tampered: typeof assertion = {
+      ...assertion,
+      payload: { ...assertion.payload, hub_url: "tls://evil.example:7422" },
+    };
+    const client = makeClient({ [`/networks/${NET}`]: () => jsonResponse(tampered) });
+
+    const result = await client.getNetworkDescriptor(NET);
+    expect(result.status).toBe("unverified");
+    if (result.status === "unverified") expect(result.reason).toBe("bad_signature");
+  });
+
+  test("rejects a descriptor signed by the WRONG registry key (pin mismatch, DD-9)", async () => {
+    const attacker = await generateKeypair();
+    // Attacker signs a valid-looking assertion with THEIR key + stamps THEIR
+    // pubkey as `registry`. The pin is the real registry's key.
+    const assertion = await signAssertion(
+      attacker.privateKey,
+      attacker.publicKeyB64,
+      makeDescriptor(NET),
+    );
+    const client = makeClient({ [`/networks/${NET}`]: () => jsonResponse(assertion) });
+
+    const result = await client.getNetworkDescriptor(NET);
+    expect(result.status).toBe("unverified");
+    if (result.status === "unverified") expect(result.reason).toBe("registry_pubkey_mismatch");
+  });
+
+  test("returns not_found on a 404 (unknown network)", async () => {
+    const client = makeClient({
+      [`/networks/${NET}`]: () => jsonResponse({ error: "not_found" }, 404),
+    });
+    const result = await client.getNetworkDescriptor(NET);
+    expect(result.status).toBe("not_found");
+  });
+
+  test("returns unreachable on a transport error (distinct from not_found)", async () => {
+    const client = new NetworkRegistryClient({
+      url: "https://registry.example",
+      pubkey: registryPubkey,
+      fetch: (() =>
+        Promise.reject(new Error("ECONNREFUSED"))) as unknown as typeof globalThis.fetch,
+      logError: noopLog,
+      cacheOptions: { cacheDir: tmp, logError: noopLog },
+    });
+    const result = await client.getNetworkDescriptor(NET);
+    expect(result.status).toBe("unreachable");
+  });
+
+  test("rejects a verified-but-wrong-shape payload as unverified", async () => {
+    // Registry signs garbage (no hub_url). Signature verifies, shape doesn't.
+    const assertion = await signAssertion(registryPrivate, registryPubkey, {
+      network_id: NET,
+      members: [],
+    });
+    const client = makeClient({ [`/networks/${NET}`]: () => jsonResponse(assertion) });
+    const result = await client.getNetworkDescriptor(NET);
+    expect(result.status).toBe("unverified");
+  });
+});
+
+describe("NetworkRegistryClient — roster", () => {
+  test("parses a valid signed roster", async () => {
+    const assertion = await signAssertion(registryPrivate, registryPubkey, makeRoster(NET));
+    const client = makeClient({ [`/networks/${NET}/roster`]: () => jsonResponse(assertion) });
+
+    const result = await client.getNetworkRoster(NET);
+    expect(result.status).toBe("ok");
+    if (result.status === "ok") {
+      expect(result.value.members).toHaveLength(2);
+      expect(result.value.members[0]).toEqual({
+        principal_id: "andreas",
+        stack_id: "andreas/meta-factory",
+        principal_pubkey: PEER_PUBKEY,
+      });
+      // Second member has no stack_id — optional field omitted.
+      expect(result.value.members[1]?.stack_id).toBeUndefined();
+    }
+  });
+
+  test("rejects a roster with a BAD signature (DD-9)", async () => {
+    const assertion = await signAssertion(registryPrivate, registryPubkey, makeRoster(NET));
+    const tampered: typeof assertion = {
+      ...assertion,
+      payload: {
+        ...assertion.payload,
+        members: [{ principal_id: "evil", principal_pubkey: PEER_PUBKEY }],
+      },
+    };
+    const client = makeClient({ [`/networks/${NET}/roster`]: () => jsonResponse(tampered) });
+
+    const result = await client.getNetworkRoster(NET);
+    expect(result.status).toBe("unverified");
+    if (result.status === "unverified") expect(result.reason).toBe("bad_signature");
+  });
+
+  test("rejects a roster whose peer pubkey is not base64-Ed25519", async () => {
+    const bad: NetworkRosterResult = {
+      network_id: NET,
+      members: [{ principal_id: "andreas", principal_pubkey: "not-a-key" }],
+    };
+    const assertion = await signAssertion(registryPrivate, registryPubkey, bad);
+    const client = makeClient({ [`/networks/${NET}/roster`]: () => jsonResponse(assertion) });
+    const result = await client.getNetworkRoster(NET);
+    expect(result.status).toBe("unverified");
+  });
+});
+
+describe("NetworkRegistryClient — disk cache (DD-10)", () => {
+  test("fetchAndCache persists a verified pair; loadCached reads it back", async () => {
+    const descAssertion = await signAssertion(registryPrivate, registryPubkey, makeDescriptor(NET));
+    const rosterAssertion = await signAssertion(registryPrivate, registryPubkey, makeRoster(NET));
+    const client = makeClient({
+      [`/networks/${NET}/roster`]: () => jsonResponse(rosterAssertion),
+      [`/networks/${NET}`]: () => jsonResponse(descAssertion),
+    });
+
+    const fetched = await client.fetchAndCache(NET);
+    expect(fetched.status).toBe("ok");
+
+    const cached = client.loadCached(NET);
+    expect(cached).toBeDefined();
+    expect(cached?.descriptor.hub_url).toBe("tls://hub.meta-factory.ai:7422");
+    expect(cached?.roster.members).toHaveLength(2);
+  });
+
+  test("loadCached survives a fresh client instance (true disk persistence)", async () => {
+    const descAssertion = await signAssertion(registryPrivate, registryPubkey, makeDescriptor(NET));
+    const rosterAssertion = await signAssertion(registryPrivate, registryPubkey, makeRoster(NET));
+    const writer = makeClient({
+      [`/networks/${NET}/roster`]: () => jsonResponse(rosterAssertion),
+      [`/networks/${NET}`]: () => jsonResponse(descAssertion),
+    });
+    await writer.fetchAndCache(NET);
+
+    // A brand-new client (no in-memory state) reading the same cache dir.
+    const reader = makeClient({});
+    const cached = reader.loadCached(NET);
+    expect(cached?.descriptor.leaf_port).toBe(7422);
+  });
+
+  test("does NOT cache when the descriptor fails verification (DD-9 trust boundary)", async () => {
+    const descAssertion = await signAssertion(registryPrivate, registryPubkey, makeDescriptor(NET));
+    const tampered: typeof descAssertion = {
+      ...descAssertion,
+      payload: { ...descAssertion.payload, hub_url: "tls://evil.example:7422" },
+    };
+    const rosterAssertion = await signAssertion(registryPrivate, registryPubkey, makeRoster(NET));
+    const client = makeClient({
+      [`/networks/${NET}/roster`]: () => jsonResponse(rosterAssertion),
+      [`/networks/${NET}`]: () => jsonResponse(tampered),
+    });
+
+    const fetched = await client.fetchAndCache(NET);
+    expect(fetched.status).toBe("unverified");
+    // Nothing should have been written — the verification gate is upstream of
+    // the cache write.
+    expect(client.loadCached(NET)).toBeUndefined();
+  });
+
+  test("does NOT cache when only the descriptor verifies but the roster does not", async () => {
+    const descAssertion = await signAssertion(registryPrivate, registryPubkey, makeDescriptor(NET));
+    const rosterAssertion = await signAssertion(registryPrivate, registryPubkey, makeRoster(NET));
+    const tamperedRoster: typeof rosterAssertion = {
+      ...rosterAssertion,
+      payload: {
+        ...rosterAssertion.payload,
+        members: [{ principal_id: "evil", principal_pubkey: PEER_PUBKEY }],
+      },
+    };
+    const client = makeClient({
+      [`/networks/${NET}/roster`]: () => jsonResponse(tamperedRoster),
+      [`/networks/${NET}`]: () => jsonResponse(descAssertion),
+    });
+
+    const fetched = await client.fetchAndCache(NET);
+    expect(fetched.status).toBe("unverified");
+    expect(client.loadCached(NET)).toBeUndefined();
+  });
+
+  test("loadCached returns undefined when nothing is cached", async () => {
+    const client = makeClient({});
+    expect(client.loadCached("never-fetched")).toBeUndefined();
+  });
+});
+
+describe("NetworkRegistryClient — TOFU + unconfigured", () => {
+  test("rejects an 'unconfigured' registry assertion", async () => {
+    // Registry has no signing key → sentinel registry field + empty sig.
+    const unconfigured = {
+      payload: makeDescriptor(NET),
+      issued_at: new Date().toISOString(),
+      registry: "unconfigured",
+      signature: "",
+    };
+    // Pin a real key so the mismatch path isn't what triggers; the sentinel
+    // is caught first only when pinned===sentinel, so test TOFU instead:
+    const client = new NetworkRegistryClient({
+      url: "https://registry.example",
+      // No pubkey → TOFU. Registry returns the unconfigured sentinel pubkey.
+      fetch: routeFetch({
+        "/registry/pubkey": () => jsonResponse({ algorithm: "Ed25519", public_key: "unconfigured" }),
+        [`/networks/${NET}`]: () => jsonResponse(unconfigured),
+      }),
+      logError: noopLog,
+      cacheOptions: { cacheDir: tmp, logError: noopLog },
+    });
+
+    const result = await client.getNetworkDescriptor(NET);
+    // TOFU refused the unconfigured pubkey → no pin → unreachable.
+    expect(result.status).toBe("unreachable");
+  });
+
+  test("TOFU pins the registry pubkey then verifies", async () => {
+    const descAssertion = await signAssertion(registryPrivate, registryPubkey, makeDescriptor(NET));
+    const client = new NetworkRegistryClient({
+      url: "https://registry.example",
+      // No config pin → TOFU discovers the real key.
+      fetch: routeFetch({
+        "/registry/pubkey": () => jsonResponse({ algorithm: "Ed25519", public_key: registryPubkey }),
+        [`/networks/${NET}`]: () => jsonResponse(descAssertion),
+      }),
+      logError: noopLog,
+      cacheOptions: { cacheDir: tmp, logError: noopLog },
+    });
+
+    const result = await client.getNetworkDescriptor(NET);
+    expect(result.status).toBe("ok");
+  });
+});

--- a/src/common/registry/encoding.ts
+++ b/src/common/registry/encoding.ts
@@ -1,0 +1,98 @@
+/**
+ * S1 (Network Join Control Plane, #735 / epic #733) — pubkey-encoding
+ * bridge between the two surfaces of one Ed25519 key.
+ *
+ * **DD-8 (one canonical pubkey encoding per surface).** Config + peers use
+ * NATS NKey-U (`U…`, 56-char base32); the registry stores base64 raw
+ * ed25519 (32 bytes → 44 chars w/ padding). The join control plane is the
+ * single place these translate so humans never hand-convert (the §1
+ * bring-up "encoding confusion" trap, design doc step 4).
+ *
+ * Both encodings cover the SAME 32-byte ed25519 pubkey underneath:
+ *
+ *   - nkey-U  = `U` prefix-byte + 32 raw bytes + 2-byte CRC, crockford-
+ *               base32-encoded (56 ASCII chars total).
+ *   - base64  = the 32 raw bytes, standard-base64-encoded (44 chars).
+ *
+ * The decode direction (nkey-U → base64) already exists as
+ * `nkeyToBase64Pubkey` in `src/bus/verify-signed-by-chain.ts` — re-exported
+ * here so the registry layer has one import for both directions. This module
+ * adds the inverse (`base64PubkeyToNkey`), needed by S2's config-load peer
+ * resolver: the registry roster serves base64, but `policy.federated.
+ * networks[].peers[].principal_pubkey` is declared in nkey-U, so a
+ * registry-resolved peer must be re-encoded to nkey-U before it can be
+ * compared against (or merged into) the config surface.
+ *
+ * **Crypto is NOT hand-rolled** — both directions go through
+ * `@nats-io/nkeys`'s `Codec` (the same internal base32 + CRC16 + prefix
+ * codec the bus-side verifier already trusts), per the S1 brief.
+ */
+
+import { Prefix } from "@nats-io/nkeys";
+// `Codec` is the internal NKey base32 + CRC + prefix-byte codec. Marked
+// `@ignore` in @nats-io/nkeys but stable; it is the SAME subpath the
+// bus-side verifier uses (`src/bus/verify-signed-by-chain.ts`) to decode an
+// NKey to raw bytes — we use its `encode` for the inverse here so both
+// directions share one crockford-base32 + CRC16 implementation.
+import { Codec } from "@nats-io/nkeys/lib/codec";
+
+// Re-export the existing decode helper so callers in the registry layer have
+// a single import surface for the DD-8 translation pair. The implementation
+// stays in the bus module (it is consumed there by the crypto-verify
+// registry bridge) — moving it would be an out-of-scope refactor.
+export { nkeyToBase64Pubkey } from "../../bus/verify-signed-by-chain";
+
+/** Base64 Ed25519 grammar: 43 standard-alphabet chars + one `=` of padding. */
+const BASE64_ED25519 = /^[A-Za-z0-9+/]{43}=$/;
+
+/**
+ * Decode a standard-base64 raw ed25519 pubkey (44 chars w/ padding) to its
+ * 32 raw bytes. Returns `undefined` if the input is not valid base64 or does
+ * not decode to exactly 32 bytes — a malformed key must fail loudly at the
+ * boundary, never silently produce a wrong nkey.
+ */
+function base64PubkeyToBytes(b64: string): Uint8Array | undefined {
+  if (!BASE64_ED25519.test(b64)) return undefined;
+  let bin: string;
+  try {
+    bin = atob(b64);
+  } catch (_err) {
+    // atob throws on a non-base64 alphabet; the regex above should have
+    // caught it, so this is defensive only. Safe to swallow — we return the
+    // negative outcome the caller branches on, not a thrown error.
+    return undefined;
+  }
+  if (bin.length !== 32) return undefined;
+  const out = new Uint8Array(32);
+  for (let i = 0; i < 32; i++) out[i] = bin.charCodeAt(i);
+  return out;
+}
+
+/**
+ * Convert a base64 raw ed25519 pubkey (the registry surface, 44 chars w/
+ * padding) to a NATS NKey-U public key (the config/peers surface, `U…`,
+ * 56-char base32) — the **DD-8** encode direction.
+ *
+ * Round-trips with `nkeyToBase64Pubkey`:
+ *   `nkeyToBase64Pubkey(base64PubkeyToNkey(b64)) === b64` for any valid key
+ *   (pinned by the encoding round-trip test).
+ *
+ * Returns `undefined` (never throws) if the input is not a valid base64
+ * 32-byte ed25519 pubkey, so a poison registry value cannot crash the
+ * config-load resolver that consumes this in S2.
+ */
+export function base64PubkeyToNkey(b64: string): string | undefined {
+  const raw = base64PubkeyToBytes(b64);
+  if (raw === undefined) return undefined;
+  try {
+    // `Codec.encode(Prefix.User, raw)` prepends the `U` prefix byte, appends
+    // a 2-byte CRC16, and crockford-base32-encodes the lot → the 56-char
+    // `U…` NKey string. `TextDecoder` turns the ASCII bytes into the string.
+    const encoded = Codec.encode(Prefix.User, raw);
+    return new TextDecoder().decode(encoded);
+  } catch (_err) {
+    // Codec rejected the input (should not happen for a validated 32-byte
+    // key); return the negative outcome rather than throwing.
+    return undefined;
+  }
+}

--- a/src/common/registry/index.ts
+++ b/src/common/registry/index.ts
@@ -20,6 +20,16 @@ export {
   PrincipalPubkeyResolver,
   resolvePrincipalPubkey,
 } from "./resolve-pubkey";
+export { NetworkRegistryClient } from "./network-client";
+export type {
+  NetworkFetchResult,
+  NetworkRegistryClientOptions,
+} from "./network-client";
+export { NetworkCache } from "./network-cache";
+export type { CachedNetwork, NetworkCacheOptions } from "./network-cache";
+export { base64PubkeyToNkey, nkeyToBase64Pubkey } from "./encoding";
+export { verifySignedAssertion } from "./verify-assertion";
+export type { VerifyAssertionResult } from "./verify-assertion";
 export type {
   PrincipalPubkeyResolverOptions,
   ResolveResult,
@@ -34,6 +44,9 @@ export type {
 } from "./identity-registry";
 export type {
   Capability,
+  NetworkDescriptor,
+  NetworkRosterPeer,
+  NetworkRosterResult,
   PrincipalRecord,
   RegistryClientOptions,
   RegistryClientReader,

--- a/src/common/registry/network-cache.ts
+++ b/src/common/registry/network-cache.ts
@@ -1,0 +1,199 @@
+/**
+ * S1 (Network Join Control Plane, #735) — on-disk last-known-good cache for
+ * verified network descriptors + rosters.
+ *
+ * **DD-10 (registry-down → cached roster + warn).** When the registry is
+ * unreachable at boot, federation must NOT be silently torn down: the stack
+ * falls back to the last verified descriptor + roster it cached. S2's
+ * config-load peer resolver reads this via {@link NetworkCache.load} when a
+ * live fetch fails; S1 writes it via {@link NetworkCache.store} — but ONLY
+ * after the response signature verified against the pinned registry pubkey
+ * (DD-9). An unverified response is never cached, so the cache is a trust
+ * extension of the pin, not a bypass of it.
+ *
+ * Path convention: one JSON file per network under a cache dir, default
+ * `~/.config/cortex/network-cache/` (matches the `~/.config/cortex/` stack
+ * config dir convention used across the CLIs). The dir + filename are
+ * injectable so tests use a tmp dir and never touch a real home directory.
+ *
+ * Failure handling (CLAUDE.md: NEVER empty catch): every read/write error is
+ * logged via `logError` (defaults to stderr) and turned into a negative
+ * return — a missing/corrupt cache file degrades to "no cache", never a throw.
+ */
+
+import { mkdirSync, readFileSync, writeFileSync } from "fs";
+import { homedir } from "os";
+import { join } from "path";
+
+import type { NetworkDescriptor, NetworkRosterResult } from "./types";
+
+/** Default cache dir — sibling of `~/.config/cortex/cortex.yaml`. */
+const DEFAULT_CACHE_DIR = join(homedir(), ".config", "cortex", "network-cache");
+
+/** Schema version stamped into each cache file so a future shape change can
+ *  detect + discard stale entries rather than mis-parsing them. */
+const CACHE_SCHEMA_VERSION = 1 as const;
+
+/**
+ * The on-disk record for one network: the last verified descriptor + roster,
+ * plus the time they were cached. Both halves are written together so a reader
+ * always gets a consistent pair (descriptor + its matching roster).
+ */
+export interface CachedNetwork {
+  schema_version: typeof CACHE_SCHEMA_VERSION;
+  /** ISO-8601 time this record was written (i.e. last verified). */
+  cached_at: string;
+  descriptor: NetworkDescriptor;
+  roster: NetworkRosterResult;
+}
+
+/** Construction options for {@link NetworkCache}. */
+export interface NetworkCacheOptions {
+  /**
+   * Directory cache files live under. Defaults to
+   * `~/.config/cortex/network-cache/`. Tests pass a tmp dir.
+   */
+  cacheDir?: string;
+  /**
+   * Logger seam — defaults to `process.stderr.write` (CLAUDE.md "no empty
+   * catches"). Tests inject a spy / no-op.
+   */
+  logError?: (msg: string) => void;
+}
+
+/**
+ * Last-known-good disk cache for network descriptors + rosters. One file per
+ * network. Construct once; call `store()` after a verified fetch and `load()`
+ * on the registry-down fallback path (S2).
+ */
+export class NetworkCache {
+  private readonly cacheDir: string;
+  private readonly logError: (msg: string) => void;
+
+  constructor(options: NetworkCacheOptions = {}) {
+    this.cacheDir = options.cacheDir ?? DEFAULT_CACHE_DIR;
+    this.logError =
+      options.logError ??
+      ((msg: string) => {
+        process.stderr.write(`network-cache: ${msg}\n`);
+      });
+  }
+
+  /**
+   * Persist a verified descriptor + roster for `networkId`. Call ONLY after
+   * the responses verified against the pinned registry pubkey (DD-9) — this
+   * method does NOT verify, it only writes. Returns `true` on success,
+   * `false` (with a log line) on any I/O error; a cache-write failure must
+   * not fail the calling fetch (the live data is already in hand).
+   */
+  store(
+    networkId: string,
+    descriptor: NetworkDescriptor,
+    roster: NetworkRosterResult,
+  ): boolean {
+    const record: CachedNetwork = {
+      schema_version: CACHE_SCHEMA_VERSION,
+      cached_at: new Date().toISOString(),
+      descriptor,
+      roster,
+    };
+    try {
+      mkdirSync(this.cacheDir, { recursive: true });
+      // Pretty-print: these files are human-inspectable during ops triage of
+      // a registry outage, and the size is trivial (a handful of peers).
+      writeFileSync(this.pathFor(networkId), JSON.stringify(record, null, 2), {
+        encoding: "utf8",
+      });
+      return true;
+    } catch (err) {
+      this.logError(
+        `store(${networkId}) failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      return false;
+    }
+  }
+
+  /**
+   * Load the last-known-good cached record for `networkId`, or `undefined` if
+   * there is no cache file, it cannot be read, it is not valid JSON, or it
+   * fails the structural shape check. NEVER throws — a corrupt cache degrades
+   * to "no cache" so the caller falls through to its no-cache path rather
+   * than crashing on a poison file.
+   */
+  load(networkId: string): CachedNetwork | undefined {
+    let text: string;
+    try {
+      text = readFileSync(this.pathFor(networkId), { encoding: "utf8" });
+    } catch (err) {
+      // ENOENT is the common, expected case (no cache yet) — log at the same
+      // fidelity as other misses so a silent "why is there no cache" is still
+      // observable, but it is not an error condition for the caller.
+      const code = (err as NodeJS.ErrnoException | undefined)?.code;
+      if (code !== "ENOENT") {
+        this.logError(
+          `load(${networkId}) read failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+      return undefined;
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(text);
+    } catch (err) {
+      this.logError(
+        `load(${networkId}) JSON parse failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      return undefined;
+    }
+
+    if (!isCachedNetwork(parsed, networkId)) {
+      this.logError(
+        `load(${networkId}) cache file failed shape/version check; ignoring`,
+      );
+      return undefined;
+    }
+    return parsed;
+  }
+
+  /** Absolute path to the cache file for `networkId`. */
+  private pathFor(networkId: string): string {
+    // `networkId` is letter-prefixed lowercase-alphanumeric + hyphen per the
+    // schema grammar, so it is filesystem-safe as a bare filename. Defend
+    // anyway: a path separator would let a malformed id escape the cache dir.
+    const safe = networkId.replace(/[^a-z0-9-]/g, "_");
+    return join(this.cacheDir, `${safe}.json`);
+  }
+}
+
+/**
+ * Structural guard for a parsed cache file. Checks the schema version, the
+ * descriptor/roster shape, and that the cached `network_id` matches the id we
+ * loaded under — a swapped file (descriptor for a different network) is
+ * treated as corrupt.
+ */
+function isCachedNetwork(value: unknown, networkId: string): value is CachedNetwork {
+  if (value === null || typeof value !== "object") return false;
+  const v = value as Record<string, unknown>;
+  if (v.schema_version !== CACHE_SCHEMA_VERSION) return false;
+  if (typeof v.cached_at !== "string") return false;
+
+  const descriptor = v.descriptor;
+  if (descriptor === null || typeof descriptor !== "object") return false;
+  const d = descriptor as Record<string, unknown>;
+  if (
+    d.network_id !== networkId ||
+    typeof d.hub_url !== "string" ||
+    typeof d.leaf_port !== "number" ||
+    !Array.isArray(d.members)
+  ) {
+    return false;
+  }
+
+  const roster = v.roster;
+  if (roster === null || typeof roster !== "object") return false;
+  const r = roster as Record<string, unknown>;
+  if (r.network_id !== networkId || !Array.isArray(r.members)) return false;
+
+  return true;
+}

--- a/src/common/registry/network-client.ts
+++ b/src/common/registry/network-client.ts
@@ -1,0 +1,413 @@
+/**
+ * S1 (Network Join Control Plane, #735 · epic #733 · spec
+ * `docs/design-network-join-control-plane.md` §6 F1) — typed registry client
+ * for the network **descriptor** + **roster**.
+ *
+ * This is the F1 client: the registry-mediated half of `cortex network join`
+ * (DD-3/DD-4). It extends the existing cortex registry consumers
+ * (`RegistryClient`, `PrincipalPubkeyResolver`) with the two network-scoped
+ * endpoints the join path needs, and it folds in the three S1 design
+ * decisions:
+ *
+ *   - **DD-12** — `getNetworkDescriptor(id)` resolves `GET /networks/{id}` to
+ *     a typed {@link NetworkDescriptor} (`hub_url` / `leaf_port` / `members`),
+ *     so the hub is registry-served and relocatable, never hand-pinned.
+ *   - **DD-9**  — EVERY response is a `SignedAssertion` verified against a
+ *     PINNED registry pubkey (config `policy.federated.registry.pubkey`, or
+ *     TOFU). An unverified response is rejected (a typed error / negative);
+ *     it is NEVER returned and NEVER cached.
+ *   - **DD-10** — a verified descriptor + roster pair is persisted to disk
+ *     (after verification only) so S2's config-load resolver can fall back to
+ *     the last-known-good when the registry is unreachable.
+ *
+ * **Crypto is reused, not hand-rolled.** Signature verification goes through
+ * the shared {@link verifySignedAssertion} (same `canonicalJSON` +
+ * `verifyEd25519` primitives the principal client + resolver use); the DD-8
+ * pubkey-encoding bridge lives in `./encoding.ts`.
+ *
+ * **Failure model.** Unlike the boot-time `RegistryClient` (which swallows
+ * every failure to `undefined` because a background refresh must never crash
+ * the bot), this client is called from the foreground join/resolve path where
+ * the caller needs to DISTINGUISH "not found" (a real "no such network") from
+ * "could not verify" (fall back to cache, DD-10) from a successful fetch. So
+ * `getNetworkDescriptor` / `getNetworkRoster` return a discriminated
+ * {@link NetworkFetchResult}, never throw, and let the caller branch. A
+ * thrown error is reserved for a programmer mistake (no pinned key AND no
+ * TOFU configured at construction).
+ */
+
+import { NetworkCache, type NetworkCacheOptions } from "./network-cache";
+import type {
+  NetworkDescriptor,
+  NetworkRosterPeer,
+  NetworkRosterResult,
+} from "./types";
+import { verifySignedAssertion } from "./verify-assertion";
+
+/** Base64 Ed25519 grammar: 43 standard-alphabet chars + one `=` of padding. */
+const BASE64_ED25519 = /^[A-Za-z0-9+/]{43}=$/;
+
+const DEFAULT_REQUEST_TIMEOUT_MS = 10_000;
+
+/**
+ * Discriminated outcome of a descriptor / roster fetch. NEVER thrown — the
+ * caller branches.
+ *
+ * - `ok`         — verified payload of the requested shape.
+ * - `not_found`  — the registry returned 404 (no such network). Stable.
+ * - `unverified` — a response arrived but failed the DD-9 pin+verify gate
+ *                  (bad signature, wrong/sentinel registry pubkey, or a
+ *                  malformed envelope). The load-bearing rejection — the
+ *                  payload is NOT returned. `reason` carries the precise class
+ *                  for audit.
+ * - `unreachable`— transport failure (network error, timeout, non-404 HTTP,
+ *                  unparseable body) OR no pinned pubkey available. The
+ *                  caller's DD-10 cache fallback hangs off this branch.
+ */
+export type NetworkFetchResult<T> =
+  | { status: "ok"; value: T }
+  | { status: "not_found" }
+  | { status: "unverified"; reason: string }
+  | { status: "unreachable"; reason: string };
+
+/** Construction options for {@link NetworkRegistryClient}. */
+export interface NetworkRegistryClientOptions {
+  /**
+   * Registry base URL (`policy.federated.registry.url`). Trailing slashes are
+   * normalised away before path joining.
+   */
+  url: string;
+  /**
+   * Pinned registry pubkey (`policy.federated.registry.pubkey`, base64
+   * Ed25519, 44 chars w/ padding). When absent, the client performs TOFU via
+   * `GET {url}/registry/pubkey` on first I/O and pins the response for its
+   * lifetime — the documented Phase-B caveat shared with the other registry
+   * consumers. Supplying it (out-of-band) is the recommended zero-TOFU
+   * posture (DD-9).
+   */
+  pubkey?: string;
+  /** Per-request timeout (ms). Default 10s. Wraps each `fetch` via abort. */
+  requestTimeoutMs?: number;
+  /** `fetch` implementation. Defaults to `globalThis.fetch`. Tests inject. */
+  fetch?: typeof globalThis.fetch;
+  /**
+   * Logger seam — defaults to `process.stderr.write` (CLAUDE.md "no empty
+   * catches"). Tests inject a spy / no-op.
+   */
+  logError?: (msg: string) => void;
+  /**
+   * Disk-cache options (DD-10). `cacheDir` defaults to
+   * `~/.config/cortex/network-cache/`; tests pass a tmp dir. An injected
+   * {@link NetworkCache} (e.g. a shared instance) can be supplied instead.
+   */
+  cache?: NetworkCache;
+  cacheOptions?: NetworkCacheOptions;
+}
+
+/**
+ * Typed network descriptor + roster client. Single-process; no background
+ * timers (unlike `RegistryClient`) — the join/resolve path calls it on demand.
+ */
+export class NetworkRegistryClient {
+  private readonly url: string;
+  private readonly requestTimeoutMs: number;
+  private readonly fetchImpl: typeof globalThis.fetch;
+  private readonly logError: (msg: string) => void;
+  private readonly cache: NetworkCache;
+
+  /** Pinned registry pubkey. Set in ctor (config) or via TOFU on first I/O. */
+  private pinnedPubkey: string | undefined;
+  /** Whether the pin must be discovered via TOFU (no config pin). */
+  private readonly tofuMode: boolean;
+
+  constructor(options: NetworkRegistryClientOptions) {
+    this.url = options.url.replace(/\/+$/, "");
+    this.requestTimeoutMs =
+      options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
+    this.fetchImpl = options.fetch ?? globalThis.fetch.bind(globalThis);
+    this.logError =
+      options.logError ??
+      ((msg: string) => {
+        process.stderr.write(`network-registry-client: ${msg}\n`);
+      });
+    this.cache = options.cache ?? new NetworkCache(options.cacheOptions);
+    this.pinnedPubkey = options.pubkey;
+    this.tofuMode = options.pubkey === undefined;
+  }
+
+  /**
+   * Resolve `GET /networks/{networkId}` to a verified {@link NetworkDescriptor}
+   * (DD-12). The response is pin+verified (DD-9) and, when it AND a roster
+   * fetch both succeed via {@link fetchAndCache}, persisted to disk (DD-10).
+   * This bare getter does NOT write the cache (a descriptor without its roster
+   * is an incomplete pair); use {@link fetchAndCache} to refresh the cache.
+   */
+  async getNetworkDescriptor(
+    networkId: string,
+  ): Promise<NetworkFetchResult<NetworkDescriptor>> {
+    const verified = await this.fetchVerified(
+      `/networks/${encodeURIComponent(networkId)}`,
+    );
+    if (verified.status !== "ok") return verified;
+    const descriptor = parseDescriptor(verified.value, networkId);
+    if (descriptor === undefined) {
+      this.logError(
+        `getNetworkDescriptor(${networkId}): verified payload is not a valid descriptor; rejecting`,
+      );
+      return { status: "unverified", reason: "descriptor payload shape invalid" };
+    }
+    return { status: "ok", value: descriptor };
+  }
+
+  /**
+   * Resolve `GET /networks/{networkId}/roster` to a verified
+   * {@link NetworkRosterResult}. Pin+verified (DD-9); peer pubkeys are
+   * grammar-gated as base64 Ed25519 before the roster is trusted.
+   */
+  async getNetworkRoster(
+    networkId: string,
+  ): Promise<NetworkFetchResult<NetworkRosterResult>> {
+    const verified = await this.fetchVerified(
+      `/networks/${encodeURIComponent(networkId)}/roster`,
+    );
+    if (verified.status !== "ok") return verified;
+    const roster = parseRoster(verified.value, networkId);
+    if (roster === undefined) {
+      this.logError(
+        `getNetworkRoster(${networkId}): verified payload is not a valid roster; rejecting`,
+      );
+      return { status: "unverified", reason: "roster payload shape invalid" };
+    }
+    return { status: "ok", value: roster };
+  }
+
+  /**
+   * Fetch BOTH the descriptor and the roster, verify both (DD-9), and on
+   * success persist the pair to disk (DD-10) — the refresh path the join
+   * command + S2 resolver drive. Returns the verified pair on success; on any
+   * non-`ok` for either half, returns that negative WITHOUT writing the cache
+   * (a half-pair is never cached). The previously-cached pair, if any, is left
+   * untouched so a transient failure never blanks last-known-good.
+   */
+  async fetchAndCache(
+    networkId: string,
+  ): Promise<
+    NetworkFetchResult<{ descriptor: NetworkDescriptor; roster: NetworkRosterResult }>
+  > {
+    const descriptorResult = await this.getNetworkDescriptor(networkId);
+    if (descriptorResult.status !== "ok") return descriptorResult;
+    const rosterResult = await this.getNetworkRoster(networkId);
+    if (rosterResult.status !== "ok") return rosterResult;
+
+    // BOTH halves verified — only now is it safe to cache (DD-10: cache only
+    // after signature verification).
+    this.cache.store(networkId, descriptorResult.value, rosterResult.value);
+    return {
+      status: "ok",
+      value: { descriptor: descriptorResult.value, roster: rosterResult.value },
+    };
+  }
+
+  /**
+   * DD-10 fallback read — the last verified descriptor + roster for
+   * `networkId`, or `undefined` if nothing is cached. S2 calls this when a
+   * live fetch returns `unreachable`, so federation stays up across a
+   * transient registry outage. NEVER throws.
+   */
+  loadCached(
+    networkId: string,
+  ): { descriptor: NetworkDescriptor; roster: NetworkRosterResult } | undefined {
+    const cached = this.cache.load(networkId);
+    if (cached === undefined) return undefined;
+    return { descriptor: cached.descriptor, roster: cached.roster };
+  }
+
+  // ===========================================================================
+  // Private — verified fetch + TOFU
+  // ===========================================================================
+
+  /**
+   * Fetch a registry path and verify the `SignedAssertion` against the pinned
+   * pubkey (DD-9). Returns the verified, still-untyped `payload` on success;
+   * a discriminated negative otherwise. The shared {@link verifySignedAssertion}
+   * is the single DD-9 gate.
+   */
+  private async fetchVerified(path: string): Promise<NetworkFetchResult<unknown>> {
+    // TOFU the registry pubkey on first I/O if it wasn't config-pinned.
+    // Retried on every call until it succeeds — a transient outage on the
+    // first attempt must not leave the client permanently unable to verify.
+    if (this.pinnedPubkey === undefined && this.tofuMode) {
+      await this.fetchAndPinRegistryPubkey();
+    }
+    if (this.pinnedPubkey === undefined) {
+      this.logError(
+        `fetch ${path}: no pinned registry pubkey (TOFU failing or never supplied); cannot verify`,
+      );
+      return { status: "unreachable", reason: "no pinned registry pubkey" };
+    }
+
+    const fetched = await this.fetchJson(`${this.url}${path}`);
+    if (fetched.kind === "not_found") return { status: "not_found" };
+    if (fetched.kind === "error") {
+      return { status: "unreachable", reason: fetched.reason };
+    }
+
+    const result = await verifySignedAssertion(fetched.body, this.pinnedPubkey);
+    switch (result.kind) {
+      case "ok":
+        return { status: "ok", value: result.payload };
+      case "bad_signature":
+        this.logError(`fetch ${path}: signature did not verify; rejecting (DD-9)`);
+        return { status: "unverified", reason: "bad_signature" };
+      case "pubkey_mismatch":
+        this.logError(
+          `fetch ${path}: registry pubkey mismatch (got ${result.got.slice(0, 8)}…, pinned ${this.pinnedPubkey.slice(0, 8)}…); rejecting (DD-9)`,
+        );
+        return { status: "unverified", reason: "registry_pubkey_mismatch" };
+      case "unconfigured":
+        this.logError(`fetch ${path}: registry assertion says "unconfigured"; rejecting`);
+        return { status: "unverified", reason: "registry_unconfigured" };
+      case "malformed":
+        this.logError(`fetch ${path}: malformed assertion (${result.detail}); rejecting`);
+        return { status: "unverified", reason: `malformed_assertion: ${result.detail}` };
+    }
+  }
+
+  private async fetchAndPinRegistryPubkey(): Promise<void> {
+    const fetched = await this.fetchJson(`${this.url}/registry/pubkey`);
+    if (fetched.kind !== "ok") {
+      this.logError(
+        `TOFU failed: could not fetch /registry/pubkey; client stays unpinned and rejects until a later attempt succeeds`,
+      );
+      return;
+    }
+    const raw = fetched.body;
+    if (
+      typeof raw !== "object" ||
+      raw === null ||
+      (raw as { algorithm?: unknown }).algorithm !== "Ed25519" ||
+      typeof (raw as { public_key?: unknown }).public_key !== "string"
+    ) {
+      this.logError("TOFU failed: malformed /registry/pubkey response");
+      return;
+    }
+    const publicKey = (raw as { public_key: string }).public_key;
+    if (publicKey === "" || publicKey === "unconfigured") {
+      this.logError("TOFU failed: registry returned unconfigured pubkey; refusing to pin");
+      return;
+    }
+    this.pinnedPubkey = publicKey;
+  }
+
+  /**
+   * Issue a JSON GET. Distinguishes 404 (a stable "no such network") from
+   * every other failure (`error`, with a reason) and success (`ok`). Wraps
+   * timeout + non-2xx + parse failure into a discriminated return — NEVER
+   * throws.
+   */
+  private async fetchJson(
+    url: string,
+  ): Promise<
+    | { kind: "ok"; body: unknown }
+    | { kind: "not_found" }
+    | { kind: "error"; reason: string }
+  > {
+    const controller = new AbortController();
+    const timeoutHandle = setTimeout(() => {
+      controller.abort();
+    }, this.requestTimeoutMs);
+    try {
+      const res = await this.fetchImpl(url, { signal: controller.signal });
+      if (res.status === 404) return { kind: "not_found" };
+      if (!res.ok) {
+        this.logError(`GET ${url} returned ${res.status}`);
+        return { kind: "error", reason: `http_${res.status}` };
+      }
+      try {
+        return { kind: "ok", body: await res.json() };
+      } catch (err) {
+        const reason = err instanceof Error ? err.message : String(err);
+        this.logError(`GET ${url} JSON parse failed: ${reason}`);
+        return { kind: "error", reason: "json_parse_failed" };
+      }
+    } catch (err) {
+      if (err instanceof Error && err.name === "AbortError") {
+        this.logError(`GET ${url} timed out after ${this.requestTimeoutMs}ms`);
+        return { kind: "error", reason: "timeout" };
+      }
+      const reason = err instanceof Error ? err.message : String(err);
+      this.logError(`GET ${url} failed: ${reason}`);
+      return { kind: "error", reason: "network_error" };
+    } finally {
+      clearTimeout(timeoutHandle);
+    }
+  }
+}
+
+// =============================================================================
+// Payload shape parsers (private) — validate the verified payload is the shape
+// we asked for. A verified-but-wrong-shape payload is treated as unverified:
+// the registry signed something that isn't a descriptor/roster, which is a
+// wire-contract violation, not a value to trust.
+// =============================================================================
+
+/** Parse + validate a verified payload as a {@link NetworkDescriptor}. */
+function parseDescriptor(
+  payload: unknown,
+  networkId: string,
+): NetworkDescriptor | undefined {
+  if (payload === null || typeof payload !== "object") return undefined;
+  const p = payload as Record<string, unknown>;
+  if (p.network_id !== networkId) return undefined;
+  if (typeof p.hub_url !== "string" || p.hub_url.length === 0) return undefined;
+  if (typeof p.leaf_port !== "number" || !Number.isInteger(p.leaf_port)) {
+    return undefined;
+  }
+  if (!Array.isArray(p.members) || !p.members.every((m) => typeof m === "string")) {
+    return undefined;
+  }
+  const members: string[] = p.members.filter(
+    (m): m is string => typeof m === "string",
+  );
+  return {
+    network_id: networkId,
+    hub_url: p.hub_url,
+    leaf_port: p.leaf_port,
+    members,
+  };
+}
+
+/** Parse + validate a verified payload as a {@link NetworkRosterResult}. */
+function parseRoster(
+  payload: unknown,
+  networkId: string,
+): NetworkRosterResult | undefined {
+  if (payload === null || typeof payload !== "object") return undefined;
+  const p = payload as Record<string, unknown>;
+  if (p.network_id !== networkId) return undefined;
+  if (!Array.isArray(p.members)) return undefined;
+
+  const members: NetworkRosterPeer[] = [];
+  for (const raw of p.members) {
+    if (raw === null || typeof raw !== "object") return undefined;
+    const m = raw as Record<string, unknown>;
+    if (typeof m.principal_id !== "string" || m.principal_id.length === 0) {
+      return undefined;
+    }
+    if (typeof m.principal_pubkey !== "string") return undefined;
+    // Grammar-gate the peer pubkey — a signed-but-malformed key is still a
+    // wire-contract violation; reject the whole roster rather than cache a
+    // poison value a downstream resolver would choke on.
+    if (!BASE64_ED25519.test(m.principal_pubkey)) return undefined;
+    // `stack_id` is optional on the roster (see NetworkRosterPeer JSDoc).
+    if (m.stack_id !== undefined && typeof m.stack_id !== "string") {
+      return undefined;
+    }
+    members.push({
+      principal_id: m.principal_id,
+      principal_pubkey: m.principal_pubkey,
+      ...(typeof m.stack_id === "string" ? { stack_id: m.stack_id } : {}),
+    });
+  }
+  return { network_id: networkId, members };
+}

--- a/src/common/registry/types.ts
+++ b/src/common/registry/types.ts
@@ -94,6 +94,82 @@ export interface RegistryPubkeyResponse {
 }
 
 /**
+ * S1 (Network Join Control Plane, #735) — the network **descriptor** payload
+ * carried by `GET /networks/{network_id}` inside a `SignedAssertion`.
+ *
+ * **DD-12 (hub via registry-served descriptor).** The hub's reachability
+ * (`hub_url` + `leaf_port`) is served by the registry, NOT pinned in each
+ * peer's local config, so the hub can relocate without every peer
+ * re-editing `cortex.yaml`. The join command (S4) and the leaf renderer
+ * (S3) derive the nats-server leaf remote from this descriptor.
+ *
+ * Like every registry GET, the descriptor is wrapped in a
+ * `SignedAssertion<NetworkDescriptor>` and verified against the pinned
+ * registry pubkey before it is trusted (DD-9).
+ *
+ * NOTE: at S1 the server-side `GET /networks/{id}` route is not yet
+ * implemented (the registry currently serves only `/roster`); the client +
+ * its stub tests land first per the epic's phasing. The shape below is the
+ * client's contract for that route and the source of truth the S3/S4 server
+ * work targets.
+ */
+export interface NetworkDescriptor {
+  /** Network id — letter-prefixed lowercase-alphanumeric + hyphen. */
+  network_id: string;
+  /**
+   * The hub's leaf-node dial URL (e.g. `tls://hub.meta-factory.ai:7422`).
+   * Where a joining stack's nats-server leaf remote points. DD-12: relocatable
+   * via the registry, never hand-pinned.
+   */
+  hub_url: string;
+  /**
+   * The hub's leaf-node listen port (e.g. 7422). Carried alongside `hub_url`
+   * so the leaf renderer can validate / reconstruct the remote independently
+   * of URL parsing.
+   */
+  leaf_port: number;
+  /**
+   * Principal ids that are members of this network. The lightweight
+   * membership view on the descriptor; the full per-peer roster (with
+   * pubkeys + stacks) comes from `GET /networks/{id}/roster`.
+   */
+  members: string[];
+}
+
+/**
+ * S1 (#735) — a single peer entry in a network roster as consumed by the
+ * cortex client. Mirrors one element of the service-side `NetworkRoster.
+ * members[]` (`src/services/network-registry/src/types.ts`), narrowed to the
+ * fields the join/resolve path needs: who the peer is (`principal_id`), which
+ * stack carries its signing identity (`stack_id`), and the verified Ed25519
+ * pubkey to anchor trust against (`principal_pubkey`, base64 raw — DD-8
+ * translates to nkey-U at the config surface).
+ *
+ * `stack_id` is OPTIONAL: the registry's roster route derives membership from
+ * announced capabilities and does not always carry a stack id per member at
+ * S1. When absent, S2's resolver falls back to the principal's first
+ * registered stack via `GET /principals/{id}`.
+ */
+export interface NetworkRosterPeer {
+  /** Peer principal id — letter-prefixed lowercase-alphanumeric + hyphen. */
+  principal_id: string;
+  /** `{principal_id}/{stack_slug}` — the peer's signing stack, when known. */
+  stack_id?: string;
+  /** Base64 Ed25519 pubkey (32 raw bytes → 44 chars w/ padding). */
+  principal_pubkey: string;
+}
+
+/**
+ * S1 (#735) — the roster payload carried by `GET /networks/{network_id}/roster`
+ * inside a `SignedAssertion<NetworkRosterResult>`. Mirrors the service-side
+ * `NetworkRoster` shape; `members[]` is narrowed to {@link NetworkRosterPeer}.
+ */
+export interface NetworkRosterResult {
+  network_id: string;
+  members: NetworkRosterPeer[];
+}
+
+/**
  * Configuration for `RegistryClient`. The required fields are the
  * registry URL and the list of peer principal ids to track; everything
  * else has a sensible default. Tests supply `fetch` + `setTimer` to

--- a/src/common/registry/verify-assertion.ts
+++ b/src/common/registry/verify-assertion.ts
@@ -1,0 +1,114 @@
+/**
+ * S1 (Network Join Control Plane, #735) — shared registry signed-assertion
+ * verification.
+ *
+ * **DD-9 (pin + verify the registry).** Every registry GET response is a
+ * `SignedAssertion<T>` = `{ payload, issued_at, registry, signature }`, where
+ * `signature` is Ed25519 over `canonicalJSON({ payload, issued_at, registry })`.
+ * A consumer MUST verify that signature against a **pinned** registry pubkey
+ * before trusting `payload` — a spoofed/compromised registry (or a path
+ * attacker) otherwise injects arbitrary hub URLs and peer pubkeys.
+ *
+ * This helper is the one place that gate lives for the S1 network-descriptor +
+ * roster client. It mirrors — and is kept in lock-step with — the inline
+ * verification already in `RegistryClient.verifyAssertion` (`./client.ts`) and
+ * `PrincipalPubkeyResolver.verifyAssertion` (`./resolve-pubkey.ts`); those two
+ * predate this extraction and were not folded in to avoid a drive-by refactor
+ * of already-reviewed hot paths (CLAUDE.md). New registry consumers (the S1
+ * client) use THIS shared helper rather than adding a third copy.
+ *
+ * The helper does the encoding-agnostic envelope work (shape gate →
+ * registry-pubkey pin check → canonical-JSON Ed25519 verify) and returns the
+ * verified `payload` as `unknown`. Payload-shape validation (descriptor vs
+ * roster) is the caller's concern — the caller knows what `T` it asked for.
+ *
+ * NEVER throws: a verification failure returns a discriminated negative so
+ * federation/registry problems can be turned into "use cache + warn" (DD-10)
+ * by the caller rather than crashing a boot path.
+ */
+
+import { canonicalJSON, verifyEd25519 } from "./signing";
+
+/**
+ * Outcome of {@link verifySignedAssertion}. Discriminated so a caller can log
+ * the precise failure class AND decide its fallback (DD-10 cache reuse) per
+ * reason.
+ *
+ * - `ok`            — signature verified against the pinned pubkey; `payload`
+ *                     is the verified (but not yet shape-validated) body.
+ * - `malformed`     — the response is not a well-formed `SignedAssertion`
+ *                     envelope (missing/typed-wrong fields).
+ * - `unconfigured`  — the assertion's `registry` field is the `"unconfigured"`
+ *                     sentinel (registry has no signing key) — never trusted.
+ * - `pubkey_mismatch` — the assertion's `registry` pubkey differs from the
+ *                     pinned one (wrong/rotated/spoofed registry).
+ * - `bad_signature` — the envelope is well-formed and the registry pubkey
+ *                     matches, but the Ed25519 signature does not verify. THE
+ *                     load-bearing DD-9 rejection.
+ */
+export type VerifyAssertionResult =
+  | { kind: "ok"; payload: unknown }
+  | { kind: "malformed"; detail: string }
+  | { kind: "unconfigured" }
+  | { kind: "pubkey_mismatch"; got: string }
+  | { kind: "bad_signature" };
+
+/**
+ * Verify a raw (untrusted, off-the-wire) value as a registry
+ * `SignedAssertion` against `pinnedPubkey`. Accepts `unknown` deliberately:
+ * the input is JSON straight off `fetch`, and the shape checks here ARE the
+ * validation — trusting a static type at the boundary would defeat DD-9.
+ *
+ * @param raw          the parsed JSON body of a registry GET
+ * @param pinnedPubkey base64 Ed25519 registry pubkey, pinned from config
+ *                     (`policy.federated.registry.pubkey`) or TOFU
+ */
+export async function verifySignedAssertion(
+  raw: unknown,
+  pinnedPubkey: string,
+): Promise<VerifyAssertionResult> {
+  // Shape gate first — cheaper than crypto and gives a precise failure class.
+  if (raw === null || typeof raw !== "object") {
+    return { kind: "malformed", detail: "assertion is not an object" };
+  }
+  const assertion = raw as Record<string, unknown>;
+  if (
+    typeof assertion.signature !== "string" ||
+    typeof assertion.issued_at !== "string" ||
+    typeof assertion.registry !== "string" ||
+    assertion.payload === null ||
+    typeof assertion.payload !== "object"
+  ) {
+    return { kind: "malformed", detail: "assertion envelope fields missing or wrong type" };
+  }
+
+  const registry = assertion.registry;
+  if (registry === "unconfigured") {
+    // The registry has no signing key — no signature path can verify a
+    // sentinel value. Refuse rather than trust an unsigned payload.
+    return { kind: "unconfigured" };
+  }
+  if (registry !== pinnedPubkey) {
+    return { kind: "pubkey_mismatch", got: registry };
+  }
+
+  // Reconstruct the canonical bound triple and verify the registry signature.
+  const bound = canonicalJSON({
+    payload: assertion.payload,
+    issued_at: assertion.issued_at,
+    registry,
+  });
+  const message = new TextEncoder().encode(bound);
+  let ok: boolean;
+  try {
+    ok = await verifyEd25519(pinnedPubkey, assertion.signature, message);
+  } catch (_err) {
+    // verifyEd25519 is documented never-throw, but a thrown error here is
+    // indistinguishable (security-wise) from a failed verify — treat as a bad
+    // signature, the fail-closed direction.
+    return { kind: "bad_signature" };
+  }
+  if (!ok) return { kind: "bad_signature" };
+
+  return { kind: "ok", payload: assertion.payload };
+}


### PR DESCRIPTION
Closes #735
Refs #733

Phase A · S1 of the **Network Join Control Plane** epic (#733). Spec: `docs/design-network-join-control-plane.md` §6 F1, decisions **DD-9 / DD-10 / DD-12** (and **DD-8** encoding).

## What this adds

Extends the existing cortex registry consumers (`RegistryClient`, `PrincipalPubkeyResolver`) with the two **network-scoped** endpoints the registry-mediated `cortex network join` path needs — client + verify + cache + encoding **only** (no resolver, no leaf renderer, no CLI; those are S2/S3/S4).

| File | Role |
|------|------|
| `src/common/registry/network-client.ts` | `NetworkRegistryClient` — `getNetworkDescriptor`, `getNetworkRoster`, `fetchAndCache`, `loadCached` |
| `src/common/registry/verify-assertion.ts` | Shared `verifySignedAssertion` — the one DD-9 pin+verify gate (reuses `canonicalJSON` + `verifyEd25519`) |
| `src/common/registry/network-cache.ts` | `NetworkCache` — per-network disk cache (DD-10) |
| `src/common/registry/encoding.ts` | `base64PubkeyToNkey` (new encode dir) + re-export `nkeyToBase64Pubkey` (DD-8) |
| `src/common/registry/types.ts` | `NetworkDescriptor`, `NetworkRosterResult`, `NetworkRosterPeer` |

## Design-decision specifics

- **DD-12** — `getNetworkDescriptor(id)` resolves `GET /networks/:id` → typed `NetworkDescriptor` (`hub_url` / `leaf_port` / `members`). Hub is registry-served, relocatable, never hand-pinned.
- **DD-9** — every response is a `SignedAssertion` verified against a **pinned** registry pubkey (`policy.federated.registry.pubkey`, or TOFU). A bad signature / wrong-registry-key / malformed envelope returns `{ status: "unverified", reason }` — the payload is **never returned and never cached**. Crypto reused, not hand-rolled.
- **DD-10** — `fetchAndCache()` writes a verified descriptor+roster pair to `~/.config/cortex/network-cache/<network>.json` **only after both halves verify**; `loadCached()` exposes last-known-good for S2's registry-down fallback. A half-pair or unverified response never writes.
- **DD-8** — `base64PubkeyToNkey()` adds the registry-base64 → config-nkey-U direction via `@nats-io/nkeys` `Codec`, round-tripping the existing decode helper.

## Tests (`bun test`, stub registry, no network I/O)

26 new tests: valid descriptor + roster parse · **bad-signature → rejected (DD-9)** · registry-pubkey mismatch · 404 → `not_found` · transport error → `unreachable` · cache write-after-verify + cross-instance `loadCached` (DD-10) · **no-cache-on-unverified** · TOFU pin · base64↔nkey-U round-trip · corrupt/wrong-network/bad-version cache rejection.

## Verify

- `bunx tsc --noEmit` — **0 errors**
- `bun test` — full suite **4447 pass / 0 fail** (2 pre-existing skips); registry dir **73 pass**
- `eslint` (new files) — clean
- vocab carve-out gate (`scripts/check-carveouts.sh`) — PASS

## Deviations from the brief (with rationale)

1. **`registry.pubkey` config field already exists.** `PolicyFederatedRegistrySchema.pubkey` (base64 Ed25519, `~/Developer/cortex` `src/common/types/cortex-config.ts`) was already present from D.4.3 and already serves DD-9 — no schema change was needed. The new client reads it via the same `pubkey` construction option the existing `RegistryClient` uses.
2. **Server-side `GET /networks/:id` descriptor route does not exist yet** (the registry currently serves only `/roster`). Per S1 scope (client + tests only), the client is built against the documented DD-12 contract and exercised with a stub registry; the real route lands with S3/S4. Called out inline in `types.ts` and the PR.
3. **New shared `verifySignedAssertion` helper** rather than reusing the inline copies in `client.ts` / `resolve-pubkey.ts` — those predate it and were left untouched to avoid a drive-by refactor of reviewed hot paths (CLAUDE.md). New consumers use the shared helper; consolidating the older two is a tracked follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)