### PR TITLE
fix(network): #756 #757 — config-split-aware policy write + nats-server restart on join

### DIFF
--- a/src/cli/cortex/commands/__tests__/network-adapters.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-adapters.test.ts
@@ -14,9 +14,11 @@
  */
 
 import { describe, test, expect, afterEach } from "bun:test";
-import { mkdtempSync, rmSync, writeFileSync, readFileSync } from "fs";
-import { tmpdir } from "os";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, readFileSync, existsSync } from "fs";
+import { tmpdir, homedir } from "os";
 import { join } from "path";
+
+import { parse as parseYaml } from "yaml";
 
 import {
   buildDryRunPorts,
@@ -27,6 +29,7 @@ import {
   ensureConfigArg,
   renderProgramArguments,
 } from "../../../../common/nats/nats-plist-loader";
+import type { PolicyFederatedNetwork } from "../../../../common/types/cortex-config";
 
 const tmpDirs: string[] = [];
 function freshDir(): string {
@@ -234,5 +237,299 @@ describe("#754 live leaf-include wiring", () => {
 
     // The file on disk is untouched.
     expect(readFileSync(conf, "utf-8")).toBe(original);
+  });
+});
+
+// =============================================================================
+// #756 — the config-store port is CONFIG-SPLIT-AWARE: it writes
+// policy.federated.networks[] to the per-stack split path
+// (~/.config/cortex/<slug>/stacks/<slug>.yaml) when the per-stack dir exists,
+// falling back to the flat legacy path otherwise. The join's policy block must
+// land in the file the DAEMON composes, not a stray orphan.
+//
+// expandTilde() reads $HOME, so each test points $HOME at a temp dir and builds
+// the layout under <tmp>/.config/cortex/.
+// =============================================================================
+
+const realHome = homedir();
+
+function withHome(home: string, fn: () => void): void {
+  const prev = process.env.HOME;
+  process.env.HOME = home;
+  try {
+    fn();
+  } finally {
+    if (prev === undefined) delete process.env.HOME;
+    else process.env.HOME = prev;
+  }
+}
+
+function cfgForStack(slug: string): LivePortsConfig {
+  return {
+    networkId: "metafactory",
+    principalId: "andreas",
+    stackId: `andreas/${slug}`,
+    natsConfigPath: "/Users/andreas/.config/nats/local.conf",
+    plistPath: "/nonexistent/plist",
+  };
+}
+
+function sampleNetwork(id: string): PolicyFederatedNetwork {
+  return {
+    id,
+    leaf_node: id,
+    peers: [],
+    accept_subjects: ["federated.andreas.meta-factory.>"],
+    deny_subjects: [],
+    announce_capabilities: [],
+    max_hop: 1,
+  };
+}
+
+describe("#756 config-split-aware policy write", () => {
+  test("writes to <slug>/stacks/<slug>.yaml when the per-stack split dir exists", () => {
+    const home = freshDir();
+    const cortexDir = join(home, ".config", "cortex");
+    // Build the config-split layout: the per-stack dir with its system marker.
+    mkdirSync(join(cortexDir, "meta-factory", "system"), { recursive: true });
+    writeFileSync(
+      join(cortexDir, "meta-factory", "system", "system.yaml"),
+      "nats:\n  url: nats://localhost:4222\n",
+      "utf-8",
+    );
+
+    withHome(home, () => {
+      const ports = buildLivePorts(cfgForStack("meta-factory"));
+      ports.configStore.writeNetworks([sampleNetwork("metafactory")]);
+    });
+
+    const splitPath = join(cortexDir, "meta-factory", "stacks", "meta-factory.yaml");
+    const flatPath = join(cortexDir, "stacks", "meta-factory.yaml");
+    // The policy block landed in the SPLIT path (the file the daemon composes).
+    expect(existsSync(splitPath)).toBe(true);
+    // And NOT in the flat orphan path.
+    expect(existsSync(flatPath)).toBe(false);
+
+    const parsed = parseYaml(readFileSync(splitPath, "utf-8")) as {
+      policy?: { federated?: { networks?: PolicyFederatedNetwork[] } };
+    };
+    expect(parsed.policy?.federated?.networks?.[0]?.id).toBe("metafactory");
+  });
+
+  test("derives the slug from the part AFTER the `/` in --stack", () => {
+    const home = freshDir();
+    const cortexDir = join(home, ".config", "cortex");
+    mkdirSync(join(cortexDir, "meta-factory", "system"), { recursive: true });
+    writeFileSync(join(cortexDir, "meta-factory", "system", "system.yaml"), "{}\n", "utf-8");
+
+    withHome(home, () => {
+      // stackId = "andreas/meta-factory" → slug "meta-factory" (NOT "andreas").
+      const ports = buildLivePorts(cfgForStack("meta-factory"));
+      ports.configStore.writeNetworks([sampleNetwork("metafactory")]);
+    });
+
+    expect(existsSync(join(cortexDir, "meta-factory", "stacks", "meta-factory.yaml"))).toBe(true);
+    expect(existsSync(join(cortexDir, "andreas", "stacks", "andreas.yaml"))).toBe(false);
+  });
+
+  test("idempotent: replace network-by-id, preserving the rest of the policy block", () => {
+    const home = freshDir();
+    const cortexDir = join(home, ".config", "cortex");
+    const stacksDir = join(cortexDir, "meta-factory", "stacks");
+    mkdirSync(join(cortexDir, "meta-factory", "system"), { recursive: true });
+    writeFileSync(join(cortexDir, "meta-factory", "system", "system.yaml"), "{}\n", "utf-8");
+    mkdirSync(stacksDir, { recursive: true });
+    // An EXISTING stack file with principals/roles/agents + a hand-pinned peer
+    // network — none of which the join must clobber.
+    const existing = [
+      "policy:",
+      "  principals:",
+      "    - id: andreas",
+      "      roles: [operator]",
+      "  agents:",
+      "    - id: echo",
+      "  federated:",
+      "    networks:",
+      "      - id: metafactory",
+      "        leaf_node: metafactory",
+      "        peers:",
+      "          - principal_id: jc",
+      "            stack_id: jc/sage-host",
+      "            principal_pubkey: UHANDPINNEDKEY",
+      "        accept_subjects: [federated.andreas.meta-factory.>]",
+      "        deny_subjects: []",
+      "        announce_capabilities: []",
+      "        max_hop: 1",
+      "      - id: research",
+      "        leaf_node: research",
+      "        peers: []",
+      "        accept_subjects: [federated.andreas.meta-factory.>]",
+      "        deny_subjects: []",
+      "        announce_capabilities: []",
+      "        max_hop: 1",
+      "",
+    ].join("\n");
+    const splitPath = join(stacksDir, "meta-factory.yaml");
+    writeFileSync(splitPath, existing, "utf-8");
+
+    withHome(home, () => {
+      const ports = buildLivePorts(cfgForStack("meta-factory"));
+      const current = ports.configStore.readNetworks();
+      // Replace metafactory by id (idempotent merge done by the orchestrator;
+      // here we simulate it), keep research untouched.
+      const replaced = current.map((n) =>
+        n.id === "metafactory" ? { ...sampleNetwork("metafactory"), max_hop: 2 } : n,
+      );
+      ports.configStore.writeNetworks(replaced);
+    });
+
+    const parsed = parseYaml(readFileSync(splitPath, "utf-8")) as {
+      policy?: {
+        principals?: { id: string }[];
+        agents?: { id: string }[];
+        federated?: { networks?: PolicyFederatedNetwork[] };
+      };
+    };
+    // The rest of the policy block is intact.
+    expect(parsed.policy?.principals?.[0]?.id).toBe("andreas");
+    expect(parsed.policy?.agents?.[0]?.id).toBe("echo");
+    // Both networks still present; research untouched; metafactory replaced.
+    const nets = parsed.policy?.federated?.networks ?? [];
+    expect(nets.map((n) => n.id).sort()).toEqual(["metafactory", "research"]);
+    const meta = nets.find((n) => n.id === "metafactory")!;
+    expect(meta.max_hop).toBe(2);
+    const research = nets.find((n) => n.id === "research")!;
+    // research's hand state is preserved verbatim.
+    expect(research.max_hop).toBe(1);
+  });
+
+  test("preserves a peer's hand-pinned pubkey on an unrelated network", () => {
+    const home = freshDir();
+    const cortexDir = join(home, ".config", "cortex");
+    const stacksDir = join(cortexDir, "meta-factory", "stacks");
+    mkdirSync(join(cortexDir, "meta-factory", "system"), { recursive: true });
+    writeFileSync(join(cortexDir, "meta-factory", "system", "system.yaml"), "{}\n", "utf-8");
+    mkdirSync(stacksDir, { recursive: true });
+    const existing = [
+      "policy:",
+      "  federated:",
+      "    networks:",
+      "      - id: research",
+      "        leaf_node: research",
+      "        peers:",
+      "          - principal_id: jc",
+      "            stack_id: jc/sage-host",
+      "            principal_pubkey: UHANDPINNEDKEY12345",
+      "        accept_subjects: [federated.andreas.meta-factory.>]",
+      "        deny_subjects: []",
+      "        announce_capabilities: []",
+      "        max_hop: 1",
+      "",
+    ].join("\n");
+    const splitPath = join(stacksDir, "meta-factory.yaml");
+    writeFileSync(splitPath, existing, "utf-8");
+
+    withHome(home, () => {
+      const ports = buildLivePorts(cfgForStack("meta-factory"));
+      const current = ports.configStore.readNetworks();
+      // Join a DIFFERENT network — research must be untouched.
+      ports.configStore.writeNetworks([...current, sampleNetwork("metafactory")]);
+    });
+
+    const parsed = parseYaml(readFileSync(splitPath, "utf-8")) as {
+      policy?: { federated?: { networks?: PolicyFederatedNetwork[] } };
+    };
+    const research = parsed.policy?.federated?.networks?.find((n) => n.id === "research");
+    expect(research?.peers?.[0]?.principal_pubkey).toBe("UHANDPINNEDKEY12345");
+  });
+
+  test("falls back to the flat legacy path when no per-stack split dir exists", () => {
+    const home = freshDir();
+    const cortexDir = join(home, ".config", "cortex");
+    // No per-stack dir / marker — legacy flat layout.
+    mkdirSync(cortexDir, { recursive: true });
+
+    withHome(home, () => {
+      const ports = buildLivePorts(cfgForStack("meta-factory"));
+      ports.configStore.writeNetworks([sampleNetwork("metafactory")]);
+    });
+
+    expect(existsSync(join(cortexDir, "stacks", "meta-factory.yaml"))).toBe(true);
+    expect(existsSync(join(cortexDir, "meta-factory", "stacks", "meta-factory.yaml"))).toBe(false);
+  });
+
+  test("dry-run writeNetworks is inert even on the split layout", () => {
+    const home = freshDir();
+    const cortexDir = join(home, ".config", "cortex");
+    mkdirSync(join(cortexDir, "meta-factory", "system"), { recursive: true });
+    writeFileSync(join(cortexDir, "meta-factory", "system", "system.yaml"), "{}\n", "utf-8");
+
+    withHome(home, () => {
+      const ports = buildDryRunPorts(cfgForStack("meta-factory"));
+      ports.configStore.writeNetworks([sampleNetwork("metafactory")]);
+    });
+
+    // Nothing written anywhere.
+    expect(existsSync(join(cortexDir, "meta-factory", "stacks", "meta-factory.yaml"))).toBe(false);
+    expect(existsSync(join(cortexDir, "stacks", "meta-factory.yaml"))).toBe(false);
+    // Sanity: we never touched the real home.
+    expect(realHome).not.toBe(home);
+  });
+});
+
+// =============================================================================
+// #757 — the live nats-server port restarts the service named by the --plist's
+// <key>Label</key>. The dry-run port is inert; error branches (missing plist /
+// missing label) never spawn launchctl. We do NOT exercise the real launchctl
+// spawn in tests (the S4 SAFETY rule — no live mutation).
+// =============================================================================
+
+describe("#757 nats-server restart port", () => {
+  test("dry-run nats-server restart is inert (no spawn, ok)", async () => {
+    const dir = freshDir();
+    const plistPath = join(dir, "nats-server.plist");
+    writeFileSync(plistPath, barePlist(), "utf-8");
+    const ports = buildDryRunPorts(cfgFor(plistPath));
+    expect(ports.natsServer).toBeDefined();
+    const res = await ports.natsServer!.restart();
+    expect(res.ok).toBe(true);
+  });
+
+  test("live restart fails cleanly when the plist is absent (no spawn)", async () => {
+    const cfg: LivePortsConfig = {
+      networkId: "metafactory",
+      principalId: "andreas",
+      stackId: "andreas/meta-factory",
+      natsConfigPath: "/x/local.conf",
+      plistPath: "/nonexistent/nats-server.plist",
+    };
+    const ports = buildLivePorts(cfg);
+    const res = await ports.natsServer!.restart();
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.reason).toContain("plist not found");
+  });
+
+  test("live restart fails cleanly when the plist has no Label (no spawn)", async () => {
+    const dir = freshDir();
+    const plistPath = join(dir, "no-label.plist");
+    // A plist with ProgramArguments but NO <key>Label</key>.
+    writeFileSync(
+      plistPath,
+      [
+        '<?xml version="1.0" encoding="UTF-8"?>',
+        '<plist version="1.0">',
+        "<dict>",
+        "\t<key>ProgramArguments</key>",
+        "\t<array><string>/opt/homebrew/bin/nats-server</string></array>",
+        "</dict>",
+        "</plist>",
+        "",
+      ].join("\n"),
+      "utf-8",
+    );
+    const ports = buildLivePorts(cfgFor(plistPath));
+    const res = await ports.natsServer!.restart();
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.reason).toContain("Label");
   });
 });

