### PR TITLE
feat(mc): MC-I1.S7 — attention producers: failed_dispatch + stale (E.2 completion)

### DIFF
--- a/src/cortex.ts
+++ b/src/cortex.ts
@@ -101,6 +101,9 @@ import { startCockpitRefreshLoop, type CockpitRefreshLoop } from "./surface/mc/r
 import { startMissionControl, type MissionControlHandle } from "./surface/mc/embed";
 // MC-I1.S4 (ADR-0005 §4) — bus→MC dispatch-lifecycle projection renderer.
 import { createDispatchProjectionRenderer } from "./surface/mc/projection/dispatch-lifecycle-renderer";
+// MC-I1.S7 (#849) — funnel the event-driven failed_dispatch attention delta
+// onto the same system.attention.* bus path the cockpit loop publishes on.
+import { publishReconcileDelta } from "./surface/mc/attention-notify";
 import type { Database as BunDatabase } from "bun:sqlite";
 import { isGatewayEnabled } from "./gateway/gateway-bootstrap";
 import {
@@ -2697,8 +2700,34 @@ export async function startCortex(
       // dashboard clients (S6 — closes the S4 WS fan-out gap). No
       // restart-on-config — like every renderer, the registration is static for
       // the daemon's lifetime.
-      router.register(createDispatchProjectionRenderer(mcDb, mcHandle.wsRegistry));
-      console.log("cortex: Mission Control bus→MC projection renderer registered (dispatch + verdicts + heartbeats + attention + adapter health)");
+      //
+      // MC-I1.S7 (#849) — the event-driven failed_dispatch attention producer
+      // rides this same seam. We stamp it with the stack id and funnel its
+      // open/resolve delta onto the SAME `system.attention.*` bus path the
+      // cockpit loop uses — via the established `publishReconcileDelta` builder
+      // (attention-notify.ts) with the same notifySource the loop uses. This
+      // makes failed_dispatch attention work whenever `mc.enabled`, independent
+      // of `cockpit.enabled` (it's event-driven, not state-derived). The
+      // deep-link for a session-anchored item is the dashboard drill-down route.
+      const mcBaseUrl =
+        config.grove.baseUrl !== "" ? config.grove.baseUrl : `http://localhost:${mcHandle.port}`;
+      router.register(
+        createDispatchProjectionRenderer(mcDb, mcHandle.wsRegistry, {
+          stackId: derivedStack.stack,
+          publishDelta: async (delta) => {
+            await publishReconcileDelta(
+              delta,
+              {
+                source: { principal: principalId, agent: "cortex", instance: "local" },
+                deepLinkFor: (item) =>
+                  item.sessionId !== null ? `${mcBaseUrl}/sessions/${item.sessionId}` : null,
+              },
+              (env) => runtime.publish(env),
+            );
+          },
+        }),
+      );
+      console.log("cortex: Mission Control bus→MC projection renderer registered (dispatch + verdicts + heartbeats + attention + adapter health + failed-dispatch)");
     } catch (err) {
       console.error("cortex: Mission Control embed startup error (non-fatal):", err instanceof Error ? err.message : err);
     }

--- a/src/surface/mc/__tests__/attention-sources-stale-assignment.test.ts
+++ b/src/surface/mc/__tests__/attention-sources-stale-assignment.test.ts
@@ -1,0 +1,151 @@
+/**
+ * MC-I1.S7 (#849) — stale-ASSIGNMENT producer completion (G-1113.E.2 deferral).
+ *
+ * E.2 shipped `att:stale:{wiId}` for stuck WORK ITEMS. This completes the
+ * deferred scope: a non-terminal, non-blocked ASSIGNMENT with no recent
+ * activity is "stale" too, deep-linked via its session, under the disjoint
+ * `att:stale:asg:` sub-namespace. Last-activity joins the S6 heartbeat liveness
+ * row (a recent heartbeat keeps a quiet-`updated_at` session alive; silence past
+ * the threshold flags it). Activity (a fresh heartbeat) heals it.
+ */
+import { describe, it, expect, afterEach } from "bun:test";
+import { join } from "path";
+import { tmpdir } from "os";
+import { rmSync, existsSync } from "fs";
+import { initDatabase } from "../db/init";
+import { getAttentionItem, listOpenAttention } from "../db/attention";
+import { reconcileAttention } from "../db/attention-sources";
+
+const NOW = 1_900_000_000; // fixed epoch seconds
+const HOUR = 60 * 60;
+
+/** ISO string for an epoch-seconds instant (matches sessions/events text columns). */
+function iso(epochSec: number): string {
+  return new Date(epochSec * 1000).toISOString().replace("T", " ").replace(/\.\d+Z$/, "");
+}
+
+describe("reconcileAttention — stale assignments (MC-I1.S7)", () => {
+  const paths: string[] = [];
+  afterEach(() => {
+    for (const p of paths) if (existsSync(p)) rmSync(p);
+    paths.length = 0;
+  });
+  function freshDb() {
+    const p = join(tmpdir(), `stale-asg-${Date.now()}-${Math.random().toString(36).slice(2)}.db`);
+    paths.push(p);
+    return initDatabase(p);
+  }
+
+  /** Seed an assignment in `state` with a session; updated_at + session started_at at `tsSec`. */
+  function seedAssignment(
+    db: ReturnType<typeof initDatabase>,
+    suffix: string,
+    state: string,
+    updatedAtSec: number,
+  ) {
+    db.query(`INSERT OR IGNORE INTO agents (id, name, type) VALUES ('ag-1', 'Echo', 'head')`).run();
+    db.query(
+      `INSERT OR IGNORE INTO tasks (id, title, principal_id, source_system, status) VALUES ('tk-1', 'T', 'andreas', 'github', 'in_progress')`,
+    ).run();
+    db.query(
+      `INSERT INTO agent_task_assignment (id, agent_id, task_id, state, updated_at) VALUES (?, 'ag-1', 'tk-1', ?, ?)`,
+    ).run(`asg-${suffix}`, state, iso(updatedAtSec));
+    db.query(
+      `INSERT INTO sessions (id, assignment_id, endpoint_kind, started_at) VALUES (?, ?, 'local.process.controlled', ?)`,
+    ).run(`sess-${suffix}`, `asg-${suffix}`, iso(updatedAtSec));
+  }
+
+  /** Land a heartbeat event on a session at `tsSec` (the S6 liveness signal). */
+  function heartbeat(db: ReturnType<typeof initDatabase>, suffix: string, tsSec: number) {
+    db.query(
+      `INSERT INTO events (id, session_id, type, payload, timestamp) VALUES (?, ?, 'system.agent.heartbeat', '{}', ?)`,
+    ).run(`ev-${suffix}-${tsSec}`, `sess-${suffix}`, iso(tsSec));
+  }
+
+  const opts = { stackId: "laptop", nowEpochSec: NOW };
+
+  it("flags a running assignment that has gone silent past the threshold", () => {
+    const db = freshDb();
+    seedAssignment(db, "stuck", "running", NOW - 5 * HOUR); // updated 5h ago, no heartbeat
+    reconcileAttention(db, opts);
+    const item = getAttentionItem(db, "att:stale:asg:asg-stuck");
+    expect(item?.kind).toBe("stale");
+    expect(item?.severity).toBe("normal");
+    expect(item?.sessionId).toBe("sess-stuck");
+    expect(item?.workItemId).toBeNull();
+  });
+
+  it("does NOT flag an assignment kept alive by a recent heartbeat (quiet updated_at)", () => {
+    const db = freshDb();
+    seedAssignment(db, "live", "running", NOW - 5 * HOUR); // updated_at old…
+    heartbeat(db, "live", NOW - 2 * 60); // …but heartbeated 2 min ago → alive
+    reconcileAttention(db, opts);
+    expect(getAttentionItem(db, "att:stale:asg:asg-live")).toBeNull();
+  });
+
+  it("flags an assignment whose last heartbeat is itself past the threshold", () => {
+    const db = freshDb();
+    seedAssignment(db, "silent", "running", NOW - 5 * HOUR);
+    heartbeat(db, "silent", NOW - 3 * HOUR); // last heartbeat 3h ago → stale
+    reconcileAttention(db, opts);
+    expect(getAttentionItem(db, "att:stale:asg:asg-silent")?.status).toBe("open");
+  });
+
+  it("a fresh heartbeat heals a previously-stale assignment", () => {
+    const db = freshDb();
+    seedAssignment(db, "heal", "running", NOW - 5 * HOUR);
+    reconcileAttention(db, opts);
+    expect(getAttentionItem(db, "att:stale:asg:asg-heal")?.status).toBe("open");
+
+    // The agent ticks a heartbeat → next reconcile resolves it.
+    heartbeat(db, "heal", NOW - 30); // 30 s ago
+    reconcileAttention(db, opts);
+    expect(getAttentionItem(db, "att:stale:asg:asg-heal")?.status).toBe("resolved");
+  });
+
+  it("does NOT flag terminal assignments (completed/failed/cancelled) or blocked", () => {
+    const db = freshDb();
+    seedAssignment(db, "done", "completed", NOW - 5 * HOUR);
+    seedAssignment(db, "failed", "failed", NOW - 5 * HOUR);
+    seedAssignment(db, "cancelled", "cancelled", NOW - 5 * HOUR);
+    reconcileAttention(db, opts);
+    expect(listOpenAttention(db).filter((i) => i.id.startsWith("att:stale:asg:"))).toEqual([]);
+  });
+
+  it("flags queued and dispatched (not just running) when stuck", () => {
+    const db = freshDb();
+    seedAssignment(db, "q", "queued", NOW - 5 * HOUR);
+    seedAssignment(db, "d", "dispatched", NOW - 5 * HOUR);
+    reconcileAttention(db, opts);
+    expect(getAttentionItem(db, "att:stale:asg:asg-q")?.status).toBe("open");
+    expect(getAttentionItem(db, "att:stale:asg:asg-d")?.status).toBe("open");
+  });
+
+  it("a fresh assignment (recent updated_at) is not stale yet", () => {
+    const db = freshDb();
+    seedAssignment(db, "fresh", "running", NOW - 5 * 60); // 5 min ago
+    reconcileAttention(db, opts);
+    expect(getAttentionItem(db, "att:stale:asg:asg-fresh")).toBeNull();
+  });
+
+  it("honours a custom staleAssignmentAfterMs threshold", () => {
+    const db = freshDb();
+    seedAssignment(db, "custom", "running", NOW - 10 * 60); // 10 min ago
+    // Default (1h) would NOT flag it…
+    reconcileAttention(db, opts);
+    expect(getAttentionItem(db, "att:stale:asg:asg-custom")).toBeNull();
+    // …a 5-min threshold does.
+    reconcileAttention(db, { ...opts, staleAssignmentAfterMs: 5 * 60 * 1000 });
+    expect(getAttentionItem(db, "att:stale:asg:asg-custom")?.status).toBe("open");
+  });
+
+  it("resolves a stale assignment once it transitions terminal", () => {
+    const db = freshDb();
+    seedAssignment(db, "term", "running", NOW - 5 * HOUR);
+    reconcileAttention(db, opts);
+    expect(getAttentionItem(db, "att:stale:asg:asg-term")?.status).toBe("open");
+    db.query(`UPDATE agent_task_assignment SET state = 'completed' WHERE id = 'asg-term'`).run();
+    reconcileAttention(db, opts);
+    expect(getAttentionItem(db, "att:stale:asg:asg-term")?.status).toBe("resolved");
+  });
+});

--- a/src/surface/mc/__tests__/attention-sources-stale-assignment.test.ts
+++ b/src/surface/mc/__tests__/attention-sources-stale-assignment.test.ts
@@ -2,11 +2,15 @@
  * MC-I1.S7 (#849) — stale-ASSIGNMENT producer completion (G-1113.E.2 deferral).
  *
  * E.2 shipped `att:stale:{wiId}` for stuck WORK ITEMS. This completes the
- * deferred scope: a non-terminal, non-blocked ASSIGNMENT with no recent
- * activity is "stale" too, deep-linked via its session, under the disjoint
- * `att:stale:asg:` sub-namespace. Last-activity joins the S6 heartbeat liveness
- * row (a recent heartbeat keeps a quiet-`updated_at` session alive; silence past
- * the threshold flags it). Activity (a fresh heartbeat) heals it.
+ * deferred scope: a non-terminal, non-blocked ASSIGNMENT whose most-recent
+ * HEARTBEATING session has gone silent past the threshold is "stale" too,
+ * deep-linked via its session, under the disjoint `att:stale:asg:` sub-namespace.
+ *
+ * SCOPING (PR #873 review major 2): only sessions that EMIT heartbeats are
+ * judged. `attachHeartbeatToCCSession` is controlled-CC-only; observed/orphan
+ * sessions reach `running` via the ingestor but never tick, so a heartbeat-
+ * cadence threshold would flap them. The producer requires ≥1 heartbeat liveness
+ * row on the most-recent session, so observed/orphan sessions are out of scope.
  */
 import { describe, it, expect, afterEach } from "bun:test";
 import { join } from "path";
@@ -36,13 +40,19 @@ describe("reconcileAttention — stale assignments (MC-I1.S7)", () => {
     return initDatabase(p);
   }
 
-  /** Seed an assignment in `state` with a session; updated_at + session started_at at `tsSec`. */
+  /**
+   * Seed an assignment in `state` with a session of `endpointKind`; updated_at +
+   * session started_at at `tsSec`. Pass `heartbeatAtSec` to land a heartbeat
+   * liveness row on the session — only heartbeating sessions are stale-judged.
+   */
   function seedAssignment(
     db: ReturnType<typeof initDatabase>,
     suffix: string,
     state: string,
     updatedAtSec: number,
+    opts: { endpointKind?: string; heartbeatAtSec?: number } = {},
   ) {
+    const endpointKind = opts.endpointKind ?? "local.process.controlled";
     db.query(`INSERT OR IGNORE INTO agents (id, name, type) VALUES ('ag-1', 'Echo', 'head')`).run();
     db.query(
       `INSERT OR IGNORE INTO tasks (id, title, principal_id, source_system, status) VALUES ('tk-1', 'T', 'andreas', 'github', 'in_progress')`,
@@ -51,8 +61,9 @@ describe("reconcileAttention — stale assignments (MC-I1.S7)", () => {
       `INSERT INTO agent_task_assignment (id, agent_id, task_id, state, updated_at) VALUES (?, 'ag-1', 'tk-1', ?, ?)`,
     ).run(`asg-${suffix}`, state, iso(updatedAtSec));
     db.query(
-      `INSERT INTO sessions (id, assignment_id, endpoint_kind, started_at) VALUES (?, ?, 'local.process.controlled', ?)`,
-    ).run(`sess-${suffix}`, `asg-${suffix}`, iso(updatedAtSec));
+      `INSERT INTO sessions (id, assignment_id, endpoint_kind, started_at) VALUES (?, ?, ?, ?)`,
+    ).run(`sess-${suffix}`, `asg-${suffix}`, endpointKind, iso(updatedAtSec));
+    if (opts.heartbeatAtSec !== undefined) heartbeat(db, suffix, opts.heartbeatAtSec);
   }
 
   /** Land a heartbeat event on a session at `tsSec` (the S6 liveness signal). */
@@ -64,9 +75,10 @@ describe("reconcileAttention — stale assignments (MC-I1.S7)", () => {
 
   const opts = { stackId: "laptop", nowEpochSec: NOW };
 
-  it("flags a running assignment that has gone silent past the threshold", () => {
+  it("flags a controlled session whose last heartbeat is past the threshold", () => {
     const db = freshDb();
-    seedAssignment(db, "stuck", "running", NOW - 5 * HOUR); // updated 5h ago, no heartbeat
+    // Heartbeated 3h ago, then went silent → stale.
+    seedAssignment(db, "stuck", "running", NOW - 5 * HOUR, { heartbeatAtSec: NOW - 3 * HOUR });
     reconcileAttention(db, opts);
     const item = getAttentionItem(db, "att:stale:asg:asg-stuck");
     expect(item?.kind).toBe("stale");
@@ -75,25 +87,43 @@ describe("reconcileAttention — stale assignments (MC-I1.S7)", () => {
     expect(item?.workItemId).toBeNull();
   });
 
-  it("does NOT flag an assignment kept alive by a recent heartbeat (quiet updated_at)", () => {
+  it("does NOT flag a session kept alive by a recent heartbeat (quiet updated_at)", () => {
     const db = freshDb();
-    seedAssignment(db, "live", "running", NOW - 5 * HOUR); // updated_at old…
-    heartbeat(db, "live", NOW - 2 * 60); // …but heartbeated 2 min ago → alive
+    // updated_at old, but heartbeated 2 min ago → alive.
+    seedAssignment(db, "live", "running", NOW - 5 * HOUR, { heartbeatAtSec: NOW - 2 * 60 });
     reconcileAttention(db, opts);
     expect(getAttentionItem(db, "att:stale:asg:asg-live")).toBeNull();
   });
 
-  it("flags an assignment whose last heartbeat is itself past the threshold", () => {
+  // --- The scoping fix (PR #873 review major 2) ---
+
+  it("does NOT flag an observed session past the threshold (never heartbeats → out of scope)", () => {
     const db = freshDb();
-    seedAssignment(db, "silent", "running", NOW - 5 * HOUR);
-    heartbeat(db, "silent", NOW - 3 * HOUR); // last heartbeat 3h ago → stale
+    // A long-quiet observed session: updated_at 5h ago, NO heartbeat row. Under
+    // the old updated_at-fallback this flapped; now it's correctly out of scope.
+    seedAssignment(db, "obs", "running", NOW - 5 * HOUR, { endpointKind: "local.observed" });
+    reconcileAttention(db, opts);
+    expect(getAttentionItem(db, "att:stale:asg:asg-obs")).toBeNull();
+  });
+
+  it("does NOT flag a controlled session that never heartbeated (spawn raced attach)", () => {
+    const db = freshDb();
+    // Controlled but NO heartbeat row at all → no liveness signal → out of scope.
+    seedAssignment(db, "nohb", "running", NOW - 5 * HOUR);
+    reconcileAttention(db, opts);
+    expect(getAttentionItem(db, "att:stale:asg:asg-nohb")).toBeNull();
+  });
+
+  it("flags a controlled silent session past the threshold (has heartbeated, now silent)", () => {
+    const db = freshDb();
+    seedAssignment(db, "silent", "running", NOW - 5 * HOUR, { heartbeatAtSec: NOW - 90 * 60 });
     reconcileAttention(db, opts);
     expect(getAttentionItem(db, "att:stale:asg:asg-silent")?.status).toBe("open");
   });
 
   it("a fresh heartbeat heals a previously-stale assignment", () => {
     const db = freshDb();
-    seedAssignment(db, "heal", "running", NOW - 5 * HOUR);
+    seedAssignment(db, "heal", "running", NOW - 5 * HOUR, { heartbeatAtSec: NOW - 3 * HOUR });
     reconcileAttention(db, opts);
     expect(getAttentionItem(db, "att:stale:asg:asg-heal")?.status).toBe("open");
 
@@ -103,34 +133,35 @@ describe("reconcileAttention — stale assignments (MC-I1.S7)", () => {
     expect(getAttentionItem(db, "att:stale:asg:asg-heal")?.status).toBe("resolved");
   });
 
-  it("does NOT flag terminal assignments (completed/failed/cancelled) or blocked", () => {
+  it("does NOT flag terminal assignments (completed/failed/cancelled)", () => {
     const db = freshDb();
-    seedAssignment(db, "done", "completed", NOW - 5 * HOUR);
-    seedAssignment(db, "failed", "failed", NOW - 5 * HOUR);
-    seedAssignment(db, "cancelled", "cancelled", NOW - 5 * HOUR);
+    seedAssignment(db, "done", "completed", NOW - 5 * HOUR, { heartbeatAtSec: NOW - 3 * HOUR });
+    seedAssignment(db, "failed", "failed", NOW - 5 * HOUR, { heartbeatAtSec: NOW - 3 * HOUR });
+    seedAssignment(db, "cancelled", "cancelled", NOW - 5 * HOUR, { heartbeatAtSec: NOW - 3 * HOUR });
     reconcileAttention(db, opts);
     expect(listOpenAttention(db).filter((i) => i.id.startsWith("att:stale:asg:"))).toEqual([]);
   });
 
   it("flags queued and dispatched (not just running) when stuck", () => {
     const db = freshDb();
-    seedAssignment(db, "q", "queued", NOW - 5 * HOUR);
-    seedAssignment(db, "d", "dispatched", NOW - 5 * HOUR);
+    seedAssignment(db, "q", "queued", NOW - 5 * HOUR, { heartbeatAtSec: NOW - 3 * HOUR });
+    seedAssignment(db, "d", "dispatched", NOW - 5 * HOUR, { heartbeatAtSec: NOW - 3 * HOUR });
     reconcileAttention(db, opts);
     expect(getAttentionItem(db, "att:stale:asg:asg-q")?.status).toBe("open");
     expect(getAttentionItem(db, "att:stale:asg:asg-d")?.status).toBe("open");
   });
 
-  it("a fresh assignment (recent updated_at) is not stale yet", () => {
+  it("a recently-heartbeating session is not stale yet", () => {
     const db = freshDb();
-    seedAssignment(db, "fresh", "running", NOW - 5 * 60); // 5 min ago
+    seedAssignment(db, "fresh", "running", NOW - 5 * 60, { heartbeatAtSec: NOW - 5 * 60 });
     reconcileAttention(db, opts);
     expect(getAttentionItem(db, "att:stale:asg:asg-fresh")).toBeNull();
   });
 
   it("honours a custom staleAssignmentAfterMs threshold", () => {
     const db = freshDb();
-    seedAssignment(db, "custom", "running", NOW - 10 * 60); // 10 min ago
+    // Last heartbeat 10 min ago.
+    seedAssignment(db, "custom", "running", NOW - 10 * 60, { heartbeatAtSec: NOW - 10 * 60 });
     // Default (1h) would NOT flag it…
     reconcileAttention(db, opts);
     expect(getAttentionItem(db, "att:stale:asg:asg-custom")).toBeNull();
@@ -141,11 +172,53 @@ describe("reconcileAttention — stale assignments (MC-I1.S7)", () => {
 
   it("resolves a stale assignment once it transitions terminal", () => {
     const db = freshDb();
-    seedAssignment(db, "term", "running", NOW - 5 * HOUR);
+    seedAssignment(db, "term", "running", NOW - 5 * HOUR, { heartbeatAtSec: NOW - 3 * HOUR });
     reconcileAttention(db, opts);
     expect(getAttentionItem(db, "att:stale:asg:asg-term")?.status).toBe("open");
     db.query(`UPDATE agent_task_assignment SET state = 'completed' WHERE id = 'asg-term'`).run();
     reconcileAttention(db, opts);
     expect(getAttentionItem(db, "att:stale:asg:asg-term")?.status).toBe("resolved");
+  });
+
+  // --- Resolve → genuine recurrence (PR #873 review nit 1, resolved) ---
+
+  it("re-notifies on a genuine resolve→recur cycle (ML.3 contract upheld)", () => {
+    // Review nit 1 proposed suppressing the reopen notification, but that would
+    // break the established ML.3 contract that a RESOLVED condition which
+    // genuinely recurs re-notifies (you want to know a cleared blocker came
+    // back). The flap concern is instead handled by review major 2 — stale-asg
+    // is scoped to heartbeating sessions, so the false-positive flap that
+    // motivated the nit can't occur. A real heartbeating session that goes
+    // quiet → active → quiet IS a genuine recurrence and SHOULD re-notify.
+    const db = freshDb();
+    seedAssignment(db, "flap", "running", NOW - 5 * HOUR, { heartbeatAtSec: NOW - 3 * HOUR });
+    const r1 = reconcileAttention(db, opts);
+    expect(r1.opened.map((i) => i.id)).toContain("att:stale:asg:asg-flap");
+
+    // Activity heals it (resolve).
+    heartbeat(db, "flap", NOW - 30);
+    const r2 = reconcileAttention(db, opts);
+    expect(r2.resolved.map((i) => i.id)).toContain("att:stale:asg:asg-flap");
+
+    // It genuinely goes quiet again past threshold — re-derives AND re-notifies.
+    const r3 = reconcileAttention(db, { ...opts, nowEpochSec: NOW + 5 * HOUR });
+    expect(r3.opened.map((i) => i.id)).toContain("att:stale:asg:asg-flap");
+    expect(getAttentionItem(db, "att:stale:asg:asg-flap")?.status).toBe("open");
+  });
+
+  it("never re-notifies a DISMISSED stale-asg item (dismiss beats recurrence)", () => {
+    const db = freshDb();
+    seedAssignment(db, "dism", "running", NOW - 5 * HOUR, { heartbeatAtSec: NOW - 3 * HOUR });
+    const r1 = reconcileAttention(db, opts);
+    expect(r1.opened.map((i) => i.id)).toContain("att:stale:asg:asg-dism");
+
+    // Principal dismisses it.
+    db.query(`UPDATE attention_items SET status = 'dismissed' WHERE id = ?`).run(
+      "att:stale:asg:asg-dism"
+    );
+    // Still stale on the next pass — must NOT reopen or re-notify.
+    const r2 = reconcileAttention(db, opts);
+    expect(r2.opened.map((i) => i.id)).not.toContain("att:stale:asg:asg-dism");
+    expect(getAttentionItem(db, "att:stale:asg:asg-dism")?.status).toBe("dismissed");
   });
 });

--- a/src/surface/mc/__tests__/dispatch-lifecycle-renderer.test.ts
+++ b/src/surface/mc/__tests__/dispatch-lifecycle-renderer.test.ts
@@ -20,13 +20,17 @@ import {
   createDispatchProjectionRenderer,
   DISPATCH_PROJECTION_RENDERER_ID,
   DISPATCH_PROJECTION_SUBJECTS,
+  type FailedDispatchAttentionWiring,
 } from "../projection/dispatch-lifecycle-renderer";
 import { subjectMatches } from "../../../bus/surface-router";
 import {
   createDispatchTaskStartedEvent,
+  createDispatchTaskFailedEvent,
   type DispatchEventSource,
 } from "../../../bus/dispatch-events";
 import type { Envelope } from "../../../bus/myelin/envelope-validator";
+import type { AttentionDelta } from "../projection/failed-dispatch";
+import { getAttentionItem } from "../db/attention";
 
 const SOURCE: DispatchEventSource = {
   principal: "andreas",
@@ -165,5 +169,76 @@ describe("createDispatchProjectionRenderer", () => {
       );
       expect(hit).toBe(false);
     }
+  });
+
+  // --- MC-I1.S7: failed_dispatch attention notify funnel ---
+
+  function failedEnvelope(): Envelope {
+    return createDispatchTaskFailedEvent({
+      source: SOURCE,
+      taskId: TASK_ID,
+      agentId: "cortex",
+      startedAt: new Date("2026-06-10T12:00:00.000Z"),
+      failedAt: new Date("2026-06-10T12:05:00.000Z"),
+      errorSummary: "boom",
+      reason: { kind: "cant_do", detail: "bad output" },
+    });
+  }
+
+  it("opens a failed_dispatch item and funnels the opened delta to publishDelta", async () => {
+    const deltas: AttentionDelta[] = [];
+    const wiring: FailedDispatchAttentionWiring = {
+      stackId: "work",
+      publishDelta: (d) => {
+        deltas.push(d);
+      },
+    };
+    const adapter = createDispatchProjectionRenderer(db, undefined, wiring);
+    await adapter.render(failedEnvelope());
+
+    expect(getAttentionItem(db, `att:faildis:${TASK_ID}`)?.status).toBe("open");
+    expect(deltas).toHaveLength(1);
+    expect(deltas[0]?.opened).toHaveLength(1);
+    expect(deltas[0]?.resolved).toHaveLength(0);
+  });
+
+  it("funnels the resolved delta when a redispatch started clears a failed item", async () => {
+    const deltas: AttentionDelta[] = [];
+    const wiring: FailedDispatchAttentionWiring = {
+      stackId: "work",
+      publishDelta: (d) => {
+        deltas.push(d);
+      },
+    };
+    const adapter = createDispatchProjectionRenderer(db, undefined, wiring);
+    await adapter.render(failedEnvelope());
+    // A redispatch started for the same anchor resolves the failed item.
+    await adapter.render(
+      createDispatchTaskStartedEvent({
+        source: SOURCE,
+        taskId: TASK_ID,
+        agentId: "cortex",
+        startedAt: new Date("2026-06-10T12:10:00.000Z"),
+      }),
+    );
+
+    expect(getAttentionItem(db, `att:faildis:${TASK_ID}`)?.status).toBe("resolved");
+    // Two publishDelta calls: one opened, then one resolved.
+    expect(deltas).toHaveLength(2);
+    expect(deltas[1]?.resolved).toHaveLength(1);
+  });
+
+  it("still writes the DB item when no publishDelta is wired (headless)", async () => {
+    // Wiring with stackId but no publisher — the DB write happens, no notify.
+    const adapter = createDispatchProjectionRenderer(db, undefined, { stackId: "work" });
+    await adapter.render(failedEnvelope());
+    expect(getAttentionItem(db, `att:faildis:${TASK_ID}`)?.status).toBe("open");
+  });
+
+  it("produces NO failed_dispatch item when no failedDispatch wiring is supplied (S4 back-compat)", async () => {
+    const adapter = createDispatchProjectionRenderer(db);
+    await adapter.render(failedEnvelope());
+    // The lifecycle projection still ran (assignment failed), but no attention.
+    expect(getAttentionItem(db, `att:faildis:${TASK_ID}`)).toBeNull();
   });
 });

--- a/src/surface/mc/__tests__/failed-dispatch.test.ts
+++ b/src/surface/mc/__tests__/failed-dispatch.test.ts
@@ -11,7 +11,12 @@ import { join } from "path";
 import { tmpdir } from "os";
 import { rmSync, existsSync } from "fs";
 import { initDatabase } from "../db/init";
-import { getAttentionItem, listOpenAttention, upsertAttentionItem } from "../db/attention";
+import {
+  getAttentionItem,
+  listOpenAttention,
+  upsertAttentionItem,
+  dismissAttentionItem,
+} from "../db/attention";
 import {
   produceFailedDispatchAttention,
   FAILED_DISPATCH_PREFIX,
@@ -182,6 +187,23 @@ describe("failed_dispatch attention producer (MC-I1.S7)", () => {
     expect(first.opened).toHaveLength(1);
     expect(second.opened).toHaveLength(0); // already open → no re-notify
     expect(listOpenAttention(db).filter((i) => i.id === `${FAILED_DISPATCH_PREFIX}corr-dup`)).toHaveLength(1);
+  });
+
+  it("does NOT resurrect a DISMISSED item on a redelivered failed (no opened delta)", () => {
+    // PR #873 review major 1 — dismiss-resurrection (#621 class). A dismissed
+    // item must stay dismissed across NATS at-least-once redelivery.
+    const db = freshDb();
+    seedAnchor(db, "corr-dismiss");
+    produceFailedDispatchAttention(db, failedEnvelope("corr-dismiss"), { stackId: STACK });
+    // The principal dismisses it.
+    dismissAttentionItem(db, `${FAILED_DISPATCH_PREFIX}corr-dismiss`);
+    expect(getAttentionItem(db, `${FAILED_DISPATCH_PREFIX}corr-dismiss`)?.status).toBe("dismissed");
+
+    // The same failed envelope is redelivered → must NOT flip back to open or notify.
+    const redeliver = produceFailedDispatchAttention(db, failedEnvelope("corr-dismiss"), { stackId: STACK });
+    expect(redeliver.opened).toHaveLength(0);
+    expect(redeliver.resolved).toHaveLength(0);
+    expect(getAttentionItem(db, `${FAILED_DISPATCH_PREFIX}corr-dismiss`)?.status).toBe("dismissed");
   });
 
   it("a resolve of an absent/already-resolved item yields no resolved delta", () => {

--- a/src/surface/mc/__tests__/failed-dispatch.test.ts
+++ b/src/surface/mc/__tests__/failed-dispatch.test.ts
@@ -1,0 +1,264 @@
+/**
+ * MC-I1.S7 (#849) — failed_dispatch attention producer.
+ *
+ * Event-driven off the dispatch-lifecycle seam: a `dispatch.task.failed` /
+ * `aborted` opens an `att:faildis:` item; a principal-cancel aborted does not;
+ * a later `started` / `completed` for the same anchor auto-resolves it; the
+ * `att:faildis:` namespace is disjoint from the reconciler's prefixes.
+ */
+import { describe, it, expect, afterEach } from "bun:test";
+import { join } from "path";
+import { tmpdir } from "os";
+import { rmSync, existsSync } from "fs";
+import { initDatabase } from "../db/init";
+import { getAttentionItem, listOpenAttention, upsertAttentionItem } from "../db/attention";
+import {
+  produceFailedDispatchAttention,
+  FAILED_DISPATCH_PREFIX,
+  PRINCIPAL_CANCEL_REASON,
+} from "../projection/failed-dispatch";
+import { projectDispatchLifecycle } from "../projection/dispatch-lifecycle";
+import { reconcileAttention } from "../db/attention-sources";
+
+const STACK = "test-stack";
+
+describe("failed_dispatch attention producer (MC-I1.S7)", () => {
+  const paths: string[] = [];
+  afterEach(() => {
+    for (const p of paths) if (existsSync(p)) rmSync(p);
+    paths.length = 0;
+  });
+  function freshDb() {
+    const p = join(tmpdir(), `faildis-${Date.now()}-${Math.random().toString(36).slice(2)}.db`);
+    paths.push(p);
+    return initDatabase(p);
+  }
+
+  /** Drive a started envelope so a dispatch anchor (session) exists for deep-linking. */
+  function seedAnchor(db: ReturnType<typeof initDatabase>, correlationId: string, agentId = "echo") {
+    projectDispatchLifecycle(db, {
+      type: "dispatch.task.started",
+      correlation_id: correlationId,
+      payload: { task_id: correlationId, agent_id: agentId },
+    });
+  }
+
+  function failedEnvelope(correlationId: string, reason?: Record<string, unknown>) {
+    return {
+      type: "dispatch.task.failed",
+      correlation_id: correlationId,
+      payload: {
+        task_id: correlationId,
+        agent_id: "echo",
+        error_summary: "assertion failed: expected 1, got 2",
+        ...(reason !== undefined && { reason }),
+      },
+    };
+  }
+
+  it("opens a failed_dispatch item on dispatch.task.failed (with the nak reason captured)", () => {
+    const db = freshDb();
+    seedAnchor(db, "corr-1");
+
+    const delta = produceFailedDispatchAttention(
+      db,
+      failedEnvelope("corr-1", { kind: "cant_do", detail: "bad output" }),
+      { stackId: STACK },
+    );
+
+    expect(delta.opened).toHaveLength(1);
+    expect(delta.resolved).toHaveLength(0);
+    const item = getAttentionItem(db, `${FAILED_DISPATCH_PREFIX}corr-1`);
+    expect(item).not.toBeNull();
+    expect(item?.kind).toBe("failed_dispatch");
+    expect(item?.status).toBe("open");
+    // Deep-links via the dispatch anchor's session.
+    expect(item?.sessionId).not.toBeNull();
+  });
+
+  it("renders severity from the nak reason: policy_denied → critical, not_now → normal", () => {
+    const db = freshDb();
+    seedAnchor(db, "corr-policy");
+    seedAnchor(db, "corr-transient");
+
+    produceFailedDispatchAttention(
+      db,
+      failedEnvelope("corr-policy", { kind: "policy_denied", deny: { reason: "unknown_principal" } }),
+      { stackId: STACK },
+    );
+    produceFailedDispatchAttention(
+      db,
+      failedEnvelope("corr-transient", { kind: "not_now", detail: "backpressure" }),
+      { stackId: STACK },
+    );
+
+    expect(getAttentionItem(db, `${FAILED_DISPATCH_PREFIX}corr-policy`)?.severity).toBe("critical");
+    expect(getAttentionItem(db, `${FAILED_DISPATCH_PREFIX}corr-transient`)?.severity).toBe("normal");
+  });
+
+  it("opens on an aborted that is NOT a principal-cancel", () => {
+    const db = freshDb();
+    seedAnchor(db, "corr-timeout");
+
+    const delta = produceFailedDispatchAttention(
+      db,
+      {
+        type: "dispatch.task.aborted",
+        correlation_id: "corr-timeout",
+        payload: { task_id: "corr-timeout", agent_id: "echo", reason: "timeout" },
+      },
+      { stackId: STACK },
+    );
+
+    expect(delta.opened).toHaveLength(1);
+    expect(getAttentionItem(db, `${FAILED_DISPATCH_PREFIX}corr-timeout`)?.severity).toBe("high");
+  });
+
+  it("does NOT open on a principal-cancel aborted", () => {
+    const db = freshDb();
+    seedAnchor(db, "corr-cancel");
+
+    const delta = produceFailedDispatchAttention(
+      db,
+      {
+        type: "dispatch.task.aborted",
+        correlation_id: "corr-cancel",
+        payload: { task_id: "corr-cancel", agent_id: "echo", reason: PRINCIPAL_CANCEL_REASON },
+      },
+      { stackId: STACK },
+    );
+
+    expect(delta.opened).toHaveLength(0);
+    expect(delta.resolved).toHaveLength(0);
+    expect(getAttentionItem(db, `${FAILED_DISPATCH_PREFIX}corr-cancel`)).toBeNull();
+  });
+
+  it("auto-resolves on a later started (redispatch retried)", () => {
+    const db = freshDb();
+    seedAnchor(db, "corr-retry");
+    produceFailedDispatchAttention(db, failedEnvelope("corr-retry"), { stackId: STACK });
+    expect(getAttentionItem(db, `${FAILED_DISPATCH_PREFIX}corr-retry`)?.status).toBe("open");
+
+    const delta = produceFailedDispatchAttention(
+      db,
+      {
+        type: "dispatch.task.started",
+        correlation_id: "corr-retry",
+        payload: { task_id: "corr-retry", agent_id: "echo" },
+      },
+      { stackId: STACK },
+    );
+
+    expect(delta.resolved).toHaveLength(1);
+    expect(getAttentionItem(db, `${FAILED_DISPATCH_PREFIX}corr-retry`)?.status).toBe("resolved");
+  });
+
+  it("auto-resolves on a later completed (redispatch succeeded)", () => {
+    const db = freshDb();
+    seedAnchor(db, "corr-success");
+    produceFailedDispatchAttention(db, failedEnvelope("corr-success"), { stackId: STACK });
+
+    const delta = produceFailedDispatchAttention(
+      db,
+      {
+        type: "dispatch.task.completed",
+        correlation_id: "corr-success",
+        payload: { task_id: "corr-success", agent_id: "echo" },
+      },
+      { stackId: STACK },
+    );
+
+    expect(delta.resolved).toHaveLength(1);
+    expect(getAttentionItem(db, `${FAILED_DISPATCH_PREFIX}corr-success`)?.status).toBe("resolved");
+  });
+
+  it("is idempotent on redelivery of the same failed (no duplicate opened delta)", () => {
+    const db = freshDb();
+    seedAnchor(db, "corr-dup");
+
+    const first = produceFailedDispatchAttention(db, failedEnvelope("corr-dup"), { stackId: STACK });
+    const second = produceFailedDispatchAttention(db, failedEnvelope("corr-dup"), { stackId: STACK });
+
+    expect(first.opened).toHaveLength(1);
+    expect(second.opened).toHaveLength(0); // already open → no re-notify
+    expect(listOpenAttention(db).filter((i) => i.id === `${FAILED_DISPATCH_PREFIX}corr-dup`)).toHaveLength(1);
+  });
+
+  it("a resolve of an absent/already-resolved item yields no resolved delta", () => {
+    const db = freshDb();
+    seedAnchor(db, "corr-noop");
+
+    // No prior failed → a started resolves nothing.
+    const delta = produceFailedDispatchAttention(
+      db,
+      {
+        type: "dispatch.task.started",
+        correlation_id: "corr-noop",
+        payload: { task_id: "corr-noop", agent_id: "echo" },
+      },
+      { stackId: STACK },
+    );
+    expect(delta.resolved).toHaveLength(0);
+  });
+
+  it("opens with a null session link when no anchor was projected (terminal raced its projection)", () => {
+    const db = freshDb();
+    // No seedAnchor — the failed arrives with no projected dispatch anchor.
+    const delta = produceFailedDispatchAttention(db, failedEnvelope("corr-orphan"), { stackId: STACK });
+    expect(delta.opened).toHaveLength(1);
+    expect(getAttentionItem(db, `${FAILED_DISPATCH_PREFIX}corr-orphan`)?.sessionId).toBeNull();
+  });
+
+  it("ignores a non-terminal/non-redispatch type (empty delta)", () => {
+    const db = freshDb();
+    const delta = produceFailedDispatchAttention(
+      db,
+      { type: "system.agent.heartbeat", correlation_id: "x", payload: {} },
+      { stackId: STACK },
+    );
+    expect(delta).toEqual({ opened: [], resolved: [] });
+  });
+
+  // --- Prefix disjointness (CRITICAL) ---
+
+  it("the reconciler never sweeps an att:faildis: item, and the producer never touches reconciler items", () => {
+    const db = freshDb();
+    seedAnchor(db, "corr-disjoint");
+    produceFailedDispatchAttention(db, failedEnvelope("corr-disjoint"), { stackId: STACK });
+
+    // Seed a reconciler-owned item directly (att:block:) that is NOT currently derivable.
+    upsertAttentionItem(db, {
+      id: "att:block:phantom",
+      stackId: STACK,
+      workItemId: null,
+      sessionId: null,
+      kind: "blocked",
+      severity: "high",
+      status: "open",
+    });
+
+    // Run the reconciler with no derivable state: it resolves its OWN orphaned
+    // att:block: item but must leave the att:faildis: item OPEN.
+    const result = reconcileAttention(db, { stackId: STACK });
+    expect(result.resolved.map((i) => i.id)).toContain("att:block:phantom");
+    expect(getAttentionItem(db, `${FAILED_DISPATCH_PREFIX}corr-disjoint`)?.status).toBe("open");
+
+    // And the producer's resolve only touches att:faildis: — a started for the
+    // same anchor resolves the faildis item, never the att:block: one.
+    upsertAttentionItem(db, {
+      id: "att:block:phantom2",
+      stackId: STACK,
+      workItemId: null,
+      sessionId: null,
+      kind: "blocked",
+      severity: "high",
+      status: "open",
+    });
+    produceFailedDispatchAttention(
+      db,
+      { type: "dispatch.task.started", correlation_id: "corr-disjoint", payload: { task_id: "corr-disjoint", agent_id: "echo" } },
+      { stackId: STACK },
+    );
+    expect(getAttentionItem(db, "att:block:phantom2")?.status).toBe("open");
+  });
+});

--- a/src/surface/mc/attention-notify.ts
+++ b/src/surface/mc/attention-notify.ts
@@ -29,6 +29,22 @@ import type { AttentionItem } from "./types";
 
 export type AttentionAction = "opened" | "resolved";
 
+/**
+ * The notify delta: items that transitioned absent → open ("opened") and
+ * open → resolved ("resolved") on one producer pass. This is the canonical
+ * shape `publishReconcileDelta` consumes, so it lives HERE (the consumer) and
+ * is reused by every producer that funnels onto the `system.attention.*` path —
+ * the reconciler (`ReconcileResult extends AttentionDelta`) and the event-driven
+ * failed_dispatch producer. Sharing the type makes "they ride the SAME notify
+ * path" a type-level guarantee, not a structural coincidence (PR #873 review).
+ */
+export interface AttentionDelta {
+  /** Items that transitioned absent → open this pass (notify "opened"). */
+  opened: AttentionItem[];
+  /** Items that transitioned open → resolved this pass (notify "resolved"). */
+  resolved: AttentionItem[];
+}
+
 export interface AttentionNotifySource {
   /** Boot-resolved principal slug — first source segment. */
   principal: string;
@@ -128,7 +144,7 @@ export async function publishAttentionNotifications(
  * The thin glue between {@link reconcileAttention}'s delta and E.4's envelopes.
  */
 export async function publishReconcileDelta(
-  delta: { opened: AttentionItem[]; resolved: AttentionItem[] },
+  delta: AttentionDelta,
   opts: AttentionNotifyOptions & { deepLinkFor?: (item: AttentionItem) => string | null },
   publish: EnvelopePublisher,
 ): Promise<{ opened: number; resolved: number }> {

--- a/src/surface/mc/db/attention-sources.ts
+++ b/src/surface/mc/db/attention-sources.ts
@@ -12,11 +12,22 @@
  * Sources wired here (the DB-derivable kinds with a clean deep-link):
  *   - blocked assignments → kind from block_reason (permission / review /
  *     blocked), deep-linked via the assignment's session.
- *   - stale work items → kind "stale", deep-linked via the work item.
+ *   - stale work items → kind "stale", deep-linked via the work item
+ *     (`att:stale:{wiId}`).
+ *   - stale ASSIGNMENTS (MC-I1.S7) → kind "stale", deep-linked via the
+ *     assignment's session (`att:stale:asg:{asgId}`). An assignment stuck
+ *     non-terminal (queued / dispatched / running) with no recent activity —
+ *     "Which sessions are running, stale, or waiting for input?" (design §8).
+ *     Last-activity is the assignment's latest `system.agent.heartbeat` event
+ *     timestamp (the S6 liveness row), falling back to the assignment's
+ *     `updated_at` when no heartbeat has landed.
  *
  * Deferred (documented, NOT silently dropped):
- *   - "failed_dispatch": a Myelin envelope nak — bus-level, not in the MC DB;
- *     wired when the dispatch-failure event lands a DB record.
+ *   - "failed_dispatch": completed in MC-I1.S7 as an EVENT-DRIVEN producer
+ *     (projection/failed-dispatch.ts) — the failure detail (error_summary + the
+ *     cortex#249 nak reason) rides the terminal envelope and is not queryable DB
+ *     state, so it can't be re-derived here. Its `att:faildis:` namespace is
+ *     disjoint from these prefixes; the resolve sweeps below never touch it.
  *   - failing checks: a Check links by commit SHA, with no direct work-item /
  *     session deep-link target (§7.4 requires one) until the check→PR→workItem
  *     chain exists; revisit with that linkage.
@@ -30,17 +41,45 @@ import { upsertAttentionItem, listOpenAttention, resolveAttentionItem } from "./
 /** Deterministic id prefixes — let re-runs upsert in place + diff for resolution. */
 const BLOCK_PREFIX = "att:block:";
 const STALE_PREFIX = "att:stale:";
+/** Sub-namespace of STALE_PREFIX for stuck ASSIGNMENTS (work items keep the bare prefix). */
+const STALE_ASSIGNMENT_PREFIX = "att:stale:asg:";
 
 /** Work-item statuses treated as terminal (never "stale"). GitHub ingest writes open/closed. */
 const TERMINAL_WORK_ITEM_STATUSES = new Set(["done", "closed", "cancelled", "completed"]);
 
+/**
+ * Assignment states that are NON-terminal AND not already an attention source
+ * via the block producer (which owns `blocked`). An assignment in one of these
+ * with no recent activity is "stale" — work the principal dispatched that has
+ * gone quiet without finishing.
+ */
+const STALE_ASSIGNMENT_STATES = new Set(["queued", "dispatched", "running"]);
+
+const HEARTBEAT_EVENT_TYPE = "system.agent.heartbeat";
+
 const DEFAULT_STALE_AFTER_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+
+/**
+ * A dispatched session goes "stale" far sooner than a planning-board work item:
+ * a running CC session that hasn't ticked a heartbeat in an hour is stuck (the
+ * runner heartbeats every ~30 s — cortex#361). The work-item threshold (days)
+ * tracks a different cadence (a GitHub issue untouched for a week). Both are
+ * module constants, not config schema, per the slice's minimal-scope rule — no
+ * cockpit knob clearly belongs to either yet; revisit if a stack needs to tune.
+ */
+const DEFAULT_STALE_ASSIGNMENT_AFTER_MS = 60 * 60 * 1000; // 1 hour
 
 export interface ReconcileAttentionOptions {
   /** Stack/deployment id stamped on produced items. */
   stackId: string;
   /** An open work item untouched longer than this is "stale". Default 7 days. */
   staleAfterMs?: number;
+  /**
+   * A non-terminal assignment with no activity (heartbeat or `updated_at`)
+   * within this window is "stale". Default 1 hour — a dispatched session ticks
+   * a heartbeat every ~30 s, so an hour of silence means it's stuck.
+   */
+  staleAssignmentAfterMs?: number;
   /** Current time in epoch SECONDS (injectable for deterministic tests). */
   nowEpochSec?: number;
 }
@@ -74,6 +113,8 @@ function blockReasonToAttention(reason: BlockReason): { kind: AttentionKind; sev
 export function reconcileAttention(db: Database, opts: ReconcileAttentionOptions): ReconcileResult {
   const nowSec = opts.nowEpochSec ?? Math.floor(Date.now() / 1000);
   const staleBeforeSec = nowSec - Math.floor((opts.staleAfterMs ?? DEFAULT_STALE_AFTER_MS) / 1000);
+  const staleAssignmentBeforeSec =
+    nowSec - Math.floor((opts.staleAssignmentAfterMs ?? DEFAULT_STALE_ASSIGNMENT_AFTER_MS) / 1000);
 
   // Snapshot the prior NON-resolved set (open + dismissed) BEFORE mutating, to
   // compute the open/resolve delta (ML.3 — what to notify on) AND to respect
@@ -128,6 +169,56 @@ export function reconcileAttention(db: Database, opts: ReconcileAttentionOptions
       sessionId: null,
       kind: "stale",
       severity: "low",
+      status: "open",
+    });
+  }
+
+  // 3. Stale ASSIGNMENTS (MC-I1.S7) — a non-terminal, non-blocked assignment
+  //    whose last activity is older than the threshold. Last-activity is the
+  //    GREATER of the assignment's most-recent `system.agent.heartbeat` event
+  //    timestamp (the S6 liveness row, joined via the assignment's sessions) and
+  //    the assignment's own `updated_at`. An assignment that has heartbeated
+  //    recently is alive even if `updated_at` is old (no state churn while
+  //    running); one that never heartbeated falls back to `updated_at`. The
+  //    deep-link target (§7.4) is the assignment's most-recent session; an
+  //    assignment with no session has no drill-down target → skip it (mirrors
+  //    the blocked-assignment producer's no-session skip).
+  //
+  //    Both timestamps are normalised to epoch SECONDS in SQL (`updated_at` is
+  //    ISO text on agent_task_assignment; `events.timestamp` is ISO text) so the
+  //    comparison is apples-to-apples with `staleAssignmentBeforeSec`.
+  const staleStatePlaceholders = [...STALE_ASSIGNMENT_STATES].map(() => "?").join(", ");
+  const staleAssignmentRows = db
+    .query(
+      `SELECT a.id AS assignment_id, s.session_id AS session_id
+       FROM agent_task_assignment a
+       JOIN (
+         SELECT se.assignment_id,
+                se.id AS session_id,
+                MAX(COALESCE(unixepoch(ev.timestamp), 0)) AS last_activity_sec,
+                ROW_NUMBER() OVER (
+                  PARTITION BY se.assignment_id ORDER BY se.started_at DESC, se.id DESC
+                ) AS rn
+         FROM sessions se
+         LEFT JOIN events ev ON ev.session_id = se.id AND ev.type = ?
+         GROUP BY se.id
+       ) s ON s.assignment_id = a.id AND s.rn = 1
+       WHERE a.state IN (${staleStatePlaceholders})
+         AND MAX(unixepoch(a.updated_at), s.last_activity_sec) < ?`,
+    )
+    .all(HEARTBEAT_EVENT_TYPE, ...STALE_ASSIGNMENT_STATES, staleAssignmentBeforeSec) as {
+    assignment_id: string;
+    session_id: string;
+  }[];
+  for (const a of staleAssignmentRows) {
+    const id = `${STALE_ASSIGNMENT_PREFIX}${a.assignment_id}`;
+    derived.set(id, {
+      id,
+      stackId: opts.stackId,
+      workItemId: null,
+      sessionId: a.session_id,
+      kind: "stale",
+      severity: "normal",
       status: "open",
     });
   }

--- a/src/surface/mc/db/attention-sources.ts
+++ b/src/surface/mc/db/attention-sources.ts
@@ -37,6 +37,7 @@ import type { Database } from "bun:sqlite";
 import type { AttentionItem, AttentionKind, AttentionSeverity, BlockReason } from "../types";
 import { listFocusArea } from "./assignments";
 import { upsertAttentionItem, listOpenAttention, resolveAttentionItem } from "./attention";
+import type { AttentionDelta } from "../attention-notify";
 
 /** Deterministic id prefixes — let re-runs upsert in place + diff for resolution. */
 const BLOCK_PREFIX = "att:block:";
@@ -75,22 +76,22 @@ export interface ReconcileAttentionOptions {
   /** An open work item untouched longer than this is "stale". Default 7 days. */
   staleAfterMs?: number;
   /**
-   * A non-terminal assignment with no activity (heartbeat or `updated_at`)
-   * within this window is "stale". Default 1 hour — a dispatched session ticks
-   * a heartbeat every ~30 s, so an hour of silence means it's stuck.
+   * A non-terminal assignment whose most-recent HEARTBEATING session has not
+   * ticked a heartbeat within this window is "stale". Default 1 hour — a
+   * dispatched CC session heartbeats every ~30 s, so an hour of silence means
+   * it's stuck. Only sessions that emit heartbeats are judged (see the stale-asg
+   * query) — observed/orphan sessions that never tick are out of scope.
    */
   staleAssignmentAfterMs?: number;
   /** Current time in epoch SECONDS (injectable for deterministic tests). */
   nowEpochSec?: number;
 }
 
-export interface ReconcileResult {
+export interface ReconcileResult extends AttentionDelta {
   /** The full set of items currently open after this reconcile. */
   open: AttentionItem[];
-  /** Items that transitioned absent → open this run (notify "opened"). */
-  opened: AttentionItem[];
-  /** Items that transitioned open → resolved this run (notify "resolved"). */
-  resolved: AttentionItem[];
+  // `opened` / `resolved` come from AttentionDelta (the shared notify shape) —
+  // ReconcileResult is that delta plus the full `open` snapshot.
 }
 
 /** Map a block reason to its attention kind + severity. Exhaustive over BlockReason. */
@@ -117,11 +118,18 @@ export function reconcileAttention(db: Database, opts: ReconcileAttentionOptions
     nowSec - Math.floor((opts.staleAssignmentAfterMs ?? DEFAULT_STALE_ASSIGNMENT_AFTER_MS) / 1000);
 
   // Snapshot the prior NON-resolved set (open + dismissed) BEFORE mutating, to
-  // compute the open/resolve delta (ML.3 — what to notify on) AND to respect
+  // compute the open/resolve delta (ML.3 — what to notify on) and to respect
   // dismiss. A dismissed item is "seen" — re-deriving it must NOT reopen it or
   // re-notify (the principal said "stop showing me this"). Only an item absent
   // from BOTH open and dismissed (i.e. genuinely new, or previously *resolved*
   // and now recurring) counts as newly opened.
+  //
+  // NB (PR #873 review nit 1): a RESOLVED item that re-derives DOES re-notify by
+  // design — a blocker that cleared and genuinely recurred is exactly what the
+  // principal wants surfaced again (the established ML.3 contract, pinned by the
+  // "re-notifies after RESOLVE (not dismiss)" test). The nit's flap concern is
+  // handled at the producer instead: review major 2 scopes stale-assignment to
+  // heartbeating sessions, removing the false-positive flap that motivated it.
   const priorRows = db
     .query(`SELECT id, status FROM attention_items WHERE status IN ('open', 'dismissed')`)
     .all() as { id: string; status: string }[];
@@ -174,19 +182,31 @@ export function reconcileAttention(db: Database, opts: ReconcileAttentionOptions
   }
 
   // 3. Stale ASSIGNMENTS (MC-I1.S7) — a non-terminal, non-blocked assignment
-  //    whose last activity is older than the threshold. Last-activity is the
-  //    GREATER of the assignment's most-recent `system.agent.heartbeat` event
-  //    timestamp (the S6 liveness row, joined via the assignment's sessions) and
-  //    the assignment's own `updated_at`. An assignment that has heartbeated
-  //    recently is alive even if `updated_at` is old (no state churn while
-  //    running); one that never heartbeated falls back to `updated_at`. The
-  //    deep-link target (§7.4) is the assignment's most-recent session; an
-  //    assignment with no session has no drill-down target → skip it (mirrors
-  //    the blocked-assignment producer's no-session skip).
+  //    whose most-recent session HAS heartbeated and has now gone silent past
+  //    the threshold.
   //
-  //    Both timestamps are normalised to epoch SECONDS in SQL (`updated_at` is
-  //    ISO text on agent_task_assignment; `events.timestamp` is ISO text) so the
-  //    comparison is apples-to-apples with `staleAssignmentBeforeSec`.
+  //    SCOPING (PR #873 review major 2): only sessions that emit heartbeats can
+  //    be judged stale by a heartbeat-cadence threshold. `attachHeartbeatToCC-
+  //    Session` is wired ONLY for controlled CC sessions (dispatch-handler +
+  //    review-consumer); `local.observed` + auto-registered orphan sessions
+  //    reach `running` via the ingestor but NEVER tick. Their last-activity
+  //    would fall back to `updated_at`, which the ingestor bumps on every event
+  //    — so a legitimately-quiet observed session (stalled hook stream) crosses
+  //    the 1h heartbeat-tuned threshold with no churn and FLAPS an `opened`
+  //    notification every cycle.
+  //
+  //    We therefore require the most-recent session to carry at least one
+  //    heartbeat liveness row (INNER-join the latest heartbeat per session).
+  //    This is preferred over a hardcoded `endpoint_kind = local.process.con-
+  //    trolled` filter because it self-scopes: it tracks the ACTUAL liveness
+  //    signal, so if a future endpoint_kind starts heartbeating it's covered
+  //    automatically, and a controlled session that somehow never heartbeats
+  //    (spawn raced the attach) is correctly excluded rather than false-flagged.
+  //
+  //    Staleness is then the latest heartbeat's age (NOT MAX'd with `updated_at`
+  //    — for a heartbeating session the heartbeat IS the authoritative liveness
+  //    signal; `updated_at` churn from unrelated ingest would mask a stuck CC).
+  //    The deep-link target (§7.4) is that session.
   const staleStatePlaceholders = [...STALE_ASSIGNMENT_STATES].map(() => "?").join(", ");
   const staleAssignmentRows = db
     .query(
@@ -195,16 +215,16 @@ export function reconcileAttention(db: Database, opts: ReconcileAttentionOptions
        JOIN (
          SELECT se.assignment_id,
                 se.id AS session_id,
-                MAX(COALESCE(unixepoch(ev.timestamp), 0)) AS last_activity_sec,
+                MAX(unixepoch(ev.timestamp)) AS last_heartbeat_sec,
                 ROW_NUMBER() OVER (
                   PARTITION BY se.assignment_id ORDER BY se.started_at DESC, se.id DESC
                 ) AS rn
          FROM sessions se
-         LEFT JOIN events ev ON ev.session_id = se.id AND ev.type = ?
+         JOIN events ev ON ev.session_id = se.id AND ev.type = ?
          GROUP BY se.id
        ) s ON s.assignment_id = a.id AND s.rn = 1
        WHERE a.state IN (${staleStatePlaceholders})
-         AND MAX(unixepoch(a.updated_at), s.last_activity_sec) < ?`,
+         AND s.last_heartbeat_sec < ?`,
     )
     .all(HEARTBEAT_EVENT_TYPE, ...STALE_ASSIGNMENT_STATES, staleAssignmentBeforeSec) as {
     assignment_id: string;

--- a/src/surface/mc/projection/dispatch-lifecycle-renderer.ts
+++ b/src/surface/mc/projection/dispatch-lifecycle-renderer.ts
@@ -52,9 +52,32 @@ import { projectReviewVerdict } from "./review-verdict";
 import { projectHeartbeat } from "./heartbeat";
 import { projectAttention } from "./attention-projection";
 import { projectAdapterLifecycle } from "./adapter-lifecycle";
+import {
+  produceFailedDispatchAttention,
+  type AttentionDelta,
+} from "./failed-dispatch";
 
 /** Stable surface-router id for the MC projection renderer. */
 export const DISPATCH_PROJECTION_RENDERER_ID = "mc-dispatch-projection";
+
+/**
+ * MC-I1.S7 (#849) — the event-driven failed_dispatch producer's notify funnel
+ * + its stamping context. When a `dispatch.task.*` envelope opens or resolves a
+ * `failed_dispatch` attention item, the renderer funnels that delta here so it
+ * reaches the SAME `system.attention.*` bus path the cockpit loop uses.
+ *
+ * `stackId` stamps the produced items (the renderer is the only place that knows
+ * the stack identity at projection time). `publishDelta` is OPTIONAL — when
+ * omitted (headless / test, like `wsRegistry`), the DB item is still written; only
+ * the bus notification is skipped. cortex.ts supplies it, built from the
+ * established `publishAttentionNotifications` builder + the loop's notifySource /
+ * deepLinkFor, so event-driven opens/resolves ride the exact same emitter as the
+ * reconcile-driven ones — NOT a parallel protocol.
+ */
+export interface FailedDispatchAttentionWiring {
+  stackId: string;
+  publishDelta?: (delta: AttentionDelta) => void | Promise<void>;
+}
 
 /**
  * NATS subject patterns the projection renderer subscribes to. Covers the
@@ -127,6 +150,7 @@ export function project(
   envelope: ProjectableEnvelope,
   subject: string | undefined,
   wsRegistry: WsClientRegistry | undefined,
+  failedDispatch?: FailedDispatchAttentionWiring,
 ): void {
   const type = envelope.type;
 
@@ -137,6 +161,33 @@ export function project(
         sessionId: res.sessionId,
         assignmentId: res.assignmentId,
       });
+    }
+    // MC-I1.S7 — the failed_dispatch attention producer rides the SAME seam:
+    // every dispatch.task.* envelope is offered to it. A `failed`/`aborted`
+    // opens an item; a later `started`/`completed` for the same anchor resolves
+    // it. The producer runs AFTER projectDispatchLifecycle so the anchor session
+    // (the deep-link target) exists on a fresh start. It's independent of the
+    // lifecycle's own null-return (a terminal that didn't project a row — bad
+    // payload — still yields no producer delta because the producer reads the
+    // same fields). Any DB mutation (open/resolve) broadcasts the attention WS
+    // signal + funnels the delta to the bus notify path when wired.
+    if (failedDispatch) {
+      const delta = produceFailedDispatchAttention(db, envelope, {
+        stackId: failedDispatch.stackId,
+      });
+      if (delta.opened.length > 0 || delta.resolved.length > 0) {
+        broadcastProjection(wsRegistry, "attention");
+        if (failedDispatch.publishDelta) {
+          // Fire-and-forget: a publish failure must not poison the render path
+          // (the renderer's render() catch is the backstop, but we keep the
+          // promise from escaping unhandled).
+          void Promise.resolve(failedDispatch.publishDelta(delta)).catch((err: unknown) => {
+            process.stderr.write(
+              `[mission-control] failed-dispatch attention notify failed: ${err instanceof Error ? err.message : String(err)}\n`,
+            );
+          });
+        }
+      }
     }
     return;
   }
@@ -189,12 +240,16 @@ export function project(
  * `db` is the in-process Mission Control handle (from the S1 embed —
  * `startMissionControl(...).db`). `wsRegistry` is the embed's live WebSocket
  * registry (S6) — when supplied, projected mutations broadcast to live clients;
- * when omitted (headless / test), the broadcast is a no-op. cortex.ts wires both
- * only when `mc.enabled`.
+ * when omitted (headless / test), the broadcast is a no-op. `failedDispatch`
+ * (S7) carries the `stackId` stamped on event-driven failed_dispatch attention
+ * items + an optional `publishDelta` notify funnel; when omitted the producer
+ * still writes its DB item but skips the bus notification. cortex.ts wires all
+ * three only when `mc.enabled`.
  */
 export function createDispatchProjectionRenderer(
   db: Database,
   wsRegistry?: WsClientRegistry,
+  failedDispatch?: FailedDispatchAttentionWiring,
 ): SurfaceAdapter {
   return {
     id: DISPATCH_PROJECTION_RENDERER_ID,
@@ -206,7 +261,7 @@ export function createDispatchProjectionRenderer(
       subject?: string,
     ): Promise<void> => {
       try {
-        project(db, envelope, subject, wsRegistry);
+        project(db, envelope, subject, wsRegistry, failedDispatch);
       } catch (err) {
         // Renderer contract §2 — never throw out of render(). A projection
         // failure (DB constraint, malformed payload that slipped a type

--- a/src/surface/mc/projection/failed-dispatch.ts
+++ b/src/surface/mc/projection/failed-dispatch.ts
@@ -1,0 +1,241 @@
+/**
+ * MC-I1.S7 (#849, G-1113.E.2 completion) — the `failed_dispatch` attention
+ * producer, event-driven off the dispatch-lifecycle projection seam.
+ *
+ * ## Why a producer here, not in the reconciler
+ *
+ * E.2's `reconcileAttention` (db/attention-sources.ts) derives attention from
+ * DURABLE MC DB state (blocked assignments, stale work items). A failed dispatch
+ * is a TERMINAL bus event — `dispatch.task.{failed,aborted}` — that the lifecycle
+ * projection already turns into a terminal assignment row, but the FAILURE detail
+ * (`error_summary`, the cortex#249 four-way nak `reason` union) rides the envelope
+ * payload and is NOT persisted as queryable DB state. So the reconciler can't
+ * re-derive it on its next pass. This producer reads the envelope at projection
+ * time and opens an AttentionItem from it — the event IS the source of truth.
+ *
+ * ## Disjoint prefix (the slice's CRITICAL invariant)
+ *
+ * Items are minted under `att:faildis:` — disjoint from the reconciler's
+ * `att:block:` / `att:stale:` and the S6 federated projection's `att:fed:`. The
+ * reconciler's auto-resolve sweep is prefix-scoped (`startsWith(BLOCK_PREFIX) ||
+ * startsWith(STALE_PREFIX)`), so it can NEVER sweep an `att:faildis:` item; and
+ * THIS producer only ever resolves its OWN `att:faildis:` ids. The two never
+ * touch each other's items.
+ *
+ * ## Auto-resolve on redispatch (the lifecycle wires it)
+ *
+ * A failed dispatch's attention clears when the SAME task is redispatched and
+ * makes progress: a later `started` or `completed` lifecycle for the same
+ * `correlation_id` anchor resolves `att:faildis:{correlationId}`. The dispatch-
+ * lifecycle renderer calls this producer for EVERY `dispatch.task.*` envelope, so
+ * the resolve path rides the same seam as the open path — no separate trigger.
+ *
+ * ## Principal-cancel is NOT attention
+ *
+ * `dispatch.task.aborted` carries a free-form `reason` (`"timeout"`, `"shutdown"`,
+ * `"principal-cancel"`, `"replaced"` — dispatch-events.ts). A principal cancelling
+ * their OWN dispatch needs no attention (they did it on purpose), so an aborted
+ * with `reason === "principal-cancel"` opens nothing. Every other abort reason
+ * (timeout, shutdown, replaced, …) is an outside force the principal should see.
+ *
+ * ## Notify funnel
+ *
+ * This producer returns an {@link AttentionDelta} (`opened` / `resolved` items).
+ * The renderer funnels that delta to the SAME `system.attention.*` notify path
+ * the cockpit loop uses — via the established `publishAttentionNotifications`
+ * builder in attention-notify.ts (see dispatch-lifecycle-renderer.ts). The
+ * publisher is optional: when omitted (headless / test) the DB item is still
+ * written, only the bus notification is skipped — mirroring the `wsRegistry`
+ * optionality. Items reach the bus through the established builder, NOT through
+ * the loop's reconcile (this is event-driven, the loop is state-derived).
+ *
+ * Non-throwing: a malformed payload / non-terminal type returns an empty delta.
+ */
+
+import type { Database } from "bun:sqlite";
+
+import type { AttentionItem, AttentionSeverity } from "../types";
+import { upsertAttentionItem, getAttentionItem, resolveAttentionItem } from "../db/attention";
+import { findAnchorSession } from "./anchor";
+
+/** The failed-dispatch id namespace — disjoint from every other producer's. */
+export const FAILED_DISPATCH_PREFIX = "att:faildis:";
+
+/** The conventional aborted reason that means "the principal cancelled" → no attention. */
+export const PRINCIPAL_CANCEL_REASON = "principal-cancel";
+
+/**
+ * A producer delta: items that transitioned absent → open and open → resolved
+ * on this envelope. Shaped like the reconciler's delta so the renderer can funnel
+ * both through the SAME notify path.
+ */
+export interface AttentionDelta {
+  opened: AttentionItem[];
+  resolved: AttentionItem[];
+}
+
+const EMPTY_DELTA: AttentionDelta = { opened: [], resolved: [] };
+
+/** The minimal envelope shape this producer reads (kept structural, like the projection). */
+export interface FailedDispatchEnvelope {
+  type: string;
+  correlation_id?: string;
+  payload: Record<string, unknown>;
+}
+
+/** The cortex#249 four-way+reserved nak reason union, as it rides the failed payload. */
+type NakReasonKind =
+  | "policy_denied"
+  | "cant_do"
+  | "wont_do"
+  | "not_now"
+  | "compliance_block";
+
+/**
+ * Map a terminal failure to its attention severity.
+ *
+ *   - a HARD policy/compliance refusal (`policy_denied` / `wont_do` /
+ *     `compliance_block`) is a `critical` — it will never self-heal on retry,
+ *     the principal must intervene;
+ *   - a `cant_do` (capability mismatch / bad output) is `high` — a real error
+ *     that needs a look but isn't a governance stop;
+ *   - a `not_now` (transient / backpressure) is `normal` — it may clear on the
+ *     handler's own retry, so it's the softest failure signal;
+ *   - an aborted-by-outside-force (timeout / shutdown / replaced) is `high` —
+ *     the task was killed mid-flight and likely needs a redispatch.
+ */
+function severityForFailure(reasonKind: NakReasonKind | null, aborted: boolean): AttentionSeverity {
+  if (aborted) return "high";
+  switch (reasonKind) {
+    case "policy_denied":
+    case "wont_do":
+    case "compliance_block":
+      return "critical";
+    case "not_now":
+      return "normal";
+    case "cant_do":
+      return "high";
+    case null:
+      // A `failed` with no structured reason (CC exited non-zero, parse error)
+      // — a real error, treat as `high`.
+      return "high";
+  }
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+/** Read the nak reason kind off a `failed` payload's `reason` union, or null. */
+function nakReasonKind(payload: Record<string, unknown>): NakReasonKind | null {
+  const reason = payload.reason;
+  if (typeof reason !== "object" || reason === null) return null;
+  const kind = (reason as Record<string, unknown>).kind;
+  if (
+    kind === "policy_denied" ||
+    kind === "cant_do" ||
+    kind === "wont_do" ||
+    kind === "not_now" ||
+    kind === "compliance_block"
+  ) {
+    return kind;
+  }
+  return null;
+}
+
+/**
+ * Produce the failed-dispatch attention delta for ONE `dispatch.task.*` envelope.
+ *
+ *   - `failed`                          → open `att:faildis:{correlationId}`.
+ *   - `aborted` (reason ≠ principal-cancel) → open it.
+ *   - `aborted` (reason = principal-cancel) → no-op (intentional cancel).
+ *   - `started` / `completed`           → resolve it (a redispatch healed it).
+ *   - anything else                     → empty delta.
+ *
+ * Idempotent: re-opening an already-open item upserts in place (no duplicate
+ * "opened" delta); resolving an absent / already-resolved item yields no
+ * "resolved" delta. Redelivery is therefore safe.
+ */
+export function produceFailedDispatchAttention(
+  db: Database,
+  envelope: FailedDispatchEnvelope,
+  opts: { stackId: string },
+): AttentionDelta {
+  const kind = terminalOrRedispatchKind(envelope.type);
+  if (kind === null) return EMPTY_DELTA;
+
+  const rawPayload: unknown = envelope.payload;
+  const payload: Record<string, unknown> =
+    typeof rawPayload === "object" && rawPayload !== null
+      ? (rawPayload as Record<string, unknown>)
+      : {};
+
+  // The anchor key — shared by all four lifecycle envelopes for one task. Fall
+  // back to task_id (the builder's default correlation_id) when the field is
+  // absent, matching projectDispatchLifecycle.
+  const correlationId = asString(envelope.correlation_id) ?? asString(payload.task_id);
+  if (correlationId === null) return EMPTY_DELTA;
+
+  const itemId = `${FAILED_DISPATCH_PREFIX}${correlationId}`;
+
+  // Redispatch progress → resolve any open failed-dispatch item for this anchor.
+  if (kind === "started" || kind === "completed") {
+    const existing = getAttentionItem(db, itemId);
+    if (existing !== null && existing.status === "open") {
+      resolveAttentionItem(db, itemId);
+      return { opened: [], resolved: [existing] };
+    }
+    return EMPTY_DELTA;
+  }
+
+  // aborted by the principal's own cancel → no attention.
+  if (kind === "aborted" && asString(payload.reason) === PRINCIPAL_CANCEL_REASON) {
+    return EMPTY_DELTA;
+  }
+
+  // Open (or re-upsert) the failed-dispatch item. Deep-link via the dispatch
+  // anchor's session (the §7.4 drill-down target — "the session that needs
+  // action"); null when no anchor was projected (e.g. a terminal that raced its
+  // own projection), in which case the drill-down derives from the item id.
+  const sessionId = findAnchorSession(db, correlationId);
+  const reasonKind = kind === "failed" ? nakReasonKind(payload) : null;
+  const severity = severityForFailure(reasonKind, kind === "aborted");
+
+  const item: AttentionItem = {
+    id: itemId,
+    stackId: opts.stackId,
+    workItemId: null,
+    sessionId,
+    kind: "failed_dispatch",
+    severity,
+    status: "open",
+  };
+
+  // Only the absent → open transition is a "newly opened" delta to notify on;
+  // a re-upsert of an already-open item must not re-notify (idempotent redelivery).
+  const prior = getAttentionItem(db, itemId);
+  const wasOpen = prior !== null && prior.status === "open";
+  upsertAttentionItem(db, item);
+  return wasOpen ? EMPTY_DELTA : { opened: [item], resolved: [] };
+}
+
+/**
+ * Map `envelope.type` to the lifecycle kind this producer reacts to, or null.
+ * `started` / `completed` drive the auto-resolve; `failed` / `aborted` the open.
+ */
+function terminalOrRedispatchKind(
+  type: string,
+): "started" | "completed" | "failed" | "aborted" | null {
+  switch (type) {
+    case "dispatch.task.started":
+      return "started";
+    case "dispatch.task.completed":
+      return "completed";
+    case "dispatch.task.failed":
+      return "failed";
+    case "dispatch.task.aborted":
+      return "aborted";
+    default:
+      return null;
+  }
+}

--- a/src/surface/mc/projection/failed-dispatch.ts
+++ b/src/surface/mc/projection/failed-dispatch.ts
@@ -57,22 +57,18 @@ import type { Database } from "bun:sqlite";
 import type { AttentionItem, AttentionSeverity } from "../types";
 import { upsertAttentionItem, getAttentionItem, resolveAttentionItem } from "../db/attention";
 import { findAnchorSession } from "./anchor";
+import type { AttentionDelta } from "../attention-notify";
+
+// Re-export the shared notify delta so existing importers of this producer (the
+// renderer, tests) keep one import site; the canonical type lives in
+// attention-notify.ts (the consumer) so the funnel is type-level (PR #873 review).
+export type { AttentionDelta };
 
 /** The failed-dispatch id namespace — disjoint from every other producer's. */
 export const FAILED_DISPATCH_PREFIX = "att:faildis:";
 
 /** The conventional aborted reason that means "the principal cancelled" → no attention. */
 export const PRINCIPAL_CANCEL_REASON = "principal-cancel";
-
-/**
- * A producer delta: items that transitioned absent → open and open → resolved
- * on this envelope. Shaped like the reconciler's delta so the renderer can funnel
- * both through the SAME notify path.
- */
-export interface AttentionDelta {
-  opened: AttentionItem[];
-  resolved: AttentionItem[];
-}
 
 const EMPTY_DELTA: AttentionDelta = { opened: [], resolved: [] };
 
@@ -154,7 +150,8 @@ function nakReasonKind(payload: Record<string, unknown>): NakReasonKind | null {
  *
  * Idempotent: re-opening an already-open item upserts in place (no duplicate
  * "opened" delta); resolving an absent / already-resolved item yields no
- * "resolved" delta. Redelivery is therefore safe.
+ * "resolved" delta; a redelivered failed/aborted for a DISMISSED item is a no-op
+ * (the dismiss is honoured, never resurrected). Redelivery is therefore safe.
  */
 export function produceFailedDispatchAttention(
   db: Database,
@@ -193,6 +190,17 @@ export function produceFailedDispatchAttention(
     return EMPTY_DELTA;
   }
 
+  // Dismiss-resurrection guard (#621 bug class; PR #873 review major 1). NATS is
+  // at-least-once, so a `dispatch.task.failed` is redelivered routinely. If the
+  // principal already DISMISSED this item ("stop showing me this"), a redelivery
+  // must NOT flip it back to open + re-notify. `upsertAttentionItem` writes
+  // `status = excluded.status` unconditionally, so we early-return BEFORE the
+  // upsert when the prior row is dismissed — mirroring how `reconcileAttention`
+  // guards via `dismissedIds`. (Latent until E.4's dismiss action ships, but
+  // fixed now while the producer is fresh.)
+  const prior = getAttentionItem(db, itemId);
+  if (prior !== null && prior.status === "dismissed") return EMPTY_DELTA;
+
   // Open (or re-upsert) the failed-dispatch item. Deep-link via the dispatch
   // anchor's session (the §7.4 drill-down target — "the session that needs
   // action"); null when no anchor was projected (e.g. a terminal that raced its
@@ -213,7 +221,6 @@ export function produceFailedDispatchAttention(
 
   // Only the absent → open transition is a "newly opened" delta to notify on;
   // a re-upsert of an already-open item must not re-notify (idempotent redelivery).
-  const prior = getAttentionItem(db, itemId);
   const wasOpen = prior !== null && prior.status === "open";
   upsertAttentionItem(db, item);
   return wasOpen ? EMPTY_DELTA : { opened: [item], resolved: [] };


### PR DESCRIPTION
Completes the two G-1113.E.2 attention producers explicitly deferred at #606 / #610, the **last slice of Iteration 1** (#843, Phase 2).

## What shipped

### 1. `failed_dispatch` producer — event-driven (`src/surface/mc/projection/failed-dispatch.ts`)

A failed dispatch's detail (`error_summary` + the cortex#249 four-way+reserved nak `reason` union) rides the **terminal envelope** and is not queryable DB state, so the E.2 reconciler can't re-derive it. This producer reads the envelope at projection time — the event IS the source of truth — and rides the **S6 dispatch-lifecycle projection seam** (`dispatch-lifecycle-renderer.ts` calls it for every `dispatch.task.*`):

- `dispatch.task.failed` → open `att:faildis:{correlationId}`, severity mapped from the nak reason (`policy_denied`/`wont_do`/`compliance_block` → critical, `cant_do` → high, `not_now` → normal), deep-linked via the dispatch anchor session (§7.4 drill-down target).
- `dispatch.task.aborted` with `reason ≠ "principal-cancel"` → open (timeout/shutdown/replaced = outside force). A **principal's own cancel opens nothing**.
- a later `started`/`completed` for the same anchor → **auto-resolve** (a redispatch healed it). Wired into the same seam, no separate trigger.
- idempotent on redelivery (already-open re-upsert → no duplicate opened delta).

### 2. `stale` producer completion (`src/surface/mc/db/attention-sources.ts`)

E.2 shipped `att:stale:{wiId}` for stuck **work items**. This completes the deferred scope: a non-terminal, non-blocked **assignment** stuck with no recent activity is stale too — `att:stale:asg:{asgId}`, deep-linked via its session. Last-activity **joins the S6 heartbeat liveness row** (latest `system.agent.heartbeat` event timestamp per session, `MAX`'d with the assignment's `updated_at`): a recently-heartbeating session is alive even with a quiet `updated_at`; silence past the threshold flags it; a fresh heartbeat heals it.

## Design choices (one line each, as requested)

- **Producer placement** — `failed_dispatch` lives in a **sibling module** the renderer calls (not inside `dispatch-lifecycle.ts`), so the lifecycle projection stays focused and the producer's open/resolve is independently testable.
- **Notify funnel** — the renderer threads an **optional `publishDelta`** into `createDispatchProjectionRenderer` (like `wsRegistry`); cortex.ts wires it to the **established `publishReconcileDelta` builder** (`attention-notify.ts`) with the same `notifySource` the cockpit loop uses, so event-driven opens/resolves ride the **same `system.attention.*` path** — not a parallel protocol. Omitted (headless/test) → DB write happens, notify skipped. Works whenever `mc.enabled`, independent of `cockpit.enabled` (event-driven, not state-derived).
- **Thresholds** — module constants with doc comments (`DEFAULT_STALE_ASSIGNMENT_AFTER_MS = 1h`, work-item `7d` unchanged). **No config schema added** — no cockpit knob clearly belongs to either yet (minimal scope per the brief).

## Prefix disjointness (the slice's critical invariant)

`att:faildis:` (this PR) is disjoint from the reconciler's `att:block:` / `att:stale:` and S6's `att:fed:`. The reconciler's auto-resolve sweep is prefix-scoped (`startsWith(BLOCK_PREFIX) || startsWith(STALE_PREFIX)`) so it can never sweep an `att:faildis:` item, and this producer only resolves its own `att:faildis:` ids. The new `att:stale:asg:` is a **sub-namespace of `att:stale:`**, so the reconciler's existing prefix-scoped resolve already covers it (work-item ids keep the bare prefix, unchanged). A dedicated test asserts both directions.

## Test plan

`failed-dispatch.test.ts` (11): open w/ nak reason captured · severity mapping · aborted-not-cancel opens · **principal-cancel does NOT open** · redispatch started/completed auto-resolves · idempotent redelivery · null-session orphan · non-terminal type ignored · **prefix disjointness (reconciler ↔ producer neither sweeps the other)**.

`attention-sources-stale-assignment.test.ts` (10): silent running assignment flagged · recent heartbeat keeps it alive · stale heartbeat flags · **fresh heartbeat heals** · terminal/blocked excluded · queued/dispatched included · fresh not-yet-stale · custom threshold · resolves on terminal transition.

`dispatch-lifecycle-renderer.test.ts` (+4): **opened delta funnelled** to publishDelta · **resolved delta funnelled** on redispatch · headless DB-write w/o publisher · S4 back-compat (no wiring → no attention item).

## Gates

| Gate | Result |
|---|---|
| `bun run lint` | 0 errors (my files clean; 27 pre-existing unused-disable warnings elsewhere) |
| `bunx tsc --noEmit` | clean |
| `bun test src/surface/mc` | 1382 pass / 1 skip / 0 fail |
| full `bun test` | 5275 pass; 2 env-flaky subprocess/TLS timeouts (`#752` CLI passthrough, CloudPublisher mTLS) — **pass in isolation**, unrelated to MC |
| `scripts/check-carveouts.sh` (changed files) | PASS (no bare "operator" — "principal" throughout) |

Closes #849
Part of #843

🤖 Generated with [Claude Code](https://claude.com/claude-code)