### PR TITLE
fix(bus): C-836 — review consumer gates requester check on subject scope, not the federated mode flag (unblocks local dispatch on federated stacks)

### DIFF
--- a/docs/design-agentic-dev-pipeline.md
+++ b/docs/design-agentic-dev-pipeline.md
@@ -195,7 +195,7 @@ the-metafactory/dev-loop/
 │   ├── dev/                     # type: agent — dev.implement consumer
 │   ├── approver/                # type: agent — merge.approve (five-check gate)
 │   └── release/                 # type: agent — release.cut (gated)
-├── skill/                       # operator surface: kick off / status / pause / resume
+├── skill/                       # principal surface: kick off / status / pause / resume
 └── docs/                        # the SOP set the process encodes
 # depends_on: agent-state (state bundle), pulse (engine), cortex (IoAW substrate ≥ vX)
 ```

--- a/src/bus/__tests__/review-consumer.test.ts
+++ b/src/bus/__tests__/review-consumer.test.ts
@@ -1962,6 +1962,93 @@ describe("ReviewConsumer — per-message scope gate (cortex#836, ADR 0001)", () 
       "dispatch.task.completed",
     ]);
   });
+
+  test("6. foreign originator on a LOCAL subject is IGNORED → ACCEPTED, local-scope emission (not leaked to federated.mallory.*)", async () => {
+    const runtime = createRecordingRuntime();
+    // A LOCAL self-dispatch subject, but the envelope carries a foreign
+    // `originator.identity` for a non-peer (`mallory`). On the local path the
+    // originator MUST be ignored entirely — the requester gate never runs, so
+    // the foreign identity can neither deny the review NOR redirect the verdict
+    // onto a cross-principal `federated.mallory.*` subject. (Adversarial Attack 4.)
+    const request = makeRequest("typescript");
+    (request as { originator?: unknown }).originator = {
+      identity: "did:mf:mallory-evil",
+      attribution: "federated",
+    };
+    const verdict = buildVerdictEnvelope(request, "approved");
+
+    const consumer = new ReviewConsumer(
+      baseOpts(
+        federatedOpts({
+          runtime,
+          pipelineRunner: fixedPipeline((opts) => {
+            // Local path → the foreign originator is never read → no requester →
+            // local-scope (classification undefined).
+            expect(opts.classification).toBeUndefined();
+            return { kind: "verdict", envelope: verdict };
+          }),
+        }),
+      ),
+    );
+
+    const decision = await consumer.processEnvelope(
+      request,
+      LOCAL_SELF_SUBJECT,
+      null,
+    );
+    expect(decision).toEqual({ kind: "ack" });
+
+    // EVERY emission routes on the LOCAL path; NOTHING on `publishOnSubject` —
+    // the foreign originator was not leaked to a `federated.mallory.*` subject.
+    expect(runtime.publishedOnSubject).toHaveLength(0);
+    expect(runtime.published.map((e) => e.type)).toEqual([
+      "dispatch.task.started",
+      "review.verdict.approved",
+      "dispatch.task.completed",
+    ]);
+  });
+
+  test("7. a public.> (third-scope) subject is treated as local / fail-safe → ACCEPTED, local-scope emission", async () => {
+    const runtime = createRecordingRuntime();
+    // Public scope is a near-future spec (`{scope} ∈ local | federated | public`).
+    // `isFederatedRequest` is false for any non-`federated.` prefix, so a
+    // `public.>` inbound bypasses the cross-principal requester/deny gate and
+    // defaults to the local path — the fail-safe default we lock in now.
+    const PUBLIC_SUBJECT =
+      "public.metafactory.meta-factory.tasks.code-review.typescript";
+    const request = makeRequest("typescript");
+    const verdict = buildVerdictEnvelope(request, "approved");
+
+    let pipelineRan = false;
+    const consumer = new ReviewConsumer(
+      baseOpts(
+        federatedOpts({
+          runtime,
+          pipelineRunner: fixedPipeline((opts) => {
+            pipelineRan = true;
+            // Not the federated deny path: the review RUNS, local-scope.
+            expect(opts.classification).toBeUndefined();
+            return { kind: "verdict", envelope: verdict };
+          }),
+        }),
+      ),
+    );
+
+    const decision = await consumer.processEnvelope(
+      request,
+      PUBLIC_SUBJECT,
+      null,
+    );
+    // Did NOT hit the federated deny path (which would term + publish nothing).
+    expect(decision).toEqual({ kind: "ack" });
+    expect(pipelineRan).toBe(true);
+    expect(runtime.publishedOnSubject).toHaveLength(0);
+    expect(runtime.published.map((e) => e.type)).toEqual([
+      "dispatch.task.started",
+      "review.verdict.approved",
+      "dispatch.task.completed",
+    ]);
+  });
 });
 
 describe("ReviewConsumer — federated DIRECT mode (cortex#725, ADR 0001/0002 §2)", () => {

--- a/src/bus/__tests__/review-consumer.test.ts
+++ b/src/bus/__tests__/review-consumer.test.ts
@@ -1775,6 +1775,195 @@ describe("ReviewConsumer — federated mode (cortex#686, ADR 0002)", () => {
   });
 });
 
+describe("ReviewConsumer — per-message scope gate (cortex#836, ADR 0001)", () => {
+  // The bug: once a stack joins a network, `federated: true` is set for the
+  // WHOLE consumer (cortex.ts wires it when ≥1 network is configured). But the
+  // requester-deny gate must key on the SUBJECT scope, not the coarse mode
+  // flag: ADR 0001 says `local.` never crosses the principal boundary
+  // (same-principal self-dispatch — the requester IS self, so there is
+  // legitimately NO requester in `originator.identity`), while `federated.`
+  // always crosses it (a peer requester MUST be present + on `peers[]`).
+  //
+  // Before the fix, a federated-mode consumer ran the requester-deny gate on
+  // EVERY inbound regardless of subject, so a LOCAL self-dispatch (no
+  // requester) was DENIED + DROPPED — blocking the whole pilot-review-loop on
+  // any federated stack. The fix gates the requester parse + deny block on
+  // `this.federated && subject.startsWith("federated.")`.
+
+  /** A local same-principal self-dispatch subject (`local.{me}.{stack}.…`). */
+  const LOCAL_SELF_SUBJECT =
+    "local.metafactory.meta-factory.tasks.code-review.typescript";
+
+  /** Federated subject targeting us — the cross-principal path. */
+  const FED_SUBJECT =
+    "federated.metafactory.meta-factory.tasks.code-review.typescript";
+
+  /** Federated mode + the `jc`-peer network (mirrors a network-joined stack). */
+  function federatedOpts(
+    overrides: Partial<ReviewConsumerOpts> = {},
+  ): Partial<ReviewConsumerOpts> {
+    return {
+      federated: true,
+      federatedNetworks: [makeNetwork()],
+      ...overrides,
+    };
+  }
+
+  test("1. RED — federated-mode consumer, LOCAL self-dispatch subject, NO originator → ACCEPTED, verdict on LOCAL publish path", async () => {
+    const runtime = createRecordingRuntime();
+    // A plain local self-dispatch: NO originator (the requester IS self).
+    const request = makeRequest("typescript");
+    const verdict = buildVerdictEnvelope(request, "approved");
+
+    let pipelineRan = false;
+    const consumer = new ReviewConsumer(
+      baseOpts(
+        federatedOpts({
+          runtime,
+          pipelineRunner: fixedPipeline((opts) => {
+            pipelineRan = true;
+            // A LOCAL inbound bypasses the requester gate → no requester →
+            // local-scope emission (classification undefined), identical to a
+            // non-federated consumer.
+            expect(opts.classification).toBeUndefined();
+            return { kind: "verdict", envelope: verdict };
+          }),
+        }),
+      ),
+    );
+
+    const decision = await consumer.processEnvelope(
+      request,
+      LOCAL_SELF_SUBJECT,
+      null,
+    );
+
+    // The review RUNS and the verdict is ACKed — not denied/dropped.
+    expect(decision).toEqual({ kind: "ack" });
+    expect(pipelineRan).toBe(true);
+
+    // The verdict + lifecycle route on the LOCAL `publish` path (local scope),
+    // NOT the federated `publishOnSubject` path.
+    expect(runtime.publishedOnSubject).toHaveLength(0);
+    expect(runtime.published.map((e) => e.type)).toEqual([
+      "dispatch.task.started",
+      "review.verdict.approved",
+      "dispatch.task.completed",
+    ]);
+  });
+
+  test("2. fail-closed lock — federated subject, NO/malformed originator → STILL DENIED + DROPPED (term, nothing published)", async () => {
+    const runtime = createRecordingRuntime();
+    // Federated subject but no originator block — un-attributable cross-principal.
+    const request = makeFederatedRequest(NO_ORIGINATOR);
+
+    let pipelineRan = false;
+    const consumer = new ReviewConsumer(
+      baseOpts(
+        federatedOpts({
+          runtime,
+          pipelineRunner: fixedPipeline(() => {
+            pipelineRan = true;
+            throw new Error("reviewer must NOT spawn for an un-attributable federated request");
+          }),
+        }),
+      ),
+    );
+
+    const decision = await consumer.processEnvelope(request, FED_SUBJECT, null);
+    expect(decision.kind).toBe("term");
+    expect(pipelineRan).toBe(false);
+    // Nothing reaches any principal — fail closed on the federated path.
+    expect(runtime.published).toHaveLength(0);
+    expect(runtime.publishedOnSubject).toHaveLength(0);
+  });
+
+  test("3. peers[] lock — federated subject, valid originator but requester NOT a peer → STILL DENIED + DROPPED", async () => {
+    const runtime = createRecordingRuntime();
+    // Well-formed DID for `mallory`, who is in no network's peers[].
+    const request = makeFederatedRequest("did:mf:mallory-host");
+
+    let pipelineRan = false;
+    const consumer = new ReviewConsumer(
+      baseOpts(
+        federatedOpts({
+          runtime,
+          pipelineRunner: fixedPipeline(() => {
+            pipelineRan = true;
+            throw new Error("reviewer must NOT spawn for a non-peer requester");
+          }),
+        }),
+      ),
+    );
+
+    const decision = await consumer.processEnvelope(request, FED_SUBJECT, null);
+    expect(decision.kind).toBe("term");
+    expect(pipelineRan).toBe(false);
+    expect(runtime.published).toHaveLength(0);
+    expect(runtime.publishedOnSubject).toHaveLength(0);
+  });
+
+  test("4. verdict-back lock — federated subject, valid peer requester → ACCEPTED, verdict routes to requester's federated scope", async () => {
+    const runtime = createRecordingRuntime();
+    const request = makeFederatedRequest(); // jc.sage-host — a configured peer
+    const verdict = buildVerdictEnvelope(request, "approved");
+
+    const consumer = new ReviewConsumer(
+      baseOpts(
+        federatedOpts({
+          runtime,
+          pipelineRunner: fixedPipeline((opts) => {
+            // Federated inbound → federated sovereignty stamped.
+            expect(opts.classification).toBe("federated");
+            return { kind: "verdict", envelope: verdict };
+          }),
+        }),
+      ),
+    );
+
+    const decision = await consumer.processEnvelope(request, FED_SUBJECT, null);
+    expect(decision).toEqual({ kind: "ack" });
+
+    // Everything routes to the REQUESTER's federated scope (jc.sage-host),
+    // nothing on the local path — the verdict-back path is intact.
+    expect(runtime.published).toHaveLength(0);
+    const subjects = runtime.publishedOnSubject.map((p) => p.subject);
+    expect(subjects).toEqual([
+      "federated.jc.sage-host.dispatch.task.started",
+      "federated.jc.sage-host.review.verdict.approved",
+      "federated.jc.sage-host.dispatch.task.completed",
+    ]);
+  });
+
+  test("5. baseline — federated:false LOCAL inbound → ACCEPTED (unchanged)", async () => {
+    const runtime = createRecordingRuntime();
+    const request = makeRequest("typescript");
+    const verdict = buildVerdictEnvelope(request, "approved");
+    const consumer = new ReviewConsumer(
+      baseOpts({
+        runtime,
+        // federated NOT set.
+        pipelineRunner: fixedPipeline((opts) => {
+          expect(opts.classification).toBeUndefined();
+          return { kind: "verdict", envelope: verdict };
+        }),
+      }),
+    );
+    const decision = await consumer.processEnvelope(
+      request,
+      LOCAL_SELF_SUBJECT,
+      null,
+    );
+    expect(decision).toEqual({ kind: "ack" });
+    expect(runtime.publishedOnSubject).toHaveLength(0);
+    expect(runtime.published.map((e) => e.type)).toEqual([
+      "dispatch.task.started",
+      "review.verdict.approved",
+      "dispatch.task.completed",
+    ]);
+  });
+});
+
 describe("ReviewConsumer — federated DIRECT mode (cortex#725, ADR 0001/0002 §2)", () => {
   // pilot#149 Direct dispatch (`--reviewer echo@jc/sage-host`) lands on this
   // stack's OWN `federated.{me}.{my-stack}.tasks.@{did-encoded-reviewer}.code-review.{flavor}`

--- a/src/bus/review-consumer.ts
+++ b/src/bus/review-consumer.ts
@@ -528,20 +528,26 @@ export class ReviewConsumer {
     // envelopes (the verdict still reaches pilot via correlation_id).
     const responseRouting = readLogicalResponseRouting(envelope) ?? undefined;
 
-    // cortex#836 (ADR 0001) — the cross-principal TRUST BOUNDARY is per-message
-    // and lives in the SUBJECT SCOPE, NOT in the coarse `this.federated` mode
-    // flag. ADR 0001: `local.` NEVER crosses the principal boundary (a
-    // same-principal self-dispatch — the requester IS self, so there is
-    // legitimately no requester in `originator.identity`), while `federated.`
-    // ALWAYS crosses it (a peer requester MUST be present + on `peers[]`).
+    // cortex#836 — the cross-principal TRUST BOUNDARY is per-message and lives in
+    // the SUBJECT SCOPE, NOT in the coarse `this.federated` mode flag (see
+    // ADR-0001 §scope: `local.` is same-principal, `federated.` is cross-principal).
     //
     // `this.federated` is set for the WHOLE consumer once a stack joins a network
     // (≥1 network configured — see cortex.ts), so it cannot distinguish a local
-    // self-dispatch from a federated cross-principal request. Keying the
-    // requester parse + deny gate on the per-message subject scope instead means
-    // a `local.>` self-dispatch on a network-joined stack bypasses the gate
-    // (requester stays `undefined` → local-scope emission, identical to
-    // non-federated mode), while a `federated.>` request keeps the FULL gate.
+    // self-dispatch from a federated cross-principal request. Keying the requester
+    // parse + deny gate on the per-message subject scope instead means a `local.>`
+    // self-dispatch on a network-joined stack bypasses the gate (requester stays
+    // `undefined` → local-scope emission, identical to non-federated mode), while a
+    // `federated.>` request keeps the FULL gate. Any non-`federated.` scope
+    // (`local.`, the near-future `public.`) is fail-safe: it defaults to the local
+    // path, never the cross-principal deny gate.
+    //
+    // SAFE because the leaf's `accept_subjects` is `federated.{me}.{stack}.>` ONLY
+    // (built at `src/cli/cortex/commands/network-lib.ts:~290`), so a `local.>`
+    // envelope is same-principal-only BY TRANSPORT CONSTRUCTION — a remote peer's
+    // leaf cannot deliver one across the boundary. A future reader MUST NOT widen
+    // `accept_subjects` to admit `local.>`/`public.>` from a peer without revisiting
+    // this gate, or the scope-based trust assumption breaks.
     const isFederatedRequest = subject.startsWith("federated.");
 
     // cortex#686 (ADR 0002) — in federated mode, derive the REQUESTER

--- a/src/bus/review-consumer.ts
+++ b/src/bus/review-consumer.ts
@@ -528,6 +528,22 @@ export class ReviewConsumer {
     // envelopes (the verdict still reaches pilot via correlation_id).
     const responseRouting = readLogicalResponseRouting(envelope) ?? undefined;
 
+    // cortex#836 (ADR 0001) — the cross-principal TRUST BOUNDARY is per-message
+    // and lives in the SUBJECT SCOPE, NOT in the coarse `this.federated` mode
+    // flag. ADR 0001: `local.` NEVER crosses the principal boundary (a
+    // same-principal self-dispatch — the requester IS self, so there is
+    // legitimately no requester in `originator.identity`), while `federated.`
+    // ALWAYS crosses it (a peer requester MUST be present + on `peers[]`).
+    //
+    // `this.federated` is set for the WHOLE consumer once a stack joins a network
+    // (≥1 network configured — see cortex.ts), so it cannot distinguish a local
+    // self-dispatch from a federated cross-principal request. Keying the
+    // requester parse + deny gate on the per-message subject scope instead means
+    // a `local.>` self-dispatch on a network-joined stack bypasses the gate
+    // (requester stays `undefined` → local-scope emission, identical to
+    // non-federated mode), while a `federated.>` request keeps the FULL gate.
+    const isFederatedRequest = subject.startsWith("federated.");
+
     // cortex#686 (ADR 0002) — in federated mode, derive the REQUESTER
     // `{principal}.{stack}` from the inbound envelope's `originator.identity`
     // ONCE so every emitted envelope routes back to the requester on the
@@ -539,16 +555,18 @@ export class ReviewConsumer {
     // target. Reading the requester off the subject (the cortex#715 BLOCKER)
     // routes every verdict to SELF and the loop never closes.
     //
-    // `undefined` in local mode, OR (in federated mode) when
+    // `undefined` for a LOCAL inbound (cortex#836: a `local.>` self-dispatch has
+    // no requester — the requester is self), OR (on the `federated.>` path) when
     // `originator.identity` is absent / malformed. An un-attributable federated
     // request is DENIED + DROPPED by the gate below (we never even reach
     // `safePublish`); the `safePublish` local fall-through remains the
     // belt-and-braces backstop for the non-denied path against a runtime that
     // lacks `publishOnSubject` (a disabled runtime / legacy stub — never a live
     // wire), so a verdict is never guessed onto a cross-principal target.
-    const requester = this.federated
-      ? parseRequesterFromOriginator(envelope)
-      : undefined;
+    const requester =
+      this.federated && isFederatedRequest
+        ? parseRequesterFromOriginator(envelope)
+        : undefined;
 
     // cortex#686 (ADR 0002 §5) — defense-in-depth `peers[]` gate ON THE CONSUMER
     // PATH. Run the membership check BEFORE spawning the reviewer or emitting
@@ -558,7 +576,12 @@ export class ReviewConsumer {
     // no CC subprocess, no verdict, no lifecycle envelope. Under `signing: off`
     // this membership check is the application-layer trust boundary; under
     // `enforce` the signed_by chain + signed originator add the crypto check.
-    if (this.federated) {
+    //
+    // cortex#836 (ADR 0001) — gated on `isFederatedRequest` so it runs ONLY for
+    // a `federated.>` inbound (cross-principal). A `local.>` self-dispatch on a
+    // network-joined stack bypasses the gate entirely — same-principal traffic
+    // never crosses the boundary the gate guards.
+    if (this.federated && isFederatedRequest) {
       const denyReason = this.federatedRequesterDenyReason(requester);
       if (denyReason !== null) {
         process.stderr.write(


### PR DESCRIPTION
Closes #836.

## Problem
`ReviewConsumer`'s requester-identity deny gate fired on the static `this.federated` mode flag (true when ≥1 network is configured) for **every** inbound, regardless of subject. The consumer subscribes to BOTH `local.{me}.{stack}.tasks.code-review.>` (self-dispatch) AND `federated.{me}.{stack}.tasks.code-review.>` (cross-principal). So once a stack joined a network, a **LOCAL same-principal self-dispatch** (e.g. sage's `local.jc.default.tasks.code-review.typescript`) — which legitimately carries no requester in `originator.identity` (the requester IS self) — was DENIED + DROPPED, blocking the whole pilot-review-loop on every federated stack (JC's, and ours).

## Fix
The trust boundary is per-message and lives in the SUBJECT (ADR-0001: `local.` never crosses the principal boundary; `federated.` always does). Gate the requester parse + `federatedRequesterDenyReason` + `peers[]` check on `this.federated && subject.startsWith("federated.")` instead of the bare mode flag (+28/−5 in `review-consumer.ts`):
- `local.>` inbound → bypasses the requester gate, `requester=undefined`, verdict/lifecycle route on LOCAL scope (identical to non-federated mode).
- `federated.>` inbound → FULL requester+peer gate unchanged.

**No weakening of the cross-principal trust boundary** — a forged `federated.>` request with absent/malformed `originator.identity` still fails closed; a non-peer requester is still denied. wire-check: **5/5 PASS** (federation-wire-protocol SOP; the fix restores a rule-5 scope violation in the prior code).

## Tests (RED→GREEN, src/bus/__tests__/review-consumer.test.ts)
1. RED→GREEN: federated-mode consumer, LOCAL self-dispatch, no originator → ACCEPTED, verdict on local scope (was: denied).
2. fail-closed lock: federated subject, no/malformed originator → STILL denied+dropped.
3. peers[] lock: federated subject, valid originator, non-peer requester → STILL denied.
4. verdict-back lock: federated subject, valid peer → accepted, verdict to requester's federated scope.
5. baseline: federated:false local inbound → accepted (unchanged).

Full suite 5175 pass / 0 fail; tsc/lint/carveouts green.