### PR TITLE
fix(network): C-820 — union capability networks[] on join (multi-network cap-roster membership)

### DIFF
--- a/src/bus/__tests__/stack-provisioning.test.ts
+++ b/src/bus/__tests__/stack-provisioning.test.ts
@@ -32,6 +32,7 @@ import {
   buildRegistrationClaim,
   fetchExistingStacks,
   resolveMergedCapabilities,
+  resolveCapabilitiesAfterLeave,
   fingerprintOf,
 } from "../stack-provisioning";
 import { nkeyToBase64Pubkey } from "../verify-signed-by-chain";
@@ -556,7 +557,7 @@ describe("C-819 — resolveMergedCapabilities preserves caps across re-register"
       registryUrl: "http://registry.test",
       registryPubkey,
       announce: [], // provision-stack register announces no caps
-      isAddStack: true,
+      mergeExisting: true,
       fetchImpl: registryFetch(env),
     });
     expect(caps.ok).toBe(true);
@@ -631,7 +632,7 @@ describe("C-819 — resolveMergedCapabilities preserves caps across re-register"
         { id: "tasks.review", description: "new desc", networks: ["net-c"] },
         { id: "tasks.fresh", networks: ["net-d"] },
       ],
-      isAddStack: true,
+      mergeExisting: true,
       fetchImpl: registryFetch(env),
     });
     expect(caps.ok).toBe(true);
@@ -647,7 +648,7 @@ describe("C-819 — resolveMergedCapabilities preserves caps across re-register"
     expect(byId.get("tasks.fresh")?.networks).toEqual(["net-d"]);
   });
 
