### PR TITLE
fix(network): #754 — wire local.conf to include the rendered leaf file (close the dormant-leaf gap)

### DIFF
--- a/src/cli/cortex/commands/__tests__/network-adapters.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-adapters.test.ts
@@ -18,7 +18,11 @@ import { mkdtempSync, rmSync, writeFileSync, readFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 
-import { buildLivePorts, type LivePortsConfig } from "../network-adapters";
+import {
+  buildDryRunPorts,
+  buildLivePorts,
+  type LivePortsConfig,
+} from "../network-adapters";
 import {
   ensureConfigArg,
   renderProgramArguments,
@@ -130,5 +134,105 @@ describe("live plist writer uses S3's canonical renderProgramArguments", () => {
     expect(after).toContain(expectedBlock);
     expect(after).not.toContain("<string>-c</string>");
     expect(after).not.toContain(`<string>${NATS_CONFIG}</string>`);
+  });
+});
+
+// =============================================================================
+// #754 — the live leaf-file port wires local.conf to INCLUDE the rendered leaf
+// (close the dormant-leaf gap). Round-trips a real temp nats config; dry-run
+// is inert.
+// =============================================================================
+
+/** A representative operator-mode local.conf with ZERO include directives. */
+function bareLocalConf(): string {
+  return [
+    "// nats-server operator-mode config.",
+    "system_account: ADSYSACCOUNT",
+    "jetstream { store_dir: /Users/andreas/.config/nats/js }",
+    "",
+  ].join("\n");
+}
+
+function cfgWithConfig(natsConfigPath: string): LivePortsConfig {
+  return {
+    networkId: "metafactory",
+    principalId: "andreas",
+    stackId: "andreas/meta-factory",
+    natsConfigPath,
+    plistPath: "/nonexistent/plist", // not exercised here
+  };
+}
+
+describe("#754 live leaf-include wiring", () => {
+  test("ensureInclude adds the include directive to local.conf (was dormant)", () => {
+    const dir = freshDir();
+    const conf = join(dir, "local.conf");
+    writeFileSync(conf, bareLocalConf(), "utf-8");
+
+    const ports = buildLivePorts(cfgWithConfig(conf));
+    ports.leafFile.ensureInclude("metafactory");
+
+    const after = readFileSync(conf, "utf-8");
+    expect(after).toContain('include "leafnodes-metafactory.conf"');
+    // Original content preserved.
+    expect(after).toContain("system_account: ADSYSACCOUNT");
+  });
+
+  test("ensureInclude is idempotent + byte-stable on the live file", () => {
+    const dir = freshDir();
+    const conf = join(dir, "local.conf");
+    writeFileSync(conf, bareLocalConf(), "utf-8");
+    const ports = buildLivePorts(cfgWithConfig(conf));
+
+    ports.leafFile.ensureInclude("metafactory");
+    const first = readFileSync(conf, "utf-8");
+    ports.leafFile.ensureInclude("metafactory");
+    const second = readFileSync(conf, "utf-8");
+    expect(second).toBe(first);
+  });
+
+  test("ensure → removeInclude round-trips local.conf back to original bytes", () => {
+    const dir = freshDir();
+    const conf = join(dir, "local.conf");
+    const original = bareLocalConf();
+    writeFileSync(conf, original, "utf-8");
+    const ports = buildLivePorts(cfgWithConfig(conf));
+
+    ports.leafFile.ensureInclude("metafactory");
+    ports.leafFile.removeInclude("metafactory");
+    expect(readFileSync(conf, "utf-8")).toBe(original);
+  });
+
+  test("multiple networks each get their own include directive", () => {
+    const dir = freshDir();
+    const conf = join(dir, "local.conf");
+    writeFileSync(conf, bareLocalConf(), "utf-8");
+    const ports = buildLivePorts(cfgWithConfig(conf));
+
+    ports.leafFile.ensureInclude("metafactory");
+    ports.leafFile.ensureInclude("research");
+    const after = readFileSync(conf, "utf-8");
+    expect(after).toContain('include "leafnodes-metafactory.conf"');
+    expect(after).toContain('include "leafnodes-research.conf"');
+
+    // removeInclude drops exactly one.
+    ports.leafFile.removeInclude("metafactory");
+    const final = readFileSync(conf, "utf-8");
+    expect(final).not.toContain('include "leafnodes-metafactory.conf"');
+    expect(final).toContain('include "leafnodes-research.conf"');
+  });
+
+  test("dry-run ensureInclude / removeInclude write NOTHING (inert)", () => {
+    const dir = freshDir();
+    const conf = join(dir, "local.conf");
+    const original = bareLocalConf();
+    writeFileSync(conf, original, "utf-8");
+
+    const ports = buildDryRunPorts(cfgWithConfig(conf));
+    ports.leafFile.ensureInclude("metafactory");
+    ports.leafFile.removeInclude("metafactory");
+
+    // The file on disk is untouched.
+    expect(readFileSync(conf, "utf-8")).toBe(original);
   });
 });

