### PR TITLE
fix(network): #762 — announce caps into network on join (populate roster) + preserve hand-pins on empty roster

### DIFF
--- a/src/cli/cortex/commands/__tests__/network-adapters.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-adapters.test.ts
@@ -30,6 +30,12 @@ import {
   renderProgramArguments,
 } from "../../../../common/nats/nats-plist-loader";
 import type { PolicyFederatedNetwork } from "../../../../common/types/cortex-config";
+import { generateStackIdentity } from "../../../../bus/stack-provisioning";
+import {
+  InMemoryRegistryStore,
+  rosterFromPrincipals,
+  membersFromPrincipals,
+} from "../../../../services/network-registry/src/store";
 
 const tmpDirs: string[] = [];
 function freshDir(): string {
@@ -531,5 +537,129 @@ describe("#757 nats-server restart port", () => {
     const res = await ports.natsServer!.restart();
     expect(res.ok).toBe(false);
     if (!res.ok) expect(res.reason).toContain("Label");
+  });
+});
+
+// =============================================================================
+// #762 — federated registerStack() announces caps INTO the network (roster)
+// =============================================================================
+
+describe("#762 registerStack announces capabilities into the network", () => {
+  /** The shape the registry route receives (mirror of RegistrationClaimShape). */
+  interface CapturedClaim {
+    claim: {
+      principal_id: string;
+      principal_pubkey: string;
+      stacks: { stack_id: string }[];
+      capabilities: { id: string; networks?: string[] }[];
+    };
+  }
+
+  /**
+   * Stub global fetch to capture the POSTed registration body and return a
+   * 201. Restores the real fetch on cleanup. Fakes only — no live mutation.
+   */
+  function withFetchCapture(
+    fn: (capture: { last?: CapturedClaim }) => Promise<void>,
+  ): Promise<void> {
+    const real = globalThis.fetch;
+    const capture: { last?: CapturedClaim } = {};
+    globalThis.fetch = (async (_url: string, init?: RequestInit) => {
+      // registerStackIdentity always sends a JSON string body — parse it.
+      const body = typeof init?.body === "string" ? init.body : "";
+      capture.last = JSON.parse(body) as CapturedClaim;
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 201,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as typeof globalThis.fetch;
+    return fn(capture).finally(() => {
+      globalThis.fetch = real;
+    });
+  }
+
+  function cfgWithSeed(
+    seedPath: string,
+    announceCapabilities: string[],
+  ): LivePortsConfig {
+    return {
+      networkId: "metafactory",
+      principalId: "jc",
+      stackId: "jc/sage-host",
+      registryUrl: "https://registry.meta-factory.ai",
+      seedPath,
+      natsConfigPath: "/x/local.conf",
+      plistPath: "/nonexistent/plist",
+      announceCapabilities,
+    };
+  }
+
+  test("announces each declared cap with networks:[networkId] → principal lands in roster", async () => {
+    const dir = freshDir();
+    const seedPath = join(dir, "jc.nk");
+    generateStackIdentity({ seedPath }); // real seed file (no network I/O)
+
+    await withFetchCapture(async (capture) => {
+      const ports = buildLivePorts(cfgWithSeed(seedPath, ["chat", "release"]));
+      const res = await ports.registry.registerStack();
+      expect(res.ok).toBe(true);
+
+      const claim = capture.last!.claim;
+      // Every announced cap carries networks:[networkId] — the implicit-
+      // membership key the registry roster reads.
+      expect(claim.capabilities).toEqual([
+        { id: "chat", networks: ["metafactory"] },
+        { id: "release", networks: ["metafactory"] },
+      ]);
+
+      // PROOF the shape lands in the roster: feed the captured claim into the
+      // registry's own derivation. The principal now appears as a member.
+      const store = new InMemoryRegistryStore();
+      await store.putPrincipal(
+        claim.principal_id,
+        claim.principal_pubkey,
+        claim.stacks,
+        claim.capabilities,
+      );
+      const principals = await store.listPrincipals();
+      expect(membersFromPrincipals(principals, "metafactory")).toEqual(["jc"]);
+      const roster = rosterFromPrincipals(principals, "metafactory");
+      expect(roster.members[0]?.principal_id).toBe("jc");
+      expect(roster.members[0]?.capabilities).toEqual(["chat", "release"]);
+    });
+  });
+
+  test("a cap targeting ANOTHER network is NOT in this network's roster", async () => {
+    const store = new InMemoryRegistryStore();
+    // jc announced chat into "metafactory"; andreas announced chat into "other".
+    await store.putPrincipal("jc", "k1", [{ stack_id: "jc/sage-host" }], [
+      { id: "chat", networks: ["metafactory"] },
+    ]);
+    await store.putPrincipal("andreas", "k2", [{ stack_id: "andreas/meta-factory" }], [
+      { id: "chat", networks: ["other"] },
+    ]);
+    const principals = await store.listPrincipals();
+    // Only jc is in metafactory; andreas (targets "other") is NOT.
+    expect(membersFromPrincipals(principals, "metafactory")).toEqual(["jc"]);
+    expect(membersFromPrincipals(principals, "other")).toEqual(["andreas"]);
+  });
+
+  test("empty announceCapabilities → registers with NO cap (pre-#762 empty-roster path)", async () => {
+    const dir = freshDir();
+    const seedPath = join(dir, "jc.nk");
+    generateStackIdentity({ seedPath });
+
+    await withFetchCapture(async (capture) => {
+      const ports = buildLivePorts(cfgWithSeed(seedPath, []));
+      const res = await ports.registry.registerStack();
+      expect(res.ok).toBe(true);
+      // No capability announced → the principal does NOT join the roster.
+      expect(capture.last!.claim.capabilities).toEqual([]);
+      const store = new InMemoryRegistryStore();
+      const c = capture.last!.claim;
+      await store.putPrincipal(c.principal_id, c.principal_pubkey, c.stacks, c.capabilities);
+      const principals = await store.listPrincipals();
+      expect(membersFromPrincipals(principals, "metafactory")).toEqual([]);
+    });
   });
 });

--- a/src/cli/cortex/commands/__tests__/network-derive.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-derive.test.ts
@@ -83,7 +83,61 @@ describe("deriveJoinInputs — config-only (the one-liner)", () => {
       plistPath: "~/Library/LaunchAgents/nats.plist",
       account: "A" + "B".repeat(55),
       credsPath: "~/.config/nats/mf.creds",
+      // #762 — FULL declares no network block, so no caps to announce.
+      announceCapabilities: [],
     });
+  });
+
+  test("#762 — announceCapabilities derives from the matching network block", () => {
+    const cfg = loaded({
+      principal: { id: "andreas" },
+      stack: {
+        id: "andreas/meta-factory",
+        nkey_seed_path: "~/seed.nk",
+        nats_infra: {
+          config_path: "~/local.conf",
+          plist_path: "~/nats.plist",
+          account: "A" + "B".repeat(55),
+        },
+      },
+      policy: {
+        principals: [],
+        roles: [],
+        federated: {
+          networks: [
+            {
+              id: "other-net",
+              leaf_node: "other-net",
+              peers: [],
+              accept_subjects: ["federated.andreas.meta-factory.>"],
+              deny_subjects: [],
+              announce_capabilities: ["chat", "code-review.typescript"],
+              max_hop: 1,
+            },
+            {
+              id: "metafactory",
+              leaf_node: "metafactory",
+              peers: [],
+              accept_subjects: ["federated.andreas.meta-factory.>"],
+              deny_subjects: [],
+              announce_capabilities: ["chat", "release"],
+              max_hop: 1,
+            },
+          ],
+          registry: { url: "https://registry.meta-factory.ai" },
+        },
+      },
+    });
+    const res = deriveJoinInputs("metafactory", {}, "/cfg", reader(cfg));
+    expect(res.ok).toBe(true);
+    // Only the metafactory block's caps — never the other network's.
+    expect(res.inputs?.announceCapabilities).toEqual(["chat", "release"]);
+  });
+
+  test("#762 — no matching network block → announceCapabilities is empty", () => {
+    const res = deriveJoinInputs("brand-new-net", {}, "/cfg/cortex.yaml", reader(FULL));
+    expect(res.ok).toBe(true);
+    expect(res.inputs?.announceCapabilities).toEqual([]);
   });
 
   test("creds_path absent in config → convention ~/.config/nats/<network>.creds", () => {
@@ -181,6 +235,8 @@ describe("deriveJoinInputs — flag overrides win", () => {
       plistPath: "/flag/nats.plist",
       account: "A" + "F".repeat(55),
       credsPath: "/flag/x.creds",
+      // #762 — no caps flag exists; caps derive from the network block (none here).
+      announceCapabilities: [],
     });
   });
 