-  test("first register (isAddStack=false) — announce passes through unchanged, no fetch", async () => {
+  test("first register (mergeExisting=false) — announce passes through unchanged, no fetch", async () => {
     // On a first register there is nothing on record to preserve; the merge is
     // a pure pass-through and never touches the registry (a failing fetch would
     // throw if it did).
@@ -658,7 +659,7 @@ describe("C-819 — resolveMergedCapabilities preserves caps across re-register"
       registryUrl: "http://registry.test",
       registryPubkey: "unused",
       announce: [{ id: "tasks.x", networks: ["net-z"] }],
-      isAddStack: false,
+      mergeExisting: false,
       fetchImpl: failingFetch,
     });
     expect(caps.ok).toBe(true);
@@ -674,12 +675,232 @@ describe("C-819 — resolveMergedCapabilities preserves caps across re-register"
       registryUrl: "http://registry.test",
       registryPubkey: "anything",
       announce: [],
-      isAddStack: true,
+      mergeExisting: true,
       fetchImpl: failingFetch,
     });
     expect(caps.ok).toBe(false);
     if (!caps.ok) {
       expect(caps.reason).toMatch(/connection refused|without dropping/i);
     }
+  });
+});
+
+describe("C-820 — capability networks[] union on join + set-difference on leave", () => {
+  let registryPubkey = "";
+  async function configuredEnv(): Promise<Env> {
+    resetStores();
+    const reg = await makeRegistryKey();
+    registryPubkey = reg.publicKey;
+    return {
+      REGISTRY_SIGNING_KEY: reg.signingKey,
+      REGISTRY_PUBLIC_KEY: reg.publicKey,
+      ENVIRONMENT: "test",
+    };
+  }
+
+  /** A fetch impl routed at the in-memory registry app for `env`. */
+  function registryFetch(env: Env): typeof globalThis.fetch {
+    return ((input: Request | string | URL, init?: RequestInit) => {
+      const req = input instanceof Request ? input : new Request(input, init);
+      return registryApp.fetch(req, env);
+    }) as typeof globalThis.fetch;
+  }
+
+  /**
+   * Register `jc` with a single capability `chat` already tagged into the
+   * `metafactory` network (the FIRST join's effect) — so the merge/leave helpers
+   * have a verified prior-network state to read.
+   */
+  async function seedJcInMetafactory(env: Env): Promise<{ root: ReturnType<typeof generateStackIdentity> }> {
+    const root = generateStackIdentity({ seedPath: join(freshDir(), "jc.nk") });
+    const body = await buildRegistrationClaim({
+      principalId: "jc",
+      material: root,
+      stacks: [{ stack_id: "jc/clawbox" }],
+      capabilities: [{ id: "chat.message", networks: ["metafactory"] }],
+    });
+    await registryApp.fetch(
+      new Request("http://registry.test/principals/jc/register", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      }),
+      env,
+    );
+    return { root };
+  }
+
+  test("JOIN UNION — a second-network announce ADDS to networks[] (metafactory ∪ community), no clobber, no dup", async () => {
+    const env = await configuredEnv();
+    await seedJcInMetafactory(env);
+
+    // The community join announces the SAME cap `chat` tagged community.
+    const res = await resolveMergedCapabilities({
+      principalId: "jc",
+      registryUrl: "http://registry.test",
+      registryPubkey,
+      announce: [{ id: "chat.message", networks: ["community"] }],
+      mergeExisting: true,
+      fetchImpl: registryFetch(env),
+    });
+
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    const chat = res.capabilities.find((c) => c.id === "chat.message");
+    expect(chat).toBeDefined();
+    // BOTH networks present — the prior metafactory tag survived the community join.
+    expect(new Set(chat!.networks)).toEqual(new Set(["metafactory", "community"]));
+    // No duplicate network ids.
+    expect(chat!.networks).toHaveLength(2);
+  });
+
+  test("JOIN UNION — re-announcing the SAME network is idempotent (no duplicate id)", async () => {
+    const env = await configuredEnv();
+    await seedJcInMetafactory(env);
+
+    const res = await resolveMergedCapabilities({
+      principalId: "jc",
+      registryUrl: "http://registry.test",
+      registryPubkey,
+      announce: [{ id: "chat.message", networks: ["metafactory"] }],
+      mergeExisting: true,
+      fetchImpl: registryFetch(env),
+    });
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    const chat = res.capabilities.find((c) => c.id === "chat.message");
+    expect(chat!.networks).toEqual(["metafactory"]);
+  });
+
+  test("JOIN UNION — mergeExisting:false uses the announce verbatim (first-register, nothing on record)", async () => {
+    const res = await resolveMergedCapabilities({
+      principalId: "jc",
+      registryUrl: "http://registry.test",
+      registryPubkey,
+      announce: [{ id: "chat.message", networks: ["community"] }],
+      mergeExisting: false,
+    });
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.capabilities).toEqual([{ id: "chat.message", networks: ["community"] }]);
+  });
+
+  test("JOIN UNION — absent principal (404) falls back to the announce (clean first registration)", async () => {
+    const env = await configuredEnv();
+    // nobody registered → 404 → absent → announce verbatim.
+    const res = await resolveMergedCapabilities({
+      principalId: "nobody",
+      registryUrl: "http://registry.test",
+      registryPubkey,
+      announce: [{ id: "chat.message", networks: ["metafactory"] }],
+      mergeExisting: true,
+      fetchImpl: registryFetch(env),
+    });
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.capabilities).toEqual([{ id: "chat.message", networks: ["metafactory"] }]);
+  });
+
+  test("JOIN UNION SECURITY — an unverifiable read ABORTS (never clobbers off a partial read)", async () => {
+    const failingFetch = (() =>
+      Promise.reject(new Error("connection refused"))) as unknown as typeof globalThis.fetch;
+    const res = await resolveMergedCapabilities({
+      principalId: "jc",
+      registryUrl: "http://registry.test",
+      registryPubkey: "anything",
+      announce: [{ id: "chat.message", networks: ["community"] }],
+      mergeExisting: true,
+      fetchImpl: failingFetch,
+    });
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.reason).toMatch(/connection refused/);
+  });
+
+  test("LEAVE SET-DIFF — leaving community removes ONLY community, metafactory survives", async () => {
+    const env = await configuredEnv();
+    // Seed jc with `chat` tagged into BOTH networks (the post-union state).
+    const root = generateStackIdentity({ seedPath: join(freshDir(), "jc.nk") });
+    const body = await buildRegistrationClaim({
+      principalId: "jc",
+      material: root,
+      stacks: [{ stack_id: "jc/clawbox" }],
+      capabilities: [{ id: "chat.message", networks: ["metafactory", "community"] }],
+    });
+    await registryApp.fetch(
+      new Request("http://registry.test/principals/jc/register", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      }),
+      env,
+    );
+
+    const res = await resolveCapabilitiesAfterLeave({
+      principalId: "jc",
+      registryUrl: "http://registry.test",
+      registryPubkey,
+      networkId: "community",
+      fetchImpl: registryFetch(env),
+    });
+    expect(res.ok).toBe(true);
+    if (!res.ok || !res.present) {
+      throw new Error("expected present capability set");
+    }
+    const chat = res.capabilities.find((c) => c.id === "chat.message");
+    expect(chat).toBeDefined();
+    // Only community removed; metafactory remains.
+    expect(chat!.networks).toEqual(["metafactory"]);
+  });
+
+  test("LEAVE SET-DIFF — leaving the LAST network drops the now-empty networks[] key (cap kept)", async () => {
+    const env = await configuredEnv();
+    await seedJcInMetafactory(env); // chat tagged metafactory only.
+
+    const res = await resolveCapabilitiesAfterLeave({
+      principalId: "jc",
+      registryUrl: "http://registry.test",
+      registryPubkey,
+      networkId: "metafactory",
+      fetchImpl: registryFetch(env),
+    });
+    expect(res.ok).toBe(true);
+    if (!res.ok || !res.present) {
+      throw new Error("expected present capability set");
+    }
+    const chat = res.capabilities.find((c) => c.id === "chat.message");
+    // The capability is KEPT (still announced on the public index), but its
+    // networks[] is gone (no roster membership) — the convention: drop the key.
+    expect(chat).toBeDefined();
+    expect(chat!.networks).toBeUndefined();
+  });
+
+  test("LEAVE SET-DIFF — absent principal is a clean no-op (present:false)", async () => {
+    const env = await configuredEnv();
+    const res = await resolveCapabilitiesAfterLeave({
+      principalId: "nobody",
+      registryUrl: "http://registry.test",
+      registryPubkey,
+      networkId: "community",
+      fetchImpl: registryFetch(env),
+    });
+    expect(res.ok).toBe(true);
+    if (!res.ok) return;
+    expect(res.present).toBe(false);
+  });
+
+  test("LEAVE SET-DIFF SECURITY — an unverifiable read ABORTS (never re-attests off a partial read)", async () => {
+    const failingFetch = (() =>
+      Promise.reject(new Error("connection refused"))) as unknown as typeof globalThis.fetch;
+    const res = await resolveCapabilitiesAfterLeave({
+      principalId: "jc",
+      registryUrl: "http://registry.test",
+      registryPubkey: "anything",
+      networkId: "community",
+      fetchImpl: failingFetch,
+    });
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.reason).toMatch(/connection refused/);
   });
 });

