### PR TITLE
feat(bus): provision REVIEW_LIFECYCLE stream (verdict + dispatch.task) — durable-reactor enabler

### DIFF
--- a/src/__tests__/cortex.lifecycle-stream-boot.test.ts
+++ b/src/__tests__/cortex.lifecycle-stream-boot.test.ts
@@ -1,0 +1,342 @@
+/**
+ * cortex#835 / pilot#154 — REVIEW_LIFECYCLE stream boot-wiring tests.
+ *
+ * cortex provisions a SECOND JetStream stream (`REVIEW_LIFECYCLE`) alongside
+ * `CODE_REVIEW`. It carries the verdict + dispatch-lifecycle envelope families
+ * so a downstream reactor (pilot's verdict watch) can later bind a durable
+ * consumer and replay history instead of racing a transient core-NATS
+ * subscription. cortex provisions the STREAM only; the durable consumers that
+ * read it are the downstream reactor's concern (the cortex#835 follow-up).
+ *
+ * These tests pin the boot wiring:
+ *
+ *   1. With a JSM available, BOTH streams are provisioned — CODE_REVIEW (its
+ *      `…tasks.code-review.>` namespace) AND REVIEW_LIFECYCLE (the three
+ *      lifecycle subject families: `…review.verdict.>`, `…code.pr.review.>`,
+ *      `…dispatch.task.>`).
+ *   2. OVERLAP INVARIANT — the two streams' subject sets are DISJOINT (no
+ *      subject of one is a prefix of, or prefixed by, any subject of the
+ *      other). JetStream rejects overlapping subjects across streams; this
+ *      test is the codified guard that the partition holds at boot.
+ *   3. Config gating — when the runtime exposes NO `jetstreamManager` (dormant
+ *      / NATS-absent), NEITHER stream is provisioned. The REVIEW_LIFECYCLE
+ *      provisioning rides the SAME `reviewJsm !== null` gate as CODE_REVIEW, so
+ *      byte-identical behaviour holds when the bus/JetStream is not configured.
+ *
+ * Test infrastructure mirrors `cortex.review-consumer-boot.test.ts` (recording
+ * runtime + inline agents + captured logs), extended with a recording JSM stub
+ * so the boot path's `streams.add` calls are observable without standing up a
+ * real broker. No real NATS, Discord, filesystem-watcher, or `claude` spawning.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { AgentConfigSchema, type AgentConfig } from "../common/types/config";
+import type { Agent, AgentRuntime } from "../common/types/cortex-config";
+import { startCortex } from "../cortex";
+import type { Envelope } from "../bus/myelin/envelope-validator";
+import type {
+  EnvelopeHandler,
+  MyelinRuntime,
+  MyelinSubscribePullOpts,
+} from "../bus/myelin/runtime";
+import type { MyelinSubscriber } from "../bus/myelin/subscriber";
+import type { ProvisionJsm } from "../bus/jetstream/types";
+import type { ConsumerInfo, StreamInfo, StreamConfig } from "nats";
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function minimalConfig(overrides: Partial<Record<string, unknown>> = {}): AgentConfig {
+  return AgentConfigSchema.parse({
+    agent: { name: "test-cortex", displayName: "TestCortex" },
+    discord: [],
+    mattermost: [],
+    claude: { timeoutMs: 120_000 },
+    paths: { publishedEventsDir: "/tmp/grove-cortex-lifecycle-test-published" },
+    ...overrides,
+  });
+}
+
+/** Records every `streams.add` so the boot test can read back the provisioned
+ *  stream configs. Stream/consumer `info` always 404s (virgin broker) so the
+ *  provisioning helpers take the create path. */
+interface JsmRecorder {
+  jsm: ProvisionJsm;
+  streamAdds: Partial<StreamConfig>[];
+}
+
+function makeRecordingJsm(): JsmRecorder {
+  const streamAdds: Partial<StreamConfig>[] = [];
+  const notFound = (kind: "stream" | "consumer"): Error => {
+    const err = new Error(`${kind} not found`);
+    (err as unknown as { api_error: { err_code: number } }).api_error = {
+      err_code: kind === "stream" ? 10059 : 10014,
+    };
+    return err;
+  };
+  const jsm: ProvisionJsm = {
+    streams: {
+      info: async () => {
+        throw notFound("stream");
+      },
+      add: async (cfg) => {
+        streamAdds.push(cfg);
+        return { config: cfg } as unknown as StreamInfo;
+      },
+    },
+    consumers: {
+      info: async () => {
+        throw notFound("consumer");
+      },
+      add: async (_stream, cfg) =>
+        ({ name: cfg.durable_name } as unknown as ConsumerInfo),
+      update: async (_stream, durable, cfg) =>
+        ({ name: durable, config: cfg } as unknown as ConsumerInfo),
+    },
+  };
+  return { jsm, streamAdds };
+}
+
+interface RecordingRuntime extends MyelinRuntime {
+  onEnvelopeHandlers: Set<EnvelopeHandler>;
+  published: Envelope[];
+  subscribePullCalls: MyelinSubscribePullOpts[];
+}
+
+/** A runtime that EXPOSES a recording `jetstreamManager` so the boot path
+ *  resolves a real JSM and provisions both streams. `withJsm: false` omits the
+ *  helper entirely → `resolveReviewProvisioningJsm` returns null → dormant. */
+function createRecordingRuntime(opts: {
+  jsm?: ProvisionJsm;
+}): RecordingRuntime {
+  const onEnvelopeHandlers = new Set<EnvelopeHandler>();
+  const published: Envelope[] = [];
+  const subscribePullCalls: MyelinSubscribePullOpts[] = [];
+  const runtime: RecordingRuntime = {
+    enabled: true,
+    onEnvelopeHandlers,
+    published,
+    subscribePullCalls,
+    onEnvelope(handler) {
+      onEnvelopeHandlers.add(handler);
+      return {
+        unregister: () => {
+          onEnvelopeHandlers.delete(handler);
+        },
+      };
+    },
+    publish: async (envelope: Envelope) => {
+      published.push(envelope);
+    },
+    subscribePull: (o: MyelinSubscribePullOpts): MyelinSubscriber => {
+      subscribePullCalls.push(o);
+      return {
+        pattern: o.pattern,
+        ready: Promise.resolve(),
+        stop: async () => {},
+      } as unknown as MyelinSubscriber;
+    },
+    stop: async () => {},
+  };
+  if (opts.jsm !== undefined) {
+    runtime.jetstreamManager = async () => opts.jsm!;
+  }
+  return runtime;
+}
+
+function makeAgent(id: string, capabilities: readonly string[]): Agent {
+  const runtime: AgentRuntime = {
+    substrate: "claude-code",
+    mode: "in-process",
+    capabilities: [...capabilities],
+  };
+  return {
+    id,
+    displayName: id.charAt(0).toUpperCase() + id.slice(1),
+    persona: `/tmp/${id}-persona.md`,
+    trust: [],
+    presence: {},
+    runtime,
+  };
+}
+
+function withCapturedConsoleLog<T>(
+  fn: () => Promise<T>,
+): Promise<{ result: T; logs: string[] }> {
+  const original = console.log.bind(console);
+  const logs: string[] = [];
+  console.log = (...args: unknown[]): void => {
+    logs.push(args.map((a) => String(a)).join(" "));
+  };
+  return fn()
+    .then((result) => {
+      console.log = original;
+      return { result, logs };
+    })
+    .catch((err: unknown) => {
+      console.log = original;
+      throw err;
+    });
+}
+
+/**
+ * Subject-set overlap predicate — true iff `a` and `b` would collide as
+ * JetStream stream subjects (one is a prefix of the other under the `.`
+ * token grammar, treating a trailing `>` as "matches the rest"). This is the
+ * relation JetStream uses to reject overlapping subjects across streams; the
+ * test asserts NO pair across the two streams satisfies it.
+ */
+function subjectsOverlap(a: string, b: string): boolean {
+  const at = a.split(".");
+  const bt = b.split(".");
+  const n = Math.min(at.length, bt.length);
+  for (let i = 0; i < n; i++) {
+    const x = at[i]!;
+    const y = bt[i]!;
+    if (x === ">" || y === ">") return true; // tail wildcard swallows the rest
+    if (x === "*" || y === "*") continue; // single-token wildcard matches either
+    if (x !== y) return false; // a literal token diverged → disjoint
+  }
+  // One subject is a strict token-prefix of the other with no divergence →
+  // they overlap only if the shorter ends in a wildcard tail; a shorter
+  // subject with no `>`/`*` tail does NOT subsume a longer one here.
+  return at.length === bt.length;
+}
+
+const PRINCIPAL = "test-op";
+const STACK = "default";
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("startCortex — REVIEW_LIFECYCLE stream boot wiring (cortex#835 / pilot#154)", () => {
+  test("provisions REVIEW_LIFECYCLE covering verdict + code.pr.review + dispatch.task, alongside CODE_REVIEW", async () => {
+    const { jsm, streamAdds } = makeRecordingJsm();
+    const runtime = createRecordingRuntime({ jsm });
+    const tmpAgentsDir = mkdtempSync(join(tmpdir(), "cortex-lifecycle-boot-"));
+    const inlineAgents: Agent[] = [makeAgent("echo", ["code-review.typescript"])];
+
+    const { result: handle, logs } = await withCapturedConsoleLog(() =>
+      startCortex(minimalConfig(), {
+        disableConfigWatcher: true,
+        disableDashboard: true,
+        disableOutboundPoller: true,
+        agentsDir: tmpAgentsDir,
+        injectRuntime: runtime,
+        inlineAgents,
+        principal: { id: PRINCIPAL },
+      }),
+    );
+
+    // BOTH streams provisioned.
+    const byName = new Map(streamAdds.map((c) => [c.name, c]));
+    expect(byName.has("CODE_REVIEW")).toBe(true);
+    expect(byName.has("REVIEW_LIFECYCLE")).toBe(true);
+
+    const lifecycle = byName.get("REVIEW_LIFECYCLE")!;
+    // The three lifecycle subject families, stack-aware 6-segment grammar.
+    expect(lifecycle.subjects).toEqual([
+      `local.${PRINCIPAL}.${STACK}.review.verdict.>`,
+      `local.${PRINCIPAL}.${STACK}.code.pr.review.>`,
+      `local.${PRINCIPAL}.${STACK}.dispatch.task.>`,
+    ]);
+    // Config posture mirrors CODE_REVIEW EXACTLY: Interest retention, File
+    // storage, 24h max_age, finite 512 MiB max_bytes, single replica.
+    expect(String(lifecycle.retention)).toBe("interest");
+    expect(String(lifecycle.storage)).toBe("file");
+    expect(lifecycle.max_age).toBe(24 * 3600 * 1e9);
+    expect(lifecycle.max_bytes).toBe(512 * 1024 * 1024);
+    expect(lifecycle.max_msgs).toBe(-1);
+    expect(lifecycle.num_replicas).toBe(1);
+
+    // Boot log surfaces the provisioning.
+    const provisionedLog = logs.find(
+      (l) =>
+        l.includes('provisioned JetStream stream "REVIEW_LIFECYCLE"') ||
+        l.includes('JetStream stream "REVIEW_LIFECYCLE" already present'),
+    );
+    expect(provisionedLog).toBeDefined();
+
+    await handle.stop();
+    rmSync(tmpAgentsDir, { recursive: true, force: true });
+  });
+
+  test("OVERLAP INVARIANT — CODE_REVIEW and REVIEW_LIFECYCLE subject sets are disjoint", async () => {
+    const { jsm, streamAdds } = makeRecordingJsm();
+    const runtime = createRecordingRuntime({ jsm });
+    const tmpAgentsDir = mkdtempSync(join(tmpdir(), "cortex-lifecycle-overlap-"));
+    const inlineAgents: Agent[] = [makeAgent("echo", ["code-review.typescript"])];
+
+    const { result: handle } = await withCapturedConsoleLog(() =>
+      startCortex(minimalConfig(), {
+        disableConfigWatcher: true,
+        disableDashboard: true,
+        disableOutboundPoller: true,
+        agentsDir: tmpAgentsDir,
+        injectRuntime: runtime,
+        inlineAgents,
+        principal: { id: PRINCIPAL },
+      }),
+    );
+
+    const byName = new Map(streamAdds.map((c) => [c.name, c]));
+    const codeReview = byName.get("CODE_REVIEW")!.subjects ?? [];
+    const lifecycle = byName.get("REVIEW_LIFECYCLE")!.subjects ?? [];
+    expect(codeReview.length).toBeGreaterThan(0);
+    expect(lifecycle.length).toBeGreaterThan(0);
+
+    // No cross-stream pair may overlap — JetStream would reject the second
+    // `streams.add` if any did.
+    for (const cr of codeReview) {
+      for (const lc of lifecycle) {
+        expect(subjectsOverlap(cr, lc)).toBe(false);
+      }
+    }
+
+    await handle.stop();
+    rmSync(tmpAgentsDir, { recursive: true, force: true });
+  });
+
+  test("config gating — no jetstreamManager → NEITHER stream provisioned (byte-identical when bus/JS unconfigured)", async () => {
+    // Runtime omits `jetstreamManager` → `resolveReviewProvisioningJsm`
+    // returns null → the whole `reviewJsm !== null` block (both CODE_REVIEW
+    // AND REVIEW_LIFECYCLE provisioning) is skipped. No JSM stub means any
+    // accidental provisioning attempt would throw, so the witness is simply
+    // that boot completes cleanly and the lifecycle provision log is absent.
+    const runtime = createRecordingRuntime({});
+    const tmpAgentsDir = mkdtempSync(join(tmpdir(), "cortex-lifecycle-dormant-"));
+    const inlineAgents: Agent[] = [makeAgent("echo", ["code-review.typescript"])];
+
+    const { result: handle, logs } = await withCapturedConsoleLog(() =>
+      startCortex(minimalConfig(), {
+        disableConfigWatcher: true,
+        disableDashboard: true,
+        disableOutboundPoller: true,
+        agentsDir: tmpAgentsDir,
+        injectRuntime: runtime,
+        inlineAgents,
+        principal: { id: PRINCIPAL },
+      }),
+    );
+
+    const lifecycleProvisionLogs = logs.filter((l) =>
+      l.includes('JetStream stream "REVIEW_LIFECYCLE"'),
+    );
+    expect(lifecycleProvisionLogs.length).toBe(0);
+    // And no CODE_REVIEW provisioning either — confirms the SHARED gate.
+    const codeReviewProvisionLogs = logs.filter(
+      (l) =>
+        l.includes('provisioned JetStream stream "CODE_REVIEW"') ||
+        l.includes('JetStream stream "CODE_REVIEW" already present'),
+    );
+    expect(codeReviewProvisionLogs.length).toBe(0);
+
+    await handle.stop();
+    rmSync(tmpAgentsDir, { recursive: true, force: true });
+  });
+});

