### PR TITLE
fix(cortex): C-800 — resolve daemon restart by --config, not stack slug

### DIFF
--- a/src/cli/cortex/commands/__tests__/daemon-locator.test.ts
+++ b/src/cli/cortex/commands/__tests__/daemon-locator.test.ts
@@ -1,0 +1,247 @@
+/**
+ * #800 — the daemon locator: resolve the cortex daemon's launchd/systemd service
+ * by its `--config` arg, so the join/leave restart targets the real service
+ * instead of guessing `ai.meta-factory.cortex.<stack-slug>`.
+ *
+ * The matcher is pure (file I/O injected), so these tests pin the resolution
+ * logic — including the driving case `jc/default` whose plist suffix is
+ * `meta-factory`, NOT the slug — without touching the host's LaunchAgents.
+ */
+
+import { describe, test, expect } from "bun:test";
+
+import {
+  configArgValue,
+  findCortexDaemonDescriptor,
+  parsePlistProgramArguments,
+  parseUnitExecStartArgs,
+  type DaemonLocatorIO,
+} from "../daemon-locator";
+
+// =============================================================================
+// Fixtures
+// =============================================================================
+
+const CFG = "/Users/jc/.config/cortex/cortex.yaml";
+
+/** The arc-rendered cortex daemon plist for stack jc/default — suffix `meta-factory`. */
+function daemonPlist(configPath: string): string {
+  return [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<plist version="1.0"><dict>',
+    "<key>Label</key><string>ai.meta-factory.cortex.meta-factory</string>",
+    "<key>ProgramArguments</key><array>",
+    "<string>/Users/jc/bin/cortex</string>",
+    "<string>start</string>",
+    "<string>--config</string>",
+    `<string>${configPath}</string>`,
+    "</array></dict></plist>",
+  ].join("\n");
+}
+
+/** The relay sibling — `relay.ts start`, NO --config. Must NOT match. */
+const RELAY_PLIST = [
+  '<?xml version="1.0" encoding="UTF-8"?>',
+  '<plist version="1.0"><dict>',
+  "<key>Label</key><string>ai.meta-factory.cortex.relay</string>",
+  "<key>ProgramArguments</key><array>",
+  "<string>/Users/jc/.bun/bin/bun</string>",
+  "<string>/pkg/cortex/src/taps/cc-events/relay.ts</string>",
+  "<string>start</string>",
+  "</array></dict></plist>",
+].join("\n");
+
+/** The mc sibling — `run …/index.ts`, NO --config. Must NOT match. */
+const MC_PLIST = [
+  '<?xml version="1.0" encoding="UTF-8"?>',
+  '<plist version="1.0"><dict>',
+  "<key>Label</key><string>ai.meta-factory.cortex.mc</string>",
+  "<key>ProgramArguments</key><array>",
+  "<string>/Users/jc/.bun/bin/bun</string>",
+  "<string>run</string>",
+  "<string>/pkg/cortex/src/surface/mc/index.ts</string>",
+  "</array></dict></plist>",
+].join("\n");
+
+/** Build an injected IO over an in-memory `{ dir: { file: content } }` tree. */
+function fakeIO(tree: Record<string, Record<string, string>>): DaemonLocatorIO {
+  return {
+    // The locator only ever checks directory existence (the scan root).
+    exists: (p) => p in tree,
+    listDir: (dir) => Object.keys(tree[dir] ?? {}),
+    readFile: (p) => {
+      const f = tree[dirOf(p)]?.[baseOf(p)];
+      if (f === undefined) throw new Error(`ENOENT ${p}`);
+      return f;
+    },
+  };
+}
+const dirOf = (p: string) => p.slice(0, p.lastIndexOf("/"));
+const baseOf = (p: string) => p.slice(p.lastIndexOf("/") + 1);
+
+// =============================================================================
+// configArgValue
+// =============================================================================
+
+describe("#800 configArgValue", () => {
+  test("reads the value after -c", () => {
+    expect(configArgValue(["nats-server", "-c", "/x/local.conf"])).toBe("/x/local.conf");
+  });
+  test("reads the value after --config", () => {
+    expect(configArgValue(["cortex", "start", "--config", CFG])).toBe(CFG);
+  });
+  test("reads the --config=<v> joined form", () => {
+    expect(configArgValue(["cortex", `--config=${CFG}`])).toBe(CFG);
+  });
+  test("returns undefined when no config arg is present", () => {
+    expect(configArgValue(["bun", "run", "/pkg/index.ts"])).toBeUndefined();
+  });
+  test("returns undefined when -c is the trailing arg (no value)", () => {
+    expect(configArgValue(["nats-server", "-c"])).toBeUndefined();
+  });
+});
+
+// =============================================================================
+// Arg parsers
+// =============================================================================
+
+describe("#800 parsePlistProgramArguments", () => {
+  test("extracts the <string> entries in order", () => {
+    expect(parsePlistProgramArguments(daemonPlist(CFG))).toEqual([
+      "/Users/jc/bin/cortex",
+      "start",
+      "--config",
+      CFG,
+    ]);
+  });
+  test("unescapes XML entities", () => {
+    const xml = "<key>ProgramArguments</key><array><string>a&amp;b</string></array>";
+    expect(parsePlistProgramArguments(xml)).toEqual(["a&b"]);
+  });
+  test("returns [] when there is no ProgramArguments block", () => {
+    expect(parsePlistProgramArguments("<plist><dict></dict></plist>")).toEqual([]);
+  });
+});
+
+describe("#800 parseUnitExecStartArgs", () => {
+  test("parses ExecStart argv, stripping the `-` prefix", () => {
+    const unit = "[Service]\nExecStart=-/usr/bin/cortex start --config /home/clawbox/cortex.yaml\n";
+    expect(parseUnitExecStartArgs(unit)).toEqual([
+      "/usr/bin/cortex",
+      "start",
+      "--config",
+      "/home/clawbox/cortex.yaml",
+    ]);
+  });
+  test("returns [] when there is no ExecStart line", () => {
+    expect(parseUnitExecStartArgs("[Unit]\nDescription=x\n")).toEqual([]);
+  });
+});
+
+// =============================================================================
+// findCortexDaemonDescriptor — the driving case
+// =============================================================================
+
+describe("#800 findCortexDaemonDescriptor (darwin)", () => {
+  const LA = "/Users/jc/Library/LaunchAgents";
+
+  test("resolves the daemon by --config even when the plist suffix ≠ stack slug", () => {
+    // Stack is jc/default; the matching plist is `…cortex.meta-factory`. The
+    // pre-#800 slug guess `…cortex.default` would never find this.
+    const io = fakeIO({
+      [LA]: {
+        "ai.meta-factory.cortex.meta-factory.plist": daemonPlist(CFG),
+        "ai.meta-factory.cortex.relay.plist": RELAY_PLIST,
+        "ai.meta-factory.cortex.mc.plist": MC_PLIST,
+      },
+    });
+    const found = findCortexDaemonDescriptor({
+      platform: "darwin",
+      cortexConfigPath: CFG,
+      launchAgentsDir: LA,
+      systemdUserDir: "/unused",
+      io,
+    });
+    expect(found).toBe(`${LA}/ai.meta-factory.cortex.meta-factory.plist`);
+  });
+
+  test("matches across `~` vs expanded config paths", () => {
+    const io = fakeIO({
+      [LA]: { "ai.meta-factory.cortex.meta-factory.plist": daemonPlist(CFG) },
+    });
+    // The plist stores the absolute path; the join may carry the same path. A
+    // `~`-form on either side still resolves to the same file.
+    const found = findCortexDaemonDescriptor({
+      platform: "darwin",
+      cortexConfigPath: CFG,
+      launchAgentsDir: LA,
+      systemdUserDir: "/unused",
+      io,
+    });
+    expect(found).toBeDefined();
+  });
+
+  test("returns undefined when no installed plist references the config", () => {
+    const io = fakeIO({
+      [LA]: {
+        "ai.meta-factory.cortex.relay.plist": RELAY_PLIST,
+        "ai.meta-factory.cortex.mc.plist": MC_PLIST,
+      },
+    });
+    const found = findCortexDaemonDescriptor({
+      platform: "darwin",
+      cortexConfigPath: CFG,
+      launchAgentsDir: LA,
+      systemdUserDir: "/unused",
+      io,
+    });
+    expect(found).toBeUndefined();
+  });
+
+  test("returns undefined when a DIFFERENT stack's config is requested", () => {
+    const io = fakeIO({
+      [LA]: { "ai.meta-factory.cortex.meta-factory.plist": daemonPlist(CFG) },
+    });
+    const found = findCortexDaemonDescriptor({
+      platform: "darwin",
+      cortexConfigPath: "/Users/jc/.config/cortex/other.yaml",
+      launchAgentsDir: LA,
+      systemdUserDir: "/unused",
+      io,
+    });
+    expect(found).toBeUndefined();
+  });
+
+  test("returns undefined when the LaunchAgents dir is absent", () => {
+    const io = fakeIO({});
+    const found = findCortexDaemonDescriptor({
+      platform: "darwin",
+      cortexConfigPath: CFG,
+      launchAgentsDir: LA,
+      systemdUserDir: "/unused",
+      io,
+    });
+    expect(found).toBeUndefined();
+  });
+});
+
+describe("#800 findCortexDaemonDescriptor (linux/systemd)", () => {
+  const SD = "/home/clawbox/.config/systemd/user";
+  const LXCFG = "/home/clawbox/.config/cortex/cortex.yaml";
+  const unit = `[Service]\nExecStart=/usr/bin/cortex start --config ${LXCFG}\n`;
+  const otherUnit = "[Service]\nExecStart=/usr/bin/something-else\n";
+
+  test("resolves the cortex-bot unit by ExecStart --config", () => {
+    const io = fakeIO({
+      [SD]: { "cortex-bot.service": unit, "other.service": otherUnit },
+    });
+    const found = findCortexDaemonDescriptor({
+      platform: "linux",
+      cortexConfigPath: LXCFG,
+      launchAgentsDir: "/unused",
+      systemdUserDir: SD,
+      io,
+    });
+    expect(found).toBe(`${SD}/cortex-bot.service`);
+  });
+});

