### PR TITLE
fix(network-registry): #825 — optimistic-concurrency CAS for concurrent register/join

### DIFF
--- a/src/bus/stack-provisioning.ts
+++ b/src/bus/stack-provisioning.ts
@@ -117,6 +117,8 @@ export interface RegistrationClaimShape {
     metadata?: Record<string, string>;
   }[];
   capabilities: { id: string; description?: string; networks?: string[] }[];
+  /** #825 — optimistic-concurrency CAS token (record `updated_at` the merge read). */
+  expected_updated_at?: string;
   issued_at: string;
   nonce: string;
 }
@@ -379,6 +381,14 @@ export interface BuildRegistrationClaimOptions {
    * @internal
    */
   readonly nonce?: string;
+  /**
+   * #825 — optimistic-concurrency CAS token: the `updated_at` of the record the
+   * merge was computed from (from `resolveMergedStacks().existingUpdatedAt`).
+   * When set, it is signed into the claim as `expected_updated_at`; the registry
+   * CAS-rejects (`409 stale_record`) if the row changed since. Omit on a first
+   * register / when no existing record was read.
+   */
+  readonly expectedUpdatedAt?: string;
 }
 
 /**
@@ -416,6 +426,7 @@ export async function buildRegistrationClaim(
     principal_pubkey: authority.pubkeyB64,
     stacks,
     capabilities: opts.capabilities ?? [],
+    ...(opts.expectedUpdatedAt !== undefined && { expected_updated_at: opts.expectedUpdatedAt }),
     issued_at: opts.issuedAt ?? new Date().toISOString(),
     nonce: opts.nonce ?? randomNonce(),
   };
@@ -631,7 +642,7 @@ export interface FetchExistingStacksOptions {
  *                  C-791 verified-merge-read security fix).
  */
 export type FetchExistingStacksResult =
-  | { kind: "present"; stacks: StackEntryShape[]; capabilities: CapabilityEntryShape[] }
+  | { kind: "present"; stacks: StackEntryShape[]; capabilities: CapabilityEntryShape[]; updated_at?: string }
   | { kind: "absent" }
   | { kind: "error"; reason: string };
 
@@ -722,7 +733,7 @@ export async function fetchExistingStacks(
 
   // Shape: verified payload is a PrincipalRecord → payload.stacks[] + .capabilities[].
   const payload = verified.payload as
-    | { stacks?: unknown; capabilities?: unknown }
+    | { stacks?: unknown; capabilities?: unknown; updated_at?: unknown }
     | null;
   const stacksRaw = payload?.stacks;
   if (!Array.isArray(stacksRaw)) {
@@ -749,7 +760,10 @@ export async function fetchExistingStacks(
       }
     }
   }
-  return { kind: "present", stacks, capabilities };
+  // #825 — surface the record's `updated_at` so the caller can send it as the
+  // claim's `expected_updated_at` (optimistic-concurrency CAS token).
+  const updatedAt = typeof payload?.updated_at === "string" ? payload.updated_at : undefined;
+  return { kind: "present", stacks, capabilities, ...(updatedAt !== undefined && { updated_at: updatedAt }) };
 }
 
 // =============================================================================
