### PR TITLE
docs: config example → config-split format (refs #805/#807/#808)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,6 +121,44 @@ discord read                                          # Read last 10 messages
 
 Useful at the end of workflows to update the team. See `discord --help` for full command list.
 
+## Configuration files
+
+cortex is configured with the **config-split (multi-file) layout** — this is the
+**standard**. A stack's config is a directory the daemon points `--config` at; a
+pointer (sentinel) file's dirname selects the layout, and the boot composer
+(`composeRawConfig`, `src/common/config/loader.ts`) deep-merges the layers in a
+fixed precedence (later layers win on leaf keys), producing the SAME
+`LoadedConfig` the old single file produced.
+
+| Layer | Owns | Blast radius |
+|---|---|---|
+| `system/system.yaml` | substrate / transport: `claude`, `execution`, `attachments`, `paths`, **`nats` (incl. the `nats.subjects` landmine — ONE place), `bus`** | whole stack |
+| `network/*.yaml` | federation roster (`policy.federated.{registry, networks[]}`) — OPTIONAL | cross-principal |
+| `surfaces/surfaces.yaml` | shared surface-gateway bindings (Discord/Slack/Mattermost tokens) — OPTIONAL | cross-stack |
+| `stacks/*.yaml` | per-deployment `principal` / `stack` / `policy` / `capabilities` / `agents` / `github` | one stack |
+
+Precedence: `system/` → `network/*` (sorted) → `surfaces/` → `stacks/*` (sorted).
+`nats.subjects` lives in **exactly one place** (`system/system.yaml`) — a
+duplicate double-binds the boot subscriber and double-delivers every envelope
+(cortex#491). Never re-declare it in a stack file.
+
+- **Single-file `cortex.yaml` is LEGACY.** It still loads via the transitional
+  single-file fallback (no `system/system.yaml` marker present), so monolith
+  deployments keep working — but it is not the form a fresh install should adopt.
+- **Pointer-file naming is load-bearing.** cortex derives its single-instance
+  PID file from the `--config` basename; per-stack deployments MUST give each
+  pointer a per-stack name (`research.yaml`, `work.yaml`, …), never a uniform
+  `cortex.yaml`, or the second daemon collides on `cortex-cortex.pid`.
+
+**Canonical template:** [`docs/config-layout/`](docs/config-layout/) — copy that
+directory to `~/.config/cortex/<slug>/`, fill the `<REPLACE_ME>` markers, point
+your daemon at the pointer file. The repo-root `cortex.yaml.example` is the
+legacy single-file reference. See
+[`docs/config-layout/README.md`](docs/config-layout/README.md),
+[`docs/sop-stack-onboarding.md`](docs/sop-stack-onboarding.md) (Step 3 copies
+this template), and
+[`docs/migrations/0003-config-split-layout.md`](docs/migrations/0003-config-split-layout.md).
+
 
 ## Naming
 

--- a/agents-md.yaml
+++ b/agents-md.yaml
@@ -31,6 +31,8 @@ sections:
     file: docs/agents-md/discord-routing.md
   - position: "after:description"
     file: docs/agents-md/pai-integration.md
+  - position: "after:description"
+    file: docs/agents-md/config-files.md
   - position: "after:critical-rules"
     file: docs/agents-md/critical-rules.md
   - position: "after:sop-table"

--- a/cortex.yaml.example
+++ b/cortex.yaml.example
@@ -1,4 +1,26 @@
-# cortex.yaml — example configuration for a fresh install
+# =============================================================================
+# ⚠️  LEGACY SINGLE-FILE FORM — NOT the standard layout for new installs
+# =============================================================================
+#
+# This is the LEGACY single-file (monolith) `cortex.yaml` example. It still
+# LOADS — the boot composer falls back to single-file parsing when no
+# `system/system.yaml` marker is present (the transitional fallback, migration
+# 0003) — so existing deployments keep working unchanged.
+#
+# But the STANDARD layout is now the CONFIG-SPLIT (multi-file) layout. A fresh
+# install should NOT copy this file; copy the template directory instead:
+#
+#     cp -R docs/config-layout ~/.config/cortex/<your-stack-slug>
+#     # → fill the <REPLACE_ME> markers, point --config at the pointer file
+#
+# See **docs/config-layout/** (the canonical, self-documenting config template)
+# and docs/migrations/0003-config-split-layout.md for why the split exists (it
+# isolates the dangerous transport knobs — `nats.subjects` etc. — from routine
+# per-stack edits). This file is retained as the worked single-file reference
+# and for the single-file fallback path; it is no longer the recommended form.
+#
+# -----------------------------------------------------------------------------
+# cortex.yaml — example configuration (single-file form)
 #
 # Copy this file to one of the locations the cortex CLI scans (default:
 # `~/.config/cortex/cortex.yaml`) and replace every `<REPLACE_ME>` marker

--- a/docs/agents-md/config-files.md
+++ b/docs/agents-md/config-files.md
@@ -1,0 +1,37 @@
+## Configuration files
+
+cortex is configured with the **config-split (multi-file) layout** — this is the
+**standard**. A stack's config is a directory the daemon points `--config` at; a
+pointer (sentinel) file's dirname selects the layout, and the boot composer
+(`composeRawConfig`, `src/common/config/loader.ts`) deep-merges the layers in a
+fixed precedence (later layers win on leaf keys), producing the SAME
+`LoadedConfig` the old single file produced.
+
+| Layer | Owns | Blast radius |
+|---|---|---|
+| `system/system.yaml` | substrate / transport: `claude`, `execution`, `attachments`, `paths`, **`nats` (incl. the `nats.subjects` landmine — ONE place), `bus`** | whole stack |
+| `network/*.yaml` | federation roster (`policy.federated.{registry, networks[]}`) — OPTIONAL | cross-principal |
+| `surfaces/surfaces.yaml` | shared surface-gateway bindings (Discord/Slack/Mattermost tokens) — OPTIONAL | cross-stack |
+| `stacks/*.yaml` | per-deployment `principal` / `stack` / `policy` / `capabilities` / `agents` / `github` | one stack |
+
+Precedence: `system/` → `network/*` (sorted) → `surfaces/` → `stacks/*` (sorted).
+`nats.subjects` lives in **exactly one place** (`system/system.yaml`) — a
+duplicate double-binds the boot subscriber and double-delivers every envelope
+(cortex#491). Never re-declare it in a stack file.
+
+- **Single-file `cortex.yaml` is LEGACY.** It still loads via the transitional
+  single-file fallback (no `system/system.yaml` marker present), so monolith
+  deployments keep working — but it is not the form a fresh install should adopt.
+- **Pointer-file naming is load-bearing.** cortex derives its single-instance
+  PID file from the `--config` basename; per-stack deployments MUST give each
+  pointer a per-stack name (`research.yaml`, `work.yaml`, …), never a uniform
+  `cortex.yaml`, or the second daemon collides on `cortex-cortex.pid`.
+
+**Canonical template:** [`docs/config-layout/`](docs/config-layout/) — copy that
+directory to `~/.config/cortex/<slug>/`, fill the `<REPLACE_ME>` markers, point
+your daemon at the pointer file. The repo-root `cortex.yaml.example` is the
+legacy single-file reference. See
+[`docs/config-layout/README.md`](docs/config-layout/README.md),
+[`docs/sop-stack-onboarding.md`](docs/sop-stack-onboarding.md) (Step 3 copies
+this template), and
+[`docs/migrations/0003-config-split-layout.md`](docs/migrations/0003-config-split-layout.md).

--- a/docs/config-layout/README.md
+++ b/docs/config-layout/README.md
@@ -1,9 +1,40 @@
-# Reference multi-file config layout (IAW CFG)
+# The cortex config template — config-split (multi-file) layout
 
-This directory is a **documented, loadable reference** for the multi-file
-`cortex` config layout introduced by the IAW **CFG** epic
-(`docs/plan-internet-of-agentic-work.md` §13.1). It is an example/fixture, not a
-live deployment — copy it to your config dir and fill in real tokens/keys.
+**This directory IS the canonical, copy-paste-and-go config template that ships
+with cortex.** The multi-file **config-split** layout is the **standard** way to
+configure a cortex stack. The single-file `cortex.yaml` (repo root
+`cortex.yaml.example`) is a **legacy / transitional fallback** — it still loads,
+but new installs should land here.
+
+## Quick start (copy → fill → point)
+
+```bash
+# 1. Copy this directory to your config dir, naming it after your stack slug
+cp -R docs/config-layout ~/.config/cortex/research
+
+# 2. Fill in every <REPLACE_ME> marker across the files below
+#    (secrets/ids: principal id, stack signing keys, Discord token/guild/channels)
+$EDITOR ~/.config/cortex/research/{system/system.yaml,stacks/research.yaml,surfaces/surfaces.yaml}
+
+# 3. Point your daemon at the POINTER (sentinel) file — its dirname selects the layout
+cortex start --config ~/.config/cortex/research/research.yaml
+```
+
+The pointer file [`research.yaml`](./research.yaml) is the file `--config`
+points at; **its contents are ignored** — only its dirname selects the layout,
+and its basename names the single-instance PID file (so per-stack deployments
+MUST give each pointer a per-stack name — see the migration note below).
+
+> **config-split is the standard layout.** The single-file `cortex.yaml` form
+> (`cortex.yaml.example`) still loads via the transitional single-file fallback
+> (no `system/system.yaml` marker present), so existing monolith deployments
+> keep working unchanged — but it is **legacy**, not the form a fresh install
+> should adopt. When in doubt, copy this directory.
+
+This directory is also a **loadable reference/fixture** for the config-split
+layout introduced by the IAW **CFG** epic
+(`docs/plan-internet-of-agentic-work.md` §13.1) — every file parses cleanly out
+of the box with `<REPLACE_ME>` markers standing in for real tokens/keys.
 
 ## Why split the config
 
@@ -91,15 +122,35 @@ present for the same platform, the surfaces.yaml binding **wins on leaf keys**
 agent absent from every stack fails **loudly** rather than silently dropping a
 credential.
 
-## This example
+## The files in this template
 
-- [`system/system.yaml`](./system/system.yaml) — the substrate layer, with the
-  prominently-commented `nats.subjects` block (kept at the safe `[]` default).
-- [`surfaces/surfaces.yaml`](./surfaces/surfaces.yaml) — the surface binding map;
-  binds the `ivy` agent's Discord presence (Slack + Mattermost commented out).
-- [`stacks/research.yaml`](./stacks/research.yaml) — one per-deployment stack
-  (principal + one agent), carrying no transport knobs and an EMPTY
-  `presence: {}` — its Discord binding folds in from `surfaces.yaml`.
+| File | Layer | What to fill in |
+|---|---|---|
+| [`research.yaml`](./research.yaml) | pointer | nothing — rename it after your stack slug; contents ignored, dirname selects the layout, basename names the PID file |
+| [`system/system.yaml`](./system/system.yaml) | substrate / transport | `nats.url` + identity; leave `nats.subjects` at the safe `[]` default |
+| [`network/example-network.yaml`](./network/example-network.yaml) | federation roster (OPTIONAL) | peers, registry, accept-subjects — only if you federate; inert until uncommented |
+| [`surfaces/surfaces.yaml`](./surfaces/surfaces.yaml) | shared surface bindings (OPTIONAL) | Discord/Slack/Mattermost `token` / `guild` / channels for each agent |
+| [`stacks/research.yaml`](./stacks/research.yaml) | per-deployment stack | `principal`, `stack` signing keys, `policy` (principal-only pattern), `agents`, `github.repos` |
 
-`network/` is omitted here — the network roster lands with the federation
-phases; it is an optional layer the composer skips when absent.
+- **`stacks/research.yaml`** is the file you edit daily. It carries the
+  `<REPLACE_ME>` markers for your principal id, stack signing keys, the
+  principal-only `policy` block (the human principal's Discord id under
+  `platform_ids.discord`), the agent, and `github.repos`. Its agent declares an
+  EMPTY `presence: {}` — the Discord binding folds in from `surfaces.yaml`
+  (style A). The inline-presence fallback (style B) is shown commented at the
+  bottom of that file.
+- **`surfaces/surfaces.yaml`** binds the `ivy` agent's Discord presence (Slack +
+  Mattermost commented out) — the credential surface-of-truth.
+- **`network/example-network.yaml`** documents the federation layer
+  (`policy.federated.{registry, networks[]}`). It is OPTIONAL and ships
+  fully commented (inert) — a non-federating stack omits the `network/` dir
+  entirely and the composer skips the layer. Read the network SOPs
+  (`docs/sop-network-join.md`, `docs/sop-federation-onboarding.md`,
+  `docs/sop-stack-onboarding.md`) before enabling anything there.
+
+See [`docs/sop-stack-onboarding.md`](../sop-stack-onboarding.md) for the
+end-to-end stand-up procedure (this template is the config it tells you to copy
+at Step 3), and
+[`docs/migrations/0003-config-split-layout.md`](../migrations/0003-config-split-layout.md)
+for the split rationale, the loader's precedence rules, and the PID-collision
+landmine.

--- a/docs/config-layout/network/example-network.yaml
+++ b/docs/config-layout/network/example-network.yaml
@@ -1,0 +1,71 @@
+# =============================================================================
+# network/example-network.yaml — the federation roster layer (IAW CFG)
+# =============================================================================
+#
+# OPTIONAL LAYER. This is the cross-PRINCIPAL layer of the multi-file config
+# layout. A stack that runs purely local (no federation) does not need a
+# `network/` directory at all — the composer skips the layer when it is absent,
+# and the stack rides its own primary NATS link only.
+#
+# Files here carry ONE fragment of `policy.federated` — the federation roster
+# the composer deep-merges into the stack's policy block (sorted by filename, so
+# split your networks across files freely). Blast radius: CROSS-PRINCIPAL — a
+# wrong peer pubkey or accept-subject here lets (or blocks) another principal's
+# traffic, so this layer is reviewed as a federation change.
+#
+# The shape below is the SAME `policy.federated.{registry, networks[]}` the
+# single-file `cortex.yaml` carries inline; here it just lives in its own layer.
+# Federation is the IoAW federation phases (plan §13) — see the network SOPs
+# before enabling anything here:
+#   - docs/sop-network-join.md          (join / multi-stack / status / leave)
+#   - docs/sop-stack-onboarding.md      (stand up + federate a stack; operator-mode bus)
+#   - docs/sop-federation-onboarding.md (peer-principal onboarding + trust)
+#
+# DO NOT enable a network here until you have read those SOPs. A federating
+# stack's bus MUST be operator-mode (an anonymous / hard-isolated bus cannot
+# federate — the leaf remote binds an account the server does not know and
+# nats-server crashes). `cortex network join` fails fast on such a bus (#794).
+#
+# Replace every <REPLACE_ME> before enabling. Until then this file is inert
+# (the whole `policy:` block below is commented out, so the layer composes to a
+# no-op and the stack stays local-only).
+
+# policy:
+#   federated:
+#     # registry — the network-registry endpoint + DD-9 trust pin.
+#     # `cortex network join <network>` (#753) derives its --registry-url /
+#     # --registry-pubkey from here, so the one-liner needs no registry flags.
+#     registry:
+#       url: https://registry.meta-factory.ai
+#       # OPTIONAL pinned Ed25519 pubkey (base64, 44 chars). Omit for TOFU on
+#       # first boot; paste the pinned value here for zero-TOFU.
+#       # pubkey: <REPLACE_ME_REGISTRY_PUBKEY>
+#
+#     networks:
+#       - id: research-collab
+#         # routing label / link-pool de-dup key. Two networks sharing a
+#         # leaf_node name share ONE physical link, so their `nats:` blocks must
+#         # be consistent (byte-identical, or omitted on all but one).
+#         leaf_node: nats-leaf-research
+#         # OPTIONAL — a dedicated leaf-node link for this network (F-3a, #657).
+#         # When ABSENT the network rides the primary link (system/system.yaml
+#         # `nats:`). Only url / credsPath / name are accepted here.
+#         nats:
+#           url: nats://research.example.com:4222
+#           credsPath: ~/.config/cortex/creds/research.creds
+#         # peers — the other principals' stacks in this trust closure.
+#         peers:
+#           - principal_id: <REPLACE_ME_PEER_PRINCIPAL>     # e.g. jcfischer
+#             stack_id: <REPLACE_ME_PEER_STACK>             # e.g. jcfischer/sage-host
+#             principal_pubkey: <REPLACE_ME_PEER_PUBKEY>    # peer stack NKey pub (U…, 56 chars)
+#         # accept_subjects — the federated.* subjects this stack will RECEIVE.
+#         accept_subjects:
+#           - federated.research-collab.>
+#         # deny_subjects — explicit blocks (evaluated before accept).
+#         deny_subjects: []
+#         # announce_capabilities — which of this stack's capabilities[] are
+#         # advertised to the network registry.
+#         announce_capabilities:
+#           - code-review.typescript
+#         # max_hop — federation hop budget (1 = direct peers only).
+#         max_hop: 1

--- a/docs/config-layout/research.yaml
+++ b/docs/config-layout/research.yaml
@@ -1,0 +1,37 @@
+# =============================================================================
+# research.yaml — the POINTER (sentinel) file (IAW CFG / migration 0003)
+# =============================================================================
+#
+# This is the file your cortex daemon's `--config` flag points at:
+#
+#     cortex start --config ~/.config/cortex/research/research.yaml
+#
+# Its CONTENTS ARE IGNORED. The loader does NOT parse this file for config — it
+# uses only its **dirname** to select the layout. When the composer
+# (`composeRawConfig`, src/common/config/loader.ts) sees the marker file
+# `system/system.yaml` in this directory, it switches to the multi-file layout
+# and deep-merges, in this fixed precedence:
+#
+#     system/system.yaml      (base — substrate / transport)
+#     network/*.yaml          (federation roster, sorted by filename)
+#     surfaces/surfaces.yaml  (shared surface-gateway bindings — CFG.c / GW)
+#     stacks/*.yaml           (per-deployment policy / capabilities / agents)
+#
+# Two things the pointer file's NAME is load-bearing for (migration 0003):
+#
+#  1. It selects the directory, via `dirname(--config)`. Point `--config` here
+#     and the composer reads `system/`, `network/`, `surfaces/`, `stacks/`
+#     beside it.
+#
+#  2. It names the single-instance PID file. cortex derives its PID-file name
+#     from the `--config` BASENAME (`cortex-<basename>.pid`). If you run more
+#     than one stack, each pointer file MUST be named per-stack
+#     (`research.yaml`, `work.yaml`, …) — NOT a uniform `cortex.yaml` — or the
+#     second daemon to start collides on `cortex-cortex.pid` and aborts with
+#     `cortex: already running`. (See docs/migrations/0003-config-split-layout.md
+#     — "The PID-collision landmine".)
+#
+# So: name this file after the stack, keep it next to system/ + stacks/, and
+# leave the body empty (or a one-line note like the marker below). The dirname
+# does the work.
+pointer: true   # cosmetic marker only — the loader never reads this value

--- a/docs/config-layout/stacks/research.yaml
+++ b/docs/config-layout/stacks/research.yaml
@@ -1,38 +1,164 @@
 # =============================================================================
-# stacks/research.yaml — a per-deployment stack layer (reference example)
+# stacks/research.yaml — a per-deployment stack layer (the file you EDIT daily)
 # =============================================================================
 #
-# The MOST SPECIFIC layer. One stack only — routine per-stack edits land here
-# (capabilities, policy, agents, the assistant prose path). Blast radius is this
-# stack alone, so this is the file you touch for day-to-day work — deliberately
-# NOT the place the dangerous transport knobs (system.yaml) live.
+# The MOST SPECIFIC layer. One stack only. Routine per-stack edits land here —
+# `principal`, `stack` identity, `capabilities`, `policy`, `agents`,
+# `github.repos`. Blast radius is THIS stack alone, which is exactly why the
+# dangerous transport knobs (`nats`, `bus`, `claude`, `execution`, …) do NOT
+# live here — they live in `system/system.yaml`, one layer up, reviewed as a
+# transport change. A stack file never re-declares the `nats.subjects` list;
+# that is the structural fix for the double-message problem (cortex#491).
 #
-# This reference carries the principal block + a single agent so the layout
-# composes to a complete, valid `LoadedConfig`. In a real multi-stack
-# deployment, the principal block can live in any layer (it is most natural in
-# system.yaml when one principal owns every stack on the host); it is kept here
-# to make this example self-contained.
+# This reference is complete + loadable: copy it, replace every <REPLACE_ME>,
+# and it composes (with system/ + surfaces/) into a valid LoadedConfig.
 #
-# Note what is ABSENT: no `nats.subjects`, no `nats` transport block at all, no
-# surface tokens. Transport lives in system.yaml; surface bindings live in
-# surfaces.yaml (CFG.c / GW) and the composer FOLDS them back into this agent's
-# `presence.discord` block at load. A stack file never re-declares the subject
-# list — that is the structural fix for the double-message problem.
-#
-# The agent below declares an EMPTY `presence: {}` — its surface binding (the
-# Discord token + guild + channels) lives in `surfaces/surfaces.yaml`, keyed by
-# this agent's id (`ivy`). Non-binding presence knobs (e.g. `contextDepth`,
-# `surfaceSubjects`) could still be declared here inline; the surfaces.yaml
-# binding merges on top, winning on the credential leaf keys.
+# Two surface-binding styles are shown:
+#   (A) the agent declares an EMPTY `presence: {}` and its Discord binding folds
+#       in from `surfaces/surfaces.yaml` (the CFG.c / shared-gateway path — the
+#       recommended layout; tokens live in ONE file); OR
+#   (B) the agent carries its `presence.discord` block INLINE here (the
+#       transitional fallback the three live single-file stacks take).
+# Style (A) is active below; style (B) is shown commented at the bottom.
 
+# -----------------------------------------------------------------------------
+# principal — who is running this stack (id + Discord identity)
+# -----------------------------------------------------------------------------
+# `id` surfaces as the `{principal}` segment in NATS subjects
+# (`local.{principal}.>`). Lowercase, letter-prefixed: `^[a-z][a-z0-9-]*$`.
+# In a real multi-stack deployment the principal block can live in any layer
+# (most natural in system.yaml when one principal owns every stack on the host);
+# it is kept here to make this example self-contained.
 principal:
-  id: andreas
-  displayName: Andreas
+  id: andreas               # <REPLACE_ME>: your short slug
+  displayName: Andreas      # <REPLACE_ME>
+  discordId: "<REPLACE_ME>" # <REPLACE_ME>: your numeric Discord snowflake
 
+# -----------------------------------------------------------------------------
+# stack — identity of THIS deployment within the principal (signing identity)
+# -----------------------------------------------------------------------------
+# Stack signing is ON by default. Without an `nkey_seed_path` cortex publishes
+# UNSIGNED and peers running signed-chain verification reject the traffic.
+# `arc upgrade Cortex` auto-provisions a seed at `nkey_seed_path` if missing.
+# See docs/sop-stack-identity.md for rotation + threat-model background.
+stack:
+  id: andreas/research                          # <REPLACE_ME>: keep the principal half in sync with principal.id
+  nkey_seed_path: ~/.config/nats/cortex-research.nk   # SU…-prefixed NATS user seed, chmod 600
+  # 56-char base32 NKey public key (U…-prefixed). Pin it so boot catches a
+  # rotated-seed split-brain. Omit on first install; paste from the cortex log
+  # line `stack signing key staged — principal=…` after first boot.
+  nkey_pub: <REPLACE_ME>                        # <REPLACE_ME>: U-prefixed pubkey from the seed
+
+# -----------------------------------------------------------------------------
+# capabilities — STACK CATALOG (source of truth for capability-dispatch)
+# -----------------------------------------------------------------------------
+# Each entry is the canonical declaration the dispatch consumer + network
+# registry consult. Every id an agent lists under `runtime.capabilities[]` MUST
+# also appear here (cross-validated at src/common/types/cortex-config.ts) — an
+# unresolved reference fails config load. `chat` is the baseline keyword
+# capability; add review/skill flavors as your agents provide them.
+capabilities:
+  - id: chat
+    description: Conversational dispatch (no-prefix synchronous chat)
+    provided_by: [ivy]
+
+# -----------------------------------------------------------------------------
+# policy — principal + role registry consumed by the PolicyEngine
+# -----------------------------------------------------------------------------
+# PRINCIPAL-ONLY pattern (CRITICAL for any guild others can join):
+# list ONLY the human principal in `principals[]` with their Discord id via
+# `platform_ids.discord`. A non-principal's @mention resolves to
+# authorIsPrincipal=false (non-spoofable, cortex#729) → hard-blocked silently
+# (a `system.access.denied` audit envelope on the bus, NO channel post). The
+# assistant answers the principal and no one else.
+#
+# The stack's OWN signing identity (the agent `ivy`) is also a principal here so
+# it can sign/dispatch; it carries no platform_ids (it is not a human).
+policy:
+  principals:
+    - id: ivy                      # the stack's own signing identity (the agent)
+      home_principal: andreas      # <REPLACE_ME>: keep in sync with principal.id
+      home_stack: andreas/research # <REPLACE_ME>: keep in sync with stack.id
+      nkey_pub: <REPLACE_ME>       # <REPLACE_ME>: ivy's U-prefixed pubkey (matches agents[].nkey_pub)
+      role:
+        - principal-role
+      trust: []
+      platform_ids: {}
+    - id: andreas                  # <REPLACE_ME>: the human — the ONLY human principal
+      home_principal: andreas      # <REPLACE_ME>
+      home_stack: andreas/research # <REPLACE_ME>
+      role:
+        - principal-role
+      trust: []
+      platform_ids:
+        discord:
+          - "<REPLACE_ME>"         # <REPLACE_ME>: your numeric Discord id
+  roles:
+    - id: principal-role
+      capabilities:
+        - dispatch.ivy             # may dispatch to the ivy agent
+        - keyword.chat             # no-prefix synchronous chat
+        - keyword.async            # async: fire-and-forget
+        - keyword.team             # team: spawn a multi-agent team
+        - tool.bash
+        - tool.read
+        - tool.glob
+        - tool.grep
+
+# -----------------------------------------------------------------------------
+# agents — first-class agents on this stack
+# -----------------------------------------------------------------------------
+# One agent (`ivy`). Style (A): its surface binding (token/guild/channels) lives
+# in surfaces/surfaces.yaml keyed by this agent's id, so `presence` is EMPTY and
+# folds in at load. Non-binding presence knobs (contextDepth, surfaceSubjects)
+# MAY still be declared inline; the surfaces.yaml binding merges on top, winning
+# on the credential leaf keys.
 agents:
   - id: ivy
     displayName: Ivy
     persona: ./personas/ivy.md
+    # OPTIONAL but REQUIRED for NKey-verified bot↔bot dispatch: ivy's Ed25519
+    # public key (U-prefixed) from its NATS creds. Without it a peer signing as
+    # did:mf:ivy is rejected `principal_has_no_nkey_pub` (falls back to
+    # platform-id trust only). Must match the policy principal `ivy` above.
+    nkey_pub: <REPLACE_ME>         # <REPLACE_ME>: ivy's U-prefixed pubkey
     roles: []
     trust: []
+    runtime:
+      substrate: claude-code
+      mode: in-process
+      capabilities:
+        - chat                     # MUST also appear in the top-level capabilities[] catalog
+    # Style (A): EMPTY — the Discord binding folds in from surfaces/surfaces.yaml.
     presence: {}
+
+# -----------------------------------------------------------------------------
+# github — webhook ingestion + which repos this stack is scoped to
+# -----------------------------------------------------------------------------
+# `repos[]` scopes the agent's repo context (Discord channel routing matches a
+# channel name against these short names). Leave `webhookSecret` empty to keep
+# webhooks off; paste the GitHub App HMAC secret once you wire it.
+github:
+  webhookSecret: ""                # <REPLACE_ME> once you wire the GitHub App; empty = webhooks off
+  repos: []                        # <REPLACE_ME>: e.g. [{ short: cortex, full: the-metafactory/cortex }]
+
+# =============================================================================
+# Style (B) — INLINE presence (the transitional fallback; DELETE style (A)'s
+# `presence: {}` above and DELETE surfaces/surfaces.yaml if you use this). Shown
+# commented so the agent reads the full Discord binding shape in one place.
+# =============================================================================
+#
+#   presence:
+#     discord:
+#       enabled: true
+#       dmOwner: false                 # true only if this stack owns the principal's DMs
+#       token: <REPLACE_ME>            # the bot token (chmod 600 the file)
+#       guildId: "<REPLACE_ME>"
+#       agentChannelId: "<REPLACE_ME>" # nominal default; the assistant answers @mentions guild-wide
+#       logChannelId: "<REPLACE_ME>"
+#       contextDepth: 10
+#       # Inbound task envelopes must NOT be surfaced here (would render raw
+#       # envelope JSON to Discord — the cortex#477/#479 leak). Review OUTPUT is
+#       # rendered by the review-sink as deterministic markdown. Leave empty
+#       # unless an agent must surface a non-task subject.
+#       surfaceSubjects: []

--- a/docs/config-layout/stacks/research.yaml
+++ b/docs/config-layout/stacks/research.yaml
@@ -46,8 +46,9 @@ stack:
   nkey_seed_path: ~/.config/nats/cortex-research.nk   # SU…-prefixed NATS user seed, chmod 600
   # 56-char base32 NKey public key (U…-prefixed). Pin it so boot catches a
   # rotated-seed split-brain. Omit on first install; paste from the cortex log
-  # line `stack signing key staged — principal=…` after first boot.
-  nkey_pub: <REPLACE_ME>                        # <REPLACE_ME>: U-prefixed pubkey from the seed
+  # line `stack signing key staged — principal=…` after first boot. The all-A
+  # value below is a valid-FORMAT placeholder so the example loads — REPLACE it.
+  nkey_pub: UAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA  # <REPLACE_ME>: U-prefixed pubkey from the seed
 
 # -----------------------------------------------------------------------------
 # capabilities — STACK CATALOG (source of truth for capability-dispatch)
@@ -79,7 +80,7 @@ policy:
     - id: ivy                      # the stack's own signing identity (the agent)
       home_principal: andreas      # <REPLACE_ME>: keep in sync with principal.id
       home_stack: andreas/research # <REPLACE_ME>: keep in sync with stack.id
-      nkey_pub: <REPLACE_ME>       # <REPLACE_ME>: ivy's U-prefixed pubkey (matches agents[].nkey_pub)
+      nkey_pub: UAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA  # <REPLACE_ME>: ivy's U-prefixed pubkey (matches agents[].nkey_pub)
       role:
         - principal-role
       trust: []
@@ -121,7 +122,7 @@ agents:
     # public key (U-prefixed) from its NATS creds. Without it a peer signing as
     # did:mf:ivy is rejected `principal_has_no_nkey_pub` (falls back to
     # platform-id trust only). Must match the policy principal `ivy` above.
-    nkey_pub: <REPLACE_ME>         # <REPLACE_ME>: ivy's U-prefixed pubkey
+    nkey_pub: UAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA  # <REPLACE_ME>: ivy's U-prefixed pubkey
     roles: []
     trust: []
     runtime:

--- a/docs/sop-stack-onboarding.md
+++ b/docs/sop-stack-onboarding.md
@@ -75,6 +75,16 @@ lsof -nP -iTCP:<port> -sTCP:LISTEN | grep nats   # verify up
 
 ### Step 3 — Write the cortex config (`~/.config/cortex/<slug>/`)
 
+**Start from the canonical template.** [`docs/config-layout/`](config-layout/) is
+the self-documenting config-split template — copy it and fill the `<REPLACE_ME>`
+markers rather than hand-rolling the directory:
+
+```bash
+cp -R docs/config-layout ~/.config/cortex/<slug>
+# rename the pointer file after your slug, then fill the <REPLACE_ME> markers
+mv ~/.config/cortex/<slug>/research.yaml ~/.config/cortex/<slug>/<slug>.yaml
+```
+
 Multi-file layout (`composer` reads `system/` + `stacks/`):
 
 - **`<slug>.yaml`** — pointer (contents ignored; the dirname selects the layout).

--- a/scripts/check-carveouts.sh
+++ b/scripts/check-carveouts.sh
@@ -129,6 +129,13 @@ ALLOWLIST_PATHS=(
   # cutover design doc carry it as a kept role-id string.
   'src/common/policy/'
   'docs/design-policy-cutover.md'
+  # cortex.yaml.example policy roles — the `operator` capability literal in the
+  # principal role's `capabilities[]` is the reserved authz CAPABILITY token the
+  # PolicyEngine checks (`allow("operator")` in src/common/policy/resolve-access.ts,
+  # already allowlisted above), NOT the principal vocabulary. Renaming it would
+  # break the worked example. Same class as the `src/common/policy/` cluster.
+  # RETIRE: with the `operator` policy-capability literal itself.
+  'cortex.yaml.example'
   # User-auth RBAC tier `viewer|operator|admin` — the MC authorization role
   # (CONTEXT.md, #513). A persisted privilege level, never the principal.
   'src/surface/mc/worker/src/user-auth/'


### PR DESCRIPTION
## What

Make the **config-split (multi-file) layout** the canonical, self-documenting config example that ships with cortex — so a fresh install (and contributors) land on the new format, not the legacy monolith. (This is the layout JC / #805 / #807 missed by copying the old single-file example.)

Docs/config + CLAUDE.md only — **no `src/` changes**.

## Changes

- **`docs/config-layout/` finished into a complete, copy-paste-and-go template:**
  - `research.yaml` (NEW) — the **pointer/sentinel** file: contents ignored, dirname selects the layout, basename names the PID file (per-stack naming is load-bearing — migration 0003).
  - `stacks/research.yaml` — fleshed out from a 38-line stub into a real, fully-commented stack: `principal` (id+discordId), `stack` signing (`nkey_seed_path`/`nkey_pub`), `capabilities`, **`policy`** (the **principal-only** pattern — human principal via `platform_ids.discord` + roles), **`agents`** (one agent, presence style A = `surfaces.yaml` fold, style B = inline shown commented), `github.repos`. `<REPLACE_ME>` markers for all secrets/ids.
  - `network/example-network.yaml` (NEW) — the **federation layer** fragment (`policy.federated.{registry, networks[]}`), inert until uncommented; references the network SOPs.
  - `README.md` — rewritten as the **out-of-the-box template guide**: copy dir → fill markers → point daemon at the pointer file. States plainly that **config-split is the standard; single-file `cortex.yaml` is legacy/transitional.**
- **`cortex.yaml.example`** — prominent **LEGACY** header (still loads via the single-file fallback; copy `docs/config-layout/` instead). Not deleted.
- **`docs/agents-md/config-files.md`** (NEW) + `agents-md.yaml` (`after:description`) — durable CLAUDE.md **"Configuration files"** section (layout + per-layer blast radius + single-file=legacy + pointers). **CLAUDE.md regenerated** via compass `generateRules()` targeting the cortex worktree only (NOT `arc upgrade compass`).
- **`docs/sop-stack-onboarding.md`** — Step 3 now copies `docs/config-layout/` as the canonical template.
- **`scripts/check-carveouts.sh`** — allowlist `cortex.yaml.example`: the `operator` policy **capability literal** is the reserved authz token (`allow("operator")` in `resolve-access.ts`), same class as the already-allowlisted `src/common/policy/` cluster — not the principal vocab.

## Gates

- `git diff --name-only origin/main | bash scripts/check-carveouts.sh -` → **PASS**.
- All `docs/config-layout/*.yaml` parse cleanly (YAML.parse).

Refs #805 #807 #808

🤖 Generated with [Claude Code](https://claude.com/claude-code)