### PR TITLE
fix(test): #771 — de-flake dispatch-listener re-sign / ConfigWatcher (deterministic CI gate)

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,15 @@
+# Bun configuration.
+#
+# [test] timeout — per-test timeout in ms (cortex#771). Bun's default is 5000ms.
+# A handful of suite tests spawn child processes (`cortex` / `bun` CLIs) or wait
+# on real `node:fs.watch` events; on a loaded/shared CI runner these legitimately
+# approach the 5s ceiling and time out non-deterministically (observed in the
+# #771 investigation: `cortex network --help`, the bash-guard PreToolUse hook,
+# `updateIteration`, and the agents-directory watcher all timed out at 5–6.7s
+# only under peak parallelism, never in a clean single run). Raising the global
+# ceiling to 20s gives subprocess/fs tests headroom under CI load while still
+# bounding a genuine hang. It does NOT mask the assertion-race flakes #771 was
+# about — those are fixed at the source (terminal-event waits + de-raced fixtures
+# in the runner/config tests); this is defense-in-depth for the timeout class.
+[test]
+timeout = 20000

--- a/src/adapters/slack/__tests__/slack-adapter.test.ts
+++ b/src/adapters/slack/__tests__/slack-adapter.test.ts
@@ -15,6 +15,26 @@ import type { Agent, SlackPresence } from "../../../common/types/cortex-config";
 import type { InboundMessage } from "../../types";
 import type { Envelope } from "../../../bus/myelin/envelope-validator";
 
+/**
+ * Poll `condition` until truthy or `timeoutMs` expires (cortex#771). The inbound
+ * drain runs `setTimeout`-backed async callbacks; a fixed sleep for "all N
+ * messages drained" raced that loop under full-suite concurrency (Bun runs test
+ * FILES in parallel, the event loop is saturated, the drain lands after the
+ * fixed wait), so we poll a predicate with a generous deadline instead.
+ */
+async function pollFor(
+  condition: () => boolean,
+  timeoutMs = 2000,
+  intervalMs = 5,
+): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (condition()) return true;
+    await new Promise<void>((resolve) => setTimeout(resolve, intervalMs));
+  }
+  return condition();
+}
+
 // ---------------------------------------------------------------------------
 // Fake SlackClient — records calls and exposes a hook to simulate inbound
 // events. Tests assert against `postedMessages` / `wasStopped` and drive
@@ -1230,7 +1250,10 @@ describe("SlackAdapter — two-pass dispatch gate (cortex#235 r1#7)", () => {
     // picks it up via the per-iteration length check, arrival
     // order preserved.
     await emit(makeSlackEvent({ ts: "1700000000.000003", text: "mid-drain-3" }));
-    await new Promise<void>((resolve) => setTimeout(resolve, 30));
+    // Poll until all three messages have drained instead of a fixed 30ms wait:
+    // the drain awaits a 5ms-per-message callback, and on a loaded CI runner the
+    // three callbacks land past 30ms (cortex#771).
+    await pollFor(() => calls.length === 3);
     expect(calls).toEqual(["queued-1", "queued-2", "mid-drain-3"]);
     await adapter.stop();
   });

--- a/src/cli/cortex/commands/__tests__/network-adapters.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-adapters.test.ts
@@ -512,6 +512,11 @@ describe("#757 nats-server restart port", () => {
       stackId: "andreas/meta-factory",
       natsConfigPath: "/x/local.conf",
       plistPath: "/nonexistent/nats-server.plist",
+      // Pin darwin (launchd): the assertion is about the plist-not-found path.
+      // Without it the Linux CI host defaults to systemd and never inspects
+      // `plistPath`, so the "plist not found" reason never appears (cortex#771
+      // — pre-existing #757/#763 host-platform leak surfaced here).
+      platform: "darwin",
     };
     const ports = buildLivePorts(cfg);
     const res = await ports.natsServer!.restart();

--- a/src/cli/cortex/commands/__tests__/network-derive.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-derive.test.ts
@@ -130,14 +130,20 @@ describe("deriveJoinInputs — config-only (the one-liner)", () => {
         },
       },
     });
-    const res = deriveJoinInputs("metafactory", {}, "/cfg", reader(cfg));
+    // Pin darwin: this fixture configures `plist_path` (launchd), so the
+    // service-descriptor resolves on macOS. Without the pin the host platform
+    // leaks in and the descriptor fails on Linux CI (cortex#771 — these
+    // platform-default tests were green on macOS dev boxes but red on the
+    // Linux runner, a pre-existing #762/#763 breakage surfaced here).
+    const res = deriveJoinInputs("metafactory", {}, "/cfg", reader(cfg), "darwin");
     expect(res.ok).toBe(true);
     // Only the metafactory block's caps — never the other network's.
     expect(res.inputs?.announceCapabilities).toEqual(["chat", "release"]);
   });
 
   test("#762 — no matching network block → announceCapabilities is empty", () => {
-    const res = deriveJoinInputs("brand-new-net", {}, "/cfg/cortex.yaml", reader(FULL));
+    // Pin darwin — FULL configures `plist_path` (cortex#771; see above).
+    const res = deriveJoinInputs("brand-new-net", {}, "/cfg/cortex.yaml", reader(FULL), "darwin");
     expect(res.ok).toBe(true);
     expect(res.inputs?.announceCapabilities).toEqual([]);
   });
@@ -160,7 +166,8 @@ describe("deriveJoinInputs — config-only (the one-liner)", () => {
         federated: { networks: [], registry: { url: "https://r.test" } },
       },
     });
-    const res = deriveJoinInputs("metafactory", {}, "/cfg", reader(cfg));
+    // Pin darwin — `plist_path` fixture (cortex#771; see above).
+    const res = deriveJoinInputs("metafactory", {}, "/cfg", reader(cfg), "darwin");
     expect(res.ok).toBe(true);
     expect(res.inputs?.credsPath).toBe("~/.config/nats/metafactory.creds");
     expect(defaultCredsPath("metafactory")).toBe("~/.config/nats/metafactory.creds");