--- a/src/cli/cortex/commands/__tests__/daemon-locator.test.ts
+++ b/src/cli/cortex/commands/__tests__/daemon-locator.test.ts
@@ -181,6 +181,22 @@ describe("#800 findCortexDaemonDescriptor (darwin)", () => {
     expect(found).toBeDefined();
   });
 
+  test("matches despite a non-normalised config path (`.` segment / trailing slash)", () => {
+    const io = fakeIO({
+      [LA]: { "ai.meta-factory.cortex.meta-factory.plist": daemonPlist(CFG) },
+    });
+    // The plist stores the clean absolute path; the query carries a `.` segment.
+    // path.resolve on both sides normalises them to the same file.
+    const found = findCortexDaemonDescriptor({
+      platform: "darwin",
+      cortexConfigPath: "/Users/jc/.config/cortex/./cortex.yaml",
+      launchAgentsDir: LA,
+      systemdUserDir: "/unused",
+      io,
+    });
+    expect(found).toBe(`${LA}/ai.meta-factory.cortex.meta-factory.plist`);
+  });
+
   test("returns undefined when no installed plist references the config", () => {
     const io = fakeIO({
       [LA]: {

--- a/src/cli/cortex/commands/__tests__/network-adapters.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-adapters.test.ts
@@ -25,7 +25,6 @@ import {
   buildLeafStatePort,
   buildLivePorts,
   DEFAULT_MONITOR_URL,
-  resolveDaemonLabel,
   type LivePortsConfig,
 } from "../network-adapters";
 import { leaveNetwork } from "../network-lib";
@@ -1175,101 +1174,6 @@ describe("C-797 buildLeafStatePort (/leafz monitor)", () => {
   });
 });
 
-// =============================================================================
-// #800 — the cortex DAEMON restart target is resolved from the configured
-// nats plist's <key>Label</key> (suffix-shared with the cortex daemon label),
-// NOT from the stack slug. The peer bug: slug `default`, but the real plists
-// are `…cortex.meta-factory` / `…nats.meta-factory` → a slug-derived
-// `…cortex.default` label always 113/503s.
-// =============================================================================
-
-/** A nats-server plist whose Label is `ai.meta-factory.nats.<suffix>`. */
-function natsPlistWithLabel(suffix: string): string {
-  return [
-    '<?xml version="1.0" encoding="UTF-8"?>',
-    '<plist version="1.0">',
-    "<dict>",
-    "\t<key>Label</key>",
-    `\t<string>ai.meta-factory.nats.${suffix}</string>`,
-    "\t<key>ProgramArguments</key>",
-    "\t<array><string>/opt/homebrew/bin/nats-server</string></array>",
-    "</dict>",
-    "</plist>",
-    "",
-  ].join("\n");
-}
-
-describe("#800 daemon restart label resolves from nats_infra.plist_path", () => {
-  test("slug ≠ plist suffix → daemon label uses the PLIST suffix, not the slug", () => {
-    const dir = freshDir();
-    const plistPath = join(dir, "nats.plist");
-    // The peer case: real nats plist suffix is `meta-factory`...
-    writeFileSync(plistPath, natsPlistWithLabel("meta-factory"), "utf-8");
-
-    const cfg: LivePortsConfig = {
-      networkId: "metafactory-community",
-      principalId: "jc",
-      // ...but the stack slug is `default` (the slug-guess bug source).
-      stackId: "jc/default",
-      natsConfigPath: "/Users/jc/.config/nats/local.conf",
-      plistPath,
-      platform: "darwin",
-    };
-
-    // The daemon label maps `…nats.meta-factory` → `…cortex.meta-factory`,
-    // NOT the slug-derived `…cortex.default`.
-    expect(resolveDaemonLabel(cfg)).toBe("ai.meta-factory.cortex.meta-factory");
-    expect(resolveDaemonLabel(cfg)).not.toBe("ai.meta-factory.cortex.default");
-  });
-
-  test("slug == plist suffix → unchanged (label matches the slug, as before)", () => {
-    const dir = freshDir();
-    const plistPath = join(dir, "nats.plist");
-    writeFileSync(plistPath, natsPlistWithLabel("community"), "utf-8");
-    const cfg: LivePortsConfig = {
-      networkId: "community",
-      principalId: "andreas",
-      stackId: "andreas/community",
-      natsConfigPath: "/x/local.conf",
-      plistPath,
-      platform: "darwin",
-    };
-    expect(resolveDaemonLabel(cfg)).toBe("ai.meta-factory.cortex.community");
-  });
-
-  test("a plist already carrying a `.cortex.` label is used verbatim", () => {
-    const dir = freshDir();
-    const plistPath = join(dir, "daemon.plist");
-    writeFileSync(
-      plistPath,
-      natsPlistWithLabel("x").replace("nats.x", "cortex.work"),
-      "utf-8",
-    );
-    const cfg: LivePortsConfig = {
-      networkId: "n",
-      principalId: "andreas",
-      stackId: "andreas/default",
-      natsConfigPath: "/x/local.conf",
-      plistPath,
-      platform: "darwin",
-    };
-    expect(resolveDaemonLabel(cfg)).toBe("ai.meta-factory.cortex.work");
-  });
-
-  test("no readable plist label → falls back to the slug-derived label", () => {
-    const cfg: LivePortsConfig = {
-      networkId: "n",
-      principalId: "jc",
-      stackId: "jc/default",
-      natsConfigPath: "/x/local.conf",
-      plistPath: "/nonexistent/nats.plist",
-      platform: "darwin",
-    };
-    // No plist to read → the slug fallback (best effort) rather than a guess at
-    // the suffix.
-    expect(resolveDaemonLabel(cfg)).toBe("ai.meta-factory.cortex.default");
-  });
-});
 
 // =============================================================================
 // #799 — the live leaf-file port renders a NO-ACCOUNT remote for a $G/default
@@ -1472,5 +1376,54 @@ describe("#801 leave preserves the base -c arg (nats stays startable)", () => {
     expect(confAfter).not.toContain('include "leafnodes-metafactory.conf"');
     expect(confAfter).toContain("system_account: ADSYS"); // base config intact
     expect(existsSync(join(dir, "leafnodes-metafactory.conf"))).toBe(false);
+  });
+});
+
+// =============================================================================
+// #800 — the daemon-restart port resolves the cortex daemon's service from the
+// `--config` arg (cortexConfigPath), NOT the guessed `cortex.<slug>` label. The
+// dry-run port is inert; error branches (no config threaded / no matching
+// service) never spawn launchctl. The resolution logic itself is covered by
+// daemon-locator.test.ts; here we pin the PORT's behaviour + reasons.
+// =============================================================================
+
+describe("#800 daemon restart port", () => {
+  test("dry-run daemon restart is inert (no spawn, ok)", async () => {
+    const ports = buildDryRunPorts({
+      networkId: "metafactory",
+      principalId: "jc",
+      stackId: "jc/default",
+      cortexConfigPath: "/Users/jc/.config/cortex/cortex.yaml",
+      platform: "darwin",
+    });
+    const res = await ports.daemon.restart();
+    expect(res.ok).toBe(true);
+  });
+
+  test("live restart fails cleanly when no cortex config path is threaded", async () => {
+    const ports = buildLivePorts({
+      networkId: "metafactory",
+      principalId: "jc",
+      stackId: "jc/default",
+      platform: "darwin",
+      // cortexConfigPath intentionally unset.
+    });
+    const res = await ports.daemon.restart();
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.reason).toContain("cortexConfigPath");
+  });
+
+  test("live restart fails cleanly when no installed service matches the config (no spawn)", async () => {
+    const ports = buildLivePorts({
+      networkId: "metafactory",
+      principalId: "jc",
+      stackId: "jc/default",
+      // A config path no installed plist/unit references → resolves to nothing.
+      cortexConfigPath: "/tmp/cortex-c800-nonexistent-config.yaml",
+      platform: "darwin",
+    });
+    const res = await ports.daemon.restart();
+    expect(res.ok).toBe(false);
+    if (!res.ok) expect(res.reason).toContain("no cortex daemon service found");
   });
 });

