### PR TITLE
refactor: G-2a/G-3a #774 — CORTEX_*-native EventLogger env path (GROVE_* read-fallback retained)

### DIFF
--- a/src/cli/cldyo-live
+++ b/src/cli/cldyo-live
@@ -31,6 +31,13 @@ LIVE_NAME="${OPERATOR_NAME:-${DISPLAY_NAME:-$(whoami)}}"
 BOT_NAME="${DISPLAY_NAME:-${AGENT_NAME:-Ivy}}"
 
 export CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1
+# cortex#774 (G-2a/G-3a): export the canonical CORTEX_* instrumentation names.
+# The legacy GROVE_* exports are kept alongside during the transition so any
+# unmigrated reader still resolves; both are dropped once the GROVE_* read
+# fallbacks retire (a future PR, after MIG-8 is confirmed closed).
+export CORTEX_CHANNEL="${1:-${LIVE_ID}}"
+export CORTEX_AGENT_NAME="${BOT_NAME}"
+export CORTEX_AGENT_ID="${LIVE_ID}"
 export GROVE_CHANNEL="${1:-${LIVE_ID}}"
 export GROVE_AGENT_NAME="${BOT_NAME}"
 export GROVE_AGENT_ID="${LIVE_ID}"

--- a/src/runner/__tests__/cc-session-env.test.ts
+++ b/src/runner/__tests__/cc-session-env.test.ts
@@ -1,0 +1,61 @@
+import { describe, test, expect } from "bun:test";
+import { buildSessionEnv } from "../cc-session";
+
+describe("buildSessionEnv — G-2a/G-3a (cortex#774) sets CORTEX_* instrumentation names", () => {
+  const baseEnv = { PATH: "/usr/bin" } as Record<string, string>;
+
+  test("sets the CORTEX_* names from the session opts", () => {
+    const env = buildSessionEnv(baseEnv, {
+      groveChannel: "ivy",
+      groveNetwork: "metafactory",
+      agentName: "Ivy",
+      agentId: "ivy-001",
+      project: "cortex",
+      entity: "issue/774",
+      principal: "andreas",
+    });
+
+    expect(env.CORTEX_CHANNEL).toBe("ivy");
+    expect(env.CORTEX_NETWORK).toBe("metafactory");
+    expect(env.CORTEX_AGENT_NAME).toBe("Ivy");
+    expect(env.CORTEX_AGENT_ID).toBe("ivy-001");
+    expect(env.CORTEX_PROJECT).toBe("cortex");
+    expect(env.CORTEX_ENTITY).toBe("issue/774");
+    expect(env.CORTEX_PRINCIPAL).toBe("andreas");
+  });
+
+  test("does NOT set the legacy GROVE_* instrumentation names", () => {
+    const env = buildSessionEnv(baseEnv, {
+      groveChannel: "ivy",
+      groveNetwork: "metafactory",
+      agentName: "Ivy",
+      agentId: "ivy-001",
+      project: "cortex",
+      entity: "issue/774",
+      principal: "andreas",
+    });
+
+    expect(env.GROVE_CHANNEL).toBeUndefined();
+    expect(env.GROVE_NETWORK).toBeUndefined();
+    expect(env.GROVE_AGENT_NAME).toBeUndefined();
+    expect(env.GROVE_AGENT_ID).toBeUndefined();
+    expect(env.GROVE_PROJECT).toBeUndefined();
+    expect(env.GROVE_ENTITY).toBeUndefined();
+    expect(env.GROVE_OPERATOR).toBeUndefined();
+  });
+
+  test("omits unset optional fields", () => {
+    const env = buildSessionEnv(baseEnv, {
+      groveChannel: "ivy",
+    });
+    expect(env.CORTEX_CHANNEL).toBe("ivy");
+    expect(env.CORTEX_NETWORK).toBeUndefined();
+    expect(env.CORTEX_AGENT_NAME).toBeUndefined();
+    expect(env.CORTEX_PRINCIPAL).toBeUndefined();
+  });
+
+  test("preserves the inherited base env", () => {
+    const env = buildSessionEnv(baseEnv, { groveChannel: "ivy" });
+    expect(env.PATH).toBe("/usr/bin");
+  });
+});