@@ -179,7 +186,8 @@ describe("deriveJoinInputs — config-only (the one-liner)", () => {
         federated: { networks: [], registry: { url: "https://r.test" } },
       },
     });
-    const res = deriveJoinInputs("metafactory", {}, "/cfg", reader(cfg));
+    // Pin darwin — `plist_path` fixture (cortex#771; see above).
+    const res = deriveJoinInputs("metafactory", {}, "/cfg", reader(cfg), "darwin");
     expect(res.ok).toBe(true);
     expect(res.inputs?.registryPubkey).toBeUndefined();
   });
@@ -198,7 +206,8 @@ describe("deriveJoinInputs — config-only (the one-liner)", () => {
         federated: { networks: [], registry: { url: "https://r.test" } },
       },
     });
-    const res = deriveJoinInputs("metafactory", {}, "/cfg", reader(cfg));
+    // Pin darwin — `plist_path` fixture (cortex#771; see above).
+    const res = deriveJoinInputs("metafactory", {}, "/cfg", reader(cfg), "darwin");
     expect(res.ok).toBe(true);
     expect(res.inputs?.stack).toBe("andreas/default");
   });
@@ -324,7 +333,11 @@ describe("deriveJoinInputs — actionable missing-config errors", () => {
         federated: { networks: [], registry: { url: "https://r" } },
       },
     });
-    const res = deriveJoinInputs("metafactory", {}, "/cfg", reader(cfg));
+    // Pin darwin so the deriver reaches the account check (the `plist_path`
+    // fixture satisfies the macOS descriptor); without the pin, the Linux CI
+    // host hits the systemd `unit_path` error FIRST and names the wrong field
+    // (cortex#771 — pre-existing #762/#763 breakage surfaced here).
+    const res = deriveJoinInputs("metafactory", {}, "/cfg", reader(cfg), "darwin");
     expect(res.ok).toBe(false);
     expect(res.reason).toContain("stack.nats_infra.account");
   });

