### PR TITLE
fix(network-registry): C-819 — merge-preserve capabilities on re-register (stop silent roster eviction)

### DIFF
--- a/src/bus/__tests__/stack-provisioning.test.ts
+++ b/src/bus/__tests__/stack-provisioning.test.ts
@@ -31,6 +31,7 @@ import {
   materialFromSeedString,
   buildRegistrationClaim,
   fetchExistingStacks,
+  resolveMergedCapabilities,
   fingerprintOf,
 } from "../stack-provisioning";
 import { nkeyToBase64Pubkey } from "../verify-signed-by-chain";
@@ -460,6 +461,225 @@ describe("C-787 / C-791 — fetchExistingStacks (verified read side of add-stack
     expect(res.kind).toBe("error");
     if (res.kind === "error") {
       expect(res.reason).toMatch(/did not verify/i);
+    }
+  });
+});
+
+// =============================================================================
+// C-819 — capability merge-preserve (stop silent roster eviction)
+// =============================================================================
+//
+// The register route does a FULL-OVERWRITE upsert of the `capabilities` column
+// (store.ts: `capabilities = excluded.capabilities`), identical to the stacks
+// column. Roster membership is IMPLICIT: a principal is "in" network X iff one
+// of its announced capabilities lists X in `capability.networks[]`. So a bare
+// re-register whose claim carries NO capabilities silently zeroes the set and
+// evicts the principal from every roster. `resolveMergedCapabilities` is the
+// capability twin of `resolveMergedStacks`: on the add-stack path it fetches
+// the (verified) existing set and unions the announce in, so an EMPTY announce
+// preserves the existing caps unchanged. These tests pin both the unit merge
+// semantics AND the end-to-end roster-survival behaviour against the real route.
+describe("C-819 — resolveMergedCapabilities preserves caps across re-register", () => {
+  let registryPubkey = "";
+  async function configuredEnv(): Promise<Env> {
+    resetStores();
+    const reg = await makeRegistryKey();
+    registryPubkey = reg.publicKey;
+    return {
+      REGISTRY_SIGNING_KEY: reg.signingKey,
+      REGISTRY_PUBLIC_KEY: reg.publicKey,
+      ENVIRONMENT: "test",
+    };
+  }
+
+  function registryFetch(env: Env): typeof globalThis.fetch {
+    return ((input: Request | string | URL, init?: RequestInit) => {
+      const req = input instanceof Request ? input : new Request(input, init);
+      return registryApp.fetch(req, env);
+    }) as typeof globalThis.fetch;
+  }
+
+  async function post(env: Env, path: string, body: unknown): Promise<Response> {
+    return registryApp.fetch(
+      new Request(`http://registry.test${path}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      }),
+      env,
+    );
+  }
+
+  async function rosterMembers(env: Env, networkId: string): Promise<string[]> {
+    const res = await registryApp.fetch(
+      new Request(`http://registry.test/networks/${networkId}/roster`),
+      env,
+    );
+    const json = (await res.json()) as {
+      payload: { members: { principal_id: string }[] };
+    };
+    return json.payload.members.map((m) => m.principal_id).sort();
+  }
+
+  /**
+   * Seed principal `jc` with a single stack that announces a `community-net`
+   * capability — so JC lands on the `community-net` roster (the live repro:
+   * `metafactory-community` listed `jc`). Returns the root material so a later
+   * re-register can sign as the same root (the rotation gate requires it).
+   */
+  async function seedJcWithCommunityCaps(env: Env) {
+    const root = generateStackIdentity({ seedPath: join(freshDir(), "jc-root.nk") });
+    const body = await buildRegistrationClaim({
+      principalId: "jc",
+      material: root,
+      stacks: [{ stack_id: "jc/meta-factory" }],
+      capabilities: [
+        { id: "tasks.code-review", description: "JC reviews", networks: ["community-net"] },
+      ],
+    });
+    await post(env, "/principals/jc/register", body);
+    return root;
+  }
+
+  test("ACCEPTANCE — a bare add-stack register (empty announce) preserves JC's caps + roster membership", async () => {
+    const env = await configuredEnv();
+    const root = await seedJcWithCommunityCaps(env);
+
+    // Precondition: JC is on the community roster.
+    expect(await rosterMembers(env, "community-net")).toEqual(["jc"]);
+
+    // Now stand up `jc/clawbox` (the live repro). It is a SECOND stack added by
+    // the principal root, announcing NO capabilities of its own. The CLI mirrors
+    // the stacks merge: resolveMergedCapabilities with an EMPTY announce.
+    const caps = await resolveMergedCapabilities({
+      principalId: "jc",
+      registryUrl: "http://registry.test",
+      registryPubkey,
+      announce: [], // provision-stack register announces no caps
+      isAddStack: true,
+      fetchImpl: registryFetch(env),
+    });
+    expect(caps.ok).toBe(true);
+    if (!caps.ok) throw new Error(caps.reason);
+    // Empty ∪ existing = existing — the community cap survives the merge.
+    expect(caps.capabilities.map((cc) => cc.id)).toEqual(["tasks.code-review"]);
+    expect(caps.capabilities[0]!.networks).toEqual(["community-net"]);
+
+    // The new stack (root re-attests the FULL stack set, here just the merged
+    // caps drive the assertion). Build + POST the re-register the CLI would.
+    const newStack = generateStackIdentity({ seedPath: join(freshDir(), "jc-clawbox.nk") });
+    const body = await buildRegistrationClaim({
+      principalId: "jc",
+      material: newStack,
+      rootMaterial: root, // root signs the add-stack
+      stacks: [{ stack_id: "jc/meta-factory" }, { stack_id: "jc/clawbox" }],
+      capabilities: caps.capabilities, // the PRESERVED set
+    });
+    const res = await post(env, "/principals/jc/register", body);
+    expect(res.status).toBe(201);
+
+    // The footgun is closed: JC is STILL on the community roster.
+    expect(await rosterMembers(env, "community-net")).toEqual(["jc"]);
+  });
+
+  test("REGRESSION GUARD — WITHOUT the merge (empty caps claim), the route DOES wipe + evict", async () => {
+    // Proves the merge is load-bearing: the same re-register WITHOUT
+    // resolveMergedCapabilities (empty caps in the claim) zeroes the set and
+    // evicts JC. This is the bug; the test above is the fix.
+    const env = await configuredEnv();
+    const root = await seedJcWithCommunityCaps(env);
+    expect(await rosterMembers(env, "community-net")).toEqual(["jc"]);
+
+    const newStack = generateStackIdentity({ seedPath: join(freshDir(), "jc-clawbox.nk") });
+    const body = await buildRegistrationClaim({
+      principalId: "jc",
+      material: newStack,
+      rootMaterial: root,
+      stacks: [{ stack_id: "jc/meta-factory" }, { stack_id: "jc/clawbox" }],
+      // capabilities omitted → defaults to [] → full-overwrite to empty.
+    });
+    const res = await post(env, "/principals/jc/register", body);
+    expect(res.status).toBe(201);
+    // Roster eviction reproduced (jc → empty).
+    expect(await rosterMembers(env, "community-net")).toEqual([]);
+  });
+
+  test("union — a NEW announce is added, existing unrelated caps are kept (same-id new wins)", async () => {
+    const env = await configuredEnv();
+    const root = generateStackIdentity({ seedPath: join(freshDir(), "p-root.nk") });
+    // Seed with two caps across two networks.
+    await post(
+      env,
+      "/principals/p/register",
+      await buildRegistrationClaim({
+        principalId: "p",
+        material: root,
+        stacks: [{ stack_id: "p/s1" }],
+        capabilities: [
+          { id: "tasks.review", description: "old desc", networks: ["net-a"] },
+          { id: "tasks.deploy", networks: ["net-b"] },
+        ],
+      }),
+    );
+
+    const caps = await resolveMergedCapabilities({
+      principalId: "p",
+      registryUrl: "http://registry.test",
+      registryPubkey,
+      // Re-announce an EXISTING id into a new network + add a brand-new id.
+      announce: [
+        { id: "tasks.review", description: "new desc", networks: ["net-c"] },
+        { id: "tasks.fresh", networks: ["net-d"] },
+      ],
+      isAddStack: true,
+      fetchImpl: registryFetch(env),
+    });
+    expect(caps.ok).toBe(true);
+    if (!caps.ok) throw new Error(caps.reason);
+
+    const byId = new Map(caps.capabilities.map((cc) => [cc.id, cc]));
+    // Unrelated existing cap kept untouched.
+    expect(byId.get("tasks.deploy")?.networks).toEqual(["net-b"]);
+    // Same-id: networks UNIONED, description updated to the new claim's.
+    expect(byId.get("tasks.review")?.networks).toEqual(["net-a", "net-c"]);
+    expect(byId.get("tasks.review")?.description).toBe("new desc");
+    // Brand-new id appended.
+    expect(byId.get("tasks.fresh")?.networks).toEqual(["net-d"]);
+  });
+
+  test("first register (isAddStack=false) — announce passes through unchanged, no fetch", async () => {
+    // On a first register there is nothing on record to preserve; the merge is
+    // a pure pass-through and never touches the registry (a failing fetch would
+    // throw if it did).
+    const failingFetch = (() =>
+      Promise.reject(new Error("must not be called"))) as unknown as typeof globalThis.fetch;
+    const caps = await resolveMergedCapabilities({
+      principalId: "newcomer",
+      registryUrl: "http://registry.test",
+      registryPubkey: "unused",
+      announce: [{ id: "tasks.x", networks: ["net-z"] }],
+      isAddStack: false,
+      fetchImpl: failingFetch,
+    });
+    expect(caps.ok).toBe(true);
+    if (!caps.ok) throw new Error(caps.reason);
+    expect(caps.capabilities).toEqual([{ id: "tasks.x", networks: ["net-z"] }]);
+  });
+
+  test("error — an unverifiable read ABORTS (never overwrites caps off a partial/unverified read)", async () => {
+    const failingFetch = (() =>
+      Promise.reject(new Error("connection refused"))) as unknown as typeof globalThis.fetch;
+    const caps = await resolveMergedCapabilities({
+      principalId: "jc",
+      registryUrl: "http://registry.test",
+      registryPubkey: "anything",
+      announce: [],
+      isAddStack: true,
+      fetchImpl: failingFetch,
+    });
+    expect(caps.ok).toBe(false);
+    if (!caps.ok) {
+      expect(caps.reason).toMatch(/connection refused|without dropping/i);
     }
   });
 });

--- a/src/cli/cortex/commands/__tests__/provision-stack.test.ts
+++ b/src/cli/cortex/commands/__tests__/provision-stack.test.ts
@@ -18,6 +18,14 @@ import { tmpdir } from "os";
 import { join } from "path";
 
 import { dispatchProvisionStack } from "../provision-stack";
+// C-819 — seed an existing principal that ALREADY announces network caps (the
+// CLI register path announces none), so the add-stack preservation can be
+// asserted end-to-end. Same NKey root the CLI uses, so the rotation gate admits
+// the later add-stack.
+import {
+  buildRegistrationClaim,
+  materialFromSeedString,
+} from "../../../../bus/stack-provisioning";
 
 // Real registry route for the register round-trip.
 import registryApp from "../../../../services/network-registry/src/index";
@@ -389,6 +397,97 @@ describe("cortex provision-stack register — C-787 add-stack (no data loss)", (
       );
       const json = (await getRes.json()) as { payload: { stacks: { stack_id: string }[] } };
       expect(json.payload.stacks.map((s) => s.stack_id)).toEqual(["andreas/meta-factory"]);
+    } finally {
+      restore();
+    }
+  });
+
+  // ===========================================================================
+  // C-819 — add-stack register PRESERVES the principal's capabilities (and thus
+  // their roster membership). Live repro: standing up `jc/clawbox` dropped JC's
+  // community caps → `metafactory-community` roster went `jc → empty`.
+  // ===========================================================================
+  test("C-819 — adding a 2nd stack PRESERVES the principal's caps + roster membership", async () => {
+    const env = await configuredEnv();
+    const dir = freshDir();
+    const rootSeed = join(dir, "jc-root.nk"); // principal ROOT (first stack)
+    const clawboxSeed = join(dir, "jc-clawbox.nk"); // the joining stack's own key
+
+    await dispatchProvisionStack(["generate", "jc", "--seed-path", rootSeed]);
+    await dispatchProvisionStack(["generate", "jc", "--seed-path", clawboxSeed]);
+
+    const restore = routeFetchToRegistry(env);
+    try {
+      // 1. Seed `jc` WITH a community capability so JC lands on the community
+      //    roster. The CLI register announces no caps, so build this first claim
+      //    (with caps) directly using the SAME NKey root the CLI generated.
+      const root = materialFromSeedString(readFileSync(rootSeed, "utf-8"));
+      const seedBody = await buildRegistrationClaim({
+        principalId: "jc",
+        material: root,
+        stacks: [{ stack_id: "jc/meta-factory" }],
+        capabilities: [
+          { id: "tasks.code-review", description: "JC reviews", networks: ["community-net"] },
+        ],
+      });
+      const seedRes = await registryApp.fetch(
+        new Request("http://registry.test/principals/jc/register", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(seedBody),
+        }),
+        env,
+      );
+      expect(seedRes.status).toBe(201);
+
+      // Precondition: JC is on the community roster.
+      const rosterBefore = await registryApp.fetch(
+        new Request("http://registry.test/networks/community-net/roster"),
+        env,
+      );
+      const before = (await rosterBefore.json()) as {
+        payload: { members: { principal_id: string }[] };
+      };
+      expect(before.payload.members.map((m) => m.principal_id)).toEqual(["jc"]);
+
+      // 2. Stand up `jc/clawbox` via the CLI add-stack path (root-signed). It
+      //    announces NO caps — pre-fix this zeroed JC's cap set.
+      const add = await dispatchProvisionStack([
+        "register", "jc",
+        "--seed-path", clawboxSeed,
+        "--stack-id", "jc/clawbox",
+        "--principal-seed", rootSeed,
+        "--registry-url", "http://registry.test",
+        "--registry-pubkey", registryPubkey,
+      ]);
+      expect(add.exitCode).toBe(0);
+
+      // 3. JC's caps survived → JC is STILL on the community roster (footgun closed).
+      const rosterAfter = await registryApp.fetch(
+        new Request("http://registry.test/networks/community-net/roster"),
+        env,
+      );
+      const after = (await rosterAfter.json()) as {
+        payload: { members: { principal_id: string }[] };
+      };
+      expect(after.payload.members.map((m) => m.principal_id)).toEqual(["jc"]);
+
+      // And both stacks are present (no regression to the C-787 stack merge).
+      const getRes = await registryApp.fetch(
+        new Request("http://registry.test/principals/jc"),
+        env,
+      );
+      const principal = (await getRes.json()) as {
+        payload: {
+          stacks: { stack_id: string }[];
+          capabilities: { id: string; networks?: string[] }[];
+        };
+      };
+      expect(principal.payload.stacks.map((s) => s.stack_id).sort()).toEqual([
+        "jc/clawbox",
+        "jc/meta-factory",
+      ]);
+      expect(principal.payload.capabilities.map((cc) => cc.id)).toEqual(["tasks.code-review"]);
     } finally {
       restore();
     }

--- a/src/cli/cortex/commands/provision-stack.ts
+++ b/src/cli/cortex/commands/provision-stack.ts
@@ -57,6 +57,7 @@ import {
   buildRegistrationClaim,
   registerStackIdentity,
   resolveMergedStacks,
+  resolveMergedCapabilities,
   type StackIdentityMaterial,
   type SignedRegistrationBody,
 } from "../../../bus/stack-provisioning";
@@ -369,15 +370,40 @@ async function doRegister(
   // merge the new one in, so the root re-attests the full set and the route's
   // overwrite becomes correct. C-791 — the merge-read is signature-verified
   // against `registryPubkey` (fail closed on the add-stack path when absent).
+  const isAddStack = rootMaterial !== undefined;
+
   const stacksRes = await resolveMergedStacks({
     principalId,
     stackId,
     stackPubkey: material.pubkeyB64,
     registryUrl,
     ...(registryPubkey !== undefined && { registryPubkey }),
-    isAddStack: rootMaterial !== undefined,
+    isAddStack,
   });
   if (!stacksRes.ok) return { ok: false, reason: stacksRes.reason };
+
+  // C-819 — merge-preserve CAPABILITIES, mirroring the stacks merge above. The
+  // register route does the SAME full-overwrite upsert on the `capabilities`
+  // column (store.ts: `capabilities = excluded.capabilities`), so a claim that
+  // carries no caps zeroes the principal's existing set — silently evicting
+  // them from every network roster (membership is implicit via
+  // `capability.networks[]`). `provision-stack register` announces NO new caps
+  // (it provisions a stack IDENTITY, not a network membership — that is what
+  // `cortex network join` is for), so its `announce` is empty: on the add-stack
+  // path the fetch+verify+union therefore PRESERVES the principal's existing
+  // caps unchanged (empty ∪ existing = existing), and on a first register there
+  // is nothing on record to preserve. Same `isAddStack`/`registryPubkey` gating
+  // as the stacks merge keeps the two consistent (and shares the C-791
+  // fail-closed verified read). A register that genuinely intends to SHRINK
+  // caps is out of scope for this command — it never announces caps at all.
+  const capsRes = await resolveMergedCapabilities({
+    principalId,
+    registryUrl,
+    ...(registryPubkey !== undefined && { registryPubkey }),
+    announce: [],
+    isAddStack,
+  });
+  if (!capsRes.ok) return { ok: false, reason: capsRes.reason };
 
   let body: SignedRegistrationBody;
   try {
@@ -389,6 +415,9 @@ async function doRegister(
       // and `material` both declares + signs (pre-C-787 behaviour).
       ...(rootMaterial !== undefined && { rootMaterial }),
       stacks: stacksRes.stacks,
+      // C-819 — re-attest the merged (preserved) capability set so the route's
+      // full-overwrite writes the complete set instead of clobbering to empty.
+      capabilities: capsRes.capabilities,
     });
   } catch (err) {
     return { ok: false, reason: `failed to build registration claim: ${err instanceof Error ? err.message : String(err)}` };


### PR DESCRIPTION
## Problem (footgun — silent roster eviction)

A bare `cortex provision-stack register` (root seed / add-stack) carried **no capabilities** in its claim. The register route does a **full-overwrite** upsert of the `capabilities` column (`store.ts`: `capabilities = excluded.capabilities`) — identical to how it handles `stacks`. Roster membership is **implicit** via `capability.networks[]`, so the empty-caps claim silently zeroed the principal's cap set and evicted them from every network roster.

Live repro (Luna, 2026-06-09): standing up `jc/clawbox` dropped JC's community caps → `metafactory-community` roster went `jc → empty`.

## Where the merge-preserve landed: the **CLI** (not the worker)

`origin/main` already had `resolveMergedCapabilities` in `src/bus/stack-provisioning.ts` — the capability twin of `resolveMergedStacks`, added by C-791 — but it was **only wired into `cortex network join`** (`network-adapters.ts`). The `provision-stack register` path merge-preserved `stacks` via `resolveMergedStacks` but passed capabilities straight through (defaulting to `[]`).

This PR wires `resolveMergedCapabilities` into `provision-stack register`'s `doRegister`, mirroring the stacks merge **exactly**:
- same `isAddStack` / `registryPubkey` gating,
- shared **C-791 fail-closed verified read** (`fetchExistingStacks` requires a pinned registry pubkey and verifies the signature, else aborts),
- the command announces no caps (`announce: []`), so on the add-stack path the fetch+verify+**union** PRESERVES the existing set unchanged (`empty ∪ existing = existing`); on a first register there is nothing on record to preserve.

**Deploy implication:** the fix is entirely in the **root-side CLI** (`src/cli/...` + `src/bus/...`), not the network-registry worker. The registry worker source is untouched. → ship via **`arc upgrade Cortex`**, not `wrangler`.

## Merge semantics chosen

- **Union by capability id.** An existing id keeps its description and **gains** any new `networks[]` (so a cap announced into `metafactory` also gains `community-net` if re-announced there). On a same-id conflict the **new/later claim wins** (description updated; networks unioned). A brand-new id is appended. Unrelated existing caps are kept.
- **Bare register (empty announce) → existing set preserved verbatim.** This closes the footgun: a register whose claim carries no caps can no longer zero an existing non-empty set.
- **Shrink is out of scope for this command** — `provision-stack register` never announces caps, so it can only preserve/extend, never intentionally shrink. (Deliberate shrink, if ever needed, is a separate `network join`-style flow.)

## Store semantics intentionally unchanged

The route/store full-overwrite is **correct by design**: the CLI rebuilds the **complete** set (stacks AND now capabilities) and the root re-attests it, exactly as the stacks path already does. Merging in the store would diverge from the stacks model and break the complete-set contract, so `store.ts` is untouched (D1 + InMemory stay behaviorally identical, as their `:330` comment requires).

## Tests

`src/bus/__tests__/stack-provisioning.test.ts` (new `C-819` block, exercises the real registry route):
- **ACCEPTANCE** — bare add-stack (empty announce) preserves JC's caps; `community-net` roster still lists `jc` after standing up `jc/clawbox`.
- **REGRESSION GUARD** — the same re-register *without* the merge (empty caps claim) DOES wipe + evict (`jc → []`). Proves the merge is load-bearing.
- **union** — same-id new wins (networks unioned, description updated), unrelated caps kept, new id appended.
- **first register** (`isAddStack=false`) — announce passes through unchanged, no registry fetch.
- **error** — an unverifiable/unreachable read ABORTS rather than overwriting off a partial read.

`src/cli/cortex/commands/__tests__/provision-stack.test.ts` (new `C-819` test):
- CLI add-stack via `provision-stack register --principal-seed … --registry-pubkey …` PRESERVES caps + roster membership; both stacks present afterward (no regression to the C-787 stack merge).

## Verification

- `bunx tsc --noEmit` (root tsconfig — the CI gate): **0 errors**.
- `bun run lint:errors`: **clean**; full eslint on touched files: clean.
- `bun test` (touched + network-registry suites): **164 pass / 0 fail**.

Note: the network-registry strict tsconfig (`-p src/services/network-registry/tsconfig.json`, #679) shows 27 `Uint8Array<ArrayBufferLike>` lib-skew errors — these are **pre-existing on clean `origin/main`** (verified), not introduced here, not in the CI typecheck gate, and not in any file this PR touches.

Closes #819

🤖 Generated with [Claude Code](https://claude.com/claude-code)
