### PR TITLE
fix(network): join never renders a nats-crashing leaf config — operator-mode account-required + pre-flight + restart-rollback (closes #821)

### DIFF
--- a/src/cli/cortex/commands/__tests__/network-adapters.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-adapters.test.ts
@@ -786,6 +786,133 @@ describe("#757 nats-server restart port", () => {
 });
 
 // =============================================================================
+// #821 — live adapter: creds-existence pre-flight + leaf-state snapshot/restore
+// + the post-restart health probe. Temp dirs only; no real ~/.config/nats, no
+// real server, no real spawn.
+// =============================================================================
+
+describe("#821 live leaf-file pre-flight + rollback adapters", () => {
+  test("credsExist is true for a present file, false for a missing one", () => {
+    const dir = freshDir();
+    const conf = join(dir, "local.conf");
+    writeFileSync(conf, bareLocalConf(), "utf-8");
+    const credsPath = join(dir, "andreas.creds");
+    writeFileSync(credsPath, "-----BEGIN NATS USER JWT-----\n", "utf-8");
+
+    const ports = buildLivePorts(cfgWithConfig(conf));
+    expect(ports.leafFile.credsExist(credsPath)).toBe(true);
+    expect(ports.leafFile.credsExist(join(dir, "does-not-exist.creds"))).toBe(false);
+    // Empty path → false (never treat "" as present).
+    expect(ports.leafFile.credsExist("")).toBe(false);
+  });
+
+  test("snapshot → mutate → restore returns the leaf state to prior bytes", () => {
+    const dir = freshDir();
+    const conf = join(dir, "local.conf");
+    const original = bareLocalConf();
+    writeFileSync(conf, original, "utf-8");
+    const ports = buildLivePorts(cfgWithConfig(conf));
+
+    // Take the snapshot of the PRIOR state (no include file, base config present).
+    const snap = ports.leafFile.snapshotLeafState("metafactory");
+    expect(snap.includeFile).toBeUndefined();
+    expect(snap.natsConfig).toBe(original);
+
+    // Mutate: write the leaf include file + ensure the include directive.
+    ports.leafFile.write({
+      descriptor: brandVerified(descriptorForLeaf("metafactory")),
+      binding: {
+        credentials: "/Users/andreas/.config/nats/andreas.creds",
+        account: "AADPQ7M7LQZTKPNF5CTE7V4XKB2FUYPGKLWZVMW6VXCEEKH62BYKGBHX",
+      },
+    });
+    ports.leafFile.ensureInclude("metafactory");
+    expect(existsSync(join(dir, "leafnodes-metafactory.conf"))).toBe(true);
+    expect(readFileSync(conf, "utf-8")).toContain('include "leafnodes-metafactory.conf"');
+
+    // Roll back: the include file is removed (it didn't exist pre-join) and the
+    // base config is restored to the exact prior bytes.
+    ports.leafFile.restoreLeafState(snap);
+    expect(existsSync(join(dir, "leafnodes-metafactory.conf"))).toBe(false);
+    expect(readFileSync(conf, "utf-8")).toBe(original);
+  });
+
+  test("restore rewrites a pre-existing include file back to its prior bytes", () => {
+    const dir = freshDir();
+    const conf = join(dir, "local.conf");
+    writeFileSync(conf, bareLocalConf(), "utf-8");
+    const includePath = join(dir, "leafnodes-metafactory.conf");
+    const priorInclude = "leafnodes {\n  remotes: [ /* prior working remote */ ]\n}\n";
+    writeFileSync(includePath, priorInclude, "utf-8");
+    const ports = buildLivePorts(cfgWithConfig(conf));
+
+    const snap = ports.leafFile.snapshotLeafState("metafactory");
+    expect(snap.includeFile).toBe(priorInclude);
+
+    // Overwrite the include file (simulating the crashing join's write)...
+    writeFileSync(includePath, "leafnodes { remotes: [ /* BAD no-account */ ] }\n", "utf-8");
+    // ...then roll back — the prior working include bytes are restored.
+    ports.leafFile.restoreLeafState(snap);
+    expect(readFileSync(includePath, "utf-8")).toBe(priorInclude);
+  });
+
+  test("dry-run restoreLeafState is inert (writes nothing)", () => {
+    const dir = freshDir();
+    const conf = join(dir, "local.conf");
+    const original = bareLocalConf();
+    writeFileSync(conf, original, "utf-8");
+    const ports = buildDryRunPorts(cfgWithConfig(conf));
+    const snap = ports.leafFile.snapshotLeafState("metafactory");
+    // Mutate the file out-of-band, then call the dry-run restore — it must NOT
+    // touch disk (the file keeps the out-of-band content).
+    writeFileSync(conf, "mutated\n", "utf-8");
+    ports.leafFile.restoreLeafState(snap);
+    expect(readFileSync(conf, "utf-8")).toBe("mutated\n");
+  });
+
+  test("isHealthy probes the monitor and reports healthy on a 200", async () => {
+    // Stand up a tiny local server that answers /healthz 200.
+    const server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        return new URL(req.url).pathname === "/healthz"
+          ? new Response("ok", { status: 200 })
+          : new Response("not found", { status: 404 });
+      },
+    });
+    try {
+      const cfg: LivePortsConfig = {
+        ...cfgWithConfig("/x/local.conf"),
+        monitorUrl: `http://127.0.0.1:${(server.port ?? 0).toString()}`,
+      };
+      const ports = buildLivePorts(cfg);
+      const res = await ports.natsServer!.isHealthy();
+      expect(res.healthy).toBe(true);
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  test("isHealthy reports UNhealthy when the monitor is unreachable (server down)", async () => {
+    const cfg: LivePortsConfig = {
+      ...cfgWithConfig("/x/local.conf"),
+      // A port nothing is listening on → connection refused → unhealthy.
+      monitorUrl: "http://127.0.0.1:1",
+    };
+    const ports = buildLivePorts(cfg);
+    const res = await ports.natsServer!.isHealthy();
+    expect(res.healthy).toBe(false);
+    if (!res.healthy) expect(res.reason).toContain("unreachable");
+  });
+
+  test("dry-run isHealthy is trivially healthy (never probes)", async () => {
+    const ports = buildDryRunPorts(cfgWithConfig("/x/local.conf"));
+    const res = await ports.natsServer!.isHealthy();
+    expect(res.healthy).toBe(true);
+  });
+});
+
+// =============================================================================
 // #762 — federated registerStack() announces caps INTO the network (roster)
 // =============================================================================
 

--- a/src/cli/cortex/commands/__tests__/network-adapters.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-adapters.test.ts
@@ -938,6 +938,40 @@ describe("#821 live leaf-file pre-flight + rollback adapters", () => {
     expect(res.healthy).toBe(true);
   });
 
+  test("MAJOR: isHealthy TIMES OUT (healthy:false) when the monitor accepts but never responds", async () => {
+    // A nats-server that accepts the monitor TCP connection but HANGS (never
+    // sends a response) is exactly the deadlock the probe exists to catch. An
+    // unbounded fetch would hang joinNetwork forever; the probe must abort and
+    // report healthy:false within its timeout. The handler returns a Promise
+    // that never resolves → the connection is accepted, the response never comes.
+    const server = Bun.serve({
+      port: 0,
+      fetch() {
+        return new Promise<Response>(() => {
+          /* never resolves — simulate a hung monitor */
+        });
+      },
+    });
+    try {
+      const cfg: LivePortsConfig = {
+        ...cfgWithConfig("/x/local.conf"),
+        monitorUrl: `http://127.0.0.1:${(server.port ?? 0).toString()}`,
+        // Short timeout so the test asserts the bound without a real 5s wait.
+        healthProbeTimeoutMs: 250,
+      };
+      const ports = buildLivePorts(cfg);
+      const started = Date.now();
+      const res = await ports.natsServer!.isHealthy();
+      const elapsed = Date.now() - started;
+      expect(res.healthy).toBe(false);
+      if (!res.healthy) expect(res.reason.toLowerCase()).toContain("timed out");
+      // Resolved promptly via the abort — well under a multi-second hang.
+      expect(elapsed).toBeLessThan(3000);
+    } finally {
+      server.stop(true);
+    }
+  });
+
   test("MAJOR: isHealthy probes the bus's OWN monitor port DERIVED from the nats config (community :8224)", async () => {
     // Stand up a probe-target server, then write a nats config naming THAT port
     // via `http_port:` — with NO --monitor-url. The probe must derive + hit it.

--- a/src/cli/cortex/commands/__tests__/network-adapters.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-adapters.test.ts
@@ -806,17 +806,17 @@ describe("#821 live leaf-file pre-flight + rollback adapters", () => {
     expect(ports.leafFile.credsExist("")).toBe(false);
   });
 
-  test("snapshot → mutate → restore returns the leaf state to prior bytes", () => {
+  test("snapshot → mutate → restore reverts the include file + directive to prior state", () => {
     const dir = freshDir();
     const conf = join(dir, "local.conf");
     const original = bareLocalConf();
     writeFileSync(conf, original, "utf-8");
     const ports = buildLivePorts(cfgWithConfig(conf));
 
-    // Take the snapshot of the PRIOR state (no include file, base config present).
+    // Snapshot the PRIOR state: no include file, directive NOT present.
     const snap = ports.leafFile.snapshotLeafState("metafactory");
     expect(snap.includeFile).toBeUndefined();
-    expect(snap.natsConfig).toBe(original);
+    expect(snap.natsConfig).toBeUndefined(); // directive absent pre-join
 
     // Mutate: write the leaf include file + ensure the include directive.
     ports.leafFile.write({
@@ -831,16 +831,20 @@ describe("#821 live leaf-file pre-flight + rollback adapters", () => {
     expect(readFileSync(conf, "utf-8")).toContain('include "leafnodes-metafactory.conf"');
 
     // Roll back: the include file is removed (it didn't exist pre-join) and the
-    // base config is restored to the exact prior bytes.
+    // join-added directive is dropped — restoring the base config to its prior
+    // bytes WITHOUT ever deleting the base file.
     ports.leafFile.restoreLeafState(snap);
     expect(existsSync(join(dir, "leafnodes-metafactory.conf"))).toBe(false);
+    expect(existsSync(conf)).toBe(true); // base config NEVER deleted
     expect(readFileSync(conf, "utf-8")).toBe(original);
   });
 
-  test("restore rewrites a pre-existing include file back to its prior bytes", () => {
+  test("restore rewrites a pre-existing include file back to its prior bytes + keeps a pre-existing directive", () => {
     const dir = freshDir();
     const conf = join(dir, "local.conf");
-    writeFileSync(conf, bareLocalConf(), "utf-8");
+    // The base config ALREADY includes the directive (a prior working join).
+    const base = bareLocalConf() + 'include "leafnodes-metafactory.conf"\n';
+    writeFileSync(conf, base, "utf-8");
     const includePath = join(dir, "leafnodes-metafactory.conf");
     const priorInclude = "leafnodes {\n  remotes: [ /* prior working remote */ ]\n}\n";
     writeFileSync(includePath, priorInclude, "utf-8");
@@ -848,12 +852,35 @@ describe("#821 live leaf-file pre-flight + rollback adapters", () => {
 
     const snap = ports.leafFile.snapshotLeafState("metafactory");
     expect(snap.includeFile).toBe(priorInclude);
+    expect(snap.natsConfig).toBe("directive-present"); // directive WAS present
 
     // Overwrite the include file (simulating the crashing join's write)...
     writeFileSync(includePath, "leafnodes { remotes: [ /* BAD no-account */ ] }\n", "utf-8");
-    // ...then roll back — the prior working include bytes are restored.
+    // ...then roll back — the prior working include bytes are restored AND the
+    // pre-existing directive is kept (idempotent ensure).
     ports.leafFile.restoreLeafState(snap);
     expect(readFileSync(includePath, "utf-8")).toBe(priorInclude);
+    expect(readFileSync(conf, "utf-8")).toContain('include "leafnodes-metafactory.conf"');
+  });
+
+  test("NIT: restore NEVER deletes the base config, even when its prior snapshot had no directive", () => {
+    const dir = freshDir();
+    const conf = join(dir, "local.conf");
+    const original = bareLocalConf();
+    writeFileSync(conf, original, "utf-8");
+    const ports = buildLivePorts(cfgWithConfig(conf));
+
+    // Snapshot (no directive), then the join writes the include + directive...
+    const snap = ports.leafFile.snapshotLeafState("metafactory");
+    ports.leafFile.write({
+      descriptor: brandVerified(descriptorForLeaf("metafactory")),
+      binding: { credentials: "/x/andreas.creds", account: "AADPQ7M7LQZTKPNF5CTE7V4XKB2FUYPGKLWZVMW6VXCEEKH62BYKGBHX" },
+    });
+    ports.leafFile.ensureInclude("metafactory");
+    // ...rollback. The base config must still EXIST (only the directive dropped).
+    ports.leafFile.restoreLeafState(snap);
+    expect(existsSync(conf)).toBe(true);
+    expect(readFileSync(conf, "utf-8")).toBe(original);
   });
 
   test("dry-run restoreLeafState is inert (writes nothing)", () => {
@@ -909,6 +936,118 @@ describe("#821 live leaf-file pre-flight + rollback adapters", () => {
     const ports = buildDryRunPorts(cfgWithConfig("/x/local.conf"));
     const res = await ports.natsServer!.isHealthy();
     expect(res.healthy).toBe(true);
+  });
+
+  test("MAJOR: isHealthy probes the bus's OWN monitor port DERIVED from the nats config (community :8224)", async () => {
+    // Stand up a probe-target server, then write a nats config naming THAT port
+    // via `http_port:` — with NO --monitor-url. The probe must derive + hit it.
+    const server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        return new URL(req.url).pathname === "/healthz"
+          ? new Response("ok", { status: 200 })
+          : new Response("nf", { status: 404 });
+      },
+    });
+    try {
+      const dir = freshDir();
+      const conf = join(dir, "community.conf");
+      writeFileSync(
+        conf,
+        [
+          "operator: /x/operator.creds",
+          "system_account: ADSYSACCOUNT",
+          "port: 4224",
+          `http_port: ${(server.port ?? 0).toString()}`,
+          "",
+        ].join("\n"),
+        "utf-8",
+      );
+      // No monitorUrl flag → must derive the port from the config.
+      const ports = buildLivePorts(cfgWithConfig(conf));
+      const res = await ports.natsServer!.isHealthy();
+      expect(res.healthy).toBe(true);
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  test("MAJOR: explicit --monitor-url WINS over the config-derived port", async () => {
+    const server = Bun.serve({
+      port: 0,
+      fetch() {
+        return new Response("ok", { status: 200 });
+      },
+    });
+    try {
+      const dir = freshDir();
+      const conf = join(dir, "community.conf");
+      // Config says a DIFFERENT (dead) port; the flag must win.
+      writeFileSync(conf, ["http_port: 9", ""].join("\n"), "utf-8");
+      const cfg: LivePortsConfig = {
+        ...cfgWithConfig(conf),
+        monitorUrl: `http://127.0.0.1:${(server.port ?? 0).toString()}`,
+      };
+      const ports = buildLivePorts(cfg);
+      const res = await ports.natsServer!.isHealthy();
+      expect(res.healthy).toBe(true);
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  test("MAJOR-1: validateConfig SKIPS (ok) when nats-server is not on PATH (no block)", async () => {
+    // The live adapter shells out to `nats-server -t`; on a host without the
+    // binary it must SKIP the gate (return ok), never block the join. We can't
+    // guarantee nats-server is absent on CI, so assert the result is well-formed
+    // (ok:true when skipped/passed; ok:false only with a -t reason).
+    const dir = freshDir();
+    const conf = join(dir, "local.conf");
+    writeFileSync(conf, bareLocalConf(), "utf-8");
+    const ports = buildLivePorts(cfgWithConfig(conf));
+    const res = await ports.natsServer!.validateConfig();
+    if (!res.ok) {
+      expect(res.reason).toContain("nats-server");
+    } else {
+      expect(res.ok).toBe(true);
+    }
+  });
+
+  test("MAJOR-1: dry-run validateConfig is inert (ok, never spawns)", async () => {
+    const ports = buildDryRunPorts(cfgWithConfig("/x/local.conf"));
+    const res = await ports.natsServer!.validateConfig();
+    expect(res.ok).toBe(true);
+  });
+
+  test("NIT-1: credsExist rejects a directory, a 0-byte file, and a non-creds file", () => {
+    const dir = freshDir();
+    const conf = join(dir, "local.conf");
+    writeFileSync(conf, bareLocalConf(), "utf-8");
+    const ports = buildLivePorts(cfgWithConfig(conf));
+
+    // A directory at the creds path → not a usable creds file.
+    const asDir = join(dir, "creds-dir");
+    mkdirSync(asDir, { recursive: true });
+    expect(ports.leafFile.credsExist(asDir)).toBe(false);
+
+    // A 0-byte file → dormant trap, rejected.
+    const empty = join(dir, "empty.creds");
+    writeFileSync(empty, "", "utf-8");
+    expect(ports.leafFile.credsExist(empty)).toBe(false);
+
+    // A non-empty file WITHOUT the NATS creds marker → rejected.
+    const notCreds = join(dir, "random.creds");
+    writeFileSync(notCreds, "just some text\n", "utf-8");
+    expect(ports.leafFile.credsExist(notCreds)).toBe(false);
+
+    // A genuine creds file (carries the marker) → accepted.
+    const good = join(dir, "andreas.creds");
+    writeFileSync(
+      good,
+      "-----BEGIN NATS USER JWT-----\neyJ0...\n------END NATS USER JWT------\n",
+      "utf-8",
+    );
+    expect(ports.leafFile.credsExist(good)).toBe(true);
   });
 });
 

--- a/src/cli/cortex/commands/__tests__/network-lib.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-lib.test.ts
@@ -125,6 +125,8 @@ interface Recorder {
   restores: string[];
   /** #821 — count of nats-server health probes after restart. */
   healthProbes: number;
+  /** #821 MAJOR-1 — count of `nats-server -c <cfg> -t` validation gate runs. */
+  validateConfigs: number;
 }
 
 function makeFakes(opts: {
@@ -157,8 +159,16 @@ function makeFakes(opts: {
    * Default: healthy.
    */
   natsHealthy?: boolean;
-  /** #821 — make the rollback recovery restart ALSO fail (worst-case path). */
+  /** #821 — make the rollback recovery restart ALSO fail by EXIT CODE (worst-case). */
   recoveryRestartFails?: boolean;
+  /**
+   * #821 BLOCKER — model the recovery restart's HEALTH (post-restart probe).
+   * `false` = the recovery restart exits 0 but the server is still DOWN — must
+   * report failure, never "restored to prior state". Default: healthy.
+   */
+  recoveryHealthy?: boolean;
+  /** #821 MAJOR-1 — make the pre-restart `nats-server -t` syntax gate FAIL. */
+  validateConfigFails?: boolean;
 }): { ports: NetworkPorts; rec: Recorder; storeRef: { networks: PolicyFederatedNetwork[] } } {
   const rec: Recorder = {
     registered: 0,
@@ -180,6 +190,7 @@ function makeFakes(opts: {
     snapshots: [],
     restores: [],
     healthProbes: 0,
+    validateConfigs: 0,
   };
   const storeRef = { networks: opts.initialNetworks ?? [] };
   const leafFilesPresent = new Set<string>(
@@ -325,6 +336,14 @@ function makeFakes(opts: {
   };
 
   const natsServer: NatsServerPort = {
+    async validateConfig() {
+      rec.validateConfigs++;
+      // #821 MAJOR-1 — default: the -t syntax gate passes. A test opts into a
+      // -t failure via `validateConfigFails: true`.
+      return opts.validateConfigFails === true
+        ? { ok: false, reason: "nats-server -t: parse error near line 12" }
+        : { ok: true };
+    },
     async restart() {
       rec.natsRestarts++;
       rec.restartOrder.push("nats");
@@ -343,11 +362,23 @@ function makeFakes(opts: {
     },
     async isHealthy() {
       rec.healthProbes++;
-      // #821 — default: healthy. `natsHealthy: false` models the community case
-      // (restart exited 0 but the server then crashed on the bad leaf).
-      return opts.natsHealthy === false
-        ? { healthy: false, reason: "monitor port 8224 not listening" }
-        : { healthy: true };
+      // #821 — health is modelled PER PROBE so a test can make the FIRST restart
+      // come up down (triggering rollback) and the RECOVERY restart ALSO come up
+      // down (the BLOCKER case: a recovery that exits 0 but leaves the bus DOWN
+      // must still report failure, never "restored"). The first probe follows the
+      // first restart; the second probe follows the recovery restart.
+      const isRecoveryProbe = rec.healthProbes > 1;
+      const healthy = isRecoveryProbe
+        ? opts.recoveryHealthy ?? true
+        : opts.natsHealthy ?? true;
+      return healthy
+        ? { healthy: true }
+        : {
+            healthy: false,
+            reason: isRecoveryProbe
+              ? "recovery: monitor port 8224 not listening"
+              : "monitor port 8224 not listening",
+          };
     },
   };
 
@@ -663,8 +694,87 @@ describe("join", () => {
       expect(res.ok).toBe(false);
       expect(rec.restores).toEqual(["metafactory"]);
       expect(rec.natsRestarts).toBe(2);
-      expect(res.reason).toContain("recovery restart ALSO failed");
+      expect(res.reason).toContain("recovery restart");
       expect(res.warnings?.some((w) => w.includes("intervene manually"))).toBe(true);
+    });
+
+    // -------------------------------------------------------------------------
+    // #821 BLOCKER — the recovery restart must be HEALTH-PROBED, not trusted by
+    // exit code. A recovery that exits 0 but leaves the bus DOWN must report
+    // FAILURE + manual-intervention, NEVER "restored to prior state". This is
+    // the original sin reborn on the recovery path: the first restart is probed,
+    // but the recovery restart was decided on `recovery.ok` (exit code) alone.
+    // -------------------------------------------------------------------------
+    test("BLOCKER: recovery restart exits 0 but bus DOWN → reports failure, NOT 'restored'", async () => {
+      const { ports, rec } = makeFakes({
+        busType: "operator-mode",
+        natsHealthy: false, // first restart: exit 0 but DOWN → triggers rollback
+        recoveryHealthy: false, // recovery restart: exit 0 but STILL DOWN
+      });
+      const res = await joinNetwork("metafactory", LOCAL, ports);
+
+      expect(res.ok).toBe(false);
+      // Rollback ran and the recovery restart was issued + HEALTH-PROBED.
+      expect(rec.restores).toEqual(["metafactory"]);
+      expect(rec.natsRestarts).toBe(2);
+      expect(rec.healthProbes).toBe(2); // BOTH restarts probed (the fix)
+      // It must NOT claim the bus was restored — the recovery is down too.
+      expect(res.reason).not.toContain("restored to prior state");
+      expect(res.warnings?.some((w) => w.includes("restored to prior state"))).toBe(
+        false,
+      );
+      // It must surface the manual-intervention escalation.
+      expect(res.reason).toContain("intervene manually");
+      expect(res.warnings?.some((w) => w.includes("intervene manually"))).toBe(true);
+    });
+
+    // -------------------------------------------------------------------------
+    // #821 MAJOR-1 — the cheap pre-restart `nats-server -t` syntax gate. A `-t`
+    // FAILURE must refuse BEFORE restarting (never crash the bus on a config we
+    // already know is broken) and revert the leaf write.
+    // -------------------------------------------------------------------------
+    test("MAJOR-1: a failing `-t` gate refuses BEFORE restart + reverts the leaf write", async () => {
+      const { ports, rec } = makeFakes({
+        busType: "operator-mode",
+        validateConfigFails: true,
+      });
+      const res = await joinNetwork("metafactory", LOCAL, ports);
+
+      expect(res.ok).toBe(false);
+      expect(res.reason).toContain("config validation (-t) failed");
+      // The gate ran...
+      expect(rec.validateConfigs).toBe(1);
+      // ...and NO restart happened (refused before it).
+      expect(rec.natsRestarts).toBe(0);
+      expect(rec.restarts).toBe(0);
+      // The leaf write was reverted (snapshot restored) so the on-disk config is
+      // clean for the next attempt.
+      expect(rec.restores).toEqual(["metafactory"]);
+    });
+
+    test("MAJOR-1: the `-t` gate runs on the happy path (before the restart)", async () => {
+      const { ports, rec } = makeFakes({ busType: "operator-mode" });
+      const res = await joinNetwork("metafactory", LOCAL, ports);
+      expect(res.ok).toBe(true);
+      expect(rec.validateConfigs).toBe(1);
+      // Order: validate (1) ran before the single restart.
+      expect(rec.natsRestarts).toBe(1);
+    });
+
+    test("recovery restart exits 0 AND healthy → reports 'restored to prior state'", async () => {
+      const { ports, rec } = makeFakes({
+        busType: "operator-mode",
+        natsHealthy: false, // first restart down → rollback
+        recoveryHealthy: true, // recovery comes back UP
+      });
+      const res = await joinNetwork("metafactory", LOCAL, ports);
+
+      expect(res.ok).toBe(false); // the JOIN still failed (the leaf was bad)...
+      expect(rec.healthProbes).toBe(2);
+      // ...but the bus WAS restored — only then may we say so.
+      expect(res.warnings?.some((w) => w.includes("restored to prior state"))).toBe(
+        true,
+      );
     });
   });
 

--- a/src/cli/cortex/commands/__tests__/network-lib.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-lib.test.ts
@@ -117,6 +117,14 @@ interface Recorder {
   bindModeChecks: { account: string | undefined; hasCreds: boolean }[];
   /** C-820 — network ids the leave path asked the registry to deregister from. */
   deregistered: string[];
+  /** #821 — creds-existence paths pre-flighted. */
+  credsChecks: string[];
+  /** #821 — networks whose leaf state was snapshotted (pre-mutation). */
+  snapshots: string[];
+  /** #821 — networks whose leaf state was restored (rollback). */
+  restores: string[];
+  /** #821 — count of nats-server health probes after restart. */
+  healthProbes: number;
 }
 
 function makeFakes(opts: {
@@ -141,6 +149,16 @@ function makeFakes(opts: {
    * The fake's `resolveBindMode` mirrors the real `resolveLeafBindMode` decision.
    */
   busType?: "operator-mode" | "default-g";
+  /** #821 — model the leaf creds file as MISSING (pre-flight refuses). */
+  credsMissing?: boolean;
+  /**
+   * #821 — model nats-server's post-restart health. `false` = the restart exited
+   * 0 but the server then crashed (the community case) → orchestrator rolls back.
+   * Default: healthy.
+   */
+  natsHealthy?: boolean;
+  /** #821 — make the rollback recovery restart ALSO fail (worst-case path). */
+  recoveryRestartFails?: boolean;
 }): { ports: NetworkPorts; rec: Recorder; storeRef: { networks: PolicyFederatedNetwork[] } } {
   const rec: Recorder = {
     registered: 0,
@@ -158,6 +176,10 @@ function makeFakes(opts: {
     bindChecks: [],
     bindModeChecks: [],
     deregistered: [],
+    credsChecks: [],
+    snapshots: [],
+    restores: [],
+    healthProbes: 0,
   };
   const storeRef = { networks: opts.initialNetworks ?? [] };
   const leafFilesPresent = new Set<string>(
@@ -247,9 +269,29 @@ function makeFakes(opts: {
       if (trimmed !== undefined && trimmed.length > 0) {
         return { mode: "operator-account", account: trimmed };
       }
-      // operator-mode bus but no account offered → creds-only (the binding must
-      // ride in the creds JWT; nothing to account-bind).
-      return { mode: "creds-only" };
+      // #821 — operator-mode bus but NO account offered → REFUSE. Rendering a
+      // no-account ($G) remote onto an operator-mode bus crashes nats-server
+      // (it rejects a remote carrying no account nkey). The pre-#821 fake
+      // (and the real resolveLeafBindMode) wrongly returned creds-only here.
+      return {
+        mode: "refuse",
+        reason:
+          "operator-mode bus requires the leaf remote to declare an account nkey, " +
+          "but none was offered",
+      };
+    },
+    credsExist(path) {
+      rec.credsChecks.push(path);
+      // #821 — default: the creds file exists. A test opts into the missing-file
+      // refusal via `credsMissing: true`.
+      return opts.credsMissing !== true;
+    },
+    snapshotLeafState(networkId) {
+      rec.snapshots.push(networkId);
+      return { networkId, includeFile: undefined, natsConfig: undefined };
+    },
+    restoreLeafState(snapshot) {
+      rec.restores.push(snapshot.networkId);
     },
   };
 
@@ -286,9 +328,26 @@ function makeFakes(opts: {
     async restart() {
       rec.natsRestarts++;
       rec.restartOrder.push("nats");
+      // #821 — the SECOND nats restart is the rollback-recovery restart; let a
+      // test fail it independently to exercise the worst-case "recovery also
+      // failed" path. The first restart obeys `natsRestartOk`.
+      const isRecovery = rec.natsRestarts > 1;
+      if (isRecovery) {
+        return opts.recoveryRestartFails === true
+          ? { ok: false, reason: "recovery nats-server kickstart failed" }
+          : { ok: true };
+      }
       return opts.natsRestartOk === false
         ? { ok: false, reason: "nats-server kickstart failed" }
         : { ok: true };
+    },
+    async isHealthy() {
+      rec.healthProbes++;
+      // #821 — default: healthy. `natsHealthy: false` models the community case
+      // (restart exited 0 but the server then crashed on the bad leaf).
+      return opts.natsHealthy === false
+        ? { healthy: false, reason: "monitor port 8224 not listening" }
+        : { healthy: true };
     },
   };
 
@@ -451,6 +510,40 @@ describe("join", () => {
       if (!res.ok) expect(res.reason).toBeUndefined();
     });
 
+    // -------------------------------------------------------------------------
+    // #821 — THE INCIDENT. An operator-mode bus joined WITHOUT an account must
+    // REFUSE (and touch nothing), not fall through to a no-account ($G) leaf
+    // that crashes nats-server. This is the andreas/community crash: an
+    // operator-mode community.conf + a join run without --account rendered a
+    // no-account remote → nats-server exited 1 → the live bus went DOWN, yet
+    // join reported success.
+    // -------------------------------------------------------------------------
+    test("#821 operator-mode bus + NO account → REFUSES (the community crash)", async () => {
+      const NO_ACCOUNT: JoiningStack = {
+        principalId: "andreas",
+        stackSlug: "community",
+        credentials: "/Users/andreas/.config/nats/andreas.creds",
+        // No account — and the bus is operator-mode. Pre-#821 this fell through
+        // to creds-only and crashed nats-server.
+      };
+      const { ports, rec, storeRef } = makeFakes({ busType: "operator-mode" });
+      const res = await joinNetwork("metafactory-community", NO_ACCOUNT, ports);
+
+      expect(res.ok).toBe(false);
+      expect(res.reason).toContain("operator-mode");
+      expect(res.reason).toContain("cortex#794/#799");
+      // The bind-mode pre-flight ran with no account...
+      expect(rec.bindModeChecks).toEqual([{ account: undefined, hasCreds: true }]);
+      // ...and NOTHING was mutated — the bus is never touched.
+      expect(rec.writes.length).toBe(0); // no leaf include
+      expect(rec.includesEnsured).toEqual([]); // no local.conf include
+      expect(rec.ensured).toEqual([]); // no plist ensure
+      expect(rec.configWrites.length).toBe(0); // no federation config write
+      expect(rec.restarts).toBe(0); // no daemon restart
+      expect(rec.natsRestarts).toBe(0); // no nats-server restart
+      expect(storeRef.networks.length).toBe(0); // config untouched
+    });
+
     test("#799 REFUSES when there are NO creds (can't authenticate to the hub)", async () => {
       const NO_CREDS: JoiningStack = {
         principalId: "jc",
@@ -465,6 +558,113 @@ describe("join", () => {
       expect(rec.writes.length).toBe(0);
       expect(storeRef.networks.length).toBe(0);
       expect(rec.bindModeChecks).toEqual([{ account: undefined, hasCreds: false }]);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // #821 guarantee 2 — PRE-FLIGHT the creds file BEFORE writing/restarting.
+  // ---------------------------------------------------------------------------
+  describe("#821 creds-existence pre-flight", () => {
+    test("REFUSES before any mutation when the leaf creds file is missing", async () => {
+      const { ports, rec, storeRef } = makeFakes({
+        busType: "operator-mode",
+        credsMissing: true,
+      });
+      const res = await joinNetwork("metafactory", LOCAL, ports);
+
+      expect(res.ok).toBe(false);
+      expect(res.reason).toContain("creds file not found");
+      expect(res.reason).toContain("cortex#821");
+      // The creds path was checked...
+      expect(rec.credsChecks).toEqual([LOCAL.credentials]);
+      // ...and NOTHING was written/restarted (the refusal is before any mutation).
+      expect(rec.writes.length).toBe(0);
+      expect(rec.includesEnsured).toEqual([]);
+      expect(rec.configWrites.length).toBe(0);
+      expect(rec.natsRestarts).toBe(0);
+      expect(rec.restarts).toBe(0);
+      expect(storeRef.networks.length).toBe(0);
+      // No snapshot taken (refused before the snapshot step).
+      expect(rec.snapshots).toEqual([]);
+    });
+
+    test("proceeds when the creds file exists (the happy path checks it)", async () => {
+      const { ports, rec } = makeFakes({ busType: "operator-mode" });
+      const res = await joinNetwork("metafactory", LOCAL, ports);
+      expect(res.ok).toBe(true);
+      expect(rec.credsChecks).toEqual([LOCAL.credentials]);
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // #821 guarantee 3 — restart safety: verify nats came back up; ROLL BACK on
+  // failure so a failed join never leaves the bus down.
+  // ---------------------------------------------------------------------------
+  describe("#821 restart safety + rollback", () => {
+    test("snapshots the prior leaf state BEFORE mutating + probes health after restart", async () => {
+      const { ports, rec } = makeFakes({ busType: "operator-mode" });
+      const res = await joinNetwork("metafactory", LOCAL, ports);
+      expect(res.ok).toBe(true);
+      // Snapshot taken before the write.
+      expect(rec.snapshots).toEqual(["metafactory"]);
+      // Health probed after the (single) restart; no rollback on the happy path.
+      expect(rec.healthProbes).toBe(1);
+      expect(rec.restores).toEqual([]);
+      expect(rec.natsRestarts).toBe(1);
+      expect(res.steps.some((s) => s.includes("verified healthy"))).toBe(true);
+    });
+
+    test("restart exits 0 but server is DOWN → ROLLS BACK + re-restarts + reports FAILURE", async () => {
+      // The community case: kickstart returned 0, nats-server then crashed on the
+      // bad leaf. Health probe catches it; the snapshot is restored + re-restarted.
+      const { ports, rec } = makeFakes({
+        busType: "operator-mode",
+        natsHealthy: false,
+      });
+      const res = await joinNetwork("metafactory", LOCAL, ports);
+
+      // The join is reported as FAILED — never success while the bus is down.
+      expect(res.ok).toBe(false);
+      expect(res.reason).toContain("did not come back up");
+      // Rollback ran: snapshot restored + a recovery restart issued.
+      expect(rec.snapshots).toEqual(["metafactory"]);
+      expect(rec.restores).toEqual(["metafactory"]);
+      // Two nats restarts: the failed one + the recovery one.
+      expect(rec.natsRestarts).toBe(2);
+      // The cortex daemon was NEVER restarted (we bailed before step e.2).
+      expect(rec.restarts).toBe(0);
+      // The recovery succeeded — the warning says the bus was restored.
+      expect(res.warnings?.some((w) => w.includes("restored to prior state"))).toBe(true);
+    });
+
+    test("restart EXITS non-zero → ROLLS BACK + re-restarts + reports FAILURE", async () => {
+      const { ports, rec } = makeFakes({
+        busType: "operator-mode",
+        natsRestartOk: false,
+      });
+      const res = await joinNetwork("metafactory", LOCAL, ports);
+
+      expect(res.ok).toBe(false);
+      expect(res.reason).toContain("nats-server restart failed");
+      // Rollback restored the prior config + re-restarted.
+      expect(rec.restores).toEqual(["metafactory"]);
+      expect(rec.natsRestarts).toBe(2);
+      expect(rec.restarts).toBe(0);
+    });
+
+    test("worst case: recovery restart ALSO fails → reports a clear manual-intervention warning", async () => {
+      const { ports, rec } = makeFakes({
+        busType: "operator-mode",
+        natsHealthy: false,
+        recoveryRestartFails: true,
+      });
+      const res = await joinNetwork("metafactory", LOCAL, ports);
+
+      expect(res.ok).toBe(false);
+      expect(rec.restores).toEqual(["metafactory"]);
+      expect(rec.natsRestarts).toBe(2);
+      expect(res.reason).toContain("recovery restart ALSO failed");
+      expect(res.warnings?.some((w) => w.includes("intervene manually"))).toBe(true);
     });
   });
 
@@ -554,12 +754,15 @@ describe("#757 nats-server restart on join", () => {
   test("step log records the nats-server restart line", async () => {
     const { ports } = makeFakes({});
     const res = await joinNetwork("metafactory", LOCAL, ports);
+    // #821 — the line now carries the post-restart health verification.
     expect(
-      res.steps.some((s) => s === "restarted nats-server to load leaf config"),
+      res.steps.some((s) => s === "restarted nats-server to load leaf config (verified healthy)"),
     ).toBe(true);
     expect(res.steps.some((s) => s === "restarted stack daemon")).toBe(true);
     // nats-server step precedes the cortex daemon step.
-    const natsIdx = res.steps.indexOf("restarted nats-server to load leaf config");
+    const natsIdx = res.steps.indexOf(
+      "restarted nats-server to load leaf config (verified healthy)",
+    );
     const cortexIdx = res.steps.indexOf("restarted stack daemon");
     expect(natsIdx).toBeLessThan(cortexIdx);
   });
@@ -574,7 +777,10 @@ describe("#757 nats-server restart on join", () => {
     expect(storeRef.networks.length).toBe(1);
     // The cortex daemon was NOT restarted — we abort on the nats failure first.
     expect(rec.restarts).toBe(0);
-    expect(rec.restartOrder).toEqual(["nats"]);
+    // #821 — the failed restart now triggers a rollback + recovery restart, so
+    // the nats service is restarted a SECOND time to bring the bus back up.
+    expect(rec.restartOrder).toEqual(["nats", "nats"]);
+    expect(rec.restores).toEqual(["metafactory"]);
   });
 
   test("absent nats-server port → restart skipped (pre-#757 caller still works)", async () => {

--- a/src/cli/cortex/commands/__tests__/network-lib.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-lib.test.ts
@@ -169,6 +169,10 @@ function makeFakes(opts: {
   recoveryHealthy?: boolean;
   /** #821 MAJOR-1 — make the pre-restart `nats-server -t` syntax gate FAIL. */
   validateConfigFails?: boolean;
+  /** #821 item-2 — make natsServer.restart() THROW synchronously (Bun.spawn ENOENT). */
+  restartThrows?: boolean;
+  /** #821 item-2 — make natsServer.validateConfig() THROW synchronously (spawn ENOENT). */
+  validateThrows?: boolean;
 }): { ports: NetworkPorts; rec: Recorder; storeRef: { networks: PolicyFederatedNetwork[] } } {
   const rec: Recorder = {
     registered: 0,
@@ -338,6 +342,11 @@ function makeFakes(opts: {
   const natsServer: NatsServerPort = {
     async validateConfig() {
       rec.validateConfigs++;
+      // #821 item-2 — model a SYNCHRONOUS throw escaping the port (e.g. Bun.spawn
+      // ENOENT when the test tool isn't on PATH). joinNetwork must NOT propagate.
+      if (opts.validateThrows === true) {
+        throw new Error("spawn nats-server ENOENT");
+      }
       // #821 MAJOR-1 — default: the -t syntax gate passes. A test opts into a
       // -t failure via `validateConfigFails: true`.
       return opts.validateConfigFails === true
@@ -347,6 +356,12 @@ function makeFakes(opts: {
     async restart() {
       rec.natsRestarts++;
       rec.restartOrder.push("nats");
+      // #821 item-2 — model a SYNCHRONOUS throw escaping restart() (Bun.spawn
+      // ENOENT: launchctl/systemctl not on PATH). The never-throws contract means
+      // joinNetwork must catch this and return a failure verdict, not crash.
+      if (opts.restartThrows === true) {
+        throw new Error("spawn launchctl ENOENT");
+      }
       // #821 — the SECOND nats restart is the rollback-recovery restart; let a
       // test fail it independently to exercise the worst-case "recovery also
       // failed" path. The first restart obeys `natsRestartOk`.
@@ -759,6 +774,69 @@ describe("join", () => {
       expect(rec.validateConfigs).toBe(1);
       // Order: validate (1) ran before the single restart.
       expect(rec.natsRestarts).toBe(1);
+    });
+
+    // -------------------------------------------------------------------------
+    // #821 item-2 — never-throws contract. A SYNCHRONOUS throw from the
+    // nats-server port (Bun.spawn ENOENT when launchctl/systemctl/nats-server is
+    // not on PATH) must be CAUGHT by joinNetwork and returned as a failure
+    // verdict — never propagated as an uncaught stack trace that wedges the CLI.
+    // -------------------------------------------------------------------------
+    test("item-2: a THROWING restart() → joinNetwork returns a failure verdict, does NOT throw", async () => {
+      const { ports } = makeFakes({ busType: "operator-mode", restartThrows: true });
+      let res: Awaited<ReturnType<typeof joinNetwork>> | undefined;
+      let threw = false;
+      try {
+        res = await joinNetwork("metafactory", LOCAL, ports);
+      } catch {
+        threw = true;
+      }
+      expect(threw).toBe(false); // never-throws contract honoured
+      expect(res?.ok).toBe(false);
+      expect(res?.reason).toContain("ENOENT");
+    });
+
+    test("item-2: a THROWING validateConfig() → joinNetwork returns a failure verdict, does NOT throw", async () => {
+      const { ports } = makeFakes({ busType: "operator-mode", validateThrows: true });
+      let res: Awaited<ReturnType<typeof joinNetwork>> | undefined;
+      let threw = false;
+      try {
+        res = await joinNetwork("metafactory", LOCAL, ports);
+      } catch {
+        threw = true;
+      }
+      expect(threw).toBe(false);
+      expect(res?.ok).toBe(false);
+      expect(res?.reason).toContain("ENOENT");
+    });
+
+    test("item-2: a throwing RECOVERY restart is still caught (rollback path never throws)", async () => {
+      // First restart down → rollback re-restarts; make THAT recovery restart
+      // throw. The existing recovery try/catch must absorb it into the verdict.
+      const { ports, rec } = makeFakes({
+        busType: "operator-mode",
+        natsHealthy: false, // first restart exits 0 but DOWN → triggers rollback
+      });
+      // Patch the fake to throw on the SECOND (recovery) restart only.
+      const realRestart = ports.natsServer!.restart.bind(ports.natsServer);
+      let calls = 0;
+      ports.natsServer!.restart = async () => {
+        calls += 1;
+        if (calls >= 2) throw new Error("spawn launchctl ENOENT");
+        return realRestart();
+      };
+      let threw = false;
+      let res: Awaited<ReturnType<typeof joinNetwork>> | undefined;
+      try {
+        res = await joinNetwork("metafactory", LOCAL, ports);
+      } catch {
+        threw = true;
+      }
+      expect(threw).toBe(false);
+      expect(res?.ok).toBe(false);
+      // The rollback path absorbed the throw and escalated to manual intervention.
+      expect(res?.reason).toContain("intervene manually");
+      expect(rec.restores).toEqual(["metafactory"]);
     });
 
     test("recovery restart exits 0 AND healthy → reports 'restored to prior state'", async () => {

--- a/src/cli/cortex/commands/network-adapters.ts
+++ b/src/cli/cortex/commands/network-adapters.ts
@@ -133,6 +133,15 @@ export interface LivePortsConfig {
   platform?: ServicePlatform;
   monitorUrl?: string;
   /**
+   * #821 MAJOR — bound the health-probe `fetch` so a nats-server that accepts
+   * the monitor TCP connection but never RESPONDS (hung/deadlocked — exactly the
+   * failure the probe exists to catch) cannot hang `joinNetwork` forever. The
+   * probe aborts after this many ms and treats the abort as `healthy:false`.
+   * Defaults to {@link DEFAULT_HEALTH_PROBE_TIMEOUT_MS}; tests pin a short value
+   * so the timeout path is asserted without a real multi-second wait.
+   */
+  healthProbeTimeoutMs?: number;
+  /**
    * #800 — the cortex.yaml the stack's CORTEX daemon loads (the join's
    * `--config`, default `~/.config/cortex/cortex.yaml`). Used to LOCATE the
    * daemon's launchd/systemd service for the restart: the daemon is the service
@@ -879,6 +888,13 @@ function buildDaemonPort(cfg: LivePortsConfig, mutate: boolean): DaemonPort {
 // =============================================================================
 
 /**
+ * #821 MAJOR — default health-probe timeout (ms). Bounds the `/healthz` fetch so
+ * a hung monitor cannot stall the join. 5s is generous for a loopback probe yet
+ * far below any "the CLI is wedged" threshold.
+ */
+export const DEFAULT_HEALTH_PROBE_TIMEOUT_MS = 5000;
+
+/**
  * #821 MAJOR (code-review) — resolve the nats-server HTTP monitor BASE url the
  * health probe (and leaf-state) should hit. Precedence:
  *   1. explicit `--monitor-url` (cfg.monitorUrl) — highest, the principal's override;
@@ -966,8 +982,17 @@ function buildNatsServerPort(cfg: LivePortsConfig, mutate: boolean): NatsServerP
       // the stack's nats config (`http_port`/`monitor_port`/`http`); else the
       // upstream default.
       const base = resolveMonitorBase(cfg).replace(/\/+$/, "");
+      // #821 MAJOR — BOUND the probe. A monitor that accepts the TCP connection
+      // but never responds (hung/deadlocked nats-server — exactly the failure the
+      // probe exists to catch) would hang an unbounded `fetch` forever and stall
+      // joinNetwork with no verdict. AbortSignal.timeout aborts after the
+      // configured budget; a timeout/abort is treated as healthy:false (the
+      // restart did NOT bring a responsive bus up).
+      const timeoutMs = cfg.healthProbeTimeoutMs ?? DEFAULT_HEALTH_PROBE_TIMEOUT_MS;
       try {
-        const res = await fetch(`${base}/healthz`);
+        const res = await fetch(`${base}/healthz`, {
+          signal: AbortSignal.timeout(timeoutMs),
+        });
         if (!res.ok) {
           return {
             healthy: false,
@@ -976,11 +1001,17 @@ function buildNatsServerPort(cfg: LivePortsConfig, mutate: boolean): NatsServerP
         }
         return { healthy: true };
       } catch (err) {
-        // Monitor unreachable → the server is down (or the monitor port isn't
-        // listening). Either way the restart did NOT bring a healthy bus up.
+        // A timeout/abort means the monitor accepted but did not respond in time
+        // — the bus is hung, NOT healthy. A connection error means it's down or
+        // the port isn't listening. Either way the restart did NOT bring a
+        // healthy bus up. Distinguish the timeout for an actionable reason.
+        const isTimeout =
+          err instanceof DOMException && err.name === "TimeoutError";
         return {
           healthy: false,
-          reason: `nats-server monitor ${base} unreachable: ${err instanceof Error ? err.message : String(err)}`,
+          reason: isTimeout
+            ? `nats-server monitor ${base}/healthz timed out after ${timeoutMs.toString()}ms (accepted the connection but never responded — bus hung)`
+            : `nats-server monitor ${base} unreachable: ${err instanceof Error ? err.message : String(err)}`,
         };
       }
     },

--- a/src/cli/cortex/commands/network-adapters.ts
+++ b/src/cli/cortex/commands/network-adapters.ts
@@ -26,6 +26,7 @@ import {
   readdirSync,
   readFileSync,
   rmSync,
+  statSync,
   writeFileSync,
 } from "fs";
 import { basename, dirname, join } from "path";
@@ -35,8 +36,10 @@ import { parse as parseYaml, parseDocument } from "yaml";
 import { expandTilde } from "../../../common/config/loader";
 import {
   ensureLeafInclude,
+  leafIncludeDirectivePresent,
   leafIncludeFileName,
   natsConfigCanBindAccount,
+  natsConfigMonitorUrl,
   removeLeafInclude,
   renderLeafIncludeFile,
   resolveLeafBindMode,
@@ -488,31 +491,65 @@ function buildLeafFilePort(cfg: LivePortsConfig, mutate: boolean): LeafFilePort 
     },
     credsExist(path) {
       // #821 — pure READ (identical in live + dry-run): does the leaf creds file
-      // exist? `nats-server -t` never dereferences it, so a missing creds file
-      // passes `-t` yet leaves the leaf un-authenticatable. The path is
-      // tilde-expanded to match how nats-server resolves it.
+      // exist AS A USABLE CREDS FILE? `nats-server -t` never dereferences it, so a
+      // missing/empty/wrong-type creds file passes `-t` yet leaves the leaf
+      // un-authenticatable. NIT-1 — beyond mere existence we require it to be a
+      // regular NON-EMPTY file (a directory or 0-byte file is a dormant trap) and
+      // sniff the `-----BEGIN NATS USER JWT-----` marker a real `.creds` carries.
+      // The path is tilde-expanded to match how nats-server resolves it.
       const expanded = expandTilde(path);
-      return expanded.length > 0 && existsSync(expanded);
+      if (expanded.length === 0) return false;
+      let st;
+      try {
+        st = statSync(expanded);
+      } catch (_err) {
+        return false; // ENOENT / unreadable → treat as missing.
+      }
+      if (!st.isFile() || st.size === 0) return false;
+      // Sniff the NATS user-creds marker. A genuine `.creds` from `nsc`/the
+      // provisioner carries the decorated JWT+seed block; reject a file that
+      // does not (e.g. a stray text file at the conventional path).
+      let head: string;
+      try {
+        head = readFileSync(expanded, "utf-8").slice(0, 512);
+      } catch (_err) {
+        return false;
+      }
+      return head.includes("-----BEGIN NATS USER JWT-----");
     },
     snapshotLeafState(networkId) {
-      // #821 — capture the per-network include file + the base nats config bytes
-      // so a failed restart can be rolled back. A READ.
+      // #821 — capture the per-network include file bytes + WHETHER the base nats
+      // config carried the `include` directive, so a failed restart can be rolled
+      // back. A READ. We capture the directive PRESENCE (not the whole base
+      // config bytes) so restore only ever touches the ONE directive the join
+      // adds — never the externally-owned base `local.conf` as a whole.
       const includePath = join(dir, leafIncludeFileName(networkId));
       const configPath = expandTilde(cfg.natsConfigPath ?? "");
+      const baseConfig =
+        configPath.length > 0 && existsSync(configPath)
+          ? readFileSync(configPath, "utf-8")
+          : undefined;
       return {
         networkId,
         includeFile: existsSync(includePath)
           ? readFileSync(includePath, "utf-8")
           : undefined,
-        natsConfig: existsSync(configPath)
-          ? readFileSync(configPath, "utf-8")
-          : undefined,
+        // Record only whether the include DIRECTIVE was present pre-join. We do
+        // NOT snapshot the whole base-config bytes — see restoreLeafState.
+        natsConfig:
+          baseConfig !== undefined &&
+          leafIncludeDirectivePresentInBaseConfig(baseConfig, networkId)
+            ? "directive-present"
+            : undefined,
       };
     },
     restoreLeafState(snapshot) {
-      // #821 — rollback: rewrite (or delete) the per-network include file and the
-      // base nats config to exactly the snapshot bytes, so the next restart
-      // brings the bus back to its prior working state. Dry-run is inert.
+      // #821 — rollback: return the leaf state to its pre-join shape. Dry-run is
+      // inert. NIT (code-review) — restore ONLY the per-network include file +
+      // the single `include` DIRECTIVE the join added; NEVER rmSync the whole
+      // base `local.conf` (it is the externally-owned `-c` config, #801, and may
+      // carry directives this join never touched). We add/remove exactly the
+      // directive via the same idempotent helpers join used.
       if (!mutate) return;
       const includePath = join(dir, leafIncludeFileName(snapshot.networkId));
       if (snapshot.includeFile === undefined) {
@@ -522,16 +559,31 @@ function buildLeafFilePort(cfg: LivePortsConfig, mutate: boolean): LeafFilePort 
         mkdirSync(dir, { recursive: true });
         writeFileSync(includePath, snapshot.includeFile, "utf-8");
       }
+
+      // Restore the include DIRECTIVE in the base config to its pre-join presence.
       const configPath = expandTilde(cfg.natsConfigPath ?? "");
-      if (snapshot.natsConfig === undefined) {
-        // The base config did not exist pre-join (unusual) — remove the join's write.
-        rmSync(configPath, { force: true });
-      } else {
-        mkdirSync(dirname(configPath), { recursive: true });
-        writeFileSync(configPath, snapshot.natsConfig, "utf-8");
-      }
+      if (configPath.length === 0 || !existsSync(configPath)) return;
+      const current = readFileSync(configPath, "utf-8");
+      const directiveWasPresent = snapshot.natsConfig === "directive-present";
+      const next = directiveWasPresent
+        ? ensureLeafInclude(current, snapshot.networkId) // it was there → keep it
+        : removeLeafInclude(current, snapshot.networkId); // join added it → drop it
+      if (next !== current) writeFileSync(configPath, next, "utf-8");
     },
   };
+}
+
+/**
+ * #821 — does the base nats config already carry the `include
+ * "leafnodes-<network>.conf"` directive? Thin wrapper over
+ * {@link leafIncludeDirectivePresent} so the snapshot records directive PRESENCE
+ * (the only base-config state the join changes) rather than the whole file.
+ */
+function leafIncludeDirectivePresentInBaseConfig(
+  baseConfig: string,
+  networkId: string,
+): boolean {
+  return leafIncludeDirectivePresent(baseConfig, networkId);
 }
 
 // =============================================================================
@@ -826,6 +878,25 @@ function buildDaemonPort(cfg: LivePortsConfig, mutate: boolean): DaemonPort {
 // file name). No hardcoded service id; no platform branching here.
 // =============================================================================
 
+/**
+ * #821 MAJOR (code-review) — resolve the nats-server HTTP monitor BASE url the
+ * health probe (and leaf-state) should hit. Precedence:
+ *   1. explicit `--monitor-url` (cfg.monitorUrl) — highest, the principal's override;
+ *   2. DERIVED from the stack's nats config (`http_port`/`monitor_port`/`http`),
+ *      so a non-default bus (the community :8224) is probed on its OWN port;
+ *   3. the upstream default `:8222`.
+ * The config read is best-effort (a missing/unreadable file just falls through).
+ */
+function resolveMonitorBase(cfg: LivePortsConfig): string {
+  if (cfg.monitorUrl !== undefined && cfg.monitorUrl !== "") return cfg.monitorUrl;
+  const configPath = expandTilde(cfg.natsConfigPath ?? "");
+  if (configPath.length > 0 && existsSync(configPath)) {
+    const derived = natsConfigMonitorUrl(readFileSync(configPath, "utf-8"));
+    if (derived !== undefined) return derived;
+  }
+  return DEFAULT_MONITOR_URL;
+}
+
 function buildNatsServerPort(cfg: LivePortsConfig, mutate: boolean): NatsServerPort {
   return {
     async restart() {
@@ -849,16 +920,52 @@ function buildNatsServerPort(cfg: LivePortsConfig, mutate: boolean): NatsServerP
       }
       return mgr.restart();
     },
+    async validateConfig() {
+      // #821 MAJOR-1 — cheap pre-restart syntax gate: `nats-server -c <cfg> -t`.
+      // Dry-run is inert. The gate is NECESSARY-NOT-SUFFICIENT (a syntax check
+      // that does not resolve leaf creds/accounts — it passed for the original
+      // crash), so a non-zero exit is a HARD signal the config is broken, while a
+      // missing `nats-server` binary is SKIPPED (returns ok) rather than blocking
+      // the join on a machine where the test tool isn't installed.
+      if (!mutate) return { ok: true };
+      const configPath = expandTilde(cfg.natsConfigPath ?? "");
+      if (configPath.length === 0) {
+        // No config to test — the restart step will surface the real error.
+        return { ok: true };
+      }
+      let result: { code: number; stderr: string };
+      try {
+        result = await bunExecRunner(["nats-server", "-c", configPath, "-t"]);
+      } catch (err) {
+        // Spawn failure (e.g. binary not on PATH) → SKIP the gate, don't block.
+        process.stderr.write(
+          `network join: skipping nats-server -t gate (could not run nats-server: ${err instanceof Error ? err.message : String(err)})\n`,
+        );
+        return { ok: true };
+      }
+      if (result.code !== 0) {
+        return {
+          ok: false,
+          reason: `nats-server -c ${configPath} -t exited ${result.code.toString()}: ${result.stderr.trim()}`,
+        };
+      }
+      return { ok: true };
+    },
     async isHealthy() {
       // #821 — probe nats-server's HTTP monitor to confirm it actually came back
       // UP after the restart. `launchctl kickstart` / `systemctl restart` can
       // exit 0 even when the server then crashes on the new config at runtime
       // (the community incident). `/healthz` is nats-server's liveness endpoint;
       // a reachable 200 means the process is up and reading its config. A
-      // dry-run never restarts, so it is trivially "healthy". The monitor URL is
-      // the same one the leaf-state port uses (defaults to the local monitor).
+      // dry-run never restarts, so it is trivially "healthy".
       if (!mutate) return { healthy: true };
-      const base = (cfg.monitorUrl ?? DEFAULT_MONITOR_URL).replace(/\/+$/, "");
+      // #821 MAJOR (code-review) — target THIS bus's OWN monitor port. The
+      // community bus monitors on :8224, not the upstream-default :8222; probing
+      // the wrong port would ECONNREFUSED and false-trip a rollback on a GOOD
+      // join. Precedence: explicit --monitor-url wins; else derive the port from
+      // the stack's nats config (`http_port`/`monitor_port`/`http`); else the
+      // upstream default.
+      const base = resolveMonitorBase(cfg).replace(/\/+$/, "");
       try {
         const res = await fetch(`${base}/healthz`);
         if (!res.ok) {
@@ -900,7 +1007,10 @@ export function buildLeafStatePort(cfg: LivePortsConfig): LeafStatePort {
   // C-797 — always wire the port; default to the local nats-server monitor when
   // no `--monitor-url` was supplied. (Previously: undefined ⇒ no port ⇒
   // link:unknown for everyone.)
-  const base = (cfg.monitorUrl ?? DEFAULT_MONITOR_URL).replace(/\/+$/, "");
+  // #821 MAJOR (code-review) — use the SAME monitor-base resolution as the health
+  // probe (explicit flag → derived-from-config → default), so status reads the
+  // bus's OWN monitor port (community :8224) instead of the wrong default :8222.
+  const base = resolveMonitorBase(cfg).replace(/\/+$/, "");
   return {
     async linkStates() {
       try {

--- a/src/cli/cortex/commands/network-adapters.ts
+++ b/src/cli/cortex/commands/network-adapters.ts
@@ -486,6 +486,51 @@ function buildLeafFilePort(cfg: LivePortsConfig, mutate: boolean): LeafFilePort 
         : "";
       return resolveLeafBindMode(text, account, hasCreds);
     },
+    credsExist(path) {
+      // #821 — pure READ (identical in live + dry-run): does the leaf creds file
+      // exist? `nats-server -t` never dereferences it, so a missing creds file
+      // passes `-t` yet leaves the leaf un-authenticatable. The path is
+      // tilde-expanded to match how nats-server resolves it.
+      const expanded = expandTilde(path);
+      return expanded.length > 0 && existsSync(expanded);
+    },
+    snapshotLeafState(networkId) {
+      // #821 — capture the per-network include file + the base nats config bytes
+      // so a failed restart can be rolled back. A READ.
+      const includePath = join(dir, leafIncludeFileName(networkId));
+      const configPath = expandTilde(cfg.natsConfigPath ?? "");
+      return {
+        networkId,
+        includeFile: existsSync(includePath)
+          ? readFileSync(includePath, "utf-8")
+          : undefined,
+        natsConfig: existsSync(configPath)
+          ? readFileSync(configPath, "utf-8")
+          : undefined,
+      };
+    },
+    restoreLeafState(snapshot) {
+      // #821 — rollback: rewrite (or delete) the per-network include file and the
+      // base nats config to exactly the snapshot bytes, so the next restart
+      // brings the bus back to its prior working state. Dry-run is inert.
+      if (!mutate) return;
+      const includePath = join(dir, leafIncludeFileName(snapshot.networkId));
+      if (snapshot.includeFile === undefined) {
+        // The include file did not exist pre-join — remove what the join wrote.
+        rmSync(includePath, { force: true });
+      } else {
+        mkdirSync(dir, { recursive: true });
+        writeFileSync(includePath, snapshot.includeFile, "utf-8");
+      }
+      const configPath = expandTilde(cfg.natsConfigPath ?? "");
+      if (snapshot.natsConfig === undefined) {
+        // The base config did not exist pre-join (unusual) — remove the join's write.
+        rmSync(configPath, { force: true });
+      } else {
+        mkdirSync(dirname(configPath), { recursive: true });
+        writeFileSync(configPath, snapshot.natsConfig, "utf-8");
+      }
+    },
   };
 }
 
@@ -803,6 +848,34 @@ function buildNatsServerPort(cfg: LivePortsConfig, mutate: boolean): NatsServerP
         };
       }
       return mgr.restart();
+    },
+    async isHealthy() {
+      // #821 — probe nats-server's HTTP monitor to confirm it actually came back
+      // UP after the restart. `launchctl kickstart` / `systemctl restart` can
+      // exit 0 even when the server then crashes on the new config at runtime
+      // (the community incident). `/healthz` is nats-server's liveness endpoint;
+      // a reachable 200 means the process is up and reading its config. A
+      // dry-run never restarts, so it is trivially "healthy". The monitor URL is
+      // the same one the leaf-state port uses (defaults to the local monitor).
+      if (!mutate) return { healthy: true };
+      const base = (cfg.monitorUrl ?? DEFAULT_MONITOR_URL).replace(/\/+$/, "");
+      try {
+        const res = await fetch(`${base}/healthz`);
+        if (!res.ok) {
+          return {
+            healthy: false,
+            reason: `nats-server monitor ${base}/healthz returned HTTP ${res.status.toString()}`,
+          };
+        }
+        return { healthy: true };
+      } catch (err) {
+        // Monitor unreachable → the server is down (or the monitor port isn't
+        // listening). Either way the restart did NOT bring a healthy bus up.
+        return {
+          healthy: false,
+          reason: `nats-server monitor ${base} unreachable: ${err instanceof Error ? err.message : String(err)}`,
+        };
+      }
     },
   };
 }

--- a/src/cli/cortex/commands/network-lib.ts
+++ b/src/cli/cortex/commands/network-lib.ts
@@ -384,7 +384,20 @@ export async function joinNetwork(
     // means the config is definitely broken → refuse BEFORE restarting (nothing
     // to roll back: we have not restarted yet, and the leaf write is reverted by
     // restoring the snapshot to keep the on-disk config clean for the next try).
-    const validate = await natsServer.validateConfig();
+    // #821 item-2 — never-throws contract. validateConfig (and restart, below)
+    // ultimately shell out via Bun.spawn, which THROWS SYNCHRONOUSLY on ENOENT
+    // (launchctl/systemctl/nats-server not on PATH). joinNetwork is documented
+    // "never throws", so guard the call: a thrown spawn error becomes a clean
+    // failure verdict, not an uncaught stack trace that wedges the CLI.
+    let validate: { ok: true } | { ok: false; reason: string };
+    try {
+      validate = await natsServer.validateConfig();
+    } catch (err) {
+      validate = {
+        ok: false,
+        reason: `nats-server config validation could not run: ${err instanceof Error ? err.message : String(err)}`,
+      };
+    }
     if (!validate.ok) {
       try {
         ports.leafFile.restoreLeafState(snapshot);
@@ -417,19 +430,31 @@ export async function joinNetwork(
     // the SAME standard — exit code is necessary-not-sufficient (#821 BLOCKER:
     // the recovery path previously trusted exit code alone and could claim the
     // bus was "restored" while it was DOWN).
+    // #821 item-2 — restartAndProbe catches INTERNALLY so BOTH call sites (the
+    // initial restart AND the rollback-recovery restart) honour the never-throws
+    // contract. NatsServiceManager.restart()/isHealthy() shell out via Bun.spawn
+    // (throws synchronously on ENOENT) / fetch; a throw here becomes a failure
+    // result, never an uncaught escape from joinNetwork.
     const restartAndProbe = async (): Promise<
       { ok: true } | { ok: false; reason: string }
     > => {
-      const r = await natsServer.restart();
-      if (!r.ok) return { ok: false, reason: r.reason };
-      const health = await natsServer.isHealthy();
-      if (!health.healthy) {
+      try {
+        const r = await natsServer.restart();
+        if (!r.ok) return { ok: false, reason: r.reason };
+        const health = await natsServer.isHealthy();
+        if (!health.healthy) {
+          return {
+            ok: false,
+            reason: `nats-server did not come back up after restart (${health.reason})`,
+          };
+        }
+        return { ok: true };
+      } catch (err) {
         return {
           ok: false,
-          reason: `nats-server did not come back up after restart (${health.reason})`,
+          reason: `nats-server restart/probe could not run: ${err instanceof Error ? err.message : String(err)}`,
         };
       }
-      return { ok: true };
     };
 
     const initial = await restartAndProbe();

--- a/src/cli/cortex/commands/network-lib.ts
+++ b/src/cli/cortex/commands/network-lib.ts
@@ -374,35 +374,78 @@ export async function joinNetwork(
   // the leaf); the live `join` path always supplies one.
   if (ports.natsServer !== undefined) {
     const natsServer = ports.natsServer;
-    const natsRestart = await natsServer.restart();
+
+    // (e.0) #821 MAJOR-1 — a CHEAP pre-restart config-syntax gate (`nats-server
+    // -c <cfg> -t`). This catches an obviously-broken config BEFORE the restart
+    // that would crash the bus. It is NECESSARY-NOT-SUFFICIENT (it's a syntax
+    // check — it did NOT catch the original #821 crash, which is a runtime
+    // account-resolution failure), so it sits ON TOP of the account-required +
+    // creds-exist + health-probe defenses, never replacing them. A `-t` FAILURE
+    // means the config is definitely broken → refuse BEFORE restarting (nothing
+    // to roll back: we have not restarted yet, and the leaf write is reverted by
+    // restoring the snapshot to keep the on-disk config clean for the next try).
+    const validate = await natsServer.validateConfig();
+    if (!validate.ok) {
+      try {
+        ports.leafFile.restoreLeafState(snapshot);
+      } catch (err) {
+        // Restore failed — surface it; we have NOT restarted, so the bus is still
+        // up on its prior in-memory config, but the on-disk config now carries the
+        // bad leaf. Report so the principal can clean up before the next restart.
+        process.stderr.write(
+          `network join: leaf snapshot restore after a failed -t gate also failed: ${err instanceof Error ? err.message : String(err)}\n`,
+        );
+      }
+      return {
+        ok: false,
+        steps,
+        reason:
+          `nats-server config validation (-t) failed before restart, refusing to restart ` +
+          `(reverted the leaf write): ${validate.reason}`,
+        network: entry,
+        usedCache,
+        resolvedPeers: peers.map((p) => p.principal_id),
+        ...(warnings.length > 0 && { warnings }),
+      };
+    }
 
     // #821 — a restart that EXITS non-zero, OR one that exits 0 but leaves the
     // server DOWN (the community crash: `launchctl kickstart` returned 0, then
-    // nats-server exited 1 on the bad leaf), must NOT be reported as success and
-    // must NOT leave the bus down. Probe health after the restart; on failure,
-    // ROLL BACK the leaf snapshot + re-restart so the bus returns to its prior
-    // working state, then report the failure.
-    let restartFailure: string | undefined;
-    if (!natsRestart.ok) {
-      restartFailure = natsRestart.reason;
-    } else {
+    // nats-server exited 1 on the bad leaf), must NOT be reported as healthy.
+    // restartAndProbe couples the restart with the post-restart health probe so
+    // BOTH the initial restart AND the rollback-recovery restart are judged by
+    // the SAME standard — exit code is necessary-not-sufficient (#821 BLOCKER:
+    // the recovery path previously trusted exit code alone and could claim the
+    // bus was "restored" while it was DOWN).
+    const restartAndProbe = async (): Promise<
+      { ok: true } | { ok: false; reason: string }
+    > => {
+      const r = await natsServer.restart();
+      if (!r.ok) return { ok: false, reason: r.reason };
       const health = await natsServer.isHealthy();
       if (!health.healthy) {
-        restartFailure = `nats-server did not come back up after restart (${health.reason})`;
+        return {
+          ok: false,
+          reason: `nats-server did not come back up after restart (${health.reason})`,
+        };
       }
-    }
+      return { ok: true };
+    };
 
-    if (restartFailure !== undefined) {
+    const initial = await restartAndProbe();
+
+    if (!initial.ok) {
       // Restore the prior leaf state + re-restart to bring the bus back. A failed
-      // join MUST NEVER leave the bus down. The rollback restart's own outcome is
-      // appended to the step log so the principal sees whether recovery succeeded.
+      // join MUST NEVER leave the bus down. The recovery restart is HEALTH-PROBED
+      // (not trusted by exit code) so we only claim "restored" when the bus is
+      // verifiably back up; otherwise we escalate to manual intervention.
       let rollbackNote: string;
       try {
         ports.leafFile.restoreLeafState(snapshot);
-        const recovery = await natsServer.restart();
+        const recovery = await restartAndProbe();
         rollbackNote = recovery.ok
-          ? "rolled back leaf config + restarted nats-server (bus restored to prior state)"
-          : `rolled back leaf config but the recovery restart ALSO failed (${recovery.reason}) — bus may be DOWN, intervene manually`;
+          ? "rolled back leaf config + restarted nats-server (bus restored to prior state, verified healthy)"
+          : `rolled back leaf config but the recovery restart did NOT bring the bus back up (${recovery.reason}) — bus may be DOWN, intervene manually`;
       } catch (err) {
         rollbackNote = `rollback FAILED (${err instanceof Error ? err.message : String(err)}) — bus may be DOWN, intervene manually`;
       }
@@ -410,7 +453,7 @@ export async function joinNetwork(
       return {
         ok: false,
         steps,
-        reason: `nats-server restart failed (${restartFailure}); ${rollbackNote}`,
+        reason: `nats-server restart failed (${initial.reason}); ${rollbackNote}`,
         network: entry,
         usedCache,
         resolvedPeers: peers.map((p) => p.principal_id),

--- a/src/cli/cortex/commands/network-lib.ts
+++ b/src/cli/cortex/commands/network-lib.ts
@@ -235,6 +235,29 @@ export async function joinNetwork(
   const leafAccount =
     bindMode.mode === "operator-account" ? bindMode.account : undefined;
 
+  // (b.6) #821 — PRE-FLIGHT the creds file BEFORE any mutation. `nats-server -c
+  // <cfg> -t` validates HOCON syntax but does NOT dereference the leaf remote's
+  // `credentials` path, so a remote pointing at a NON-EXISTENT creds file passes
+  // `-t` yet makes the leaf un-authenticatable at runtime. The community
+  // incident's rendered remote pointed at a creds file that did not exist. A
+  // READ (identical in live + dry-run); refuse here rather than render a leaf
+  // that can never connect.
+  if (!ports.leafFile.credsExist(stack.credentials)) {
+    return {
+      ok: false,
+      steps,
+      reason:
+        `leaf creds file not found at ${stack.credentials} — refusing to render a ` +
+        `leaf remote that cannot authenticate to the hub. Set stack.nats_infra.creds_path ` +
+        `(or pass --creds) to an existing .creds file (cortex#821).`,
+    };
+  }
+
+  // (b.7) #821 — SNAPSHOT the prior leaf state BEFORE any mutation, so a failed
+  // nats-server restart (step e.1) can be rolled back to the exact pre-join
+  // bytes. Captures the per-network include file + the base nats config. A READ.
+  const snapshot = ports.leafFile.snapshotLeafState(networkId);
+
   // (c) Render + write the leaf include (S3) and ensure the plist loads the
   // nats config (DD-6, closes the configured-but-dormant trap). The renderer
   // fails loud on a bad binding — surface it as a join failure, never a crash.
@@ -350,19 +373,51 @@ export async function joinNetwork(
   // Skipped only when no nats-server port is wired (a caller that doesn't mutate
   // the leaf); the live `join` path always supplies one.
   if (ports.natsServer !== undefined) {
-    const natsRestart = await ports.natsServer.restart();
+    const natsServer = ports.natsServer;
+    const natsRestart = await natsServer.restart();
+
+    // #821 — a restart that EXITS non-zero, OR one that exits 0 but leaves the
+    // server DOWN (the community crash: `launchctl kickstart` returned 0, then
+    // nats-server exited 1 on the bad leaf), must NOT be reported as success and
+    // must NOT leave the bus down. Probe health after the restart; on failure,
+    // ROLL BACK the leaf snapshot + re-restart so the bus returns to its prior
+    // working state, then report the failure.
+    let restartFailure: string | undefined;
     if (!natsRestart.ok) {
+      restartFailure = natsRestart.reason;
+    } else {
+      const health = await natsServer.isHealthy();
+      if (!health.healthy) {
+        restartFailure = `nats-server did not come back up after restart (${health.reason})`;
+      }
+    }
+
+    if (restartFailure !== undefined) {
+      // Restore the prior leaf state + re-restart to bring the bus back. A failed
+      // join MUST NEVER leave the bus down. The rollback restart's own outcome is
+      // appended to the step log so the principal sees whether recovery succeeded.
+      let rollbackNote: string;
+      try {
+        ports.leafFile.restoreLeafState(snapshot);
+        const recovery = await natsServer.restart();
+        rollbackNote = recovery.ok
+          ? "rolled back leaf config + restarted nats-server (bus restored to prior state)"
+          : `rolled back leaf config but the recovery restart ALSO failed (${recovery.reason}) — bus may be DOWN, intervene manually`;
+      } catch (err) {
+        rollbackNote = `rollback FAILED (${err instanceof Error ? err.message : String(err)}) — bus may be DOWN, intervene manually`;
+      }
+      steps.push(`WARN: ${rollbackNote}`);
       return {
         ok: false,
         steps,
-        reason: `config written but nats-server restart failed: ${natsRestart.reason}`,
+        reason: `nats-server restart failed (${restartFailure}); ${rollbackNote}`,
         network: entry,
         usedCache,
         resolvedPeers: peers.map((p) => p.principal_id),
-        ...(warnings.length > 0 && { warnings }),
+        warnings: [...warnings, rollbackNote],
       };
     }
-    steps.push("restarted nats-server to load leaf config");
+    steps.push("restarted nats-server to load leaf config (verified healthy)");
   }
 
   // (e.2) Restart the cortex daemon so it reconnects to the bus (now carrying

--- a/src/cli/cortex/commands/network-ports.ts
+++ b/src/cli/cortex/commands/network-ports.ts
@@ -296,6 +296,18 @@ export interface NatsServerPort {
   /** Restart nats-server so it reloads `local.conf` (the new leaf include). */
   restart(): Promise<{ ok: true } | { ok: false; reason: string }>;
   /**
+   * #821 MAJOR-1 — a cheap PRE-RESTART config-syntax gate: run `nats-server -c
+   * <cfg> -t` (the upstream config-test flag) so an obviously-broken config is
+   * caught BEFORE the restart that would otherwise crash the bus. NOTE: `-t` is
+   * a SYNTAX check — it does NOT dereference leaf creds paths or resolve a
+   * leaf-remote's account against the account tree, so it PASSED for the original
+   * #821 crash. It is therefore NECESSARY-NOT-SUFFICIENT: a cheap extra gate
+   * layered ON TOP of the account-required + creds-exist + health-probe defenses,
+   * never the primary defense. A dry-run is inert (returns ok). When `nats-server`
+   * is not on PATH the gate is SKIPPED (returns ok) rather than blocking the join.
+   */
+  validateConfig(): Promise<{ ok: true } | { ok: false; reason: string }>;
+  /**
    * #821 — restart-safety HEALTH PROBE. After a restart, confirm nats-server
    * actually came back UP (its monitor port is listening / the process is
    * healthy). `launchctl kickstart` / `systemctl restart` can exit 0 even when
@@ -304,6 +316,13 @@ export interface NatsServerPort {
    * leaving the bus DOWN). The orchestrator probes AFTER the restart; an
    * unhealthy result triggers a snapshot rollback + re-restart. Returns
    * `{ healthy: true }` when the server is reachable, else a reason.
+   *
+   * #821 NIT-2 (follow-up) — `/healthz` is a LIVENESS probe: it confirms the
+   * server process is up, but cannot distinguish "up, and the leaf connected"
+   * from "up, but the leaf remote was rejected". A stronger JOIN-verification
+   * would additionally poll `/leafz` for the expected remote (the C-797
+   * leaf-state surface). Tracked as a follow-up; liveness is sufficient to catch
+   * the #821 crash (a crashed server fails `/healthz`).
    */
   isHealthy(): Promise<{ healthy: true } | { healthy: false; reason: string }>;
 }

--- a/src/cli/cortex/commands/network-ports.ts
+++ b/src/cli/cortex/commands/network-ports.ts
@@ -189,6 +189,48 @@ export interface LeafFilePort {
    * creds path; `account` is the candidate nkey-U (or `undefined`).
    */
   resolveBindMode(account: string | undefined, hasCreds: boolean): LeafBindMode;
+  /**
+   * #821 — pre-flight: does the leaf `.creds` file at `path` actually EXIST on
+   * disk? `nats-server -c <cfg> -t` only validates HOCON syntax — it does NOT
+   * dereference a leaf remote's `credentials` path, so a remote pointing at a
+   * NON-EXISTENT creds file passes `-t` yet makes nats-server fail at runtime
+   * (the leaf can never authenticate). The community incident pointed at
+   * `~/.config/nats/metafactory-community.creds`, which did not exist. The
+   * orchestrator calls this BEFORE writing the include + restarting, and REFUSES
+   * when the creds file is missing — a READ, identical in live + dry-run.
+   */
+  credsExist(path: string): boolean;
+  /**
+   * #821 — restart-safety SNAPSHOT. Capture the current on-disk leaf state for
+   * `networkId` (the per-network include file + the base nats config's `include`
+   * directive presence) so a failed nats-server restart can be ROLLED BACK to
+   * the prior working bytes via {@link restoreLeafState}. Returned as an opaque
+   * token. A READ — taken BEFORE the join mutates anything.
+   */
+  snapshotLeafState(networkId: string): LeafStateSnapshot;
+  /**
+   * #821 — restart-safety ROLLBACK. Restore the leaf state captured by
+   * {@link snapshotLeafState}: rewrite (or delete) the per-network include file
+   * and the base config's `include` directive to exactly the snapshot's bytes.
+   * Called ONLY when a nats-server restart left the bus down, so the next
+   * restart brings the bus back to its prior working state. Idempotent.
+   */
+  restoreLeafState(snapshot: LeafStateSnapshot): void;
+}
+
+/**
+ * #821 — opaque rollback token for {@link LeafFilePort.snapshotLeafState} /
+ * {@link LeafFilePort.restoreLeafState}. Captures whether the per-network leaf
+ * include file existed (+ its bytes) and whether the base nats config carried
+ * the `include` directive (+ its full bytes), so a failed restart can be
+ * reverted to exactly the pre-join state.
+ */
+export interface LeafStateSnapshot {
+  networkId: string;
+  /** The per-network include file's prior contents, or `undefined` if absent. */
+  includeFile: string | undefined;
+  /** The base nats config's prior contents, or `undefined` if the file was absent. */
+  natsConfig: string | undefined;
 }
 
 /**
@@ -253,6 +295,17 @@ export interface DaemonPort {
 export interface NatsServerPort {
   /** Restart nats-server so it reloads `local.conf` (the new leaf include). */
   restart(): Promise<{ ok: true } | { ok: false; reason: string }>;
+  /**
+   * #821 — restart-safety HEALTH PROBE. After a restart, confirm nats-server
+   * actually came back UP (its monitor port is listening / the process is
+   * healthy). `launchctl kickstart` / `systemctl restart` can exit 0 even when
+   * the server then crashes on the new config at runtime (the community
+   * incident: the restart "succeeded" but nats-server exited 1 on the bad leaf,
+   * leaving the bus DOWN). The orchestrator probes AFTER the restart; an
+   * unhealthy result triggers a snapshot rollback + re-restart. Returns
+   * `{ healthy: true }` when the server is reachable, else a reason.
+   */
+  isHealthy(): Promise<{ healthy: true } | { healthy: false; reason: string }>;
 }
 
 /**

--- a/src/common/nats/__tests__/leaf-remote-renderer.test.ts
+++ b/src/common/nats/__tests__/leaf-remote-renderer.test.ts
@@ -21,6 +21,7 @@ import { describe, expect, test } from "bun:test";
 import type { NetworkDescriptor } from "../../registry/types";
 import {
   natsConfigHasAccountTree,
+  natsConfigMonitorUrl,
   leafIncludeFileName,
   mergeLeafRemotes,
   renderLeafIncludeFile,
@@ -310,6 +311,74 @@ describe("#799 natsConfigHasAccountTree", () => {
     const commented = "// operator: /x/operator.creds\n# accounts { }\njetstream { }\n";
     expect(natsConfigHasAccountTree(commented)).toBe(false);
   });
+
+  // #821 MAJOR-1 — non-canonical-but-valid operator-mode shapes. The detector
+  // previously checked only the canonical account-tree keys (NSC operator JWT
+  // key / accounts / resolver_preload), so these valid operator-mode configs
+  // (all in this repo's own SOP/migration docs) were misclassified as $G → a
+  // no-account remote was rendered → the #821 crash. Erring toward operator-mode
+  // only OVER-refuses (recoverable); never crashes.
+  test("MAJOR-1: true for a `resolver:`-only config (e.g. resolver: MEMORY)", () => {
+    const conf = ["resolver: MEMORY", "port: 4222", ""].join("\n");
+    expect(natsConfigHasAccountTree(conf)).toBe(true);
+  });
+
+  test("MAJOR-1: true for a `resolver { ... }` block config", () => {
+    const conf = ["resolver {", "  type: full", "  dir: /x/jwt", "}", ""].join("\n");
+    expect(natsConfigHasAccountTree(conf)).toBe(true);
+  });
+
+  test("MAJOR-1: true for a `system_account:`-only config", () => {
+    const conf = ["system_account: ADSYSACCOUNT", "port: 4224", ""].join("\n");
+    expect(natsConfigHasAccountTree(conf)).toBe(true);
+  });
+
+  test("MAJOR-1: true (fail-closed) for an `include` split config", () => {
+    // The account tree may live in the included file; the pure text scanner can't
+    // resolve it, so fail closed — assume operator-mode + require an account.
+    const conf = ['include "accounts.conf"', "port: 4224", ""].join("\n");
+    expect(natsConfigHasAccountTree(conf)).toBe(true);
+  });
+
+  test("MAJOR-1: single-quoted + extra-whitespace include still fails closed", () => {
+    const conf = ["include   'accounts.conf'", "port: 4224", ""].join("\n");
+    expect(natsConfigHasAccountTree(conf)).toBe(true);
+  });
+
+  test("MAJOR-1: a COMMENTED-OUT include/resolver/system_account does NOT count", () => {
+    const commented = [
+      "// include \"accounts.conf\"",
+      "# resolver: MEMORY",
+      "# system_account: ADSYSACCOUNT",
+      "jetstream { store_dir: /x/js }",
+      "",
+    ].join("\n");
+    expect(natsConfigHasAccountTree(commented)).toBe(false);
+  });
+
+  test("MAJOR-1: still false for a genuine $G bus (no operator-mode signal)", () => {
+    // Regression guard: the widened detector must NOT start flagging a real $G
+    // bus (the jc/default case) — that would break #803.
+    expect(natsConfigHasAccountTree(DEFAULT_G_CONF)).toBe(false);
+  });
+
+  test("MAJOR-1: a $G bus with the join's OWN leafnodes-*.conf include stays $G (re-join safe)", () => {
+    // After a $G bus joins once, `ensureLeafInclude` adds `include
+    // "leafnodes-<net>.conf"`. The fail-closed include signal must NOT count the
+    // join's own leaf fragment — else a RE-join flips the $G bus to operator-mode
+    // and over-refuses it (a #803 regression on the idempotent re-join path).
+    const reJoined = [
+      DEFAULT_G_CONF,
+      'include "leafnodes-metafactory-community.conf"',
+      "",
+    ].join("\n");
+    expect(natsConfigHasAccountTree(reJoined)).toBe(false);
+  });
+
+  test("MAJOR-1: a $G bus with a NON-leaf include DOES fail closed (account tree may be there)", () => {
+    const withRealInclude = [DEFAULT_G_CONF, 'include "accounts.conf"', ""].join("\n");
+    expect(natsConfigHasAccountTree(withRealInclude)).toBe(true);
+  });
 });
 
 describe("#799 resolveLeafBindMode", () => {
@@ -373,5 +442,56 @@ describe("#799 resolveLeafBindMode", () => {
     // An empty/whitespace account is "no account offered" — same crash path.
     const mode = resolveLeafBindMode(OPERATOR_MODE_CONF, "   ", true);
     expect(mode.mode).toBe("refuse");
+  });
+});
+
+// #821 MAJOR (code-review) — the health probe must target the bus's OWN monitor
+// port, derived from the nats config, NOT a hardcoded :8222. The community bus
+// monitors on :8224; probing :8222 false-trips rollback on a SUCCESSFUL join.
+describe("#821 natsConfigMonitorUrl", () => {
+  test("derives from `http_port: 8224`", () => {
+    const conf = ["http_port: 8224", "port: 4224", ""].join("\n");
+    expect(natsConfigMonitorUrl(conf)).toBe("http://127.0.0.1:8224");
+  });
+
+  test("derives from `monitor_port: 8224` (alias)", () => {
+    const conf = ["monitor_port: 8224", ""].join("\n");
+    expect(natsConfigMonitorUrl(conf)).toBe("http://127.0.0.1:8224");
+  });
+
+  test("derives host:port from `http: 0.0.0.0:8224` (binds 0.0.0.0 → probe 127.0.0.1)", () => {
+    const conf = ["http: 0.0.0.0:8224", ""].join("\n");
+    // We always PROBE loopback even when the server BINDS 0.0.0.0.
+    expect(natsConfigMonitorUrl(conf)).toBe("http://127.0.0.1:8224");
+  });
+
+  test("derives from `http: \"localhost:8224\"` (quoted)", () => {
+    const conf = ['http: "localhost:8224"', ""].join("\n");
+    expect(natsConfigMonitorUrl(conf)).toBe("http://127.0.0.1:8224");
+  });
+
+  test("derives from a bare `http: 8224` (port only)", () => {
+    const conf = ["http: 8224", ""].join("\n");
+    expect(natsConfigMonitorUrl(conf)).toBe("http://127.0.0.1:8224");
+  });
+
+  test("a COMMENTED-OUT http directive does NOT count", () => {
+    const conf = ["// http_port: 8224", "# http: 8225", "port: 4224", ""].join("\n");
+    expect(natsConfigMonitorUrl(conf)).toBeUndefined();
+  });
+
+  test("no monitor directive → undefined (caller falls back)", () => {
+    expect(natsConfigMonitorUrl(DEFAULT_G_CONF.replace(/http:.*/g, ""))).toBeUndefined();
+  });
+
+  test("the community bus shape (operator-mode + http_port 8224) resolves :8224", () => {
+    const community = [
+      "operator: /Users/andreas/.config/nats/operator.creds",
+      "system_account: ADSYSACCOUNT",
+      "port: 4224",
+      "http_port: 8224",
+      "",
+    ].join("\n");
+    expect(natsConfigMonitorUrl(community)).toBe("http://127.0.0.1:8224");
   });
 });

--- a/src/common/nats/__tests__/leaf-remote-renderer.test.ts
+++ b/src/common/nats/__tests__/leaf-remote-renderer.test.ts
@@ -352,4 +352,26 @@ describe("#799 resolveLeafBindMode", () => {
     const mode = resolveLeafBindMode(otherAccountConf, VALID_ACCOUNT, true);
     expect(mode.mode).toBe("refuse");
   });
+
+  // #821 — THE INCIDENT. An operator-mode bus joined WITHOUT an account
+  // (no --account, no stack.nats_infra.account) must REFUSE, NOT fall through to
+  // creds-only. Rendering a no-account ($G) leaf onto an operator-mode bus makes
+  // nats-server exit 1 at runtime (it rejects a remote that carries no account
+  // nkey) — the crash that took the live andreas/community bus down. The
+  // pre-#821 code skipped the account branch entirely when none was offered and
+  // returned `creds-only` regardless of bus type.
+  test("operator-mode bus + NO account offered + creds → refuse (the #821 crash)", () => {
+    const mode = resolveLeafBindMode(OPERATOR_MODE_CONF, undefined, true);
+    expect(mode.mode).toBe("refuse");
+    if (mode.mode === "refuse") {
+      expect(mode.reason).toContain("operator-mode");
+      expect(mode.reason).toContain("account");
+    }
+  });
+
+  test("operator-mode bus + empty-string account + creds → refuse (#821)", () => {
+    // An empty/whitespace account is "no account offered" — same crash path.
+    const mode = resolveLeafBindMode(OPERATOR_MODE_CONF, "   ", true);
+    expect(mode.mode).toBe("refuse");
+  });
 });

--- a/src/common/nats/__tests__/leaf-remote-renderer.test.ts
+++ b/src/common/nats/__tests__/leaf-remote-renderer.test.ts
@@ -480,6 +480,30 @@ describe("#821 natsConfigMonitorUrl", () => {
     expect(natsConfigMonitorUrl(conf)).toBeUndefined();
   });
 
+  // #821 NIT (item 3) — an INLINE trailing comment on the `http:` directive must
+  // not defeat the port match (else → undefined → false-fallback to :8222 →
+  // false-trip rollback on a HEALTHY join). `http_port:` already tolerated this;
+  // `http:` must be symmetric.
+  test("item-3: `http: 0.0.0.0:8224 # mon` (inline #-comment) derives :8224", () => {
+    const conf = ["http: 0.0.0.0:8224 # monitor", ""].join("\n");
+    expect(natsConfigMonitorUrl(conf)).toBe("http://127.0.0.1:8224");
+  });
+
+  test("item-3: `http: 8224 // mon` (inline //-comment, bare port) derives :8224", () => {
+    const conf = ["http: 8224 // monitor", ""].join("\n");
+    expect(natsConfigMonitorUrl(conf)).toBe("http://127.0.0.1:8224");
+  });
+
+  test("item-3: `http_port: 8224 # mon` stays correct (symmetry regression)", () => {
+    const conf = ["http_port: 8224 # monitor", ""].join("\n");
+    expect(natsConfigMonitorUrl(conf)).toBe("http://127.0.0.1:8224");
+  });
+
+  test("item-3: quoted value with an inline comment after the quote derives the port", () => {
+    const conf = ['http: "localhost:8224"  # mon', ""].join("\n");
+    expect(natsConfigMonitorUrl(conf)).toBe("http://127.0.0.1:8224");
+  });
+
   test("no monitor directive → undefined (caller falls back)", () => {
     expect(natsConfigMonitorUrl(DEFAULT_G_CONF.replace(/http:.*/g, ""))).toBeUndefined();
   });

--- a/src/common/nats/__tests__/nats-config-bind-account.test.ts
+++ b/src/common/nats/__tests__/nats-config-bind-account.test.ts
@@ -129,4 +129,86 @@ describe("natsConfigCanBindAccount", () => {
     const res = natsConfigCanBindAccount(eqForm, ACCOUNT);
     expect(res.canBind).toBe(true);
   });
+
+  // #821 MAJOR-2 — a false-positive bind IS the crash. A substring `includes()`
+  // match (over text that strips only `//`/`#`, not `/* */`) can claim canBind
+  // when nats-server CANNOT resolve the account → an account-bound remote →
+  // `cannot find local account` crash. These cases must all return canBind:false.
+
+  test("MAJOR-2: account named ONLY inside a `/* */` block comment → cannot bind", () => {
+    const blockCommented = [
+      "operator: /x/operator.jwt", // operator-mode so the account-tree gate passes
+      "resolver_preload: {",
+      `  /* historic: ${ACCOUNT}: "old-jwt" */`,
+      `  ${OTHER_ACCOUNT}: "eyJ..."`,
+      "}",
+      "",
+    ].join("\n");
+    const res = natsConfigCanBindAccount(blockCommented, ACCOUNT);
+    expect(res.canBind).toBe(false);
+    expect(res.reason).toContain("does not define account");
+  });
+
+  test("MAJOR-2: a multi-line `/* ... */` block hiding the account → cannot bind", () => {
+    const multiLine = [
+      "operator: /x/operator.jwt", // NSC operator JWT key
+      "/*",
+      `  decommissioned account ${ACCOUNT}`,
+      "*/",
+      "resolver_preload: {",
+      `  ${OTHER_ACCOUNT}: "eyJ..."`,
+      "}",
+      "",
+    ].join("\n");
+    const res = natsConfigCanBindAccount(multiLine, ACCOUNT);
+    expect(res.canBind).toBe(false);
+  });
+
+  test("MAJOR-2: account equal to `system_account` is NOT leaf-bindable → cannot bind", () => {
+    // SYS is the system account; a leaf cannot bind it. If the candidate account
+    // appears ONLY as the system_account value, that is not a bindable account.
+    const sysOnly = [
+      "operator: /x/operator.jwt", // NSC operator JWT key
+      `system_account: ${ACCOUNT}`,
+      "resolver_preload: {",
+      `  ${OTHER_ACCOUNT}: "eyJ..."`,
+      "}",
+      "",
+    ].join("\n");
+    const res = natsConfigCanBindAccount(sysOnly, ACCOUNT);
+    expect(res.canBind).toBe(false);
+  });
+
+  test("MAJOR-2: account as a SUBSTRING of a larger token → cannot bind (token boundary)", () => {
+    // The account string appears only embedded inside a longer base32-ish run
+    // (e.g. a JWT body), never as a standalone key. A bare includes() would
+    // false-positive; a token-boundary match must not.
+    const embedded = [
+      "operator: /x/operator.jwt", // NSC operator JWT key
+      "resolver_preload: {",
+      `  ${OTHER_ACCOUNT}: "eyJ0${ACCOUNT}MOREBASE32TRAILING0123456789ABCDEFGHIJ"`,
+      "}",
+      "",
+    ].join("\n");
+    const res = natsConfigCanBindAccount(embedded, ACCOUNT);
+    expect(res.canBind).toBe(false);
+  });
+
+  test("MAJOR-2 regression: a genuine resolver_preload key still binds", () => {
+    // The token-boundary tightening must NOT break the real bind case.
+    const res = natsConfigCanBindAccount(OPERATOR_WITH_ACCOUNT, ACCOUNT);
+    expect(res.canBind).toBe(true);
+  });
+
+  test("MAJOR-2 regression: an `accounts { ACCOUNT { ... } }` key still binds", () => {
+    const accountsBlock = [
+      "operator: /x/operator.jwt", // NSC operator JWT key
+      "accounts: {",
+      `  ${ACCOUNT}: { jetstream: enabled, users: [] }`,
+      "}",
+      "",
+    ].join("\n");
+    const res = natsConfigCanBindAccount(accountsBlock, ACCOUNT);
+    expect(res.canBind).toBe(true);
+  });
 });

--- a/src/common/nats/__tests__/nats-service-manager.test.ts
+++ b/src/common/nats/__tests__/nats-service-manager.test.ts
@@ -206,6 +206,34 @@ describe("systemd manager — ExecStart ensure-config-arg (live)", () => {
     expect(res.ok).toBe(false);
     if (!res.ok) expect(res.reason).toContain("Failed to restart");
   });
+
+  test("item-2: restart NEVER THROWS when exec throws synchronously (systemctl ENOENT)", async () => {
+    const dir = freshDir();
+    const unitPath = join(dir, "nats-server.service");
+    writeFileSync(unitPath, bareUnit(), "utf-8");
+
+    // Bun.spawn throws synchronously on ENOENT (binary not on PATH). The manager
+    // must honour its documented "never throws" contract → { ok: false }.
+    const throwing: ExecRunner = () => {
+      throw new Error("spawn systemctl ENOENT");
+    };
+    const mgr = selectNatsServiceManager({
+      descriptorPath: unitPath,
+      platform: "linux",
+      mutate: true,
+      exec: throwing,
+    });
+    let threw = false;
+    let res: Awaited<ReturnType<typeof mgr.restart>> | undefined;
+    try {
+      res = await mgr.restart();
+    } catch {
+      threw = true;
+    }
+    expect(threw).toBe(false);
+    expect(res?.ok).toBe(false);
+    if (res && !res.ok) expect(res.reason).toContain("ENOENT");
+  });
 });
 
 // =============================================================================
@@ -249,6 +277,33 @@ describe("launchd manager — plist path unchanged (regression)", () => {
     expect(calls[0]?.[0]).toBe("launchctl");
     expect(calls[0]).toContain("kickstart");
     expect(calls[0]?.join(" ")).toContain("gui/501/homebrew.mxcl.nats-server");
+  });
+
+  test("item-2: restart NEVER THROWS when exec throws synchronously (launchctl ENOENT)", async () => {
+    const dir = freshDir();
+    const plistPath = join(dir, "nats-server.plist");
+    writeFileSync(plistPath, barePlist(), "utf-8");
+
+    const throwing: ExecRunner = () => {
+      throw new Error("spawn launchctl ENOENT");
+    };
+    const mgr = selectNatsServiceManager({
+      descriptorPath: plistPath,
+      platform: "darwin",
+      mutate: true,
+      exec: throwing,
+      uid: 501,
+    });
+    let threw = false;
+    let res: Awaited<ReturnType<typeof mgr.restart>> | undefined;
+    try {
+      res = await mgr.restart();
+    } catch {
+      threw = true;
+    }
+    expect(threw).toBe(false);
+    expect(res?.ok).toBe(false);
+    if (res && !res.ok) expect(res.reason).toContain("ENOENT");
   });
 });
 

--- a/src/common/nats/leaf-remote-renderer.ts
+++ b/src/common/nats/leaf-remote-renderer.ts
@@ -589,8 +589,28 @@ export function resolveLeafBindMode(
     }
   }
 
-  // No account offered (or a `$G` bus where the account is moot) + creds present
-  // → bind via the creds JWT, no `account:` line.
+  // #821 — THE CRASH GUARD. No account offered. A `$G`/default bus binds via the
+  // creds JWT (creds-only). But an operator-mode bus REQUIRES every leaf remote
+  // to declare an account nkey — nats-server exits 1 at runtime (it rejects a
+  // remote with no `account:` line as requiring "account nkeys in remotes") and
+  // the bus goes DOWN. The pre-#821 code returned `creds-only` here regardless
+  // of bus type, so an operator-mode `cortex network join` run without
+  // `--account` rendered a no-account ($G) remote onto the operator-mode bus and
+  // crashed nats-server. Refuse instead, with the same actionable message as the
+  // missing-account case.
+  if (natsConfigHasAccountTree(natsConfigText)) {
+    return {
+      mode: "refuse",
+      reason:
+        "operator-mode bus requires the leaf remote to declare an account nkey, " +
+        "but none was offered (no --account and no stack.nats_infra.account). " +
+        "Rendering a no-account remote would crash nats-server (an operator-mode " +
+        "bus rejects remotes with no account nkey). Pass --account <A…> (or set " +
+        "stack.nats_infra.account).",
+    };
+  }
+
+  // `$G`/default bus + creds present → bind via the creds JWT, no `account:` line.
   return { mode: "creds-only" };
 }
 

--- a/src/common/nats/leaf-remote-renderer.ts
+++ b/src/common/nats/leaf-remote-renderer.ts
@@ -746,12 +746,14 @@ export function natsConfigMonitorUrl(natsConfigText: string): string | undefined
   }
 
   // `http: <value>` — value may be a bare port (`8224`), `host:port`
-  // (`0.0.0.0:8224`), or quoted (`"localhost:8224"`). Take the trailing port.
-  const httpDirective = /^[ \t]*http[ \t]*[:=][ \t]*["']?([^"'\n]+?)["']?[ \t]*$/m.exec(
-    text,
-  );
+  // (`0.0.0.0:8224`), or quoted (`"localhost:8224"`), optionally followed by an
+  // INLINE trailing comment (`# mon` / `// mon`). Capture the rest of the line,
+  // then strip the inline comment + quotes before taking the trailing port.
+  // #821 item-3 — without stripping the inline comment the end-anchored port
+  // match failed (→ undefined → false-fallback to :8222 → false-trip rollback).
+  const httpDirective = /^[ \t]*http[ \t]*[:=][ \t]*(.+)$/m.exec(text);
   if (httpDirective?.[1] !== undefined) {
-    const value = httpDirective[1].trim();
+    const value = stripInlineComment(httpDirective[1]).replace(/["']/g, "").trim();
     // Trailing port: either `:<port>` at the end, or the whole value is a port.
     const portMatch = /(?::|^)(\d{1,5})$/.exec(value);
     if (portMatch?.[1] !== undefined) {
@@ -760,6 +762,16 @@ export function natsConfigMonitorUrl(natsConfigText: string): string | undefined
   }
 
   return undefined;
+}
+
+/**
+ * Strip a trailing inline `#` or `//` comment from a single config-line value.
+ * `0.0.0.0:8224 # mon` → `0.0.0.0:8224`. Conservative: only cuts at a `#` or
+ * `//` that is preceded by whitespace or start-of-string, so a `#`/`//` inside a
+ * value (unusual for a monitor host:port) is left alone.
+ */
+function stripInlineComment(value: string): string {
+  return value.replace(/(^|[ \t])(#|\/\/).*$/, "").trimEnd();
 }
 
 /** Build a loopback monitor url for `port`, or `undefined` if out of range. */

--- a/src/common/nats/leaf-remote-renderer.ts
+++ b/src/common/nats/leaf-remote-renderer.ts
@@ -412,15 +412,27 @@ export function removeLeafInclude(
 // =============================================================================
 
 /**
- * Strip line comments (`//` and `#`) from a nats config so a commented-out
- * account-tree directive or account string can't produce a false positive. We
- * strip only LINE comments (the shapes humans actually leave in `local.conf`);
- * HOCON block comments are rare and treated as content (worst case: a
- * false-positive bind decision inside a block comment, which is benign — the
- * server would simply not see a real account there and the join re-runs).
+ * Strip comments from a nats config so a commented-out account-tree directive or
+ * account string can't produce a false positive.
+ *
+ * #821 MAJOR-2 — we strip BOTH line comments (`//` and `#`) AND HOCON/C-style
+ * block comments (slash-star … star-slash, including multi-line). The earlier
+ * code stripped only line comments and called a block-commented account
+ * "benign" — that was WRONG: a false-positive bind is exactly the #821 crash (an
+ * account named only inside a block comment would make
+ * {@link natsConfigCanBindAccount} return canBind:true → an account-bound remote
+ * → `cannot find local account`). Block comments are replaced with whitespace
+ * (newlines preserved) so line structure — which the operator-mode line-anchored
+ * regexes depend on — is unchanged.
  */
 function stripConfigComments(natsConfigText: string): string {
-  return natsConfigText
+  // Strip block comments first (they may span lines), preserving newlines so the
+  // line-anchored operator-mode detectors keep their line structure. Then strip
+  // whole-line `//` / `#` comments.
+  const noBlocks = natsConfigText.replace(/\/\*[\s\S]*?\*\//g, (m) =>
+    m.replace(/[^\n]/g, " "),
+  );
+  return noBlocks
     .split("\n")
     .map((line) => {
       const trimmed = line.trimStart();
@@ -451,12 +463,16 @@ export interface AccountBindCheck {
  *     account tree (`accounts` / `resolver_preload`). A config with NONE of
  *     these is **anonymous + hard-isolated**: it defines no accounts, so the
  *     account the leaf binds can never be found → `canBind: false`.
- *   - AND the literal `account` nkey-U string must appear in the config (it is
- *     the key/value naming the account in `resolver_preload`/`accounts`). An
- *     operator-mode config that does not name THIS account also cannot bind it
- *     → `canBind: false`.
+ *   - AND the `account` nkey-U must appear as a standalone TOKEN naming the
+ *     account in `resolver_preload`/`accounts` — NOT embedded in a longer token,
+ *     and NOT only as the `system_account` value (the SYS account is not
+ *     leaf-bindable). An operator-mode config that does not name THIS account as
+ *     a bindable account cannot bind it → `canBind: false` (#821 MAJOR-2: a
+ *     false-positive bind IS the crash, so the match is token-bounded, not a
+ *     bare substring).
  *
- * Comments are stripped first so a commented-out directive never counts.
+ * Comments — line (`//`/`#`) AND block (slash-star … star-slash) — are stripped
+ * first so a commented-out directive or account string never counts (MAJOR-2).
  *
  * Pure: reads the text, writes nothing. The caller (the join orchestrator)
  * passes the resolved `config_path` contents and refuses BEFORE any mutation
@@ -490,13 +506,38 @@ export function natsConfigCanBindAccount(
     };
   }
 
-  // operator-mode, but does it name THIS account? The nkey-U appears as the
-  // key (resolver_preload) or value naming the account. A substring check is
-  // sufficient: nkey-U keys are high-entropy and won't collide with prose.
-  if (!text.includes(trimmedAccount)) {
+  // operator-mode, but does it name THIS account as a BINDABLE account?
+  //
+  // #821 MAJOR-2 — a bare `text.includes()` is unsafe (a false-positive bind IS
+  // the crash). We require the nkey-U to appear at a TOKEN BOUNDARY (not embedded
+  // inside a longer base32/alnum run — e.g. a JWT body), AND we EXCLUDE the
+  // `system_account` value (the SYS account is not leaf-bindable). nkey grammar
+  // is `A[A-Z2-7]{55}`, so the "token" charset to bound against is `[A-Za-z0-9]`
+  // (base32 ⊂ alnum); the account must not be flanked by another alnum char.
+  const tokenBoundary = new RegExp(
+    `(?<![A-Za-z0-9])${trimmedAccount}(?![A-Za-z0-9])`,
+  );
+  if (!tokenBoundary.test(text)) {
     return {
       canBind: false,
       reason: `config is operator-mode but does not define account ${trimmedAccount}`,
+    };
+  }
+
+  // The account appears as a standalone token — but if its ONLY appearance is as
+  // the `system_account` value, it is the SYS account, which a leaf cannot bind.
+  // Strip the system_account line(s) and re-test: if the token survives, there is
+  // a genuine (non-SYS) definition; if not, this account is only the SYS account.
+  const withoutSysAccount = text.replace(
+    /^[ \t]*system_account[ \t]*[:=].*$/gm,
+    "",
+  );
+  if (!tokenBoundary.test(withoutSysAccount)) {
+    return {
+      canBind: false,
+      reason:
+        `config is operator-mode but account ${trimmedAccount} is only the ` +
+        `system_account (SYS) — a leaf cannot bind the system account`,
     };
   }
 
@@ -615,19 +656,117 @@ export function resolveLeafBindMode(
 }
 
 /**
- * True iff the config is OPERATOR-MODE — it carries an NSC operator JWT key OR
- * an account tree (`accounts` / `resolver_preload`). The negation is a
- * `$G`/default-account bus (a simple creds-authenticated leaf-client). Mirrors
- * the operator-mode signal inside {@link natsConfigCanBindAccount} (comments
- * stripped first) so the two cannot drift. (#799)
+ * True iff the config is OPERATOR-MODE — it carries any signal of an NSC
+ * account tree. The negation is a `$G`/default-account bus (a simple
+ * creds-authenticated leaf-client). Mirrors the operator-mode signal inside
+ * {@link natsConfigCanBindAccount} (comments stripped first) so the two cannot
+ * drift. (#799)
+ *
+ * #821 MAJOR-1 — the detector must recognise the FULL set of valid operator-mode
+ * shapes, not just the canonical `operator:`/`accounts`/`resolver_preload`.
+ * Missing a valid operator-mode config misclassifies it as `$G` → renders a
+ * no-account remote → the #821 crash. So we add:
+ *
+ *   - `resolver:` / `resolver {` — an NSC JWT resolver (e.g. `resolver: MEMORY`,
+ *     `resolver { type: full … }`). Present ⇒ JWT-based accounts ⇒ operator-mode.
+ *   - `system_account:` — names the SYS account; only operator-mode (account-mode)
+ *     configs declare one.
+ *   - `include "<file>"` — the account tree may be split into an included file
+ *     this pure text scanner cannot resolve. FAIL CLOSED: an `include` ⇒ assume
+ *     operator-mode ⇒ require an account. Erring toward operator-mode only
+ *     OVER-refuses (recoverable — the principal passes `--account`), and never
+ *     renders the no-account remote that crashes nats-server.
+ *
+ * Erring toward operator-mode is the SAFE direction: a false "operator-mode"
+ * blocks a join (recoverable); a false "$G" crashes the server.
  */
 export function natsConfigHasAccountTree(natsConfigText: string): boolean {
   const text = stripConfigComments(natsConfigText);
   return (
     /^[ \t]*operator[ \t]*[:=]/m.test(text) || // NSC operator JWT key
     /^[ \t]*accounts[ \t]*[:={]/m.test(text) ||
-    /^[ \t]*resolver_preload[ \t]*[:={]/m.test(text)
+    /^[ \t]*resolver_preload[ \t]*[:={]/m.test(text) ||
+    // #821 MAJOR-1 — `resolver:` / `resolver =` / `resolver {` (NSC JWT
+    // resolver). The `[ \t]+{` alt catches `resolver { … }` with a space before
+    // the brace; `resolver_preload` is excluded because `_` is not in [ \t:={].
+    /^[ \t]*resolver[ \t]*(?:[:={]|[ \t]+\{)/m.test(text) ||
+    /^[ \t]*system_account[ \t]*[:=]/m.test(text) || // names the SYS account
+    // #821 MAJOR-1 — fail-closed on a split config: an `include "<file>"` may
+    // pull in the account tree we cannot scan here. Treat as operator-mode.
+    // EXCLUDE the join's OWN per-network leaf includes (`leafnodes-<net>.conf`,
+    // {@link leafIncludeFileName}) — those carry the leaf REMOTE, never an
+    // account tree, and `ensureLeafInclude` adds one on the first join. Counting
+    // them would flip a genuine $G bus to "operator-mode" on RE-join and
+    // over-refuse it (a #803 regression). Only a NON-leafnodes include counts.
+    hasNonLeafInclude(text)
   );
+}
+
+/**
+ * True iff `text` carries an `include "<file>"` directive whose target is NOT a
+ * join-managed `leafnodes-<network>.conf` leaf fragment. Used by
+ * {@link natsConfigHasAccountTree} so the join's own leaf include (added by
+ * {@link ensureLeafInclude}) never trips the fail-closed operator-mode signal on
+ * re-join. (#821 MAJOR-1)
+ */
+function hasNonLeafInclude(text: string): boolean {
+  const re = /^[ \t]*include[ \t]+["']([^"']+)["']/gm;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(text)) !== null) {
+    const file = m[1] ?? "";
+    // The join's own leaf fragments are `leafnodes-<network>.conf` — skip them.
+    if (/^leafnodes-[a-z][a-z0-9-]*\.conf$/.test(file)) continue;
+    return true; // a non-leaf include — the account tree may live there.
+  }
+  return false;
+}
+
+/**
+ * #821 MAJOR (code-review) — derive the nats-server HTTP MONITOR url from its
+ * config, so the post-restart health probe targets THIS bus's monitor port (the
+ * community bus monitors on :8224), not a hardcoded :8222. Returns the loopback
+ * monitor url (`http://127.0.0.1:<port>`) parsed from the config's `http_port` /
+ * `monitor_port` / `http` directive, or `undefined` when none is present (the
+ * caller falls back to an explicit `--monitor-url` then the default).
+ *
+ * We always probe LOOPBACK (`127.0.0.1`) regardless of the bind host the config
+ * names (`0.0.0.0`, a LAN ip, a hostname) — the join runs on the same host as
+ * nats-server, so loopback is the correct, security-tight probe target; we take
+ * only the PORT from the config. Comments are stripped first.
+ */
+export function natsConfigMonitorUrl(natsConfigText: string): string | undefined {
+  const text = stripConfigComments(natsConfigText);
+
+  // `http_port: <n>` / `monitor_port: <n>` — the port-only directives.
+  const portDirective = /^[ \t]*(?:http_port|monitor_port)[ \t]*[:=][ \t]*(\d{1,5})\b/m.exec(
+    text,
+  );
+  if (portDirective?.[1] !== undefined) {
+    return monitorUrlForPort(portDirective[1]);
+  }
+
+  // `http: <value>` — value may be a bare port (`8224`), `host:port`
+  // (`0.0.0.0:8224`), or quoted (`"localhost:8224"`). Take the trailing port.
+  const httpDirective = /^[ \t]*http[ \t]*[:=][ \t]*["']?([^"'\n]+?)["']?[ \t]*$/m.exec(
+    text,
+  );
+  if (httpDirective?.[1] !== undefined) {
+    const value = httpDirective[1].trim();
+    // Trailing port: either `:<port>` at the end, or the whole value is a port.
+    const portMatch = /(?::|^)(\d{1,5})$/.exec(value);
+    if (portMatch?.[1] !== undefined) {
+      return monitorUrlForPort(portMatch[1]);
+    }
+  }
+
+  return undefined;
+}
+
+/** Build a loopback monitor url for `port`, or `undefined` if out of range. */
+function monitorUrlForPort(port: string): string | undefined {
+  const n = Number.parseInt(port, 10);
+  if (!Number.isInteger(n) || n <= 0 || n > 65535) return undefined;
+  return `http://127.0.0.1:${n.toString()}`;
 }
 
 /** Serialize one {@link LeafRemote} as a HOCON object literal (indented). */

--- a/src/common/nats/nats-service-manager.ts
+++ b/src/common/nats/nats-service-manager.ts
@@ -221,7 +221,19 @@ class LaunchdServiceManager implements NatsServiceManager {
       return { ok: false, reason: `no <key>Label</key> in nats-server plist ${this.plistPath}` };
     }
     const argv = ["launchctl", "kickstart", "-k", `gui/${this.uid.toString()}/${label}`];
-    const { code, stderr } = await this.exec(argv);
+    // #821 item-2 — `exec` (Bun.spawn) THROWS SYNCHRONOUSLY on ENOENT (launchctl
+    // not on PATH). Honour the documented "never throws" contract: a spawn
+    // failure becomes a clean { ok: false }, never an uncaught escape.
+    let code: number;
+    let stderr: string;
+    try {
+      ({ code, stderr } = await this.exec(argv));
+    } catch (err) {
+      return {
+        ok: false,
+        reason: `launchctl kickstart ${label} could not run: ${err instanceof Error ? err.message : String(err)}`,
+      };
+    }
     if (code !== 0) {
       return {
         ok: false,
@@ -303,7 +315,18 @@ class SystemdServiceManager implements NatsServiceManager {
       scope === "user"
         ? ["systemctl", "--user", "restart", serviceId]
         : ["systemctl", "restart", serviceId];
-    const { code, stderr } = await this.exec(argv);
+    // #821 item-2 — `exec` (Bun.spawn) THROWS SYNCHRONOUSLY on ENOENT (systemctl
+    // not on PATH). Honour the "never throws" contract → { ok: false }.
+    let code: number;
+    let stderr: string;
+    try {
+      ({ code, stderr } = await this.exec(argv));
+    } catch (err) {
+      return {
+        ok: false,
+        reason: `systemctl ${scope === "user" ? "--user " : ""}restart ${serviceId} could not run: ${err instanceof Error ? err.message : String(err)}`,
+      };
+    }
     if (code !== 0) {
       return {
         ok: false,


### PR DESCRIPTION
## Incident (HIGH)
`cortex network join metafactory-community --apply` on the operator-mode `andreas/community` bus, run without `--account`, rendered a no-account (`$G`) leaf remote at a non-existent creds path, restarted nats-server → `operator mode requires account nkeys in remotes`, exit 1, **bus down** — and the join reported success.

## Root cause
`resolveLeafBindMode` (#799) only consulted the bus type INSIDE its `if (hasAccount)` branch; with no account offered it fell straight through to `creds-only`, never checking the bus was operator-mode. `nats-server -t` passed (syntactically valid) — the account requirement is a runtime check.

## Fix — the 3 guarantees
1. **Operator-mode ⇒ account-bound, fail-fast.** `resolveLeafBindMode` now refuses the no-account path when the config has an account tree (operator-mode), with an actionable error. A genuine `$G` bus + creds still renders the no-account remote — **#803 preserved**.
2. **Pre-flight.** Verifies the referenced `.creds` file exists before ANY write/restart (the incident's creds path didn't exist) — refuses otherwise.
3. **Restart-rollback.** Snapshots the leaf include + base config before mutating; probes nats-server health (`/healthz`) after restart; on failure restores the snapshot + re-restarts so the bus returns to its prior state, reporting failure (not false success).

RED-first tests at renderer + orchestration + live-adapter levels (operator-mode+no-account refuses; missing creds refuses; failed restart rolls back; `$G`+creds still joins). 5004 tests / 0 fail, tsc/lint/vocab clean. closes #821.