### PR TITLE
chore: bump to v5.5.0

### DIFF
--- a/arc-manifest.yaml
+++ b/arc-manifest.yaml
@@ -8,7 +8,7 @@ name: "Cortex"
 # now fail to load (strict canonical-only schemas). Run `cortex migrate-config`
 # to rewrite a pre-v4 config to the canonical `principal:` / `principalId` /
 # `principal_id` shape.
-version: "5.4.4"
+version: "5.5.0"
 type: component
 tier: community
 description: "Layer-7 collaboration surface for the metafactory ecosystem — the M7 application that consumes the Myelin stack"


### PR DESCRIPTION
Version bump for the iteration-1 wave-1 merges (#842, #854, #852, #856). Release notes land on the v5.5.0 GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)