### PR TITLE
feat(mc): MC-I1.S6 — generalize the MC projection renderer (verdicts, heartbeats, adapter health) + live WS push

### DIFF
--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -2686,16 +2686,19 @@ export async function startCortex(
       mcDb = mcHandle.db;
       console.log(`cortex: Mission Control embed listening on http://localhost:${mcHandle.port} — db ${dbPath}`);
 
-      // MC-I1.S4 (ADR-0005 §3/§4) — register the bus→MC projection renderer so
-      // `dispatch.task.*` lifecycle envelopes land as session/assignment rows on
-      // the working grid. The seam is a surface-router renderer (§4), subscribing
-      // to the dispatch-lifecycle subjects only; its render() is non-throwing
-      // (the surface-router isolates errors too, but the renderer owns the
-      // contract). S6 (#848) extends the same renderer's project() dispatcher to
-      // verdicts / attention / heartbeats. No restart-on-config — like every
-      // renderer, the registration is static for the daemon's lifetime.
-      router.register(createDispatchProjectionRenderer(mcDb));
-      console.log("cortex: Mission Control dispatch-lifecycle projection renderer registered");
+      // MC-I1.S4/S6 (ADR-0005 §3/§4) — register the bus→MC projection renderer.
+      // The seam is a surface-router renderer (§4) with a single project()
+      // dispatcher: S4 lands `dispatch.task.*` lifecycle envelopes as
+      // session/assignment rows; S6 (#848) generalises it to review verdicts,
+      // agent heartbeats, federated attention, and adapter health. Its render()
+      // is non-throwing (the surface-router isolates errors too, but the
+      // renderer owns the contract). The embed's `wsRegistry` is threaded in so
+      // projected mutations broadcast `mc.projection` refresh signals to live
+      // dashboard clients (S6 — closes the S4 WS fan-out gap). No
+      // restart-on-config — like every renderer, the registration is static for
+      // the daemon's lifetime.
+      router.register(createDispatchProjectionRenderer(mcDb, mcHandle.wsRegistry));
+      console.log("cortex: Mission Control bus→MC projection renderer registered (dispatch + verdicts + heartbeats + attention + adapter health)");
     } catch (err) {
       console.error("cortex: Mission Control embed startup error (non-fatal):", err instanceof Error ? err.message : err);
     }

--- a/src/renderers/dashboard.ts
+++ b/src/renderers/dashboard.ts
@@ -1,29 +1,35 @@
 /**
  * MIG-7.2d — Dashboard renderer (in-memory buffer stub).
  *
- * Architecture §9.2 makes the dashboard activity-centric, not agent-centric.
- * The eventual Mission Control v3 surface (under `src/surface/mc/`) reads
- * from a stream of recent bus envelopes and projects them into
- * Kanban/inbox/status-banner views. Full Mission Control integration
- * lands at MIG-7.13 (integration test) when cortex.ts wires MC into the
- * top-level startup.
+ * ## SUPERSEDED as the MC feed (ADR-0005 §4, MC-I1.S6 #848)
  *
- * For this slice the dashboard renderer is the *sink* that satisfies the
- * G-1111 §4.6 fail-safe rule's pairing requirement alongside
- * `PagerDutyRenderer` — operationally distinct platform classes both
- * subscribed to `local.{principal}.system.>` so a degraded NATS subscription
- * for one doesn't blind the principal on the other.
+ * This ring buffer was the MIG-7.13 plan's anticipated bus→MC IPC mechanism:
+ * MC was to POLL `getRecent()` and project the recent-envelope window onto the
+ * glass. **ADR-0005 §4 demotes that plan.** The bus→MC seam is now a registered
+ * surface-router renderer (`src/surface/mc/projection/dispatch-lifecycle-renderer.ts`)
+ * doing push-based `project(envelope)` straight into MC rows — no polling, no
+ * 1000-envelope bound that drops bursts, no dedup bookkeeping. The ADR records
+ * this buffer "survives, if at all, only as the drill-down's recent-raw-envelopes
+ * feed."
  *
- * Implementation: a bounded ring buffer over the last N envelopes the
- * router delivered. Tests probe `getRecent()` to assert the renderer is
- * actually receiving; Mission Control's projection pipeline will graduate
- * the buffer to a richer data structure at MIG-7.13.
+ * **S6 disposition: RETAINED, not retired.** Verified at S6 time that NOTHING in
+ * production reads `getRecent()` (only this file's own tests do) — so the buffer
+ * is functionally inert as an MC feed. It is kept rather than removed because:
+ *   - it is still a user-facing `renderers:` config `kind: dashboard` in the
+ *     `RendererSchema` discriminated union; removing it is a config-breaking
+ *     change (a principal carrying `kind: dashboard` would fail to boot), wider
+ *     blast radius than the faithful demotion this slice owns; and
+ *   - it still satisfies the G-1111 §4.6 fail-safe-pairing rule alongside
+ *     `PagerDutyRenderer` (two operationally-distinct sinks on
+ *     `local.{principal}.system.>` so a degraded subscription for one doesn't
+ *     blind the principal on the other) — retiring it would also need that rule
+ *     re-homed.
+ * If/when the ADR's "drill-down recent-raw feed" consumer is built it reads off
+ * `getRecent()`; until then this is a no-op sink, intentionally.
  *
- * The renderer DOES NOT serve HTTP itself — Mission Control's existing
- * Bun server keeps that concern. Wiring is one direction only: cortex.ts
- * registers the renderer with the surface-router; MC's server (a separate
- * Bun process today, an in-process module post-MIG-7.13) reads the buffer
- * out of process when it lands.
+ * The renderer DOES NOT serve HTTP itself — Mission Control's existing Bun
+ * server keeps that concern. Architecture §9.2 makes the dashboard
+ * activity-centric, not agent-centric.
  */
 
 import type { Envelope } from "../bus/myelin/envelope-validator";

