### PR TITLE
fix(runner): C-127 — plumb receiving-stack bashAllowlist through bus dispatch path

### DIFF
--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -2400,6 +2400,19 @@ export async function startCortex(
     // TC-2d (cortex#635) — federated.* peer-pubkey resolution seam.
     // Inert for local.* dispatches; `undefined` under off/permissive.
     ...(resolveFederatedPeer !== undefined && { resolveFederatedPeer }),
+    // cortex#127 — RECEIVING-STACK-AUTHORITATIVE bash allowlist. Thread the
+    // executing stack's OWN `claude.bashAllowlist` config to the listener so
+    // every bus-mediated dispatch's CC session gets `CORTEX_BASH_GUARD` set
+    // (the bus path previously dropped it — the guard hook then fell through
+    // to an unanswerable `claude --print` permission prompt and bounced every
+    // allowlisted command, blocking GUILD-only stacks). Spread-guarded like
+    // the other optional fields so an unconfigured stack stays default-deny.
+    // Never wire-supplied: the payload has no bash_allowlist by design.
+    // (No `claude.bashGuardDisabled` config field exists, so it is not passed
+    // here; the listener option remains available for a future config knob.)
+    ...(config.claude.bashAllowlist !== undefined && {
+      bashAllowlist: config.claude.bashAllowlist,
+    }),
   });
   await dispatchListener.start();
 

--- a/src/runner/__tests__/dispatch-listener.test.ts
+++ b/src/runner/__tests__/dispatch-listener.test.ts
@@ -738,6 +738,71 @@ describe("dispatch-listener — success path", () => {
     expect(opts.resumeSessionId).toBe("prior-session");
   });
 
