### PR TITLE
feat(runner): MC-I1.S3 — stamp cc_session_id onto dispatch.task.started

### DIFF
--- a/src/bus/__tests__/dispatch-events.test.ts
+++ b/src/bus/__tests__/dispatch-events.test.ts
@@ -365,6 +365,48 @@ describe("dispatch.task.* — correlation_id contract", () => {
   });
 });
 
+describe("dispatch.task.* — cc_session_id parameterisation (MC-I1.S3)", () => {
+  const common = {
+    source: SOURCE,
+    taskId: TASK_ID,
+    agentId: "cortex",
+    startedAt: STARTED_AT,
+  };
+  const CC_SESSION_ID = "b3a1c2d4-0000-4000-8000-aaaaaaaaaaaa";
+
+  test("omitting ccSessionId leaves the field ABSENT (not empty) on every helper", () => {
+    const envs = [
+      createDispatchTaskStartedEvent(common),
+      createDispatchTaskCompletedEvent({ ...common, completedAt: COMPLETED_AT }),
+      createDispatchTaskFailedEvent({ ...common, failedAt: COMPLETED_AT, errorSummary: "x" }),
+      createDispatchTaskAbortedEvent({ ...common, abortedAt: COMPLETED_AT, reason: "timeout" }),
+    ];
+    for (const env of envs) {
+      // Absent, not undefined-valued — same omission contract as response_routing.
+      expect("cc_session_id" in env.payload).toBe(false);
+      expect(validateEnvelope(env).ok).toBe(true);
+    }
+  });
+
+  test("ccSessionId lands in payload.cc_session_id on started and round-trips through schema", () => {
+    const env = createDispatchTaskStartedEvent({ ...common, ccSessionId: CC_SESSION_ID });
+    expect(env.payload.cc_session_id).toBe(CC_SESSION_ID);
+    expect(validateEnvelope(env).ok).toBe(true);
+  });
+
+  test("ccSessionId lands in payload.cc_session_id on every terminal helper", () => {
+    const envs = [
+      createDispatchTaskCompletedEvent({ ...common, completedAt: COMPLETED_AT, ccSessionId: CC_SESSION_ID }),
+      createDispatchTaskFailedEvent({ ...common, failedAt: COMPLETED_AT, errorSummary: "x", ccSessionId: CC_SESSION_ID }),
+      createDispatchTaskAbortedEvent({ ...common, abortedAt: COMPLETED_AT, reason: "timeout", ccSessionId: CC_SESSION_ID }),
+    ];
+    for (const env of envs) {
+      expect(env.payload.cc_session_id).toBe(CC_SESSION_ID);
+      expect(validateEnvelope(env).ok).toBe(true);
+    }
+  });
+});
+
 describe("dispatch.task.* — data_residency parameterisation", () => {
   test("source without dataResidency defaults to NZ", () => {
     const env = createDispatchTaskStartedEvent({

--- a/src/bus/dispatch-events.ts
+++ b/src/bus/dispatch-events.ts
@@ -239,8 +239,13 @@ export interface DispatchTaskCommonOpts {
    * harness has no CC session — e.g. the bus-peer harness, the agent-team
    * moderator path, or a claude-code `started` envelope yielded BEFORE the
    * session id is known (see {@link createDispatchTaskStartedEvent} timing
-   * note). When present, every lifecycle event for one task shares the same
-   * value; surfaces also key on `correlation_id` to stitch the timeline.
+   * note). On a RESUME dispatch the values can DIVERGE across one task's
+   * lifecycle: `started` carries the prior session's id (the `--resume`
+   * argument — the only id known at started-time), while the terminal
+   * envelope carries the authoritative id from the CC result event, which
+   * may differ post-resume. Consumers MUST stitch the timeline on
+   * `correlation_id` and treat the terminal envelope's id as authoritative
+   * (ADR-0005 §3; the S4 projection keys rows this way).
    *
    * **Payload-only.** This widens the lifecycle payload; the wire grammar
    * (subject, envelope metadata, sovereignty) is untouched — the myelin

--- a/src/bus/dispatch-events.ts
+++ b/src/bus/dispatch-events.ts
@@ -228,6 +228,25 @@ export interface DispatchTaskCommonOpts {
    * The builder passes whatever it receives through verbatim.
    */
   responseRouting?: AnyResponseRouting;
+  /**
+   * MC-I1.S3 (ADR-0005 §3) — the Claude Code session id this dispatch's
+   * runner learned from the CC stream-init event (cc-session.ts emits a
+   * `session-id` event). Surfaces as `payload.cc_session_id` so Mission
+   * Control — playing the dispatch-sink role — can JOIN `dispatch.task.*`
+   * lifecycle envelopes onto session/assignment rows.
+   *
+   * Optional, and OMITTED from the payload (not an empty string) when the
+   * harness has no CC session — e.g. the bus-peer harness, the agent-team
+   * moderator path, or a claude-code `started` envelope yielded BEFORE the
+   * session id is known (see {@link createDispatchTaskStartedEvent} timing
+   * note). When present, every lifecycle event for one task shares the same
+   * value; surfaces also key on `correlation_id` to stitch the timeline.
+   *
+   * **Payload-only.** This widens the lifecycle payload; the wire grammar
+   * (subject, envelope metadata, sovereignty) is untouched — the myelin
+   * schema already accepts additional payload properties.
+   */
+  ccSessionId?: string;
 }
 
 /**
@@ -260,6 +279,12 @@ function buildBaseEnvelope(
       ...(common.responseRouting !== undefined && {
         response_routing: common.responseRouting,
       }),
+      // MC-I1.S3 — stamp the CC session id when the harness knows it, so MC
+      // can join lifecycle → session rows. Omitted (no field on the wire)
+      // for harnesses without a CC session, same pattern as response_routing.
+      ...(common.ccSessionId !== undefined && {
+        cc_session_id: common.ccSessionId,
+      }),
       ...payloadExtras,
     },
   });
@@ -284,6 +309,15 @@ export interface DispatchTaskStartedOpts extends DispatchTaskCommonOpts {
  * Emitted once when the runner begins executing a task — typically right
  * after spawning the CC session. Pairs with one of `completed`, `failed`,
  * or `aborted` via the shared `correlation_id`.
+ *
+ * **MC-I1.S3 timing note.** The claude-code harness yields this envelope
+ * BEFORE it spawns the CC process, so the stream-init session id is not yet
+ * known — `cc_session_id` is therefore ABSENT here on a fresh dispatch and
+ * is carried instead by the terminal envelope (same `correlation_id`). The
+ * one exception is a RESUME dispatch, where the resume id is the known CC
+ * session id at started-time and the harness stamps it. The field is on
+ * `DispatchTaskCommonOpts` so any caller that DOES know the id early (or a
+ * future early-id substrate) can populate `started` directly.
  */
 export function createDispatchTaskStartedEvent(
   opts: DispatchTaskStartedOpts,

--- a/src/substrates/bus-peer/__tests__/harness.test.ts
+++ b/src/substrates/bus-peer/__tests__/harness.test.ts
@@ -96,11 +96,9 @@ function fakeRuntime() {
         },
       };
     },
-    // eslint-disable-next-line @typescript-eslint/require-await
     async publish(envelope) {
       published.push(envelope);
     },
-    // eslint-disable-next-line @typescript-eslint/require-await
     async stop() {
       handlers.clear();
     },
@@ -217,6 +215,11 @@ describe("BusPeerHarness — round-trip + verification gate", () => {
     expect(yielded).toHaveLength(2);
     expect(yielded[0]?.type).toBe("dispatch.task.started");
     expect(yielded[1]?.type).toBe("dispatch.task.completed");
+
+    // MC-I1.S3 — the bus-peer harness has no Claude Code session, so
+    // cc_session_id is ABSENT (not empty) on its lifecycle envelopes.
+    expect("cc_session_id" in (yielded[0]?.payload ?? {})).toBe(false);
+    expect("cc_session_id" in (yielded[1]?.payload ?? {})).toBe(false);
   });
 
   test("drops an inbound envelope whose signer is not in receiver's trust list", async () => {

--- a/src/substrates/claude-code/__tests__/harness.test.ts
+++ b/src/substrates/claude-code/__tests__/harness.test.ts
@@ -538,6 +538,11 @@ describe("ClaudeCodeHarness — cc_session_id stamping (MC-I1.S3)", () => {
 
     expect(envelopes[0]?.type).toBe("dispatch.task.started");
     expect(envelopes[0]?.payload.cc_session_id).toBe("cc-resume-id");
+
+    // Pin the divergence contract: the terminal envelope carries the
+    // AUTHORITATIVE post-resume id, which differs from started's resume id.
+    expect(envelopes[1]?.type).toBe("dispatch.task.completed");
+    expect(envelopes[1]?.payload.cc_session_id).toBe("cc-sess-resumed");
   });
 
   test("started has NO cc_session_id when there is no resume id (id not yet known)", async () => {

--- a/src/substrates/claude-code/__tests__/harness.test.ts
+++ b/src/substrates/claude-code/__tests__/harness.test.ts
@@ -466,6 +466,92 @@ describe("ClaudeCodeHarness — DispatchRequest → CCSessionOpts mapping", () =
 });
 
 // ---------------------------------------------------------------------------
+// cc_session_id stamping (MC-I1.S3 — ADR-0005 §3)
+// ---------------------------------------------------------------------------
+
+describe("ClaudeCodeHarness — cc_session_id stamping (MC-I1.S3)", () => {
+  // Timing: `started` is yielded BEFORE start() spawns CC, so the stream-init
+  // session id is not yet known. The authoritative id rides the TERMINAL
+  // envelope, sourced from CCSessionResult.sessionId. The terminal shares the
+  // started envelope's correlation_id, so MC's session projection (S4) joins
+  // started → terminal on that key and reads cc_session_id off the terminal.
+
+  test("completed envelope carries cc_session_id from result.sessionId", async () => {
+    const cap = captureFactory(makeResult({ sessionId: "cc-sess-xyz" }));
+    const h = new ClaudeCodeHarness({ source: SOURCE, ccSessionFactory: cap.factory });
+
+    const envelopes = await drain(h.dispatch(makeRequest()));
+
+    expect(envelopes[1]?.type).toBe("dispatch.task.completed");
+    expect(envelopes[1]?.payload.cc_session_id).toBe("cc-sess-xyz");
+  });
+
+  test("failed envelope carries cc_session_id from result.sessionId", async () => {
+    const cap = captureFactory(
+      makeResult({ success: false, exitCode: 1, sessionId: "cc-sess-fail" }),
+    );
+    const h = new ClaudeCodeHarness({ source: SOURCE, ccSessionFactory: cap.factory });
+
+    const envelopes = await drain(h.dispatch(makeRequest()));
+
+    expect(envelopes[1]?.type).toBe("dispatch.task.failed");
+    expect(envelopes[1]?.payload.cc_session_id).toBe("cc-sess-fail");
+  });
+
+  test("aborted envelope carries cc_session_id from result.sessionId", async () => {
+    const cap = captureFactory(
+      makeResult({
+        success: false,
+        exitCode: 1,
+        aborted: true,
+        abortReason: "timeout",
+        sessionId: "cc-sess-abort",
+      }),
+    );
+    const h = new ClaudeCodeHarness({ source: SOURCE, ccSessionFactory: cap.factory });
+
+    const envelopes = await drain(h.dispatch(makeRequest()));
+
+    expect(envelopes[1]?.type).toBe("dispatch.task.aborted");
+    expect(envelopes[1]?.payload.cc_session_id).toBe("cc-sess-abort");
+  });
+
+  test("cc_session_id is ABSENT (not empty) on terminal when result has no sessionId", async () => {
+    const cap = captureFactory(makeResult({ sessionId: undefined }));
+    const h = new ClaudeCodeHarness({ source: SOURCE, ccSessionFactory: cap.factory });
+
+    const envelopes = await drain(h.dispatch(makeRequest()));
+
+    expect(envelopes[1]?.type).toBe("dispatch.task.completed");
+    expect("cc_session_id" in (envelopes[1]?.payload ?? {})).toBe(false);
+  });
+
+  test("started carries cc_session_id from the resume id when one is supplied", async () => {
+    // The resume id is the only CC session id the harness knows at started-time
+    // (it's threaded as --resume). Without a resume id, started has no session
+    // id available yet (the stream-init id arrives after start()).
+    const cap = captureFactory(makeResult({ sessionId: "cc-sess-resumed" }));
+    const h = new ClaudeCodeHarness({ source: SOURCE, ccSessionFactory: cap.factory });
+    const req = makeRequest({ runtime: { resumeSessionId: "cc-resume-id" } });
+
+    const envelopes = await drain(h.dispatch(req));
+
+    expect(envelopes[0]?.type).toBe("dispatch.task.started");
+    expect(envelopes[0]?.payload.cc_session_id).toBe("cc-resume-id");
+  });
+
+  test("started has NO cc_session_id when there is no resume id (id not yet known)", async () => {
+    const cap = captureFactory(makeResult({ sessionId: "cc-sess-fresh" }));
+    const h = new ClaudeCodeHarness({ source: SOURCE, ccSessionFactory: cap.factory });
+
+    const envelopes = await drain(h.dispatch(makeRequest()));
+
+    expect(envelopes[0]?.type).toBe("dispatch.task.started");
+    expect("cc_session_id" in (envelopes[0]?.payload ?? {})).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Failure paths
 // ---------------------------------------------------------------------------
 

--- a/src/substrates/claude-code/harness.ts
+++ b/src/substrates/claude-code/harness.ts
@@ -451,17 +451,35 @@ export class ClaudeCodeHarness implements SessionHarness {
     return randomUUID();
   }
 
+  /**
+   * MC-I1.S3 (ADR-0005 §3) — the CC session id known at started-time.
+   *
+   * On a FRESH dispatch this is `undefined`: `started` is yielded before
+   * `start()` spawns CC, so the stream-init session id doesn't exist yet —
+   * the authoritative id rides the terminal envelope instead (see
+   * {@link buildTerminalEnvelope}). On a RESUME dispatch the runtime carries
+   * `resumeSessionId` (the `--resume <id>` target), which IS a CC session id
+   * the harness knows up front, so we stamp it onto `started`.
+   *
+   * Returns the id or `undefined`; the builder omits the field when undefined.
+   */
+  private startedSessionId(req: DispatchRequest): string | undefined {
+    return req.runtime?.resumeSessionId;
+  }
+
   private buildStartedEnvelope(
     req: DispatchRequest,
     startedAt: Date,
     correlationId: string,
   ): Envelope {
+    const ccSessionId = this.startedSessionId(req);
     return createDispatchTaskStartedEvent({
       source: this.source,
       taskId: req.requestId,
       agentId: req.agent.id,
       correlationId,
       startedAt,
+      ...(ccSessionId !== undefined && { ccSessionId }),
     });
   }
 
@@ -472,6 +490,8 @@ export class ClaudeCodeHarness implements SessionHarness {
     completedAt: Date,
     resultSummary?: string,
     chatResponse?: string,
+    // MC-I1.S3 — the authoritative CC session id from CCSessionResult.
+    ccSessionId?: string,
   ): Envelope {
     return createDispatchTaskCompletedEvent({
       source: this.source,
@@ -485,6 +505,8 @@ export class ClaudeCodeHarness implements SessionHarness {
       // sink can post the complete chat round-trip back to the channel.
       // `resultSummary` stays the first-line/1000-char dashboard label.
       ...(chatResponse !== undefined && { chatResponse }),
+      // MC-I1.S3 — stamp the CC session id so MC can join lifecycle → session.
+      ...(ccSessionId !== undefined && { ccSessionId }),
     });
   }
 
@@ -493,6 +515,9 @@ export class ClaudeCodeHarness implements SessionHarness {
     startedAt: Date,
     correlationId: string,
     errorSummary: string,
+    // MC-I1.S3 — present on the result path; undefined on the no-result
+    // paths (shutdown refusal, runtime-error before any CC session existed).
+    ccSessionId?: string,
   ): Envelope {
     return createDispatchTaskFailedEvent({
       source: this.source,
@@ -502,6 +527,7 @@ export class ClaudeCodeHarness implements SessionHarness {
       startedAt,
       failedAt: new Date(),
       errorSummary: truncateDispatchErrorSummary(errorSummary),
+      ...(ccSessionId !== undefined && { ccSessionId }),
     });
   }
 
@@ -510,6 +536,8 @@ export class ClaudeCodeHarness implements SessionHarness {
     startedAt: Date,
     correlationId: string,
     reason: string,
+    // MC-I1.S3 — the CC session id from CCSessionResult, when available.
+    ccSessionId?: string,
   ): Envelope {
     return createDispatchTaskAbortedEvent({
       source: this.source,
@@ -519,6 +547,7 @@ export class ClaudeCodeHarness implements SessionHarness {
       startedAt,
       abortedAt: new Date(),
       reason,
+      ...(ccSessionId !== undefined && { ccSessionId }),
     });
   }
 
@@ -551,6 +580,12 @@ export class ClaudeCodeHarness implements SessionHarness {
       );
     }
 
+    // MC-I1.S3 — the authoritative CC session id rides the terminal envelope.
+    // CCSessionResult.sessionId is populated from the stream-init/result event;
+    // undefined only if CC never emitted one (e.g. it died before init), in
+    // which case the field is omitted (not empty) on the wire.
+    const ccSessionId = result.sessionId;
+
     if (result.success) {
       return this.buildCompletedEnvelope(
         req,
@@ -560,6 +595,7 @@ export class ClaudeCodeHarness implements SessionHarness {
         result.response ? truncateDispatchResultSummary(result.response) : undefined,
         // cortex#491 — full reply, untruncated, for the chat round-trip.
         result.response ? result.response : undefined,
+        ccSessionId,
       );
     }
 
@@ -573,6 +609,7 @@ export class ClaudeCodeHarness implements SessionHarness {
         startedAt,
         correlationId,
         result.abortReason ?? "timeout",
+        ccSessionId,
       );
     }
 
@@ -581,6 +618,7 @@ export class ClaudeCodeHarness implements SessionHarness {
       startedAt,
       correlationId,
       `claude exited ${result.exitCode}`,
+      ccSessionId,
     );
   }
 }


### PR DESCRIPTION
## What

Phase 1, slice 3 of #843, implementing **ADR-0005 §3** (bus-driven session projection). Mission Control will project `dispatch.task.*` lifecycle envelopes into session/assignment rows (slice S4). For that join it needs the Claude Code session id on the lifecycle wire.

- Add optional `ccSessionId` to `DispatchTaskCommonOpts` → stamps `payload.cc_session_id` on **all four** lifecycle helpers (`started`, `completed`, `failed`, `aborted`). Omitted from the payload (**not** an empty string) when absent, mirroring the existing `response_routing` omission pattern.
- The **claude-code harness** stamps the authoritative id from `CCSessionResult.sessionId` onto the terminal envelope, and the resume id (`req.runtime.resumeSessionId`) onto `started` when present.
- **Absent** for non-CC paths (bus-peer harness, agent-team moderator).

## Why payload-only (wire-grammar untouched)

The myelin envelope schema already accepts additional payload properties, so this **widens the lifecycle payload only** — the subject grammar, envelope metadata, and sovereignty are untouched. This satisfies the federation wire-protocol constraint that this be a payload-only change.

## Timing finding (load-bearing for S4)

**Does `dispatch.task.started` carry `cc_session_id`? — SOMETIMES, and here's exactly when:**

For the claude-code harness, the CC session id is **NOT available when `started` is published on a fresh dispatch**. `started` is yielded at `harness.ts` *before* `session.start()` spawns CC (`harness.ts:218-246`); the session id only arrives **afterwards**, asynchronously, via the cc-session stream-init `session-id` event (`cc-session.ts:509-512`). The id **is** reliably available on `CCSessionResult.sessionId` for the **terminal** envelopes.

I rejected reordering `started` to wait for the init event:
1. The harness **intentionally** yields `started` before `start()` so the lifecycle envelope is observable even if `start()` throws synchronously (e.g. `claude` missing from `$PATH`) — documented at `harness.ts:218-221`. Reordering loses that `started` on a spawn failure (behavior change with real risk).
2. The session id arrives asynchronously mid-stream — capturing it onto `started` is not a trivial, behavior-preserving reorder; it would require restructuring the generator to await an event.

**Net behavior:**
- `started` carries `cc_session_id` **only on a RESUME dispatch** (the resume id is the known CC session id at started-time).
- A **fresh** dispatch's `started` **omits** it.
- The authoritative id **ALWAYS** lands on the **terminal** envelope (`completed`/`failed`/`aborted`), which shares the `started` envelope's `correlation_id`.

**Guidance for S4:** join `started` → terminal on `correlation_id` and read `cc_session_id` off the **terminal** envelope for the fresh-dispatch case; the started envelope's id is a bonus on resume only. The type field is on `DispatchTaskCommonOpts` so a future early-id substrate (or an upstream that learns the id sooner) can populate `started` directly with no further wire change.

## Test plan

- **dispatch-events**: `cc_session_id` round-trips through the myelin schema on every helper; absent (not empty) when omitted.
- **claude-code harness**: `completed`/`failed`/`aborted` stamp from `result.sessionId`; `started` stamps from the resume id; absent when result has no id and no resume id.
- **bus-peer harness**: `cc_session_id` absent on its lifecycle envelopes (non-CC path).

### Gate results

| Gate | Result |
|---|---|
| `bun run lint` | exit 0 (clean) |
| `bunx tsc --noEmit` | exit 0 |
| `bun test` (full) | 5186 pass / 0 fail (clean run; flaky NATS/Discord integration tests are network-dependent and pass on re-run) |
| `bash scripts/check-carveouts.sh` | PASS |

Files changed: `src/bus/dispatch-events.ts`, `src/bus/__tests__/dispatch-events.test.ts`, `src/substrates/claude-code/harness.ts`, `src/substrates/claude-code/__tests__/harness.test.ts`, `src/substrates/bus-peer/__tests__/harness.test.ts`.

Closes #845
Part of #843

🤖 Generated with [Claude Code](https://claude.com/claude-code)