### PR TITLE
feat(mc): MC-I1.S1 — mc: config + in-process Mission Control embed; retire setupDashboard's dead import

### DIFF
--- a/docs/iteration-mission-control-pane-of-glass.md
+++ b/docs/iteration-mission-control-pane-of-glass.md
@@ -1,0 +1,89 @@
+# Iteration plan — Mission Control pane of glass (Iteration 1: light the local pane)
+
+**Status tracker for the umbrella GH issue [#843](https://github.com/the-metafactory/cortex/issues/843).**
+Phases 0–2, local only. When a box ticks here, tick it on the umbrella issue too.
+
+Capstone framing + decision record:
+
+- **ADR-0005** — Mission Control integration architecture (in-process, bus-projected, no legacy lift) — [`docs/adr/0005-mission-control-integration-architecture.md`](adr/0005-mission-control-integration-architecture.md) (PR #842).
+- **ADR-0006** — network-view feed (registry-anchored; Phase 3, NOT this iteration) — [`docs/adr/0006-mission-control-network-view-feed.md`](adr/0006-mission-control-network-view-feed.md).
+- Survey + grilling: `.prd/PRD-20260610-mc-pane-of-glass-plumbing.md` (2026-06-10).
+
+---
+
+## Goal
+
+Bring Mission Control to life as the local pane of glass: the cockpit lit
+in-process, agent sessions visible live, and the bus projected onto the glass.
+
+The cockpit UI is complete but dark — `setupDashboard()`'s dead import (#712),
+ingestor session drops, an unconsumed renderer buffer, an unfed cloud pane. This
+iteration plumbs the local pane end-to-end.
+
+---
+
+## Scope (Iteration 1 = Phases 0–2, local only)
+
+- **Phase 0 — light what's built:** `mc:` config block, in-process embed, retire
+  `setupDashboard()`'s dead import (#712); enable on the meta-factory stack.
+- **Phase 1 — agents on the glass:** bus-driven session projection
+  (`cc_session_id` on `dispatch.task.started`), ingestor orphan auto-register.
+- **Phase 2 — bus onto the glass:** MC projection renderer registered with the
+  surface-router; attention producers completed.
+
+**Out of scope (future iterations):**
+Phase 3 (G-1114 [#355](https://github.com/the-metafactory/cortex/issues/355)
+network topology + registry-anchored cloud feed per ADR-0006), Phase 4 (signal
+trace deep-link, signal#99).
+
+---
+
+## PR plan
+
+Each slice is a sub-issue of the umbrella; its PR closes it. Tick the box on
+merge (here and on the umbrella).
+
+| Slice | PR | Depends on | Files / area | Done |
+|---|---|---|---|---|
+| **S1** | `mc:` block + embed module + retire setupDashboard | — | `config.ts`, `surface/mc/embed.ts`, `cortex.ts` | [ ] |
+| **S2** | enable meta-factory + live verify + config-layout docs | S1 | `docs/config-layout`, deployment | [ ] |
+| **S3** | `cc_session_id` on `dispatch.task.started` | — | `runner/cc-session`, bus types | [ ] |
+| **S4** | MC session projection from lifecycle envelopes | S1, S3 | `surface/mc` projection | [ ] |
+| **S5** | ingestor orphan auto-register (`local.observed`) | S1 | `surface/mc/hooks/ingestor` | [ ] |
+| **S6** | MC projection renderer on the surface-router | S1, S4 | `renderers`, `surface/mc` | [ ] |
+| **S7** | attention producers: `failed_dispatch` + `stale` | S6 | `surface/mc/db/attention-sources` | [ ] |
+
+---
+
+## S1 — `mc:` config block + in-process embed + retire setupDashboard's dead import
+
+Closes [#712](https://github.com/the-metafactory/cortex/issues/712). Implements
+ADR-0005's in-process-embed + retire-the-legacy-lift decision.
+
+- [ ] `mc:` config block on `AgentConfigSchema` (`enabled` / `configPath` /
+      `dbPath` / `port`), using the `emptyDefault()` + transform idiom so the
+      all-defaults parse path stays populated.
+- [ ] `src/surface/mc/embed.ts` — `startMissionControl()` mirrors the standalone
+      `index.ts` composition (loadConfig → initDatabase → ProcessManager →
+      startServer → HookStreamPoller); embedded mode overrides db + cursor +
+      port (ADR-0005 §2), MC yaml governs hooks / ws / log only.
+- [ ] `cortex.ts` — boot the embed when `mc.enabled`; per-slug default db at
+      `~/.local/share/cortex/mc/<stack>/mission-control.db` with the hook cursor
+      beside it; cockpit loop's `baseUrl` reads the embed's actual port.
+- [ ] `cortex.ts` — `api.enabled` warns once that the legacy embedded dashboard
+      is retired (it never migrated from grove-v2, #712) and directs to `mc:`;
+      `setupDashboard` + `runStartupCloudSync` + the dead `as string` import
+      deleted. The `api:` schema block stays (back-compat reader); `CloudPublisher`
+      instantiation stays (Phase 3 / ADR-0006 re-homes its dead call site).
+- [ ] Tests: `mc` defaults parse + explicit values honored; embed boots against a
+      tmp dbPath on an OS-assigned port, serves `/health`, lands db + cursor
+      beside each other, releases the port on `stop()`.
+
+---
+
+## Notes
+
+- Merge reports post to the MC thread in Discord (control plane); review detail
+  stays on the PRs (data plane).
+- The iteration doc lands with S1; subsequent slices fill in their own
+  acceptance checklists under their headings as they're picked up.

--- a/src/common/config/__tests__/watcher.test.ts
+++ b/src/common/config/__tests__/watcher.test.ts
@@ -132,6 +132,12 @@ const TEST_CONFIG: AgentConfig = {
     refreshIntervalMs: 300_000,
     attention: { surface: "discord", channel: "" },
   },
+  mc: {
+    enabled: false,
+    configPath: "",
+    dbPath: "",
+    port: 0,
+  },
   networksDir: "./networks",
   networks: [],
 };

--- a/src/common/types/__tests__/cortex-config.test.ts
+++ b/src/common/types/__tests__/cortex-config.test.ts
@@ -563,6 +563,71 @@ describe("AgentConfigSchema.nats.accountSigningKeyPath (MIRROR)", () => {
   });
 });
 
+describe("AgentConfigSchema.mc (MC-I1.S1)", () => {
+  /** Minimal AgentConfig shell; `mc` override is spread in when provided. */
+  function minAgentConfig(mc?: Record<string, unknown>) {
+    return {
+      agent: { name: "test", displayName: "Test" },
+      discord: [],
+      mattermost: [],
+      claude: { timeoutMs: 1000 },
+      paths: { publishedEventsDir: "/tmp/x" },
+      ...(mc !== undefined && { mc }),
+    };
+  }
+
+  test("absent mc block → enabled false, all fields populated by the transform", () => {
+    // The `.default(emptyDefault())` quirk: without the transform re-applying
+    // inner defaults, these fields would be undefined. Assert the populated shape.
+    const parsed = AgentConfigSchema.parse(minAgentConfig());
+    expect(parsed.mc).toEqual({
+      enabled: false,
+      configPath: "",
+      dbPath: "",
+      port: 0,
+    });
+  });
+
+  test("empty mc block ({}) → same populated defaults", () => {
+    const parsed = AgentConfigSchema.parse(minAgentConfig({}));
+    expect(parsed.mc.enabled).toBe(false);
+    expect(parsed.mc.configPath).toBe("");
+    expect(parsed.mc.dbPath).toBe("");
+    expect(parsed.mc.port).toBe(0);
+  });
+
+  test("explicit values are honored", () => {
+    const parsed = AgentConfigSchema.parse(
+      minAgentConfig({
+        enabled: true,
+        configPath: "~/.config/cortex/mc.yaml",
+        dbPath: "~/.local/share/cortex/mc/meta-factory/mission-control.db",
+        port: 8767,
+      }),
+    );
+    expect(parsed.mc.enabled).toBe(true);
+    expect(parsed.mc.configPath).toBe("~/.config/cortex/mc.yaml");
+    expect(parsed.mc.dbPath).toBe("~/.local/share/cortex/mc/meta-factory/mission-control.db");
+    expect(parsed.mc.port).toBe(8767);
+  });
+
+  test("partial mc block fills the rest from defaults", () => {
+    const parsed = AgentConfigSchema.parse(minAgentConfig({ enabled: true }));
+    expect(parsed.mc.enabled).toBe(true);
+    expect(parsed.mc.configPath).toBe("");
+    expect(parsed.mc.dbPath).toBe("");
+    expect(parsed.mc.port).toBe(0);
+  });
+
+  test("port rejects a negative value (nonnegative int)", () => {
+    expect(() => AgentConfigSchema.parse(minAgentConfig({ port: -1 }))).toThrow();
+  });
+
+  test("port rejects a non-integer value", () => {
+    expect(() => AgentConfigSchema.parse(minAgentConfig({ port: 8767.5 }))).toThrow();
+  });
+});
+
 // =============================================================================
 // Renderer URL validation
 // =============================================================================

--- a/src/common/types/config.ts
+++ b/src/common/types/config.ts
@@ -526,6 +526,38 @@ export const AgentConfigSchema = z.object({
     cfAccessClientSecret: z.string().default(""),
   }).default(emptyDefault()),
 
+  /**
+   * MC-I1.S1 (ADR-0005): in-process Mission Control embed. Supersedes the dead
+   * `api.*` embedded-dashboard path (#712). OFF by default (opt-in) so existing
+   * deployments are unchanged. When `enabled`, `startCortex` boots the MC v3
+   * server in-process (see `src/surface/mc/embed.ts`).
+   *
+   * Embedded mode deliberately overrides db + cursor + port; an MC yaml at
+   * `configPath` governs only hooks / ws / log (ADR-0005 §2). Empty `dbPath` /
+   * `port` resolve to the per-slug default / the MC yaml's port at boot.
+   */
+  mc: z.object({
+    enabled: z.boolean().default(false),
+    /** Optional MC yaml supplying hooks/ws/log settings. Empty → MC defaults. */
+    configPath: z.string().default(""),
+    /** Absolute (or leading-`~`) db path. Empty → per-slug default at boot. */
+    dbPath: z.string().default(""),
+    /** Listen port. 0 → fall back to the MC yaml's port (default 8767). */
+    port: z.number().int().nonnegative().default(0),
+  }).default(emptyDefault()).transform((val) => ({
+    // Same `emptyDefault()` quirk documented on the `cockpit` block below:
+    // `.default(emptyDefault())` returns `{}` literally rather than re-parsing
+    // the inner defaults, so the fields would be undefined. Re-apply the inner
+    // defaults so callers get the populated shape. The `??` chains are
+    // load-bearing (not redundant) for the all-defaults parse path.
+    /* eslint-disable @typescript-eslint/no-unnecessary-condition */
+    enabled: val.enabled ?? false,
+    configPath: val.configPath ?? "",
+    dbPath: val.dbPath ?? "",
+    port: val.port ?? 0,
+    /* eslint-enable @typescript-eslint/no-unnecessary-condition */
+  })),
+
   paths: z.object({
     publishedEventsDir: z.string().default("~/.claude/events/published"),
     logDir: z.string().default("~/.config/grove/logs"),

--- a/src/common/types/config.ts
+++ b/src/common/types/config.ts
@@ -540,7 +540,14 @@ export const AgentConfigSchema = z.object({
     enabled: z.boolean().default(false),
     /** Optional MC yaml supplying hooks/ws/log settings. Empty → MC defaults. */
     configPath: z.string().default(""),
-    /** Absolute (or leading-`~`) db path. Empty → per-slug default at boot. */
+    /**
+     * Absolute (or leading-`~`) db path. Empty → per-slug default at boot.
+     * ONE db per stack is required: the hook cursor lands beside the db
+     * (`mc-hook-cursor.json`), so two stacks pointed at the same explicit
+     * `dbPath` would share — and race — the cursor (and the db itself). The
+     * per-slug default keeps stacks isolated; only override with a path unique
+     * to this stack.
+     */
     dbPath: z.string().default(""),
     /** Listen port. 0 → fall back to the MC yaml's port (default 8767). */
     port: z.number().int().nonnegative().default(0),

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -2870,6 +2870,7 @@ export async function startCortex(
     const rendererStopNames = renderers.map((r) => `renderer ${r.id} stop`);
     const allSlots: string[] = [
       "config-watcher stop",
+      "cockpit refresh loop stop",
       "mc embed stop",
       "github webhook receiver stop",
       ...adapterCleanup.map((_, i) => `outbound poller stop[${i}]`),
@@ -2912,7 +2913,10 @@ export async function startCortex(
 
     const drain = async (): Promise<void> => {
       completeSync("config-watcher stop", () => configWatcher?.stop());
-      completeSync("cockpit refresh loop stop", () => cockpitLoop?.stop());
+      // Await the cockpit loop's stop BEFORE the embed's stop: stop() now awaits
+      // any in-flight refreshCockpit tick, so the bun:sqlite handle the embed
+      // closes is only released after the last tick settles (no use-after-close).
+      await completeAsync("cockpit refresh loop stop", cockpitLoop?.stop());
       await completeAsync("mc embed stop", mcHandle?.stop());
       completeSync("github webhook receiver stop", () => githubReceiver?.stop());
       for (let i = 0; i < adapterCleanup.length; i++) {

--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -20,23 +20,21 @@ import "./bootstrap/ws-transport";
 import { Command } from "commander";
 import { existsSync, writeFileSync, readFileSync, unlinkSync, mkdirSync, readdirSync } from "fs";
 import { basename, join, dirname, isAbsolute } from "path";
+import { homedir } from "os";
 import { parse as parseYaml } from "yaml";
 import type { TextChannel } from "discord.js";
 
 import { loadConfigWithAgents, loadAgentsDirectory, expandTilde, FragmentLoadError } from "./common/config/loader";
 import { ConfigWatcher } from "./common/config/watcher";
-import { type AgentConfig, getAllRepos } from "./common/types/config";
+import { type AgentConfig } from "./common/types/config";
 import { resolveSigningKnobs } from "./common/security-posture";
 import { buildHttpsMtlsMaterial } from "./common/config/transport-mtls";
-import { fetchWithTimeout } from "./common/timeout";
-import { UsageMonitor } from "./common/usage/monitor";
 import { AgentRegistry } from "./common/agents/registry";
 import { TrustResolver } from "./common/agents/trust-resolver";
 // cortex#79 — creds minting moved to `arc nats … --json` (shelled out from
 // `src/cli/cortex/commands/creds.ts`). No daemon-side RPC handler in
 // cortex; the account-signature verifier in TrustResolver keeps using
 // `loadAccountSigningKey` independently.
-import type { UsageStats } from "./runner/stream-parser";
 
 import { buildSecurityPreamble } from "./runner/security-preamble";
 import { DispatchHandler } from "./bus/dispatch-handler";
@@ -99,6 +97,8 @@ import { startGatewayIfEnabled } from "./gateway/start-gateway";
 // G-1113 ML.5 — cockpit live-refresh loop (opt-in via config.cockpit).
 import { refreshCockpit, defaultWorkItemSourceFor } from "./surface/mc/refresh";
 import { startCockpitRefreshLoop, type CockpitRefreshLoop } from "./surface/mc/refresh-loop";
+// MC-I1.S1 (ADR-0005) — in-process Mission Control embed (supersedes api.*).
+import { startMissionControl, type MissionControlHandle } from "./surface/mc/embed";
 import type { Database as BunDatabase } from "bun:sqlite";
 import { isGatewayEnabled } from "./gateway/gateway-bootstrap";
 import {
@@ -2657,15 +2657,34 @@ export async function startCortex(
     configWatcher.start();
   }
 
-  // Dashboard API + usage monitor (G-201 / G-206) — opt-in.
-  let dashboardApi: { stop?: () => void } | null = null;
-  let usageMonitor: UsageMonitor | null = null;
+  // MC-I1.S1 (ADR-0005): in-process Mission Control embed — opt-in via `config.mc.enabled`.
+  // The legacy `api.*` embedded-dashboard path (G-201) is retired: its dynamic
+  // import never migrated from grove-v2 (#712) and threw on every boot. When a
+  // config still sets `api.enabled`, warn once and direct the principal to `mc:`.
+  if (config.api.enabled) {
+    console.warn(
+      "cortex: `api.enabled` (the legacy embedded dashboard) is retired per ADR-0005 — " +
+        "it never migrated from grove-v2 (#712). Use the `mc:` config block instead.",
+    );
+  }
+  let mcHandle: MissionControlHandle | null = null;
   let mcDb: BunDatabase | null = null;
-  if (config.api.enabled && !options.disableDashboard) {
+  if (config.mc.enabled && !options.disableDashboard) {
+    // Per-slug default keeps each stack's MC db isolated; the cursor lands beside it.
+    const defaultDbPath = join(
+      homedir(), ".local", "share", "cortex", "mc", derivedStack.stack, "mission-control.db",
+    );
+    const dbPath = config.mc.dbPath !== "" ? expandTilde(config.mc.dbPath) : defaultDbPath;
     try {
-      ({ api: dashboardApi, usageMonitor, mcDb } = await setupDashboard(config, principalId, options.principal?.displayName, dispatchHandler, cloudPublisher));
+      mcHandle = await startMissionControl({
+        configPath: config.mc.configPath || undefined,
+        dbPath,
+        port: config.mc.port,
+      });
+      mcDb = mcHandle.db;
+      console.log(`cortex: Mission Control embed listening on http://localhost:${mcHandle.port} — db ${dbPath}`);
     } catch (err) {
-      console.error("cortex: dashboard API startup error (non-fatal):", err instanceof Error ? err.message : err);
+      console.error("cortex: Mission Control embed startup error (non-fatal):", err instanceof Error ? err.message : err);
     }
   }
 
@@ -2678,7 +2697,7 @@ export async function startCortex(
     const cockpitDb = mcDb;
     const [repoOwner, repoName] = config.cockpit.repo.split("/");
     const defaultRepo = repoOwner && repoName ? { owner: repoOwner, repo: repoName } : undefined;
-    const baseUrl = config.grove.baseUrl !== "" ? config.grove.baseUrl : `http://localhost:${config.api.port}`;
+    const baseUrl = config.grove.baseUrl !== "" ? config.grove.baseUrl : `http://localhost:${mcHandle?.port ?? 8767}`;
     // Resolve docsDir to an absolute path so the ingest doesn't depend on the
     // launchd plist's CWD (which isn't guaranteed to be the repo root). Warn
     // once at startup if it's missing rather than only failing every tick.
@@ -2704,7 +2723,7 @@ export async function startCortex(
     });
     console.log(`cortex: cockpit refresh loop started — every ${config.cockpit.refreshIntervalMs}ms, docs=${docsDir}`);
   } else if (config.cockpit.enabled && mcDb === null) {
-    console.warn(`cortex: cockpit.enabled but dashboard DB unavailable (api.enabled=${config.api.enabled}, disableDashboard=${!!options.disableDashboard}) — refresh loop not started`);
+    console.warn(`cortex: cockpit.enabled but Mission Control DB unavailable (mc.enabled=${config.mc.enabled}, disableDashboard=${!!options.disableDashboard}) — refresh loop not started`);
   }
 
   // MIG-5.6 (C-106): GitHub webhook receiver — opt-in via `github.receiver.enabled`
@@ -2851,8 +2870,7 @@ export async function startCortex(
     const rendererStopNames = renderers.map((r) => `renderer ${r.id} stop`);
     const allSlots: string[] = [
       "config-watcher stop",
-      "usage-monitor stop",
-      "dashboard stop",
+      "mc embed stop",
       "github webhook receiver stop",
       ...adapterCleanup.map((_, i) => `outbound poller stop[${i}]`),
       ...reviewConsumers.map((c, i) => `review-consumer stop[${i}] (agent=${c.agent.id})`),
@@ -2894,9 +2912,8 @@ export async function startCortex(
 
     const drain = async (): Promise<void> => {
       completeSync("config-watcher stop", () => configWatcher?.stop());
-      completeSync("usage-monitor stop", () => usageMonitor?.stop());
       completeSync("cockpit refresh loop stop", () => cockpitLoop?.stop());
-      completeSync("dashboard stop", () => dashboardApi?.stop?.());
+      await completeAsync("mc embed stop", mcHandle?.stop());
       completeSync("github webhook receiver stop", () => githubReceiver?.stop());
       for (let i = 0; i < adapterCleanup.length; i++) {
         const cleanup = adapterCleanup[i];
@@ -3016,19 +3033,6 @@ export async function startCortex(
 }
 
 /**
- * G-201 / G-206 dashboard wiring. Dynamic import: surface/mc uses bun-only
- * globals tsc can't see, so we keep this off the type-check path. Tests
- * pass `disableDashboard` and never enter here.
- *
- * The `await import("./surface/mc/api/index" as string)` deliberately
- * sidesteps TS module resolution to keep the bun-only surface out of
- * `tsc --noEmit`. Every downstream interaction with `DashboardApi` is
- * therefore `any`-typed at lint time, even though the runtime contract is
- * well-defined. Suppressing the unsafe-* family inside this function is
- * the boundary; production callers see the typed return signature.
- */
-/* eslint-disable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unnecessary-type-assertion */
-/**
  * cortex#338 — resolve the JetStreamManager-shaped provisioning
  * capability needed by the review-stream + per-agent durable boot
  * wiring. Returns `null` when the runtime is dormant (no NATS / connect
@@ -3059,76 +3063,6 @@ async function resolveReviewProvisioningJsm(
     return null;
   }
 }
-
-async function setupDashboard(
-  config: AgentConfig,
-  principalId: string,
-  principalDisplayName: string | undefined,
-  dispatchHandler: DispatchHandler,
-  cloudPublisher: CloudPublisher | null,
-): Promise<{ api: { stop?: () => void }; usageMonitor: UsageMonitor; mcDb: BunDatabase | null }> {
-  const { DashboardApi } = await import("./surface/mc/api/index" as string);
-  const dbPath = join(STATE_DIR, "dashboard.db");
-  const cortexRoot = join(dirname(import.meta.dir), ".");
-  const dashboardDir = join(cortexRoot, "dist", "dashboard");
-  const api = new DashboardApi({
-    port: config.api.port,
-    corsOrigin: config.api.corsOrigin,
-    dbPath,
-    github: { ...config.github, repos: getAllRepos(config) },
-    apiMode: config.api.mode,
-    // cortex#427 — dashboard reads the shared `principalId` so the
-    // principal-id column matches the `{principal}` segment of incoming
-    // envelopes. cortex#429 PR-C retired the legacy `agent.operatorName`
-    // field; the dashboard display name now flows in via
-    // `principalDisplayName` (sourced from
-    // `LoadedConfig.principal.displayName`) and falls back to
-    // `principalId` when the principal omitted the display name on
-    // cortex.yaml. R2.D renamed the options-bag keys to `principalId` /
-    // `principalName`; the underlying D1 column is already `principal_id`.
-    principalId: principalId,
-    principalName: principalDisplayName ?? principalId,
-    dashboardDir,
-  });
-  console.log(`cortex: dashboard DB at ${dbPath}`);
-
-  const publishedDir = config.paths.publishedEventsDir.replace(/^~/, process.env.HOME ?? "~");
-  const replayed = api.getState().rehydrate(publishedDir);
-  if (replayed > 0) console.log(`cortex: rehydrated dashboard with ${replayed} events from disk`);
-  api.start();
-
-  const cloudNetworks = config.networks.filter((n) => n.cloud);
-  if (cloudNetworks.length > 0) {
-    runStartupCloudSync(cloudNetworks, api).catch((err: unknown) => {
-      console.error("cortex: cloud sync error:", err instanceof Error ? err.message : String(err));
-    });
-  } else {
-    api.runStartupSync();
-  }
-  if (cloudPublisher) {
-    api.setCloudPublisher((event: unknown) => {
-      cloudPublisher.publish(event as never);
-    });
-  }
-
-  const usageMonitor = new UsageMonitor((usage, snapshot) => {
-    api.getState().setAccountUsage(usage);
-    api.getDb()?.insertUsageSnapshot(snapshot);
-    api.notifyStateChanged();
-  });
-  api.setUsageMonitor(usageMonitor);
-  usageMonitor.start();
-
-  dispatchHandler.on("session-usage", (sessionId: string, usage: UsageStats) => {
-    const changed = api.getState().updateSessionUsage(sessionId, usage);
-    if (changed) api.notifyStateChanged();
-  });
-  // ML.5 — expose the MC DB handle so the bot can run the cockpit refresh loop
-  // (it has `runtime.publish` in scope; the dashboard owns the DB).
-  const mcDb = (api.getDb() ?? null) as BunDatabase | null;
-  return { api, usageMonitor, mcDb };
-}
-/* eslint-enable @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unnecessary-type-assertion */
 
 /** Subscribe a Discord adapter to the published-events JSONL stream so legacy
  *  `#agent-log` and per-task worklog threads keep working. Mirrors grove-bot's
@@ -3226,45 +3160,6 @@ function setupOutboundLog(
       pollInterval = null;
     }
   };
-}
-
-/** G-204a + G-500: Issue startup `/api/sync` POST against each cloud-capable
- *  network; fall back to a local sync for any network that errors. */
-async function runStartupCloudSync(
-  cloudNetworks: AgentConfig["networks"],
-  api: { runStartupSync: () => unknown },
-): Promise<void> {
-  let anyFailed = false;
-  for (const network of cloudNetworks) {
-    if (!network.cloud) continue;
-    const { endpoint, apiKey, cfAccessClientId, cfAccessClientSecret } = network.cloud;
-    try {
-      const syncUrl = `${endpoint.replace(/\/+$/, "")}/api/sync`;
-      const headers: Record<string, string> = {
-        Authorization: `Bearer ${apiKey}`,
-        "Content-Type": "application/json",
-      };
-      if (cfAccessClientId && cfAccessClientSecret) {
-        headers["CF-Access-Client-Id"] = cfAccessClientId;
-        headers["CF-Access-Client-Secret"] = cfAccessClientSecret;
-      }
-      const res = await fetchWithTimeout("startup_sync", 15_000, syncUrl, {
-        method: "POST",
-        headers,
-      });
-      if (res.ok) {
-        const result = (await res.json()) as { repos?: number; issues?: number; prs?: number };
-        console.log(`cortex: cloud sync [${network.id}] — ${result.repos ?? 0} repo(s), ${result.issues ?? 0} issues, ${result.prs ?? 0} PRs`);
-      } else {
-        console.error(`cortex: cloud sync [${network.id}] failed: HTTP ${res.status}`);
-        anyFailed = true;
-      }
-    } catch (err) {
-      console.error(`cortex: cloud sync [${network.id}] error:`, err instanceof Error ? err.message : err);
-      anyFailed = true;
-    }
-  }
-  if (anyFailed) await api.runStartupSync();
 }
 
 // CLI

--- a/src/surface/mc/__tests__/embed.test.ts
+++ b/src/surface/mc/__tests__/embed.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdirSync, writeFileSync, rmSync, existsSync } from "fs";
+import { join, dirname } from "path";
+import { tmpdir } from "os";
+
+import { startMissionControl, type MissionControlHandle } from "../embed";
+
+/**
+ * MC-I1.S1 (ADR-0005) — in-process Mission Control embed.
+ *
+ * Hermetic: every path (db, cursor, hooks.rawEventsDir) is under a per-test tmp
+ * dir, and the server binds an OS-assigned port (port 0). No writes to
+ * ~/.config or ~/.local.
+ */
+describe("startMissionControl (embed)", () => {
+  let tmpDir: string;
+  let handle: MissionControlHandle | null;
+
+  beforeEach(() => {
+    tmpDir = join(
+      tmpdir(),
+      `mc-embed-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    );
+    mkdirSync(tmpDir, { recursive: true });
+    handle = null;
+  });
+
+  afterEach(async () => {
+    if (handle) await handle.stop();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  /** Write a minimal MC yaml that keeps the hook poller hermetic (tmp rawEventsDir). */
+  function writeMcYaml(): string {
+    const cfgPath = join(tmpDir, "mc.yaml");
+    const rawEventsDir = join(tmpDir, "events", "raw");
+    mkdirSync(rawEventsDir, { recursive: true });
+    writeFileSync(cfgPath, `hooks:\n  rawEventsDir: ${rawEventsDir}\n`);
+    return cfgPath;
+  }
+
+  it("boots, serves /health, and lands db + cursor beside each other", async () => {
+    const dbPath = join(tmpDir, "data", "mission-control.db");
+    handle = await startMissionControl({
+      configPath: writeMcYaml(),
+      dbPath,
+      port: 0, // OS-assigned free port — hermetic, no fixed-port collisions
+    });
+
+    // Bun.serve resolves port 0 to an assigned port; the handle exposes the real one.
+    expect(handle.port).toBeGreaterThan(0);
+
+    const res = await fetch(`http://127.0.0.1:${handle.port}/health`);
+    expect(res.ok).toBe(true);
+    const body = (await res.json()) as { status: string };
+    expect(body.status).toBe("ok");
+
+    // db lands at the requested path; the cursor lands BESIDE it (so per-stack
+    // DBs never share a hook cursor) — ADR-0005 §2.
+    expect(existsSync(dbPath)).toBe(true);
+    const cursorPath = join(dirname(dbPath), "mc-hook-cursor.json");
+    // The DB dir is the cursor's dir.
+    expect(dirname(cursorPath)).toBe(dirname(dbPath));
+
+    // The handle exposes the live db handle (the cockpit loop consumes it).
+    expect(handle.db).toBeDefined();
+    expect(() => handle!.db.query("SELECT 1").get()).not.toThrow();
+  });
+
+  it("releases the port on stop()", async () => {
+    handle = await startMissionControl({
+      configPath: writeMcYaml(),
+      dbPath: join(tmpDir, "data", "mission-control.db"),
+      port: 0,
+    });
+    const port = handle.port;
+
+    // Confirm it's live first.
+    expect((await fetch(`http://127.0.0.1:${port}/health`)).ok).toBe(true);
+
+    await handle.stop();
+    handle = null; // prevent afterEach double-stop
+
+    // After stop, the port is released — a connection is refused.
+    await expect(fetch(`http://127.0.0.1:${port}/health`)).rejects.toThrow();
+  });
+
+  it("port 0 falls back to the MC yaml's port when not overridden", async () => {
+    // The MC yaml's own port (here an OS-assigned 0) governs when opts.port is 0.
+    const cfgPath = join(tmpDir, "mc.yaml");
+    const rawEventsDir = join(tmpDir, "events", "raw");
+    mkdirSync(rawEventsDir, { recursive: true });
+    writeFileSync(cfgPath, `port: 0\nhooks:\n  rawEventsDir: ${rawEventsDir}\n`);
+
+    handle = await startMissionControl({
+      configPath: cfgPath,
+      dbPath: join(tmpDir, "data", "mission-control.db"),
+      // port omitted → falls back to the yaml's port
+    });
+    expect(handle.port).toBeGreaterThan(0);
+    expect((await fetch(`http://127.0.0.1:${handle.port}/health`)).ok).toBe(true);
+  });
+});

--- a/src/surface/mc/__tests__/embed.test.ts
+++ b/src/surface/mc/__tests__/embed.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { Database } from "bun:sqlite";
 import { mkdirSync, writeFileSync, rmSync, existsSync } from "fs";
 import { join, dirname } from "path";
 import { tmpdir } from "os";
@@ -99,5 +100,35 @@ describe("startMissionControl (embed)", () => {
     });
     expect(handle.port).toBeGreaterThan(0);
     expect((await fetch(`http://127.0.0.1:${handle.port}/health`)).ok).toBe(true);
+  });
+
+  it("rejects on a busy port AND releases the db handle (no partial-boot leak)", async () => {
+    // Occupy a port on loopback so startServer's bind fails (EADDRINUSE).
+    const blocker = Bun.serve({ port: 0, hostname: "127.0.0.1", fetch: () => new Response("blocker") });
+    const busyPort = blocker.port;
+    try {
+      const dbPath = join(tmpDir, "data", "mission-control.db");
+      await expect(
+        startMissionControl({ configPath: writeMcYaml(), dbPath, port: busyPort }),
+      ).rejects.toThrow();
+      handle = null; // startMissionControl rejected → nothing to stop in afterEach
+
+      // The db opened during the failed boot must have been closed: the file
+      // exists (initDatabase created it) but no handle is left on it — we can
+      // reopen it and delete it cleanly.
+      expect(existsSync(dbPath)).toBe(true);
+      const reopened = new Database(dbPath, { readwrite: true });
+      expect(() => reopened.query("PRAGMA user_version").get()).not.toThrow();
+      reopened.close();
+      expect(() => rmSync(dbPath, { force: true })).not.toThrow();
+      expect(existsSync(dbPath)).toBe(false);
+
+      // No listener was left behind on the busy port other than the blocker —
+      // it's still the blocker answering, not a leaked MC server.
+      const res = await fetch(`http://127.0.0.1:${busyPort}/`);
+      expect(await res.text()).toBe("blocker");
+    } finally {
+      blocker.stop(true);
+    }
   });
 });

--- a/src/surface/mc/__tests__/refresh-loop.test.ts
+++ b/src/surface/mc/__tests__/refresh-loop.test.ts
@@ -56,12 +56,61 @@ describe("startCockpitRefreshLoop (ML.5)", () => {
     expect((errors[0] as Error).message).toBe("boom 1");
   });
 
-  it("stop() cancels the schedule and is idempotent", () => {
+  it("stop() cancels the schedule and is idempotent", async () => {
     const s = fakeScheduler();
     const loop = startCockpitRefreshLoop({ run: async () => {}, intervalMs: 1000, runOnStart: false, schedule: s.schedule });
     expect(s.cancelled).toBe(false);
-    loop.stop();
+    await loop.stop();
     expect(s.cancelled).toBe(true);
-    loop.stop(); // idempotent — no throw
+    await loop.stop(); // idempotent — no throw
+  });
+
+  it("stop() awaits an in-flight tick before resolving", async () => {
+    const s = fakeScheduler();
+    let settled = false;
+    let release!: () => void;
+    const gate = new Promise<void>((r) => { release = r; });
+    const loop = startCockpitRefreshLoop({
+      // A run parked on `gate` — mirrors refreshCockpit awaiting ingest/publish.
+      run: async () => { await gate; settled = true; },
+      intervalMs: 1000,
+      runOnStart: true,
+      schedule: s.schedule,
+    });
+    await flush(); // let the runOnStart tick reach its await
+
+    const stopPromise = loop.stop(); // must NOT resolve while the run is parked
+    let stopResolved = false;
+    void stopPromise.then(() => { stopResolved = true; });
+    await flush();
+    expect(s.cancelled).toBe(true); // schedule cleared immediately
+    expect(stopResolved).toBe(false); // but stop is still waiting on the run
+    expect(settled).toBe(false);
+
+    release(); // let the parked run finish
+    await stopPromise; // stop now resolves
+    expect(settled).toBe(true);
+    expect(stopResolved).toBe(true);
+  });
+
+  it("stop() still resolves when the in-flight tick rejects (error isolation)", async () => {
+    const s = fakeScheduler();
+    const errors: unknown[] = [];
+    let release!: () => void;
+    const gate = new Promise<void>((r) => { release = r; });
+    const loop = startCockpitRefreshLoop({
+      run: async () => { await gate; throw new Error("tick boom"); },
+      intervalMs: 1000,
+      runOnStart: true,
+      onError: (e) => errors.push(e),
+      schedule: s.schedule,
+    });
+    await flush();
+
+    const stopPromise = loop.stop();
+    release();
+    await stopPromise; // resolves (does not reject) despite the run throwing
+    expect(errors).toHaveLength(1);
+    expect((errors[0] as Error).message).toBe("tick boom");
   });
 });

--- a/src/surface/mc/embed.ts
+++ b/src/surface/mc/embed.ts
@@ -1,0 +1,88 @@
+/**
+ * MC-I1.S1 (ADR-0005) — in-process Mission Control embed.
+ *
+ * Boots the Mission Control v3 server inside the cortex daemon process,
+ * mirroring the standalone entrypoint's composition (`src/surface/mc/index.ts`)
+ * exactly: loadConfig → initDatabase → ProcessManager → startServer →
+ * HookStreamPoller.start(). `stop()` reverses index.ts's shutdown ordering.
+ *
+ * Embedded mode deliberately OVERRIDES `db.path`, `hooks.cursorPath`, and
+ * `port`: cortex owns the per-stack db location and listen port, so the MC
+ * yaml at `configPath` governs only hooks / ws / log (ADR-0005 §2). The cursor
+ * lives beside the db so per-stack DBs never share a hook cursor.
+ */
+
+import type { Database } from "bun:sqlite";
+import { dirname, join } from "path";
+
+import { loadConfig } from "./config";
+import { initDatabase } from "./db/init";
+import { startServer } from "./server";
+import { ProcessManager } from "./session/process-manager";
+import { HookStreamPoller } from "./hooks/poller";
+import type { Config } from "./types";
+
+export interface MissionControlHandle {
+  db: Database;
+  port: number;
+  stop(): Promise<void>;
+}
+
+export interface StartMissionControlOptions {
+  /** Optional MC yaml supplying hooks / ws / log settings. Empty/undefined → MC defaults. */
+  configPath?: string;
+  /** Absolute db path. cortex owns this; the cursor lands beside it. */
+  dbPath: string;
+  /** Listen port. `> 0` overrides the MC yaml's port; otherwise the yaml's port (default 8767) wins. */
+  port?: number;
+}
+
+/**
+ * Boot the in-process Mission Control server. Returns a handle exposing the
+ * bun:sqlite db (the cockpit refresh loop needs it), the effective listen port,
+ * and an async `stop()`.
+ */
+// The composition (loadConfig → initDatabase → startServer) is synchronous;
+// `async` is the public contract (callers `await startMissionControl(...)` and
+// the returned handle's `stop()` is async). require-await has nothing to flag.
+// eslint-disable-next-line @typescript-eslint/require-await
+export async function startMissionControl(
+  opts: StartMissionControlOptions,
+): Promise<MissionControlHandle> {
+  // `||` (not `??`) is intentional: an empty `configPath` must collapse to
+  // `undefined` so loadConfig uses its own default-path lookup, not `""`.
+  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+  const loaded = loadConfig(opts.configPath || undefined);
+
+  // cortex owns db + cursor + port; the MC yaml governs hooks/ws/log only.
+  const config: Config = {
+    ...loaded,
+    port: opts.port && opts.port > 0 ? opts.port : loaded.port,
+    db: { path: opts.dbPath },
+    hooks: {
+      ...loaded.hooks,
+      cursorPath: join(dirname(opts.dbPath), "mc-hook-cursor.json"),
+    },
+  };
+
+  const db = initDatabase(config.db.path);
+  const processManager = new ProcessManager();
+  const serverCtx = startServer(config, db, { processManager });
+  const { server, wsRegistry } = serverCtx;
+  const hookPoller = new HookStreamPoller(db, config.hooks, wsRegistry);
+
+  hookPoller.start();
+
+  const stop = async (): Promise<void> => {
+    hookPoller.stop();
+    await processManager.closeAll();
+    serverCtx.stop(true);
+    db.close();
+  };
+
+  // The ACTUAL bound port — when `config.port` is 0, Bun.serve assigns one;
+  // callers (the cockpit refresh loop's baseUrl) need the real listen port.
+  // Bun.serve guarantees a numeric `port` once started; the `?? config.port`
+  // coalesce only satisfies the optional type on `Server.port`.
+  return { db, port: server.port ?? config.port, stop };
+}

--- a/src/surface/mc/embed.ts
+++ b/src/surface/mc/embed.ts
@@ -31,7 +31,11 @@ export interface MissionControlHandle {
 export interface StartMissionControlOptions {
   /** Optional MC yaml supplying hooks / ws / log settings. Empty/undefined → MC defaults. */
   configPath?: string;
-  /** Absolute db path. cortex owns this; the cursor lands beside it. */
+  /**
+   * Absolute db path. cortex owns this; the hook cursor lands beside it
+   * (`mc-hook-cursor.json`). ONE db per stack is required — two stacks sharing
+   * an explicit `dbPath` would share (and race) both the cursor and the db.
+   */
   dbPath: string;
   /** Listen port. `> 0` overrides the MC yaml's port; otherwise the yaml's port (default 8767) wins. */
   port?: number;
@@ -65,24 +69,40 @@ export async function startMissionControl(
     },
   };
 
+  // Build incrementally so a partial-boot failure tears down exactly what was
+  // acquired, in reverse. The embedding daemon's catch is non-fatal (unlike the
+  // standalone index.ts, which process.exit(1)s and lets the OS reclaim), so an
+  // unhandled throw here would otherwise leak the db handle — and the bound
+  // socket — for the whole daemon lifetime (e.g. EADDRINUSE on a busy fixed port).
   const db = initDatabase(config.db.path);
-  const processManager = new ProcessManager();
-  const serverCtx = startServer(config, db, { processManager });
-  const { server, wsRegistry } = serverCtx;
-  const hookPoller = new HookStreamPoller(db, config.hooks, wsRegistry);
+  let serverCtx: ReturnType<typeof startServer> | null = null;
+  let hookPoller: HookStreamPoller | null = null;
+  try {
+    const processManager = new ProcessManager();
+    serverCtx = startServer(config, db, { processManager });
+    const { server, wsRegistry } = serverCtx;
+    hookPoller = new HookStreamPoller(db, config.hooks, wsRegistry);
+    hookPoller.start();
 
-  hookPoller.start();
+    const startedPoller = hookPoller;
+    const boundCtx = serverCtx;
+    const stop = async (): Promise<void> => {
+      startedPoller.stop();
+      await processManager.closeAll();
+      boundCtx.stop(true);
+      db.close();
+    };
 
-  const stop = async (): Promise<void> => {
-    hookPoller.stop();
-    await processManager.closeAll();
-    serverCtx.stop(true);
+    // The ACTUAL bound port — when `config.port` is 0, Bun.serve assigns one;
+    // callers (the cockpit refresh loop's baseUrl) need the real listen port.
+    // Bun.serve guarantees a numeric `port` once started; the `?? config.port`
+    // coalesce only satisfies the optional type on `Server.port`.
+    return { db, port: server.port ?? config.port, stop };
+  } catch (err) {
+    // Reverse-order teardown of whatever was constructed before the throw.
+    hookPoller?.stop();
+    serverCtx?.stop(true);
     db.close();
-  };
-
-  // The ACTUAL bound port — when `config.port` is 0, Bun.serve assigns one;
-  // callers (the cockpit refresh loop's baseUrl) need the real listen port.
-  // Bun.serve guarantees a numeric `port` once started; the `?? config.port`
-  // coalesce only satisfies the optional type on `Server.port`.
-  return { db, port: server.port ?? config.port, stop };
+    throw err;
+  }
 }

--- a/src/surface/mc/refresh-loop.ts
+++ b/src/surface/mc/refresh-loop.ts
@@ -25,8 +25,13 @@ export interface CockpitRefreshLoopOptions {
 }
 
 export interface CockpitRefreshLoop {
-  /** Stop the loop (idempotent). */
-  stop: () => void;
+  /**
+   * Stop the loop (idempotent). Clears the schedule, then awaits any in-flight
+   * tick so a parked `run()` settles before callers tear down shared resources
+   * the run touches (e.g. closing the bun:sqlite handle in cortex.ts's drain).
+   * A tick that rejects still releases the await (error isolation preserved).
+   */
+  stop: () => Promise<void>;
 }
 
 const defaultSchedule = (fn: () => void, ms: number): (() => void) => {
@@ -45,12 +50,26 @@ export function startCockpitRefreshLoop(opts: CockpitRefreshLoopOptions): Cockpi
         `[cockpit-refresh-loop] refresh failed: ${err instanceof Error ? err.message : String(err)}\n`
       ));
 
-  // Each tick is fire-and-forget + self-isolating: a rejected run routes to
-  // onError, never escaping the timer callback.
+  // The currently-running tick, tracked so `stop()` can await an in-flight run
+  // before shared resources (the bun:sqlite handle) are torn down. `null`
+  // between ticks. The tracked promise is the error-isolated one, so awaiting it
+  // in stop() never rejects.
+  let inFlight: Promise<void> | null = null;
+
+  // Each tick is self-isolating: a rejected run routes to onError, never
+  // escaping. The isolated promise is recorded so stop() can join it, and
+  // cleared on settle so we never await a stale run.
   const tick = (): void => {
-    void Promise.resolve()
+    const run = Promise.resolve()
       .then(() => opts.run())
-      .catch(onError);
+      .then(
+        () => undefined,
+        (err: unknown) => { onError(err); },
+      )
+      .finally(() => {
+        if (inFlight === run) inFlight = null;
+      });
+    inFlight = run;
   };
 
   if (opts.runOnStart !== false) tick();
@@ -58,10 +77,14 @@ export function startCockpitRefreshLoop(opts: CockpitRefreshLoopOptions): Cockpi
 
   let stopped = false;
   return {
-    stop: () => {
+    stop: async () => {
       if (stopped) return;
       stopped = true;
       cancel();
+      // Await the in-flight tick (if any) so a parked run settles before the
+      // caller closes resources it touches. The tracked promise is already
+      // error-isolated — it resolves on both success and failure.
+      if (inFlight) await inFlight;
     },
   };
 }


### PR DESCRIPTION
## What

Phase 0 / slice **S1** of the Mission Control pane-of-glass iteration (umbrella **#843**), implementing **ADR-0005**'s in-process-embed + retire-the-legacy-lift decision.

- **`mc:` config block** on `AgentConfigSchema` (`enabled` / `configPath` / `dbPath` / `port`), built with the documented `emptyDefault()` + `.transform(...)` idiom (the `cockpit:` block's pattern) so the all-defaults parse path stays populated — the same quirk that broke 34 startCortex tests once.
- **`src/surface/mc/embed.ts`** — `startMissionControl()` mirrors the standalone `src/surface/mc/index.ts` composition exactly: `loadConfig → initDatabase → ProcessManager → startServer → HookStreamPoller.start()`; `stop()` reverses index.ts's shutdown ordering (`hookPoller.stop` → `await processManager.closeAll()` → `serverCtx.stop(true)` → `db.close()`). Embedded mode deliberately **overrides db + cursor + port** (ADR-0005 §2); the MC yaml at `configPath` governs hooks / ws / log only. The hook cursor lands **beside** the db so per-stack DBs never share a cursor.
- **`cortex.ts`** — boots the embed when `config.mc.enabled && !disableDashboard` (non-fatal try/catch, same posture as before). Per-slug default db at `~/.local/share/cortex/mc/<stack>/mission-control.db` (`derivedStack.stack`); a leading `~` in `mc.dbPath` is expanded. The cockpit refresh loop's `baseUrl` fallback now reads the embed handle's **actual** listen port (falling back to `8767` when MC is disabled).
- **`docs/iteration-mission-control-pane-of-glass.md`** — new; mirrors umbrella #843 (goal, ADR links, Phase 0–2 scope, the 7-slice PR-plan table, out-of-scope note).

## Why

Per the pane-of-glass survey (ADR-0005), `setupDashboard()` dynamically imports `./surface/mc/api/index` — a grove-v2 class **that was never lifted** into cortex. The `as string` cast hides the missing module from tsc, so the import throws on every boot where `api.enabled: true` and is swallowed by a non-fatal catch: the embedded dashboard has been dead code on every install (#712). ADR-0005 retires that path and runs the MC v3 server **in-process** behind the new `mc:` block instead.

### Behavior change — `api.*` deprecation

`api.enabled: true` no longer attempts the (broken) embedded dashboard. Instead cortex **warns once** that the legacy embedded dashboard is retired per ADR-0005 and directs the principal to `mc:`. The `api:` **schema block stays** (back-compat reader; `buildLegacyNetwork` still consumes its cloud fields). Deleted: `setupDashboard`, `runStartupCloudSync` (only caller was setupDashboard), the dead `as string` import, the `dashboardApi` / `usageMonitor` locals + their shutdown slots + the `session-usage` wiring, and the now-orphaned imports (`UsageMonitor`, `UsageStats`, `fetchWithTimeout`, `getAllRepos`) and the eslint-disable banner that wrapped the dynamic import. `CloudPublisher` instantiation is untouched — only its dead call site inside setupDashboard went (Phase 3 / ADR-0006 re-homes it).

### Per-slug default path

`~/.local/share/cortex/mc/<stack>/mission-control.db`, with `mc-hook-cursor.json` beside it — each stack's MC db (and its hook cursor) stays isolated.

## Test plan

All gates run green at the final state:

| Gate | Result |
|---|---|
| `bun run lint` (`lint:errors`, blocking) | **pass** — 0 errors (my files: 0 warnings) |
| `bunx tsc --noEmit` | **pass** — 0 errors |
| `bun test` (full suite) | **5186 pass, 2 skip, 0 fail** (295 files) |
| `scripts/check-carveouts.sh` (changed files) | **PASS** — no ungated deprecated-term violations |

New tests:
- **config** (`cortex-config.test.ts`): absent `mc` block → `enabled false`, all fields populated by the transform; empty `{}` → same; explicit values honored; partial fills the rest; `port` rejects negative / non-integer.
- **embed** (`surface/mc/__tests__/embed.test.ts`): boots against a tmp-dir dbPath on an OS-assigned port (port 0), asserts `/health` ok, db + cursor land beside each other in the tmp dir, the live db handle is queryable; `stop()` releases the port; port-0 falls back to the MC yaml's port. Fully hermetic (no `~/.config` / `~/.local` writes).

## Flagged interpretations

- **Embed handle's `port` is the ACTUAL bound port** (`serverCtx.server.port`), not the requested config port — when `mc.port: 0`, Bun.serve assigns one, and the cockpit loop's `baseUrl` needs the real value. The `?? config.port` coalesce only satisfies the optional type on `Server.port` (Bun guarantees it numeric once started).
- ADR-0005/0006 files (`docs/adr/0005-…`, `0006-…`) land with PR #842, not yet merged at the time of this PR — the iteration doc references them by path **and** by PR #842 (same forward-reference the umbrella uses).

Part of #843
Closes #712

🤖 Generated with [Claude Code](https://claude.com/claude-code)