### PR TITLE
refactor(adapters): deepen response routing delivery

### DIFF
--- a/src/adapters/__tests__/response-routing-delivery.test.ts
+++ b/src/adapters/__tests__/response-routing-delivery.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, test } from "bun:test";
+import type { Envelope } from "../../bus/myelin/envelope-validator";
+import {
+  deliverRoutedResponse,
+  readLogicalRouting,
+  readResponseRouting,
+} from "../response-routing-delivery";
+import type { ResponseTarget } from "../types";
+
+function envelope(
+  type: string,
+  payload: Record<string, unknown>,
+  correlationId = "corr-1",
+): Envelope {
+  return {
+    id: "00000000-0000-4000-8000-000000000099",
+    source: "metafactory.runner.local",
+    type,
+    timestamp: "2026-05-09T12:00:00Z",
+    correlation_id: correlationId,
+    sovereignty: {
+      classification: "local",
+      data_residency: "NZ",
+      max_hop: 0,
+      frontier_ok: false,
+      model_class: "local-only",
+    },
+    payload,
+  };
+}
+
+describe("response-routing-delivery", () => {
+  test("parses snowflake and logical response routing shapes", () => {
+    expect(
+      readResponseRouting(
+        envelope("dispatch.task.completed", {
+          response_routing: {
+            adapter_instance: "discord-pai",
+            channel_id: "C123",
+            thread_id: "T456",
+          },
+        }),
+      ),
+    ).toEqual({
+      adapter_instance: "discord-pai",
+      channel_id: "C123",
+      thread_id: "T456",
+    });
+
+    expect(
+      readLogicalRouting(
+        envelope("review.verdict.approved", {
+          response_routing: {
+            surface: "discord",
+            channel: "cortex",
+            thread: "cortex/pr/57",
+          },
+        }),
+      ),
+    ).toEqual({
+      surface: "discord",
+      channel: "cortex",
+      thread: "cortex/pr/57",
+    });
+
+    expect(
+      readResponseRouting(
+        envelope("dispatch.task.completed", {
+          response_routing: { surface: "discord", channel: "cortex" },
+        }),
+      ),
+    ).toBeNull();
+    expect(
+      readLogicalRouting(
+        envelope("review.verdict.approved", {
+          response_routing: { adapter_instance: "discord-pai", channel_id: "C123" },
+        }),
+      ),
+    ).toBeNull();
+  });
+
+  test("started sends progress with correlation key, terminal clears then posts", async () => {
+    const calls: string[] = [];
+    const adapter = {
+      sendProgress: async (target: ResponseTarget, text: string): Promise<void> => {
+        calls.push(`progress:${target.sessionId ?? ""}:${text}`);
+      },
+      clearProgress: async (target: ResponseTarget): Promise<void> => {
+        calls.push(`clear:${target.sessionId ?? ""}`);
+      },
+      postResponse: async (target: ResponseTarget, text: string): Promise<void> => {
+        calls.push(`post:${target.sessionId ?? ""}:${text}`);
+      },
+    };
+    const target: ResponseTarget = {
+      instanceId: "discord-pai",
+      channelId: "C123",
+      threadId: "T456",
+    };
+    const errors: unknown[] = [];
+
+    await deliverRoutedResponse({
+      envelope: envelope("dispatch.task.started", {}, "task-A"),
+      adapter,
+      target,
+      text: "Luna is working...",
+      onError: (err) => { errors.push(err); },
+    });
+    await deliverRoutedResponse({
+      envelope: envelope("dispatch.task.completed", {}, "task-A"),
+      adapter,
+      target,
+      text: "done",
+      onError: (err) => { errors.push(err); },
+    });
+
+    expect(calls).toEqual([
+      "progress:task-A:Luna is working...",
+      "clear:task-A",
+      "post::done",
+    ]);
+    expect(errors).toHaveLength(0);
+  });
+
+  test("delivery failures are reported through onError without throwing", async () => {
+    const err = new Error("rate limited");
+    const adapter = {
+      sendProgress: async (): Promise<void> => {},
+      clearProgress: async (): Promise<void> => {},
+      postResponse: async (): Promise<void> => {
+        throw err;
+      },
+    };
+    const errors: unknown[] = [];
+
+    await expect(
+      deliverRoutedResponse({
+        envelope: envelope("dispatch.task.completed", {}),
+        adapter,
+        target: { instanceId: "discord-pai", channelId: "C123" },
+        text: "done",
+        onError: (seen) => { errors.push(seen); },
+      }),
+    ).resolves.toBeUndefined();
+    expect(errors).toEqual([err]);
+  });
+});