--- a/src/cli/cortex/commands/daemon-locator.ts
+++ b/src/cli/cortex/commands/daemon-locator.ts
@@ -1,0 +1,152 @@
+/**
+ * #800 — locate the cortex daemon's service descriptor so `network join`/`leave`
+ * restart the RIGHT service instead of guessing `ai.meta-factory.cortex.<slug>`.
+ *
+ * ## The bug this closes
+ *
+ * The daemon-restart step derived the launchd label from the stack slug:
+ * `ai.meta-factory.cortex.${stackId.split("/")[1]}`. When the slug differs from
+ * the plist suffix — the driving case `jc/default` whose real daemon is
+ * `ai.meta-factory.cortex.meta-factory` — `launchctl kickstart` always fails
+ * with `113 / Could not find service … (503)`, so the join reports FAILED even
+ * though the leaf config landed.
+ *
+ * ## The fix
+ *
+ * Don't guess. The stack daemon is the launchd service (macOS) or systemd user
+ * unit (Linux) whose argv carries `--config <cortexConfigPath>` — the very
+ * cortex.yaml the join derives its inputs from. That config arg uniquely
+ * identifies the stack daemon: its `relay`/`mc` siblings under the same
+ * `ai.meta-factory.cortex.*` prefix don't carry it (relay runs `relay.ts start`,
+ * mc runs `run …/index.ts`). We discover the descriptor by that match and hand
+ * its PATH to {@link selectNatsServiceManager}, which restarts by the real
+ * `<key>Label</key>` (launchd) / unit id (systemd) — the same #763 mechanism the
+ * nats-server restart already uses.
+ *
+ * All file I/O is injected ({@link DaemonLocatorIO}) so the matcher is a pure,
+ * unit-testable function with no dependence on the host's `~/Library/LaunchAgents`.
+ */
+
+import { join } from "path";
+
+import { expandTilde } from "../../../common/config/loader";
+import type { ServicePlatform } from "../../../common/nats/nats-service-manager";
+
+/** Injected filesystem seam — real `fs` in prod, fakes in tests. */
+export interface DaemonLocatorIO {
+  /** List directory entries (file names only). Returns `[]` if absent/unreadable. */
+  listDir(dir: string): string[];
+  /** Read a file as UTF-8. */
+  readFile(path: string): string;
+  /** Does the path exist? */
+  exists(path: string): boolean;
+}
+
+/**
+ * Extract the value of a `-c` / `--config` / `--config=<v>` argument from an
+ * argv list. Returns `undefined` when no config arg is present.
+ */
+export function configArgValue(args: string[]): string | undefined {
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i] ?? "";
+    if (a === "-c" || a === "--config") {
+      const v = args[i + 1];
+      if (v !== undefined && v !== "") return v;
+    }
+    const eq = /^--config=(.+)$/.exec(a);
+    if (eq) return eq[1];
+  }
+  return undefined;
+}
+
+/** Parse the `<key>ProgramArguments</key><array><string>…</string></array>` entries. */
+export function parsePlistProgramArguments(xml: string): string[] {
+  const block = /<key>ProgramArguments<\/key>\s*<array>([\s\S]*?)<\/array>/.exec(xml);
+  if (block === null) return [];
+  const args: string[] = [];
+  const re = /<string>([\s\S]*?)<\/string>/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(block[1] ?? "")) !== null) {
+    args.push(
+      (m[1] ?? "")
+        .replace(/&lt;/g, "<")
+        .replace(/&gt;/g, ">")
+        .replace(/&quot;/g, '"')
+        .replace(/&apos;/g, "'")
+        .replace(/&amp;/g, "&"),
+    );
+  }
+  return args;
+}
+
+/** Parse the `ExecStart=` argv from a systemd unit, stripping the `@-+!:` prefixes. */
+export function parseUnitExecStartArgs(unitText: string): string[] {
+  const line = unitText.split("\n").find((l) => /^\s*ExecStart\s*=/.test(l));
+  if (line === undefined) return [];
+  const value = line.slice(line.indexOf("=") + 1).trim();
+  const prefix = /^([@\-+!:]+)/.exec(value)?.[1] ?? "";
+  return value
+    .slice(prefix.length)
+    .trim()
+    .split(/\s+/)
+    .filter((t) => t.length > 0);
+}
+
+/** Two config paths point at the same file once `~` is expanded. */
+function sameConfig(a: string, b: string): boolean {
+  return expandTilde(a) === expandTilde(b);
+}
+
+/**
+ * Discover the cortex daemon's service descriptor for the stack whose daemon
+ * loads `cortexConfigPath`. Returns the descriptor path (launchd plist on macOS,
+ * systemd unit on Linux) or `undefined` when no installed service references it.
+ */
+export function findCortexDaemonDescriptor(opts: {
+  platform: ServicePlatform;
+  cortexConfigPath: string;
+  launchAgentsDir: string;
+  systemdUserDir: string;
+  io: DaemonLocatorIO;
+}): string | undefined {
+  const { platform, cortexConfigPath, io } = opts;
+  if (platform === "darwin") {
+    return scanDir(opts.launchAgentsDir, /^ai\.meta-factory\.cortex\..+\.plist$/, io, (text) =>
+      configMatches(parsePlistProgramArguments(text), cortexConfigPath),
+    );
+  }
+  // Linux (systemd user units). The clawbox daemon is `cortex-bot.service`; match
+  // by the ExecStart `--config` rather than a hard-coded unit name.
+  return scanDir(opts.systemdUserDir, /\.service$/, io, (text) =>
+    configMatches(parseUnitExecStartArgs(text), cortexConfigPath),
+  );
+}
+
+function configMatches(args: string[], cortexConfigPath: string): boolean {
+  const cfgArg = configArgValue(args);
+  return cfgArg !== undefined && sameConfig(cfgArg, cortexConfigPath);
+}
+
+/** Return the first descriptor in `dir` matching `namePattern` whose body passes `predicate`. */
+function scanDir(
+  dir: string,
+  namePattern: RegExp,
+  io: DaemonLocatorIO,
+  predicate: (text: string) => boolean,
+): string | undefined {
+  if (!io.exists(dir)) return undefined;
+  for (const name of io.listDir(dir)) {
+    if (!namePattern.test(name)) continue;
+    const path = join(dir, name);
+    let text: string;
+    try {
+      text = io.readFile(path);
+    } catch (_err) {
+      // Unreadable descriptor (race/permissions) — safe to skip; another
+      // candidate may still match. Nothing actionable to log per-file.
+      continue;
+    }
+    if (predicate(text)) return path;
+  }
+  return undefined;
+}

