### PR TITLE
fix(gateway): group Discord bindings by bot token

### DIFF
--- a/src/adapters/discord/index.ts
+++ b/src/adapters/discord/index.ts
@@ -130,6 +130,11 @@ export interface DiscordAdapterInfra {
    * gateway adapters pass every guild served by the one Discord token.
    */
   allowedGuildIds?: ReadonlySet<string>;
+  /**
+   * Gateway-only per-guild presence map for grouped token connections. Direct
+   * adapters omit this and read the constructor `presence` for their one guild.
+   */
+  presenceByGuildId?: ReadonlyMap<string, DiscordPresence>;
 }
 
 interface PendingResult {
@@ -170,6 +175,7 @@ export class DiscordAdapter implements PlatformAdapter {
   private runtime: MyelinRuntime | undefined;
   private systemEventSource: SystemEventSource | undefined;
   private readonly allowedGuildIds: ReadonlySet<string>;
+  private readonly presenceByGuildId: ReadonlyMap<string, DiscordPresence>;
   /**
    * cortex#84: snapshot of `infra.trustedBotIds` taken at construction
    * time. `ReadonlySet` so the messageCreate hot path can't accidentally
@@ -204,7 +210,11 @@ export class DiscordAdapter implements PlatformAdapter {
     this.instanceId = infra.instanceId;
     this.runtime = infra.runtime;
     this.systemEventSource = infra.systemEventSource;
-    this.allowedGuildIds = infra.allowedGuildIds ?? new Set([presence.guildId]);
+    this.presenceByGuildId = new Map([
+      [presence.guildId, presence],
+      ...(infra.presenceByGuildId ?? new Map()),
+    ]);
+    this.allowedGuildIds = infra.allowedGuildIds ?? new Set(this.presenceByGuildId.keys());
     // cortex#84: snapshot the allowlist at construction. Pre-build the
     // empty-set sentinel so the messageCreate hot path can call
     // `set.has` unconditionally without a null check.
@@ -220,6 +230,11 @@ export class DiscordAdapter implements PlatformAdapter {
         `discord-${this.instanceId}: surfaceSubjects is empty — adapter will never render bus envelopes`,
       );
     }
+  }
+
+  private presenceForGuild(guildId: string | null | undefined): DiscordPresence {
+    if (!guildId) return this.presence;
+    return this.presenceByGuildId.get(guildId) ?? this.presence;
   }
 
   /**
@@ -388,6 +403,7 @@ export class DiscordAdapter implements PlatformAdapter {
       if (message.guildId && !this.allowedGuildIds.has(message.guildId)) {
         return;
       }
+      const messagePresence = this.presenceForGuild(message.guildId);
 
       // Deduplicate — skip if we've already seen this message ID
       if (recentMessageIds.has(message.id)) return;
@@ -413,7 +429,7 @@ export class DiscordAdapter implements PlatformAdapter {
         // `DiscordPresenceSchema.dmOwner` for the misconfiguration semantics
         // (all-true → today's double-answer; all-false → DMs unanswered, the
         // deliberate fail-safe direction).
-        if (!this.presence.dmOwner) {
+        if (!messagePresence.dmOwner) {
           return;
         }
         // Self-loop guard — never respond to our own DMs, regardless of

--- a/src/adapters/discord/index.ts
+++ b/src/adapters/discord/index.ts
@@ -124,6 +124,12 @@ export interface DiscordAdapterInfra {
    * the principal record.
    */
   policyRegistry?: PrincipalRegistry;
+  /**
+   * Gateway-only guild allowlist. Direct per-stack adapters omit this and keep
+   * the strict single-guild isolation gate from `presence.guildId`; grouped
+   * gateway adapters pass every guild served by the one Discord token.
+   */
+  allowedGuildIds?: ReadonlySet<string>;
 }
 
 interface PendingResult {
@@ -163,6 +169,7 @@ export class DiscordAdapter implements PlatformAdapter {
    */
   private runtime: MyelinRuntime | undefined;
   private systemEventSource: SystemEventSource | undefined;
+  private readonly allowedGuildIds: ReadonlySet<string>;
   /**
    * cortex#84: snapshot of `infra.trustedBotIds` taken at construction
    * time. `ReadonlySet` so the messageCreate hot path can't accidentally
@@ -197,6 +204,7 @@ export class DiscordAdapter implements PlatformAdapter {
     this.instanceId = infra.instanceId;
     this.runtime = infra.runtime;
     this.systemEventSource = infra.systemEventSource;
+    this.allowedGuildIds = infra.allowedGuildIds ?? new Set([presence.guildId]);
     // cortex#84: snapshot the allowlist at construction. Pre-build the
     // empty-set sentinel so the messageCreate hot path can call
     // `set.has` unconditionally without a null check.
@@ -377,7 +385,7 @@ export class DiscordAdapter implements PlatformAdapter {
       //     that branch unreachable.
       //   - String compare (no coercion games): both sides are Discord
       //     snowflake strings post-schema; `!==` is exact.
-      if (message.guildId && message.guildId !== this.presence.guildId) {
+      if (message.guildId && !this.allowedGuildIds.has(message.guildId)) {
         return;
       }
 

--- a/src/gateway/__tests__/gateway-adapters.test.ts
+++ b/src/gateway/__tests__/gateway-adapters.test.ts
@@ -37,6 +37,7 @@ interface FactoryCall {
   binding: Record<string, unknown>;
   runtime: MyelinRuntime | undefined;
   allowedGuildIds?: string[];
+  presenceByGuildId?: Record<string, { agentChannelId: string; logChannelId: string }>;
 }
 
 function makeFakeAdapter(
@@ -71,6 +72,15 @@ function makeRecordingFactory(): {
   const calls: FactoryCall[] = [];
   const factory: GatewayAdapterFactory = {
     discord: (args) => {
+      const presenceByGuildId = Object.fromEntries(
+        [...args.presenceByGuildId].map(([guildId, presence]) => [
+          guildId,
+          {
+            agentChannelId: presence.agentChannelId,
+            logChannelId: presence.logChannelId,
+          },
+        ]),
+      );
       calls.push({
         platform: "discord",
         instanceId: args.instanceId,
@@ -78,6 +88,7 @@ function makeRecordingFactory(): {
         binding: args.binding,
         runtime: args.runtime,
         allowedGuildIds: [...args.allowedGuildIds].sort(),
+        presenceByGuildId,
       });
       return makeFakeAdapter("discord", args.instanceId);
     },
@@ -264,6 +275,16 @@ describe("buildGatewayAdapters", () => {
       "1487023327791808592",
       "1505549701674700991",
     ]);
+    expect(calls[0]?.presenceByGuildId).toEqual({
+      "1487023327791808592": {
+        agentChannelId: "1487023328324616266",
+        logChannelId: "1487023328324616266",
+      },
+      "1505549701674700991": {
+        agentChannelId: "1513296336739635322",
+        logChannelId: "1513296336739635322",
+      },
+    });
   });
 
   test("mixed surfaces → one adapter per binding, correct platforms", () => {

--- a/src/gateway/__tests__/gateway-adapters.test.ts
+++ b/src/gateway/__tests__/gateway-adapters.test.ts
@@ -174,6 +174,31 @@ const SAME_TOKEN_DISCORD_SURFACES: Surfaces = {
   ],
 };
 
+const SAME_TOKEN_DIFFERENT_STACKS_DISCORD_SURFACES: Surfaces = {
+  discord: [
+    {
+      agent: "juniper",
+      stack: "jc/default",
+      binding: {
+        token: "tok-juniper",
+        guildId: "1487023327791808592",
+        agentChannelId: "1487023328324616266",
+        logChannelId: "1487023328324616266",
+      },
+    },
+    {
+      agent: "juniper",
+      stack: "jc/research",
+      binding: {
+        token: "tok-juniper",
+        guildId: "1505549701674700991",
+        agentChannelId: "1513296336739635322",
+        logChannelId: "1513296336739635322",
+      },
+    },
+  ],
+};
+
 const MULTI_SURFACES: Surfaces = {
   discord: [
     {
@@ -285,6 +310,24 @@ describe("buildGatewayAdapters", () => {
         logChannelId: "1513296336739635322",
       },
     });
+  });
+
+  test("same Discord token across two stacks → separate stack-scoped adapters", () => {
+    const { factory, calls } = makeRecordingFactory();
+    const adapters = buildGatewayAdapters(
+      SAME_TOKEN_DIFFERENT_STACKS_DISCORD_SURFACES,
+      makeDeps(factory),
+    );
+
+    expect(adapters.length).toBe(2);
+    expect(calls.map((call) => call.instanceId)).toEqual([
+      "discord:1487023327791808592",
+      "discord:1505549701674700991",
+    ]);
+    expect(calls.map((call) => call.allowedGuildIds)).toEqual([
+      ["1487023327791808592"],
+      ["1505549701674700991"],
+    ]);
   });
 
   test("mixed surfaces → one adapter per binding, correct platforms", () => {

--- a/src/gateway/__tests__/gateway-adapters.test.ts
+++ b/src/gateway/__tests__/gateway-adapters.test.ts
@@ -36,6 +36,7 @@ interface FactoryCall {
   /** The credential block handed to the factory (presence-shaped). */
   binding: Record<string, unknown>;
   runtime: MyelinRuntime | undefined;
+  allowedGuildIds?: string[];
 }
 
 function makeFakeAdapter(
@@ -76,6 +77,7 @@ function makeRecordingFactory(): {
         source: args.source,
         binding: args.binding,
         runtime: args.runtime,
+        allowedGuildIds: [...args.allowedGuildIds].sort(),
       });
       return makeFakeAdapter("discord", args.instanceId);
     },
@@ -131,6 +133,31 @@ const DISCORD_SURFACES: Surfaces = {
         guildId: "111222333444555666",
         agentChannelId: "aaa000000000000001",
         logChannelId: "bbb000000000000002",
+      },
+    },
+  ],
+};
+
+const SAME_TOKEN_DISCORD_SURFACES: Surfaces = {
+  discord: [
+    {
+      agent: "juniper",
+      stack: "jc/default",
+      binding: {
+        token: "tok-juniper",
+        guildId: "1487023327791808592",
+        agentChannelId: "1487023328324616266",
+        logChannelId: "1487023328324616266",
+      },
+    },
+    {
+      agent: "juniper",
+      stack: "jc/default",
+      binding: {
+        token: "tok-juniper",
+        guildId: "1505549701674700991",
+        agentChannelId: "1513296336739635322",
+        logChannelId: "1513296336739635322",
       },
     },
   ],
@@ -223,6 +250,20 @@ describe("buildGatewayAdapters", () => {
     const { factory, calls } = makeRecordingFactory();
     buildGatewayAdapters(DISCORD_SURFACES, makeDeps(factory));
     expect(calls[0]?.runtime).toBe(RUNTIME_STUB);
+  });
+
+  test("same Discord token across two guild bindings → one adapter with both guilds allowed", () => {
+    const { factory, calls } = makeRecordingFactory();
+    const adapters = buildGatewayAdapters(SAME_TOKEN_DISCORD_SURFACES, makeDeps(factory));
+
+    expect(adapters.length).toBe(1);
+    expect(calls.length).toBe(1);
+    expect(calls[0]?.platform).toBe("discord");
+    expect(calls[0]?.instanceId).toMatch(/^discord:token:[0-9a-f]{12}$/);
+    expect(calls[0]?.allowedGuildIds).toEqual([
+      "1487023327791808592",
+      "1505549701674700991",
+    ]);
   });
 
   test("mixed surfaces → one adapter per binding, correct platforms", () => {

--- a/src/gateway/__tests__/start-gateway.test.ts
+++ b/src/gateway/__tests__/start-gateway.test.ts
@@ -255,6 +255,52 @@ describe("startGatewayIfEnabled — flag on", () => {
     ]);
   });
 
+  test("same Discord token across two guild bindings → starts one token-scoped adapter", async () => {
+    const started: string[] = [];
+    const { factory, constructed } = makeCountingFactory(started);
+    const sameToken: Surfaces = {
+      discord: [
+        {
+          agent: "juniper",
+          stack: "jc/default",
+          binding: {
+            token: "tok-juniper",
+            guildId: "1487023327791808592",
+            agentChannelId: "1487023328324616266",
+            logChannelId: "1487023328324616266",
+          },
+        },
+        {
+          agent: "juniper",
+          stack: "jc/default",
+          binding: {
+            token: "tok-juniper",
+            guildId: "1505549701674700991",
+            agentChannelId: "1513296336739635322",
+            logChannelId: "1513296336739635322",
+          },
+        },
+      ],
+    };
+
+    const gw = await startGatewayWithPlan({
+      env: { CORTEX_GATEWAY: "1" },
+      surfaces: sameToken,
+      principal: "jc",
+      runtime: RUNTIME_STUB,
+      source: SOURCE_STUB,
+      policyEngine: POLICY_ENGINE_STUB,
+      factory,
+    });
+
+    expect(gw?.gateway).toBeInstanceOf(SurfaceGateway);
+    expect(constructed).toHaveLength(1);
+    expect(started).toEqual(constructed);
+    expect(constructed[0]).toMatch(/^discord:token:[0-9a-f]{12}$/);
+    expect(gw?.adapters.map((a) => a.instanceId)).toEqual(constructed);
+    expect(gw?.principalStacks).toEqual([{ principal: "jc", stack: "default" }]);
+  });
+
   test("multi-principal bindings → WARNS, starts, exposes per-principal pairs (F-1, cortex#629)", async () => {
     const started: string[] = [];
     const { factory } = makeCountingFactory(started);

--- a/src/gateway/__tests__/surface-ownership-plan.test.ts
+++ b/src/gateway/__tests__/surface-ownership-plan.test.ts
@@ -161,6 +161,46 @@ describe("planSurfaceOwnership", () => {
     expect([...plan.ownedSurfaceKeys]).toEqual(["discord:juniper"]);
     expect(plan.outboundPrincipalStacks).toEqual([{ principal: "jc", stack: "default" }]);
   });
+
+  test("same Discord token across two stacks keeps separate Gateway ids", () => {
+    const plan = planSurfaceOwnership({
+      surfaces: {
+        discord: [
+          {
+            agent: "juniper",
+            stack: "jc/default",
+            binding: {
+              token: "discord-token",
+              guildId: "1487023327791808592",
+              agentChannelId: "1487023328324616266",
+              logChannelId: "1487023328324616266",
+            },
+          },
+          {
+            agent: "juniper",
+            stack: "jc/research",
+            binding: {
+              token: "discord-token",
+              guildId: "1505549701674700991",
+              agentChannelId: "1513296336739635322",
+              logChannelId: "1513296336739635322",
+            },
+          },
+        ],
+      },
+      gatewayEnabled: true,
+      principal: "jc",
+    });
+
+    expect(plan.gatewayAdapterInstanceIds).toEqual([
+      "discord:1487023327791808592",
+      "discord:1505549701674700991",
+    ]);
+    expect(plan.outboundPrincipalStacks).toEqual([
+      { principal: "jc", stack: "default" },
+      { principal: "jc", stack: "research" },
+    ]);
+  });
 });
 
 describe("gatewayAdapterInstanceCollisions", () => {

--- a/src/gateway/__tests__/surface-ownership-plan.test.ts
+++ b/src/gateway/__tests__/surface-ownership-plan.test.ts
@@ -125,6 +125,42 @@ describe("planSurfaceOwnership", () => {
     ]);
     expect(plan.crossPrincipalBindings).toEqual(["robin/research"]);
   });
+
+  test("same Discord token across two guild bindings plans one token-scoped Gateway id", () => {
+    const plan = planSurfaceOwnership({
+      surfaces: {
+        discord: [
+          {
+            agent: "juniper",
+            stack: "jc/default",
+            binding: {
+              token: "discord-token",
+              guildId: "1487023327791808592",
+              agentChannelId: "1487023328324616266",
+              logChannelId: "1487023328324616266",
+            },
+          },
+          {
+            agent: "juniper",
+            stack: "jc/default",
+            binding: {
+              token: "discord-token",
+              guildId: "1505549701674700991",
+              agentChannelId: "1513296336739635322",
+              logChannelId: "1513296336739635322",
+            },
+          },
+        ],
+      },
+      gatewayEnabled: true,
+      principal: "jc",
+    });
+
+    expect(plan.gatewayAdapterInstanceIds).toHaveLength(1);
+    expect(plan.gatewayAdapterInstanceIds[0]).toMatch(/^discord:token:[0-9a-f]{12}$/);
+    expect([...plan.ownedSurfaceKeys]).toEqual(["discord:juniper"]);
+    expect(plan.outboundPrincipalStacks).toEqual([{ principal: "jc", stack: "default" }]);
+  });
 });
 
 describe("gatewayAdapterInstanceCollisions", () => {

--- a/src/gateway/discord-token-groups.ts
+++ b/src/gateway/discord-token-groups.ts
@@ -1,0 +1,43 @@
+import { createHash } from "node:crypto";
+
+import type { Surfaces } from "../common/types/surfaces";
+
+type DiscordSurfaceBinding = NonNullable<Surfaces["discord"]>[number];
+
+export interface DiscordTokenGroup {
+  token: string;
+  entries: DiscordSurfaceBinding[];
+  guildIds: string[];
+  instanceId: string;
+}
+
+export function discordTokenInstanceId(token: string): string {
+  const digest = createHash("sha256").update(token).digest("hex").slice(0, 12);
+  return `discord:token:${digest}`;
+}
+
+export function groupDiscordBindingsByToken(
+  entries: readonly DiscordSurfaceBinding[],
+): DiscordTokenGroup[] {
+  const groups = new Map<string, DiscordSurfaceBinding[]>();
+  for (const entry of entries) {
+    const token = entry.binding.token;
+    const group = groups.get(token);
+    if (group) {
+      group.push(entry);
+    } else {
+      groups.set(token, [entry]);
+    }
+  }
+
+  return [...groups].map(([token, groupedEntries]) => {
+    const guildIds = groupedEntries.map((entry) => entry.binding.guildId);
+    const firstGuildId = guildIds[0];
+    const instanceId =
+      guildIds.length === 1 && firstGuildId !== undefined
+        ? `discord:${firstGuildId}`
+        : discordTokenInstanceId(token);
+
+    return { token, entries: groupedEntries, guildIds, instanceId };
+  });
+}

--- a/src/gateway/discord-token-groups.ts
+++ b/src/gateway/discord-token-groups.ts
@@ -5,14 +5,15 @@ import type { Surfaces } from "../common/types/surfaces";
 type DiscordSurfaceBinding = NonNullable<Surfaces["discord"]>[number];
 
 export interface DiscordTokenGroup {
-  token: string;
   entries: DiscordSurfaceBinding[];
-  guildIds: string[];
   instanceId: string;
 }
 
-export function discordTokenInstanceId(token: string): string {
-  const digest = createHash("sha256").update(token).digest("hex").slice(0, 12);
+export function discordTokenInstanceId(token: string, stack: string | undefined): string {
+  const digest = createHash("sha256")
+    .update(JSON.stringify({ token, stack: stack ?? null }))
+    .digest("hex")
+    .slice(0, 12);
   return `discord:token:${digest}`;
 }
 
@@ -21,23 +22,29 @@ export function groupDiscordBindingsByToken(
 ): DiscordTokenGroup[] {
   const groups = new Map<string, DiscordSurfaceBinding[]>();
   for (const entry of entries) {
-    const token = entry.binding.token;
-    const group = groups.get(token);
+    const groupKey = JSON.stringify({
+      token: entry.binding.token,
+      stack: entry.stack ?? null,
+    });
+    const group = groups.get(groupKey);
     if (group) {
       group.push(entry);
     } else {
-      groups.set(token, [entry]);
+      groups.set(groupKey, [entry]);
     }
   }
 
-  return [...groups].map(([token, groupedEntries]) => {
+  return [...groups.values()].map((groupedEntries) => {
+    const firstEntry = groupedEntries[0];
+    const token = firstEntry?.binding.token ?? "";
+    const stack = firstEntry?.stack;
     const guildIds = groupedEntries.map((entry) => entry.binding.guildId);
     const firstGuildId = guildIds[0];
     const instanceId =
       guildIds.length === 1 && firstGuildId !== undefined
         ? `discord:${firstGuildId}`
-        : discordTokenInstanceId(token);
+        : discordTokenInstanceId(token, stack);
 
-    return { token, entries: groupedEntries, guildIds, instanceId };
+    return { entries: groupedEntries, instanceId };
   });
 }

--- a/src/gateway/gateway-adapters.ts
+++ b/src/gateway/gateway-adapters.ts
@@ -51,6 +51,8 @@
  * can be threaded through `deps` if needed.
  */
 
+import { createHash } from "node:crypto";
+
 import { DiscordAdapter } from "../adapters/discord";
 import { SlackAdapter } from "../adapters/slack";
 import { MattermostAdapter } from "../adapters/mattermost";
@@ -92,6 +94,8 @@ interface FactoryArgsBase {
 
 interface DiscordFactoryArgs extends FactoryArgsBase {
   presence: DiscordPresence;
+  /** Discord guild ids accepted by this gateway-owned token connection. */
+  allowedGuildIds: ReadonlySet<string>;
 }
 interface SlackFactoryArgs extends FactoryArgsBase {
   presence: SlackPresence;
@@ -158,12 +162,13 @@ function syntheticGatewayAgent(
  * adapters are CONSTRUCTED only — `buildGatewayAdapters` does not start them.
  */
 export const defaultGatewayAdapterFactory: GatewayAdapterFactory = {
-  discord: ({ instanceId, source, presence, runtime }) =>
+  discord: ({ instanceId, source, presence, runtime, allowedGuildIds }) =>
     new DiscordAdapter(syntheticGatewayAgent(source.agent, { discord: presence }), presence, {
       instanceId,
       principal: {},
       ...(runtime !== undefined && { runtime }),
       systemEventSource: source,
+      allowedGuildIds,
     }),
 
   slack: ({ instanceId, source, presence, runtime }) =>
@@ -196,6 +201,27 @@ function gatewaySource(principal: string, instance: string): SystemEventSource {
   return { principal, agent: "gateway", instance };
 }
 
+function discordTokenInstanceId(token: string): string {
+  const digest = createHash("sha256").update(token).digest("hex").slice(0, 12);
+  return `discord:token:${digest}`;
+}
+
+function discordTokenGroups(
+  entries: NonNullable<Surfaces["discord"]>,
+): Map<string, NonNullable<Surfaces["discord"]>> {
+  const groups = new Map<string, NonNullable<Surfaces["discord"]>>();
+  for (const entry of entries) {
+    const token = entry.binding.token;
+    const group = groups.get(token);
+    if (group) {
+      group.push(entry);
+    } else {
+      groups.set(token, [entry]);
+    }
+  }
+  return groups;
+}
+
 /**
  * Construct ONE {@link PlatformAdapter} per surface binding.
  *
@@ -217,17 +243,28 @@ export function buildGatewayAdapters(
   const { principal, runtime, factory } = deps;
   const adapters: PlatformAdapter[] = [];
 
-  // ── Discord — demux key = guildId ─────────────────────────────────────────
-  for (const entry of surfaces.discord ?? []) {
-    const presence = DiscordPresenceSchema.parse(entry.binding);
-    const instanceId = `discord:${presence.guildId}`;
+  // ── Discord — one gateway connection per bot token ────────────────────────
+  //
+  // Discord delivers every guild event for a bot token over that token's one
+  // gateway session. Surface routing remains guild-keyed, but the platform
+  // connection is token-keyed so one assistant can serve multiple guilds
+  // without opening duplicate sessions for the same bot identity.
+  for (const group of discordTokenGroups(surfaces.discord ?? []).values()) {
+    const presences = group.map((entry) => DiscordPresenceSchema.parse(entry.binding));
+    const presence = presences[0];
+    const firstBinding = group[0]?.binding;
+    if (!presence || !firstBinding) continue;
+    const allowedGuildIds = new Set(presences.map((p) => p.guildId));
+    const instanceId =
+      presences.length === 1 ? `discord:${presence.guildId}` : discordTokenInstanceId(presence.token);
     adapters.push(
       factory.discord({
         instanceId,
         source: gatewaySource(principal, instanceId),
-        binding: entry.binding,
+        binding: firstBinding,
         runtime,
         presence,
+        allowedGuildIds,
       }),
     );
   }

--- a/src/gateway/gateway-adapters.ts
+++ b/src/gateway/gateway-adapters.ts
@@ -95,6 +95,8 @@ interface DiscordFactoryArgs extends FactoryArgsBase {
   presence: DiscordPresence;
   /** Discord guild ids accepted by this gateway-owned token connection. */
   allowedGuildIds: ReadonlySet<string>;
+  /** Per-guild presence config for grouped token connections. */
+  presenceByGuildId: ReadonlyMap<string, DiscordPresence>;
 }
 interface SlackFactoryArgs extends FactoryArgsBase {
   presence: SlackPresence;
@@ -161,13 +163,14 @@ function syntheticGatewayAgent(
  * adapters are CONSTRUCTED only — `buildGatewayAdapters` does not start them.
  */
 export const defaultGatewayAdapterFactory: GatewayAdapterFactory = {
-  discord: ({ instanceId, source, presence, runtime, allowedGuildIds }) =>
+  discord: ({ instanceId, source, presence, runtime, allowedGuildIds, presenceByGuildId }) =>
     new DiscordAdapter(syntheticGatewayAgent(source.agent, { discord: presence }), presence, {
       instanceId,
       principal: {},
       ...(runtime !== undefined && { runtime }),
       systemEventSource: source,
       allowedGuildIds,
+      presenceByGuildId,
     }),
 
   slack: ({ instanceId, source, presence, runtime }) =>
@@ -232,7 +235,8 @@ export function buildGatewayAdapters(
     const presence = presences[0];
     const firstBinding = group.entries[0]?.binding;
     if (!presence || !firstBinding) continue;
-    const allowedGuildIds = new Set(presences.map((p) => p.guildId));
+    const presenceByGuildId = new Map(presences.map((p) => [p.guildId, p] as const));
+    const allowedGuildIds = new Set(presenceByGuildId.keys());
     adapters.push(
       factory.discord({
         instanceId: group.instanceId,
@@ -241,6 +245,7 @@ export function buildGatewayAdapters(
         runtime,
         presence,
         allowedGuildIds,
+        presenceByGuildId,
       }),
     );
   }

--- a/src/gateway/gateway-adapters.ts
+++ b/src/gateway/gateway-adapters.ts
@@ -51,8 +51,6 @@
  * can be threaded through `deps` if needed.
  */
 
-import { createHash } from "node:crypto";
-
 import { DiscordAdapter } from "../adapters/discord";
 import { SlackAdapter } from "../adapters/slack";
 import { MattermostAdapter } from "../adapters/mattermost";
@@ -69,6 +67,7 @@ import {
 } from "../common/types/cortex-config";
 import type { SystemEventSource } from "../bus/system-events";
 import type { MyelinRuntime } from "../bus/myelin/runtime";
+import { groupDiscordBindingsByToken } from "./discord-token-groups";
 // Back-compat re-export for callers that still import the old suppression helper here.
 export { gatewayOwnedSurfaceKeys } from "./surface-ownership-plan";
 
@@ -201,27 +200,6 @@ function gatewaySource(principal: string, instance: string): SystemEventSource {
   return { principal, agent: "gateway", instance };
 }
 
-function discordTokenInstanceId(token: string): string {
-  const digest = createHash("sha256").update(token).digest("hex").slice(0, 12);
-  return `discord:token:${digest}`;
-}
-
-function discordTokenGroups(
-  entries: NonNullable<Surfaces["discord"]>,
-): Map<string, NonNullable<Surfaces["discord"]>> {
-  const groups = new Map<string, NonNullable<Surfaces["discord"]>>();
-  for (const entry of entries) {
-    const token = entry.binding.token;
-    const group = groups.get(token);
-    if (group) {
-      group.push(entry);
-    } else {
-      groups.set(token, [entry]);
-    }
-  }
-  return groups;
-}
-
 /**
  * Construct ONE {@link PlatformAdapter} per surface binding.
  *
@@ -249,18 +227,16 @@ export function buildGatewayAdapters(
   // gateway session. Surface routing remains guild-keyed, but the platform
   // connection is token-keyed so one assistant can serve multiple guilds
   // without opening duplicate sessions for the same bot identity.
-  for (const group of discordTokenGroups(surfaces.discord ?? []).values()) {
-    const presences = group.map((entry) => DiscordPresenceSchema.parse(entry.binding));
+  for (const group of groupDiscordBindingsByToken(surfaces.discord ?? [])) {
+    const presences = group.entries.map((entry) => DiscordPresenceSchema.parse(entry.binding));
     const presence = presences[0];
-    const firstBinding = group[0]?.binding;
+    const firstBinding = group.entries[0]?.binding;
     if (!presence || !firstBinding) continue;
     const allowedGuildIds = new Set(presences.map((p) => p.guildId));
-    const instanceId =
-      presences.length === 1 ? `discord:${presence.guildId}` : discordTokenInstanceId(presence.token);
     adapters.push(
       factory.discord({
-        instanceId,
-        source: gatewaySource(principal, instanceId),
+        instanceId: group.instanceId,
+        source: gatewaySource(principal, group.instanceId),
         binding: firstBinding,
         runtime,
         presence,

--- a/src/gateway/surface-ownership-plan.ts
+++ b/src/gateway/surface-ownership-plan.ts
@@ -11,6 +11,7 @@
 
 import type { PlatformAdapter } from "../adapters/types";
 import type { Surfaces } from "../common/types/surfaces";
+import { createHash } from "node:crypto";
 import {
   crossPrincipalBindings,
   distinctBoundPrincipalStacks,
@@ -67,8 +68,22 @@ function ownedKeys(surfaces: Surfaces | undefined): Set<string> {
 function gatewayInstanceIds(surfaces: Surfaces | undefined): string[] {
   const ids: string[] = [];
   if (surfaces === undefined) return ids;
+  const discordByToken = new Map<string, string[]>();
   for (const entry of surfaces.discord ?? []) {
-    ids.push(`discord:${entry.binding.guildId}`);
+    const guilds = discordByToken.get(entry.binding.token);
+    if (guilds) {
+      guilds.push(entry.binding.guildId);
+    } else {
+      discordByToken.set(entry.binding.token, [entry.binding.guildId]);
+    }
+  }
+  for (const [token, guilds] of discordByToken) {
+    const firstGuild = guilds[0];
+    if (guilds.length === 1 && firstGuild !== undefined) {
+      ids.push(`discord:${firstGuild}`);
+    } else {
+      ids.push(`discord:token:${createHash("sha256").update(token).digest("hex").slice(0, 12)}`);
+    }
   }
   for (const entry of surfaces.slack ?? []) {
     ids.push(`slack:${entry.binding.workspaceId}`);

--- a/src/gateway/surface-ownership-plan.ts
+++ b/src/gateway/surface-ownership-plan.ts
@@ -11,13 +11,13 @@
 
 import type { PlatformAdapter } from "../adapters/types";
 import type { Surfaces } from "../common/types/surfaces";
-import { createHash } from "node:crypto";
 import {
   crossPrincipalBindings,
   distinctBoundPrincipalStacks,
   distinctBoundStacks,
   type BoundPrincipalStack,
 } from "./binding-resolver";
+import { groupDiscordBindingsByToken } from "./discord-token-groups";
 
 export interface SurfaceOwnershipPlan {
   /** True when `CORTEX_GATEWAY` selected the Gateway path. */
@@ -68,22 +68,8 @@ function ownedKeys(surfaces: Surfaces | undefined): Set<string> {
 function gatewayInstanceIds(surfaces: Surfaces | undefined): string[] {
   const ids: string[] = [];
   if (surfaces === undefined) return ids;
-  const discordByToken = new Map<string, string[]>();
-  for (const entry of surfaces.discord ?? []) {
-    const guilds = discordByToken.get(entry.binding.token);
-    if (guilds) {
-      guilds.push(entry.binding.guildId);
-    } else {
-      discordByToken.set(entry.binding.token, [entry.binding.guildId]);
-    }
-  }
-  for (const [token, guilds] of discordByToken) {
-    const firstGuild = guilds[0];
-    if (guilds.length === 1 && firstGuild !== undefined) {
-      ids.push(`discord:${firstGuild}`);
-    } else {
-      ids.push(`discord:token:${createHash("sha256").update(token).digest("hex").slice(0, 12)}`);
-    }
+  for (const group of groupDiscordBindingsByToken(surfaces.discord ?? [])) {
+    ids.push(group.instanceId);
   }
   for (const entry of surfaces.slack ?? []) {
     ids.push(`slack:${entry.binding.workspaceId}`);


### PR DESCRIPTION
## Summary

- group Discord gateway surface bindings by bot token so one bot identity can serve multiple configured guilds through one gateway connection
- add a gateway-only Discord guild allowlist so grouped adapters accept each configured guild while direct per-stack adapters keep single-guild isolation
- align surface ownership planning and gateway tests with token-scoped Discord adapter instance ids

## Verification

- `rtk bunx tsc --noEmit`
- `rtk bunx eslint src/adapters/discord/index.ts src/gateway/gateway-adapters.ts src/gateway/surface-ownership-plan.ts src/gateway/__tests__/gateway-adapters.test.ts src/gateway/__tests__/start-gateway.test.ts src/gateway/__tests__/surface-ownership-plan.test.ts`
- `rtk bun test src/gateway/__tests__/gateway-adapters.test.ts src/gateway/__tests__/start-gateway.test.ts src/gateway/__tests__/surface-ownership-plan.test.ts src/gateway/__tests__/cross-principal-routing.integration.test.ts`

## Live Validation

- applied a compatible hotfix to Clawbox `v5.1.3` checkout and verified:
  - `bun test src/gateway/__tests__/gateway-adapters.test.ts src/gateway/__tests__/start-gateway.test.ts src/gateway/__tests__/gateway-owned-surface-keys.test.ts`
  - `bunx tsc --noEmit`
  - gateway config dry-run with the Codex Discord binding
- enabled Clawbox `cortex-bot.service` gateway drop-in with `CORTEX_GATEWAY=1` and `CORTEX_GATEWAY_PUBLISH=1`
- runtime log showed `2 bindings, 1 adapter` and `connected as Juniper#6019`
- user confirmed Juniper replied in the Codex Discord server

## Rollback Notes

- existing direct Discord adapters default `allowedGuildIds` to `presence.guildId`, preserving current single-guild behavior
- single Discord binding keeps the existing `discord:<guildId>` instance id
- Clawbox config backup from the live test: `/home/clawbox/.config/cortex/cortex.yaml.pre-juniper-codex-gateway-20260608T064149`
- Clawbox gateway enablement drop-in: `/home/clawbox/.config/systemd/user/cortex-bot.service.d/gateway.conf`
