### PR TITLE
refactor(gateway): add surface ownership plan

### DIFF
--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -101,7 +101,10 @@ import { refreshCockpit, defaultWorkItemSourceFor } from "./surface/mc/refresh";
 import { startCockpitRefreshLoop, type CockpitRefreshLoop } from "./surface/mc/refresh-loop";
 import type { Database as BunDatabase } from "bun:sqlite";
 import { isGatewayEnabled } from "./gateway/gateway-bootstrap";
-import { gatewayOwnedSurfaceKeys } from "./gateway/gateway-adapters";
+import {
+  gatewayAdapterInstanceCollisions,
+  planSurfaceOwnership,
+} from "./gateway/surface-ownership-plan";
 import type { Surfaces } from "./common/types/surfaces";
 import type { SurfaceGateway } from "./gateway/surface-gateway";
 
@@ -1723,24 +1726,26 @@ export async function startCortex(
   const adapters: PlatformAdapter[] = [];
   const adapterCleanup: (() => void)[] = [];
 
-  // GW.a.3b.2c (cortex#524) — the per-stack adapter suppression set. When
+  // GW.a.3b.2c (cortex#524) — the surface ownership plan. When
   // `CORTEX_GATEWAY` is set, the shared surface gateway (constructed below via
   // `startGatewayIfEnabled`) builds ONE adapter per `surfaces:` binding on the
   // SAME bot token the fold also wrote into `agents[].presence.{platform}`.
   // Starting the per-stack adapter too would double-connect that bot identity
-  // and double-deliver every message (the §1.2 bug). Each loop below skips an
-  // instance whose `{platform}:{agent.id}` is in this set, yielding that
-  // surface to the gateway.
+  // and double-deliver every message (the §1.2 bug). The plan is the single
+  // place that computes the per-stack suppression keys, Gateway adapter ids,
+  // and outbound stack pairs.
   //
-  // SAFETY: `gatewayOwnedSurfaceKeys` returns an EMPTY set when the flag is off
-  // (or no surfaces are configured). An empty set makes every `.has(...)` below
+  // SAFETY: the plan returns an EMPTY suppression set when the flag is off (or
+  // no surfaces are configured). An empty set makes every `.has(...)` below
   // false → no `continue` → the per-stack loops are byte-identical to the
   // pre-GW boot. `CORTEX_GATEWAY` is off on every live stack, so this is a
   // true no-op on the live boot path.
-  const gatewayOwned = gatewayOwnedSurfaceKeys(
-    options.surfaces,
-    isGatewayEnabled(process.env),
-  );
+  const surfaceOwnershipPlan = planSurfaceOwnership({
+    surfaces: options.surfaces,
+    gatewayEnabled: isGatewayEnabled(process.env),
+    principal: principalId,
+  });
+  const gatewayOwned = surfaceOwnershipPlan.ownedSurfaceKeys;
 
   // MIG-7.2e: per-instance agent lookup. When cortex.yaml supplies
   // `inlineAgents` (reused from the registry-merge block above), each
@@ -2646,6 +2651,7 @@ export async function startCortex(
     // additive args, no behaviour change on a dormant stack.
     source: systemEventSource,
     policyEngine: adapterPolicyEngine,
+    ownershipPlan: surfaceOwnershipPlan,
   });
   const gw: SurfaceGateway | undefined = startedGateway?.gateway;
 
