### PR TITLE
feat(cli): S4 — cortex network join/leave/status (one-command join)

### DIFF
--- a/src/cli/cortex/commands/__tests__/network-adapters.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-adapters.test.ts
@@ -1,0 +1,134 @@
+/**
+ * S4 (#738) — `network-adapters.ts` live plist-writer tests.
+ *
+ * Pins the MAJOR review fix: the live plist writer renders its
+ * `<key>ProgramArguments</key>` block via S3's canonical
+ * `renderProgramArguments` (`src/common/nats/nats-plist-loader.ts`), the single
+ * source of truth — NOT a bespoke copy. These tests write a real temp plist and
+ * assert the spliced block is byte-identical to what S3 emits, so the two
+ * render paths can never drift again.
+ *
+ * Scope: the plist port only (a temp plist file). No registry / daemon / leaf
+ * I/O — `ensureConfigLoaded` / `dropConfigArg` are exercised directly off the
+ * live ports bundle.
+ */
+
+import { describe, test, expect, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync, readFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+import { buildLivePorts, type LivePortsConfig } from "../network-adapters";
+import {
+  ensureConfigArg,
+  renderProgramArguments,
+} from "../../../../common/nats/nats-plist-loader";
+
+const tmpDirs: string[] = [];
+function freshDir(): string {
+  const d = mkdtempSync(join(tmpdir(), "s4-adapters-"));
+  tmpDirs.push(d);
+  return d;
+}
+afterEach(() => {
+  while (tmpDirs.length > 0) rmSync(tmpDirs.pop()!, { recursive: true, force: true });
+});
+
+const NATS_CONFIG = "/Users/andreas/.config/nats/local.conf";
+
+/** A minimal nats-server plist running bare `nats-server -js` (the bring-up trap). */
+function barePlist(): string {
+  return [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">',
+    '<plist version="1.0">',
+    "<dict>",
+    "\t<key>Label</key>",
+    "\t<string>homebrew.mxcl.nats-server</string>",
+    "\t<key>ProgramArguments</key>",
+    "\t<array>",
+    "\t\t<string>/opt/homebrew/bin/nats-server</string>",
+    "\t\t<string>-js</string>",
+    "\t</array>",
+    "\t<key>RunAtLoad</key>",
+    "\t<true/>",
+    "</dict>",
+    "</plist>",
+    "",
+  ].join("\n");
+}
+
+function cfgFor(plistPath: string): LivePortsConfig {
+  return {
+    networkId: "metafactory",
+    principalId: "andreas",
+    stackId: "andreas/meta-factory",
+    natsConfigPath: NATS_CONFIG,
+    plistPath,
+  };
+}
+
+describe("live plist writer uses S3's canonical renderProgramArguments", () => {
+  test("ensureConfigLoaded splices the EXACT block S3 renders (no drift)", () => {
+    const dir = freshDir();
+    const plistPath = join(dir, "nats-server.plist");
+    writeFileSync(plistPath, barePlist(), "utf-8");
+
+    const ports = buildLivePorts(cfgFor(plistPath));
+    ports.plist.ensureConfigLoaded(NATS_CONFIG);
+
+    const after = readFileSync(plistPath, "utf-8");
+
+    // The canonical expectation: bare args + `-c <config>` appended, rendered
+    // by S3's renderProgramArguments — the SINGLE source of truth.
+    const expectedArgs = ensureConfigArg(
+      ["/opt/homebrew/bin/nats-server", "-js"],
+      NATS_CONFIG,
+    );
+    const expectedBlock = renderProgramArguments(expectedArgs);
+
+    expect(after).toContain(expectedBlock);
+    // The -c flag + path are present; the rest of the plist is intact.
+    expect(after).toContain("<string>-c</string>");
+    expect(after).toContain(`<string>${NATS_CONFIG}</string>`);
+    expect(after).toContain("<key>RunAtLoad</key>");
+    expect(after).toContain("homebrew.mxcl.nats-server");
+  });
+
+  test("ensureConfigLoaded is idempotent — already-correct plist is a no-op", () => {
+    const dir = freshDir();
+    const plistPath = join(dir, "nats-server.plist");
+    writeFileSync(plistPath, barePlist(), "utf-8");
+    const ports = buildLivePorts(cfgFor(plistPath));
+
+    ports.plist.ensureConfigLoaded(NATS_CONFIG);
+    const first = readFileSync(plistPath, "utf-8");
+    ports.plist.ensureConfigLoaded(NATS_CONFIG);
+    const second = readFileSync(plistPath, "utf-8");
+
+    expect(second).toBe(first);
+  });
+
+  test("dropConfigArg removes the -c flag via the canonical renderer", () => {
+    const dir = freshDir();
+    const plistPath = join(dir, "nats-server.plist");
+    // Start from a plist that already loads the config.
+    const loaded = barePlist().replace(
+      "\t\t<string>-js</string>\n\t</array>",
+      `\t\t<string>-js</string>\n\t\t<string>-c</string>\n\t\t<string>${NATS_CONFIG}</string>\n\t</array>`,
+    );
+    writeFileSync(plistPath, loaded, "utf-8");
+
+    const ports = buildLivePorts(cfgFor(plistPath));
+    ports.plist.dropConfigArg(NATS_CONFIG);
+
+    const after = readFileSync(plistPath, "utf-8");
+    const expectedBlock = renderProgramArguments([
+      "/opt/homebrew/bin/nats-server",
+      "-js",
+    ]);
+    expect(after).toContain(expectedBlock);
+    expect(after).not.toContain("<string>-c</string>");
+    expect(after).not.toContain(`<string>${NATS_CONFIG}</string>`);
+  });
+});

--- a/src/cli/cortex/commands/__tests__/network-cli.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-cli.test.ts
@@ -1,0 +1,230 @@
+/**
+ * S4 (#738) — `cortex network` CLI dispatcher tests.
+ *
+ * Covers the command surface: parsing, usage errors, help, dry-run SAFETY (the
+ * default — no disk/daemon mutation), apply/dry-run exclusivity, and status
+ * rendering against a real (temp) stack config file. The deep join/leave/status
+ * FLOW logic is covered by `network-lib.test.ts` with fake ports; here we
+ * exercise the wiring + the real adapters' read/no-op-write behaviour.
+ *
+ * No live mutation: every test points the adapters at a fresh tmp dir and
+ * asserts that a dry-run writes NOTHING.
+ */
+
+import { describe, test, expect, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, existsSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+import { dispatchNetwork } from "../network";
+
+const tmpDirs: string[] = [];
+function freshDir(): string {
+  const d = mkdtempSync(join(tmpdir(), "s4-network-cli-"));
+  tmpDirs.push(d);
+  return d;
+}
+afterEach(() => {
+  while (tmpDirs.length > 0) rmSync(tmpDirs.pop()!, { recursive: true, force: true });
+});
+
+// =============================================================================
+// dispatch / usage / help
+// =============================================================================
+
+describe("dispatch", () => {
+  test("no subcommand → exit 2 with usage", async () => {
+    const res = await dispatchNetwork([]);
+    expect(res.exitCode).toBe(2);
+    expect(res.stderr).toContain("no subcommand specified");
+  });
+
+  test("unknown subcommand → exit 2", async () => {
+    const res = await dispatchNetwork(["frobnicate"]);
+    expect(res.exitCode).toBe(2);
+    expect(res.stderr).toContain('unknown subcommand "frobnicate"');
+  });
+
+  test("--help → exit 0 with usage", async () => {
+    const res = await dispatchNetwork(["--help"]);
+    expect(res.exitCode).toBe(0);
+    expect(res.stdout).toContain("cortex network");
+    expect(res.stdout).toContain("join");
+    expect(res.stdout).toContain("leave");
+    expect(res.stdout).toContain("status");
+  });
+});
+
+// =============================================================================
+// join — usage validation
+// =============================================================================
+
+describe("join usage", () => {
+  test("rejects a bad network id (exit 2)", async () => {
+    const res = await dispatchNetwork(["join", "BAD_CAPS", "--principal", "andreas"]);
+    expect(res.exitCode).toBe(2);
+    expect(res.stderr).toContain("must be lowercase");
+  });
+
+  test("requires --principal (exit 2)", async () => {
+    const res = await dispatchNetwork(["join", "metafactory"]);
+    expect(res.exitCode).toBe(2);
+    expect(res.stderr).toContain("--principal is required");
+  });
+
+  test("requires the live-config flags (exit 2)", async () => {
+    const res = await dispatchNetwork(["join", "metafactory", "--principal", "andreas"]);
+    expect(res.exitCode).toBe(2);
+    // First missing required flag surfaces.
+    expect(res.stderr).toMatch(/--registry-url is required/);
+  });
+
+  test("--apply and --dry-run are mutually exclusive (exit 2)", async () => {
+    const dir = freshDir();
+    const res = await dispatchNetwork([
+      "join", "metafactory",
+      "--principal", "andreas",
+      "--registry-url", "http://r.test",
+      "--seed-path", join(dir, "seed.nk"),
+      "--creds", join(dir, "x.creds"),
+      "--account", "A" + "B".repeat(55),
+      "--nats-config", join(dir, "local.conf"),
+      "--plist", join(dir, "nats.plist"),
+      "--apply", "--dry-run",
+    ]);
+    expect(res.exitCode).toBe(2);
+    expect(res.stderr).toContain("mutually exclusive");
+  });
+
+  test("rejects --stack whose prefix mismatches --principal (exit 2)", async () => {
+    const res = await dispatchNetwork([
+      "join", "metafactory",
+      "--principal", "andreas",
+      "--stack", "someoneelse/research",
+      "--registry-url", "http://r.test",
+      "--seed-path", "/tmp/x",
+      "--creds", "/tmp/x.creds",
+      "--account", "A" + "B".repeat(55),
+      "--nats-config", "/tmp/local.conf",
+      "--plist", "/tmp/nats.plist",
+    ]);
+    expect(res.exitCode).toBe(2);
+    expect(res.stderr).toContain("prefix matching");
+  });
+});
+
+// =============================================================================
+// join — dry-run SAFETY (the default): no disk mutation
+// =============================================================================
+
+describe("join dry-run safety", () => {
+  test("dry-run join does NOT write the leaf file, plist, or config (no --apply)", async () => {
+    const dir = freshDir();
+    const seedPath = join(dir, "seed.nk");
+    // A real-ish seed is not needed: dry-run register fails gracefully but we
+    // assert NO files are written regardless. Use a non-existent registry so
+    // there is no network I/O hang.
+    const natsConfig = join(dir, "nats", "local.conf");
+    const plist = join(dir, "nats.plist");
+
+    const res = await dispatchNetwork([
+      "join", "metafactory",
+      "--principal", "andreas",
+      "--registry-url", "http://127.0.0.1:0", // unreachable by construction
+      "--seed-path", seedPath,
+      "--creds", join(dir, "andreas.creds"),
+      "--account", "A" + "B".repeat(55),
+      "--nats-config", natsConfig,
+      "--plist", plist,
+    ]);
+
+    // The join FAILS (no seed / unreachable registry) — but the critical S4
+    // SAFETY assertion is that NOTHING was written to disk on a dry-run.
+    expect(existsSync(natsConfig)).toBe(false);
+    expect(existsSync(join(dir, "nats"))).toBe(false);
+    expect(existsSync(plist)).toBe(false);
+    // It reports a failure (register failed), exit 1.
+    expect(res.exitCode).toBe(1);
+  });
+
+  test("dry-run banner is present in human output", async () => {
+    const dir = freshDir();
+    const res = await dispatchNetwork([
+      "join", "metafactory",
+      "--principal", "andreas",
+      "--registry-url", "http://127.0.0.1:0",
+      "--seed-path", join(dir, "seed.nk"),
+      "--creds", join(dir, "andreas.creds"),
+      "--account", "A" + "B".repeat(55),
+      "--nats-config", join(dir, "local.conf"),
+      "--plist", join(dir, "nats.plist"),
+    ]);
+    // Failure output goes to stderr; it still carries the dry-run banner.
+    expect(res.stderr).toContain("dry-run");
+  });
+});
+
+// =============================================================================
+// status — renders against a real (temp) stack config
+// =============================================================================
+
+describe("status", () => {
+  test("requires --principal (exit 2)", async () => {
+    const res = await dispatchNetwork(["status"]);
+    expect(res.exitCode).toBe(2);
+    expect(res.stderr).toContain("--principal is required");
+  });
+
+  test("reports 'no networks joined' when the stack config is absent", async () => {
+    // Point at a principal whose stacks/<slug>.yaml does not exist under the
+    // home config dir. Using a unique slug guarantees absence.
+    const uniqueSlug = `s4test${Date.now().toString()}`;
+    const res = await dispatchNetwork([
+      "status",
+      "--principal", "andreas",
+      "--stack", `andreas/${uniqueSlug}`,
+    ]);
+    expect(res.exitCode).toBe(0);
+    expect(res.stdout).toContain("no networks joined");
+  });
+
+  test("--json emits an envelope", async () => {
+    const uniqueSlug = `s4test${Date.now().toString()}j`;
+    const res = await dispatchNetwork([
+      "status",
+      "--principal", "andreas",
+      "--stack", `andreas/${uniqueSlug}`,
+      "--json",
+    ]);
+    expect(res.exitCode).toBe(0);
+    const env = JSON.parse(res.stdout) as { status: string; items: unknown[] };
+    expect(env.status).toBe("ok");
+    expect(Array.isArray(env.items)).toBe(true);
+  });
+});
+
+// =============================================================================
+// leave — usage + idempotent no-op
+// =============================================================================
+
+describe("leave usage", () => {
+  test("requires --principal (exit 2)", async () => {
+    const res = await dispatchNetwork(["leave", "metafactory"]);
+    expect(res.exitCode).toBe(2);
+    expect(res.stderr).toContain("--principal is required");
+  });
+
+  test("leaving an un-joined network is a clean no-op (exit 0)", async () => {
+    const dir = freshDir();
+    const uniqueSlug = `s4leave${Date.now().toString()}`;
+    const res = await dispatchNetwork([
+      "leave", "metafactory",
+      "--principal", "andreas",
+      "--stack", `andreas/${uniqueSlug}`,
+      "--nats-config", join(dir, "local.conf"),
+      "--plist", join(dir, "nats.plist"),
+    ]);
+    expect(res.exitCode).toBe(0);
+    expect(res.stdout).toContain("not joined");
+  });
+});

--- a/src/cli/cortex/commands/__tests__/network-lib.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-lib.test.ts
@@ -1,0 +1,485 @@
+/**
+ * S4 (Network Join Control Plane, #738) — join/leave/status orchestration tests.
+ *
+ * Every I/O is a FAKE port (no real fs / exec / registry / launchctl — the S4
+ * SAFETY rule). Coverage maps to the brief's TESTS list:
+ *
+ *   - join writes the expected leaf include + plist arg + config block + calls
+ *     restart; idempotent on re-run (no dup network).
+ *   - only a VERIFIED descriptor reaches the renderer (a bad-signature
+ *     descriptor aborts join — DD-9 + the branded-type boundary).
+ *   - registry-down → uses cached + warns, join still configures (DD-10).
+ *   - peers resolved by principal_id (DD-5); the local principal is never in
+ *     its own peers[].
+ *   - leave reverses exactly + is idempotent.
+ *   - status renders joined networks + peers + link state.
+ *   - wire contract: accept_subjects = the stack's OWN federated.{me}.{stack}.>
+ *     (no network id on the wire).
+ */
+
+import { describe, test, expect } from "bun:test";
+
+import {
+  joinNetwork,
+  leaveNetwork,
+  networkStatus,
+  type JoiningStack,
+} from "../network-lib";
+import type {
+  ConfigStorePort,
+  DaemonPort,
+  LeafFilePort,
+  LeafStatePort,
+  NetworkPorts,
+  NetworkRegistryPort,
+  PlistPort,
+  RenderLeafInputs,
+} from "../network-ports";
+import type {
+  NetworkDescriptor,
+  NetworkRosterResult,
+} from "../../../../common/registry/types";
+import type { NetworkFetchResult } from "../../../../common/registry/network-client";
+import type { PolicyFederatedNetwork } from "../../../../common/types/cortex-config";
+import { renderLeafIncludeFile } from "../../../../common/nats/leaf-remote-renderer";
+import { nkeyToBase64Pubkey } from "../../../../common/registry/encoding";
+
+// =============================================================================
+// Fixtures
+// =============================================================================
+
+// A valid base64 ed25519 pubkey (44 chars w/ padding) that re-encodes to a
+// valid nkey-U via the encoding module — so the join's nkey re-encode produces
+// a deterministic peer pubkey we can round-trip-assert.
+function validPeerBase64(): string {
+  // A 32-byte all-0x01 key, base64-encoded — valid base64 ed25519 grammar.
+  const raw = new Uint8Array(32).fill(1);
+  let bin = "";
+  for (const b of raw) bin += String.fromCharCode(b);
+  return btoa(bin);
+}
+
+const PEER_B64 = validPeerBase64();
+
+const LOCAL: JoiningStack = {
+  principalId: "andreas",
+  stackSlug: "meta-factory",
+  credentials: "/Users/andreas/.config/nats/andreas.creds",
+  account: "A" + "B".repeat(55), // valid nkey-U account grammar (A + 55 base32)
+};
+
+function descriptorFor(networkId: string): NetworkDescriptor {
+  return {
+    network_id: networkId,
+    hub_url: "tls://hub.meta-factory.ai:7422",
+    leaf_port: 7422,
+    members: ["andreas", "jc"],
+  };
+}
+
+function rosterFor(networkId: string): NetworkRosterResult {
+  return {
+    network_id: networkId,
+    members: [
+      // The local principal — must be EXCLUDED from peers[].
+      { principal_id: "andreas", principal_pubkey: PEER_B64, stack_id: "andreas/meta-factory" },
+      // A real peer.
+      { principal_id: "jc", principal_pubkey: PEER_B64, stack_id: "jc/sage-host" },
+    ],
+  };
+}
+
+// =============================================================================
+// Fake ports
+// =============================================================================
+
+interface Recorder {
+  registered: number;
+  restarts: number;
+  writes: RenderLeafInputs[];
+  removes: string[];
+  ensured: string[];
+  dropped: string[];
+  configWrites: PolicyFederatedNetwork[][];
+  warnings: string[];
+}
+
+function makeFakes(opts: {
+  fetch?: NetworkFetchResult<{ descriptor: NetworkDescriptor; roster: NetworkRosterResult }>;
+  cached?: { descriptor: NetworkDescriptor; roster: NetworkRosterResult };
+  registerOk?: boolean;
+  restartOk?: boolean;
+  initialNetworks?: PolicyFederatedNetwork[];
+  leafState?: LeafStatePort;
+}): { ports: NetworkPorts; rec: Recorder; storeRef: { networks: PolicyFederatedNetwork[] } } {
+  const rec: Recorder = {
+    registered: 0,
+    restarts: 0,
+    writes: [],
+    removes: [],
+    ensured: [],
+    dropped: [],
+    configWrites: [],
+    warnings: [],
+  };
+  const storeRef = { networks: opts.initialNetworks ?? [] };
+  const leafFilesPresent = new Set<string>(
+    (opts.initialNetworks ?? []).map((n) => n.id),
+  );
+
+  const registry: NetworkRegistryPort = {
+    async registerStack() {
+      rec.registered++;
+      return opts.registerOk === false
+        ? { ok: false, reason: "registry rejected" }
+        : { ok: true, note: "HTTP 201" };
+    },
+    async fetchVerified(_id) {
+      return (
+        opts.fetch ?? {
+          status: "ok",
+          value: { descriptor: descriptorFor(_id), roster: rosterFor(_id) },
+        }
+      );
+    },
+    loadCached(_id) {
+      return opts.cached;
+    },
+  };
+
+  const leafFile: LeafFilePort = {
+    write(inputs) {
+      rec.writes.push(inputs);
+      leafFilesPresent.add(inputs.descriptor.network_id);
+    },
+    remove(networkId) {
+      rec.removes.push(networkId);
+      leafFilesPresent.delete(networkId);
+    },
+    list() {
+      return [...leafFilesPresent];
+    },
+    natsConfigPath() {
+      return "/Users/andreas/.config/nats/local.conf";
+    },
+  };
+
+  const plist: PlistPort = {
+    ensureConfigLoaded(p) {
+      rec.ensured.push(p);
+    },
+    dropConfigArg(p) {
+      rec.dropped.push(p);
+    },
+  };
+
+  const configStore: ConfigStorePort = {
+    readNetworks() {
+      return storeRef.networks;
+    },
+    writeNetworks(networks) {
+      storeRef.networks = networks;
+      rec.configWrites.push(networks);
+    },
+  };
+
+  const daemon: DaemonPort = {
+    async restart() {
+      rec.restarts++;
+      return opts.restartOk === false
+        ? { ok: false, reason: "launchctl kickstart failed" }
+        : { ok: true };
+    },
+  };
+
+  return {
+    ports: { registry, leafFile, plist, configStore, daemon, leafState: opts.leafState },
+    rec,
+    storeRef,
+  };
+}
+
+// =============================================================================
+// join
+// =============================================================================
+
+describe("join", () => {
+  test("writes leaf include + plist arg + config block + restarts (DD-4)", async () => {
+    const { ports, rec, storeRef } = makeFakes({});
+    const res = await joinNetwork("metafactory", LOCAL, ports);
+
+    expect(res.ok).toBe(true);
+    // (a) registered exactly once.
+    expect(rec.registered).toBe(1);
+    // (c) leaf include written for the network, from a VERIFIED descriptor.
+    expect(rec.writes.length).toBe(1);
+    expect(rec.writes[0]!.descriptor.network_id).toBe("metafactory");
+    // The S3 renderer accepts the branded descriptor + binding without throwing.
+    const rendered = renderLeafIncludeFile(
+      rec.writes[0]!.descriptor,
+      rec.writes[0]!.binding,
+    );
+    expect(rendered).toContain("leafnodes {");
+    expect(rendered).toContain("tls://hub.meta-factory.ai:7422");
+    // (c) plist ensured to load the nats config.
+    expect(rec.ensured).toEqual(["/Users/andreas/.config/nats/local.conf"]);
+    // (d) config block written.
+    expect(storeRef.networks.length).toBe(1);
+    const net = storeRef.networks[0]!;
+    expect(net.id).toBe("metafactory");
+    // (e) restarted.
+    expect(rec.restarts).toBe(1);
+  });
+
+  test("accept_subjects is the stack's OWN federated.{me}.{stack}.> (wire contract)", async () => {
+    const { ports, storeRef } = makeFakes({});
+    await joinNetwork("metafactory", LOCAL, ports);
+    const net = storeRef.networks[0]!;
+    // The wire contract: own principal/stack segment, NOT the network id.
+    expect(net.accept_subjects).toEqual(["federated.andreas.meta-factory.>"]);
+    // Network id must NOT appear in any accept subject (no network on the wire).
+    expect(net.accept_subjects.some((s) => s.includes("metafactory"))).toBe(false);
+  });
+
+  test("peers resolved by principal_id, local principal excluded (DD-5)", async () => {
+    const { ports, storeRef } = makeFakes({});
+    const res = await joinNetwork("metafactory", LOCAL, ports);
+    const net = storeRef.networks[0]!;
+    // Only the peer "jc" — the local "andreas" is never in its own peers[].
+    expect(net.peers.map((p) => p.principal_id)).toEqual(["jc"]);
+    expect(res.resolvedPeers).toEqual(["jc"]);
+    // The peer declares principal_id + stack_id; pubkey resolved to nkey-U.
+    const peer = net.peers[0]!;
+    expect(peer.stack_id).toBe("jc/sage-host");
+    expect(peer.principal_pubkey).toBeDefined();
+    // The resolved nkey re-encodes back to the roster's base64 (DD-8 round-trip).
+    expect(nkeyToBase64Pubkey(peer.principal_pubkey!)).toBe(PEER_B64);
+  });
+
+  test("idempotent — re-running replaces, does not duplicate the network", async () => {
+    const { ports, storeRef, rec } = makeFakes({});
+    await joinNetwork("metafactory", LOCAL, ports);
+    await joinNetwork("metafactory", LOCAL, ports);
+    // Still exactly one network entry.
+    expect(storeRef.networks.length).toBe(1);
+    // Both runs wrote the leaf + restarted (converge), no dup network.
+    expect(rec.writes.length).toBe(2);
+    expect(rec.restarts).toBe(2);
+  });
+
+  test("a second distinct network accumulates (multi-network, OQ3)", async () => {
+    const { ports, storeRef } = makeFakes({});
+    await joinNetwork("metafactory", LOCAL, ports);
+    await joinNetwork("research", LOCAL, ports);
+    expect(storeRef.networks.map((n) => n.id).sort()).toEqual([
+      "metafactory",
+      "research",
+    ]);
+  });
+
+  test("writes a conscious max_hop (schema has no default)", async () => {
+    const { ports, storeRef } = makeFakes({});
+    await joinNetwork("metafactory", LOCAL, ports);
+    expect(storeRef.networks[0]!.max_hop).toBe(1);
+  });
+});
+
+// =============================================================================
+// DD-9 trust boundary — only a verified descriptor reaches the renderer
+// =============================================================================
+
+describe("DD-9 trust boundary", () => {
+  test("a bad-signature descriptor aborts join — renderer never called", async () => {
+    const { ports, rec, storeRef } = makeFakes({
+      fetch: { status: "unverified", reason: "bad_signature" },
+    });
+    const res = await joinNetwork("metafactory", LOCAL, ports);
+
+    expect(res.ok).toBe(false);
+    expect(res.reason).toContain("verification");
+    // The leaf renderer was NEVER called with an unverified descriptor.
+    expect(rec.writes.length).toBe(0);
+    // No config written, no plist touched, no restart.
+    expect(storeRef.networks.length).toBe(0);
+    expect(rec.ensured.length).toBe(0);
+    expect(rec.restarts).toBe(0);
+  });
+
+  test("not_found aborts join cleanly", async () => {
+    const { ports, rec } = makeFakes({ fetch: { status: "not_found" } });
+    const res = await joinNetwork("ghost", LOCAL, ports);
+    expect(res.ok).toBe(false);
+    expect(res.reason).toContain("not found");
+    expect(rec.writes.length).toBe(0);
+  });
+});
+
+// =============================================================================
+// DD-10 — registry-down → cached + warn, join still configures
+// =============================================================================
+
+describe("DD-10 cached fallback", () => {
+  test("registry unreachable → uses cached descriptor, join still configures", async () => {
+    const { ports, rec, storeRef } = makeFakes({
+      fetch: { status: "unreachable", reason: "timeout" },
+      cached: { descriptor: descriptorFor("metafactory"), roster: rosterFor("metafactory") },
+    });
+    const res = await joinNetwork("metafactory", LOCAL, ports);
+
+    expect(res.ok).toBe(true);
+    expect(res.usedCache).toBe(true);
+    // The step log carries the DD-10 warning.
+    expect(res.steps.some((s) => s.includes("DD-10"))).toBe(true);
+    // Join still configured everything.
+    expect(rec.writes.length).toBe(1);
+    expect(storeRef.networks.length).toBe(1);
+    expect(rec.restarts).toBe(1);
+  });
+
+  test("registry unreachable AND no cache → join fails (cannot render unverified)", async () => {
+    const { ports, rec } = makeFakes({
+      fetch: { status: "unreachable", reason: "timeout" },
+      cached: undefined,
+    });
+    const res = await joinNetwork("metafactory", LOCAL, ports);
+    expect(res.ok).toBe(false);
+    expect(res.reason).toContain("no cached descriptor");
+    expect(rec.writes.length).toBe(0);
+  });
+});
+
+// =============================================================================
+// failure surfacing
+// =============================================================================
+
+describe("join failure surfacing", () => {
+  test("register failure aborts before any mutation", async () => {
+    const { ports, rec } = makeFakes({ registerOk: false });
+    const res = await joinNetwork("metafactory", LOCAL, ports);
+    expect(res.ok).toBe(false);
+    expect(res.reason).toContain("register failed");
+    expect(rec.writes.length).toBe(0);
+    expect(rec.restarts).toBe(0);
+  });
+
+  test("restart failure → config is written but result is not ok", async () => {
+    const { ports, storeRef } = makeFakes({ restartOk: false });
+    const res = await joinNetwork("metafactory", LOCAL, ports);
+    expect(res.ok).toBe(false);
+    expect(res.reason).toContain("restart failed");
+    // Config WAS written (the restart is the last step) — surfaced to the user.
+    expect(storeRef.networks.length).toBe(1);
+  });
+});
+
+// =============================================================================
+// leave
+// =============================================================================
+
+describe("leave", () => {
+  function joinedNetwork(id: string): PolicyFederatedNetwork {
+    return {
+      id,
+      leaf_node: id,
+      peers: [{ principal_id: "jc", stack_id: "jc/sage-host" }],
+      accept_subjects: ["federated.andreas.meta-factory.>"],
+      deny_subjects: [],
+      announce_capabilities: [],
+      max_hop: 1,
+    };
+  }
+
+  test("reverses exactly: removes config + leaf, drops plist arg, restarts", async () => {
+    const { ports, rec, storeRef } = makeFakes({
+      initialNetworks: [joinedNetwork("metafactory")],
+    });
+    const res = await leaveNetwork("metafactory", ports);
+
+    expect(res.ok).toBe(true);
+    // Config entry removed.
+    expect(storeRef.networks.length).toBe(0);
+    // Leaf include deleted.
+    expect(rec.removes).toEqual(["metafactory"]);
+    // No networks remain → plist -c dropped.
+    expect(rec.dropped).toEqual(["/Users/andreas/.config/nats/local.conf"]);
+    // Restarted.
+    expect(rec.restarts).toBe(1);
+  });
+
+  test("keeps the plist arg when other networks remain", async () => {
+    const { ports, rec, storeRef } = makeFakes({
+      initialNetworks: [joinedNetwork("metafactory"), joinedNetwork("research")],
+    });
+    const res = await leaveNetwork("metafactory", ports);
+    expect(res.ok).toBe(true);
+    expect(storeRef.networks.map((n) => n.id)).toEqual(["research"]);
+    expect(rec.removes).toEqual(["metafactory"]);
+    // research still has a leaf → plist arg NOT dropped.
+    expect(rec.dropped.length).toBe(0);
+  });
+
+  test("idempotent — leaving a network never joined is a clean no-op", async () => {
+    const { ports, rec, storeRef } = makeFakes({ initialNetworks: [] });
+    const res = await leaveNetwork("metafactory", ports);
+    expect(res.ok).toBe(true);
+    expect(res.notJoined).toBe(true);
+    expect(rec.removes.length).toBe(0);
+    expect(rec.restarts).toBe(0);
+    expect(storeRef.networks.length).toBe(0);
+  });
+});
+
+// =============================================================================
+// status
+// =============================================================================
+
+describe("status", () => {
+  function joinedNetwork(id: string): PolicyFederatedNetwork {
+    return {
+      id,
+      leaf_node: id,
+      peers: [{ principal_id: "jc", stack_id: "jc/sage-host" }],
+      accept_subjects: [`federated.andreas.meta-factory.>`],
+      deny_subjects: [],
+      announce_capabilities: [],
+      max_hop: 1,
+    };
+  }
+
+  test("renders joined networks + peers + accept subjects + link state", async () => {
+    const leafState: LeafStatePort = {
+      async linkStates() {
+        return {
+          metafactory: { state: "established", inMsgs: 42, outMsgs: 7 },
+        };
+      },
+    };
+    const { ports } = makeFakes({
+      initialNetworks: [joinedNetwork("metafactory")],
+      leafState,
+    });
+    const res = await networkStatus(ports);
+
+    expect(res.ok).toBe(true);
+    expect(res.networks.length).toBe(1);
+    const row = res.networks[0]!;
+    expect(row.networkId).toBe("metafactory");
+    expect(row.peers).toEqual(["jc"]);
+    expect(row.acceptSubjects).toEqual(["federated.andreas.meta-factory.>"]);
+    expect(row.link.state).toBe("established");
+    expect(row.link.inMsgs).toBe(42);
+  });
+
+  test("link state is 'unknown' when no leaf-state provider is wired", async () => {
+    const { ports } = makeFakes({ initialNetworks: [joinedNetwork("metafactory")] });
+    const res = await networkStatus(ports);
+    expect(res.networks[0]!.link.state).toBe("unknown");
+  });
+
+  test("empty when no networks are joined", async () => {
+    const { ports } = makeFakes({ initialNetworks: [] });
+    const res = await networkStatus(ports);
+    expect(res.ok).toBe(true);
+    expect(res.networks.length).toBe(0);
+  });
+});

--- a/src/cli/cortex/commands/network-adapters.ts
+++ b/src/cli/cortex/commands/network-adapters.ts
@@ -1,0 +1,361 @@
+/**
+ * S4 (#738) — the REAL + DRY-RUN port adapters for `cortex network`.
+ *
+ * The orchestration (`network-lib.ts`) is pure over {@link NetworkPorts}. This
+ * module builds the two concrete bundles:
+ *
+ *   - {@link buildLivePorts}   — mutates the live deployment (leaf include file,
+ *     nats-server plist, the stack's federation config, launchctl). Used only
+ *     on `--apply`.
+ *   - {@link buildDryRunPorts} — the DEFAULT-safe bundle: every effect is a
+ *     no-op that the orchestrator's step log captures, so an accidental run
+ *     during development touches nothing (the S4 SAFETY rule). Reads still hit
+ *     disk (a dry-run join needs to know the current config to show the diff),
+ *     but no write/exec/restart happens.
+ *
+ * Wiring of the S1–S3 pieces:
+ *   - S1 `NetworkRegistryClient` (pin+verify, DD-9) + `registerStackIdentity`
+ *     (proof-of-possession, reused from provision-stack) → {@link NetworkRegistryPort}.
+ *   - S3 `renderLeafIncludeFile` + `leafIncludeFileName` → {@link LeafFilePort}.
+ *   - S3 `ensureConfigArg` + `renderProgramArguments` → {@link PlistPort}.
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "fs";
+import { dirname, join } from "path";
+
+import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
+
+import { expandTilde } from "../../../common/config/loader";
+import {
+  leafIncludeFileName,
+  renderLeafIncludeFile,
+} from "../../../common/nats/leaf-remote-renderer";
+import {
+  ensureConfigArg,
+  plistConfigArgPresent,
+} from "../../../common/nats/nats-plist-loader";
+import { NetworkRegistryClient } from "../../../common/registry/network-client";
+import {
+  buildRegistrationClaim,
+  materialFromSeedString,
+  registerStackIdentity,
+} from "../../../bus/stack-provisioning";
+import type { PolicyFederatedNetwork } from "../../../common/types/cortex-config";
+
+import type {
+  ConfigStorePort,
+  DaemonPort,
+  LeafFilePort,
+  LeafStatePort,
+  NetworkPorts,
+  NetworkRegistryPort,
+  PlistPort,
+  RenderLeafInputs,
+} from "./network-ports";
+
+/** Everything the live adapters need, threaded from the CLI flags. */
+export interface LivePortsConfig {
+  networkId: string;
+  principalId: string;
+  stackId: string;
+  registryUrl?: string;
+  registryPubkey?: string;
+  seedPath?: string;
+  natsConfigPath?: string;
+  plistPath?: string;
+  monitorUrl?: string;
+}
+
+// =============================================================================
+// Registry port — S1 client + provision-stack register (proof-of-possession).
+// =============================================================================
+
+function buildRegistryPort(cfg: LivePortsConfig): NetworkRegistryPort {
+  const url = cfg.registryUrl ?? "";
+  const client = new NetworkRegistryClient({
+    url,
+    ...(cfg.registryPubkey !== undefined ? { pubkey: cfg.registryPubkey } : {}),
+  });
+
+  return {
+    async registerStack() {
+      if (cfg.seedPath === undefined) {
+        return { ok: false, reason: "no --seed-path for registration" };
+      }
+      const seedFile = expandTilde(cfg.seedPath);
+      if (!existsSync(seedFile)) {
+        return { ok: false, reason: `seed file not found at ${seedFile}` };
+      }
+      let material;
+      try {
+        material = materialFromSeedString(readFileSync(seedFile, "utf-8"));
+      } catch (err) {
+        return { ok: false, reason: `seed load failed: ${err instanceof Error ? err.message : String(err)}` };
+      }
+      const body = await buildRegistrationClaim({
+        principalId: cfg.principalId,
+        material,
+        stacks: [{ stack_id: cfg.stackId }],
+      });
+      let result;
+      try {
+        result = await registerStackIdentity({ registryUrl: url, principalId: cfg.principalId, body });
+      } catch (err) {
+        return { ok: false, reason: `registry POST failed: ${err instanceof Error ? err.message : String(err)}` };
+      }
+      if (!result.ok) {
+        return { ok: false, reason: `registry rejected registration (HTTP ${result.status.toString()})` };
+      }
+      return { ok: true, note: `HTTP ${result.status.toString()}` };
+    },
+    fetchVerified(networkId) {
+      // S1's fetchAndCache returns { descriptor, roster } on ok and refreshes
+      // the disk cache (DD-10) — exactly the port's contract.
+      return client.fetchAndCache(networkId);
+    },
+    loadCached(networkId) {
+      return client.loadCached(networkId);
+    },
+  };
+}
+
+// =============================================================================
+// Leaf-file port — S3 renderer output written to the nats config dir.
+// =============================================================================
+
+/** Directory the per-network leaf include files live in (beside nats config). */
+function leafDir(cfg: LivePortsConfig): string {
+  const natsConfig = expandTilde(cfg.natsConfigPath ?? "");
+  return dirname(natsConfig);
+}
+
+function buildLeafFilePort(cfg: LivePortsConfig, mutate: boolean): LeafFilePort {
+  const dir = leafDir(cfg);
+  return {
+    write(inputs: RenderLeafInputs) {
+      const content = renderLeafIncludeFile(inputs.descriptor, inputs.binding);
+      if (!mutate) return; // dry-run: render to validate, but do not write.
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(join(dir, leafIncludeFileName(inputs.descriptor.network_id)), content, "utf-8");
+    },
+    remove(networkId) {
+      if (!mutate) return;
+      const p = join(dir, leafIncludeFileName(networkId));
+      rmSync(p, { force: true });
+    },
+    list() {
+      if (!existsSync(dir)) return [];
+      return readdirSync(dir)
+        .filter((f) => /^leafnodes-[a-z][a-z0-9-]*\.conf$/.test(f))
+        .map((f) => f.replace(/^leafnodes-/, "").replace(/\.conf$/, ""));
+    },
+    natsConfigPath() {
+      return expandTilde(cfg.natsConfigPath ?? "");
+    },
+  };
+}
+
+// =============================================================================
+// Plist port — S3 ensureConfigArg / renderProgramArguments.
+// =============================================================================
+
+/** Read the `ProgramArguments` <string> entries from a launchd plist. */
+function readProgramArguments(plistPath: string): string[] {
+  const xml = readFileSync(plistPath, "utf-8");
+  const block = /<key>ProgramArguments<\/key>\s*<array>([\s\S]*?)<\/array>/.exec(xml);
+  if (block === null) return [];
+  const args: string[] = [];
+  const re = /<string>([\s\S]*?)<\/string>/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(block[1] ?? "")) !== null) {
+    args.push(unescapeXml(m[1] ?? ""));
+  }
+  return args;
+}
+
+function unescapeXml(v: string): string {
+  return v
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&amp;/g, "&");
+}
+
+function escapeXml(v: string): string {
+  return v
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+/** Rewrite the plist's ProgramArguments array in place with `nextArgs`. */
+function writeProgramArguments(plistPath: string, nextArgs: string[]): void {
+  const xml = readFileSync(plistPath, "utf-8");
+  const items = nextArgs.map((a) => `\t\t<string>${escapeXml(a)}</string>`).join("\n");
+  const replacement = `<key>ProgramArguments</key>\n\t<array>\n${items}\n\t</array>`;
+  const next = xml.replace(
+    /<key>ProgramArguments<\/key>\s*<array>[\s\S]*?<\/array>/,
+    replacement,
+  );
+  writeFileSync(plistPath, next, "utf-8");
+}
+
+function buildPlistPort(cfg: LivePortsConfig, mutate: boolean): PlistPort {
+  const plistPath = expandTilde(cfg.plistPath ?? "");
+  return {
+    ensureConfigLoaded(configPath) {
+      if (!existsSync(plistPath)) return;
+      const args = readProgramArguments(plistPath);
+      if (plistConfigArgPresent(args, configPath)) return; // idempotent no-op
+      const next = ensureConfigArg(args, configPath);
+      if (!mutate) return;
+      writeProgramArguments(plistPath, next);
+    },
+    dropConfigArg(configPath) {
+      if (!existsSync(plistPath)) return;
+      const args = readProgramArguments(plistPath);
+      const next = args.filter((a, i) => {
+        if (a === "-c" || a === "--config") return false;
+        if (i > 0 && (args[i - 1] === "-c" || args[i - 1] === "--config")) return false;
+        if (a === `--config=${configPath}`) return false;
+        return true;
+      });
+      if (!mutate) return;
+      writeProgramArguments(plistPath, next);
+    },
+  };
+}
+
+// =============================================================================
+// Config-store port — read/write policy.federated.networks[] in stacks/<stack>.yaml.
+// =============================================================================
+
+/** The stack-scoped config file that carries policy.federated.networks[]. */
+function stackConfigPath(cfg: LivePortsConfig): string {
+  // The config-split stack file. The stack id is `{principal}/{slug}`; the file
+  // is `stacks/<slug>.yaml` under the cortex config dir derived from the nats
+  // config's grandparent (~/.config/cortex). Kept overridable via a future
+  // flag; for S4 we derive it deterministically from the stack slug.
+  const slug = cfg.stackId.split("/")[1] ?? "default";
+  const cortexDir = expandTilde("~/.config/cortex");
+  return join(cortexDir, "stacks", `${slug}.yaml`);
+}
+
+function buildConfigStorePort(cfg: LivePortsConfig, mutate: boolean): ConfigStorePort {
+  const path = stackConfigPath(cfg);
+  return {
+    readNetworks() {
+      if (!existsSync(path)) return [];
+      const raw = parseYaml(readFileSync(path, "utf-8")) as
+        | { policy?: { federated?: { networks?: PolicyFederatedNetwork[] } } }
+        | null;
+      return raw?.policy?.federated?.networks ?? [];
+    },
+    writeNetworks(networks) {
+      if (!mutate) return;
+      const raw = existsSync(path)
+        ? ((parseYaml(readFileSync(path, "utf-8")) ?? {}) as Record<string, unknown>)
+        : {};
+      const policy = (raw.policy ??= {}) as Record<string, unknown>;
+      const federated = ((policy as { federated?: unknown }).federated ??= {}) as Record<string, unknown>;
+      federated.networks = networks;
+      mkdirSync(dirname(path), { recursive: true });
+      writeFileSync(path, stringifyYaml(raw), "utf-8");
+    },
+  };
+}
+
+// =============================================================================
+// Daemon port — launchctl kickstart of the stack daemon.
+// =============================================================================
+
+function buildDaemonPort(cfg: LivePortsConfig, mutate: boolean): DaemonPort {
+  return {
+    async restart() {
+      if (!mutate) return { ok: true }; // dry-run: pretend success.
+      const label = `ai.meta-factory.cortex.${cfg.stackId.split("/")[1] ?? "default"}`;
+      const proc = Bun.spawn(["launchctl", "kickstart", "-k", `gui/${process.getuid?.() ?? 501}/${label}`], {
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const code = await proc.exited;
+      if (code !== 0) {
+        const err = await new Response(proc.stderr).text();
+        return { ok: false, reason: `launchctl kickstart exited ${code.toString()}: ${err.trim()}` };
+      }
+      return { ok: true };
+    },
+  };
+}
+
+// =============================================================================
+// Leaf-state port — nats-server monitor /leafz for status.
+// =============================================================================
+
+function buildLeafStatePort(cfg: LivePortsConfig): LeafStatePort | undefined {
+  if (cfg.monitorUrl === undefined) return undefined;
+  const base = cfg.monitorUrl.replace(/\/+$/, "");
+  return {
+    async linkStates() {
+      try {
+        const res = await fetch(`${base}/leafz`);
+        if (!res.ok) return {};
+        const body = (await res.json()) as {
+          leafs?: { account?: string; name?: string; in_msgs?: number; out_msgs?: number }[];
+        };
+        const out: Record<string, { state: "established"; inMsgs?: number; outMsgs?: number }> = {};
+        for (const leaf of body.leafs ?? []) {
+          const key = leaf.name ?? leaf.account ?? "";
+          if (key === "") continue;
+          out[key] = { state: "established", inMsgs: leaf.in_msgs, outMsgs: leaf.out_msgs };
+        }
+        return out;
+      } catch (err) {
+        // Monitor unreachable — status degrades to "unknown" link state.
+        process.stderr.write(
+          `network-adapters: leaf-state fetch failed: ${err instanceof Error ? err.message : String(err)}\n`,
+        );
+        return {};
+      }
+    },
+  };
+}
+
+// =============================================================================
+// Bundle builders
+// =============================================================================
+
+function buildPorts(cfg: LivePortsConfig, mutate: boolean): NetworkPorts {
+  const leafState = buildLeafStatePort(cfg);
+  return {
+    registry: buildRegistryPort(cfg),
+    leafFile: buildLeafFilePort(cfg, mutate),
+    plist: buildPlistPort(cfg, mutate),
+    configStore: buildConfigStorePort(cfg, mutate),
+    daemon: buildDaemonPort(cfg, mutate),
+    ...(leafState !== undefined ? { leafState } : {}),
+  };
+}
+
+/** Live ports — every effect mutates the deployment. Use only on `--apply`. */
+export function buildLivePorts(cfg: LivePortsConfig): NetworkPorts {
+  return buildPorts(cfg, true);
+}
+
+/**
+ * Dry-run ports — reads hit disk; every WRITE/EXEC/RESTART is a no-op (the
+ * orchestrator's step log still records the intended action). The S4 default.
+ */
+export function buildDryRunPorts(cfg: LivePortsConfig): NetworkPorts {
+  return buildPorts(cfg, false);
+}

--- a/src/cli/cortex/commands/network-adapters.ts
+++ b/src/cli/cortex/commands/network-adapters.ts
@@ -40,6 +40,7 @@ import {
 import {
   ensureConfigArg,
   plistConfigArgPresent,
+  renderProgramArguments,
 } from "../../../common/nats/nats-plist-loader";
 import { NetworkRegistryClient } from "../../../common/registry/network-client";
 import {
@@ -163,7 +164,11 @@ function buildLeafFilePort(cfg: LivePortsConfig, mutate: boolean): LeafFilePort 
 }
 
 // =============================================================================
-// Plist port — S3 ensureConfigArg / renderProgramArguments.
+// Plist port — built on S3's canonical ensureConfigArg + renderProgramArguments
+// (`src/common/nats/nats-plist-loader.ts`) as the single source of truth for
+// the ProgramArguments arg-list transform AND its XML rendering. This adapter
+// only does the plist I/O: read the existing args back out, and splice S3's
+// rendered block into the file. No bespoke arg/XML logic lives here.
 // =============================================================================
 
 /** Read the `ProgramArguments` <string> entries from a launchd plist. */
@@ -189,23 +194,20 @@ function unescapeXml(v: string): string {
     .replace(/&amp;/g, "&");
 }
 
-function escapeXml(v: string): string {
-  return v
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&apos;");
-}
-
-/** Rewrite the plist's ProgramArguments array in place with `nextArgs`. */
+/**
+ * Rewrite the plist's ProgramArguments block in place with `nextArgs`. The XML
+ * block is rendered by S3's canonical {@link renderProgramArguments} (the
+ * single source of truth for the ProgramArguments key+array XML, including the
+ * five-entity escaping) — this adapter only splices it into the plist. Matches
+ * the existing `<key>ProgramArguments</key>` block INCLUDING its leading
+ * horizontal indent so S3's own `\t`-prefixed output replaces it 1:1 (no
+ * double-indent), keeping the on-disk plist byte-shape stable.
+ */
 function writeProgramArguments(plistPath: string, nextArgs: string[]): void {
   const xml = readFileSync(plistPath, "utf-8");
-  const items = nextArgs.map((a) => `\t\t<string>${escapeXml(a)}</string>`).join("\n");
-  const replacement = `<key>ProgramArguments</key>\n\t<array>\n${items}\n\t</array>`;
   const next = xml.replace(
-    /<key>ProgramArguments<\/key>\s*<array>[\s\S]*?<\/array>/,
-    replacement,
+    /[ \t]*<key>ProgramArguments<\/key>\s*<array>[\s\S]*?<\/array>/,
+    renderProgramArguments(nextArgs),
   );
   writeFileSync(plistPath, next, "utf-8");
 }

--- a/src/cli/cortex/commands/network-lib.ts
+++ b/src/cli/cortex/commands/network-lib.ts
@@ -1,0 +1,383 @@
+/**
+ * S4 (#738) — the join/leave/status orchestration, pure over {@link NetworkPorts}.
+ *
+ * This is the executable form of the §1 friction table (DD-4: what was done by
+ * hand on 2026-06-06 becomes one command). The flows never touch a real
+ * filesystem, plist, launchctl, or registry directly — every effect is a port.
+ *
+ * ## Wire-protocol contract (federation-wire-protocol SOP /wire-check)
+ *
+ * S4 writes the federation config, so it must be on-contract:
+ *
+ *   - **accept_subjects** = the stack's OWN `federated.{me}.{stack}.>` ONLY.
+ *     A network never names itself on the wire; accept-lists gate by the
+ *     stack's own principal/stack segment. We NEVER write the network id into
+ *     a subject.
+ *   - **peers[]** declare by `principal_id` (+ `stack_id`), pubkey
+ *     registry-resolved (DD-5) — the local principal is never in its own
+ *     peers[].
+ *   - **max_hop** is a conscious value (schema has no default); join writes a
+ *     conservative `1` (direct hub + one relay), which the principal can edit.
+ *
+ * ## Idempotency
+ *
+ * `join` converges: re-running replaces the network's entry in
+ * `policy.federated.networks[]` (keyed by network id) rather than appending,
+ * re-writes the (byte-stable) leaf include, and re-ensures the plist `-c` arg
+ * (a no-op when already present). `leave` removes exactly what `join` added and
+ * is a no-op when the network was never joined.
+ */
+
+import type {
+  PolicyFederatedNetwork,
+  PolicyFederatedPeer,
+} from "../../../common/types/cortex-config";
+import type { NetworkRosterResult } from "../../../common/registry/types";
+import { base64PubkeyToNkey } from "../../../common/registry/encoding";
+
+import {
+  brandVerified,
+  type NetworkPorts,
+  type LeafLinkState,
+} from "./network-ports";
+
+// =============================================================================
+// Identity of the joining stack — who "me" is on the wire.
+// =============================================================================
+
+/**
+ * The local stack's wire identity + leaf binding, supplied by the CLI from the
+ * loaded config. `principalId`/`stackSlug` build the OWN accept-subject; the
+ * `account` (nkey-U) + `credentials` path are the leaf binding S3 needs.
+ */
+export interface JoiningStack {
+  /** Local principal id — the `{me}` segment of `federated.{me}.{stack}.>`. */
+  principalId: string;
+  /** Local stack slug — the `{stack}` segment (the part after the `/`). */
+  stackSlug: string;
+  /** Path to the leaf `.creds` file (absolute). */
+  credentials: string;
+  /** Local nkey-U account the leaf binds to (DD-8 already in nkey-U). */
+  account: string;
+  /**
+   * The `leaf_node` connection name to write on the network entry. Defaults to
+   * the network id when unset (one leaf per network, OQ3-clean).
+   */
+  leafNode?: string;
+  /** max_hop to write (schema has no default). Conservative default: 1. */
+  maxHop?: number;
+}
+
+// =============================================================================
+// Flow results — discriminated so the CLI renders + sets exit codes.
+// =============================================================================
+
+export interface JoinResult {
+  ok: boolean;
+  /** Human-readable step log (ordered). Rendered by the CLI. */
+  steps: string[];
+  /** The network entry that was written (on success). */
+  network?: PolicyFederatedNetwork;
+  /** Failure reason (on `ok: false`). */
+  reason?: string;
+  /** True when the registry was unreachable and a cached descriptor was used (DD-10). */
+  usedCache?: boolean;
+  /** Peers that resolved (principal ids) — for the CLI summary. */
+  resolvedPeers?: string[];
+}
+
+export interface LeaveResult {
+  ok: boolean;
+  steps: string[];
+  reason?: string;
+  /** True when the network was not joined (no-op leave). */
+  notJoined?: boolean;
+  /** Networks still joined after leave (for plist teardown decision). */
+  remaining?: string[];
+}
+
+export interface StatusResult {
+  ok: boolean;
+  networks: StatusNetworkRow[];
+  reason?: string;
+}
+
+export interface StatusNetworkRow {
+  networkId: string;
+  leafNode: string;
+  peers: string[];
+  acceptSubjects: string[];
+  maxHop: number;
+  link: LeafLinkState;
+}
+
+// =============================================================================
+// join
+// =============================================================================
+
+/**
+ * Join `networkId`, idempotently (DD-4). Steps mirror §1's friction table:
+ *   (a) register the stack pubkey,
+ *   (b) pull the VERIFIED descriptor + roster (DD-9; cached fallback DD-10),
+ *   (c) render + write the leaf include and ensure the plist loads it (DD-6),
+ *   (d) merge the network into policy.federated.networks[] with registry-
+ *       resolved peers (DD-5) + the OWN accept-subject,
+ *   (e) restart the daemon.
+ *
+ * Never throws — every failure becomes a `{ ok: false, reason }`.
+ */
+export async function joinNetwork(
+  networkId: string,
+  stack: JoiningStack,
+  ports: NetworkPorts,
+): Promise<JoinResult> {
+  const steps: string[] = [];
+
+  // (a) Register (idempotent). A registration failure is fatal: without a
+  // registered pubkey the peer cannot be verified by others (DD-9 symmetric).
+  const reg = await ports.registry.registerStack();
+  if (!reg.ok) {
+    return { ok: false, steps, reason: `register failed: ${reg.reason}` };
+  }
+  steps.push(`registered stack pubkey (${reg.note})`);
+
+  // (b) Pull the verified descriptor + roster (DD-9). On unreachable, fall back
+  // to the last-known-good cache (DD-10) so a join during a transient outage
+  // still configures. A bad signature / not_found / shape-invalid ABORTS —
+  // an unverified descriptor must NEVER reach the renderer.
+  let descriptor;
+  let roster: NetworkRosterResult;
+  let usedCache = false;
+  const fetched = await ports.registry.fetchVerified(networkId);
+  if (fetched.status === "ok") {
+    descriptor = fetched.value.descriptor;
+    roster = fetched.value.roster;
+    steps.push(`pulled verified descriptor + roster for "${networkId}"`);
+  } else if (fetched.status === "unreachable") {
+    const cached = ports.registry.loadCached(networkId);
+    if (cached === undefined) {
+      return {
+        ok: false,
+        steps,
+        reason: `registry unreachable (${fetched.reason}) and no cached descriptor for "${networkId}" — cannot join`,
+      };
+    }
+    descriptor = cached.descriptor;
+    roster = cached.roster;
+    usedCache = true;
+    steps.push(
+      `registry unreachable (${fetched.reason}) — using last-known-good cached descriptor + roster (DD-10)`,
+    );
+  } else {
+    // not_found / unverified — a definitive negative. Do NOT render.
+    const detail =
+      fetched.status === "unverified"
+        ? `descriptor failed verification (${fetched.reason}) — refusing to join (DD-9)`
+        : `network "${networkId}" not found in registry`;
+    return { ok: false, steps, reason: detail };
+  }
+
+  // TRUST BOUNDARY: brand only here, after the verified-fetch / verified-cache
+  // path. The renderer demands a VerifiedNetworkDescriptor; a plain descriptor
+  // would be a tsc error at the next line.
+  const verified = brandVerified(descriptor);
+
+  // (c) Render + write the leaf include (S3) and ensure the plist loads the
+  // nats config (DD-6, closes the configured-but-dormant trap). The renderer
+  // fails loud on a bad binding — surface it as a join failure, never a crash.
+  try {
+    ports.leafFile.write({
+      descriptor: verified,
+      binding: { credentials: stack.credentials, account: stack.account },
+    });
+  } catch (err) {
+    return {
+      ok: false,
+      steps,
+      reason: `leaf render/write failed: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+  steps.push(`wrote leaf include for "${networkId}" (hub ${verified.hub_url})`);
+
+  ports.plist.ensureConfigLoaded(ports.leafFile.natsConfigPath());
+  steps.push(`ensured nats-server plist loads ${ports.leafFile.natsConfigPath()}`);
+
+  // (d) Merge the network into the federation config with registry-resolved
+  // peers (DD-5) + the OWN accept-subject (wire contract). Idempotent: replace
+  // the entry keyed by network id, never append a duplicate.
+  const peers = buildPeers(stack.principalId, roster);
+  const acceptSubject = `federated.${stack.principalId}.${stack.stackSlug}.>`;
+  const entry: PolicyFederatedNetwork = {
+    id: networkId,
+    leaf_node: stack.leafNode ?? networkId,
+    peers,
+    accept_subjects: [acceptSubject],
+    deny_subjects: [],
+    announce_capabilities: [],
+    max_hop: stack.maxHop ?? 1,
+  };
+
+  const existing = ports.configStore.readNetworks();
+  const merged = mergeNetwork(existing, entry);
+  ports.configStore.writeNetworks(merged);
+  steps.push(
+    `wrote policy.federated.networks["${networkId}"] — ${peers.length.toString()} peer(s), accept ${acceptSubject}`,
+  );
+
+  // (e) Restart the daemon so the rendered leaf takes effect.
+  const restart = await ports.daemon.restart();
+  if (!restart.ok) {
+    return {
+      ok: false,
+      steps,
+      reason: `config written but daemon restart failed: ${restart.reason}`,
+      network: entry,
+      usedCache,
+      resolvedPeers: peers.map((p) => p.principal_id),
+    };
+  }
+  steps.push("restarted stack daemon");
+
+  return {
+    ok: true,
+    steps,
+    network: entry,
+    usedCache,
+    resolvedPeers: peers.map((p) => p.principal_id),
+  };
+}
+
+/**
+ * Build `peers[]` from the verified roster (DD-5). Excludes the LOCAL principal
+ * (a stack is never in its own peers[]). Each peer declares `principal_id` +
+ * `stack_id`; `principal_pubkey` is filled from the roster (re-encoded to
+ * nkey-U, DD-8) when the roster carries a re-encodable key — otherwise it is
+ * LEFT OFF so the S2 config-load resolver resolves it (DD-5: declare by id).
+ */
+function buildPeers(
+  localPrincipalId: string,
+  roster: NetworkRosterResult,
+): PolicyFederatedPeer[] {
+  const peers: PolicyFederatedPeer[] = [];
+  for (const member of roster.members) {
+    if (member.principal_id === localPrincipalId) continue; // never self
+    const stackId =
+      member.stack_id ?? `${member.principal_id}/default`;
+    const nkey = base64PubkeyToNkey(member.principal_pubkey);
+    const peer: PolicyFederatedPeer = nkey === undefined
+      ? { principal_id: member.principal_id, stack_id: stackId }
+      : {
+          principal_id: member.principal_id,
+          stack_id: stackId,
+          principal_pubkey: nkey,
+        };
+    peers.push(peer);
+  }
+  return peers;
+}
+
+/**
+ * Replace-or-append the network in the list, keyed by id (idempotency). Pure:
+ * input array not mutated, order preserved, replacement in place.
+ */
+export function mergeNetwork(
+  existing: readonly PolicyFederatedNetwork[],
+  next: PolicyFederatedNetwork,
+): PolicyFederatedNetwork[] {
+  const out = existing.map((n) => ({ ...n }));
+  const idx = out.findIndex((n) => n.id === next.id);
+  if (idx >= 0) {
+    out[idx] = next;
+  } else {
+    out.push(next);
+  }
+  return out;
+}
+
+// =============================================================================
+// leave
+// =============================================================================
+
+/**
+ * Leave `networkId` — the exact reverse of join, idempotently:
+ *   - remove the network from policy.federated.networks[],
+ *   - delete the leaf include file,
+ *   - if NO leaf includes remain, drop the plist `-c` arg,
+ *   - restart the daemon.
+ *
+ * A leave of a network that was never joined is a clean no-op (ok, notJoined).
+ */
+export async function leaveNetwork(
+  networkId: string,
+  ports: NetworkPorts,
+): Promise<LeaveResult> {
+  const steps: string[] = [];
+  const existing = ports.configStore.readNetworks();
+  const wasJoined = existing.some((n) => n.id === networkId);
+
+  if (!wasJoined) {
+    return {
+      ok: true,
+      steps: [`network "${networkId}" not joined — nothing to do`],
+      notJoined: true,
+      remaining: existing.map((n) => n.id),
+    };
+  }
+
+  // Remove from federation config.
+  const remaining = existing.filter((n) => n.id !== networkId);
+  ports.configStore.writeNetworks(remaining);
+  steps.push(`removed policy.federated.networks["${networkId}"]`);
+
+  // Delete the leaf include (idempotent).
+  ports.leafFile.remove(networkId);
+  steps.push(`deleted leaf include for "${networkId}"`);
+
+  // If no networks have a leaf include anymore, drop the plist -c arg so the
+  // server reverts to its bare invocation (clean teardown).
+  const stillHaveLeaves = ports.leafFile.list().length > 0;
+  if (!stillHaveLeaves) {
+    ports.plist.dropConfigArg(ports.leafFile.natsConfigPath());
+    steps.push("no networks remain — dropped nats-server plist -c arg");
+  }
+
+  const restart = await ports.daemon.restart();
+  if (!restart.ok) {
+    return {
+      ok: false,
+      steps,
+      reason: `config reverted but daemon restart failed: ${restart.reason}`,
+      remaining: remaining.map((n) => n.id),
+    };
+  }
+  steps.push("restarted stack daemon");
+
+  return { ok: true, steps, remaining: remaining.map((n) => n.id) };
+}
+
+// =============================================================================
+// status
+// =============================================================================
+
+/**
+ * Report joined networks: leaf link state (from the optional {@link LeafStatePort},
+ * "unknown" when none wired), peers, accept-subjects, and counters. Read-only;
+ * never restarts or mutates anything.
+ */
+export async function networkStatus(ports: NetworkPorts): Promise<StatusResult> {
+  const networks = ports.configStore.readNetworks();
+  const linkStates = ports.leafState
+    ? await ports.leafState.linkStates()
+    : {};
+
+  const rows: StatusNetworkRow[] = networks.map((n) => ({
+    networkId: n.id,
+    leafNode: n.leaf_node,
+    peers: n.peers.map((p) => p.principal_id),
+    acceptSubjects: n.accept_subjects,
+    maxHop: n.max_hop,
+    link: linkStates[n.id] ?? { state: "unknown" },
+  }));
+
+  return { ok: true, networks: rows };
+}

--- a/src/cli/cortex/commands/network-lib.ts
+++ b/src/cli/cortex/commands/network-lib.ts
@@ -199,12 +199,14 @@ export async function joinNetwork(
   }
   steps.push(`wrote leaf include for "${networkId}" (hub ${verified.hub_url})`);
 
-  ports.plist.ensureConfigLoaded(ports.leafFile.natsConfigPath());
-  steps.push(`ensured nats-server plist loads ${ports.leafFile.natsConfigPath()}`);
-
-  // (d) Merge the network into the federation config with registry-resolved
-  // peers (DD-5) + the OWN accept-subject (wire contract). Idempotent: replace
-  // the entry keyed by network id, never append a duplicate.
+  // The plist + config writes hit the live filesystem in the `--apply` adapter
+  // (plist XML splice + stack YAML rewrite). A failure there (permission denied,
+  // an unparseable plist, a disk error) must surface as a `{ ok: false }` per
+  // this function's "never throws" contract — NOT as an uncaught exception that
+  // escapes with a stack trace and leaves the deployment half-mutated (leaf
+  // written, config not). A failed `--apply` is recoverable: re-running join
+  // converges (idempotent). `try` spans both writes so the step log records how
+  // far the mutation got before the failure.
   const peers = buildPeers(stack.principalId, roster);
   const acceptSubject = `federated.${stack.principalId}.${stack.stackSlug}.>`;
   const entry: PolicyFederatedNetwork = {
@@ -217,12 +219,27 @@ export async function joinNetwork(
     max_hop: stack.maxHop ?? 1,
   };
 
-  const existing = ports.configStore.readNetworks();
-  const merged = mergeNetwork(existing, entry);
-  ports.configStore.writeNetworks(merged);
-  steps.push(
-    `wrote policy.federated.networks["${networkId}"] — ${peers.length.toString()} peer(s), accept ${acceptSubject}`,
-  );
+  try {
+    // (c, cont.) Ensure the plist loads the nats config (DD-6).
+    ports.plist.ensureConfigLoaded(ports.leafFile.natsConfigPath());
+    steps.push(`ensured nats-server plist loads ${ports.leafFile.natsConfigPath()}`);
+
+    // (d) Merge the network into the federation config with registry-resolved
+    // peers (DD-5) + the OWN accept-subject (wire contract). Idempotent: replace
+    // the entry keyed by network id, never append a duplicate.
+    const existing = ports.configStore.readNetworks();
+    const merged = mergeNetwork(existing, entry);
+    ports.configStore.writeNetworks(merged);
+    steps.push(
+      `wrote policy.federated.networks["${networkId}"] — ${peers.length.toString()} peer(s), accept ${acceptSubject}`,
+    );
+  } catch (err) {
+    return {
+      ok: false,
+      steps,
+      reason: `plist/config write failed: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
 
   // (e) Restart the daemon so the rendered leaf takes effect.
   const restart = await ports.daemon.restart();
@@ -324,21 +341,35 @@ export async function leaveNetwork(
     };
   }
 
-  // Remove from federation config.
   const remaining = existing.filter((n) => n.id !== networkId);
-  ports.configStore.writeNetworks(remaining);
-  steps.push(`removed policy.federated.networks["${networkId}"]`);
+  // The config rewrite, leaf-include delete, and plist edit hit the live
+  // filesystem in `--apply`. As in join, a write failure must surface as a
+  // `{ ok: false }` per contract, not an uncaught throw — and the step log
+  // records how far teardown got. A failed `--apply` leave is recoverable:
+  // re-running converges (idempotent).
+  try {
+    // Remove from federation config.
+    ports.configStore.writeNetworks(remaining);
+    steps.push(`removed policy.federated.networks["${networkId}"]`);
 
-  // Delete the leaf include (idempotent).
-  ports.leafFile.remove(networkId);
-  steps.push(`deleted leaf include for "${networkId}"`);
+    // Delete the leaf include (idempotent).
+    ports.leafFile.remove(networkId);
+    steps.push(`deleted leaf include for "${networkId}"`);
 
-  // If no networks have a leaf include anymore, drop the plist -c arg so the
-  // server reverts to its bare invocation (clean teardown).
-  const stillHaveLeaves = ports.leafFile.list().length > 0;
-  if (!stillHaveLeaves) {
-    ports.plist.dropConfigArg(ports.leafFile.natsConfigPath());
-    steps.push("no networks remain — dropped nats-server plist -c arg");
+    // If no networks have a leaf include anymore, drop the plist -c arg so the
+    // server reverts to its bare invocation (clean teardown).
+    const stillHaveLeaves = ports.leafFile.list().length > 0;
+    if (!stillHaveLeaves) {
+      ports.plist.dropConfigArg(ports.leafFile.natsConfigPath());
+      steps.push("no networks remain — dropped nats-server plist -c arg");
+    }
+  } catch (err) {
+    return {
+      ok: false,
+      steps,
+      reason: `teardown write failed: ${err instanceof Error ? err.message : String(err)}`,
+      remaining: remaining.map((n) => n.id),
+    };
   }
 
   const restart = await ports.daemon.restart();

--- a/src/cli/cortex/commands/network-ports.ts
+++ b/src/cli/cortex/commands/network-ports.ts
@@ -1,0 +1,201 @@
+/**
+ * S4 (Network Join Control Plane, #738 · epic #733 · spec
+ * `docs/design-network-join-control-plane.md` §6 F4) — the injected-dependency
+ * seams + the trust-boundary types for `cortex network join/leave/status`.
+ *
+ * ## Why ports
+ *
+ * `join` mutates the *live* deployment: it writes a nats-server leaf include
+ * file, edits the launchd plist, rewrites a stack's federation config, and
+ * restarts a daemon. None of that may run in a test (or accidentally during
+ * development — CLAUDE.md / the S4 brief's SAFETY rule). So every side-effect
+ * is a port: an interface the orchestrator (`network-lib.ts`) depends on, a
+ * REAL adapter the CLI (`network.ts`) wires for production, and a FAKE the
+ * tests assert against. The orchestrator itself is pure over its ports.
+ *
+ * ## The trust boundary — `VerifiedNetworkDescriptor` (S3-review N2)
+ *
+ * DD-9 requires that only a signature-verified descriptor reaches the leaf
+ * renderer. S3 enforced that in PROSE. S4 makes it a TYPE: a
+ * {@link VerifiedNetworkDescriptor} is a {@link NetworkDescriptor} branded with
+ * a unique symbol that CANNOT be constructed outside this module. The only
+ * mint is {@link brandVerified}, which this module calls EXCLUSIVELY from the
+ * `NetworkRegistryPort.fetchVerified` success path (an `ok` result off S1's
+ * pin+verify client). A descriptor that failed verification is a plain
+ * `NetworkDescriptor` and is rejected by `tsc` at the `renderLeafInclude` call
+ * site — the trust boundary is compiler-enforced, not reviewer-enforced.
+ */
+
+import type {
+  NetworkDescriptor,
+  NetworkRosterResult,
+} from "../../../common/registry/types";
+import type { NetworkFetchResult } from "../../../common/registry/network-client";
+import type { StackLeafBinding } from "../../../common/nats/leaf-remote-renderer";
+import type { PolicyFederatedNetwork } from "../../../common/types/cortex-config";
+
+// =============================================================================
+// Trust-boundary type — only a VERIFIED descriptor flows into the renderer.
+// =============================================================================
+
+/** Unique brand symbol. Not exported — un-forgeable outside this module. */
+declare const VERIFIED_DESCRIPTOR: unique symbol;
+
+/**
+ * A {@link NetworkDescriptor} that has passed the DD-9 pin+verify gate. The
+ * brand is phantom (zero runtime cost). Because the symbol is module-private,
+ * NO caller can write `{ ...descriptor, [VERIFIED_DESCRIPTOR]: true }` — the
+ * only way to obtain one is {@link brandVerified}, which this module calls only
+ * from a verified-fetch `ok` branch. The leaf renderer entrypoint
+ * ({@link RenderLeafInputs}) demands this type, so an UNVERIFIED descriptor is
+ * a `tsc` error at the call site.
+ */
+export type VerifiedNetworkDescriptor = NetworkDescriptor & {
+  readonly [VERIFIED_DESCRIPTOR]: true;
+};
+
+/**
+ * Mint a {@link VerifiedNetworkDescriptor}. INTERNAL to the join orchestration:
+ * callable only after a {@link NetworkRegistryPort} returned `status: "ok"`
+ * (S1's client only returns `ok` when the response signature verified against
+ * the pinned registry pubkey — DD-9). Never call this on a descriptor that has
+ * not been through that gate.
+ */
+export function brandVerified(d: NetworkDescriptor): VerifiedNetworkDescriptor {
+  return d as VerifiedNetworkDescriptor;
+}
+
+// =============================================================================
+// Ports — every side effect the orchestrator depends on.
+// =============================================================================
+
+/**
+ * The registry control-plane seam (S1). Wraps `NetworkRegistryClient` so the
+ * orchestrator never imports the concrete transport. `registerStack` is the
+ * idempotent proof-of-possession registration (reuses provision-stack's
+ * `register`); `fetchVerified` returns S1's discriminated, pin+verified
+ * descriptor+roster pair.
+ */
+export interface NetworkRegistryPort {
+  /**
+   * Register this stack's signing pubkey with the registry (idempotent —
+   * re-registering the same pubkey converges). Returns a log-safe note on
+   * success, or an error reason. DD-4 step (a).
+   */
+  registerStack(): Promise<{ ok: true; note: string } | { ok: false; reason: string }>;
+  /**
+   * Pull + pin+verify (DD-9) the descriptor + roster for `networkId`. On `ok`
+   * the descriptor is safe to {@link brandVerified}; every other branch aborts
+   * the join (or, for `unreachable`, lets the caller try {@link loadCached}).
+   */
+  fetchVerified(
+    networkId: string,
+  ): Promise<
+    NetworkFetchResult<{ descriptor: NetworkDescriptor; roster: NetworkRosterResult }>
+  >;
+  /**
+   * DD-10 fallback — last-known-good verified descriptor + roster, or
+   * `undefined`. Used when `fetchVerified` returns `unreachable` so a join
+   * configured during a transient registry outage still uses trusted cached
+   * data.
+   */
+  loadCached(
+    networkId: string,
+  ): { descriptor: NetworkDescriptor; roster: NetworkRosterResult } | undefined;
+}
+
+/** Inputs to the leaf-include render — the trust boundary in one place. */
+export interface RenderLeafInputs {
+  /** A descriptor that PASSED DD-9 verification. Plain descriptors rejected. */
+  descriptor: VerifiedNetworkDescriptor;
+  /** The stack's local leaf binding (creds path + nkey-U account). */
+  binding: StackLeafBinding;
+}
+
+/**
+ * The nats-server leaf-include file seam (S3 renderer output written to disk).
+ * `write` renders + persists the per-network include; `remove` deletes it on
+ * `leave`; `list` reports which networks currently have an include (used to
+ * decide whether to keep the plist `-c` arg).
+ */
+export interface LeafFilePort {
+  /** Render (S3 `renderLeafIncludeFile`) + write the include for the network. */
+  write(inputs: RenderLeafInputs): void;
+  /** Delete a network's include file (idempotent — absent file is a no-op). */
+  remove(networkId: string): void;
+  /** Network ids that currently have an include file present. */
+  list(): string[];
+  /**
+   * Absolute path to the nats-server config the plist should load (`-c`). This
+   * is the config that `include`s the per-network leaf files; the leaf port
+   * owns where it lives so the plist port can be told which path to ensure.
+   */
+  natsConfigPath(): string;
+}
+
+/**
+ * The launchd plist seam (S3 `ensureConfigArg`/`renderProgramArguments`).
+ * `ensureConfigLoaded` rewrites the nats-server plist so it loads
+ * `configPath` (closing the configured-but-dormant trap, DD-6);
+ * `dropConfigArg` reverts to a bare invocation when no networks remain.
+ */
+export interface PlistPort {
+  /** Ensure the nats-server plist loads `configPath` via `-c`. Idempotent. */
+  ensureConfigLoaded(configPath: string): void;
+  /** Remove the `-c <configPath>` arg from the plist (leave teardown). */
+  dropConfigArg(configPath: string): void;
+}
+
+/**
+ * The stack-federation-config seam — reads + writes `policy.federated.
+ * networks[]` for a stack (the config-split `stacks/<stack>.yaml`, DD-5). The
+ * orchestrator computes the new networks array; this port persists it.
+ */
+export interface ConfigStorePort {
+  /** Current `policy.federated.networks[]` for the stack (empty if none). */
+  readNetworks(): PolicyFederatedNetwork[];
+  /** Persist the full `policy.federated.networks[]` for the stack. */
+  writeNetworks(networks: PolicyFederatedNetwork[]): void;
+}
+
+/**
+ * The daemon-restart seam — `launchctl kickstart` of the stack's nats-server
+ * (and/or cortex) so the rendered config takes effect. Injected so tests
+ * assert the restart was requested without touching launchctl.
+ */
+export interface DaemonPort {
+  /** Restart the stack daemon so the new leaf config is loaded. */
+  restart(): Promise<{ ok: true } | { ok: false; reason: string }>;
+}
+
+/**
+ * Read-only leaf-link telemetry for `status` (the nats-server monitor `/leafz`
+ * surface, when available). Optional — `status` degrades gracefully to "link
+ * state unknown" when no provider is wired (S4 keeps this injected; the live
+ * monitor client is out of S4 scope).
+ */
+export interface LeafStatePort {
+  /** Per-network leaf link state + in/out counters, keyed by network id. */
+  linkStates(): Promise<Record<string, LeafLinkState>>;
+}
+
+/** One network's leaf link state for `status`. */
+export interface LeafLinkState {
+  /** ESTABLISHED / connecting / down / unknown. */
+  state: "established" | "connecting" | "down" | "unknown";
+  /** Messages received over the leaf since connect. */
+  inMsgs?: number;
+  /** Messages sent over the leaf since connect. */
+  outMsgs?: number;
+}
+
+/** The full port bundle the orchestrator depends on. */
+export interface NetworkPorts {
+  registry: NetworkRegistryPort;
+  leafFile: LeafFilePort;
+  plist: PlistPort;
+  configStore: ConfigStorePort;
+  daemon: DaemonPort;
+  /** Optional — status link telemetry. Absent → link state "unknown". */
+  leafState?: LeafStatePort;
+}

--- a/src/cli/cortex/commands/network.ts
+++ b/src/cli/cortex/commands/network.ts
@@ -1,0 +1,461 @@
+#!/usr/bin/env bun
+/**
+ * `cortex network <subcommand>` — S4 (#738) the headline one-command join.
+ *
+ * Spec `docs/design-network-join-control-plane.md` §6 F4 + §9 ("feel like
+ * TCP/IP"). Connecting a stack to a network used to be ~10 manual steps across
+ * four Myelin layers + two config files + an out-of-band key swap (the §1
+ * friction table). This command is the executable form: hand it a network name,
+ * it does everything (DD-4).
+ *
+ *   join <network>     register → pull VERIFIED descriptor (DD-9; cached
+ *                      fallback DD-10) → render leaf + load plist (DD-6) →
+ *                      write policy.federated.networks[] with registry-resolved
+ *                      peers (DD-5) + the OWN accept-subject → restart.
+ *                      Idempotent (DD-4).
+ *   status             leaf link state + joined networks + peers + counters.
+ *   leave <network>    reverse it all, cleanly + idempotently.
+ *
+ * ## Wiring (the S1–S3 pieces this command composes)
+ *
+ *   - S1 `NetworkRegistryClient` — `fetchAndCache`/`loadCached`, pin+verify
+ *     (DD-9). Wrapped by the {@link NetworkRegistryPort} adapter.
+ *   - S1 `registerStackIdentity` (via provision-stack's register flow) —
+ *     idempotent proof-of-possession registration.
+ *   - S3 `renderLeafIncludeFile` + `leafIncludeFileName` — the leaf include
+ *     file. S3 `ensureConfigArg`/`renderProgramArguments` — the plist loader.
+ *   - The branded {@link VerifiedNetworkDescriptor} — only a signature-verified
+ *     descriptor flows into the renderer (compiler-enforced, S3-review N2).
+ *
+ * ## SAFETY (S4 brief)
+ *
+ * The real adapters MUTATE the live deployment (leaf file, plist, config,
+ * launchctl). The orchestration is pure over injected ports
+ * (`network-lib.ts`); the live adapters live in `network-adapters.ts` and are
+ * only constructed on a real invocation. `--dry-run` (the DEFAULT-safe posture
+ * for `join`/`leave`) swaps in no-op effect adapters that record the intended
+ * actions and print them WITHOUT touching disk or daemons — so an accidental
+ * run during development is inert.
+ *
+ * Exit codes: 0 success · 1 operational failure · 2 usage error.
+ */
+
+import { expandTilde } from "../../../common/config/loader";
+
+import { CliArgsError } from "./_shared/arg-error";
+import { envelopeError, envelopeOk, renderJson } from "./_shared/envelope";
+import { type ExitResult } from "./_shared/exit-result";
+import { parseSubcommandArgs, type SubcommandSpec } from "./_shared/parser";
+import {
+  joinNetwork,
+  leaveNetwork,
+  networkStatus,
+  type JoiningStack,
+} from "./network-lib";
+import type { NetworkPorts } from "./network-ports";
+import {
+  buildLivePorts,
+  buildDryRunPorts,
+  type LivePortsConfig,
+} from "./network-adapters";
+
+export { type ExitResult } from "./_shared/exit-result";
+
+// =============================================================================
+// Grammar
+// =============================================================================
+
+type NetworkSubcommand = "join" | "leave" | "status";
+
+const NETWORK_ID_RE = /^[a-z][a-z0-9-]*$/;
+const PRINCIPAL_ID_RE = /^[a-z][a-z0-9-]*$/;
+
+const SPEC: SubcommandSpec<NetworkSubcommand> = {
+  cliName: "network",
+  subcommands: {
+    join: {
+      positionals: ["network"],
+      flags: {
+        "--principal": "value",
+        "--stack": "value",
+        "--registry-url": "value",
+        "--registry-pubkey": "value",
+        "--seed-path": "value",
+        "--creds": "value",
+        "--account": "value",
+        "--nats-config": "value",
+        "--plist": "value",
+        "--max-hop": "value",
+        "--leaf-node": "value",
+        "--apply": "bool",
+        "--dry-run": "bool",
+      },
+    },
+    leave: {
+      positionals: ["network"],
+      flags: {
+        "--principal": "value",
+        "--stack": "value",
+        "--nats-config": "value",
+        "--plist": "value",
+        "--apply": "bool",
+        "--dry-run": "bool",
+      },
+    },
+    status: {
+      positionals: [],
+      flags: {
+        "--principal": "value",
+        "--stack": "value",
+        "--monitor-url": "value",
+      },
+    },
+  },
+  universal: { "--json": "bool", "--help": "bool", "-h": "bool" },
+};
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+function requireValueFlag(
+  flags: Record<string, string | true>,
+  name: string,
+): { ok: true; value: string } | { ok: false; reason: string } {
+  const v = flags[name];
+  if (v === undefined) return { ok: false, reason: `${name} is required` };
+  if (v === true) return { ok: false, reason: `${name} requires a value` };
+  return { ok: true, value: v };
+}
+
+function optionalValueFlag(
+  flags: Record<string, string | true>,
+  name: string,
+): string | undefined {
+  const v = flags[name];
+  return typeof v === "string" ? v : undefined;
+}
+
+/** Resolve the stack slug from `--stack` (`{principal}/{slug}`) or default. */
+function resolveStackSlug(
+  principalId: string,
+  stackFlag: string | undefined,
+): { ok: true; slug: string } | { ok: false; reason: string } {
+  if (stackFlag === undefined) return { ok: true, slug: "default" };
+  const parts = stackFlag.split("/");
+  if (parts.length !== 2 || parts[0] !== principalId) {
+    return {
+      ok: false,
+      reason: `--stack "${stackFlag}" must be {principal}/{slug} with prefix matching --principal "${principalId}"`,
+    };
+  }
+  const slug = parts[1] ?? "";
+  if (!/^[a-z][a-z0-9_-]*$/.test(slug)) {
+    return { ok: false, reason: `--stack slug "${slug}" must be letter-prefixed lowercase` };
+  }
+  return { ok: true, slug };
+}
+
+/**
+ * `join`/`leave` mutate the live deployment. The DEFAULT is dry-run (safe);
+ * `--apply` opts into real mutation. `--dry-run` is accepted explicitly too.
+ * `--apply` and `--dry-run` together is a usage error.
+ */
+function resolveApply(
+  flags: Record<string, string | true>,
+): { ok: true; apply: boolean } | { ok: false; reason: string } {
+  const apply = flags["--apply"] === true;
+  const dry = flags["--dry-run"] === true;
+  if (apply && dry) {
+    return { ok: false, reason: "--apply and --dry-run are mutually exclusive" };
+  }
+  return { ok: true, apply };
+}
+
+// =============================================================================
+// Subcommand handlers
+// =============================================================================
+
+async function runJoin(
+  networkId: string,
+  flags: Record<string, string | true>,
+  json: boolean,
+): Promise<ExitResult> {
+  if (!NETWORK_ID_RE.test(networkId)) {
+    return usageError("join", `network "${networkId}" must be lowercase alphanumeric + hyphen, letter-prefixed`, json);
+  }
+  const principalRes = requireValueFlag(flags, "--principal");
+  if (!principalRes.ok) return usageError("join", principalRes.reason, json);
+  if (!PRINCIPAL_ID_RE.test(principalRes.value)) {
+    return usageError("join", `--principal "${principalRes.value}" must be lowercase alphanumeric + hyphen, letter-prefixed`, json);
+  }
+  const slugRes = resolveStackSlug(principalRes.value, optionalValueFlag(flags, "--stack"));
+  if (!slugRes.ok) return usageError("join", slugRes.reason, json);
+
+  // All six are required for a live join; resolve them typed so the stack
+  // identity carries real strings (no non-null assertions).
+  for (const required of ["--registry-url", "--seed-path", "--nats-config", "--plist"]) {
+    const r = requireValueFlag(flags, required);
+    if (!r.ok) return usageError("join", r.reason, json);
+  }
+  const credsRes = requireValueFlag(flags, "--creds");
+  if (!credsRes.ok) return usageError("join", credsRes.reason, json);
+  const accountRes = requireValueFlag(flags, "--account");
+  if (!accountRes.ok) return usageError("join", accountRes.reason, json);
+
+  const maxHopRaw = optionalValueFlag(flags, "--max-hop");
+  let maxHop: number | undefined;
+  if (maxHopRaw !== undefined) {
+    maxHop = Number.parseInt(maxHopRaw, 10);
+    if (!Number.isInteger(maxHop) || maxHop < 0) {
+      return usageError("join", `--max-hop "${maxHopRaw}" must be a non-negative integer`, json);
+    }
+  }
+
+  const applyRes = resolveApply(flags);
+  if (!applyRes.ok) return usageError("join", applyRes.reason, json);
+
+  const stack: JoiningStack = {
+    principalId: principalRes.value,
+    stackSlug: slugRes.slug,
+    credentials: expandTilde(credsRes.value),
+    account: accountRes.value,
+    leafNode: optionalValueFlag(flags, "--leaf-node"),
+    maxHop,
+  };
+
+  const cfg = portsConfig(networkId, principalRes.value, slugRes.slug, flags);
+  const ports = applyRes.apply ? buildLivePorts(cfg) : buildDryRunPorts(cfg);
+
+  const res = await joinNetwork(networkId, stack, ports);
+  return renderFlowResult("join", networkId, res.ok, res.reason, res.steps, applyRes.apply, json, {
+    used_cache: res.usedCache === true ? "true" : "false",
+    peers: (res.resolvedPeers ?? []).join(","),
+  });
+}
+
+async function runLeave(
+  networkId: string,
+  flags: Record<string, string | true>,
+  json: boolean,
+): Promise<ExitResult> {
+  if (!NETWORK_ID_RE.test(networkId)) {
+    return usageError("leave", `network "${networkId}" must be lowercase alphanumeric + hyphen, letter-prefixed`, json);
+  }
+  const principalRes = requireValueFlag(flags, "--principal");
+  if (!principalRes.ok) return usageError("leave", principalRes.reason, json);
+  const slugRes = resolveStackSlug(principalRes.value, optionalValueFlag(flags, "--stack"));
+  if (!slugRes.ok) return usageError("leave", slugRes.reason, json);
+  for (const required of ["--nats-config", "--plist"]) {
+    const r = requireValueFlag(flags, required);
+    if (!r.ok) return usageError("leave", r.reason, json);
+  }
+  const applyRes = resolveApply(flags);
+  if (!applyRes.ok) return usageError("leave", applyRes.reason, json);
+
+  const cfg = portsConfig(networkId, principalRes.value, slugRes.slug, flags);
+  const ports = applyRes.apply ? buildLivePorts(cfg) : buildDryRunPorts(cfg);
+
+  const res = await leaveNetwork(networkId, ports);
+  return renderFlowResult("leave", networkId, res.ok, res.reason, res.steps, applyRes.apply, json, {
+    not_joined: res.notJoined === true ? "true" : "false",
+    remaining: (res.remaining ?? []).join(","),
+  });
+}
+
+async function runStatus(
+  flags: Record<string, string | true>,
+  json: boolean,
+): Promise<ExitResult> {
+  const principalRes = requireValueFlag(flags, "--principal");
+  if (!principalRes.ok) return usageError("status", principalRes.reason, json);
+  const slugRes = resolveStackSlug(principalRes.value, optionalValueFlag(flags, "--stack"));
+  if (!slugRes.ok) return usageError("status", slugRes.reason, json);
+
+  const cfg = portsConfig("", principalRes.value, slugRes.slug, flags);
+  // status is read-only — live ports, but it only ever reads.
+  const ports: NetworkPorts = buildLivePorts(cfg);
+
+  const res = await networkStatus(ports);
+  if (json) {
+    return ok(renderJson(envelopeOk(res.networks)));
+  }
+  if (res.networks.length === 0) {
+    return ok("cortex network status: no networks joined\n");
+  }
+  const lines = ["cortex network status:", ""];
+  for (const n of res.networks) {
+    lines.push(`  ${n.networkId}  [leaf:${n.leafNode}]  link:${n.link.state}`);
+    lines.push(`    peers:    ${n.peers.length > 0 ? n.peers.join(", ") : "(none)"}`);
+    lines.push(`    accept:   ${n.acceptSubjects.join(", ")}`);
+    lines.push(`    max_hop:  ${n.maxHop.toString()}`);
+    if (n.link.inMsgs !== undefined || n.link.outMsgs !== undefined) {
+      lines.push(`    counters: in=${(n.link.inMsgs ?? 0).toString()} out=${(n.link.outMsgs ?? 0).toString()}`);
+    }
+    lines.push("");
+  }
+  return ok(lines.join("\n"));
+}
+
+// =============================================================================
+// Ports config + result rendering
+// =============================================================================
+
+function portsConfig(
+  networkId: string,
+  principalId: string,
+  stackSlug: string,
+  flags: Record<string, string | true>,
+): LivePortsConfig {
+  return {
+    networkId,
+    principalId,
+    stackId: `${principalId}/${stackSlug}`,
+    registryUrl: optionalValueFlag(flags, "--registry-url"),
+    registryPubkey: optionalValueFlag(flags, "--registry-pubkey"),
+    seedPath: optionalValueFlag(flags, "--seed-path"),
+    natsConfigPath: optionalValueFlag(flags, "--nats-config"),
+    plistPath: optionalValueFlag(flags, "--plist"),
+    monitorUrl: optionalValueFlag(flags, "--monitor-url"),
+  };
+}
+
+function renderFlowResult(
+  sub: string,
+  networkId: string,
+  okFlag: boolean,
+  reason: string | undefined,
+  steps: string[],
+  applied: boolean,
+  json: boolean,
+  data: Record<string, string>,
+): ExitResult {
+  if (json) {
+    const env = okFlag
+      ? envelopeOk([{ network: networkId, applied, steps }], data)
+      : envelopeError(reason ?? "unknown failure", { network: networkId, ...data });
+    return { exitCode: okFlag ? 0 : 1, stdout: okFlag ? renderJson(env) : "", stderr: okFlag ? "" : renderJson(env) };
+  }
+  const banner = applied ? "" : "  (dry-run — no live mutation; pass --apply to execute)\n";
+  const body =
+    `cortex network ${sub} ${networkId}: ${okFlag ? "ok" : "FAILED"}\n` +
+    banner +
+    steps.map((s) => `  • ${s}`).join("\n") +
+    (okFlag ? "" : `\n  ✗ ${reason ?? "unknown failure"}`) +
+    "\n";
+  return okFlag ? ok(body) : { exitCode: 1, stdout: "", stderr: body };
+}
+
+// =============================================================================
+// Result builders
+// =============================================================================
+
+function ok(stdout: string): ExitResult {
+  return { exitCode: 0, stdout, stderr: "" };
+}
+
+function usageError(sub: string, reason: string, json: boolean): ExitResult {
+  const stderr = json
+    ? renderJson(envelopeError(reason, { subcommand: sub }))
+    : `cortex network ${sub}: ${reason}\n${topLevelHelp()}`;
+  return { exitCode: 2, stdout: "", stderr };
+}
+
+// =============================================================================
+// Dispatcher
+// =============================================================================
+
+export async function dispatchNetwork(argv: string[]): Promise<ExitResult> {
+  let parsed;
+  try {
+    parsed = parseSubcommandArgs(SPEC, argv);
+  } catch (err) {
+    if (err instanceof CliArgsError) {
+      return { exitCode: 2, stdout: "", stderr: `cortex network: ${err.message}\n${topLevelHelp()}` };
+    }
+    throw err;
+  }
+
+  const json = parsed.flags["--json"] === true;
+
+  if (parsed.subcommand === "help" || parsed.help) {
+    return { exitCode: 0, stdout: topLevelHelp(), stderr: "" };
+  }
+  if (parsed.subcommand === "unknown") {
+    const msg =
+      parsed.rawSubcommand === ""
+        ? "usage error — no subcommand specified."
+        : `unknown subcommand "${parsed.rawSubcommand}".`;
+    return { exitCode: 2, stdout: "", stderr: `cortex network: ${msg}\n${topLevelHelp()}` };
+  }
+
+  switch (parsed.subcommand) {
+    case "join":
+      return runJoin(parsed.positionals.network ?? "", parsed.flags, json);
+    case "leave":
+      return runLeave(parsed.positionals.network ?? "", parsed.flags, json);
+    case "status":
+      return runStatus(parsed.flags, json);
+  }
+}
+
+// =============================================================================
+// Help
+// =============================================================================
+
+function topLevelHelp(): string {
+  return `cortex network — one-command join to the Internet of Agentic Work (S4, #738)
+
+Usage:
+  cortex network join  <network> --principal <id> --registry-url <url> \\
+                        --seed-path <p> --creds <p> --account <nkey-U> \\
+                        --nats-config <p> --plist <p> [--stack <id>] \\
+                        [--registry-pubkey <b64>] [--leaf-node <name>] \\
+                        [--max-hop <n>] [--apply] [--json]
+  cortex network leave  <network> --principal <id> --nats-config <p> \\
+                        --plist <p> [--stack <id>] [--apply] [--json]
+  cortex network status --principal <id> [--stack <id>] [--monitor-url <url>] [--json]
+
+Subcommands:
+  join    Register → pull the SIGNED+VERIFIED network descriptor (DD-9; cached
+          fallback on registry outage, DD-10) → render the nats-server leaf +
+          ensure the plist loads it (DD-6) → write policy.federated.networks[]
+          with registry-resolved peers (DD-5) + the stack's OWN accept-subject
+          → restart. Idempotent (re-running converges).
+  status  Show joined networks, peers, accept-subjects, leaf link state + counters.
+  leave   Reverse a join cleanly: remove the network + leaf include, drop the
+          plist -c arg if no networks remain, restart. Idempotent.
+
+Safety:
+  join/leave default to DRY-RUN (no disk/daemon mutation — they print the
+  intended actions). Pass --apply to execute for real. --apply and --dry-run
+  are mutually exclusive.
+
+Flags:
+  --principal <id>        Local principal id (the {me} subject segment).
+  --stack <id>            {principal}/{slug}; defaults to <principal>/default.
+  --registry-url <url>    Network-registry base URL (control plane).
+  --registry-pubkey <b64> Pinned registry Ed25519 pubkey (DD-9); TOFU if omitted.
+  --seed-path <p>         Stack signing seed for registration (proof-of-possession).
+  --creds <p>             nats-server leaf .creds file (absolute).
+  --account <nkey-U>      Local NATS account the leaf binds to (A… nkey-U).
+  --nats-config <p>       nats-server config the plist loads (-c) + includes the leaf.
+  --plist <p>             nats-server launchd plist to ensure loads the config.
+  --leaf-node <name>      Leaf connection name on the network entry (default: network id).
+  --max-hop <n>           Hop budget written on the network (default: 1).
+  --monitor-url <url>     (status) nats-server monitor base URL for leaf telemetry.
+  --apply                 Execute the live mutation (default: dry-run).
+  --json                  Emit a { status, items, data, error } envelope.
+`;
+}
+
+// =============================================================================
+// Main
+// =============================================================================
+
+if (import.meta.main) {
+  const result = await dispatchNetwork(process.argv.slice(2));
+  if (result.stdout) process.stdout.write(result.stdout);
+  if (result.stderr) process.stderr.write(result.stderr);
+  process.exit(result.exitCode);
+}


### PR DESCRIPTION
## S4 — `cortex network join/leave/status` (#738, epic #733)

The headline one-command join (spec §6 F4 + §9 "feel like TCP/IP"). What was ~10 manual steps across four Myelin layers + two config files + an out-of-band key swap (the §1 friction table) becomes one idempotent command, wiring the merged S1/S2/S3 pieces.

### Files + functions
- **`src/cli/cortex/commands/network-ports.ts`** — injected-dependency seams (`NetworkRegistryPort`, `LeafFilePort`, `PlistPort`, `ConfigStorePort`, `DaemonPort`, `LeafStatePort`) + the branded **`VerifiedNetworkDescriptor`** trust-boundary type and `brandVerified()`.
- **`src/cli/cortex/commands/network-lib.ts`** — pure orchestration: `joinNetwork`, `leaveNetwork`, `networkStatus`, `mergeNetwork`.
- **`src/cli/cortex/commands/network-adapters.ts`** — `buildLivePorts` (real fs/plist/launchctl/registry) + `buildDryRunPorts` (default-safe no-op writes).
- **`src/cli/cortex/commands/network.ts`** — `dispatchNetwork` + `SubcommandSpec` + `import.meta.main`, following the `provision-stack` pattern.

### The verified-descriptor trust boundary (S3-review N2)
DD-9 says only a signature-verified descriptor may reach the leaf renderer. S3 enforced that in prose; S4 makes it a **type**. `VerifiedNetworkDescriptor` is a `NetworkDescriptor` branded with a module-private `unique symbol`, mintable ONLY via `brandVerified()`, which the orchestrator calls EXCLUSIVELY from the verified-fetch (S1 `status: "ok"`, pin+verify) / verified-cache path. `RenderLeafInputs.descriptor` demands the branded type, so a plain (unverified) descriptor is a **`tsc` error** at the call site — confirmed: `Type 'NetworkDescriptor' is not assignable to type 'VerifiedNetworkDescriptor'`.

### Flows
- **join** (idempotent): (a) register stack pubkey (proof-of-possession, reuses provision-stack's register) → (b) pull the VERIFIED descriptor+roster (DD-9; on `unreachable` fall back to last-known-good cache + warn, DD-10; `unverified`/`not_found` aborts — never renders) → (c) render the S3 leaf include + ensure the plist `-c` loads the nats config (DD-6) → (d) merge `policy.federated.networks[]` keyed by id (replace, no dup) with registry-resolved peers (DD-5, local principal excluded) + the OWN `federated.{me}.{stack}.>` accept-subject + `max_hop` → (e) restart the daemon.
- **leave** (idempotent): remove the network from config, delete the leaf include, drop the plist `-c` arg iff no leaves remain, restart. No-op when not joined.
- **status**: joined networks + peers + accept-subjects + leaf link state/counters (from the optional `/leafz` monitor port; "unknown" when none wired).

### Idempotency
`mergeNetwork` replaces the entry keyed by network id (never appends); the S3 leaf include is byte-stable; `ensureConfigArg` is a no-op when `-c` already points right. Re-running join converges; leave removes exactly what join added.

### wire-check 5/5 PASS
`accept_subjects = federated.{me}.{my-stack}.>` (the receiver's OWN scope, ADR-0001 — supersedes cortex#661, no `network_id` on the wire); peers declared by `principal_id`; the network resolves from `peers[]` at `selectLink`. Rules 3–4 (originator/verdict) N/A — S4 writes config, doesn't emit envelopes (DD-1 data plane untouched). Confirmed against `PolicySchema` cross-validators.

### SAFETY — no live mutation in dev
join/leave default to **dry-run**: reads hit disk but every write/exec/restart is a no-op that the step log records. `--apply` opts into real mutation. No real `~/.config/cortex/*`, `~/.config/nats/*`, plist, or daemon was touched during development (verified: no `stacks/` dir, no `leafnodes-*.conf` created).

### Tests — 33 new, all mock I/O
`network-lib.test.ts` (18, fake ports): join writes leaf+plist+config+restart; idempotent re-run (no dup); accept_subjects = own scope; peers by principal_id, local excluded; **bad-signature descriptor aborts — renderer never called**; `not_found` aborts; DD-10 cached fallback configures + warns; uncached unreachable fails; register/restart failure surfacing; multi-network; leave reverses + idempotent; status renders + "unknown" without a monitor.
`network-cli.test.ts` (15): dispatch/usage/help; join usage validation; `--apply`/`--dry-run` exclusivity; **dry-run writes nothing to disk**; status rendering; leave no-op.

### Verify
- `bunx tsc --noEmit` → 0 errors
- `bun test` → 4545 pass, 0 fail, 2 skip (full suite); 33 new green; no new failures
- lint clean; vocab carve-out gate PASS

### Out of scope (per brief)
S5 (public scope), S6 (docs/SOP). Config-derivation of join inputs from the loaded cortex config is deferred to a follow-up (S4 takes them as flags); the `stacks/<slug>.yaml` config-store path is derived deterministically and overridable later.

Closes #738
Refs #733

🤖 Generated with [Claude Code](https://claude.com/claude-code)