### PR TITLE
feat(cli): #752 #753 — one-liner cortex network join (dispatcher + config-derived inputs)

### DIFF
--- a/cortex.yaml.example
+++ b/cortex.yaml.example
@@ -82,6 +82,27 @@ stack:
   # principal=…`) into the field after first boot for the consistency
   # check to kick in.
   nkey_pub: UAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA  # <REPLACE_ME>: paste the U-prefixed pubkey from the seed
+  # ---------------------------------------------------------------------------
+  # nats_infra — per-stack nats-server infra paths + leaf account (#753)
+  # ---------------------------------------------------------------------------
+  # The stable per-stack values `cortex network join <network>` derives its
+  # --nats-config / --plist / --account / --creds from, so joining a federation
+  # network is a true one-liner: `cortex network join metafactory --apply`.
+  # Set ONCE per stack; the CLI flags survive only as optional per-invocation
+  # overrides. Fully OPTIONAL — omit the block and pass the flags by hand
+  # (legacy fully-flagged join still works). arc-populating this block at
+  # install is a follow-up; for now set it once by hand.
+  # nats_infra:
+  #   # nats-server config the launchd plist loads (-c). The per-network leaf
+  #   # include file is rendered beside it and wired in via `include`.
+  #   config_path: ~/.config/nats/local.conf
+  #   # launchd plist `cortex network join` ensures loads the config.
+  #   plist_path: ~/Library/LaunchAgents/ai.meta-factory.nats.plist
+  #   # Local NATS ACCOUNT (A…-prefixed nkey-U) the network's leaf binds to.
+  #   account: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+  #   # OPTIONAL — leaf .creds file. When omitted, the join uses the convention
+  #   # ~/.config/nats/<network>.creds (per-network creds file).
+  #   creds_path: ~/.config/nats/metafactory.creds
 
 # -----------------------------------------------------------------------------
 # security — TC-0 unified posture toggles (#628). OPTIONAL; every layer
@@ -212,6 +233,14 @@ policy:
   # identity are intentionally not accepted here.
   #
   # federated:
+  #   # registry — the network-registry endpoint + DD-9 trust pin.
+  #   # `cortex network join <network>` (#753) derives its --registry-url /
+  #   # --registry-pubkey from here, so the one-liner needs no registry flags.
+  #   registry:
+  #     url: https://registry.meta-factory.ai
+  #     # OPTIONAL pinned Ed25519 pubkey (base64, 44 chars). Omit for TOFU on
+  #     # first boot; paste the pinned value here for zero-TOFU.
+  #     # pubkey: AAAA…=
   #   networks:
   #     - id: research-collab
   #       leaf_node: nats-leaf-research   # routing label / link-pool key

--- a/src/__tests__/cortex.cli-dispatch.test.ts
+++ b/src/__tests__/cortex.cli-dispatch.test.ts
@@ -1,0 +1,119 @@
+/**
+ * #752 — commander passthrough dispatcher routing.
+ *
+ * `cortex.ts` is the commander CLI. Before #752 it registered only
+ * `start`/`stop`/`status`, so `cortex network …` / `cortex provision-stack …`
+ * errored "unknown command". #752 registers both as PASSTHROUGH subcommands
+ * that hand the raw remaining argv to the module dispatchers
+ * (`dispatchNetwork` / `dispatchProvisionStack`) WITHOUT commander interpreting
+ * the flags.
+ *
+ * These tests spawn the real entrypoint (`bun src/cortex.ts …`) so the
+ * `import.meta.main` commander block actually runs — the only faithful way to
+ * exercise the passthrough wiring + `process.exit(code)` contract. We assert:
+ *   - `network` / `provision-stack` route to the right dispatcher (help banner).
+ *   - The dispatcher's own arg parsing handles flags (no commander interception).
+ *   - An unknown SUBCOMMAND surfaces the dispatcher's usage error, exit 2.
+ *   - `start`/`stop`/`status` still parse (status against a fresh config is
+ *     inert — no daemon boot).
+ *   - NEITHER passthrough boots the daemon (no "cortex: starting…" banner).
+ */
+
+import { describe, test, expect } from "bun:test";
+import { join } from "path";
+
+// import.meta.dir = …/src/__tests__ ; the entrypoint is …/src/cortex.ts
+const ENTRY = join(import.meta.dir, "..", "cortex.ts");
+
+interface RunResult {
+  code: number;
+  stdout: string;
+  stderr: string;
+}
+
+async function runCortex(args: string[]): Promise<RunResult> {
+  const proc = Bun.spawn(["bun", ENTRY, ...args], {
+    stdout: "pipe",
+    stderr: "pipe",
+    // Clean env: no CORTEX_*/GROVE_* instrumentation leaking from the runner.
+    env: { ...process.env, CORTEX_GATEWAY: "" },
+  });
+  const [stdout, stderr] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+  ]);
+  const code = await proc.exited;
+  return { code, stdout, stderr };
+}
+
+describe("#752 — network passthrough", () => {
+  test("`cortex network --help` routes to the network dispatcher", async () => {
+    const r = await runCortex(["network", "--help"]);
+    expect(r.code).toBe(0);
+    expect(r.stdout).toContain("cortex network");
+    expect(r.stdout).toContain("join");
+    expect(r.stdout).toContain("leave");
+    expect(r.stdout).toContain("status");
+    // Must NOT have booted the daemon.
+    expect(r.stdout + r.stderr).not.toContain("cortex: starting");
+  });
+
+  test("`cortex network frobnicate` surfaces the dispatcher's unknown-subcommand error (exit 2)", async () => {
+    const r = await runCortex(["network", "frobnicate"]);
+    expect(r.code).toBe(2);
+    expect(r.stderr).toContain('unknown subcommand "frobnicate"');
+  });
+
+  test("`cortex network status --principal …` is handled by the dispatcher (no commander flag interception)", async () => {
+    // status with a unique slug → no networks joined, exit 0. Proves the
+    // `--principal` / `--stack` flags reach the dispatcher untouched.
+    const r = await runCortex([
+      "network",
+      "status",
+      "--principal",
+      "andreas",
+      "--stack",
+      `andreas/dispatch${Date.now().toString()}`,
+    ]);
+    expect(r.code).toBe(0);
+    expect(r.stdout).toContain("no networks joined");
+    expect(r.stdout + r.stderr).not.toContain("cortex: starting");
+  });
+});
+
+describe("#752 — provision-stack passthrough", () => {
+  test("`cortex provision-stack --help` routes to the provision-stack dispatcher", async () => {
+    const r = await runCortex(["provision-stack", "--help"]);
+    expect(r.code).toBe(0);
+    expect(r.stdout).toContain("cortex provision-stack");
+    expect(r.stdout).toContain("generate");
+    expect(r.stdout).toContain("register");
+    expect(r.stdout + r.stderr).not.toContain("cortex: starting");
+  });
+
+  test("`cortex provision-stack claim BADCAPS` reaches the dispatcher's principal-id grammar (exit 2)", async () => {
+    const r = await runCortex(["provision-stack", "claim", "BAD_CAPS", "--seed-path", "/tmp/x"]);
+    expect(r.code).toBe(2);
+    expect(r.stderr).toContain("principal-id");
+  });
+});
+
+describe("#752 — start/stop/status unaffected", () => {
+  test("`cortex status` against a fresh config is inert (no daemon boot)", async () => {
+    // Point at a config path that doesn't exist → `cortex: not running`.
+    const r = await runCortex(["status", "--config", `/tmp/nonexistent-${Date.now().toString()}.yaml`]);
+    expect(r.code).toBe(0);
+    expect(r.stdout).toContain("not running");
+    expect(r.stdout + r.stderr).not.toContain("cortex: starting");
+  });
+
+  test("`cortex --help` lists network + provision-stack alongside start/stop/status", async () => {
+    const r = await runCortex(["--help"]);
+    expect(r.code).toBe(0);
+    expect(r.stdout).toContain("start");
+    expect(r.stdout).toContain("stop");
+    expect(r.stdout).toContain("status");
+    expect(r.stdout).toContain("network");
+    expect(r.stdout).toContain("provision-stack");
+  });
+});

--- a/src/cli/cortex/commands/__tests__/network-cli.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-cli.test.ts
@@ -17,6 +17,17 @@ import { tmpdir } from "os";
 import { join } from "path";
 
 import { dispatchNetwork } from "../network";