--- a/src/adapters/dispatch-sink.ts
+++ b/src/adapters/dispatch-sink.ts
@@ -37,69 +37,13 @@ import type { Envelope } from "../bus/myelin/envelope-validator";
 import type { MyelinRuntime } from "../bus/myelin/runtime";
 import type { MyelinSubscriber } from "../bus/myelin/subscriber";
 import { formatDispatchLifecycle } from "./envelope-renderer";
+import {
+  deliverRoutedResponse,
+  LIFECYCLE_TYPE_PREFIX,
+  readResponseRouting,
+} from "./response-routing-delivery";
+export { dispatchCorrelationKey } from "./response-routing-delivery";
 import type { PlatformAdapter, ResponseTarget } from "./types";
-
-/**
- * Response-routing shape as it appears on a lifecycle envelope's payload
- * (snake_case wire idiom). Structurally the same triple a `ResponseTarget`
- * carries. Mirrors `ResponseRouting` in `src/bus/dispatch-events.ts`; kept
- * local to the sink's parse so the consumer doesn't depend on the runner's
- * publish-side type for a read-only decode.
- */
-interface WireResponseRouting {
-  adapter_instance: string;
-  channel_id: string;
-  thread_id?: string;
-}
-
-/**
- * Parse `payload.response_routing` into a typed routing record, or `null`
- * when the envelope carried none / it was malformed. Bus-peer and Offer
- * dispatches have no originating surface address, so a missing field is a
- * normal, non-error case — the sink simply ignores those envelopes.
- */
-function readResponseRouting(envelope: Envelope): WireResponseRouting | null {
-  const raw = envelope.payload.response_routing;
-  if (raw === null || typeof raw !== "object") return null;
-  const r = raw as Record<string, unknown>;
-  if (typeof r.adapter_instance !== "string" || typeof r.channel_id !== "string") {
-    return null;
-  }
-  return {
-    adapter_instance: r.adapter_instance,
-    channel_id: r.channel_id,
-    ...(typeof r.thread_id === "string" && { thread_id: r.thread_id }),
-  };
-}
-
-/**
- * cortex#721 — derive the per-dispatch correlation key for progress keying.
- *
- * The Discord adapter keys its "working…" progress placeholder on
- * `target.sessionId` (`progressKey` = `sessionId ? scope:sessionId : scope`).
- * The in-process dispatch-handler path (cortex#708/#713) threads the inbound
- * correlation onto `sessionId`; the BUS sink path never did, so every
- * dispatch's `started` progress fell back to channel-scope and collapsed
- * onto ONE edited-in-place message.
- *
- * The lifecycle envelope already carries a per-dispatch correlation: the
- * UUID-shaped `envelope.correlation_id` (set to the task UUID by
- * `dispatch-events.buildBaseEnvelope`), with `payload.task_id` as the
- * belt-and-braces fallback (the same `correlation_id ?? task_id` join the
- * runner uses). Returns `undefined` only when neither is present — then
- * channel-scoped keying is the correct (pre-#708) behaviour.
- */
-export function dispatchCorrelationKey(envelope: Envelope): string | undefined {
-  if (typeof envelope.correlation_id === "string" && envelope.correlation_id.length > 0) {
-    return envelope.correlation_id;
-  }
-  const taskId = envelope.payload.task_id;
-  if (typeof taskId === "string" && taskId.length > 0) return taskId;
-  return undefined;
-}
-
-/** Lifecycle event types the sink delivers. */
-const LIFECYCLE_TYPE_PREFIX = "dispatch.task.";
 
 export interface DispatchSinkOptions {
   /**
@@ -288,44 +232,23 @@ export function createDispatchSink(opts: DispatchSinkOptions): DispatchSink {
       ...(routing.thread_id !== undefined && { threadId: routing.thread_id }),
     };
 
-    // cortex#721 — key per-dispatch progress on the lifecycle envelope's
-    // correlation id so two dispatches in the same channel/thread each get
-    // their OWN "working…" placeholder instead of editing one shared message.
-    // `sessionId` rides ONLY the progress target: `postResponse` ignores it,
-    // and only `sendProgress`/`clearProgress` read it via the adapter's
-    // `progressKey`. The terminal branch MUST reuse this exact key to delete
-    // the placeholder the `started` branch created (cortex#731).
-    const correlationKey = dispatchCorrelationKey(envelope);
-    const progressTarget: ResponseTarget =
-      correlationKey !== undefined
-        ? { ...target, sessionId: correlationKey }
-        : target;
-
-    try {
-      if (envelope.type === "dispatch.task.started") {
-        // A `started` event is a progress/typing indicator, not a final
-        // reply — edit-in-place so the terminal `completed`/`failed`
-        // reply is the durable message in the channel.
-        await adapter.sendProgress(progressTarget, text);
-        return;
-      }
-      // `completed` / `failed` / `aborted` — the terminal reply. Clear the
-      // `started` "working…" placeholder first (same correlation-keyed
-      // target), else it orphans above the durable reply (cortex#731), then
-      // post the reply.
-      await adapter.clearProgress(progressTarget);
-      await adapter.postResponse(target, text);
-    } catch (err) {
-      // A platform post failure must not crash the fan-out. Log to
-      // stderr (per CLAUDE.md no-empty-catch rule) and move on; the
-      // dispatch already completed on the bus, only the surface delivery
-      // failed (rate limit, deleted channel, etc.).
-      process.stderr.write(
-        `cortex: dispatch-sink postResponse failed (instance=${routing.adapter_instance}, ` +
-          `channel=${routing.channel_id}, type=${envelope.type}): ` +
-          `${err instanceof Error ? err.message : String(err)}\n`,
-      );
-    }
+    await deliverRoutedResponse({
+      envelope,
+      adapter,
+      target,
+      text,
+      onError: (err) => {
+        // A platform post failure must not crash the fan-out. Log to
+        // stderr (per CLAUDE.md no-empty-catch rule) and move on; the
+        // dispatch already completed on the bus, only the surface delivery
+        // failed (rate limit, deleted channel, etc.).
+        process.stderr.write(
+          `cortex: dispatch-sink postResponse failed (instance=${routing.adapter_instance}, ` +
+            `channel=${routing.channel_id}, type=${envelope.type}): ` +
+            `${err instanceof Error ? err.message : String(err)}\n`,
+        );
+      },
+    });
   }
 
   return {

--- a/src/adapters/response-routing-delivery.ts
+++ b/src/adapters/response-routing-delivery.ts
@@ -1,0 +1,120 @@
+import type { Envelope } from "../bus/myelin/envelope-validator";
+import type { ResponseTarget } from "./types";
+
+export const LIFECYCLE_TYPE_PREFIX = "dispatch.task.";
+const LIFECYCLE_STARTED_TYPE = "dispatch.task.started";
+
+/**
+ * Snowflake response-routing shape as it appears on a lifecycle envelope's
+ * payload. Mirrors `ResponseRouting` in `src/bus/dispatch-events.ts`.
+ */
+export interface WireResponseRouting {
+  adapter_instance: string;
+  channel_id: string;
+  thread_id?: string;
+}
+
+/**
+ * Logical response-routing shape as it appears on review/attention envelopes.
+ * Mirrors `LogicalResponseRouting` in `src/bus/dispatch-events.ts`.
+ */
+export interface WireLogicalRouting {
+  surface: string;
+  channel: string;
+  thread?: string;
+}
+
+/**
+ * Parse the chat-path `payload.response_routing` snowflake triple. Missing or
+ * malformed routing is normal for bus-peer / Offer dispatches and returns null.
+ */
+export function readResponseRouting(envelope: Envelope): WireResponseRouting | null {
+  const raw = envelope.payload.response_routing;
+  if (raw === null || typeof raw !== "object") return null;
+  const r = raw as Record<string, unknown>;
+  if (typeof r.adapter_instance !== "string" || typeof r.channel_id !== "string") {
+    return null;
+  }
+  return {
+    adapter_instance: r.adapter_instance,
+    channel_id: r.channel_id,
+    ...(typeof r.thread_id === "string" && { thread_id: r.thread_id }),
+  };
+}
+
+/**
+ * Parse the review-path `payload.response_routing` logical address. Missing or
+ * malformed routing is normal for pilot-only / Offer dispatches and returns null.
+ */
+export function readLogicalRouting(envelope: Envelope): WireLogicalRouting | null {
+  const raw = envelope.payload.response_routing;
+  if (raw === null || typeof raw !== "object") return null;
+  const r = raw as Record<string, unknown>;
+  if (typeof r.surface !== "string" || typeof r.channel !== "string") {
+    return null;
+  }
+  return {
+    surface: r.surface,
+    channel: r.channel,
+    ...(typeof r.thread === "string" && { thread: r.thread }),
+  };
+}
+
+/**
+ * cortex#721 - derive the per-dispatch correlation key for progress keying.
+ *
+ * The lifecycle envelope carries a per-dispatch correlation via
+ * `envelope.correlation_id`, with `payload.task_id` as the fallback. Returns
+ * undefined only when neither exists, preserving channel-scoped progress.
+ */
+export function dispatchCorrelationKey(envelope: Envelope): string | undefined {
+  if (typeof envelope.correlation_id === "string" && envelope.correlation_id.length > 0) {
+    return envelope.correlation_id;
+  }
+  const taskId = envelope.payload.task_id;
+  if (typeof taskId === "string" && taskId.length > 0) return taskId;
+  return undefined;
+}
+
+interface ReplyAdapter {
+  sendProgress: (target: ResponseTarget, text: string) => Promise<void>;
+  clearProgress: (target: ResponseTarget) => Promise<void>;
+  postResponse: (target: ResponseTarget, text: string) => Promise<void>;
+}
+
+export interface DeliverRoutedResponseOptions {
+  envelope: Envelope;
+  adapter: ReplyAdapter;
+  target: ResponseTarget;
+  text: string;
+  onError: (err: unknown) => void;
+}
+
+/**
+ * Shared delivery policy for response-routed surface replies:
+ *
+ * - `dispatch.task.started` is a progress update.
+ * - every terminal/reply envelope clears the same progress key, then posts.
+ * - delivery failures never escape the runtime fan-out.
+ */
+export async function deliverRoutedResponse(
+  opts: DeliverRoutedResponseOptions,
+): Promise<void> {
+  const { envelope, adapter, target, text, onError } = opts;
+  const correlationKey = dispatchCorrelationKey(envelope);
+  const progressTarget: ResponseTarget =
+    correlationKey !== undefined
+      ? { ...target, sessionId: correlationKey }
+      : target;
+
+  try {
+    if (envelope.type === LIFECYCLE_STARTED_TYPE) {
+      await adapter.sendProgress(progressTarget, text);
+      return;
+    }
+    await adapter.clearProgress(progressTarget);
+    await adapter.postResponse(target, text);
+  } catch (err) {
+    onError(err);
+  }
+}

--- a/src/adapters/review-sink.ts
+++ b/src/adapters/review-sink.ts
@@ -56,46 +56,18 @@
 import type { Envelope } from "../bus/myelin/envelope-validator";
 import type { MyelinRuntime } from "../bus/myelin/runtime";
 import type { MyelinSubscriber } from "../bus/myelin/subscriber";
-import { dispatchCorrelationKey } from "./dispatch-sink";
 import {
   formatDispatchLifecycle,
   formatReviewVerdict,
 } from "./envelope-renderer";
+import {
+  deliverRoutedResponse,
+  LIFECYCLE_TYPE_PREFIX,
+  readLogicalRouting,
+  type WireLogicalRouting,
+} from "./response-routing-delivery";
 import type { PlatformAdapter, ResponseTarget } from "./types";
 
-/**
- * The logical response-routing shape as it appears on a review envelope's
- * payload. Mirrors `LogicalResponseRouting` in `src/bus/dispatch-events.ts`;
- * kept local to the sink's parse so the consumer doesn't depend on the
- * publish-side type for a read-only decode.
- */
-interface WireLogicalRouting {
-  surface: string;
-  channel: string;
-  thread?: string;
-}
-
-/**
- * Parse `payload.response_routing` into a typed logical routing record, or
- * `null` when the envelope carried none / it was malformed. Bus-peer /
- * pilot-only / Offer dispatches have no originating surface address, so a
- * missing field is a normal, non-error case — the sink ignores those.
- */
-function readLogicalRouting(envelope: Envelope): WireLogicalRouting | null {
-  const raw = envelope.payload.response_routing;
-  if (raw === null || typeof raw !== "object") return null;
-  const r = raw as Record<string, unknown>;
-  if (typeof r.surface !== "string" || typeof r.channel !== "string") {
-    return null;
-  }
-  return {
-    surface: r.surface,
-    channel: r.channel,
-    ...(typeof r.thread === "string" && { thread: r.thread }),
-  };
-}
-
-const LIFECYCLE_TYPE_PREFIX = "dispatch.task.";
 const VERDICT_TYPE_PREFIX = "review.verdict.";
 // G-1113.ML.4 — the attention notification stream (system.attention.{opened,resolved}).
 const ATTENTION_TYPE_PREFIX = "system.attention.";
@@ -351,45 +323,24 @@ export function createReviewSink(opts: ReviewSinkOptions): ReviewSink {
     const adapter = adapters.find((a) => a.instanceId === target.instanceId);
     if (adapter === undefined) return;
 
-    // cortex#721 — key the per-review progress placeholder on the lifecycle
-    // envelope's correlation id (resolved targets carry no `sessionId`), so
-    // two reviews in the same channel/thread each get their OWN "reviewing…"
-    // message instead of editing one shared placeholder. `postResponse`
-    // ignores `sessionId`; only `sendProgress`/`clearProgress` read it via the
-    // adapter's `progressKey`. The terminal branch MUST reuse this exact key
-    // to delete the placeholder the `started` branch created (cortex#731).
-    const correlationKey = dispatchCorrelationKey(envelope);
-    const progressTarget: ResponseTarget =
-      correlationKey !== undefined
-        ? { ...target, sessionId: correlationKey }
-        : target;
-
-    try {
-      if (envelope.type === "dispatch.task.started") {
-        // `started` is a progress/typing indicator (e.g. "Echo is
-        // reviewing…"), not a final reply — edit-in-place so the terminal
-        // verdict/failed reply is the durable message.
-        await adapter.sendProgress(progressTarget, text);
-        return;
-      }
-      // Verdict / completed / failed / aborted — the terminal reply. Clear the
-      // `started` "reviewing…" placeholder first (same correlation-keyed
-      // target), else it orphans above the durable verdict (cortex#731), then
-      // post the reply.
-      await adapter.clearProgress(progressTarget);
-      await adapter.postResponse(target, text);
-    } catch (err) {
-      // A platform post failure must not crash the fan-out (per CLAUDE.md
-      // no-empty-catch rule). The review already completed on the bus;
-      // only the surface delivery failed (rate limit, deleted channel,
-      // etc.). The authoritative verdict still reached pilot via
-      // correlation_id.
-      process.stderr.write(
-        `cortex: review-sink postResponse failed (surface=${routing.surface}, ` +
-          `channel=${routing.channel}, type=${envelope.type}): ` +
-          `${err instanceof Error ? err.message : String(err)}\n`,
-      );
-    }
+    await deliverRoutedResponse({
+      envelope,
+      adapter,
+      target,
+      text,
+      onError: (err) => {
+        // A platform post failure must not crash the fan-out (per CLAUDE.md
+        // no-empty-catch rule). The review already completed on the bus;
+        // only the surface delivery failed (rate limit, deleted channel,
+        // etc.). The authoritative verdict still reached pilot via
+        // correlation_id.
+        process.stderr.write(
+          `cortex: review-sink postResponse failed (surface=${routing.surface}, ` +
+            `channel=${routing.channel}, type=${envelope.type}): ` +
+            `${err instanceof Error ? err.message : String(err)}\n`,
+        );
+      },
+    });
   }
 
   return {


### PR DESCRIPTION
## Summary
- extract shared response-routing parsing and delivery policy into response-routing-delivery
- keep dispatch and review sinks as public entry modules while delegating progress/clear/post handling
- add direct helper coverage for routing parsing, progress keying, terminal posting, and swallowed delivery errors

## Verification
- rtk bunx tsc --noEmit
- rtk bunx eslint src/adapters/response-routing-delivery.ts src/adapters/dispatch-sink.ts src/adapters/review-sink.ts src/adapters/__tests__/response-routing-delivery.test.ts
- rtk bun test src/adapters/__tests__/response-routing-delivery.test.ts src/adapters/__tests__/dispatch-sink.test.ts src/adapters/__tests__/review-sink.test.ts
- rtk bun test