--- a/src/bus/stack-provisioning.ts
+++ b/src/bus/stack-provisioning.ts
@@ -890,11 +890,19 @@ export interface ResolveMergedCapabilitiesOptions {
    */
   readonly announce: ClaimCapability[];
   /**
-   * `true` when the principal already exists (add-stack / re-announce). Triggers
-   * the fetch+merge so the full-overwrite route preserves prior-network caps.
-   * `false` for a first registration (nothing on record to preserve).
+   * C-820 — `true` when the merge must read the principal's CURRENT registered
+   * capability set and union the announce into it (preserving prior-network
+   * `networks[]` tags). The federated `cortex network join` register step passes
+   * `true` UNCONDITIONALLY — NOT gated on `--principal-seed`/add-stack — because
+   * a plain re-join into a SECOND network (no root seed) must STILL union, or the
+   * full-overwrite register clobbers the first network's tag and evicts the
+   * principal from its roster (the #820 footgun: re-joining `metafactory` then
+   * `community` left caps `community`-only). The `absent` (404) branch handles a
+   * genuine first registration cleanly — there is nothing on record to preserve,
+   * so the announce is used verbatim. `false` skips the read entirely (a first
+   * register that KNOWS it carries the complete intended set).
    */
-  readonly isAddStack: boolean;
+  readonly mergeExisting: boolean;
   /** Injected fetch (tests). Defaults to global fetch. @internal */
   readonly fetchImpl?: typeof globalThis.fetch;
 }
@@ -918,14 +926,16 @@ function unionNetworks(a: string[] | undefined, b: string[] | undefined): string
  * silently evict meta-factory from the metafactory network roster (roster
  * membership is implicit via `capability.networks[]`).
  *
- * First registration (`isAddStack === false`): just the announce — nothing on
- * record to preserve.
+ * No-merge (`mergeExisting === false`): just the announce — the caller knows it
+ * carries the complete intended set, nothing on record to preserve.
  *