--- a/src/cli/cortex/commands/__tests__/network-lib.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-lib.test.ts
@@ -491,6 +491,105 @@ describe("join failure surfacing", () => {
 });
 
 // =============================================================================
+// #762 — empty roster must NOT clobber a working hand-pinned peer
+// =============================================================================
+
+/** A roster with NO members — the bug condition (nobody announced caps in). */
+function emptyRosterFor(networkId: string): NetworkRosterResult {
+  return { network_id: networkId, members: [] };
+}
+
+/** An existing config entry carrying a hand-pinned peer (the offline fallback). */
+function handPinnedNetwork(networkId: string): PolicyFederatedNetwork {
+  return {
+    id: networkId,
+    leaf_node: networkId,
+    peers: [
+      {
+        principal_id: "andreas",
+        stack_id: "andreas/meta-factory",
+        principal_pubkey: "U" + "A".repeat(55), // valid nkey-U grammar
+      },
+    ],
+    accept_subjects: [`federated.jc.sage-host.>`],
+    deny_subjects: [],
+    announce_capabilities: [],
+    max_hop: 1,
+  };
+}
+
+describe("#762 empty roster preserves hand-pins", () => {
+  test("empty roster + existing hand-pin → hand-pin PRESERVED, not wiped", async () => {
+    const { ports, storeRef, rec } = makeFakes({
+      fetch: {
+        status: "ok",
+        value: { descriptor: descriptorFor("metafactory"), roster: emptyRosterFor("metafactory") },
+      },
+      initialNetworks: [handPinnedNetwork("metafactory")],
+    });
+    const res = await joinNetwork("metafactory", LOCAL, ports);
+
+    expect(res.ok).toBe(true);
+    // The hand-pinned peer SURVIVES the join (was NOT overwritten with []).
+    const net = storeRef.networks.find((n) => n.id === "metafactory")!;
+    expect(net.peers.map((p) => p.principal_id)).toEqual(["andreas"]);
+    expect(net.peers[0]!.principal_pubkey).toBe("U" + "A".repeat(55));
+    // The config was still written (the join converges other fields), but the
+    // peer list is the preserved hand-pin, not the empty roster.
+    expect(rec.configWrites.length).toBe(1);
+  });
+
+  test("empty roster + hand-pin → a warning is emitted (not silent)", async () => {
+    const { ports, storeRef } = makeFakes({
+      fetch: {
+        status: "ok",
+        value: { descriptor: descriptorFor("metafactory"), roster: emptyRosterFor("metafactory") },
+      },
+      initialNetworks: [handPinnedNetwork("metafactory")],
+    });
+    const res = await joinNetwork("metafactory", LOCAL, ports);
+
+    expect(res.warnings).toBeDefined();
+    expect(res.warnings!.some((w) => w.includes("0 peers"))).toBe(true);
+    expect(res.warnings!.some((w) => w.includes("preserved"))).toBe(true);
+    // The warning is also in the step log (principal-visible).
+    expect(res.steps.some((s) => s.startsWith("WARN:"))).toBe(true);
+    expect(storeRef.networks[0]!.peers.length).toBe(1);
+  });
+
+  test("empty roster + NO existing peers → writes 0 peers (nothing to preserve, no warning)", async () => {
+    const { ports, storeRef } = makeFakes({
+      fetch: {
+        status: "ok",
+        value: { descriptor: descriptorFor("metafactory"), roster: emptyRosterFor("metafactory") },
+      },
+      // No initial networks — first join, nothing to clobber.
+    });
+    const res = await joinNetwork("metafactory", LOCAL, ports);
+
+    expect(res.ok).toBe(true);
+    expect(storeRef.networks[0]!.peers).toEqual([]);
+    // No hand-pin existed, so no preservation warning.
+    expect(res.warnings).toBeUndefined();
+  });
+
+  test("non-empty roster + existing hand-pin → roster peers used (registry is source of truth, DD-5)", async () => {
+    const { ports, storeRef } = makeFakes({
+      // Default fetch returns rosterFor() with peer "jc".
+      initialNetworks: [handPinnedNetwork("metafactory")],
+    });
+    const res = await joinNetwork("metafactory", LOCAL, ports);
+
+    expect(res.ok).toBe(true);
+    // The roster resolved "jc" → that wins; the stale hand-pin is replaced.
+    const net = storeRef.networks.find((n) => n.id === "metafactory")!;
+    expect(net.peers.map((p) => p.principal_id)).toEqual(["jc"]);
+    // A non-empty roster is the normal path — no preservation warning.
+    expect(res.warnings).toBeUndefined();
+  });
+});
+
+// =============================================================================
 // leave
 // =============================================================================
 

