### PR TITLE
fix(cli): C-794 — cortex network join fails fast on a bus that can't bind the leaf account

### DIFF
--- a/src/cli/cortex/commands/__tests__/network-lib.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-lib.test.ts
@@ -111,6 +111,8 @@ interface Recorder {
   dropped: string[];
   configWrites: PolicyFederatedNetwork[][];
   warnings: string[];
+  /** #794 — accounts the orchestrator pre-flighted via canBindAccount(). */
+  bindChecks: string[];
 }
 
 function makeFakes(opts: {
@@ -124,6 +126,8 @@ function makeFakes(opts: {
   withoutNatsServer?: boolean;
   initialNetworks?: PolicyFederatedNetwork[];
   leafState?: LeafStatePort;
+  /** #794 — make the stack's nats config UNABLE to bind the leaf account. */
+  canBind?: boolean;
 }): { ports: NetworkPorts; rec: Recorder; storeRef: { networks: PolicyFederatedNetwork[] } } {
   const rec: Recorder = {
     registered: 0,
@@ -138,6 +142,7 @@ function makeFakes(opts: {
     dropped: [],
     configWrites: [],
     warnings: [],
+    bindChecks: [],
   };
   const storeRef = { networks: opts.initialNetworks ?? [] };
   const leafFilesPresent = new Set<string>(
@@ -184,6 +189,18 @@ function makeFakes(opts: {
     },
     natsConfigPath() {
       return "/Users/andreas/.config/nats/local.conf";
+    },
+    canBindAccount(account) {
+      rec.bindChecks.push(account);
+      // #794 — default: the bus can bind (operator-mode). A test opts into the
+      // anonymous-bus crash case via `canBind: false`.
+      return opts.canBind === false
+        ? {
+            canBind: false,
+            reason:
+              "config is anonymous/hard-isolated (no operator-mode account tree)",
+          }
+        : { canBind: true };
     },
   };
 
@@ -277,6 +294,64 @@ describe("join", () => {
     expect(net.id).toBe("metafactory");
     // (e) restarted.
     expect(rec.restarts).toBe(1);
+    // (b.5) #794 — the account was pre-flighted before any mutation.
+    expect(rec.bindChecks).toEqual([LOCAL.account]);
+  });
+
+  // ---------------------------------------------------------------------------
+  // #794 — FAIL FAST on a bus that can't bind the leaf account (no crash).
+  // ---------------------------------------------------------------------------
+  describe("#794 fail-fast (anonymous / hard-isolated bus)", () => {
+    test("REFUSES when the nats config can't bind the leaf account", async () => {
+      const { ports } = makeFakes({ canBind: false });
+      const res = await joinNetwork("metafactory", LOCAL, ports);
+
+      expect(res.ok).toBe(false);
+      // Actionable error: names the config path, the missing account, the fix.
+      expect(res.reason).toContain("/Users/andreas/.config/nats/local.conf");
+      expect(res.reason).toContain(LOCAL.account);
+      expect(res.reason).toContain("operator-mode");
+      expect(res.reason).toContain("cortex#794");
+    });
+
+    test("touches NOTHING when it refuses (no leaf, no include, no restart)", async () => {
+      const { ports, rec, storeRef } = makeFakes({ canBind: false });
+      const res = await joinNetwork("metafactory", LOCAL, ports);
+
+      expect(res.ok).toBe(false);
+      // The pre-flight ran...
+      expect(rec.bindChecks).toEqual([LOCAL.account]);
+      // ...but NO mutation followed it.
+      expect(rec.writes.length).toBe(0); // no leaf include written
+      expect(rec.includesEnsured).toEqual([]); // no local.conf include
+      expect(rec.ensured).toEqual([]); // no plist ensure
+      expect(rec.configWrites.length).toBe(0); // no federation config write
+      expect(rec.restarts).toBe(0); // no daemon restart
+      expect(rec.natsRestarts).toBe(0); // no nats-server restart
+      expect(storeRef.networks.length).toBe(0); // config untouched
+    });
+
+    test("dry-run surfaces the SAME refusal (canBindAccount is a READ)", async () => {
+      // The orchestrator is identical under dry-run/live; the fake models the
+      // dry-run adapter (reads hit disk, writes no-op) — and the guard fires on
+      // the READ, so a dry-run join refuses just like --apply would.
+      const { ports, rec } = makeFakes({ canBind: false });
+      const res = await joinNetwork("metafactory", LOCAL, ports);
+      expect(res.ok).toBe(false);
+      expect(res.reason).toContain("cortex#794");
+      expect(rec.writes.length).toBe(0);
+    });
+
+    test("proceeds normally when the config CAN bind the account", async () => {
+      const { ports, rec, storeRef } = makeFakes({ canBind: true });
+      const res = await joinNetwork("metafactory", LOCAL, ports);
+      expect(res.ok).toBe(true);
+      expect(rec.bindChecks).toEqual([LOCAL.account]);
+      // Existing join flow unchanged: leaf written, restarted, config written.
+      expect(rec.writes.length).toBe(1);
+      expect(rec.restarts).toBe(1);
+      expect(storeRef.networks.length).toBe(1);
+    });
   });
 
   test("accept_subjects is the stack's OWN federated.{me}.{stack}.> (wire contract)", async () => {

--- a/src/cli/cortex/commands/network-adapters.ts
+++ b/src/cli/cortex/commands/network-adapters.ts
@@ -36,6 +36,7 @@ import { expandTilde } from "../../../common/config/loader";
 import {
   ensureLeafInclude,
   leafIncludeFileName,
+  natsConfigCanBindAccount,
   removeLeafInclude,
   renderLeafIncludeFile,
 } from "../../../common/nats/leaf-remote-renderer";
@@ -378,6 +379,17 @@ function buildLeafFilePort(cfg: LivePortsConfig, mutate: boolean): LeafFilePort 
     },
     natsConfigPath() {
       return expandTilde(cfg.natsConfigPath ?? "");
+    },
+    canBindAccount(account) {
+      // #794 — pure READ (identical in live + dry-run): an anonymous bus that
+      // can't bind the leaf account would crash nats-server on restart, so the
+      // orchestrator refuses BEFORE any mutation. An absent/empty config file is
+      // anonymous-by-definition → cannot bind.
+      const configPath = expandTilde(cfg.natsConfigPath ?? "");
+      const text = existsSync(configPath)
+        ? readFileSync(configPath, "utf-8")
+        : "";
+      return natsConfigCanBindAccount(text, account);
     },
   };
 }

--- a/src/cli/cortex/commands/network-lib.ts
+++ b/src/cli/cortex/commands/network-lib.ts
@@ -189,6 +189,33 @@ export async function joinNetwork(
   // would be a tsc error at the next line.
   const verified = brandVerified(descriptor);
 
+  // (b.5) #794 — FAIL FAST: never render a leaf that would CRASH the stack's
+  // bus. The leaf remote binds `stack.account` (nkey-U); nats-server resolves
+  // that account against the LOCAL nats config's account tree on startup. If
+  // the config is anonymous + hard-isolated (no operator-mode account tree —
+  // the halden/community pattern) or is operator-mode but doesn't define THIS
+  // account, nats-server crashes (`cannot find local account "<A…>" specified
+  // in leafnode remote`) and the whole bus goes DOWN. So pre-validate the
+  // resolved config BEFORE any mutation (no leaf write, no include, no
+  // restart) — a READ, so dry-run surfaces the same refusal. Recoverable: the
+  // operator converts the bus to operator-mode (define the account) or passes a
+  // config that does. Refusing here is strictly safer than a crashed server.
+  const bind = ports.leafFile.canBindAccount(stack.account);
+  if (!bind.canBind) {
+    const configPath = ports.leafFile.natsConfigPath();
+    return {
+      ok: false,
+      steps,
+      reason:
+        `nats config ${configPath} cannot bind account ${stack.account} ` +
+        `(${bind.reason ?? "unknown"}) — this bus is anonymous/isolated and ` +
+        `cannot federate. Convert it to operator-mode (define the account; see ` +
+        `docs/sop-stack-onboarding.md §Part 2) or pass a config that defines the ` +
+        `account (--nats-config). Refusing to render a leaf that would crash ` +
+        `nats-server (cortex#794).`,
+    };
+  }
+
   // (c) Render + write the leaf include (S3) and ensure the plist loads the
   // nats config (DD-6, closes the configured-but-dormant trap). The renderer
   // fails loud on a bad binding — surface it as a join failure, never a crash.

--- a/src/cli/cortex/commands/network-ports.ts
+++ b/src/cli/cortex/commands/network-ports.ts
@@ -31,7 +31,10 @@ import type {
   NetworkRosterResult,
 } from "../../../common/registry/types";
 import type { NetworkFetchResult } from "../../../common/registry/network-client";
-import type { StackLeafBinding } from "../../../common/nats/leaf-remote-renderer";
+import type {
+  AccountBindCheck,
+  StackLeafBinding,
+} from "../../../common/nats/leaf-remote-renderer";
 import type { PolicyFederatedNetwork } from "../../../common/types/cortex-config";
 
 // =============================================================================
@@ -147,6 +150,17 @@ export interface LeafFilePort {
    * owns where it lives so the plist port can be told which path to ensure.
    */
   natsConfigPath(): string;
+  /**
+   * #794 — pre-flight: can the stack's nats config (`natsConfigPath()`) BIND a
+   * leaf to `account` (nkey-U) without crashing nats-server? An anonymous /
+   * hard-isolated bus (no operator-mode account tree) does NOT define the
+   * account, so rendering a leaf that binds it makes nats-server crash on
+   * startup (`cannot find local account "<A…>"`), taking the bus down. The
+   * orchestrator calls this BEFORE any mutation and REFUSES the join when the
+   * config can't bind — a READ, so live + dry-run behave identically. Delegates
+   * to {@link natsConfigCanBindAccount}; an absent config file → cannot bind.
+   */
+  canBindAccount(account: string): AccountBindCheck;
 }
 
 /**

--- a/src/common/nats/__tests__/nats-config-bind-account.test.ts
+++ b/src/common/nats/__tests__/nats-config-bind-account.test.ts
@@ -1,0 +1,132 @@
+/**
+ * #794 — `natsConfigCanBindAccount` pre-flight tests (RED-first).
+ *
+ * `cortex network join` renders a leaf remote with `account: <A…>` and restarts
+ * nats-server. nats-server resolves that account against the LOCAL config's
+ * account tree. An anonymous + hard-isolated bus (no operator-mode account
+ * tree — the halden/community pattern) does NOT define the account, so the
+ * server crashes on startup (`cannot find local account "<A…>" specified in
+ * leafnode remote`) and the whole bus goes DOWN.
+ *
+ * `natsConfigCanBindAccount` is the pure pre-flight the join orchestrator runs
+ * BEFORE any mutation: operator-mode config that names the account → can bind;
+ * anonymous config, or operator-mode missing THIS account → cannot bind.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { natsConfigCanBindAccount } from "../leaf-remote-renderer";
+
+// A valid nkey-U account public key grammar (A + 55 base32 chars).
+const ACCOUNT = "A" + "B".repeat(55);
+const OTHER_ACCOUNT = "A" + "C".repeat(55);
+
+// An operator-mode local.conf that DEFINES the account (resolver_preload names
+// it as a key) — the andreas/meta-factory shape. nats-server can bind the leaf.
+const OPERATOR_WITH_ACCOUNT = [
+  "// nats-server operator-mode config.",
+  "operator: /Users/andreas/.config/nats/operator.jwt", // NSC operator JWT key
+  "system_account: ADSYSACCOUNT",
+  "resolver: { type: full, dir: /Users/andreas/.config/nats/jwt }",
+  "resolver_preload: {",
+  `  ${ACCOUNT}: "eyJ0eXAiOiJKV1QiLCJhbGciOiJlZDI1NTE5LW5rZXkifQ..."`,
+  "}",
+  "",
+].join("\n");
+
+// An operator-mode config that DOESN'T define this specific account (it defines
+// a different one). nats-server would crash binding ACCOUNT.
+const OPERATOR_WITHOUT_ACCOUNT = [
+  "operator: /Users/andreas/.config/nats/operator.jwt", // NSC operator JWT key
+  "resolver_preload: {",
+  `  ${OTHER_ACCOUNT}: "eyJ0eXAiOiJKV1Qi..."`,
+  "}",
+  "",
+].join("\n");
+
+// The halden/community pattern: anonymous + hard-isolated. No NSC operator JWT,
+// no accounts, no resolver_preload — nats-server defines NO accounts at all.
+const ANONYMOUS = [
+  "// anonymous hard-isolated bus (community pattern).",
+  "host: 0.0.0.0",
+  "port: 4224",
+  "jetstream { store_dir: /Users/andreas/.config/nats/community-js }",
+  "",
+].join("\n");
+
+describe("natsConfigCanBindAccount", () => {
+  test("operator-mode config that DEFINES the account → can bind", () => {
+    const res = natsConfigCanBindAccount(OPERATOR_WITH_ACCOUNT, ACCOUNT);
+    expect(res.canBind).toBe(true);
+    expect(res.reason).toBeUndefined();
+  });
+
+  test("anonymous / hard-isolated config → cannot bind (the crash case)", () => {
+    const res = natsConfigCanBindAccount(ANONYMOUS, ACCOUNT);
+    expect(res.canBind).toBe(false);
+    expect(res.reason).toContain("anonymous");
+  });
+
+  test("operator-mode config MISSING this account → cannot bind", () => {
+    const res = natsConfigCanBindAccount(OPERATOR_WITHOUT_ACCOUNT, ACCOUNT);
+    expect(res.canBind).toBe(false);
+    expect(res.reason).toContain("does not define account");
+  });
+
+  test("empty config (absent file) → cannot bind", () => {
+    const res = natsConfigCanBindAccount("", ACCOUNT);
+    expect(res.canBind).toBe(false);
+  });
+
+  test("a COMMENTED-OUT operator directive does NOT count as operator-mode", () => {
+    const commented = [
+      "// operator: /Users/andreas/.config/nats/operator.jwt", // NSC operator JWT (commented out)
+      "# accounts { FOO {} }",
+      "port: 4224",
+      "",
+    ].join("\n");
+    const res = natsConfigCanBindAccount(commented, ACCOUNT);
+    expect(res.canBind).toBe(false);
+  });
+
+  test("a COMMENTED-OUT account line does NOT count as defining the account", () => {
+    const commented = [
+      "operator: /Users/andreas/.config/nats/operator.jwt", // NSC operator JWT key
+      "resolver_preload: {",
+      `  // ${ACCOUNT}: "jwt..."`,
+      "}",
+      "",
+    ].join("\n");
+    const res = natsConfigCanBindAccount(commented, ACCOUNT);
+    expect(res.canBind).toBe(false);
+    expect(res.reason).toContain("does not define account");
+  });
+
+  test("accounts block (no NSC operator JWT key) still counts as operator-mode", () => {
+    const accountsOnly = [
+      "accounts: {",
+      `  MYACC: { jetstream: enabled, users: [] }`,
+      `  preload: ${ACCOUNT}`,
+      "}",
+      "",
+    ].join("\n");
+    const res = natsConfigCanBindAccount(accountsOnly, ACCOUNT);
+    expect(res.canBind).toBe(true);
+  });
+
+  test("a malformed account is rejected (not a valid nkey-U)", () => {
+    const res = natsConfigCanBindAccount(OPERATOR_WITH_ACCOUNT, "not-an-account");
+    expect(res.canBind).toBe(false);
+    expect(res.reason).toContain("not a valid nkey-U");
+  });
+
+  test("tolerates the `key =` HOCON assignment form for the NSC operator JWT key", () => {
+    const eqForm = [
+      "operator = /Users/andreas/.config/nats/operator.jwt", // NSC operator JWT key
+      `resolver_preload: { ${ACCOUNT}: "jwt..." }`,
+      "",
+    ].join("\n");
+    const res = natsConfigCanBindAccount(eqForm, ACCOUNT);
+    expect(res.canBind).toBe(true);
+  });
+});

--- a/src/common/nats/leaf-remote-renderer.ts
+++ b/src/common/nats/leaf-remote-renderer.ts
@@ -362,6 +362,124 @@ export function removeLeafInclude(
   return natsConfigText.replace(global, "");
 }
 
+// =============================================================================
+// #794 — pre-flight: can this nats config BIND the leaf account?
+//
+// `cortex network join` renders a leaf remote with `account: <A…>` (the leaf
+// creds' account) and restarts nats-server. nats-server resolves that account
+// against the LOCAL config's account tree. If the config is operator-mode and
+// defines the account (e.g. via `resolver_preload`/`accounts`), the leaf binds.
+// If the config is anonymous + hard-isolated (no `operator:` and no account
+// tree — the halden/community pattern), the account is unknown and nats-server
+// CRASHES on startup with `cannot find local account "<A…>" specified in
+// leafnode remote`, taking the whole bus DOWN.
+//
+// So before the join writes the leaf include + restarts nats, the orchestrator
+// pre-validates with {@link natsConfigCanBindAccount}. The check is a targeted
+// text heuristic (documented below) rather than a full HOCON+JWT parse: a
+// false "cannot bind" only blocks a join (recoverable — the principal converts
+// the bus or passes a config that defines the account), whereas the failure we
+// must never produce is a leaf render that crashes the server.
+// =============================================================================
+
+/**
+ * Strip line comments (`//` and `#`) from a nats config so a commented-out
+ * account-tree directive or account string can't produce a false positive. We
+ * strip only LINE comments (the shapes humans actually leave in `local.conf`);
+ * HOCON block comments are rare and treated as content (worst case: a
+ * false-positive bind decision inside a block comment, which is benign — the
+ * server would simply not see a real account there and the join re-runs).
+ */
+function stripConfigComments(natsConfigText: string): string {
+  return natsConfigText
+    .split("\n")
+    .map((line) => {
+      const trimmed = line.trimStart();
+      if (trimmed.startsWith("//") || trimmed.startsWith("#")) return "";
+      return line;
+    })
+    .join("\n");
+}
+
+/** The result of the #794 pre-flight bind check. */
+export interface AccountBindCheck {
+  /** True iff the config is operator-mode AND names the account (can bind). */
+  canBind: boolean;
+  /** Present when `canBind` is false — why the config can't bind the account. */
+  reason?: string;
+}
+
+/**
+ * Decide whether `natsConfigText` can bind a leaf to `account` (an nkey-U
+ * public key, `A…`) WITHOUT crashing nats-server (#794).
+ *
+ * Heuristic (deliberately simple + robust; a full HOCON+JWT parse is not worth
+ * the dependency and the failure mode of the heuristic is a recoverable refusal,
+ * never a crash):
+ *
+ *   - The config must be **operator-mode** — it contains a top-level
+ *     `operator:` / `operator =` key (the NSC operator JWT reference) OR an
+ *     account tree (`accounts` / `resolver_preload`). A config with NONE of
+ *     these is **anonymous + hard-isolated**: it defines no accounts, so the
+ *     account the leaf binds can never be found → `canBind: false`.
+ *   - AND the literal `account` nkey-U string must appear in the config (it is
+ *     the key/value naming the account in `resolver_preload`/`accounts`). An
+ *     operator-mode config that does not name THIS account also cannot bind it
+ *     → `canBind: false`.
+ *
+ * Comments are stripped first so a commented-out directive never counts.
+ *
+ * Pure: reads the text, writes nothing. The caller (the join orchestrator)
+ * passes the resolved `config_path` contents and refuses BEFORE any mutation
+ * when `canBind` is false.
+ */
+export function natsConfigCanBindAccount(
+  natsConfigText: string,
+  account: string,
+): AccountBindCheck {
+  const trimmedAccount = account.trim();
+  if (trimmedAccount.length === 0 || !NKEY_ACCOUNT.test(trimmedAccount)) {
+    // A malformed/empty account can't be reasoned about — treat as un-bindable
+    // (the renderer would reject it anyway; refuse early with a clear reason).
+    return {
+      canBind: false,
+      reason: `account ${JSON.stringify(account)} is not a valid nkey-U account public key`,
+    };
+  }
+
+  const text = stripConfigComments(natsConfigText);
+
+  // operator-mode signal: an NSC operator JWT key OR an account-tree directive
+  // (`accounts` / `resolver_preload`). HOCON allows `key:` or `key =` and
+  // leading whitespace; the regex matches the literal config key as its own
+  // token (the NATS account-tree root NSC operator JWT key, not the principal).
+  const hasAccountTree =
+    /^[ \t]*operator[ \t]*[:=]/m.test(text) || // NSC operator JWT key
+    /^[ \t]*accounts[ \t]*[:={]/m.test(text) ||
+    /^[ \t]*resolver_preload[ \t]*[:={]/m.test(text);
+
+  if (!hasAccountTree) {
+    return {
+      canBind: false,
+      reason:
+        "config is anonymous/hard-isolated (no operator-mode account tree: " +
+        "no NSC operator JWT key, `accounts`, or `resolver_preload`)",
+    };
+  }
+
+  // operator-mode, but does it name THIS account? The nkey-U appears as the
+  // key (resolver_preload) or value naming the account. A substring check is
+  // sufficient: nkey-U keys are high-entropy and won't collide with prose.
+  if (!text.includes(trimmedAccount)) {
+    return {
+      canBind: false,
+      reason: `config is operator-mode but does not define account ${trimmedAccount}`,
+    };
+  }
+
+  return { canBind: true };
+}
+
 /** Serialize one {@link LeafRemote} as a HOCON object literal (indented). */
 function serializeRemote(remote: LeafRemote, indent: string): string {
   // `url` + `credentials` are quoted (they contain `:`, `/`, `.` which are


### PR DESCRIPTION
Closes #794 (fail-fast half).

`cortex network join` rendered an account-bound leaf remote + restarted nats even when the stack's bus is **anonymous/hard-isolated** (no operator/accounts) → `cannot find local account "<A…>"` → **nats crashed**, taking the stack's bus down (hit joining `andreas/community`).

## Fix — refuse, touch nothing
Before any mutation (after the verified descriptor, **before** leaf write / include / config write / nats restart), `joinNetwork` checks the resolved nats config can bind the leaf account. If not → **returns a clear, actionable refusal** (names the file + account + the operator-mode fix + the SOP) and **writes nothing / restarts nothing**. Fails safe: worst case it refuses a valid bus; it can never crash one.

Detection heuristic (`natsConfigCanBindAccount`, comment-stripped): operator-mode signal (`operator:` / `accounts` / `resolver_preload`) **and** the account nkey-U present. Anonymous bus → refuse. Scoped to `joinNetwork` (`joinPublic` renders no leaf).

## Tests
11 heuristic unit tests + a `#794 fail-fast` block in network-lib (refusal writes nothing). 490 pass across nats + network CLI; tsc + eslint + carve-out clean.