+import type { LoadedConfig } from "../../../../common/config/loader";
+import type { AgentConfig } from "../../../../common/types/config";
+
+// #753 — a reader returning an EMPTY config so derivation tests are
+// deterministic (no dependence on the dev machine's real ~/.config/cortex).
+// With an empty config + no flags, every derived field is absent, so the
+// derivation surfaces its actionable "cannot resolve …" usage error.
+const EMPTY_READER = (): LoadedConfig => ({
+  config: {} as AgentConfig,
+  inlineAgents: [],
+});
 
 const tmpDirs: string[] = [];
 function freshDir(): string {
@@ -66,17 +77,24 @@ describe("join usage", () => {
     expect(res.stderr).toContain("must be lowercase");
   });
 
-  test("requires --principal (exit 2)", async () => {
-    const res = await dispatchNetwork(["join", "metafactory"]);
+  test("#753 — no principal anywhere → actionable usage error (exit 2)", async () => {
+    // With an empty config and no --principal flag, derivation names the
+    // missing config field + the override flag (the flag-wall is gone; #753).
+    const res = await dispatchNetwork(["join", "metafactory"], EMPTY_READER);
     expect(res.exitCode).toBe(2);
-    expect(res.stderr).toContain("--principal is required");
+    expect(res.stderr).toContain("cannot resolve principal");
+    expect(res.stderr).toContain("principal.id");
   });
 
-  test("requires the live-config flags (exit 2)", async () => {
-    const res = await dispatchNetwork(["join", "metafactory", "--principal", "andreas"]);
+  test("#753 — principal flagged but no registry derivable → names registry field (exit 2)", async () => {
+    const res = await dispatchNetwork(
+      ["join", "metafactory", "--principal", "andreas"],
+      EMPTY_READER,
+    );
     expect(res.exitCode).toBe(2);
-    // First missing required flag surfaces.
-    expect(res.stderr).toMatch(/--registry-url is required/);
+    // First underivable required value after seed surfaces; with empty config
+    // the seed is also missing, so seed is named first.
+    expect(res.stderr).toMatch(/cannot resolve (signing seed|registry URL)/);
   });
 
   test("--apply and --dry-run are mutually exclusive (exit 2)", async () => {
@@ -91,7 +109,7 @@ describe("join usage", () => {
       "--nats-config", join(dir, "local.conf"),
       "--plist", join(dir, "nats.plist"),
       "--apply", "--dry-run",
-    ]);
+    ], EMPTY_READER);
     expect(res.exitCode).toBe(2);
     expect(res.stderr).toContain("mutually exclusive");
   });
@@ -107,7 +125,7 @@ describe("join usage", () => {
       "--account", "A" + "B".repeat(55),
       "--nats-config", "/tmp/local.conf",
       "--plist", "/tmp/nats.plist",
-    ]);
+    ], EMPTY_READER);
     expect(res.exitCode).toBe(2);
     expect(res.stderr).toContain("prefix matching");
   });
@@ -136,7 +154,7 @@ describe("join dry-run safety", () => {
       "--account", "A" + "B".repeat(55),
       "--nats-config", natsConfig,
       "--plist", plist,
-    ]);
+    ], EMPTY_READER);
 
     // The join FAILS (no seed / unreachable registry) — but the critical S4
     // SAFETY assertion is that NOTHING was written to disk on a dry-run.
@@ -158,7 +176,7 @@ describe("join dry-run safety", () => {
       "--account", "A" + "B".repeat(55),
       "--nats-config", join(dir, "local.conf"),
       "--plist", join(dir, "nats.plist"),
-    ]);
+    ], EMPTY_READER);
     // Failure output goes to stderr; it still carries the dry-run banner.
     expect(res.stderr).toContain("dry-run");
   });
@@ -208,10 +226,11 @@ describe("status", () => {
 // =============================================================================
 
 describe("leave usage", () => {
-  test("requires --principal (exit 2)", async () => {
-    const res = await dispatchNetwork(["leave", "metafactory"]);
+  test("#753 — no principal/nats-config derivable → actionable usage error (exit 2)", async () => {
+    const res = await dispatchNetwork(["leave", "metafactory"], EMPTY_READER);
     expect(res.exitCode).toBe(2);
-    expect(res.stderr).toContain("--principal is required");
+    // Empty config + no flags: principal is the first underivable value.
+    expect(res.stderr).toContain("cannot resolve principal");
   });
 
   test("leaving an un-joined network is a clean no-op (exit 0)", async () => {
@@ -223,7 +242,7 @@ describe("leave usage", () => {
       "--stack", `andreas/${uniqueSlug}`,
       "--nats-config", join(dir, "local.conf"),
       "--plist", join(dir, "nats.plist"),
-    ]);
+    ], EMPTY_READER);
     expect(res.exitCode).toBe(0);
     expect(res.stdout).toContain("not joined");
   });
@@ -324,7 +343,7 @@ describe("leave public", () => {
       "--seed-path", join(dir, "seed.nk"),
       "--nats-config", join(dir, "local.conf"),
       "--plist", join(dir, "nats.plist"),
-    ]);
+    ], EMPTY_READER);
     expect(res.exitCode).toBe(0);
     expect(res.stdout).toContain("nothing to do");
   });

