### PR TITLE
feat(network): #763 — Linux/systemd support for cortex network join (launchd/systemd abstraction)

### DIFF
--- a/src/cli/cortex/commands/__tests__/network-adapters.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-adapters.test.ts
@@ -78,6 +78,10 @@ function cfgFor(plistPath: string): LivePortsConfig {
     stackId: "andreas/meta-factory",
     natsConfigPath: NATS_CONFIG,
     plistPath,
+    // #763 — pin darwin so the launchd-plist adapter is selected deterministically
+    // (on Linux CI the default platform would otherwise route to systemd and
+    // reject the .plist descriptor as a mismatch).
+    platform: "darwin",
   };
 }
 

--- a/src/cli/cortex/commands/__tests__/network-cli.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-cli.test.ts
@@ -183,6 +183,55 @@ describe("join dry-run safety", () => {
 });
 
 // =============================================================================
+// #763 — Linux/systemd: `--unit` join is accepted + writes nothing on dry-run
+// =============================================================================
+
+describe("#763 — systemd `--unit` join", () => {
+  test("dry-run join with --unit (no --plist) writes nothing and routes to systemd", async () => {
+    const dir = freshDir();
+    const unit = join(dir, "nats-server.service");
+    const natsConfig = join(dir, "nats", "local.conf");
+
+    const res = await dispatchNetwork([
+      "join", "metafactory",
+      "--principal", "jc",
+      "--registry-url", "http://127.0.0.1:0", // unreachable by construction
+      "--seed-path", join(dir, "seed.nk"),
+      "--creds", join(dir, "jc.creds"),
+      "--account", "A" + "B".repeat(55),
+      "--nats-config", natsConfig,
+      "--unit", unit, // systemd descriptor — self-describing, platform-independent
+    ], EMPTY_READER);
+
+    // DRY-RUN SAFETY: the systemd unit + config are NOT written/created.
+    expect(existsSync(unit)).toBe(false);
+    expect(existsSync(natsConfig)).toBe(false);
+    expect(existsSync(join(dir, "nats"))).toBe(false);
+    // Join fails on the unreachable registry (register step), exit 1 — but it
+    // got PAST descriptor resolution (no "cannot resolve … unit" usage error).
+    expect(res.exitCode).toBe(1);
+    expect(res.stderr).not.toContain("cannot resolve");
+  });
+
+  test("passing BOTH --plist and --unit is a clear usage error (exit 2)", async () => {
+    const dir = freshDir();
+    const res = await dispatchNetwork([
+      "join", "metafactory",
+      "--principal", "jc",
+      "--registry-url", "http://r.test",
+      "--seed-path", join(dir, "seed.nk"),
+      "--creds", join(dir, "x.creds"),
+      "--account", "A" + "B".repeat(55),
+      "--nats-config", join(dir, "local.conf"),
+      "--plist", join(dir, "nats.plist"),
+      "--unit", join(dir, "nats-server.service"),
+    ], EMPTY_READER);
+    expect(res.exitCode).toBe(2);
+    expect(res.stderr).toContain("only one of --plist");
+  });
+});
+
+// =============================================================================
 // status — renders against a real (temp) stack config
 // =============================================================================
 