--- a/src/common/agents/__tests__/registry.test.ts
+++ b/src/common/agents/__tests__/registry.test.ts
@@ -72,6 +72,13 @@ function cortexConfigFixture(agents: Agent[]): CortexConfig {
         },
         consumer: { maxDeliver: 5 },
       },
+      lifecycle: {
+        stream: {
+          name: "REVIEW_LIFECYCLE",
+          maxAgeSeconds: 86_400,
+          maxBytes: 512 * 1024 * 1024,
+        },
+      },
     },
     agents,
     renderers: [],

--- a/src/common/types/__tests__/cortex-config.test.ts
+++ b/src/common/types/__tests__/cortex-config.test.ts
@@ -19,6 +19,7 @@ import {
   AgentDetectionSchema,
   AgentSchema,
   AttachmentsConfigSchema,
+  BusConfigSchema,
   ClaudeConfigSchema,
   CortexConfigSchema,
   DashboardRendererSchema,
@@ -635,6 +636,44 @@ describe("Cross-cutting schemas — defaults populated by emptyDefault helper", 
     const parsed = AgentDetectionSchema.parse({});
     expect(parsed.branchPatterns).toEqual(["^feat/(g|f|i)-\\d+"]);
     expect(parsed.commentPatterns).toEqual(["^Starting:", "^Completed:"]);
+  });
+
+  test("BusConfigSchema applies review + lifecycle stream defaults (cortex#835)", () => {
+    const parsed = BusConfigSchema.parse({});
+    // Existing CODE_REVIEW posture — unchanged.
+    expect(parsed.review.stream.name).toBe("CODE_REVIEW");
+    expect(parsed.review.stream.maxAgeSeconds).toBe(86_400);
+    expect(parsed.review.stream.maxBytes).toBe(512 * 1024 * 1024);
+    expect(parsed.review.consumer.maxDeliver).toBe(5);
+    // New REVIEW_LIFECYCLE stream — mirrors CODE_REVIEW's stream posture
+    // exactly, and intentionally carries NO consumer sub-block (cortex
+    // provisions the stream; the durable consumers are the downstream
+    // reactor's concern — the cortex#835 follow-up).
+    expect(parsed.lifecycle.stream.name).toBe("REVIEW_LIFECYCLE");
+    expect(parsed.lifecycle.stream.maxAgeSeconds).toBe(86_400);
+    expect(parsed.lifecycle.stream.maxBytes).toBe(512 * 1024 * 1024);
+    expect("consumer" in parsed.lifecycle).toBe(false);
+    // The two stream names MUST differ — they own disjoint subject spaces,
+    // and a shared name would clash on `streams.add`.
+    expect(parsed.lifecycle.stream.name).not.toBe(parsed.review.stream.name);
+  });
+
+  test("BusConfigSchema honors explicit lifecycle overrides", () => {
+    const parsed = BusConfigSchema.parse({
+      lifecycle: { stream: { name: "MY_LIFECYCLE", maxAgeSeconds: 3600, maxBytes: 1024 } },
+    });
+    expect(parsed.lifecycle.stream.name).toBe("MY_LIFECYCLE");
+    expect(parsed.lifecycle.stream.maxAgeSeconds).toBe(3600);
+    expect(parsed.lifecycle.stream.maxBytes).toBe(1024);
+  });
+
+  test("BusConfigSchema rejects non-positive lifecycle stream limits", () => {
+    expect(() =>
+      BusConfigSchema.parse({ lifecycle: { stream: { maxAgeSeconds: 0 } } }),
+    ).toThrow();
+    expect(() =>
+      BusConfigSchema.parse({ lifecycle: { stream: { maxBytes: -1 } } }),
+    ).toThrow();
   });
 });
 

