### PR TITLE
fix(bash-guard): #777 — auto-approve (permissionDecision:allow) allowlisted commands so async dispatch runs them

### DIFF
--- a/src/runner/hooks/__tests__/bash-guard.hook.test.ts
+++ b/src/runner/hooks/__tests__/bash-guard.hook.test.ts
@@ -8,6 +8,15 @@
  *     CORTEX_BASH_GUARD disabled behaviour
  *   - block telemetry event written to the JSONL fallback
  *   - block telemetry event POSTed to the HTTP ingest endpoint
+ *
+ * Plus the cortex#777 grant changes:
+ *   - the allowlist-MATCH terminal now emits Claude Code's auto-approve
+ *     PreToolUse decision (permissionDecision:"allow") so allowlisted
+ *     commands run in async dispatch WITHOUT a "requires approval" prompt.
+ *   - genuine pass-through paths (non-Grove / CLI principal / disabled-guard /
+ *     non-Bash / empty command) keep the {"continue": true} contract.
+ *   - every deny path still gates BEFORE the grant; no deny-worthy or
+ *     unvalidated command ever reaches the grant terminal.
  */
 
 import { describe, test, expect, beforeEach, afterEach } from "bun:test";
@@ -70,6 +79,23 @@ function runHook(
   return { status: result.status, stdout: result.stdout, stderr: result.stderr };
 }
 