--- a/src/cli/cortex/commands/__tests__/network-lib.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-lib.test.ts
@@ -30,6 +30,7 @@ import type {
   DaemonPort,
   LeafFilePort,
   LeafStatePort,
+  NatsServerPort,
   NetworkPorts,
   NetworkRegistryPort,
   PlistPort,
@@ -96,6 +97,10 @@ function rosterFor(networkId: string): NetworkRosterResult {
 interface Recorder {
   registered: number;
   restarts: number;
+  /** #757 — count of nats-server restarts requested. */
+  natsRestarts: number;
+  /** #757 — ordered restart log: "nats" / "cortex" in call order. */
+  restartOrder: ("nats" | "cortex")[];
   writes: RenderLeafInputs[];
   removes: string[];
   /** #754 — networks whose include directive was ensured into local.conf. */
@@ -113,12 +118,18 @@ function makeFakes(opts: {
   cached?: { descriptor: NetworkDescriptor; roster: NetworkRosterResult };
   registerOk?: boolean;
   restartOk?: boolean;
+  /** #757 — make the nats-server restart fail (default: ok). */
+  natsRestartOk?: boolean;
+  /** #757 — omit the nats-server port entirely (pre-#757 caller). */
+  withoutNatsServer?: boolean;
   initialNetworks?: PolicyFederatedNetwork[];
   leafState?: LeafStatePort;
 }): { ports: NetworkPorts; rec: Recorder; storeRef: { networks: PolicyFederatedNetwork[] } } {
   const rec: Recorder = {
     registered: 0,
     restarts: 0,
+    natsRestarts: 0,
+    restartOrder: [],
     writes: [],
     removes: [],
     includesEnsured: [],
@@ -198,14 +209,33 @@ function makeFakes(opts: {
   const daemon: DaemonPort = {
     async restart() {
       rec.restarts++;
+      rec.restartOrder.push("cortex");
       return opts.restartOk === false
         ? { ok: false, reason: "launchctl kickstart failed" }
         : { ok: true };
     },
   };
 
+  const natsServer: NatsServerPort = {
+    async restart() {
+      rec.natsRestarts++;
+      rec.restartOrder.push("nats");
+      return opts.natsRestartOk === false
+        ? { ok: false, reason: "nats-server kickstart failed" }
+        : { ok: true };
+    },
+  };
+
   return {
-    ports: { registry, leafFile, plist, configStore, daemon, leafState: opts.leafState },
+    ports: {
+      registry,
+      leafFile,
+      plist,
+      configStore,
+      daemon,
+      ...(opts.withoutNatsServer === true ? {} : { natsServer }),
+      leafState: opts.leafState,
+    },
     rec,
     storeRef,
   };
@@ -299,6 +329,76 @@ describe("join", () => {
     const { ports, storeRef } = makeFakes({});
     await joinNetwork("metafactory", LOCAL, ports);
     expect(storeRef.networks[0]!.max_hop).toBe(1);
+  });
+});
+
+// =============================================================================
+// #757 — join restarts nats-server (so the leaf loads) BEFORE the cortex daemon
+// =============================================================================
+
+describe("#757 nats-server restart on join", () => {
+  test("join restarts nats-server, then the cortex daemon (order matters)", async () => {
+    const { ports, rec } = makeFakes({});
+    const res = await joinNetwork("metafactory", LOCAL, ports);
+
+    expect(res.ok).toBe(true);
+    // nats-server restarted exactly once (loads local.conf + the new leaf).
+    expect(rec.natsRestarts).toBe(1);
+    // cortex daemon also restarted (reconnect).
+    expect(rec.restarts).toBe(1);
+    // Order: nats-server FIRST (bus carries the leaf), THEN cortex reconnects.
+    expect(rec.restartOrder).toEqual(["nats", "cortex"]);
+  });
+
+  test("the nats-server restart happens AFTER the config writes", async () => {
+    const { ports, rec, storeRef } = makeFakes({});
+    await joinNetwork("metafactory", LOCAL, ports);
+    // Config + include were written before the restart fired.
+    expect(storeRef.networks.length).toBe(1);
+    expect(rec.includesEnsured).toEqual(["metafactory"]);
+    expect(rec.ensured.length).toBe(1);
+    // The restart order proves nats came after the writes (writes are sync,
+    // restarts are the last two awaited calls).
+    expect(rec.restartOrder).toEqual(["nats", "cortex"]);
+  });
+
+  test("step log records the nats-server restart line", async () => {
+    const { ports } = makeFakes({});
+    const res = await joinNetwork("metafactory", LOCAL, ports);
+    expect(
+      res.steps.some((s) => s === "restarted nats-server to load leaf config"),
+    ).toBe(true);
+    expect(res.steps.some((s) => s === "restarted stack daemon")).toBe(true);
+    // nats-server step precedes the cortex daemon step.
+    const natsIdx = res.steps.indexOf("restarted nats-server to load leaf config");
+    const cortexIdx = res.steps.indexOf("restarted stack daemon");
+    expect(natsIdx).toBeLessThan(cortexIdx);
+  });
+
+  test("a nats-server restart failure fails the join (config NOT lost, never throws)", async () => {
+    const { ports, rec, storeRef } = makeFakes({ natsRestartOk: false });
+    const res = await joinNetwork("metafactory", LOCAL, ports);
+
+    expect(res.ok).toBe(false);
+    expect(res.reason).toContain("nats-server restart failed");
+    // The config block WAS written (mutation got that far) — re-running converges.
+    expect(storeRef.networks.length).toBe(1);
+    // The cortex daemon was NOT restarted — we abort on the nats failure first.
+    expect(rec.restarts).toBe(0);
+    expect(rec.restartOrder).toEqual(["nats"]);
+  });
+
+  test("absent nats-server port → restart skipped (pre-#757 caller still works)", async () => {
+    const { ports, rec } = makeFakes({ withoutNatsServer: true });
+    const res = await joinNetwork("metafactory", LOCAL, ports);
+    expect(res.ok).toBe(true);
+    // No nats restart, but the cortex daemon still restarts.
+    expect(rec.natsRestarts).toBe(0);
+    expect(rec.restarts).toBe(1);
+    expect(rec.restartOrder).toEqual(["cortex"]);
+    expect(
+      res.steps.some((s) => s === "restarted nats-server to load leaf config"),
+    ).toBe(false);
   });
 });
 

--- a/src/cli/cortex/commands/network-adapters.ts
+++ b/src/cli/cortex/commands/network-adapters.ts
@@ -60,6 +60,7 @@ import type {
   DaemonPort,
   LeafFilePort,
   LeafStatePort,
+  NatsServerPort,
   NetworkPorts,
   NetworkRegistryPort,
   PlistPort,
@@ -294,14 +295,37 @@ function buildPlistPort(cfg: LivePortsConfig, mutate: boolean): PlistPort {
 // Config-store port — read/write policy.federated.networks[] in stacks/<stack>.yaml.
 // =============================================================================
 
-/** The stack-scoped config file that carries policy.federated.networks[]. */
+/**
+ * The stack-scoped config file that carries policy.federated.networks[] (#756).
+ *
+ * Two layouts, resolved the same way the loader's composer resolves its
+ * ingestion path (`LAYOUT_MARKER = system/system.yaml`):
+ *
+ *   - **config-split (current, migration 0003 / #714):** per-stack dirs. Each
+ *     stack lives at `~/.config/cortex/<slug>/`, with its policy block in
+ *     `~/.config/cortex/<slug>/stacks/<slug>.yaml`. This is the file the daemon
+ *     actually composes + loads, so the join's `policy.federated.networks[]`
+ *     MUST land here. Detected by the per-stack marker
+ *     `~/.config/cortex/<slug>/system/system.yaml`.
+ *   - **flat (legacy):** `~/.config/cortex/stacks/<slug>.yaml`. The pre-split
+ *     path; used only as a fallback when the per-stack dir is absent.
+ *
+ * Before #756 the join wrote the FLAT path unconditionally, so on a config-split
+ * deployment the policy block landed as a stray orphan the daemon never read.
+ * We now prefer the split layout whenever its per-stack dir exists.
+ */
 function stackConfigPath(cfg: LivePortsConfig): string {
-  // The config-split stack file. The stack id is `{principal}/{slug}`; the file
-  // is `stacks/<slug>.yaml` under the cortex config dir derived from the nats
-  // config's grandparent (~/.config/cortex). Kept overridable via a future
-  // flag; for S4 we derive it deterministically from the stack slug.
   const slug = cfg.stackId.split("/")[1] ?? "default";
   const cortexDir = expandTilde("~/.config/cortex");
+  // Config-split: the per-stack dir is marked by `<slug>/system/system.yaml`
+  // (the same marker the loader's composer keys on). When present, the policy
+  // block belongs in the per-stack `stacks/<slug>.yaml` the daemon composes.
+  const perStackDir = join(cortexDir, slug);
+  const splitMarker = join(perStackDir, "system", "system.yaml");
+  if (existsSync(splitMarker)) {
+    return join(perStackDir, "stacks", `${slug}.yaml`);
+  }
+  // Flat (legacy) fallback.
   return join(cortexDir, "stacks", `${slug}.yaml`);
 }
 
@@ -353,6 +377,54 @@ function buildDaemonPort(cfg: LivePortsConfig, mutate: boolean): DaemonPort {
 }
 
 // =============================================================================
+// Nats-server port — launchctl kickstart of the nats-server plist's service
+// (#757). The join mutates local.conf (leaf include + `include` directive); the
+// nats-server process that reads local.conf must be restarted for the leaf to
+// take effect. We restart the service named by the join's `--plist`
+// (the nats-server plist), reading its `<key>Label</key>` so the kickstart
+// target is whatever the principal's plist declares (homebrew.mxcl.nats-server,
+// a custom label, etc.) — no hardcoded label.
+// =============================================================================
+
+/** Read the launchd `<key>Label</key><string>…</string>` from a plist. */
+function readPlistLabel(plistPath: string): string | undefined {
+  const xml = readFileSync(plistPath, "utf-8");
+  const m = /<key>Label<\/key>\s*<string>([\s\S]*?)<\/string>/.exec(xml);
+  if (m === null) return undefined;
+  const label = unescapeXml(m[1] ?? "").trim();
+  return label === "" ? undefined : label;
+}
+
+function buildNatsServerPort(cfg: LivePortsConfig, mutate: boolean): NatsServerPort {
+  const plistPath = expandTilde(cfg.plistPath ?? "");
+  return {
+    async restart() {
+      if (!mutate) return { ok: true }; // dry-run: pretend success, touch nothing.
+      if (cfg.plistPath === undefined || !existsSync(plistPath)) {
+        return { ok: false, reason: `nats-server plist not found at ${plistPath}` };
+      }
+      const label = readPlistLabel(plistPath);
+      if (label === undefined) {
+        return { ok: false, reason: `no <key>Label</key> in nats-server plist ${plistPath}` };
+      }
+      const proc = Bun.spawn(
+        ["launchctl", "kickstart", "-k", `gui/${process.getuid?.() ?? 501}/${label}`],
+        { stdout: "pipe", stderr: "pipe" },
+      );
+      const code = await proc.exited;
+      if (code !== 0) {
+        const err = await new Response(proc.stderr).text();
+        return {
+          ok: false,
+          reason: `launchctl kickstart ${label} exited ${code.toString()}: ${err.trim()}`,
+        };
+      }
+      return { ok: true };
+    },
+  };
+}
+
+// =============================================================================
 // Leaf-state port — nats-server monitor /leafz for status.
 // =============================================================================
 
@@ -397,6 +469,7 @@ function buildPorts(cfg: LivePortsConfig, mutate: boolean): NetworkPorts {
     plist: buildPlistPort(cfg, mutate),
     configStore: buildConfigStorePort(cfg, mutate),
     daemon: buildDaemonPort(cfg, mutate),
+    natsServer: buildNatsServerPort(cfg, mutate),
     ...(leafState !== undefined ? { leafState } : {}),
   };
 }

--- a/src/cli/cortex/commands/network-lib.ts
+++ b/src/cli/cortex/commands/network-lib.ts
@@ -122,7 +122,8 @@ export interface StatusNetworkRow {
  *   (c) render + write the leaf include and ensure the plist loads it (DD-6),
  *   (d) merge the network into policy.federated.networks[] with registry-
  *       resolved peers (DD-5) + the OWN accept-subject,
- *   (e) restart the daemon.
+ *   (e) restart nats-server so it reloads local.conf + the new leaf (#757),
+ *       THEN restart the cortex daemon so it reconnects to the bus.
  *
  * Never throws — every failure becomes a `{ ok: false, reason }`.
  */
@@ -248,7 +249,31 @@ export async function joinNetwork(
     };
   }
 
-  // (e) Restart the daemon so the rendered leaf takes effect.
+  // (e.1) Restart nats-server so it RELOADS local.conf + the freshly-included
+  // leaf (#757). nats-server is the process that actually reads local.conf; the
+  // config writes above + the plist ensure are dormant until it restarts. Order
+  // matters: bring the bus up with the leaf FIRST, then reconnect cortex (e.2)
+  // so it attaches to a leaf that is already established. Kept inside the
+  // never-throws contract — a failed nats restart is a recoverable `{ ok: false }`.
+  // Skipped only when no nats-server port is wired (a caller that doesn't mutate
+  // the leaf); the live `join` path always supplies one.
+  if (ports.natsServer !== undefined) {
+    const natsRestart = await ports.natsServer.restart();
+    if (!natsRestart.ok) {
+      return {
+        ok: false,
+        steps,
+        reason: `config written but nats-server restart failed: ${natsRestart.reason}`,
+        network: entry,
+        usedCache,
+        resolvedPeers: peers.map((p) => p.principal_id),
+      };
+    }
+    steps.push("restarted nats-server to load leaf config");
+  }
+
+  // (e.2) Restart the cortex daemon so it reconnects to the bus (now carrying
+  // the leaf).
   const restart = await ports.daemon.restart();
   if (!restart.ok) {
     return {

--- a/src/cli/cortex/commands/network-ports.ts
+++ b/src/cli/cortex/commands/network-ports.ts
@@ -175,12 +175,30 @@ export interface ConfigStorePort {
 }
 
 /**
- * The daemon-restart seam — `launchctl kickstart` of the stack's nats-server
- * (and/or cortex) so the rendered config takes effect. Injected so tests
+ * The daemon-restart seam — `launchctl kickstart` of the stack's CORTEX daemon
+ * so it reconnects after the leaf config takes effect. Injected so tests
  * assert the restart was requested without touching launchctl.
  */
 export interface DaemonPort {
-  /** Restart the stack daemon so the new leaf config is loaded. */
+  /** Restart the stack (cortex) daemon so it reconnects to the bus. */
+  restart(): Promise<{ ok: true } | { ok: false; reason: string }>;
+}
+
+/**
+ * The nats-server-restart seam (#757). `join` mutates `local.conf` (the leaf
+ * include + the `include` directive) and ensures the plist loads it — but
+ * nats-server, the process that actually READS `local.conf`, must be restarted
+ * for the leaf to take effect. Without this the leaf change stays dormant until
+ * a manual `launchctl kickstart` of nats-server (the #757 trap, sibling of the
+ * #754 dormant-include trap).
+ *
+ * The live adapter restarts the launchd service named by the join's `--plist`
+ * (the **nats-server** plist, read from its `<key>Label</key>`); the dry-run
+ * adapter is inert. The orchestrator calls this BEFORE {@link DaemonPort.restart}
+ * so the bus carries the leaf before cortex reconnects.
+ */
+export interface NatsServerPort {
+  /** Restart nats-server so it reloads `local.conf` (the new leaf include). */
   restart(): Promise<{ ok: true } | { ok: false; reason: string }>;
 }
 
@@ -212,6 +230,13 @@ export interface NetworkPorts {
   plist: PlistPort;
   configStore: ConfigStorePort;
   daemon: DaemonPort;
+  /**
+   * Restart nats-server so it reloads `local.conf` (#757). Optional so `leave`
+   * / `status` and any caller that does not mutate the leaf can omit it; `join`
+   * calls it when present. Absent → the nats-server restart step is skipped
+   * (the pre-#757 behavior, kept for callers that don't supply it).
+   */
+  natsServer?: NatsServerPort;
   /** Optional — status link telemetry. Absent → link state "unknown". */
   leafState?: LeafStatePort;
 }


### PR DESCRIPTION
## Summary

Two `cortex network join` integration bugs, both surfaced migrating `andreas/meta-factory` to v5. Additive fixes — they do not regress #754's include-directive, the leaf write, the plist ensure, dry-run inertness, or the never-throws contract.

### #756 — policy write was not config-split-aware
`joinNetwork` wrote `policy.federated.networks[]` via `ConfigStorePort` to the FLAT legacy path `~/.config/cortex/stacks/<slug>.yaml`. On the active config-split layout (migration 0003 / #714) the daemon composes the per-stack file `~/.config/cortex/<slug>/stacks/<slug>.yaml`, so the join's policy block landed as a stray orphan the daemon never loaded.

**Fix** (`network-adapters.ts` `stackConfigPath`): detect the per-stack split dir via the same marker the loader's composer keys on (`<slug>/system/system.yaml`). When present, write `<slug>/stacks/<slug>.yaml`; otherwise fall back to the flat legacy path. The slug is the part of `--stack andreas/meta-factory` AFTER the `/` (= `meta-factory`). The existing read-merge-write preserves the rest of the policy block (principals/roles/agents) and replaces networks by id (idempotent).

### #757 — join mutated local.conf but never restarted nats-server
The join wrote the leaf include + `include` directive + ensured the plist loads `local.conf`, then restarted only the **cortex daemon**. nats-server — the process that actually reads `local.conf` — was never restarted, so the leaf stayed dormant until a manual `launchctl kickstart`.

**Fix**: new `NatsServerPort` (`network-ports.ts`); live adapter (`network-adapters.ts`) restarts the launchd service named by the join's `--plist` `<key>Label</key>` (no hardcoded label), dry-run inert. `joinNetwork` (`network-lib.ts`) restarts nats-server AFTER the config writes and BEFORE the cortex daemon restart — bus carries the leaf, then cortex reconnects. Inside the never-throws try/catch contract; adds step line `restarted nats-server to load leaf config`. The port is optional on `NetworkPorts` so non-leaf callers (leave/status) are unaffected.

## Tests (TDD)
- `network-lib.test.ts` — #757: nats-server restarted then cortex (order asserted), after the config writes, step-log line present + ordered, a nats restart failure fails the join without losing the config and without restarting cortex, absent port → skipped.
- `network-adapters.test.ts` — #756: split path targeted when the per-stack dir exists (not the flat orphan), slug derived from after the `/`, idempotent replace-by-id preserving principals/agents + a peer's hand-pinned pubkey on an unrelated network, flat fallback, dry-run inert. #757: dry-run restart inert, error branches (missing plist / missing Label) never spawn launchctl.

## Verification
- `bunx tsc --noEmit` → 0 errors
- `bun test` full suite → 4613 pass, 0 fail (2 pre-existing skips)
- touched network tests → 40 pass
- `eslint` touched files → clean
- vocab gate (`scripts/check-carveouts.sh`) → PASS
- **No live mutation in dev:** every write/exec/restart routes through the dry-run-inert adapters; the only launchctl spawn is in the live `--apply` path and is never exercised in tests.

Closes #756
Closes #757
Refs #738 #733