@@ -818,7 +832,7 @@ export interface ResolveMergedStacksOptions {
  */
 export async function resolveMergedStacks(
   opts: ResolveMergedStacksOptions,
-): Promise<{ ok: true; stacks: ClaimStack[] } | { ok: false; reason: string }> {
+): Promise<{ ok: true; stacks: ClaimStack[]; existingUpdatedAt?: string } | { ok: false; reason: string }> {
   const newStack: ClaimStack = { stack_id: opts.stackId, stack_pubkey: opts.stackPubkey };
   if (!opts.isAddStack) {
     return { ok: true, stacks: [newStack] };
@@ -867,7 +881,8 @@ export async function resolveMergedStacks(
   } else {
     merged.push(newStack);
   }
-  return { ok: true, stacks: merged };
+  // #825 — carry the read record's updated_at as the CAS token for the claim.
+  return { ok: true, stacks: merged, ...(existing.updated_at !== undefined && { existingUpdatedAt: existing.updated_at }) };
 }
 
 /** A capability as carried in a registration claim. */

--- a/src/cli/cortex/commands/network-adapters.ts
+++ b/src/cli/cortex/commands/network-adapters.ts
@@ -296,6 +296,9 @@ async function registerWithCapabilities(
     ...(rootMaterial !== undefined && { rootMaterial }),
     stacks: stacksRes.stacks,
     capabilities: capsRes.capabilities,
+    // #825 — CAS token: the updated_at the merge read. The route 409s on a
+    // concurrent change so two hosts joining/registering can't lost-update.
+    ...(stacksRes.existingUpdatedAt !== undefined && { expectedUpdatedAt: stacksRes.existingUpdatedAt }),
   });
   let result;
   try {

--- a/src/cli/cortex/commands/provision-stack.ts
+++ b/src/cli/cortex/commands/provision-stack.ts
@@ -418,6 +418,9 @@ async function doRegister(
       // C-819 — re-attest the merged (preserved) capability set so the route's
       // full-overwrite writes the complete set instead of clobbering to empty.
       capabilities: capsRes.capabilities,
+      // #825 — CAS token: the updated_at the merge read. The route rejects
+      // (409 stale_record) if a concurrent host changed the row since.
+      ...(stacksRes.existingUpdatedAt !== undefined && { expectedUpdatedAt: stacksRes.existingUpdatedAt }),
     });
   } catch (err) {
     return { ok: false, reason: `failed to build registration claim: ${err instanceof Error ? err.message : String(err)}` };

--- a/src/services/network-registry/__tests__/d1-mock.ts
+++ b/src/services/network-registry/__tests__/d1-mock.ts
@@ -123,13 +123,22 @@ export class MockD1 {
 
     // principals: UPSERT
     if (sql.startsWith("INSERT INTO principals")) {
-      const [principalId, pubkey, stacks, capabilities, updatedAt] = args as [
+      const [principalId, pubkey, stacks, capabilities, updatedAt, expectedUpdatedAt] = args as [
         string,
         string,
         string,
         string,
         string,
+        string | undefined,
       ];
+      // #825 — when the SQL carries the optimistic-concurrency upsert guard
+      // (`... ON CONFLICT DO UPDATE SET ... WHERE principals.updated_at = ?`),
+      // honour it: an existing row whose updated_at != the expected (last bind)
+      // means the conflict-update's WHERE is false → no-op → changes === 0.
+      const existing = this.principals.get(principalId);
+      if (sql.includes("WHERE principals.updated_at = ?") && existing && existing.updated_at !== expectedUpdatedAt) {
+        return { meta: { changes: 0 } };
+      }
       this.principals.set(principalId, {
         principal_id: principalId,
         principal_pubkey: pubkey,

--- a/src/services/network-registry/__tests__/d1-store.test.ts
+++ b/src/services/network-registry/__tests__/d1-store.test.ts
@@ -15,6 +15,7 @@ import {
   D1RegistryStore,
   InMemoryRegistryStore,
   InMemoryNonceCache,
+  StaleRecordError,
   NONCE_WINDOW_MS,
   getStore,
   getNonceCache,
@@ -60,6 +61,47 @@ describe("D1RegistryStore", () => {
   test("getPrincipal returns undefined for unknown id", async () => {
     const store = new D1RegistryStore(asD1(new MockD1()));
     expect(await store.getPrincipal("nobody")).toBeUndefined();
+  });
+
+  // #825 — optimistic concurrency: a CAS write only lands if the stored
+  // updated_at still matches the value the caller's read-merge was based on.
+  describe("putPrincipal CAS (#825)", () => {
+    test("matching expectedUpdatedAt → write lands", async () => {
+      const store = new D1RegistryStore(asD1(new MockD1()));
+      const first = await store.putPrincipal("p", "k", [], []);
+      const second = await store.putPrincipal("p", "k", stacks, [], first.updated_at);
+      expect(second.stacks).toEqual(stacks);
+      expect((await store.getPrincipal("p"))!.stacks).toEqual(stacks);
+    });
+
+    test("stale expectedUpdatedAt → StaleRecordError, record unchanged", async () => {
+      const store = new D1RegistryStore(asD1(new MockD1()));
+      const first = await store.putPrincipal("p", "k", stacks, []);
+      let threw: unknown;
+      try {
+        await store.putPrincipal("p", "k", [], [], "1999-01-01T00:00:00.000Z");
+      } catch (e) {
+        threw = e;
+      }
+      expect(threw).toBeInstanceOf(StaleRecordError);
+      // The winner's record is intact — the stale write did NOT clobber it.
+      expect((await store.getPrincipal("p"))!.stacks).toEqual(stacks);
+      expect((await store.getPrincipal("p"))!.updated_at).toBe(first.updated_at);
+    });
+
+    test("no existing record → CAS is a no-op (nothing to clobber)", async () => {
+      const store = new D1RegistryStore(asD1(new MockD1()));
+      const written = await store.putPrincipal("fresh", "k", stacks, [], "1999-01-01T00:00:00.000Z");
+      expect(written.stacks).toEqual(stacks);
+    });
+
+    test("InMemory store enforces the same CAS", async () => {
+      const store = new InMemoryRegistryStore();
+      await store.putPrincipal("p", "k", stacks, []);
+      await expect(
+        store.putPrincipal("p", "k", [], [], "1999-01-01T00:00:00.000Z"),
+      ).rejects.toBeInstanceOf(StaleRecordError);
+    });
   });
 
   test("listPrincipals returns every stored principal", async () => {

--- a/src/services/network-registry/__tests__/helpers.ts
+++ b/src/services/network-registry/__tests__/helpers.ts
@@ -74,6 +74,8 @@ export async function makeSignedRegistration(
     pubkeyOverride?: string;
     /** Sign with a DIFFERENT key than `pKey` — forged-signature tests (C-787). */
     signWith?: PrincipalKey;
+    /** #825 — optimistic-concurrency CAS token signed into the claim. */
+    expectedUpdatedAt?: string;
   } = {},
 ): Promise<{ claim: RegistrationClaim; signature: string }> {
   const claim: RegistrationClaim = {
@@ -81,6 +83,7 @@ export async function makeSignedRegistration(
     principal_pubkey: opts.pubkeyOverride ?? pKey.publicKeyB64,
     stacks: opts.stacks ?? [],
     capabilities: opts.capabilities ?? [],
+    ...(opts.expectedUpdatedAt !== undefined && { expected_updated_at: opts.expectedUpdatedAt }),
     issued_at: opts.issuedAt ?? new Date().toISOString(),
     nonce: opts.nonce ?? randomNonce(),
   };

--- a/src/services/network-registry/__tests__/principals.test.ts
+++ b/src/services/network-registry/__tests__/principals.test.ts
@@ -85,6 +85,50 @@ describe("POST /principals/:id/register — happy path", () => {
   });
 });
 
+describe("POST /principals/:id/register — optimistic concurrency (#825)", () => {
+  // End-to-end through the SIGNED wire path: the CAS token rides inside the
+  // signed claim, so this also pins that adding `expected_updated_at` doesn't
+  // break signature verification (the validator must preserve it).
+  test("stale expected_updated_at → 409 stale_record with the live current_updated_at", async () => {
+    const v1 = await makeSignedRegistration("andreas", pKey, {
+      stacks: [{ stack_id: "andreas/laptop" }],
+    });
+    const r1 = await post("/principals/andreas/register", v1);
+    expect(r1.status).toBe(201);
+    const live = ((await r1.json()) as SignedAssertion<PrincipalRecord>).payload.updated_at;
+
+    // A second host whose read-merge was based on a now-stale version.
+    const stale = await makeSignedRegistration("andreas", pKey, {
+      stacks: [{ stack_id: "andreas/laptop" }, { stack_id: "andreas/desktop" }],
+      expectedUpdatedAt: "2000-01-01T00:00:00.000Z",
+    });
+    const r2 = await post("/principals/andreas/register", stale);
+    expect(r2.status).toBe(409);
+    const body = (await r2.json()) as { error: string; current_updated_at: string };
+    expect(body.error).toBe("stale_record");
+    expect(body.current_updated_at).toBe(live);
+
+    // The winner's record is intact — the stale write did NOT clobber it.
+    const got = (await (await get("/principals/andreas")).json()) as SignedAssertion<PrincipalRecord>;
+    expect(got.payload.stacks).toHaveLength(1); // desktop was rejected, not added
+  });
+
+  test("matching expected_updated_at → write lands (201)", async () => {
+    const v1 = await makeSignedRegistration("andreas", pKey, {
+      stacks: [{ stack_id: "andreas/laptop" }],
+    });
+    const live = ((await (await post("/principals/andreas/register", v1)).json()) as SignedAssertion<PrincipalRecord>).payload.updated_at;
+
+    const v2 = await makeSignedRegistration("andreas", pKey, {
+      stacks: [{ stack_id: "andreas/laptop" }, { stack_id: "andreas/desktop" }],
+      expectedUpdatedAt: live,
+    });
+    const r2 = await post("/principals/andreas/register", v2);
+    expect(r2.status).toBe(201);
+    expect(((await r2.json()) as SignedAssertion<PrincipalRecord>).payload.stacks).toHaveLength(2);
+  });
+});
+
 describe("POST /principals/:id/register — validation failures", () => {
   test("rejects invalid principal_id in path", async () => {
     const body = await makeSignedRegistration("andreas", pKey);

--- a/src/services/network-registry/src/routes/principals.ts
+++ b/src/services/network-registry/src/routes/principals.ts
@@ -16,7 +16,7 @@
 import { Hono } from "hono";
 import { getRegistryPublicKey, type Env } from "../index";
 import { signEd25519, verifyEd25519, canonicalJSON } from "../signing";
-import { getNonceCache, getStore } from "../store";
+import { getNonceCache, getStore, StaleRecordError } from "../store";
 import {
   checkRateLimit,
   clientKey,
@@ -175,12 +175,33 @@ export function principalRoutes(): Hono<{ Bindings: Env }> {
       stack_pubkey: s.stack_pubkey ?? claim.principal_pubkey,
     }));
 
-    const record = await store.putPrincipal(
-      principalId,
-      claim.principal_pubkey,
-      stacksWithPubkeys,
-      claim.capabilities,
-    );
+    // #825 — optimistic concurrency. The client read-merged from a record at
+    // `claim.expected_updated_at`; CAS the write so a concurrent host that
+    // mutated the row in between is rejected (409) rather than silently
+    // clobbered. Absent on a first register → unconditional upsert (unchanged).
+    let record: PrincipalRecord;
+    try {
+      record = await store.putPrincipal(
+        principalId,
+        claim.principal_pubkey,
+        stacksWithPubkeys,
+        claim.capabilities,
+        claim.expected_updated_at,
+      );
+    } catch (err) {
+      if (err instanceof StaleRecordError) {
+        return c.json(
+          {
+            error: "stale_record",
+            details:
+              "the principal record changed since your read; re-read, re-merge, and retry",
+            current_updated_at: err.current?.updated_at ?? null,
+          },
+          409,
+        );
+      }
+      throw err;
+    }
 
     // Sign + return the canonical view so the principal gets the same
     // signed assertion shape peers will see.

--- a/src/services/network-registry/src/store.ts
+++ b/src/services/network-registry/src/store.ts
@@ -366,8 +366,9 @@ export class D1RegistryStore implements RegistryStore {
     // mutated the row since this caller's verified read leaves `updated_at`
     // mismatched, the WHERE is false, the UPDATE is a no-op (changes === 0), and
     // we raise StaleRecordError so the loser re-reads + re-merges instead of
-    // silently clobbering the winner. `updated_at` is always a fresh timestamp,
-    // so a matched CAS always reports changes >= 1 (no false conflict on no-op).
+    // silently clobbering the winner. No false-conflict risk: SQLite counts the
+    // conflict-target match, not a value delta, so a matched CAS reports
+    // changes === 1 even for a byte-identical update (verified vs sqlite3 3.41).
     const sql = expectedUpdatedAt === undefined
       ? `INSERT INTO principals (principal_id, principal_pubkey, stacks, capabilities, updated_at)
          VALUES (?, ?, ?, ?, ?)
@@ -393,7 +394,9 @@ export class D1RegistryStore implements RegistryStore {
 
     if (expectedUpdatedAt !== undefined && (res.meta?.changes ?? 0) === 0) {
       // CAS failed: a row existed whose updated_at != expected (a fresh INSERT
-      // would have reported changes === 1). Surface the current row for the 409.
+      // would have reported changes === 1). Re-read the current row for the 409
+      // body — best-effort + non-atomic (a third writer could change it again),
+      // so `current_updated_at` is advisory, not an authoritative retry token.
       const current = await this.getPrincipal(principalId);
       throw new StaleRecordError(current);
     }

--- a/src/services/network-registry/src/store.ts
+++ b/src/services/network-registry/src/store.ts
@@ -82,17 +82,38 @@ export interface D1PreparedLike {
 // Store interface
 // =============================================================================
 
+/**
+ * Optimistic-concurrency conflict (#825). Thrown by `putPrincipal` when the
+ * caller passed `expectedUpdatedAt` and the stored row's `updated_at` no longer
+ * matches — i.e. another writer (a second host doing a concurrent register/join)
+ * mutated the record between this caller's verified read-merge and its write.
+ * The route maps it to `409 stale_record`; the client re-reads, re-merges, retries.
+ */
+export class StaleRecordError extends Error {
+  constructor(public readonly current: PrincipalRecord | undefined) {
+    super("stale_record: principal record changed since the expected version");
+    this.name = "StaleRecordError";
+  }
+}
+
 export interface RegistryStore {
   /**
    * Upsert a principal record. Returns the post-write view. The
    * `validate` step at the route layer has already enforced grammar
    * + signature; the store only worries about persistence.
+   *
+   * `expectedUpdatedAt` (#825 — optimistic concurrency): when provided, the
+   * write is a compare-and-set — it succeeds only if the stored row's
+   * `updated_at` equals this value (or no row exists yet). On mismatch it
+   * throws `StaleRecordError`. Omit it for the first register / non-merging
+   * writes (unconditional upsert — backward-compatible).
    */
   putPrincipal(
     principalId: string,
     pubkey: string,
     stacks: StackIdentity[],
     capabilities: Capability[],
+    expectedUpdatedAt?: string,
   ): Promise<PrincipalRecord>;
 
   getPrincipal(principalId: string): Promise<PrincipalRecord | undefined>;
@@ -266,7 +287,16 @@ export class InMemoryRegistryStore implements RegistryStore {
     pubkey: string,
     stacks: StackIdentity[],
     capabilities: Capability[],
+    expectedUpdatedAt?: string,
   ): Promise<PrincipalRecord> {
+    if (expectedUpdatedAt !== undefined) {
+      const current = this.principals.get(principalId);
+      // CAS: only enforce against an existing row. If the record is gone, the
+      // merge had nothing to preserve, so a fresh write loses nothing.
+      if (current && current.updated_at !== expectedUpdatedAt) {
+        throw new StaleRecordError(current);
+      }
+    }
     const record: PrincipalRecord = {
       principal_id: principalId,
       principal_pubkey: pubkey,
@@ -319,6 +349,7 @@ export class D1RegistryStore implements RegistryStore {
     pubkey: string,
     stacks: StackIdentity[],
     capabilities: Capability[],
+    expectedUpdatedAt?: string,
   ): Promise<PrincipalRecord> {
     const record: PrincipalRecord = {
       principal_id: principalId,
@@ -327,28 +358,45 @@ export class D1RegistryStore implements RegistryStore {
       capabilities,
       updated_at: new Date().toISOString(),
     };
-    // UPSERT: a re-register replaces the row in place, so the new stacks/
-    // capabilities fully overwrite the old (matches InMemory semantics —
-    // no leftover stacks). Parameterised; the JSON columns hold the
-    // serialised lists.
-    await this.db
-      .prepare(
-        `INSERT INTO principals (principal_id, principal_pubkey, stacks, capabilities, updated_at)
+
+    // UPSERT. Without `expectedUpdatedAt` it is an unconditional overwrite (the
+    // new stacks/capabilities fully replace the old — matches InMemory; this is
+    // the first-register / non-merging path). WITH it (#825), the conflict-update
+    // carries an upsert `WHERE updated_at = ?` guard: a concurrent host that
+    // mutated the row since this caller's verified read leaves `updated_at`
+    // mismatched, the WHERE is false, the UPDATE is a no-op (changes === 0), and
+    // we raise StaleRecordError so the loser re-reads + re-merges instead of
+    // silently clobbering the winner. `updated_at` is always a fresh timestamp,
+    // so a matched CAS always reports changes >= 1 (no false conflict on no-op).
+    const sql = expectedUpdatedAt === undefined
+      ? `INSERT INTO principals (principal_id, principal_pubkey, stacks, capabilities, updated_at)
          VALUES (?, ?, ?, ?, ?)
          ON CONFLICT(principal_id) DO UPDATE SET
            principal_pubkey = excluded.principal_pubkey,
            stacks           = excluded.stacks,
            capabilities     = excluded.capabilities,
-           updated_at       = excluded.updated_at`,
-      )
-      .bind(
-        principalId,
-        pubkey,
-        JSON.stringify(stacks),
-        JSON.stringify(capabilities),
-        record.updated_at,
-      )
-      .run();
+           updated_at       = excluded.updated_at`
+      : `INSERT INTO principals (principal_id, principal_pubkey, stacks, capabilities, updated_at)
+         VALUES (?, ?, ?, ?, ?)
+         ON CONFLICT(principal_id) DO UPDATE SET
+           principal_pubkey = excluded.principal_pubkey,
+           stacks           = excluded.stacks,
+           capabilities     = excluded.capabilities,
+           updated_at       = excluded.updated_at
+         WHERE principals.updated_at = ?`;
+
+    const binds = expectedUpdatedAt === undefined
+      ? [principalId, pubkey, JSON.stringify(stacks), JSON.stringify(capabilities), record.updated_at]
+      : [principalId, pubkey, JSON.stringify(stacks), JSON.stringify(capabilities), record.updated_at, expectedUpdatedAt];
+
+    const res = await this.db.prepare(sql).bind(...binds).run();
+
+    if (expectedUpdatedAt !== undefined && (res.meta?.changes ?? 0) === 0) {
+      // CAS failed: a row existed whose updated_at != expected (a fresh INSERT
+      // would have reported changes === 1). Surface the current row for the 409.
+      const current = await this.getPrincipal(principalId);
+      throw new StaleRecordError(current);
+    }
     return record;
   }
 

--- a/src/services/network-registry/src/types.ts
+++ b/src/services/network-registry/src/types.ts
@@ -87,6 +87,16 @@ export interface RegistrationClaim {
   stacks: StackIdentity[];
   /** Capabilities the principal wants advertised. */
   capabilities: Capability[];
+  /**
+   * #825 — optimistic concurrency. The `updated_at` of the record this claim's
+   * merge was computed from (captured during the client's verified read). The
+   * registry compare-and-sets on it: if the stored row changed since (a
+   * concurrent host's register/join), the write is rejected `409 stale_record`
+   * and the client re-reads + re-merges. Omitted on a first register / when the
+   * client read no existing record (nothing to clobber). Part of the signed
+   * canonical payload — a MITM cannot strip or forge the CAS token.
+   */
+  expected_updated_at?: string;
   /** ISO-8601 UTC timestamp at which the principal signed this claim. */
   issued_at: string;
   /**

--- a/src/services/network-registry/src/validate.ts
+++ b/src/services/network-registry/src/validate.ts
@@ -300,6 +300,14 @@ export function validateRegistrationClaim(
     errors.push({ field: "nonce", message: "must be a string between 8 and 128 chars" });
   }
 
+  // #825 — optional optimistic-concurrency token. Must be a string when present.
+  // CRITICAL: it is part of the SIGNED canonical claim, so it must be PRESERVED
+  // into the reconstructed claim verbatim — silently dropping it would change the
+  // canonical bytes the route verifies and reject every CAS-bearing claim (401).
+  if (c.expected_updated_at !== undefined && typeof c.expected_updated_at !== "string") {
+    errors.push({ field: "expected_updated_at", message: "must be a string when present" });
+  }
+
   if (errors.length > 0) return { ok: false, errors };
 
   return {
@@ -309,6 +317,7 @@ export function validateRegistrationClaim(
       principal_pubkey: c.principal_pubkey as string,
       stacks,
       capabilities,
+      ...(typeof c.expected_updated_at === "string" && { expected_updated_at: c.expected_updated_at }),
       issued_at: c.issued_at as string,
       nonce: c.nonce as string,
     },


### PR DESCRIPTION
## #825 — registry CAS (the Model-B multi-host companion to the merge fix)

The principal-record clobber (register/join overwriting each other's half) was already fixed by **#823 (C-819)** + **C-791** — client-side **fail-closed read-merge → complete root-signed claim** (the approach `wire-check` endorsed; server-side merge A was correctly avoided). But that merge is `GET-merge-POST` with **no version guard**, so two hosts (JC's two-machine Model B) registering/joining **concurrently** still lost-update each other. This adds the optimistic-concurrency CAS that closes it.

### Server (compare-and-set)
- `store.putPrincipal(..., expectedUpdatedAt?)` — CAS write. **D1**: `ON CONFLICT DO UPDATE SET … WHERE principals.updated_at = ?` (no-op → `changes===0` → conflict). **InMemory**: mirrors it. On mismatch → new **`StaleRecordError`**. Absent → unconditional upsert (first register / backward-compatible). **No server-side union** — preserves "root attests the whole record."
- register route → `409 stale_record` + `current_updated_at` on conflict.
- **`validate.ts` preserves `expected_updated_at`** in the reconstructed claim — it's inside the SIGNED canonical payload, so dropping it broke sig-verify (this was 401-ing every CAS add-stack until fixed; caught by the existing C-787/C-819 tests).

### Client (send the token)
- `fetchExistingStacks` surfaces the read record's `updated_at` → `resolveMergedStacks().existingUpdatedAt` → `buildRegistrationClaim` signs it as `expected_updated_at` → both `provision-stack register` + `network join` pass it. `canonicalJSON` sorts keys ⇒ the optional field is signature-safe.

### Verification
- New CAS tests (D1 via extended mock honouring the upsert `WHERE`/`changes`, + InMemory): match lands · stale → `StaleRecordError` (winner's record intact) · absent → no-op. **1109 pass / 0 fail.**
- root `tsc` clean · lint 0 errors · carve-outs PASS.
- Auto-retry on 409 (re-read + re-merge) deferred as polish — without it a concurrent loser gets a clear `stale_record` and re-runs; **no lost update** either way.

Closes #825. Validated against CONTEXT.md + ADR-0001 via `wire-check` (control-plane; "root attests whole record" upheld, networks stay control-plane).

🤖 Generated with [Claude Code](https://claude.com/claude-code)