--- a/src/cli/cortex/commands/__tests__/network-lib.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-lib.test.ts
@@ -587,6 +587,38 @@ describe("#762 empty roster preserves hand-pins", () => {
     // A non-empty roster is the normal path — no preservation warning.
     expect(res.warnings).toBeUndefined();
   });
+
+  test("join PRESERVES the hand-authored announce_capabilities (does not blank it)", async () => {
+    // The hand-authored caps are the SOURCE deriveJoinInputs reads to announce
+    // into the roster. If join blanks them to [], a re-join announces nothing →
+    // the roster empties again, defeating the fix. They must survive a join.
+    const withCaps: PolicyFederatedNetwork = {
+      ...handPinnedNetwork("metafactory"),
+      announce_capabilities: ["chat", "release"],
+    };
+
+    // Non-empty roster path (the normal converge).
+    const a = makeFakes({ initialNetworks: [withCaps] });
+    const resA = await joinNetwork("metafactory", LOCAL, a.ports);
+    expect(resA.ok).toBe(true);
+    expect(
+      a.storeRef.networks.find((n) => n.id === "metafactory")!.announce_capabilities,
+    ).toEqual(["chat", "release"]);
+
+    // Empty-roster path (the bug condition) — caps still preserved.
+    const b = makeFakes({
+      fetch: {
+        status: "ok",
+        value: { descriptor: descriptorFor("metafactory"), roster: emptyRosterFor("metafactory") },
+      },
+      initialNetworks: [withCaps],
+    });
+    const resB = await joinNetwork("metafactory", LOCAL, b.ports);
+    expect(resB.ok).toBe(true);
+    expect(
+      b.storeRef.networks.find((n) => n.id === "metafactory")!.announce_capabilities,
+    ).toEqual(["chat", "release"]);
+  });
 });
 
 // =============================================================================