- * Add-stack/re-announce (`isAddStack === true`): FETCH the (verified) existing
- * capability set and union the announce in: an existing capability id keeps its
- * description and gains any new `networks[]` (so a cap already announced into
- * `metafactory` ALSO gains `community-net` if re-announced there); a new id is
- * appended. The principal's prior-network roster membership therefore survives.
+ * Merge (`mergeExisting === true`): FETCH the (verified) existing capability set
+ * and union the announce in: an existing capability id keeps its description and
+ * gains any new `networks[]` (so a cap already announced into `metafactory` ALSO
+ * gains `community` if re-announced there — C-820); a new id is appended. The
+ * principal's prior-network roster membership therefore survives. The federated
+ * join sets this UNCONDITIONALLY (not only on `--principal-seed`/add-stack), so
+ * a plain second-network re-join unions rather than clobbers (#820).
  *
  * Failure handling mirrors {@link resolveMergedStacks}: `absent` → just the
  * announce (no record yet); `error` (unreachable / UNVERIFIED read) → ABORT
@@ -934,7 +944,7 @@ function unionNetworks(a: string[] | undefined, b: string[] | undefined): string
 export async function resolveMergedCapabilities(
   opts: ResolveMergedCapabilitiesOptions,
 ): Promise<{ ok: true; capabilities: ClaimCapability[] } | { ok: false; reason: string }> {
-  if (!opts.isAddStack) {
+  if (!opts.mergeExisting) {
     return { ok: true, capabilities: opts.announce };
   }
 
@@ -982,6 +992,91 @@ export async function resolveMergedCapabilities(
     }
   }
   return { ok: true, capabilities: merged };
+}
+
+export interface ResolveCapabilitiesAfterLeaveOptions {
+  /** The principal whose capabilities are being re-tagged on leave. */
+  readonly principalId: string;
+  /** Registry base URL (for the existing-capabilities fetch). */
+  readonly registryUrl: string;
+  /** C-791 (security) — pinned registry pubkey; the read is verified or fails closed. */
+  readonly registryPubkey?: string;
+  /** The network id being left — removed from each capability's `networks[]`. */
+  readonly networkId: string;
+  /** Injected fetch (tests). Defaults to global fetch. @internal */
+  readonly fetchImpl?: typeof globalThis.fetch;
+}
+
+/**
+ * C-820 (leave symmetry) — compute the principal's capability set AFTER leaving
+ * `networkId`: the exact inverse of {@link resolveMergedCapabilities}'s union.
+ *
+ * FETCH the (verified) existing capability set and SET-DIFFERENCE `networkId`
+ * out of each capability's `networks[]`, leaving the OTHER network tags intact
+ * (so `leave community` removes only `community`, `metafactory` survives — the
+ * #820 acceptance criterion). A capability that ends with an EMPTY `networks[]`
+ * keeps its membership dropped only for THIS network: the convention is to drop
+ * the now-empty `networks` key (omitting it, matching how the merge omits an
+ * absent tag) rather than wiping the capability itself — the cap stays announced
+ * on the principal's public index, just no longer rostered in any network.
+ *
+ * The result is the COMPLETE intended capability set, ready to re-attest through
+ * the full-overwrite register route (so this composes with #819's registry
+ * merge-preserve: we carry the whole set, never relying on overwrite-vs-merge).
+ *
+ * Failure handling mirrors {@link resolveMergedCapabilities}:
+ *   - `absent` (404) → the principal has no record / no caps; nothing to retag.
+ *     Returns `{ present: false }` so the caller skips the registry re-attest.
+ *   - `error` (unreachable / UNVERIFIED read) → ABORT. We never re-attest a
+ *     capability set off an untrusted/partial read (that would risk dropping
+ *     unrelated caps — the same data-loss class C-791 guards against).
+ */
+export async function resolveCapabilitiesAfterLeave(
+  opts: ResolveCapabilitiesAfterLeaveOptions,
+): Promise<
+  | { ok: true; present: false }
+  | { ok: true; present: true; capabilities: ClaimCapability[] }
+  | { ok: false; reason: string }
+> {
+  let existing: FetchExistingStacksResult;
+  try {
+    existing = await fetchExistingStacks({
+      registryUrl: opts.registryUrl,
+      principalId: opts.principalId,
+      ...(opts.registryPubkey !== undefined && { registryPubkey: opts.registryPubkey }),
+      ...(opts.fetchImpl !== undefined && { fetchImpl: opts.fetchImpl }),
+    });
+  } catch (err) {
+    return {
+      ok: false,
+      reason: `failed to fetch existing capabilities for leave-retag: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+
+  if (existing.kind === "error") {
+    return {
+      ok: false,
+      reason:
+        `cannot retag capabilities on leave without risking dropping existing ones: ${existing.reason}. ` +
+        `Refusing to re-attest the capability set off a partial/unverified read.`,
+    };
+  }
+  if (existing.kind === "absent") {
+    // No record — nothing to retag. The caller skips the registry re-attest.
+    return { ok: true, present: false };
+  }
+
+  // present — drop `networkId` from each capability's `networks[]` (set-diff),
+  // omitting an emptied `networks` key entirely (the merge-side convention).
+  const retagged: ClaimCapability[] = existing.capabilities.map((c) => {
+    const kept = (c.networks ?? []).filter((n) => n !== opts.networkId);
+    return {
+      id: c.id,
+      ...(c.description !== undefined && { description: c.description }),
+      ...(kept.length > 0 && { networks: kept }),
+    };
+  });
+  return { ok: true, present: true, capabilities: retagged };
 }
 
 /**

--- a/src/cli/cortex/commands/__tests__/network-adapters.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-adapters.test.ts
@@ -809,7 +809,20 @@ describe("#762 registerStack announces capabilities into the network", () => {
   ): Promise<void> {
     const real = globalThis.fetch;
     const capture: { last?: CapturedClaim } = {};
-    globalThis.fetch = (async (_url: string, init?: RequestInit) => {
+    globalThis.fetch = (async (url: string | URL | Request, init?: RequestInit) => {
+      const method =
+        url instanceof Request ? url.method : (init?.method ?? "GET");
+      // C-820 — registerStack now does a GET merge-read (union the announce into
+      // the principal's existing caps) BEFORE the POST. These tests model a
+      // FIRST registration with nothing on record, so the GET returns 404
+      // (absent) → the union falls back to the announce verbatim, exactly the
+      // shape these tests assert on the captured POST.
+      if (method === "GET") {
+        return new Response(JSON.stringify({ error: "not_found" }), {
+          status: 404,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
       // registerStackIdentity always sends a JSON string body — parse it.
       const body = typeof init?.body === "string" ? init.body : "";
       capture.last = JSON.parse(body) as CapturedClaim;

--- a/src/cli/cortex/commands/__tests__/network-derive.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-derive.test.ts
@@ -379,7 +379,33 @@ describe("deriveLeaveInputs", () => {
       natsConfigPath: "~/.config/nats/local.conf",
       plistPath: "~/Library/LaunchAgents/nats.plist",
       platform: "darwin",
+      // C-820 — leave now ALSO resolves the registry coordinates + seed so it can
+      // retag the principal's capabilities (the inverse of join's union).
+      registryUrl: "https://registry.meta-factory.ai",
+      registryPubkey: "A".repeat(43) + "=",
+      seedPath: "~/.config/nats/cortex.nk",
     });
+  });
+
+  test("C-820 — registry/seed are OPTIONAL: leave still derives when they're absent", () => {
+    // A config with NO registry block + NO seed: leave's PRIMARY effect (local
+    // teardown) must still derive; the registry retag is simply skipped later.
+    const noRegistry = loaded({
+      principal: { id: "jc" },
+      stack: {
+        id: "jc/clawbox",
+        nats_infra: {
+          config_path: "~/.config/nats/local.conf",
+          plist_path: "~/Library/LaunchAgents/nats.plist",
+        },
+      },
+      policy: { principals: [], roles: [], federated: { networks: [] } },
+    });
+    const res = deriveLeaveInputs({}, "/cfg", reader(noRegistry), "darwin");
+    expect(res.ok).toBe(true);
+    expect(res.inputs?.registryUrl).toBeUndefined();
+    expect(res.inputs?.seedPath).toBeUndefined();
+    expect(res.inputs?.principal).toBe("jc");
   });
 
   test("flag overrides win", () => {

--- a/src/cli/cortex/commands/__tests__/network-lib.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-lib.test.ts
@@ -115,12 +115,16 @@ interface Recorder {
   bindChecks: string[];
   /** #799 — bind-mode resolutions: the (account, hasCreds) pairs queried. */
   bindModeChecks: { account: string | undefined; hasCreds: boolean }[];
+  /** C-820 — network ids the leave path asked the registry to deregister from. */
+  deregistered: string[];
 }
 
 function makeFakes(opts: {
   fetch?: NetworkFetchResult<{ descriptor: NetworkDescriptor; roster: NetworkRosterResult }>;
   cached?: { descriptor: NetworkDescriptor; roster: NetworkRosterResult };
   registerOk?: boolean;
+  /** C-820 — outcome of the leave-side registry deregister (default: ok). */
+  deregisterOk?: boolean;
   restartOk?: boolean;
   /** #757 — make the nats-server restart fail (default: ok). */
   natsRestartOk?: boolean;
@@ -153,6 +157,7 @@ function makeFakes(opts: {
     warnings: [],
     bindChecks: [],
     bindModeChecks: [],
+    deregistered: [],
   };
   const storeRef = { networks: opts.initialNetworks ?? [] };
   const leafFilesPresent = new Set<string>(
@@ -176,6 +181,12 @@ function makeFakes(opts: {
     },
     loadCached(_id) {
       return opts.cached;
+    },
+    async deregisterFromNetwork(networkId) {
+      rec.deregistered.push(networkId);
+      return opts.deregisterOk === false
+        ? { ok: false, reason: "registry unreachable for retag" }
+        : { ok: true, note: "retagged" };
     },
   };
 
@@ -862,6 +873,44 @@ describe("leave", () => {
     expect(rec.removes.length).toBe(0);
     expect(rec.restarts).toBe(0);
     expect(storeRef.networks.length).toBe(0);
+    // C-820 — a no-op leave never touches the registry.
+    expect(rec.deregistered.length).toBe(0);
+  });
+
+  test("C-820 — leave deregisters the network from the registry cap roster (symmetry with join's union)", async () => {
+    const { ports, rec, storeRef } = makeFakes({
+      initialNetworks: [joinedNetwork("metafactory"), joinedNetwork("community")],
+    });
+    const res = await leaveNetwork("community", ports);
+
+    expect(res.ok).toBe(true);
+    // Local teardown still happened.
+    expect(storeRef.networks.map((n) => n.id)).toEqual(["metafactory"]);
+    // The registry was asked to deregister EXACTLY the left network.
+    expect(rec.deregistered).toEqual(["community"]);
+    // The step log records the deregister.
+    expect(
+      res.steps.some((s) => s.includes("deregistered capabilities") && s.includes("community")),
+    ).toBe(true);
+    // No warning on the happy path.
+    expect(res.warnings ?? []).toHaveLength(0);
+  });
+
+  test("C-820 — a registry deregister FAILURE is non-fatal: local leave still ok, surfaced as a warning", async () => {
+    const { ports, rec, storeRef } = makeFakes({
+      initialNetworks: [joinedNetwork("community")],
+      deregisterOk: false,
+    });
+    const res = await leaveNetwork("community", ports);
+
+    // The LOCAL leave succeeded despite the registry retag failing.
+    expect(res.ok).toBe(true);
+    expect(storeRef.networks.length).toBe(0);
+    expect(rec.removes).toEqual(["community"]);
+    expect(rec.restarts).toBe(1);
+    // The failure is surfaced as a warning (re-runnable), not a hard failure.
+    expect(rec.deregistered).toEqual(["community"]);
+    expect((res.warnings ?? []).some((w) => w.includes("deregister-from-network") && w.includes("community"))).toBe(true);
   });
 });
 

--- a/src/cli/cortex/commands/network-adapters.ts
+++ b/src/cli/cortex/commands/network-adapters.ts
@@ -59,6 +59,7 @@ import {
   registerStackIdentity,
   resolveMergedStacks,
   resolveMergedCapabilities,
+  resolveCapabilitiesAfterLeave,
   isStackRegistered,
   type StackIdentityMaterial,
   type ClaimCapability,
@@ -221,6 +222,18 @@ async function registerWithCapabilities(
    * the join proceeds rather than skipping (see {@link isStackRegistered}).
    */
   allowIdempotentSkip = false,
+  /**
+   * C-820 — union the announced capabilities into the principal's CURRENT
+   * registered set (preserving prior-network `networks[]` tags) instead of
+   * sending the announce verbatim. The federated `registerStack` passes `true`
+   * UNCONDITIONALLY (decoupled from `--principal-seed`/add-stack): a plain
+   * re-join into a SECOND network must still union or the full-overwrite
+   * register clobbers the first network's tag and evicts the principal from its
+   * roster (#820). The public-index announce/deregister path passes the default
+   * `false` — it intentionally REPLACES the advertised cap set (the whole point
+   * of `deregisterCapabilities` is to shrink it to empty), so it must NOT union.
+   */
+  mergeExistingCaps = false,
 ): Promise<{ ok: true; note: string } | { ok: false; reason: string }> {
   const url = cfg.registryUrl ?? "";
   const registryPubkey = cfg.registryPubkey;
@@ -278,15 +291,18 @@ async function registerWithCapabilities(
   });
   if (!stacksRes.ok) return { ok: false, reason: stacksRes.reason };
 
-  // MAJOR 2 — merge the announced capabilities into the principal's existing
-  // set so the full-overwrite register does not drop prior-network caps (which
-  // would evict those networks from the principal's roster membership).
+  // MAJOR 2 / C-820 — merge the announced capabilities into the principal's
+  // existing set so the full-overwrite register does not drop prior-network caps
+  // (which would evict those networks from the principal's roster membership).
+  // `mergeExistingCaps` is decoupled from `isAddStack`: the federated join always
+  // unions (so a plain second-network re-join accumulates rather than clobbers,
+  // #820), even without a root seed.
   const capsRes = await resolveMergedCapabilities({
     principalId: cfg.principalId,
     registryUrl: url,
     ...(registryPubkey !== undefined && { registryPubkey }),
     announce: capabilities,
-    isAddStack,
+    mergeExisting: mergeExistingCaps,
   });
   if (!capsRes.ok) return { ok: false, reason: capsRes.reason };
 
@@ -338,7 +354,11 @@ function buildRegistryPort(cfg: LivePortsConfig): NetworkRegistryPort {
       // C-791 — federated register: enable the idempotency skip (a re-run or a
       // join-after-provision-stack-register converges instead of 409-ing) and
       // honour the optional root seed (root-signed add-stack for a 2nd stack).
-      return registerWithCapabilities(cfg, announced, true);
+      // C-820 — UNION the announced caps into the principal's existing set
+      // (4th arg `true`), decoupled from the root seed: a plain re-join into a
+      // SECOND network must accumulate `networks[]` (metafactory ∪ community),
+      // not clobber the prior tag and evict the principal from that roster.
+      return registerWithCapabilities(cfg, announced, true, true);
     },
     fetchVerified(networkId) {
       // S1's fetchAndCache returns { descriptor, roster } on ok and refreshes
@@ -347,6 +367,39 @@ function buildRegistryPort(cfg: LivePortsConfig): NetworkRegistryPort {
     },
     loadCached(networkId) {
       return client.loadCached(networkId);
+    },
+    async deregisterFromNetwork(networkId) {
+      // C-820 (leave symmetry) — remove ONLY `networkId` from each capability's
+      // registry `networks[]` (set-difference), re-attesting the reduced set so
+      // the principal exits this ONE network's roster while staying in the
+      // others. A registry control-plane POST, never a `federated.*` wire
+      // envelope (the network name never goes on the bus). Never throws.
+      //
+      // SKIP cleanly (a `note`, not an error/warning) when the registry can't be
+      // signed-to: no registry URL, or no seed to sign the re-attestation. Leave
+      // is a LOCAL teardown first; a stack with no configured registry/seed just
+      // has no registry roster to exit, so this is a no-op, not a failure.
+      if (url === "" || cfg.seedPath === undefined || cfg.seedPath === "") {
+        return {
+          ok: true,
+          note: "no registry url/seed configured — skipped registry cap retag (local leave only)",
+        };
+      }
+      const retag = await resolveCapabilitiesAfterLeave({
+        principalId: cfg.principalId,
+        registryUrl: url,
+        ...(cfg.registryPubkey !== undefined && { registryPubkey: cfg.registryPubkey }),
+        networkId,
+      });
+      if (!retag.ok) return { ok: false, reason: retag.reason };
+      if (!retag.present) {
+        // No principal record / nothing to retag — a clean no-op.
+        return { ok: true, note: "no registry capability record — nothing to retag" };
+      }
+      // Re-attest the COMPLETE reduced set through the full-overwrite register
+      // route. `mergeExistingCaps:false` — we already computed the exact intended
+      // set (the union-then-subtract), so we must NOT re-union it back in.
+      return registerWithCapabilities(cfg, retag.capabilities, true, false);
     },
   };
 }

--- a/src/cli/cortex/commands/network-derive.ts
+++ b/src/cli/cortex/commands/network-derive.ts
@@ -95,6 +95,18 @@ export interface DerivedLeaveInputs {
   unitPath?: string;
   /** #763 — the resolved platform. */
   platform: ServicePlatform;
+  /**
+   * C-820 — registry coordinates for the leave-side cap retag (the inverse of
+   * join's union). All OPTIONAL: leave's PRIMARY effect is the LOCAL teardown,
+   * which must succeed even when the registry can't be resolved (offline / no
+   * registry configured). When all three resolve, `leave` also retags the
+   * principal's registry capabilities to drop this network; when any is missing,
+   * the registry deregister is skipped (the local leave still completes, with a
+   * warning) rather than failing the whole command.
+   */
+  registryUrl?: string;
+  registryPubkey?: string;
+  seedPath?: string;
 }
 
 /** Flag overrides — any field present on the CLI wins over config/convention. */
@@ -383,7 +395,17 @@ export function deriveJoinInputs(
  * include + plist). Same override-then-config-then-convention precedence.
  */
 export function deriveLeaveInputs(
-  overrides: Pick<JoinOverrides, "principal" | "stack" | "natsConfigPath" | "plistPath" | "unitPath">,
+  overrides: Pick<
+    JoinOverrides,
+    | "principal"
+    | "stack"
+    | "natsConfigPath"
+    | "plistPath"
+    | "unitPath"
+    | "registryUrl"
+    | "registryPubkey"
+    | "seedPath"
+  >,
   configPath: string,
   load: ConfigReader,
   platform: ServicePlatform = defaultPlatform(),
@@ -415,6 +437,15 @@ export function deriveLeaveInputs(
   );
   if (!descriptor.ok) return fail(descriptor.reason);
 
+  // C-820 — registry coordinates for the leave-side cap retag, resolved the
+  // SAME way join does (flag wins, else policy.federated.registry / stack seed).
+  // All OPTIONAL: an unresolved registry/seed does NOT fail leave — the local
+  // teardown still runs and the registry retag is skipped with a warning.
+  const registry = cfg.policy?.federated?.registry;
+  const registryUrl = overrides.registryUrl ?? registry?.url;
+  const registryPubkey = overrides.registryPubkey ?? registry?.pubkey;
+  const seedPath = overrides.seedPath ?? cfg.stack?.nkey_seed_path;
+
   return {
     ok: true,
     inputs: {
@@ -424,6 +455,9 @@ export function deriveLeaveInputs(
       ...(descriptor.plistPath !== undefined && { plistPath: descriptor.plistPath }),
       ...(descriptor.unitPath !== undefined && { unitPath: descriptor.unitPath }),
       platform: descriptor.platform,
+      ...(registryUrl !== undefined && registryUrl !== "" && { registryUrl }),
+      ...(registryPubkey !== undefined && registryPubkey !== "" && { registryPubkey }),
+      ...(seedPath !== undefined && seedPath !== "" && { seedPath }),
     },
   };
 }

--- a/src/cli/cortex/commands/network-lib.ts
+++ b/src/cli/cortex/commands/network-lib.ts
@@ -104,6 +104,13 @@ export interface LeaveResult {
   notJoined?: boolean;
   /** Networks still joined after leave (for plist teardown decision). */
   remaining?: string[];
+  /**
+   * C-820 — non-fatal warnings surfaced during leave. A registry
+   * deregister-from-network failure lands here (and in {@link steps}): the LOCAL
+   * teardown succeeded, but the principal's registry cap tags were not retagged,
+   * so the principal must re-run when the registry is reachable.
+   */
+  warnings?: string[];
 }
 
 export interface StatusResult {
@@ -466,6 +473,30 @@ export async function leaveNetwork(
   }
 
   const remaining = existing.filter((n) => n.id !== networkId);
+  const warnings: string[] = [];
+
+  // C-820 (leave symmetry) — BEFORE the local teardown, remove `networkId` from
+  // each capability's registry `networks[]` (set-difference) so the principal
+  // exits this ONE network's roster while staying in the others. This is the
+  // inverse of join's union: join tags caps with the network on the registry,
+  // leave un-tags them. A registry deregister FAILURE is NON-FATAL — the local
+  // teardown still proceeds (the principal's bus must come down regardless), and
+  // the failure is surfaced as a warning so it can be re-run when the registry
+  // is reachable. The leave still reports `ok` because the local effect (the
+  // one that keeps nats-server / cortex from talking to the left network)
+  // succeeded. A `not-wired` registry port (no registryUrl on leave) skips this.
+  const dereg = await ports.registry.deregisterFromNetwork(networkId);
+  if (dereg.ok) {
+    steps.push(`deregistered capabilities from network "${networkId}" roster (${dereg.note})`);
+  } else {
+    const warn =
+      `registry deregister-from-network for "${networkId}" failed (${dereg.reason}) — ` +
+      `the LOCAL leave completed, but the principal's capability tags were not retagged; ` +
+      `re-run \`cortex network leave ${networkId}\` when the registry is reachable to exit the roster.`;
+    warnings.push(warn);
+    steps.push(`WARN: ${warn}`);
+  }
+
   // The config rewrite, leaf-include delete, and plist edit hit the live
   // filesystem in `--apply`. As in join, a write failure must surface as a
   // `{ ok: false }` per contract, not an uncaught throw — and the step log
@@ -506,6 +537,7 @@ export async function leaveNetwork(
       steps,
       reason: `teardown write failed: ${err instanceof Error ? err.message : String(err)}`,
       remaining: remaining.map((n) => n.id),
+      ...(warnings.length > 0 && { warnings }),
     };
   }
 
@@ -516,11 +548,17 @@ export async function leaveNetwork(
       steps,
       reason: `config reverted but daemon restart failed: ${restart.reason}`,
       remaining: remaining.map((n) => n.id),
+      ...(warnings.length > 0 && { warnings }),
     };
   }
   steps.push("restarted stack daemon");
 
-  return { ok: true, steps, remaining: remaining.map((n) => n.id) };
+  return {
+    ok: true,
+    steps,
+    remaining: remaining.map((n) => n.id),
+    ...(warnings.length > 0 && { warnings }),
+  };
 }
 
 // =============================================================================

