### PR TITLE
fix(cli): C-799/800/801 — join no-account $G leaf + restart plist-label + leave preserves base -c

### DIFF
--- a/src/cli/cortex/commands/__tests__/network-adapters.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-adapters.test.ts
@@ -25,8 +25,12 @@ import {
   buildLeafStatePort,
   buildLivePorts,
   DEFAULT_MONITOR_URL,
+  resolveDaemonLabel,
   type LivePortsConfig,
 } from "../network-adapters";
+import { leaveNetwork } from "../network-lib";
+import { brandVerified, type RenderLeafInputs } from "../network-ports";
+import type { NetworkDescriptor } from "../../../../common/registry/types";
 import {
   ensureConfigArg,
   renderProgramArguments,
@@ -1168,5 +1172,305 @@ describe("C-797 buildLeafStatePort (/leafz monitor)", () => {
     } finally {
       f.restore();
     }
+  });
+});
+
+// =============================================================================
+// #800 — the cortex DAEMON restart target is resolved from the configured
+// nats plist's <key>Label</key> (suffix-shared with the cortex daemon label),
+// NOT from the stack slug. The peer bug: slug `default`, but the real plists
+// are `…cortex.meta-factory` / `…nats.meta-factory` → a slug-derived
+// `…cortex.default` label always 113/503s.
+// =============================================================================
+
+/** A nats-server plist whose Label is `ai.meta-factory.nats.<suffix>`. */
+function natsPlistWithLabel(suffix: string): string {
+  return [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<plist version="1.0">',
+    "<dict>",
+    "\t<key>Label</key>",
+    `\t<string>ai.meta-factory.nats.${suffix}</string>`,
+    "\t<key>ProgramArguments</key>",
+    "\t<array><string>/opt/homebrew/bin/nats-server</string></array>",
+    "</dict>",
+    "</plist>",
+    "",
+  ].join("\n");
+}
+
+describe("#800 daemon restart label resolves from nats_infra.plist_path", () => {
+  test("slug ≠ plist suffix → daemon label uses the PLIST suffix, not the slug", () => {
+    const dir = freshDir();
+    const plistPath = join(dir, "nats.plist");
+    // The peer case: real nats plist suffix is `meta-factory`...
+    writeFileSync(plistPath, natsPlistWithLabel("meta-factory"), "utf-8");
+
+    const cfg: LivePortsConfig = {
+      networkId: "metafactory-community",
+      principalId: "jc",
+      // ...but the stack slug is `default` (the slug-guess bug source).
+      stackId: "jc/default",
+      natsConfigPath: "/Users/jc/.config/nats/local.conf",
+      plistPath,
+      platform: "darwin",
+    };
+
+    // The daemon label maps `…nats.meta-factory` → `…cortex.meta-factory`,
+    // NOT the slug-derived `…cortex.default`.
+    expect(resolveDaemonLabel(cfg)).toBe("ai.meta-factory.cortex.meta-factory");
+    expect(resolveDaemonLabel(cfg)).not.toBe("ai.meta-factory.cortex.default");
+  });
+
+  test("slug == plist suffix → unchanged (label matches the slug, as before)", () => {
+    const dir = freshDir();
+    const plistPath = join(dir, "nats.plist");
+    writeFileSync(plistPath, natsPlistWithLabel("community"), "utf-8");
+    const cfg: LivePortsConfig = {
+      networkId: "community",
+      principalId: "andreas",
+      stackId: "andreas/community",
+      natsConfigPath: "/x/local.conf",
+      plistPath,
+      platform: "darwin",
+    };
+    expect(resolveDaemonLabel(cfg)).toBe("ai.meta-factory.cortex.community");
+  });
+
+  test("a plist already carrying a `.cortex.` label is used verbatim", () => {
+    const dir = freshDir();
+    const plistPath = join(dir, "daemon.plist");
+    writeFileSync(
+      plistPath,
+      natsPlistWithLabel("x").replace("nats.x", "cortex.work"),
+      "utf-8",
+    );
+    const cfg: LivePortsConfig = {
+      networkId: "n",
+      principalId: "andreas",
+      stackId: "andreas/default",
+      natsConfigPath: "/x/local.conf",
+      plistPath,
+      platform: "darwin",
+    };
+    expect(resolveDaemonLabel(cfg)).toBe("ai.meta-factory.cortex.work");
+  });
+
+  test("no readable plist label → falls back to the slug-derived label", () => {
+    const cfg: LivePortsConfig = {
+      networkId: "n",
+      principalId: "jc",
+      stackId: "jc/default",
+      natsConfigPath: "/x/local.conf",
+      plistPath: "/nonexistent/nats.plist",
+      platform: "darwin",
+    };
+    // No plist to read → the slug fallback (best effort) rather than a guess at
+    // the suffix.
+    expect(resolveDaemonLabel(cfg)).toBe("ai.meta-factory.cortex.default");
+  });
+});
+
+// =============================================================================
+// #799 — the live leaf-file port renders a NO-ACCOUNT remote for a $G/default
+// bus (binding rides in the creds JWT) and an account-bound remote for an
+// operator-mode bus. Round-trips a real temp nats config + leaf dir.
+// =============================================================================
+
+function descriptorForLeaf(networkId: string): NetworkDescriptor {
+  return {
+    network_id: networkId,
+    hub_url: "tls://hub.meta-factory.ai:7422",
+    leaf_port: 7422,
+    members: [],
+  };
+}
+
+describe("#799 live leaf write renders no-account vs account-bound by bus type", () => {
+  test("$G/default bus + creds → leaf include file has NO account line", () => {
+    const dir = freshDir();
+    const conf = join(dir, "local.conf");
+    // A $G/default-account bus: no account tree (no operator-mode key,
+    // no `accounts{}`, no resolver_preload).
+    writeFileSync(conf, "jetstream { store_dir: /x/js }\nhttp: localhost:8222\n", "utf-8");
+
+    const cfg: LivePortsConfig = {
+      networkId: "metafactory-community",
+      principalId: "jc",
+      stackId: "jc/default",
+      natsConfigPath: conf,
+      plistPath: "/nonexistent/plist",
+    };
+    const ports = buildLivePorts(cfg);
+
+    // The orchestrator decides the bind mode is creds-only → it passes a binding
+    // with NO account. Here we drive the port directly with that binding.
+    const inputs: RenderLeafInputs = {
+      descriptor: brandVerified(descriptorForLeaf("metafactory-community")),
+      binding: { credentials: "/Users/jc/.config/nats/jc.creds" },
+    };
+    ports.leafFile.write(inputs);
+
+    const leaf = readFileSync(join(dir, "leafnodes-metafactory-community.conf"), "utf-8");
+    expect(leaf).toContain('credentials: "/Users/jc/.config/nats/jc.creds"');
+    expect(leaf).toContain('url: "tls://hub.meta-factory.ai:7422"');
+    // The critical assertion: NO account line (would crash a $G nats-server).
+    expect(leaf).not.toContain("account:");
+
+    // And resolveBindMode for this bus + creds returns creds-only.
+    const mode = ports.leafFile.resolveBindMode(undefined, true);
+    expect(mode.mode).toBe("creds-only");
+  });
+
+  test("operator-mode bus that defines the account → leaf has the account line", () => {
+    const dir = freshDir();
+    const conf = join(dir, "local.conf");
+    const account = "AADPQ7M7LQZTKPNF5CTE7V4XKB2FUYPGKLWZVMW6VXCEEKH62BYKGBHX";
+    writeFileSync(
+      conf,
+      `operator: /x/operator.creds\nresolver_preload: {\n  ${account}: eyJ...\n}\n`,
+      "utf-8",
+    );
+    const cfg: LivePortsConfig = {
+      networkId: "metafactory",
+      principalId: "andreas",
+      stackId: "andreas/meta-factory",
+      natsConfigPath: conf,
+      plistPath: "/nonexistent/plist",
+    };
+    const ports = buildLivePorts(cfg);
+
+    // resolveBindMode says operator-account for this bus + the defined account.
+    const mode = ports.leafFile.resolveBindMode(account, true);
+    expect(mode.mode).toBe("operator-account");
+
+    const inputs: RenderLeafInputs = {
+      descriptor: brandVerified(descriptorForLeaf("metafactory")),
+      binding: { credentials: "/Users/andreas/.config/nats/andreas.creds", account },
+    };
+    ports.leafFile.write(inputs);
+    const leaf = readFileSync(join(dir, "leafnodes-metafactory.conf"), "utf-8");
+    expect(leaf).toContain(`account: ${account}`);
+  });
+
+  test("no creds at all → resolveBindMode refuses (can't authenticate)", () => {
+    const dir = freshDir();
+    const conf = join(dir, "local.conf");
+    writeFileSync(conf, "jetstream { store_dir: /x/js }\n", "utf-8");
+    const ports = buildLivePorts({
+      networkId: "n",
+      principalId: "jc",
+      stackId: "jc/default",
+      natsConfigPath: conf,
+      plistPath: "/nonexistent/plist",
+    });
+    const mode = ports.leafFile.resolveBindMode(undefined, false);
+    expect(mode.mode).toBe("refuse");
+  });
+});
+
+// =============================================================================
+// #801 — `leave` (live) preserves the base `-c <config>` plist arg. Drives the
+// REAL leave orchestration over live FILE ports, but injects a NO-OP daemon
+// port so no `launchctl` is ever spawned (the S4 SAFETY rule — no live
+// mutation/exec in tests). After leaving the last network, the plist STILL
+// carries `-c <config>` so nats-server stays startable.
+// =============================================================================
+
+describe("#801 leave preserves the base -c arg (nats stays startable)", () => {
+  test("after leave with NO networks remaining, the plist still has -c <config>", async () => {
+    const dir = freshDir();
+    const conf = join(dir, "local.conf");
+    const plistPath = join(dir, "nats.plist");
+
+    // Base config that INCLUDES one leaf, and a plist already loading `-c conf`.
+    writeFileSync(
+      conf,
+      ['system_account: ADSYS', 'include "leafnodes-metafactory.conf"', ""].join("\n"),
+      "utf-8",
+    );
+    writeFileSync(join(dir, "leafnodes-metafactory.conf"), "leafnodes { remotes: [] }\n", "utf-8");
+    // Plist with -c <conf> already present + a real nats Label.
+    writeFileSync(
+      plistPath,
+      [
+        '<?xml version="1.0" encoding="UTF-8"?>',
+        '<plist version="1.0">',
+        "<dict>",
+        "\t<key>Label</key>",
+        "\t<string>ai.meta-factory.nats.meta-factory</string>",
+        "\t<key>ProgramArguments</key>",
+        "\t<array>",
+        "\t\t<string>/opt/homebrew/bin/nats-server</string>",
+        "\t\t<string>-c</string>",
+        `\t\t<string>${conf}</string>`,
+        "\t</array>",
+        "</dict>",
+        "</plist>",
+        "",
+      ].join("\n"),
+      "utf-8",
+    );
+
+    // A stack config carrying the one joined network, in the flat layout under a
+    // temp HOME (so the live ConfigStorePort reads/writes it).
+    const home = freshDir();
+    const stacksDir = join(home, ".config", "cortex", "stacks");
+    mkdirSync(stacksDir, { recursive: true });
+    writeFileSync(
+      join(stacksDir, "default.yaml"),
+      [
+        "policy:",
+        "  federated:",
+        "    networks:",
+        "      - id: metafactory",
+        "        leaf_node: metafactory",
+        "        peers: []",
+        "        accept_subjects: [federated.jc.default.>]",
+        "        deny_subjects: []",
+        "        announce_capabilities: []",
+        "        max_hop: 1",
+        "",
+      ].join("\n"),
+      "utf-8",
+    );
+
+    const cfg: LivePortsConfig = {
+      networkId: "metafactory",
+      principalId: "jc",
+      stackId: "jc/default",
+      natsConfigPath: conf,
+      plistPath,
+      platform: "darwin",
+    };
+
+    const prevHome = process.env.HOME;
+    process.env.HOME = home;
+    try {
+      const ports = buildLivePorts(cfg);
+      // Inject a no-op daemon port — the live file teardown is what we assert on;
+      // we must NOT spawn launchctl in a test (S4 SAFETY rule).
+      const noSpawnPorts = {
+        ...ports,
+        daemon: { async restart() { return { ok: true } as const; } },
+      };
+      await leaveNetwork("metafactory", noSpawnPorts);
+    } finally {
+      if (prevHome === undefined) delete process.env.HOME;
+      else process.env.HOME = prevHome;
+    }
+
+    // The base config is intact and STILL referenced by the plist `-c` arg
+    // (the #801 fix: leave NEVER strips it).
+    const plistAfter = readFileSync(plistPath, "utf-8");
+    expect(plistAfter).toContain("<string>-c</string>");
+    expect(plistAfter).toContain(`<string>${conf}</string>`);
+
+    // The network-specific teardown DID happen: the include directive is gone +
+    // the leaf file deleted + the policy entry removed.
+    const confAfter = readFileSync(conf, "utf-8");
+    expect(confAfter).not.toContain('include "leafnodes-metafactory.conf"');
+    expect(confAfter).toContain("system_account: ADSYS"); // base config intact
+    expect(existsSync(join(dir, "leafnodes-metafactory.conf"))).toBe(false);
   });
 });

