### PR TITLE
docs: S6 — network-join SOP + CONTEXT.md + supersede peering runbook + ADR-0003

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -23,6 +23,8 @@ _Avoid_: daemon (the per-assistant runtime identity is the **agent**), server, h
 **Network**:
 A federation of **principals** whose **stacks** interconnect at the NATS leaf-node layer — `metafactory` is the network this ecosystem runs on. A network is **not a subject segment**: it is deployment topology. Cross-principal reach is the `federated.` **scope** prefix, never a network name on the wire. A principal may belong to more than one network.
 
+A stack **joins** a network through the **network-join control plane** — `cortex network join <network>` (`docs/sop-network-join.md`, spec `docs/design-network-join-control-plane.md`, binding decisions `docs/adr/0003-network-join-control-plane.md`). The control plane is additive over the unchanged L1–L7 data plane: the **registry** (`network.meta-factory.ai`) is the source of truth for the network descriptor (`hub_url`/`leaf_port`) + peer roster; cortex pins + verifies the registry (DD-9), resolves peers from the roster (DD-5), and renders the leaf link from the descriptor (DD-12). Joining is one command, not the ~10 manual steps it replaces. Hand-pinning a peer pubkey survives as the offline fallback only.
+
 **Federation is the default for multi-principal collaboration**, not the exception. When two principals' bots interact (e.g. Andreas's assistant replies to a message JC's user posted), the dispatch envelope MUST publish on `federated.{principal}.{stack}.…` — `local.` never crosses the principal boundary. This is the OSI/L3 routing equivalent: `local.` is one broadcast domain, `federated.` is cross-network routing. A shared platform channel (Discord, Mattermost, Slack) does NOT make cross-principal traffic intra-principal — the surface is L7; the routing happens at L1–L3 on the bus.
 _Avoid_: federation (that is the relationship, not the thing), mesh, fabric, org, cluster
 
@@ -48,7 +50,9 @@ _Avoid_: topic (the Kafka/MQTT word — NATS subjects have different semantics),
 
 **Scope**:
 How far a **subject** may travel, set by its prefix — exactly three values: `local` (never leaves the **principal** boundary), `federated` (crosses to peer principals in a **network**), `public` (unrestricted; carries no principal/stack segment).
-_Avoid_: reach, visibility, tier, level
+
+The three scopes are also the three **onboarding tiers** of the network-join control plane (`docs/adr/0003-network-join-control-plane.md`, `docs/sop-network-join.md`): **local** is zero-config (the home bus — nothing to join); **federated** is the registry-mediated `cortex network join <network>` (the registry resolves hub + roster + peer pubkeys); **public** is the opt-in open square — the Internet of Agentic Work. The same wire grammar governs all three; only the scope prefix and the gate's trust source differ. The security posture (`signing: off → permissive → enforce`) is orthogonal to scope — joining a tier never changes your signing posture.
+_Avoid_: reach, visibility, tier, level (when naming the prefix; "onboarding tier" is fine for the join model)
 
 **Domain**:
 The functional-domain segment of a **subject** — groups related signals. Values: `tasks`, `agent`, `system`, `code`, `review`, `dispatch`. Always the segment ("the tasks domain"). The `tasks` and `dispatch` domains are distinct and coexist: **`tasks.{capability}.{subcapability}`** is the work-request namespace (where Offer-mode work is published, capability-routed); **`dispatch.task.{action}`** is the task-lifecycle namespace (events about an active dispatch — `received`, `dispatched`, `started`, `completed`, `failed`, `aborted`). Not a rename in flight.