--- a/src/cli/cortex/commands/daemon-locator.ts
+++ b/src/cli/cortex/commands/daemon-locator.ts
@@ -27,7 +27,7 @@
  * unit-testable function with no dependence on the host's `~/Library/LaunchAgents`.
  */
 
-import { join } from "path";
+import { join, resolve } from "path";
 
 import { expandTilde } from "../../../common/config/loader";
 import type { ServicePlatform } from "../../../common/nats/nats-service-manager";
@@ -92,9 +92,17 @@ export function parseUnitExecStartArgs(unitText: string): string[] {
     .filter((t) => t.length > 0);
 }
 
-/** Two config paths point at the same file once `~` is expanded. */
+/**
+ * Two config paths point at the same file. We `expandTilde` then `resolve` both
+ * sides, so a relative `--config`, a trailing slash, or a `.`/`..` segment still
+ * matches the absolute path arc renders into the plist. NOTE: this does NOT
+ * resolve symlinks (e.g. macOS `/var`→`/private/var`) — that would need a
+ * realpath syscall, which the injected-IO purity here deliberately avoids; arc
+ * renders a non-symlinked absolute path and the join expands the same default,
+ * so the symlinked-HOME edge is a known, accepted gap (PR #806 review note).
+ */
 function sameConfig(a: string, b: string): boolean {
-  return expandTilde(a) === expandTilde(b);
+  return resolve(expandTilde(a)) === resolve(expandTilde(b));
 }
 
 /**

--- a/src/cli/cortex/commands/network-adapters.ts
+++ b/src/cli/cortex/commands/network-adapters.ts
@@ -605,6 +605,10 @@ function buildDaemonPort(cfg: LivePortsConfig, mutate: boolean): DaemonPort {
       }
       let mgr;
       try {
+        // NB: `selectNatsServiceManager` is named for its original nats-server
+        // caller, but it's generic — it restarts ANY launchd/systemd descriptor
+        // by reading its `<key>Label</key>` / unit id. Here we hand it the CORTEX
+        // daemon descriptor we just discovered, not a nats-server one.
         mgr = selectNatsServiceManager({ descriptorPath, platform, mutate, exec: bunExecRunner });
       } catch (err) {
         return { ok: false, reason: err instanceof Error ? err.message : String(err) };

--- a/src/cli/cortex/commands/network-adapters.ts
+++ b/src/cli/cortex/commands/network-adapters.ts
@@ -44,12 +44,15 @@ import {
 import {
   bunExecRunner,
   currentServicePlatform,
-  readPlistLabel,
   selectNatsServiceManager,
   type NatsServiceManager,
   type ServicePlatform,
 } from "../../../common/nats/nats-service-manager";
 import { NetworkRegistryClient } from "../../../common/registry/network-client";
+import {
+  findCortexDaemonDescriptor,
+  type DaemonLocatorIO,
+} from "./daemon-locator";
 import {
   buildRegistrationClaim,
   materialFromSeedString,
@@ -125,6 +128,16 @@ export interface LivePortsConfig {
    */
   platform?: ServicePlatform;
   monitorUrl?: string;
