### PR TITLE
fix(network): C-797 — cortex network status reflects authoritative leafz leaf-state (no more link:unknown)

### DIFF
--- a/src/cli/cortex/commands/__tests__/network-adapters.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-adapters.test.ts
@@ -22,7 +22,9 @@ import { parse as parseYaml } from "yaml";
 
 import {
   buildDryRunPorts,
+  buildLeafStatePort,
   buildLivePorts,
+  DEFAULT_MONITOR_URL,
   type LivePortsConfig,
 } from "../network-adapters";
 import {
@@ -1057,5 +1059,114 @@ describe("C-791 — registerStack supports a principal's 2nd+ stack", () => {
       const stacks = await getStacks("andreas");
       expect(stacks.map((s) => s.stack_id)).toEqual(["andreas/meta-factory"]);
     });
+  });
+});
+
+// =============================================================================
+// C-797 — leaf-state port reads the authoritative /leafz view
+// =============================================================================
+
+describe("C-797 buildLeafStatePort (/leafz monitor)", () => {
+  function leafCfg(monitorUrl?: string): LivePortsConfig {
+    return {
+      networkId: "metafactory",
+      principalId: "andreas",
+      stackId: "andreas/meta-factory",
+      natsConfigPath: NATS_CONFIG,
+      ...(monitorUrl !== undefined && { monitorUrl }),
+    };
+  }
+
+  /** Stub global fetch, recording the URL hit, returning the given /leafz body. */
+  function stubFetch(
+    body: unknown,
+    opts: { ok?: boolean; throws?: boolean } = {},
+  ): { urls: string[]; restore: () => void } {
+    const real = globalThis.fetch;
+    const urls: string[] = [];
+    // The leafz adapter always calls fetch() with a string URL (mirrors the
+    // existing withFetchCapture stub in this file).
+    globalThis.fetch = (async (url: string) => {
+      urls.push(url);
+      if (opts.throws === true) throw new Error("ECONNREFUSED");
+      return {
+        ok: opts.ok ?? true,
+        async json() {
+          return body;
+        },
+      } as Response;
+    }) as typeof globalThis.fetch;
+    return { urls, restore: () => (globalThis.fetch = real) };
+  }
+
+  test("always wires a port (never undefined) — C-797 status reads leafz by default", () => {
+    // Pre-#797 this returned undefined when monitorUrl was omitted → link:unknown.
+    expect(typeof buildLeafStatePort(leafCfg()).linkStates).toBe("function");
+  });
+
+  test("defaults to the local nats-server monitor when --monitor-url is omitted", async () => {
+    const f = stubFetch({ leafs: [] });
+    try {
+      await buildLeafStatePort(leafCfg()).linkStates();
+      expect(f.urls).toEqual([`${DEFAULT_MONITOR_URL}/leafz`]);
+    } finally {
+      f.restore();
+    }
+  });
+
+  test("honors an explicit --monitor-url override (trailing slash trimmed)", async () => {
+    const f = stubFetch({ leafs: [] });
+    try {
+      await buildLeafStatePort(leafCfg("http://127.0.0.1:8224/")).linkStates();
+      expect(f.urls).toEqual(["http://127.0.0.1:8224/leafz"]);
+    } finally {
+      f.restore();
+    }
+  });
+
+  test("maps a connected leaf to 'established', keyed by the leaf-node name", async () => {
+    const f = stubFetch({
+      leafs: [{ name: "shared-hub", in_msgs: 12, out_msgs: 4 }],
+    });
+    try {
+      const states = await buildLeafStatePort(leafCfg()).linkStates();
+      expect(states["shared-hub"]).toEqual({
+        state: "established",
+        inMsgs: 12,
+        outMsgs: 4,
+      });
+    } finally {
+      f.restore();
+    }
+  });
+
+  test("falls back to the bound account when /leafz omits the leaf name", async () => {
+    const f = stubFetch({ leafs: [{ account: "ALOCALACCOUNT", in_msgs: 1 }] });
+    try {
+      const states = await buildLeafStatePort(leafCfg()).linkStates();
+      expect(states.ALOCALACCOUNT?.state).toBe("established");
+    } finally {
+      f.restore();
+    }
+  });
+
+  test("degrades to {} when the monitor is unreachable (status → 'unknown')", async () => {
+    const f = stubFetch(undefined, { throws: true });
+    try {
+      const states = await buildLeafStatePort(leafCfg()).linkStates();
+      expect(states).toEqual({});
+    } finally {
+      f.restore();
+    }
+  });
+
+  test("degrades to {} on a non-200 monitor response", async () => {
+    const f = stubFetch({ leafs: [{ name: "x" }] }, { ok: false });
+    try {
+      const states = await buildLeafStatePort(leafCfg()).linkStates();
+      expect(states).toEqual({});
+    } finally {
+      f.restore();
+    }
   });
 });

