### PR TITLE
feat(mc): MC-I1.S4 — project dispatch lifecycle envelopes into MC sessions

### DIFF
--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -99,6 +99,8 @@ import { refreshCockpit, defaultWorkItemSourceFor } from "./surface/mc/refresh";
 import { startCockpitRefreshLoop, type CockpitRefreshLoop } from "./surface/mc/refresh-loop";
 // MC-I1.S1 (ADR-0005) — in-process Mission Control embed (supersedes api.*).
 import { startMissionControl, type MissionControlHandle } from "./surface/mc/embed";
+// MC-I1.S4 (ADR-0005 §4) — bus→MC dispatch-lifecycle projection renderer.
+import { createDispatchProjectionRenderer } from "./surface/mc/projection/dispatch-lifecycle-renderer";
 import type { Database as BunDatabase } from "bun:sqlite";
 import { isGatewayEnabled } from "./gateway/gateway-bootstrap";
 import {
@@ -2683,6 +2685,17 @@ export async function startCortex(
       });
       mcDb = mcHandle.db;
       console.log(`cortex: Mission Control embed listening on http://localhost:${mcHandle.port} — db ${dbPath}`);
+
+      // MC-I1.S4 (ADR-0005 §3/§4) — register the bus→MC projection renderer so
+      // `dispatch.task.*` lifecycle envelopes land as session/assignment rows on
+      // the working grid. The seam is a surface-router renderer (§4), subscribing
+      // to the dispatch-lifecycle subjects only; its render() is non-throwing
+      // (the surface-router isolates errors too, but the renderer owns the
+      // contract). S6 (#848) extends the same renderer's project() dispatcher to
+      // verdicts / attention / heartbeats. No restart-on-config — like every
+      // renderer, the registration is static for the daemon's lifetime.
+      router.register(createDispatchProjectionRenderer(mcDb));
+      console.log("cortex: Mission Control dispatch-lifecycle projection renderer registered");
     } catch (err) {
       console.error("cortex: Mission Control embed startup error (non-fatal):", err instanceof Error ? err.message : err);
     }