--- a/src/common/types/cortex-config.ts
+++ b/src/common/types/cortex-config.ts
@@ -987,6 +987,55 @@ export const BusReviewConfigSchema = z.object({
   }).default({ maxDeliver: 5 }),
 });
 
+/**
+ * Review-lifecycle JetStream provisioning knobs (cortex#835 / pilot#154).
+ * Tune cortex's REVIEW_LIFECYCLE stream — the durable-history stream that
+ * carries the verdict + dispatch-lifecycle envelopes a downstream reactor
+ * (pilot's verdict watch) wants to replay from a durable consumer instead
+ * of racing a transient core-NATS subscription.
+ *
+ * Subjects (derived at boot from the stack identity, NOT configured here):
+ *   - `local.{principal}.{stack}.review.verdict.>`   (the verdict family)
+ *   - `local.{principal}.{stack}.code.pr.review.>`   (sage's `code` domain)
+ *   - `local.{principal}.{stack}.dispatch.task.>`    (dispatch lifecycle)
+ *
+ * These NEVER overlap the CODE_REVIEW stream, which owns the disjoint
+ * `…tasks.code-review.>` namespace (JetStream rejects overlapping subjects
+ * across streams — the two streams partition the subject space cleanly).
+ *
+ * Posture mirrors `BusReviewConfigSchema.stream` EXACTLY (Interest
+ * retention, File storage, 24h max_age, finite 512 MiB max_bytes). There
+ * is intentionally NO `consumer` sub-block: cortex provisions the stream
+ * only; the durable consumers that read it are the DOWNSTREAM reactor's
+ * concern (pilot's durable-consumer upgrade — the cortex#835 follow-up).
+ */
+export const BusLifecycleConfigSchema = z.object({
+  stream: z.object({
+    /**
+     * Stream name that carries the verdict + dispatch.task lifecycle
+     * envelopes. MUST differ from `bus.review.stream.name` (the streams
+     * own disjoint subject spaces; a shared name would clash on add).
+     */
+    name: z.string().min(1).default("REVIEW_LIFECYCLE"),
+    /** How long lifecycle/verdict history remains replayable in JetStream. */
+    maxAgeSeconds: z
+      .number()
+      .int("bus.lifecycle.stream.maxAgeSeconds must be an integer number of seconds")
+      .positive("bus.lifecycle.stream.maxAgeSeconds must be positive")
+      .default(86_400),
+    /** Finite storage cap; avoids account-level reservation failures. */
+    maxBytes: z
+      .number()
+      .int("bus.lifecycle.stream.maxBytes must be an integer number of bytes")
+      .positive("bus.lifecycle.stream.maxBytes must be positive")
+      .default(512 * 1024 * 1024),
+  }).default({
+    name: "REVIEW_LIFECYCLE",
+    maxAgeSeconds: 86_400,
+    maxBytes: 512 * 1024 * 1024,
+  }),
+});
+
 export const BusConfigSchema = z.object({
   review: BusReviewConfigSchema.default({
     stream: {
@@ -996,10 +1045,18 @@ export const BusConfigSchema = z.object({
     },
     consumer: { maxDeliver: 5 },
   }),
+  lifecycle: BusLifecycleConfigSchema.default({
+    stream: {
+      name: "REVIEW_LIFECYCLE",
+      maxAgeSeconds: 86_400,
+      maxBytes: 512 * 1024 * 1024,
+    },
+  }),
 });
 
 export type BusConfig = z.infer<typeof BusConfigSchema>;
 export type BusReviewConfig = z.infer<typeof BusReviewConfigSchema>;
+export type BusLifecycleConfig = z.infer<typeof BusLifecycleConfigSchema>;
 
 // =============================================================================
 // Cross-cutting infra blocks — carried forward in same shape as AgentConfig

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -1107,7 +1107,11 @@ export async function startCortex(
   // consumer and REPLAY history instead of racing a transient core-NATS
   // subscription. cortex provisions the stream only — the durable consumers
   // that read it are the downstream reactor's concern (the cortex#835
-  // follow-up). Config posture mirrors CODE_REVIEW exactly.
+  // follow-up). Config posture mirrors CODE_REVIEW exactly. NOTE (#851
+  // review): retention is INTEREST — with zero registered consumers the
+  // stream retains NOTHING, so until pilot's durable consumer exists this
+  // is a structural enabler, not history. Replay-from-history begins only
+  // once the first durable consumer is bound.
   const lifecycleConfig = options.bus?.lifecycle;
   const lifecycleStream = lifecycleConfig?.stream.name ?? "REVIEW_LIFECYCLE";
   const lifecycleStreamMaxAgeNs =

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -1101,6 +1101,20 @@ export async function startCortex(
     reviewConfig?.stream.maxBytes ?? 512 * 1024 * 1024;
   const reviewConsumerMaxDeliver = reviewConfig?.consumer.maxDeliver ?? 5;
 
+  // cortex#835 / pilot#154 — the REVIEW_LIFECYCLE stream. A SECOND JetStream
+  // stream that carries the verdict + dispatch-lifecycle envelopes so a
+  // downstream reactor (pilot's verdict watch) can later bind a DURABLE
+  // consumer and REPLAY history instead of racing a transient core-NATS
+  // subscription. cortex provisions the stream only — the durable consumers
+  // that read it are the downstream reactor's concern (the cortex#835
+  // follow-up). Config posture mirrors CODE_REVIEW exactly.
+  const lifecycleConfig = options.bus?.lifecycle;
+  const lifecycleStream = lifecycleConfig?.stream.name ?? "REVIEW_LIFECYCLE";
+  const lifecycleStreamMaxAgeNs =
+    (lifecycleConfig?.stream.maxAgeSeconds ?? 86_400) * 1_000_000_000;
+  const lifecycleStreamMaxBytes =
+    lifecycleConfig?.stream.maxBytes ?? 512 * 1024 * 1024;
+
   // cortex#338 — resolve the provisioning JSM and provision the
   // CODE_REVIEW stream up-front so the per-agent `ReviewConsumer.start`
   // calls below can bind without hitting "stream not found" against a
@@ -1133,6 +1147,34 @@ export async function startCortex(
       ]
     : [reviewSubjectPattern];
 
+  // cortex#835 / pilot#154 — REVIEW_LIFECYCLE subject set. Covers the THREE
+  // local lifecycle families a downstream verdict-reactor races for (the
+  // exact set pilot's `subscribe-verdict.ts` listens on, plus the dispatch
+  // lifecycle the task brief names):
+  //   - `…review.verdict.>`   — the verdict envelopes (approved / changes /
+  //                             commented) the review consumer publishes
+  //   - `…code.pr.review.>`   — sage's `code` domain verdict family (pilot
+  //                             subscribes both verdict families explicitly)
+  //   - `…dispatch.task.>`    — dispatch lifecycle (received / dispatched /
+  //                             completed / failed / aborted)
+  //
+  // OVERLAP ANALYSIS (JetStream rejects overlapping subjects across streams):
+  // CODE_REVIEW owns `…tasks.code-review.>` (+ federated `tasks.*.code-review`).
+  // Those live under the `tasks.` token at segment 4; the three families here
+  // live under disjoint tokens (`review.`, `code.`, `dispatch.`) at segment 4.
+  // No prefix of any subject here is a prefix of (or prefixed by) any
+  // CODE_REVIEW subject — the two streams partition the subject space cleanly.
+  // Federated verdict/lifecycle traffic is intentionally NOT mirrored here:
+  // the durable-history need is local-reactor-scoped (pilot watches its OWN
+  // `local.{principal}.{stack}.…` scope); a federated-history follow-up can
+  // extend this set the same way `reviewStreamSubjects` extends under
+  // `federationConfigured` if/when a cross-principal reactor needs replay.
+  const lifecycleStreamSubjects = [
+    `local.${reviewPrincipalId}.${derivedStack.stack}.review.verdict.>`,
+    `local.${reviewPrincipalId}.${derivedStack.stack}.code.pr.review.>`,
+    `local.${reviewPrincipalId}.${derivedStack.stack}.dispatch.task.>`,
+  ];
+
   if (reviewJsm !== null) {
     try {
       const outcome = await provisionReviewStream({
@@ -1159,6 +1201,39 @@ export async function startCortex(
       // We log here so principals see provisioning was even attempted.
       process.stderr.write(
         `cortex: provisionReviewStream failed for "${reviewStream}": ` +
+          `${err instanceof Error ? err.message : String(err)}\n`,
+      );
+    }
+
+    // cortex#835 / pilot#154 — provision the REVIEW_LIFECYCLE stream in the
+    // SAME `reviewJsm !== null` gate so it inherits the identical config
+    // posture as CODE_REVIEW: created iff a JSM resolved (review-capable
+    // agents present AND `runtime.jetstreamManager` available), skipped
+    // entirely when the runtime is dormant. Reuses the generic
+    // `provisionReviewStream` helper (idempotent ensure, Interest retention,
+    // File storage, drift-warning) — only the name / subjects / limits
+    // differ. A failure here does NOT abort boot, identical to CODE_REVIEW.
+    try {
+      const lifecycleOutcome = await provisionReviewStream({
+        jsm: reviewJsm,
+        name: lifecycleStream,
+        subjects: lifecycleStreamSubjects,
+        maxAgeNs: lifecycleStreamMaxAgeNs,
+        maxBytes: lifecycleStreamMaxBytes,
+      });
+      if (lifecycleOutcome === "created") {
+        console.log(
+          `cortex: provisioned JetStream stream "${lifecycleStream}" (subjects=[${lifecycleStreamSubjects.join(", ")}])`,
+        );
+      } else if (lifecycleOutcome === "exists") {
+        console.log(
+          `cortex: JetStream stream "${lifecycleStream}" already present — binding existing config`,
+        );
+      }
+      // config-drift-warning is already logged by the helper.
+    } catch (err) {
+      process.stderr.write(
+        `cortex: provisionReviewStream failed for "${lifecycleStream}": ` +
           `${err instanceof Error ? err.message : String(err)}\n`,
       );
     }


### PR DESCRIPTION
## What

Provision a SECOND JetStream stream, **`REVIEW_LIFECYCLE`**, alongside the existing `CODE_REVIEW` stream. It covers the review-verdict + dispatch-lifecycle subject families so a downstream reactor (pilot's verdict watch) can later bind a **durable** consumer and **replay history** instead of racing a transient core-NATS subscription.

Refs **cortex#835** (dev-loop epic) — flagged during **pilot#154**.

## Why

Today pilot's verdict watch (`subscribe-verdict.ts`) consumes verdict/lifecycle envelopes over a transient core-NATS subscription: a reactor that wasn't subscribed at publish-time misses the envelope, and there's no replay. Standing up a durable-history stream is the cortex-side enabler for pilot's eventual durable-consumer upgrade.

This PR provisions the **stream only**. Pilot's durable-consumer upgrade is the **follow-up** (the durable consumers that read this stream are the downstream reactor's concern, not cortex's).

## Stream config + subject set

`REVIEW_LIFECYCLE` (subjects derived at boot from the stack identity):

| Subject | Family |
|---|---|
| `local.{principal}.{stack}.review.verdict.>` | verdict envelopes (approved / changes-requested / commented) |
| `local.{principal}.{stack}.code.pr.review.>` | sage's `code` domain verdict family |
| `local.{principal}.{stack}.dispatch.task.>` | dispatch lifecycle (received / dispatched / completed / failed / aborted) |

These are exactly the families pilot's `subscribe-verdict.ts` listens on, plus the `dispatch.task.>` lifecycle named in the brief.

**Posture mirrors `CODE_REVIEW` exactly** — reuses the generic `provisionReviewStream` helper:
- Interest retention, File storage
- `max_age` 24h, `max_bytes` finite 512 MiB (avoids account-reservation `max_bytes:-1` rejection), `max_msgs: -1`, `num_replicas: 1`
- idempotent ensure (`info` → `add` on 404), drift-warning (no auto-update)
- **No `consumer` sub-block** — cortex provisions the stream; durable consumers are the downstream reactor's concern (the cortex#835 follow-up).

Config: new `bus.lifecycle.stream.{name,maxAgeSeconds,maxBytes}` block (defaults `REVIEW_LIFECYCLE` / 86400 / 512 MiB), mirroring `bus.review.stream`.

## Overlap analysis (no subject collision with CODE_REVIEW)

JetStream rejects overlapping subjects across streams. `CODE_REVIEW` owns the disjoint `…tasks.code-review.>` (+ federated `tasks.*.code-review`) namespace — the `tasks.` token sits at **segment 4**. The three families here sit under **disjoint segment-4 tokens** (`review.`, `code.`, `dispatch.`). No subject of one stream is a prefix of (or prefixed by) any subject of the other, so the partition is clean. A boot test codifies this as an invariant (`subjectsOverlap()` over every cross-stream pair).

Federated verdict/lifecycle traffic is intentionally **not** mirrored here — the durable-history need is local-reactor-scoped (pilot watches its OWN `local.{principal}.{stack}.…` scope). A federated-history follow-up can extend the set the same way `reviewStreamSubjects` extends under `federationConfigured`.

## Config gating (byte-identical when bus/JS unconfigured)

The `REVIEW_LIFECYCLE` provisioning rides the **same `reviewJsm !== null` gate** as CODE_REVIEW. Dormant runtime (no NATS / no `jetstreamManager`) → **neither** stream provisioned. A boot test asserts the shared gate.

## Gates

- `tsc --noEmit` — clean (exit 0)
- `eslint --quiet src/` — clean (exit 0)
- `bun test src/` — **5183 pass / 2 skip / 0 fail** (295 files)
- `check-carveouts` — **PASS** (no ungated deprecated-term violations)
- boot smoke — **OK** (real config loader on `cortex.yaml.example`; `bus.lifecycle` default materializes as `REVIEW_LIFECYCLE` / 86400 / 512 MiB, distinct from `CODE_REVIEW`)

## Follow-up

Pilot's durable-consumer upgrade — bind a durable pull consumer on `REVIEW_LIFECYCLE` and replay verdict/lifecycle history instead of the transient core-NATS subscription (cortex#835 dev-loop epic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)