### PR TITLE
feat(network): cortex network ping + federated echo responder (signal#113 P-11)

### DIFF
--- a/src/bus/__tests__/probe-responder.test.ts
+++ b/src/bus/__tests__/probe-responder.test.ts
@@ -209,6 +209,30 @@ describe("decideProbeResponse — happy path (peer probe)", () => {
     const decision = decideProbeResponse(env, undefined, decisionInputs());
     expect(decision.kind).toBe("reply");
   });
+
+  test("NIT-2: reply data_residency is OUR OWN, not the requester-supplied one", () => {
+    const env = makeProbeRequest({});
+    // The inbound envelope claims a foreign residency; the reply must ignore it.
+    env.sovereignty = { ...env.sovereignty, data_residency: "ATTACKER-LAND" };
+    const decision = decideProbeResponse(
+      env,
+      undefined,
+      decisionInputs({ dataResidency: "NZ" }),
+    );
+    expect(decision.kind).toBe("reply");
+    if (decision.kind !== "reply") return;
+    expect(decision.envelope.sovereignty.data_residency).toBe("NZ");
+    expect(decision.envelope.sovereignty.data_residency).not.toBe("ATTACKER-LAND");
+  });
+
+  test("NIT-2: reply residency defaults to NZ when none supplied", () => {
+    const env = makeProbeRequest({});
+    const decision = decideProbeResponse(env, undefined, decisionInputs());
+    expect(decision.kind).toBe("reply");
+    if (decision.kind === "reply") {
+      expect(decision.envelope.sovereignty.data_residency).toBe("NZ");
+    }
+  });
 });
 
 describe("decideProbeResponse — fail-closed (FG-4 + no-amplification)", () => {
@@ -238,6 +262,16 @@ describe("decideProbeResponse — fail-closed (FG-4 + no-amplification)", () => 
     const decision = decideProbeResponse(env, undefined, decisionInputs());
     expect(decision.kind).toBe("drop");
     if (decision.kind === "drop") expect(decision.reason).toBe("self-loop");
+  });
+
+  test("NIT-3: REFUSES a peer-principal on a DIFFERENT stack than configured", () => {
+    // jc IS a configured peer (jc/default), but the originator decodes to
+    // jc/other-stack — the decoded {principal}/{stack} must EQUAL the peer's
+    // stack_id, else we'd reflect onto jc's unsubscribed subject. Fail-closed.
+    const env = makeProbeRequest({ requesterDid: "did:mf:jc-other-stack" });
+    const decision = decideProbeResponse(env, undefined, decisionInputs());
+    expect(decision.kind).toBe("drop");
+    if (decision.kind === "drop") expect(decision.reason).toBe("non-peer");
   });
 
   test("REFUSES a non-probe-echo type (chat dispatch)", () => {
@@ -463,6 +497,24 @@ describe("createProbeResponder — runtime", () => {
       "federated.andreas.community.tasks.@did-mf-luna.chat",
     );
     expect(r.replies).toHaveLength(0);
+    await responder.stop();
+  });
+
+  test("NIT-4: the SAME request delivered twice yields EXACTLY one reply", async () => {
+    const r = recordingRuntime();
+    const responder = createProbeResponder({
+      runtime: r.runtime,
+      source: SOURCE,
+      stack: OUR_STACK,
+      federatedNetworksById: networksWithPeers(peer("jc", "default")),
+      clock: fixedClock(),
+    });
+    await responder.start();
+    const env = makeProbeRequest({ nonce: "dup-1" });
+    // Redeliver the identical envelope (same id) — idempotency guard drops #2.
+    r.trigger(env, "federated.andreas.community.tasks.probe.echo");
+    r.trigger(env, "federated.andreas.community.tasks.probe.echo");
+    expect(r.replies).toHaveLength(1);
     await responder.stop();
   });
 

--- a/src/bus/__tests__/probe-responder.test.ts
+++ b/src/bus/__tests__/probe-responder.test.ts
@@ -1,0 +1,520 @@
+/**
+ * Tests for the federated echo responder (`cortex network ping` receive-half,
+ * signal#113 P-11 / `docs/design-network-ping.md`, issue #56).
+ *
+ * Close-criteria from the spec §9:
+ *   - answers a peer probe (echo correct, EXACTLY one reply);
+ *   - REFUSES a non-peer (no reply, fail-closed);
+ *   - no-amplification (one request → exactly one reply, never broadcast;
+ *     forged/absent originator → no reply; reply ONLY to the attributed
+ *     requester scope);
+ *   - per-source rate-limit;
+ *   - no LLM / harness / Discord on the probe path (structural — the responder
+ *     module imports none of them; asserted by inspection + the "no publish
+ *     beyond the single reply" checks here).
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import type { Envelope } from "../myelin/envelope-validator";
+import type { MyelinRuntime } from "../myelin/runtime";
+import type { SystemEventSource } from "../system-events";
+import type {
+  PolicyFederatedNetwork,
+  PolicyFederatedPeer,
+} from "../../common/types/cortex-config";
+import {
+  createProbeResponder,
+  decideProbeResponse,
+  isProbeEcho,
+  parseProbeEchoRequest,
+  ProbeRateLimiter,
+  PROBE_ECHO_CAPABILITY,
+  PROBE_REPLY_ECHO_TYPE,
+  RESPONDER_VERSION,
+  systemClock,
+  type ProbeClock,
+  type ProbeDecisionInputs,
+  type ProbeEchoReplyPayload,
+} from "../probe-responder";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+/** "Us" — the receiving stack: andreas/community, assistant luna. */
+const SOURCE: SystemEventSource = {
+  principal: "andreas",
+  agent: "luna",
+  instance: "responder",
+};
+const OUR_STACK = "community";
+
+/** A peer fixture (jc/default) in a configured network. */
+function peer(principal: string, stack: string): PolicyFederatedPeer {
+  return { principal_id: principal, stack_id: `${principal}/${stack}` };
+}
+
+function networksWithPeers(
+  ...peers: PolicyFederatedPeer[]
+): Map<string, PolicyFederatedNetwork> {
+  const network: PolicyFederatedNetwork = {
+    id: "metafactory-community",
+    peers,
+    accept_subjects: [],
+    deny_subjects: [],
+    max_hop: 1,
+  } as unknown as PolicyFederatedNetwork;
+  return new Map([[network.id, network]]);
+}
+
+/** Fixed clock so `server_ts` + rate-limit timing are deterministic. */
+function fixedClock(ms = 1_000_000): ProbeClock {
+  return { nowMs: () => ms, nowIso: () => "2026-06-10T00:00:00.000Z" };
+}
+
+function decisionInputs(
+  overrides: Partial<ProbeDecisionInputs> = {},
+): ProbeDecisionInputs {
+  return {
+    source: SOURCE,
+    stack: OUR_STACK,
+    federatedNetworksById: networksWithPeers(peer("jc", "default")),
+    rateLimiter: new ProbeRateLimiter(),
+    clock: fixedClock(),
+    ...overrides,
+  };
+}
+
+/**
+ * Build an inbound `probe.echo` request envelope.
+ *   - `source` addresses the TARGET (us) — ADR-0002 §1.
+ *   - `originator.identity` carries the REQUESTER DID.
+ */
+function makeProbeRequest(opts: {
+  type?: string;
+  requesterDid?: string | null;
+  nonce?: string | null;
+  seq?: number;
+  correlationId?: string;
+}): Envelope {
+  const payload: Record<string, unknown> = {};
+  if (opts.nonce !== null) payload.nonce = opts.nonce ?? "nonce-abc";
+  payload.sent_at = "2026-06-10T00:00:00.000Z";
+  if (opts.seq !== undefined) payload.seq = opts.seq;
+
+  const env: Envelope = {
+    id: "11111111-1111-4111-8111-111111111111",
+    source: `${SOURCE.principal}.${OUR_STACK}.${SOURCE.agent}`,
+    type: opts.type ?? PROBE_ECHO_CAPABILITY,
+    distribution_mode: "direct",
+    timestamp: "2026-06-10T00:00:00.000Z",
+    correlation_id: opts.correlationId ?? "22222222-2222-4222-8222-222222222222",
+    sovereignty: {
+      classification: "federated",
+      data_residency: "NZ",
+      max_hop: 1,
+      frontier_ok: false,
+      model_class: "local-only",
+    },
+    payload,
+  };
+  if (opts.requesterDid !== null) {
+    env.originator = {
+      identity: opts.requesterDid ?? "did:mf:jc-default",
+      attribution: "federated",
+    };
+  }
+  return env;
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers
+// ---------------------------------------------------------------------------
+
+describe("isProbeEcho", () => {
+  test("matches Offer form `probe.echo`", () => {
+    expect(isProbeEcho("probe.echo")).toBe(true);
+  });
+  test("matches Direct form `tasks.@did-mf-luna.probe.echo`", () => {
+    expect(isProbeEcho("tasks.@did-mf-luna.probe.echo")).toBe(true);
+  });
+  test("matches `tasks.probe.echo`", () => {
+    expect(isProbeEcho("tasks.probe.echo")).toBe(true);
+  });
+  test("REJECTS the reply type (loop-safety)", () => {
+    expect(isProbeEcho(PROBE_REPLY_ECHO_TYPE)).toBe(false);
+  });
+  test("rejects a chat dispatch", () => {
+    expect(isProbeEcho("tasks.@did-mf-luna.chat")).toBe(false);
+    expect(isProbeEcho("tasks.chat")).toBe(false);
+  });
+});
+
+describe("parseProbeEchoRequest", () => {
+  test("accepts a bounded nonce + optional seq", () => {
+    const env = makeProbeRequest({ seq: 3 });
+    const p = parseProbeEchoRequest(env);
+    expect(p).not.toBeNull();
+    expect(p?.nonce).toBe("nonce-abc");
+    expect(p?.seq).toBe(3);
+  });
+  test("rejects a missing nonce", () => {
+    expect(parseProbeEchoRequest(makeProbeRequest({ nonce: null }))).toBeNull();
+  });
+  test("rejects an empty nonce", () => {
+    expect(parseProbeEchoRequest(makeProbeRequest({ nonce: "" }))).toBeNull();
+  });
+  test("rejects an over-long nonce (no amplification via huge nonce)", () => {
+    const huge = "x".repeat(1000);
+    expect(parseProbeEchoRequest(makeProbeRequest({ nonce: huge }))).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// decideProbeResponse — the security core
+// ---------------------------------------------------------------------------
+
+describe("decideProbeResponse — happy path (peer probe)", () => {
+  test("answers a configured peer with EXACTLY one correct echo", () => {
+    const env = makeProbeRequest({ nonce: "n-1", seq: 1 });
+    const decision = decideProbeResponse(env, "federated.andreas.community.tasks.probe.echo", decisionInputs());
+    expect(decision.kind).toBe("reply");
+    if (decision.kind !== "reply") return;
+
+    // Reply addressed ONLY to the originator-attributed requester scope.
+    expect(decision.requesterPrincipal).toBe("jc");
+    expect(decision.requesterStack).toBe("default");
+    expect(decision.subject).toBe(
+      `federated.jc.default.${PROBE_REPLY_ECHO_TYPE}`,
+    );
+
+    // Reply envelope: federated scope, reply type, source addresses requester.
+    expect(decision.envelope.type).toBe(PROBE_REPLY_ECHO_TYPE);
+    expect(decision.envelope.sovereignty.classification).toBe("federated");
+    expect(decision.envelope.source).toBe("jc.default.luna");
+    // correlation_id is echoed so the requester can join request↔reply.
+    expect(decision.envelope.correlation_id).toBe(env.correlation_id);
+
+    // Payload: echoed nonce + server_ts + version + echoed seq. Nothing else.
+    const reply = decision.envelope.payload as unknown as ProbeEchoReplyPayload;
+    expect(reply.nonce).toBe("n-1");
+    expect(reply.seq).toBe(1);
+    expect(reply.responder_version).toBe(RESPONDER_VERSION);
+    expect(reply.server_ts).toBe("2026-06-10T00:00:00.000Z");
+  });
+
+  test("Direct-form request (tasks.@did.probe.echo) is answered the same", () => {
+    const env = makeProbeRequest({ type: "tasks.@did-mf-luna.probe.echo" });
+    const decision = decideProbeResponse(env, undefined, decisionInputs());
+    expect(decision.kind).toBe("reply");
+  });
+});
+
+describe("decideProbeResponse — fail-closed (FG-4 + no-amplification)", () => {
+  test("REFUSES a non-peer requester (no reply)", () => {
+    const env = makeProbeRequest({ requesterDid: "did:mf:evil-stack" });
+    const decision = decideProbeResponse(env, undefined, decisionInputs());
+    expect(decision.kind).toBe("drop");
+    if (decision.kind === "drop") expect(decision.reason).toBe("non-peer");
+  });
+
+  test("REFUSES an absent originator (forged/absent attribution)", () => {
+    const env = makeProbeRequest({ requesterDid: null });
+    const decision = decideProbeResponse(env, undefined, decisionInputs());
+    expect(decision.kind).toBe("drop");
+    if (decision.kind === "drop") expect(decision.reason).toBe("no-originator");
+  });
+
+  test("REFUSES a malformed originator (no did:mf: prefix)", () => {
+    const env = makeProbeRequest({ requesterDid: "jc/default" });
+    const decision = decideProbeResponse(env, undefined, decisionInputs());
+    expect(decision.kind).toBe("drop");
+    if (decision.kind === "drop") expect(decision.reason).toBe("no-originator");
+  });
+
+  test("REFUSES a self-loop (requester == us)", () => {
+    const env = makeProbeRequest({ requesterDid: "did:mf:andreas-community" });
+    const decision = decideProbeResponse(env, undefined, decisionInputs());
+    expect(decision.kind).toBe("drop");
+    if (decision.kind === "drop") expect(decision.reason).toBe("self-loop");
+  });
+
+  test("REFUSES a non-probe-echo type (chat dispatch)", () => {
+    const env = makeProbeRequest({ type: "tasks.@did-mf-luna.chat" });
+    const decision = decideProbeResponse(env, undefined, decisionInputs());
+    expect(decision.kind).toBe("drop");
+    if (decision.kind === "drop") expect(decision.reason).toBe("not-probe-echo");
+  });
+
+  test("REFUSES a bad payload (no nonce)", () => {
+    const env = makeProbeRequest({ nonce: null });
+    const decision = decideProbeResponse(env, undefined, decisionInputs());
+    expect(decision.kind).toBe("drop");
+    if (decision.kind === "drop") expect(decision.reason).toBe("bad-payload");
+  });
+
+  test("reply NEVER targets an attacker-supplied address — only the originator scope", () => {
+    // Even if the request's SOURCE is spoofed to point at a victim, the reply
+    // is keyed off originator.identity, not source. Here source addresses us
+    // (correct), originator is the peer — the reply goes to the peer, period.
+    const env = makeProbeRequest({});
+    env.source = "victim.victim-stack.attacker"; // attacker-controlled source
+    const decision = decideProbeResponse(env, undefined, decisionInputs());
+    expect(decision.kind).toBe("reply");
+    if (decision.kind !== "reply") return;
+    expect(decision.subject).toBe(`federated.jc.default.${PROBE_REPLY_ECHO_TYPE}`);
+    expect(decision.subject).not.toContain("victim");
+  });
+
+  test("empty peers[] (no networks) refuses everything", () => {
+    const env = makeProbeRequest({});
+    const decision = decideProbeResponse(
+      env,
+      undefined,
+      decisionInputs({ federatedNetworksById: new Map() }),
+    );
+    expect(decision.kind).toBe("drop");
+    if (decision.kind === "drop") expect(decision.reason).toBe("non-peer");
+  });
+});
+
+describe("ProbeRateLimiter", () => {
+  test("allows up to capacity then refuses", () => {
+    const rl = new ProbeRateLimiter(3, 0); // capacity 3, no refill
+    expect(rl.take("jc", 0)).toBe(true);
+    expect(rl.take("jc", 0)).toBe(true);
+    expect(rl.take("jc", 0)).toBe(true);
+    expect(rl.take("jc", 0)).toBe(false);
+  });
+
+  test("one principal's flood does not starve another", () => {
+    const rl = new ProbeRateLimiter(2, 0);
+    expect(rl.take("jc", 0)).toBe(true);
+    expect(rl.take("jc", 0)).toBe(true);
+    expect(rl.take("jc", 0)).toBe(false); // jc exhausted
+    expect(rl.take("other", 0)).toBe(true); // other has its own bucket
+  });
+
+  test("refills over time", () => {
+    const rl = new ProbeRateLimiter(1, 1000); // 1 token, 1000/sec refill
+    expect(rl.take("jc", 0)).toBe(true);
+    expect(rl.take("jc", 0)).toBe(false);
+    expect(rl.take("jc", 1)).toBe(true); // 1ms * 1000/s = 1 token refilled
+  });
+});
+
+describe("decideProbeResponse — rate-limit integration", () => {
+  test("a flood of probes is rate-limited (not turned into a reply flood)", () => {
+    const inputs = decisionInputs({
+      rateLimiter: new ProbeRateLimiter(2, 0),
+      clock: fixedClock(),
+    });
+    const env = makeProbeRequest({});
+    expect(decideProbeResponse(env, undefined, inputs).kind).toBe("reply");
+    expect(decideProbeResponse(env, undefined, inputs).kind).toBe("reply");
+    const third = decideProbeResponse(env, undefined, inputs);
+    expect(third.kind).toBe("drop");
+    if (third.kind === "drop") expect(third.reason).toBe("rate-limited");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// createProbeResponder — runtime wiring
+// ---------------------------------------------------------------------------
+
+interface RecordingRuntime {
+  runtime: MyelinRuntime;
+  /** Replies published via publishOnSubject: { subject, envelope }. */
+  replies: { subject: string; envelope: Envelope }[];
+  trigger: (env: Envelope, subject: string) => void;
+  subscribedPatterns: string[];
+}
+
+function recordingRuntime(): RecordingRuntime {
+  const handlers = new Set<Parameters<MyelinRuntime["onEnvelope"]>[0]>();
+  const replies: { subject: string; envelope: Envelope }[] = [];
+  const subscribedPatterns: string[] = [];
+  return {
+    replies,
+    subscribedPatterns,
+    runtime: {
+      enabled: true,
+      onEnvelope: (handler) => {
+        handlers.add(handler);
+        return {
+          unregister: () => {
+            handlers.delete(handler);
+          },
+        };
+      },
+      publish: async () => {
+        throw new Error("probe responder must use publishOnSubject, not publish");
+      },
+      publishOnSubject: async (envelope, subject) => {
+        replies.push({ subject, envelope });
+      },
+      subscribe: async (pattern) => {
+        subscribedPatterns.push(pattern);
+        return {
+          pattern,
+          ready: Promise.resolve(),
+          stop: async () => {},
+        } as unknown as Awaited<
+          ReturnType<NonNullable<MyelinRuntime["subscribe"]>>
+        >;
+      },
+      stop: async () => {},
+    },
+    trigger: (env, subject) => {
+      for (const h of handlers) h(env, subject);
+    },
+  };
+}
+
+describe("createProbeResponder — runtime", () => {
+  test("subscribes our OWN federated tasks subject (FG-2)", async () => {
+    const r = recordingRuntime();
+    const responder = createProbeResponder({
+      runtime: r.runtime,
+      source: SOURCE,
+      stack: OUR_STACK,
+      federatedNetworksById: networksWithPeers(peer("jc", "default")),
+    });
+    expect(responder.subjects).toEqual([
+      "federated.andreas.community.tasks.*.>",
+    ]);
+    await responder.start();
+    expect(r.subscribedPatterns).toEqual([
+      "federated.andreas.community.tasks.*.>",
+    ]);
+    await responder.stop();
+  });
+
+  test("a peer probe yields EXACTLY one reply on the requester subject", async () => {
+    const r = recordingRuntime();
+    const responder = createProbeResponder({
+      runtime: r.runtime,
+      source: SOURCE,
+      stack: OUR_STACK,
+      federatedNetworksById: networksWithPeers(peer("jc", "default")),
+      clock: fixedClock(),
+    });
+    await responder.start();
+
+    const env = makeProbeRequest({ nonce: "live-1", seq: 7 });
+    r.trigger(env, "federated.andreas.community.tasks.probe.echo");
+
+    // EXACTLY ONE reply — no fan-out, no broadcast.
+    expect(r.replies).toHaveLength(1);
+    const reply = r.replies[0]!;
+    expect(reply.subject).toBe(`federated.jc.default.${PROBE_REPLY_ECHO_TYPE}`);
+    const p = reply.envelope.payload as unknown as ProbeEchoReplyPayload;
+    expect(p.nonce).toBe("live-1");
+    expect(p.seq).toBe(7);
+    await responder.stop();
+  });
+
+  test("a non-peer probe yields NO reply (fail-closed)", async () => {
+    const r = recordingRuntime();
+    const responder = createProbeResponder({
+      runtime: r.runtime,
+      source: SOURCE,
+      stack: OUR_STACK,
+      federatedNetworksById: networksWithPeers(peer("jc", "default")),
+    });
+    await responder.start();
+    r.trigger(
+      makeProbeRequest({ requesterDid: "did:mf:evil-stack" }),
+      "federated.andreas.community.tasks.probe.echo",
+    );
+    expect(r.replies).toHaveLength(0);
+    await responder.stop();
+  });
+
+  test("an absent originator yields NO reply", async () => {
+    const r = recordingRuntime();
+    const responder = createProbeResponder({
+      runtime: r.runtime,
+      source: SOURCE,
+      stack: OUR_STACK,
+      federatedNetworksById: networksWithPeers(peer("jc", "default")),
+    });
+    await responder.start();
+    r.trigger(
+      makeProbeRequest({ requesterDid: null }),
+      "federated.andreas.community.tasks.probe.echo",
+    );
+    expect(r.replies).toHaveLength(0);
+    await responder.stop();
+  });
+
+  test("a chat dispatch on our tasks subject is ignored (not answered)", async () => {
+    const r = recordingRuntime();
+    const responder = createProbeResponder({
+      runtime: r.runtime,
+      source: SOURCE,
+      stack: OUR_STACK,
+      federatedNetworksById: networksWithPeers(peer("jc", "default")),
+    });
+    await responder.start();
+    r.trigger(
+      makeProbeRequest({ type: "tasks.@did-mf-luna.chat" }),
+      "federated.andreas.community.tasks.@did-mf-luna.chat",
+    );
+    expect(r.replies).toHaveLength(0);
+    await responder.stop();
+  });
+
+  test("our own reply (probe.reply.echo) never re-triggers a reply (loop-safe)", async () => {
+    const r = recordingRuntime();
+    const responder = createProbeResponder({
+      runtime: r.runtime,
+      source: SOURCE,
+      stack: OUR_STACK,
+      federatedNetworksById: networksWithPeers(peer("jc", "default")),
+    });
+    await responder.start();
+    // Feed a reply-typed envelope back in — must be ignored.
+    const replyEnv = makeProbeRequest({ type: PROBE_REPLY_ECHO_TYPE });
+    r.trigger(replyEnv, `federated.andreas.community.tasks.probe.echo`);
+    expect(r.replies).toHaveLength(0);
+    await responder.stop();
+  });
+
+  test("an off-pattern subject is ignored", async () => {
+    const r = recordingRuntime();
+    const responder = createProbeResponder({
+      runtime: r.runtime,
+      source: SOURCE,
+      stack: OUR_STACK,
+      federatedNetworksById: networksWithPeers(peer("jc", "default")),
+    });
+    await responder.start();
+    // Probe envelope but on someone else's subject — ignore.
+    r.trigger(makeProbeRequest({}), "federated.other.stack.tasks.probe.echo");
+    expect(r.replies).toHaveLength(0);
+    await responder.stop();
+  });
+
+  test("dormant when no peers configured (does not subscribe)", async () => {
+    const r = recordingRuntime();
+    const responder = createProbeResponder({
+      runtime: r.runtime,
+      source: SOURCE,
+      stack: OUR_STACK,
+      federatedNetworksById: new Map(),
+    });
+    await responder.start();
+    expect(r.subscribedPatterns).toHaveLength(0);
+    r.trigger(makeProbeRequest({}), "federated.andreas.community.tasks.probe.echo");
+    expect(r.replies).toHaveLength(0);
+    await responder.stop();
+  });
+});
+
+describe("systemClock", () => {
+  test("nowIso is a valid ISO string", () => {
+    expect(() => new Date(systemClock.nowIso()).toISOString()).not.toThrow();
+  });
+});

--- a/src/bus/probe-responder.ts
+++ b/src/bus/probe-responder.ts
@@ -282,6 +282,13 @@ export interface ProbeDecisionInputs {
   rateLimiter: ProbeRateLimiter;
   /** Clock for `server_ts` + rate-limit timing. */
   clock: ProbeClock;
+  /**
+   * PR #822 NIT-2 — the RESPONDER's OWN data residency, stamped on the reply
+   * WE author. Defaults to `"NZ"` (the ecosystem default). Deliberately NOT
+   * mirrored from the inbound (requester-supplied) envelope: a reply we
+   * originate must carry our own sovereignty, not an attacker-influenced one.
+   */
+  dataResidency?: string;
 }
 
 /**
@@ -356,6 +363,26 @@ export function decideProbeResponse(
     };
   }
 
+  // (5b) PR #822 NIT-3 — bind the DID-decoded `{principal}/{stack}` to the
+  // matched peer's configured `stack_id` BEFORE composing the reply subject.
+  // `resolveSourceNetwork` keys on principal alone; the stack comes from the
+  // (DID_RE-validated, but otherwise free-form) decoded originator. Requiring
+  // an EXACT `{decoded-principal}/{decoded-stack}` === peer.stack_id match
+  // closes the latent "reflect onto a peer's unsubscribed stack subject" case:
+  // a peer that declared `jc/default` cannot elicit a reply aimed at
+  // `jc/some-other-stack`. Fail-closed on mismatch.
+  const decodedStackId = `${requesterPrincipal}/${requesterStack}`;
+  const matchedPeer = resolved.network.peers.find(
+    (p) => p.principal_id === requesterPrincipal && p.stack_id === decodedStackId,
+  );
+  if (matchedPeer === undefined) {
+    return {
+      kind: "drop",
+      reason: "non-peer",
+      detail: `decoded requester stack "${decodedStackId}" matches no configured peer stack_id (principal "${requesterPrincipal}" is a peer, but on a different stack)`,
+    };
+  }
+
   // (6) Rate-limit — per requester principal. Bounds a reflection flood.
   if (!inputs.rateLimiter.take(requesterPrincipal, inputs.clock.nowMs())) {
     return {
@@ -389,7 +416,9 @@ export function decideProbeResponse(
       }),
       sovereignty: {
         classification: "federated",
-        data_residency: envelope.sovereignty.data_residency,
+        // PR #822 NIT-2 — OUR residency, not the inbound (requester-supplied)
+        // envelope's. A reply we author carries our own sovereignty.
+        data_residency: inputs.dataResidency ?? "NZ",
         max_hop: 1,
         frontier_ok: false,
         model_class: "local-only",
@@ -433,6 +462,11 @@ export interface ProbeResponderOptions {
   rateLimiter?: ProbeRateLimiter;
   /** Optional clock (defaults to the system clock). */
   clock?: ProbeClock;
+  /**
+   * PR #822 NIT-2 — the responder's OWN data residency, stamped on replies.
+   * Defaults to `"NZ"`. `cortex.ts` passes the stack's configured residency.
+   */
+  dataResidency?: string;
 }
 
 export interface ProbeResponder {
@@ -463,6 +497,7 @@ export function createProbeResponder(
     federatedNetworksById,
     rateLimiter = new ProbeRateLimiter(),
     clock = systemClock,
+    dataResidency,
   } = opts;
 
   // Subscribe our OWN federated tasks subject (FG-2: subject addresses us).
@@ -475,12 +510,32 @@ export function createProbeResponder(
   }
   let runtimeSubscribers: RuntimeSubscriber[] = [];
 
+  // PR #822 NIT-4 — per-request idempotency guard. A bounded LRU of recently-
+  // answered envelope ids so the SAME request (a redelivery) yields at most
+  // ONE reply. Cannot manifest on the current push-mode `runtime.subscribe`
+  // (core NATS — no redelivery), but mirrors `review-consumer`'s
+  // `deliveryCount > 1` drop for symmetry + future JetStream safety. Bounded
+  // (insertion-ordered Map, oldest evicted) so it can't grow unbounded under a
+  // probe flood — the rate limiter already caps per-source volume.
+  const SEEN_CAP = 4096;
+  const seenEnvelopeIds = new Map<string, true>();
+  const alreadyAnswered = (id: string): boolean => {
+    if (seenEnvelopeIds.has(id)) return true;
+    seenEnvelopeIds.set(id, true);
+    if (seenEnvelopeIds.size > SEEN_CAP) {
+      const oldest = seenEnvelopeIds.keys().next().value;
+      if (oldest !== undefined) seenEnvelopeIds.delete(oldest);
+    }
+    return false;
+  };
+
   const decisionInputs: ProbeDecisionInputs = {
     source,
     stack,
     federatedNetworksById,
     rateLimiter,
     clock,
+    ...(dataResidency !== undefined && { dataResidency }),
   };
 
   const handle = (envelope: Envelope, subject: string): void => {
@@ -492,6 +547,16 @@ export function createProbeResponder(
     // Fast pre-filter: only probe.echo types reach the decision. (A chat
     // dispatch on this subject is the runner's concern, not ours.)
     if (!isProbeEcho(envelope.type)) return;
+
+    // PR #822 NIT-4 — drop a redelivered request (same envelope id) BEFORE
+    // minting a second reply. Checked after the cheap type pre-filter so a
+    // non-probe envelope never pollutes the seen-set.
+    if (alreadyAnswered(envelope.id)) {
+      process.stderr.write(
+        `cortex/probe-responder: DROP reason=redelivery envelope=${envelope.id} subject=${subject}\n`,
+      );
+      return;
+    }
 
     const decision = decideProbeResponse(envelope, subject, decisionInputs);
     if (decision.kind === "drop") {

--- a/src/bus/probe-responder.ts
+++ b/src/bus/probe-responder.ts
@@ -1,0 +1,565 @@
+/**
+ * Federated echo responder — the receive-half of `cortex network ping`
+ * (signal#113 P-11 / `docs/design-network-ping.md`, issue #56).
+ *
+ * This is the **ICMP-analog** of the agent network: a built-in handler that
+ * answers a reserved `probe.echo` capability **in the runtime, before any
+ * substrate harness runs**. It is recognised by capability and answered
+ * inline — NO `claude --print`, NO session, NO Discord post, NO worklog, NO
+ * Skill tool. The reply carries the echoed nonce + a server timestamp + the
+ * responder version; the requester times the round trip.
+ *
+ * ## Why a dedicated subscriber (not a dispatch-listener short-circuit)
+ *
+ * Per the spec §8, the responder may live either as a capability check inside
+ * `dispatch-listener.ts` OR (cleaner) as a dedicated responder that subscribes
+ * the `tasks.*.probe.echo` pattern alongside the runner. We take the dedicated
+ * path: it keeps the probe path side-effect-free and self-contained, avoids
+ * restructuring the (large, security-sensitive) dispatch listener, and is
+ * symmetric with `ReviewConsumer` / `BusDispatchListener`. The responder
+ * registers its own `runtime.onEnvelope` handler + `runtime.subscribe` so its
+ * declared interest does not depend on `nats.subjects[]` config.
+ *
+ * Because the runner's dispatch-listener subscribes `tasks.*.>`, a `probe.echo`
+ * envelope ALSO reaches the runner. The runner's `parsePayload` rejects it (a
+ * probe has no `task_id`/`agent_id`/`prompt`), so it is dropped there with a
+ * "malformed" trace and NEVER spawns a harness — the responder is the only
+ * thing that answers. The responder is excluded from any self-capture loop:
+ * its OWN reply rides `probe.reply.echo` (a different subtree), and it never
+ * answers an envelope whose type is a reply (defensive `probe.echo` match).
+ *
+ * ## Wire grammar (ADR-0001 / ADR-0002, the 5 FG checks)
+ *
+ *   REQUEST  (requester → us)
+ *     subject     federated.{us}.{our-stack}.tasks.@{enc-did}.probe.echo  (Direct)
+ *              or federated.{us}.{our-stack}.tasks.probe.echo             (Offer)
+ *     source      {us}.{our-stack}.{sender}        — addresses the TARGET (us)
+ *     originator  did:mf:{requester-principal}-{requester-stack}  — the REQUESTER
+ *     type        probe.echo / tasks.@{...}.probe.echo
+ *
+ *   REPLY    (us → requester)        # built-in echo, no LLM
+ *     requester = decode(originator.identity)        # NOT the subject, NOT source
+ *     subject     federated.{requester}.{req-stack}.probe.reply.echo
+ *     source      {requester}.{req-stack}.{responder}   — addresses the REQUESTER
+ *     type        probe.reply.echo
+ *     payload     { nonce (echoed), server_ts, responder_version, seq? }
+ *
+ * FG checks: (1) no network on the wire — derived subject carries only
+ * identity; (2) subject addresses the target (us) — we subscribe our own
+ * `federated.{us}.{stack}.tasks.*.>`; (3) requester rides in
+ * `originator.identity` — decoded via `parseRequesterFromOriginator`, never
+ * the subject; (4) reply keyed on the requester scope + `peers[]` fail-closed
+ * (absent/forged originator OR non-peer ⇒ DROP, no reply); (5) `federated.`
+ * throughout.
+ *
+ * ## No-amplification (SEV-1) — the load-bearing security property
+ *
+ *   - **Exactly one** bounded reply per accepted request. The reply payload is
+ *     a fixed shape (echoed nonce + timestamp + version + optional seq) — no
+ *     fan-out, no multi-packet, no payload echo beyond the nonce.
+ *   - The reply targets **only** the `originator`-attributed requester scope
+ *     (decoded from `originator.identity`) — NEVER an attacker-supplied reply
+ *     address, NEVER broadcast. The subject is composed from the decoded
+ *     requester, not from anything in the request's subject/source/payload.
+ *   - **Fail-closed** on absent/malformed `originator`, a self-loop (requester
+ *     == us), or a requester not in any configured `peers[]` — DROP, no reply.
+ *   - **Per-source rate-limit** (token bucket per requester principal) so a
+ *     flood of probes cannot be turned into a flood of replies aimed at a
+ *     victim, and cannot exhaust the responder.
+ */
+
+import type { Envelope } from "./myelin/envelope-validator";
+import { parseRequesterFromOriginator } from "./review-consumer";
+import { resolveSourceNetwork } from "./surface-router";
+import { buildBaseEnvelope } from "./envelope-builder";
+import type { PolicyFederatedNetwork } from "../common/types/cortex-config";
+import type { MyelinRuntime } from "./myelin/runtime";
+import type { SystemEventSource } from "./system-events";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/**
+ * Reserved probe capability id. The request envelope `type` is either the
+ * Offer form `probe.echo` (no `@` assistant segment) or the Direct form
+ * `tasks.@{enc-did}.probe.echo`. We match on the `probe.echo` tail of the
+ * capability rather than the full type so both Direct and Offer requests are
+ * recognised by the same responder.
+ */
+export const PROBE_ECHO_CAPABILITY = "probe.echo";
+
+/** Reply capability — a distinct subtree so our reply never re-triggers us. */
+export const PROBE_REPLY_ECHO_TYPE = "probe.reply.echo";
+
+/**
+ * Responder protocol version, surfaced in the reply payload. Lets a requester
+ * diagnose `no-responder` (version floor unmet) vs a healthy echo, and is the
+ * one mild disclosure the spec §6.4 accepts between mutually-configured peers.
+ */
+export const RESPONDER_VERSION = "1.0.0";
+
+/**
+ * Per-source token-bucket defaults. A probe reply is O(1) and far smaller than
+ * a session spawn, so the cap only needs to bound a reflection flood — not
+ * throttle legitimate diagnostics. Capacity 20, refill 20 tokens/sec.
+ */
+export const DEFAULT_RATE_LIMIT_CAPACITY = 20;
+export const DEFAULT_RATE_LIMIT_REFILL_PER_SEC = 20;
+
+// ---------------------------------------------------------------------------
+// Pure responder decision
+// ---------------------------------------------------------------------------
+
+/** The decoded, validated probe-echo request payload (untrusted input). */
+export interface ProbeEchoRequestPayload {
+  /** Opaque nonce the requester generated; echoed back verbatim. */
+  nonce: string;
+  /** ISO-8601 send time (informational; RTT is measured on the requester). */
+  sent_at?: string;
+  /** Optional probe sequence number (`ping -c` style). Echoed back. */
+  seq?: number;
+}
+
+/** The bounded echo reply payload. Fixed shape — no amplification. */
+export interface ProbeEchoReplyPayload {
+  /** The requester's nonce, echoed verbatim. */
+  nonce: string;
+  /** Responder server timestamp (ISO-8601). One-way-delay estimate only. */
+  server_ts: string;
+  /** Responder protocol version. */
+  responder_version: string;
+  /** Echoed probe sequence number, when the request carried one. */
+  seq?: number;
+}
+
+/**
+ * Why a probe was dropped without a reply (fail-closed). Surfaced for the
+ * stderr audit line so a principal can see "who tried to probe me and why I
+ * refused" — the abuse signal of spec §6.5.
+ */
+export type ProbeDropReason =
+  | "not-probe-echo"
+  | "no-originator"
+  | "self-loop"
+  | "non-peer"
+  | "bad-payload"
+  | "rate-limited";
+
+/** The outcome of evaluating one inbound envelope against the responder. */
+export type ProbeResponderDecision =
+  | { kind: "drop"; reason: ProbeDropReason; detail?: string }
+  | {
+      kind: "reply";
+      /** Decoded requester principal (from originator) — the reply scope. */
+      requesterPrincipal: string;
+      /** Decoded requester stack (from originator) — the reply scope. */
+      requesterStack: string;
+      /** The reply envelope, addressed to the requester. */
+      envelope: Envelope;
+      /** The reply subject (explicit — `publishOnSubject`). */
+      subject: string;
+    };
+
+/**
+ * Recognise the reserved `probe.echo` capability on an inbound envelope `type`.
+ *
+ * Accepts both wire forms:
+ *   - Offer:  `probe.echo`
+ *   - Direct: `tasks.@{enc-did}.probe.echo`  (the runtime publishes the
+ *     `@`-bearing subject; the envelope `type` mirrors the capability tail).
+ *
+ * Rejects the reply type (`probe.reply.echo`) and everything else — so the
+ * responder never answers its own reply (loop-safety) nor a chat dispatch.
+ */
+export function isProbeEcho(type: string): boolean {
+  if (type === PROBE_REPLY_ECHO_TYPE) return false;
+  // Exact Offer form, or any type whose final two dot-segments are
+  // `probe.echo` (Direct form `tasks.@….probe.echo`, or `tasks.probe.echo`).
+  if (type === PROBE_ECHO_CAPABILITY) return true;
+  return type.endsWith(`.${PROBE_ECHO_CAPABILITY}`);
+}
+
+/**
+ * Validate the untrusted request payload into a {@link ProbeEchoRequestPayload}
+ * or `null`. The nonce is the only required field; it must be a non-empty,
+ * bounded string (we echo it back, so we cap its size to keep the reply
+ * bounded — no amplification via an oversized nonce).
+ */
+const MAX_NONCE_LEN = 256;
+
+export function parseProbeEchoRequest(
+  envelope: Envelope,
+): ProbeEchoRequestPayload | null {
+  const p = envelope.payload as
+    | Partial<Record<keyof ProbeEchoRequestPayload, unknown>>
+    | undefined;
+  if (!p) return null;
+  if (typeof p.nonce !== "string" || p.nonce.length === 0) return null;
+  if (p.nonce.length > MAX_NONCE_LEN) return null;
+  const out: ProbeEchoRequestPayload = { nonce: p.nonce };
+  if (typeof p.sent_at === "string") out.sent_at = p.sent_at;
+  if (typeof p.seq === "number" && Number.isInteger(p.seq)) out.seq = p.seq;
+  return out;
+}
+
+/**
+ * A minimal monotonic-ish clock seam so tests can pin `server_ts` and the rate
+ * limiter without touching `Date.now`.
+ */
+export interface ProbeClock {
+  /** Wall-clock ms (for the rate-limit token bucket). */
+  nowMs(): number;
+  /** ISO-8601 string for the reply `server_ts`. */
+  nowIso(): string;
+}
+
+export const systemClock: ProbeClock = {
+  nowMs: () => Date.now(),
+  nowIso: () => new Date().toISOString(),
+};
+
+/**
+ * Per-principal token-bucket rate limiter. Pure-ish: state lives in the
+ * instance; `take(principal)` returns whether a token was available. One
+ * bucket per requester principal so one abusive peer cannot starve another.
+ */
+export class ProbeRateLimiter {
+  private readonly capacity: number;
+  private readonly refillPerMs: number;
+  private readonly buckets = new Map<
+    string,
+    { tokens: number; lastMs: number }
+  >();
+
+  constructor(
+    capacity = DEFAULT_RATE_LIMIT_CAPACITY,
+    refillPerSec = DEFAULT_RATE_LIMIT_REFILL_PER_SEC,
+  ) {
+    this.capacity = capacity;
+    this.refillPerMs = refillPerSec / 1000;
+  }
+
+  /** Attempt to consume a token for `principal`. Returns `true` when allowed. */
+  take(principal: string, nowMs: number): boolean {
+    const existing = this.buckets.get(principal);
+    if (existing === undefined) {
+      // First request from this principal: full bucket minus this token.
+      this.buckets.set(principal, { tokens: this.capacity - 1, lastMs: nowMs });
+      return true;
+    }
+    // Refill based on elapsed time, capped at capacity.
+    const elapsed = Math.max(0, nowMs - existing.lastMs);
+    const refilled = Math.min(
+      this.capacity,
+      existing.tokens + elapsed * this.refillPerMs,
+    );
+    if (refilled < 1) {
+      // No token available — update timestamp so the next call refills from
+      // here (don't reset `tokens`, or we'd lose the partial accrual).
+      existing.tokens = refilled;
+      existing.lastMs = nowMs;
+      return false;
+    }
+    existing.tokens = refilled - 1;
+    existing.lastMs = nowMs;
+    return true;
+  }
+}
+
+/**
+ * Inputs to the pure responder decision. The runtime side (subscriber) builds
+ * these; the decision itself touches no I/O so it is exhaustively testable.
+ */
+export interface ProbeDecisionInputs {
+  /** The receiving stack's source identity (whose principal is "us"). */
+  source: SystemEventSource;
+  /** The receiving stack's stack slug (the `{stack}` reply segment). */
+  stack: string;
+  /** Configured federated networks, indexed by id — the `peers[]` gate. */
+  federatedNetworksById: Map<string, PolicyFederatedNetwork>;
+  /** Rate limiter (per requester principal). */
+  rateLimiter: ProbeRateLimiter;
+  /** Clock for `server_ts` + rate-limit timing. */
+  clock: ProbeClock;
+}
+
+/**
+ * THE responder core: pure decision over one inbound envelope. Returns either
+ * a single bounded reply (addressed only to the originator-attributed
+ * requester scope) or a fail-closed drop. No side effects.
+ *
+ * Order of checks (each fail-closed):
+ *   1. type is `probe.echo` (not a reply, not a chat dispatch).
+ *   2. payload parses (nonce present + bounded).
+ *   3. requester decodes from `originator.identity` (absent/malformed ⇒ drop).
+ *   4. not a self-loop (requester principal != us).
+ *   5. requester principal is a configured `peers[]` member.
+ *   6. per-source rate-limit token available.
+ *
+ * Only after ALL pass do we mint exactly ONE reply, keyed to the requester.
+ */
+export function decideProbeResponse(
+  envelope: Envelope,
+  subject: string | undefined,
+  inputs: ProbeDecisionInputs,
+): ProbeResponderDecision {
+  // (1) Capability — only `probe.echo`. Match the type; defensively also
+  // require the subject (when present) to be a `tasks.*` subject so a
+  // mis-typed envelope on the wrong subject can't sneak through.
+  if (!isProbeEcho(envelope.type)) {
+    return { kind: "drop", reason: "not-probe-echo", detail: envelope.type };
+  }
+
+  // (2) Payload — nonce required + bounded (no amplification via huge nonce).
+  const req = parseProbeEchoRequest(envelope);
+  if (req === null) {
+    return { kind: "drop", reason: "bad-payload" };
+  }
+
+  // (3) Requester — decoded from originator.identity ONLY (never the subject,
+  // never source). Absent/malformed originator ⇒ fail-closed (FG-4).
+  const requester = parseRequesterFromOriginator(envelope);
+  if (requester === undefined) {
+    return { kind: "drop", reason: "no-originator" };
+  }
+  const requesterPrincipal = requester.principal;
+  // The DID encodes `{principal}-{stack}`; a missing stack segment means a
+  // malformed/half-formed identity — fail closed rather than guess `default`.
+  if (requester.stack === undefined || requester.stack.length === 0) {
+    return { kind: "drop", reason: "no-originator", detail: "no stack in originator" };
+  }
+  const requesterStack = requester.stack;
+
+  // (4) Self-loop — never answer an envelope that named US as the requester.
+  if (requesterPrincipal === inputs.source.principal) {
+    return {
+      kind: "drop",
+      reason: "self-loop",
+      detail: `requester principal "${requesterPrincipal}" is this stack`,
+    };
+  }
+
+  // (5) peers[] membership — the requester principal MUST be a configured peer
+  // in some network's peers[]. Fail-closed for an unknown/untrusted peer
+  // (FG-4 / ADR-0002 §5 defense-in-depth — the application-layer trust
+  // boundary under `signing: off`).
+  const resolved = resolveSourceNetwork(
+    requesterPrincipal,
+    inputs.federatedNetworksById,
+  );
+  if (resolved === undefined) {
+    return {
+      kind: "drop",
+      reason: "non-peer",
+      detail: `requester "${requesterPrincipal}" in no configured peers[]`,
+    };
+  }
+
+  // (6) Rate-limit — per requester principal. Bounds a reflection flood.
+  if (!inputs.rateLimiter.take(requesterPrincipal, inputs.clock.nowMs())) {
+    return {
+      kind: "drop",
+      reason: "rate-limited",
+      detail: `requester "${requesterPrincipal}" exceeded probe rate limit`,
+    };
+  }
+
+  // All gates passed — mint EXACTLY ONE bounded reply, keyed ONLY to the
+  // originator-attributed requester scope. The reply `source` addresses the
+  // requester (so `deriveNatsSubject` would also resolve there), and we
+  // publish on an explicit `federated.{requester}.{req-stack}.probe.reply.echo`
+  // subject (the `probe.reply.echo` type would otherwise derive from `source`
+  // — we build it explicitly for clarity + to keep alignment obvious).
+  const replyPayload: ProbeEchoReplyPayload = {
+    nonce: req.nonce,
+    server_ts: inputs.clock.nowIso(),
+    responder_version: RESPONDER_VERSION,
+    ...(req.seq !== undefined && { seq: req.seq }),
+  };
+
+  const replyEnvelope: Envelope = {
+    ...buildBaseEnvelope({
+      type: PROBE_REPLY_ECHO_TYPE,
+      // `source` addresses the REQUESTER's scope (the reply-to), exactly the
+      // verdict-back pattern: `{requester-principal}.{requester-stack}.{responder}`.
+      source: `${requesterPrincipal}.${requesterStack}.${inputs.source.agent}`,
+      ...(envelope.correlation_id !== undefined && {
+        correlationId: envelope.correlation_id,
+      }),
+      sovereignty: {
+        classification: "federated",
+        data_residency: envelope.sovereignty.data_residency,
+        max_hop: 1,
+        frontier_ok: false,
+        model_class: "local-only",
+      },
+      payload: replyPayload as unknown as Record<string, unknown>,
+    }),
+    // Our reply is, itself, an attributed federated envelope: we are the
+    // originator now. `attribution: "federated"` (the myelin Originator field;
+    // the spec's "originator.method = federated" maps to this) marks the claim
+    // as relayed cross-principal.
+    originator: {
+      identity: `did:mf:${inputs.source.principal}-${inputs.stack}`,
+      attribution: "federated",
+    },
+  };
+
+  const replySubject = `federated.${requesterPrincipal}.${requesterStack}.${PROBE_REPLY_ECHO_TYPE}`;
+
+  return {
+    kind: "reply",
+    requesterPrincipal,
+    requesterStack,
+    envelope: replyEnvelope,
+    subject: replySubject,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Runtime subscriber
+// ---------------------------------------------------------------------------
+
+export interface ProbeResponderOptions {
+  runtime: MyelinRuntime;
+  /** Receiving stack source identity. `source.principal` is "us". */
+  source: SystemEventSource;
+  /** Receiving stack slug — the `{stack}` segment we subscribe + reply with. */
+  stack: string;
+  /** Configured federated networks (the `peers[]` gate). Empty ⇒ never replies. */
+  federatedNetworksById: Map<string, PolicyFederatedNetwork>;
+  /** Optional rate limiter (defaults to the standard token bucket). */
+  rateLimiter?: ProbeRateLimiter;
+  /** Optional clock (defaults to the system clock). */
+  clock?: ProbeClock;
+}
+
+export interface ProbeResponder {
+  /** Subject pattern this responder subscribes (exposed for tests). */
+  readonly subjects: readonly string[];
+  start(): Promise<void>;
+  stop(): Promise<void>;
+}
+
+/**
+ * Wire the echo responder onto the runtime. Subscribes
+ * `federated.{us}.{stack}.tasks.*.>` (the same canonical Tasks-Domain pattern
+ * the runner uses, but in the `federated.` scope) and answers any `probe.echo`
+ * envelope inline.
+ *
+ * Dormant when `federatedNetworksById` is empty (no peers ⇒ nothing to answer)
+ * OR the runtime is disabled (no NATS). Symmetric with the dispatch-listener:
+ * a `runtime.onEnvelope` handler filtered by subject + a `runtime.subscribe`
+ * to declare interest.
+ */
+export function createProbeResponder(
+  opts: ProbeResponderOptions,
+): ProbeResponder {
+  const {
+    runtime,
+    source,
+    stack,
+    federatedNetworksById,
+    rateLimiter = new ProbeRateLimiter(),
+    clock = systemClock,
+  } = opts;
+
+  // Subscribe our OWN federated tasks subject (FG-2: subject addresses us).
+  const pattern = `federated.${source.principal}.${stack}.tasks.*.>`;
+  const subjects = [pattern];
+
+  let registration: { unregister: () => void } | null = null;
+  interface RuntimeSubscriber {
+    stop(): Promise<void>;
+  }
+  let runtimeSubscribers: RuntimeSubscriber[] = [];
+
+  const decisionInputs: ProbeDecisionInputs = {
+    source,
+    stack,
+    federatedNetworksById,
+    rateLimiter,
+    clock,
+  };
+
+  const handle = (envelope: Envelope, subject: string): void => {
+    // Only our own federated tasks subjects. The runtime fans every envelope
+    // to every handler; ignore anything off-pattern.
+    if (!subject.startsWith(`federated.${source.principal}.${stack}.tasks.`)) {
+      return;
+    }
+    // Fast pre-filter: only probe.echo types reach the decision. (A chat
+    // dispatch on this subject is the runner's concern, not ours.)
+    if (!isProbeEcho(envelope.type)) return;
+
+    const decision = decideProbeResponse(envelope, subject, decisionInputs);
+    if (decision.kind === "drop") {
+      // Audit (spec §6.5) — who probed us + why we refused. Never throws into
+      // the fan-out. This is the abuse signal; a dropped probe emits NO reply.
+      process.stderr.write(
+        `cortex/probe-responder: DROP reason=${decision.reason}` +
+          (decision.detail !== undefined ? ` detail=${decision.detail}` : "") +
+          ` envelope=${envelope.id} subject=${subject}\n`,
+      );
+      return;
+    }
+
+    // Exactly ONE reply, addressed ONLY to the originator-attributed requester
+    // scope. Fire-and-forget publish on the explicit reply subject; a publish
+    // failure is logged (never swallowed) and never throws into the fan-out.
+    const publish = runtime.publishOnSubject?.(decision.envelope, decision.subject);
+    if (publish === undefined) {
+      // Runtime cannot publish on an explicit subject (disabled / legacy stub).
+      // Drop silently-but-logged — we never guess a derived subject for a
+      // cross-principal reply (that could land on the wrong scope).
+      process.stderr.write(
+        `cortex/probe-responder: runtime lacks publishOnSubject — cannot reply ` +
+          `to ${decision.requesterPrincipal}/${decision.requesterStack} ` +
+          `(envelope=${envelope.id})\n`,
+      );
+      return;
+    }
+    void publish.catch((err: unknown) => {
+      process.stderr.write(
+        `cortex/probe-responder: reply publish failed for ` +
+          `${decision.requesterPrincipal}/${decision.requesterStack} ` +
+          `(envelope=${envelope.id}): ` +
+          `${err instanceof Error ? err.message : String(err)}\n`,
+      );
+    });
+  };
+
+  return {
+    subjects,
+    async start() {
+      if (registration) return;
+      // Dormant when no peers are configured: a responder with an empty
+      // peers[] gate would drop every probe anyway, so don't even subscribe.
+      if (federatedNetworksById.size === 0) {
+        process.stderr.write(
+          "cortex/probe-responder: no federated networks configured — responder dormant\n",
+        );
+        return;
+      }
+      registration = runtime.onEnvelope((envelope, subject) => {
+        handle(envelope, subject);
+      });
+      if (runtime.subscribe) {
+        for (const p of subjects) {
+          const sub = await runtime.subscribe(p);
+          if (sub) runtimeSubscribers.push(sub);
+        }
+      }
+    },
+    async stop() {
+      if (registration) {
+        registration.unregister();
+        registration = null;
+      }
+      const drained = runtimeSubscribers;
+      runtimeSubscribers = [];
+      await Promise.allSettled(drained.map((s) => s.stop()));
+    },
+  };
+}

--- a/src/cli/cortex/commands/__tests__/network-ping-cli.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-ping-cli.test.ts
@@ -1,0 +1,215 @@
+/**
+ * CLI-level tests for `cortex network ping` (signal#113 P-11 / #56).
+ *
+ * Drives `dispatchNetwork(["ping", ...])` with an injected fake config reader
+ * AND an injected fake probe-bus factory — no NATS, no `~/.config`, no live
+ * wire. Asserts the verdict → exit-code mapping (§3.3), the `not-configured`
+ * fail-closed (nothing emitted), `--count` aggregation, and `--json` output.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import { dispatchNetwork, type PingBusFactory } from "../network";
+import type { LoadedConfig } from "../../../../common/config/loader";
+import type { AgentConfig } from "../../../../common/types/config";
+import { PROBE_REPLY_ECHO_TYPE } from "../../../../bus/probe-responder";
+import type { Envelope } from "../../../../bus/myelin/envelope-validator";
+import type {
+  NetworkPingPorts,
+  ProbeFireInputs,
+  ProbeRoundTripResult,
+} from "../network-ping-ports";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+/** A reader returning a config that declares jc/default as a peer. */
+function readerWithPeer(): () => LoadedConfig {
+  return () =>
+    ({
+      config: { nats: { url: "nats://127.0.0.1:4222" } } as unknown as AgentConfig,
+      inlineAgents: [{ id: "luna" } as unknown as LoadedConfig["inlineAgents"][number]],
+      principal: { id: "andreas" },
+      stack: { id: "andreas/community" },
+      policy: {
+        federated: {
+          networks: [
+            {
+              id: "metafactory-community",
+              peers: [{ principal_id: "jc", stack_id: "jc/default" }],
+            } as unknown as NonNullable<
+              NonNullable<LoadedConfig["policy"]>["federated"]
+            >["networks"][number],
+          ],
+        },
+      } as unknown as LoadedConfig["policy"],
+    });
+}
+
+/**
+ * A fake bus factory whose responder is scripted by `respond`. Records whether
+ * the factory was invoked (i.e. whether a probe was actually attempted).
+ */
+function fakeBusFactory(
+  respond: (f: ProbeFireInputs, seq: number) => ProbeRoundTripResult,
+): { factory: PingBusFactory; invoked: () => boolean; stopped: () => boolean } {
+  let wasInvoked = false;
+  let wasStopped = false;
+  let seq = 0;
+  const factory: PingBusFactory = async () => {
+    wasInvoked = true;
+    const ports: NetworkPingPorts = {
+      bus: {
+        fireProbe: async (f) => {
+          seq++;
+          return respond(f, seq);
+        },
+      },
+      newNonce: () => `nonce-${seq}`,
+      newCorrelationId: () => `corr-${seq}`,
+    };
+    return { ports, stop: async () => { wasStopped = true; } };
+  };
+  return { factory, invoked: () => wasInvoked, stopped: () => wasStopped };
+}
+
+function echoReply(f: ProbeFireInputs, rttMs: number): ProbeRoundTripResult {
+  const reqPayload = f.request.payload as { nonce: string; seq?: number };
+  const reply: Envelope = {
+    id: crypto.randomUUID(),
+    source: "andreas.community.luna",
+    type: PROBE_REPLY_ECHO_TYPE,
+    timestamp: "2026-06-10T00:00:00.000Z",
+    correlation_id: f.correlationId,
+    sovereignty: {
+      classification: "federated",
+      data_residency: "NZ",
+      max_hop: 1,
+      frontier_ok: false,
+      model_class: "local-only",
+    },
+    payload: {
+      nonce: reqPayload.nonce,
+      server_ts: "2026-06-10T00:00:00.000Z",
+      responder_version: "1.0.0",
+      ...(reqPayload.seq !== undefined && { seq: reqPayload.seq }),
+    },
+  };
+  return { kind: "reply", rttMs, reply };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("cortex network ping — verdicts + exit codes", () => {
+  test("reachable — exit 0, prints RTT", async () => {
+    const bus = fakeBusFactory((f) => echoReply(f, 41));
+    const res = await dispatchNetwork(["ping", "jc"], readerWithPeer(), bus.factory);
+    expect(res.exitCode).toBe(0);
+    expect(res.stdout).toContain("PING jc/default");
+    expect(res.stdout).toContain("reachable");
+    expect(res.stdout).toContain("rtt=41ms");
+    expect(bus.invoked()).toBe(true);
+    expect(bus.stopped()).toBe(true);
+  });
+
+  test("not-configured — exit 2, bus NEVER built (nothing emitted)", async () => {
+    const bus = fakeBusFactory((f) => echoReply(f, 1));
+    const res = await dispatchNetwork(
+      ["ping", "stranger"],
+      readerWithPeer(),
+      bus.factory,
+    );
+    expect(res.exitCode).toBe(2);
+    expect(res.stderr).toContain("not-configured");
+    expect(bus.invoked()).toBe(false); // fail-closed at the publish boundary
+  });
+
+  test("timeout — exit 4", async () => {
+    const bus = fakeBusFactory(() => ({ kind: "timeout" }));
+    const res = await dispatchNetwork(["ping", "jc"], readerWithPeer(), bus.factory);
+    expect(res.exitCode).toBe(4);
+    expect(res.stderr).toContain("timeout");
+  });
+
+  test("no-responder (wrong nonce) — exit 3", async () => {
+    const bus = fakeBusFactory((f) => {
+      const r = echoReply(f, 5);
+      if (r.kind === "reply") (r.reply.payload).nonce = "X";
+      return r;
+    });
+    const res = await dispatchNetwork(["ping", "jc"], readerWithPeer(), bus.factory);
+    expect(res.exitCode).toBe(3);
+    expect(res.stderr).toContain("no-responder");
+  });
+
+  test("publish-failed ⇒ not-configured (exit 2)", async () => {
+    const bus = fakeBusFactory(() => ({ kind: "publish-failed", reason: "no route" }));
+    const res = await dispatchNetwork(["ping", "jc"], readerWithPeer(), bus.factory);
+    expect(res.exitCode).toBe(2);
+  });
+});
+
+describe("cortex network ping — --count + --json", () => {
+  test("--count 3 aggregates min/avg/max + loss in output", async () => {
+    const rtts = [39, 42, 45];
+    const bus = fakeBusFactory((f, seq) => echoReply(f, rtts[seq - 1]!));
+    const res = await dispatchNetwork(
+      ["ping", "jc", "--count", "3"],
+      readerWithPeer(),
+      bus.factory,
+    );
+    expect(res.exitCode).toBe(0);
+    expect(res.stdout).toContain("3 probes sent, 3 echoes received, 0% loss");
+    expect(res.stdout).toContain("rtt min/avg/max = 39/42.0/45 ms");
+  });
+
+  test("--json emits the envelope with verdict + stats", async () => {
+    const bus = fakeBusFactory((f) => echoReply(f, 40));
+    const res = await dispatchNetwork(
+      ["ping", "jc", "--json"],
+      readerWithPeer(),
+      bus.factory,
+    );
+    expect(res.exitCode).toBe(0);
+    const parsed = JSON.parse(res.stdout) as {
+      status: string;
+      data: { peer: string; verdict: string; received: string };
+    };
+    expect(parsed.data.peer).toBe("jc/default");
+    expect(parsed.data.verdict).toBe("reachable");
+    expect(parsed.data.received).toBe("1");
+  });
+
+  test("--count 0 is a usage error (exit 2)", async () => {
+    const bus = fakeBusFactory((f) => echoReply(f, 1));
+    const res = await dispatchNetwork(
+      ["ping", "jc", "--count", "0"],
+      readerWithPeer(),
+      bus.factory,
+    );
+    expect(res.exitCode).toBe(2);
+    expect(res.stderr).toContain("--count");
+  });
+
+  test("ping {principal}/{stack} parses an explicit stack", async () => {
+    const bus = fakeBusFactory((f) => echoReply(f, 10));
+    const res = await dispatchNetwork(
+      ["ping", "jc/default"],
+      readerWithPeer(),
+      bus.factory,
+    );
+    expect(res.exitCode).toBe(0);
+    expect(res.stdout).toContain("PING jc/default");
+  });
+});
+
+describe("cortex network ping — help", () => {
+  test("top-level help mentions ping", async () => {
+    const res = await dispatchNetwork(["--help"]);
+    expect(res.exitCode).toBe(0);
+    expect(res.stdout).toContain("cortex network ping");
+  });
+});

--- a/src/cli/cortex/commands/__tests__/network-ping-lib.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-ping-lib.test.ts
@@ -1,0 +1,423 @@
+/**
+ * Tests for the `cortex network ping` orchestration (signal#113 P-11 /
+ * `docs/design-network-ping.md`, issue #56).
+ *
+ * Close-criteria (spec §3.3 / §9):
+ *   - each verdict (reachable via a mock responder, not-configured, timeout,
+ *     no-responder) + its exit code;
+ *   - RTT measured + min/avg/max aggregation over `--count`;
+ *   - the request envelope is FG-conformant: `source` addresses the target,
+ *     `originator` carries our DID, the reply subscription is OUR scope.
+ *
+ * The bus is a FAKE (injected port) — no NATS, no `~/.config`, no live wire.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+import type { Envelope } from "../../../../bus/myelin/envelope-validator";
+import {
+  PROBE_REPLY_ECHO_TYPE,
+  type ProbeEchoReplyPayload,
+} from "../../../../bus/probe-responder";
+import type { LoadedConfig } from "../../../../common/config/loader";
+import {
+  buildProbeRequestEnvelope,
+  buildProbeRequestSubject,
+  buildReplySubjectPattern,
+  classifyRoundTrip,
+  derivePingInputs,
+  pingPeer,
+  VERDICT_EXIT_CODE,
+  type PingInputs,
+} from "../network-ping-lib";
+import type {
+  NetworkPingPorts,
+  ProbeFireInputs,
+  ProbeRoundTripResult,
+} from "../network-ping-ports";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function inputs(overrides: Partial<PingInputs> = {}): PingInputs {
+  return {
+    requesterPrincipal: "andreas",
+    requesterStack: "community",
+    requesterAssistant: "luna",
+    targetPrincipal: "jc",
+    targetStack: "default",
+    targetAssistantDid: "did:mf:jc-default",
+    count: 1,
+    timeoutMs: 2000,
+    isConfiguredPeer: true,
+    ...overrides,
+  };
+}
+
+/**
+ * A fake bus that runs a scripted responder. The `respond` callback decides,
+ * per fired probe, what round-trip to return. Records every fired probe.
+ */
+function fakeBus(
+  respond: (fired: ProbeFireInputs, seq: number) => ProbeRoundTripResult,
+): { ports: NetworkPingPorts; fired: ProbeFireInputs[] } {
+  const fired: ProbeFireInputs[] = [];
+  let nonceN = 0;
+  let corrN = 0;
+  let probeSeq = 0;
+  const ports: NetworkPingPorts = {
+    bus: {
+      fireProbe: async (f) => {
+        fired.push(f);
+        probeSeq++;
+        return respond(f, probeSeq);
+      },
+    },
+    newNonce: () => `nonce-${++nonceN}`,
+    newCorrelationId: () => `corr-${++corrN}`,
+  };
+  return { ports, fired };
+}
+
+/** Build a conformant echo reply for a fired probe (mock responder). */
+function echoReply(fired: ProbeFireInputs, rttMs: number): ProbeRoundTripResult {
+  const reqPayload = fired.request.payload as { nonce: string; seq?: number };
+  const reply: Envelope = {
+    id: crypto.randomUUID(),
+    source: "andreas.community.luna",
+    type: PROBE_REPLY_ECHO_TYPE,
+    timestamp: "2026-06-10T00:00:00.000Z",
+    correlation_id: fired.correlationId,
+    sovereignty: {
+      classification: "federated",
+      data_residency: "NZ",
+      max_hop: 1,
+      frontier_ok: false,
+      model_class: "local-only",
+    },
+    payload: {
+      nonce: reqPayload.nonce,
+      server_ts: "2026-06-10T00:00:00.000Z",
+      responder_version: "1.0.0",
+      ...(reqPayload.seq !== undefined && { seq: reqPayload.seq }),
+    } satisfies ProbeEchoReplyPayload,
+  };
+  return { kind: "reply", rttMs, reply };
+}
+
+// ---------------------------------------------------------------------------
+// Subject + envelope construction (FG conformance)
+// ---------------------------------------------------------------------------
+
+describe("buildProbeRequestSubject — FG-2 (subject addresses the target)", () => {
+  test("Direct subject carries the target + encoded assistant DID, no network", () => {
+    const s = buildProbeRequestSubject("jc", "default", "did:mf:jc-default");
+    expect(s).toBe("federated.jc.default.tasks.@did-mf-jc-default.probe.echo");
+    expect(s).not.toContain("metafactory-community"); // network NOT on the wire
+  });
+});
+
+describe("buildReplySubjectPattern — FG-4 (reply keyed on the requester)", () => {
+  test("we subscribe OUR OWN scope", () => {
+    expect(buildReplySubjectPattern("andreas", "community")).toBe(
+      "federated.andreas.community.probe.reply.>",
+    );
+  });
+});
+
+describe("buildProbeRequestEnvelope — FG conformance", () => {
+  test("source addresses the target; originator carries OUR DID", () => {
+    const env = buildProbeRequestEnvelope({
+      inputs: inputs(),
+      nonce: "n",
+      correlationId: "c",
+      seq: 1,
+    });
+    // FG-2: source first segments are the TARGET.
+    expect(env.source).toBe("jc.default.luna");
+    // FG-3: requester rides in originator.identity = our DID.
+    expect(env.originator?.identity).toBe("did:mf:andreas-community");
+    expect(env.sovereignty.classification).toBe("federated");
+    expect(env.sovereignty.max_hop).toBe(1);
+    expect(env.distribution_mode).toBe("direct");
+    // FG-1: no network_id anywhere.
+    expect(JSON.stringify(env)).not.toContain("network_id");
+    expect(env.correlation_id).toBe("c");
+    const p = env.payload as { nonce: string; seq: number };
+    expect(p.nonce).toBe("n");
+    expect(p.seq).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// classifyRoundTrip — verdict taxonomy
+// ---------------------------------------------------------------------------
+
+describe("classifyRoundTrip", () => {
+  test("conformant echo with matching nonce ⇒ reachable", () => {
+    const { ports, fired } = fakeBus(() => ({ kind: "timeout" }));
+    void ports;
+    // Build a reply directly.
+    const reply: Envelope = {
+      id: "x",
+      source: "andreas.community.luna",
+      type: PROBE_REPLY_ECHO_TYPE,
+      timestamp: "t",
+      sovereignty: {
+        classification: "federated",
+        data_residency: "NZ",
+        max_hop: 1,
+        frontier_ok: false,
+        model_class: "local-only",
+      },
+      payload: { nonce: "abc", server_ts: "t", responder_version: "1.0.0" },
+    };
+    const c = classifyRoundTrip({ kind: "reply", rttMs: 42, reply }, "abc");
+    expect(c.verdict).toBe("reachable");
+    expect(c.rttMs).toBe(42);
+    void fired;
+  });
+
+  test("mismatched nonce ⇒ no-responder (never reachable)", () => {
+    const reply: Envelope = {
+      id: "x",
+      source: "andreas.community.luna",
+      type: PROBE_REPLY_ECHO_TYPE,
+      timestamp: "t",
+      sovereignty: {
+        classification: "federated",
+        data_residency: "NZ",
+        max_hop: 1,
+        frontier_ok: false,
+        model_class: "local-only",
+      },
+      payload: { nonce: "WRONG", server_ts: "t", responder_version: "1.0.0" },
+    };
+    const c = classifyRoundTrip({ kind: "reply", rttMs: 5, reply }, "abc");
+    expect(c.verdict).toBe("no-responder");
+  });
+
+  test("timeout ⇒ timeout", () => {
+    expect(classifyRoundTrip({ kind: "timeout" }, "abc").verdict).toBe("timeout");
+  });
+
+  test("publish-failed ⇒ not-configured", () => {
+    expect(
+      classifyRoundTrip({ kind: "publish-failed", reason: "no route" }, "abc").verdict,
+    ).toBe("not-configured");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// pingPeer — the verdicts + exit codes + RTT aggregation
+// ---------------------------------------------------------------------------
+
+describe("pingPeer — verdicts + exit codes", () => {
+  test("reachable (via mock responder) — exit 0, RTT measured", async () => {
+    const { ports, fired } = fakeBus((f) => echoReply(f, 40));
+    const res = await pingPeer(inputs(), ports);
+    expect(res.verdict).toBe("reachable");
+    expect(res.exitCode).toBe(0);
+    expect(res.stats.received).toBe(1);
+    expect(res.stats.loss).toBe(0);
+    expect(res.stats.rttMinMs).toBe(40);
+    expect(res.stats.rttAvgMs).toBe(40);
+    expect(res.stats.rttMaxMs).toBe(40);
+    // The fired probe addressed the target + our scope.
+    expect(fired[0]!.requestSubject).toBe(
+      "federated.jc.default.tasks.@did-mf-jc-default.probe.echo",
+    );
+    expect(fired[0]!.replySubjectPattern).toBe(
+      "federated.andreas.community.probe.reply.>",
+    );
+  });
+
+  test("not-configured — exit 2, NOTHING emitted (no probe fired)", async () => {
+    const { ports, fired } = fakeBus((f) => echoReply(f, 1));
+    const res = await pingPeer(inputs({ isConfiguredPeer: false }), ports);
+    expect(res.verdict).toBe("not-configured");
+    expect(res.exitCode).toBe(2);
+    expect(fired).toHaveLength(0); // fail-closed at the publish boundary
+    expect(res.detail).toContain("peers[]");
+  });
+
+  test("timeout — exit 4", async () => {
+    const { ports } = fakeBus(() => ({ kind: "timeout" }));
+    const res = await pingPeer(inputs(), ports);
+    expect(res.verdict).toBe("timeout");
+    expect(res.exitCode).toBe(4);
+    expect(res.stats.loss).toBe(1);
+  });
+
+  test("no-responder (reply but wrong nonce) — exit 3", async () => {
+    const { ports } = fakeBus((f) => {
+      const r = echoReply(f, 5);
+      if (r.kind === "reply") {
+        (r.reply.payload).nonce = "TAMPERED";
+      }
+      return r;
+    });
+    const res = await pingPeer(inputs(), ports);
+    expect(res.verdict).toBe("no-responder");
+    expect(res.exitCode).toBe(3);
+  });
+
+  test("publish-failed ⇒ not-configured (exit 2)", async () => {
+    const { ports } = fakeBus(() => ({
+      kind: "publish-failed",
+      reason: "no leaf route",
+    }));
+    const res = await pingPeer(inputs(), ports);
+    expect(res.verdict).toBe("not-configured");
+    expect(res.exitCode).toBe(2);
+  });
+});
+
+describe("pingPeer — --count aggregation", () => {
+  test("three reachable probes aggregate min/avg/max RTT + 0% loss", async () => {
+    const rtts = [39, 42, 45];
+    const { ports, fired } = fakeBus((f, seq) => echoReply(f, rtts[seq - 1]!));
+    const res = await pingPeer(inputs({ count: 3 }), ports);
+    expect(res.verdict).toBe("reachable");
+    expect(res.probes).toHaveLength(3);
+    expect(fired).toHaveLength(3);
+    expect(res.stats.sent).toBe(3);
+    expect(res.stats.received).toBe(3);
+    expect(res.stats.loss).toBe(0);
+    expect(res.stats.rttMinMs).toBe(39);
+    expect(res.stats.rttMaxMs).toBe(45);
+    expect(res.stats.rttAvgMs).toBeCloseTo(42, 5);
+    // Per-seq rows carry their own RTT.
+    expect(res.probes.map((p) => p.seq)).toEqual([1, 2, 3]);
+    expect(res.probes[0]!.rttMs).toBe(39);
+  });
+
+  test("partial loss — reachable overall, loss fraction reported", async () => {
+    const { ports } = fakeBus((f, seq) =>
+      seq === 2 ? { kind: "timeout" } : echoReply(f, 50),
+    );
+    const res = await pingPeer(inputs({ count: 3 }), ports);
+    expect(res.verdict).toBe("reachable"); // at least one echo
+    expect(res.stats.sent).toBe(3);
+    expect(res.stats.received).toBe(2);
+    expect(res.stats.loss).toBeCloseTo(1 / 3, 5);
+  });
+
+  test("all probes time out ⇒ timeout overall, 100% loss", async () => {
+    const { ports } = fakeBus(() => ({ kind: "timeout" }));
+    const res = await pingPeer(inputs({ count: 3 }), ports);
+    expect(res.verdict).toBe("timeout");
+    expect(res.stats.loss).toBe(1);
+    expect(res.stats.received).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// derivePingInputs — config derivation + peers[] membership
+// ---------------------------------------------------------------------------
+
+function loadedConfig(
+  peers: { principal_id: string; stack_id: string }[],
+  networkId = "metafactory-community",
+): LoadedConfig {
+  return {
+    config: {} as unknown as LoadedConfig["config"],
+    inlineAgents: [{ id: "luna" } as unknown as LoadedConfig["inlineAgents"][number]],
+    principal: { id: "andreas" },
+    stack: { id: "andreas/community" },
+    policy: {
+      federated: {
+        networks: [
+          { id: networkId, peers } as unknown as NonNullable<
+            NonNullable<LoadedConfig["policy"]>["federated"]
+          >["networks"][number],
+        ],
+      },
+    } as unknown as LoadedConfig["policy"],
+  };
+}
+
+describe("derivePingInputs", () => {
+  test("resolves requester from config + target as a configured peer", () => {
+    const cfg = loadedConfig([{ principal_id: "jc", stack_id: "jc/default" }]);
+    const r = derivePingInputs({
+      cfg,
+      targetPrincipal: "jc",
+      targetStack: "default",
+      count: 1,
+      timeoutMs: 2000,
+    });
+    expect(r.ok).toBe(true);
+    expect(r.inputs?.requesterPrincipal).toBe("andreas");
+    expect(r.inputs?.requesterStack).toBe("community");
+    expect(r.inputs?.requesterAssistant).toBe("luna");
+    expect(r.inputs?.targetAssistantDid).toBe("did:mf:jc-default");
+    expect(r.inputs?.isConfiguredPeer).toBe(true);
+  });
+
+  test("a target NOT in peers[] resolves isConfiguredPeer=false", () => {
+    const cfg = loadedConfig([{ principal_id: "jc", stack_id: "jc/default" }]);
+    const r = derivePingInputs({
+      cfg,
+      targetPrincipal: "stranger",
+      targetStack: "default",
+      count: 1,
+      timeoutMs: 2000,
+    });
+    expect(r.inputs?.isConfiguredPeer).toBe(false);
+  });
+
+  test("--assistant overrides the target assistant DID (Direct routing)", () => {
+    const cfg = loadedConfig([{ principal_id: "jc", stack_id: "jc/default" }]);
+    const r = derivePingInputs({
+      cfg,
+      targetPrincipal: "jc",
+      targetStack: "default",
+      assistant: "sage",
+      count: 1,
+      timeoutMs: 2000,
+    });
+    expect(r.inputs?.targetAssistantDid).toBe("did:mf:sage");
+  });
+
+  test("--network scopes peer resolution to that network", () => {
+    const cfg = loadedConfig(
+      [{ principal_id: "jc", stack_id: "jc/default" }],
+      "other-net",
+    );
+    // Scoped to a different network id ⇒ not found.
+    const r = derivePingInputs({
+      cfg,
+      targetPrincipal: "jc",
+      targetStack: "default",
+      network: "metafactory-community",
+      count: 1,
+      timeoutMs: 2000,
+    });
+    expect(r.inputs?.isConfiguredPeer).toBe(false);
+  });
+
+  test("fails closed when principal cannot be resolved", () => {
+    const cfg = { ...loadedConfig([]), principal: undefined } as LoadedConfig;
+    const r = derivePingInputs({
+      cfg,
+      targetPrincipal: "jc",
+      targetStack: "default",
+      count: 1,
+      timeoutMs: 2000,
+    });
+    expect(r.ok).toBe(false);
+    expect(r.reason).toContain("principal");
+  });
+});
+
+describe("VERDICT_EXIT_CODE — spec §3.3 mapping", () => {
+  test("exact exit-code taxonomy", () => {
+    expect(VERDICT_EXIT_CODE.reachable).toBe(0);
+    expect(VERDICT_EXIT_CODE["not-configured"]).toBe(2);
+    expect(VERDICT_EXIT_CODE["no-responder"]).toBe(3);
+    expect(VERDICT_EXIT_CODE.timeout).toBe(4);
+    expect(VERDICT_EXIT_CODE.refused).toBe(5);
+  });
+});

--- a/src/cli/cortex/commands/__tests__/network-ping-signer.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-ping-signer.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Tests for `buildPingSignerFromConfig` (PR #822 review, MAJOR-1).
+ *
+ * Proves the posture-gated stack-signer build that lets `cortex network ping`
+ * carry a signed request to an `enforce`-posture peer (spec §9 close-criterion):
+ *   - `enforce` / `permissive` posture + a valid SU seed → a signer whose
+ *     `principal` DID == `did:mf:{principal}-{stack}` and whose `rawSeedBytes`
+ *     round-trip to the seed's keypair (so the probe is signed like every
+ *     other federated dispatch);
+ *   - `off` posture → `undefined` (publish unsigned, byte-identical to pre-#822);
+ *   - `enforce` but NO seed → `undefined` (fail-closed, unsigned);
+ *   - a pubkey-consistency mismatch → `undefined` (fail-closed, logged).
+ *
+ * Seeds are generated fresh per-test (createUser) at chmod 600 — no real key
+ * material in the repo, same discipline as stack-signing-key.test.ts.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { chmodSync, mkdirSync, rmSync, writeFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { createUser } from "nkeys.js";
+
+import type { LoadedConfig } from "../../../../common/config/loader";
+import type { AgentConfig } from "../../../../common/types/config";
+import { buildPingSignerFromConfig } from "../network-ping-signer";
+
+let testDir: string;
+
+beforeEach(() => {
+  testDir = join(
+    tmpdir(),
+    `cortex-ping-signer-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+  mkdirSync(testDir, { recursive: true });
+});
+afterEach(() => {
+  rmSync(testDir, { recursive: true, force: true });
+});
+
+function writeSeed(): { path: string; pubkey: string; rawSeed: Uint8Array } {
+  const kp = createUser();
+  const seed = new TextDecoder().decode(kp.getSeed());
+  const path = join(testDir, "stack.nk");
+  writeFileSync(path, seed);
+  chmodSync(path, 0o600);
+  // `getRawSeed()` is the 32-byte ed25519 seed — the SAME shape the signer
+  // exposes as `rawSeedBytes` (MyelinRuntime base64-encodes it for signEnvelope).
+  const rawSeed = (kp as unknown as { getRawSeed(): Uint8Array }).getRawSeed();
+  return { path, pubkey: kp.getPublicKey(), rawSeed };
+}
+
+function cfg(opts: {
+  signing: "off" | "permissive" | "enforce";
+  seedPath?: string;
+  nkeyPub?: string;
+  stackId?: string;
+}): LoadedConfig {
+  return {
+    config: {
+      security: { signing: opts.signing },
+    } as unknown as AgentConfig,
+    inlineAgents: [],
+    principal: { id: "andreas" },
+    stack: {
+      id: opts.stackId ?? "andreas/community",
+      ...(opts.seedPath !== undefined && { nkey_seed_path: opts.seedPath }),
+      ...(opts.nkeyPub !== undefined && { nkey_pub: opts.nkeyPub }),
+    },
+  };
+}
+
+describe("buildPingSignerFromConfig", () => {
+  test("MAJOR-1: enforce posture + valid seed → a signer with the right DID", async () => {
+    const { path, pubkey } = writeSeed();
+    const signer = await buildPingSignerFromConfig(
+      cfg({ signing: "enforce", seedPath: path, nkeyPub: pubkey }),
+    );
+    expect(signer).toBeDefined();
+    expect(signer?.principal).toBe("did:mf:andreas-community");
+    // rawSeedBytes round-trip: re-deriving the keypair from the seed file's
+    // bytes yields the SAME public key the signer will stamp with.
+    expect(signer?.rawSeedBytes).toBeInstanceOf(Uint8Array);
+  });
+
+  test("permissive posture also attaches a signer", async () => {
+    const { path } = writeSeed();
+    const signer = await buildPingSignerFromConfig(
+      cfg({ signing: "permissive", seedPath: path }),
+    );
+    expect(signer).toBeDefined();
+    expect(signer?.principal).toBe("did:mf:andreas-community");
+  });
+
+  test("off posture → undefined (publish unsigned)", async () => {
+    const { path } = writeSeed();
+    const signer = await buildPingSignerFromConfig(
+      cfg({ signing: "off", seedPath: path }),
+    );
+    expect(signer).toBeUndefined();
+  });
+
+  test("enforce posture but NO seed → undefined (fail-closed)", async () => {
+    const signer = await buildPingSignerFromConfig(cfg({ signing: "enforce" }));
+    expect(signer).toBeUndefined();
+  });
+
+  test("pubkey-consistency mismatch → undefined (fail-closed)", async () => {
+    const { path } = writeSeed();
+    // Declare a DIFFERENT pubkey than the seed derives → split-brain guard.
+    const other = createUser().getPublicKey();
+    const signer = await buildPingSignerFromConfig(
+      cfg({ signing: "enforce", seedPath: path, nkeyPub: other }),
+    );
+    expect(signer).toBeUndefined();
+  });
+
+  test("DID derivation handles a hyphenated stack slug", async () => {
+    const { path } = writeSeed();
+    const signer = await buildPingSignerFromConfig(
+      cfg({ signing: "enforce", seedPath: path, stackId: "andreas/meta-factory" }),
+    );
+    expect(signer?.principal).toBe("did:mf:andreas-meta-factory");
+  });
+
+  test("the signer's rawSeedBytes match the on-disk seed", async () => {
+    const { path, rawSeed } = writeSeed();
+    const signer = await buildPingSignerFromConfig(
+      cfg({ signing: "enforce", seedPath: path }),
+    );
+    expect(signer).toBeDefined();
+    if (signer === undefined) return;
+    // The signer carries the EXACT 32-byte raw ed25519 seed from the file —
+    // same bytes MyelinRuntime base64-encodes for signEnvelope, so the probe
+    // is signed by this stack's real identity.
+    expect(Array.from(signer.rawSeedBytes)).toEqual(Array.from(rawSeed));
+  });
+});

--- a/src/cli/cortex/commands/_shared/exit-result.ts
+++ b/src/cli/cortex/commands/_shared/exit-result.ts
@@ -8,7 +8,14 @@
  * creds.ts) used to redeclare this shape inline; now they import.
  */
 export interface ExitResult {
-  exitCode: 0 | 1 | 2;
+  /**
+   * Process exit code. Most subcommands use the classic 0 (success) / 1
+   * (operational failure) / 2 (usage error) trichotomy. `cortex network ping`
+   * (#56) additionally uses 3 (no-responder) / 4 (timeout) / 5 (refused) per
+   * its verdict taxonomy (`docs/design-network-ping.md` §3.3), so this is a
+   * plain `number` rather than the narrow `0 | 1 | 2` union.
+   */
+  exitCode: number;
   stdout: string;
   stderr: string;
 }

--- a/src/cli/cortex/commands/network-ping-adapters.ts
+++ b/src/cli/cortex/commands/network-ping-adapters.ts
@@ -1,0 +1,148 @@
+/**
+ * `cortex network ping` — LIVE bus adapter (signal#113 P-11 /
+ * `docs/design-network-ping.md`, issue #56).
+ *
+ * Wires the real {@link MyelinRuntime} into the {@link ProbeBusPort} the pure
+ * orchestrator (`network-ping-lib.ts`) depends on. Constructed only on a real
+ * `cortex network ping` invocation; tests inject a fake bus and never reach
+ * this file.
+ *
+ * Per probe: subscribe OUR OWN `federated.{us}.{stack}.probe.reply.>`, register
+ * an `onEnvelope` matcher keyed on `correlation_id`, publish the request on the
+ * explicit federated subject (`publishOnSubject`), and resolve with the first
+ * matching reply (+ RTT measured single-clock on the requester) or a timeout.
+ *
+ * The runtime is started ONCE for the whole `ping` run and stopped on exit, so
+ * `--count N` reuses one NATS connection.
+ */
+
+import type { AgentConfig } from "../../../common/types/config";
+import type { Envelope } from "../../../bus/myelin/envelope-validator";
+import type { MyelinRuntime, BusEnvelopeSigner } from "../../../bus/myelin/runtime";
+import { startMyelinRuntime } from "../../../bus/myelin/runtime";
+import type {
+  ProbeBusPort,
+  ProbeFireInputs,
+  ProbeRoundTripResult,
+} from "./network-ping-ports";
+
+/**
+ * A live probe bus bound to a running runtime. Build via {@link createLiveProbeBus}
+ * (which starts the runtime); call {@link stop} when the ping run finishes.
+ */
+export interface LiveProbeBus extends ProbeBusPort {
+  /** Whether the underlying runtime actually connected (NATS configured). */
+  readonly enabled: boolean;
+  stop(): Promise<void>;
+}
+
+/**
+ * Start a runtime from the stack's `AgentConfig` and return a live probe bus.
+ *
+ * `signer` is the stack's envelope signer (when a seed loaded under
+ * `permissive`/`enforce`) so the request is signed exactly like every other
+ * federated dispatch; omit under `signing: off` (publishes unsigned, identical
+ * to today). The runtime stays the single owner of the NATS connection.
+ */
+export async function createLiveProbeBus(
+  config: AgentConfig,
+  signer?: BusEnvelopeSigner,
+): Promise<LiveProbeBus> {
+  const runtime: MyelinRuntime = await startMyelinRuntime(
+    config,
+    signer !== undefined ? { signer } : undefined,
+  );
+  return wrapRuntimeAsProbeBus(runtime);
+}
+
+/**
+ * Wrap an already-started runtime as a probe bus. Exported separately so an
+ * integration test (or a future caller that already holds a runtime) can reuse
+ * the fire/await logic without re-starting NATS.
+ */
+export function wrapRuntimeAsProbeBus(runtime: MyelinRuntime): LiveProbeBus {
+  return {
+    enabled: runtime.enabled,
+
+    async fireProbe(fired: ProbeFireInputs): Promise<ProbeRoundTripResult> {
+      if (!runtime.enabled || typeof runtime.publishOnSubject !== "function") {
+        // No bus / no explicit-subject publish — nothing can go on the wire.
+        return {
+          kind: "publish-failed",
+          reason: "runtime disabled or lacks publishOnSubject (no NATS configured)",
+        };
+      }
+
+      // Subscribe our OWN reply scope + register a correlation-id matcher
+      // BEFORE publishing, so a fast echo can't race ahead of our listener.
+      let resolveReply: ((env: Envelope) => void) | undefined;
+      const replyPromise = new Promise<Envelope>((resolve) => {
+        resolveReply = resolve;
+      });
+      const registration = runtime.onEnvelope((env, subject) => {
+        // Match on correlation_id (subject-agnostic — mirrors pilot --wait).
+        if (env.correlation_id !== fired.correlationId) return;
+        // Defensive: only accept on our own reply scope.
+        if (!subject.startsWith(replyScopePrefix(fired.replySubjectPattern))) {
+          return;
+        }
+        resolveReply?.(env);
+      });
+
+      // Declare interest on the reply pattern (push subscription). May be null
+      // when the runtime is disabled — but we checked `enabled` above.
+      const sub = runtime.subscribe
+        ? await runtime.subscribe(fired.replySubjectPattern)
+        : null;
+
+      const startMs = Date.now();
+      try {
+        await runtime.publishOnSubject(fired.request, fired.requestSubject);
+      } catch (err) {
+        registration.unregister();
+        if (sub) await sub.stop();
+        return {
+          kind: "publish-failed",
+          reason: err instanceof Error ? err.message : String(err),
+        };
+      }
+
+      // Await the matching reply or the per-probe timeout.
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      const timeoutPromise = new Promise<"timeout">((resolve) => {
+        timer = setTimeout(() => {
+          resolve("timeout");
+        }, fired.timeoutMs);
+      });
+
+      try {
+        const outcome = await Promise.race([replyPromise, timeoutPromise]);
+        if (outcome === "timeout") {
+          return { kind: "timeout" };
+        }
+        const rttMs = Date.now() - startMs;
+        return { kind: "reply", rttMs, reply: outcome };
+      } finally {
+        if (timer !== undefined) clearTimeout(timer);
+        registration.unregister();
+        if (sub) await sub.stop();
+      }
+    },
+
+    async stop() {
+      await runtime.stop();
+    },
+  };
+}
+
+/**
+ * Derive the literal subject prefix from a reply pattern
+ * `federated.{us}.{stack}.probe.reply.>` → `federated.{us}.{stack}.probe.reply.`
+ * so the matcher can confirm a reply landed on OUR scope (never trust a reply
+ * that arrived on someone else's subject, even if the correlation_id collides).
+ */
+function replyScopePrefix(pattern: string): string {
+  // Strip a trailing `>` wildcard; keep the dotted literal prefix.
+  if (pattern.endsWith(".>")) return pattern.slice(0, -1); // keep trailing dot
+  return pattern;
+}

--- a/src/cli/cortex/commands/network-ping-lib.ts
+++ b/src/cli/cortex/commands/network-ping-lib.ts
@@ -450,9 +450,17 @@ export async function pingPeer(
 function aggregateVerdict(probes: PingProbeResult[]): PingVerdict {
   if (probes.some((p) => p.verdict === "reachable")) return "reachable";
   // Failure precedence — surface the most diagnostic.
+  //
+  // PR #822 NIT-5 — `refused` is RESERVED for Ping-B (P-13 roster correlation
+  // / enforce-posture gate signal) and is NOT produced by any v1 transport
+  // outcome (`classifyRoundTrip` only emits reachable / no-responder / timeout
+  // / not-configured). It stays in the precedence list so the taxonomy is
+  // complete and Ping-B is a drop-in; in v1 the `refused` branch is
+  // unreachable. `no-responder` IS reachable in v1 (a reply with a mismatched
+  // nonce / non-conformant payload).
   const order: PingVerdict[] = [
     "no-responder",
-    "refused",
+    "refused", // reserved for Ping-B (P-13 correlation); unreachable in v1
     "timeout",
     "not-configured",
   ];
@@ -470,6 +478,8 @@ function failureDetail(verdict: PingVerdict, inputs: PingInputs): string {
     case "timeout":
       return `no echo from ${peer} within ${inputs.timeoutMs}ms (peer offline, leaf down, hub partition, or not gated in)`;
     case "refused":
+      // PR #822 NIT-5 — reserved for Ping-B; v1 never emits `refused` from a
+      // transport outcome, so this detail string is currently unreachable.
       return `peer ${peer} refused the probe (we are not in its peers[], or signing posture rejected us)`;
     case "not-configured":
       return `peer ${peer} is not reachable on any configured network`;

--- a/src/cli/cortex/commands/network-ping-lib.ts
+++ b/src/cli/cortex/commands/network-ping-lib.ts
@@ -1,0 +1,479 @@
+/**
+ * `cortex network ping` — PURE orchestration (signal#113 P-11 /
+ * `docs/design-network-ping.md` §3, issue #56).
+ *
+ * Fires the Direct probe at a configured peer, awaits the echo on our own
+ * `probe.reply.echo`, measures RTT, and returns the verdict per the §3.3
+ * taxonomy + exit codes. Pure over {@link NetworkPingPorts}: no bus, no
+ * config, no clock here — the live adapter (`network.ts`) wires those; tests
+ * inject a fake bus.
+ *
+ * ## Wire grammar (ADR-0001 / ADR-0002 — the request half)
+ *
+ *   REQUEST (us → peer), Direct mode:
+ *     subject     federated.{target}.{target-stack}.tasks.@{enc-target-did}.probe.echo
+ *     source      {target}.{target-stack}.{our-assistant}   — addresses the TARGET
+ *     originator  did:mf:{us}-{our-stack}                    — the REQUESTER (us)
+ *     type        tasks.@{enc-target-did}.probe.echo
+ *     classification federated · distribution_mode direct · max_hop 1 · NO network_id
+ *     correlation_id <uuid> · payload { nonce, sent_at, seq }
+ *
+ *   REPLY (peer → us): subscribed on `federated.{us}.{our-stack}.probe.reply.>`,
+ *   matched by `correlation_id`.
+ *
+ * The network is NEVER on the wire — `selectLink` resolves the target leaf from
+ * the target principal's `peers[]` membership (FG-1). A target not in OUR
+ * `peers[]` ⇒ `not-configured` (exit 2, nothing emitted).
+ */
+
+import { encodeDidSegment } from "@the-metafactory/myelin/subjects";
+
+import type { Envelope } from "../../../bus/myelin/envelope-validator";
+import {
+  PROBE_REPLY_ECHO_TYPE,
+  type ProbeEchoReplyPayload,
+} from "../../../bus/probe-responder";
+import type { LoadedConfig } from "../../../common/config/loader";
+import type { NetworkPingPorts } from "./network-ping-ports";
+
+// ---------------------------------------------------------------------------
+// Config derivation (the #753 config-derivation seam, ping subset)
+// ---------------------------------------------------------------------------
+
+/** Resolve the requester stack slug from `stack.id` (`{principal}/{slug}`). */
+function requesterStackSlug(principal: string, cfg: LoadedConfig): string {
+  const id = cfg.stack?.id;
+  if (id === undefined) return "default";
+  const parts = id.split("/");
+  // `{principal}/{slug}` — take the slug; fall back to the whole id if it's
+  // not in slash form (defensive — schema enforces the slash form).
+  const slug = parts[1];
+  if (parts.length === 2 && parts[0] === principal && slug !== undefined) {
+    return slug;
+  }
+  return slug ?? id;
+}
+
+/** The result of resolving ping inputs from config + CLI flags. */
+export interface PingDeriveResult {
+  ok: boolean;
+  inputs?: PingInputs;
+  /** Actionable, field-naming error when a required value can't be resolved. */
+  reason?: string;
+}
+
+/**
+ * Derive the {@link PingInputs} from the loaded config + CLI selections, and
+ * resolve whether the target is a configured peer in OUR
+ * `policy.federated.networks[].peers[]`.
+ *
+ *   - requester principal/stack/assistant come from config (the #753 seam);
+ *   - the target principal/stack come from the `<peer>` positional;
+ *   - `--assistant` overrides the target assistant DID (Direct routing); when
+ *     omitted it defaults to the target stack's reserved DID
+ *     `did:mf:{target}-{target-stack}` (spec §8 default-assistant follow-up);
+ *   - `isConfiguredPeer` is `true` iff the target `{principal}/{stack}` appears
+ *     in some configured network's `peers[]` (spec §3.3 `not-configured` gate).
+ *
+ * When `--network <id>` is supplied, peer resolution is scoped to that
+ * network's `peers[]` (the topology selector, NEVER a wire segment — ADR-0002 §4).
+ */
+export function derivePingInputs(opts: {
+  cfg: LoadedConfig;
+  targetPrincipal: string;
+  targetStack: string;
+  assistant?: string;
+  network?: string;
+  count: number;
+  timeoutMs: number;
+  /** Flag overrides for principal / stack (parity with join). */
+  principalOverride?: string;
+  stackSlugOverride?: string;
+}): PingDeriveResult {
+  const { cfg } = opts;
+  const requesterPrincipal = opts.principalOverride ?? cfg.principal?.id;
+  if (requesterPrincipal === undefined || requesterPrincipal === "") {
+    return {
+      ok: false,
+      reason:
+        "cannot resolve principal — pass --principal or set `principal.id` in cortex.yaml",
+    };
+  }
+  const requesterStack =
+    opts.stackSlugOverride ?? requesterStackSlug(requesterPrincipal, cfg);
+
+  // Our assistant id — the first declared agent, else the stack slug as a
+  // best-effort label (only used as the `source` sender segment + reply
+  // `source.agent`; the routing identity is the originator DID).
+  const requesterAssistant = cfg.inlineAgents[0]?.id ?? requesterStack;
+
+  // Target assistant DID — `--assistant` overrides; default to the target
+  // stack's reserved DID.
+  const targetAssistantDid =
+    opts.assistant !== undefined
+      ? `did:mf:${opts.assistant}`
+      : `did:mf:${opts.targetPrincipal}-${opts.targetStack}`;
+
+  // peers[] membership — fail-closed `not-configured` when the target is in no
+  // configured network's peers[]. Scope to `--network` when supplied.
+  const networks = cfg.policy?.federated?.networks ?? [];
+  const targetStackId = `${opts.targetPrincipal}/${opts.targetStack}`;
+  const scoped =
+    opts.network !== undefined
+      ? networks.filter((n) => n.id === opts.network)
+      : networks;
+  const isConfiguredPeer = scoped.some((n) =>
+    n.peers.some(
+      (p) =>
+        p.principal_id === opts.targetPrincipal && p.stack_id === targetStackId,
+    ),
+  );
+
+  return {
+    ok: true,
+    inputs: {
+      requesterPrincipal,
+      requesterStack,
+      requesterAssistant,
+      targetPrincipal: opts.targetPrincipal,
+      targetStack: opts.targetStack,
+      targetAssistantDid,
+      count: opts.count,
+      timeoutMs: opts.timeoutMs,
+      isConfiguredPeer,
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Verdict taxonomy (spec §3.3)
+// ---------------------------------------------------------------------------
+
+/**
+ * The §3.3 verdict taxonomy + exit codes:
+ *   reachable (0) · not-configured (2) · no-responder (3) · timeout (4) · refused (5)
+ *
+ * v1 is **timeout-only**: in the pure-echo design the requester cannot directly
+ * distinguish "routed but no responder" from "no route at all", so everything-
+ * not-reachable that produced no reply is `timeout`. `no-responder` /
+ * `refused` are reserved in the taxonomy + carried as types for Ping-B's P-13
+ * roster-correlation refinement; v1 emits `reachable`, `not-configured`, and
+ * `timeout`. A `publish-failed` (no resolvable leaf route) is `not-configured`.
+ */
+export type PingVerdict =
+  | "reachable"
+  | "not-configured"
+  | "no-responder"
+  | "timeout"
+  | "refused";
+
+export const VERDICT_EXIT_CODE: Record<PingVerdict, number> = {
+  reachable: 0,
+  "not-configured": 2,
+  "no-responder": 3,
+  timeout: 4,
+  refused: 5,
+};
+
+// ---------------------------------------------------------------------------
+// Inputs / outputs
+// ---------------------------------------------------------------------------
+
+export interface PingInputs {
+  /** Our principal id (the requester). */
+  requesterPrincipal: string;
+  /** Our stack slug (the requester stack). */
+  requesterStack: string;
+  /** Our assistant id (the `source` sender segment + reply `source.agent`). */
+  requesterAssistant: string;
+  /** Target peer principal. */
+  targetPrincipal: string;
+  /** Target peer stack slug (defaults to `default` at the CLI boundary). */
+  targetStack: string;
+  /**
+   * The target assistant DID for the Direct probe's `@{enc-did}` segment.
+   * Defaults at the CLI boundary to the target stack's reserved DID
+   * (`did:mf:{target}-{target-stack}`) when `--assistant` is omitted.
+   */
+  targetAssistantDid: string;
+  /** Number of probes to send (`ping -c`). */
+  count: number;
+  /** Per-probe timeout (ms). */
+  timeoutMs: number;
+  /**
+   * Whether the target is a configured peer in OUR `peers[]`. Resolved by the
+   * caller from config; `false` ⇒ `not-configured` (nothing emitted).
+   */
+  isConfiguredPeer: boolean;
+}
+
+/** One probe's result row (for per-seq reporting). */
+export interface PingProbeResult {
+  seq: number;
+  verdict: PingVerdict;
+  rttMs?: number;
+}
+
+export interface PingStats {
+  sent: number;
+  received: number;
+  /** Loss as a fraction 0..1. */
+  loss: number;
+  rttMinMs?: number;
+  rttAvgMs?: number;
+  rttMaxMs?: number;
+}
+
+export interface PingResult {
+  /** The overall verdict — the worst/most-informative across all probes. */
+  verdict: PingVerdict;
+  exitCode: number;
+  probes: PingProbeResult[];
+  stats: PingStats;
+  /** Human-facing reason when not reachable (surfaced in the CLI output). */
+  detail?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Subject + envelope construction
+// ---------------------------------------------------------------------------
+
+/**
+ * Compose the Direct federated probe request subject. The `@{enc-did}` segment
+ * addresses the target assistant; the `{target}.{target-stack}` segments
+ * address the target stack (FG-2). The network is NOT a segment (FG-1).
+ */
+export function buildProbeRequestSubject(
+  targetPrincipal: string,
+  targetStack: string,
+  targetAssistantDid: string,
+): string {
+  const enc = encodeDidSegment(targetAssistantDid);
+  return `federated.${targetPrincipal}.${targetStack}.tasks.${enc}.probe.echo`;
+}
+
+/** The requester's reply subscription pattern (our own scope). */
+export function buildReplySubjectPattern(
+  requesterPrincipal: string,
+  requesterStack: string,
+): string {
+  return `federated.${requesterPrincipal}.${requesterStack}.probe.reply.>`;
+}
+
+/**
+ * Build one Direct probe request envelope. `source` addresses the TARGET (so
+ * `deriveNatsSubject`/`selectLink` route there); `originator.identity` carries
+ * the REQUESTER DID (the reply-to); `type` mirrors the Direct capability.
+ */
+export function buildProbeRequestEnvelope(opts: {
+  inputs: PingInputs;
+  nonce: string;
+  correlationId: string;
+  seq: number;
+}): Envelope {
+  const { inputs, nonce, correlationId, seq } = opts;
+  const enc = encodeDidSegment(inputs.targetAssistantDid);
+  return {
+    id: crypto.randomUUID(),
+    // `source` addresses the TARGET stack (ADR-0002 §1) — the sender assistant
+    // is our own assistant id.
+    source: `${inputs.targetPrincipal}.${inputs.targetStack}.${inputs.requesterAssistant}`,
+    type: `tasks.${enc}.probe.echo`,
+    distribution_mode: "direct",
+    timestamp: new Date().toISOString(),
+    correlation_id: correlationId,
+    sovereignty: {
+      classification: "federated",
+      data_residency: "NZ",
+      max_hop: 1,
+      frontier_ok: false,
+      model_class: "local-only",
+    },
+    // `originator` carries the REQUESTER (us) — the DID the responder decodes
+    // to key the reply back. `did:mf:{principal}-{stack}` per ADR-0002 §1.
+    originator: {
+      identity: `did:mf:${inputs.requesterPrincipal}-${inputs.requesterStack}`,
+      attribution: "federated",
+    },
+    payload: {
+      nonce,
+      sent_at: new Date().toISOString(),
+      seq,
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Verdict classification
+// ---------------------------------------------------------------------------
+
+/**
+ * Classify ONE probe round-trip into a verdict (v1 timeout-only).
+ *
+ *   - a matched reply with a well-formed echo payload ⇒ `reachable`;
+ *   - a matched reply with a MALFORMED payload ⇒ `no-responder` (something
+ *     answered but not a conformant echo — e.g. an old responder);
+ *   - a timeout ⇒ `timeout`;
+ *   - a publish-failure (no leaf route) ⇒ `not-configured`.
+ *
+ * The echoed nonce MUST match the request nonce — a mismatched nonce is treated
+ * as `no-responder` (a non-conformant / confused responder), never `reachable`.
+ */
+export function classifyRoundTrip(
+  result:
+    | { kind: "reply"; rttMs: number; reply: Envelope }
+    | { kind: "timeout" }
+    | { kind: "publish-failed"; reason: string },
+  expectedNonce: string,
+): { verdict: PingVerdict; rttMs?: number; detail?: string } {
+  if (result.kind === "publish-failed") {
+    return { verdict: "not-configured", detail: result.reason };
+  }
+  if (result.kind === "timeout") {
+    return { verdict: "timeout" };
+  }
+  const payload = result.reply.payload as
+    | Partial<ProbeEchoReplyPayload>
+    | undefined;
+  if (
+    result.reply.type !== PROBE_REPLY_ECHO_TYPE ||
+    payload === undefined ||
+    typeof payload.nonce !== "string" ||
+    payload.nonce !== expectedNonce
+  ) {
+    return {
+      verdict: "no-responder",
+      detail: "reply received but echo payload did not match (old/non-conformant responder)",
+    };
+  }
+  return { verdict: "reachable", rttMs: result.rttMs };
+}
+
+// ---------------------------------------------------------------------------
+// The orchestrator
+// ---------------------------------------------------------------------------
+
+/**
+ * Fire `count` Direct probes at the target peer, await each echo, aggregate
+ * RTT + loss, and return the verdict + exit code. Pure over the ports.
+ */
+export async function pingPeer(
+  inputs: PingInputs,
+  ports: NetworkPingPorts,
+): Promise<PingResult> {
+  // Fail-closed at OUR publish boundary: a target not in our peers[] never
+  // emits (FG-4 / spec §3.3 `not-configured`, exit 2).
+  if (!inputs.isConfiguredPeer) {
+    return {
+      verdict: "not-configured",
+      exitCode: VERDICT_EXIT_CODE["not-configured"],
+      probes: [],
+      stats: { sent: 0, received: 0, loss: 1 },
+      detail: `peer "${inputs.targetPrincipal}/${inputs.targetStack}" is not in this stack's policy.federated.networks[].peers[]`,
+    };
+  }
+
+  const probes: PingProbeResult[] = [];
+  const rtts: number[] = [];
+  const replySubjectPattern = buildReplySubjectPattern(
+    inputs.requesterPrincipal,
+    inputs.requesterStack,
+  );
+
+  for (let seq = 1; seq <= inputs.count; seq++) {
+    const nonce = ports.newNonce();
+    const correlationId = ports.newCorrelationId();
+    const request = buildProbeRequestEnvelope({
+      inputs,
+      nonce,
+      correlationId,
+      seq,
+    });
+    const requestSubject = buildProbeRequestSubject(
+      inputs.targetPrincipal,
+      inputs.targetStack,
+      inputs.targetAssistantDid,
+    );
+
+    const rt = await ports.bus.fireProbe({
+      request,
+      requestSubject,
+      replySubjectPattern,
+      correlationId,
+      timeoutMs: inputs.timeoutMs,
+    });
+
+    const classified = classifyRoundTrip(rt, nonce);
+    const probe: PingProbeResult = {
+      seq,
+      verdict: classified.verdict,
+      ...(classified.rttMs !== undefined && { rttMs: classified.rttMs }),
+    };
+    probes.push(probe);
+    if (classified.verdict === "reachable" && classified.rttMs !== undefined) {
+      rtts.push(classified.rttMs);
+    }
+  }
+
+  // Overall verdict: reachable iff at least one probe got a conformant echo.
+  // Otherwise pick the most-informative failure across the probes
+  // (no-responder > refused > timeout > not-configured precedence — a
+  // responder-present signal is more useful than a bare timeout).
+  const overall = aggregateVerdict(probes);
+
+  const received = rtts.length;
+  const sent = probes.length;
+  const stats: PingStats = {
+    sent,
+    received,
+    loss: sent === 0 ? 1 : (sent - received) / sent,
+    ...(rtts.length > 0 && {
+      rttMinMs: Math.min(...rtts),
+      rttMaxMs: Math.max(...rtts),
+      rttAvgMs: rtts.reduce((a, b) => a + b, 0) / rtts.length,
+    }),
+  };
+
+  const detail = probes.find((p) => p.verdict === overall && overall !== "reachable");
+  return {
+    verdict: overall,
+    exitCode: VERDICT_EXIT_CODE[overall],
+    probes,
+    stats,
+    ...(detail !== undefined && overall !== "reachable"
+      ? { detail: failureDetail(overall, inputs) }
+      : {}),
+  };
+}
+
+/** Pick the overall verdict from the per-probe verdicts. */
+function aggregateVerdict(probes: PingProbeResult[]): PingVerdict {
+  if (probes.some((p) => p.verdict === "reachable")) return "reachable";
+  // Failure precedence — surface the most diagnostic.
+  const order: PingVerdict[] = [
+    "no-responder",
+    "refused",
+    "timeout",
+    "not-configured",
+  ];
+  for (const v of order) {
+    if (probes.some((p) => p.verdict === v)) return v;
+  }
+  return "timeout";
+}
+
+function failureDetail(verdict: PingVerdict, inputs: PingInputs): string {
+  const peer = `${inputs.targetPrincipal}/${inputs.targetStack}`;
+  switch (verdict) {
+    case "no-responder":
+      return `peer ${peer} routed the probe but did not echo a conformant reply (responder absent or too old)`;
+    case "timeout":
+      return `no echo from ${peer} within ${inputs.timeoutMs}ms (peer offline, leaf down, hub partition, or not gated in)`;
+    case "refused":
+      return `peer ${peer} refused the probe (we are not in its peers[], or signing posture rejected us)`;
+    case "not-configured":
+      return `peer ${peer} is not reachable on any configured network`;
+    case "reachable":
+      return "";
+  }
+}

--- a/src/cli/cortex/commands/network-ping-ports.ts
+++ b/src/cli/cortex/commands/network-ping-ports.ts
@@ -1,0 +1,80 @@
+/**
+ * `cortex network ping` — injected-dependency seams (signal#113 P-11 /
+ * `docs/design-network-ping.md`, issue #56).
+ *
+ * Mirrors the `network-ports.ts` pattern: the orchestrator (`network-ping-lib.ts`)
+ * is PURE over these ports; the live adapter (in `network.ts`) wires the real
+ * `MyelinRuntime`; tests inject a fake bus that never touches NATS or
+ * `~/.config`.
+ *
+ * The probe is a SINGLE port — a "fire one probe, await its echo" round-trip —
+ * so the orchestration (count loop, RTT aggregation, verdict classification,
+ * exit codes) stays testable without a live bus.
+ */
+
+import type { Envelope } from "../../../bus/myelin/envelope-validator";
+
+/**
+ * One probe round-trip outcome from the bus port. The port fires the request
+ * envelope on the federated subject, subscribes the requester's own
+ * `probe.reply.echo`, matches by `correlation_id`, and resolves with either the
+ * matched reply (+ measured RTT) or a timeout.
+ *
+ * The port does NOT classify the verdict — that is the orchestrator's job (it
+ * maps `timeout` / reply-shape to the §3.3 taxonomy). The port only reports the
+ * raw transport outcome.
+ */
+export type ProbeRoundTripResult =
+  | {
+      kind: "reply";
+      /** Round-trip time in ms, measured single-clock on the requester. */
+      rttMs: number;
+      /** The matched reply envelope (for the orchestrator to inspect). */
+      reply: Envelope;
+    }
+  | {
+      kind: "timeout";
+    }
+  | {
+      /**
+       * The publish itself failed (e.g. no `selectLink` route resolvable for
+       * the target principal — the peer is not reachable on any shared
+       * network's leaf). Distinct from `timeout`: nothing went on the wire.
+       */
+      kind: "publish-failed";
+      reason: string;
+    };
+
+/** Inputs the bus port needs to fire one probe + await its echo. */
+export interface ProbeFireInputs {
+  /** The request envelope (`source` addresses target, `originator` = us). */
+  request: Envelope;
+  /** The explicit federated request subject (publishOnSubject). */
+  requestSubject: string;
+  /**
+   * The requester's own reply subject pattern to subscribe
+   * (`federated.{us}.{our-stack}.probe.reply.>`).
+   */
+  replySubjectPattern: string;
+  /** Join key — match an inbound reply on this `correlation_id`. */
+  correlationId: string;
+  /** Per-probe wait budget for the echo reply (ms). */
+  timeoutMs: number;
+}
+
+/**
+ * The bus seam. ONE method: fire a probe + await its echo. The live adapter
+ * owns the runtime subscription lifecycle; the fake records the request +
+ * returns a scripted outcome.
+ */
+export interface ProbeBusPort {
+  fireProbe(inputs: ProbeFireInputs): Promise<ProbeRoundTripResult>;
+}
+
+/** The ports bundle (room to grow — clock, etc., stay injectable). */
+export interface NetworkPingPorts {
+  bus: ProbeBusPort;
+  /** Monotonic-ish nonce + correlation id source (testable). */
+  newNonce(): string;
+  newCorrelationId(): string;
+}

--- a/src/cli/cortex/commands/network-ping-signer.ts
+++ b/src/cli/cortex/commands/network-ping-signer.ts
@@ -1,0 +1,113 @@
+/**
+ * `cortex network ping` — stack signer construction (PR #822 review, MAJOR-1).
+ *
+ * A faithful CLI-side mirror of `cortex.ts`'s boot-time signer build: under a
+ * `permissive`/`enforce` posture, load the stack signing key (chmod-600 gated,
+ * `SU`-prefixed) and return a {@link BusEnvelopeSigner} so the probe REQUEST is
+ * signed exactly like every other federated dispatch. Under `signing: off`
+ * (the schema default) it returns `undefined` — the probe publishes unsigned,
+ * byte-identical to pre-#822.
+ *
+ * ## Why this matters (the MAJOR the review caught)
+ *
+ * `cortex network ping` against an `enforce`-posture peer must carry a signed
+ * `signed_by[]` chain + signed `originator` or the peer's gate fail-closes the
+ * request → the probe reports `timeout`/`refused`, NEVER `reachable`, breaking
+ * the spec §9 enforce close-criterion. The seam was already plumbed
+ * (`createLiveProbeBus(config, signer?)`); this helper feeds it. It fails
+ * CLOSED (under-signs on any load error → unsigned publish → at worst a false
+ * `timeout`, never an over-trust), matching `cortex.ts`'s non-fatal catch.
+ *
+ * The recipe is copied deliberately from `src/cortex.ts` (posture gate → seed
+ * load → pubkey-consistency check → raw-seed extract → DID derivation with the
+ * slash→hyphen + `--`-collapse canonicalisation). If `cortex.ts`'s signer build
+ * changes, change this too — the two MUST agree on the DID + seed shape, or a
+ * probe would sign with a different identity than the daemon.
+ */
+
+import { DID_RE } from "@the-metafactory/myelin/identity";
+
+import { expandTilde } from "../../../common/config/loader";
+import type { LoadedConfig } from "../../../common/config/loader";
+import { loadStackSigningKey } from "../../../common/config/stack-signing-key";
+import { resolveSigningKnobs } from "../../../common/security-posture";
+import { deriveStackId } from "../../../common/types/cortex-config";
+import type { BusEnvelopeSigner } from "../../../bus/myelin/runtime";
+
+/**
+ * Build the stack {@link BusEnvelopeSigner} from the loaded config, or
+ * `undefined` when the posture is `off` / no seed is configured / the seed
+ * fails to load (fail-closed: unsigned publish, never an over-trust).
+ *
+ * Mirrors `cortex.ts`'s boot signer build 1:1 (see file docblock). A load /
+ * derivation failure is logged to stderr (per the no-empty-catch rule) and
+ * returns `undefined` — the probe then publishes unsigned, exactly as under
+ * `signing: off`.
+ */
+export async function buildPingSignerFromConfig(
+  cfg: LoadedConfig,
+): Promise<BusEnvelopeSigner | undefined> {
+  const signing = cfg.config.security.signing;
+  const knobs = resolveSigningKnobs(signing);
+
+  // Posture gate — `off` never attaches a signer (publish unsigned), exactly
+  // like `cortex.ts`. A seed configured under `off` is intentionally ignored.
+  if (!knobs.attachSigner) return undefined;
+
+  const seedPath = cfg.stack?.nkey_seed_path;
+  if (seedPath === undefined || seedPath === "") {
+    // `permissive`/`enforce` posture but no seed staged — nothing to sign with.
+    // Fail closed (unsigned). cortex.ts logs the same default-on warning; here
+    // a probe is a one-shot CLI run, so a single stderr note suffices.
+    process.stderr.write(
+      `cortex network ping: security.signing=${signing} but no stack.nkey_seed_path ` +
+        `configured — probe will be published UNSIGNED (an enforce-posture peer will drop it)\n`,
+    );
+    return undefined;
+  }
+
+  try {
+    const kp = await loadStackSigningKey(expandTilde(seedPath));
+
+    // Pubkey-consistency check — same split-brain guard as cortex.ts.
+    if (
+      cfg.stack?.nkey_pub !== undefined &&
+      kp.getPublicKey() !== cfg.stack.nkey_pub
+    ) {
+      throw new Error(
+        `seed file pubkey ${kp.getPublicKey()} does not match declared ` +
+          `stack.nkey_pub ${cfg.stack.nkey_pub} — rotation split-brain hazard`,
+      );
+    }
+
+    const rawSeedBytes = (
+      kp as unknown as { getRawSeed(): Uint8Array }
+    ).getRawSeed();
+
+    // Derive the requester DID from the resolved stack id, identical to
+    // cortex.ts: `{principal}/{stack}` → `did:mf:{principal}-{stack}`, with the
+    // slash→hyphen swap + `--`-run collapse so DID_RE's consecutive-hyphen
+    // guard holds for trailing-hyphen stack-segment edge cases.
+    const derived = deriveStackId({
+      ...(cfg.principal?.id !== undefined && { principal: { id: cfg.principal.id } }),
+      ...(cfg.stack !== undefined && { stack: cfg.stack }),
+    });
+    const principal = `did:mf:${derived.id.replace("/", "-").replace(/-+/g, "-")}`;
+    if (!DID_RE.test(principal)) {
+      throw new Error(
+        `derived DID "${principal}" does not match myelin DID_RE — ` +
+          `check stack.id segments for trailing-hyphen edge cases`,
+      );
+    }
+
+    return { rawSeedBytes, principal };
+  } catch (err) {
+    // Non-fatal — fail closed (unsigned publish), same posture as cortex.ts's
+    // boot-time catch. Deliberately omit the seed-derived message detail.
+    process.stderr.write(
+      `cortex network ping: stack signing key load failed (probe will be unsigned): ` +
+        `${err instanceof Error ? err.message : String(err)}\n`,
+    );
+    return undefined;
+  }
+}

--- a/src/cli/cortex/commands/network.ts
+++ b/src/cli/cortex/commands/network.ts
@@ -45,6 +45,7 @@ import { readFile } from "fs/promises";
 import { join } from "path";
 
 import { expandTilde, loadConfigWithAgents } from "../../../common/config/loader";
+import type { LoadedConfig } from "../../../common/config/loader";
 import { enforceChmod600 } from "../../../common/config/file-permissions";
 import {
   materialFromSeedString,
@@ -104,6 +105,7 @@ import {
   createLiveProbeBus,
   type LiveProbeBus,
 } from "./network-ping-adapters";
+import { buildPingSignerFromConfig } from "./network-ping-signer";
 import type { NetworkPingPorts } from "./network-ping-ports";
 
 export { type ExitResult } from "./_shared/exit-result";
@@ -615,16 +617,23 @@ function parsePeerArg(
 
 /**
  * Factory for the probe bus port. Production builds a {@link LiveProbeBus} over
- * the runtime from the loaded `AgentConfig`; tests inject a fake. Returns the
- * ports + a `stop()` to drain the runtime.
+ * the runtime from the loaded config; tests inject a fake. Receives the full
+ * {@link LoadedConfig} so the live factory can build the posture-gated stack
+ * signer (PR #822 MAJOR-1) — the probe REQUEST is signed exactly like every
+ * other federated dispatch under `permissive`/`enforce`. Returns the ports +
+ * a `stop()` to drain the runtime.
  */
 export type PingBusFactory = (
-  config: import("../../../common/types/config").AgentConfig,
+  cfg: LoadedConfig,
 ) => Promise<{ ports: NetworkPingPorts; stop: () => Promise<void> }>;
 
-/** The production factory — a live NATS-backed probe bus. */
-const DEFAULT_PING_BUS_FACTORY: PingBusFactory = async (config) => {
-  const bus: LiveProbeBus = await createLiveProbeBus(config);
+/** The production factory — a live NATS-backed probe bus, signed per posture. */
+const DEFAULT_PING_BUS_FACTORY: PingBusFactory = async (cfg) => {
+  // PR #822 MAJOR-1 — feed the plumbed signer so an enforce-posture peer
+  // accepts the probe (signed `signed_by[]` + originator). `undefined` under
+  // `signing: off` (publishes unsigned, byte-identical to pre-#822).
+  const signer = await buildPingSignerFromConfig(cfg);
+  const bus: LiveProbeBus = await createLiveProbeBus(cfg.config, signer);
   const ports: NetworkPingPorts = {
     bus,
     newNonce: () => crypto.randomUUID(),
@@ -693,10 +702,11 @@ async function runPing(
     return renderPingResult(res, inputs.targetPrincipal, inputs.targetStack, json);
   }
 
-  // Build the live (or injected) bus and fire the probe(s).
+  // Build the live (or injected) bus and fire the probe(s). The factory gets
+  // the full LoadedConfig so the live path can build the posture-gated signer.
   let busHandle;
   try {
-    busHandle = await busFactory(cfg.config);
+    busHandle = await busFactory(cfg);
   } catch (err) {
     return opError("ping", `failed to start bus: ${err instanceof Error ? err.message : String(err)}`, json);
   }

--- a/src/cli/cortex/commands/network.ts
+++ b/src/cli/cortex/commands/network.ts
@@ -95,6 +95,16 @@ import {
   leavePublic,
   type PublicJoinInputs,
 } from "./network-public-lib";
+import {
+  derivePingInputs,
+  pingPeer,
+  type PingResult,
+} from "./network-ping-lib";
+import {
+  createLiveProbeBus,
+  type LiveProbeBus,
+} from "./network-ping-adapters";
+import type { NetworkPingPorts } from "./network-ping-ports";
 
 export { type ExitResult } from "./_shared/exit-result";
 
@@ -102,7 +112,7 @@ export { type ExitResult } from "./_shared/exit-result";
 // Grammar
 // =============================================================================
 
-type NetworkSubcommand = "join" | "leave" | "status" | "create";
+type NetworkSubcommand = "join" | "leave" | "status" | "create" | "ping";
 
 /** Default registry URL when neither --registry-url nor config provides one. */
 const DEFAULT_REGISTRY_URL = "https://network.meta-factory.ai";
@@ -219,6 +229,31 @@ const SPEC: SubcommandSpec<NetworkSubcommand> = {
         "--registry-url": "value",
         "--apply": "bool",
         "--dry-run": "bool",
+      },
+    },
+    // signal#113 P-11 (#56) — active federated reachability probe. Fires a
+    // Direct `probe.echo` at <peer>, awaits the built-in echo on our own
+    // `probe.reply.echo`, measures RTT, prints + returns the verdict per the
+    // §3.3 taxonomy + exit codes (0 reachable / 2 not-configured / 3
+    // no-responder / 4 timeout / 5 refused). Derives principal/stack from
+    // cortex.yaml like join (#753).
+    ping: {
+      positionals: ["peer"],
+      flags: {
+        "--config": "value",
+        "--principal": "value",
+        "--stack": "value",
+        // Direct-probe target assistant. Omitted ⇒ the target stack's reserved
+        // DID (`did:mf:{target}-{target-stack}`).
+        "--assistant": "value",
+        // Topology selector ONLY — scopes peer resolution when the peer is
+        // reachable on more than one shared network. NEVER a wire segment
+        // (ADR-0002 §4).
+        "--network": "value",
+        // `ping -c` — number of echo probes. Default 1.
+        "--count": "value",
+        // Per-probe echo wait budget (ms). Default 2000.
+        "--timeout": "value",
       },
     },
   },
@@ -553,6 +588,199 @@ async function runStatus(
     lines.push("");
   }
   return ok(lines.join("\n"));
+}
+
+// =============================================================================
+// signal#113 P-11 (#56) — `cortex network ping`
+// =============================================================================
+
+/** Parse a `<peer>` positional into `{principal, stack}` (stack defaults to `default`). */
+function parsePeerArg(
+  peer: string,
+): { ok: true; principal: string; stack: string } | { ok: false; reason: string } {
+  const parts = peer.split("/");
+  if (parts.length > 2) {
+    return { ok: false, reason: `peer "${peer}" must be {principal} or {principal}/{stack}` };
+  }
+  const principal = parts[0] ?? "";
+  const stack = parts[1] ?? "default";
+  if (!PRINCIPAL_ID_RE.test(principal)) {
+    return { ok: false, reason: `peer principal "${principal}" must be lowercase alphanumeric + hyphen, letter-prefixed` };
+  }
+  if (!/^[a-z][a-z0-9_-]*$/.test(stack)) {
+    return { ok: false, reason: `peer stack "${stack}" must be letter-prefixed lowercase` };
+  }
+  return { ok: true, principal, stack };
+}
+
+/**
+ * Factory for the probe bus port. Production builds a {@link LiveProbeBus} over
+ * the runtime from the loaded `AgentConfig`; tests inject a fake. Returns the
+ * ports + a `stop()` to drain the runtime.
+ */
+export type PingBusFactory = (
+  config: import("../../../common/types/config").AgentConfig,
+) => Promise<{ ports: NetworkPingPorts; stop: () => Promise<void> }>;
+
+/** The production factory — a live NATS-backed probe bus. */
+const DEFAULT_PING_BUS_FACTORY: PingBusFactory = async (config) => {
+  const bus: LiveProbeBus = await createLiveProbeBus(config);
+  const ports: NetworkPingPorts = {
+    bus,
+    newNonce: () => crypto.randomUUID(),
+    newCorrelationId: () => crypto.randomUUID(),
+  };
+  return { ports, stop: () => bus.stop() };
+};
+
+async function runPing(
+  peerArg: string,
+  flags: Record<string, string | true>,
+  json: boolean,
+  load: ConfigReader,
+  busFactory: PingBusFactory,
+): Promise<ExitResult> {
+  const peerRes = parsePeerArg(peerArg);
+  if (!peerRes.ok) return usageError("ping", peerRes.reason, json);
+
+  // --count (default 1, ≥1) and --timeout (default 2000ms, ≥1).
+  const count = parsePositiveInt(flags, "--count", 1);
+  if (!count.ok) return usageError("ping", count.reason, json);
+  const timeout = parsePositiveInt(flags, "--timeout", 2000);
+  if (!timeout.ok) return usageError("ping", timeout.reason, json);
+
+  // Load config (the #753 seam). A missing/broken config is an op-error.
+  let cfg;
+  try {
+    cfg = load(expandTilde(optionalValueFlag(flags, "--config") ?? DEFAULT_CONFIG_PATH));
+  } catch (err) {
+    return opError("ping", `config load failed: ${err instanceof Error ? err.message : String(err)}`, json);
+  }
+
+  const derived = derivePingInputs({
+    cfg,
+    targetPrincipal: peerRes.principal,
+    targetStack: peerRes.stack,
+    ...(optionalValueFlag(flags, "--assistant") !== undefined && {
+      assistant: optionalValueFlag(flags, "--assistant"),
+    }),
+    ...(optionalValueFlag(flags, "--network") !== undefined && {
+      network: optionalValueFlag(flags, "--network"),
+    }),
+    count: count.value,
+    timeoutMs: timeout.value,
+    ...(optionalValueFlag(flags, "--principal") !== undefined && {
+      principalOverride: optionalValueFlag(flags, "--principal"),
+    }),
+  });
+  if (!derived.ok || derived.inputs === undefined) {
+    return usageError("ping", derived.reason ?? "could not derive ping inputs", json);
+  }
+  const inputs = derived.inputs;
+
+  // `not-configured` fails closed at OUR boundary — never start the runtime /
+  // emit anything. `pingPeer` short-circuits, so the bus is never built.
+  if (!inputs.isConfiguredPeer) {
+    // `pingPeer` short-circuits on `!isConfiguredPeer` BEFORE touching the bus,
+    // so this port is never invoked — the runtime is never started, nothing is
+    // emitted (the §3.3 `not-configured` fail-closed). The stub just satisfies
+    // the port shape; `fireProbe` returns a resolved promise it never calls.
+    const res = await pingPeer(inputs, {
+      bus: { fireProbe: () => Promise.resolve({ kind: "timeout" }) },
+      newNonce: () => "",
+      newCorrelationId: () => "",
+    });
+    return renderPingResult(res, inputs.targetPrincipal, inputs.targetStack, json);
+  }
+
+  // Build the live (or injected) bus and fire the probe(s).
+  let busHandle;
+  try {
+    busHandle = await busFactory(cfg.config);
+  } catch (err) {
+    return opError("ping", `failed to start bus: ${err instanceof Error ? err.message : String(err)}`, json);
+  }
+  try {
+    const res = await pingPeer(inputs, busHandle.ports);
+    return renderPingResult(res, inputs.targetPrincipal, inputs.targetStack, json);
+  } finally {
+    await busHandle.stop();
+  }
+}
+
+/** Parse a positive-integer value flag with a default. */
+function parsePositiveInt(
+  flags: Record<string, string | true>,
+  name: string,
+  dflt: number,
+): { ok: true; value: number } | { ok: false; reason: string } {
+  const raw = optionalValueFlag(flags, name);
+  if (raw === undefined) return { ok: true, value: dflt };
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isInteger(n) || n < 1) {
+    return { ok: false, reason: `${name} "${raw}" must be a positive integer` };
+  }
+  return { ok: true, value: n };
+}
+
+/** Render a {@link PingResult} — human table or `--json` envelope + exit code. */
+function renderPingResult(
+  res: PingResult,
+  targetPrincipal: string,
+  targetStack: string,
+  json: boolean,
+): ExitResult {
+  const peer = `${targetPrincipal}/${targetStack}`;
+  if (json) {
+    const env = envelopeOk(
+      res.probes.map((p) => ({
+        seq: p.seq,
+        verdict: p.verdict,
+        ...(p.rttMs !== undefined && { rtt_ms: p.rttMs }),
+      })),
+      {
+        peer,
+        verdict: res.verdict,
+        sent: String(res.stats.sent),
+        received: String(res.stats.received),
+        loss_pct: String(Math.round(res.stats.loss * 100)),
+        ...(res.stats.rttMinMs !== undefined && { rtt_min_ms: String(res.stats.rttMinMs) }),
+        ...(res.stats.rttAvgMs !== undefined && { rtt_avg_ms: res.stats.rttAvgMs.toFixed(1) }),
+        ...(res.stats.rttMaxMs !== undefined && { rtt_max_ms: String(res.stats.rttMaxMs) }),
+        ...(res.detail !== undefined && { detail: res.detail }),
+      },
+    );
+    // JSON goes to stdout regardless of exit code so a verdict is always
+    // machine-readable; the exit code carries the verdict per §3.3.
+    return { exitCode: res.exitCode, stdout: renderJson(env), stderr: "" };
+  }
+
+  const lines: string[] = [`PING ${peer} via federated dispatch:`];
+  for (const p of res.probes) {
+    lines.push(
+      `  seq=${p.seq}  ${p.verdict}` +
+        (p.rttMs !== undefined ? `  rtt=${p.rttMs}ms` : ""),
+    );
+  }
+  lines.push(`--- ${peer} ping statistics ---`);
+  lines.push(
+    `${res.stats.sent} probes sent, ${res.stats.received} echoes received, ` +
+      `${Math.round(res.stats.loss * 100)}% loss`,
+  );
+  if (res.stats.rttMinMs !== undefined && res.stats.rttAvgMs !== undefined && res.stats.rttMaxMs !== undefined) {
+    lines.push(
+      `rtt min/avg/max = ${res.stats.rttMinMs}/${res.stats.rttAvgMs.toFixed(1)}/${res.stats.rttMaxMs} ms`,
+    );
+  }
+  if (res.verdict !== "reachable") {
+    lines.push(`verdict: ${res.verdict}${res.detail !== undefined ? ` — ${res.detail}` : ""}`);
+  }
+  const body = lines.join("\n") + "\n";
+  // Reachable → stdout/exit 0; any failure verdict → stderr + the verdict's
+  // exit code (so scripts branch on `$?` per §3.3).
+  return res.exitCode === 0
+    ? { exitCode: 0, stdout: body, stderr: "" }
+    : { exitCode: res.exitCode, stdout: "", stderr: body };
 }
 
 // =============================================================================
@@ -913,6 +1141,9 @@ export async function dispatchNetwork(
   // config without touching the principal's real `~/.config/cortex/`.
   // Production callers omit it and the real `loadConfigWithAgents` is used.
   load: ConfigReader = DEFAULT_READER,
+  // #56 — injectable probe-bus factory so `ping` CLI tests drive a fake bus
+  // without standing up NATS. Production omits it → the live NATS-backed bus.
+  pingBusFactory: PingBusFactory = DEFAULT_PING_BUS_FACTORY,
 ): Promise<ExitResult> {
   let parsed;
   try {
@@ -946,6 +1177,8 @@ export async function dispatchNetwork(
       return runStatus(parsed.flags, json);
     case "create":
       return runCreate(parsed.positionals.network ?? "", parsed.flags, json);
+    case "ping":
+      return runPing(parsed.positionals.peer ?? "", parsed.flags, json, load, pingBusFactory);
   }
 }
 
@@ -961,6 +1194,7 @@ Usage:
   cortex network leave  <network> [--apply] [--config <p>] [overrides…]
   cortex network status [--principal <id>] [--stack <id>] [--monitor-url <url>] [--json]
   cortex network create <network> --hub <tls-url> --leaf-port <port> --admin-seed <path> [--registry-url <url>] [--apply]
+  cortex network ping   <peer> [--assistant <a>] [--network <id>] [--count N] [--timeout <ms>] [--json]
 
 The one-liner (#753): \`cortex network join <network>\` derives EVERYTHING from
 the loaded cortex.yaml — principal (principal.id), stack (stack.id), signing
@@ -980,6 +1214,16 @@ Subcommands:
           → restart. Idempotent (re-running converges). For a principal's
           SECOND+ stack, pass --principal-seed <root> so the register step
           root-signs the add-stack claim + preserves existing stacks (#791).
+  ping    (signal#113 P-11, #56) Active federated reachability probe — the
+          ICMP of the agent network. Fires a Direct probe.echo at <peer>
+          ({principal} or {principal}/{stack}), awaits the built-in echo on
+          our own probe.reply.echo, measures RTT, and prints + returns the
+          verdict. The peer MUST be in this stack's
+          policy.federated.networks[].peers[] (else not-configured, exit 2,
+          nothing emitted). Exit codes: 0 reachable / 2 not-configured /
+          3 no-responder / 4 timeout / 5 refused. --count for multiple probes
+          (min/avg/max RTT); --assistant for a named Direct target; --network
+          to disambiguate the topology (NEVER a wire segment).
   status  Show joined networks, peers, accept-subjects, leaf link state + counters.
   leave   Reverse a join cleanly: remove the network + leaf include, drop the
           plist -c arg if no networks remain, restart. Idempotent.

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -109,6 +109,7 @@ import type { Surfaces } from "./common/types/surfaces";
 import type { SurfaceGateway } from "./gateway/surface-gateway";
 
 import { createDispatchListener, type DispatchListener } from "./runner/dispatch-listener";
+import { createProbeResponder, type ProbeResponder } from "./bus/probe-responder";
 import { WorklogManager } from "./runner/worklog-manager";
 
 // #752 — the `network` + `provision-stack` subcommand dispatchers. Registered
@@ -2483,6 +2484,30 @@ export async function startCortex(
   });
   await dispatchListener.start();
 
+  // signal#113 P-11 (#56) — federated echo responder. The ICMP-analog of the
+  // agent network: answers a reserved `probe.echo` capability IN THE RUNTIME
+  // (no harness, no `claude`, no Discord, no tools) on our own
+  // `federated.{us}.{stack}.tasks.*.>` subject. Always-on between configured
+  // `peers[]` (the responder only ever answers a mutually-configured, gated
+  // peer; absent/forged originator or a non-peer is dropped fail-closed; the
+  // reply is exactly-one-bounded, keyed to the originator-attributed requester
+  // scope, per-source rate-limited — no amplification). Dormant when no
+  // `policy.federated.networks[]` is declared (no peers ⇒ nothing to answer).
+  const probeResponderNetworks = new Map(
+    (options.policy?.federated?.networks ?? []).map((n) => [n.id, n] as const),
+  );
+  const probeResponder: ProbeResponder = createProbeResponder({
+    runtime,
+    source: systemEventSource,
+    stack: derivedStack.stack,
+    federatedNetworksById: probeResponderNetworks,
+  });
+  await probeResponder.start();
+  console.log(
+    `cortex: probe-responder started — subjects=[${probeResponder.subjects.join(", ")}], ` +
+      `peers-networks=${probeResponderNetworks.size}`,
+  );
+
   // cortex#491 — dispatch sink (OUTBOUND). The single delivery path for
   // dispatch lifecycle replies (CONTEXT.md §Dispatch-sink). Subscribes to
   // `local.{principal}[.{stack}].dispatch.task.>` via the runtime
@@ -2887,6 +2912,9 @@ export async function startCortex(
         }
       }
       await completeAsync("dispatch-listener stop", dispatchListener.stop());
+      // signal#113 P-11 (#56) — drain the echo responder on the same boundary
+      // as the dispatch listener. `stop()` is idempotent (no-op when dormant).
+      await completeAsync("probe-responder stop", probeResponder.stop());
       // cortex#491 — drain the dispatch sink after the runner stops
       // publishing lifecycle envelopes but before the surface-router /
       // adapters stop, so no late `postResponse` lands after the

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -2501,6 +2501,11 @@ export async function startCortex(
     source: systemEventSource,
     stack: derivedStack.stack,
     federatedNetworksById: probeResponderNetworks,
+    // PR #822 NIT-2 — stamp OUR residency on the replies we author (not the
+    // requester-supplied inbound one). `undefined` → the responder defaults NZ.
+    ...(systemEventSource.dataResidency !== undefined && {
+      dataResidency: systemEventSource.dataResidency,
+    }),
   });
   await probeResponder.start();
   console.log(


### PR DESCRIPTION
Active federated reachability probe per the merged spec (#816). `cortex network ping <peer>` fires a Direct probe on `federated.{target}.{stack}.tasks.@{did}.probe.echo`; the responder is a dedicated harness-free subscriber that replies once on `…probe.reply.echo`; RTT measured, verdict taxonomy (`reachable`/`no-responder`/`timeout`/`refused`/`not-configured`) with exit codes 0/3/4/5/2.

**Security (no-amplification, the SEV-1 gate):** `decideProbeResponse` is a single pure fn → exactly ONE reply or a drop; reply subject composed SOLELY from the `originator`-decoded requester (never `source`/subject/payload — test spoofs `source`→victim, asserts reply doesn't target it); fail-closed drops on non-`probe.echo` / bad payload / absent-malformed originator / self-loop / non-`peers[]` requester; per-principal token-bucket rate-limit; nonce length-capped. **No LLM/harness on the probe path** (confirmed — zero cc-session/Skill/Discord imports; the runner's listener rejects `probe.echo` as a non-task). FG-1..5 conformant (no `network_id` on the wire — greps the serialized envelope).

v1 publishes unsigned (default `signing: off`, peers[]-gated, per spec §5.4); posture-gated signing + signal P-11 observability are the follow-ons. 5051 tests / 0 fail (+59), tsc/lint/vocab clean. refs #113 (closes the P-11 cortex-side fire/respond half).