### PR TITLE
feat(federation): S5 — public scope opt-in (IoAW)

### DIFF
--- a/src/bus/__tests__/surface-router.test.ts
+++ b/src/bus/__tests__/surface-router.test.ts
@@ -25,10 +25,12 @@ import { validateEnvelope } from "../myelin/envelope-validator";
 import {
   createSurfaceRouter,
   evaluateFederationGate,
+  evaluatePublicGate,
   evaluateVisibility,
   subjectMatches,
   type SurfaceAdapter,
 } from "../surface-router";
+import type { PolicyPublic } from "../../common/types/cortex-config";
 import type { SystemEventSource } from "../system-events";
 
 // ---------------------------------------------------------------------------
@@ -957,9 +959,23 @@ describe("evaluateVisibility — pure rule predicate", () => {
   });
 });
 
+// S5 (#739) — these visibility tests dispatch `public.*` envelopes to exercise
+// the VISIBILITY filter (not the public gate). After S5 the public gate is
+// deny-by-default, so they must first opt into the public scope and allowlist
+// the test envelope's source principal (`metafactory`, from `makeEnvelope`'s
+// default source `metafactory.pilot.local`) — otherwise the public gate drops
+// them BEFORE the visibility filter under test ever runs.
+const PUBLIC_VISIBILITY_OPTIN: PolicyPublic = {
+  enabled: true,
+  allow_principals: ["metafactory"],
+  announce_capabilities: [],
+};
+
 describe("createSurfaceRouter — visibility filter wiring", () => {
   test("adapter with no visibility config receives every envelope (back-compat)", async () => {
-    const router = createSurfaceRouter(fakeRuntime());
+    const router = createSurfaceRouter(fakeRuntime(), {
+      public: PUBLIC_VISIBILITY_OPTIN,
+    });
     const a = recordingAdapter({ id: "a", subjects: [">"] });
     router.register(a.adapter);
 
@@ -1146,6 +1162,7 @@ describe("createSurfaceRouter — visibility filter wiring", () => {
     const fake = fakeRuntimeWithPublishLog();
     const router = createSurfaceRouter(fake.runtime, {
       systemEventSource: TEST_SYSTEM_EVENT_SOURCE,
+      public: PUBLIC_VISIBILITY_OPTIN,
     });
     const a = recordingAdapter({
       id: "federation-surface",
@@ -1225,6 +1242,7 @@ describe("createSurfaceRouter — visibility filter wiring", () => {
     const fake = fakeRuntimeWithPublishLog();
     const router = createSurfaceRouter(fake.runtime, {
       systemEventSource: TEST_SYSTEM_EVENT_SOURCE,
+      public: PUBLIC_VISIBILITY_OPTIN,
     });
     const a = recordingAdapter({
       id: "strict-dashboard",
@@ -2137,6 +2155,203 @@ describe("createSurfaceRouter — F-3d sourceLink threaded into the gate", () =>
       makeFederatedEnvelope(),
       "federated.research-collab.tasks.code-review.ts",
       "leaf-research",
+    );
+    await new Promise((r) => setTimeout(r, 0));
+    expect(a.calls).toHaveLength(1);
+  });
+});
+
+// ===========================================================================
+// S5 (#739) — public-scope allowlist gate (OQ1 safe default)
+// ===========================================================================
+
+// A `public.*` envelope carries NO principal/stack on the SUBJECT (scope grammar:
+// `public.{domain}.{entity}.{action}`). The gate keys on the SOURCE principal
+// (the signing identity, leading segment of `envelope.source`), NOT the subject.
+function makePublicEnvelope(sourcePrincipal: string): Envelope {
+  return makeEnvelope({
+    source: `${sourcePrincipal}.somestack.someagent`,
+    sovereignty: {
+      classification: "public",
+      data_residency: "NZ",
+      max_hop: 0,
+      frontier_ok: true,
+      model_class: "any",
+    },
+  });
+}
+
+describe("evaluatePublicGate — OQ1 safe default (deny-by-default)", () => {
+  test("no policy.public block → drop (not opted in; never auto-trusted)", () => {
+    const decision = evaluatePublicGate(
+      "public.tasks.code-review.typescript",
+      makePublicEnvelope("stranger"),
+      undefined,
+    );
+    expect(decision).toMatchObject({ kind: "public_not_enabled" });
+  });
+
+  test("enabled:false → drop even with a populated allowlist", () => {
+    const pub: PolicyPublic = {
+      enabled: false,
+      allow_principals: ["jc"],
+      announce_capabilities: [],
+    };
+    const decision = evaluatePublicGate(
+      "public.tasks.code-review.typescript",
+      makePublicEnvelope("jc"),
+      pub,
+    );
+    expect(decision).toMatchObject({ kind: "public_not_enabled" });
+  });
+
+  test("enabled:true + empty allowlist → drop (trust nobody, NOT everybody)", () => {
+    const pub: PolicyPublic = {
+      enabled: true,
+      allow_principals: [],
+      announce_capabilities: [],
+    };
+    const decision = evaluatePublicGate(
+      "public.tasks.code-review.typescript",
+      makePublicEnvelope("anyone"),
+      pub,
+    );
+    expect(decision).toMatchObject({ kind: "public_sender_not_allowlisted" });
+  });
+
+  test("enabled:true + sender NOT in allowlist → drop (no open anonymous claim)", () => {
+    const pub: PolicyPublic = {
+      enabled: true,
+      allow_principals: ["jc"],
+      announce_capabilities: [],
+    };
+    const decision = evaluatePublicGate(
+      "public.tasks.code-review.typescript",
+      makePublicEnvelope("attacker"),
+      pub,
+    );
+    expect(decision).toMatchObject({
+      kind: "public_sender_not_allowlisted",
+      sourcePrincipal: "attacker",
+    });
+  });
+
+  test("enabled:true + sender IN allowlist → allow", () => {
+    const pub: PolicyPublic = {
+      enabled: true,
+      allow_principals: ["jc", "joel"],
+      announce_capabilities: [],
+    };
+    const decision = evaluatePublicGate(
+      "public.tasks.code-review.typescript",
+      makePublicEnvelope("joel"),
+      pub,
+    );
+    expect(decision).toBe("allow");
+  });
+
+  test("non-public subject → allow (gate is scoped to public.* only)", () => {
+    // Defensive: the gate is only called for public.* subjects, but a
+    // federated/local subject must never be denied by THIS gate.
+    const decision = evaluatePublicGate(
+      "federated.andreas.main.tasks.code-review.ts",
+      makePublicEnvelope("andreas"),
+      { enabled: true, allow_principals: [], announce_capabilities: [] },
+    );
+    expect(decision).toBe("allow");
+  });
+});
+
+describe("evaluatePublicGate — no-principal-segment scope does NOT trip federated peer checks", () => {
+  test("a public.* subject is never routed through the federated peer/network resolution", () => {
+    // The federated gate resolves the SOURCE network from peers[]; if a public
+    // subject leaked into evaluateFederationGate it would be denied as an
+    // unknown_network. Confirm the PUBLIC gate decides public.* purely on the
+    // allowlist — it neither needs nor consults any federated network/peer.
+    const pub: PolicyPublic = {
+      enabled: true,
+      allow_principals: ["jc"],
+      announce_capabilities: [],
+    };
+    // `jc` is allowlisted on PUBLIC but is in NO federated network's peers[].
+    const decision = evaluatePublicGate(
+      "public.tasks.code-review.typescript",
+      makePublicEnvelope("jc"),
+      pub,
+    );
+    expect(decision).toBe("allow");
+
+    // And the federated gate, fed the SAME public subject, would (defensively)
+    // allow-pass it untouched — it is out of the federated domain. This proves
+    // the two gates are disjoint: public never enters federated peer logic.
+    const fedDecision = evaluateFederationGate(
+      "public.tasks.code-review.typescript",
+      makePublicEnvelope("jc"),
+      networksMap([makeNetwork()]),
+    );
+    expect(fedDecision).toBe("allow");
+  });
+});
+
+describe("createSurfaceRouter — public gate threaded into dispatch", () => {
+  test("public.* dropped when not opted in (no adapter render)", async () => {
+    const router = createSurfaceRouter(fakeRuntime(), {});
+    const a = recordingAdapter({ id: "a", subjects: ["public.>"] });
+    router.register(a.adapter);
+    await router.start();
+
+    await router.dispatch(
+      makePublicEnvelope("stranger"),
+      "public.tasks.code-review.typescript",
+    );
+    await new Promise((r) => setTimeout(r, 0));
+    expect(a.calls).toHaveLength(0);
+  });
+
+  test("public.* dropped when sender not allowlisted (no adapter render)", async () => {
+    const router = createSurfaceRouter(fakeRuntime(), {
+      public: { enabled: true, allow_principals: ["jc"], announce_capabilities: [] },
+    });
+    const a = recordingAdapter({ id: "a", subjects: ["public.>"] });
+    router.register(a.adapter);
+    await router.start();
+
+    await router.dispatch(
+      makePublicEnvelope("attacker"),
+      "public.tasks.code-review.typescript",
+    );
+    await new Promise((r) => setTimeout(r, 0));
+    expect(a.calls).toHaveLength(0);
+  });
+
+  test("public.* admitted when sender is allowlisted (adapter renders)", async () => {
+    const router = createSurfaceRouter(fakeRuntime(), {
+      public: { enabled: true, allow_principals: ["jc"], announce_capabilities: [] },
+    });
+    const a = recordingAdapter({ id: "a", subjects: ["public.>"] });
+    router.register(a.adapter);
+    await router.start();
+
+    await router.dispatch(
+      makePublicEnvelope("jc"),
+      "public.tasks.code-review.typescript",
+    );
+    await new Promise((r) => setTimeout(r, 0));
+    expect(a.calls).toHaveLength(1);
+  });
+
+  test("federated.* dispatch is unchanged by the presence of a public block", async () => {
+    const router = createSurfaceRouter(fakeRuntime(), {
+      federated: { networks: [makeNetwork()] },
+      public: { enabled: true, allow_principals: ["jc"], announce_capabilities: [] },
+    });
+    const a = recordingAdapter({ id: "a", subjects: ["federated.research-collab.>"] });
+    router.register(a.adapter);
+    await router.start();
+
+    await router.dispatch(
+      makeFederatedEnvelope(),
+      "federated.research-collab.tasks.code-review.typescript",
     );
     await new Promise((r) => setTimeout(r, 0));
     expect(a.calls).toHaveLength(1);

--- a/src/bus/surface-router.ts
+++ b/src/bus/surface-router.ts
@@ -35,6 +35,7 @@
 import type {
   PolicyFederated,
   PolicyFederatedNetwork,
+  PolicyPublic,
   RendererVisibility,
 } from "../common/types/cortex-config";
 import {
@@ -156,6 +157,24 @@ export interface SurfaceRouterOptions {
    * gates handle those).
    */
   federated?: PolicyFederated;
+  /**
+   * IAW S5 (#739) — the `policy.public` block. When the principal has opted
+   * into the public scope (`cortex network join public`), this carries the
+   * inbound allowlist. The router gates every inbound `public.*` envelope
+   * against {@link evaluatePublicGate}:
+   *
+   *   - block ABSENT or `enabled: false` → inbound `public.*` is DROPPED
+   *     (not opted in; a public sender is never auto-trusted).
+   *   - `enabled: true` → admit ONLY senders whose source principal is in
+   *     `allow_principals[]` (empty = drop everyone — OQ1 safe default; no
+   *     open anonymous claim).
+   *
+   * This closes the OQ1 gap the pre-S5 router left open ("none for public" in
+   * the dispatch comment): public inbound was previously ungated. Announcing
+   * capabilities to the registry is a separate control-plane action and does
+   * NOT relax this gate.
+   */
+  public?: PolicyPublic;
 }
 
 export interface SurfaceRouter {
@@ -288,6 +307,11 @@ export function createSurfaceRouter(
     federatedNetworksById.set(network.id, network);
   }
 
+  // IAW S5 (#739) — the public-scope opt-in + allowlist. Captured once at
+  // construction (same reload contract as `federated`). `undefined` ⇒ not
+  // opted into public; the gate drops all inbound `public.*`.
+  const policyPublic: PolicyPublic | undefined = opts?.public;
+
   let started = false;
   let stopped = false;
   let envelopeReg: { unregister: () => void } | null = null;
@@ -393,6 +417,36 @@ export function createSurfaceRouter(
           // audit envelope above is the principal's only signal that
           // this dispatch was attempted; without it the deny is
           // silent.
+          return;
+        }
+      }
+
+      // IAW S5 (#739) — the public-scope gate. CLOSES the OQ1 gap the pre-S5
+      // router left open (the comment above used to read "none for public"):
+      // inbound `public.*` was previously ungated, so any public sender was
+      // implicitly trusted. Now it is DENY-BY-DEFAULT — dropped unless the
+      // principal opted into the public scope AND the sender's source principal
+      // is on the allowlist. This is a SEPARATE branch from the federated gate
+      // (above): `public.*` carries no `{principal}.{stack}` segment, so it must
+      // NOT be routed through the federated peer/network resolution (a different
+      // trust tier, not a federated peer — wire-protocol SOP check #5). Local
+      // (`local.*`) subjects are unaffected — `evaluatePublicGate` only gates
+      // `public.*` and the visibility filter governs local rendering.
+      if (effectiveSubject.startsWith("public.")) {
+        const decision = evaluatePublicGate(
+          effectiveSubject,
+          envelope,
+          policyPublic,
+        );
+        if (decision !== "allow") {
+          emitPublicDenied(
+            runtime,
+            systemEventSource,
+            envelope,
+            effectiveSubject,
+            decision,
+          );
+          // Hard drop — a non-allowlisted public sender never reaches adapters.
           return;
         }
       }
@@ -895,6 +949,84 @@ export function evaluateFederationGate(
   return "allow";
 }
 
+// ===========================================================================
+// S5 (#739) — public-scope allowlist gate (OQ1 safe default)
+// ===========================================================================
+
+/**
+ * The decision the public gate returns. `"allow"` admits the envelope; any
+ * object is a deny carrying a searchable reason for the audit stream.
+ *
+ *   - `public_not_enabled` — the stack has not opted into the public scope
+ *     (`policy.public` absent or `enabled: false`). Inbound `public.*` is
+ *     dropped. Opting in to ANNOUNCE capabilities to the registry does NOT
+ *     enable inbound public trust — that is a separate control-plane action.
+ *   - `public_sender_not_allowlisted` — the stack IS opted in, but the
+ *     envelope's SOURCE principal is not in `allow_principals[]` (this
+ *     includes the empty-allowlist case: "trust nobody on public"). This is
+ *     the OQ1 safe gate: a non-allowlisted public sender is NEVER auto-trusted;
+ *     open anonymous claim is deferred to the security ramp.
+ */
+export type PublicGateDecision =
+  | "allow"
+  | { kind: "public_not_enabled" }
+  | { kind: "public_sender_not_allowlisted"; sourcePrincipal: string };
+
+/**
+ * IAW S5 (#739) — gate an inbound `public.*` envelope against the principal's
+ * `policy.public` opt-in + allowlist. The OQ1 SAFE DEFAULT in code:
+ *
+ *   policy.public absent / enabled:false  → DENY (public_not_enabled)
+ *   enabled:true, allow_principals = []    → DENY (public_sender_not_allowlisted)
+ *   enabled:true, sender ∉ allow_principals → DENY (public_sender_not_allowlisted)
+ *   enabled:true, sender ∈ allow_principals → ALLOW
+ *
+ * ## Trust tier — NOT a federated peer (wire-protocol SOP check #5)
+ *
+ * `public.*` carries NO `{principal}.{stack}` segment on the subject (scope
+ * grammar: `public.{domain}.{entity}.{action}`, CONTEXT.md §Scope). So this
+ * gate is DISJOINT from {@link evaluateFederationGate}: it never resolves a
+ * source NETWORK from `peers[]`, never runs the leaf anti-spoof cross-check,
+ * and never reads a target principal off the subject. It keys ONLY on the
+ * SOURCE principal (the signing identity — leading segment of
+ * `envelope.source`, via {@link principalFromEnvelope}) against the public
+ * allowlist. Public is a different trust tier, not a federated peer; mixing
+ * the two would mis-apply the federated peer checks to the no-principal-segment
+ * scope (the precise failure the S5 brief calls out).
+ *
+ * Pure function — exported so tests can probe each branch without a runtime.
+ * Defensive: a NON-`public.` subject returns `"allow"` (the caller only ever
+ * routes `public.*` here; a leaked federated/local subject must not be denied
+ * by THIS gate — its own gate governs it).
+ */
+export function evaluatePublicGate(
+  subject: string,
+  envelope: Envelope,
+  policyPublic: PolicyPublic | undefined,
+): PublicGateDecision {
+  // Out of the public domain — not ours to gate. The caller guards on the
+  // prefix; this fail-open (for THIS gate) keeps standalone tests of
+  // local/federated subjects from being denied here.
+  if (!subject.startsWith("public.")) {
+    return "allow";
+  }
+
+  // Not opted in → drop. Absence and `enabled: false` are identical: the stack
+  // is not accepting inbound public traffic. (Announcing capabilities to the
+  // registry is a control-plane action that does not flip this.)
+  if (!policyPublic?.enabled) {
+    return { kind: "public_not_enabled" };
+  }
+
+  // Opted in — admit ONLY allowlisted source principals. An empty allowlist
+  // means "trust nobody on public" (deny-by-default), NOT "trust everybody".
+  const sourcePrincipal = principalFromEnvelope(envelope);
+  if (!policyPublic.allow_principals.includes(sourcePrincipal)) {
+    return { kind: "public_sender_not_allowlisted", sourcePrincipal };
+  }
+  return "allow";
+}
+
 /**
  * Emit a `system.access.denied` envelope describing a federation-gate
  * rejection. Mirrors `emitAccessFiltered` — best-effort, runtime
@@ -1006,6 +1138,43 @@ export function emitFederationDenied(
       err instanceof Error ? err.message : err,
     );
   }
+}
+
+/**
+ * IAW S5 (#739) — observe a public-gate denial. The SECURITY property (a
+ * non-allowlisted public sender never reaches an adapter) is enforced by the
+ * hard-drop in `dispatch`; this is the OBSERVABILITY of that drop.
+ *
+ * Bounded by design: it logs the denial rather than emitting a fully-typed
+ * `system.access.denied` envelope. The existing
+ * `createSystemAccessFederationDeniedEvent` reason union is FEDERATION-specific
+ * (`peer_not_in_accept_list` / `source_link_mismatch` / `max_hop_exceeded`),
+ * and reusing it for a public deny would mislabel a public-tier drop as a
+ * federated-peer rejection — exactly the trust-tier confusion the S5 brief
+ * warns against. A dedicated `public_denied` audit-event variant is a
+ * follow-up (tracked against the OQ1 security-ramp work); S5 keeps the gate's
+ * observability to a structured log line and leaves the typed audit envelope
+ * to the phase that also decides open-claim/enforce.
+ *
+ * No-op-safe: `source` is accepted for signature-symmetry with
+ * {@link emitFederationDenied} (so a future typed-envelope upgrade is a
+ * drop-in) but is not required to log.
+ */
+export function emitPublicDenied(
+  _runtime: MyelinRuntime,
+  _source: SystemEventSource | undefined,
+  _envelope: Envelope,
+  envelopeSubject: string,
+  decision: Exclude<PublicGateDecision, "allow">,
+): void {
+  const detail =
+    decision.kind === "public_sender_not_allowlisted"
+      ? `source="${decision.sourcePrincipal}" not in policy.public.allow_principals`
+      : "policy.public absent or enabled:false (not opted into the public scope)";
+  console.info(
+    `surface-router: public deny subject="${envelopeSubject}" reason=${decision.kind} — ${detail} ` +
+      `(OQ1 safe default — dropped, not auto-trusted)`,
+  );
 }
 
 /**

--- a/src/cli/cortex/commands/__tests__/network-cli.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-cli.test.ts
@@ -228,3 +228,104 @@ describe("leave usage", () => {
     expect(res.stdout).toContain("not joined");
   });
 });
+
+// =============================================================================
+// S5 (#739) — `join public` / `leave public` (the open square)
+// =============================================================================
+
+describe("join public usage", () => {
+  test("rejects a malformed --capabilities id (exit 2)", async () => {
+    const dir = freshDir();
+    const res = await dispatchNetwork([
+      "join", "public",
+      "--principal", "andreas",
+      "--registry-url", "http://r.test",
+      "--seed-path", join(dir, "seed.nk"),
+      "--nats-config", join(dir, "local.conf"),
+      "--plist", join(dir, "nats.plist"),
+      "--capabilities", "BAD_CAP",
+    ]);
+    expect(res.exitCode).toBe(2);
+    expect(res.stderr).toContain("capability");
+  });
+
+  test("rejects a malformed --allow principal id (exit 2)", async () => {
+    const dir = freshDir();
+    const res = await dispatchNetwork([
+      "join", "public",
+      "--principal", "andreas",
+      "--registry-url", "http://r.test",
+      "--seed-path", join(dir, "seed.nk"),
+      "--nats-config", join(dir, "local.conf"),
+      "--plist", join(dir, "nats.plist"),
+      "--allow", "BAD_PRINCIPAL",
+    ]);
+    expect(res.exitCode).toBe(2);
+    expect(res.stderr).toContain("allow");
+  });
+
+  test("does NOT require --creds / --account (public has no leaf)", async () => {
+    // The public path validates its OWN required flags — creds/account are
+    // federated-only. Omitting them must NOT surface a creds/account error.
+    const dir = freshDir();
+    const res = await dispatchNetwork([
+      "join", "public",
+      "--principal", "andreas",
+      "--registry-url", "http://127.0.0.1:0", // unreachable by construction
+      "--seed-path", join(dir, "seed.nk"),
+      "--nats-config", join(dir, "local.conf"),
+      "--plist", join(dir, "nats.plist"),
+      "--capabilities", "code-review.typescript",
+    ]);
+    // It will FAIL at announce (no seed / unreachable registry) — exit 1 — but
+    // NOT a usage error about creds/account.
+    expect(res.exitCode).not.toBe(2);
+    expect(res.stderr).not.toContain("--creds");
+    expect(res.stderr).not.toContain("--account");
+  });
+});
+
+describe("join public dry-run safety (OQ1 + no live mutation)", () => {
+  test("dry-run join public writes NOTHING to disk", async () => {
+    const dir = freshDir();
+    const natsConfig = join(dir, "nats", "local.conf");
+    const plist = join(dir, "nats.plist");
+    const uniqueSlug = `s5pub${Date.now().toString()}`;
+
+    const res = await dispatchNetwork([
+      "join", "public",
+      "--principal", "andreas",
+      "--stack", `andreas/${uniqueSlug}`,
+      "--registry-url", "http://127.0.0.1:0",
+      "--seed-path", join(dir, "seed.nk"),
+      "--nats-config", natsConfig,
+      "--plist", plist,
+      "--capabilities", "code-review.typescript",
+    ]);
+
+    // Critical S5 SAFETY: a dry-run touches no disk + no daemon.
+    expect(existsSync(natsConfig)).toBe(false);
+    expect(existsSync(join(dir, "nats"))).toBe(false);
+    expect(existsSync(plist)).toBe(false);
+    // Output carries the dry-run banner.
+    expect(res.stderr + res.stdout).toContain("dry-run");
+  });
+});
+
+describe("leave public", () => {
+  test("leaving public when never joined is a clean no-op (exit 0)", async () => {
+    const dir = freshDir();
+    const uniqueSlug = `s5publeave${Date.now().toString()}`;
+    const res = await dispatchNetwork([
+      "leave", "public",
+      "--principal", "andreas",
+      "--stack", `andreas/${uniqueSlug}`,
+      "--registry-url", "http://127.0.0.1:0",
+      "--seed-path", join(dir, "seed.nk"),
+      "--nats-config", join(dir, "local.conf"),
+      "--plist", join(dir, "nats.plist"),
+    ]);
+    expect(res.exitCode).toBe(0);
+    expect(res.stdout).toContain("nothing to do");
+  });
+});

--- a/src/cli/cortex/commands/__tests__/network-public-lib.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-public-lib.test.ts
@@ -1,0 +1,238 @@
+/**
+ * S5 (Network Join Control Plane, #739, spec F5) — public-scope opt-in
+ * orchestration tests. The open square of the Internet of Agentic Work.
+ *
+ * Every I/O is a FAKE port (no real fs / exec / registry — the S4/S5 SAFETY
+ * rule; dry-run-default). Coverage maps to the S5 brief's TESTS list:
+ *
+ *   - `join public` subscribes `public.>` + announces declared capabilities to
+ *     the registry public capability index (dry-run writes NOTHING).
+ *   - the inbound public gate is allowlist-gated by default — `join public`
+ *     does NOT auto-trust anyone; it writes `policy.public` with
+ *     `enabled:false` (off) OR an explicit allowlist when `--allow` is given,
+ *     and NEVER an open-claim posture.
+ *   - `leave public` reverses: unsubscribe `public.>` + deregister capabilities
+ *     + clear the opt-in.
+ *   - the no-principal-segment scope (`public.>`) doesn't trip the federated
+ *     peer gate — public is a separate trust tier (asserted in the
+ *     surface-router gate tests; here we assert the lib never touches federated
+ *     state).
+ */
+
+import { describe, test, expect } from "bun:test";
+
+import {
+  joinPublic,
+  leavePublic,
+  type PublicJoinInputs,
+} from "../network-public-lib";
+import type {
+  PublicScopePorts,
+  PublicRegistryPort,
+  PublicSubscribePort,
+  PublicPolicyPort,
+} from "../network-public-ports";
+import type { DaemonPort } from "../network-ports";
+import type { PolicyPublic } from "../../../../common/types/cortex-config";
+
+// =============================================================================
+// Fake ports + recorder
+// =============================================================================
+
+interface Recorder {
+  announced: string[][];
+  deregistered: number;
+  subscribed: number;
+  unsubscribed: number;
+  policyWrites: (PolicyPublic | undefined)[];
+  restarts: number;
+}
+
+function makeFakes(opts?: {
+  announceOk?: boolean;
+  restartOk?: boolean;
+  initialSubscribed?: boolean;
+  initialPublic?: PolicyPublic;
+  mutate?: boolean; // false ⇒ dry-run: every WRITE is a no-op (the recorder still logs intent)
+}): { ports: PublicScopePorts; rec: Recorder } {
+  const mutate = opts?.mutate ?? true;
+  const rec: Recorder = {
+    announced: [],
+    deregistered: 0,
+    subscribed: 0,
+    unsubscribed: 0,
+    policyWrites: [],
+    restarts: 0,
+  };
+
+  let subscribed = opts?.initialSubscribed ?? false;
+  let pub: PolicyPublic | undefined = opts?.initialPublic;
+
+  const registry: PublicRegistryPort = {
+    async announceCapabilities(caps) {
+      rec.announced.push([...caps]);
+      return opts?.announceOk === false
+        ? { ok: false, reason: "registry rejected" }
+        : { ok: true, note: "HTTP 201" };
+    },
+    async deregisterCapabilities() {
+      rec.deregistered++;
+      return opts?.announceOk === false
+        ? { ok: false, reason: "registry rejected" }
+        : { ok: true, note: "HTTP 201" };
+    },
+  };
+
+  const subscribe: PublicSubscribePort = {
+    hasPublicSubscription() {
+      return subscribed;
+    },
+    addPublicSubscription() {
+      rec.subscribed++;
+      if (mutate) subscribed = true;
+    },
+    removePublicSubscription() {
+      rec.unsubscribed++;
+      if (mutate) subscribed = false;
+    },
+  };
+
+  const policy: PublicPolicyPort = {
+    readPublic() {
+      return pub;
+    },
+    writePublic(next) {
+      rec.policyWrites.push(next);
+      if (mutate) pub = next;
+    },
+  };
+
+  const daemon: DaemonPort = {
+    async restart() {
+      rec.restarts++;
+      return opts?.restartOk === false
+        ? { ok: false, reason: "launchctl kickstart failed" }
+        : { ok: true };
+    },
+  };
+
+  return { ports: { registry, subscribe, policy, daemon }, rec };
+}
+
+const BASE_INPUTS: PublicJoinInputs = {
+  capabilities: ["code-review.typescript", "research.synthesis"],
+  allowPrincipals: [],
+};
+
+// =============================================================================
+// join public
+// =============================================================================
+
+describe("joinPublic", () => {
+  test("subscribes public.> + announces declared capabilities + restarts", async () => {
+    const { ports, rec } = makeFakes({});
+    const res = await joinPublic(BASE_INPUTS, ports);
+
+    expect(res.ok).toBe(true);
+    // announced the declared capabilities to the registry public index.
+    expect(rec.announced).toEqual([["code-review.typescript", "research.synthesis"]]);
+    // subscribed public.> exactly once.
+    expect(rec.subscribed).toBe(1);
+    // wrote a policy.public block.
+    expect(rec.policyWrites.length).toBe(1);
+    // restarted so the new subscription takes effect.
+    expect(rec.restarts).toBe(1);
+  });
+
+  test("SAFE DEFAULT (OQ1): with no --allow, the opt-in is deny-by-default (enabled:false, empty allowlist)", async () => {
+    const { ports, rec } = makeFakes({});
+    const res = await joinPublic({ capabilities: ["a.b"], allowPrincipals: [] }, ports);
+
+    expect(res.ok).toBe(true);
+    const written = rec.policyWrites[0];
+    expect(written).toBeDefined();
+    // INBOUND public is OFF — announcing/discovering does not open the bus.
+    expect(written?.enabled).toBe(false);
+    expect(written?.allow_principals).toEqual([]);
+    // no "open_claim"/"anonymous" field exists at all — open claim is deferred.
+    expect("open_claim" in (written ?? {})).toBe(false);
+    expect("anonymous" in (written ?? {})).toBe(false);
+  });
+
+  test("with --allow principals, inbound is enabled but ALLOWLIST-gated (not open)", async () => {
+    const { ports, rec } = makeFakes({});
+    const res = await joinPublic(
+      { capabilities: ["a.b"], allowPrincipals: ["jc", "joel"] },
+      ports,
+    );
+
+    expect(res.ok).toBe(true);
+    const written = rec.policyWrites[0];
+    expect(written?.enabled).toBe(true);
+    // ONLY the named principals — a non-allowlisted public sender is NOT trusted.
+    expect(written?.allow_principals).toEqual(["jc", "joel"]);
+  });
+
+  test("idempotent — re-joining when already subscribed does not double-subscribe", async () => {
+    const { ports, rec } = makeFakes({ initialSubscribed: true });
+    const res = await joinPublic(BASE_INPUTS, ports);
+
+    expect(res.ok).toBe(true);
+    // already subscribed → no second addPublicSubscription.
+    expect(rec.subscribed).toBe(0);
+  });
+
+  test("a registry announce failure is fatal (no half-join)", async () => {
+    const { ports, rec } = makeFakes({ announceOk: false });
+    const res = await joinPublic(BASE_INPUTS, ports);
+
+    expect(res.ok).toBe(false);
+    expect(res.reason).toContain("announce");
+    // never restarted on a failed announce.
+    expect(rec.restarts).toBe(0);
+  });
+
+  test("DRY-RUN writes nothing (no subscribe/policy mutation) but records intent + restart is a no-op", async () => {
+    const { ports, rec } = makeFakes({ mutate: false });
+    const res = await joinPublic(BASE_INPUTS, ports);
+
+    expect(res.ok).toBe(true);
+    // intent recorded in the step log + recorder...
+    expect(rec.subscribed).toBe(1);
+    expect(rec.policyWrites.length).toBe(1);
+    // ...but the fake's mutate=false means hasPublicSubscription() is still false
+    // after the call (no real mutation happened).
+    expect(ports.subscribe.hasPublicSubscription()).toBe(false);
+  });
+});
+
+// =============================================================================
+// leave public
+// =============================================================================
+
+describe("leavePublic", () => {
+  test("unsubscribes public.> + deregisters capabilities + clears the opt-in + restarts", async () => {
+    const { ports, rec } = makeFakes({
+      initialSubscribed: true,
+      initialPublic: { enabled: true, allow_principals: ["jc"], announce_capabilities: ["a.b"] },
+    });
+    const res = await leavePublic(ports);
+
+    expect(res.ok).toBe(true);
+    expect(rec.unsubscribed).toBe(1);
+    expect(rec.deregistered).toBe(1);
+    // cleared the policy.public block (undefined = removed).
+    expect(rec.policyWrites).toEqual([undefined]);
+    expect(rec.restarts).toBe(1);
+  });
+
+  test("idempotent — leaving when never joined is a clean no-op", async () => {
+    const { ports, rec } = makeFakes({ initialSubscribed: false, initialPublic: undefined });
+    const res = await leavePublic(ports);
+
+    expect(res.ok).toBe(true);
+    expect(res.notJoined).toBe(true);
+    expect(rec.unsubscribed).toBe(0);
+    expect(rec.restarts).toBe(0);
+  });
+});

--- a/src/cli/cortex/commands/network-adapters.ts
+++ b/src/cli/cortex/commands/network-adapters.ts
@@ -48,7 +48,10 @@ import {
   materialFromSeedString,
   registerStackIdentity,
 } from "../../../bus/stack-provisioning";
-import type { PolicyFederatedNetwork } from "../../../common/types/cortex-config";
+import type {
+  PolicyFederatedNetwork,
+  PolicyPublic,
+} from "../../../common/types/cortex-config";
 
 import type {
   ConfigStorePort,
@@ -60,6 +63,12 @@ import type {
   PlistPort,
   RenderLeafInputs,
 } from "./network-ports";
+import type {
+  PublicPolicyPort,
+  PublicRegistryPort,
+  PublicScopePorts,
+  PublicSubscribePort,
+} from "./network-public-ports";
 
 /** Everything the live adapters need, threaded from the CLI flags. */
 export interface LivePortsConfig {
@@ -78,6 +87,49 @@ export interface LivePortsConfig {
 // Registry port — S1 client + provision-stack register (proof-of-possession).
 // =============================================================================
 
+/**
+ * Shared idempotent proof-of-possession registration (reused by the S4
+ * `registerStack` and the S5 public-index announce/deregister). Loads the seed,
+ * builds + signs the claim with the supplied `capabilities`, and POSTs it. An
+ * EMPTY `capabilities` list de-advertises the stack on the public index
+ * (the registry searches over the claim's `capabilities`). Never throws.
+ */
+async function registerWithCapabilities(
+  cfg: LivePortsConfig,
+  capabilities: { id: string }[],
+): Promise<{ ok: true; note: string } | { ok: false; reason: string }> {
+  const url = cfg.registryUrl ?? "";
+  if (cfg.seedPath === undefined) {
+    return { ok: false, reason: "no --seed-path for registration" };
+  }
+  const seedFile = expandTilde(cfg.seedPath);
+  if (!existsSync(seedFile)) {
+    return { ok: false, reason: `seed file not found at ${seedFile}` };
+  }
+  let material;
+  try {
+    material = materialFromSeedString(readFileSync(seedFile, "utf-8"));
+  } catch (err) {
+    return { ok: false, reason: `seed load failed: ${err instanceof Error ? err.message : String(err)}` };
+  }
+  const body = await buildRegistrationClaim({
+    principalId: cfg.principalId,
+    material,
+    stacks: [{ stack_id: cfg.stackId }],
+    capabilities,
+  });
+  let result;
+  try {
+    result = await registerStackIdentity({ registryUrl: url, principalId: cfg.principalId, body });
+  } catch (err) {
+    return { ok: false, reason: `registry POST failed: ${err instanceof Error ? err.message : String(err)}` };
+  }
+  if (!result.ok) {
+    return { ok: false, reason: `registry rejected registration (HTTP ${result.status.toString()})` };
+  }
+  return { ok: true, note: `HTTP ${result.status.toString()}` };
+}
+
 function buildRegistryPort(cfg: LivePortsConfig): NetworkRegistryPort {
   const url = cfg.registryUrl ?? "";
   const client = new NetworkRegistryClient({
@@ -87,34 +139,8 @@ function buildRegistryPort(cfg: LivePortsConfig): NetworkRegistryPort {
 
   return {
     async registerStack() {
-      if (cfg.seedPath === undefined) {
-        return { ok: false, reason: "no --seed-path for registration" };
-      }
-      const seedFile = expandTilde(cfg.seedPath);
-      if (!existsSync(seedFile)) {
-        return { ok: false, reason: `seed file not found at ${seedFile}` };
-      }
-      let material;
-      try {
-        material = materialFromSeedString(readFileSync(seedFile, "utf-8"));
-      } catch (err) {
-        return { ok: false, reason: `seed load failed: ${err instanceof Error ? err.message : String(err)}` };
-      }
-      const body = await buildRegistrationClaim({
-        principalId: cfg.principalId,
-        material,
-        stacks: [{ stack_id: cfg.stackId }],
-      });
-      let result;
-      try {
-        result = await registerStackIdentity({ registryUrl: url, principalId: cfg.principalId, body });
-      } catch (err) {
-        return { ok: false, reason: `registry POST failed: ${err instanceof Error ? err.message : String(err)}` };
-      }
-      if (!result.ok) {
-        return { ok: false, reason: `registry rejected registration (HTTP ${result.status.toString()})` };
-      }
-      return { ok: true, note: `HTTP ${result.status.toString()}` };
+      // S4 federated register — proof-of-possession with no capability change.
+      return registerWithCapabilities(cfg, []);
     },
     fetchVerified(networkId) {
       // S1's fetchAndCache returns { descriptor, roster } on ok and refreshes
@@ -360,4 +386,131 @@ export function buildLivePorts(cfg: LivePortsConfig): NetworkPorts {
  */
 export function buildDryRunPorts(cfg: LivePortsConfig): NetworkPorts {
   return buildPorts(cfg, false);
+}
+
+// =============================================================================
+// S5 (#739) — public-scope adapters (join/leave public)
+// =============================================================================
+
+/**
+ * The system-layer config file that carries `nats.subjects[]` — `system/system.yaml`
+ * under the cortex config dir (the config-split puts the transport block in the
+ * system layer, NOT the stack file — the double-message structural fix). The
+ * `public.>` subscription is added/removed here.
+ */
+function systemConfigPath(): string {
+  return join(expandTilde("~/.config/cortex"), "system", "system.yaml");
+}
+
+/** The literal `public.>` subscribe pattern. */
+const PUBLIC_SUBSCRIBE = "public.>";
+
+// S5 — public capability announce/deregister: re-register the stack with (caps)
+// or (empty) so the registry's `/capabilities` public index includes/drops it.
+function buildPublicRegistryPort(cfg: LivePortsConfig): PublicRegistryPort {
+  return {
+    async announceCapabilities(capabilities) {
+      return registerWithCapabilities(
+        cfg,
+        capabilities.map((id) => ({ id })),
+      );
+    },
+    async deregisterCapabilities() {
+      // De-advertise — register with an EMPTY capability list.
+      return registerWithCapabilities(cfg, []);
+    },
+  };
+}
+
+// S5 — manage `public.>` in system.yaml's `nats.subjects[]`.
+function buildPublicSubscribePort(mutate: boolean): PublicSubscribePort {
+  const path = systemConfigPath();
+  const readSubjects = (): string[] => {
+    if (!existsSync(path)) return [];
+    const raw = parseYaml(readFileSync(path, "utf-8")) as
+      | { nats?: { subjects?: string[] } }
+      | null;
+    return raw?.nats?.subjects ?? [];
+  };
+  return {
+    hasPublicSubscription() {
+      return readSubjects().includes(PUBLIC_SUBSCRIBE);
+    },
+    addPublicSubscription() {
+      if (!mutate) return;
+      const raw = existsSync(path)
+        ? ((parseYaml(readFileSync(path, "utf-8")) ?? {}) as Record<string, unknown>)
+        : {};
+      const nats = (raw.nats ??= {}) as Record<string, unknown>;
+      const subjects = Array.isArray(nats.subjects) ? (nats.subjects as string[]) : [];
+      // Idempotent — never double-bind (the cortex#491 double-message footgun).
+      if (!subjects.includes(PUBLIC_SUBSCRIBE)) subjects.push(PUBLIC_SUBSCRIBE);
+      nats.subjects = subjects;
+      mkdirSync(dirname(path), { recursive: true });
+      writeFileSync(path, stringifyYaml(raw), "utf-8");
+    },
+    removePublicSubscription() {
+      if (!mutate) return;
+      if (!existsSync(path)) return;
+      const raw = (parseYaml(readFileSync(path, "utf-8")) ?? {}) as Record<string, unknown>;
+      const nats = raw.nats as { subjects?: string[] } | undefined;
+      if (nats?.subjects === undefined) return;
+      nats.subjects = nats.subjects.filter((s) => s !== PUBLIC_SUBSCRIBE);
+      writeFileSync(path, stringifyYaml(raw), "utf-8");
+    },
+  };
+}
+
+// S5 — read/write `policy.public` in the stack file (same file S4's
+// ConfigStorePort writes policy.federated.networks[] to).
+function buildPublicPolicyPort(cfg: LivePortsConfig, mutate: boolean): PublicPolicyPort {
+  const path = stackConfigPath(cfg);
+  return {
+    readPublic() {
+      if (!existsSync(path)) return undefined;
+      const raw = parseYaml(readFileSync(path, "utf-8")) as
+        | { policy?: { public?: PolicyPublic } }
+        | null;
+      return raw?.policy?.public;
+    },
+    writePublic(next) {
+      if (!mutate) return;
+      const raw = existsSync(path)
+        ? ((parseYaml(readFileSync(path, "utf-8")) ?? {}) as Record<string, unknown>)
+        : {};
+      const policy = (raw.policy ??= {}) as Record<string, unknown>;
+      if (next === undefined) {
+        // Leave teardown — drop the block entirely.
+        delete (policy as { public?: unknown }).public;
+      } else {
+        (policy as { public?: unknown }).public = next;
+      }
+      mkdirSync(dirname(path), { recursive: true });
+      writeFileSync(path, stringifyYaml(raw), "utf-8");
+    },
+  };
+}
+
+function buildPublicPorts(cfg: LivePortsConfig, mutate: boolean): PublicScopePorts {
+  return {
+    registry: buildPublicRegistryPort(cfg),
+    subscribe: buildPublicSubscribePort(mutate),
+    policy: buildPublicPolicyPort(cfg, mutate),
+    daemon: buildDaemonPort(cfg, mutate),
+  };
+}
+
+/** Live public-scope ports — mutate system.yaml + stack config. `--apply` only. */
+export function buildLivePublicPorts(cfg: LivePortsConfig): PublicScopePorts {
+  return buildPublicPorts(cfg, true);
+}
+
+/**
+ * Dry-run public-scope ports — the S5 default-safe posture. Reads hit disk (so
+ * idempotency checks like `hasPublicSubscription` are accurate); every
+ * WRITE/RESTART is a no-op. An accidental `join public` during development
+ * touches nothing.
+ */
+export function buildDryRunPublicPorts(cfg: LivePortsConfig): PublicScopePorts {
+  return buildPublicPorts(cfg, false);
 }

--- a/src/cli/cortex/commands/network-public-lib.ts
+++ b/src/cli/cortex/commands/network-public-lib.ts
@@ -1,0 +1,198 @@
+/**
+ * S5 (Network Join Control Plane, #739, spec F5) — `join/leave public`
+ * orchestration, pure over {@link PublicScopePorts}.
+ *
+ * The PUBLIC scope is the open square of the Internet of Agentic Work (design
+ * §3): unrestricted reach, and — uniquely — it carries NO `{principal}.{stack}`
+ * segment on the wire (`public.{domain}.{entity}.{action}`, CONTEXT.md §Scope).
+ * A stack opts in EXPLICITLY with `cortex network join public`.
+ *
+ * ## What opting in does (bounded — F5)
+ *
+ *   (a) announce the stack's declared capabilities to the registry's PUBLIC
+ *       capability index (so peers can discover them),
+ *   (b) subscribe `public.>` (add it to `nats.subjects[]`),
+ *   (c) write the `policy.public` opt-in block — the INBOUND allowlist gate,
+ *   (d) restart the daemon so the subscription takes effect.
+ *
+ * ## OQ1 — the safe-by-default gate (the deferred abuse story)
+ *
+ * Spec OQ1 leaves the public-scope abuse model OPEN: anonymous offer/claim on
+ * `public.>` needs a spam/abuse story before it can be enabled beyond an
+ * allowlist. So step (c) is DENY-BY-DEFAULT:
+ *
+ *   - no `--allow` → `policy.public.enabled = false`. The stack ANNOUNCES and
+ *     can DISCOVER on the public index, but the surface-router DROPS all
+ *     inbound `public.*` — announcing is not a trust grant.
+ *   - `--allow jc,joel` → `enabled = true`, `allow_principals = [jc, joel]`.
+ *     Inbound public traffic is admitted ONLY from those signing principals.
+ *
+ * There is NO open-claim / anonymous path: a non-allowlisted public sender is
+ * NEVER auto-trusted. Open anonymous claim on `public.>` is OUT OF SCOPE for S5
+ * — a later decision on the security ramp (DD-7), gated on the OQ1 abuse story.
+ *
+ * ## Trust tier — public is NOT a federated peer
+ *
+ * This flow touches NO federated state (`policy.federated.networks[]`, peers,
+ * leaf links). Public is a separate trust tier; the inbound gate
+ * (`evaluatePublicGate`, surface-router) keys on the SENDER's source principal
+ * against the public allowlist, never on a federated network/peer resolution.
+ * Keeping the orchestration disjoint here is the lib-side half of that
+ * guarantee (the gate-side half is in `surface-router.ts`).
+ *
+ * Never throws — every failure becomes a `{ ok: false, reason }`.
+ */
+
+import type { PolicyPublic } from "../../../common/types/cortex-config";
+import type { PublicScopePorts } from "./network-public-ports";
+
+// =============================================================================
+// Inputs + results
+// =============================================================================
+
+/** What `cortex network join public` supplies to the orchestration. */
+export interface PublicJoinInputs {
+  /**
+   * Capability ids to announce to the public index (`<domain>.<entity>` grammar,
+   * validated by the CLI). Empty = "discoverable presence, no advertised
+   * capabilities".
+   */
+  capabilities: readonly string[];
+  /**
+   * Allowlist of public-scope SENDER principal ids (`--allow`). When EMPTY, the
+   * opt-in is written deny-by-default (`enabled: false`) — the OQ1 safe
+   * posture. When non-empty, inbound public is enabled but admits ONLY these
+   * principals.
+   */
+  allowPrincipals: readonly string[];
+}
+
+export interface PublicJoinResult {
+  ok: boolean;
+  /** Ordered, human-readable step log. Rendered by the CLI. */
+  steps: string[];
+  reason?: string;
+  /** The `policy.public` block that was written (on success). */
+  written?: PolicyPublic;
+}
+
+export interface PublicLeaveResult {
+  ok: boolean;
+  steps: string[];
+  reason?: string;
+  /** True when the stack was never opted into public (clean no-op leave). */
+  notJoined?: boolean;
+}
+
+// =============================================================================
+// join public
+// =============================================================================
+
+export async function joinPublic(
+  inputs: PublicJoinInputs,
+  ports: PublicScopePorts,
+): Promise<PublicJoinResult> {
+  const steps: string[] = [];
+
+  // (a) Announce capabilities to the public index. A failure here is fatal:
+  // without a successful announce the stack is not discoverable, and we must
+  // NOT proceed to flip the local bus open (no half-join).
+  const announce = await ports.registry.announceCapabilities(inputs.capabilities);
+  if (!announce.ok) {
+    return { ok: false, steps, reason: `public capability announce failed: ${announce.reason}` };
+  }
+  steps.push(
+    inputs.capabilities.length > 0
+      ? `announced ${inputs.capabilities.length.toString()} capability(ies) to the public index (${announce.note})`
+      : `registered a public presence with no advertised capabilities (${announce.note})`,
+  );
+
+  // (b) Subscribe public.> (idempotent — never double-bind the same pattern,
+  // the cortex#491 double-message footgun).
+  if (ports.subscribe.hasPublicSubscription()) {
+    steps.push("public.> already subscribed — no change");
+  } else {
+    ports.subscribe.addPublicSubscription();
+    steps.push("subscribed public.> (added to nats.subjects[])");
+  }
+
+  // (c) Write the policy.public opt-in — the INBOUND allowlist gate. OQ1 SAFE
+  // DEFAULT: no --allow ⇒ enabled:false (announce/discover only, inbound stays
+  // closed); --allow ⇒ enabled:true gated to the named principals ONLY. Never
+  // an open-claim posture.
+  const enabled = inputs.allowPrincipals.length > 0;
+  const written: PolicyPublic = {
+    enabled,
+    allow_principals: [...inputs.allowPrincipals],
+    announce_capabilities: [...inputs.capabilities],
+  };
+  ports.policy.writePublic(written);
+  steps.push(
+    enabled
+      ? `wrote policy.public — inbound ENABLED, allowlist-gated to [${written.allow_principals.join(", ")}] (no open claim)`
+      : "wrote policy.public — inbound DISABLED (OQ1 safe default: announce/discover only; inbound public stays closed)",
+  );
+
+  // (d) Restart so the new public.> subscription takes effect.
+  const restart = await ports.daemon.restart();
+  if (!restart.ok) {
+    return {
+      ok: false,
+      steps,
+      reason: `opt-in written but daemon restart failed: ${restart.reason}`,
+      written,
+    };
+  }
+  steps.push("restarted stack daemon");
+
+  return { ok: true, steps, written };
+}
+
+// =============================================================================
+// leave public
+// =============================================================================
+
+export async function leavePublic(
+  ports: PublicScopePorts,
+): Promise<PublicLeaveResult> {
+  const steps: string[] = [];
+  const wasSubscribed = ports.subscribe.hasPublicSubscription();
+  const wasOptedIn = ports.policy.readPublic() !== undefined;
+
+  if (!wasSubscribed && !wasOptedIn) {
+    return {
+      ok: true,
+      steps: ["not opted into the public scope — nothing to do"],
+      notJoined: true,
+    };
+  }
+
+  // Deregister from the public index (register with empty capabilities). A
+  // deregister failure is fatal — we must not leave the stack advertised on
+  // the public index while tearing down the local subscription (no half-leave).
+  const dereg = await ports.registry.deregisterCapabilities();
+  if (!dereg.ok) {
+    return { ok: false, steps, reason: `public deregister failed: ${dereg.reason}` };
+  }
+  steps.push(`deregistered from the public index (${dereg.note})`);
+
+  // Unsubscribe public.> (idempotent).
+  ports.subscribe.removePublicSubscription();
+  steps.push("unsubscribed public.> (removed from nats.subjects[])");
+
+  // Clear the policy.public opt-in (reverts the surface-router to deny-all).
+  ports.policy.writePublic(undefined);
+  steps.push("removed policy.public — surface-router reverts to deny-all-public");
+
+  const restart = await ports.daemon.restart();
+  if (!restart.ok) {
+    return {
+      ok: false,
+      steps,
+      reason: `opt-in removed but daemon restart failed: ${restart.reason}`,
+    };
+  }
+  steps.push("restarted stack daemon");
+
+  return { ok: true, steps };
+}

--- a/src/cli/cortex/commands/network-public-ports.ts
+++ b/src/cli/cortex/commands/network-public-ports.ts
@@ -1,0 +1,94 @@
+/**
+ * S5 (Network Join Control Plane, #739, spec F5) — the injected-dependency
+ * seams for `cortex network join/leave public` (the public-scope opt-in, the
+ * open square of the Internet of Agentic Work).
+ *
+ * Same ports discipline as S4 (`network-ports.ts`): the orchestration
+ * (`network-public-lib.ts`) is pure over these interfaces; the LIVE adapters
+ * (in `network-adapters.ts`) mutate the deployment and are only built on a real
+ * invocation; the DRY-RUN adapters (the S5 default-safe posture) record intent
+ * without touching disk, registry, or daemons.
+ *
+ * ## What `join public` actually does (bounded — F5)
+ *
+ *   1. ANNOUNCE the stack's declared capabilities to the registry's PUBLIC
+ *      capability index (the `/capabilities` search surface, fed by the
+ *      principal-register `capabilities` claim) — {@link PublicRegistryPort}.
+ *   2. SUBSCRIBE `public.>` so the stack receives public-scope traffic — by
+ *      adding `public.>` to the stack's `nats.subjects[]` — {@link PublicSubscribePort}.
+ *   3. WRITE the `policy.public` opt-in block (the allowlist gate) so the
+ *      surface-router admits inbound public traffic ONLY from allowlisted
+ *      senders — {@link PublicPolicyPort}.
+ *   4. RESTART the daemon so the new subscription takes effect ({@link DaemonPort},
+ *      shared with S4).
+ *
+ * ## OQ1 safe default (the deferred abuse story)
+ *
+ * Step 3 is DENY-BY-DEFAULT. With no `--allow`, the written block is
+ * `enabled: false` — announcing/discovering capabilities does NOT open the
+ * local bus to public senders. There is NO open-claim/anonymous seam here:
+ * open anonymous claim on `public.>` is out of scope for S5 and deferred to the
+ * security ramp (DD-7), gated on the OQ1 abuse story.
+ */
+
+import type { PolicyPublic } from "../../../common/types/cortex-config";
+import type { DaemonPort } from "./network-ports";
+
+// =============================================================================
+// Ports
+// =============================================================================
+
+/**
+ * The registry control-plane seam for the PUBLIC capability index. Announcing
+ * = upserting the stack's principal record with its declared `capabilities`
+ * (the registry's `/capabilities` route searches over these). Deregistering =
+ * re-registering with an EMPTY capability list, so the stack is no longer
+ * discoverable on the public index. Both are idempotent proof-of-possession
+ * registrations (same trust model as S4's `registerStack`).
+ */
+export interface PublicRegistryPort {
+  /** Announce these capability ids to the public index (register w/ caps). */
+  announceCapabilities(
+    capabilities: readonly string[],
+  ): Promise<{ ok: true; note: string } | { ok: false; reason: string }>;
+  /** Remove the stack from the public index (register w/ empty caps). */
+  deregisterCapabilities(): Promise<
+    { ok: true; note: string } | { ok: false; reason: string }
+  >;
+}
+
+/**
+ * The `public.>` subscription seam. `join public` adds `public.>` to the
+ * stack's `nats.subjects[]` (the runtime's boot-time subscribe list); `leave
+ * public` removes it. `hasPublicSubscription` makes the add idempotent (a
+ * re-join when already subscribed is a no-op — never double-bind the same
+ * pattern, the cortex#491 double-message footgun).
+ */
+export interface PublicSubscribePort {
+  /** True when `public.>` is already in the stack's `nats.subjects[]`. */
+  hasPublicSubscription(): boolean;
+  /** Add `public.>` to `nats.subjects[]` (idempotent — caller guards). */
+  addPublicSubscription(): void;
+  /** Remove `public.>` from `nats.subjects[]` (idempotent — absent is a no-op). */
+  removePublicSubscription(): void;
+}
+
+/**
+ * The `policy.public` opt-in seam — reads + writes the inbound allowlist block
+ * for the stack. `writePublic(undefined)` REMOVES the block (the `leave`
+ * teardown), reverting the surface-router to its deny-all-public default.
+ */
+export interface PublicPolicyPort {
+  /** Current `policy.public` for the stack (undefined when not opted in). */
+  readPublic(): PolicyPublic | undefined;
+  /** Persist `policy.public`; `undefined` removes the block (leave teardown). */
+  writePublic(next: PolicyPublic | undefined): void;
+}
+
+/** The full public-scope port bundle. Reuses S4's {@link DaemonPort}. */
+export interface PublicScopePorts {
+  registry: PublicRegistryPort;
+  subscribe: PublicSubscribePort;
+  policy: PublicPolicyPort;
+  daemon: DaemonPort;
+}

--- a/src/cli/cortex/commands/network.ts
+++ b/src/cli/cortex/commands/network.ts
@@ -56,8 +56,15 @@ import type { NetworkPorts } from "./network-ports";
 import {
   buildLivePorts,
   buildDryRunPorts,
+  buildLivePublicPorts,
+  buildDryRunPublicPorts,
   type LivePortsConfig,
 } from "./network-adapters";
+import {
+  joinPublic,
+  leavePublic,
+  type PublicJoinInputs,
+} from "./network-public-lib";
 
 export { type ExitResult } from "./_shared/exit-result";
 
@@ -69,6 +76,9 @@ type NetworkSubcommand = "join" | "leave" | "status";
 
 const NETWORK_ID_RE = /^[a-z][a-z0-9-]*$/;
 const PRINCIPAL_ID_RE = /^[a-z][a-z0-9-]*$/;
+// S5 — capability id grammar (`<domain>.<entity>`, matches the schema's
+// announce_capabilities[] rule) + principal-id grammar for the allowlist.
+const CAPABILITY_ID_RE = /^[a-z][a-z0-9-]*(\.[a-z][a-z0-9-]*)+$/;
 
 const SPEC: SubcommandSpec<NetworkSubcommand> = {
   cliName: "network",
@@ -87,6 +97,12 @@ const SPEC: SubcommandSpec<NetworkSubcommand> = {
         "--plist": "value",
         "--max-hop": "value",
         "--leaf-node": "value",
+        // S5 (#739) — public-scope flags. `--capabilities` (comma-separated)
+        // announces to the public index; `--allow` (comma-separated) is the
+        // INBOUND allowlist (empty ⇒ deny-by-default, OQ1 safe). Only consumed
+        // on `join public`; ignored on a federated join.
+        "--capabilities": "value",
+        "--allow": "value",
         "--apply": "bool",
         "--dry-run": "bool",
       },
@@ -96,6 +112,8 @@ const SPEC: SubcommandSpec<NetworkSubcommand> = {
       flags: {
         "--principal": "value",
         "--stack": "value",
+        "--registry-url": "value",
+        "--seed-path": "value",
         "--nats-config": "value",
         "--plist": "value",
         "--apply": "bool",
@@ -181,6 +199,13 @@ async function runJoin(
   flags: Record<string, string | true>,
   json: boolean,
 ): Promise<ExitResult> {
+  // S5 (#739) — `join public` is the open-square opt-in, structurally distinct
+  // from a federated join (no leaf, no creds/account, no peers). Route it to
+  // the public path BEFORE the federated network-id grammar check ("public" is
+  // the literal scope name, not a network id).
+  if (networkId === "public") {
+    return runJoinPublic(flags, json);
+  }
   if (!NETWORK_ID_RE.test(networkId)) {
     return usageError("join", `network "${networkId}" must be lowercase alphanumeric + hyphen, letter-prefixed`, json);
   }
@@ -239,6 +264,10 @@ async function runLeave(
   flags: Record<string, string | true>,
   json: boolean,
 ): Promise<ExitResult> {
+  // S5 (#739) — `leave public` reverses the open-square opt-in.
+  if (networkId === "public") {
+    return runLeavePublic(flags, json);
+  }
   if (!NETWORK_ID_RE.test(networkId)) {
     return usageError("leave", `network "${networkId}" must be lowercase alphanumeric + hyphen, letter-prefixed`, json);
   }
@@ -295,6 +324,94 @@ async function runStatus(
     lines.push("");
   }
   return ok(lines.join("\n"));
+}
+
+// =============================================================================
+// S5 (#739) — public-scope opt-in (join/leave public)
+// =============================================================================
+
+/** Split a comma-separated flag value into trimmed, non-empty tokens. */
+function splitCsv(raw: string | undefined): string[] {
+  if (raw === undefined) return [];
+  return raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+async function runJoinPublic(
+  flags: Record<string, string | true>,
+  json: boolean,
+): Promise<ExitResult> {
+  const principalRes = requireValueFlag(flags, "--principal");
+  if (!principalRes.ok) return usageError("join", principalRes.reason, json);
+  if (!PRINCIPAL_ID_RE.test(principalRes.value)) {
+    return usageError("join", `--principal "${principalRes.value}" must be lowercase alphanumeric + hyphen, letter-prefixed`, json);
+  }
+  const slugRes = resolveStackSlug(principalRes.value, optionalValueFlag(flags, "--stack"));
+  if (!slugRes.ok) return usageError("join", slugRes.reason, json);
+
+  // Public-path required flags: registry (announce), seed (proof-of-possession),
+  // nats-config (subscribe public.>), plist (daemon arg). NOT creds/account —
+  // public has no leaf.
+  for (const required of ["--registry-url", "--seed-path", "--nats-config", "--plist"]) {
+    const r = requireValueFlag(flags, required);
+    if (!r.ok) return usageError("join", r.reason, json);
+  }
+
+  // --capabilities (CSV) — announce to the public index. Validate each id.
+  const capabilities = splitCsv(optionalValueFlag(flags, "--capabilities"));
+  for (const cap of capabilities) {
+    if (!CAPABILITY_ID_RE.test(cap)) {
+      return usageError("join", `--capabilities "${cap}" must be a <domain>.<entity> capability id (e.g. 'code-review.typescript')`, json);
+    }
+  }
+
+  // --allow (CSV) — the INBOUND allowlist. Empty ⇒ deny-by-default (OQ1 safe).
+  const allowPrincipals = splitCsv(optionalValueFlag(flags, "--allow"));
+  for (const p of allowPrincipals) {
+    if (!PRINCIPAL_ID_RE.test(p)) {
+      return usageError("join", `--allow "${p}" must be a principal id (lowercase alphanumeric + hyphen, letter-prefixed)`, json);
+    }
+  }
+
+  const applyRes = resolveApply(flags);
+  if (!applyRes.ok) return usageError("join", applyRes.reason, json);
+
+  const cfg = portsConfig("public", principalRes.value, slugRes.slug, flags);
+  const ports = applyRes.apply ? buildLivePublicPorts(cfg) : buildDryRunPublicPorts(cfg);
+  const inputs: PublicJoinInputs = { capabilities, allowPrincipals };
+
+  const res = await joinPublic(inputs, ports);
+  return renderFlowResult("join", "public", res.ok, res.reason, res.steps, applyRes.apply, json, {
+    inbound: res.written?.enabled === true ? "enabled" : "disabled",
+    allow: (res.written?.allow_principals ?? []).join(","),
+    announced: capabilities.join(","),
+  });
+}
+
+async function runLeavePublic(
+  flags: Record<string, string | true>,
+  json: boolean,
+): Promise<ExitResult> {
+  const principalRes = requireValueFlag(flags, "--principal");
+  if (!principalRes.ok) return usageError("leave", principalRes.reason, json);
+  const slugRes = resolveStackSlug(principalRes.value, optionalValueFlag(flags, "--stack"));
+  if (!slugRes.ok) return usageError("leave", slugRes.reason, json);
+  for (const required of ["--registry-url", "--seed-path", "--nats-config", "--plist"]) {
+    const r = requireValueFlag(flags, required);
+    if (!r.ok) return usageError("leave", r.reason, json);
+  }
+  const applyRes = resolveApply(flags);
+  if (!applyRes.ok) return usageError("leave", applyRes.reason, json);
+
+  const cfg = portsConfig("public", principalRes.value, slugRes.slug, flags);
+  const ports = applyRes.apply ? buildLivePublicPorts(cfg) : buildDryRunPublicPorts(cfg);
+
+  const res = await leavePublic(ports);
+  return renderFlowResult("leave", "public", res.ok, res.reason, res.steps, applyRes.apply, json, {
+    not_joined: res.notJoined === true ? "true" : "false",
+  });
 }
 
 // =============================================================================
@@ -426,6 +543,17 @@ Subcommands:
   leave   Reverse a join cleanly: remove the network + leaf include, drop the
           plist -c arg if no networks remain, restart. Idempotent.
 
+  join public   (S5, #739) Opt into the PUBLIC scope — the open square of the
+          Internet of Agentic Work. Announces --capabilities to the registry
+          public index + subscribes public.> + writes the policy.public opt-in.
+          SAFE BY DEFAULT (OQ1): without --allow, inbound public is DISABLED
+          (announce/discover only). With --allow <ids>, inbound is enabled but
+          ALLOWLIST-gated to those principals — a non-allowlisted public sender
+          is NEVER auto-trusted. There is no open-claim flag (deferred to the
+          security ramp). public carries NO leaf — no --creds/--account needed.
+  leave public  Reverse it: deregister from the public index + unsubscribe
+          public.> + remove policy.public. Idempotent.
+
 Safety:
   join/leave default to DRY-RUN (no disk/daemon mutation — they print the
   intended actions). Pass --apply to execute for real. --apply and --dry-run
@@ -443,6 +571,11 @@ Flags:
   --plist <p>             nats-server launchd plist to ensure loads the config.
   --leaf-node <name>      Leaf connection name on the network entry (default: network id).
   --max-hop <n>           Hop budget written on the network (default: 1).
+  --capabilities <csv>    (join public) Comma-separated capability ids to announce
+                          to the public index (e.g. code-review.typescript,research.synthesis).
+  --allow <csv>           (join public) Comma-separated INBOUND allowlist of public
+                          sender principals. Empty (default) = inbound DISABLED (OQ1
+                          safe). Non-empty = inbound enabled, gated to these ids only.
   --monitor-url <url>     (status) nats-server monitor base URL for leaf telemetry.
   --apply                 Execute the live mutation (default: dry-run).
   --json                  Emit a { status, items, data, error } envelope.

--- a/src/common/types/__tests__/cortex-config.test.ts
+++ b/src/common/types/__tests__/cortex-config.test.ts
@@ -31,6 +31,7 @@ import {
   PathsConfigSchema,
   PolicyFederatedRegistrySchema,
   PolicyFederatedSchema,
+  PolicyPublicSchema,
   RendererSchema,
 } from "../cortex-config";
 
@@ -851,6 +852,49 @@ describe("PolicyFederatedRegistrySchema — IAW D.4.3", () => {
       registry: { url: "https://network.meta-factory.ai" },
     });
     expect(withReg.registry?.url).toBe("https://network.meta-factory.ai");
+  });
+});
+
+describe("PolicyPublicSchema — IAW S5 (#739) public-scope opt-in (OQ1 safe default)", () => {
+  test("defaults are deny-by-default: enabled=false, empty allowlist", () => {
+    const parsed = PolicyPublicSchema.parse({});
+    expect(parsed.enabled).toBe(false);
+    expect(parsed.allow_principals).toEqual([]);
+    expect(parsed.announce_capabilities).toEqual([]);
+  });
+
+  test("there is NO open-claim / anonymous knob (strict — rejects extra keys)", () => {
+    // The safe-default contract: a config CANNOT express 'open anonymous claim'.
+    // .strict() rejects an attempt to add one, so the abuse story stays deferred.
+    expect(() =>
+      PolicyPublicSchema.parse({ enabled: true, open_claim: true }),
+    ).toThrow();
+    expect(() =>
+      PolicyPublicSchema.parse({ enabled: true, anonymous: true }),
+    ).toThrow();
+  });
+
+  test("accepts an explicit allowlist (the only way to admit a public sender)", () => {
+    const parsed = PolicyPublicSchema.parse({
+      enabled: true,
+      allow_principals: ["jc", "joel"],
+      announce_capabilities: ["code-review.typescript"],
+    });
+    expect(parsed.enabled).toBe(true);
+    expect(parsed.allow_principals).toEqual(["jc", "joel"]);
+    expect(parsed.announce_capabilities).toEqual(["code-review.typescript"]);
+  });
+
+  test("rejects a malformed allow_principals id", () => {
+    expect(() =>
+      PolicyPublicSchema.parse({ enabled: true, allow_principals: ["BAD_ID"] }),
+    ).toThrow();
+  });
+
+  test("rejects a malformed announce_capabilities id (must be <domain>.<entity>)", () => {
+    expect(() =>
+      PolicyPublicSchema.parse({ announce_capabilities: ["nodot"] }),
+    ).toThrow();
   });
 });
 

--- a/src/common/types/cortex-config.ts
+++ b/src/common/types/cortex-config.ts
@@ -1731,10 +1731,85 @@ export const PolicyFederatedSchema = z.object({
 
 export type PolicyFederated = z.infer<typeof PolicyFederatedSchema>;
 
+/**
+ * `policy.public` block — IAW S5 (Network Join Control Plane, #739, spec F5) —
+ * the **public scope opt-in** (the open square of the Internet of Agentic Work).
+ *
+ * The `public` scope (CONTEXT.md §Scope) is unrestricted and carries NO
+ * principal/stack segment: subjects are `public.{domain}.{entity}.{action}`,
+ * NOT `public.{principal}.{stack}.…`. A stack opts in explicitly with
+ * `cortex network join public`, which writes this block.
+ *
+ * ## Safe-by-default (OQ1 — the deferred abuse story)
+ *
+ * Spec OQ1 leaves the public-scope abuse model OPEN: anonymous offer/claim on
+ * `public.>` needs a spam/abuse story before it can be enabled beyond an
+ * allowlist. So this block is **deny-by-default** on the INBOUND side:
+ *
+ *   - `enabled: false` (the default) — the surface-router drops ALL inbound
+ *     `public.*` traffic. Opting into the public scope to ANNOUNCE/DISCOVER
+ *     capabilities (the registry control-plane side) does not by itself open
+ *     the local bus to public senders.
+ *   - `enabled: true` + `allow_principals: []` — still drops every inbound
+ *     public sender. An empty allowlist is "trust nobody on public", NOT
+ *     "trust everybody". A non-allowlisted public sender is NEVER auto-trusted.
+ *   - `enabled: true` + `allow_principals: ["jc", …]` — admits inbound public
+ *     traffic ONLY from those signing principals. This is the allowlist gate.
+ *
+ * There is deliberately NO `open_claim`/`anonymous` flag: open anonymous claim
+ * on `public.>` is OUT OF SCOPE for S5 and is a later decision on the security
+ * ramp (DD-7), gated on the OQ1 abuse story. Until then the allowlist is the
+ * only way to admit a public sender.
+ *
+ * The block is fully additive — absence means "not opted into public scope"
+ * and the gate drops inbound `public.*` exactly as `enabled: false` does.
+ */
+export const PolicyPublicSchema = z.object({
+  /**
+   * Opt-in switch for the public scope. `false` (default) → inbound `public.*`
+   * is dropped by the surface-router; announcing/discovering capabilities via
+   * the registry is unaffected (that is a control-plane action, not a wire
+   * trust grant). `true` → inbound public traffic is admitted, but ONLY from
+   * `allow_principals[]` (still deny-by-default when that list is empty).
+   */
+  enabled: z.boolean().default(false),
+  /**
+   * Allowlist of public-scope sender principal ids. An inbound `public.*`
+   * envelope is admitted only when its SOURCE principal
+   * (`principalFromEnvelope`) is in this list. Empty = "trust nobody on
+   * public" (the safe default — a non-allowlisted sender is NOT auto-trusted).
+   * This is the OQ1 safe gate: open anonymous claim is deferred to the
+   * security ramp.
+   */
+  allow_principals: z.array(
+    z.string().regex(
+      LETTER_PREFIX_ID_REGEX,
+      "public.allow_principals[] entries must match the principal id grammar (lowercase alphanumeric + hyphen, starting with a letter)",
+    ),
+  ).default([]),
+  /**
+   * Capability ids this stack announces to the registry's PUBLIC capability
+   * index (the `/capabilities` search surface) when joined to the public
+   * scope. Distinct from `policy.federated.networks[].announce_capabilities`
+   * (which scopes announcements to a named network) — public announcements are
+   * unrestricted-discovery. Empty = "discoverable presence with no advertised
+   * capabilities". Same `<domain>.<entity>` grammar as the federated list.
+   */
+  announce_capabilities: z.array(
+    z.string().regex(
+      /^[a-z][a-z0-9-]*(\.[a-z][a-z0-9-]*)+$/,
+      "announce_capabilities[] entries must follow the <domain>.<entity> capability id grammar (e.g. 'code-review.typescript')",
+    ),
+  ).default([]),
+}).strict();
+
+export type PolicyPublic = z.infer<typeof PolicyPublicSchema>;
+
 export const PolicySchema = z.object({
   principals: z.array(PolicyPrincipalSchema).default([]),
   roles: z.array(PolicyRoleSchema).default([]),
   federated: PolicyFederatedSchema.optional(),
+  public: PolicyPublicSchema.optional(),
   // v2.0.0 cutover (cortex#297) — `parallel_mode_enabled` retired with
   // the parallel-mode plumbing in adapters. PolicyEngine is the sole
   // authorisation gate; legacy role-resolver is gone.

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -1577,6 +1577,11 @@ export async function startCortex(
   const router: SurfaceRouter = createSurfaceRouter(runtime, {
     systemEventSource,
     ...(options.policy?.federated !== undefined && { federated: options.policy.federated }),
+    // IAW S5 (#739) — the public-scope opt-in. Absent ⇒ the router drops all
+    // inbound `public.*` (deny-by-default, OQ1 safe). Written by
+    // `cortex network join public`; an inbound public sender is admitted only
+    // when `enabled: true` AND its source principal is on `allow_principals[]`.
+    ...(options.policy?.public !== undefined && { public: options.policy.public }),
     onAdapterError: (adapterId, err) => {
       console.error(`cortex: surface adapter "${adapterId}" render error:`, err.message);
     },


### PR DESCRIPTION
## S5 — public scope opt-in (the open square)

Phase C of the Network Join Control Plane (epic #733), spec §6 **F5** + **OQ1**. The third onboarding tier: the **public** scope — unrestricted, carries **no** principal/stack segment (`public.{domain}.{entity}.{action}`).

### What this adds (bounded — F5)
- **`cortex network join public`** — announces the stack's declared `--capabilities` to the registry's PUBLIC capability index (`/capabilities`, fed by the principal-register `capabilities` claim), subscribes `public.>` (adds it to `nats.subjects[]`), and writes the `policy.public` opt-in block. Idempotent; **dry-run-default** (`--apply` to act).
- **`cortex network leave public`** — reverses: deregister (register with empty caps) + unsubscribe `public.>` + remove `policy.public`.
- **`policy.public` schema** (`PolicyPublicSchema`, `.strict()`): `enabled` (default `false`), `allow_principals[]` (default `[]`), `announce_capabilities[]`.
- **`evaluatePublicGate`** + a dispatch branch in the surface-router.

### OQ1 — safe-by-default (the deferred abuse story)
The surface-router previously left inbound `public.*` **ungated** (`"none for public"`). S5 closes that gap with a **deny-by-default** gate:

| `policy.public` | inbound `public.*` |
|---|---|
| absent / `enabled:false` | **dropped** (announce/discover ≠ trust grant) |
| `enabled:true`, `allow_principals:[]` | **dropped** (trust nobody, not everybody) |
| `enabled:true`, sender ∉ allowlist | **dropped** — never auto-trusted |
| `enabled:true`, sender ∈ allowlist | allowed |

There is **no open-claim / anonymous knob** — the schema is `.strict()`, so a config *cannot* express open anonymous claim. Open claim on `public.>` is **deferred** to the security ramp (DD-7), gated on the OQ1 abuse story.

### No-principal-segment scope correctness (wire-check 5/5)
`public.>` carries no `{principal}.{stack}` segment. The public gate is **disjoint** from `evaluateFederationGate` — it keys on the **sender** source principal against the public allowlist, never resolving a federated network/peer. Public is a separate trust tier, not a federated peer, so the federated peer checks are never mis-applied. `selectLink` already routes `public.*` → primary (unchanged); the federated join path (S4) and `local` scope are untouched.

### Tests (fully-faked I/O)
- public gate: deny-by-default, enabled+empty-allowlist deny, non-allowlisted deny, allowlisted allow, federated unchanged, disjointness from the federated peer gate.
- `joinPublic`/`leavePublic`: announce + subscribe + restart; safe-default opt-in; allowlist-gated; idempotent; dry-run writes nothing; leave reverses + no-op when never joined.
- CLI: `join public` flag validation (no `--creds`/`--account` needed), dry-run writes nothing to disk, `leave public` clean no-op.
- schema: defaults deny-by-default; `.strict()` rejects `open_claim`/`anonymous`.

### Verify
`bunx tsc --noEmit` 0 · `bun test` 4577 pass / 0 fail / 2 skip (pre-existing) · lint clean · vocab/carveout gate PASS.

### Not touched (out of scope)
Federated join path (S4, merged) · docs/SOP (S6, parallel) · open anonymous claim (security ramp). **No live config/daemon mutation** (dry-run default) and **no open-claim enabled**.

Closes #739
Refs #733

🤖 Generated with [Claude Code](https://claude.com/claude-code)