--- a/src/cli/cortex/commands/__tests__/network-derive.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-derive.test.ts
@@ -320,7 +320,32 @@ describe("deriveJoinInputs — actionable missing-config errors", () => {
     expect(res.reason).toContain("stack.nats_infra.config_path");
   });
 
-  test("no account → names stack.nats_infra.account", () => {
+  test("#799 no account → derives OK with account undefined ($G/default bus)", () => {
+    // Pre-#799 a missing account FAILED ("names stack.nats_infra.account"). After
+    // #799 the account is OPTIONAL: a $G/default-account bus has none, and the
+    // join renders a no-account leaf (binding via the creds JWT). The genuine
+    // refusal (no creds / operator-mode missing account) is decided downstream
+    // by resolveLeafBindMode, not here.
+    const cfg = loaded({
+      principal: { id: "jc" },
+      stack: {
+        id: "jc/default",
+        nkey_seed_path: "~/s",
+        nats_infra: { config_path: "~/c", plist_path: "~/p" },
+      },
+      policy: {
+        principals: [], roles: [],
+        federated: { networks: [], registry: { url: "https://r" } },
+      },
+    });
+    const res = deriveJoinInputs("metafactory", {}, "/cfg", reader(cfg), "darwin");
+    expect(res.ok).toBe(true);
+    expect(res.inputs?.account).toBeUndefined();
+    // creds still resolve via convention.
+    expect(res.inputs?.credsPath).toBeDefined();
+  });
+
+  test("#799 --account override is still honoured (operator-mode opt-in)", () => {
     const cfg = loaded({
       principal: { id: "andreas" },
       stack: {
@@ -333,13 +358,10 @@ describe("deriveJoinInputs — actionable missing-config errors", () => {
         federated: { networks: [], registry: { url: "https://r" } },
       },
     });
-    // Pin darwin so the deriver reaches the account check (the `plist_path`
-    // fixture satisfies the macOS descriptor); without the pin, the Linux CI
-    // host hits the systemd `unit_path` error FIRST and names the wrong field
-    // (cortex#771 — pre-existing #762/#763 breakage surfaced here).
-    const res = deriveJoinInputs("metafactory", {}, "/cfg", reader(cfg), "darwin");
-    expect(res.ok).toBe(false);
-    expect(res.reason).toContain("stack.nats_infra.account");
+    const acct = "A" + "B".repeat(55);
+    const res = deriveJoinInputs("metafactory", { account: acct }, "/cfg", reader(cfg), "darwin");
+    expect(res.ok).toBe(true);
+    expect(res.inputs?.account).toBe(acct);
   });
 });
 

--- a/src/cli/cortex/commands/__tests__/network-lib.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-lib.test.ts
@@ -113,6 +113,8 @@ interface Recorder {
   warnings: string[];
   /** #794 — accounts the orchestrator pre-flighted via canBindAccount(). */
   bindChecks: string[];
+  /** #799 — bind-mode resolutions: the (account, hasCreds) pairs queried. */
+  bindModeChecks: { account: string | undefined; hasCreds: boolean }[];
 }
 
 function makeFakes(opts: {
@@ -128,6 +130,13 @@ function makeFakes(opts: {
   leafState?: LeafStatePort;
   /** #794 — make the stack's nats config UNABLE to bind the leaf account. */
   canBind?: boolean;
+  /**
+   * #799 — model the bus type the leaf-file port resolves a bind mode against:
+   *   - "operator-mode" (default) → operator-mode bus that binds the account.
+   *   - "default-g"               → $G/default-account bus (no account tree).
+   * The fake's `resolveBindMode` mirrors the real `resolveLeafBindMode` decision.
+   */
+  busType?: "operator-mode" | "default-g";
 }): { ports: NetworkPorts; rec: Recorder; storeRef: { networks: PolicyFederatedNetwork[] } } {
   const rec: Recorder = {
     registered: 0,
@@ -143,6 +152,7 @@ function makeFakes(opts: {
     configWrites: [],
     warnings: [],
     bindChecks: [],
+    bindModeChecks: [],
   };
   const storeRef = { networks: opts.initialNetworks ?? [] };
   const leafFilesPresent = new Set<string>(
@@ -201,6 +211,34 @@ function makeFakes(opts: {
               "config is anonymous/hard-isolated (no operator-mode account tree)",
           }
         : { canBind: true };
+    },
+    resolveBindMode(account, hasCreds) {
+      rec.bindModeChecks.push({ account, hasCreds });
+      // #799 — mirror the real resolveLeafBindMode decision over the modelled
+      // bus type. No creds → refuse (can't authenticate to the hub).
+      if (!hasCreds) {
+        return { mode: "refuse", reason: "no leaf creds available" };
+      }
+      const busType = opts.busType ?? "operator-mode";
+      if (busType === "default-g") {
+        // $G/default-account bus + creds → no-account remote (creds JWT binds).
+        return { mode: "creds-only" };
+      }
+      // operator-mode bus. `canBind: false` models an operator-mode bus that
+      // does NOT define the offered account → refuse (would crash nats-server).
+      if (opts.canBind === false) {
+        return {
+          mode: "refuse",
+          reason: "operator-mode bus does not define the leaf account",
+        };
+      }
+      const trimmed = account?.trim();
+      if (trimmed !== undefined && trimmed.length > 0) {
+        return { mode: "operator-account", account: trimmed };
+      }
+      // operator-mode bus but no account offered → creds-only (the binding must
+      // ride in the creds JWT; nothing to account-bind).
+      return { mode: "creds-only" };
     },
   };
 
@@ -294,33 +332,40 @@ describe("join", () => {
     expect(net.id).toBe("metafactory");
     // (e) restarted.
     expect(rec.restarts).toBe(1);
-    // (b.5) #794 — the account was pre-flighted before any mutation.
-    expect(rec.bindChecks).toEqual([LOCAL.account]);
+    // (b.5) #799 — the bind mode was resolved before any mutation (account +
+    // creds present → operator-account).
+    expect(rec.bindModeChecks).toEqual([
+      { account: LOCAL.account, hasCreds: true },
+    ]);
+    // The operator-mode account WAS written into the leaf remote.
+    expect(rec.writes[0]!.binding.account).toBe(LOCAL.account);
   });
 
   // ---------------------------------------------------------------------------
-  // #794 — FAIL FAST on a bus that can't bind the leaf account (no crash).
+  // #794/#799 — choose the bind mode by bus type; FAIL FAST only on a genuinely
+  // un-joinable bus (no crash). #799 relaxes the #794 guard for $G+creds buses.
   // ---------------------------------------------------------------------------
-  describe("#794 fail-fast (anonymous / hard-isolated bus)", () => {
-    test("REFUSES when the nats config can't bind the leaf account", async () => {
-      const { ports } = makeFakes({ canBind: false });
+  describe("#794/#799 bind-mode fail-fast", () => {
+    test("REFUSES when an operator-mode bus does NOT define the leaf account", async () => {
+      // canBind:false models an operator-mode bus missing THIS account → still
+      // refuse (rendering an account-bound leaf there crashes nats-server).
+      const { ports } = makeFakes({ canBind: false, busType: "operator-mode" });
       const res = await joinNetwork("metafactory", LOCAL, ports);
 
       expect(res.ok).toBe(false);
-      // Actionable error: names the config path, the missing account, the fix.
+      // Actionable error: names the config path + the fix + the issue refs.
       expect(res.reason).toContain("/Users/andreas/.config/nats/local.conf");
-      expect(res.reason).toContain(LOCAL.account);
       expect(res.reason).toContain("operator-mode");
-      expect(res.reason).toContain("cortex#794");
+      expect(res.reason).toContain("cortex#794/#799");
     });
 
     test("touches NOTHING when it refuses (no leaf, no include, no restart)", async () => {
-      const { ports, rec, storeRef } = makeFakes({ canBind: false });
+      const { ports, rec, storeRef } = makeFakes({ canBind: false, busType: "operator-mode" });
       const res = await joinNetwork("metafactory", LOCAL, ports);
 
       expect(res.ok).toBe(false);
-      // The pre-flight ran...
-      expect(rec.bindChecks).toEqual([LOCAL.account]);
+      // The bind-mode pre-flight ran...
+      expect(rec.bindModeChecks).toEqual([{ account: LOCAL.account, hasCreds: true }]);
       // ...but NO mutation followed it.
       expect(rec.writes.length).toBe(0); // no leaf include written
       expect(rec.includesEnsured).toEqual([]); // no local.conf include
@@ -331,26 +376,84 @@ describe("join", () => {
       expect(storeRef.networks.length).toBe(0); // config untouched
     });
 
-    test("dry-run surfaces the SAME refusal (canBindAccount is a READ)", async () => {
-      // The orchestrator is identical under dry-run/live; the fake models the
-      // dry-run adapter (reads hit disk, writes no-op) — and the guard fires on
-      // the READ, so a dry-run join refuses just like --apply would.
-      const { ports, rec } = makeFakes({ canBind: false });
+    test("dry-run surfaces the SAME refusal (resolveBindMode is a READ)", async () => {
+      const { ports, rec } = makeFakes({ canBind: false, busType: "operator-mode" });
       const res = await joinNetwork("metafactory", LOCAL, ports);
       expect(res.ok).toBe(false);
-      expect(res.reason).toContain("cortex#794");
+      expect(res.reason).toContain("cortex#794/#799");
       expect(rec.writes.length).toBe(0);
     });
 
-    test("proceeds normally when the config CAN bind the account", async () => {
-      const { ports, rec, storeRef } = makeFakes({ canBind: true });
+    test("proceeds account-bound when the operator-mode bus CAN bind the account", async () => {
+      const { ports, rec, storeRef } = makeFakes({ canBind: true, busType: "operator-mode" });
       const res = await joinNetwork("metafactory", LOCAL, ports);
       expect(res.ok).toBe(true);
-      expect(rec.bindChecks).toEqual([LOCAL.account]);
-      // Existing join flow unchanged: leaf written, restarted, config written.
+      expect(rec.bindModeChecks).toEqual([{ account: LOCAL.account, hasCreds: true }]);
+      // Existing join flow unchanged: account-bound leaf written, restarted.
       expect(rec.writes.length).toBe(1);
+      expect(rec.writes[0]!.binding.account).toBe(LOCAL.account);
       expect(rec.restarts).toBe(1);
       expect(storeRef.networks.length).toBe(1);
+    });
+
+    // -------------------------------------------------------------------------
+    // #799 — the critical new behaviour: a $G/default-account bus + creds is
+    // now JOINABLE via a NO-ACCOUNT leaf remote (the case #794 wrongly refused).
+    // -------------------------------------------------------------------------
+    test("#799 $G/default bus + creds → joins with a NO-ACCOUNT leaf remote", async () => {
+      // The driving case: jc/default ($G bus + jc.creds) → metafactory-community.
+      const G_PEER: JoiningStack = {
+        principalId: "jc",
+        stackSlug: "default",
+        credentials: "/Users/jc/.config/nats/jc.creds",
+        // No account — a $G bus has no operator-mode account to bind.
+      };
+      const { ports, rec, storeRef } = makeFakes({ busType: "default-g" });
+      const res = await joinNetwork("metafactory-community", G_PEER, ports);
+
+      expect(res.ok).toBe(true);
+      // The leaf remote was rendered WITHOUT an account (creds JWT binds it).
+      expect(rec.writes.length).toBe(1);
+      expect(rec.writes[0]!.binding.account).toBeUndefined();
+      expect(rec.writes[0]!.binding.credentials).toBe(
+        "/Users/jc/.config/nats/jc.creds",
+      );
+      // The join completed end-to-end (config written, restarted) — the bus is
+      // NOT taken down.
+      expect(storeRef.networks.length).toBe(1);
+      expect(rec.restarts).toBe(1);
+      // The bind-mode pre-flight saw creds present (account omitted is fine).
+      expect(rec.bindModeChecks).toEqual([{ account: undefined, hasCreds: true }]);
+    });
+
+    test("#799 a $G+creds bus is NOT refused by the #794 fail-fast", async () => {
+      // Explicit regression for the #794-over-refusal: a $G bus with creds must
+      // NOT be refused even though it cannot bind an account.
+      const G_PEER: JoiningStack = {
+        principalId: "jc",
+        stackSlug: "default",
+        credentials: "/Users/jc/.config/nats/jc.creds",
+      };
+      const { ports } = makeFakes({ busType: "default-g" });
+      const res = await joinNetwork("metafactory-community", G_PEER, ports);
+      expect(res.ok).toBe(true);
+      if (!res.ok) expect(res.reason).toBeUndefined();
+    });
+
+    test("#799 REFUSES when there are NO creds (can't authenticate to the hub)", async () => {
+      const NO_CREDS: JoiningStack = {
+        principalId: "jc",
+        stackSlug: "default",
+        credentials: "", // no creds
+      };
+      const { ports, rec, storeRef } = makeFakes({ busType: "default-g" });
+      const res = await joinNetwork("metafactory-community", NO_CREDS, ports);
+      expect(res.ok).toBe(false);
+      expect(res.reason).toContain("cortex#794/#799");
+      // No mutation followed the refusal.
+      expect(rec.writes.length).toBe(0);
+      expect(storeRef.networks.length).toBe(0);
+      expect(rec.bindModeChecks).toEqual([{ account: undefined, hasCreds: false }]);
     });
   });
 
@@ -713,7 +816,7 @@ describe("leave", () => {
     };
   }
 
-  test("reverses exactly: removes config + leaf, drops plist arg, restarts", async () => {
+  test("reverses exactly: removes config + leaf, PRESERVES base -c arg, restarts (#801)", async () => {
     const { ports, rec, storeRef } = makeFakes({
       initialNetworks: [joinedNetwork("metafactory")],
     });
@@ -726,13 +829,20 @@ describe("leave", () => {
     expect(rec.includesRemoved).toEqual(["metafactory"]);
     // Leaf include deleted.
     expect(rec.removes).toEqual(["metafactory"]);
-    // No networks remain → plist -c dropped.
-    expect(rec.dropped).toEqual(["/Users/andreas/.config/nats/local.conf"]);
+    // #801 — even with NO networks remaining, the base nats-server `-c <config>`
+    // arg is NEVER stripped (it names the BASE config the leaf files include
+    // INTO; stripping it leaves nats-server unstartable). dropConfigArg is never
+    // called by leave.
+    expect(rec.dropped).toEqual([]);
+    // The step log records the intentional preservation.
+    expect(
+      res.steps.some((s) => s.includes("left intact") && s.includes("#801")),
+    ).toBe(true);
     // Restarted.
     expect(rec.restarts).toBe(1);
   });
 
-  test("keeps the plist arg when other networks remain", async () => {
+  test("#801 leave with networks remaining also never drops the base -c arg", async () => {
     const { ports, rec, storeRef } = makeFakes({
       initialNetworks: [joinedNetwork("metafactory"), joinedNetwork("research")],
     });
@@ -740,7 +850,7 @@ describe("leave", () => {
     expect(res.ok).toBe(true);
     expect(storeRef.networks.map((n) => n.id)).toEqual(["research"]);
     expect(rec.removes).toEqual(["metafactory"]);
-    // research still has a leaf → plist arg NOT dropped.
+    // base -c arg never dropped (true regardless of remaining networks).
     expect(rec.dropped.length).toBe(0);
   });
 

--- a/src/cli/cortex/commands/network-adapters.ts
+++ b/src/cli/cortex/commands/network-adapters.ts
@@ -39,10 +39,12 @@ import {
   natsConfigCanBindAccount,
   removeLeafInclude,
   renderLeafIncludeFile,
+  resolveLeafBindMode,
 } from "../../../common/nats/leaf-remote-renderer";
 import {
   bunExecRunner,
   currentServicePlatform,
+  readPlistLabel,
   selectNatsServiceManager,
   type NatsServiceManager,
   type ServicePlatform,
@@ -391,6 +393,17 @@ function buildLeafFilePort(cfg: LivePortsConfig, mutate: boolean): LeafFilePort 
         : "";
       return natsConfigCanBindAccount(text, account);
     },
+    resolveBindMode(account, hasCreds) {
+      // #799 — pure READ (identical in live + dry-run): choose the leaf-remote
+      // bind mode by bus type. operator-mode + account → account-bound; $G
+      // /default + creds → no-account (creds JWT binds); neither possible →
+      // refuse. An absent/empty config file reads as a $G/default bus.
+      const configPath = expandTilde(cfg.natsConfigPath ?? "");
+      const text = existsSync(configPath)
+        ? readFileSync(configPath, "utf-8")
+        : "";
+      return resolveLeafBindMode(text, account, hasCreds);
+    },
   };
 }
 
@@ -521,11 +534,44 @@ function buildConfigStorePort(cfg: LivePortsConfig, mutate: boolean): ConfigStor
 // Daemon port — launchctl kickstart of the stack daemon.
 // =============================================================================
 
+/**
+ * #800 — resolve the cortex DAEMON launchctl label.
+ *
+ * The bug: the label was derived as `ai.meta-factory.cortex.<stack-slug>`. When
+ * the slug ≠ the plist suffix (the peer case — slug `default`, but the real
+ * plists are `…cortex.meta-factory` / `…nats.meta-factory`) the kickstart always
+ * 113/503s against a service that does not exist.
+ *
+ * The cortex daemon plist and the nats-server plist share a SUFFIX
+ * (`ai.meta-factory.cortex.<suffix>` ↔ `ai.meta-factory.nats.<suffix>`). The
+ * configured `stack.nats_infra.plist_path` is the authority for that suffix, so
+ * we read the nats plist's `<key>Label</key>` and swap its service segment
+ * (`…nats.<suffix>` → `…cortex.<suffix>`) to name the cortex daemon. The slug is
+ * only a last-resort fallback when no plist label can be read (e.g. a Linux
+ * stack with a unit, or a missing plist).
+ */
+export function resolveDaemonLabel(cfg: LivePortsConfig): string {
+  const slugFallback = `ai.meta-factory.cortex.${cfg.stackId.split("/")[1] ?? "default"}`;
+  const plistPath = cfg.plistPath !== undefined ? expandTilde(cfg.plistPath) : undefined;
+  if (plistPath === undefined) return slugFallback;
+  const natsLabel = readPlistLabel(plistPath);
+  if (natsLabel === undefined) return slugFallback;
+  // Map the nats-server service segment to the cortex daemon segment, preserving
+  // the shared suffix: `<prefix>.nats.<suffix>` → `<prefix>.cortex.<suffix>`.
+  // If the label is already a `.cortex.` label (a stack that points plist_path
+  // at the cortex daemon plist directly), use it verbatim.
+  if (natsLabel.includes(".cortex.")) return natsLabel;
+  if (natsLabel.includes(".nats.")) return natsLabel.replace(/\.nats\./, ".cortex.");
+  // An unrecognised label shape — fall back to the slug-derived label rather
+  // than kickstart an unexpected service.
+  return slugFallback;
+}
+
 function buildDaemonPort(cfg: LivePortsConfig, mutate: boolean): DaemonPort {
   return {
     async restart() {
       if (!mutate) return { ok: true }; // dry-run: pretend success.
-      const label = `ai.meta-factory.cortex.${cfg.stackId.split("/")[1] ?? "default"}`;
+      const label = resolveDaemonLabel(cfg);
       const proc = Bun.spawn(["launchctl", "kickstart", "-k", `gui/${process.getuid?.() ?? 501}/${label}`], {
         stdout: "pipe",
         stderr: "pipe",
@@ -533,7 +579,7 @@ function buildDaemonPort(cfg: LivePortsConfig, mutate: boolean): DaemonPort {
       const code = await proc.exited;
       if (code !== 0) {
         const err = await new Response(proc.stderr).text();
-        return { ok: false, reason: `launchctl kickstart exited ${code.toString()}: ${err.trim()}` };
+        return { ok: false, reason: `launchctl kickstart ${label} exited ${code.toString()}: ${err.trim()}` };
       }
       return { ok: true };
     },

--- a/src/cli/cortex/commands/network-derive.ts
+++ b/src/cli/cortex/commands/network-derive.ts
@@ -65,7 +65,14 @@ export interface DerivedJoinInputs {
   unitPath?: string;
   /** #763 — the platform the descriptor was resolved for (launchd vs systemd). */
   platform: ServicePlatform;
-  account: string;
+  /**
+   * The leaf account (nkey-U) the leaf binds to — OPTIONAL (#799). Present for
+   * an operator-mode bus (`--account` / `stack.nats_infra.account`); ABSENT for
+   * a `$G`/default-account bus, where the account binding rides in the creds
+   * JWT and rendering an `account:` line would crash nats-server. No longer a
+   * hard requirement: a `$G` peer (e.g. jc/default) joins with creds only.
+   */
+  account?: string;
   credsPath: string;
   /**
    * #762 — the capability ids this stack announces INTO the network, read from
@@ -324,12 +331,15 @@ export function deriveJoinInputs(
   );
   if (!descriptor.ok) return fail(descriptor.reason);
 
-  const account = overrides.account ?? natsInfra?.account;
-  if (account === undefined || account === "") {
-    return fail(
-      "cannot resolve leaf account — pass --account or set `stack.nats_infra.account` in cortex.yaml",
-    );
-  }
+  // #799 — the leaf account is OPTIONAL. An operator-mode bus supplies it (via
+  // `--account` / `stack.nats_infra.account`) → the leaf renders an `account:`
+  // line. A `$G`/default-account bus has none → the join renders a no-account
+  // leaf (binding rides in the creds JWT). So an absent account is NOT an
+  // error here; the bind-mode decision (resolveLeafBindMode) refuses only the
+  // genuinely-unjoinable case (no creds, or operator-mode missing the account).
+  const accountRaw = overrides.account ?? natsInfra?.account;
+  const account =
+    accountRaw === undefined || accountRaw === "" ? undefined : accountRaw;
 
   // creds — flag wins, else stack.nats_infra.creds_path, else convention.
   const credsPath =
@@ -356,7 +366,7 @@ export function deriveJoinInputs(
       ...(descriptor.plistPath !== undefined && { plistPath: descriptor.plistPath }),
       ...(descriptor.unitPath !== undefined && { unitPath: descriptor.unitPath }),
       platform: descriptor.platform,
-      account,
+      ...(account !== undefined && { account }),
       credsPath,
       announceCapabilities,
     },

--- a/src/cli/cortex/commands/network-lib.ts
+++ b/src/cli/cortex/commands/network-lib.ts
@@ -57,8 +57,12 @@ export interface JoiningStack {
   stackSlug: string;
   /** Path to the leaf `.creds` file (absolute). */
   credentials: string;
-  /** Local nkey-U account the leaf binds to (DD-8 already in nkey-U). */
-  account: string;
+  /**
+   * Local nkey-U account the leaf binds to (DD-8 already in nkey-U) — OPTIONAL
+   * (#799). Present for an operator-mode bus; OMITTED for a `$G`/default bus
+   * (the binding rides in the creds JWT, so no `account:` is rendered).
+   */
+  account?: string;
   /**
    * The `leaf_node` connection name to write on the network entry. Defaults to
    * the network id when unset (one leaf per network, OQ3-clean).
@@ -189,32 +193,40 @@ export async function joinNetwork(
   // would be a tsc error at the next line.
   const verified = brandVerified(descriptor);
 
-  // (b.5) #794 — FAIL FAST: never render a leaf that would CRASH the stack's
-  // bus. The leaf remote binds `stack.account` (nkey-U); nats-server resolves
-  // that account against the LOCAL nats config's account tree on startup. If
-  // the config is anonymous + hard-isolated (no operator-mode account tree —
-  // the halden/community pattern) or is operator-mode but doesn't define THIS
-  // account, nats-server crashes (`cannot find local account "<A…>" specified
-  // in leafnode remote`) and the whole bus goes DOWN. So pre-validate the
-  // resolved config BEFORE any mutation (no leaf write, no include, no
-  // restart) — a READ, so dry-run surfaces the same refusal. Recoverable: the
-  // operator converts the bus to operator-mode (define the account) or passes a
-  // config that does. Refusing here is strictly safer than a crashed server.
-  const bind = ports.leafFile.canBindAccount(stack.account);
-  if (!bind.canBind) {
+  // (b.5) #799 (peer-side counterpart to #794) — choose the leaf-remote BIND
+  // MODE by bus type, and FAIL FAST only on a genuinely un-joinable bus.
+  //
+  // The leaf remote authenticates with `stack.credentials` and (in operator-mode)
+  // binds `stack.account`. nats-server resolves an `account:` line against the
+  // LOCAL config's account tree on startup:
+  //   - operator-mode bus that defines the account → render account-bound (#794).
+  //   - `$G`/default bus (no account tree) + creds → render NO-account; the
+  //     creds JWT binds it (the case #794 wrongly refused → bus stayed down).
+  //   - no creds, or operator-mode bus missing the account → REFUSE (rendering
+  //     an account-bound leaf there crashes nats-server, taking the bus DOWN).
+  // This is a READ (no mutation), so dry-run surfaces the same decision.
+  const hasCreds =
+    typeof stack.credentials === "string" && stack.credentials.trim().length > 0;
+  const bindMode = ports.leafFile.resolveBindMode(stack.account, hasCreds);
+  if (bindMode.mode === "refuse") {
     const configPath = ports.leafFile.natsConfigPath();
     return {
       ok: false,
       steps,
       reason:
-        `nats config ${configPath} cannot bind account ${stack.account} ` +
-        `(${bind.reason ?? "unknown"}) — this bus is anonymous/isolated and ` +
-        `cannot federate. Convert it to operator-mode (define the account; see ` +
-        `docs/sop-stack-onboarding.md §Part 2) or pass a config that defines the ` +
-        `account (--nats-config). Refusing to render a leaf that would crash ` +
-        `nats-server (cortex#794).`,
+        `nats config ${configPath} cannot federate (${bindMode.reason}). ` +
+        `An operator-mode bus must DEFINE the leaf account (convert it — see ` +
+        `docs/sop-stack-onboarding.md §Part 2 — or pass a config that does via ` +
+        `--nats-config); a $G/default bus needs valid leaf creds. Refusing to ` +
+        `render a leaf that would crash nats-server (cortex#794/#799).`,
     };
   }
+
+  // The account written into the leaf remote: the nkey-U for an operator-mode
+  // bus, or OMITTED (undefined) for a $G/default bus (#799 — the binding rides
+  // in the creds JWT; an `account:` line there crashes nats-server).
+  const leafAccount =
+    bindMode.mode === "operator-account" ? bindMode.account : undefined;
 
   // (c) Render + write the leaf include (S3) and ensure the plist loads the
   // nats config (DD-6, closes the configured-but-dormant trap). The renderer
@@ -222,7 +234,10 @@ export async function joinNetwork(
   try {
     ports.leafFile.write({
       descriptor: verified,
-      binding: { credentials: stack.credentials, account: stack.account },
+      binding: {
+        credentials: stack.credentials,
+        ...(leafAccount !== undefined && { account: leafAccount }),
+      },
     });
   } catch (err) {
     return {
@@ -423,9 +438,13 @@ export function mergeNetwork(
 /**
  * Leave `networkId` — the exact reverse of join, idempotently:
  *   - remove the network from policy.federated.networks[],
+ *   - remove the `include` directive from the base nats config,
  *   - delete the leaf include file,
- *   - if NO leaf includes remain, drop the plist `-c` arg,
  *   - restart the daemon.
+ *
+ * #801 — leave NEVER strips the base `-c <config>` plist arg. That config is
+ * the BASE nats-server config the leaf files are `include`d into, not a
+ * per-network artifact; removing it would leave nats-server unstartable.
  *
  * A leave of a network that was never joined is a clean no-op (ok, notJoined).
  */
@@ -467,12 +486,19 @@ export async function leaveNetwork(
     ports.leafFile.remove(networkId);
     steps.push(`deleted leaf include for "${networkId}"`);
 
-    // If no networks have a leaf include anymore, drop the plist -c arg so the
-    // server reverts to its bare invocation (clean teardown).
-    const stillHaveLeaves = ports.leafFile.list().length > 0;
-    if (!stillHaveLeaves) {
-      ports.plist.dropConfigArg(ports.leafFile.natsConfigPath());
-      steps.push("no networks remain — dropped nats-server plist -c arg");
+    // #801 — DO NOT touch the plist `-c <config>` arg. That config (e.g.
+    // local.conf) is the BASE nats-server config; the per-network leaf remotes
+    // are `include`d INTO it, they are not the base config itself. Stripping
+    // `-c <config>` on leave (even when no networks remain) leaves nats-server
+    // with no config to load → unstartable (the #801 bug: jc/default leave
+    // stripped `-c local.conf` and the bus would not come back up). Leave's
+    // teardown is exactly: remove the policy.federated.networks[] entry, remove
+    // the `include` directive, delete the leaf file. The base `-c` arg is
+    // owned by stack provisioning, never by join/leave.
+    if (ports.leafFile.list().length === 0) {
+      steps.push(
+        "no networks remain — base nats-server `-c <config>` arg left intact (#801)",
+      );
     }
   } catch (err) {
     return {

--- a/src/cli/cortex/commands/network-ports.ts
+++ b/src/cli/cortex/commands/network-ports.ts
@@ -33,6 +33,7 @@ import type {
 import type { NetworkFetchResult } from "../../../common/registry/network-client";
 import type {
   AccountBindCheck,
+  LeafBindMode,
   StackLeafBinding,
 } from "../../../common/nats/leaf-remote-renderer";
 import type { PolicyFederatedNetwork } from "../../../common/types/cortex-config";
@@ -161,18 +162,44 @@ export interface LeafFilePort {
    * to {@link natsConfigCanBindAccount}; an absent config file → cannot bind.
    */
   canBindAccount(account: string): AccountBindCheck;
+  /**
+   * #799 — choose the leaf-remote BIND MODE for the stack's nats config:
+   *   - `operator-account` — operator-mode bus that defines the account →
+   *     render an `account:`-bound remote (the #794-safe path).
+   *   - `creds-only` — `$G`/default bus WITH creds → render a NO-account remote;
+   *     the creds JWT binds it (the case #794 wrongly refused).
+   *   - `refuse` — no creds (can't authenticate to the hub), or an operator-mode
+   *     bus that doesn't define the account (would crash nats-server).
+   *
+   * Delegates to {@link resolveLeafBindMode}. The orchestrator calls this BEFORE
+   * any mutation (a READ — identical in live + dry-run) and either renders the
+   * chosen remote or refuses. `hasCreds` is judged from the stack's resolved
+   * creds path; `account` is the candidate nkey-U (or `undefined`).
+   */
+  resolveBindMode(account: string | undefined, hasCreds: boolean): LeafBindMode;
 }
 
 /**
  * The launchd plist seam (S3 `ensureConfigArg`/`renderProgramArguments`).
- * `ensureConfigLoaded` rewrites the nats-server plist so it loads
- * `configPath` (closing the configured-but-dormant trap, DD-6);
- * `dropConfigArg` reverts to a bare invocation when no networks remain.
+ * `ensureConfigLoaded` rewrites the nats-server plist so it loads `configPath`
+ * (closing the configured-but-dormant trap, DD-6).
+ *
+ * #801 — `leave` NO LONGER calls `dropConfigArg`. The `-c <config>` arg names
+ * the BASE nats-server config (`local.conf`); the per-network leaf remotes are
+ * `include`d INTO it. Stripping the base `-c` on leave left nats-server with no
+ * config to load → unstartable. The base `-c` is owned by stack provisioning,
+ * never by join/leave. `dropConfigArg` stays on the port for provisioning-side
+ * teardown (the inverse of `ensureConfigLoaded`), but the leave flow does not
+ * use it.
  */
 export interface PlistPort {
   /** Ensure the nats-server plist loads `configPath` via `-c`. Idempotent. */
   ensureConfigLoaded(configPath: string): void;
-  /** Remove the `-c <configPath>` arg from the plist (leave teardown). */
+  /**
+   * Remove the `-c <configPath>` arg from the plist. NOT used by `leave` (#801)
+   * — retained for provisioning-side teardown (the inverse of
+   * {@link PlistPort.ensureConfigLoaded}).
+   */
   dropConfigArg(configPath: string): void;
 }
 

--- a/src/common/nats/__tests__/leaf-remote-renderer.test.ts
+++ b/src/common/nats/__tests__/leaf-remote-renderer.test.ts
@@ -20,10 +20,12 @@ import { describe, expect, test } from "bun:test";
 
 import type { NetworkDescriptor } from "../../registry/types";
 import {
+  natsConfigHasAccountTree,
   leafIncludeFileName,
   mergeLeafRemotes,
   renderLeafIncludeFile,
   renderLeafRemote,
+  resolveLeafBindMode,
   type LeafRemote,
   type StackLeafBinding,
 } from "../leaf-remote-renderer";
@@ -91,9 +93,21 @@ describe("renderLeafRemote", () => {
     expect(() => renderLeafRemote(DESCRIPTOR, bad)).toThrow();
   });
 
-  test("throws on a missing account (operator-mode requires the bound account)", () => {
-    const bad: StackLeafBinding = { ...BINDING, account: "" };
-    expect(() => renderLeafRemote(DESCRIPTOR, bad)).toThrow();
+  // #799 — a missing account is NO LONGER an error: it is the $G/default-bus
+  // mode where the binding rides in the creds JWT. The remote renders WITHOUT
+  // an account.
+  test("#799 omits account when none is supplied ($G/default bus)", () => {
+    const noAccount: StackLeafBinding = { credentials: BINDING.credentials };
+    const remote = renderLeafRemote(DESCRIPTOR, noAccount);
+    expect(remote.account).toBeUndefined();
+    expect(remote.url).toBe("tls://nats.meta-factory.dev:7422");
+    expect(remote.credentials).toBe(BINDING.credentials);
+  });
+
+  test("#799 treats an empty-string account the same as absent (no account)", () => {
+    const empty: StackLeafBinding = { ...BINDING, account: "" };
+    const remote = renderLeafRemote(DESCRIPTOR, empty);
+    expect(remote.account).toBeUndefined();
   });
 
   test("rejects an account that is not a valid nkey-U (HOCON-injection guard)", () => {
@@ -227,5 +241,115 @@ describe("renderLeafIncludeFile — HOCON fragment for a single network", () => 
     expect(renderLeafIncludeFile(DESCRIPTOR, BINDING)).toBe(
       renderLeafIncludeFile(DESCRIPTOR, BINDING),
     );
+  });
+
+  // #799 — a $G/default bus renders a NO-ACCOUNT remote: no `account:` line at
+  // all (the creds JWT binds it). An emitted `account:` would crash nats-server.
+  test("#799 emits NO `account:` line for a $G/default bus (account omitted)", () => {
+    const noAccount: StackLeafBinding = { credentials: BINDING.credentials };
+    const conf = renderLeafIncludeFile(DESCRIPTOR, noAccount);
+    // url + credentials still present...
+    expect(conf).toContain('url: "tls://nats.meta-factory.dev:7422"');
+    expect(conf).toContain(
+      'credentials: "/Users/andreas/.config/nats/andreas.creds"',
+    );
+    // ...but NO account line anywhere (the regression that crashed the bus).
+    expect(conf).not.toContain("account:");
+    expect(conf).not.toMatch(/account\s*:/);
+  });
+
+  test("#799 operator-mode bus still emits the account line (unchanged)", () => {
+    const conf = renderLeafIncludeFile(DESCRIPTOR, BINDING);
+    expect(conf).toContain(
+      "account: AADPQ7M7LQZTKPNF5CTE7V4XKB2FUYPGKLWZVMW6VXCEEKH62BYKGBHX",
+    );
+  });
+});
+
+// =============================================================================
+// #799 — bus-type detection + bind-mode resolution.
+// =============================================================================
+
+// A representative operator-mode config: NSC operator JWT + resolver +
+// system_account + the account named in the account tree. (The account-tree
+// root key path is an NSC operator.creds carve-out, not a principal.)
+const OPERATOR_MODE_CONF = [
+  "operator: /Users/andreas/.config/nats/operator.creds",
+  "system_account: ADSYSACCOUNT",
+  "resolver_preload: {",
+  "  AADPQ7M7LQZTKPNF5CTE7V4XKB2FUYPGKLWZVMW6VXCEEKH62BYKGBHX: eyJ...",
+  "}",
+  "",
+].join("\n");
+
+// A $G/default-account config: a simple creds-authenticated leaf-client — no
+// account tree (no operator-mode key, no `accounts{}`, no resolver_preload).
+const DEFAULT_G_CONF = [
+  "// $G/default-account bus — a simple leaf-client.",
+  "jetstream { store_dir: /Users/jc/.config/nats/js }",
+  "http: localhost:8222",
+  "",
+].join("\n");
+
+const VALID_ACCOUNT = "AADPQ7M7LQZTKPNF5CTE7V4XKB2FUYPGKLWZVMW6VXCEEKH62BYKGBHX";
+
+describe("#799 natsConfigHasAccountTree", () => {
+  test("true for an operator-mode config (operator JWT / resolver_preload)", () => {
+    expect(natsConfigHasAccountTree(OPERATOR_MODE_CONF)).toBe(true);
+  });
+
+  test("true when only `accounts {` is present", () => {
+    expect(natsConfigHasAccountTree("accounts {\n  A: { users: [] }\n}\n")).toBe(true);
+  });
+
+  test("false for a $G/default-account config (no account tree)", () => {
+    expect(natsConfigHasAccountTree(DEFAULT_G_CONF)).toBe(false);
+  });
+
+  test("a COMMENTED-OUT account-tree key does not count (comments stripped)", () => {
+    const commented = "// operator: /x/operator.creds\n# accounts { }\njetstream { }\n";
+    expect(natsConfigHasAccountTree(commented)).toBe(false);
+  });
+});
+
+describe("#799 resolveLeafBindMode", () => {
+  test("operator-mode bus + defined account + creds → operator-account", () => {
+    const mode = resolveLeafBindMode(OPERATOR_MODE_CONF, VALID_ACCOUNT, true);
+    expect(mode.mode).toBe("operator-account");
+    if (mode.mode === "operator-account") expect(mode.account).toBe(VALID_ACCOUNT);
+  });
+
+  test("$G/default bus + creds (no account) → creds-only (the #799 fix)", () => {
+    const mode = resolveLeafBindMode(DEFAULT_G_CONF, undefined, true);
+    expect(mode.mode).toBe("creds-only");
+  });
+
+  test("$G/default bus + creds + a stray account → STILL creds-only (account moot)", () => {
+    // Even if an account is offered, a $G bus has no account tree to bind it —
+    // the binding rides in the creds JWT, so we render no-account rather than
+    // refuse (and rather than crash by emitting an unresolvable account line).
+    const mode = resolveLeafBindMode(DEFAULT_G_CONF, VALID_ACCOUNT, true);
+    expect(mode.mode).toBe("creds-only");
+  });
+
+  test("no creds at all → refuse (cannot authenticate to the hub)", () => {
+    const mode = resolveLeafBindMode(DEFAULT_G_CONF, undefined, false);
+    expect(mode.mode).toBe("refuse");
+    if (mode.mode === "refuse") expect(mode.reason).toContain("creds");
+  });
+
+  test("operator-mode bus that does NOT define the account → refuse (would crash)", () => {
+    // An operator-mode bus whose account tree lacks THIS account: rendering an
+    // account-bound leaf crashes nats-server, and operator-mode has no creds-
+    // only fallback (its leaves are account-bound by construction).
+    const otherAccountConf = [
+      "operator: /x/operator.creds",
+      "resolver_preload: {",
+      "  ASOMEOTHERACCOUNTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX: eyJ...",
+      "}",
+      "",
+    ].join("\n");
+    const mode = resolveLeafBindMode(otherAccountConf, VALID_ACCOUNT, true);
+    expect(mode.mode).toBe("refuse");
   });
 });

--- a/src/common/nats/leaf-remote-renderer.ts
+++ b/src/common/nats/leaf-remote-renderer.ts
@@ -80,13 +80,25 @@ export interface StackLeafBinding {
    */
   credentials: string;
   /**
-   * The LOCAL NATS account (nkey-U `A…`) that leaf traffic binds to.
-   * NSC operator-mode requires each leaf remote to declare this; it is the
-   * stack's user-data account (system traffic stays on SYS). DD-8: the
-   * config surface uses nkey-U; the registry stores base64 — translation
-   * is the join command's job, this renderer takes the already-nkey-U value.
+   * The LOCAL NATS account (nkey-U `A…`) that leaf traffic binds to —
+   * OPTIONAL (#799).
+   *
+   *   - **Operator-mode bus** (NSC operator JWT + `accounts`/`resolver_preload`
+   *     defining the account): the leaf remote MUST declare the account so
+   *     nats-server can resolve it against the local account tree. Pass the
+   *     nkey-U here → the rendered remote carries an `account:` line.
+   *   - **`$G`/default-account bus** (a simple creds-authenticated leaf-client —
+   *     no `operator:`/`accounts{}`): there is NO local account tree to resolve
+   *     an `account:` against, so emitting one makes nats-server refuse to boot
+   *     (`cannot find local account "<A…>"`). The account binding rides in the
+   *     `.creds` JWT instead. OMIT this field (leave `undefined`) → the rendered
+   *     remote has NO `account:` line, mirroring a working hand-built `$G` leaf.
+   *
+   * DD-8: the config surface uses nkey-U; the registry stores base64 —
+   * translation is the join command's job; this renderer takes the
+   * already-nkey-U value (or `undefined` for the `$G`/creds-bound case).
    */
-  account: string;
+  account?: string;
 }
 
 /**
@@ -99,10 +111,15 @@ export interface LeafRemote {
   network_id: string;
   /** Fully-qualified leaf dial URL, e.g. `tls://nats.meta-factory.dev:7422`. */
   url: string;
-  /** Absolute path to the `.creds` file (operator-mode leaf auth). */
+  /** Absolute path to the `.creds` file (leaf auth). */
   credentials: string;
-  /** The local NATS account (nkey-U) the leaf binds to. */
-  account: string;
+  /**
+   * The local NATS account (nkey-U) the leaf binds to — present ONLY in
+   * operator-mode (#799). Absent (`undefined`) for a `$G`/default bus, where
+   * the account binding rides in the `.creds` JWT and an `account:` line would
+   * crash nats-server. When absent, {@link serializeRemote} omits the line.
+   */
+  account?: string;
 }
 
 /** A network id may only be a single path segment of safe characters. */
@@ -171,10 +188,18 @@ function resolveLeafUrl(descriptor: NetworkDescriptor): string {
 
 /**
  * Render a single {@link LeafRemote} from a verified descriptor + the stack's
- * leaf binding. Fails loud at the boundary on a missing/relative creds path
- * or a missing account — operator-mode cannot connect a leaf without either,
- * so a silent bad value would produce a dormant link, the exact trap S3
- * closes.
+ * leaf binding. Fails loud at the boundary on a missing/relative creds path —
+ * a leaf cannot authenticate to the hub without creds, so a silent bad value
+ * would produce a dormant link, the exact trap S3 closes.
+ *
+ * The `account` is OPTIONAL (#799):
+ *   - present → operator-mode; the nkey-U is validated (grammar + HOCON-injection
+ *     guard) and the rendered remote carries an `account:` line.
+ *   - absent → a `$G`/default bus; the rendered remote has NO `account:` line
+ *     and the account binding rides in the `.creds` JWT. (The caller — the join
+ *     orchestrator — decides which mode applies via the bus-type detection in
+ *     {@link natsConfigCanBindAccount}: it passes the account only for an
+ *     operator-mode bus that defines it, and omits it for a `$G`+creds bus.)
  */
 export function renderLeafRemote(
   descriptor: NetworkDescriptor,
@@ -193,27 +218,31 @@ export function renderLeafRemote(
     );
   }
 
-  const account = binding.account.trim();
-  if (account.length === 0) {
-    throw new Error(
-      `leaf-remote-renderer: operator-mode requires a bound account (nkey-U) for network "${descriptor.network_id}"; got empty`,
-    );
-  }
-  if (!NKEY_ACCOUNT.test(account)) {
-    // The account is emitted BARE into HOCON (matching local.conf). Anything
-    // outside the nkey-U grammar could break out of the remotes[] block and
-    // inject directives, so reject it at the boundary — a bad account is a
-    // broken/dormant leaf, the exact trap S3 closes.
-    throw new Error(
-      `leaf-remote-renderer: account for network "${descriptor.network_id}" is not a valid nkey-U account public key (expected ${NKEY_ACCOUNT}); got ${JSON.stringify(binding.account)}`,
-    );
+  // #799 — the account is OPTIONAL. When absent/empty the remote is rendered
+  // WITHOUT an `account:` line (the `$G`/default-bus mode — binding rides in the
+  // creds JWT). When present it must be a valid nkey-U: it is emitted BARE
+  // (unquoted) into HOCON (matching local.conf), so anything outside the nkey-U
+  // grammar could break out of the remotes[] block and inject directives.
+  const account = binding.account?.trim();
+  if (account !== undefined && account.length > 0) {
+    if (!NKEY_ACCOUNT.test(account)) {
+      throw new Error(
+        `leaf-remote-renderer: account for network "${descriptor.network_id}" is not a valid nkey-U account public key (expected ${NKEY_ACCOUNT}); got ${JSON.stringify(binding.account)}`,
+      );
+    }
+    return {
+      network_id: descriptor.network_id,
+      url: resolveLeafUrl(descriptor),
+      credentials,
+      account,
+    };
   }
 
+  // No account → `$G`/default mode: omit `account:` entirely.
   return {
     network_id: descriptor.network_id,
     url: resolveLeafUrl(descriptor),
     credentials,
-    account,
   };
 }
 
@@ -450,15 +479,9 @@ export function natsConfigCanBindAccount(
   const text = stripConfigComments(natsConfigText);
 
   // operator-mode signal: an NSC operator JWT key OR an account-tree directive
-  // (`accounts` / `resolver_preload`). HOCON allows `key:` or `key =` and
-  // leading whitespace; the regex matches the literal config key as its own
-  // token (the NATS account-tree root NSC operator JWT key, not the principal).
-  const hasAccountTree =
-    /^[ \t]*operator[ \t]*[:=]/m.test(text) || // NSC operator JWT key
-    /^[ \t]*accounts[ \t]*[:={]/m.test(text) ||
-    /^[ \t]*resolver_preload[ \t]*[:={]/m.test(text);
-
-  if (!hasAccountTree) {
+  // (`accounts` / `resolver_preload`). Shared with {@link natsConfigHasAccountTree}
+  // so the #794 guard and the #799 bind-mode decision cannot drift.
+  if (!natsConfigHasAccountTree(natsConfigText)) {
     return {
       canBind: false,
       reason:
@@ -480,18 +503,134 @@ export function natsConfigCanBindAccount(
   return { canBind: true };
 }
 
+// =============================================================================
+// #799 — choose the leaf-remote BIND MODE by bus type.
+//
+// #794 added `natsConfigCanBindAccount` to refuse a join that would render an
+// `account:`-bound leaf onto a bus with no matching account (→ nats-server
+// crash). But that conflated two distinct un-bindable shapes:
+//
+//   1. An operator-mode bus that doesn't DEFINE the account → genuinely
+//      un-joinable with that account (still refuse).
+//   2. A `$G`/default-account bus (a simple creds-authenticated leaf-client,
+//      no `operator:`/`accounts{}`) → joinable WITHOUT an `account:` line; the
+//      binding rides in the creds JWT (the working hand-built-leaf shape).
+//
+// Case 2 was wrongly refused. {@link resolveLeafBindMode} is the corrected
+// decision: it returns the bind MODE the renderer should use, given the bus
+// config + the candidate account + whether creds are available.
+// =============================================================================
+
+/** The leaf-remote bind mode {@link resolveLeafBindMode} selects (#799). */
+export type LeafBindMode =
+  /** operator-mode bus that defines the account → render `{ url, creds, account }`. */
+  | { mode: "operator-account"; account: string }
+  /** `$G`/default bus with creds → render `{ url, creds }` (omit `account:`). */
+  | { mode: "creds-only" }
+  /** Un-joinable (no creds, or operator-mode bus missing the account). */
+  | { mode: "refuse"; reason: string };
+
+/**
+ * Decide how a leaf remote for this bus should bind (#799), WITHOUT crashing
+ * nats-server. Pure: reads the config text + the candidate account, writes
+ * nothing.
+ *
+ *   - **operator-mode bus that defines `account`** → `operator-account` (the
+ *     #794-safe account-bound remote; unchanged behaviour).
+ *   - **`$G`/default bus (no operator-mode account tree) WITH creds** →
+ *     `creds-only`: render a no-account remote; the creds JWT binds it. This is
+ *     the case #794 wrongly refused.
+ *   - **no creds at all** → `refuse`: a leaf cannot authenticate to the hub
+ *     without creds, so neither mode is possible.
+ *   - **operator-mode bus that does NOT define `account`** → `refuse`: rendering
+ *     an account-bound remote there crashes nats-server, and there is no creds-
+ *     only fallback for an operator-mode bus (operator-mode leaves are
+ *     account-bound by construction).
+ *
+ * `hasCreds` is supplied by the caller (the orchestrator knows the resolved
+ * creds path); an absent/empty account is treated as "no account offered"
+ * (the `$G` path).
+ */
+export function resolveLeafBindMode(
+  natsConfigText: string,
+  account: string | undefined,
+  hasCreds: boolean,
+): LeafBindMode {
+  if (!hasCreds) {
+    return {
+      mode: "refuse",
+      reason:
+        "no leaf creds available — a leaf cannot authenticate to the hub " +
+        "without a `.creds` file (set stack.nats_infra.creds_path or pass --creds)",
+    };
+  }
+
+  const trimmedAccount = account?.trim();
+  const hasAccount = trimmedAccount !== undefined && trimmedAccount.length > 0;
+
+  // When an account is offered, reuse the #794 detection: if the operator-mode
+  // bus binds it, render account-bound. (canBindAccount also validates the
+  // nkey-U grammar.)
+  if (hasAccount) {
+    const bind = natsConfigCanBindAccount(natsConfigText, trimmedAccount);
+    if (bind.canBind) {
+      return { mode: "operator-account", account: trimmedAccount };
+    }
+    // The bus can't bind the offered account. If it's an OPERATOR-MODE bus that
+    // simply doesn't define this account, refuse (no creds-only fallback for
+    // operator-mode — its leaves are account-bound). If it's a `$G`/default bus
+    // (no account tree at all), fall through to the creds-only path: the offered
+    // account is moot because the binding rides in the creds JWT.
+    if (natsConfigHasAccountTree(natsConfigText)) {
+      return {
+        mode: "refuse",
+        reason: bind.reason ?? `operator-mode bus does not define account ${trimmedAccount}`,
+      };
+    }
+  }
+
+  // No account offered (or a `$G` bus where the account is moot) + creds present
+  // → bind via the creds JWT, no `account:` line.
+  return { mode: "creds-only" };
+}
+
+/**
+ * True iff the config is OPERATOR-MODE — it carries an NSC operator JWT key OR
+ * an account tree (`accounts` / `resolver_preload`). The negation is a
+ * `$G`/default-account bus (a simple creds-authenticated leaf-client). Mirrors
+ * the operator-mode signal inside {@link natsConfigCanBindAccount} (comments
+ * stripped first) so the two cannot drift. (#799)
+ */
+export function natsConfigHasAccountTree(natsConfigText: string): boolean {
+  const text = stripConfigComments(natsConfigText);
+  return (
+    /^[ \t]*operator[ \t]*[:=]/m.test(text) || // NSC operator JWT key
+    /^[ \t]*accounts[ \t]*[:={]/m.test(text) ||
+    /^[ \t]*resolver_preload[ \t]*[:={]/m.test(text)
+  );
+}
+
 /** Serialize one {@link LeafRemote} as a HOCON object literal (indented). */
 function serializeRemote(remote: LeafRemote, indent: string): string {
   // `url` + `credentials` are quoted (they contain `:`, `/`, `.` which are
   // HOCON-significant); `account` is a bare nkey-U token (matches the live
   // local.conf, which leaves the account pubkey unquoted).
-  return [
+  //
+  // #799 — `account:` is OMITTED entirely for a `$G`/default-bus remote (no
+  // account on the binding). A working hand-built `$G` leaf has no `account:`
+  // line — the binding rides in the creds JWT — and emitting one would crash
+  // nats-server (`cannot find local account "<A…>"`). Only an operator-mode
+  // remote (account present) carries the line.
+  const lines = [
     `${indent}{`,
     `${indent}  url: ${JSON.stringify(remote.url)}`,
     `${indent}  credentials: ${JSON.stringify(remote.credentials)}`,
-    `${indent}  account: ${remote.account}`,
-    `${indent}}`,
-  ].join("\n");
+  ];
+  if (remote.account !== undefined && remote.account.length > 0) {
+    lines.push(`${indent}  account: ${remote.account}`);
+  }
+  lines.push(`${indent}}`);
+  return lines.join("\n");
 }
 
 /**

--- a/src/common/nats/nats-service-manager.ts
+++ b/src/common/nats/nats-service-manager.ts
@@ -165,8 +165,14 @@ function writeProgramArguments(plistPath: string, nextArgs: string[]): void {
   writeFileSync(plistPath, next, "utf-8");
 }
 
-/** Read the launchd `<key>Label</key><string>…</string>`. */
-function readPlistLabel(plistPath: string): string | undefined {
+/**
+ * Read the launchd `<key>Label</key><string>…</string>` from a plist file at
+ * `plistPath`. Returns `undefined` when the file is absent or carries no Label.
+ * Exported (#800) so the daemon-restart adapter can derive the launchctl target
+ * from the CONFIGURED nats plist's Label rather than a slug guess.
+ */
+export function readPlistLabel(plistPath: string): string | undefined {
+  if (!existsSync(plistPath)) return undefined;
   const xml = readFileSync(plistPath, "utf-8");
   const m = /<key>Label<\/key>\s*<string>([\s\S]*?)<\/string>/.exec(xml);
   if (m === null) return undefined;


### PR DESCRIPTION
Closes #799, closes #800, closes #801. Surfaced when a peer principal (`jc/default`, a `$G`/default-account bus) tried to join `metafactory-community` — it broke their bus three ways.

## #799 — no-account leaf remote for `$G` buses (critical)
`join` always wrote `account: <A…>`; a `$G` bus (no account tree) then refused to boot (`cannot find local account`). Now `resolveLeafBindMode` picks by bus type: **operator-mode + account** → account-bound remote (unchanged); **`$G` + creds** → `{url, credentials}`, **`account:` omitted** (the creds JWT binds it); **no creds** → refused. The #794 fail-fast is relaxed to refuse only the genuinely-unjoinable case (no creds, or operator-mode missing the account) — not a joinable `$G`+creds bus. `--account` is now an operator-mode override, not a hard requirement. **No auth weakening** — the leaf still authenticates with its creds.

## #800 — restart targets the configured plist, not `cortex.<slug>`
`resolveDaemonLabel` reads the nats plist's `Label` (mapping `.nats.` → `.cortex.`) instead of guessing `ai.meta-factory.cortex.<slug>` — fixes the 113/503 when slug ≠ plist suffix.

## #801 — leave preserves the base `-c <config>`
`leave` no longer drops the `-c <config>` plist arg (that's the BASE server config; leaf remotes are `include`d into it). It only removes the network include + policy entry.

## Tests
RED-first for all three + updated #794 tests to the relaxed semantics. 525 pass, typecheck/eslint/carve-out clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)