@@ -2670,10 +2676,10 @@ export async function startCortex(
   // `{platform}:{demuxKey}` form would collide and let one envelope post to two
   // channels. Assert disjointness LOUDLY at boot rather than trust convention.
   if (startedGateway !== undefined) {
-    const perStackInstances = new Set(adapters.map((a) => a.instanceId));
-    const collisions = startedGateway.adapters
-      .map((a) => a.instanceId)
-      .filter((id) => perStackInstances.has(id));
+    const collisions = gatewayAdapterInstanceCollisions(
+      adapters,
+      startedGateway.adapters,
+    );
     if (collisions.length > 0) {
       throw new Error(
         `cortex: gateway adapter instanceId(s) ${collisions.map((c) => `"${c}"`).join(", ")} ` +

--- a/src/gateway/__tests__/cross-principal-routing.integration.test.ts
+++ b/src/gateway/__tests__/cross-principal-routing.integration.test.ts
@@ -37,8 +37,8 @@
  */
 
 import { describe, expect, test } from "bun:test";
-import { startGatewayIfEnabled } from "../start-gateway";
 import { BusInboundSink } from "../bus-inbound-sink";
+import { startGatewayWithPlan } from "./start-gateway-test-helper";
 import { createDispatchSink } from "../../adapters/dispatch-sink";
 import { MockAdapter } from "../../adapters/mock";
 import type { GatewayAdapterFactory } from "../gateway-adapters";
@@ -257,7 +257,7 @@ describe("F-2 — cross-principal collaboration through one gateway (unsigned)",
 
     let started;
     try {
-      started = await startGatewayIfEnabled({
+      started = await startGatewayWithPlan({
         env: { CORTEX_GATEWAY: "1", CORTEX_GATEWAY_PUBLISH: "1" },
         surfaces: TWO_PRINCIPAL_SURFACES,
         principal: "andreas", // gateway principal; joel is cross-principal
@@ -419,7 +419,7 @@ describe("F-2 — cross-principal collaboration through one gateway (unsigned)",
     process.stderr.write = (): boolean => true; // mute the F-1 cross-principal WARN
     let started;
     try {
-      started = await startGatewayIfEnabled({
+      started = await startGatewayWithPlan({
         env: { CORTEX_GATEWAY: "1", CORTEX_GATEWAY_PUBLISH: "1" },
         surfaces: TWO_PRINCIPAL_SURFACES,
         principal: "andreas",

--- a/src/gateway/__tests__/start-gateway-test-helper.ts
+++ b/src/gateway/__tests__/start-gateway-test-helper.ts
@@ -1,0 +1,19 @@
+import {
+  startGatewayIfEnabled,
+  type StartGatewayOpts,
+} from "../start-gateway";
+import { isGatewayEnabled } from "../gateway-bootstrap";
+import { planSurfaceOwnership } from "../surface-ownership-plan";
+
+export function startGatewayWithPlan(
+  opts: Omit<StartGatewayOpts, "ownershipPlan">,
+): ReturnType<typeof startGatewayIfEnabled> {
+  return startGatewayIfEnabled({
+    ...opts,
+    ownershipPlan: planSurfaceOwnership({
+      surfaces: opts.surfaces,
+      gatewayEnabled: isGatewayEnabled(opts.env),
+      principal: opts.principal,
+    }),
+  });
+}

--- a/src/gateway/__tests__/start-gateway.test.ts
+++ b/src/gateway/__tests__/start-gateway.test.ts
@@ -13,9 +13,9 @@
  */
 
 import { describe, expect, test } from "bun:test";
-import { startGatewayIfEnabled } from "../start-gateway";
 import { SurfaceGateway, LoggingInboundSink } from "../surface-gateway";
 import { BusInboundSink } from "../bus-inbound-sink";
+import { startGatewayWithPlan } from "./start-gateway-test-helper";
 import type { GatewayAdapterFactory } from "../gateway-adapters";
 import type { PlatformAdapter } from "../../adapters/types";
 import type { Surfaces } from "../../common/types/surfaces";
@@ -127,7 +127,7 @@ describe("startGatewayIfEnabled — flag off", () => {
   test("CORTEX_GATEWAY unset → returns undefined, constructs NOTHING", async () => {
     const started: string[] = [];
     const { factory, constructed } = makeCountingFactory(started);
-    const gw = await startGatewayIfEnabled({
+    const gw = await startGatewayWithPlan({
       env: {}, // flag unset
       surfaces: DISCORD_SURFACES,
       principal: "andreas",
@@ -145,7 +145,7 @@ describe("startGatewayIfEnabled — flag off", () => {
   test("CORTEX_GATEWAY='0' → returns undefined, constructs NOTHING", async () => {
     const started: string[] = [];
     const { factory, constructed } = makeCountingFactory(started);
-    const gw = await startGatewayIfEnabled({
+    const gw = await startGatewayWithPlan({
       env: { CORTEX_GATEWAY: "0" },
       surfaces: DISCORD_SURFACES,
       principal: "andreas",
@@ -162,7 +162,7 @@ describe("startGatewayIfEnabled — flag off", () => {
   test("CORTEX_GATEWAY='true' → returns undefined (only '1' is truthy)", async () => {
     const started: string[] = [];
     const { factory, constructed } = makeCountingFactory(started);
-    const gw = await startGatewayIfEnabled({
+    const gw = await startGatewayWithPlan({
       env: { CORTEX_GATEWAY: "true" },
       surfaces: DISCORD_SURFACES,
       principal: "andreas",
@@ -180,7 +180,7 @@ describe("startGatewayIfEnabled — flag on", () => {
   test("flag on + surfaces → builds adapters, returns a started SurfaceGateway", async () => {
     const started: string[] = [];
     const { factory, constructed } = makeCountingFactory(started);
-    const gw = await startGatewayIfEnabled({
+    const gw = await startGatewayWithPlan({
       env: { CORTEX_GATEWAY: "1" },
       surfaces: DISCORD_SURFACES,
       principal: "andreas",
@@ -235,7 +235,7 @@ describe("startGatewayIfEnabled — flag on", () => {
         },
       ],
     };
-    const gw = await startGatewayIfEnabled({
+    const gw = await startGatewayWithPlan({
       env: { CORTEX_GATEWAY: "1" },
       surfaces: multiStack,
       principal: "andreas",
@@ -293,7 +293,7 @@ describe("startGatewayIfEnabled — flag on", () => {
 
     let gw;
     try {
-      gw = await startGatewayIfEnabled({
+      gw = await startGatewayWithPlan({
         env: { CORTEX_GATEWAY: "1" },
         surfaces: multiPrincipal,
         // gateway principal "andreas" — "robin" is cross-principal
@@ -350,7 +350,7 @@ describe("startGatewayIfEnabled — flag on", () => {
     try {
       // F-1 (cortex#629): a cross-principal binding is no longer a hard throw —
       // the gateway starts and the binding is allowed (UNSIGNED/dev-only).
-      gw = await startGatewayIfEnabled({
+      gw = await startGatewayWithPlan({
         env: { CORTEX_GATEWAY: "1" },
         surfaces: crossPrincipal,
         principal: "andreas",
@@ -385,7 +385,7 @@ describe("startGatewayIfEnabled — flag on", () => {
   test("flag on but surfaces undefined → returns undefined (graceful degrade)", async () => {
     const started: string[] = [];
     const { factory, constructed } = makeCountingFactory(started);
-    const gw = await startGatewayIfEnabled({
+    const gw = await startGatewayWithPlan({
       env: { CORTEX_GATEWAY: "1" },
       surfaces: undefined,
       principal: "andreas",
@@ -403,7 +403,7 @@ describe("startGatewayIfEnabled — flag on", () => {
   test("flag on but surfaces empty → returns undefined", async () => {
     const started: string[] = [];
     const { factory, constructed } = makeCountingFactory(started);
-    const gw = await startGatewayIfEnabled({
+    const gw = await startGatewayWithPlan({
       env: { CORTEX_GATEWAY: "1" },
       surfaces: {},
       principal: "andreas",
@@ -419,7 +419,7 @@ describe("startGatewayIfEnabled — flag on", () => {
   test("the returned gateway can be stopped", async () => {
     const started: string[] = [];
     const { factory } = makeCountingFactory(started);
-    const gw = await startGatewayIfEnabled({
+    const gw = await startGatewayWithPlan({
       env: { CORTEX_GATEWAY: "1" },
       surfaces: DISCORD_SURFACES,
       principal: "andreas",
@@ -442,7 +442,7 @@ describe("startGatewayIfEnabled — sink selection (CORTEX_GATEWAY_PUBLISH)", ()
   test("publish flag OFF (gateway on) → gateway uses LoggingInboundSink (SHADOW)", async () => {
     const started: string[] = [];
     const { factory } = makeCountingFactory(started);
-    const gw = await startGatewayIfEnabled({
+    const gw = await startGatewayWithPlan({
       env: { CORTEX_GATEWAY: "1" }, // publish flag absent
       surfaces: DISCORD_SURFACES,
       principal: "andreas",
@@ -461,7 +461,7 @@ describe("startGatewayIfEnabled — sink selection (CORTEX_GATEWAY_PUBLISH)", ()
   test("publish flag '0' (gateway on) → still SHADOW (only '1' is truthy)", async () => {
     const started: string[] = [];
     const { factory } = makeCountingFactory(started);
-    const gw = await startGatewayIfEnabled({
+    const gw = await startGatewayWithPlan({
       env: { CORTEX_GATEWAY: "1", CORTEX_GATEWAY_PUBLISH: "0" },
       surfaces: DISCORD_SURFACES,
       principal: "andreas",
@@ -476,7 +476,7 @@ describe("startGatewayIfEnabled — sink selection (CORTEX_GATEWAY_PUBLISH)", ()
   test("publish flag 'true' (gateway on) → still SHADOW (only '1' is truthy)", async () => {
     const started: string[] = [];
     const { factory } = makeCountingFactory(started);
-    const gw = await startGatewayIfEnabled({
+    const gw = await startGatewayWithPlan({
       env: { CORTEX_GATEWAY: "1", CORTEX_GATEWAY_PUBLISH: "true" },
       surfaces: DISCORD_SURFACES,
       principal: "andreas",
@@ -491,7 +491,7 @@ describe("startGatewayIfEnabled — sink selection (CORTEX_GATEWAY_PUBLISH)", ()
   test("BOTH flags '1' → gateway uses BusInboundSink (LIVE — publishing)", async () => {
     const started: string[] = [];
     const { factory } = makeCountingFactory(started);
-    const gw = await startGatewayIfEnabled({
+    const gw = await startGatewayWithPlan({
       env: { CORTEX_GATEWAY: "1", CORTEX_GATEWAY_PUBLISH: "1" },
       surfaces: DISCORD_SURFACES,
       principal: "andreas",
@@ -508,7 +508,7 @@ describe("startGatewayIfEnabled — sink selection (CORTEX_GATEWAY_PUBLISH)", ()
   test("publish flag '1' but gateway flag OFF → undefined (gateway gate still wins)", async () => {
     const started: string[] = [];
     const { factory, constructed } = makeCountingFactory(started);
-    const gw = await startGatewayIfEnabled({
+    const gw = await startGatewayWithPlan({
       env: { CORTEX_GATEWAY_PUBLISH: "1" }, // gateway flag absent
       surfaces: DISCORD_SURFACES,
       principal: "andreas",
@@ -527,7 +527,7 @@ describe("startGatewayIfEnabled — sink selection (CORTEX_GATEWAY_PUBLISH)", ()
   test("both flags '1' but no bindings → undefined, never reaches BusInboundSink", async () => {
     const started: string[] = [];
     const { factory, constructed } = makeCountingFactory(started);
-    const gw = await startGatewayIfEnabled({
+    const gw = await startGatewayWithPlan({
       env: { CORTEX_GATEWAY: "1", CORTEX_GATEWAY_PUBLISH: "1" },
       surfaces: {}, // no bindings → Path-2 degrade, no publish
       principal: "andreas",

--- a/src/gateway/__tests__/surface-ownership-plan.test.ts
+++ b/src/gateway/__tests__/surface-ownership-plan.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, test } from "bun:test";
+import {
+  gatewayAdapterInstanceCollisions,
+  planSurfaceOwnership,
+} from "../surface-ownership-plan";
+import type { Surfaces } from "../../common/types/surfaces";
+
+const SURFACES: Surfaces = {
+  discord: [
+    {
+      agent: "luna",
+      stack: "andreas/meta-factory",
+      binding: {
+        token: "discord-token",
+        guildId: "111222333444555666",
+        agentChannelId: "aaa000000000000001",
+        logChannelId: "bbb000000000000002",
+      },
+    },
+    {
+      agent: "sage",
+      stack: "robin/research",
+      binding: {
+        token: "discord-token-2",
+        guildId: "222333444555666777",
+        agentChannelId: "ccc000000000000003",
+        logChannelId: "ddd000000000000004",
+      },
+    },
+  ],
+  slack: [
+    {
+      agent: "echo",
+      stack: "andreas/meta-factory",
+      binding: {
+        botToken: "xoxb-aaa",
+        appToken: "xapp-bbb",
+        workspaceId: "T01234567",
+      },
+    },
+  ],
+  mattermost: [
+    {
+      agent: "nova",
+      binding: {
+        apiUrl: "https://mm.example.com",
+        apiToken: "mm-token",
+      },
+    },
+  ],
+};
+
+describe("planSurfaceOwnership", () => {
+  test("flag off keeps an inactive plan even when surfaces have bindings", () => {
+    const plan = planSurfaceOwnership({
+      surfaces: SURFACES,
+      gatewayEnabled: false,
+      principal: "andreas",
+    });
+
+    expect(plan.gatewayEnabled).toBe(false);
+    expect(plan.hasSurfaceBindings).toBe(true);
+    expect(plan.gatewayStartEligible).toBe(false);
+    expect([...plan.ownedSurfaceKeys]).toEqual([]);
+    expect(plan.gatewayAdapterInstanceIds).toEqual([]);
+    expect(plan.outboundStacks).toEqual([]);
+    expect(plan.outboundPrincipalStacks).toEqual([]);
+    expect(plan.crossPrincipalBindings).toEqual([]);
+  });
+
+  test("flag on with no surfaces keeps a graceful no-start plan", () => {
+    const plan = planSurfaceOwnership({
+      surfaces: undefined,
+      gatewayEnabled: true,
+      principal: "andreas",
+    });
+
+    expect(plan.gatewayEnabled).toBe(true);
+    expect(plan.hasSurfaceBindings).toBe(false);
+    expect(plan.gatewayStartEligible).toBe(false);
+    expect([...plan.ownedSurfaceKeys]).toEqual([]);
+  });
+
+  test("flag on with an empty surfaces map keeps a no-start plan", () => {
+    const plan = planSurfaceOwnership({
+      surfaces: { discord: [], slack: [], mattermost: [] },
+      gatewayEnabled: true,
+      principal: "andreas",
+    });
+
+    expect(plan.gatewayEnabled).toBe(true);
+    expect(plan.hasSurfaceBindings).toBe(false);
+    expect(plan.gatewayStartEligible).toBe(false);
+    expect([...plan.ownedSurfaceKeys]).toEqual([]);
+    expect(plan.gatewayAdapterInstanceIds).toEqual([]);
+    expect(plan.outboundStacks).toEqual([]);
+    expect(plan.outboundPrincipalStacks).toEqual([]);
+  });
+
+  test("flag on with bindings plans suppression, Gateway ids, and outbound subjects", () => {
+    const plan = planSurfaceOwnership({
+      surfaces: SURFACES,
+      gatewayEnabled: true,
+      principal: "andreas",
+    });
+
+    expect(plan.gatewayStartEligible).toBe(true);
+    expect([...plan.ownedSurfaceKeys].sort()).toEqual([
+      "discord:luna",
+      "discord:sage",
+      "mattermost:nova",
+      "slack:echo",
+    ]);
+    expect(plan.gatewayAdapterInstanceIds).toEqual([
+      "discord:111222333444555666",
+      "discord:222333444555666777",
+      "slack:T01234567",
+      "mattermost:https://mm.example.com",
+    ]);
+    expect(plan.outboundStacks).toEqual(["meta-factory", "research", undefined]);
+    expect(plan.outboundPrincipalStacks).toEqual([
+      { principal: "andreas", stack: "meta-factory" },
+      { principal: "robin", stack: "research" },
+      { principal: "andreas", stack: undefined },
+    ]);
+    expect(plan.crossPrincipalBindings).toEqual(["robin/research"]);
+  });
+});
+
+describe("gatewayAdapterInstanceCollisions", () => {
+  test("reports Gateway adapter ids that collide with per-stack adapter ids", () => {
+    const collisions = gatewayAdapterInstanceCollisions(
+      [
+        { instanceId: "discord:111222333444555666" },
+        { instanceId: "slack-stack" },
+      ],
+      [
+        { instanceId: "discord:111222333444555666" },
+        { instanceId: "slack:T01234567" },
+      ],
+    );
+
+    expect(collisions).toEqual(["discord:111222333444555666"]);
+  });
+
+  test("returns an empty list when instance id sets are disjoint", () => {
+    const collisions = gatewayAdapterInstanceCollisions(
+      [{ instanceId: "discord-stack" }],
+      [{ instanceId: "discord:111222333444555666" }],
+    );
+
+    expect(collisions).toEqual([]);
+  });
+});

--- a/src/gateway/gateway-adapters.ts
+++ b/src/gateway/gateway-adapters.ts
@@ -67,6 +67,8 @@ import {
 } from "../common/types/cortex-config";
 import type { SystemEventSource } from "../bus/system-events";
 import type { MyelinRuntime } from "../bus/myelin/runtime";
+// Back-compat re-export for callers that still import the old suppression helper here.
+export { gatewayOwnedSurfaceKeys } from "./surface-ownership-plan";
 
 // =============================================================================
 // Factory seam — injected so tests construct without live connections
@@ -263,61 +265,4 @@ export function buildGatewayAdapters(
   }
 
   return adapters;
-}
-
-// =============================================================================
-// gatewayOwnedSurfaceKeys — the per-stack suppression set (GW.a.3b.2c)
-// =============================================================================
-
-/**
- * Build the set of `{platform}:{agentId}` keys the gateway OWNS, so the
- * per-stack adapter loops in `src/cortex.ts` can yield those surfaces to the
- * gateway and avoid a second connection on the same bot identity (cortex#524,
- * the §1.2 double-message bug).
- *
- * The problem this closes: `foldSurfaceBindings` folds a `surfaces:` binding
- * INTO `agents[].presence.{platform}`, so the per-stack loop would start an
- * adapter on that token — AND `buildGatewayAdapters` (above) ALSO builds an
- * adapter on the same token from the same `Surfaces` map. Two connections on
- * one bot identity in one runtime double-deliver every message. This set lets
- * the per-stack loop skip exactly the (platform, agent) pairs the gateway owns.
- *
- * Keying convention: `{platform}:{agentId}` where `agentId` is the binding's
- * `.agent` field (the fold-join key against `agents[].id`). The per-stack loop
- * matches each instance to its `Agent` and checks `has(`{platform}:${agent.id}`)`.
- * This is the SAME agent id both sides reference — the binding names it, the
- * fold writes it into that agent's presence, and the loop resolves it back.
- *
- * ## Hard safety contract
- *
- * Returns an **empty set** when `enabled` is false OR `surfaces` is undefined.
- * The per-stack loops gate their skip on `gatewayOwned.has(...)`; an empty set
- * makes every `.has(...)` false → no skip → byte-identical flag-off boot. This
- * is the single point that guarantees `CORTEX_GATEWAY` off changes nothing.
- *
- * Pure + side-effect-free — independently unit-testable.
- */
-export function gatewayOwnedSurfaceKeys(
-  surfaces: Surfaces | undefined,
-  enabled: boolean,
-): Set<string> {
-  const keys = new Set<string>();
-
-  // Flag off OR no surfaces → empty set → zero suppression (byte-identical
-  // flag-off boot). This guard is the safety contract; do not weaken it.
-  if (!enabled || surfaces === undefined) {
-    return keys;
-  }
-
-  for (const entry of surfaces.discord ?? []) {
-    keys.add(`discord:${entry.agent}`);
-  }
-  for (const entry of surfaces.slack ?? []) {
-    keys.add(`slack:${entry.agent}`);
-  }
-  for (const entry of surfaces.mattermost ?? []) {
-    keys.add(`mattermost:${entry.agent}`);
-  }
-
-  return keys;
 }

--- a/src/gateway/start-gateway.ts
+++ b/src/gateway/start-gateway.ts
@@ -2,10 +2,9 @@
  * GW.a.3b.2b — flag-gated gateway start orchestration (cortex#524).
  *
  * `startGatewayIfEnabled` is the ONE call cortex.ts makes to (maybe) stand up
- * the shared surface gateway. It keeps the boot path thin: cortex.ts adds a
- * single guarded `const gw = await startGatewayIfEnabled(...)` after its
- * per-stack adapters are built, and registers `gw?.stop()` in the existing
- * shutdown sequence. All flag-on orchestration lives HERE.
+ * the shared surface gateway. Cortex computes the pure ownership plan once
+ * before per-stack adapter boot, then passes the same plan here for Gateway
+ * start and outbound subject derivation.
  *
  * ## HARD SAFETY CONTRACT
  *
@@ -41,11 +40,11 @@
  * platform adapters opens no connection (start is deferred) — still, building
  * zero-value adapters for a no-binding config is pointless work, and the
  * factory-never-called invariant in the no-binding case keeps the contract
- * crisp + testable. We compute `hasBindings` up front and short-circuit.
+ * crisp + testable. The ownership plan computes `hasSurfaceBindings` up front,
+ * and this start path short-circuits from that decision.
  */
 
 import {
-  isGatewayEnabled,
   isGatewayPublishEnabled,
   maybeCreateSurfaceGateway,
 } from "./gateway-bootstrap";
@@ -55,12 +54,8 @@ import {
   type GatewayAdapterFactory,
 } from "./gateway-adapters";
 import { BusInboundSink } from "./bus-inbound-sink";
-import {
-  distinctBoundStacks,
-  distinctBoundPrincipalStacks,
-  crossPrincipalBindings,
-  type BoundPrincipalStack,
-} from "./binding-resolver";
+import type { BoundPrincipalStack } from "./binding-resolver";
+import type { SurfaceOwnershipPlan } from "./surface-ownership-plan";
 import type { SurfaceGateway } from "./surface-gateway";
 import type { Surfaces } from "../common/types/surfaces";
 import type { MyelinRuntime } from "../bus/myelin/runtime";
@@ -105,6 +100,12 @@ export interface StartGatewayOpts {
   factory?: GatewayAdapterFactory;
   /** Optional unroutable-message hook forwarded to the gateway. */
   onUnroutable?: (msg: InboundMessage, reason: string) => void;
+  /**
+   * Precomputed pure ownership plan from the boot path. Required so Gateway
+   * start, per-stack suppression, and outbound sink subject derivation all use
+   * the same ownership decision.
+   */
+  ownershipPlan: SurfaceOwnershipPlan;
 }
 
 /**
@@ -147,15 +148,6 @@ export interface StartedGateway {
   principalStacks: readonly BoundPrincipalStack[];
 }
 
-/** Count the total bindings across all platforms in a `Surfaces` map. */
-function countBindings(surfaces: Surfaces): number {
-  return (
-    (surfaces.discord?.length ?? 0) +
-    (surfaces.slack?.length ?? 0) +
-    (surfaces.mattermost?.length ?? 0)
-  );
-}
-
 /**
  * Flag-gated: maybe construct + start the shared surface gateway.
  *
@@ -171,10 +163,10 @@ function countBindings(surfaces: Surfaces): number {
 export async function startGatewayIfEnabled(
   opts: StartGatewayOpts,
 ): Promise<StartedGateway | undefined> {
-  const enabled = isGatewayEnabled(opts.env);
+  const { ownershipPlan } = opts;
 
   // ── Path 1: flag off → true no-op. Construct NOTHING. ─────────────────────
-  if (!enabled) {
+  if (!ownershipPlan.gatewayEnabled) {
     return undefined;
   }
 
@@ -182,7 +174,7 @@ export async function startGatewayIfEnabled(
   // Short-circuit BEFORE buildGatewayAdapters so the factory is never called
   // when there is nothing to demux (keeps the no-binding invariant crisp).
   const { surfaces } = opts;
-  if (surfaces === undefined || countBindings(surfaces) === 0) {
+  if (!ownershipPlan.gatewayStartEligible) {
     // maybeCreateSurfaceGateway emits the principal-facing stderr warning for
     // the no-binding case AND returns `undefined` (zero bindings). Call it for
     // that one-place log side-effect, then return `undefined` — there is no
@@ -194,6 +186,11 @@ export async function startGatewayIfEnabled(
       ...(opts.onUnroutable !== undefined && { onUnroutable: opts.onUnroutable }),
     });
     return undefined;
+  }
+  if (surfaces === undefined) {
+    throw new Error(
+      "surface-gateway ownership plan is start-eligible but surfaces are undefined",
+    );
   }
 
   // ── Path 3: flag on + bindings → build, construct, start. ─────────────────
@@ -212,7 +209,7 @@ export async function startGatewayIfEnabled(
   // untrusted peers until signing is layered on (cortex#552 / cortex#635).
   // `crossPrincipalBindings` stays the detector — only this consumer changed
   // from throw→warn.
-  const crossPrincipal = crossPrincipalBindings(surfaces, opts.principal);
+  const crossPrincipal = ownershipPlan.crossPrincipalBindings;
   if (crossPrincipal.length > 0) {
     process.stderr.write(
       `[surface-gateway] WARNING: cross-principal surface bindings are UNSIGNED/UNAUTHENTICATED ` +
@@ -290,7 +287,7 @@ export async function startGatewayIfEnabled(
   return {
     gateway: gw,
     adapters,
-    stacks: distinctBoundStacks(surfaces),
-    principalStacks: distinctBoundPrincipalStacks(surfaces, opts.principal),
+    stacks: ownershipPlan.outboundStacks,
+    principalStacks: ownershipPlan.outboundPrincipalStacks,
   };
 }

--- a/src/gateway/surface-ownership-plan.ts
+++ b/src/gateway/surface-ownership-plan.ts
@@ -1,0 +1,154 @@
+/**
+ * Surface ownership planning for the shared Gateway.
+ *
+ * The Gateway owns surface bindings from `surfaces.yaml`; the per-stack
+ * adapter loops own folded `agents[].presence`. Because a Gateway-owned binding
+ * is also folded into stack presence, runtime boot needs one pure plan that
+ * says which per-stack adapters yield, which Gateway adapter instance ids must
+ * stay disjoint, and which stack subjects the Gateway dispatch sink subscribes
+ * to.
+ */
+
+import type { PlatformAdapter } from "../adapters/types";
+import type { Surfaces } from "../common/types/surfaces";
+import {
+  crossPrincipalBindings,
+  distinctBoundPrincipalStacks,
+  distinctBoundStacks,
+  type BoundPrincipalStack,
+} from "./binding-resolver";
+
+export interface SurfaceOwnershipPlan {
+  /** True when `CORTEX_GATEWAY` selected the Gateway path. */
+  gatewayEnabled: boolean;
+  /** True when the composed `Surfaces` map has at least one binding. */
+  hasSurfaceBindings: boolean;
+  /** True when boot should attempt to construct and start the Gateway. */
+  gatewayStartEligible: boolean;
+  /** `{platform}:{agentId}` keys that per-stack adapter loops must yield. */
+  ownedSurfaceKeys: ReadonlySet<string>;
+  /** Expected Gateway adapter instance ids, derived from surface demux keys. */
+  gatewayAdapterInstanceIds: readonly string[];
+  /**
+   * Legacy distinct stack leaves for single-principal dispatch sink callers.
+   * `undefined` is the stackless binding bucket.
+   */
+  outboundStacks: readonly (string | undefined)[];
+  /** Distinct `(principal, stack)` pairs for Gateway dispatch sink subjects. */
+  outboundPrincipalStacks: readonly BoundPrincipalStack[];
+  /** Raw `stack` values whose principal differs from the Gateway principal. */
+  crossPrincipalBindings: readonly string[];
+}
+
+export interface SurfaceOwnershipPlanOpts {
+  surfaces: Surfaces | undefined;
+  gatewayEnabled: boolean;
+  principal: string;
+}
+
+function countSurfaceBindings(surfaces: Surfaces | undefined): number {
+  if (surfaces === undefined) return 0;
+  return (
+    (surfaces.discord?.length ?? 0) +
+    (surfaces.slack?.length ?? 0) +
+    (surfaces.mattermost?.length ?? 0)
+  );
+}
+
+function ownedKeys(surfaces: Surfaces | undefined): Set<string> {
+  const keys = new Set<string>();
+  if (surfaces === undefined) return keys;
+  for (const entry of surfaces.discord ?? []) keys.add(`discord:${entry.agent}`);
+  for (const entry of surfaces.slack ?? []) keys.add(`slack:${entry.agent}`);
+  for (const entry of surfaces.mattermost ?? []) keys.add(`mattermost:${entry.agent}`);
+  return keys;
+}
+
+function gatewayInstanceIds(surfaces: Surfaces | undefined): string[] {
+  const ids: string[] = [];
+  if (surfaces === undefined) return ids;
+  for (const entry of surfaces.discord ?? []) {
+    ids.push(`discord:${entry.binding.guildId}`);
+  }
+  for (const entry of surfaces.slack ?? []) {
+    ids.push(`slack:${entry.binding.workspaceId}`);
+  }
+  for (const entry of surfaces.mattermost ?? []) {
+    ids.push(`mattermost:${entry.binding.apiUrl}`);
+  }
+  return ids;
+}
+
+function emptyPlan(
+  opts: SurfaceOwnershipPlanOpts,
+  hasSurfaceBindings: boolean,
+): SurfaceOwnershipPlan {
+  return {
+    gatewayEnabled: opts.gatewayEnabled,
+    hasSurfaceBindings,
+    gatewayStartEligible: false,
+    ownedSurfaceKeys: new Set(),
+    gatewayAdapterInstanceIds: [],
+    outboundStacks: [],
+    outboundPrincipalStacks: [],
+    crossPrincipalBindings: [],
+  };
+}
+
+/**
+ * Build the Gateway ownership plan from composed surfaces and the Gateway flag.
+ *
+ * Flag off always yields an inactive plan: no per-stack suppression, no Gateway
+ * adapter ids, and no outbound subject pairs. This is the byte-identical
+ * flag-off safety contract.
+ */
+export function planSurfaceOwnership(
+  opts: SurfaceOwnershipPlanOpts,
+): SurfaceOwnershipPlan {
+  const hasSurfaceBindings = countSurfaceBindings(opts.surfaces) > 0;
+  if (!opts.gatewayEnabled || opts.surfaces === undefined || !hasSurfaceBindings) {
+    return emptyPlan(opts, hasSurfaceBindings);
+  }
+
+  return {
+    gatewayEnabled: true,
+    hasSurfaceBindings,
+    gatewayStartEligible: true,
+    ownedSurfaceKeys: ownedKeys(opts.surfaces),
+    gatewayAdapterInstanceIds: gatewayInstanceIds(opts.surfaces),
+    outboundStacks: distinctBoundStacks(opts.surfaces),
+    outboundPrincipalStacks: distinctBoundPrincipalStacks(
+      opts.surfaces,
+      opts.principal,
+    ),
+    crossPrincipalBindings: crossPrincipalBindings(opts.surfaces, opts.principal),
+  };
+}
+
+/**
+ * Compatibility helper for existing per-stack loops and tests.
+ *
+ * Prefer `planSurfaceOwnership` when the caller also needs Gateway adapter ids
+ * or outbound stack pairs.
+ */
+export function gatewayOwnedSurfaceKeys(
+  surfaces: Surfaces | undefined,
+  enabled: boolean,
+): Set<string> {
+  if (!enabled) return new Set();
+  return ownedKeys(surfaces);
+}
+
+/**
+ * Return Gateway adapter instance ids that collide with already-started
+ * per-stack adapters. Runtime boot throws on a non-empty result.
+ */
+export function gatewayAdapterInstanceCollisions(
+  perStackAdapters: readonly Pick<PlatformAdapter, "instanceId">[],
+  gatewayAdapters: readonly Pick<PlatformAdapter, "instanceId">[],
+): string[] {
+  const perStackInstances = new Set(perStackAdapters.map((a) => a.instanceId));
+  return gatewayAdapters
+    .map((a) => a.instanceId)
+    .filter((id) => perStackInstances.has(id));
+}


### PR DESCRIPTION
## Summary

- add a pure Surface Ownership Plan Module for Gateway-enabled surface binding ownership
- route per-stack suppression, Gateway start stack derivation, and adapter instance collision checks through the plan
- keep gatewayOwnedSurfaceKeys as a compatibility export and add focused ownership-plan tests

## Verification

- rtk bun test src/gateway/__tests__/surface-ownership-plan.test.ts src/gateway/__tests__/gateway-owned-surface-keys.test.ts src/gateway/__tests__/start-gateway.test.ts src/gateway/__tests__/gateway-adapters.test.ts
- rtk bunx tsc --noEmit
- rtk bun run lint:errors
- rtk bun test