--- a/src/cli/cortex/commands/__tests__/network-derive.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-derive.test.ts
@@ -1,0 +1,305 @@
+/**
+ * #753 — config-derived `cortex network join`/`leave` inputs.
+ *
+ * The one-liner north star: `cortex network join <network>` with NO other
+ * flags derives principal / stack / seed / registry / nats-infra from the
+ * loaded config + conventions. Flags survive as optional overrides (flag wins).
+ * A required value that is neither flagged nor derivable fails with a clear,
+ * field-naming error (never a stack trace).
+ *
+ * Pure-over-injected-reader: every test passes a fake `ConfigReader` returning
+ * a fixture `LoadedConfig` — no disk, no real `~/.config/cortex/`.
+ */
+
+import { describe, test, expect } from "bun:test";
+
+import {
+  deriveJoinInputs,
+  deriveLeaveInputs,
+  defaultCredsPath,
+  type ConfigReader,
+} from "../network-derive";
+import type { LoadedConfig } from "../../../../common/config/loader";
+import type { AgentConfig } from "../../../../common/types/config";
+
+// A minimal LoadedConfig stub — only the fields the deriver reads matter; the
+// `config` AgentConfig is never inspected by the deriver, so a bare cast keeps
+// the fixture focused on principal/stack/policy.
+function loaded(partial: Partial<LoadedConfig>): LoadedConfig {
+  return {
+    config: {} as AgentConfig,
+    inlineAgents: [],
+    ...partial,
+  };
+}
+
+/** A reader that always returns the given config regardless of path. */
+function reader(cfg: LoadedConfig): ConfigReader {
+  return () => cfg;
+}
+
+// A fully-populated cortex-shape config: principal + stack (seed + nats_infra)
+// + policy.federated.registry. The "everything in config" happy path.
+const FULL = loaded({
+  principal: { id: "andreas" },
+  stack: {
+    id: "andreas/meta-factory",
+    nkey_seed_path: "~/.config/nats/cortex.nk",
+    nats_infra: {
+      config_path: "~/.config/nats/local.conf",
+      plist_path: "~/Library/LaunchAgents/nats.plist",
+      account: "A" + "B".repeat(55),
+      creds_path: "~/.config/nats/mf.creds",
+    },
+  },
+  policy: {
+    principals: [],
+    roles: [],
+    federated: {
+      networks: [],
+      registry: {
+        url: "https://registry.meta-factory.ai",
+        pubkey: "A".repeat(43) + "=",
+      },
+    },
+  },
+});
+
+// =============================================================================
+// Happy path — no flags, everything from config
+// =============================================================================
+
+describe("deriveJoinInputs — config-only (the one-liner)", () => {
+  test("derives all inputs from config with NO flags", () => {
+    const res = deriveJoinInputs("metafactory", {}, "/cfg/cortex.yaml", reader(FULL));
+    expect(res.ok).toBe(true);
+    expect(res.inputs).toEqual({
+      principal: "andreas",
+      stack: "andreas/meta-factory",
+      seedPath: "~/.config/nats/cortex.nk",
+      registryUrl: "https://registry.meta-factory.ai",
+      registryPubkey: "A".repeat(43) + "=",
+      natsConfigPath: "~/.config/nats/local.conf",
+      plistPath: "~/Library/LaunchAgents/nats.plist",
+      account: "A" + "B".repeat(55),
+      credsPath: "~/.config/nats/mf.creds",
+    });
+  });
+
+  test("creds_path absent in config → convention ~/.config/nats/<network>.creds", () => {
+    const cfg = loaded({
+      principal: { id: "andreas" },
+      stack: {
+        id: "andreas/meta-factory",
+        nkey_seed_path: "~/seed.nk",
+        nats_infra: {
+          config_path: "~/local.conf",
+          plist_path: "~/nats.plist",
+          account: "A" + "C".repeat(55),
+          // creds_path omitted on purpose
+        },
+      },
+      policy: {
+        principals: [], roles: [],
+        federated: { networks: [], registry: { url: "https://r.test" } },
+      },
+    });
+    const res = deriveJoinInputs("metafactory", {}, "/cfg", reader(cfg));
+    expect(res.ok).toBe(true);
+    expect(res.inputs?.credsPath).toBe("~/.config/nats/metafactory.creds");
+    expect(defaultCredsPath("metafactory")).toBe("~/.config/nats/metafactory.creds");
+  });
+
+  test("registry pubkey absent → omitted (TOFU), still ok", () => {
+    const cfg = loaded({
+      principal: { id: "andreas" },
+      stack: {
+        id: "andreas/meta-factory",
+        nkey_seed_path: "~/seed.nk",
+        nats_infra: { config_path: "~/c", plist_path: "~/p", account: "A" + "D".repeat(55) },
+      },
+      policy: {
+        principals: [], roles: [],
+        federated: { networks: [], registry: { url: "https://r.test" } },
+      },
+    });
+    const res = deriveJoinInputs("metafactory", {}, "/cfg", reader(cfg));
+    expect(res.ok).toBe(true);
+    expect(res.inputs?.registryPubkey).toBeUndefined();
+  });
+
+  test("no stack.id → convention {principal}/default", () => {
+    const cfg = loaded({
+      principal: { id: "andreas" },
+      stack: {
+        // id intentionally derived; but stack block must carry seed + infra.
+        // Use a stack with id default-shaped to exercise the fallback: omit id.
+        nkey_seed_path: "~/seed.nk",
+        nats_infra: { config_path: "~/c", plist_path: "~/p", account: "A" + "E".repeat(55) },
+      } as unknown as LoadedConfig["stack"],
+      policy: {
+        principals: [], roles: [],
+        federated: { networks: [], registry: { url: "https://r.test" } },
+      },
+    });
+    const res = deriveJoinInputs("metafactory", {}, "/cfg", reader(cfg));
+    expect(res.ok).toBe(true);
+    expect(res.inputs?.stack).toBe("andreas/default");
+  });
+});
+
+// =============================================================================
+// Flag overrides win
+// =============================================================================
+
+describe("deriveJoinInputs — flag overrides win", () => {
+  test("every flag overrides its config-derived value", () => {
+    const res = deriveJoinInputs(
+      "metafactory",
+      {
+        principal: "override-p",
+        stack: "override-p/other",
+        seedPath: "/flag/seed.nk",
+        registryUrl: "https://flag.registry",
+        registryPubkey: "Z".repeat(43) + "=",
+        natsConfigPath: "/flag/local.conf",
+        plistPath: "/flag/nats.plist",
+        account: "A" + "F".repeat(55),
+        credsPath: "/flag/x.creds",
+      },
+      "/cfg",
+      reader(FULL),
+    );
+    expect(res.ok).toBe(true);
+    expect(res.inputs).toEqual({
+      principal: "override-p",
+      stack: "override-p/other",
+      seedPath: "/flag/seed.nk",
+      registryUrl: "https://flag.registry",
+      registryPubkey: "Z".repeat(43) + "=",
+      natsConfigPath: "/flag/local.conf",
+      plistPath: "/flag/nats.plist",
+      account: "A" + "F".repeat(55),
+      credsPath: "/flag/x.creds",
+    });
+  });
+
+  test("flags fully satisfy a config that derives NOTHING (back-compat)", () => {
+    // An empty config (legacy bot.yaml-shape: no principal/stack/policy) plus a
+    // fully-flagged invocation still derives — preserving the old workflow.
+    const empty = loaded({});
+    const res = deriveJoinInputs(
+      "metafactory",
+      {
+        principal: "andreas",
+        seedPath: "/s",
+        registryUrl: "https://r",
+        natsConfigPath: "/c",
+        plistPath: "/p",
+        account: "A" + "G".repeat(55),
+        credsPath: "/creds",
+      },
+      "/cfg",
+      reader(empty),
+    );
+    expect(res.ok).toBe(true);
+    expect(res.inputs?.principal).toBe("andreas");
+    expect(res.inputs?.stack).toBe("andreas/default");
+  });
+});
+
+// =============================================================================
+// Missing config → clear, field-naming errors (no stack trace)
+// =============================================================================
+
+describe("deriveJoinInputs — actionable missing-config errors", () => {
+  test("no principal anywhere → names principal.id", () => {
+    const res = deriveJoinInputs("metafactory", {}, "/cfg", reader(loaded({})));
+    expect(res.ok).toBe(false);
+    expect(res.reason).toContain("principal.id");
+    expect(res.reason).toContain("--principal");
+  });
+
+  test("no seed anywhere → names stack.nkey_seed_path", () => {
+    const cfg = loaded({ principal: { id: "andreas" } });
+    const res = deriveJoinInputs("metafactory", {}, "/cfg", reader(cfg));
+    expect(res.ok).toBe(false);
+    expect(res.reason).toContain("stack.nkey_seed_path");
+  });
+
+  test("no registry anywhere → names policy.federated.registry.url", () => {
+    const cfg = loaded({
+      principal: { id: "andreas" },
+      stack: { id: "andreas/mf", nkey_seed_path: "~/s" },
+    });
+    const res = deriveJoinInputs("metafactory", {}, "/cfg", reader(cfg));
+    expect(res.ok).toBe(false);
+    expect(res.reason).toContain("policy.federated.registry.url");
+  });
+
+  test("no nats config path → names stack.nats_infra.config_path", () => {
+    const cfg = loaded({
+      principal: { id: "andreas" },
+      stack: { id: "andreas/mf", nkey_seed_path: "~/s" },
+      policy: {
+        principals: [], roles: [],
+        federated: { networks: [], registry: { url: "https://r" } },
+      },
+    });
+    const res = deriveJoinInputs("metafactory", {}, "/cfg", reader(cfg));
+    expect(res.ok).toBe(false);
+    expect(res.reason).toContain("stack.nats_infra.config_path");
+  });
+
+  test("no account → names stack.nats_infra.account", () => {
+    const cfg = loaded({
+      principal: { id: "andreas" },
+      stack: {
+        id: "andreas/mf",
+        nkey_seed_path: "~/s",
+        nats_infra: { config_path: "~/c", plist_path: "~/p" },
+      },
+      policy: {
+        principals: [], roles: [],
+        federated: { networks: [], registry: { url: "https://r" } },
+      },
+    });
+    const res = deriveJoinInputs("metafactory", {}, "/cfg", reader(cfg));
+    expect(res.ok).toBe(false);
+    expect(res.reason).toContain("stack.nats_infra.account");
+  });
+});
+
+// =============================================================================
+// Leave derivation
+// =============================================================================
+
+describe("deriveLeaveInputs", () => {
+  test("derives principal/stack/nats-config/plist from config (no flags)", () => {
+    const res = deriveLeaveInputs({}, "/cfg", reader(FULL));
+    expect(res.ok).toBe(true);
+    expect(res.inputs).toEqual({
+      principal: "andreas",
+      stack: "andreas/meta-factory",
+      natsConfigPath: "~/.config/nats/local.conf",
+      plistPath: "~/Library/LaunchAgents/nats.plist",
+    });
+  });
+
+  test("flag overrides win", () => {
+    const res = deriveLeaveInputs(
+      { principal: "p2", stack: "p2/s", natsConfigPath: "/c", plistPath: "/p" },
+      "/cfg",
+      reader(FULL),
+    );
+    expect(res.inputs?.principal).toBe("p2");
+    expect(res.inputs?.natsConfigPath).toBe("/c");
+  });
+
+  test("missing nats config → actionable error", () => {
+    const cfg = loaded({ principal: { id: "andreas" } });
+    const res = deriveLeaveInputs({}, "/cfg", reader(cfg));
+    expect(res.ok).toBe(false);
+    expect(res.reason).toContain("stack.nats_infra.config_path");
+  });
+});

