### PR TITLE
Fix #760: make network join service management platform-aware

### DIFF
--- a/src/cli/cortex/commands/__tests__/network-adapters.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-adapters.test.ts
@@ -71,6 +71,21 @@ function barePlist(): string {
   ].join("\n");
 }
 
+function bareSystemdUnit(): string {
+  return [
+    "[Unit]",
+    "Description=NATS Server",
+    "",
+    "[Service]",
+    "ExecStart=/home/clawbox/bin/nats-server -js",
+    "Restart=always",
+    "",
+    "[Install]",
+    "WantedBy=default.target",
+    "",
+  ].join("\n");
+}
+
 function cfgFor(plistPath: string): LivePortsConfig {
   return {
     networkId: "metafactory",
@@ -537,6 +552,62 @@ describe("#757 nats-server restart port", () => {
     const res = await ports.natsServer!.restart();
     expect(res.ok).toBe(false);
     if (!res.ok) expect(res.reason).toContain("Label");
+  });
+
+  test("#760 systemd service-file gets the nats config arg idempotently", () => {
+    const dir = freshDir();
+    const unitPath = join(dir, "nats-server.service");
+    const natsConfig = "/home/clawbox/.config/nats/local.conf";
+    writeFileSync(unitPath, bareSystemdUnit(), "utf-8");
+
+    const ports = buildLivePorts({
+      networkId: "metafactory",
+      principalId: "jc",
+      stackId: "jc/default",
+      natsConfigPath: natsConfig,
+      serviceManager: "systemd",
+      serviceFile: unitPath,
+      daemonService: "cortex-bot.service",
+    });
+
+    ports.plist.ensureConfigLoaded(natsConfig);
+    const first = readFileSync(unitPath, "utf-8");
+    expect(first).toContain(`ExecStart=/home/clawbox/bin/nats-server -js -c ${natsConfig}`);
+
+    ports.plist.ensureConfigLoaded(natsConfig);
+    expect(readFileSync(unitPath, "utf-8")).toBe(first);
+
+    ports.plist.dropConfigArg(natsConfig);
+    expect(readFileSync(unitPath, "utf-8")).toContain("ExecStart=/home/clawbox/bin/nats-server -js");
+    expect(readFileSync(unitPath, "utf-8")).not.toContain(` -c ${natsConfig}`);
+  });
+
+  test("#760 systemd dry-run needs no plist or service file", async () => {
+    const ports = buildDryRunPorts({
+      networkId: "metafactory",
+      principalId: "jc",
+      stackId: "jc/default",
+      natsConfigPath: "/home/clawbox/.config/nats/local.conf",
+      serviceManager: "systemd",
+    });
+
+    ports.plist.ensureConfigLoaded("/home/clawbox/.config/nats/local.conf");
+    const res = await ports.natsServer!.restart();
+    expect(res.ok).toBe(true);
+  });
+
+  test("#760 systemd live restart fails clearly when service_file is missing", async () => {
+    const ports = buildLivePorts({
+      networkId: "metafactory",
+      principalId: "jc",
+      stackId: "jc/default",
+      natsConfigPath: "/home/clawbox/.config/nats/local.conf",
+      serviceManager: "systemd",
+    });
+
+    const res = await ports.natsServer!.restart();
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.reason).toContain("service file");
   });
 });
 

--- a/src/cli/cortex/commands/__tests__/network-cli.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-cli.test.ts
@@ -114,6 +114,16 @@ describe("join usage", () => {
     expect(res.stderr).toContain("mutually exclusive");
   });
 
