### PR TITLE
feat(federation): resolve federated peers[] from the registry roster at boot (DD-5 wiring)

### DIFF
--- a/src/__tests__/cortex.federated-peer-boot.test.ts
+++ b/src/__tests__/cortex.federated-peer-boot.test.ts
@@ -1,0 +1,253 @@
+/**
+ * S4 (Network Join Control Plane, epic #733; DD-5 wiring) — integration test
+ * that `startCortex` invokes the boot-path federated-peer resolver and feeds
+ * the resolved `peers[]` into the SAME membership gate a hand-pin feeds.
+ *
+ * This closes the `cortex-config.ts` "WIRING STATUS (S2)" gap: before S4 the
+ * resolver was never called at boot. Here we drive the real `startCortex` with
+ * an injected fixture roster provider (NO network I/O, NO `~/.config` touch)
+ * and assert:
+ *
+ *   1. DD-5 — a peer declared with only `principal_id` + `stack_id` (no
+ *      `principal_pubkey`) has its key filled from the verified roster after
+ *      boot, and the resolved network's `peers[]` is what the gate now sees.
+ *   2. The gate (`evaluateFederationGate` / `resolveSourceNetwork`) admits the
+ *      registry-resolved peer IDENTICALLY to a hand-pinned one — there is no
+ *      separate registry-resolved code path (DD-5).
+ *   3. DD-11 — a hand-pin that disagrees with the roster is dropped from the
+ *      gate at boot, so the gate then DENIES that peer as `unknown_network`.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { startCortex, type StartCortexOptions } from "../cortex";
+import { AgentConfigSchema, type AgentConfig } from "../common/types/config";
+import type { Envelope } from "../bus/myelin/envelope-validator";
+import type { EnvelopeHandler, MyelinRuntime } from "../bus/myelin/runtime";
+import {
+  evaluateFederationGate,
+  type FederationGateDecision,
+} from "../bus/surface-router";
+import { base64PubkeyToNkey } from "../common/registry/encoding";
+import type { NetworkRosterProvider } from "../common/registry/resolve-federated-peers";
+import type { NetworkFetchResult } from "../common/registry/network-client";
+import type { NetworkRosterResult } from "../common/registry/types";
+import type {
+  Policy,
+  PolicyFederatedNetwork,
+} from "../common/types/cortex-config";
+
+const PEER_B64 = "AQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQE=";
+const PEER_B64_OTHER = "AgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI=";
+const PEER_NKEY = base64PubkeyToNkey(PEER_B64)!;
+
+function minimalConfig(): AgentConfig {
+  return AgentConfigSchema.parse({
+    agent: { name: "test-cortex", displayName: "TestCortex" },
+    discord: [],
+    mattermost: [],
+    claude: { timeoutMs: 120_000 },
+    paths: { publishedEventsDir: "/tmp/grove-cortex-fedboot-published" },
+  });
+}
+
+function createNoopRuntime(): MyelinRuntime {
+  /* eslint-disable @typescript-eslint/no-empty-function */
+  return {
+    enabled: false,
+    onEnvelope: (_handler: EnvelopeHandler) => ({ unregister: () => {} }),
+    publish: async () => {},
+    stop: async () => {},
+  };
+  /* eslint-enable @typescript-eslint/no-empty-function */
+}
+
+function networkWith(
+  peers: PolicyFederatedNetwork["peers"],
+): PolicyFederatedNetwork {
+  return {
+    id: "metafactory-community",
+    leaf_node: "primary",
+    peers,
+    // Accept federated traffic addressed to the LOCAL principal/stack.
+    accept_subjects: ["federated.test-op.default.>"],
+    deny_subjects: [],
+    announce_capabilities: [],
+    max_hop: 3,
+  };
+}
+
+function policyWith(networks: PolicyFederatedNetwork[]): Policy {
+  return {
+    principals: [],
+    federated: {
+      networks,
+      registry: { url: "https://network.meta-factory.ai" },
+    },
+  } as unknown as Policy;
+}
+
+function fixtureProvider(roster: NetworkRosterResult): NetworkRosterProvider {
+  return {
+    async fetchAndCache(): Promise<NetworkFetchResult<{ roster: NetworkRosterResult }>> {
+      return { status: "ok", value: { roster } };
+    },
+    loadCached() {
+      return undefined;
+    },
+  };
+}
+
+/** A federated envelope whose `source` principal is `sourcePrincipal`. */
+function federatedEnvelopeFrom(sourcePrincipal: string): Envelope {
+  return {
+    source: `${sourcePrincipal}.sage-host`,
+  } as unknown as Envelope;
+}
+
+async function bootWithPolicy(
+  policy: Policy,
+  provider: NetworkRosterProvider,
+): Promise<{ resolvedPolicy: Policy | undefined; stop: () => Promise<void> }> {
+  const tmpAgentsDir = mkdtempSync(join(tmpdir(), "cortex-fedboot-"));
+  const options: StartCortexOptions = {
+    disableConfigWatcher: true,
+    disableDashboard: true,
+    disableOutboundPoller: true,
+    disableGithubReceiver: true,
+    agentsDir: tmpAgentsDir,
+    injectRuntime: createNoopRuntime(),
+    principal: { id: "test-op" },
+    policy,
+    bootFederatedRosterProvider: provider,
+  };
+  const handle = await startCortex(minimalConfig(), options);
+  return {
+    // `startCortex` rewrites `options.policy` in place with the resolved set.
+    resolvedPolicy: options.policy,
+    stop: async () => {
+      await handle.stop();
+      rmSync(tmpAgentsDir, { recursive: true, force: true });
+    },
+  };
+}
+
+/** Build the gate's network map from a resolved policy + evaluate one subject. */
+function gateDecision(
+  resolvedPolicy: Policy | undefined,
+  sourcePrincipal: string,
+): FederationGateDecision {
+  const networksById = new Map<string, PolicyFederatedNetwork>();
+  for (const n of resolvedPolicy?.federated?.networks ?? []) {
+    networksById.set(n.id, n);
+  }
+  return evaluateFederationGate(
+    "federated.test-op.default.tasks.code-review.req",
+    federatedEnvelopeFrom(sourcePrincipal),
+    networksById,
+    "primary",
+  );
+}
+
+describe("startCortex — federated-peer boot resolution (DD-5 wiring)", () => {
+  test("a pubkey-less peer is registry-resolved at boot and admitted by the gate", async () => {
+    const policy = policyWith([
+      networkWith([{ principal_id: "jcfischer", stack_id: "jcfischer/sage-host" }]),
+    ]);
+    const provider = fixtureProvider({
+      network_id: "metafactory-community",
+      members: [{ principal_id: "jcfischer", principal_pubkey: PEER_B64 }],
+    });
+
+    const { resolvedPolicy, stop } = await bootWithPolicy(policy, provider);
+    try {
+      // DD-5 — the peer's pubkey is filled from the roster (nkey-U).
+      const peers = resolvedPolicy?.federated?.networks[0]?.peers ?? [];
+      expect(peers).toHaveLength(1);
+      expect(peers[0]?.principal_id).toBe("jcfischer");
+      expect(peers[0]?.principal_pubkey).toBe(PEER_NKEY);
+
+      // The gate now admits the registry-resolved peer (membership keys on
+      // `peers[].principal_id`, populated by the resolver — same path a
+      // hand-pin feeds). `allow` for an accepted subject.
+      expect(gateDecision(resolvedPolicy, "jcfischer")).toBe("allow");
+    } finally {
+      await stop();
+    }
+  });
+
+  test("a registry-resolved peer is admitted IDENTICALLY to a hand-pinned one", async () => {
+    // Network A: peer hand-pinned. Network B: same peer pubkey-less (resolved).
+    // Both must yield the SAME gate verdict for the same source principal.
+    const handPinned = policyWith([
+      networkWith([
+        { principal_id: "jcfischer", stack_id: "jcfischer/sage-host", principal_pubkey: PEER_NKEY },
+      ]),
+    ]);
+    const resolvedOnly = policyWith([
+      networkWith([{ principal_id: "jcfischer", stack_id: "jcfischer/sage-host" }]),
+    ]);
+    const provider = fixtureProvider({
+      network_id: "metafactory-community",
+      members: [{ principal_id: "jcfischer", principal_pubkey: PEER_B64 }],
+    });
+
+    const a = await bootWithPolicy(handPinned, provider);
+    const b = await bootWithPolicy(resolvedOnly, provider);
+    try {
+      const verdictHandPinned = gateDecision(a.resolvedPolicy, "jcfischer");
+      const verdictResolved = gateDecision(b.resolvedPolicy, "jcfischer");
+      expect(verdictResolved).toEqual(verdictHandPinned);
+      expect(verdictResolved).toBe("allow");
+      // And both carry the same resolved key on the gate's network.
+      expect(b.resolvedPolicy?.federated?.networks[0]?.peers[0]?.principal_pubkey).toBe(
+        a.resolvedPolicy?.federated?.networks[0]?.peers[0]?.principal_pubkey,
+      );
+    } finally {
+      await a.stop();
+      await b.stop();
+    }
+  });
+
+  test("DD-11 — a hand-pin disagreeing with the roster is dropped; gate denies it", async () => {
+    const policy = policyWith([
+      networkWith([
+        // hand-pinned to PEER_NKEY, but the roster will say PEER_B64_OTHER.
+        { principal_id: "jcfischer", stack_id: "jcfischer/sage-host", principal_pubkey: PEER_NKEY },
+        // a pubkey-less peer forces the roster fetch (without it the resolver's
+        // back-compat fast path skips the registry, so DD-11 wouldn't fire).
+        { principal_id: "andreas", stack_id: "andreas/community" },
+      ]),
+    ]);
+    const provider = fixtureProvider({
+      network_id: "metafactory-community",
+      members: [
+        { principal_id: "jcfischer", principal_pubkey: PEER_B64_OTHER },
+        { principal_id: "andreas", principal_pubkey: PEER_B64 },
+      ],
+    });
+
+    const { resolvedPolicy, stop } = await bootWithPolicy(policy, provider);
+    try {
+      // jcfischer dropped (DD-11 mismatch); andreas resolved + kept.
+      const peers = resolvedPolicy?.federated?.networks[0]?.peers ?? [];
+      expect(peers.map((p) => p.principal_id)).toEqual(["andreas"]);
+
+      // The gate now treats jcfischer as an unknown peer (dropped from peers[]).
+      const denied = gateDecision(resolvedPolicy, "jcfischer");
+      expect(typeof denied).toBe("object");
+      if (typeof denied === "object" && denied.kind === "peer_not_in_accept_list") {
+        expect(denied.unknown_network).toBe(true);
+      } else {
+        throw new Error(`expected peer_not_in_accept_list, got ${JSON.stringify(denied)}`);
+      }
+      // andreas (resolved) is still admitted.
+      expect(gateDecision(resolvedPolicy, "andreas")).toBe("allow");
+    } finally {
+      await stop();
+    }
+  });
+});