+  /**
+   * #800 — the cortex.yaml the stack's CORTEX daemon loads (the join's
+   * `--config`, default `~/.config/cortex/cortex.yaml`). Used to LOCATE the
+   * daemon's launchd/systemd service for the restart: the daemon is the service
+   * whose argv carries `--config <cortexConfigPath>`. Without it the restart
+   * fell back to guessing `ai.meta-factory.cortex.<stack-slug>`, which fails
+   * whenever the slug differs from the plist suffix (e.g. `jc/default` →
+   * `ai.meta-factory.cortex.meta-factory`).
+   */
+  cortexConfigPath?: string;
   /**
    * #762 — the capability ids this stack announces INTO `networkId`, sourced
    * from the network's `announce_capabilities[]` policy block. The federated
@@ -531,57 +544,72 @@ function buildConfigStorePort(cfg: LivePortsConfig, mutate: boolean): ConfigStor
 }
 
 // =============================================================================
-// Daemon port — launchctl kickstart of the stack daemon.
+// Daemon port — restart the stack's CORTEX daemon (#800).
+//
+// We DISCOVER the daemon's launchd/systemd service by matching the descriptor
+// whose argv carries `--config <cortexConfigPath>` (the cortex.yaml the daemon
+// loads), then restart it via its real `<key>Label</key>` / unit id through the
+// shared {@link selectNatsServiceManager} mechanism. The pre-#800 code guessed
+// `ai.meta-factory.cortex.<stack-slug>`, which fails (113/503) whenever the slug
+// differs from the plist suffix — the `jc/default` → `…cortex.meta-factory`
+// case. We no longer guess: an unresolvable daemon returns a CLEAR reason rather
+// than kickstarting a fabricated label.
 // =============================================================================
 
-/**
- * #800 — resolve the cortex DAEMON launchctl label.
- *
- * The bug: the label was derived as `ai.meta-factory.cortex.<stack-slug>`. When
- * the slug ≠ the plist suffix (the peer case — slug `default`, but the real
- * plists are `…cortex.meta-factory` / `…nats.meta-factory`) the kickstart always
- * 113/503s against a service that does not exist.
- *
- * The cortex daemon plist and the nats-server plist share a SUFFIX
- * (`ai.meta-factory.cortex.<suffix>` ↔ `ai.meta-factory.nats.<suffix>`). The
- * configured `stack.nats_infra.plist_path` is the authority for that suffix, so
- * we read the nats plist's `<key>Label</key>` and swap its service segment
- * (`…nats.<suffix>` → `…cortex.<suffix>`) to name the cortex daemon. The slug is
- * only a last-resort fallback when no plist label can be read (e.g. a Linux
- * stack with a unit, or a missing plist).
- */
-export function resolveDaemonLabel(cfg: LivePortsConfig): string {
-  const slugFallback = `ai.meta-factory.cortex.${cfg.stackId.split("/")[1] ?? "default"}`;
-  const plistPath = cfg.plistPath !== undefined ? expandTilde(cfg.plistPath) : undefined;
-  if (plistPath === undefined) return slugFallback;
-  const natsLabel = readPlistLabel(plistPath);
-  if (natsLabel === undefined) return slugFallback;
-  // Map the nats-server service segment to the cortex daemon segment, preserving
-  // the shared suffix: `<prefix>.nats.<suffix>` → `<prefix>.cortex.<suffix>`.
-  // If the label is already a `.cortex.` label (a stack that points plist_path
-  // at the cortex daemon plist directly), use it verbatim.
-  if (natsLabel.includes(".cortex.")) return natsLabel;
-  if (natsLabel.includes(".nats.")) return natsLabel.replace(/\.nats\./, ".cortex.");
-  // An unrecognised label shape — fall back to the slug-derived label rather
-  // than kickstart an unexpected service.
-  return slugFallback;
-}
+/** Live {@link DaemonLocatorIO} backed by real `fs`. */
+const liveDaemonLocatorIO: DaemonLocatorIO = {
+  listDir(dir) {
+    try {
+      return readdirSync(dir);
+    } catch (_err) {
+      // Missing/unreadable dir → no candidates here. Caller treats as "not found".
+      return [];
+    }
+  },
+  readFile(path) {
+    return readFileSync(path, "utf-8");
+  },
+  exists(path) {
+    return existsSync(path);
+  },
+};
 
 function buildDaemonPort(cfg: LivePortsConfig, mutate: boolean): DaemonPort {
   return {
     async restart() {
       if (!mutate) return { ok: true }; // dry-run: pretend success.
-      const label = resolveDaemonLabel(cfg);
-      const proc = Bun.spawn(["launchctl", "kickstart", "-k", `gui/${process.getuid?.() ?? 501}/${label}`], {
-        stdout: "pipe",
-        stderr: "pipe",
-      });
-      const code = await proc.exited;
-      if (code !== 0) {
-        const err = await new Response(proc.stderr).text();
-        return { ok: false, reason: `launchctl kickstart ${label} exited ${code.toString()}: ${err.trim()}` };
+      const platform = cfg.platform ?? currentServicePlatform();
+      if (cfg.cortexConfigPath === undefined) {
+        return {
+          ok: false,
+          reason:
+            "cannot locate the cortex daemon service: no cortex config path threaded " +
+            "(internal: LivePortsConfig.cortexConfigPath unset)",
+        };
       }
-      return { ok: true };
+      const descriptorPath = findCortexDaemonDescriptor({
+        platform,
+        cortexConfigPath: cfg.cortexConfigPath,
+        launchAgentsDir: expandTilde("~/Library/LaunchAgents"),
+        systemdUserDir: expandTilde("~/.config/systemd/user"),
+        io: liveDaemonLocatorIO,
+      });
+      if (descriptorPath === undefined) {
+        const where = platform === "darwin" ? "~/Library/LaunchAgents" : "~/.config/systemd/user";
+        return {
+          ok: false,
+          reason:
+            `no cortex daemon service found referencing --config ${cfg.cortexConfigPath} ` +
+            `under ${where} — is the stack daemon installed? (arc upgrade Cortex)`,
+        };
+      }
+      let mgr;
+      try {
+        mgr = selectNatsServiceManager({ descriptorPath, platform, mutate, exec: bunExecRunner });
+      } catch (err) {
+        return { ok: false, reason: err instanceof Error ? err.message : String(err) };
+      }
+      return mgr.restart();
     },
   };
 }

--- a/src/cli/cortex/commands/network.ts
+++ b/src/cli/cortex/commands/network.ts
@@ -113,6 +113,16 @@ const DEFAULT_REGISTRY_URL = "https://network.meta-factory.ai";
  */
 const DEFAULT_CONFIG_PATH = "~/.config/cortex/cortex.yaml";
 
+/**
+ * #800 — the cortex.yaml the stack's CORTEX daemon loads (the join's `--config`,
+ * default {@link DEFAULT_CONFIG_PATH}). Threaded into the ports config so the
+ * daemon-restart can LOCATE the daemon's launchd/systemd service by its
+ * `--config` arg instead of guessing `ai.meta-factory.cortex.<stack-slug>`.
+ */
+function cortexConfigPathFromFlags(flags: Record<string, string | true>): string {
+  return expandTilde(optionalValueFlag(flags, "--config") ?? DEFAULT_CONFIG_PATH);
+}
+
 const NETWORK_ID_RE = /^[a-z][a-z0-9-]*$/;
 const PRINCIPAL_ID_RE = /^[a-z][a-z0-9-]*$/;
 // S5 — capability id grammar (`<domain>.<entity>`, matches the schema's
@@ -427,6 +437,8 @@ async function runLeave(
     ...(inputs.plistPath !== undefined && { plistPath: inputs.plistPath }),
     ...(inputs.unitPath !== undefined && { unitPath: inputs.unitPath }),
     platform: inputs.platform,
+    // #800 — locate the daemon service for the post-leave restart.
+    cortexConfigPath: cortexConfigPathFromFlags(flags),
   };
   const ports = applyRes.apply ? buildLivePorts(cfg) : buildDryRunPorts(cfg);
 
@@ -720,6 +732,7 @@ function portsConfig(
     natsConfigPath: optionalValueFlag(flags, "--nats-config"),
     plistPath: optionalValueFlag(flags, "--plist"),
     monitorUrl: optionalValueFlag(flags, "--monitor-url"),
+    cortexConfigPath: cortexConfigPathFromFlags(flags),
   };
 }
 