--- a/src/cli/cortex/commands/__tests__/network-lib.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-lib.test.ts
@@ -808,4 +808,74 @@ describe("status", () => {
     expect(res.ok).toBe(true);
     expect(res.networks.length).toBe(0);
   });
+
+  // C-797 — leafz keys the leaf connection by the leaf-node (remote) name, which
+  // is NOT necessarily the network id. The status join must key on `leaf_node`
+  // so a connected leaf reports `established` (up), not `unknown`.
+  test("C-797: joins leafz by leaf_node when it differs from the network id", async () => {
+    const net: PolicyFederatedNetwork = {
+      ...joinedNetwork("research-collab"),
+      // The physical leaf link is named differently from the network id.
+      leaf_node: "shared-hub",
+    };
+    const leafState: LeafStatePort = {
+      async linkStates() {
+        // leafz reports the link keyed by the leaf-node name, not the network id.
+        return { "shared-hub": { state: "established", inMsgs: 5, outMsgs: 3 } };
+      },
+    };
+    const { ports } = makeFakes({ initialNetworks: [net], leafState });
+    const res = await networkStatus(ports);
+
+    const row = res.networks[0]!;
+    expect(row.networkId).toBe("research-collab");
+    // BEFORE the fix this was "unknown" (lookup by network id missed the
+    // leaf_node-keyed leafz row) — the exact #797 symptom.
+    expect(row.link.state).toBe("established");
+    expect(row.link.inMsgs).toBe(5);
+    expect(row.link.outMsgs).toBe(3);
+  });
+
+  test("C-797: a genuinely-down leaf reports its reported state, not 'unknown'", async () => {
+    const leafState: LeafStatePort = {
+      async linkStates() {
+        return { metafactory: { state: "down" } };
+      },
+    };
+    const { ports } = makeFakes({
+      initialNetworks: [joinedNetwork("metafactory")],
+      leafState,
+    });
+    const res = await networkStatus(ports);
+    expect(res.networks[0]!.link.state).toBe("down");
+  });
+
+  test("C-797: leaf_node lookup still works when leaf_node equals the network id", async () => {
+    const leafState: LeafStatePort = {
+      async linkStates() {
+        return { metafactory: { state: "established" } };
+      },
+    };
+    const { ports } = makeFakes({
+      initialNetworks: [joinedNetwork("metafactory")], // leaf_node === id
+      leafState,
+    });
+    const res = await networkStatus(ports);
+    expect(res.networks[0]!.link.state).toBe("established");
+  });
+
+  test("C-797: degrades to 'unknown' when leafz has no row for the leaf (genuinely unreachable monitor)", async () => {
+    const leafState: LeafStatePort = {
+      async linkStates() {
+        // Monitor unreachable / no matching leaf row — empty map.
+        return {};
+      },
+    };
+    const { ports } = makeFakes({
+      initialNetworks: [joinedNetwork("metafactory")],
+      leafState,
+    });
+    const res = await networkStatus(ports);
+    expect(res.networks[0]!.link.state).toBe("unknown");
+  });
 });

--- a/src/cli/cortex/commands/network-adapters.ts
+++ b/src/cli/cortex/commands/network-adapters.ts
@@ -581,26 +581,58 @@ function buildNatsServerPort(cfg: LivePortsConfig, mutate: boolean): NatsServerP
 // Leaf-state port — nats-server monitor /leafz for status.
 // =============================================================================
 