--- a/src/__tests__/cortex.federated-peer-boot.test.ts
+++ b/src/__tests__/cortex.federated-peer-boot.test.ts
@@ -111,8 +111,15 @@ function federatedEnvelopeFrom(sourcePrincipal: string): Envelope {
 async function bootWithPolicy(
   policy: Policy,
   provider: NetworkRosterProvider,
-): Promise<{ resolvedPolicy: Policy | undefined; stop: () => Promise<void> }> {
+): Promise<{
+  resolvedPolicy: Policy | undefined;
+  callerPolicyUnchanged: boolean;
+  stop: () => Promise<void>;
+}> {
   const tmpAgentsDir = mkdtempSync(join(tmpdir(), "cortex-fedboot-"));
+  // PR #818 NIT-6 — `startCortex` no longer mutates `options.policy`. Capture
+  // the resolved view via the test-only `onBootResolvedPolicy` observation seam.
+  let resolvedPolicy: Policy | undefined;
   const options: StartCortexOptions = {
     disableConfigWatcher: true,
     disableDashboard: true,
@@ -123,11 +130,15 @@ async function bootWithPolicy(
     principal: { id: "test-op" },
     policy,
     bootFederatedRosterProvider: provider,
+    onBootResolvedPolicy: (p) => {
+      resolvedPolicy = p;
+    },
   };
   const handle = await startCortex(minimalConfig(), options);
   return {
-    // `startCortex` rewrites `options.policy` in place with the resolved set.
-    resolvedPolicy: options.policy,
+    resolvedPolicy,
+    // The caller's `options.policy` reference must be UNTOUCHED (NIT-6).
+    callerPolicyUnchanged: options.policy === policy,
     stop: async () => {
       await handle.stop();
       rmSync(tmpAgentsDir, { recursive: true, force: true });
@@ -162,7 +173,10 @@ describe("startCortex — federated-peer boot resolution (DD-5 wiring)", () => {
       members: [{ principal_id: "jcfischer", principal_pubkey: PEER_B64 }],
     });
 
-    const { resolvedPolicy, stop } = await bootWithPolicy(policy, provider);
+    const { resolvedPolicy, callerPolicyUnchanged, stop } = await bootWithPolicy(
+      policy,
+      provider,
+    );
     try {
       // DD-5 — the peer's pubkey is filled from the roster (nkey-U).
       const peers = resolvedPolicy?.federated?.networks[0]?.peers ?? [];
@@ -174,6 +188,13 @@ describe("startCortex — federated-peer boot resolution (DD-5 wiring)", () => {
       // `peers[].principal_id`, populated by the resolver — same path a
       // hand-pin feeds). `allow` for an accepted subject.
       expect(gateDecision(resolvedPolicy, "jcfischer")).toBe("allow");
+
+      // PR #818 NIT-6 — the caller's `options.policy` reference is NOT mutated:
+      // the resolved view is a fresh local binding in `startCortex`. (The input
+      // peer was pubkey-less; the resolved one carries the filled key — so they
+      // are also not the same object.)
+      expect(callerPolicyUnchanged).toBe(true);
+      expect(policy.federated?.networks[0]?.peers[0]?.principal_pubkey).toBeUndefined();
     } finally {
       await stop();
     }
@@ -217,8 +238,8 @@ describe("startCortex — federated-peer boot resolution (DD-5 wiring)", () => {
       networkWith([
         // hand-pinned to PEER_NKEY, but the roster will say PEER_B64_OTHER.
         { principal_id: "jcfischer", stack_id: "jcfischer/sage-host", principal_pubkey: PEER_NKEY },
-        // a pubkey-less peer forces the roster fetch (without it the resolver's
-        // back-compat fast path skips the registry, so DD-11 wouldn't fire).
+        // a second, pubkey-less peer (resolved) — proves the mismatch drop is
+        // per-peer, not all-or-nothing.
         { principal_id: "andreas", stack_id: "andreas/community" },
       ]),
     ]);
@@ -246,6 +267,45 @@ describe("startCortex — federated-peer boot resolution (DD-5 wiring)", () => {
       }
       // andreas (resolved) is still admitted.
       expect(gateDecision(resolvedPolicy, "andreas")).toBe("allow");
+    } finally {
+      await stop();
+    }
+  });
+
+  test("DD-11 MAJOR-1 — a FULLY hand-pinned network is cross-checked; a drifted pin is dropped", async () => {
+    // PR #818 review MAJOR-1 regression guard. BEFORE the fix this network made
+    // ZERO registry calls (every peer hand-pinned ⇒ `needsRegistry` false), so a
+    // hand-pin that had drifted from a rotated/tampered roster key was admitted
+    // on the stale pin and DD-11 never fired. AFTER the fix the roster IS fetched
+    // for any non-empty network when a registry is configured, so the pin↔roster
+    // cross-check fires and the drifted peer is DROPPED.
+    const policy = policyWith([
+      networkWith([
+        // The ONLY peer — fully hand-pinned to PEER_NKEY.
+        { principal_id: "jcfischer", stack_id: "jcfischer/sage-host", principal_pubkey: PEER_NKEY },
+      ]),
+    ]);
+    // The registry serves a DIFFERENT key for the same principal (rotation /
+    // compromise): drift signal.
+    const provider = fixtureProvider({
+      network_id: "metafactory-community",
+      members: [{ principal_id: "jcfischer", principal_pubkey: PEER_B64_OTHER }],
+    });
+
+    const { resolvedPolicy, stop } = await bootWithPolicy(policy, provider);
+    try {
+      // The drifted hand-pin is DROPPED (not silently kept on the stale pin).
+      const peers = resolvedPolicy?.federated?.networks[0]?.peers ?? [];
+      expect(peers).toHaveLength(0);
+
+      // The gate denies the dropped peer as an unknown network member.
+      const denied = gateDecision(resolvedPolicy, "jcfischer");
+      expect(typeof denied).toBe("object");
+      if (typeof denied === "object" && denied.kind === "peer_not_in_accept_list") {
+        expect(denied.unknown_network).toBe(true);
+      } else {
+        throw new Error(`expected peer_not_in_accept_list, got ${JSON.stringify(denied)}`);
+      }
     } finally {
       await stop();
     }

--- a/src/common/registry/__tests__/resolve-federated-peers-boot.adversarial.test.ts
+++ b/src/common/registry/__tests__/resolve-federated-peers-boot.adversarial.test.ts
@@ -1,0 +1,238 @@
+/**
+ * S4 (Network Join Control Plane, epic #733) — ADVERSARIAL trust-anchor probes
+ * for the boot-path federated-peer resolution, exercised end-to-end through the
+ * REAL {@link NetworkRegistryClient} (DD-9 pin+verify) rather than a stub
+ * provider. These complement the stub-based unit tests in
+ * `resolve-federated-peers-boot.test.ts` by attacking the actual signature /
+ * pinning / fail-closed boundary.
+ *
+ * Folded from the PR #818 adversarial review probe (its passing fail-closed
+ * cases — forged signature, MITM pubkey swap, registry 500, malformed JSON —
+ * plus the cache-poison probe turned into a real assertion that the NIT-5
+ * cache grammar-gate now rejects a poisoned roster pubkey).
+ *
+ * Every probe asserts the security invariant: an attacker who tampers with the
+ * roster, swaps the signer, downs the registry, or poisons the disk cache can
+ * NEVER get a peer admitted to the membership gate — the peer is DROPPED
+ * (fail-closed), never admitted on attacker-controlled data.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { NetworkRegistryClient } from "../network-client";
+import { NetworkCache } from "../network-cache";
+import { resolveBootFederatedPeers } from "../resolve-federated-peers-boot";
+import { canonicalJSON } from "../signing";
+import type { Policy } from "../../types/cortex-config";
+
+const NET = "advnet";
+
+// --- crypto helpers ----------------------------------------------------------
+
+function b64(bytes: Uint8Array): string {
+  let bin = "";
+  for (const x of bytes) bin += String.fromCharCode(x);
+  return btoa(bin);
+}
+
+async function genKey(): Promise<{ kp: CryptoKeyPair; pubB64: string }> {
+  const kp = await crypto.subtle.generateKey({ name: "Ed25519" }, true, [
+    "sign",
+    "verify",
+  ]);
+  const raw = new Uint8Array(await crypto.subtle.exportKey("raw", kp.publicKey));
+  return { kp, pubB64: b64(raw) };
+}
+
+async function peerPubkey(): Promise<string> {
+  return (await genKey()).pubB64; // base64 raw ed25519 (roster surface)
+}
+
+async function signAssertion(
+  privKey: CryptoKey,
+  registryPubB64: string,
+  payload: unknown,
+): Promise<Record<string, unknown>> {
+  const issued_at = new Date().toISOString();
+  const bound = canonicalJSON({ payload, issued_at, registry: registryPubB64 });
+  const sig = new Uint8Array(
+    await crypto.subtle.sign(
+      { name: "Ed25519" },
+      privKey,
+      new TextEncoder().encode(bound),
+    ),
+  );
+  return { payload, issued_at, registry: registryPubB64, signature: b64(sig) };
+}
+
+/** A route serves either a JSON-able body (signed → 200) or a custom Response. */
+type Route = (() => Response) | Record<string, unknown> | unknown[];
+
+/** A `fetch` double serving the descriptor + roster routes. */
+function makeFetch(routes: Record<string, Route>): typeof globalThis.fetch {
+  return (async (url: string | URL): Promise<Response> => {
+    const u = typeof url === "string" ? url : url.toString();
+    const path = u.replace(/^https?:\/\/[^/]+/, "");
+    const handler = routes[path];
+    if (handler === undefined) return new Response("nf", { status: 404 });
+    if (typeof handler === "function") return handler();
+    return new Response(JSON.stringify(handler), { status: 200 });
+  }) as unknown as typeof globalThis.fetch;
+}
+
+function tmpCacheDir(): string {
+  return mkdtempSync(join(tmpdir(), "adv-cache-"));
+}
+
+function descriptor() {
+  return { network_id: NET, hub_url: "nats://h", leaf_port: 4222, members: ["evil"] };
+}
+
+function policyWith(
+  peers: { principal_id: string; stack_id: string; principal_pubkey?: string }[],
+  registryPubkey: string,
+): Policy {
+  return {
+    principals: [],
+    federated: {
+      registry: { url: "https://reg.example", pubkey: registryPubkey },
+      networks: [
+        {
+          id: NET,
+          leaf_node: "primary",
+          max_hop: 1,
+          accept_subjects: [],
+          deny_subjects: [],
+          announce_capabilities: [],
+          peers,
+        },
+      ],
+    },
+  } as unknown as Policy;
+}
+
+describe("resolveBootFederatedPeers — adversarial trust anchor (real client)", () => {
+  test("forged roster signature (signed by a different key) → peer NOT admitted", async () => {
+    const reg = await genKey();
+    const attacker = await genKey();
+    const peerKey = await peerPubkey();
+    const goodDesc = await signAssertion(reg.kp.privateKey, reg.pubB64, descriptor());
+    // Roster signed by the ATTACKER's key but CLAIMING reg.pubB64 as the signer.
+    const roster = { network_id: NET, members: [{ principal_id: "evil", principal_pubkey: peerKey }] };
+    const forged = await signAssertion(attacker.kp.privateKey, reg.pubB64, roster);
+
+    const client = new NetworkRegistryClient({
+      url: "https://reg.example",
+      pubkey: reg.pubB64, // pinned
+      fetch: makeFetch({ [`/networks/${NET}`]: goodDesc, [`/networks/${NET}/roster`]: forged }),
+      cacheOptions: { cacheDir: tmpCacheDir() },
+    });
+
+    const policy = policyWith([{ principal_id: "evil", stack_id: "evil/s" }], reg.pubB64);
+    const res = await resolveBootFederatedPeers(policy, { rosterProvider: client, warn: () => {} });
+
+    const out = res.policy?.federated?.networks[0]?.peers ?? [];
+    expect(out.find((p) => p.principal_id === "evil")).toBeUndefined(); // dropped
+    expect(res.errors.some((e) => e.principalId === "evil")).toBe(true);
+  });
+
+  test("MITM swaps the signer (valid sig under attacker's pinned-claimed key) → peer NOT admitted", async () => {
+    const realReg = await genKey();
+    const mitm = await genKey();
+    const peerKey = await peerPubkey();
+    // MITM serves fully valid assertions under ITS OWN key (registry field = mitm).
+    const dDesc = await signAssertion(mitm.kp.privateKey, mitm.pubB64, descriptor());
+    const dRost = await signAssertion(mitm.kp.privateKey, mitm.pubB64, {
+      network_id: NET,
+      members: [{ principal_id: "evil", principal_pubkey: peerKey }],
+    });
+
+    const client = new NetworkRegistryClient({
+      url: "https://reg.example",
+      pubkey: realReg.pubB64, // principal pinned the REAL registry
+      fetch: makeFetch({ [`/networks/${NET}`]: dDesc, [`/networks/${NET}/roster`]: dRost }),
+      cacheOptions: { cacheDir: tmpCacheDir() },
+    });
+
+    const policy = policyWith([{ principal_id: "evil", stack_id: "evil/s" }], realReg.pubB64);
+    const res = await resolveBootFederatedPeers(policy, { rosterProvider: client, warn: () => {} });
+
+    expect(res.policy?.federated?.networks[0]?.peers.find((p) => p.principal_id === "evil")).toBeUndefined();
+  });
+
+  test("registry 500 + no cache → fail-CLOSED (pubkey-less peer dropped)", async () => {
+    const reg = await genKey();
+    const client = new NetworkRegistryClient({
+      url: "https://reg.example",
+      pubkey: reg.pubB64,
+      fetch: makeFetch({
+        [`/networks/${NET}`]: () => new Response("err", { status: 500 }),
+        [`/networks/${NET}/roster`]: () => new Response("err", { status: 500 }),
+      }),
+      cacheOptions: { cacheDir: tmpCacheDir() },
+    });
+    const policy = policyWith([{ principal_id: "evil", stack_id: "evil/s" }], reg.pubB64);
+    const res = await resolveBootFederatedPeers(policy, { rosterProvider: client, warn: () => {} });
+
+    expect(res.policy?.federated?.networks[0]?.peers.length).toBe(0); // dropped
+    expect(res.errors.some((e) => e.kind === "unresolved")).toBe(true);
+  });
+
+  test("malformed JSON body → never throws, fail-closed", async () => {
+    const reg = await genKey();
+    const client = new NetworkRegistryClient({
+      url: "https://reg.example",
+      pubkey: reg.pubB64,
+      fetch: makeFetch({
+        [`/networks/${NET}`]: () => new Response("{not json", { status: 200 }),
+        [`/networks/${NET}/roster`]: () => new Response("{not json", { status: 200 }),
+      }),
+      cacheOptions: { cacheDir: tmpCacheDir() },
+    });
+    const policy = policyWith([{ principal_id: "evil", stack_id: "evil/s" }], reg.pubB64);
+    const res = await resolveBootFederatedPeers(policy, { rosterProvider: client, warn: () => {} });
+
+    expect(res.policy?.federated?.networks[0]?.peers.length).toBe(0);
+  });
+
+  test("NIT-5 — a disk-cache record with a MALFORMED roster pubkey is rejected (grammar-gate)", async () => {
+    // Hand-write a cache record with a peer pubkey that is NOT base64 ed25519.
+    // parseRoster would reject this on the network path; after the NIT-5 fix the
+    // on-disk reader (`NetworkCache.load` → isCachedNetwork) rejects it too, so a
+    // poison key can never be served to a future cache consumer.
+    const cacheDir = tmpCacheDir();
+    const cache = new NetworkCache({ cacheDir, logError: () => {} });
+    const poison = {
+      schema_version: 1,
+      cached_at: new Date().toISOString(),
+      descriptor: descriptor(),
+      roster: { network_id: NET, members: [{ principal_id: "evil", principal_pubkey: "<<<not-a-key>>>" }] },
+    };
+    mkdirSync(cacheDir, { recursive: true });
+    writeFileSync(join(cacheDir, `${NET}.json`), JSON.stringify(poison));
+
+    // The poison record is treated as corrupt → load returns undefined.
+    expect(cache.load(NET)).toBeUndefined();
+  });
+
+  test("NIT-5 — a well-formed cache record (valid base64 ed25519) still loads", async () => {
+    // Guard against over-tightening: a legitimately-cached roster must still load.
+    const cacheDir = tmpCacheDir();
+    const cache = new NetworkCache({ cacheDir, logError: () => {} });
+    const goodKey = await peerPubkey();
+    const ok = {
+      schema_version: 1,
+      cached_at: new Date().toISOString(),
+      descriptor: descriptor(),
+      roster: { network_id: NET, members: [{ principal_id: "evil", principal_pubkey: goodKey }] },
+    };
+    mkdirSync(cacheDir, { recursive: true });
+    writeFileSync(join(cacheDir, `${NET}.json`), JSON.stringify(ok));
+
+    const loaded = cache.load(NET);
+    expect(loaded?.roster.members[0]?.principal_pubkey).toBe(goodKey);
+  });
+});

--- a/src/common/registry/__tests__/resolve-federated-peers-boot.test.ts
+++ b/src/common/registry/__tests__/resolve-federated-peers-boot.test.ts
@@ -1,0 +1,285 @@
+/**
+ * S4 (Network Join Control Plane, epic #733) — boot-path federated-peer
+ * resolution wiring tests.
+ *
+ * These exercise the {@link resolveBootFederatedPeers} seam directly (the unit
+ * the boot path calls), against a STUB roster provider — NO network I/O, NO
+ * `~/.config` touch. The full integration (that `startCortex` feeds the result
+ * into the membership gate) lives in `src/__tests__/cortex.federated-peer-boot.test.ts`.
+ *
+ * Coverage maps to the three load-bearing decisions:
+ *   - DD-5  — a pubkey-less peer is filled from the verified roster (nkey-U).
+ *   - DD-5  — a hand-pin + a roster-resolved peer MERGE into one network.
+ *   - DD-11 — a hand-pin that DISAGREES with the roster → fail-closed drop.
+ *   - DD-10 — registry unreachable → cached roster + static peers + warn.
+ *   - no-op — no policy / no federation / no registry → untouched pass-through.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { base64PubkeyToNkey } from "../encoding";
+import { resolveBootFederatedPeers } from "../resolve-federated-peers-boot";
+import type { NetworkRosterProvider } from "../resolve-federated-peers";
+import type { NetworkFetchResult } from "../network-client";
+import type { NetworkRosterResult } from "../types";
+import type { Policy, PolicyFederatedNetwork } from "../../types/cortex-config";
+
+const PEER_B64_A = "AQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQE=";
+const PEER_B64_B = "AgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgI=";
+const PEER_NKEY_A = base64PubkeyToNkey(PEER_B64_A)!;
+const PEER_NKEY_B = base64PubkeyToNkey(PEER_B64_B)!;
+
+function networkWith(
+  peers: PolicyFederatedNetwork["peers"],
+): PolicyFederatedNetwork {
+  return {
+    id: "metafactory-community",
+    leaf_node: "hub-leaf",
+    peers,
+    accept_subjects: ["federated.andreas.community.>"],
+    deny_subjects: [],
+    announce_capabilities: [],
+    max_hop: 1,
+  };
+}
+
+function policyWith(
+  networks: PolicyFederatedNetwork[],
+  opts: { withRegistry?: boolean } = {},
+): Policy {
+  return {
+    principals: [],
+    federated: {
+      networks,
+      ...(opts.withRegistry !== false && {
+        registry: { url: "https://network.meta-factory.ai" },
+      }),
+    },
+  } as unknown as Policy;
+}
+
+function rosterWith(
+  members: NetworkRosterResult["members"],
+): NetworkRosterResult {
+  return { network_id: "metafactory-community", members };
+}
+
+function stubProvider(opts: {
+  live?: NetworkFetchResult<{ roster: NetworkRosterResult }>;
+  cached?: { roster: NetworkRosterResult } | undefined;
+}): NetworkRosterProvider & { fetched: string[] } {
+  const fetched: string[] = [];
+  return {
+    fetched,
+    async fetchAndCache(networkId) {
+      fetched.push(networkId);
+      return (
+        opts.live ?? { status: "unreachable", reason: "no live result scripted" }
+      );
+    },
+    loadCached() {
+      return opts.cached;
+    },
+  };
+}
+
+describe("resolveBootFederatedPeers — DD-5 boot wiring", () => {
+  test("fills a pubkey-less peer from the verified roster (nkey-U) into the policy", async () => {
+    const policy = policyWith([
+      networkWith([{ principal_id: "jcfischer", stack_id: "jcfischer/sage-host" }]),
+    ]);
+    const provider = stubProvider({
+      live: {
+        status: "ok",
+        value: {
+          roster: rosterWith([
+            { principal_id: "jcfischer", principal_pubkey: PEER_B64_A },
+          ]),
+        },
+      },
+    });
+    const warnings: string[] = [];
+
+    const result = await resolveBootFederatedPeers(policy, {
+      rosterProvider: provider,
+      warn: (m) => warnings.push(m),
+    });
+
+    expect(result.errors).toHaveLength(0);
+    const peers = result.policy?.federated?.networks[0]?.peers ?? [];
+    expect(peers).toHaveLength(1);
+    expect(peers[0]?.principal_pubkey).toBe(PEER_NKEY_A);
+    expect(provider.fetched).toEqual(["metafactory-community"]);
+  });
+
+  test("merges a hand-pinned peer and a registry-resolved peer in the same network", async () => {
+    const policy = policyWith([
+      networkWith([
+        { principal_id: "andreas", stack_id: "andreas/community", principal_pubkey: PEER_NKEY_B },
+        { principal_id: "jcfischer", stack_id: "jcfischer/sage-host" },
+      ]),
+    ]);
+    const provider = stubProvider({
+      live: {
+        status: "ok",
+        value: {
+          roster: rosterWith([
+            { principal_id: "andreas", principal_pubkey: PEER_B64_B },
+            { principal_id: "jcfischer", principal_pubkey: PEER_B64_A },
+          ]),
+        },
+      },
+    });
+
+    const result = await resolveBootFederatedPeers(policy, { rosterProvider: provider });
+
+    expect(result.errors).toHaveLength(0);
+    const peers = result.policy?.federated?.networks[0]?.peers ?? [];
+    const byId = new Map(peers.map((p) => [p.principal_id, p.principal_pubkey]));
+    expect(byId.get("andreas")).toBe(PEER_NKEY_B); // hand-pin honored (matches)
+    expect(byId.get("jcfischer")).toBe(PEER_NKEY_A); // registry-resolved
+  });
+});
+
+describe("resolveBootFederatedPeers — DD-11 fail-closed", () => {
+  test("a hand-pin that disagrees with the roster drops the peer and reports an error", async () => {
+    const policy = policyWith([
+      // A second, pubkey-less peer forces the roster fetch — without it the
+      // resolver's back-compat fast path skips the registry entirely (DD-11's
+      // cross-check only has teeth once the network opts into registry
+      // resolution by leaving at least one peer pubkey-less).
+      networkWith([
+        // hand-pinned to A, but the roster says B → drift/attack signal.
+        { principal_id: "jcfischer", stack_id: "jcfischer/sage-host", principal_pubkey: PEER_NKEY_A },
+        { principal_id: "andreas", stack_id: "andreas/community" },
+      ]),
+    ]);
+    const provider = stubProvider({
+      live: {
+        status: "ok",
+        value: {
+          roster: rosterWith([
+            { principal_id: "jcfischer", principal_pubkey: PEER_B64_B },
+            { principal_id: "andreas", principal_pubkey: PEER_B64_A },
+          ]),
+        },
+      },
+    });
+    const warnings: string[] = [];
+
+    const result = await resolveBootFederatedPeers(policy, {
+      rosterProvider: provider,
+      warn: (m) => warnings.push(m),
+    });
+
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]?.kind).toBe("pin_mismatch");
+    expect(result.errors[0]?.principalId).toBe("jcfischer");
+    // The mismatching peer is dropped from the gate; the resolvable one stays.
+    const peers = result.policy?.federated?.networks[0]?.peers ?? [];
+    expect(peers.map((p) => p.principal_id)).toEqual(["andreas"]);
+    // Aggregate summary warning emitted.
+    expect(warnings.some((w) => w.includes("failed closed at") && w.includes("pin_mismatch"))).toBe(true);
+  });
+});
+
+describe("resolveBootFederatedPeers — DD-10 registry-down fallback", () => {
+  test("falls back to the cached roster + warns when the registry is unreachable", async () => {
+    const policy = policyWith([
+      networkWith([{ principal_id: "jcfischer", stack_id: "jcfischer/sage-host" }]),
+    ]);
+    const provider = stubProvider({
+      live: { status: "unreachable", reason: "ECONNREFUSED" },
+      cached: {
+        roster: rosterWith([
+          { principal_id: "jcfischer", principal_pubkey: PEER_B64_A },
+        ]),
+      },
+    });
+    const warnings: string[] = [];
+
+    const result = await resolveBootFederatedPeers(policy, {
+      rosterProvider: provider,
+      warn: (m) => warnings.push(m),
+    });
+
+    expect(result.errors).toHaveLength(0);
+    expect(result.policy?.federated?.networks[0]?.peers[0]?.principal_pubkey).toBe(PEER_NKEY_A);
+    expect(warnings.some((w) => w.includes("unreachable") && w.includes("cached"))).toBe(true);
+  });
+
+  test("hand-pinned peer survives a total registry outage (offline fallback)", async () => {
+    const policy = policyWith([
+      networkWith([
+        { principal_id: "andreas", stack_id: "andreas/community", principal_pubkey: PEER_NKEY_B },
+        // a pubkey-less peer forces the roster fetch; the hand-pin must survive
+        // even though the registry is fully down + uncached.
+        { principal_id: "jcfischer", stack_id: "jcfischer/sage-host" },
+      ]),
+    ]);
+    const provider = stubProvider({
+      live: { status: "unreachable", reason: "ECONNREFUSED" },
+      cached: undefined,
+    });
+
+    const result = await resolveBootFederatedPeers(policy, { rosterProvider: provider });
+
+    const peers = result.policy?.federated?.networks[0]?.peers ?? [];
+    // hand-pin kept; the unresolved registry-only peer fails closed.
+    expect(peers.map((p) => p.principal_id)).toEqual(["andreas"]);
+    expect(peers[0]?.principal_pubkey).toBe(PEER_NKEY_B);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]?.kind).toBe("unresolved");
+  });
+});
+
+describe("resolveBootFederatedPeers — no-op pass-through", () => {
+  test("undefined policy is returned unchanged", async () => {
+    const result = await resolveBootFederatedPeers(undefined);
+    expect(result.policy).toBeUndefined();
+    expect(result.errors).toHaveLength(0);
+  });
+
+  test("a policy with no federation block is returned by reference", async () => {
+    const policy = { principals: [] } as unknown as Policy;
+    const result = await resolveBootFederatedPeers(policy);
+    expect(result.policy).toBe(policy);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  test("federation declared but no registry + a pubkey-less peer warns, keeps static peers, makes no call", async () => {
+    const policy = policyWith(
+      [networkWith([{ principal_id: "jcfischer", stack_id: "jcfischer/sage-host" }])],
+      { withRegistry: false },
+    );
+    const warnings: string[] = [];
+
+    const result = await resolveBootFederatedPeers(policy, {
+      warn: (m) => warnings.push(m),
+    });
+
+    // No registry, no injected provider → no resolution; the policy is the input.
+    expect(result.policy).toBe(policy);
+    expect(result.errors).toHaveLength(0);
+    expect(warnings.some((w) => w.includes("no policy.federated.registry"))).toBe(true);
+  });
+
+  test("a fully hand-pinned network with no registry passes through silently", async () => {
+    const policy = policyWith(
+      [
+        networkWith([
+          { principal_id: "andreas", stack_id: "andreas/community", principal_pubkey: PEER_NKEY_B },
+        ]),
+      ],
+      { withRegistry: false },
+    );
+    const warnings: string[] = [];
+
+    const result = await resolveBootFederatedPeers(policy, {
+      warn: (m) => warnings.push(m),
+    });
+
+    expect(result.policy).toBe(policy);
+    expect(warnings).toHaveLength(0);
+  });
+});

--- a/src/common/registry/__tests__/resolve-federated-peers-boot.test.ts
+++ b/src/common/registry/__tests__/resolve-federated-peers-boot.test.ts
@@ -144,13 +144,10 @@ describe("resolveBootFederatedPeers — DD-5 boot wiring", () => {
 describe("resolveBootFederatedPeers — DD-11 fail-closed", () => {
   test("a hand-pin that disagrees with the roster drops the peer and reports an error", async () => {
     const policy = policyWith([
-      // A second, pubkey-less peer forces the roster fetch — without it the
-      // resolver's back-compat fast path skips the registry entirely (DD-11's
-      // cross-check only has teeth once the network opts into registry
-      // resolution by leaving at least one peer pubkey-less).
       networkWith([
         // hand-pinned to A, but the roster says B → drift/attack signal.
         { principal_id: "jcfischer", stack_id: "jcfischer/sage-host", principal_pubkey: PEER_NKEY_A },
+        // a resolvable peer alongside it — proves the drop is per-peer.
         { principal_id: "andreas", stack_id: "andreas/community" },
       ]),
     ]);
@@ -180,6 +177,37 @@ describe("resolveBootFederatedPeers — DD-11 fail-closed", () => {
     expect(peers.map((p) => p.principal_id)).toEqual(["andreas"]);
     // Aggregate summary warning emitted.
     expect(warnings.some((w) => w.includes("failed closed at") && w.includes("pin_mismatch"))).toBe(true);
+  });
+
+  test("MAJOR-1 — a FULLY hand-pinned network is cross-checked; a drifted pin is dropped", async () => {
+    // PR #818 review MAJOR-1 regression guard at the boot seam: a single
+    // hand-pinned peer (no pubkey-less peer to force a fetch) must STILL be
+    // cross-checked against the roster, and a drifted pin DROPPED. Before the
+    // fix this network made zero registry calls and the stale pin was admitted.
+    const policy = policyWith([
+      networkWith([
+        { principal_id: "jcfischer", stack_id: "jcfischer/sage-host", principal_pubkey: PEER_NKEY_A },
+      ]),
+    ]);
+    const provider = stubProvider({
+      live: {
+        status: "ok",
+        value: {
+          roster: rosterWith([{ principal_id: "jcfischer", principal_pubkey: PEER_B64_B }]),
+        },
+      },
+    });
+    const warnings: string[] = [];
+
+    const result = await resolveBootFederatedPeers(policy, {
+      rosterProvider: provider,
+      warn: (m) => warnings.push(m),
+    });
+
+    expect(provider.fetched).toEqual(["metafactory-community"]);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]?.kind).toBe("pin_mismatch");
+    expect(result.policy?.federated?.networks[0]?.peers ?? []).toHaveLength(0);
   });
 });
 

--- a/src/common/registry/__tests__/resolve-federated-peers.test.ts
+++ b/src/common/registry/__tests__/resolve-federated-peers.test.ts
@@ -17,8 +17,10 @@
  *              (peer kept, no alert).
  *   5. a registry-only peer that is unresolvable AND uncached → typed error +
  *              the peer is NOT admitted (the gate must never hold a keyless peer).
- *   6. back-compat — a fully hand-pinned config resolves offline with no
- *              registry calls at all; output is byte-identical to input.
+ *   6. MAJOR-1 (PR #818) — a fully hand-pinned network is cross-checked against
+ *              the roster when the registry is reachable (a drifted pin → DD-11
+ *              drop), and still survives a total registry outage offline (DD-10).
+ *              Only an empty-peers network makes zero registry calls.
  */
 
 import { describe, expect, test } from "bun:test";
@@ -308,33 +310,92 @@ describe("resolveFederatedPeers — DD-11 mismatch fail-closed", () => {
 // Back-compat — hand-pinned-only configs resolve offline, unchanged
 // =============================================================================
 
-describe("resolveFederatedPeers — back-compat", () => {
-  test("fully hand-pinned config makes NO registry calls and is unchanged", async () => {
+describe("resolveFederatedPeers — fully hand-pinned cross-check (MAJOR-1) + back-compat", () => {
+  test("a fully hand-pinned network IS cross-checked when the registry is reachable; matching pins kept", async () => {
+    // PR #818 review MAJOR-1: a fully hand-pinned network is NO LONGER a
+    // zero-call fast path. When a registry (client) is available, the roster IS
+    // fetched and every hand-pin is cross-checked (DD-11). Matching pins are
+    // honored (no-op); a drifted pin would be dropped (covered below).
     const network = networkWith([
-      {
-        principal_id: "jc",
-        stack_id: "jc/sage-host",
-        principal_pubkey: PEER_NKEY_A,
-      },
-      {
-        principal_id: "mel",
-        stack_id: "mel/host",
-        principal_pubkey: PEER_NKEY_B,
-      },
+      { principal_id: "jc", stack_id: "jc/sage-host", principal_pubkey: PEER_NKEY_A },
+      { principal_id: "mel", stack_id: "mel/host", principal_pubkey: PEER_NKEY_B },
     ]);
-    const provider = stubProvider({});
+    const provider = stubProvider({
+      live: {
+        status: "ok",
+        value: {
+          roster: rosterWith([
+            { principal_id: "jc", principal_pubkey: PEER_B64_A },
+            { principal_id: "mel", principal_pubkey: PEER_B64_B },
+          ]),
+        },
+      },
+    });
     const warnings: string[] = [];
 
     const result = await resolveFederatedPeers([network], provider, {
       warn: (m) => warnings.push(m),
     });
 
-    // Hand-pinned peers always resolve offline — no registry needed.
-    expect(provider.fetched).toEqual([]);
-    expect(provider.loadedCached).toEqual([]);
+    // The roster IS fetched now (the MAJOR-1 fix), and the matching pins are
+    // kept unchanged.
+    expect(provider.fetched).toEqual(["research-collab"]);
     expect(result.errors).toHaveLength(0);
     expect(warnings).toHaveLength(0);
     expect(result.networks[0]!.peers).toEqual(network.peers);
+  });
+
+  test("MAJOR-1 — a fully hand-pinned network with a DRIFTED pin → peer dropped (pin_mismatch)", async () => {
+    // The regression guard: jc is hand-pinned to A, but the registry now serves
+    // B for jc (rotation / tamper). DD-11 must fire even though every peer is
+    // hand-pinned — the peer is DROPPED, not admitted on the stale pin.
+    const network = networkWith([
+      { principal_id: "jc", stack_id: "jc/sage-host", principal_pubkey: PEER_NKEY_A },
+    ]);
+    const provider = stubProvider({
+      live: {
+        status: "ok",
+        value: {
+          roster: rosterWith([{ principal_id: "jc", principal_pubkey: PEER_B64_B }]),
+        },
+      },
+    });
+    const warnings: string[] = [];
+
+    const result = await resolveFederatedPeers([network], provider, {
+      warn: (m) => warnings.push(m),
+    });
+
+    expect(provider.fetched).toEqual(["research-collab"]);
+    expect(result.networks[0]!.peers).toHaveLength(0); // dropped, not kept
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]!.kind).toBe("pin_mismatch");
+  });
+
+  test("MAJOR-1 — a fully hand-pinned network survives a total registry outage (DD-10 offline)", async () => {
+    // The MAJOR-1 fix does NOT break "hand-pins always resolve offline": a fetch
+    // that is unreachable + uncached leaves the roster undefined, and a
+    // hand-pinned peer with no registry value to cross-check is admitted as-is.
+    const network = networkWith([
+      { principal_id: "jc", stack_id: "jc/sage-host", principal_pubkey: PEER_NKEY_A },
+      { principal_id: "mel", stack_id: "mel/host", principal_pubkey: PEER_NKEY_B },
+    ]);
+    const provider = stubProvider({
+      live: { status: "unreachable", reason: "ECONNREFUSED" },
+      cached: undefined,
+    });
+    const warnings: string[] = [];
+
+    const result = await resolveFederatedPeers([network], provider, {
+      warn: (m) => warnings.push(m),
+    });
+
+    // The fetch is attempted (and falls back), but the hand-pins survive.
+    expect(provider.fetched).toEqual(["research-collab"]);
+    expect(result.errors).toHaveLength(0);
+    expect(result.networks[0]!.peers).toEqual(network.peers);
+    // A loud DD-10 warning is emitted (registry unreachable + no cache).
+    expect(warnings.some((w) => w.includes("unreachable"))).toBe(true);
   });
 
   test("a network with no peers is a no-op (no registry calls)", async () => {

--- a/src/common/registry/index.ts
+++ b/src/common/registry/index.ts
@@ -44,6 +44,11 @@ export type {
   ResolveFederatedPeersOptions,
   ResolveFederatedPeersResult,
 } from "./resolve-federated-peers";
+export { resolveBootFederatedPeers } from "./resolve-federated-peers-boot";
+export type {
+  ResolveBootFederatedPeersOptions,
+  ResolveBootFederatedPeersResult,
+} from "./resolve-federated-peers-boot";
 export type {
   PrincipalPubkeyResolverOptions,
   ResolveResult,

--- a/src/common/registry/network-cache.ts
+++ b/src/common/registry/network-cache.ts
@@ -35,6 +35,17 @@ const DEFAULT_CACHE_DIR = join(homedir(), ".config", "cortex", "network-cache");
 const CACHE_SCHEMA_VERSION = 1 as const;
 
 /**
+ * Base64 raw ed25519 pubkey grammar (44 chars incl. `=` padding) — the SAME
+ * gate `network-client.parseRoster` applies before a roster is trusted. PR #818
+ * review NIT-5 (defense-in-depth): a cache record is only written AFTER
+ * signature verification (DD-9), so a poisoned file implies local-disk tamper —
+ * but the on-disk reader must not be a softer gate than the network reader, lest
+ * a future cache consumer inherit an ungated (malformed/poison) pubkey. We apply
+ * the identical grammar to cached roster members on load.
+ */
+const BASE64_ED25519 = /^[A-Za-z0-9+/]{43}=$/;
+
+/**
  * The on-disk record for one network: the last verified descriptor + roster,
  * plus the time they were cached. Both halves are written together so a reader
  * always gets a consistent pair (descriptor + its matching roster).
@@ -194,6 +205,20 @@ function isCachedNetwork(value: unknown, networkId: string): value is CachedNetw
   if (roster === null || typeof roster !== "object") return false;
   const r = roster as Record<string, unknown>;
   if (r.network_id !== networkId || !Array.isArray(r.members)) return false;
+
+  // PR #818 review NIT-5 — grammar-gate each cached roster member's pubkey with
+  // the SAME `BASE64_ED25519` regex `parseRoster` applies on the network path. A
+  // member with a missing/non-string/malformed `principal_pubkey` taints the
+  // whole record (consistent with parseRoster rejecting the whole roster), so
+  // the cache file is treated as corrupt and ignored rather than serving a
+  // poison key to a future consumer.
+  for (const member of r.members) {
+    if (member === null || typeof member !== "object") return false;
+    const m = member as Record<string, unknown>;
+    if (typeof m.principal_id !== "string") return false;
+    if (typeof m.principal_pubkey !== "string") return false;
+    if (!BASE64_ED25519.test(m.principal_pubkey)) return false;
+  }
 
   return true;
 }

--- a/src/common/registry/resolve-federated-peers-boot.ts
+++ b/src/common/registry/resolve-federated-peers-boot.ts
@@ -12,12 +12,24 @@
  *
  * Before S4, `resolveFederatedPeers` was shipped + unit-tested but never
  * invoked on the boot path (the `cortex-config.ts` "WIRING STATUS (S2)" note):
- * the membership gate keyed on `stack_id` from the STATIC `peers[]` only, and a
- * peer that declared just `principal_id` + `stack_id` (no `principal_pubkey`)
- * was admitted by the relaxed schema but never resolved. This module closes
- * that gap by resolving at boot and feeding the resolved networks into the SAME
- * `options.policy.federated.networks[]` field every gate already reads — there
- * is no registry-resolved-specific downstream path (DD-5).
+ * the membership gate keyed on `principal_id` from the STATIC `peers[]` only,
+ * and a peer that declared just `principal_id` + `stack_id` (no
+ * `principal_pubkey`) was admitted by the relaxed schema but never resolved nor
+ * cross-checked. This module closes that gap by resolving at boot and feeding
+ * the resolved networks into the SAME `policy.federated.networks[]` view every
+ * gate already reads.
+ *
+ * ## What it ENFORCES (PR #818 review MAJOR-2 — scope honestly)
+ *
+ * The security property delivered here is the **fail-closed DROP**: a peer that
+ * is unresolvable (DD-5 `unresolved`) or whose hand-pin disagrees with the
+ * roster (DD-11 `pin_mismatch`) is REMOVED from `peers[]`, so the
+ * `principal_id`-keyed membership gate then denies its federated traffic as
+ * `unknown_network`. The filled-in `principal_pubkey` value is, today,
+ * informational — the gate keys on `principal_id` and the crypto-verify path
+ * resolves keys from the registry on-demand (`MultiPrincipalIdentityRegistry`),
+ * NOT from this config field. Wiring the resolved key into the verify path is a
+ * tracked follow-up (PR #818 body).
  *
  * ## What it does
  *
@@ -25,12 +37,16 @@
  *      (pin+verify via the S1 {@link NetworkRegistryClient}) and fill each
  *      pubkey-less peer's `principal_pubkey` from roster membership.
  *   2. **DD-11** — a hand-pinned key that DISAGREES with the registry-resolved
- *      key fails that peer closed (dropped from `peers[]`), never merged.
+ *      key fails that peer closed (dropped from `peers[]`), never merged. PR #818
+ *      review MAJOR-1: this cross-check fires for FULLY hand-pinned networks too
+ *      (the roster is fetched whenever a registry is configured), so a drifted /
+ *      tampered pin is caught rather than admitted on the stale value.
  *   3. **DD-10** — registry-unreachable falls back to the cached roster + the
  *      static/hand-pinned peers, with a loud warning; federation stays up.
  *
  * Hand-pin support is preserved end-to-end (DD-5: hand-pin is the offline
- * fallback): a fully hand-pinned network makes zero registry calls.
+ * fallback) — a hand-pin survives a total registry outage (DD-10), it is just
+ * additionally cross-checked when the registry IS reachable.
  *
  * ## Boot-safety
  *

--- a/src/common/registry/resolve-federated-peers-boot.ts
+++ b/src/common/registry/resolve-federated-peers-boot.ts
@@ -1,0 +1,195 @@
+/**
+ * S4 (Network Join Control Plane, epic #733 · spec
+ * `docs/design-network-join-control-plane.md` §6 F2 "wiring") — the boot-path
+ * seam that invokes the S2 {@link resolveFederatedPeers} resolver during
+ * `startCortex` config-load and rewrites `policy.federated.networks[]` in place
+ * so EVERY downstream consumer (the runtime LinkPool, the surface-router /
+ * dispatch-listener membership gates, the review-consumer subjects, the public
+ * index) reads the registry-resolved `peers[]` rather than the raw static
+ * config.
+ *
+ * ## Why this exists (DD-5: no separate code path)
+ *
+ * Before S4, `resolveFederatedPeers` was shipped + unit-tested but never
+ * invoked on the boot path (the `cortex-config.ts` "WIRING STATUS (S2)" note):
+ * the membership gate keyed on `stack_id` from the STATIC `peers[]` only, and a
+ * peer that declared just `principal_id` + `stack_id` (no `principal_pubkey`)
+ * was admitted by the relaxed schema but never resolved. This module closes
+ * that gap by resolving at boot and feeding the resolved networks into the SAME
+ * `options.policy.federated.networks[]` field every gate already reads — there
+ * is no registry-resolved-specific downstream path (DD-5).
+ *
+ * ## What it does
+ *
+ *   1. **DD-5** — for each joined network, fetch the VERIFIED registry roster
+ *      (pin+verify via the S1 {@link NetworkRegistryClient}) and fill each
+ *      pubkey-less peer's `principal_pubkey` from roster membership.
+ *   2. **DD-11** — a hand-pinned key that DISAGREES with the registry-resolved
+ *      key fails that peer closed (dropped from `peers[]`), never merged.
+ *   3. **DD-10** — registry-unreachable falls back to the cached roster + the
+ *      static/hand-pinned peers, with a loud warning; federation stays up.
+ *
+ * Hand-pin support is preserved end-to-end (DD-5: hand-pin is the offline
+ * fallback): a fully hand-pinned network makes zero registry calls.
+ *
+ * ## Boot-safety
+ *
+ * NEVER throws. A missing `policy.federated` (no federation declared) or a
+ * missing `registry` sub-block (federation declared but no registry to resolve
+ * against — fully hand-pinned deployments) is a no-op: the policy is returned
+ * unchanged and no registry client is constructed. Every fail-closed drop and
+ * every degraded-mode fallback is surfaced via the `warn` sink (defaults to
+ * `process.stderr`, per CLAUDE.md "no empty catches"); the caller additionally
+ * logs an aggregate so a silent peer-drop can't hide.
+ */
+
+import { NetworkRegistryClient } from "./network-client";
+import {
+  resolveFederatedPeers,
+  type FederatedPeerResolveError,
+  type NetworkRosterProvider,
+} from "./resolve-federated-peers";
+import type {
+  Policy,
+  PolicyFederatedRegistry,
+} from "../types/cortex-config";
+
+/** Options for {@link resolveBootFederatedPeers}. */
+export interface ResolveBootFederatedPeersOptions {
+  /**
+   * Loud-warning sink (DD-10 fallback + DD-11 alert + every fail-closed drop +
+   * the aggregate summary). Defaults to `process.stderr`. The boot path injects
+   * a sink that also goes to the cortex console logs.
+   */
+  warn?: (message: string) => void;
+  /**
+   * Inject a roster provider instead of constructing a live
+   * {@link NetworkRegistryClient} from `policy.federated.registry`. Tests pass a
+   * fixture/stub provider so the boot wiring runs with NO network I/O and NO
+   * `~/.config` cache touch. Production omits this and a real client is built.
+   *
+   * @internal — not part of the public API.
+   */
+  rosterProvider?: NetworkRosterProvider;
+}
+
+/** Result of the boot-path resolution. */
+export interface ResolveBootFederatedPeersResult {
+  /**
+   * The input policy with `federated.networks[]` rewritten to the resolved set
+   * (pubkeys filled, fail-closed peers dropped). When federation/registry is
+   * absent, this is the input policy returned unchanged (referential identity
+   * preserved for the no-op path). Networks are NEVER mutated in place.
+   */
+  policy: Policy | undefined;
+  /** Typed fail-closed drops (DD-11 mismatch / DD-5 unresolved), for alerting. */
+  errors: FederatedPeerResolveError[];
+}
+
+/**
+ * Build the live S1 roster provider from the registry sub-block. Separated so
+ * the construction (and its `cacheDir` default of `~/.config/cortex/...`) is
+ * skipped entirely when a test injects a provider.
+ */
+function liveProvider(registry: PolicyFederatedRegistry): NetworkRosterProvider {
+  return new NetworkRegistryClient({
+    url: registry.url,
+    ...(registry.pubkey !== undefined && { pubkey: registry.pubkey }),
+  });
+}
+
+/**
+ * Resolve `policy.federated.networks[].peers[]` from the registry roster at
+ * boot (DD-5/DD-10/DD-11). NEVER throws.
+ *
+ * No-op (returns the policy unchanged) when:
+ *   - `policy` is `undefined` (no `policy:` block), OR
+ *   - `policy.federated` is absent (no federation declared), OR
+ *   - `policy.federated.networks` is empty, OR
+ *   - `policy.federated.registry` is absent AND no `rosterProvider` is injected
+ *     (federation declared but no registry to resolve against — a fully
+ *     hand-pinned deployment; the resolver would make zero calls anyway).
+ *
+ * @param policy   the loaded `policy:` block (or `undefined`)
+ * @param options  warn sink + optional injected roster provider (tests)
+ */
+export async function resolveBootFederatedPeers(
+  policy: Policy | undefined,
+  options: ResolveBootFederatedPeersOptions = {},
+): Promise<ResolveBootFederatedPeersResult> {
+  const warn =
+    options.warn ??
+    ((message: string) => {
+      process.stderr.write(`cortex federated-peer boot resolve: ${message}\n`);
+    });
+
+  const federated = policy?.federated;
+  if (
+    policy === undefined ||
+    federated === undefined ||
+    federated.networks.length === 0
+  ) {
+    // No federation to resolve — pass through untouched.
+    return { policy, errors: [] };
+  }
+
+  // Pick the roster provider: an injected one (tests) or a live client built
+  // from the registry sub-block. With NEITHER, every network is necessarily
+  // fully hand-pinned (there is no registry to resolve a pubkey-less peer
+  // against) — so resolution is a no-op and we skip building a client. A
+  // network that left a peer pubkey-less WITHOUT declaring a registry is a
+  // config error caught by the resolver's fail-closed `unresolved` drop the
+  // moment a registry IS configured; with no registry we cannot reach the
+  // roster at all, so we leave the static peers as-is and warn.
+  const provider =
+    options.rosterProvider ??
+    (federated.registry !== undefined
+      ? liveProvider(federated.registry)
+      : undefined);
+
+  if (provider === undefined) {
+    const hasPubkeylessPeer = federated.networks.some((n) =>
+      n.peers.some((p) => p.principal_pubkey === undefined),
+    );
+    if (hasPubkeylessPeer) {
+      warn(
+        "policy.federated declares a pubkey-less peer but no " +
+          "policy.federated.registry — cannot registry-resolve it. Such peers " +
+          "stay in config but carry no key; add a registry block (DD-5) or " +
+          "hand-pin the peer's principal_pubkey.",
+      );
+    }
+    return { policy, errors: [] };
+  }
+
+  const resolved = await resolveFederatedPeers(federated.networks, provider, {
+    warn,
+  });
+
+  if (resolved.errors.length > 0) {
+    // Aggregate summary so a silent peer-drop can't hide in per-peer warns.
+    const summary = resolved.errors
+      .map((e) => `${e.networkId}/${e.principalId} (${e.kind})`)
+      .join(", ");
+    warn(
+      `${resolved.errors.length.toString()} federated peer(s) failed closed at ` +
+        `boot and were dropped from the membership gate: ${summary}. ` +
+        `Federation continues for the peers that DID resolve.`,
+    );
+  }
+
+  // Rewrite the policy's federated networks with the resolved set. NEW objects
+  // throughout (resolveFederatedPeers never mutates its input); the rest of the
+  // policy is carried by reference. This is the single field every downstream
+  // consumer (runtime LinkPool, surface-router + dispatch-listener gates,
+  // review subjects, public index) reads — DD-5: no separate code path.
+  const nextPolicy: Policy = {
+    ...policy,
+    federated: {
+      ...federated,
+      networks: resolved.networks,
+    },
+  };
+
+  return { policy: nextPolicy, errors: resolved.errors };
+}

--- a/src/common/registry/resolve-federated-peers.ts
+++ b/src/common/registry/resolve-federated-peers.ts
@@ -6,10 +6,26 @@
  * This is the F2 seam: it sits between config parse and the surface-router /
  * crypto-verify federation gate, and fills in each `policy.federated.
  * networks[].peers[].principal_pubkey` that the principal did NOT hand-pin —
- * resolving it from the registry-signed roster (DD-5). It feeds the SAME gate
- * and verify path a hand-pinned key feeds: the resolver's only job is to make
- * every admitted peer carry a key in the config's nkey-U surface, however that
- * key was obtained. There is no separate downstream code path.
+ * resolving it from the registry-signed roster (DD-5).
+ *
+ * ## What this seam actually ENFORCES (PR #818 review MAJOR-2 — scope honestly)
+ *
+ * The load-bearing enforcement this seam delivers is the **fail-closed DROP** of
+ * a peer that cannot be trusted: a registry-only peer whose key is unresolvable
+ * (DD-5 `unresolved`) or a hand-pin that disagrees with the roster (DD-11
+ * `pin_mismatch`) is REMOVED from `peers[]`, so the `principal_id`-keyed
+ * membership gate (`evaluateFederationGate` / `resolveSourceNetwork`) then denies
+ * its traffic as `unknown_network`. THAT is the security property.
+ *
+ * The filled-in `principal_pubkey` value itself is, today, **informational and
+ * NOT yet consumed by the admission gate**: the surface-router gate + the runtime
+ * LinkPool key on `principal_id`, and the crypto-verify path resolves peer
+ * pubkeys from the registry on-demand (`MultiPrincipalIdentityRegistry`), not
+ * from this config field. Wiring the pinned/resolved key into the verify path so
+ * the config surface becomes the trust anchor is a tracked follow-up — see the
+ * PR #818 body. Until then, "no separate downstream code path" means the DROP
+ * flows through the SAME `principal_id` gate a hand-pin's absence would; it does
+ * NOT mean the resolved key is read for admission.
  *
  * ## The three design decisions this implements
  *
@@ -142,10 +158,13 @@ export interface ResolveFederatedPeersOptions {
  * NEVER throws.
  *
  * Resolution is per-network: a network's roster is fetched at most once
- * (`fetchAndCache`), and only when that network has at least one peer that
- * needs the registry (a peer missing a pubkey, or a hand-pinned peer we want to
- * cross-check). A fully hand-pinned network makes ZERO registry calls and is
- * returned byte-identical (back-compat).
+ * (`fetchAndCache`) whenever the network has ANY peer — a pubkey-less peer to
+ * resolve (DD-5) OR a hand-pinned peer to cross-check (DD-11). PR #818 review
+ * MAJOR-1: a fully hand-pinned network is NO LONGER a zero-call fast path — when
+ * a registry is configured (this resolver is only invoked with a `client` then),
+ * its hand-pins are cross-checked against the verified roster so a drifted /
+ * tampered key is caught (DD-11). Only an EMPTY-peers network makes zero calls.
+ * Hand-pins still survive a registry outage (DD-10: down → cached → admit-as-is).
  *
  * @param networks  the parsed `policy.federated.networks[]`
  * @param client    the S1 {@link NetworkRegistryClient} (or a structural stub)
@@ -166,26 +185,31 @@ export async function resolveFederatedPeers(
   const outNetworks: PolicyFederatedNetwork[] = [];
 
   for (const network of networks) {
-    // Does any peer in this network need the registry? Trigger the roster
-    // fetch when at least one peer is pubkey-less (DD-5 needs the registry to
-    // resolve it). Once the roster IS fetched for the network, EVERY peer in
-    // it — including hand-pinned ones — is cross-checked against it (DD-11).
+    // PR #818 review MAJOR-1 fix — fetch the roster for EVERY non-empty network,
+    // not only when a peer is pubkey-less. The resolver is only ever handed a
+    // `client` when a registry is configured (the boot seam constructs/injects
+    // one only then), so a network with ANY peer — hand-pinned or pubkey-less —
+    // must be cross-checked against the verified roster.
     //
-    // The deliberate boundary (back-compat, DD-5 "hand-pin is the offline
-    // fallback"): a network where EVERY peer is hand-pinned makes ZERO
-    // registry calls and is returned byte-identical. Such a network is, by the
-    // principal's choice, fully offline-pinned, so there is no registry key to
-    // drift against — the DD-11 guard only has teeth once the network opts into
-    // registry resolution by leaving at least one peer pubkey-less. This keeps
-    // a hand-pinned-only deployment up across a total registry outage and
-    // matches "hand-pinned peers always resolve offline".
-    const needsRegistry = network.peers.some(
-      (p) => p.principal_pubkey === undefined,
-    );
-
-    if (!needsRegistry || network.peers.length === 0) {
-      // Back-compat fast path: every peer is hand-pinned (or there are none).
-      // No registry call; the network passes through unchanged.
+    // Why this matters (the DD-11 fast-path gap the old `needsRegistry` left
+    // open): a FULLY hand-pinned network used to make ZERO registry calls, so a
+    // hand-pin that had drifted from a rotated/tampered roster key was admitted
+    // on the STALE pin and DD-11 never fired — contradicting the spec's
+    // unconditional "when both a hand-pin AND a registry-resolved key exist they
+    // MUST agree," and silently defeating exactly the stale/compromised-pin case
+    // DD-11 exists to catch. Now the pin↔roster cross-check fires for
+    // hand-pinned-only networks too.
+    //
+    // The extra fetch is safe and does NOT break "hand-pins always resolve
+    // offline" (DD-5): a roster fetch that returns `unreachable` falls back to
+    // the cached roster (DD-10); a fetch that yields no roster at all (down +
+    // uncached, or a definitive negative) leaves `roster === undefined`, and
+    // `resolvePeer` admits a hand-pinned peer as-is when it has no registry value
+    // to cross-check against. So a hand-pinned-only deployment still stays up
+    // across a total registry outage — it just gains the DD-11 guard whenever the
+    // registry IS reachable (or cached).
+    if (network.peers.length === 0) {
+      // No peers ⇒ nothing to resolve or cross-check; pass through unchanged.
       outNetworks.push(network);
       continue;
     }

--- a/src/common/types/cortex-config.ts
+++ b/src/common/types/cortex-config.ts
@@ -1440,19 +1440,20 @@ export const PolicyFederatedPeerSchema = z.object({
    * `resolveSourceNetwork`, which key on `stack_id` membership) denies its
    * federated traffic as `unknown_network`.
    *
-   * WIRING STATUS (S2): the resolver is shipped + unit-tested but is not
-   * yet invoked on the boot path — per the epic-#733 slice matrix, wiring
-   * the S1–S3 pieces into `cortex.ts` config-load is **S4's** deliverable
-   * ("PR-4 join/leave/status wiring S1–S3"). Until S4 lands, this field is
-   * forward-declared: no runtime gate reads a config peer's
-   * `principal_pubkey` (the membership gate keys on `stack_id`;
-   * `buildIdentityRegistry` is built from the agent registry + local stack,
-   * and federated peer pubkeys are resolved on demand via the TC-2d
-   * `MultiPrincipalIdentityRegistry` resolver, not from this field). So a
-   * keyless peer admitted by the relaxed schema cannot fail open today —
-   * it simply isn't consumed yet. The S4 wiring MUST feed the resolver's
-   * output into the same gate/verify path a hand-pin would feed (DD-5: no
-   * separate registry-resolved code path).
+   * WIRING STATUS (S4 — WIRED): the resolver is now invoked on the boot path.
+   * `startCortex` calls `resolveBootFederatedPeers`
+   * (`src/common/registry/resolve-federated-peers-boot.ts`) BEFORE any consumer
+   * reads `policy.federated.networks[]`, and rewrites that field with the
+   * resolved set. A pubkey-less peer has THIS field filled from the verified
+   * roster (DD-5); a hand-pin that disagrees with the roster fails the peer
+   * closed and DROPS it from `peers[]` (DD-11); a registry outage falls back to
+   * the cached roster + a loud warn (DD-10). The resolved networks feed the SAME
+   * downstream consumers — the runtime LinkPool, the surface-router +
+   * dispatch-listener membership gates (`evaluateFederationGate` /
+   * `resolveSourceNetwork`, which key on `peers[].principal_id`), the
+   * review-consumer subjects, and the public index — so there is NO separate
+   * registry-resolved code path (DD-5). A keyless peer is never admitted to the
+   * gate (fail-closed): it is either resolved to a key or dropped.
    */
   principal_pubkey: z.string().regex(
     NKEY_PUBKEY_REGEX,

--- a/src/common/types/cortex-config.ts
+++ b/src/common/types/cortex-config.ts
@@ -1433,27 +1433,30 @@ export const PolicyFederatedPeerSchema = z.object({
    * (`src/common/registry/resolve-federated-peers.ts`): it fetches the
    * peer's pubkey from the registry-signed roster, re-encodes it to nkey-U
    * (DD-8), and fills this field. Hand-pinning stays as the offline
-   * fallback (DD-5) — a hand-pinned peer always resolves without the
-   * registry. When BOTH a hand-pin AND a registry-resolved key exist and
-   * they DIFFER, the resolver fails that peer closed (DD-11), dropping the
-   * peer from `peers[]` so the membership gate (`evaluateFederationGate` /
-   * `resolveSourceNetwork`, which key on `stack_id` membership) denies its
-   * federated traffic as `unknown_network`.
+   * fallback (DD-5) — a hand-pinned peer survives a registry outage (DD-10).
+   * When BOTH a hand-pin AND a registry-resolved key exist and they DIFFER,
+   * the resolver fails that peer closed (DD-11), dropping the peer from
+   * `peers[]` so the membership gate (`evaluateFederationGate` /
+   * `resolveSourceNetwork`, which key on `peers[].principal_id` membership)
+   * denies its federated traffic as `unknown_network`.
    *
    * WIRING STATUS (S4 — WIRED): the resolver is now invoked on the boot path.
    * `startCortex` calls `resolveBootFederatedPeers`
    * (`src/common/registry/resolve-federated-peers-boot.ts`) BEFORE any consumer
-   * reads `policy.federated.networks[]`, and rewrites that field with the
-   * resolved set. A pubkey-less peer has THIS field filled from the verified
-   * roster (DD-5); a hand-pin that disagrees with the roster fails the peer
-   * closed and DROPS it from `peers[]` (DD-11); a registry outage falls back to
-   * the cached roster + a loud warn (DD-10). The resolved networks feed the SAME
-   * downstream consumers — the runtime LinkPool, the surface-router +
-   * dispatch-listener membership gates (`evaluateFederationGate` /
-   * `resolveSourceNetwork`, which key on `peers[].principal_id`), the
-   * review-consumer subjects, and the public index — so there is NO separate
-   * registry-resolved code path (DD-5). A keyless peer is never admitted to the
-   * gate (fail-closed): it is either resolved to a key or dropped.
+   * reads `policy.federated.networks[]`, and threads the resolved set (a fresh
+   * local view; the caller's `options` is NOT mutated) to every consumer.
+   *
+   * WHAT IS ENFORCED (PR #818 review MAJOR-2 — scope honestly): the load-bearing
+   * security property is the fail-closed DROP. A pubkey-less peer that cannot be
+   * resolved (DD-5 `unresolved`) and a hand-pin that disagrees with the roster
+   * (DD-11 `pin_mismatch`, now cross-checked even for fully hand-pinned networks
+   * per MAJOR-1) are REMOVED from `peers[]`; the `principal_id`-keyed gate then
+   * denies them as `unknown_network`. The pubkey VALUE filled into THIS field is
+   * currently informational and is NOT yet read for admission — the gate +
+   * LinkPool key on `principal_id`, and the crypto-verify path resolves peer
+   * pubkeys from the registry on-demand (`MultiPrincipalIdentityRegistry`), not
+   * from this field. Wiring the resolved/pinned key into the verify path so this
+   * field becomes the trust anchor is a tracked follow-up (see the PR #818 body).
    */
   principal_pubkey: z.string().regex(
     NKEY_PUBKEY_REGEX,

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -286,6 +286,17 @@ export interface StartCortexOptions {
    */
   bootFederatedRosterProvider?: NetworkRosterProvider;
   /**
+   * S4 (Network Join Control Plane, epic #733) — test-only observation hook,
+   * invoked synchronously with the resolved policy view right after the
+   * boot-path federated-peer resolution (DD-5/DD-10/DD-11). Tests use it to
+   * assert what the membership gate will see WITHOUT mutating the caller's
+   * `options` (PR #818 review NIT-6) and without growing the public
+   * `CortexHandle`. Production omits it.
+   *
+   * @internal — not part of the public API; semver does not apply.
+   */
+  onBootResolvedPolicy?: (policy: Policy | undefined) => void;
+  /**
    * Override the 15s shutdown timeout. Tests use a small value (50–200ms)
    * to exercise the abandoned-set tracking path without holding the test
    * runner hostage for 15 real seconds.
@@ -659,35 +670,40 @@ export async function startCortex(
   // filled here from the verified registry roster (DD-5). Hand-pins are kept as
   // the offline fallback; a hand-pin that DISAGREES with the registry-resolved
   // key fails that peer closed (DD-11); a registry outage falls back to the
-  // cached roster + a loud warn (DD-10). The resolved networks are written back
-  // onto `options.policy.federated.networks` so EVERY downstream consumer (the
-  // runtime LinkPool below, the surface-router + dispatch-listener membership
-  // gates, the review-consumer subjects, the public index) reads the SAME
-  // resolved set — DD-5: no separate registry-resolved code path. NEVER throws;
-  // closes the `cortex-config.ts` "WIRING STATUS (S2)" gap.
-  {
-    const bootResolve = await resolveBootFederatedPeers(options.policy, {
-      warn: (message) => {
-        // Loud — drops + DD-10 fallback must be visible in the daemon logs.
-        process.stderr.write(`cortex: federated-peer boot resolve — ${message}\n`);
-      },
-      // Test-only seam: inject a fixture roster provider so the boot wiring runs
-      // with NO network I/O and NO `~/.config` cache touch. Production omits
-      // this and a live `NetworkRegistryClient` is built from the registry block.
-      ...(options.bootFederatedRosterProvider !== undefined && {
-        rosterProvider: options.bootFederatedRosterProvider,
-      }),
-    });
-    // Rewrite the single field every consumer reads. When federation/registry
-    // is absent this is the input policy returned unchanged (no-op).
-    options.policy = bootResolve.policy;
-    if (bootResolve.errors.length > 0) {
-      console.error(
-        `cortex: ${bootResolve.errors.length.toString()} federated peer(s) ` +
-          `failed closed at boot and were dropped from the membership gate ` +
-          `(see stderr warnings above for per-peer detail).`,
-      );
-    }
+  // cached roster + a loud warn (DD-10). The resolved networks become the local
+  // `resolvedPolicy` that EVERY downstream consumer (the runtime LinkPool below,
+  // the surface-router + dispatch-listener membership gates, the review-consumer
+  // subjects, the public index) reads — DD-5: no separate registry-resolved code
+  // path. NEVER throws; closes the `cortex-config.ts` "WIRING STATUS (S2)" gap.
+  //
+  // PR #818 review NIT-6 — we do NOT mutate the caller's `options.policy`. The
+  // resolved view is a fresh local binding; the caller's object is untouched
+  // (the resolver returns new objects and never mutates its input). All boot
+  // reads below go through `resolvedPolicy`, never `options.policy`.
+  const bootResolve = await resolveBootFederatedPeers(options.policy, {
+    warn: (message) => {
+      // Loud — drops + DD-10 fallback must be visible in the daemon logs.
+      process.stderr.write(`cortex: federated-peer boot resolve — ${message}\n`);
+    },
+    // Test-only seam: inject a fixture roster provider so the boot wiring runs
+    // with NO network I/O and NO `~/.config` cache touch. Production omits this
+    // and a live `NetworkRegistryClient` is built from the registry block.
+    ...(options.bootFederatedRosterProvider !== undefined && {
+      rosterProvider: options.bootFederatedRosterProvider,
+    }),
+  });
+  // The resolved policy view used by every consumer below. When
+  // federation/registry is absent this is the input policy returned unchanged.
+  const resolvedPolicy = bootResolve.policy;
+  // Test-only observation seam (NIT-6): surface the resolved view without
+  // mutating `options`. No-op in production.
+  options.onBootResolvedPolicy?.(resolvedPolicy);
+  if (bootResolve.errors.length > 0) {
+    console.error(
+      `cortex: ${bootResolve.errors.length.toString()} federated peer(s) ` +
+        `failed closed at boot and were dropped from the membership gate ` +
+        `(see stderr warnings above for per-peer detail).`,
+    );
   }
 
   // Bus runtime (M2-M6) — no-op when `config.nats?` is absent. Tests inject
@@ -737,8 +753,8 @@ export async function startCortex(
         // the SAME `policy.federated.networks[]` the surface-router gate
         // keys off — NEVER `config.networks[]` (the legacy grove
         // cloud-publish table; design §3.2 NAME-COLLISION).
-        ...(options.policy?.federated?.networks !== undefined && {
-          federatedNetworks: options.policy.federated.networks,
+        ...(resolvedPolicy?.federated?.networks !== undefined && {
+          federatedNetworks: resolvedPolicy.federated.networks,
         }),
         // TC-4d/4e (#627 Phase 4) — transport-mTLS posture for the LinkPool
         // (primary + every federated leaf). Default `off` ⇒ no tls block on
@@ -1057,7 +1073,7 @@ export async function startCortex(
   // policy block: a deployment with no federation declared adds no federated
   // filter/consumer (back-compat — local path byte-for-byte unchanged).
   const federationConfigured =
-    (options.policy?.federated?.networks ?? []).length > 0;
+    (resolvedPolicy?.federated?.networks ?? []).length > 0;
   const reviewFederatedSubjectPattern = `federated.${reviewPrincipalId}.${derivedStack.stack}.tasks.code-review.>`;
   // cortex#725 (ADR 0001/0002 §2) — the FEDERATED **Direct** review pattern.
   // pilot#149's `--reviewer {name}@{principal}/{stack}` Direct dispatch lands
@@ -1296,7 +1312,7 @@ export async function startCortex(
           // application-layer trust boundary on the consumer path.
           ...(federated && {
             federated: true,
-            federatedNetworks: options.policy?.federated?.networks ?? [],
+            federatedNetworks: resolvedPolicy?.federated?.networks ?? [],
           }),
         });
 
@@ -1532,7 +1548,7 @@ export async function startCortex(
   let resolveFederatedPeer:
     | ((peerPrincipal: string) => Promise<FederatedPeerResolution>)
     | undefined;
-  const federationRegistryConfig = options.policy?.federated?.registry;
+  const federationRegistryConfig = resolvedPolicy?.federated?.registry;
   const federationVerifyEnabled = config.security.signing === "enforce";
   if (
     federationVerifyEnabled &&
@@ -1637,12 +1653,12 @@ export async function startCortex(
   // Federation enforcement is opt-in.
   const router: SurfaceRouter = createSurfaceRouter(runtime, {
     systemEventSource,
-    ...(options.policy?.federated !== undefined && { federated: options.policy.federated }),
+    ...(resolvedPolicy?.federated !== undefined && { federated: resolvedPolicy.federated }),
     // IAW S5 (#739) — the public-scope opt-in. Absent ⇒ the router drops all
     // inbound `public.*` (deny-by-default, OQ1 safe). Written by
     // `cortex network join public`; an inbound public sender is admitted only
     // when `enabled: true` AND its source principal is on `allow_principals[]`.
-    ...(options.policy?.public !== undefined && { public: options.policy.public }),
+    ...(resolvedPolicy?.public !== undefined && { public: resolvedPolicy.public }),
     onAdapterError: (adapterId, err) => {
       console.error(`cortex: surface adapter "${adapterId}" render error:`, err.message);
     },
@@ -1669,11 +1685,11 @@ export async function startCortex(
   // `src/common/registry/client.ts` JSDoc for the full failure-mode
   // table.
   let registryClient: RegistryClient | null = null;
-  const registryConfig = options.policy?.federated?.registry;
+  const registryConfig = resolvedPolicy?.federated?.registry;
   if (registryConfig !== undefined) {
     const peerPrincipalIds = Array.from(
       new Set(
-        (options.policy?.federated?.networks ?? []).flatMap((n) =>
+        (resolvedPolicy?.federated?.networks ?? []).flatMap((n) =>
           n.peers.map((p) => p.principal_id),
         ),
       ),
@@ -1716,9 +1732,9 @@ export async function startCortex(
   // adapter loop) so the DispatchHandler can consume the engine for
   // adapter-side platform-id → principal resolution at envelope-publish
   // time. See `dispatch-source-publisher` / CONTEXT.md §Dispatch-source.
-  const adapterPolicyEngine = policyEngineFromConfig(options.policy);
-  const adapterPolicyLookup = buildPlatformPrincipalIndex(options.policy);
-  const adapterPolicyRegistry = buildPrincipalRegistry(options.policy);
+  const adapterPolicyEngine = policyEngineFromConfig(resolvedPolicy);
+  const adapterPolicyLookup = buildPlatformPrincipalIndex(resolvedPolicy);
+  const adapterPolicyRegistry = buildPrincipalRegistry(resolvedPolicy);
 
   // Dispatch-handler — synchronous platform-message → CC pipeline.
   //
@@ -2383,12 +2399,12 @@ export async function startCortex(
   // accepted and fall through to the policy gate; signed chains must
   // verify against the principal's NKey roster. The pre-Phase-B
   // authorization-without-authentication gap is closed.
-  if (options.policy?.principals.length === 0) {
+  if (resolvedPolicy?.principals.length === 0) {
     console.warn(
       `cortex: policy: block declared with empty principals[] — no authorisation gate engages; the dispatch-listener stays on the legacy path.`,
     );
   }
-  const policyEngine = policyEngineFromConfig(options.policy);
+  const policyEngine = policyEngineFromConfig(resolvedPolicy);
   if (policyEngine !== undefined) {
     console.log(
       `cortex: policy-engine active — principals=${policyEngine.principalCount} roles=${policyEngine.roleCount} (signed_by chain verified; empty chains accepted for adapter-originated dispatches)`,

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -129,6 +129,8 @@ import type {
   RegistryClientReader,
   FederatedPeerResolution,
 } from "./common/registry";
+import { resolveBootFederatedPeers } from "./common/registry/resolve-federated-peers-boot";
+import type { NetworkRosterProvider } from "./common/registry/resolve-federated-peers";
 import { JsonlReader } from "./taps/cc-events/lib/jsonl-reader";
 import { PublishedEventSchema } from "./taps/cc-events/hooks/lib/event-types";
 import { formatEventForDiscord } from "./adapters/discord/event-formatter";
@@ -273,6 +275,16 @@ export interface StartCortexOptions {
    * @internal — not part of the public API; semver does not apply.
    */
   injectRuntime?: MyelinRuntime;
+  /**
+   * S4 (Network Join Control Plane, epic #733) — inject a roster provider for
+   * the boot-path federated-peer resolution instead of building a live
+   * `NetworkRegistryClient` from `policy.federated.registry`. Tests pass a
+   * fixture/stub provider so the DD-5/DD-10/DD-11 boot wiring runs with NO
+   * network I/O and NO `~/.config` cache touch. Production omits this.
+   *
+   * @internal — not part of the public API; semver does not apply.
+   */
+  bootFederatedRosterProvider?: NetworkRosterProvider;
   /**
    * Override the 15s shutdown timeout. Tests use a small value (50–200ms)
    * to exercise the abandoned-set tracking path without holding the test
@@ -638,6 +650,44 @@ export async function startCortex(
         "  `stack.nkey_seed_path` (+ optionally `stack.nkey_pub`) to cortex.yaml.\n" +
         "  See docs/sop-stack-identity.md for the full SOP.\n",
     );
+  }
+
+  // S4 (Network Join Control Plane, epic #733; DD-5 wiring) — resolve the
+  // federated `peers[]` from the registry roster BEFORE any consumer reads
+  // them. Joining a network names the NETWORK, not each principal: a peer may
+  // declare just `principal_id` + `stack_id` and have its `principal_pubkey`
+  // filled here from the verified registry roster (DD-5). Hand-pins are kept as
+  // the offline fallback; a hand-pin that DISAGREES with the registry-resolved
+  // key fails that peer closed (DD-11); a registry outage falls back to the
+  // cached roster + a loud warn (DD-10). The resolved networks are written back
+  // onto `options.policy.federated.networks` so EVERY downstream consumer (the
+  // runtime LinkPool below, the surface-router + dispatch-listener membership
+  // gates, the review-consumer subjects, the public index) reads the SAME
+  // resolved set — DD-5: no separate registry-resolved code path. NEVER throws;
+  // closes the `cortex-config.ts` "WIRING STATUS (S2)" gap.
+  {
+    const bootResolve = await resolveBootFederatedPeers(options.policy, {
+      warn: (message) => {
+        // Loud — drops + DD-10 fallback must be visible in the daemon logs.
+        process.stderr.write(`cortex: federated-peer boot resolve — ${message}\n`);
+      },
+      // Test-only seam: inject a fixture roster provider so the boot wiring runs
+      // with NO network I/O and NO `~/.config` cache touch. Production omits
+      // this and a live `NetworkRegistryClient` is built from the registry block.
+      ...(options.bootFederatedRosterProvider !== undefined && {
+        rosterProvider: options.bootFederatedRosterProvider,
+      }),
+    });
+    // Rewrite the single field every consumer reads. When federation/registry
+    // is absent this is the input policy returned unchanged (no-op).
+    options.policy = bootResolve.policy;
+    if (bootResolve.errors.length > 0) {
+      console.error(
+        `cortex: ${bootResolve.errors.length.toString()} federated peer(s) ` +
+          `failed closed at boot and were dropped from the membership gate ` +
+          `(see stderr warnings above for per-peer detail).`,
+      );
+    }
   }
 
   // Bus runtime (M2-M6) — no-op when `config.nats?` is absent. Tests inject


### PR DESCRIPTION
**Diagnosis:** `resolveFederatedPeers` (S2) was shipped + unit-tested but had **zero non-test call sites** — never invoked at boot, so `peers[]` was static-config-only (hand-pin). The membership gate keys on `peers[].principal_id` from static config. Separately, the **roster is empty registry-side** (the registry derives membership from announced caps tagged with the network; the deployed worker either predates #762's route or our registration carries no network-tagged cap) — flagged as a separate re-join/deploy, NOT fixed here.

**Implemented (cortex boot, DD-5):** a boot seam (`resolve-federated-peers-boot.ts`) builds the pin+verify `NetworkRegistryClient` from `policy.federated.registry`, runs the S2 resolver, and rewrites `policy.federated.networks[].peers[]` ONCE at `startCortex` before the first consumer — so the runtime LinkPool, surface-router gate, dispatch-listener gate, review subjects all feed the resolved peers identically to a hand-pin (DD-5: no separate code path). DD-11 (hand-pin disagrees with roster → drop, gate denies `unknown_network`), DD-10 (registry-down → cached roster + loud warn, hand-pins survive offline). Never throws; no-op without policy/federation/registry. Hand-pin support fully preserved.

**Tests:** 9 boot-seam units (DD-5 fill, hand-pin+roster merge, DD-11 drop, DD-10 cached + offline hand-pin survival, no-op pass-throughs) + 3 integration driving real `startCortex` (gate admits a roster-resolved peer == a hand-pinned one; denies a DD-11 drop). Full suite 5000 pass / 0 fail, tsc/lint/vocab clean. Schema doc updated S2→WIRED.

Registry-side follow-up: re-join `metafactory-community` with non-empty `announce_capabilities[]` (network-tagged) so the roster populates; cortex resolution is correct the moment it's non-empty.