### PR TITLE
fix(network): C-830 ping config-split aware + C-831 join health inconclusive on absent monitor

### DIFF
--- a/src/cli/cortex/commands/__tests__/network-adapters.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-adapters.test.ts
@@ -938,6 +938,24 @@ describe("#821 live leaf-file pre-flight + rollback adapters", () => {
     expect(res.healthy).toBe(true);
   });
 
+  test("#831 isHealthy is INCONCLUSIVE (healthy) when the bus declares no monitor", async () => {
+    // JC's single-file local.conf had no http_port → resolveMonitorBase fell
+    // back to :8222 and the probe ECONNREFUSED-rolled-back a GOOD join. With no
+    // monitor configured the probe is inconclusive, not a failure → healthy:true.
+    const dir = freshDir();
+    const conf = join(dir, "local.conf");
+    writeFileSync(conf, "listen: 127.0.0.1:4222\n", "utf-8"); // no http_port
+    const ports = buildLivePorts(cfgWithConfig(conf)); // no monitorUrl
+    const res = await ports.natsServer!.isHealthy();
+    expect(res.healthy).toBe(true);
+  });
+
+  test("#831 a CONFIGURED-but-down monitor still reports UNhealthy (safety intact)", async () => {
+    const ports = buildLivePorts({ ...cfgWithConfig("/x/local.conf"), monitorUrl: "http://127.0.0.1:1" });
+    const res = await ports.natsServer!.isHealthy();
+    expect(res.healthy).toBe(false);
+  });
+
   test("MAJOR: isHealthy TIMES OUT (healthy:false) when the monitor accepts but never responds", async () => {
     // A nats-server that accepts the monitor TCP connection but HANGS (never
     // sends a response) is exactly the deadlock the probe exists to catch. An

--- a/src/cli/cortex/commands/__tests__/network-ping-cli.test.ts
+++ b/src/cli/cortex/commands/__tests__/network-ping-cli.test.ts
@@ -115,6 +115,22 @@ describe("cortex network ping — verdicts + exit codes", () => {
     expect(bus.stopped()).toBe(true);
   });
 
+  test("#830 resolves the LOCAL stack config layout-aware from --stack (not the flat default)", async () => {
+    // The bug: ping ignored --stack/--principal and read the flat
+    // DEFAULT_CONFIG_PATH (~/.config/cortex/cortex.yaml), so a config-split stack's
+    // peers were invisible → false not-configured. The fix ports #814's
+    // resolveStatusConfigPath: --stack selects the slug-specific locator.
+    let seenPath = "";
+    const capturingReader = (path: string): LoadedConfig => {
+      seenPath = path;
+      return readerWithPeer()();
+    };
+    const bus = fakeBusFactory((f) => echoReply(f, 41));
+    await dispatchNetwork(["ping", "jc", "--stack", "andreas/c830slice"], capturingReader, bus.factory);
+    expect(seenPath).toContain("c830slice"); // slug-specific locator, honoured --stack
+    expect(seenPath.endsWith("/cortex.yaml")).toBe(false); // NOT the bare flat default
+  });
+
   test("not-configured — exit 2, bus NEVER built (nothing emitted)", async () => {
     const bus = fakeBusFactory((f) => echoReply(f, 1));
     const res = await dispatchNetwork(

--- a/src/cli/cortex/commands/network-adapters.ts
+++ b/src/cli/cortex/commands/network-adapters.ts
@@ -903,14 +903,18 @@ export const DEFAULT_HEALTH_PROBE_TIMEOUT_MS = 5000;
  *   3. the upstream default `:8222`.
  * The config read is best-effort (a missing/unreadable file just falls through).
  */
-function resolveMonitorBase(cfg: LivePortsConfig): string {
-  if (cfg.monitorUrl !== undefined && cfg.monitorUrl !== "") return cfg.monitorUrl;
+function resolveMonitorBase(cfg: LivePortsConfig): { url: string; configured: boolean } {
+  // #831 — `configured` says whether THIS bus actually declares a monitor
+  // (explicit `--monitor-url` or an `http_port`/`monitor` in its nats config),
+  // vs falling back to the upstream default `:8222`. The health probe uses it to
+  // treat an absent monitor as INCONCLUSIVE rather than a failure.
+  if (cfg.monitorUrl !== undefined && cfg.monitorUrl !== "") return { url: cfg.monitorUrl, configured: true };
   const configPath = expandTilde(cfg.natsConfigPath ?? "");
   if (configPath.length > 0 && existsSync(configPath)) {
     const derived = natsConfigMonitorUrl(readFileSync(configPath, "utf-8"));
-    if (derived !== undefined) return derived;
+    if (derived !== undefined) return { url: derived, configured: true };
   }
-  return DEFAULT_MONITOR_URL;
+  return { url: DEFAULT_MONITOR_URL, configured: false };
 }
 
 function buildNatsServerPort(cfg: LivePortsConfig, mutate: boolean): NatsServerPort {
@@ -981,7 +985,15 @@ function buildNatsServerPort(cfg: LivePortsConfig, mutate: boolean): NatsServerP
       // join. Precedence: explicit --monitor-url wins; else derive the port from
       // the stack's nats config (`http_port`/`monitor_port`/`http`); else the
       // upstream default.
-      const base = resolveMonitorBase(cfg).replace(/\/+$/, "");
+      const monitor = resolveMonitorBase(cfg);
+      // #831 — when THIS bus declares no monitor, the liveness probe is
+      // INCONCLUSIVE, not a failure. `restart()` already exited 0; without a
+      // monitor we cannot confirm liveness, but we MUST NOT roll back a join
+      // whose policy + peer were already written (the false-FAIL incident: a
+      // single-file `local.conf` with no `http_port` ECONNREFUSED `:8222` and
+      // rolled back a good join). Absent monitor → treat as healthy.
+      if (!monitor.configured) return { healthy: true };
+      const base = monitor.url.replace(/\/+$/, "");
       // #821 MAJOR — BOUND the probe. A monitor that accepts the TCP connection
       // but never responds (hung/deadlocked nats-server — exactly the failure the
       // probe exists to catch) would hang an unbounded `fetch` forever and stall
@@ -1041,7 +1053,7 @@ export function buildLeafStatePort(cfg: LivePortsConfig): LeafStatePort {
   // #821 MAJOR (code-review) — use the SAME monitor-base resolution as the health
   // probe (explicit flag → derived-from-config → default), so status reads the
   // bus's OWN monitor port (community :8224) instead of the wrong default :8222.
-  const base = resolveMonitorBase(cfg).replace(/\/+$/, "");
+  const base = resolveMonitorBase(cfg).url.replace(/\/+$/, "");
   return {
     async linkStates() {
       try {

--- a/src/cli/cortex/commands/network.ts
+++ b/src/cli/cortex/commands/network.ts
@@ -375,6 +375,27 @@ function resolveStatusConfigPath(slug: string): string {
 }
 
 /**
+ * #830 — resolve the LOCAL stack's config path for a network command, layout-aware:
+ * explicit `--config` wins; otherwise the `--stack` flag (full `{principal}/{slug}`
+ * or a bare slug) selects the slug and {@link resolveStatusConfigPath} maps it to
+ * the split sentinel or the legacy monolith. Shared so `ping` and any future
+ * command resolve identically to `status` and can't drift (the gap that made ping
+ * read the flat default and report `not-configured` for a config-split peer).
+ */
+function resolveLocalStackConfigPath(flags: Record<string, string | true>): string {
+  const explicitConfig = optionalValueFlag(flags, "--config");
+  if (explicitConfig !== undefined) return expandTilde(explicitConfig);
+  const stackFlag = optionalValueFlag(flags, "--stack");
+  const slug =
+    stackFlag === undefined
+      ? "default"
+      : stackFlag.includes("/")
+        ? (stackFlag.split("/")[1] ?? "default")
+        : stackFlag;
+  return resolveStatusConfigPath(slug);
+}
+
+/**
  * `join`/`leave` mutate the live deployment. The DEFAULT is dry-run (safe);
  * `--apply` opts into real mutation. `--dry-run` is accepted explicitly too.
  * `--apply` and `--dry-run` together is a usage error.
@@ -677,17 +698,7 @@ async function runPing(
   // `meta-factory` bare-name default, handled inside resolveStatusConfigPath).
   let cfg;
   try {
-    const explicitConfig = optionalValueFlag(flags, "--config");
-    const stackFlag = optionalValueFlag(flags, "--stack");
-    const localSlug =
-      stackFlag === undefined
-        ? "default"
-        : stackFlag.includes("/")
-          ? (stackFlag.split("/")[1] ?? "default")
-          : stackFlag;
-    const configPath =
-      explicitConfig !== undefined ? expandTilde(explicitConfig) : resolveStatusConfigPath(localSlug);
-    cfg = load(configPath);
+    cfg = load(resolveLocalStackConfigPath(flags));
   } catch (err) {
     return opError("ping", `config load failed: ${err instanceof Error ? err.message : String(err)}`, json);
   }

--- a/src/cli/cortex/commands/network.ts
+++ b/src/cli/cortex/commands/network.ts
@@ -669,9 +669,25 @@ async function runPing(
   if (!timeout.ok) return usageError("ping", timeout.reason, json);
 
   // Load config (the #753 seam). A missing/broken config is an op-error.
+  // #830 — resolve the LOCAL stack's config LAYOUT-AWARE (port of #814's status
+  // resolver) so ping reads the file the daemon composes `peers[]` from on a
+  // config-split stack, instead of the flat default monolith (which made ping
+  // report `not-configured` for a peer that IS in the split policy). Explicit
+  // `--config` wins; otherwise `--stack` selects the slug (none → the
+  // `meta-factory` bare-name default, handled inside resolveStatusConfigPath).
   let cfg;
   try {
-    cfg = load(expandTilde(optionalValueFlag(flags, "--config") ?? DEFAULT_CONFIG_PATH));
+    const explicitConfig = optionalValueFlag(flags, "--config");
+    const stackFlag = optionalValueFlag(flags, "--stack");
+    const localSlug =
+      stackFlag === undefined
+        ? "default"
+        : stackFlag.includes("/")
+          ? (stackFlag.split("/")[1] ?? "default")
+          : stackFlag;
+    const configPath =
+      explicitConfig !== undefined ? expandTilde(explicitConfig) : resolveStatusConfigPath(localSlug);
+    cfg = load(configPath);
   } catch (err) {
     return opError("ping", `config load failed: ${err instanceof Error ? err.message : String(err)}`, json);
   }


### PR DESCRIPTION
Fixes the two ping/join tooling gaps Luna grounded (#830, #831). Both surfaced while standing up JC's community peering on his config-split stack.

## #830 — `cortex network ping` is config-split-aware
`runPing` read the flat `DEFAULT_CONFIG_PATH` (`network.ts:674`), so on a config-split stack it reported `not-configured` for a peer that IS in the daemon's composed `policy.federated.networks[].peers[]`. Now it resolves the LOCAL stack's config the same way `status` does — a direct port of #814's `resolveStatusConfigPath`: `--stack` selects the slug locator (split sentinel or legacy monolith), explicit `--config` still wins.

## #831 — join health-probe: absent monitor is inconclusive, not failure
`resolveMonitorBase` silently fell back to `:8222` when the nats config declares no monitor; `isHealthy` then fetched `:8222/healthz`, got connection-refused, returned `healthy:false`, and the orchestrator **rolled back a join whose policy + peer were already written** (JC's single-file `local.conf` has no `http_port`). Now `resolveMonitorBase` returns `{ url, configured }` and `isHealthy` returns `healthy:true` when no monitor is declared — inconclusive, not down. A **configured-but-down** monitor still reports unhealthy, so the #821 safety is intact.

## Tests
- ping resolves the slug-specific locator from `--stack` (not the bare flat default)
- isHealthy inconclusive on no monitor; still unhealthy on a configured-but-down monitor

## Verification
- `bun test src/cli/cortex/commands/__tests__/` → 557 pass (+3 new), tsc + eslint clean
- The 1 remaining fail (`network-cli` "leaving an un-joined network") is **pre-existing** and **local-only** — it fails only on a host with a real `~/.config/cortex/cortex.yaml` carrying `metafactory` (test-isolation leaks to the real home). Green on CI, identical on origin/main, unchanged by this PR. The test-isolation gap is separate.

Closes #830, #831.

Generated with Claude Code