--- a/src/cli/cortex/commands/network-derive.ts
+++ b/src/cli/cortex/commands/network-derive.ts
@@ -1,0 +1,291 @@
+/**
+ * #753 — derive `cortex network join`/`leave` inputs from the loaded cortex
+ * config so the headline invocation is a true one-liner:
+ *
+ *     cortex network join <network> [--apply]
+ *
+ * Everything the join needs — principal, stack, signing seed, registry pin +
+ * endpoint, and the per-stack nats-server infra paths (config / plist /
+ * account / creds) — derives from the stack's loaded config + conventions.
+ * Flags survive ONLY as optional per-invocation overrides: a flag, when
+ * present, always wins; otherwise the value derives from config; a value that
+ * is neither flagged nor derivable fails with a clear, field-naming error
+ * (never a cryptic stack trace).
+ *
+ * Sources (in override precedence — flag beats config beats convention):
+ *
+ *   | join input        | flag              | config source                                  | convention default                |
+ *   |-------------------|-------------------|------------------------------------------------|------------------------------------|
+ *   | principal         | --principal       | principal.id                                   | —                                  |
+ *   | stack             | --stack           | stack.id (single configured stack)             | {principal}/default                |
+ *   | seed-path         | --seed-path       | stack.nkey_seed_path                            | —                                  |
+ *   | registry-url      | --registry-url    | policy.federated.registry.url                  | —                                  |
+ *   | registry-pubkey   | --registry-pubkey | policy.federated.registry.pubkey               | — (TOFU when absent)               |
+ *   | nats-config       | --nats-config     | stack.nats_infra.config_path                   | —                                  |
+ *   | plist             | --plist           | stack.nats_infra.plist_path                     | —                                  |
+ *   | account           | --account         | stack.nats_infra.account                       | —                                  |
+ *   | creds             | --creds           | stack.nats_infra.creds_path                     | ~/.config/nats/<network>.creds     |
+ *
+ * This module is PURE over an injected `loadConfig` reader (the loader is
+ * threaded in by the caller) so it is unit-testable against a fixture config
+ * without touching the principal's real `~/.config/cortex/`. The CLI passes
+ * `loadConfigWithAgents`.
+ *
+ * arc-populating `stack.nats_infra` + `policy.federated.registry` at install
+ * is a follow-up (see PR notes) — today the principal sets these once by hand
+ * (or via `cortex provision-stack`), and the join derives from them.
+ */
+
+import type { LoadedConfig } from "../../../common/config/loader";
+
+// =============================================================================
+// Types
+// =============================================================================
+
+/** The five join inputs `cortex network join` previously demanded as flags. */
+export interface DerivedJoinInputs {
+  principal: string;
+  /** `{principal}/{slug}` canonical stack id. */
+  stack: string;
+  seedPath: string;
+  registryUrl: string;
+  registryPubkey?: string;
+  natsConfigPath: string;
+  plistPath: string;
+  account: string;
+  credsPath: string;
+}
+
+/** The leave inputs — a strict subset (no registry / seed / account / creds). */
+export interface DerivedLeaveInputs {
+  principal: string;
+  stack: string;
+  natsConfigPath: string;
+  plistPath: string;
+}
+
+/** Flag overrides — any field present on the CLI wins over config/convention. */
+export interface JoinOverrides {
+  principal?: string;
+  stack?: string;
+  seedPath?: string;
+  registryUrl?: string;
+  registryPubkey?: string;
+  natsConfigPath?: string;
+  plistPath?: string;
+  account?: string;
+  credsPath?: string;
+}
+
+/** A reader that loads + validates the cortex config from a path. */
+export type ConfigReader = (path: string) => LoadedConfig;
+
+export interface DeriveResult<T> {
+  ok: boolean;
+  inputs?: T;
+  /** Actionable, field-naming error when a required value can't be resolved. */
+  reason?: string;
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+/**
+ * Default per-network creds path convention: `~/.config/nats/<network>.creds`.
+ * Per-network so a stack joined to two networks keeps distinct creds files.
+ */
+export function defaultCredsPath(networkId: string): string {
+  return `~/.config/nats/${networkId}.creds`;
+}
+
+/**
+ * Resolve the stack identity from config. Precedence:
+ *   1. `--stack` flag (validated by the caller's grammar).
+ *   2. `stack.id` when the principal declared exactly one stack block.
+ *   3. convention `{principal}/default`.
+ *
+ * The single-stack rule is deliberate: the loaded config carries at most one
+ * `stack:` block (`LoadedConfig.stack`), so "the single configured stack" is
+ * unambiguous. A future multi-stack layout (stacks/*.yaml) would surface a
+ * default selection here — out of scope for #753.
+ */
+function resolveStack(
+  principal: string,
+  stackFlag: string | undefined,
+  cfg: LoadedConfig,
+): string {
+  if (stackFlag !== undefined) return stackFlag;
+  if (cfg.stack?.id !== undefined) return cfg.stack.id;
+  return `${principal}/default`;
+}
+
+function fail<T>(reason: string): DeriveResult<T> {
+  return { ok: false, reason };
+}
+
+/** An empty LoadedConfig — every derived field absent, so the deriver falls
+ *  through to flags / convention. Returned by {@link tolerantReader} when no
+ *  config file is present (fully-flagged back-compat path). */
+export const EMPTY_CONFIG: LoadedConfig = {
+  config: {} as LoadedConfig["config"],
+  inlineAgents: [],
+};
+
+/**
+ * Wrap a config reader so that a MISSING file is benign (returns
+ * {@link EMPTY_CONFIG}, letting the deriver fall through to flags/convention)
+ * while a file that EXISTS but fails to parse/validate still throws (so the
+ * caller surfaces the loader's message rather than masking it behind a vaguer
+ * "missing field" error). This is the CLI seam: the pure deriver always trusts
+ * its reader, and the CLI feeds it this tolerant wrapper. `fileExists` is
+ * injectable for unit tests; the CLI passes `fs.existsSync` over the expanded
+ * path.
+ */
+export function tolerantReader(
+  load: ConfigReader,
+  fileExists: (path: string) => boolean,
+): ConfigReader {
+  return (path: string): LoadedConfig => {
+    if (!fileExists(path)) return EMPTY_CONFIG;
+    return load(path);
+  };
+}
+
+// =============================================================================
+// Join derivation
+// =============================================================================
+
+/**
+ * Derive the full set of `cortex network join` inputs from the loaded config,
+ * applying flag overrides. `configPath` is the `--config` path the CLI is
+ * pointed at (the same default as `cortex start`).
+ *
+ * Returns `{ ok: false, reason }` with a clear, field-naming message when a
+ * required value is neither flagged nor derivable — the caller turns this into
+ * a usage error. Config-load errors (bad YAML, schema violations) propagate
+ * from the injected reader; the caller wraps them.
+ */
+export function deriveJoinInputs(
+  networkId: string,
+  overrides: JoinOverrides,
+  configPath: string,
+  load: ConfigReader,
+): DeriveResult<DerivedJoinInputs> {
+  const cfg = load(configPath);
+
+  // principal — flag wins, else principal.id.
+  const principal = overrides.principal ?? cfg.principal?.id;
+  if (principal === undefined || principal === "") {
+    return fail(
+      "cannot resolve principal — pass --principal or set `principal.id` in cortex.yaml",
+    );
+  }
+
+  const stack = resolveStack(principal, overrides.stack, cfg);
+
+  // seed-path — flag wins, else stack.nkey_seed_path.
+  const seedPath = overrides.seedPath ?? cfg.stack?.nkey_seed_path;
+  if (seedPath === undefined || seedPath === "") {
+    return fail(
+      "cannot resolve signing seed — pass --seed-path or set `stack.nkey_seed_path` in cortex.yaml",
+    );
+  }
+
+  // registry — flag wins, else policy.federated.registry.{url,pubkey}.
+  const registry = cfg.policy?.federated?.registry;
+  const registryUrl = overrides.registryUrl ?? registry?.url;
+  if (registryUrl === undefined || registryUrl === "") {
+    return fail(
+      "cannot resolve registry URL — pass --registry-url or set `policy.federated.registry.url` in cortex.yaml",
+    );
+  }
+  // pubkey stays optional everywhere (TOFU when absent).
+  const registryPubkey = overrides.registryPubkey ?? registry?.pubkey;
+
+  // nats-infra — flag wins, else stack.nats_infra.{config_path,plist_path,account}.
+  const natsInfra = cfg.stack?.nats_infra;
+
+  const natsConfigPath = overrides.natsConfigPath ?? natsInfra?.config_path;
+  if (natsConfigPath === undefined || natsConfigPath === "") {
+    return fail(
+      "cannot resolve nats config path — pass --nats-config or set `stack.nats_infra.config_path` in cortex.yaml",
+    );
+  }
+
+  const plistPath = overrides.plistPath ?? natsInfra?.plist_path;
+  if (plistPath === undefined || plistPath === "") {
+    return fail(
+      "cannot resolve plist path — pass --plist or set `stack.nats_infra.plist_path` in cortex.yaml",
+    );
+  }
+
+  const account = overrides.account ?? natsInfra?.account;
+  if (account === undefined || account === "") {
+    return fail(
+      "cannot resolve leaf account — pass --account or set `stack.nats_infra.account` in cortex.yaml",
+    );
+  }
+
+  // creds — flag wins, else stack.nats_infra.creds_path, else convention.
+  const credsPath =
+    overrides.credsPath ?? natsInfra?.creds_path ?? defaultCredsPath(networkId);
+
+  return {
+    ok: true,
+    inputs: {
+      principal,
+      stack,
+      seedPath,
+      registryUrl,
+      ...(registryPubkey !== undefined && { registryPubkey }),
+      natsConfigPath,
+      plistPath,
+      account,
+      credsPath,
+    },
+  };
+}
+
+// =============================================================================
+// Leave derivation
+// =============================================================================
+
+/**
+ * Derive the `cortex network leave` inputs — a subset of join (no registry,
+ * seed, account, or creds; leave only needs to find + tear down the leaf
+ * include + plist). Same override-then-config-then-convention precedence.
+ */
+export function deriveLeaveInputs(
+  overrides: Pick<JoinOverrides, "principal" | "stack" | "natsConfigPath" | "plistPath">,
+  configPath: string,
+  load: ConfigReader,
+): DeriveResult<DerivedLeaveInputs> {
+  const cfg = load(configPath);
+
+  const principal = overrides.principal ?? cfg.principal?.id;
+  if (principal === undefined || principal === "") {
+    return fail(
+      "cannot resolve principal — pass --principal or set `principal.id` in cortex.yaml",
+    );
+  }
+
+  const stack = resolveStack(principal, overrides.stack, cfg);
+  const natsInfra = cfg.stack?.nats_infra;
+
+  const natsConfigPath = overrides.natsConfigPath ?? natsInfra?.config_path;
+  if (natsConfigPath === undefined || natsConfigPath === "") {
+    return fail(
+      "cannot resolve nats config path — pass --nats-config or set `stack.nats_infra.config_path` in cortex.yaml",
+    );
+  }
+
+  const plistPath = overrides.plistPath ?? natsInfra?.plist_path;
+  if (plistPath === undefined || plistPath === "") {
+    return fail(
+      "cannot resolve plist path — pass --plist or set `stack.nats_infra.plist_path` in cortex.yaml",
+    );
+  }
+
+  return { ok: true, inputs: { principal, stack, natsConfigPath, plistPath } };
+}

--- a/src/cli/cortex/commands/network.ts
+++ b/src/cli/cortex/commands/network.ts
@@ -40,7 +40,27 @@
  * Exit codes: 0 success · 1 operational failure · 2 usage error.
  */
 
-import { expandTilde } from "../../../common/config/loader";
+import { existsSync } from "fs";
+
+import { expandTilde, loadConfigWithAgents } from "../../../common/config/loader";
+
+import {
+  deriveJoinInputs,
+  deriveLeaveInputs,
+  tolerantReader,
+  type ConfigReader,
+} from "./network-derive";
+
+/**
+ * #753 — the production config reader: `loadConfigWithAgents` wrapped so a
+ * MISSING cortex.yaml is benign (a fully-flagged back-compat invocation works
+ * on a machine with no config), while a present-but-broken file still surfaces
+ * its parse/schema error. Tests inject their own reader through `dispatchNetwork`.
+ */
+const DEFAULT_READER: ConfigReader = tolerantReader(
+  loadConfigWithAgents,
+  (path) => existsSync(expandTilde(path)),
+);
 
 import { CliArgsError } from "./_shared/arg-error";
 import { envelopeError, envelopeOk, renderJson } from "./_shared/envelope";
@@ -74,6 +94,13 @@ export { type ExitResult } from "./_shared/exit-result";
 
 type NetworkSubcommand = "join" | "leave" | "status";
 
+/**
+ * #753 — default cortex.yaml path the config-deriver reads when no `--config`
+ * is passed. Same canonical path as `cortex agents` (`agents.ts`). The
+ * one-liner `cortex network join <network>` reads here.
+ */
+const DEFAULT_CONFIG_PATH = "~/.config/cortex/cortex.yaml";
+
 const NETWORK_ID_RE = /^[a-z][a-z0-9-]*$/;
 const PRINCIPAL_ID_RE = /^[a-z][a-z0-9-]*$/;
 // S5 — capability id grammar (`<domain>.<entity>`, matches the schema's
@@ -86,6 +113,12 @@ const SPEC: SubcommandSpec<NetworkSubcommand> = {
     join: {
       positionals: ["network"],
       flags: {
+        // #753 — `--config` points the deriver at the cortex.yaml to read
+        // principal / stack / seed / registry / nats-infra from. All other
+        // value-flags below are now OPTIONAL OVERRIDES: present ⇒ wins;
+        // absent ⇒ derived from this config (or convention). The one-liner is
+        // `cortex network join <network>` with NO other flags.
+        "--config": "value",
         "--principal": "value",
         "--stack": "value",
         "--registry-url": "value",
@@ -110,6 +143,8 @@ const SPEC: SubcommandSpec<NetworkSubcommand> = {
     leave: {
       positionals: ["network"],
       flags: {
+        // #753 — same config-derivation seam as join (subset of inputs).
+        "--config": "value",
         "--principal": "value",
         "--stack": "value",
         "--registry-url": "value",
@@ -152,6 +187,27 @@ function optionalValueFlag(
 ): string | undefined {
   const v = flags[name];
   return typeof v === "string" ? v : undefined;
+}
+
+/**
+ * #753 — build a single-key override fragment for the config-deriver from a
+ * value-flag. When the flag is absent (or valueless) the fragment is empty, so
+ * the deriver falls through to config / convention. `key` defaults to the
+ * camelCase of the flag's tail; pass it explicitly where the names differ.
+ * Spreading the result keeps the override object free of `undefined` keys
+ * (which would otherwise shadow the config value with `undefined`).
+ */
+function readOverride(
+  flags: Record<string, string | true>,
+  flagName: string,
+  key?: string,
+): Record<string, string> {
+  const v = optionalValueFlag(flags, flagName);
+  if (v === undefined) return {};
+  // Default key: strip leading `--`, drop hyphens → `principal` from
+  // `--principal`. Callers pass an explicit `key` for the renamed inputs.
+  const resolvedKey = key ?? flagName.replace(/^--/, "").replace(/-/g, "");
+  return { [resolvedKey]: v };
 }
 
 /** Resolve the stack slug from `--stack` (`{principal}/{slug}`) or default. */
@@ -198,6 +254,7 @@ async function runJoin(
   networkId: string,
   flags: Record<string, string | true>,
   json: boolean,
+  load: ConfigReader,
 ): Promise<ExitResult> {
   // S5 (#739) — `join public` is the open-square opt-in, structurally distinct
   // from a federated join (no leaf, no creds/account, no peers). Route it to
@@ -209,24 +266,44 @@ async function runJoin(
   if (!NETWORK_ID_RE.test(networkId)) {
     return usageError("join", `network "${networkId}" must be lowercase alphanumeric + hyphen, letter-prefixed`, json);
   }
-  const principalRes = requireValueFlag(flags, "--principal");
-  if (!principalRes.ok) return usageError("join", principalRes.reason, json);
-  if (!PRINCIPAL_ID_RE.test(principalRes.value)) {
-    return usageError("join", `--principal "${principalRes.value}" must be lowercase alphanumeric + hyphen, letter-prefixed`, json);
-  }
-  const slugRes = resolveStackSlug(principalRes.value, optionalValueFlag(flags, "--stack"));
-  if (!slugRes.ok) return usageError("join", slugRes.reason, json);
 
-  // All six are required for a live join; resolve them typed so the stack
-  // identity carries real strings (no non-null assertions).
-  for (const required of ["--registry-url", "--seed-path", "--nats-config", "--plist"]) {
-    const r = requireValueFlag(flags, required);
-    if (!r.ok) return usageError("join", r.reason, json);
+  // #753 — derive principal / stack / seed / registry / nats-infra (config +
+  // convention), with each flag surviving as an optional override. Config-load
+  // errors (bad YAML, schema violations) surface as an op-error with the
+  // loader's message; a derivable-but-missing required value surfaces as a
+  // usage error naming the config field.
+  let derived;
+  try {
+    derived = deriveJoinInputs(
+      networkId,
+      {
+        ...readOverride(flags, "--principal"),
+        ...readOverride(flags, "--stack", "stack"),
+        ...readOverride(flags, "--seed-path", "seedPath"),
+        ...readOverride(flags, "--registry-url", "registryUrl"),
+        ...readOverride(flags, "--registry-pubkey", "registryPubkey"),
+        ...readOverride(flags, "--nats-config", "natsConfigPath"),
+        ...readOverride(flags, "--plist", "plistPath"),
+        ...readOverride(flags, "--account", "account"),
+        ...readOverride(flags, "--creds", "credsPath"),
+      },
+      expandTilde(optionalValueFlag(flags, "--config") ?? DEFAULT_CONFIG_PATH),
+      load,
+    );
+  } catch (err) {
+    return opError("join", `config load failed: ${err instanceof Error ? err.message : String(err)}`, json);
   }
-  const credsRes = requireValueFlag(flags, "--creds");
-  if (!credsRes.ok) return usageError("join", credsRes.reason, json);
-  const accountRes = requireValueFlag(flags, "--account");
-  if (!accountRes.ok) return usageError("join", accountRes.reason, json);
+  if (!derived.ok || derived.inputs === undefined) {
+    return usageError("join", derived.reason ?? "could not derive join inputs", json);
+  }
+  const inputs = derived.inputs;
+
+  // Grammar checks on the RESOLVED principal (derived or flagged).
+  if (!PRINCIPAL_ID_RE.test(inputs.principal)) {
+    return usageError("join", `principal "${inputs.principal}" must be lowercase alphanumeric + hyphen, letter-prefixed`, json);
+  }
+  const slugRes = resolveStackSlug(inputs.principal, inputs.stack);
+  if (!slugRes.ok) return usageError("join", slugRes.reason, json);
 
   const maxHopRaw = optionalValueFlag(flags, "--max-hop");
   let maxHop: number | undefined;
@@ -241,15 +318,15 @@ async function runJoin(
   if (!applyRes.ok) return usageError("join", applyRes.reason, json);
 
   const stack: JoiningStack = {
-    principalId: principalRes.value,
+    principalId: inputs.principal,
     stackSlug: slugRes.slug,
-    credentials: expandTilde(credsRes.value),
-    account: accountRes.value,
+    credentials: expandTilde(inputs.credsPath),
+    account: inputs.account,
     leafNode: optionalValueFlag(flags, "--leaf-node"),
     maxHop,
   };
 
-  const cfg = portsConfig(networkId, principalRes.value, slugRes.slug, flags);
+  const cfg = portsConfigFromInputs(networkId, inputs, slugRes.slug, flags);
   const ports = applyRes.apply ? buildLivePorts(cfg) : buildDryRunPorts(cfg);
 
   const res = await joinNetwork(networkId, stack, ports);
@@ -263,6 +340,7 @@ async function runLeave(
   networkId: string,
   flags: Record<string, string | true>,
   json: boolean,
+  load: ConfigReader,
 ): Promise<ExitResult> {
   // S5 (#739) — `leave public` reverses the open-square opt-in.
   if (networkId === "public") {
@@ -271,18 +349,40 @@ async function runLeave(
   if (!NETWORK_ID_RE.test(networkId)) {
     return usageError("leave", `network "${networkId}" must be lowercase alphanumeric + hyphen, letter-prefixed`, json);
   }
-  const principalRes = requireValueFlag(flags, "--principal");
-  if (!principalRes.ok) return usageError("leave", principalRes.reason, json);
-  const slugRes = resolveStackSlug(principalRes.value, optionalValueFlag(flags, "--stack"));
-  if (!slugRes.ok) return usageError("leave", slugRes.reason, json);
-  for (const required of ["--nats-config", "--plist"]) {
-    const r = requireValueFlag(flags, required);
-    if (!r.ok) return usageError("leave", r.reason, json);
+
+  // #753 — derive principal / stack / nats-config / plist (the leave subset).
+  let derived;
+  try {
+    derived = deriveLeaveInputs(
+      {
+        ...readOverride(flags, "--principal"),
+        ...readOverride(flags, "--stack", "stack"),
+        ...readOverride(flags, "--nats-config", "natsConfigPath"),
+        ...readOverride(flags, "--plist", "plistPath"),
+      },
+      expandTilde(optionalValueFlag(flags, "--config") ?? DEFAULT_CONFIG_PATH),
+      load,
+    );
+  } catch (err) {
+    return opError("leave", `config load failed: ${err instanceof Error ? err.message : String(err)}`, json);
   }
+  if (!derived.ok || derived.inputs === undefined) {
+    return usageError("leave", derived.reason ?? "could not derive leave inputs", json);
+  }
+  const inputs = derived.inputs;
+
+  const slugRes = resolveStackSlug(inputs.principal, inputs.stack);
+  if (!slugRes.ok) return usageError("leave", slugRes.reason, json);
   const applyRes = resolveApply(flags);
   if (!applyRes.ok) return usageError("leave", applyRes.reason, json);
 
-  const cfg = portsConfig(networkId, principalRes.value, slugRes.slug, flags);
+  const cfg: LivePortsConfig = {
+    networkId,
+    principalId: inputs.principal,
+    stackId: `${inputs.principal}/${slugRes.slug}`,
+    natsConfigPath: inputs.natsConfigPath,
+    plistPath: inputs.plistPath,
+  };
   const ports = applyRes.apply ? buildLivePorts(cfg) : buildDryRunPorts(cfg);
 
   const res = await leaveNetwork(networkId, ports);
@@ -437,6 +537,31 @@ function portsConfig(
   };
 }
 
+/**
+ * #753 — build the live/dry-run ports config from the DERIVED join inputs
+ * (config + convention + flag-overrides resolved upstream by the deriver),
+ * rather than re-reading raw flags. `--monitor-url` is the one read-only-status
+ * flag that doesn't participate in the join derivation, so it's read here.
+ */
+function portsConfigFromInputs(
+  networkId: string,
+  inputs: import("./network-derive").DerivedJoinInputs,
+  stackSlug: string,
+  flags: Record<string, string | true>,
+): LivePortsConfig {
+  return {
+    networkId,
+    principalId: inputs.principal,
+    stackId: `${inputs.principal}/${stackSlug}`,
+    registryUrl: inputs.registryUrl,
+    ...(inputs.registryPubkey !== undefined && { registryPubkey: inputs.registryPubkey }),
+    seedPath: inputs.seedPath,
+    natsConfigPath: inputs.natsConfigPath,
+    plistPath: inputs.plistPath,
+    monitorUrl: optionalValueFlag(flags, "--monitor-url"),
+  };
+}
+
 function renderFlowResult(
   sub: string,
   networkId: string,
@@ -478,11 +603,29 @@ function usageError(sub: string, reason: string, json: boolean): ExitResult {
   return { exitCode: 2, stdout: "", stderr };
 }
 
+/**
+ * #753 — operational failure (exit 1), distinct from a usage error (exit 2).
+ * Used when the config file itself fails to load/parse — that is an
+ * operational problem, not a CLI-grammar mistake.
+ */
+function opError(sub: string, reason: string, json: boolean): ExitResult {
+  const stderr = json
+    ? renderJson(envelopeError(reason, { subcommand: sub }))
+    : `cortex network ${sub}: ${reason}\n`;
+  return { exitCode: 1, stdout: "", stderr };
+}
+
 // =============================================================================
 // Dispatcher
 // =============================================================================
 
-export async function dispatchNetwork(argv: string[]): Promise<ExitResult> {
+export async function dispatchNetwork(
+  argv: string[],
+  // #753 — injectable config reader so CLI tests can derive from a fixture
+  // config without touching the principal's real `~/.config/cortex/`.
+  // Production callers omit it and the real `loadConfigWithAgents` is used.
+  load: ConfigReader = DEFAULT_READER,
+): Promise<ExitResult> {
   let parsed;
   try {
     parsed = parseSubcommandArgs(SPEC, argv);
@@ -508,9 +651,9 @@ export async function dispatchNetwork(argv: string[]): Promise<ExitResult> {
 
   switch (parsed.subcommand) {
     case "join":
-      return runJoin(parsed.positionals.network ?? "", parsed.flags, json);
+      return runJoin(parsed.positionals.network ?? "", parsed.flags, json, load);
     case "leave":
-      return runLeave(parsed.positionals.network ?? "", parsed.flags, json);
+      return runLeave(parsed.positionals.network ?? "", parsed.flags, json, load);
     case "status":
       return runStatus(parsed.flags, json);
   }
@@ -521,17 +664,22 @@ export async function dispatchNetwork(argv: string[]): Promise<ExitResult> {
 // =============================================================================
 
 function topLevelHelp(): string {
-  return `cortex network — one-command join to the Internet of Agentic Work (S4, #738)
+  return `cortex network — one-command join to the Internet of Agentic Work (S4, #738; #752/#753)
 
 Usage:
-  cortex network join  <network> --principal <id> --registry-url <url> \\
-                        --seed-path <p> --creds <p> --account <nkey-U> \\
-                        --nats-config <p> --plist <p> [--stack <id>] \\
-                        [--registry-pubkey <b64>] [--leaf-node <name>] \\
-                        [--max-hop <n>] [--apply] [--json]
-  cortex network leave  <network> --principal <id> --nats-config <p> \\
-                        --plist <p> [--stack <id>] [--apply] [--json]
-  cortex network status --principal <id> [--stack <id>] [--monitor-url <url>] [--json]
+  cortex network join  <network> [--apply] [--config <p>] [overrides…]
+  cortex network leave  <network> [--apply] [--config <p>] [overrides…]
+  cortex network status [--principal <id>] [--stack <id>] [--monitor-url <url>] [--json]
+
+The one-liner (#753): \`cortex network join <network>\` derives EVERYTHING from
+the loaded cortex.yaml — principal (principal.id), stack (stack.id), signing
+seed (stack.nkey_seed_path), registry (policy.federated.registry.{url,pubkey}),
+and the nats-server infra (stack.nats_infra.{config_path,plist_path,account,
+creds_path}). Pass --config <p> to point at a non-default cortex.yaml
+(default: ~/.config/cortex/cortex.yaml). The flags below are OPTIONAL
+OVERRIDES: a passed flag wins; otherwise the value derives from config (or, for
+creds, the convention ~/.config/nats/<network>.creds). A required value that is
+neither flagged nor derivable fails with a clear error naming the config field.
 
 Subcommands:
   join    Register → pull the SIGNED+VERIFIED network descriptor (DD-9; cached
@@ -559,16 +707,17 @@ Safety:
   intended actions). Pass --apply to execute for real. --apply and --dry-run
   are mutually exclusive.
 
-Flags:
-  --principal <id>        Local principal id (the {me} subject segment).
-  --stack <id>            {principal}/{slug}; defaults to <principal>/default.
-  --registry-url <url>    Network-registry base URL (control plane).
-  --registry-pubkey <b64> Pinned registry Ed25519 pubkey (DD-9); TOFU if omitted.
-  --seed-path <p>         Stack signing seed for registration (proof-of-possession).
-  --creds <p>             nats-server leaf .creds file (absolute).
-  --account <nkey-U>      Local NATS account the leaf binds to (A… nkey-U).
-  --nats-config <p>       nats-server config the plist loads (-c) + includes the leaf.
-  --plist <p>             nats-server launchd plist to ensure loads the config.
+Flags (all OPTIONAL OVERRIDES — derived from cortex.yaml when omitted; #753):
+  --config <p>            cortex.yaml to derive inputs from (default: ~/.config/cortex/cortex.yaml).
+  --principal <id>        Override principal.id (the {me} subject segment).
+  --stack <id>            Override stack.id; {principal}/{slug}; defaults to <principal>/default.
+  --registry-url <url>    Override policy.federated.registry.url.
+  --registry-pubkey <b64> Override policy.federated.registry.pubkey (DD-9); TOFU if omitted.
+  --seed-path <p>         Override stack.nkey_seed_path (proof-of-possession).
+  --creds <p>             Override stack.nats_infra.creds_path (default: ~/.config/nats/<network>.creds).
+  --account <nkey-U>      Override stack.nats_infra.account (A… nkey-U the leaf binds to).
+  --nats-config <p>       Override stack.nats_infra.config_path (nats-server -c config).
+  --plist <p>             Override stack.nats_infra.plist_path (nats-server launchd plist).
   --leaf-node <name>      Leaf connection name on the network entry (default: network id).
   --max-hop <n>           Hop budget written on the network (default: 1).
   --capabilities <csv>    (join public) Comma-separated capability ids to announce

--- a/src/common/types/stack.ts
+++ b/src/common/types/stack.ts
@@ -43,6 +43,66 @@ import { z } from "zod/v4";
 import { NKEY_PUBKEY_REGEX } from "./nkey";
 
 // =============================================================================
+// Per-stack NATS infrastructure paths — #753 (one-liner `cortex network join`)
+// =============================================================================
+
+/**
+ * `stack.nats_infra` — the stable per-stack nats-server infrastructure paths +
+ * leaf account that `cortex network join`/`leave` need to render the leaf
+ * include file, ensure the plist loads it, and bind the leaf to the local
+ * account. These are set ONCE per stack (they describe where the stack's
+ * nats-server config + launchd plist live on disk and which account its leaf
+ * binds to), then every `cortex network join <network>` derives its
+ * `--nats-config` / `--plist` / `--account` / `--creds` from this block.
+ *
+ * #753 — the friction-removal block. Before this, every `cortex network join`
+ * had to pass `--nats-config --plist --account --creds` on the command line;
+ * these never change between joins on the same stack, so they belong in config.
+ * The headline `cortex network join <network>` derives all four from here, with
+ * the CLI flags surviving only as optional per-invocation overrides.
+ *
+ * Fully OPTIONAL — a stack that never federates omits the block entirely and
+ * the legacy fully-flagged `cortex network join` invocation still works
+ * unchanged (the derivation falls back to flags; a missing value that is
+ * neither in config nor on the flag fails with a clear, field-naming error).
+ */
+export const StackNatsInfraSchema = z.object({
+  /**
+   * Path to the nats-server config the launchd plist loads (`-c`). The leaf
+   * include file is rendered beside it and wired in via an `include`
+   * directive. Maps to the `--nats-config` join flag. Leading `~/` expands to
+   * `$HOME` at the CLI (same `expandTilde` treatment as `nkey_seed_path`).
+   */
+  config_path: z.string().min(1).optional(),
+  /**
+   * Path to the nats-server launchd plist `cortex network join` ensures loads
+   * the config (and reloads on join/leave). Maps to the `--plist` flag.
+   */
+  plist_path: z.string().min(1).optional(),
+  /**
+   * The local NATS account (`A…` nkey-U) the network's leaf binds to. Maps to
+   * the `--account` flag. Same 56-char U-prefixed base32 NKey grammar as every
+   * other NKey on the schema, but the prefix is `A` (account) not `U` (user) —
+   * validated softly here (length + alphabet) since the leaf account is an
+   * account-class key, and strict prefix discrimination happens in the leaf
+   * renderer.
+   */
+  account: z.string().regex(
+    /^A[A-Z0-9]{55}$/,
+    "stack.nats_infra.account must be an account-class NKey (A-prefixed, 56 chars total)",
+  ).optional(),
+  /**
+   * Path to the leaf `.creds` file for the network connection. Maps to the
+   * `--creds` flag. OPTIONAL even within the block: when omitted, the join
+   * derives the convention default `~/.config/nats/<network>.creds`
+   * (per-network creds file). Declare here only to override the convention.
+   */
+  creds_path: z.string().min(1).optional(),
+}).strict();
+
+export type StackNatsInfra = z.infer<typeof StackNatsInfraSchema>;
+
+// =============================================================================
 // Schema
 // =============================================================================
 
@@ -130,6 +190,14 @@ export const StackConfigSchema = z.object({
    * `loadStackSigningKey` seam.
    */
   nkey_seed_path: z.string().optional(),
+  /**
+   * #753 — per-stack nats-server infrastructure paths + leaf account that
+   * `cortex network join`/`leave` derive their `--nats-config` / `--plist` /
+   * `--account` / `--creds` inputs from. Stable per stack; set once. Fully
+   * optional — omitting it keeps the legacy fully-flagged join working
+   * unchanged. See {@link StackNatsInfraSchema}.
+   */
+  nats_infra: StackNatsInfraSchema.optional(),
 });
 
 export type StackConfig = z.infer<typeof StackConfigSchema>;

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -108,6 +108,13 @@ import type { SurfaceGateway } from "./gateway/surface-gateway";
 import { createDispatchListener, type DispatchListener } from "./runner/dispatch-listener";
 import { WorklogManager } from "./runner/worklog-manager";
 
+// #752 — the `network` + `provision-stack` subcommand dispatchers. Registered
+// as passthrough commander subcommands below so `cortex network join …` and
+// `cortex provision-stack register …` work directly (no `bun src/...` prefix).
+// These do NOT boot the daemon — only `start` does.
+import { dispatchNetwork } from "./cli/cortex/commands/network";
+import { dispatchProvisionStack } from "./cli/cortex/commands/provision-stack";
+
 import { CloudPublisher } from "./taps/cc-events/cloud-publisher";
 import {
   RegistryClient,
@@ -2901,7 +2908,7 @@ export async function startCortex(
  * well-defined. Suppressing the unsafe-* family inside this function is
  * the boundary; production callers see the typed return signature.
  */
-/* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unnecessary-type-assertion */
+/* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unnecessary-type-assertion */
 /**
  * cortex#338 — resolve the JetStreamManager-shaped provisioning
  * capability needed by the review-stream + per-agent durable boot
@@ -3002,7 +3009,7 @@ async function setupDashboard(
   const mcDb = (api.getDb() ?? null) as BunDatabase | null;
   return { api, usageMonitor, mcDb };
 }
-/* eslint-enable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unnecessary-type-assertion */
+/* eslint-enable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unnecessary-type-assertion */
 
 /** Subscribe a Discord adapter to the published-events JSONL stream so legacy
  *  `#agent-log` and per-task worklog threads keep working. Mirrors grove-bot's
@@ -3272,6 +3279,11 @@ if (import.meta.main) {
   const program = new Command()
     .name("cortex")
     .description("Cortex — the M7 conscious processing surface agent")
+    // #752 — required so the `network` / `provision-stack` passthrough
+    // subcommands below can call `.passThroughOptions()`: commander stops
+    // interpreting options after the subcommand name and hands the raw
+    // remaining argv to the subcommand's own `[args...]` parser.
+    .enablePositionalOptions()
     .version(getVersion());
 
   program
@@ -3387,6 +3399,42 @@ if (import.meta.main) {
         console.log(`cortex: stale PID file ${pidFile}`);
         unlinkSync(pidFile);
       }
+    });
+
+  // #752 — passthrough subcommands. The module dispatchers
+  // (`dispatchNetwork` / `dispatchProvisionStack`) own their own arg parsing
+  // via `parseSubcommandArgs(SPEC, argv)`, so commander must hand them the raw
+  // remaining argv UNTOUCHED: no option interpretation, no `--help`
+  // interception, no unknown-option rejection. The variadic `[args...]`
+  // argument + `.allowUnknownOption()` + `passThroughOptions()` +
+  // `.helpOption(false)` achieve that. Neither boots the daemon — only `start`
+  // does — so `cortex network join …` runs the CLI flow and exits.
+  program
+    .command("network")
+    .description("Manage federation network membership (join / leave / status)")
+    .argument("[args...]", "network subcommand + flags (see `cortex network --help`)")
+    .allowUnknownOption()
+    .passThroughOptions()
+    .helpOption(false)
+    .action(async (args: string[]) => {
+      const result = await dispatchNetwork(args);
+      if (result.stdout) process.stdout.write(result.stdout);
+      if (result.stderr) process.stderr.write(result.stderr);
+      process.exit(result.exitCode);
+    });
+
+  program
+    .command("provision-stack")
+    .description("Provision a stack signing identity (generate / claim / register)")
+    .argument("[args...]", "provision-stack subcommand + flags (see `cortex provision-stack --help`)")
+    .allowUnknownOption()
+    .passThroughOptions()
+    .helpOption(false)
+    .action(async (args: string[]) => {
+      const result = await dispatchProvisionStack(args);
+      if (result.stdout) process.stdout.write(result.stdout);
+      if (result.stderr) process.stderr.write(result.stderr);
+      process.exit(result.exitCode);
     });
 
   program.parse();


### PR DESCRIPTION
Closes #752
Closes #753
Refs #738 #733

## North star (spec §9 — "feel like TCP/IP")

`cortex network join <network> [--apply]` with **NO other flags required**. Everything derives from the loaded cortex config + conventions; flags survive as optional overrides.

## Part A — #752: commander passthrough dispatcher

`cortex.ts` was a commander CLI with only `start`/`stop`/`status` → `cortex network …` errored "unknown command". Now `network` + `provision-stack` are registered as **passthrough** subcommands:

- `.enablePositionalOptions()` on the program + `.passThroughOptions()` + `.allowUnknownOption()` + `.argument("[args...]")` + `.helpOption(false)` on each subcommand → commander hands the raw remaining argv to the module dispatchers (`dispatchNetwork` / `dispatchProvisionStack`), which keep doing their own `parseSubcommandArgs(SPEC, argv)` parsing.
- The action writes stdout/stderr and `process.exit(result.code)`.
- **Neither boots the daemon** — only `start` does.

Result: `cortex network join …` and `cortex provision-stack register …` work directly (no `bun src/...` prefix).

## Part B — #753: derive inputs from config

New pure deriver `src/cli/cortex/commands/network-derive.ts` (unit-testable over an injected `ConfigReader`). Derived fields + their source:

| join input | flag (override) | config source | convention |
|---|---|---|---|
| principal | `--principal` | `principal.id` | — |
| stack | `--stack` | `stack.id` (single configured stack) | `{principal}/default` |
| seed-path | `--seed-path` | `stack.nkey_seed_path` | — |
| registry-url | `--registry-url` | `policy.federated.registry.url` | — |
| registry-pubkey | `--registry-pubkey` | `policy.federated.registry.pubkey` | — (TOFU) |
| nats-config | `--nats-config` | `stack.nats_infra.config_path` | — |
| plist | `--plist` | `stack.nats_infra.plist_path` | — |
| account | `--account` | `stack.nats_infra.account` | — |
| creds | `--creds` | `stack.nats_infra.creds_path` | `~/.config/nats/<network>.creds` |

**New config block** (`src/common/types/stack.ts`): `stack.nats_infra { config_path?, plist_path?, account?, creds_path? }` — the stable per-stack nats-server infra paths + leaf account, set once. The registry pin already existed at `policy.federated.registry.{url,pubkey}` (DD-9) — reused, not re-added.

**Precedence:** flag → config → convention. A value that is neither flagged nor derivable fails with a clear, **field-naming** error (e.g. `cannot resolve nats config path — pass --nats-config or set \`stack.nats_infra.config_path\` in cortex.yaml`), not a stack trace.

**Back-compat:** existing fully-flagged invocations still work. A `tolerantReader` returns empty config when no cortex.yaml is present (so a flag-complete join needs no config file); a present-but-broken config still surfaces its parse error.

## Out of scope (unchanged)

Wire grammar, leaf renderer, registry. Dry-run-default + never-throws contracts preserved.

## Tests

- `network-derive.test.ts` (14) — config-only one-liner derives all inputs; creds convention; TOFU pubkey; stack default; flag overrides win; fully-flagged back-compat; missing-config → field-naming errors; leave subset.
- `cortex.cli-dispatch.test.ts` (7) — spawns the real entrypoint: `network`/`provision-stack` route to the right dispatcher; flags reach the dispatcher untouched; unknown subcommand → exit 2; start/stop/status unaffected; no daemon boot; `--help` lists both.
- `network-cli.test.ts` updated to the #753 contract (flag-wall removed; deterministic via injected empty reader).
- `bunx tsc --noEmit` 0 · `bun test` 4634 pass / 0 fail / 2 skip · eslint clean.

## Follow-up

arc-populating `stack.nats_infra` + `policy.federated.registry` at install time is a follow-up (today the principal sets them once by hand, or via `cortex provision-stack`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)