--- a/src/surface/mc/__tests__/agents-ensure-row.test.ts
+++ b/src/surface/mc/__tests__/agents-ensure-row.test.ts
@@ -1,0 +1,141 @@
+/**
+ * MC-I1.S6 (#848) — tests for the `ensureAgentRow` DRY helper (the deferred
+ * #861-review finding-3 pickup) AND the three call sites it now backs.
+ *
+ * The helper itself: insert-only-name idempotency + the type/persistent
+ * parameterisation. The call sites: behaviour-unchanged proof that
+ * `ensureNamedAgent` / `ensureOrphanAgent` / the dispatch anchor still land
+ * the SAME rows they did before the extraction.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { Database } from "bun:sqlite";
+
+import { SCHEMA_SQL } from "../db/schema";
+import { ensureAgentRow } from "../db/agents";
+import { registerOrphanSession, orphanAgentId } from "../db/sessions";
+import { projectDispatchLifecycle } from "../projection/dispatch-lifecycle";
+import {
+  createDispatchTaskStartedEvent,
+  type DispatchEventSource,
+} from "../../../bus/dispatch-events";
+
+const SOURCE: DispatchEventSource = {
+  principal: "andreas",
+  agent: "cortex",
+  instance: "local",
+};
+const TASK_ID = "44444444-4444-4444-8444-444444444444";
+
+function setupDb(): Database {
+  const db = new Database(":memory:");
+  db.exec("PRAGMA journal_mode = WAL");
+  db.exec("PRAGMA foreign_keys = ON");
+  for (const sql of SCHEMA_SQL) db.exec(sql);
+  return db;
+}
+
+interface AgentRow {
+  id: string;
+  name: string;
+  type: string;
+  persistent: number;
+}
+
+function agent(db: Database, id: string): AgentRow | null {
+  return db
+    .query(`SELECT id, name, type, persistent FROM agents WHERE id = ?`)
+    .get(id) as AgentRow | null;
+}
+
+describe("ensureAgentRow", () => {
+  let db: Database;
+  beforeEach(() => {
+    db = setupDb();
+  });
+  afterEach(() => {
+    db.close();
+  });
+
+  it("inserts a head/persistent agent", () => {
+    ensureAgentRow(db, { id: "echo", name: "Echo", type: "head", persistent: true });
+    expect(agent(db, "echo")).toEqual({
+      id: "echo",
+      name: "Echo",
+      type: "head",
+      persistent: 1,
+    });
+  });
+
+  it("inserts a hands/non-persistent agent", () => {
+    ensureAgentRow(db, { id: "worker", name: "Worker", type: "hands", persistent: false });
+    expect(agent(db, "worker")).toEqual({
+      id: "worker",
+      name: "Worker",
+      type: "hands",
+      persistent: 0,
+    });
+  });
+
+  it("is insert-only on the name — a second call never clobbers a principal-edited name", () => {
+    ensureAgentRow(db, { id: "luna", name: "Luna", type: "head", persistent: true });
+    // Principal renames the agent out-of-band.
+    db.query(`UPDATE agents SET name = ? WHERE id = ?`).run("Luna (renamed)", "luna");
+    // A re-dispatch calls ensureAgentRow again with the ORIGINAL name.
+    ensureAgentRow(db, { id: "luna", name: "Luna", type: "head", persistent: true });
+    expect(agent(db, "luna")?.name).toBe("Luna (renamed)");
+  });
+
+  it("is idempotent — repeated calls do not create duplicate rows", () => {
+    ensureAgentRow(db, { id: "echo", name: "Echo", type: "head", persistent: true });
+    ensureAgentRow(db, { id: "echo", name: "Echo", type: "head", persistent: true });
+    const n = (
+      db.query(`SELECT COUNT(*) AS n FROM agents WHERE id = 'echo'`).get() as {
+        n: number;
+      }
+    ).n;
+    expect(n).toBe(1);
+  });
+});
+
+describe("ensureAgentRow — call sites behaviour unchanged", () => {
+  let db: Database;
+  beforeEach(() => {
+    db = setupDb();
+  });
+  afterEach(() => {
+    db.close();
+  });
+
+  it("registerOrphanSession still lands a head/non-persistent agent (ensureOrphanAgent path)", () => {
+    const cc = "cccccccc-cccc-4ccc-8ccc-cccccccccccc";
+    registerOrphanSession(db, cc, "Andreas");
+    const row = agent(db, orphanAgentId(cc));
+    expect(row).not.toBeNull();
+    expect(row?.type).toBe("head");
+    expect(row?.persistent).toBe(0);
+    expect(row?.name).toBe("Andreas");
+  });
+
+  it("registerOrphanSession falls back to the cc_session_id when no name (ensureOrphanAgent path)", () => {
+    const cc = "dddddddd-dddd-4ddd-8ddd-dddddddddddd";
+    registerOrphanSession(db, cc);
+    expect(agent(db, orphanAgentId(cc))?.name).toBe(cc);
+  });
+
+  it("the dispatch anchor still lands a head/persistent agent (S4 copy path)", () => {
+    projectDispatchLifecycle(
+      db,
+      createDispatchTaskStartedEvent({
+        source: SOURCE,
+        taskId: TASK_ID,
+        agentId: "echo",
+        startedAt: new Date("2026-06-10T12:00:00.000Z"),
+      }),
+    );
+    const row = agent(db, "echo");
+    expect(row).not.toBeNull();
+    expect(row?.type).toBe("head");
+    expect(row?.persistent).toBe(1);
+  });
+});

--- a/src/surface/mc/__tests__/dispatch-lifecycle-renderer.test.ts
+++ b/src/surface/mc/__tests__/dispatch-lifecycle-renderer.test.ts
@@ -122,13 +122,44 @@ describe("createDispatchProjectionRenderer", () => {
     }
   });
 
-  it("does NOT match non-dispatch subjects", () => {
-    const nonDispatch = [
-      "local.andreas.work.system.heartbeat",
-      "local.andreas.work.review.verdict.completed",
-      "local.andreas.tasks.@did-mf-luna.chat",
+  it("subjects match the S6-generalized families (verdict / heartbeat / attention / adapter)", () => {
+    // S6 (#848) extends the seam beyond dispatch.task.*: the renderer now
+    // subscribes to the four additional projection families on the local
+    // (stack-ful + stack-less) and federated grammars.
+    const derived = [
+      // review verdicts
+      "local.andreas.work.review.verdict.changes-requested",
+      "local.andreas.review.verdict.approved",
+      "federated.peer.work.review.verdict.commented",
+      // agent heartbeat
+      "local.andreas.work.system.agent.heartbeat",
+      "local.andreas.system.agent.heartbeat",
+      "federated.peer.work.system.agent.heartbeat",
+      // attention
+      "local.andreas.work.system.attention.opened",
+      "federated.peer.work.system.attention.resolved",
+      // adapter health
+      "local.andreas.work.system.adapter.degraded",
+      "federated.peer.work.system.adapter.recovered",
     ];
-    for (const subject of nonDispatch) {
+    for (const subject of derived) {
+      const hit = DISPATCH_PROJECTION_SUBJECTS.some((p) =>
+        subjectMatches(p, subject),
+      );
+      expect(hit).toBe(true);
+    }
+  });
+
+  it("does NOT match subjects outside any projection family", () => {
+    const nonProjection = [
+      // a chat dispatch (handled elsewhere), not a projection family
+      "local.andreas.tasks.@did-mf-luna.chat",
+      // a different system.* subdomain the projection doesn't own
+      "local.andreas.work.system.inbound.aborted",
+      // github webhook events
+      "local.andreas.work.github.push.created",
+    ];
+    for (const subject of nonProjection) {
       const hit = DISPATCH_PROJECTION_SUBJECTS.some((p) =>
         subjectMatches(p, subject),
       );

--- a/src/surface/mc/__tests__/embed.test.ts
+++ b/src/surface/mc/__tests__/embed.test.ts
@@ -66,6 +66,14 @@ describe("startMissionControl (embed)", () => {
     // The handle exposes the live db handle (the cockpit loop consumes it).
     expect(handle.db).toBeDefined();
     expect(() => handle!.db.query("SELECT 1").get()).not.toThrow();
+
+    // MC-I1.S6 (#848) — the handle exposes the live WebSocket registry so the
+    // bus→MC projection renderer can broadcast `mc.projection` refresh signals
+    // to live dashboard clients. It must be the SAME registry the server's
+    // hooks/API use (broadcast() callable, starts with zero clients).
+    expect(handle.wsRegistry).toBeDefined();
+    expect(typeof handle.wsRegistry.broadcast).toBe("function");
+    expect(handle.wsRegistry.size).toBe(0);
   });
 
   it("releases the port on stop()", async () => {

--- a/src/surface/mc/__tests__/projection-families.test.ts
+++ b/src/surface/mc/__tests__/projection-families.test.ts
@@ -1,0 +1,446 @@
+/**
+ * MC-I1.S6 (#848, ADR-0005 §4) — tests for the generalized MC projection
+ * families (verdicts, heartbeats, federated attention, adapter health) and the
+ * renderer's dispatcher + WS broadcast.
+ *
+ * Coverage axes (per the slice brief's TDD list):
+ *   - verdict joinable (dispatch anchor present) + unattached (no anchor)
+ *   - heartbeat liveness touch on the projected session
+ *   - adapter health open/resolve
+ *   - federated attention ingest; local attention IGNORED (scoping decision)
+ *   - WS broadcast emitted on a projected mutation (fake registry)
+ *   - idempotency under redelivery
+ *   - non-dispatch families ignored by the dispatch handler and vice versa
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { Database } from "bun:sqlite";
+
+import { SCHEMA_SQL } from "../db/schema";
+import { projectDispatchLifecycle } from "../projection/dispatch-lifecycle";
+import { projectReviewVerdict } from "../projection/review-verdict";
+import { projectHeartbeat } from "../projection/heartbeat";
+import {
+  projectAttention,
+  FEDERATED_ATTENTION_PREFIX,
+} from "../projection/attention-projection";
+import {
+  projectAdapterLifecycle,
+  ADAPTER_ATTENTION_PREFIX,
+} from "../projection/adapter-lifecycle";
+import {
+  createDispatchProjectionRenderer,
+  project,
+} from "../projection/dispatch-lifecycle-renderer";
+import {
+  createDispatchTaskStartedEvent,
+  type DispatchEventSource,
+} from "../../../bus/dispatch-events";
+import { createReviewVerdictEvent } from "../../../bus/review-events";
+import { createAgentHeartbeatEvent } from "../../../bus/system-events";
+import {
+  createSystemAdapterDegradedEvent,
+  createSystemAdapterRecoveredEvent,
+} from "../../../bus/system-events";
+import { attentionNotificationEnvelope } from "../attention-notify";
+import type { Envelope } from "../../../bus/myelin/envelope-validator";
+import type { AttentionItem } from "../types";
+import type { WsClientRegistry } from "../ws/client-registry";
+import type { WsServerMessage } from "../ws/types";
+
+const SOURCE: DispatchEventSource = {
+  principal: "andreas",
+  agent: "cortex",
+  instance: "local",
+};
+const CORRELATION = "99999999-9999-4999-8999-999999999999";
+const TASK_ID = "88888888-8888-4888-8888-888888888888";
+
+function setupDb(): Database {
+  const db = new Database(":memory:");
+  db.exec("PRAGMA journal_mode = WAL");
+  db.exec("PRAGMA foreign_keys = ON");
+  for (const sql of SCHEMA_SQL) db.exec(sql);
+  return db;
+}
+
+/** Project a dispatch `started` keyed on CORRELATION so other families can join. */
+function seedDispatchAnchor(db: Database): void {
+  const env = createDispatchTaskStartedEvent({
+    source: SOURCE,
+    taskId: TASK_ID,
+    agentId: "echo",
+    startedAt: new Date("2026-06-10T12:00:00.000Z"),
+    correlationId: CORRELATION,
+  });
+  projectDispatchLifecycle(db, env);
+}
+
+function eventsOfType(db: Database, type: string): { session_id: string; payload: string }[] {
+  return db
+    .query(`SELECT session_id, payload FROM events WHERE type = ?`)
+    .all(type) as { session_id: string; payload: string }[];
+}
+
+function attentionRow(
+  db: Database,
+  id: string,
+): { id: string; status: string; kind: string; severity: string } | null {
+  return db
+    .query(`SELECT id, status, kind, severity FROM attention_items WHERE id = ?`)
+    .get(id) as { id: string; status: string; kind: string; severity: string } | null;
+}
+
+function makeVerdict(opts: { correlationId?: string } = {}): Envelope {
+  return createReviewVerdictEvent({
+    source: SOURCE,
+    kind: "changes-requested",
+    correlationId: opts.correlationId ?? CORRELATION,
+    payload: {
+      repo: "the-metafactory/cortex",
+      pr: 861,
+      reviewer: "echo",
+      verdict: "changes-requested",
+      summary: "verdict: blockers=0 majors=2 nits=3",
+      github_review_id: 123,
+      github_review_url: "https://github.com/the-metafactory/cortex/pull/861#review-123",
+      submitted_at: "2026-06-10T12:03:00.000Z",
+      commit_id: "abc123",
+      findings: { blockers: 0, majors: 2, nits: 3 },
+      inline_comments: 5,
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Review verdicts
+// ---------------------------------------------------------------------------
+
+describe("projectReviewVerdict", () => {
+  let db: Database;
+  beforeEach(() => {
+    db = setupDb();
+  });
+  afterEach(() => {
+    db.close();
+  });
+
+  it("joins a verdict onto the dispatch anchor session via correlation_id", () => {
+    seedDispatchAnchor(db);
+    const res = projectReviewVerdict(db, makeVerdict());
+    expect(res).not.toBeNull();
+    expect(res?.attached).toBe(true);
+    const evs = eventsOfType(db, "review.verdict");
+    expect(evs.length).toBe(1);
+    expect(evs[0]?.session_id).toBe(res?.sessionId);
+  });
+
+  it("stores an unattached verdict when no dispatch anchor matches", () => {
+    // No seedDispatchAnchor — correlation_id has no projected anchor.
+    const res = projectReviewVerdict(db, makeVerdict({ correlationId: "no-such" }));
+    expect(res).not.toBeNull();
+    expect(res?.attached).toBe(false);
+    expect(eventsOfType(db, "review.verdict").length).toBe(1);
+  });
+
+  it("is idempotent on redelivery (same envelope id) — one verdict event", () => {
+    seedDispatchAnchor(db);
+    const env = makeVerdict();
+    projectReviewVerdict(db, env);
+    projectReviewVerdict(db, env);
+    expect(eventsOfType(db, "review.verdict").length).toBe(1);
+  });
+
+  it("ignores a non-verdict type", () => {
+    expect(
+      projectReviewVerdict(db, { type: "dispatch.task.started", payload: {} }),
+    ).toBeNull();
+  });
+
+  it("ignores a malformed payload (missing repo/pr)", () => {
+    expect(
+      projectReviewVerdict(db, {
+        type: "review.verdict.approved",
+        correlation_id: CORRELATION,
+        payload: { verdict: "approved" },
+      }),
+    ).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Heartbeats
+// ---------------------------------------------------------------------------
+
+describe("projectHeartbeat", () => {
+  let db: Database;
+  beforeEach(() => {
+    db = setupDb();
+  });
+  afterEach(() => {
+    db.close();
+  });
+
+  function makeHeartbeat(iteration: number): Envelope {
+    return createAgentHeartbeatEvent({
+      source: SOURCE,
+      agentId: "echo",
+      taskId: TASK_ID,
+      correlationId: CORRELATION,
+      phase: "tool_use",
+      lastActivityMsAgo: 1200,
+      iteration,
+    });
+  }
+
+  it("touches liveness on the projected session via correlation_id", () => {
+    seedDispatchAnchor(db);
+    const res = projectHeartbeat(db, makeHeartbeat(1));
+    expect(res).not.toBeNull();
+    expect(res?.iteration).toBe(1);
+    const evs = eventsOfType(db, "system.agent.heartbeat");
+    expect(evs.length).toBe(1);
+    expect(evs[0]?.session_id).toBe(res?.sessionId);
+  });
+
+  it("returns null when no dispatch anchor exists (does not synthesise one)", () => {
+    expect(projectHeartbeat(db, makeHeartbeat(1))).toBeNull();
+    expect(eventsOfType(db, "system.agent.heartbeat").length).toBe(0);
+  });
+
+  it("collapses a redelivered tick (same iteration) to one row, appends new ticks", () => {
+    seedDispatchAnchor(db);
+    projectHeartbeat(db, makeHeartbeat(1));
+    projectHeartbeat(db, makeHeartbeat(1)); // redelivery
+    projectHeartbeat(db, makeHeartbeat(2)); // new tick
+    expect(eventsOfType(db, "system.agent.heartbeat").length).toBe(2);
+  });
+
+  it("ignores a non-heartbeat type", () => {
+    expect(
+      projectHeartbeat(db, { type: "review.verdict.approved", payload: {} }),
+    ).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Adapter health
+// ---------------------------------------------------------------------------
+
+describe("projectAdapterLifecycle", () => {
+  let db: Database;
+  beforeEach(() => {
+    db = setupDb();
+  });
+  afterEach(() => {
+    db.close();
+  });
+
+  function degraded(): Envelope {
+    return createSystemAdapterDegradedEvent({
+      source: SOURCE,
+      adapterId: "discord-luna",
+      platform: "discord",
+      disconnectedSince: new Date("2026-06-10T12:00:00.000Z"),
+      thresholdMs: 60_000,
+    });
+  }
+  function recovered(): Envelope {
+    return createSystemAdapterRecoveredEvent({
+      source: SOURCE,
+      adapterId: "discord-luna",
+      platform: "discord",
+      degradedForMs: 90_000,
+    });
+  }
+
+  it("opens an adapter-health attention item on degraded", () => {
+    const res = projectAdapterLifecycle(db, degraded());
+    expect(res?.action).toBe("opened");
+    const id = `${ADAPTER_ATTENTION_PREFIX}discord-luna`;
+    expect(attentionRow(db, id)?.status).toBe("open");
+    expect(attentionRow(db, id)?.severity).toBe("high");
+  });
+
+  it("resolves the adapter-health item on recovered", () => {
+    projectAdapterLifecycle(db, degraded());
+    const res = projectAdapterLifecycle(db, recovered());
+    expect(res?.action).toBe("resolved");
+    expect(attentionRow(db, `${ADAPTER_ATTENTION_PREFIX}discord-luna`)?.status).toBe(
+      "resolved",
+    );
+  });
+
+  it("is idempotent — a re-degrade upserts the same single row", () => {
+    projectAdapterLifecycle(db, degraded());
+    projectAdapterLifecycle(db, degraded());
+    const n = (
+      db
+        .query(`SELECT COUNT(*) AS n FROM attention_items WHERE id LIKE 'att:adapter:%'`)
+        .get() as { n: number }
+    ).n;
+    expect(n).toBe(1);
+  });
+
+  it("ignores a non-adapter type", () => {
+    expect(
+      projectAdapterLifecycle(db, { type: "system.agent.heartbeat", payload: {} }),
+    ).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Attention — FEDERATED only (scoping decision)
+// ---------------------------------------------------------------------------
+
+describe("projectAttention (federated-only)", () => {
+  let db: Database;
+  beforeEach(() => {
+    db = setupDb();
+  });
+  afterEach(() => {
+    db.close();
+  });
+
+  const PEER_ITEM: AttentionItem = {
+    id: "att:block:peer-assignment-1",
+    stackId: "peer-stack",
+    workItemId: null,
+    sessionId: null,
+    kind: "permission",
+    severity: "high",
+    status: "open",
+  };
+
+  function attEnv(action: "opened" | "resolved"): Envelope {
+    return attentionNotificationEnvelope(PEER_ITEM, action, {
+      source: { principal: "peer" },
+      deepLinkUrl: null,
+    });
+  }
+
+  it("ingests a federated attention.opened under the att:fed: namespace", () => {
+    const res = projectAttention(db, attEnv("opened"), "federated.peer.work.system.attention.opened");
+    expect(res?.action).toBe("opened");
+    const id = `${FEDERATED_ATTENTION_PREFIX}${PEER_ITEM.id}`;
+    expect(res?.itemId).toBe(id);
+    expect(attentionRow(db, id)?.status).toBe("open");
+  });
+
+  it("resolves a federated attention item on resolved", () => {
+    projectAttention(db, attEnv("opened"), "federated.peer.work.system.attention.opened");
+    projectAttention(db, attEnv("resolved"), "federated.peer.work.system.attention.resolved");
+    expect(
+      attentionRow(db, `${FEDERATED_ATTENTION_PREFIX}${PEER_ITEM.id}`)?.status,
+    ).toBe("resolved");
+  });
+
+  it("IGNORES a LOCAL attention envelope (does not fight the local reconciler)", () => {
+    // Same envelope, but delivered on a LOCAL subject → not ingested.
+    const res = projectAttention(db, attEnv("opened"), "local.andreas.work.system.attention.opened");
+    expect(res).toBeNull();
+    const n = (
+      db.query(`SELECT COUNT(*) AS n FROM attention_items`).get() as { n: number }
+    ).n;
+    expect(n).toBe(0);
+  });
+
+  it("stores federated items under a DISJOINT namespace from the local reconciler", () => {
+    projectAttention(db, attEnv("opened"), "federated.peer.work.system.attention.opened");
+    // The local reconciler's prefixes are att:block: / att:stale:. The projected
+    // id must NOT collide with the peer's RAW id (which happened to be att:block:).
+    expect(attentionRow(db, PEER_ITEM.id)).toBeNull(); // raw id NOT used
+    expect(
+      attentionRow(db, `${FEDERATED_ATTENTION_PREFIX}${PEER_ITEM.id}`),
+    ).not.toBeNull();
+  });
+
+  it("ignores a non-attention type even on a federated subject", () => {
+    expect(
+      projectAttention(
+        db,
+        { type: "system.adapter.degraded", payload: {} },
+        "federated.peer.work.system.adapter.degraded",
+      ),
+    ).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Renderer dispatcher + WS broadcast
+// ---------------------------------------------------------------------------
+
+describe("project() dispatcher + WS broadcast", () => {
+  let db: Database;
+  let broadcasts: WsServerMessage[];
+  let fakeRegistry: WsClientRegistry;
+
+  beforeEach(() => {
+    db = setupDb();
+    broadcasts = [];
+    fakeRegistry = {
+      broadcast: (msg: WsServerMessage) => {
+        broadcasts.push(msg);
+      },
+    } as unknown as WsClientRegistry;
+  });
+  afterEach(() => {
+    db.close();
+  });
+
+  it("broadcasts mc.projection on a dispatch-lifecycle projection", () => {
+    const env = createDispatchTaskStartedEvent({
+      source: SOURCE,
+      taskId: TASK_ID,
+      agentId: "echo",
+      startedAt: new Date(),
+      correlationId: CORRELATION,
+    });
+    project(db, env, "local.andreas.work.dispatch.task.started", fakeRegistry);
+    expect(broadcasts.length).toBe(1);
+    expect(broadcasts[0]).toMatchObject({ type: "mc.projection", family: "dispatch.lifecycle" });
+  });
+
+  it("broadcasts mc.projection on a verdict projection", () => {
+    seedDispatchAnchor(db);
+    broadcasts = []; // reset (seed used projectDispatchLifecycle directly, no broadcast)
+    project(db, makeVerdict(), "local.andreas.work.review.verdict.changes-requested", fakeRegistry);
+    expect(broadcasts.some((m) => m.type === "mc.projection" && m.family === "review.verdict")).toBe(true);
+  });
+
+  it("does NOT broadcast when a projection is a no-op (unjoinable heartbeat)", () => {
+    const hb = createAgentHeartbeatEvent({
+      source: SOURCE,
+      agentId: "echo",
+      taskId: TASK_ID,
+      correlationId: "no-anchor",
+      phase: "thinking",
+      lastActivityMsAgo: 0,
+      iteration: 1,
+    });
+    project(db, hb, "local.andreas.work.system.agent.heartbeat", fakeRegistry);
+    expect(broadcasts.length).toBe(0);
+  });
+
+  it("renderer render() never throws on a malformed envelope and writes nothing", async () => {
+    const adapter = createDispatchProjectionRenderer(db, fakeRegistry);
+    const bad = { id: "x", type: "review.verdict.approved", payload: null } as unknown as Envelope;
+    await expect(adapter.render(bad)).resolves.toBeUndefined();
+    expect(eventsOfType(db, "review.verdict").length).toBe(0);
+    expect(broadcasts.length).toBe(0);
+  });
+
+  it("the dispatch handler ignores non-dispatch families (and vice versa)", () => {
+    // A verdict envelope routed through project() does NOT create a dispatch
+    // session anchor (no dispatch task row).
+    seedDispatchAnchor(db);
+    const dispatchTasksBefore = (
+      db.query(`SELECT COUNT(*) AS n FROM tasks WHERE id LIKE 'mc-dispatch-task-%'`).get() as { n: number }
+    ).n;
+    project(db, makeVerdict(), "local.andreas.work.review.verdict.changes-requested", fakeRegistry);
+    const dispatchTasksAfter = (
+      db.query(`SELECT COUNT(*) AS n FROM tasks WHERE id LIKE 'mc-dispatch-task-%'`).get() as { n: number }
+    ).n;
+    expect(dispatchTasksAfter).toBe(dispatchTasksBefore); // verdict didn't make a dispatch anchor
+  });
+});

--- a/src/surface/mc/__tests__/projection-families.test.ts
+++ b/src/surface/mc/__tests__/projection-families.test.ts
@@ -208,12 +208,38 @@ describe("projectHeartbeat", () => {
     expect(eventsOfType(db, "system.agent.heartbeat").length).toBe(0);
   });
 
-  it("collapses a redelivered tick (same iteration) to one row, appends new ticks", () => {
+  it("keeps EXACTLY ONE heartbeat row per session — N ticks collapse, latest iteration wins", () => {
     seedDispatchAnchor(db);
-    projectHeartbeat(db, makeHeartbeat(1));
-    projectHeartbeat(db, makeHeartbeat(1)); // redelivery
-    projectHeartbeat(db, makeHeartbeat(2)); // new tick
-    expect(eventsOfType(db, "system.agent.heartbeat").length).toBe(2);
+    // A burst of distinct 30s ticks (the unbounded-growth case the #862 review
+    // flagged) MUST stay at one row, carrying the latest iteration's liveness.
+    for (const it of [1, 2, 3, 4, 5]) {
+      projectHeartbeat(db, makeHeartbeat(it));
+    }
+    const evs = eventsOfType(db, "system.agent.heartbeat");
+    expect(evs.length).toBe(1);
+    const payload = JSON.parse(evs[0]!.payload) as { iteration: number };
+    expect(payload.iteration).toBe(5);
+  });
+
+  it("an exact redelivery of the latest tick is idempotent (still one row, same iteration)", () => {
+    seedDispatchAnchor(db);
+    projectHeartbeat(db, makeHeartbeat(3));
+    projectHeartbeat(db, makeHeartbeat(3)); // redelivery of the latest tick
+    const evs = eventsOfType(db, "system.agent.heartbeat");
+    expect(evs.length).toBe(1);
+    expect((JSON.parse(evs[0]!.payload) as { iteration: number }).iteration).toBe(3);
+  });
+
+  it("an out-of-order OLDER tick does NOT regress the recorded liveness", () => {
+    seedDispatchAnchor(db);
+    projectHeartbeat(db, makeHeartbeat(5)); // latest seen
+    const res = projectHeartbeat(db, makeHeartbeat(2)); // reordered older tick
+    // One row, still the newer iteration — the older tick must not overwrite it.
+    const evs = eventsOfType(db, "system.agent.heartbeat");
+    expect(evs.length).toBe(1);
+    expect((JSON.parse(evs[0]!.payload) as { iteration: number }).iteration).toBe(5);
+    // The result reflects the row's retained (newer) iteration, not the stale one.
+    expect(res?.iteration).toBe(5);
   });
 
   it("ignores a non-heartbeat type", () => {

--- a/src/surface/mc/api/handlers.ts
+++ b/src/surface/mc/api/handlers.ts
@@ -72,6 +72,7 @@ import {
   findLatestSessionForAssignment,
   SHADOW_AGENT_ID,
 } from "../db/sessions";
+import { ensureAgentRow } from "../db/agents";
 import {
   parseGitHubRef,
   canonicalRef,
@@ -539,12 +540,14 @@ function ensureNamedAgent(
   agentName: string | undefined
 ): string {
   const displayName = agentName && agentName.length > 0 ? agentName : agentId;
-  db.query(
-    `INSERT INTO agents (id, name, type, persistent)
-     VALUES (?, ?, 'head', 1)
-     ON CONFLICT(id) DO NOTHING`
-  ).run(agentId, displayName);
-  return agentId;
+  // head / persistent. Insert-only name via the shared ensureAgentRow helper
+  // (S6 DRY pickup, #861 finding 3).
+  return ensureAgentRow(db, {
+    id: agentId,
+    name: displayName,
+    type: "head",
+    persistent: true,
+  });
 }
 
 // F-19 Decision 5 — server-side dispatch debounce.

--- a/src/surface/mc/db/agents.ts
+++ b/src/surface/mc/db/agents.ts
@@ -1,0 +1,58 @@
+/**
+ * MC-I1.S6 (#848, the deferred #861-review finding-3 DRY pickup) — single
+ * `agents` upsert helper.
+ *
+ * Three sites independently INSERT-OR-IGNORE an `agents` row with the same
+ * insert-only-name semantics:
+ *   - `ensureNamedAgent`  (api/handlers.ts)  — F-20 observed sessions; head/persistent.
+ *   - `ensureOrphanAgent` (db/sessions.ts)   — S5 orphan sessions; head/non-persistent.
+ *   - S4's dispatch-anchor copy (projection/dispatch-lifecycle.ts) — head/persistent.
+ *
+ * They differ only in `type` + `persistent` + the name-fallback rule. Folding
+ * the SQL into one helper removes the drift surface flagged in the #861 review
+ * (finding 3): a schema change to `agents` (a new column, a CHECK) now lands in
+ * one place, not three.
+ *
+ * **Insert-only name (load-bearing).** `ON CONFLICT(id) DO NOTHING` is the
+ * shared contract: the FIRST writer lands the display name; subsequent calls
+ * never overwrite it, so a principal-edited name survives re-dispatch /
+ * re-observation. Every call site relied on this; the helper preserves it.
+ */
+
+import type { Database } from "bun:sqlite";
+
+/** The two `agents.type` values the schema's CHECK constraint allows. */
+export type AgentRowType = "head" | "hands";
+
+export interface EnsureAgentRowParams {
+  /** Stable agent id (PK). */
+  id: string;
+  /**
+   * Display name. Applied ONLY on insert (the `ON CONFLICT DO NOTHING` keeps a
+   * principal-edited name from being clobbered). Callers that want a fallback
+   * (e.g. "name or the id") resolve it BEFORE calling — the helper stores the
+   * string verbatim.
+   */
+  name: string;
+  /** `agents.type` — `head` runs a task, `hands` is a worker/sentinel. */
+  type: AgentRowType;
+  /**
+   * `agents.persistent` flag. `true` for principal-visible/dispatch agents,
+   * `false` for per-orphan ephemeral agents. Stored as 1/0.
+   */
+  persistent: boolean;
+}
+
+/**
+ * Idempotently insert an `agents` row. No-op when the id already exists (the
+ * existing row — including a principal-edited name — is preserved). Returns the
+ * id for call-site ergonomics (mirrors the prior helpers' return shape).
+ */
+export function ensureAgentRow(db: Database, params: EnsureAgentRowParams): string {
+  db.query(
+    `INSERT INTO agents (id, name, type, persistent)
+     VALUES (?, ?, ?, ?)
+     ON CONFLICT(id) DO NOTHING`,
+  ).run(params.id, params.name, params.type, params.persistent ? 1 : 0);
+  return params.id;
+}

--- a/src/surface/mc/db/sessions.ts
+++ b/src/surface/mc/db/sessions.ts
@@ -5,6 +5,7 @@
 import type { Database } from "bun:sqlite";
 import type { EndpointKind, Session } from "../types";
 import { generateId } from "./events";
+import { ensureAgentRow } from "./agents";
 
 export function createSession(
   db: Database,
@@ -278,12 +279,9 @@ function ensureOrphanAgent(
   // empty agent_name values): this fallback must hold for ANY caller, not
   // just the ingestor path.
   const name = displayName && displayName.length > 0 ? displayName : ccSessionId;
-  db.query(
-    `INSERT INTO agents (id, name, type, persistent)
-     VALUES (?, ?, 'head', 0)
-     ON CONFLICT(id) DO NOTHING`
-  ).run(id, name);
-  return id;
+  // head / non-persistent (per-orphan ephemeral agent). Insert-only name via
+  // the shared ensureAgentRow helper (S6 DRY pickup, #861 finding 3).
+  return ensureAgentRow(db, { id, name, type: "head", persistent: false });
 }
 
 export interface OrphanSession {

--- a/src/surface/mc/embed.ts
+++ b/src/surface/mc/embed.ts
@@ -21,10 +21,19 @@ import { startServer } from "./server";
 import { ProcessManager } from "./session/process-manager";
 import { HookStreamPoller } from "./hooks/poller";
 import type { Config } from "./types";
+import type { WsClientRegistry } from "./ws/client-registry";
 
 export interface MissionControlHandle {
   db: Database;
   port: number;
+  /**
+   * The live WebSocket client registry (MC-I1.S6, #848). Exposed so the bus→MC
+   * projection renderer can broadcast `mc.projection` refresh signals to live
+   * dashboard clients on a projected mutation — closing the S4 "projection
+   * writes bypass WS fan-out" gap. The cockpit/API mutation paths reach the
+   * SAME registry; the projection reuses the existing broadcast helpers.
+   */
+  wsRegistry: WsClientRegistry;
   stop(): Promise<void>;
 }
 
@@ -97,7 +106,7 @@ export async function startMissionControl(
     // callers (the cockpit refresh loop's baseUrl) need the real listen port.
     // Bun.serve guarantees a numeric `port` once started; the `?? config.port`
     // coalesce only satisfies the optional type on `Server.port`.
-    return { db, port: server.port ?? config.port, stop };
+    return { db, port: server.port ?? config.port, wsRegistry, stop };
   } catch (err) {
     // Reverse-order teardown of whatever was constructed before the throw.
     hookPoller?.stop();

--- a/src/surface/mc/notifications.ts
+++ b/src/surface/mc/notifications.ts
@@ -189,6 +189,44 @@ export function broadcastTaskUpdated(
 }
 
 /**
+ * MC-I1.S6 (#848) — projection family the broadcast describes. Mirrors the
+ * `mc.projection` WS message's `family` union (ws/types.ts).
+ */
+export type ProjectionFamily =
+  | "dispatch.lifecycle"
+  | "review.verdict"
+  | "agent.heartbeat"
+  | "attention"
+  | "adapter.health";
+
+/**
+ * MC-I1.S6 (#848) — broadcast an `mc.projection` refresh signal to all connected
+ * dashboard clients after the projection renderer mutated MC state from a bus
+ * envelope. Closes the S4 "projection writes bypass WS fan-out" gap: the
+ * projection's writes (verdicts, heartbeats, federated attention, adapter
+ * health, AND S4's dispatch-lifecycle transitions) now push to live clients the
+ * same way API mutations do, instead of waiting for the next poll/refetch.
+ *
+ * Like `broadcastTransition`, this is a fan-out of an already-committed write —
+ * a REFRESH SIGNAL, not authoritative-by-payload — so clients react with the
+ * existing debounced refetch. `wsRegistry` may be undefined when MC runs without
+ * a live server (tests, headless), in which case this is a no-op.
+ */
+export function broadcastProjection(
+  wsRegistry: WsClientRegistry | undefined,
+  family: ProjectionFamily,
+  refs?: { sessionId?: string; assignmentId?: string }
+): void {
+  if (!wsRegistry) return;
+  wsRegistry.broadcast({
+    type: "mc.projection",
+    family,
+    ...(refs?.sessionId !== undefined && { sessionId: refs.sessionId }),
+    ...(refs?.assignmentId !== undefined && { assignmentId: refs.assignmentId }),
+  });
+}
+
+/**
  * F-12 Decision 11 — process-kill observer.
  *
  * Decisions 5/6/7 all assume a side effect that the existing process-manager

--- a/src/surface/mc/projection/adapter-lifecycle.ts
+++ b/src/surface/mc/projection/adapter-lifecycle.ts
@@ -1,0 +1,116 @@
+/**
+ * MC-I1.S6 (#848, ADR-0005 §4) — project `system.adapter.*` lifecycle envelopes
+ * into the MC attention queue as surface-health items.
+ *
+ * A degraded / disconnected adapter is a "the principal's Discord/Slack surface
+ * is down" condition the cockpit should show. There is NO local MC producer for
+ * adapter health (the producers live in the adapters themselves and only emit on
+ * the bus), so — unlike `system.attention.*` — there is no reconciler to fight:
+ * the projection is the SOLE writer of adapter-health attention. We store it
+ * under a distinct `att:adapter:` namespace keyed on the adapter id, so:
+ *   - `system.adapter.degraded` / `system.adapter.disconnected` (was_clean=false)
+ *     → OPEN a `blocked`/high attention item ("discord-luna degraded").
+ *   - `system.adapter.recovered` (or a clean disconnect) → RESOLVE it.
+ *
+ * One open item per adapter id (deterministic `att:adapter:{adapter_id}`):
+ * a flap that re-degrades before recovery upserts the same row (idempotent),
+ * and recovery resolves exactly that row. `work_item_id` / `session_id` are NULL
+ * (adapter health has no work-item/session deep-link); `stack_id` carries the
+ * adapter id segment so a multi-stack view can group by origin.
+ *
+ * Non-throwing: malformed payloads / non-adapter types return null.
+ */
+
+import type { Database } from "bun:sqlite";
+
+import { upsertAttentionItem, resolveAttentionItem } from "../db/attention";
+import type { AttentionItem } from "../types";
+
+/** The adapter-health attention id namespace — disjoint from local + federated. */
+export const ADAPTER_ATTENTION_PREFIX = "att:adapter:";
+
+type AdapterLifecycleKind = "degraded" | "recovered" | "disconnected";
+
+export interface ProjectableAdapterEnvelope {
+  id?: string;
+  type: string;
+  payload: Record<string, unknown>;
+}
+
+export interface AdapterProjectionResult {
+  /** Whether the projection opened or resolved the adapter-health item. */
+  action: "opened" | "resolved";
+  /** The MC attention item id (`att:adapter:`-prefixed). */
+  itemId: string;
+  /** The adapter id the health item tracks. */
+  adapterId: string;
+}
+
+/**
+ * Project one `system.adapter.{degraded,recovered,disconnected}` envelope into
+ * an adapter-health attention item. Returns null for a non-adapter type or a
+ * malformed payload (missing `adapter_id`).
+ */
+export function projectAdapterLifecycle(
+  db: Database,
+  envelope: ProjectableAdapterEnvelope,
+): AdapterProjectionResult | null {
+  const kind = adapterKind(envelope.type);
+  if (kind === null) return null;
+
+  const rawPayload: unknown = envelope.payload;
+  const payload =
+    typeof rawPayload === "object" && rawPayload !== null
+      ? (rawPayload as Record<string, unknown>)
+      : {};
+
+  const adapterId = asString(payload.adapter_id);
+  if (adapterId === null) {
+    process.stderr.write(
+      `[mission-control] adapter-projection: ignoring ${envelope.type} — missing adapter_id\n`,
+    );
+    return null;
+  }
+  const itemId = `${ADAPTER_ATTENTION_PREFIX}${adapterId}`;
+
+  // A clean disconnect (was_clean=true) is a routine shutdown, NOT an outage —
+  // treat it as a resolve (or no-op if nothing was open), same as recovered.
+  const wasClean = payload.was_clean === true;
+  const opensOutage =
+    kind === "degraded" || (kind === "disconnected" && !wasClean);
+
+  if (!opensOutage) {
+    // recovered, or a clean disconnect → resolve the open adapter-health item.
+    resolveAttentionItem(db, itemId);
+    return { action: "resolved", itemId, adapterId };
+  }
+
+  const item: AttentionItem = {
+    id: itemId,
+    stackId: adapterId,
+    workItemId: null,
+    sessionId: null,
+    kind: "blocked",
+    severity: "high",
+    status: "open",
+  };
+  upsertAttentionItem(db, item);
+  return { action: "opened", itemId, adapterId };
+}
+
+function adapterKind(type: string): AdapterLifecycleKind | null {
+  switch (type) {
+    case "system.adapter.degraded":
+      return "degraded";
+    case "system.adapter.recovered":
+      return "recovered";
+    case "system.adapter.disconnected":
+      return "disconnected";
+    default:
+      return null;
+  }
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}

--- a/src/surface/mc/projection/anchor.ts
+++ b/src/surface/mc/projection/anchor.ts
@@ -1,0 +1,55 @@
+/**
+ * MC-I1.S6 (#848) — shared dispatch-anchor join (the #862-review cheap-fold 1).
+ *
+ * S4's dispatch-lifecycle projection anchors one MC task per dispatch
+ * `correlation_id` under the deterministic id `mc-dispatch-task-{correlation_id}`,
+ * with a non-cancelled assignment → most-recent session hanging off it. The S6
+ * verdict + heartbeat projections JOIN onto that anchor's session by the SAME
+ * correlation_id (the review consumer / dispatch handler stamp it on the
+ * verdict / heartbeat envelopes too).
+ *
+ * The `ANCHOR_TASK_PREFIX` constant + the correlation_id→anchor-task→session
+ * `SELECT` were copy-pasted across three sites (dispatch-lifecycle.ts,
+ * review-verdict.ts, heartbeat.ts) — slightly ironic in a slice whose theme is
+ * the `ensureAgentRow` DRY pickup (#861 finding 3). This module is the single
+ * home: a schema change to the anchor join (the `agent_task_assignment` /
+ * `sessions` shape, or the tiebreak) now lands in ONE place.
+ */
+
+import type { Database } from "bun:sqlite";
+
+/**
+ * Deterministic MC task id prefix for a dispatch correlation_id. One MC task per
+ * dispatch (`dispatch-lifecycle.ts` mints `${ANCHOR_TASK_PREFIX}${correlationId}`
+ * on `started`; the verdict / heartbeat joins read it back).
+ */
+export const ANCHOR_TASK_PREFIX = "mc-dispatch-task-";
+
+/** The deterministic anchor-task id for a correlation_id. */
+export function anchorTaskId(correlationId: string): string {
+  return `${ANCHOR_TASK_PREFIX}${correlationId}`;
+}
+
+/**
+ * Find the dispatch anchor's session for a `correlation_id`: the anchor task →
+ * its assignment → most-recent session (the `ORDER BY s.started_at DESC, s.id
+ * DESC LIMIT 1` tiebreak matches `dispatch-lifecycle.ts`'s own anchor lookup so
+ * verdict/heartbeat land on the SAME session the lifecycle projection drives).
+ * Returns the session id, or null when no anchor exists for the correlation_id.
+ */
+export function findAnchorSession(
+  db: Database,
+  correlationId: string,
+): string | null {
+  const row = db
+    .query(
+      `SELECT s.id AS session_id
+       FROM agent_task_assignment a
+       JOIN sessions s ON s.assignment_id = a.id
+       WHERE a.task_id = ?
+       ORDER BY s.started_at DESC, s.id DESC
+       LIMIT 1`,
+    )
+    .get(anchorTaskId(correlationId)) as { session_id: string } | null;
+  return row ? row.session_id : null;
+}

--- a/src/surface/mc/projection/attention-projection.ts
+++ b/src/surface/mc/projection/attention-projection.ts
@@ -89,6 +89,22 @@ export function projectAttention(
   // Gate: federated only. A missing subject (direct test call without the
   // router) is treated as non-federated — the renderer always passes one in
   // production, and a subject-less call has no provenance to trust as federated.
+  //
+  // PROVENANCE (#862 review): this projection trusts the post-gate `federated.`
+  // subject and does NOT re-verify signatures — that is the correct layering.
+  // The surface-router's `evaluateFederationGate` is the SINGLE ingress trust
+  // boundary for `federated.*` envelopes: it resolves the source principal →
+  // `peers[]` membership, cross-checks the delivering leaf link for anti-spoof,
+  // and applies the network's accept/deny patterns + hop budget BEFORE any
+  // `render()` fires. Re-verifying the signed_by chain in every consumer would
+  // be wrong duplication (mirrors how every other renderer consumes the bus).
+  // CAVEAT: that gate is OPT-IN — it engages only when `policy.federated.networks[]`
+  // is configured (`federatedNetworksById.size > 0`). On a network-joined stack
+  // with no `federated:` policy block, a `federated.*` subject passes ungated
+  // and this projection ingests it on subject-prefix alone. That is the
+  // ecosystem-wide renderer posture (not a regression here), but flagged because
+  // this is the first projection to write federated peer data into a
+  // principal-visible queue.
   if (!subject?.startsWith("federated.")) return null;
 
   const action = attentionAction(envelope.type);

--- a/src/surface/mc/projection/attention-projection.ts
+++ b/src/surface/mc/projection/attention-projection.ts
@@ -1,0 +1,165 @@
+/**
+ * MC-I1.S6 (#848, ADR-0005 §4) — project `system.attention.*` envelopes into
+ * the MC attention queue.
+ *
+ * ## Scoping decision (stated in the PR): FEDERATED attention only.
+ *
+ * MC already has a LOCAL attention producer: `reconcileAttention`
+ * (db/attention-sources.ts), driven by the cockpit refresh loop, derives the
+ * open attention set from LOCAL DB state (blocked assignments, stale work items)
+ * under its OWN id namespace (`att:block:` / `att:stale:`) and — critically —
+ * resolves ONLY items carrying those prefixes ("never touch items produced by
+ * other sources"). The cockpit loop ALSO publishes those local deltas as
+ * `system.attention.*` envelopes onto the bus.
+ *
+ * If the projection ingested EVERY `system.attention.*` envelope it would fight
+ * the local reconciler two ways:
+ *   1. It would re-ingest the loop's OWN published local deltas — a write echo.
+ *   2. A federated item under a foreign prefix would never be resolved by the
+ *      prefix-scoped local reconciler, and a locally-derived item re-published
+ *      by the projection under a different prefix would double-count.
+ *
+ * So the projection's value is the attention the local loop CANNOT see:
+ * **federated attention from peer stacks** arriving on `federated.*` subjects.
+ * Local (own-principal) attention stays the cockpit loop's job. The projection:
+ *   - ingests ONLY envelopes delivered on a `federated.` subject (the renderer
+ *     passes the matched subject; we gate on its prefix),
+ *   - stores them under a DISTINCT `att:fed:` id namespace so the local
+ *     reconciler's prefix-scoped resolve never touches them and vice-versa,
+ *   - NULLs the local FK link targets (`work_item_id` / `session_id`): a peer's
+ *     session/work-item ids are not local rows, and the schema FKs would reject
+ *     them. The peer `stack_id` is stamped (plain key, no FK) so a multi-stack
+ *     view can group federated items by origin.
+ *
+ * `opened` → upsert open; `resolved` → resolve. Idempotent on the item id.
+ * Non-throwing: malformed payloads / non-federated subjects return null.
+ */
+
+import type { Database } from "bun:sqlite";
+
+import { upsertAttentionItem, resolveAttentionItem } from "../db/attention";
+import type {
+  AttentionItem,
+  AttentionKind,
+  AttentionSeverity,
+} from "../types";
+
+/** The federated-attention id namespace — disjoint from the local reconciler's. */
+export const FEDERATED_ATTENTION_PREFIX = "att:fed:";
+
+const ATTENTION_KINDS = new Set<AttentionKind>([
+  "input_needed",
+  "permission",
+  "review",
+  "failed_dispatch",
+  "stale",
+  "blocked",
+]);
+const ATTENTION_SEVERITIES = new Set<AttentionSeverity>([
+  "low",
+  "normal",
+  "high",
+  "critical",
+]);
+
+export interface ProjectableAttentionEnvelope {
+  id?: string;
+  type: string;
+  payload: Record<string, unknown>;
+}
+
+export interface AttentionProjectionResult {
+  /** The lifecycle action projected. */
+  action: "opened" | "resolved";
+  /** The MC attention item id (always `att:fed:`-prefixed). */
+  itemId: string;
+}
+
+/**
+ * Project one `system.attention.{opened,resolved}` envelope. `subject` is the
+ * matched NATS subject the renderer passes through — the projection ingests
+ * ONLY envelopes on a `federated.` subject (see scoping decision). Returns null
+ * for a non-federated subject, a non-attention type, or a malformed payload.
+ */
+export function projectAttention(
+  db: Database,
+  envelope: ProjectableAttentionEnvelope,
+  subject: string | undefined,
+): AttentionProjectionResult | null {
+  // Gate: federated only. A missing subject (direct test call without the
+  // router) is treated as non-federated — the renderer always passes one in
+  // production, and a subject-less call has no provenance to trust as federated.
+  if (!subject?.startsWith("federated.")) return null;
+
+  const action = attentionAction(envelope.type);
+  if (action === null) return null;
+
+  const rawPayload: unknown = envelope.payload;
+  const payload =
+    typeof rawPayload === "object" && rawPayload !== null
+      ? (rawPayload as Record<string, unknown>)
+      : {};
+  const rawAttention: unknown = payload.attention;
+  const attention =
+    typeof rawAttention === "object" && rawAttention !== null
+      ? (rawAttention as Record<string, unknown>)
+      : {};
+
+  const sourceId = asString(attention.id);
+  if (sourceId === null) {
+    process.stderr.write(
+      `[mission-control] attention-projection: ignoring ${envelope.type} — missing attention.id\n`,
+    );
+    return null;
+  }
+  // Re-namespace the peer's item id into our federated namespace so it can never
+  // collide with a local `att:block:`/`att:stale:` id (and the local reconciler
+  // never resolves it).
+  const itemId = `${FEDERATED_ATTENTION_PREFIX}${sourceId}`;
+
+  const kind = asKind(attention.kind);
+  const severity = asSeverity(attention.severity);
+  const stackId = asString(attention.stack_id) ?? subject.split(".")[1] ?? "peer";
+
+  if (action === "resolved") {
+    resolveAttentionItem(db, itemId);
+    return { action, itemId };
+  }
+
+  // opened: upsert as open. FK link targets are NULL — a peer's session /
+  // work-item ids are not local rows; the schema FKs would reject them.
+  const item: AttentionItem = {
+    id: itemId,
+    stackId,
+    workItemId: null,
+    sessionId: null,
+    kind: kind ?? "input_needed",
+    severity: severity ?? "normal",
+    status: "open",
+  };
+  upsertAttentionItem(db, item);
+  return { action, itemId };
+}
+
+function attentionAction(type: string): "opened" | "resolved" | null {
+  if (type === "system.attention.opened") return "opened";
+  if (type === "system.attention.resolved") return "resolved";
+  return null;
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function asKind(value: unknown): AttentionKind | null {
+  return typeof value === "string" && ATTENTION_KINDS.has(value as AttentionKind)
+    ? (value as AttentionKind)
+    : null;
+}
+
+function asSeverity(value: unknown): AttentionSeverity | null {
+  return typeof value === "string" &&
+    ATTENTION_SEVERITIES.has(value as AttentionSeverity)
+    ? (value as AttentionSeverity)
+    : null;
+}

--- a/src/surface/mc/projection/dispatch-lifecycle-renderer.ts
+++ b/src/surface/mc/projection/dispatch-lifecycle-renderer.ts
@@ -1,18 +1,24 @@
 /**
- * MC-I1.S4 (ADR-0005 §4) — the bus→MC projection renderer.
+ * MC-I1.S4/S6 (ADR-0005 §4) — the bus→MC projection renderer.
  *
  * §4 makes the bus→MC seam a registered surface-router renderer: a push-based
  * `render(envelope)` rather than the polled DashboardRenderer ring buffer (§4
  * demotes that to, at most, the drill-down's recent-raw-envelopes feed). cortex.ts
- * registers this adapter with the surface-router when `mc.enabled`, subscribing
- * to the `dispatch.task.*` lifecycle subjects only.
+ * registers this adapter with the surface-router when `mc.enabled`.
  *
- * The adapter is deliberately SKELETAL: a single `project(envelope)` dispatcher
- * keyed on `envelope.type`, today routing `dispatch.task.*` into
- * {@link projectDispatchLifecycle}. S6 (#848) generalizes this seam to verdicts
- * / attention / heartbeats — it EXTENDS the `project()` switch (adds cases)
- * rather than rewriting the renderer, so the surface-router registration and the
- * non-throwing contract stay intact.
+ * The adapter is a single `project(envelope, subject)` dispatcher keyed on
+ * `envelope.type`. S4 shipped the `dispatch.task.*` case; **S6 (#848) generalises
+ * the seam** to four more families — extending the dispatcher (adding cases),
+ * NOT rewriting the renderer, so the surface-router registration and the
+ * non-throwing contract stay intact:
+ *
+ *   | envelope.type                       | handler                          |
+ *   |-------------------------------------|----------------------------------|
+ *   | `dispatch.task.{started,…}`         | projectDispatchLifecycle (S4)    |
+ *   | `review.verdict.{approved,…}`       | projectReviewVerdict             |
+ *   | `system.agent.heartbeat`            | projectHeartbeat                 |
+ *   | `system.attention.{opened,resolved}`| projectAttention (FEDERATED only)|
+ *   | `system.adapter.{degraded,…}`       | projectAdapterLifecycle          |
  *
  * ## Non-throwing contract
  *
@@ -22,83 +28,192 @@
  * not poison the dispatch loop. We catch inside `render()` and route failures to
  * stderr, mirroring the DashboardRenderer + ingestor error posture.
  *
- * ## WS broadcast — known gap for S6 (#848)
+ * ## WS push (S6 — closes the S4-documented gap)
  *
  * The MC server's WebSocket broadcasts on state transitions via a
- * `WsClientRegistry` the db layer doesn't know about; existing mutation paths
- * (api/handlers, the ingestor) fan out by calling `broadcastTransition` /
- * `broadcastEvent` at the call site AFTER the db write. The projection writes
- * here bypass that fan-out, so a freshly-projected session/transition won't push
- * to live dashboard clients until their next poll/refetch. Wiring the registry
- * through requires threading the projection's per-envelope transition results
- * into `broadcastTransition`; S6 owns the generalized notification seam, so this
- * slice leaves it as a documented gap rather than a partial wire-up. The embed
- * (embed.ts) holds the `wsRegistry`; a follow-up passes it here.
+ * `WsClientRegistry`. S4's projection writes bypassed that fan-out, so a
+ * freshly-projected change wouldn't push to live dashboard clients until their
+ * next poll. S6 threads the embed's `wsRegistry` into the renderer
+ * (`createProjectionRenderer(db, wsRegistry)`); each projected mutation now
+ * emits an `mc.projection` refresh signal via {@link broadcastProjection},
+ * reusing the existing broadcast helper rather than inventing a parallel
+ * protocol. `wsRegistry` is optional — headless/test wiring passes none and the
+ * broadcast is a no-op.
  */
 
 import type { Database } from "bun:sqlite";
 
 import type { Envelope } from "../../../bus/myelin/envelope-validator";
 import type { SurfaceAdapter } from "../../../bus/surface-router";
+import type { WsClientRegistry } from "../ws/client-registry";
+import { broadcastProjection } from "../notifications";
 import { projectDispatchLifecycle } from "./dispatch-lifecycle";
+import { projectReviewVerdict } from "./review-verdict";
+import { projectHeartbeat } from "./heartbeat";
+import { projectAttention } from "./attention-projection";
+import { projectAdapterLifecycle } from "./adapter-lifecycle";
 
-/** Stable surface-router id for the dispatch-lifecycle projection renderer. */
+/** Stable surface-router id for the MC projection renderer. */
 export const DISPATCH_PROJECTION_RENDERER_ID = "mc-dispatch-projection";
 
 /**
- * NATS subject patterns the projection renderer subscribes to. Covers both the
- * stack-ful (`local.{principal}.{stack}.dispatch.task.*`) and stack-less
- * (`local.{principal}.dispatch.task.*`) local grammars AND the federated
- * (`federated.{principal}.{stack}.dispatch.task.*`) one — ADR-0005 §3 notes the
- * projection "works unchanged for peer-stack sessions arriving on `federated.`
- * lifecycle envelopes". The wildcards are intentionally broad; the
- * authoritative type filter is {@link projectDispatchLifecycle}'s own
- * `lifecycleKind` check (it returns null — a no-op — for anything that isn't a
- * recognised `dispatch.task.{started|completed|failed|aborted}`), so a subject
- * that over-matches costs only a cheap type compare.
+ * NATS subject patterns the projection renderer subscribes to. Covers the
+ * stack-ful (`local.{principal}.{stack}.…`) + stack-less (`local.{principal}.…`)
+ * LOCAL grammars and the federated (`federated.{principal}.{stack}.…`) one for
+ * every family the dispatcher handles. The wildcards are intentionally broad;
+ * the authoritative filter is each projection's own type check (a subject that
+ * over-matches costs only a cheap type compare).
  *
  * `*` matches exactly one segment, `>` one-or-more trailing segments (per the
- * surface-router's NATS matcher). `local.>` would also work but the explicit
- * `dispatch.task` tail keeps the subscription self-documenting and narrows the
- * router's per-envelope payload-filter pass.
+ * surface-router's NATS matcher).
+ *
+ * Families:
+ *   - `dispatch.task.*`  (S4) — dispatch lifecycle.
+ *   - `review.verdict.*` (S6) — review verdicts.
+ *   - `system.agent.heartbeat` (S6) — agent liveness.
+ *   - `system.attention.*` (S6) — attention (the projection ingests the
+ *     FEDERATED ones only — see attention-projection.ts; the broad subscription
+ *     is harmless, the federated-subject gate is the real filter).
+ *   - `system.adapter.*` (S6) — adapter health.
+ *
+ * The local `system.*` + `review.verdict.*` families have both stack-ful and
+ * stack-less local shapes; the federated grammar is always
+ * `federated.{principal}.{stack}.…` (ADR-0001 / CONTEXT.md §Subject), so the
+ * federated twins are 3-segment-prefix only.
  */
 export const DISPATCH_PROJECTION_SUBJECTS: string[] = [
+  // dispatch lifecycle (S4)
   "local.*.dispatch.task.*",
   "local.*.*.dispatch.task.*",
-  // Deliberately NO stack-less federated twin: the federated grammar is always
-  // `federated.{principal}.{stack}.…` (ADR-0001 / CONTEXT.md §Subject) — the
-  // stack-less variant exists only as the legacy LOCAL shape.
   "federated.*.*.dispatch.task.*",
+  // review verdicts (S6)
+  "local.*.review.verdict.*",
+  "local.*.*.review.verdict.*",
+  "federated.*.*.review.verdict.*",
+  // agent heartbeat (S6)
+  "local.*.system.agent.heartbeat",
+  "local.*.*.system.agent.heartbeat",
+  "federated.*.*.system.agent.heartbeat",
+  // attention (S6 — federated only at the projection; subscription is broad)
+  "local.*.system.attention.*",
+  "local.*.*.system.attention.*",
+  "federated.*.*.system.attention.*",
+  // adapter health (S6)
+  "local.*.system.adapter.*",
+  "local.*.*.system.adapter.*",
+  "federated.*.*.system.adapter.*",
 ];
 
+/** A structural view of an envelope the projections read (kept loose so any
+ *  validated Envelope is assignable). */
+interface ProjectableEnvelope {
+  id?: string;
+  type: string;
+  correlation_id?: string;
+  payload: Record<string, unknown>;
+}
+
 /**
- * Build the `SurfaceAdapter` the surface-router consumes for the
- * dispatch-lifecycle projection. The `render()` is non-throwing: every
- * projection error is caught + logged so a malformed envelope can't poison the
- * router's dispatch loop.
+ * The single `project(envelope, subject)` dispatcher (§4). Routes on
+ * `envelope.type` to the per-family projection, broadcasting an `mc.projection`
+ * refresh signal on any mutation. Each projection is itself the authoritative
+ * type filter (returns null for a non-matching type), so an over-broad subject
+ * subscription is harmless.
+ *
+ * Exported for direct unit testing of the routing without the surface-router.
+ */
+export function project(
+  db: Database,
+  envelope: ProjectableEnvelope,
+  subject: string | undefined,
+  wsRegistry: WsClientRegistry | undefined,
+): void {
+  const type = envelope.type;
+
+  if (type.startsWith("dispatch.task.")) {
+    const res = projectDispatchLifecycle(db, envelope);
+    if (res !== null) {
+      broadcastProjection(wsRegistry, "dispatch.lifecycle", {
+        sessionId: res.sessionId,
+        assignmentId: res.assignmentId,
+      });
+    }
+    return;
+  }
+
+  if (type.startsWith("review.verdict.")) {
+    const res = projectReviewVerdict(db, envelope);
+    if (res !== null) {
+      broadcastProjection(wsRegistry, "review.verdict", {
+        sessionId: res.sessionId,
+      });
+    }
+    return;
+  }
+
+  if (type === "system.agent.heartbeat") {
+    const res = projectHeartbeat(db, envelope);
+    if (res !== null) {
+      broadcastProjection(wsRegistry, "agent.heartbeat", {
+        sessionId: res.sessionId,
+      });
+    }
+    return;
+  }
+
+  if (type.startsWith("system.attention.")) {
+    const res = projectAttention(db, envelope, subject);
+    if (res !== null) {
+      broadcastProjection(wsRegistry, "attention");
+    }
+    return;
+  }
+
+  if (type.startsWith("system.adapter.")) {
+    const res = projectAdapterLifecycle(db, envelope);
+    if (res !== null) {
+      broadcastProjection(wsRegistry, "adapter.health");
+    }
+    return;
+  }
+
+  // Any other type the broad subscription caught is not a projection family —
+  // a no-op (mirrors each projection's own null-return type filter).
+}
+
+/**
+ * Build the `SurfaceAdapter` the surface-router consumes for the MC projection.
+ * The `render()` is non-throwing: every projection error is caught + logged so a
+ * malformed envelope can't poison the router's dispatch loop.
  *
  * `db` is the in-process Mission Control handle (from the S1 embed —
- * `startMissionControl(...).db`). cortex.ts wires this only when `mc.enabled`,
- * so `db` is always the live MC db here.
+ * `startMissionControl(...).db`). `wsRegistry` is the embed's live WebSocket
+ * registry (S6) — when supplied, projected mutations broadcast to live clients;
+ * when omitted (headless / test), the broadcast is a no-op. cortex.ts wires both
+ * only when `mc.enabled`.
  */
-export function createDispatchProjectionRenderer(db: Database): SurfaceAdapter {
+export function createDispatchProjectionRenderer(
+  db: Database,
+  wsRegistry?: WsClientRegistry,
+): SurfaceAdapter {
   return {
     id: DISPATCH_PROJECTION_RENDERER_ID,
     subjects: DISPATCH_PROJECTION_SUBJECTS,
     // eslint-disable-next-line @typescript-eslint/require-await
-    render: async (envelope: Envelope): Promise<void> => {
+    render: async (
+      envelope: Envelope,
+      _signal?: AbortSignal,
+      subject?: string,
+    ): Promise<void> => {
       try {
-        // The single `project(envelope)` dispatcher (§4). Today it routes
-        // `dispatch.task.*` into the lifecycle projection; S6 (#848) adds
-        // verdict / attention / heartbeat cases here.
-        projectDispatchLifecycle(db, envelope);
+        project(db, envelope, subject, wsRegistry);
       } catch (err) {
         // Renderer contract §2 — never throw out of render(). A projection
-        // failure (DB constraint, malformed payload that slipped the type
+        // failure (DB constraint, malformed payload that slipped a type
         // filter) logs + drops; the surface-router's isolation is belt, this
         // is braces.
         process.stderr.write(
-          `[mission-control] dispatch-projection renderer: render() swallowed an error for envelope ${envelope.id} (${envelope.type}): ${err instanceof Error ? err.message : String(err)}\n`,
+          `[mission-control] projection renderer: render() swallowed an error for envelope ${envelope.id} (${envelope.type}): ${err instanceof Error ? err.message : String(err)}\n`,
         );
       }
     },

--- a/src/surface/mc/projection/dispatch-lifecycle.ts
+++ b/src/surface/mc/projection/dispatch-lifecycle.ts
@@ -76,6 +76,7 @@ import type { Database } from "bun:sqlite";
 import { generateId } from "../db/events";
 import { ensureAgentRow } from "../db/agents";
 import { applyTransition } from "../db/transitions";
+import { anchorTaskId } from "./anchor";
 import type { AssignmentState } from "../types";
 
 /**
@@ -240,15 +241,13 @@ export function projectDispatchLifecycle(
 // Anchor
 // ---------------------------------------------------------------------------
 
-const ANCHOR_TASK_PREFIX = "mc-dispatch-task-";
+// The deterministic anchor-task id (`ANCHOR_TASK_PREFIX` + `anchorTaskId`) is
+// shared via `./anchor` so the verdict + heartbeat projections join the SAME
+// anchor (#862 review cheap-fold 1). The constants below are dispatch-lifecycle-
+// local bookkeeping for the anchor task ROW the projection writes.
 const ANCHOR_TASK_PRINCIPAL = "mc-dispatch";
 const ANCHOR_TASK_SOURCE_SYSTEM = "internal";
 const CONTROLLED_ENDPOINT = "local.process.controlled";
-
-/** Deterministic MC task id for a dispatch correlation_id. One task per dispatch. */
-function anchorTaskId(correlationId: string): string {
-  return `${ANCHOR_TASK_PREFIX}${correlationId}`;
-}
 
 interface AnchorParams {
   correlationId: string;

--- a/src/surface/mc/projection/dispatch-lifecycle.ts
+++ b/src/surface/mc/projection/dispatch-lifecycle.ts
@@ -74,6 +74,7 @@
 import type { Database } from "bun:sqlite";
 
 import { generateId } from "../db/events";
+import { ensureAgentRow } from "../db/agents";
 import { applyTransition } from "../db/transitions";
 import type { AssignmentState } from "../types";
 
@@ -303,13 +304,15 @@ function ensureAnchor(
     ANCHOR_TASK_SOURCE_SYSTEM,
   );
 
-  // The dispatched agent. `head` type (it runs a task) — insert-only name so a
-  // principal-edited display name is never overwritten, matching ensureNamedAgent.
-  db.query(
-    `INSERT INTO agents (id, name, type, persistent)
-     VALUES (?, ?, 'head', 1)
-     ON CONFLICT(id) DO NOTHING`,
-  ).run(params.agentId, params.agentId);
+  // The dispatched agent. `head` type (it runs a task), persistent — insert-only
+  // name via the shared ensureAgentRow helper (S6 DRY pickup, #861 finding 3) so
+  // a principal-edited display name is never overwritten, matching ensureNamedAgent.
+  ensureAgentRow(db, {
+    id: params.agentId,
+    name: params.agentId,
+    type: "head",
+    persistent: true,
+  });
 
   const assignmentId = generateId();
   const sessionId = generateId();

--- a/src/surface/mc/projection/heartbeat.ts
+++ b/src/surface/mc/projection/heartbeat.ts
@@ -13,12 +13,23 @@
  * when the data can ride an existing surface. A heartbeat lands as an `events`
  * row (type `system.agent.heartbeat`) on the joined session — the working grid's
  * recent-events feed already carries the session's last activity, so "Echo last
- * seen 4s ago" derives from the newest heartbeat event's timestamp + the
- * payload's `last_activity_ms_ago`. No new column, no migration.
+ * seen 4s ago" derives from the heartbeat event's timestamp + the payload's
+ * `last_activity_ms_ago`.
  *
- * Idempotency: each heartbeat is a distinct tick (the `iteration` counter), so
- * we DON'T dedupe on envelope id — a redelivered heartbeat with the same
- * `(correlation_id, iteration)` is collapsed to one row (latest wins per tick).
+ * **One latest-heartbeat row per session (#862 review — bounded growth).**
+ * Liveness only needs "last seen", and `system.agent.heartbeat` is the busiest
+ * event source in the system (a 30 s tick → ~120 rows/hr/session), with NO
+ * server-side `events` retention. Appending a fresh row per tick would silently
+ * make heartbeats the dominant table writer and grow linearly with session
+ * duration (events#864). So we keep EXACTLY ONE heartbeat event per session:
+ *   - INSERT when the session has no heartbeat row yet;
+ *   - UPDATE that single row in place on every later tick (payload + timestamp
+ *     refreshed) — O(1) per session, not O(ticks).
+ * The update is GUARDED on `iteration`: an out-of-order OLDER tick (a redelivered
+ * or reordered earlier heartbeat) MUST NOT regress the row to stale liveness, so
+ * we only overwrite when the incoming `iteration` is `>=` the stored one. (`>=`
+ * not `>`: an exact redelivery of the latest tick is idempotently re-applied,
+ * which is harmless and keeps the timestamp fresh.)
  *
  * No-op when no dispatch anchor exists for the correlation_id: a heartbeat for a
  * task MC never saw projected (e.g. the `started` was lost AND no terminal has
@@ -31,9 +42,9 @@
 import type { Database } from "bun:sqlite";
 
 import { insertEvent } from "../db/events";
+import { findAnchorSession } from "./anchor";
 
 const HEARTBEAT_TYPE = "system.agent.heartbeat";
-const ANCHOR_TASK_PREFIX = "mc-dispatch-task-";
 
 export interface ProjectableHeartbeatEnvelope {
   id?: string;
@@ -45,22 +56,19 @@ export interface ProjectableHeartbeatEnvelope {
 export interface HeartbeatProjectionResult {
   /** MC session the liveness touch landed on. */
   sessionId: string;
-  /** The heartbeat tick iteration. */
+  /** The heartbeat tick iteration now recorded on the session's liveness row. */
   iteration: number;
   /** ms since last activity, echoed from the payload. */
   lastActivityMsAgo: number;
-  /** The MC event id created (or updated). */
+  /** The MC event id created (or updated in place). */
   eventId: string;
-}
-
-function anchorTaskId(correlationId: string): string {
-  return `${ANCHOR_TASK_PREFIX}${correlationId}`;
 }
 
 /**
  * Project one `system.agent.heartbeat` envelope into a liveness touch. Returns
- * null for a non-heartbeat type, a malformed payload, or an unjoinable
- * heartbeat (no projected dispatch anchor).
+ * null for a non-heartbeat type, a malformed payload, an unjoinable heartbeat
+ * (no projected dispatch anchor), or an out-of-order OLDER tick that would
+ * regress the session's recorded liveness.
  */
 export function projectHeartbeat(
   db: Database,
@@ -101,20 +109,27 @@ export function projectHeartbeat(
       correlation_id: correlationId,
     };
 
-    // Collapse to one row per (session, iteration): a redelivered tick updates
-    // the existing row's payload rather than appending a duplicate. Distinct
-    // ticks (new iteration) append fresh, giving the grid a monotonic liveness
-    // trail without unbounded growth on redelivery.
+    // ONE latest-heartbeat row per session. Find the session's existing
+    // heartbeat row (there is at most one — this invariant is maintained here).
     const existing = db
       .query(
-        `SELECT id FROM events
+        `SELECT id, json_extract(payload, '$.iteration') AS iteration
+         FROM events
          WHERE session_id = ? AND type = ?
-           AND json_extract(payload, '$.iteration') = ?
          LIMIT 1`,
       )
-      .get(sessionId, HEARTBEAT_TYPE, iteration) as { id: string } | null;
+      .get(sessionId, HEARTBEAT_TYPE) as
+      | { id: string; iteration: number | null }
+      | null;
 
     if (existing !== null) {
+      const storedIteration =
+        typeof existing.iteration === "number" ? existing.iteration : -1;
+      // Out-of-order OLDER tick → do NOT regress the recorded liveness. `>=`
+      // tolerates an exact redelivery of the latest tick (idempotent refresh).
+      if (iteration < storedIteration) {
+        return { sessionId, iteration: storedIteration, lastActivityMsAgo, eventId: existing.id };
+      }
       db.query(
         `UPDATE events SET payload = ?, timestamp = ? WHERE id = ?`,
       ).run(
@@ -134,20 +149,6 @@ export function projectHeartbeat(
   });
 
   return txn();
-}
-
-function findAnchorSession(db: Database, correlationId: string): string | null {
-  const row = db
-    .query(
-      `SELECT s.id AS session_id
-       FROM agent_task_assignment a
-       JOIN sessions s ON s.assignment_id = a.id
-       WHERE a.task_id = ?
-       ORDER BY s.started_at DESC, s.id DESC
-       LIMIT 1`,
-    )
-    .get(anchorTaskId(correlationId)) as { session_id: string } | null;
-  return row ? row.session_id : null;
 }
 
 function asString(value: unknown): string | null {

--- a/src/surface/mc/projection/heartbeat.ts
+++ b/src/surface/mc/projection/heartbeat.ts
@@ -1,0 +1,159 @@
+/**
+ * MC-I1.S6 (#848, ADR-0005 §4) — project `system.agent.heartbeat` envelopes
+ * into a liveness touch on the projected session.
+ *
+ * A heartbeat says "agent X is still working on task Y" (cortex#361). The
+ * dispatch-lifecycle projection (S4) keys its session on `correlation_id` (the
+ * heartbeat's `payload.correlation_id` / envelope `correlation_id` is the SAME
+ * value the review consumer / dispatch handler stamps on the lifecycle
+ * envelopes), so a heartbeat JOINS onto the dispatch anchor's session.
+ *
+ * **Storage decision (stated in the PR): events-table write, NO schema change.**
+ * The brief prefers avoiding a `sessions.last_activity` column + REBUILD_MIGRATIONS
+ * when the data can ride an existing surface. A heartbeat lands as an `events`
+ * row (type `system.agent.heartbeat`) on the joined session — the working grid's
+ * recent-events feed already carries the session's last activity, so "Echo last
+ * seen 4s ago" derives from the newest heartbeat event's timestamp + the
+ * payload's `last_activity_ms_ago`. No new column, no migration.
+ *
+ * Idempotency: each heartbeat is a distinct tick (the `iteration` counter), so
+ * we DON'T dedupe on envelope id — a redelivered heartbeat with the same
+ * `(correlation_id, iteration)` is collapsed to one row (latest wins per tick).
+ *
+ * No-op when no dispatch anchor exists for the correlation_id: a heartbeat for a
+ * task MC never saw projected (e.g. the `started` was lost AND no terminal has
+ * arrived) has nothing to touch. We do NOT synthesise an anchor from a heartbeat
+ * — the lifecycle envelopes own anchor creation; a heartbeat is liveness ON TOP.
+ *
+ * Non-throwing: malformed payloads / unjoinable heartbeats return null.
+ */
+
+import type { Database } from "bun:sqlite";
+
+import { insertEvent } from "../db/events";
+
+const HEARTBEAT_TYPE = "system.agent.heartbeat";
+const ANCHOR_TASK_PREFIX = "mc-dispatch-task-";
+
+export interface ProjectableHeartbeatEnvelope {
+  id?: string;
+  type: string;
+  correlation_id?: string;
+  payload: Record<string, unknown>;
+}
+
+export interface HeartbeatProjectionResult {
+  /** MC session the liveness touch landed on. */
+  sessionId: string;
+  /** The heartbeat tick iteration. */
+  iteration: number;
+  /** ms since last activity, echoed from the payload. */
+  lastActivityMsAgo: number;
+  /** The MC event id created (or updated). */
+  eventId: string;
+}
+
+function anchorTaskId(correlationId: string): string {
+  return `${ANCHOR_TASK_PREFIX}${correlationId}`;
+}
+
+/**
+ * Project one `system.agent.heartbeat` envelope into a liveness touch. Returns
+ * null for a non-heartbeat type, a malformed payload, or an unjoinable
+ * heartbeat (no projected dispatch anchor).
+ */
+export function projectHeartbeat(
+  db: Database,
+  envelope: ProjectableHeartbeatEnvelope,
+): HeartbeatProjectionResult | null {
+  if (envelope.type !== HEARTBEAT_TYPE) return null;
+
+  const rawPayload: unknown = envelope.payload;
+  const payload =
+    typeof rawPayload === "object" && rawPayload !== null
+      ? (rawPayload as Record<string, unknown>)
+      : {};
+
+  // correlation_id is the dispatch anchor key (envelope-level OR payload — both
+  // carry it per cortex#361; prefer the envelope field, fall back to payload).
+  const correlationId =
+    asString(envelope.correlation_id) ?? asString(payload.correlation_id);
+  if (correlationId === null) return null;
+
+  const agentId = asString(payload.agent_id) ?? "agent";
+  const phase = asString(payload.phase) ?? "thinking";
+  const iteration = asNumber(payload.iteration) ?? 0;
+  const lastActivityMsAgo = asNumber(payload.last_activity_ms_ago) ?? 0;
+
+  const txn = db.transaction((): HeartbeatProjectionResult | null => {
+    const sessionId = findAnchorSession(db, correlationId);
+    if (sessionId === null) {
+      // Unjoinable — the lifecycle anchor isn't projected yet. Liveness rides
+      // on top of the anchor; we don't synthesise one from a heartbeat.
+      return null;
+    }
+
+    const eventPayload: Record<string, unknown> = {
+      agent_id: agentId,
+      phase,
+      iteration,
+      last_activity_ms_ago: lastActivityMsAgo,
+      correlation_id: correlationId,
+    };
+
+    // Collapse to one row per (session, iteration): a redelivered tick updates
+    // the existing row's payload rather than appending a duplicate. Distinct
+    // ticks (new iteration) append fresh, giving the grid a monotonic liveness
+    // trail without unbounded growth on redelivery.
+    const existing = db
+      .query(
+        `SELECT id FROM events
+         WHERE session_id = ? AND type = ?
+           AND json_extract(payload, '$.iteration') = ?
+         LIMIT 1`,
+      )
+      .get(sessionId, HEARTBEAT_TYPE, iteration) as { id: string } | null;
+
+    if (existing !== null) {
+      db.query(
+        `UPDATE events SET payload = ?, timestamp = ? WHERE id = ?`,
+      ).run(
+        JSON.stringify(eventPayload),
+        new Date().toISOString(),
+        existing.id,
+      );
+      return { sessionId, iteration, lastActivityMsAgo, eventId: existing.id };
+    }
+
+    const ev = insertEvent(db, {
+      sessionId,
+      type: HEARTBEAT_TYPE,
+      payload: eventPayload,
+    });
+    return { sessionId, iteration, lastActivityMsAgo, eventId: ev.id };
+  });
+
+  return txn();
+}
+
+function findAnchorSession(db: Database, correlationId: string): string | null {
+  const row = db
+    .query(
+      `SELECT s.id AS session_id
+       FROM agent_task_assignment a
+       JOIN sessions s ON s.assignment_id = a.id
+       WHERE a.task_id = ?
+       ORDER BY s.started_at DESC, s.id DESC
+       LIMIT 1`,
+    )
+    .get(anchorTaskId(correlationId)) as { session_id: string } | null;
+  return row ? row.session_id : null;
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function asNumber(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}

--- a/src/surface/mc/projection/review-verdict.ts
+++ b/src/surface/mc/projection/review-verdict.ts
@@ -1,0 +1,278 @@
+/**
+ * MC-I1.S6 (#848, ADR-0005 §4) — project `review.verdict.*` envelopes into MC.
+ *
+ * A verdict is the reviewing agent's decision on a PR. The review pipeline
+ * correlates a verdict to its request via `correlation_id` = the request
+ * envelope's `id` (see `bus/review-events.ts` §5.1). The dispatch-lifecycle
+ * projection (S4) keys its MC anchor on that SAME `correlation_id` (the review
+ * consumer emits `dispatch.task.*` lifecycle envelopes carrying the request id
+ * as their correlation_id). So a verdict whose `correlation_id` matches a
+ * projected dispatch anchor JOINS onto that session — the working grid shows
+ * "Echo reviewed PR #861: changes-requested" against the right tile.
+ *
+ * **Join strategy (stated in the PR).** Verdicts carry `repo` + `pr` in the
+ * payload, NOT an MC task id. Two join paths, in priority order:
+ *   1. `correlation_id` → the dispatch anchor's session (the strong join — the
+ *      review consumer's lifecycle envelopes share the verdict's correlation_id).
+ *   2. No matching anchor → store as an UNATTACHED MC event on the orphan
+ *      catch-all session for the verdict (a per-verdict observed anchor), so the
+ *      verdict is never silently dropped. (repo+pr alone don't reliably resolve
+ *      to a local session — MC tasks carry GitHub SourceRefs but a verdict for a
+ *      peer's PR has no local task; the correlation_id join is the only sound
+ *      one, so the fallback is "keep it, unattached" rather than a fuzzy match.)
+ *
+ * The verdict lands as an `events` row (type `review.verdict`) on the joined
+ * session — surfaces render it from the session's recent-events feed, the same
+ * channel hook events use. Idempotent on `(session, envelope.id)`: a redelivered
+ * verdict with the same envelope id is not double-inserted.
+ *
+ * Non-throwing: malformed payloads return null (no-op); the renderer's catch is
+ * the outer belt.
+ */
+
+import type { Database } from "bun:sqlite";
+
+import { insertEvent } from "../db/events";
+import { ensureAgentRow } from "../db/agents";
+import { registerOrphanSession } from "../db/sessions";
+
+/** The three verdict kinds (mirror `bus/review-events.ts:ReviewVerdictKind`). */
+const VERDICT_KINDS = new Set(["approved", "changes-requested", "commented"]);
+
+/** Minimal projectable shape — the renderer hands any validated envelope here. */
+export interface ProjectableVerdictEnvelope {
+  id?: string;
+  type: string;
+  correlation_id?: string;
+  payload: Record<string, unknown>;
+}
+
+export interface VerdictProjectionResult {
+  /** Whether the verdict joined a dispatch anchor (true) or landed unattached (false). */
+  attached: boolean;
+  /** MC session the verdict event landed on. */
+  sessionId: string;
+  /** The verdict kind projected. */
+  verdict: string;
+  /** The MC event id created. */
+  eventId: string;
+}
+
+const ANCHOR_TASK_PREFIX = "mc-dispatch-task-";
+const VERDICT_EVENT_TYPE = "review.verdict";
+
+/** Deterministic dispatch anchor task id (must match dispatch-lifecycle.ts). */
+function anchorTaskId(correlationId: string): string {
+  return `${ANCHOR_TASK_PREFIX}${correlationId}`;
+}
+
+/**
+ * Project one `review.verdict.*` envelope into MC. Returns null for any
+ * non-verdict type (the authoritative filter — the renderer subscribes broadly)
+ * or a malformed payload.
+ */
+export function projectReviewVerdict(
+  db: Database,
+  envelope: ProjectableVerdictEnvelope,
+): VerdictProjectionResult | null {
+  const kind = verdictKind(envelope.type);
+  if (kind === null) return null;
+
+  const rawPayload: unknown = envelope.payload;
+  const payload =
+    typeof rawPayload === "object" && rawPayload !== null
+      ? (rawPayload as Record<string, unknown>)
+      : {};
+
+  const verdict = asString(payload.verdict) ?? kind;
+  const repo = asString(payload.repo);
+  const pr = asNumber(payload.pr);
+  const reviewer = asString(payload.reviewer) ?? "reviewer";
+  if (repo === null || pr === null) {
+    process.stderr.write(
+      `[mission-control] verdict-projection: ignoring ${envelope.type} — missing repo/pr\n`,
+    );
+    return null;
+  }
+
+  const correlationId = asString(envelope.correlation_id);
+  const envelopeId = asString(envelope.id);
+
+  const eventPayload: Record<string, unknown> = {
+    verdict,
+    repo,
+    pr,
+    reviewer,
+    ...(asString(payload.summary) !== null && { summary: payload.summary }),
+    ...(asString(payload.github_review_url) !== null && {
+      github_review_url: payload.github_review_url,
+    }),
+    ...(payload.findings !== undefined && { findings: payload.findings }),
+    ...(asString(payload.presentation) !== null && {
+      presentation: payload.presentation,
+    }),
+    ...(envelopeId !== null && { envelope_id: envelopeId }),
+  };
+
+  const txn = db.transaction((): VerdictProjectionResult => {
+    // 1. Strong join: a dispatch anchor for this correlation_id.
+    const joined =
+      correlationId !== null
+        ? findAnchorSession(db, correlationId)
+        : null;
+
+    if (joined !== null) {
+      // Idempotency: skip if this exact verdict envelope already landed on
+      // the session (redelivery).
+      if (envelopeId !== null && verdictEventExists(db, joined, envelopeId)) {
+        return existingResult(db, joined, verdict, envelopeId, true);
+      }
+      const ev = insertEvent(db, {
+        sessionId: joined,
+        type: VERDICT_EVENT_TYPE,
+        payload: eventPayload,
+      });
+      return { attached: true, sessionId: joined, verdict, eventId: ev.id };
+    }
+
+    // 2. Fallback: unattached. Anchor a per-verdict observed session keyed on a
+    //    synthetic cc id (repo#pr + envelope id) so redelivery dedupes, then
+    //    store the verdict event on it. Never silently drop the verdict.
+    const syntheticCc = `verdict:${repo}#${pr}:${envelopeId ?? correlationId ?? "anon"}`;
+    const existingSession = findSessionByCcId(db, syntheticCc);
+    const sessionId = existingSession ?? anchorUnattachedVerdict(db, syntheticCc, reviewer);
+
+    if (
+      existingSession !== null &&
+      envelopeId !== null &&
+      verdictEventExists(db, sessionId, envelopeId)
+    ) {
+      return existingResult(db, sessionId, verdict, envelopeId, false);
+    }
+
+    const ev = insertEvent(db, {
+      sessionId,
+      type: VERDICT_EVENT_TYPE,
+      payload: eventPayload,
+    });
+    return { attached: false, sessionId, verdict, eventId: ev.id };
+  });
+
+  return txn();
+}
+
+// ---------------------------------------------------------------------------
+// Joins
+// ---------------------------------------------------------------------------
+
+/** Find the dispatch anchor's session for a correlation_id (via the anchor task). */
+function findAnchorSession(db: Database, correlationId: string): string | null {
+  const row = db
+    .query(
+      `SELECT s.id AS session_id
+       FROM agent_task_assignment a
+       JOIN sessions s ON s.assignment_id = a.id
+       WHERE a.task_id = ?
+       ORDER BY s.started_at DESC, s.id DESC
+       LIMIT 1`,
+    )
+    .get(anchorTaskId(correlationId)) as { session_id: string } | null;
+  return row ? row.session_id : null;
+}
+
+function findSessionByCcId(db: Database, ccSessionId: string): string | null {
+  const row = db
+    .query(`SELECT id FROM sessions WHERE cc_session_id = ? LIMIT 1`)
+    .get(ccSessionId) as { id: string } | null;
+  return row ? row.id : null;
+}
+
+/**
+ * Anchor an unattached verdict on a per-verdict observed session. Reuses the S5
+ * orphan pattern (synthetic task + per-anchor agent + assignment + session) so
+ * the verdict is reachable through the same assignment-anchored joins the
+ * working grid uses. The agent is a `head`/non-persistent reviewer tile.
+ */
+function anchorUnattachedVerdict(
+  db: Database,
+  syntheticCc: string,
+  reviewer: string,
+): string {
+  const orphan = registerOrphanSession(db, syntheticCc, `${reviewer} (verdict)`);
+  if (orphan !== null) {
+    // registerOrphanSession created a `head`/non-persistent agent already; the
+    // reviewer label rides as the display name. Nothing else to do.
+    return orphan.sessionId;
+  }
+  // Race: another writer created it between our miss + the insert. Re-find.
+  const found = findSessionByCcId(db, syntheticCc);
+  if (found !== null) return found;
+  // Should not happen (registerOrphanSession only returns null when a session
+  // already exists for the cc id), but keep the helper total: stamp the agent
+  // and surface the error rather than throwing out of render().
+  ensureAgentRow(db, {
+    id: `verdict-${syntheticCc}`,
+    name: `${reviewer} (verdict)`,
+    type: "head",
+    persistent: false,
+  });
+  throw new Error(
+    `verdict-projection: could not anchor unattached verdict for ${syntheticCc}`,
+  );
+}
+
+function verdictEventExists(
+  db: Database,
+  sessionId: string,
+  envelopeId: string,
+): boolean {
+  const row = db
+    .query(
+      `SELECT 1 FROM events
+       WHERE session_id = ? AND type = ? AND json_extract(payload, '$.envelope_id') = ?
+       LIMIT 1`,
+    )
+    .get(sessionId, VERDICT_EVENT_TYPE, envelopeId);
+  return row !== null;
+}
+
+function existingResult(
+  db: Database,
+  sessionId: string,
+  verdict: string,
+  envelopeId: string,
+  attached: boolean,
+): VerdictProjectionResult {
+  const row = db
+    .query(
+      `SELECT id FROM events
+       WHERE session_id = ? AND type = ? AND json_extract(payload, '$.envelope_id') = ?
+       LIMIT 1`,
+    )
+    .get(sessionId, VERDICT_EVENT_TYPE, envelopeId) as { id: string } | null;
+  return {
+    attached,
+    sessionId,
+    verdict,
+    eventId: row?.id ?? "",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function verdictKind(type: string): string | null {
+  const prefix = "review.verdict.";
+  if (!type.startsWith(prefix)) return null;
+  const kind = type.slice(prefix.length);
+  return VERDICT_KINDS.has(kind) ? kind : null;
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function asNumber(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}

--- a/src/surface/mc/projection/review-verdict.ts
+++ b/src/surface/mc/projection/review-verdict.ts
@@ -35,6 +35,7 @@ import type { Database } from "bun:sqlite";
 import { insertEvent } from "../db/events";
 import { ensureAgentRow } from "../db/agents";
 import { registerOrphanSession } from "../db/sessions";
+import { findAnchorSession } from "./anchor";
 
 /** The three verdict kinds (mirror `bus/review-events.ts:ReviewVerdictKind`). */
 const VERDICT_KINDS = new Set(["approved", "changes-requested", "commented"]);
@@ -58,13 +59,7 @@ export interface VerdictProjectionResult {
   eventId: string;
 }
 
-const ANCHOR_TASK_PREFIX = "mc-dispatch-task-";
 const VERDICT_EVENT_TYPE = "review.verdict";
-
-/** Deterministic dispatch anchor task id (must match dispatch-lifecycle.ts). */
-function anchorTaskId(correlationId: string): string {
-  return `${ANCHOR_TASK_PREFIX}${correlationId}`;
-}
 
 /**
  * Project one `review.verdict.*` envelope into MC. Returns null for any
@@ -164,21 +159,6 @@ export function projectReviewVerdict(
 // ---------------------------------------------------------------------------
 // Joins
 // ---------------------------------------------------------------------------
-
-/** Find the dispatch anchor's session for a correlation_id (via the anchor task). */
-function findAnchorSession(db: Database, correlationId: string): string | null {
-  const row = db
-    .query(
-      `SELECT s.id AS session_id
-       FROM agent_task_assignment a
-       JOIN sessions s ON s.assignment_id = a.id
-       WHERE a.task_id = ?
-       ORDER BY s.started_at DESC, s.id DESC
-       LIMIT 1`,
-    )
-    .get(anchorTaskId(correlationId)) as { session_id: string } | null;
-  return row ? row.session_id : null;
-}
 
 function findSessionByCcId(db: Database, ccSessionId: string): string | null {
   const row = db

--- a/src/surface/mc/ws/types.ts
+++ b/src/surface/mc/ws/types.ts
@@ -5,6 +5,14 @@
  * shapes. Clients check `protocolVersion` on the `connected` handshake to
  * detect incompatibility.
  *
+ * ADDITIVE frame types are BACK-COMPAT — NOT a version bump. The client
+ * dispatcher (dashboard-v2 `use-websocket.ts`) is a type-keyed subscription map
+ * (`subs.get(parsed.type)?.forEach(...)`), so a frame `type` an older client
+ * doesn't know finds no handler and no-ops (falling through only to an opt-in
+ * `"*"` wildcard). Only a BREAKING change to an EXISTING frame's shape bumps
+ * `WS_PROTOCOL_VERSION`. (E.g. MC-I1.S6's `mc.projection` frame is additive and
+ * intentionally ships without a bump.)
+ *
  * v2 (cortex#436): the input/curation event kinds were renamed to
  * `principal.input` / `principal.curation`; the identity field was renamed
  * to `principalId`. Clients must read the principal.* kinds.

--- a/src/surface/mc/ws/types.ts
+++ b/src/surface/mc/ws/types.ts
@@ -79,6 +79,26 @@ export type WsServerMessage =
   // Backend now broadcasts a fresh `TaskListItem` (re-read with the
   // updated denorm) so subscribers replace the row in place.
   | { type: "task.updated"; task: TaskListItem }
+  // MC-I1.S6 (#848) — bus→MC projection signal. Emitted when the projection
+  // renderer mutates MC state from a bus envelope (verdict, heartbeat,
+  // federated attention, adapter health, or a dispatch-lifecycle transition).
+  // Carries the projected `family` + the optional joined session/assignment so
+  // a client can scope its refetch. Like `state.transition`, it's a REFRESH
+  // SIGNAL — the authoritative rows come from the REST API on refetch, not from
+  // this frame's fields — so it reuses the existing debounced-refetch pattern
+  // rather than inventing an authoritative-by-payload protocol. Closes the S4
+  // "projection writes bypass WS fan-out" gap.
+  | {
+      type: "mc.projection";
+      family:
+        | "dispatch.lifecycle"
+        | "review.verdict"
+        | "agent.heartbeat"
+        | "attention"
+        | "adapter.health";
+      sessionId?: string;
+      assignmentId?: string;
+    }
   | { type: "pong" }
   | { type: "ping" }
   | {


### PR DESCRIPTION
## What

Generalizes the S4 bus→MC projection seam (#861) from dispatch-only to a five-family `project(envelope, subject)` dispatcher, threads the embed's `WsClientRegistry` through so projected mutations push to live dashboard clients (closing S4's documented WS fan-out gap), retires-or-annotates the ring buffer per ADR-0005 §4, and lands the deferred `ensureAgentRow` DRY pickup.

Implements ADR-0005 §4 ("The bus→MC seam is a registered renderer"). Extends the S4 dispatcher — adds cases, does not rewrite — so the surface-router registration + non-throwing contract stay intact.

## New projection families

Each handler is idempotent + non-throwing, same error-isolation contract as S4's renderer.

| envelope.type | projection | join / storage |
|---|---|---|
| `review.verdict.{approved,changes-requested,commented}` | `projectReviewVerdict` | strong join onto the dispatch anchor via `correlation_id`; **unattached** (per-verdict observed anchor, never dropped) when no anchor — verdicts carry repo+pr but no MC task id, so the correlation_id join is the only sound one |
| `system.agent.heartbeat` | `projectHeartbeat` | liveness touch as an **events-table write** on the joined session (no schema change); collapse-per-iteration on redelivery, append new ticks |
| `system.attention.{opened,resolved}` | `projectAttention` | **FEDERATED-only** ingest under a disjoint `att:fed:` namespace |
| `system.adapter.{degraded,recovered,disconnected}` | `projectAdapterLifecycle` | adapter-health attention under `att:adapter:`, open on outage / resolve on recovery (clean disconnect = resolve) |

## WS push (closes the S4-documented gap)

`embed.ts` now exposes `wsRegistry` on `MissionControlHandle`. The renderer takes it (`createDispatchProjectionRenderer(db, wsRegistry)`) and broadcasts a single **new** `mc.projection` refresh signal (`ws/types.ts` + `broadcastProjection` in `notifications.ts`) on every projected mutation — **reusing the existing broadcast helper**, not a parallel protocol. Like `state.transition`, it's a debounced-refetch signal (authoritative rows come from the REST API). Covers S4's dispatch-lifecycle transitions too. `wsRegistry` is optional — headless/test wiring passes none and the broadcast no-ops.

## Three scoping decisions

1. **Attention — FEDERATED only.** The local `reconcileAttention` (cockpit loop) owns local-derived attention under `att:block:`/`att:stale:` with a prefix-scoped resolve ("never touch items produced by other sources") and re-publishes those deltas onto the bus. Ingesting every `system.attention.*` would (a) echo the loop's own local writes and (b) double-count. So the projection ingests **only `federated.` subjects** (gated on the matched subject the router passes), stores under a **disjoint `att:fed:` namespace**, and NULLs local FK targets (a peer's session/work-item ids aren't local rows). Local attention stays the cockpit loop's job; the projection's value is peer attention the loop can't see.

2. **Ring buffer — RETAINED + annotated (smaller faithful change).** Verified nothing reads `DashboardRenderer.getRecent()` in production (only its own tests), so it's inert as an MC feed per ADR-0005 §4. Kept rather than retired because it's a user-facing `renderers:` config `kind: dashboard` in the schema discriminated union (removing it is config-breaking) **and** it's the G-1111 §4.6 fail-safe pair with PagerDuty. Annotated as superseded; the ADR's "drill-down recent-raw feed" consumer can read `getRecent()` if/when built.

3. **Heartbeat storage — events-table write, no schema change.** A `sessions.last_activity` column + REBUILD_MIGRATIONS is avoidable: a heartbeat lands as a `system.agent.heartbeat` event on the joined session, and the working grid's recent-events feed already carries last activity. Collapse-per-`iteration` on redelivery bounds growth.

## DRY (deferred #861 review finding 3)

`ensureAgentRow` (`db/agents.ts`) — one insert-only-name `agents` upsert parameterised on type/persistent — now backs all three copies: `ensureNamedAgent` (handlers.ts), `ensureOrphanAgent` (sessions.ts), and S4's dispatch-anchor copy. Behaviour unchanged (proved by tests).

## Files changed

New: `db/agents.ts`, `projection/review-verdict.ts`, `projection/heartbeat.ts`, `projection/attention-projection.ts`, `projection/adapter-lifecycle.ts`, two test files.
Modified: `projection/dispatch-lifecycle-renderer.ts` (generalized dispatcher + subjects + WS), `projection/dispatch-lifecycle.ts` (DRY), `api/handlers.ts` (DRY), `db/sessions.ts` (DRY), `embed.ts` (expose wsRegistry), `notifications.ts` + `ws/types.ts` (mc.projection broadcast), `renderers/dashboard.ts` (annotation), `cortex.ts` (thread wsRegistry), S4 renderer test (updated for generalized subjects), embed test (wsRegistry assertion).

## Test plan (TDD)

- `agents-ensure-row.test.ts` (7) — helper insert-only-name + idempotency; the three call sites land the same rows.
- `projection-families.test.ts` (23) — verdict joinable + unattached + idempotent; heartbeat touch + unjoinable null + iteration collapse; adapter open/resolve/idempotent; **federated attention ingest vs local IGNORED + disjoint namespace**; WS broadcast emitted on projected mutation (fake registry) + not on no-op; renderer never throws on malformed; dispatch handler ignores non-dispatch families and vice versa.
- `dispatch-lifecycle-renderer.test.ts` — updated: subjects now match the five families, reject non-projection subjects.
- `embed.test.ts` — asserts the handle exposes the live `wsRegistry`.

## Gates

- `bun run lint` → 0 errors (27 pre-existing unused-directive warnings in unrelated files; none in changed files)
- `bunx tsc --noEmit` → clean
- `bun test` (full) → 5251 pass, 0 fail (one flaky timeout test settled across re-runs; not from these changes)
- `bash scripts/check-carveouts.sh` on changed files → PASS
- No bare "operator" in changed files (uses "principal")

Closes #848
Part of #843

🤖 Generated with [Claude Code](https://claude.com/claude-code)