--- a/src/surface/mc/__tests__/dispatch-lifecycle-projection.test.ts
+++ b/src/surface/mc/__tests__/dispatch-lifecycle-projection.test.ts
@@ -1,0 +1,292 @@
+/**
+ * MC-I1.S4 (ADR-0005 §3/§4) — tests for the dispatch-lifecycle projection.
+ *
+ * The projection is the bus→MC seam: it turns `dispatch.task.*` lifecycle
+ * envelopes into MC session/assignment/task rows so dispatch-spawned work
+ * appears live on the working grid (started) and transitions on terminal —
+ * with the authoritative `cc_session_id` backfilled onto the SAME session the
+ * S5 ingestor's hook events join onto (not a duplicate orphan).
+ *
+ * Coverage axes (per the slice brief's TDD list):
+ *   1. Full lifecycle started→completed: anchor created, assignment running
+ *      then completed, cc_session_id backfilled from the terminal payload.
+ *   2. failed / aborted map to their terminal assignment states.
+ *   3. Idempotent on redelivered envelopes (same correlation_id) — a second
+ *      `started` does not create a second task/agent/assignment/session.
+ *   4. Orphan-reconciliation: when the S5 ingestor already orphan-registered
+ *      the cc_session_id (hook events raced ahead of the terminal envelope),
+ *      the projection adopts the orphan's session + events into the projected
+ *      assignment rather than leaving two rows.
+ *   5. Resume-divergence: `started` carries the prior session's id, the
+ *      terminal carries the authoritative id — terminal wins.
+ *   6. Non-dispatch envelope types are ignored.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { Database } from "bun:sqlite";
+
+import { SCHEMA_SQL } from "../db/schema";
+import { registerOrphanSession } from "../db/sessions";
+import { ingestEvents } from "../hooks/ingestor";
+import type { RawHookEvent } from "../hooks/types";
+import { projectDispatchLifecycle } from "../projection/dispatch-lifecycle";
+import {
+  createDispatchTaskStartedEvent,
+  createDispatchTaskCompletedEvent,
+  createDispatchTaskFailedEvent,
+  createDispatchTaskAbortedEvent,
+  type DispatchEventSource,
+} from "../../../bus/dispatch-events";
+import type { Envelope } from "../../../bus/myelin/envelope-validator";
+
+const SOURCE: DispatchEventSource = {
+  principal: "andreas",
+  agent: "cortex",
+  instance: "local",
+};
+
+const TASK_ID = "11111111-1111-4111-8111-111111111111";
+const CC_SESSION = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const RESUME_PRIOR = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+const STARTED_AT = new Date("2026-06-10T12:00:00.000Z");
+const COMPLETED_AT = new Date("2026-06-10T12:05:00.000Z");
+
+function setupDb(): Database {
+  const db = new Database(":memory:");
+  db.exec("PRAGMA journal_mode = WAL");
+  db.exec("PRAGMA foreign_keys = ON");
+  for (const sql of SCHEMA_SQL) db.exec(sql);
+  return db;
+}
+
+interface SessionRow {
+  id: string;
+  assignment_id: string;
+  cc_session_id: string | null;
+  endpoint_kind: string;
+  ended_at: string | null;
+}
+
+function sessionsFor(db: Database): SessionRow[] {
+  return db
+    .query(
+      `SELECT id, assignment_id, cc_session_id, endpoint_kind, ended_at FROM sessions`,
+    )
+    .all() as SessionRow[];
+}
+
+function assignmentState(db: Database, assignmentId: string): string {
+  const row = db
+    .query(`SELECT state FROM agent_task_assignment WHERE id = ?`)
+    .get(assignmentId) as { state: string } | null;
+  if (!row) throw new Error(`assignment ${assignmentId} not found`);
+  return row.state;
+}
+
+function makeStarted(opts: { ccSessionId?: string } = {}): Envelope {
+  return createDispatchTaskStartedEvent({
+    source: SOURCE,
+    taskId: TASK_ID,
+    agentId: "cortex",
+    startedAt: STARTED_AT,
+    ...(opts.ccSessionId !== undefined && { ccSessionId: opts.ccSessionId }),
+  });
+}
+
+function makeCompleted(opts: { ccSessionId?: string } = {}): Envelope {
+  return createDispatchTaskCompletedEvent({
+    source: SOURCE,
+    taskId: TASK_ID,
+    agentId: "cortex",
+    startedAt: STARTED_AT,
+    completedAt: COMPLETED_AT,
+    resultSummary: "done",
+    ...(opts.ccSessionId !== undefined && { ccSessionId: opts.ccSessionId }),
+  });
+}
+
+function makeRawEvent(eventId: string, ccSessionId: string): RawHookEvent {
+  return {
+    event_id: eventId,
+    event_type: "tool.bash",
+    timestamp: new Date().toISOString(),
+    session_id: ccSessionId,
+    agent_id: "cortex",
+    agent_name: "Cortex",
+    source: { hook: "PostToolUse", tool_name: "tool.bash" },
+    payload: { test: true },
+  };
+}
+
+describe("projectDispatchLifecycle", () => {
+  let db: Database;
+
+  beforeEach(() => {
+    db = setupDb();
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it("started creates the anchor: task + agent + assignment(dispatched) + session keyed on correlation_id", () => {
+    const res = projectDispatchLifecycle(db, makeStarted());
+    expect(res).not.toBeNull();
+
+    const sessions = sessionsFor(db);
+    expect(sessions).toHaveLength(1);
+    const session = sessions[0]!;
+    // cc_session_id is PENDING at started for a fresh dispatch (no resume id).
+    expect(session.cc_session_id).toBeNull();
+    // Dispatch-spawned work is controlled, not observed.
+    expect(session.endpoint_kind).toBe("local.process.controlled");
+
+    // Assignment born then driven to running by the started projection so the
+    // working grid shows the session as active.
+    expect(assignmentState(db, session.assignment_id)).toBe("running");
+
+    // The dispatched agent row exists.
+    const agent = db
+      .query(`SELECT id FROM agents WHERE id = ?`)
+      .get("cortex") as { id: string } | null;
+    expect(agent).not.toBeNull();
+  });
+
+  it("idempotent on redelivered started (same correlation_id) — no duplicate rows", () => {
+    projectDispatchLifecycle(db, makeStarted());
+    projectDispatchLifecycle(db, makeStarted());
+
+    expect(sessionsFor(db)).toHaveLength(1);
+    const assignments = db
+      .query(`SELECT id FROM agent_task_assignment`)
+      .all() as { id: string }[];
+    expect(assignments).toHaveLength(1);
+    const tasks = db.query(`SELECT id FROM tasks`).all() as { id: string }[];
+    expect(tasks).toHaveLength(1);
+  });
+
+  it("full lifecycle started→completed: transitions to completed and backfills authoritative cc_session_id", () => {
+    projectDispatchLifecycle(db, makeStarted());
+    const res = projectDispatchLifecycle(db, makeCompleted({ ccSessionId: CC_SESSION }));
+    expect(res).not.toBeNull();
+
+    const sessions = sessionsFor(db);
+    expect(sessions).toHaveLength(1);
+    const session = sessions[0]!;
+    expect(session.cc_session_id).toBe(CC_SESSION);
+    expect(assignmentState(db, session.assignment_id)).toBe("completed");
+  });
+
+  it("failed maps the assignment to 'failed'", () => {
+    projectDispatchLifecycle(db, makeStarted());
+    projectDispatchLifecycle(
+      db,
+      createDispatchTaskFailedEvent({
+        source: SOURCE,
+        taskId: TASK_ID,
+        agentId: "cortex",
+        startedAt: STARTED_AT,
+        failedAt: COMPLETED_AT,
+        errorSummary: "boom",
+        ccSessionId: CC_SESSION,
+      }),
+    );
+    const session = sessionsFor(db)[0]!;
+    expect(assignmentState(db, session.assignment_id)).toBe("failed");
+    expect(session.cc_session_id).toBe(CC_SESSION);
+  });
+
+  it("aborted maps the assignment to 'cancelled'", () => {
+    projectDispatchLifecycle(db, makeStarted());
+    projectDispatchLifecycle(
+      db,
+      createDispatchTaskAbortedEvent({
+        source: SOURCE,
+        taskId: TASK_ID,
+        agentId: "cortex",
+        startedAt: STARTED_AT,
+        abortedAt: COMPLETED_AT,
+        reason: "timeout",
+        ccSessionId: CC_SESSION,
+      }),
+    );
+    const session = sessionsFor(db)[0]!;
+    expect(assignmentState(db, session.assignment_id)).toBe("cancelled");
+    expect(session.cc_session_id).toBe(CC_SESSION);
+  });
+
+  it("resume-divergence: started's prior cc id is provisional; the terminal id wins", () => {
+    // Resume dispatch — started carries the PRIOR session id.
+    projectDispatchLifecycle(db, makeStarted({ ccSessionId: RESUME_PRIOR }));
+    let session = sessionsFor(db)[0]!;
+    expect(session.cc_session_id).toBe(RESUME_PRIOR);
+
+    // Terminal carries the authoritative (post-resume) id — it must overwrite.
+    projectDispatchLifecycle(db, makeCompleted({ ccSessionId: CC_SESSION }));
+    session = sessionsFor(db)[0]!;
+    expect(session.cc_session_id).toBe(CC_SESSION);
+    expect(assignmentState(db, session.assignment_id)).toBe("completed");
+  });
+
+  it("orphan-reconciliation: an S5 orphan for the terminal cc_session_id is adopted, not duplicated", () => {
+    // started anchors the projection (cc_session_id pending).
+    projectDispatchLifecycle(db, makeStarted());
+
+    // Hook events race ahead of the terminal envelope: S5's ingestor
+    // orphan-registers the cc_session_id and ingests its events.
+    const ingest = ingestEvents(db, [
+      makeRawEvent("e-1", CC_SESSION),
+      makeRawEvent("e-2", CC_SESSION),
+    ]);
+    expect(ingest.count).toBe(2);
+
+    // Two sessions exist right now: the projected placeholder (cc pending) and
+    // the orphan (cc = CC_SESSION, with the hook events).
+    expect(sessionsFor(db)).toHaveLength(2);
+
+    // Terminal envelope carries the authoritative cc_session_id — the
+    // projection MUST reconcile to a SINGLE session, not leave two.
+    projectDispatchLifecycle(db, makeCompleted({ ccSessionId: CC_SESSION }));
+
+    const sessions = sessionsFor(db).filter((s) => s.cc_session_id === CC_SESSION);
+    expect(sessions).toHaveLength(1);
+    const session = sessions[0]!;
+
+    // The reconciled session belongs to the PROJECTED assignment, which is
+    // transitioned to completed.
+    expect(assignmentState(db, session.assignment_id)).toBe("completed");
+
+    // The orphan's hook events survived the merge — they now hang off the
+    // reconciled session.
+    const eventCount = db
+      .query(`SELECT COUNT(*) AS n FROM events WHERE session_id = ?`)
+      .get(session.id) as { n: number };
+    expect(eventCount.n).toBeGreaterThanOrEqual(2);
+
+    // No dangling duplicate carrying the same cc_session_id.
+    const allWithCc = sessionsFor(db).filter(
+      (s) => s.cc_session_id === CC_SESSION,
+    );
+    expect(allWithCc).toHaveLength(1);
+  });
+
+  it("ignores non-dispatch envelope types", () => {
+    const notDispatch: Envelope = {
+      ...makeStarted(),
+      type: "system.heartbeat",
+    };
+    const res = projectDispatchLifecycle(db, notDispatch);
+    expect(res).toBeNull();
+    expect(sessionsFor(db)).toHaveLength(0);
+  });
+
+  it("terminal without a prior started still anchors then transitions (out-of-order delivery)", () => {
+    // A terminal envelope can arrive before/without the started (lost started,
+    // or reordered delivery). The projection should still anchor + transition.
+    const res = projectDispatchLifecycle(db, makeCompleted({ ccSessionId: CC_SESSION }));
+    expect(res).not.toBeNull();
+    const session = sessionsFor(db)[0]!;
+    expect(session.cc_session_id).toBe(CC_SESSION);
+    expect(assignmentState(db, session.assignment_id)).toBe("completed");
+  });
+});

--- a/src/surface/mc/__tests__/dispatch-lifecycle-renderer.test.ts
+++ b/src/surface/mc/__tests__/dispatch-lifecycle-renderer.test.ts
@@ -1,0 +1,138 @@
+/**
+ * MC-I1.S4 (ADR-0005 §4) — tests for the dispatch-lifecycle projection renderer
+ * (the bus→MC surface-router seam).
+ *
+ * Verifies:
+ *   1. The adapter's subjects + id are stable + match the dispatch-lifecycle
+ *      grammar (local stack-ful/stack-less + federated).
+ *   2. render() routes a `dispatch.task.*` envelope into MC rows.
+ *   3. render() ignores non-dispatch envelopes (no rows written).
+ *   4. render() NEVER throws — a malformed envelope is swallowed + logged.
+ *   5. The renderer subjects actually match real derived subjects via the
+ *      surface-router's NATS matcher (the wire-level join).
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { Database } from "bun:sqlite";
+
+import { SCHEMA_SQL } from "../db/schema";
+import {
+  createDispatchProjectionRenderer,
+  DISPATCH_PROJECTION_RENDERER_ID,
+  DISPATCH_PROJECTION_SUBJECTS,
+} from "../projection/dispatch-lifecycle-renderer";
+import { subjectMatches } from "../../../bus/surface-router";
+import {
+  createDispatchTaskStartedEvent,
+  type DispatchEventSource,
+} from "../../../bus/dispatch-events";
+import type { Envelope } from "../../../bus/myelin/envelope-validator";
+
+const SOURCE: DispatchEventSource = {
+  principal: "andreas",
+  agent: "cortex",
+  instance: "local",
+};
+const TASK_ID = "33333333-3333-4333-8333-333333333333";
+
+function setupDb(): Database {
+  const db = new Database(":memory:");
+  db.exec("PRAGMA journal_mode = WAL");
+  db.exec("PRAGMA foreign_keys = ON");
+  for (const sql of SCHEMA_SQL) db.exec(sql);
+  return db;
+}
+
+function sessionCount(db: Database): number {
+  return (
+    db.query(`SELECT COUNT(*) AS n FROM sessions`).get() as { n: number }
+  ).n;
+}
+
+describe("createDispatchProjectionRenderer", () => {
+  let db: Database;
+
+  beforeEach(() => {
+    db = setupDb();
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it("exposes a stable id + the dispatch-lifecycle subjects", () => {
+    const adapter = createDispatchProjectionRenderer(db);
+    expect(adapter.id).toBe(DISPATCH_PROJECTION_RENDERER_ID);
+    expect(adapter.subjects).toEqual(DISPATCH_PROJECTION_SUBJECTS);
+  });
+
+  it("render() projects a dispatch.task.started envelope into MC rows", async () => {
+    const adapter = createDispatchProjectionRenderer(db);
+    const env = createDispatchTaskStartedEvent({
+      source: SOURCE,
+      taskId: TASK_ID,
+      agentId: "cortex",
+      startedAt: new Date("2026-06-10T12:00:00.000Z"),
+    });
+    await adapter.render(env);
+    expect(sessionCount(db)).toBe(1);
+  });
+
+  it("render() ignores a non-dispatch envelope (no rows written)", async () => {
+    const adapter = createDispatchProjectionRenderer(db);
+    const env: Envelope = {
+      ...createDispatchTaskStartedEvent({
+        source: SOURCE,
+        taskId: TASK_ID,
+        agentId: "cortex",
+        startedAt: new Date(),
+      }),
+      type: "system.heartbeat",
+    };
+    await adapter.render(env);
+    expect(sessionCount(db)).toBe(0);
+  });
+
+  it("render() never throws on a malformed envelope", async () => {
+    const adapter = createDispatchProjectionRenderer(db);
+    // A dispatch type but a garbage payload — must be swallowed, not thrown.
+    const bad = {
+      id: "x",
+      type: "dispatch.task.started",
+      payload: null,
+    } as unknown as Envelope;
+    await expect(adapter.render(bad)).resolves.toBeUndefined();
+    expect(sessionCount(db)).toBe(0);
+  });
+
+  it("subjects match real derived dispatch.task subjects via the router matcher", () => {
+    // Stack-ful, stack-less, and federated derived subjects (from
+    // @the-metafactory/myelin deriveSubject) must each be caught by at least
+    // one of the renderer's subscribe patterns.
+    const derived = [
+      "local.andreas.work.dispatch.task.started",
+      "local.andreas.dispatch.task.completed",
+      "federated.peer.work.dispatch.task.failed",
+    ];
+    for (const subject of derived) {
+      const hit = DISPATCH_PROJECTION_SUBJECTS.some((p) =>
+        subjectMatches(p, subject),
+      );
+      expect(hit).toBe(true);
+    }
+  });
+
+  it("does NOT match non-dispatch subjects", () => {
+    const nonDispatch = [
+      "local.andreas.work.system.heartbeat",
+      "local.andreas.work.review.verdict.completed",
+      "local.andreas.tasks.@did-mf-luna.chat",
+    ];
+    for (const subject of nonDispatch) {
+      const hit = DISPATCH_PROJECTION_SUBJECTS.some((p) =>
+        subjectMatches(p, subject),
+      );
+      expect(hit).toBe(false);
+    }
+  });
+});

--- a/src/surface/mc/projection/dispatch-lifecycle-renderer.ts
+++ b/src/surface/mc/projection/dispatch-lifecycle-renderer.ts
@@ -65,6 +65,9 @@ export const DISPATCH_PROJECTION_RENDERER_ID = "mc-dispatch-projection";
 export const DISPATCH_PROJECTION_SUBJECTS: string[] = [
   "local.*.dispatch.task.*",
   "local.*.*.dispatch.task.*",
+  // Deliberately NO stack-less federated twin: the federated grammar is always
+  // `federated.{principal}.{stack}.…` (ADR-0001 / CONTEXT.md §Subject) — the
+  // stack-less variant exists only as the legacy LOCAL shape.
   "federated.*.*.dispatch.task.*",
 ];
 

--- a/src/surface/mc/projection/dispatch-lifecycle-renderer.ts
+++ b/src/surface/mc/projection/dispatch-lifecycle-renderer.ts
@@ -1,0 +1,103 @@
+/**
+ * MC-I1.S4 (ADR-0005 §4) — the bus→MC projection renderer.
+ *
+ * §4 makes the bus→MC seam a registered surface-router renderer: a push-based
+ * `render(envelope)` rather than the polled DashboardRenderer ring buffer (§4
+ * demotes that to, at most, the drill-down's recent-raw-envelopes feed). cortex.ts
+ * registers this adapter with the surface-router when `mc.enabled`, subscribing
+ * to the `dispatch.task.*` lifecycle subjects only.
+ *
+ * The adapter is deliberately SKELETAL: a single `project(envelope)` dispatcher
+ * keyed on `envelope.type`, today routing `dispatch.task.*` into
+ * {@link projectDispatchLifecycle}. S6 (#848) generalizes this seam to verdicts
+ * / attention / heartbeats — it EXTENDS the `project()` switch (adds cases)
+ * rather than rewriting the renderer, so the surface-router registration and the
+ * non-throwing contract stay intact.
+ *
+ * ## Non-throwing contract
+ *
+ * The surface-router wraps every `render()` in a timeout + `Promise.allSettled`
+ * (`renderWithIsolation`), but the Renderer contract (renderers/types.ts §2)
+ * ALSO obliges the renderer itself to never throw — a projection error must
+ * not poison the dispatch loop. We catch inside `render()` and route failures to
+ * stderr, mirroring the DashboardRenderer + ingestor error posture.
+ *
+ * ## WS broadcast — known gap for S6 (#848)
+ *
+ * The MC server's WebSocket broadcasts on state transitions via a
+ * `WsClientRegistry` the db layer doesn't know about; existing mutation paths
+ * (api/handlers, the ingestor) fan out by calling `broadcastTransition` /
+ * `broadcastEvent` at the call site AFTER the db write. The projection writes
+ * here bypass that fan-out, so a freshly-projected session/transition won't push
+ * to live dashboard clients until their next poll/refetch. Wiring the registry
+ * through requires threading the projection's per-envelope transition results
+ * into `broadcastTransition`; S6 owns the generalized notification seam, so this
+ * slice leaves it as a documented gap rather than a partial wire-up. The embed
+ * (embed.ts) holds the `wsRegistry`; a follow-up passes it here.
+ */
+
+import type { Database } from "bun:sqlite";
+
+import type { Envelope } from "../../../bus/myelin/envelope-validator";
+import type { SurfaceAdapter } from "../../../bus/surface-router";
+import { projectDispatchLifecycle } from "./dispatch-lifecycle";
+
+/** Stable surface-router id for the dispatch-lifecycle projection renderer. */
+export const DISPATCH_PROJECTION_RENDERER_ID = "mc-dispatch-projection";
+
+/**
+ * NATS subject patterns the projection renderer subscribes to. Covers both the
+ * stack-ful (`local.{principal}.{stack}.dispatch.task.*`) and stack-less
+ * (`local.{principal}.dispatch.task.*`) local grammars AND the federated
+ * (`federated.{principal}.{stack}.dispatch.task.*`) one — ADR-0005 §3 notes the
+ * projection "works unchanged for peer-stack sessions arriving on `federated.`
+ * lifecycle envelopes". The wildcards are intentionally broad; the
+ * authoritative type filter is {@link projectDispatchLifecycle}'s own
+ * `lifecycleKind` check (it returns null — a no-op — for anything that isn't a
+ * recognised `dispatch.task.{started|completed|failed|aborted}`), so a subject
+ * that over-matches costs only a cheap type compare.
+ *
+ * `*` matches exactly one segment, `>` one-or-more trailing segments (per the
+ * surface-router's NATS matcher). `local.>` would also work but the explicit
+ * `dispatch.task` tail keeps the subscription self-documenting and narrows the
+ * router's per-envelope payload-filter pass.
+ */
+export const DISPATCH_PROJECTION_SUBJECTS: string[] = [
+  "local.*.dispatch.task.*",
+  "local.*.*.dispatch.task.*",
+  "federated.*.*.dispatch.task.*",
+];
+
+/**
+ * Build the `SurfaceAdapter` the surface-router consumes for the
+ * dispatch-lifecycle projection. The `render()` is non-throwing: every
+ * projection error is caught + logged so a malformed envelope can't poison the
+ * router's dispatch loop.
+ *
+ * `db` is the in-process Mission Control handle (from the S1 embed —
+ * `startMissionControl(...).db`). cortex.ts wires this only when `mc.enabled`,
+ * so `db` is always the live MC db here.
+ */
+export function createDispatchProjectionRenderer(db: Database): SurfaceAdapter {
+  return {
+    id: DISPATCH_PROJECTION_RENDERER_ID,
+    subjects: DISPATCH_PROJECTION_SUBJECTS,
+    // eslint-disable-next-line @typescript-eslint/require-await
+    render: async (envelope: Envelope): Promise<void> => {
+      try {
+        // The single `project(envelope)` dispatcher (§4). Today it routes
+        // `dispatch.task.*` into the lifecycle projection; S6 (#848) adds
+        // verdict / attention / heartbeat cases here.
+        projectDispatchLifecycle(db, envelope);
+      } catch (err) {
+        // Renderer contract §2 — never throw out of render(). A projection
+        // failure (DB constraint, malformed payload that slipped the type
+        // filter) logs + drops; the surface-router's isolation is belt, this
+        // is braces.
+        process.stderr.write(
+          `[mission-control] dispatch-projection renderer: render() swallowed an error for envelope ${envelope.id} (${envelope.type}): ${err instanceof Error ? err.message : String(err)}\n`,
+        );
+      }
+    },
+  };
+}

