### PR TITLE
feat(discord-cli): --create-thread — spawn a thread from the posted message

### DIFF
--- a/src/cli/discord/discord.ts
+++ b/src/cli/discord/discord.ts
@@ -12,7 +12,7 @@ import { loadConfig, saveConfig, getConfigPath } from "./lib/config";
 import { resolveServerContext, registerServerProfile, ServerContextError } from "./lib/server-context";
 import type { ResolvedServerContext, ServerContextOptions } from "./lib/server-context";
 import type { DiscordCliConfig } from "./lib/config";
-import { postMessage, resolveChannelByName, resolveThreadByName, readMessages, listChannels, listThreads } from "./lib/discord";
+import { postMessage, createThreadFromMessage, resolveChannelByName, resolveThreadByName, readMessages, listChannels, listThreads } from "./lib/discord";
 
 // Per-command option shapes. Commander's typing is permissive; pinning each
 // `.action((opts) => …)` to the concrete shape lets the typed-checked preset
@@ -21,6 +21,7 @@ import { postMessage, resolveChannelByName, resolveThreadByName, readMessages, l
 interface PostOptions extends ServerContextOptions {
   channel?: string;
   thread?: string;
+  createThread?: string;
 }
 interface ReadOptions extends ServerContextOptions {
   channel?: string;
@@ -71,12 +72,18 @@ program
   .argument("<message...>", "Message text (multiple words joined)")
   .option("-c, --channel <name>", "Channel name (default: defaultChannel from config)")
   .option("-t, --thread <name-or-id>", "Thread name or ID to post into")
+  .option("-T, --create-thread <name>", "Create a thread from the posted message and print its ID")
   .option("-g, --guild <id>", "Guild ID to resolve channel/thread names against (overrides config)")
   .option("-s, --server <name>", "Named server profile from config (layers guildId + overrides)")
   .action(async (messageParts: string[], opts: PostOptions) => {
     const config = loadConfig();
     const ctx = resolveContextOrExit(config, opts);
     const message = messageParts.join(" ");
+
+    if (opts.thread && opts.createThread) {
+      console.error("--thread and --create-thread are mutually exclusive (a thread cannot contain a thread).");
+      process.exit(1);
+    }
 
     if (!ctx.botToken) {
       console.error("Bot token required. Run: discord config set botToken <token>");
@@ -130,11 +137,24 @@ program
     }
 
     const result = await postMessage(ctx.botToken, targetId, message);
-    if (result.success) {
-      console.log(`Posted to #${channelName}${opts.thread ? ` (thread)` : ""}`);
-    } else {
+    if (!result.success) {
       console.error(`Failed: ${result.error}`);
       process.exit(1);
+    }
+    console.log(`Posted to #${channelName}${opts.thread ? ` (thread)` : ""}`);
+
+    if (opts.createThread) {
+      if (!result.messageId) {
+        console.error("Cannot create thread: Discord did not return a message id.");
+        process.exit(1);
+      }
+      const thread = await createThreadFromMessage(ctx.botToken, targetId, result.messageId, opts.createThread);
+      if (!thread.success) {
+        console.error(`Thread creation failed: ${thread.error}`);
+        process.exit(1);
+      }
+      // Machine-readable last line — callers parse this id to post follow-ups via --thread
+      console.log(`thread:${thread.threadId}`);
     }
   });
 

--- a/src/cli/discord/lib/discord.ts
+++ b/src/cli/discord/lib/discord.ts
@@ -102,6 +102,42 @@ export async function postMessage(
   return { success: true, messageId: data.id };
 }
 
+export interface CreateThreadResult {
+  success: boolean;
+  threadId?: string;
+  error?: string;
+}
+
+/**
+ * Create a public thread from an existing message.
+ * Discord: POST /channels/{channelId}/messages/{messageId}/threads
+ */
+export async function createThreadFromMessage(
+  botToken: string,
+  channelId: string,
+  messageId: string,
+  name: string,
+  autoArchiveMinutes: 60 | 1440 | 4320 | 10080 = 10080
+): Promise<CreateThreadResult> {
+  // Discord caps thread names at 100 characters
+  const res = await fetch(`${DISCORD_API}/channels/${channelId}/messages/${messageId}/threads`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bot ${botToken}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ name: name.slice(0, 100), auto_archive_duration: autoArchiveMinutes }),
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    return { success: false, error: `${res.status}: ${text}` };
+  }
+
+  const data = (await res.json()) as { id: string };
+  return { success: true, threadId: data.id };
+}
+
 /**
  * Resolve a channel name to its ID via bot API.
  */


### PR DESCRIPTION
## What

`discord post` gains `-T/--create-thread <name>`:

1. posts the message to the channel as before
2. creates a public thread from that message (`POST /channels/{channelId}/messages/{messageId}/threads`, `auto_archive_duration: 10080`, name capped at Discord's 100-char limit)
3. prints `thread:<id>` as a machine-readable last line so scripts can post follow-ups with `--thread <id>`

`--thread` and `--create-thread` are mutually exclusive (a thread cannot contain a thread).

## Why

Long multi-message posts (e.g. the pulse build journal) bury a channel. The pattern we want is teaser-in-channel + detail-in-thread; the CLI could post *into* threads but not create them.

First consumer: pulse `P_BUILD_JOURNAL` (`examples/build-journal/A_POST_DISCORD`) — it probes for the flag and falls back to teaser+link when running against an older CLI.

## Verification

- `bunx tsc --noEmit` clean for `src/cli/discord`
- existing discord CLI tests pass (19/19)
- new API call follows the same `PostResult`-style result shape and error handling as `postMessage`
- live API exercised on the next pulse `--post` journal run

🤖 Generated with [Claude Code](https://claude.com/claude-code)