+/**
+ * Assert the hook emitted Claude Code's auto-approve PreToolUse decision —
+ * the cortex#777 grant terminal. The harness reads
+ * `hookSpecificOutput.permissionDecision`, so we assert that exact shape (NOT
+ * `{continue:true}`, which would leave Claude Code's normal gate in place and
+ * stall async `--print` dispatch on "requires approval").
+ */
+function expectGrantDecision(stdout: string): void {
+  const out = JSON.parse(stdout.trim());
+  expect(out.hookSpecificOutput).toBeDefined();
+  expect(out.hookSpecificOutput.hookEventName).toBe("PreToolUse");
+  expect(out.hookSpecificOutput.permissionDecision).toBe("allow");
+  expect(typeof out.hookSpecificOutput.permissionDecisionReason).toBe("string");
+  // A grant is NOT a pass-through — `continue` must be absent.
+  expect(out.continue).toBeUndefined();
+}
+
 describe("bash-guard.hook — pass-through behaviour", () => {
   test("passes through when GROVE_CHANNEL is not set", () => {
     const r = runHook("rm -rf /", { GROVE_CHANNEL: undefined });
@@ -96,30 +122,130 @@ describe("bash-guard.hook — pass-through behaviour", () => {
     expect(JSON.parse(r.stdout.trim())).toEqual({ continue: true });
   });
 
-  test("allowed command passes with {continue:true}", () => {
-    const r = runHook("ls -la", {
-      GROVE_CHANNEL: "test-channel",
-      GROVE_AGENT_ID: undefined,
-    });
-    expect(r.status).toBe(0);
-    expect(JSON.parse(r.stdout.trim())).toEqual({ continue: true });
-  });
-
   test("non-Bash tool passes through unchanged", () => {
     const r = runHook("ignored", { GROVE_CHANNEL: "test-channel" }, "Read");
     expect(r.status).toBe(0);
     expect(JSON.parse(r.stdout.trim())).toEqual({ continue: true });
   });
+});
 
-  test("custom allowlist permits a widened command (e.g. bun)", () => {
+// =============================================================================
+// cortex#777 — allowlist MATCH now GRANTS (auto-approve), not pass-through.
+//
+// In a restricted (non-principal-DM) async `--print` session, a pass-through
+// ({continue:true}) leaves Claude Code's normal permission gate in place, so an
+// allowlisted command still returns "requires approval" — which async dispatch
+// can't surface, so the command never runs. The match terminal must instead
+// emit the auto-approve decision so the allowlisted+safe command runs without a
+// prompt.
+// =============================================================================
+describe("bash-guard.hook — allowlist match grants (auto-approve)", () => {
+  test("an allowlisted command GRANTS with permissionDecision:allow (not continue)", () => {
+    const r = runHook("ls -la", {
+      GROVE_CHANNEL: "test-channel",
+      GROVE_AGENT_ID: undefined,
+    });
+    expect(r.status).toBe(0);
+    expectGrantDecision(r.stdout);
+  });
+
+  test("gh issue create (halden's case) is GRANTED, not gated", () => {
+    // halden's allowlist matches `^gh\s+(pr|issue|repo|api|run)\s`. Before #777
+    // this was a pass-through → "requires approval" → async stall. Now: grant.
+    const r = runHook("gh issue create --repo the-metafactory/cortex --title x", {
+      GROVE_CHANNEL: "test-channel",
+      GROVE_AGENT_ID: undefined,
+      CORTEX_BASH_GUARD: JSON.stringify({
+        rules: [{ pattern: "^gh\\s+(pr|issue|repo|api|run)\\s" }],
+        repos: ["the-metafactory/cortex"],
+      }),
+    });
+    expect(r.status).toBe(0);
+    expectGrantDecision(r.stdout);
+  });
+
+  test("a custom-allowlisted command (e.g. bun) is GRANTED", () => {
     const r = runHook("bun test", {
       GROVE_CHANNEL: "test-channel",
       GROVE_AGENT_ID: undefined,
       CORTEX_BASH_GUARD: JSON.stringify({ rules: [{ pattern: "^bun\\s+" }] }),
     });
     expect(r.status).toBe(0);
-    expect(JSON.parse(r.stdout.trim())).toEqual({ continue: true });
+    expectGrantDecision(r.stdout);
   });
+
+  test("a chain of ALL-allowed commands is GRANTED once (&& preserved)", () => {
+    const r = runHook("ls && pwd", {
+      GROVE_CHANNEL: "test-channel",
+      GROVE_AGENT_ID: undefined,
+    });
+    expect(r.status).toBe(0);
+    expectGrantDecision(r.stdout);
+  });
+
+  test("a grant writes no block telemetry (grant is not a block)", () => {
+    const homeDir = mkdtempSync(join(tmpdir(), "bash-guard-grant-"));
+    try {
+      const sessionId = "grant-no-telemetry";
+      const r = runHook(
+        "ls",
+        { GROVE_CHANNEL: "test-channel", GROVE_AGENT_ID: undefined, HOME: homeDir },
+        "Bash",
+        sessionId,
+      );
+      expect(r.status).toBe(0);
+      expectGrantDecision(r.stdout);
+      const rawFile = join(homeDir, ".claude", "events", "raw", `${sessionId}.jsonl`);
+      expect(existsSync(rawFile)).toBe(false);
+    } finally {
+      rmSync(homeDir, { recursive: true, force: true });
+    }
+  });
+});
+
+// =============================================================================
+// cortex#777 SECURITY INVARIANT — the grant is the strict success terminal.
+// permissionDecision:"allow" is emitted ONLY when a command passed
+// rejectsChaining AND every chained part matched an allowlist rule AND any gh
+// repo-restriction passed. Every deny-worthy input must reach a DENY, never a
+// grant. This table-drives the negative space the adversarial reviewer checks.
+// =============================================================================
+describe("bash-guard.hook — grant is the strict success terminal (no deny-worthy input grants)", () => {
+  const config = JSON.stringify({
+    rules: [
+      { pattern: "^gh\\s+(pr|issue|repo|api|run)\\s" },
+      { pattern: "^ls\\b" },
+      { pattern: "^pwd$" },
+    ],
+    repos: ["the-metafactory/cortex"],
+  });
+
+  const DENY_WORTHY: [string, string][] = [
+    ["no allowlist match", "curl http://evil.example"],
+    ["one bad part in a chain", "ls && curl http://evil.example"],
+    ["repo not in allowlist", "gh issue create --repo evil/repo --title x"],
+    ["pipe smuggle past allowed head", "ls | curl http://evil.example"],
+    ["command substitution", "ls $(curl http://evil.example)"],
+    ["backtick substitution", "ls `id`"],
+    ["redirect clobber", "ls > /etc/passwd"],
+    ["background control token", "ls & curl http://evil.example"],
+    ["env-prefix substitution smuggle", 'X="$(id)" ls'],
+  ];
+
+  for (const [label, cmd] of DENY_WORTHY) {
+    test(`DENY (never grant): ${label}`, () => {
+      const r = runHook(cmd, {
+        GROVE_CHANNEL: "test-channel",
+        GROVE_AGENT_ID: undefined,
+        CORTEX_BASH_GUARD: config,
+      });
+      expect(r.status).toBe(0);
+      const out = JSON.parse(r.stdout.trim());
+      expect(out.hookSpecificOutput?.permissionDecision).toBe("deny");
+      // Hard guarantee: a deny-worthy command must NEVER produce an allow.
+      expect(out.hookSpecificOutput?.permissionDecision).not.toBe("allow");
+    });
+  }
 });
 
 describe("bash-guard.hook — structured deny output", () => {
@@ -382,20 +508,20 @@ describe("bash-guard.hook — no-bypass (metacharacter rejection)", () => {
     expectDeny('X="`id`" aws sts get-caller-identity');
   });
 
-  test("a plain (metacharacter-free) env-prefix is still allowed", () => {
+  test("a plain (metacharacter-free) env-prefix is still allowed (grants)", () => {
     // The whole point of PR #770: `AWS_PROFILE=halden-dev <allowed> …` must
     // pass. Use `ls` (in DEFAULT_CONFIG) so this case is independent of the
     // aws rule — it proves the raw-command metacharacter scan does not
-    // over-reject a benign `NAME=value` prefix.
+    // over-reject a benign `NAME=value` prefix. Post-#777 a match GRANTS.
     const r = runHook("AWS_PROFILE=halden-dev ls", env);
     expect(r.status).toBe(0);
-    expect(JSON.parse(r.stdout.trim())).toEqual({ continue: true });
+    expectGrantDecision(r.stdout);
   });
 
-  test("a chain of ALL-allowed commands still passes (&& preserved)", () => {
+  test("a chain of ALL-allowed commands still passes (&& preserved, grants)", () => {
     const r = runHook("ls && pwd", env);
     expect(r.status).toBe(0);
-    expect(JSON.parse(r.stdout.trim())).toEqual({ continue: true });
+    expectGrantDecision(r.stdout);
   });
 
   test("a chain with one disallowed command is denied (existing contract)", () => {
@@ -498,9 +624,10 @@ describe("bash-guard.hook — read-only aws (integration via hook + halden confi
   }
 
   function expectAllow(cmd: string): void {
+    // Post-#777: an allowlist MATCH GRANTS (auto-approve), not a pass-through.
     const r = run(cmd);
     expect(r.status).toBe(0);
-    expect(JSON.parse(r.stdout.trim())).toEqual({ continue: true });
+    expectGrantDecision(r.stdout);
   }
 
   function expectDeny(cmd: string): void {

--- a/src/runner/hooks/__tests__/bash-guard.hook.test.ts
+++ b/src/runner/hooks/__tests__/bash-guard.hook.test.ts
@@ -246,6 +246,97 @@ describe("bash-guard.hook — grant is the strict success terminal (no deny-wort
       expect(out.hookSpecificOutput?.permissionDecision).not.toBe("allow");
     });
   }
+
+  // ---------------------------------------------------------------------------
+  // Echo (adversarial review, cortex#778) — vectors not in the inline table
+  // above because they need a real control character or a non-string payload.
+  // Each confirms the grant terminal stays unreachable for a deny-worthy input.
+  // ---------------------------------------------------------------------------
+
+  test("DENY (never grant): a REAL newline smuggles a second command", () => {
+    // The inline table can't carry a literal newline; feed one directly so the
+    // rejectsChaining `[\r\n]` arm is exercised end-to-end, not just in isolation.
+    const r = runHook("ls\nrm -rf /", {
+      GROVE_CHANNEL: "test-channel",
+      GROVE_AGENT_ID: undefined,
+      CORTEX_BASH_GUARD: config,
+    });
+    expect(r.status).toBe(0);
+    const out = JSON.parse(r.stdout.trim());
+    expect(out.hookSpecificOutput?.permissionDecision).toBe("deny");
+    expect(out.hookSpecificOutput?.permissionDecision).not.toBe("allow");
+  });
+
+  test("DENY (never grant): a carriage-return smuggles a second command", () => {
+    const r = runHook("ls\rrm -rf /", {
+      GROVE_CHANNEL: "test-channel",
+      GROVE_AGENT_ID: undefined,
+      CORTEX_BASH_GUARD: config,
+    });
+    expect(r.status).toBe(0);
+    const out = JSON.parse(r.stdout.trim());
+    expect(out.hookSpecificOutput?.permissionDecision).toBe("deny");
+  });
+
+  test("DENY (never grant): the LAST part of a 3-part chain is unallowed (loop validates ALL parts)", () => {
+    // Loop-ordering proof: the first two parts match; the grant terminal must
+    // stay unreachable because a later part fails. Guards against a per-part
+    // `grant` slipping in before the loop finishes.
+    const r = runHook("ls && pwd && curl http://evil.example", {
+      GROVE_CHANNEL: "test-channel",
+      GROVE_AGENT_ID: undefined,
+      CORTEX_BASH_GUARD: config,
+    });
+    expect(r.status).toBe(0);
+    const out = JSON.parse(r.stdout.trim());
+    expect(out.hookSpecificOutput?.permissionDecision).toBe("deny");
+    expect(out.hookSpecificOutput?.permissionDecision).not.toBe("allow");
+  });
+
+  test("DENY (never grant): a MIDDLE part of a chain is unallowed", () => {
+    const r = runHook("ls && curl http://evil.example && pwd", {
+      GROVE_CHANNEL: "test-channel",
+      GROVE_AGENT_ID: undefined,
+      CORTEX_BASH_GUARD: config,
+    });
+    expect(r.status).toBe(0);
+    const out = JSON.parse(r.stdout.trim());
+    expect(out.hookSpecificOutput?.permissionDecision).toBe("deny");
+  });
+
+  test("DENY (never grant): TAB-delimited chaining is split and validated (\\s split robustness)", () => {
+    // `\t` is whitespace, so the `\s*(?:&&|…)\s*` splitter must isolate the
+    // unallowed tail rather than fold it into an allowed head.
+    const r = runHook("ls\t&&\tcurl http://evil.example", {
+      GROVE_CHANNEL: "test-channel",
+      GROVE_AGENT_ID: undefined,
+      CORTEX_BASH_GUARD: config,
+    });
+    expect(r.status).toBe(0);
+    const out = JSON.parse(r.stdout.trim());
+    expect(out.hookSpecificOutput?.permissionDecision).toBe("deny");
+  });
+
+  test("FAIL-SAFE: unparseable hook stdin passes through, NEVER grants", () => {
+    // The fail-open path must defer to Claude Code's normal gate ({continue:true}),
+    // not auto-approve. An error must never silently widen to an allow. Feed raw
+    // malformed JSON directly (runHook always wraps in valid JSON, so bypass it).
+    const merged: Record<string, string> = {};
+    for (const [k, v] of Object.entries(process.env)) {
+      if (v !== undefined && !GROVE_ENV_KEYS.includes(k)) merged[k] = v;
+    }
+    merged.GROVE_CHANNEL = "test-channel";
+    merged.CORTEX_BASH_GUARD = config;
+    const r = spawnSync("bun", [HOOK_PATH], {
+      encoding: "utf-8",
+      input: "this is not valid json {{{",
+      env: merged,
+    });
+    expect(r.status).toBe(0);
+    const out = JSON.parse((r.stdout ?? "").trim());
+    expect(out).toEqual({ continue: true });
+    expect(out.hookSpecificOutput?.permissionDecision).not.toBe("allow");
+  });
 });
 
 describe("bash-guard.hook — structured deny output", () => {

--- a/src/runner/hooks/bash-guard.hook.ts
+++ b/src/runner/hooks/bash-guard.hook.ts
@@ -202,12 +202,54 @@ function rejectsChaining(command: string): boolean {
 }
 
 // =============================================================================
-// Pass / deny output — Claude Code PreToolUse hook protocol.
+// Pass / grant / deny output — Claude Code PreToolUse hook protocol.
+//
+// Three decisions, three meanings:
+//   pass()  — pass-through ({"continue": true}). Defer to Claude Code's normal
+//             permission flow. Used by the paths that are out of this guard's
+//             scope (non-Grove / CLI-principal / disabled-guard / non-Bash /
+//             empty command). NOT an approval: in a restricted default-mode
+//             session the normal gate still applies. That is intentional for
+//             these paths — they are either already-permissive or not ours.
+//   grant() — auto-approve (permissionDecision:"allow"). The STRICT success
+//             terminal of the allowlist (cortex#777). Emitted ONLY after a
+//             command passed rejectsChaining, matched an allowlist rule for
+//             every chained part, and cleared any gh repo-restriction. This is
+//             what lets an allowlisted+safe command run in async `--print`
+//             dispatch without a "requires approval" prompt.
+//   deny()  — permissionDecision:"deny" with a reason that surfaces to the
+//             agent and the Cortex→Discord relay.
 // =============================================================================
 
-/** Emit the pass-through decision (unchanged contract). */
-function allow(): void {
+/** Emit the pass-through decision (unchanged contract). Defers to CC's gate. */
+function pass(): void {
   console.log(JSON.stringify({ continue: true }));
+}
+
+/**
+ * Emit Claude Code's structured PreToolUse *auto-approve* decision (cortex#777).
+ *
+ * This is the allowlist's success terminal. The harness reads
+ * `hookSpecificOutput.permissionDecision` — "allow" tells Claude Code to run
+ * the tool call WITHOUT prompting, so an allowlisted command actually executes
+ * in a restricted async `--print` session instead of stalling on "requires
+ * approval".
+ *
+ * SECURITY INVARIANT: grant() is the strict success terminal. It is reachable
+ * ONLY from the end of main() — after rejectsChaining passed, every chained
+ * part matched an allowlist rule, and any gh repo-restriction passed. There is
+ * no other call site, and every deny-worthy branch returns BEFORE this point.
+ */
+function grant(reason: string): void {
+  console.log(
+    JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "allow",
+        permissionDecisionReason: reason,
+      },
+    }),
+  );
 }
 
 /**
@@ -306,7 +348,7 @@ async function emitBlockEvent(
 async function main(): Promise<void> {
   // Not a Grove session — pass through silently
   if (!process.env.GROVE_CHANNEL) {
-    allow();
+    pass();
     return;
   }
 
@@ -314,7 +356,7 @@ async function main(): Promise<void> {
   // Bot sessions also set GROVE_AGENT_ID but override via CORTEX_BASH_GUARD config,
   // so they still get guarded by the loadConfig() path below.
   if (process.env.GROVE_AGENT_ID) {
-    allow();
+    pass();
     return;
   }
 
@@ -335,18 +377,18 @@ async function main(): Promise<void> {
     await Promise.race([readLoop, new Promise<void>((r) => setTimeout(r, 200))]);
 
     if (!raw.trim()) {
-      allow();
+      pass();
       return;
     }
     input = JSON.parse(raw) as HookInput;
   } catch {
-    allow();
+    pass();
     return;
   }
 
   // Only guard Bash commands
   if (input.tool_name !== "Bash") {
-    allow();
+    pass();
     return;
   }
 
@@ -358,7 +400,7 @@ async function main(): Promise<void> {
   const command = stripEnvPrefix(rawCommand).trim();
 
   if (!command) {
-    allow();
+    pass();
     return;
   }
 
@@ -367,9 +409,12 @@ async function main(): Promise<void> {
 
   const config = loadConfig();
 
-  // G-300: Guard disabled (principal DM) — allow everything
+  // G-300: Guard disabled (principal DM) — pass through, defer to the already-
+  // permissive bypass session. Intentionally NOT a grant: this path is out of
+  // the allowlist's scope, and broadening it to auto-approve would be a strictly
+  // wider authority than the disabled-guard contract promises (cortex#777).
   if (config === null) {
-    allow();
+    pass();
     return;
   }
 
@@ -445,10 +490,18 @@ async function main(): Promise<void> {
     }
   }
 
-  // All parts matched — allow
-  allow();
+  // All parts matched, no chaining metacharacters, repo-restriction (if any)
+  // cleared — this is the STRICT success terminal. Auto-approve so the
+  // allowlisted+safe command runs in async dispatch without a "requires
+  // approval" prompt (cortex#777). Every deny-worthy branch returned above.
+  grant(
+    "[Grove Bash Guard] Auto-approved: command matches the bash allowlist " +
+      "and contains no chaining metacharacters.",
+  );
 }
 
 main().catch(() => {
-  allow();
+  // Fail open to Claude Code's normal permission gate (pass-through), NOT to an
+  // auto-approve. An unexpected error must never silently grant.
+  pass();
 });


### PR DESCRIPTION
Closes #777
Refs #769 #770

## Problem

For an allowlisted command the bash-guard hook emitted `{"continue": true}` — a **pass-through**, not an approval. In a restricted (non-principal-DM) session running default permission mode, pass-through means Claude Code still gates the tool call → "requires approval" → the async `--print` dispatch stalls. So allowlisted writes (e.g. `gh issue create`, which halden's allowlist already matches via `^gh\s+(pr |issue|repo|api|run)\s`) were *allowed but never granted* — they never ran in async dispatch.

## Fix

Split the single `allow()` into three explicit decisions:

| Emitter | Output | Meaning |
|---------|--------|---------|
| `pass()` | `{"continue": true}` | Pass-through — defer to CC's normal gate. Out-of-scope paths only. |
| `grant(reason)` | `hookSpecificOutput.permissionDecision:"allow"` | **Auto-approve** — the strict allowlist success terminal. |
| `deny(reason)` | `hookSpecificOutput.permissionDecision:"deny"` | Unchanged. |

### Exact grant JSON
```json
{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"allow","permissionDecisionReason":"[Grove Bash Guard] Auto-approved: command matches the bash allowlist and contains no chaining metacharacters."}}
```

### Kept as pass-through (`{"continue": true}`)
- non-Grove session, CLI-principal bypass (`GROVE_AGENT_ID`)
- **disabled-guard** (`config === null`, principal-DM bypass) — intentionally NOT broadened to a grant
- non-Bash tool, empty command, and the `main().catch` fail-open

### deny — UNCHANGED, gates BEFORE grant
`rejectsChaining` (#770), no allowlist match, and gh repo-restriction all `deny()` + `return` before control can reach the grant.

## Security invariant

`permissionDecision:"allow"` is emitted **only** at the end of `main()` — after the command passed `rejectsChaining` AND every chained part matched an allowlist rule AND any gh repo-restriction passed. `grant()` has a single call site (the success terminal); every deny-worthy branch `return`s before it. No deny-worthy or unvalidated command can reach `grant()`.

## Order in `main()` (unchanged)
`disabled → pass` → `rejectsChaining → deny` → per-part loop (`no-match → deny`, `gh-repo-not-allowed → deny`) → **all parts matched → grant**.

## Tests
- Allowlist matches (`ls`, `gh issue create`, `bun`, `ls && pwd`, aws read-only verbs) now assert `permissionDecision:"allow"` (not `{continue:true}`).
- Genuine pass-throughs keep `{continue:true}`.
- Table-driven "grant is the strict success terminal" suite: chaining / no-match / repo-denied / pipe / `$( )` / backtick / redirect / background-` & ` / env-prefix-smuggle all **deny**, never allow.
- `108 pass / 0 fail` (bash-guard + skill-guard); full runner suite `467 pass / 0 fail`.

## Verify
`bunx tsc --noEmit` → 0 · `bun test src/runner/hooks/` → 108/0 · lint errors 0 · vocab carve-out gate PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)