--- a/src/cli/cortex/commands/network-adapters.ts
+++ b/src/cli/cortex/commands/network-adapters.ts
@@ -84,6 +84,17 @@ export interface LivePortsConfig {
   natsConfigPath?: string;
   plistPath?: string;
   monitorUrl?: string;
+  /**
+   * #762 — the capability ids this stack announces INTO `networkId`, sourced
+   * from the network's `announce_capabilities[]` policy block. The federated
+   * `registerStack` step announces these to the registry with
+   * `networks: [networkId]` so the principal joins the network's roster
+   * (`membersFromPrincipals` — implicit membership via `capability.networks[]`).
+   * Empty/absent → the stack registers with no capability targeting the network
+   * (the pre-#762 behaviour that left the roster empty); the join then warns and
+   * preserves any existing hand-pins rather than wiping them.
+   */
+  announceCapabilities?: string[];
 }
 
 // =============================================================================
@@ -99,7 +110,7 @@ export interface LivePortsConfig {
  */
 async function registerWithCapabilities(
   cfg: LivePortsConfig,
-  capabilities: { id: string }[],
+  capabilities: { id: string; description?: string; networks?: string[] }[],
 ): Promise<{ ok: true; note: string } | { ok: false; reason: string }> {
   const url = cfg.registryUrl ?? "";
   if (cfg.seedPath === undefined) {
@@ -142,8 +153,24 @@ function buildRegistryPort(cfg: LivePortsConfig): NetworkRegistryPort {
 
   return {
     async registerStack() {
-      // S4 federated register — proof-of-possession with no capability change.
-      return registerWithCapabilities(cfg, []);
+      // #762 — federated register MUST announce the stack's declared
+      // capabilities INTO this network so the principal joins the network's
+      // roster. Roster membership is implicit (`membersFromPrincipals`): a
+      // principal is "in" `networkId` iff one of its announced capabilities
+      // lists `networkId` in `capability.networks[]`. The pre-#762 code
+      // registered with an EMPTY capability list — the principal appeared at
+      // `/principals/{id}` but never in `/networks/{networkId}/roster`, so a
+      // registry-resolved join wrote 0 peers (and risked wiping a working
+      // hand-pin). We tag each announced capability with `networks: [networkId]`.
+      //
+      // This is a registry CONTROL-PLANE action (a signed HTTP POST to
+      // /principals/.../register), NOT a `federated.*` wire envelope — the
+      // network name never goes on the bus (federation-wire-protocol check 1).
+      const announced = (cfg.announceCapabilities ?? []).map((id) => ({
+        id,
+        networks: [cfg.networkId],
+      }));
+      return registerWithCapabilities(cfg, announced);
     },
     fetchVerified(networkId) {
       // S1's fetchAndCache returns { descriptor, roster } on ok and refreshes

--- a/src/cli/cortex/commands/network-derive.ts
+++ b/src/cli/cortex/commands/network-derive.ts
@@ -54,6 +54,14 @@ export interface DerivedJoinInputs {
   plistPath: string;
   account: string;
   credsPath: string;
+  /**
+   * #762 — the capability ids this stack announces INTO the network, read from
+   * the matching `policy.federated.networks[].announce_capabilities[]` block in
+   * config (empty when the network isn't yet declared locally or declares no
+   * caps). The join announces these with `networks: [<network>]` so the
+   * principal joins the network's roster.
+   */
+  announceCapabilities: string[];
 }
 
 /** The leave inputs — a strict subset (no registry / seed / account / creds). */
@@ -231,6 +239,15 @@ export function deriveJoinInputs(
   const credsPath =
     overrides.credsPath ?? natsInfra?.creds_path ?? defaultCredsPath(networkId);
 
+  // #762 — announce_capabilities for THIS network, read from the matching
+  // policy.federated.networks[] block. The join announces these to the registry
+  // with networks:[networkId] so the principal joins the roster. Absent network
+  // block (first join before the block exists) → empty; the join then warns +
+  // preserves hand-pins rather than wiping them.
+  const announceCapabilities =
+    cfg.policy?.federated?.networks.find((n) => n.id === networkId)
+      ?.announce_capabilities ?? [];
+
   return {
     ok: true,
     inputs: {
@@ -243,6 +260,7 @@ export function deriveJoinInputs(
       plistPath,
       account,
       credsPath,
+      announceCapabilities,
     },
   };
 }

--- a/src/cli/cortex/commands/network-lib.ts
+++ b/src/cli/cortex/commands/network-lib.ts
@@ -84,6 +84,12 @@ export interface JoinResult {
   usedCache?: boolean;
   /** Peers that resolved (principal ids) — for the CLI summary. */
   resolvedPeers?: string[];
+  /**
+   * Non-fatal warnings surfaced during the join (#762). The empty-roster
+   * hand-pin-preservation warning lands here (and in {@link steps}) so the CLI
+   * can render it and a caller can assert on it without scraping prose.
+   */
+  warnings?: string[];
 }
 
 export interface LeaveResult {
@@ -208,8 +214,40 @@ export async function joinNetwork(
   // written, config not). A failed `--apply` is recoverable: re-running join
   // converges (idempotent). `try` spans both writes so the step log records how
   // far the mutation got before the failure.
-  const peers = buildPeers(stack.principalId, roster);
+  const resolvedPeers = buildPeers(stack.principalId, roster);
   const acceptSubject = `federated.${stack.principalId}.${stack.stackSlug}.>`;
+  const warnings: string[] = [];
+
+  // (d-pre) #762 — never clobber a working hand-pin with 0 resolved peers.
+  //
+  // The registry roster is populated implicitly: a principal is "in" a network
+  // only if one of its announced capabilities lists that network in
+  // `capability.networks[]`. If nobody has announced into the network yet (the
+  // exact bug found in clawbox dry-runs — `jc` registered but announced no caps
+  // into `metafactory`), the roster is EMPTY and `buildPeers` yields 0 peers.
+  //
+  // Writing those 0 peers over an existing entry would wipe a hand-pinned peer
+  // (the DD-5 offline fallback) that is actively carrying federated traffic. So
+  // when the roster resolves no peers, we PRESERVE the existing hand-pins for
+  // this network rather than overwriting them, and warn loudly. When the roster
+  // DOES resolve peers we use them as-is (registry is source of truth, DD-5).
+  const existing = ports.configStore.readNetworks();
+  const priorEntry = existing.find((n) => n.id === networkId);
+  const priorPeers = priorEntry?.peers ?? [];
+  let peers = resolvedPeers;
+  if (resolvedPeers.length === 0 && priorPeers.length > 0) {
+    // Preserve every existing hand-pin (the roster named nobody, so there is no
+    // registry peer to merge or supersede). The hand-pins stay verbatim.
+    peers = priorPeers.map((p) => ({ ...p }));
+    const warn =
+      `registry roster for "${networkId}" resolved 0 peers — ` +
+      `preserved ${priorPeers.length.toString()} existing hand-pinned peer(s) ` +
+      `(${priorPeers.map((p) => p.principal_id).join(", ")}) rather than wiping them. ` +
+      `Peers join the roster by announcing a capability with networks:["${networkId}"].`;
+    warnings.push(warn);
+    steps.push(`WARN: ${warn}`);
+  }
+
   const entry: PolicyFederatedNetwork = {
     id: networkId,
     leaf_node: stack.leafNode ?? networkId,
@@ -235,7 +273,6 @@ export async function joinNetwork(
     // (d) Merge the network into the federation config with registry-resolved
     // peers (DD-5) + the OWN accept-subject (wire contract). Idempotent: replace
     // the entry keyed by network id, never append a duplicate.
-    const existing = ports.configStore.readNetworks();
     const merged = mergeNetwork(existing, entry);
     ports.configStore.writeNetworks(merged);
     steps.push(
@@ -267,6 +304,7 @@ export async function joinNetwork(
         network: entry,
         usedCache,
         resolvedPeers: peers.map((p) => p.principal_id),
+        ...(warnings.length > 0 && { warnings }),
       };
     }
     steps.push("restarted nats-server to load leaf config");
@@ -283,6 +321,7 @@ export async function joinNetwork(
       network: entry,
       usedCache,
       resolvedPeers: peers.map((p) => p.principal_id),
+      ...(warnings.length > 0 && { warnings }),
     };
   }
   steps.push("restarted stack daemon");
@@ -293,6 +332,7 @@ export async function joinNetwork(
     network: entry,
     usedCache,
     resolvedPeers: peers.map((p) => p.principal_id),
+    ...(warnings.length > 0 && { warnings }),
   };
 }
 

--- a/src/cli/cortex/commands/network-lib.ts
+++ b/src/cli/cortex/commands/network-lib.ts
@@ -254,7 +254,13 @@ export async function joinNetwork(
     peers,
     accept_subjects: [acceptSubject],
     deny_subjects: [],
-    announce_capabilities: [],
+    // #762 — PRESERVE the hand-authored announce_capabilities for this network.
+    // `deriveJoinInputs` sources the caps the join announces INTO the roster from
+    // exactly this config block, so blanking it to [] here would make a re-join
+    // (or any later config-derived join) announce nothing → the roster empties
+    // again, defeating the fix above. Carry the prior entry's value verbatim
+    // (default [] only on a first join where no block exists yet).
+    announce_capabilities: priorEntry?.announce_capabilities ?? [],
     max_hop: stack.maxHop ?? 1,
   };
 

--- a/src/cli/cortex/commands/network.ts
+++ b/src/cli/cortex/commands/network.ts
@@ -559,6 +559,9 @@ function portsConfigFromInputs(
     natsConfigPath: inputs.natsConfigPath,
     plistPath: inputs.plistPath,
     monitorUrl: optionalValueFlag(flags, "--monitor-url"),
+    // #762 — caps the join announces INTO the network so the principal joins
+    // the roster (registry control-plane; never on the wire).
+    announceCapabilities: inputs.announceCapabilities,
   };
 }
 


### PR DESCRIPTION
Closes #762
Refs #736 #738 #733

## Root cause

The federated `cortex network join` registered the principal (`/principals/{id}` → 200) but never **announced its capabilities INTO the network**. Roster membership is implicit (`membersFromPrincipals`): a principal is "in" network X iff one of its capabilities lists X in `capability.networks[]`. With no cap targeting the network, `/networks/<network>/roster` stayed **empty** → a registry-resolved join wrote **0 peers** and would have wiped the working hand-pinned Andreas peer.

## Fix

**Part 1 — announce caps into the network on join.**
- `deriveJoinInputs` now reads the matching `policy.federated.networks[].announce_capabilities[]` block → `DerivedJoinInputs.announceCapabilities`.
- threaded through `portsConfigFromInputs` → `LivePortsConfig.announceCapabilities`.
- the live registry port's `registerStack()` announces each declared capability with `networks: [<network>]`. The wire shape (`buildRegistrationClaim` → `RegistrationClaimShape.capabilities[]`) already carries `networks?`, so it lands directly in the registry's `rosterFromPrincipals`/`membersFromPrincipals`.

**Part 2 — never clobber a hand-pin with 0 resolved peers.**
- when the roster resolves 0 peers, `joinNetwork` preserves the existing hand-pinned `peers[]` for that network rather than overwriting them, and emits a warning (in `JoinResult.warnings` + the step log). A non-empty roster uses the registry peers as-is (DD-5 — registry is source of truth).

## Wire-check

`SOP: federation-wire-protocol | touches: route (peers[] + register control-plane) | checklist: 5/5 PASS`

Capability-announce is a registry **control-plane** action (a signed HTTP POST to `/principals/.../register`), **not** a `federated.*` envelope — the network name never goes on the bus. The written `peers[]` stay on-contract: gated by `principal_id`, `accept_subjects` = own `federated.{me}.{stack}.>`, no network name in any subject.

## Tests (fakes only — no live mutation)

- derive surfaces only the matching network's caps; empty when no block.
- `registerStack()` announces caps with `networks:[networkId]`; the captured claim fed into the registry's own `rosterFromPrincipals` yields the principal as a member; a cap targeting another network is excluded.
- empty roster + hand-pin → hand-pin **preserved** + warning (not wiped); empty roster + no peers → 0 peers, no warning; non-empty roster + hand-pin → roster peers win.

## Verification

- `bunx tsc --noEmit` → 0 errors
- `bun test` → 4643 pass / 0 fail / 2 skip (no new failures)
- `eslint` on changed files → clean
- `scripts/check-carveouts.sh` (vocab gate) → PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)