--- a/src/runner/__tests__/cc-session-isolation.test.ts
+++ b/src/runner/__tests__/cc-session-isolation.test.ts
@@ -99,7 +99,8 @@ describe("CCSession — settings isolation (default ON)", () => {
       expect(env.CLAUDE_CODE_EXTRA_SETTINGS).toBeUndefined();
       expect(env.CLAUDE_HOOKS_PATH).toBeUndefined();
       // Cortex's own pipeline var (set from groveChannel) survives.
-      expect(env.GROVE_CHANNEL).toBe("test");
+      // cortex#774: the setter now writes the canonical CORTEX_CHANNEL name.
+      expect(env.CORTEX_CHANNEL).toBe("test");
     } finally {
       restore();
       process.env.CLAUDE_CODE_EXTRA_SETTINGS = prev.CLAUDE_CODE_EXTRA_SETTINGS;

--- a/src/runner/cc-session.ts
+++ b/src/runner/cc-session.ts
@@ -112,6 +112,46 @@ export interface CCSessionResult {
   abortReason?: "timeout";
 }
 
+/**
+ * cortex#774 (G-2a/G-3a) — layer cortex's instrumentation env vars onto the
+ * (already-scoped) base env for a spawned CC session.
+ *
+ * Sets the canonical `CORTEX_*` names — `CORTEX_CHANNEL`, `CORTEX_NETWORK`,
+ * `CORTEX_AGENT_NAME`, `CORTEX_AGENT_ID`, `CORTEX_PROJECT`, `CORTEX_ENTITY`,
+ * and `CORTEX_PRINCIPAL` — that the EventLogger / GroveContext hooks read.
+ * The legacy `GROVE_*` instrumentation names are NO LONGER set here; the
+ * hooks retain a `GROVE_*` read-fallback (see `surface-env.ts` /
+ * `principal-env.ts`) so external setters still on `GROVE_*` keep resolving
+ * during the transition.
+ *
+ * Pure function: does not mutate `baseEnv`. Extracted from `start()` so the
+ * spawned env is unit-testable without invoking the `claude` binary.
+ */
+export function buildSessionEnv(
+  baseEnv: Record<string, string>,
+  opts: Pick<
+    CCSessionOpts,
+    | "groveChannel"
+    | "groveNetwork"
+    | "agentName"
+    | "agentId"
+    | "project"
+    | "entity"
+    | "principal"
+  >,
+): Record<string, string> {
+  return {
+    ...baseEnv,
+    ...(opts.groveChannel && { CORTEX_CHANNEL: opts.groveChannel }),
+    ...(opts.groveNetwork && { CORTEX_NETWORK: opts.groveNetwork }),
+    ...(opts.agentName && { CORTEX_AGENT_NAME: opts.agentName }),
+    ...(opts.agentId && { CORTEX_AGENT_ID: opts.agentId }),
+    ...(opts.project && { CORTEX_PROJECT: opts.project }),
+    ...(opts.entity && { CORTEX_ENTITY: opts.entity }),
+    ...(opts.principal && { CORTEX_PRINCIPAL: opts.principal }),
+  };
+}
+
 export class CCSession extends EventEmitter {
   private proc: ReturnType<typeof Bun.spawn> | null = null;
   private timeoutId: Timer | null = null;
@@ -213,14 +253,7 @@ export class CCSession extends EventEmitter {
       : { ...(process.env as Record<string, string>) };
 
     const env: Record<string, string> = {
-      ...baseEnv,
-      ...(this.opts.groveChannel && { GROVE_CHANNEL: this.opts.groveChannel }),
-      ...(this.opts.groveNetwork && { GROVE_NETWORK: this.opts.groveNetwork }),
-      ...(this.opts.agentName && { GROVE_AGENT_NAME: this.opts.agentName }),
-      ...(this.opts.agentId && { GROVE_AGENT_ID: this.opts.agentId }),
-      ...(this.opts.project && { GROVE_PROJECT: this.opts.project }),
-      ...(this.opts.entity && { GROVE_ENTITY: this.opts.entity }),
-      ...(this.opts.principal && { GROVE_OPERATOR: this.opts.principal }),
+      ...buildSessionEnv(baseEnv, this.opts),
       // cortex#710 — pass the per-skill grant list to the Skill Guard hook.
       // Only set when the curated settings actually registered the hook
       // (hasSkillGrants), so the env var and the hook move atomically. Layered

--- a/src/taps/cc-events/cloud-publisher.ts
+++ b/src/taps/cc-events/cloud-publisher.ts
@@ -236,7 +236,7 @@ export class CloudPublisher {
     if (!networkConfig) {
       console.warn(
         `cloud-publisher: unknown network "${networkId}" — skipping ${events.length} event(s). ` +
-        `Check networks[] config or ensure GROVE_NETWORK matches a configured network.`,
+        `Check networks[] config or ensure CORTEX_NETWORK (legacy GROVE_NETWORK) matches a configured network.`,
       );
       return;
     }

--- a/src/taps/cc-events/hooks/EventLogger.hook.ts
+++ b/src/taps/cc-events/hooks/EventLogger.hook.ts
@@ -2,7 +2,8 @@
 /**
  * T-2.1 + T-2.2 + T-2.3: EventLogger Hook
  * Captures raw events to JSONL. Zero external dependencies beyond filesystem.
- * Only active when GROVE_CHANNEL env var is set (session scoping).
+ * Only active when CORTEX_CHANNEL (legacy GROVE_CHANNEL) env var is set
+ * (session scoping).
  */
 
 import { appendFileSync, mkdirSync, chmodSync, existsSync, readFileSync } from "fs";
@@ -10,6 +11,7 @@ import { join } from "path";
 import { createRawEvent, type RawEvent } from "./lib/event-types";
 import { mapHookToEventType, EVENT_TYPES } from "./lib/event-taxonomy";
 import { resolvePrincipalEnv } from "./lib/principal-env";
+import { resolveSurfaceEnv } from "./lib/surface-env";
 
 // =============================================================================
 // Hook input shape — what Claude Code writes to stdin per hook firing.
@@ -80,17 +82,20 @@ const INGEST_URL = "http://localhost:8766/api/events/ingest";
 // Session Scoping (T-2.2)
 // =============================================================================
 
-const groveChannel = process.env.GROVE_CHANNEL;
+// cortex#774: read CORTEX_* first, fall back to legacy GROVE_* (see
+// surface-env.ts). The session is instrumented when a channel resolves
+// from either tier.
+const groveChannel = resolveSurfaceEnv("CHANNEL");
 if (!groveChannel) {
-  process.exit(0); // Not a Grove session — silent exit
+  process.exit(0); // Not an instrumented session — silent exit
 }
 
-const groveNetwork = process.env.GROVE_NETWORK;
-const groveProject = process.env.GROVE_PROJECT;
-const groveEntity = process.env.GROVE_ENTITY;
+const groveNetwork = resolveSurfaceEnv("NETWORK");
+const groveProject = resolveSurfaceEnv("PROJECT");
+const groveEntity = resolveSurfaceEnv("ENTITY");
 // R9 (cortex#388 PR-3): the human-the-stack-owner concept is now `principal`.
 // Read `CORTEX_PRINCIPAL` with a compat fallback to the legacy
-// `CORTEX_OPERATOR` / `GROVE_OPERATOR` names (see principal-env.ts).
+// `GROVE_OPERATOR` name (see principal-env.ts).
 const principal = resolvePrincipalEnv();
 
 // =============================================================================

--- a/src/taps/cc-events/hooks/GroveContext.hook.ts
+++ b/src/taps/cc-events/hooks/GroveContext.hook.ts
@@ -1,22 +1,27 @@
 #!/usr/bin/env bun
 /**
  * G-501: GroveContext Hook
- * Injects network identity and Grove-specific context into Claude Code sessions.
- * Only active when GROVE_CHANNEL env var is set (session scoping).
+ * Injects network identity and session context into Claude Code sessions.
+ * Only active when CORTEX_CHANNEL (legacy GROVE_CHANNEL) env var is set
+ * (session scoping).
  */
+
+import { resolveSurfaceEnv } from "./lib/surface-env";
 
 // =============================================================================
 // Session Scoping
 // =============================================================================
 
-const groveChannel = process.env.GROVE_CHANNEL;
+// cortex#774: read CORTEX_* first, fall back to legacy GROVE_* (see
+// surface-env.ts).
+const groveChannel = resolveSurfaceEnv("CHANNEL");
 if (!groveChannel) {
-  process.exit(0); // Not a Grove session — silent exit
+  process.exit(0); // Not an instrumented session — silent exit
 }
 
-const groveNetwork = process.env.GROVE_NETWORK;
-const groveAgentId = process.env.GROVE_AGENT_ID;
-const groveAgentName = process.env.GROVE_AGENT_NAME;
+const groveNetwork = resolveSurfaceEnv("NETWORK");
+const groveAgentId = resolveSurfaceEnv("AGENT_ID");
+const groveAgentName = resolveSurfaceEnv("AGENT_NAME");
 
 // =============================================================================
 // Context Injection

--- a/src/taps/cc-events/hooks/__tests__/grove-context.test.ts
+++ b/src/taps/cc-events/hooks/__tests__/grove-context.test.ts
@@ -93,4 +93,47 @@ describe("GroveContext.hook", () => {
     const output = JSON.parse(result.stdout.trim());
     expect(output.prompt).toContain("Network: metafactory");
   });
+
+  // G-2a/G-3a (cortex#774) — CORTEX_*-native read path with GROVE_* fallback.
+  describe("CORTEX_* env path (cortex#774)", () => {
+    test("injects context when CORTEX_CHANNEL is set", () => {
+      const result = runHook({
+        CORTEX_CHANNEL: "cortex-channel",
+        CORTEX_NETWORK: "metafactory",
+        CORTEX_AGENT_NAME: "Ivy",
+        CORTEX_AGENT_ID: "ivy-001",
+      });
+
+      expect(result.status).toBe(0);
+      const output = JSON.parse(result.stdout.trim());
+      expect(output.prompt).toContain("Channel: cortex-channel");
+      expect(output.prompt).toContain("Network: metafactory");
+      expect(output.prompt).toContain("Agent Name: Ivy");
+      expect(output.prompt).toContain("Agent ID: ivy-001");
+    });
+
+    test("CORTEX_CHANNEL wins over GROVE_CHANNEL", () => {
+      const result = runHook({
+        CORTEX_CHANNEL: "cortex-channel",
+        GROVE_CHANNEL: "grove-channel",
+      });
+
+      expect(result.status).toBe(0);
+      const output = JSON.parse(result.stdout.trim());
+      expect(output.prompt).toContain("Channel: cortex-channel");
+      expect(output.prompt).not.toContain("Channel: grove-channel");
+    });
+
+    test("still resolves with only GROVE_* set (fallback intact)", () => {
+      const result = runHook({
+        GROVE_CHANNEL: "grove-only",
+        GROVE_NETWORK: "metafactory",
+      });
+
+      expect(result.status).toBe(0);
+      const output = JSON.parse(result.stdout.trim());
+      expect(output.prompt).toContain("Channel: grove-only");
+      expect(output.prompt).toContain("Network: metafactory");
+    });
+  });
 });

--- a/src/taps/cc-events/hooks/lib/__tests__/event-types-env.test.ts
+++ b/src/taps/cc-events/hooks/lib/__tests__/event-types-env.test.ts
@@ -1,0 +1,71 @@
+import { test, expect, describe, afterEach } from "bun:test";
+import { createRawEvent } from "../event-types";
+
+/**
+ * G-2a/G-3a (cortex#774) — createRawEvent reads the surface instrumentation
+ * fields from CORTEX_* first, falling back to the legacy GROVE_* names.
+ */
+describe("createRawEvent — CORTEX_* env resolution with GROVE_* fallback", () => {
+  afterEach(() => {
+    delete process.env.CORTEX_CHANNEL;
+    delete process.env.CORTEX_AGENT_ID;
+    delete process.env.CORTEX_AGENT_NAME;
+    delete process.env.CORTEX_NETWORK;
+    delete process.env.GROVE_CHANNEL;
+    delete process.env.GROVE_AGENT_ID;
+    delete process.env.GROVE_AGENT_NAME;
+    delete process.env.GROVE_NETWORK;
+  });
+
+  test("reads CORTEX_* names when set", () => {
+    process.env.CORTEX_CHANNEL = "ivy";
+    process.env.CORTEX_AGENT_ID = "ivy-001";
+    process.env.CORTEX_AGENT_NAME = "Ivy";
+    process.env.CORTEX_NETWORK = "metafactory";
+
+    const event = createRawEvent("agent.task.started", "Stop", {}, {
+      sessionId: "s1",
+    });
+
+    expect(event.grove_channel).toBe("ivy");
+    expect(event.agent_id).toBe("ivy-001");
+    expect(event.agent_name).toBe("Ivy");
+    expect(event.network_id).toBe("metafactory");
+  });
+
+  test("falls back to GROVE_* names when only GROVE_* is set", () => {
+    process.env.GROVE_CHANNEL = "ivy";
+    process.env.GROVE_AGENT_ID = "ivy-001";
+    process.env.GROVE_AGENT_NAME = "Ivy";
+    process.env.GROVE_NETWORK = "metafactory";
+
+    const event = createRawEvent("agent.task.started", "Stop", {}, {
+      sessionId: "s1",
+    });
+
+    expect(event.grove_channel).toBe("ivy");
+    expect(event.agent_id).toBe("ivy-001");
+    expect(event.agent_name).toBe("Ivy");
+    expect(event.network_id).toBe("metafactory");
+  });
+
+  test("CORTEX_* wins over GROVE_* when both are set", () => {
+    process.env.CORTEX_CHANNEL = "ivy";
+    process.env.GROVE_CHANNEL = "legacy";
+
+    const event = createRawEvent("agent.task.started", "Stop", {}, {
+      sessionId: "s1",
+    });
+
+    expect(event.grove_channel).toBe("ivy");
+  });
+
+  test("explicit options still win over both env tiers", () => {
+    process.env.CORTEX_CHANNEL = "ivy";
+    const event = createRawEvent("agent.task.started", "Stop", {}, {
+      sessionId: "s1",
+      groveChannel: "explicit",
+    });
+    expect(event.grove_channel).toBe("explicit");
+  });
+});

--- a/src/taps/cc-events/hooks/lib/__tests__/surface-env.test.ts
+++ b/src/taps/cc-events/hooks/lib/__tests__/surface-env.test.ts
@@ -1,0 +1,62 @@
+import { test, expect, describe } from "bun:test";
+import { resolveSurfaceEnv } from "../surface-env";
+
+describe("resolveSurfaceEnv — G-2a/G-3a (cortex#774) CORTEX_* with GROVE_* read-fallback", () => {
+  test("returns the canonical CORTEX_* value when set", () => {
+    const env = { CORTEX_CHANNEL: "ivy" };
+    expect(resolveSurfaceEnv("CHANNEL", env)).toBe("ivy");
+  });
+
+  test("canonical CORTEX_* name wins over the legacy GROVE_* name", () => {
+    const env = { CORTEX_CHANNEL: "ivy", GROVE_CHANNEL: "legacy" };
+    expect(resolveSurfaceEnv("CHANNEL", env)).toBe("ivy");
+  });
+
+  test("falls back to the legacy GROVE_* name when only GROVE_* is set", () => {
+    const env = { GROVE_CHANNEL: "legacy" };
+    expect(resolveSurfaceEnv("CHANNEL", env)).toBe("legacy");
+  });
+
+  test("returns undefined when neither tier is set", () => {
+    expect(resolveSurfaceEnv("CHANNEL", {})).toBeUndefined();
+  });
+
+  test("resolves each instrumentation field from CORTEX_* first", () => {
+    const env = {
+      CORTEX_CHANNEL: "ivy",
+      CORTEX_NETWORK: "metafactory",
+      CORTEX_AGENT_NAME: "Ivy",
+      CORTEX_AGENT_ID: "ivy-001",
+      CORTEX_PROJECT: "cortex",
+      CORTEX_ENTITY: "issue/774",
+    };
+    expect(resolveSurfaceEnv("CHANNEL", env)).toBe("ivy");
+    expect(resolveSurfaceEnv("NETWORK", env)).toBe("metafactory");
+    expect(resolveSurfaceEnv("AGENT_NAME", env)).toBe("Ivy");
+    expect(resolveSurfaceEnv("AGENT_ID", env)).toBe("ivy-001");
+    expect(resolveSurfaceEnv("PROJECT", env)).toBe("cortex");
+    expect(resolveSurfaceEnv("ENTITY", env)).toBe("issue/774");
+  });
+
+  test("falls back per-field to GROVE_* when only GROVE_* is set", () => {
+    const env = {
+      GROVE_CHANNEL: "ivy",
+      GROVE_NETWORK: "metafactory",
+      GROVE_AGENT_NAME: "Ivy",
+      GROVE_AGENT_ID: "ivy-001",
+      GROVE_PROJECT: "cortex",
+      GROVE_ENTITY: "issue/774",
+    };
+    expect(resolveSurfaceEnv("CHANNEL", env)).toBe("ivy");
+    expect(resolveSurfaceEnv("NETWORK", env)).toBe("metafactory");
+    expect(resolveSurfaceEnv("AGENT_NAME", env)).toBe("Ivy");
+    expect(resolveSurfaceEnv("AGENT_ID", env)).toBe("ivy-001");
+    expect(resolveSurfaceEnv("PROJECT", env)).toBe("cortex");
+    expect(resolveSurfaceEnv("ENTITY", env)).toBe("issue/774");
+  });
+
+  test("preserves an explicit empty string from CORTEX_* (defined wins)", () => {
+    const env = { CORTEX_CHANNEL: "", GROVE_CHANNEL: "legacy" };
+    expect(resolveSurfaceEnv("CHANNEL", env)).toBe("");
+  });
+});

--- a/src/taps/cc-events/hooks/lib/event-types.ts
+++ b/src/taps/cc-events/hooks/lib/event-types.ts
@@ -4,6 +4,7 @@
  */
 
 import { z } from "zod/v4";
+import { resolveSurfaceEnv } from "./surface-env";
 
 // =============================================================================
 // Raw Event (PAI-internal, never exposed to consumers)
@@ -66,10 +67,11 @@ export function createRawEvent(
     event_type: eventType,
     timestamp: new Date().toISOString(),
     session_id: options?.sessionId ?? process.env.CLAUDE_SESSION_ID ?? "unknown",
-    grove_channel: options?.groveChannel ?? process.env.GROVE_CHANNEL,
-    agent_id: options?.agentId ?? process.env.GROVE_AGENT_ID,
-    agent_name: options?.agentName ?? process.env.GROVE_AGENT_NAME,
-    network_id: options?.networkId ?? process.env.GROVE_NETWORK,
+    // cortex#774: read CORTEX_* first, fall back to legacy GROVE_*.
+    grove_channel: options?.groveChannel ?? resolveSurfaceEnv("CHANNEL"),
+    agent_id: options?.agentId ?? resolveSurfaceEnv("AGENT_ID"),
+    agent_name: options?.agentName ?? resolveSurfaceEnv("AGENT_NAME"),
+    network_id: options?.networkId ?? resolveSurfaceEnv("NETWORK"),
     source: {
       hook,
       tool_name: options?.toolName,

--- a/src/taps/cc-events/hooks/lib/surface-env.ts
+++ b/src/taps/cc-events/hooks/lib/surface-env.ts
@@ -1,0 +1,50 @@
+/**
+ * G-2a/G-3a (cortex#774) — surface instrumentation env-var resolver. The
+ * `GROVE_*` → `CORTEX_*` namespace migration renames the EventLogger
+ * instrumentation env vars (channel / network / agent-name / agent-id /
+ * project / entity) to the `CORTEX_*` prefix.
+ *
+ * NON-BREAKING transition: readers prefer `CORTEX_{field}` and retain a
+ * read-fallback to the legacy `GROVE_{field}` name so any external setter
+ * still on `GROVE_*` keeps resolving during the cutover. The fallback is
+ * removed only once MIG-8 is confirmed closed and external setters are
+ * audited (deferred to a future PR).
+ *
+ * NOTE: the `principal`-the-human field is NOT handled here — it has its own
+ * resolver (`principal-env.ts`) with a different chain
+ * (`CORTEX_PRINCIPAL` → `GROVE_OPERATOR`).
+ */
+
+/** Instrumentation field suffixes carried by both the CORTEX_* and GROVE_* names. */
+export type SurfaceField =
+  | "CHANNEL"
+  | "NETWORK"
+  | "AGENT_NAME"
+  | "AGENT_ID"
+  | "PROJECT"
+  | "ENTITY";
+
+/**
+ * Resolve a surface instrumentation env var.
+ *
+ * Lookup order (first defined wins):
+ *   1. `CORTEX_{field}` — the canonical name.
+ *   2. `GROVE_{field}`  — retained read-fallback for the transition window.
+ *
+ * @param field the instrumentation field, e.g. `"CHANNEL"` for
+ *   `CORTEX_CHANNEL` / `GROVE_CHANNEL`.
+ * @param env the environment to read; defaults to `process.env`. Injectable
+ *   for tests.
+ * @returns the resolved value, or `undefined` when neither tier is set.
+ */
+export function resolveSurfaceEnv(
+  field: SurfaceField,
+  env: Record<string, string | undefined> = process.env,
+): string | undefined {
+  const canonical = env[`CORTEX_${field}`];
+  if (canonical !== undefined) return canonical;
+
+  // Pre-cortex tier. No warning here: the GROVE_* → CORTEX_* namespace
+  // rename is a transition with its own deprecation window (cortex#774).
+  return env[`GROVE_${field}`];
+}

--- a/src/taps/cc-events/lib/policy-engine.ts
+++ b/src/taps/cc-events/lib/policy-engine.ts
@@ -4,6 +4,7 @@
  */
 
 import type { RawEvent, PublishedEvent } from "../hooks/lib/event-types";
+import { resolveSurfaceEnv } from "../hooks/lib/surface-env";
 import type { RelayPolicy } from "./policy-schema";
 
 // =============================================================================
@@ -135,7 +136,8 @@ export function processEvent(
     event_type: raw.event_type,
     timestamp: raw.timestamp,
     session_id: raw.session_id,
-    grove_channel: raw.grove_channel ?? process.env.GROVE_CHANNEL,
+    // cortex#774: read CORTEX_CHANNEL first, fall back to legacy GROVE_CHANNEL.
+    grove_channel: raw.grove_channel ?? resolveSurfaceEnv("CHANNEL"),
     agent_id: raw.agent_id,
     agent_name: raw.agent_name,
     payload: redacted,

--- a/src/taps/cc-events/relay.ts
+++ b/src/taps/cc-events/relay.ts
@@ -208,7 +208,7 @@ program
 
     if (!existsSync(RAW_DIR)) {
       console.error(`Raw events directory not found: ${RAW_DIR}`);
-      console.error("Events will be created when GROVE_CHANNEL is set");
+      console.error("Events will be created when CORTEX_CHANNEL (legacy GROVE_CHANNEL) is set");
       // Create it so the watcher doesn't fail
       const { mkdirSync } = await import("fs");
       mkdirSync(RAW_DIR, { recursive: true, mode: 0o700 });


### PR DESCRIPTION
Closes #774
Refs #767

## What

Makes cortex `CORTEX_*`-native for the EventLogger instrumentation env path, **non-breaking** — the legacy `GROVE_*` names are retained as a **read-fallback**. Touches the live dashboard event pipeline; verified working both ways.

## Set/read rename

**Setter** (`src/runner/cc-session.ts`): extracted a pure, unit-testable `buildSessionEnv()` and switched it to set the canonical `CORTEX_*` names (replacing the `GROVE_*` sets):

- `CORTEX_CHANNEL`, `CORTEX_NETWORK`, `CORTEX_AGENT_NAME`, `CORTEX_AGENT_ID`, `CORTEX_PROJECT`, `CORTEX_ENTITY`, `CORTEX_PRINCIPAL`
- `GROVE_BASH_GUARD` left untouched (per #772 scope).

**Readers**: new `src/taps/cc-events/hooks/lib/surface-env.ts` resolver — `resolveSurfaceEnv(field)` reads `CORTEX_{field}` first, falls back to `GROVE_{field}`. Wired into:

- `EventLogger.hook.ts` (channel/network/project/entity)
- `GroveContext.hook.ts` (channel/network/agent-name/agent-id)
- `event-types.ts` `createRawEvent` (channel/agent-id/agent-name/network)
- `policy-engine.ts` (channel)

## Retained GROVE_* read-fallbacks (NOT removed — that is the breaking step)

- `GROVE_CHANNEL`, `GROVE_NETWORK`, `GROVE_AGENT_NAME`, `GROVE_AGENT_ID`, `GROVE_PROJECT`, `GROVE_ENTITY` — via `surface-env.ts`
- `GROVE_OPERATOR` — principal chain `CORTEX_PRINCIPAL → GROVE_OPERATOR` via `principal-env.ts` (left intact)

Removal deferred to a future PR once MIG-8 is confirmed closed and external setters are audited.

## cldyo-live

Exports the `CORTEX_*` names; keeps the `GROVE_*` exports too for transition safety.

## Dashboard pipeline — verified BOTH ways

Ran the real `EventLogger.hook.ts` with (a) only `CORTEX_*` set and (b) only `GROVE_*` set; both emit identical JSONL with `grove_channel`, `agent_id`, `agent_name`, `network_id`, `project`, `entity`, `principal` all resolved.

## Tests / verify

- `bunx tsc --noEmit`: **0 errors**
- `bun test src/taps/ src/runner/`: **670 pass, 0 fail**
- full `bun test`: **4765 pass, 0 fail, 2 skip**
- `bun run lint:errors`: clean
- `bash scripts/check-carveouts.sh` (vocab gate): PASS

New tests: `surface-env.test.ts`, `cc-session-env.test.ts`, `event-types-env.test.ts`, plus CORTEX_* cases added to `grove-context.test.ts`; updated `cc-session-isolation.test.ts` env-key assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)