--- a/docs/adr/0003-network-join-control-plane.md
+++ b/docs/adr/0003-network-join-control-plane.md
@@ -1,0 +1,38 @@
+# ADR 0003 — Network join control plane
+
+**Status:** Accepted (2026-06-07)
+**Relates:** [`docs/design-network-join-control-plane.md`](../design-network-join-control-plane.md) (the spec these decisions are promoted from), [ADR-0001](./0001-federated-subject-grammar.md) (federated subject grammar), [ADR-0002](./0002-federated-dispatch-addressing-and-verdict-back.md) (dispatch addressing + verdict-back), `CONTEXT.md` §Network/§Scope, [`compass/sops/federation-wire-protocol.md`](https://github.com/the-metafactory/compass/blob/main/sops/federation-wire-protocol.md), [`docs/sop-network-join.md`](../sop-network-join.md) (the one-command join SOP).
+**Supersedes operationally:** the manual, cloudflared-led peering procedure in [`docs/runbook-federation-peering.md`](../runbook-federation-peering.md) (#728), which is retained as the offline / hand-pin fallback only.
+
+## Context
+
+Connecting a cortex **stack** to a **network** — so two principals' stacks interconnect at the NATS leaf-node layer — was ~10 manual steps across four Myelin layers, two config files, and an out-of-band key exchange (recorded firsthand bringing `andreas/meta-factory` onto JC's hub, 2026-06-06; see the spec §1 friction table). The L1–L7 **data plane** was already well-specified — ADR-0001 put `federated.{principal}.{stack}.…` on the wire and took topology off it; ADR-0002 settled dispatch addressing and verdict-back. What was missing was a **control plane**: a defined way for a stack to *join* a network.
+
+The Network Join Control Plane epic (#733) added that control plane as a thin layer over the unchanged data plane, framed around the three bus **scopes** — `local` / `federated` / `public` — and delivered as one command (`cortex network join <network>`, S4 #738). The design spec's §4 enumerated twelve design decisions (DD-1…DD-12). This ADR promotes the load-bearing subset to binding status. The remainder stay descriptive in the spec.
+
+## Decision
+
+The following design decisions are **binding** for any code, config, or operations touching the join control plane:
+
+- **DD-1 — Additive control plane; the data plane is untouched.** The 5-check `federated.*` wire grammar (ADR-0001/0002, the federation-wire-protocol SOP) does not change. The join/discovery control plane sits *above* it. Any proposal that puts topology on the wire or identity in myelin is rejected on sight (the wire-protocol layer split: L7 owns identity addressing, L1–L3 own topology & routing). The control plane only exchanges identity, descriptors, and rosters; traffic still flows leaf-to-leaf on the unchanged bus.
+
+- **DD-2 — The registry is the source of truth for network + peer discovery.** The network-registry (`network.meta-factory.ai`, `src/services/network-registry/`) resolves `principal → pubkey`, serves the per-network descriptor (`GET /networks/:id`) and roster (`GET /networks/:id/roster`). Joining *pulls* from it; in steady state it is never bypassed by hand-pinning. The registry is the self-hosted control-plane analog of a mesh-overlay control server (Headscale/NetBird): it exchanges identity and keys, never the data-plane traffic.
+
+- **DD-9 — Pin + verify the registry (trust anchor).** The registry signs its roster/principal/descriptor responses (`registry:` pubkey + `signature`). Cortex pins the registry pubkey in config and verifies **every** response signature before trusting a resolved peer pubkey. An unverified response is rejected, not trusted. A spoofed or compromised registry cannot inject peer keys.
+
+- **DD-10 — Registry-down → cached roster + warn.** On registry-unreachable at boot, cortex uses the last-known-good cached roster and emits a loud `system.error`/warn; federation stays up. Hand-pinned peers always resolve offline. A transient registry outage never silently tears federation down — graceful degradation, like the IP stack staying routable through a partial DNS outage.
+
+- **DD-11 — Resolved-vs-pinned mismatch → fail-closed.** If a peer carries both a hand-pinned `principal_pubkey` and a *different* registry-resolved key, cortex refuses to load that peer and alerts. A divergence is a drift or attack signal, not a value to merge. A matching pin is honored. (Complements DD-5's "pin is the fallback" — when both exist, they MUST agree.)
+
+- **DD-12 — Hub via registry-served descriptor.** The network's `hub_url` + `leaf_port` come from `GET /networks/:id` (the descriptor), not from local config — so the hub can relocate without every peer re-editing config. The join command derives the leaf remote from the descriptor; no out-of-band port/creds wrangling.
+
+## Consequences
+
+- **Joining a network is one command.** `cortex network join <network> --apply` performs the whole §1 sequence idempotently — the "feel like TCP/IP" north star (spec §9): hand the registry a network name, it hands back everything the layers need (descriptor + roster + trust anchor). The procedure documented in [`docs/sop-network-join.md`](../sop-network-join.md) is the binding operational form.
+- **Hand-pinning becomes a fallback, not the path** (DD-5, descriptive in the spec; the operational consequence of DD-2). The manual cloudflared-led runbook (#728) is superseded for the steady-state case and retained only as the offline / no-public-hub fallback.
+- **Security is a separate axis** (DD-7, descriptive). Join works at any signing posture (`off → permissive → enforce`); ramping signing never changes who you are joined to, and joining never changes your signing posture. DD-9/DD-11 protect the *control plane's* trust anchor regardless of the *data plane's* signing posture.
+- **The public scope is the opt-in tier.** `local` is zero-config (home), `federated` is the registry-mediated join above, `public` is the open square — opted into explicitly (the Internet of Agentic Work; see S5/#739). The same wire grammar governs all three; only the scope prefix and the gate's trust source differ.
+
+## Status of the non-promoted DDs
+
+DD-3 (three tiers = three scopes), DD-4 (one-command join), DD-5 (registry-resolved peers; hand-pin is fallback), DD-6 (runtime owns leaf rendering), DD-7 (security ramp orthogonal), and DD-8 (one canonical pubkey encoding per surface) remain documented in the spec §4 and are realized by the shipped S1–S4 code; they are not promoted to binding ADR status here because they are implementation shape rather than cross-cutting contract. They may be promoted later if a future change pressures them.

--- a/docs/runbook-federation-peering.md
+++ b/docs/runbook-federation-peering.md
@@ -1,3 +1,18 @@
+> # ⚠️ SUPERSEDED — use `cortex network join`
+>
+> **This manual, cloudflared-led runbook (#728) is superseded by the one-command join** ([`docs/sop-network-join.md`](./sop-network-join.md), S6 / Network Join Control Plane #733). For the steady-state case, **do not follow the steps below** — run:
+>
+> ```bash
+> cortex provision-stack register <principal-id> --seed-path <p> --registry-url <url> --stack-id <id>   # once
+> cortex network join <network> --principal <id> --registry-url <url> --registry-pubkey <b64> \
+>   --seed-path <p> --creds <p> --account <A…> --nats-config <p> --plist <p> --apply
+> cortex network status --principal <id>
+> ```
+>
+> The registry is now the source of truth (descriptor + roster + trust anchor — [ADR-0003](./adr/0003-network-join-control-plane.md) DD-2/DD-9/DD-12); the command absorbs every manual step below.
+>
+> **This document is kept for historical reference and as the manual fallback** for: no reachable registry, the offline hand-pin path (DD-5 fallback), or bringing up a brand-new hub before its descriptor exists. Note that a **public NATS hub** (JC's hub) makes the cloudflared "Reachability" section below **moot for the 2-party case** — leaf nodes dial outbound to the public hub (NAT-safe), so no tunnel is needed.
+
 # Runbook — Configure Federation Peering (cross-principal review test)
 
 **Goal:** wire two principals' cortex stacks together so a `pilot request-review` on one side is reviewed by the other and the verdict comes back — the end-to-end cross-principal review loop.

--- a/docs/sop-network-join.md
+++ b/docs/sop-network-join.md
@@ -1,0 +1,124 @@
+# SOP — Network join (one command)
+
+**Status:** active (S6 / Network Join Control Plane epic #733)
+**Owner:** principal
+**Audience:** a **principal** joining one of their **stacks** to a **network** (a federation of peer principals whose stacks interconnect at the NATS leaf-node layer), and the mirror-image join on the peer side.
+**Authoritative detail:** [`CONTEXT.md`](../CONTEXT.md) §Scope/§Network · [`docs/adr/0003-network-join-control-plane.md`](./adr/0003-network-join-control-plane.md) (binding DDs) · [`docs/design-network-join-control-plane.md`](./design-network-join-control-plane.md) (the spec) · [`compass/sops/federation-wire-protocol.md`](https://github.com/the-metafactory/compass/blob/main/sops/federation-wire-protocol.md) (the wire grammar this rides on, unchanged).
+**Supersedes:** the manual, cloudflared-led [`docs/runbook-federation-peering.md`](./runbook-federation-peering.md) (#728) for the steady-state case. That runbook is retained only as the offline / hand-pin fallback.
+
+> **What changed.** Joining a network used to be ~10 manual steps across four Myelin layers, two config files, and an out-of-band key swap (the design spec §1 friction table). It is **now one command**. The registry is the source of truth; the command absorbs every step in that table.
+
+---
+
+## Pre-flight
+
+After reading this SOP, output:
+
+```
+SOP: network-join | network: {name} | mode: {dry-run|apply} | step: {register?→join→status}
+```
+
+Verify before proceeding:
+
+- You know the **network id** to join (lowercase, letter-prefixed — e.g. `metafactory`).
+- You have the **registry URL** and the **pinned registry pubkey** (DD-9 — the trust anchor; without the pin the join is trust-on-first-use).
+- Your stack has a **signing seed** (`--seed-path`), a **NATS leaf `.creds`** file, and the local **nats-server config** + **launchd plist** the daemon loads.
+- `join`/`leave` **default to dry-run** — they print the intended actions and touch nothing. Add `--apply` only when you mean to mutate the live deployment.
+
+---
+
+## The flow (≤3 steps — the "feel like TCP/IP" test)
+
+The success test for this control plane (spec §9): joining a network feels like a machine joining the internet — plug in and it works. If the flow below grows past these three steps, that is a **bug in the design**, not the principal's problem — flag it.
+
+### Step 1 — Register the stack identity (once per stack)
+
+Skip if this stack is already registered with the network's registry. Registration is idempotent.
+
+```bash
+cortex provision-stack register <principal-id> \
+  --seed-path ~/.config/nats/cortex.nk \
+  --registry-url https://network.meta-factory.ai \
+  --stack-id <principal-id>/<stack>
+```
+
+This proves possession of the stack's signing key and publishes the stack's pubkey + capabilities to the registry, so peers resolve you (DD-2/DD-5). `--stack-id` defaults to `<principal-id>/default`.
+
+### Step 2 — Join the network
+
+```bash
+cortex network join <network> \
+  --principal <principal-id> \
+  --registry-url https://network.meta-factory.ai \
+  --registry-pubkey <base64-registry-pubkey> \
+  --seed-path ~/.config/nats/cortex.nk \
+  --creds ~/.config/nats/leaf.creds \
+  --account <A…-nkey-U> \
+  --nats-config ~/.config/nats/<conf>.conf \
+  --plist ~/Library/LaunchAgents/ai.meta-factory.cortex.<stack>.plist \
+  --apply
+```
+
+`join` performs the whole §1 sequence, idempotently (DD-4): register (if needed) → pull the **signature-verified** network descriptor (`hub_url`/`leaf_port` from the registry, DD-12; cached fallback on a registry outage, DD-10) → render the nats-server leaf remote + ensure the plist loads it (DD-6) → write `policy.federated.networks[]` with **registry-resolved** peers (DD-5) plus the stack's own accept-subject → restart.
+
+**Run it without `--apply` first.** The default dry-run prints every action with no disk or daemon mutation, so you see exactly what the live run will do. `--apply` and `--dry-run` are mutually exclusive.
+
+Optional flags: `--stack <principal>/<slug>` (defaults to `<principal>/default`), `--leaf-node <name>` (leaf connection name; defaults to the network id), `--max-hop <n>` (hop budget; defaults to 1), `--json` (machine-readable `{ status, items, data, error }` envelope).
+
+### Step 3 — Verify
+
+```bash
+cortex network status --principal <principal-id> [--stack <principal>/<slug>] [--monitor-url <nats-monitor-url>]
+```
+
+Shows each joined network with its leaf link state, resolved peers, accept-subjects, max-hop, and in/out counters. A healthy join shows the leaf `link:` established and the expected peers listed.
+
+---
+
+## Leaving a network
+
+```bash
+cortex network leave <network> \
+  --principal <principal-id> \
+  --nats-config ~/.config/nats/<conf>.conf \
+  --plist ~/Library/LaunchAgents/ai.meta-factory.cortex.<stack>.plist \
+  --apply
+```
+
+`leave` reverses a join cleanly and idempotently: removes the network entry + its leaf include, drops the plist `-c` config arg if no networks remain, and restarts. Like `join`, it defaults to dry-run; pass `--apply` to execute. Re-running on a network you are not joined to is a no-op.
+
+---
+
+## Security posture (what protects the join)
+
+The join control plane is additive over the unchanged wire grammar (DD-1). The control-plane trust properties:
+
+- **Registry-resolved peers** (DD-5) — `peers[]` carry `principal_id`; cortex resolves the pubkey + stack from the registry roster at config-load. No hand-maintained pubkey lists in steady state.
+- **Pin + verify the registry** (DD-9) — cortex verifies **every** registry response (descriptor, roster, principal) against the pinned registry pubkey before trusting a resolved peer key. An unverified response is rejected. Pass `--registry-pubkey` to pin; omitting it is trust-on-first-use.
+- **Fail-closed on mismatch** (DD-11) — if a peer has both a hand-pinned pubkey and a *different* registry-resolved key, that peer is refused and an alert is raised. A divergence is a drift/attack signal, never a merge.
+- **Cached-roster degradation** (DD-10) — a transient registry outage uses the last-known-good cached roster and warns loudly; federation stays up, it is not silently torn down.
+- **Dry-run by default** — `join`/`leave` never mutate the live deployment without `--apply`.
+
+**Security ramp is orthogonal to join** (DD-7). Joining works at any signing posture (`off → permissive → enforce`); ramping signing changes the crypto verification on the *data plane*, never who you are joined to. Confidentiality (mTLS on the leaf, payload encryption) is a separate axis — see [`docs/runbook-federation-peering.md`](./runbook-federation-peering.md) §"After the test works".
+
+---
+
+## Scopes — local / federated / public
+
+This SOP covers the **federated** scope (joining a named network of peer principals). The other two onboarding tiers (CONTEXT.md §Scope, spec §3):
+
+- **local** — a stack's own bus (loopback nats-server); the home broadcast domain. **Zero-config** — it is home, the runtime's primary link. Nothing to join.
+- **federated** — a named network of peer principals. **This SOP** — registry-mediated `cortex network join <network>`.
+- **public** — the open square (the Internet of Agentic Work); unrestricted, carries no principal/stack segment. Opt-in publish/discover of capabilities openly. See **S5 / #739** for the public-scope opt-in.
+
+---
+
+## When the one command is not enough
+
+Reach for the manual fallback in [`docs/runbook-federation-peering.md`](./runbook-federation-peering.md) (#728) only when:
+
+- there is **no reachable registry** for the network, or
+- you need an **offline hand-pin** of a peer (DD-5's fallback: a `principal_pubkey` pasted out-of-band), or
+- you are bringing up a **brand-new network/hub** before its descriptor exists in the registry.
+
+Otherwise, the one command above is the path. If a join step still demands NATS/PKI expertise, that is a design bug (spec §9) — file it against #733.


### PR DESCRIPTION
Closes #740
Refs #733

Phase C · spec §6 F6 of the Network Join Control Plane epic. **Docs only — no code touched.**

## What this adds

The §1 friction table (~10 manual steps across four Myelin layers + two config files + an out-of-band key swap) is now **one command**. This documents the shipped S1–S4 control plane.

| File | Change |
|---|---|
| `docs/sop-network-join.md` | **New.** The one-command join SOP — house-style pre-flight line, `register → join → status` in ≤3 steps (the spec §9 "feel like TCP/IP" test), `leave` covered, security posture (DD-5/DD-9/DD-10/DD-11 + dry-run-default). |
| `docs/adr/0003-network-join-control-plane.md` | **New.** Promotes **DD-1** (additive control plane), **DD-2** (registry source of truth), **DD-9** (pin+verify), **DD-10** (cached-roster), **DD-11** (fail-closed mismatch), **DD-12** (registry-served descriptor) to **binding**; references the spec; notes DD-3..DD-8 stay descriptive. |
| `CONTEXT.md` §Scope/§Network | Reference the join control plane + the three `local`/`federated`/`public` onboarding tiers (spec §3). One canonical term per concept. |
| `docs/runbook-federation-peering.md` (#728) | **SUPERSEDED** banner → points to the one-command flow; kept as the offline / hand-pin fallback. Notes the public NATS hub makes the cloudflared reachability section moot for the 2-party case. |

S5 public scope referenced generically (**S5/#739**); does not depend on its merge.

## Verification

- **Every documented command/flag verified against the shipped CLI** — `src/cli/cortex/commands/network.ts` (`topLevelHelp()` + the join/leave/status SPEC) and `provision-stack.ts` (register subcommand), not from the spec alone. SOP flags match the shipped `--principal/--registry-url/--registry-pubkey/--seed-path/--creds/--account/--nats-config/--plist/--stack/--leaf-node/--max-hop/--apply/--json` set; `--apply`/dry-run-default confirmed in `resolveApply`.
- `bunx tsc --noEmit` → **0 errors**.
- **Vocab carve-out gate** (`scripts/check-carveouts.sh`) → **PASS**, whole-tree and diff-mode. Zero bare `operator` in the new SOP/ADR/banner; wrote `principal`/`stack`/`network` per CONTEXT.md.
- `bun test` → **4548 pass / 0 fail / 2 skip**.
- ESLint unaffected (TS-only; no code touched). Compass governance validator (`label-check.ts`) is repo-label-scoped, unaffected.

## Notes / deviations

- **SOP placement:** written to `docs/sop-network-join.md`, not `compass/sops/`. compass is a **separate repo**; cortex hosts its own SOPs under `docs/sop-*.md` (siblings: `sop-federation-onboarding.md`, `sop-network-registry.md`), and the runbook being superseded lives in cortex `docs/`. This follows the repo's actual SOP convention (the task's "or `docs/sops/` per the repo's convention" carve-out).\n- **CONTEXT.md sections:** there are no literal `§Scope`/`§Network` headers; those concepts live in the **Scope** and **Network** glossary entries under §Language — both updated.\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)