--- a/src/common/config/__tests__/fragment-watcher.test.ts
+++ b/src/common/config/__tests__/fragment-watcher.test.ts
@@ -26,10 +26,15 @@ const WAIT_AFTER_EVENT = 130;
  * Poll `condition` every `intervalMs` until truthy or `timeoutMs` expires.
  * Returns true when satisfied, false on deadline. Replaces fixed-duration
  * sleeps that proved racy under loaded CI runners (cortex#699).
+ *
+ * Default deadline 4000ms (cortex#771): these tests await a real
+ * `node:fs.watch` event plus the 50ms debounce, and the 2000ms default was
+ * still occasionally missed under full-suite concurrency. 4000ms stays inside
+ * Bun's 5s per-test timeout while absorbing kernel inotify/FSEvents latency.
  */
 async function pollUntil(
   condition: () => boolean,
-  timeoutMs = 2000,
+  timeoutMs = 4000,
   intervalMs = 30,
 ): Promise<boolean> {
   const deadline = Date.now() + timeoutMs;
@@ -110,7 +115,10 @@ describe("AgentsDirectoryWatcher", () => {
     test("drop a fragment → fires with agentsAdded", async () => {
       await startWatcher();
       dropFragment("echo");
-      await sleep(WAIT_AFTER_EVENT);
+      // Poll for the semantic event instead of a fixed sleep: fs.watch + the
+      // 50ms debounce can exceed WAIT_AFTER_EVENT on a loaded CI runner, so a
+      // fixed wait raced the event and read 0 events (cortex#771).
+      await pollUntil(() => events.some((e) => e.agentsAdded.includes("echo")));
       // macOS fs.watch sometimes fires duplicate events; assert there is AT
       // LEAST one event that captured the change. Each test asserts the
       // semantic-content event, not the last event.
@@ -127,7 +135,8 @@ describe("AgentsDirectoryWatcher", () => {
       await startWatcher(initial);
       // Modify: change the displayName by rewriting with extra field
       dropFragment("echo", "echo.md", { trust: ["holly"] });
-      await sleep(WAIT_AFTER_EVENT);
+      // Poll for the semantic event (cortex#771 — see "drop a fragment").
+      await pollUntil(() => events.some((e) => e.agentsChanged.includes("echo")));
       const significant = events.find((e) => e.agentsChanged.includes("echo"));
       expect(significant).toBeDefined();
       expect(significant!.failed).toBe(false);
@@ -140,7 +149,8 @@ describe("AgentsDirectoryWatcher", () => {
       const initial = loadAgentsDirectory(tmpAgentsDir);
       await startWatcher(initial);
       unlinkSync(join(tmpAgentsDir, "echo.yaml"));
-      await sleep(WAIT_AFTER_EVENT);
+      // Poll for the semantic event (cortex#771 — see "drop a fragment").
+      await pollUntil(() => events.some((e) => e.agentsRemoved.includes("echo")));
       const significant = events.find((e) => e.agentsRemoved.includes("echo"));
       expect(significant).toBeDefined();
       expect(significant!.failed).toBe(false);

--- a/src/common/config/__tests__/watcher.test.ts
+++ b/src/common/config/__tests__/watcher.test.ts
@@ -11,14 +11,21 @@ import type { AgentConfig } from "../../types/config";
 
 /**
  * Poll `condition` every `intervalMs` until it returns truthy or `timeoutMs`
- * expires (default 2000ms). Returns true when condition satisfied, false on
- * timeout. Replaces fixed-duration `setTimeout(300)` waits that proved racy
- * under loaded CI runners where fs.watch + the 200ms ConfigWatcher debounce
- * together could exceed 300ms (cortex#699).
+ * expires. Returns true when condition satisfied, false on timeout. Replaces
+ * fixed-duration `setTimeout(300)` waits that proved racy under loaded CI
+ * runners where fs.watch + the 200ms ConfigWatcher debounce together could
+ * exceed 300ms (cortex#699).
+ *
+ * The default deadline is 4000ms (cortex#771): the reload tests depend on a
+ * real `node:fs.watch` event PLUS the watcher's 200ms debounce, and under
+ * full-suite concurrency the 2000ms default was still occasionally missed
+ * (observed: an `identifies restart-required field changes` reload that landed
+ * at ~2.1s). 4000ms stays inside Bun's default 5s per-test timeout while
+ * absorbing kernel inotify/FSEvents latency on a loaded runner.
  */
 async function pollUntil(
   condition: () => boolean,
-  timeoutMs = 2000,
+  timeoutMs = 4000,
   intervalMs = 30,
 ): Promise<boolean> {
   const deadline = Date.now() + timeoutMs;
@@ -133,7 +140,14 @@ describe("ConfigWatcher", () => {
   let testConfigPath: string;
 
   beforeEach(() => {
-    testConfigPath = join(tmpdir(), `test-bot-${Date.now()}.yaml`);
+    // Unique suffix (not just Date.now()) so concurrent test FILES — Bun runs
+    // them in parallel — can never collide on the same /tmp fixture path and
+    // unlink each other's config mid-watch (cortex#771). Mirrors the
+    // github.repos block's `${Date.now()}-${Math.random()}` pattern below.
+    testConfigPath = join(
+      tmpdir(),
+      `test-bot-${Date.now()}-${Math.random().toString(36).slice(2)}.yaml`,
+    );
     // Write initial config
     const yaml = `
 agent:

--- a/src/runner/__tests__/dispatch-listener.test.ts
+++ b/src/runner/__tests__/dispatch-listener.test.ts
@@ -51,6 +51,82 @@ const SOURCE: SystemEventSource = {
 const TASK_ID = "11111111-1111-4111-8111-111111111111";
 
 /**
+ * Wait for the async dispatch pipeline to finish, instead of sleeping a fixed
+ * 10ms (cortex#771 — de-flake the full-suite Test gate).
+ *
+ * THE FLAKE. After a synchronous `r.trigger(...)` the listener runs
+ * chain-verify → (optional) re-sign → policy gate → harness before pushing onto
+ * `r.published[]`. The chain-verify and re-sign steps call WebCrypto
+ * (`signAsync`/`verifyAsync` → `subtle.digest`), which runs OFF the JS thread.
+ * The original `await new Promise(r => setTimeout(r, 10))` was a blind race:
+ * under full-suite concurrency Bun runs many test FILES in parallel, the event
+ * loop is saturated, the off-thread crypto resolves AFTER the 10ms timer, and
+ * the assertion read a half-populated (often empty) `published[]` — surfacing as
+ * `expected array/object, received undefined` on the audit envelope, and as
+ * `toEqual([...])` mismatches on the lifecycle sequence. There is NO shared
+ * mutable state and no product bug; it is purely the fixed sleep racing
+ * off-thread crypto.
+ *
+ * THE FIX — wait for an OBSERVABLE TERMINAL CONDITION, never a fixed duration.
+ * Every accepted dispatch ends by publishing a TERMINAL envelope:
+ *   - a lifecycle terminal — `dispatch.task.{completed,failed,aborted}`, or
+ *   - a denial — `system.access.denied` (paired with `dispatch.task.failed`).
+ * A REJECTED dispatch (subject/recipient mismatch, empty-chain reject) publishes
+ * nothing at all (a "drop"). `settle()` returns as soon as a terminal envelope is
+ * observed — deterministic and immune to off-thread-crypto latency, because the
+ * terminal only appears AFTER the whole chain-verify → re-sign → policy → harness
+ * path (including all WebCrypto) has run. The brief idle confirmation after a
+ * terminal lets any same-turn trailing envelope (e.g. the `failed` that pairs a
+ * `denied`) land so the following assertion sees the complete set.
+ *
+ * For DROP tests (which publish nothing by design) there is no terminal to wait
+ * for, so `settle` falls back to a bounded observation window: it waits long
+ * enough that the synchronously-scheduled verify/policy path has demonstrably
+ * run and produced nothing. `minObserveMs` is deliberately generous so the
+ * off-thread verify crypto on a loaded runner completes inside it — a drop is
+ * only concluded after the pipeline has had real time to (not) produce.
+ *
+ * No per-test counts, nothing serialized: a saturated event loop just means the
+ * terminal envelope arrives a few ms later and `settle` waits for it.
+ */
+const TERMINAL_TYPES = new Set([
+  "dispatch.task.completed",
+  "dispatch.task.failed",
+  "dispatch.task.aborted",
+  "system.access.denied",
+]);
+
+async function settle(
+  published: () => readonly Envelope[],
+  {
+    idleMs = 25,
+    minObserveMs = 250,
+  }: { idleMs?: number; minObserveMs?: number } = {},
+): Promise<void> {
+  const tick = () => new Promise<void>((resolve) => setTimeout(resolve, 2));
+  const hasTerminal = () => published().some((e) => TERMINAL_TYPES.has(e.type));
+
+  // Wait UP TO `minObserveMs` for a terminal envelope. `minObserveMs` is the
+  // grace in which the off-thread chain-verify/re-sign/policy crypto must
+  // produce a terminal if the dispatch is accepted; it is sized to dwarf that
+  // crypto even on a loaded runner. A drop publishes nothing, so it simply
+  // exhausts this window.
+  const observeUntil = Date.now() + minObserveMs;
+  while (Date.now() < observeUntil && !hasTerminal()) {
+    await tick();
+  }
+
+  // Terminal seen → drain a short idle window so any same-turn trailing
+  // envelope (e.g. the `failed` that pairs a `denied`) also lands before the
+  // caller asserts. No terminal → it's a drop; we already observed long enough
+  // to be sure nothing was produced.
+  if (hasTerminal()) {
+    const until = Date.now() + idleMs;
+    while (Date.now() < until) await tick();
+  }
+}
+
+/**
  * Canonical Tasks-Domain chat subject for cortex (`@did-mf-cortex`). Shared
  * across every `trigger()` call so a future canonical-grammar change is a
  * one-line edit here rather than a mechanical sweep of every test (cortex#409
@@ -498,7 +574,7 @@ describe("dispatch-listener — success path", () => {
     r.trigger(makeReceivedEnvelope(), CANONICAL_CORTEX_CHAT_SUBJECT);
 
     // Wait briefly for async render to complete
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await settle(() => r.published);
 
     // v2.0.1: policy engine is active, so an audit envelope precedes lifecycle.
     expect(r.published).toHaveLength(3);
@@ -534,7 +610,7 @@ describe("dispatch-listener — success path", () => {
     await router.start();
 
     r.trigger(makeReceivedEnvelope(), CANONICAL_CORTEX_CHAT_SUBJECT);
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await settle(() => r.published);
 
     const completed = r.published.find((e) => e.type === "dispatch.task.completed");
     expect(completed).toBeDefined();
@@ -570,7 +646,7 @@ describe("dispatch-listener — success path", () => {
       }),
       CANONICAL_CORTEX_CHAT_SUBJECT,
     );
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await settle(() => r.published);
 
     // Every LIFECYCLE envelope (started/completed) carries the echoed
     // routing so the dispatch sink can target the reply. The audit
@@ -597,7 +673,7 @@ describe("dispatch-listener — success path", () => {
 
     // bus-peer / Offer style inbound — no response_routing on the payload.
     r.trigger(makeReceivedEnvelope(), CANONICAL_CORTEX_CHAT_SUBJECT);
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await settle(() => r.published);
 
     const lifecycle = r.published.filter((e) => e.type.startsWith("dispatch.task."));
     expect(lifecycle.length).toBeGreaterThan(0);
@@ -638,7 +714,7 @@ describe("dispatch-listener — success path", () => {
       }),
       CANONICAL_CORTEX_CHAT_SUBJECT,
     );
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await settle(() => r.published);
 
     expect(optsCaptured).toHaveLength(1);
     const opts = optsCaptured[0]!;
@@ -685,7 +761,7 @@ describe("dispatch-listener — success path", () => {
       }),
       CANONICAL_CORTEX_CHAT_SUBJECT,
     );
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await settle(() => r.published);
 
     expect(optsCaptured).toHaveLength(1);
     const opts = optsCaptured[0]!;
@@ -714,7 +790,7 @@ describe("dispatch-listener — success path", () => {
 
     // No agent_name on the payload — only agent_id.
     r.trigger(makeReceivedEnvelope(), CANONICAL_CORTEX_CHAT_SUBJECT);
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await settle(() => r.published);
 
     expect(optsCaptured).toHaveLength(1);
     const opts = optsCaptured[0]!;
@@ -741,7 +817,7 @@ describe("dispatch-listener — success path", () => {
     await router.start();
 
     r.trigger(makeReceivedEnvelope(), CANONICAL_CORTEX_CHAT_SUBJECT);
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await settle(() => r.published);
 
     expect(optsCaptured).toHaveLength(1);
     const opts = optsCaptured[0]!;
@@ -788,7 +864,7 @@ describe("dispatch-listener — success path", () => {
       },
       CANONICAL_CORTEX_CHAT_SUBJECT,
     );
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await settle(() => r.published);
 
     expect(cc.optsCaptured).toHaveLength(0);
     expect(team.optsCaptured).toHaveLength(1);
@@ -827,7 +903,7 @@ describe("dispatch-listener — failure paths", () => {
       },
       CANONICAL_CORTEX_CHAT_SUBJECT,
     );
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await settle(() => r.published);
 
     expect(cc.optsCaptured).toHaveLength(0);
     expect(r.published).toHaveLength(1);
@@ -850,7 +926,7 @@ describe("dispatch-listener — failure paths", () => {
     await router.start();
 
     r.trigger(makeReceivedEnvelope(), CANONICAL_CORTEX_CHAT_SUBJECT);
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await settle(() => r.published);
 
     expect(r.published.map((e) => e.type)).toEqual([
       "system.access.allowed",
@@ -875,7 +951,7 @@ describe("dispatch-listener — failure paths", () => {
     await router.start();
 
     r.trigger(makeReceivedEnvelope(), CANONICAL_CORTEX_CHAT_SUBJECT);
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await settle(() => r.published);
 
     expect(r.published.map((e) => e.type)).toEqual([
       "system.access.allowed",
@@ -901,7 +977,7 @@ describe("dispatch-listener — failure paths", () => {
     await router.start();
 
     r.trigger(makeReceivedEnvelope(), CANONICAL_CORTEX_CHAT_SUBJECT);
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await settle(() => r.published);
 
     expect(r.published.map((e) => e.type)).toEqual([
       "system.access.allowed",
@@ -927,7 +1003,7 @@ describe("dispatch-listener — failure paths", () => {
     await router.start();
 
     r.trigger(makeReceivedEnvelope(), CANONICAL_CORTEX_CHAT_SUBJECT);
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await settle(() => r.published);
 
     expect(r.published.map((e) => e.type)).toEqual([
       "system.access.allowed",
@@ -969,7 +1045,7 @@ describe("dispatch-listener — malformed payload", () => {
       payload: { task_id: TASK_ID, agent_id: "cortex" }, // no prompt
     };
     r.trigger(malformed, CANONICAL_CORTEX_CHAT_SUBJECT);
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await settle(() => r.published);
 
     expect(r.published).toHaveLength(0);
   });
@@ -1000,7 +1076,7 @@ describe("dispatch-listener — malformed payload", () => {
       payload: { agent_id: "cortex", prompt: "x" },
     };
     r.trigger(malformed, CANONICAL_CORTEX_CHAT_SUBJECT);
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await settle(() => r.published);
 
     expect(r.published).toHaveLength(0);
   });
@@ -1037,7 +1113,7 @@ describe("dispatch-listener — malformed payload", () => {
       payload: { task_id: "not-a-uuid", agent_id: "cortex", prompt: "x" },
     };
     r.trigger(malformed, CANONICAL_CORTEX_CHAT_SUBJECT);
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await settle(() => r.published);
 
     expect(r.published).toHaveLength(0);
     expect(optsCaptured).toHaveLength(0);
@@ -1063,7 +1139,7 @@ describe("dispatch-listener — start/stop", () => {
     await router.start();
 
     r.trigger(makeReceivedEnvelope(), CANONICAL_CORTEX_CHAT_SUBJECT);
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await settle(() => r.published);
 
     // Single registration → exactly one started + one completed (not double)
     expect(r.published.map((e) => e.type)).toEqual([
@@ -1087,7 +1163,7 @@ describe("dispatch-listener — start/stop", () => {
     await listener.stop();
 
     r.trigger(makeReceivedEnvelope(), CANONICAL_CORTEX_CHAT_SUBJECT);
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await settle(() => r.published);
 
     expect(r.published).toHaveLength(0);
   });
@@ -1125,7 +1201,7 @@ describe("dispatch-listener — subject filtering", () => {
 
     // Same envelope, different subject — should not match
     r.trigger(makeReceivedEnvelope(), "local.othermetafactory.tasks.@did-mf-cortex.chat");
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await settle(() => r.published);
 
     expect(r.published).toHaveLength(0);
   });
@@ -1175,7 +1251,7 @@ describe("dispatch-listener — policy gating (C.3.1)", () => {
     await router.start();
 
     r.trigger(makeReceivedEnvelope(), CANONICAL_CORTEX_CHAT_SUBJECT);
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await settle(() => r.published);
 
     expect(r.published.map((e) => e.type)).toEqual(["dispatch.task.failed"]);
     const failed = r.published[0]!;
@@ -1198,7 +1274,7 @@ describe("dispatch-listener — policy gating (C.3.1)", () => {
     await router.start();
 
     r.trigger(makeReceivedEnvelope(), CANONICAL_CORTEX_CHAT_SUBJECT);
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await settle(() => r.published);
 
     // C.4.1 — system.access.allowed audit envelope precedes the
     // lifecycle envelopes on the allow path.
@@ -1224,7 +1300,7 @@ describe("dispatch-listener — policy gating (C.3.1)", () => {
     await router.start();
 
     r.trigger(makeReceivedEnvelope(), CANONICAL_CORTEX_CHAT_SUBJECT);
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await settle(() => r.published);
 
     // C.4.2 — deny path emits both system.access.denied (audit) +
     // dispatch.task.failed (lifecycle terminal — Echo cortex#220 M-1).
@@ -1268,7 +1344,7 @@ describe("dispatch-listener — policy gating (C.3.1)", () => {
       makeReceivedEnvelope({ agent_id: "ghost-agent" }),
       "local.metafactory.tasks.@did-mf-ghost-agent.chat",
     );
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await settle(() => r.published);
 
     expect(r.published.map((e) => e.type)).toEqual([
       "system.access.denied",
@@ -1334,7 +1410,7 @@ describe("dispatch-listener — policy gating (C.3.1)", () => {
     };
 
     r.trigger(env, CANONICAL_CORTEX_CHAT_SUBJECT);
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await settle(() => r.published);
 
     expect(captured).toHaveLength(1);
     const seen = captured[0]!;
@@ -1373,7 +1449,7 @@ describe("dispatch-listener — policy gating (C.3.1)", () => {
     ];
 
     r.trigger(env, CANONICAL_CORTEX_CHAT_SUBJECT);
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await settle(() => r.published);
 
     expect(r.published.map((e) => e.type)).toEqual([
       "system.access.allowed",
@@ -1402,7 +1478,7 @@ describe("dispatch-listener — policy gating (C.3.1)", () => {
     await router.start();
 
     r.trigger(makeReceivedEnvelope(), CANONICAL_CORTEX_CHAT_SUBJECT);
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await settle(() => r.published);
 
     const allowed = r.published.find((e) => e.type === "system.access.allowed");
     expect(allowed).toBeDefined();
@@ -1465,7 +1541,7 @@ describe("dispatch-listener — policy gating (C.3.1)", () => {
       },
     ];
     r.trigger(env, CANONICAL_CORTEX_CHAT_SUBJECT);
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await settle(() => r.published);
 
     const allowed = r.published.find((e) => e.type === "system.access.allowed");
     expect(allowed).toBeDefined();
@@ -1580,7 +1656,7 @@ describe("dispatch-listener — policy gating (C.3.1)", () => {
       makeReceivedEnvelope(),
       "federated.research-collab.dispatch.task.received",
     );
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await settle(() => r.published);
 
     expect(r.published.map((e) => e.type)).toEqual([
       "system.access.allowed",
@@ -1622,7 +1698,7 @@ describe("dispatch-listener — policy gating (C.3.1)", () => {
       makeReceivedEnvelope(),
       "federated.partner-only.dispatch.task.received",
     );
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await settle(() => r.published);
 
     expect(r.published.map((e) => e.type)).toEqual([
       "system.access.denied",
@@ -1674,7 +1750,7 @@ describe("dispatch-listener — policy gating (C.3.1)", () => {
       makeReceivedEnvelope(),
       "federated.andreas.meta-factory.dispatch.task.received",
     );
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await settle(() => r.published);
 
     expect(r.published.map((e) => e.type)).toEqual([
       "system.access.denied",
@@ -1720,7 +1796,7 @@ describe("dispatch-listener — policy gating (C.3.1)", () => {
       makeReceivedEnvelope(),
       "federated.research-collab.dispatch.task.received",
     );
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await settle(() => r.published);
 
     const denied = r.published.find((e) => e.type === "system.access.denied");
     expect(denied).toBeDefined();
@@ -1760,7 +1836,7 @@ describe("dispatch-listener — policy gating (C.3.1)", () => {
     await router.start();
 
     r.trigger(makeReceivedEnvelope(), CANONICAL_CORTEX_CHAT_SUBJECT);
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await settle(() => r.published);
 
     expect(r.published.map((e) => e.type)).toEqual([
       "system.access.allowed",
@@ -1806,7 +1882,7 @@ describe("dispatch-listener — policy gating (C.3.1)", () => {
       makeReceivedEnvelope(),
       "federated.research-collab.dispatch.task.received",
     );
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await settle(() => r.published);
 
     expect(captured).toHaveLength(1);
     expect(captured[0]!.intent.source_network).toBe("research-collab");
@@ -1835,7 +1911,7 @@ describe("dispatch-listener — policy gating (C.3.1)", () => {
       },
     ];
     r.trigger(env, CANONICAL_CORTEX_CHAT_SUBJECT);
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await settle(() => r.published);
 
     const denied = r.published.find((e) => e.type === "system.access.denied");
     expect(denied).toBeDefined();
@@ -1960,7 +2036,7 @@ describe("dispatch-listener — chain verification (cortex#320)", () => {
     env.signed_by = [runnerEd25519Stamp("did:mf:cortex")];
 
     r.trigger(env, CANONICAL_CORTEX_CHAT_SUBJECT);
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await settle(() => r.published);
 
     // Verifier accepts → policy gate sees verified principal → allow →
     // audit envelope + lifecycle pair.
@@ -1997,7 +2073,7 @@ describe("dispatch-listener — chain verification (cortex#320)", () => {
 
     // No signed_by on the envelope — legitimate adapter shape.
     r.trigger(makeReceivedEnvelope(), CANONICAL_CORTEX_CHAT_SUBJECT);
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await settle(() => r.published);
 
     // Verifier sees empty chain, returns `valid: true` (rejectEmpty=false).
     // Policy gate sees the empty-chain fallback principal id (agent_id)
@@ -2037,7 +2113,7 @@ describe("dispatch-listener — chain verification (cortex#320)", () => {
     env.signed_by = [runnerEd25519Stamp("did:mf:ghost")];
 
     r.trigger(env, CANONICAL_CORTEX_CHAT_SUBJECT);
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await settle(() => r.published);
 
     expect(r.published.map((e) => e.type)).toEqual([
       "system.access.denied",
@@ -2094,7 +2170,7 @@ describe("dispatch-listener — chain verification (cortex#320)", () => {
     await router.start();
 
     r.trigger(makeReceivedEnvelope(), CANONICAL_CORTEX_CHAT_SUBJECT);
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await settle(() => r.published);
 
     // Empty chain accepted; lifecycle flows.
     expect(r.published.map((e) => e.type)).toEqual([
@@ -2135,7 +2211,7 @@ describe("dispatch-listener — chain verification (cortex#320)", () => {
     const signed = await signEnvelope(base, privateKeyBase64, "did:mf:cortex");
 
     r.trigger(signed, CANONICAL_CORTEX_CHAT_SUBJECT);
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await settle(() => r.published);
 
     expect(r.published.map((e) => e.type)).toEqual([
       "system.access.allowed",
@@ -2183,7 +2259,7 @@ describe("dispatch-listener — chain verification (cortex#320)", () => {
     const signed = await signEnvelope(base, stackSeed, stackIdentity);
 
     r.trigger(signed, CANONICAL_CORTEX_CHAT_SUBJECT);
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await settle(() => r.published);
 
     // Verifier short-circuits on stackIdentity match (no registry hit
     // needed); crypto pass finds the stack registered in the bridged
@@ -2250,7 +2326,7 @@ describe("dispatch-listener — chain verification (cortex#320)", () => {
     };
 
     r.trigger(tampered, CANONICAL_CORTEX_CHAT_SUBJECT);
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await settle(() => r.published);
 
     expect(r.published.map((e) => e.type)).toEqual([
       "system.access.denied",
@@ -2292,7 +2368,7 @@ describe("dispatch-listener — chain verification (cortex#320)", () => {
     await router.start();
 
     r.trigger(makeReceivedEnvelope(), CANONICAL_CORTEX_CHAT_SUBJECT);
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await settle(() => r.published);
 
     // Both audit (system.access.denied) and lifecycle (dispatch.task.failed)
     // envelopes emitted; harness never constructed.
@@ -2404,7 +2480,7 @@ describe("dispatch-listener — Shape B re-sign on ingest (TC-1c #552)", () => {
     await router.start();
 
     r.trigger(gatewayInjectedEnvelope(), CANONICAL_CORTEX_CHAT_SUBJECT);
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await settle(() => r.published);
 
     // Allow path: audit + lifecycle envelopes flow (dispatch is not dropped).
     expect(r.published.map((e) => e.type)).toEqual([
@@ -2457,7 +2533,7 @@ describe("dispatch-listener — Shape B re-sign on ingest (TC-1c #552)", () => {
     await router.start();
 
     r.trigger(gatewayInjectedEnvelope(), CANONICAL_CORTEX_CHAT_SUBJECT);
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await settle(() => r.published);
 
     // Dispatch is NOT dropped — allow + lifecycle flow.
     expect(r.published.map((e) => e.type)).toEqual([
@@ -2528,7 +2604,7 @@ describe("dispatch-listener — Shape B re-sign on ingest (TC-1c #552)", () => {
     expect(chainOf(preSigned)).toHaveLength(1);
 
     r.trigger(preSigned, CANONICAL_CORTEX_CHAT_SUBJECT);
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await settle(() => r.published);
 
     // Allow + lifecycle (own-stack short-circuit accepts the single stamp).
     expect(r.published.map((e) => e.type)).toEqual([
@@ -2590,7 +2666,7 @@ describe("dispatch-listener — Shape B re-sign on ingest (TC-1c #552)", () => {
     await router.start();
 
     r.trigger(gatewayInjectedEnvelope(), CANONICAL_CORTEX_CHAT_SUBJECT);
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await settle(() => r.published);
 
     // Dispatch is NOT dropped — the sign failure fell through to the policy
     // gate and the harness ran (allow + lifecycle).
@@ -2689,7 +2765,7 @@ describe("dispatch-listener — originator (cortex#346 / myelin#161)", () => {
     };
 
     r.trigger(env, CANONICAL_CORTEX_CHAT_SUBJECT);
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await settle(() => r.published);
 
     expect(captured).toHaveLength(1);
     expect(captured[0]!.principalId).toBe("alice");
@@ -2742,7 +2818,7 @@ describe("dispatch-listener — originator (cortex#346 / myelin#161)", () => {
     // No env.originator on purpose — legacy envelope.
 
     r.trigger(env, CANONICAL_CORTEX_CHAT_SUBJECT);
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await settle(() => r.published);
 
     expect(captured).toHaveLength(1);
     expect(captured[0]!.principalId).toBe("cortex");
@@ -2790,7 +2866,7 @@ describe("dispatch-listener — originator (cortex#346 / myelin#161)", () => {
       makeReceivedEnvelope(),
       CANONICAL_CORTEX_CHAT_SUBJECT,
     );
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await settle(() => r.published);
 
     expect(captured).toHaveLength(1);
     expect(captured[0]!.principalId).toBe("cortex");
@@ -2851,7 +2927,7 @@ describe("dispatch-listener — originator (cortex#346 / myelin#161)", () => {
     };
 
     r.trigger(tampered, CANONICAL_CORTEX_CHAT_SUBJECT);
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await settle(() => r.published);
 
     expect(r.published.map((e) => e.type)).toEqual([
       "system.access.denied",
@@ -2934,7 +3010,7 @@ describe("dispatch-listener — originator DID resolution (cortex#486)", () => {
     };
 
     r.trigger(env, CANONICAL_CORTEX_CHAT_SUBJECT);
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await settle(() => r.published);
 
     expect(captured).toHaveLength(1);
     expect(captured[0]!.principalId).toBe("andreas");
@@ -2995,7 +3071,7 @@ describe("dispatch-listener — originator DID resolution (cortex#486)", () => {
     };
 
     r.trigger(env, CANONICAL_CORTEX_CHAT_SUBJECT);
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await settle(() => r.published);
 
     expect(captured).toHaveLength(1);
     // Listener strips `did:mf:` and forwards the raw tail verbatim.
@@ -3044,7 +3120,7 @@ describe("dispatch-listener — stage tracing (cortex#492)", () => {
       await listener.start();
 
       r.trigger(makeReceivedEnvelope(), CANONICAL_CORTEX_CHAT_SUBJECT);
-      await new Promise((resolve) => setTimeout(resolve, 10));
+      await settle(() => r.published);
 
       // Lifecycle + audit envelopes still flow; ZERO trace envelopes.
       expect(traceEnvelopes(r.published)).toHaveLength(0);
@@ -3074,7 +3150,7 @@ describe("dispatch-listener — stage tracing (cortex#492)", () => {
       await listener.start();
 
       r.trigger(makeReceivedEnvelope(), CANONICAL_CORTEX_CHAT_SUBJECT);
-      await new Promise((resolve) => setTimeout(resolve, 10));
+      await settle(() => r.published);
 
       expect(traceEnvelopes(r.published).length).toBeGreaterThan(0);
     } finally {
@@ -3096,7 +3172,7 @@ describe("dispatch-listener — stage tracing (cortex#492)", () => {
     await listener.start();
 
     r.trigger(makeReceivedEnvelope(), CANONICAL_CORTEX_CHAT_SUBJECT);
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await settle(() => r.published);
 
     // No trustResolver wired → chain-verify-start / chain-verified stages
     // are skipped (the verifier is the only legitimate skip path). Every
@@ -3146,7 +3222,7 @@ describe("dispatch-listener — stage tracing (cortex#492)", () => {
       makeReceivedEnvelope(),
       "local.someoneelse.tasks.@did-mf-other.chat",
     );
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await settle(() => r.published);
 
     expect(traceStages(r.published)).toEqual(["received", "subject-rejected"]);
     const rejected = traceEnvelopes(r.published).find(
@@ -3174,7 +3250,7 @@ describe("dispatch-listener — stage tracing (cortex#492)", () => {
     await listener.start();
 
     r.trigger(makeReceivedEnvelope(), CANONICAL_CORTEX_CHAT_SUBJECT);
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await settle(() => r.published);
 
     const stages = traceStages(r.published);
     expect(stages).toEqual([
@@ -3205,7 +3281,7 @@ describe("dispatch-listener — stage tracing (cortex#492)", () => {
     await listener.start();
 
     r.trigger(makeReceivedEnvelope(), CANONICAL_CORTEX_CHAT_SUBJECT);
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await settle(() => r.published);
 
     expect(traceStages(r.published)).toEqual([
       "received",
@@ -3249,7 +3325,7 @@ describe("dispatch-listener — stage tracing (cortex#492)", () => {
 
     // Empty signed_by[] (adapter-originated) → verification passes.
     r.trigger(makeReceivedEnvelope(), CANONICAL_CORTEX_CHAT_SUBJECT);
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await settle(() => r.published);
 
     const stages = traceStages(r.published);
     // chain-verify-start lands immediately before chain-verified, between
@@ -3290,7 +3366,7 @@ describe("dispatch-listener — stage tracing (cortex#492)", () => {
     // Subject's assistant segment (@did-mf-other) won't match the
     // envelope target (did:mf:cortex) → mismatch.
     r.trigger(env, "local.metafactory.tasks.@did-mf-other.chat");
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await settle(() => r.published);
 
     const stages = traceStages(r.published);
     // received → subject-matched (tasks.*.> matches) → parsed →

--- a/src/surface/mc/__tests__/work-item-detail.test.ts
+++ b/src/surface/mc/__tests__/work-item-detail.test.ts
@@ -1,10 +1,7 @@
 /**
  * G-1113.D.5 — work-item detail projection (api/work-item-detail.ts).
  */
-import { describe, it, expect, afterEach } from "bun:test";
-import { join } from "path";
-import { tmpdir } from "os";
-import { rmSync, existsSync } from "fs";
+import { describe, it, expect } from "bun:test";
 import { initDatabase } from "../db/init";
 import { upsertPlan, upsertPlanPhase } from "../db/plans";
 import { upsertWorkItem } from "../db/work-items";
@@ -37,12 +34,13 @@ const review: Review = {
 };
 
 describe("getWorkItemDetail (D.5)", () => {
-  const paths: string[] = [];
-  afterEach(() => { for (const p of paths) if (existsSync(p)) rmSync(p); paths.length = 0; });
+  // In-memory DB (cortex#771): the prior on-disk tmp-file path ran the full
+  // schema + WAL journal on disk, and under full-suite parallel disk I/O the
+  // synchronous init occasionally blew past the 5s per-test timeout (a pure
+  // I/O-contention flake, no logic race). `:memory:` runs the same schema with
+  // zero filesystem contention and needs no afterEach cleanup.
   function freshDb() {
-    const p = join(tmpdir(), `wid-${Date.now()}-${Math.random().toString(36).slice(2)}.db`);
-    paths.push(p);
-    return initDatabase(p);
+    return initDatabase(":memory:");
   }
 
   it("projects work item + plan/phase context + linked PRs with reviews", () => {

--- a/src/surface/mc/db/init.ts
+++ b/src/surface/mc/db/init.ts
@@ -14,9 +14,16 @@ import { COLUMN_ADD_MIGRATIONS, REBUILD_MIGRATIONS, SCHEMA_SQL } from "./schema"
  * Creates parent directories if they don't exist.
  */
 export function initDatabase(dbPath: string): Database {
-  // TC-4b (cortex#637): the Mission Control SQLite dir holds event rows with
-  // prompt/command/tool previews — owner-only (0o700), never world-readable.
-  mkdirSync(dirname(dbPath), { recursive: true, mode: 0o700 });
+  // In-memory databases (`:memory:`) have no filesystem path to secure or
+  // create — used by tests that want the full schema without on-disk WAL I/O
+  // (which contends under parallel test runs; cortex#771).
+  const inMemory = dbPath === ":memory:";
+
+  if (!inMemory) {
+    // TC-4b (cortex#637): the Mission Control SQLite dir holds event rows with
+    // prompt/command/tool previews — owner-only (0o700), never world-readable.
+    mkdirSync(dirname(dbPath), { recursive: true, mode: 0o700 });
+  }
 
   const db = new Database(dbPath, { create: true });
   db.run("PRAGMA journal_mode = WAL");


### PR DESCRIPTION
Closes #771

## Root cause

The full-suite Test gate failed reliably in CI but passed in isolation — a concurrency/timing flake blocking real PRs (including a security PR).

The headline flake — `dispatch-listener — Shape B re-sign on ingest (b)` — was **not** shared crypto/keystore/registry state. It was a fixed `setTimeout(resolve, 10)` racing **off-thread WebCrypto**.

The dispatch path runs **chain-verify → re-sign → policy → harness** before pushing onto `r.published[]`. Chain-verify and re-sign call myelin's `signAsync`/`verifyAsync`, which hash via WebCrypto `subtle.digest` — **off the JS thread**. The test then slept a fixed 10ms and asserted. Under full-suite concurrency Bun runs many test FILES in parallel, the event loop is saturated, the off-thread crypto resolves *after* the 10ms timer, and the assertion reads a half-populated (often empty) `published[]`:
- `expected array/object, received undefined` on the audit envelope's `signed_by[]`
- `toEqual([...])` mismatches on the lifecycle sequence

No shared mutable state, no product bug — `src/runner/dispatch-listener.ts` is unchanged.

## Fix — wait for an observable terminal condition, never a fixed duration

- **dispatch-listener** (the named flake): replaced all 61 fixed `setTimeout(resolve, 10)` sleeps with a `settle()` helper that waits for the **terminal** lifecycle/denial envelope (`dispatch.task.{completed,failed,aborted}` / `system.access.denied`) to actually appear. The terminal only lands after the *entire* async path (including all WebCrypto) has run, so it cannot return mid-stream. Drop tests (which publish nothing) observe a bounded window then conclude. Deterministic; nothing serialized.

Sibling timing flakes surfaced during verification and fixed in the same spirit:

- **ConfigWatcher + AgentsDirectoryWatcher** (the issue's "ConfigWatcher file-watch timing test"): `pollUntil` default `2000ms → 4000ms` (still inside the per-test timeout) for `fs.watch` + debounce under load; the three positive `file events` tests now poll for the semantic event instead of a fixed sleep; unique `/tmp` fixture paths so concurrent test files can't unlink each other's config mid-watch.
- **Slack** `mid-drain arrivals preserve arrival order`: poll for the drained count instead of a fixed 30ms.
- **work-item-detail (D.5)**: in-memory SQLite (`:memory:`) instead of an on-disk tmp DB — eliminates the WAL disk-I/O contention that blew past the 5s per-test timeout under parallel load. (`initDatabase` now skips the filesystem mkdir for `:memory:`.)
- **bunfig.toml**: global per-test timeout `5s → 20s` — defense-in-depth headroom for subprocess (`cortex` / `bun` CLI) and `fs.watch` tests on a loaded CI runner. Does **not** mask the assertion races (fixed at source).

## Verification

- **12/12 consecutive clean full-suite runs green** (`4747 pass / 0 fail`).
- **80/80** on the targeted high-concurrency repro (`dispatch-listener` + 6 crypto-heavy files) that previously failed ~1-in-10 to 1-in-3.
- `bunx tsc --noEmit` 0 · `bun run lint:errors` 0 · `check-carveouts.sh` PASS.

Nothing was serialized / run-in-band — every fix waits on a real observable condition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)