### PR TITLE
feat(cortex): cortex stack create — born-aligned, unique stack scaffold (closes #808)

### DIFF
--- a/docs/agents-md/network-management.md
+++ b/docs/agents-md/network-management.md
@@ -1,6 +1,19 @@
-## Network Management
+## Platform Management
 
-`cortex network` is the control plane for a stack's network lifecycle (the "feel like TCP/IP" join, #738). A **network** is a federation of principals whose stacks interconnect at the NATS leaf-node layer.
+`cortex stack` + `cortex network` are the control plane for a stack's full lifecycle: stand one up locally (`stack`), then federate it onto a network (`network`).
+
+### Standing up a stack
+
+`cortex stack create <slug>` scaffolds a config-split stack skeleton **born aligned** — the dir basename, the slug, and the trailing segment of `stack.id` are all the same — so the slug↔`stack.id` drift the install-time `warn_stack_identity_drift` detector catches ([ADR-0004](docs/adr/0004-stack-slug-authority.md)) can never form for a stack created this way. It is the prevent-side complement to that detector.
+
+| Command | Purpose |
+|---|---|
+| `cortex stack create <slug> [--principal <id>] [--apply]` | Scaffold a born-aligned (dir==slug==`stack.id` trailing segment), unique-within-principal config-split stack from the `docs/config-layout/` template (#808). Sets `stack.nkey_seed_path` to the conventional path — `arc upgrade Cortex` auto-provisions the seed. Dry-run by default; never overwrites an existing dir. |
+| `cortex stack list [--config-dir <path>]` | List discovered stacks with their `stack.id` and an aligned/DRIFT flag. |
+
+### Network lifecycle
+
+A **network** is a federation of principals whose stacks interconnect at the NATS leaf-node layer ("feel like TCP/IP" join, #738).
 
 | Command | Purpose |
 |---|---|
@@ -12,9 +25,10 @@
 
 The one-rule essentials:
 
+- **Stacks are scaffolded with `cortex stack create`** — born aligned (dir==slug==`stack.id` trailing segment) so drift can't form, and unique within the principal (it refuses a dir collision OR a duplicate `stack.id`). Dry-run by default; pass `--apply` to write.
 - **Networks are created with `cortex network create`, not SQL.** The registry's `POST /networks/<id>` is fail-closed: the admin pubkey must be on `REGISTRY_ADMIN_PUBKEYS` or it returns `503 admin_not_configured` / `403 admin_not_authorized`.
 - **A principal's 2nd+ stack joins with `--principal-seed <root>`** (the FIRST stack's seed, #791). The add-stack claim is root-signed and fetch-merges the principal's existing stacks so they survive; on the standalone `provision-stack register` path the pinned `--registry-pubkey` is also required. Omit `--principal-seed` for a first-stack join.
 - **A federating stack's bus must be operator-mode** — it must define the NSC operator + the account the leaf binds to (mirror `~/.config/nats/local.conf`). An **anonymous / hard-isolated** bus (the `halden` / `community` pattern) **cannot federate**: the leaf remote names an account the server doesn't know and `nats-server` crashes. The #794 fix makes `cortex network join` refuse (fail-fast) on such a bus rather than taking it offline — convert the bus to operator-mode first.
-- **`join` / `leave` / `create` default to dry-run** — they print the intended actions and touch nothing. Pass `--apply` to mutate the live deployment.
+- **`stack create` / network `join` / `leave` / `create` default to dry-run** — they print the intended actions and touch nothing. Pass `--apply` to mutate the live deployment.
 
-SOPs: [`docs/sop-network-join.md`](docs/sop-network-join.md) (join / multi-stack / status / leave), [`docs/sop-stack-onboarding.md`](docs/sop-stack-onboarding.md) (stand up a stack + federate it; §B0.1 operator-mode bus), [`docs/sop-federation-onboarding.md`](docs/sop-federation-onboarding.md) (peer-principal onboarding).
+SOPs: [`docs/sop-stack-onboarding.md`](docs/sop-stack-onboarding.md) (stand up a stack with `cortex stack create`, then federate it; §B0.1 operator-mode bus), [`docs/sop-network-join.md`](docs/sop-network-join.md) (join / multi-stack / status / leave), [`docs/sop-federation-onboarding.md`](docs/sop-federation-onboarding.md) (peer-principal onboarding).

--- a/docs/config-layout/README.md
+++ b/docs/config-layout/README.md
@@ -6,6 +6,33 @@ configure a cortex stack. The single-file `cortex.yaml` (repo root
 `cortex.yaml.example`) is a **legacy / transitional fallback** — it still loads,
 but new installs should land here.
 
+## Even easier: `cortex stack create <slug>`
+
+This whole copy → fill → align dance is what `cortex stack create` automates
+(#808). It scaffolds this exact skeleton **born aligned** — the dir basename,
+the slug, and `stack.id`'s trailing segment are all the same, so the
+slug↔`stack.id` drift the install-time `warn_stack_identity_drift` detector
+catches ([ADR-0004](../adr/0004-stack-slug-authority.md)) can never form — and
+**unique within the principal** (it refuses a dir collision or a duplicate
+`stack.id`):
+
+```bash
+# Dry-run first (DEFAULT — prints the file set it would write, touches nothing):
+cortex stack create research --principal andreas
+
+# Write it for real:
+cortex stack create research --principal andreas --apply
+
+# Then provision the signing seed → point your daemon → (optionally) federate:
+arc upgrade Cortex                                              # auto-provisions ~/.config/nats/cortex-research.nk
+cortex start --config ~/.config/cortex/research/research.yaml
+cortex network join <network>                                  # federate (optional)
+```
+
+It fills in your real `slug` / `principal` / `agent`, keeping `<REPLACE_ME>`
+only for true secrets (Discord token/guild/channels + the post-first-boot
+`nkey_pub`). The manual copy steps below remain the fallback.
+
 ## Quick start (copy → fill → point)
 
 ```bash

--- a/docs/sop-stack-onboarding.md
+++ b/docs/sop-stack-onboarding.md
@@ -5,7 +5,7 @@
 **Audience:** a **principal** standing up a NEW cortex **stack** bound to a Discord guild — on its own **hard-isolated local bus** (the `halden` / `community` pattern), optionally **federated** onto a network afterward (Part 2).
 **Authoritative detail:** [`CONTEXT.md`](../CONTEXT.md) §Principals/stacks/networks · [`sop-stack-identity.md`](./sop-stack-identity.md) (the signing key) · [`sop-network-join.md`](./sop-network-join.md) (federation, Part 2) · [`sop-discord-channel-routing.md`](./sop-discord-channel-routing.md).
 
-> **What this is.** Standing up a Discord-facing stack used to be an undocumented manual recipe (identity → isolated bus → cortex config + Discord binding → plist → load). This SOP captures it so the next one is a checklist — and flags the steps that are candidates for a future one-command `cortex stack add`.
+> **What this is.** Standing up a Discord-facing stack used to be an undocumented manual recipe (identity → isolated bus → cortex config + Discord binding → plist → load). This SOP captures it so the next one is a checklist. The config-write half (Step 3) is now automated by **`cortex stack create`** (#808) — Part 1 leads with it; the manual recipe remains as the fallback + the explanation of what each generated file is.
 
 ---
 
@@ -33,6 +33,38 @@ A **stack** is one cortex deployment under a **principal** — its own signing i
 ---
 
 ## Part 1 — Stand up the local stack
+
+### The fast path — `cortex stack create` (#808)
+
+Most of Part 1 is now one command. `cortex stack create <slug>` scaffolds the
+whole config-split skeleton **born aligned** (dir basename == slug == `stack.id`
+trailing segment, so the slug↔`stack.id` drift [ADR-0004](./adr/0004-stack-slug-authority.md)
+catches can never form) and **unique within the principal** (it refuses a dir
+collision or a duplicate `stack.id`):
+
+```bash
+# Dry-run first (DEFAULT — prints the file set, touches nothing):
+cortex stack create <slug> --principal <principal>
+
+# Write it:
+cortex stack create <slug> --principal <principal> --apply
+```
+
+It writes `system/system.yaml`, `surfaces/surfaces.yaml`, `stacks/<slug>.yaml`,
+the `<slug>.yaml` pointer, and a `personas/<agent>.md` stub — filling your real
+slug / principal / agent and keeping `<REPLACE_ME>` only for true secrets
+(Discord token/guild/channels + the post-first-boot `nkey_pub`). It sets
+`stack.nkey_seed_path` to the conventional `~/.config/nats/cortex-<slug>.nk` and
+does **not** generate the seed — `arc upgrade Cortex` auto-provisions it on first
+install (Step 1 below).
+
+After it writes, the remaining work is: pick a free bus port (Step 2), fill the
+`<REPLACE_ME>` secrets in `stacks/<slug>.yaml` + `surfaces/surfaces.yaml`
+(Steps 2–3), write the plist (Step 4), and verify (Step 5). When the stack
+should join a network afterward, continue to **Part 2** (`cortex network join`).
+
+The remaining Steps 0–5 below are the **manual recipe** — read them to
+understand each generated file, or to stand a stack up without the command.
 
 ### Step 0 — Choose a semantic slug
 

--- a/src/cli/cortex/commands/__tests__/stack-cli.test.ts
+++ b/src/cli/cortex/commands/__tests__/stack-cli.test.ts
@@ -1,0 +1,326 @@
+/**
+ * C-808 — `cortex stack create` CLI dispatcher tests.
+ *
+ * Covers the command surface: parsing, usage errors, help, slug/principal
+ * validation, the born-aligned uniqueness guarantees (#808 — dir==slug==
+ * trailing segment of stack.id; refuse on dir-collision OR duplicate stack.id),
+ * the DEFAULT-safe dry-run posture (writes NOTHING without --apply), the
+ * --apply file set, refuse-overwrite, and principal inference.
+ *
+ * NEVER touches the real ~/.config/cortex — every test points --config-dir at a
+ * fresh tmp dir and asserts dry-run leaves it empty.
+ */
+
+import { describe, test, expect, afterEach } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync, readFileSync, readdirSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+import { dispatchStack } from "../stack";
+import { loadConfigWithAgents } from "../../../../common/config/loader";
+
+const tmpDirs: string[] = [];
+function freshDir(): string {
+  const d = mkdtempSync(join(tmpdir(), "c808-stack-cli-"));
+  tmpDirs.push(d);
+  return d;
+}
+afterEach(() => {
+  while (tmpDirs.length > 0) rmSync(tmpDirs.pop()!, { recursive: true, force: true });
+});
+
+/** Seed an existing split-layout stack under <configDir>/<slug>/ with stack.id. */
+function seedSplitStack(configDir: string, slug: string, stackId: string): void {
+  const dir = join(configDir, slug);
+  mkdirSync(join(dir, "system"), { recursive: true });
+  mkdirSync(join(dir, "stacks"), { recursive: true });
+  writeFileSync(join(dir, "system", "system.yaml"), "nats:\n  url: nats://127.0.0.1:4222\n");
+  writeFileSync(join(dir, "stacks", `${slug}.yaml`), `principal:\n  id: ${stackId.split("/")[0]}\nstack:\n  id: ${stackId}\n`);
+}
+
+/** Seed a legacy monolith cortex.<slug>.yaml carrying a stack.id. */
+function seedLegacyMonolith(configDir: string, fileSlug: string, stackId: string): void {
+  const name = fileSlug === "meta-factory" ? "cortex.yaml" : `cortex.${fileSlug}.yaml`;
+  mkdirSync(configDir, { recursive: true });
+  writeFileSync(join(configDir, name), `stack:\n  id: ${stackId}\n`);
+}
+
+// =============================================================================
+// dispatch / usage / help
+// =============================================================================
+
+describe("dispatch", () => {
+  test("no subcommand → exit 2 with usage", async () => {
+    const res = await dispatchStack([]);
+    expect(res.exitCode).toBe(2);
+    expect(res.stderr).toContain("no subcommand specified");
+  });
+
+  test("unknown subcommand → exit 2", async () => {
+    const res = await dispatchStack(["frobnicate"]);
+    expect(res.exitCode).toBe(2);
+    expect(res.stderr).toContain('unknown subcommand "frobnicate"');
+  });
+
+  test("--help → exit 0 with usage", async () => {
+    const res = await dispatchStack(["--help"]);
+    expect(res.exitCode).toBe(0);
+    expect(res.stdout).toContain("cortex stack");
+    expect(res.stdout).toContain("create");
+  });
+});
+
+// =============================================================================
+// create — slug + principal validation
+// =============================================================================
+
+describe("create validation", () => {
+  test("rejects a bad slug (uppercase) → exit 2", async () => {
+    const cfg = freshDir();
+    const res = await dispatchStack(["create", "BadSlug", "--principal", "andreas", "--config-dir", cfg]);
+    expect(res.exitCode).toBe(2);
+    expect(res.stderr).toContain("slug");
+    expect(res.stderr).toContain("must be");
+  });
+
+  test("rejects a slug starting with a digit → exit 2", async () => {
+    const cfg = freshDir();
+    const res = await dispatchStack(["create", "2026research", "--principal", "andreas", "--config-dir", cfg]);
+    expect(res.exitCode).toBe(2);
+    expect(res.stderr).toContain("slug");
+  });
+
+  test("rejects a bad principal id → exit 2", async () => {
+    const cfg = freshDir();
+    const res = await dispatchStack(["create", "research", "--principal", "Bad_CAPS!", "--config-dir", cfg]);
+    expect(res.exitCode).toBe(2);
+    expect(res.stderr).toContain("principal");
+  });
+
+  test("accepts an underscore in the slug (stack.id grammar allows it)", async () => {
+    const cfg = freshDir();
+    const res = await dispatchStack(["create", "research_2026", "--principal", "andreas", "--config-dir", cfg]);
+    expect(res.exitCode).toBe(0);
+    expect(res.stdout).toContain("andreas/research_2026");
+  });
+
+  test("no principal and no existing stack to infer from → exit 2", async () => {
+    const cfg = freshDir();
+    const res = await dispatchStack(["create", "research", "--config-dir", cfg]);
+    expect(res.exitCode).toBe(2);
+    expect(res.stderr).toContain("--principal");
+  });
+});
+
+// =============================================================================
+// create — principal inference (#808)
+// =============================================================================
+
+describe("create principal inference", () => {
+  test("infers principal from the single existing stack", async () => {
+    const cfg = freshDir();
+    seedSplitStack(cfg, "research", "andreas/research");
+    const res = await dispatchStack(["create", "work", "--config-dir", cfg]);
+    expect(res.exitCode).toBe(0);
+    expect(res.stdout).toContain("andreas/work");
+  });
+
+  test("refuses to infer when two principals are present → exit 2", async () => {
+    const cfg = freshDir();
+    seedSplitStack(cfg, "research", "andreas/research");
+    seedSplitStack(cfg, "jcwork", "jc/jcwork");
+    const res = await dispatchStack(["create", "work", "--config-dir", cfg]);
+    expect(res.exitCode).toBe(2);
+    expect(res.stderr).toContain("--principal");
+  });
+});
+
+// =============================================================================
+// create — uniqueness (#808)
+// =============================================================================
+
+describe("create uniqueness", () => {
+  test("refuses when the target dir already exists → exit 1", async () => {
+    const cfg = freshDir();
+    mkdirSync(join(cfg, "research"), { recursive: true });
+    const res = await dispatchStack(["create", "research", "--principal", "andreas", "--config-dir", cfg, "--apply"]);
+    expect(res.exitCode).toBe(1);
+    expect(res.stderr).toContain("already exists");
+  });
+
+  test("refuses when an existing split stack already owns the stack.id → exit 1", async () => {
+    const cfg = freshDir();
+    // A differently-NAMED dir whose stack.id is andreas/research → duplicate id.
+    seedSplitStack(cfg, "old-research-dir", "andreas/research");
+    const res = await dispatchStack(["create", "research", "--principal", "andreas", "--config-dir", cfg, "--apply"]);
+    expect(res.exitCode).toBe(1);
+    expect(res.stderr).toContain("andreas/research");
+    expect(res.stderr).toContain("already");
+  });
+
+  test("refuses when a legacy monolith already owns the stack.id → exit 1", async () => {
+    const cfg = freshDir();
+    seedLegacyMonolith(cfg, "research", "andreas/research");
+    const res = await dispatchStack(["create", "research", "--principal", "andreas", "--config-dir", cfg, "--apply"]);
+    expect(res.exitCode).toBe(1);
+    expect(res.stderr).toContain("andreas/research");
+  });
+
+  test("a different principal's same slug is NOT a conflict", async () => {
+    const cfg = freshDir();
+    seedSplitStack(cfg, "research", "jc/research");
+    // andreas/research is a distinct stack.id; only a dir-name collision or a
+    // SAME stack.id conflicts. Here neither: dir `research` exists so this is a
+    // DIR collision — assert that. (Uniqueness is dir OR id, conservatively.)
+    const res = await dispatchStack(["create", "research", "--principal", "andreas", "--config-dir", cfg, "--apply"]);
+    expect(res.exitCode).toBe(1);
+    expect(res.stderr).toContain("already exists");
+  });
+});
+
+// =============================================================================
+// create — dry-run (DEFAULT-safe)
+// =============================================================================
+
+describe("create dry-run (default)", () => {
+  test("writes NOTHING without --apply, lists the file set, exit 0", async () => {
+    const cfg = freshDir();
+    const res = await dispatchStack(["create", "demo", "--principal", "andreas", "--config-dir", cfg]);
+    expect(res.exitCode).toBe(0);
+    expect(res.stdout).toContain("dry-run");
+    // The file set is enumerated.
+    expect(res.stdout).toContain("system/system.yaml");
+    expect(res.stdout).toContain("stacks/demo.yaml");
+    expect(res.stdout).toContain("demo.yaml");
+    expect(res.stdout).toContain("personas/luna.md");
+    // NOTHING was written.
+    expect(existsSync(join(cfg, "demo"))).toBe(false);
+  });
+
+  test("reports the born-aligned dir==slug==stack.id guarantee", async () => {
+    const cfg = freshDir();
+    const res = await dispatchStack(["create", "demo", "--principal", "andreas", "--config-dir", cfg]);
+    expect(res.exitCode).toBe(0);
+    expect(res.stdout).toContain("andreas/demo");
+  });
+});
+
+// =============================================================================
+// create — apply
+// =============================================================================
+
+describe("create --apply", () => {
+  test("writes the expected file set + born-aligned stack.id", async () => {
+    const cfg = freshDir();
+    const res = await dispatchStack(["create", "demo", "--principal", "andreas", "--config-dir", cfg, "--apply"]);
+    expect(res.exitCode).toBe(0);
+
+    const dir = join(cfg, "demo");
+    expect(existsSync(join(dir, "system", "system.yaml"))).toBe(true);
+    expect(existsSync(join(dir, "stacks", "demo.yaml"))).toBe(true);
+    expect(existsSync(join(dir, "demo.yaml"))).toBe(true);
+    expect(existsSync(join(dir, "personas", "luna.md"))).toBe(true);
+
+    // dir basename == slug == trailing segment of stack.id (the #808 invariant).
+    const stackYaml = readFileSync(join(dir, "stacks", "demo.yaml"), "utf-8");
+    expect(stackYaml).toContain("id: andreas/demo");
+    expect(stackYaml).toContain("nkey_seed_path: ~/.config/nats/cortex-demo.nk");
+    // The chosen agent id is luna by default.
+    expect(stackYaml).toContain("luna");
+  });
+
+  test("honours --agent + --display-name", async () => {
+    const cfg = freshDir();
+    const res = await dispatchStack([
+      "create", "demo", "--principal", "andreas", "--agent", "echo",
+      "--display-name", "Demo Stack", "--config-dir", cfg, "--apply",
+    ]);
+    expect(res.exitCode).toBe(0);
+    const stackYaml = readFileSync(join(cfg, "demo", "stacks", "demo.yaml"), "utf-8");
+    expect(stackYaml).toContain("echo");
+    expect(existsSync(join(cfg, "demo", "personas", "echo.md"))).toBe(true);
+  });
+
+  test("composed stack is discoverable as itself (round-trip uniqueness)", async () => {
+    const cfg = freshDir();
+    await dispatchStack(["create", "demo", "--principal", "andreas", "--config-dir", cfg, "--apply"]);
+    // A second create of the SAME slug now conflicts (dir exists).
+    const res = await dispatchStack(["create", "demo", "--principal", "andreas", "--config-dir", cfg, "--apply"]);
+    expect(res.exitCode).toBe(1);
+  });
+
+  test("the scaffolded config composes + loads via the real loader (born loadable)", async () => {
+    // The whole point of the docs/config-layout/ template is that it parses
+    // cleanly out of the box (valid-FORMAT placeholders, not bare <REPLACE_ME>,
+    // for schema-validated keys like nkey_pub). A scaffold that can't load
+    // would be a defect — assert the composer accepts what we wrote.
+    const cfg = freshDir();
+    await dispatchStack(["create", "demo", "--principal", "andreas", "--config-dir", cfg, "--apply"]);
+    const loaded = loadConfigWithAgents(join(cfg, "demo", "demo.yaml"));
+    expect(loaded.stack?.id).toBe("andreas/demo");
+  });
+
+  test("prints next steps (provision → point daemon → network join)", async () => {
+    const cfg = freshDir();
+    const res = await dispatchStack(["create", "demo", "--principal", "andreas", "--config-dir", cfg, "--apply"]);
+    expect(res.exitCode).toBe(0);
+    expect(res.stdout).toContain("arc upgrade");
+    expect(res.stdout).toContain("network join");
+  });
+});
+
+// =============================================================================
+// create — refuse overwrite
+// =============================================================================
+
+describe("create refuse-overwrite", () => {
+  test("never clobbers an existing dir even with --apply", async () => {
+    const cfg = freshDir();
+    const dir = join(cfg, "demo");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "sentinel-keepme.txt"), "do not delete");
+    const res = await dispatchStack(["create", "demo", "--principal", "andreas", "--config-dir", cfg, "--apply"]);
+    expect(res.exitCode).toBe(1);
+    // The pre-existing content is untouched.
+    expect(existsSync(join(dir, "sentinel-keepme.txt"))).toBe(true);
+    expect(readdirSync(dir)).toContain("sentinel-keepme.txt");
+  });
+});
+
+// =============================================================================
+// apply + dry-run mutual exclusion
+// =============================================================================
+
+describe("create flag exclusivity", () => {
+  test("--apply and --dry-run together → exit 2", async () => {
+    const cfg = freshDir();
+    const res = await dispatchStack(["create", "demo", "--principal", "andreas", "--config-dir", cfg, "--apply", "--dry-run"]);
+    expect(res.exitCode).toBe(2);
+    expect(res.stderr).toContain("mutually exclusive");
+  });
+});
+
+// =============================================================================
+// list (cheap)
+// =============================================================================
+
+describe("list", () => {
+  test("lists discovered stacks with aligned/drift flags", async () => {
+    const cfg = freshDir();
+    seedSplitStack(cfg, "research", "andreas/research");      // aligned
+    seedSplitStack(cfg, "old-dir", "andreas/work");           // drift (dir != slug)
+    const res = await dispatchStack(["list", "--config-dir", cfg]);
+    expect(res.exitCode).toBe(0);
+    expect(res.stdout).toContain("research");
+    expect(res.stdout).toContain("andreas/work");
+    expect(res.stdout.toLowerCase()).toContain("drift");
+    expect(res.stdout.toLowerCase()).toContain("aligned");
+  });
+
+  test("empty config dir → exit 0, no stacks", async () => {
+    const cfg = freshDir();
+    const res = await dispatchStack(["list", "--config-dir", cfg]);
+    expect(res.exitCode).toBe(0);
+    expect(res.stdout.toLowerCase()).toContain("no stacks");
+  });
+});

--- a/src/cli/cortex/commands/__tests__/stack-cli.test.ts
+++ b/src/cli/cortex/commands/__tests__/stack-cli.test.ts
@@ -104,6 +104,30 @@ describe("create validation", () => {
     expect(res.stdout).toContain("andreas/research_2026");
   });
 
+  test("rejects a --display-name with a newline (YAML-injection guard) → exit 2, writes nothing", async () => {
+    const cfg = freshDir();
+    const res = await dispatchStack([
+      "create", "research", "--principal", "andreas", "--config-dir", cfg,
+      "--display-name", "Luna\n    roles:\n      - injected-superuser", "--apply",
+    ]);
+    expect(res.exitCode).toBe(2);
+    expect(res.stderr).toContain("display-name");
+    expect(existsSync(join(cfg, "research"))).toBe(false);
+  });
+
+  test("--apply with YAML-special chars in --display-name stays born-loadable", async () => {
+    const cfg = freshDir();
+    const res = await dispatchStack([
+      "create", "research", "--principal", "andreas", "--config-dir", cfg,
+      "--display-name", 'Ivy: the #1 "researcher"', "--apply",
+    ]);
+    expect(res.exitCode).toBe(0);
+    // The colon/hash/quotes survive inside a valid YAML scalar (JSON.stringify
+    // quoting), so the scaffold still composes through the real loader.
+    const loaded = loadConfigWithAgents(join(cfg, "research", "research.yaml"));
+    expect(loaded.stack?.id).toBe("andreas/research");
+  });
+
   test("no principal and no existing stack to infer from → exit 2", async () => {
     const cfg = freshDir();
     const res = await dispatchStack(["create", "research", "--config-dir", cfg]);

--- a/src/cli/cortex/commands/__tests__/stack-lib.test.ts
+++ b/src/cli/cortex/commands/__tests__/stack-lib.test.ts
@@ -1,0 +1,150 @@
+/**
+ * C-808 — `cortex stack` pure-logic tests.
+ *
+ * The discovery scan (TS replica of plist-render.sh's discover_stack_slugs +
+ * extract_stack_id_slug), the born-aligned scaffold renderer, and the
+ * alignment self-check — all pure over a tmp dir / plain inputs. The CLI wiring
+ * is covered by stack-cli.test.ts.
+ */
+
+import { describe, test, expect, afterEach } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+import {
+  discoverStacks,
+  assertAligned,
+  renderScaffold,
+  type ScaffoldInputs,
+} from "../stack-lib";
+
+const tmpDirs: string[] = [];
+function freshDir(): string {
+  const d = mkdtempSync(join(tmpdir(), "c808-stack-lib-"));
+  tmpDirs.push(d);
+  return d;
+}
+afterEach(() => {
+  while (tmpDirs.length > 0) rmSync(tmpDirs.pop()!, { recursive: true, force: true });
+});
+
+function seedSplit(cfg: string, slug: string, stackId: string): void {
+  const dir = join(cfg, slug);
+  mkdirSync(join(dir, "system"), { recursive: true });
+  mkdirSync(join(dir, "stacks"), { recursive: true });
+  writeFileSync(join(dir, "system", "system.yaml"), "nats:\n  url: x\n");
+  writeFileSync(join(dir, "stacks", `${slug}.yaml`), `stack:\n  id: ${stackId}\n`);
+}
+
+// =============================================================================
+// discoverStacks
+// =============================================================================
+
+describe("discoverStacks", () => {
+  test("finds split-layout stacks and reads stack.id", () => {
+    const cfg = freshDir();
+    seedSplit(cfg, "research", "andreas/research");
+    seedSplit(cfg, "work", "andreas/work");
+    const found = discoverStacks(cfg);
+    const ids = found.map((s) => s.stackId).sort();
+    expect(ids).toEqual(["andreas/research", "andreas/work"]);
+    expect(found.every((s) => s.aligned)).toBe(true);
+  });
+
+  test("flags drift when dir basename != stack.id trailing segment", () => {
+    const cfg = freshDir();
+    seedSplit(cfg, "old-dir", "andreas/work");
+    const found = discoverStacks(cfg);
+    expect(found).toHaveLength(1);
+    expect(found[0]?.slugLocator).toBe("old-dir");
+    expect(found[0]?.stackId).toBe("andreas/work");
+    expect(found[0]?.aligned).toBe(false);
+  });
+
+  test("finds legacy monolith cortex.<slug>.yaml", () => {
+    const cfg = freshDir();
+    mkdirSync(cfg, { recursive: true });
+    writeFileSync(join(cfg, "cortex.community.yaml"), "stack:\n  id: andreas/community\n");
+    const found = discoverStacks(cfg);
+    expect(found).toHaveLength(1);
+    expect(found[0]?.stackId).toBe("andreas/community");
+    expect(found[0]?.slugLocator).toBe("community");
+  });
+
+  test("directory layout wins over a same-slug legacy monolith (no dup)", () => {
+    const cfg = freshDir();
+    seedSplit(cfg, "research", "andreas/research");
+    writeFileSync(join(cfg, "cortex.research.yaml"), "stack:\n  id: andreas/research\n");
+    const found = discoverStacks(cfg);
+    expect(found.filter((s) => s.slugLocator === "research")).toHaveLength(1);
+  });
+
+  test("missing config dir → empty", () => {
+    expect(discoverStacks(join(tmpdir(), "c808-does-not-exist-xyz"))).toEqual([]);
+  });
+
+  test("a stack with no parseable stack.id still surfaces (id undefined)", () => {
+    const cfg = freshDir();
+    const dir = join(cfg, "weird");
+    mkdirSync(join(dir, "system"), { recursive: true });
+    mkdirSync(join(dir, "stacks"), { recursive: true });
+    writeFileSync(join(dir, "system", "system.yaml"), "nats:\n  url: x\n");
+    writeFileSync(join(dir, "stacks", "weird.yaml"), "principal:\n  id: andreas\n");
+    const found = discoverStacks(cfg);
+    expect(found).toHaveLength(1);
+    expect(found[0]?.stackId).toBeUndefined();
+  });
+});
+
+// =============================================================================
+// assertAligned (the #808 structural guarantee)
+// =============================================================================
+
+describe("assertAligned", () => {
+  test("passes when dir == slug == trailing segment of stack.id", () => {
+    expect(() => assertAligned("demo", "andreas/demo")).not.toThrow();
+  });
+
+  test("throws when stack.id trailing segment != slug", () => {
+    expect(() => assertAligned("demo", "andreas/other")).toThrow();
+  });
+});
+
+// =============================================================================
+// renderScaffold
+// =============================================================================
+
+describe("renderScaffold", () => {
+  const inputs: ScaffoldInputs = {
+    slug: "demo",
+    principal: "andreas",
+    stackId: "andreas/demo",
+    agentId: "luna",
+    displayName: "Demo",
+    seedPath: "~/.config/nats/cortex-demo.nk",
+  };
+
+  test("emits the full file set", () => {
+    const files = renderScaffold(inputs);
+    const rels = files.map((f) => f.relPath).sort();
+    expect(rels).toEqual(
+      ["demo.yaml", "personas/luna.md", "stacks/demo.yaml", "surfaces/surfaces.yaml", "system/system.yaml"].sort(),
+    );
+  });
+
+  test("stacks/<slug>.yaml carries the born-aligned identity + seed path", () => {
+    const files = renderScaffold(inputs);
+    const stack = files.find((f) => f.relPath === "stacks/demo.yaml");
+    expect(stack?.contents).toContain("id: andreas/demo");
+    expect(stack?.contents).toContain("nkey_seed_path: ~/.config/nats/cortex-demo.nk");
+    expect(stack?.contents).toContain("luna");
+  });
+
+  test("does NOT inline any signing seed material (key auto-provisioned later)", () => {
+    const files = renderScaffold(inputs);
+    const all = files.map((f) => f.contents).join("\n");
+    // No SU… seed ever appears in scaffolded output.
+    expect(all).not.toMatch(/\bSU[A-Z0-9]{20,}/);
+  });
+});

--- a/src/cli/cortex/commands/stack-lib.ts
+++ b/src/cli/cortex/commands/stack-lib.ts
@@ -1,0 +1,509 @@
+/**
+ * `cortex stack` pure logic (C-808, closes #808) — discovery, the born-aligned
+ * scaffold renderer, and the alignment self-check.
+ *
+ * This is the PREVENT-side complement to v5.3.8's `warn_stack_identity_drift`
+ * (the DETECT side, `scripts/lib/plist-render.sh` + ADR-0004). That detector
+ * warns when a stack's filesystem locator (dir basename / `cortex.<slug>.yaml`
+ * filename) drifts from `stack.id`'s trailing segment. This module makes that
+ * drift STRUCTURALLY IMPOSSIBLE for a stack created via `cortex stack create`:
+ * it derives `stack.id = {principal}/{slug}`, writes the dir as `<slug>`, and
+ * asserts dir == slug == trailing-segment BEFORE writing (`assertAligned`).
+ *
+ * Discovery (`discoverStacks`) is a faithful TS replica of the shell discovery
+ * in `plist-render.sh` (`discover_stack_slugs` + `extract_stack_id_slug` +
+ * `config_file_to_slug`), used for the uniqueness scan and `stack list`. Kept
+ * deliberately dependency-light (no YAML parser) so it matches the install-time
+ * awk extraction byte-for-byte on the `stack.id` it reads.
+ *
+ * No I/O beyond reading for discovery — the actual writes live in `stack.ts`
+ * so this module stays pure + trivially testable (mirrors the network-lib /
+ * network.ts split).
+ */
+
+import { existsSync, readdirSync, readFileSync, statSync } from "fs";
+import { join } from "path";
+
+// =============================================================================
+// Discovery
+// =============================================================================
+
+/** A stack discovered under a config dir, with its alignment verdict. */
+export interface DiscoveredStack {
+  /** The filesystem LOCATOR slug — dir basename, or the cortex.<slug>.yaml
+   *  filename slug (cosmetic; ADR-0004 DA-1). */
+  slugLocator: string;
+  /** `stack.id` (`{principal}/{slug}`) read from the config, or undefined when
+   *  absent/unparseable (a degenerate stack the detector skips). */
+  stackId?: string;
+  /** Layout the stack was found under. */
+  layout: "split" | "monolith";
+  /** Absolute path of the stack's config file that carries `stack.id`. */
+  configPath: string;
+  /** True when the locator slug == `stack.id`'s trailing segment (ADR-0004).
+   *  Undefined `stackId` ⇒ undefined verdict (nothing to compare). */
+  aligned?: boolean;
+}
+
+/**
+ * Replica of `config_file_to_slug` (plist-render.sh): map a `cortex*.yaml`
+ * filename to its locator slug. `cortex.yaml` → `meta-factory` (the single-file
+ * default-stack special case); `cortex.<slug>.yaml` → `<slug>`. Anything else
+ * returns undefined (caller skips the file).
+ */
+function configFileToSlug(filename: string): string | undefined {
+  if (filename === "cortex.yaml") return "meta-factory";
+  const m = /^cortex\.(.+)\.yaml$/.exec(filename);
+  return m?.[1];
+}
+
+/**
+ * Replica of `extract_stack_id_slug` (plist-render.sh) — extract `stack.id`
+ * scoped to the top-level `stack:` block so the sibling `principal.id` /
+ * `agents[].id` keys are never mistaken for it. Returns the full
+ * `{principal}/{slug}` literal, or undefined when absent/unparseable.
+ *
+ * Deliberately a line scan (not a YAML parse) to match the install-time awk
+ * extraction exactly — the SAME bytes the drift detector reads.
+ */
+function extractStackId(configPath: string): string | undefined {
+  let text: string;
+  try {
+    text = readFileSync(configPath, "utf-8");
+  } catch (_err) {
+    // A discovered config that can't be read carries no comparable id — the
+    // shell detector skips it too (the filename locator stands). Safe to ignore.
+    return undefined;
+  }
+  let inStack = false;
+  for (const rawLine of text.split("\n")) {
+    const line = rawLine.replace(/\r$/, "");
+    if (/^stack:\s*$/.test(line)) {
+      inStack = true;
+      continue;
+    }
+    // A non-indented, non-comment line dedents out of the `stack:` block.
+    if (inStack && /^[^\s#]/.test(line)) inStack = false;
+    if (inStack) {
+      const m = /^\s+id:\s*(.+)$/.exec(line);
+      if (m?.[1] !== undefined) {
+        // Strip quotes + trailing comment, trim.
+        const value = m[1].replace(/["']/g, "").replace(/#.*$/, "").trim();
+        return value.length > 0 ? value : undefined;
+      }
+    }
+  }
+  return undefined;
+}
+
+/** The trailing `{slug}` segment of a `{principal}/{slug}` stack id. */
+function stackIdTrailingSlug(stackId: string): string {
+  const idx = stackId.lastIndexOf("/");
+  return idx === -1 ? stackId : stackId.slice(idx + 1);
+}
+
+/**
+ * Discover all stacks under `configDir` — split-layout dirs (with the
+ * `system/system.yaml` marker) and legacy `cortex*.yaml` monoliths. Mirrors
+ * `discover_stack_slugs`: the directory layout WINS over a same-slug monolith
+ * (the split retains the root monolith as a rollback anchor, so it must not be
+ * double-discovered). Returns each with its `stack.id` + alignment verdict.
+ */
+export function discoverStacks(configDir: string): DiscoveredStack[] {
+  if (!existsSync(configDir)) return [];
+
+  const found: DiscoveredStack[] = [];
+  const dirSlugs = new Set<string>();
+
+  // Pass 1: split-layout dirs — <configDir>/<slug>/system/system.yaml marker.
+  let entries: string[];
+  try {
+    entries = readdirSync(configDir);
+  } catch (_err) {
+    // Unreadable config dir → nothing to discover; an empty list is the safe,
+    // truthful answer (callers treat it as "no stacks present"). Safe to ignore.
+    return [];
+  }
+  for (const entry of entries.sort()) {
+    const dir = join(configDir, entry);
+    try {
+      if (!statSync(dir).isDirectory()) continue;
+    } catch (_err) {
+      // A racing unlink between readdir and stat — skip this entry. Safe to ignore.
+      continue;
+    }
+    if (!existsSync(join(dir, "system", "system.yaml"))) continue;
+    // Agents/stack.id live in stacks/<slug>.yaml under the split layout.
+    const configPath = join(dir, "stacks", `${entry}.yaml`);
+    const stackId = existsSync(configPath) ? extractStackId(configPath) : undefined;
+    dirSlugs.add(entry);
+    found.push(buildDiscovered(entry, stackId, "split", configPath));
+  }
+
+  // Pass 2: legacy monoliths — emit only when no split dir already claimed the
+  // slug (dir wins → dedupe).
+  for (const entry of entries.sort()) {
+    if (!/^cortex.*\.yaml$/.test(entry)) continue;
+    const file = join(configDir, entry);
+    try {
+      if (!statSync(file).isFile()) continue;
+    } catch (_err) {
+      // racing unlink between readdir and stat — skip. Safe to ignore.
+      continue;
+    }
+    const slug = configFileToSlug(entry);
+    if (slug === undefined) continue;
+    if (dirSlugs.has(slug)) continue;
+    const stackId = extractStackId(file);
+    found.push(buildDiscovered(slug, stackId, "monolith", file));
+  }
+
+  return found;
+}
+
+function buildDiscovered(
+  slugLocator: string,
+  stackId: string | undefined,
+  layout: "split" | "monolith",
+  configPath: string,
+): DiscoveredStack {
+  return {
+    slugLocator,
+    ...(stackId !== undefined && { stackId }),
+    layout,
+    configPath,
+    ...(stackId !== undefined && { aligned: stackIdTrailingSlug(stackId) === slugLocator }),
+  };
+}
+
+// =============================================================================
+// Alignment self-check (the #808 structural guarantee)
+// =============================================================================
+
+/**
+ * Assert dir basename == slug == trailing segment of the stack.id about to be
+ * written. The whole point of `cortex stack create` (#808): a stack born this
+ * way CANNOT drift, because we refuse to write unless all three agree. Throws
+ * on a mismatch — a programming error in the command, never a principal input
+ * error (those are validated + rejected upstream as usage errors).
+ */
+export function assertAligned(slug: string, stackId: string): void {
+  const trailing = stackIdTrailingSlug(stackId);
+  if (trailing !== slug) {
+    throw new Error(
+      `alignment self-check failed (#808): stack.id "${stackId}" trailing segment "${trailing}" != slug "${slug}"`,
+    );
+  }
+}
+
+// =============================================================================
+// Scaffold renderer
+// =============================================================================
+
+/** Inputs for the born-aligned scaffold. All resolved + validated upstream. */
+export interface ScaffoldInputs {
+  slug: string;
+  principal: string;
+  stackId: string;
+  agentId: string;
+  displayName: string;
+  /** Conventional seed path (`~/.config/nats/cortex-<slug>.nk`). NOT generated
+   *  here — `arc upgrade Cortex` auto-provisions the seed on first install. */
+  seedPath: string;
+}
+
+/** A scaffold file to write, relative to the new stack's dir. */
+export interface ScaffoldFile {
+  relPath: string;
+  contents: string;
+}
+
+/**
+ * Render the full born-aligned config-split skeleton for a new stack. Derived
+ * from `docs/config-layout/` with the `research`/`andreas`/`ivy` placeholders
+ * substituted for the real slug / principal / agent, keeping `<REPLACE_ME>`
+ * only for true secrets (Discord token/guild/channel ids + the post-first-boot
+ * `nkey_pub`). NEVER emits private key material — the seed is auto-provisioned
+ * later (see `arc upgrade Cortex` / postupgrade.sh §2).
+ */
+export function renderScaffold(inputs: ScaffoldInputs): ScaffoldFile[] {
+  const { slug, principal, stackId, agentId, displayName, seedPath } = inputs;
+  const Display = displayName;
+
+  return [
+    { relPath: "system/system.yaml", contents: systemYaml() },
+    { relPath: "surfaces/surfaces.yaml", contents: surfacesYaml(agentId, stackId) },
+    { relPath: `stacks/${slug}.yaml`, contents: stackYaml(slug, principal, stackId, agentId, Display, seedPath) },
+    { relPath: `${slug}.yaml`, contents: pointerYaml(slug) },
+    { relPath: `personas/${agentId}.md`, contents: personaStub(agentId, Display, stackId) },
+  ];
+}
+
+function systemYaml(): string {
+  // The cross-cutting substrate layer — substituted from
+  // docs/config-layout/system/system.yaml. Identity is left at the safe
+  // conventional default; `arc upgrade Cortex` auto-provisions the seed.
+  return `# =============================================================================
+# system.yaml — the cross-cutting machine / substrate layer (IAW CFG.b)
+# =============================================================================
+# Generated by \`cortex stack create\` (#808). BASE layer of the config-split
+# layout: the dangerous transport knobs (claude / execution / attachments /
+# paths / nats / bus) live HERE, one layer up from the per-stack stacks/*.yaml,
+# reviewed as a transport change. See docs/config-layout/system/system.yaml for
+# the fully-annotated reference.
+
+claude:
+  timeoutMs: 300000
+  asyncTimeoutMs: 900000
+  additionalArgs: []
+  allowedTools: []
+  disallowedTools:
+    - Write
+
+execution:
+  default: local
+  backends: []
+
+attachments:
+  enabled: true
+  maxFileSizeBytes: 10485760
+  maxTotalSizeBytes: 26214400
+  maxAttachmentsPerMessage: 10
+
+paths:
+  publishedEventsDir: ~/.claude/events/published
+  logDir: ~/.config/cortex/logs
+
+# nats — M2 transport. nats.subjects is the SINGLE place subject overrides live
+# (IAW CFG.b.2). KEEP IT EMPTY ([]) unless you know exactly why — a duplicate
+# pattern double-binds the boot subscriber (the double-message problem,
+# cortex#491). The dispatch-listener self-subscribes its own interest at start.
+nats:
+  url: nats://127.0.0.1:4222
+  name: cortex
+  subjects: []
+  # NKey identity for envelope signing. The seedPath is the conventional path
+  # \`arc upgrade Cortex\` auto-provisions on first install; publicKey is pinned
+  # after first boot (paste from the cortex log \`stack signing key staged …\`).
+  identity:
+    seedPath: ~/.config/nats/cortex.nk
+    # Valid-FORMAT placeholder so this file loads; REPLACE after first boot.
+    publicKey: ${NKEY_PUB_PLACEHOLDER}   # <REPLACE_ME>: U-prefixed pubkey
+
+bus:
+  review:
+    stream:
+      name: CODE_REVIEW
+      maxAgeSeconds: 86400
+      maxBytes: 536870912
+    consumer:
+      maxDeliver: 5
+`;
+}
+
+function surfacesYaml(agentId: string, stackId: string): string {
+  // The shared surface-gateway binding map (IAW CFG.c). Substituted from
+  // docs/config-layout/surfaces/surfaces.yaml with the real agent + stack id.
+  // Secrets stay <REPLACE_ME> (Discord token/guild/channel ids).
+  return `# =============================================================================
+# surfaces/surfaces.yaml — the shared surface-gateway binding map (IAW CFG.c)
+# =============================================================================
+# Generated by \`cortex stack create\` (#808). Holds the per-platform surface
+# bindings (Discord/Slack/Mattermost token/guild/channels), folded into the
+# matching agent's presence.{platform} at load. OPTIONAL — per-stack inline
+# presence is always the fallback. See docs/config-layout/surfaces/surfaces.yaml.
+
+surfaces:
+  discord:
+    - agent: ${agentId}
+      stack: ${stackId}
+      binding:
+        token: "<REPLACE_ME>"            # the bot token (chmod 600 the file)
+        guildId: "<REPLACE_ME>"
+        agentChannelId: "<REPLACE_ME>"
+        logChannelId: "<REPLACE_ME>"
+
+  # slack:
+  #   - agent: ${agentId}
+  #     stack: ${stackId}
+  #     binding:
+  #       botToken: xoxb-REPLACE
+  #       appToken: xapp-REPLACE
+  #       workspaceId: T01234567
+
+  # mattermost:
+  #   - agent: ${agentId}
+  #     stack: ${stackId}
+  #     binding:
+  #       apiUrl: https://mattermost.example.com
+  #       apiToken: REPLACE_WITH_MATTERMOST_TOKEN
+`;
+}
+
+/**
+ * Valid-FORMAT NKey public-key placeholder (U-prefixed, 56 chars). The config
+ * schema's `nkey_pub` fields are regex-validated at load (`/^U[A-Z2-7]{55}$/`),
+ * so a bare `<REPLACE_ME>` would FAIL to parse — defeating the "every file
+ * parses cleanly out of the box" guarantee. Matching `docs/config-layout/`'s
+ * own convention, we emit this valid-format all-A placeholder (it parses) with
+ * a REPLACE_ME comment beside it. REPLACE it with the real pubkey after first
+ * boot (paste from the cortex log `stack signing key staged …`).
+ */
+const NKEY_PUB_PLACEHOLDER = "UAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+
+function stackYaml(
+  slug: string,
+  principal: string,
+  stackId: string,
+  agentId: string,
+  displayName: string,
+  seedPath: string,
+): string {
+  // The per-deployment stack layer — substituted from
+  // docs/config-layout/stacks/research.yaml. principal-only policy pattern.
+  return `# =============================================================================
+# stacks/${slug}.yaml — this stack's per-deployment layer (the file you EDIT daily)
+# =============================================================================
+# Generated by \`cortex stack create\` (#808), born aligned: this file lives at
+# <config-dir>/${slug}/stacks/${slug}.yaml and its stack.id trailing segment is
+# "${slug}" — dir == slug == stack.id, so the slug<->stack.id drift the install-
+# time \`warn_stack_identity_drift\` detector (ADR-0004) catches can never form.
+# See docs/config-layout/stacks/research.yaml for the fully-annotated reference.
+
+# -----------------------------------------------------------------------------
+# principal — who is running this stack (id + Discord identity)
+# -----------------------------------------------------------------------------
+principal:
+  id: ${principal}
+  displayName: ${principal}
+  discordId: "<REPLACE_ME>"   # your numeric Discord snowflake
+
+# -----------------------------------------------------------------------------
+# stack — identity of THIS deployment within the principal (signing identity)
+# -----------------------------------------------------------------------------
+# \`arc upgrade Cortex\` auto-provisions the seed at nkey_seed_path on first
+# install if it is missing — do NOT generate it by hand. After first boot, paste
+# the U-prefixed pubkey from the cortex log line \`stack signing key staged …\`
+# into nkey_pub to pin it.
+stack:
+  id: ${stackId}
+  nkey_seed_path: ${seedPath}   # SU…-prefixed NATS user seed, chmod 600 (auto-provisioned)
+  # Valid-FORMAT placeholder so this file loads; REPLACE with the real U-prefixed
+  # pubkey after first boot (cortex log: "stack signing key staged …").
+  nkey_pub: ${NKEY_PUB_PLACEHOLDER}  # <REPLACE_ME>
+
+# -----------------------------------------------------------------------------
+# capabilities — STACK CATALOG (source of truth for capability-dispatch)
+# -----------------------------------------------------------------------------
+capabilities:
+  - id: chat
+    description: Conversational dispatch (no-prefix synchronous chat)
+    provided_by: [${agentId}]
+
+# -----------------------------------------------------------------------------
+# policy — PRINCIPAL-ONLY pattern (CRITICAL for any guild others can join)
+# -----------------------------------------------------------------------------
+# List ONLY the human principal in principals[] with their Discord id. A
+# non-principal's @mention resolves to authorIsPrincipal=false → hard-blocked
+# silently. The assistant answers the principal and no one else.
+policy:
+  principals:
+    - id: ${agentId}                  # the stack's own signing identity (the agent)
+      home_principal: ${principal}
+      home_stack: ${stackId}
+      nkey_pub: ${NKEY_PUB_PLACEHOLDER}  # <REPLACE_ME>: ${agentId}'s U-prefixed pubkey (matches agents[].nkey_pub)
+      role:
+        - principal-role
+      trust: []
+      platform_ids: {}
+    - id: ${principal}                # the human — the ONLY human principal
+      home_principal: ${principal}
+      home_stack: ${stackId}
+      role:
+        - principal-role
+      trust: []
+      platform_ids:
+        discord:
+          - "<REPLACE_ME>"            # your numeric Discord id
+  roles:
+    - id: principal-role
+      capabilities:
+        - dispatch.${agentId}
+        - keyword.chat
+        - keyword.async
+        - keyword.team
+        - tool.bash
+        - tool.read
+        - tool.glob
+        - tool.grep
+
+# -----------------------------------------------------------------------------
+# agents — first-class agents on this stack
+# -----------------------------------------------------------------------------
+agents:
+  - id: ${agentId}
+    displayName: ${displayName}
+    persona: ./personas/${agentId}.md
+    nkey_pub: ${NKEY_PUB_PLACEHOLDER}  # <REPLACE_ME>: ${agentId}'s U-prefixed pubkey
+    roles: []
+    trust: []
+    runtime:
+      substrate: claude-code
+      mode: in-process
+      capabilities:
+        - chat
+    # EMPTY — the Discord binding folds in from surfaces/surfaces.yaml.
+    presence: {}
+
+# -----------------------------------------------------------------------------
+# github — webhook ingestion + which repos this stack is scoped to
+# -----------------------------------------------------------------------------
+github:
+  webhookSecret: ""                   # paste the GitHub App HMAC secret once wired; empty = off
+  repos: []                           # e.g. [{ short: cortex, full: the-metafactory/cortex }]
+`;
+}
+
+function pointerYaml(slug: string): string {
+  // The sentinel pointer — contents ignored; dirname selects the layout, basename
+  // names the per-stack PID file. Per-stack name (not uniform cortex.yaml) avoids
+  // the PID-collision landmine (migration 0003).
+  return `# =============================================================================
+# ${slug}.yaml — the POINTER (sentinel) file (IAW CFG / migration 0003)
+# =============================================================================
+# Generated by \`cortex stack create\` (#808). Point your daemon's --config here:
+#
+#     cortex start --config ~/.config/cortex/${slug}/${slug}.yaml
+#
+# Its CONTENTS ARE IGNORED. The loader uses only its DIRNAME to select the
+# config-split layout (the system/system.yaml marker beside it), and its
+# BASENAME to name the single-instance PID file (cortex-${slug}.pid) — which is
+# why every stack's pointer MUST be per-stack-named, never a uniform
+# cortex.yaml (the PID-collision landmine, migration 0003).
+pointer: true   # cosmetic marker only — the loader never reads this value
+`;
+}
+
+function personaStub(agentId: string, displayName: string, stackId: string): string {
+  return `# ${displayName}
+
+You are **${displayName}** (\`${agentId}\`), the assistant on the \`${stackId}\` cortex stack.
+
+<!-- Generated by \`cortex stack create\` (#808) — a minimal persona stub. -->
+
+## Role
+
+Collaborate with the principal in this stack's Discord guild. Answer questions,
+run tasks, and surface results. You answer the principal and no one else (the
+principal-only policy in \`stacks/${stackId.split("/")[1] ?? agentId}.yaml\`).
+
+## Repo scope
+
+<!-- Append your allowed repo slugs here so you know them without being told,
+     e.g. "You work in the \`cortex\` repo (the-metafactory/cortex)." -->
+
+## Style
+
+Be concise, accurate, and verify before claiming. Read before you describe code.
+`;
+}

--- a/src/cli/cortex/commands/stack-lib.ts
+++ b/src/cli/cortex/commands/stack-lib.ts
@@ -64,7 +64,10 @@ function configFileToSlug(filename: string): string | undefined {
  * `{principal}/{slug}` literal, or undefined when absent/unparseable.
  *
  * Deliberately a line scan (not a YAML parse) to match the install-time awk
- * extraction exactly — the SAME bytes the drift detector reads.
+ * extraction on every well-formed config — the same `stack.id` the drift
+ * detector reads. (Both this scan and the awk converge to undefined on the
+ * degenerate cases — flow-style `stack: {id: …}`, an empty `id:` — and the real
+ * loader rejects those configs anyway, so neither is a reachable dup bypass.)
  */
 function extractStackId(configPath: string): string | undefined {
   let text: string;
@@ -442,7 +445,7 @@ policy:
 # -----------------------------------------------------------------------------
 agents:
   - id: ${agentId}
-    displayName: ${displayName}
+    displayName: ${JSON.stringify(displayName)}
     persona: ./personas/${agentId}.md
     nkey_pub: ${NKEY_PUB_PLACEHOLDER}  # <REPLACE_ME>: ${agentId}'s U-prefixed pubkey
     roles: []

--- a/src/cli/cortex/commands/stack.ts
+++ b/src/cli/cortex/commands/stack.ts
@@ -33,7 +33,7 @@
  * Exit codes: 0 success · 1 operational failure (conflict / write error) · 2 usage.
  */
 
-import { existsSync, mkdirSync, writeFileSync } from "fs";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "fs";
 import { dirname, join } from "path";
 import { homedir } from "os";
 
@@ -209,6 +209,20 @@ function runCreate(
     );
   }
   const displayName = optionalValueFlag(flags, "--display-name") ?? capitalize(agentId);
+  // --display-name is the one free-form input — it gets interpolated into the
+  // generated YAML (stacks/<slug>.yaml `displayName:`) and the persona stub.
+  // Reject control characters (the YAML-injection vector: a newline payload
+  // could inject sibling keys — a forged nkey_pub, extra roles); the YAML emit
+  // also JSON-quotes the scalar as defense-in-depth (stack-lib renderScaffold).
+  // Allow ordinary printable text (spaces, unicode, punctuation), capped.
+  // eslint-disable-next-line no-control-regex
+  if (/[\u0000-\u001f\u007f]/.test(displayName) || displayName.length > 64) {
+    return usageError(
+      "create",
+      `--display-name must be a single line of printable text (≤64 chars, no control characters)`,
+      json,
+    );
+  }
 
   // --- derive the born-aligned stack id ------------------------------------
   const stackId = `${principal}/${slug}`;
@@ -271,9 +285,23 @@ function runCreate(
       writeFileSync(dest, f.contents);
     }
   } catch (err) {
+    // Roll back the partial scaffold so a mid-write failure (ENOSPC, EACCES on
+    // a subpath, …) doesn't leave a half-written, non-loadable dir that the
+    // dir-collision guard (above) would then refuse to re-create. targetDir was
+    // confirmed ABSENT before the scan, so the whole subtree is owned by this
+    // command — safe to remove. force:true swallows already-gone.
+    try {
+      rmSync(targetDir, { recursive: true, force: true });
+    } catch (cleanupErr) {
+      // Best-effort cleanup; surface it so the principal knows a manual rm may
+      // be needed, but the original write error stays the primary failure.
+      process.stderr.write(
+        `  ⚠ stack create: rollback of ${targetDir} failed: ${cleanupErr instanceof Error ? cleanupErr.message : String(cleanupErr)}\n`,
+      );
+    }
     return opError(
       "create",
-      `write failed: ${err instanceof Error ? err.message : String(err)}`,
+      `write failed (partial scaffold rolled back): ${err instanceof Error ? err.message : String(err)}`,
       json,
     );
   }

--- a/src/cli/cortex/commands/stack.ts
+++ b/src/cli/cortex/commands/stack.ts
@@ -1,0 +1,506 @@
+#!/usr/bin/env bun
+/**
+ * `cortex stack <subcommand>` — C-808 (#808) born-aligned stack scaffolding.
+ *
+ * The PREVENT-side complement to v5.3.8's `warn_stack_identity_drift` (the
+ * DETECT side — `scripts/lib/plist-render.sh` + `docs/adr/0004-stack-slug-
+ * authority.md`). That detector WARNS at `arc upgrade` time when a stack's
+ * filesystem locator (dir basename / `cortex.<slug>.yaml` filename) drifts from
+ * `stack.id`'s trailing segment. THIS command makes that drift structurally
+ * IMPOSSIBLE for a stack it creates:
+ *
+ *   - dir basename == slug (the positional), and
+ *   - `stack.id = {principal}/{slug}` (derived, never free-typed), and
+ *   - an `assertAligned` self-check refuses to write unless all three agree.
+ *
+ * And UNIQUE within the principal: it refuses if the target dir exists, OR if
+ * scanning the existing stacks (split-layout dirs + legacy `cortex*.yaml`
+ * monoliths) finds any whose `stack.id` already equals `{principal}/{slug}`.
+ *
+ * Subcommands:
+ *   create <slug>   Scaffold a config-split stack skeleton (the
+ *                   docs/config-layout/ template, filled). DRY-RUN by default
+ *                   (prints the file set it WOULD write, touches nothing);
+ *                   `--apply` writes for real. NEVER overwrites an existing dir.
+ *   list            Discovered stacks + their stack.id + aligned/drift flag.
+ *
+ * SAFETY (mirrors `cortex network`): `create` is dry-run unless `--apply`, so
+ * an accidental run during development is inert. It never generates signing
+ * keys — `stack.nkey_seed_path` is set to the conventional path and
+ * `arc upgrade Cortex` auto-provisions the seed on first install
+ * (taps/.../postupgrade.sh §2 — the existing flow).
+ *
+ * Exit codes: 0 success · 1 operational failure (conflict / write error) · 2 usage.
+ */
+
+import { existsSync, mkdirSync, writeFileSync } from "fs";
+import { dirname, join } from "path";
+import { homedir } from "os";
+
+import { CliArgsError } from "./_shared/arg-error";
+import { envelopeError, envelopeOk, renderJson } from "./_shared/envelope";
+import { type ExitResult } from "./_shared/exit-result";
+import { parseSubcommandArgs, type SubcommandSpec } from "./_shared/parser";
+import {
+  assertAligned,
+  discoverStacks,
+  renderScaffold,
+  type ScaffoldFile,
+} from "./stack-lib";
+
+export { type ExitResult } from "./_shared/exit-result";
+
+// =============================================================================
+// Grammar
+// =============================================================================
+
+type StackSubcommand = "create" | "list";
+
+/**
+ * Slug + principal grammar. A slug is a single `{stack_id}` segment of the
+ * `stack.id` `{principal}/{stack_id}` grammar (src/common/types/stack.ts):
+ * lowercase, letter-prefixed, alphanumeric + hyphen/underscore. The principal
+ * half matches `PrincipalConfigSchema.id` (provision-stack.ts) — the narrower
+ * no-underscore form. Born-aligning to that schema is the whole point (#808):
+ * we never write a stack.id the loader would later reject.
+ */
+const SLUG_RE = /^[a-z][a-z0-9_-]*$/;
+const PRINCIPAL_ID_RE = /^[a-z][a-z0-9-]*$/;
+
+/** Default config dir (same canonical path the daemon + network CLI use). */
+const DEFAULT_CONFIG_DIR = "~/.config/cortex";
+/** Default agent id for the scaffolded stack. */
+const DEFAULT_AGENT_ID = "luna";
+
+const SPEC: SubcommandSpec<StackSubcommand> = {
+  cliName: "stack",
+  subcommands: {
+    create: {
+      positionals: ["slug"],
+      flags: {
+        "--principal": "value",
+        "--display-name": "value",
+        "--agent": "value",
+        "--config-dir": "value",
+        "--apply": "bool",
+        "--dry-run": "bool",
+      },
+    },
+    list: {
+      positionals: [],
+      flags: {
+        "--config-dir": "value",
+      },
+    },
+  },
+  universal: { "--json": "bool", "--help": "bool", "-h": "bool" },
+};
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+/** Expand a leading `~/` to $HOME (same treatment as the loader's expandTilde,
+ *  re-implemented locally so the command stays free of loader coupling). */
+function expandTildePath(p: string): string {
+  if (p === "~") return homedir();
+  if (p.startsWith("~/")) return join(homedir(), p.slice(2));
+  return p;
+}
+
+function optionalValueFlag(
+  flags: Record<string, string | true>,
+  name: string,
+): string | undefined {
+  const v = flags[name];
+  return typeof v === "string" ? v : undefined;
+}
+
+/**
+ * `create` writes to disk; the DEFAULT is dry-run (safe). `--apply` opts into
+ * the real write; `--dry-run` is accepted explicitly. Both together is a usage
+ * error. Mirrors `cortex network`'s `resolveApply`.
+ */
+function resolveApply(
+  flags: Record<string, string | true>,
+): { ok: true; apply: boolean } | { ok: false; reason: string } {
+  const apply = flags["--apply"] === true;
+  const dry = flags["--dry-run"] === true;
+  if (apply && dry) {
+    return { ok: false, reason: "--apply and --dry-run are mutually exclusive" };
+  }
+  return { ok: true, apply };
+}
+
+/**
+ * Resolve the principal: explicit `--principal`, else infer from the config dir
+ * when EXACTLY one principal is present across the discovered stacks, else a
+ * usage error naming the flag. Inferring from a single principal is the common
+ * case (one human owns every stack on the host); ambiguity (0 or 2+) is a
+ * deliberate usage error so we never guess wrong.
+ */
+function resolvePrincipal(
+  flags: Record<string, string | true>,
+  configDir: string,
+): { ok: true; principal: string } | { ok: false; reason: string } {
+  const flagged = optionalValueFlag(flags, "--principal");
+  if (flagged !== undefined) return { ok: true, principal: flagged };
+
+  // Infer: collect distinct principal halves of every discovered stack.id.
+  const principals = new Set<string>();
+  for (const s of discoverStacks(configDir)) {
+    if (s.stackId === undefined) continue;
+    const principalHalf = s.stackId.split("/")[0];
+    if (principalHalf !== undefined && principalHalf.length > 0) principals.add(principalHalf);
+  }
+  if (principals.size === 1) {
+    const only = [...principals][0];
+    if (only !== undefined) return { ok: true, principal: only };
+  }
+  const detail =
+    principals.size === 0
+      ? "no existing stack to infer it from"
+      : `${principals.size.toString()} distinct principals present (${[...principals].sort().join(", ")})`;
+  return {
+    ok: false,
+    reason: `--principal is required (${detail})`,
+  };
+}
+
+// =============================================================================
+// create
+// =============================================================================
+
+function runCreate(
+  slug: string,
+  flags: Record<string, string | true>,
+  json: boolean,
+): ExitResult {
+  // --- validate slug -------------------------------------------------------
+  if (!SLUG_RE.test(slug)) {
+    return usageError(
+      "create",
+      `slug "${slug}" must be lowercase alphanumeric + hyphen/underscore, letter-prefixed (the {stack_id} segment grammar)`,
+      json,
+    );
+  }
+
+  const configDir = expandTildePath(optionalValueFlag(flags, "--config-dir") ?? DEFAULT_CONFIG_DIR);
+
+  // --- resolve + validate principal ---------------------------------------
+  const principalRes = resolvePrincipal(flags, configDir);
+  if (!principalRes.ok) return usageError("create", principalRes.reason, json);
+  const principal = principalRes.principal;
+  if (!PRINCIPAL_ID_RE.test(principal)) {
+    return usageError(
+      "create",
+      `principal "${principal}" must be lowercase alphanumeric + hyphen, letter-prefixed`,
+      json,
+    );
+  }
+
+  // --- agent + display name ------------------------------------------------
+  const agentId = optionalValueFlag(flags, "--agent") ?? DEFAULT_AGENT_ID;
+  if (!PRINCIPAL_ID_RE.test(agentId)) {
+    return usageError(
+      "create",
+      `--agent "${agentId}" must be lowercase alphanumeric + hyphen, letter-prefixed`,
+      json,
+    );
+  }
+  const displayName = optionalValueFlag(flags, "--display-name") ?? capitalize(agentId);
+
+  // --- derive the born-aligned stack id ------------------------------------
+  const stackId = `${principal}/${slug}`;
+  const seedPath = `~/.config/nats/cortex-${slug}.nk`;
+
+  const applyRes = resolveApply(flags);
+  if (!applyRes.ok) return usageError("create", applyRes.reason, json);
+
+  const targetDir = join(configDir, slug);
+
+  // --- uniqueness: dir collision ------------------------------------------
+  // Never overwrite. Refuse a dir that already exists BEFORE the scan so a
+  // partial/foreign dir is a clear, specific error.
+  if (existsSync(targetDir)) {
+    return opError(
+      "create",
+      `refusing to create: ${targetDir} already exists (never overwriting). Remove or rename it, or pick a different slug.`,
+      json,
+    );
+  }
+
+  // --- uniqueness: duplicate stack.id within the principal -----------------
+  // Scan existing stacks (split dirs + legacy monoliths) for the SAME stack.id.
+  // A differently-named dir whose stack.id == {principal}/{slug} would create
+  // the exact two-stacks-one-identity ambiguity #808 prevents.
+  for (const existing of discoverStacks(configDir)) {
+    if (existing.stackId === stackId) {
+      return opError(
+        "create",
+        `refusing to create: stack.id "${stackId}" is already used by ${existing.configPath} (locator slug "${existing.slugLocator}", ${existing.layout} layout). Stack ids must be unique within a principal.`,
+        json,
+      );
+    }
+  }
+
+  // --- alignment self-check (the #808 structural guarantee) ----------------
+  // dir basename == slug == trailing segment of the stack.id we're about to
+  // write. Throws on a mismatch — that would be a bug in THIS command, not a
+  // principal input error (those were rejected above). Belt-and-braces before
+  // any disk write.
+  try {
+    assertAligned(slug, stackId);
+  } catch (err) {
+    return opError("create", err instanceof Error ? err.message : String(err), json);
+  }
+
+  // --- render --------------------------------------------------------------
+  const files = renderScaffold({ slug, principal, stackId, agentId, displayName, seedPath });
+
+  // --- dry-run (DEFAULT): print the file set, touch NOTHING ----------------
+  if (!applyRes.apply) {
+    return renderPlan(slug, principal, stackId, agentId, seedPath, targetDir, files, false, json);
+  }
+
+  // --- apply: write the file set -------------------------------------------
+  try {
+    for (const f of files) {
+      const dest = join(targetDir, f.relPath);
+      mkdirSync(dirname(dest), { recursive: true });
+      writeFileSync(dest, f.contents);
+    }
+  } catch (err) {
+    return opError(
+      "create",
+      `write failed: ${err instanceof Error ? err.message : String(err)}`,
+      json,
+    );
+  }
+
+  return renderPlan(slug, principal, stackId, agentId, seedPath, targetDir, files, true, json);
+}
+
+function renderPlan(
+  slug: string,
+  principal: string,
+  stackId: string,
+  agentId: string,
+  seedPath: string,
+  targetDir: string,
+  files: ScaffoldFile[],
+  applied: boolean,
+  json: boolean,
+): ExitResult {
+  if (json) {
+    return ok(
+      renderJson(
+        envelopeOk(
+          files.map((f) => ({ path: join(targetDir, f.relPath) })),
+          {
+            slug,
+            principal,
+            stack_id: stackId,
+            agent: agentId,
+            seed_path: seedPath,
+            aligned: "true",
+            applied: applied ? "true" : "false",
+          },
+        ),
+      ),
+    );
+  }
+
+  const lines: string[] = [];
+  lines.push(`cortex stack create ${slug}: ${applied ? "created" : "dry-run"}`);
+  if (!applied) lines.push("  (dry-run — no disk mutation; pass --apply to write)");
+  lines.push("");
+  lines.push(`  principal:  ${principal}`);
+  lines.push(`  stack.id:   ${stackId}   (born aligned: dir == slug == trailing segment)`);
+  lines.push(`  agent:      ${agentId}`);
+  lines.push(`  seed path:  ${seedPath}   (auto-provisioned by 'arc upgrade Cortex' — NOT generated here)`);
+  lines.push("");
+  lines.push(`  ${applied ? "wrote" : "would write"} under ${targetDir}:`);
+  for (const f of files) lines.push(`    • ${f.relPath}`);
+  lines.push("");
+  if (applied) {
+    lines.push("Next steps:");
+    lines.push("  1. Fill the <REPLACE_ME> markers (Discord token/guild/channels, your Discord id).");
+    lines.push(`  2. Provision the signing seed: arc upgrade Cortex   (auto-provisions ${seedPath} on first install)`);
+    lines.push(`  3. Point your daemon at the pointer: cortex start --config ${join(targetDir, `${slug}.yaml`)}`);
+    lines.push(`  4. Federate (optional): cortex network join <network>   (run from this stack's config)`);
+  } else {
+    lines.push("Re-run with --apply to write these files.");
+  }
+  lines.push("");
+  return ok(lines.join("\n"));
+}
+
+function capitalize(s: string): string {
+  return s.length === 0 ? s : s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+// =============================================================================
+// list
+// =============================================================================
+
+function runList(
+  flags: Record<string, string | true>,
+  json: boolean,
+): ExitResult {
+  const configDir = expandTildePath(optionalValueFlag(flags, "--config-dir") ?? DEFAULT_CONFIG_DIR);
+  const stacks = discoverStacks(configDir);
+
+  if (json) {
+    return ok(
+      renderJson(
+        envelopeOk(
+          stacks.map((s) => ({
+            slug_locator: s.slugLocator,
+            stack_id: s.stackId ?? "",
+            layout: s.layout,
+            aligned: s.aligned === undefined ? "unknown" : s.aligned ? "true" : "false",
+          })),
+          { config_dir: configDir, count: stacks.length.toString() },
+        ),
+      ),
+    );
+  }
+
+  if (stacks.length === 0) {
+    return ok(`cortex stack list: no stacks under ${configDir}\n`);
+  }
+  const lines = [`cortex stack list (${configDir}):`, ""];
+  for (const s of stacks) {
+    const flag =
+      s.aligned === undefined ? "no stack.id" : s.aligned ? "aligned" : "DRIFT";
+    lines.push(`  ${s.slugLocator}  →  ${s.stackId ?? "(no stack.id)"}  [${s.layout}, ${flag}]`);
+  }
+  lines.push("");
+  return ok(lines.join("\n"));
+}
+
+// =============================================================================
+// Result builders
+// =============================================================================
+
+function ok(stdout: string): ExitResult {
+  return { exitCode: 0, stdout, stderr: "" };
+}
+
+function usageError(sub: string, reason: string, json: boolean): ExitResult {
+  const stderr = json
+    ? renderJson(envelopeError(reason, { subcommand: sub }))
+    : `cortex stack ${sub}: ${reason}\n${topLevelHelp()}`;
+  return { exitCode: 2, stdout: "", stderr };
+}
+
+/** Operational failure (exit 1) — a conflict or write error, distinct from a
+ *  CLI-grammar mistake (exit 2). */
+function opError(sub: string, reason: string, json: boolean): ExitResult {
+  const stderr = json
+    ? renderJson(envelopeError(reason, { subcommand: sub }))
+    : `cortex stack ${sub}: ${reason}\n`;
+  return { exitCode: 1, stdout: "", stderr };
+}
+
+// =============================================================================
+// Dispatcher
+// =============================================================================
+
+// Returns a Promise to match the passthrough contract in src/cortex.ts (and the
+// `dispatchNetwork` / `dispatchProvisionStack` siblings), even though every
+// handler is synchronous (no disk I/O is awaited — `stack` neither talks to the
+// bus nor the registry). Declared non-`async` so the linter's require-await rule
+// is satisfied; the explicit `Promise.resolve` wrapping keeps the awaited shape.
+export function dispatchStack(argv: string[]): Promise<ExitResult> {
+  let parsed;
+  try {
+    parsed = parseSubcommandArgs(SPEC, argv);
+  } catch (err) {
+    if (err instanceof CliArgsError) {
+      return Promise.resolve({ exitCode: 2 as const, stdout: "", stderr: `cortex stack: ${err.message}\n${topLevelHelp()}` });
+    }
+    throw err;
+  }
+
+  const json = parsed.flags["--json"] === true;
+
+  if (parsed.subcommand === "help" || parsed.help) {
+    return Promise.resolve({ exitCode: 0 as const, stdout: topLevelHelp(), stderr: "" });
+  }
+  if (parsed.subcommand === "unknown") {
+    const msg =
+      parsed.rawSubcommand === ""
+        ? "usage error — no subcommand specified."
+        : `unknown subcommand "${parsed.rawSubcommand}".`;
+    return Promise.resolve({ exitCode: 2 as const, stdout: "", stderr: `cortex stack: ${msg}\n${topLevelHelp()}` });
+  }
+
+  switch (parsed.subcommand) {
+    case "create":
+      return Promise.resolve(runCreate(parsed.positionals.slug ?? "", parsed.flags, json));
+    case "list":
+      return Promise.resolve(runList(parsed.flags, json));
+  }
+}
+
+// =============================================================================
+// Help
+// =============================================================================
+
+function topLevelHelp(): string {
+  return `cortex stack — scaffold + inspect cortex stacks (C-808, #808)
+
+Usage:
+  cortex stack create <slug> [--principal <id>] [--apply] [options]
+  cortex stack list [--config-dir <path>] [--json]
+
+The prevent-side complement to the install-time slug<->stack.id drift detector
+(warn_stack_identity_drift / ADR-0004). \`create\` scaffolds a config-split stack
+BORN ALIGNED — dir basename == slug == trailing segment of stack.id — so that
+drift can NEVER form for a stack created this way, and UNIQUE within the
+principal (refuses a dir collision OR a duplicate stack.id).
+
+Subcommands:
+  create  Scaffold a config-split stack skeleton (the docs/config-layout/
+          template, filled with your real slug/principal/agent; <REPLACE_ME>
+          kept only for true secrets — Discord token/guild/channels + the
+          post-first-boot nkey_pub). Derives stack.id = {principal}/{slug};
+          sets stack.nkey_seed_path to the conventional ~/.config/nats/
+          cortex-<slug>.nk and does NOT generate the seed — 'arc upgrade Cortex'
+          auto-provisions it on first install. NEVER overwrites an existing dir.
+  list    Show discovered stacks (split-layout dirs + legacy cortex*.yaml
+          monoliths) with their stack.id and an aligned/DRIFT flag.
+
+Safety:
+  create defaults to DRY-RUN (prints the file set it WOULD write, touches
+  nothing). Pass --apply to write. --apply and --dry-run are mutually exclusive.
+
+Flags (create):
+  --principal <id>      The principal half of stack.id. Default: inferred from
+                        the single existing principal under --config-dir; if
+                        zero or 2+ principals are present, it is REQUIRED.
+  --display-name <name> The agent's display name (default: capitalized agent id).
+  --agent <id>          The agent id on the scaffolded stack (default: luna).
+  --config-dir <path>   Config dir to create the stack under (default:
+                        ~/.config/cortex). The stack lands at <config-dir>/<slug>/.
+  --apply               Write the files (default: dry-run).
+  --json                Emit a { status, items, data, error } envelope.
+
+Flags (list):
+  --config-dir <path>   Config dir to scan (default: ~/.config/cortex).
+  --json                Emit a { status, items, data, error } envelope.
+`;
+}
+
+// =============================================================================
+// Main
+// =============================================================================
+
+if (import.meta.main) {
+  const result = await dispatchStack(process.argv.slice(2));
+  if (result.stdout) process.stdout.write(result.stdout);
+  if (result.stderr) process.stderr.write(result.stderr);
+  process.exit(result.exitCode);
+}

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -117,6 +117,7 @@ import { WorklogManager } from "./runner/worklog-manager";
 // These do NOT boot the daemon — only `start` does.
 import { dispatchNetwork } from "./cli/cortex/commands/network";
 import { dispatchProvisionStack } from "./cli/cortex/commands/provision-stack";
+import { dispatchStack } from "./cli/cortex/commands/stack";
 
 import { CloudPublisher } from "./taps/cc-events/cloud-publisher";
 import {
@@ -3451,6 +3452,23 @@ if (import.meta.main) {
     .helpOption(false)
     .action(async (args: string[]) => {
       const result = await dispatchProvisionStack(args);
+      if (result.stdout) process.stdout.write(result.stdout);
+      if (result.stderr) process.stderr.write(result.stderr);
+      process.exit(result.exitCode);
+    });
+
+  // C-808 (#808) — born-aligned, unique stack scaffold. Same passthrough shape
+  // as `network` / `provision-stack`: `dispatchStack` owns its own arg parsing,
+  // so commander hands it the raw remaining argv untouched.
+  program
+    .command("stack")
+    .description("Scaffold + inspect cortex stacks (create / list)")
+    .argument("[args...]", "stack subcommand + flags (see `cortex stack --help`)")
+    .allowUnknownOption()
+    .passThroughOptions()
+    .helpOption(false)
+    .action(async (args: string[]) => {
+      const result = await dispatchStack(args);
       if (result.stdout) process.stdout.write(result.stdout);
       if (result.stderr) process.stderr.write(result.stderr);
       process.exit(result.exitCode);


### PR DESCRIPTION
## What & why (closes #808)

The prevent-side complement to v5.3.8's drift **detector** (`warn_stack_identity_drift` / ADR-0004). `cortex stack create <slug>` scaffolds a config-split stack **born aligned** — dir basename == slug == trailing segment of `stack.id` — so the slug↔`stack.id` drift that bit JC can **never form** for a stack created this way, and **unique within the principal** (refuses a dir collision OR a duplicate `stack.id`).

This is the `cortex stack` counterpart to the `cortex network` family (the gap your question surfaced: `stack.id` was hand-authored with a silent `${principal}/default` fallback, and nothing generated/uniquified it).

## Changes
- **`src/cli/cortex/commands/stack.ts`** — `dispatchStack` + `create`/`list` (mirrors `dispatchNetwork`; exit codes 0/1/2; **dry-run default**, `--apply` to write).
- **`src/cli/cortex/commands/stack-lib.ts`** — pure logic: `discoverStacks` (TS replica of `plist-render.sh` discovery), `assertAligned` (the structural guarantee — pre-write self-check), `renderScaffold`.
- **`src/cortex.ts`** — `stack` passthrough commander subcommand.
- **Tests** — `stack-cli.test.ts` + `stack-lib.test.ts` (36 tests): slug/principal validation, uniqueness rejection (dir + duplicate stack.id), dir==slug==stack.id alignment, dry-run-writes-nothing, `--apply` file set, refuse-overwrite, principal inference, **born-loadable** (scaffold composes through the real loader).
- **Docs** — `docs/agents-md/network-management.md` → broadened to "Platform Management" (+ `cortex stack create` row); `docs/config-layout/README.md` "Even easier" quick-start; `docs/sop-stack-onboarding.md` Part 1 leads with the command. (CLAUDE.md regenerates via `arc upgrade compass`.)

## Design notes
- **Slug regex matches the real schema** `^[a-z][a-z0-9_-]*$` (underscores allowed for the stack segment per `stack.ts`) — never emits a `stack.id` the loader rejects.
- **`nkey_pub` uses the valid-format all-A `U…` placeholder** (like `docs/config-layout/`), not bare `<REPLACE_ME>` — the schema regex-validates those at load; a born-loadable regression test guards it. `<REPLACE_ME>` kept for true free-form secrets only (Discord token/guild/channel, discordId).
- **Does NOT generate signing keys** — sets `nkey_seed_path` to the conventional path; `arc upgrade Cortex` auto-provisions on first install (existing flow). Never overwrites an existing dir.

## Verification
- stack tests: **36 pass / 0 fail** · `tsc --noEmit` clean · `lint:errors` clean · vocab carve-out **PASS**
- Full `bun test`: 2 pre-existing load-induced flakies (bash-guard telemetry, fs-watcher timing) unrelated to this diff; pass in isolation.

closes #808