### PR TITLE
refactor: G-1 #768 — GROVE_BASH_GUARD → CORTEX_BASH_GUARD

### DIFF
--- a/src/cli/cldyo-live
+++ b/src/cli/cldyo-live
@@ -40,7 +40,7 @@ export GROVE_AGENT_ID="${LIVE_ID}"
 # The legacy export is removed in v3.0.0 (PR-11).
 export CORTEX_PRINCIPAL="${LIVE_NAME}"
 export GROVE_OPERATOR="${LIVE_NAME}"
-export GROVE_BASH_GUARD='{"disabled":true}'
+export CORTEX_BASH_GUARD='{"disabled":true}'
 TASK_LABEL="${1:-${LIVE_ID}}"
 shift 2>/dev/null
 

--- a/src/common/substrates/types.ts
+++ b/src/common/substrates/types.ts
@@ -253,7 +253,7 @@ export interface DispatchRuntime {
   allowedDirs?: string[];
   /**
    * Bash guard allowlist config. CC's `bash-guard.hook.ts` reads this
-   * via the `GROVE_BASH_GUARD` env var and refuses any `Bash` tool
+   * via the `CORTEX_BASH_GUARD` env var and refuses any `Bash` tool
    * invocation whose command doesn't match the allowlist. Future
    * non-CC harnesses ignore this field.
    */

--- a/src/runner/__tests__/dm-trust-chain.test.ts
+++ b/src/runner/__tests__/dm-trust-chain.test.ts
@@ -89,13 +89,13 @@ describe("DM trust chain", () => {
   // tests cover the surface).
 
   describe("bash guard config propagation", () => {
-    test("GROVE_BASH_GUARD disabled config is valid JSON", () => {
+    test("CORTEX_BASH_GUARD disabled config is valid JSON", () => {
       const config = JSON.stringify({ disabled: true });
       const parsed = JSON.parse(config);
       expect(parsed.disabled).toBe(true);
     });
 
-    test("GROVE_BASH_GUARD with allowlist config is valid JSON", () => {
+    test("CORTEX_BASH_GUARD with allowlist config is valid JSON", () => {
       const allowlist = {
         rules: [
           { pattern: "^gh\\s+", repos: ["the-metafactory/grove"] },

--- a/src/runner/__tests__/session-settings.test.ts
+++ b/src/runner/__tests__/session-settings.test.ts
@@ -185,11 +185,11 @@ describe("scopeSessionEnv — principal CLAUDE_* vars dropped", () => {
   test("preserves cortex's own pipeline + non-Claude vars", () => {
     const scoped = scopeSessionEnv({
       CORTEX_CHANNEL: "andreas",
-      GROVE_BASH_GUARD: "{}",
+      CORTEX_BASH_GUARD: "{}",
       SOME_OTHER_VAR: "v",
     });
     expect(scoped.CORTEX_CHANNEL).toBe("andreas");
-    expect(scoped.GROVE_BASH_GUARD).toBe("{}");
+    expect(scoped.CORTEX_BASH_GUARD).toBe("{}");
     expect(scoped.SOME_OTHER_VAR).toBe("v");
   });
 

--- a/src/runner/cc-session.ts
+++ b/src/runner/cc-session.ts
@@ -33,7 +33,7 @@ export interface CCSessionOpts {
   timeoutMs?: number;
   cwd?: string;
   additionalArgs?: string[];
-  /** Bash allowlist config — passed to bash-guard.hook.ts via GROVE_BASH_GUARD env var. */
+  /** Bash allowlist config — passed to bash-guard.hook.ts via CORTEX_BASH_GUARD env var. */
   bashAllowlist?: { rules: { pattern: string; repos?: string[] }[]; repos: string[] };
   /** G-300: When true, disables bash guard entirely (principal DM). */
   bashGuardDisabled?: boolean;
@@ -233,9 +233,9 @@ export class CCSession extends EventEmitter {
 
     // Pass bash allowlist config to bash-guard.hook.ts
     if (this.opts.bashGuardDisabled) {
-      env.GROVE_BASH_GUARD = JSON.stringify({ disabled: true });
+      env.CORTEX_BASH_GUARD = JSON.stringify({ disabled: true });
     } else if (this.opts.bashAllowlist) {
-      env.GROVE_BASH_GUARD = JSON.stringify(this.opts.bashAllowlist);
+      env.CORTEX_BASH_GUARD = JSON.stringify(this.opts.bashAllowlist);
     }
 
     // Suppress ANTHROPIC_API_KEY when OAuth token is present

--- a/src/runner/hooks/__tests__/bash-guard.hook.test.ts
+++ b/src/runner/hooks/__tests__/bash-guard.hook.test.ts
@@ -5,7 +5,7 @@
  *   - structured PreToolUse deny output (replaces exit(2) + stderr)
  *   - unchanged pass-through ({"continue": true})
  *   - preserved GROVE_CHANNEL gate / GROVE_AGENT_ID bypass /
- *     GROVE_BASH_GUARD disabled behaviour
+ *     CORTEX_BASH_GUARD disabled behaviour
  *   - block telemetry event written to the JSONL fallback
  *   - block telemetry event POSTed to the HTTP ingest endpoint
  */
@@ -27,14 +27,14 @@ interface RunResult {
 // Grove env vars the hook reads. The test process itself may run inside a
 // Cortex agent session (which sets these), so the helper strips ALL of them
 // from the child env first, then re-applies only what each test specifies.
-// Without this, an inherited GROVE_BASH_GUARD / GROVE_AGENT_ID silently
+// Without this, an inherited CORTEX_BASH_GUARD / GROVE_AGENT_ID silently
 // bypasses the guard and tests pass for the wrong reason.
 const GROVE_ENV_KEYS = [
   "GROVE_CHANNEL",
   "GROVE_AGENT_ID",
   "GROVE_AGENT_NAME",
   "GROVE_NETWORK",
-  "GROVE_BASH_GUARD",
+  "CORTEX_BASH_GUARD",
   "GROVE_PROJECT",
   "GROVE_ENTITY",
   "GROVE_OPERATOR",
@@ -90,7 +90,7 @@ describe("bash-guard.hook — pass-through behaviour", () => {
     const r = runHook("rm -rf /tmp/x", {
       GROVE_CHANNEL: "test-channel",
       GROVE_AGENT_ID: undefined,
-      GROVE_BASH_GUARD: JSON.stringify({ disabled: true }),
+      CORTEX_BASH_GUARD: JSON.stringify({ disabled: true }),
     });
     expect(r.status).toBe(0);
     expect(JSON.parse(r.stdout.trim())).toEqual({ continue: true });
@@ -115,7 +115,7 @@ describe("bash-guard.hook — pass-through behaviour", () => {
     const r = runHook("bun test", {
       GROVE_CHANNEL: "test-channel",
       GROVE_AGENT_ID: undefined,
-      GROVE_BASH_GUARD: JSON.stringify({ rules: [{ pattern: "^bun\\s+" }] }),
+      CORTEX_BASH_GUARD: JSON.stringify({ rules: [{ pattern: "^bun\\s+" }] }),
     });
     expect(r.status).toBe(0);
     expect(JSON.parse(r.stdout.trim())).toEqual({ continue: true });
@@ -154,7 +154,7 @@ describe("bash-guard.hook — structured deny output", () => {
     const r = runHook("gh pr view --repo evil/repo 1", {
       GROVE_CHANNEL: "test-channel",
       GROVE_AGENT_ID: undefined,
-      GROVE_BASH_GUARD: JSON.stringify({
+      CORTEX_BASH_GUARD: JSON.stringify({
         rules: [{ pattern: "^gh\\s+" }],
         repos: ["the-metafactory/cortex"],
       }),
@@ -493,7 +493,7 @@ describe("bash-guard.hook — read-only aws (integration via hook + halden confi
     return runHook(cmd, {
       GROVE_CHANNEL: "test-channel",
       GROVE_AGENT_ID: undefined,
-      GROVE_BASH_GUARD: haldenConfig,
+      CORTEX_BASH_GUARD: haldenConfig,
     });
   }
 

--- a/src/runner/hooks/bash-guard.hook.ts
+++ b/src/runner/hooks/bash-guard.hook.ts
@@ -6,7 +6,7 @@
  * Enforces a command allowlist with repo restrictions for gh CLI.
  * Non-Grove sessions pass through unchanged.
  *
- * Config via GROVE_BASH_GUARD env var (JSON):
+ * Config via CORTEX_BASH_GUARD env var (JSON):
  *   { "rules": [{ "pattern": "^gh\\s+pr", "repos": ["owner/repo"] }] }
  *
  * If no config env var, uses sensible defaults (gh, git read-only, ls, pwd).
@@ -110,7 +110,7 @@ const DEFAULT_CONFIG: GuardConfig = {
   repos: [],
 };
 
-// Narrow projection of the GROVE_BASH_GUARD env var payload. The hook
+// Narrow projection of the CORTEX_BASH_GUARD env var payload. The hook
 // reads only `disabled` / `rules` / `repos`; anything else is ignored.
 interface GuardConfigRaw {
   disabled?: boolean;
@@ -119,7 +119,7 @@ interface GuardConfigRaw {
 }
 
 function loadConfig(): GuardConfig | null {
-  const raw = process.env.GROVE_BASH_GUARD;
+  const raw = process.env.CORTEX_BASH_GUARD;
   if (raw) {
     try {
       const parsed = JSON.parse(raw) as GuardConfigRaw;
@@ -311,7 +311,7 @@ async function main(): Promise<void> {
   }
 
   // CLI principal session (cldyo-live sets GROVE_AGENT_ID) — full trust, bypass guard.
-  // Bot sessions also set GROVE_AGENT_ID but override via GROVE_BASH_GUARD config,
+  // Bot sessions also set GROVE_AGENT_ID but override via CORTEX_BASH_GUARD config,
   // so they still get guarded by the loadConfig() path below.
   if (process.env.GROVE_AGENT_ID) {
     allow();

--- a/src/runner/hooks/skill-guard.hook.ts
+++ b/src/runner/hooks/skill-guard.hook.ts
@@ -27,7 +27,7 @@
  *     `Skill` in the curated `--settings` file, AND broadly allows `Skill`.
  *   - The grant list reaches this hook via the `CORTEX_SKILL_GRANTS` env
  *     var (a JSON array of allowed skill names), set on the child env by
- *     `cc-session.ts` — the same layering as `GROVE_BASH_GUARD`.
+ *     `cc-session.ts` — the same layering as `CORTEX_BASH_GUARD`.
  *   - A session with NO grants does NOT register this hook; it keeps the
  *     bare-`Skill` `disallowedTools` deny (default-deny, no Skill tool).
  *

--- a/src/runner/session-settings.ts
+++ b/src/runner/session-settings.ts
@@ -157,7 +157,7 @@ export const CORTEX_PRESERVED_CLAUDE_ENV = new Set<string>([
  * Set on the child env by `cc-session.ts`, layered AFTER `scopeSessionEnv`
  * (it is not a `CLAUDE_*` var, so scoping passes it through regardless; the
  * explicit layering keeps it alongside cortex's other pipeline vars). Mirrors
- * how `GROVE_BASH_GUARD` carries the bash-guard config to that hook.
+ * how `CORTEX_BASH_GUARD` carries the bash-guard config to that hook.
  */
 export const CORTEX_SKILL_GRANTS_ENV = "CORTEX_SKILL_GRANTS";
 


### PR DESCRIPTION
Closes #768
Refs #767

## What

Rename the internal `GROVE_BASH_GUARD` env var to `CORTEX_BASH_GUARD` — part of the GROVE-naming retirement (#767).

## Why atomic (no shim)

`GROVE_BASH_GUARD` is cortex→cortex plumbing: `src/runner/cc-session.ts` sets it on the child env, and `src/runner/hooks/bash-guard.hook.ts` reads it. Both ends are cortex and deploy together → no external consumer → clean atomic rename, no back-compat fallback.

## Scope

- **Setter** `cc-session.ts` and **reader** `bash-guard.hook.ts` changed together to stay in sync.
- Hook-test `GROVE_ENV_KEYS` strip-list updated so an inherited `CORTEX_BASH_GUARD` can't silently bypass the guard in tests.
- CLI wrapper `cldyo-live`, plus doc-comment refs in `session-settings.ts`, `skill-guard.hook.ts`, `types.ts`.
- **Out of scope:** other `GROVE_*` vars (`GROVE_OPERATOR`/G-3, `GROVE_AGENT_ID`, etc.) — left untouched. Rebased on #770.

22 references renamed across 9 files (22 insertions / 22 deletions).

## Verify

- `bunx tsc --noEmit` → 0 errors
- `bun test` bash-guard + cc-session + session-settings + dm-trust-chain → 92 + 13 pass, 0 fail
- `grep -rn GROVE_BASH_GUARD src/` → nothing (grep-clean)
- `eslint` changed files → clean
- vocab carve-out gate (`scripts/check-carveouts.sh`) → PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)