+  test("#760 rejects malformed --service-manager (exit 2)", async () => {
+    const res = await dispatchNetwork([
+      "join", "metafactory",
+      "--principal", "andreas",
+      "--service-manager", "systmd",
+    ], EMPTY_READER);
+    expect(res.exitCode).toBe(2);
+    expect(res.stderr).toContain("--service-manager");
+  });
+
   test("rejects --stack whose prefix mismatches --principal (exit 2)", async () => {
     const res = await dispatchNetwork([
       "join", "metafactory",
@@ -136,6 +146,27 @@ describe("join usage", () => {
 // =============================================================================
 
 describe("join dry-run safety", () => {
+  test("#760 systemd dry-run does not require --plist", async () => {
+    const dir = freshDir();
+    const res = await dispatchNetwork([
+      "join", "metafactory",
+      "--principal", "jc",
+      "--registry-url", "http://127.0.0.1:0",
+      "--seed-path", join(dir, "seed.nk"),
+      "--creds", join(dir, "jc.creds"),
+      "--account", "A" + "B".repeat(55),
+      "--nats-config", join(dir, "local.conf"),
+      "--service-manager", "systemd",
+      "--dry-run",
+    ], EMPTY_READER);
+
+    // It fails operationally because the seed/registry are fake, but the old
+    // launchd-only "--plist is required" usage gate is gone.
+    expect(res.exitCode).toBe(1);
+    expect(res.stderr).not.toContain("--plist");
+    expect(res.stderr).toContain("dry-run");
+  });
+
   test("dry-run join does NOT write the leaf file, plist, or config (no --apply)", async () => {
     const dir = freshDir();
     const seedPath = join(dir, "seed.nk");
@@ -293,7 +324,6 @@ describe("join public usage", () => {
       "--registry-url", "http://127.0.0.1:0", // unreachable by construction
       "--seed-path", join(dir, "seed.nk"),
       "--nats-config", join(dir, "local.conf"),
-      "--plist", join(dir, "nats.plist"),
       "--capabilities", "code-review.typescript",
     ]);
     // It will FAIL at announce (no seed / unreachable registry) — exit 1 — but
@@ -301,6 +331,7 @@ describe("join public usage", () => {
     expect(res.exitCode).not.toBe(2);
     expect(res.stderr).not.toContain("--creds");
     expect(res.stderr).not.toContain("--account");
+    expect(res.stderr).not.toContain("--plist");
   });
 });
 
@@ -318,7 +349,6 @@ describe("join public dry-run safety (OQ1 + no live mutation)", () => {
       "--registry-url", "http://127.0.0.1:0",
       "--seed-path", join(dir, "seed.nk"),
       "--nats-config", natsConfig,
-      "--plist", plist,
       "--capabilities", "code-review.typescript",
     ]);
 
@@ -342,7 +372,6 @@ describe("leave public", () => {
       "--registry-url", "http://127.0.0.1:0",
       "--seed-path", join(dir, "seed.nk"),
       "--nats-config", join(dir, "local.conf"),
-      "--plist", join(dir, "nats.plist"),
     ], EMPTY_READER);
     expect(res.exitCode).toBe(0);
     expect(res.stdout).toContain("nothing to do");

--- a/src/cli/cortex/commands/__tests__/network-derive.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-derive.test.ts
@@ -80,6 +80,8 @@ describe("deriveJoinInputs — config-only (the one-liner)", () => {
       registryUrl: "https://registry.meta-factory.ai",
       registryPubkey: "A".repeat(43) + "=",
       natsConfigPath: "~/.config/nats/local.conf",
+      serviceManager: "auto",
+      serviceFile: "~/Library/LaunchAgents/nats.plist",
       plistPath: "~/Library/LaunchAgents/nats.plist",
       account: "A" + "B".repeat(55),
       credsPath: "~/.config/nats/mf.creds",
@@ -232,6 +234,8 @@ describe("deriveJoinInputs — flag overrides win", () => {
       registryUrl: "https://flag.registry",
       registryPubkey: "Z".repeat(43) + "=",
       natsConfigPath: "/flag/local.conf",
+      serviceManager: "auto",
+      serviceFile: "/flag/nats.plist",
       plistPath: "/flag/nats.plist",
       account: "A" + "F".repeat(55),
       credsPath: "/flag/x.creds",
@@ -261,6 +265,31 @@ describe("deriveJoinInputs — flag overrides win", () => {
     expect(res.ok).toBe(true);
     expect(res.inputs?.principal).toBe("andreas");
     expect(res.inputs?.stack).toBe("andreas/default");
+  });
+
+  test("#760 — systemd service metadata works without a plist", () => {
+    const res = deriveJoinInputs(
+      "metafactory",
+      {
+        principal: "jc",
+        stack: "jc/default",
+        seedPath: "/home/clawbox/.config/nats/cortex.nk",
+        registryUrl: "https://network.meta-factory.ai",
+        natsConfigPath: "/home/clawbox/.config/nats/local.conf",
+        serviceManager: "systemd",
+        serviceFile: "/home/clawbox/.config/systemd/user/nats-server.service",
+        daemonService: "cortex-bot.service",
+        account: "A" + "H".repeat(55),
+        credsPath: "/home/clawbox/.config/nats/jc.creds",
+      },
+      "/cfg",
+      reader(loaded({})),
+    );
+    expect(res.ok).toBe(true);
+    expect(res.inputs?.serviceManager).toBe("systemd");
+    expect(res.inputs?.serviceFile).toBe("/home/clawbox/.config/systemd/user/nats-server.service");
+    expect(res.inputs?.plistPath).toBeUndefined();
+    expect(res.inputs?.daemonService).toBe("cortex-bot.service");
   });
 });
 
@@ -338,6 +367,8 @@ describe("deriveLeaveInputs", () => {
       principal: "andreas",
       stack: "andreas/meta-factory",
       natsConfigPath: "~/.config/nats/local.conf",
+      serviceManager: "auto",
+      serviceFile: "~/Library/LaunchAgents/nats.plist",
       plistPath: "~/Library/LaunchAgents/nats.plist",
     });
   });

--- a/src/cli/cortex/commands/network-adapters.ts
+++ b/src/cli/cortex/commands/network-adapters.ts
@@ -28,7 +28,7 @@ import {
   rmSync,
   writeFileSync,
 } from "fs";
-import { dirname, join } from "path";
+import { basename, dirname, join } from "path";
 
 import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
 
@@ -82,7 +82,10 @@ export interface LivePortsConfig {
   registryPubkey?: string;
   seedPath?: string;
   natsConfigPath?: string;
+  serviceManager?: "auto" | "launchd" | "systemd" | "none";
+  serviceFile?: string;
   plistPath?: string;
+  daemonService?: string;
   monitorUrl?: string;
   /**
    * #762 — the capability ids this stack announces INTO `networkId`, sourced
@@ -95,6 +98,30 @@ export interface LivePortsConfig {
    * preserves any existing hand-pins rather than wiping them.
    */
   announceCapabilities?: string[];
+}
+
+type ResolvedServiceManager = "launchd" | "systemd" | "none" | "unsupported";
+
+function serviceFilePath(cfg: LivePortsConfig): string | undefined {
+  return cfg.serviceFile ?? cfg.plistPath;
+}
+
+function resolveServiceManager(cfg: LivePortsConfig): ResolvedServiceManager {
+  const configured = cfg.serviceManager ?? "auto";
+  if (configured !== "auto") return configured;
+  const file = serviceFilePath(cfg);
+  if (file !== undefined) {
+    if (file.endsWith(".service")) return "systemd";
+    if (file.endsWith(".plist")) return "launchd";
+  }
+  if (process.platform === "darwin") return "launchd";
+  if (process.platform === "linux") return "systemd";
+  return "unsupported";
+}
+
+function missingServiceFileReason(cfg: LivePortsConfig): string {
+  const manager = resolveServiceManager(cfg);
+  return `no nats-server service file configured for ${manager}; pass --service-file or set stack.nats_infra.service_file`;
 }
 
 // =============================================================================
@@ -292,8 +319,8 @@ function writeProgramArguments(plistPath: string, nextArgs: string[]): void {
   writeFileSync(plistPath, next, "utf-8");
 }
 
-function buildPlistPort(cfg: LivePortsConfig, mutate: boolean): PlistPort {
-  const plistPath = expandTilde(cfg.plistPath ?? "");
+function buildLaunchdConfigPort(cfg: LivePortsConfig, mutate: boolean): PlistPort {
+  const plistPath = expandTilde(serviceFilePath(cfg) ?? "");
   return {
     ensureConfigLoaded(configPath) {
       if (!existsSync(plistPath)) return;
@@ -316,6 +343,95 @@ function buildPlistPort(cfg: LivePortsConfig, mutate: boolean): PlistPort {
       writeProgramArguments(plistPath, next);
     },
   };
+}
+
+function escapeRegExp(v: string): string {
+  return v.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function systemdArg(configPath: string): string {
+  return /[\s"'\\]/.test(configPath)
+    ? `"${configPath.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`
+    : configPath;
+}
+
+function systemdConfigArgPresent(execStart: string, configPath: string): boolean {
+  const p = escapeRegExp(configPath);
+  return new RegExp(`(?:^|\\s)(?:-c|--config)(?:\\s+${p}|=${p})(?:\\s|$)`).test(execStart);
+}
+
+function ensureSystemdExecStartConfig(execStart: string, configPath: string): string {
+  if (systemdConfigArgPresent(execStart, configPath)) return execStart;
+  // If the unit already points at a different config, keep the operator's
+  // choice intact rather than guessing how to rewrite an arbitrary shell line.
+  if (/(?:^|\s)(?:-c|--config)(?:\s+|=)/.test(execStart)) return execStart;
+  return `${execStart} -c ${systemdArg(configPath)}`;
+}
+
+function dropSystemdExecStartConfig(execStart: string, configPath: string): string {
+  const p = escapeRegExp(configPath);
+  return execStart
+    .replace(new RegExp(`\\s+(?:-c|--config)\\s+${p}(?=\\s|$)`), "")
+    .replace(new RegExp(`\\s+--config=${p}(?=\\s|$)`), "");
+}
+
+function rewriteSystemdExecStart(
+  unitPath: string,
+  transform: (execStart: string) => string,
+): void {
+  const unit = readFileSync(unitPath, "utf-8");
+  let found = false;
+  const next = unit.replace(/^([ \t]*ExecStart=)(.*)$/m, (_line, prefix: string, value: string) => {
+    found = true;
+    return `${prefix}${transform(value.trim())}`;
+  });
+  if (!found) {
+    throw new Error(`systemd unit ${unitPath} has no ExecStart= line`);
+  }
+  if (next !== unit) writeFileSync(unitPath, next, "utf-8");
+}
+
+function buildSystemdConfigPort(cfg: LivePortsConfig, mutate: boolean): PlistPort {
+  const unitPath = serviceFilePath(cfg) === undefined
+    ? undefined
+    : expandTilde(serviceFilePath(cfg)!);
+  return {
+    ensureConfigLoaded(configPath) {
+      if (!mutate) return;
+      if (unitPath === undefined || !existsSync(unitPath)) {
+        throw new Error(missingServiceFileReason(cfg));
+      }
+      rewriteSystemdExecStart(unitPath, (execStart) =>
+        ensureSystemdExecStartConfig(execStart, configPath),
+      );
+    },
+    dropConfigArg(configPath) {
+      if (!mutate) return;
+      if (unitPath === undefined || !existsSync(unitPath)) return;
+      rewriteSystemdExecStart(unitPath, (execStart) =>
+        dropSystemdExecStartConfig(execStart, configPath),
+      );
+    },
+  };
+}
+
+function buildNoopServiceConfigPort(): PlistPort {
+  return {
+    ensureConfigLoaded() {},
+    dropConfigArg() {},
+  };
+}
+
+function buildServiceConfigPort(cfg: LivePortsConfig, mutate: boolean): PlistPort {
+  switch (resolveServiceManager(cfg)) {
+    case "launchd":
+      return buildLaunchdConfigPort(cfg, mutate);
+    case "systemd":
+      return buildSystemdConfigPort(cfg, mutate);
+    case "none":
+    case "unsupported":
+      return buildNoopServiceConfigPort();
+  }
 }
 
 // =============================================================================
@@ -384,21 +500,59 @@ function buildConfigStorePort(cfg: LivePortsConfig, mutate: boolean): ConfigStor
 // Daemon port — launchctl kickstart of the stack daemon.
 // =============================================================================
 
+async function spawnChecked(
+  args: string[],
+  failurePrefix: string,
+): Promise<{ ok: true } | { ok: false; reason: string }> {
+  const proc = Bun.spawn(args, { stdout: "pipe", stderr: "pipe" });
+  const code = await proc.exited;
+  if (code !== 0) {
+    const err = await new Response(proc.stderr).text();
+    return { ok: false, reason: `${failurePrefix} exited ${code.toString()}: ${err.trim()}` };
+  }
+  return { ok: true };
+}
+
+function launchdTarget(label: string): string {
+  return `gui/${process.getuid?.() ?? 501}/${label}`;
+}
+
+async function restartSystemdUserService(serviceName: string): Promise<{ ok: true } | { ok: false; reason: string }> {
+  const reload = await spawnChecked(
+    ["systemctl", "--user", "daemon-reload"],
+    "systemctl --user daemon-reload",
+  );
+  if (!reload.ok) return reload;
+  return spawnChecked(
+    ["systemctl", "--user", "restart", serviceName],
+    `systemctl --user restart ${serviceName}`,
+  );
+}
+
 function buildDaemonPort(cfg: LivePortsConfig, mutate: boolean): DaemonPort {
   return {
     async restart() {
       if (!mutate) return { ok: true }; // dry-run: pretend success.
-      const label = `ai.meta-factory.cortex.${cfg.stackId.split("/")[1] ?? "default"}`;
-      const proc = Bun.spawn(["launchctl", "kickstart", "-k", `gui/${process.getuid?.() ?? 501}/${label}`], {
-        stdout: "pipe",
-        stderr: "pipe",
-      });
-      const code = await proc.exited;
-      if (code !== 0) {
-        const err = await new Response(proc.stderr).text();
-        return { ok: false, reason: `launchctl kickstart exited ${code.toString()}: ${err.trim()}` };
+      switch (resolveServiceManager(cfg)) {
+        case "launchd": {
+          const label = cfg.daemonService ?? `ai.meta-factory.cortex.${cfg.stackId.split("/")[1] ?? "default"}`;
+          return spawnChecked(
+            ["launchctl", "kickstart", "-k", launchdTarget(label)],
+            `launchctl kickstart ${label}`,
+          );
+        }
+        case "systemd": {
+          const service = cfg.daemonService ?? "cortex-bot.service";
+          return restartSystemdUserService(service);
+        }
+        case "none":
+          return { ok: true };
+        case "unsupported":
+          return {
+            ok: false,
+            reason: `service manager auto cannot manage platform ${process.platform}; pass --service-manager launchd|systemd|none`,
+          };
       }
-      return { ok: true };
     },
   };
 }
@@ -423,30 +577,39 @@ function readPlistLabel(plistPath: string): string | undefined {
 }
 
 function buildNatsServerPort(cfg: LivePortsConfig, mutate: boolean): NatsServerPort {
-  const plistPath = expandTilde(cfg.plistPath ?? "");
+  const file = serviceFilePath(cfg);
+  const servicePath = file === undefined ? undefined : expandTilde(file);
   return {
     async restart() {
       if (!mutate) return { ok: true }; // dry-run: pretend success, touch nothing.
-      if (cfg.plistPath === undefined || !existsSync(plistPath)) {
-        return { ok: false, reason: `nats-server plist not found at ${plistPath}` };
+      switch (resolveServiceManager(cfg)) {
+        case "launchd": {
+          if (servicePath === undefined || !existsSync(servicePath)) {
+            return { ok: false, reason: `nats-server plist not found at ${servicePath ?? ""}` };
+          }
+          const label = readPlistLabel(servicePath);
+          if (label === undefined) {
+            return { ok: false, reason: `no <key>Label</key> in nats-server plist ${servicePath}` };
+          }
+          return spawnChecked(
+            ["launchctl", "kickstart", "-k", launchdTarget(label)],
+            `launchctl kickstart ${label}`,
+          );
+        }
+        case "systemd": {
+          if (servicePath === undefined || !existsSync(servicePath)) {
+            return { ok: false, reason: missingServiceFileReason(cfg) };
+          }
+          return restartSystemdUserService(basename(servicePath));
+        }
+        case "none":
+          return { ok: true };
+        case "unsupported":
+          return {
+            ok: false,
+            reason: `service manager auto cannot manage platform ${process.platform}; pass --service-manager launchd|systemd|none`,
+          };
       }
-      const label = readPlistLabel(plistPath);
-      if (label === undefined) {
-        return { ok: false, reason: `no <key>Label</key> in nats-server plist ${plistPath}` };
-      }
-      const proc = Bun.spawn(
-        ["launchctl", "kickstart", "-k", `gui/${process.getuid?.() ?? 501}/${label}`],
-        { stdout: "pipe", stderr: "pipe" },
-      );
-      const code = await proc.exited;
-      if (code !== 0) {
-        const err = await new Response(proc.stderr).text();
-        return {
-          ok: false,
-          reason: `launchctl kickstart ${label} exited ${code.toString()}: ${err.trim()}`,
-        };
-      }
-      return { ok: true };
     },
   };
 }
@@ -493,7 +656,7 @@ function buildPorts(cfg: LivePortsConfig, mutate: boolean): NetworkPorts {
   return {
     registry: buildRegistryPort(cfg),
     leafFile: buildLeafFilePort(cfg, mutate),
-    plist: buildPlistPort(cfg, mutate),
+    plist: buildServiceConfigPort(cfg, mutate),
     configStore: buildConfigStorePort(cfg, mutate),
     daemon: buildDaemonPort(cfg, mutate),
     natsServer: buildNatsServerPort(cfg, mutate),

--- a/src/cli/cortex/commands/network-derive.ts
+++ b/src/cli/cortex/commands/network-derive.ts
@@ -5,7 +5,7 @@
  *     cortex network join <network> [--apply]
  *
  * Everything the join needs — principal, stack, signing seed, registry pin +
- * endpoint, and the per-stack nats-server infra paths (config / plist /
+ * endpoint, and the per-stack nats-server infra paths (config / service /
  * account / creds) — derives from the stack's loaded config + conventions.
  * Flags survive ONLY as optional per-invocation overrides: a flag, when
  * present, always wins; otherwise the value derives from config; a value that
@@ -22,7 +22,9 @@
  *   | registry-url      | --registry-url    | policy.federated.registry.url                  | —                                  |
  *   | registry-pubkey   | --registry-pubkey | policy.federated.registry.pubkey               | — (TOFU when absent)               |
  *   | nats-config       | --nats-config     | stack.nats_infra.config_path                   | —                                  |
- *   | plist             | --plist           | stack.nats_infra.plist_path                     | —                                  |
+ *   | service-manager   | --service-manager | stack.nats_infra.service_manager                | auto                               |
+ *   | service-file      | --service-file    | stack.nats_infra.service_file / plist_path      | —                                  |
+ *   | plist             | --plist           | stack.nats_infra.plist_path                     | — (legacy launchd alias)           |
  *   | account           | --account         | stack.nats_infra.account                       | —                                  |
  *   | creds             | --creds           | stack.nats_infra.creds_path                     | ~/.config/nats/<network>.creds     |
  *
@@ -42,6 +44,8 @@ import type { LoadedConfig } from "../../../common/config/loader";
 // Types
 // =============================================================================
 
+export type ServiceManager = "auto" | "launchd" | "systemd" | "none";
+
 /** The five join inputs `cortex network join` previously demanded as flags. */
 export interface DerivedJoinInputs {
   principal: string;
@@ -51,7 +55,11 @@ export interface DerivedJoinInputs {
   registryUrl: string;
   registryPubkey?: string;
   natsConfigPath: string;
-  plistPath: string;
+  serviceManager: ServiceManager;
+  serviceFile?: string;
+  /** Back-compat launchd plist alias. Present when configured or flagged. */
+  plistPath?: string;
+  daemonService?: string;
   account: string;
   credsPath: string;
   /**
@@ -69,7 +77,10 @@ export interface DerivedLeaveInputs {
   principal: string;
   stack: string;
   natsConfigPath: string;
-  plistPath: string;
+  serviceManager: ServiceManager;
+  serviceFile?: string;
+  plistPath?: string;
+  daemonService?: string;
 }
 
 /** Flag overrides — any field present on the CLI wins over config/convention. */
@@ -80,7 +91,10 @@ export interface JoinOverrides {
   registryUrl?: string;
   registryPubkey?: string;
   natsConfigPath?: string;
+  serviceManager?: ServiceManager;
+  serviceFile?: string;
   plistPath?: string;
+  daemonService?: string;
   account?: string;
   credsPath?: string;
 }
@@ -221,12 +235,10 @@ export function deriveJoinInputs(
     );
   }
 
+  const serviceManager = overrides.serviceManager ?? natsInfra?.service_manager ?? "auto";
   const plistPath = overrides.plistPath ?? natsInfra?.plist_path;
-  if (plistPath === undefined || plistPath === "") {
-    return fail(
-      "cannot resolve plist path — pass --plist or set `stack.nats_infra.plist_path` in cortex.yaml",
-    );
-  }
+  const serviceFile = overrides.serviceFile ?? natsInfra?.service_file ?? plistPath;
+  const daemonService = overrides.daemonService ?? natsInfra?.daemon_service;
 
   const account = overrides.account ?? natsInfra?.account;
   if (account === undefined || account === "") {
@@ -257,7 +269,10 @@ export function deriveJoinInputs(
       registryUrl,
       ...(registryPubkey !== undefined && { registryPubkey }),
       natsConfigPath,
-      plistPath,
+      serviceManager,
+      ...(serviceFile !== undefined && serviceFile !== "" && { serviceFile }),
+      ...(plistPath !== undefined && plistPath !== "" && { plistPath }),
+      ...(daemonService !== undefined && daemonService !== "" && { daemonService }),
       account,
       credsPath,
       announceCapabilities,
@@ -275,7 +290,7 @@ export function deriveJoinInputs(
  * include + plist). Same override-then-config-then-convention precedence.
  */
 export function deriveLeaveInputs(
-  overrides: Pick<JoinOverrides, "principal" | "stack" | "natsConfigPath" | "plistPath">,
+  overrides: Pick<JoinOverrides, "principal" | "stack" | "natsConfigPath" | "serviceManager" | "serviceFile" | "plistPath" | "daemonService">,
   configPath: string,
   load: ConfigReader,
 ): DeriveResult<DerivedLeaveInputs> {
@@ -298,12 +313,21 @@ export function deriveLeaveInputs(
     );
   }
 
+  const serviceManager = overrides.serviceManager ?? natsInfra?.service_manager ?? "auto";
   const plistPath = overrides.plistPath ?? natsInfra?.plist_path;
-  if (plistPath === undefined || plistPath === "") {
-    return fail(
-      "cannot resolve plist path — pass --plist or set `stack.nats_infra.plist_path` in cortex.yaml",
-    );
-  }
+  const serviceFile = overrides.serviceFile ?? natsInfra?.service_file ?? plistPath;
+  const daemonService = overrides.daemonService ?? natsInfra?.daemon_service;
 
-  return { ok: true, inputs: { principal, stack, natsConfigPath, plistPath } };
+  return {
+    ok: true,
+    inputs: {
+      principal,
+      stack,
+      natsConfigPath,
+      serviceManager,
+      ...(serviceFile !== undefined && serviceFile !== "" && { serviceFile }),
+      ...(plistPath !== undefined && plistPath !== "" && { plistPath }),
+      ...(daemonService !== undefined && daemonService !== "" && { daemonService }),
+    },
+  };
 }

--- a/src/cli/cortex/commands/network.ts
+++ b/src/cli/cortex/commands/network.ts
@@ -49,6 +49,7 @@ import {
   deriveLeaveInputs,
   tolerantReader,
   type ConfigReader,
+  type ServiceManager,
 } from "./network-derive";
 
 /**
@@ -127,7 +128,10 @@ const SPEC: SubcommandSpec<NetworkSubcommand> = {
         "--creds": "value",
         "--account": "value",
         "--nats-config": "value",
+        "--service-manager": "value",
+        "--service-file": "value",
         "--plist": "value",
+        "--daemon-service": "value",
         "--max-hop": "value",
         "--leaf-node": "value",
         // S5 (#739) — public-scope flags. `--capabilities` (comma-separated)
@@ -150,7 +154,10 @@ const SPEC: SubcommandSpec<NetworkSubcommand> = {
         "--registry-url": "value",
         "--seed-path": "value",
         "--nats-config": "value",
+        "--service-manager": "value",
+        "--service-file": "value",
         "--plist": "value",
+        "--daemon-service": "value",
         "--apply": "bool",
         "--dry-run": "bool",
       },
@@ -187,6 +194,20 @@ function optionalValueFlag(
 ): string | undefined {
   const v = flags[name];
   return typeof v === "string" ? v : undefined;
+}
+
+function optionalServiceManagerFlag(
+  flags: Record<string, string | true>,
+): { ok: true; value?: ServiceManager } | { ok: false; reason: string } {
+  const value = optionalValueFlag(flags, "--service-manager");
+  if (value === undefined) return { ok: true };
+  if (value === "auto" || value === "launchd" || value === "systemd" || value === "none") {
+    return { ok: true, value };
+  }
+  return {
+    ok: false,
+    reason: `--service-manager "${value}" must be auto, launchd, systemd, or none`,
+  };
 }
 
 /**
@@ -272,6 +293,8 @@ async function runJoin(
   // errors (bad YAML, schema violations) surface as an op-error with the
   // loader's message; a derivable-but-missing required value surfaces as a
   // usage error naming the config field.
+  const serviceManager = optionalServiceManagerFlag(flags);
+  if (!serviceManager.ok) return usageError("join", serviceManager.reason, json);
   let derived;
   try {
     derived = deriveJoinInputs(
@@ -283,7 +306,10 @@ async function runJoin(
         ...readOverride(flags, "--registry-url", "registryUrl"),
         ...readOverride(flags, "--registry-pubkey", "registryPubkey"),
         ...readOverride(flags, "--nats-config", "natsConfigPath"),
+        ...(serviceManager.value !== undefined && { serviceManager: serviceManager.value }),
+        ...readOverride(flags, "--service-file", "serviceFile"),
         ...readOverride(flags, "--plist", "plistPath"),
+        ...readOverride(flags, "--daemon-service", "daemonService"),
         ...readOverride(flags, "--account", "account"),
         ...readOverride(flags, "--creds", "credsPath"),
       },
@@ -351,6 +377,8 @@ async function runLeave(
   }
 
   // #753 — derive principal / stack / nats-config / plist (the leave subset).
+  const serviceManager = optionalServiceManagerFlag(flags);
+  if (!serviceManager.ok) return usageError("leave", serviceManager.reason, json);
   let derived;
   try {
     derived = deriveLeaveInputs(
@@ -358,7 +386,10 @@ async function runLeave(
         ...readOverride(flags, "--principal"),
         ...readOverride(flags, "--stack", "stack"),
         ...readOverride(flags, "--nats-config", "natsConfigPath"),
+        ...(serviceManager.value !== undefined && { serviceManager: serviceManager.value }),
+        ...readOverride(flags, "--service-file", "serviceFile"),
         ...readOverride(flags, "--plist", "plistPath"),
+        ...readOverride(flags, "--daemon-service", "daemonService"),
       },
       expandTilde(optionalValueFlag(flags, "--config") ?? DEFAULT_CONFIG_PATH),
       load,
@@ -381,7 +412,10 @@ async function runLeave(
     principalId: inputs.principal,
     stackId: `${inputs.principal}/${slugRes.slug}`,
     natsConfigPath: inputs.natsConfigPath,
+    serviceManager: inputs.serviceManager,
+    serviceFile: inputs.serviceFile,
     plistPath: inputs.plistPath,
+    daemonService: inputs.daemonService,
   };
   const ports = applyRes.apply ? buildLivePorts(cfg) : buildDryRunPorts(cfg);
 
@@ -452,9 +486,9 @@ async function runJoinPublic(
   if (!slugRes.ok) return usageError("join", slugRes.reason, json);
 
   // Public-path required flags: registry (announce), seed (proof-of-possession),
-  // nats-config (subscribe public.>), plist (daemon arg). NOT creds/account —
+  // nats-config (subscribe public.>). NOT creds/account —
   // public has no leaf.
-  for (const required of ["--registry-url", "--seed-path", "--nats-config", "--plist"]) {
+  for (const required of ["--registry-url", "--seed-path", "--nats-config"]) {
     const r = requireValueFlag(flags, required);
     if (!r.ok) return usageError("join", r.reason, json);
   }
@@ -477,6 +511,8 @@ async function runJoinPublic(
 
   const applyRes = resolveApply(flags);
   if (!applyRes.ok) return usageError("join", applyRes.reason, json);
+  const serviceManager = optionalServiceManagerFlag(flags);
+  if (!serviceManager.ok) return usageError("join", serviceManager.reason, json);
 
   const cfg = portsConfig("public", principalRes.value, slugRes.slug, flags);
   const ports = applyRes.apply ? buildLivePublicPorts(cfg) : buildDryRunPublicPorts(cfg);
@@ -498,12 +534,14 @@ async function runLeavePublic(
   if (!principalRes.ok) return usageError("leave", principalRes.reason, json);
   const slugRes = resolveStackSlug(principalRes.value, optionalValueFlag(flags, "--stack"));
   if (!slugRes.ok) return usageError("leave", slugRes.reason, json);
-  for (const required of ["--registry-url", "--seed-path", "--nats-config", "--plist"]) {
+  for (const required of ["--registry-url", "--seed-path", "--nats-config"]) {
     const r = requireValueFlag(flags, required);
     if (!r.ok) return usageError("leave", r.reason, json);
   }
   const applyRes = resolveApply(flags);
   if (!applyRes.ok) return usageError("leave", applyRes.reason, json);
+  const serviceManager = optionalServiceManagerFlag(flags);
+  if (!serviceManager.ok) return usageError("leave", serviceManager.reason, json);
 
   const cfg = portsConfig("public", principalRes.value, slugRes.slug, flags);
   const ports = applyRes.apply ? buildLivePublicPorts(cfg) : buildDryRunPublicPorts(cfg);
@@ -524,6 +562,7 @@ function portsConfig(
   stackSlug: string,
   flags: Record<string, string | true>,
 ): LivePortsConfig {
+  const serviceManager = optionalServiceManagerFlag(flags);
   return {
     networkId,
     principalId,
@@ -532,7 +571,10 @@ function portsConfig(
     registryPubkey: optionalValueFlag(flags, "--registry-pubkey"),
     seedPath: optionalValueFlag(flags, "--seed-path"),
     natsConfigPath: optionalValueFlag(flags, "--nats-config"),
+    serviceManager: serviceManager.ok ? serviceManager.value : undefined,
+    serviceFile: optionalValueFlag(flags, "--service-file"),
     plistPath: optionalValueFlag(flags, "--plist"),
+    daemonService: optionalValueFlag(flags, "--daemon-service"),
     monitorUrl: optionalValueFlag(flags, "--monitor-url"),
   };
 }
@@ -557,7 +599,10 @@ function portsConfigFromInputs(
     ...(inputs.registryPubkey !== undefined && { registryPubkey: inputs.registryPubkey }),
     seedPath: inputs.seedPath,
     natsConfigPath: inputs.natsConfigPath,
+    serviceManager: inputs.serviceManager,
+    serviceFile: inputs.serviceFile,
     plistPath: inputs.plistPath,
+    daemonService: inputs.daemonService,
     monitorUrl: optionalValueFlag(flags, "--monitor-url"),
     // #762 — caps the join announces INTO the network so the principal joins
     // the roster (registry control-plane; never on the wire).
@@ -677,8 +722,8 @@ Usage:
 The one-liner (#753): \`cortex network join <network>\` derives EVERYTHING from
 the loaded cortex.yaml — principal (principal.id), stack (stack.id), signing
 seed (stack.nkey_seed_path), registry (policy.federated.registry.{url,pubkey}),
-and the nats-server infra (stack.nats_infra.{config_path,plist_path,account,
-creds_path}). Pass --config <p> to point at a non-default cortex.yaml
+and the nats-server infra (stack.nats_infra.{config_path,service_manager,
+service_file,plist_path,account,creds_path}). Pass --config <p> to point at a non-default cortex.yaml
 (default: ~/.config/cortex/cortex.yaml). The flags below are OPTIONAL
 OVERRIDES: a passed flag wins; otherwise the value derives from config (or, for
 creds, the convention ~/.config/nats/<network>.creds). A required value that is
@@ -687,12 +732,12 @@ neither flagged nor derivable fails with a clear error naming the config field.
 Subcommands:
   join    Register → pull the SIGNED+VERIFIED network descriptor (DD-9; cached
           fallback on registry outage, DD-10) → render the nats-server leaf +
-          ensure the plist loads it (DD-6) → write policy.federated.networks[]
+          ensure the nats service loads it (DD-6) → write policy.federated.networks[]
           with registry-resolved peers (DD-5) + the stack's OWN accept-subject
           → restart. Idempotent (re-running converges).
   status  Show joined networks, peers, accept-subjects, leaf link state + counters.
   leave   Reverse a join cleanly: remove the network + leaf include, drop the
-          plist -c arg if no networks remain, restart. Idempotent.
+          service -c arg if no networks remain, restart. Idempotent.
 
   join public   (S5, #739) Opt into the PUBLIC scope — the open square of the
           Internet of Agentic Work. Announces --capabilities to the registry
@@ -720,7 +765,10 @@ Flags (all OPTIONAL OVERRIDES — derived from cortex.yaml when omitted; #753):
   --creds <p>             Override stack.nats_infra.creds_path (default: ~/.config/nats/<network>.creds).
   --account <nkey-U>      Override stack.nats_infra.account (A… nkey-U the leaf binds to).
   --nats-config <p>       Override stack.nats_infra.config_path (nats-server -c config).
-  --plist <p>             Override stack.nats_infra.plist_path (nats-server launchd plist).
+  --service-manager <m>   Override stack.nats_infra.service_manager: auto, launchd, systemd, none.
+  --service-file <p>      Override stack.nats_infra.service_file (launchd plist or systemd user unit).
+  --plist <p>             Legacy launchd alias for --service-file / stack.nats_infra.plist_path.
+  --daemon-service <name> Override cortex daemon service (launchd label or systemd unit).
   --leaf-node <name>      Leaf connection name on the network entry (default: network id).
   --max-hop <n>           Hop budget written on the network (default: 1).
   --capabilities <csv>    (join public) Comma-separated capability ids to announce

--- a/src/common/types/__tests__/stack.test.ts
+++ b/src/common/types/__tests__/stack.test.ts
@@ -89,6 +89,23 @@ describe("StackConfigSchema", () => {
     expect(parsed.nkey_pub).toBe(VALID_NKEY);
   });
 
+  test("#760 accepts platform-neutral nats_infra service metadata", () => {
+    const parsed = StackConfigSchema.parse({
+      id: "jc/default",
+      nats_infra: {
+        config_path: "/home/clawbox/.config/nats/local.conf",
+        service_manager: "systemd",
+        service_file: "/home/clawbox/.config/systemd/user/nats-server.service",
+        daemon_service: "cortex-bot.service",
+        account: "A" + "B".repeat(55),
+        creds_path: "/home/clawbox/.config/nats/jc.creds",
+      },
+    });
+    expect(parsed.nats_infra?.service_manager).toBe("systemd");
+    expect(parsed.nats_infra?.service_file).toBe("/home/clawbox/.config/systemd/user/nats-server.service");
+    expect(parsed.nats_infra?.daemon_service).toBe("cortex-bot.service");
+  });
+
   test("rejects uppercase principal segment", () => {
     expect(() =>
       StackConfigSchema.parse({ id: "Andreas/research" }),

--- a/src/common/types/stack.ts
+++ b/src/common/types/stack.ts
@@ -51,9 +51,9 @@ import { NKEY_PUBKEY_REGEX } from "./nkey";
  * leaf account that `cortex network join`/`leave` need to render the leaf
  * include file, ensure the plist loads it, and bind the leaf to the local
  * account. These are set ONCE per stack (they describe where the stack's
- * nats-server config + launchd plist live on disk and which account its leaf
+ * nats-server config + service file live on disk and which account its leaf
  * binds to), then every `cortex network join <network>` derives its
- * `--nats-config` / `--plist` / `--account` / `--creds` from this block.
+ * `--nats-config` / service metadata / `--account` / `--creds` from this block.
  *
  * #753 — the friction-removal block. Before this, every `cortex network join`
  * had to pass `--nats-config --plist --account --creds` on the command line;
@@ -75,10 +75,28 @@ export const StackNatsInfraSchema = z.object({
    */
   config_path: z.string().min(1).optional(),
   /**
-   * Path to the nats-server launchd plist `cortex network join` ensures loads
-   * the config (and reloads on join/leave). Maps to the `--plist` flag.
+   * Platform service manager for the nats-server service. `auto` derives from
+   * the host platform and `plist_path`/`service_file`; `launchd` edits/restarts
+   * a macOS plist, `systemd` edits/restarts a Linux user unit, and `none`
+   * leaves service management to the principal.
+   */
+  service_manager: z.enum(["auto", "launchd", "systemd", "none"]).optional(),
+  /**
+   * Path to the nats-server service file. On macOS this is the launchd plist;
+   * on Linux this is the systemd user unit. Maps to `--service-file`.
+   */
+  service_file: z.string().min(1).optional(),
+  /**
+   * Back-compat alias for the nats-server launchd plist. Maps to the legacy
+   * `--plist` flag and implies `launchd` when no service manager is declared.
    */
   plist_path: z.string().min(1).optional(),
+  /**
+   * Optional cortex daemon service name for reload after nats-server has
+   * reloaded the leaf. Launchd defaults to `ai.meta-factory.cortex.<slug>`;
+   * systemd defaults to `cortex-bot.service`.
+   */
+  daemon_service: z.string().min(1).optional(),
   /**
    * The local NATS account (`A…` nkey-U) the network's leaf binds to. Maps to
    * the `--account` flag. Same 56-char U-prefixed base32 NKey grammar as every


### PR DESCRIPTION
## Summary

- Fix #760 by adding service-manager metadata for `stack.nats_infra` and CLI overrides: `--service-manager`, `--service-file`, and `--daemon-service`, while keeping `--plist` / `plist_path` as a launchd-compatible alias.
- Make the network live adapters service-aware: launchd keeps existing plist mutation/restart behavior; systemd user units can be updated idempotently with `-c <nats config>` and restarted with `systemctl --user`.
- Remove the launchd-only `--plist` requirement from federated dry-runs and the public-scope paths.

## Verification

```sh
bun test src/cli/cortex/commands/__tests__/network-derive.test.ts src/cli/cortex/commands/__tests__/network-adapters.test.ts src/cli/cortex/commands/__tests__/network-cli.test.ts src/common/types/__tests__/stack.test.ts
bun test src/common/types/__tests__/cortex-config.test.ts src/common/types/__tests__/stack.test.ts
bunx tsc --noEmit
git diff --check
```