--- a/src/cli/cortex/commands/__tests__/network-derive.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-derive.test.ts
@@ -71,7 +71,8 @@ const FULL = loaded({
 
 describe("deriveJoinInputs — config-only (the one-liner)", () => {
   test("derives all inputs from config with NO flags", () => {
-    const res = deriveJoinInputs("metafactory", {}, "/cfg/cortex.yaml", reader(FULL));
+    // Pin darwin so the macOS plist-path derivation is deterministic on Linux CI.
+    const res = deriveJoinInputs("metafactory", {}, "/cfg/cortex.yaml", reader(FULL), "darwin");
     expect(res.ok).toBe(true);
     expect(res.inputs).toEqual({
       principal: "andreas",
@@ -81,6 +82,7 @@ describe("deriveJoinInputs — config-only (the one-liner)", () => {
       registryPubkey: "A".repeat(43) + "=",
       natsConfigPath: "~/.config/nats/local.conf",
       plistPath: "~/Library/LaunchAgents/nats.plist",
+      platform: "darwin",
       account: "A" + "B".repeat(55),
       credsPath: "~/.config/nats/mf.creds",
       // #762 — FULL declares no network block, so no caps to announce.
@@ -223,6 +225,7 @@ describe("deriveJoinInputs — flag overrides win", () => {
       },
       "/cfg",
       reader(FULL),
+      "darwin",
     );
     expect(res.ok).toBe(true);
     expect(res.inputs).toEqual({
@@ -233,6 +236,7 @@ describe("deriveJoinInputs — flag overrides win", () => {
       registryPubkey: "Z".repeat(43) + "=",
       natsConfigPath: "/flag/local.conf",
       plistPath: "/flag/nats.plist",
+      platform: "darwin",
       account: "A" + "F".repeat(55),
       credsPath: "/flag/x.creds",
       // #762 — no caps flag exists; caps derive from the network block (none here).
@@ -332,13 +336,14 @@ describe("deriveJoinInputs — actionable missing-config errors", () => {
 
 describe("deriveLeaveInputs", () => {
   test("derives principal/stack/nats-config/plist from config (no flags)", () => {
-    const res = deriveLeaveInputs({}, "/cfg", reader(FULL));
+    const res = deriveLeaveInputs({}, "/cfg", reader(FULL), "darwin");
     expect(res.ok).toBe(true);
     expect(res.inputs).toEqual({
       principal: "andreas",
       stack: "andreas/meta-factory",
       natsConfigPath: "~/.config/nats/local.conf",
       plistPath: "~/Library/LaunchAgents/nats.plist",
+      platform: "darwin",
     });
   });
 
@@ -357,5 +362,86 @@ describe("deriveLeaveInputs", () => {
     const res = deriveLeaveInputs({}, "/cfg", reader(cfg));
     expect(res.ok).toBe(false);
     expect(res.reason).toContain("stack.nats_infra.config_path");
+  });
+});
+
+// =============================================================================
+// #763 — Linux/systemd platform-aware descriptor derivation
+// =============================================================================
+
+// A Linux-shape config: nats_infra carries `unit_path` (the systemd unit), not
+// `plist_path`. Otherwise identical to FULL.
+const FULL_LINUX = loaded({
+  principal: { id: "jc" },
+  stack: {
+    id: "jc/clawbox",
+    nkey_seed_path: "~/.config/nats/cortex.nk",
+    nats_infra: {
+      config_path: "~/.config/nats/local.conf",
+      unit_path: "~/.config/systemd/user/nats-server.service",
+      account: "A" + "B".repeat(55),
+    },
+  },
+  policy: {
+    principals: [],
+    roles: [],
+    federated: {
+      networks: [],
+      registry: { url: "https://registry.meta-factory.ai" },
+    },
+  },
+});
+
+describe("#763 — deriveJoinInputs platform-aware descriptor", () => {
+  test("on LINUX, derives the systemd unit_path (not plist_path) + platform", () => {
+    const res = deriveJoinInputs("metafactory", {}, "/cfg", reader(FULL_LINUX), "linux");
+    expect(res.ok).toBe(true);
+    expect(res.inputs?.unitPath).toBe("~/.config/systemd/user/nats-server.service");
+    expect(res.inputs?.plistPath).toBeUndefined();
+    expect(res.inputs?.platform).toBe("linux");
+  });
+
+  test("on macOS, derives the plist_path (not unit_path) + platform", () => {
+    const res = deriveJoinInputs("metafactory", {}, "/cfg", reader(FULL), "darwin");
+    expect(res.ok).toBe(true);
+    expect(res.inputs?.plistPath).toBe("~/Library/LaunchAgents/nats.plist");
+    expect(res.inputs?.unitPath).toBeUndefined();
+    expect(res.inputs?.platform).toBe("darwin");
+  });
+
+  test("--unit flag overrides the config unit_path on Linux", () => {
+    const res = deriveJoinInputs(
+      "metafactory",
+      { unitPath: "/flag/nats.service" },
+      "/cfg",
+      reader(FULL_LINUX),
+      "linux",
+    );
+    expect(res.inputs?.unitPath).toBe("/flag/nats.service");
+  });
+
+  test("on LINUX with NO unit configured → actionable error naming unit_path", () => {
+    // FULL has only plist_path; on linux that is not the right descriptor.
+    const res = deriveJoinInputs("metafactory", {}, "/cfg", reader(FULL), "linux");
+    expect(res.ok).toBe(false);
+    expect(res.reason).toContain("stack.nats_infra.unit_path");
+    expect(res.reason).toContain("--unit");
+  });
+
+  test("on macOS with NO plist configured → actionable error naming plist_path", () => {
+    const res = deriveJoinInputs("metafactory", {}, "/cfg", reader(FULL_LINUX), "darwin");
+    expect(res.ok).toBe(false);
+    expect(res.reason).toContain("stack.nats_infra.plist_path");
+    expect(res.reason).toContain("--plist");
+  });
+});
+
+describe("#763 — deriveLeaveInputs platform-aware descriptor", () => {
+  test("on LINUX derives unit_path + platform", () => {
+    const res = deriveLeaveInputs({}, "/cfg", reader(FULL_LINUX), "linux");
+    expect(res.ok).toBe(true);
+    expect(res.inputs?.unitPath).toBe("~/.config/systemd/user/nats-server.service");
+    expect(res.inputs?.plistPath).toBeUndefined();
+    expect(res.inputs?.platform).toBe("linux");
   });
 });

--- a/src/cli/cortex/commands/network-adapters.ts
+++ b/src/cli/cortex/commands/network-adapters.ts
@@ -40,10 +40,12 @@ import {
   renderLeafIncludeFile,
 } from "../../../common/nats/leaf-remote-renderer";
 import {
-  ensureConfigArg,
-  plistConfigArgPresent,
-  renderProgramArguments,
-} from "../../../common/nats/nats-plist-loader";
+  bunExecRunner,
+  currentServicePlatform,
+  selectNatsServiceManager,
+  type NatsServiceManager,
+  type ServicePlatform,
+} from "../../../common/nats/nats-service-manager";
 import { NetworkRegistryClient } from "../../../common/registry/network-client";
 import {
   buildRegistrationClaim,
@@ -82,7 +84,24 @@ export interface LivePortsConfig {
   registryPubkey?: string;
   seedPath?: string;
   natsConfigPath?: string;
+  /**
+   * macOS (launchd) nats-server descriptor — the plist whose `ProgramArguments`
+   * carry `-c <config>` and that `launchctl kickstart` restarts. On a Linux
+   * stack this is absent and {@link LivePortsConfig.unitPath} is set instead.
+   */
   plistPath?: string;
+  /**
+   * #763 — Linux (systemd) nats-server descriptor: the systemd unit whose
+   * `[Service] ExecStart=` carries `-c <config>` and that `systemctl restart`
+   * reloads. Mutually-platform-exclusive with {@link LivePortsConfig.plistPath}.
+   */
+  unitPath?: string;
+  /**
+   * #763 — platform the join runs on. Selects launchd vs systemd service
+   * management. Defaults to `process.platform` when omitted (the CLI sets it
+   * explicitly; tests pin it).
+   */
+  platform?: ServicePlatform;
   monitorUrl?: string;
   /**
    * #762 — the capability ids this stack announces INTO `networkId`, sourced
@@ -244,76 +263,62 @@ function buildLeafFilePort(cfg: LivePortsConfig, mutate: boolean): LeafFilePort 
 }
 
 // =============================================================================
-// Plist port — built on S3's canonical ensureConfigArg + renderProgramArguments
-// (`src/common/nats/nats-plist-loader.ts`) as the single source of truth for
-// the ProgramArguments arg-list transform AND its XML rendering. This adapter
-// only does the plist I/O: read the existing args back out, and splice S3's
-// rendered block into the file. No bespoke arg/XML logic lives here.
+// nats-server service management — the launchd/systemd abstraction (#763).
+//
+// Pre-#763 this adapter hardcoded launchd: it read/wrote the plist
+// `ProgramArguments` and restarted via `launchctl`. On Linux (clawbox) the
+// descriptor is a systemd unit, so feeding it here errored cryptically
+// ("ProgramArguments is empty"). The launchd/systemd split now lives in
+// `src/common/nats/nats-service-manager.ts` (the `NatsServiceManager` seam);
+// this adapter only selects the right manager per platform/descriptor and
+// threads it into BOTH the `PlistPort` (config-arg ensure) and the
+// `NatsServerPort` (restart) — the two ports the orchestrator already depends
+// on. The macOS behavior is byte-for-byte the lifted launchd implementation.
 // =============================================================================
 
-/** Read the `ProgramArguments` <string> entries from a launchd plist. */
-function readProgramArguments(plistPath: string): string[] {
-  const xml = readFileSync(plistPath, "utf-8");
-  const block = /<key>ProgramArguments<\/key>\s*<array>([\s\S]*?)<\/array>/.exec(xml);
-  if (block === null) return [];
-  const args: string[] = [];
-  const re = /<string>([\s\S]*?)<\/string>/g;
-  let m: RegExpExecArray | null;
-  while ((m = re.exec(block[1] ?? "")) !== null) {
-    args.push(unescapeXml(m[1] ?? ""));
-  }
-  return args;
-}
-
-function unescapeXml(v: string): string {
-  return v
-    .replace(/&lt;/g, "<")
-    .replace(/&gt;/g, ">")
-    .replace(/&quot;/g, '"')
-    .replace(/&apos;/g, "'")
-    .replace(/&amp;/g, "&");
+/**
+ * Resolve the nats-server service descriptor for the stack: the systemd unit
+ * (`unitPath`) on Linux, the launchd plist (`plistPath`) on macOS. Returns the
+ * tilde-expanded path, or `undefined` when the platform's descriptor is unset
+ * (a caller that does not manage the nats-server service — the port then no-ops
+ * gracefully, matching the pre-#763 "plist not found" contract).
+ */
+function descriptorPathFor(cfg: LivePortsConfig): string | undefined {
+  const platform = cfg.platform ?? currentServicePlatform();
+  const raw = platform === "linux" ? cfg.unitPath ?? cfg.plistPath : cfg.plistPath ?? cfg.unitPath;
+  if (raw === undefined || raw === "") return undefined;
+  return expandTilde(raw);
 }
 
 /**
- * Rewrite the plist's ProgramArguments block in place with `nextArgs`. The XML
- * block is rendered by S3's canonical {@link renderProgramArguments} (the
- * single source of truth for the ProgramArguments key+array XML, including the
- * five-entity escaping) — this adapter only splices it into the plist. Matches
- * the existing `<key>ProgramArguments</key>` block INCLUDING its leading
- * horizontal indent so S3's own `\t`-prefixed output replaces it 1:1 (no
- * double-indent), keeping the on-disk plist byte-shape stable.
+ * Build the {@link NatsServiceManager} for the stack, or `undefined` when no
+ * descriptor is configured for the platform. A descriptor whose type does not
+ * match the platform (plist-on-Linux / unit-on-macOS) makes
+ * `selectNatsServiceManager` throw a CLEAR error — the join's never-throws
+ * orchestration surfaces it as a `{ ok: false }` (it runs inside the port
+ * methods, which the orchestrator's try/await guards).
  */
-function writeProgramArguments(plistPath: string, nextArgs: string[]): void {
-  const xml = readFileSync(plistPath, "utf-8");
-  const next = xml.replace(
-    /[ \t]*<key>ProgramArguments<\/key>\s*<array>[\s\S]*?<\/array>/,
-    renderProgramArguments(nextArgs),
-  );
-  writeFileSync(plistPath, next, "utf-8");
+function buildServiceManager(
+  cfg: LivePortsConfig,
+  mutate: boolean,
+): NatsServiceManager | undefined {
+  const descriptorPath = descriptorPathFor(cfg);
+  if (descriptorPath === undefined) return undefined;
+  return selectNatsServiceManager({
+    descriptorPath,
+    platform: cfg.platform ?? currentServicePlatform(),
+    mutate,
+    exec: bunExecRunner,
+  });
 }
 
 function buildPlistPort(cfg: LivePortsConfig, mutate: boolean): PlistPort {
-  const plistPath = expandTilde(cfg.plistPath ?? "");
   return {
     ensureConfigLoaded(configPath) {
-      if (!existsSync(plistPath)) return;
-      const args = readProgramArguments(plistPath);
-      if (plistConfigArgPresent(args, configPath)) return; // idempotent no-op
-      const next = ensureConfigArg(args, configPath);
-      if (!mutate) return;
-      writeProgramArguments(plistPath, next);
+      buildServiceManager(cfg, mutate)?.ensureConfigLoaded(configPath);
     },
     dropConfigArg(configPath) {
-      if (!existsSync(plistPath)) return;
-      const args = readProgramArguments(plistPath);
-      const next = args.filter((a, i) => {
-        if (a === "-c" || a === "--config") return false;
-        if (i > 0 && (args[i - 1] === "-c" || args[i - 1] === "--config")) return false;
-        if (a === `--config=${configPath}`) return false;
-        return true;
-      });
-      if (!mutate) return;
-      writeProgramArguments(plistPath, next);
+      buildServiceManager(cfg, mutate)?.dropConfigArg(configPath);
     },
   };
 }
@@ -404,49 +409,38 @@ function buildDaemonPort(cfg: LivePortsConfig, mutate: boolean): DaemonPort {
 }
 
 // =============================================================================
-// Nats-server port — launchctl kickstart of the nats-server plist's service
+// Nats-server port — restart the nats-server service so it reloads local.conf
 // (#757). The join mutates local.conf (leaf include + `include` directive); the
 // nats-server process that reads local.conf must be restarted for the leaf to
-// take effect. We restart the service named by the join's `--plist`
-// (the nats-server plist), reading its `<key>Label</key>` so the kickstart
-// target is whatever the principal's plist declares (homebrew.mxcl.nats-server,
-// a custom label, etc.) — no hardcoded label.
+// take effect. The restart is delegated to the platform's
+// {@link NatsServiceManager}: `launchctl kickstart -k gui/<uid>/<label>` on
+// macOS (label read from the plist `<key>Label</key>`), `systemctl
+// [--user] restart <unit>` on Linux (#763, unit id read from the `.service`
+// file name). No hardcoded service id; no platform branching here.
 // =============================================================================
 
-/** Read the launchd `<key>Label</key><string>…</string>` from a plist. */
-function readPlistLabel(plistPath: string): string | undefined {
-  const xml = readFileSync(plistPath, "utf-8");
-  const m = /<key>Label<\/key>\s*<string>([\s\S]*?)<\/string>/.exec(xml);
-  if (m === null) return undefined;
-  const label = unescapeXml(m[1] ?? "").trim();
-  return label === "" ? undefined : label;
-}
-
 function buildNatsServerPort(cfg: LivePortsConfig, mutate: boolean): NatsServerPort {
-  const plistPath = expandTilde(cfg.plistPath ?? "");
   return {
     async restart() {
-      if (!mutate) return { ok: true }; // dry-run: pretend success, touch nothing.
-      if (cfg.plistPath === undefined || !existsSync(plistPath)) {
-        return { ok: false, reason: `nats-server plist not found at ${plistPath}` };
+      // `buildServiceManager` → `selectNatsServiceManager` throws on a
+      // platform/descriptor mismatch (plist-on-Linux / unit-on-macOS, #763).
+      // The orchestrator awaits this restart OUTSIDE a try/catch, so we honor
+      // the never-throws contract here and surface the clear message as a
+      // `{ ok: false }` reason rather than letting it escape as a stack trace.
+      let mgr: NatsServiceManager | undefined;
+      try {
+        mgr = buildServiceManager(cfg, mutate);
+      } catch (err) {
+        return { ok: false, reason: err instanceof Error ? err.message : String(err) };
       }
-      const label = readPlistLabel(plistPath);
-      if (label === undefined) {
-        return { ok: false, reason: `no <key>Label</key> in nats-server plist ${plistPath}` };
-      }
-      const proc = Bun.spawn(
-        ["launchctl", "kickstart", "-k", `gui/${process.getuid?.() ?? 501}/${label}`],
-        { stdout: "pipe", stderr: "pipe" },
-      );
-      const code = await proc.exited;
-      if (code !== 0) {
-        const err = await new Response(proc.stderr).text();
+      if (mgr === undefined) {
         return {
           ok: false,
-          reason: `launchctl kickstart ${label} exited ${code.toString()}: ${err.trim()}`,
+          reason:
+            "no nats-server service descriptor configured (set stack.nats_infra.plist_path on macOS or unit_path on Linux)",
         };
       }
-      return { ok: true };
+      return mgr.restart();
     },
   };
 }

--- a/src/cli/cortex/commands/network-derive.ts
+++ b/src/cli/cortex/commands/network-derive.ts
@@ -37,6 +37,7 @@
  */
 
 import type { LoadedConfig } from "../../../common/config/loader";
+import type { ServicePlatform } from "../../../common/nats/nats-service-manager";
 
 // =============================================================================
 // Types
@@ -51,7 +52,19 @@ export interface DerivedJoinInputs {
   registryUrl: string;
   registryPubkey?: string;
   natsConfigPath: string;
-  plistPath: string;
+  /**
+   * macOS — the nats-server launchd plist path (`stack.nats_infra.plist_path`
+   * / `--plist`). Present on a darwin join; absent on a Linux join (where
+   * {@link DerivedJoinInputs.unitPath} carries the systemd unit instead).
+   */
+  plistPath?: string;
+  /**
+   * #763 — Linux — the nats-server systemd unit path
+   * (`stack.nats_infra.unit_path` / `--unit`). Present on a linux join.
+   */
+  unitPath?: string;
+  /** #763 — the platform the descriptor was resolved for (launchd vs systemd). */
+  platform: ServicePlatform;
   account: string;
   credsPath: string;
   /**
@@ -69,7 +82,12 @@ export interface DerivedLeaveInputs {
   principal: string;
   stack: string;
   natsConfigPath: string;
-  plistPath: string;
+  /** macOS launchd plist (absent on Linux). */
+  plistPath?: string;
+  /** #763 — Linux systemd unit (absent on macOS). */
+  unitPath?: string;
+  /** #763 — the resolved platform. */
+  platform: ServicePlatform;
 }
 
 /** Flag overrides — any field present on the CLI wins over config/convention. */
@@ -81,6 +99,8 @@ export interface JoinOverrides {
   registryPubkey?: string;
   natsConfigPath?: string;
   plistPath?: string;
+  /** #763 — `--unit` override for the systemd unit path on Linux. */
+  unitPath?: string;
   account?: string;
   credsPath?: string;
 }
@@ -132,6 +152,78 @@ function fail<T>(reason: string): DeriveResult<T> {
   return { ok: false, reason };
 }
 
+/** The default platform — mapped from `process.platform` (darwin vs linux). */
+function defaultPlatform(): ServicePlatform {
+  return process.platform === "darwin" ? "darwin" : "linux";
+}
+
+/**
+ * #763 — resolve the nats-server service descriptor.
+ *
+ * An EXPLICIT descriptor flag wins AND is self-describing: `--plist` means "this
+ * is a launchd plist", `--unit` means "this is a systemd unit", regardless of
+ * the host platform. This keeps the fully-flagged legacy invocation (and its
+ * cross-platform CLI tests) working: a `--plist`-flagged join resolves the
+ * launchd descriptor even when `process.platform` is Linux. Flagging BOTH is a
+ * conflict (you cannot manage two descriptor types for one nats-server).
+ *
+ * When NEITHER flag is given, the descriptor derives from config by the host
+ * `platform`: macOS reads `stack.nats_infra.plist_path`, Linux reads
+ * `stack.nats_infra.unit_path`. A descriptor for the OTHER platform in config is
+ * ignored (a stack may carry a legacy `plist_path` it no longer uses on Linux).
+ * A missing descriptor yields a clear, field-naming error.
+ *
+ * The returned `platform` is the descriptor's OWN platform (launchd→darwin,
+ * systemd→linux), so the adapter selects the matching `NatsServiceManager`.
+ */
+function resolveDescriptor(
+  platform: ServicePlatform,
+  overrides: { plistPath?: string; unitPath?: string },
+  natsInfra: { plist_path?: string; unit_path?: string } | undefined,
+):
+  | { ok: true; platform: ServicePlatform; plistPath?: string; unitPath?: string }
+  | { ok: false; reason: string } {
+  const flagPlist = overrides.plistPath;
+  const flagUnit = overrides.unitPath;
+
+  // Explicit-flag path — self-describing, platform-independent.
+  if (flagPlist !== undefined && flagPlist !== "" && flagUnit !== undefined && flagUnit !== "") {
+    return {
+      ok: false,
+      reason: "pass only one of --plist (launchd) or --unit (systemd), not both",
+    };
+  }
+  if (flagPlist !== undefined && flagPlist !== "") {
+    return { ok: true, platform: "darwin", plistPath: flagPlist };
+  }
+  if (flagUnit !== undefined && flagUnit !== "") {
+    return { ok: true, platform: "linux", unitPath: flagUnit };
+  }
+
+  // Config path — derive by the host platform.
+  if (platform === "darwin") {
+    const plistPath = natsInfra?.plist_path;
+    if (plistPath === undefined || plistPath === "") {
+      return {
+        ok: false,
+        reason:
+          "cannot resolve nats-server launchd plist — pass --plist or set `stack.nats_infra.plist_path` in cortex.yaml",
+      };
+    }
+    return { ok: true, platform: "darwin", plistPath };
+  }
+  // Linux / systemd.
+  const unitPath = natsInfra?.unit_path;
+  if (unitPath === undefined || unitPath === "") {
+    return {
+      ok: false,
+      reason:
+        "cannot resolve nats-server systemd unit — pass --unit or set `stack.nats_infra.unit_path` in cortex.yaml",
+    };
+  }
+  return { ok: true, platform: "linux", unitPath };
+}
+
 /** An empty LoadedConfig — every derived field absent, so the deriver falls
  *  through to flags / convention. Returned by {@link tolerantReader} when no
  *  config file is present (fully-flagged back-compat path). */
@@ -179,6 +271,7 @@ export function deriveJoinInputs(
   overrides: JoinOverrides,
   configPath: string,
   load: ConfigReader,
+  platform: ServicePlatform = defaultPlatform(),
 ): DeriveResult<DerivedJoinInputs> {
   const cfg = load(configPath);
 
@@ -221,12 +314,15 @@ export function deriveJoinInputs(
     );
   }
 
-  const plistPath = overrides.plistPath ?? natsInfra?.plist_path;
-  if (plistPath === undefined || plistPath === "") {
-    return fail(
-      "cannot resolve plist path — pass --plist or set `stack.nats_infra.plist_path` in cortex.yaml",
-    );
-  }
+  // #763 — resolve the platform's service descriptor (plist on macOS, systemd
+  // unit on Linux). Flag wins over config; a clear, field-naming error when the
+  // platform's descriptor is neither flagged nor configured.
+  const descriptor = resolveDescriptor(
+    platform,
+    { ...(overrides.plistPath !== undefined && { plistPath: overrides.plistPath }), ...(overrides.unitPath !== undefined && { unitPath: overrides.unitPath }) },
+    natsInfra,
+  );
+  if (!descriptor.ok) return fail(descriptor.reason);
 
   const account = overrides.account ?? natsInfra?.account;
   if (account === undefined || account === "") {
@@ -257,7 +353,9 @@ export function deriveJoinInputs(
       registryUrl,
       ...(registryPubkey !== undefined && { registryPubkey }),
       natsConfigPath,
-      plistPath,
+      ...(descriptor.plistPath !== undefined && { plistPath: descriptor.plistPath }),
+      ...(descriptor.unitPath !== undefined && { unitPath: descriptor.unitPath }),
+      platform: descriptor.platform,
       account,
       credsPath,
       announceCapabilities,
@@ -275,9 +373,10 @@ export function deriveJoinInputs(
  * include + plist). Same override-then-config-then-convention precedence.
  */
 export function deriveLeaveInputs(
-  overrides: Pick<JoinOverrides, "principal" | "stack" | "natsConfigPath" | "plistPath">,
+  overrides: Pick<JoinOverrides, "principal" | "stack" | "natsConfigPath" | "plistPath" | "unitPath">,
   configPath: string,
   load: ConfigReader,
+  platform: ServicePlatform = defaultPlatform(),
 ): DeriveResult<DerivedLeaveInputs> {
   const cfg = load(configPath);
 
@@ -298,12 +397,23 @@ export function deriveLeaveInputs(
     );
   }
 
-  const plistPath = overrides.plistPath ?? natsInfra?.plist_path;
-  if (plistPath === undefined || plistPath === "") {
-    return fail(
-      "cannot resolve plist path — pass --plist or set `stack.nats_infra.plist_path` in cortex.yaml",
-    );
-  }
+  // #763 — same platform-aware descriptor resolution as join.
+  const descriptor = resolveDescriptor(
+    platform,
+    { ...(overrides.plistPath !== undefined && { plistPath: overrides.plistPath }), ...(overrides.unitPath !== undefined && { unitPath: overrides.unitPath }) },
+    natsInfra,
+  );
+  if (!descriptor.ok) return fail(descriptor.reason);
 
-  return { ok: true, inputs: { principal, stack, natsConfigPath, plistPath } };
+  return {
+    ok: true,
+    inputs: {
+      principal,
+      stack,
+      natsConfigPath,
+      ...(descriptor.plistPath !== undefined && { plistPath: descriptor.plistPath }),
+      ...(descriptor.unitPath !== undefined && { unitPath: descriptor.unitPath }),
+      platform: descriptor.platform,
+    },
+  };
 }

--- a/src/cli/cortex/commands/network.ts
+++ b/src/cli/cortex/commands/network.ts
@@ -128,6 +128,9 @@ const SPEC: SubcommandSpec<NetworkSubcommand> = {
         "--account": "value",
         "--nats-config": "value",
         "--plist": "value",
+        // #763 — Linux/systemd: the nats-server systemd unit path (the
+        // launchd plist's sibling). Maps to stack.nats_infra.unit_path.
+        "--unit": "value",
         "--max-hop": "value",
         "--leaf-node": "value",
         // S5 (#739) — public-scope flags. `--capabilities` (comma-separated)
@@ -151,6 +154,7 @@ const SPEC: SubcommandSpec<NetworkSubcommand> = {
         "--seed-path": "value",
         "--nats-config": "value",
         "--plist": "value",
+        "--unit": "value",
         "--apply": "bool",
         "--dry-run": "bool",
       },
@@ -284,6 +288,7 @@ async function runJoin(
         ...readOverride(flags, "--registry-pubkey", "registryPubkey"),
         ...readOverride(flags, "--nats-config", "natsConfigPath"),
         ...readOverride(flags, "--plist", "plistPath"),
+        ...readOverride(flags, "--unit", "unitPath"),
         ...readOverride(flags, "--account", "account"),
         ...readOverride(flags, "--creds", "credsPath"),
       },
@@ -359,6 +364,7 @@ async function runLeave(
         ...readOverride(flags, "--stack", "stack"),
         ...readOverride(flags, "--nats-config", "natsConfigPath"),
         ...readOverride(flags, "--plist", "plistPath"),
+        ...readOverride(flags, "--unit", "unitPath"),
       },
       expandTilde(optionalValueFlag(flags, "--config") ?? DEFAULT_CONFIG_PATH),
       load,
@@ -381,7 +387,10 @@ async function runLeave(
     principalId: inputs.principal,
     stackId: `${inputs.principal}/${slugRes.slug}`,
     natsConfigPath: inputs.natsConfigPath,
-    plistPath: inputs.plistPath,
+    // #763 — platform-resolved descriptor (plist on macOS, unit on Linux).
+    ...(inputs.plistPath !== undefined && { plistPath: inputs.plistPath }),
+    ...(inputs.unitPath !== undefined && { unitPath: inputs.unitPath }),
+    platform: inputs.platform,
   };
   const ports = applyRes.apply ? buildLivePorts(cfg) : buildDryRunPorts(cfg);
 
@@ -557,7 +566,12 @@ function portsConfigFromInputs(
     ...(inputs.registryPubkey !== undefined && { registryPubkey: inputs.registryPubkey }),
     seedPath: inputs.seedPath,
     natsConfigPath: inputs.natsConfigPath,
-    plistPath: inputs.plistPath,
+    // #763 — platform-resolved service descriptor: plist on macOS, systemd unit
+    // on Linux. The deriver sets exactly one + the platform; thread both through
+    // so the adapter selects the right NatsServiceManager.
+    ...(inputs.plistPath !== undefined && { plistPath: inputs.plistPath }),
+    ...(inputs.unitPath !== undefined && { unitPath: inputs.unitPath }),
+    platform: inputs.platform,
     monitorUrl: optionalValueFlag(flags, "--monitor-url"),
     // #762 — caps the join announces INTO the network so the principal joins
     // the roster (registry control-plane; never on the wire).
@@ -720,7 +734,9 @@ Flags (all OPTIONAL OVERRIDES — derived from cortex.yaml when omitted; #753):
   --creds <p>             Override stack.nats_infra.creds_path (default: ~/.config/nats/<network>.creds).
   --account <nkey-U>      Override stack.nats_infra.account (A… nkey-U the leaf binds to).
   --nats-config <p>       Override stack.nats_infra.config_path (nats-server -c config).
-  --plist <p>             Override stack.nats_infra.plist_path (nats-server launchd plist).
+  --plist <p>             Override stack.nats_infra.plist_path (macOS nats-server launchd plist).
+  --unit <p>              Override stack.nats_infra.unit_path (Linux nats-server systemd unit; #763).
+                          Pass exactly ONE of --plist / --unit; each is self-describing.
   --leaf-node <name>      Leaf connection name on the network entry (default: network id).
   --max-hop <n>           Hop budget written on the network (default: 1).
   --capabilities <csv>    (join public) Comma-separated capability ids to announce

--- a/src/common/nats/__tests__/nats-service-manager.test.ts
+++ b/src/common/nats/__tests__/nats-service-manager.test.ts
@@ -1,0 +1,384 @@
+/**
+ * #763 — `NatsServiceManager` tests: the launchd/systemd abstraction the
+ * `cortex network join` adapters select on by platform/descriptor.
+ *
+ * Two implementations behind one seam:
+ *   - launchd (macOS): ensure the nats-server plist `ProgramArguments` carry
+ *     `-c <config>`, restart via `launchctl kickstart -k gui/<uid>/<label>`.
+ *   - systemd (Linux): ensure the unit `[Service] ExecStart=` carries
+ *     `-c <config>`, restart via `systemctl [--user] restart <unit>`.
+ *
+ * These tests write real temp descriptor files (a sample `.plist` + a sample
+ * `.service` unit) and assert on the rewritten file bytes + the restart command
+ * the manager WOULD run (captured via an injected exec, never a real
+ * launchctl/systemctl). They cover: systemd ExecStart ensure (add / no-op /
+ * repoint), launchd path unchanged (regression), platform/descriptor selection,
+ * dry-run execs nothing, and the clear-error mismatch cases (plist-on-Linux /
+ * unit-on-macOS).
+ */
+
+import { describe, test, expect, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync, readFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+import {
+  selectNatsServiceManager,
+  type ExecRunner,
+  type ExecResult,
+} from "../nats-service-manager";
+
+const tmpDirs: string[] = [];
+function freshDir(): string {
+  const d = mkdtempSync(join(tmpdir(), "s763-svcmgr-"));
+  tmpDirs.push(d);
+  return d;
+}
+afterEach(() => {
+  while (tmpDirs.length > 0) rmSync(tmpDirs.pop()!, { recursive: true, force: true });
+});
+
+const NATS_CONFIG = "/home/jc/.config/nats/local.conf";
+const NATS_BIN = "/usr/bin/nats-server";
+
+function barePlist(): string {
+  return [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<plist version="1.0">',
+    "<dict>",
+    "\t<key>Label</key>",
+    "\t<string>homebrew.mxcl.nats-server</string>",
+    "\t<key>ProgramArguments</key>",
+    "\t<array>",
+    "\t\t<string>/opt/homebrew/bin/nats-server</string>",
+    "\t\t<string>-js</string>",
+    "\t</array>",
+    "</dict>",
+    "</plist>",
+    "",
+  ].join("\n");
+}
+
+function bareUnit(): string {
+  return [
+    "[Unit]",
+    "Description=NATS Server",
+    "",
+    "[Service]",
+    `ExecStart=${NATS_BIN} -js`,
+    "Restart=on-failure",
+    "",
+    "[Install]",
+    "WantedBy=default.target",
+    "",
+  ].join("\n");
+}
+
+/** A capturing exec runner — records argv, returns a success by default. */
+function capturingExec(): { runner: ExecRunner; calls: string[][] } {
+  const calls: string[][] = [];
+  const runner: ExecRunner = async (argv: string[]): Promise<ExecResult> => {
+    calls.push(argv);
+    return { code: 0, stderr: "" };
+  };
+  return { runner, calls };
+}
+
+// =============================================================================
+// systemd — ExecStart ensure (live write) + restart command
+// =============================================================================
+
+describe("systemd manager — ExecStart ensure-config-arg (live)", () => {
+  test("ensureConfigLoaded adds -c <config> to the unit ExecStart", () => {
+    const dir = freshDir();
+    const unitPath = join(dir, "nats-server.service");
+    writeFileSync(unitPath, bareUnit(), "utf-8");
+
+    const mgr = selectNatsServiceManager({
+      descriptorPath: unitPath,
+      platform: "linux",
+      mutate: true,
+      exec: capturingExec().runner,
+    });
+    mgr.ensureConfigLoaded(NATS_CONFIG);
+
+    const after = readFileSync(unitPath, "utf-8");
+    expect(after).toContain(`ExecStart=${NATS_BIN} -js -c ${NATS_CONFIG}`);
+  });
+
+  test("ensureConfigLoaded is a byte-stable no-op when already present", () => {
+    const dir = freshDir();
+    const unitPath = join(dir, "nats-server.service");
+    const already = bareUnit().replace(
+      `ExecStart=${NATS_BIN} -js`,
+      `ExecStart=${NATS_BIN} -js -c ${NATS_CONFIG}`,
+    );
+    writeFileSync(unitPath, already, "utf-8");
+
+    const mgr = selectNatsServiceManager({
+      descriptorPath: unitPath,
+      platform: "linux",
+      mutate: true,
+      exec: capturingExec().runner,
+    });
+    mgr.ensureConfigLoaded(NATS_CONFIG);
+
+    expect(readFileSync(unitPath, "utf-8")).toBe(already);
+  });
+
+  test("dropConfigArg removes the -c arg from the unit ExecStart", () => {
+    const dir = freshDir();
+    const unitPath = join(dir, "nats-server.service");
+    const withArg = bareUnit().replace(
+      `ExecStart=${NATS_BIN} -js`,
+      `ExecStart=${NATS_BIN} -js -c ${NATS_CONFIG}`,
+    );
+    writeFileSync(unitPath, withArg, "utf-8");
+
+    const mgr = selectNatsServiceManager({
+      descriptorPath: unitPath,
+      platform: "linux",
+      mutate: true,
+      exec: capturingExec().runner,
+    });
+    mgr.dropConfigArg(NATS_CONFIG);
+
+    const after = readFileSync(unitPath, "utf-8");
+    expect(after).toContain(`ExecStart=${NATS_BIN} -js`);
+    expect(after).not.toContain(`-c ${NATS_CONFIG}`);
+  });
+
+  test("restart runs `systemctl --user restart <unit>` for a user-scope unit", async () => {
+    const dir = freshDir();
+    // A path under a `systemd/user/` dir → user scope.
+    const userDir = join(dir, "systemd", "user");
+    rmSync(userDir, { recursive: true, force: true });
+    const fs = await import("fs");
+    fs.mkdirSync(userDir, { recursive: true });
+    const unitPath = join(userDir, "nats-server.service");
+    writeFileSync(unitPath, bareUnit(), "utf-8");
+
+    const { runner, calls } = capturingExec();
+    const mgr = selectNatsServiceManager({
+      descriptorPath: unitPath,
+      platform: "linux",
+      mutate: true,
+      exec: runner,
+    });
+    const res = await mgr.restart();
+    expect(res.ok).toBe(true);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toEqual(["systemctl", "--user", "restart", "nats-server.service"]);
+  });
+
+  test("restart runs system-scope `systemctl restart <unit>` for a /etc/systemd/system unit", async () => {
+    const dir = freshDir();
+    const sysDir = join(dir, "etc", "systemd", "system");
+    const fs = await import("fs");
+    fs.mkdirSync(sysDir, { recursive: true });
+    const unitPath = join(sysDir, "nats-server.service");
+    writeFileSync(unitPath, bareUnit(), "utf-8");
+
+    const { runner, calls } = capturingExec();
+    const mgr = selectNatsServiceManager({
+      descriptorPath: unitPath,
+      platform: "linux",
+      mutate: true,
+      exec: runner,
+    });
+    await mgr.restart();
+    expect(calls[0]).toEqual(["systemctl", "restart", "nats-server.service"]);
+  });
+
+  test("restart surfaces a non-zero systemctl exit as { ok: false }", async () => {
+    const dir = freshDir();
+    const unitPath = join(dir, "nats-server.service");
+    writeFileSync(unitPath, bareUnit(), "utf-8");
+
+    const failing: ExecRunner = async () => ({ code: 5, stderr: "Failed to restart" });
+    const mgr = selectNatsServiceManager({
+      descriptorPath: unitPath,
+      platform: "linux",
+      mutate: true,
+      exec: failing,
+    });
+    const res = await mgr.restart();
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.reason).toContain("Failed to restart");
+  });
+});
+
+// =============================================================================
+// launchd — regression: behavior unchanged
+// =============================================================================
+
+describe("launchd manager — plist path unchanged (regression)", () => {
+  test("ensureConfigLoaded appends -c <config> to ProgramArguments", () => {
+    const dir = freshDir();
+    const plistPath = join(dir, "nats-server.plist");
+    writeFileSync(plistPath, barePlist(), "utf-8");
+
+    const mgr = selectNatsServiceManager({
+      descriptorPath: plistPath,
+      platform: "darwin",
+      mutate: true,
+      exec: capturingExec().runner,
+    });
+    mgr.ensureConfigLoaded(NATS_CONFIG);
+
+    const after = readFileSync(plistPath, "utf-8");
+    expect(after).toContain("<string>-c</string>");
+    expect(after).toContain(`<string>${NATS_CONFIG}</string>`);
+  });
+
+  test("restart runs `launchctl kickstart -k gui/<uid>/<label>` reading the plist Label", async () => {
+    const dir = freshDir();
+    const plistPath = join(dir, "nats-server.plist");
+    writeFileSync(plistPath, barePlist(), "utf-8");
+
+    const { runner, calls } = capturingExec();
+    const mgr = selectNatsServiceManager({
+      descriptorPath: plistPath,
+      platform: "darwin",
+      mutate: true,
+      exec: runner,
+      uid: 501,
+    });
+    const res = await mgr.restart();
+    expect(res.ok).toBe(true);
+    expect(calls[0]?.[0]).toBe("launchctl");
+    expect(calls[0]).toContain("kickstart");
+    expect(calls[0]?.join(" ")).toContain("gui/501/homebrew.mxcl.nats-server");
+  });
+});
+
+// =============================================================================
+// selection — platform/descriptor picks the right manager + clear mismatch errors
+// =============================================================================
+
+describe("selectNatsServiceManager — platform/descriptor selection", () => {
+  test("a .service descriptor on linux selects the systemd manager", () => {
+    const dir = freshDir();
+    const unitPath = join(dir, "nats-server.service");
+    writeFileSync(unitPath, bareUnit(), "utf-8");
+    const mgr = selectNatsServiceManager({
+      descriptorPath: unitPath,
+      platform: "linux",
+      mutate: false,
+      exec: capturingExec().runner,
+    });
+    expect(mgr.kind).toBe("systemd");
+  });
+
+  test("a .plist descriptor on darwin selects the launchd manager", () => {
+    const dir = freshDir();
+    const plistPath = join(dir, "nats-server.plist");
+    writeFileSync(plistPath, barePlist(), "utf-8");
+    const mgr = selectNatsServiceManager({
+      descriptorPath: plistPath,
+      platform: "darwin",
+      mutate: false,
+      exec: capturingExec().runner,
+    });
+    expect(mgr.kind).toBe("launchd");
+  });
+
+  test("a plist descriptor on LINUX is a clear error (no cryptic ProgramArguments-empty)", () => {
+    const dir = freshDir();
+    const plistPath = join(dir, "nats-server.plist");
+    writeFileSync(plistPath, barePlist(), "utf-8");
+    expect(() =>
+      selectNatsServiceManager({
+        descriptorPath: plistPath,
+        platform: "linux",
+        mutate: false,
+        exec: capturingExec().runner,
+      }),
+    ).toThrow(/launchd plist.*Linux|plist.*systemd|does not match/i);
+  });
+
+  test("a systemd unit descriptor on macOS is a clear error", () => {
+    const dir = freshDir();
+    const unitPath = join(dir, "nats-server.service");
+    writeFileSync(unitPath, bareUnit(), "utf-8");
+    expect(() =>
+      selectNatsServiceManager({
+        descriptorPath: unitPath,
+        platform: "darwin",
+        mutate: false,
+        exec: capturingExec().runner,
+      }),
+    ).toThrow(/systemd unit.*macOS|unit.*launchd|does not match/i);
+  });
+
+  test("detects descriptor type by CONTENT when the extension is ambiguous", () => {
+    const dir = freshDir();
+    // A `.conf`-ish path carrying systemd unit content on linux → systemd.
+    const unitPath = join(dir, "nats-server.unit");
+    writeFileSync(unitPath, bareUnit(), "utf-8");
+    const mgr = selectNatsServiceManager({
+      descriptorPath: unitPath,
+      platform: "linux",
+      mutate: false,
+      exec: capturingExec().runner,
+    });
+    expect(mgr.kind).toBe("systemd");
+  });
+});
+
+// =============================================================================
+// dry-run — execs nothing, writes nothing
+// =============================================================================
+
+describe("dry-run posture — no exec, no write", () => {
+  test("systemd dry-run ensureConfigLoaded does NOT write the unit", () => {
+    const dir = freshDir();
+    const unitPath = join(dir, "nats-server.service");
+    const before = bareUnit();
+    writeFileSync(unitPath, before, "utf-8");
+
+    const mgr = selectNatsServiceManager({
+      descriptorPath: unitPath,
+      platform: "linux",
+      mutate: false,
+      exec: capturingExec().runner,
+    });
+    mgr.ensureConfigLoaded(NATS_CONFIG);
+
+    expect(readFileSync(unitPath, "utf-8")).toBe(before);
+  });
+
+  test("systemd dry-run restart execs NOTHING and reports ok", async () => {
+    const dir = freshDir();
+    const unitPath = join(dir, "nats-server.service");
+    writeFileSync(unitPath, bareUnit(), "utf-8");
+
+    const { runner, calls } = capturingExec();
+    const mgr = selectNatsServiceManager({
+      descriptorPath: unitPath,
+      platform: "linux",
+      mutate: false,
+      exec: runner,
+    });
+    const res = await mgr.restart();
+    expect(res.ok).toBe(true);
+    expect(calls).toHaveLength(0);
+  });
+
+  test("launchd dry-run restart execs NOTHING and reports ok", async () => {
+    const dir = freshDir();
+    const plistPath = join(dir, "nats-server.plist");
+    writeFileSync(plistPath, barePlist(), "utf-8");
+
+    const { runner, calls } = capturingExec();
+    const mgr = selectNatsServiceManager({
+      descriptorPath: plistPath,
+      platform: "darwin",
+      mutate: false,
+      exec: runner,
+    });
+    const res = await mgr.restart();
+    expect(res.ok).toBe(true);
+    expect(calls).toHaveLength(0);
+  });
+});

--- a/src/common/nats/__tests__/systemd-unit-loader.test.ts
+++ b/src/common/nats/__tests__/systemd-unit-loader.test.ts
@@ -1,0 +1,177 @@
+/**
+ * #763 — nats-server systemd unit-loader tests (the Linux sibling of
+ * `nats-plist-loader.test.ts`).
+ *
+ * On Linux (clawbox, systemd) the nats-server service is a systemd unit, not a
+ * launchd plist. The dormant-config trap is the same: a unit whose
+ * `[Service] ExecStart=` runs bare `nats-server -js` never loads the rendered
+ * leaf config. This unit takes the unit file's text + the config path and
+ * returns the corrected unit text whose `ExecStart` carries `-c <config>` —
+ * IDEMPOTENT + byte-stable (no-op when already present), preserving every other
+ * `ExecStart` argument and every other unit section. It also reads the unit's
+ * service id (its file name / `Description`) — the systemd analogue of the
+ * launchd `<key>Label</key>`. It does NOT write the unit or restart anything;
+ * the S4 adapter applies. Pure + fixture-driven (no real `systemctl`).
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import {
+  ensureUnitConfigArg,
+  systemdUnitConfigArgPresent,
+  systemdUnitServiceId,
+} from "../systemd-unit-loader";
+
+const NATS_BIN = "/usr/bin/nats-server";
+const CONFIG = "/home/jc/.config/nats/local.conf";
+
+/** A bare unit running `nats-server -js` (the dormant trap). */
+function bareUnit(): string {
+  return [
+    "[Unit]",
+    "Description=NATS Server",
+    "After=network.target",
+    "",
+    "[Service]",
+    `ExecStart=${NATS_BIN} -js`,
+    "Restart=on-failure",
+    "",
+    "[Install]",
+    "WantedBy=default.target",
+    "",
+  ].join("\n");
+}
+
+describe("ensureUnitConfigArg", () => {
+  test("adds -c <config> to ExecStart when the dormant unit runs bare -js", () => {
+    const next = ensureUnitConfigArg(bareUnit(), CONFIG);
+    expect(next).toContain(`ExecStart=${NATS_BIN} -js -c ${CONFIG}`);
+  });
+
+  test("is a no-op (byte-stable) when -c <config> is already present", () => {
+    const already = bareUnit().replace(
+      `ExecStart=${NATS_BIN} -js`,
+      `ExecStart=${NATS_BIN} -js -c ${CONFIG}`,
+    );
+    expect(ensureUnitConfigArg(already, CONFIG)).toBe(already);
+  });
+
+  test("repoints -c when present but pointing at a different config (one -c only)", () => {
+    const stale = bareUnit().replace(
+      `ExecStart=${NATS_BIN} -js`,
+      `ExecStart=${NATS_BIN} -js -c /old/path/other.conf`,
+    );
+    const next = ensureUnitConfigArg(stale, CONFIG);
+    expect(next).toContain(`ExecStart=${NATS_BIN} -js -c ${CONFIG}`);
+    expect(next).not.toContain("/old/path/other.conf");
+    // exactly one -c in the ExecStart line
+    const execLine = next
+      .split("\n")
+      .find((l) => l.startsWith("ExecStart="));
+    expect(execLine?.match(/(^|\s)-c(\s|$)/g)?.length ?? 0).toBe(1);
+  });
+
+  test("supports the --config=<path> long form already present (no-op)", () => {
+    const already = bareUnit().replace(
+      `ExecStart=${NATS_BIN} -js`,
+      `ExecStart=${NATS_BIN} -js --config=${CONFIG}`,
+    );
+    expect(ensureUnitConfigArg(already, CONFIG)).toBe(already);
+  });
+
+  test("supports the --config <path> split long form already present (no-op)", () => {
+    const already = bareUnit().replace(
+      `ExecStart=${NATS_BIN} -js`,
+      `ExecStart=${NATS_BIN} -js --config ${CONFIG}`,
+    );
+    expect(ensureUnitConfigArg(already, CONFIG)).toBe(already);
+  });
+
+  test("preserves the other ExecStart args and every other unit section", () => {
+    const next = ensureUnitConfigArg(bareUnit(), CONFIG);
+    // Other ExecStart args survive.
+    expect(next).toContain("-js");
+    // Other sections + directives survive verbatim.
+    expect(next).toContain("[Unit]");
+    expect(next).toContain("Description=NATS Server");
+    expect(next).toContain("After=network.target");
+    expect(next).toContain("Restart=on-failure");
+    expect(next).toContain("[Install]");
+    expect(next).toContain("WantedBy=default.target");
+  });
+
+  test("rewrites only the ExecStart line, leaving line count + ordering stable", () => {
+    const before = bareUnit();
+    const after = ensureUnitConfigArg(before, CONFIG);
+    expect(after.split("\n").length).toBe(before.split("\n").length);
+  });
+
+  test("does not mutate when there is no [Service] ExecStart (throws clearly)", () => {
+    const noExec = ["[Unit]", "Description=NATS Server", "", "[Service]", "Restart=on-failure", ""].join("\n");
+    expect(() => ensureUnitConfigArg(noExec, CONFIG)).toThrow(/ExecStart/);
+  });
+
+  test("throws on a non-absolute config path (nats-server needs an absolute path)", () => {
+    expect(() => ensureUnitConfigArg(bareUnit(), "local.conf")).toThrow();
+  });
+
+  test("is idempotent across repeated application (apply twice == apply once)", () => {
+    const once = ensureUnitConfigArg(bareUnit(), CONFIG);
+    const twice = ensureUnitConfigArg(once, CONFIG);
+    expect(twice).toBe(once);
+  });
+
+  test("handles ExecStart= with a leading +/-/@ prefix (systemd special exec prefixes)", () => {
+    const prefixed = bareUnit().replace(
+      `ExecStart=${NATS_BIN} -js`,
+      `ExecStart=-${NATS_BIN} -js`,
+    );
+    const next = ensureUnitConfigArg(prefixed, CONFIG);
+    expect(next).toContain(`ExecStart=-${NATS_BIN} -js -c ${CONFIG}`);
+  });
+});
+
+describe("systemdUnitConfigArgPresent", () => {
+  test("detects the short -c form in ExecStart", () => {
+    const unit = bareUnit().replace(
+      `ExecStart=${NATS_BIN} -js`,
+      `ExecStart=${NATS_BIN} -js -c ${CONFIG}`,
+    );
+    expect(systemdUnitConfigArgPresent(unit, CONFIG)).toBe(true);
+  });
+
+  test("detects the --config=<path> long form", () => {
+    const unit = bareUnit().replace(
+      `ExecStart=${NATS_BIN} -js`,
+      `ExecStart=${NATS_BIN} -js --config=${CONFIG}`,
+    );
+    expect(systemdUnitConfigArgPresent(unit, CONFIG)).toBe(true);
+  });
+
+  test("returns false when ExecStart runs bare -js (the dormant trap)", () => {
+    expect(systemdUnitConfigArgPresent(bareUnit(), CONFIG)).toBe(false);
+  });
+
+  test("returns false when -c points at a different config", () => {
+    const unit = bareUnit().replace(
+      `ExecStart=${NATS_BIN} -js`,
+      `ExecStart=${NATS_BIN} -js -c /other.conf`,
+    );
+    expect(systemdUnitConfigArgPresent(unit, CONFIG)).toBe(false);
+  });
+});
+
+describe("systemdUnitServiceId — the systemd analogue of the plist Label", () => {
+  test("derives the service id from a unit file path's basename", () => {
+    expect(
+      systemdUnitServiceId("/home/jc/.config/systemd/user/nats-server.service", bareUnit()),
+    ).toBe("nats-server.service");
+  });
+
+  test("falls back to a synthesized id from Description when path has no .service basename", () => {
+    // Defensive: a non-.service path still yields a usable id (never undefined).
+    const id = systemdUnitServiceId("/tmp/whatever", bareUnit());
+    expect(typeof id).toBe("string");
+    expect(id.length).toBeGreaterThan(0);
+  });
+});

--- a/src/common/nats/index.ts
+++ b/src/common/nats/index.ts
@@ -26,3 +26,23 @@ export {
   plistConfigArgPresent,
   renderProgramArguments,
 } from "./nats-plist-loader";
+
+export {
+  ensureUnitConfigArg,
+  systemdUnitConfigArgPresent,
+  systemdUnitServiceId,
+} from "./systemd-unit-loader";
+
+export {
+  bunExecRunner,
+  currentServicePlatform,
+  detectDescriptorKind,
+  selectNatsServiceManager,
+} from "./nats-service-manager";
+export type {
+  ExecResult,
+  ExecRunner,
+  NatsServiceManager,
+  SelectServiceManagerOptions,
+  ServicePlatform,
+} from "./nats-service-manager";

--- a/src/common/nats/nats-service-manager.ts
+++ b/src/common/nats/nats-service-manager.ts
@@ -1,0 +1,366 @@
+/**
+ * #763 — `NatsServiceManager`: the launchd/systemd abstraction for the
+ * nats-server service that `cortex network join`/`leave` manages.
+ *
+ * ## The bug this closes
+ *
+ * The join's nats-server service management was macOS-only. It assumed the
+ * service descriptor was a launchd plist: it spliced `-c <config>` into the
+ * plist `ProgramArguments` and restarted via `launchctl kickstart`. On clawbox
+ * (Linux, systemd) the descriptor is a systemd **unit**, so feeding it to the
+ * plist parser produced the cryptic `ProgramArguments is empty` error and the
+ * `launchctl` restart was meaningless.
+ *
+ * ## The seam
+ *
+ * One small interface — {@link NatsServiceManager} — with two implementations:
+ *
+ *   - **launchd (macOS):** ensure the plist `ProgramArguments` carry
+ *     `-c <config>` (S3's `ensureConfigArg`/`renderProgramArguments`), restart
+ *     via `launchctl kickstart -k gui/<uid>/<label>` reading the plist
+ *     `<key>Label</key>`. This is the EXISTING behavior, lifted here verbatim.
+ *   - **systemd (Linux):** ensure the unit `[Service] ExecStart=` carries
+ *     `-c <config>` (S3-sibling `ensureUnitConfigArg`), restart via
+ *     `systemctl [--user] restart <unit>` reading the unit's `.service` id
+ *     (the systemd analogue of the plist Label). `--user` vs system scope is
+ *     chosen from the unit's on-disk location.
+ *
+ * {@link selectNatsServiceManager} picks the implementation by the descriptor
+ * type (plist XML vs systemd unit — detected from path extension, falling back
+ * to a content sniff) cross-checked against the platform, and throws a CLEAR,
+ * actionable error on a mismatch (plist-on-Linux / unit-on-macOS) instead of
+ * the old cryptic parser failure.
+ *
+ * Side effects are injected: the file I/O uses `fs`, but the process exec
+ * (`launchctl`/`systemctl`) goes through an injected {@link ExecRunner} so tests
+ * capture the command without spawning anything. `mutate: false` is the
+ * dry-run posture — reads still hit disk, but no write and NO exec happen.
+ */
+
+import { existsSync, readFileSync, writeFileSync } from "fs";
+
+import {
+  ensureConfigArg,
+  plistConfigArgPresent,
+  renderProgramArguments,
+} from "./nats-plist-loader";
+import {
+  ensureUnitConfigArg,
+  systemdUnitConfigArgPresent,
+  systemdUnitServiceId,
+} from "./systemd-unit-loader";
+
+// =============================================================================
+// Public types
+// =============================================================================
+
+/** Result of running a service-management subprocess. */
+export interface ExecResult {
+  code: number;
+  stderr: string;
+}
+
+/** Injected process runner — captured in tests, real `Bun.spawn` in prod. */
+export type ExecRunner = (argv: string[]) => Promise<ExecResult>;
+
+/** macOS (`darwin`) vs Linux. The only two platforms cortex's join supports. */
+export type ServicePlatform = "darwin" | "linux";
+
+/**
+ * The nats-server service-management seam. Both the plist `PlistPort` and the
+ * `NatsServerPort` of `network-ports.ts` are satisfied by one manager:
+ * `ensureConfigLoaded`/`dropConfigArg` are the config-arg-ensure half (plist
+ * `ProgramArguments` or unit `ExecStart`), and `restart` reloads the daemon.
+ */
+export interface NatsServiceManager {
+  /** Which implementation this is — for selection assertions + logging. */
+  readonly kind: "launchd" | "systemd";
+  /** Ensure the descriptor loads `configPath` via `-c`. Idempotent + byte-stable. */
+  ensureConfigLoaded(configPath: string): void;
+  /** Remove the `-c <configPath>` arg from the descriptor (leave teardown). */
+  dropConfigArg(configPath: string): void;
+  /** Restart nats-server so it reloads its config. Never throws. */
+  restart(): Promise<{ ok: true } | { ok: false; reason: string }>;
+}
+
+/** Inputs to {@link selectNatsServiceManager}. */
+export interface SelectServiceManagerOptions {
+  /** Path to the service descriptor (launchd plist or systemd unit). */
+  descriptorPath: string;
+  /** Platform the join is running on. Defaults to `process.platform` mapping. */
+  platform: ServicePlatform;
+  /** `true` mutates the live descriptor + execs the restart; `false` = dry-run. */
+  mutate: boolean;
+  /** Injected process runner (launchctl/systemctl). */
+  exec: ExecRunner;
+  /** launchd `gui/<uid>` target uid (defaults to `process.getuid()`/501). */
+  uid?: number;
+}
+
+// =============================================================================
+// Descriptor detection
+// =============================================================================
+
+type DescriptorKind = "launchd" | "systemd";
+
+/**
+ * Detect whether `descriptorPath` is a launchd plist or a systemd unit. Path
+ * extension first (`.plist` → launchd, `.service` → systemd), then a content
+ * sniff for the ambiguous case (a plist `<?xml … <plist` vs a systemd
+ * `[Unit]`/`[Service]` section). Returns `undefined` when neither is detectable.
+ */
+export function detectDescriptorKind(
+  descriptorPath: string,
+): DescriptorKind | undefined {
+  if (/\.plist$/i.test(descriptorPath)) return "launchd";
+  if (/\.service$/i.test(descriptorPath)) return "systemd";
+  // Ambiguous extension — sniff the content if the file exists.
+  if (!existsSync(descriptorPath)) return undefined;
+  const text = readFileSync(descriptorPath, "utf-8");
+  if (/<\?xml/i.test(text) && /<plist/i.test(text)) return "launchd";
+  if (/^\s*\[(Unit|Service|Install)\]/m.test(text)) return "systemd";
+  return undefined;
+}
+
+/** The descriptor kind a given platform expects. */
+function expectedKindFor(platform: ServicePlatform): DescriptorKind {
+  return platform === "darwin" ? "launchd" : "systemd";
+}
+
+// =============================================================================
+// launchd implementation (existing macOS behavior, lifted verbatim)
+// =============================================================================
+
+/** Unescape the five XML predefined entities. */
+function unescapeXml(v: string): string {
+  return v
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&amp;/g, "&");
+}
+
+/** Read the `ProgramArguments` <string> entries from a launchd plist. */
+function readProgramArguments(plistPath: string): string[] {
+  const xml = readFileSync(plistPath, "utf-8");
+  const block = /<key>ProgramArguments<\/key>\s*<array>([\s\S]*?)<\/array>/.exec(xml);
+  if (block === null) return [];
+  const args: string[] = [];
+  const re = /<string>([\s\S]*?)<\/string>/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(block[1] ?? "")) !== null) {
+    args.push(unescapeXml(m[1] ?? ""));
+  }
+  return args;
+}
+
+/** Splice S3's canonical rendered ProgramArguments block into the plist. */
+function writeProgramArguments(plistPath: string, nextArgs: string[]): void {
+  const xml = readFileSync(plistPath, "utf-8");
+  const next = xml.replace(
+    /[ \t]*<key>ProgramArguments<\/key>\s*<array>[\s\S]*?<\/array>/,
+    renderProgramArguments(nextArgs),
+  );
+  writeFileSync(plistPath, next, "utf-8");
+}
+
+/** Read the launchd `<key>Label</key><string>…</string>`. */
+function readPlistLabel(plistPath: string): string | undefined {
+  const xml = readFileSync(plistPath, "utf-8");
+  const m = /<key>Label<\/key>\s*<string>([\s\S]*?)<\/string>/.exec(xml);
+  if (m === null) return undefined;
+  const label = unescapeXml(m[1] ?? "").trim();
+  return label === "" ? undefined : label;
+}
+
+class LaunchdServiceManager implements NatsServiceManager {
+  readonly kind = "launchd" as const;
+  constructor(
+    private readonly plistPath: string,
+    private readonly mutate: boolean,
+    private readonly exec: ExecRunner,
+    private readonly uid: number,
+  ) {}
+
+  ensureConfigLoaded(configPath: string): void {
+    if (!existsSync(this.plistPath)) return;
+    const args = readProgramArguments(this.plistPath);
+    if (plistConfigArgPresent(args, configPath)) return; // idempotent no-op
+    const next = ensureConfigArg(args, configPath);
+    if (!this.mutate) return;
+    writeProgramArguments(this.plistPath, next);
+  }
+
+  dropConfigArg(configPath: string): void {
+    if (!existsSync(this.plistPath)) return;
+    const args = readProgramArguments(this.plistPath);
+    const next = args.filter((a, i) => {
+      if (a === "-c" || a === "--config") return false;
+      if (i > 0 && (args[i - 1] === "-c" || args[i - 1] === "--config")) return false;
+      if (a === `--config=${configPath}`) return false;
+      return true;
+    });
+    if (!this.mutate) return;
+    writeProgramArguments(this.plistPath, next);
+  }
+
+  async restart(): Promise<{ ok: true } | { ok: false; reason: string }> {
+    if (!this.mutate) return { ok: true }; // dry-run: touch nothing.
+    if (!existsSync(this.plistPath)) {
+      return { ok: false, reason: `nats-server plist not found at ${this.plistPath}` };
+    }
+    const label = readPlistLabel(this.plistPath);
+    if (label === undefined) {
+      return { ok: false, reason: `no <key>Label</key> in nats-server plist ${this.plistPath}` };
+    }
+    const argv = ["launchctl", "kickstart", "-k", `gui/${this.uid.toString()}/${label}`];
+    const { code, stderr } = await this.exec(argv);
+    if (code !== 0) {
+      return {
+        ok: false,
+        reason: `launchctl kickstart ${label} exited ${code.toString()}: ${stderr.trim()}`,
+      };
+    }
+    return { ok: true };
+  }
+}
+
+// =============================================================================
+// systemd implementation (new Linux behavior)
+// =============================================================================
+
+/**
+ * Decide `systemctl --user` vs system scope from the unit's on-disk location.
+ * User units live under a `systemd/user/` dir (`~/.config/systemd/user/…`);
+ * everything else (e.g. `/etc/systemd/system/`, `/usr/lib/systemd/system/`) is
+ * a system unit. This mirrors the systemd convention: `--user` for the
+ * per-user manager, plain `systemctl` for the system manager.
+ */
+function systemdScope(unitPath: string): "user" | "system" {
+  return /(^|\/)systemd\/user\//.test(unitPath) ? "user" : "system";
+}
+
+class SystemdServiceManager implements NatsServiceManager {
+  readonly kind = "systemd" as const;
+  constructor(
+    private readonly unitPath: string,
+    private readonly mutate: boolean,
+    private readonly exec: ExecRunner,
+  ) {}
+
+  ensureConfigLoaded(configPath: string): void {
+    if (!existsSync(this.unitPath)) return;
+    const text = readFileSync(this.unitPath, "utf-8");
+    if (systemdUnitConfigArgPresent(text, configPath)) return; // idempotent no-op
+    const next = ensureUnitConfigArg(text, configPath);
+    if (!this.mutate) return;
+    if (next === text) return; // byte-stable no-op
+    writeFileSync(this.unitPath, next, "utf-8");
+  }
+
+  dropConfigArg(configPath: string): void {
+    if (!existsSync(this.unitPath)) return;
+    const text = readFileSync(this.unitPath, "utf-8");
+    const lines = text.split("\n");
+    const idx = lines.findIndex((l) => /^\s*ExecStart\s*=/.test(l));
+    if (idx < 0) return;
+    const line = lines[idx] ?? "";
+    const eq = line.indexOf("=");
+    const indent = /^(\s*)/.exec(line)?.[1] ?? "";
+    const value = line.slice(eq + 1).trim();
+    const prefixMatch = /^([@\-+!:]+)/.exec(value);
+    const prefix = prefixMatch?.[1] ?? "";
+    const argv = value.slice(prefix.length).trim().split(/\s+/).filter((t) => t.length > 0);
+    const dropped = argv.filter((a, i) => {
+      if (a === "-c" || a === "--config") return false;
+      if (i > 0 && (argv[i - 1] === "-c" || argv[i - 1] === "--config")) return false;
+      if (a === `--config=${configPath}`) return false;
+      return true;
+    });
+    const nextLine = `${indent}ExecStart=${prefix}${dropped.join(" ")}`;
+    if (nextLine === line) return; // no-op
+    if (!this.mutate) return;
+    lines[idx] = nextLine;
+    writeFileSync(this.unitPath, lines.join("\n"), "utf-8");
+  }
+
+  async restart(): Promise<{ ok: true } | { ok: false; reason: string }> {
+    if (!this.mutate) return { ok: true }; // dry-run: touch nothing.
+    if (!existsSync(this.unitPath)) {
+      return { ok: false, reason: `nats-server systemd unit not found at ${this.unitPath}` };
+    }
+    const unitText = readFileSync(this.unitPath, "utf-8");
+    const serviceId = systemdUnitServiceId(this.unitPath, unitText);
+    const scope = systemdScope(this.unitPath);
+    const argv =
+      scope === "user"
+        ? ["systemctl", "--user", "restart", serviceId]
+        : ["systemctl", "restart", serviceId];
+    const { code, stderr } = await this.exec(argv);
+    if (code !== 0) {
+      return {
+        ok: false,
+        reason: `systemctl ${scope === "user" ? "--user " : ""}restart ${serviceId} exited ${code.toString()}: ${stderr.trim()}`,
+      };
+    }
+    return { ok: true };
+  }
+}
+
+// =============================================================================
+// Selection
+// =============================================================================
+
+/**
+ * Select the {@link NatsServiceManager} for `descriptorPath` on `platform`.
+ *
+ * Detection: extension first (`.plist` / `.service`), content sniff as fallback.
+ * The detected kind is cross-checked against the platform's expected kind; a
+ * mismatch (a launchd plist on Linux, or a systemd unit on macOS) throws a
+ * CLEAR error naming both the descriptor type and the platform — replacing the
+ * old cryptic "ProgramArguments is empty" that a systemd unit fed to the plist
+ * parser produced (#763). An UNDETECTABLE descriptor defaults to the platform's
+ * expected kind (so a hand-authored descriptor with an unusual name on the
+ * right platform still works).
+ */
+export function selectNatsServiceManager(
+  opts: SelectServiceManagerOptions,
+): NatsServiceManager {
+  const expected = expectedKindFor(opts.platform);
+  const detected = detectDescriptorKind(opts.descriptorPath);
+
+  if (detected !== undefined && detected !== expected) {
+    const platformName = opts.platform === "darwin" ? "macOS" : "Linux";
+    const detectedName = detected === "launchd" ? "launchd plist" : "systemd unit";
+    const expectedName = expected === "launchd" ? "launchd plist" : "systemd unit";
+    throw new Error(
+      `nats-server service descriptor ${JSON.stringify(opts.descriptorPath)} looks like a ${detectedName}, ` +
+        `which does not match the ${platformName} platform (expected a ${expectedName}). ` +
+        `On ${platformName}, set stack.nats_infra.${expected === "launchd" ? "plist_path" : "unit_path"} ` +
+        `to the correct descriptor (or pass --${expected === "launchd" ? "plist" : "unit"}).`,
+    );
+  }
+
+  const kind = detected ?? expected;
+  const uid = opts.uid ?? process.getuid?.() ?? 501;
+
+  if (kind === "launchd") {
+    return new LaunchdServiceManager(opts.descriptorPath, opts.mutate, opts.exec, uid);
+  }
+  return new SystemdServiceManager(opts.descriptorPath, opts.mutate, opts.exec);
+}
+
+/** Map `process.platform` onto the supported {@link ServicePlatform} set. */
+export function currentServicePlatform(): ServicePlatform {
+  return process.platform === "darwin" ? "darwin" : "linux";
+}
+
+/** A real `Bun.spawn`-backed {@link ExecRunner} for production wiring. */
+export const bunExecRunner: ExecRunner = async (argv) => {
+  const [cmd, ...rest] = argv;
+  const proc = Bun.spawn([cmd ?? "", ...rest], { stdout: "pipe", stderr: "pipe" });
+  const code = await proc.exited;
+  const stderr = await new Response(proc.stderr).text();
+  return { code, stderr };
+};

--- a/src/common/nats/systemd-unit-loader.ts
+++ b/src/common/nats/systemd-unit-loader.ts
@@ -1,0 +1,189 @@
+/**
+ * #763 (Linux/systemd support for `cortex network join`) — nats-server systemd
+ * unit loader. The Linux sibling of {@link file://./nats-plist-loader.ts}.
+ *
+ * ## What this is
+ *
+ * On macOS the nats-server service is a launchd plist whose `ProgramArguments`
+ * carry the `-c <config>` flag (see `nats-plist-loader.ts`). On Linux (clawbox
+ * and any systemd peer) the same service is a **systemd unit** whose
+ * `[Service] ExecStart=` line carries the flag. The dormant-config trap is
+ * identical: a unit running bare `nats-server -js` never loads the rendered
+ * leaf config, so a leaf can be written to disk and silently ignored.
+ *
+ * This module is the pure half that corrects the unit's `ExecStart=` line to
+ * include `-c <config>`, mirroring the plist loader's `ensureConfigArg`:
+ *
+ *   - {@link ensureUnitConfigArg} — given the full unit text + the config path,
+ *     returns the corrected unit text. Idempotent + BYTE-STABLE: when the
+ *     `ExecStart` already loads `configPath` the input is returned verbatim; a
+ *     `-c`/`--config` pointing elsewhere is repointed (one config flag only);
+ *     every other `ExecStart` argument and every other unit section/directive
+ *     is preserved verbatim. Only the single `ExecStart=` line is rewritten.
+ *   - {@link systemdUnitConfigArgPresent} — predicate for the no-op fast path.
+ *   - {@link systemdUnitServiceId} — read the unit's service id (its `.service`
+ *     file basename, falling back to a `Description`-derived id) — the systemd
+ *     analogue of the launchd plist `<key>Label</key>` used as the
+ *     `systemctl restart` target.
+ *
+ * The actual arg-list transform is delegated to the plist loader's
+ * {@link ensureConfigArg} / {@link plistConfigArgPresent} — the SINGLE source of
+ * truth for "ensure exactly one `-c <config>` in this argv". This module only
+ * parses/serialises the systemd `ExecStart=` line around it (tokenise → ensure
+ * → re-join), so the launchd and systemd paths share one tested arg algorithm.
+ *
+ * Pure + fixture-driven: no live `~/.config/systemd/...` read/write, no
+ * `systemctl`. The S4 adapter (`network-adapters.ts`) does the I/O + restart.
+ */
+
+import { ensureConfigArg, plistConfigArgPresent } from "./nats-plist-loader";
+
+/**
+ * systemd `ExecStart=` may carry one or more special exec prefixes
+ * (`@`, `-`, `+`, `!`, `!!`, `:`) BEFORE the executable path. We preserve any
+ * such prefix verbatim and only ensure the config flag on the argv that
+ * follows. See `man systemd.service` → "Command lines".
+ */
+const EXEC_PREFIX_RE = /^([@\-+!:]+)/;
+
+/** Locate the single `ExecStart=` directive line in a systemd unit. */
+function findExecStartLine(
+  unitText: string,
+): { lines: string[]; index: number } | undefined {
+  const lines = unitText.split("\n");
+  const index = lines.findIndex((l) => /^\s*ExecStart\s*=/.test(l));
+  if (index < 0) return undefined;
+  return { lines, index };
+}
+
+/**
+ * Split an `ExecStart=` value into [exec-prefix, ...argv]. The prefix (if any)
+ * is kept attached to the binary token so re-joining reproduces the line.
+ */
+function splitExecArgv(value: string): { prefix: string; argv: string[] } {
+  const trimmed = value.trim();
+  const m = EXEC_PREFIX_RE.exec(trimmed);
+  const prefix = m?.[1] ?? "";
+  const rest = trimmed.slice(prefix.length).trim();
+  // Whitespace tokenisation matches systemd's default (non-quoted) splitting,
+  // which is all the nats-server invocation needs (no quoted args in play).
+  const argv = rest.length === 0 ? [] : rest.split(/\s+/);
+  return { prefix, argv };
+}
+
+/** The `ExecStart=` value (everything after the first `=`). */
+function execStartValue(line: string): string {
+  const eq = line.indexOf("=");
+  return eq < 0 ? "" : line.slice(eq + 1);
+}
+
+/**
+ * True iff the unit's `ExecStart` already loads exactly `configPath` via
+ * `-c <path>`, `--config <path>`, or `--config=<path>`. Used by callers to
+ * decide whether a unit rewrite is even needed (the no-op fast path). Returns
+ * false when there is no `ExecStart` line at all.
+ */
+export function systemdUnitConfigArgPresent(
+  unitText: string,
+  configPath: string,
+): boolean {
+  const found = findExecStartLine(unitText);
+  if (found === undefined) return false;
+  const { argv } = splitExecArgv(execStartValue(found.lines[found.index] ?? ""));
+  return plistConfigArgPresent(argv, configPath);
+}
+
+/**
+ * Return the unit text with `ExecStart=` corrected to load `configPath`,
+ * idempotently + byte-stably:
+ *
+ *   - already loading `configPath` (any supported flag form) → input returned
+ *     verbatim (byte-stable no-op).
+ *   - a `-c`/`--config` flag present but pointing elsewhere → repointed to
+ *     `configPath` (the stale-config case), keeping exactly one config flag.
+ *   - no config flag → `-c <configPath>` appended to the `ExecStart` argv.
+ *
+ * Only the single `ExecStart=` line is touched; every other line (other unit
+ * sections, other `[Service]` directives, comments, blank lines) is preserved
+ * verbatim, and the line count + ordering are unchanged. Any systemd exec
+ * prefix (`@`, `-`, `+`, …) on `ExecStart=` is preserved.
+ *
+ * Pure: the input string is never mutated. Throws on a missing `ExecStart`
+ * (no nats-server invocation to correct — the systemd analogue of the plist
+ * loader's empty-`ProgramArguments` guard, with an actionable message rather
+ * than the cryptic "ProgramArguments is empty" the plist parser emitted when a
+ * systemd unit was fed to it) or a non-absolute config path.
+ */
+export function ensureUnitConfigArg(
+  unitText: string,
+  configPath: string,
+): string {
+  const found = findExecStartLine(unitText);
+  if (found === undefined) {
+    throw new Error(
+      "systemd-unit-loader: no `[Service] ExecStart=` directive — not a nats-server systemd unit (or no command to invoke)",
+    );
+  }
+  if (!configPath.startsWith("/")) {
+    throw new Error(
+      `systemd-unit-loader: config path must be absolute, got ${JSON.stringify(configPath)}`,
+    );
+  }
+
+  const { lines, index } = found;
+  const line = lines[index] ?? "";
+  const value = execStartValue(line);
+  const { prefix, argv } = splitExecArgv(value);
+
+  if (argv.length === 0) {
+    throw new Error(
+      "systemd-unit-loader: `ExecStart=` has no command — no nats-server binary to invoke",
+    );
+  }
+
+  // Byte-stable fast path: already loading the right config → return verbatim.
+  if (plistConfigArgPresent(argv, configPath)) {
+    return unitText;
+  }
+
+  // Reuse the launchd arg algorithm (single source of truth): ensure exactly
+  // one `-c <configPath>`, dropping any stale config flag.
+  const nextArgv = ensureConfigArg(argv, configPath);
+
+  // Preserve the directive's leading indentation (if any) verbatim.
+  const indentMatch = /^(\s*)ExecStart\s*=/.exec(line);
+  const indent = indentMatch?.[1] ?? "";
+  const nextValue = `${prefix}${nextArgv.join(" ")}`;
+  const nextLines = [...lines];
+  nextLines[index] = `${indent}ExecStart=${nextValue}`;
+  return nextLines.join("\n");
+}
+
+/**
+ * The unit's service id — the `systemctl restart <id>` target, analogous to the
+ * launchd plist `<key>Label</key>`. Prefers the `.service` file basename (the
+ * canonical systemd unit name, e.g. `nats-server.service`); when the path is
+ * not a `.service` file, falls back to a `Description`-derived slug so the
+ * function is total (never returns an empty id). The unit text is read only for
+ * the fallback.
+ */
+export function systemdUnitServiceId(
+  unitPath: string,
+  unitText: string,
+): string {
+  const base = unitPath.split("/").pop() ?? "";
+  if (base.endsWith(".service") && base.length > ".service".length) {
+    return base;
+  }
+  // Fallback: derive from Description=… (slugified) + `.service`.
+  const desc = /^\s*Description\s*=\s*(.+)$/m.exec(unitText)?.[1]?.trim();
+  if (desc !== undefined && desc !== "") {
+    const slug = desc
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "");
+    if (slug !== "") return `${slug}.service`;
+  }
+  // Last resort: the basename as-is (or a stable placeholder).
+  return base !== "" ? base : "nats-server.service";
+}

--- a/src/common/types/__tests__/stack.test.ts
+++ b/src/common/types/__tests__/stack.test.ts
@@ -196,6 +196,72 @@ describe("StackConfigSchema", () => {
 });
 
 // =============================================================================
+// #753/#763 — stack.nats_infra (plist_path on macOS, unit_path on Linux)
+// =============================================================================
+
+const VALID_ACCOUNT = "A" + "B".repeat(55); // A + 55 base32
+
+describe("StackConfigSchema.nats_infra — platform service descriptor", () => {
+  test("accepts a macOS nats_infra with plist_path", () => {
+    const parsed = StackConfigSchema.parse({
+      id: "andreas/meta-factory",
+      nats_infra: {
+        config_path: "~/.config/nats/local.conf",
+        plist_path: "~/Library/LaunchAgents/nats.plist",
+        account: VALID_ACCOUNT,
+      },
+    });
+    expect(parsed.nats_infra?.plist_path).toBe("~/Library/LaunchAgents/nats.plist");
+    expect(parsed.nats_infra?.unit_path).toBeUndefined();
+  });
+
+  test("#763 — accepts a Linux nats_infra with unit_path (systemd unit)", () => {
+    const parsed = StackConfigSchema.parse({
+      id: "jc/clawbox",
+      nats_infra: {
+        config_path: "~/.config/nats/local.conf",
+        unit_path: "~/.config/systemd/user/nats-server.service",
+        account: VALID_ACCOUNT,
+      },
+    });
+    expect(parsed.nats_infra?.unit_path).toBe("~/.config/systemd/user/nats-server.service");
+    expect(parsed.nats_infra?.plist_path).toBeUndefined();
+  });
+
+  test("#763 — a stack may carry BOTH descriptors (the join picks per platform)", () => {
+    const parsed = StackConfigSchema.parse({
+      id: "andreas/meta-factory",
+      nats_infra: {
+        config_path: "~/c",
+        plist_path: "~/nats.plist",
+        unit_path: "~/nats-server.service",
+        account: VALID_ACCOUNT,
+      },
+    });
+    expect(parsed.nats_infra?.plist_path).toBe("~/nats.plist");
+    expect(parsed.nats_infra?.unit_path).toBe("~/nats-server.service");
+  });
+
+  test("rejects an empty unit_path (min(1))", () => {
+    expect(() =>
+      StackConfigSchema.parse({
+        id: "jc/clawbox",
+        nats_infra: { unit_path: "" },
+      }),
+    ).toThrow();
+  });
+
+  test("rejects an unknown nats_infra key (strict schema)", () => {
+    expect(() =>
+      StackConfigSchema.parse({
+        id: "jc/clawbox",
+        nats_infra: { unit_path: "~/x.service", bogus: "no" },
+      }),
+    ).toThrow();
+  });
+});
+
+// =============================================================================
 // CortexConfigSchema — stack block is optional at the top level
 // =============================================================================
 

--- a/src/common/types/stack.ts
+++ b/src/common/types/stack.ts
@@ -75,10 +75,22 @@ export const StackNatsInfraSchema = z.object({
    */
   config_path: z.string().min(1).optional(),
   /**
-   * Path to the nats-server launchd plist `cortex network join` ensures loads
-   * the config (and reloads on join/leave). Maps to the `--plist` flag.
+   * macOS only — path to the nats-server **launchd plist** `cortex network
+   * join` ensures loads the config (and `launchctl kickstart` reloads on
+   * join/leave). Maps to the `--plist` flag. On a Linux/systemd stack use
+   * {@link StackNatsInfraSchema.shape.unit_path} instead (#763).
    */
   plist_path: z.string().min(1).optional(),
+  /**
+   * #763 — Linux only — path to the nats-server **systemd unit** `cortex
+   * network join` ensures loads the config (the unit's `[Service] ExecStart=`
+   * carries `-c <config>`; `systemctl [--user] restart` reloads on
+   * join/leave). The systemd analogue of {@link StackNatsInfraSchema.shape.plist_path};
+   * a stack declares the one that matches its platform. Maps to the `--unit`
+   * flag. `--user` vs system scope is inferred from the unit's on-disk location
+   * (`~/.config/systemd/user/…` → user scope, otherwise system).
+   */
+  unit_path: z.string().min(1).optional(),
   /**
    * The local NATS account (`A…` nkey-U) the network's leaf binds to. Maps to
    * the `--account` flag. Same 56-char U-prefixed base32 NKey grammar as every


### PR DESCRIPTION
Closes #763
Refs #738 #757 #733

## Problem

`cortex network join` was macOS-launchd-only. On clawbox (Linux, systemd) it failed: passing the systemd unit to `--plist` errored `ProgramArguments is empty` (the launchd plist parser was fed a systemd unit), and the plist-ensure + `launchctl kickstart` restart were launchd-specific.

## Fix — `NatsServiceManager` abstraction

Platform-abstract the join's nats-server service management behind a small `NatsServiceManager` seam (`ensureConfigLoaded` / `dropConfigArg` / `restart`) with two implementations selected by platform/descriptor:

- **launchd (macOS):** ensure plist `ProgramArguments` carry `-c <config>` (S3's `ensureConfigArg`/`renderProgramArguments`), restart via `launchctl kickstart -k gui/<uid>/<label>` reading the plist `<key>Label</key>`. **Lifted verbatim — macOS behavior is unchanged.**
- **systemd (Linux):** ensure the unit `[Service] ExecStart=` carries `-c <config>` (new `systemd-unit-loader.ts`, mirroring the plist loader and reusing its arg algorithm), restart via `systemctl [--user] restart <unit>` (scope inferred from the unit's on-disk location), unit id read from the `.service` file name.

`selectNatsServiceManager()` detects the descriptor type (extension first, content sniff fallback), cross-checks it against the platform, and throws a **clear, actionable error** on a plist-on-Linux / unit-on-macOS mismatch — replacing the cryptic `ProgramArguments is empty`.

## How systemd ExecStart ensure works

`ensureUnitConfigArg(unitText, configPath)` locates the single `[Service] ExecStart=` line, tokenises its argv (preserving any `@`/`-`/`+` exec prefix), runs the **same** `ensureConfigArg` arg transform the launchd path uses (one source of truth: add `-c` when absent, repoint a stale `-c`, no-op when present), and rewrites only that one line. Idempotent + byte-stable; every other ExecStart arg, unit section, and line is preserved verbatim.

## Config / schema

`StackNatsInfraSchema` gains `unit_path` (Linux systemd unit) beside `plist_path` (macOS launchd plist). `network-derive.ts` derives the descriptor per platform; a new `--unit` CLI flag mirrors `--plist`. An explicit `--plist`/`--unit` flag is self-describing (platform-independent); config derivation picks by host platform; passing both is a usage error.

The orchestrator (`network-lib.ts`) is untouched — it already abstracts over the `PlistPort` + `NatsServerPort` seam.

## Safety

- Dry-run (default) execs nothing and writes nothing (S4 SAFETY preserved).
- The never-throws join contract is honored — the restart port catches the selection-mismatch error and surfaces it as `{ ok: false }`.

## Verification

- `bunx tsc --noEmit` → 0
- `bun test` → 4690 pass / 0 fail (full suite)
- `eslint --quiet .` → clean
- `scripts/check-carveouts.sh` (vocab gate) → PASS

## Tests added

- systemd ExecStart ensure: add-when-absent, byte-stable no-op when present, repoint stale, preserve other args + unit sections, exec-prefix, throws on missing ExecStart / non-absolute path.
- launchd regression (plist path + `launchctl` restart unchanged).
- platform/descriptor selection picks the right manager; mismatch → clear error; content-sniff fallback.
- dry-run execs nothing / writes nothing (both platforms).
- `StackNatsInfra` schema `unit_path` parse + strict-key rejection.
- CLI `--unit` dry-run join (routes to systemd, writes nothing) + both-flags usage error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)