### PR TITLE
feat(mc): MC-I1.S5 — ingestor auto-registers orphan observed sessions

### DIFF
--- a/src/surface/mc/__tests__/ingestor.test.ts
+++ b/src/surface/mc/__tests__/ingestor.test.ts
@@ -72,28 +72,57 @@ describe("ingestEvents", () => {
     expect(rows[1].type).toBe("assistant.message");
   });
 
-  it("skips events from unregistered sessions", () => {
+  // MC-I1.S5 (ADR-0005 §3) — the old "drop events for unregistered sessions"
+  // contract is replaced by orphan auto-registration. An unknown
+  // cc_session_id now creates a `local.observed` orphan session and ingests
+  // its events instead of dropping them.
+  it("auto-registers an orphan session for an unknown cc_session_id and ingests its events", () => {
     const events = [
       makeRawEvent("e-1", "unknown-session-xyz"),
     ];
 
     const result = ingestEvents(db, events);
-    expect(result.count).toBe(0);
-    expect(result.events).toHaveLength(0);
+    // `result.count` is the number of INGESTED hook events (1). The F-20
+    // dispatched → running auto-transition additionally writes a
+    // `state.transition` event into the DB, but that's not counted as an
+    // ingested hook event.
+    expect(result.count).toBe(1);
+    expect(result.events).toHaveLength(1);
 
-    const rows = db.query("SELECT * FROM events").all();
-    expect(rows).toHaveLength(0);
+    // An orphan session row now exists for the unknown cc_session_id, and it's
+    // observed (distinguishable from controlled dispatch sessions).
+    const orphanSession = db
+      .query(
+        `SELECT id, endpoint_kind FROM sessions WHERE cc_session_id = 'unknown-session-xyz'`
+      )
+      .get() as { id: string; endpoint_kind: string } | null;
+    expect(orphanSession).not.toBeNull();
+    expect(orphanSession!.endpoint_kind).toBe("local.observed");
+
+    // The hook event landed against the orphan session (filter out the
+    // F-20 state.transition the auto-start writes — the hook event's type is
+    // the default `test.event` from makeRawEvent).
+    const rows = db
+      .query("SELECT * FROM events WHERE session_id = ? AND type = 'test.event'")
+      .all(orphanSession!.id);
+    expect(rows).toHaveLength(1);
   });
 
-  it("handles mixed registered and unregistered sessions", () => {
+  it("handles mixed registered and unregistered sessions (orphan auto-registered)", () => {
     const events = [
-      makeRawEvent("e-1", "cc-session-abc"),   // matched
-      makeRawEvent("e-2", "unknown-session"),   // not matched
-      makeRawEvent("e-3", "cc-session-abc"),   // matched
+      makeRawEvent("e-1", "cc-session-abc"),   // matched (registered)
+      makeRawEvent("e-2", "unknown-session"),   // orphan auto-registered
+      makeRawEvent("e-3", "cc-session-abc"),   // matched (registered)
     ];
 
     const result = ingestEvents(db, events);
-    expect(result.count).toBe(2);
+    // 2 registered + 1 orphan = all 3 ingested now (none dropped).
+    expect(result.count).toBe(3);
+
+    const orphan = db
+      .query(`SELECT id FROM sessions WHERE cc_session_id = 'unknown-session'`)
+      .get();
+    expect(orphan).not.toBeNull();
   });
 
   it("returns 0 for empty events array", () => {
@@ -130,7 +159,9 @@ describe("ingestEvents", () => {
     expect(rows).toHaveLength(1);
   });
 
-  it("logs unregistered session drops to stderr", () => {
+  // MC-I1.S5 — observability: one stderr line per orphan auto-register, NOT
+  // per event, and the line names the cc_session_id.
+  it("logs a single orphan auto-register line to stderr (once, not per event)", () => {
     const written: string[] = [];
     const origWrite = process.stderr.write;
     process.stderr.write = (chunk: string) => {
@@ -139,12 +170,20 @@ describe("ingestEvents", () => {
     };
 
     try {
-      const events = [makeRawEvent("e-1", "totally-unknown-session")];
+      // Three events for the SAME unknown session — registration happens once.
+      const events = [
+        makeRawEvent("e-1", "totally-unknown-session"),
+        makeRawEvent("e-2", "totally-unknown-session"),
+        makeRawEvent("e-3", "totally-unknown-session"),
+      ];
       const result = ingestEvents(db, events);
 
-      expect(result.count).toBe(0);
-      expect(written.some((s) => s.includes("unregistered session"))).toBe(true);
-      expect(written.some((s) => s.includes("totally-unknown-session"))).toBe(true);
+      expect(result.count).toBe(3);
+      const autoRegLines = written.filter((s) =>
+        s.includes("auto-registered orphan")
+      );
+      expect(autoRegLines).toHaveLength(1);
+      expect(autoRegLines[0]).toContain("totally-unknown-session");
     } finally {
       process.stderr.write = origWrite;
     }
@@ -232,5 +271,165 @@ describe("ingestEvents", () => {
       .query("SELECT state FROM agent_task_assignment WHERE id = 'ata-ctrl'")
       .get() as { state: string };
     expect(row.state).toBe("dispatched");
+  });
+
+  // ==========================================================================
+  // MC-I1.S5 (ADR-0005 §3) — orphan observed-session auto-registration.
+  // ==========================================================================
+
+  it("creates the orphan session exactly once across two ingest batches (dedupe)", () => {
+    // First batch — auto-registers.
+    ingestEvents(db, [makeRawEvent("e-1", "orphan-dedupe", "tool.bash")]);
+    // Second batch, same cc_session_id — must NOT create a second session.
+    ingestEvents(db, [makeRawEvent("e-2", "orphan-dedupe", "tool.bash")]);
+
+    const sessions = db
+      .query(`SELECT id FROM sessions WHERE cc_session_id = 'orphan-dedupe'`)
+      .all();
+    expect(sessions).toHaveLength(1);
+
+    // Both HOOK events landed against the single orphan session. (The first
+    // batch also wrote one F-20 `state.transition` event for the
+    // dispatched → running auto-start; filter to the hook events.)
+    const events = db
+      .query(
+        `SELECT e.id FROM events e
+         JOIN sessions s ON s.id = e.session_id
+         WHERE s.cc_session_id = 'orphan-dedupe' AND e.type = 'tool.bash'`
+      )
+      .all();
+    expect(events).toHaveLength(2);
+
+    // And exactly one assignment / one agent for it.
+    const sessionRow = db
+      .query(
+        `SELECT assignment_id FROM sessions WHERE cc_session_id = 'orphan-dedupe'`
+      )
+      .get() as { assignment_id: string };
+    const assignments = db
+      .query(`SELECT id FROM agent_task_assignment WHERE id = ?`)
+      .all(sessionRow.assignment_id);
+    expect(assignments).toHaveLength(1);
+  });
+
+  it("captures agent_name from the raw event onto the orphan agent display name", () => {
+    const ev = makeRawEvent("e-1", "orphan-named", "tool.bash");
+    ev.agent_name = "Andreas";
+    ingestEvents(db, [ev]);
+
+    const agent = db
+      .query(
+        `SELECT ag.name AS name
+         FROM agents ag
+         JOIN agent_task_assignment a ON a.agent_id = ag.id
+         JOIN sessions s ON s.assignment_id = a.id
+         WHERE s.cc_session_id = 'orphan-named'`
+      )
+      .get() as { name: string } | null;
+    expect(agent).not.toBeNull();
+    expect(agent!.name).toBe("Andreas");
+  });
+
+  it("falls back to the cc_session_id as the orphan agent name when agent_name is absent", () => {
+    const ev = makeRawEvent("e-1", "orphan-nameless", "tool.bash");
+    delete (ev as { agent_name?: string }).agent_name;
+    ingestEvents(db, [ev]);
+
+    const agent = db
+      .query(
+        `SELECT ag.name AS name
+         FROM agents ag
+         JOIN agent_task_assignment a ON a.agent_id = ag.id
+         JOIN sessions s ON s.assignment_id = a.id
+         WHERE s.cc_session_id = 'orphan-nameless'`
+      )
+      .get() as { name: string } | null;
+    expect(agent).not.toBeNull();
+    expect(agent!.name).toBe("orphan-nameless");
+  });
+
+  it("orphan assignment is born 'dispatched' and auto-transitions to 'running' on first event", () => {
+    ingestEvents(db, [makeRawEvent("e-1", "orphan-running", "tool.bash")]);
+
+    const row = db
+      .query(
+        `SELECT a.state AS state
+         FROM agent_task_assignment a
+         JOIN sessions s ON s.assignment_id = a.id
+         WHERE s.cc_session_id = 'orphan-running'`
+      )
+      .get() as { state: string };
+    // F-20 auto-transition runs against the orphan exactly like any observed
+    // session: dispatched → running on the first ingested event.
+    expect(row.state).toBe("running");
+  });
+
+  it("orphan session auto-transitions running → completed on a Stop event in a later batch", () => {
+    ingestEvents(db, [makeRawEvent("e-1", "orphan-complete", "tool.bash")]); // → running
+    ingestEvents(db, [makeRawEvent("e-2", "orphan-complete", "Stop")]); // → completed
+
+    const row = db
+      .query(
+        `SELECT a.state AS state
+         FROM agent_task_assignment a
+         JOIN sessions s ON s.assignment_id = a.id
+         WHERE s.cc_session_id = 'orphan-complete'`
+      )
+      .get() as { state: string };
+    expect(row.state).toBe("completed");
+  });
+
+  it("orphan sessions are queryable through the assignment-anchored joins (the storage-shape edge)", () => {
+    // This is the blast-radius assertion: orphans must surface through the
+    // SAME assignment→session LEFT JOIN the dashboard list endpoints use. If
+    // we had relaxed assignment_id to NULL with no assignment row, this join
+    // would yield zero rows and the orphan would be invisible.
+    ingestEvents(db, [makeRawEvent("e-1", "orphan-visible", "tool.bash")]);
+
+    const joined = db
+      .query(
+        `SELECT a.id AS assignment_id, a.state AS state,
+                s.endpoint_kind AS endpoint_kind, t.id AS task_id, ag.id AS agent_id
+         FROM agent_task_assignment a
+         JOIN tasks t ON t.id = a.task_id
+         JOIN agents ag ON ag.id = a.agent_id
+         LEFT JOIN sessions s ON s.id = (
+           SELECT id FROM sessions
+           WHERE assignment_id = a.id
+           ORDER BY started_at DESC, id DESC
+           LIMIT 1
+         )
+         WHERE s.cc_session_id = 'orphan-visible'`
+      )
+      .get() as
+      | {
+          assignment_id: string;
+          state: string;
+          endpoint_kind: string;
+          task_id: string;
+          agent_id: string;
+        }
+      | null;
+    expect(joined).not.toBeNull();
+    expect(joined!.endpoint_kind).toBe("local.observed");
+    // Distinguishable: the orphan agent carries the mc-orphan- prefix.
+    expect(joined!.agent_id.startsWith("mc-orphan-")).toBe(true);
+  });
+
+  it("does not duplicate the orphan task across multiple distinct orphan sessions", () => {
+    ingestEvents(db, [makeRawEvent("e-1", "orphan-a", "tool.bash")]);
+    ingestEvents(db, [makeRawEvent("e-2", "orphan-b", "tool.bash")]);
+
+    // Two distinct orphan sessions → two agents + two assignments …
+    const agents = db
+      .query(`SELECT id FROM agents WHERE id LIKE 'mc-orphan-%'`)
+      .all();
+    expect(agents.length).toBeGreaterThanOrEqual(2);
+
+    // … but they share the SINGLE catch-all orphan task.
+    const tasks = db
+      .query(`SELECT id FROM tasks WHERE id = 'mc-orphan-task'`)
+      .all();
+    expect(tasks).toHaveLength(1);
   });
 });

--- a/src/surface/mc/__tests__/poller.test.ts
+++ b/src/surface/mc/__tests__/poller.test.ts
@@ -97,14 +97,28 @@ describe("HookStreamPoller", () => {
     expect(count).toBe(0);
   });
 
-  it("skips unregistered sessions", () => {
+  // MC-I1.S5 (ADR-0005 §3) — unregistered sessions are no longer dropped;
+  // they are auto-registered as orphan `local.observed` sessions and their
+  // events ingested. (`count` reflects the ingested hook event; the F-20
+  // dispatched → running auto-transition writes an additional state.transition
+  // event into the DB but is not counted in `count`.)
+  it("auto-registers an orphan for an unregistered session and ingests its event", () => {
     const file = join(rawDir, "unknown-session.jsonl");
     writeFileSync(file, JSON.stringify(makeEvent("e-1", "unknown-session")) + "\n");
 
     const poller = new HookStreamPoller(db, config);
     const count = poller.poll();
 
-    expect(count).toBe(0);
+    expect(count).toBe(1);
+
+    // The orphan session row now exists and is observed.
+    const orphan = db
+      .query(
+        `SELECT endpoint_kind FROM sessions WHERE cc_session_id = 'unknown-session'`
+      )
+      .get() as { endpoint_kind: string } | null;
+    expect(orphan).not.toBeNull();
+    expect(orphan!.endpoint_kind).toBe("local.observed");
   });
 
   it("reads incrementally across multiple polls", () => {
@@ -177,17 +191,23 @@ describe("HookStreamPoller", () => {
   });
 
   it("persists cursor even when no events are ingested (offset-advance case)", () => {
-    // Write events for an UNREGISTERED session — reader advances offsets
-    // but ingestor ingests 0 events.
-    const file = join(rawDir, "some-unknown-session.jsonl");
-    writeFileSync(
-      file,
-      JSON.stringify(makeEvent("e-1", "totally-unknown-session")) + "\n"
-    );
+    // MC-I1.S5 — unregistered sessions now auto-register, so the genuine
+    // "0 events ingested but reader advanced offsets" case is a file whose only
+    // line is malformed JSON: JsonlTailReader skips it (0 parsed events) but
+    // still advances the byte offset. The cursor must persist that advance so
+    // the bad line isn't re-scanned on restart.
+    const file = join(rawDir, "malformed-only.jsonl");
+    writeFileSync(file, "{ this is not valid json\n");
 
     const poller = new HookStreamPoller(db, config);
     const count = poller.poll();
     expect(count).toBe(0);
+
+    // No event ingested, no orphan session created (the line never parsed).
+    const sessions = db.query("SELECT COUNT(*) AS c FROM events").get() as {
+      c: number;
+    };
+    expect(sessions.c).toBe(0);
 
     // Cursor should STILL be persisted so the offset advance survives restart.
     // Previously this was gated by `totalIngested > 0` which lost the advance.

--- a/src/surface/mc/db/sessions.ts
+++ b/src/surface/mc/db/sessions.ts
@@ -195,3 +195,153 @@ export function createShadowAssignmentAndSession(
     shadowSessionId: ids.sessionId,
   };
 }
+
+// ============================================================================
+// MC-I1.S5 (ADR-0005 §3) — orphan observed-session auto-registration
+// ============================================================================
+//
+// An ORPHAN is a real instrumented CC session (CORTEX_CHANNEL set — e.g. the
+// principal's own `cldyo-live` terminal) that writes raw hook events but was
+// NEVER registered with Mission Control: no dispatch, no `POST /api/sessions`,
+// so no task/assignment/session row exists for its `cc_session_id`. The
+// ingestor used to HARD-DROP these events; ADR-0005 §3 (the catch-all half of
+// Phase 1) says auto-register them so the session lights up on the glass.
+//
+// Storage shape — DECISION (b): synthetic task + per-orphan agent + assignment.
+// We reuse the established F-12b pattern (`ensureShadowAgent` +
+// `createShadowAssignmentAndSession`) rather than relaxing `sessions.assignment_id`
+// to nullable. Rationale:
+//   - EVERY read query joins FROM `agent_task_assignment` outward to sessions
+//     (`mostRecentSessionLeftJoin`, `listWorkingAgents`, `mostActiveAgent`,
+//     the ingestor's own F-20 SELECT). A NULL `assignment_id` with no
+//     assignment row would make the orphan session exist but render NOWHERE —
+//     it is unreachable through every assignment-anchored join. The synthetic
+//     assignment keeps orphans visible through the unchanged join paths.
+//   - Zero schema change → zero blast radius on the 20-table schema, no
+//     REBUILD_MIGRATIONS, no nullable-column audit across N queries.
+//
+// Distinguishability: orphan agents carry the `mc-orphan-` id prefix and the
+// session is `endpoint_kind = 'local.observed'`, so the dashboard can tell
+// them apart from dispatch-spawned controlled sessions. They are PER-orphan
+// (one agent + assignment + session per `cc_session_id`), so each instrumented
+// terminal is its own working-grid tile rather than collapsing into one.
+//
+// Lifecycle: the orphan assignment is born `dispatched` so the ingestor's F-20
+// auto-transitions drive it normally — `dispatched → running` on the first
+// event, `running → completed` on Stop/SessionEnd — exactly like any other
+// observed session. Nothing in F-20 needs to special-case orphans.
+
+export const ORPHAN_AGENT_PREFIX = "mc-orphan-";
+const ORPHAN_TASK_ID = "mc-orphan-task";
+const ORPHAN_TASK_TITLE = "Observed sessions (unregistered)";
+// Synthetic task needs a principal_id + source_system (both NOT NULL). The task
+// is an internal MC bookkeeping row, not a real provider work item.
+const ORPHAN_TASK_PRINCIPAL = "mc-orphan";
+const ORPHAN_TASK_SOURCE_SYSTEM = "internal";
+
+/**
+ * Lazily insert the well-known orphan catch-all task. Idempotent. All orphan
+ * assignments hang off this single task (the task is bookkeeping; the agent +
+ * assignment + session carry the per-session identity).
+ */
+function ensureOrphanTask(db: Database): string {
+  db.query(
+    `INSERT INTO tasks (id, title, priority, principal_id, source_system, status)
+     VALUES (?, ?, 2, ?, ?, 'in_progress')
+     ON CONFLICT(id) DO NOTHING`
+  ).run(ORPHAN_TASK_ID, ORPHAN_TASK_TITLE, ORPHAN_TASK_PRINCIPAL, ORPHAN_TASK_SOURCE_SYSTEM);
+  return ORPHAN_TASK_ID;
+}
+
+/**
+ * Deterministic orphan-agent id for a `cc_session_id`. One agent per orphan
+ * session → one working-grid tile per instrumented terminal. The `mc-orphan-`
+ * prefix makes orphans distinguishable from dispatch-spawned agents.
+ */
+export function orphanAgentId(ccSessionId: string): string {
+  return `${ORPHAN_AGENT_PREFIX}${ccSessionId}`;
+}
+
+/**
+ * Lazily insert the per-orphan agent. `displayName` is taken from the raw
+ * event's `agent_name` when present, otherwise the cc_session_id — applied
+ * only on insert (subsequent events never overwrite a name the principal may
+ * have since edited), matching `ensureNamedAgent`'s semantics.
+ */
+function ensureOrphanAgent(
+  db: Database,
+  ccSessionId: string,
+  displayName: string | undefined
+): string {
+  const id = orphanAgentId(ccSessionId);
+  const name = displayName && displayName.length > 0 ? displayName : ccSessionId;
+  db.query(
+    `INSERT INTO agents (id, name, type, persistent)
+     VALUES (?, ?, 'head', 0)
+     ON CONFLICT(id) DO NOTHING`
+  ).run(id, name);
+  return id;
+}
+
+export interface OrphanSession {
+  agentId: string;
+  assignmentId: string;
+  sessionId: string;
+}
+
+/**
+ * Auto-register an orphan observed session for an unknown `cc_session_id`.
+ *
+ * Idempotent on `cc_session_id`: if a session row already carries this
+ * `cc_session_id` we return null (the caller then proceeds with the existing
+ * session — no duplicate task/agent/assignment/session is created). The first
+ * call lands the synthetic task (shared), a per-orphan agent, an assignment in
+ * `dispatched`, and a `local.observed` session.
+ *
+ * Wrapped in a single transaction so a partial insert can never leave a
+ * dangling agent/assignment without its session.
+ *
+ * @param displayName  Raw event `agent_name`, surfaced as the orphan agent's
+ *                     display name where the schema allows (insert-only).
+ */
+export function registerOrphanSession(
+  db: Database,
+  ccSessionId: string,
+  displayName?: string
+): OrphanSession | null {
+  // Dedupe: any existing session for this cc_session_id (orphan or otherwise)
+  // means we must NOT create a second one. The ingestor's own lookup already
+  // ran and missed, but this guard keeps the helper safe to call directly.
+  const existing = db
+    .query(`SELECT 1 FROM sessions WHERE cc_session_id = ? LIMIT 1`)
+    .get(ccSessionId);
+  if (existing) return null;
+
+  const assignmentId = generateId();
+  const sessionId = generateId();
+
+  const txn = db.transaction(() => {
+    ensureOrphanTask(db);
+    const agentId = ensureOrphanAgent(db, ccSessionId, displayName);
+
+    // Born `dispatched` so the ingestor's F-20 auto-transitions
+    // (dispatched → running on first event, running → completed on
+    // Stop/SessionEnd) drive the orphan exactly like a registered observed
+    // session — no orphan-specific lifecycle code needed.
+    db.query(
+      `INSERT INTO agent_task_assignment (id, agent_id, task_id, state)
+       VALUES (?, ?, ?, 'dispatched')`
+    ).run(assignmentId, agentId, ORPHAN_TASK_ID);
+
+    const now = new Date().toISOString();
+    db.query(
+      `INSERT INTO sessions
+         (id, assignment_id, cc_session_id, endpoint_kind, pid, started_at)
+       VALUES (?, ?, ?, 'local.observed', NULL, ?)`
+    ).run(sessionId, assignmentId, ccSessionId, now);
+
+    return { agentId, assignmentId, sessionId };
+  });
+
+  return txn();
+}

--- a/src/surface/mc/db/sessions.ts
+++ b/src/surface/mc/db/sessions.ts
@@ -274,6 +274,9 @@ function ensureOrphanAgent(
   displayName: string | undefined
 ): string {
   const id = orphanAgentId(ccSessionId);
+  // Deliberate double-guard with the ingestor's pick (which already skips
+  // empty agent_name values): this fallback must hold for ANY caller, not
+  // just the ingestor path.
   const name = displayName && displayName.length > 0 ? displayName : ccSessionId;
   db.query(
     `INSERT INTO agents (id, name, type, persistent)

--- a/src/surface/mc/hooks/ingestor.ts
+++ b/src/surface/mc/hooks/ingestor.ts
@@ -27,6 +27,7 @@ import type { RawHookEvent } from "./types";
 import type { WsClientRegistry } from "../ws/client-registry";
 import { insertEvent } from "../db/events";
 import { applyTransition } from "../db/transitions";
+import { registerOrphanSession } from "../db/sessions";
 import { broadcastTransition, broadcastEvent } from "../notifications";
 
 export interface IngestResult {
@@ -72,12 +73,12 @@ export function ingestEvents(
   let count = 0;
   const inserted: McEvent[] = [];
 
-  for (const [ccSessionId, sessionEvents] of bySession) {
-    // Look up session by cc_session_id — most recent first, regardless of
-    // ended_at status. F-20 widens the SELECT to also pull endpoint_kind
-    // + assignment state so we can drive observed-session auto-transitions
-    // without a second query.
-    const session = db
+  // Reusable lookup: session by cc_session_id — most recent first, regardless
+  // of ended_at status. F-20 widens the SELECT to also pull endpoint_kind +
+  // assignment state so we can drive observed-session auto-transitions without
+  // a second query.
+  const lookupSession = (ccSessionId: string): ObservedSessionRow | null =>
+    db
       .query(
         `SELECT s.id AS id, s.endpoint_kind AS endpoint_kind,
                 s.assignment_id AS assignment_id,
@@ -89,11 +90,42 @@ export function ingestEvents(
       )
       .get(ccSessionId) as ObservedSessionRow | null;
 
+  for (const [ccSessionId, sessionEvents] of bySession) {
+    let session = lookupSession(ccSessionId);
+
     if (!session) {
-      process.stderr.write(
-        `[mission-control] ingestor: dropping ${sessionEvents.length} event(s) for unregistered session '${ccSessionId}'\n`
-      );
-      continue;
+      // MC-I1.S5 (ADR-0005 §3) — auto-register the unknown cc_session_id as an
+      // orphan `local.observed` session instead of dropping its events. Catches
+      // instrumented non-dispatch sessions (e.g. cldyo-live). Idempotent on
+      // cc_session_id: registerOrphanSession dedupes, so subsequent batches for
+      // the same orphan don't duplicate rows. One stderr line per auto-register
+      // (observability) — NOT one per event.
+      //
+      // Capture display metadata from the raw events: prefer the first event's
+      // agent_name so the orphan agent card shows a human label rather than the
+      // raw cc_session_id.
+      const displayName = sessionEvents.find(
+        (e) => e.agent_name !== undefined && e.agent_name.length > 0
+      )?.agent_name;
+      const orphan = registerOrphanSession(db, ccSessionId, displayName);
+      if (orphan) {
+        process.stderr.write(
+          `[mission-control] ingestor: auto-registered orphan observed session '${ccSessionId}' (assignment '${orphan.assignmentId}')\n`
+        );
+      }
+      // Re-read so the rest of the loop (event insert + F-20 transitions) runs
+      // unchanged against the freshly-created (or pre-existing, on a dedup
+      // race) orphan row.
+      session = lookupSession(ccSessionId);
+      if (!session) {
+        // Should be unreachable — registerOrphanSession either created the row
+        // or a concurrent writer did. If the lookup still misses, something is
+        // wrong with the DB; surface it rather than silently dropping.
+        process.stderr.write(
+          `[mission-control] ingestor: orphan auto-register did not yield a session for '${ccSessionId}'; dropping ${sessionEvents.length} event(s)\n`
+        );
+        continue;
+      }
     }
 
     // Insert events first — they're the authoritative record. Then


### PR DESCRIPTION
## What

Replaces the ingestor's hard-drop of events for unknown `cc_session_id`s (`src/surface/mc/hooks/ingestor.ts`) with **orphan auto-registration**. The first event for an unregistered `cc_session_id` now creates an orphan `local.observed` session, then ingestion proceeds normally; subsequent events for the same session dedupe onto that row.

Implements **ADR-0005 §3** (decision item 3) — the **catch-all half** of Phase 1's session projection. The dispatch-driven half is sibling slice **S4** and is intentionally **not** built here.

## Why

ADR-0005 §3: *"The ingestor additionally auto-registers unknown `cc_session_id`s as orphan `local.observed` sessions (catches instrumented non-dispatch sessions, e.g. `cldyo-live`)."*

Before this, any instrumented CC session that wasn't dispatch-spawned — most importantly the principal's own `cldyo-live` terminal (`CORTEX_CHANNEL` set) — wrote raw JSONL whose events the ingestor silently dropped (`stderr 'dropping … for unregistered session'`). Those sessions were invisible on the glass. This is the deliberate contract change that lights them up.

## Storage-shape decision — (b) synthetic task + per-orphan agent + assignment

Chose **(b)** over **(a) relaxing `sessions.assignment_id` to nullable**. Rationale (verified against the actual queries):

- **Every** read path joins *from* `agent_task_assignment` outward to sessions — `session-join.ts` (`mostRecentSessionLeftJoin`, used by `listAssignments`/`listFocusArea`/`db/tasks.ts`), `working-agents.ts` (`listWorkingAgents`), `assignments.ts` (`mostActiveAgent`), and the ingestor's **own F-20 SELECT** (`sessions s JOIN agent_task_assignment a ON a.id = s.assignment_id`). A NULL `assignment_id` with no assignment row would make the orphan session **exist but render nowhere** — unreachable through every assignment-anchored join, including the one the ingestor itself uses to drive F-20.
- **Zero schema change** → no `REBUILD_MIGRATIONS`, no nullable-column audit across the 20-table schema. Smallest blast radius.
- Reuses the **established F-12b shadow pattern** (`ensureShadowAgent` / `createShadowAssignmentAndSession`) already in `db/sessions.ts`.

Shape: a single shared catch-all task (`mc-orphan-task`), one **per-orphan agent** (`mc-orphan-{cc_session_id}` — so each instrumented terminal is its own working-grid tile, not one collapsed tile), a per-orphan assignment born `dispatched`, and a `local.observed` session. The `mc-orphan-` agent-id prefix + `local.observed` endpoint make orphans **distinguishable** from dispatch-spawned controlled sessions. The assignment being born `dispatched` means the existing **F-20 auto-transitions** (`dispatched → running` on first event, `running → completed` on `Stop`/`SessionEnd`) drive orphans **unchanged** — no orphan-specific lifecycle code.

## Visibility / UI

Orphans surface through the unchanged assignment→session joins: the orphan task appears in `listTasks`, the orphan assignment in `listWorkingAgents` (in `running`). No list query crashes; no UI change was required. Deeper UI treatment (a dedicated "observed/untracked" visual lane) is **out of scope** — follow-up if warranted.

## Test plan

TDD: tests updated to the new contract first, then implementation.

- **ingestor.test.ts** — old "skips/drops unregistered" tests rewritten to assert auto-register; added: dedupe across two batches (one session/agent/assignment, both hook events ingested), `agent_name` → orphan display name + cc_session_id fallback, F-20 `dispatched → running` and `running → completed` on the orphan, the assignment-anchored-join visibility assertion (the storage-shape edge), and "distinct orphans share one catch-all task".
- **poller.test.ts** — `HookStreamPoller` consumer updated: the unregistered-session test now asserts auto-register + ingest; the "persists cursor on 0-ingested" test now uses a malformed-JSON line (the genuine 0-ingested-but-offset-advances case post-contract-change).

### Gate results

| Gate | Result |
|---|---|
| `bun run lint` (eslint) | **0 errors** (29 pre-existing warnings, none in changed files) |
| `bunx tsc --noEmit` | **0 errors** (deps installed) |
| `bun test` (full) | **5184 pass, 2 skip, 0 fail** |
| `scripts/check-carveouts.sh` (changed files) | **PASS** |

Never wrote a bare "operator" — verified in the diff.

Closes #847
Part of #843

🤖 Generated with [Claude Code](https://claude.com/claude-code)