@@ -757,6 +770,8 @@ function portsConfigFromInputs(
     ...(inputs.unitPath !== undefined && { unitPath: inputs.unitPath }),
     platform: inputs.platform,
     monitorUrl: optionalValueFlag(flags, "--monitor-url"),
+    // #800 — locate the daemon service for the post-join restart.
+    cortexConfigPath: cortexConfigPathFromFlags(flags),
     // #762 — caps the join announces INTO the network so the principal joins
     // the roster (registry control-plane; never on the wire).
     announceCapabilities: inputs.announceCapabilities,


### PR DESCRIPTION
## Problem (#800)

`cortex network join`/`leave` restart the cortex daemon by a derived launchd label. v5.3.5's `resolveDaemonLabel` (#803) reads the **nats** plist's `<key>Label</key>` and maps `…nats.<suffix>` → `…cortex.<suffix>`. That assumes the nats plist follows the `ai.meta-factory.nats.<suffix>` naming.

On my stack the nats plist is the legacy **`ch.invisible.nats-server`** (Label `ch.invisible.nats-server` — no `.nats.`/`.cortex.` segment), so `resolveDaemonLabel` hits its *"unrecognised shape"* branch and returns the slug fallback `ai.meta-factory.cortex.default` → the restart still **113/503**s:

```
launchctl kickstart ai.meta-factory.cortex.default exited 113:
  Could not find service "ai.meta-factory.cortex.default" in domain for user gui: 503
```

This is exactly the namespace fragility flagged in the #803 discussion: **the plist-label shape is the wrong signal.**

## Fix — supersede `resolveDaemonLabel` with `--config` discovery

Use the `--config` filename as the authority. The stack daemon is the launchd service (macOS) / systemd user unit (Linux) whose argv carries `--config <cortexConfigPath>` — the cortex.yaml the join already reads via `--config`. Its `relay`/`mc` siblings under the same `ai.meta-factory.cortex.*` prefix don't carry it (relay runs `relay.ts start`, mc runs `run …/index.ts`), so the match is **unique**.

We discover the descriptor by that arg and restart via its real `<key>Label</key>` / unit id through the shared `selectNatsServiceManager` mechanism (#763). An unresolvable daemon returns a **clear, actionable reason** instead of kickstarting a fabricated label.

## Changes
- **new** `daemon-locator.ts` — pure, fs-injected matcher: `configArgValue`, plist/unit arg parsers, `findCortexDaemonDescriptor` (darwin + linux).
- `network-adapters.ts` — **replace** `resolveDaemonLabel` with `--config` discovery in `buildDaemonPort`; `LivePortsConfig` gains `cortexConfigPath`.
- `network.ts` — thread `cortexConfigPath` into the join, leave, status, and public ports configs.
- tests — `daemon-locator.test.ts` (16 cases incl. the `jc/default → cortex.meta-factory` resolution, relay/mc non-match, linux unit); `network-adapters.test.ts` daemon-port branches; **removed** the obsolete `resolveDaemonLabel` suite.

## AC (#800)
- [x] restart succeeds when slug ≠ plist suffix (`jc/default`, daemon `…cortex.meta-factory`) — incl. the `ch.invisible.nats-server` nats-plist case the suffix-swap couldn't handle.
- [x] test: restart target resolves from the configured service descriptor (`--config`), not `cortex.<slug>` nor the nats-plist label shape.

## Verification
- Rebased onto current `main` (v5.3.5); supersedes #803's `resolveDaemonLabel`.
- `bun test src/cli/cortex/commands/__tests__/` → **435 pass, 0 fail** · `bunx tsc --noEmit` clean · `eslint` clean

## Coordination / out of scope
- **#805** (join persists policy to `~/.config/cortex/stacks/<slug>.yaml`, ignoring `--config`, so a monolithic-`cortex.yaml` daemon never reads it) is **@Luna's** — not in this PR. Both bugs share the same "`--config` is the authority" root; the `cortexConfigPath` plumbing added here is reusable for #805's `stackConfigPath` fix.

Closes #800.

🤖 Generated with [Claude Code](https://claude.com/claude-code)