### PR TITLE
feat(cli): C-791 — cortex network join supports multi-stack principals (--principal-seed)

### DIFF
--- a/src/bus/__tests__/stack-provisioning.test.ts
+++ b/src/bus/__tests__/stack-provisioning.test.ts
@@ -318,10 +318,12 @@ describe("secrets discipline (TC-1b #632)", () => {
   });
 });
 
-describe("C-787 — fetchExistingStacks (read side of add-stack merge)", () => {
+describe("C-787 / C-791 — fetchExistingStacks (verified read side of add-stack merge)", () => {
+  let registryPubkey = "";
   async function configuredEnv(): Promise<Env> {
     resetStores();
     const reg = await makeRegistryKey();
+    registryPubkey = reg.publicKey;
     return {
       REGISTRY_SIGNING_KEY: reg.signingKey,
       REGISTRY_PUBLIC_KEY: reg.publicKey,
@@ -337,8 +339,8 @@ describe("C-787 — fetchExistingStacks (read side of add-stack merge)", () => {
     }) as typeof globalThis.fetch;
   }
 
-  test("present — returns the principal's stacks with their stack_pubkeys", async () => {
-    const env = await configuredEnv();
+  /** Register a principal with one stack so the GET has something to return. */
+  async function seedPrincipal(env: Env): Promise<{ rootPubkey: string }> {
     const root = generateStackIdentity({ seedPath: join(freshDir(), "mf.nk") });
     const body = await buildRegistrationClaim({
       principalId: "andreas",
@@ -353,17 +355,25 @@ describe("C-787 — fetchExistingStacks (read side of add-stack merge)", () => {
       }),
       env,
     );
+    return { rootPubkey: root.pubkeyB64 };
+  }
+
+  test("present — VERIFIED read returns the principal's stacks + capabilities", async () => {
+    const env = await configuredEnv();
+    const { rootPubkey } = await seedPrincipal(env);
 
     const res = await fetchExistingStacks({
       registryUrl: "http://registry.test",
       principalId: "andreas",
+      registryPubkey,
       fetchImpl: registryFetch(env),
     });
     expect(res.kind).toBe("present");
     if (res.kind === "present") {
       expect(res.stacks).toHaveLength(1);
       expect(res.stacks[0]!.stack_id).toBe("andreas/meta-factory");
-      expect(res.stacks[0]!.stack_pubkey).toBe(root.pubkeyB64);
+      expect(res.stacks[0]!.stack_pubkey).toBe(rootPubkey);
+      expect(Array.isArray(res.capabilities)).toBe(true);
     }
   });
 
@@ -372,6 +382,7 @@ describe("C-787 — fetchExistingStacks (read side of add-stack merge)", () => {
     const res = await fetchExistingStacks({
       registryUrl: "http://registry.test",
       principalId: "nobody",
+      registryPubkey,
       fetchImpl: registryFetch(env),
     });
     expect(res.kind).toBe("absent");
@@ -383,11 +394,72 @@ describe("C-787 — fetchExistingStacks (read side of add-stack merge)", () => {
     const res = await fetchExistingStacks({
       registryUrl: "http://registry.test",
       principalId: "andreas",
+      registryPubkey: "anything",
       fetchImpl: failingFetch,
     });
     expect(res.kind).toBe("error");
     if (res.kind === "error") {
       expect(res.reason).toMatch(/connection refused/);
+    }
+  });
+
+  test("C-791 SECURITY — NO pinned pubkey fails closed (refuses to merge off an unverifiable read)", async () => {
+    const env = await configuredEnv();
+    await seedPrincipal(env);
+    const res = await fetchExistingStacks({
+      registryUrl: "http://registry.test",
+      principalId: "andreas",
+      // registryPubkey omitted
+      fetchImpl: registryFetch(env),
+    });
+    expect(res.kind).toBe("error");
+    if (res.kind === "error") {
+      expect(res.reason).toMatch(/no pinned registry pubkey/i);
+    }
+  });
+
+  test("C-791 SECURITY — a TAMPERED principal-read (dropped stack, stale signature) fails closed", async () => {
+    const env = await configuredEnv();
+    await seedPrincipal(env);
+    // Malicious proxy: serve the real assertion but with stacks wiped, keeping
+    // the now-invalid signature. The verify gate must reject it.
+    const tamperingFetch = (async (input: Request | string | URL, init?: RequestInit) => {
+      const req = input instanceof Request ? input : new Request(input, init);
+      const res = await registryApp.fetch(req, env);
+      const json = (await res.json()) as { payload: Record<string, unknown> };
+      json.payload = { ...json.payload, stacks: [] };
+      return new Response(JSON.stringify(json), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as typeof globalThis.fetch;
+
+    const res = await fetchExistingStacks({
+      registryUrl: "http://registry.test",
+      principalId: "andreas",
+      registryPubkey,
+      fetchImpl: tamperingFetch,
+    });
+    expect(res.kind).toBe("error");
+    if (res.kind === "error") {
+      expect(res.reason).toMatch(/did not verify/i);
+    }
+  });
+
+  test("C-791 SECURITY — a pubkey MISMATCH (wrong/spoofed registry) fails closed", async () => {
+    const env = await configuredEnv();
+    await seedPrincipal(env);
+    // Pin a DIFFERENT registry pubkey than the one that signed → mismatch.
+    const otherKey = await makeRegistryKey();
+    const res = await fetchExistingStacks({
+      registryUrl: "http://registry.test",
+      principalId: "andreas",
+      registryPubkey: otherKey.publicKey,
+      fetchImpl: registryFetch(env),
+    });
+    expect(res.kind).toBe("error");
+    if (res.kind === "error") {
+      expect(res.reason).toMatch(/did not verify/i);
     }
   });
 });

--- a/src/bus/stack-provisioning.ts
+++ b/src/bus/stack-provisioning.ts
@@ -58,6 +58,7 @@ import { writeFileSync, existsSync, chmodSync } from "fs";
 import { createUser, fromSeed, type KeyPair } from "nkeys.js";
 
 import { canonicalJSON } from "../common/registry/signing";
+import { verifySignedAssertion } from "../common/registry/verify-assertion";
 import { nkeyToBase64Pubkey } from "./verify-signed-by-chain";
 
 // =============================================================================
@@ -584,11 +585,27 @@ export interface StackEntryShape {
   readonly metadata?: Record<string, string>;
 }
 
+/** One element of a principal's registered `capabilities[]`. */
+export interface CapabilityEntryShape {
+  readonly id: string;
+  readonly description?: string;
+  /** Networks this capability is announced into (the roster-membership key). */
+  readonly networks?: string[];
+}
+
 export interface FetchExistingStacksOptions {
   /** Registry base URL (no trailing slash needed). */
   readonly registryUrl: string;
   /** The principal id (the `:principal_id` path segment). */
   readonly principalId: string;
+  /**
+   * C-791 (security) — the PINNED registry pubkey (base64 ed25519), from
+   * `policy.federated.registry.pubkey`. REQUIRED: the principal-read is the
+   * destructive half of a full-overwrite re-attestation, so the read MUST be
+   * verified against this pin before it can drive the merge. Absent ⇒ the read
+   * FAILS CLOSED (`error`) — we never merge off an unverifiable read.
+   */
+  readonly registryPubkey?: string;
   /** Injected fetch (tests). Defaults to global fetch. @internal */
   readonly fetchImpl?: typeof globalThis.fetch;
   /** Request timeout (ms). Default 10s. */
@@ -599,39 +616,48 @@ export interface FetchExistingStacksOptions {
  * Outcome of {@link fetchExistingStacks}. Discriminated so the add-stack
  * caller can branch CORRECTLY rather than guess:
  *   - `present`  — the principal exists; `stacks` is its current registered set
- *                  (each entry carries its `stack_pubkey`). The caller MERGES
- *                  the new stack in and re-attests the COMPLETE set.
+ *                  (each entry carries its `stack_pubkey`) and `capabilities`
+ *                  its current announced set. Read from a SIGNATURE-VERIFIED
+ *                  registry assertion. The caller MERGES in the new stack +
+ *                  capabilities and re-attests the COMPLETE set.
  *   - `absent`   — the registry returned 404 (first registration). The caller
  *                  proceeds with just the new stack, as pre-C-787.
  *   - `error`    — the registry was unreachable / returned a non-200/404 / a
- *                  malformed body. The caller MUST abort with a clear error
- *                  rather than send a partial set that would DROP existing
- *                  stacks (the data-loss the C-787 review flagged on #790).
+ *                  malformed body / an UNVERIFIED assertion (bad signature, no
+ *                  pinned pubkey, pubkey mismatch, unconfigured registry). The
+ *                  caller MUST abort with a clear error rather than send a
+ *                  partial/forged set that would DROP existing stacks or caps
+ *                  (the data-loss the C-787 review flagged on #790, and the
+ *                  C-791 verified-merge-read security fix).
  */
 export type FetchExistingStacksResult =
-  | { kind: "present"; stacks: StackEntryShape[] }
+  | { kind: "present"; stacks: StackEntryShape[]; capabilities: CapabilityEntryShape[] }
   | { kind: "absent" }
   | { kind: "error"; reason: string };
 
 /**
- * C-787 — `GET /principals/{principalId}` and extract the registered
- * `stacks[]`. The READ half of the add-stack fetch+merge: the register route
- * does a FULL-OVERWRITE upsert of the `stacks` column, so an add-stack claim
- * MUST carry the complete intended set or it silently drops every stack it
- * omits. This read lets the caller rebuild that complete set (existing +
- * new) and have the root re-attest it.
+ * C-787 / C-791 — `GET /principals/{principalId}`, VERIFY the registry's
+ * `SignedAssertion` against the pinned pubkey, then extract the registered
+ * `stacks[]` + `capabilities[]`.
+ *
+ * The READ half of the add-stack fetch+merge: the register route does a
+ * FULL-OVERWRITE upsert of the `stacks` AND `capabilities` columns, so an
+ * add-stack claim MUST carry the complete intended set or it silently drops
+ * every stack/capability it omits. This read lets the caller rebuild that
+ * complete set (existing + new) and have the root re-attest it.
+ *
+ * **C-791 security — the read is signature-verified (fail closed).** This read
+ * is the *destructive* half of a re-attestation: whatever it returns gets
+ * root-signed into a full-overwrite. A malicious/compromised registry or an
+ * attacker-controlled `--registry-url` that OMITS a stack/capability from the
+ * read would otherwise drive a silent drop. So the assertion is verified with
+ * the SAME pin+verify gate (`verifySignedAssertion`) the descriptor/roster
+ * fetch uses (DD-9). A read that does not verify — or that arrives with no
+ * pinned pubkey to verify against — returns `error`; the merge caller aborts
+ * rather than re-attesting a set it could not trust.
  *
  * Distinguishes 404 (`absent` → first registration) from every other failure
  * (`error`) so the caller never sends a partial set on a transient outage.
- * The GET payload is a `SignedAssertion<PrincipalRecord>`; we read
- * `payload.stacks` WITHOUT verifying the registry signature here — this is a
- * convenience read to AVOID DATA LOSS, not a trust decision: the stacks we
- * merge are re-attested by the principal ROOT signature on the register POST,
- * and the registry re-verifies that. (A tampered GET could at worst cause the
- * root to re-attest a stack it did not intend; the principal running the root
- * reviews the merged set, and federated VERIFY still resolves per-stack keys from the
- * registry-signed record. Signature-verifying this read is a possible
- * hardening follow-up, not required to close the data-loss blocker.)
  */
 export async function fetchExistingStacks(
   opts: FetchExistingStacksOptions,
@@ -667,9 +693,38 @@ export async function fetchExistingStacks(
       reason: `GET ${url} returned non-JSON body: ${err instanceof Error ? err.message : String(err)}`,
     };
   }
-  // Shape: SignedAssertion<PrincipalRecord> → body.payload.stacks[].
-  const payload = (body as { payload?: unknown } | null)?.payload;
-  const stacksRaw = (payload as { stacks?: unknown } | null | undefined)?.stacks;
+
+  // C-791 security — VERIFY the registry's SignedAssertion before trusting its
+  // payload. No pinned pubkey ⇒ nothing to verify against ⇒ fail closed (the
+  // merge that follows is destructive). This is the same gate the S1
+  // descriptor/roster fetch applies (DD-9), now extended to the principal read.
+  if (opts.registryPubkey === undefined || opts.registryPubkey === "") {
+    return {
+      kind: "error",
+      reason:
+        `GET ${url}: no pinned registry pubkey to verify the principal assertion against — ` +
+        `refusing to merge off an unverifiable read (set policy.federated.registry.pubkey / --registry-pubkey)`,
+    };
+  }
+  const verified = await verifySignedAssertion(body, opts.registryPubkey);
+  if (verified.kind !== "ok") {
+    const why =
+      verified.kind === "pubkey_mismatch"
+        ? `registry pubkey mismatch (got ${verified.got.slice(0, 8)}…)`
+        : verified.kind === "malformed"
+          ? `malformed assertion (${verified.detail})`
+          : verified.kind;
+    return {
+      kind: "error",
+      reason: `GET ${url}: registry assertion did not verify (${why}) — refusing to merge off an unverified read`,
+    };
+  }
+
+  // Shape: verified payload is a PrincipalRecord → payload.stacks[] + .capabilities[].
+  const payload = verified.payload as
+    | { stacks?: unknown; capabilities?: unknown }
+    | null;
+  const stacksRaw = payload?.stacks;
   if (!Array.isArray(stacksRaw)) {
     return {
       kind: "error",
@@ -683,7 +738,18 @@ export async function fetchExistingStacks(
       stacks.push(s as StackEntryShape);
     }
   }
-  return { kind: "present", stacks };
+  // Capabilities are optional on the record (empty when none announced). Narrow
+  // each entry to a well-formed capability ({ id: string, … }).
+  const capsRaw = payload?.capabilities;
+  const capabilities: CapabilityEntryShape[] = [];
+  if (Array.isArray(capsRaw)) {
+    for (const cap of capsRaw) {
+      if (typeof cap === "object" && cap !== null && typeof (cap as { id?: unknown }).id === "string") {
+        capabilities.push(cap as CapabilityEntryShape);
+      }
+    }
+  }
+  return { kind: "present", stacks, capabilities };
 }
 
 // =============================================================================
@@ -713,6 +779,12 @@ export interface ResolveMergedStacksOptions {
   readonly stackPubkey: string;
   /** Registry base URL (for the existing-stacks fetch on the add-stack path). */
   readonly registryUrl: string;
+  /**
+   * C-791 (security) — pinned registry pubkey, forwarded to
+   * {@link fetchExistingStacks} so the merge-read is signature-verified before
+   * it can drive the destructive full-overwrite. Absent ⇒ the read fails closed.
+   */
+  readonly registryPubkey?: string;
   /**
    * `true` when adding a 2nd+ stack to an already-registered principal (a
    * `--principal-seed`/root-signed claim). Triggers the fetch+merge so the
@@ -757,6 +829,7 @@ export async function resolveMergedStacks(
     existing = await fetchExistingStacks({
       registryUrl: opts.registryUrl,
       principalId: opts.principalId,
+      ...(opts.registryPubkey !== undefined && { registryPubkey: opts.registryPubkey }),
       ...(opts.fetchImpl !== undefined && { fetchImpl: opts.fetchImpl }),
     });
   } catch (err) {
@@ -797,6 +870,120 @@ export async function resolveMergedStacks(
   return { ok: true, stacks: merged };
 }
 
+/** A capability as carried in a registration claim. */
+export interface ClaimCapability {
+  id: string;
+  description?: string;
+  networks?: string[];
+}
+
+export interface ResolveMergedCapabilitiesOptions {
+  /** The principal whose capabilities are being merged. */
+  readonly principalId: string;
+  /** Registry base URL (for the existing-capabilities fetch). */
+  readonly registryUrl: string;
+  /** C-791 (security) — pinned registry pubkey; the read is verified or fails closed. */
+  readonly registryPubkey?: string;
+  /**
+   * The capabilities this join announces (already tagged with `networks:[id]`).
+   * Unioned into the principal's existing set.
+   */
+  readonly announce: ClaimCapability[];
+  /**
+   * `true` when the principal already exists (add-stack / re-announce). Triggers
+   * the fetch+merge so the full-overwrite route preserves prior-network caps.
+   * `false` for a first registration (nothing on record to preserve).
+   */
+  readonly isAddStack: boolean;
+  /** Injected fetch (tests). Defaults to global fetch. @internal */
+  readonly fetchImpl?: typeof globalThis.fetch;
+}
+
+/** Union two `networks[]` lists, order-preserving, deduped. */
+function unionNetworks(a: string[] | undefined, b: string[] | undefined): string[] {
+  const out: string[] = [];
+  for (const n of [...(a ?? []), ...(b ?? [])]) {
+    if (!out.includes(n)) out.push(n);
+  }
+  return out;
+}
+
+/**
+ * C-791 (MAJOR 2) — compute the COMPLETE `capabilities[]` for a registration
+ * claim, merging this join's announce into the principal's existing announced
+ * set. The capability twin of {@link resolveMergedStacks}: the register route
+ * full-overwrites the `capabilities` column too, so adding `andreas/community`
+ * (caps tagged `networks:[community-net]`) with a claim that carried ONLY those
+ * caps would DROP `andreas/meta-factory`'s caps (`networks:[metafactory]`) and
+ * silently evict meta-factory from the metafactory network roster (roster
+ * membership is implicit via `capability.networks[]`).
+ *
+ * First registration (`isAddStack === false`): just the announce — nothing on
+ * record to preserve.
+ *
+ * Add-stack/re-announce (`isAddStack === true`): FETCH the (verified) existing
+ * capability set and union the announce in: an existing capability id keeps its
+ * description and gains any new `networks[]` (so a cap already announced into
+ * `metafactory` ALSO gains `community-net` if re-announced there); a new id is
+ * appended. The principal's prior-network roster membership therefore survives.
+ *
+ * Failure handling mirrors {@link resolveMergedStacks}: `absent` → just the
+ * announce (no record yet); `error` (unreachable / UNVERIFIED read) → ABORT
+ * (never overwrite the cap set off an untrusted/partial read).
+ */
+export async function resolveMergedCapabilities(
+  opts: ResolveMergedCapabilitiesOptions,
+): Promise<{ ok: true; capabilities: ClaimCapability[] } | { ok: false; reason: string }> {
+  if (!opts.isAddStack) {
+    return { ok: true, capabilities: opts.announce };
+  }
+
+  let existing: FetchExistingStacksResult;
+  try {
+    existing = await fetchExistingStacks({
+      registryUrl: opts.registryUrl,
+      principalId: opts.principalId,
+      ...(opts.registryPubkey !== undefined && { registryPubkey: opts.registryPubkey }),
+      ...(opts.fetchImpl !== undefined && { fetchImpl: opts.fetchImpl }),
+    });
+  } catch (err) {
+    return {
+      ok: false,
+      reason: `failed to fetch existing capabilities for merge: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+
+  if (existing.kind === "error") {
+    return {
+      ok: false,
+      reason:
+        `cannot announce a capability without dropping existing ones: ${existing.reason}. ` +
+        `Refusing to overwrite the principal's capability set off a partial/unverified read.`,
+    };
+  }
+  if (existing.kind === "absent") {
+    return { ok: true, capabilities: opts.announce };
+  }
+
+  // present — union the announce into the existing set (by capability id).
+  const merged: ClaimCapability[] = existing.capabilities.map((c) => ({
+    id: c.id,
+    ...(c.description !== undefined && { description: c.description }),
+    ...(c.networks !== undefined && { networks: c.networks }),
+  }));
+  for (const cap of opts.announce) {
+    const existing = merged.find((m) => m.id === cap.id);
+    if (existing !== undefined) {
+      // Existing id — union its networks with the announce's, keep description.
+      existing.networks = unionNetworks(existing.networks, cap.networks);
+      if (cap.description !== undefined) existing.description = cap.description;
+    } else {
+      merged.push(cap);
+    }
+  }
+  return { ok: true, capabilities: merged };
+}
+
 /**
  * C-791 — is the joining stack ALREADY registered with its current pubkey?
  *
@@ -824,6 +1011,17 @@ export async function isStackRegistered(opts: {
   principalId: string;
   stackId: string;
   stackPubkey: string;
+  /** C-791 (security) — pinned registry pubkey; the read is verified or fails to `error`. */
+  registryPubkey?: string;
+  /**
+   * C-791 (MAJOR 1) — the capabilities this join would announce (already tagged
+   * with `networks:[id]`). The skip is "fully converged" ONLY when the stack
+   * pubkey AND every announced capability are already on record. With caps
+   * still to announce, the join must NOT skip — it must proceed so the
+   * principal lands in the network roster (implicit membership via
+   * `capability.networks[]`). Omit/empty ⇒ pubkey match alone is convergence.
+   */
+  announce?: ClaimCapability[];
   fetchImpl?: typeof globalThis.fetch;
 }): Promise<"registered" | "not-registered" | "error"> {
   let existing: FetchExistingStacksResult;
@@ -831,18 +1029,35 @@ export async function isStackRegistered(opts: {
     existing = await fetchExistingStacks({
       registryUrl: opts.registryUrl,
       principalId: opts.principalId,
+      ...(opts.registryPubkey !== undefined && { registryPubkey: opts.registryPubkey }),
       ...(opts.fetchImpl !== undefined && { fetchImpl: opts.fetchImpl }),
     });
-  } catch {
+  } catch (_err) {
+    // fetchExistingStacks already maps I/O failures to a `{ kind: "error" }`
+    // result; a *thrown* error here would be unexpected, but we map it to the
+    // same fail-safe `"error"` outcome (the caller then proceeds to the normal
+    // register path rather than wrongly assuming idempotency).
     return "error";
   }
   if (existing.kind === "error") return "error";
   if (existing.kind === "absent") return "not-registered";
   const match = existing.stacks.find((s) => s.stack_id === opts.stackId);
-  if (match?.stack_pubkey === opts.stackPubkey) {
-    return "registered";
+  if (match?.stack_pubkey !== opts.stackPubkey) {
+    return "not-registered";
   }
-  return "not-registered";
+  // C-791 (MAJOR 1) — the stack pubkey is on record. Only treat the join as
+  // CONVERGED (skip) if every announced capability is ALSO already on record
+  // with this network tagged. Otherwise the announce still has to happen.
+  const announce = opts.announce ?? [];
+  for (const cap of announce) {
+    const onRecord = existing.capabilities.find((c) => c.id === cap.id);
+    const wantNetworks = cap.networks ?? [];
+    const haveNetworks = onRecord?.networks ?? [];
+    if (onRecord === undefined || !wantNetworks.every((n) => haveNetworks.includes(n))) {
+      return "not-registered"; // caps not yet announced → don't skip.
+    }
+  }
+  return "registered";
 }
 
 /** Shared POST-JSON-with-timeout used by both register + network-create. */

--- a/src/bus/stack-provisioning.ts
+++ b/src/bus/stack-provisioning.ts
@@ -686,6 +686,165 @@ export async function fetchExistingStacks(
   return { kind: "present", stacks };
 }
 
+// =============================================================================
+// C-787 / C-791 — shared add-stack merge (the fetch+merge half of multi-stack
+// registration). Extracted here so BOTH `cortex provision-stack register` AND
+// `cortex network join` reuse ONE implementation rather than hand-rolling the
+// data-loss-prone merge twice (the C-791 reuse requirement). The register route
+// does a FULL-OVERWRITE upsert of the `stacks` column with no read-merge, so an
+// add-stack claim MUST carry the complete intended set or it silently drops
+// every stack it omits.
+// =============================================================================
+
+/** A stack entry as carried in a registration claim. */
+export interface ClaimStack {
+  stack_id: string;
+  stack_pubkey?: string;
+  display_name?: string;
+  metadata?: Record<string, string>;
+}
+
+export interface ResolveMergedStacksOptions {
+  /** The principal whose stacks are being merged. */
+  readonly principalId: string;
+  /** The stack id being added/updated (`{principalId}/{slug}`). */
+  readonly stackId: string;
+  /** The base64 ed25519 pubkey of the stack being added/updated. */
+  readonly stackPubkey: string;
+  /** Registry base URL (for the existing-stacks fetch on the add-stack path). */
+  readonly registryUrl: string;
+  /**
+   * `true` when adding a 2nd+ stack to an already-registered principal (a
+   * `--principal-seed`/root-signed claim). Triggers the fetch+merge so the
+   * full-overwrite route does not drop the principal's existing stacks. `false`
+   * for a first registration (just the new stack — nothing to preserve).
+   */
+  readonly isAddStack: boolean;
+  /** Injected fetch (tests). Defaults to global fetch. @internal */
+  readonly fetchImpl?: typeof globalThis.fetch;
+}
+
+/**
+ * C-787 — compute the COMPLETE `stacks[]` for a registration claim, merging the
+ * new stack into the principal's existing registered set on the add-stack path.
+ *
+ * First registration (`isAddStack === false`): just the new stack — the route
+ * establishes the principal from scratch, nothing to drop.
+ *
+ * Add-stack (`isAddStack === true`): FETCH the principal's existing stacks and
+ * merge the new one in (replace-by-stack_id if it already exists, else append),
+ * each existing entry keeping its own `stack_pubkey`. The full-overwrite route
+ * then writes the complete intended set instead of clobbering the existing
+ * stacks with only the new one.
+ *
+ * Failure handling:
+ *   - registry returns 404 (`absent`) on the add-stack path → the principal
+ *     isn't registered yet, nothing to merge; proceed with just the new stack.
+ *   - registry unreachable / malformed (`error`) → ABORT with a clear error. We
+ *     do NOT fall back to sending only the new stack: that is precisely the
+ *     silent stack-drop the data-loss blocker is about.
+ */
+export async function resolveMergedStacks(
+  opts: ResolveMergedStacksOptions,
+): Promise<{ ok: true; stacks: ClaimStack[] } | { ok: false; reason: string }> {
+  const newStack: ClaimStack = { stack_id: opts.stackId, stack_pubkey: opts.stackPubkey };
+  if (!opts.isAddStack) {
+    return { ok: true, stacks: [newStack] };
+  }
+
+  let existing: FetchExistingStacksResult;
+  try {
+    existing = await fetchExistingStacks({
+      registryUrl: opts.registryUrl,
+      principalId: opts.principalId,
+      ...(opts.fetchImpl !== undefined && { fetchImpl: opts.fetchImpl }),
+    });
+  } catch (err) {
+    return {
+      ok: false,
+      reason: `failed to fetch existing stacks for merge: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+
+  if (existing.kind === "error") {
+    return {
+      ok: false,
+      reason:
+        `cannot add a stack without dropping existing ones: ${existing.reason}. ` +
+        `Refusing to register a partial stack set (would overwrite the principal's stacks). ` +
+        `Verify the registry URL and retry.`,
+    };
+  }
+  if (existing.kind === "absent") {
+    // No record yet — nothing to preserve. Proceed with just the new stack.
+    return { ok: true, stacks: [newStack] };
+  }
+
+  // present — merge: replace-by-stack_id if present, else append.
+  const merged: ClaimStack[] = existing.stacks.map((s: StackEntryShape) => ({
+    stack_id: s.stack_id,
+    ...(s.stack_pubkey !== undefined && { stack_pubkey: s.stack_pubkey }),
+    ...(s.display_name !== undefined && { display_name: s.display_name }),
+    ...(s.metadata !== undefined && { metadata: s.metadata }),
+  }));
+  const idx = merged.findIndex((s) => s.stack_id === opts.stackId);
+  if (idx >= 0) {
+    // Re-keying an existing stack: keep position, swap in the new pubkey.
+    merged[idx] = { ...merged[idx], stack_id: opts.stackId, stack_pubkey: opts.stackPubkey };
+  } else {
+    merged.push(newStack);
+  }
+  return { ok: true, stacks: merged };
+}
+
+/**
+ * C-791 — is the joining stack ALREADY registered with its current pubkey?
+ *
+ * The idempotency probe for `cortex network join`'s register step. When a
+ * principal's stack has already been registered (e.g. via a prior
+ * `provision-stack register --principal-seed`, or a re-run of the same join),
+ * the register POST would either no-op (root re-signs the same set) or 409
+ * (`pubkey_rotation_not_supported`, when the join signs with the stack key but
+ * the principal root is a different key). Detecting the already-registered case
+ * lets the join SKIP the POST entirely so a re-run converges (DD-4 idempotency)
+ * without depending on a root seed being threaded through.
+ *
+ * Returns:
+ *   - `registered` — the stack is on record with EXACTLY `stackPubkey`. The
+ *     caller skips the register POST (idempotent no-op).
+ *   - `not-registered` — the principal is absent, OR the stack is absent, OR the
+ *     stack is on record with a DIFFERENT pubkey (a genuine re-key, which must
+ *     go through the authorized register path — not silently skipped).
+ *   - `error` — the registry was unreachable/malformed. The caller MUST NOT
+ *     assume idempotency (could hide a needed registration); it proceeds to the
+ *     normal register path, which surfaces the registry's own error.
+ */
+export async function isStackRegistered(opts: {
+  registryUrl: string;
+  principalId: string;
+  stackId: string;
+  stackPubkey: string;
+  fetchImpl?: typeof globalThis.fetch;
+}): Promise<"registered" | "not-registered" | "error"> {
+  let existing: FetchExistingStacksResult;
+  try {
+    existing = await fetchExistingStacks({
+      registryUrl: opts.registryUrl,
+      principalId: opts.principalId,
+      ...(opts.fetchImpl !== undefined && { fetchImpl: opts.fetchImpl }),
+    });
+  } catch {
+    return "error";
+  }
+  if (existing.kind === "error") return "error";
+  if (existing.kind === "absent") return "not-registered";
+  const match = existing.stacks.find((s) => s.stack_id === opts.stackId);
+  if (match?.stack_pubkey === opts.stackPubkey) {
+    return "registered";
+  }
+  return "not-registered";
+}
+
 /** Shared POST-JSON-with-timeout used by both register + network-create. */
 async function postSigned(
   fetchImpl: typeof globalThis.fetch,

--- a/src/cli/cortex/commands/__tests__/network-adapters.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-adapters.test.ts
@@ -36,6 +36,16 @@ import {
   rosterFromPrincipals,
   membersFromPrincipals,
 } from "../../../../services/network-registry/src/store";
+import registryApp from "../../../../services/network-registry/src/index";
+import type { Env } from "../../../../services/network-registry/src/index";
+import {
+  makeRegistryKey,
+  resetStores,
+} from "../../../../services/network-registry/__tests__/helpers";
+import type {
+  SignedAssertion,
+  PrincipalRecord,
+} from "../../../../services/network-registry/src/types";
 
 const tmpDirs: string[] = [];
 function freshDir(): string {
@@ -669,6 +679,190 @@ describe("#762 registerStack announces capabilities into the network", () => {
       await store.putPrincipal(c.principal_id, c.principal_pubkey, c.stacks, c.capabilities);
       const principals = await store.listPrincipals();
       expect(membersFromPrincipals(principals, "metafactory")).toEqual([]);
+    });
+  });
+});
+
+// =============================================================================
+// C-791 — `cortex network join` register step supports multi-stack principals.
+//
+// These tests drive the REAL network-registry Worker route end-to-end (the same
+// route #787's per-stack-pubkeys tests use), so the add-stack authorization +
+// rotation gate run EXACTLY as in production — no re-implemented verifier. We
+// stub `globalThis.fetch` to route the adapter's register/GET calls into
+// `registryApp.fetch(request, env)`.
+// =============================================================================
+
+describe("C-791 — registerStack supports a principal's 2nd+ stack", () => {
+  let env: Env;
+
+  /** Route `globalThis.fetch` into the live registry Worker for the duration of `fn`. */
+  function withLiveRegistry(fn: () => Promise<void>): Promise<void> {
+    const real = globalThis.fetch;
+    globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+      const req = input instanceof Request ? input : new Request(input, init);
+      return registryApp.fetch(req, env);
+    }) as typeof globalThis.fetch;
+    return fn().finally(() => {
+      globalThis.fetch = real;
+    });
+  }
+
+  const REGISTRY_URL = "http://localhost";
+
+  function cfg(overrides: Partial<LivePortsConfig>): LivePortsConfig {
+    return {
+      networkId: "metafactory",
+      principalId: "andreas",
+      stackId: "andreas/meta-factory",
+      registryUrl: REGISTRY_URL,
+      natsConfigPath: "/x/local.conf",
+      plistPath: "/nonexistent/plist",
+      platform: "darwin",
+      announceCapabilities: [],
+      ...overrides,
+    };
+  }
+
+  async function getStacks(principalId: string): Promise<{ stack_id: string; stack_pubkey?: string }[]> {
+    const res = await registryApp.fetch(
+      new Request(`${REGISTRY_URL}/principals/${principalId}`),
+      env,
+    );
+    if (res.status === 404) return [];
+    const json = (await res.json()) as SignedAssertion<PrincipalRecord>;
+    return json.payload.stacks;
+  }
+
+  // Fresh registry + keys per test.
+  async function setup(): Promise<void> {
+    resetStores();
+    const reg = await makeRegistryKey();
+    env = {
+      REGISTRY_SIGNING_KEY: reg.signingKey,
+      REGISTRY_PUBLIC_KEY: reg.publicKey,
+      ENVIRONMENT: "test",
+    };
+  }
+
+  test("first-stack join (no --principal-seed) registers, principal absent ⇒ unchanged", async () => {
+    await setup();
+    const dir = freshDir();
+    const rootSeed = join(dir, "root.nk");
+    generateStackIdentity({ seedPath: rootSeed });
+
+    await withLiveRegistry(async () => {
+      const ports = buildLivePorts(cfg({ stackId: "andreas/meta-factory", seedPath: rootSeed }));
+      const res = await ports.registry.registerStack();
+      expect(res.ok).toBe(true);
+      const stacks = await getStacks("andreas");
+      expect(stacks.map((s) => s.stack_id)).toEqual(["andreas/meta-factory"]);
+    });
+  });
+
+  test("2nd-stack join WITH --principal-seed succeeds (no 409) + preserves the existing stack", async () => {
+    await setup();
+    const dir = freshDir();
+    const rootSeed = join(dir, "root.nk"); // andreas/meta-factory (the root)
+    const communitySeed = join(dir, "community.nk"); // andreas/community (2nd stack)
+    const rootMat = generateStackIdentity({ seedPath: rootSeed });
+    const communityMat = generateStackIdentity({ seedPath: communitySeed });
+
+    await withLiveRegistry(async () => {
+      // Establish the principal via a first-stack join (root signs its own).
+      const first = buildLivePorts(cfg({ stackId: "andreas/meta-factory", seedPath: rootSeed }));
+      expect((await first.registry.registerStack()).ok).toBe(true);
+
+      // 2nd-stack join: the joining stack key (community) ≠ the registered root.
+      // WITHOUT --principal-seed this would 409 at the rotation gate. WITH it,
+      // the root signs the add-stack claim and existing stacks are merged.
+      const second = buildLivePorts(
+        cfg({
+          networkId: "community-net",
+          stackId: "andreas/community",
+          seedPath: communitySeed,
+          rootSeedPath: rootSeed,
+        }),
+      );
+      const res = await second.registry.registerStack();
+      expect(res.ok).toBe(true); // NOT a 409
+
+      // Both stacks survive, each with its own pubkey; root unchanged.
+      const stacks = await getStacks("andreas");
+      const byId = Object.fromEntries(stacks.map((s) => [s.stack_id, s.stack_pubkey]));
+      expect(Object.keys(byId).sort()).toEqual(["andreas/community", "andreas/meta-factory"]);
+      expect(byId["andreas/meta-factory"]).toBe(rootMat.pubkeyB64);
+      expect(byId["andreas/community"]).toBe(communityMat.pubkeyB64);
+    });
+  });
+
+  test("2nd-stack join WITHOUT --principal-seed 409s (no auth relaxation) — root-auth still required", async () => {
+    await setup();
+    const dir = freshDir();
+    const rootSeed = join(dir, "root.nk");
+    const communitySeed = join(dir, "community.nk");
+    generateStackIdentity({ seedPath: rootSeed });
+    generateStackIdentity({ seedPath: communitySeed });
+
+    await withLiveRegistry(async () => {
+      const first = buildLivePorts(cfg({ stackId: "andreas/meta-factory", seedPath: rootSeed }));
+      expect((await first.registry.registerStack()).ok).toBe(true);
+
+      // No --principal-seed: the community key signs + declares itself as
+      // principal_pubkey ≠ registered root → the registry's rotation gate
+      // rejects it (409). This proves #787's root-authorization is NOT relaxed:
+      // a non-root key cannot add a stack via the join path either.
+      const second = buildLivePorts(
+        cfg({ networkId: "community-net", stackId: "andreas/community", seedPath: communitySeed }),
+      );
+      const res = await second.registry.registerStack();
+      expect(res.ok).toBe(false);
+      if (!res.ok) expect(res.reason).toContain("HTTP 409");
+
+      // The community stack was NOT added.
+      const stacks = await getStacks("andreas");
+      expect(stacks.map((s) => s.stack_id)).toEqual(["andreas/meta-factory"]);
+    });
+  });
+
+  test("idempotent: an already-registered stack re-join is a NO-OP skip (no 409), even without --principal-seed", async () => {
+    await setup();
+    const dir = freshDir();
+    const rootSeed = join(dir, "root.nk");
+    const communitySeed = join(dir, "community.nk");
+    generateStackIdentity({ seedPath: rootSeed });
+    generateStackIdentity({ seedPath: communitySeed });
+
+    await withLiveRegistry(async () => {
+      // Establish root + add community out-of-band (the provision-stack path).
+      const first = buildLivePorts(cfg({ stackId: "andreas/meta-factory", seedPath: rootSeed }));
+      expect((await first.registry.registerStack()).ok).toBe(true);
+      const add = buildLivePorts(
+        cfg({
+          networkId: "community-net",
+          stackId: "andreas/community",
+          seedPath: communitySeed,
+          rootSeedPath: rootSeed,
+        }),
+      );
+      expect((await add.registry.registerStack()).ok).toBe(true);
+
+      // Now re-run the community join WITHOUT --principal-seed. The stack is
+      // already on record with this pubkey, so the register skips (no 409,
+      // converges — the DD-4 idempotency promise).
+      const rejoin = buildLivePorts(
+        cfg({ networkId: "community-net", stackId: "andreas/community", seedPath: communitySeed }),
+      );
+      const res = await rejoin.registry.registerStack();
+      expect(res.ok).toBe(true);
+      if (res.ok) expect(res.note).toContain("idempotent");
+
+      // Still exactly two stacks.
+      const stacks = await getStacks("andreas");
+      expect(stacks.map((s) => s.stack_id).sort()).toEqual([
+        "andreas/community",
+        "andreas/meta-factory",
+      ]);
     });
   });
 });

--- a/src/cli/cortex/commands/__tests__/network-adapters.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-adapters.test.ts
@@ -695,6 +695,7 @@ describe("#762 registerStack announces capabilities into the network", () => {
 
 describe("C-791 — registerStack supports a principal's 2nd+ stack", () => {
   let env: Env;
+  let registryPubkey = "";
 
   /** Route `globalThis.fetch` into the live registry Worker for the duration of `fn`. */
   function withLiveRegistry(fn: () => Promise<void>): Promise<void> {
@@ -716,6 +717,9 @@ describe("C-791 — registerStack supports a principal's 2nd+ stack", () => {
       principalId: "andreas",
       stackId: "andreas/meta-factory",
       registryUrl: REGISTRY_URL,
+      // C-791 — the merge-read is signature-verified, so the live join pins the
+      // registry pubkey (from policy.federated.registry.pubkey in production).
+      registryPubkey,
       natsConfigPath: "/x/local.conf",
       plistPath: "/nonexistent/plist",
       platform: "darwin",
@@ -724,20 +728,35 @@ describe("C-791 — registerStack supports a principal's 2nd+ stack", () => {
     };
   }
 
-  async function getStacks(principalId: string): Promise<{ stack_id: string; stack_pubkey?: string }[]> {
+  async function getRecord(
+    principalId: string,
+  ): Promise<{ stacks: { stack_id: string; stack_pubkey?: string }[]; capabilities: { id: string; networks?: string[] }[] }> {
     const res = await registryApp.fetch(
       new Request(`${REGISTRY_URL}/principals/${principalId}`),
       env,
     );
-    if (res.status === 404) return [];
+    if (res.status === 404) return { stacks: [], capabilities: [] };
     const json = (await res.json()) as SignedAssertion<PrincipalRecord>;
-    return json.payload.stacks;
+    return { stacks: json.payload.stacks, capabilities: json.payload.capabilities };
+  }
+
+  async function getStacks(principalId: string): Promise<{ stack_id: string; stack_pubkey?: string }[]> {
+    return (await getRecord(principalId)).stacks;
+  }
+
+  /** Networks tagged on the principal's `capabilities[]` (the roster-membership key). */
+  async function networksOnRecord(principalId: string): Promise<string[]> {
+    const { capabilities } = await getRecord(principalId);
+    const nets = new Set<string>();
+    for (const c of capabilities) for (const n of c.networks ?? []) nets.add(n);
+    return [...nets].sort();
   }
 
   // Fresh registry + keys per test.
   async function setup(): Promise<void> {
     resetStores();
     const reg = await makeRegistryKey();
+    registryPubkey = reg.publicKey;
     env = {
       REGISTRY_SIGNING_KEY: reg.signingKey,
       REGISTRY_PUBLIC_KEY: reg.publicKey,
@@ -825,7 +844,7 @@ describe("C-791 — registerStack supports a principal's 2nd+ stack", () => {
     });
   });
 
-  test("idempotent: an already-registered stack re-join is a NO-OP skip (no 409), even without --principal-seed", async () => {
+  test("idempotent: a FULLY-CONVERGED re-join (stack + caps on record) is a NO-OP skip", async () => {
     await setup();
     const dir = freshDir();
     const rootSeed = join(dir, "root.nk");
@@ -834,9 +853,161 @@ describe("C-791 — registerStack supports a principal's 2nd+ stack", () => {
     generateStackIdentity({ seedPath: communitySeed });
 
     await withLiveRegistry(async () => {
-      // Establish root + add community out-of-band (the provision-stack path).
       const first = buildLivePorts(cfg({ stackId: "andreas/meta-factory", seedPath: rootSeed }));
       expect((await first.registry.registerStack()).ok).toBe(true);
+      // Add community WITH caps announced into community-net (root-signed).
+      const add = buildLivePorts(
+        cfg({
+          networkId: "community-net",
+          stackId: "andreas/community",
+          seedPath: communitySeed,
+          rootSeedPath: rootSeed,
+          announceCapabilities: ["chat.relay"],
+        }),
+      );
+      expect((await add.registry.registerStack()).ok).toBe(true);
+
+      // Re-run the SAME community join (stack pubkey + caps already on record):
+      // converged ⇒ skip. No 409, even without --principal-seed.
+      const rejoin = buildLivePorts(
+        cfg({
+          networkId: "community-net",
+          stackId: "andreas/community",
+          seedPath: communitySeed,
+          announceCapabilities: ["chat.relay"],
+        }),
+      );
+      const res = await rejoin.registry.registerStack();
+      expect(res.ok).toBe(true);
+      if (res.ok) expect(res.note).toContain("idempotent");
+
+      const stacks = await getStacks("andreas");
+      expect(stacks.map((s) => s.stack_id).sort()).toEqual([
+        "andreas/community",
+        "andreas/meta-factory",
+      ]);
+    });
+  });
+
+  test("MAJOR 1 — an already-registered stack whose network caps are NOT yet announced STILL announces (lands in roster)", async () => {
+    await setup();
+    const dir = freshDir();
+    const rootSeed = join(dir, "root.nk");
+    const communitySeed = join(dir, "community.nk");
+    generateStackIdentity({ seedPath: rootSeed });
+    generateStackIdentity({ seedPath: communitySeed });
+
+    await withLiveRegistry(async () => {
+      // meta-factory established.
+      const first = buildLivePorts(cfg({ stackId: "andreas/meta-factory", seedPath: rootSeed }));
+      expect((await first.registry.registerStack()).ok).toBe(true);
+
+      // community registered out-of-band (the provision-stack path) WITHOUT any
+      // network caps — the real #791 scenario. Roster for community-net is empty.
+      const provision = buildLivePorts(
+        cfg({
+          networkId: "community-net",
+          stackId: "andreas/community",
+          seedPath: communitySeed,
+          rootSeedPath: rootSeed,
+          announceCapabilities: [], // no caps yet
+        }),
+      );
+      expect((await provision.registry.registerStack()).ok).toBe(true);
+      expect(await networksOnRecord("andreas")).toEqual([]); // NOT in any roster
+
+      // Now `cortex network join community-net` with caps to announce. The stack
+      // pubkey is already on record, but the caps are NOT — so the join must NOT
+      // skip; it must announce so the principal lands in community-net's roster.
+      const joinWithCaps = buildLivePorts(
+        cfg({
+          networkId: "community-net",
+          stackId: "andreas/community",
+          seedPath: communitySeed,
+          rootSeedPath: rootSeed,
+          announceCapabilities: ["chat.relay"],
+        }),
+      );
+      const res = await joinWithCaps.registry.registerStack();
+      expect(res.ok).toBe(true);
+      if (res.ok) expect(res.note).not.toContain("idempotent"); // did NOT skip
+
+      // The principal is now in community-net's roster (cap tagged with it).
+      expect(await networksOnRecord("andreas")).toContain("community-net");
+    });
+  });
+
+  test("MAJOR 2 — adding a 2nd stack PRESERVES the prior-network capability/roster membership", async () => {
+    await setup();
+    const dir = freshDir();
+    const rootSeed = join(dir, "root.nk");
+    const communitySeed = join(dir, "community.nk");
+    generateStackIdentity({ seedPath: rootSeed });
+    generateStackIdentity({ seedPath: communitySeed });
+
+    await withLiveRegistry(async () => {
+      // meta-factory joins the `metafactory` network WITH a cap → in that roster.
+      const first = buildLivePorts(
+        cfg({
+          networkId: "metafactory",
+          stackId: "andreas/meta-factory",
+          seedPath: rootSeed,
+          announceCapabilities: ["code-review.ts"],
+        }),
+      );
+      expect((await first.registry.registerStack()).ok).toBe(true);
+      expect(await networksOnRecord("andreas")).toEqual(["metafactory"]);
+
+      // Add community into `community-net` WITH its own cap. The full-overwrite
+      // register MUST NOT drop meta-factory's metafactory-tagged cap.
+      const add = buildLivePorts(
+        cfg({
+          networkId: "community-net",
+          stackId: "andreas/community",
+          seedPath: communitySeed,
+          rootSeedPath: rootSeed,
+          announceCapabilities: ["chat.relay"],
+        }),
+      );
+      expect((await add.registry.registerStack()).ok).toBe(true);
+
+      // BOTH networks survive on the capability set → BOTH rosters intact.
+      expect(await networksOnRecord("andreas")).toEqual(["community-net", "metafactory"]);
+    });
+  });
+
+  test("MAJOR 3 SECURITY — a TAMPERED principal-read fails closed (merge aborts, no overwrite)", async () => {
+    await setup();
+    const dir = freshDir();
+    const rootSeed = join(dir, "root.nk");
+    const communitySeed = join(dir, "community.nk");
+    generateStackIdentity({ seedPath: rootSeed });
+    generateStackIdentity({ seedPath: communitySeed });
+
+    await withLiveRegistry(async () => {
+      const first = buildLivePorts(cfg({ stackId: "andreas/meta-factory", seedPath: rootSeed }));
+      expect((await first.registry.registerStack()).ok).toBe(true);
+    });
+
+    // Now route the principal GET through a MALICIOUS proxy that tampers the
+    // payload (drops a stack) while leaving the (now-invalid) signature. The
+    // verified merge-read must REJECT it and the add-stack must abort.
+    const real = globalThis.fetch;
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const req = input instanceof Request ? input : new Request(input, init);
+      const res = await registryApp.fetch(req, env);
+      if (req.method === "GET" && req.url.includes("/principals/")) {
+        const json = (await res.json()) as SignedAssertion<PrincipalRecord>;
+        // Tamper: wipe the stacks array but keep the original signature.
+        json.payload = { ...json.payload, stacks: [] };
+        return new Response(JSON.stringify(json), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      return res;
+    }) as typeof globalThis.fetch;
+    try {
       const add = buildLivePorts(
         cfg({
           networkId: "community-net",
@@ -845,24 +1016,46 @@ describe("C-791 — registerStack supports a principal's 2nd+ stack", () => {
           rootSeedPath: rootSeed,
         }),
       );
-      expect((await add.registry.registerStack()).ok).toBe(true);
+      const res = await add.registry.registerStack();
+      expect(res.ok).toBe(false);
+      if (!res.ok) expect(res.reason).toMatch(/did not verify|unverified|merge/i);
+    } finally {
+      globalThis.fetch = real;
+    }
 
-      // Now re-run the community join WITHOUT --principal-seed. The stack is
-      // already on record with this pubkey, so the register skips (no 409,
-      // converges — the DD-4 idempotency promise).
-      const rejoin = buildLivePorts(
-        cfg({ networkId: "community-net", stackId: "andreas/community", seedPath: communitySeed }),
+    // The registry still holds only meta-factory (the tampered merge never applied).
+    const stacks = await getStacks("andreas");
+    expect(stacks.map((s) => s.stack_id)).toEqual(["andreas/meta-factory"]);
+  });
+
+  test("MAJOR 3 SECURITY — no pinned registry pubkey fails closed on the add-stack merge-read", async () => {
+    await setup();
+    const dir = freshDir();
+    const rootSeed = join(dir, "root.nk");
+    const communitySeed = join(dir, "community.nk");
+    generateStackIdentity({ seedPath: rootSeed });
+    generateStackIdentity({ seedPath: communitySeed });
+
+    await withLiveRegistry(async () => {
+      const first = buildLivePorts(cfg({ stackId: "andreas/meta-factory", seedPath: rootSeed }));
+      expect((await first.registry.registerStack()).ok).toBe(true);
+
+      // Add-stack with NO registryPubkey pinned → the merge-read can't verify →
+      // fail closed (never re-attest off an unverifiable read).
+      const add = buildLivePorts(
+        cfg({
+          networkId: "community-net",
+          stackId: "andreas/community",
+          seedPath: communitySeed,
+          rootSeedPath: rootSeed,
+          registryPubkey: undefined,
+        }),
       );
-      const res = await rejoin.registry.registerStack();
-      expect(res.ok).toBe(true);
-      if (res.ok) expect(res.note).toContain("idempotent");
-
-      // Still exactly two stacks.
+      const res = await add.registry.registerStack();
+      expect(res.ok).toBe(false);
+      if (!res.ok) expect(res.reason).toMatch(/no pinned registry pubkey|unverif/i);
       const stacks = await getStacks("andreas");
-      expect(stacks.map((s) => s.stack_id).sort()).toEqual([
-        "andreas/community",
-        "andreas/meta-factory",
-      ]);
+      expect(stacks.map((s) => s.stack_id)).toEqual(["andreas/meta-factory"]);
     });
   });
 });

--- a/src/cli/cortex/commands/__tests__/provision-stack.test.ts
+++ b/src/cli/cortex/commands/__tests__/provision-stack.test.ts
@@ -227,9 +227,14 @@ describe("cortex provision-stack register (TC-1b #632)", () => {
 });
 
 describe("cortex provision-stack register — C-787 add-stack (no data loss)", () => {
+  // C-791 — the add-stack merge-read is signature-verified, so tests must thread
+  // the registry pubkey. We keep it alongside the env so each test can pass it
+  // via --registry-pubkey.
+  let registryPubkey = "";
   async function configuredEnv(): Promise<Env> {
     resetStores();
     const reg = await makeRegistryKey();
+    registryPubkey = reg.publicKey;
     return {
       REGISTRY_SIGNING_KEY: reg.signingKey,
       REGISTRY_PUBLIC_KEY: reg.publicKey,
@@ -286,6 +291,9 @@ describe("cortex provision-stack register — C-787 add-stack (no data loss)", (
         rootSeed,
         "--registry-url",
         "http://registry.test",
+        // C-791 — pin the registry pubkey so the merge-read verifies.
+        "--registry-pubkey",
+        registryPubkey,
       ]);
       expect(add.exitCode).toBe(0);
 
@@ -340,6 +348,46 @@ describe("cortex provision-stack register — C-787 add-stack (no data loss)", (
       const json = (await getRes.json()) as {
         payload: { stacks: { stack_id: string }[] };
       };
+      expect(json.payload.stacks.map((s) => s.stack_id)).toEqual(["andreas/meta-factory"]);
+    } finally {
+      restore();
+    }
+  });
+
+  test("C-791 SECURITY — add-stack WITHOUT --registry-pubkey fails closed (unverifiable merge-read)", async () => {
+    const env = await configuredEnv();
+    const dir = freshDir();
+    const rootSeed = join(dir, "meta-factory.nk");
+    const communitySeed = join(dir, "community.nk");
+    await dispatchProvisionStack(["generate", "andreas", "--seed-path", rootSeed]);
+    await dispatchProvisionStack(["generate", "andreas", "--seed-path", communitySeed]);
+
+    const restore = routeFetchToRegistry(env);
+    try {
+      // Establish the principal (first register — no merge-read needed).
+      const first = await dispatchProvisionStack([
+        "register", "andreas", "--seed-path", rootSeed,
+        "--stack-id", "andreas/meta-factory", "--registry-url", "http://registry.test",
+        "--registry-pubkey", registryPubkey,
+      ]);
+      expect(first.exitCode).toBe(0);
+
+      // Add-stack WITHOUT --registry-pubkey: the destructive merge-read cannot be
+      // verified, so the command MUST fail closed rather than re-attest off an
+      // unverifiable read. The existing meta-factory stack is preserved.
+      const add = await dispatchProvisionStack([
+        "register", "andreas", "--seed-path", communitySeed,
+        "--stack-id", "andreas/community", "--principal-seed", rootSeed,
+        "--registry-url", "http://registry.test",
+      ]);
+      expect(add.exitCode).toBe(1);
+      expect(add.stderr).toMatch(/no pinned registry pubkey|unverif/i);
+
+      const getRes = await registryApp.fetch(
+        new Request("http://registry.test/principals/andreas"),
+        env,
+      );
+      const json = (await getRes.json()) as { payload: { stacks: { stack_id: string }[] } };
       expect(json.payload.stacks.map((s) => s.stack_id)).toEqual(["andreas/meta-factory"]);
     } finally {
       restore();

--- a/src/cli/cortex/commands/network-adapters.ts
+++ b/src/cli/cortex/commands/network-adapters.ts
@@ -51,6 +51,9 @@ import {
   buildRegistrationClaim,
   materialFromSeedString,
   registerStackIdentity,
+  resolveMergedStacks,
+  isStackRegistered,
+  type StackIdentityMaterial,
 } from "../../../bus/stack-provisioning";
 import type {
   PolicyFederatedNetwork,
@@ -83,6 +86,20 @@ export interface LivePortsConfig {
   registryUrl?: string;
   registryPubkey?: string;
   seedPath?: string;
+  /**
+   * C-791 — the principal ROOT seed path (the FIRST stack's seed), present ONLY
+   * when joining a SECOND+ stack of an already-registered principal. Mirrors
+   * `provision-stack register --principal-seed`: the join's register step then
+   * SIGNS the add-stack claim with the ROOT (the authorization the registry
+   * requires — `principal_pubkey` stays the registered root, so the rotation
+   * gate admits it) while {@link LivePortsConfig.seedPath} is the NEW stack's
+   * own signing key (its pubkey becomes the new stack's `stack_pubkey`). The
+   * existing stacks are fetch+merged so the full-overwrite register route does
+   * not drop them. Omitted → first-stack register (the pre-C-791 path), with an
+   * idempotency skip when the stack is already on record (see
+   * {@link registerWithCapabilities}).
+   */
+  rootSeedPath?: string;
   natsConfigPath?: string;
   /**
    * macOS (launchd) nats-server descriptor — the plist whose `ProgramArguments`
@@ -120,35 +137,110 @@ export interface LivePortsConfig {
 // Registry port — S1 client + provision-stack register (proof-of-possession).
 // =============================================================================
 
+/** Load + re-derive identity material from a seed file. Never throws. */
+function loadSeedMaterial(
+  seedPathRaw: string,
+  label: string,
+): { ok: true; material: StackIdentityMaterial } | { ok: false; reason: string } {
+  const seedFile = expandTilde(seedPathRaw);
+  if (!existsSync(seedFile)) {
+    return { ok: false, reason: `${label} seed file not found at ${seedFile}` };
+  }
+  try {
+    return { ok: true, material: materialFromSeedString(readFileSync(seedFile, "utf-8")) };
+  } catch (err) {
+    return { ok: false, reason: `${label} seed load failed: ${err instanceof Error ? err.message : String(err)}` };
+  }
+}
+
 /**
  * Shared idempotent proof-of-possession registration (reused by the S4
  * `registerStack` and the S5 public-index announce/deregister). Loads the seed,
  * builds + signs the claim with the supplied `capabilities`, and POSTs it. An
  * EMPTY `capabilities` list de-advertises the stack on the public index
  * (the registry searches over the claim's `capabilities`). Never throws.
+ *
+ * C-791 — multi-stack principals:
+ *
+ *   1. **Idempotency skip.** Before posting, probe whether THIS stack is already
+ *      registered with its current pubkey. If so, the register is a NO-OP (the
+ *      DD-4 "re-running converges" promise) — crucially, this is what lets a
+ *      2nd-stack join succeed even WITHOUT a root seed when the stack was
+ *      already registered out-of-band (e.g. by `provision-stack register
+ *      --principal-seed`), instead of 409-ing at the rotation gate.
+ *   2. **Root-signed add-stack.** When {@link LivePortsConfig.rootSeedPath} is
+ *      set (the principal's root/first-stack seed), the claim is SIGNED BY THE
+ *      ROOT and the principal's existing stacks are fetch+merged in, so the
+ *      registry admits the add-stack (its `principal_pubkey` stays the
+ *      registered root) and the full-overwrite upsert preserves the other
+ *      stacks. This is the #787 root-authorization, NOT relaxed: a non-root key
+ *      still cannot mint an accepted add-stack claim.
  */
 async function registerWithCapabilities(
   cfg: LivePortsConfig,
   capabilities: { id: string; description?: string; networks?: string[] }[],
+  /**
+   * C-791 — enable the idempotency SKIP (federated join only). The public
+   * announce/deregister path re-registers to CHANGE the advertised capability
+   * set with the SAME pubkey, so it must NOT short-circuit on a pubkey match —
+   * the skip is keyed on stack_id+pubkey, not on capabilities. Federated
+   * `registerStack` (where the 409 lives) passes `true`; the public ports pass
+   * the default `false`.
+   */
+  allowIdempotentSkip = false,
 ): Promise<{ ok: true; note: string } | { ok: false; reason: string }> {
   const url = cfg.registryUrl ?? "";
   if (cfg.seedPath === undefined) {
     return { ok: false, reason: "no --seed-path for registration" };
   }
-  const seedFile = expandTilde(cfg.seedPath);
-  if (!existsSync(seedFile)) {
-    return { ok: false, reason: `seed file not found at ${seedFile}` };
+  const matRes = loadSeedMaterial(cfg.seedPath, "--seed-path");
+  if (!matRes.ok) return matRes;
+  const material = matRes.material;
+
+  // (1) Idempotency (federated join): if this stack is ALREADY registered with
+  // its current pubkey, the register is a no-op. Re-running a join, or joining
+  // after a `provision-stack register`, converges WITHOUT a 409 — and without
+  // needing a root seed threaded through. A registry error here is non-fatal:
+  // we fall through to the normal register, which surfaces the registry's own
+  // error. Gated by `allowIdempotentSkip` so the public-index announce path,
+  // which changes capabilities under an unchanged pubkey, never short-circuits.
+  if (allowIdempotentSkip) {
+    const idempotent = await isStackRegistered({
+      registryUrl: url,
+      principalId: cfg.principalId,
+      stackId: cfg.stackId,
+      stackPubkey: material.pubkeyB64,
+    });
+    if (idempotent === "registered") {
+      return { ok: true, note: "already registered (idempotent skip)" };
+    }
   }
-  let material;
-  try {
-    material = materialFromSeedString(readFileSync(seedFile, "utf-8"));
-  } catch (err) {
-    return { ok: false, reason: `seed load failed: ${err instanceof Error ? err.message : String(err)}` };
+
+  // (2) Add-stack: when a root seed is supplied, the ROOT signs the claim and
+  // the existing stacks are fetch+merged so the full-overwrite route preserves
+  // them. Without it, this is a first-stack register (the new stack both
+  // declares + signs — pre-C-791 behaviour).
+  let rootMaterial: StackIdentityMaterial | undefined;
+  if (cfg.rootSeedPath !== undefined) {
+    const rootRes = loadSeedMaterial(cfg.rootSeedPath, "--principal-seed");
+    if (!rootRes.ok) return rootRes;
+    rootMaterial = rootRes.material;
   }
+
+  const stacksRes = await resolveMergedStacks({
+    principalId: cfg.principalId,
+    stackId: cfg.stackId,
+    stackPubkey: material.pubkeyB64,
+    registryUrl: url,
+    isAddStack: rootMaterial !== undefined,
+  });
+  if (!stacksRes.ok) return { ok: false, reason: stacksRes.reason };
+
   const body = await buildRegistrationClaim({
     principalId: cfg.principalId,
     material,
-    stacks: [{ stack_id: cfg.stackId }],
+    ...(rootMaterial !== undefined && { rootMaterial }),
+    stacks: stacksRes.stacks,
     capabilities,
   });
   let result;
@@ -189,7 +281,10 @@ function buildRegistryPort(cfg: LivePortsConfig): NetworkRegistryPort {
         id,
         networks: [cfg.networkId],
       }));
-      return registerWithCapabilities(cfg, announced);
+      // C-791 — federated register: enable the idempotency skip (a re-run or a
+      // join-after-provision-stack-register converges instead of 409-ing) and
+      // honour the optional root seed (root-signed add-stack for a 2nd stack).
+      return registerWithCapabilities(cfg, announced, true);
     },
     fetchVerified(networkId) {
       // S1's fetchAndCache returns { descriptor, roster } on ok and refreshes

--- a/src/cli/cortex/commands/network-adapters.ts
+++ b/src/cli/cortex/commands/network-adapters.ts
@@ -52,8 +52,10 @@ import {
   materialFromSeedString,
   registerStackIdentity,
   resolveMergedStacks,
+  resolveMergedCapabilities,
   isStackRegistered,
   type StackIdentityMaterial,
+  type ClaimCapability,
 } from "../../../bus/stack-provisioning";
 import type {
   PolicyFederatedNetwork,
@@ -178,18 +180,21 @@ function loadSeedMaterial(
  */
 async function registerWithCapabilities(
   cfg: LivePortsConfig,
-  capabilities: { id: string; description?: string; networks?: string[] }[],
+  capabilities: ClaimCapability[],
   /**
    * C-791 — enable the idempotency SKIP (federated join only). The public
    * announce/deregister path re-registers to CHANGE the advertised capability
-   * set with the SAME pubkey, so it must NOT short-circuit on a pubkey match —
-   * the skip is keyed on stack_id+pubkey, not on capabilities. Federated
-   * `registerStack` (where the 409 lives) passes `true`; the public ports pass
-   * the default `false`.
+   * set with the SAME pubkey, so it must NOT short-circuit on a pubkey match.
+   * Federated `registerStack` passes `true`; the public ports pass the default
+   * `false`. NOTE (MAJOR 1): even on the federated path the skip fires ONLY when
+   * the stack pubkey AND the announced capabilities are ALREADY on record — if
+   * caps still need announcing (the principal isn't yet in the network roster),
+   * the join proceeds rather than skipping (see {@link isStackRegistered}).
    */
   allowIdempotentSkip = false,
 ): Promise<{ ok: true; note: string } | { ok: false; reason: string }> {
   const url = cfg.registryUrl ?? "";
+  const registryPubkey = cfg.registryPubkey;
   if (cfg.seedPath === undefined) {
     return { ok: false, reason: "no --seed-path for registration" };
   }
@@ -197,29 +202,12 @@ async function registerWithCapabilities(
   if (!matRes.ok) return matRes;
   const material = matRes.material;
 
-  // (1) Idempotency (federated join): if this stack is ALREADY registered with
-  // its current pubkey, the register is a no-op. Re-running a join, or joining
-  // after a `provision-stack register`, converges WITHOUT a 409 — and without
-  // needing a root seed threaded through. A registry error here is non-fatal:
-  // we fall through to the normal register, which surfaces the registry's own
-  // error. Gated by `allowIdempotentSkip` so the public-index announce path,
-  // which changes capabilities under an unchanged pubkey, never short-circuits.
-  if (allowIdempotentSkip) {
-    const idempotent = await isStackRegistered({
-      registryUrl: url,
-      principalId: cfg.principalId,
-      stackId: cfg.stackId,
-      stackPubkey: material.pubkeyB64,
-    });
-    if (idempotent === "registered") {
-      return { ok: true, note: "already registered (idempotent skip)" };
-    }
-  }
-
-  // (2) Add-stack: when a root seed is supplied, the ROOT signs the claim and
-  // the existing stacks are fetch+merged so the full-overwrite route preserves
-  // them. Without it, this is a first-stack register (the new stack both
-  // declares + signs — pre-C-791 behaviour).
+  // (2) Add-stack root material — load it up front (the skip below needs the
+  // verified merge-read, which root-auth doesn't change, but the cap merge +
+  // claim signing do). When a root seed is supplied, the ROOT signs the claim
+  // and the existing stacks + caps are fetch+merged so the full-overwrite route
+  // preserves them. Without it, this is a first-stack register (the new stack
+  // both declares + signs — pre-C-791 behaviour).
   let rootMaterial: StackIdentityMaterial | undefined;
   if (cfg.rootSeedPath !== undefined) {
     const rootRes = loadSeedMaterial(cfg.rootSeedPath, "--principal-seed");
@@ -227,21 +215,58 @@ async function registerWithCapabilities(
     rootMaterial = rootRes.material;
   }
 
+  // (1) Idempotency (federated join): skip ONLY when fully converged — the
+  // stack pubkey AND the announced capabilities are already on record. This is
+  // the MAJOR 1 fix: an already-registered stack whose network caps are NOT yet
+  // announced must STILL register so the announce lands the principal in the
+  // network roster (0-peers-otherwise). A registry error here is non-fatal: we
+  // fall through to the normal register, which surfaces the registry's own
+  // error. Gated by `allowIdempotentSkip` so the public-index announce path
+  // never short-circuits.
+  if (allowIdempotentSkip) {
+    const idempotent = await isStackRegistered({
+      registryUrl: url,
+      principalId: cfg.principalId,
+      stackId: cfg.stackId,
+      stackPubkey: material.pubkeyB64,
+      ...(registryPubkey !== undefined && { registryPubkey }),
+      announce: capabilities,
+    });
+    if (idempotent === "registered") {
+      return { ok: true, note: "already registered + announced (idempotent skip)" };
+    }
+  }
+
+  const isAddStack = rootMaterial !== undefined;
+
   const stacksRes = await resolveMergedStacks({
     principalId: cfg.principalId,
     stackId: cfg.stackId,
     stackPubkey: material.pubkeyB64,
     registryUrl: url,
-    isAddStack: rootMaterial !== undefined,
+    ...(registryPubkey !== undefined && { registryPubkey }),
+    isAddStack,
   });
   if (!stacksRes.ok) return { ok: false, reason: stacksRes.reason };
+
+  // MAJOR 2 — merge the announced capabilities into the principal's existing
+  // set so the full-overwrite register does not drop prior-network caps (which
+  // would evict those networks from the principal's roster membership).
+  const capsRes = await resolveMergedCapabilities({
+    principalId: cfg.principalId,
+    registryUrl: url,
+    ...(registryPubkey !== undefined && { registryPubkey }),
+    announce: capabilities,
+    isAddStack,
+  });
+  if (!capsRes.ok) return { ok: false, reason: capsRes.reason };
 
   const body = await buildRegistrationClaim({
     principalId: cfg.principalId,
     material,
     ...(rootMaterial !== undefined && { rootMaterial }),
     stacks: stacksRes.stacks,
-    capabilities,
+    capabilities: capsRes.capabilities,
   });
   let result;
   try {

--- a/src/cli/cortex/commands/network.ts
+++ b/src/cli/cortex/commands/network.ts
@@ -136,6 +136,14 @@ const SPEC: SubcommandSpec<NetworkSubcommand> = {
         "--registry-url": "value",
         "--registry-pubkey": "value",
         "--seed-path": "value",
+        // C-791 — the principal ROOT seed (the FIRST stack's seed). Present ONLY
+        // when joining a SECOND+ stack of an already-registered principal: the
+        // register step then signs the add-stack claim with the root + fetch-
+        // merges the existing stacks (mirrors `provision-stack register
+        // --principal-seed`). Omit for a first-stack join (then `--seed-path` is
+        // itself the root). The flag wins over config; no config field is
+        // derived for it (no natural cortex.yaml field exists — see help).
+        "--principal-seed": "value",
         "--creds": "value",
         "--account": "value",
         "--nats-config": "value",
@@ -734,6 +742,13 @@ function portsConfigFromInputs(
     registryUrl: inputs.registryUrl,
     ...(inputs.registryPubkey !== undefined && { registryPubkey: inputs.registryPubkey }),
     seedPath: inputs.seedPath,
+    // C-791 — optional principal ROOT seed for a 2nd-stack join. Flag-only (no
+    // config field): present ⇒ the register step root-signs the add-stack claim
+    // + fetch-merges existing stacks; absent ⇒ first-stack register (with the
+    // idempotency skip when the stack is already on record).
+    ...(optionalValueFlag(flags, "--principal-seed") !== undefined && {
+      rootSeedPath: optionalValueFlag(flags, "--principal-seed"),
+    }),
     natsConfigPath: inputs.natsConfigPath,
     // #763 — platform-resolved service descriptor: plist on macOS, systemd unit
     // on Linux. The deriver sets exactly one + the platform; thread both through
@@ -875,7 +890,9 @@ Subcommands:
           fallback on registry outage, DD-10) → render the nats-server leaf +
           ensure the plist loads it (DD-6) → write policy.federated.networks[]
           with registry-resolved peers (DD-5) + the stack's OWN accept-subject
-          → restart. Idempotent (re-running converges).
+          → restart. Idempotent (re-running converges). For a principal's
+          SECOND+ stack, pass --principal-seed <root> so the register step
+          root-signs the add-stack claim + preserves existing stacks (#791).
   status  Show joined networks, peers, accept-subjects, leaf link state + counters.
   leave   Reverse a join cleanly: remove the network + leaf include, drop the
           plist -c arg if no networks remain, restart. Idempotent.
@@ -911,6 +928,18 @@ Flags (all OPTIONAL OVERRIDES — derived from cortex.yaml when omitted; #753):
   --registry-url <url>    Override policy.federated.registry.url.
   --registry-pubkey <b64> Override policy.federated.registry.pubkey (DD-9); TOFU if omitted.
   --seed-path <p>         Override stack.nkey_seed_path (proof-of-possession).
+  --principal-seed <p>    (join, #791) The principal ROOT seed (the FIRST stack's
+                          seed). Pass ONLY when joining a SECOND+ stack of an
+                          already-registered principal: the register step then
+                          signs the add-stack claim with the root and fetch-
+                          merges the principal's existing stacks (so other stacks
+                          survive), mirroring \`provision-stack register
+                          --principal-seed\`. Omit for a first-stack join (then
+                          --seed-path is itself the root). A re-run, or a join
+                          after \`provision-stack register\`, is idempotent (the
+                          register no-ops when the stack is already on record),
+                          so --principal-seed is only needed to register a NEW
+                          2nd stack — not to re-run a converged one.
   --creds <p>             Override stack.nats_infra.creds_path (default: ~/.config/nats/<network>.creds).
   --account <nkey-U>      Override stack.nats_infra.account (A… nkey-U the leaf binds to).
   --nats-config <p>       Override stack.nats_infra.config_path (nats-server -c config).

--- a/src/cli/cortex/commands/provision-stack.ts
+++ b/src/cli/cortex/commands/provision-stack.ts
@@ -56,10 +56,9 @@ import {
   materialFromSeedString,
   buildRegistrationClaim,
   registerStackIdentity,
-  fetchExistingStacks,
+  resolveMergedStacks,
   type StackIdentityMaterial,
   type SignedRegistrationBody,
-  type StackEntryShape,
 } from "../../../bus/stack-provisioning";
 
 import { CliArgsError } from "./_shared/arg-error";
@@ -350,13 +349,13 @@ async function doRegister(
   // the add-stack path we therefore FETCH the principal's existing stacks and
   // merge the new one in, so the root re-attests the full set and the route's
   // overwrite becomes correct.
-  const stacksRes = await resolveMergedStacks(
+  const stacksRes = await resolveMergedStacks({
     principalId,
     stackId,
-    material.pubkeyB64,
+    stackPubkey: material.pubkeyB64,
     registryUrl,
-    rootMaterial !== undefined,
-  );
+    isAddStack: rootMaterial !== undefined,
+  });
   if (!stacksRes.ok) return { ok: false, reason: stacksRes.reason };
 
   let body: SignedRegistrationBody;
@@ -391,87 +390,6 @@ async function doRegister(
     };
   }
   return { ok: true, note: `registered pubkey ${material.fingerprint}… at ${registryUrl} (HTTP ${result.status.toString()})` };
-}
-
-/** A stack entry as carried in the registration claim. */
-interface ClaimStack {
-  stack_id: string;
-  stack_pubkey?: string;
-  display_name?: string;
-  metadata?: Record<string, string>;
-}
-
-/**
- * C-787 — compute the COMPLETE `stacks[]` for the registration claim.
- *
- * First registration (`isAddStack === false`): just the new stack — pre-C-787
- * behaviour; the route establishes the principal from scratch, nothing to drop.
- *
- * Add-stack (`isAddStack === true`): FETCH the principal's existing stacks and
- * merge the new one in (replace-by-stack_id if it already exists, else append),
- * each existing entry keeping its own `stack_pubkey`. This is the data-loss
- * fix: the full-overwrite route then writes the complete intended set instead
- * of clobbering the existing stacks with only the new one.
- *
- * Failure handling:
- *   - registry returns 404 (`absent`) on the add-stack path → the principal
- *     isn't registered yet, so there is nothing to merge; proceed with just the
- *     new stack (equivalent to a first registration).
- *   - registry unreachable / malformed (`error`) → ABORT with a clear error. We
- *     do NOT fall back to sending only the new stack: that is precisely the
- *     silent stack-drop the blocker is about.
- */
-async function resolveMergedStacks(
-  principalId: string,
-  stackId: string,
-  stackPubkey: string,
-  registryUrl: string,
-  isAddStack: boolean,
-): Promise<{ ok: true; stacks: ClaimStack[] } | { ok: false; reason: string }> {
-  const newStack: ClaimStack = { stack_id: stackId, stack_pubkey: stackPubkey };
-  if (!isAddStack) {
-    return { ok: true, stacks: [newStack] };
-  }
-
-  let existing: Awaited<ReturnType<typeof fetchExistingStacks>>;
-  try {
-    existing = await fetchExistingStacks({ registryUrl, principalId });
-  } catch (err) {
-    return {
-      ok: false,
-      reason: `failed to fetch existing stacks for merge: ${err instanceof Error ? err.message : String(err)}`,
-    };
-  }
-
-  if (existing.kind === "error") {
-    return {
-      ok: false,
-      reason:
-        `cannot add a stack without dropping existing ones: ${existing.reason}. ` +
-        `Refusing to register a partial stack set (would overwrite the principal's stacks). ` +
-        `Verify --registry-url and retry.`,
-    };
-  }
-  if (existing.kind === "absent") {
-    // No record yet — nothing to preserve. Proceed with just the new stack.
-    return { ok: true, stacks: [newStack] };
-  }
-
-  // present — merge: replace-by-stack_id if present, else append.
-  const merged: ClaimStack[] = existing.stacks.map((s: StackEntryShape) => ({
-    stack_id: s.stack_id,
-    ...(s.stack_pubkey !== undefined && { stack_pubkey: s.stack_pubkey }),
-    ...(s.display_name !== undefined && { display_name: s.display_name }),
-    ...(s.metadata !== undefined && { metadata: s.metadata }),
-  }));
-  const idx = merged.findIndex((s) => s.stack_id === stackId);
-  if (idx >= 0) {
-    // Re-keying an existing stack: keep position, swap in the new pubkey.
-    merged[idx] = { ...merged[idx], stack_id: stackId, stack_pubkey: stackPubkey };
-  } else {
-    merged.push(newStack);
-  }
-  return { ok: true, stacks: merged };
 }
 
 // =============================================================================

--- a/src/cli/cortex/commands/provision-stack.ts
+++ b/src/cli/cortex/commands/provision-stack.ts
@@ -106,6 +106,12 @@ const SPEC: SubcommandSpec<ProvisionSubcommand> = {
         // is the NEW stack's own key. Omit for a first registration (then
         // `--seed-path` is itself the root, as pre-C-787).
         "--principal-seed": "value",
+        // C-791 (security) — the PINNED registry pubkey. REQUIRED on the
+        // add-stack path (--principal-seed): the merge-read of the principal's
+        // existing stacks is signature-verified against this pin before it
+        // drives the destructive full-overwrite re-attestation, so a
+        // compromised registry can't omit a stack and cause a silent drop.
+        "--registry-pubkey": "value",
       },
     },
   },
@@ -313,12 +319,24 @@ async function runRegister(ctx: HandlerCtx): Promise<ExitResult> {
     rootMaterial = rootRes.material;
   }
 
+  // C-791 (security) — optional pinned registry pubkey. The add-stack merge-read
+  // is verified against it (fail closed when absent on the add-stack path).
+  const pubkeyFlag = ctx.flags["--registry-pubkey"];
+  let registryPubkey: string | undefined;
+  if (pubkeyFlag !== undefined) {
+    if (pubkeyFlag === true || typeof pubkeyFlag !== "string") {
+      return usageError("register", "--registry-pubkey requires a value", ctx.json);
+    }
+    registryPubkey = pubkeyFlag;
+  }
+
   const reg = await doRegister(
     ctx.principalId,
     matRes.material,
     stackIdRes.stackId,
     urlRes.value,
     rootMaterial,
+    registryPubkey,
   );
   if (!reg.ok) return opError(reg.reason, ctx.json, { fingerprint: matRes.material.fingerprint });
 
@@ -341,6 +359,7 @@ async function doRegister(
   stackId: string,
   registryUrl: string,
   rootMaterial?: StackIdentityMaterial,
+  registryPubkey?: string,
 ): Promise<{ ok: true; note: string } | { ok: false; reason: string }> {
   // C-787 — build the COMPLETE intended `stacks[]`. The register route does a
   // FULL-OVERWRITE upsert of the `stacks` column with no read-merge, so a claim
@@ -348,12 +367,14 @@ async function doRegister(
   // exact federation #787 exists to preserve (PR #790 data-loss blocker). On
   // the add-stack path we therefore FETCH the principal's existing stacks and
   // merge the new one in, so the root re-attests the full set and the route's
-  // overwrite becomes correct.
+  // overwrite becomes correct. C-791 — the merge-read is signature-verified
+  // against `registryPubkey` (fail closed on the add-stack path when absent).
   const stacksRes = await resolveMergedStacks({
     principalId,
     stackId,
     stackPubkey: material.pubkeyB64,
     registryUrl,
+    ...(registryPubkey !== undefined && { registryPubkey }),
     isAddStack: rootMaterial !== undefined,
   });
   if (!stacksRes.ok) return { ok: false, reason: stacksRes.reason };
@@ -472,7 +493,7 @@ function topLevelHelp(): string {
 Usage:
   cortex provision-stack generate <principal-id> --seed-path <path> [--stack-id <id>] [--force] [--register --registry-url <url>] [--json]
   cortex provision-stack claim    <principal-id> --seed-path <path> [--stack-id <id>] [--json]
-  cortex provision-stack register <principal-id> --seed-path <path> --registry-url <url> [--stack-id <id>] [--json]
+  cortex provision-stack register <principal-id> --seed-path <path> --registry-url <url> [--stack-id <id>] [--principal-seed <root-path> --registry-pubkey <b64>] [--json]
 
 Subcommands:
   generate   Generate a fresh NKey signing identity; write seed chmod 600
@@ -489,6 +510,16 @@ Flags:
   --force                Allow overwriting an existing seed (DELIBERATE rotation).
   --register             (generate only) also register the pubkey after generating.
   --registry-url <url>   Network-registry base URL for registration.
+  --principal-seed <p>   (register, #787) The principal ROOT seed (the FIRST
+                         stack's seed) for adding a SECOND+ stack. The add-stack
+                         claim is then root-signed; --seed-path is the new
+                         stack's own key.
+  --registry-pubkey <b64> (register, #791) Pinned registry pubkey. REQUIRED with
+                         --principal-seed: the merge-read of the principal's
+                         existing stacks is signature-verified against it before
+                         the destructive full-overwrite re-attestation (fails
+                         closed if absent — guards against a compromised registry
+                         silently dropping a stack).
   --json                 Emit a { status, items, data, error } envelope.
 
 Secrets: the NKey SEED is written to disk + held in memory to sign the claim;


### PR DESCRIPTION
Closes #791.

`cortex network join`'s register step hard-coded the joining stack's own key as the claim `principal_pubkey`, so a principal's **2nd stack** tripped the registry rotation gate → 409. #787 solved this for `provision-stack register`; this extends `join` the same way.

## Change
- **`--principal-seed <root>`** on `cortex network join`: the register step root-signs the add-stack claim and **fetch+merges** existing stacks (preserving e.g. `andreas/meta-factory`). Reuses the #787 logic via a shared `resolveMergedStacks` (no hand-rolling).
- **Idempotency:** `isStackRegistered` probe — if the stack is already registered with its current pubkey, the register step is a **no-op skip** (so join-after-`provision-stack register`, or a re-run, converges with no 409).
- **#787 root-auth NOT relaxed:** a 2nd-stack join *without* `--principal-seed` (and not already registered) still 409s; the route's rotation/signature gates are untouched.

## Tests
4 new end-to-end C-791 tests against the real registry route (2nd-stack add succeeds; without --principal-seed 409s; idempotent skip; meta-factory preserved). 1269 pass, typecheck clean, eslint clean, carve-out PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)