-function buildLeafStatePort(cfg: LivePortsConfig): LeafStatePort | undefined {
-  if (cfg.monitorUrl === undefined) return undefined;
-  const base = cfg.monitorUrl.replace(/\/+$/, "");
+/**
+ * C-797 — the nats-server HTTP monitor endpoint defaults to `127.0.0.1:8222`
+ * (the upstream default `http_port`). Before this fix `buildLeafStatePort`
+ * returned `undefined` whenever `--monitor-url` was omitted, so `cortex network
+ * status` never queried `/leafz` and every link fell back to `link:unknown` —
+ * even though leafz (the authoritative source) showed the leaf up. Defaulting
+ * the monitor URL makes status read the authoritative leaf-state out of the box;
+ * a genuinely-unreachable monitor still degrades gracefully to "unknown" via the
+ * fetch catch below.
+ */
+export const DEFAULT_MONITOR_URL = "http://127.0.0.1:8222";
+
+export function buildLeafStatePort(cfg: LivePortsConfig): LeafStatePort {
+  // C-797 — always wire the port; default to the local nats-server monitor when
+  // no `--monitor-url` was supplied. (Previously: undefined ⇒ no port ⇒
+  // link:unknown for everyone.)
+  const base = (cfg.monitorUrl ?? DEFAULT_MONITOR_URL).replace(/\/+$/, "");
   return {
     async linkStates() {
       try {
         const res = await fetch(`${base}/leafz`);
         if (!res.ok) return {};
         const body = (await res.json()) as {
-          leafs?: { account?: string; name?: string; in_msgs?: number; out_msgs?: number }[];
+          leafs?: {
+            account?: string;
+            name?: string;
+            in_msgs?: number;
+            out_msgs?: number;
+          }[];
         };
-        const out: Record<string, { state: "established"; inMsgs?: number; outMsgs?: number }> = {};
+        const out: Record<
+          string,
+          { state: "established"; inMsgs?: number; outMsgs?: number }
+        > = {};
         for (const leaf of body.leafs ?? []) {
+          // `/leafz` reports each leaf connection by its remote/leaf-node name
+          // (`name`), falling back to the bound NATS `account`. `networkStatus`
+          // joins these against each network's `leaf_node` (C-797), so an
+          // established leaf maps onto its network and reports `established`
+          // (up) rather than `unknown`.
           const key = leaf.name ?? leaf.account ?? "";
           if (key === "") continue;
-          out[key] = { state: "established", inMsgs: leaf.in_msgs, outMsgs: leaf.out_msgs };
+          out[key] = {
+            state: "established",
+            inMsgs: leaf.in_msgs,
+            outMsgs: leaf.out_msgs,
+          };
         }
         return out;
       } catch (err) {
-        // Monitor unreachable — status degrades to "unknown" link state.
+        // Monitor genuinely unreachable — status degrades to "unknown" link
+        // state (the #797 graceful-fallback path, preserved).
         process.stderr.write(
           `network-adapters: leaf-state fetch failed: ${err instanceof Error ? err.message : String(err)}\n`,
         );
@@ -615,7 +647,6 @@ function buildLeafStatePort(cfg: LivePortsConfig): LeafStatePort | undefined {
 // =============================================================================
 
 function buildPorts(cfg: LivePortsConfig, mutate: boolean): NetworkPorts {
-  const leafState = buildLeafStatePort(cfg);
   return {
     registry: buildRegistryPort(cfg),
     leafFile: buildLeafFilePort(cfg, mutate),
@@ -623,7 +654,9 @@ function buildPorts(cfg: LivePortsConfig, mutate: boolean): NetworkPorts {
     configStore: buildConfigStorePort(cfg, mutate),
     daemon: buildDaemonPort(cfg, mutate),
     natsServer: buildNatsServerPort(cfg, mutate),
-    ...(leafState !== undefined ? { leafState } : {}),
+    // C-797 — always present now (defaults to the local monitor); status reads
+    // the authoritative leafz view instead of falling back to link:unknown.
+    leafState: buildLeafStatePort(cfg),
   };
 }
 

--- a/src/cli/cortex/commands/network-lib.ts
+++ b/src/cli/cortex/commands/network-lib.ts
@@ -518,7 +518,13 @@ export async function networkStatus(ports: NetworkPorts): Promise<StatusResult> 
     peers: n.peers.map((p) => p.principal_id),
     acceptSubjects: n.accept_subjects,
     maxHop: n.max_hop,
-    link: linkStates[n.id] ?? { state: "unknown" },
+    // C-797 — `/leafz` keys each connection by the leaf-node (remote) name, which
+    // is NOT necessarily the network id (two networks may share one `leaf_node`,
+    // or it may be named independently). Join on `leaf_node` first so a connected
+    // leaf reports `established` (up); fall back to the network-id key for the
+    // common case where they coincide, then to "unknown" when leafz has no row
+    // (monitor genuinely unreachable).
+    link: linkStates[n.leaf_node] ?? linkStates[n.id] ?? { state: "unknown" },
   }));
 
   return { ok: true, networks: rows };

--- a/src/cli/cortex/commands/network-ports.ts
+++ b/src/cli/cortex/commands/network-ports.ts
@@ -223,7 +223,11 @@ export interface NatsServerPort {
  * monitor client is out of S4 scope).
  */
 export interface LeafStatePort {
-  /** Per-network leaf link state + in/out counters, keyed by network id. */
+  /**
+   * Leaf link state + in/out counters, keyed by the leaf-node (remote) name as
+   * reported by `/leafz`. `networkStatus` joins these against each network's
+   * `leaf_node` (C-797), falling back to the network id and then "unknown".
+   */
   linkStates(): Promise<Record<string, LeafLinkState>>;
 }
 


### PR DESCRIPTION
Closes #797.

## Summary

`cortex network status` reported `link:unknown` for a leaf that `leafz` (the authoritative NATS monitoring endpoint) showed **up**. This is a telemetry-display gap, not a real connectivity problem — the status command's monitor path couldn't read leaf-state, so it fell back to `link:unknown` instead of reflecting the authoritative `leafz` view.

## Root cause

Two compounding bugs:

1. **No default monitor URL.** `buildLeafStatePort` only returned a port when `cfg.monitorUrl` was set, and `monitorUrl` is populated *only* by the `--monitor-url` flag. With the flag omitted (the normal case) the leaf-state port was `undefined`, `networkStatus` never queried `/leafz`, and every link defaulted to `{ state: "unknown" }`.

2. **Key mismatch.** `/leafz` keys each leaf connection by the leaf-node (remote) name (falling back to the bound NATS account), but `networkStatus` looked the state up by **network id** (`linkStates[n.id]`). When a network's `leaf_node` differs from its `id` (the documented de-dup / pool key — two networks may share one physical leaf, or it may be named independently), even a correctly-wired monitor returned `unknown`.

## Fix

- Default the monitor URL to the local nats-server monitor endpoint (`http://127.0.0.1:8222`, the upstream default `http_port`) when `--monitor-url` is not supplied, so status reads the authoritative leaf-state out of the box. An explicit `--monitor-url` still overrides.
- Join `/leafz` rows against each network's `leaf_node` first, falling back to the network id (back-compat for the common case where they coincide), then to `unknown`. A connected leaf now reports `established` (up).
- Preserve graceful degradation: an unreachable or non-200 monitor still yields `link:unknown` rather than throwing. The `unknown` fallback is intentionally retained for the genuinely-unreachable case.

Surgical change — no behavior change to join/leave/provision paths; `status` is read-only.

## Tests

Lib-level (`network-lib.test.ts`):
- joins leafz by `leaf_node` when it differs from the network id → `established` (the exact #797 symptom, now fixed)
- a genuinely-down leaf reports its state, not `unknown`
- `leaf_node` lookup still works when `leaf_node` equals the network id
- degrades to `unknown` when leafz has no matching row

Adapter-level (`network-adapters.test.ts`):
- always wires a port (never `undefined`)
- defaults to the local monitor when `--monitor-url` is omitted
- honors an explicit `--monitor-url` override (trailing slash trimmed)
- maps a connected leaf to `established`, keyed by leaf-node name
- falls back to the bound account when leafz omits the name
- degrades to `{}` when the monitor is unreachable or returns non-200

`tsc --noEmit`: 0 errors. `eslint`: clean. 93 touched tests green.

## Migration provenance

Bug fix against migrated grove-v2 status code; not a phase move. Behavior-preserving outside the status read path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