+  // cortex#127 — RECEIVING-STACK-AUTHORITATIVE bash allowlist plumbing.
+  // The bus dispatch path used to drop the stack's bashAllowlist, so the
+  // spawned session never got CORTEX_BASH_GUARD set; the bash-guard hook
+  // then treated it as a non-Grove session and fell through to an
+  // unanswerable `claude --print` permission prompt, bouncing every
+  // allowlisted command and blocking GUILD-only stacks. The fix threads the
+  // EXECUTING stack's own config-supplied allowlist through the listener.
+  test("receiving-stack bashAllowlist reaches CCSessionOpts on a bus dispatch (cortex#127)", async () => {
+    const r = recordingRuntime();
+    const router = createSurfaceRouter(r.runtime);
+    const { factory, optsCaptured } = fakeFactory(SUCCESS_RESULT);
+    const stackAllowlist = {
+      rules: [{ pattern: "gh api repos/.*", repos: ["community"] }],
+      repos: ["community"],
+    };
+    const listener = createDispatchListener({
+      runtime: r.runtime,
+      source: SOURCE,
+      ccSessionFactory: factory,
+      policyEngine: engineGranting(["dispatch.cortex"]),
+      // The receiving stack's OWN configured allowlist (as cortex.ts threads
+      // `config.claude.bashAllowlist`).
+      bashAllowlist: stackAllowlist,
+    });
+    await listener.start();
+    await router.start();
+
+    // A bare payload — NO bash_allowlist field exists on the wire by design.
+    r.trigger(makeReceivedEnvelope(), CANONICAL_CORTEX_CHAT_SUBJECT);
+    await settle(() => r.published);
+
+    expect(optsCaptured).toHaveLength(1);
+    const opts = optsCaptured[0]!;
+    // The stack's allowlist reached the session opts → cc-session will
+    // serialise it into CORTEX_BASH_GUARD → the guard hook auto-approves
+    // allowlisted commands instead of bouncing.
+    expect(opts.bashAllowlist).toEqual(stackAllowlist);
+  });
+
+  // cortex#127 — default-deny posture is preserved when the stack configures
+  // NO allowlist: nothing is injected, so the session runs with the guard's
+  // deny-everything default (a Grove session with no CORTEX_BASH_GUARD
+  // allowlist denies every Bash command — it never silently opens up).
+  test("no bashAllowlist option → CCSessionOpts.bashAllowlist stays undefined (default-deny, cortex#127)", async () => {
+    const r = recordingRuntime();
+    const router = createSurfaceRouter(r.runtime);
+    const { factory, optsCaptured } = fakeFactory(SUCCESS_RESULT);
+    const listener = createDispatchListener({
+      runtime: r.runtime,
+      source: SOURCE,
+      ccSessionFactory: factory,
+      policyEngine: engineGranting(["dispatch.cortex"]),
+      // No bashAllowlist supplied — stack has none configured.
+    });
+    await listener.start();
+    await router.start();
+
+    r.trigger(makeReceivedEnvelope(), CANONICAL_CORTEX_CHAT_SUBJECT);
+    await settle(() => r.published);
+
+    expect(optsCaptured).toHaveLength(1);
+    const opts = optsCaptured[0]!;
+    expect(opts.bashAllowlist).toBeUndefined();
+  });
+
   test("allowed_skills round-trips payload → harness → CCSessionOpts (cortex#710)", async () => {
     // The grant decision rides the payload's `allowed_skills`; the harness
     // turns it into {broad Skill allow + allowedSkills (→ gate hook)} —

--- a/src/runner/dispatch-listener.ts
+++ b/src/runner/dispatch-listener.ts
@@ -164,18 +164,30 @@ export type CCSessionFactory = ClaudeCodeFactory;
  * **Known asymmetry vs. DispatchRequest / DispatchRuntime (Echo cortex#127 items 2 + 3).**
  *
  * The in-process dispatch contract carries typed knobs that this bus
- * payload intentionally does not yet surface:
+ * payload intentionally does not surface:
  *
  *   - `DispatchRequest.inactivityMs` (top-level, alongside `timeoutMs`) —
  *     no corresponding `inactivity_ms` here.
  *   - `DispatchRuntime.bashAllowlist` / `DispatchRuntime.bashGuardDisabled` —
  *     no corresponding `bash_allowlist` / `bash_guard_disabled` here.
  *
- * Adapter-direct (non-bus) dispatches can populate these in-process
- * fields; bus-mediated dispatches today pick up the harness/dispatch-handler
- * defaults. Plumbing them through is future-facing work — natural fit for
- * the next payload-schema revision (Phase A.5+ stack identity expansion or
- * a dedicated payload-versioning PR).
+ * **cortex#127 — bash allowlist is now plumbed receiving-side, NOT via the
+ * payload.** The fix for the GUILD-only-stack bounce (dispatched sessions
+ * never got `CORTEX_BASH_GUARD` set, so the bash-guard hook fell through to
+ * an unanswerable `claude --print` permission prompt) plumbs
+ * `bashAllowlist` / `bashGuardDisabled` through the LISTENER, sourced from
+ * the EXECUTING stack's `claude.bashAllowlist` config in `cortex.ts` — see
+ * {@link DispatchListenerOptions.bashAllowlist}. The wire payload still has
+ * NO `bash_allowlist` / `bash_guard_disabled` field by design: the receiving
+ * stack's configured allowlist is authoritative, and letting a remote
+ * dispatcher supply one would let it weaken/replace/expand the guard on a
+ * public-facing surface. So the absence here is now intentional and
+ * load-bearing, not a TODO.
+ *
+ * `inactivity_ms` remains genuinely unplumbed; adapter-direct (non-bus)
+ * dispatches can populate it in-process, bus-mediated ones pick up the
+ * harness/dispatch-handler default. Surfacing it is future-facing work
+ * (Phase A.5+ or a dedicated payload-versioning PR).
  */
 export interface DispatchTaskReceivedPayload {
   /** UUID-shaped task identifier (also envelope.correlation_id). */
@@ -450,6 +462,48 @@ export interface DispatchListenerOptions {
    * cortex.yaml can set it from parsed config.
    */
   traceDispatch?: boolean;
+  /**
+   * cortex#127 — **receiving-stack bash allowlist (RECEIVING-STACK-
+   * AUTHORITATIVE).** The EXECUTING stack's own `claude.bashAllowlist`
+   * config, applied to EVERY dispatch this listener runs so the spawned
+   * Claude Code session gets `CORTEX_BASH_GUARD` set (via
+   * `CCSessionOpts.bashAllowlist` → cc-session env serialisation). Without
+   * it, the bash-guard PreToolUse hook treats the session as a non-Grove
+   * session and falls through to Claude Code's permission prompt — which is
+   * unanswerable in async `claude --print`, so every allowlisted command
+   * bounces. That blocked all GUILD-only stacks (`andreas/community`,
+   * `andreas/halden`); meta-factory dodged it only because principal DMs get
+   * full access with no guard.
+   *
+   * **Security — stack config wins, full stop.** This is the receiving
+   * stack's OWN configured value, threaded from `cortex.ts`
+   * (`config.claude.bashAllowlist`). It is NEVER sourced from the wire
+   * payload: `DispatchTaskReceivedPayload` deliberately carries no
+   * `bash_allowlist` field (see the asymmetry docblock above), so a remote
+   * dispatcher cannot supply, weaken, replace, or expand the allowlist. The
+   * listener injects this onto every `DispatchRequest.runtime` regardless of
+   * the inbound envelope. When omitted (no `claude.bashAllowlist` in config),
+   * nothing is injected → the default-deny posture is preserved (the guard
+   * hook denies every Bash command in a Grove session with no allowlist).
+   *
+   * Same shape as `CCSessionOpts.bashAllowlist` /
+   * `DispatchRuntime.bashAllowlist`.
+   */
+  bashAllowlist?: {
+    rules: { pattern: string; repos?: string[] }[];
+    repos: string[];
+  };
+  /**
+   * cortex#127 — receiving-stack bash-guard disable flag. When `true`,
+   * the spawned session runs with the bash guard OFF (the highest-privilege
+   * posture, e.g. principal DMs). Like {@link bashAllowlist} this is the
+   * RECEIVING stack's own configured value — never wire-supplied — and is
+   * injected onto every `DispatchRequest.runtime`. There is no corresponding
+   * config field today (cortex.yaml `claude` has no `bashGuardDisabled`), so
+   * `cortex.ts` does not currently pass it; the option exists so the
+   * plumbing is complete and a future config knob is a one-line wire-up.
+   */
+  bashGuardDisabled?: boolean;
 }
 
 export interface DispatchListener {
@@ -704,6 +758,8 @@ export function createDispatchListener(
     stackNKeyPub,
     resignSigner,
     resolveFederatedPeer,
+    bashAllowlist,
+    bashGuardDisabled,
     adapterId = "runner-dispatch-listener",
   } = opts;
   // v2.0.2 default: structural trust + ed25519 crypto verification.
@@ -783,6 +839,8 @@ export function createDispatchListener(
         resolveFederatedPeer,
         federatedNetworksById,
         traceDispatch,
+        bashAllowlist,
+        bashGuardDisabled,
       });
     } catch (err) {
       process.stderr.write(
@@ -1137,6 +1195,22 @@ interface DispatchHandlerContext {
    * just reads it and passes it to `trace()`.
    */
   traceDispatch: boolean;
+  /**
+   * cortex#127 — RECEIVING-STACK-AUTHORITATIVE bash allowlist. The
+   * executing stack's own `claude.bashAllowlist`, injected onto every
+   * `DispatchRequest.runtime` so the spawned session gets
+   * `CORTEX_BASH_GUARD` set. NEVER sourced from the wire payload — see
+   * {@link DispatchListenerOptions.bashAllowlist}.
+   */
+  bashAllowlist:
+    | { rules: { pattern: string; repos?: string[] }[]; repos: string[] }
+    | undefined;
+  /**
+   * cortex#127 — receiving-stack bash-guard disable flag. Same
+   * receiving-side authority as {@link bashAllowlist}. `undefined` today
+   * (no config knob); injected onto `DispatchRequest.runtime` when set.
+   */
+  bashGuardDisabled: boolean | undefined;
 }
 
 async function handleDispatchEnvelope(
@@ -1162,6 +1236,8 @@ async function handleDispatchEnvelope(
     resolveFederatedPeer,
     federatedNetworksById,
     traceDispatch,
+    bashAllowlist,
+    bashGuardDisabled,
   } = ctx;
   // cortex#492 — pre-parse trace context. Refined to the trusted payload
   // fields (`task_id`, `agent_id`) once the parse succeeds.
@@ -1662,6 +1738,37 @@ async function handleDispatchEnvelope(
   // structurally compatible between `SystemEventSource` and the harness's
   // `DispatchEventSource` (both alias the same shape in `dispatch-events.ts`).
   const req = buildDispatchRequest(payload, gatedPrincipal);
+
+  // cortex#127 — RECEIVING-STACK-AUTHORITATIVE bash guard injection.
+  //
+  // The bus payload carries NO bash allowlist (by design — a remote
+  // dispatcher must not be able to weaken/replace/expand the guard on this
+  // public-facing surface). Instead the EXECUTING stack's own configured
+  // `claude.bashAllowlist` (threaded from `cortex.ts`) is injected onto
+  // EVERY dispatch's `runtime` block here, so the spawned CC session gets
+  // `CORTEX_BASH_GUARD` set (`runtime.bashAllowlist` → the claude-code
+  // harness `buildCCOpts` → `CCSessionOpts.bashAllowlist` → cc-session env
+  // serialisation). Without this the guard hook treated the dispatched
+  // session as a non-Grove session and fell through to an unanswerable
+  // `claude --print` permission prompt, bouncing every allowlisted command
+  // and blocking all GUILD-only stacks (cortex#127).
+  //
+  // Security invariant: this overwrites whatever (if anything) was on
+  // `req.runtime.bashAllowlist` — and since `buildDispatchRequest` never
+  // populates it from the payload, there is nothing wire-supplied to
+  // overwrite. Stack config is the single source of truth. When
+  // `bashAllowlist` is undefined (no `claude.bashAllowlist` in config) we
+  // inject nothing, preserving default-deny (the guard denies every Bash
+  // command in a Grove session that has no allowlist).
+  if (bashAllowlist !== undefined || bashGuardDisabled !== undefined) {
+    const runtime = req.runtime ?? {};
+    if (bashAllowlist !== undefined) runtime.bashAllowlist = bashAllowlist;
+    if (bashGuardDisabled !== undefined) {
+      runtime.bashGuardDisabled = bashGuardDisabled;
+    }
+    req.runtime = runtime;
+  }
+
   const harness: SessionHarness =
     envelope.distribution_mode === "delegate"
       ? new AgentTeamHarness({


### PR DESCRIPTION
## Problem

The canonical **bus dispatch path** drops the receiving stack's `bashAllowlist`, so dispatched Claude Code sessions never get `CORTEX_BASH_GUARD` set. The bash-guard PreToolUse hook then treats the session as "not a Grove session" and falls through to Claude Code's normal permission prompt — **unanswerable in async `claude --print`**, so every allowlisted command (e.g. `gh api repos/owner/name/...`) **bounces** instead of auto-approving.

This blocks **all GUILD-only stacks** (`andreas/community`, `andreas/halden`). meta-factory dodged it only because principal DMs get full access (no guard). Documented asymmetry: `dispatch-listener.ts` "Echo cortex#127 items 2+3".

Surfaced live: Luna (community stack) bounced on `gh issue list`, `gh pr list`, and `gh api repos/mellanon/pai-collab/commits` despite a correct `claude.bashAllowlist`.

## Fix — RECEIVING-STACK-AUTHORITATIVE

The **executing** stack applies its **own** configured `claude.bashAllowlist` to every dispatch it runs, plumbed at the **listener** level — never trusted from the wire payload.

- `createDispatchListener` gains `bashAllowlist?` / `bashGuardDisabled?` options → `DispatchHandlerContext`.
- `handleDispatchEnvelope` injects them onto `DispatchRequest.runtime` **after** `buildDispatchRequest` → claude-code harness `runtime.bashAllowlist` → `CCSessionOpts.bashAllowlist` → `CORTEX_BASH_GUARD`.
- `cortex.ts` passes `config.claude.bashAllowlist` (spread-guarded) at the `createDispatchListener` call.

### Security invariant
Stack config is the **single source of truth**. The payload carries no allowlist (by design — a remote dispatcher must not weaken/replace/expand the guard on a public-facing surface). When no `claude.bashAllowlist` is configured, **nothing is injected → default-deny preserved**.

## Tests
- 2 new dispatch-listener tests (stack allowlist reaches `CCSessionOpts`; no option → undefined / default-deny).
- `bun test src/runner` 475/475; dispatch-listener 77/77; substrates 39/39.

Unblocks guild-only stacks (community + halden). Refs cortex#127.

🤖 Generated with [Claude Code](https://claude.com/claude-code)