--- a/src/cli/cortex/commands/network-ports.ts
+++ b/src/cli/cortex/commands/network-ports.ts
@@ -106,6 +106,18 @@ export interface NetworkRegistryPort {
   loadCached(
     networkId: string,
   ): { descriptor: NetworkDescriptor; roster: NetworkRosterResult } | undefined;
+  /**
+   * C-820 (leave symmetry) — remove `networkId` from each of the principal's
+   * registered capabilities' `networks[]` (set-difference) and re-attest the
+   * reduced set, so `leave` exits this ONE network's roster while leaving the
+   * principal's OTHER network memberships intact (the inverse of `registerStack`'s
+   * union). A registry CONTROL-PLANE POST, never a `federated.*` wire envelope.
+   * Returns a log-safe note on success, or an error reason. A `note` may also
+   * report a clean no-op (no principal record / nothing to retag).
+   */
+  deregisterFromNetwork(
+    networkId: string,
+  ): Promise<{ ok: true; note: string } | { ok: false; reason: string }>;
 }
 
 /** Inputs to the leaf-include render — the trust boundary in one place. */

--- a/src/cli/cortex/commands/network.ts
+++ b/src/cli/cortex/commands/network.ts
@@ -505,6 +505,10 @@ async function runLeave(
         ...readOverride(flags, "--nats-config", "natsConfigPath"),
         ...readOverride(flags, "--plist", "plistPath"),
         ...readOverride(flags, "--unit", "unitPath"),
+        // C-820 — registry coordinates for the leave-side cap retag (optional).
+        ...readOverride(flags, "--registry-url", "registryUrl"),
+        ...readOverride(flags, "--registry-pubkey", "registryPubkey"),
+        ...readOverride(flags, "--seed-path", "seedPath"),
       },
       expandTilde(optionalValueFlag(flags, "--config") ?? DEFAULT_CONFIG_PATH),
       load,
