### PR TITLE
docs: network SOPs — cortex network create (#747)

### DIFF
--- a/docs/sop-federation-onboarding.md
+++ b/docs/sop-federation-onboarding.md
@@ -103,6 +103,8 @@ Schema: `PolicyFederatedRegistrySchema` in `src/common/types/cortex-config.ts`. 
 
 This is the one mutual topology step. Both principals **agree on which side hosts the leaf hub**, then wire the leafnode link that joins the two buses into the `metafactory` network. This is a NATS-server config concern, **separate from the registry** ([§6](#6-the-leaf-link-topology)). The registry resolves *identity*; it does **not** create the bus link.
 
+> **Standing up a brand-new network.** For `metafactory` the network descriptor (its `hub_url` / `leaf_port`) already exists in the registry. When you bring up a *new* network, a network admin first creates its topology row with one command — `cortex network create <network> --hub <tls-url> --leaf-port <port> --admin-seed <seed> --apply` (#747, v5.2.0; signed-admin claim, no raw SQL). See [`sop-stack-onboarding.md` §B1](./sop-stack-onboarding.md) for the full flow + the one-time `REGISTRY_ADMIN_PUBKEYS` prerequisite.
+
 ### Step (v) — set `accept_subjects` + announce capabilities
 
 On the network entry in `policy.federated.networks[]` (`PolicyFederatedNetworkSchema`, `src/common/types/cortex-config.ts`), declare what inbound federated traffic you accept and what you offer:

--- a/docs/sop-network-join.md
+++ b/docs/sop-network-join.md
@@ -118,7 +118,8 @@ This SOP covers the **federated** scope (joining a named network of peer princip
 Reach for the manual fallback in [`docs/runbook-federation-peering.md`](./runbook-federation-peering.md) (#728) only when:
 
 - there is **no reachable registry** for the network, or
-- you need an **offline hand-pin** of a peer (DD-5's fallback: a `principal_pubkey` pasted out-of-band), or
-- you are bringing up a **brand-new network/hub** before its descriptor exists in the registry.
+- you need an **offline hand-pin** of a peer (DD-5's fallback: a `principal_pubkey` pasted out-of-band).
+
+Bringing up a **brand-new network** before its descriptor exists is **not** a fallback case — it is its own one command: a network admin runs `cortex network create <network> --hub <tls-url> --leaf-port <port> --admin-seed <seed> --apply` to write the topology row, then principals `join` it as below. See [`sop-stack-onboarding.md` §B1](./sop-stack-onboarding.md) for the full create flow + the one-time `REGISTRY_ADMIN_PUBKEYS` prerequisite (#747).
 
 Otherwise, the one command above is the path. If a join step still demands NATS/PKI expertise, that is a design bug (spec §9) — file it against #733.

--- a/docs/sop-stack-onboarding.md
+++ b/docs/sop-stack-onboarding.md
@@ -162,19 +162,48 @@ Federating turns the stack's hard-isolated local bus into a **leaf** of a shared
 - **A reachable NATS leaf hub** (`host:port` + TLS). Reuse an existing endpoint under a NEW network id (e.g. `tls://nats.meta-factory.dev:7422`), or stand one up.
 - **A leaf `.creds` for THIS stack on that hub** — the gating manual artifact (like a VPN cert). Issued by the hub admin (`nsc`: a user under the hub's leaf account → `nsc generate creds`). Drop at `~/.config/nats/<network>.creds`. Note the **account** NKey (`A…`) it belongs to — it goes in `stack.nats_infra.account`. See [`runbook-federation-peering.md`](./runbook-federation-peering.md) for the manual hub side.
 
-### B1 — Seed the network in the registry (admin)
+### B1 — Create the network in the registry (network admin)
 
-The registry has no public create route (#747) — seed the topology row directly (D1 UPSERT, the `putNetwork` shape). Needs `CLOUDFLARE_API_TOKEN` + Node 22:
+Standing up a network is now **one command** (#747, v5.2.0) — no raw SQL, no `CLOUDFLARE_API_TOKEN`. `cortex network create` POSTs a **signed-admin claim** to the registry's fail-closed `POST /networks/<network>`; the registry verifies the Ed25519 signature and checks the signing pubkey against its `REGISTRY_ADMIN_PUBKEYS` allowlist before writing the topology row.
+
+**One-time prerequisite (per registry, done once).** The registry must trust a network-admin key before it will accept any create:
+
+1. Generate the network-admin signing key — the same `SU…` seed shape every stack identity uses. Keep the seed chmod 600; note the base64 pubkey it prints:
+   ```bash
+   cortex provision-stack generate <network-admin-id> \
+     --seed-path ~/.config/nats/network-admin.nk \
+     --stack-id <network-admin-id>/registry-admin
+   ```
+2. Allowlist that pubkey on the registry and redeploy (a one-time `wrangler secret put` — the value is the **base64 admin pubkey**, comma-separated if more than one admin):
+   ```bash
+   cd <pkg>/src/services/network-registry
+   wrangler secret put REGISTRY_ADMIN_PUBKEYS --env production   # paste the base64 pubkey(s)
+   wrangler deploy --env production
+   ```
+   Until `REGISTRY_ADMIN_PUBKEYS` is set the route **fails closed** — `POST /networks/<network>` returns `503 admin_not_configured` and nothing is persisted (there is never an anonymous `hub_url` write). A claim signed by a key NOT in the allowlist gets `403 admin_not_authorized`.
+
+**Create the network** (dry-run is the default — it prints the signed claim it *would* POST and touches no registry; add `--apply` to write):
 
 ```bash
-cd <pkg>/src/services/network-registry
-CLOUDFLARE_API_TOKEN=… fnm exec --using=22 -- npx wrangler d1 execute cortex-network-registry --env production --remote \
-  --command "INSERT INTO networks (network_id, hub_url, leaf_port, updated_at) \
-    VALUES ('<network>', 'tls://<hub>:<port>', <port>, strftime('%Y-%m-%dT%H:%M:%SZ','now')) \
-    ON CONFLICT(network_id) DO UPDATE SET hub_url=excluded.hub_url, leaf_port=excluded.leaf_port, updated_at=excluded.updated_at"
+# dry-run first — inspect the claim + the derived admin_pubkey
+cortex network create <network> \
+  --hub tls://<hub>:<port> \
+  --leaf-port <port> \
+  --admin-seed ~/.config/nats/network-admin.nk \
+  --registry-url https://network.meta-factory.ai
+
+# then write it
+cortex network create <network> \
+  --hub tls://<hub>:<port> \
+  --leaf-port <port> \
+  --admin-seed ~/.config/nats/network-admin.nk \
+  --registry-url https://network.meta-factory.ai \
+  --apply
 ```
 
-Verify: `curl https://network.meta-factory.ai/networks/<network>` returns the signed descriptor.
+`--registry-url` defaults to the production registry, so it can be omitted in the common case. The command derives `admin_pubkey` from the seed (the same key shape `provision-stack` uses), so the pubkey you allowlisted in the prerequisite is exactly the one the registry checks.
+
+Verify: `curl https://network.meta-factory.ai/networks/<network>` returns the signed descriptor (`hub_url` / `leaf_port` matching what you created).
 
 ### B2 — Federated config on the stack
 


### PR DESCRIPTION
## What changed

`cortex network create` (shipped **v5.2.0**, #747) replaced the raw-SQL/D1 path for standing up a network. Standing up a network previously required a raw `wrangler d1 execute … INSERT INTO networks …` write (CF token needed). Now there is a one-command, no-SQL flow that POSTs a **signed-admin claim** to the registry's fail-closed `POST /networks/:id` (Ed25519-over-claim, verified against the `REGISTRY_ADMIN_PUBKEYS` allowlist).

This PR updates the network/stack onboarding SOPs to match.

### Files
- **`docs/sop-stack-onboarding.md` §B1** — replaced the raw `wrangler d1 execute … INSERT INTO networks …` UPSERT with `cortex network create … --apply`. Added the one-time prerequisite: generate the network-admin key (`cortex provision-stack generate`), set `REGISTRY_ADMIN_PUBKEYS` on the registry (`wrangler secret put` + deploy). Dry-run is the default; `--apply` writes. B0/B2–B5 stay coherent.
- **`docs/sop-network-join.md`** — "brand-new network/hub before its descriptor exists" is no longer a manual fallback bullet; it now points at `cortex network create`. The join flow itself is unchanged.
- **`docs/sop-federation-onboarding.md` §2(iv)** — light-touch note that standing up a *new* network uses `cortex network create` (seeding/creation step only; peer-registration flow unchanged).

### Verification
- All command signatures, flags, the fail-closed `503 admin_not_configured` / `403 admin_not_authorized` behaviour, and the `REGISTRY_ADMIN_PUBKEYS` provisioning path were verified against `src/cli/cortex/commands/network.ts`, `src/services/network-registry/src/{index,routes/networks}.ts`, and the `#747` create CLI tests — not paraphrased.
- **Vocab carve-out gate:** `git diff --name-only origin/main | bash scripts/check-carveouts.sh -` → **PASS** (no bare `operator`; uses admin / network admin / principal; no new `- id: operator` role literal).

Refs #747 (docs follow-up).