--- a/src/cli/cortex/commands/__tests__/network-lib.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-lib.test.ts
@@ -98,6 +98,10 @@ interface Recorder {
   restarts: number;
   writes: RenderLeafInputs[];
   removes: string[];
+  /** #754 — networks whose include directive was ensured into local.conf. */
+  includesEnsured: string[];
+  /** #754 — networks whose include directive was removed from local.conf. */
+  includesRemoved: string[];
   ensured: string[];
   dropped: string[];
   configWrites: PolicyFederatedNetwork[][];
@@ -117,6 +121,8 @@ function makeFakes(opts: {
     restarts: 0,
     writes: [],
     removes: [],
+    includesEnsured: [],
+    includesRemoved: [],
     ensured: [],
     dropped: [],
     configWrites: [],
@@ -155,6 +161,12 @@ function makeFakes(opts: {
     remove(networkId) {
       rec.removes.push(networkId);
       leafFilesPresent.delete(networkId);
+    },
+    ensureInclude(networkId) {
+      rec.includesEnsured.push(networkId);
+    },
+    removeInclude(networkId) {
+      rec.includesRemoved.push(networkId);
     },
     list() {
       return [...leafFilesPresent];
@@ -223,6 +235,12 @@ describe("join", () => {
     expect(rendered).toContain("tls://hub.meta-factory.ai:7422");
     // (c) plist ensured to load the nats config.
     expect(rec.ensured).toEqual(["/Users/andreas/.config/nats/local.conf"]);
+    // (c) #754 — local.conf ensured to INCLUDE the rendered leaf file, so the
+    // leaf is actually loaded (not dormant).
+    expect(rec.includesEnsured).toEqual(["metafactory"]);
+    expect(
+      res.steps.some((s) => s === "ensured local.conf includes leafnodes-metafactory.conf"),
+    ).toBe(true);
     // (d) config block written.
     expect(storeRef.networks.length).toBe(1);
     const net = storeRef.networks[0]!;
@@ -398,6 +416,8 @@ describe("leave", () => {
     expect(res.ok).toBe(true);
     // Config entry removed.
     expect(storeRef.networks.length).toBe(0);
+    // #754 — the include directive removed from local.conf (inverse of join).
+    expect(rec.includesRemoved).toEqual(["metafactory"]);
     // Leaf include deleted.
     expect(rec.removes).toEqual(["metafactory"]);
     // No networks remain → plist -c dropped.

--- a/src/cli/cortex/commands/network-adapters.ts
+++ b/src/cli/cortex/commands/network-adapters.ts
@@ -34,7 +34,9 @@ import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
 
 import { expandTilde } from "../../../common/config/loader";
 import {
+  ensureLeafInclude,
   leafIncludeFileName,
+  removeLeafInclude,
   renderLeafIncludeFile,
 } from "../../../common/nats/leaf-remote-renderer";
 import {
@@ -176,6 +178,30 @@ function buildLeafFilePort(cfg: LivePortsConfig, mutate: boolean): LeafFilePort 
       if (!mutate) return;
       const p = join(dir, leafIncludeFileName(networkId));
       rmSync(p, { force: true });
+    },
+    ensureInclude(networkId) {
+      // #754 — wire the main nats config to `include` the rendered leaf file.
+      // Read local.conf, apply S3's idempotent ensure, write back. Dry-run is
+      // inert (the orchestrator's step log still records the intended action).
+      if (!mutate) return;
+      const configPath = expandTilde(cfg.natsConfigPath ?? "");
+      const current = existsSync(configPath)
+        ? readFileSync(configPath, "utf-8")
+        : "";
+      const next = ensureLeafInclude(current, networkId);
+      if (next === current) return; // byte-stable no-op.
+      mkdirSync(dirname(configPath), { recursive: true });
+      writeFileSync(configPath, next, "utf-8");
+    },
+    removeInclude(networkId) {
+      // #754 — leave teardown: drop the include directive (inverse of ensure).
+      if (!mutate) return;
+      const configPath = expandTilde(cfg.natsConfigPath ?? "");
+      if (!existsSync(configPath)) return;
+      const current = readFileSync(configPath, "utf-8");
+      const next = removeLeafInclude(current, networkId);
+      if (next === current) return; // no-op.
+      writeFileSync(configPath, next, "utf-8");
     },
     list() {
       if (!existsSync(dir)) return [];

--- a/src/cli/cortex/commands/network-lib.ts
+++ b/src/cli/cortex/commands/network-lib.ts
@@ -224,6 +224,13 @@ export async function joinNetwork(
     ports.plist.ensureConfigLoaded(ports.leafFile.natsConfigPath());
     steps.push(`ensured nats-server plist loads ${ports.leafFile.natsConfigPath()}`);
 
+    // (c, cont.) Ensure the nats config actually `include`s the rendered leaf
+    // file (#754). Without this the plist loads a config that never references
+    // the leaf → the leaf sits configured-but-dormant (the DD-6 trap). This is
+    // the idempotent ensure-include step mirroring the plist ensure pattern.
+    ports.leafFile.ensureInclude(networkId);
+    steps.push(`ensured local.conf includes leafnodes-${networkId}.conf`);
+
     // (d) Merge the network into the federation config with registry-resolved
     // peers (DD-5) + the OWN accept-subject (wire contract). Idempotent: replace
     // the entry keyed by network id, never append a duplicate.
@@ -352,7 +359,13 @@ export async function leaveNetwork(
     ports.configStore.writeNetworks(remaining);
     steps.push(`removed policy.federated.networks["${networkId}"]`);
 
-    // Delete the leaf include (idempotent).
+    // Remove the `include` directive from the nats config (#754 — the inverse
+    // of join's ensure-include) BEFORE deleting the file, so the config never
+    // references a missing include.
+    ports.leafFile.removeInclude(networkId);
+    steps.push(`removed local.conf include for leafnodes-${networkId}.conf`);
+
+    // Delete the leaf include file (idempotent).
     ports.leafFile.remove(networkId);
     steps.push(`deleted leaf include for "${networkId}"`);
 

--- a/src/cli/cortex/commands/network-ports.ts
+++ b/src/cli/cortex/commands/network-ports.ts
@@ -123,6 +123,22 @@ export interface LeafFilePort {
   write(inputs: RenderLeafInputs): void;
   /** Delete a network's include file (idempotent — absent file is a no-op). */
   remove(networkId: string): void;
+  /**
+   * Ensure the nats config (`local.conf`) `include`s the network's leaf file
+   * (#754 — close the dormant-leaf gap). Mirrors {@link PlistPort.ensureConfigLoaded}:
+   * idempotent + byte-stable when the directive is already present. Without
+   * this step nats-server loads a config that never references the rendered
+   * leaf, so the leaf sits configured-but-dormant. Live adapter reads
+   * `natsConfigPath()`, applies S3's `ensureLeafInclude`, and writes it back;
+   * the dry-run adapter is inert.
+   */
+  ensureInclude(networkId: string): void;
+  /**
+   * Remove the network's `include` directive from the nats config (leave
+   * teardown — the inverse of {@link ensureInclude}). Idempotent. Live adapter
+   * applies S3's `removeLeafInclude`; dry-run inert.
+   */
+  removeInclude(networkId: string): void;
   /** Network ids that currently have an include file present. */
   list(): string[];
   /**

--- a/src/common/nats/__tests__/leaf-include-wiring.test.ts
+++ b/src/common/nats/__tests__/leaf-include-wiring.test.ts
@@ -1,0 +1,160 @@
+/**
+ * #754 — leaf-include WIRING tests (RED-first).
+ *
+ * The dormant-leaf bug: `cortex network join --apply` rendered the per-network
+ * `leafnodes-<network>.conf` and ensured the launchd plist loads `local.conf`,
+ * but NOTHING ever made `local.conf` actually `include` the rendered leaf file.
+ * nats-server loaded `local.conf`, which never referenced the leaf → the leaf
+ * sat configured-but-dormant (the exact S3/DD-6 trap).
+ *
+ * The fix mirrors the plist `ensureConfigArg` idempotent-ensure pattern at the
+ * nats-config text level: {@link ensureLeafInclude} adds a top-level
+ * `include "leafnodes-<network>.conf"` directive when absent (no-op +
+ * byte-stable when present), {@link removeLeafInclude} removes exactly that one
+ * directive on leave. Both are pure over the nats-config TEXT — no live
+ * `~/.config/nats/local.conf` is read or written here.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  ensureLeafInclude,
+  leafIncludeDirectivePresent,
+  leafIncludeFileName,
+  removeLeafInclude,
+} from "../leaf-remote-renderer";
+
+// A representative operator-mode local.conf (NSC operator JWT + resolver +
+// system_account), the shape the live config carries — with ZERO include
+// directives (the bug).
+const LOCAL_CONF = [
+  "// nats-server operator-mode config (hand-built bring-up).",
+  "system_account: ADSYSACCOUNT",
+  "resolver: {",
+  "  type: full",
+  "  dir: /Users/andreas/.config/nats/jwt",
+  "}",
+  "jetstream {",
+  "  store_dir: /Users/andreas/.config/nats/js",
+  "}",
+  "",
+].join("\n");
+
+describe("leafIncludeFileName (reused — same name everywhere)", () => {
+  test("the directive references the SAME file the leaf writer writes", () => {
+    expect(leafIncludeFileName("metafactory")).toBe("leafnodes-metafactory.conf");
+  });
+});
+
+describe("ensureLeafInclude", () => {
+  test("adds a top-level include directive when absent", () => {
+    const next = ensureLeafInclude(LOCAL_CONF, "metafactory");
+    expect(next).toContain('include "leafnodes-metafactory.conf"');
+    // The original config is preserved verbatim (we only append).
+    expect(next).toContain("system_account: ADSYSACCOUNT");
+    expect(next).toContain("store_dir: /Users/andreas/.config/nats/js");
+  });
+
+  test("places the include at TOP LEVEL (not nested inside a block)", () => {
+    const next = ensureLeafInclude(LOCAL_CONF, "metafactory");
+    // The include line must not be indented (top-level HOCON) and must sit
+    // outside the resolver/jetstream braces.
+    const line = next
+      .split("\n")
+      .find((l) => l.includes('include "leafnodes-metafactory.conf"'));
+    expect(line).toBeDefined();
+    expect(line).toBe('include "leafnodes-metafactory.conf"');
+  });
+
+  test("is a no-op when the directive is already present (idempotent)", () => {
+    const once = ensureLeafInclude(LOCAL_CONF, "metafactory");
+    const twice = ensureLeafInclude(once, "metafactory");
+    expect(twice).toBe(once);
+  });
+
+  test("is byte-stable across repeated application", () => {
+    const once = ensureLeafInclude(LOCAL_CONF, "metafactory");
+    const twice = ensureLeafInclude(once, "metafactory");
+    const thrice = ensureLeafInclude(twice, "metafactory");
+    expect(thrice).toBe(once);
+  });
+
+  test("matches an existing directive regardless of quote/whitespace shape", () => {
+    // A hand-written single-quoted directive with extra spaces still counts as
+    // present — we must not add a duplicate.
+    const handWritten = LOCAL_CONF + "include   'leafnodes-metafactory.conf'\n";
+    const next = ensureLeafInclude(handWritten, "metafactory");
+    expect(next).toBe(handWritten);
+    // exactly one include for this network.
+    expect(
+      next.match(/include\s+["']leafnodes-metafactory\.conf["']/g)?.length,
+    ).toBe(1);
+  });
+
+  test("multiple networks each get their own include (idempotent, OQ3-clean)", () => {
+    let cfg = ensureLeafInclude(LOCAL_CONF, "metafactory");
+    cfg = ensureLeafInclude(cfg, "research");
+    expect(cfg).toContain('include "leafnodes-metafactory.conf"');
+    expect(cfg).toContain('include "leafnodes-research.conf"');
+    // Re-ensuring either is a no-op.
+    expect(ensureLeafInclude(cfg, "metafactory")).toBe(cfg);
+    expect(ensureLeafInclude(cfg, "research")).toBe(cfg);
+  });
+
+  test("rejects an invalid network id (cannot smuggle a directive)", () => {
+    expect(() => ensureLeafInclude(LOCAL_CONF, "../etc/passwd")).toThrow();
+    expect(() => ensureLeafInclude(LOCAL_CONF, "Bad Id")).toThrow();
+  });
+
+  test("an empty config still gets a valid top-level include", () => {
+    const next = ensureLeafInclude("", "metafactory");
+    expect(next).toContain('include "leafnodes-metafactory.conf"');
+  });
+});
+
+describe("leafIncludeDirectivePresent", () => {
+  test("false on a config with no includes (the bug)", () => {
+    expect(leafIncludeDirectivePresent(LOCAL_CONF, "metafactory")).toBe(false);
+  });
+
+  test("true once ensured", () => {
+    const next = ensureLeafInclude(LOCAL_CONF, "metafactory");
+    expect(leafIncludeDirectivePresent(next, "metafactory")).toBe(true);
+  });
+
+  test("does not confuse one network's include for another", () => {
+    const next = ensureLeafInclude(LOCAL_CONF, "metafactory");
+    expect(leafIncludeDirectivePresent(next, "research")).toBe(false);
+  });
+});
+
+describe("removeLeafInclude", () => {
+  test("removes exactly the one network's include directive", () => {
+    let cfg = ensureLeafInclude(LOCAL_CONF, "metafactory");
+    cfg = ensureLeafInclude(cfg, "research");
+    const after = removeLeafInclude(cfg, "metafactory");
+    expect(after).not.toContain('include "leafnodes-metafactory.conf"');
+    // research's include survives.
+    expect(after).toContain('include "leafnodes-research.conf"');
+  });
+
+  test("is a no-op when the directive is absent (idempotent)", () => {
+    expect(removeLeafInclude(LOCAL_CONF, "metafactory")).toBe(LOCAL_CONF);
+  });
+
+  test("ensure → remove round-trips back to the original config (byte-stable)", () => {
+    const ensured = ensureLeafInclude(LOCAL_CONF, "metafactory");
+    const removed = removeLeafInclude(ensured, "metafactory");
+    expect(removed).toBe(LOCAL_CONF);
+  });
+
+  test("removes a hand-written single-quoted / extra-space directive too", () => {
+    const handWritten = LOCAL_CONF + "include   'leafnodes-metafactory.conf'\n";
+    const after = removeLeafInclude(handWritten, "metafactory");
+    expect(after).not.toContain("leafnodes-metafactory.conf");
+  });
+
+  test("rejects an invalid network id", () => {
+    expect(() => removeLeafInclude(LOCAL_CONF, "../x")).toThrow();
+  });
+});

--- a/src/common/nats/index.ts
+++ b/src/common/nats/index.ts
@@ -8,8 +8,11 @@
  */
 
 export {
+  ensureLeafInclude,
+  leafIncludeDirectivePresent,
   leafIncludeFileName,
   mergeLeafRemotes,
+  removeLeafInclude,
   renderLeafIncludeFile,
   renderLeafRemote,
 } from "./leaf-remote-renderer";

--- a/src/common/nats/leaf-remote-renderer.ts
+++ b/src/common/nats/leaf-remote-renderer.ts
@@ -253,6 +253,115 @@ export function leafIncludeFileName(networkId: string): string {
   return `leafnodes-${networkId}.conf`;
 }
 
+// =============================================================================
+// #754 — wiring the include directive into the main nats config.
+//
+// S3 rendered the per-network `leafnodes-<network>.conf` and S4 ensured the
+// launchd plist loads `local.conf` — but NOTHING made `local.conf` actually
+// `include` the rendered leaf file, so nats-server loaded a config that never
+// referenced the leaf → dormant leaf (the exact DD-6 trap S3 set out to kill).
+//
+// These two pure helpers mirror the plist `ensureConfigArg`/`dropConfigArg`
+// idempotent-ensure pattern, but at the nats-config TEXT level: ensure the
+// `include "leafnodes-<network>.conf"` directive is present (byte-stable
+// no-op when already there), and remove exactly that one directive on leave.
+//
+// HOCON `include "file"` is a top-level statement; the included file's tokens
+// are spliced at the point of inclusion. We append the directive on its own
+// top-level line (column 0) so it sits OUTSIDE any `{ ... }` block — appending
+// at end-of-file is always at top level. For the single-network case (the
+// common onboarding path) the included `leafnodes { remotes: [...] }` becomes
+// the config's `leafnodes` block; for multi-network the OQ3 note in the module
+// header still holds (the runtime composes), but each network's include is
+// tracked independently and idempotently here.
+// =============================================================================
+
+/**
+ * The literal include directive a config carries for `networkId`. Quoted (the
+ * file name carries a `.`, and quoting is the canonical HOCON form). Uses
+ * {@link leafIncludeFileName} so the directive and the written file can never
+ * drift apart.
+ */
+function leafIncludeDirective(networkId: string): string {
+  return `include "${leafIncludeFileName(networkId)}"`;
+}
+
+/**
+ * A matcher for an EXISTING include of `networkId`'s leaf file, tolerant of the
+ * hand-written shapes a human might have typed: single OR double quotes, and
+ * any run of horizontal whitespace between `include` and the file name. Used so
+ * we never add a duplicate directive for a network already wired by hand.
+ */
+function leafIncludeDirectiveRegex(networkId: string): RegExp {
+  // leafIncludeFileName validates the id; escape the literal `.` in `.conf`.
+  const file = leafIncludeFileName(networkId).replace(/\./g, "\\.");
+  return new RegExp(`^[ \\t]*include[ \\t]+["']${file}["'][ \\t]*$`, "m");
+}
+
+/**
+ * True iff `natsConfigText` already includes `networkId`'s leaf file (any
+ * quote/whitespace shape). The predicate callers gate on before a rewrite.
+ */
+export function leafIncludeDirectivePresent(
+  natsConfigText: string,
+  networkId: string,
+): boolean {
+  return leafIncludeDirectiveRegex(networkId).test(natsConfigText);
+}
+
+/**
+ * Return `natsConfigText` with a top-level `include "leafnodes-<network>.conf"`
+ * directive ensured. Mirrors {@link ensureConfigArg}'s idempotent contract:
+ *
+ *   - directive already present (any quote/whitespace shape) → returned
+ *     UNCHANGED (byte-stable no-op).
+ *   - directive absent → the canonical double-quoted directive is appended as
+ *     its own top-level line (with a single trailing newline), so it sits
+ *     outside any `{ ... }` block.
+ *
+ * Pure: the input string is never mutated. Throws on an invalid network id
+ * (delegated to {@link leafIncludeFileName}) — a bad id must never reach disk.
+ */
+export function ensureLeafInclude(
+  natsConfigText: string,
+  networkId: string,
+): string {
+  const directive = leafIncludeDirective(networkId); // validates the id
+
+  if (leafIncludeDirectivePresent(natsConfigText, networkId)) {
+    return natsConfigText; // idempotent no-op (byte-stable).
+  }
+
+  // Append as a fresh top-level line. Normalise so there is exactly one
+  // newline before the directive and one after — byte-stable on re-render
+  // because the present-check above short-circuits the second call.
+  const base = natsConfigText.replace(/\n*$/, "");
+  const prefix = base.length === 0 ? "" : `${base}\n`;
+  return `${prefix}${directive}\n`;
+}
+
+/**
+ * Return `natsConfigText` with `networkId`'s include directive removed. Removes
+ * exactly the matching line(s) (any quote/whitespace shape) and nothing else;
+ * a config that never had the directive is returned UNCHANGED. The inverse of
+ * {@link ensureLeafInclude}: ensure→remove round-trips to the original bytes.
+ *
+ * Pure. Throws on an invalid network id.
+ */
+export function removeLeafInclude(
+  natsConfigText: string,
+  networkId: string,
+): string {
+  const re = leafIncludeDirectiveRegex(networkId);
+  if (!re.test(natsConfigText)) {
+    return natsConfigText; // idempotent no-op.
+  }
+  // Drop the matching line AND the newline it owns, so removing the directive
+  // we appended in ensureLeafInclude restores the pre-ensure bytes exactly.
+  const global = new RegExp(re.source + "\\n?", "gm");
+  return natsConfigText.replace(global, "");
+}
+
 /** Serialize one {@link LeafRemote} as a HOCON object literal (indented). */
 function serializeRemote(remote: LeafRemote, indent: string): string {
   // `url` + `credentials` are quoted (they contain `:`, `/`, `.` which are


### PR DESCRIPTION
Closes #754
Refs #738 #737 #733