@@ -533,6 +537,12 @@ async function runLeave(
     platform: inputs.platform,
     // #800 — locate the daemon service for the post-leave restart.
     cortexConfigPath: cortexConfigPathFromFlags(flags),
+    // C-820 — registry coordinates for the leave-side cap retag (the inverse of
+    // join's union). All optional: absent ⇒ the registry deregister is skipped
+    // (the local leave still completes, with a warning).
+    ...(inputs.registryUrl !== undefined && { registryUrl: inputs.registryUrl }),
+    ...(inputs.registryPubkey !== undefined && { registryPubkey: inputs.registryPubkey }),
+    ...(inputs.seedPath !== undefined && { seedPath: inputs.seedPath }),
   };
   const ports = applyRes.apply ? buildLivePorts(cfg) : buildDryRunPorts(cfg);
 

--- a/src/cli/cortex/commands/provision-stack.ts
+++ b/src/cli/cortex/commands/provision-stack.ts
@@ -392,16 +392,20 @@ async function doRegister(
   // `cortex network join` is for), so its `announce` is empty: on the add-stack
   // path the fetch+verify+union therefore PRESERVES the principal's existing
   // caps unchanged (empty ∪ existing = existing), and on a first register there
-  // is nothing on record to preserve. Same `isAddStack`/`registryPubkey` gating
-  // as the stacks merge keeps the two consistent (and shares the C-791
-  // fail-closed verified read). A register that genuinely intends to SHRINK
-  // caps is out of scope for this command — it never announces caps at all.
+  // is nothing on record to preserve. `mergeExisting: isAddStack` keeps this
+  // consistent with the stacks merge (and shares the C-791 fail-closed verified
+  // read): merge only when adding to an already-registered principal (C-820
+  // renamed the field from `isAddStack`; here the merge IS gated on add-stack —
+  // provision-stack only preserves caps, it never re-announces network tags, so
+  // unlike the federated join it has no reason to fetch+merge on a first
+  // register). A register that genuinely intends to SHRINK caps is out of scope
+  // for this command — it never announces caps at all.
   const capsRes = await resolveMergedCapabilities({
     principalId,
     registryUrl,
     ...(registryPubkey !== undefined && { registryPubkey }),
     announce: [],
-    isAddStack,
+    mergeExisting: isAddStack,
   });
   if (!capsRes.ok) return { ok: false, reason: capsRes.reason };
 


### PR DESCRIPTION
## What

Fixes #820 — `cortex network join` **overwrote** a capability's `networks[]` tag instead of **unioning** it, so a principal could not be capability-rostered in two networks via sequential joins. Each join clobbered the prior tag, evicting the principal from the earlier network's cap-roster.

## Root cause (verified against `origin/main`)

The join's register step (`network-adapters.ts` `registerStack`) tags each announced cap with `networks: [networkId]` and hands it to `resolveMergedCapabilities`. But that merge **only unioned** when `isAddStack === true` — i.e. when a `--principal-seed` (root seed) was threaded for a multi-stack add. A **plain re-join of the same stack into a second network** (the live repro) takes the `isAddStack === false` branch, which returned the announce **verbatim** → the registry's full-overwrite register dropped the first network's tag.

Live repro: re-joining `metafactory` then `community` left JC's caps `community`-only, dropping them from the metafactory cap-roster.

Separately, `leaveNetwork` had **no registry symmetry** at all — it only edited the local `policy.federated.networks[]` + leaf files, never un-tagging the capability at the registry, so a leave left the principal in the network roster.

## The fix

**Join — union (unconditional):**
- Decouple cap-merging from stack-add semantics: rename the `resolveMergedCapabilities` gate `isAddStack` → `mergeExisting`, and have the federated `registerStack` pass it **unconditionally** (4th arg of `registerWithCapabilities`).
- Every federated join now reads the principal's current **verified** cap set and unions the announced `networks[]` per capability id (dedup). Sequential joins accumulate (`metafactory ∪ community`).
- The `absent` (404) branch keeps a genuine first registration clean. The C-791 fail-closed read (no pinned pubkey / unverified assertion) still **aborts** rather than clobbering off a partial read.

**Leave — set-difference (symmetry):**
- New `resolveCapabilitiesAfterLeave`: fetch the verified cap set, set-difference `networkId` out of each cap's `networks[]` (others intact), dropping a now-empty `networks` key (cap kept, just no longer rostered — per the merge-side convention).
- New `NetworkRegistryPort.deregisterFromNetwork` re-attests the **complete reduced set**. `leaveNetwork` calls it **before** local teardown; a registry failure is **non-fatal** (local leave still completes; surfaced as a warning + re-runnable). Registry coordinates + seed are threaded into the leave deriver/ports, **all optional** — an offline / no-registry leave skips the retag and still tears down locally.

## Exact write-site change

- **Join write site** — `src/cli/cortex/commands/network-adapters.ts` `registerStack`: `registerWithCapabilities(cfg, announced, true)` → `registerWithCapabilities(cfg, announced, true, /* mergeExistingCaps */ true)`. The new flag drives `resolveMergedCapabilities({ …, mergeExisting: true })` (was `isAddStack`), so the union runs on every join, not just `--principal-seed` add-stacks.
- **Leave path change** — `src/cli/cortex/commands/network-lib.ts` `leaveNetwork`: now calls `ports.registry.deregisterFromNetwork(networkId)` (new port method) before the local config/leaf teardown, which runs `resolveCapabilitiesAfterLeave` (set-difference) and re-registers the reduced set. Non-fatal on failure (warning).

## Relationship to #819 (sister fix — merge-preserve caps on register)

#819 makes the **registry** (`store.ts`) merge-preserve capabilities on register (registry-side). **This PR is independent of it and composes cleanly:** both the union and the leave-retag re-attest the **complete intended capability set** through the full-overwrite register route, so neither relies on the registry's overwrite-vs-merge behavior. #819's branch `fix/c-819-merge-preserve-caps` is **not yet pushed** (issue still open); no rebase coordination needed — the two touch different layers (`store.ts` vs CLI/bus claim-merge). When both land, the registry-side merge is belt-and-suspenders to this PR's complete-set re-attestation.

## Note (consistent-with-existing behavior)

`buildRegistryPort` is not `mutate`-gated on `origin/main`, so dry-run `registerStack` already POSTs to the registry; the new `deregisterFromNetwork` follows the same convention (POSTs in dry-run too). The destructive effect is idempotent and registry-side; if a stricter dry-run posture is wanted, gating both register + deregister on `mutate` is a clean follow-up.

## Tests

`src/bus/__tests__/stack-provisioning.test.ts` (against the **real** registry route) + `network-lib.test.ts` + `network-derive.test.ts`:
- `join metafactory` then `join community` → cap tagged **both**, principal in **both** rosters.
- re-join same network → idempotent (no duplicate id).
- `leave community` → only `community` removed, `metafactory` remains.
- leave-last-network → empty `networks[]` key dropped, cap kept.
- fail-closed read aborts **both** join-union and leave-retag (never clobbers off a partial/unverified read).
- leave registry-deregister failure → non-fatal warning, local leave still ok.
- leave deriver resolves registry/seed (and stays ok when they're absent).

`bun run` (tsc) **0 errors**, `eslint` clean, full suite **5000 pass / 0 fail**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
