### PR TITLE
feat(runner): F-2.1 — dev.implement capability consumer (dormant; warm sessions)

### DIFF
--- a/src/bus/__tests__/dev-events.test.ts
+++ b/src/bus/__tests__/dev-events.test.ts
@@ -1,0 +1,111 @@
+/**
+ * F-2.1 (cortex#835) — tests for `bus/dev-events.ts`.
+ *
+ * Mirrors `review-events.test.ts` style: construct a request, assert the
+ * envelope shape; round-trip the payload parser; cover the chain-id helper.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  createDevImplementRequestEvent,
+  parseDevImplementPayload,
+  devCorrelationChainId,
+  type DevEventSource,
+  type DevImplementPayload,
+} from "../dev-events";
+import type { Envelope } from "../myelin/envelope-validator";
+
+const SOURCE: DevEventSource = { principal: "andreas", agent: "cortex", instance: "local" };
+const PAYLOAD: DevImplementPayload = {
+  repo: "the-metafactory/cortex",
+  branch: "feat/c-300-panel",
+  base: "main",
+  brief: "Implement the panel.",
+  issue: 300,
+  gates: ["bunx tsc --noEmit"],
+  feature: "C-300",
+  title: "feat: panel",
+};
+
+describe("createDevImplementRequestEvent", () => {
+  test("builds a tasks.dev.implement envelope with the canonical payload", () => {
+    const env = createDevImplementRequestEvent({ source: SOURCE, payload: PAYLOAD });
+    expect(env.type).toBe("tasks.dev.implement");
+    expect(env.source).toBe("andreas.cortex.local");
+    expect(env.sovereignty.classification).toBe("local");
+    expect(env.payload).toMatchObject({
+      repo: "the-metafactory/cortex",
+      branch: "feat/c-300-panel",
+      base: "main",
+      brief: "Implement the panel.",
+      issue: 300,
+      gates: ["bunx tsc --noEmit"],
+    });
+    // Fresh UUID id; no correlation_id on a first-of-chain request.
+    expect(env.id).toMatch(/^[0-9a-f-]{36}$/);
+  });
+
+  test("federated classification opt-in", () => {
+    const env = createDevImplementRequestEvent({
+      source: SOURCE,
+      classification: "federated",
+      payload: PAYLOAD,
+    });
+    expect(env.sovereignty.classification).toBe("federated");
+  });
+});
+
+describe("parseDevImplementPayload", () => {
+  function envWith(payload: Record<string, unknown>): Envelope {
+    const env = createDevImplementRequestEvent({ source: SOURCE, payload: PAYLOAD });
+    env.payload = payload;
+    return env;
+  }
+
+  test("round-trips a valid payload", () => {
+    const env = createDevImplementRequestEvent({ source: SOURCE, payload: PAYLOAD });
+    const parsed = parseDevImplementPayload(env);
+    expect(parsed).toEqual(PAYLOAD);
+  });
+
+  test("minimal payload (no optionals)", () => {
+    const env = envWith({
+      repo: "the-metafactory/cortex",
+      branch: "feat/x",
+      base: "main",
+      brief: "do it",
+    });
+    expect(parseDevImplementPayload(env)).toEqual({
+      repo: "the-metafactory/cortex",
+      branch: "feat/x",
+      base: "main",
+      brief: "do it",
+    });
+  });
+
+  test.each([
+    ["bad repo", { repo: "noslash", branch: "feat/x", base: "main", brief: "b" }],
+    ["blank brief", { repo: "o/r", branch: "feat/x", base: "main", brief: "   " }],
+    ["missing branch", { repo: "o/r", base: "main", brief: "b" }],
+    ["bad branch (space)", { repo: "o/r", branch: "a b", base: "main", brief: "b" }],
+    ["non-int issue", { repo: "o/r", branch: "x", base: "main", brief: "b", issue: 1.5 }],
+    ["negative issue", { repo: "o/r", branch: "x", base: "main", brief: "b", issue: -1 }],
+    ["gates not array", { repo: "o/r", branch: "x", base: "main", brief: "b", gates: "tsc" }],
+    ["empty gate", { repo: "o/r", branch: "x", base: "main", brief: "b", gates: [""] }],
+  ])("rejects: %s", (_label, payload) => {
+    expect(parseDevImplementPayload(envWith(payload as Record<string, unknown>))).toBeNull();
+  });
+});
+
+describe("devCorrelationChainId", () => {
+  test("uses correlation_id when present (the chain root)", () => {
+    const env = createDevImplementRequestEvent({ source: SOURCE, payload: PAYLOAD });
+    (env as { correlation_id?: string }).correlation_id = "chain-root-id";
+    expect(devCorrelationChainId(env)).toBe("chain-root-id");
+  });
+
+  test("falls back to envelope.id for a first-of-chain request", () => {
+    const env = createDevImplementRequestEvent({ source: SOURCE, payload: PAYLOAD });
+    expect(devCorrelationChainId(env)).toBe(env.id);
+  });
+});

--- a/src/bus/__tests__/dev-events.test.ts
+++ b/src/bus/__tests__/dev-events.test.ts
@@ -88,6 +88,8 @@ describe("parseDevImplementPayload", () => {
     ["blank brief", { repo: "o/r", branch: "feat/x", base: "main", brief: "   " }],
     ["missing branch", { repo: "o/r", base: "main", brief: "b" }],
     ["bad branch (space)", { repo: "o/r", branch: "a b", base: "main", brief: "b" }],
+    ["branch with .. (traversal)", { repo: "o/r", branch: "feat/x..y", base: "main", brief: "b" }],
+    ["base with .. (traversal)", { repo: "o/r", branch: "feat/x", base: "..", brief: "b" }],
     ["non-int issue", { repo: "o/r", branch: "x", base: "main", brief: "b", issue: 1.5 }],
     ["negative issue", { repo: "o/r", branch: "x", base: "main", brief: "b", issue: -1 }],
     ["gates not array", { repo: "o/r", branch: "x", base: "main", brief: "b", gates: "tsc" }],

--- a/src/bus/dev-events.ts
+++ b/src/bus/dev-events.ts
@@ -182,12 +182,15 @@ export function createDevImplementRequestEvent(
 
 // `owner/name` — same grammar as `review-events.ts`'s OWNER_REPO_RE.
 const OWNER_REPO_RE = /^[A-Za-z0-9][\w.-]*\/[A-Za-z0-9][\w.-]*$/;
-// A git branch / ref name — conservative: no whitespace, no `..`, no leading
-// `-`, no control chars. Not the full `git check-ref-format` grammar (that is
-// the forge seam's job to honour); this is the cheap structural gate so a
-// blank or obviously-malformed branch fails fast as `cant_do` rather than
-// reaching `git worktree add`.
-const BRANCH_RE = /^[A-Za-z0-9][\w./-]*$/;
+// A git branch / ref name — conservative: no whitespace, no `..` segment, no
+// leading `-`, no control chars. Not the full `git check-ref-format` grammar
+// (that is the forge seam's job to honour); this is the cheap structural gate
+// so a blank or obviously-malformed branch fails fast as `cant_do` rather than
+// reaching `git worktree add`. The `(?!.*\.\.)` lookahead enforces the stated
+// "no `..`" intent (a `..` in a ref is both a git-illegal sequence AND a
+// path-traversal shape) — defense-in-depth even though the worktree/forge
+// seams would also reject it downstream.
+const BRANCH_RE = /^(?!.*\.\.)[A-Za-z0-9][\w./-]*$/;
 
 /**
  * Parse a `tasks.dev.implement` envelope's payload into the canonical

--- a/src/bus/dev-events.ts
+++ b/src/bus/dev-events.ts
@@ -1,0 +1,272 @@
+/**
+ * F-2.1 (cortex#835) — `tasks.dev.implement` request envelope + payload parser
+ * for the agentic dev-loop's `dev.implement` capability consumer.
+ *
+ * Mirrors `bus/review-events.ts` shape-for-shape. The reviewer side ships
+ * `tasks.code-review.<flavor>` request + `review.verdict.<kind>` reply
+ * builders; the dev side ships ONE request family
+ * (`tasks.dev.implement`) and reuses the shared `dispatch.task.*` lifecycle
+ * envelopes (`dispatch-events.ts`) for started / completed / failed — there
+ * is NO bespoke verdict reply (the PR ref rides `dispatch.task.completed`'s
+ * payload). See `docs/design-agentic-dev-pipeline.md` §3.1 (dev-agent row),
+ * §3.4 step 2 (event walk).
+ *
+ * **What this file ships:**
+ *   - `createDevImplementRequestEvent` → `tasks.dev.implement` request
+ *     envelope. Production producer is pilot's tick (§3.4 step 1); this
+ *     cortex-side helper lets the consumer's tests synthesise requests
+ *     without a pilot harness — exactly the role `createReviewRequestEvent`
+ *     plays for the review consumer.
+ *   - `parseDevImplementPayload` → validate + normalise an inbound
+ *     envelope's payload to the canonical {@link DevImplementPayload}. The
+ *     consumer trusts an already-parsed payload, so validation lives here.
+ *
+ * **What this file is NOT:**
+ *   - NOT a publisher — no NATS, no I/O. Pure envelope construction +
+ *     payload parsing.
+ *   - NOT a subscriber — the consumer lives in `runner/dev-consumer.ts`.
+ *   - NOT a lifecycle-envelope builder — `dispatch-events.ts` owns those;
+ *     the consumer co-emits them (started / completed / failed) the same
+ *     way `review-consumer.ts` does. Re-exported here for ergonomics so the
+ *     consumer imports one module.
+ *
+ * **Brief = intent + references, never a context bundle** (design DD-P3):
+ * the payload carries issue / brief refs, repo, branch name, base, and the
+ * gate command list. The worker pulls the actual slice (the repo, the issue
+ * body, the design §) with its own tools inside the CC session.
+ */
+
+import type { Classification, Envelope } from "./myelin/envelope-validator";
+import { buildBaseEnvelope as buildSharedEnvelope } from "./envelope-builder";
+import type { SystemEventSource } from "./system-events";
+
+// Re-export the source shape under a domain-neutral alias — mirrors
+// `ReviewEventSource` in `review-events.ts`. Callers import from one place.
+export type DevEventSource = SystemEventSource;
+
+// Re-exported from `dispatch-events.ts` so the dev consumer imports one
+// module for the failure taxonomy (single source of truth stays in
+// `dispatch-events.ts` per cortex#249).
+export type { DispatchTaskFailedReason } from "./dispatch-events";
+
+function buildSource(src: SystemEventSource): string {
+  return `${src.principal}.${src.agent}.${src.instance}`;
+}
+
+/**
+ * Default sovereignty for `tasks.dev.implement` envelopes. Same posture as
+ * `tasks.code-review.*` and `dispatch.task.*`: principal-local by default,
+ * local residency, no frontier, no hops. A dev task names a repo + branch +
+ * issue — principal-private until federation (F-5) opts a request into
+ * `classification: "federated"`.
+ *
+ * Returned as a fresh literal per call so a downstream mutation on one
+ * envelope's `sovereignty` cannot leak into a sibling envelope.
+ */
+function defaultDevSovereignty(
+  source: SystemEventSource,
+  classification: Classification = "local",
+): Envelope["sovereignty"] {
+  return {
+    classification,
+    data_residency: source.dataResidency ?? "NZ",
+    max_hop: 0,
+    frontier_ok: false,
+    model_class: "local-only",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// tasks.dev.implement — request payload
+// ---------------------------------------------------------------------------
+
+/**
+ * Canonical `tasks.dev.implement` payload (§3.4 step 1 brief = intent + refs).
+ *
+ * Required fields are the load-bearing routing keys the consumer cannot
+ * proceed without:
+ *   - `repo`  — `owner/name`, the repo to branch + open the PR against.
+ *   - `branch` — the feature branch name (worktree-discipline SOP form,
+ *     e.g. `feat/c-300-panel`).
+ *   - `base`  — the base branch the worktree is cut from + the PR targets
+ *     (almost always `main` per the SOP, but explicit so a release branch
+ *     can override).
+ *   - `brief` — the intent string handed to the CC session. INTENT + REFS,
+ *     not a context bundle: it names the issue, the design §, the
+ *     acceptance criteria, and (on a fix cycle) the review findings refs.
+ *
+ * Optional fields:
+ *   - `issue`  — issue number the work closes (stamped into the PR body so
+ *     merging auto-closes it). Surfaces render for context.
+ *   - `gates`  — the gate command list run after the CC session, BEFORE the
+ *     PR opens (e.g. `["bunx tsc --noEmit", "bun test src/"]`). When omitted
+ *     the consumer opens the PR without running gates (the caller is then
+ *     responsible for gating in review).
+ *   - `feature` / `title` — principal-supplied context surfaces render but
+ *     the consumer does not branch on.
+ */
+export interface DevImplementPayload {
+  /** `owner/name` repo string, e.g. `"the-metafactory/cortex"`. */
+  repo: string;
+  /** Feature branch name (worktree-discipline SOP), e.g. `"feat/c-300-panel"`. */
+  branch: string;
+  /** Base branch the worktree is cut from + the PR targets, e.g. `"main"`. */
+  base: string;
+  /** Intent string handed to the CC session — refs, not a context dump. */
+  brief: string;
+  /** Optional issue number the PR closes (auto-close via `Closes #N`). */
+  issue?: number;
+  /** Optional gate commands run after the session, before the PR opens. */
+  gates?: readonly string[];
+  /** Optional feature id (e.g. `"F-2.1"`). Surfaces render for context. */
+  feature?: string;
+  /** Optional human-readable PR title. */
+  title?: string;
+}
+
+/** Options for {@link createDevImplementRequestEvent}. */
+export interface CreateDevImplementRequestEventOpts {
+  source: DevEventSource;
+  /**
+   * Optional sovereignty classification. Defaults to `"local"` (principal-
+   * private). `"federated"` for cross-principal dispatch (F-5). Mismatch
+   * with the publish-time subject is a protocol violation caught by
+   * `validateSubjectEnvelopeAlignment`.
+   */
+  classification?: Classification;
+  /** Payload per §3.4 step 1. */
+  payload: DevImplementPayload;
+}
+
+/**
+ * Construct a `tasks.dev.implement` request envelope.
+ *
+ * The envelope's `id` is the correlation root for the whole implement →
+ * fix-cycle chain (§3.6b warm sessions): every lifecycle envelope the
+ * consumer emits carries it as `correlation_id`, and the consumer's
+ * warm-session store keys the CC session id on the request's
+ * `correlation_id` (or its explicit chain id) so a subsequent fix-cycle
+ * request resumes the same CC session.
+ *
+ * This is the cortex-side mirror of pilot's tick publisher. The cortex
+ * consumer does NOT publish request envelopes in production — pilot does —
+ * but cortex-side tests synthesise them to drive the consumer pipeline
+ * without a pilot harness.
+ *
+ * @returns a fresh `Envelope` literal with a new UUID id; safe to publish.
+ */
+export function createDevImplementRequestEvent(
+  opts: CreateDevImplementRequestEventOpts,
+): Envelope {
+  const p = opts.payload;
+  return buildSharedEnvelope({
+    type: "tasks.dev.implement",
+    source: buildSource(opts.source),
+    sovereignty: defaultDevSovereignty(opts.source, opts.classification),
+    payload: {
+      repo: p.repo,
+      branch: p.branch,
+      base: p.base,
+      brief: p.brief,
+      ...(p.issue !== undefined && { issue: p.issue }),
+      ...(p.gates !== undefined && { gates: [...p.gates] }),
+      ...(p.feature !== undefined && { feature: p.feature }),
+      ...(p.title !== undefined && { title: p.title }),
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// payload parsing — validate + normalise an inbound envelope
+// ---------------------------------------------------------------------------
+
+// `owner/name` — same grammar as `review-events.ts`'s OWNER_REPO_RE.
+const OWNER_REPO_RE = /^[A-Za-z0-9][\w.-]*\/[A-Za-z0-9][\w.-]*$/;
+// A git branch / ref name — conservative: no whitespace, no `..`, no leading
+// `-`, no control chars. Not the full `git check-ref-format` grammar (that is
+// the forge seam's job to honour); this is the cheap structural gate so a
+// blank or obviously-malformed branch fails fast as `cant_do` rather than
+// reaching `git worktree add`.
+const BRANCH_RE = /^[A-Za-z0-9][\w./-]*$/;
+
+/**
+ * Parse a `tasks.dev.implement` envelope's payload into the canonical
+ * {@link DevImplementPayload}, or `null` on any shape violation.
+ *
+ * The consumer maps a `null` here to a `cant_do` permanent failure (term
+ * ack) — a malformed brief won't become valid on redelivery, exactly the
+ * way `review-consumer.ts` treats `parseReviewRequestPayload` returning
+ * `null`.
+ *
+ * Validates the load-bearing routing keys structurally:
+ *   - `repo` matches `owner/name`.
+ *   - `branch` + `base` match the conservative branch grammar above.
+ *   - `brief` is a non-empty string.
+ *   - `gates`, when present, is an array of non-empty strings.
+ *   - `issue`, when present, is a positive integer.
+ *
+ * Exported for the dev-consumer tests.
+ */
+export function parseDevImplementPayload(
+  envelope: Envelope,
+): DevImplementPayload | null {
+  const p = envelope.payload as Record<string, unknown> | undefined;
+  if (!p || typeof p !== "object") return null;
+
+  if (typeof p.repo !== "string" || !OWNER_REPO_RE.test(p.repo)) return null;
+  if (typeof p.branch !== "string" || !BRANCH_RE.test(p.branch)) return null;
+  if (typeof p.base !== "string" || !BRANCH_RE.test(p.base)) return null;
+  if (typeof p.brief !== "string" || p.brief.trim().length === 0) return null;
+
+  const out: DevImplementPayload = {
+    repo: p.repo,
+    branch: p.branch,
+    base: p.base,
+    brief: p.brief,
+  };
+
+  if (p.issue !== undefined) {
+    if (typeof p.issue !== "number" || !Number.isInteger(p.issue) || p.issue <= 0) {
+      return null;
+    }
+    out.issue = p.issue;
+  }
+
+  if (p.gates !== undefined) {
+    if (!Array.isArray(p.gates)) return null;
+    const gates: string[] = [];
+    for (const g of p.gates) {
+      if (typeof g !== "string" || g.trim().length === 0) return null;
+      gates.push(g);
+    }
+    out.gates = gates;
+  }
+
+  if (typeof p.feature === "string") out.feature = p.feature;
+  if (typeof p.title === "string") out.title = p.title;
+
+  return out;
+}
+
+/**
+ * Extract the correlation CHAIN id from an inbound `tasks.dev.implement`
+ * envelope — the key the warm-session store maps to a CC session id
+ * (§3.6b). The fix-cycle carries the SAME chain id as the implement that
+ * preceded it, so a subsequent task resumes the same CC session.
+ *
+ * Resolution precedence:
+ *   1. `envelope.correlation_id` — pilot stamps the chain's root request id
+ *      here on every task in the chain (the implement AND its fix cycles),
+ *      so it is the durable chain key.
+ *   2. `envelope.id` — fallback for a first-of-chain request that carries no
+ *      explicit `correlation_id` (the cortex-side test synthesiser path);
+ *      the root request's own id IS the chain root.
+ *
+ * Never returns empty: both branches are UUID-shaped by envelope
+ * construction. Exported for the dev-consumer tests.
+ */
+export function devCorrelationChainId(envelope: Envelope): string {
+  const corr = envelope.correlation_id;
+  if (typeof corr === "string" && corr.length > 0) return corr;
+  return envelope.id;
+}

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -61,6 +61,7 @@ import {
   type ReviewConsumerAgent,
   type SignatureVerifier,
 } from "./bus/review-consumer";
+import { wireDevConsumers } from "./runner/dev-consumer-boot";
 import {
   provisionReviewStream,
   provisionReviewConsumer,
@@ -1501,6 +1502,54 @@ export async function startCortex(
     );
   }
 
+  // F-2.1 (cortex#835) — dev.implement consumer boot wiring.
+  //
+  // DORMANT BY DEFAULT: `wireDevConsumers` returns an EMPTY array — touching
+  // no filesystem, spawning nothing, reading no token — unless an agent
+  // declares a `dev.implement` (or bare `dev`) capability in
+  // `runtime.capabilities[]`. Every live stack today declares none, so this
+  // block is inert: byte-identical boot. Mirrors the review-consumer
+  // dormancy contract above; runs AFTER it so a principal scanning boot logs
+  // sees the review path first.
+  const devConsumers = wireDevConsumers({
+    agents: mergedAgents,
+    runtime,
+    source: systemEventSource,
+    principalId,
+    stack: derivedStack.stack,
+  });
+  for (const consumer of devConsumers) {
+    try {
+      // Stream provisioning for `tasks.dev.implement` is deliberately a
+      // sibling slice (see dev-consumer-boot.ts header FLAG) — until a
+      // dev-capable agent exists this loop never runs, so the deferral
+      // changes no live behaviour. `start()` stays dormant-safe: a disabled
+      // runtime returns `subscribed: false` and the consumer never binds.
+      const started = await consumer.start({
+        pattern: `local.${principalId}.${derivedStack.stack}.tasks.dev.implement`,
+        stream: "DEV_IMPLEMENT",
+        durable: `cortex-dev-consumer-${principalId}-${consumer.agent.id}`,
+      });
+      if (started.subscribed) {
+        console.log(`cortex: dev.implement consumer ready for agent=${consumer.agent.id}`);
+      } else {
+        console.log(
+          `cortex: dev.implement consumer DORMANT for agent=${consumer.agent.id} — ` +
+            `cortex MyelinRuntime subscriptions disabled (G-1111 pending; tasks.dev.implement ` +
+            `envelopes will not be claimed by this consumer)`,
+        );
+      }
+    } catch (err) {
+      // Per CLAUDE.md: log every error. One agent's consumer crash does NOT
+      // abort boot; siblings still wire and the shutdown drain still calls
+      // `.stop()` (idempotent — handles the "never subscribed" case).
+      process.stderr.write(
+        `cortex: dev consumer init failed for agent=${consumer.agent.id}: ` +
+          `${err instanceof Error ? err.message : String(err)}\n`,
+      );
+    }
+  }
+
   // IAW Phase B.2a (refs cortex#114) — inbound peer-dispatch listener.
   // Subscribes via the runtime's onEnvelope fan-out, filters for
   // `dispatch.task.dispatched` envelopes from non-self sources, runs
@@ -2856,6 +2905,7 @@ export async function startCortex(
       "github webhook receiver stop",
       ...adapterCleanup.map((_, i) => `outbound poller stop[${i}]`),
       ...reviewConsumers.map((c, i) => `review-consumer stop[${i}] (agent=${c.agent.id})`),
+      ...devConsumers.map((c, i) => `dev-consumer stop[${i}] (agent=${c.agent.id})`),
       "dispatch-listener stop",
       "dispatch-sink stop",
       "review-sink stop",
@@ -2912,6 +2962,20 @@ export async function startCortex(
         if (consumer) {
           await completeAsync(
             `review-consumer stop[${i}] (agent=${consumer.agent.id})`,
+            consumer.stop(),
+          );
+        }
+      }
+      // F-2.1 (cortex#835) — drain dev consumers on the same boundary so an
+      // in-flight implement (worktree + CC + gates + PR) publishes its
+      // terminal envelope before the runtime closes. `DevConsumer.stop()` is
+      // idempotent and awaits its in-flight set (the "never subscribed" /
+      // dormant case is a no-op). Empty on every default stack.
+      for (let i = 0; i < devConsumers.length; i++) {
+        const consumer = devConsumers[i];
+        if (consumer) {
+          await completeAsync(
+            `dev-consumer stop[${i}] (agent=${consumer.agent.id})`,
             consumer.stop(),
           );
         }

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -1517,6 +1517,12 @@ export async function startCortex(
     source: systemEventSource,
     principalId,
     stack: derivedStack.stack,
+    // §3.5b — thread the same guardrail config the review path uses
+    // (`config.claude`: bashAllowlist + allowedTools/Dirs + async timeout) so
+    // the higher-authority dev push session is never LESS-guarded than the
+    // review session. `buildDevSessionOpts` also sets the bash-guard Gate-1
+    // channel + a conservative allowlist default when the config declares none.
+    guardrails: config.claude,
   });
   for (const consumer of devConsumers) {
     try {

--- a/src/runner/__tests__/dev-consumer-boot.test.ts
+++ b/src/runner/__tests__/dev-consumer-boot.test.ts
@@ -13,9 +13,12 @@
 import { describe, expect, test } from "bun:test";
 import {
   wireDevConsumers,
+  buildDevSessionOpts,
   devSubjectPattern,
   devDurableName,
+  DEFAULT_DEV_BASH_ALLOWLIST,
   type DevBootAgent,
+  type DevGuardrailConfig,
   type WireDevConsumersOpts,
 } from "../dev-consumer-boot";
 import type { Envelope } from "../../bus/myelin/envelope-validator";
@@ -170,6 +173,71 @@ describe("wireDevConsumers — §3.5b authority warning", () => {
       log: { info: (m) => logs.info.push(m), warn: (m) => logs.warn.push(m) },
     });
     expect(logs.warn).toHaveLength(0);
+  });
+});
+
+describe("buildDevSessionOpts — §3.5b guardrail parity", () => {
+  const agent: DevBootAgent = {
+    id: "forge",
+    displayName: "Forge",
+    runtime: { capabilities: ["dev.implement"] },
+  };
+
+  test("ALWAYS sets groveChannel — bash-guard Gate-1 engagement precondition", () => {
+    // Without a channel, cc-session never sets CORTEX_CHANNEL and the guard
+    // disengages (pass-through). The channel MUST be present on both the
+    // no-config and the with-config paths.
+    expect(buildDevSessionOpts(agent, undefined).groveChannel).toBe("forge");
+    expect(buildDevSessionOpts(agent, { allowedTools: ["Bash"] }).groveChannel).toBe("forge");
+  });
+
+  test("ALWAYS sets bashAllowlist — conservative default when config declares none", () => {
+    const opts = buildDevSessionOpts(agent, undefined);
+    expect(opts.bashAllowlist).toBe(DEFAULT_DEV_BASH_ALLOWLIST);
+    // Setting bashAllowlist is what keeps the session OUT of bash-guard's
+    // Gate-2 CLI-bypass (AGENT_ID && !CORTEX_BASH_GUARD). It must be present.
+    expect(opts.bashAllowlist).toBeDefined();
+    // And the guard is NOT disabled on the higher-authority push session.
+    expect((opts as { bashGuardDisabled?: boolean }).bashGuardDisabled).toBeUndefined();
+  });
+
+  test("config bashAllowlist wins over the default", () => {
+    const custom = { rules: [{ pattern: "^git push" }], repos: ["the-metafactory/cortex"] };
+    const opts = buildDevSessionOpts(agent, { bashAllowlist: custom });
+    expect(opts.bashAllowlist).toBe(custom);
+  });
+
+  test("threads allowedTools / disallowedTools / allowedDirs / timeout from config", () => {
+    const g: DevGuardrailConfig = {
+      allowedTools: ["Bash", "Read", "Edit", "Write"],
+      disallowedTools: ["WebFetch"],
+      allowedDirs: ["/repo", "/shared-cache"],
+      asyncTimeoutMs: 1_800_000,
+      additionalArgs: ["--verbose"],
+    };
+    const opts = buildDevSessionOpts(agent, g);
+    expect(opts.allowedTools).toEqual(["Bash", "Read", "Edit", "Write"]);
+    expect(opts.disallowedTools).toEqual(["WebFetch"]);
+    expect(opts.allowedDirs).toEqual(["/repo", "/shared-cache"]);
+    expect(opts.timeoutMs).toBe(1_800_000);
+    expect(opts.additionalArgs).toEqual(["--verbose"]);
+  });
+
+  test("absent allowedDirs is NOT set here (consumer defaults it to the worktree)", () => {
+    // The worktree path isn't known at boot, so an absent allowedDirs is left
+    // unset in the boot opts; DevConsumer fills it with the worktree per-task.
+    const opts = buildDevSessionOpts(agent, undefined);
+    expect(opts.allowedDirs).toBeUndefined();
+  });
+
+  test("wired consumers carry the guardrails end-to-end", () => {
+    const g: DevGuardrailConfig = { allowedTools: ["Bash"], asyncTimeoutMs: 1_000_000 };
+    const consumers = wireDevConsumers(baseOpts([agent], { guardrails: g }));
+    expect(consumers).toHaveLength(1);
+    // The consumer doesn't expose sessionOpts publicly; the contract is proven
+    // by buildDevSessionOpts above + the consumer's worktree-allowedDir test in
+    // dev-consumer.test.ts. Here we just confirm wiring doesn't throw.
+    expect(consumers[0]!.agent.id).toBe("forge");
   });
 });
 

--- a/src/runner/__tests__/dev-consumer-boot.test.ts
+++ b/src/runner/__tests__/dev-consumer-boot.test.ts
@@ -1,0 +1,183 @@
+/**
+ * F-2.1 (cortex#835) — dev-consumer boot-wiring tests.
+ *
+ * The DORMANCY PROOF at the wiring level: `wireDevConsumers` returns an empty
+ * array — touching NOTHING — when no agent declares `dev.implement`. Plus the
+ * §3.5b authority warning (loud when no scoped token) and the subject/durable
+ * naming.
+ *
+ * The full boot smoke (`startCortex` with no dev capability → no consumer) is
+ * proven by `src/__tests__/cortex.test.ts` running green unchanged.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  wireDevConsumers,
+  devSubjectPattern,
+  devDurableName,
+  type DevBootAgent,
+  type WireDevConsumersOpts,
+} from "../dev-consumer-boot";
+import type { Envelope } from "../../bus/myelin/envelope-validator";
+import type { EnvelopeHandler, MyelinRuntime } from "../../bus/myelin/runtime";
+import type { DispatchEventSource } from "../../bus/dispatch-events";
+import type {
+  DevWorkspace,
+  DevCommandRunner,
+  DevForge,
+} from "../dev-consumer";
+import { MemoryDevSessionStore } from "../dev-session-store";
+
+const SOURCE: DispatchEventSource = { principal: "andreas", agent: "cortex", instance: "local" };
+
+function fakeRuntime(): MyelinRuntime {
+  const handlers = new Set<EnvelopeHandler>();
+  return {
+    enabled: false,
+    onEnvelope(h) {
+      handlers.add(h);
+      return { unregister: () => handlers.delete(h) };
+    },
+    publish: async (_e: Envelope) => {},
+    stop: async () => {},
+  };
+}
+
+// Inert seams so the boot test never reaches real git/gh/CC even when a dev
+// agent IS declared.
+const NOOP_SEAMS: NonNullable<WireDevConsumersOpts["seamsOverride"]> = {
+  workspace: {
+    create: async () => ({ path: "/tmp/x" }),
+    remove: async () => {},
+  } satisfies DevWorkspace,
+  commandRunner: { run: async () => ({ ok: true }) } satisfies DevCommandRunner,
+  forge: {
+    openPr: async () => ({ repo: "o/r", number: 1, url: "u" }),
+  } satisfies DevForge,
+  sessionStore: new MemoryDevSessionStore(),
+};
+
+function baseOpts(
+  agents: DevBootAgent[],
+  overrides: Partial<WireDevConsumersOpts> = {},
+): WireDevConsumersOpts {
+  return {
+    agents,
+    runtime: fakeRuntime(),
+    source: SOURCE,
+    principalId: "andreas",
+    stack: "work",
+    seamsOverride: NOOP_SEAMS,
+    env: {},
+    log: { info: () => {}, warn: () => {} },
+    ...overrides,
+  };
+}
+
+describe("wireDevConsumers — dormancy", () => {
+  test("no dev-capable agent → EMPTY array, no warning, no seams touched", () => {
+    const logs = { info: [] as string[], warn: [] as string[] };
+    const consumers = wireDevConsumers({
+      agents: [
+        { id: "luna", runtime: { capabilities: ["chat"] } },
+        { id: "echo", runtime: { capabilities: ["code-review.typescript"] } },
+        { id: "headless" }, // no runtime block at all
+      ],
+      runtime: fakeRuntime(),
+      source: SOURCE,
+      principalId: "andreas",
+      stack: "work",
+      env: {},
+      log: { info: (m) => logs.info.push(m), warn: (m) => logs.warn.push(m) },
+    });
+    expect(consumers).toEqual([]);
+    // Silent — no token warning, because no dev agent means no forge identity.
+    expect(logs.warn).toHaveLength(0);
+    expect(logs.info).toHaveLength(0);
+  });
+
+  test("dev.implement-capable agent → one consumer", () => {
+    const consumers = wireDevConsumers(
+      baseOpts([{ id: "forge", displayName: "Forge", runtime: { capabilities: ["dev.implement"] } }]),
+    );
+    expect(consumers).toHaveLength(1);
+    expect(consumers[0]!.agent.id).toBe("forge");
+  });
+
+  test("bare `dev` capability also qualifies", () => {
+    const consumers = wireDevConsumers(
+      baseOpts([{ id: "forge", runtime: { capabilities: ["dev"] } }]),
+    );
+    expect(consumers).toHaveLength(1);
+  });
+
+  test("maxConcurrent carried onto the consumer agent", () => {
+    const consumers = wireDevConsumers(
+      baseOpts([
+        { id: "forge", runtime: { capabilities: ["dev.implement"], maxConcurrent: 3 } },
+      ]),
+    );
+    expect(consumers[0]!.agent.maxConcurrent).toBe(3);
+  });
+});
+
+describe("wireDevConsumers — §3.5b authority warning", () => {
+  test("no scoped token → LOUD warning citing the accepted-risk note", () => {
+    const logs = { info: [] as string[], warn: [] as string[] };
+    wireDevConsumers({
+      agents: [{ id: "forge", runtime: { capabilities: ["dev.implement"] } }],
+      runtime: fakeRuntime(),
+      source: SOURCE,
+      principalId: "andreas",
+      stack: "work",
+      seamsOverride: NOOP_SEAMS,
+      env: {}, // CORTEX_DEV_GH_TOKEN unset
+      log: { info: (m) => logs.info.push(m), warn: (m) => logs.warn.push(m) },
+    });
+    expect(logs.warn).toHaveLength(1);
+    expect(logs.warn[0]).toContain("AMBIENT");
+    expect(logs.warn[0]).toContain("§3.5b");
+    expect(logs.warn[0]).toContain("CORTEX_DEV_GH_TOKEN");
+  });
+
+  test("scoped token present → info line, no warning", () => {
+    const logs = { info: [] as string[], warn: [] as string[] };
+    wireDevConsumers({
+      agents: [{ id: "forge", runtime: { capabilities: ["dev.implement"] } }],
+      runtime: fakeRuntime(),
+      source: SOURCE,
+      principalId: "andreas",
+      stack: "work",
+      seamsOverride: NOOP_SEAMS,
+      env: { CORTEX_DEV_GH_TOKEN: "ghp_scoped_machine_user" },
+      log: { info: (m) => logs.info.push(m), warn: (m) => logs.warn.push(m) },
+    });
+    expect(logs.warn).toHaveLength(0);
+    expect(logs.info.some((m) => m.includes("scoped forge identity"))).toBe(true);
+  });
+
+  test("custom token env name honoured", () => {
+    const logs = { info: [] as string[], warn: [] as string[] };
+    wireDevConsumers({
+      agents: [{ id: "forge", runtime: { capabilities: ["dev.implement"] } }],
+      runtime: fakeRuntime(),
+      source: SOURCE,
+      principalId: "andreas",
+      stack: "work",
+      seamsOverride: NOOP_SEAMS,
+      devGhTokenEnv: "FORGE_PAT",
+      env: { FORGE_PAT: "x" },
+      log: { info: (m) => logs.info.push(m), warn: (m) => logs.warn.push(m) },
+    });
+    expect(logs.warn).toHaveLength(0);
+  });
+});
+
+describe("naming helpers", () => {
+  test("subject pattern + durable name", () => {
+    expect(devSubjectPattern("andreas", "work")).toBe(
+      "local.andreas.work.tasks.dev.implement",
+    );
+    expect(devDurableName("andreas", "forge")).toBe("cortex-dev-consumer-andreas-forge");
+  });
+});

--- a/src/runner/__tests__/dev-consumer.test.ts
+++ b/src/runner/__tests__/dev-consumer.test.ts
@@ -1,0 +1,614 @@
+/**
+ * F-2.1 (cortex#835) — tests for `runner/dev-consumer.ts`.
+ *
+ * Coverage axes (mirrors `bus/__tests__/review-consumer.test.ts`):
+ *
+ *   1. Happy path — valid request, capability match, CC succeeds, gates green,
+ *      PR opens → started + completed{pr} published, AckDecision is `ack`.
+ *   2. Non-dev subject/type → `cant_do` failed + term.
+ *   3. Bad payload → `cant_do` failed + term.
+ *   4. No capability match → `cant_do` failed + term.
+ *   5. Gates red → `cant_do` failed (detail names the gate) + term.
+ *   6. CC failure → `cant_do` failed + term.
+ *   7. CC abort (timeout) → `not_now` failed + nak.
+ *   8. Backpressure at maxConcurrent → `not_now` failed + nak(delay).
+ *   9. Forge openPr throws → `cant_do` failed + term.
+ *  10. Redelivery > 1 → ALSO emits `dispatch.task.aborted`.
+ *  11. correlation_id contract — request.id === started/completed/failed
+ *      correlation_id (the load-bearing reactor contract).
+ *  12. Warm sessions — two tasks on the same chain: the second RESUMES the
+ *      first's CC session (fake records `resumeSessionId`).
+ *  13. Worktree removed on every exit path (success + failure).
+ *  14. failedReasonToAckDecision mapping table.
+ *
+ * The DORMANT-boot proof (no capability declared → byte-identical boot) is in
+ * the cortex smoke test `src/__tests__/cortex.test.ts` and the boot-wiring
+ * test `src/__tests__/cortex.dev-consumer-boot.test.ts` (the §3 boot loop).
+ *
+ * No real NATS, no real CC, no real git/gh. All seams are fakes.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { Envelope } from "../../bus/myelin/envelope-validator";
+import type { EnvelopeHandler, MyelinRuntime } from "../../bus/myelin/runtime";
+import type { DispatchEventSource, DispatchTaskFailedReason } from "../../bus/dispatch-events";
+import type { AckDecision } from "../../bus/myelin/subscriber";
+import type { JsMsg } from "nats";
+import {
+  createDevImplementRequestEvent,
+  type DevImplementPayload,
+} from "../../bus/dev-events";
+import {
+  DevConsumer,
+  failedReasonToAckDecision,
+  type DevConsumerAgent,
+  type DevConsumerOpts,
+  type DevWorkspace,
+  type DevCommandRunner,
+  type DevCommandResult,
+  type DevForge,
+  type DevPrRef,
+} from "../dev-consumer";
+import { MemoryDevSessionStore, type DevSessionStore } from "../dev-session-store";
+import type { CCSessionFactory, CCSessionLike } from "../../substrates/claude-code/harness";
+import type { CCSessionOpts, CCSessionResult } from "../cc-session";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const SOURCE: DispatchEventSource = {
+  principal: "andreas",
+  agent: "cortex",
+  instance: "local",
+};
+
+const PAYLOAD: DevImplementPayload = {
+  repo: "the-metafactory/cortex",
+  branch: "feat/c-300-panel",
+  base: "main",
+  brief: "Implement the dashboard panel per design §4 — closes the issue.",
+  issue: 300,
+  gates: ["bunx tsc --noEmit", "bun test src/"],
+  feature: "C-300",
+  title: "feat: dashboard panel",
+};
+
+interface RecordingRuntime extends MyelinRuntime {
+  published: Envelope[];
+}
+
+function createRecordingRuntime(): RecordingRuntime {
+  const published: Envelope[] = [];
+  const onEnvelopeHandlers = new Set<EnvelopeHandler>();
+  return {
+    enabled: false,
+    published,
+    onEnvelope(handler) {
+      onEnvelopeHandlers.add(handler);
+      return { unregister: () => onEnvelopeHandlers.delete(handler) };
+    },
+    publish: async (envelope: Envelope) => {
+      published.push(envelope);
+    },
+    stop: async () => {},
+  };
+}
+
+function buildAgent(overrides: Partial<DevConsumerAgent> = {}): DevConsumerAgent {
+  return { id: "forge", capabilities: ["dev.implement"], ...overrides };
+}
+
+function makeRequest(
+  payload: DevImplementPayload = PAYLOAD,
+  correlationId?: string,
+): Envelope {
+  const env = createDevImplementRequestEvent({ source: SOURCE, payload });
+  if (correlationId !== undefined) {
+    (env as { correlation_id?: string }).correlation_id = correlationId;
+  }
+  return env;
+}
+
+// --- fake seams ------------------------------------------------------------
+
+interface FakeWorkspace extends DevWorkspace {
+  created: { repo: string; branch: string; base: string; chainId: string }[];
+  removed: { path: string }[];
+}
+function fakeWorkspace(opts: { path?: string; failCreate?: boolean } = {}): FakeWorkspace {
+  const created: FakeWorkspace["created"] = [];
+  const removed: FakeWorkspace["removed"] = [];
+  const path = opts.path ?? "/tmp/Cortex-c-300";
+  return {
+    created,
+    removed,
+    create: async (c) => {
+      created.push(c);
+      if (opts.failCreate) throw new Error("worktree add failed: branch exists");
+      return { path };
+    },
+    remove: async (r) => {
+      removed.push(r);
+    },
+  };
+}
+
+interface FakeRunner extends DevCommandRunner {
+  ran: { command: string; cwd: string }[];
+}
+function fakeRunner(
+  outcome: (command: string) => DevCommandResult | Promise<DevCommandResult> = () => ({
+    ok: true,
+  }),
+): FakeRunner {
+  const ran: FakeRunner["ran"] = [];
+  return {
+    ran,
+    run: async ({ command, cwd }) => {
+      ran.push({ command, cwd });
+      return outcome(command);
+    },
+  };
+}
+
+interface FakeForge extends DevForge {
+  calls: { repo: string; branch: string; cwd: string }[];
+}
+function fakeForge(opts: { fail?: boolean; pr?: DevPrRef } = {}): FakeForge {
+  const calls: FakeForge["calls"] = [];
+  const pr = opts.pr ?? {
+    repo: "the-metafactory/cortex",
+    number: 57,
+    url: "https://github.com/the-metafactory/cortex/pull/57",
+  };
+  return {
+    calls,
+    openPr: async ({ repo, branch, cwd }) => {
+      calls.push({ repo, branch, cwd });
+      if (opts.fail) throw new Error("gh pr create failed: auth");
+      return pr;
+    },
+  };
+}
+
+/** A CC session factory returning a fixed result; records the opts it saw. */
+function fakeCcFactory(
+  result: CCSessionResult,
+  seen?: { opts: CCSessionOpts[] },
+): CCSessionFactory {
+  return (opts: CCSessionOpts): CCSessionLike => {
+    seen?.opts.push(opts);
+    return {
+      start() {
+        return this;
+      },
+      wait: async () => result,
+    };
+  };
+}
+
+function okCcResult(sessionId = "sess-abc"): CCSessionResult {
+  return { success: true, response: "done", sessionId, exitCode: 0, durationMs: 1000 };
+}
+
+function makeJsMsg(redeliveryCount: number): JsMsg {
+  return {
+    info: { redeliveryCount },
+    redelivered: redeliveryCount > 1,
+  } as unknown as JsMsg;
+}
+
+function baseOpts(overrides: Partial<DevConsumerOpts> = {}): DevConsumerOpts {
+  return {
+    agent: buildAgent(),
+    source: SOURCE,
+    runtime: overrides.runtime ?? createRecordingRuntime(),
+    ccSessionFactory: overrides.ccSessionFactory ?? fakeCcFactory(okCcResult()),
+    promptBuilder: ({ payload }) => `Implement ${payload.branch}`,
+    workspace: overrides.workspace ?? fakeWorkspace(),
+    commandRunner: overrides.commandRunner ?? fakeRunner(),
+    forge: overrides.forge ?? fakeForge(),
+    sessionStore: overrides.sessionStore ?? new MemoryDevSessionStore(),
+    ...overrides,
+  };
+}
+
+const LOCAL_SUBJECT = "local.andreas.work.tasks.dev.implement";
+
+function reasonOf(env: Envelope): DispatchTaskFailedReason | undefined {
+  const p = env.payload as { reason?: DispatchTaskFailedReason };
+  return p.reason;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("DevConsumer.processEnvelope — F-2.1", () => {
+  test("1. happy path → started + completed{pr} + ack", async () => {
+    const runtime = createRecordingRuntime();
+    const workspace = fakeWorkspace();
+    const runner = fakeRunner();
+    const forge = fakeForge();
+    const request = makeRequest();
+
+    const consumer = new DevConsumer(
+      baseOpts({ runtime, workspace, commandRunner: runner, forge }),
+    );
+    const decision = await consumer.processEnvelope(request, LOCAL_SUBJECT, null);
+
+    expect(decision).toEqual({ kind: "ack" });
+
+    // started + completed, in order.
+    expect(runtime.published.map((e) => e.type)).toEqual([
+      "dispatch.task.started",
+      "dispatch.task.completed",
+    ]);
+
+    // Worktree created from origin base, then removed.
+    expect(workspace.created).toHaveLength(1);
+    expect(workspace.created[0]!.repo).toBe("the-metafactory/cortex");
+    expect(workspace.created[0]!.base).toBe("main");
+    expect(workspace.removed).toHaveLength(1);
+
+    // Both gates ran in declared order, in the worktree.
+    expect(runner.ran.map((r) => r.command)).toEqual(["bunx tsc --noEmit", "bun test src/"]);
+    expect(runner.ran.every((r) => r.cwd === "/tmp/Cortex-c-300")).toBe(true);
+
+    // Forge opened the PR in the worktree.
+    expect(forge.calls).toHaveLength(1);
+    expect(forge.calls[0]!.cwd).toBe("/tmp/Cortex-c-300");
+
+    // completed carries the PR ref.
+    const completed = runtime.published[1]!;
+    const chat = (completed.payload as { chat_response?: string }).chat_response;
+    expect(chat).toBeDefined();
+    expect(JSON.parse(chat!)).toEqual({
+      pr: {
+        repo: "the-metafactory/cortex",
+        number: 57,
+        url: "https://github.com/the-metafactory/cortex/pull/57",
+      },
+    });
+    expect((completed.payload as { result_summary?: string }).result_summary).toBe(
+      "opened the-metafactory/cortex#57",
+    );
+  });
+
+  test("2. non-dev subject/type → cant_do + term (no worktree)", async () => {
+    const runtime = createRecordingRuntime();
+    const workspace = fakeWorkspace();
+    // Forge a foreign-typed envelope.
+    const request = makeRequest();
+    (request as { type: string }).type = "tasks.code-review.typescript";
+
+    const consumer = new DevConsumer(baseOpts({ runtime, workspace }));
+    const decision = await consumer.processEnvelope(request, "local.x.y.tasks.code-review.typescript", null);
+
+    expect(decision.kind).toBe("term");
+    expect(workspace.created).toHaveLength(0);
+    const failed = runtime.published.find((e) => e.type === "dispatch.task.failed")!;
+    expect(reasonOf(failed)!.kind).toBe("cant_do");
+  });
+
+  test("3. bad payload → cant_do + term", async () => {
+    const runtime = createRecordingRuntime();
+    const request = makeRequest();
+    // Blank brief is invalid.
+    request.payload.brief = "   ";
+
+    const consumer = new DevConsumer(baseOpts({ runtime }));
+    const decision = await consumer.processEnvelope(request, LOCAL_SUBJECT, null);
+
+    expect(decision.kind).toBe("term");
+    const failed = runtime.published.find((e) => e.type === "dispatch.task.failed")!;
+    expect(reasonOf(failed)!.kind).toBe("cant_do");
+    expect((reasonOf(failed) as { detail: string }).detail).toContain("payload validation");
+  });
+
+  test("4. no capability match → cant_do + term", async () => {
+    const runtime = createRecordingRuntime();
+    const consumer = new DevConsumer(
+      baseOpts({ runtime, agent: buildAgent({ capabilities: ["code-review.typescript"] }) }),
+    );
+    const decision = await consumer.processEnvelope(makeRequest(), LOCAL_SUBJECT, null);
+
+    expect(decision.kind).toBe("term");
+    const failed = runtime.published.find((e) => e.type === "dispatch.task.failed")!;
+    expect((reasonOf(failed) as { detail: string }).detail).toContain("does not claim dev.implement");
+  });
+
+  test("bare `dev` capability claims dev.implement (family wildcard)", async () => {
+    const runtime = createRecordingRuntime();
+    const consumer = new DevConsumer(
+      baseOpts({ runtime, agent: buildAgent({ capabilities: ["dev"] }) }),
+    );
+    const decision = await consumer.processEnvelope(makeRequest(), LOCAL_SUBJECT, null);
+    expect(decision).toEqual({ kind: "ack" });
+  });
+
+  test("5. gates red → cant_do (names the gate) + term; PR never opens", async () => {
+    const runtime = createRecordingRuntime();
+    const forge = fakeForge();
+    const runner = fakeRunner((cmd) =>
+      cmd === "bun test src/" ? { ok: false, output: "2 tests failed" } : { ok: true },
+    );
+
+    const consumer = new DevConsumer(baseOpts({ runtime, commandRunner: runner, forge }));
+    const decision = await consumer.processEnvelope(makeRequest(), LOCAL_SUBJECT, null);
+
+    expect(decision.kind).toBe("term");
+    // tsc ran, test ran (and failed) — fail-fast stopped before opening the PR.
+    expect(runner.ran.map((r) => r.command)).toEqual(["bunx tsc --noEmit", "bun test src/"]);
+    expect(forge.calls).toHaveLength(0);
+    const failed = runtime.published.find((e) => e.type === "dispatch.task.failed")!;
+    const detail = (reasonOf(failed) as { detail: string }).detail;
+    expect(detail).toContain('gate "bun test src/" failed');
+    expect(detail).toContain("2 tests failed");
+  });
+
+  test("6. CC failure (non-zero exit) → cant_do + term", async () => {
+    const runtime = createRecordingRuntime();
+    const forge = fakeForge();
+    const cc = fakeCcFactory({
+      success: false,
+      response: "",
+      exitCode: 1,
+      durationMs: 100,
+    });
+
+    const consumer = new DevConsumer(baseOpts({ runtime, ccSessionFactory: cc, forge }));
+    const decision = await consumer.processEnvelope(makeRequest(), LOCAL_SUBJECT, null);
+
+    expect(decision.kind).toBe("term");
+    expect(forge.calls).toHaveLength(0);
+    const failed = runtime.published.find((e) => e.type === "dispatch.task.failed")!;
+    expect(reasonOf(failed)!.kind).toBe("cant_do");
+  });
+
+  test("7. CC abort (timeout) → not_now + nak", async () => {
+    const runtime = createRecordingRuntime();
+    const cc = fakeCcFactory({
+      success: false,
+      response: "",
+      exitCode: 1,
+      durationMs: 100,
+      aborted: true,
+      abortReason: "timeout",
+    });
+
+    const consumer = new DevConsumer(baseOpts({ runtime, ccSessionFactory: cc }));
+    const decision = await consumer.processEnvelope(makeRequest(), LOCAL_SUBJECT, null);
+
+    expect(decision.kind).toBe("nak");
+    const failed = runtime.published.find((e) => e.type === "dispatch.task.failed")!;
+    expect(reasonOf(failed)!.kind).toBe("not_now");
+  });
+
+  test("8. backpressure at maxConcurrent → not_now + nak(delay)", async () => {
+    const runtime = createRecordingRuntime();
+    // Block CC so the first task stays in-flight while we send a second.
+    let release!: () => void;
+    const gate = new Promise<void>((r) => (release = r));
+    const cc: CCSessionFactory = () => ({
+      start() {
+        return this;
+      },
+      wait: async () => {
+        await gate;
+        return okCcResult();
+      },
+    });
+
+    const consumer = new DevConsumer(
+      baseOpts({ runtime, ccSessionFactory: cc, agent: buildAgent({ maxConcurrent: 1 }) }),
+    );
+
+    const first = consumer.processEnvelope(makeRequest(), LOCAL_SUBJECT, null);
+    // Let the first task pass the concurrency gate and enter the pipeline.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const second = await consumer.processEnvelope(makeRequest(), LOCAL_SUBJECT, null);
+    expect(second.kind).toBe("nak");
+    expect((second as { delayMs?: number }).delayMs).toBe(5000);
+    const failed = runtime.published.find((e) => e.type === "dispatch.task.failed")!;
+    expect(reasonOf(failed)!.kind).toBe("not_now");
+
+    release();
+    expect((await first).kind).toBe("ack");
+  });
+
+  test("9. forge openPr throws → cant_do + term; worktree still removed", async () => {
+    const runtime = createRecordingRuntime();
+    const workspace = fakeWorkspace();
+    const forge = fakeForge({ fail: true });
+
+    const consumer = new DevConsumer(baseOpts({ runtime, workspace, forge }));
+    const decision = await consumer.processEnvelope(makeRequest(), LOCAL_SUBJECT, null);
+
+    expect(decision.kind).toBe("term");
+    expect(workspace.removed).toHaveLength(1); // cleanup ran on the failure path
+    const failed = runtime.published.find((e) => e.type === "dispatch.task.failed")!;
+    expect((reasonOf(failed) as { detail: string }).detail).toContain("forge openPr failed");
+  });
+
+  test("10. redelivery > 1 → also emits dispatch.task.aborted", async () => {
+    const runtime = createRecordingRuntime();
+    const consumer = new DevConsumer(baseOpts({ runtime }));
+    await consumer.processEnvelope(makeRequest(), LOCAL_SUBJECT, makeJsMsg(2));
+
+    const aborted = runtime.published.find((e) => e.type === "dispatch.task.aborted");
+    expect(aborted).toBeDefined();
+    expect((aborted!.payload as { reason?: string }).reason).toContain("redelivery");
+  });
+
+  test("11. correlation_id contract — request.id threads every lifecycle envelope", async () => {
+    const runtime = createRecordingRuntime();
+    const request = makeRequest();
+    const consumer = new DevConsumer(baseOpts({ runtime }));
+    await consumer.processEnvelope(request, LOCAL_SUBJECT, null);
+
+    for (const env of runtime.published) {
+      expect(env.correlation_id).toBe(request.id);
+    }
+  });
+
+  test("12. warm sessions — fix cycle on the same chain RESUMES the CC session", async () => {
+    const runtime = createRecordingRuntime();
+    const store: DevSessionStore = new MemoryDevSessionStore();
+    const seen = { opts: [] as CCSessionOpts[] };
+    const cc = fakeCcFactory(okCcResult("sess-warm-1"), seen);
+
+    const consumer = new DevConsumer(baseOpts({ runtime, ccSessionFactory: cc, sessionStore: store }));
+
+    // First task — chain root. Its correlation_id is the chain id.
+    const chainId = crypto.randomUUID();
+    const first = makeRequest(PAYLOAD, chainId);
+    await consumer.processEnvelope(first, LOCAL_SUBJECT, null);
+
+    // Cold first run — no resume id passed.
+    expect(seen.opts[0]!.resumeSessionId).toBeUndefined();
+    // The session id was persisted under the chain.
+    expect(await store.get(chainId)).toBe("sess-warm-1");
+
+    // Second task on the SAME chain (the fix cycle).
+    const second = makeRequest(PAYLOAD, chainId);
+    await consumer.processEnvelope(second, LOCAL_SUBJECT, null);
+
+    // Warm — the second CC session resumed the first's session id.
+    expect(seen.opts[1]!.resumeSessionId).toBe("sess-warm-1");
+  });
+
+  test("13. worktree removed on the success path", async () => {
+    const workspace = fakeWorkspace();
+    const consumer = new DevConsumer(baseOpts({ workspace }));
+    await consumer.processEnvelope(makeRequest(), LOCAL_SUBJECT, null);
+    expect(workspace.removed).toEqual([{ path: "/tmp/Cortex-c-300" }]);
+  });
+
+  test("worktree create failure → cant_do + term; no CC spawned", async () => {
+    const runtime = createRecordingRuntime();
+    const workspace = fakeWorkspace({ failCreate: true });
+    const seen = { opts: [] as CCSessionOpts[] };
+    const cc = fakeCcFactory(okCcResult(), seen);
+
+    const consumer = new DevConsumer(baseOpts({ runtime, workspace, ccSessionFactory: cc }));
+    const decision = await consumer.processEnvelope(makeRequest(), LOCAL_SUBJECT, null);
+
+    expect(decision.kind).toBe("term");
+    expect(seen.opts).toHaveLength(0); // CC never ran
+    const failed = runtime.published.find((e) => e.type === "dispatch.task.failed")!;
+    expect((reasonOf(failed) as { detail: string }).detail).toContain("worktree create failed");
+  });
+
+  test("no gates declared → opens PR without running any (gating deferred to review)", async () => {
+    const runner = fakeRunner();
+    const forge = fakeForge();
+    const noGates: DevImplementPayload = { ...PAYLOAD, gates: undefined };
+    delete (noGates as { gates?: unknown }).gates;
+
+    const consumer = new DevConsumer(baseOpts({ commandRunner: runner, forge }));
+    const decision = await consumer.processEnvelope(makeRequest(noGates), LOCAL_SUBJECT, null);
+
+    expect(decision).toEqual({ kind: "ack" });
+    expect(runner.ran).toHaveLength(0);
+    expect(forge.calls).toHaveLength(1);
+  });
+});
+
+describe("DevConsumer.stop — drain", () => {
+  test("idempotent; drains the in-flight pipeline before resolving", async () => {
+    const runtime = createRecordingRuntime();
+    let release!: () => void;
+    const gate = new Promise<void>((r) => (release = r));
+    const cc: CCSessionFactory = () => ({
+      start() {
+        return this;
+      },
+      wait: async () => {
+        await gate;
+        return okCcResult();
+      },
+    });
+
+    const consumer = new DevConsumer(baseOpts({ runtime, ccSessionFactory: cc }));
+    const inflight = consumer.processEnvelope(makeRequest(), LOCAL_SUBJECT, null);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    let drained = false;
+    const stopP = consumer.stop().then(() => (drained = true));
+    await Promise.resolve();
+    expect(drained).toBe(false); // still draining the in-flight task
+
+    release();
+    await inflight;
+    await stopP;
+    expect(drained).toBe(true);
+
+    // Idempotent — second stop resolves without error.
+    await consumer.stop();
+  });
+
+  test("after stop, a new task refuses with not_now + nak", async () => {
+    const runtime = createRecordingRuntime();
+    const consumer = new DevConsumer(baseOpts({ runtime }));
+    await consumer.stop();
+
+    const decision = await consumer.processEnvelope(makeRequest(), LOCAL_SUBJECT, null);
+    expect(decision.kind).toBe("nak");
+    const failed = runtime.published.find((e) => e.type === "dispatch.task.failed")!;
+    expect(reasonOf(failed)!.kind).toBe("not_now");
+  });
+});
+
+describe("DevConsumer.start — dormancy", () => {
+  test("runtime without subscribePull → DORMANT (subscribed:false), no throw", async () => {
+    const consumer = new DevConsumer(baseOpts());
+    const info = await consumer.start({
+      pattern: LOCAL_SUBJECT,
+      stream: "DEV_IMPLEMENT",
+      durable: "cortex-dev-consumer-andreas-forge",
+    });
+    expect(info).toEqual({ agentId: "forge", subscribed: false });
+  });
+
+  test("subscribePull returning null → DORMANT", async () => {
+    const runtime = createRecordingRuntime();
+    (runtime as { subscribePull?: unknown }).subscribePull = () => null;
+    const consumer = new DevConsumer(baseOpts({ runtime }));
+    const info = await consumer.start({
+      pattern: LOCAL_SUBJECT,
+      stream: "DEV_IMPLEMENT",
+      durable: "d",
+    });
+    expect(info.subscribed).toBe(false);
+  });
+});
+
+describe("failedReasonToAckDecision", () => {
+  test("maps each reason kind to the right ack control", () => {
+    expect(failedReasonToAckDecision(undefined)).toEqual({ kind: "ack" });
+    expect(failedReasonToAckDecision({ kind: "cant_do", detail: "x" })).toEqual({
+      kind: "term",
+      reason: "cant_do: x",
+    });
+    expect(failedReasonToAckDecision({ kind: "wont_do", detail: "y" })).toEqual({
+      kind: "term",
+      reason: "wont_do: y",
+    });
+    expect(
+      failedReasonToAckDecision({ kind: "not_now", detail: "busy", retry_after_ms: 250 }),
+    ).toEqual({ kind: "nak", delayMs: 250 });
+    expect(failedReasonToAckDecision({ kind: "policy_denied", deny: { role: "x" } })).toEqual({
+      kind: "term",
+      reason: "policy_denied: role",
+    });
+    expect(failedReasonToAckDecision({ kind: "compliance_block", detail: "z" })).toEqual({
+      kind: "term",
+      reason: "v1 does not handle compliance_block",
+    });
+  });
+});

--- a/src/runner/__tests__/dev-consumer.test.ts
+++ b/src/runner/__tests__/dev-consumer.test.ts
@@ -516,6 +516,52 @@ describe("DevConsumer.processEnvelope — F-2.1", () => {
     expect(runner.ran).toHaveLength(0);
     expect(forge.calls).toHaveLength(1);
   });
+
+  test("§3.5b guardrails — CC session is scoped to the worktree when boot supplies no allowedDirs", async () => {
+    const seen = { opts: [] as CCSessionOpts[] };
+    const cc = fakeCcFactory(okCcResult(), seen);
+    // No sessionOpts.allowedDirs → the consumer must default to the worktree.
+    const consumer = new DevConsumer(baseOpts({ ccSessionFactory: cc }));
+    await consumer.processEnvelope(makeRequest(), LOCAL_SUBJECT, null);
+
+    expect(seen.opts).toHaveLength(1);
+    // cwd IS the worktree; allowedDirs is scoped to ONLY the worktree (the one
+    // dir this higher-authority push session legitimately writes to) — never
+    // unrestricted.
+    expect(seen.opts[0]!.cwd).toBe("/tmp/Cortex-c-300");
+    expect(seen.opts[0]!.allowedDirs).toEqual(["/tmp/Cortex-c-300"]);
+    expect(seen.opts[0]!.bashGuardDisabled).toBeUndefined();
+  });
+
+  test("§3.5b guardrails — boot-supplied allowedDirs + channel + bashAllowlist flow into the CC session", async () => {
+    const seen = { opts: [] as CCSessionOpts[] };
+    const cc = fakeCcFactory(okCcResult(), seen);
+    const bashAllowlist = { rules: [{ pattern: "^git" }], repos: [] };
+    const consumer = new DevConsumer(
+      baseOpts({
+        ccSessionFactory: cc,
+        sessionOpts: {
+          agentId: "forge",
+          // The bash-guard Gate-1 engagement precondition.
+          groveChannel: "forge",
+          bashAllowlist,
+          allowedTools: ["Bash", "Read"],
+          allowedDirs: ["/repo"],
+        },
+      }),
+    );
+    await consumer.processEnvelope(makeRequest(), LOCAL_SUBJECT, null);
+
+    const o = seen.opts[0]!;
+    // Channel present → bash-guard engages (not pass-through).
+    expect(o.groveChannel).toBe("forge");
+    // bashAllowlist present → guard has rules AND the session avoids the
+    // CLI-bypass (CORTEX_BASH_GUARD set).
+    expect(o.bashAllowlist).toEqual(bashAllowlist);
+    expect(o.allowedTools).toEqual(["Bash", "Read"]);
+    // Boot-supplied allowedDirs wins over the worktree default.
+    expect(o.allowedDirs).toEqual(["/repo"]);
+  });
 });
 
 describe("DevConsumer.stop — drain", () => {

--- a/src/runner/__tests__/dev-session-store.test.ts
+++ b/src/runner/__tests__/dev-session-store.test.ts
@@ -1,0 +1,84 @@
+/**
+ * F-2.1 (cortex#835) — tests for the warm-session store (§3.6b).
+ *
+ * Covers the in-memory fake (used by the consumer tests) and the
+ * file-backed durable store (the production durability clause: "a restarted
+ * agent resumes rather than restarts").
+ */
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import {
+  MemoryDevSessionStore,
+  FileDevSessionStore,
+} from "../dev-session-store";
+
+const dirs: string[] = [];
+function tmpDir(): string {
+  const d = mkdtempSync(join(tmpdir(), "dev-session-store-"));
+  dirs.push(d);
+  return d;
+}
+afterEach(() => {
+  for (const d of dirs.splice(0)) rmSync(d, { recursive: true, force: true });
+});
+
+describe("MemoryDevSessionStore", () => {
+  test("get/set/delete", async () => {
+    const s = new MemoryDevSessionStore();
+    expect(await s.get("c1")).toBeUndefined();
+    await s.set("c1", "sess-1");
+    expect(await s.get("c1")).toBe("sess-1");
+    await s.set("c1", "sess-2"); // overwrite — last write wins
+    expect(await s.get("c1")).toBe("sess-2");
+    await s.delete("c1");
+    expect(await s.get("c1")).toBeUndefined();
+  });
+});
+
+describe("FileDevSessionStore", () => {
+  test("persists across instances (the restart-resume clause)", async () => {
+    const path = join(tmpDir(), "warm.json");
+    const a = new FileDevSessionStore(path);
+    await a.set("chain-x", "sess-warm");
+
+    // A fresh instance (simulating a daemon restart) reads the same map.
+    const b = new FileDevSessionStore(path);
+    expect(await b.get("chain-x")).toBe("sess-warm");
+  });
+
+  test("delete persists", async () => {
+    const path = join(tmpDir(), "warm.json");
+    const a = new FileDevSessionStore(path);
+    await a.set("chain-x", "sess-warm");
+    await a.delete("chain-x");
+
+    const b = new FileDevSessionStore(path);
+    expect(await b.get("chain-x")).toBeUndefined();
+  });
+
+  test("missing file → empty map (cold first boot)", async () => {
+    const path = join(tmpDir(), "does-not-exist.json");
+    const s = new FileDevSessionStore(path);
+    expect(await s.get("anything")).toBeUndefined();
+  });
+
+  test("corrupt file → empty map, no throw (degrade to cold-start)", async () => {
+    const path = join(tmpDir(), "corrupt.json");
+    writeFileSync(path, "{ not json", "utf8");
+    const s = new FileDevSessionStore(path);
+    expect(await s.get("anything")).toBeUndefined();
+    // Still writable after a corrupt read.
+    await s.set("c", "sess");
+    expect(await s.get("c")).toBe("sess");
+  });
+
+  test("non-object JSON → empty map", async () => {
+    const path = join(tmpDir(), "array.json");
+    writeFileSync(path, "[1,2,3]", "utf8");
+    const s = new FileDevSessionStore(path);
+    expect(await s.get("anything")).toBeUndefined();
+  });
+});

--- a/src/runner/dev-consumer-boot.ts
+++ b/src/runner/dev-consumer-boot.ts
@@ -23,6 +23,19 @@
  * is the residual risk F-5b's sandboxing retires. The warning is the honest
  * F-2 caveat made visible at boot, not buried.
  *
+ * **Session guardrails — REVIEW PARITY (§3.5b "guardrails from the agent
+ * manifest").** The dev CC session is the HIGHER-authority path (it writes
+ * code + pushes), so it MUST be at least as guarded as the review session.
+ * `buildDevSessionOpts` threads the same `config.claude` guardrails the review
+ * path uses (`bashAllowlist` + `allowedTools` + `allowedDirs` + async timeout),
+ * and — critically — sets `groveChannel`, the env var (`CORTEX_CHANNEL`) that
+ * is `bash-guard.hook.ts`'s Gate-1 ENGAGEMENT precondition. Without a channel
+ * the guard `pass()`-es through on every Bash command; the original wiring
+ * omitted it, so the guard disengaged on the push path (the review BLOCKER this
+ * fixes). When the agent declares no allowlist, a conservative repo-shaped
+ * default ({@link DEFAULT_DEV_BASH_ALLOWLIST}) applies — the session is STILL
+ * guarded, never unrestricted.
+ *
  * **Stream provisioning — FLAGGED for the PR body.** The review path
  * provisions a `CODE_REVIEW` JetStream stream + per-agent durable up-front
  * (`bus/jetstream/provision.ts`). The dev path needs the equivalent for
@@ -72,6 +85,33 @@ export interface DevBootAgent {
   };
 }
 
+/**
+ * §3.5b guardrail source — the narrow projection of `AgentConfig.claude` the
+ * dev session needs to reach review-path PARITY. Kept structural (not the full
+ * Zod config) so `cortex.ts` passes `config.claude` directly and the boot test
+ * builds a fixture cheaply. Every field optional: an absent block means "apply
+ * the conservative defaults" (worktree-only `allowedDirs`, a repo-conventional
+ * bash allowlist) so the higher-authority push session is NEVER less-guarded
+ * than the review session.
+ */
+export interface DevGuardrailConfig {
+  /** Bash command allowlist (`bash-guard.hook.ts` shape). */
+  bashAllowlist?: {
+    rules: { pattern: string; repos?: string[] }[];
+    repos: string[];
+  };
+  /** Tools the session may use (e.g. Bash/Read/Edit/Write/gh). */
+  allowedTools?: string[];
+  /** Tools to deny (applied on top of `allowedTools`). */
+  disallowedTools?: string[];
+  /** Read+write dirs. Empty/absent → the consumer defaults to the worktree. */
+  allowedDirs?: string[];
+  /** Async-task timeout (dev work is long-running). */
+  asyncTimeoutMs?: number;
+  /** Extra args threaded to `claude`. */
+  additionalArgs?: string[];
+}
+
 /** Inputs `cortex.ts` threads into the boot wiring. */
 export interface WireDevConsumersOpts {
   agents: readonly DevBootAgent[];
@@ -81,6 +121,11 @@ export interface WireDevConsumersOpts {
   principalId: string;
   /** `{stack}` subject segment — for the subscribe pattern. */
   stack: string;
+  /**
+   * §3.5b guardrail config (review parity). `cortex.ts` passes `config.claude`;
+   * the boot test passes a fixture. Omitted → conservative defaults only.
+   */
+  guardrails?: DevGuardrailConfig;
   /** Repo-root worktrees are cut from; defaults to `process.cwd()`. */
   repoRoot?: string;
   /**
@@ -175,11 +220,7 @@ export function wireDevConsumers(opts: WireDevConsumersOpts): DevConsumer[] {
         maxConcurrent: agent.runtime.maxConcurrent,
       }),
     };
-    const sessionOpts: Partial<Omit<CCSessionOpts, "prompt" | "cwd" | "resumeSessionId">> =
-      {
-        agentId: agent.id,
-        ...(agent.displayName !== undefined && { agentName: agent.displayName }),
-      };
+    const sessionOpts = buildDevSessionOpts(agent, opts.guardrails);
     consumers.push(
       new DevConsumer({
         agent: consumerAgent,
@@ -201,6 +242,85 @@ export function wireDevConsumers(opts: WireDevConsumersOpts): DevConsumer[] {
     );
   }
   return consumers;
+}
+
+/**
+ * The conservative repo-shaped bash allowlist applied when the agent's config
+ * declares none. Mirrors the shape `bash-guard.hook.ts` enforces: read-only +
+ * dev-loop commands (git, gh, bun, tsc/eslint/test gates) are matched; anything
+ * else is denied. NOT permissive — a dev session with no declared allowlist is
+ * STILL guarded (the security-first default), it just gets a sensible baseline
+ * instead of an empty one (which would deny everything and stall the session).
+ *
+ * `repos: []` means the gh-repo restriction is "any repo the push target names"
+ * — the dev agent legitimately pushes to whatever repo the task addressed; the
+ * forge identity (scoped token, §3.5b) is the authority bound, not this list.
+ */
+export const DEFAULT_DEV_BASH_ALLOWLIST: {
+  rules: { pattern: string; repos?: string[] }[];
+  repos: string[];
+} = {
+  rules: [
+    { pattern: "^git( |$)" },
+    { pattern: "^gh( |$)" },
+    { pattern: "^bun( |x)?( |$)" },
+    { pattern: "^(npx |)tsc( |$)" },
+    { pattern: "^(npx |bunx |)eslint( |$)" },
+    { pattern: "^(ls|cat|head|tail|rg|grep|find|pwd|echo|test|true|mkdir|cd)( |$)" },
+  ],
+  repos: [],
+};
+
+/**
+ * Build the dev CC session opts at REVIEW PARITY (§3.5b — guardrails from the
+ * agent manifest). Exported so `__tests__/dev-consumer-boot.test.ts` can assert
+ * the guardrails are wired without standing up `startCortex`.
+ *
+ * **The load-bearing field is `groveChannel`.** `cc-session.ts` maps it to the
+ * `CORTEX_CHANNEL` env var, which is `bash-guard.hook.ts`'s Gate-1 ENGAGEMENT
+ * precondition: without it the guard `pass()`-es through on every Bash command
+ * (the disengagement the review found). We set it to the agent id so the guard
+ * actually runs on this higher-authority push session.
+ *
+ * **`bashAllowlist` is always set** — to the config value when present, else
+ * {@link DEFAULT_DEV_BASH_ALLOWLIST}. This is double-duty: it gives the guard
+ * its rules AND it sets `CORTEX_BASH_GUARD`, which keeps the session OUT of
+ * bash-guard Gate-2's CLI-bypass (`AGENT_ID && !CORTEX_BASH_GUARD` → pass).
+ * We MUST NOT set `bashGuardDisabled`.
+ *
+ * `allowedDirs` is left to the config (when declared); when absent the CONSUMER
+ * defaults it to the per-task worktree (the worktree path isn't known at boot).
+ */
+export function buildDevSessionOpts(
+  agent: DevBootAgent,
+  guardrails: DevGuardrailConfig | undefined,
+): Partial<Omit<CCSessionOpts, "prompt" | "cwd" | "resumeSessionId">> {
+  const g = guardrails ?? {};
+  const opts: Partial<Omit<CCSessionOpts, "prompt" | "cwd" | "resumeSessionId">> = {
+    agentId: agent.id,
+    // bash-guard Gate-1 engagement precondition — without a channel the guard
+    // disengages. The agent id is a stable, non-PII channel label for the
+    // headless dev session (it has no Discord/Mattermost surface).
+    groveChannel: agent.id,
+    // Always guarded: config allowlist or the conservative repo-shaped default.
+    // Setting this ALSO keeps the session out of the Gate-2 CLI-bypass.
+    bashAllowlist: g.bashAllowlist ?? DEFAULT_DEV_BASH_ALLOWLIST,
+    ...(agent.displayName !== undefined && { agentName: agent.displayName }),
+    ...(g.allowedTools !== undefined && g.allowedTools.length > 0 && {
+      allowedTools: g.allowedTools,
+    }),
+    ...(g.disallowedTools !== undefined && g.disallowedTools.length > 0 && {
+      disallowedTools: g.disallowedTools,
+    }),
+    ...(g.allowedDirs !== undefined && g.allowedDirs.length > 0 && {
+      allowedDirs: g.allowedDirs,
+    }),
+    ...(g.asyncTimeoutMs !== undefined && { timeoutMs: g.asyncTimeoutMs }),
+    ...(g.additionalArgs !== undefined && g.additionalArgs.length > 0 && {
+      additionalArgs: g.additionalArgs,
+    }),
+  };
+  return opts;
 }
 
 /** Subscribe pattern for a dev consumer: `local.{principal}.{stack}.tasks.dev.implement`. */

--- a/src/runner/dev-consumer-boot.ts
+++ b/src/runner/dev-consumer-boot.ts
@@ -1,0 +1,375 @@
+/**
+ * F-2.1 (cortex#835) — boot wiring for the `dev.implement` capability
+ * consumer + the production shell-backed seams.
+ *
+ * **THE DORMANCY CONTRACT (the hard safety guarantee).** `wireDevConsumers`
+ * returns an EMPTY array when no agent declares a `dev.implement*` capability
+ * in `runtime.capabilities[]` — and does so WITHOUT touching the filesystem,
+ * spawning anything, or reading any token. Every live stack today declares
+ * none, so this entire module is inert on boot for them: byte-identical
+ * behaviour to before F-2. Only a stack that explicitly opts an agent into
+ * `dev.implement` brings any of this code to life.
+ *
+ * Extracted from `cortex.ts` (mirroring how complex boot blocks are factored)
+ * so the dormancy decision + the seam construction are unit-testable in
+ * isolation — see `__tests__/dev-consumer-boot.test.ts`.
+ *
+ * **Authority model (§3.5b).** The forge seam pushes branches + opens PRs
+ * with a SCOPED forge identity, never the principal's ambient PAT. The token
+ * is read from the env var named by `dev_gh_token_env` (default
+ * `CORTEX_DEV_GH_TOKEN`). When that env var is UNSET the consumer falls back
+ * to ambient `gh` auth — and emits a LOUD boot warning citing the design's
+ * accepted-risk note, because ambient authority on the principal's own machine
+ * is the residual risk F-5b's sandboxing retires. The warning is the honest
+ * F-2 caveat made visible at boot, not buried.
+ *
+ * **Stream provisioning — FLAGGED for the PR body.** The review path
+ * provisions a `CODE_REVIEW` JetStream stream + per-agent durable up-front
+ * (`bus/jetstream/provision.ts`). The dev path needs the equivalent for
+ * `tasks.dev.implement`. This module wires the consumer's `subscribePull`
+ * binding (dormant-safe: null runtime → DORMANT, no bind), but does NOT
+ * provision a `DEV_IMPLEMENT` stream — that is deliberately deferred to a
+ * sibling slice so this PR stays "one mergeable, dormant-by-default
+ * consumer." A dev-capable agent on a live bus therefore needs the stream
+ * provisioned alongside (the FLAG). Because no agent declares the capability
+ * yet, nothing binds yet, so the deferral changes no live behaviour.
+ */
+
+import { spawn } from "child_process";
+import type { MyelinRuntime } from "../bus/myelin/runtime";
+import type { DispatchEventSource } from "../bus/dispatch-events";
+import type { CCSessionOpts } from "./cc-session";
+import { CCSession } from "./cc-session";
+import {
+  DevConsumer,
+  type DevConsumerAgent,
+  type DevWorkspace,
+  type DevCommandRunner,
+  type DevCommandResult,
+  type DevForge,
+  type DevPrRef,
+} from "./dev-consumer";
+import { FileDevSessionStore, type DevSessionStore } from "./dev-session-store";
+
+export { DevConsumer } from "./dev-consumer";
+
+// ---------------------------------------------------------------------------
+// The narrow agent shape the boot wiring consumes
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal projection of a cortex.yaml `Agent` the boot wiring needs — kept
+ * structural (not the full Zod `Agent`) so the boot test builds fixtures
+ * cheaply, and so `cortex.ts` can pass `mergedAgents` (which satisfies this
+ * shape) without a cast.
+ */
+export interface DevBootAgent {
+  id: string;
+  displayName?: string;
+  runtime?: {
+    capabilities?: readonly string[];
+    maxConcurrent?: number;
+  };
+}
+
+/** Inputs `cortex.ts` threads into the boot wiring. */
+export interface WireDevConsumersOpts {
+  agents: readonly DevBootAgent[];
+  runtime: MyelinRuntime;
+  source: DispatchEventSource;
+  /** `{principal}` subject segment — for the durable name. */
+  principalId: string;
+  /** `{stack}` subject segment — for the subscribe pattern. */
+  stack: string;
+  /** Repo-root worktrees are cut from; defaults to `process.cwd()`. */
+  repoRoot?: string;
+  /**
+   * Warm-session store path. Defaults to
+   * `~/.config/cortex/dev-warm-sessions.json`. The file-backed store is the
+   * §3.6b durability bridge until F-3's agent-state store lands.
+   */
+  sessionStorePath?: string;
+  /** Env var name carrying the scoped forge token. Default `CORTEX_DEV_GH_TOKEN`. */
+  devGhTokenEnv?: string;
+  /** Test seam — env lookup. Defaults to `process.env`. */
+  env?: Record<string, string | undefined>;
+  /**
+   * Test seam — fully override the seams so the boot test asserts wiring +
+   * dormancy WITHOUT real git/gh/CC. Production omits this; the shell-backed
+   * seams below are used.
+   */
+  seamsOverride?: {
+    workspace: DevWorkspace;
+    commandRunner: DevCommandRunner;
+    forge: DevForge;
+    sessionStore: DevSessionStore;
+  };
+  /** Optional logger. Defaults to `console`. */
+  log?: { info: (m: string) => void; warn: (m: string) => void };
+}
+
+const DEFAULT_TOKEN_ENV = "CORTEX_DEV_GH_TOKEN";
+
+/** True when the agent claims `dev.implement` (exact) or the bare `dev` family. */
+function claimsDevImplement(agent: DevBootAgent): boolean {
+  const caps = agent.runtime?.capabilities ?? [];
+  return caps.includes("dev.implement") || caps.includes("dev");
+}
+
+/**
+ * Build (but do NOT start) the dev consumers for every dev-implement-capable
+ * agent. Returns an EMPTY array — touching nothing — when none qualify (the
+ * dormancy contract). The caller (`cortex.ts`) then `start()`s each and lands
+ * them in the shutdown-drain list.
+ */
+export function wireDevConsumers(opts: WireDevConsumersOpts): DevConsumer[] {
+  const log = opts.log ?? console;
+  const capable = opts.agents.filter(claimsDevImplement);
+  if (capable.length === 0) {
+    // DORMANCY: no dev-capable agent → no seams, no token read, no FS, no
+    // consumers. Byte-identical boot. Silent — there is nothing to warn about
+    // (a stack with no dev agent is the normal, expected shape today).
+    return [];
+  }
+
+  const env = opts.env ?? process.env;
+  const tokenEnv = opts.devGhTokenEnv ?? DEFAULT_TOKEN_ENV;
+  const scopedToken = env[tokenEnv];
+
+  // §3.5b authority — loud boot warning when the dev agent will push with
+  // AMBIENT authority instead of a scoped forge identity. This is the honest
+  // F-2 caveat surfaced, not hidden.
+  if (scopedToken === undefined || scopedToken.length === 0) {
+    log.warn(
+      `cortex: dev.implement consumer wired WITHOUT a scoped forge token ` +
+        `(${tokenEnv} unset) — it will push branches + open PRs using AMBIENT gh ` +
+        `authority. Per docs/design-agentic-dev-pipeline.md §3.5b this residual ` +
+        `risk is accepted for v1 on the principal's OWN stacks (identical to the ` +
+        `in-session posture) and is what F-5b sandboxing retires. Set ${tokenEnv} ` +
+        `to a repo-scoped machine-user token to bound it.`,
+    );
+  } else {
+    log.info(
+      `cortex: dev.implement consumer using scoped forge identity from ${tokenEnv} (§3.5b)`,
+    );
+  }
+
+  const repoRoot = opts.repoRoot ?? process.cwd();
+  const seams =
+    opts.seamsOverride ??
+    buildShellSeams({
+      repoRoot,
+      sessionStorePath:
+        opts.sessionStorePath ??
+        `${env.HOME ?? "."}/.config/cortex/dev-warm-sessions.json`,
+      scopedToken,
+      env,
+    });
+
+  const consumers: DevConsumer[] = [];
+  for (const agent of capable) {
+    const consumerAgent: DevConsumerAgent = {
+      id: agent.id,
+      capabilities: agent.runtime?.capabilities ?? [],
+      ...(agent.runtime?.maxConcurrent !== undefined && {
+        maxConcurrent: agent.runtime.maxConcurrent,
+      }),
+    };
+    const sessionOpts: Partial<Omit<CCSessionOpts, "prompt" | "cwd" | "resumeSessionId">> =
+      {
+        agentId: agent.id,
+        ...(agent.displayName !== undefined && { agentName: agent.displayName }),
+      };
+    consumers.push(
+      new DevConsumer({
+        agent: consumerAgent,
+        source: opts.source,
+        runtime: opts.runtime,
+        // Real CC session — spawns `claude` in the worktree. Only reached when
+        // a `dev.implement` task actually arrives for this agent.
+        ccSessionFactory: (o) => new CCSession(o),
+        promptBuilder: ({ payload }) =>
+          // Dispatch INTENT, not method (DD-P3): hand the brief; the agent's
+          // persona owns HOW. The brief already carries the issue/design refs.
+          payload.brief,
+        workspace: seams.workspace,
+        commandRunner: seams.commandRunner,
+        forge: seams.forge,
+        sessionStore: seams.sessionStore,
+        sessionOpts,
+      }),
+    );
+  }
+  return consumers;
+}
+
+/** Subscribe pattern for a dev consumer: `local.{principal}.{stack}.tasks.dev.implement`. */
+export function devSubjectPattern(principalId: string, stack: string): string {
+  return `local.${principalId}.${stack}.tasks.dev.implement`;
+}
+
+/** Durable name for a dev consumer: `cortex-dev-consumer-{principal}-{agent}`. */
+export function devDurableName(principalId: string, agentId: string): string {
+  return `cortex-dev-consumer-${principalId}-${agentId}`;
+}
+
+// ---------------------------------------------------------------------------
+// Shell-backed production seams
+// ---------------------------------------------------------------------------
+
+interface ShellSeamsOpts {
+  repoRoot: string;
+  sessionStorePath: string;
+  scopedToken: string | undefined;
+  env: Record<string, string | undefined>;
+}
+
+interface BuiltSeams {
+  workspace: DevWorkspace;
+  commandRunner: DevCommandRunner;
+  forge: DevForge;
+  sessionStore: DevSessionStore;
+}
+
+/**
+ * Construct the production seams that drive real `git worktree`, gate
+ * commands, and `gh pr create`. Constructed ONLY when a dev-capable agent
+ * exists (the dormancy contract) — `buildShellSeams` itself does no I/O; the
+ * I/O happens inside the seam methods when a task arrives.
+ */
+function buildShellSeams(opts: ShellSeamsOpts): BuiltSeams {
+  const slugify = (branch: string): string =>
+    branch.replace(/[^A-Za-z0-9]+/g, "-").replace(/^-+|-+$/g, "") || "dev";
+
+  const workspace: DevWorkspace = {
+    create: async ({ branch, base, chainId }) => {
+      // Worktree-discipline SOP: `../Cortex-{slug}` cut from origin/{base}.
+      const slug = `${slugify(branch)}-${chainId.slice(0, 8)}`;
+      const path = `${opts.repoRoot}/../Cortex-${slug}`;
+      await run(
+        "git",
+        ["worktree", "add", path, "-b", branch, `origin/${base}`],
+        { cwd: opts.repoRoot, env: opts.env },
+      );
+      return { path };
+    },
+    remove: async ({ path }) => {
+      await run("git", ["worktree", "remove", "--force", path], {
+        cwd: opts.repoRoot,
+        env: opts.env,
+      });
+    },
+  };
+
+  const commandRunner: DevCommandRunner = {
+    run: async ({ command, cwd }): Promise<DevCommandResult> => {
+      // Gate commands are full shell strings (e.g. `bunx tsc --noEmit`);
+      // run via the shell so pipes/globs in a gate string work.
+      const res = await run("bash", ["-lc", command], {
+        cwd,
+        env: opts.env,
+        allowFailure: true,
+      });
+      return res.code === 0
+        ? { ok: true }
+        : { ok: false, output: `${res.stdout}\n${res.stderr}`.trim() };
+    },
+  };
+
+  const forge: DevForge = {
+    openPr: async ({ branch, base, cwd, title, issue, brief }): Promise<DevPrRef> => {
+      // §3.5b — push + PR with the SCOPED token when provided (injected into
+      // the child env as GH_TOKEN), never the principal's ambient PAT unless
+      // the scoped token is absent (the warned ambient-fallback path).
+      const childEnv: Record<string, string | undefined> = { ...opts.env };
+      if (opts.scopedToken !== undefined && opts.scopedToken.length > 0) {
+        childEnv.GH_TOKEN = opts.scopedToken;
+      }
+      await run("git", ["push", "-u", "origin", branch], { cwd, env: childEnv });
+      const body = issue !== undefined ? `${brief}\n\nCloses #${issue}` : brief;
+      const args = [
+        "pr",
+        "create",
+        "--base",
+        base,
+        "--head",
+        branch,
+        "--title",
+        title ?? branch,
+        "--body",
+        body,
+      ];
+      const res = await run("gh", args, { cwd, env: childEnv });
+      const url = res.stdout.trim().split("\n").pop() ?? "";
+      const number = parsePrNumber(url);
+      // `gh repo view` is avoided; derive `owner/name` from the PR URL.
+      const repo = parseRepoFromUrl(url) ?? "";
+      return { repo, number, url };
+    },
+  };
+
+  const sessionStore = new FileDevSessionStore(opts.sessionStorePath);
+  return { workspace, commandRunner, forge, sessionStore };
+}
+
+interface RunResult {
+  code: number;
+  stdout: string;
+  stderr: string;
+}
+
+/**
+ * Spawn a child process, capturing stdout/stderr. Rejects on a non-zero exit
+ * UNLESS `allowFailure` (gate commands resolve with the code instead). Uses
+ * `child_process.spawn` (not `Bun.spawn`) so the seam stays portable and the
+ * boot test never needs Bun-specific stubbing — though the seam is only ever
+ * reached when a dev task actually arrives.
+ */
+function run(
+  cmd: string,
+  args: string[],
+  opts: {
+    cwd: string;
+    env: Record<string, string | undefined>;
+    allowFailure?: boolean;
+  },
+): Promise<RunResult> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(cmd, args, { cwd: opts.cwd, env: opts.env });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (d) => {
+      stdout += String(d);
+    });
+    child.stderr.on("data", (d) => {
+      stderr += String(d);
+    });
+    child.on("error", (err) => {
+      reject(err);
+    });
+    child.on("close", (code) => {
+      const result: RunResult = { code: code ?? 1, stdout, stderr };
+      if (result.code !== 0 && !opts.allowFailure) {
+        reject(
+          new Error(
+            `${cmd} ${args.join(" ")} exited ${result.code}: ${stderr.trim() || stdout.trim()}`,
+          ),
+        );
+        return;
+      }
+      resolve(result);
+    });
+  });
+}
+
+/** Parse the PR number from a `gh pr create` URL (`.../pull/57`). */
+function parsePrNumber(url: string): number {
+  const m = /\/pull\/(\d+)\/?$/.exec(url.trim());
+  return m ? Number(m[1]) : 0;
+}
+
+/** Derive `owner/name` from a GitHub PR URL. */
+function parseRepoFromUrl(url: string): string | null {
+  const m = /github\.com\/([^/]+)\/([^/]+)\/pull\/\d+/.exec(url.trim());
+  return m ? `${m[1]}/${m[2]}` : null;
+}

--- a/src/runner/dev-consumer.ts
+++ b/src/runner/dev-consumer.ts
@@ -412,6 +412,17 @@ export class DevConsumer {
     }
 
     // 4. Concurrency gate — at the cap → nak `not_now`.
+    //
+    // TOCTOU parity note (review-consumer posture): the size-check and the
+    // later `inFlight.add` are not atomic, so two near-simultaneous
+    // deliveries could both observe `size < cap` and over-admit by one. This
+    // is the SAME window `ReviewConsumer`'s maxConcurrent gate carries, and it
+    // is benign for the same reason: JetStream delivers to a durable pull
+    // consumer SERIALLY (one in-flight `onEnvelope` at a time per the pull
+    // batch), so the two callers don't actually race on this path in
+    // production. If a future push-mode or parallel-batch delivery ever makes
+    // the race real, BOTH consumers harden together (a single shared
+    // admit-token primitive) — they must not drift.
     if (this.inFlight.size >= this.maxConcurrent) {
       const retryAfterMs = 5000;
       await this.publishFailed(
@@ -539,11 +550,24 @@ export class DevConsumer {
 
       // 7b. CC session — warm-resume when the chain has a stored session id.
       const resumeId = await this.sessionStore.get(chainId);
+      // Guardrail default (review parity, §3.5b): when the boot wiring did
+      // NOT declare an `allowedDirs` scope, default it to the WORKTREE only —
+      // the one directory this session legitimately writes to. The worktree
+      // path is per-task (not known at boot), so the narrow default is set
+      // HERE rather than in the boot opts. A boot-supplied `allowedDirs`
+      // (e.g. the repo root + shared caches) wins; we only fill the empty
+      // case so the higher-authority push session is never unrestricted.
+      const bootDirs = this.sessionOpts?.allowedDirs;
+      const allowedDirs =
+        bootDirs !== undefined && bootDirs.length > 0 ? bootDirs : [worktreePath];
       const ccOpts: CCSessionOpts = {
         prompt: this.promptBuilder({ agentId: this.agent.id, payload }),
         agentId: this.agent.id,
         cwd: worktreePath,
         ...(this.sessionOpts ?? {}),
+        // After the spread so the worktree-default (or boot value) is the
+        // effective scope — never dropped by an empty `sessionOpts.allowedDirs`.
+        allowedDirs,
         ...(resumeId !== undefined && { resumeSessionId: resumeId }),
       };
 

--- a/src/runner/dev-consumer.ts
+++ b/src/runner/dev-consumer.ts
@@ -1,0 +1,796 @@
+/**
+ * F-2.1 (cortex#835) — `dev.implement` capability consumer.
+ *
+ * The one genuinely NEW piece of the agentic dev pipeline
+ * (`docs/design-agentic-dev-pipeline.md` §3.1 dev-agent row, §3.4 step 2,
+ * §3.5b authority, §3.6b warm sessions). Mirrors `bus/review-consumer.ts`
+ * shape-for-shape — that consumer is the reference for claim semantics,
+ * lifecycle co-emission, typed-failure → ack/term/nak mapping, the
+ * `processEnvelope`/`start` testability split, and `correlation_id`
+ * discipline. Where this consumer DIVERGES (it acts: worktree → CC →
+ * gates → PR) every action is behind an INJECTED seam so tests drive the
+ * full pipeline with fakes and never spawn real `claude`/`git`/`gh`.
+ *
+ * **DORMANT BY DEFAULT — the hard safety contract.** The consumer is only
+ * instantiated + started by the boot wiring (`src/cortex.ts`) for an agent
+ * that declares a `dev.implement*` capability in `runtime.capabilities[]`.
+ * Every live stack today declares none, so boot is byte-identical: nothing
+ * subscribes, nothing acts. This file ships the consumer + its boot helper;
+ * the boot wiring gates on the capability exactly the way the review path
+ * gates on `code-review*`.
+ *
+ * **Per-envelope pipeline (one `tasks.dev.implement` task):**
+ *   1. redelivery > 1 → emit `dispatch.task.aborted` (advisory) then continue.
+ *   2. validate subject (`tasks.dev.implement`) — else `cant_do` + term.
+ *   3. validate payload (repo/branch/base/brief) — else `cant_do` + term.
+ *   4. capability gate — agent must claim `dev.implement` — else `cant_do` + term.
+ *   5. concurrency gate — at `maxConcurrent` → `not_now` + nak.
+ *   6. emit `dispatch.task.started`.
+ *   7. run the pipeline: worktree → CC session (warm-resume if the chain has
+ *      a stored session) → gates → push + PR → emit `dispatch.task.completed
+ *      {pr}` OR `dispatch.task.failed` with a typed reason:
+ *        - gates red          → `cant_do` (detail names the failing gate).
+ *        - worktree/forge err  → `cant_do` (detail names the step).
+ *        - mid-shutdown        → `not_now` (nak).
+ *   8. record the CC session id under the chain id so the next fix-cycle task
+ *      resumes it (§3.6b).
+ *
+ * **typed-failure → ack/term/nak** is the SAME mapping `review-consumer.ts`
+ * locks in (`failedReasonToAckDecision`): `cant_do`/`wont_do`/`policy_denied`
+ * → term (permanent); `not_now` → nak (transient).
+ *
+ * **Anti-scope (per task spec):** NOT pulse process hosting (F-3); NOT
+ * `release.cut` (F-4); NOT remote backends (F-5b); NOT pilot-side dispatch.
+ * NOT a registry — the capability claim is built from the constructor's
+ * agent snapshot. NOT a renderer — emitted lifecycle envelopes flow through
+ * the existing surface-router fan-out (worklog-manager renders them).
+ */
+
+import type { JsMsg } from "nats";
+import type { MyelinRuntime } from "../bus/myelin/runtime";
+import type { Envelope } from "../bus/myelin/envelope-validator";
+import type { MyelinSubscriber, AckDecision } from "../bus/myelin/subscriber";
+import {
+  createDispatchTaskStartedEvent,
+  createDispatchTaskCompletedEvent,
+  createDispatchTaskFailedEvent,
+  createDispatchTaskAbortedEvent,
+  type DispatchEventSource,
+  type DispatchTaskFailedReason,
+} from "../bus/dispatch-events";
+import {
+  parseDevImplementPayload,
+  devCorrelationChainId,
+  type DevImplementPayload,
+} from "../bus/dev-events";
+import type { CCSessionFactory, CCSessionLike } from "../substrates/claude-code/harness";
+import type { CCSessionOpts, CCSessionResult } from "./cc-session";
+import type { DevSessionStore } from "./dev-session-store";
+
+// ---------------------------------------------------------------------------
+// Injected seams — the testability + authority surface
+// ---------------------------------------------------------------------------
+
+/**
+ * Worktree management seam (worktree-discipline SOP). Production wires a
+ * real `git worktree` runner; tests inject a fake that records calls and
+ * returns a fixed path. Kept narrow — the consumer needs exactly create +
+ * remove, nothing else.
+ */
+export interface DevWorkspace {
+  /**
+   * Create a worktree for `branch` cut from `base` of `repo`, returning the
+   * absolute path the CC session runs in (the worktree-discipline
+   * `../Cortex-{slug}` pattern is the runner's to honour). Throws on
+   * failure — the consumer maps the throw to a `cant_do` failure.
+   */
+  create(opts: {
+    repo: string;
+    branch: string;
+    base: string;
+    chainId: string;
+  }): Promise<{ path: string }>;
+  /** Remove a worktree (terminal cleanup; best-effort — failure logs only). */
+  remove(opts: { path: string }): Promise<void>;
+}
+
+/**
+ * Gate command runner. Production runs each declared gate command in the
+ * worktree (e.g. `bunx tsc --noEmit`); tests inject a fake that returns a
+ * fixed pass/fail. The consumer runs gates in declared order and STOPS at
+ * the first failure (fail-fast — a red `tsc` means the branch isn't worth
+ * linting yet).
+ */
+export interface DevCommandRunner {
+  /**
+   * Run one gate command in `cwd`. Resolves with the outcome; a non-zero
+   * exit is `{ ok: false }`, NOT a throw (a failing gate is a normal,
+   * expected result, not an exception). A throw (the command couldn't be
+   * spawned at all) is treated by the consumer as a gate failure too.
+   */
+  run(opts: { command: string; cwd: string }): Promise<DevCommandResult>;
+}
+
+export interface DevCommandResult {
+  ok: boolean;
+  /** Short tail of stdout/stderr for the failure detail. Optional. */
+  output?: string;
+}
+
+/**
+ * Forge seam — push the branch + open the PR (§3.5b authority model). The
+ * dev agent's forge identity is the forge implementation's concern (it
+ * closes over the scoped credential); the consumer never sees the token.
+ * Production wires a `git push` + `gh pr create` runner bound to the agent's
+ * scoped credential; tests inject a fake returning a fixed PR ref.
+ */
+export interface DevForge {
+  /**
+   * Push the worktree branch and open a PR. Returns the PR reference. Throws
+   * on failure — the consumer maps the throw to a `cant_do` failure.
+   */
+  openPr(opts: {
+    repo: string;
+    branch: string;
+    base: string;
+    cwd: string;
+    title?: string;
+    issue?: number;
+    brief: string;
+  }): Promise<DevPrRef>;
+}
+
+/** A reference to the PR the dev agent opened. Rides `dispatch.task.completed`. */
+export interface DevPrRef {
+  /** `owner/name`, echoed from the request. */
+  repo: string;
+  /** PR number. */
+  number: number;
+  /** Deep link to the PR. */
+  url: string;
+}
+
+// ---------------------------------------------------------------------------
+// Construction options
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal snapshot of cortex.yaml `agents[]` data the consumer needs. Kept
+ * narrow so tests build a fixture without the full Zod `Agent` shape —
+ * mirrors `ReviewConsumerAgent`.
+ */
+export interface DevConsumerAgent {
+  /** Logical agent id (e.g. `"forge"`). Stamped onto every emitted envelope. */
+  id: string;
+  /**
+   * Capability ids this agent claims, e.g. `["dev.implement"]`. The consumer
+   * claims a task when it holds `dev.implement` (exact) or the bare `dev`
+   * capability (wildcard over the dev family).
+   */
+  capabilities: readonly string[];
+  /**
+   * Optional per-agent `maxConcurrent`. When set, the consumer admits at most
+   * `maxConcurrent` in-flight implements; further tasks nak `not_now`. When
+   * undefined, `DEFAULT_MAX_CONCURRENT` (1) applies — a dev implement is a
+   * heavy, long-running action and serial-by-default is the safe posture
+   * (parallel claims across repos are a deliberate opt-in via a higher cap;
+   * worktree isolation makes them safe — design §3.5 row "dev concurrency").
+   */
+  maxConcurrent?: number;
+}
+
+/**
+ * Per-request CC prompt builder. Production assembles the security preamble
+ * + the brief + the assistant prefix; tests inject a deterministic stub.
+ * Returning a string (not `CCSessionOpts`) keeps the consumer free of
+ * skill-allowlist / cwd / timeout policy — those flow through `sessionOpts`.
+ * Mirrors `ReviewPromptBuilder`.
+ */
+export type DevPromptBuilder = (input: {
+  agentId: string;
+  payload: DevImplementPayload;
+}) => string;
+
+/** Construction options. Every dependency injected — no module-scope singletons. */
+export interface DevConsumerOpts {
+  /** The agent this consumer serves. One consumer per agent. */
+  agent: DevConsumerAgent;
+  /** Envelope source (`{principal}.{agent}.{instance}`). */
+  source: DispatchEventSource;
+  /** The myelin runtime — used for `publish` of lifecycle envelopes. */
+  runtime: MyelinRuntime;
+  /** CC session factory — the execution seam. Tests inject a fake. */
+  ccSessionFactory: CCSessionFactory;
+  /** Per-request CC prompt builder. */
+  promptBuilder: DevPromptBuilder;
+  /** Worktree create/remove seam. */
+  workspace: DevWorkspace;
+  /** Gate command runner seam. */
+  commandRunner: DevCommandRunner;
+  /** Forge push + PR-open seam (carries the agent's scoped identity). */
+  forge: DevForge;
+  /**
+   * Warm-session store (§3.6b). Maps correlation-chain id → CC session id so
+   * a fix-cycle resumes the implement session. Tests inject
+   * `MemoryDevSessionStore`; production wires `FileDevSessionStore`.
+   */
+  sessionStore: DevSessionStore;
+  /**
+   * Optional per-request `CCSessionOpts` overrides (cwd is set by the
+   * consumer to the worktree path; allowedDirs/bashAllowlist/timeouts flow
+   * through here). `resumeSessionId` is injected by the consumer for warm
+   * resume — a value here is ignored on the warm path.
+   */
+  sessionOpts?: Partial<Omit<CCSessionOpts, "prompt" | "cwd" | "resumeSessionId">>;
+  /** Test seam — clock. Defaults to `() => new Date()`. */
+  clock?: () => Date;
+}
+
+/**
+ * Boot/log entry the consumer produces — surfaced so `src/cortex.ts` can
+ * render a uniform "ready"/"DORMANT" line. `subscribed: false` when the
+ * runtime is disabled (no NATS / G-1111 pending) so the boot path logs
+ * honestly. Mirrors `ReviewConsumerStartedInfo`.
+ */
+export interface DevConsumerStartedInfo {
+  agentId: string;
+  subscribed: boolean;
+}
+
+/** Options for {@link DevConsumer.start} when binding a JetStream pull consumer. */
+export interface DevConsumerStartOpts {
+  /** Subject pattern, e.g. `local.{principal}.{stack}.tasks.dev.implement`. */
+  pattern: string;
+  /** JetStream stream name carrying the bound consumer. */
+  stream: string;
+  /** Durable consumer name. */
+  durable: string;
+  maxMessages?: number;
+  expiresMs?: number;
+  thresholdMessages?: number;
+}
+
+/** Default per-consumer concurrency — serial. See {@link DevConsumerAgent.maxConcurrent}. */
+export const DEFAULT_MAX_CONCURRENT = 1;
+
+// ---------------------------------------------------------------------------
+// Consumer
+// ---------------------------------------------------------------------------
+
+export class DevConsumer {
+  readonly agent: DevConsumerAgent;
+
+  private readonly source: DispatchEventSource;
+  private readonly runtime: MyelinRuntime;
+  private readonly ccSessionFactory: CCSessionFactory;
+  private readonly promptBuilder: DevPromptBuilder;
+  private readonly workspace: DevWorkspace;
+  private readonly commandRunner: DevCommandRunner;
+  private readonly forge: DevForge;
+  private readonly sessionStore: DevSessionStore;
+  private readonly sessionOpts?: Partial<
+    Omit<CCSessionOpts, "prompt" | "cwd" | "resumeSessionId">
+  >;
+  private readonly clock: () => Date;
+  /** Effective concurrency cap — agent value or the serial default. */
+  private readonly maxConcurrent: number;
+
+  /** In-flight pipelines so `stop()` can drain. */
+  private readonly inFlight = new Set<Promise<void>>();
+
+  private subscriber: MyelinSubscriber | null = null;
+  private stopped = false;
+  private stopPromise: Promise<void> | null = null;
+
+  constructor(opts: DevConsumerOpts) {
+    this.agent = opts.agent;
+    this.source = opts.source;
+    this.runtime = opts.runtime;
+    this.ccSessionFactory = opts.ccSessionFactory;
+    this.promptBuilder = opts.promptBuilder;
+    this.workspace = opts.workspace;
+    this.commandRunner = opts.commandRunner;
+    this.forge = opts.forge;
+    this.sessionStore = opts.sessionStore;
+    if (opts.sessionOpts !== undefined) this.sessionOpts = opts.sessionOpts;
+    this.clock = opts.clock ?? (() => new Date());
+    this.maxConcurrent = opts.agent.maxConcurrent ?? DEFAULT_MAX_CONCURRENT;
+  }
+
+  /**
+   * Bind a JetStream pull consumer and start delivering envelopes into
+   * `processEnvelope`. Returns `subscribed: false` (dormant) when the runtime
+   * is disabled or omits `subscribePull` — the boot path logs DORMANT and the
+   * consumer's drain works against the empty in-flight set. Same contract as
+   * `ReviewConsumer.start`.
+   */
+  async start(opts: DevConsumerStartOpts): Promise<DevConsumerStartedInfo> {
+    if (this.subscriber !== null) {
+      throw new Error(`dev-consumer: already started for agent="${this.agent.id}"`);
+    }
+    const subscribePullOpts: {
+      pattern: string;
+      stream: string;
+      durable: string;
+      onEnvelope: (envelope: Envelope, subject: string) => Promise<AckDecision>;
+      maxMessages?: number;
+      expiresMs?: number;
+      thresholdMessages?: number;
+    } = {
+      pattern: opts.pattern,
+      stream: opts.stream,
+      durable: opts.durable,
+      onEnvelope: async (envelope, subject) =>
+        this.processEnvelope(envelope, subject, null),
+    };
+    if (opts.maxMessages !== undefined) subscribePullOpts.maxMessages = opts.maxMessages;
+    if (opts.expiresMs !== undefined) subscribePullOpts.expiresMs = opts.expiresMs;
+    if (opts.thresholdMessages !== undefined) {
+      subscribePullOpts.thresholdMessages = opts.thresholdMessages;
+    }
+    const sub = this.runtime.subscribePull
+      ? this.runtime.subscribePull(subscribePullOpts)
+      : null;
+    if (sub === null) {
+      return { agentId: this.agent.id, subscribed: false };
+    }
+    this.subscriber = sub;
+    await this.subscriber.ready;
+    return { agentId: this.agent.id, subscribed: true };
+  }
+
+  /**
+   * Drive one envelope through the pipeline. Public for tests (which call it
+   * directly); production arrives via `start()`'s `onEnvelope` handler.
+   *
+   * `msg` carries `info.redeliveryCount` for the redelivery aborted-emit;
+   * tests pass `null` to skip that branch. ALWAYS returns an `AckDecision`.
+   */
+  async processEnvelope(
+    envelope: Envelope,
+    subject: string,
+    msg: JsMsg | null,
+  ): Promise<AckDecision> {
+    // Redelivery > 1 → advisory `dispatch.task.aborted` BEFORE re-running.
+    // Mirrors review-consumer §2.3: the per-attempt pipeline still runs and
+    // emits its own terminal envelope; this is the early "in trouble" signal
+    // so a watcher can react before the dead-letter window runs out.
+    const deliveryCount = redeliveryCountFrom(msg);
+    if (deliveryCount > 1) {
+      await this.safePublish(
+        createDispatchTaskAbortedEvent({
+          source: this.source,
+          taskId: crypto.randomUUID(),
+          agentId: this.agent.id,
+          correlationId: envelope.id,
+          startedAt: this.clock(),
+          abortedAt: this.clock(),
+          reason: `redelivery (attempt ${deliveryCount})`,
+        }),
+        "dispatch.task.aborted",
+      );
+    }
+
+    // 1. Subject/type gate.
+    if (envelope.type !== "tasks.dev.implement") {
+      await this.publishFailed(
+        envelope,
+        {
+          kind: "cant_do",
+          detail: `envelope type "${envelope.type}" is not a tasks.dev.implement request`,
+        },
+        `unrecognised dev subject: ${subject}`,
+      );
+      return { kind: "term", reason: "non-dev subject" };
+    }
+
+    // 2. Payload gate.
+    const payload = parseDevImplementPayload(envelope);
+    if (payload === null) {
+      await this.publishFailed(
+        envelope,
+        {
+          kind: "cant_do",
+          detail: "payload validation failed (missing/invalid repo, branch, base, or brief)",
+        },
+        `bad payload for ${subject}`,
+      );
+      return { kind: "term", reason: "payload validation failed" };
+    }
+
+    // 3. Capability gate — does THIS agent claim dev.implement?
+    if (!this.claims()) {
+      await this.publishFailed(
+        envelope,
+        {
+          kind: "cant_do",
+          detail: `agent "${this.agent.id}" does not claim dev.implement`,
+        },
+        "no capability match for dev.implement",
+      );
+      return { kind: "term", reason: "no capability match" };
+    }
+
+    // 4. Concurrency gate — at the cap → nak `not_now`.
+    if (this.inFlight.size >= this.maxConcurrent) {
+      const retryAfterMs = 5000;
+      await this.publishFailed(
+        envelope,
+        {
+          kind: "not_now",
+          detail: `agent at maxConcurrent (${this.maxConcurrent}) — try again`,
+          retry_after_ms: retryAfterMs,
+        },
+        "dev consumer at maxConcurrent",
+      );
+      return { kind: "nak", delayMs: retryAfterMs };
+    }
+
+    // 5. Mid-shutdown refusal — don't start new pipelines while draining.
+    if (this.stopped) {
+      await this.publishFailed(
+        envelope,
+        { kind: "not_now", detail: "dev consumer is shutting down", retry_after_ms: 0 },
+        "consumer shutting down before pipeline start",
+      );
+      return { kind: "nak", delayMs: 0 };
+    }
+
+    // 6. Emit started — paired with the eventual terminal via correlation_id.
+    const startedAt = this.clock();
+    await this.safePublish(
+      createDispatchTaskStartedEvent({
+        source: this.source,
+        taskId: crypto.randomUUID(),
+        agentId: this.agent.id,
+        correlationId: envelope.id,
+        startedAt,
+      }),
+      "dispatch.task.started",
+    );
+
+    // 7. Run the pipeline. Track the promise for `stop()` drain.
+    const pipelinePromise = this.runPipeline(envelope, payload, startedAt);
+    const tracked = pipelinePromise.then((decision) => ({ decision }));
+    const drainSentinel = tracked.then(() => undefined);
+    this.inFlight.add(drainSentinel);
+    try {
+      const { decision } = await tracked;
+      return decision;
+    } finally {
+      this.inFlight.delete(drainSentinel);
+    }
+  }
+
+  /**
+   * Stop accepting new envelopes and drain in-flight pipelines. Idempotent.
+   * The drain awaits every in-flight `processEnvelope` (incl. terminal
+   * publish) so a watcher sees the terminal envelope from a mid-flight
+   * implement at SIGTERM instead of a phantom timeout. Mirrors
+   * `ReviewConsumer.stop`.
+   */
+  async stop(): Promise<void> {
+    if (this.stopPromise) return this.stopPromise;
+    this.stopPromise = (async () => {
+      this.stopped = true;
+      const sub = this.subscriber;
+      if (sub) {
+        try {
+          await sub.stop();
+        } catch (err) {
+          process.stderr.write(
+            `dev-consumer: subscriber stop failed for agent=${this.agent.id}: ` +
+              `${err instanceof Error ? err.message : String(err)}\n`,
+          );
+        }
+      }
+      if (this.inFlight.size > 0) {
+        await Promise.allSettled(Array.from(this.inFlight));
+      }
+    })();
+    return this.stopPromise;
+  }
+
+  // -------------------------------------------------------------------------
+  // Internals
+  // -------------------------------------------------------------------------
+
+  /** Capability claim: exact `dev.implement` or the bare `dev` family wildcard. */
+  private claims(): boolean {
+    return (
+      this.agent.capabilities.includes("dev.implement") ||
+      this.agent.capabilities.includes("dev")
+    );
+  }
+
+  /**
+   * The act: worktree → CC (warm-resume if the chain has a stored session) →
+   * gates → push + PR → terminal envelope. Returns the `AckDecision`.
+   *
+   * Every step's failure is mapped to a typed `dispatch.task.failed` reason
+   * + the matching ack control; a step that throws is captured (never
+   * propagated) so `processEnvelope` always returns an `AckDecision`. The
+   * worktree is removed on every exit path (best-effort).
+   */
+  private async runPipeline(
+    envelope: Envelope,
+    payload: DevImplementPayload,
+    startedAt: Date,
+  ): Promise<AckDecision> {
+    const chainId = devCorrelationChainId(envelope);
+    let worktreePath: string | null = null;
+
+    try {
+      // 7a. Worktree.
+      try {
+        const created = await this.workspace.create({
+          repo: payload.repo,
+          branch: payload.branch,
+          base: payload.base,
+          chainId,
+        });
+        worktreePath = created.path;
+      } catch (err) {
+        return await this.failTerminal(envelope, startedAt, {
+          kind: "cant_do",
+          detail: `worktree create failed: ${errText(err)}`,
+        });
+      }
+
+      // 7b. CC session — warm-resume when the chain has a stored session id.
+      const resumeId = await this.sessionStore.get(chainId);
+      const ccOpts: CCSessionOpts = {
+        prompt: this.promptBuilder({ agentId: this.agent.id, payload }),
+        agentId: this.agent.id,
+        cwd: worktreePath,
+        ...(this.sessionOpts ?? {}),
+        ...(resumeId !== undefined && { resumeSessionId: resumeId }),
+      };
+
+      let ccResult: CCSessionResult;
+      try {
+        const session: CCSessionLike = this.ccSessionFactory(ccOpts);
+        session.start();
+        ccResult = await session.wait();
+      } catch (err) {
+        return await this.failTerminal(envelope, startedAt, {
+          kind: "cant_do",
+          detail: `cc session threw: ${errText(err)}`,
+        });
+      }
+
+      // Persist the session id for the next fix-cycle resume (§3.6b) — even on
+      // a CC failure, so a fix cycle resumes the SAME session that got partway.
+      if (ccResult.sessionId !== undefined && ccResult.sessionId.length > 0) {
+        await this.sessionStore.set(chainId, ccResult.sessionId);
+      }
+
+      if (!ccResult.success) {
+        const reason: DispatchTaskFailedReason = ccResult.aborted
+          ? {
+              kind: "not_now",
+              detail: `cc session aborted (${ccResult.abortReason ?? "timeout"}) — retry`,
+              retry_after_ms: 0,
+            }
+          : {
+              kind: "cant_do",
+              detail: `cc session exited ${ccResult.exitCode} without completing the brief`,
+            };
+        return await this.failTerminal(envelope, startedAt, reason);
+      }
+
+      // 7c. Gates — run in declared order, stop at the first red.
+      const gates = payload.gates ?? [];
+      for (const command of gates) {
+        let gateResult: DevCommandResult;
+        try {
+          gateResult = await this.commandRunner.run({ command, cwd: worktreePath });
+        } catch (err) {
+          return await this.failTerminal(envelope, startedAt, {
+            kind: "cant_do",
+            detail: `gate "${command}" could not run: ${errText(err)}`,
+          });
+        }
+        if (!gateResult.ok) {
+          const tail = gateResult.output ? ` — ${truncate(gateResult.output)}` : "";
+          return await this.failTerminal(envelope, startedAt, {
+            kind: "cant_do",
+            detail: `gate "${command}" failed${tail}`,
+          });
+        }
+      }
+
+      // 7d. Push + PR.
+      let pr: DevPrRef;
+      try {
+        pr = await this.forge.openPr({
+          repo: payload.repo,
+          branch: payload.branch,
+          base: payload.base,
+          cwd: worktreePath,
+          brief: payload.brief,
+          ...(payload.title !== undefined && { title: payload.title }),
+          ...(payload.issue !== undefined && { issue: payload.issue }),
+        });
+      } catch (err) {
+        return await this.failTerminal(envelope, startedAt, {
+          kind: "cant_do",
+          detail: `forge openPr failed: ${errText(err)}`,
+        });
+      }
+
+      // 7e. Terminal success — `dispatch.task.completed` carrying the PR ref.
+      await this.safePublish(
+        createDispatchTaskCompletedEvent({
+          source: this.source,
+          taskId: crypto.randomUUID(),
+          agentId: this.agent.id,
+          correlationId: envelope.id,
+          startedAt,
+          completedAt: this.clock(),
+          resultSummary: `opened ${pr.repo}#${pr.number}`,
+          // The PR ref is the load-bearing result the reactor advances on. It
+          // rides `chat_response` as a JSON blob so a surface can render the
+          // deep link AND a programmatic consumer can parse it — the dispatch
+          // builder has no dedicated `pr` field, and adding one is a wire-
+          // schema change out of scope for F-2 (FLAGGED in the PR body).
+          chatResponse: JSON.stringify({ pr }),
+        }),
+        "dispatch.task.completed",
+      );
+      return { kind: "ack" };
+    } finally {
+      // Best-effort worktree cleanup on every exit path. A removal failure is
+      // logged, never thrown — a leaked worktree is a janitorial concern, not
+      // a reason to nak a task whose terminal envelope already shipped.
+      if (worktreePath !== null) {
+        try {
+          await this.workspace.remove({ path: worktreePath });
+        } catch (err) {
+          process.stderr.write(
+            `dev-consumer: worktree remove failed for ${worktreePath} ` +
+              `(agent=${this.agent.id}): ${errText(err)}\n`,
+          );
+        }
+      }
+    }
+  }
+
+  /**
+   * Publish a `dispatch.task.failed` for a pipeline-internal failure and
+   * return the matching `AckDecision`. The `errorSummary` mirrors the
+   * reason's detail so the worklog + dead-letter views agree.
+   */
+  private async failTerminal(
+    envelope: Envelope,
+    startedAt: Date,
+    reason: DispatchTaskFailedReason,
+  ): Promise<AckDecision> {
+    await this.safePublish(
+      createDispatchTaskFailedEvent({
+        source: this.source,
+        taskId: crypto.randomUUID(),
+        agentId: this.agent.id,
+        correlationId: envelope.id,
+        startedAt,
+        failedAt: this.clock(),
+        errorSummary: reasonDetail(reason),
+        reason,
+      }),
+      "dispatch.task.failed",
+    );
+    return failedReasonToAckDecision(reason);
+  }
+
+  /**
+   * Publish a `dispatch.task.failed` built locally for a pre-pipeline failure
+   * branch (bad subject/payload, no capability, backpressure, shutdown).
+   * Threads `correlation_id = envelope.id` (the request id) per the lifecycle
+   * contract.
+   */
+  private async publishFailed(
+    request: Envelope,
+    reason: DispatchTaskFailedReason,
+    errorSummary: string,
+  ): Promise<void> {
+    const now = this.clock();
+    await this.safePublish(
+      createDispatchTaskFailedEvent({
+        source: this.source,
+        taskId: crypto.randomUUID(),
+        agentId: this.agent.id,
+        correlationId: request.id,
+        startedAt: now,
+        failedAt: now,
+        errorSummary,
+        reason,
+      }),
+      "dispatch.task.failed",
+    );
+  }
+
+  /**
+   * SINGLE PUBLISH PATH — every lifecycle envelope the consumer emits routes
+   * through here. Traps + logs publish errors (CLAUDE.md "no empty catch")
+   * so a failed publish never crashes the consumer or stops the handler from
+   * returning an `AckDecision`. Mirrors `ReviewConsumer.safePublish` (local
+   * mode only — federated dev dispatch is F-5, out of scope).
+   */
+  private async safePublish(envelope: Envelope, label: string): Promise<void> {
+    try {
+      await this.runtime.publish(envelope);
+    } catch (err) {
+      process.stderr.write(
+        `dev-consumer: publish failed for ${label} (agent=${this.agent.id}): ` +
+          `${err instanceof Error ? err.message : String(err)}\n`,
+      );
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers (exported for tests)
+// ---------------------------------------------------------------------------
+
+/**
+ * Map a `DispatchTaskFailedReason` to the JetStream `AckDecision`. The SAME
+ * mapping `review-consumer.ts` locks in: permanent failures term (so the
+ * dead-letter view carries a structured reason), transient `not_now` naks
+ * with the retry hint. Duplicated rather than imported to keep the dev
+ * consumer free of a `bus/review-consumer.ts` dependency (the two are
+ * sibling capability consumers, not a shared base).
+ */
+export function failedReasonToAckDecision(
+  reason: DispatchTaskFailedReason | undefined,
+): AckDecision {
+  if (!reason) return { kind: "ack" };
+  switch (reason.kind) {
+    case "cant_do":
+      return { kind: "term", reason: `cant_do: ${reason.detail}` };
+    case "wont_do":
+      return { kind: "term", reason: `wont_do: ${reason.detail}` };
+    case "policy_denied": {
+      const denyKeys = Object.keys(reason.deny);
+      const summary = denyKeys.length > 0 ? denyKeys.join(",") : "(no deny detail)";
+      return { kind: "term", reason: `policy_denied: ${summary}` };
+    }
+    case "not_now": {
+      const out: AckDecision = { kind: "nak" };
+      if (reason.retry_after_ms !== undefined) out.delayMs = reason.retry_after_ms;
+      return out;
+    }
+    case "compliance_block":
+      return { kind: "term", reason: "v1 does not handle compliance_block" };
+  }
+}
+
+/** Human-readable detail for a reason — used as the `error_summary`. */
+function reasonDetail(reason: DispatchTaskFailedReason): string {
+  switch (reason.kind) {
+    case "cant_do":
+    case "wont_do":
+    case "not_now":
+    case "compliance_block":
+      return reason.detail;
+    case "policy_denied":
+      return `policy_denied: ${Object.keys(reason.deny).join(",")}`;
+  }
+}
+
+/** Read JetStream redelivery count from a `JsMsg`; `1` when no msg (tests). */
+function redeliveryCountFrom(msg: JsMsg | null): number {
+  if (!msg) return 1;
+  const info = (msg.info as { redeliveryCount?: number } | undefined) ?? undefined;
+  if (info && typeof info.redeliveryCount === "number") return info.redeliveryCount;
+  return msg.redelivered ? 2 : 1;
+}
+
+function errText(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+/** Cap a gate's output tail for the failure detail. */
+function truncate(s: string, max = 500): string {
+  const trimmed = s.trim();
+  return trimmed.length > max ? `${trimmed.slice(0, max)}…` : trimmed;
+}

--- a/src/runner/dev-session-store.ts
+++ b/src/runner/dev-session-store.ts
@@ -1,0 +1,163 @@
+/**
+ * F-2.1 (cortex#835) — warm-session store for the `dev.implement` consumer.
+ *
+ * Design ref: `docs/design-agentic-dev-pipeline.md` §3.6b — "agent-state
+ * durably maps errand → session id so a restarted agent resumes rather than
+ * restarts." This is the **smallest honest durable version** of that map:
+ * a single JSON file, one process owns it, written atomically (temp +
+ * rename) so a crash mid-write never corrupts it.
+ *
+ * **Why a file, not sqlite / agent-state.** §3.6b assigns the durable
+ * errand→session map to agent-state in the fully-composed dev-loop (F-3/F-6).
+ * That substrate isn't wired into cortex's runner yet (the in-process
+ * `dev.implement` consumer is the FIRST piece — F-2 per the design's "what's
+ * new" table). Standing up agent-state here would be over-engineering ahead
+ * of F-3; a JSON file is the lightweight, dependency-free bridge that makes
+ * warm-resume work TODAY and is trivially swapped for the agent-state store
+ * when F-3 lands (the `DevSessionStore` interface is the seam). Per the
+ * pragmatic-solutions principle: port/bridge over heavy-dep.
+ *
+ * **The map.** `correlationChainId → ccSessionId`. The chain id is the
+ * `dev-events.devCorrelationChainId` value (the request's `correlation_id`,
+ * or its `id` when first-of-chain); the CC session id is the value
+ * `CCSessionResult.sessionId` carries after the implement session runs. A
+ * subsequent fix-cycle task on the same chain reads the stored id and passes
+ * it as `resumeSessionId` so the CC session `--resume`s instead of
+ * cold-starting.
+ *
+ * **What this file is NOT:**
+ *   - NOT a general KV — two methods (`get` / `set`) plus a `delete` for
+ *     cleanup. No TTL, no eviction (a chain is short-lived; the principal /
+ *     a future F-3 reaper prunes stale entries — flagged, not built).
+ *   - NOT concurrency-safe across PROCESSES — one cortex daemon owns one
+ *     store file (the single-instance PID-file model the daemon already
+ *     enforces). In-process concurrent `set`s serialise through the async
+ *     write; the last write wins, which is correct for the
+ *     one-session-per-chain invariant.
+ */
+
+import { mkdirSync, readFileSync, renameSync, writeFileSync, existsSync } from "fs";
+import { dirname } from "path";
+
+/**
+ * The warm-session store seam. The consumer depends on this interface, not
+ * the file-backed implementation, so tests inject an in-memory fake (mirrors
+ * how `review-consumer.ts` injects every dependency) and the F-3 agent-state
+ * store can replace `FileDevSessionStore` without touching the consumer.
+ */
+export interface DevSessionStore {
+  /** CC session id last recorded for this chain, or `undefined` if cold. */
+  get(chainId: string): Promise<string | undefined>;
+  /** Record (or overwrite) the CC session id for this chain. */
+  set(chainId: string, sessionId: string): Promise<void>;
+  /** Drop a chain's entry (terminal success/failure cleanup; optional use). */
+  delete(chainId: string): Promise<void>;
+}
+
+/**
+ * In-memory `DevSessionStore`. Volatile — loses the map on restart, so it
+ * does NOT satisfy §3.6b's "a restarted agent resumes" durability clause. Use
+ * it only in tests; production wires {@link FileDevSessionStore}.
+ */
+export class MemoryDevSessionStore implements DevSessionStore {
+  private readonly map = new Map<string, string>();
+
+  // eslint-disable-next-line @typescript-eslint/require-await
+  async get(chainId: string): Promise<string | undefined> {
+    return this.map.get(chainId);
+  }
+
+  // eslint-disable-next-line @typescript-eslint/require-await
+  async set(chainId: string, sessionId: string): Promise<void> {
+    this.map.set(chainId, sessionId);
+  }
+
+  // eslint-disable-next-line @typescript-eslint/require-await
+  async delete(chainId: string): Promise<void> {
+    this.map.delete(chainId);
+  }
+}
+
+/**
+ * JSON-file-backed `DevSessionStore`. Durable across restarts (the §3.6b
+ * requirement). The whole map is held in memory and the file is rewritten
+ * atomically on every `set` / `delete` — fine for the small, short-lived
+ * chain set a single stack carries (typically a handful of in-flight
+ * errands). When the map grows large enough that whole-file rewrites hurt,
+ * the seam swaps to the F-3 agent-state store (the cost is per-chain, not
+ * per-write, so this scales to the realistic dev-loop fleet size).
+ */
+export class FileDevSessionStore implements DevSessionStore {
+  private readonly path: string;
+  private map: Map<string, string>;
+
+  constructor(path: string) {
+    this.path = path;
+    this.map = loadMap(path);
+  }
+
+  // eslint-disable-next-line @typescript-eslint/require-await
+  async get(chainId: string): Promise<string | undefined> {
+    return this.map.get(chainId);
+  }
+
+  async set(chainId: string, sessionId: string): Promise<void> {
+    this.map.set(chainId, sessionId);
+    await this.flush();
+  }
+
+  async delete(chainId: string): Promise<void> {
+    if (this.map.delete(chainId)) {
+      await this.flush();
+    }
+  }
+
+  /**
+   * Atomic write: serialise to a temp sibling, then `rename` over the real
+   * file. `rename` is atomic on a single filesystem, so a crash mid-write
+   * leaves either the old file or the new one — never a half-written one.
+   */
+  // eslint-disable-next-line @typescript-eslint/require-await
+  private async flush(): Promise<void> {
+    const dir = dirname(this.path);
+    mkdirSync(dir, { recursive: true });
+    const tmp = `${this.path}.${process.pid}.${Date.now()}.tmp`;
+    const obj: Record<string, string> = {};
+    for (const [k, v] of this.map) obj[k] = v;
+    writeFileSync(tmp, JSON.stringify(obj, null, 2), "utf8");
+    renameSync(tmp, this.path);
+  }
+}
+
+/**
+ * Load the persisted map from disk. A missing file → empty map (cold first
+ * boot). A corrupt / unreadable file → empty map + a stderr warning rather
+ * than a boot crash: a lost warm-session map degrades to cold-starting the
+ * next fix cycle (a slower-but-correct fallback), which is strictly better
+ * than refusing to boot. (CLAUDE.md: never swallow silently — we log.)
+ */
+function loadMap(path: string): Map<string, string> {
+  if (!existsSync(path)) return new Map();
+  try {
+    const raw = readFileSync(path, "utf8");
+    const parsed = JSON.parse(raw) as unknown;
+    if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+      process.stderr.write(
+        `dev-session-store: ${path} is not a JSON object — starting with an empty warm-session map\n`,
+      );
+      return new Map();
+    }
+    const map = new Map<string, string>();
+    for (const [k, v] of Object.entries(parsed as Record<string, unknown>)) {
+      if (typeof v === "string") map.set(k, v);
+    }
+    return map;
+  } catch (err) {
+    process.stderr.write(
+      `dev-session-store: failed to read ${path} (${
+        err instanceof Error ? err.message : String(err)
+      }) — starting with an empty warm-session map\n`,
+    );
+    return new Map();
+  }
+}


### PR DESCRIPTION
## What

The one genuinely **new** piece of the agentic dev pipeline (epic #835): a capability consumer for `tasks.dev.implement`. Claims an implement Offer → cuts a worktree from `origin/main` → runs the brief through a CC session → runs the declared gates → pushes + opens a PR → emits `dispatch.task.completed {pr}` (or `failed` with a typed reason). Mirrors `bus/review-consumer.ts` shape-for-shape.

Refs #835. Design: `docs/design-agentic-dev-pipeline.md` §3.1 (dev-agent row), §3.4 step 2 (event walk), §3.5b (authority model), §3.6b (warm sessions).

## The hard safety contract — DORMANT BY DEFAULT

`wireDevConsumers` returns an **empty array** — touching no filesystem, spawning nothing, reading no token — unless an agent declares `dev.implement` (or the bare `dev` family) in `runtime.capabilities[]`. Every live stack today declares none, so boot is **byte-identical**. The dormancy is proven two ways:

- `src/__tests__/cortex.test.ts` (the boot smoke) runs green **unchanged** — a stack with no dev capability stands up exactly as before (27 tests pass).
- `src/runner/__tests__/dev-consumer-boot.test.ts` asserts `wireDevConsumers([...no dev agent])` → `[]` with no token read, no warning, no seams constructed.

## Files

| File | Role |
|---|---|
| `src/runner/dev-consumer.ts` | The consumer. Every action behind an **injected seam** (`workspace` / `commandRunner` / `forge` / `ccSessionFactory` / `sessionStore`) so tests drive the full pipeline with fakes and never spawn real `claude`/`git`/`gh`. Lifecycle via the existing `dispatch.task.*` builders; typed-failure → ack/term/nak mapping **identical** to review-consumer (`cant_do`/`wont_do` → term; `not_now` → nak). Per-consumer `maxConcurrent` (default **1**, serial) → `not_now` beyond it. |
| `src/bus/dev-events.ts` | `tasks.dev.implement` request builder + payload parser + correlation-chain-id helper (mirrors `review-events.ts`). |
| `src/runner/dev-session-store.ts` | Warm-session store (§3.6b). `Memory` + file-backed (atomic temp+rename) `DevSessionStore`: `correlationChain → ccSessionId`, so a fix-cycle **resumes** the implement session via `--resume`. |
| `src/runner/dev-consumer-boot.ts` | Dormancy gate + §3.5b forge-identity knob + shell-backed production seams. |
| `src/cortex.ts` | Boot wiring after the review-consumer block + shutdown drain. |

## How it mirrors review-consumer (and where it diverges)

**Mirrored:** the `processEnvelope`/`start` testability split returning `AckDecision`; `start()` → `subscribed:false` (DORMANT) on a disabled runtime; the redelivery `dispatch.task.aborted` advisory; the single `safePublish` error-trapped path; `correlation_id = request.id` on every lifecycle envelope; the `failedReasonToAckDecision` table; `stop()` draining the in-flight set.

**Diverged:** review-consumer *reads*; this consumer *acts*. The act (worktree → CC → gates → PR) lives behind injected seams; the worktree is removed on **every** exit path; the PR ref rides `dispatch.task.completed.chat_response` as a JSON blob.

## Warm-session store design (§3.6b)

`DevSessionStore` is a seam (`get`/`set`/`delete`). The **smallest honest durable version**: a single JSON file, one process owns it, written atomically (temp + rename) so a crash mid-write never corrupts it. Maps the correlation-chain id (`correlation_id`, or the request `id` when first-of-chain) → the CC `sessionId`. A fix-cycle task carrying the same chain reads the stored id and passes it as `resumeSessionId`. Corrupt/missing file → empty map + a stderr warning (degrade to cold-start, never a boot crash). The interface is the swap-point for F-3's agent-state store.

## Authority model (§3.5b)

The forge seam pushes + opens PRs with a **scoped** identity from `CORTEX_DEV_GH_TOKEN` (env-var name configurable). When unset, it falls back to ambient `gh` auth **and emits a loud boot warning** citing the design's accepted-risk note — the honest F-2 caveat surfaced, not buried. The consumer never sees the token.

## Gates (real outputs)

\`\`\`
$ bunx tsc --noEmit
(exit 0 — clean)

$ bunx eslint --quiet src/
(exit 0 — clean, zero output)

$ bash scripts/check-carveouts.sh
check-carveouts: PASS — no ungated deprecated-term live violations

$ bun test src/runner/__tests__/dev-consumer.test.ts \
           src/runner/__tests__/dev-consumer-boot.test.ts \
           src/runner/__tests__/dev-session-store.test.ts \
           src/bus/__tests__/dev-events.test.ts
49 pass / 0 fail / 109 expect() calls

$ bun test src/__tests__/cortex.test.ts        # the DORMANCY PROOF
27 pass / 0 fail

$ bun test src/                                 # full suite
5218 pass / 2 skip / 8 fail / 6 errors
\`\`\`

The 8 fails / 6 errors in the full run are **pre-existing parallel-load flakes** (timeout-bound suites: `api.test.ts` 40 MB-body 413, `fragment-watcher`, `network-cli` status). Each **passes solo** on both clean `origin/main` and this branch — none touch the dev files, and none of my 4 new test files fail.

## Flags

1. **Stream provisioning deferred (decision needed).** The review path provisions a `CODE_REVIEW` JetStream stream + per-agent durable up-front. This PR wires the dev consumer's `subscribePull` binding (dormant-safe) but does **not** provision a `DEV_IMPLEMENT` stream — deliberately deferred to a sibling slice to keep this PR "one mergeable, dormant-by-default consumer." Because no agent declares `dev.implement` yet, nothing binds yet, so the deferral changes zero live behaviour. **A dev-capable agent on a live bus will need the `DEV_IMPLEMENT` stream provisioned alongside.**
2. **No token accounting.** §3.5 names per-errand cost/token budgets as runaway protection. This consumer carries no cost cap — that gate lives at the pilot reactor / process layer (F-3), not the consumer. Flagged so it isn't assumed present.
3. **PR ref on `chat_response`.** The `dispatch.task.completed` builder has no dedicated `pr` field; the PR ref rides `chat_response` as JSON. Adding a first-class `pr` payload field is a wire-schema change out of scope for F-2.
4. **Config schema knob.** The forge token is read from an **env var** (`CORTEX_DEV_GH_TOKEN`), not yet a cortex.yaml `agent.runtime.dev.*` field — env keeps secrets out of config files (matches how CC OAuth tokens flow). A typed config knob can follow when a dev agent is first declared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)