--- a/src/surface/mc/projection/dispatch-lifecycle.ts
+++ b/src/surface/mc/projection/dispatch-lifecycle.ts
@@ -1,0 +1,591 @@
+/**
+ * MC-I1.S4 (ADR-0005 §3 + §4) — project `dispatch.task.*` lifecycle envelopes
+ * into Mission Control session/assignment/task rows.
+ *
+ * ADR-0005 §3 ("Session rows are projected from the bus") assigns Mission
+ * Control the dispatch-sink role: the runner stamps `cc_session_id` onto the
+ * lifecycle envelopes (S3, #852) and MC projects them into rows so
+ * dispatch-spawned work appears live on the working grid. §4 makes the bus→MC
+ * seam a registered surface-router renderer (`project(envelope)` push) rather
+ * than a polled ring buffer.
+ *
+ * This module is the projection itself — pure-ish `(db, envelope)` functions,
+ * no bus / HTTP / NATS imports. The renderer that pushes envelopes here lives
+ * in `dispatch-lifecycle-renderer.ts`; cortex.ts registers it with the
+ * surface-router when `mc.enabled`.
+ *
+ * ## The cc_session_id timing contract (#846 design comment, S3 #852)
+ *
+ * The claude-code harness yields `dispatch.task.started` BEFORE it spawns the
+ * CC process (so the lifecycle envelope survives a synchronous spawn failure),
+ * so on a FRESH dispatch the CC session id is structurally unknown at started.
+ * `cc_session_id` is authoritative on the TERMINAL envelope
+ * (`completed|failed|aborted`, from `CCSessionResult.sessionId`); `started`
+ * carries it only on RESUME (the prior session's id, which may diverge from the
+ * post-resume id). Therefore:
+ *
+ *   - the session row is created from `started` keyed by `correlation_id`
+ *     (cc_session_id PENDING — or stamped PROVISIONALLY from a resume id), and
+ *   - the authoritative cc_session_id is BACKFILLED when the terminal envelope
+ *     arrives, overwriting a provisional resume id if it diverged.
+ *
+ * Keying the session on `correlation_id` (NOT cc_session_id) at creation time
+ * is the load-bearing decision: all four lifecycle envelopes for one task share
+ * one `correlation_id`, so the projection always finds its own anchor, while the
+ * cc_session_id only becomes the ingestor-join key once the terminal stamps it.
+ *
+ * ## Anchor shape (follows the S5 synthetic-anchor pattern, dispatch-flavored)
+ *
+ * Mirroring `registerOrphanSession` (db/sessions.ts):
+ *   - one MC `task` per dispatch correlation_id (deterministic id), titled from
+ *     the dispatched agent — the lifecycle envelopes carry NO human description
+ *     (`DispatchTaskReceivedPayload.prompt` is NOT echoed onto lifecycle
+ *     payloads), so `agent_id` is the only label available;
+ *   - the dispatched `agent` row (`payload.agent_id` → MC agents);
+ *   - an `agent_task_assignment` born `dispatched`, driven `running` on started;
+ *   - a `session` row keyed (indirectly, via task→assignment→session) on the
+ *     correlation_id, `endpoint_kind = 'local.process.controlled'` (dispatch
+ *     spawns are controlled, distinguishing them from S5's `local.observed`
+ *     orphans).
+ *
+ * ## Orphan reconciliation (the dedup the slice brief calls CRITICAL)
+ *
+ * If hook events race ahead of the terminal envelope, S5's ingestor
+ * auto-registers the cc_session_id as a `local.observed` ORPHAN session
+ * (its own task/agent/assignment). When the terminal envelope then arrives
+ * carrying that same cc_session_id, naively backfilling it onto the projected
+ * session would violate the partial unique index
+ * `idx_sessions_active_cc_session_id` (≤ 1 OPEN session per cc_session_id).
+ *
+ * DIRECTION (stated in the PR): ADOPT the orphan session INTO the projected
+ * assignment. We re-point `sessions.assignment_id` of the orphan row to the
+ * projected assignment (O(1) — the orphan's hook events follow via the
+ * `events.session_id → sessions.id` FK, no event re-write), drop the now-empty
+ * projected placeholder session, transition the projected assignment, and
+ * delete the orphan's emptied assignment. This is cheaper than re-pointing N
+ * events and preserves every hook event + its CASCADE. The orphan's shared
+ * catch-all task/agent are bookkeeping and left in place (idempotent, shared).
+ */
+
+import type { Database } from "bun:sqlite";
+
+import { generateId } from "../db/events";
+import { applyTransition } from "../db/transitions";
+import type { AssignmentState } from "../types";
+
+/**
+ * The four `dispatch.task.*` lifecycle kinds this projection handles. Keyed by
+ * the trailing segment of `envelope.type` (`dispatch.task.<kind>`). S6 (#848)
+ * extends the seam to verdicts / attention / heartbeats; this set stays the
+ * dispatch-lifecycle slice's scope.
+ */
+type LifecycleKind = "started" | "completed" | "failed" | "aborted";
+
+/** Terminal kinds carry the AUTHORITATIVE cc_session_id and a terminal state. */
+const TERMINAL_ACTION: Record<
+  Exclude<LifecycleKind, "started">,
+  "complete" | "fail" | "cancel"
+> = {
+  completed: "complete",
+  failed: "fail",
+  aborted: "cancel",
+};
+
+/**
+ * Minimal view of the lifecycle payload the projection reads. The lifecycle
+ * envelopes carry `task_id`, `agent_id`, and (optionally) `cc_session_id`; no
+ * human description rides the wire (see module docblock).
+ */
+interface LifecyclePayload {
+  task_id?: unknown;
+  agent_id?: unknown;
+  cc_session_id?: unknown;
+}
+
+/** A read of the projected session for a correlation_id, via the anchor task. */
+interface ProjectedSessionRow {
+  sessionId: string;
+  assignmentId: string;
+  ccSessionId: string | null;
+}
+
+/**
+ * The minimal envelope shape the projection reads — kept structural (not the
+ * full `Envelope` import) so the renderer can hand any validated envelope here.
+ */
+export interface ProjectableEnvelope {
+  type: string;
+  correlation_id?: string;
+  payload: Record<string, unknown>;
+}
+
+export interface ProjectionResult {
+  /** The lifecycle kind that was projected. */
+  kind: LifecycleKind;
+  /** Correlation id used as the projection anchor. */
+  correlationId: string;
+  /** MC session row id the projection landed on. */
+  sessionId: string;
+  /** MC assignment row id. */
+  assignmentId: string;
+}
+
+// ---------------------------------------------------------------------------
+// Public entry point
+// ---------------------------------------------------------------------------
+
+/**
+ * Project one `dispatch.task.*` lifecycle envelope into MC rows.
+ *
+ * Returns `null` (a no-op) for any envelope that is NOT a recognised
+ * `dispatch.task.{started|completed|failed|aborted}` — the renderer subscribes
+ * broadly and this is the authoritative type filter. Also returns `null` when
+ * the payload is malformed (missing `task_id`/`agent_id`) so a bad publisher
+ * can't create half-formed anchors.
+ *
+ * Idempotent on `correlation_id`: a redelivered `started` reuses the existing
+ * anchor; a redelivered terminal re-applies the (already-terminal) transition
+ * harmlessly (the state machine rejects the redundant move, which we tolerate).
+ */
+export function projectDispatchLifecycle(
+  db: Database,
+  envelope: ProjectableEnvelope,
+): ProjectionResult | null {
+  const kind = lifecycleKind(envelope.type);
+  if (kind === null) return null;
+
+  // Defensive read: the schema makes `payload` a non-null object, but a
+  // malformed envelope that slipped the validator (or a renderer handing us a
+  // hand-built object) could carry a non-object payload. Treat anything
+  // non-object as "no fields", so `asString` below returns null and we ignore
+  // the envelope rather than throwing on a property access of null.
+  const rawPayload: unknown = envelope.payload;
+  const payload: LifecyclePayload =
+    typeof rawPayload === "object" && rawPayload !== null ? rawPayload : {};
+  const taskId = asString(payload.task_id);
+  const agentId = asString(payload.agent_id);
+  if (taskId === null || agentId === null) {
+    process.stderr.write(
+      `[mission-control] dispatch-projection: ignoring ${envelope.type} — missing task_id/agent_id\n`,
+    );
+    return null;
+  }
+
+  // The lifecycle envelopes share one correlation_id; fall back to task_id
+  // (the builder's default) when the field is absent on the wire.
+  const correlationId = envelope.correlation_id ?? taskId;
+  const ccSessionId = asString(payload.cc_session_id);
+
+  // Everything below runs in ONE transaction: anchor creation, transition, and
+  // (for terminal) cc_session_id backfill + orphan reconciliation must be
+  // atomic so a partial write can't leave a dangling row or a double cc_session.
+  const txn = db.transaction((): ProjectionResult => {
+    // Idempotently ensure the anchor (task + agent + assignment + session).
+    const anchor = ensureAnchor(db, {
+      correlationId,
+      taskId,
+      agentId,
+      // started on a RESUME may stamp the prior session's id provisionally;
+      // a fresh dispatch's started carries no id (pending).
+      provisionalCcSessionId: kind === "started" ? ccSessionId : null,
+    });
+
+    if (kind === "started") {
+      // Drive the assignment dispatched → running so the working grid shows the
+      // session as active. Idempotent: a redelivered started finds the
+      // assignment already `running` and the transition is a no-op (the state
+      // machine rejects start-from-running; we tolerate that).
+      driveTo(db, anchor.assignmentId, anchor.sessionId, "start");
+      return {
+        kind,
+        correlationId,
+        sessionId: anchor.sessionId,
+        assignmentId: anchor.assignmentId,
+      };
+    }
+
+    // Terminal kinds: backfill the AUTHORITATIVE cc_session_id, reconcile any
+    // S5 orphan that already holds it, then transition to the terminal state.
+    let sessionId = anchor.sessionId;
+    if (ccSessionId !== null) {
+      sessionId = backfillCcSessionId(db, {
+        projectedSessionId: anchor.sessionId,
+        projectedAssignmentId: anchor.assignmentId,
+        ccSessionId,
+      });
+    }
+
+    // A terminal envelope can arrive before the assignment ever reached
+    // `running` (lost/reordered `started`). Walk it forward through the legal
+    // path so the terminal transition is always valid.
+    driveToTerminal(db, anchor.assignmentId, sessionId, TERMINAL_ACTION[kind]);
+
+    return {
+      kind,
+      correlationId,
+      sessionId,
+      assignmentId: anchor.assignmentId,
+    };
+  });
+
+  return txn();
+}
+
+// ---------------------------------------------------------------------------
+// Anchor
+// ---------------------------------------------------------------------------
+
+const ANCHOR_TASK_PREFIX = "mc-dispatch-task-";
+const ANCHOR_TASK_PRINCIPAL = "mc-dispatch";
+const ANCHOR_TASK_SOURCE_SYSTEM = "internal";
+const CONTROLLED_ENDPOINT = "local.process.controlled";
+
+/** Deterministic MC task id for a dispatch correlation_id. One task per dispatch. */
+function anchorTaskId(correlationId: string): string {
+  return `${ANCHOR_TASK_PREFIX}${correlationId}`;
+}
+
+interface AnchorParams {
+  correlationId: string;
+  taskId: string;
+  agentId: string;
+  /** Provisional cc id from a resume `started`, or null (pending). */
+  provisionalCcSessionId: string | null;
+}
+
+/**
+ * Idempotently create (or find) the projection anchor for a correlation_id:
+ * a per-dispatch MC task, the dispatched agent row, an assignment born
+ * `dispatched`, and a controlled session. Re-finds the existing anchor on a
+ * redelivered envelope so the projection never duplicates rows.
+ */
+function ensureAnchor(
+  db: Database,
+  params: AnchorParams,
+): { sessionId: string; assignmentId: string } {
+  // Fast path: anchor already exists for this correlation_id.
+  const existing = findProjectedSession(db, params.correlationId);
+  if (existing) {
+    // A provisional resume cc id can land on a session that was created without
+    // one (e.g. the terminal raced the started). Stamp it only if still pending
+    // — the terminal backfill remains authoritative.
+    if (
+      params.provisionalCcSessionId !== null &&
+      existing.ccSessionId === null
+    ) {
+      setProvisionalCcSessionId(
+        db,
+        existing.sessionId,
+        params.provisionalCcSessionId,
+      );
+    }
+    return {
+      sessionId: existing.sessionId,
+      assignmentId: existing.assignmentId,
+    };
+  }
+
+  // Create the anchor task (one per dispatch). Bookkeeping row, not a real
+  // provider work item — same shape as S5's orphan catch-all task.
+  const taskRowId = anchorTaskId(params.correlationId);
+  db.query(
+    `INSERT INTO tasks (id, title, priority, principal_id, source_system, status)
+     VALUES (?, ?, 2, ?, ?, 'in_progress')
+     ON CONFLICT(id) DO NOTHING`,
+  ).run(
+    taskRowId,
+    `Dispatched task (${params.agentId})`,
+    ANCHOR_TASK_PRINCIPAL,
+    ANCHOR_TASK_SOURCE_SYSTEM,
+  );
+
+  // The dispatched agent. `head` type (it runs a task) — insert-only name so a
+  // principal-edited display name is never overwritten, matching ensureNamedAgent.
+  db.query(
+    `INSERT INTO agents (id, name, type, persistent)
+     VALUES (?, ?, 'head', 1)
+     ON CONFLICT(id) DO NOTHING`,
+  ).run(params.agentId, params.agentId);
+
+  const assignmentId = generateId();
+  const sessionId = generateId();
+  const now = new Date().toISOString();
+
+  // Assignment born `dispatched` — the started projection drives it to running;
+  // a terminal-first delivery walks it forward via the legal path.
+  db.query(
+    `INSERT INTO agent_task_assignment (id, agent_id, task_id, state)
+     VALUES (?, ?, ?, 'dispatched')`,
+  ).run(assignmentId, params.agentId, taskRowId);
+
+  // Controlled session — dispatch spawns are controlled, distinguishing them
+  // from S5's local.observed orphans. cc_session_id is the provisional resume
+  // id when present, else NULL (pending until the terminal backfills it).
+  db.query(
+    `INSERT INTO sessions
+       (id, assignment_id, cc_session_id, endpoint_kind, pid, started_at)
+     VALUES (?, ?, ?, ?, NULL, ?)`,
+  ).run(
+    sessionId,
+    assignmentId,
+    params.provisionalCcSessionId,
+    CONTROLLED_ENDPOINT,
+    now,
+  );
+
+  return { sessionId, assignmentId };
+}
+
+/**
+ * Find the projection's session for a correlation_id via the deterministic
+ * anchor task → its non-cancelled assignment → most-recent session. Returns the
+ * session + assignment + current cc_session_id, or null when no anchor exists.
+ */
+function findProjectedSession(
+  db: Database,
+  correlationId: string,
+): ProjectedSessionRow | null {
+  const row = db
+    .query(
+      `SELECT s.id AS session_id, s.assignment_id AS assignment_id,
+              s.cc_session_id AS cc_session_id
+       FROM agent_task_assignment a
+       JOIN sessions s ON s.assignment_id = a.id
+       WHERE a.task_id = ?
+       ORDER BY s.started_at DESC, s.id DESC
+       LIMIT 1`,
+    )
+    .get(anchorTaskId(correlationId)) as
+    | { session_id: string; assignment_id: string; cc_session_id: string | null }
+    | null;
+  if (!row) return null;
+  return {
+    sessionId: row.session_id,
+    assignmentId: row.assignment_id,
+    ccSessionId: row.cc_session_id,
+  };
+}
+
+function setProvisionalCcSessionId(
+  db: Database,
+  sessionId: string,
+  ccSessionId: string,
+): void {
+  db.query(`UPDATE sessions SET cc_session_id = ? WHERE id = ?`).run(
+    ccSessionId,
+    sessionId,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// cc_session_id backfill + orphan reconciliation
+// ---------------------------------------------------------------------------
+
+interface BackfillParams {
+  projectedSessionId: string;
+  projectedAssignmentId: string;
+  ccSessionId: string;
+}
+
+/**
+ * Backfill the AUTHORITATIVE cc_session_id onto the projected session, after
+ * reconciling any S5 orphan that already holds it.
+ *
+ * Returns the session id the projection should regard as canonical going
+ * forward (the projected session in the no-orphan path; still the projected
+ * session in the orphan path — we adopt the orphan's events ONTO the projected
+ * assignment's session, see below).
+ */
+function backfillCcSessionId(db: Database, params: BackfillParams): string {
+  const orphan = findReconcilableOrphan(db, params);
+
+  if (orphan === null) {
+    // No competing row — straight backfill (overwriting a provisional resume id
+    // if it diverged; terminal is authoritative).
+    db.query(`UPDATE sessions SET cc_session_id = ? WHERE id = ?`).run(
+      params.ccSessionId,
+      params.projectedSessionId,
+    );
+    return params.projectedSessionId;
+  }
+
+  // Orphan reconciliation. The orphan session carries the hook events (FK
+  // `events.session_id → sessions.id`). ADOPT it onto the projected assignment
+  // by re-pointing its assignment_id, then drop the empty projected placeholder
+  // and the orphan's now-empty assignment. This is O(1) row moves — the hook
+  // events follow the session, no per-event rewrite.
+  //
+  // Order matters against the partial unique index `idx_sessions_active_assignment`
+  // (≤ 1 OPEN session per assignment): the projected placeholder must be removed
+  // BEFORE the orphan is re-pointed onto the projected assignment, or two open
+  // sessions would momentarily share it. The placeholder has no events of its
+  // own (started created it empty), so deleting it loses nothing.
+
+  // 1. Delete the empty projected placeholder session.
+  db.query(`DELETE FROM sessions WHERE id = ?`).run(params.projectedSessionId);
+
+  // 2. Re-point the orphan session onto the projected assignment and stamp the
+  //    authoritative cc_session_id (idempotent — it already equals ccSessionId,
+  //    but the SET keeps the write explicit and survives a provisional mismatch).
+  db.query(
+    `UPDATE sessions SET assignment_id = ?, cc_session_id = ? WHERE id = ?`,
+  ).run(params.projectedAssignmentId, params.ccSessionId, orphan.sessionId);
+
+  // 3. Delete the orphan's now-empty assignment (its session moved away; the
+  //    shared orphan task + per-orphan agent are bookkeeping, left in place).
+  db.query(`DELETE FROM agent_task_assignment WHERE id = ?`).run(
+    orphan.assignmentId,
+  );
+
+  return orphan.sessionId;
+}
+
+/**
+ * Find an S5 orphan session holding `ccSessionId` that is NOT already the
+ * projection's own session. Returns the orphan's session + assignment, or null
+ * when there's nothing to reconcile (no orphan, or the projected session already
+ * carries the id from a provisional stamp).
+ */
+function findReconcilableOrphan(
+  db: Database,
+  params: BackfillParams,
+): { sessionId: string; assignmentId: string } | null {
+  const row = db
+    .query(
+      `SELECT id, assignment_id
+       FROM sessions
+       WHERE cc_session_id = ? AND id != ?
+       ORDER BY started_at DESC, id DESC
+       LIMIT 1`,
+    )
+    .get(params.ccSessionId, params.projectedSessionId) as
+    | { id: string; assignment_id: string }
+    | null;
+  if (!row) return null;
+  return { sessionId: row.id, assignmentId: row.assignment_id };
+}
+
+// ---------------------------------------------------------------------------
+// State-machine driving
+// ---------------------------------------------------------------------------
+
+/**
+ * Apply one transition, tolerating an idempotent no-op (a redelivered envelope
+ * trying to re-apply an already-applied move). Logs other failures to stderr —
+ * the projection must not throw out of the renderer's render() path.
+ */
+function driveTo(
+  db: Database,
+  assignmentId: string,
+  sessionId: string,
+  action: "start",
+): void {
+  // Idempotency: a redelivered `started` finds the assignment already advanced
+  // past `dispatched`. The state machine only allows `start` FROM `dispatched`,
+  // so re-applying it from any later state is a benign no-op — NOT an error
+  // worth a log line. Guard on the current state so redelivery stays silent and
+  // only a genuinely-unexpected failure (assignment vanished mid-txn) surfaces.
+  const current = currentAssignmentState(db, assignmentId);
+  if (current !== "dispatched") return;
+
+  const result = applyTransition(db, assignmentId, sessionId, { type: action });
+  if (!result.ok) {
+    process.stderr.write(
+      `[mission-control] dispatch-projection: '${action}' on assignment '${assignmentId}' failed unexpectedly (${result.error})\n`,
+    );
+  }
+}
+
+/**
+ * Walk an assignment to a terminal state. A terminal envelope may arrive while
+ * the assignment is still `dispatched` (started lost/reordered), or already
+ * `running`. The state machine only allows complete/fail/cancel FROM `running`
+ * (cancel also from queued/dispatched/blocked), so:
+ *
+ *   - `cancel` (aborted): legal from dispatched OR running → one step.
+ *   - `complete`/`fail`: require `running` → if still `dispatched`, drive
+ *     `start` first, then the terminal action.
+ *
+ * Idempotent: re-running on an already-terminal assignment is a tolerated
+ * no-op (the state machine rejects outgoing transitions from terminal states).
+ */
+function driveToTerminal(
+  db: Database,
+  assignmentId: string,
+  sessionId: string,
+  action: "complete" | "fail" | "cancel",
+): void {
+  const current = currentAssignmentState(db, assignmentId);
+  if (current === null) return;
+
+  // Already terminal → idempotent no-op.
+  if (
+    current === "completed" ||
+    current === "failed" ||
+    current === "cancelled"
+  ) {
+    return;
+  }
+
+  // complete/fail need `running`; bridge from `dispatched` via `start`.
+  if (
+    (action === "complete" || action === "fail") &&
+    current === "dispatched"
+  ) {
+    const started = applyTransition(db, assignmentId, sessionId, {
+      type: "start",
+    });
+    if (!started.ok) {
+      process.stderr.write(
+        `[mission-control] dispatch-projection: bridge 'start' before '${action}' failed for assignment '${assignmentId}': ${started.error}\n`,
+      );
+      return;
+    }
+  }
+
+  const result = applyTransition(db, assignmentId, sessionId, { type: action });
+  if (!result.ok) {
+    process.stderr.write(
+      `[mission-control] dispatch-projection: terminal '${action}' failed for assignment '${assignmentId}': ${result.error}\n`,
+    );
+  }
+}
+
+function currentAssignmentState(
+  db: Database,
+  assignmentId: string,
+): AssignmentState | null {
+  const row = db
+    .query(`SELECT state FROM agent_task_assignment WHERE id = ?`)
+    .get(assignmentId) as { state: AssignmentState } | null;
+  return row ? row.state : null;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Map `envelope.type` to its lifecycle kind, or null when the type is not a
+ * recognised `dispatch.task.{started|completed|failed|aborted}`. This is the
+ * authoritative type filter — the renderer subscribes broadly (subject
+ * wildcards) and everything non-matching is dropped here.
+ */
+function lifecycleKind(type: string): LifecycleKind | null {
+  switch (type) {
+    case "dispatch.task.started":
+      return "started";
+    case "dispatch.task.completed":
+      return "completed";
+    case "dispatch.task.failed":
+      return "failed";
+    case "dispatch.task.aborted":
+      return "aborted";
+    default:
+      return null;
+  }
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}

--- a/src/surface/mc/projection/dispatch-lifecycle.ts
+++ b/src/surface/mc/projection/dispatch-lifecycle.ts
@@ -63,7 +63,11 @@
  * `events.session_id → sessions.id` FK, no event re-write), drop the now-empty
  * projected placeholder session, transition the projected assignment, and
  * delete the orphan's emptied assignment. This is cheaper than re-pointing N
- * events and preserves every hook event + its CASCADE. The orphan's shared
+ * events and preserves every HOOK event (they ride the orphan session's FK).
+ * What is NOT preserved verbatim: the placeholder's own `state.transition`
+ * events CASCADE away with its DELETE, and `driveToTerminal` re-synthesizes
+ * the start→terminal pair on the adopted row at TERMINAL-time timestamps —
+ * transition history is reconstructed, not carried over. The orphan's shared
  * catch-all task/agent are bookkeeping and left in place (idempotent, shared).
  */
 
@@ -427,6 +431,12 @@ function backfillCcSessionId(db: Database, params: BackfillParams): string {
   // 2. Re-point the orphan session onto the projected assignment and stamp the
   //    authoritative cc_session_id (idempotent — it already equals ccSessionId,
   //    but the SET keeps the write explicit and survives a provisional mismatch).
+  //    INTENTIONAL INVARIANT: the adopted session stays OPEN (`ended_at` NULL)
+  //    after the terminal transition — sessions are closed by the ingestor's
+  //    convention (hook Stop), not by lifecycle projection, so late-arriving
+  //    hook events still ingest. The open row keeps occupying the
+  //    `idx_sessions_active_cc_session_id` partial index by design: it IS the
+  //    one active row for that cc_session_id.
   db.query(
     `UPDATE sessions SET assignment_id = ?, cc_session_id = ? WHERE id = ?`,
   ).run(params.projectedAssignmentId, params.ccSessionId, orphan.sessionId);


### PR DESCRIPTION
## What

Project `dispatch.task.*` lifecycle envelopes into Mission Control session/assignment/task rows, so dispatch-driven work appears **live** on the working grid: when the daemon dispatches a task to an agent, MC shows the session (started); on terminal the assignment transitions **and** the session row carries the authoritative `cc_session_id` — so the S5 ingestor's hook events join onto the **same** session, not a duplicate orphan.

## Why

Implements **ADR-0005 §3** ("Session rows are projected from the bus" — MC plays the dispatch-sink role) and **§4** ("The bus→MC seam is a registered renderer" — push-based `project(envelope)`, demoting the `DashboardRenderer` ring-buffer stub). Builds directly on the merged stack: S1 (in-process MC embed, `mcDb`), S3 (`cc_session_id` stamped onto the lifecycle envelopes — authoritative on the terminal), S5 (`registerOrphanSession` synthetic-anchor pattern + the ingestor's orphan auto-register).

Per the **#846 design comment** cc_session_id timing contract: the harness emits `started` *before* spawning CC, so on a fresh dispatch the session id is unknown at `started`; it is authoritative on the **terminal** envelope. So the projection keys the session on `correlation_id` (id pending — or provisional on resume) and **backfills** the authoritative id when the terminal arrives.

## Task-mapping decision

The lifecycle envelopes carry `task_id`, `agent_id`, optional `cc_session_id` + timestamps — but **no human description** (`DispatchTaskReceivedPayload.prompt` is deliberately *not* echoed onto lifecycle payloads). So: **one MC task per dispatch `correlation_id`** (deterministic id `mc-dispatch-task-{correlation_id}`), titled from the dispatched `agent_id` (the only label on the wire); the dispatched `agent_id` → an MC `agents` row; an assignment born `dispatched` → driven `running` on started → terminal state on terminal; a `local.process.controlled` session (distinguishing dispatch spawns from S5's `local.observed` orphans), found via task→assignment→session (the `correlation_id` anchor). Mirrors S5's `registerOrphanSession` synthetic-anchor pattern, dispatch-flavored.

## Orphan-reconciliation decision

If hook events race ahead of the terminal envelope, S5's ingestor orphan-registers the `cc_session_id` as a `local.observed` session (its own task/agent/assignment, carrying the events). Naively backfilling that id onto the projected session would violate the partial unique index `idx_sessions_active_cc_session_id` (≤ 1 **open** session per cc_session_id). **Direction chosen: adopt the orphan session INTO the projected assignment** — re-point `sessions.assignment_id` (O(1); the orphan's hook events follow via the `events.session_id → sessions.id` FK, no per-event rewrite), drop the empty projected placeholder session, transition the projected assignment, delete the orphan's emptied assignment. Cheaper than re-pointing N events; preserves every hook event + its CASCADE. (Re-pointing the session row beats re-pointing events; the placeholder is empty so deleting it loses nothing.)

## Files

- `src/surface/mc/projection/dispatch-lifecycle.ts` — pure-ish `(db, envelope)` projection; anchor on started, terminal transition + cc_session_id backfill + orphan reconciliation, all in one transaction. Out-of-order safe (terminal can arrive without/before started — bridges via the legal state path). Idempotent on `correlation_id`.
- `src/surface/mc/projection/dispatch-lifecycle-renderer.ts` — the §4 seam: a **non-throwing** `SurfaceAdapter` with a single `project(envelope)` dispatcher keyed on `envelope.type` (today `dispatch.task.*`; S6 #848 extends it to verdicts/attention/heartbeats). Subscribes to the local stack-ful/stack-less + federated `dispatch.task.*` subjects; the authoritative type filter is the projection's own `lifecycleKind` check.
- `src/cortex.ts` — register the renderer with the surface-router when `mc.enabled`, beside the S1 `mcDb` wiring.

## Known gap (S6 #848)

The MC server's WS broadcasts on transitions via a `WsClientRegistry` the db layer doesn't know about; existing mutation paths (api/handlers, the ingestor) fan out at the call site after the db write. The projection's writes bypass that fan-out, so a freshly-projected session/transition won't push to live dashboard clients until their next poll/refetch. Threading the registry through is the generalized notification seam **S6 owns**; documented in the renderer module, left as a gap here rather than a partial wire-up.

## Test plan

TDD (RED → GREEN). New: `dispatch-lifecycle-projection.test.ts` (10 cases), `dispatch-lifecycle-renderer.test.ts` (6 cases):
- full lifecycle started→completed: anchor + transitions + cc_session_id backfill
- failed → `failed`, aborted → `cancelled`
- idempotent on redelivered `started` (same correlation_id) — no duplicate rows
- **orphan-reconciliation**: S5 orphan for the terminal cc_session_id is adopted (single session, events survive), not duplicated
- **resume-divergence**: started's prior id is provisional; the terminal id wins
- terminal-first / out-of-order delivery still anchors + transitions
- non-dispatch envelope types ignored; renderer never throws on malformed input
- renderer subjects match real derived `dispatch.task` subjects via the router's NATS matcher, and reject non-dispatch subjects

**Gate results:**
- `bun run lint` → 0 errors (27 pre-existing unused-directive warnings in unrelated files; none in changed files)
- `bunx tsc --noEmit` → clean
- `bun test` (full) → 5220 pass, 0 fail
- `bash scripts/check-carveouts.sh` on changed files → PASS

Closes #846
Part of #843

🤖 Generated with [Claude Code](https://claude.com/claude-code)